### PR TITLE
Add ports 8880, 8881, 8882 to tcp-client

### DIFF
--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -270,6 +270,9 @@ FillTCPPorts(DataFieldEnum &dfe)
   dfe.addEnumText(_T("4352"), 4352);
   dfe.addEnumText(_T("2000"), 2000);
   dfe.addEnumText(_T("23"), 23);
+  dfe.addEnumText(_T("8880"), 8880);
+  dfe.addEnumText(_T("8881"), 8881);
+  dfe.addEnumText(_T("8882"), 8882);
 }
 
 static void


### PR DESCRIPTION
Added ports 8880, 8881, 8882 to tcp-client to be able to use ESP32-Serial-Bridge without adjusting any ports (https://github.com/AlphaLima/ESP32-Serial-Bridge)

Tested ESP32-Serial bridge with FLARM (Bluetooth and WIFI)