### PR TITLE
Manual: Fr: French LaTeX package update

### DIFF
--- a/doc/manual/fr/XCSoar-manual-fr.tex
+++ b/doc/manual/fr/XCSoar-manual-fr.tex
@@ -1,4 +1,4 @@
-\documentclass[a4paper,12pt,twoside]{refrep}
+\documentclass[french, a4paper, 12pt, twoside]{refrep}
 \input{xcsoar.sty}
 
 \title{Manuel de l'utilisateur}
@@ -10,7 +10,8 @@
 
 \input{title-xcsoar.sty}
 \usepackage{xkeyval}
-\usepackage{frenchle}
+\usepackage{framed}
+\usepackage{babel}
 \begin{document}
 \maketitle
 


### PR DESCRIPTION
LaTeX package frenchle is obsolete (see https://www.ctan.org/pkg/frenchle).
Using babel French instead.