### PR TITLE
Increase max communication payload size for IMI Erixx driver

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,7 @@ Version 7.0 - not yet released
   - device manager: show flag if device provides data from
       environmental sensors (temperature, humidity)
   - combine traffic from all FLARM devices (support both FLARM and OGN devices on board)
+  - IMI: raise max payload size to 2kB
 * weather
   - merge all weather data in one dialog
   - allow showing both terrain and RASP

--- a/src/Device/Driver/IMI/Protocol/Types.hpp
+++ b/src/Device/Driver/IMI/Protocol/Types.hpp
@@ -70,7 +70,7 @@ namespace IMI
   const IMIBYTE IMICOMM_SYNC_CHAR2 = 'X';
   const unsigned IMICOMM_SYNC_LEN  = 2;
   const unsigned IMICOMM_CRC_LEN   = 2;
-  const unsigned COMM_MAX_PAYLOAD_SIZE = 1024;
+  const unsigned COMM_MAX_PAYLOAD_SIZE = 2048;
   const unsigned COMM_MAX_BULK_SIZE = 0xFFFF + 1;
 
   const unsigned IMIDECL_PLT_LENGTH = 30;


### PR DESCRIPTION
- Reflect change in communication protocol introduced by IMI Gliding

- E-mail correspondence between XCSoar contributor kicune and Juraj Rojko <juraj@rojko.cz> of IMI Gliding in January 2018 confirms change in protocol on IMI side.

Juraj Rojko:
The driver for Erixx was written quite a long time ago, basicaly without our participation, I just provided them with data structures, some basic description and IIRC also with some simple demo code. Since then there were some minor changes in the Erixx FW. COMM_MAX_PAYLOAD_SIZE has now the value of 2048. I am not absolutely sure if that was the only change. If you can recompile the XCSoar, I would recommend to try the new size. If this does not help, then we could compare the definitions in XCSoar with ours. I am sure that the differences are not significant and it should be simple to make it work.