### PR TITLE
Amend FLARM device task declaration to use waypoint Short Name instead of index

### DIFF
--- a/src/Device/Declaration.hpp
+++ b/src/Device/Declaration.hpp
@@ -85,6 +85,11 @@ struct Declaration {
     return turnpoints[i].waypoint.name.c_str();
   }
 
+  gcc_pure
+  const TCHAR *GetShortName(const unsigned i) const {
+    return turnpoints[i].waypoint.shortname.c_str();
+  }
+
   const GeoPoint &GetLocation(const unsigned i) const {
     return turnpoints[i].waypoint.location;
   }

--- a/src/Device/Driver/FLARM/Declare.cpp
+++ b/src/Device/Driver/FLARM/Declare.cpp
@@ -24,6 +24,8 @@ Copyright_License {
 #include "Device.hpp"
 #include "Device/Declaration.hpp"
 #include "Operation/Operation.hpp"
+#include "util/ConvertString.hpp"
+#include "TextProtocol.hpp"
 
 bool
 FlarmDevice::Declare(const Declaration &declaration,
@@ -106,18 +108,24 @@ FlarmDevice::DeclareInternal(const Declaration &declaration,
     MinLon = (tmp - DegLon) * 60 * 1000;
 
     /*
-     * We use the waypoint index here as name to get around the 192 byte
-     * task size limit of the FLARM devices.
-     *
-     * see Flarm DataPort Manual:
+     * FLARM task declaration is limited to 192 bytes
+     * See Flarm DataPort Manual:
      * "The total data size entered through this command may not surpass
      * 192 bytes when calculated as follows: 7+(Number of Waypoints * 9) +
      * (sum of length of all task and waypoint descriptions)"
+     *
+     * In addition, FLARM devices will not accept a declaration of more than
+     * 10 waypoints (excluding takeoff and landing)
+     *
+     * This means we can use the <= 6 character short name in the waypoint declaration
+     * without hitting the 192 byte limit.
      */
     NarrowString<90> buffer;
-    buffer.Format("%02d%05.0f%c,%03d%05.0f%c,%d",
-                  DegLat, (double)MinLat, NoS,
-                  DegLon, (double)MinLon, EoW, i + 1);
+	const WideToUTF8Converter shortName(declaration.GetShortName(i));
+	buffer.Format("%02d%05.0f%c,%03d%05.0f%c,",
+			  DegLat, (double)MinLat, NoS,
+			  DegLon, (double)MinLon, EoW);
+	CopyCleanFlarmString(buffer.buffer() + buffer.length(), shortName, 6);
 
     if (!SetConfig("ADDWP", buffer, env))
       return false;

--- a/src/Device/Driver/FLARM/Declare.cpp
+++ b/src/Device/Driver/FLARM/Declare.cpp
@@ -119,6 +119,9 @@ FlarmDevice::DeclareInternal(const Declaration &declaration,
      *
      * This means we can use the <= 6 character short name in the waypoint declaration
      * without hitting the 192 byte limit.
+     * Wouldn't expect to see a short name > 6 characters, but the optional 3rd
+     * parameter of CopyCleanFlarmString() allows us to trim off excess characters
+     * so that a dodgy waypoint configuration doesn't cause an overflow.
      */
     NarrowString<90> buffer;
 	const WideToUTF8Converter shortName(declaration.GetShortName(i));

--- a/src/Device/Driver/FLARM/TextProtocol.cpp
+++ b/src/Device/Driver/FLARM/TextProtocol.cpp
@@ -43,10 +43,10 @@ IsForbiddenFlarmChar(unsigned char ch)
 }
 
 char *
-CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, int nChars)
+CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, std::size_t maxBytes)
 {
-  int i=0;
-  while (nChars == 0 || i < nChars) {
+  std::size_t i=0;
+  while (maxBytes == 0 || i < maxBytes) {
     char ch = *src++;
     if (ch == 0)
       break;

--- a/src/Device/Driver/FLARM/TextProtocol.cpp
+++ b/src/Device/Driver/FLARM/TextProtocol.cpp
@@ -43,15 +43,18 @@ IsForbiddenFlarmChar(unsigned char ch)
 }
 
 char *
-CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src)
+CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, int nChars)
 {
-  while (true) {
+  int i=0;
+  while (nChars == 0 || i < nChars) {
     char ch = *src++;
     if (ch == 0)
       break;
 
-    if (!IsForbiddenFlarmChar(ch))
+    if (!IsForbiddenFlarmChar(ch)) {
       *dest++ = ch;
+      i++;
+    }
   }
 
   *dest = 0;

--- a/src/Device/Driver/FLARM/TextProtocol.hpp
+++ b/src/Device/Driver/FLARM/TextProtocol.hpp
@@ -33,6 +33,6 @@ Copyright_License {
  * (worst-case).
  */
 char *
-CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src);
+CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, int nChars = 0);
 
 #endif

--- a/src/Device/Driver/FLARM/TextProtocol.hpp
+++ b/src/Device/Driver/FLARM/TextProtocol.hpp
@@ -26,13 +26,17 @@ Copyright_License {
 
 #include "util/Compiler.h"
 
+#include <cstddef>
+
 /**
  * Copy a string, ignoring all characters that are illegal in a
  * setting value.  There is no buffer overflow check; the destination
  * buffer must be large enough to fit all of the source string
  * (worst-case).
+ * If maxBytes > 0, copy no more than maxBytes bytes (excluding null terminator)
+ * If maxBytes == 0, copy full string (excluding illegal characters)
  */
 char *
-CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, int nChars = 0);
+CopyCleanFlarmString(char *gcc_restrict dest, const char *gcc_restrict src, std::size_t maxBytes = 0);
 
 #endif


### PR DESCRIPTION
Allows up to 10 turnpoints per task (which is the same as the limit was previously, and the maximum a FLARM device will accept).