### PR TITLE
Ticket 3930 - Task Editor Crashes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ The following people and organizations have contributed code to XCSoar:
  Steffen Engel <steffen.engel@nutrimat.de>
  Alex Graf <xcsoar@grafitation.ch>
  Bruno de Lacheisserie <bruno.de.lacheisserie@gmail.com>
+ Peter F Bradshaw <pfb@exadios.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 6.8.12 - not yet released
 * Android
   - increase targetSdkVersion to 26 (required by Google Play)
+* Task Editor
+  - fixed task editor crashes (Ticket 3930).
 
 Version 6.8.11 - 2018/08/18
 * terrain

--- a/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
+++ b/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
@@ -246,6 +246,17 @@ TaskManagerDialog::Revert()
   OrderedTask *temp = protected_task_manager->TaskClone();
   delete task;
   task = temp;
+  /**
+   * \todo Having local pointers scattered about is an accident waiting to
+   *       happen. Need a semantic that provides the authoritative pointer to
+   *       the current task to all.
+   */
+  /**
+   * Update our widget's ordered task because it is now out of date.
+   */
+  auto &task_view = (ButtonWidget &)GetExtra();
+  auto &renderer = (TaskMapButtonRenderer &)task_view.GetRenderer();
+  renderer.SetTask(task);
   modified = false;
 }
 

--- a/src/Dialogs/Task/Manager/TaskMapButtonRenderer.hpp
+++ b/src/Dialogs/Task/Manager/TaskMapButtonRenderer.hpp
@@ -36,6 +36,10 @@ class OrderedTask;
 class TaskMapButtonRenderer : public ButtonRenderer {
   const MapLook &look;
 
+  /**
+   * \todo This should not be store within this class. Instead this class
+   *       should obtain this information from an authoritative source.
+   */
   const OrderedTask *task;
 
   mutable BufferCanvas buffer;


### PR DESCRIPTION
This patch addresses Ticket 3930. A valgrind trace is attached to that ticket. A core file is available on request.
