### PR TITLE
Select position of ThermalAssistant

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,7 @@ Version 7.0 - not yet released
   - new translation: Traditional Chinese
   - new Logger-setting "CoPilot"
   - new setting "Thermal Averager needle"
+  - select position of Thermal Assistant
 * data files
   - optimise the terrain loader
   - support runway width in CUP files

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -292,7 +292,27 @@ MainWindow::ReinitialiseLayoutTA(PixelRect rc,
 {
   unsigned sz = std::min(layout.control_size.cy,
                          layout.control_size.cx) * 2;
-  rc.right = rc.left + sz;
+
+  switch (CommonInterface::GetUISettings().thermal_assistant_position) {
+  case (UISettings::ThermalAssistantPosition::BOTTOM_LEFT_AVOID_IB):
+    rc.bottom = GetMainRect().bottom;
+    rc.left = GetMainRect().left;
+    rc.right = rc.left + sz;
+    break;
+  case (UISettings::ThermalAssistantPosition::BOTTOM_RIGHT_AVOID_IB):
+    rc.bottom = GetMainRect().bottom;
+    rc.right = GetMainRect().right;
+    rc.left = rc.right - sz;
+    break;
+  case (UISettings::ThermalAssistantPosition::BOTTOM_RIGHT):
+    rc.right = GetMainRect().right;
+    rc.left = rc.right - sz;
+    break;
+  default: // BOTTOM_LEFT
+    rc.left = GetMainRect().left;
+    rc.right = rc.left + sz;
+    break;
+  } 
   rc.top = rc.bottom - sz;
   thermal_assistant.Move(rc);
 }
@@ -617,7 +637,7 @@ MainWindow::RunTimer() noexcept
 
   UpdateGaugeVisibility();
 
-  if (!CommonInterface::GetUISettings().enable_thermal_assistant_gauge) {
+  if (CommonInterface::GetUISettings().thermal_assistant_position == UISettings::ThermalAssistantPosition::OFF) {
     thermal_assistant.Clear();
   } else if (!CommonInterface::Calculated().circling ||
              InputEvents::IsFlavour(_T("TA"))) {

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -150,6 +150,7 @@ const char EnableFLARMMap[] = "EnableFLARMDisplay";
 const char EnableFLARMGauge[] = "EnableFLARMGauge";
 const char AutoCloseFlarmDialog[] = "AutoCloseFlarmDialog";
 const char EnableTAGauge[] = "EnableTAGauge";
+const char TAPosition[] = "TAPosition";
 const char EnableThermalProfile[] = "EnableThermalProfile";
 const char GliderScreenPosition[] = "GliderScreenPosition";
 const char SetSystemTimeFromGPS[] = "SetSystemTimeFromGPS";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -141,6 +141,7 @@ extern const char TerrainRamp[];
 extern const char EnableFLARMMap[];
 extern const char EnableFLARMGauge[];
 extern const char AutoCloseFlarmDialog[];
+extern const char TAPosition[];
 extern const char EnableTAGauge[];
 extern const char EnableThermalProfile[];
 extern const char TrailDrift[];

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -130,8 +130,14 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
   if (settings.custom_dpi < 120 || settings.custom_dpi > 520)
     settings.custom_dpi = 0;
 
-  map.Get(ProfileKeys::EnableTAGauge, settings.enable_thermal_assistant_gauge);
-
+  /* Migrate old data if TA enabled */
+  if (!map.GetEnum(ProfileKeys::TAPosition, settings.thermal_assistant_position)) {
+    bool enable_thermal_assistant_gauge_obsolete;
+    map.Get(ProfileKeys::EnableTAGauge, enable_thermal_assistant_gauge_obsolete);
+    enable_thermal_assistant_gauge_obsolete ?
+      settings.thermal_assistant_position = UISettings::ThermalAssistantPosition::BOTTOM_LEFT :
+      settings.thermal_assistant_position = UISettings::ThermalAssistantPosition::OFF;
+  }
   map.Get(ProfileKeys::AirspaceWarningDialog, settings.enable_airspace_warning_dialog);
 
   map.GetEnum(ProfileKeys::AppStatusMessageAlignment, settings.popup_message_position);

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -34,7 +34,7 @@ UISettings::SetDefaults()
 
   custom_dpi = 0;  // automatic
 
-  enable_thermal_assistant_gauge = true;
+  thermal_assistant_position = ThermalAssistantPosition::BOTTOM_LEFT;
 
   enable_airspace_warning_dialog = true;
 

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -52,8 +52,14 @@ struct UISettings {
   /** Override OS dpi settings */
   unsigned custom_dpi;
 
-  /** Show ThermalAssistant if circling */
-  bool enable_thermal_assistant_gauge;
+  /** Position ThermalAssistant */
+  enum class ThermalAssistantPosition: uint8_t {
+    OFF,
+    BOTTOM_LEFT,
+    BOTTOM_LEFT_AVOID_IB,
+    BOTTOM_RIGHT,
+    BOTTOM_RIGHT_AVOID_IB,
+  } thermal_assistant_position;
 
   /** Enable warning dialog */
   bool enable_airspace_warning_dialog;


### PR DESCRIPTION
Allow user to select position of ThermalAssistant.
Includes avoiding infoboxes if in the way.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
