### PR TITLE
fixes #178 added an optional vario needle mode

### DIFF
--- a/src/Dialogs/Settings/Panels/VarioConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/VarioConfigPanel.cpp
@@ -36,6 +36,7 @@ enum ControlIndex {
   AppGaugeVarioBallast,
   AppGaugeVarioGross,
   AppAveNeedle,
+  AppAveThermalNeedle,
 };
 
 
@@ -86,6 +87,13 @@ VarioConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
                  "average gross value."),
              settings.show_average_needle);
   SetExpertRow(AppAveNeedle);
+
+  AddBoolean(_("Thermal Averager needle"),
+             _("If true, the vario gauge will display a thermal averager needle instead of current climb rate needle.  During cruise, this "
+               "needle displays the last thermal average netto value.  During circling, this needle displays the "
+               "average net value."),
+             settings.show_thermal_average_needle);
+  SetExpertRow(AppAveThermalNeedle);
 }
 
 bool
@@ -108,6 +116,8 @@ VarioConfigPanel::Save(bool &_changed)
   changed |= SaveValue(AppGaugeVarioGross, ProfileKeys::AppGaugeVarioGross, settings.show_gross);
 
   changed |= SaveValue(AppAveNeedle, ProfileKeys::AppAveNeedle, settings.show_average_needle);
+
+  changed |= SaveValue(AppAveThermalNeedle, ProfileKeys::AppAveThermalNeedle, settings.show_thermal_average_needle);
 
   _changed |= changed;
 

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -114,6 +114,11 @@ GaugeVario::OnPaintBuffer(Canvas &canvas)
 
   dirty = false;
   int ival, sval, ival_av = 0;
+  int ival_av_thermal = 0;
+  if (Settings().show_thermal_average_needle) {
+      ival_av_thermal = ValueToNeedlePos(Calculated().current_thermal.lift_rate);
+  }
+  static int ival_av_last = 0;
   static int vval_last = 0;
   static int sval_last = 0;
   static int ival_last = 0;
@@ -141,18 +146,27 @@ GaugeVario::OnPaintBuffer(Canvas &canvas)
     RenderVarioLine(canvas, vval_last, sval_last, true);
 
   sval_last = sval;
+  if (Settings().show_thermal_average_needle) {
+      if (!IsPersistent() || ival_av_thermal != ival_av_last)
+          RenderNeedle(canvas, ival_av_last, false, true);
 
-  if (!IsPersistent() || ival != vval_last)
-    RenderNeedle(canvas, vval_last, false, true);
+      ival_av_last = ival_av_thermal;
+  } else {
+      if (!IsPersistent() || ival != vval_last)
+        RenderNeedle(canvas, vval_last, false, true);
 
-  vval_last = ival;
+      vval_last = ival;
+  }
 
   // now draw items
   RenderVarioLine(canvas, ival, sval, false);
   if (Settings().show_average_needle)
     RenderNeedle(canvas, ival_av, true, false);
 
-  RenderNeedle(canvas, ival, false, false);
+  if (Settings().show_thermal_average_needle)
+    RenderNeedle(canvas, ival_av_thermal, false, false);
+  else
+    RenderNeedle(canvas, ival, false, false);
 
   if (Settings().show_gross) {
     auto vvaldisplay = Clamp(Units::ToUserVSpeed(vval),

--- a/src/Gauge/VarioSettings.cpp
+++ b/src/Gauge/VarioSettings.cpp
@@ -33,4 +33,5 @@ VarioSettings::SetDefaults()
   show_bugs = false;
   show_gross = true;
   show_average_needle = false;
+  show_thermal_average_needle = false;
 }

--- a/src/Gauge/VarioSettings.hpp
+++ b/src/Gauge/VarioSettings.hpp
@@ -32,6 +32,7 @@ struct VarioSettings {
   bool show_bugs;
   bool show_gross;
   bool show_average_needle;
+  bool show_thermal_average_needle;
 
   void SetDefaults();
 };

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -135,6 +135,7 @@ const char ShowMenuButton[] = "ShowMenuButton";
 const char CursorSize[] = "CursorSize";
 
 const char AppAveNeedle[] = "AppAveNeedle";
+const char AppAveThermalNeedle[] = "AppAveThermalNeedle";
 
 const char AutoAdvance[] = "AutoAdvance";
 const char UTCOffset[] = "UTCOffset";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -127,6 +127,7 @@ extern const char AppDialogTabStyle[];
 extern const char AppDialogStyle[];
 extern const char AppInfoBoxBorder[];
 extern const char AppAveNeedle[];
+extern const char AppAveThermalNeedle[];
 extern const char CursorSize[];
 extern const char AutoAdvance[];
 extern const char UTCOffset[];

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -64,6 +64,7 @@ Profile::Load(const ProfileMap &map, VarioSettings &settings)
   map.Get(ProfileKeys::AppGaugeVarioBallast, settings.show_ballast);
   map.Get(ProfileKeys::AppGaugeVarioGross, settings.show_gross);
   map.Get(ProfileKeys::AppAveNeedle, settings.show_average_needle);
+  map.Get(ProfileKeys::AppAveThermalNeedle, settings.show_thermal_average_needle);
 }
 
 void


### PR DESCRIPTION
fixes #178 by showing the average thermal climb ratio instead of current climb ratio. The color bar shows unchanged the current thermal. While not climbing the last average climb ratio is shown. This view allows a fast assessment of the current thermal by comparing the 30s average and the average over thermal.