### PR TITLE
Detect initial screen orientation

### DIFF
--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -43,6 +43,7 @@ Display::LoadOrientation(VerboseOperationEnvironment &env)
 
   DisplayOrientation orientation =
     CommonInterface::GetUISettings().display.orientation;
+
 #ifdef KOBO
   /* on the Kobo, the display orientation must be loaded explicitly
      (portrait), because the hardware default is landscape */
@@ -86,4 +87,10 @@ Display::RestoreOrientation()
 #ifdef USE_POLL_EVENT
   event_queue->SetDisplayOrientation(DisplayOrientation::DEFAULT);
 #endif
+}
+
+DisplayOrientation
+Display::DetectInitialOrientation()
+{
+  return DisplayOrientation::DEFAULT;
 }

--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -27,6 +27,8 @@ Copyright_License {
 #include "LogFile.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
+#include "OS/Path.hpp"
+#include "OS/FileUtil.hpp"
 
 #ifdef USE_POLL_EVENT
 #include "Event/Globals.hpp"
@@ -92,5 +94,21 @@ Display::RestoreOrientation()
 DisplayOrientation
 Display::DetectInitialOrientation()
 {
-  return DisplayOrientation::DEFAULT;
+  auto orientation = DisplayOrientation::DEFAULT;
+
+#ifdef MESA_KMS
+  // When running in DRM/KMS mode, infer the display orientation from the linux
+  // console rotation.
+  char buf[3];
+  auto rotatepath = Path("/sys/class/graphics/fbcon/rotate");
+  if (File::ReadString(rotatepath, buf, sizeof(buf))) {
+    switch (*buf) {
+    case '0': orientation = DisplayOrientation::LANDSCAPE; break;
+    case '1': orientation = DisplayOrientation::REVERSE_PORTRAIT; break;
+    case '2': orientation = DisplayOrientation::REVERSE_LANDSCAPE; break;
+    case '3': orientation = DisplayOrientation::PORTRAIT; break;
+    }
+  }
+#endif
+  return orientation;
 }

--- a/src/Hardware/DisplayGlue.hpp
+++ b/src/Hardware/DisplayGlue.hpp
@@ -24,12 +24,15 @@ Copyright_License {
 #ifndef XCSOAR_HARDWARE_DISPLAY_GLUE_H
 #define XCSOAR_HARDWARE_DISPLAY_GLUE_H
 
+#include "DisplayOrientation.hpp"
+
 class VerboseOperationEnvironment;
 
 namespace Display
 {
   void LoadOrientation(VerboseOperationEnvironment &env);
   void RestoreOrientation();
+  DisplayOrientation DetectInitialOrientation();
 }
 
 #endif

--- a/src/Screen/Custom/TopWindow.cpp
+++ b/src/Screen/Custom/TopWindow.cpp
@@ -65,6 +65,9 @@ TopWindow::Create(const TCHAR *text, PixelSize size,
     return;
   }
 
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  screen->SetDisplayOrientation(style.GetInitialOrientation());
+#endif
   ContainerWindow::Create(nullptr, screen->GetRect(), style);
 }
 

--- a/src/Screen/TopWindow.hpp
+++ b/src/Screen/TopWindow.hpp
@@ -50,7 +50,7 @@ struct SDL_Window;
 #include <tchar.h>
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
-enum class DisplayOrientation : uint8_t;
+#include "DisplayOrientation.hpp"
 #endif
 
 #ifndef USE_WINUSER
@@ -80,6 +80,9 @@ class TopWindowStyle : public WindowStyle {
 #endif
 #ifdef ENABLE_SDL
   bool resizable = false;
+#endif
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  DisplayOrientation initial_orientation = DisplayOrientation::DEFAULT;
 #endif
 
 public:
@@ -124,6 +127,15 @@ public:
     return false;
 #endif
   }
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  void InitialOrientation(DisplayOrientation orientation) {
+    initial_orientation = orientation;
+  }
+
+  DisplayOrientation GetInitialOrientation() const {
+    return initial_orientation;
+  }
+#endif
 };
 
 /**

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -191,6 +191,10 @@ Startup()
 
   style.Resizable();
 
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  style.InitialOrientation(Display::DetectInitialOrientation());
+#endif
+
   MainWindow *const main_window = CommonInterface::main_window =
     new MainWindow();
   main_window->Create(SystemWindowSize(), style);


### PR DESCRIPTION
On devices with fixed physical screens (such as Openvario) the orientation of initial screens, such as Fly/Simulator selection or profile selector might appear sideways (see the example screenshot below). 

This PR adds ability to autodetect the display orientation from the OS environment and implements detection from linux console orientation when XCSoar is run under DRM/KMS (Openvario case).

See the commit messages for more detailed description.

![IMG_20200710_004529 resized](https://user-images.githubusercontent.com/59499/87094342-68816b00-c247-11ea-8226-cc321d5a2c5c.jpg)
