### PR TITLE
Revert "Fix inverted cruise/circling mode in Borgelt and XCVario protocol"

### DIFF
--- a/src/Device/Driver/BorgeltB50.cpp
+++ b/src/Device/Driver/BorgeltB50.cpp
@@ -104,11 +104,11 @@ PBB50(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
   }
 

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -102,11 +102,11 @@ PXCV(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
   }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -353,7 +353,7 @@ TestBorgeltB50()
   ok1(equals(nmea_info.settings.bugs, 0.9));
   ok1(nmea_info.settings.ballast_overload_available);
   ok1(equals(nmea_info.settings.ballast_overload, 1.3));
-  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CRUISE);
+  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CIRCLING);
   ok1(nmea_info.temperature_available);
   ok1(equals(nmea_info.temperature.ToKelvin(), 245.15));
 


### PR DESCRIPTION
Reverts XCSoar/XCSoar#774 according to a discussion in https://github.com/XCSoar/XCSoar/issues/812 the documentation is inverted to the actual behavior. 