### PR TITLE
Driver/KRT2: Add workaround for possible GCC bug

### DIFF
--- a/src/Device/Driver/KRT2.cpp
+++ b/src/Device/Driver/KRT2.cpp
@@ -150,6 +150,13 @@ public:
                             struct NMEAInfo &info) override;
 };
 
+/* Workaround for some GCC versions which don't inline the constexpr
+   despite being defined so in C++17, see
+   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2.pdf */
+#if GCC_VERSION == 80300 || GCC_VERSION == 60300
+    constexpr std::chrono::milliseconds KRT2Device::CMD_TIMEOUT;
+#endif
+
 KRT2Device::KRT2Device(Port &_port)
  : port(_port)
 {


### PR DESCRIPTION
~~WORK IN PROGRESS~~
This commit adds the redeclaration of CMD_TIMEOUT at namespace
scope as required before C++17. This commit is introduced in order
to fix a potential gcc bug, where gcc 6.3 and 8.3 doesn't inline
the variable (despite the constexpr modifier).