### PR TITLE
Add CLARA_HD to list of Kobos

### DIFF
--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -87,6 +87,7 @@ GetDPI()
 #ifdef KOBO
   switch (DetectKoboModel()) {
   case KoboModel::GLO_HD:
+  case KoboModel::CLARA_HD:
     return 300;
 
   case KoboModel::TOUCH2:

--- a/src/Kobo/Model.cpp
+++ b/src/Kobo/Model.cpp
@@ -64,6 +64,7 @@ static constexpr struct {
   { "SN-R13A5", KoboModel::GLO },
   { "SN-N437", KoboModel::GLO_HD },
   { "SN-RN437", KoboModel::GLO_HD },
+  { "SN-N249", KoboModel::CLARA_HD },
   { "SN-N306", KoboModel::NIA },
 };
 

--- a/src/Kobo/Model.hpp
+++ b/src/Kobo/Model.hpp
@@ -35,6 +35,7 @@ enum class KoboModel {
   AURA2,
   GLO,
   GLO_HD,
+  CLARA_HD,
   NIA,
 };
 

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -195,6 +195,7 @@ TopCanvas::Create(PixelSize new_size,
   case KoboModel::TOUCH2:
   case KoboModel::GLO_HD:
   case KoboModel::AURA2:
+  case KoboModel::CLARA_HD:
     frame_sync = true;
     break;
 
@@ -302,7 +303,8 @@ TopCanvas::Flip()
              (/* use A2 mode only on some Kobo models */
               DetectKoboModel() == KoboModel::TOUCH2 ||
               DetectKoboModel() == KoboModel::GLO_HD ||
-              DetectKoboModel() == KoboModel::AURA2)
+              DetectKoboModel() == KoboModel::AURA2 ||
+              DetectKoboModel() == KoboModel::CLARA_HD)
              ? WAVEFORM_MODE_A2
              : WAVEFORM_MODE_AUTO),
     UPDATE_MODE_FULL, // PARTIAL


### PR DESCRIPTION
Customized for CLARA_HD the following:
DPI, battery status, poweroff(), Wifi, Export USB,
frame_sync and reboot.  rcS was previously customized.
All else is common to all Kobo models and was left unchanged.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
For each instance of model specific code, CLARA_HD was added as appropriate
following the coding style of the particular source file.  All changes were made
to leave other models unaffected and the changes were tested on a Clara HD 
successfully.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
No current issue is addressed but this adds one common model of Kobo and
provides functionality that was missing.

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
