### PR TITLE
Fix for LXNAV Varios

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,8 @@ Version 7.19 - not yet released
   - fix crash bug in terrain loader
   - support short name in CUP files
   - search waypoints via short name
+* devices
+  - improved support for LXNAV S8x/S10x varios, including task declaration.
 * user interface
   - consistent progress bar during startup
 * Android

--- a/build/main.mk
+++ b/build/main.mk
@@ -26,8 +26,8 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Device/ManageFlarmDialog.cpp \
 	$(SRC)/Dialogs/Device/BlueFly/BlueFlyConfigurationDialog.cpp \
 	$(SRC)/Dialogs/Device/ManageI2CPitotDialog.cpp \
-	$(SRC)/Dialogs/Device/LX/ManageV7Dialog.cpp \
-	$(SRC)/Dialogs/Device/LX/V7ConfigWidget.cpp \
+	$(SRC)/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp \
+	$(SRC)/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp \
 	$(SRC)/Dialogs/Device/LX/ManageNanoDialog.cpp \
 	$(SRC)/Dialogs/Device/LX/NanoConfigWidget.cpp \
 	$(SRC)/Dialogs/Device/LX/ManageLX16xxDialog.cpp \

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -719,7 +719,7 @@ DeviceDescriptor::IsManageable() const
 
     if (StringIsEqual(driver->name, _T("LX")) && device != nullptr) {
       const LXDevice &lx = *(const LXDevice *)device;
-      return lx.IsV7() || lx.IsNano() || lx.IsLX16xx();
+      return lx.IsManageable();
     }
   }
 

--- a/src/Device/Driver/LX/Declare.cpp
+++ b/src/Device/Driver/LX/Declare.cpp
@@ -218,7 +218,7 @@ LXDevice::Declare(const Declaration &declaration,
   if (declaration.Size() < 2 || declaration.Size() > 12)
     return false;
 
-  if (IsNano())
+  if (IsLXNAVLogger())
     return Nano::Declare(port, declaration, env);
 
   if (!EnableCommandMode(env))

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -57,6 +57,11 @@ class LXDevice: public AbstractDevice
    */
   bool is_colibri;
 
+  /*
+   * Indicates whether pass-through mode should be used
+   */
+  bool use_pass_through;
+
   /**
    * Was a LXNAV V7 detected?
    */
@@ -103,10 +108,10 @@ class LXDevice: public AbstractDevice
 
 public:
   LXDevice(Port &_port, unsigned baud_rate, unsigned _bulk_baud_rate,
-           bool _port_is_nano=false)
+           bool _use_pass_through, bool _port_is_nano=false)
     :port(_port), bulk_baud_rate(_bulk_baud_rate),
      busy(false),
-     is_colibri(baud_rate == 4800),
+     is_colibri(baud_rate == 4800), use_pass_through(_use_pass_through),
      is_v7(false), is_nano(_port_is_nano), port_is_nano(_port_is_nano),
      is_lx16xx(false), is_forwarded_nano(false),
      mode(Mode::UNKNOWN), old_baud_rate(0) {}
@@ -158,6 +163,10 @@ public:
    */
   bool IsManageable() const {
     return IsV7() || IsSVario() || IsNano() || IsLX16xx();
+  }
+
+  bool UsePassThrough() {
+    return use_pass_through;
   }
 
   void ResetDeviceDetection() {

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -50,7 +50,7 @@ class LXDevice: public AbstractDevice
   /**
    * Is this ia Colibri or LX20 or a similar "old" logger?  This is
    * initialised to true if the NMEA baud rate is configured to 4800,
-   * which disables the advanced V7/Nano protocol, to avoid confusing
+   * which disables the advanced LX Vario/Nano protocol, to avoid confusing
    * the Colibri.  It is cleared as soon as a "modern" LX product is
    * detected (passively).
    */
@@ -77,14 +77,14 @@ class LXDevice: public AbstractDevice
   bool is_lx16xx;
 
   /**
-   * Was a V7 with a Nano on the GPS port detected?
+   * Was a vario with a Nano on the GPS port detected?
    */
   bool is_forwarded_nano;
 
   /**
-   * Settings that were received in PLXV0 (LXNAV V7) sentences.
+   * Settings that were received in PLXV0 (LXNAV Vario) sentences.
    */
-  DeviceSettingsMap<std::string> v7_settings;
+  DeviceSettingsMap<std::string> lxnav_vario_settings;
 
   /**
    * Settings that were received in PLXVC (LXNAV Nano) sentences.
@@ -131,37 +131,37 @@ public:
   }
 
   /**
-   * Write a setting to a LXNAV V7.
+   * Write a setting to a LXNAV Vario.
    *
    * @return true if sending the command has succeeded (it does not
-   * indicate whether the V7 has understood and processed it)
+   * indicate whether the Vario has understood and processed it)
    */
-  bool SendV7Setting(const char *name, const char *value,
+  bool SendLXNAVVarioSetting(const char *name, const char *value,
                      OperationEnvironment &env);
 
   /**
-   * Request a setting from a LXNAV V7.  The V7 will send the value,
+   * Request a setting from a LXNAV Vario.  The Vario will send the value,
    * but this method will not wait for that.
    *
    * @return true if sending the command has succeeded (it does not
-   * indicate whether the V7 has understood and processed it)
+   * indicate whether the Vario has understood and processed it)
    */
-  bool RequestV7Setting(const char *name, OperationEnvironment &env);
+  bool RequestLXNAVVarioSetting(const char *name, OperationEnvironment &env);
 
   /**
    * Wait for the specified setting to be received.  Returns the value
    * on success, or an empty string on timeout.
    */
-  std::string WaitV7Setting(const char *name, OperationEnvironment &env,
+  std::string WaitLXNAVVarioSetting(const char *name, OperationEnvironment &env,
                             unsigned timeout_ms);
 
   /**
-   * Look up the given setting in the table of received LXNAV V7
+   * Look up the given setting in the table of received LXNAV Vario
    * values.  If the value does not exist, an empty string is
    * returned.
    */
   gcc_pure
-  std::string GetV7Setting(const char *name) const;
+  std::string GetLXNAVVarioSetting(const char *name) const;
 
   /**
    * Write a setting to a LXNAV Nano.
@@ -202,7 +202,7 @@ protected:
    * mode.  If the Nano is connected through a LXNAV V7, it will
    * enable pass-through mode on the V7.
    */
-  bool EnableNanoNMEA(OperationEnvironment &env);
+  bool EnableLoggerNMEA(OperationEnvironment &env);
 
   bool EnableCommandMode(OperationEnvironment &env);
 

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -153,6 +153,13 @@ public:
     return is_lx16xx;
   }
 
+  /**
+   * Can this device be managed by XCSoar?
+   */
+  bool IsManageable() const {
+    return IsV7() || IsSVario() || IsNano() || IsLX16xx();
+  }
+
   void ResetDeviceDetection() {
     is_v7 = is_sVario = is_nano = is_lx16xx = is_forwarded_nano = false;
   }

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -28,6 +28,7 @@ Copyright_License {
 #include "Device/Driver.hpp"
 #include "Device/SettingsMap.hpp"
 #include "thread/Mutex.hxx"
+#include "util/StaticString.hxx"
 
 #include <atomic>
 #include <cstdint>
@@ -60,6 +61,11 @@ class LXDevice: public AbstractDevice
    * Was a LXNAV V7 detected?
    */
   bool is_v7;
+
+  /**
+   * Was a LXNAV S series vario detected?
+   */
+  bool is_sVario;
 
   /**
    * Was a LXNAV Nano detected?
@@ -113,10 +119,31 @@ public:
   }
 
   /**
+   * Was a LXNAV S series vario detected?
+   */
+  bool IsSVario() const {
+    return is_sVario;
+  }
+
+  /**
+   * Was a LXNAV vario device detected?
+   */
+  bool IsLXNAVVario() const {
+    return IsV7() || IsSVario();
+  }
+
+  /**
    * Was a LXNAV Nano detected?
    */
   bool IsNano() const {
     return port_is_nano || is_nano || is_forwarded_nano;
+  }
+
+  /**
+   * Was an LXNAV logger device detected?
+   */
+  bool IsLXNAVLogger() const {
+    return IsNano() || IsSVario();
   }
 
   /**
@@ -127,7 +154,15 @@ public:
   }
 
   void ResetDeviceDetection() {
-    is_v7 = is_nano = is_lx16xx = is_forwarded_nano = false;
+    is_v7 = is_sVario = is_nano = is_lx16xx = is_forwarded_nano = false;
+  }
+
+  void IdDeviceByName(NarrowString<16> productName)
+  {
+    is_v7 = productName.equals("V7");
+    is_sVario = productName.equals("NINC") || productName.equals("S8x");
+    is_nano = productName.equals("NANO") || productName.equals("NANO3") || productName.equals("NANO4");
+    is_lx16xx = productName.equals("1606") || productName.equals("1600");
   }
 
   /**

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -21,8 +21,8 @@ Copyright_License {
 }
 */
 
-#ifndef XCSOAR_DEVICE_DRIVER_LX_V7_HPP
-#define XCSOAR_DEVICE_DRIVER_LX_V7_HPP
+#ifndef XCSOAR_DEVICE_DRIVER_LX_LXVARIO_HPP
+#define XCSOAR_DEVICE_DRIVER_LX_LXVARIO_HPP
 
 #include "Device/Port/Port.hpp"
 #include "Device/Util/NMEAWriter.hpp"
@@ -33,9 +33,9 @@ Copyright_License {
 /**
  * Code specific to LXNav varios (e.g. V7).
  *
- * Source: V7 Dataport specification Version 1.98
+ * Source: LXNav Vario Dataport specification Version 1.03
  */
-namespace V7 {
+namespace LXNAVVario {
   /**
    * Enable direct link with GPS port.
    */
@@ -46,16 +46,16 @@ namespace V7 {
   }
 
   /**
-   * Enable communication with V7.
+   * Enable communication with the vario.
    */
   static inline bool
-  ModeVSeven(Port &port, OperationEnvironment &env)
+  ModeNormal(Port &port, OperationEnvironment &env)
   {
     return PortWriteNMEA(port, "PLXV0,CONNECTION,W,VSEVEN", env);
   }
 
   /**
-   * Set up the NMEA sentences sent by the V7 vario:
+   * Set up the NMEA sentences sent by the vario:
    *
    * - PLXVF at 2 Hz
    * - PLXVS every 5 seconds
@@ -72,7 +72,7 @@ namespace V7 {
   }
 
   /**
-   * Set the MC setting of the V7 vario
+   * Set the MC setting of the vario
    * @param mc in m/s
    */
   static inline bool
@@ -84,7 +84,7 @@ namespace V7 {
   }
 
   /**
-   * Set the ballast setting of the V7 vario
+   * Set the ballast setting of the vario
    * @param overload 1.0 - 1.4 (100 - 140%)
    */
   static inline bool
@@ -96,7 +96,7 @@ namespace V7 {
   }
 
   /**
-   * Set the bugs setting of the V7 vario
+   * Set the bugs setting of the vario
    * @param bugs 0 - 30 %
    */
   static inline bool
@@ -108,7 +108,7 @@ namespace V7 {
   }
 
   /**
-   * Set the QNH setting of the V7 vario
+   * Set the QNH setting of the vario
    */
   static inline bool
   SetQNH(Port &port, OperationEnvironment &env, const AtmosphericPressure &qnh)
@@ -120,7 +120,7 @@ namespace V7 {
   }
 
   /**
-   * Send pilotevent to V7 vario 
+   * Send pilotevent to vario 
    * (needs S10x/S8x firmware 8.01 or newer)
    */
   static inline bool

--- a/src/Device/Driver/LX/Logger.cpp
+++ b/src/Device/Driver/LX/Logger.cpp
@@ -148,7 +148,7 @@ bool
 LXDevice::ReadFlightList(RecordedFlightList &flight_list,
                          OperationEnvironment &env)
 {
-  if (IsNano()) {
+  if (IsLXNAVLogger()) {
     if (!EnableLoggerNMEA(env))
       return false;
 

--- a/src/Device/Driver/LX/Logger.cpp
+++ b/src/Device/Driver/LX/Logger.cpp
@@ -149,7 +149,7 @@ LXDevice::ReadFlightList(RecordedFlightList &flight_list,
                          OperationEnvironment &env)
 {
   if (IsNano()) {
-    if (!EnableNanoNMEA(env))
+    if (!EnableLoggerNMEA(env))
       return false;
 
     assert(!busy);

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -22,7 +22,7 @@ Copyright_License {
 */
 
 #include "Internal.hpp"
-#include "V7.hpp"
+#include "LXNAVVario.hpp"
 #include "LX1600.hpp"
 #include "NanoProtocol.hpp"
 #include "Device/Port/Port.hpp"
@@ -38,8 +38,8 @@ LXDevice::LinkTimeout()
   ResetDeviceDetection();
 
   {
-    const std::lock_guard<Mutex> lock(v7_settings);
-    v7_settings.clear();
+    const std::lock_guard<Mutex> lock(lxnav_vario_settings);
+    lxnav_vario_settings.clear();
   }
 
   {
@@ -75,9 +75,9 @@ LXDevice::EnableNMEA(OperationEnvironment &env)
   }
 
   /* just in case the V7 is still in pass-through mode: */
-  V7::ModeVSeven(port, env);
+  LXNAVVario::ModeNormal(port, env);
 
-  V7::SetupNMEA(port, env);
+  LXNAVVario::SetupNMEA(port, env);
   if (!is_v7)
     LX1600::SetupNMEA(port, env);
 
@@ -112,7 +112,7 @@ LXDevice::EnablePassThrough(OperationEnvironment &env)
     return true;
 
   if (is_v7) {
-    if (!V7::ModeDirect(port, env))
+    if (!LXNAVVario::ModeDirect(port, env))
       return false;
   }
 
@@ -121,7 +121,7 @@ LXDevice::EnablePassThrough(OperationEnvironment &env)
 }
 
 bool
-LXDevice::EnableNanoNMEA(OperationEnvironment &env)
+LXDevice::EnableLoggerNMEA(OperationEnvironment &env)
 {
   return IsV7()
     ? EnablePassThrough(env)

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -111,7 +111,7 @@ LXDevice::EnablePassThrough(OperationEnvironment &env)
   if (mode == Mode::PASS_THROUGH)
     return true;
 
-  if (is_v7) {
+  if (is_v7 || use_pass_through) {
     if (!LXNAVVario::ModeDirect(port, env))
       return false;
   }
@@ -123,9 +123,9 @@ LXDevice::EnablePassThrough(OperationEnvironment &env)
 bool
 LXDevice::EnableLoggerNMEA(OperationEnvironment &env)
 {
-  return IsV7()
+  return IsV7() || UsePassThrough()
     ? EnablePassThrough(env)
-    : true;
+    : LXNAVVario::ModeNormal(port, env);
 }
 
 bool

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -78,7 +78,7 @@ LXDevice::EnableNMEA(OperationEnvironment &env)
   LXNAVVario::ModeNormal(port, env);
 
   LXNAVVario::SetupNMEA(port, env);
-  if (!is_v7)
+  if (!IsLXNAVVario())
     LX1600::SetupNMEA(port, env);
 
   if (old_baud_rate != 0)
@@ -87,7 +87,7 @@ LXDevice::EnableNMEA(OperationEnvironment &env)
   port.Flush();
 
   Nano::RequestForwardedInfo(port, env);
-  if (!is_v7)
+  if (!IsLXNAVVario())
     Nano::RequestInfo(port, env);
 
   return true;

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -357,9 +357,12 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
       : info.device;
     LXWP1(line, device_info);
 
+    const bool saw_sVario = device_info.product.equals("NINC") || 
+                            device_info.product.equals("S8x");
     const bool saw_v7 = device_info.product.equals("V7");
     const bool saw_nano = device_info.product.equals("NANO") ||
-                            device_info.product.equals("NANO3");
+                            device_info.product.equals("NANO3") || 
+                            device_info.product.equals("NANO4");
     const bool saw_lx16xx = device_info.product.equals("1606") ||
                              device_info.product.equals("1600");
 
@@ -368,16 +371,18 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
          because the V7 is still there, even though it's "hidden"
          currently */
       is_v7 |= saw_v7;
+      is_sVario |= saw_sVario;
       is_nano |= saw_nano;
       is_lx16xx |= saw_lx16xx;
       is_forwarded_nano = saw_nano;
     } else {
       is_v7 = saw_v7;
+      is_sVario = saw_sVario;
       is_nano = saw_nano;
       is_lx16xx = saw_lx16xx;
     }
 
-    if (saw_v7 || saw_nano || saw_lx16xx)
+    if (saw_v7 || saw_sVario || saw_nano || saw_lx16xx)
       is_colibri = false;
 
     return true;
@@ -400,7 +405,11 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
     is_colibri = false;
     PLXVC(line, info.device, info.secondary_device, nano_settings);
     is_forwarded_nano = info.secondary_device.product.equals("NANO") ||
-                          info.secondary_device.product.equals("NANO3");
+                          info.secondary_device.product.equals("NANO3") ||
+                          info.secondary_device.product.equals("NANO4");
+
+    LXDevice::IdDeviceByName(info.device.product);
+
     return true;
   }
 

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -395,13 +395,11 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
     return LXWP3(line, info);
 
   if (StringIsEqual(type, "$PLXV0")) {
-    is_v7 = true;
     is_colibri = false;
     return PLXV0(line, lxnav_vario_settings);
   }
 
   if (StringIsEqual(type, "$PLXVC")) {
-    is_nano = true;
     is_colibri = false;
     PLXVC(line, info.device, info.secondary_device, nano_settings);
     is_forwarded_nano = info.secondary_device.product.equals("NANO") ||
@@ -414,13 +412,11 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
   }
 
   if (StringIsEqual(type, "$PLXVF")) {
-    is_v7 = true;
     is_colibri = false;
     return PLXVF(line, info);
   }
 
   if (StringIsEqual(type, "$PLXVS")) {
-    is_v7 = true;
     is_colibri = false;
     return PLXVS(line, info);
   }

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -193,7 +193,7 @@ LXWP3(NMEAInputLine &line, NMEAInfo &info)
 }
 
 /**
- * Parse the $PLXV0 sentence (LXNav V7).
+ * Parse the $PLXV0 sentence (LXNAV sVarios (including V7)).
  */
 static bool
 PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings)
@@ -217,7 +217,7 @@ PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings)
 }
 
 static void
-ParseNanoInfo(NMEAInputLine &line, DeviceInfo &device)
+ParseNanoVarioInfo(NMEAInputLine &line, DeviceInfo &device)
 {
   ReadString(line, device.product);
   ReadString(line, device.software_version);
@@ -226,7 +226,7 @@ ParseNanoInfo(NMEAInputLine &line, DeviceInfo &device)
 }
 
 /**
- * Parse the $PLXVC sentence (LXNAV Nano).
+ * Parse the $PLXVC sentence (LXNAV Nano and sVarios).
  *
  * $PLXVC,<key>,<type>,<values>*<checksum><cr><lf>
  */
@@ -250,7 +250,7 @@ PLXVC(NMEAInputLine &line, DeviceInfo &device,
       settings.Set(name, std::string(value.begin(), value.end()));
     }
   } else if (StringIsEqual(key, "INFO") && type[0] == 'A') {
-    ParseNanoInfo(line, device);
+    ParseNanoVarioInfo(line, device);
   } else if (StringIsEqual(key, "GPSINFO") && type[0] == 'A') {
     /* the LXNAV V7 (firmware >= 2.01) forwards the Nano's INFO
        sentence with the "GPS" prefix */
@@ -263,13 +263,13 @@ PLXVC(NMEAInputLine &line, DeviceInfo &device,
     } else if (StringIsEqual(name, "INFO")) {
       line.Read(type, ARRAY_SIZE(type));
       if (type[0] == 'A')
-        ParseNanoInfo(line, secondary_device);
+        ParseNanoVarioInfo(line, secondary_device);
     }
   }
 }
 
 /**
- * Parse the $PLXVF sentence (LXNav V7).
+ * Parse the $PLXVF sentence (LXNAV sVarios (including V7)).
  *
  * $PLXVF,time ,AccX,AccY,AccZ,Vario,IAS,PressAlt*CS<CR><LF>
  *
@@ -301,7 +301,7 @@ PLXVF(NMEAInputLine &line, NMEAInfo &info)
 }
 
 /**
- * Parse the $PLXVS sentence (LXNav V7).
+ * Parse the $PLXVS sentence (LXNAV sVarios (including V7)).
  *
  * $PLXVS,OAT,mode,voltage *CS<CR><LF>
  *
@@ -392,7 +392,7 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
   if (StringIsEqual(type, "$PLXV0")) {
     is_v7 = true;
     is_colibri = false;
-    return PLXV0(line, v7_settings);
+    return PLXV0(line, lxnav_vario_settings);
   }
 
   if (StringIsEqual(type, "$PLXVC")) {

--- a/src/Device/Driver/LX/Register.cpp
+++ b/src/Device/Driver/LX/Register.cpp
@@ -34,7 +34,7 @@ LXCreateOnPort(const DeviceConfig &config, Port &com_port)
 
   const bool is_nano = config.BluetoothNameStartsWith("LXNAV-NANO");
 
-  return new LXDevice(com_port, baud_rate, bulk_baud_rate, is_nano);
+  return new LXDevice(com_port, baud_rate, bulk_baud_rate, config.use_second_device, is_nano);
 }
 
 const struct DeviceRegister lx_driver = {

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -149,7 +149,7 @@ LXDevice::PutBallast(gcc_unused double fraction, double overload,
   if (!EnableNMEA(env))
     return false;
 
-  if (IsV7())
+  if (IsLXNAVVario())
     return LXNAVVario::SetBallast(port, env, overload);
   else
     return LX1600::SetBallast(port, env, overload);
@@ -163,7 +163,7 @@ LXDevice::PutBugs(double bugs, OperationEnvironment &env)
 
   int transformed_bugs_value = 100 - (int)(bugs*100);
 
-  if (IsV7())
+  if (IsLXNAVVario())
     return LXNAVVario::SetBugs(port, env, transformed_bugs_value);
   else
     return LX1600::SetBugs(port, env, transformed_bugs_value);
@@ -175,7 +175,7 @@ LXDevice::PutMacCready(double mac_cready, OperationEnvironment &env)
   if (!EnableNMEA(env))
     return false;
 
-  if (IsV7())
+  if (IsLXNAVVario())
     return LXNAVVario::SetMacCready(port, env, mac_cready);
   else
     return LX1600::SetMacCready(port, env, mac_cready);
@@ -187,7 +187,7 @@ LXDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
   if (!EnableNMEA(env))
     return false;
 
-  if (IsV7())
+  if (IsLXNAVVario())
     return LXNAVVario::SetQNH(port, env, pres);
   else
     return LX1600::SetQNH(port, env, pres);
@@ -205,7 +205,7 @@ LXDevice::PutVolume(unsigned volume, OperationEnvironment &env)
 bool
 LXDevice::PutPilotEvent(OperationEnvironment &env)
 {
-  if (!IsV7())
+  if (!IsLXNAVVario())
     return false;
 
   return LXNAVVario::PutPilotEvent(env, port);

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -24,20 +24,20 @@ Copyright_License {
 #include "Internal.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "LX1600.hpp"
-#include "V7.hpp"
+#include "LXNAVVario.hpp"
 
 #include <cstdio>
 
 bool
-LXDevice::SendV7Setting(const char *name, const char *value,
+LXDevice::SendLXNAVVarioSetting(const char *name, const char *value,
                         OperationEnvironment &env)
 {
   if (!EnableNMEA(env))
     return false;
 
   {
-    const std::lock_guard<Mutex> lock(v7_settings);
-    v7_settings.MarkOld(name);
+    const std::lock_guard<Mutex> lock(lxnav_vario_settings);
+    lxnav_vario_settings.MarkOld(name);
   }
 
   char buffer[256];
@@ -46,14 +46,14 @@ LXDevice::SendV7Setting(const char *name, const char *value,
 }
 
 bool
-LXDevice::RequestV7Setting(const char *name, OperationEnvironment &env)
+LXDevice::RequestLXNAVVarioSetting(const char *name, OperationEnvironment &env)
 {
   if (!EnableNMEA(env))
     return false;
 
   {
-    const std::lock_guard<Mutex> lock(v7_settings);
-    v7_settings.MarkOld(name);
+    const std::lock_guard<Mutex> lock(lxnav_vario_settings);
+    lxnav_vario_settings.MarkOld(name);
   }
 
   char buffer[256];
@@ -62,24 +62,24 @@ LXDevice::RequestV7Setting(const char *name, OperationEnvironment &env)
 }
 
 std::string
-LXDevice::WaitV7Setting(const char *name, OperationEnvironment &env,
+LXDevice::WaitLXNAVVarioSetting(const char *name, OperationEnvironment &env,
                         unsigned timeout_ms)
 {
-  std::unique_lock<Mutex> lock(v7_settings);
-  auto i = v7_settings.Wait(lock, name, env,
+  std::unique_lock<Mutex> lock(lxnav_vario_settings);
+  auto i = lxnav_vario_settings.Wait(lock, name, env,
                             std::chrono::milliseconds(timeout_ms));
-  if (i == v7_settings.end())
+  if (i == lxnav_vario_settings.end())
     return std::string();
 
   return *i;
 }
 
 std::string
-LXDevice::GetV7Setting(const char *name) const
+LXDevice::GetLXNAVVarioSetting(const char *name) const
 {
-  std::lock_guard<Mutex> lock(v7_settings);
-  auto i = v7_settings.find(name);
-  if (i == v7_settings.end())
+  std::lock_guard<Mutex> lock(lxnav_vario_settings);
+  auto i = lxnav_vario_settings.find(name);
+  if (i == lxnav_vario_settings.end())
     return std::string();
 
   return *i;
@@ -89,7 +89,7 @@ bool
 LXDevice::SendNanoSetting(const char *name, const char *value,
                         OperationEnvironment &env)
 {
-  if (!EnableNanoNMEA(env))
+  if (!EnableLoggerNMEA(env))
     return false;
 
   {
@@ -105,7 +105,7 @@ LXDevice::SendNanoSetting(const char *name, const char *value,
 bool
 LXDevice::RequestNanoSetting(const char *name, OperationEnvironment &env)
 {
-  if (!EnableNanoNMEA(env))
+  if (!EnableLoggerNMEA(env))
     return false;
 
   {
@@ -150,7 +150,7 @@ LXDevice::PutBallast(gcc_unused double fraction, double overload,
     return false;
 
   if (IsV7())
-    return V7::SetBallast(port, env, overload);
+    return LXNAVVario::SetBallast(port, env, overload);
   else
     return LX1600::SetBallast(port, env, overload);
 }
@@ -164,7 +164,7 @@ LXDevice::PutBugs(double bugs, OperationEnvironment &env)
   int transformed_bugs_value = 100 - (int)(bugs*100);
 
   if (IsV7())
-    return V7::SetBugs(port, env, transformed_bugs_value);
+    return LXNAVVario::SetBugs(port, env, transformed_bugs_value);
   else
     return LX1600::SetBugs(port, env, transformed_bugs_value);
 }
@@ -176,7 +176,7 @@ LXDevice::PutMacCready(double mac_cready, OperationEnvironment &env)
     return false;
 
   if (IsV7())
-    return V7::SetMacCready(port, env, mac_cready);
+    return LXNAVVario::SetMacCready(port, env, mac_cready);
   else
     return LX1600::SetMacCready(port, env, mac_cready);
 }
@@ -188,7 +188,7 @@ LXDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
     return false;
 
   if (IsV7())
-    return V7::SetQNH(port, env, pres);
+    return LXNAVVario::SetQNH(port, env, pres);
   else
     return LX1600::SetQNH(port, env, pres);
 }
@@ -208,5 +208,5 @@ LXDevice::PutPilotEvent(OperationEnvironment &env)
   if (!IsV7())
     return false;
 
-  return V7::PutPilotEvent(env, port);
+  return LXNAVVario::PutPilotEvent(env, port);
 }

--- a/src/Device/Driver/PosiGraph.cpp
+++ b/src/Device/Driver/PosiGraph.cpp
@@ -40,7 +40,7 @@ Copyright_License {
 class PGDevice : public LXDevice {
 public:
   PGDevice(Port &_port, unsigned baud_rate, unsigned bulk_baud_rate)
-    :LXDevice(_port, baud_rate, bulk_baud_rate) {}
+    :LXDevice(_port, baud_rate, bulk_baud_rate, true) {}
 
   /* virtual methods from class Device */
   bool ParseNMEA(const char *line, struct NMEAInfo &info) override;

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -28,7 +28,7 @@ Copyright_License {
 #include "ManageI2CPitotDialog.hpp"
 #include "ManageCAI302Dialog.hpp"
 #include "ManageFlarmDialog.hpp"
-#include "LX/ManageV7Dialog.hpp"
+#include "LX/ManageLXNAVVarioDialog.hpp"
 #include "LX/ManageNanoDialog.hpp"
 #include "LX/ManageLX16xxDialog.hpp"
 #include "PortMonitor.hpp"
@@ -670,7 +670,7 @@ DeviceListWidget::ManageCurrent()
 
     LXDevice &lx_device = *(LXDevice *)device;
     if (lx_device.IsV7())
-      ManageV7Dialog(lx_device, info, secondary_info);
+      ManageLXNAVVarioDialog(lx_device, info, secondary_info);
     else if (lx_device.IsNano())
       ManageNanoDialog(lx_device, info);
     else if (lx_device.IsLX16xx())

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -669,7 +669,7 @@ DeviceListWidget::ManageCurrent()
     }
 
     LXDevice &lx_device = *(LXDevice *)device;
-    if (lx_device.IsV7())
+    if (lx_device.IsLXNAVVario())
       ManageLXNAVVarioDialog(lx_device, info, secondary_info);
     else if (lx_device.IsNano())
       ManageNanoDialog(lx_device, info);

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp
@@ -21,13 +21,13 @@ Copyright_License {
 }
 */
 
-#include "V7ConfigWidget.hpp"
+#include "LXNAVVarioConfigWidget.hpp"
 #include "Device/Driver/LX/Internal.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Language/Language.hpp"
 #include "Operation/PopupOperationEnvironment.hpp"
 
-static const char *const v7_setting_names[] = {
+static const char *const lxnav_vario_setting_names[] = {
   "BRGPS",
   "BRPDA",
   NULL
@@ -38,8 +38,8 @@ RequestAllSettings(LXDevice &device)
 {
   PopupOperationEnvironment env;
 
-  for (auto i = v7_setting_names; *i != NULL; ++i)
-    if (!device.RequestV7Setting(*i, env))
+  for (auto i = lxnav_vario_setting_names; *i != NULL; ++i)
+    if (!device.RequestLXNAVVarioSetting(*i, env))
       return false;
 
   return true;
@@ -50,7 +50,7 @@ WaitUnsignedValue(LXDevice &device, const char *name,
                   unsigned default_value)
 {
   PopupOperationEnvironment env;
-  const auto x = device.WaitV7Setting(name, env, 500);
+  const auto x = device.WaitLXNAVVarioSetting(name, env, 500);
   if (!x.empty()) {
     char *endptr;
     unsigned long y = strtoul(x.c_str(), &endptr, 10);
@@ -62,7 +62,7 @@ WaitUnsignedValue(LXDevice &device, const char *name,
 }
 
 void
-V7ConfigWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+LXNAVVarioConfigWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 {
   RequestAllSettings(device);
 
@@ -89,7 +89,7 @@ V7ConfigWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 }
 
 bool
-V7ConfigWidget::Save(bool &_changed) noexcept
+LXNAVVarioConfigWidget::Save(bool &_changed) noexcept
 {
   PopupOperationEnvironment env;
   bool changed = false;
@@ -97,13 +97,13 @@ V7ConfigWidget::Save(bool &_changed) noexcept
 
   if (SaveValue(BRGPS, brgps)) {
     buffer.UnsafeFormat("%u", brgps);
-    device.SendV7Setting("BRGPS", buffer, env);
+    device.SendLXNAVVarioSetting("BRGPS", buffer, env);
     changed = true;
   }
 
   if (SaveValue(BRPDA, brpda)) {
     buffer.UnsafeFormat("%u", brpda);
-    device.SendV7Setting("BRPDA", buffer, env);
+    device.SendLXNAVVarioSetting("BRPDA", buffer, env);
     changed = true;
   }
 

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
@@ -21,14 +21,30 @@ Copyright_License {
 }
 */
 
-#ifndef XCSOAR_MANAGE_V7_DIALOG_HPP
-#define XCSOAR_MANAGE_V7_DIALOG_HPP
+#ifndef XCSOAR_LX_VARIO_CONFIG_WIDGET_HPP
+#define XCSOAR_LX_VARIO_CONFIG_WIDGET_HPP
 
-class Device;
-struct DeviceInfo;
+#include "Widget/RowFormWidget.hpp"
 
-void
-ManageV7Dialog(Device &device, const DeviceInfo &info,
-               const DeviceInfo &secondary_info);
+class LXDevice;
+
+class LXNAVVarioConfigWidget final : public RowFormWidget {
+  enum Controls {
+    BRGPS,
+    BRPDA
+  };
+
+  LXDevice &device;
+
+  unsigned brgps, brpda;
+
+public:
+  LXNAVVarioConfigWidget(const DialogLook &look, LXDevice &_device)
+    :RowFormWidget(look), device(_device) {}
+
+  /* virtual methods from Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
 
 #endif

--- a/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
+++ b/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
@@ -21,8 +21,8 @@ Copyright_License {
 }
 */
 
-#include "ManageV7Dialog.hpp"
-#include "V7ConfigWidget.hpp"
+#include "ManageLXNAVVarioDialog.hpp"
+#include "LXNAVVarioConfigWidget.hpp"
 #include "ManageNanoDialog.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
@@ -32,14 +32,14 @@ Copyright_License {
 #include "Device/Driver/LX/Internal.hpp"
 #include "NMEA/DeviceInfo.hpp"
 
-class ManageV7Widget final
+class ManageLXNAVVarioWidget final
   : public RowFormWidget {
   LXDevice &device;
   const DeviceInfo info;
   const DeviceInfo secondary_info;
 
 public:
-  ManageV7Widget(const DialogLook &look, LXDevice &_device,
+  ManageLXNAVVarioWidget(const DialogLook &look, LXDevice &_device,
                  const DeviceInfo &info,
                  const DeviceInfo &secondary_info)
     :RowFormWidget(look), device(_device), info(info),
@@ -50,7 +50,7 @@ public:
 };
 
 void
-ManageV7Widget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+ManageLXNAVVarioWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 {
   StaticString<64> buffer;
 
@@ -79,9 +79,9 @@ ManageV7Widget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   }
 
   AddButton(_("Setup"), [this](){
-    V7ConfigWidget widget(GetLook(), device);
+    LXNAVVarioConfigWidget widget(GetLook(), device);
     DefaultWidgetDialog(UIGlobals::GetMainWindow(), GetLook(),
-                        _T("LXNAV V7"), widget);
+                        _T("LXNAV Vario"), widget);
   });
 
   if (device.IsNano())
@@ -95,13 +95,13 @@ ManageV7Widget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 }
 
 void
-ManageV7Dialog(Device &device, const DeviceInfo &info,
+ManageLXNAVVarioDialog(Device &device, const DeviceInfo &info,
                const DeviceInfo &secondary_info)
 {
   WidgetDialog dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
                       UIGlobals::GetDialogLook(),
-                      _T("LXNAV V7"),
-                      new ManageV7Widget(UIGlobals::GetDialogLook(),
+                      _T("LXNAV Vario"),
+                      new ManageLXNAVVarioWidget(UIGlobals::GetDialogLook(),
                                          (LXDevice &)device, info,
                                          secondary_info));
   dialog.AddButton(_("Close"), mrCancel);

--- a/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.hpp
+++ b/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.hpp
@@ -21,30 +21,14 @@ Copyright_License {
 }
 */
 
-#ifndef XCSOAR_V7_CONFIG_WIDGET_HPP
-#define XCSOAR_V7_CONFIG_WIDGET_HPP
+#ifndef XCSOAR_MANAGE_LX_VARIO_DIALOG_HPP
+#define XCSOAR_MANAGE_LX_VARIO_DIALOG_HPP
 
-#include "Widget/RowFormWidget.hpp"
+class Device;
+struct DeviceInfo;
 
-class LXDevice;
-
-class V7ConfigWidget final : public RowFormWidget {
-  enum Controls {
-    BRGPS,
-    BRPDA
-  };
-
-  LXDevice &device;
-
-  unsigned brgps, brpda;
-
-public:
-  V7ConfigWidget(const DialogLook &look, LXDevice &_device)
-    :RowFormWidget(look), device(_device) {}
-
-  /* virtual methods from Widget */
-  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
-  bool Save(bool &changed) noexcept override;
-};
+void
+ManageLXNAVVarioDialog(Device &device, const DeviceInfo &info,
+               const DeviceInfo &secondary_info);
 
 #endif

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -352,7 +352,7 @@ struct NMEAInfo {
 
   /**
    * Information about the "secondary" device, e.g. the GPS connected
-   * "behind" the LXNAV V7.
+   * "behind" the LXNAV Vario.
    */
   DeviceInfo secondary_device;
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1007,24 +1007,42 @@ TestLX(const struct DeviceRegister &driver, bool condor=false)
     ok1(!lx_device.IsV7());
     ok1(!lx_device.IsNano());
     ok1(!lx_device.IsLX16xx());
+    ok1(!lx_device.IsSVario());
 
     lx_device.ResetDeviceDetection();
     ok1(device->ParseNMEA("$LXWP1,V7,12345,1.0,1.0,12345*6f", nmea_info));
     ok1(lx_device.IsV7());
     ok1(!lx_device.IsNano());
     ok1(!lx_device.IsLX16xx());
+    ok1(!lx_device.IsSVario());
 
     lx_device.ResetDeviceDetection();
     ok1(device->ParseNMEA("$LXWP1,NANO,12345,1.0,1.0,12345*00", nmea_info));
     ok1(!lx_device.IsV7());
     ok1(lx_device.IsNano());
     ok1(!lx_device.IsLX16xx());
+    ok1(!lx_device.IsSVario());
+
+    lx_device.ResetDeviceDetection();
+    ok1(device->ParseNMEA("$LXWP1,NINC,12345,1.0,1.0,12345*04", nmea_info));
+    ok1(!lx_device.IsV7());
+    ok1(!lx_device.IsNano());
+    ok1(!lx_device.IsLX16xx());
+    ok1(lx_device.IsSVario());
+
+    lx_device.ResetDeviceDetection();
+    ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", nmea_info));
+    ok1(!lx_device.IsV7());
+    ok1(!lx_device.IsNano());
+    ok1(!lx_device.IsLX16xx());
+    ok1(lx_device.IsSVario());
 
     lx_device.ResetDeviceDetection();
     ok1(device->ParseNMEA("$LXWP1,1606,4294967295,1.90,1.00,4294967295*06", nmea_info));
     ok1(!lx_device.IsV7());
     ok1(!lx_device.IsNano());
     ok1(lx_device.IsLX16xx());
+    ok1(!lx_device.IsSVario());
 
     ok1(nmea_info.device.product == "1606");
     ok1(nmea_info.device.serial == "4294967295");
@@ -1062,17 +1080,12 @@ TestLXV7()
   ok1(basic.pressure_altitude_available);
   ok1(equals(basic.pressure_altitude, 244.3));
 
-  ok1(lx_device.IsV7());
-  lx_device.ResetDeviceDetection();
-
   ok1(device->ParseNMEA("$PLXVS,23.1,0,12.3,*71", basic));
   ok1(basic.temperature_available);
   ok1(equals(basic.temperature.ToKelvin(), 296.25));
   ok1(basic.switch_state.flight_mode == SwitchState::FlightMode::CIRCLING);
   ok1(basic.voltage_available);
   ok1(equals(basic.voltage, 12.3));
-
-  ok1(lx_device.IsV7());
 
   delete device;
 }
@@ -1602,7 +1615,7 @@ TestFlightList(const struct DeviceRegister &driver)
 
 int main(int argc, char **argv)
 {
-  plan_tests(827);
+  plan_tests(839);
 
   TestGeneric();
   TestTasman();


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Fixes issues with declaring tasks and other comms with LXNAV S series varios.

Based on original work from LXNAV located here: https://github.com/XCSoar/XCSoar/pull/220/

Tested with an LXNAV S100 vario. No testing has yet been performed with other LXNAV Varios or their passthrough capability with the Nano.

Related issues and discussions
------------------------------
Closes #688 

Update to indicate test steps taken with S100 vario:

1. NAV->Task->Manage->Declare; XCSoar indicates success, S100 receives task.
2. Config->Flight; made changes to ballast and bugs. Vario recevies updated values. 
3. Changed manual MC value; vario receives the updated value.
4. Changed MC, ballast and bugs at vario; XCSoar receives the updated values.
5. Config->Devices->LXNAV->Manage; the vario management dialog appears.
6. Config->Devices->Flight Download; flight list is read with all flights displayed. Selecting a flight and clicking Download causes the flight to be downloaded.
