### PR TITLE
Fix adjust to previous task point, rev2

### DIFF
--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -25,6 +25,8 @@ Copyright_License {
 #include "Task/RoutePlannerGlue.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/ASTPoint.hpp"
+#include "Engine/Task/Ordered/Points/AATPoint.hpp"
 #include "Engine/Task/Points/TaskWaypoint.hpp"
 #include "Engine/Route/ReachResult.hpp"
 
@@ -84,11 +86,14 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
 {
   ExclusiveLease lease(*this);
   TaskAdvance &advance = lease->SetTaskAdvance();
+  TaskWaypoint *twp = nullptr;
 
   switch (advance.GetState()) {
   case TaskAdvance::MANUAL:
-  case TaskAdvance::AUTO:
-    lease->IncrementActiveTaskPoint(offset);
+  case TaskAdvance::AUTO: {
+      lease->IncrementActiveTaskPoint(offset);
+      twp = lease->GetActiveTaskPoint();
+    }
     break;
   case TaskAdvance::START_DISARMED:
   case TaskAdvance::TURN_DISARMED:
@@ -96,16 +101,34 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
       advance.SetArmed(true);
     } else {
       lease->IncrementActiveTaskPoint(offset);
+      twp = lease->GetActiveTaskPoint();
     }
     break;
   case TaskAdvance::START_ARMED:
   case TaskAdvance::TURN_ARMED:
     if (offset>0) {
       lease->IncrementActiveTaskPoint(offset);
+      twp = lease->GetActiveTaskPoint();
     } else {
       advance.SetArmed(false);
     }
     break;
+  }
+  if (twp) {
+    switch (twp->GetType()) {
+    case TaskPointType::AST : {
+      ASTPoint *p = (ASTPoint *)twp;
+      if (p->HasEntered()) p->Reset();
+      }
+      break;
+    case TaskPointType::AAT : {
+      AATPoint *p = (AATPoint *)twp;
+      if (p->HasEntered()) p->Reset();
+      }
+      break;
+    default:
+      break;
+    }
   }
 }
 

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -25,8 +25,7 @@ Copyright_License {
 #include "Task/RoutePlannerGlue.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
-#include "Engine/Task/Ordered/Points/ASTPoint.hpp"
-#include "Engine/Task/Ordered/Points/AATPoint.hpp"
+#include "Engine/Task/Ordered/Points/IntermediatePoint.hpp"
 #include "Engine/Task/Points/TaskWaypoint.hpp"
 #include "Engine/Route/ReachResult.hpp"
 
@@ -86,14 +85,13 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
 {
   ExclusiveLease lease(*this);
   TaskAdvance &advance = lease->SetTaskAdvance();
-  TaskWaypoint *twp = nullptr;
+  IntermediateTaskPoint *nextwp = nullptr;
 
   switch (advance.GetState()) {
   case TaskAdvance::MANUAL:
-  case TaskAdvance::AUTO: {
-      lease->IncrementActiveTaskPoint(offset);
-      twp = lease->GetActiveTaskPoint();
-    }
+  case TaskAdvance::AUTO:
+    lease->IncrementActiveTaskPoint(offset);
+    nextwp = (IntermediateTaskPoint *)lease->GetActiveTaskPoint();
     break;
   case TaskAdvance::START_DISARMED:
   case TaskAdvance::TURN_DISARMED:
@@ -101,35 +99,21 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
       advance.SetArmed(true);
     } else {
       lease->IncrementActiveTaskPoint(offset);
-      twp = lease->GetActiveTaskPoint();
+      nextwp = (IntermediateTaskPoint *)lease->GetActiveTaskPoint();
     }
     break;
   case TaskAdvance::START_ARMED:
   case TaskAdvance::TURN_ARMED:
     if (offset>0) {
       lease->IncrementActiveTaskPoint(offset);
-      twp = lease->GetActiveTaskPoint();
+      nextwp = (IntermediateTaskPoint *)lease->GetActiveTaskPoint();
     } else {
       advance.SetArmed(false);
     }
     break;
   }
-  if (twp) {
-    switch (twp->GetType()) {
-    case TaskPointType::AST : {
-      ASTPoint *p = (ASTPoint *)twp;
-      if (p->HasEntered()) p->Reset();
-      }
-      break;
-    case TaskPointType::AAT : {
-      AATPoint *p = (AATPoint *)twp;
-      if (p->HasEntered()) p->Reset();
-      }
-      break;
-    default:
-      break;
-    }
-  }
+
+  if(nextwp) nextwp->Reset();
 }
 
 bool 


### PR DESCRIPTION
When manually adjusting to the previous turn point it must forget that it had visited that task point before. If it finds this TP had been visited before it auto-increments to the next TP.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
This fix addresses Issue #492 
A more detailed description of the issue is there.

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
