### PR TITLE
src/Form: change degrees from auto to double

### DIFF
--- a/src/Form/DigitEntry.cpp
+++ b/src/Form/DigitEntry.cpp
@@ -661,7 +661,7 @@ DigitEntry::GetGeoAngle(CoordinateFormat format) const
   assert(columns[1].type == Column::Type::DIGIT ||
          columns[1].type == Column::Type::DIGIT19);
   assert(columns[2].type == Column::Type::DIGIT);
-  auto degrees = columns[1].value * 10 + columns[2].value;
+  double degrees = columns[1].value * 10 + columns[2].value;
 
   // Read columns according to specified format
   /// \todo support UTM format


### PR DESCRIPTION
Using auto, degrees is created as an int, causing entered coordinates' fractional parts to be ignored (i.e., causing latitude and longitude to be in integer degrees).

To run unit testing for this, use "make debug" and then run RunGeoPointEntry.