### PR TITLE
Ide docker updates

### DIFF
--- a/ide/docker/Dockerfile
+++ b/ide/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN /root/install-debian-packages.sh && apt-get clean
 COPY ./provisioning/install-android-tools.sh /root/install-android-tools.sh
 RUN chmod 755 /root/install-android-tools.sh /root/install-debian-packages.sh
 RUN /root/install-android-tools.sh && apt-get clean
-RUN apt-get -y install python-minimal python3 vim ccache python3-pkgconfig && apt-get clean
+RUN apt-get -y install python-minimal python3 vim ccache python3-pkgconfig gdb && apt-get clean
 
 WORKDIR /opt/xcsoar
 

--- a/ide/docker/README.md
+++ b/ide/docker/README.md
@@ -45,9 +45,10 @@ In this case you can start XCSoar inside the container and let it be displayed o
 docker run \
     --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
     --volume="$HOME/.Xauthority:/root/.Xauthority:rw" \
+    -v $HOME/.xcsoar/:/root/.xcsoar \
     --env="DISPLAY" --net=host \
     -it xscoar/xcsoar-build /bin/bash
-
+```
 Compile and run the binary (UNIX-SDL target):
 ```
 xcsoar-compile UNIX-SDL


### PR DESCRIPTION
Brief summary of the changes
----------------------------

* Add `libglm-dev` to the debian packages to fix `glm/fwd.hpp` missing file error

* Since XCSoar can now be run inside the container, also include `gdb` for debugging inside the container. 
* Finally, to make running XCSoar inside the docker container slightly nicer, I added a way to mount the xcsoar data folder to the example in the readme (which had a typo that I also took the liberty to fix).
