### PR TITLE
python: Keep original exceptions for argument parse failures

### DIFF
--- a/python/src/Airspaces.cpp
+++ b/python/src/Airspaces.cpp
@@ -90,7 +90,6 @@ PyObject* xcsoar_Airspaces_addPolygon(Pyxcsoar_Airspaces *self, PyObject *args) 
   if (!PyArg_ParseTuple(args, "OOOdOdO", &py_points, &py_name, &py_as_class,
                                          &base_alt, &py_base_ref,
                                          &top_alt, &py_top_ref)) {
-    PyErr_SetString(PyExc_AttributeError, "Error reading attributes.");
     return nullptr;
   }
 
@@ -206,7 +205,6 @@ PyObject* xcsoar_Airspaces_findIntrusions(Pyxcsoar_Airspaces *self, PyObject *ar
   PyObject *py_flight = nullptr;
 
   if (!PyArg_ParseTuple(args, "O", &py_flight)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument.");
     return nullptr;
   }
 

--- a/python/src/Flight.cpp
+++ b/python/src/Flight.cpp
@@ -45,7 +45,6 @@ PyObject* xcsoar_Flight_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|b", kwlist,
                                    &py_input_data, &keep)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return 0;
   }
 
@@ -115,7 +114,6 @@ PyObject* xcsoar_Flight_setQNH(Pyxcsoar_Flight *self, PyObject *args) {
   double qnh;
 
   if (!PyArg_ParseTuple(args, "d", &qnh)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse QNH.");
     return nullptr;
   }
 
@@ -129,7 +127,6 @@ PyObject* xcsoar_Flight_path(Pyxcsoar_Flight *self, PyObject *args) {
            *py_end = nullptr;
 
   if (!PyArg_ParseTuple(args, "|OO", &py_begin, &py_end)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return nullptr;
   }
 
@@ -251,7 +248,6 @@ PyObject* xcsoar_Flight_reduce(Pyxcsoar_Flight *self, PyObject *args, PyObject *
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|OOIIIdIO", kwlist,
                                    &py_begin, &py_end, &num_levels, &zoom_factor,
                                    &max_delta_time, &threshold, &max_points, &py_force_endpoints)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return nullptr;
   }
 
@@ -301,7 +297,6 @@ PyObject* xcsoar_Flight_analyse(Pyxcsoar_Flight *self, PyObject *args, PyObject 
                                    &py_takeoff, &py_scoring_start, &py_scoring_end, &py_landing,
                                    &full, &triangle, &sprint,
                                    &max_iterations, &max_tree_size)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return nullptr;
   }
 
@@ -404,7 +399,6 @@ PyObject* xcsoar_Flight_encode(Pyxcsoar_Flight *self, PyObject *args) {
            *py_end = nullptr;
 
   if (!PyArg_ParseTuple(args, "|OO", &py_begin, &py_end)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return nullptr;
   }
 

--- a/python/src/PythonConverters.cpp
+++ b/python/src/PythonConverters.cpp
@@ -339,7 +339,6 @@ bool Python::PyTupleToIGCFixEnhanced(PyObject *py_fix, IGCFixEnhanced &fix) {
          &py_gps_alt, &py_pressure_alt,
          &py_enl, &py_trt, &py_gsp, &py_tas, &py_ias,
          &py_siu, &py_elevation, &py_level)) {
-    PyErr_SetString(PyExc_TypeError, "Failed to parse tuple.");
     return false;
   }
 

--- a/python/src/Util.cpp
+++ b/python/src/Util.cpp
@@ -41,7 +41,6 @@ PyObject* xcsoar_encode(PyObject *self, PyObject *args, PyObject *kwargs) {
 
   if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|idO", kwlist,
                                    &py_list, &delta, &floor_to, &py_method)) {
-    PyErr_SetString(PyExc_AttributeError, "Can't parse argument list.");
     return nullptr;
   }
 


### PR DESCRIPTION
`PyArg_ParseTuple()` already calls `PyErr_SetString()` with a descriptive message, and by overriding that message we make it much harder to debug broken calls