### PR TITLE
Repo file checksums

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -637,6 +637,7 @@ XCSOAR_SOURCES := \
 	\
 	$(SRC)/Repository/FileRepository.cpp \
 	$(SRC)/Repository/Parser.cpp \
+	$(SRC)/Repository/RepoFileManager.cpp \
 	\
 	$(SRC)/Job/Thread.cpp \
 	$(SRC)/Job/Async.cpp \

--- a/src/Repository/RepoFileManager.cpp
+++ b/src/Repository/RepoFileManager.cpp
@@ -1,0 +1,169 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Repository/RepoFileManager.hpp"
+#include "IO/BufferedOutputStream.hxx"
+#include "IO/FileOutputStream.hxx"
+#include "IO/KeyValueFileReader.hpp"
+#include "IO/KeyValueFileWriter.hpp"
+#include "LocalPath.hpp"
+#include "IO/FileLineReader.hpp"
+#include "Net/HTTP/DownloadManager.hpp"
+#include "OS/FileUtil.hpp"
+#include "Repository/FileRepository.hpp"
+#include "Repository/Parser.hpp"
+#include "Time/BrokenDate.hpp"
+#include "Time/BrokenDateTime.hpp"
+#include "Util/ConvertString.hpp"
+#include "Util/HexString.hpp"
+
+void
+RepoFileManager::Load(Path repofilepath)
+{
+  repository.Clear();
+
+  try {
+    FileLineReaderA reader(repofilepath);
+    bool success = ParseFileRepository(repository, reader);
+
+    if (!success) {
+      repository.Clear();
+    }
+  } catch (...) {
+    repository.Clear();
+    return;
+  }
+
+  LoadLocalHashes();
+}
+
+void
+RepoFileManager::Download(const char *name)
+{
+  const AvailableFile *remote_file = repository.FindByName(name);
+  if (remote_file == nullptr)
+    return;
+
+  const UTF8ToWideConverter base(remote_file->GetName());
+  if (!base.IsValid())
+    return;
+
+  Net::DownloadManager::Enqueue(remote_file->GetURI(), Path(base));
+
+  if (remote_file->HasHash()) {
+    local_hashes[remote_file->name] = remote_file->sha256_hash;
+  }
+}
+
+bool
+RepoFileManager::IsOutOfDate(const char *name)
+{
+  const AvailableFile *remote_file = repository.FindByName(name);
+
+  if (remote_file == nullptr)
+    return false;
+
+  if (remote_file->HasHash()) {
+    try {
+      std::array<std::byte, 32> local_hash = local_hashes.at(name);
+
+      return local_hash != remote_file->sha256_hash;
+    } catch (std::exception &e) {
+      // No hash of the local version was found so mark as out of date.
+      return true;
+    }
+  }
+
+#ifdef HAVE_POSIX
+  BrokenDate remote_changed = remote_file->update_date;
+
+  const UTF8ToWideConverter base(remote_file->GetName());
+  if (!base.IsValid())
+    return false;
+
+  BrokenDate local_changed = static_cast<BrokenDate>(BrokenDateTime::FromUnixTimeUTC(
+        File::GetLastModification(LocalPath(base))));
+
+  return local_changed < remote_changed;
+#else
+  return false;
+#endif
+}
+
+
+/**
+ * Reads the hashes of files from the repo from the disk.
+ * Every line is an entry of the form `filename = hash`.
+ * This is done so we don't have to calculate the
+ * checksum of the local files on every start.
+ */
+void
+RepoFileManager::LoadLocalHashes()
+{
+  try {
+    FileLineReaderA linereader(LocalPath(LOCAL_HASHES_FILE));
+    KeyValueFileReader kvreader(linereader);
+
+    KeyValuePair kv_pair;
+    while (kvreader.Read(kv_pair)) {
+      std::string name = kv_pair.key;
+      try {
+        std::array<std::byte, 32> sha256 = ParseHexString<32>(kv_pair.value);
+
+        local_hashes[name] = sha256;
+      } catch (std::exception &e) {
+        // invalid hash in the hash file don't add anything
+      }
+    }
+  } catch (...) {
+    local_hashes.clear();
+  }
+}
+
+/**
+ * Writes the hashes of the files from the repo to the disk.
+ */
+void
+RepoFileManager::SaveLocalHashes()
+{
+  FileOutputStream file_os(LocalPath(LOCAL_HASHES_FILE),
+                           FileOutputStream::Mode::CREATE);
+  BufferedOutputStream buf_os(file_os);
+  KeyValueFileWriter kvwriter(buf_os);
+
+  for (const auto &pair : local_hashes) {
+    const char *name = pair.first.c_str();
+    const char *hash = RenderHexString(pair.second).c_str();
+    kvwriter.Write(name, hash);
+  }
+
+  buf_os.Flush();
+  file_os.Commit();
+}
+
+void
+RepoFileManager::Close()
+{
+  SaveLocalHashes();
+  local_hashes.clear();
+}

--- a/src/Repository/RepoFileManager.hpp
+++ b/src/Repository/RepoFileManager.hpp
@@ -1,0 +1,71 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Repository/FileRepository.hpp"
+
+#include <map>
+
+class Path;
+
+/**
+ * Wraps a FileRepository to allow checking for updates.
+ * Maintains a `local_hashes` file that holds the sha256
+ * sum of downloaded files.
+ */
+class RepoFileManager {
+  std::map<std::string, std::array<std::byte, 32>> local_hashes;
+
+  static const char *LOCAL_HASHES_FILE = "local_hashes";
+
+public:
+  FileRepository repository;
+
+  /**
+   * Loads a repository file.
+   * @param repofilepath The path to the repository file.
+   */
+  void Load(Path repofilepath);
+
+  /**
+   * Writes the updated hashes to the `local_hashes` file.
+   */
+  void Close();
+
+  /**
+   * Downloads a file from the repository.
+   * @param name The filename of the file to download.
+   */
+  void Download(const char *name);
+
+  /**
+   * Checks if a local file has a newer version in the repository.
+   * If hashes are available they are compared, if not the file
+   * modification timestamp is older than the `update` field in
+   * the repository file.
+   */
+  bool IsOutOfDate(const char *name);
+
+private:
+  void LoadLocalHashes();
+  void SaveLocalHashes();
+};

--- a/src/Util/HexString.hpp
+++ b/src/Util/HexString.hpp
@@ -24,6 +24,8 @@ Copyright_License {
 #ifndef HEX_STRING_HPP
 #define HEX_STRING_HPP
 
+#include "Util/StringBuffer.hxx"
+
 #include <array>
 #include <string_view>
 #include <stdexcept>
@@ -68,5 +70,24 @@ ParseHexString(const std::string_view hex_str)
   }
 
   return raw_hash;
+}
+
+template<std::size_t len>
+StringBuffer<len*2 + 1>
+RenderHexString(const std::array<std::byte, len> data)
+{
+  constexpr char digits[] = "0123456789ABCDEF";
+  StringBuffer<len*2 + 1> out;
+
+  for (std::size_t i = 0; i < len; i++) {
+    unsigned char upper = (static_cast<unsigned char>(data[i])&0xF0)>>4;
+    unsigned char lower =  static_cast<unsigned char>(data[i])&0x0F;
+
+    out[i*2]     = digits[upper];
+    out[i*2 + 1] = digits[lower];
+  }
+
+  out[len * 2] = out.SENTINEL;
+  return out;
 }
 #endif


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

This puts the handling of repository files into a class FileRepository.
When the repository file is loaded another file `local_hashes` is loaded.
Upon downloading a file the hash that is denoted in the `repository` file is saved and persisted in the `local_hashes`.
Out-of-date-ness is checked by comparing the hashes, or falling back to the file modification timestamps.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Issue #417 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
