### PR TITLE
InfoBoxes/Layout: add 3x5 InfoBoxes layout

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,8 @@ Version 7.18 - not yet released
   - TCP Client: fix crash bug
 * tracking
   - SkyLines: fix "Show nearby traffic" setting
+* user interface
+  - add 3x5 InfoBoxes layout
 
 Version 7.17 - 2021/09/04
 * map display

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -89,6 +89,8 @@ static constexpr StaticEnumChoice info_box_geometry_list[] = {
     N_("10 Split") },
   { (unsigned)InfoBoxSettings::Geometry::SPLIT_3X4,
     N_("12 Split in 3 rows") },
+  { (unsigned)InfoBoxSettings::Geometry::SPLIT_3X5,
+    N_("15 Split in 3 rows") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_RIGHT_8,
     N_("8 Bottom or Right") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_8_VARIO,

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -37,6 +37,7 @@ static constexpr unsigned char geometry_counts[] = {
   12, 9, 8, 4, 4, 4, 4,
   8, 16, 15, 10, 10, 10,
   12, // 3 rows X 4 boxes
+  15, // 3 rows X 5 boxes
 };
 
 namespace InfoBoxLayout {
@@ -328,6 +329,24 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry) noexc
     }
     break;
 
+  case InfoBoxSettings::Geometry::SPLIT_3X5:
+    if (layout.landscape) {
+      rc.left = MakeLeftColumn(layout, layout.positions, 5,
+                               rc.left, rc.top, rc.bottom);
+      rc.left = MakeLeftColumn(layout, layout.positions + 5, 5,
+                               rc.left, rc.top, rc.bottom);
+      rc.right = MakeRightColumn(layout, layout.positions + 10, 5,
+                               rc.right, rc.top, rc.bottom);
+    } else {
+      rc.top = MakeTopRow(layout, layout.positions, 5,
+                          rc.left, rc.right, rc.top);
+      rc.top = MakeTopRow(layout, layout.positions + 5, 5,
+                          rc.left, rc.right, rc.top);
+      rc.bottom = MakeBottomRow(layout, layout.positions + 10, 5,
+                          rc.left, rc.right, rc.bottom);
+    }
+    break;
+
   case InfoBoxSettings::Geometry::RIGHT_16:
     rc.right = MakeRightColumn(layout, layout.positions + 8, 8,
                                rc.right, rc.top, rc.bottom);
@@ -411,6 +430,7 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
     case InfoBoxSettings::Geometry::SPLIT_8:
     case InfoBoxSettings::Geometry::SPLIT_10:
     case InfoBoxSettings::Geometry::SPLIT_3X4:
+    case InfoBoxSettings::Geometry::SPLIT_3X5:
     case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
     case InfoBoxSettings::Geometry::TOP_LEFT_8:
     case InfoBoxSettings::Geometry::OBSOLETE_SPLIT_8:
@@ -448,6 +468,7 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
     case InfoBoxSettings::Geometry::SPLIT_8:
     case InfoBoxSettings::Geometry::SPLIT_10:
     case InfoBoxSettings::Geometry::SPLIT_3X4:
+    case InfoBoxSettings::Geometry::SPLIT_3X5:
     case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
     case InfoBoxSettings::Geometry::TOP_LEFT_8:
     case InfoBoxSettings::Geometry::OBSOLETE_SPLIT_8:
@@ -537,6 +558,7 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
     break;
 
   case InfoBoxSettings::Geometry::SPLIT_3X4:
+  case InfoBoxSettings::Geometry::SPLIT_3X5:
     if (landscape) {
       layout.control_size.height = 3 * screen_size.height / layout.count;
       layout.control_size.width = CalculateInfoBoxColumnWidth(screen_size.width,
@@ -668,6 +690,27 @@ InfoBoxLayout::GetBorder(InfoBoxSettings::Geometry geometry, bool landscape,
         border |= BORDERTOP;
 
       if (i != 3 && i != 7 && i != 11)
+        border |= BORDERRIGHT;
+    }
+
+    break;
+
+  case InfoBoxSettings::Geometry::SPLIT_3X5:
+    if (landscape) {
+      if (i != 4 && i != 9 && i != 14)
+        border |= BORDERBOTTOM;
+
+      if (i < 10)
+        border |= BORDERRIGHT;
+      else
+        border |= BORDERLEFT;
+    } else {
+      if (i < 10)
+        border |= BORDERBOTTOM;
+      else
+        border |= BORDERTOP;
+
+      if (i != 4 && i != 9 && i != 14)
         border |= BORDERRIGHT;
     }
 

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -123,6 +123,8 @@ struct InfoBoxSettings {
     SPLIT_10 = 23,
     /** 12 infoboxes 3X4 split bottom/top or left/right */
     SPLIT_3X4 = 24,
+    /** 15 infoboxes 3X5 split bottom/top or left/right */
+    SPLIT_3X5 = 25,
 
   } geometry;
 

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -78,6 +78,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
   case InfoBoxSettings::Geometry::SPLIT_8:
   case InfoBoxSettings::Geometry::SPLIT_10:
   case InfoBoxSettings::Geometry::SPLIT_3X4:
+  case InfoBoxSettings::Geometry::SPLIT_3X5:
   case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
   case InfoBoxSettings::Geometry::TOP_LEFT_8:
     break;


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Adds a new 3x5 layout, aimed at modern mobile phones Aspect Ratios, exactly as done in 202d7f0faff847c74861bd8cc91969f18fb6793c

Related issues and discussions
------------------------------
Closes #614 