### PR TITLE
Add basic CircleCI instructions (for `master` branch)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: buildpack-deps:stretch
+
+    steps:
+      - type: shell
+        name: Install System Dependencies
+        command: |
+          apt-get update -qqy
+          apt-get install -qqy --no-install-recommends \
+            ffmpeg \
+            gettext \
+            libasound2-dev \
+            libgeotiff-dev \
+            libgl1-mesa-dev \
+            liblua5.2-dev \
+            librsvg2-bin \
+            quilt \
+            xsltproc
+
+      - type: checkout
+
+      - type: run
+        name: Update git submodules
+        command: git submodule update --init --recursive
+
+      - type: run
+        name: Build
+        command: make -j2 TARGET=UNIX everything
+
+      - type: run
+        name: Tests
+        command: make TARGET=UNIX check

--- a/build/libboost.mk
+++ b/build/libboost.mk
@@ -1,4 +1,4 @@
-BOOST_URL = http://downloads.sourceforge.net/project/boost/boost/1.65.1/boost_1_65_1.tar.bz2
+BOOST_URL = https://dl.bintray.com/boostorg/release/1.65.1/source/boost_1_65_1.tar.bz2
 BOOST_ALTERNATIVE_URL = https://fossies.org/linux/misc/boost_1_65_1.tar.bz2
 BOOST_MD5 = 9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81
 


### PR DESCRIPTION
This is a forward port of https://github.com/XCSoar/XCSoar/pull/59 to the `master` branch