### PR TITLE
Update AirspaceParser.cpp

### DIFF
--- a/src/Airspace/AirspaceParser.cpp
+++ b/src/Airspace/AirspaceParser.cpp
@@ -608,8 +608,11 @@ ParseLine(Airspaces &airspace_database, StringParser<TCHAR> &&input,
         ReadAltitude(input, temp_area.top);
       break;
 
+    /** 'AR 999.999 or 'AF 999.999' in accordance with the Naviter change proposed in 2018 - (Find 'Additional OpenAir fields' here) http://www.winpilot.com/UsersGuide/UserAirspace.asp **/
     case _T('R'):
     case _T('r'):
+    case _T('F'):
+    case _T('f'):
       if (input.SkipWhitespace())
         temp_area.radio = input.c_str();
       break;


### PR DESCRIPTION
---Request for harmonization of codes---
Since 2018, Naviter proposes the following change 'AF 999.999' for Frequency field - (Find 'Additional OpenAir fields' here) - http://www.winpilot.com/UsersGuide/UserAirspace.asp
I understand the evolution of XCsoar which has just added the new 'AR' tag for the same need.
Pending a possible harmonization of approaches; I propose to treat the 2 cases simultaneously - 'AR 999.999 or 'AF 999.999'
Note: To date, it is a shame to have to create 2 different Openair files to adapt to different devices! (search for 'LK8000' or 'XCsoar' - https://xcaustralia.org/download/other.php


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
