### PR TITLE
Revert "Disabled set_idle call that caused crashes on Android 8.0"

### DIFF
--- a/src/Thread/Util.hpp
+++ b/src/Thread/Util.hpp
@@ -30,7 +30,7 @@
 #ifndef THREAD_UTIL_HXX
 #define THREAD_UTIL_HXX
 
-#if defined(__linux__) && !defined(ANDROID)
+#ifdef __linux__
 #include <sched.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -38,7 +38,7 @@
 #include <windows.h>
 #endif
 
-#if defined(__linux__) && !defined(ANDROID)
+#ifdef __linux__
 
 static int
 ioprio_set(int which, int who, int ioprio)
@@ -78,11 +78,7 @@ SetThreadIdlePriority()
   sched_setscheduler(0, SCHED_IDLE, &sched_param);
 #endif
 
-#ifndef ANDROID
-  /* this system call is forbidden via seccomp on Android 8 and leads
-   * to crash (SIGSYS) */
   ioprio_set_idle();
-#endif  
 
 #elif defined(WIN32)
   SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_IDLE);


### PR DESCRIPTION
Reverts XCSoar/XCSoar#122