### PR TITLE
Screen/X11/TopWindow: add missing include

### DIFF
--- a/src/Screen/X11/TopWindow.cpp
+++ b/src/Screen/X11/TopWindow.cpp
@@ -33,6 +33,8 @@ Copyright_License {
 
 #include <X11/Xatom.h>
 
+#include <stdio.h>
+
 void
 TopWindow::CreateNative(const TCHAR *text, PixelSize size,
                         TopWindowStyle style)


### PR DESCRIPTION
Rebased from master, commit a09fa72.
Fixes UNIX build on current debian stretch host.

Fixes #81.
Please, DON'T hit "Merge" and pollute the git history with two additional commits for this one-line fix from 2015, merge via fast-forward, or cherry-pick yourself

git cherry-pick a09fa72

Thanks!