### PR TITLE
Color code relative altitude of FLARM traffic in map window

### DIFF
--- a/src/Look/TrafficLook.cpp
+++ b/src/Look/TrafficLook.cpp
@@ -35,10 +35,12 @@ TrafficLook::Initialise(const Font &_font)
 {
   safe_color = Color(0x1d,0x9b,0xc5);
   warning_color = Color(0xfe,0x84,0x38);
+  warning_in_altitude_range_color = Color(0xff,0x00,0xff);
   alarm_color = Color(0xfb,0x35,0x2f);
 
   safe_brush.Create(safe_color);
   warning_brush.Create(warning_color);
+  warning_in_altitude_range_brush.Create(warning_in_altitude_range_color);
   alarm_brush.Create(alarm_color);
 
   unsigned width = Layout::ScalePenWidth(2);

--- a/src/Look/TrafficLook.cpp
+++ b/src/Look/TrafficLook.cpp
@@ -33,12 +33,14 @@ constexpr Color TrafficLook::team_color_yellow;
 void
 TrafficLook::Initialise(const Font &_font)
 {
-  safe_color = Color(0x1d,0x9b,0xc5);
+  safe_above_color = Color(0x1d,0x9b,0xc5);
+  safe_below_color = Color(0x1d,0xc5,0x10);
   warning_color = Color(0xfe,0x84,0x38);
   warning_in_altitude_range_color = Color(0xff,0x00,0xff);
   alarm_color = Color(0xfb,0x35,0x2f);
 
-  safe_brush.Create(safe_color);
+  safe_above_brush.Create(safe_above_color);
+  safe_below_brush.Create(safe_below_color);
   warning_brush.Create(warning_color);
   warning_in_altitude_range_brush.Create(warning_in_altitude_range_color);
   alarm_brush.Create(alarm_color);

--- a/src/Look/TrafficLook.hpp
+++ b/src/Look/TrafficLook.hpp
@@ -32,12 +32,14 @@
 class Font;
 
 struct TrafficLook {
-  Color safe_color;
+  Color safe_above_color;
+  Color safe_below_color;
   Color warning_color;
   Color warning_in_altitude_range_color;
   Color alarm_color;
 
-  Brush safe_brush;
+  Brush safe_above_brush;
+  Brush safe_below_brush;
   Brush warning_brush;
   Brush warning_in_altitude_range_brush;
   Brush alarm_brush;

--- a/src/Look/TrafficLook.hpp
+++ b/src/Look/TrafficLook.hpp
@@ -34,10 +34,12 @@ class Font;
 struct TrafficLook {
   Color safe_color;
   Color warning_color;
+  Color warning_in_altitude_range_color;
   Color alarm_color;
 
   Brush safe_brush;
   Brush warning_brush;
+  Brush warning_in_altitude_range_brush;
   Brush alarm_brush;
 
   static constexpr Color team_color_green = Color(0x74, 0xff, 0);

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -55,7 +55,12 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     canvas.Select(traffic_look.alarm_brush);
     break;
   case FlarmTraffic::AlarmType::NONE:
-    canvas.Select(traffic_look.safe_brush);
+    if ((traffic.relative_altitude < (const RoughAltitude)50) &&
+        (traffic.relative_altitude > (const RoughAltitude)-50)) {
+      canvas.Select(traffic_look.warning_in_altitude_range_brush);
+    } else {
+      canvas.Select(traffic_look.safe_brush);
+    }
     break;
   }
 

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -55,11 +55,12 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     canvas.Select(traffic_look.alarm_brush);
     break;
   case FlarmTraffic::AlarmType::NONE:
-    if ((traffic.relative_altitude < (const RoughAltitude)50) &&
-        (traffic.relative_altitude > (const RoughAltitude)-50)) {
+    if (traffic.relative_altitude > (const RoughAltitude)50) {
+      canvas.Select(traffic_look.safe_above_brush);
+    } else if (traffic.relative_altitude > (const RoughAltitude)-50) {
       canvas.Select(traffic_look.warning_in_altitude_range_brush);
     } else {
-      canvas.Select(traffic_look.safe_brush);
+      canvas.Select(traffic_look.safe_below_brush);
     }
     break;
   }
@@ -109,7 +110,7 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     { 0, 3 },
   };
 
-  canvas.Select(traffic_look.safe_brush);
+  canvas.Select(traffic_look.safe_above_brush);
 
   // Select black pen
   if (IsDithered())


### PR DESCRIPTION
New attempt to address Issue #480

FLARM traffic symbols are colored Magenta if the traffic is within +/- 50m of my FLARM's altitude.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
I want to identify the FLARM targets in the same altitude range as me (+/- 50m). I’m using color to visualize this as opposed to using text. So I need 2 colors: color1 for in range, color2 for outside of altitude range.
For color1 I picked Magenta
Color2 remains unchanged: Blue

Later in an additional commit, I'd like to differentiate the "outside altitude range" in two: "below altitude range" and "above altitude range" each with its own color.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
