### PR TITLE
Add InfoBoxes for Radio settings

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -388,6 +388,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/InfoBoxes/Content/Trace.cpp \
 	$(SRC)/InfoBoxes/Content/Weather.cpp \
 	$(SRC)/InfoBoxes/Content/Airspace.cpp \
+	$(SRC)/InfoBoxes/Content/Radio.cpp \
 	$(SRC)/InfoBoxes/Data.cpp \
 	$(SRC)/InfoBoxes/Format.cpp \
 	$(SRC)/InfoBoxes/Units.cpp \

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -298,6 +298,9 @@ ActionInterface::SetActiveFrequency(const RadioFrequency & freq, const TCHAR * f
   /* update interface settings */
 
   SetComputerSettings().radio.active_frequency = freq;
+  if(freq_name != nullptr) {
+    SetComputerSettings().radio.active_name = freq_name;
+  }
 
   /* update InfoBoxes (that might show the ActiveFrequency setting) */
 
@@ -317,7 +320,9 @@ ActionInterface::SetStandbyFrequency(const RadioFrequency & freq, const TCHAR * 
   /* update interface settings */
 
   SetComputerSettings().radio.standby_frequency = freq;
-
+  if(freq_name != nullptr) {
+    SetComputerSettings().radio.standby_name = freq_name;
+  }
   /* update InfoBoxes (that might show the ActiveFrequency setting) */
 
   InfoBoxManager::SetDirty();

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -291,3 +291,23 @@ ActionInterface::SendUIState()
 
   main_window->SetUIState(GetUIState());
 }
+
+void
+ActionInterface::SetActiveFrequency(const RadioFrequency & freq, const TCHAR * freq_name, bool to_devices)
+{
+  /* update interface settings */
+
+  SetComputerSettings().radio.active_frequency = freq;
+
+  /* update InfoBoxes (that might show the ActiveFrequency setting) */
+
+  InfoBoxManager::SetDirty();
+
+  /* send to external devices */
+
+  if (to_devices) {
+    MessageOperationEnvironment env;
+    device_blackboard->SetActiveFrequency(freq, freq_name, env);
+  }
+
+}

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -309,5 +309,23 @@ ActionInterface::SetActiveFrequency(const RadioFrequency & freq, const TCHAR * f
     MessageOperationEnvironment env;
     device_blackboard->SetActiveFrequency(freq, freq_name, env);
   }
+}
 
+void
+ActionInterface::SetStandbyFrequency(const RadioFrequency & freq, const TCHAR * freq_name, bool to_devices)
+{
+  /* update interface settings */
+
+  SetComputerSettings().radio.standby_frequency = freq;
+
+  /* update InfoBoxes (that might show the ActiveFrequency setting) */
+
+  InfoBoxManager::SetDirty();
+
+  /* send to external devices */
+
+  if (to_devices) {
+    MessageOperationEnvironment env;
+    device_blackboard->SetStandbyFrequency(freq, freq_name, env);
+  }
 }

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -104,6 +104,14 @@ namespace ActionInterface {
    * and redraws relevant parts of the screen.
    */
   void SendUIState();
+
+  /**
+   * Update the Active Radio Frequency in #ComputerSettings, and
+   * forward it to all XCSoar modules that want it.
+   *
+   * @param to_devices send the new setting to all devices?
+   */
+  void SetActiveFrequency(const RadioFrequency & freq, const TCHAR * freq_name, bool to_devices=true);
 };
 
 /** 

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -112,6 +112,14 @@ namespace ActionInterface {
    * @param to_devices send the new setting to all devices?
    */
   void SetActiveFrequency(const RadioFrequency & freq, const TCHAR * freq_name, bool to_devices=true);
+
+  /**
+   * Update the Standby Radio Frequency in #ComputerSettings, and
+   * forward it to all XCSoar modules that want it.
+   *
+   * @param to_devices send the new setting to all devices?
+   */
+  void SetStandbyFrequency(const RadioFrequency & freq, const TCHAR * freq_name, bool to_devices=true);
 };
 
 /** 

--- a/src/Computer/Settings.cpp
+++ b/src/Computer/Settings.cpp
@@ -84,4 +84,5 @@ ComputerSettings::SetDefaults()
   tracking.SetDefaults();
 #endif
   weather.SetDefaults();
+  radio.SetDefaults();
 }

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -130,9 +130,14 @@ struct RadioSettings {
   RadioFrequency active_frequency;
   RadioFrequency standby_frequency;
 
+  StaticString<32> active_name;
+  StaticString<32> standby_name;
+
   void SetDefaults() {
     active_frequency.Clear();
     standby_frequency.Clear();
+    active_name = "";
+    standby_name = "";
   }
 };
 

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -39,6 +39,7 @@ Copyright_License {
 #include "Plane/Plane.hpp"
 #include "Wind/Settings.hpp"
 #include "WaveSettings.hpp"
+#include "RadioFrequency.hpp"
 
 #include <type_traits>
 
@@ -122,6 +123,18 @@ struct PlacesOfInterestSettings {
   void SetHome(const Waypoint &wp);
 };
 
+/**
+ * Options for radio remote control
+ */
+struct RadioSettings {
+  RadioFrequency active_frequency;
+  RadioFrequency standby_frequency;
+
+  void SetDefaults() {
+    active_frequency.Clear();
+    standby_frequency.Clear();
+  }
+};
 
 /**
  * Options for glide computer features
@@ -211,6 +224,8 @@ struct ComputerSettings {
 #endif
 
   WeatherSettings weather;
+
+  RadioSettings radio;
 
   void SetDefaults();
 };

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
@@ -39,6 +39,7 @@ Copyright_License {
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Profile/Current.hpp"
+#include "ActionInterface.hpp"
 
 enum Commands {
   REPLACE_IN_TASK,
@@ -268,13 +269,13 @@ WaypointCommandsWidget::OnAction(int id) noexcept
     break;
 
   case SET_ACTIVE_FREQUENCY:
-    device_blackboard->SetActiveFrequency(waypoint->radio_frequency,
-                                          waypoint->name.c_str(), env);
+    ActionInterface::SetActiveFrequency(waypoint->radio_frequency,
+                                        waypoint->name.c_str());
     break;
 
   case SET_STANDBY_FREQUENCY:
-    device_blackboard->SetStandbyFrequency(waypoint->radio_frequency,
-                                           waypoint->name.c_str(), env);
+    ActionInterface::SetStandbyFrequency(waypoint->radio_frequency,
+                                         waypoint->name.c_str());
     break;
 
   case EDIT:

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1075,6 +1075,13 @@ static constexpr MetaData meta_data[] = {
     N_("The currently active Radio Frequency"),
     UpdateInfoBoxActiveFrequency,
   },
+  
+  {
+    N_("Standby Radio Frequency"),
+    N_("Stby Freq"),
+    N_("The currently standby Radio Frequency"),
+    UpdateInfoBoxStandbyFrequency,
+  },
 
 };
 

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -41,6 +41,7 @@ Copyright_License {
 #include "InfoBoxes/Content/Trace.hpp"
 #include "InfoBoxes/Content/Weather.hpp"
 #include "InfoBoxes/Content/Airspace.hpp"
+#include "InfoBoxes/Content/Radio.hpp"
 
 #include "Util/Macros.hpp"
 #include "Language/Language.hpp"
@@ -1065,6 +1066,14 @@ static constexpr MetaData meta_data[] = {
     N_("Satellites"),
     N_("The number of actually used (seen) satellites by GPS module. If this information is unavailable, the displayed value is '---'."),
     UpdateInfoBoxNbrSat,
+  },
+  
+  // Radio
+  {
+    N_("Active Radio Frequency"),
+    N_("Act Freq"),
+    N_("The currently active Radio Frequency"),
+    UpdateInfoBoxActiveFrequency,
   },
 
 };

--- a/src/InfoBoxes/Content/Radio.cpp
+++ b/src/InfoBoxes/Content/Radio.cpp
@@ -1,0 +1,61 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "InfoBoxes/Content/Radio.hpp"
+#include "InfoBoxes/Data.hpp"
+#include "Interface.hpp"
+#include "Units/Units.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Language/Language.hpp"
+
+#include <tchar.h>
+
+/*
+ * Subpart callback function pointers
+ */
+
+static constexpr InfoBoxPanel panels[] = {
+  { nullptr, nullptr }
+};
+
+const InfoBoxPanel *
+InfoBoxContentRadio::GetDialogContent() {
+  return panels;
+}
+
+/*
+ * Subpart normal operations
+ */
+
+void
+InfoBoxContentRadio::Update(InfoBoxData &data)
+{
+  TCHAR buffer[32];
+
+  const ComputerSettings &settings_computer =
+    CommonInterface::GetComputerSettings();
+
+  settings_computer.radio.active_frequency.Format(buffer, 32);
+  data.SetValue(buffer);
+  data.SetValueUnit(_T("MHz"));
+}

--- a/src/InfoBoxes/Content/Radio.cpp
+++ b/src/InfoBoxes/Content/Radio.cpp
@@ -31,15 +31,10 @@ Copyright_License {
 #include <tchar.h>
 
 void
-UpdateInfoBoxActiveFrequency(InfoBoxData &data)
+UpdateInfoBoxFrequency(InfoBoxData & data, const RadioFrequency & freq)
 {
-  TCHAR buffer[32];
-
-  const ComputerSettings &settings_computer =
-    CommonInterface::GetComputerSettings();
-
-  const auto & freq = settings_computer.radio.active_frequency;
   if(freq.IsDefined()) {
+    TCHAR buffer[32];
     freq.Format(buffer, 32);
     data.SetValue(buffer);
   }
@@ -47,3 +42,20 @@ UpdateInfoBoxActiveFrequency(InfoBoxData &data)
     data.SetValue(_T("---"));
   }
 }
+
+void
+UpdateInfoBoxActiveFrequency(InfoBoxData &data)
+{
+  const ComputerSettings &settings_computer =
+    CommonInterface::GetComputerSettings();
+  UpdateInfoBoxFrequency(data, settings_computer.radio.active_frequency);
+}
+
+void
+UpdateInfoBoxStandbyFrequency(InfoBoxData &data)
+{
+  const ComputerSettings &settings_computer =
+    CommonInterface::GetComputerSettings();
+  UpdateInfoBoxFrequency(data, settings_computer.radio.standby_frequency);
+}
+

--- a/src/InfoBoxes/Content/Radio.cpp
+++ b/src/InfoBoxes/Content/Radio.cpp
@@ -30,32 +30,20 @@ Copyright_License {
 
 #include <tchar.h>
 
-/*
- * Subpart callback function pointers
- */
-
-static constexpr InfoBoxPanel panels[] = {
-  { nullptr, nullptr }
-};
-
-const InfoBoxPanel *
-InfoBoxContentRadio::GetDialogContent() {
-  return panels;
-}
-
-/*
- * Subpart normal operations
- */
-
 void
-InfoBoxContentRadio::Update(InfoBoxData &data)
+UpdateInfoBoxActiveFrequency(InfoBoxData &data)
 {
   TCHAR buffer[32];
 
   const ComputerSettings &settings_computer =
     CommonInterface::GetComputerSettings();
 
-  settings_computer.radio.active_frequency.Format(buffer, 32);
-  data.SetValue(buffer);
-  data.SetValueUnit(_T("MHz"));
+  const auto & freq = settings_computer.radio.active_frequency;
+  if(freq.IsDefined()) {
+    freq.Format(buffer, 32);
+    data.SetValue(buffer);
+  }
+  else {
+    data.SetValue(_T("---"));
+  }
 }

--- a/src/InfoBoxes/Content/Radio.cpp
+++ b/src/InfoBoxes/Content/Radio.cpp
@@ -31,31 +31,33 @@ Copyright_License {
 #include <tchar.h>
 
 void
-UpdateInfoBoxFrequency(InfoBoxData & data, const RadioFrequency & freq)
+UpdateInfoBoxFrequency(InfoBoxData & data, const RadioFrequency & freq, const TCHAR * freq_name)
 {
   if(freq.IsDefined()) {
     TCHAR buffer[32];
     freq.Format(buffer, 32);
     data.SetValue(buffer);
+    data.SetComment(freq_name);
   }
   else {
-    data.SetValue(_T("---"));
+    data.SetValueInvalid();
+    data.SetCommentInvalid();
   }
 }
 
 void
 UpdateInfoBoxActiveFrequency(InfoBoxData &data)
 {
-  const ComputerSettings &settings_computer =
-    CommonInterface::GetComputerSettings();
-  UpdateInfoBoxFrequency(data, settings_computer.radio.active_frequency);
+  const auto &settings_radio =
+    CommonInterface::GetComputerSettings().radio;
+  UpdateInfoBoxFrequency(data, settings_radio.active_frequency, settings_radio.active_name);
 }
 
 void
 UpdateInfoBoxStandbyFrequency(InfoBoxData &data)
 {
-  const ComputerSettings &settings_computer =
-    CommonInterface::GetComputerSettings();
-  UpdateInfoBoxFrequency(data, settings_computer.radio.standby_frequency);
+  const auto &settings_radio =
+    CommonInterface::GetComputerSettings().radio;
+  UpdateInfoBoxFrequency(data, settings_radio.standby_frequency, settings_radio.standby_name);
 }
 

--- a/src/InfoBoxes/Content/Radio.hpp
+++ b/src/InfoBoxes/Content/Radio.hpp
@@ -25,6 +25,9 @@ Copyright_License {
 #define XCSOAR_INFOBOX_CONTENT_RADIO_HPP
 
 #include "InfoBoxes/Content/Base.hpp"
+#include "RadioFrequency.hpp"
 
+void UpdateInfoBoxFrequency(InfoBoxData &data, const RadioFrequency & freq);
 void UpdateInfoBoxActiveFrequency(InfoBoxData &data);
+void UpdateInfoBoxStandbyFrequency(InfoBoxData &data);
 #endif

--- a/src/InfoBoxes/Content/Radio.hpp
+++ b/src/InfoBoxes/Content/Radio.hpp
@@ -1,0 +1,37 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_INFOBOX_CONTENT_RADIO_HPP
+#define XCSOAR_INFOBOX_CONTENT_RADIO_HPP
+
+#include "InfoBoxes/Content/Base.hpp"
+
+class InfoBoxContentRadio : public InfoBoxContent
+{
+public:
+  virtual const InfoBoxPanel *GetDialogContent() override;
+
+  virtual void Update(InfoBoxData &data) override;
+};
+
+#endif

--- a/src/InfoBoxes/Content/Radio.hpp
+++ b/src/InfoBoxes/Content/Radio.hpp
@@ -26,12 +26,5 @@ Copyright_License {
 
 #include "InfoBoxes/Content/Base.hpp"
 
-class InfoBoxContentRadio : public InfoBoxContent
-{
-public:
-  virtual const InfoBoxPanel *GetDialogContent() override;
-
-  virtual void Update(InfoBoxData &data) override;
-};
-
+void UpdateInfoBoxActiveFrequency(InfoBoxData &data);
 #endif

--- a/src/InfoBoxes/Content/Radio.hpp
+++ b/src/InfoBoxes/Content/Radio.hpp
@@ -27,7 +27,7 @@ Copyright_License {
 #include "InfoBoxes/Content/Base.hpp"
 #include "RadioFrequency.hpp"
 
-void UpdateInfoBoxFrequency(InfoBoxData &data, const RadioFrequency & freq);
+void UpdateInfoBoxFrequency(InfoBoxData &data, const RadioFrequency & freq, const TCHAR * freq_name);
 void UpdateInfoBoxActiveFrequency(InfoBoxData &data);
 void UpdateInfoBoxStandbyFrequency(InfoBoxData &data);
 #endif

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -164,7 +164,9 @@ namespace InfoBoxFactory
 
     e_NbrSat, /* Number of used Sat by GPS module */
 
-    e_Radio, /* Active Radio Frequency */
+    e_ActiveRadio, /* Active Radio Frequency */
+
+    e_StandbyRadio, /* Standby Radio Frequency */
 
     e_NUM_TYPES /* Last item */
   };

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -164,6 +164,8 @@ namespace InfoBoxFactory
 
     e_NbrSat, /* Number of used Sat by GPS module */
 
+    e_Radio, /* Active Radio Frequency */
+
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
This pull request adds two infoboxes:
- One to show the currently configured Active Frequency, with the name as comment
- One to show the currently configured Standby Frequency, with the name as comment