### PR TITLE
Scalable InfoBox title font

### DIFF
--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -684,6 +684,10 @@ angepaßt werden.
 \begin{description}
 \item[\textit{InfoBox Geometrie}]  Eine Auswahlliste von mehreren Anordnungen der InfoBox Seiten Je nach Gerät und persöhnlichem
 Geschmack muß dies schlicht ausprobiert werden. Die angebene Zahl entspricht der Anzahl der InfoBoxen auf der entsprechenden InfoBoxSeite.
+\item[\textit{InfoBox Titelgröße}]  Mit diesem Parameter skaliert die Schriftgröße sowohl der Titelzeile,
+als auch der Kommentarzeile. Die Titelzeile ist die obere der 3 Zeilen in den InfoBoxen,
+die Kommentarzeile ist die untere Zeile.
+Die Skalierung ermöglicht eine Abwägung zwischen Lesbarkeit und Länge des angezeigten Textes.
 \item[\textit{FLARM Anzeige$^{\textcolor{blue}{\star}}$}]  \label{conf:flarmradar-place}
 Wen das \fl angeschaltet wird, kannst Du das kleine \fl Radar es hiermit an entsprechenden stellen einer InfoBoxSeite plazieren.
 Als Standard ist ein ''Auto''-Setup vorhanden, was bedeutet, daß das Radar lediglich die InfoBoxen

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -457,6 +457,9 @@ your personal version of Infoboxes go through the following procedure.
 \item[InfoBox geometry] Choose a basic Infobox geometry or layout.  This basic 
 layout is maintained through any changes in-flight, affecting InfoBox content 
 only.\config{interface-appearance}
+\item[InfoBox title size] An InfoBox has 3 lines: the value in the middle,
+the title in the top line and the comment in the bottom line.
+This parameter scales title and comment line.
 \item[Choose Infobox set ``Auto''] Configure at least one screen page with the
 choice of Infoboxes ``Auto''. As can be seen on the corresponding configuration
 screen, there are more screen pages pre-defined. \config{screenpages}  These 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -645,6 +645,9 @@ This page once more details the appearance of the graphical user interface of XC
 \item[InfoBox geometry]  A list of possible InfoBox layouts. Do some trials to find the 
   best for your screen size. The preceding number refer to the total number of 
   InfoBoxes of this geometry.
+\item[InfoBox title size]
+  This parameter scales title and comment line of the InfoBoxes.
+  Trade off readability vs. number of characters being displayed in these lines.
 \item[FLARM display*]  \label{conf:flarmradar-place}
   In case you enabled the FLARM display this is to configure the
   place on the screen, where the tiny radar window appears. As a default an `Auto' setup 

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -45,6 +45,7 @@ Copyright_License {
 enum ControlIndex {
   MapOrientation,
   AppInfoBoxGeom,
+  InfoBoxTitleScale,
   AppFlarmLocation,
   TabDialogStyle,
   AppStatusMessageAlignment,
@@ -188,6 +189,11 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
 
+  AddInteger(_("InfoBox title size"), nullptr,
+             _T("%d %%"), _T("%d"), 50, 150, 5,
+             ui_settings.info_boxes.scale_title_font);
+  SetExpertRow(InfoBoxTitleScale);
+
   AddEnum(_("FLARM display"), _("Choose a location for the FLARM display."),
           flarm_display_location_list,
           (unsigned)ui_settings.traffic.gauge_location);
@@ -251,6 +257,10 @@ LayoutConfigPanel::Save(bool &_changed)
   info_box_geometry_changed |=
     SaveValueEnum(AppInfoBoxGeom, ProfileKeys::InfoBoxGeometry,
                   ui_settings.info_boxes.geometry);
+
+  info_box_geometry_changed |=
+    SaveValueEnum(InfoBoxTitleScale, ProfileKeys::InfoBoxTitleScale,
+                  ui_settings.info_boxes.scale_title_font);
 
   info_box_geometry_changed |=
     SaveValueEnum(AppFlarmLocation, ProfileKeys::FlarmLocation,

--- a/src/InfoBoxes/InfoBoxSettings.cpp
+++ b/src/InfoBoxes/InfoBoxSettings.cpp
@@ -53,6 +53,7 @@ InfoBoxSettings::SetDefaults()
 
   geometry = Geometry::SPLIT_8;
 
+  scale_title_font = 100U; // default to 100%
   inverse = false;
   use_colors = true;
   border_style = BorderStyle::BOX;

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -126,6 +126,12 @@ struct InfoBoxSettings {
 
   } geometry;
 
+  /*
+  scales the font for InfoBox titles and comments between 50% and 150%
+  the value of scale_title_font ranges from 50 to 150 accordingly.
+  */
+  unsigned scale_title_font;
+
   bool inverse, use_colors;
 
   enum class BorderStyle : uint8_t {

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -41,7 +41,7 @@ Copyright_License {
 
 void
 InfoBoxLook::Initialise(bool _inverse, bool use_colors,
-                        unsigned width)
+                        unsigned width, unsigned scale_title_font)
 {
   inverse = _inverse;
 
@@ -57,7 +57,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
   Color border_color = Color(128, 128, 128);
   border_pen.Create(BORDER_WIDTH, border_color);
 
-  ReinitialiseLayout(width);
+  ReinitialiseLayout(width, scale_title_font);
 
   unit_fraction_pen.Create(1, value.fg_color);
 
@@ -73,10 +73,11 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
 }
 
 void
-InfoBoxLook::ReinitialiseLayout(unsigned width)
+InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
 {
   FontDescription title_font_d(8);
-  AutoSizeFont(title_font_d, width, _T("123456789012345"));
+  unsigned scaled_width = (width * scale_title_font) / 100U;
+  AutoSizeFont(title_font_d, scaled_width, _T("123456789012345"));
   title_font.Load(title_font_d);
 
   FontDescription value_font_d(10, true);

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -62,9 +62,9 @@ struct InfoBoxLook {
   Color colors[6];
 
   void Initialise(bool inverse, bool use_colors,
-                  unsigned width);
+                  unsigned width, unsigned scale_title_font);
 
-  void ReinitialiseLayout(unsigned width);
+  void ReinitialiseLayout(unsigned width, unsigned scale_title_font);
 
   Color GetColor(int i, Color default_color) const {
     if (i < 0)

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -49,7 +49,8 @@ Look::InitialiseConfigured(const UISettings &settings,
   trace_history.Initialise(settings.info_boxes.inverse);
   info_box.Initialise(settings.info_boxes.inverse,
                       settings.info_boxes.use_colors,
-                      infobox_width);
+                      infobox_width,
+		      settings.info_boxes.scale_title_font);
   vario.Initialise(settings.info_boxes.inverse,
                    settings.info_boxes.use_colors,
                    info_box.title_font);
@@ -64,7 +65,7 @@ Look::InitialiseConfigured(const UISettings &settings,
 }
 
 void
-Look::ReinitialiseLayout(unsigned infobox_width)
+Look::ReinitialiseLayout(unsigned infobox_width, unsigned scale_title_font)
 {
-  info_box.ReinitialiseLayout(infobox_width);
+  info_box.ReinitialiseLayout(infobox_width, scale_title_font);
 }

--- a/src/Look/Look.hpp
+++ b/src/Look/Look.hpp
@@ -74,7 +74,7 @@ struct Look {
                             const Font &map_font, const Font &map_bold_font,
                             unsigned infobox_width);
 
-  void ReinitialiseLayout(unsigned infobox_width);
+  void ReinitialiseLayout(unsigned infobox_width, unsigned scale_title_font);
 };
 
 #endif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -192,7 +192,7 @@ MainWindow::InitialiseConfigured()
 {
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 
-  if (ui_settings.scale != 100)
+  if (ui_settings.scale != 100 || ui_settings.info_boxes.scale_title_font != 100)
     /* call Initialise() again to reload fonts with the new scale */
     Initialise();
 
@@ -321,7 +321,8 @@ MainWindow::ReinitialiseLayout()
   const InfoBoxLayout::Layout ib_layout =
     InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
 
-  look->ReinitialiseLayout(ib_layout.control_size.cx);
+  look->ReinitialiseLayout(ib_layout.control_size.cx,
+    ui_settings.info_boxes.scale_title_font);
 
   InfoBoxManager::Create(*this, ib_layout, look->info_box);
   InfoBoxManager::ProcessTimer();

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -127,6 +127,10 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
     break;
   }
 
+  map.Get(ProfileKeys::InfoBoxTitleScale, settings.scale_title_font);
+  if (settings.scale_title_font < 50 || settings.scale_title_font > 150)
+    settings.scale_title_font = 100; // discard unreasonable values
+
   map.Get(ProfileKeys::AppInverseInfoBox, settings.inverse);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);
 

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -217,6 +217,7 @@ const char FontTeamCodeFont[] = "TeamCodeFont";
 
 const char UseFinalGlideDisplayMode[] = "UseFinalGlideDisplayMode";
 const char InfoBoxGeometry[] = "InfoBoxGeometry";
+const char InfoBoxTitleScale[] = "InfoBoxTitleScale";
 
 const char FlarmSideData[] = "FlarmRadarSideData";
 const char FlarmAutoZoom[] = "FlarmRadarAutoZoom";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -215,6 +215,7 @@ extern const char FontTeamCodeFont[];
 extern const char UseFinalGlideDisplayMode[];
 
 extern const char InfoBoxGeometry[];
+extern const char InfoBoxTitleScale[];
 
 extern const char FlarmSideData[];
 extern const char FlarmAutoZoom[];


### PR DESCRIPTION
Introduce a user parameter "InfoBox title size" 80% ... 150% to scale the font for the title and comment in the InfoBoxes.
The intention is to improve readability of InfoBox title and comment in particular on tall and narrow displays. It allows the user to trade off readability vs. length of text being displayed.

Added documentation in a separate commit.