### PR TITLE
add SoftRF Academy and ES into 'white list' of USB devices

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.23 - not yet released
+* Android
+  - add SoftRF Academy and ES into 'white list' of USB devices
 
 Version 7.22 - 2022/01/14
 * user interface

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -62,6 +62,8 @@ public class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x0403, 0x6015), // Digifly AIR (FT X-Series)
     createDevice(0x0483, 0x5740), // SoftRF Dongle
     createDevice(0x239A, 0x8029), // SoftRF Badge
+    createDevice(0x2341, 0x804d), // SoftRF Academy
+    createDevice(0x1d50, 0x6089), // SoftRF ES
 
     createDevice(0x0403, 0x6001), // FT232AM, FT232BM, FT232R FT245R,
     createDevice(0x0403, 0x6010), // FT2232D, FT2232H


### PR DESCRIPTION

Brief summary of the changes
----------------------------

add USB VID/PID pairs for SoftRF Academy and ES Editions into (Android) 'white list' of USB devices



