### PR TITLE
Device Manager: Show if sensor data is available

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,8 @@ Version 7.0 - not yet released
   - driver for KRT2 radio
   - show detailed error message in device list
   - FLARM/OGN - make it possible to set/download registered device database
+  - device manager: show flag if device provides data from
+      environmental sensors (temperature, humidity)
 * weather
   - merge all weather data in one dialog
   - allow showing both terrain and RASP

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -81,6 +81,8 @@ class DeviceListWidget final
     bool duplicate:1;
     bool open:1, error:1;
     bool alive:1, location:1, gps:1, baro:1, airspeed:1, vario:1, traffic:1;
+    bool temperature:1;
+    bool humidity:1;
     bool debug:1;
 
     void Set(const DeviceConfig &config, const DeviceDescriptor &device,
@@ -116,6 +118,8 @@ class DeviceListWidget final
       airspeed = basic.airspeed_available;
       vario = basic.total_energy_vario_available;
       traffic = basic.flarm.IsDetected();
+      temperature = basic.temperature_available;
+      humidity = basic.humidity_available;
       debug = device.IsDumpEnabled();
     }
   };
@@ -384,6 +388,11 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc, unsigned idx)
 
     if (flags.traffic)
       buffer.append(_T("; FLARM"));
+
+    if (flags.temperature || flags.humidity) {
+      buffer.append(_T("; "));
+      buffer.append(_T("Environment"));
+    }
 
     if (flags.debug) {
       buffer.append(_T("; "));


### PR DESCRIPTION
This adds labels for Temperature and Humidity to the device dialog if a device provides that data.