### PR TITLE
map: ability to show the short name of waypoints

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,7 @@ Version 7.19 - not yet released
   - fix crash bug in terrain loader
   - support short name in CUP files
   - search waypoints via short name
+  - ability to display short name on map
 * user interface
   - consistent progress bar during startup
 * Android

--- a/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
@@ -97,6 +97,9 @@ WaypointDisplayConfigPanel::Prepare(ContainerWindow &parent,
       N_("The first 5 letters of the waypoint name are displayed.") },
     { (unsigned)WaypointRendererSettings::DisplayTextType::NONE,
       N_("None"), N_("No waypoint name is displayed.") },
+    { (unsigned)WaypointRendererSettings::DisplayTextType::SHORT_NAME,
+      N_("Short Name"),
+      N_("The short name of each waypoint is displayed. If unavailable, the first five letters of the full name are displayed.") },
     { 0 }
   };
   AddEnum(_("Label format"), _("Determines how labels are displayed with each waypoint"),

--- a/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
@@ -70,6 +70,13 @@ static constexpr StaticEnumChoice waypoint_types[] = {
   { 0, N_("Turnpoint"), nullptr },
   { 1, N_("Airport"), nullptr },
   { 2, N_("Landable"), nullptr },
+  { 3, N_("Mountain Pass"), nullptr },
+  { 4, N_("Mountain Top"), nullptr },
+  { 5, N_("Transmitter Mast"), nullptr },
+  { 6, N_("Tower"), nullptr },
+  { 7, N_("Tunnel"), nullptr },
+  { 8, N_("Bridge"), nullptr },
+  { 9, N_("Power Plant"), nullptr },
   { 0 }
 };
 
@@ -112,6 +119,34 @@ WaypointEditWidget::Save(bool &_changed) noexcept
 
   case 2:
     value.type = Waypoint::Type::OUTLANDING;
+    break;
+
+  case 3:
+    value.type = Waypoint::Type::MOUNTAIN_PASS;
+    break;
+
+  case 4:
+    value.type = Waypoint::Type::MOUNTAIN_TOP;
+    break;
+
+  case 5:
+    value.type = Waypoint::Type::OBSTACLE;
+    break;
+
+  case 6:
+    value.type = Waypoint::Type::TOWER;
+    break;
+
+  case 7:
+    value.type = Waypoint::Type::TUNNEL;
+    break;
+
+  case 8:
+    value.type = Waypoint::Type::BRIDGE;
+    break;
+
+  case 9:
+    value.type = Waypoint::Type::POWERPLANT;
     break;
 
   default:

--- a/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
@@ -36,6 +36,7 @@ Copyright_License {
 class WaypointEditWidget final : public RowFormWidget, DataFieldListener {
   enum Rows {
     NAME,
+    SHORTNAME,
     COMMENT,
     LOCATION,
     ELEVATION,
@@ -77,6 +78,7 @@ WaypointEditWidget::Prepare(gcc_unused ContainerWindow &parent,
                             gcc_unused const PixelRect &rc) noexcept
 {
   AddText(_("Name"), nullptr, value.name.c_str(), this);
+  AddText(_("Short Name"), nullptr, value.shortname.c_str(), this);
   AddText(_("Comment"), nullptr, value.comment.c_str(), this);
   Add(_("Location"), nullptr,
       new GeoPointDataField(value.location,
@@ -96,6 +98,7 @@ WaypointEditWidget::Save(bool &_changed) noexcept
 {
   bool changed = modified;
   value.name = GetValueString(NAME);
+  value.shortname = GetValueString(SHORTNAME);
   value.comment = GetValueString(COMMENT);
   value.location = ((GeoPointDataField &)GetDataField(LOCATION)).GetValue();
   changed |= SaveValue(ELEVATION, UnitGroup::ALTITUDE, value.elevation);

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -214,6 +214,13 @@ protected:
         tmp[0] = '\0';
       break;
 
+    case WaypointRendererSettings::DisplayTextType::SHORT_NAME:
+      if (!way_point.shortname.empty())
+        CopyTruncateString(buffer, buffer_size, way_point.shortname.c_str());
+      else
+        CopyTruncateString(buffer, buffer_size, way_point.name.c_str(), 5);
+      break;
+
     case WaypointRendererSettings::DisplayTextType::OBSOLETE_DONT_USE_NUMBER:
     case WaypointRendererSettings::DisplayTextType::OBSOLETE_DONT_USE_NAMEIFINTASK:
       assert(false);

--- a/src/Renderer/WaypointRendererSettings.hpp
+++ b/src/Renderer/WaypointRendererSettings.hpp
@@ -38,6 +38,7 @@ struct WaypointRendererSettings {
     FIRST_THREE,
     OBSOLETE_DONT_USE_NAMEIFINTASK,
     FIRST_WORD,
+    SHORT_NAME,
   } display_text_type;
 
   /** Which arrival height to display next to waypoint labels */

--- a/src/Waypoint/CupWriter.cpp
+++ b/src/Waypoint/CupWriter.cpp
@@ -112,8 +112,10 @@ WriteCup(BufferedOutputStream &writer, const Waypoint &wp)
   writer.Write('"');
   writer.Write(',');
 
-  // Write Code
-  writer.Write(',');
+  // Write Code / Short Name
+  writer.Write('"');
+  writer.Write(wp.shortname.c_str());
+  writer.Write('"');
 
   // Write Country
   writer.Write(',');


### PR DESCRIPTION
Makes the short name selectable in the lables setting. If unavailable fall back to 5 letters of the full name.