### PR TITLE
Update Flight Level infobox description

### DIFF
--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -53,7 +53,7 @@ sea level obtained from the terrain file at the current GPS location.}
 \ibi{Height above take-off}{H T/O}{Height based on an automatic take-off reference 
 elevation (like a QFE reference).\footnotemark[1]}
 \ibi{Flight level}{Flight Level}{Pressure Altitude given as Flight Level. 
-Only available if barometric altitude available and correct QNH set.\footnotemark[1]}
+If barometric altitude is not available, FL is calculated from GPS altitude, given that the correct QNH is set. In case the FL is calculated from the GPS altitude, the FL label is coloured red.\footnotemark[1]}
 \ibi{Barogram}{Barogram}{Trace of altitude during flight.}
 
 \footnotetext[1]{In simulator mode an additional dialogue is available to change the value 

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -772,7 +772,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Flight level"),
     N_("FL"),
-    N_("Pressure Altitude given as Flight Level. Only available if barometric altitude available and correct QNH set."),
+    N_("Pressure Altitude given as Flight Level. If barometric altitude is not available, FL is calculated from GPS altitude, given that the correct QNH is set. In case the FL is calculated from the GPS altitude, the FL label is coloured red."),
     UpdateInfoBoxAltitudeFlightLevel,
     altitude_infobox_panels,
   },


### PR DESCRIPTION
- Previous description implied that QNH needs to be set (this is not the case if barometric altitude is available -> if barometric altitude is available, the FL value is referenced to 1013 hPa)

- Description changed to take into account fallback FL calculation from GPS altitude (in this case the QNH does need to be set)

- Description changed to make user aware that red "FL" label indicates fallback GPS flight level calculation
