### PR TITLE
CAI 302 fix for downloading waypoint files; adds termination message …

### DIFF
--- a/src/Device/Driver/CAI302/Internal.hpp
+++ b/src/Device/Driver/CAI302/Internal.hpp
@@ -142,6 +142,8 @@ public:
 
   bool WriteNavpoint(unsigned id, const Waypoint &wp,
                      OperationEnvironment &env);
+
+  bool CloseNavpoints(OperationEnvironment &env);
 };
 
 #endif

--- a/src/Device/Driver/CAI302/Manage.cpp
+++ b/src/Device/Driver/CAI302/Manage.cpp
@@ -274,3 +274,10 @@ CAI302Device::WriteNavpoint(unsigned id, const Waypoint &wp,
 
   return true;
 }
+
+bool
+CAI302Device::CloseNavpoints(OperationEnvironment &env)
+{
+  return CAI302::CloseNavpoints(port, env);
+}
+

--- a/src/Device/Driver/CAI302/Protocol.cpp
+++ b/src/Device/Driver/CAI302/Protocol.cpp
@@ -475,6 +475,13 @@ CAI302::DownloadNavpoint(Port &port, const GeoPoint &location,
 }
 
 bool
+CAI302::CloseNavpoints(Port &port, OperationEnvironment &env)
+{
+  return DownloadCommand(port, "C,-1\r", env, 5000);
+}
+
+
+bool
 CAI302::DeclareTP(Port &port, unsigned i, const GeoPoint &location,
                   int altitude, const char *name, OperationEnvironment &env)
 {

--- a/src/Device/Driver/CAI302/Protocol.hpp
+++ b/src/Device/Driver/CAI302/Protocol.hpp
@@ -478,6 +478,9 @@ namespace CAI302 {
                  OperationEnvironment &env);
 
   bool
+  CloseNavpoints(Port &port, OperationEnvironment &env);
+
+  bool
   DownloadNavpoint(Port &port, const GeoPoint &location,
                    int altitude, unsigned id,
                    bool turnpoint, bool airfield, bool markpoint,

--- a/src/Dialogs/Device/CAI302/WaypointUploader.cpp
+++ b/src/Dialogs/Device/CAI302/WaypointUploader.cpp
@@ -76,6 +76,6 @@ CAI302WaypointUploader::Run(OperationEnvironment &env)
       break;
     }
   }
-
+  device.CloseNavpoints(env);
   device.DisableBulkMode(env);
 }


### PR DESCRIPTION
…after last waypoint

Using XCSoar to download waypoints to a Cambridge 302 leaves the 302 with no waypoints stored, or sometimes just one waypoint.  The problem arises from a requirement that is not mentioned in the 302 documentation.  You must write "C,-1" after downloading the last waypoint.  This is similar to the requirement to write "D,255" after the last waypoint when downloading a task.

The heart of the fix is this following method which must be invoked (indirectly) from **CAI302WaypointUploader::Run(...)** after downloading the last waypoint.

bool CAI302::CloseNavpoints(Port &port, OperationEnvironment &env)
{
  return DownloadCommand(port, "C,-1\r", env, 5000);
}

I was only able to identify this unwritten requirement by capturing the serial stream from Cambridge Aero's original 302 utility.

**This commit fixes this problem, but another problem remains: the waypoints get stored in a strange order.**  The 302's alphabetical waypoint listing is fine, but the sequential listing is a mess.  I will look into fixing this problem next.