### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,67 @@
+---
+name: Bug report
+about: Report a problem with XCSoar to help us resolve it
+---
+
+<!--
+
+Welcome! - We kindly ask that you:
+
+  1. Fill out the issue template below - not doing so needs a good reason.
+  2. Use the forum if you have a question rather than a bug or feature request.
+
+The forum is at: https://forum.xcsoar.org
+
+Thanks for understanding, and for contributing to the project!
+
+-->
+
+
+XCSoar versions having and not having the problem
+-------------------------------------------------
+
+<!--
+Which XCSoar version are you using when seeing the problem?
+Which XCSoar version is the last one you know that did not show the problem?
+-->
+
+
+Expected behavior
+-----------------
+
+<!--
+Please describe what you expected to see/should happen.
+-->
+
+
+Actual behavior
+---------------
+
+<!--
+Please describe the exact symptoms that you were seeing instead.
+-->
+
+
+Steps to reproduce the behavior
+-------------------------------
+
+<!--
+The more time you spend describing an easy way to reproduce the behavior (if
+this is possible), the easier it is for the project developers to fix it!
+-->
+
+
+Do you have any idea what may have caused this?
+-----------------------------------------------
+
+<!--
+This might give us ideas we haven't thought of, feel free to suggest causes.
+-->
+
+
+Do you have an idea how to solve the issue?
+-------------------------------------------
+
+<!--
+This might give us ideas we haven't thought of, feel free to suggest solutions.
+-->

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,0 +1,42 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement for XCSoar
+---
+
+<!--
+
+Welcome! - We kindly ask that you:
+
+  1. Fill out the issue template below - not doing so needs a good reason.
+  2. Use the forum if you have a question rather than a bug or feature request.
+
+The forum is at: https://forum.xcsoar.org
+
+Thanks for understanding, and for contributing to the project!
+
+-->
+
+
+XCSoar version
+--------------
+
+<!--
+Which XCSoar version are you using?
+-->
+
+
+What should XCSoar do differently, what functionality should be added?
+----------------------------------------------------------------------
+
+<!--
+Please describe the feature you'd like us to add/change.
+-->
+
+
+What are you trying to do, what is the use case for the suggestion?
+-------------------------------------------------------------------
+
+<!--
+Please describe briefly what you're trying to do, that would be possible if
+the suggested feature was implemented.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: XCSoar forum
+    url: https://forum.xcsoar.org
+    about: Please ask questions about using XCSoar here, do not open an issue for usage or general questions.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+
+<!--
+
+Thank you for your interest in contributing to XCSoar! Please read the
+following information to make it easier for us to review your changes.
+
+We appreciate if you make sure to:
+
+  - Document the changes (in the NEWS.txt file, and the manual when relevant)
+  - Enable maintainer edits[1] (in case we need to help with the PR)
+  - Check your commits and their messages (so they're all tidy and coherent)
+
+[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork
+
+-->
+
+
+Brief summary of the changes
+----------------------------
+
+<!--
+Please note that the commit messages is where detailed descriptions of the
+changes should be made - this section is just for a brief summary/overview.
+-->
+
+
+Related issues and discussions
+------------------------------
+
+<!--
+Please link any relevant issues or forum posts here, for reference.
+
+If this PR resolves an existing issue, please write "Closes #1234" so that
+the issue is closed automatically when this PR is merged.
+-->


### PR DESCRIPTION
Adds issue templates for types Bug and Feature requests, as well as a PR template for pull requests.

Also includes a link to the forum which is shown when the contributor is presented with a menu where they select which type of issue they want to open.