### PR TITLE
Waypoint/WaypointReaderSeeYou: handle file with rwwidth field

### DIFF
--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -170,18 +170,11 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
     iStyle = 6,
     iRWDir = 7,
     iRWLen = 8,
-    iFrequency = 9,
-    iDescription = 10,
   };
 
-  if (first) {
-    first = false;
-
-    /* skip first line if it doesn't begin with a quotation character
-       (usually the field order line) */
-    if (line[0] != _T('\"'))
-      return true;
-  }
+  // field positions for typical CUP file
+  static unsigned iFrequency = 9;
+  static unsigned iDescription = 10;
 
   // If (end-of-file or comment)
   if (StringIsEmpty(line) ||
@@ -204,6 +197,28 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
   const TCHAR *params[20];
   size_t n_params = ExtractParameters(line, ctemp, params,
                                       ARRAY_SIZE(params), true, _T('"'));
+
+  if (first) {
+    first = false;
+    if (line[0] != _T('\"')) {
+      /*
+       * If the first line doesn't begin with a quotation mark, it
+       * doesn't describe a waypoint. It probably contains field names.
+       */
+      if (StringIsEqual(params[9], _T("rwwidth"))) {
+        /*
+         * The name of the 10th field is "rwwidth" (runway width).
+         * This field doesn't exist in "typical" SeeYou (*.cup) waypoint
+         * files but is in files saved by at least some versions of
+         * SeeYou Mobile. If the rwwidth field exists, the frequency and
+         * description fields are shifted one position to the right.
+         */
+        iFrequency = 10;
+        iDescription = 11;
+      }
+      return true;
+    }
+  }
 
   // Check if the basic fields are provided
   if (iName >= n_params ||

--- a/test/data/waypoints2.cup
+++ b/test/data/waypoints2.cup
@@ -1,0 +1,7 @@
+name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc
+"Aconcagua","Aconcagua",,3239.200S,07000.700W,6962.0m,7,0,0.0m,,"","Highest mountain in south-america"
+"Bergneustadt","",,5103.117N  ,00742.367E,  488.0m,  5  ,040,590m,15m,"123.650" , "Rabbit holes, 20" ditch south end of rwy"
+"Golden Gate Bridge","GGB",,3749.050N,12228.700W,227.0m,14,0,0.005NM,,"",""
+"Red Square","RedSqr",,5545.250N,03737.200E,123.0m,3,90,0.01ml,,"",""
+"Sydney Opera","Opera",,3351.417S,15112.916E,5.0m,1,0,0.0m,,"",""
+-----Related Tasks-----

--- a/test/src/TestWaypointReader.cpp
+++ b/test/src/TestWaypointReader.cpp
@@ -271,17 +271,31 @@ TestSeeYouWaypoint(const Waypoint org_wp, const Waypoint *wp)
 static void
 TestSeeYou(wp_vector org_wp)
 {
+  // Test a SeeYou waypoint file with no runway width field:
   Waypoints way_points;
   if (!TestWaypointFile(Path(_T("test/data/waypoints.cup")), way_points,
                         org_wp.size())) {
-    skip(9 * org_wp.size(), 0, "opening waypoint file failed");
+    skip(9 * org_wp.size(), 0, "opening waypoints.cup failed");
+  } else {
+    wp_vector::iterator it;
+    for (it = org_wp.begin(); it < org_wp.end(); it++) {
+      const auto wp = GetWaypoint(*it, way_points);
+      TestSeeYouWaypoint(*it, wp.get());
+    }
+  }
+
+  // Test a SeeYou waypoint file with a runway width field:
+  Waypoints way_points2;
+  if (!TestWaypointFile(Path(_T("test/data/waypoints2.cup")), way_points2,
+                        org_wp.size())) {
+    skip(9 * org_wp.size(), 0, "opening waypoints2.cup failed");
     return;
   }
 
-  wp_vector::iterator it;
-  for (it = org_wp.begin(); it < org_wp.end(); it++) {
-    const auto wp = GetWaypoint(*it, way_points);
-    TestSeeYouWaypoint(*it, wp.get());
+  wp_vector::iterator it2;
+  for (it2 = org_wp.begin(); it2 < org_wp.end(); it2++) {
+    const auto wp2 = GetWaypoint(*it2, way_points2);
+    TestSeeYouWaypoint(*it2, wp2.get());
   }
 }
 
@@ -523,7 +537,7 @@ int main(int argc, char **argv)
 {
   wp_vector org_wp = CreateOriginalWaypoints();
 
-  plan_tests(307);
+  plan_tests(360);
 
   TestExtractParameters();
 


### PR DESCRIPTION
Some SeeYou WP files contain a field for runway width (called "rwwidth" in the file header, if present). For example, at least some versions of SeeYou Mobile create files like this (if saved due to user editing of a waypoint). This extra field is inserted just before the radio frequency field, thus shifting that field and the description field to the right. Without this change, when XCSoar uses such a file, the radio frequency isn't shown (in XCSoar's frequency field), the description/comments field in XCSoar contains only the radio frequency (from the WP file), and the description/comments from the WP file are nowhere in XCSoar.