### PR TITLE
Waypoint/WaypointReaderSeeYou: handle file with rwwidth field

### DIFF
--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -169,19 +169,8 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
     iElevation = 5,
     iStyle = 6,
     iRWDir = 7,
-    iRWLen = 8,
-    iFrequency = 9,
-    iDescription = 10,
+    iRWLen = 8
   };
-
-  if (first) {
-    first = false;
-
-    /* skip first line if it doesn't begin with a quotation character
-       (usually the field order line) */
-    if (line[0] != _T('\"'))
-      return true;
-  }
 
   // If (end-of-file or comment)
   if (StringIsEmpty(line) ||
@@ -204,6 +193,28 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
   const TCHAR *params[20];
   size_t n_params = ExtractParameters(line, ctemp, params,
                                       ARRAY_SIZE(params), true, _T('"'));
+
+  if (first) {
+    first = false;
+    if (line[0] != _T('\"')) {
+      /*
+       * If the first line doesn't begin with a quotation mark, it
+       * doesn't describe a waypoint. It probably contains field names.
+       */
+      if (StringIsEqual(params[9], _T("rwwidth"))) {
+        /*
+         * The name of the 10th field is "rwwidth" (runway width).
+         * This field doesn't exist in "typical" SeeYou (*.cup) waypoint
+         * files but is in files saved by at least some versions of
+         * SeeYou Mobile. If the rwwidth field exists, the frequency and
+         * description fields are shifted one position to the right.
+         */
+        iFrequency = 10;
+        iDescription = 11;
+      }
+      return true;
+    }
+  }
 
   // Check if the basic fields are provided
   if (iName >= n_params ||

--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -169,7 +169,7 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
     iElevation = 5,
     iStyle = 6,
     iRWDir = 7,
-    iRWLen = 8
+    iRWLen = 8,
   };
 
   // If (end-of-file or comment)

--- a/src/Waypoint/WaypointReaderSeeYou.hpp
+++ b/src/Waypoint/WaypointReaderSeeYou.hpp
@@ -44,6 +44,11 @@ public:
 protected:
   /* virtual methods from class WaypointReaderBase */
   bool ParseLine(const TCHAR* line, Waypoints &way_points) override;
+
+private:
+  /* field positions for typical SeeYou *.cup waypoint file */
+  unsigned short iFrequency = 9;
+  unsigned short iDescription = 10;
 };
 
 #endif

--- a/src/Waypoint/WaypointReaderSeeYou.hpp
+++ b/src/Waypoint/WaypointReaderSeeYou.hpp
@@ -37,6 +37,11 @@ class WaypointReaderSeeYou final : public WaypointReaderBase {
 
   bool ignore_following = false;
 
+private:
+  /* field positions for typical SeeYou *.cup waypoint file */
+  unsigned iFrequency = 9;
+  unsigned iDescription = 10;
+
 public:
   explicit WaypointReaderSeeYou(WaypointFactory _factory)
     :WaypointReaderBase(_factory) {}
@@ -44,11 +49,6 @@ public:
 protected:
   /* virtual methods from class WaypointReaderBase */
   bool ParseLine(const TCHAR* line, Waypoints &way_points) override;
-
-private:
-  /* field positions for typical SeeYou *.cup waypoint file */
-  unsigned short iFrequency = 9;
-  unsigned short iDescription = 10;
 };
 
 #endif


### PR DESCRIPTION
Some SeeYou WP files contain a field for runway width (called "rwwidth" in the file header, if present). For example, at least some versions of SeeYou Mobile create files like this (if saved due to user editing of a WP). This extra field is inserted just before the radio frequency field, thus shifting that field and the description field to the right. Without this change, when XCSoar uses such a file, the radio frequency isn't shown (in XCSoar's frequency field), the description/comments field in XCSoar contains only the radio frequency (from the WP file), and the description/comments from the WP file are nowhere in XCSoar.