### PR TITLE
Util/StringCompare: Handle the case when an arg is null.

### DIFF
--- a/src/Util/StringCompare.hxx
+++ b/src/Util/StringCompare.hxx
@@ -41,7 +41,14 @@
 static inline bool
 StringIsEmpty(const char *string) noexcept
 {
-	return *string == 0;
+  /*
+   * It is possible that string is null. If so it cannot be anything else
+   * but empty.
+   */
+  if (string == nullptr)
+    return true;
+  else
+	  return *string == 0;
 }
 
 gcc_pure gcc_nonnull_all


### PR DESCRIPTION
It is possible that string is null in StringIsEmpty(const char *string)
Handle this case.

Issue #139 