### PR TITLE
IGCParser: Add support for long-form `DTE` header

### DIFF
--- a/src/IGC/IGCParser.cpp
+++ b/src/IGC/IGCParser.cpp
@@ -96,6 +96,13 @@ IGCParseDateRecord(const char *line, BrokenDate &date)
 
   line += 5;
 
+  if (strncmp(line, "DATE", 4) == 0) {
+    line += 4;
+  }
+  if (line[0] == ':') {
+    line += 1;
+  }
+
   char *endptr;
   unsigned long value = strtoul(line, &endptr, 10);
   if (endptr != line + 6)

--- a/test/src/TestIGCParser.cpp
+++ b/test/src/TestIGCParser.cpp
@@ -101,6 +101,24 @@ TestDate()
   ok1(date.year == 1999);
   ok1(date.month == 12);
   ok1(date.day == 31);
+
+  // long-form header is supported
+  ok1(IGCParseDateRecord("HFDTEDATE:170520", date));
+  ok1(date.year == 2020);
+  ok1(date.month == 5);
+  ok1(date.day == 17);
+
+  // long-form header without colon is supported
+  ok1(IGCParseDateRecord("HFDTEDATE170520", date));
+  ok1(date.year == 2020);
+  ok1(date.month == 5);
+  ok1(date.day == 17);
+
+  // header extensions are ignored
+  ok1(IGCParseDateRecord("HFDTEDATE:170520,01", date));
+  ok1(date.year == 2020);
+  ok1(date.month == 5);
+  ok1(date.day == 17);
 }
 
 static void
@@ -252,7 +270,7 @@ TestDeclarationTurnpoint()
 
 int main(int argc, char **argv)
 {
-  plan_tests(136);
+  plan_tests(148);
 
   TestHeader();
   TestDate();


### PR DESCRIPTION
Resolves #412 