### PR TITLE
extending the NMEA protocol and reducing the traffic over the port

### DIFF
--- a/src/Device/Driver/OpenVario.cpp
+++ b/src/Device/Driver/OpenVario.cpp
@@ -183,6 +183,13 @@ OpenVarioDevice::OnCalculatedUpdate(const MoreData &basic,
 
   PutIdealPolar(calculated, env);
   PutRealPolar(calculated, env);
+
+  if (!_mc_valid) {
+    // this is the MacCready at start up
+    _mc = calculated.glide_polar_safety.GetMC();
+    _mc_valid = true;
+    RepeatMacCready(env);
+    }
 }
 
 bool
@@ -290,10 +297,10 @@ OpenVarioDevice::POV(NMEAInputLine &line, NMEAInfo &info)
         if (strlen(query_item) == 0) return true;
 
         if (StringIsEqual(query_item,"WL")) RepeatBallast(env);
-        if (StringIsEqual(query_item,"BU")) RepeatBugs(env);
-        if (StringIsEqual(query_item,"MC")) RepeatMacCready(env);
-        if (StringIsEqual(query_item,"IPO")) RepeatIdealPolar(env);
-        if (StringIsEqual(query_item,"RPO")) RepeatRealPolar(env);
+        else if (StringIsEqual(query_item,"BU")) RepeatBugs(env);
+        else if (StringIsEqual(query_item,"MC")) RepeatMacCready(env);
+        else if (StringIsEqual(query_item,"IPO")) RepeatIdealPolar(env);
+        else if (StringIsEqual(query_item,"RPO")) RepeatRealPolar(env);
       }
       return false;
     }


### PR DESCRIPTION
There are 2 changes to the protocol, which are covered in the restructuring:

1.
I have created a mechanism for the connected device (e.g. variod)
to read the relevant current settings of XCSoar (MacCready, wing load,
polar, polar degradation). The connected device responds with these settings.
The connected device can do this at any time, especially upon restart
to sync up with XCSoar’s settings.

In case the requested setting is not available, e.g. the Pilot has not yet
set the Ballast, then the request will be answered with a "POV,C,NA,xx" sentence
where "xx" indicates the value.

2.
Since there is no method like "PutPolar" in class Device, I
continue to use OnCalculatedUpdate to transfer the polar data,
only that I check whether the coefficients have changed.
If not, then no string is sent.

The previous implementation of the OpenVario driver produced 2 polar
string (ideal polar, real polar) every time OnCalculatedUpdate() is called.
At a minimum this happens for every GPS position XCSoar receives.
So it easily sends out 4 polar strings per second, even though nothing has
changed in these polars for a while. So the change to address this is to
check if the polar information has changed before it is sends it out.
As a result polar strings are sent only when needed.

A detailed documentation of the NMEA protocol will be in the OpenVario Documentation.