### PR TITLE
Use task defaults when height ref is missing in task file

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,7 @@
 Version 7.13 - not yet released
+* task management
+  - Use task defaults for start and finish height ref (MSL or AGL) when loading
+    tasks from soarscore.com
 
 Version 7.12 - 2021/08/13
 * calculations

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -239,15 +239,20 @@ DeserialiseTaskpoint(AbstractTaskFactory &fact, const ConstDataNode &node,
   fact.Append(*pt, false);
 }
 
-[[gnu::pure]]
-static AltitudeReference
-GetHeightRef(const ConstDataNode &node, const TCHAR *nodename)
+static bool
+GetHeightRef(const ConstDataNode &node, const TCHAR *nodename,
+             AltitudeReference &value)
 {
   const TCHAR *type = node.GetAttribute(nodename);
-  if (type != nullptr && StringIsEqual(type, _T("MSL")))
-    return AltitudeReference::MSL;
-
-  return AltitudeReference::AGL;
+  if (type == nullptr) {
+    return false;
+  }
+  if (StringIsEqual(type, _T("MSL"))) {
+    value = AltitudeReference::MSL;
+  } else {
+    value = AltitudeReference::AGL;
+  }
+  return true;
 }
 
 static void
@@ -258,15 +263,16 @@ Deserialise(OrderedTaskSettings &data, const ConstDataNode &node)
                     data.start_constraints.require_arm);
   node.GetAttribute(_T("start_max_speed"), data.start_constraints.max_speed);
   node.GetAttribute(_T("start_max_height"), data.start_constraints.max_height);
-  data.start_constraints.max_height_ref =
-    GetHeightRef(node, _T("start_max_height_ref"));
+  GetHeightRef(node, _T("start_max_height_ref"),
+               data.start_constraints.max_height_ref);
   data.start_constraints.open_time_span =
     node.GetAttributeRoughTimeSpan(_T("start_open_time"),
                                    _T("start_close_time"));
   node.GetAttribute(_T("finish_min_height"),
                     data.finish_constraints.min_height);
-  data.finish_constraints.min_height_ref =
-    GetHeightRef(node, _T("finish_min_height_ref"));
+
+  GetHeightRef(node, _T("finish_min_height_ref"),
+               data.finish_constraints.min_height_ref);
   node.GetAttribute(_T("fai_finish"), data.finish_constraints.fai_finish);
   data.start_constraints.fai_finish = data.finish_constraints.fai_finish;
   node.GetAttribute(_T("pev_start_wait_time"),


### PR DESCRIPTION
In task files, generated by external tools some task attributes might be missing in the task xml file. When loading such tasks we want to keep task default values, set in the XCSoar system settings.

For example, tasks, gnerated by soarscore.com are missing start and finish height settings. This is on purpose, because this information is not available on soaringspot.com, which is used as a source for the task generation. Instead of putting some arbitrary values in the generated task xml file, attributes, such as `finish_min_height` or `finish_min_height_ref` are simply omitted. When XCSoar loads such a task file, it correctly sets `FinishConstraints.min_height` to the value from the task defaults, however `min_height_ref` gets always reset to "AGL". When competition rules specify min. finish height as MSL, user has to manually adjust this task property every time the task is loaded.

This fixes this issue by making `GetHeightRef()` behave more like `ConstDataNode.GetAttribute()`: when attribute is not present in the XML node, value is not modified.
