### PR TITLE
average climb needle color is not inverted

### DIFF
--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -294,8 +294,10 @@ GaugeVario::RenderNeedle(Canvas &canvas, int i, bool average, bool clear)
   // legacy behaviour
   if (clear ^ look.inverse) {
     canvas.SelectWhiteBrush();
+    canvas.SelectWhitePen();
   } else {
     canvas.SelectBlackBrush();
+    canvas.SelectBlackPen();
   }
 
   if (average)


### PR DESCRIPTION
fixes #397 The average needle is painted with a pen instead a brush, therefore also the pen color is selected.