### PR TITLE
user controllable InfoBox to screen ratio

### DIFF
--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -684,6 +684,11 @@ angepaßt werden.
 \begin{description}
 \item[\textit{InfoBox Geometrie}]  Eine Auswahlliste von mehreren Anordnungen der InfoBox Seiten Je nach Gerät und persöhnlichem
 Geschmack muß dies schlicht ausprobiert werden. Die angebene Zahl entspricht der Anzahl der InfoBoxen auf der entsprechenden InfoBoxSeite.
+\item[\textit{InfoBox zu Screen Verhältnis}] Die Größe der InfoBox in X- oder Y-Richtung ist ein Bruchteil der Bildgröße in X oder Y.
+Mit diesem Parameter können Sie den Wert dieses Bruchteils wählen. Der Wert ist jedoch intern limitiert,
+damit die Mindestgröße nicht unterschritten wird. Eine allgemeine Regel: größere Zahlen geben dem Kartenfenster mehr Platz.
+Ein guter Standardwert ist 7,5 . Ändern Sie den Parameter so lange, bis Sie das richtige Verhältnis zwischen dem für die InfoBoxen
+zugewiesenen Platz auf dem Bildschirm und dem für die Karte zugewiesenen Platz auf dem Bildschirm gefunden haben.
 \item[\textit{FLARM Anzeige$^{\textcolor{blue}{\star}}$}]  \label{conf:flarmradar-place}
 Wen das \fl angeschaltet wird, kannst Du das kleine \fl Radar es hiermit an entsprechenden stellen einer InfoBoxSeite plazieren.
 Als Standard ist ein ''Auto''-Setup vorhanden, was bedeutet, daß das Radar lediglich die InfoBoxen

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -645,6 +645,13 @@ This page once more details the appearance of the graphical user interface of XC
 \item[InfoBox geometry]  A list of possible InfoBox layouts. Do some trials to find the 
   best for your screen size. The preceding number refer to the total number of 
   InfoBoxes of this geometry.
+\item[InfoBox to Screen ratio] The size of the InfoBox in X or Y direction is a fraction
+  of the screen size in X or Y. This parameter lets you choose the value of this fraction.
+  However, the value is constraint so that the minimum size requirement is not violated.
+  A general rule: larger numbers give more space to the Map Window.
+  A good default value is 7.5 .
+  Change the number until you find the right balance between the amount of screen space
+  allocated for the InfoBoxes vs. the mount of screen space allocated for the Map.
 \item[FLARM display*]  \label{conf:flarmradar-place}
   In case you enabled the FLARM display this is to configure the
   place on the screen, where the tiny radar window appears. As a default an `Auto' setup 

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -24,6 +24,7 @@ Copyright_License {
 #include "LayoutConfigPanel.hpp"
 #include "Profile/ProfileKeys.hpp"
 #include "Profile/Profile.hpp"
+#include "Form/DataField/Float.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"
@@ -45,6 +46,7 @@ Copyright_License {
 enum ControlIndex {
   MapOrientation,
   AppInfoBoxGeom,
+  AppInfoBoxScreenRatio,
   AppFlarmLocation,
   TabDialogStyle,
   AppStatusMessageAlignment,
@@ -180,6 +182,15 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
 
+  AddFloat(_("InfoBox to Screen ratio"),
+           _("The ratio of the InfoBox size to the screen size. "
+	     "Larger numbers give more space for the Map Window. "
+	     "Internally it is limmited to reasonable InfoBox sizes. "
+	     "A good choice is 7.5."),
+	   _T("%.2f %s"), _T("%.2f"),
+           6, 10, 0.25, false,
+           ui_settings.info_boxes.ib_to_screen_ratio);
+
   AddEnum(_("FLARM display"), _("Choose a location for the FLARM display."),
           flarm_display_location_list,
           (unsigned)ui_settings.traffic.gauge_location);
@@ -243,6 +254,10 @@ LayoutConfigPanel::Save(bool &_changed)
   info_box_geometry_changed |=
     SaveValueEnum(AppInfoBoxGeom, ProfileKeys::InfoBoxGeometry,
                   ui_settings.info_boxes.geometry);
+
+  info_box_geometry_changed |=
+    SaveValue(AppInfoBoxScreenRatio, ProfileKeys::InfoBoxScreenRatio,
+    		  ui_settings.info_boxes.ib_to_screen_ratio);
 
   info_box_geometry_changed |=
     SaveValueEnum(AppFlarmLocation, ProfileKeys::FlarmLocation,

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -22,11 +22,10 @@ Copyright_License {
 */
 
 #include "InfoBoxes/InfoBoxLayout.hpp"
+#include "Interface.hpp"
 #include "Border.hpp"
 #include "Util/Macros.hpp"
 #include "Util/Clamp.hpp"
-
-static constexpr double CONTROLHEIGHTRATIO = 7.4;
 
 /**
  * The number of info boxes in each geometry.
@@ -409,18 +408,22 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
   return geometry;
 }
 
-static constexpr unsigned
+static unsigned
 CalculateInfoBoxRowHeight(unsigned screen_height, unsigned control_width)
 {
-  return Clamp(unsigned(screen_height / CONTROLHEIGHTRATIO),
+  const double i2s = CommonInterface::GetUISettings().info_boxes.ib_to_screen_ratio;
+
+  return Clamp(unsigned(screen_height / i2s),
                control_width * 5 / 7,
                control_width);
 }
 
-static constexpr unsigned
+static unsigned
 CalculateInfoBoxColumnWidth(unsigned screen_width, unsigned control_height)
 {
-  return Clamp(unsigned(screen_width / CONTROLHEIGHTRATIO * 1.3),
+  const double i2s = CommonInterface::GetUISettings().info_boxes.ib_to_screen_ratio;
+
+  return Clamp(unsigned(screen_width / i2s * 1.3),
                control_height,
                control_height * 7 / 5);
 }

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -117,6 +117,8 @@ struct InfoBoxSettings {
 
   } geometry;
 
+  double ib_to_screen_ratio;
+
   bool inverse, use_colors;
 
   enum class BorderStyle : uint8_t {

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -123,6 +123,10 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
     break;
   }
 
+  map.Get(ProfileKeys::InfoBoxScreenRatio, settings.ib_to_screen_ratio);
+  if (settings.ib_to_screen_ratio < 5.99 || settings.ib_to_screen_ratio > 10.01)
+    settings.ib_to_screen_ratio = 7.4;
+
   map.Get(ProfileKeys::AppInverseInfoBox, settings.inverse);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);
 

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -215,6 +215,7 @@ const char FontTeamCodeFont[] = "TeamCodeFont";
 
 const char UseFinalGlideDisplayMode[] = "UseFinalGlideDisplayMode";
 const char InfoBoxGeometry[] = "InfoBoxGeometry";
+const char InfoBoxScreenRatio[] = "InfoBoxScreenRatio";
 
 const char FlarmSideData[] = "FlarmRadarSideData";
 const char FlarmAutoZoom[] = "FlarmRadarAutoZoom";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -213,6 +213,7 @@ extern const char FontTeamCodeFont[];
 extern const char UseFinalGlideDisplayMode[];
 
 extern const char InfoBoxGeometry[];
+extern const char InfoBoxScreenRatio[];
 
 extern const char FlarmSideData[];
 extern const char FlarmAutoZoom[];


### PR DESCRIPTION
Improve readability of InfoBoxes and still give maximum screen space to the Map

This feature makes the constant CONTROLHEIGHTRATIO in InfoBoxes/InfoBoxLayout.cpp user-accessible.
Previously it was set to 7.4 which doesn't always yield the optimal results in terms of trade-off between screen space for InfoBoxes vs. screen space for the Map.

(Previously filed as #311 which was closed)