### PR TITLE
[Android] Make it possible to play external wav files

### DIFF
--- a/android/src/SoundUtil.java
+++ b/android/src/SoundUtil.java
@@ -24,8 +24,10 @@ Copyright_License {
 package org.xcsoar;
 
 import java.util.HashMap;
+import java.io.File;
 import android.media.MediaPlayer;
 import android.content.Context;
+import android.net.Uri;
 
 public class SoundUtil {
   private static HashMap<String, Integer> resources = new HashMap();
@@ -44,9 +46,29 @@ public class SoundUtil {
     if (id == null)
       return false;
 
-    MediaPlayer mp = MediaPlayer.create(context, id);
-    if (mp == null)
+    return run(MediaPlayer.create(context, id));
+  }
+
+  public static boolean playExternal(Context context, String path) {
+    final File file = new File(path);
+    if (!file.exists()) {
       return false;
+    }
+
+    return run(MediaPlayer.create(context, Uri.fromFile(file)));
+  }
+
+  private static boolean run(final MediaPlayer mp) {
+    if (mp == null) {
+      return false;
+    }
+
+    mp.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+      @Override
+      public void onCompletion(MediaPlayer mediaPlayer) {
+        mp.release();
+      }
+    });
 
     mp.start();
     return true;

--- a/src/Android/SoundUtil.cpp
+++ b/src/Android/SoundUtil.cpp
@@ -24,10 +24,13 @@ Copyright_License {
 #include "SoundUtil.hpp"
 #include "Java/Class.hxx"
 #include "Java/String.hxx"
+#include "LocalPath.hpp"
+#include "OS/Path.hpp"
 
 namespace SoundUtil {
   static Java::TrivialClass cls;
   static jmethodID play_method;
+  static jmethodID playExternal_method;
 }
 
 void
@@ -40,6 +43,9 @@ SoundUtil::Initialise(JNIEnv *env)
   play_method = env->GetStaticMethodID(cls, "play",
                                        "(Landroid/content/Context;"
                                        "Ljava/lang/String;)Z");
+  playExternal_method = env->GetStaticMethodID(cls, "playExternal",
+                                               "(Landroid/content/Context;"
+                                               "Ljava/lang/String;)Z");
 }
 
 void
@@ -53,5 +59,14 @@ SoundUtil::Play(JNIEnv *env, jobject context, const char *name)
 {
   Java::String paramName(env, name);
   return env->CallStaticBooleanMethod(cls, play_method, context,
+                                      paramName.Get());
+}
+
+bool
+SoundUtil::PlayExternal(JNIEnv *env, jobject context, const char *path)
+{
+  AllocatedPath absolutePath = LocalPath(_T(path));
+  Java::String paramName(env, absolutePath.c_str());
+  return env->CallStaticBooleanMethod(cls, playExternal_method, context,
                                       paramName.Get());
 }

--- a/src/Android/SoundUtil.hpp
+++ b/src/Android/SoundUtil.hpp
@@ -31,6 +31,7 @@ namespace SoundUtil {
   void Deinitialise(JNIEnv *env);
 
   bool Play(JNIEnv *env, jobject context, const char *name);
+  bool PlayExternal(JNIEnv *env, jobject context, const char *path);
 };
 
 #endif

--- a/src/Audio/Sound.cpp
+++ b/src/Audio/Sound.cpp
@@ -44,6 +44,8 @@ PlayResource(const TCHAR *resource_name)
 {
 #ifdef ANDROID
 
+  if (_tcsstr(resource_name, _T(".wav")))
+    return SoundUtil::PlayExternal(Java::GetEnv(), context->Get(), resource_name);
   return SoundUtil::Play(Java::GetEnv(), context->Get(), resource_name);
 
 #elif defined(WIN32)


### PR DESCRIPTION
This brings SoundUtil functionality on Android on par with WIN32. If the name of the resource to be played ends with .wav it will be loaded as an external file and played. A quick way to test it is with a simple init.lua file:
```lua
xcsoar.fire_legacy_event("PlaySound", "test.wav")
```