### PR TITLE
 Reactivation PC-Met access, part 2

### DIFF
--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -47,9 +47,9 @@ BitmapDialog(const Bitmap &bitmap)
   TWidgetDialog<ViewImageWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
            UIGlobals::GetDialogLook(),
-           _T("pc_met"));
+           _T("pc_met"), new ViewImageWidget(bitmap));
   dialog.AddButton(_("Close"), mrOK);
-  dialog.SetWidget();
+//  dialog.SetWidget();
   dialog.ShowModal();
 }
 

--- a/src/ui/canvas/gdi/GdiPlusBitmap.cpp
+++ b/src/ui/canvas/gdi/GdiPlusBitmap.cpp
@@ -60,12 +60,9 @@ GdiLoadImage(const TCHAR* filename)
   Gdiplus::Bitmap bitmap(filename, false);
   if (bitmap.GetLastStatus() != Gdiplus::Ok)
     return nullptr;
-  Gdiplus::Color color = Gdiplus::Color::White;
-#ifndef NDEBUG
-  Gdiplus::Status status =
-#endif
-    bitmap.GetHBITMAP(color, &result);
-  assert(status == Gdiplus::Status::Ok);
+  const Gdiplus::Color color = Gdiplus::Color::White;
+  if (bitmap.GetHBITMAP(color, &result) != Gdiplus::Ok)
+    return nullptr;
 #endif  // _UNICODE
   return result;
 }


### PR DESCRIPTION
Brief summary of the changes
----------------------------

Unfortunately the wheather images from PC-Met are still blank in XCSoar, It was missing the setting of the image dialog with the regarded widget ;-(


Related issues and discussions
------------------------------

See is a small but important addition to PR 540 "Reactivation PC-Met access"
