### PR TITLE
Vagrant debian10

### DIFF
--- a/doc/manual/en/developsetuplinux.tex
+++ b/doc/manual/en/developsetuplinux.tex
@@ -30,6 +30,7 @@ dependencies for various \xc target platforms.
 
 \begin{verbatim}
 cd ide/provisioning
+sudo ./add-debian-unstable.sh
 sudo ./install-debian-packages.sh
 ./install-android-tools.sh
 \end{verbatim}

--- a/ide/provisioning/add-debian-unstable.sh
+++ b/ide/provisioning/add-debian-unstable.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Adds stretch sources list to debian for jdk8 dependency
+echo 'deb http://deb.debian.org/debian stretch main' > /etc/apt/sources.list.d/unstable.list
+echo 'APT::Default-Release "stable";' > /etc/apt/apt.conf.d/99defaultrelease

--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -9,6 +9,7 @@ EOF
 
 sudo apt-get update
 
+sudo /xcsoar-host-src/ide/provisioning/add-debian-unstable.sh
 sudo /xcsoar-host-src/ide/provisioning/install-debian-packages.sh
 /xcsoar-host-src/ide/provisioning/install-android-tools.sh
 

--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -22,7 +22,7 @@ git remote add master https://github.com/XCSoar/XCSoar.git
 SCRIPT
 
 Vagrant.configure("2") do |config|
-    config.vm.box = "koalephant/debian9-amd64"
+    config.vm.box = "generic/debian10"
 
     config.vm.network "private_network", type: "dhcp"
     config.vm.synced_folder "../..", "/xcsoar-host-src"

--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -16,7 +16,7 @@ sudo /xcsoar-host-src/ide/provisioning/install-debian-packages.sh
 sudo apt-get clean
 
 cd
-git clone -o host /xcsoar-host-src xcsoar-src
+git clone --recurse-submodules -o host /xcsoar-host-src xcsoar-src
 cd xcsoar-src
 git remote add master https://github.com/XCSoar/XCSoar.git
 

--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -25,7 +25,6 @@ SCRIPT
 Vagrant.configure("2") do |config|
     config.vm.box = "generic/debian10"
 
-    config.vm.network "private_network", type: "dhcp"
     config.vm.synced_folder "../..", "/xcsoar-host-src"
 
     config.vm.provider "virtualbox" do |v|


### PR DESCRIPTION
This updates the vagrant box to debian-10. We are also switching to the generic box provider from vagrantup. These boxes are built by lavabit and the entire [process](https://github.com/lavabit/robox/blob/master/http/generic.debian10.vagrant.cfg) is here on github.
The boxes support all possible providers for vagrant, such as: virtualbox,hyperv,libvirt and even parallels on OSX.

The clone process also now initializes submodules without which a build would fail.

Fixes #292 

I'm not entierly happy about adding the repos in the vagrantfile. This should be a seperate script in ide/provisioning/setuprepos.sh or similar and should be references by both docker and vagrant.


