### PR TITLE
Fix adjust to previous turnpoint in a task

### DIFF
--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -25,6 +25,7 @@ Copyright_License {
 #include "Task/RoutePlannerGlue.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
 #include "Engine/Task/Points/TaskWaypoint.hpp"
 #include "Engine/Route/ReachResult.hpp"
 
@@ -84,11 +85,13 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
 {
   ExclusiveLease lease(*this);
   TaskAdvance &advance = lease->SetTaskAdvance();
+  OrderedTaskPoint *nextwp = nullptr;
 
   switch (advance.GetState()) {
   case TaskAdvance::MANUAL:
   case TaskAdvance::AUTO:
     lease->IncrementActiveTaskPoint(offset);
+    nextwp = dynamic_cast<OrderedTaskPoint *>(lease->GetActiveTaskPoint());
     break;
   case TaskAdvance::START_DISARMED:
   case TaskAdvance::TURN_DISARMED:
@@ -96,17 +99,22 @@ ProtectedTaskManager::IncrementActiveTaskPointArm(int offset)
       advance.SetArmed(true);
     } else {
       lease->IncrementActiveTaskPoint(offset);
+      nextwp = dynamic_cast<OrderedTaskPoint *>(lease->GetActiveTaskPoint());
     }
     break;
   case TaskAdvance::START_ARMED:
   case TaskAdvance::TURN_ARMED:
     if (offset>0) {
       lease->IncrementActiveTaskPoint(offset);
+      nextwp = dynamic_cast<OrderedTaskPoint *>(lease->GetActiveTaskPoint());
     } else {
       advance.SetArmed(false);
     }
     break;
   }
+
+  // forget that we have visited that waypoint already
+  if(nextwp && nextwp->HasEntered()) nextwp->Reset();
 }
 
 bool 


### PR DESCRIPTION


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
When manually adjusting to the previous turn point it must forget that it had visited that turn point before. If it finds this TP had been visited before it auto-increments to the next TP.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Issue #492 

This was previously addressed in PR #528 .
I misread Max' comment and started with a new PR. But when Max told me to fix the old PR it was already too late and I had delete the old branch. Sorry for this.
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
