### PR TITLE
Fix for ANDROID build - (OpenSSL, JAVA) on master-branch

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -194,7 +194,7 @@ $(ANDROID_BUILD)/gen/org/xcsoar/R.java: $(ANDROID_BUILD)/resources.apk
 
 $(ANDROID_BUILD)/classes.dex: $(JAVA_SOURCES) $(ANDROID_BUILD)/gen/org/xcsoar/R.java | $(JAVA_CLASSFILES_DIR)/dirstamp
 	@$(NQ)echo "  JAVAC   $(JAVA_CLASSFILES_DIR)"
-	$(Q)$(JAVAC) -source 1.6 -target 1.6 -Xlint:-options \
+	$(Q)$(JAVAC) -source 1.7 -target 1.7 -Xlint:-options \
 		-cp $(ANDROID_SDK_PLATFORM_DIR)/android.jar:$(JAVA_CLASSFILES_DIR) \
 		-d $(JAVA_CLASSFILES_DIR) $(ANDROID_BUILD)/gen/org/xcsoar/R.java \
 		-h $(NATIVE_INCLUDE) \

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -54,8 +54,8 @@ libstdcxx_musl_headers = LibstdcxxMuslHeadersProject(
 )
 
 openssl = OpenSSLProject(
-    'https://www.openssl.org/source/openssl-3.0.0-alpha4.tar.gz',
-    'ftp://ftp.cert.dfn.de/pub/tools/net/openssl/source/openssl-3.0.0-alpha4.tar.gz',
+    'https://www.openssl.org/source/old/3.0/openssl-3.0.0-alpha4.tar.gz',
+    'ftp://ftp.cert.dfn.de/pub/tools/net/old/3.0/openssl/source/openssl-3.0.0-alpha4.tar.gz',
     'd930b650e0899f5baca8b80c50e7401620c129fef6c50198400999776a39bd37',
     'include/openssl/ossl_typ.h',
 )


### PR DESCRIPTION
When trying to do a fresh build of the master-branch for TARGET=ANDROID it currently fails because of two reasons:

**OpenSSL (libs.py) **
The file 
https://www.openssl.org/source/openssl-3.0.0-alpha4.tar.gz
has been moved to
https://www.openssl.org/source/ **old/3.0/** openssl-3.0.0-alpha4.tar.gz
Therefore the build breaks if this file has not been downloaded upfront / manually.

**JAVA (android.mk)**
The JAVA-build for android fails on newer JDKs because building JAVA 1.6 is not supported anymore. Therefore changed the build to 1.7