### PR TITLE
Adds a small indicator to the poweroff screen to show the battery lev…

### DIFF
--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -52,6 +52,7 @@ KOBO_POWER_OFF_SOURCES = \
 	$(SRC)/Hardware/RotateDisplay.cpp \
 	$(SRC)/Hardware/DisplayDPI.cpp \
 	$(SRC)/Hardware/DisplaySize.cpp \
+	$(SRC)/Hardware/Battery.cpp \
 	$(SRC)/Screen/Layout.cpp \
 	$(SRC)/Logger/FlightParser.cpp \
 	$(SRC)/Renderer/FlightListRenderer.cpp \

--- a/src/Kobo/PowerOff.cpp
+++ b/src/Kobo/PowerOff.cpp
@@ -37,6 +37,8 @@ Copyright_License {
 #include "io/FileLineReader.hpp"
 #include "Resources.hpp"
 #include "Model.hpp"
+#include "Hardware/Battery.hpp"
+#include "Hardware/PowerInfo.hpp"
 
 #include <algorithm>
 #include <stdexcept>
@@ -84,10 +86,14 @@ DrawBanner(Canvas &canvas, PixelRect &rc)
   canvas.DrawText({x, rc.top + int(banner_height - normal_font.GetHeight()) / 2},
                   website);
 
-  const TCHAR *const comment = _T("powered off");
-  canvas.DrawText({rc.right - (int)canvas.CalcTextWidth(comment) - padding, rc.top + padding},
-                  comment);
+  TCHAR comment[30] = _T("powered off");   
+  const auto power_info = Power::GetInfo();
+  if (power_info.battery.remaining_percent) {
+    snprintf ( comment+strlen(comment), 30-strlen(comment), _T(" - battery %d%%"), *power_info.battery.remaining_percent);  
+  }
 
+  canvas.DrawText({rc.right - (int)canvas.CalcTextWidth(comment) - padding, rc.top + padding},
+                          comment);
   rc.top += banner_height + 8;
 }
 


### PR DESCRIPTION
…el at the time the Kobo was shut down

<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
I added a small indicator in the top right corner of the power off screen to show at a glance how much battery the Kobo had when shut down, so one can make his considerations in order to see if recharging is needed without the hassle of turning it on and launching XCSoar.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
kinda closes issue #457 

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
