### PR TITLE
Settings/TrackingConfigPanel: same tracking intervals for Livetrack24 as for SkyLines

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.9 - not yet released
+* settings
+  - allow LiveTrack24 tracking intervals smaller than 5 seconds
 
 Version 7.8 - 2021/06/02
 * don't delete old IGC files automatically

--- a/src/Dialogs/Settings/Panels/TrackingConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TrackingConfigPanel.cpp
@@ -86,6 +86,8 @@ public:
 private:
   /* methods from DataFieldListener */
   void OnModified(DataField &df) noexcept override;
+
+  unsigned int FindClosestTrackingInterval(unsigned int) noexcept;
 };
 
 #ifdef HAVE_SKYLINES_TRACKING
@@ -145,7 +147,7 @@ TrackingConfigPanel::OnModified(DataField &df) noexcept
 #endif
 }
 
-#ifdef HAVE_SKYLINES_TRACKING
+#if (defined HAVE_SKYLINES_TRACKING || defined HAVE_LIVETRACK24)
 
 static constexpr StaticEnumChoice tracking_intervals[] = {
   { 1, _T("1 sec") },
@@ -164,6 +166,10 @@ static constexpr StaticEnumChoice tracking_intervals[] = {
   { 600, _T("10 min") },
   { 900, _T("15 min") },
   { 1200, _T("20 min") },
+  { 1800, _T("30 min") },
+  { 2400, _T("40 min") },
+  { 3000, _T("50 min") },
+  { 3600, _T("60 min") },
   { 0 },
 };
 
@@ -204,7 +210,7 @@ TrackingConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexc
   AddBoolean(_T("Roaming"), nullptr, settings.skylines.roaming, this);
 #endif
   AddEnum(_("Tracking Interval"), nullptr, tracking_intervals,
-          settings.skylines.interval);
+          FindClosestTrackingInterval(settings.skylines.interval));
 
   AddBoolean(_("Track friends"),
              _("Download the position of your friends live from the SkyLines server."),
@@ -229,7 +235,8 @@ TrackingConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexc
 #ifdef HAVE_LIVETRACK24
   AddBoolean(_T("LiveTrack24"),  _T(""), settings.livetrack24.enabled, this);
 
-  AddTime(_("Tracking Interval"), _T(""), 5, 3600, 5, settings.livetrack24.interval);
+  AddEnum(_("Tracking Interval"), nullptr, tracking_intervals, 
+          FindClosestTrackingInterval(settings.livetrack24.interval));
 
   AddEnum(_("Vehicle Type"), _("Type of vehicle used."), vehicle_type_list,
           (unsigned) settings.livetrack24.vehicleType);
@@ -325,6 +332,22 @@ TrackingConfigPanel::Save(bool &_changed) noexcept
   _changed |= changed;
 
   return true;
+}
+
+unsigned int
+TrackingConfigPanel::FindClosestTrackingInterval(unsigned int value) noexcept
+{
+  unsigned int closest_value = 0;
+  int closest_diff = INT_MAX;
+  
+  for (const StaticEnumChoice *p = tracking_intervals; p->display_string != nullptr; ++p) {
+    int diff = abs(static_cast<int>(value) - static_cast<int>(p->id));
+    if (diff < closest_diff) {
+      closest_diff = diff;
+      closest_value = p->id;
+    }
+  }
+  return closest_value;
 }
 
 std::unique_ptr<Widget>


### PR DESCRIPTION



<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

Use the existing tracking intervals list for SkyLines also for LiveTrack24.
Currently LiveTrack24 allows tracking intervals between 5 seconds and 1 hour using 5 second increments.

Intent: Allow LiveTrack24 tracking intervals smaller than 5 seconds.

Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->

none


Caveats
--------

Users with an existing setting of `TrackingInterval` outside of the values specified in the `tracking_intervals` array (e.g. "1800") will have their tracking interval set to 1 second.