### PR TITLE
musl libc (for Kobo)

### DIFF
--- a/build/ct-ng/armv7a-a8neon-linux-musleabihf.config
+++ b/build/ct-ng/armv7a-a8neon-linux-musleabihf.config
@@ -1,0 +1,544 @@
+# crosstool-ng 1.23.0
+#
+# Automatically generated file; DO NOT EDIT.
+# Crosstool-NG Configuration
+#
+CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_wget=y
+CT_CONFIGURE_has_curl=y
+CT_CONFIGURE_has_stat_flavor_GNU=y
+CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
+CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
+CT_CONFIGURE_has_autoconf_2_63_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_63_or_newer=y
+CT_CONFIGURE_has_automake_1_15_or_newer=y
+CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_svn=y
+CT_CONFIGURE_has_git=y
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+# CT_OBSOLETE is not set
+CT_EXPERIMENTAL=y
+# CT_ALLOW_BUILD_AS_ROOT is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR="${HOME}/src"
+CT_SAVE_TARBALLS=y
+CT_WORK_DIR="${CT_TOP_DIR}/.build"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_PREFIX_DIR="${CT_PREFIX:-${HOME}/x-tools}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+CT_PREFIX_DIR_RO=y
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+# CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES is not set
+
+#
+# Downloading
+#
+CT_DOWNLOAD_AGENT_WGET=y
+# CT_DOWNLOAD_AGENT_CURL is not set
+# CT_DOWNLOAD_AGENT_NONE is not set
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERRIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+CT_PATCH_BUNDLED=y
+# CT_PATCH_LOCAL is not set
+# CT_PATCH_BUNDLED_LOCAL is not set
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_BUNDLED_FALLBACK_LOCAL is not set
+# CT_PATCH_LOCAL_FALLBACK_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD=""
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST=""
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+# CT_LOG_INFO is not set
+CT_LOG_EXTRA=y
+# CT_LOG_ALL is not set
+# CT_LOG_DEBUG is not set
+CT_LOG_LEVEL_MAX="EXTRA"
+# CT_LOG_SEE_TOOLS_WARN is not set
+CT_LOG_PROGRESS_BAR=y
+CT_LOG_TO_FILE=y
+CT_LOG_FILE_COMPRESS=y
+
+#
+# Target options
+#
+CT_ARCH="arm"
+# CT_ARCH_alpha is not set
+CT_ARCH_arm=y
+# CT_ARCH_avr is not set
+# CT_ARCH_m68k is not set
+# CT_ARCH_microblaze is not set
+# CT_ARCH_mips is not set
+# CT_ARCH_nios2 is not set
+# CT_ARCH_powerpc is not set
+# CT_ARCH_s390 is not set
+# CT_ARCH_sh is not set
+# CT_ARCH_sparc is not set
+# CT_ARCH_x86 is not set
+# CT_ARCH_xtensa is not set
+CT_ARCH_alpha_AVAILABLE=y
+CT_ARCH_arm_AVAILABLE=y
+CT_ARCH_avr_AVAILABLE=y
+CT_ARCH_m68k_AVAILABLE=y
+CT_ARCH_microblaze_AVAILABLE=y
+CT_ARCH_mips_AVAILABLE=y
+CT_ARCH_nios2_AVAILABLE=y
+CT_ARCH_powerpc_AVAILABLE=y
+CT_ARCH_s390_AVAILABLE=y
+CT_ARCH_sh_AVAILABLE=y
+CT_ARCH_sparc_AVAILABLE=y
+CT_ARCH_x86_AVAILABLE=y
+CT_ARCH_xtensa_AVAILABLE=y
+CT_ARCH_SUFFIX="v7a"
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_DEMULTILIB=y
+CT_ARCH_SUPPORTS_BOTH_MMU=y
+CT_ARCH_DEFAULT_HAS_MMU=y
+CT_ARCH_USE_MMU=y
+CT_ARCH_SUPPORTS_BOTH_ENDIAN=y
+CT_ARCH_DEFAULT_LE=y
+# CT_ARCH_BE is not set
+CT_ARCH_LE=y
+CT_ARCH_ENDIAN="little"
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_DEFAULT_32=y
+CT_ARCH_BITNESS=32
+CT_ARCH_32=y
+# CT_ARCH_64 is not set
+
+#
+# Target optimisations
+#
+CT_ARCH_SUPPORTS_WITH_ARCH=y
+CT_ARCH_SUPPORTS_WITH_CPU=y
+CT_ARCH_SUPPORTS_WITH_TUNE=y
+CT_ARCH_SUPPORTS_WITH_FLOAT=y
+CT_ARCH_SUPPORTS_WITH_FPU=y
+CT_ARCH_SUPPORTS_SOFTFP=y
+CT_ARCH_EXCLUSIVE_WITH_CPU=y
+CT_ARCH_CPU="cortex-a8"
+CT_ARCH_FPU="neon"
+# CT_ARCH_FLOAT_AUTO is not set
+CT_ARCH_FLOAT_HW=y
+# CT_ARCH_FLOAT_SOFTFP is not set
+# CT_ARCH_FLOAT_SW is not set
+CT_TARGET_CFLAGS=""
+CT_TARGET_LDFLAGS=""
+CT_ARCH_FLOAT="hard"
+
+#
+# arm other options
+#
+CT_ARCH_ARM_MODE="arm"
+CT_ARCH_ARM_MODE_ARM=y
+# CT_ARCH_ARM_MODE_THUMB is not set
+# CT_ARCH_ARM_INTERWORKING is not set
+CT_ARCH_ARM_EABI_FORCE=y
+CT_ARCH_ARM_EABI=y
+CT_ARCH_ARM_TUPLE_USE_EABIHF=y
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_FORCE_SYSROOT=y
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+CT_WANTS_STATIC_LINK=y
+CT_WANTS_STATIC_LINK_CXX=y
+# CT_STATIC_TOOLCHAIN is not set
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
+CT_TARGET_VENDOR="a8neon"
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+# CT_NATIVE is not set
+CT_CROSS=y
+# CT_CROSS_NATIVE is not set
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+
+#
+# Operating System
+#
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+CT_KERNEL="linux"
+CT_KERNEL_VERSION="4.10.8"
+# CT_KERNEL_bare_metal is not set
+CT_KERNEL_linux=y
+CT_KERNEL_bare_metal_AVAILABLE=y
+CT_KERNEL_linux_AVAILABLE=y
+# CT_KERNEL_LINUX_CUSTOM is not set
+CT_KERNEL_V_4_10=y
+# CT_KERNEL_V_4_9 is not set
+# CT_KERNEL_V_4_4 is not set
+# CT_KERNEL_V_4_1 is not set
+# CT_KERNEL_V_3_16 is not set
+# CT_KERNEL_V_3_12 is not set
+# CT_KERNEL_V_3_10 is not set
+# CT_KERNEL_V_3_4 is not set
+# CT_KERNEL_V_3_2 is not set
+CT_KERNEL_windows_AVAILABLE=y
+
+#
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+
+#
+# linux other options
+#
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+CT_KERNEL_LINUX_INSTALL_CHECK=y
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_binutils=y
+
+#
+# GNU binutils
+#
+# CT_BINUTILS_CUSTOM is not set
+CT_BINUTILS_VERSION="2.28"
+# CT_BINUTILS_SHOW_LINARO is not set
+CT_BINUTILS_V_2_28=y
+# CT_BINUTILS_V_2_27 is not set
+# CT_BINUTILS_V_2_26 is not set
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_2_26_or_later=y
+CT_BINUTILS_2_25_1_or_later=y
+CT_BINUTILS_2_25_or_later=y
+CT_BINUTILS_2_24_or_later=y
+CT_BINUTILS_2_23_2_or_later=y
+CT_BINUTILS_HAS_HASH_STYLE=y
+CT_BINUTILS_HAS_GOLD=y
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_GOLD_SUPPORT=y
+CT_BINUTILS_HAS_PLUGINS=y
+CT_BINUTILS_HAS_PKGVERSION_BUGURL=y
+# CT_BINUTILS_LINKER_LD is not set
+# CT_BINUTILS_LINKER_GOLD is not set
+# CT_BINUTILS_LINKER_LD_GOLD is not set
+CT_BINUTILS_LINKER_GOLD_LD=y
+CT_BINUTILS_GOLD_INSTALLED=y
+CT_BINUTILS_GOLD_THREADS=y
+CT_BINUTILS_LINKER_BOTH=y
+CT_BINUTILS_LINKERS_LIST="gold,ld"
+CT_BINUTILS_LD_WRAPPER=y
+CT_BINUTILS_LINKER_DEFAULT="gold"
+CT_BINUTILS_PLUGINS=y
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+CT_BINUTILS_FOR_TARGET=y
+CT_BINUTILS_FOR_TARGET_IBERTY=y
+CT_BINUTILS_FOR_TARGET_BFD=y
+
+#
+# binutils other options
+#
+
+#
+# C-library
+#
+CT_LIBC="musl"
+CT_LIBC_VERSION="1.1.16"
+# CT_LIBC_glibc is not set
+CT_LIBC_musl=y
+# CT_LIBC_uClibc is not set
+CT_LIBC_avr_libc_AVAILABLE=y
+CT_LIBC_glibc_AVAILABLE=y
+CT_THREADS="musl"
+CT_LIBC_mingw_AVAILABLE=y
+CT_LIBC_musl_AVAILABLE=y
+# CT_LIBC_MUSL_CUSTOM is not set
+CT_LIBC_MUSL_V_1_1_16=y
+CT_LIBC_newlib_AVAILABLE=y
+CT_LIBC_none_AVAILABLE=y
+CT_LIBC_uClibc_AVAILABLE=y
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
+
+#
+# Common C library options
+#
+CT_THREADS_NATIVE=y
+# CT_CREATE_LDSO_CONF is not set
+CT_LIBC_XLDD=y
+
+#
+# musl other options
+#
+# CT_LIBC_MUSL_DEBUG is not set
+# CT_LIBC_MUSL_WARNINGS is not set
+# CT_LIBC_MUSL_OPTIMIZE_NONE is not set
+CT_LIBC_MUSL_OPTIMIZE_AUTO=y
+# CT_LIBC_MUSL_OPTIMIZE_SPEED is not set
+# CT_LIBC_MUSL_OPTIMIZE_SIZE is not set
+CT_LIBC_MUSL_OPTIMIZE="auto"
+
+#
+# C compiler
+#
+CT_CC="gcc"
+CT_CC_CORE_PASSES_NEEDED=y
+CT_CC_CORE_PASS_1_NEEDED=y
+CT_CC_CORE_PASS_2_NEEDED=y
+CT_CC_gcc=y
+# CT_CC_GCC_CUSTOM is not set
+CT_CC_GCC_VERSION="6.3.0"
+# CT_CC_GCC_SHOW_LINARO is not set
+CT_CC_GCC_V_6_3_0=y
+# CT_CC_GCC_V_5_4_0 is not set
+# CT_CC_GCC_V_4_9_4 is not set
+CT_CC_GCC_4_8_or_later=y
+CT_CC_GCC_4_9_or_later=y
+CT_CC_GCC_5_or_later=y
+CT_CC_GCC_6=y
+CT_CC_GCC_6_or_later=y
+CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_GCC_GOLD=y
+CT_CC_GCC_HAS_LIBMPX=y
+CT_CC_GCC_ENABLE_CXX_FLAGS=""
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_EXTRA_CONFIG_ARRAY=""
+CT_CC_GCC_STATIC_LIBSTDCXX=y
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+CT_CC_GCC_CONFIG_TLS=m
+
+#
+# Optimisation features
+#
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_USE_LTO=y
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_TARGET_OPTSPACE=y
+# CT_CC_GCC_LIBMUDFLAP is not set
+# CT_CC_GCC_LIBGOMP is not set
+# CT_CC_GCC_LIBSSP is not set
+# CT_CC_GCC_LIBQUADMATH is not set
+
+#
+# Misc. obscure options.
+#
+CT_CC_CXA_ATEXIT=y
+# CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
+CT_CC_GCC_LDBL_128=m
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOAT_AUTO=y
+# CT_CC_GCC_DEC_FLOAT_BID is not set
+# CT_CC_GCC_DEC_FLOAT_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_JAVA=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+# CT_CC_LANG_FORTRAN is not set
+# CT_CC_LANG_JAVA is not set
+# CT_CC_LANG_ADA is not set
+# CT_CC_LANG_OBJC is not set
+# CT_CC_LANG_OBJCXX is not set
+# CT_CC_LANG_GOLANG is not set
+CT_CC_LANG_OTHERS=""
+
+#
+# Debug facilities
+#
+CT_DEBUG_duma=y
+CT_DUMA_SO=y
+CT_DUMA_CUSTOM_WRAPPER=y
+CT_DUMA_V_2_5_15=y
+CT_DUMA_VERSION="2_5_15"
+CT_DEBUG_gdb=y
+CT_GDB_CROSS=y
+CT_GDB_CROSS_STATIC=y
+# CT_GDB_CROSS_SIM is not set
+CT_GDB_CROSS_EXTRA_CONFIG_ARRAY=""
+CT_GDB_NATIVE=y
+CT_GDB_NATIVE_STATIC=y
+CT_GDB_GDBSERVER=y
+CT_GDB_GDBSERVER_HAS_IPA_LIB=y
+CT_GDB_GDBSERVER_STATIC=y
+
+#
+# gdb version
+#
+# CT_GDB_CUSTOM is not set
+CT_GDB_VERSION="7.12.1"
+CT_GDB_V_7_12_1=y
+# CT_GDB_V_7_11_1 is not set
+CT_GDB_7_12_or_later=y
+CT_GDB_7_2_or_later=y
+CT_GDB_7_0_or_later=y
+CT_GDB_HAS_PKGVERSION_BUGURL=y
+CT_GDB_HAS_PYTHON=y
+CT_GDB_INSTALL_GDBINIT=y
+# CT_DEBUG_ltrace is not set
+CT_DEBUG_strace=y
+CT_STRACE_V_4_16=y
+# CT_STRACE_V_4_15 is not set
+CT_STRACE_VERSION="4.16"
+
+#
+# Companion libraries
+#
+CT_COMPLIBS_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_EXPAT_NEEDED=y
+CT_NCURSES_NEEDED=y
+CT_COMPLIBS=y
+# CT_LIBICONV is not set
+# CT_GETTEXT is not set
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_EXPAT=y
+CT_EXPAT_TARGET=y
+CT_NCURSES=y
+CT_NCURSES_TARGET=y
+# CT_ZLIB is not set
+CT_GMP_V_6_1_2=y
+CT_GMP_5_0_2_or_later=y
+CT_GMP_VERSION="6.1.2"
+CT_MPFR_V_3_1_5=y
+CT_MPFR_VERSION="3.1.5"
+CT_ISL_V_0_18=y
+# CT_ISL_V_0_17_1 is not set
+# CT_ISL_V_0_16_1 is not set
+# CT_ISL_V_0_15 is not set
+CT_ISL_V_0_16_or_later=y
+CT_ISL_V_0_15_or_later=y
+CT_ISL_V_0_14_or_later=y
+CT_ISL_V_0_12_or_later=y
+CT_ISL_VERSION="0.18"
+CT_MPC_V_1_0_3=y
+CT_MPC_VERSION="1.0.3"
+CT_EXPAT_V_2_2_0=y
+CT_EXPAT_VERSION="2.2.0"
+CT_NCURSES_V_6_0=y
+CT_NCURSES_VERSION="6.0"
+# CT_NCURSES_NEW_ABI is not set
+CT_NCURSES_HOST_CONFIG_ARGS=""
+CT_NCURSES_HOST_DISABLE_DB=y
+CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
+CT_NCURSES_TARGET_CONFIG_ARGS=""
+# CT_NCURSES_TARGET_DISABLE_DB is not set
+CT_NCURSES_TARGET_FALLBACKS=""
+
+#
+# Companion libraries common options
+#
+# CT_COMPLIBS_CHECK is not set
+
+#
+# Companion tools
+#
+# CT_COMP_TOOLS_FOR_HOST is not set
+# CT_COMP_TOOLS_autoconf is not set
+# CT_COMP_TOOLS_automake is not set
+# CT_COMP_TOOLS_libtool is not set
+# CT_COMP_TOOLS_m4 is not set
+# CT_COMP_TOOLS_make is not set
+
+#
+# Test suite
+#
+# CT_TEST_SUITE_GCC is not set

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -73,28 +73,6 @@ fi)
 BITSTREAM_VERA_NAMES = Vera VeraBd VeraIt VeraBI VeraMono
 BITSTREAM_VERA_FILES = $(patsubst %,$(BITSTREAM_VERA_DIR)/%.ttf,$(BITSTREAM_VERA_NAMES))
 
-ifeq ($(USE_CROSSTOOL_NG),y)
-  SYSROOT = $(shell $(CC) -print-sysroot)
-else
-  # from Debian package libc6-armhf-cross
-  SYSROOT = /usr/arm-linux-gnueabihf
-endif
-
-# install our version of the system libraries in /opt/xcsoar/lib; this
-# is necessary because:
-# - we cannot link statically because we need NSS (name service
-#   switch) modules
-# - Kobo's stock glibc may be incompatible on some older firmware
-#   versions
-KOBO_SYS_LIB_NAMES = libc.so.6 libm.so.6 libpthread.so.0 librt.so.1 \
-	libdl.so.2 \
-	libresolv.so.2 libnss_dns.so.2 libnss_files.so.2 \
-	ld-linux-armhf.so.3
-
-KOBO_SYS_LIB_PATHS = $(addprefix $(THIRDPARTY_LIBS_ROOT)/lib/,$(KOBO_SYS_LIB_NAMES))
-
-# from Debian package libgcc1-armhf-cross
-KOBO_SYS_LIB_PATHS += $(SYSROOT)/lib/libgcc_s.so.1
 THIRDPARTY_TOOL_NAMES = simple_usbmodeswitch
 THIRDPARTY_TOOL_FILES = $(addprefix $(THIRDPARTY_LIBS_ROOT)/bin/,$(THIRDPARTY_TOOL_NAMES))
 
@@ -111,7 +89,6 @@ $(TARGET_OUTPUT_DIR)/KoboRoot.tgz: $(XCSOAR_BIN) \
 	$(Q)rm -rf $(@D)/KoboRoot
 	$(Q)install -m 0755 -d $(@D)/KoboRoot/etc/udev/rules.d $(@D)/KoboRoot/opt/xcsoar/bin $(@D)/KoboRoot/opt/xcsoar/lib/kernel $(@D)/KoboRoot/opt/xcsoar/share/fonts
 	$(Q)install -m 0755 $(XCSOAR_BIN) $(KOBO_MENU_BIN) $(KOBO_POWER_OFF_BIN) $(topdir)/kobo/rcS $(@D)/KoboRoot/opt/xcsoar/bin
-	$(Q)install --strip --strip-program=$(STRIP) -m 0755 $(KOBO_SYS_LIB_PATHS) $(@D)/KoboRoot/opt/xcsoar/lib
 	$(Q)install -m 0755 --strip --strip-program=$(STRIP) $(THIRDPARTY_TOOL_FILES) $(@D)/KoboRoot/opt/xcsoar/bin
 	$(Q)if test -f $(KOBO_KERNEL_DIR)/uImage.kobo; then install -m 0644 $(KOBO_KERNEL_DIR)/uImage.kobo $(@D)/KoboRoot/opt/xcsoar/lib/kernel; fi
 	$(Q)if test -f $(KOBO_KERNEL_DIR)/uImage.otg; then install -m 0644 $(KOBO_KERNEL_DIR)/uImage.otg $(@D)/KoboRoot/opt/xcsoar/lib/kernel; fi

--- a/build/python/build/autotools.py
+++ b/build/python/build/autotools.py
@@ -59,6 +59,16 @@ class AutotoolsProject(MakeProject):
             import re
             cppflags = re.sub(r'\s*-isystem\s+\S+\s*', ' ', cppflags)
 
+        cflags = toolchain.cflags
+        if self.name == 'musl':
+            # WORKAROUND: Use ARM instructions (not Thumb) for musl, to
+            # circumvent crash.
+            # See http://www.openwall.com/lists/musl/2017/10/08/2
+            if '-mthumb' in cflags:
+              cflags = cflags.replace('-mthumb', '-marm')
+            else:
+              cflags = cflags + ' -marm '
+
         install_prefix = self.install_prefix
         if install_prefix is None:
             install_prefix = toolchain.install_prefix
@@ -67,7 +77,7 @@ class AutotoolsProject(MakeProject):
             os.path.join(src, self.config_script),
             'CC=' + toolchain.cc,
             'CXX=' + toolchain.cxx,
-            'CFLAGS=' + self._filter_cflags(toolchain.cflags),
+            'CFLAGS=' + self._filter_cflags(cflags),
             'CXXFLAGS=' + self._filter_cflags(toolchain.cxxflags),
             'CPPFLAGS=' + cppflags + ' ' + self.cppflags,
             'LDFLAGS=' + toolchain.ldflags + ' ' + self.ldflags,

--- a/build/python/build/autotools.py
+++ b/build/python/build/autotools.py
@@ -14,6 +14,7 @@ class AutotoolsProject(MakeProject):
                  use_destdir=False,
                  make_args=[],
                  config_script='configure',
+                 use_actual_arch=False,
                  **kwargs):
         MakeProject.__init__(self, url, alternative_url, md5, installed, **kwargs)
         self.configure_args = configure_args
@@ -26,6 +27,7 @@ class AutotoolsProject(MakeProject):
         self.use_destdir = use_destdir
         self.make_args = make_args
         self.config_script = config_script
+        self.use_actual_arch = use_actual_arch
 
     def _filter_cflags(self, flags):
         if self.shared:
@@ -74,7 +76,7 @@ class AutotoolsProject(MakeProject):
             'ARFLAGS=' + toolchain.arflags,
             'RANLIB=' + toolchain.ranlib,
             'STRIP=' + toolchain.strip,
-            '--host=' + toolchain.arch,
+            '--host=' + (toolchain.actual_arch if self.use_actual_arch else toolchain.toolchain_arch),
             '--prefix=' + install_prefix,
             '--enable-silent-rules',
         ] + self.configure_args

--- a/build/python/build/autotools.py
+++ b/build/python/build/autotools.py
@@ -13,6 +13,7 @@ class AutotoolsProject(MakeProject):
                  install_target='install',
                  use_destdir=False,
                  make_args=[],
+                 config_script='configure',
                  **kwargs):
         MakeProject.__init__(self, url, alternative_url, md5, installed, **kwargs)
         self.configure_args = configure_args
@@ -24,6 +25,7 @@ class AutotoolsProject(MakeProject):
         self.install_prefix = install_prefix
         self.use_destdir = use_destdir
         self.make_args = make_args
+        self.config_script = config_script
 
     def _filter_cflags(self, flags):
         if self.shared:
@@ -60,7 +62,7 @@ class AutotoolsProject(MakeProject):
             install_prefix = toolchain.install_prefix
 
         configure = [
-            os.path.join(src, 'configure'),
+            os.path.join(src, self.config_script),
             'CC=' + toolchain.cc,
             'CXX=' + toolchain.cxx,
             'CFLAGS=' + self._filter_cflags(toolchain.cflags),

--- a/build/python/build/curl.py
+++ b/build/python/build/curl.py
@@ -3,7 +3,7 @@ from build.autotools import AutotoolsProject
 class CurlProject(AutotoolsProject):
     def configure(self, toolchain):
         # disable usage of pthreads for Win32 builds
-        if 'mingw' in toolchain.arch:
+        if 'mingw' in toolchain.actual_arch:
             self.configure_args.append('--enable-pthreads=no')
 
         return AutotoolsProject.configure(self, toolchain)

--- a/build/python/build/libpng.py
+++ b/build/python/build/libpng.py
@@ -3,7 +3,7 @@ from build.autotools import AutotoolsProject
 class LibPNGProject(AutotoolsProject):
     def configure(self, toolchain):
         # append argument --enable-arm-neon for targets supporting NEON
-        if toolchain.arch.startswith('aarch64') or '-mfpu=neon' in toolchain.cflags:
+        if toolchain.actual_arch.startswith('aarch64') or '-mfpu=neon' in toolchain.cflags:
             self.configure_args.append('--enable-arm-neon')
 
         return AutotoolsProject.configure(self, toolchain)

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -35,6 +35,7 @@ musl = AutotoolsProject(
     [
         '--disable-shared',
     ],
+    patches=abspath('lib/musl/patches'),
 )
 
 openssl = OpenSSLProject(

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -27,6 +27,16 @@ glibc = AutotoolsProject(
     make_args=['default-rpath=/opt/xcsoar/lib'],
 )
 
+musl = AutotoolsProject(
+    'https://www.musl-libc.org/releases/musl-1.1.16.tar.gz',
+    'https://fossies.org/linux/misc/musl-1.1.16.tar.gz',
+    '937185a5e5d721050306cf106507a006c3f1f86d86cd550024ea7be909071011',
+    'include/unistd.h',
+    [
+        '--disable-shared',
+    ],
+)
+
 openssl = OpenSSLProject(
     'https://www.openssl.org/source/openssl-1.0.2k.tar.gz',
     'ftp://ftp.kfki.hu/pub/packages/security/openssl/openssl-1.0.2k.tar.gz',

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -6,6 +6,7 @@ from build.openssl import OpenSSLProject
 from build.freetype import FreeTypeProject
 from build.curl import CurlProject
 from build.libpng import LibPNGProject
+from build.libstdcxxmuslheaders import LibstdcxxMuslHeadersProject
 from build.sdl2 import SDL2Project
 from build.lua import LuaProject
 
@@ -36,6 +37,20 @@ musl = AutotoolsProject(
         '--disable-shared',
     ],
     patches=abspath('lib/musl/patches'),
+)
+
+libstdcxx_musl_headers = LibstdcxxMuslHeadersProject(
+    'https://ftp.gnu.org/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.xz',
+    'http://mirrors.ibiblio.org/gnu/ftp/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.xz',
+    '850bf21eafdfe5cd5f6827148184c08c4a0852a37ccf36ce69855334d2c914d4',
+    'include/libstdc++/algorithm',
+    [
+        '--enable-clocale=generic',
+        '--disable-shared',
+        '--disable-multilib',
+    ],
+    config_script='libstdc++-v3/configure',
+    use_actual_arch=True,
 )
 
 openssl = OpenSSLProject(

--- a/build/python/build/libstdcxxmuslheaders.py
+++ b/build/python/build/libstdcxxmuslheaders.py
@@ -1,0 +1,15 @@
+from build.autotools import AutotoolsProject
+from build.makeproject import MakeProject
+
+# Installer for musl compatible libstdc++ headers.
+# The static libstdc++ (and libsupc++) libraries from GNU toolchains are
+# musl comptatible, but the headers are not musl compatible.
+# So we need to install a set of libstd++ headers, which are included in the gcc
+# source tarball.
+class LibstdcxxMuslHeadersProject(AutotoolsProject):
+    def build(self, toolchain):
+        build = self.configure(toolchain)
+        incdir_param = 'gxx_include_dir=' + toolchain.install_prefix + '/include/libstdc++'
+        self.make(toolchain, build + '/libsupc++', [incdir_param, 'install-bitsHEADERS'])
+        self.make(toolchain, build + '/libsupc++', [incdir_param, 'install-stdHEADERS'])
+        self.make(toolchain, build + '/include', [incdir_param, 'install-headers'])

--- a/build/python/build/makeproject.py
+++ b/build/python/build/makeproject.py
@@ -1,4 +1,4 @@
-import subprocess
+import subprocess, multiprocessing
 
 from build.project import Project
 
@@ -10,7 +10,12 @@ class MakeProject(Project):
         self.install_target = install_target
 
     def get_simultaneous_jobs(self):
-        return 12
+        try:
+            # use twice as many simultaneous jobs as we have CPU cores
+            return multiprocessing.cpu_count() * 2
+        except NotImplementedError:
+            # default to 12, if multiprocessing.cpu_count() is not implemented
+            return 12
 
     def get_make_args(self, toolchain):
         return ['--quiet', '-j' + str(self.get_simultaneous_jobs())]

--- a/build/python/build/makeproject.py
+++ b/build/python/build/makeproject.py
@@ -1,0 +1,28 @@
+import subprocess
+
+from build.project import Project
+
+class MakeProject(Project):
+    def __init__(self, url, alternative_url, md5, installed,
+                 install_target='install',
+                 **kwargs):
+        Project.__init__(self, url, alternative_url, md5, installed, **kwargs)
+        self.install_target = install_target
+
+    def get_simultaneous_jobs(self):
+        return 12
+
+    def get_make_args(self, toolchain):
+        return ['--quiet', '-j' + str(self.get_simultaneous_jobs())]
+
+    def get_make_install_args(self, toolchain):
+        return ['--quiet', self.install_target]
+
+    def make(self, toolchain, wd, args):
+        subprocess.check_call(['/usr/bin/make'] + args,
+                              cwd=wd, env=toolchain.env)
+
+    def build(self, toolchain, wd, install=True):
+        self.make(toolchain, wd, self.get_make_args(toolchain))
+        if install:
+            self.make(toolchain, wd, self.get_make_install_args(toolchain))

--- a/build/python/build/openssl.py
+++ b/build/python/build/openssl.py
@@ -1,11 +1,21 @@
 import subprocess
 
-from build.project import Project
+from build.makeproject import MakeProject
 
-class OpenSSLProject(Project):
+class OpenSSLProject(MakeProject):
     def __init__(self, url, alternative_url, md5, installed,
                  **kwargs):
-        Project.__init__(self, url, alternative_url, md5, installed, **kwargs)
+        MakeProject.__init__(self, url, alternative_url, md5, installed, install_target='install_sw', **kwargs)
+
+    def get_simultaneous_jobs(self):
+        return 1
+
+    def get_make_args(self, toolchain):
+        return MakeProject.get_make_args(self, toolchain) + [
+            'CC=' + toolchain.cc,
+            'AR=' + toolchain.ar + ' r',
+            'RANLIB=arm-linux-gnueabihf-ranlib'
+        ]
 
     def build(self, toolchain):
         src = self.unpack(toolchain, out_of_tree=False)
@@ -14,13 +24,4 @@ class OpenSSLProject(Project):
                                'dist', 'no-dso', 'no-krb5',
                                '--prefix=' + toolchain.install_prefix],
                               cwd=src, env=toolchain.env)
-        subprocess.check_call(['/usr/bin/make', '--quiet', '-j12',
-                               'CC=' + toolchain.cc,
-                               'AR=' + toolchain.ar + ' r',
-                               'RANLIB=arm-linux-gnueabihf-ranlib'],
-                              cwd=src, env=toolchain.env)
-        subprocess.check_call(['/usr/bin/make', '--quiet', 'install_sw',
-                               'CC=' + toolchain.cc,
-                               'AR=' + toolchain.ar + ' r',
-                               'RANLIB=arm-linux-gnueabihf-ranlib'],
-                              cwd=src, env=toolchain.env)
+        MakeProject.build(self, toolchain, wd)

--- a/build/python/build/sdl2.py
+++ b/build/python/build/sdl2.py
@@ -4,7 +4,7 @@ from build.autotools import AutotoolsProject
 
 class SDL2Project(AutotoolsProject):
     def configure(self, toolchain):
-        if re.match('(arm.*|aarch64)-apple-darwin', toolchain.arch) is not None:
+        if re.match('(arm.*|aarch64)-apple-darwin', toolchain.actual_arch) is not None:
             # for building SDL2 with autotools, several workarounds are
             # required:
             # * out-of-tree build is not supported
@@ -23,7 +23,7 @@ class SDL2Project(AutotoolsProject):
                 'LIBS=' + toolchain.libs,
                 'AR=' + toolchain.ar,
                 'STRIP=' + toolchain.strip,
-                '--host=' + toolchain.arch,
+                '--host=' + toolchain.toolchain_arch,
                 '--prefix=' + toolchain.install_prefix,
             ] + self.configure_args
 

--- a/build/python/build/zlib.py
+++ b/build/python/build/zlib.py
@@ -1,23 +1,26 @@
 import subprocess
 
-from build.project import Project
+from build.makeproject import MakeProject
 
-class ZlibProject(Project):
+class ZlibProject(MakeProject):
     def __init__(self, url, alternative_url, md5, installed,
                  **kwargs):
-        Project.__init__(self, url, alternative_url, md5, installed, **kwargs)
+        MakeProject.__init__(self, url, alternative_url, md5, installed, **kwargs)
+
+    def get_make_args(self, toolchain):
+        return MakeProject.get_make_args(self, toolchain) + [
+            'CC=' + toolchain.cc + ' ' + toolchain.cppflags + ' ' + toolchain.cflags,
+            'CPP=' + toolchain.cc + ' -E ' + toolchain.cppflags,
+            'AR=' + toolchain.ar,
+            'ARFLAGS=' + toolchain.arflags,
+            'RANLIB=' + toolchain.ranlib,
+            'LDSHARED=' + toolchain.cc + ' -shared',
+            'libz.a'
+        ]
 
     def build(self, toolchain):
         src = self.unpack(toolchain, out_of_tree=False)
 
         subprocess.check_call(['./configure', '--prefix=' + toolchain.install_prefix, '--static'],
                               cwd=src, env=toolchain.env)
-        subprocess.check_call(['/usr/bin/make', '--quiet',
-                               'CC=' + toolchain.cc + ' ' + toolchain.cppflags + ' ' + toolchain.cflags,
-                               'CPP=' + toolchain.cc + ' -E ' + toolchain.cppflags,
-                               'AR=' + toolchain.ar,
-                               'ARFLAGS=' + toolchain.arflags,
-                               'RANLIB=' + toolchain.ranlib,
-                               'LDSHARED=' + toolchain.cc + ' -shared',
-                               'install'],
-                              cwd=src, env=toolchain.env)
+        MakeProject.build(self, toolchain, src)

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -316,9 +316,9 @@ ifeq ($(TARGET),UNIX)
 
   ifeq ($(TARGET_IS_ARM)$(TARGET_IS_LINUX),yy)
     ifeq ($(TARGET_IS_ARMHF),y)
-      LLVM_TARGET = arm-linux-gnueabihf
+      LLVM_TARGET ?= arm-linux-gnueabihf
     else
-      LLVM_TARGET = arm-linux-gnueabi
+      LLVM_TARGET ?= arm-linux-gnueabi
     endif
   endif
 endif

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -219,9 +219,9 @@ ifeq ($(TARGET),NEON)
   # Experimental target for generic ARMv7 with NEON on Linux
   override TARGET = UNIX
   ifeq ($(USE_CROSSTOOL_NG),y)
-    HOST_TRIPLET = arm-unknown-linux-gnueabihf
+    HOST_TRIPLET ?= arm-unknown-linux-gnueabihf
   else
-    HOST_TRIPLET = arm-linux-gnueabihf
+    HOST_TRIPLET ?= arm-linux-gnueabihf
   endif
   TCPREFIX = $(HOST_TRIPLET)-
   ifeq ($(CLANG),n)

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -223,7 +223,7 @@ ifeq ($(TARGET),NEON)
   else
     HOST_TRIPLET ?= arm-linux-gnueabihf
   endif
-  TCPREFIX = $(HOST_TRIPLET)-
+  TCPREFIX ?= $(HOST_TRIPLET)-
   ifeq ($(CLANG),n)
     TARGET_ARCH += -mcpu=cortex-a8
   endif

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -530,9 +530,15 @@ ifeq ($(TARGET_IS_KOBO),y)
 
   ifeq ($(USE_CROSSTOOL_NG),y)
     HOST_TRIPLET = $(ACTUAL_HOST_TRIPLET)
+    LLVM_TARGET = $(ACTUAL_HOST_TRIPLET)
     KOBO_TOOLCHAIN = $(HOME)/x-tools/$(HOST_TRIPLET)
     KOBO_SYSROOT = $(KOBO_TOOLCHAIN)/$(HOST_TRIPLET)/sysroot
     TCPREFIX = $(KOBO_TOOLCHAIN)/bin/$(HOST_TRIPLET)-
+
+    ifeq ($(CLANG),y)
+      TARGET_CPPFLAGS += -B$(KOBO_TOOLCHAIN)
+      TARGET_CPPFLAGS += --sysroot=$(KOBO_SYSROOT)
+    endif
   else
     LIBSTDCXX_HEADERS_DIR = $(abspath $(THIRDPARTY_LIBS_ROOT)/include/libstdc++)
     TARGET_CXXFLAGS += \
@@ -621,7 +627,13 @@ endif
 
 ifeq ($(TARGET_IS_KOBO),y)
   TARGET_LDFLAGS += --static
-  ifneq ($(USE_CROSSTOOL_NG),y)
+  ifeq ($(USE_CROSSTOOL_NG),y)
+    ifeq ($(CLANG),y)
+     TARGET_LDFLAGS += -B$(KOBO_TOOLCHAIN)
+     TARGET_LDFLAGS += -B$(KOBO_TOOLCHAIN)/bin
+     TARGET_LDFLAGS += --sysroot=$(KOBO_SYSROOT)
+    endif
+  else
     TARGET_LDFLAGS += -specs=$(abspath $(THIRDPARTY_LIBS_ROOT)/lib/musl-gcc.specs)
   endif
 endif

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -528,11 +528,18 @@ ifeq ($(TARGET_IS_KOBO),y)
   # the actual host triplet is different.
   ACTUAL_HOST_TRIPLET = armv7a-a8neon-linux-musleabihf
 
-  LIBSTDCXX_HEADERS_DIR = $(abspath $(THIRDPARTY_LIBS_ROOT)/include/libstdc++)
-  TARGET_CXXFLAGS += \
+  ifeq ($(USE_CROSSTOOL_NG),y)
+    HOST_TRIPLET = $(ACTUAL_HOST_TRIPLET)
+    KOBO_TOOLCHAIN = $(HOME)/x-tools/$(HOST_TRIPLET)
+    KOBO_SYSROOT = $(KOBO_TOOLCHAIN)/$(HOST_TRIPLET)/sysroot
+    TCPREFIX = $(KOBO_TOOLCHAIN)/bin/$(HOST_TRIPLET)-
+  else
+    LIBSTDCXX_HEADERS_DIR = $(abspath $(THIRDPARTY_LIBS_ROOT)/include/libstdc++)
+    TARGET_CXXFLAGS += \
       -nostdinc++ \
       -isystem $(LIBSTDCXX_HEADERS_DIR) \
       -isystem $(LIBSTDCXX_HEADERS_DIR)/$(ACTUAL_HOST_TRIPLET)
+  endif
 endif
 
 ifeq ($(TARGET),ANDROID)
@@ -613,7 +620,10 @@ ifeq ($(HOST_IS_ARM)$(TARGET_HAS_MALI),ny)
 endif
 
 ifeq ($(TARGET_IS_KOBO),y)
-  TARGET_LDFLAGS += --static -specs=$(abspath $(THIRDPARTY_LIBS_ROOT)/lib/musl-gcc.specs)
+  TARGET_LDFLAGS += --static
+  ifneq ($(USE_CROSSTOOL_NG),y)
+    TARGET_LDFLAGS += -specs=$(abspath $(THIRDPARTY_LIBS_ROOT)/lib/musl-gcc.specs)
+  endif
 endif
 
 ifeq ($(TARGET),ANDROID)

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -518,6 +518,21 @@ endif
 
 ifeq ($(TARGET_IS_KOBO),y)
   TARGET_CPPFLAGS += -DKOBO
+
+  # Use Thumb instructions (which is the default in Debian's arm-linux-gnueabihf
+  # toolchain, but this might be different when using another toolchain, or
+  # Clang instead of GCC).
+  TARGET_ARCH += -mthumb
+
+  # We are using a GNU toolchain (triplet arm-linux-gnueabihf) by default, but
+  # the actual host triplet is different.
+  ACTUAL_HOST_TRIPLET = armv7a-a8neon-linux-musleabihf
+
+  LIBSTDCXX_HEADERS_DIR = $(abspath $(THIRDPARTY_LIBS_ROOT)/include/libstdc++)
+  TARGET_CXXFLAGS += \
+      -nostdinc++ \
+      -isystem $(LIBSTDCXX_HEADERS_DIR) \
+      -isystem $(LIBSTDCXX_HEADERS_DIR)/$(ACTUAL_HOST_TRIPLET)
 endif
 
 ifeq ($(TARGET),ANDROID)
@@ -598,12 +613,7 @@ ifeq ($(HOST_IS_ARM)$(TARGET_HAS_MALI),ny)
 endif
 
 ifeq ($(TARGET_IS_KOBO),y)
-  TARGET_LDFLAGS += -static-libstdc++
-
-  # use our glibc version and its ld.so on the Kobo, not the one from
-  # the stock Kobo firmware, as it may be incompatible
-  TARGET_LDFLAGS += -Wl,--dynamic-linker=/opt/xcsoar/lib/ld-linux-armhf.so.3
-  TARGET_LDFLAGS += -Wl,--rpath=/opt/xcsoar/lib
+  TARGET_LDFLAGS += --static -specs=$(abspath $(THIRDPARTY_LIBS_ROOT)/lib/musl-gcc.specs)
 endif
 
 ifeq ($(TARGET),ANDROID)

--- a/build/thirdparty.mk
+++ b/build/thirdparty.mk
@@ -21,10 +21,20 @@ endif
 
 ifeq ($(USE_THIRDPARTY_LIBS),y)
 
+# In most cases, the ACTUAL_HOST_TRIPLET is not explicitly set. Set it to the
+# value of HOST_TRIPLET in this case.
+# This is for targets for which a toolchain is used, which was originally
+# intended for another target ABI, e. g. when the arm-linux-gnueabihf toolchain
+# used to compile for musl instead of glibc, and so the actual triplet is
+# something like arm-linux-musleabihf.
+ifeq ($(ACTUAL_HOST_TRIPLET),)
+  ACTUAL_HOST_TRIPLET = $(HOST_TRIPLET)
+endif
+
 # -Wl,--gc-sections breaks the (Kobo) glibc build
 THIRDPARTY_LDFLAGS_FILTER_OUT = -L% -Wl,--gc-sections
 
-THIRDPARTY_LIBS_DIR = $(TARGET_OUTPUT_DIR)/lib/$(HOST_TRIPLET)
+THIRDPARTY_LIBS_DIR = $(TARGET_OUTPUT_DIR)/lib/$(ACTUAL_HOST_TRIPLET)
 THIRDPARTY_LIBS_ROOT = $(THIRDPARTY_LIBS_DIR)/root
 
 .PHONY: libs
@@ -32,7 +42,7 @@ libs: $(THIRDPARTY_LIBS_DIR)/stamp
 
 compile-depends += $(THIRDPARTY_LIBS_DIR)/stamp
 $(THIRDPARTY_LIBS_DIR)/stamp:
-	./build/thirdparty.py $(TARGET_OUTPUT_DIR) $(TARGET) $(HOST_TRIPLET) "$(TARGET_ARCH)" "$(TARGET_CPPFLAGS)" "$(filter-out $(THIRDPARTY_LDFLAGS_FILTER_OUT),$(TARGET_LDFLAGS))" $(CC) $(CXX) $(AR) "$(ARFLAGS)" $(RANLIB) $(STRIP)
+	./build/thirdparty.py $(TARGET_OUTPUT_DIR) $(TARGET) $(HOST_TRIPLET) $(ACTUAL_HOST_TRIPLET) "$(TARGET_ARCH)" "$(TARGET_CPPFLAGS)" "$(filter-out $(THIRDPARTY_LDFLAGS_FILTER_OUT),$(TARGET_LDFLAGS))" $(CC) $(CXX) $(AR) "$(ARFLAGS)" $(RANLIB) $(STRIP)
 	touch $@
 
 TARGET_CPPFLAGS += -isystem $(THIRDPARTY_LIBS_ROOT)/include

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -103,6 +103,18 @@ elif target == 'ANDROID':
         libtiff,
         libgeotiff,
     ]
+elif toolchain_host_triplet.endswith('-musleabihf'):
+    thirdparty_libs = [
+        zlib,
+        freetype,
+        curl,
+        libpng,
+        libjpeg,
+        lua,
+        libsalsa,
+        libusb,
+        simple_usbmodeswitch,
+    ]
 else:
     thirdparty_libs = [
         musl,

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -105,7 +105,8 @@ elif target == 'ANDROID':
     ]
 else:
     thirdparty_libs = [
-        glibc,
+        musl,
+        libstdcxx_musl_headers,
         zlib,
         freetype,
         curl,

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -4,11 +4,11 @@ import os, os.path
 import re
 import sys
 
-if len(sys.argv) != 13:
-    print("Usage: build.py TARGET_OUTPUT_DIR TARGET HOST_TRIPLET ARCH_CFLAGS CPPFLAGS ARCH_LDFLAGS CC CXX AR ARFLAGS RANLIB STRIP", file=sys.stderr)
+if len(sys.argv) != 14:
+    print("Usage: build.py TARGET_OUTPUT_DIR TARGET HOST_TRIPLET ACTUAL_HOST_TRIPLET ARCH_CFLAGS CPPFLAGS ARCH_LDFLAGS CC CXX AR ARFLAGS RANLIB STRIP", file=sys.stderr)
     sys.exit(1)
 
-target_output_dir, target, host_triplet, arch_cflags, cppflags, arch_ldflags, cc, cxx, ar, arflags, ranlib, strip = sys.argv[1:]
+target_output_dir, target, toolchain_host_triplet, actual_host_triplet, arch_cflags, cppflags, arch_ldflags, cc, cxx, ar, arflags, ranlib, strip = sys.argv[1:]
 
 # the path to the XCSoar sources
 xcsoar_path = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]) or '.', '..'))
@@ -20,7 +20,7 @@ from build.dirs import tarball_path, src_path
 target_output_dir = os.path.abspath(target_output_dir)
 
 lib_path = os.path.join(target_output_dir, 'lib')
-arch_path = os.path.join(lib_path, host_triplet)
+arch_path = os.path.join(lib_path, actual_host_triplet)
 build_path = os.path.join(arch_path, 'build')
 install_prefix = os.path.join(arch_path, 'root')
 
@@ -31,13 +31,14 @@ if 'MAKEFLAGS' in os.environ:
 
 class Toolchain:
     def __init__(self, tarball_path, src_path, build_path, install_prefix,
-                 arch, arch_cflags, cppflags, arch_ldflags,
-                 cc, cxx, ar, arflags, ranlib, strip):
+                 toolchain_arch, actual_arch, arch_cflags, cppflags,
+                 arch_ldflags, cc, cxx, ar, arflags, ranlib, strip):
         self.tarball_path = tarball_path
         self.src_path = src_path
         self.build_path = build_path
         self.install_prefix = install_prefix
-        self.arch = arch
+        self.toolchain_arch = toolchain_arch
+        self.actual_arch = actual_arch
 
         self.cc = cc
         self.cxx = cxx
@@ -71,13 +72,13 @@ class Toolchain:
 # a list of third-party libraries to be used by XCSoar
 from build.libs import *
 
-if 'mingw32' in host_triplet:
+if 'mingw32' in actual_host_triplet:
     thirdparty_libs = [
         zlib,
         curl,
         lua,
     ]
-elif re.match('(arm.*|aarch64)-apple-darwin', host_triplet) is not None:
+elif re.match('(arm.*|aarch64)-apple-darwin', actual_host_triplet) is not None:
     thirdparty_libs = [
         curl,
         lua,
@@ -86,7 +87,7 @@ elif re.match('(arm.*|aarch64)-apple-darwin', host_triplet) is not None:
         libgeotiff,
         sdl2
     ]
-elif 'apple-darwin' in host_triplet:
+elif 'apple-darwin' in actual_host_triplet:
     thirdparty_libs = [
         lua,
         proj,
@@ -118,8 +119,9 @@ else:
 
 # build the third-party libraries
 toolchain = Toolchain(tarball_path, src_path, build_path, install_prefix,
-                      host_triplet, arch_cflags, cppflags, arch_ldflags,
-                      cc, cxx, ar, arflags, ranlib, strip)
+                      toolchain_host_triplet, actual_host_triplet,
+                      arch_cflags, cppflags, arch_ldflags, cc, cxx, ar, arflags,
+                      ranlib, strip)
 for x in thirdparty_libs:
     if not x.is_installed(toolchain):
         x.build(toolchain)

--- a/lib/musl/patches/arm_atomics_recent_binutils.patch
+++ b/lib/musl/patches/arm_atomics_recent_binutils.patch
@@ -1,0 +1,40 @@
+From b261a24256792177a5f0531dbb25cc6267220ca5 Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Wed, 15 Feb 2017 17:05:50 -0500
+Subject: fix build regression in arm atomics asm with new binutils
+
+binutils commit bada43421274615d0d5f629a61a60b7daa71bc15 tightened
+immediate fixup handling in gas in such a way that the final .arch of
+an object file must be compatible with the fixups used when the
+instruction was assembled; this in turn broke assembling of atomics.s,
+at least in thumb mode.
+
+it's not clear whether this should be considered a bug in gas, but
+.object_arch is preferable anyway for our purpose here of controlling
+the ISA level tag on the object file being produced, and it's the
+intended directive for use in object files with runtime code
+selection. research by Szabolcs Nagy confirmed that .object_arch is
+supported in all relevant versions of binutils and clang's integrated
+assembler.
+
+patch by Reiner Herrmann.
+---
+ src/thread/arm/atomics.s | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/thread/arm/atomics.s b/src/thread/arm/atomics.s
+index 202faa4..101ad39 100644
+--- a/src/thread/arm/atomics.s
++++ b/src/thread/arm/atomics.s
+@@ -84,7 +84,7 @@ __a_gettp_cp15:
+ 	bx lr
+ 
+ /* Tag this file with minimum ISA level so as not to affect linking. */
+-.arch armv4t
++.object_arch armv4t
+ .eabi_attribute 6,2
+ 
+ .data
+-- 
+cgit v0.11.2
+

--- a/lib/musl/patches/musl-1.1.16-__sprintf_chk.patch
+++ b/lib/musl/patches/musl-1.1.16-__sprintf_chk.patch
@@ -1,0 +1,23 @@
+This is required for ABI compatibility with older libstdc++ versions
+(e. g. from the arm-linux-gnueabihf GCC 5 toolchain in Ubuntu 16.04).
+
+Adapted from this patch:
+https://github.com/luckboy/toyroot/blob/master/patch/musl-1.0.4-__sprintf_chk.patch
+
+diff -Nuar musl-1.1.16.orig/src/stdio/__sprintf_chk.c musl-1.1.16/src/stdio/__sprintf_chk.c
+--- musl-1.1.16.orig/src/stdio/__sprintf_chk.c	1970-01-01 01:00:00.000000000 +0100
++++ musl-1.1.16/src/stdio/__sprintf_chk.c	2017-10-01 14:58:28.226941584 +0200
+@@ -0,0 +1,13 @@
++#include <stdarg.h>
++#include <stdio.h>
++#include "atomic.h"
++
++int __sprintf_chk(char *s, int flag, size_t slen, const char *fmt, ...)
++{
++	va_list ap;
++	va_start(ap, fmt);
++	int ret = vsnprintf(s, slen, fmt, ap);
++	if(ret >= 0 && (size_t) ret >= slen) a_crash();
++	va_end(ap);
++	return ret;
++}

--- a/lib/musl/patches/series
+++ b/lib/musl/patches/series
@@ -1,1 +1,2 @@
 arm_atomics_recent_binutils.patch
+musl-1.1.16-__sprintf_chk.patch

--- a/lib/musl/patches/series
+++ b/lib/musl/patches/series
@@ -1,0 +1,1 @@
+arm_atomics_recent_binutils.patch

--- a/lib/salsa-lib/patches/correct_poll_h.diff
+++ b/lib/salsa-lib/patches/correct_poll_h.diff
@@ -1,0 +1,194 @@
+commit 6879d82954bbd8dcf65699921f91faa441c7862b
+Author: Felix Hädicke <felixhaedicke@web.de>
+Date:   Wed Jul 12 22:01:40 2017 +0200
+
+    Include <poll.h> instead of <sys/poll.h>
+    
+    According to POSIX.1-2001, the correct include path is <poll.h>. And
+    when compiling against musl, it generates "deprecated" warnings, if
+    <sys/poll.h> is included.
+    
+    Signed-off-by: Felix Hädicke <felixhaedicke@web.de>
+
+diff --git a/src/asoundlib-head.h b/src/asoundlib-head.h
+index a852fbe..cc7b154 100644
+--- a/src/asoundlib-head.h
++++ b/src/asoundlib-head.h
+@@ -29,7 +29,7 @@
+ #include <fcntl.h>
+ #include <assert.h>
+ #include <endian.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <errno.h>
+ #include <stdarg.h>
+ 
+diff --git a/src/control.c b/src/control.c
+index 17398ba..c9eab72 100644
+--- a/src/control.c
++++ b/src/control.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "control.h"
+ #include "local.h"
+ #if SALSA_SUPPORT_FLOAT
+diff --git a/src/ctl_macros.h b/src/ctl_macros.h
+index 9ed3357..ce86a8f 100644
+--- a/src/ctl_macros.h
++++ b/src/ctl_macros.h
+@@ -12,7 +12,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ struct _snd_ctl {
+ 	char *name;
+diff --git a/src/hcontrol.c b/src/hcontrol.c
+index fce1b13..14dfeb1 100644
+--- a/src/hcontrol.c
++++ b/src/hcontrol.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "hcontrol.h"
+ #include "local.h"
+ 
+diff --git a/src/hctl_macros.h b/src/hctl_macros.h
+index fc1348b..613237b 100644
+--- a/src/hctl_macros.h
++++ b/src/hctl_macros.h
+@@ -12,7 +12,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ struct _snd_hctl {
+ 	snd_ctl_t *ctl;
+diff --git a/src/hwdep.c b/src/hwdep.c
+index 3b5ee6d..b4c23f9 100644
+--- a/src/hwdep.c
++++ b/src/hwdep.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "hwdep.h"
+ #include "local.h"
+ 
+diff --git a/src/hwdep_macros.h b/src/hwdep_macros.h
+index 6a52c68..3d2ea13 100644
+--- a/src/hwdep_macros.h
++++ b/src/hwdep_macros.h
+@@ -11,7 +11,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ struct _snd_hwdep {
+ 	const char *name;
+diff --git a/src/mixer.c b/src/mixer.c
+index c0ccc3d..15fcc30 100644
+--- a/src/mixer.c
++++ b/src/mixer.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "mixer.h"
+ #include "local.h"
+ 
+diff --git a/src/mixer_macros.h b/src/mixer_macros.h
+index c0e8c8a..7355046 100644
+--- a/src/mixer_macros.h
++++ b/src/mixer_macros.h
+@@ -10,7 +10,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ struct _snd_mixer {
+ 	snd_hctl_t *hctl;
+diff --git a/src/pcm_macros.h b/src/pcm_macros.h
+index a35c794..f252014 100644
+--- a/src/pcm_macros.h
++++ b/src/pcm_macros.h
+@@ -12,7 +12,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ typedef struct {
+ 	struct sndrv_pcm_channel_info info;
+diff --git a/src/rawmidi.c b/src/rawmidi.c
+index 79f9b21..ca96f5d 100644
+--- a/src/rawmidi.c
++++ b/src/rawmidi.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "rawmidi.h"
+ #include "control.h"
+ #include "local.h"
+diff --git a/src/rawmidi_macros.h b/src/rawmidi_macros.h
+index c32b440..c3146cc 100644
+--- a/src/rawmidi_macros.h
++++ b/src/rawmidi_macros.h
+@@ -13,7 +13,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ typedef struct _snd_rawmidi_hw {
+ 	char *name;
+diff --git a/src/timer.c b/src/timer.c
+index 00a8534..b9fbb00 100644
+--- a/src/timer.c
++++ b/src/timer.c
+@@ -26,7 +26,7 @@
+ #include <string.h>
+ #include <fcntl.h>
+ #include <signal.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include "timer.h"
+ #include "local.h"
+ 
+diff --git a/src/timer_macros.h b/src/timer_macros.h
+index a1837e7..1cd37be 100644
+--- a/src/timer_macros.h
++++ b/src/timer_macros.h
+@@ -11,7 +11,7 @@
+ #include <errno.h>
+ #include <unistd.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ struct _snd_timer {
+ 	char *name;

--- a/lib/salsa-lib/patches/series
+++ b/lib/salsa-lib/patches/series
@@ -1,2 +1,3 @@
 no_implicit_pointer_casts.diff
 remove_generated_headers.diff
+correct_poll_h.diff

--- a/src/Math/Trig.hpp
+++ b/src/Math/Trig.hpp
@@ -34,12 +34,12 @@ gcc_const
 static inline std::pair<double, double>
 sin_cos(const double thetha)
 {
-#if defined(__GLIBC__) && defined(_GNU_SOURCE)
+#ifdef __BIONIC__
+  return std::make_pair(sin(thetha), cos(thetha));
+#else
   double s, c;
   sincos(thetha, &s, &c);
   return std::make_pair(s, c);
-#else
-  return std::make_pair(sin(thetha), cos(thetha));
 #endif
 }
 

--- a/src/Net/IPv4Address.cxx
+++ b/src/Net/IPv4Address.cxx
@@ -39,7 +39,7 @@
 #include <arpa/inet.h>
 #endif
 
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if !defined(WIN32) && !defined(__BIONIC__)
 #include <ifaddrs.h>
 #endif
 
@@ -56,7 +56,7 @@ CastToIPv4(const struct sockaddr *p)
 IPv4Address::IPv4Address(SocketAddress src)
 	:address(*CastToIPv4(src.GetAddress())) {}
 
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if !defined(WIN32) && !defined(__BIONIC__)
 
 /**
  * helper to iterate over available devices, locate the

--- a/src/Net/IPv4Address.hxx
+++ b/src/Net/IPv4Address.hxx
@@ -140,7 +140,7 @@ public:
 		return address.sin_addr;
 	}
 
-#if defined(__GLIBC__) || defined(__APPLE__)
+#if !defined(WIN32) && !defined(__BIONIC__)
 	/**
 	 * Returns a StaticSocketAddress for the specified device. Caller
 	 * should check for validity of returned StaticSocketAddress.

--- a/src/Thread/Name.hpp
+++ b/src/Thread/Name.hpp
@@ -25,13 +25,24 @@ Copyright_License {
 #define XCSOAR_THREAD_NAME_HPP
 
 #ifdef HAVE_POSIX
+
+#ifdef __APPLE__
+#define HAVE_PTHREAD_SETNAME_NP
+#else
+
+#include <features.h>
+#ifdef __GLIBC__
+#define HAVE_PTHREAD_SETNAME_NP
+#endif
+
+#endif
+
 #ifdef __BIONIC__
 /* Bionic supports pthread_setname_np() since API level 9, but since
    we build with API level 8, we fall back to prctl(PR_SET_NAME) */
 #define HAVE_PR_SET_NAME
-#else
-#define HAVE_PTHREAD_SETNAME_NP
 #endif
+
 #endif
 
 #ifdef HAVE_PR_SET_NAME

--- a/src/Topography/shapelib/mapserver-config.h
+++ b/src/Topography/shapelib/mapserver-config.h
@@ -1,12 +1,16 @@
 #ifndef _MAPSERVER_CONFIG_H
 #define _MAPSERVER_CONFIG_H
 
+#if !defined(WIN32) && !defined(__APPLE__)
+#include <features.h>
+#endif
+
 #define HAVE_STRRSTR 1
 #define HAVE_STRCASECMP 1
 #define HAVE_STRCASESTR 1
 #define HAVE_STRDUP 1
 
-#if defined(__APPLE__) || defined(ANDROID)
+#if !defined(__GLIBC__) && !defined(WIN32)
 #define HAVE_STRLCAT 1
 #define HAVE_STRLCPY 1
 #endif

--- a/src/zzip/_config.h
+++ b/src/zzip/_config.h
@@ -12,9 +12,9 @@
 /* #undef HAVE_ALIGNED_ACCESS_REQUIRED */
 
 /* Define to 1 if you have the <byteswap.h> header file. */
-#ifdef __GLIBC__
-#ifndef ZZIP_HAVE_BYTESWAP_H 
-#define ZZIP_HAVE_BYTESWAP_H  1 
+#if !defined(__APPLE__) && !defined(WIN32)
+#ifndef ZZIP_HAVE_BYTESWAP_H
+#define ZZIP_HAVE_BYTESWAP_H  1
 #endif
 #endif
 


### PR DESCRIPTION
Add musl libc support, and use it instead of glibc for the KOBO target.

Advantages:
* very lightweight
* can be statically linked
* support for old Linux kernels

Uploaded my build of the toolchain here: http://s15356785.onlinehome-server.info/~felix/arm-unknown-linux-musleabihf-2017-09-17.tar.gz
sha256sum: ca2a4d104aacf364612f55353cfc16b1868722fa6eab2ecf11b2b35e917e430f
Built with ct-ng with the configuration "build/ct-ng/arm-unknown-linux-musleabihf.config" (see commit f7129dc).