### PR TITLE
Driver/LX: Add support for LX7000 Pro IGC

### DIFF
--- a/src/Device/Driver/LX/Convert.cpp
+++ b/src/Device/Driver/LX/Convert.cpp
@@ -252,23 +252,34 @@ LX::ConvertLXNToIGC(const void *_data, size_t _length,
 
     case LXN::SECURITY_7000:
       data += sizeof(*packet.security_7000);
-      if (data > end ||
-          packet.security_7000->x40 != 0x40)
+      if (data > end)
         return false;
 
-      fprintf(file, "G3");
-      for (auto ch : packet.security_7000->line1)
-        fprintf(file, "%02X", ch);
+      if (packet.security_7000->x40 == 0x12) {
+        fprintf(file, "G3");
+        for (unsigned i = 0; i < 20; ++i)
+          fprintf(file, "%02X", packet.security_7000->line1[i]);
 
-      fprintf(file, "\r\nG");
-      for (auto ch : packet.security_7000->line2)
-        fprintf(file, "%02X", ch);
+        fprintf(file, "\r\n");
+      }
+      else if (packet.security_7000->x40 == 0x40) {
+        fprintf(file, "G3");
+        for (auto ch : packet.security_7000->line1)
+          fprintf(file, "%02X", ch);
 
-      fprintf(file, "\r\nG");
-      for (auto ch : packet.security_7000->line3)
-        fprintf(file, "%02X", ch);
+        fprintf(file, "\r\nG");
+        for (auto ch : packet.security_7000->line2)
+          fprintf(file, "%02X", ch);
 
-      fprintf(file, "\r\n");
+        fprintf(file, "\r\nG");
+        for (auto ch : packet.security_7000->line3)
+          fprintf(file, "%02X", ch);
+
+        fprintf(file, "\r\n");
+      }
+      else
+        fprintf(file, "GSECURITY_NOT_CONVERTED\r\n");
+
       break;
 
     case LXN::COMPETITION_CLASS:


### PR DESCRIPTION
Currently it is not possible to download flights from GNSS FR LX7000 Pro IGC, firmware 2.05.
XCSoar doesn't support G-record format produced by this device in its LXN data.
Conversion of LXN data to IGC file fails.

Unfortunately it is unable to find any LXN format/protocol specification.

New behavior:
When converting downloaded flight from internal LXN format to IGC format for mentioned above device
this commit allows to convert G-record with not only magic number 0x41 but also with magic number 0x12.
It seems, the encrypted data is shorter in case of magic 0x12 then in case of magic 0x41.
Perhaps another type of cipher?
Patch behavior was verified by comparison between IGC file downloaded by SeeYou an IGC file downloaded by patched XCSoar.
Final G-record is the same for SeeYou and PR of XCSoar IGC files.
Unsuported magic numbers (other then 0x40, 0x12) allows download of IGC file, but with invalid G-record now.

Signed-off-by: Vaclav Svoboda <svoboda@neng.cz>