### PR TITLE
Correct the description in SafetyFactorsConfigPanel for simple mode alternates

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -7206,8 +7206,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/ca.po
+++ b/po/ca.po
@@ -7148,8 +7148,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/cs.po
+++ b/po/cs.po
@@ -7574,8 +7574,7 @@ msgstr "Zjednodušeně"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Alternativy budou uspořádány pouze podle typu (letiště/nouzová plocha) a "
 "výšky příletu."

--- a/po/da.po
+++ b/po/da.po
@@ -7146,8 +7146,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/de.po
+++ b/po/de.po
@@ -7638,8 +7638,7 @@ msgstr "Einfach"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Alternativen werden nur nach Wegpunkt-Typ (Flugplatz/Landefeld) und "
 "Ankunftshöhe sortiert."

--- a/po/el.po
+++ b/po/el.po
@@ -7191,8 +7191,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/es.po
+++ b/po/es.po
@@ -7923,8 +7923,7 @@ msgstr "Sencillo"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Las alternativas solo se ordenarán por tipo de punto de ruta (aeropuerto / "
 "campo externo) y altura de llegada."

--- a/po/fi.po
+++ b/po/fi.po
@@ -7190,8 +7190,7 @@ msgstr "Yksinkertainen"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/fr.po
+++ b/po/fr.po
@@ -7673,8 +7673,7 @@ msgstr "Simple"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Les dégagements ne seront ordonnés que par type de points (aérodrome/champ "
 "posable) et hauteur d'arrivée."

--- a/po/he.po
+++ b/po/he.po
@@ -7141,8 +7141,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/hr.po
+++ b/po/hr.po
@@ -7122,8 +7122,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/hu.po
+++ b/po/hu.po
@@ -7563,8 +7563,7 @@ msgstr "Egyszerű"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/it.po
+++ b/po/it.po
@@ -7692,11 +7692,9 @@ msgstr "Semplice"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
-"Le alternative saranno ordinate solo per tipo (aeroporti/aviosuperfici) e "
-"altezza di arrivo."
+"Gli alternati saranno ordinati solo per altezza di arrivo."
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82
 #, no-c-format

--- a/po/ja.po
+++ b/po/ja.po
@@ -7548,8 +7548,7 @@ msgstr "シンプル"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "代替ポイントは、ウエイポイントのタイプと（飛行場かアウトランディングポイン"
 "ト）および到着高度で選別される"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7374,8 +7374,7 @@ msgstr "심플(간단)"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "대체포인트는 웨이포인트(활공장(공항)/외곽착륙장) 및 도달 고도에서 사용한다."
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -7159,8 +7159,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/nb.po
+++ b/po/nb.po
@@ -7454,8 +7454,7 @@ msgstr "Enkel"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/nl.po
+++ b/po/nl.po
@@ -7669,8 +7669,7 @@ msgstr "Eenvoudig"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "De alternatieven worden gesorteerd op keerpunttype (vliegveld, "
 "buitenlandingsveld) en aankomsthoogte."

--- a/po/pl.po
+++ b/po/pl.po
@@ -7682,8 +7682,7 @@ msgstr "Prosty"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Sortowanie wyłącznie wg. rodzaju lądowiska (lotnisko/teren przygodny) i "
 "wysokości przylotu."

--- a/po/pt.po
+++ b/po/pt.po
@@ -7530,8 +7530,7 @@ msgstr "Simples"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7528,8 +7528,7 @@ msgstr "Simples"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/ro.po
+++ b/po/ro.po
@@ -7265,8 +7265,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/ru.po
+++ b/po/ru.po
@@ -7536,8 +7536,7 @@ msgstr "Простой"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Запасные будут отсортированы только по типам путевых точек (аэропорт/"
 "площадка для посадки) и по высоте прибытия."

--- a/po/sk.po
+++ b/po/sk.po
@@ -7580,8 +7580,7 @@ msgstr "Jednoduché"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Alternatívy budú usporiadané iba podla typu (letisko/náhradná plocha) a "
 "výšky príletu."

--- a/po/sl.po
+++ b/po/sl.po
@@ -7204,8 +7204,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/sr.po
+++ b/po/sr.po
@@ -7127,8 +7127,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/sv.po
+++ b/po/sv.po
@@ -7535,8 +7535,7 @@ msgstr "Enkel"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Landningar sorteras endast enligt vägpunktstyp (flygplats/utelandningsfält) "
 "och ankomsthöjd."

--- a/po/te.po
+++ b/po/te.po
@@ -7118,8 +7118,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/tr.po
+++ b/po/tr.po
@@ -7154,8 +7154,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/uk.po
+++ b/po/uk.po
@@ -7567,8 +7567,7 @@ msgstr "Простий"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 "Запасні будуть відсортовані тільки по типам шляхових точок (аеропорт/"
 "майданчик для посадки) і по висоті прибуття."

--- a/po/vi.po
+++ b/po/vi.po
@@ -7124,8 +7124,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -7116,8 +7116,7 @@ msgstr ""
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr ""
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7303,8 +7303,7 @@ msgstr "简单"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr "备用地将仅由航点类型（机场/外场着陆区域）和到达高度排序。"
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7303,8 +7303,7 @@ msgstr "簡單"
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:80
 #, no-c-format
 msgid ""
-"The alternates will only be sorted by waypoint type (airport/outlanding "
-"field) and arrival height."
+"The alternates will only be sorted by arrival height."
 msgstr "備用地將僅由航點類型（機場/外場著陸區域）和到達高度排序。"
 
 #: src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp:82

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -77,7 +77,7 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
 
   static constexpr StaticEnumChoice abort_task_mode_list[] = {
     { (unsigned)AbortTaskMode::SIMPLE, N_("Simple"),
-      N_("The alternates will only be sorted by waypoint type (airport/outlanding field) and arrival height.") },
+      N_("The alternates will only be sorted by arrival height.") },
     { (unsigned)AbortTaskMode::TASK, N_("Task"),
       N_("The sorting will also take the current task direction into account.") },
     { (unsigned)AbortTaskMode::HOME, N_("Home"),


### PR DESCRIPTION

<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
On the configuration panel about safety factor on "alternates mode" input there are 3 options.
On first option (simple) the description was "The alternates will only be sorted by waypoint type (airport/outlanding field) and arrival height." but is not correct.
The correct is "The alternates will only be sorted by arrival height."

Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/555
