### PR TITLE
correct function return for line with dx<0

### DIFF
--- a/src/Geo/Flat/FlatLine.cpp
+++ b/src/Geo/Flat/FlatLine.cpp
@@ -42,6 +42,7 @@ bool
 FlatLine::IntersectOriginCircle(const double r,
                                 FlatPoint &i1, FlatPoint &i2) const
 {
+  // http://mathworld.wolfram.com/Circle-LineIntersection.html
   const auto d = GetVector();
   const auto dr = GetSquaredDistance();
   const auto D = CrossProduct();
@@ -53,8 +54,9 @@ FlatLine::IntersectOriginCircle(const double r,
 
   det = sqrt(det);
   const auto inv_dr = 1. / dr;
-  i1.x = (D * d.y + copysign(d.x, d.y) * det) * inv_dr;
-  i2.x = (D * d.y - copysign(d.x, d.y) * det) * inv_dr;
+  const auto sign_dx = (d.y < 0) ? -d.x : d.x;
+  i1.x = (D * d.y + sign_dx * det) * inv_dr;
+  i2.x = (D * d.y - sign_dx * det) * inv_dr;
   i1.y = (-D * d.x + fabs(d.y) * det) * inv_dr;
   i2.y = (-D * d.x - fabs(d.y) * det) * inv_dr;
   return true;


### PR DESCRIPTION
I stumbled upon what appears to be a problem with the FlatLine::IntersectOriginCircle function. The problem manifests itself as incorrect predicted entry points for a circular airspace area if the predicted track is westerly – with the error being largest on a track of 225 or 315 degrees. With a due west track or any easterly track, there is no error.

The following website describes how to calculate the locations of intersection points between a line and a circle (the stated purpose of this function): http://mathworld.wolfram.com/Circle-LineIntersection.html. The subject function does the calculation exactly as shown here except that it uses a call to the copysign function. This difference causes a sign error when dx (d.x) is negative (as on a westerly track). The result is that instead of returning the intersection points as (x1, y1) and (x2, y2), if on a westerly track, the locations (x1, y2) and (x2, y1) are returned. To clarify, if on a westerly track and the actual intersection point locations are (1, 4) and (5, 2), the function as it is now computes intersection point locations as (1, 2) and (5, 4). (The due west track case is exempt from this error, because the Y value is the same for both intersection points in this case.) You can easily see this by heading toward a circular airspace area on a NW or SW track and watching where the airspace intersection warning marker is placed. I’ve attached a screen shot of a chart I made to help me understand what was happening. It shows the actual and incorrect (as the function currently calculates them) intersection points for a particular scenario.

![intersections](https://user-images.githubusercontent.com/628891/30086651-e2c7f668-9261-11e7-8d2b-68899f87fc94.jpg)

In case you’re interested in why using copysign causes a problem, here’s an explanation. The call copysign(x, y) returns the magnitude (absolute value) of x with the sign of y. So for x = -1 and y = 2, copysign(x, y) = 1. The Wolfram solution, however, (which I proved accurate using Excel and test scenarios approaching the circle from all quadrants) says that this part of the solution should be x multiplied by -1 if y is negative (otherwise by 1). So this would give, for x = -1 and y = 2, a result of -1. When x>=0, copysign coincidentally gives the correct result, but otherwise (westerly tracks), it reverses the sign for this part of the formula.

I’ve tested this trouble scenario in version 6.8.7 Android, and there’s no problem (approaching the airspace area from any direction). It looks like the file containing this function hasn’t been altered since version 6.8.7 was released (last change: 2016-03-04). Therefore, I think 6.8.7 uses this function just as it is now (including its use of the copysign function). I haven’t been able to answer why this problem doesn’t exist in 6.8.7. Any ideas?

This pull request is for my fix for this. I’ve compiled and tested it (for/on Android), and it corrects the airspace intersection marker issue.