### PR TITLE
[6.8] prevent DownloadFilePicker options from being listed twice

### DIFF
--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -271,6 +271,7 @@ DownloadFilePickerWidget::RefreshList()
   if (!reader.error()) {
     ParseFileRepository(repository, reader);
 
+    items.clear();
     for (auto &i : repository)
       if (i.type == file_type)
         items.emplace_back(std::move(i));


### PR DESCRIPTION
When the repository is cached locally  DownloadFilePickerWidget::RefreshList is called twice on initial load - once
for the local cache and then again when the repository download finishes. Since RefreshList() is not idempotent this results
in repository items to be added twice to the items vector. This change prevents that by clearing the items vector each time.

Fixes https://github.com/XCSoar/XCSoar/issues/108