### PR TITLE
Doc: French: GPL: 3 --> 2

### DIFF
--- a/doc/manual/fr/gpl.tex
+++ b/doc/manual/fr/gpl.tex
@@ -1,885 +1,452 @@
+
+
+Ceci est une traduction non officielle de la licence publique générale GNU (GNU GPL) en français (\url{http://www.fsffrance.org/gpl/gpl-fr.fr.html}). Elle n'a pas été publiée par la Free Software Foundation et n'établit pas juridiquement les termes de distribution des logiciels qui utilisent la GNU GPL – seul le texte anglais original de la GNU GPL le fait. Cependant, nous espérons que cette traduction aidera les francophones à mieux comprendre la GNU GPL.\\ 
+Le texte original en anglais apparaît ensuite.
+
+This is an unofficial translation of the GNU General Public License into French (\url{http://www.fsffrance.org/gpl/gpl-fr.fr.html}). It was not published by the Free Software Foundation, and does not legally state the distribution terms for software that uses the GNU GPL—only the original English text of the GNU GPL does that. However, we hope that this translation will help French speakers understand the GNU GPL better.\\
+The original English text is included after.
+\newpage
+
 {\small
-\begin{center}
-		 LICENCE PUBLIQUE GÉNÉRALE GNU
-                         Version 3, du 29 juin 2007.
+	
+	\begin{center}
+	
+Licence Publique Générale GNU
 
-\end{center}
+	\end{center}
 
-Copyright (C) 2007 Free Software Foundation, Inc. \href{http://fsf.org/}{http://fsf.org/}
+Les licences de la plupart des logiciels sont conçues pour vous enlever toute liberté de les partager et de les modifier.
 
-Chacun est autorisé à copier et distribuer des copies conformes de ce
-document de licence, mais toute modification en est proscrite.
+A contrario, la Licence Publique Générale est destinée à garantir votre liberté de partager et de modifier les logiciels libres, et à assurer que ces logiciels soient libres pour tous leurs utilisateurs.
 
-Traduction française par Philippe Verdy \href{mailto:verdy\_p@wanado.fr}{verdy\_p@wanado.fr}
+La présente Licence Publique Générale s'applique à la plupart des logiciels de la Free Software Foundation, ainsi qu'à tout autre programme pour lequel ses auteurs s'engagent à l'utiliser.
 
-\begin{center}
-\textsc{\textbf{Avertissement important au sujet de cette traduction française.}}
-\end{center}
-Ceci est une traduction en français de la licence “GNU General Public
-License” (GPL). Cette traduction est fournie ici dans l’espoir qu’elle
-facilitera sa compréhension, mais elle ne constitue pas une traduction
-officielle ou approuvée d’un point de vue juridique.
+(Certains autres logiciels de la Free Software Foundation sont couverts par la GNU Lesser General Public License à la place.)
 
-La Free Software Foundation (FSF) ne publie pas cette traduction et ne
-l’a pas approuvée en tant que substitut valide au plan légal pour la
-licence authentique “GNU General Public Licence”. Cette traduction n’a
-pas encore été passée en revue attentivement par un juriste et donc le
-traducteur ne peut garantir avec certitude qu’elle représente avec
-exactitude la signification légale des termes de la licence authentique
-“GNU General Public License” publiée en anglais. Cette traduction
-n’établit donc légalement aucun des termes et conditions d’utilisation
-d’un logiciel sous licence GNU GPL — seul le texte original en anglais
-le fait. Si vous souhaitez être sûr que les activités que vous projetez
-seront autorisées par la GNU General Public License, veuillez vous
-référer à sa seule version anglaise authentique.
+Vous pouvez aussi l'appliquer aux programmes qui sont les vôtres.
 
-La FSF vous recommande fermement de ne pas utiliser cette traduction en
-tant que termes officiels pour vos propres programmes ; veuillez plutôt
-utiliser la version anglaise authentique telle que publiée par la FSF.
-Si vous choisissez d’acheminer cette traduction en même temps qu’un
-Programme sous licence GNU GPL, cela ne vous dispense pas de l’obligation
-d’acheminer en même temps une copie de la licence authentique en anglais,
-et de conserver dans la traduction cet avertissement important en
-français et son équivalent en anglais ci-dessous.
+Quand nous parlons de logiciels libres, nous parlons de liberté, non de prix.
 
-\begin{center}
-\textsc{\textbf{Important Warning About This French Translation.}}
-\end{center}
+Nos licences publiques générales sont conçues pour vous donner l'assurance d'être libres de distribuer des copies des logiciels libres (et de facturer ce service, si vous le souhaitez), de recevoir le code source ou de pouvoir l'obtenir si vous le souhaitez, de pouvoir modifier les logiciels ou en utiliser des éléments dans de nouveaux programmes libres et de savoir que vous pouvez le faire.
 
-This is a translation of the GNU General Public License (GPL) into
-French. This translation is distributed in the hope that it will
-facilitate understanding, but it is not an official or legally approved
-translation.
+Pour protéger vos droits, il nous est nécessaire d'imposer des limitations qui interdisent à quiconque de vous refuser ces droits ou de vous demander d'y renoncer.
 
-The Free Software Foundation (FSF) is not the publisher of this
-translation and has not approved it as a legal substitute for the
-authentic GNU General Public License. The translation has not been
-reviewed carefully by lawyers, and therefore the translator cannot be
-sure that it exactly represents the legal meaning of the authentic GNU
-General Public License published in English. This translation does not
-legally state the terms and conditions of use of any Program licenced
-under GNU GPL — only the original English text of the GNU LGPL does
-that. If you wish to be sure whether your planned activities are
-permitted by the GNU General Public License, please refer to its sole
-authentic English version.
+Certaines responsabilités vous incombent en raison de ces limitations si vous distribuez des copies de ces logiciels, ou si vous les modifiez.
 
-The FSF strongly urges you not to use this translation as the official
-distribution terms for your programs; instead, please use the authentic
-English version published by the FSF. If you choose to convey this
-translation along with a Program covered by the GPL Licence, this does
-not remove your obligation to convey at the same time a copy of the
-authentic GNU GPL License in English, and you must keep in this
-translation this important warning in English and its equivalent in
-French above.
-\begin{center}
-			    Préambule
-\end{center}
+Par exemple, si vous distribuez des copies d'un tel programme, à titre gratuit ou contre une rémunération, vous devez accorder aux destinataires tous les droits dont vous disposez.
 
-  Les licences de la plupart des œuvres logicielles et autres travaux de
-pratique sont conçues pour ôter votre liberté de partager et modifier
-ces travaux. En contraste, la Licence Publique Générale GNU a pour but
-de garantir votre liberté de partager et changer toutes les versions
-d’un programme — afin d’assurer qu’il restera libre pour tous les
-utilisateurs. Nous, la Free Software Foundation, utilisons la Licence
-Publique Générale GNU pour la plupart de nos logiciels ; cela
-s’applique aussi à tout autre travail édité de cette façon par ses
-auteurs. Vous pouvez, vous aussi, l’appliquer à vos propres programmes.
+Vous devez vous assurer qu'eux aussi reçoivent ou puissent disposer du code source.
 
-  Quand nous parlons de logiciel libre (“free”), nous nous référons à la
-liberté (“freedom”), pas au prix. Nos Licences Publiques Générales sont
-conçues pour assurer que vous ayez la liberté de distribuer des copies
-de logiciel libre (et le facturer si vous le souhaitez), que vous
-receviez le code source ou pouviez l’obtenir si vous le voulez, que
-vous pouviez modifier le logiciel ou en utiliser toute partie dans de
-nouveaux logiciels libres, et que vous sachiez que vous avez le droit
-de faire tout ceci.
+Et vous devez leur montrer les présentes conditions afin qu'ils aient connaissance de leurs droits.
 
-  Pour protéger vos droits, nous avons besoin d’empêcher que d’autres
-vous restreignent ces droits ou vous demande de leur abandonner ces
-droits. En conséquence, vous avez certaines responsabilités si vous
-distribuez des copies d’un tel programme ou si vous le modifiez :
-les responsabilités de respecter la liberté des autres.
+Nous protégeons vos droits en deux étapes : (1) nous sommes titulaires des droits d'auteur du logiciel, et (2) nous vous délivrons cette licence, qui vous donne l'autorisation légale de copier, distribuer et/ou modifier le logiciel.
 
-  Par exemple, si vous distribuez des copies d’un tel programme, que ce
-soit gratuit ou contre un paiement, vous devez accorder aux
-Destinataires les mêmes libertés que vous avez reçues. Vous devez aussi
-vous assurer qu’eux aussi reçoivent ou peuvent recevoir son code
-source. Et vous devez leur montrer les termes de cette licence afin
-qu’ils connaissent leurs droits.
+En outre, pour la protection de chaque auteur ainsi que la nôtre, nous voulons nous assurer que chacun comprenne que ce logiciel libre ne fait l'objet d'aucune garantie.
 
-  Les développeurs qui utilisent la GPL GNU protègent vos droits en deux
-étapes : (1) ils affirment leur droits d’auteur (“copyright”) sur le
-logiciel, et (2) vous accordent cette Licence qui vous donne la
-permission légale de le copier, le distribuer et/ou le modifier.
+Si le logiciel est modifié par quelqu'un d'autre puis transmis à des tiers, nous voulons que les destinataires soient mis au courant que ce qu'ils ont reçu n'est pas le logiciel d'origine, de sorte que tout problème introduit par d'autres ne puisse entacher la réputation de l'auteur originel.
 
-  Pour la protection des développeurs et auteurs, la GPL stipule
-clairement qu’il n’y a pas de garantie pour ce logiciel libre. Aux fins
-à la fois des utilisateurs et auteurs, la GPL requière que les versions
-modifiées soient marquées comme changées, afin que leurs problèmes ne
-soient pas attribués de façon erronée aux auteurs des versions
-précédentes.
+En définitive, un programme libre restera à la merci des brevets de logiciels.
 
-  Certains dispositifs sont conçus pour empêcher l’accès des utilisateurs
-à l’installation ou l’exécution de versions modifiées du logiciel à
-l’intérieur de ces dispositifs, alors que les fabricants le peuvent.
-Ceci est fondamentalement incompatible avec le but de protéger la
-liberté des utilisateurs de modifier le logiciel. L’aspect systématique
-de tels abus se produit dans le secteur des produits destinés aux
-utilisateurs individuels, ce qui est précidément ce qui est le plus
-inacceptable. Aussi, nous avons conçu cette version de la GPL pour
-prohiber cette pratique pour ces produits. Si de tels problèmes
-surviennent dans d’autres domaines, nous nous tenons prêt à étendre
-cette restriction à ces domaines dans de futures versions de la GPL,
-autant qu’il sera nécessaire pour protéger la liberté des utilisateurs.
+Nous souhaitons éviter le risque que les redistributeurs d'un programme libre fassent des demandes individuelles de licence de brevet, ceci ayant pour effet de rendre le programme propriétaire.
 
-  Finalement, chaque programme est constamment menacé par les brevets
-logiciels. Les États ne devraient pas autoriser de tels brevets à
-restreindre le développement et l’utilisation de logiciels libres sur
-des ordinateurs d’usage général ; mais dans ceux qui le font, nous
-voulons spécialement éviter le danger que les brevets appliqués à un
-programme libre puisse le rendre effectivement propriétaire. Pour
-empêcher ceci, la GPL assure que les brevets ne peuvent être utilisés
-pour rendre le programme non-libre.
+Pour éviter cela, nous établissons clairement que toute licence de brevet doit être concédée de façon à ce que l'usage en soit libre pour tous ou bien qu'aucune licence ne soit concédée.
 
-  Les termes précis et conditions concernant la copie, la distribution
-et la modification suivent.
+Les termes exacts et les conditions de copie, distribution et modification sont les suivants:
+Conditions de copie, distribution et modification de la Licence Publique Générale GNU.
 
-\begin{center}
-TERMES ET CONDITIONS
-\end{center}
+	\begin{enumerate}
 
-Article 0. Définitions.
+\item La présente Licence s'applique à tout programme ou tout autre ouvrage contenant un avis, apposé par le titulaire des droits d'auteur, stipulant qu'il peut être distribué au titre des conditions de la présente Licence Publique Générale.
 
-« Cette Licence » se réfère à la version 3 de la “GNU General Public
-License” (le texte original en anglais).
+Ci-après, le "Programme" désigne l'un quelconque de ces programmes ou ouvrages, et un "ouvrage fondé sur le Programme" désigne soit le Programme, soit un ouvrage qui en dérive au titre des lois sur le droit d'auteur : en d'autres termes, un ouvrage contenant le Programme ou une partie de ce dernier, soit à l'identique, soit avec des modifications et/ou traduit dans un autre langage.
 
-« Droit d’Auteur » signifie aussi les droits du “copyright” ou voisins
-qui s’appliquent à d’autres types de travaux, tels que ceux sur les
-masques de semi-conducteurs.
+(Ci-après, le terme "modification" implique, sans s'y réduire, le terme traduction)
 
-« Le Programme » se réfère à tout travail qui peut être sujet au Droit
-d’Auteur (“copyright”) et dont les droits d’utilisation sont concédés
-en vertu de cette Licence. Chacun des Licenciés, à qui cette Licence
-est concédée, est désigné par « vous. » Les « Licenciés » et les
-« Destinataires » peuvent être des personnes physiques ou morales
-(individus ou organisations).
+Chaque concessionaire sera désigné par "vous".
 
-« Modifier » un travail signifie en obtenir une copie et adapter tout
-ou partie du travail d’une façon nécessitant une autorisation d’un
-titulaire de Droit d’Auteur, autre que celle permettant d’en produire
-une copie conforme. Le travail résultant est appelé une « version
-modifiée » du précédent travail, ou un travail « basé sur » le
-précédent travail.
+Les activités autres que la copie, la distribution et la modification ne sont pas couvertes par la présente Licence ; elles sont hors de son champ d'application.
 
-Un « Travail Couvert » signifie soit le Programme non modifié soit un
-travail basé sur le Programme.
+L'opération consistant à exécuter le Programme n'est soumise à aucune limitation et les sorties du programme ne sont couvertes que si leur contenu constitue un ouvrage fondé sur le Programme (indépendamment du fait qu'il ait été réalisé par l'exécution du Programme).
 
-« Propager » un travail signifie faire quoi que ce soit avec lui qui,
-sans permission, vous rendrait directement ou indirectement responsable
-d’un délit de contrefaçon suivant les lois relatives au Droit d’Auteur,
-à l’exception de son exécution sur un ordinateur ou de la modification
-d’une copie privée. La propagation inclue la copie, la distribution
-(avec ou sans modification), la mise à disposition envers le public, et
-aussi d'autres activités dans certains pays.
+La validité de ce qui précède dépend de ce que fait le Programme.
 
-« Acheminer » un travail signifie tout moyen de propagation de celui-ci
-qui permet à d’autres parties de réaliser ou recevoir des copies. La
-simple interaction d’un utilisateur à travers un réseau informatique,
-sans transfert effectif d’une copie, ne constitue pas un acheminement.
+\item  Vous pouvez copier et distribuer des copies à l'identique du code source du Programme tel que vous l'avez reçu, sur n'importe quel support, du moment que vous apposiez sur chaque copie, de manière ad hoc et parfaitement visible, l'avis de droit d'auteur adéquat et une exonération de garantie ; que vous gardiez intacts tous les avis faisant référence à la présente Licence et à l'absence de toute garantie ; et que vous fournissiez à tout destinataire du Programme autre que vous-même un exemplaire de la présente Licence en même temps que le Programme.
 
-Une interface utilisateur interactive affiche des « Notices Légales
-Appropriées » quand elle comprend un dispositif convenable, bien
-visible et évident qui (1) affiche une notice appropriée sur les droits
-d’auteur et (2) informe l’utilisateur qu’il n’y a pas de garantie pour
-le travail (sauf si des garanties ont été fournies hors du cadre de
-cette Licence), que les licenciés peuvent acheminer le travail sous
-cette Licence, et comment voir une copie de cette Licence. Si
-l’interface présente une liste de commandes utilisateur ou d’options,
-tel qu’un menu, un élément évident dans la liste présentée remplit ce
-critère.
+Vous pouvez faire payer l'acte physique de transmission d'une copie, et vous pouvez, à votre discrétion, proposer une garantie contre rémunération.
+
+\item  Vous pouvez modifier votre copie ou des copies du Programme ou n'importe quelle partie de celui-ci, créant ainsi un ouvrage fondé sur le Programme, et copier et distribuer de telles modifications ou ouvrage selon les termes de l'Article 1 ci-dessus, à condition de vous conformer également à chacune des obligations suivantes :
 
 
-Article 1. Code source.
-
-Le « code source » d’un travail signifie la forme préférée du travail
-permettant ou facilitant les modifications de celui-ci. Le « code
-objet » d’un travail signifie toute forme du travail qui n’en est pas
-le code source.
-
-Une « Interface Standard » signifie une interface qui est soit celle
-d’une norme officielle définie par un organisme de normalisation
-reconnu ou, dans le cas des interfaces spécifiées pour un langage de
-programmation particulier, une interface largement utilisée parmi les
-développeurs travaillant dans ce langage.
-
-Les « Bibliothèques Système » d’un travail exécutable incluent tout ce
-qui, en dehors du travail dans son ensemble, (a) est inclus dans la
-forme usuelle de paquetage d’un Composant Majeur mais ne fait pas
-partie de ce Composant Majeur et (b) sert seulement à permettre
-l’utilisation du travail avec ce Composant Majeur ou à implémenter une
-Interface Standard pour laquelle une implémentation est disponible au
-public sous forme de code source ; un « Composant Majeur » signifie,
-dans ce contexte, un composant majeur essentiel (noyau, système de
-fenêtrage, etc.) du système d’exploitation (le cas échéant) d’un
-système sur lequel le travail exécutable fonctionne, ou bien un
-compilateur utilisé pour produire le code objet du travail, ou un
-interprète de code objet utilisé pour exécuter celui-ci.
-
-Le « Source Correspondant » d’un travail sous forme de code objet
-signifie l’ensemble des codes sources nécessaires pour générer,
-installer et (dans le cas d’un travail exécutable) exécuter le code
-objet et modifier le travail, y compris les scripts pour contrôler ces
-activités. Cependant, cela n’inclue pas les Bibliothèques Système du
-travail, ni les outils d’usage général ou les programmes libres
-généralement disponibles qui peuvent être utilisés sans modification
-pour achever ces activités mais ne sont pas partie de ce travail. Par
-exemple le Source Correspondant inclut les fichiers de définition
-d’interfaces associés aux fichiers sources du travail, et le code
-source des bibliothèques partagées et des sous-routines liées
-dynamiquement, pour lesquelles le travail est spécifiquement conçu pour
-les requérir via, par exemple, des communications de données ou
-contrôles de flux internes entre ces sous-programmes et d’autres
-parties du travail.
-
-Le Source Correspondant n’a pas besoin d’inclure tout ce que les
-utilisateurs peuvent regénérer automatiquement à partir d’autres
-parties du Source Correspondant.
-
-Le Source Correspondant pour un travail sous forme de code source est
-ce même travail.
-
-Article 2. Permissions de base.
-
-Tous les droits accordés suivant cette Licence le sont jusqu’au terme
-des Droits d’Auteur (“copyright”) sur le Programme, et sont
-irrévocables pourvu que les conditions établies soient remplies. Cette
-Licence affirme explicitement votre permission illimitée d’exécuter le
-Programme non modifié. La sortie produite par l’exécution d’un Travail
-Couvert n’est couverte par cette Licence que si cette sortie, étant
-donné leur contenu, constitue un Travail Couvert. Cette Licence
-reconnait vos propres droits d’usage raisonnable (“fair use” en
-législation des États-Unis d’Amérique) ou autres équivalents, tels
-qu’ils sont pourvus par la loi applicable sur le Droit d’Auteur
-(“copyright”).
-
-Vous pouvez créer, exécuter et propager sans condition des Travaux
-Couverts que vous n’acheminez pas, aussi longtemps que votre licence
-demeure en vigueur. Vous pouvez acheminer des Travaux Couverts à
-d’autres personnes dans le seul but de leur faire réaliser des
-modifications à votre usage exclusif, ou pour qu’ils vous fournissent
-des facilités vous permettant d’exécuter ces travaux, pourvu que vous
-vous conformiez aux termes de cette Licence lors de l’acheminement de
-tout matériel dont vous ne contrôlez pas le Droit d’Auteur
-(“copyright”). Ceux qui, dès lors, réalisent ou exécutent pour vous les
-Travaux Couverts ne doivent alors le faire qu’exclusivement pour votre
-propre compte, sous votre direction et votre contrôle, suivant des
-termes qui leur interdisent de réaliser, en dehors de leurs relations
-avec vous, toute copie de votre matériel soumis au Droit d’Auteur.
-
-L’acheminement dans toutes les autres circonstances n’est permis que
-selon les conditions établies ci-dessous. La concession de
-sous-licences n’est pas autorisé ; l’article 10 rend cet usage non
-nécessaire.
-
-
-Article 3. Protection des droits légaux des utilisateurs envers les
-lois anti-contournement.
-
-Aucun Travail Couvert ne doit être vu comme faisant partie d’une mesure
-technologique effective selon toute loi applicable remplissant les
-obligations prévues à l’article 11 du traité international sur le droit
-d’auteur adopté à l’OMPI le 20 décembre 1996, ou toutes lois similaires
-qui prohibent ou restreignent le contournement de telles mesures.
-
-Si vous acheminez un Travail Couvert, vous renoncez à tout pouvoir légal
-d’interdire le contournement des mesures technologiques dans tous les
-cas où un tel contournement serait effectué en exerçant les droits
-prévus dans cette Licence pour ce Travail Couvert, et vous déclarez
-rejeter toute intention de limiter l’opération ou la modification du
-Travail, en tant que moyens de renforcer, à l’encontre des utilisateurs
-de ce Travail, vos droits légaux ou ceux de tierces parties d’interdire
-le contournement des mesures technologiques.
-
-
-Article 4. Acheminement des copies conformes.
-
-Vous pouvez acheminer des copies conformes du code source du Programme
-tel que vous l’avez reçu, sur n’importe quel support, pourvu que vous
-publiiez scrupuleusement et de façon appropriée sur chaque copie une
-notice de Droit d’Auteur appropriée ; gardez intactes toutes les
-notices établissant que cette Licence et tous les termes additionnels non
-permissifs ajoutés en accord avec l’article 7 s’appliquent à ce code ;
-et donnez à chacun des Destinataires une copie de cette Licence en même
-temps que le Programme.
-
-Vous pouvez facturer à un prix quelconque, y compris gratuit, chacune
-des copies que vous acheminez, et vous pouvez offrir une protection
-additionnelle de support ou de garantie en échange d’un paiement.
-
-
-Article 5. Acheminement des versions sources modifiées.
-
-Vous pouvez acheminer un travail basé sur le Programme, ou bien les
-modifications pour le produire à partir du Programme, sous la forme de
-code source suivant les termes de l’article 4, pourvu que vous
-satisfassiez aussi à chacune des conditions requises suivantes :
 \begin{enumerate}
-\item [a)] Le travail doit comporter des notices évidentes établissant que
-     vous l’avez modifié et donnant la date correspondante.
+\item Vous devez munir les fichiers modifiés d'avis bien visibles stipulants que vous avez modifié ces fichiers, ainsi que la date de chaque modification ;
 
-\item [b)] Le travail doit comporter des notices évidentes établissant qu’il
-     est édité selon cette Licence et les conditions ajoutées d’après
-     l’article 7. Cette obligation vient modifier l’obligation de
-     l’article 4 de « garder intactes toutes les notices. »
+\item Vous devez prendre les dispositions nécessaires pour que tout ouvrage que vous distribuez ou publiez, et qui, en totalité ou en partie, contient ou est fondé sur le Programme - ou une partie quelconque de ce dernier - soit concédé comme un tout, à titre gratuit, à n'importe quel tiers, au titre des conditions de la présente Licence.
 
-\item [c)] Vous devez licencier le travail entier, comme un tout, suivant
-     cette Licence à quiconque entre en possession d’une copie. Cette
-     Licence s’appliquera en conséquence, avec les termes additionnels
-     applicables prévus par l’article 7, à la totalité du travail et
-     chacune de ses parties, indépendamment de la façon dont ils sont
-     empaquetés. Cette licence ne donne aucune permission de licencier
-     le travail d’une autre façon, mais elle n’invalide pas une telle
-     permission si vous l’avez reçue séparément. 
+\item Si le programme modifié lit habituellement des instructions de façon interactive lorsqu'on l'exécute, vous devez, quand il commence son exécution pour ladite utilisation interactive de la manière la plus usuelle, faire en sorte qu'il imprime ou affiche une annonce comprenant un avis de droit d'auteur ad hoc, et un avis stipulant qu'il n'y a pas de garantie (ou bien indiquant que c'est vous qui fournissez la garantie), et que les utilisateurs peuvent redistribuer le programme en respectant les présentes obligations, et expliquant à l'utilisateur comment voir une copie de la présente Licence.
 
-\item [d)] Si le travail a des interfaces utilisateurs interactives, chacune
-     doit afficher les Notices Légales Appropriées ; cependant si le
-     Programme a des interfaces qui n’affichent pas les Notices Légales
-     Appropriées, votre travail n’a pas à les modifier pour qu’elles
-     les affichent. 
+
+\end{enumerate}
+(Exception : si le Programme est lui-même interactif mais n'imprime pas habituellement une telle annonce, votre ouvrage fondé sur le Programme n'est pas obligé d'imprimer une annonce).
+
+Ces obligations s'appliquent à l'ouvrage modifié pris comme un tout.
+
+Si des éléments identifiables de cet ouvrage ne sont pas fondés sur le Programme et peuvent raisonnablement être considérés comme des ouvrages indépendants distincts en eux mêmes, alors la présente Licence et ses conditions ne s'appliquent pas à ces éléments lorsque vous les distribuez en tant qu'ouvrages distincts.
+
+Mais lorsque vous distribuez ces mêmes éléments comme partie d'un tout, lequel constitue un ouvrage fondé sur le Programme, la distribution de ce tout doit être soumise aux conditions de la présente Licence, et les autorisations qu'elle octroie aux autres concessionnaires s'étendent à l'ensemble de l'ouvrage et par conséquent à chaque et toute partie indifférement de qui l'a écrite.
+
+Par conséquent, l'objet du présent article n'est pas de revendiquer des droits ou de contester vos droits sur un ouvrage entièrement écrit par vous; son objet est plutôt d'exercer le droit de contrôler la distribution d'ouvrages dérivés ou d'ouvrages collectifs fondés sur le Programme.
+
+De plus, la simple proximité du Programme avec un autre ouvrage qui n'est pas fondé sur le Programme (ou un ouvrage fondé sur le Programme) sur une partition d'un espace de stockage ou un support de distribution ne place pas cet autre ouvrage dans le champ d'application de la présente Licence.
+
+\item  Vous pouvez copier et distribuer le Programme (ou un ouvrage fondé sur lui, selon l'Article 2) sous forme de code objet ou d'exécutable, selon les termes des Articles 1 et 2 ci-dessus, à condition que vous accomplissiez l'un des points suivants :
+
+
+\begin{enumerate}
+\item L'accompagner de l'intégralité du code source correspondant, sous une forme lisible par un ordinateur, lequel doit être distribué au titre des termes des Articles 1 et 2 ci-dessus, sur un support habituellement utilisé pour l'échange de logiciels; ou,
+
+\item L'accompagner d'une proposition écrite, valable pendant au moins trois ans, de fournir à tout tiers, à un tarif qui ne soit pas supérieur à ce que vous coûte l'acte physique de réaliser une distribution source, une copie intégrale du code source correspondant sous une forme lisible par un ordinateur, qui sera distribuée au titre des termes des Articles 1 et 2 ci-dessus, sur un support habituellement utilisé pour l'échange de logiciels; ou,
+
+\item  L'accompagner des informations reçues par vous concernant la proposition de distribution du code source correspondant. (Cette solution n'est autorisée que dans le cas d'une distribution non commerciale et seulement si vous avez reçu le programme sous forme de code objet ou d'exécutable accompagné d'une telle proposition - en conformité avec le sous-Article b ci-dessus.)
 \end{enumerate}
 
-Une compilation d’un Travail Couvert avec d’autres travaux séparés et
-indépendants, qui ne sont pas par leur nature des extensions du Travail
-Couvert, et qui ne sont pas combinés avec lui de façon à former un
-programme plus large, dans ou sur un volume de stockage ou un support
-de distribution, est appelé un « aggrégat » si la compilation et son
-Droit d’Auteur résultant ne sont pas utilisés pour limiter l’accès ou
-les droits légaux des utilisateurs de la compilation en deça de ce que
-permettent les travaux individuels. L’inclusion d’un Travail Couvert
-dans un aggrégat ne cause pas l’application de cette Licence aux
-autres parties de l’aggrégat.
-
-
-Article 6. Acheminement des formes non sources.
-
-Vous pouvez acheminer sous forme de code objet un Travail Couvert
-suivant les termes des articles 4 et 5, pourvu que vous acheminiez
-également suivant les termes de cette Licence le Source Correspondant
-lisible par une machine, d’une des façons suivantes :
-\begin{enumerate}
-\item [a)]  Acheminer le code objet sur, ou inclus dans, un produit physique
-     (y compris un support de distribution physique), accompagné par le
-     Source Correspondant fixé sur un support physique durable
-     habituellement utilisé pour les échanges de logiciels.
-
-\item [b)]  Acheminer le code objet sur, ou inclus dans, un produit physique
-     (y compris un support de distribution physique), accompagné d’une
-     offre écrite, valide pour au moins trois années et valide pour
-     aussi longtemps que vous fournissez des pièces de rechange ou un
-     support client pour ce modèle de produit, afin de donner à
-     quiconque possède le code objet soit (1) une copie du Source
-     Correspondant à tout logiciel dans ce produit qui est couvert par
-     cette Licence, sur un support physique durable habituellement
-     utilisé pour les échanges de logiciels, pour un prix non supérieur
-     au coût raisonnable de la réalisation physique de l’acheminement
-     de la source, ou soit (2) un accès permettant de copier le Source
-     Correspondant depuis un serveur réseau sans frais.
-
-\item [c)]  Acheminer des copies individuelles du code objet avec une copie de
-     l’offre écrite de fournir le Source Correspondant. Cette
-     alternative est permise seulement occasionellement et non
-     commercialement, et seulement si vous avez reçu le code objet avec
-     une telle offre, en accord avec l’article 6 alinéa b.
-
-\item [d)]  Acheminer le code objet en offrant un accès depuis un emplacement
-     désigné (gratuit ou contre facturation) et offrir un accès
-     équivalent au Source Correspondant de la même façon via le même
-     emplacement et sans facturation supplémentaire. Vous n’avez pas
-     besoin d’obliger les Destinataires à copier le Source
-     Correspondant en même temps que le code objet. Si l’emplacement
-     pour copier le code objet est un serveur réseau, le Source
-     Correspondant peut être sur un serveur différent (opéré par vous
-     ou par un tiers) qui supporte des facilités équivalentes de
-     copie, pourvu que vous mainteniez des directions claires à
-     proximité du code objet indiquant où trouver le Source
-     Correspondant. Indépendamment de quel serveur héberge le Source
-     Correspondant, vous restez obligé de vous assurer qu’il reste
-     disponible aussi longtemps que nécessaire pour satisfaire à ces
-     obligations.
-
-\item [e)]  Acheminer le code objet en utilisant une transmission
-     d’égal-à-égal, pourvu que vous informiez les autres participants
-     sur où le code objet et le Source Correspondant du travail sont
-     offerts sans frais au public général suivant l’article 6 alinéa d.
-     Une portion séparable du code objet, dont le code source est exclu
-     du Source Correspondant en tant que Bibliothèque Système, n’a pas
-     besoin d’être inclu dans l’acheminement du travail sous forme de
-     code objet.
-\end{enumerate}
-
-Un « Produit Utilisateur » est soit (1) un « Produit de Consommation, »
-ce qui signifie toute propriété personnelle tangible normalement
-utilisée à des fins personnelles, familiales ou relatives au foyer,
-soit (2) toute chose conçue ou vendue pour l’incorporation dans un lieu
-d’habitation. Pour déterminer si un produit constitue un Produit de
-Consommation, les cas ambigus sont résolus en fonction de la
-couverture. Pour un produit particulier reçu par un utilisateur
-particulier, l’expression « normalement utilisée » ci-avant se réfère
-à une utilisation typique ou l’usage commun de produits de même
-catégorie, indépendamment du statut de cet utilisateur particulier ou
-de la façon spécifique dont cet utilisateur particulier utilise
-effectivement ou s’attend lui-même ou est attendu à utiliser ce
-produit. Un produit est un Produit de Consommation indépendamment du
-fait que ce produit a ou n’a pas d’utilisations substantielles
-commerciales, industrielles ou hors Consommation, à moins que de telles
-utilisations représentent le seul mode significatif d’utilisation du
-produit.
-
-Les « Informations d’Installation » d’un Produit Utilisateur signifient
-toutes les méthodes, procédures, clés d’autorisation ou autres
-informations requises pour installer et exécuter des versions modifiées
-d’un Travail Couvert dans ce Produit Utilisateur à partir d’une version
-modifiée de son Source Correspondant. Les informations qui suffisent à
-assurer la continuité de fonctionnement du code objet modifié ne
-doivent en aucun cas être empêchées ou interférées du seul fait qu’une
-modification a été effectuée.
-
-Si vous acheminez le code objet d’un Travail Couvert dans, ou avec, ou
-spécifiquement pour l’utilisation dans, un Produit Utilisateur et
-l’acheminement se produit en tant qu’élément d’une transaction dans
-laquelle le droit de possession et d’utilisation du Produit
-Utilisateur est transféré au Destinataire définitivement ou pour un
-terme fixé (indépendamment de la façon dont la transaction est
-caractérisée), le Source Correspondant acheminé selon cet article-ci
-doit être accompagné des Informations d’Installation. Mais cette
-obligation ne s’applique pas si ni vous ni aucune tierce partie ne
-détient la possibilité d’intaller un code objet modifié sur le Produit
-Utilisateur (par exemple, le travail a été installé en mémoire morte).
-
-L’obligation de fournir les Informations d’Installation n’inclue pas
-celle de continuer à fournir un service de support, une garantie ou des
-mises à jour pour un travail qui a été modifié ou installé par le
-Destinataire, ou pour le Produit Utilisateur dans lequel il a été
-modifié ou installé. L’accès à un réseau peut être rejeté quand la
-modification elle-même affecte matériellement et défavorablement les
-opérations du réseau ou viole les règles et protocoles de communication
-au travers du réseau.
-
-Le Source Correspondant acheminé et les Informations d’Installation
-fournies, en accord avec cet article, doivent être dans un format
-publiquement documenté (et dont une implémentation est disponible
-auprès du public sous forme de code source) et ne doit nécessiter
-aucune clé ou mot de passe spécial pour le dépaquetage, la lecture ou
-la copie.
-
-
-Article 7. Termes additionnels.
-
-Les « permissions additionelles » désignent les termes qui
-supplémentent ceux de cette Licence en émettant des exceptions à l’une
-ou plusieurs de ses conditions. Les permissions additionnelles qui
-sont applicables au Programme entier doivent être traitées comme si
-elles étaient incluent dans cette Licence, dans les limites de leur
-validité suivant la loi applicable. Si des permissions additionnelles
-s’appliquent seulement à une partie du Programme, cette partie peut
-être utilisée séparément suivant ces permissions, mais le Programme
-tout entier reste gouverné par cette Licence sans regard aux
-permissions additionelles.
-
-Quand vous acheminez une copie d’un Travail Couvert, vous pouvez à
-votre convenance ôter toute permission additionelle de cette copie, ou
-de n’importe quelle partie de celui-ci. (Des permissions
-additionnelles peuvent être rédigées de façon à requérir leur propre
-suppression dans certains cas où vous modifiez le travail.) Vous
-pouvez placer les permissions additionnelles sur le matériel acheminé,
-ajoutées par vous à un Travail Couvert pour lequel vous avez ou pouvez
-donner les permissions de Droit d’Auteur (“copyright”) appropriées.
-
-Nonobstant toute autre clause de cette Licence, pour tout constituant
-que vous ajoutez à un Travail Couvert, vous pouvez (si autorisé par les
-titulaires de Droit d’Auteur pour ce constituant) supplémenter les
-termes de cette Licence avec des termes :
-\begin{enumerate}
-\item [a)] qui rejettent la garantie ou limitent la responsabilité de façon
-     différente des termes des articles 15 et 16 de cette Licence ; ou
-\item [b)] qui requièrent la préservation de notices légales raisonnables
-     spécifiées ou les attributions d’auteur dans ce constituant ou
-     dans les Notices Légales Appropriées affichées par les travaux qui
-     le contiennent ; ou
-
-\item [c)] qui prohibent la représentation incorrecte de l’origine de ce
-     constituant, ou qui requièrent que les versions modifiées d’un tel
-     constituant soit marquées par des moyens raisonnables comme
-     différentes de la version originale ; ou
-
-\item [d)] qui limitent l’usage à but publicitaire des noms des concédants de
-     licence et des auteurs du constituant ; ou
-
-\item [e)]  qui refusent à accorder des droits selon la législation relative
-     aux marques commerciales, pour l’utilisation dans des noms
-     commerciaux, marques commerciales ou marques de services ; ou
-
-\item [f)] qui requièrent l’indemnisation des concédants de licences et
-     auteurs du constituant par quiconque achemine ce constituant (ou
-     des versions modifiées de celui-ci) en assumant contractuellement
-     la responsabilité envers le Destinataire, pour toute
-     responsabilité que ces engagements contractuels imposent
-     directement à ces octroyants de licences et auteurs.
-\end{enumerate}
-
-Tous les autres termes additionnels non permissifs sont considérés
-comme des « restrictions avancées » dans le sens de l’article 10. Si le
-Programme tel que vous l’avez reçu, ou toute partie de celui-ci,
-contient une notice établissant qu’il est gouverné par cette Licence en
-même temps qu’un terme qui est une restriction avancée, vous pouvez
-ôter ce terme. Si un document de licence contient une restriction
-avancée mais permet la reconcession de licence ou l’acheminement
-suivant cette Licence, vous pouvez ajouter un Travail Couvert
-constituant gouverné par les termes de ce document de licence, pourvu
-que la restriction avancée ne survit pas à un telle cession de licence
-ou acheminement.
-
-Si vous ajoutez des termes à un Travail Couvert en accord avec cet
-article, vous devez placer, dans les fichiers sources appropriés, une
-déclaration des termes additionnels qui s’appliquent à ces fichiers, ou
-une notice indiquant où trouver les termes applicables.
-
-Les termes additionnels, qu’ils soient permissifs ou non permissifs,
-peuvent être établis sous la forme d’une licence écrite séparément, ou
-établis comme des exceptions ; les obligations ci-dessus s’appliquent
-dans chacun de ces cas.
-
-
-Article 8. Terminaison.
-
-Vous ne pouvez ni propager ni modifier un Travail Couvert autrement que
-suivant les termes de cette Licence. Toute autre tentative de le
-propager ou le modifier est nulle et terminera automatiquement vos
-droits selon cette Licence (y compris toute licence de brevet accordée
-selon le troisième paragraphe de l’article 11).
-
-Cependant, si vous cessez toute violation de cette Licence, alors votre
-licence depuis un titulaire de Droit d’Auteur (“copyright”) est
-réinstaurée (a) à titre provisoire à moins que et jusqu’à ce que le
-titulaire de Droit d’Auteur termine finalement et explicitement votre
-licence, et (b) de façon permanente si le titulaire de Droit d’Auteur
-ne parvient pas à vous notifier de la violation par quelque moyen
-raisonnable dans les soixante (60) jours après la cessation.
-
-De plus, votre licence depuis un titulaire particulier de Droit
-d’Auteur est réinstaurée de façon permanente si ce titulaire vous
-notifie de la violation par quelque moyen raisonnable, c’est la
-première fois que vous avez reçu une notification deviolation de cette
-Licence (pour un travail quelconque) depuis ce titulaire de Droit
-d’Auteur, et vous résolvez la violation dans les trente (30) jours qui
-suivent votre réception de la notification.
-
-La terminaison de vos droits suivant cette section ne terminera pas les
-licences des parties qui ont reçu des copies ou droits de votre part
-suivant cette Licence. Si vos droits ont été terminés et non
-réinstaurés de façon permanente, vous n’êtes plus qualifié à recevoir
-de nouvelles licences pour les mêmes constituants selon l’article 10.
-
-
-Article 9. Acceptation non requise pour obtenir des copies.
-
-Vous n’êtes pas obligé d’accepter cette licence afin de recevoir ou
-exécuter une copie du Programme. La propagation asservie d’un Travail
-Couvert qui se produit simplement en conséquence d’une transmission
-d’égal-à-égal pour recevoir une copie ne nécessite pas l’acceptation.
-Cependant, rien d’autre que cette Licence ne vous accorde la
-permission de propager ou modifier un quelconque Travail Couvert. Ces
-actions enfreignent le Droit d’Auteur si vous n’acceptez pas cette
-Licence. Par conséquent, en modifiant ou propageant un Travail Couvert,
-vous indiquez votre acceptation de cette Licence pour agir ainsi.
-
-
-Article 10. Cession automatique de Licence aux Destinataires et
-intermédiaires.
-
-Chaque fois que vous acheminez un Travail Couvert, le Destinataire
-reçoit automatiquement une licence depuis les concédants originaux,
-pour exécuter, modifier et propager ce travail, suivant les termes de
-cette Licence. Vous n’êtes pas responsable du renforcement de la
-conformation des tierces parties avec cette Licence.
-
-Une « transaction d’entité » désigne une transaction qui transfère le
-contrôle d’une organisation, ou de substantiellement tous ses actifs,
-ou la subdivision d’une organisation, ou la fusion de plusieurs
-organisations. Si la propagation d’un Travail Couvert résulte d’une
-transaction d’entité, chaque partie à cette transaction qui reçoit une
-copie du travail reçoit aussi les licences pour le travail que le
-prédécesseur intéressé à cette partie avait ou pourrait donner selon le
-paragraphe précédent, plus un droit de possession du Source
-Correspondant de ce travail depuis le prédécesseur intéressé si ce
-prédécesseur en dispose ou peut l’obtenir par des efforts raisonnables.
-
-Vous ne pouvez imposer aucune restriction avancée dans l’exercice des
-droits accordés ou affirmés selon cette Licence. Par exemple, vous ne
-pouvez imposer aucun paiement pour la licence, aucune royaltie, ni
-aucune autre charge pour l’exercice des droits accordés selon cette
-Licence ; et vous ne pouvez amorcer aucun litige judiciaire (y compris
-une réclamation croisée ou contre-réclamation dans un procès) sur
-l’allégation qu’une revendication de brevet est enfreinte par la
-réalisation, l’utilisation, la vente, l’offre de vente, ou
-l’importation du Programme ou d’une quelconque portion de celui-ci.
-
-
-Article 11. Brevets.
-
-Un « contributeur » est un titulaire de Droit d’Auteur (“copyright”)
-qui autorise l’utilisation selon cette Licence du Programme ou du
-travail sur lequel le Programme est basé. Le travail ainsi soumis à
-licence est appelé la « version contributive » de ce contributeur.
-
-Les « revendications de brevet essentielles » sont toutes les
-revendications de brevets détenues ou contrôlées par le contributeur,
-qu’elles soient déjà acquises par lui ou acquises subséquemment, qui
-pourraient être enfreintes de quelque manière, permises par cette
-Licence, sur la réalisation, l’utilisation ou la vente de la version
-contributive de celui-ci. Aux fins de cette définition, le « contrôle »
-inclue le droit de concéder des sous-licences de brevets d’une manière
-consistante, nécessaire et suffisante, avec les obligations de cette
-Licence.
-
-Chaque contributeur vous accorde une licence de brevet non exclusive,
-mondiale et libre de toute royaltie, selon les revendications de brevet
-essentielles, pour réaliser, utiliser, vendre, offrir à la vente,
-importer et autrement exécuter, modifier et propager les contenus de sa
-version contributive.
-
-Dans les trois paragraphes suivants, une « licence de brevet » désigne
-tous les accords ou engagements exprimés, quel que soit le nom que vous
-lui donnez, de ne pas mettre en vigueur un brevet (telle qu’une
-permission explicite pour mettre en pratique un brevet, ou un accord
-pour ne pas poursuivre un Destinataire pour cause de violation de
-brevet). « Accorder » une telle licence de brevet à une partie signifie
-conclure un tel accord ou engagement à ne pas faire appliquer le brevet
-à cette partie.
-
-Si vous acheminez un Travail Couvert, dépendant en connaissance d’une
-licence de brevet, et si le Source Correspondant du travail n’est pas
-disponible à quiconque copie, sans frais et suivant les termes de cette
-Licence, à travers un serveur réseau publiquement acessible ou tout
-autre moyen immédiatement accessible, alors vous devez soit (1) rendre
-la Source Correspondante ainsi disponible, soit (2) vous engager à vous
-priver pour vous-même du bénéfice de la licence de brevet pour ce
-travail particulier, soit (3) vous engager, d’une façon consistante
-avec les obligations de cette Licence, à étendre la licence de brevet
-aux Destinataires de ce travail. « Dépendant en connaissance » signifie
-que vous avez effectivement connaissance que, selon la licence de
-brevet, votre acheminement du Travail Couvert dans un pays, ou
-l’utilisation du Travail Couvert par votre Destinataire dans un pays,
-infreindrait un ou plusieurs brevets identifiables dans ce pays où vous
-avez des raisons de penser qu’ils sont valides.
-
-Si, conformément à ou en liaison avec une même transaction ou un même
-arrangement, vous acheminez, ou propagez en procurant un acheminement
-de, un Travail Couvert et accordez une licence de brevet à l’une des
-parties recevant le Travail Couvert pour lui permettre d’utiliser,
-propager, modifier ou acheminer une copie spécifique du Travail
-Couvert, alors votre accord est automatiquement étendu à tous les
-Destinataires du Travail Couvert et des travaux basés sur celui-ci.
-
-Une licence de brevet est « discriminatoire » si, dans le champ de sa
-couverture, elle n’inclut pas un ou plusieurs des droits qui sont
-spécifiquement accordés selon cette Licence, ou en prohibe l’exercice,
-ou est conditionnée par le non-exercice d’un ou plusieurs de ces
-droits. Vous ne pouvez pas acheminer un Travail Couvert si vous êtes
-partie à un arrangement selon lequel une partie tierce exerçant son
-activité dans la distribution de logiciels et à laquelle vous effectuez
-un paiement fondé sur l’étendue de votre activité d’acheminement du
-travail, et selon lequel la partie tierce accorde, à une quelconque
-partie qui recevrait depuis vous le Travail Couvert, une licence de
-brevet discriminatoire (a) en relation avec les copies du Travail
-Couvert acheminées par vous (ou les copies réalisées à partir de ces
-copies), ou (b) avant tout destinée et en relation avec des produits
-spécifiques ou compilations contenant le Travail Couvert, à moins que
-vous ayez conclu cet arrangement ou que la licence de brevet ait été
-accordée avant le 28 mars 2007.
-
-Rien dans cette Licence ne devrait être interprété comme devant exclure
-ou limiter toute licence implicite ou d’autres moyens de défense à une
-infraction qui vous seraient autrement disponible selon la loi
-applicable relative aux brevets.
-
-
-Article 12. Non abandon de la liberté des autres.
-
-Si des conditions vous sont imposées (que ce soit par décision
-judiciaire, par un accord ou autrement) qui contredisent les conditions
-de cette Licence, elles ne vous excusent pas des conditions de cette
-Licence. Si vous ne pouvez pas acheminer un Travail Couvert de façon à
-satisfaire simulténément vos obligations suivant cette Licence et
-toutes autres obligations pertinentes, alors en conséquence vous ne
-pouvez pas du tout l’acheminer. Par exemple, si vous avez un accord sur
-des termes qui vous obligent à collecter pour le réacheminement des
-royalties depuis ceux à qui vous acheminez le Programme, la seule façon
-qui puisse vous permettre de satisfaire à la fois à ces termes et ceux
-de cette Licence sera de vous abstenir entièrement d’acheminer le
-Programme.
-
-
-Article 13. Utilisation avec la Licence Générale Publique Affero GNU.
-
-Nonobstant toute autre clause de cette Licence, vous avez la permission
-de lier ou combiner tout Travail Couvert avec un travail placé sous la
-version 3 de la Licence Générale Publique GNU Affero (“GNU Affero
-General Public License”) en un seul travail combiné, et d’acheminer le
-travail résultant. Les termes de cette Licence continueront à
-s’appliquer à la partie formant un Travail Couvert, mais les
-obligations spéciales de la Licence Générale Publique GNU Affero,
-article 13, concernant l’interaction à travers un réseau s’appliqueront
-à la combinaison en tant que telle.
-
-
-Article 14. Versions révisées de cette License.
-
-La Free Software Foundation peut publier des versions révisées et/ou
-nouvelles de la Licence Publique Générale GNU (“GNU General Public
-License”) de temps en temps. De telles version nouvelles resteront
-similaires dans l’esprit avec la présente version, mais peuvent
-différer dans le détail afin de traiter de nouveaux problèmes ou
-préoccupations.
-
-Chaque version reçoit un numéro de version distinctif. Si le Programme
-indique qu’une version spécifique de la Licence Publique Générale GNU
-« ou toute version ultérieure » (“or any later version”) s’applique à
-celui-ci, vous avez le choix de suivre soit les termes et conditions de
-cette version numérotée, soit ceux de n’importe quelle version publiée
-ultérieurement par la Free Software Foundation. Si le Programme
-n’indique pas une version spécifique de la Licence Publique Générale
-GNU, vous pouvez choisir l’une quelconque des versions qui ont été
-publiées par la Free Software Foundation.
-
-Si le Programme spécifie qu’un intermédiaire peut décider quelles
-versions futures de la Licence Générale Publique GNU peut être
-utilisée, la déclaration publique d’acceptation d’une version par cet
-intermédiaire vous autorise à choisir cette version pour le Programme.
-
-Des versions ultérieures de la licence peuvent vous donner des
-permissions additionelles ou différentes. Cependant aucune obligation
-additionelle n’est imposée à l’un des auteurs ou titulaires de Droit
-d’Auteur du fait de votre choix de suivre une version ultérieure.
-
-
-Article 15. Déclaration d’absence de garantie.
-
-IL N’Y A AUCUNE GARANTIE POUR LE PROGRAMME, DANS LES LIMITES PERMISES
-PAR LA LOI APPLICABLE. À MOINS QUE CELA NE SOIT ÉTABLI DIFFÉREMMENT PAR
-ÉCRIT, LES PROPRIÉTAIRES DE DROITS ET/OU LES AUTRES PARTIES FOURNISSENT
-LE PROGRAMME « EN L’ÉTAT » SANS GARANTIE D’AUCUNE SORTE, QU’ELLE SOIT
-EXPRIMÉE OU IMPLICITE, CECI COMPRENANT, SANS SE LIMITER À CELLES-CI,
-LES GARANTIES IMPLICITES DE COMMERCIALISABILITÉ ET D’ADÉQUATION À UN
-OBJECTIF PARTICULIER. VOUS ASSUMEZ LE RISQUE ENTIER CONCERNANT LA
-QUALITÉ ET LES PERFORMANCES DU PROGRAMME. DANS L’ÉVENTUALITÉ OÙ LE
-PROGRAMME  S’AVÉRERAIT DÉFECTUEUX, VOUS ASSUMEZ 
-LES COÛTS DE TOUS LES SERVICES, RÉPARATIONS OU CORRECTIONS NÉCESSAIRES.
-
-
-Article 16. Limitation de responsabilité.
-
-EN AUCUNE AUTRE CIRCONSTANCE QUE CELLES REQUISES PAR LA LOI APPLICABLE
-OU ACCORDÉES PAR ÉCRIT, UN TITULAIRE DE DROITS SUR LE PROGRAMME, OU
-TOUT AUTRE PARTIE QUI MODIFIE OU ACHEMINE LE PROGRAMME COMME PERMIS
-CI-DESSUS, NE PEUT ÊTRE TENU POUR RESPONSABLE ENVERS VOUS POUR LES
-DOMMAGES, INCLUANT TOUT DOMMAGE GÉNÉRAL, SPÉCIAL, ACCIDENTEL OU INDUIT
-SURVENANT PAR SUITE DE L’UTILISATION OU DE L’INCAPACITÉ D’UTILISER LE
-PROGRAMME (Y COMPRIS, SANS SE LIMITER À CELLES-CI, LA PERTE DE DONNÉES
-OU L’INEXACTITUDE DES DONNÉES RETOURNÉES OU LES PERTES SUBIES PAR VOUS
-OU DES PARTIES TIERCES OU L’INCAPACITÉ DU PROGRAMME À FONCTIONNER AVEC
-TOUT AUTRE PROGRAMME), MÊME SI UN TEL TITULAIRE OU TOUTE AUTRE PARTIE
-A ÉTÉ AVISÉ DE LA POSSIBILITÉ DE TELS DOMMAGES.
-
-
-Article 17. Interprétation des sections 15 et 16.
-
-Si la déclaration d’absence de garantie et la limitation de
-responsabilité fournies ci-dessus ne peuvent prendre effet localement
-selon leurs termes, les cours de justice qui les examinent doivent
-appliquer la législation locale qui approche au plus près possible une
-levée absolue de toute responsabilité civile liée au Programme, à moins
-qu’une garantie ou assumation de responsabilité accompagne une copie du
-Programme en échange d’un paiement.
-
-
-FIN DES TERMES ET CONDITIONS.
-
-
-
-Comment appliquer ces termes à vos nouveaux programmes
-
-Si vous développez un nouveau programme et voulez qu’il soit le plus
-possible utilisable par le public, la meilleure façon d’y parvenir et
-d’en faire un logiciel libre que chacun peut redistribuer et changer
-suivant ces termes-ci.
-
-Pour appliquer ces termes, attachez les notices suivantes au programme.
-Il est plus sûr de les attacher au début de chacun des fichiers sources
-afin de transporter de façon la plus effective possible l’exclusion de
-garantie ; et chaque fichier devrait comporter au moins la ligne de
-réservation de droit (“copyright”) et une indication permettant de savoir
-où la notice complète peut être trouvée :
-
-  <une ligne donnant le nom du programme et une brève idée de ce qu’il fait.>
-  Copyright (C) <année> <nom de l’auteur> — Tous droits réservés.
-  
-  Ce programme est un logiciel libre ; vous pouvez le redistribuer ou le
-  modifier suivant les termes de la “GNU General Public License” telle que
-  publiée par la Free Software Foundation : soit la version 3 de cette
-  licence, soit (à votre gré) toute version ultérieure.
-  
-  Ce programme est distribué dans l’espoir qu’il vous sera utile, mais SANS
-  AUCUNE GARANTIE : sans même la garantie implicite de COMMERCIALISABILITÉ
-  ni d’ADÉQUATION À UN OBJECTIF PARTICULIER. Consultez la Licence Générale
-  Publique GNU pour plus de détails.
-  
-  Vous devriez avoir reçu une copie de la Licence Générale Publique GNU avec
-  ce programme ; si ce n’est pas le cas, consultez :
-\begin{center}
-\href{http://www.gnu.org/licenses/}{http://www.gnu.org/licenses/}
-\end{center}
-
-Ajoutez également les informations permettant de vous contacter par
-courrier électronique ou postal.
-
-Si le programme produit une interaction sur un terminal, faites lui
-afficher une courte notice comme celle-ci lors de son démarrage en mode
-interactif :
-
-  "programme" Copyright (C) "année" "nom de l’auteur"
-  Ce programme vient SANS ABSOLUMENT AUCUNE GARANTIE ; taper “affiche g” pour
-  les détails. Ceci est un logiciel libre et vous êtes invité à le redistribuer
-  suivant certaines conditions ; taper “affiche c” pour les détails.
-
-Les commandes hypothétiques “affiche g” and “affiche c” devrait
-afficher les parties appropriées de la Licence Générale Publique. Bien
-sûr, les commandes de votre programme peuvent être différentes ; pour
-une interface graphique, vous pourriez utiliser une « boîte À propos. »
-
-Vous devriez également obtenir de votre employeur (si vous travaillez
-en tant que programmeur) ou de votre école un « renoncement aux droits
-de propriété » pour ce programme, si nécessaire. Pour plus
-d’informations à ce sujet, et comment appliquer la GPL GNU, consultez:
-\begin{center}
-\href{http://www.gnu.org/licenses/}{http://www.gnu.org/licenses/}
-\end{center}
-
-La Licence Générale Publique GNU ne permet pas d’incorporer votre
-programme dans des programmes propriétaires. Si votre programme est une
-bibliothèque de sous-routines, vous pourriez considérer qu’il serait
-plus utile de permettre de lier des applications propriétaires avec la
-bibliothèque. Si c’est ce que vous voulez faire, utilisez la Licence
-Générale Publique Limitée GNU au lieu de cette Licence ; mais d’abord,
-veuillez lire:
-\begin{center}
- \href{http://www.gnu.org/philosophy/why-not-lgpl.html}{http://www.gnu.org/philosophy/why-not-lgpl.html}
-\end{center}
-
-
-
-
-
-
+Le code source d'un ouvrage désigne la forme favorite pour travailler à des modifications de cet ouvrage. Pour un ouvrage exécutable, le code source intégral désigne la totalité du code source de la totalité des modules qu'il contient, ainsi que les éventuels fichiers de définition des interfaces qui y sont associés, ainsi que les scripts utilisés pour contrôler la compilation et l'installation de l'exécutable. Cependant, par exception spéciale, le code source distribué n'est pas censé inclure quoi que ce soit de normalement distribué (que ce soit sous forme source ou binaire) avec les composants principaux (compilateur, noyau, et autre) du système d'exploitation sur lequel l'exécutable tourne, à moins que ce composant lui-même n'accompagne l'exécutable.
+
+Si distribuer un exécutable ou un code objet consiste à offrir un accès permettant leur copie depuis un endroit particulier, alors l'offre d'un accès équivalent pour copier le code source depuis le même endroit compte comme une distribution du code source - même si les tiers ne sont pas contraints de copier le source en même temps que le code objet.
+
+\item  Vous ne pouvez copier, modifier, concéder en sous-licence, ou distribuer le Programme, sauf tel qu'expressément prévu par la présente Licence. Toute tentative de copier, modifier, concéder en sous-licence, ou distribuer le Programme d'une autre manière est réputée non valable, et met immédiatement fin à vos droits au titre de la présente Licence. Toutefois, les tiers ayant reçu de vous des copies, ou des droits, au titre de la présente Licence ne verront pas leurs autorisations résiliées aussi longtemps que ledits tiers se conforment pleinement à elle.
+
+\item  Vous n'êtes pas obligé d'accepter la présente Licence étant donné que vous ne l'avez pas signée. Cependant, rien d'autre ne vous accorde l'autorisation de modifier ou distribuer le Programme ou les ouvrages fondés sur lui. Ces actions sont interdites par la loi si vous n'acceptez pas la présente Licence. En conséquence, en modifiant ou distribuant le Programme (ou un ouvrage quelconque fondé sur le Programme), vous signifiez votre acceptation de la présente Licence en le faisant, et de toutes ses conditions concernant la copie, la distribution ou la modification du Programme ou d'ouvrages fondés sur lui.
+
+\item  Chaque fois que vous redistribuez le Programme (ou n'importe quel ouvrage fondé sur le Programme), une licence est automatiquement concédée au destinataire par le concédant originel de la licence, l'autorisant à copier, distribuer ou modifier le Programme, sous réserve des présentes conditions. Vous ne pouvez imposer une quelconque limitation supplémentaire à l'exercice des droits octroyés au titre des présentes par le destinataire. Vous n'avez pas la responsabilité d'imposer le respect de la présente Licence à des tiers.
+
+\item  Si, conséquement à une décision de justice ou l'allégation d'une transgression de brevet ou pour toute autre raison (non limitée à un probleme de brevet), des obligations vous sont imposées (que ce soit par jugement, conciliation ou autre) qui contredisent les conditions de la présente Licence, elles ne vous excusent pas des conditions de la présente Licence. Si vous ne pouvez distribuer de manière à satisfaire simultanément vos obligations au titre de la présente Licence et toute autre obligation pertinente, alors il en découle que vous ne pouvez pas du tout distribuer le Programme. Par exemple, si une licence de brevet ne permettait pas une redistribution sans redevance du Programme par tous ceux qui reçoivent une copie directement ou indirectement par votre intermédiaire, alors la seule façon pour vous de satisfaire à la fois à la licence du brevet et à la présente Licence serait de vous abstenir totalement de toute distribution du Programme.
+
+Si une partie quelconque de cet article est tenue pour nulle ou inopposable dans une circonstance particulière quelconque, l'intention est que le reste de l'article s'applique. La totalité de la section s'appliquera dans toutes les autres circonstances.
+
+Cet article n'a pas pour but de vous induire à transgresser un quelconque brevet ou d'autres revendications à un droit de propriété ou à contester la validité de la moindre de ces revendications ; cet article a pour seul objectif de protéger l'intégrité du système de distribution du logiciel libre, qui est mis en oeuvre par la pratique des licenses publiques. De nombreuses personnes ont fait de généreuses contributions au large spectre de logiciels distribués par ce système en se fiant à l'application cohérente de ce système ; il appartient à chaque auteur/donateur de décider si il ou elle veut distribuer du logiciel par l'intermédiaire d'un quelconque autre système et un concessionaire ne peut imposer ce choix.
+
+Cet article a pour but de rendre totalement limpide ce que l'on pense être une conséquence du reste de la présente Licence.
+
+\item  Si la distribution et/ou l'utilisation du Programme est limitée dans certains pays que ce soit par des brevets ou par des interfaces soumises au droit d'auteur, le titulaire originel des droits d'auteur qui décide de couvrir le Programme par la présente Licence peut ajouter une limitation géographique de distribution explicite qui exclue ces pays afin que la distribution soit permise seulement dans ou entre les pays qui ne sont pas ainsi exclus. Dans ce cas, la présente Licence incorpore la limitation comme si elle était écrite dans le corps de la présente Licence.
+
+\item  La Free Software Foundation peut, de temps à autre, publier des versions révisées et/ou nouvelles de la Licence Publique Générale. De telles nouvelles versions seront similaires à la présente version dans l'esprit mais pourront différer dans le détail pour prendre en compte de nouvelles problématiques ou inquiétudes.
+
+Chaque version possède un numéro de version la distinguant. Si le Programme précise le numéro de version de la présente Licence qui s'y applique et "une version ultérieure quelconque", vous avez le choix de suivre les conditions de la présente version ou de toute autre version ultérieure publiée par la Free Software Foundation. Si le Programme ne spécifie aucun numéro de version de la présente Licence, vous pouvez choisir une version quelconque publiée par la Free Software Foundation à quelque moment que ce soit.
+
+\item  Si vous souhaitez incorporer des parties du Programme dans d'autres programmes libres dont les conditions de distribution sont différentes, écrivez à l'auteur pour lui en demander l'autorisation. Pour les logiciels dont la Free Software Foundation est titulaire des droits d'auteur, écrivez à la Free Software Foundation ; nous faisons parfois des exceptions dans ce sens. Notre décision sera guidée par le double objectif de préserver le statut libre de tous les dérivés de nos logiciels libres et de promouvoir le partage et la réutilisation des logiciels en général.
+ABSENCE DE GARANTIE
+
+\item  COMME LA LICENCE DU PROGRAMME EST CONCEDEE A TITRE GRATUIT, AUCUNE GARANTIE NE S'APPLIQUE AU PROGRAMME, DANS LES LIMITES AUTORISEES PAR LA LOI APPLICABLE. SAUF MENTION CONTRAIRE ECRITE, LES TITULAIRES DU DROIT D'AUTEUR ET/OU LES AUTRES PARTIES FOURNISSENT LE PROGRAMME "EN L'ETAT", SANS AUCUNE GARANTIE DE QUELQUE NATURE QUE CE SOIT, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS Y ETRE LIMITE, LES GARANTIES IMPLICITES DE COMMERCIABILITE ET DE LA CONFORMITE A UNE UTILISATION PARTICULIERE. VOUS ASSUMEZ LA TOTALITE DES RISQUES LIES A LA QUALITE ET AUX PERFORMANCES DU PROGRAMME. SI LE PROGRAMME SE REVELAIT DEFECTUEUX, LE COUT DE L'ENTRETIEN, DES REPARATIONS OU DES CORRECTIONS NECESSAIRES VOUS INCOMBENT INTEGRALEMENT.
+
+\item  EN AUCUN CAS, SAUF LORSQUE LA LOI APPLICABLE OU UNE CONVENTION ECRITE L'EXIGE, UN TITULAIRE DE DROIT D'AUTEUR QUEL QU'IL SOIT, OU TOUTE PARTIE QUI POURRAIT MODIFIER ET/OU REDISTRIBUER LE PROGRAMME COMME PERMIS CI-DESSUS, NE POURRAIT ETRE TENU POUR RESPONSABLE A VOTRE EGARD DES DOMMAGES, INCLUANT LES DOMMAGES GENERIQUES, SPECIFIQUES, SECONDAIRES OU CONSECUTIFS, RESULTANT DE L'UTILISATION OU DE L'INCAPACITE D'UTILISER LE PROGRAMME (Y COMPRIS, MAIS SANS Y ETRE LIMITE, LA PERTE DE DONNEES, OU LE FAIT QUE DES DONNEES SOIENT RENDUES IMPRECISES, OU LES PERTES EPROUVEES PAR VOUS OU PAR DES TIERS, OU LE FAIT QUE LE PROGRAMME ECHOUE A INTEROPERER AVEC UN AUTRE PROGRAMME QUEL QU'IL SOIT) MEME SI LE DIT TITULAIRE DU DROIT D'AUTEUR OU LE PARTIE CONCERNEE A ETE AVERTI DE L'EVENTUALITE DE TELS DOMMAGES.
+
+		\end{enumerate}
+
+
+FIN DES CONDITIONS
+
+\vspace{1cm}
+Sur les pages suivantes, la version original en anglais de la General Public License. 
+\newpage 
+
+	\begin{center}
+		GNU GENERAL PUBLIC LICENSE
+		
+		Version 2, June 1991
+		
+		
+	\end{center}
+	
+	Copyright (C) 1989, 1991 Free Software Foundation, Inc.
+	
+	59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+	
+	Everyone is permitted to copy and distribute verbatim copies
+	of this license document, but changing it is not allowed.
+	
+	\begin{center}
+		Preamble
+	\end{center}
+	
+	The licenses for most software are designed to take away your
+	freedom to share and change it.  By contrast, the GNU General Public
+	License is intended to guarantee your freedom to share and change free
+	software--to make sure the software is free for all its users.  This
+	General Public License applies to most of the Free Software
+	Foundation's software and to any other program whose authors commit to
+	using it.  (Some other Free Software Foundation software is covered by
+	the GNU Library General Public License instead.)  You can apply it to
+	your programs, too.
+	
+	When we speak of free software, we are referring to freedom, not
+	price.  Our General Public Licenses are designed to make sure that you
+	have the freedom to distribute copies of free software (and charge for
+	this service if you wish), that you receive source code or can get it
+	if you want it, that you can change the software or use pieces of it
+	in new free programs; and that you know you can do these things.
+	
+	To protect your rights, we need to make restrictions that forbid
+	anyone to deny you these rights or to ask you to surrender the rights.
+	These restrictions translate to certain responsibilities for you if you
+	distribute copies of the software, or if you modify it.
+	
+	For example, if you distribute copies of such a program, whether
+	gratis or for a fee, you must give the recipients all the rights that
+	you have.  You must make sure that they, too, receive or can get the
+	source code.  And you must show them these terms so they know their
+	rights.
+	
+	We protect your rights with two steps: (1) copyright the software, and
+	(2) offer you this license which gives you legal permission to copy,
+	distribute and/or modify the software.
+	
+	Also, for each author's protection and ours, we want to make certain
+	that everyone understands that there is no warranty for this free
+	software.  If the software is modified by someone else and passed on, we
+	want its recipients to know that what they have is not the original, so
+	that any problems introduced by others will not reflect on the original
+	authors' reputations.
+	
+	Finally, any free program is threatened constantly by software
+	patents.  We wish to avoid the danger that redistributors of a free
+	program will individually obtain patent licenses, in effect making the
+	program proprietary.  To prevent this, we have made it clear that any
+	patent must be licensed for everyone's free use or not licensed at all.
+	
+	The precise terms and conditions for copying, distribution and
+	modification follow.
+	
+	\begin{center}
+		GNU GENERAL PUBLIC LICENSE
+		
+		TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+	\end{center}
+	
+	\begin{enumerate}
+		\item This License applies to any program or other work which contains
+		a notice placed by the copyright holder saying it may be distributed
+		under the terms of this General Public License.  The ``Program'', below,
+		refers to any such program or work, and a ``work based on the Program''
+		means either the Program or any derivative work under copyright law:
+		that is to say, a work containing the Program or a portion of it,
+		either verbatim or with modifications and/or translated into another
+		language.  (Hereinafter, translation is included without limitation in
+		the term ``modification''.)  Each licensee is addressed as ``you''.
+		
+		Activities other than copying, distribution and modification are not
+		covered by this License; they are outside its scope.  The act of
+		running the Program is not restricted, and the output from the Program
+		is covered only if its contents constitute a work based on the
+		Program (independent of having been made by running the Program).
+		Whether that is true depends on what the Program does.
+		
+		\item You may copy and distribute verbatim copies of the Program's
+		source code as you receive it, in any medium, provided that you
+		conspicuously and appropriately publish on each copy an appropriate
+		copyright notice and disclaimer of warranty; keep intact all the
+		notices that refer to this License and to the absence of any warranty;
+		and give any other recipients of the Program a copy of this License
+		along with the Program.
+		
+		You may charge a fee for the physical act of transferring a copy, and
+		you may at your option offer warranty protection in exchange for a fee.
+		
+		\item You may modify your copy or copies of the Program or any portion
+		of it, thus forming a work based on the Program, and copy and
+		distribute such modifications or work under the terms of Section 1
+		above, provided that you also meet all of these conditions:
+		
+		\begin{enumerate}
+			\item You must cause the modified files to carry prominent notices
+			stating that you changed the files and the date of any change.
+			
+			\item You must cause any work that you distribute or publish, that in
+			whole or in part contains or is derived from the Program or any
+			part thereof, to be licensed as a whole at no charge to all third
+			parties under the terms of this License.
+			
+			\item If the modified program normally reads commands interactively
+			when run, you must cause it, when started running for such
+			interactive use in the most ordinary way, to print or display an
+			announcement including an appropriate copyright notice and a
+			notice that there is no warranty (or else, saying that you provide
+			a warranty) and that users may redistribute the program under
+			these conditions, and telling the user how to view a copy of this
+			License.  (Exception: if the Program itself is interactive but
+			does not normally print such an announcement, your work based on
+			the Program is not required to print an announcement.)
+		\end{enumerate}
+		
+		These requirements apply to the modified work as a whole.  If
+		identifiable sections of that work are not derived from the Program,
+		and can be reasonably considered independent and separate works in
+		themselves, then this License, and its terms, do not apply to those
+		sections when you distribute them as separate works.  But when you
+		distribute the same sections as part of a whole which is a work based
+		on the Program, the distribution of the whole must be on the terms of
+		this License, whose permissions for other licensees extend to the
+		entire whole, and thus to each and every part regardless of who wrote it.
+		
+		Thus, it is not the intent of this section to claim rights or contest
+		your rights to work written entirely by you; rather, the intent is to
+		exercise the right to control the distribution of derivative or
+		collective works based on the Program.
+		
+		In addition, mere aggregation of another work not based on the Program
+		with the Program (or with a work based on the Program) on a volume of
+		a storage or distribution medium does not bring the other work under
+		the scope of this License.
+		
+		\item You may copy and distribute the Program (or a work based on it,
+		under Section 2) in object code or executable form under the terms of
+		Sections 1 and 2 above provided that you also do one of the following:
+		
+		\begin{enumerate}
+			\item Accompany it with the complete corresponding machine-readable
+			source code, which must be distributed under the terms of Sections
+			1 and 2 above on a medium customarily used for software interchange; or,
+			
+			\item Accompany it with a written offer, valid for at least three
+			years, to give any third party, for a charge no more than your
+			cost of physically performing source distribution, a complete
+			machine-readable copy of the corresponding source code, to be
+			distributed under the terms of Sections 1 and 2 above on a medium
+			customarily used for software interchange; or,
+			
+			\item Accompany it with the information you received as to the offer
+			to distribute corresponding source code.  (This alternative is
+			allowed only for noncommercial distribution and only if you
+			received the program in object code or executable form with such
+			an offer, in accord with Subsection b above.)
+		\end{enumerate}
+		
+		The source code for a work means the preferred form of the work for
+		making modifications to it.  For an executable work, complete source
+		code means all the source code for all modules it contains, plus any
+		associated interface definition files, plus the scripts used to
+		control compilation and installation of the executable.  However, as a
+		special exception, the source code distributed need not include
+		anything that is normally distributed (in either source or binary
+		form) with the major components (compiler, kernel, and so on) of the
+		operating system on which the executable runs, unless that component
+		itself accompanies the executable.
+		
+		If distribution of executable or object code is made by offering
+		access to copy from a designated place, then offering equivalent
+		access to copy the source code from the same place counts as
+		distribution of the source code, even though third parties are not
+		compelled to copy the source along with the object code.
+		
+		\item You may not copy, modify, sublicense, or distribute the Program
+		except as expressly provided under this License.  Any attempt
+		otherwise to copy, modify, sublicense or distribute the Program is
+		void, and will automatically terminate your rights under this License.
+		However, parties who have received copies, or rights, from you under
+		this License will not have their licenses terminated so long as such
+		parties remain in full compliance.
+		
+		\item You are not required to accept this License, since you have not
+		signed it.  However, nothing else grants you permission to modify or
+		distribute the Program or its derivative works.  These actions are
+		prohibited by law if you do not accept this License.  Therefore, by
+		modifying or distributing the Program (or any work based on the
+		Program), you indicate your acceptance of this License to do so, and
+		all its terms and conditions for copying, distributing or modifying
+		the Program or works based on it.
+		
+		\item Each time you redistribute the Program (or any work based on the
+		Program), the recipient automatically receives a license from the
+		original licensor to copy, distribute or modify the Program subject to
+		these terms and conditions.  You may not impose any further
+		restrictions on the recipients' exercise of the rights granted herein.
+		You are not responsible for enforcing compliance by third parties to
+		this License.
+		
+		\item If, as a consequence of a court judgment or allegation of patent
+		infringement or for any other reason (not limited to patent issues),
+		conditions are imposed on you (whether by court order, agreement or
+		otherwise) that contradict the conditions of this License, they do not
+		excuse you from the conditions of this License.  If you cannot
+		distribute so as to satisfy simultaneously your obligations under this
+		License and any other pertinent obligations, then as a consequence you
+		may not distribute the Program at all.  For example, if a patent
+		license would not permit royalty-free redistribution of the Program by
+		all those who receive copies directly or indirectly through you, then
+		the only way you could satisfy both it and this License would be to
+		refrain entirely from distribution of the Program.
+		
+		If any portion of this section is held invalid or unenforceable under
+		any particular circumstance, the balance of the section is intended to
+		apply and the section as a whole is intended to apply in other
+		circumstances.
+		
+		It is not the purpose of this section to induce you to infringe any
+		patents or other property right claims or to contest validity of any
+		such claims; this section has the sole purpose of protecting the
+		integrity of the free software distribution system, which is
+		implemented by public license practices.  Many people have made
+		generous contributions to the wide range of software distributed
+		through that system in reliance on consistent application of that
+		system; it is up to the author/donor to decide if he or she is willing
+		to distribute software through any other system and a licensee cannot
+		impose that choice.
+		
+		This section is intended to make thoroughly clear what is believed to
+		be a consequence of the rest of this License.
+		
+		\item If the distribution and/or use of the Program is restricted in
+		certain countries either by patents or by copyrighted interfaces, the
+		original copyright holder who places the Program under this License
+		may add an explicit geographical distribution limitation excluding
+		those countries, so that distribution is permitted only in or among
+		countries not thus excluded.  In such case, this License incorporates
+		the limitation as if written in the body of this License.
+		
+		\item The Free Software Foundation may publish revised and/or new versions
+		of the General Public License from time to time.  Such new versions will
+		be similar in spirit to the present version, but may differ in detail to
+		address new problems or concerns.
+		
+		Each version is given a distinguishing version number.  If the Program
+		specifies a version number of this License which applies to it and ``any
+		later version'', you have the option of following the terms and conditions
+		either of that version or of any later version published by the Free
+		Software Foundation.  If the Program does not specify a version number of
+		this License, you may choose any version ever published by the Free Software
+		Foundation.
+		
+		\item If you wish to incorporate parts of the Program into other free
+		programs whose distribution conditions are different, write to the author
+		to ask for permission.  For software which is copyrighted by the Free
+		Software Foundation, write to the Free Software Foundation; we sometimes
+		make exceptions for this.  Our decision will be guided by the two goals
+		of preserving the free status of all derivatives of our free software and
+		of promoting the sharing and reuse of software generally.
+		
+	\end{enumerate}
+	
+	\subsection*{No warranty}
+	
+	BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+	FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT
+	WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER
+	PARTIES PROVIDE THE PROGRAM ``AS IS'' WITHOUT WARRANTY OF ANY KIND,
+	EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+	IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+	PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+	PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME
+	THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+	
+	IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+	WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+	REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR
+	DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+	DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM
+	(INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED
+	INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE
+	OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH
+	HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+	DAMAGES.
+	
 }
 \endinput


### PR DESCRIPTION
The French manual contains the text of the license GPL v3, while XCSoar is under GPL v2 (https://github.com/XCSoar/XCSoar/blob/master/COPYING), as properly mentioned in the English manual.
This PR adds the correct version of the GPL license (i.e. V2) to the French manual, with both the English (official) text and an unofficial translation in French.