### PR TITLE
Basic Kobo Nia support - WiFi and USB Storage export.

### DIFF
--- a/src/Kobo/Model.cpp
+++ b/src/Kobo/Model.cpp
@@ -64,6 +64,7 @@ static constexpr struct {
   { "SN-R13A5", KoboModel::GLO },
   { "SN-N437", KoboModel::GLO_HD },
   { "SN-RN437", KoboModel::GLO_HD },
+  { "SN-N306", KoboModel::NIA },
 };
 
 static KoboModel

--- a/src/Kobo/Model.hpp
+++ b/src/Kobo/Model.hpp
@@ -35,6 +35,7 @@ enum class KoboModel {
   AURA2,
   GLO,
   GLO_HD,
+  NIA,
 };
 
 gcc_const

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -144,6 +144,14 @@ KoboExportUSBStorage()
                     "file=/dev/mmcblk0p3", "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
+  case KoboModel::NIA:
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/configfs.ko");
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/libcomposite.ko");
+    InsMod("/drivers/mx6ull-ntx/usb/gadget/usb_f_mass_storage.ko");
+    result = InsMod("/drivers/mx6ull-ntx/usb/gadget/g_file_storage.ko",
+                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    "product_id=Kobo");
+    break;
   }
   return result;
 #else
@@ -196,6 +204,11 @@ KoboWifiOn()
   case KoboModel::AURA2:
     InsMod("/drivers/mx6sl-ntx/wifi/sdio_wifi_pwr.ko");
     InsMod("/drivers/mx6sl-ntx/wifi/8189fs.ko");
+    break;
+
+  case KoboModel::NIA:
+    InsMod("/drivers/mx6ull-ntx/wifi/sdio_wifi_pwr.ko");
+    InsMod("/drivers/mx6ull-ntx/wifi/8189fs.ko");
     break;
   }
 

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -188,6 +188,7 @@ TopCanvas::Create(PixelSize new_size,
   case KoboModel::TOUCH:
   case KoboModel::GLO:
   case KoboModel::AURA:
+  case KoboModel::NIA:
     frame_sync = false;
     break;
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

Adds Kobo Nia support for WiFi and USB Storage export features. Note that XCSoar 7 does not currently boot on the Kobo Nia due to missing /dev/ entries, which needs to be addressed to actually support the Nia.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
