### PR TITLE
XCTracer-Driver-backport from 7.0_preview11 to v6.8.x

### DIFF
--- a/build/driver.mk
+++ b/build/driver.mk
@@ -82,6 +82,10 @@ BLUEFLY_SOURCES = \
 	$(DRIVER_SRC_DIR)/BlueFly/Settings.cpp \
 	$(DRIVER_SRC_DIR)/BlueFly/Register.cpp
 
+XCTRACER_SOURCES = \
+	$(DRIVER_SRC_DIR)/XCTracer/Parser.cpp \
+	$(DRIVER_SRC_DIR)/XCTracer/Register.cpp
+
 DRIVER_SOURCES = \
 	$(SRC)/Device/Driver.cpp \
 	$(SRC)/Device/Register.cpp \
@@ -93,6 +97,7 @@ DRIVER_SOURCES = \
 	$(FLYTEC_SOURCES) \
 	$(VEGA_SOURCES) \
 	$(BLUEFLY_SOURCES) \
+	$(XCTRACER_SOURCES) \
 	$(DRIVER_SRC_DIR)/AltairPro.cpp \
 	$(DRIVER_SRC_DIR)/BorgeltB50.cpp \
 	$(DRIVER_SRC_DIR)/CaiGpsNav.cpp \

--- a/src/Device/Driver/XCTracer.hpp
+++ b/src/Device/Driver/XCTracer.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_DEVICE_DRIVER_XCTRACER_HPP
+#define XCSOAR_DEVICE_DRIVER_XCTRACER_HPP
+
+extern const struct DeviceRegister xctracer_driver;
+
+#endif

--- a/src/Device/Driver/XCTracer/Internal.hpp
+++ b/src/Device/Driver/XCTracer/Internal.hpp
@@ -1,0 +1,58 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_XCTRACERVARIO_INTERNAL_HPP
+#define XCSOAR_XCTRACERVARIO_INTERNAL_HPP
+
+#include "Device/Driver.hpp"
+#include "Time/BrokenDate.hpp"
+
+struct NMEAInfo;
+class NMEAInputLine;
+
+class XCTracerDevice final : public AbstractDevice {
+  /**
+   * time and date of last GPS fix
+   * used to check whether date/time has advanced
+   */
+  double last_time = 0;
+  BrokenDate last_date = BrokenDate::Invalid();
+
+  /**
+   * parser for the LXWP0 sentence
+   */
+  bool LXWP0(NMEAInputLine &line, NMEAInfo &info);
+
+  /**
+   * parser for the XCTRC sentence
+   */
+  bool XCTRC(NMEAInputLine &line, NMEAInfo &info);
+
+public:
+  /**
+   * virtual methods from class Device
+   */
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+};
+
+#endif

--- a/src/Device/Driver/XCTracer/Parser.cpp
+++ b/src/Device/Driver/XCTracer/Parser.cpp
@@ -1,0 +1,279 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "../XCTracer/Internal.hpp"
+#include "NMEA/Checksum.hpp"
+#include "NMEA/InputLine.hpp"
+#include "NMEA/Info.hpp"
+
+/**
+ * Parser for the XCTracer Vario
+ * For the XCTracer Protocol
+ * @see https://www.xctracer.com/en/tech-specs/?oid=1861
+ *
+ * Native XTRC sentences
+ * $XCTRC,2015,1,5,16,34,33,36,46.947508,7.453117,540.32,12.35,270.4,2.78,,,,964.93,98*67
+ *
+ * $XCTRC,year,month,day,hour,minute,second,centisecond,latitude,longitude,altitude,speedoverground,
+ *      course,climbrate,res,res,res,rawpressure,batteryindication*checksum
+ *
+ * OR in LXWP0 mode with GPS sentences
+ * $GPGGA,081158.400,4837.7021,N,00806.2928,E,2,5,1.57,113.9,M,47.9,M,,*5B
+ * $LXWP0,N,,119.9,0.16,,,,,,259,,*64
+ * $GPRMC,081158.800,A,4837.7018,N,00806.2923,E,2.34,261.89,110815,,,D*69
+ */
+
+/**
+ * Helper functions to parse and check an input field
+ * Should these be added as methods to Class CSVLine ?
+ * e.g. bool CSVLine::ReadCheckedRange(unsigned &value_r, unsigned min, unsigned max)
+ *
+ * @param line Input line
+ * @param value_r Return parsed and checked value
+ * @param min Minimum value to be accepted
+ * @param max Maximum value to be accepted
+ * @return true if parsed OK and within range
+ */
+static bool
+ReadCheckedRange(NMEAInputLine &line, unsigned &value_r, unsigned min, unsigned max)
+{
+  double value;
+  if (!line.ReadChecked(value))
+    return false;
+
+  /* check min/max as floating point to catch input values out of unsigned range */
+  if (value < min || value > max)
+    return false;
+
+  /* finally we can cast/convert w/o being out of range */
+  value_r = (unsigned) value;
+  return true;
+}
+
+/* same helper as above with params of type double */
+static bool
+ReadCheckedRange(NMEAInputLine &line,double &value_r, double min, double max)
+{
+  double value;
+  if (!line.ReadChecked(value))
+    return false;
+
+  /* check range */
+  if (value < min || value > max)
+    return false;
+
+  value_r = value;
+  return true;
+}
+
+/**
+ * the parser for the LXWP0 subset sentence that the XC-Tracer can produce
+ */
+inline bool
+XCTracerDevice::LXWP0(NMEAInputLine &line, NMEAInfo &info)
+{
+  /*
+   *  $LXWP0,N,,119.9,0.16,,,,,,259,,*64
+   *  0 logger stored (Y/N)
+   *  1 n.u.
+   *  2 baroaltitude (m)
+   *  3 vario (m/s)
+   *  4-8 n.u.
+   *  9 course (0..360)
+   * 10 n.u
+   * 11 n.u.
+   */
+
+  line.Skip(2);
+
+  double value;
+  /* read baroaltitude */
+  if (line.ReadChecked(value))
+    /* XC-Tracer sends uncorrected altitude above 1013.25hPa here */
+    info.ProvidePressureAltitude(value);
+
+  /* read vario */
+  if (line.ReadChecked(value))
+    info.ProvideTotalEnergyVario(value);
+
+  line.Skip(5);
+
+  /* read course */
+  if (line.ReadChecked(value)) {
+    info.track = Angle::Degrees(value);
+    info.track_available.Update(info.clock);
+  }
+
+  return true;
+}
+
+/**
+ * the parser for the XCTRC sentence
+ */
+inline bool
+XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
+{
+  /*
+   * $XCTRC,year,month,day,hour,minute,second,centisecond,latitude,longitude,
+   *  altitude,speedoverground,course,climbrate,res,res,res,rawpressure,
+   *  batteryindication*checksum
+   * $XCTRC,2015,8,11,10,56,23,80,48.62825,8.104885,129.4,0.01,322.76,-0.05,,,,997.79,77*66
+   */
+
+  /* count the number of valid fields. If not as expected incr nmea error counter */
+  int valid_fields = 0;
+
+  /**
+   * parse the date
+   * parse and absorb all three values, even if one or more is empty, e.g. ",,13"
+   */
+  unsigned year, month, day;
+  valid_fields += ReadCheckedRange(line,year,1800,2500);
+  valid_fields += ReadCheckedRange(line,month,1,12);
+  valid_fields += ReadCheckedRange(line,day,1,31);
+
+  /**
+   * parse the time
+   * parse and check all four values, even if one or more is empty, e.g. ",,33,"
+   */
+  unsigned hour, minute, second, centisecond;
+  valid_fields += ReadCheckedRange(line,hour,0,23);
+  valid_fields += ReadCheckedRange(line,minute,0,59);
+  valid_fields += ReadCheckedRange(line,second,0,59);
+  valid_fields += ReadCheckedRange(line,centisecond,0,99);
+
+  /**
+   * parse the GPS fix
+   * parse and check both  values, even if one or more is empty, e.g. ",3.1234,"
+   */
+  double latitude, longitude;
+  valid_fields += ReadCheckedRange(line,latitude,-90.0,90.0);
+  valid_fields += ReadCheckedRange(line,longitude,-180.0,180.0);
+
+  /**
+   * we only want to accept GPS fixes with completely sane values
+   * for date, time and lat/long
+   */
+  if (valid_fields == 3+4+2) {
+    /* now convert the date, time, lat & long fields to the internal format */
+    BrokenDate date = BrokenDate(year,month,day);
+    double time = hour*60*60 + minute*60 + second + centisecond/100.0;
+
+    GeoPoint point;
+    point.latitude = Angle::Degrees(latitude);
+    point.longitude = Angle::Degrees(longitude);
+
+    /**
+     * only update GPS and date/time if time has advanced
+     */
+    if (time > last_time || date > last_date) {
+      /* update last date/time */
+      last_time = time;
+      last_date = date;
+
+      /* set time and date_time_utc, don't use ProvideTime() */
+      info.time = time;
+      info.time_available.Update(info.clock);
+      info.date_time_utc.hour = hour;
+      info.date_time_utc.minute = minute;
+      info.date_time_utc.second = second;
+
+      info.ProvideDate(date);
+      info.location = point;
+      info.location_available.Update(info.clock);
+      info.gps.real = true;
+    }
+  }
+
+  double value;
+  /* read gps altitude */
+  if (line.ReadChecked(value)) {
+    info.gps_altitude = value;
+    info.gps_altitude_available.Update(info.clock);
+    valid_fields++;
+  }
+
+  /* read spead over ground */
+  if (line.ReadChecked(value)) {
+    info.ground_speed = value;
+    info.ground_speed_available.Update(info.clock);
+    valid_fields++;
+  }
+
+  /* read course*/
+  if (line.ReadChecked(value)) {
+    /* update only if we're moving .. */
+    if (info.MovementDetected()) {
+      info.track = Angle::Degrees(value);
+      info.track_available.Update(info.clock);
+    }
+    valid_fields++;
+  }
+
+  /* read climbrate */
+  if (line.ReadChecked(value)) {
+    info.ProvideTotalEnergyVario(value);
+    valid_fields++;
+  }
+
+  /* skip 3 reserved values */
+  line.Skip(3);
+
+  /* read raw pressure */
+  if (line.ReadChecked(value)) {
+    // convert to pressure
+    info.ProvideStaticPressure(AtmosphericPressure::HectoPascal(value));
+    valid_fields++;
+  }
+
+  /* read battery level */
+  if (ReadCheckedRange(line,value,0.0,100.0)) {
+    info.battery_level = value;
+    info.battery_level_available.Update(info.clock);
+    valid_fields++;
+  }
+
+  return true;
+}
+
+/**
+ * the NMEA parser virtual function
+ */
+bool
+XCTracerDevice::ParseNMEA(const char *string, NMEAInfo &info)
+{
+  if (!VerifyNMEAChecksum(string))
+    return false;
+
+  NMEAInputLine line(string);
+  char type[16];
+  line.Read(type, 16);
+
+  if (StringIsEqual(type, "$LXWP0"))
+    return LXWP0(line, info);
+
+  if (StringIsEqual(type, "$XCTRC"))
+    return XCTRC(line, info);
+
+  return false;
+}

--- a/src/Device/Driver/XCTracer/Register.cpp
+++ b/src/Device/Driver/XCTracer/Register.cpp
@@ -1,0 +1,38 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "../XCTracer/Internal.hpp"
+#include "Device/Driver/XCTracer.hpp"
+
+static Device *
+XCTracerCreateOnPort(const DeviceConfig &config, Port &com_port)
+{
+  return new XCTracerDevice();
+}
+
+const struct DeviceRegister xctracer_driver = {
+  _T("XCTracer"),
+  _T("XC-Tracer Vario"),
+  0,
+  XCTracerCreateOnPort,
+};

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -54,6 +54,7 @@ Copyright_License {
 #include "Device/Driver/OpenVario.hpp"
 #include "Device/Driver/Vaulter.hpp"
 #include "Device/Driver/ATR833.hpp"
+#include "Device/Driver/XCTracer.hpp"
 #include "Util/Macros.hpp"
 #include "Util/StringAPI.hpp"
 
@@ -96,6 +97,7 @@ static const struct DeviceRegister *const driver_list[] = {
   /* disabled due to http://bugs.xcsoar.org/ticket/3585 and
      http://bugs.xcsoar.org/ticket/3586 - scheduled for deletion */
   &atr833_driver,
+  &xctracer_driver,
   nullptr
 };
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -46,6 +46,7 @@
 #include "Device/Driver/Vega.hpp"
 #include "Device/Driver/Volkslogger.hpp"
 #include "Device/Driver/Westerboer.hpp"
+#include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/Zander.hpp"
 #include "Device/Driver.hpp"
 #include "Device/RecordedFlight.hpp"
@@ -1382,6 +1383,95 @@ TestVaulter()
   delete device;
 }
 
+static void
+TestXCTracer()
+{
+  NullPort null;
+  Device *device = xctracer_driver.CreateOnPort(dummy_config, null);
+  ok1(device != NULL);
+
+  NMEAInfo nmea_info;
+  nmea_info.Reset();
+  nmea_info.clock = 1;
+
+  /* empty sentence */
+  ok1(device->ParseNMEA("$LXWP0,N,,,,,,,,,,,*6d", nmea_info));
+  ok1(!nmea_info.pressure_altitude_available);
+  ok1(!nmea_info.baro_altitude_available);
+  ok1(!nmea_info.airspeed_available);
+  ok1(!nmea_info.total_energy_vario_available);
+  ok1(!nmea_info.external_wind_available);
+
+  /* bad checksum */
+  ok1(!device->ParseNMEA("$XCTRC*6d", nmea_info));
+
+  nmea_info.Reset();
+  nmea_info.clock = 1;
+
+  /* altitude and !wind */
+  ok1(device->ParseNMEA("$LXWP0,N,,1266.5,,,,,,,,248,23.1*55", nmea_info));
+  ok1(nmea_info.pressure_altitude_available);
+  ok1(!nmea_info.baro_altitude_available);
+  ok1(equals(nmea_info.pressure_altitude, 1266.5));
+
+  ok1(!nmea_info.airspeed_available);
+  ok1(!nmea_info.total_energy_vario_available);
+  ok1(!nmea_info.external_wind_available);
+
+  nmea_info.Reset();
+  nmea_info.clock = 1;
+
+  /* !airspeed and vario available */
+  ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1*47",nmea_info));
+  ok1(nmea_info.pressure_altitude_available);
+  ok1(!nmea_info.baro_altitude_available);
+  ok1(equals(nmea_info.pressure_altitude,1665.5));
+  ok1(!nmea_info.airspeed_available);
+
+  ok1(nmea_info.total_energy_vario_available);
+  ok1(equals(nmea_info.total_energy_vario, 1.71));
+
+  ok1(!nmea_info.external_wind_available);
+
+  /* the XCTRC sentence */
+  ok1(device->ParseNMEA("$XCTRC,2015,8,11,10,56,23,80,48.62825,8.104885,"
+      "129.4,11.01,322.76,-5.05,,,,997.79,77*53",nmea_info));
+
+  /* invalid date and time must be ignored */
+  ok1(device->ParseNMEA("$XCTRC,3015,13,33*77",nmea_info));
+  ok1(device->ParseNMEA("$XCTRC,,,,25,-1,99,33*69",nmea_info));
+
+  /* now check the correct values */
+  ok1(nmea_info.date_time_utc.year == 2015);
+  ok1(nmea_info.date_time_utc.month == 8);
+  ok1(nmea_info.date_time_utc.day == 11);
+  ok1(nmea_info.date_time_utc.hour == 10);
+  ok1(nmea_info.date_time_utc.minute == 56);
+  ok1(nmea_info.date_time_utc.second == 23);
+  ok1(equals(nmea_info.time, 10 * 3600 + 56 * 60 + 23.80));
+
+  ok1(nmea_info.location_available);
+  ok1(equals(nmea_info.location.longitude, 8.104885));
+  ok1(equals(nmea_info.location.latitude, 48.62825));
+
+  ok1(nmea_info.gps_altitude_available);
+  ok1(equals(nmea_info.gps_altitude, 129.4));
+
+  ok1(nmea_info.ground_speed_available);
+  ok1(equals(nmea_info.ground_speed, 11.01));
+
+  ok1(nmea_info.track_available);
+  ok1(equals(nmea_info.track,Angle::Degrees(322.76)));
+
+  ok1(nmea_info.total_energy_vario_available);
+  ok1(equals(nmea_info.total_energy_vario, -5.05));
+
+  ok1(nmea_info.battery_level_available);
+  ok1(equals(nmea_info.battery_level,77));
+
+  delete device;
+}
+
 #ifdef __clang__
 /* true, the nullptr cast below is a bad kludge */
 #pragma GCC diagnostic ignored "-Wnull-dereference"
@@ -1481,6 +1571,7 @@ int main(int argc, char **argv)
   TestZander();
   TestFlyNet();
   TestVaulter();
+  TestXCTracer();
 
   /* XXX the Triadis drivers have too many dependencies, not enabling
      for now */


### PR DESCRIPTION
Copied the XCTracer driver files from the 7.0_preview11 sources to the v6.8.x branch. Edited build/driver.mk, src/Device/Register.cpp, and test/src/TestDriver.cpp to reflect the changes.