### PR TITLE
Fix software display rotation (again)

### DIFF
--- a/src/Screen/OpenGL/Init.cpp
+++ b/src/Screen/OpenGL/Init.cpp
@@ -322,12 +322,19 @@ OpenGL::SetupViewport(UnsignedPoint2D size)
   glViewport(0, 0, size.x, size.y);
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
-  projection_matrix = glm::rotate(glm::mat4(1),
-                                  (GLfloat)Angle::Degrees(OrientationToRotation(display_orientation)).Radians(),
-                                  glm::vec3(0, 0, 1));
   OrientationSwap(size, display_orientation);
 #endif
+
   projection_matrix = glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
+
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  glm::mat4 rot_matrix = glm::rotate(
+    glm::mat4(1),
+    (GLfloat)Angle::Degrees(OrientationToRotation(display_orientation)).Radians(),
+    glm::vec3(0, 0, 1));
+  projection_matrix = rot_matrix * projection_matrix;
+#endif
+
   UpdateShaderProjectionMatrix();
 
   viewport_size = size;


### PR DESCRIPTION
Initial fix (8bd49afa25e112f3d5f377dfa1ad72656effc35d) caused rendering problems (black screen) on platforms in which `SOFTWARE_ROTATE_DISPLAY` is not defined (e.g. Android). It was reverted in 6ef5768a073f7fd07442dc6f897f4fe7220d460e.

Tested on Android, but was reproducible on regular UNIX as well. The problem with original `projection_matrix *= glm::ortho` fix is that `projection_matrix` is initialized with zero matrix.

Fixes #351.