### PR TITLE
Table of contents: Better font and layout (using package tocloft)

### DIFF
--- a/doc/manual/toc.tex
+++ b/doc/manual/toc.tex
@@ -1,7 +1,4 @@
 \begingroup
-\fontfamily{ptm}
-\normalsize
-\fontseries{c}\selectfont
-\setlength{\parskip}{0.05\baselineskip}
+\setlength{\cftsecnumwidth}{3em}
 \tableofcontents
 \endgroup


### PR DESCRIPTION
Using package tocloft (as suggested in PR #268, package introduced by PR #307).
Supersedes PR #268.

**Rationale:**

Even when the documents using the xcsoar.sty file where producing text in sans serif font (see PR #267), the titles in the table of content was in sans serif. For example: https://download.xcsoar.org/releases/6.8.11/XCSoar-manual.pdf .
Moreover, the section numbers were sometimes touching the section titles. 

With this PR, the titles in the table of contents uses the same font style (i.e. sans serif) as the rest of the document, and there is always a space between the section number and title.

Before:
![TOC-before](https://user-images.githubusercontent.com/6931104/65903073-09d7b880-e3bc-11e9-9112-fcbb845f9aaa.png)

After:
![TOC-after](https://user-images.githubusercontent.com/6931104/65903078-0cd2a900-e3bc-11e9-8d35-87118b481aa1.png)
