### PR TITLE
XCVario driver: Fix unprecise ballast sync from XCS and move to GetHectoPascal()

### DIFF
--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -167,7 +167,7 @@ XVCDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 {
   /* the XCVario understands "!g,q<NNNN>" command for QNH updates with recent builds */
   char buffer[32];
-  unsigned qnh = uround(pres.GetPascal()/100);
+  unsigned qnh = uround(pres.GetHectoPascal());
   int msg_len = sprintf(buffer,"!g,q%u\r", std::min(qnh,(unsigned)2000));
   return port.FullWrite(buffer, msg_len, env, std::chrono::seconds(2) );
 }
@@ -196,10 +196,12 @@ bool
 XVCDevice::PutBallast(double fraction, gcc_unused double overload,
                       OperationEnvironment &env)
 {
-  /* the XCVario understands the CAI302 "!g" command for
-     MacCready, ballast and bugs */
-
-  return CAI302::PutBallast(port, fraction, env);
+  /* the XCVario understands CAI302 like command for ballast "!g,b" with
+     float precision */
+   char buffer[32];
+   float ballast = fraction * 10.;
+   int msg_len = sprintf(buffer,"!g,b%.3f\r", ballast );
+   return port.FullWrite(buffer, msg_len, env, std::chrono::seconds(2) );
 }
 
 static Device *

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -199,7 +199,7 @@ XVCDevice::PutBallast(double fraction, gcc_unused double overload,
   /* the XCVario understands CAI302 like command for ballast "!g,b" with
      float precision */
    char buffer[32];
-   float ballast = fraction * 10.;
+   double ballast = fraction * 10.;
    int msg_len = sprintf(buffer,"!g,b%.3f\r", ballast );
    return port.FullWrite(buffer, msg_len, env, std::chrono::seconds(2) );
 }


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Handle ballast change locally in XCVario driver instead from CAI302 inherited method by a float with 3 decimals precision instead of integer with fractions of 10% in order to see exactly same ballast on both sides.

Related issues and discussions
------------------------------
Historically the Cambride devices cannot provide more precision as fractions of 10% from max ballast, as of hardware limitation of input device. This limitation does not apply for XCVario, and there is no reason for this granularity when XCS is the source of info, correctly noted by the filed issue from @hjr. Hence the issue opened for XCVario needs a changed here, XCVario already covers parsing float precision, and has been successfully tested with this change in XCSoar. 
https://github.com/iltis42/XCVario/issues/74
