### PR TITLE
WIP: Fix upload of nightlies to download.xcsoar.org

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,3 +125,5 @@ deploy_nightlies:
     - rsync -e "ssh -o StrictHostKeyChecking=no -p ${DEPLOY_PORT}" -r ./output/* ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/${DIRECTORY}/
   only:
     - master
+  except:
+    - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,8 +114,9 @@ nightly-docs:
 
 deploy_nightlies:
   stage: deploy
+  before_script:
+    - apk update && apk add openssh-client scp
   script:
-    - 'which ssh-agent || ( apt-get update -y && apt-get install openssh-client -y )'
     - eval $(ssh-agent -s)
     - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - mkdir -p ~/.ssh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -115,12 +115,13 @@ nightly-docs:
 deploy_nightlies:
   stage: deploy
   before_script:
-    - apk update && apk add openssh-client scp
+    - apk update && apk add openssh-client rsync
   script:
     - eval $(ssh-agent -s)
     - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
-    - scp -P ${DEPLOY_PORT} ./output ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}
+    - export DIRECTORY="$(cat VERSION.txt)~git#$CI_COMMIT_SHORT_SHA"
+    - rsync -e "ssh -o StrictHostKeyChecking=no -p ${DEPLOY_PORT}" -r ./output/* ${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/${DIRECTORY}/
   only:
     - master


### PR DESCRIPTION
This would enable the upload of nightlies for every commit in the master branch to download.xcsoar.org.
Since this are ~6GB per commit currently, I propose to upload artifacts only for preview releases, but using DEBUG=n and reduced into a directory structure which resembles the structure known from the existing releases.