### PR TITLE
Fix android.max_aspect for Android device that aspect ratio greater than 16:9

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -25,7 +25,7 @@
       <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                  android:resource="@xml/usb_device_filter" />
       <meta-data android:name="android.max_aspect"
-                 android:value="ratio_float"/>
+                 android:value="2.1"/>
     </activity>
 
     <service android:name=".MyService"/>

--- a/android/testing/AndroidManifest.xml
+++ b/android/testing/AndroidManifest.xml
@@ -25,7 +25,7 @@
       <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                  android:resource="@xml/usb_device_filter" />
       <meta-data android:name="android.max_aspect"
-                 android:value="ratio_float"/>
+                 android:value="2.1"/>
     </activity>
 
     <service android:name=".MyService"/>


### PR DESCRIPTION
In https://github.com/XCSoar/XCSoar/commit/fb8370c2ed5df0e69a1055e3d53d922847ae2ea4 there was an attempt to fix full screen size for Android device that aspect ratio greater than 16:9

But there's a bug in that fix, we suppose to replace `ratio_float` with the actual number based on the document: https://android-developers.googleblog.com/2017/03/update-your-app-to-take-advantage-of.html
So the fix wasn't actually works.

This should be a real fix.
before|after
------|-----
![Screenshot_20210131-202158_300x650](https://user-images.githubusercontent.com/496209/106397156-d8358e00-6403-11eb-92cd-1ea26632a2ee.jpg)|![Screenshot_20210131-201812_300x650](https://user-images.githubusercontent.com/496209/106397160-da97e800-6403-11eb-9a04-8480bcdad974.jpg)


