### PR TITLE
Identify BLE devices when saving address

### DIFF
--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -94,6 +94,9 @@ final class BluetoothHelper {
     if (adapter == null)
       return null;
 
+    if (address.startsWith("LE:")) {
+        address = address.substring(3);
+    }
     try {
       return adapter.getRemoteDevice(address).getName();
     } catch (Exception e) {
@@ -134,11 +137,16 @@ final class BluetoothHelper {
     if (adapter == null)
       return null;
 
+    boolean isLe = false;
+    if (address.startsWith("LE:")) {
+        isLe = true;
+        address = address.substring(3);
+    }
     BluetoothDevice device = adapter.getRemoteDevice(address);
     if (device == null)
       return null;
 
-    if (hasLe && BluetoothDevice.DEVICE_TYPE_LE == device.getType()) {
+    if (hasLe && (isLe || BluetoothDevice.DEVICE_TYPE_LE == device.getType())) {
       Log.d(TAG, String.format(
                                "Bluetooth device \"%s\" (%s) is a LE device, trying to connect using GATT...",
                                device.getName(), device.getAddress()));

--- a/android/src/NativeLeScanCallback.java
+++ b/android/src/NativeLeScanCallback.java
@@ -44,6 +44,6 @@ class NativeLeScanCallback implements BluetoothAdapter.LeScanCallback {
 
   @Override
   public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
-    onLeScan(device.getAddress(), device.getName());
+    onLeScan("LE:" + device.getAddress(), device.getName());
   }
 }


### PR DESCRIPTION
This is a partial fix for #149. It solves the reconnect problem, but does not preserve the name.

My previous PR to solve both problems was rejected as it used storage outside the native XCSoar profile. I spent some time revising code to store both the device type and name in the XCSoar profile, but the number of affected files was considerable.

This PR is more modest in its scope but solves the major problem of automatic reconnection without relying on any storage other than the existing profile.