### PR TITLE
XCVario driver ported to 6.8.x branch

### DIFF
--- a/build/driver.mk
+++ b/build/driver.mk
@@ -111,6 +111,7 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/OpenVario.cpp \
 	$(DRIVER_SRC_DIR)/PosiGraph.cpp \
 	$(DRIVER_SRC_DIR)/XCOM760.cpp \
+	$(DRIVER_SRC_DIR)/XCVario.cpp \
 	$(DRIVER_SRC_DIR)/ILEC.cpp \
 	$(DRIVER_SRC_DIR)/Westerboer.cpp \
 	$(DRIVER_SRC_DIR)/Zander.cpp \

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -1,0 +1,203 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "Device/Driver/XCVario.hpp"
+#include "Device/Driver/CAI302/PocketNav.hpp"
+#include "Device/Driver.hpp"
+#include "Units/System.hpp"
+#include "NMEA/Checksum.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/InputLine.hpp"
+#include "Util/Clamp.hpp"
+#include "Atmosphere/Pressure.hpp"
+#include "Atmosphere/Temperature.hpp"
+#include <math.h>
+
+class XVCDevice : public AbstractDevice {
+  Port &port;
+
+public:
+  XVCDevice(Port &_port):port(_port) {}
+
+  // virtual methods from class Device
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+
+  bool PutMacCready(double mc, OperationEnvironment &env) override;
+  bool PutBugs(double bugs, OperationEnvironment &env) override;
+  bool PutBallast(double fraction, double overload, OperationEnvironment &env) override;
+};
+
+/*
+  For a complete documentation of the protocol refer to https://xcvario.de/handbuch and
+  search for NMEA Protokoll.
+  
+  Sentence has following format:
+  $PXCV,
+  BBB.B  = Vario, -30 to +30 m/s, negative sign for sink,
+  C.C    = MacCready 0 to 10 m/s
+  EE     = bugs degradation, 0 = clean to 30 %,
+  F.FF   = Ballast 1.00 to 1.60,
+  G      = 0 in climb, 1 in cruise,
+  HH.H   = Outside airtemp in degrees celcius ( may have leading negative sign ) e.g. 24.4,
+  QQQQ.Q = QNH in hectoPascal e.g. 1013.2,
+  PPPP.P = static pressure in hPa,
+  RRR.R  = roll angle in degree related to earth system,
+  III.I  = pitch angle related to earth system,
+  X.XX   = acceleration in X-Axis (multiples of G),
+  Y.YY   = acceleration in Y-Axis,
+  Z.ZZ   = acceleration in Z-Axis,
+  *,
+  CHK    = standard NMEA checksum, CR,LF
+ */
+static bool
+PXCV(NMEAInputLine &line, NMEAInfo &info)
+{
+  // Format as defined above.
+  double value;
+  double x, y, z;
+
+  // Kalman filtered TE Vario value in m/s
+  if (line.ReadChecked(value))
+    info.ProvideTotalEnergyVario(value);
+
+  // MC value as set in XCVario in m/s
+  if (line.ReadChecked(value))
+    info.settings.ProvideMacCready(value, info.clock);
+
+  // RMN: Changed bugs-calculation, swapped ballast and bugs to suit
+  // the XVC-string for Borgelt, it's % degradation, for us, it is %
+  // of max performance
+
+  // Bugs setting as entered in XCVario
+  if (line.ReadChecked(value))
+    info.settings.ProvideBugs(1 - Clamp(value, 0., 30.) / 100.,
+                              info.clock);
+
+  // Ballast overload value in %
+  double ballast_overload;
+  if (line.ReadChecked(ballast_overload))
+    info.settings.ProvideBallastOverload(ballast_overload, info.clock);
+
+  // inclimb/incruise 1=cruise,0=climb, OAT
+  switch (line.Read(-1)) {
+  case 0:
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    break;
+
+  case 1:
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    break;
+  }
+
+  // Outside air temperature
+  info.temperature_available = line.ReadChecked(value);
+  if (info.temperature_available)
+    info.temperature = CelsiusToKelvin(value);
+
+  // QNH as set or autoset in XCVario
+  if (line.ReadChecked(value))
+    info.settings.ProvideQNH(AtmosphericPressure::HectoPascal(value), info.clock);
+
+  // Barometric pressure
+  if (line.ReadChecked(value))
+    info.ProvideStaticPressure(AtmosphericPressure::HectoPascal(value));
+
+  // Pitot tube dynamic airspeed pressure
+  if (line.ReadChecked(value))
+    info.ProvideDynamicPressure(AtmosphericPressure::Pascal(value));
+
+  // Roll respect to Earth system - Phi [°] (i.e. +110)
+  if (line.ReadChecked(value)) {
+    info.attitude.bank_angle_available.Update(info.clock);
+    info.attitude.bank_angle = Angle::Degrees(value);
+  }
+  // Pitch angle respect to Earth system - Theta [°] (i.e.+020)
+  if (line.ReadChecked(value)) {
+    info.attitude.pitch_angle_available.Update(info.clock);
+    info.attitude.pitch_angle = Angle::Degrees(value);
+  }
+  // Aircraft relevant acceleration in Z axes 
+  if ( line.ReadChecked(x) && line.ReadChecked(y) && line.ReadChecked(z) )
+    info.acceleration.ProvideGLoad( z, true);
+
+  return true;
+}
+
+bool
+XVCDevice::ParseNMEA(const char *String, NMEAInfo &info)
+{
+  if (!VerifyNMEAChecksum(String))
+    return false;
+
+  NMEAInputLine line(String);
+  char type[16];
+  line.Read(type, 16);
+
+  if (StringIsEqual(type, "$PXCV"))
+    return PXCV(line, info);
+  else
+    return false;
+}
+
+bool
+XVCDevice::PutMacCready(double mac_cready, OperationEnvironment &env)
+{
+  /* the XCVario understands the CAI302 "!g" command for
+     MacCready, ballast and bugs */
+
+  return CAI302::PutMacCready(port, mac_cready, env);
+}
+
+bool
+XVCDevice::PutBugs(double bugs, OperationEnvironment &env)
+{
+  /* the XCVario understands the CAI302 "!g" command for
+     MacCready, ballast and bugs */
+
+  return CAI302::PutBugs(port, bugs, env);
+}
+
+bool
+XVCDevice::PutBallast(double fraction, gcc_unused double overload,
+                      OperationEnvironment &env)
+{
+  /* the XCVario understands the CAI302 "!g" command for
+     MacCready, ballast and bugs */
+
+  return CAI302::PutBallast(port, fraction, env);
+}
+
+static Device *
+XVCCreateOnPort(const DeviceConfig &config, Port &com_port)
+{
+  return new XVCDevice(com_port);
+}
+
+const struct DeviceRegister xcv_driver = {
+  _T("XCVario"),
+  _T("XCVario"),
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  XVCCreateOnPort,
+};
+
+

--- a/src/Device/Driver/XCVario.hpp
+++ b/src/Device/Driver/XCVario.hpp
@@ -1,0 +1,30 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_DEVICE_DRIVER_XCVARIOS21_HPP
+#define XCSOAR_DEVICE_DRIVER_XCVARIOS21_HPP
+
+extern const struct DeviceRegister xcv_driver;
+
+#endif
+

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -34,6 +34,7 @@ Copyright_License {
 #include "Device/Driver/NmeaOut.hpp"
 #include "Device/Driver/PosiGraph.hpp"
 #include "Device/Driver/BorgeltB50.hpp"
+#include "Device/Driver/XCVario.hpp"
 #include "Device/Driver/Volkslogger.hpp"
 #include "Device/Driver/EWMicroRecorder.hpp"
 #include "Device/Driver/LX.hpp"
@@ -76,6 +77,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &ew_microrecorder_driver,
   &lx_driver,
   &zander_driver,
+  &xcv_driver,
   &flymaster_f1_driver,
   &xcom760_driver,
   &condor_driver,


### PR DESCRIPTION
As discussed in Forum, now ported from master branch to branch 6.8.x as of user requests (>200 XCVario devices in field as of today) to make this more commonly available.
The new protocol "$PXCV" is made to support a new developed OpenSource device, the XCVario ( https://xcvario.de ) featuring Vario, TE, airspeed, Temperature, AHRS (roll/bank, 3D acceleration), and bidirectional exchange for cruise/vario mode, MC, Ballast, Bugs and QNH, running on cheap hardware available commonly now.
The protocol is implemented XCVario here, https://github.com/iltis42/XCVario and shall be the future default for new series of XCVario's in 2021.
The protocol allows all the above features, what won't be possible otherwise, and has been derived as a cherry pic from elements of OpenVario, Eye-Sensorbox, Borgelt, and Cambridge protocols. 
A detailed description in handbook is here:
https://xcvario.de/handbuch#__RefHeading___Toc5243_1697588519

