### PR TITLE
Fix pilot event (PEV) sentence for PowerFLARM

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 Version 7.12 - not yet released
 * devices
   - send Pilot Event (PEV) to LXNAV S10x/S8x devices (requires firmware 8.01 or newer)
+  - correct Pilot Event (PEV) message for PowerFLARM devices
 
 Version 7.11 - 2021/07/30
 * fix crash bug in pc_met viewer

--- a/src/Device/Driver/FLARM/Device.cpp
+++ b/src/Device/Driver/FLARM/Device.cpp
@@ -40,7 +40,7 @@ FlarmDevice::LinkTimeout()
 bool
 FlarmDevice::PutPilotEvent(OperationEnvironment &env)
 {
-  return Send("PFLAI,PILOTEVENT*", env);
+  return Send("PFLAI,PILOTEVENT", env);
 }
 
 bool


### PR DESCRIPTION
Pilot Event NMEA sentence for PowerFLARM devices was incorrect in initial implementation. Contrary to FLARM documentation, the trailing asterisk symbol is not needed (the sentence is rejected with the asterisk as invalid).

This was positively tested by PowerFLARM owner.
