### PR TITLE
Fix several bugs related to KRT2 remote control

### DIFF
--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -346,7 +346,7 @@ void ActionInterface::OffsetActiveFrequency(double offset_khz, bool to_devices)
 {
   RadioFrequency new_active_freq = SetComputerSettings().radio.active_frequency;
   if(new_active_freq.IsDefined()) {
-    new_active_freq.SetKiloHertz(new_active_freq.GetKiloHertz() + offset_khz);
+    new_active_freq.OffsetKiloHertz(offset_khz);
     if(new_active_freq.IsDefined()) {
       ActionInterface::SetActiveFrequency(new_active_freq, nullptr, to_devices);
     }
@@ -357,9 +357,20 @@ void ActionInterface::OffsetStandbyFrequency(double offset_khz, bool to_devices)
 {
   RadioFrequency new_standby_freq = SetComputerSettings().radio.standby_frequency;
   if(new_standby_freq.IsDefined()) {
-    new_standby_freq.SetKiloHertz(new_standby_freq.GetKiloHertz() + offset_khz);
+    new_standby_freq.OffsetKiloHertz(offset_khz);
     if(new_standby_freq.IsDefined()) {
       ActionInterface::SetStandbyFrequency(new_standby_freq, nullptr, to_devices);
     }
   }
+}
+
+void ActionInterface::ExchangeRadioFrequencies(bool to_devices)
+{
+  const auto radio_settings = SetComputerSettings().radio;
+
+  const auto old_active_freq = radio_settings.active_frequency;
+  const auto old_active_freq_name = radio_settings.active_name;
+
+  ActionInterface::SetActiveFrequency(radio_settings.standby_frequency, radio_settings.standby_name, to_devices);
+  ActionInterface::SetStandbyFrequency(old_active_freq, old_active_freq_name, to_devices);
 }

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -132,6 +132,12 @@ namespace ActionInterface {
    * forward it to all XCSoar modules that want it.
    */
   void OffsetStandbyFrequency(double offset_khz, bool to_devices=true);
+
+  /**
+   * Exchange the Active and Standby Radio Frequencies in #ComputerSettings, and
+   * forward them to all XCSoar modules that want it.
+   */
+  void ExchangeRadioFrequencies(bool to_devices=true);
 };
 
 /** 

--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -143,14 +143,25 @@ RadioProcess()
 
   const NMEAInfo &basic = CommonInterface::Basic();
 
-  if (basic.settings.active_frequency.IsDefined()) {
+  static Validity last_active_frequency;
+  static Validity last_standby_frequency;
+  static Validity last_swap_frequencies;
+
+  if (basic.settings.has_active_frequency.Modified(last_active_frequency)) {
     ActionInterface::SetActiveFrequency(basic.settings.active_frequency, basic.settings.active_freq_name, false);
+    last_active_frequency = basic.settings.has_active_frequency;
     modified = true;
   }
 
-  if (basic.settings.standby_frequency.IsDefined()) {
+  if (basic.settings.has_standby_frequency.Modified(last_standby_frequency)) {
     ActionInterface::SetStandbyFrequency(basic.settings.standby_frequency, basic.settings.standby_freq_name, false);
+    last_standby_frequency = basic.settings.has_standby_frequency;
     modified = true;
+  }
+
+  if (basic.settings.swap_frequencies.Modified(last_swap_frequencies)) {
+    ActionInterface::ExchangeRadioFrequencies(false);
+    last_swap_frequencies = basic.settings.swap_frequencies;
   }
 
   return modified;

--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -33,10 +33,13 @@ ExternalSettings::Clear()
   bugs_available.Clear();
   qnh_available.Clear();
   volume_available.Clear();
+  has_active_frequency.Clear();
   active_frequency.Clear();
-  standby_frequency.Clear();
   active_freq_name.clear();
+  has_standby_frequency.Clear();
+  standby_frequency.Clear();
   standby_freq_name.clear();
+  swap_frequencies.Clear();
 }
 
 void
@@ -84,14 +87,22 @@ ExternalSettings::Complement(const ExternalSettings &add)
     volume_available = add.volume_available;
   }
 
-  if (add.active_frequency.IsDefined()) {
+  if (add.has_active_frequency.Modified(has_active_frequency) &&
+      add.active_frequency.IsDefined()) {
+    has_active_frequency = add.has_active_frequency;
     active_frequency = add.active_frequency;
     active_freq_name = add.active_freq_name;
   }
 
-  if (add.standby_frequency.IsDefined()) {
+  if (add.has_standby_frequency.Modified(has_standby_frequency) &&
+      add.standby_frequency.IsDefined()) {
+    has_standby_frequency = add.has_standby_frequency;
     standby_frequency = add.standby_frequency;
     standby_freq_name = add.standby_freq_name;
+  }
+
+  if (add.swap_frequencies.Modified(swap_frequencies)) {
+    swap_frequencies = add.swap_frequencies;
   }
 }
 

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -75,10 +75,15 @@ struct ExternalSettings {
   unsigned volume;
 
   /** the radio frequencies of the device */
+  Validity has_active_frequency;
   RadioFrequency active_frequency;
-  RadioFrequency standby_frequency;
   StaticString<32> active_freq_name;
+
+  Validity has_standby_frequency;
+  RadioFrequency standby_frequency;
   StaticString<32> standby_freq_name;
+
+  Validity swap_frequencies;
 
   void Clear();
   void Expire(double time);

--- a/src/RadioFrequency.hpp
+++ b/src/RadioFrequency.hpp
@@ -31,6 +31,8 @@ Copyright_License {
 #include <stddef.h>
 #include <tchar.h>
 
+#include <cmath>
+
 /**
  * This class tores a VHF radio frequency.
  */
@@ -44,6 +46,15 @@ class RadioFrequency {
   uint16_t value;
 
   constexpr RadioFrequency(unsigned _value):value(_value) {}
+
+  /**
+   * When 8.33kHz channels are used, channels are rounded to the nearest
+   * 5kHz value for display purposes. Some channels are undefined because
+   * of this. They are matched by the pattern below.
+   */
+  constexpr static bool IsValid8KHzChannel(unsigned khz) {
+    return (khz % 25) != 20;
+  }
 
 public:
   /**
@@ -87,6 +98,13 @@ public:
       : 0;
   }
 
+  void OffsetKiloHertz(int khz_offset) {
+    unsigned new_khz = GetKiloHertz() + khz_offset;
+    if (!IsValid8KHzChannel(new_khz)) {
+      new_khz += std::copysign(5, khz_offset);
+    }
+    SetKiloHertz(new_khz);
+  }
   TCHAR *Format(TCHAR *buffer, size_t max_size) const;
 
   gcc_pure


### PR DESCRIPTION
- Fix a bug where the frequency is re-set to a previous value after using the infobox to change it.
- Enable exchanging of frequencies from the KRT2
- Fix offsetting of frequencies, skip invalid 8.33kHz channels
- Clamp MHz values in KRT2 driver to values specified in the KRT2 user manual