### PR TITLE
Add missing packages for a clean docker build run

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -15,7 +15,7 @@ apt-get install $APTOPTS make \
   git quilt zip \
   m4 automake wget \
   ttf-bitstream-vera fakeroot \
-  pkg-config
+  pkg-config cmake ninja-build
 echo
 
 echo Installing Manual dependencies...


### PR DESCRIPTION
Brief summary of the changes
----------------------------

Solve Issue #519 'In Docker some packages missing for an error free run'
Add 3 Packages to the docker-provisioning-file: 
* overall build environment: cmake, ninja-build
* linux target: libglm-dev

Related issues and discussions
------------------------------

The same packages are needed for a build in the native environment 