### PR TITLE
Reactivation PC-Met access

### DIFF
--- a/build/screen.mk
+++ b/build/screen.mk
@@ -200,6 +200,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/gdi/Pen.cpp \
 	$(CANVAS_SRC_DIR)/gdi/Brush.cpp \
 	$(CANVAS_SRC_DIR)/gdi/Bitmap.cpp \
+	$(CANVAS_SRC_DIR)/gdi/GdiPlusBitmap.cpp \
 	$(CANVAS_SRC_DIR)/gdi/ResourceBitmap.cpp \
 	$(CANVAS_SRC_DIR)/gdi/RawBitmap.cpp \
 	$(CANVAS_SRC_DIR)/gdi/Canvas.cpp \
@@ -207,7 +208,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/gdi/PaintCanvas.cpp
 GDI_CPPFLAGS = -DUSE_GDI
 GDI_CPPFLAGS += -DUSE_WINUSER
-GDI_LDLIBS = -luser32 -lgdi32 -lmsimg32
+GDI_LDLIBS = -luser32 -lgdi32 -lmsimg32 -lgdiplus
 
 ifeq ($(TARGET),PC)
 GDI_LDLIBS += -Wl,-subsystem,windows

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -97,6 +97,10 @@ Copyright_License {
 #include "Units/Units.hpp"
 #include "Formatter/UserGeoPointFormatter.hpp"
 #include "thread/Debug.hpp"
+#if defined(_WIN32) && defined(USE_GDI)
+#  include "ui/canvas/gdi/GdiPlusBitmap.hpp"
+#endif
+
 
 #include "lua/StartFile.hpp"
 #include "lua/Background.hpp"
@@ -457,6 +461,10 @@ Startup()
 #endif
 #endif
 
+#if defined(_WIN32) && defined(USE_GDI)
+  GdiStartup();
+#endif
+
   assert(!global_running);
   global_running = true;
 
@@ -483,6 +491,9 @@ Shutdown()
   // Log shutdown information
   LogFormat("Entering shutdown...");
 
+#if defined(_WIN32) && defined(USE_GDI)
+  GdiShutdown();
+#endif
   main_window->BeginShutdown();
 
   StartupLogFreeRamAndStorage();

--- a/src/Weather/PCMet/Images.cpp
+++ b/src/Weather/PCMet/Images.cpp
@@ -37,8 +37,7 @@ Copyright_License {
 #include <string.h>
 #include <stdio.h>
 
-//#define PCMET_URI "https://www.flugwetter.de"
-#define PCMET_URI "http://www.flugwetter.de"
+#define PCMET_URI "https://www.flugwetter.de"
 
 static constexpr PCMet::ImageArea rad_lokal_areas[] = {
   { "pro", _T("Prötzel") },
@@ -84,10 +83,21 @@ static constexpr PCMet::ImageArea rad_areas[] = {
 };
 
 static constexpr PCMet::ImageArea sat_areas[] = {
-  { "ceu_hrv", _T("Mitteleuropa HRV") },
-  { "ceu_rgb", _T("Mitteleuropa RGB") },
-  { "dlnw_hrv", _T("Deutschland Nordwest HRV") },
-  { "dlnw_rgb", _T("Deutschland Nordwest RGB") },
+  { "vis_hrv_eu", _T("Mitteleuropa HRV") },
+  { "ir_rgb_eu", _T("Mitteleuropa RGB") },
+  { "ir_108_eu", _T("Mitteleuropa IR") },
+  { "vis_hrv_ce", _T("Mitteleuropa HRV") },
+  { "ir_rgb_ce", _T("Mitteleuropa RGB") },
+  { "ir_108_ce", _T("Mitteleuropa IR") },
+  { "vis_hrv_mdl", _T("Deutschland HRV") },
+  { "ir_rgb_mdl", _T("Deutschland RGB") },
+  { "ir_108_mdl", _T("Deutschland IR") },
+  { "vis_hrv_ndl", _T("Deutschland Nord HRV") },
+  { "ir_rgb_ndl", _T("Deutschland Nord RGB") },
+  { "ir_108_ndl", _T("Deutschland Nord IR") },
+  { "vis_hrv_sdl", _T("Deutschland Süd HRV") },
+  { "ir_rgb_sdl", _T("Deutschland Süd RGB") },
+  { "ir_108_sdl", _T("Deutschland Süd IR") },
   { nullptr, nullptr }
 };
 
@@ -147,6 +157,8 @@ PCMet::DownloadLatestImage(const char *type, const char *area,
                                          UTF8ToWideConverter(name));
 
   if (!File::Exists(path)) {
+    // URI for a single page of a selected 'Satellitenbilder"-page with link
+    // to the latest image and the namelist array of all stored images
     snprintf(url, sizeof(url), PCMET_URI "%s", src);
 
     Net::DownloadToFileJob job2(session, url, path);
@@ -154,6 +166,7 @@ PCMet::DownloadLatestImage(const char *type, const char *area,
     if (!runner.Run(job2))
       return Bitmap();
   }
+  assert(File::Exists(path));
 
   Bitmap bitmap;
   try {

--- a/src/ui/canvas/gdi/Bitmap.cpp
+++ b/src/ui/canvas/gdi/Bitmap.cpp
@@ -22,6 +22,8 @@ Copyright_License {
 */
 
 #include "ui/canvas/Bitmap.hpp"
+#include "ui/canvas/gdi/GdiPlusBitmap.hpp"
+
 #include "Screen/Debug.hpp"
 #include "system/Path.hpp"
 
@@ -36,7 +38,11 @@ Bitmap::Bitmap(Bitmap &&src)
 bool
 Bitmap::LoadFile(Path path)
 {
-  return false;
+  bitmap = GdiLoadImage(path.c_str());
+  bool success = IsDefined();
+  assert (success);
+
+  return success;
 }
 
 void

--- a/src/ui/canvas/gdi/GdiPlusBitmap.cpp
+++ b/src/ui/canvas/gdi/GdiPlusBitmap.cpp
@@ -1,0 +1,69 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "GdiPlusBitmap.hpp"
+
+#if defined(_MSC_VER)
+# include <algorithm>
+using std::min;  // to avoid the missing 'min' in the gdiplush headers
+using std::max;  // to avoid the missing 'max' in the gdiplush headers
+#endif  // _MSC_VER
+
+#include <assert.h>
+#include <unknwn.h>
+#include <gdiplus.h>
+
+static ULONG_PTR gdiplusToken;
+
+//----------------------------------------------------------------------------
+void
+GdiStartup()
+{
+  Gdiplus::GdiplusStartupInput gdiplusStartupInput;
+  Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
+}
+
+//----------------------------------------------------------------------------
+void
+GdiShutdown()
+{
+  Gdiplus::GdiplusShutdown(gdiplusToken);
+}
+
+//----------------------------------------------------------------------------
+// can load: BMP, GIF, JPEG, PNG, TIFF, Exif, WMF, and EMF
+HBITMAP
+GdiLoadImage(const TCHAR* filename)
+{
+  HBITMAP result = nullptr;
+#ifdef _UNICODE  // TCHAR has to be WCHAR in GdiPlus
+  Gdiplus::Bitmap bitmap(filename, false);
+  Gdiplus::Color color = Gdiplus::Color::White;
+#ifndef NDEBUG
+  Gdiplus::Status status =
+#endif
+    bitmap.GetHBITMAP(color, &result);
+  assert(status == Gdiplus::Status::Ok);
+#endif  // _UNICODE
+  return result;
+}

--- a/src/ui/canvas/gdi/GdiPlusBitmap.hpp
+++ b/src/ui/canvas/gdi/GdiPlusBitmap.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef XCSOAR_UI_CANVAS_GDI_GDIBITMAP_HPP
+#define XCSOAR_UI_CANVAS_GDI_GDIBITMAP_HPP
+
+#if defined(_WIN32) && defined(USE_GDI)
+#include <windows.h>
+HBITMAP GdiLoadImage(const TCHAR* filename);
+void GdiStartup();
+void GdiShutdown();
+#endif  // _WIN32 && USE_GDI
+
+#endif  // XCSOAR_UI_CANVAS_GDI_GDIBITMAP_HPP


### PR DESCRIPTION
Brief summary of the changes
----------------------------

More then 2-3 years ago Flugwetter.de changed a lot of URI fields for accessing the DWD content like Radar, Sat images and so on. Unfortunately there was no maintainance of this component since more then 4 years. 
In this PR I changed all related things, that this access and all the views are functional. For example on GDI this couldn't display anything, because without gdiplus (or maybe an other lib) there is no possibiltiy to read JPEG files (anf PNG, GIF,... and so on) 

Related issues and discussions
------------------------------
With this functional component there are a lot of things possible to made:
* automatic update of the last current sat image
* a view with zoom in, zoom out and move... (the complete picture doesn't have the best resolution...)
* a (short) video of last pictures

At least this feature is functional again...