### PR TITLE
Dialogs/ProfileListDialog: fix copy bug #3925 in CopyClicked()

### DIFF
--- a/src/Dialogs/ProfileListDialog.cpp
+++ b/src/Dialogs/ProfileListDialog.cpp
@@ -286,7 +286,7 @@ ProfileListWidget::CopyClicked()
   }
 
   try {
-    Profile::SaveFile(data, item.path);
+    Profile::SaveFile(data, new_path);
   } catch (const std::runtime_error &e) {
     ShowError(e, _("Failed to save file."));
     return;


### PR DESCRIPTION
Credit for the patch goes entirely to apf.