### PR TITLE
Make Waypoint Details downloadable via download dialog

### DIFF
--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -102,7 +102,8 @@ SiteConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
   AddFile(_("Waypoint details"),
           _("The file may contain extracts from enroute supplements or other contributed "
             "information about individual waypoints and airfields."),
-          ProfileKeys::AirfieldFile, _T("*.txt\0"));
+          ProfileKeys::AirfieldFile, _T("*.txt\0"),
+          FileType::WAYPOINTDETAILS);
   SetExpertRow(AirfieldFile);
 
   AddFile(_("FLARM Device Database"),

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -30,6 +30,7 @@ enum class FileType : uint8_t {
   UNKNOWN,
   AIRSPACE,
   WAYPOINT,
+  WAYPOINTDETAILS,
   MAP,
   FLARMNET,
 };

--- a/src/Repository/Parser.cpp
+++ b/src/Repository/Parser.cpp
@@ -90,6 +90,8 @@ ParseFileRepository(FileRepository &repository, NLineReader &reader)
     } else if (StringIsEqual(name, "type")) {
       if (StringIsEqual(value, "airspace"))
         file.type = FileType::AIRSPACE;
+      else if (StringIsEqual(value, "waypoint-details"))
+        file.type = FileType::WAYPOINTDETAILS;
       else if (StringIsEqual(value, "waypoint"))
         file.type = FileType::WAYPOINT;
       else if (StringIsEqual(value, "map"))


### PR DESCRIPTION
This adds an additional file type to the repository parser for waypoint-details files. As this type is now known, the file picker now shows the Download button for the waypoint-details list.