### PR TITLE
WIP: Improve usabilty with hardware buttons as input device

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ The following people and organizations have contributed code to XCSoar:
  Peter F Bradshaw <pfb@exadios.com>
  Stefan Schumann <stefan.schumann@posteo.de>
  Roel Baardman <roel.baardman@gmail.com>
+ Fabian Bartschke <fabian@bartschke.de>
 
 Documentation:
 

--- a/src/Form/Button.cpp
+++ b/src/Form/Button.cpp
@@ -239,7 +239,7 @@ Button::OnPaint(Canvas &canvas)
 
   const bool pressed = down;
   const bool focused = HasCursorKeys()
-    ? HasFocus() || (selected && !HasPointer())
+    ? HasFocus() || selected
     : pressed;
 
   renderer->DrawButton(canvas, GetClientRect(),

--- a/src/Form/Button.hpp
+++ b/src/Form/Button.hpp
@@ -47,9 +47,8 @@ class Button : public PaintWindow {
   /**
    * This flag specifies whether the button is "selected".  The
    * "selected" button in a #ButtonPanel is the button that will be
-   * triggered by the #KEY_RETURN.  On some devices without touch
-   * screen, cursor keys left/right can be used to navigate the
-   * #ButtonPanel.
+   * triggered by the #KEY_RETURN. Cursor keys left/right can be used to
+   * navigate the #ButtonPanel.
    */
   bool selected;
 

--- a/src/Form/ButtonPanel.cpp
+++ b/src/Form/ButtonPanel.cpp
@@ -348,7 +348,7 @@ ButtonPanel::KeyPress(unsigned key_code)
     }
   }
 
-  if (selected_index >= 0 && !HasPointer()) {
+  if (selected_index >= 0) {
     if (key_code == KEY_LEFT) {
       SelectPrevious();
       return true;

--- a/src/Form/List.cpp
+++ b/src/Form/List.cpp
@@ -437,6 +437,7 @@ ListControl::OnKeyDown(unsigned key_code)
 
   switch (key_code) {
   case KEY_RETURN:
+    return false; // TODO: do not keep this!
     if (CanActivateItem())
       ActivateItem();
     return true;

--- a/src/Gauge/BigTrafficWidget.cpp
+++ b/src/Gauge/BigTrafficWidget.cpp
@@ -763,16 +763,10 @@ FlarmTrafficControl::OnKeyDown(unsigned key_code)
 {
   switch (key_code) {
   case KEY_UP:
-    if (!HasPointer())
-      break;
-
     ZoomIn();
     return true;
 
   case KEY_DOWN:
-    if (!HasPointer())
-      break;
-
     ZoomOut();
     return true;
   }


### PR DESCRIPTION
developer manual 7.2.4 Usability:
> Ensure all dialogs are navigable using cursor keys only

On the PC version, I simulated things I would like to do in flight using a stick remote control.

At the moment there are lots of things that should be possible using only arrow keys, Return and ESC but do not work at the moment.

I hope to get some ideas and feedback from other users/developers about this. 

(incomplete) list of actions
* alternates dialog
* waypoint dialog
* Task editor: Swap waypoints
* interacting with infoboxes (#172, #191)
* FlarmTrafficWindow: <, >, Details (zooming works)