### PR TITLE
Renderer: New waypoint display: GR + arrival alt

### DIFF
--- a/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
@@ -118,6 +118,10 @@ WaypointDisplayConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc
          "Requires \"Reach mode: Turning\" in \"Glide Computer > Route\" settings.") },
     { (unsigned)WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR,
       N_("Required glide ratio") },
+    { (unsigned)WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR_AND_TERRAIN,
+      N_("Required GR & terrain glide"),
+      N_("Both Required glide ratio and terrain avoidance height are displayed. "
+         "Requires \"Reach mode: Turning\" in \"Glide Computer > Route\" settings.") },
     { 0 }
   };
 

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -225,7 +225,8 @@ protected:
     if (!way_point.IsLandable() && !way_point.flags.watched)
       return;
 
-    if (settings.arrival_height_display == WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR) {
+    if (settings.arrival_height_display == WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR ||
+        settings.arrival_height_display == WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR_AND_TERRAIN) {
       if (!basic.location_available || !basic.NavAltitudeAvailable())
         return;
 
@@ -244,6 +245,15 @@ protected:
       size_t length = _tcslen(buffer);
       if (length > 0)
         buffer[length++] = _T(':');
+
+      if (settings.arrival_height_display == WaypointRendererSettings::ArrivalHeightDisplay::REQUIRED_GR_AND_TERRAIN &&
+         reach.IsReachableTerrain()) {
+          int uah_terrain = (int)Units::ToUserAltitude(reach.terrain);
+          StringFormatUnsafe(buffer + length, _T("%.1f/%d%s"), (double) gr,
+                            uah_terrain, altitude_unit);
+          return;
+         }
+
       StringFormatUnsafe(buffer + length, _T("%.1f"), (double) gr);
       return;
     }

--- a/src/Renderer/WaypointRendererSettings.hpp
+++ b/src/Renderer/WaypointRendererSettings.hpp
@@ -48,6 +48,7 @@ struct WaypointRendererSettings {
     TERRAIN,
     GLIDE_AND_TERRAIN,
     REQUIRED_GR,
+    REQUIRED_GR_AND_TERRAIN,
   } arrival_height_display;
 
   /** What type of waypoint labels to render */


### PR DESCRIPTION
This patch adds an additional mode for the display of “Arrival height” at a
waypoint, comprising both geometrical Glide Ratio and arrival altitude around
terrain.

Motivation: I find it safer to make my in-flight navigation decisions based
on GR (eg I decide not to go further than GR 20 from the closest landable on
a glider with theoretical L/D of 40), but the arrival altitude adds
confidence. In the current version it’s one or the other, this patch adds an
entry “Required GR & terrain glide” to the existing “None / Straight glide /
Terrain avoidance glide / Straight & terrain glide / Required glide ratio”

Files updated:

src\Renderer\WaypointRendererSettings.hpp
- Addition of REQUIRED_GR_AND_TERRAIN to  class ArrivalHeightDisplay

src\Renderer\WaypointRenderer.cpp
- Addition of code to process REQUIRED_GR_AND_TERRAIN to FormatLabel
- if reach.IsReachableTerrain then display GR and uah_terrain, else only
  display GR (nothing displayed if below waypoint)

src\Dialogs\Settings\Panels\WaypointDisplayConfigPanel.cpp
- addition of config menu entry for new setting (used GR abbreviation
  to keep string shorter)

Closes #383