### PR TITLE
Make cursor on framebuffer devices resizeable

### DIFF
--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -53,6 +53,9 @@ enum ControlIndex {
 #ifdef KOBO
   ShowMenuButton,
 #endif
+#ifdef DRAW_MOUSE_CURSOR
+  CursorSize,
+#endif
 };
 
 static constexpr StaticEnumChoice display_orientation_list[] = {
@@ -212,6 +215,10 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
   SetExpertRow(ShowMenuButton);
 #endif
 
+#ifdef DRAW_MOUSE_CURSOR
+  AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), _T("%d x"), _T("%d x"), 1, 10, 1,
+             (unsigned)ui_settings.display.cursor_size);
+#endif
 }
 
 bool
@@ -264,6 +271,10 @@ LayoutConfigPanel::Save(bool &_changed)
 
   DialogSettings &dialog_settings = CommonInterface::SetUISettings().dialog;
   changed |= SaveValueEnum(TabDialogStyle, ProfileKeys::AppDialogTabStyle, dialog_settings.tab_style);
+
+#ifdef DRAW_MOUSE_CURSOR
+  changed |= SaveValue(CursorSize, ProfileKeys::CursorSize, ui_settings.display.cursor_size);
+#endif
 
   if (orientation_changed) {
     assert(Display::RotateSupported());

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -275,6 +275,7 @@ LayoutConfigPanel::Save(bool &_changed)
 
 #ifdef DRAW_MOUSE_CURSOR
   changed |= SaveValue(CursorSize, ProfileKeys::CursorSize, ui_settings.display.cursor_size);
+  CommonInterface::main_window->SetCursorSize(ui_settings.display.cursor_size);
 #endif
 
   if (orientation_changed) {
@@ -294,8 +295,6 @@ LayoutConfigPanel::Save(bool &_changed)
     CommonInterface::main_window->CheckResize();
   } else if (info_box_geometry_changed)
     CommonInterface::main_window->ReinitialiseLayout();
-
-  CommonInterface::main_window->SetDisplaySettings(ui_settings.display);
 
   _changed |= changed;
 

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -35,6 +35,7 @@ Copyright_License {
 #include "UtilsSettings.hpp"
 #include "Asset.hpp"
 #include "Menu/ShowMenuButton.hpp"
+#include "ActionInterface.hpp"
 
 #ifdef USE_POLL_EVENT
 #include "Event/Globals.hpp"
@@ -293,6 +294,8 @@ LayoutConfigPanel::Save(bool &_changed)
     CommonInterface::main_window->CheckResize();
   } else if (info_box_geometry_changed)
     CommonInterface::main_window->ReinitialiseLayout();
+
+  CommonInterface::main_window->SetDisplaySettings(ui_settings.display);
 
   _changed |= changed;
 

--- a/src/DisplaySettings.cpp
+++ b/src/DisplaySettings.cpp
@@ -27,4 +27,5 @@ void
 DisplaySettings::SetDefaults()
 {
   orientation = DisplayOrientation::DEFAULT;
+  cursor_size = 1;
 }

--- a/src/DisplaySettings.hpp
+++ b/src/DisplaySettings.hpp
@@ -33,6 +33,7 @@ Copyright_License {
  */
 struct DisplaySettings {
   DisplayOrientation orientation;
+  uint8_t cursor_size;
 
   void SetDefaults();
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -191,7 +191,9 @@ MainWindow::Initialise()
   Layout::Initialize(GetSize(),
                      CommonInterface::GetUISettings().GetPercentScale(),
                      CommonInterface::GetUISettings().custom_dpi);
-  SetDisplaySettings(CommonInterface::GetDisplaySettings());
+#ifdef DRAW_MOUSE_CURSOR
+  SetCursorSize(CommonInterface::GetDisplaySettings().cursor_size);
+#endif
 
   LogFormat("Initialise fonts");
   if (!Fonts::Initialize()) {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -191,6 +191,7 @@ MainWindow::Initialise()
   Layout::Initialize(GetSize(),
                      CommonInterface::GetUISettings().GetPercentScale(),
                      CommonInterface::GetUISettings().custom_dpi);
+  SetDisplaySettings(CommonInterface::GetDisplaySettings());
 
   LogFormat("Initialise fonts");
   if (!Fonts::Initialize()) {

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -131,6 +131,7 @@ const char AppInfoBoxColors[] = "AppInfoBoxColors";
 const char TeamcodeRefWaypoint[] = "TeamcodeRefWaypoint";
 const char AppInfoBoxBorder[] = "AppInfoBoxBorder";
 const char ShowMenuButton[] = "ShowMenuButton";
+const char CursorSize[] = "CursorSize";
 
 const char AppAveNeedle[] = "AppAveNeedle";
 

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -126,6 +126,7 @@ extern const char AppDialogTabStyle[];
 extern const char AppDialogStyle[];
 extern const char AppInfoBoxBorder[];
 extern const char AppAveNeedle[];
+extern const char CursorSize[];
 extern const char AutoAdvance[];
 extern const char UTCOffset[];
 extern const char UTCOffsetSigned[];

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -44,6 +44,7 @@ void
 Profile::Load(const ProfileMap &map, DisplaySettings &settings)
 {
   map.GetEnum(ProfileKeys::MapOrientation, settings.orientation);
+  map.Get(ProfileKeys::CursorSize, settings.cursor_size);
 }
 
 void

--- a/src/Screen/FB/TopWindow.cpp
+++ b/src/Screen/FB/TopWindow.cpp
@@ -27,6 +27,7 @@ Copyright_License {
 #include "Event/Poll/Loop.hpp"
 #include "Event/Queue.hpp"
 #include "Event/Globals.hpp"
+#include "Interface.hpp"
 
 #ifdef DRAW_MOUSE_CURSOR
 #include "Util/Macros.hpp"
@@ -91,10 +92,14 @@ TopWindow::OnPaint(Canvas &canvas)
   /* draw the mouse cursor */
 
   const auto m = event_queue->GetMousePosition();
+  uint8_t cursorSize = CommonInterface::GetUISettings().display.cursor_size;
+  unsigned shortDistance = Layout::Scale(cursorSize * 4);
+  unsigned longDistance = Layout::Scale(cursorSize * 6);
+
   const BulkPixelPoint p[] = {
     { m.x, m.y },
-    { m.x + Layout::Scale(4), m.y + Layout::Scale(4) },
-    { m.x, m.y + Layout::Scale(6) },
+    { m.x + shortDistance, m.y + shortDistance },
+    { m.x, m.y + longDistance },
   };
 
   canvas.SelectBlackPen();

--- a/src/Screen/FB/TopWindow.cpp
+++ b/src/Screen/FB/TopWindow.cpp
@@ -27,7 +27,6 @@ Copyright_License {
 #include "Event/Poll/Loop.hpp"
 #include "Event/Queue.hpp"
 #include "Event/Globals.hpp"
-#include "Interface.hpp"
 
 #ifdef DRAW_MOUSE_CURSOR
 #include "Util/Macros.hpp"
@@ -84,6 +83,9 @@ TopWindow::OnResize(PixelSize new_size)
 }
 
 #ifdef DRAW_MOUSE_CURSOR
+
+TopWindow::TopWindow() : cursor_size(1) {}
+
 void
 TopWindow::OnPaint(Canvas &canvas)
 {
@@ -92,9 +94,8 @@ TopWindow::OnPaint(Canvas &canvas)
   /* draw the mouse cursor */
 
   const auto m = event_queue->GetMousePosition();
-  uint8_t cursorSize = CommonInterface::GetUISettings().display.cursor_size;
-  unsigned shortDistance = Layout::Scale(cursorSize * 4);
-  unsigned longDistance = Layout::Scale(cursorSize * 6);
+  unsigned shortDistance = Layout::Scale(cursor_size * 4);
+  unsigned longDistance = Layout::Scale(cursor_size * 6);
 
   const BulkPixelPoint p[] = {
     { m.x, m.y },

--- a/src/Screen/FB/TopWindow.cpp
+++ b/src/Screen/FB/TopWindow.cpp
@@ -83,9 +83,6 @@ TopWindow::OnResize(PixelSize new_size)
 }
 
 #ifdef DRAW_MOUSE_CURSOR
-
-TopWindow::TopWindow() : cursor_size(1) {}
-
 void
 TopWindow::OnPaint(Canvas &canvas)
 {

--- a/src/Screen/TopWindow.hpp
+++ b/src/Screen/TopWindow.hpp
@@ -47,7 +47,6 @@ union SDL_Event;
 struct SDL_Window;
 #endif
 
-#include "DisplaySettings.hpp"
 #include <tchar.h>
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
@@ -144,7 +143,7 @@ class TopWindow : public ContainerWindow {
   SDL_Window *window;
 #endif
 #ifdef DRAW_MOUSE_CURSOR
-  uint8_t cursor_size;
+  uint8_t cursor_size = 1;
 #endif
 
 #ifndef USE_WINUSER
@@ -194,9 +193,6 @@ class TopWindow : public ContainerWindow {
 #endif
 
 public:
-#ifdef DRAW_MOUSE_CURSOR
-  TopWindow();
-#endif
 #ifndef USE_WINUSER
   virtual ~TopWindow();
 #endif
@@ -343,11 +339,11 @@ public:
   void SetDisplayOrientation(DisplayOrientation orientation);
 #endif
 
-  void SetDisplaySettings(const DisplaySettings& displaySettings) {
 #ifdef DRAW_MOUSE_CURSOR
-    cursor_size = displaySettings.cursor_size;
-#endif
+  void SetCursorSize(const uint8_t &cursorSize) {
+    cursor_size = cursorSize;
   }
+#endif
 
 
 protected:

--- a/src/Screen/TopWindow.hpp
+++ b/src/Screen/TopWindow.hpp
@@ -47,6 +47,7 @@ union SDL_Event;
 struct SDL_Window;
 #endif
 
+#include "DisplaySettings.hpp"
 #include <tchar.h>
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
@@ -142,6 +143,9 @@ class TopWindow : public ContainerWindow {
 #elif defined(ENABLE_SDL)
   SDL_Window *window;
 #endif
+#ifdef DRAW_MOUSE_CURSOR
+  uint8_t cursor_size;
+#endif
 
 #ifndef USE_WINUSER
   TopCanvas *screen = nullptr;
@@ -190,6 +194,9 @@ class TopWindow : public ContainerWindow {
 #endif
 
 public:
+#ifdef DRAW_MOUSE_CURSOR
+  TopWindow();
+#endif
 #ifndef USE_WINUSER
   virtual ~TopWindow();
 #endif
@@ -335,6 +342,13 @@ public:
 #ifdef SOFTWARE_ROTATE_DISPLAY
   void SetDisplayOrientation(DisplayOrientation orientation);
 #endif
+
+  void SetDisplaySettings(const DisplaySettings& displaySettings) {
+#ifdef DRAW_MOUSE_CURSOR
+    cursor_size = displaySettings.cursor_size;
+#endif
+  }
+
 
 protected:
   PixelPoint PointToReal(PixelPoint p) const {

--- a/test/README
+++ b/test/README
@@ -10,7 +10,7 @@ References:
 	- http://en.wikipedia.org/wiki/Test_Anything_Protocol
 
 What is in a number?
-	0*	Test the test system itself - psudo tests
+	0*	Test the test system itself - pseudo tests
 	1*	Configuration, XML and any other file format checking
 	2*	TODO
 


### PR DESCRIPTION
This is an attempt to implement a requested user feature, that is to have the cursor resizable on embedded devices (using framebuffer). Please review thoroughly -- I am doing this for the first time and am not sure whether I should also update/extend tests & docs.