### PR TITLE
Update install-debian-packages.sh

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -17,7 +17,7 @@ apt-get install ${APTOPTS[*]} make \
   git quilt zip \
   m4 automake wget \
   ttf-bitstream-vera fakeroot \
-  pkg-config cmake ninja-build
+  pkg-config cmake ninja-build ccache
 echo
 
 echo Installing Manual dependencies...


### PR DESCRIPTION
To avoid compile problems as in the last comments of https://github.com/XCSoar/XCSoar/issues/581


Brief summary of the changes
----------------------------

the ccache program is needed to compile. The change was tested on i386 and x64 systems based on standard debian buster distribution


Related issues and discussions
------------------------------

see https://github.com/XCSoar/XCSoar/issues/581

