### PR TITLE
Identify 2D fixes

### DIFF
--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -307,9 +307,13 @@ NMEAParser::GSA(NMEAInputLine &line, NMEAInfo &info)
    */
 
   line.Skip();
-
-  if (line.Read(0) == 1)
-    info.location_available.Clear();
+  
+  // determine fix type
+  unsigned fix_mode;  
+  fix_mode = line.Read(0);  
+  if (fix_mode == 1)
+    info.location_available.Clear();  
+  info.fix_2d = (fix_mode == 2);
 
   // satellites are in items 4-15 of GSA string (4-15 is 1-indexed)
   for (unsigned i = 0; i < GPSState::MAXSATELLITES; i++)

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -308,9 +308,7 @@ NMEAParser::GSA(NMEAInputLine &line, NMEAInfo &info)
 
   line.Skip();
   
-  // determine fix type
-  unsigned fix_mode;  
-  fix_mode = line.Read(0);  
+  unsigned fix_mode = line.Read(0);  
   if (fix_mode == 1)
     info.location_available.Clear();  
   info.fix_2d = (fix_mode == 2);

--- a/src/IGC/IGCFix.cpp
+++ b/src/IGC/IGCFix.cpp
@@ -36,7 +36,7 @@ IGCFix::Apply(const NMEAInfo &basic)
 
   /* "Use A for a 3D fix and V for a 2D fix (no GPS altitude) or for
      no GPS data" */
-  gps_valid = basic.location_available && basic.gps_altitude_available && !(basic.fix_2d);
+  gps_valid = basic.location_available && basic.gps_altitude_available && !basic.fix_2d;
 
   if (basic.location_available)
     location = basic.location;

--- a/src/IGC/IGCFix.cpp
+++ b/src/IGC/IGCFix.cpp
@@ -36,7 +36,7 @@ IGCFix::Apply(const NMEAInfo &basic)
 
   /* "Use A for a 3D fix and V for a 2D fix (no GPS altitude) or for
      no GPS data" */
-  gps_valid = basic.location_available && basic.gps_altitude_available && !basic.fix_2d;
+  gps_valid = basic.location_available && basic.gps_altitude_available && (!basic.fix_2d);
 
   if (basic.location_available)
     location = basic.location;

--- a/src/IGC/IGCFix.cpp
+++ b/src/IGC/IGCFix.cpp
@@ -36,16 +36,18 @@ IGCFix::Apply(const NMEAInfo &basic)
 
   /* "Use A for a 3D fix and V for a 2D fix (no GPS altitude) or for
      no GPS data" */
-  gps_valid = basic.location_available && basic.gps_altitude_available;
+  gps_valid = basic.location_available && basic.gps_altitude_available && !(basic.fix_2d);
 
   if (basic.location_available)
     location = basic.location;
 
   time = basic.date_time_utc;
-
-  gps_altitude = basic.gps_altitude_available
-    ? (int)basic.gps_altitude
-    : 0;
+  
+  gps_altitude = basic.fix_2d
+	  ? 0
+	  : (basic.gps_altitude_available
+         ? (int)basic.gps_altitude
+         : 0);
 
   pressure_altitude = basic.pressure_altitude_available
     ? (int)basic.pressure_altitude

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -161,6 +161,8 @@ NMEAInfo::Reset()
   airspeed_available.Clear();
   ground_speed = true_airspeed = indicated_airspeed = 0;
   airspeed_real = false;
+  
+  fix_2D = false;
 
   gps_altitude_available.Clear();
 

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -162,7 +162,7 @@ NMEAInfo::Reset()
   ground_speed = true_airspeed = indicated_airspeed = 0;
   airspeed_real = false;
   
-  fix_2D = false;
+  fix_2d = false;
 
   gps_altitude_available.Clear();
 

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -124,7 +124,7 @@ struct NMEAInfo {
    * 2D fix information
    * true for 2d fix
    */  
-  bool fix_2D;
+  bool fix_2d;
 
   //##############
   //   Altitude

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -119,6 +119,12 @@ struct NMEAInfo {
    * @see AirDensityRatio
    */
   double indicated_airspeed;
+  
+  /**
+   * 2D fix information
+   * true for 2d fix
+   */  
+  bool fix_2D;
 
   //##############
   //   Altitude


### PR DESCRIPTION
Currently, XCSoar sets fix validity to A based on whether there is a valid position available and a valid GPS height available. However, both these conditions are true for a 2D fix which should have fix validity set to V.
See www.sacra.biz/2dfixes/DEBUG16082018skydrop.txt and www.sacra.biz/2dfixes/NMEAIN02092018oudie.txt for examples.

The correct way to identify 2D fixes is using the NMEA GSA sentence. This Pull Request will resolve the issue.