### PR TITLE
Larger InfoBox comments for smaller displays

### DIFF
--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -51,6 +51,7 @@ enum ControlIndex {
   AppInverseInfoBox,
   AppInfoBoxColors,
   AppInfoBoxBorder,
+  AppInfoBoxLargeComment,
 #ifdef KOBO
   ShowMenuButton,
 #endif
@@ -219,6 +220,13 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc)
           unsigned(ui_settings.info_boxes.border_style));
   SetExpertRow(AppInfoBoxBorder);
 
+  AddBoolean(_("Big InfoBox comment"),
+              _("If true, Info Box comments will be larger. Useful for smaller displays, "
+                "although long comments will be truncated."),
+              ui_settings.info_boxes.large_comments);
+  SetExpertRow(AppInfoBoxLargeComment);
+
+
 #ifdef KOBO
   AddBoolean(_("Show Menubutton"), _("Show the Menubutton"),
              ui_settings.show_menu_button);
@@ -275,6 +283,10 @@ LayoutConfigPanel::Save(bool &_changed)
       SaveValue(AppInfoBoxColors, ProfileKeys::AppInfoBoxColors,
                 ui_settings.info_boxes.use_colors))
     require_restart = changed = true;
+
+  info_box_geometry_changed |= SaveValue(AppInfoBoxLargeComment, ProfileKeys::AppInfoBoxLargeComment,
+            ui_settings.info_boxes.large_comments);
+
 
 #ifdef KOBO
   if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,ui_settings.show_menu_button))

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -126,7 +126,7 @@ struct InfoBoxSettings {
 
   } geometry;
 
-  bool inverse, use_colors;
+  bool inverse, use_colors, large_comments;
 
   enum class BorderStyle : uint8_t {
     BOX,

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -158,7 +158,7 @@ InfoBoxWindow::PaintComment(Canvas &canvas)
 
   canvas.SetTextColor(look.GetCommentColor(data.comment_color));
 
-  const Font &font = look.title_font;
+  const Font &font = look.comment_font;
   canvas.Select(font);
 
   PixelSize tsize = canvas.CalcTextSize(data.comment);
@@ -323,7 +323,7 @@ InfoBoxWindow::OnResize(PixelSize new_size)
   title_rect.bottom = rc.top + look.title_font.GetHeight();
 
   comment_rect = rc;
-  comment_rect.top = comment_rect.bottom - look.title_font.GetHeight();
+  comment_rect.top = comment_rect.bottom - look.comment_font.GetHeight();
 
   value_rect = rc;
   value_rect.top = title_rect.bottom;

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -26,6 +26,7 @@ Copyright_License {
 #include "Colors.hpp"
 #include "Screen/Layout.hpp"
 #include "AutoFont.hpp"
+#include "Interface.hpp"
 
 #ifdef HAVE_TEXT_CACHE
 #include "Screen/Custom/Cache.hpp"
@@ -75,6 +76,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
 void
 InfoBoxLook::ReinitialiseLayout(unsigned width)
 {
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
   const unsigned max_font_height = Layout::FontScale(12);
 
   FontDescription title_font_d(8);
@@ -91,6 +93,15 @@ InfoBoxLook::ReinitialiseLayout(unsigned width)
   FontDescription small_value_font_d(10);
   AutoSizeFont(small_value_font_d, width, _T("12345m"));
   small_value_font.Load(small_value_font_d);
+
+  FontDescription comment_font_d(8);
+  if (ui_settings.info_boxes.large_comments) {
+    AutoSizeFont(comment_font_d, width, _T("123456789"));
+  }
+  else {
+    AutoSizeFont(comment_font_d, width, _T("123456789012345"));
+  }
+  comment_font.Load(comment_font_d);
 
   unsigned unit_font_height = std::max(value_font_d.GetHeight() * 2u / 5u, 7u);
   unit_font.Load(FontDescription(unit_font_height));

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -59,6 +59,8 @@ struct InfoBoxLook {
 
   Font title_font;
 
+  Font comment_font;
+
   Color colors[6];
 
   void Initialise(bool inverse, bool use_colors,

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -57,9 +57,7 @@ struct InfoBoxLook {
 
   Pen unit_fraction_pen;
 
-  Font title_font;
-
-  Font comment_font;
+  Font title_font, comment_font;
 
   Color colors[6];
 

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -129,6 +129,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
 
   map.Get(ProfileKeys::AppInverseInfoBox, settings.inverse);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);
+  map.Get(ProfileKeys::AppInfoBoxLargeComment, settings.large_comments);
 
   map.GetEnum(ProfileKeys::AppInfoBoxBorder, settings.border_style);
 

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -134,6 +134,7 @@ const char AppInfoBoxBorder[] = "AppInfoBoxBorder";
 const char ShowMenuButton[] = "ShowMenuButton";
 const char CursorSize[] = "CursorSize";
 const char CursorColorsInverted[] = "CursorColorsInverted";
+const char AppInfoBoxLargeComment[] = "AppInfoBoxLargeComment";
 
 const char AppAveNeedle[] = "AppAveNeedle";
 const char AppAveThermalNeedle[] = "AppAveThermalNeedle";

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -150,6 +150,7 @@ extern const char DetourCostMarker[];
 extern const char DisplayTrackBearing[];
 extern const char GliderScreenPosition[];
 extern const char SetSystemTimeFromGPS[];
+extern const char AppInfoBoxLargeComment[];
 
 extern const char FinishMinHeight[];
 extern const char FinishHeightRef[];


### PR DESCRIPTION


Brief summary of the changes
----------------------------

InfoBox comments on smaller displays are unreadable. This change enables larger text to be used if desired.
Some comment text may be truncated as a result.

This can be configured via Config/System/Look/Screen Layout

Related issues and discussions
------------------------------

None
