### PR TITLE
Basic support for Kobo Nia - WiFi and USB storage export.

### DIFF
--- a/kobo/rcS
+++ b/kobo/rcS
@@ -45,8 +45,12 @@ if [ -f /mnt/onboard/.kobo/Kobo.tgz -o -f /mnt/onboard/.kobo/KoboRoot.tgz \
     exec /etc/init.d/rcS
 fi
 
-# Figure out our platform.
+# Figure out our platform. Older devices do not have ntx_hwconfig
+# (https://github.com/koreader/koreader/issues/421#issuecomment-46861530),
+# so we default to generic "freescale" for those.
 PLATFORM=freescale
+# If we have "HW CONFIG" block in our image, we can use ntx_hwconfig
+# to get actual CPU architecture.
 if [ `dd if=/dev/mmcblk0 bs=512 skip=1024 count=1 | grep -c "HW CONFIG"` == 1 ]; then
 	CPU=`ntx_hwconfig -s -p /dev/mmcblk0 CPU`
 	PLATFORM=$CPU-ntx
@@ -69,15 +73,18 @@ fi
 /bin/mknod /dev/null c 1 3
 /bin/chmod 666 /dev/null
 
-# udev doesn't create all /dev/ entries on some platforms (e.g. Nia),
-# we preserve and re-create /dev entries on those like the original
-# start-up script.
+# Make sure our /dev/ backup is valid (has a non-zero size).
 [ "$(ls -s /etc/udev.tgz | awk '{print $1}')" == 0 ] && rm -rf /etc/udev.tgz
+# If we don't know our specific platform, we rely on udev to create
+# /dev/ entries. Otherwise we use the /dev tree backup if it
+# exist. This is required for platforms that don't appear to have
+# complete udev support and ship a device tree instead (such as Nia).
 if [ $PLATFORM == freescale ] || [ ! -e /etc/udev.tgz ]; then
 	/sbin/udevadm control --env=STARTUP=1
 	/sbin/udevadm trigger
 	/sbin/udevadm settle --timeout=2
 	/sbin/udevadm control --env=STARTUP=
+	# Create a /dev/ tree backup to restore next time around.
 	[ $PLATFORM != freescale ] && tar cpzf /etc/udev.tgz /dev &
 else
 	tar zxf /etc/udev.tgz -C /

--- a/kobo/rcS
+++ b/kobo/rcS
@@ -45,6 +45,13 @@ if [ -f /mnt/onboard/.kobo/Kobo.tgz -o -f /mnt/onboard/.kobo/KoboRoot.tgz \
     exec /etc/init.d/rcS
 fi
 
+# Figure out our platform.
+PLATFORM=freescale
+if [ `dd if=/dev/mmcblk0 bs=512 skip=1024 count=1 | grep -c "HW CONFIG"` == 1 ]; then
+	CPU=`ntx_hwconfig -s -p /dev/mmcblk0 CPU`
+	PLATFORM=$CPU-ntx
+fi
+
 # prepare file system
 
 /bin/mkdir -p /proc /dev /root /tmp /sys /var/lib /var/log /var/run
@@ -62,8 +69,19 @@ fi
 /bin/mknod /dev/null c 1 3
 /bin/chmod 666 /dev/null
 
-/sbin/udevd --daemon
-/sbin/udevadm trigger
+# udev doesn't create all /dev/ entries on some platforms (e.g. Nia),
+# we preserve and re-create /dev entries on those like the original
+# start-up script.
+[ "$(ls -s /etc/udev.tgz | awk '{print $1}')" == 0 ] && rm -rf /etc/udev.tgz
+if [ $PLATFORM == freescale ] || [ ! -e /etc/udev.tgz ]; then
+	/sbin/udevadm control --env=STARTUP=1
+	/sbin/udevadm trigger
+	/sbin/udevadm settle --timeout=2
+	/sbin/udevadm control --env=STARTUP=
+	[ $PLATFORM != freescale ] && tar cpzf /etc/udev.tgz /dev &
+else
+	tar zxf /etc/udev.tgz -C /
+fi
 
 /sbin/hwclock -s -u
 
@@ -93,7 +111,7 @@ if [ `dd if=/dev/mmcblk0 bs=8 count=1 skip=64` = "SN-N905B" ]; then
 fi
 
 # WORKAROUND: USB devices which require USB mode switching might not
-# suffesscully switched, if simple_modeswitch was called too early (before the
+# successfully switched, if simple_modeswitch was called too early (before the
 # USB device files were created). Call it again to make sure.
 /opt/xcsoar/bin/simple_usbmodeswitch
 

--- a/src/Kobo/Model.cpp
+++ b/src/Kobo/Model.cpp
@@ -64,6 +64,7 @@ static constexpr struct {
   { "SN-R13A5", KoboModel::GLO },
   { "SN-N437", KoboModel::GLO_HD },
   { "SN-RN437", KoboModel::GLO_HD },
+  { "SN-N306", KoboModel::NIA },
 };
 
 static KoboModel

--- a/src/Kobo/Model.hpp
+++ b/src/Kobo/Model.hpp
@@ -35,6 +35,7 @@ enum class KoboModel {
   AURA2,
   GLO,
   GLO_HD,
+  NIA,
 };
 
 gcc_const

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -144,6 +144,14 @@ KoboExportUSBStorage()
                     "file=/dev/mmcblk0p3", "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
+  case KoboModel::NIA:
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/configfs.ko");
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/libcomposite.ko");
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/usb_f_mass_storage.ko");
+    result = InsMod("/drivers/mx6ull-ntx/usb/gadget/g_file_storage.ko",
+                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    "product_id=Kobo");
+    break;
   }
   return result;
 #else
@@ -196,6 +204,11 @@ KoboWifiOn()
   case KoboModel::AURA2:
     InsMod("/drivers/mx6sl-ntx/wifi/sdio_wifi_pwr.ko");
     InsMod("/drivers/mx6sl-ntx/wifi/8189fs.ko");
+    break;
+
+  case KoboModel::NIA:
+    InsMod("/drivers/mx6ull-ntx/wifi/sdio_wifi_pwr.ko");
+    InsMod("/drivers/mx6ull-ntx/wifi/8189fs.ko");
     break;
   }
 

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -188,6 +188,7 @@ TopCanvas::Create(PixelSize new_size,
   case KoboModel::TOUCH:
   case KoboModel::GLO:
   case KoboModel::AURA:
+  case KoboModel::NIA:
     frame_sync = false;
     break;
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->

Updated boot script to work on Nia (without this XCSoar 7 bricks the device and requires a full factory reset), and required kernel modules for WiFi and USB Storage export to work.

Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
