### PR TITLE
Moved the download directory out of the output directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.s
 *.so
 Doc/html/*
+download
 output
 perf.data
 perf.data.old

--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,9 @@ endif
 all: $(OUTPUTS)
 everything: $(OUTPUTS) $(OPTIONAL_OUTPUTS) debug build-check build-harness
 
+clean-download:
+	$(Q)rm -rf $(DOWNLOAD_DIR)
+
 clean:
 	@$(NQ)echo "cleaning all"
 	$(Q)rm -rf build/local-config.mk

--- a/build/dirs.mk
+++ b/build/dirs.mk
@@ -6,7 +6,7 @@ DATA = $(OUT)/data
 TEST_SRC_DIR = $(topdir)/test/src
 PYTHON_SRC = $(topdir)/python/src
 HOST_OUTPUT_DIR = $(OUT)/host
-DOWNLOAD_DIR = $(OUT)/download
+DOWNLOAD_DIR = $(topdir)/download
 TARGET_OUTPUT_DIR = $(OUT)/$(TARGET_FLAVOR)
 TARGET_BIN_DIR = $(TARGET_OUTPUT_DIR)/bin
 


### PR DESCRIPTION
Every time a 'make clean' or 'rm -rf output' gets run, the
output/download directory gets clobbered. This is pretty annoying,
if one does not have the luxury of a high speed Internet connection.

This patch fixes this problem, by moving the location of the download
directory to the XCSoar root directory.

In addition, the 'clean-download' make target was added, for the case
where one really wants to get rid of the download directory for some
reason.