### PR TITLE
Color code relative altitude of FLARM traffic in map window

### DIFF
--- a/src/Look/TrafficLook.cpp
+++ b/src/Look/TrafficLook.cpp
@@ -34,10 +34,12 @@ void
 TrafficLook::Initialise(const Font &_font)
 {
   safe_color = Color(0x1d,0x9b,0xc5);
+  safe_below_color = Color(0x1d,0xc5,0x10);
   warning_color = Color(0xfe,0x84,0x38);
   alarm_color = Color(0xfb,0x35,0x2f);
 
   safe_brush.Create(safe_color);
+  safe_below_brush.Create(safe_below_color);
   warning_brush.Create(warning_color);
   alarm_brush.Create(alarm_color);
 

--- a/src/Look/TrafficLook.hpp
+++ b/src/Look/TrafficLook.hpp
@@ -33,10 +33,12 @@ class Font;
 
 struct TrafficLook {
   Color safe_color;
+  Color safe_below_color;
   Color warning_color;
   Color alarm_color;
 
   Brush safe_brush;
+  Brush safe_below_brush;
   Brush warning_brush;
   Brush alarm_brush;
 

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -56,7 +56,13 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     canvas.Select(traffic_look.alarm_brush);
     break;
   case FlarmTraffic::AlarmType::NONE:
-    canvas.Select(traffic_look.safe_brush);
+    if (traffic.relative_altitude > (const RoughAltitude)50) {
+      canvas.Select(traffic_look.safe_brush);
+    } else if (traffic.relative_altitude > (const RoughAltitude)-50) {
+      canvas.Select(traffic_look.warning_brush);
+    } else {
+      canvas.Select(traffic_look.safe_below_brush);
+    }
     break;
   }
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Addresses Issue #480 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->

It color codes FLARM traffic symbols on the map (little triangles). Traffic 50m and deeper below is coded green. Traffic 50m and above is coded blue. Traffic in the +/-50m range is coded orange.
A FLARM alert overrides this color coding: the symbol is red (unchanged behavior).
