### PR TITLE
(Re-)Enabling MSVC

### DIFF
--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -26,6 +26,7 @@ Copyright_License {
 #include "util/GlobalSliceAllocator.hxx"
 
 #include <algorithm>
+#include <iterator>
 
 Trace::Trace(const unsigned _no_thin_time, const unsigned max_time,
              const unsigned max_size)

--- a/src/Geo/ConvexHull/GrahamScan.cpp
+++ b/src/Geo/ConvexHull/GrahamScan.cpp
@@ -22,6 +22,7 @@
 
 #include "GrahamScan.hpp"
 #include "Geo/SearchPointVector.hpp"
+#include <iterator>  // necessary for std::back_inserter
 
 static bool
 sortleft

--- a/src/LogFile.cpp
+++ b/src/LogFile.cpp
@@ -98,7 +98,7 @@ LogFormat(const char *fmt, ...) noexcept
   va_list ap;
 
   va_start(ap, fmt);
-  vsprintf(buf, fmt, ap);
+  vsnprintf(buf, sizeof(buf) - 1, fmt, ap);
   va_end(ap);
 
   LogString(buf);

--- a/src/Math/Trig.hpp
+++ b/src/Math/Trig.hpp
@@ -24,6 +24,10 @@ Copyright_License {
 #ifndef XCSOAR_MATH_TRIG_HPP
 #define XCSOAR_MATH_TRIG_HPP
 
+#if defined(_MSC_VER)
+# include "util/Compiler.h"
+#endif
+
 #include <utility>
 
 #include <math.h>
@@ -35,6 +39,9 @@ sin_cos(const double thetha) noexcept
   double s, c;
 #ifdef __APPLE__
   __sincos(thetha, &s, &c);
+#elif defined(_MSC_VER)  // STL and MSVC have no sincos...
+  s = sin(thetha);
+  c = cos(thetha);
 #else
   sincos(thetha, &s, &c);
 #endif

--- a/src/Task/LoadFile.cpp
+++ b/src/Task/LoadFile.cpp
@@ -31,6 +31,7 @@
 #include "util/StringAPI.hxx"
 
 #include <tchar.h>
+#include <stdexcept>
 
 std::unique_ptr<OrderedTask>
 LoadTask(Path path, const TaskBehaviour &task_behaviour,

--- a/src/Task/TaskFileIGC.cpp
+++ b/src/Task/TaskFileIGC.cpp
@@ -34,6 +34,7 @@ Copyright_License {
 
 #include <list>
 #include <cassert>
+#include <stdexcept>
 
 static bool
 ReadIGCDeclaration(Path path, IGCDeclarationHeader &header,

--- a/src/Task/TaskFileSeeYou.cpp
+++ b/src/Task/TaskFileSeeYou.cpp
@@ -41,6 +41,7 @@
 #include "Units/System.hpp"
 
 #include <stdlib.h>
+#include <stdexcept>
 
 struct SeeYouTaskInformation {
   /** True = RT, False = AAT */

--- a/src/io/FileCache.cpp
+++ b/src/io/FileCache.cpp
@@ -31,12 +31,13 @@ Copyright_License {
 #include <stdexcept>
 
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
-#ifndef HAVE_POSIX
-#include <windows.h>
+#ifdef HAVE_POSIX
+#   include <sys/types.h>
+#   include <sys/stat.h>
+#   include <unistd.h>
+#else
+#   include <windows.h>
 #endif
 
 static constexpr unsigned FILE_CACHE_MAGIC = 0xab352f8a;

--- a/src/net/http/ToBuffer.cpp
+++ b/src/net/http/ToBuffer.cpp
@@ -89,6 +89,7 @@ public:
     memcpy(buffer + received, data.data, data.size);
     received += data.size;
 
+    buffer[received] = 0;  // end of (string) buffer!
     env.SetProgressRange(received);
   }
 

--- a/src/system/Args.hpp
+++ b/src/system/Args.hpp
@@ -39,6 +39,7 @@ Copyright_License {
 #include <stdio.h>
 #include <string.h>
 #include <cassert>
+#include <iterator>
 
 #ifdef MORE_USAGE
 extern void PrintMoreUsage();

--- a/src/util/Compiler.h
+++ b/src/util/Compiler.h
@@ -21,8 +21,12 @@ Copyright_License {
 }
 */
 
-#ifndef COMPILER_H
-#define COMPILER_H
+#ifndef UTIL_COMPILER_H
+#define UTIL_COMPILER_H
+
+#ifdef _MSC_VER
+#   include "util/msvc"
+#else  // _MSC_VER
 
 #define GCC_MAKE_VERSION(major, minor, patchlevel) ((major) * 10000 + (minor) * 100 + patchlevel)
 
@@ -141,6 +145,8 @@ Copyright_License {
 
 #endif
 
+#endif  // _MSC_VER
+
 #if CLANG_OR_GCC_VERSION(4,3)
 
 #define gcc_hot __attribute__((hot))
@@ -195,4 +201,4 @@ Copyright_License {
 #define gcc_unreachable()
 #endif
 
-#endif
+#endif  // UTIL_COMPILER_H

--- a/src/util/TriState.hpp
+++ b/src/util/TriState.hpp
@@ -33,6 +33,7 @@
 #include <cstdint>
 
 #ifdef _WIN32
+#include <winsock2.h>
 #include <windows.h>
 #elif defined(__APPLE__)
 #import <Foundation/Foundation.h>

--- a/src/util/msvc.h
+++ b/src/util/msvc.h
@@ -1,0 +1,81 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef UTIL_MSVC_COMPILER_H
+#define UTIL_MSVC_COMPILER_H
+
+#ifdef _MSC_VER
+#if __cplusplus >= 201700L  // with C++17 it's this deprecated
+                            // struct not available anymore
+#   include "util/xcs_functional.hpp"
+#endif
+#   include <io.h>
+#   include "corecrt_math_defines.h"
+
+#define STRING2(x) #x
+#define STRING(x) STRING2(x)
+
+#define CLANG_OR_GCC_VERSION(x, y)  0
+#define GCC_CHECK_VERSION(x, y)     0
+#define GCC_OLDER_THAN(x, y)        1  // This isn't a (new!) GCC
+#define CLANG_CHECK_VERSION(x, y)   0
+
+#define DT_UNDERLINE 0            // not avalable in WinUser.h!
+
+#define __attribute__(x)
+
+#define gcc_const
+#define gcc_deprecated
+#define gcc_may_alias
+#define gcc_malloc
+#define gcc_noreturn
+#define gcc_packed
+#define gcc_printf(a,b)
+#define gcc_pure
+#define gcc_sentinel
+#define gcc_unused
+#define gcc_warn_unused_result
+#define gcc_nonnull(...)
+#define gcc_nonnull_all
+#define gcc_returns_nonnull
+#define gcc_likely(x)  (x)
+#define gcc_unlikely(x)  (x)
+#define gcc_aligned(n)
+#define gcc_visibility_hidden
+#define gcc_visibility_default
+#define gcc_always_inline
+
+// unuse deprecated functions:
+#define strncasecmp(a, b, n)  _strnicmp(a, b, n)
+#define strcasecmp(a, b)      _stricmp(a, b)
+#define strdup(a)             _strdup(a)
+#define wcsdup(a)             _wcsdup(a)
+
+// TODO(August2111): where is this defined (on GCC)?
+#ifndef ssize_t
+typedef size_t   ssize_t;
+#endif  // ssize_t
+
+#endif  // _MSC_VER
+
+#endif  // UTIL_MSVC_COMPILER_H


### PR DESCRIPTION
Brief summary of the changes
----------------------------

All compile steps for XCSoar are done in Linux - with cross compiling for Windows, Android, Kobo,...
Because as a developer I'm coming from windows and mostly my work is on Visual Studio I prefare tto enable this platform for XCSoar too.
From my point of view ther are only some small steps to change, but without I cannot compile the project. 

Related issues and discussions
------------------------------

Maybe there are some other guys with the same intention - I think with enabling MSVC the XCSoar project could attract additional volonteers ;-)
