### PR TITLE
Update METAR & TAF url to https

### DIFF
--- a/src/Weather/NOAADownloader.cpp
+++ b/src/Weather/NOAADownloader.cpp
@@ -152,7 +152,7 @@ NOAADownloader::DownloadMETAR(const char *code, METAR &metar,
   // Build file url
   char url[256];
   snprintf(url, sizeof(url),
-           "http://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT",
+           "https://tgftp.nws.noaa.gov/data/observations/metar/decoded/%s.TXT",
            code);
 
   // Request the file
@@ -246,7 +246,7 @@ NOAADownloader::DownloadTAF(const char *code, TAF &taf,
   // Build file url
   char url[256];
   snprintf(url, sizeof(url),
-           "http://tgftp.nws.noaa.gov/data/forecasts/taf/stations/%s.TXT",
+           "https://tgftp.nws.noaa.gov/data/forecasts/taf/stations/%s.TXT",
            code);
 
   // Request the file


### PR DESCRIPTION
tgftp.nws.noaa.gov switched from http to https... METARs and TAFs must be downloaded from https.

METARs and TAFs are not loaded in current version 6.8x and 7.0.x