### PR TITLE
Added navigation through infoboxes with arrow keys.

### DIFF
--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -33,6 +33,7 @@ Copyright_License {
 #include "Profile/Current.hpp"
 #include "Interface.hpp"
 #include "UIState.hpp"
+#include "Event/KeyCode.hpp"
 
 namespace InfoBoxManager
 {
@@ -50,6 +51,7 @@ namespace InfoBoxManager
 
 static bool infoboxes_dirty = false;
 static bool infoboxes_hidden = false;
+static int selected_infobox = 0;
 
 static InfoBoxWindow *infoboxes[InfoBoxSettings::Panel::MAX_CONTENTS];
 
@@ -222,4 +224,37 @@ InfoBoxManager::ShowInfoBoxPicker(const int i)
   DisplayInfoBox();
 
   Profile::Save(Profile::map, panel, panel_index);
+}
+
+bool
+InfoBoxManager::OnKeyDown(InfoBoxWindow *ctx, unsigned key_code)
+{
+  int key = 0;
+
+  switch (key_code) {
+  case KEY_UP:
+    key = -1;
+    break;
+
+  case KEY_DOWN:
+    key = 1;
+    break;
+  }
+
+  for (unsigned i = 0; i < layout.count; i++) {
+    if (infoboxes[i] == ctx) {
+      selected_infobox = i + key;
+      if ((selected_infobox >= (int)layout.count))
+        selected_infobox = 0;
+      if (selected_infobox < 0)
+        selected_infobox = layout.count - 1;
+      infoboxes[selected_infobox]->SetFocus();
+    }
+  }
+  return true;
+}
+
+void
+InfoBoxManager::SetFocus() {
+  infoboxes[selected_infobox]->SetFocus();
 }

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -24,6 +24,8 @@ Copyright_License {
 #ifndef XCSOAR_INFO_BOX_MANAGER_HPP
 #define XCSOAR_INFO_BOX_MANAGER_HPP
 
+#include "InfoBoxes/InfoBoxWindow.hpp"
+
 struct InfoBoxLook;
 class ContainerWindow;
 
@@ -51,6 +53,9 @@ namespace InfoBoxManager
    * then it configures the focused InfoBox if there is one.
    */
   void ShowInfoBoxPicker(const int id = -1);
+
+  bool OnKeyDown(InfoBoxWindow *ctx, unsigned key_code);
+  void SetFocus();
 };
 
 #endif

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -22,6 +22,7 @@ Copyright_License {
 */
 
 #include "InfoBoxWindow.hpp"
+#include "InfoBoxManager.hpp"
 #include "InfoBoxSettings.hpp"
 #include "Border.hpp"
 #include "Look/InfoBoxLook.hpp"
@@ -346,6 +347,10 @@ bool
 InfoBoxWindow::OnKeyDown(unsigned key_code)
 {
   /* handle local hot key */
+  if (HasFocus()) {
+    /* Let the InfoBoxManager decide what is to do */
+    InfoBoxManager::OnKeyDown(this, key_code);
+  }
 
   switch (key_code) {
   case KEY_UP:
@@ -442,6 +447,8 @@ InfoBoxWindow::OnMouseDouble(PixelPoint p)
 bool
 InfoBoxWindow::OnMouseMove(PixelPoint p, unsigned keys)
 {
+  SetFocus();
+
   if (dragging) {
     SetPressed(IsInside(p));
     if (!pressed)

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -84,6 +84,7 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Simulator.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
 
 #include <assert.h>
 #include <tchar.h>
@@ -226,6 +227,9 @@ InputEvents::eventScreenModes(const TCHAR *misc)
         Message::AddMessage(_("Default InfoBoxes"));
   } else if (StringIsEqual(misc, _T("previous")))
     PageActions::Prev();
+  else if (StringIsEqual(misc, _T("infoboxfocus"))) {
+    InfoBoxManager::SetFocus();
+  }
   else
     PageActions::Next();
 


### PR DESCRIPTION
This is necessary for Remote-Stick (e.g. openVario SteFly), because no
touchscreen input is available. Also the mouse over infobox focus is added.
To enter the infobox focus mode, a ScreenModes "infoboxfocus", is added. 
e.g. default.xci key left can set this screenmode, to enter in the infobox focus mode.
With this it is possible to set MC only with arrow key and enter.