### PR TITLE
InfoBoxes navigation with courser key.

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -51,6 +51,7 @@ Version 7.0 - not yet released
       climbing cruise (green), circling non-climb (orange)
   - improved auto-scaling of vario-like graphical infoboxes
   - new infobox: "Number Of Satellites"
+  - infobox courser mode: navigate with courser keys through the InfoBoxes
 * Windows
   - drop support for Windows CE
   - require Windows Vista or later

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -50,6 +50,7 @@ enum ControlIndex {
   AppInverseInfoBox,
   AppInfoBoxColors,
   AppInfoBoxBorder,
+  AppInfoBoxCourserMode,
 #ifdef KOBO
   ShowMenuButton,
 #endif
@@ -206,6 +207,11 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
           unsigned(ui_settings.info_boxes.border_style));
   SetExpertRow(AppInfoBoxBorder);
 
+  AddBoolean(_("InfoBoxes courser mode"),
+             _("If true, the InfoBoxes have an additional mode to navigate through the InfoBoxes with the courser keys."
+               "The InfoBoxe will be red in the courser mode and light red in the normal mode."),
+             ui_settings.info_boxes.courser_mode);
+  SetExpertRow(AppInfoBoxCourserMode);
 #ifdef KOBO
   AddBoolean(_("Show Menubutton"), _("Show the Menubutton"),
              ui_settings.show_menu_button);
@@ -257,6 +263,9 @@ LayoutConfigPanel::Save(bool &_changed)
                 ui_settings.info_boxes.use_colors))
     require_restart = changed = true;
 
+  if (SaveValue(AppInfoBoxCourserMode, ProfileKeys::AppInfoBoxCourserMode,
+                ui_settings.info_boxes.courser_mode))
+    require_restart = changed = true;
 #ifdef KOBO
   if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,ui_settings.show_menu_button))
     require_restart = changed = true;

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -33,6 +33,7 @@ Copyright_License {
 #include "Profile/Current.hpp"
 #include "Interface.hpp"
 #include "UIState.hpp"
+#include "Event/KeyCode.hpp"
 
 namespace InfoBoxManager
 {
@@ -50,6 +51,7 @@ namespace InfoBoxManager
 
 static bool infoboxes_dirty = false;
 static bool infoboxes_hidden = false;
+static unsigned selected_infobox = 0;
 
 static InfoBoxWindow *infoboxes[InfoBoxSettings::Panel::MAX_CONTENTS];
 
@@ -222,4 +224,38 @@ InfoBoxManager::ShowInfoBoxPicker(const int i)
   DisplayInfoBox();
 
   Profile::Save(Profile::map, panel, panel_index);
+}
+
+bool
+InfoBoxManager::OnKeyDown(unsigned infobox_id, unsigned key_code)
+{
+  int key = 0;
+
+  switch (key_code) {
+  case KEY_UP:
+  case KEY_LEFT:
+    key = infobox_id -1;
+    break;
+
+  case KEY_DOWN:
+  case KEY_RIGHT:
+    key = infobox_id + 1;
+    break;
+  }
+
+  if (key >= (int)layout.count) {
+    selected_infobox = 0;
+  } else if (key < 0) {
+    selected_infobox = layout.count - 1;
+  } else {
+    selected_infobox = key;
+  }
+  infoboxes[selected_infobox]->SetFocus();
+
+  return true;
+}
+
+void
+InfoBoxManager::SetFocus() {
+  infoboxes[selected_infobox]->SetFocus();
 }

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -51,6 +51,9 @@ namespace InfoBoxManager
    * then it configures the focused InfoBox if there is one.
    */
   void ShowInfoBoxPicker(const int id = -1);
+
+  bool OnKeyDown(unsigned infobox_id, unsigned key_code);
+  void SetFocus();
 };
 
 #endif

--- a/src/InfoBoxes/InfoBoxSettings.cpp
+++ b/src/InfoBoxes/InfoBoxSettings.cpp
@@ -55,6 +55,8 @@ InfoBoxSettings::SetDefaults()
 
   inverse = false;
   use_colors = true;
+  courser_mode = false;
+
   border_style = BorderStyle::BOX;
 
   for (unsigned i = 0; i < MAX_PANELS; ++i)

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -117,7 +117,7 @@ struct InfoBoxSettings {
 
   } geometry;
 
-  bool inverse, use_colors;
+  bool inverse, use_colors, courser_mode;
 
   enum class BorderStyle : uint8_t {
     BOX,

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -55,6 +55,11 @@ private:
   bool pressed;
 
   /**
+   * Was the mouse one time pressed inside this InfoBox?
+   */
+  bool courser_mode;
+
+  /**
    * draw the selector event if the InfoBox window is not the system focus
    */
   bool force_draw_selector;

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -84,6 +84,7 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Simulator.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
 
 #include <assert.h>
 #include <tchar.h>
@@ -226,6 +227,9 @@ InputEvents::eventScreenModes(const TCHAR *misc)
         Message::AddMessage(_("Default InfoBoxes"));
   } else if (StringIsEqual(misc, _T("previous")))
     PageActions::Prev();
+  else if (StringIsEqual(misc, _T("infoboxfocus"))) {
+    InfoBoxManager::SetFocus();
+  }
   else
     PageActions::Next();
 

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -53,6 +53,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
     : Color(0xe0, 0xe0, 0xe0);
   focused_background_color = COLOR_XCSOAR_LIGHT;
   pressed_background_color = COLOR_YELLOW;
+  courser_mode_background_color = COLOR_RED;
 
   Color border_color = Color(128, 128, 128);
   border_pen.Create(BORDER_WIDTH, border_color);

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -37,7 +37,7 @@ struct InfoBoxLook {
   bool inverse;
 
   Pen border_pen;
-  Color background_color, focused_background_color, pressed_background_color;
+  Color background_color, focused_background_color, pressed_background_color, courser_mode_background_color;
 
   /**
    * Used only by #InfoBoxSettings::BorderStyle::SHADED.

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -125,6 +125,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
 
   map.Get(ProfileKeys::AppInverseInfoBox, settings.inverse);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);
+  map.Get(ProfileKeys::AppInfoBoxCourserMode, settings.courser_mode);
 
   map.GetEnum(ProfileKeys::AppInfoBoxBorder, settings.border_style);
 

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -131,6 +131,7 @@ const char AppInfoBoxColors[] = "AppInfoBoxColors";
 const char TeamcodeRefWaypoint[] = "TeamcodeRefWaypoint";
 const char AppInfoBoxBorder[] = "AppInfoBoxBorder";
 const char ShowMenuButton[] = "ShowMenuButton";
+const char AppInfoBoxCourserMode[] = "AppInfoBoxCourserMode";
 
 const char AppAveNeedle[] = "AppAveNeedle";
 

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -113,6 +113,7 @@ extern const char AppLandableRenderingScale[];
 extern const char AppScaleRunwayLength[];
 extern const char AppInverseInfoBox[];
 extern const char AppInfoBoxColors[];
+extern const char AppInfoBoxCourserMode[];
 extern const char AppGaugeVarioSpeedToFly[];
 extern const char AppGaugeVarioAvgText[];
 extern const char AppGaugeVarioMc[];


### PR DESCRIPTION
 I created a new PR, because I did a mistake in the rebase of my fork.
The navigation with the courser key is now configurable, in the Look
dialog, where the other InfoBoxes settings are placed.
The default behavior is like it is now.
To have all features from an InfoBox, a new mode was added. If the
InfoBoxes courser mode is activ and on a InfoBox is clicked, the InfoBox
background turns red. And with the courser can be moved through the
infoboxes. If the mouse is pressed again or the enter key is pressed, it
gets in the focus mode "light red" background. With pressing the enter
again the InfoBox dialog will be open. With escape it can be exit from
each mode.
The mentioned layer problem that the InfoBoxWindow call the
InfoBoxManager is still available.
The Altair approach is not useful for Stefly, because Altair have a lot
of buttons, this isn't available.
For e.g. a custom xci file can created, with editing the default keys:
mode=default
type=key
data=LEFT
event=ScreenModes infoboxfocus
So the InfoBox courser mode can reached by pressing the left courser.