### PR TITLE
Dialogs/Waypoint: Return to waypoint list after closing waypoint details

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 7.21 - not yet released
 * data files
   - Support for AF/AR frequency fields in OpenAir 
+* user interface
+  - new input event allows returning to waypoint list from waypoint details.
 
 Version 7.20 - 2021/10/22
 * map

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -35,6 +35,8 @@ WaypointPtr
 ShowWaypointListDialog(const GeoPoint &location,
                        OrderedTask *ordered_task = nullptr,
                        unsigned ordered_task_index = 0);
+void 
+ShowWaypointListPersistentDialog(const GeoPoint &location);
 
 void
 dlgConfigWaypointsShowModal();

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -185,6 +185,7 @@ void eventTaskTransition(const TCHAR *misc);
 void eventTerrainTopography(const TCHAR *misc);
 void eventTerrainTopology(const TCHAR *misc);
 void eventWaypointDetails(const TCHAR *misc);
+void eventWaypointDetailsPersistent(const TCHAR *misc);
 void eventWaypointEditor(const TCHAR *misc);
 void eventZoom(const TCHAR *misc);
 void eventBrightness(const TCHAR *misc);

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -392,6 +392,17 @@ InputEvents::eventWaypointDetails(const TCHAR *misc)
                                 allow_navigation, allow_edit);
 }
 
+// WaypointDetailsPersistent
+// Similar to WaypointDetails, but returns to the Waypoint List 
+// when the Waypoint Details page is closed rather than returning
+// to the main view.
+void
+InputEvents::eventWaypointDetailsPersistent(gcc_unused const TCHAR *misc)
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  ShowWaypointListPersistentDialog(basic.location);
+}
+
 void
 InputEvents::eventWaypointEditor(const TCHAR *misc)
 {


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Adds a new waypoint list dialog that remains open after closing waypoint details.
New dialog is accessible through the input events. Add the following to a .xci file to override the defaults:
____________________________
mode=default
type=gesture
data=DR
event=WaypointDetailsPersistent

mode=Nav1
type=key
data=9
event=WaypointDetailsPersistent
event=Mode default
label=Waypoint\nList$(CheckWaypointFile)
location=8
____________________________
Related issues and discussions
------------------------------
Closes #620 

