### PR TITLE
WaypointListBuilder: Ensure uniqueness of waypoints in dialogs

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.20 - not yet released
+*user interace
+ - ensure uniqueness in waypoint picker
 
 Version 7.19 - 2021/10/01
 * data files

--- a/src/Waypoint/WaypointListBuilder.cpp
+++ b/src/Waypoint/WaypointListBuilder.cpp
@@ -39,5 +39,12 @@ inline void
 WaypointListBuilder::operator()(const WaypointPtr &waypoint) noexcept
 {
   if (filter.Matches(*waypoint, location, triangle_validator))
-    list.emplace_back(waypoint);
+    {
+        for (const auto &w: list)
+          {
+            if (w.waypoint==waypoint)
+		return;
+          }
+      list.emplace_back(waypoint);
+    }
 }


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->
Ensure waypoint uniqueness in dialogs.
With both shortname and name in the tree, it could be returned twice.

Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
