### PR TITLE
python/Flight: Use `const char*` for `PyUnicode_AsUTF8AndSize()` return value

### DIFF
--- a/python/src/Flight.cpp
+++ b/python/src/Flight.cpp
@@ -55,7 +55,7 @@ PyObject* xcsoar_Flight_new(PyTypeObject *type, PyObject *args, PyObject *kwargs
 #if PY_MAJOR_VERSION >= 3
   if (PyUnicode_Check(py_input_data)) {
     Py_ssize_t length;
-    char *ptr = PyUnicode_AsUTF8AndSize(py_input_data, &length);
+    const char *ptr = PyUnicode_AsUTF8AndSize(py_input_data, &length);
     if (!ptr) {
         return NULL;
     }


### PR DESCRIPTION
with Python 3.6 and below, using `char*` is fine, but 3.7 and above are failing to compile without this fix.