### PR TITLE
Driver for altimeter functionality of Air Control Display

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ The following people and organizations have contributed code to XCSoar:
  Fabian Berstecher <fabian.berstecher@rbe-avionik.de>
  Bruno de Lacheisserie <bruno.de.lacheisserie@gmail.com>
  Peter F Bradshaw <pfb@exadios.com>
+ Stefan Schumann <stefan.schumann@posteo.de>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,7 @@ Version 7.0 - not yet released
   - parse wind from standard NMEA sentence WMV
   - driver for XC Tracer Vario
   - driver for KRT2 radio
+  - driver for Air Control Display altimeter
   - show detailed error message in device list
   - FLARM/OGN - make it possible to set/download registered device database
   - device manager: show flag if device provides data from

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -124,6 +124,7 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/Zander.cpp \
 	$(DRIVER_SRC_DIR)/Vaulter.cpp \
 	$(DRIVER_SRC_DIR)/KRT2.cpp \
+	$(DRIVER_SRC_DIR)/AirControlDisplay.cpp \
 	$(DRIVER_SRC_DIR)/ATR833.cpp
 
 $(eval $(call link-library,driver,DRIVER))

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -1,0 +1,113 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Device/Driver/AirControlDisplay.hpp"
+#include "Device/Driver.hpp"
+#include "Device/Util/NMEAWriter.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/InputLine.hpp"
+#include "NMEA/Checksum.hpp"
+#include "Atmosphere/Pressure.hpp"
+#include "Units/System.hpp"
+#include "Math/Util.hpp"
+
+static bool
+ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
+{
+  double value;
+
+  char type[16];
+  line.Read(type, 16);
+
+  if (StringIsEqual(type, "ALT")) {
+    /*
+    $PAAVS,ALT,<ALTQNE>,<ALTQNH>,<QNH>
+     <ALTQNE> Current QNE altitude in meters with two decimal places
+     <ALTQNH> Current QNH altitude in meters with two decimal places
+     <QNH> Current QNH setting in pascal (unsigned integer (e.g. 101325))
+    */
+    if (line.ReadChecked(value))
+      info.ProvidePressureAltitude(value);
+
+    if (line.ReadChecked(value))
+      info.ProvideBaroAltitudeTrue(value);
+
+    if (line.ReadChecked(value)) {
+      auto qnh = AtmosphericPressure::Pascal(value);
+      info.settings.ProvideQNH(qnh, info.clock);
+    }
+  } else {
+    // ignore responses from COM and XPDR
+    return false;
+  }
+
+  return true;
+}
+
+class ACDDevice : public AbstractDevice {
+  Port &port;
+
+public:
+  ACDDevice(Port &_port):port(_port) {}
+
+  /* virtual methods from class Device */
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+  bool PutQNH(const AtmosphericPressure &pres,
+              OperationEnvironment &env) override;
+};
+
+bool
+ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
+{
+  char buffer[100];
+  unsigned qnh = uround(pres.GetPascal());
+  sprintf(buffer, "PAAVC,S,ALT,QNH,%u", qnh);
+  return PortWriteNMEA(port, buffer, env);
+}
+
+bool
+ACDDevice::ParseNMEA(const char *_line, NMEAInfo &info)
+{
+  if (!VerifyNMEAChecksum(_line))
+    return false;
+
+  NMEAInputLine line(_line);
+
+  if (line.ReadCompare("$PAAVS"))
+    return ParsePAAVS(line, info);
+  else
+    return false;
+}
+
+static Device *
+AirControlDisplayCreateOnPort(const DeviceConfig &config, Port &com_port)
+{
+  return new ACDDevice(com_port);
+}
+
+const struct DeviceRegister acd_driver = {
+  _T("ACD"),
+  _T("Air Control Display"),
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  AirControlDisplayCreateOnPort,
+};

--- a/src/Device/Driver/AirControlDisplay.hpp
+++ b/src/Device/Driver/AirControlDisplay.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_DEVICE_DRIVER_AIRCONTROLDISPLAY_HPP
+#define XCSOAR_DEVICE_DRIVER_AIRCONTROLDISPLAY_HPP
+
+extern const struct DeviceRegister acd_driver;
+
+#endif

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -23,6 +23,7 @@ Copyright_License {
 
 #include "Device/Register.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Driver/AirControlDisplay.hpp"
 #include "Device/Driver/CAI302.hpp"
 #include "Device/Driver/CaiGpsNav.hpp"
 #include "Device/Driver/CaiLNav.hpp"
@@ -99,6 +100,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &atr833_driver,
   &xctracer_driver,
   &thermalexpress_driver,
+  &acd_driver,
   nullptr
 };
 


### PR DESCRIPTION
Driver for the altimeter functionality of the Air Avionics - Air Control Display in accordance with the Installation Manual 2.0. Driver has been tested on my Openvario.

Ref.: #161 