### PR TITLE
Missing include of errno (@nico-krais)

### DIFF
--- a/src/Event/Poll/Linux/Input.cpp
+++ b/src/Event/Poll/Linux/Input.cpp
@@ -33,6 +33,7 @@ Copyright_License {
 
 #include <termios.h>
 #include <sys/ioctl.h>
+#include <errno.h>
 
 template<typename T>
 static constexpr unsigned


### PR DESCRIPTION
Brief summary of the changes
----------------------------

This adds an explicit include for a header which wasn't resolved automatically in my environment when trying to build v6.8.x

Related issues and discussions
------------------------------

Closes #445 
