### PR TITLE
user controllable InfoBox scaling

### DIFF
--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -684,6 +684,10 @@ angepaßt werden.
 \begin{description}
 \item[\textit{InfoBox Geometrie}]  Eine Auswahlliste von mehreren Anordnungen der InfoBox Seiten Je nach Gerät und persöhnlichem
 Geschmack muß dies schlicht ausprobiert werden. Die angebene Zahl entspricht der Anzahl der InfoBoxen auf der entsprechenden InfoBoxSeite.
+\item[\textit{InfoBox Grösse}] Die Größe der InfoBox in X- oder Y-Richtung als Prozentwert der normalen Größe.
+In der freien Richtung verschiebt sich die Grenze zwischen InfoBoxen und Kartenfenster.
+Bei sehr kleinen Werten kann, je nach Anzahl der InfoBoxen und Bildschirmorientierung, der Text in den InfoBoxen ineinander laufen.
+Voreinstellung ist 100% .
 \item[\textit{FLARM Anzeige$^{\textcolor{blue}{\star}}$}]  \label{conf:flarmradar-place}
 Wen das \fl angeschaltet wird, kannst Du das kleine \fl Radar es hiermit an entsprechenden stellen einer InfoBoxSeite plazieren.
 Als Standard ist ein ''Auto''-Setup vorhanden, was bedeutet, daß das Radar lediglich die InfoBoxen

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -645,6 +645,10 @@ This page once more details the appearance of the graphical user interface of XC
 \item[InfoBox geometry]  A list of possible InfoBox layouts. Do some trials to find the 
   best for your screen size. The preceding number refer to the total number of 
   InfoBoxes of this geometry.
+\item[InfoBox to Screen ratio] The size of the InfoBox in X or Y direction as a percentage of the normal size.
+In the free direction the border between InfoBoxes and map window moves.
+Depending on the number of InfoBoxes and screen orientation, very small values can make the text in the InfoBoxes hard to read.
+Default setting is 100% .
 \item[FLARM display*]  \label{conf:flarmradar-place}
   In case you enabled the FLARM display this is to configure the
   place on the screen, where the tiny radar window appears. As a default an `Auto' setup 

--- a/doc/manual/fr/ch11_configuration.tex
+++ b/doc/manual/fr/ch11_configuration.tex
@@ -411,6 +411,12 @@ Ce panel permet de personnaliser l'apparence graphique de l'interface utilisateu
 
 \begin{description}
 \item[Mise en page des InfoBoxes]  Une liste de mises en page possibles pour les InfoBoxes. Faites des essais pour trouver la meilleure pour votre taille d'écran et votre goût. Le premier chiffre donne le nombre d'InfoBoxes affichées.
+\item[Taille des InfoBoxes] 
+La taille de l'InfoBox dans la direction X ou Y en pourcentage de la taille normale.
+Dans la direction libre, la frontière entre les InfoBoxes et la fenêtre de carte se déplace.
+Avec de très petites valeurs, selon le nombre des InfoBoxes et l'orientation de l'écran,
+le texte dans les InfoBoxes peut se croiser.
+La valeur par défaut est 100% .
 \item[Affichage du FLARM*]  \label{conf:flarmradar-place}
 Si vous avez activé l'affichage du radar FLARM ceci permet de positionner sur l'écran, la petite fenêtre du radar. Par défaut le paramètre "Auto" permet de toujours superposer la fenêtre radar avec les InfoBoxes. Alors, la fenêtre radar ne se superpose avec la carte. 
 \item[Fenêtres à onglets]  Permet de choisir entre texte ou icône pour les onglets.

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -24,6 +24,7 @@ Copyright_License {
 #include "LayoutConfigPanel.hpp"
 #include "Profile/ProfileKeys.hpp"
 #include "Profile/Profile.hpp"
+#include "Form/DataField/Float.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"
@@ -45,6 +46,7 @@ Copyright_License {
 enum ControlIndex {
   MapOrientation,
   AppInfoBoxGeom,
+  AppInfoBoxScale,
   AppFlarmLocation,
   TabDialogStyle,
   AppStatusMessageAlignment,
@@ -180,6 +182,10 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
 
+  AddInteger(_("InfoBox size"), nullptr,
+               _T("%d %%"), _T("%d"), 50, 150, 5,
+           ui_settings.info_boxes.scale);
+
   AddEnum(_("FLARM display"), _("Choose a location for the FLARM display."),
           flarm_display_location_list,
           (unsigned)ui_settings.traffic.gauge_location);
@@ -243,6 +249,10 @@ LayoutConfigPanel::Save(bool &_changed)
   info_box_geometry_changed |=
     SaveValueEnum(AppInfoBoxGeom, ProfileKeys::InfoBoxGeometry,
                   ui_settings.info_boxes.geometry);
+
+  info_box_geometry_changed |=
+    SaveValue(AppInfoBoxScale, ProfileKeys::InfoBoxScale,
+    		  ui_settings.info_boxes.scale);
 
   info_box_geometry_changed |=
     SaveValueEnum(AppFlarmLocation, ProfileKeys::FlarmLocation,

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -24,7 +24,6 @@ Copyright_License {
 #include "LayoutConfigPanel.hpp"
 #include "Profile/ProfileKeys.hpp"
 #include "Profile/Profile.hpp"
-#include "Form/DataField/Float.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -411,7 +411,7 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
   return geometry;
 }
 
-static unsigned
+static constexpr unsigned
 CalculateInfoBoxRowHeight(unsigned screen_height, unsigned control_width, unsigned scale)
 {
   return Clamp(scale * control_width * 5 / 700,
@@ -419,7 +419,7 @@ CalculateInfoBoxRowHeight(unsigned screen_height, unsigned control_width, unsign
     scale * control_width * 5 / 700);
 }
 
-static unsigned
+static constexpr unsigned
 CalculateInfoBoxColumnWidth(unsigned screen_width, unsigned control_height, unsigned scale)
 {
   return (scale * control_height * 7 / 500);

--- a/src/InfoBoxes/InfoBoxLayout.hpp
+++ b/src/InfoBoxes/InfoBoxLayout.hpp
@@ -55,7 +55,7 @@ namespace InfoBoxLayout
 
   gcc_pure
   Layout
-  Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry);
+  Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry, unsigned ib_scale=100);
 
   gcc_const
   int

--- a/src/InfoBoxes/InfoBoxSettings.cpp
+++ b/src/InfoBoxes/InfoBoxSettings.cpp
@@ -56,6 +56,7 @@ InfoBoxSettings::SetDefaults()
   inverse = false;
   use_colors = true;
   border_style = BorderStyle::BOX;
+  scale = 100;
 
   for (unsigned i = 0; i < MAX_PANELS; ++i)
     panels[i].Clear();

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -117,6 +117,8 @@ struct InfoBoxSettings {
 
   } geometry;
 
+  unsigned scale; /* scales the size of the InfoBox in the free dimension between 50% and 150% */
+
   bool inverse, use_colors;
 
   enum class BorderStyle : uint8_t {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -219,7 +219,7 @@ MainWindow::InitialiseConfigured()
   PixelRect rc = GetClientRect();
 
   const InfoBoxLayout::Layout ib_layout =
-    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
+    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry, ui_settings.info_boxes.scale);
 
   assert(look != nullptr);
   look->InitialiseConfigured(CommonInterface::GetUISettings(),
@@ -339,7 +339,7 @@ MainWindow::ReinitialiseLayout()
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 
   const InfoBoxLayout::Layout ib_layout =
-    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
+    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry, ui_settings.info_boxes.scale);
 
   look->ReinitialiseLayout(ib_layout.control_size.cx);
 

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -25,6 +25,7 @@ Copyright_License {
 #include "ProfileKeys.hpp"
 #include "Map.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Util/Clamp.hpp"
 
 using namespace InfoBoxFactory;
 
@@ -122,6 +123,9 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
   case InfoBoxSettings::Geometry::TOP_8_VARIO:
     break;
   }
+
+  map.Get(ProfileKeys::InfoBoxScale, settings.scale);
+  settings.scale = Clamp((unsigned)settings.scale,(unsigned)50,(unsigned)150);
 
   map.Get(ProfileKeys::AppInverseInfoBox, settings.inverse);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -215,6 +215,7 @@ const char FontTeamCodeFont[] = "TeamCodeFont";
 
 const char UseFinalGlideDisplayMode[] = "UseFinalGlideDisplayMode";
 const char InfoBoxGeometry[] = "InfoBoxGeometry";
+const char InfoBoxScale[] = "InfoBoxSccale";
 
 const char FlarmSideData[] = "FlarmRadarSideData";
 const char FlarmAutoZoom[] = "FlarmRadarAutoZoom";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -213,6 +213,7 @@ extern const char FontTeamCodeFont[];
 extern const char UseFinalGlideDisplayMode[];
 
 extern const char InfoBoxGeometry[];
+extern const char InfoBoxScale[];
 
 extern const char FlarmSideData[];
 extern const char FlarmAutoZoom[];


### PR DESCRIPTION
Improve split between InfoBoxes and Map window

In essence, this replaces the constant CONTROLHEIGHTRATIO in InfoBoxes/InfoBoxLayout.cpp and introduces a config variable "InfoBox size" to control the free dimension of the InfoBox row.
Previously it was set to 7.4 which doesn't always yield the optimal results in terms of trade-off between screen space for InfoBoxes vs. screen space for the Map.
There is no "golden" value since it depends a lot on user preference and taste.
It may not be considered a big improvement, but to me it's worth while.

This PR is an improved version of #325 
It addresses the issues Max had flagged (I hope)
It makes it more intuitive to the user to pic the right choice for the InfoBox size.
