### PR TITLE
Device\Driver\IMI\ IMIDevice: parse PGRMZ as altitude above 1013.25 hPa

### DIFF
--- a/src/Device/Driver/IMI/Internal.hpp
+++ b/src/Device/Driver/IMI/Internal.hpp
@@ -44,7 +44,8 @@ public:
 
   bool Declare(const Declaration &declaration, const Waypoint *home,
                OperationEnvironment &env) override;
-
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;    
+  
 private:
   bool Connect(OperationEnvironment &env);
   void Disconnect(OperationEnvironment &env);


### PR DESCRIPTION
The normal Garmin $PGRMZ line contains the "true" barometric altitude above MSL (corrected with QNH), but IMIDevice differs:
it emits the uncorrected barometric altitude (i.e. pressure altitude). That is the only reason why we catch this sentence in the driver instead of letting the generic class NMEAParser do it. (solution inspired by EWMicroRecorderDevice, and AltairProDevice. )

I have tested IMIDevice (i.e. IMI ERIXX logger) both with LK8000 and SeeYou Mobile and they work OK. Only XCSoar has the bug of incorrect interpretation of NMEA sequence "PGMRZ"