### PR TITLE
Panmode map scale render fix

### DIFF
--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -58,6 +58,8 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "IO/LineReader.hpp"
 #include "Pan.hpp"
 #include "Dialogs/LockScreen.hpp"
+#include "Menu/MenuBar.hpp"
+#include "MapWindow/GlueMapWindow.hpp"
 
 #ifdef KOBO
 #include "Event/KeyCode.hpp"
@@ -198,6 +200,16 @@ InputEvents::drawButtons(Mode mode, bool full)
     : NULL;
 
   ButtonLabel::Set(menu, overlay_menu, full);
+
+  GlueMapWindow *map = CommonInterface::main_window->GetMapIfActive();
+  if (map != nullptr){
+      if (mode != MODE_DEFAULT){
+          // Set margin so that GlueMapWindow doesn't draw HUD underneath buttons
+          map->SetBottomMargin(menubar_height_scale_factor);
+      } else {
+          map->SetBottomMargin(0);
+      }
+  }
 }
 
 InputEvents::Mode
@@ -484,5 +496,5 @@ InputEvents::ProcessTimer()
 void
 InputEvents::eventLockScreen(const TCHAR *mode)
 {
-  ShowLockBox();  
+  ShowLockBox();
 }

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -106,6 +106,11 @@ class GlueMapWindow : public MapWindow {
 
   OffsetHistory offset_history;
 
+  /*
+   * Area of the map where no HUD items should be drawn
+   */
+  unsigned int bottom_margin = 0;
+
 #ifndef ENABLE_OPENGL
   /**
    * This mutex protects the attributes that are read by the
@@ -147,6 +152,7 @@ public:
   void SetMapSettings(const MapSettings &new_value);
   void SetComputerSettings(const ComputerSettings &new_value);
   void SetUIState(const UIState &new_value);
+  void SetBottomMargin(unsigned int margin);
 
   /**
    * Update the blackboard from DeviceBlackboard and

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -267,11 +267,37 @@ GlueMapWindow::DrawVario(Canvas &canvas, const PixelRect &rc) const
                                 true); //NOTE: AVG enabled for now, make it configurable ;
 }
 
+/*
+    Sets a relative margin at the bottom of the screen where no HUD
+    elements should be drawn
+*/
+void
+GlueMapWindow::SetBottomMargin(unsigned int margin_factor){
+
+    if (margin_factor == 0){
+        bottom_margin = 0;
+        QuickRedraw();
+        return;
+    }
+
+    PixelRect map_rect = GetClientRect();
+
+    if (map_rect.GetHeight() > map_rect.GetWidth()){
+        bottom_margin = map_rect.bottom / margin_factor;
+    } else {
+        bottom_margin = 0;
+    }
+    QuickRedraw();
+}
+
 void
 GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
                             const MapWindowProjection &projection) const
 {
-  RenderMapScale(canvas, projection, rc, look.overlay);
+
+  PixelRect scale_pos(rc.left, rc.top, rc.right, rc.bottom - bottom_margin);
+
+  RenderMapScale(canvas, projection, scale_pos, look.overlay);
 
   if (!projection.IsValid())
     return;
@@ -322,7 +348,7 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     canvas.Select(font);
     const unsigned height = font.GetCapitalHeight()
         + Layout::GetTextPadding();
-    int y = rc.bottom - height;
+    int y = scale_pos.bottom - height;
 
     TextInBoxMode mode;
     mode.vertical_position = TextInBoxMode::VerticalPosition::ABOVE;

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -36,7 +36,7 @@ GetButtonPosition(unsigned i, PixelRect rc)
   if (hheight > hwidth) {
     // portrait
 
-    hheight /= 6;
+    hheight /= menubar_height_scale_factor;
 
     if (i == 0) {
       rc.left = rc.right;

--- a/src/Menu/MenuBar.hpp
+++ b/src/Menu/MenuBar.hpp
@@ -28,6 +28,11 @@ Copyright_License {
 
 #include <tchar.h>
 
+/*
+    Menubar button height as a fraction of the screen height
+*/
+static constexpr unsigned menubar_height_scale_factor = 6;
+
 class ContainerWindow;
 
 /**


### PR DESCRIPTION
Second attempt at fixing issue #234. (Previous was PR #289 )

Added `GlueMapWindow::SetBottomMargin(unsigned int)` to be called whenever buttons are drawn (happens in `InputEvents::drawButtons(...)` ), so that `GlueMapWindow::DrawMapScale(..)` can avoid drawing in that area when in portrait mode.

Calling  `GlueMapWindow::SetBottomMargin(unsigned int)` triggers `QuickRedraw()`