### PR TITLE
Extend SeeYouReader to parse the ICAO Field in CUP files

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,9 +6,11 @@ Version 7.0 - not yet released
   - new Logger-setting "CoPilot"
   - new setting "Thermal Averager needle"
   - select position of Thermal Assistant
+  - search waypoints via short name
 * data files
   - optimise the terrain loader
   - support runway width in CUP files
+  - support short name in CUP files
 * devices
   - parse wind from standard NMEA sentence WMV
   - driver for XC Tracer Vario

--- a/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
@@ -130,6 +130,9 @@ WaypointInfoWidget::Prepare(ContainerWindow &parent, const PixelRect &rc)
   if (!buffer.empty())
     AddReadOnly(_("Runway"), nullptr, buffer);
 
+  if (!waypoint->shortname.empty())
+    AddReadOnly(_("Short Name"), nullptr, waypoint->shortname.c_str());
+
   if (FormatGeoPoint(waypoint->location,
                      buffer.buffer(), buffer.capacity()) != nullptr)
     AddReadOnly(_("Location"), nullptr, buffer);

--- a/src/Engine/Waypoint/Waypoint.hpp
+++ b/src/Engine/Waypoint/Waypoint.hpp
@@ -118,6 +118,9 @@ struct Waypoint {
   /** File number to store waypoint in */
   WaypointOrigin origin;
 
+  /** Short name (code) label of waypoint */
+  tstring shortname;
+
   /** Name of waypoint */
   tstring name;
   /** Additional comment text for waypoint */

--- a/src/Engine/Waypoint/Waypoints.cpp
+++ b/src/Engine/Waypoint/Waypoints.cpp
@@ -104,16 +104,22 @@ void
 Waypoints::WaypointNameTree::Add(WaypointPtr wp)
 {
   TCHAR normalized_name[wp->name.length() + 1];
+  TCHAR normalized_shortname[wp->shortname.length() +1];
   NormalizeSearchString(normalized_name, wp->name.c_str());
+  NormalizeSearchString(normalized_shortname, wp->shortname.c_str());
   RadixTree<WaypointPtr>::Add(normalized_name, std::move(wp));
+  RadixTree<WaypointPtr>::Add(normalized_shortname, std::move(wp));
 }
 
 void
 Waypoints::WaypointNameTree::Remove(const WaypointPtr &wp)
 {
   TCHAR normalized_name[wp->name.length() + 1];
+  TCHAR normalized_shortname[wp->shortname.length() + 1];
   NormalizeSearchString(normalized_name, wp->name.c_str());
+  NormalizeSearchString(normalized_shortname, wp->shortname.c_str());
   RadixTree<WaypointPtr>::Remove(normalized_name, wp);
+  RadixTree<WaypointPtr>::Remove(normalized_shortname, wp);
 }
 
 Waypoints::Waypoints()

--- a/src/Renderer/WaypointListRenderer.cpp
+++ b/src/Renderer/WaypointListRenderer.cpp
@@ -89,7 +89,13 @@ Draw(Canvas &canvas, PixelRect rc,
   row_renderer.DrawSecondRow(canvas, rc, buffer);
 
   // Draw waypoint name
-  row_renderer.DrawFirstRow(canvas, rc, waypoint.name.c_str());
+  if (!waypoint.shortname.empty()) {
+    std::string waypoint_title = waypoint.name+" ("+waypoint.shortname+")";
+    row_renderer.DrawFirstRow(canvas, rc, waypoint_title.c_str());
+  }
+  else {
+    row_renderer.DrawFirstRow(canvas, rc, waypoint.name.c_str());
+  }
 }
 
 void
@@ -153,5 +159,11 @@ WaypointListRenderer::Draw(Canvas &canvas, PixelRect rc,
   row_renderer.DrawSecondRow(canvas, rc, buffer);
 
   // Draw waypoint name
-  row_renderer.DrawFirstRow(canvas, rc, waypoint.name.c_str());
+  if (!waypoint.shortname.empty()) {
+    std::string waypoint_title = waypoint.name+" ("+waypoint.shortname+")";
+    row_renderer.DrawFirstRow(canvas, rc, waypoint_title.c_str());
+  }
+  else {
+    row_renderer.DrawFirstRow(canvas, rc, waypoint.name.c_str());
+  }
 }

--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -164,6 +164,7 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
 {
   enum {
     iName = 0,
+    iShortname = 1,
     iLatitude = 3,
     iLongitude = 4,
     iElevation = 5,
@@ -253,6 +254,10 @@ WaypointReaderSeeYou::ParseLine(const TCHAR* line, Waypoints &waypoints)
     ParseStyle(params[iStyle], new_waypoint.type);
 
   new_waypoint.flags.turn_point = true;
+
+  // Short name (code) of waypoint 
+  if (iShortname < n_params)
+    new_waypoint.shortname = params[iShortname];
 
   // Frequency & runway direction/length (for airports and landables)
   // and description (e.g. "Some Description")

--- a/test/src/TestWaypoints.cpp
+++ b/test/src/TestWaypoints.cpp
@@ -150,7 +150,7 @@ TestNamePrefixVisitor(const Waypoints &waypoints, const TCHAR *prefix,
 static void
 TestNamePrefixVisitor(const Waypoints &waypoints)
 {
-  TestNamePrefixVisitor(waypoints, _T(""), 151);
+  TestNamePrefixVisitor(waypoints, _T(""), 302);
   TestNamePrefixVisitor(waypoints, _T("Foo"), 0);
   TestNamePrefixVisitor(waypoints, _T("a"), 0);
   TestNamePrefixVisitor(waypoints, _T("A"), 22);


### PR DESCRIPTION
The ICAO field aka short name is currently unused. This parses the entry and displays it in the waypoint details dialog. It also makes the short name searchable. 

Waypoint Details
![2020-08-12-104438_640x480_scrot](https://user-images.githubusercontent.com/407371/89983587-15506d00-dc78-11ea-8d87-488ab1b75da8.png)

Waypoint Search List Dialog
![2020-08-12-104219_640x480_scrot](https://user-images.githubusercontent.com/407371/89983551-023d9d00-dc78-11ea-9d52-7742fc36f766.png)

- [x] fix the merge and rebase code
- [x] make shortname field searchable in waypoint search
- [x] actually display field in Waypoint dialog
- [x] display shortname field in Waypoint List
- [x] update NEWS.txt
