### PR TITLE
Fix plus symbol rendering in SymbolRenderer

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,5 @@
 Version 7.3 - not yet released
+- fix zoom button label in Traffic Radar View
 
 Version 7.2 - 2021/04/04
 * user interface

--- a/src/Renderer/SymbolRenderer.cpp
+++ b/src/Renderer/SymbolRenderer.cpp
@@ -59,12 +59,16 @@ void
 SymbolRenderer::DrawSign(Canvas &canvas, PixelRect rc, bool plus)
 {
   unsigned size = std::min(rc.GetWidth(), rc.GetHeight()) / 5;
-  const auto r = PixelRect{rc.GetCenter()}.WithMargin({size, size / 3});
+  const auto horizontal_rect = PixelRect{rc.GetCenter()}
+    .WithMargin({size, size / 3});
 
   // Draw horizontal bar
-  canvas.DrawRectangle(r);
+  canvas.DrawRectangle(horizontal_rect);
 
-  if (plus)
+  if (plus) {
     // Draw vertical bar
-    canvas.DrawRectangle(r);
+    const auto vertical_rect = PixelRect{rc.GetCenter()}
+      .WithMargin({size / 3, size});
+    canvas.DrawRectangle(vertical_rect);
+  }
 }


### PR DESCRIPTION
This bug was introduced in f143a2e6 which make plus symbol rendered as minus symbol

Closes #564

after:
<img width="390" alt="Screen Shot 2021-04-05 at 18 58 21" src="https://user-images.githubusercontent.com/496209/113610585-3faacc80-9645-11eb-84c2-757b69846c10.png">
