### PR TITLE
support of WCH CH9102 USB to UART bridge controller

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,7 @@ Version 7.19 - not yet released
   - consistent progress bar during startup
 * Android
   - fix crash with USB serial adapter
+  - add WCH CH9102F into the list of accepted USB serial adapters
 
 Version 7.18 - 2021/09/10
 * data files

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -69,6 +69,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x0403, 0x6014), // FT232H
 
     createDevice(0x10C4, 0xEA60), // CP210x
+    createDevice(0x1A86, 0x55D4), // CH9102
 
     createDevice(0x067B, 0x2303) // PL2303
   );


### PR DESCRIPTION
Brief summary of the changes
----------------------------

<!--

CH9102F is a pin-to-pin compatible replacement for CP2104
https://www.cnx-software.com/2021/09/14/ch9102f-a-replacement-for-cp2104-usb-to-uart-bridge/

It becomes very popular in year of 2021 since the price tag for CP2104 is growing up rapidly.
-->

This PR contains VID and PID of CH9102 for the java USB filter to allow processing of the device.

<!--
The CH9102 does typically operate with generic USB CDC driver.
-->
