### PR TITLE
Fix rendering of map scale in Pan mode (#234)

### DIFF
--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -271,10 +271,20 @@ void
 GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
                             const MapWindowProjection &projection) const
 {
-  RenderMapScale(canvas, projection, rc, look.overlay);
 
-  if (!projection.IsValid())
-    return;
+  PixelRect scaleRef(rc.left, rc.top, rc.right, rc.bottom);
+
+  /*
+    If buttons are drawn on bottom (Pan mode and portrait);
+    Change reference for rendering so scale is drawn above.
+  */
+  if (IsPanning() && !Layout::landscape)
+    scaleRef.bottom -= rc.GetHeight() / 6; // Scale factor as in MenuBar.cpp
+
+  RenderMapScale(canvas, projection, scaleRef, look.overlay);
+
+    if (!projection.IsValid())
+      return;
 
   StaticString<80> buffer;
 
@@ -327,6 +337,9 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     TextInBoxMode mode;
     mode.vertical_position = TextInBoxMode::VerticalPosition::ABOVE;
     mode.shape = LabelShape::OUTLINED;
+
+    if (IsPanning() && !Layout::landscape)
+      y -= rc.GetHeight() / 6; // Scale factor as in MenuBar.cpp
 
     TextInBox(canvas, buffer, 0, y, mode, rc, nullptr);
   }

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -42,6 +42,7 @@ Copyright_License {
 #include "Look/GestureLook.hpp"
 #include "Input/InputEvents.hpp"
 #include "Renderer/MapScaleRenderer.hpp"
+#include "Menu/MenuBar.hpp"
 
 #include <stdio.h>
 
@@ -278,8 +279,10 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     If buttons are drawn on bottom (Pan mode and portrait);
     Change reference for rendering so scale is drawn above.
   */
-  if (IsPanning() && !Layout::landscape)
-    scaleRef.bottom -= rc.GetHeight() / 6; // Scale factor as in MenuBar.cpp
+  if (IsPanning() && !Layout::landscape){
+    PixelRect barPos = GetButtonPosition(1, scaleRef);
+    scaleRef.bottom = barPos.top;
+  }
 
   RenderMapScale(canvas, projection, scaleRef, look.overlay);
 
@@ -332,16 +335,12 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     canvas.Select(font);
     const unsigned height = font.GetCapitalHeight()
         + Layout::GetTextPadding();
-    int y = rc.bottom - height;
 
     TextInBoxMode mode;
     mode.vertical_position = TextInBoxMode::VerticalPosition::ABOVE;
     mode.shape = LabelShape::OUTLINED;
 
-    if (IsPanning() && !Layout::landscape)
-      y -= rc.GetHeight() / 6; // Scale factor as in MenuBar.cpp
-
-    TextInBox(canvas, buffer, 0, y, mode, rc, nullptr);
+    TextInBox(canvas, buffer, 0, scaleRef.bottom - height, mode, rc, nullptr);
   }
 }
 

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -28,7 +28,7 @@ Copyright_License {
 #include <assert.h>
 
 gcc_pure
-static PixelRect
+PixelRect
 GetButtonPosition(unsigned i, PixelRect rc)
 {
   unsigned hwidth = rc.GetWidth(), hheight = rc.GetHeight();

--- a/src/Menu/MenuBar.hpp
+++ b/src/Menu/MenuBar.hpp
@@ -70,4 +70,6 @@ public:
   void OnResize(const PixelRect &rc);
 };
 
+PixelRect GetButtonPosition(unsigned i, PixelRect rc);
+
 #endif


### PR DESCRIPTION
Fixed issue #234. Map scale and mode indicator now render above the buttons when panning in portrait mode.