### PR TITLE
test/src: add testing for CUP file with runway width field

### DIFF
--- a/test/data/waypoints2.cup
+++ b/test/data/waypoints2.cup
@@ -1,0 +1,7 @@
+name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc
+"Aconcagua","Aconcagua",,3239.200S,07000.700W,6962.0m,7,0,0.0m,,"","Highest mountain in south-america"
+"Bergneustadt","",,5103.117N  ,00742.367E,  488.0m,  5  ,040,590m,15m,"123.650" , "Rabbit holes, 20" ditch south end of rwy"
+"Golden Gate Bridge","GGB",,3749.050N,12228.700W,227.0m,14,0,0.005NM,,"",""
+"Red Square","RedSqr",,5545.250N,03737.200E,123.0m,3,90,0.01ml,,"",""
+"Sydney Opera","Opera",,3351.417S,15112.916E,5.0m,1,0,0.0m,,"",""
+-----Related Tasks-----

--- a/test/src/TestWaypointReader.cpp
+++ b/test/src/TestWaypointReader.cpp
@@ -271,17 +271,31 @@ TestSeeYouWaypoint(const Waypoint org_wp, const Waypoint *wp)
 static void
 TestSeeYou(wp_vector org_wp)
 {
+  // Test a SeeYou waypoint file with no runway width field:
   Waypoints way_points;
   if (!TestWaypointFile(Path(_T("test/data/waypoints.cup")), way_points,
                         org_wp.size())) {
-    skip(9 * org_wp.size(), 0, "opening waypoint file failed");
+    skip(9 * org_wp.size(), 0, "opening waypoints.cup failed");
+  } else {
+    wp_vector::iterator it;
+    for (it = org_wp.begin(); it < org_wp.end(); it++) {
+      const auto wp = GetWaypoint(*it, way_points);
+      TestSeeYouWaypoint(*it, wp.get());
+    }
+  }
+
+  // Test a SeeYou waypoint file with a runway width field:
+  Waypoints way_points2;
+  if (!TestWaypointFile(Path(_T("test/data/waypoints2.cup")), way_points2,
+                        org_wp.size())) {
+    skip(9 * org_wp.size(), 0, "opening waypoints2.cup failed");
     return;
   }
 
-  wp_vector::iterator it;
-  for (it = org_wp.begin(); it < org_wp.end(); it++) {
-    const auto wp = GetWaypoint(*it, way_points);
-    TestSeeYouWaypoint(*it, wp.get());
+  wp_vector::iterator it2;
+  for (it2 = org_wp.begin(); it2 < org_wp.end(); it2++) {
+    const auto wp2 = GetWaypoint(*it2, way_points2);
+    TestSeeYouWaypoint(*it2, wp2.get());
   }
 }
 
@@ -523,7 +537,7 @@ int main(int argc, char **argv)
 {
   wp_vector org_wp = CreateOriginalWaypoints();
 
-  plan_tests(307);
+  plan_tests(360);
 
   TestExtractParameters();
 


### PR DESCRIPTION
Some CUP files (e.g., those saved/created by SeeYou Mobile) contain a runway width (rwwidth) field. This added testing demonstrates failures with such a file with the current code but demonstrates success with the pull request I submitted for a fix (PR #56).