### PR TITLE
Implement FANET '#FNF' service (type 4) sentences decoding

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,12 +22,14 @@ Version 7.0 - not yet released
   - GliderLink: new driver
   - AirControlDisplay: read radio frequencies from PAAVS,COM sentence
   - driver for LXNano modified, so declaration contains copilot
+  - driver for parsing FANET #FNF sentences
 * weather
   - merge all weather data in one dialog
   - allow showing both terrain and RASP
   - RASP download from various well-known providers
   - show satellite images from pc_met (Deutscher Wetterdienst)
   - show wave forecast from pc_met (Deutscher Wetterdienst)
+  - show wind arrow, speed and gust from parsed FANET #FNF sentences
 * calculations
   - merge redundant waves
   - task restart

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -87,7 +87,11 @@ XCTRACER_SOURCES = \
 
 THERMALEXPRESS_SOURCES = \
 	$(DRIVER_SRC_DIR)/ThermalExpress/Driver.cpp
- 
+
+FANET_SOURCES = \
+	$(DRIVER_SRC_DIR)/FANET/Register.cpp \
+	$(DRIVER_SRC_DIR)/FANET/Parser.cpp
+
 DRIVER_SOURCES = \
 	$(SRC)/Device/Driver.cpp \
 	$(SRC)/Device/Register.cpp \
@@ -101,6 +105,7 @@ DRIVER_SOURCES = \
 	$(BLUEFLY_SOURCES) \
 	$(XCTRACER_SOURCES) \
 	$(THERMALEXPRESS_SOURCES) \
+	$(FANET_SOURCES) \
 	$(DRIVER_SRC_DIR)/AltairPro.cpp \
 	$(DRIVER_SRC_DIR)/BorgeltB50.cpp \
 	$(DRIVER_SRC_DIR)/XCVario.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -248,6 +248,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/FLARM/FlarmComputer.cpp \
 	$(SRC)/FLARM/Global.cpp \
 	$(SRC)/FLARM/Glue.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/Computer/CuComputer.cpp \
 	$(SRC)/Computer/FlyingComputer.cpp \
 	$(SRC)/Computer/CirclingComputer.cpp \
@@ -490,6 +491,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/MapWindow/MapWindowTraffic.cpp \
 	$(SRC)/MapWindow/MapWindowTrail.cpp \
 	$(SRC)/MapWindow/MapWindowWaypoints.cpp \
+	$(SRC)/MapWindow/MapWindowFanetStation.cpp \
 	$(SRC)/MapWindow/GlueMapWindow.cpp \
 	$(SRC)/MapWindow/GlueMapWindowItems.cpp \
 	$(SRC)/MapWindow/GlueMapWindowEvents.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -656,6 +656,7 @@ TEST_DRIVER_SOURCES = \
 	$(SRC)/FLARM/Traffic.cpp \
 	$(SRC)/FLARM/FlarmId.cpp \
 	$(SRC)/FLARM/FlarmCalculations.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/Info.cpp \
 	$(SRC)/NMEA/GPSState.cpp \
 	$(SRC)/NMEA/Attitude.cpp \
@@ -875,6 +876,7 @@ DEBUG_REPLAY_SOURCES = \
 	$(SRC)/FLARM/FlarmId.cpp \
 	$(SRC)/FLARM/Traffic.cpp \
 	$(SRC)/FLARM/List.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/Computer/BasicComputer.cpp \
 	$(SRC)/Computer/GroundSpeedComputer.cpp \
 	$(SRC)/Computer/FlyingComputer.cpp \
@@ -1294,6 +1296,7 @@ RUN_DEVICE_DRIVER_SOURCES = \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/FLARM/Traffic.cpp \
 	$(SRC)/FLARM/List.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/Info.cpp \
 	$(SRC)/NMEA/GPSState.cpp \
 	$(SRC)/NMEA/Acceleration.cpp \
@@ -1326,6 +1329,7 @@ RUN_DECLARE_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/InputLine.cpp \
 	$(SRC)/NMEA/Checksum.cpp \
 	$(SRC)/NMEA/ExternalSettings.cpp \
@@ -1362,6 +1366,7 @@ RUN_ENABLE_NMEA_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/InputLine.cpp \
 	$(SRC)/NMEA/Checksum.cpp \
 	$(SRC)/NMEA/ExternalSettings.cpp \
@@ -1453,6 +1458,7 @@ RUN_FLIGHT_LIST_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/InputLine.cpp \
 	$(SRC)/NMEA/Checksum.cpp \
 	$(SRC)/NMEA/ExternalSettings.cpp \
@@ -1487,6 +1493,7 @@ RUN_DOWNLOAD_FLIGHT_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(SRC)/FANET/FanetStation.cpp \
 	$(SRC)/NMEA/InputLine.cpp \
 	$(SRC)/NMEA/Checksum.cpp \
 	$(SRC)/NMEA/ExternalSettings.cpp \
@@ -1829,6 +1836,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/MapWindow/MapWindowTask.cpp \
 	$(SRC)/MapWindow/MapWindowThermal.cpp \
 	$(SRC)/MapWindow/MapWindowTraffic.cpp \
+	$(SRC)/MapWindow/MapWindowFanetStation.cpp \
 	$(SRC)/MapWindow/MapWindowTrail.cpp \
 	$(SRC)/MapWindow/MapWindowWaypoints.cpp \
 	$(SRC)/MapWindow/MapCanvas.cpp \

--- a/src/Device/Driver/FANET.hpp
+++ b/src/Device/Driver/FANET.hpp
@@ -1,0 +1,29 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_DEVICE_DRIVER_FANET_HPP
+#define XCSOAR_DEVICE_DRIVER_FANET_HPP
+
+extern const struct DeviceRegister fanet_driver;
+
+#endif //XCSOAR_FANET_H

--- a/src/Device/Driver/FANET/Device.hpp
+++ b/src/Device/Driver/FANET/Device.hpp
@@ -1,0 +1,142 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_FANET_DEVICE_HPP
+#define XCSOAR_FANET_DEVICE_HPP
+
+#include "Device/Driver.hpp"
+#include "FANET/List.hpp"
+#include "FANET/FanetStation.hpp"
+
+struct NMEAInfo;
+
+class FanetDevice final : public AbstractDevice {
+private:
+  enum FanetPacketType {
+    FANET_TYPE_ACK,
+    FANET_TYPE_TRACKING,
+    FANET_TYPE_NAME,
+    FANET_TYPE_MESSAGE,
+    FANET_TYPE_SERVICE,
+    FANET_TYPE_LANDMARKS,
+    FANET_TYPE_REMOTE_CONFIG,
+    FANET_TYPE_GROUND_TRACKING,
+    FANET_TYPE_HW_INFO,
+    FANET_TYPE_THERMAL
+  };
+
+  enum FanetServiceHeaderBits {
+    FANET_SERVICE_BIT_EHEADER,
+    FANET_SERVICE_BIT_SOC,
+    FANET_SERVICE_BIT_REMOTECFGSUPPORT,
+    FANET_SERVICE_BIT_PRESSURE,
+    FANET_SERVICE_BIT_HUMIDITY,
+    FANET_SERVICE_BIT_WIND,
+    FANET_SERVICE_BIT_TEMP,
+    FANET_SERVICE_BIT_INET
+  };
+
+  /**
+   * Checks if nth bit is set
+   *
+   * @return true if its set, false otherwise
+   */
+  static bool IsNthBitSet(uint8_t byte, int bit) { return byte & (1 << bit); };
+
+  /**
+   * Decodes FANET service(type 4) payload and updates provided station with
+   * decoded info
+   *
+   * @param payload to deode
+   * @param payload_length
+   * @param station to update
+   * @return true if successfully decoded, false otherwise
+   */
+  static bool DecodeServicePayload(uint8_t *payload, int16_t payload_length,
+                                   FanetStation *station);
+
+
+  /**
+   * Decodes first 6 bytes of provided payload to GeoPoint,
+   * does not check for length!
+   *
+   * @param buf payload(>= 6byte) to decode
+   * @return GeoPoint with decoded location if successfull,
+   *    GeoPoint::Invalid() otherwise
+   */
+  static GeoPoint Payload2GeoPoint(const uint8_t *buf);
+
+  /**
+   * Converts last bits 0-6 of byte to float. if bit 7 is set multiplies it
+   * with scale
+   *
+   * @param byte payload to convert
+   * @param scale scale to apply if bit 7 is 1
+   * @return value*scale if bit 7 set, value otherwise
+   */
+  static float Payload2Float(uint8_t byte, float scale);
+
+  /**
+   * Parses #FNF line
+   *
+   * @param stations_list list of stations to add parsed station to
+   * @param clock current time
+   * @return true if packet is parsed fully
+   */
+  static bool ParseRxPacket(char *cmd_str, StationsList &stations_list,
+                            double clock);
+
+  /**
+   * Updates existing station or allocates a new one in stations_list
+   *
+   * @param stations_list list to add station to
+   * @param clock current time
+   * @param station station to add
+   * @return true if station is successfully added
+   */
+  static bool AddStationToList(StationsList &stations_list, double clock,
+                               FanetStation station);
+
+  /**
+   * Replace first occurrence of newline character with \0 and moves pointer
+   * to the first non space character
+   *
+   * @param cmd_str line to replace newline character in
+   * @return stripped cmd_str
+   */
+  static char *RemoveExtraChars(char *cmd_str);
+
+  /**
+   * Check if cmd_str contains only hexadecimal chars & commas and is > 0 chars
+   *
+   * @param cmd_str line to check
+   * @return true if check is passed, false otherwise
+   */
+  static bool IntegrityCheck(char *cmd_str);
+
+public:
+  // Virtual method from class Device
+  bool ParseNMEA(const char *line, NMEAInfo &info) override;
+};
+
+#endif //XCSOAR_FANET_DEVICE_HPP

--- a/src/Device/Driver/FANET/Parser.cpp
+++ b/src/Device/Driver/FANET/Parser.cpp
@@ -1,0 +1,304 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Device.hpp"
+#include "NMEA/Info.hpp"
+#include "FANET/FanetAddress.hpp"
+
+bool
+FanetDevice::AddStationToList(StationsList &stations_list, double clock,
+                              const FanetStation station) {
+  FanetStation *fanet_slot = stations_list.FindStations(station.address);
+
+  if (fanet_slot == nullptr) {
+    fanet_slot = stations_list.AllocateStation();
+    if (fanet_slot == nullptr)
+      // no more slots available
+      return false;
+
+    fanet_slot->Clear();
+    fanet_slot->address = station.address;
+    fanet_slot->location = station.location;
+    fanet_slot->location_available = station.location_available;
+  }
+
+  fanet_slot->valid.Update(clock);
+  fanet_slot->Update(station);
+
+  return true;
+}
+
+bool
+FanetDevice::IntegrityCheck(char *cmd_str) {
+  if (strlen(cmd_str) == 0)
+    return false;
+
+  for(char *ptr = cmd_str; *ptr != '\0'; ptr++)
+  {
+    if((*ptr >= '0' && *ptr <= '9') ||
+       (*ptr >= 'A' && *ptr <= 'F') ||
+       (*ptr >= 'a' && *ptr <= 'f') ||
+       (*ptr == ',')) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+char *
+FanetDevice::RemoveExtraChars(char *cmd_str) {
+  char *ptr = strchr(cmd_str, '\r');
+  if(ptr == nullptr)
+    ptr = strchr(cmd_str, '\n');
+  if(ptr != nullptr)
+    *ptr = '\0';
+  while(*cmd_str == ' ')
+    cmd_str++;
+  return cmd_str;
+}
+
+GeoPoint
+FanetDevice::Payload2GeoPoint(const uint8_t *buf) {
+  if(buf == nullptr)
+    return GeoPoint::Invalid();
+
+  // Integer values
+  unsigned int lati = buf[2] << 16 | buf[1] << 8 | buf[0];
+  if(lati & 0x00800000)
+    lati |= 0xFF000000;
+  unsigned int loni = buf[5] << 16 | buf[4] << 8 | buf[3];
+  if(loni & 0x00800000)
+    loni |= 0xFF000000;
+
+  return GeoPoint(Angle::Degrees((float)loni / 46603.0f), Angle::Degrees((float)lati / 93206.0f));
+}
+
+float
+FanetDevice::Payload2Float(uint8_t byte, float scale) {
+  auto value = (float)(byte & 0x7F);
+  if(byte & 1 << 7)
+    return (value * scale);
+  else
+    return value;
+}
+
+bool
+FanetDevice::DecodeServicePayload(uint8_t *payload, int16_t payload_length, FanetStation *station) {
+  if(payload == nullptr || payload_length == 0)
+    return false;
+
+  uint16_t payload_pos = 1;
+
+  // Skip extended header
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_EHEADER))
+  {
+    // TODO: decode extended header byte if set, currently not needed/used
+    payload_pos++;
+  }
+
+  // Return if no location
+  if(payload_pos + 6 > payload_length)
+    return false;
+
+  station->location = Payload2GeoPoint(&payload[payload_pos]);
+  if( ! station->location.IsValid())
+    return false;
+  station->location_available = true;
+  payload_pos += 6;
+
+  /*
+   * Temperature (+1byte in 0.5 degree, 2-Complement)
+   */
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_TEMP))
+  {
+    if(payload_pos + 1 > payload_length)
+      return false;
+    station->temperature = (float)payload[payload_pos++] / 2.0f;
+  }
+
+  /*
+   * 	Wind (+3byte: 1byte Heading in 360/256 degree, 1byte speed and 1byte
+	 *  gusts in 0.2km/h (each: bit 7 scale 5x or 1x, bit 0-6))
+   */
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_WIND))
+  {
+    if(payload_pos + 3 > payload_length)
+      return false;
+
+    station->wind_dir_deg = (((float)payload[payload_pos++]) / 0.7083333334f);
+    station->wind_speed_kmph =
+        Payload2Float(payload[payload_pos++], 5.0f) * 0.2f;
+    station->wind_gust_kmph = Payload2Float(payload[payload_pos++], 5.0f) * 0.2f;
+  }
+
+  /*
+   * Humidity (+1byte: in 0.4% (%rh*10/4))
+   */
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_HUMIDITY))
+  {
+    if(payload_pos + 1 > payload_length)
+      return false;
+    station->rel_humidity = payload[payload_pos++] / 2.5f;
+  }
+
+  /*
+   * Barometric pressure normailized (+2byte: in 10Pa, offset by 430hPa,
+   * unsigned little endian (hPa-430)*10)
+   */
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_PRESSURE))
+  {
+    if(payload_pos + 2 > payload_length)
+      return false;
+    int lsb = payload[payload_pos++];
+    int msb = payload[payload_pos++];
+    station->preasure_hpa = (((msb << 8) | lsb) / 10.0) + 430.0;
+  }
+
+  /*
+   * State of Charge  +1byte
+   * (lower 4 bits: 0x00 = 0%, 0x01 = 6.666%, .. 0x0F = 100%)
+   */
+  if(IsNthBitSet(payload[0], FANET_SERVICE_BIT_SOC))
+  {
+    if(payload_pos + 1 > payload_length)
+      return false;
+    station->soc_percent =
+        Payload2Float(payload[payload_pos++], 1.0f) * 100.0f / 15.0f;
+  }
+
+  return true;
+}
+
+/*
+ *  Service(type 4 - weather info):
+ *  #FNF src_manufacturer,src_id,broadcast,signature,type,payloadlength,payload
+ */
+bool
+FanetDevice::ParseRxPacket(char *cmd_str, StationsList &stations_list,
+                           double clock) {
+  // Prepare the line
+  cmd_str = RemoveExtraChars(cmd_str);
+  if ( ! IntegrityCheck(cmd_str))
+    return false;
+
+  char *start_ptr = (char *)cmd_str;
+  char *end_ptr;
+
+  if(! start_ptr)
+    return false;
+
+  // Manufacturer(1 byte)
+  uint8_t manufacturer = strtol(start_ptr, &end_ptr, 16);
+  if(start_ptr == end_ptr)
+    return false;
+
+  start_ptr = strchr(start_ptr, ',') + 1;  // comma after src_manufacturer
+  if (start_ptr == nullptr)
+    return false;
+
+  // Id(2 bytes)
+  uint16_t id = strtol(start_ptr, &end_ptr, 16);
+  if(start_ptr == end_ptr)
+    return false;
+
+  /*
+   * Skip broadcast(1 byte) and signature(2 bytes)
+   *  comma after src_id
+   *  comma after broadcast
+   *  comma after signature
+   */
+  for (int i = 0; i < 3; ++i) {
+    start_ptr = strchr(start_ptr, ',') + 1;
+    if (start_ptr == nullptr)
+      return false;
+  }
+
+  // Type(1 byte)
+  uint8_t type = strtol(start_ptr, &end_ptr, 16);
+  if(start_ptr == end_ptr)
+    return false;
+
+  start_ptr = strchr(start_ptr, ',') + 1;  // comma after type
+  if (start_ptr == nullptr)
+    return false;
+
+  // Payload length(1 byte)
+  uint16_t payload_length = strtol(start_ptr, &end_ptr, 16);
+  if(start_ptr == end_ptr)
+    return false;
+
+  /*
+   * Standard limitation of LoRa buffers of 256 bytes and the maximum length
+   * of the FANET MAC header of 11 bytes reduces the permitted payload length
+   * to 245 bytes.
+   */
+  if(payload_length > 245)
+    return false;
+
+  // Payload(payload_length bytes)
+  auto* payload = new uint8_t[payload_length];
+  start_ptr = strchr(start_ptr, ',') + 1;  // comma after payloadlength
+  if (start_ptr == nullptr)
+    return false;
+
+  // Extract payload
+  for(int i = 0; i < payload_length; i++)
+  {
+    char sstr[3] = {start_ptr[i * 2], start_ptr[i * 2 + 1], '\0'};
+    if(strlen(sstr) != 2)
+      return false;
+
+    payload[i] = strtol(sstr,  &end_ptr,  16);
+    if(start_ptr == end_ptr)
+      return false;
+  }
+
+  switch (type)
+  {
+    // We only decode type 4 (service / weather data) for now
+    case FANET_TYPE_SERVICE:
+      FanetStation station;
+      station.address = FanetAddress(manufacturer, id);
+      if(DecodeServicePayload(payload, payload_length, &station))
+        return AddStationToList(stations_list, clock, station);
+      return false;
+    default:
+      return false;
+  }
+}
+
+/*
+ * https://github.com/3s1d/fanet-stm32/raw/master/fanet_module.pdf
+ * https://github.com/3s1d/fanet-stm32/blob/master/Src/fanet/radio/protocol.txt
+ */
+bool
+FanetDevice::ParseNMEA(const char *line, NMEAInfo &info)
+{
+  if(StringIsEqual(line, "#FNF", strlen("#FNF"))) {
+    return ParseRxPacket(const_cast<char *>(&line[strlen("#FNF") + 1]),
+                         info.fanet.stations, info.clock);
+  }
+
+  return false;
+}

--- a/src/Device/Driver/FANET/Register.cpp
+++ b/src/Device/Driver/FANET/Register.cpp
@@ -1,0 +1,38 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Device/Driver/FANET.hpp"
+#include "Device.hpp"
+
+static Device *
+FanetCreateOnPort(const DeviceConfig &config, Port &com_port)
+{
+    return new FanetDevice();
+}
+
+const struct DeviceRegister fanet_driver = {
+        _T("FANET"),
+        _T("FANET"),
+        0,
+        FanetCreateOnPort,
+};

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -59,6 +59,7 @@ Copyright_License {
 #include "Device/Driver/ATR833.hpp"
 #include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/KRT2.hpp"
+#include "Device/Driver/FANET.hpp"
 #include "util/Macros.hpp"
 #include "util/StringAPI.hxx"
 
@@ -103,6 +104,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &xctracer_driver,
   &thermalexpress_driver,
   &acd_driver,
+  &fanet_driver,
   nullptr
 };
 

--- a/src/FANET/Data.hpp
+++ b/src/FANET/Data.hpp
@@ -1,0 +1,50 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_FANET_DATA_HPP
+#define XCSOAR_FANET_DATA_HPP
+
+#include "FANET/List.hpp"
+
+/**
+ * A container for all data received by a FANET.
+ */
+struct FanetData {
+  StationsList stations;
+
+  void Clear() {
+    stations.Clear();
+  }
+
+  void Complement(const FanetData &add) {
+    stations.Complement(add.stations);
+  }
+
+  void Expire(double clock) {
+    stations.RemoveExpired(clock);
+  }
+};
+
+static_assert(std::is_trivial<FanetData>::value, "type is not trivial");
+
+#endif //XCSOAR_FANET_DATA_HPP

--- a/src/FANET/FanetAddress.hpp
+++ b/src/FANET/FanetAddress.hpp
@@ -1,0 +1,48 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_FANET_FANETADDRESS_HPP
+#define XCSOAR_FANET_FANETADDRESS_HPP
+
+#include <cstdint>
+#include <cstdio>
+
+/**
+ * The identification of a FANET packets.
+ */
+class FanetAddress {
+  uint8_t manufacturer;
+  uint16_t id;
+
+public:
+  FanetAddress() = default;
+
+  bool operator==(FanetAddress other) const {
+    return id == other.id && manufacturer == other.manufacturer;
+  }
+
+  constexpr
+  FanetAddress(uint8_t _manufacturer, uint16_t _id):manufacturer(_manufacturer), id(_id) {}
+};
+
+#endif // XCSOAR_FANET_FANETADDRESS_HPP

--- a/src/FANET/FanetStation.cpp
+++ b/src/FANET/FanetStation.cpp
@@ -1,0 +1,36 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "FanetStation.hpp"
+
+void
+FanetStation::Update(const FanetStation &other)
+{
+  temperature = other.temperature;
+  wind_dir_deg = other.wind_dir_deg;
+  wind_speed_kmph = other.wind_speed_kmph;
+  wind_gust_kmph = other.wind_gust_kmph;
+  rel_humidity = other.rel_humidity;
+  preasure_hpa = other.preasure_hpa;
+  soc_percent = other.soc_percent;
+}

--- a/src/FANET/FanetStation.hpp
+++ b/src/FANET/FanetStation.hpp
@@ -1,0 +1,85 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_FANET_STATIONS_HPP
+#define XCSOAR_FANET_STATIONS_HPP
+
+#include "util/StaticString.hxx"
+#include <type_traits>
+#include <tchar.h>
+#include "FanetAddress.hpp"
+#include "NMEA/Validity.hpp"
+#include "Geo/GeoPoint.hpp"
+
+struct FanetStation {
+  /** Station info */
+  float temperature;
+  float wind_dir_deg;
+  float wind_speed_kmph;
+  float wind_gust_kmph;
+  float rel_humidity;
+  double preasure_hpa;
+  float soc_percent;
+
+  /** Has the geographical location been calculated yet? */
+  bool location_available;
+
+  /** Is this object valid, or has it expired already? */
+  Validity valid;
+
+  /** Location of the FANET station */
+  GeoPoint location;
+
+  /** FANET address of the FANET station */
+  FanetAddress address;
+
+  void Clear() {
+    valid.Clear();
+  }
+
+  /**
+   * Check if this station data has expired.
+   *
+   * @return true if the data is still valid
+   */
+  bool IsValid(double clock) {
+    /*
+     * Recommended interval for FANET type 4 packet is 40sec
+     * We use 60sec accounting for differences in implementations but its still
+     * short enough period to be relevant considering airports use 2min average
+     */
+    valid.Expire(clock, std::chrono::seconds(60));
+    return valid;
+  }
+
+  /**
+   * Updates weather data in this FanetStation with data from other FanetStation
+   *
+   * @param other FanetStation to update data FROM
+   */
+  void Update(const FanetStation &other);
+};
+
+static_assert(std::is_trivial<FanetStation>::value, "type is not trivial");
+
+#endif //XCSOAR_FANET_STATIONS_HPP

--- a/src/FANET/List.hpp
+++ b/src/FANET/List.hpp
@@ -1,0 +1,106 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_FANET_LIST_HPP
+#define XCSOAR_FANET_LIST_HPP
+
+#include "FanetStation.hpp"
+#include "NMEA/Validity.hpp"
+#include "util/TrivialArray.hxx"
+
+#include <type_traits>
+
+/**
+ * This list keeps track of the stations objects received from FANET.
+ */
+struct StationsList {
+  static constexpr size_t MAX_COUNT = 25;
+
+  /** Fanet Stations information */
+  TrivialArray<FanetStation, MAX_COUNT> list;
+
+  void Clear() {
+    list.clear();
+  }
+
+  bool IsEmpty() const {
+    return list.empty();
+  }
+
+  /**
+   * Adds data from the specified object, unless already present in
+   * this one.
+   */
+  void Complement(const StationsList &add) {
+    // Add unique station from 'add' list
+    for (auto &station : add.list) {
+      if (FindStations(station.address) == nullptr) {
+        FanetStation * new_station = AllocateStation();
+        if (new_station == nullptr)
+          return;
+        *new_station = station;
+      }
+    }
+  }
+
+  /**
+   * Goes trough all the station in the list and removes expired ones
+   *
+   * @param clock current time
+   */
+  void RemoveExpired(double clock) {
+    for (unsigned i = list.size(); i-- > 0;)
+      if ( ! list[i].IsValid(clock))
+        list.remove(i);
+  }
+
+  /**
+   * Looks up an item in the stations list.
+   *
+   * @param address FANET address
+   * @return the FANET_STATIONS pointer, NULL if not found
+   */
+  FanetStation *FindStations(FanetAddress address) {
+    for (auto &stations : list)
+      if (stations.address == address)
+        return &stations;
+
+    return nullptr;
+  }
+
+  /**
+   * Allocates a new FANET_STATIONS object from the array.
+   *
+   * @return the FANET_STATIONS pointer, NULL if the array is full
+   */
+  FanetStation *AllocateStation() {
+    return list.full()
+           ? nullptr
+           : &list.append();
+  }
+
+};
+
+static_assert(std::is_trivial<StationsList>::value, "type is not trivial");
+
+#endif //XCSOAR_FANET_LIST_HPP

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -308,6 +308,8 @@ protected:
   void DrawFLARMTraffic(Canvas &canvas, PixelPoint aircraft_pos) const;
   void DrawGLinkTraffic(Canvas &canvas, PixelPoint aircraft_pos) const;
 
+  void DrawFANETWeather(Canvas &canvas, PixelPoint aircraft_pos) const;
+
   // thread, main functions
   /**
    * Renders all the components of the moving map

--- a/src/MapWindow/MapWindowFanetStation.cpp
+++ b/src/MapWindow/MapWindowFanetStation.cpp
@@ -1,0 +1,109 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "MapWindow.hpp"
+#include "Screen/Icon.hpp"
+#include "Screen/Layout.hpp"
+#include "Renderer/TextInBox.hpp"
+#include "Renderer/WindArrowRenderer.hpp"
+#include "Look/Look.hpp"
+
+/**
+ * Draws the FANET wind_sock icons onto the given canvas
+ * Based on MapWindowTraffic.cpp
+ * @param canvas Canvas for drawing
+ */
+void
+MapWindow::DrawFANETWeather(Canvas &canvas,
+                            const PixelPoint aircraft_pos) const
+{
+  StationsList stations_list = Basic().fanet.stations;
+  if(stations_list.IsEmpty())
+    return;
+
+  const WindowProjection &projection = render_projection;
+
+  // If zoomed in too far out, dont draw station
+  if (projection.GetMapScale() > 7500) {
+    return;
+  }
+
+  // Draw all stations
+  for (const auto & station : stations_list.list)
+  {
+    if ( ! station.location_available)
+      continue;
+
+    GeoPoint station_loc = station.location;
+    PixelPoint sc, sc_wind_info;
+
+    // If FANET station not on the screen, continue to the next one
+    if ( ! projection.GeoToScreenIfVisible(station_loc, sc))
+      continue;
+
+    // Wind angle relative to the screen orientation
+    Angle ang = Angle::Degrees(station.wind_dir_deg);
+    auto angle = ang - projection.GetScreenAngle();
+
+    // Draw wind info box(speed|gust)
+    sc_wind_info = sc;
+
+    // If arrow pointing down move info box closer vertically
+    if (angle.Between(Angle::Degrees(280),
+                           Angle::Degrees(80)))
+      sc_wind_info.y += Layout::Scale(8);
+    // If arrow is pointing up move it further away vertically
+    else if (angle.Between(Angle::Degrees(110),
+                      Angle::Degrees(250)))
+      sc_wind_info.y += Layout::Scale(18);
+    /*
+     * We are left with the 20deg above and below the horizon on both sides,
+     * and because of the angle of the arrow we need to move it slightly lower
+     * vertically so that arrow doesnt overlap wind info box
+     */
+    else
+      sc_wind_info.y += Layout::Scale(13);
+
+    TextInBoxMode mode_wind_info;
+    mode_wind_info.shape = LabelShape::ROUNDED_BLACK;
+    mode_wind_info.align = TextInBoxMode::CENTER;
+    mode_wind_info.vertical_position = TextInBoxMode::VerticalPosition::CENTERED;
+
+    // If station is close to aircraft dont show wind info box
+    int dx = sc_wind_info.x - aircraft_pos.x;
+    int dy = sc_wind_info.y - aircraft_pos.y;
+    if (dx * dx + dy * dy > Layout::Scale(30 * 30))
+    {
+      StaticString<8> text_wind_info;
+      text_wind_info.Format(_T("%.0f|%.0f"),
+                    station.wind_speed_kmph, station.wind_gust_kmph);
+
+      TextInBox(canvas, text_wind_info, sc_wind_info.x,
+                sc_wind_info.y, mode_wind_info, GetClientRect(), nullptr);
+    }
+
+    auto style = GetMapSettings().wind_arrow_style;
+    WindArrowRenderer renderer(look.wind);
+    renderer.DrawArrow(canvas, sc, angle, 10, style, 0);
+  }
+}

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -301,6 +301,8 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc)
   if (basic.location_available)
     DrawFLARMTraffic(canvas, aircraft_pos);
 
+  DrawFANETWeather(canvas, aircraft_pos);
+
   //////////////////////////////////////////////// own aircraft
   // Finally, draw you!
   if (basic.location_available)

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -180,6 +180,8 @@ NMEAInfo::Reset()
   device.Clear();
   secondary_device.Clear();
   flarm.Clear();
+
+  fanet.Clear();
 }
 
 void
@@ -201,6 +203,18 @@ NMEAInfo::ExpireWallClock()
     time_available.Clear();
     gps.Reset();
     flarm.Clear();
+
+    /*
+     * If we have fanet station left let this stay alive so we can show them
+     * for longer than 10 seconds, otherwise they wont survive the Merge
+     */
+    {
+    fanet.Expire(clock);
+    if(fanet.stations.IsEmpty())
+      fanet.Clear();
+    else
+      alive.Update(clock);
+    }
   } else {
     time_available.Expire(clock, std::chrono::seconds(10));
   }
@@ -239,6 +253,7 @@ NMEAInfo::Expire()
   voltage_available.Expire(clock, std::chrono::minutes(5));
   battery_level_available.Expire(clock, std::chrono::minutes(5));
   flarm.Expire(clock);
+  fanet.Expire(clock);
 #ifdef ANDROID
   glink_data.Expire(clock);
 #endif
@@ -356,6 +371,8 @@ NMEAInfo::Complement(const NMEAInfo &add)
     stall_ratio = add.stall_ratio;
 
   flarm.Complement(add.flarm);
+
+  fanet.Complement(add.fanet);
 
 #ifdef ANDROID
   glink_data.Complement(add.glink_data);

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -36,6 +36,7 @@ Copyright_License {
 #include "Atmosphere/Temperature.hpp"
 #include "DeviceInfo.hpp"
 #include "FLARM/Data.hpp"
+#include "FANET/Data.hpp"
 #include "Geo/SpeedVector.hpp"
 
 #ifdef ANDROID
@@ -362,6 +363,8 @@ struct NMEAInfo {
   DeviceInfo secondary_device;
 
   FlarmData flarm;
+
+  FanetData fanet;
 
 #ifdef ANDROID
   GliderLinkData glink_data;


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->
This commit implements FANET driver for '#FNF' sentences of type 4(service) that contain current weather info and draws related wind arrow and info box with wind speed and wind gust to the screen.

![Screenshot_20201203_000354_org xcsoar testing](https://user-images.githubusercontent.com/74660311/100945259-26f8a180-3501-11eb-84be-e006bf94cf66.jpg)


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
