### PR TITLE
SiteFiles - make it possible to pick/download FLARM device database

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,6 +10,7 @@ Version 7.0 - not yet released
   - driver for XC Tracer Vario
   - driver for KRT2 radio
   - show detailed error message in device list
+  - FLARM/OGN - make it possible to set/download registered device database
 * weather
   - merge all weather data in one dialog
   - allow showing both terrain and RASP

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -40,7 +40,8 @@ enum ControlIndex {
   WatchedWaypointFile,
   AirspaceFile,
   AdditionalAirspaceFile,
-  AirfieldFile
+  AirfieldFile,
+  FlarmFile
 };
 
 class SiteConfigPanel final : public RowFormWidget {
@@ -103,6 +104,11 @@ SiteConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
             "information about individual waypoints and airfields."),
           ProfileKeys::AirfieldFile, _T("*.txt\0"));
   SetExpertRow(AirfieldFile);
+
+  AddFile(_("FLARM Device Database"),
+          _("The name of the file containing information about registered FLARM devices."),
+          ProfileKeys::FlarmFile, _T("*.fln\0"),
+          FileType::FLARMNET);
 }
 
 bool
@@ -120,10 +126,12 @@ SiteConfigPanel::Save(bool &_changed)
   AirspaceFileChanged = SaveValueFileReader(AirspaceFile, ProfileKeys::AirspaceFile);
   AirspaceFileChanged |= SaveValueFileReader(AdditionalAirspaceFile, ProfileKeys::AdditionalAirspaceFile);
 
+  FlarmFileChanged = SaveValueFileReader(FlarmFile, ProfileKeys::FlarmFile);
+
   AirfieldFileChanged = SaveValueFileReader(AirfieldFile, ProfileKeys::AirfieldFile);
 
 
-  changed = WaypointFileChanged || AirfieldFileChanged || MapFileChanged;
+  changed = WaypointFileChanged || AirfieldFileChanged || MapFileChanged || FlarmFileChanged;
 
   _changed |= changed;
 

--- a/src/FLARM/Glue.cpp
+++ b/src/FLARM/Glue.cpp
@@ -36,6 +36,8 @@ Copyright_License {
 #include "Profile/FlarmProfile.hpp"
 #include "Profile/Current.hpp"
 #include "LogFile.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/ProfileKeys.hpp"
 
 /**
  * Loads the FLARMnet file
@@ -43,9 +45,12 @@ Copyright_License {
 static void
 LoadFLARMnet(FlarmNetDatabase &db)
 try {
-  auto reader = OpenDataTextFileA(_T("data.fln"));
+  auto path = Profile::GetPath(ProfileKeys::FlarmFile);
+  if (path.IsNull()) {
+    return;
+  }
 
-  unsigned num_records = FlarmNetReader::LoadFile(*reader, db);
+  unsigned num_records = FlarmNetReader::LoadFile(path, db);
   if (num_records > 0)
     LogFormat("%u FLARMnet ids found", num_records);
 } catch (const std::runtime_error &e) {
@@ -74,6 +79,12 @@ LoadFlarmDatabases()
   if (traffic_databases != nullptr)
     return;
 
+  ReloadFlarmDatabases();
+}
+
+void
+ReloadFlarmDatabases()
+{
   traffic_databases = new TrafficDatabases();
 
   /* the MergeThread must be suspended, because it reads the FLARM
@@ -123,4 +134,3 @@ DeinitTrafficGlobals()
   delete traffic_databases;
   traffic_databases = nullptr;
 }
-

--- a/src/FLARM/Glue.hpp
+++ b/src/FLARM/Glue.hpp
@@ -31,6 +31,13 @@ Copyright_License {
 void
 LoadFlarmDatabases();
 
+/**
+ * Same as LoadFlarmDatabases except that this method forces reload even if the database
+ * has been loaded previously.
+ */
+void
+ReloadFlarmDatabases();
+
 void
 SaveFlarmColors();
 

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -87,6 +87,7 @@ const char AcknowledgementTime[] = "AcknowledgementTime";
 const char AirfieldFile[] = "AirfieldFile"; // pL
 const char AirspaceFile[] = "AirspaceFile"; // pL
 const char AdditionalAirspaceFile[] = "AdditionalAirspaceFile"; // pL
+const char FlarmFile[] = "FlarmFile";
 const char PolarFile[] = "PolarFile"; // pL
 const char WaypointFile[] = "WPFile"; // pL
 const char AdditionalWaypointFile[] = "AdditionalWPFile"; // pL

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -62,6 +62,7 @@ extern const char AdditionalWaypointFile[];
 extern const char WatchedWaypointFile[];
 extern const char AirspaceFile[];
 extern const char AdditionalAirspaceFile[];
+extern const char FlarmFile[];
 extern const char AirfieldFile[];
 extern const char PolarFile[];
 extern const char LanguageFile[];

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -59,6 +59,7 @@ Copyright_License {
 #include "Audio/VarioGlue.hpp"
 #include "Audio/VolumeController.hpp"
 #include "PageActions.hpp"
+#include "FLARM/Glue.hpp"
 
 #if defined(__BORLANDC__)  // due to compiler bug
   #include "Waypoint/Waypoints.hpp"
@@ -69,6 +70,7 @@ bool MapFileChanged = false;
 bool AirspaceFileChanged = false;
 bool AirfieldFileChanged = false;
 bool WaypointFileChanged = false;
+bool FlarmFileChanged = false;
 bool InputFileChanged = false;
 bool LanguageChanged = false;
 bool require_restart;
@@ -85,6 +87,7 @@ SettingsEnter()
   AirspaceFileChanged = false;
   AirfieldFileChanged = false;
   WaypointFileChanged = false;
+  FlarmFileChanged = false;
   InputFileChanged = false;
   DevicePortChanged = false;
   LanguageChanged = false;
@@ -192,6 +195,10 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   if (DevicePortChanged)
     devRestart();
+
+  if (FlarmFileChanged) {
+    ReloadFlarmDatabases();
+  }
 
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 

--- a/src/UtilsSettings.hpp
+++ b/src/UtilsSettings.hpp
@@ -32,6 +32,7 @@ extern bool WaypointFileChanged;
 extern bool AirfieldFileChanged;
 extern bool InputFileChanged;
 extern bool MapFileChanged;
+extern bool FlarmFileChanged;
 extern bool LanguageChanged;
 extern bool require_restart;
 


### PR DESCRIPTION
We're using [SoftRF](https://github.com/lyusupov/SoftRF) devices in our aeroclub. These devices provide information about OGN devices in the vicinity of the aircraft as a FLARM source. This change makes it possible to pick a FLARM/OGN device database in the System Configuration --> Site Files. Optionally, a fresh FLARMNET/OGN device database can be download using the [XCSoar data repository](https://github.com/XCSoar/xcsoar-data-repository). The related data repository PR is: https://github.com/XCSoar/xcsoar-data-repository/pull/101

![screenshot_20180529-190914](https://user-images.githubusercontent.com/167352/40674488-4b3693be-6375-11e8-810a-a1eee0ae79bf.png)
![screenshot_20180529-190306](https://user-images.githubusercontent.com/167352/40674487-4b124748-6375-11e8-814d-b04554b08b91.png)

