### PR TITLE
Cross section axis texts overlap

### DIFF
--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -43,6 +43,7 @@ Display::LoadOrientation(VerboseOperationEnvironment &env)
 
   DisplayOrientation orientation =
     CommonInterface::GetUISettings().display.orientation;
+
 #ifdef KOBO
   /* on the Kobo, the display orientation must be loaded explicitly
      (portrait), because the hardware default is landscape */
@@ -86,4 +87,10 @@ Display::RestoreOrientation()
 #ifdef KOBO
   event_queue->SetMouseRotation(DisplayOrientation::DEFAULT);
 #endif
+}
+
+DisplayOrientation
+Display::DetectInitialOrientation()
+{
+  return DisplayOrientation::DEFAULT;
 }

--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -27,6 +27,8 @@ Copyright_License {
 #include "LogFile.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
+#include "OS/Path.hpp"
+#include "OS/FileUtil.hpp"
 
 #ifdef KOBO
 #include "Event/Globals.hpp"
@@ -92,5 +94,21 @@ Display::RestoreOrientation()
 DisplayOrientation
 Display::DetectInitialOrientation()
 {
-  return DisplayOrientation::DEFAULT;
+  auto orientation = DisplayOrientation::DEFAULT;
+
+#ifdef MESA_KMS
+  // When running in DRM/KMS mode, infer the display orientation from the linux
+  // console rotation.
+  char buf[3];
+  auto rotatepath = Path("/sys/class/graphics/fbcon/rotate");
+  if (File::ReadString(rotatepath, buf, sizeof(buf))) {
+    switch (*buf) {
+    case '0': orientation = DisplayOrientation::LANDSCAPE; break;
+    case '1': orientation = DisplayOrientation::REVERSE_PORTRAIT; break;
+    case '2': orientation = DisplayOrientation::REVERSE_LANDSCAPE; break;
+    case '3': orientation = DisplayOrientation::PORTRAIT; break;
+    }
+  }
+#endif
+  return orientation;
 }

--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -27,7 +27,6 @@ Copyright_License {
 #include "LogFile.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
-#include "OS/Path.hpp"
 #include "OS/FileUtil.hpp"
 
 #ifdef KOBO
@@ -100,7 +99,7 @@ Display::DetectInitialOrientation()
   // When running in DRM/KMS mode, infer the display orientation from the linux
   // console rotation.
   char buf[3];
-  auto rotatepath = Path("/sys/class/graphics/fbcon/rotate");
+  const TCHAR *rotatepath = "/sys/class/graphics/fbcon/rotate";
   if (File::ReadString(rotatepath, buf, sizeof(buf))) {
     switch (*buf) {
     case '0': orientation = DisplayOrientation::LANDSCAPE; break;

--- a/src/Hardware/DisplayGlue.hpp
+++ b/src/Hardware/DisplayGlue.hpp
@@ -24,12 +24,15 @@ Copyright_License {
 #ifndef XCSOAR_HARDWARE_DISPLAY_GLUE_H
 #define XCSOAR_HARDWARE_DISPLAY_GLUE_H
 
+#include "DisplayOrientation.hpp"
+
 class VerboseOperationEnvironment;
 
 namespace Display
 {
   void LoadOrientation(VerboseOperationEnvironment &env);
   void RestoreOrientation();
+  DisplayOrientation DetectInitialOrientation();
 }
 
 #endif

--- a/src/Screen/Custom/TopWindow.cpp
+++ b/src/Screen/Custom/TopWindow.cpp
@@ -74,6 +74,9 @@ TopWindow::Create(const TCHAR *text, PixelSize size,
     return;
   }
 
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  screen->SetDisplayOrientation(style.GetInitialOrientation());
+#endif
   ContainerWindow::Create(nullptr, screen->GetRect(), style);
 
 #if defined(ENABLE_SDL) && (SDL_MAJOR_VERSION < 2)

--- a/src/Screen/TopWindow.hpp
+++ b/src/Screen/TopWindow.hpp
@@ -57,7 +57,7 @@ union SDL_Event;
 #endif
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
-enum class DisplayOrientation : uint8_t;
+#include "DisplayOrientation.hpp"
 #endif
 
 #ifndef USE_GDI
@@ -87,6 +87,9 @@ class TopWindowStyle : public WindowStyle {
 #endif
 #ifdef ENABLE_SDL
   bool resizable;
+#endif
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  DisplayOrientation initial_orientation = DisplayOrientation::DEFAULT;
 #endif
 
 public:
@@ -143,6 +146,15 @@ public:
     return false;
 #endif
   }
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  void InitialOrientation(DisplayOrientation orientation) {
+    initial_orientation = orientation;
+  }
+
+  DisplayOrientation GetInitialOrientation() const {
+    return initial_orientation;
+  }
+#endif
 };
 
 /**

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -192,6 +192,10 @@ Startup()
   if (!IsWindowsCE())
     style.Resizable();
 
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  style.InitialOrientation(Display::DetectInitialOrientation());
+#endif
+
   MainWindow *const main_window = CommonInterface::main_window =
     new MainWindow();
   main_window->Create(SystemWindowSize(), style);


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

apply font scale reduction factor derived from setup (system/look/language) in ChartLook.cpp to avoid overlapping text

Related issues and discussions
------------------------------

see issue description on https://github.com/XCSoar/XCSoar/issues/516
see changes in attached patch

[patch.txt](https://github.com/XCSoar/XCSoar/files/5933971/patch.txt)
