### PR TITLE
WeGlide Uploading IGC files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 XCSoar Glide Computer - http://www.xcsoar.org/
-Copyright (C) 2000-2021 The XCSoar Project
+Copyright (C) 2000-2022 The XCSoar Project
 
 The following people and organizations have contributed code to XCSoar:
 
@@ -59,6 +59,8 @@ The following people and organizations have contributed code to XCSoar:
  Roel Baardman <roel.baardman@gmail.com>
  Jetsada Machom <zinuzoid@gmail.com>
  Nicolas Massart <nmassart@gmail.com>
+ Uwe Augustin <info@flapsonline.de>
+ Ronald Niederhagen <ronald_niederhagen@freenet.de>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,18 @@ Version 7.23 - not yet released
   - fix broken button text background
   - add OTG support (serial, sound, net) for Clara HD
   - fix "Network failure" in Wifi dialog
+* user interface
+  - add a simple date picker for date of birth selection
+  - add a integer selection picker for large numbers
+  - new Settings "WeGlide PilotID, DayOfBirth"
+  - new Glider setting "WeGlide GliderID"
+* cloud server
+  - upload igcfiles to a cloud server (starting with WeGlide)
+* logger
+  - automatic upload after downloading flight from logger (setable)
+    with pilot (id and birthdate in Profile setting) and glider (id in Airplane setting)
+* internet
+  - add functionality for uploading igcfiles
 
 Version 7.22 - 2022/01/14
 * user interface

--- a/build/main.mk
+++ b/build/main.mk
@@ -228,6 +228,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(SRC)/Atmosphere/CuSonde.cpp \
 	$(SRC)/Cloud/weglide/WeGlideSettings.cpp \
+	$(SRC)/contest/weglide/UploadIGCFile.cpp \
 	$(SRC)/Plane/PlaneGlue.cpp \
 	$(SRC)/Plane/PlaneFileGlue.cpp \
 	$(SRC)/FLARM/FlarmId.cpp \
@@ -664,6 +665,7 @@ endif
 XCSOAR_SOURCES += \
 	$(SRC)/net/client/tim/Client.cpp \
 	$(SRC)/net/client/tim/Glue.cpp \
+	$(SRC)/Cloud/weglide/UploadFlight.cpp \
 	$(SRC)/Tracking/SkyLines/Client.cpp \
 	$(SRC)/Tracking/SkyLines/Assemble.cpp \
 	$(SRC)/Tracking/SkyLines/Key.cpp \

--- a/src/Dialogs/FilePicker.cpp
+++ b/src/Dialogs/FilePicker.cpp
@@ -43,9 +43,11 @@ FilePicker(const TCHAR *caption, FileDataField &df,
 
   const TCHAR *extra_caption = nullptr;
 #ifdef HAVE_DOWNLOAD_MANAGER
-  if (df.GetFileType() != FileType::UNKNOWN &&
-      Net::DownloadManager::IsAvailable())
-    extra_caption = _("Download");
+  // with FileType::IGC don't show the 'Download'-Button!
+  if (df.GetFileType() != FileType::IGC && 
+    df.GetFileType() != FileType::UNKNOWN &&
+    Net::DownloadManager::IsAvailable())
+      extra_caption = _("Download");
 #endif
 
   int i = ComboPicker(caption, combo_list, help_text, false, extra_caption);

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -210,6 +210,7 @@ void eventRunLuaFile(const TCHAR *misc);
 void eventResetTask(const TCHAR *misc);
 void eventLockScreen(const TCHAR *misc);
 void eventExchangeFrequencies(const TCHAR *misc);
+void eventUploadIGCFile(const TCHAR *misc);
 // -------
 
 } // namespace InputEvents

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -87,6 +87,10 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Device/MultipleDevices.hpp"
 
+#include "Form/DataField/File.hpp"
+#include "Dialogs/FilePicker.hpp"
+#include "contest/weglide/UploadIGCFile.hpp"
+
 #include <cassert>
 #include <tchar.h>
 #include <algorithm>
@@ -737,4 +741,18 @@ void
 InputEvents::eventExchangeFrequencies(const TCHAR *misc)
 {
   XCSoarInterface::ExchangeRadioFrequencies(true);
+}
+
+void
+InputEvents::eventUploadIGCFile(const TCHAR *misc) {
+  FileDataField df;
+  df.ScanMultiplePatterns(_T("*.igc"));
+  df.SetFileType(FileType::IGC);
+  if (FilePicker(_T("IGC-FilePicker"), df)) {
+    auto path = df.GetValue();
+    if (!path.IsEmpty())
+      if (WeGlide::UploadIGCFile(path)) {
+        // success!
+      }
+  }
 }

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -44,6 +44,9 @@
 #include "IGC/IGCHeader.hpp"
 #include "Formatter/IGCFilenameFormatter.hpp"
 #include "time/BrokenDate.hpp"
+#include "Interface.hpp"
+#include "contest/weglide/UploadIGCFile.hpp"
+
 
 class DeclareJob {
   DeviceDescriptor &device;
@@ -336,12 +339,24 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
     FormatIGCFilenameLong(name, date, header.manufacturer, header.id,
                           header.flight);
 
-    transaction.SetPath(AllocatedPath::Build(logs_path, name));
-
+    Path igc_path = AllocatedPath::Build(logs_path, name);
+    transaction.SetPath(igc_path);
+    
     try {
       transaction.Commit();
     } catch (...) {
       ShowError(std::current_exception(), _("Download flight"));
+    }
+
+    WeGlideSettings weglide_settings =
+      CommonInterface::GetComputerSettings().weglide;
+    if (weglide_settings.enabled && weglide_settings.automatic_upload &&
+      weglide_settings.pilot_id > 0) {
+      // ask whether this IGC should be uploaded to WeGlide
+      if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
+        _("Upload flight"), MB_YESNO | MB_ICONQUESTION) != IDYES) {
+        WeGlide::UploadIGCFile(igc_path);
+      }
     }
 
     if (ShowMessageBox(_("Do you want to download another flight?"),

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -33,6 +33,7 @@ enum class FileType : uint8_t {
   WAYPOINTDETAILS,
   MAP,
   FLARMNET,
+  IGC,
 };
 
 #endif

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -1,0 +1,192 @@
+/*
+  Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "UploadIGCFile.hpp"
+#include "Interface.hpp"
+#include "UIGlobals.hpp"
+#include "LogFile.hpp"
+#include "Cloud/weglide/UploadFlight.hpp"
+#include "Cloud/weglide/WeGlideSettings.hpp"
+#include "co/InvokeTask.hxx"
+#include "Dialogs/Message.hpp"
+#include "Dialogs/CoDialog.hpp"
+#include "Formatter/TimeFormatter.hpp"
+#include "json/ParserOutputStream.hxx"
+#include "Language/Language.hpp"
+#include "net/http/Init.hpp"
+#include "Operation/PluggableOperationEnvironment.hpp"
+#include "system/ConvertPathName.hpp"
+#include "system/FileUtil.hpp"
+#include "util/StaticString.hxx"
+#include "util/ConvertString.hpp"
+
+#include <cinttypes>
+
+// Wrapper for getting converted string values of a json string
+static const UTF8ToWideConverter 
+GetJsonString(boost::json::standalone::value json_value, std::string_view key)
+{
+  return UTF8ToWideConverter(json_value.at(key).get_string().c_str());
+}
+
+namespace WeGlide {
+
+struct User {
+  uint32_t id;
+  BrokenDate birthdate;
+  StaticString<0x80> name;
+};
+
+struct Aircraft {
+  uint32_t id;
+  StaticString<0x40> name;
+  StaticString<4> kind;  // 'MG' - motor aircraft,...
+  StaticString<10> sc_class;
+};
+
+struct FlightData {
+  uint64_t flight_id = 0;
+  User user;
+  Aircraft aircraft;
+  StaticString<0x40> scoring_date;
+  StaticString<0x40> registration;
+  StaticString<0x40> competition_id;
+};
+
+static FlightData
+UploadJsonInterpreter(const boost::json::value &json)
+{
+  FlightData flight_data;
+  // flight is the 1st flight object in this array ('at(0)')
+  auto flight = json.as_array().at(0);
+  flight_data.scoring_date = GetJsonString(flight, "scoring_date").c_str();
+  flight_data.flight_id = flight.at("id").to_number<int64_t>();
+  flight_data.registration = GetJsonString(flight, "registration").c_str();
+  flight_data.competition_id = GetJsonString(flight, "competition_id").c_str();
+
+  auto user = flight.at("user").as_object();
+  flight_data.user.id = user.at("id").to_number<uint32_t>();
+  flight_data.user.name = GetJsonString(user, "name").c_str();
+
+  auto aircraft = flight.at("aircraft").as_object();
+  flight_data.aircraft.id = aircraft.at("id").to_number<uint32_t>();
+  flight_data.aircraft.name = GetJsonString(aircraft, "name").c_str();
+  flight_data.aircraft.kind = GetJsonString(aircraft, "kind").c_str();
+  flight_data.aircraft.sc_class = GetJsonString(aircraft, "sc_class").c_str();
+
+  return flight_data;
+}
+
+// UploadSuccessDialog is only a preliminary DialogBox to show the 
+// result of this upload
+static void
+UploadSuccessDialog(const FlightData &flight_data, const TCHAR *msg)
+{
+  StaticString<0x1000> display_string;
+  // TODO: Create a real Dialog with fields in 'src/Dialogs/Cloud/weglide'!
+  // With this Dialog insert the possibilty to update/patch the flight
+  // f.e. copilot in double seater, scoring class, short comment and so on
+  display_string.Format(_T("%s\n\n%s: %u\n%s: %s\n%s: %s (%d)\n"
+    "%s: %s (%u)\n%s: %s, %s: %s"), msg,
+    _("Flight ID"), flight_data.flight_id,
+    _("Scoring Date"), flight_data.scoring_date.c_str(),
+    _("User"), flight_data.user.name.c_str(), flight_data.user.id,
+    _("Aircraft"), flight_data.aircraft.name.c_str(), flight_data.aircraft.id,
+    _("Reg."), flight_data.registration.c_str(),
+    _("Comp. ID"), flight_data.competition_id.c_str());
+
+  ShowMessageBox(display_string.c_str(), _("WeGlide Upload"), MB_OK);
+}
+
+struct CoInstance {
+  boost::json::value value;
+  Co::InvokeTask
+  UpdateTask(Path igc_path, const WeGlideSettings &settings,
+    uint_least32_t glider_id, ProgressListener &progress)
+  {
+    value = co_await UploadFlight(*Net::curl, settings, glider_id,
+      igc_path, progress);
+  }
+};
+
+static FlightData
+UploadFile(Path igc_path, StaticString<0x1000> &msg) noexcept
+{
+  FlightData flight_data({ 0 });
+  try {
+    WeGlideSettings settings = CommonInterface::GetComputerSettings().weglide;
+    uint32_t glider_id = CommonInterface::GetComputerSettings().plane
+      .weglide_glider_type;
+
+    if (!File::Exists(igc_path)) {
+      msg.Format(_("'%s' - %s"), igc_path.c_str(), _("File doesn't exist"));
+      return flight_data;  // with flight_id = 0!
+    }
+
+    PluggableOperationEnvironment env;
+    CoInstance instance;
+    if (ShowCoDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
+      _("Upload Flight"), instance.UpdateTask(igc_path, settings,
+        glider_id, env), &env) == false) {
+      msg.Format(_("'%s' - %s"), igc_path.c_str(),
+        _("ShowCoDialog with failure"));
+      return flight_data;  // with flight_id = 0!
+    }
+
+    // read the important data from json in a structure
+    flight_data = UploadJsonInterpreter(instance.value);
+
+    msg.Format(_("File upload '%s' was successful"), igc_path.c_str());
+    return flight_data;  // upload successful!
+  }
+  catch (const std::exception &e) {
+    msg.Format(_("'%s' - %s"), igc_path.c_str(),
+      UTF8ToWideConverter(e.what()).c_str());
+    return flight_data;  // with flight_id = 0!
+  }
+}
+
+bool
+UploadIGCFile(Path igc_path) noexcept
+{ 
+  try {
+    StaticString<0x1000> msg;
+    auto flight_data = UploadFile(igc_path, msg);
+    if (flight_data.flight_id > 0) {
+      // upload successful!
+      LogFormat(_("%s: %s"), _("WeGlide Upload"), msg.c_str());
+      UploadSuccessDialog(flight_data, msg.c_str());
+      return true;
+    } else {
+      // upload failed!
+      LogFormat(_T("%s: %s!"), _("WeGlide Upload Error"), msg.c_str());
+      ShowMessageBox(msg.c_str(), _("WeGlide Upload Error"),
+        MB_ICONEXCLAMATION);
+    }
+  } catch (...) {
+    LogError(std::current_exception());
+  }
+  return false;
+}
+
+} // namespace WeGlide

--- a/src/contest/weglide/UploadIGCFile.hpp
+++ b/src/contest/weglide/UploadIGCFile.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+#include <cstdint>
+
+class Path;
+
+namespace WeGlide {
+
+bool UploadIGCFile(Path igc_path) noexcept;
+
+} // namespace WeGlide


### PR DESCRIPTION
Brief summary of the changes
----------------------------

Add some components to prepare the upload feature
  * simple date picker for date of birth selection
  * integer selection picker for large numbers
  * curl  UploadFile component
  * Setting the relevant data in the 'Config/Setting/WeGlide Cloud'-Panel and in the 'Plane'-Panel
  * Uploading the IGC file with 3 options:
    *  1st: Direct upload automatically after downloading file from logger (all necessary data have to be set and additional the flag 'automatic upload'
    * 2nd: Calling the IGC-FilePicker with a (self defined) lua gesture or keypress event
    * 3rd: Upload directly over a lua file
 
Related issues and discussions
------------------------------
The upload is following the proposal Issue #505 from Bomilkar.

The 'Downloading WeGlide Task'-Job will be coming in a next step based on this!