### PR TITLE
Control backlight brightness of the Kobo Glo HD in the system dialog

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,7 @@ Version 7.21 - not yet released
   - fix inverted cruise/circling mode in borgelt and xcvario driver
 * Kobo
   - Add support for Clara HD
+  - Control backlight brightness of the Kobo Glo HD
 * Android
   - re-enable background location and comply with Google Play Store policy
 

--- a/src/Kobo/SystemDialog.cpp
+++ b/src/Kobo/SystemDialog.cpp
@@ -38,7 +38,12 @@ class SystemWidget final
     REBOOT,
     SWITCH_KERNEL,
     USB_STORAGE,
+    INCREASE_BACKLIGHT_BRIGHTNESS,
+    DECREASE_BACKLIGHT_BRIGHTNESS
   };
+
+  Button *increase_backlight_brightness;
+  Button *decrease_backlight_brightness;
 
 public:
   SystemWidget(const DialogLook &look):RowFormWidget(look) {}
@@ -46,6 +51,9 @@ public:
 private:
   void SwitchKernel();
   void ExportUSBStorage();
+  void IncreaseBacklightBrightness();
+  void DecreaseBacklightBrightness();
+  void UpdateBacklightButtons(int percent);
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent,
@@ -63,6 +71,16 @@ SystemWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 #endif
   AddButton("Export USB storage", [this](){ ExportUSBStorage(); });
   SetRowEnabled(USB_STORAGE, !IsKoboOTGKernel());
+
+  if(KoboCanChangeBacklightBrightness()) {
+    increase_backlight_brightness = AddButton("Increase Backlight Brightness", [this]() { IncreaseBacklightBrightness(); });
+    decrease_backlight_brightness = AddButton("Decrease Backlight Brightness", [this]() { DecreaseBacklightBrightness(); });
+    int current_brightness = KoboGetBacklightBrightness();
+    UpdateBacklightButtons(current_brightness);
+  } else {
+    AddDummy();
+    AddDummy();
+  }
 }
 
 inline void
@@ -133,6 +151,33 @@ SystemWidget::ExportUSBStorage()
 
   KoboUnexportUSBStorage();
   KoboMountData();
+}
+
+inline void
+SystemWidget::IncreaseBacklightBrightness()
+{
+  int current_brightness = KoboGetBacklightBrightness();
+  KoboSetBacklightBrightness(current_brightness + 20);
+  UpdateBacklightButtons(current_brightness + 20);
+}
+
+inline void
+SystemWidget::DecreaseBacklightBrightness()
+{
+  int current_brightness = KoboGetBacklightBrightness();
+  KoboSetBacklightBrightness(current_brightness - 20);
+  UpdateBacklightButtons(current_brightness - 20);
+}
+
+inline void
+SystemWidget::UpdateBacklightButtons(int percent)
+{
+  if(decrease_backlight_brightness != nullptr) {
+    decrease_backlight_brightness->SetEnabled(percent != 0);
+  }
+  if(increase_backlight_brightness != nullptr) {
+    increase_backlight_brightness->SetEnabled(percent < 100);
+  }
 }
 
 void


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->

Enable and control the backlight of a Kobo Glo HD from the system dialog.


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
