### PR TITLE
enable SSL in curl for Android and Kobo

### DIFF
--- a/build/python/build/cmake.py
+++ b/build/python/build/cmake.py
@@ -36,11 +36,12 @@ def configure(toolchain, src, build, args=()):
 
 class CmakeProject(Project):
     def __init__(self, url, alternative_url, md5, installed, configure_args=[],
-                 windows_configure_args=[],
+                 windows_configure_args=[], nonwindows_configure_args=[],
                  **kwargs):
         Project.__init__(self, url, alternative_url, md5, installed, **kwargs)
         self.configure_args = configure_args
         self.windows_configure_args = windows_configure_args
+        self.nonwindows_configure_args = nonwindows_configure_args
 
     def configure(self, toolchain):
         src = self.unpack(toolchain)
@@ -48,6 +49,8 @@ class CmakeProject(Project):
         configure_args = self.configure_args
         if toolchain.is_windows:
             configure_args = configure_args + self.windows_configure_args
+        else:
+            nonconfigure_args = configure_args + self.nonwindows_configure_args
         configure(toolchain, src, build, configure_args)
         return build
 

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -147,6 +147,9 @@ curl = CmakeProject(
     windows_configure_args=[
         '-DCMAKE_USE_SCHANNEL=ON',
     ],
+    nonwindows_configure_args=[
+        '-DCMAKE_USE_OPENSSL=ON',
+    ],
     patches=abspath('lib/curl/patches'),
 )
 

--- a/ide/provisioning/install-android-tools.sh
+++ b/ide/provisioning/install-android-tools.sh
@@ -3,23 +3,28 @@
 set -e
 
 # set ANDROID variables
-ANDROID_SDK_TOOLS_VERSION=3859397
+ANDROID_SDK_TOOLS_VERSION=6858069_latest
 ANDROID_BUILD_TOOLS_VERSION=29.0.3
-ANDROID_PLATFORM_VERSION=26
+ANDROID_PLATFORM_VERSION=29
 ANDROID_NDK_VERSION=r22b
 ANDROID_REPO_URL=https://dl.google.com/android/repository
 ANDROID_SDK_DIR=~/opt/android-sdk-linux
 ANDROID_NDK_DIR=~/opt/android-ndk-${ANDROID_NDK_VERSION}
 
-if [ -d ${ANDROID_SDK_DIR} ]
+if [ -d ${ANDROID_SDK_DIR}\build-tools\${ANDROID_BUILD_TOOLS_VERSION} ]
 then
-  echo Not installing Android NDK, because ${ANDROID_SDK_DIR} exists already
+  echo Not installing Android SDK, because ${ANDROID_SDK_DIR}\build-tools\${ANDROID_BUILD_TOOLS_VERSION} exists already
 else
+  if [ -d ${ANDROID_SDK_DIR} ]
+  then
+    echo Remove old Android SDK  '${ANDROID_SDK_DIR}'...
+    rm -r ${ANDROID_SDK_DIR}
+  fi
   echo Installing Android SDK to ${ANDROID_SDK_DIR}...
 
   android_sdk_tmp_zip=$(mktemp)
   wget --progress=bar:force:noscroll \
-      ${ANDROID_REPO_URL}/sdk-tools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip \
+      ${ANDROID_REPO_URL}/commandlinetools-linux-${ANDROID_SDK_TOOLS_VERSION}.zip \
       -O ${android_sdk_tmp_zip}
 
   mkdir -p ${ANDROID_SDK_DIR}/licenses
@@ -32,10 +37,12 @@ else
 fi
 echo
 
-cd ~/opt/android-sdk-linux
+cd ${ANDROID_SDK_DIR}
 echo Installing Android SDK packages...
-tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" \
-    "platforms;android-${ANDROID_PLATFORM_VERSION}"
+echo cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_DIR} \
+    "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-${ANDROID_PLATFORM_VERSION}"
+cmdline-tools/bin/sdkmanager --sdk_root=${ANDROID_SDK_DIR} \
+    "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" "platforms;android-${ANDROID_PLATFORM_VERSION}"
 echo
 
 if [ -d ${ANDROID_NDK_DIR} ]


### PR DESCRIPTION
Brief summary of the changes
----------------------------

With changes of commit 585e7e3384431 to enabling the WinSSL for Win64 and PC Targets unfortunately the curl link to openssl for Android  and Kobo toolchains was switched off!
Maybe this PR can help to bring the SSL in this curl libs to life.

Byside with the 2nd commit I changed the Android SDK setup for the docker build to the newest one regarding to the needs of the make run.

Related issues and discussions
------------------------------

Maybe this can help to overcome the issue #580, but unfortunately I don't have a Kobo hardware to testing this.
