### PR TITLE
Don't try to add more FLARM targets to an already full list

### DIFF
--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -71,8 +71,7 @@ struct TrafficList {
         FlarmTraffic * new_traffic = AllocateTraffic();
         if (new_traffic == nullptr)
           return;
-        new_traffic->Clear();
-        new_traffic->Update(traffic);
+        *new_traffic = traffic;
       }
     }
   }

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -67,8 +67,12 @@ struct TrafficList {
   void Complement(const TrafficList &add) {
     // Add unique traffic from 'add' list
     for (auto &traffic : add.list) {
-      if (FindTraffic(traffic.id) == NULL) {
-        list.append(traffic);
+      if (FindTraffic(traffic.id) == nullptr) {
+        FlarmTraffic * new_traffic = AllocateTraffic();
+        if (new_traffic == nullptr)
+          return;
+        new_traffic->Clear();
+        new_traffic->Update(traffic);
       }
     }
   }


### PR DESCRIPTION
The previous version of this function used list.append, which (other than an assert) assumes that the fixed size list of 25 FLARM traffic entries is not already full.
When the destination array (a TrivialArray, which uses std::array atm) is already full and we request an out-of-bounds index, this will not result in an error of any kind. Std::array also does not perform bounds checking:
https://en.cppreference.com/w/cpp/container/array/operator_at

I explicitly try to allocate a new slot in the TrafficList and check if it is not already full. If it is, there is no use in trying to add any more traffic and I abandon the Complement all-together.