### PR TITLE
gracefully handle unknown size of the active area of the display

### DIFF
--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -132,8 +132,17 @@ void
 Display::ProvideSizeMM(unsigned width_pixels, unsigned height_pixels,
                        unsigned width_mm, unsigned height_mm) noexcept
 {
-  detected_x_dpi = MMToDPI(width_pixels, width_mm);
-  detected_y_dpi = MMToDPI(height_pixels, height_mm);
+  if (width_mm == 0) { // usually means the active width is unknown
+    detected_x_dpi = Display::GetXDPI();
+  } else {
+    detected_x_dpi = MMToDPI(width_pixels, width_mm);
+  }
+
+  if (height_mm == 0) { // usually means the active height is unknown
+    detected_y_dpi = Display::GetYDPI();
+  } else {
+    detected_y_dpi = MMToDPI(height_pixels, height_mm);
+  }
 }
 
 #endif


### PR DESCRIPTION


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
If the active area is unknown usually the width and height in mm == 0.
With HAVE_DPI_DETECTION MMToDPI() runs into a divide by 0.

Instead use the DPI values known at this time. A good choice is what the user provides at the commend line.
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/475

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
