### PR TITLE
build/targets: Remove obsolete "VFP register arguments" workaround

### DIFF
--- a/build/targets.mk
+++ b/build/targets.mk
@@ -522,9 +522,6 @@ ifeq ($(TARGET),ANDROID)
     LLVM_TARGET = armv7a-none-linux-androideabi
     TARGET_ARCH += -march=armv7-a -mfloat-abi=softfp
     HAVE_FPU := y
-
-    # workaround for "... uses VFP register arguments, output does not"
-    TARGET_ARCH += -Wl,--no-warn-mismatch
   endif
 
   ifeq ($(ARMV7)$(NEON),yy)


### PR DESCRIPTION
This workaround seems to no longer be necessary and is now causing errors like:

```
clang++: error: -Wl,--no-warn-mismatch: 'linker' input unused [-Werror,-Wunused-command-line-argument]
```