### PR TITLE
new 12 InfoBox layout: 4 boxes X 3 rows

### DIFF
--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -78,6 +78,8 @@ static constexpr StaticEnumChoice info_box_geometry_list[] = {
     N_("8 Split") },
   { (unsigned)InfoBoxSettings::Geometry::SPLIT_10,
     N_("10 Split") },
+  { (unsigned)InfoBoxSettings::Geometry::SPLIT_3X4,
+    N_("12 Split in 3 rows") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_RIGHT_8,
     N_("8 Bottom or Right") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_8_VARIO,

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -121,6 +121,8 @@ struct InfoBoxSettings {
     BOTTOM_RIGHT_10 = 22,
     /** 10 infoboxes split bottom/top or left/right */
     SPLIT_10 = 23,
+    /** 12 infoboxes 3X4 split bottom/top or left/right */
+    SPLIT_3X4 = 24,
 
   } geometry;
 

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -77,6 +77,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
   switch (settings.geometry) {
   case InfoBoxSettings::Geometry::SPLIT_8:
   case InfoBoxSettings::Geometry::SPLIT_10:
+  case InfoBoxSettings::Geometry::SPLIT_3X4:
   case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
   case InfoBoxSettings::Geometry::TOP_LEFT_8:
     break;


### PR DESCRIPTION
This layout of 12 InfoBoxes is meant to support tall and narrow displays.
It makes the boxes wider to allow bigger fonts. Taller screens can afford
more space for InfoBoxes without compromising the map area.
The intention is to improve readability of InfoBox title, comment and value.
in particular on tall and narrow displays with more than 10 InfoBoxes.