### PR TITLE
Use sandbox "Documents" Folder, when building for iOS

### DIFF
--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -378,7 +378,9 @@ GetHomeDataPath(TCHAR *gcc_restrict buffer, bool create=false)
       _tcscat(buffer, _T("/Documents"));
 #else
       _tcscat(buffer, _T("/XCSoarData"));
-#endif#else
+#endif
+
+#else
     _tcscat(buffer, _T("/.xcsoar"));
 #endif
     return buffer;


### PR DESCRIPTION
Instead of using any form of a XCSoarData folder, it is much easier to use the given Documents folder inside the given application Sandbox.
This also makes it possible to use iTunes File Sharing, if UIFileSharingEnabled is set to YES in Info.plist so Maps can be uploaded via iTunes.

//Sorry for the two commits, missed a new line (or two)
