### PR TITLE
Add new device type for BLE serial ports

### DIFF
--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -25,6 +25,7 @@ package org.xcsoar;
 
 import java.util.UUID;
 import java.util.Set;
+import java.io.IOException;
 
 import android.util.Log;
 import android.bluetooth.BluetoothAdapter;
@@ -109,11 +110,12 @@ final class BluetoothHelper {
     if (devices == null)
       return null;
 
-    String[] addresses = new String[devices.size() * 2];
+    String[] addresses = new String[devices.size() * 3];
     int n = 0;
     for (BluetoothDevice device: devices) {
       addresses[n++] = device.getAddress();
       addresses[n++] = device.getName();
+      addresses[n++] = BluetoothDevice.DEVICE_TYPE_LE == device.getType() ? "BLE" : "CLASSIC";
     }
 
     return addresses;
@@ -128,6 +130,24 @@ final class BluetoothHelper {
       adapter.stopLeScan(cb);
   }
 
+  public static AndroidPort connectHM10(Context context, String address)
+    throws IOException {
+    if (adapter == null || !hasLe)
+      return null;
+
+    BluetoothDevice device = adapter.getRemoteDevice(address);
+    if (device == null)
+      return null;
+
+    Log.d(TAG, String.format(
+                             "Bluetooth device \"%s\" is a LE device, trying to connect using GATT...",
+                             address));
+    BluetoothGattClientPort gattClientPort
+      = new BluetoothGattClientPort(device);
+    gattClientPort.startConnect(context);
+    return gattClientPort;
+  }
+
   public static AndroidPort connect(Context context, String address) {
     if (adapter == null)
       return null;
@@ -137,19 +157,9 @@ final class BluetoothHelper {
       if (device == null)
         return null;
 
-      if (hasLe && BluetoothDevice.DEVICE_TYPE_LE == device.getType()) {
-        Log.d(TAG, String.format(
-            "Bluetooth device \"%s\" (%s) is a LE device, trying to connect using GATT...",
-             device.getName(), device.getAddress()));
-        BluetoothGattClientPort gattClientPort
-          = new BluetoothGattClientPort(device);
-        gattClientPort.startConnect(context);
-        return gattClientPort;
-      } else {
-        BluetoothSocket socket =
-            device.createRfcommSocketToServiceRecord(THE_UUID);
-        return new BluetoothClientPort(socket);
-      }
+      BluetoothSocket socket =
+          device.createRfcommSocketToServiceRecord(THE_UUID);
+      return new BluetoothClientPort(socket);
     } catch (Exception e) {
       Log.e(TAG, "Failed to connect to Bluetooth", e);
       return null;

--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -25,7 +25,6 @@ package org.xcsoar;
 
 import java.util.UUID;
 import java.util.Set;
-import java.io.IOException;
 
 import android.util.Log;
 import android.bluetooth.BluetoothAdapter;
@@ -130,22 +129,26 @@ final class BluetoothHelper {
       adapter.stopLeScan(cb);
   }
 
-  public static AndroidPort connectHM10(Context context, String address)
-    throws IOException {
+  public static AndroidPort connectHM10(Context context, String address) {
     if (adapter == null || !hasLe)
       return null;
 
-    BluetoothDevice device = adapter.getRemoteDevice(address);
-    if (device == null)
+    try {
+      BluetoothDevice device = adapter.getRemoteDevice(address);
+      if (device == null)
+        return null;
+  
+      Log.d(TAG, String.format(
+                               "Bluetooth device \"%s\" is a LE device, trying to connect using GATT...",
+                               address));
+      BluetoothGattClientPort gattClientPort
+        = new BluetoothGattClientPort(device);
+      gattClientPort.startConnect(context);
+      return gattClientPort;
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to connect to BLE", e);
       return null;
-
-    Log.d(TAG, String.format(
-                             "Bluetooth device \"%s\" is a LE device, trying to connect using GATT...",
-                             address));
-    BluetoothGattClientPort gattClientPort
-      = new BluetoothGattClientPort(device);
-    gattClientPort.startConnect(context);
-    return gattClientPort;
+    }
   }
 
   public static AndroidPort connect(Context context, String address) {

--- a/src/Android/BluetoothHelper.cpp
+++ b/src/Android/BluetoothHelper.cpp
@@ -37,7 +37,7 @@ namespace BluetoothHelper {
   static jfieldID hasLe_field;
   static jmethodID isEnabled_method;
   static jmethodID getNameFromAddress_method;
-  static jmethodID list_method, connect_method, createServer_method;
+  static jmethodID list_method, connect_method, createServer_method, hm10connect_method;
   static jmethodID startLeScan_method, stopLeScan_method;
 
   static std::map<std::string, std::string> address_to_name;
@@ -66,6 +66,10 @@ BluetoothHelper::Initialise(JNIEnv *env)
   createServer_method = env->GetStaticMethodID(cls, "createServer",
                                                "()Lorg/xcsoar/AndroidPort;");
 
+  hm10connect_method = env->GetStaticMethodID(cls, "connectHM10",
+                                          "(Landroid/content/Context;"
+                                          "Ljava/lang/String;)"
+                                          "Lorg/xcsoar/AndroidPort;");
   startLeScan_method = env->GetStaticMethodID(cls, "startLeScan",
                                               "(Landroid/bluetooth/BluetoothAdapter$LeScanCallback;)Z");
   stopLeScan_method = env->GetStaticMethodID(cls, "stopLeScan",
@@ -197,3 +201,24 @@ BluetoothHelper::createServer(JNIEnv *env)
 
   return helper;
 }
+
+PortBridge *
+BluetoothHelper::connectHM10(JNIEnv *env, const char *address)
+{
+  if (!cls.IsDefined())
+    return nullptr;
+
+  /* call BluetoothHelper.connectHM10() */
+
+  const Java::String address2(env, address);
+  jobject obj = env->CallStaticObjectMethod(cls, hm10connect_method,
+                                            context->Get(), address2.Get());
+  if (obj == nullptr)
+    return nullptr;
+
+  PortBridge *helper = new PortBridge(env, obj);
+  env->DeleteLocalRef(obj);
+
+  return helper;
+}
+

--- a/src/Android/BluetoothHelper.hpp
+++ b/src/Android/BluetoothHelper.hpp
@@ -80,6 +80,9 @@ namespace BluetoothHelper {
 
   gcc_malloc
   PortBridge *createServer(JNIEnv *env);
+
+  gcc_malloc
+  PortBridge *connectHM10(JNIEnv *env, const char *address);
 };
 
 #endif

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -44,6 +44,7 @@ DeviceConfig::IsAvailable() const
     return true;
 
   case PortType::RFCOMM:
+  case PortType::BLE_HM10:
   case PortType::RFCOMM_SERVER:
     return IsAndroid();
 
@@ -94,6 +95,7 @@ DeviceConfig::ShouldReopenOnTimeout() const
     return IsWindowsCE() && !IsAltair();
 
   case PortType::RFCOMM:
+  case PortType::BLE_HM10:
   case PortType::RFCOMM_SERVER:
   case PortType::IOIOUART:
   case PortType::DROIDSOAR_V2:
@@ -219,6 +221,18 @@ DeviceConfig::GetPortName(TCHAR *buffer, size_t max_size) const
   case PortType::SERIAL:
     return path.c_str();
 
+  case PortType::BLE_HM10: {
+    const TCHAR *name = bluetooth_mac.c_str();
+#ifdef ANDROID
+    const char *name2 =
+      BluetoothHelper::GetNameFromAddress(Java::GetEnv(), name);
+    if (name2 != nullptr)
+      name = name2;
+#endif
+
+    StringFormat(buffer, max_size, _T("HM10 %s"), name);
+    return buffer;
+    }
   case PortType::RFCOMM: {
     const TCHAR *name = bluetooth_mac.c_str();
 #ifdef ANDROID

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -102,6 +102,12 @@ struct DeviceConfig {
      * for debugging.
      */
     PTY,
+
+    /**
+     * Bluetooth Low Energy HM10 protocol to a paired device.
+     */
+    BLE_HM10,
+
   };
 
   /**
@@ -276,6 +282,7 @@ struct DeviceConfig {
   static bool UsesDriver(PortType port_type) {
     return port_type == PortType::SERIAL || port_type == PortType::RFCOMM ||
       port_type == PortType::RFCOMM_SERVER ||
+      port_type == PortType::BLE_HM10 ||
       port_type == PortType::AUTO || port_type == PortType::TCP_LISTENER ||
       port_type == PortType::TCP_CLIENT ||
       port_type == PortType::IOIOUART || port_type == PortType::PTY ||

--- a/src/Device/Port/AndroidBluetoothPort.cpp
+++ b/src/Device/Port/AndroidBluetoothPort.cpp
@@ -50,3 +50,17 @@ OpenAndroidBluetoothServerPort(PortListener *listener, DataHandler &handler)
 
   return new AndroidPort(listener, handler, bridge);
 }
+
+Port *
+OpenAndroidBleHm10Port(const TCHAR *address, PortListener *listener,
+                         DataHandler &handler)
+{
+  assert(address != nullptr);
+
+  PortBridge *bridge = BluetoothHelper::connectHM10(Java::GetEnv(), address);
+  if (bridge == nullptr)
+    return nullptr;
+
+  return new AndroidPort(listener, handler, bridge);
+}
+

--- a/src/Device/Port/AndroidBluetoothPort.hpp
+++ b/src/Device/Port/AndroidBluetoothPort.hpp
@@ -39,6 +39,11 @@ OpenAndroidBluetoothPort(const TCHAR *address, PortListener *_listener,
 
 gcc_malloc
 Port *
+OpenAndroidBleHm10Port(const TCHAR *address, PortListener *_listener,
+                         DataHandler &_handler);
+
+gcc_malloc
+Port *
 OpenAndroidBluetoothServerPort(PortListener *_listener, DataHandler &_handler);
 
 #endif

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -112,6 +112,19 @@ OpenPortInternal(const DeviceConfig &config, PortListener *listener,
     path = config.path.c_str();
     break;
 
+  case DeviceConfig::PortType::BLE_HM10:
+#ifdef ANDROID
+    if (config.bluetooth_mac.empty()) {
+      LogFormat("No Bluetooth MAC configured");
+      return nullptr;
+    }
+
+    return OpenAndroidBleHm10Port(config.bluetooth_mac, listener, handler);
+#else
+    LogFormat("Bluetooth not available on this platform");
+    return nullptr;
+#endif
+
   case DeviceConfig::PortType::RFCOMM:
 #ifdef ANDROID
     if (config.bluetooth_mac.empty()) {

--- a/src/Device/device.cpp
+++ b/src/Device/device.cpp
@@ -64,6 +64,7 @@ DeviceConfigOverlaps(const DeviceConfig &a, const DeviceConfig &b)
     return a.path.equals(b.path);
 
   case DeviceConfig::PortType::RFCOMM:
+  case DeviceConfig::PortType::BLE_HM10:
     return a.bluetooth_mac.equals(b.bluetooth_mac);
 
   case DeviceConfig::PortType::IOIOUART:

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -400,6 +400,7 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc, unsigned idx)
     status = buffer;
 #ifdef ANDROID
   } else if ((config.port_type == DeviceConfig::PortType::RFCOMM ||
+              config.port_type == DeviceConfig::PortType::BLE_HM10 ||
               config.port_type == DeviceConfig::PortType::RFCOMM_SERVER) &&
              !BluetoothHelper::isEnabled(Java::GetEnv())) {
     status = _("Bluetooth is disabled");
@@ -465,6 +466,7 @@ DeviceListWidget::ReconnectCurrent()
   const DeviceConfig &config =
     CommonInterface::SetSystemSettings().devices[current];
   if ((config.port_type == DeviceConfig::PortType::RFCOMM ||
+       config.port_type == DeviceConfig::PortType::BLE_HM10 ||
        config.port_type == DeviceConfig::PortType::RFCOMM_SERVER) &&
       !BluetoothHelper::isEnabled(Java::GetEnv())) {
     ShowMessageBox(_("Bluetooth is disabled"), _("Reconnect"),

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -50,6 +50,7 @@ static const char *const port_type_strings[] = {
   "tcp_listener",
   "udp_listener",
   "pty",
+  "ble_hm10",
   NULL
 };
 


### PR DESCRIPTION


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Add a new device type to represent Bluetooth Low Energy serial port devices. These must be distinguished from legacy Bluetooth serial devices using the RFCOMM profile since the connection sequence is different. The old code queried the Android BT system to try to determine the type of a device based solely on its address. This fails if the Android BT cache has been flushed (by device or BT system restart.) This commit adds a new device type - BLE_HM10 - representing a BLE device implementing a serial port on a specific characteristic.

The stored type is used to select the correct re-connection protocol.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

Fixes #149 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
