### PR TITLE
Preserve zoom level in TrafficWidget

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -36,6 +36,8 @@ Version 7.0 - not yet released
   - enable SkyLines traffic display on Windows
   - add option to show SkyLines traffic names on the map
   - show thermals obtained from the XCSoar Cloud server
+* FLARM radar
+  - preserve zoom level when switch between pages
 * analysis
   - enhanced graphics: minor tics, color scheme, layout
   - key labels drawn on lines in several pages

--- a/build/main.mk
+++ b/build/main.mk
@@ -362,6 +362,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/GlueGaugeVario.cpp \
 	$(SRC)/Gauge/TaskView.cpp \
 	$(SRC)/Gauge/LogoView.cpp \
+	$(SRC)/Gauge/TrafficUIState.cpp \
 	\
 	$(SRC)/Waypoint/WaypointDetailsReader.cpp \
 	$(SRC)/Menu/MenuData.cpp \

--- a/src/Gauge/BigTrafficWidget.cpp
+++ b/src/Gauge/BigTrafficWidget.cpp
@@ -59,9 +59,10 @@ protected:
 public:
   FlarmTrafficControl(const FlarmTrafficLook &look)
     :FlarmTrafficWindow(look, Layout::Scale(10),
-                        Layout::GetMinimumControlHeight() + Layout::Scale(2)),
+                        Layout::GetMinimumControlHeight() + Layout::Scale(2),
+                        false, GetZoomDistance(CommonInterface::GetUIState().traffic.zoom)),
      enable_auto_zoom(true), dragging(false),
-     zoom(2),
+     zoom(CommonInterface::GetUIState().traffic.zoom),
      task_direction(Angle::Degrees(-1)) {}
 
 protected:
@@ -87,6 +88,10 @@ public:
   }
 
   static unsigned GetZoomDistance(unsigned zoom);
+
+  unsigned GetZoom() {
+    return zoom;
+  }
 
   void SetZoom(unsigned _zoom) {
     zoom = _zoom;
@@ -888,6 +893,13 @@ TrafficWidget::Prepare(ContainerWindow &parent, const PixelRect &_rc)
   view->Create(GetContainer(), rc);
 
   UpdateLayout();
+}
+
+bool
+TrafficWidget::Leave()
+{
+  CommonInterface::SetUIState().traffic.zoom = view->GetZoom();
+  return true;
 }
 
 void

--- a/src/Gauge/BigTrafficWidget.hpp
+++ b/src/Gauge/BigTrafficWidget.hpp
@@ -77,6 +77,7 @@ public:
   /* virtual methods from class Widget */
   virtual void Prepare(ContainerWindow &parent,
                        const PixelRect &rc) override;
+  virtual bool Leave() override;
   virtual void Unprepare() override;
   virtual void Show(const PixelRect &rc) override;
   virtual void Hide() override;

--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -46,9 +46,10 @@
 FlarmTrafficWindow::FlarmTrafficWindow(const FlarmTrafficLook &_look,
                                        unsigned _h_padding,
                                        unsigned _v_padding,
-                                       bool _small)
+                                       bool _small,
+                                       double _distance)
   :look(_look),
-   distance(2000),
+   distance(_distance),
    selection(-1), warning(-1),
    h_padding(_h_padding), v_padding(_v_padding),
    small(_small),

--- a/src/Gauge/FlarmTrafficWindow.hpp
+++ b/src/Gauge/FlarmTrafficWindow.hpp
@@ -82,7 +82,8 @@ public:
 public:
   FlarmTrafficWindow(const FlarmTrafficLook &_look,
                      unsigned _h_padding, unsigned _v_padding,
-                     bool _small = false);
+                     bool _small = false,
+                     double distance = 2000.0);
 
 public:
   bool WarningMode() const;

--- a/src/Gauge/TrafficUIState.cpp
+++ b/src/Gauge/TrafficUIState.cpp
@@ -21,18 +21,9 @@ Copyright_License {
 }
 */
 
-#include "UIState.hpp"
+#include "TrafficUIState.hpp"
 
 void
-UIState::Clear()
-{
-  screen_blanked = false;
-  force_display_mode = DisplayMode::NONE;
-  display_mode = DisplayMode::NONE;
-  auxiliary_enabled = false;
-  panel_index = 0;
-  panel_name.clear();
-  pages.Clear();
-  weather.Clear();
-  traffic.Clear();
+TrafficUIState::Clear() {
+  zoom = 2;
 }

--- a/src/Gauge/TrafficUIState.hpp
+++ b/src/Gauge/TrafficUIState.hpp
@@ -21,18 +21,21 @@ Copyright_License {
 }
 */
 
-#include "UIState.hpp"
+#ifndef XCSOAR_TRAFFIC_UI_STATE_HPP
+#define XCSOAR_TRAFFIC_UI_STATE_HPP
 
-void
-UIState::Clear()
-{
-  screen_blanked = false;
-  force_display_mode = DisplayMode::NONE;
-  display_mode = DisplayMode::NONE;
-  auxiliary_enabled = false;
-  panel_index = 0;
-  panel_name.clear();
-  pages.Clear();
-  weather.Clear();
-  traffic.Clear();
-}
+/**
+ * The state of traffic display on the user interface.
+ */
+struct TrafficUIState {
+
+  /**
+   * Traffic map zoom level from 0 to 4
+   */
+  unsigned zoom;
+
+  void Clear();
+
+};
+
+#endif

--- a/src/UIState.hpp
+++ b/src/UIState.hpp
@@ -28,6 +28,7 @@ Copyright_License {
 #include "util/StaticString.hxx"
 #include "PageState.hpp"
 #include "Weather/WeatherUIState.hpp"
+#include "Gauge/TrafficUIState.hpp"
 
 /**
  * The state of the user interface.
@@ -79,6 +80,8 @@ struct UIState {
   PagesState pages;
 
   WeatherUIState weather;
+
+  TrafficUIState traffic;
 
   void Clear();
 };


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Preserver zoom level in FLARM radar when switching between pages
![flarm](https://user-images.githubusercontent.com/496209/100393420-7dfa0480-3031-11eb-8977-bad74e7b6377.gif)


Related issues and discussions
------------------------------
Closes #455 
