### PR TITLE
Add "Number of used Sats" infobox

### DIFF
--- a/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
@@ -81,7 +81,7 @@ SystemStatusPanel::Refresh()
     ClearText(NumSat);
   else if (gps.satellites_used_available) {
     // known number of sats
-    Temp.Format(_T("%d"), gps.satellites_used);
+    Temp.Format(_T("%u"), gps.satellites_used);
     SetText(NumSat, Temp);
   } else
     // valid but unknown number of sats
@@ -111,7 +111,7 @@ SystemStatusPanel::Refresh()
   Temp.clear();
 #ifdef HAVE_BATTERY
   if (Power::Battery::RemainingPercentValid) {
-    Temp.Format(_T("%d %% "), Power::Battery::RemainingPercent);
+    Temp.Format(_T("%u %% "), Power::Battery::RemainingPercent);
   }
 #endif
   if (basic.voltage_available)

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1058,6 +1058,15 @@ static constexpr MetaData meta_data[] = {
     N_("Pie chart of time circling and climbing, circling and descending, and climbing non-circling."),
     IBFHelper<InfoBoxContentClimbPercent>::Create,
   },
+
+  // NbrSat 
+  {
+    N_("Number of used Sats"),
+    N_("Nbr Sat"),
+    N_("The number of actually used (seen) satellites by GPS module"),
+    UpdateInfoBoxNbrSat,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -53,7 +53,7 @@ UpdateInfoBoxBattery(InfoBoxData &data)
   switch (Power::External::Status) {
     case Power::External::OFF:
       if (CommonInterface::Basic().battery_level_available)
-        data.UnsafeFormatComment(_T("%s; %d%%"),
+        data.UnsafeFormatComment(_T("%s; %u%%"),
                                  _("AC Off"),
                                  (int)CommonInterface::Basic().battery_level);
       else
@@ -188,13 +188,13 @@ UpdateInfoBoxNbrSat(InfoBoxData &data) {
     const NMEAInfo &basic = CommonInterface::Basic();
     const GPSState &gps = basic.gps;
 
-    data.SetComment(_(GetGPSStatus(basic)));
+    data.SetComment(gettext(GetGPSStatus(basic)));
     
     if (!basic.alive)
         data.SetComment(_("No GPS"));
     else if (gps.satellites_used_available) {
         // known number of sats
-        data.FormatValue(_T("%d"), gps.satellites_used);
+        data.FormatValue(_T("%u"), gps.satellites_used);
     } else {
         // valid but unknown number of sats
         data.SetValue(_("Unknown"));

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -188,19 +188,13 @@ UpdateInfoBoxNbrSat(InfoBoxData &data) {
     const NMEAInfo &basic = CommonInterface::Basic();
     const GPSState &gps = basic.gps;
 
-    StaticString<80> Temp;
-    StaticString<20> GpsStatus;
-
-    GpsStatus = gettext(GetGPSStatus(basic));
-    data.SetComment(_(GpsStatus));
+    data.SetComment(_(GetGPSStatus(basic)));
     
     if (!basic.alive)
         data.SetComment(_("No GPS"));
-        //    ClearText(NumSat);
     else if (gps.satellites_used_available) {
         // known number of sats
-        Temp.Format(_T("%d"), gps.satellites_used);
-        data.SetValue(Temp);
+        data.FormatValue(_T("%d"), gps.satellites_used);
     } else {
         // valid but unknown number of sats
         data.SetValue(_("Unknown"));

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -167,3 +167,44 @@ InfoBoxContentHorizon::Update(InfoBoxData &data)
 
   data.SetCustom();
 }
+
+
+gcc_pure
+static const TCHAR *
+GetGPSStatus(const NMEAInfo &basic)
+{
+  if (!basic.alive)
+    return N_("Disconnected");
+  else if (!basic.location_available)
+    return N_("Fix invalid");
+  else if (!basic.gps_altitude_available)
+    return N_("2D fix");
+  else
+    return N_("3D fix");
+}
+
+void
+UpdateInfoBoxNbrSat(InfoBoxData &data) {
+    const NMEAInfo &basic = CommonInterface::Basic();
+    const GPSState &gps = basic.gps;
+
+    StaticString<80> Temp;
+    StaticString<20> GpsStatus;
+
+    GpsStatus = gettext(GetGPSStatus(basic));
+    data.SetComment(_(GpsStatus));
+    
+    if (!basic.alive)
+        data.SetComment(_("No GPS"));
+        //    ClearText(NumSat);
+    else if (gps.satellites_used_available) {
+        // known number of sats
+        Temp.Format(_T("%d"), gps.satellites_used);
+        data.SetValue(Temp);
+    } else {
+        // valid but unknown number of sats
+        data.SetValue(_("Unknown"));
+    }
+}
+
+

--- a/src/InfoBoxes/Content/Other.hpp
+++ b/src/InfoBoxes/Content/Other.hpp
@@ -44,6 +44,9 @@ UpdateInfoBoxCPULoad(InfoBoxData &data);
 void
 UpdateInfoBoxFreeRAM(InfoBoxData &data);
 
+void
+UpdateInfoBoxNbrSat(InfoBoxData &data);
+
 class InfoBoxContentHorizon : public InfoBoxContent
 {
 public:

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -162,6 +162,8 @@ namespace InfoBoxFactory
 
     e_Climb_Perc_Chart,
 
+    e_NbrSat, /* Number of used Sat by GPS module */
+
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
This (small) modification is to create a new InfoBox with de "Number Of Satellite" used by GPS module.  It can be used to monitor the gps reception quality during the flight, without going to status panel. very usefull for "light users", in paraglider, because we use very light gps modules, sometimes included INTO kobo itself. 
The infobox use existing gps status code, and just obtained infos into a conventional InfoBox.  Number of sats and status of connection (3d fix, ....).
As the used words for display are same as originals, the translating system of the app work on it too.
Hope it can be usefull for others.