### PR TITLE
add a function to lock the screen and avoid unintentional touches

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -902,6 +902,14 @@ location=4
 mode=Menu
 type=key
 data=9
+event=LockScreen
+event=Mode default
+label=Lock\nScreen
+location=7
+
+mode=Menu
+type=key
+data=9
 event=Mode default
 label=Cancel
 location=8

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -18,6 +18,7 @@ KOBO_MENU_SOURCES = \
 	$(SRC)/Dialogs/WidgetDialog.cpp \
 	$(SRC)/Dialogs/HelpDialog.cpp \
 	$(SRC)/Dialogs/Message.cpp \
+	$(SRC)/Dialogs/LockScreen.cpp \
 	$(SRC)/Dialogs/TextEntry.cpp \
 	$(SRC)/Dialogs/KnobTextEntry.cpp \
 	$(SRC)/Dialogs/TouchTextEntry.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -7,6 +7,7 @@ endif
 DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Inflate.cpp \
 	$(SRC)/Dialogs/Message.cpp \
+	$(SRC)/Dialogs/LockScreen.cpp \
 	$(SRC)/Dialogs/Error.cpp \
 	$(SRC)/Dialogs/ListPicker.cpp \
 	$(SRC)/Dialogs/ProgressDialog.cpp \

--- a/src/Dialogs/LockScreen.cpp
+++ b/src/Dialogs/LockScreen.cpp
@@ -1,0 +1,70 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Dialogs/LockScreen.hpp"
+#include "Form/Button.hpp"
+#include "Form/Form.hpp"
+#include "Look/DialogLook.hpp"
+#include "Screen/Layout.hpp"
+#include "Screen/SingleWindow.hpp"
+#include "UIGlobals.hpp"
+
+#include <assert.h>
+
+void
+ShowLockBox()
+{
+  SingleWindow &main_window = UIGlobals::GetMainWindow();
+
+  const unsigned button_height = Layout::GetMinimumControlHeight();
+  const unsigned button_width = button_height;
+
+  WindowStyle style;
+  style.ControlParent();
+
+  const DialogLook &dialog_look = UIGlobals::GetDialogLook();
+
+  const PixelSize root_size = main_window.GetSize();
+  
+  // Position dialog where it shouldn't cover anything important on the screen
+  const int dialog_x = root_size.cx * 0.25 - button_width;
+  const int dialog_y = root_size.cy * 0.75 - button_height;
+
+  PixelRect form_rc;
+  form_rc.left = dialog_x;
+  form_rc.top = dialog_y;
+  form_rc.right = dialog_x + button_width;
+  form_rc.bottom = dialog_y + button_height;
+
+  WndForm wf(main_window, dialog_look, form_rc, NULL, style);
+
+  ContainerWindow &client_area = wf.GetClientAreaWindow();
+  
+  const auto button_rc = client_area.GetClientRect();
+
+  WindowStyle button_style;
+  
+  const Button button(client_area, dialog_look.button, _T("U"), button_rc, button_style, wf, 3);
+
+  wf.ShowModal();
+}

--- a/src/Dialogs/LockScreen.hpp
+++ b/src/Dialogs/LockScreen.hpp
@@ -1,0 +1,30 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_DIALOGS_LOCKSCREEN_HPP
+#define XCSOAR_DIALOGS_LOCKSCREEN_HPP
+
+void
+ShowLockBox();
+
+#endif

--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -57,6 +57,7 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "IO/ConfiguredFile.hpp"
 #include "IO/LineReader.hpp"
 #include "Pan.hpp"
+#include "Dialogs/LockScreen.hpp"
 
 #ifdef KOBO
 #include "Event/KeyCode.hpp"
@@ -478,4 +479,10 @@ InputEvents::ProcessTimer()
 {
   DoQueuedEvents();
   ProcessMenuTimer();
+}
+
+void
+InputEvents::eventLockScreen(const TCHAR *mode)
+{
+  ShowLockBox();  
 }

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -182,7 +182,7 @@ namespace InputEvents
   void eventFileManager(const TCHAR *misc);
   void eventRunLuaFile(const TCHAR *misc);
   void eventResetTask(const TCHAR *misc);
-
+  void eventLockScreen(const TCHAR *misc);
   // -------
 };
 


### PR DESCRIPTION
A button in the main menu brings up a small modal dialog with just a button, that makes all the screen unresponsive to touch, except for the button area.
The button itself does nothing, it just closes the dialog and restores the touch screen functionality screen wide.