### PR TITLE
Fix inverted cruise/circling mode in Borgelt and XCVario protocol

### DIFF
--- a/src/Device/Driver/BorgeltB50.cpp
+++ b/src/Device/Driver/BorgeltB50.cpp
@@ -104,11 +104,11 @@ PBB50(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
   }
 

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -102,11 +102,11 @@ PXCV(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
   }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -353,7 +353,7 @@ TestBorgeltB50()
   ok1(equals(nmea_info.settings.bugs, 0.9));
   ok1(nmea_info.settings.ballast_overload_available);
   ok1(equals(nmea_info.settings.ballast_overload, 1.3));
-  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CIRCLING);
+  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CRUISE);
   ok1(nmea_info.temperature_available);
   ok1(equals(nmea_info.temperature.ToKelvin(), 245.15));
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Invert Cruise/Circling mode in NMEA parsing of Borgelt B50 driver and same issue in XCVario code that took over wrong logic from there.

Related issues and discussions
------------------------------
Actually the Cruise Mode is transmitted as a "1" in the corresponding bit in native Borgelt B50 protocol, even the comment in the code indicates this, hence the parsing in the corresponding driver does exactly vice and CIRCLING is chosen once there is a one reading in the 'G' field for cruise, indicated by a circling arrow in the Vario gauge in XCSoar. 

See here the manual from B50, and also the  
// inclimb/incruise 1=cruise,0=climb, OAT
comment in the source file which also says 1=cruise.

B50 Manual (see last page):
https://www.google.com/url?sa=t&rct=j&q=&esrc=s&source=web&cd=&ved=2ahUKEwiZuIGl8YH0AhVGqaQKHVX5CUsQFnoECAgQAQ&url=http%3A%2F%2Fwww.borgeltinstruments.com%2FB50man.pdf&usg=AOvVaw1SGtyWW7LyiW7bRSWJBlM7


