### PR TITLE
request all permissions without manual restarts #377

### DIFF
--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -223,14 +223,16 @@ public class XCSoar extends Activity {
     ImmersiveFullScreenMode.enable(getWindow().getDecorView());
   }
 
-  private void checkRequestPermission(String permission) {
-    if (checkSelfPermission(permission) != PackageManager.PERMISSION_GRANTED) {
-      try {
-        this.requestPermissions(new String[]{permission}, 0);
-      } catch (Exception e) {
-        Log.e(TAG, "requestPermissions(" + permission + ") failed", e);
+  private final String[] NEEDED_PERMISSIONS = new String[] {Manifest.permission.ACCESS_FINE_LOCATION,
+                                                            Manifest.permission.WRITE_EXTERNAL_STORAGE};
+  private boolean hasAllPermissions() {
+    for (String p : NEEDED_PERMISSIONS) {
+      if (checkSelfPermission(p) != PackageManager.PERMISSION_GRANTED) {
+        return false;
       }
     }
+
+    return true;
   }
 
   private void requestAllPermissions() {
@@ -243,8 +245,13 @@ public class XCSoar extends Activity {
        permissions before using them; mentioning them in the manifest
        is not enough */
 
-    checkRequestPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
-    checkRequestPermission(Manifest.permission.ACCESS_FINE_LOCATION);
+    if (!hasAllPermissions()) {
+      try {
+        this.requestPermissions(NEEDED_PERMISSIONS, 0);
+      } catch (Exception e) {
+        Log.e(TAG, "could not request permissions: " + String.join(", ", NEEDED_PERMISSIONS));
+      }
+    }
   }
 
   @Override protected void onResume() {

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -251,8 +251,8 @@ public class XCSoar extends Activity {
     if (!hasAllPermissions()) {
       try {
         this.requestPermissions(NEEDED_PERMISSIONS, 0);
-      } catch (Exception e) {
-        Log.e(TAG, "could not request permissions: " + String.join(", ", NEEDED_PERMISSIONS));
+      } catch (IllegalArgumentException e) {
+        Log.e(TAG, "could not request permissions: " + String.join(", ", NEEDED_PERMISSIONS), e);
       }
     }
   }

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -123,11 +123,10 @@ public class XCSoar extends Activity {
     registerReceiver(batteryReceiver,
                      new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
 
-    /* TODO: this sure is the wrong place to request permissions - it
-       will cause XCSoar to quit immediately; we should request
-       permissions when we need them, but implementing that is
-       complicated, so for now, we do it here to give users a quick
-       solution for the problem */
+    /* TODO: this sure is the wrong place to request permissions -
+       we should request permissions when we need them, but
+       implementing that is complicated, so for now, we do it
+       here to give users a quick solution for the problem */
     requestAllPermissions();
   }
 

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -223,8 +223,11 @@ public class XCSoar extends Activity {
     ImmersiveFullScreenMode.enable(getWindow().getDecorView());
   }
 
-  private final String[] NEEDED_PERMISSIONS = new String[] {Manifest.permission.ACCESS_FINE_LOCATION,
-                                                            Manifest.permission.WRITE_EXTERNAL_STORAGE};
+  private static final String[] NEEDED_PERMISSIONS = new String[] {
+    Manifest.permission.ACCESS_FINE_LOCATION,
+    Manifest.permission.WRITE_EXTERNAL_STORAGE
+  };
+
   private boolean hasAllPermissions() {
     for (String p : NEEDED_PERMISSIONS) {
       if (checkSelfPermission(p) != PackageManager.PERMISSION_GRANTED) {

--- a/src/Android/Main.cpp
+++ b/src/Android/Main.cpp
@@ -289,10 +289,8 @@ JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeView_pauseNative(JNIEnv *env, jobject obj)
 {
   if (event_queue == nullptr || CommonInterface::main_window == nullptr)
-  {
-    /* event subsystem is not initialized, there is nothing to pause */
     return;
-  }
+    /* event subsystem is not initialized, there is nothing to pause */
 
   CommonInterface::main_window->Pause();
 
@@ -305,10 +303,8 @@ JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeView_resumeNative(JNIEnv *env, jobject obj)
 {
   if (event_queue == nullptr || CommonInterface::main_window == nullptr)
-  {
-    /* event subsystem is not initialized, there is nothing to resume */
     return;
-  }
+    /* event subsystem is not initialized, there is nothing to resume */
 
   CommonInterface::main_window->Resume();
 }

--- a/src/Android/Main.cpp
+++ b/src/Android/Main.cpp
@@ -289,9 +289,10 @@ JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeView_pauseNative(JNIEnv *env, jobject obj)
 {
   if (event_queue == nullptr || CommonInterface::main_window == nullptr)
-    /* pause before we have initialized the event subsystem does not
-       work - let's bail out, nothing is lost anyway */
-    exit(0);
+  {
+    /* event subsystem is not initialized, there is nothing to pause */
+    return;
+  }
 
   CommonInterface::main_window->Pause();
 
@@ -304,8 +305,10 @@ JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeView_resumeNative(JNIEnv *env, jobject obj)
 {
   if (event_queue == nullptr || CommonInterface::main_window == nullptr)
-    /* there is nothing here yet which can be resumed */
-    exit(0);
+  {
+    /* event subsystem is not initialized, there is nothing to resume */
+    return;
+  }
 
   CommonInterface::main_window->Resume();
 }


### PR DESCRIPTION
- `checkRequestPermission` is deleted and all
    permissions requested in a single call in `requestAllPermissions`
- permissions are checked in `hasAllPermissions`
- the pause when requesting the permissions does not cause an exit