### PR TITLE
Fix startup for Clara

### DIFF
--- a/kobo/rcS
+++ b/kobo/rcS
@@ -80,6 +80,11 @@ echo "dc 0" > /sys/devices/platform/pmic_light.1/lit
 echo '/mnt/onboard/XCSoarData/crash/core.%p' >/proc/sys/kernel/core_pattern
 ulimit -c unlimited
 
+# workaround for Kobo Clara HD: the touch screen doesn't respond
+# and the initial screen render is blank if we are too fast
+# delay should not cause any problem and might help other models
+usleep 100000
+
 # launch user script
 if [ -f /mnt/onboard/XCSoarData/kobo/init.sh ]; then
     source /mnt/onboard/XCSoarData/kobo/init.sh


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
This adds a 0.1s delay in rcS file for Kobo to allow touch screen and display to initialize properly.  This was specifically tested for Clara HD (N249) but other models have had similar problems (blank screen on startup or touch not active) and those models may now work better.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
#611
#317
#515 (maybe, not tested by me)
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
