### PR TITLE
Adjust URL for `android/ioio` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "android/ioio"]
 	path = android/ioio
-	url = git://git.xcsoar.org/xcsoar/master/ioio.git
+	url = git://github.com/xcsoar/ioio.git
 [submodule "lib/boost/config"]
 	path = lib/boost/config
 	url = git://github.com/boostorg/config.git


### PR DESCRIPTION
Backport of https://github.com/XCSoar/XCSoar/pull/65 to the `v6.8.x` branch.

see #64 