### PR TITLE
Add 3x6 InfoBox layout

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,8 @@ Version 7.22 - not yet released
   - add DG-800S
 * devices
   - FLARM: send turn point names in task declaration
+* user interface
+  - add 3x6 InfoBoxes layout
 * Android
   - use app-specific data directory by default
 

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -91,6 +91,8 @@ static constexpr StaticEnumChoice info_box_geometry_list[] = {
     N_("12 Split in 3 rows") },
   { (unsigned)InfoBoxSettings::Geometry::SPLIT_3X5,
     N_("15 Split in 3 rows") },
+  { (unsigned)InfoBoxSettings::Geometry::SPLIT_3X6,
+    N_("18 Split in 3 rows") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_RIGHT_8,
     N_("8 Bottom or Right") },
   { (unsigned)InfoBoxSettings::Geometry::BOTTOM_8_VARIO,

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -38,6 +38,7 @@ static constexpr unsigned char geometry_counts[] = {
   8, 16, 15, 10, 10, 10,
   12, // 3 rows X 4 boxes
   15, // 3 rows X 5 boxes
+  18, // 3 rows X 6 boxes
 };
 
 namespace InfoBoxLayout {
@@ -347,6 +348,24 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry) noexc
     }
     break;
 
+  case InfoBoxSettings::Geometry::SPLIT_3X6:
+    if (layout.landscape) {
+      rc.left = MakeLeftColumn(layout, layout.positions, 6,
+                               rc.left, rc.top, rc.bottom);
+      rc.left = MakeLeftColumn(layout, layout.positions + 6, 6,
+                               rc.left, rc.top, rc.bottom);
+      rc.right = MakeRightColumn(layout, layout.positions + 12, 6,
+                               rc.right, rc.top, rc.bottom);
+    } else {
+      rc.top = MakeTopRow(layout, layout.positions, 6,
+                          rc.left, rc.right, rc.top);
+      rc.top = MakeTopRow(layout, layout.positions + 6, 6,
+                          rc.left, rc.right, rc.top);
+      rc.bottom = MakeBottomRow(layout, layout.positions + 12, 6,
+                          rc.left, rc.right, rc.bottom);
+    }
+    break;
+
   case InfoBoxSettings::Geometry::RIGHT_16:
     rc.right = MakeRightColumn(layout, layout.positions + 8, 8,
                                rc.right, rc.top, rc.bottom);
@@ -431,6 +450,7 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
     case InfoBoxSettings::Geometry::SPLIT_10:
     case InfoBoxSettings::Geometry::SPLIT_3X4:
     case InfoBoxSettings::Geometry::SPLIT_3X5:
+    case InfoBoxSettings::Geometry::SPLIT_3X6:
     case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
     case InfoBoxSettings::Geometry::TOP_LEFT_8:
     case InfoBoxSettings::Geometry::OBSOLETE_SPLIT_8:
@@ -469,6 +489,7 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
     case InfoBoxSettings::Geometry::SPLIT_10:
     case InfoBoxSettings::Geometry::SPLIT_3X4:
     case InfoBoxSettings::Geometry::SPLIT_3X5:
+    case InfoBoxSettings::Geometry::SPLIT_3X6:
     case InfoBoxSettings::Geometry::BOTTOM_RIGHT_8:
     case InfoBoxSettings::Geometry::TOP_LEFT_8:
     case InfoBoxSettings::Geometry::OBSOLETE_SPLIT_8:
@@ -559,7 +580,8 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
 
   case InfoBoxSettings::Geometry::SPLIT_3X4:
   case InfoBoxSettings::Geometry::SPLIT_3X5:
-    if (landscape) {
+  case InfoBoxSettings::Geometry::SPLIT_3X6:
+     if (landscape) {
       layout.control_size.height = 3 * screen_size.height / layout.count;
       layout.control_size.width = CalculateInfoBoxColumnWidth(screen_size.width,
                                                               layout.control_size.height);
@@ -711,6 +733,27 @@ InfoBoxLayout::GetBorder(InfoBoxSettings::Geometry geometry, bool landscape,
         border |= BORDERTOP;
 
       if (i != 4 && i != 9 && i != 14)
+        border |= BORDERRIGHT;
+    }
+
+    break;
+
+  case InfoBoxSettings::Geometry::SPLIT_3X6:
+    if (landscape) {
+      if (i != 5 && i != 11 && i != 17)
+        border |= BORDERBOTTOM;
+
+      if (i < 12)
+        border |= BORDERRIGHT;
+      else
+        border |= BORDERLEFT;
+    } else {
+      if (i < 12)
+        border |= BORDERBOTTOM;
+      else
+        border |= BORDERTOP;
+
+      if (i != 5 && i != 11 && i != 17)
         border |= BORDERRIGHT;
     }
 

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -125,6 +125,8 @@ struct InfoBoxSettings {
     SPLIT_3X4 = 24,
     /** 15 infoboxes 3X5 split bottom/top or left/right */
     SPLIT_3X5 = 25,
+    /** 18 infoboxes 3X6 split bottom/top or left/right */
+    SPLIT_3X6 = 26,
 
   } geometry;
 

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -114,6 +114,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
   case InfoBoxSettings::Geometry::BOTTOM_8_VARIO:
   case InfoBoxSettings::Geometry::TOP_LEFT_4:
   case InfoBoxSettings::Geometry::BOTTOM_RIGHT_4:
+  case InfoBoxSettings::Geometry::SPLIT_3X6:
     break;
 
   case InfoBoxSettings::Geometry::OBSOLETE_TOP_LEFT_4:


### PR DESCRIPTION
Admittedly this is yet another hard-coded infobox layout that won't be useful to everyone, but this one is pretty useful on a 7" display (eg the 7" Openvarios, of which there are a lot around), particularly in portrait mode. Uses less screen real-estate than the existing 3x5 layout, and is easily readable on a 7" screen mounted in an instrument panel.