### PR TITLE
Allign box nomenclature for Wind info boxes.

### DIFF
--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -159,14 +159,14 @@ lift distribution over each part of the circle.}
 with the connected InfoBox dialogue. Pressing the up/down cursor keys to cycle through 
 settings, adjust the values with left/right cursor keys.}
 {figures/infobox-dialog-wind1.png}
-\ibi{Wind bearing}{Wind Brng}{Wind bearing estimated by XCSoar. Adjustable in the same 
+\ibi{Wind bearing}{Wind}{Wind bearing incl. wind speed, estimated by XCSoar. Adjustable in the same 
 manner as Wind arrow.}
-\ibi{Wind speed}{Wind V}{Wind speed estimated by XCSoar. Adjustable in the same 
+\ibi{Wind speed}{Wind}{Wind speed incl. wind direction, estimated by XCSoar. Adjustable in the same 
 manner as Wind arrow.}
-\ibi{Head wind component}{Head Wind}{The current head wind component. Head wind 
+\ibi{Wind, head component}{Head Wind}{The current head wind component. Head wind 
 is calculated from TAS and GPS ground speed if airspeed is available from 
 external device. Otherwise the estimated wind is used for the calculation.}
-\ibi{Head wind component (simplified)}{Head Wind *}{The current head wind component. % TODO wat?
+\ibi{Wind, head component (simplified)}{Head Wind *}{The current head wind component. 
 The simplified head wind is calculated by subtracting GPS ground speed from the TAS if 
 airspeed is available from external device.}
 \ibi{Outside air temperature}{OAT}{Outside air temperature measured by a probe

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -339,7 +339,7 @@ static constexpr MetaData meta_data[] = {
   // e_WindSpeed_Est
   {
     N_("Wind speed"),
-    N_("Wind V"),
+    N_("Wind"),
     N_("Wind speed estimated by XCSoar. Manual adjustment is possible with the connected InfoBox dialogue. Pressing the up/down cursor keys to cycle through settings, adjust the values with left/right cursor keys."),
     UpdateInfoBoxWindSpeed,
     wind_infobox_panels,
@@ -348,7 +348,7 @@ static constexpr MetaData meta_data[] = {
   // e_WindBearing_Est
   {
     N_("Wind bearing"),
-    N_("Wind Brng"),
+    N_("Wind"),
     N_("Wind bearing estimated by XCSoar. Manual adjustment is possible with the connected InfoBox dialogue. Pressing the up/down cursor keys to cycle through settings, adjust the values with left/right cursor keys."),
     UpdateInfoBoxWindBearing,
     wind_infobox_panels,
@@ -885,7 +885,7 @@ static constexpr MetaData meta_data[] = {
 
   // e_HeadWind
   {
-    N_("Head wind component"),
+    N_("Wind, head component"),
     N_("Head Wind"),
     N_("The current head wind component. Head wind is calculated from TAS and GPS ground speed if airspeed is available from external device. Otherwise the estimated wind is used for the calculation."),
     UpdateInfoBoxHeadWind,
@@ -918,7 +918,7 @@ static constexpr MetaData meta_data[] = {
 
   // HeadWindSimplified
   {
-    N_("Head wind component (simplified)"),
+    N_("Wind, head component (simplified)"),
     N_("Head Wind *"),
     N_("The current head wind component. The simplified head wind is calculated by subtracting GPS ground speed from the TAS if airspeed is available from external device."),
     UpdateInfoBoxHeadWindSimplified,


### PR DESCRIPTION
Followed suggestions from glider buddies not understanding the "Wind V", or "V Wind" headline in the box. 

Renaming the info box long names so that all wind related boxes group together.
