### PR TITLE
Split IsKoboOTGKernel into two routines

### DIFF
--- a/src/Kobo/Kernel.cpp
+++ b/src/Kobo/Kernel.cpp
@@ -22,6 +22,9 @@ Copyright_License {
 */
 
 #include "Kernel.hpp"
+#include "Model.hpp"
+
+#include "system/FileUtil.hpp"
 
 #include <stdexcept>
 
@@ -106,9 +109,13 @@ KoboInstallKernel(const char *uimage_path)
 #endif
 
 bool
-IsKoboOTGKernel()
+IsKoboCustomKernel()
 try {
 #ifdef KOBO
+  /* All Kobo except Clara HD have a factory kernel without OTG mode so
+     a custom kernel is installed for OTG. */
+  if (DetectKoboModel() == KoboModel::CLARA_HD) return false; 
+
   FileReader file(Path("/proc/config.gz"));
   GunzipReader gunzip(file);
   BufferedReader reader(gunzip);
@@ -121,5 +128,16 @@ try {
 
   return false;
 } catch (const std::runtime_error &e) {
+  return false;
+}
+
+bool
+IsKoboOTGHostMode()
+{
+#ifdef KOBO
+  if (DetectKoboModel() != KoboModel::CLARA_HD) return IsKoboCustomKernel();
+  /* for Clara HD, just test for existence of host mode file */
+  if (File::Exists(Path("/mnt/onboard/XCSoarData/kobo/OTG_Host_Active"))) return true;
+#endif
   return false;
 }

--- a/src/Kobo/Kernel.hpp
+++ b/src/Kobo/Kernel.hpp
@@ -33,10 +33,17 @@ bool
 KoboInstallKernel(const char *uimage_path);
 
 /**
- * Does the kernel that is currently running have USB-OTG support?
+ * Is the kernel that is currently running a custom one?
  */
 gcc_const
 bool
-IsKoboOTGKernel();
+IsKoboCustomKernel();
+
+/**
+ * Are we currently in OTG host mode?
+ */
+gcc_const
+bool
+IsKoboOTGHostMode();
 
 #endif

--- a/src/Kobo/KoboMenu.cpp
+++ b/src/Kobo/KoboMenu.cpp
@@ -94,7 +94,7 @@ void
 KoboMenuWidget::CreateButtons(WidgetDialog &buttons)
 {
   buttons.AddButton(("Nickel"), dialog.MakeModalResultCallback(LAUNCH_NICKEL))
-      ->SetEnabled(!IsKoboOTGKernel());
+      ->SetEnabled(!IsKoboCustomKernel());
   buttons.AddButton(("Tools"), [](){ ShowToolsDialog(); });
   buttons.AddButton(_("Network"), [](){ ShowNetworkDialog(); });
   buttons.AddButton("System", [](){ ShowSystemDialog(); });


### PR DESCRIPTION
With Clara HD, OTG host mode is no longer tied to custom kernel
so this splits IsKoboOTGKernel into IsKoboCustomKernel and
IsKoboOTGHostMode.  This doesn't change anything but sets the
stage for adding OTG to Clara HD (and any others that have OTG
in the factory kernel).


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
