### PR TITLE
Android: Aspect Ratio Fix

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -24,6 +24,8 @@
 		 android:resource="@xml/accessory_filter" />
       <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                  android:resource="@xml/usb_device_filter" />
+      <meta-data android:name="android.max_aspect"
+                 android:value="ratio_float"/>
     </activity>
 
     <service android:name=".MyService"/>


### PR DESCRIPTION
Currently on Android devices with aspect ratio's greater than 16:9, XCSoar does not use the full screen and instead will leave a black bar of unused space at the bottom.

As per this documentation, this should ensure the UI scales to fit the full screen:

https://android-developers.googleblog.com/2017/03/update-your-app-to-take-advantage-of.html

Note: I've been unable to test so this fix is speculative.