### PR TITLE
github/actions: build container creation/upload

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ./ide/docker/
+      - ./ide/provisioning/
+
+jobs:
+ xcsoar-docker-env:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGENAME: xcsoar-build
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: True
+      - run: echo ${{ secrets.GHRCIO }} | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin
+      - run: docker pull ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGENAME }} || true
+      - run: docker build ./ide/ --file ide/docker/Dockerfile --cache-from=${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGENAME }} -t ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGENAME }} 
+      - run: docker push ${{ env.REGISTRY }}/${{ github.actor }}/${{ env.IMAGENAME }}


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Is this builds the XCSoar-build container automatically, and pushes it to the ghcr.io/XCSoar registry. 
With this we have an official build environment for anyone ready to pull.
This also lessens the dependence on github, travis, or cicle-ci for building xcsoar, and even self-hosted building is possible.
At a later stage its planned to use it for the CI so that we have a consistent build environment and replace circle.ci.