### PR TITLE
Add -target option to TARGET_CPPFLAGS 

### DIFF
--- a/build/llvm.mk
+++ b/build/llvm.mk
@@ -23,7 +23,7 @@ endif
 ifeq ($(TARGET),ANDROID)
   TARGET_ARCH := $(filter-out -mthumb-interwork,$(TARGET_ARCH))
   TARGET_ARCH += -integrated-as
-  TARGET_CPPFLAGS += -DBIONIC -DLIBCPP_NO_IOSTREAM
+  TARGET_CPPFLAGS += -DBIONIC -DLIBCPP_NO_IOSTREAM $(TARGET_ARCH)
   TARGET_LDLIBS += -latomic
 endif # Android
 


### PR DESCRIPTION

<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Add -target option to TARGET_CPPFLAGS to ensure that when configure uses cpp to run checks that it gets the correct system include paths. Without clang (aka cpp) knowing the target architecture it cannot provide the correct include paths.


<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

Closes #450 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
