### PR TITLE
Include – (minus sign) as a legal character in the parser for xci files.

### DIFF
--- a/src/Input/InputParser.cpp
+++ b/src/Input/InputParser.cpp
@@ -215,7 +215,7 @@ ParseInputFile(InputConfig &config, TLineReader &reader)
           } else {
           #endif
 
-          ef = _stscanf(value, _T("%[^ ] %[A-Za-z0-9_ \\/().,]"), d_event,
+          ef = _stscanf(value, _T("%[^ ] %[A-Za-z0-9_ \\/().,\-]"), d_event,
               d_misc);
 
           #if defined(__BORLANDC__)


### PR DESCRIPTION
If the ‘-’ charter is not included, then strings are cut off at the position of the ‘-’ charter.

This affects for instance the following line in an xci file:
event=SendNMEAPort1 POV,C,RPO,0.000803,-0.009729,0.240054
It cuts off at this position ---------------------^