### PR TITLE
Read primary and secondary frequency from ACD to display in XCS infobox

### DIFF
--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -57,8 +57,38 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
       auto qnh = AtmosphericPressure::Pascal(value);
       info.settings.ProvideQNH(qnh, info.clock);
     }
+  } else if (StringIsEqual(type, "COM")) {
+    /*
+    $PAAVS,COM,<CHN1>,<CHN2>,<RXVOL1>,<RXVOL2>,<DWATCH>,<RX1>,<RX2>,<TX1>
+     <CHN1> Primary radio channel;
+            25kHz frequencies and 8.33kHz channels as unsigned integer
+            values between 118000 and 136990
+     <CHN2> Secondary radio channel;
+            25kHz frequencies and 8.33kHz channels as unsigned integer
+            values between 118000 and 136990
+     <RXVOL1> Primary radio channel volume (Unsigned integer values, 0–100)
+     <RXVOL2> Secondary radio channel volume (Unsigned integer values, 0–100)
+     <DWATCH> Dual watch mode (0 = off; 1 = on)
+     <RX1> Primary channel rx state (0 = no signal rec; 1 = signal rec)
+     <RX2> Secondary channel rx state (0 = no signal rec; 1 = signal rec)
+     <TX1> Transmit active (0 = no transmission; 1 = transmitting signal)
+     */
+    RadioFrequency freq;
+
+    if (line.ReadChecked(value)) {
+      freq.SetKiloHertz(value);
+      info.settings.active_frequency = freq;
+    }
+
+    if (line.ReadChecked(value)) {
+      freq.SetKiloHertz(value);
+      info.settings.standby_frequency = freq;
+    }
+
+    if (line.ReadChecked(value))
+      info.settings.volume = value;
   } else {
-    // ignore responses from COM and XPDR
+    // ignore responses from XPDR
     return false;
   }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1500,8 +1500,7 @@ TestACD()
   nmea_info.Reset();
   nmea_info.clock = 1;
 
-  /* $PAAVS responses from COM and XPDR must be ignored */
-  ok1(!device->ParseNMEA("$PAAVS,COM,118275,122550,50,50,1,0,0,0*30",nmea_info));
+  /* $PAAVS responses from XPDR must be ignored */
   ok1(!device->ParseNMEA("$PAAVS,XPDR,7000,1,0,1697,0,0*68",nmea_info));
 
   nmea_info.Reset();
@@ -1517,6 +1516,17 @@ TestACD()
   ok1(equals(nmea_info.baro_altitude, 457.33));
   ok1(nmea_info.settings.qnh_available);
   ok1(equals(nmea_info.settings.qnh.GetPascal(), 100500));
+
+  nmea_info.Reset();
+  nmea_info.clock = 1;
+
+  /* test COM response */
+  ok1(device->ParseNMEA("$PAAVS,COM,130330,122500,100,75,1,1,0,0*0D",
+                        nmea_info));
+
+  ok1(nmea_info.settings.active_frequency.GetKiloHertz() == 130330);
+  ok1(nmea_info.settings.standby_frequency.GetKiloHertz() == 122500);
+  ok1(equals(nmea_info.settings.volume, 100));
 
   delete device;
 }
@@ -1592,7 +1602,7 @@ TestFlightList(const struct DeviceRegister &driver)
 
 int main(int argc, char **argv)
 {
-  plan_tests(824);
+  plan_tests(827);
 
   TestGeneric();
   TestTasman();


### PR DESCRIPTION
As described in the title, this code change in the ACD driver makes use of the newest Infobox addition for the radio frequencies. 