### PR TITLE
Add OTG to Clara HD

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,7 @@
+Version 7.23 - 
+* Kobo
+  - add OTG support (serial, sound, net) for Clara HD
+
 Version 7.22 - 2022/01/14
 * user interface
   - close the download dialog after successful download

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -97,6 +97,7 @@ $(TARGET_OUTPUT_DIR)/KoboRoot.tgz: $(XCSOAR_BIN) \
 	$(Q)if test -f $(KOBO_KERNEL_DIR)/uImage.glohd.otg; then install -m 0644 $(KOBO_KERNEL_DIR)/uImage.glohd.otg $(@D)/KoboRoot/opt/xcsoar/lib/kernel; fi
 	$(Q)if test -f $(KOBO_KERNEL_DIR)/uImage.aura2; then install -m 0644 $(KOBO_KERNEL_DIR)/uImage.aura2 $(@D)/KoboRoot/opt/xcsoar/lib/kernel; fi
 	$(Q)if test -f $(KOBO_KERNEL_DIR)/uImage.aura2.otg; then install -m 0644 $(KOBO_KERNEL_DIR)/uImage.aura2.otg $(@D)/KoboRoot/opt/xcsoar/lib/kernel; fi
+	$(Q)if test -f $(KOBO_KERNEL_DIR)/ClaraHD_OTG_Drivers.tgz; then tar -xzf $(KOBO_KERNEL_DIR)/ClaraHD_OTG_Drivers.tgz -C $(@D)/KoboRoot/opt/xcsoar/lib; fi
 	$(Q)install -m 0644 $(topdir)/kobo/inittab $(@D)/KoboRoot/etc
 	$(Q)install -m 0644 $(topdir)/kobo/udev.rules $(@D)/KoboRoot/etc/udev/rules.d/99-xcsoar.rules
 	$(Q)install -m 0644 $(BITSTREAM_VERA_FILES) $(@D)/KoboRoot/opt/xcsoar/share/fonts

--- a/kobo/rcS
+++ b/kobo/rcS
@@ -85,6 +85,35 @@ ulimit -c unlimited
 # delay should not cause any problem and might help other models
 usleep 100000
 
+# load kernel modules for ClaraHD as factory kernel is OTG
+# but missing modules.  Also put ClaraHD in the right mode
+model=`dd if=/dev/mmcblk0 bs=8 count=1 skip=64`
+if [ `expr substr $model 1 7` = SN-N249 ]; then
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/usbserial.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/aircable.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/ch341.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/cp210x.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/ftdi_sio.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/garmin_gps.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/mos7840.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/navman.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/pl2303.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/sound/core/snd-hwdep.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/sound/core/snd-rawmidi.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/sound/usb/snd-usbmidi-lib.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/sound/usb/snd-usb-audio.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/mii.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/usbnet.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/cdc_subset.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/cdc_ether.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/cdc_eem.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/cdc_ncm.ko"
+    insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/net/usb/rndis_host.ko"
+    mount -t debugfs none /sys/kernel/debug
+    if [ -f /mnt/onboard/XCSoarData/kobo/OTG_Host_Active ]; then
+        echo host >/sys/kernel/debug/ci_hdrc.0/role
+    fi
+fi
 # launch user script
 if [ -f /mnt/onboard/XCSoarData/kobo/init.sh ]; then
     source /mnt/onboard/XCSoarData/kobo/init.sh

--- a/src/Kobo/Kernel.hpp
+++ b/src/Kobo/Kernel.hpp
@@ -42,7 +42,6 @@ IsKoboCustomKernel();
 /**
  * Are we currently in OTG host mode?
  */
-gcc_const
 bool
 IsKoboOTGHostMode();
 


### PR DESCRIPTION
Added OTG support including modules for serial, sound and
networking.  Note the modules are included in the release
separately (just as are the OTG kernels for other models).
If they are absent (e.g. a local build), no failure will occur.

NOTE!!! To make this complete, a tgz file must be put on the build server
in the SAME folder as the OTG kernels already present.  Failure to
do this will NOT cause a failure, just a loss of OTG functionality for 
Clara HD.  Let me know who to send the tgz file to.  I have tested it
on my build setup.

closes #794


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
