### PR TITLE
Acd provide gps

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,7 +9,7 @@ Version 7.0 - not yet released
   - parse wind from standard NMEA sentence WMV
   - driver for XC Tracer Vario
   - driver for KRT2 radio
-  - driver for Air Control Display altimeter
+  - driver for Air Control Display altimeter and radio
   - show detailed error message in device list
   - FLARM/OGN - make it possible to set/download registered device database
   - device manager: show flag if device provides data from

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -27,6 +27,8 @@ Copyright_License {
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
+#include "NMEA/MoreData.hpp"
+#include "Operation/Operation.hpp"
 #include "Atmosphere/Pressure.hpp"
 #include "RadioFrequency.hpp"
 #include "Units/System.hpp"
@@ -79,6 +81,8 @@ public:
   bool PutStandbyFrequency(RadioFrequency frequency,
                            const TCHAR *name,
                            OperationEnvironment &env) override;
+  void OnCalculatedUpdate(const MoreData &basic,
+                          const DerivedInfo &calculated) override;
 };
 
 bool
@@ -121,6 +125,226 @@ ACDDevice::ParseNMEA(const char *_line, NMEAInfo &info)
     return ParsePAAVS(line, info);
   else
     return false;
+}
+
+static void
+FormatLatitude(char *buffer, size_t buffer_size, Angle latitude )
+{
+  // Calculate Latitude sign
+  char sign = latitude.IsNegative() ? 'S' : 'N';
+
+  double mlat(latitude.AbsoluteDegrees());
+
+  int dd = (int)mlat;
+  // Calculate minutes
+  double mins = (mlat - dd) * 60.0;
+
+  // Save the string to the buffer
+  snprintf(buffer, buffer_size, "%02d%06.3f,%c", dd, mins, sign);
+}
+
+static void
+FormatLongitude(char *buffer, size_t buffer_size, Angle longitude)
+{
+  // Calculate Longitude sign
+  char sign = longitude.IsNegative() ? 'W' : 'E';
+
+  double mlong(longitude.AbsoluteDegrees());
+
+  int dd = (int)mlong;
+  // Calculate minutes
+  double mins = (mlong - dd) * 60.0;
+  // Save the string to the buffer
+  snprintf(buffer, buffer_size, "%02d%06.3f,%c", dd, mins, sign);
+}
+
+/*
+ * $GPRMC,hhmmss.ss,A,llll.ll,a,yyyyy.yy,a,x.x,x.x,xxxx,x.x,a,m,*hh
+ *
+ * Field Number:
+ *  1) UTC Time
+ *  2) Status, V=Navigation receiver warning A=Valid
+ *  3) Latitude
+ *  4) N or S
+ *  5) Longitude
+ *  6) E or W
+ *  7) Speed over ground, knots
+ *  8) Track made good, degrees true
+ *  9) Date, ddmmyy
+ * 10) Magnetic Variation, degrees
+ * 11) E or W
+ * 12) FAA mode indicator (NMEA 2.3 and later)
+ * 13) Checksum
+ */
+static bool
+FormatGPRMC(char *buffer, size_t buffer_size, const MoreData &info)
+{
+  char lat_buffer[20];
+  char long_buffer[20];
+
+  const GeoPoint location = info.location_available
+    ? info.location
+    : GeoPoint::Zero();
+
+  FormatLatitude(lat_buffer, sizeof(lat_buffer), location.latitude);
+  FormatLongitude(long_buffer, sizeof(long_buffer), location.longitude);
+
+  const BrokenDateTime now = info.time_available &&
+    info.date_time_utc.IsDatePlausible()
+    ? info.date_time_utc
+    : BrokenDateTime::NowUTC();
+
+  snprintf(buffer, buffer_size,
+           "GPRMC,%02u%02u%02u,%c,%s,%s,%05.1f,%05.1f,%02u%02u%02u,,",
+           now.hour, now.minute, now.second,
+           info.location.IsValid() ? 'A' : 'V',
+           lat_buffer,
+           long_buffer,
+           (double)Units::ToUserUnit(info.ground_speed, Unit::KNOTS),
+           (double)info.track.Degrees(),
+           now.day, now.month, now.year % 100);
+
+  return true;
+}
+
+/*
+ * $GPGGA,hhmmss.ss,llll.ll,a,yyyyy.yy,a,x,xx,x.x,x.x,M,x.x,M,x.x,xxxx*hh
+ *
+ * Field Number:
+ *  1) Universal Time Coordinated (UTC)
+ *  2) Latitude
+ *  3) N or S (North or South)
+ *  4) Longitude
+ *  5) E or W (East or West)
+ *  6) GPS Quality Indicator,
+ *     0 - fix not available,
+ *     1 - GPS fix,
+ *     2 - Differential GPS fix
+ *     (values above 2 are 2.3 features)
+ *     3 = PPS fix
+ *     4 = Real Time Kinematic
+ *     5 = Float RTK
+ *     6 = estimated (dead reckoning)
+ *     7 = Manual input mode
+ *     8 = Simulation mode
+ *  7) Number of satellites in view, 00 - 12
+ *  8) Horizontal Dilution of precision (meters)
+ *  9) Antenna Altitude above/below mean-sea-level (geoid) (in meters)
+ * 10) Units of antenna altitude, meters
+ * 11) Geoidal separation, the difference between the WGS-84 earth
+ *     ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level
+ *     below ellipsoid
+ * 12) Units of geoidal separation, meters
+ * 13) Age of differential GPS data, time in seconds since last SC104
+ *     type 1 or 9 update, null field when DGPS is not used
+ * 14) Differential reference station ID, 0000-1023
+ * 15) Checksum
+ */
+static bool
+FormatGPGGA(char *buffer, size_t buffer_size, const MoreData &info)
+{
+  char lat_buffer[20];
+  char long_buffer[20];
+
+  const GeoPoint location = info.location_available
+    ? info.location
+    : GeoPoint::Zero();
+
+  FormatLatitude(lat_buffer, sizeof(lat_buffer), location.latitude);
+  FormatLongitude(long_buffer, sizeof(long_buffer), location.longitude);
+
+  const BrokenDateTime now = info.time_available &&
+    info.date_time_utc.IsDatePlausible()
+    ? info.date_time_utc
+    : BrokenDateTime::NowUTC();
+
+  snprintf(buffer, buffer_size,
+           "GPGGA,%02u%02u%02u,%c,%s,%s,%u,%2u,%.1f,%.1f,%c,%.1f,%c,,",
+           now.hour, now.minute, now.second,
+           info.location.IsValid() ? 'A' : 'V',
+           lat_buffer,
+           long_buffer,
+           (int)info.gps.fix_quality,
+           info.gps.satellites_used,
+           info.gps.hdop,
+           info.gps_altitude,
+           'M',
+           info.gps_altitude,
+           'M');
+
+  return true;
+}
+
+/*
+ * $GPGSA,a,a,x,x,x,x,x,x,x,x,x,x,x,x,x,x,x.x,x.x,x.x*hh
+ *
+ * Field Number:
+ *  1) Selection mode
+ *         M=Manual, forced to operate in 2D or 3D
+ *         A=Automatic, 3D/2D
+ *  2) Mode (1 = no fix, 2 = 2D fix, 3 = 3D fix)
+ *  3) ID of 1st satellite used for fix
+ *  4) ID of 2nd satellite used for fix
+ *  ...
+ *  14) ID of 12th satellite used for fix
+ *  15) PDOP
+ *  16) HDOP
+ *  17) VDOP
+ *  18) checksum
+ */
+static bool
+FormatGPGSA(char *buffer, size_t buffer_size, const MoreData &info)
+{
+  // don't format GPGSA string if no sat id's are available
+  if(!info.gps.satellite_ids_available)
+    return false;
+
+  int gps_status;
+
+  if (!info.alive || !info.location_available)
+    gps_status = 1;
+  else if (!info.gps_altitude_available)
+    gps_status = 2;
+  else
+    gps_status = 3;
+
+  snprintf(buffer, buffer_size,
+           "GPGSA,A,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%u,%.1f,%.1f,%.1f",
+           gps_status,
+           info.gps.satellite_ids[0],
+           info.gps.satellite_ids[1],
+           info.gps.satellite_ids[2],
+           info.gps.satellite_ids[3],
+           info.gps.satellite_ids[4],
+           info.gps.satellite_ids[5],
+           info.gps.satellite_ids[6],
+           info.gps.satellite_ids[7],
+           info.gps.satellite_ids[8],
+           info.gps.satellite_ids[9],
+           info.gps.satellite_ids[10],
+           info.gps.satellite_ids[11],
+           info.gps.pdop,
+           info.gps.hdop,
+           info.gps.vdop);
+
+  return true;
+}
+
+void
+ACDDevice::OnCalculatedUpdate(const MoreData &basic,
+                        const DerivedInfo &calculated)
+{
+  NullOperationEnvironment env;
+  char buffer[100];
+
+  if (FormatGPRMC(buffer, sizeof(buffer), basic))
+    PortWriteNMEA(port, buffer, env);
+
+  if (FormatGPGSA(buffer, sizeof(buffer), basic))
+    PortWriteNMEA(port, buffer, env);
+
+  if (FormatGPGGA(buffer, sizeof(buffer), basic))
+    PortWriteNMEA(port, buffer, env);
 }
 
 static Device *

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -317,6 +317,13 @@ NMEAParser::GSA(NMEAInputLine &line, NMEAInfo &info)
 
   info.gps.satellite_ids_available.Update(info.clock);
 
+  info.gps.pdop = line.Read(-1.);
+
+  info.gps.hdop = line.Read(-1.);
+
+  info.gps.vdop = line.Read(-1.);
+
+
   return true;
 }
 

--- a/src/Logger/LoggerImpl.cpp
+++ b/src/Logger/LoggerImpl.cpp
@@ -67,6 +67,8 @@ LoggerImpl::PreTakeoffBuffer::operator=(const NMEAInfo &src)
     satellites_used = src.gps.satellites_used;
 
   hdop = src.gps.hdop;
+  pdop = src.gps.pdop;
+  vdop = src.gps.vdop;
   real = src.gps.real;
 
   satellite_ids_available = src.gps.satellite_ids_available;
@@ -188,6 +190,8 @@ LoggerImpl::LogPoint(const NMEAInfo &gps_info)
     }
 
     tmp_info.gps.hdop = src.location.IsValid() ? src.hdop : -1;
+    tmp_info.gps.pdop = src.location.IsValid() ? src.pdop : -1;
+    tmp_info.gps.vdop = src.location.IsValid() ? src.vdop : -1;
     tmp_info.gps.real = src.real;
 
     if (src.satellite_ids_available) {

--- a/src/Logger/LoggerImpl.hpp
+++ b/src/Logger/LoggerImpl.hpp
@@ -71,6 +71,10 @@ public:
     bool satellites_used_available;
     /** GPS Horizontal Dilution of precision */
     double hdop;
+    /** GPS Position (3D) Dilution of precision */
+    double pdop;
+    /** GPS Vertical Dilution of precision */
+    double vdop;
 
     /**
      * Is the fix real? (no replay, no simulator)

--- a/src/NMEA/GPSState.cpp
+++ b/src/NMEA/GPSState.cpp
@@ -36,6 +36,8 @@ GPSState::Reset()
   satellites_used_available.Clear();
   satellite_ids_available.Clear();
   hdop = -1;
+  pdop = -1;
+  vdop = -1;
   replay = false;
 }
 

--- a/src/NMEA/GPSState.hpp
+++ b/src/NMEA/GPSState.hpp
@@ -76,6 +76,22 @@ struct GPSState
   double hdop;
 
   /**
+   * Position (3D) dilution of precision.
+   *
+   * This attribute is only valid if NMEAInfo::location_available is
+   * true.  A negative value means "unknown".
+   */
+  double pdop;
+
+  /**
+   * Vertical dilution of precision.
+   *
+   * This attribute is only valid if NMEAInfo::location_available is
+   * true.  A negative value means "unknown".
+   */
+  double vdop;
+
+  /**
    * Is the fix real? (no replay, no simulator)
    */
   bool real;


### PR DESCRIPTION
ACD driver modified to provide GPS data to Air Control Display unit. The ACD makes use of the GPS data for the NEAREST function of the radio.

GPSState was changed to store VDOP and HDOP and the Parser to parse those values from the GPGSA sentence.