### PR TITLE
Screen/Layout: increase padding for text boxes

### DIFF
--- a/src/Screen/Layout.cpp
+++ b/src/Screen/Layout.cpp
@@ -115,7 +115,7 @@ Layout::Initialize(PixelSize new_size, unsigned ui_scale, unsigned custom_dpi) n
        the viewing distance is usually smaller */
     font_scale = font_scale * 2 / 3;
 
-  text_padding = VptScale(2);
+  text_padding = VptScale(4);
 
   minimum_control_height = std::min(FontScale(23),
                                     min_screen_pixels / 12);


### PR DESCRIPTION
The padding is quite compressed in the current version:
![2021-12-09-202708_640x480_scrot](https://user-images.githubusercontent.com/407371/145463359-e8b4616c-1549-4c44-be4f-446c872cd971.png)

This change improves the layout:
![2021-12-09-202602_640x480_scrot](https://user-images.githubusercontent.com/407371/145463329-44554bc5-ef39-4f0a-89d0-c6e55bc9d850.png)