### PR TITLE
Disable OTG for Clara HD and update NEWS

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,7 +4,7 @@ Version 7.21 - not yet released
 * devices
   - fix inverted cruise/circling mode in borgelt and xcvario driver
 * Kobo
-  - fix Clara HD touch screen
+  - Add support for Clara HD
 * Android
   - re-enable background location and comply with Google Play Store policy
 

--- a/src/Kobo/SystemDialog.cpp
+++ b/src/Kobo/SystemDialog.cpp
@@ -58,7 +58,9 @@ SystemWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   AddButton("Reboot", [](){ KoboReboot(); });
   AddButton(IsKoboOTGKernel() ? "Disable USB-OTG" : "Enable USB-OTG",
             [this](){ SwitchKernel(); });
-
+#ifdef KOBO
+  SetRowEnabled(SWITCH_KERNEL, DetectKoboModel() != KoboModel::CLARA_HD);
+#endif
   AddButton("Export USB storage", [this](){ ExportUSBStorage(); });
   SetRowEnabled(USB_STORAGE, !IsKoboOTGKernel());
 }


### PR DESCRIPTION
Disable OTG for Clara HD to avoid bricking the unit since the kernel is not compatible

<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
