### PR TITLE
gh-workflow: build unix target for PRs/Push

### DIFF
--- a/.github/workflows/build-unix.yml
+++ b/.github/workflows/build-unix.yml
@@ -1,0 +1,42 @@
+on:
+  workflow_dispatch:  
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+env:
+  TARGET: UNIX
+jobs:
+  xcsoar-compile:
+    runs-on: ubuntu-latest
+    steps:
+     - id: checkout 
+       uses: actions/checkout@v2
+       with:
+         submodules: True
+     - id: cache-ccache
+       uses: hendrikmuhs/ccache-action@v1
+       with:
+         key: ${{ matrix.os }}-${{ matrix.type }}-${{ env.TARGET }}
+     - id: repository
+       uses: ASzc/change-string-case-action@v1
+       with:
+         string: ${{ github.repository }}
+     - name: XCSoar Compile ${{ env.TARGET }} 
+       uses: addnab/docker-run-action@v3
+       with:
+         image: ghcr.io/${{ steps.repository.outputs.lowercase }}/xcsoar-build:latest
+         options: -v ${{ github.workspace }}:/opt/xcsoar -v /home/runner/work/XCSoar/XCSoar/.ccache:/root/.ccache
+         run: | 
+           cd /opt/xcsoar
+           xcsoar-compile ${{ env.TARGET }} USE_CCACHE=y V=2 everything
+     - name: XCSoar run checks ${{ env.TARGET }}
+       uses: addnab/docker-run-action@v3
+       with:
+         image: ghcr.io/${{ steps.repository.outputs.lowercase }}/xcsoar-build:latest
+         options: -v ${{ github.workspace }}:/opt/xcsoar -v /home/runner/work/XCSoar/XCSoar/.ccache:/root/.ccache
+         run: | 
+           cd /opt/xcsoar
+           xcsoar-compile ${{ env.TARGET }} V=2 check


### PR DESCRIPTION
Compiling the UNIX target from our own defined environment. This would deprecate circle-ci.