### PR TITLE
TaskManager: Add the feature to download your declared Task from WeGlide

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,8 @@ Version 7.24 - not yet released
   - menu: fix bogus clicks after returning from XCSoar
 * Android
   - add SoftRF Lego into 'white list' of USB devices
+* task
+  - add WeGlide declared task download, task will be stored in weglide folder
 
 Version 7.23 - 2022/02/10
 * user interface

--- a/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
@@ -124,7 +124,7 @@ LoggerConfigPanel::Save(bool &changed) noexcept
 
   changed |= SaveValue(CoPilotName, ProfileKeys::CoPilotName,
                        logger.copilot_name);
-
+                       
   changed |= SaveValue(CrewWeightTemplate, UnitGroup::MASS, ProfileKeys::CrewWeightTemplate,
                        logger.crew_mass_template);
 

--- a/src/Dialogs/Task/Manager/TaskActionsPanel.hpp
+++ b/src/Dialogs/Task/Manager/TaskActionsPanel.hpp
@@ -55,6 +55,7 @@ private:
   void OnBrowseClicked();
   void OnNewTaskClicked();
   void OnDeclareClicked();
+  void OnDownloadClicked() noexcept;
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Logger/Settings.hpp
+++ b/src/Logger/Settings.hpp
@@ -59,7 +59,7 @@ struct LoggerSettings {
   StaticString<64> pilot_name;
 
   StaticString<64> copilot_name;
-
+  
   /** Crew mass template in kg */
   unsigned crew_mass_template;
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------
This commit adds the feature to download your declared task from WeGlide. The Task must be publicly available (Authentification can be added later to also download private Tasks). This feature uses the WeGlide API: 
https://api.weglide.org/docs#/task/get_task_declared_v1_task_declaration__user_id__get

I also added a new Setting Parameter: WeGlide Pilot ID
It is located in Settings -> Logger
You can get your Pilot ID from your profile link. 
For example my ID is 67:
https://beta.weglide.org/profile/67

![image](https://user-images.githubusercontent.com/64869196/107130791-5d6fe580-68d1-11eb-91ae-a725949bbb70.png)

Here you can Download the Task and find it in the Browse Tab:
![image](https://user-images.githubusercontent.com/64869196/107130780-40d3ad80-68d1-11eb-9e2e-cf258b8496ff.png)



Related issues and discussions
------------------------------
