### PR TITLE
Documents: Sans serif font are back

### DIFF
--- a/doc/manual/xcsoar.sty
+++ b/doc/manual/xcsoar.sty
@@ -12,7 +12,6 @@
 \makeatletter
 
 % Font selection
-%\usepackage{helvet}
 \renewcommand{\familydefault}{\sfdefault}
 \fontfamily{phv}\selectfont
 

--- a/doc/manual/xcsoar.sty
+++ b/doc/manual/xcsoar.sty
@@ -12,7 +12,7 @@
 \makeatletter
 
 % Font selection
-\usepackage{helvet}
+%\usepackage{helvet}
 \renewcommand{\familydefault}{\sfdefault}
 \fontfamily{phv}\selectfont
 


### PR DESCRIPTION
For some time I was wondering why the manual in version 6.8.11 was in sans serif fonts (https://download.xcsoar.org/releases/6.8.11/XCSoar-manual.pdf) while the more recent 7.0 manual was in serif (https://download.xcsoar.org/nightly_builds/7.0_preview14~git%23923cf10d/manual/XCSoar-manual.pdf).

Removing the helvet package from the xcsoar style file solved the issue.
Moreover, the difference in font style when \emph{} is used is reestablished.

Note: the serif font in the table of contents is another issue (coming PR)

Before:
![Manual-Before](https://user-images.githubusercontent.com/6931104/65898868-c3319080-e3b2-11e9-869a-d46ef1bea8b3.png)

After:
![Manual-after](https://user-images.githubusercontent.com/6931104/65898883-cc226200-e3b2-11e9-9d4e-70d17e22b0ec.png)