### PR TITLE
Update Active and Standby Radio Frequency setting from KRT2

### DIFF
--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -136,6 +136,26 @@ MacCreadyProcessTimer()
   return modified;
 }
 
+static bool
+RadioProcess()
+{
+  bool modified = false;
+
+  const NMEAInfo &basic = CommonInterface::Basic();
+
+  if (basic.settings.active_frequency.IsDefined()) {
+    ActionInterface::SetActiveFrequency(basic.settings.active_frequency, basic.settings.active_freq_name, false);
+    modified = true;
+  }
+
+  if (basic.settings.standby_frequency.IsDefined()) {
+    ActionInterface::SetStandbyFrequency(basic.settings.standby_frequency, basic.settings.standby_freq_name, false);
+    modified = true;
+  }
+
+  return modified;
+}
+
 bool
 ApplyExternalSettings()
 {
@@ -144,5 +164,6 @@ ApplyExternalSettings()
   modified |= BugsProcessTimer();
   modified |= QNHProcessTimer();
   modified |= MacCreadyProcessTimer();
+  modified |= RadioProcess();
   return modified;
 }

--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -33,6 +33,10 @@ ExternalSettings::Clear()
   bugs_available.Clear();
   qnh_available.Clear();
   volume_available.Clear();
+  active_frequency.Clear();
+  standby_frequency.Clear();
+  active_freq_name.clear();
+  standby_freq_name.clear();
 }
 
 void
@@ -78,6 +82,16 @@ ExternalSettings::Complement(const ExternalSettings &add)
   if (add.volume_available.Modified(volume_available)) {
     volume = add.volume;
     volume_available = add.volume_available;
+  }
+
+  if (add.active_frequency.IsDefined()) {
+    active_frequency = add.active_frequency;
+    active_freq_name = add.active_freq_name;
+  }
+
+  if (add.standby_frequency.IsDefined()) {
+    standby_frequency = add.standby_frequency;
+    standby_freq_name = add.standby_freq_name;
   }
 }
 

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -26,6 +26,8 @@ Copyright_License {
 
 #include "NMEA/Validity.hpp"
 #include "Atmosphere/Pressure.hpp"
+#include "RadioFrequency.hpp"
+#include "Util/StaticString.hxx"
 
 #include <stdlib.h>
 #include <math.h>
@@ -71,6 +73,12 @@ struct ExternalSettings {
 
   /** the volume of the device [0-100%] */
   unsigned volume;
+
+  /** the radio frequencies of the device */
+  RadioFrequency active_frequency;
+  RadioFrequency standby_frequency;
+  StaticString<32> active_freq_name;
+  StaticString<32> standby_freq_name;
 
   void Clear();
   void Expire(double time);


### PR DESCRIPTION
When receiving an STX frame (identical to the one we send), update the Computer Setting for either active or standby frequency.