### PR TITLE
Multiply rotation (if there is one) with projection_matrix in OpenGL software rotation

### DIFF
--- a/src/Screen/OpenGL/Init.cpp
+++ b/src/Screen/OpenGL/Init.cpp
@@ -327,7 +327,7 @@ OpenGL::SetupViewport(UnsignedPoint2D size)
                                   glm::vec3(0, 0, 1));
   OrientationSwap(size, display_orientation);
 #endif
-  projection_matrix = glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
+  projection_matrix *= glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
   UpdateShaderProjectionMatrix();
 
   viewport_size = size;


### PR DESCRIPTION
This solves issue #351.

Tested on TARGET=UNIX OPENGL=y, as discussed in issue #351.