### PR TITLE
wolfSSL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ The following people and organizations have contributed code to XCSoar:
  Bruno de Lacheisserie <bruno.de.lacheisserie@gmail.com>
  Peter F Bradshaw <pfb@exadios.com>
  Stefan Schumann <stefan.schumann@posteo.de>
+ Dominic Spreitz <dominic@spreitz.de>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -62,6 +62,8 @@ Version 7.0 - not yet released
   - drop support for ARMv6 and MIPS CPUs
 * Kobo
   - support Kobo Glo HD
+* Added SSL support through wolfSSL
+  - added support for SSL secured connections e.g. for download manager
 
 Version 6.8.13 - not yet released
 

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -127,7 +127,7 @@ curl = CurlProject(
         '--disable-manual',
         '--disable-threaded-resolver', '--disable-verbose', '--disable-sspi',
         '--disable-crypto-auth', '--disable-ntlm-wb', '--disable-tls-srp', '--disable-cookies',
-        '--without-ssl', '--without-gnutls', '--without-nss', '--without-libssh2', '--with-cyassl'
+        '--without-ssl', '--without-gnutls', '--without-nss', '--without-libssh2', '--with-cyassl',
     ],
     patches=abspath('lib/curl/patches'),
 )

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -127,7 +127,7 @@ curl = CurlProject(
         '--disable-manual',
         '--disable-threaded-resolver', '--disable-verbose', '--disable-sspi',
         '--disable-crypto-auth', '--disable-ntlm-wb', '--disable-tls-srp', '--disable-cookies',
-        '--without-ssl', '--without-gnutls', '--without-nss', '--without-libssh2',
+        '--without-ssl', '--without-gnutls', '--without-nss', '--without-libssh2', '--with-cyassl'
     ],
     patches=abspath('lib/curl/patches'),
 )

--- a/doc/manual/en/compiling.tex
+++ b/doc/manual/en/compiling.tex
@@ -50,6 +50,7 @@ The following is needed for all targets:
 \item \href{http://www.info-zip.org/}{Info-ZIP}
 \item Perl and XML::Parser
 \item FFmpeg
+\item \href{https://www.wolfssl.com}{wolfSSL}
 \end{itemize}
 
 The following command installs these on Debian:
@@ -60,7 +61,8 @@ sudo apt-get install make \
   imagemagick gettext ffmpeg \
   git quilt zip \
   m4 automake \
-  ttf-bitstream-vera fakeroot
+  ttf-bitstream-vera fakeroot \
+  libwolfssl-dev libwolfssl15
 \end{verbatim*}
 
 \section{Target-specific Build Instructions}

--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -8,7 +8,8 @@ apt-get --assume-yes install make \
   imagemagick gettext ffmpeg \
   git quilt zip \
   m4 automake wget \
-  ttf-bitstream-vera fakeroot
+  ttf-bitstream-vera fakeroot \
+  libwolfssl-dev libwolfssl15
 echo
 
 echo Installing Manual dependencies...


### PR DESCRIPTION
This is my first attempt to fix #222 
- Updated libs.py as suggested by @lordfolken 
- Updated compiling instructions in docu

The patch builds on my ubuntu 18.04 LTS system for the default UNIX target.
However, I am a bit clueless how to test if SSL is now supported in XCS. Pls advice.