### PR TITLE
EGL Flip error, DRI/KMS and Lima support for Cubieboardupport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,14 @@
 #
 #   ENABLE_SDL  If set to "y", the UI is drawn with libSDL.
 #
+#   ENABLE_MESA_KMS If set to "y", the programs switches graphics mode on.
+#               Use this option when the program runs on a text-mode system.
+#               without graphics and window system like X11 or Wayland.
+#               Default for Rasperry PI 4, optional for Cubieboard.
+#
 #   OPENGL      "y" means render with OpenGL.
 #
-#   GLES        "y" means render with OpenGL/ES.
+#   GLES2        "y" means render with OpenGL/ES 2.0.
 #
 #   GREYSCALE   "y" means render 8-bit greyscale internally
 #

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,14 @@
 #
 #   ENABLE_SDL  If set to "y", the UI is drawn with libSDL.
 #
-#   ENABLE_MESA_KMS If set to "y", the programs switches graphics mode on.
-#               Use this option when the program runs on a text-mode system.
+#   ENABLE_MESA_KMS If set to "y", the program uses KMS to switch to graphics mode.
+#               Use this option when the program runs on a text-mode system
 #               without graphics and window system like X11 or Wayland.
 #               Default for Rasperry PI 4, optional for Cubieboard.
 #
 #   OPENGL      "y" means render with OpenGL.
 #
-#   GLES2        "y" means render with OpenGL/ES 2.0.
+#   GLES2       "y" means render with OpenGL/ES 2.0.
 #
 #   GREYSCALE   "y" means render 8-bit greyscale internally
 #

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,12 @@
 Version 7.17 - not yet released
 * Android
   - fix startup crash bug
+* Linux text mode console
+  - fix program termination for some DRI drivers, e.g. VMWare
+    in full-screen mode without Window manager.
+* Cubieboard
+  - Mali: Support for old Linux-Sunxi EGL headers, and new Bootlin EGL headers
+  - Support for KMS/DRI and Lima instead of closed source Mali blob.
 
 Version 7.16 - 2021/08/27
 * user interface

--- a/build/egl.mk
+++ b/build/egl.mk
@@ -67,6 +67,10 @@ USE_CONSOLE = y
 else ifeq ($(TARGET_HAS_MALI),y)
 EGL_FEATURE_CPPFLAGS += -DHAVE_MALI
 USE_CONSOLE = y
+# There are two different native window definitions in the ARM headers
+ifneq ($(shell test -f $(CUBIE)/usr/include/EGL/fbdev_window.h && echo y),y)
+EGL_FEATURE_CPPFLAGS += -DHAVE_MALI_NATIVE_WINDOW
+endif
 else ifeq ($(ENABLE_MESA_KMS),y)
 $(eval $(call pkg-config-library,DRM,libdrm))
 $(eval $(call pkg-config-library,GBM,gbm))

--- a/build/pkgconfig.mk
+++ b/build/pkgconfig.mk
@@ -20,7 +20,7 @@ ifeq ($(HOST_IS_PI)$(TARGET_IS_PI),ny)
   PKG_CONFIG := PKG_CONFIG_LIBDIR=$(PI)/usr/lib/arm-linux-gnueabihf/pkgconfig $(PKG_CONFIG) --define-variable=prefix=$(PI)/usr
 endif
 
-ifeq ($(HOST_IS_ARM)$(TARGET_HAS_MALI),ny)
+ifeq ($(HOST_IS_ARM)$(TARGET_IS_CUBIE),ny)
   PKG_CONFIG := PKG_CONFIG_LIBDIR=$(CUBIE)/usr/lib/arm-linux-gnueabihf/pkgconfig $(PKG_CONFIG) --define-variable=prefix=$(CUBIE)/usr
 endif
 

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -201,7 +201,7 @@ ifeq ($(TARGET),CUBIE)
   override TARGET = NEON
   CUBIE ?= /opt/cubie/root
   TARGET_IS_CUBIE=y
-  # OSS Lima driver is available and usable with XCSoar
+  # Open-source Lima driver is available and usable with XCSoar
   # in current mainline kernels, 
   # and in MESA included in recent distributions
   ifeq ($(ENABLE_MESA_KMS),y)

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -50,6 +50,7 @@ TARGET_IS_PI4 := n
 TARGET_IS_PI32 := n
 TARGET_IS_PI64 := n
 TARGET_IS_KOBO := n
+TARGET_IS_CUBIE := n
 HAVE_POSIX := n
 HAVE_WIN32 := y
 HAVE_MSVCRT := y
@@ -199,7 +200,16 @@ ifeq ($(TARGET),CUBIE)
   # cross-crompiling for Cubieboard
   override TARGET = NEON
   CUBIE ?= /opt/cubie/root
-  TARGET_HAS_MALI = y
+  TARGET_IS_CUBIE=y
+  # OSS Lima driver is available and usable with XCSoar
+  # in current mainline kernels, 
+  # and in MESA included in recent distributions
+  ifeq ($(ENABLE_MESA_KMS),y)
+    OPENGL = y
+    GLES2 = y
+  else
+    TARGET_HAS_MALI = y
+  endif
 endif
 
 ifeq ($(TARGET),KOBO)
@@ -441,7 +451,7 @@ ifeq ($(TARGET_IS_PI),y)
   endif
 endif
 
-ifeq ($(HOST_IS_ARM)$(TARGET_HAS_MALI),ny)
+ifeq ($(HOST_IS_ARM)$(TARGET_IS_CUBIE),ny)
   # cross-crompiling for Cubieboard
   TARGET_CPPFLAGS += --sysroot=$(CUBIE) -isystem $(CUBIE)/usr/include/arm-linux-gnueabihf
   TARGET_CPPFLAGS += -isystem $(CUBIE)/usr/local/stow/sunxi-mali/include
@@ -547,9 +557,9 @@ ifeq ($(HOST_IS_PI)$(TARGET_IS_PI),ny)
   TARGET_LDFLAGS += --sysroot=$(PI) -L$(PI)/usr/lib/arm-linux-gnueabihf
 endif
 
-ifeq ($(HOST_IS_ARM)$(TARGET_HAS_MALI),ny)
+ifeq ($(HOST_IS_ARM)$(TARGET_IS_CUBIE),ny)
   # cross-crompiling for Cubieboard
-  TARGET_LDFLAGS += --sysroot=$(CUBIE)
+  TARGET_LDFLAGS += -L/usr/arm-linux-gnueabihf/lib --sysroot=$(CUBIE)
   TARGET_LDFLAGS += -L$(CUBIE)/lib/arm-linux-gnueabihf
   TARGET_LDFLAGS += -L$(CUBIE)/usr/lib/arm-linux-gnueabihf
   TARGET_LDFLAGS += -L$(CUBIE)/usr/local/stow/sunxi-mali/lib

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -42,6 +42,14 @@ Copyright_License {
 #ifdef USE_EGL
 #include "ui/egl/System.hpp"
 
+#ifdef HAVE_MALI_NATIVE_WINDOW
+// The old LINUX-SUNXI EGL headers define struct mali_native_window.
+// The new headers for mainline kernels from Bootlin typedef fbdev_window.
+// The struct content is identical.
+// typedef fbdev_window from struct mali_native_window for the old headers.
+typedef struct mali_native_window fbdev_window;
+#endif
+
 #ifdef MESA_KMS
 #include <drm.h>
 #include <xf86drm.h>
@@ -102,7 +110,7 @@ class TopCanvas
   DISPMANX_ELEMENT_HANDLE_T vc_element;
   EGL_DISPMANX_WINDOW_T vc_window;
 #elif defined(HAVE_MALI)
-  struct mali_native_window mali_native_window;
+  fbdev_window mali_native_window;
 #elif defined(MESA_KMS)
   struct gbm_device *native_display;
   struct gbm_surface *native_window;

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -127,7 +127,7 @@ TopCanvas::Create(PixelSize new_size,
   const EGLNativeDisplayType native_display = EGL_DEFAULT_DISPLAY;
   mali_native_window.width = new_size.width;
   mali_native_window.height = new_size.height;
-  struct mali_native_window *native_window = &mali_native_window;
+  fbdev_window *native_window = &mali_native_window;
 #elif defined(MESA_KMS)
   current_bo = nullptr;
   connector = nullptr;

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -395,26 +395,26 @@ TopCanvas::Flip()
     saved_crtc = drmModeGetCrtc(dri_fd, encoder->crtc_id);
     drmModeSetCrtc(dri_fd, encoder->crtc_id, fb->fb_id, 0, 0,
                    &connector->connector_id, 1, &mode);
-  }
+  } else {
 
-  bool flip_finished = false;
-  int page_flip_ret = drmModePageFlip(dri_fd, encoder->crtc_id, fb->fb_id,
-                                      DRM_MODE_PAGE_FLIP_EVENT,
-                                      &flip_finished);
-  if (0 != page_flip_ret) {
-    fprintf(stderr, "drmModePageFlip() failed: %d\n", page_flip_ret);
-    exit(EXIT_FAILURE);
-  }
-  while (!flip_finished) {
-    int handle_event_ret = drmHandleEvent(dri_fd, &evctx);
-    if (0 != handle_event_ret) {
-      fprintf(stderr, "drmHandleEvent() failed: %d\n", handle_event_ret);
+    bool flip_finished = false;
+    int page_flip_ret = drmModePageFlip(dri_fd, encoder->crtc_id, fb->fb_id,
+                                        DRM_MODE_PAGE_FLIP_EVENT,
+                                        &flip_finished);
+    if (0 != page_flip_ret) {
+      fprintf(stderr, "drmModePageFlip() failed: %d\n", page_flip_ret);
       exit(EXIT_FAILURE);
     }
-  }
+    while (!flip_finished) {
+      int handle_event_ret = drmHandleEvent(dri_fd, &evctx);
+      if (0 != handle_event_ret) {
+        fprintf(stderr, "drmHandleEvent() failed: %d\n", handle_event_ret);
+        exit(EXIT_FAILURE);
+      }
+    }
 
-  if (nullptr != current_bo)
     gbm_surface_release_buffer(native_window, current_bo);
+  }
 
   current_bo = new_bo;
 #endif


### PR DESCRIPTION
- Support for old and new style native window types in Mali EGL headers
- Fix of error on first page flip with DRI/KMS for some DRI drivers
- DRI/KMS support for cross compilation for Cubieboard instead of closed-source Mali driver and blob
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
