### PR TITLE
kobo-build: add missing includes for gcc

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -60,7 +60,9 @@ apt-get install ${APTOPTS[*]} libinput-dev libgbm-dev
 echo
 
 echo Installing dependencies for ARM Linux targets...
-apt-get install ${APTOPTS[*]} g++-arm-linux-gnueabihf
+apt-get install ${APTOPTS[*]} g++-arm-linux-gnueabihf \
+  libmpc-dev \
+  gmpc-dev
 echo
 
 echo Installing PC/WIN64 dependencies...


### PR DESCRIPTION
i was able to compile the kobo target with these dependencies. 