### PR TITLE
ide/docker: merge sandrinr/docker-xcsoar-buildenv into XCSoar

### DIFF
--- a/ide/docker/Dockerfile
+++ b/ide/docker/Dockerfile
@@ -16,3 +16,10 @@ WORKDIR /opt/xcsoar
 
 COPY ./docker/bin/* /usr/local/bin/
 RUN cd /usr/local/bin && chmod 755 ./*
+
+# Environment to support running XCSoar
+ENV DISPLAY=host.docker.internal:0
+ENV SDL_RENDER_DRIVER=software
+# We set the home directory to the project root such that XCSoar generated files
+# are retained.
+ENV HOME=/opt/xcsoar

--- a/ide/docker/README.md
+++ b/ide/docker/README.md
@@ -6,12 +6,13 @@ This Docker image when built, will compile XCSoar for several targets in a clean
 ## Currently Supported Targets
 
 - UNIX (linux & co)
+- UNIX-SDL (to run XCSoar from within the Docker container)
 - ANDROID
 - PC
 - KOBO
 - DOCS
 
-## Instructions
+## Instructions for building XCSoar
 
 The build container should be considered read only. When used as described below
 the output will appear in the XCSoar project directory the same way as when
@@ -47,3 +48,45 @@ docker run -it --rm -v $PWD:/opt/xcsoar:delegated xcsoar-build xcsoar-compile AN
 Note: the `delegated` volume modifier is used to speed up compilation on non Linux hosts 
 (macOS and Windows), it allows for eventual consistent filesystem change propagation 
 from the container to the host system.
+
+
+## Instructions for running XCSoar within the Docker container
+
+You can also use the Docker container to run the Linux build of XCSoar on a non-Linux
+system. This could be helpful to perform quick tests. It will use software rendering.
+Needless to say that the experience is inferior to running XCSoar on the host
+system directly. However, installing all build dependencies might also be overkill
+for small things.
+
+### macOS
+
+1. Install dependencies (socat and an X11 server) using Homebrew:
+    ```shell script
+    brew install socat
+    brew cask install xquartz
+    ```
+    Please ensure to restart your Mac after you have installed XQuartz, it is needed
+    for its environment to work correctly.
+
+1. To forward X11 network traffic out of the Docker container to the host X11-Server run
+`socat` on the host machine in a separate terminal (it will block):
+    ```shell script
+    socat TCP-LISTEN:6000,reuseaddr,fork UNIX-CLIENT:\"$DISPLAY\"
+    ```
+
+1. To compile XCSoar for this kind of usage, run:
+    ```shell script
+    docker run -it --rm -v $PWD:/opt/xcsoar:delegated xcsoar-build xcsoar-compile UNIX-SDL
+    ```
+
+1. After compilation you may run XCSoar if you have an X11
+server installed and running and the `socat` command from above running.
+    ```shell script
+    docker run -it --rm -v $PWD:/opt/xcsoar:delegated xcsoar-build output/UNIX/bin/xcsoar
+    ```
+
+### Windows
+
+*TODO*
+(The process should be the same as on macOS, however, we need someone to verify
+this.)

--- a/ide/docker/README.md
+++ b/ide/docker/README.md
@@ -1,6 +1,6 @@
 # XCSoar Docker Image
 
-This Docker Image when built, will compile XCSoar for several targets in a clean room environment.
+This Docker image when built, will compile XCSoar for several targets in a clean room environment.
 
 
 ## Currently Supported Targets
@@ -13,25 +13,37 @@ This Docker Image when built, will compile XCSoar for several targets in a clean
 
 ## Instructions
 
-The container itself is readonly. The build results will appear in `./output/`.
+The build container should be considered read only. When used as described below
+the output will appear in the XCSoar project directory the same way as when
+building on directly the host system.
 
-To build the container:
+
+### Build the container
+
+Ensure your current working directory is the XCSoar project root. Then run:
+
 ```
-docker build \
-    --file ide/docker/Dockerfile \
-    -t xcsoar/xcsoar-build:latest ./ide/
+docker build --file ide/docker/Dockerfile -t xcsoar-build ./ide/
+```
+This will take time and download a lot of software. You only need to run this
+once as long as the XCSoar build dependencies stay the same.
+
+
+### Run the container
+
+
+Ensure your current working directory is the XCSoar project root.
+
+**Interactively:**
+```
+docker run -it --rm -v $PWD:/opt/xcsoar:delegated xcsoar-build
 ```
 
-To run the container interactivly:
+**To build a specific target, e.g. ANDROID:**
 ```
-docker run \
-    --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
-    -it xcsoar/xcsoar-build:latest /bin/bash
+docker run -it --rm -v $PWD:/opt/xcsoar:delegated xcsoar-build xcsoar-compile ANDROID
 ```
 
-To run the ANDROID build:
-```
-docker run \
-    --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
-    -it xcsoar/xcsoar-build:latest xcsoar-compile ANDROID
-```
+Note: the `delegated` volume modifier is used to speed up compilation on non Linux hosts 
+(macOS and Windows), it allows for eventual consistent filesystem change propagation 
+from the container to the host system.

--- a/ide/docker/bin/xcsoar-compile
+++ b/ide/docker/bin/xcsoar-compile
@@ -19,6 +19,9 @@ case "${1}" in
       "UNIX")
         make TARGET="${1}" -j"${CPUS}" all
       ;;
+      "UNIX-SDL")
+        make TARGET=UNIX OPENGL=n ENABLE_SDL=y USE_SDL2=y -j"${CPUS}" all
+      ;;
       "PC")
         make TARGET="${1}" -j"${CPUS}" all
       ;;
@@ -26,7 +29,7 @@ case "${1}" in
         make TARGET="${1}" -j"${CPUS}" all
       ;;
       "*")
-        echo "No target specified. Valid targets: ANDROID DOCS KOBO UNIX PC"
+        echo "No target specified. Valid targets: ANDROID DOCS KOBO UNIX UNIX-SDL PC"
         exit 1
       ;;
 esac

--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -40,6 +40,7 @@ apt-get install $APTOPTS make g++ \
   liblua5.2-dev lua5.2-dev \
   libxml-parser-perl \
   libasound2-dev \
+  libsdl2-dev \
   librsvg2-bin xsltproc \
   imagemagick gettext \
   mesa-common-dev libgl1-mesa-dev libegl1-mesa-dev \


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

- Use `delegated` volume modifier
- More concise notion of Docker commands
- Remove unnecessary "xcsoar" image path prefix
- Content and style improvements
- Support running XCSoar from within the Docker container


Related issues and discussions
------------------------------

This PR is an effort to semantically merge https://github.com/sandrinr/docker-xcsoar-buildenv into XCSoar.