### PR TITLE
Logger/FRecord: Add redeclaration of constexpr variables

### DIFF
--- a/src/Computer/RouteComputer.cpp
+++ b/src/Computer/RouteComputer.cpp
@@ -31,6 +31,13 @@ Copyright_License {
 
 #include <algorithm>
 
+/* Workaround for some GCC versions which don't inline the constexpr
+   despite being defined so in C++17, see
+   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2.pdf */
+#if GCC_OLDER_THAN(9,0)
+constexpr std::chrono::steady_clock::duration RouteComputer::PERIOD;
+#endif
+
 RouteComputer::RouteComputer(const Airspaces &airspace_database,
                              const ProtectedAirspaceWarningManager *warnings)
   :protected_route_planner(route_planner, airspace_database, warnings),

--- a/src/Computer/StatsComputer.cpp
+++ b/src/Computer/StatsComputer.cpp
@@ -26,6 +26,13 @@ Copyright_License {
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
 
+/* Workaround for some GCC versions which don't inline the constexpr
+   despite being defined so in C++17, see
+   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2.pdf */
+#if GCC_OLDER_THAN(9,0)
+constexpr std::chrono::steady_clock::duration StatsComputer::PERIOD;
+#endif
+
 void
 StatsComputer::ResetFlight(const bool full)
 {

--- a/src/Logger/LoggerFRecord.cpp
+++ b/src/Logger/LoggerFRecord.cpp
@@ -25,6 +25,14 @@ Copyright_License {
 
 #include <string.h>
 
+/* Workaround for some GCC versions which don't inline the constexpr
+   despite being defined so in C++17, see
+   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0386r2.pdf */
+#if GCC_OLDER_THAN(9,0)
+constexpr std::chrono::steady_clock::duration LoggerFRecord::DEFAULT_UPDATE_TIME;
+constexpr std::chrono::steady_clock::duration LoggerFRecord::ACCELERATED_UPDATE_TIME;
+#endif
+
 /*
  * From FAI_Tech_Spec_Gnss.pdf 
  * 4.3 F RECORD - SATELLITE CONSTELLATION.


### PR DESCRIPTION
This commit adds the redeclaration of those variables at namespace
scope as required before C++17. This commit is introduced as a
workaround for gcc (6.3 and 8.3) which don't inline the variables
(despite its constexpr modifier).

Fixes XCSoar#195.