### PR TITLE
Pilot Event (PEV) start

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -425,11 +425,21 @@ location=6
 
 mode=Nav2
 type=key
+data=8
+event=Mode default
+event=StatusMessage Pilot event announced
+event=Logger note PEV
+event=PilotEvent
+label=Pilot\nEvent
+location=7
+
+mode=Nav2
+type=key
 data=9
 event=Setup Target
 event=Mode default
 label=Target$(CheckTask)$(CheckTaskResumed)
-location=7
+location=8
 
 # -------------
 # mode=Display1

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 7.9 - not yet released
 * settings
   - allow LiveTrack24 tracking intervals smaller than 5 seconds
+* user interface
+  - support for Pilot Event (PEV) start procedure
 
 Version 7.8 - 2021/06/02
 * don't delete old IGC files automatically

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -171,11 +171,12 @@ see
 \bmenus{Nav 2/2}
  & \bmenut{Task}{Abort}
  & \bmenut{Mark}{Drop}
+ & \bmenut{Pilot}{Event}
  & \bmenus{Target}
- & {}
  & {} \\
 see
  & \ref{sec:taskabort}
+ & \ref{sec:markers}
  & \ref{sec:markers}
  & \ref{sec:waypointdetails}
 \end{tabularx}}

--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -409,6 +409,33 @@ simple way of showing all thermals encountered.
 Markers are not preserved after XCSoar is exited, however the location
 of all marks are appended to the file \verb|xcsoar-marks.txt|.
 
+\section{Pilot Event}\label{sec:pilotevent}
+
+A Pilot Event (PEV) system allows pilots to mark particular times during a
+flight, such when inside a Turn Point Observation Zone (TP OZ). Also, when
+configured, it allows to initiate a special \emph{Pilot Event} task start
+protocol\footnote{PEV start procedure may be used in competitions to reduce
+mass starts, gaggles and following.}.
+
+\menulabel{\bmenug{Nav 2}\blink\bmenut{Pilot}{Event}}
+
+When pressed, the task start window will be automatically set according to
+configuration defined in Task Rules (See \ref{sec:task-type-racing}): start
+window will open after \emph{PEV start wait time} \config{taskrules} minutes
+and will be open for \emph{PEV start window} minutes.  Also, \emph
+{Pilot Event} will be announced to connected devices, allowing loggers to
+register it without pilot pressing the physical button on the logger device
+itself. This might be useful when logger is located outside of pilot reach
+(e.g. behind the panel).
+
+In order to start a task when \emph{Pilot Event Start} is used, press the \emph
+{Pilot Event} button, wait for \emph{PEV start wait time} and then cross the
+start line within \emph{PEV start window} minutes.
+
+\tip It may be useful to have \emph{Start open} and/or \emph{Start reach}
+ infoboxes visible to effectively use the \emph{PEV Start} procedure.
+
+
 \section{Thermals}
 
 While climbing in thermals, a marker is automatically generated showing the

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -350,7 +350,7 @@ to become thoroughly familiar with each task type by referring to contest rules
 or FAI rules, which are available at \url{http://www.fai.org}. 
 
 
-\subsection*{Racing}
+\subsection*{Racing}\label{sec:task-type-racing}
 (also known as an ``assigned task'').  The racing task involves flight
 around each specified turnpoint in the specified order.  Selecting the racing task 
 type allows the pilot to enter the following parameters
@@ -374,6 +374,17 @@ type allows the pilot to enter the following parameters
     to~0 for no limit.
   \item [Finish height ref.] This specifies whether the minimum finish height 
     is referenced to ground level of the finish point (``AGL'') or Mean Sea Level (``MSL'')
+
+  \item [PEV start wait time] This specifies an interval in minutes between
+   pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button is
+   pressed and start window opens. If set to 0, the start will open
+   immediately after \emph{Pilot Event} button is pressed.
+
+  \item [PEV start window] This specifies an interval in minutes during which
+   the start window remains open when \emph{Pilot Event} (see \ref
+   {sec:pilotevent}) start procedure is used. If set to 0, the start window,
+   once opened, remains open forever.
+
   \end{description}
 
 \subsection*{Assigned area task (AAT) and Modified area task (MAT)}

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -563,6 +563,14 @@ rules. \label{conf:taskrules}
   (AGL or MSL) while finishing the task.  Set to 0 for no limit.
 \item[Finish height ref.*]  Reference used for finish min.\ height rule,
   correspondingly to the start rule height reference.
+\item [PEV start wait time*] The default interval in minutes between
+ pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button is
+ pressed and start window opens. If set to 0, the start will open
+ immediately after \emph{Pilot Event} button is pressed.
+\item [PEV start window*] The default interval in minutes during which
+ the start window remains open when \emph{Pilot Event} (see \ref
+ {sec:pilotevent}) start procedure is used. If set to 0, the start window, once
+ opened, remains open forever.
 \item[Contest]  Determines the rules used to optimise for the selected contest 
   paths. \\
   {\bf OLC FAI}: Conforms to FAI triangle rule. Three turns and common start and 

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -921,6 +921,22 @@ DeviceDescriptor::PutVolume(unsigned volume, OperationEnvironment &env)
 }
 
 bool
+DeviceDescriptor::PutPilotEvent(OperationEnvironment &env)
+{
+  assert(InMainThread());
+
+  if (device == nullptr || !config.sync_to_device)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+
+  ScopeReturnDevice restore(*this, env);
+  return device->PutPilotEvent(env);
+}
+
+bool
 DeviceDescriptor::PutActiveFrequency(RadioFrequency frequency,
                                      const TCHAR *name,
                                      OperationEnvironment &env)

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -495,6 +495,7 @@ public:
   bool PutBallast(double fraction, double overload,
                   OperationEnvironment &env);
   bool PutVolume(unsigned volume, OperationEnvironment &env);
+  bool PutPilotEvent(OperationEnvironment &env);
   bool PutActiveFrequency(RadioFrequency frequency,
                           const TCHAR *name,
                           OperationEnvironment &env);

--- a/src/Device/Driver.cpp
+++ b/src/Device/Driver.cpp
@@ -76,6 +76,13 @@ AbstractDevice::PutVolume(unsigned volume, OperationEnvironment &env)
   return true;
 }
 
+
+bool
+AbstractDevice::PutPilotEvent(OperationEnvironment &env)
+{
+  return true;
+}
+
 bool
 AbstractDevice::PutActiveFrequency(RadioFrequency frequency,
                                    const TCHAR *name,

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -120,6 +120,13 @@ public:
   virtual bool PutVolume(unsigned volume, OperationEnvironment &env) = 0;
 
   /**
+   * Declare pilot event
+   *
+   * @return true on success
+   */
+  virtual bool PutPilotEvent(OperationEnvironment &env) = 0;
+
+  /**
    * Set a new radio frequency.
    *
    * @param frequency the new frequency
@@ -244,6 +251,7 @@ public:
   bool PutQNH(const AtmosphericPressure &pres,
               OperationEnvironment &env) override;
   bool PutVolume(unsigned volume, OperationEnvironment &env) override;
+  bool PutPilotEvent(OperationEnvironment &env) override;
   bool PutActiveFrequency(RadioFrequency frequency,
                           const TCHAR *name,
                           OperationEnvironment &env) override;

--- a/src/Device/Driver/FLARM/Device.cpp
+++ b/src/Device/Driver/FLARM/Device.cpp
@@ -38,6 +38,12 @@ FlarmDevice::LinkTimeout()
 }
 
 bool
+FlarmDevice::PutPilotEvent(OperationEnvironment &env)
+{
+  return Send("PFLAI,PILOTEVENT*", env);
+}
+
+bool
 FlarmDevice::GetStealthMode(bool &enabled, OperationEnvironment &env)
 {
   char buffer[2];

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -105,6 +105,7 @@ public:
 
   bool Declare(const Declaration &declaration, const Waypoint *home,
                OperationEnvironment &env) override;
+  bool PutPilotEvent(OperationEnvironment &env) override;
 
   bool GetPilot(TCHAR *buffer, size_t length, OperationEnvironment &env);
   bool SetPilot(const TCHAR *pilot_name, OperationEnvironment &env);

--- a/src/Device/MultipleDevices.cpp
+++ b/src/Device/MultipleDevices.cpp
@@ -89,6 +89,13 @@ MultipleDevices::PutVolume(unsigned volume, OperationEnvironment &env)
 }
 
 void
+MultipleDevices::PutPilotEvent(OperationEnvironment &env)
+{
+  for (DeviceDescriptor *i : devices)
+    i->PutPilotEvent(env);
+}
+
+void
 MultipleDevices::PutActiveFrequency(RadioFrequency frequency,
                                     const TCHAR *name,
                                     OperationEnvironment &env)

--- a/src/Device/MultipleDevices.hpp
+++ b/src/Device/MultipleDevices.hpp
@@ -86,6 +86,7 @@ public:
   void PutBugs(double bugs, OperationEnvironment &env);
   void PutBallast(double fraction, double overload, OperationEnvironment &env);
   void PutVolume(unsigned volume, OperationEnvironment &env);
+  void PutPilotEvent(OperationEnvironment &env);
   void PutActiveFrequency(RadioFrequency frequency, const TCHAR *name,
                           OperationEnvironment &env);
   void PutStandbyFrequency(RadioFrequency frequency, const TCHAR *name,

--- a/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
@@ -39,6 +39,9 @@ enum ControlIndex {
   spacer_2,
   FinishMinHeight,
   FinishHeightRef,
+  spacer_3,
+  PEVStartWaitTime,
+  PEVStartWindow,
 };
 
 class TaskRulesConfigPanel final : public RowFormWidget {
@@ -116,6 +119,24 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
           altitude_reference_list,
           (unsigned)task_behaviour.ordered_defaults.finish_constraints.min_height_ref);
   SetExpertRow(FinishHeightRef);
+
+  AddSpacer();
+  SetExpertRow(spacer_3);
+
+  AddTime(_("PEV start wait time"),
+          _("Wait time in minutes after Pilot Event and before start gate opens. "
+            "0 means start opens immediately."),
+          0, 30*60, 60,
+          task_behaviour.ordered_defaults.start_constraints.pev_start_wait_time);
+  SetExpertRow(PEVStartWaitTime);
+
+  AddTime(_("PEV start window"),
+          _("Number of minutes start remains open after Pilot Event and PEV wait time."
+            "0 means start will never close after it opens."),
+          0, 30*60, 60,
+          task_behaviour.ordered_defaults.start_constraints.pev_start_window);
+  SetExpertRow(PEVStartWindow);
+
 }
 
 
@@ -151,6 +172,14 @@ TaskRulesConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValueEnum(FinishHeightRef, ProfileKeys::FinishHeightRef,
                            otb.finish_constraints.min_height_ref);
+
+  changed |= SaveValue(PEVStartWaitTime,
+                       ProfileKeys::PEVStartWaitTime,
+                       otb.start_constraints.pev_start_wait_time);
+
+  changed |= SaveValue(PEVStartWindow,
+                       ProfileKeys::PEVStartWindow,
+                       otb.start_constraints.pev_start_window);
 
   _changed |= changed;
 

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -43,6 +43,8 @@ enum Controls {
   START_HEIGHT_REF,
   FINISH_MIN_HEIGHT,
   FINISH_HEIGHT_REF,
+  PEV_START_WAIT_TIME,
+  PEV_START_WINDOW,
   FAI_FINISH_HEIGHT,
 };
 
@@ -94,6 +96,13 @@ TaskPropertiesPanel::RefreshView()
   LoadValue(FAI_FINISH_HEIGHT, fai_start_finish);
 
   LoadValueEnum(TASK_TYPE, ftype);
+
+  SetRowVisible(PEV_START_WAIT_TIME, !fai_start_finish);
+  LoadValueTime(PEV_START_WAIT_TIME,
+                p.start_constraints.pev_start_wait_time);
+  SetRowVisible(PEV_START_WINDOW, !fai_start_finish);
+  LoadValueTime(PEV_START_WINDOW,
+                p.start_constraints.pev_start_window);
 
   dialog.InvalidateTaskView();
 
@@ -153,6 +162,11 @@ TaskPropertiesPanel::ReadValues()
 
   changed |= SaveValueEnum(FINISH_HEIGHT_REF,
                            p.finish_constraints.min_height_ref);
+
+  changed |= SaveValue(PEV_START_WAIT_TIME,
+                       p.start_constraints.pev_start_wait_time);
+  changed |= SaveValue(PEV_START_WINDOW,
+                       p.start_constraints.pev_start_window);
 
   if (changed)
     ordered_task->SetOrderedTaskSettings(p);
@@ -258,6 +272,15 @@ TaskPropertiesPanel::Prepare(ContainerWindow &parent,
   AddEnum(_("Finish height ref."),
           _("Reference used for finish min height rule."),
           altitude_reference_list);
+
+  AddTime(_("PEV start wait time"),
+          _("Wait time in minutes after Pilot Event and before start gate opens. "
+            "0 means start opens immediately."),
+          0, 30*60, 60, 0);
+  AddTime(_("PEV start window"),
+          _("Number of minutes start remains open after Pilot Event and PEV wait time."
+            "0 means start will never close after it opens."),
+          0, 30*60, 60, 0);
 
   AddBoolean(_("FAI start / finish rules"),
              _("If enabled, has no max start height or max start speed and requires the minimum height above ground for finish to be greater than 1000m below the start height."),

--- a/src/Engine/Task/Ordered/StartConstraints.cpp
+++ b/src/Engine/Task/Ordered/StartConstraints.cpp
@@ -33,6 +33,8 @@ StartConstraints::SetDefaults()
   max_height_ref = AltitudeReference::AGL;
   require_arm = false;
   fai_finish = false;
+  pev_start_wait_time = 0;
+  pev_start_window = 0;
 }
 
 bool

--- a/src/Engine/Task/Ordered/StartConstraints.hpp
+++ b/src/Engine/Task/Ordered/StartConstraints.hpp
@@ -57,6 +57,17 @@ struct StartConstraints {
    */
   bool fai_finish;
 
+  /**
+   * Wait time in minutes after Pilot Event (PEV) and start gate open time.
+   */
+  unsigned pev_start_wait_time;
+
+  /**
+   * Time in minutes start gate remains open after Pilot Event and PEV Wait
+   * Time.
+   */
+  unsigned pev_start_window;
+
   void SetDefaults();
 
   /**

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -155,6 +155,7 @@ void eventLogger(const TCHAR *misc);
 void eventMacCready(const TCHAR *misc);
 void eventMainMenu(const TCHAR *misc);
 void eventMarkLocation(const TCHAR *misc);
+void eventPilotEvent(const TCHAR *misc);
 void eventMode(const TCHAR *misc);
 void eventNearestAirspaceDetails(const TCHAR *misc);
 void eventNearestWaypointDetails(const TCHAR *misc);

--- a/src/Logger/Logger.cpp
+++ b/src/Logger/Logger.cpp
@@ -65,6 +65,12 @@ Logger::LogFinishEvent(const NMEAInfo &gps_info)
   LogEvent(gps_info, "FIN");
 }
 
+void
+Logger::LogPilotEvent(const NMEAInfo &gps_info)
+{
+  LogEvent(gps_info, "PEV");
+}
+
 bool
 Logger::IsLoggerActive() const
 {

--- a/src/Logger/Logger.hpp
+++ b/src/Logger/Logger.hpp
@@ -44,6 +44,7 @@ public:
   void LogPoint(const NMEAInfo &gps_info);
   void LogStartEvent(const NMEAInfo &gps_info);
   void LogFinishEvent(const NMEAInfo &gps_info);
+  void LogPilotEvent(const NMEAInfo &gps_info);
 
   gcc_pure
   bool IsLoggerActive() const;

--- a/src/Profile/ProfileKeys.cpp
+++ b/src/Profile/ProfileKeys.cpp
@@ -172,6 +172,8 @@ const char FinishRadius[] = "FinishRadius";
 const char TaskType[] = "TaskType";
 const char AATMinTime[] = "AATMinTime";
 const char AATTimeMargin[] = "AATTimeMargin";
+const char PEVStartWaitTime[] = "PEVStartWaitTime";
+const char PEVStartWindow[] = "PEVStartWindow";
 
 const char EnableNavBaroAltitude[] = "EnableNavBaroAltitude";
 

--- a/src/Profile/ProfileKeys.hpp
+++ b/src/Profile/ProfileKeys.hpp
@@ -167,6 +167,8 @@ extern const char FinishRadius[];
 extern const char TaskType[];
 extern const char AATMinTime[];
 extern const char AATTimeMargin[];
+extern const char PEVStartWaitTime[];
+extern const char PEVStartWindow[];
 
 extern const char EnableNavBaroAltitude[];
 

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -66,6 +66,8 @@ Profile::Load(const ProfileMap &map, StartConstraints &constraints)
   map.GetEnum(ProfileKeys::StartHeightRef, constraints.max_height_ref);
   map.Get(ProfileKeys::StartMaxHeight, constraints.max_height);
   map.Get(ProfileKeys::StartMaxSpeed, constraints.max_speed);
+  map.Get(ProfileKeys::PEVStartWaitTime, constraints.pev_start_wait_time);
+  map.Get(ProfileKeys::PEVStartWindow, constraints.pev_start_window);
 }
 
 void

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -269,6 +269,11 @@ Deserialise(OrderedTaskSettings &data, const ConstDataNode &node)
     GetHeightRef(node, _T("finish_min_height_ref"));
   node.GetAttribute(_T("fai_finish"), data.finish_constraints.fai_finish);
   data.start_constraints.fai_finish = data.finish_constraints.fai_finish;
+  node.GetAttribute(_T("pev_start_wait_time"),
+                    data.start_constraints.pev_start_wait_time);
+  node.GetAttribute(_T("pev_start_window"),
+                    data.start_constraints.pev_start_window);
+
 }
 
 static TaskFactoryType

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -48,6 +48,15 @@ ProtectedTaskManager::SetGlidePolar(const GlidePolar &glide_polar)
   lease->SetGlidePolar(glide_polar);
 }
 
+void
+ProtectedTaskManager::SetStartTimeSpan(const RoughTimeSpan &open_time_span)
+{
+  ExclusiveLease lease(*this);
+  OrderedTaskSettings otb = lease->GetOrderedTask().GetOrderedTaskSettings();
+  otb.start_constraints.open_time_span = open_time_span;
+  lease->SetOrderedTaskSettings(otb);
+}
+
 const OrderedTaskSettings
 ProtectedTaskManager::GetOrderedTaskSettings() const
 {

--- a/src/Task/ProtectedTaskManager.hpp
+++ b/src/Task/ProtectedTaskManager.hpp
@@ -24,6 +24,7 @@
 #define XCSOAR_PROTECTED_TASK_MANAGER_HPP
 
 #include "thread/Guard.hpp"
+#include "time/RoughTime.hpp"
 #include "Engine/Task/Unordered/AbortIntersectionTest.hpp"
 #include "Engine/Waypoint/Ptr.hpp"
 
@@ -71,6 +72,8 @@ public:
 
   [[gnu::pure]]
   const OrderedTaskSettings GetOrderedTaskSettings() const;
+
+  void SetStartTimeSpan(const RoughTimeSpan &open_time_span);
 
   [[gnu::pure]]
   WaypointPtr GetActiveWaypoint() const;

--- a/src/Task/Serialiser.cpp
+++ b/src/Task/Serialiser.cpp
@@ -274,6 +274,10 @@ Serialise(WritableDataNode &node, const OrderedTaskSettings &data)
   node.SetAttribute(_T("finish_min_height_ref"),
                     GetHeightRef(data.finish_constraints.min_height_ref));
   node.SetAttribute(_T("fai_finish"), data.finish_constraints.fai_finish);
+  node.SetAttribute(_T("pev_start_wait_time"),
+                    data.start_constraints.pev_start_wait_time);
+  node.SetAttribute(_T("pev_start_window"),
+                    data.start_constraints.pev_start_window);
 }
 
 void


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

This adds support for Pilot Event start procedure, recently introduced for use in gliding competitions. See  [rules for world and continental gliding championships](https://www.fai.org/sites/default/files/sc3a_2020a.pdf), page 28, 29 for more details.

This PR introduces a new button, available under Nav -> Nav -> Pilot Event. When pressed, a time window for a valid start is configured according to two new user-configurable settings for the task. This feature takes advantage of existing "start open time" and "start close time" parameters as well as existing "Start open" and "Start reach" infoboxes to aid the pilot.

Expected mode of operation: when "Pilot Event" start is used in a competition day, pilot will set "PEV start wait time" and "PEV start window" task properties according to values, announced during the briefing. Later, in the air, in order to make a valid start, the pilot will press the "Pilot Event" button in XCSoar (same way they would press the button on the physical logger hardware), wait the specified amount of time and then cross the start line while start window is open. Once "Pilot Event" is pressed, "Start Open" infobox will start the countdown to the new start open time.

The pilot event is announced on connected devices (by the driver-specific NMEA message) - this is useful in case the logger device is physically unreachable by the pilot (e.g. behind the instrument panel).

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->

This PR is ready for review, but not ready to merge yet. I'd like to make a test flight in order to confirm the integration with FLARM is working as expected.

Closes #646.
