### PR TITLE
DeviceDescriptor - wrong port check

### DIFF
--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -831,7 +831,7 @@ DeviceDescriptor::WriteNMEA(const char *line,
 {
   assert(line != nullptr);
 
-  if (port != nullptr)
+  if (port == nullptr)
       return false;
 
   try {


### PR DESCRIPTION
The function have to return with false if port is NOT a nullptr!

This prevents the output via the port