### PR TITLE
fix InfoBox geometry for square layout

### DIFF
--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -358,11 +358,8 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
     case InfoBoxSettings::Geometry::TOP_8_VARIO:
       return InfoBoxSettings::Geometry::LEFT_6_RIGHT_3_VARIO;
     }
-  } else if (screen_size.cx == screen_size.cy) {
-    /* square */
-    geometry = InfoBoxSettings::Geometry::RIGHT_5;
   } else {
-    /* portrait */
+    /* portrait and square */
 
     switch (geometry) {
     case InfoBoxSettings::Geometry::SPLIT_8:


### PR DESCRIPTION
Bugfix: it ignores the “InfoBox geometry” parameter when the screen is exactly square.
I eliminate the square case, which is now treated the same as portrait.
Observe the bug: running “xcsoar -square”, then resize the window to portrait or landscape. The square case has 5 InfoBoxes regardless of the “InfoBox geometry” setting.