### PR TITLE
 Additional TCP Port 2000

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,7 @@ Version 6.8 - not yet released
   - remove option "Ignore checksum"
   - LX: implement LXNAV Nano3 task declaration (#3295)
   - Volkslogger: support DAeC keyhole declaration
+  - added TCP port 2000 to portlist (part of #3326)
 * calculations
   - wave assistant
   - use maximum speed configured in plane setup as limit for calculations

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -316,6 +316,7 @@ FillTCPPorts(DataFieldEnum &dfe)
   dfe.addEnumText(_T("4353"), 4353);
   dfe.addEnumText(_T("10110"), 10110);
   dfe.addEnumText(_T("4352"), 4352);
+  dfe.addEnumText(_T("2000"), 2000);
 }
 
 static void


### PR DESCRIPTION
Additional TCP Port 2000 to use RS232 to WLAN adapters with Port 2000 (for e.g. custom "iGlide"-WLAN-Modul, or Air-Connect with disabled password)