### PR TITLE
Skip latitude,longitude=0.0,0.0 from XCTracer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,6 +57,7 @@ The following people and organizations have contributed code to XCSoar:
  Peter F Bradshaw <pfb@exadios.com>
  Stefan Schumann <stefan.schumann@posteo.de>
  Roel Baardman <roel.baardman@gmail.com>
+ Jetsada Machom <zinuzoid@gmail.com>
 
 Documentation:
 

--- a/src/Device/Driver/XCTracer/Parser.cpp
+++ b/src/Device/Driver/XCTracer/Parser.cpp
@@ -90,9 +90,22 @@ static int
 ReadCheckedLatitudeLongitude(NMEAInputLine &line, double &value_latitude, double &value_longitude)
 {
   int valid_fields = 0;
+  double latitude, longitude;
+  double epsilon = std::numeric_limits<double>::epsilon();
 
-  valid_fields += ReadCheckedRange(line, value_latitude, -90.0, 90.0);
-  valid_fields += ReadCheckedRange(line, value_longitude, -180.0, 180.0);
+  valid_fields += ReadCheckedRange(line, latitude, -90.0, 90.0);
+  valid_fields += ReadCheckedRange(line, longitude, -180.0, 180.0);
+
+  if(valid_fields == 2 && !(fabs(latitude) < epsilon && fabs(longitude) < epsilon)) {
+    value_latitude = latitude;
+    value_longitude = longitude;
+  } else {
+    /**
+     * While inactive on the ground XCTracer send the 0.0/0.0 location.
+     * We mark as invalid here, so map is not jumping to the 0.0/0.0
+     */
+    valid_fields = 0;
+  }
 
   return valid_fields;
 }

--- a/src/Device/Driver/XCTracer/Parser.cpp
+++ b/src/Device/Driver/XCTracer/Parser.cpp
@@ -86,6 +86,17 @@ ReadCheckedRange(NMEAInputLine &line,double &value_r, double min, double max)
   return true;
 }
 
+static int
+ReadCheckedLatitudeLongitude(NMEAInputLine &line, double &value_latitude, double &value_longitude)
+{
+  int valid_fields = 0;
+
+  valid_fields += ReadCheckedRange(line, value_latitude, -90.0, 90.0);
+  valid_fields += ReadCheckedRange(line, value_longitude, -180.0, 180.0);
+
+  return valid_fields;
+}
+
 /**
  * the parser for the LXWP0 subset sentence that the XC-Tracer can produce
  */
@@ -167,8 +178,7 @@ XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
    * parse and check both  values, even if one or more is empty, e.g. ",3.1234,"
    */
   double latitude, longitude;
-  valid_fields += ReadCheckedRange(line,latitude,-90.0,90.0);
-  valid_fields += ReadCheckedRange(line,longitude,-180.0,180.0);
+  valid_fields += ReadCheckedLatitudeLongitude(line, latitude, longitude);
 
   /**
    * we only want to accept GPS fixes with completely sane values

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1485,6 +1485,15 @@ TestXCTracer()
   ok1(nmea_info.battery_level_available);
   ok1(equals(nmea_info.battery_level,77));
 
+  /* latitude,longitude=0,0 while inactive on the ground must be ignored */
+  ok1(device->ParseNMEA("$XCTRC,2020,11,27,18,47,31,0,0.000000,0.000000,"
+      "-0.26,0.00,0.0,-0.02,,,,1013.26,40*78",nmea_info));
+  
+  /* now check location and time, it should be last one as we skip the recent one */
+  ok1(equals(nmea_info.time, 10 * 3600 + 56 * 60 + 23.80));
+  ok1(equals(nmea_info.location.longitude, 8.104885));
+  ok1(equals(nmea_info.location.latitude, 48.62825));
+
   delete device;
 }
 
@@ -1602,7 +1611,7 @@ TestFlightList(const struct DeviceRegister &driver)
 
 int main(int argc, char **argv)
 {
-  plan_tests(827);
+  plan_tests(831);
 
   TestGeneric();
   TestTasman();


### PR DESCRIPTION
Brief summary of the changes
----------------------------
While on the ground the XCTracer send lat,lon = 0.0,0.0
This is annoying as your location would jumping to the middle of the ocean (where 0.0/0.0 is).
It is hard to check your waypoint like this.
So we should just skip the 0.0 0.0 location from XCTracer


Here's after the fix, no GPS fix were accepted
![Screenshot_20201127-184733_XCSoar_292x600](https://user-images.githubusercontent.com/496209/100490697-246b0600-3115-11eb-852f-b6b3392ccd95.jpg)|![Screenshot_20201128-004137_XCSoar_292x600](https://user-images.githubusercontent.com/496209/100490695-2339d900-3115-11eb-9fee-102d84d449cf.jpg)
