### PR TITLE
build/libnet: Disable `HAVE_HTTP` when building Python distribution

### DIFF
--- a/build/libnet.mk
+++ b/build/libnet.mk
@@ -10,6 +10,7 @@ LIBNET_SOURCES = \
 
 HAVE_HTTP := n
 
+ifneq ($(MAKECMDGOALS),python)
 ifneq ($(findstring $(TARGET),PC WINE CYGWIN),)
 HAVE_HTTP := y
 LIBNET_SOURCES += \
@@ -47,6 +48,7 @@ HAVE_HTTP := y
 LIBNET_SOURCES += \
 	$(SRC)/Net/HTTP/Java/Session.cpp \
 	$(SRC)/Net/HTTP/Java/Request.cpp
+endif
 endif
 
 ifeq ($(HAVE_HTTP),y)


### PR DESCRIPTION
The HTTP client is not used at all by the Python distribution, but the `pkg-config` call will still fail if `libcurl` is not available at buildtime. This PR explicitly disables the HTTP client when building the Python distribution so that `pkg-config` is never called.