### PR TITLE
Detect which lua version syntax to use.

### DIFF
--- a/build/lua.mk
+++ b/build/lua.mk
@@ -6,7 +6,9 @@ ifeq ($(USE_THIRDPARTY_LIBS),y)
 LIBLUA_LDLIBS = -llua
 LIBLUA_CPPFLAGS =
 else
-$(eval $(call pkg-config-library,LIBLUA,lua5.2))
+TARGET_LUAVER=5.2
+LUAVER?=$(shell if pkg-config --silence-errors --libs lua$(TARGET_LUAVER); then echo $(TARGET_LUAVER); else echo $(subst .,,$(TARGET_LUAVER)); fi)
+$(eval $(call pkg-config-library,LIBLUA,lua$(LUAVER)))
 endif
 
 LUA_SOURCES = \


### PR DESCRIPTION
Detect which lua version syntax to use (with or without dot).

On Arch Linux the lua libraries are loaded as lua or lua52, but lua5.2 produces the error below (pkg-config):
```
Package lua5.2 was not found in the pkg-config search path.
Perhaps you should add the directory containing `lua5.2.pc'
to the PKG_CONFIG_PATH environment variable
Package 'lua5.2', required by 'virtual:world', not found
build/compile.mk:107: *** library not found: lua5.2.  Stop.
```