### PR TITLE
[Draft] Update lua.rst

### DIFF
--- a/doc/lua.rst
+++ b/doc/lua.rst
@@ -669,7 +669,7 @@ The following methods are available in ``xcsoar.timer``:
 HTTP Client
 -----------
 
-The class ``xcsoar.http.Request`` can be used to send HTTP requests.
+The class ``xcsoar.http.Request`` can be used to send HTTP and/or HTTPS requests.
 
 .. code-block:: lua
 


### PR DESCRIPTION
This part of the documentation explains that Lua can be used with XCSoar to perform HTTP request.

I think it's supporting both HTTP and HTTPS requests as you rely on libcurl (but I may be wrong)

This can be quite misleading when knowing a bit Lua because to perform HTTP request we can use for example

    local http = require("socket.http")
    local body, code, headers, status = http.request(url)

and to perform HTTPS request

    local https = require("ssl.https")
    local body, code, headers, status = https.request(url)


"Pure" Lua script using `socket.http` will perform an HTTP request... even if the url looks like https://... (secured url)

In your example same content is available at https://download.xcsoar.org/repository and http://download.xcsoar.org/repository so that's not a big problem but that's not the case for example for

https://www.sia.aviation-civile.gouv.fr/dvd/eAIP_07_OCT_2021/Atlas-VAC/PDF_AIPparSSection/VAC/AD/AD-2.LFBI.pdf

and

http://www.sia.aviation-civile.gouv.fr/dvd/eAIP_07_OCT_2021/Atlas-VAC/PDF_AIPparSSection/VAC/AD/AD-2.LFBI.pdf

the second URL will in fact first output an HTML page with a redirect