### PR TITLE
WeGlide step2 add dialog form before and after the upload

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -669,6 +669,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Contest/WeGlide/FlightUploadDialog.cpp \
 	$(SRC)/Dialogs/Contest/WeGlide/FlightUploadResponse.cpp \
 	$(SRC)/Cloud/weglide/UploadFlight.cpp \
+	$(SRC)/Cloud/weglide/GetJsonString.cpp \
 	$(SRC)/Tracking/SkyLines/Client.cpp \
 	$(SRC)/Tracking/SkyLines/Assemble.cpp \
 	$(SRC)/Tracking/SkyLines/Key.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -666,6 +666,7 @@ endif
 XCSOAR_SOURCES += \
 	$(SRC)/net/client/tim/Client.cpp \
 	$(SRC)/net/client/tim/Glue.cpp \
+	$(SRC)/Dialogs/Contest/WeGlide/FlightUploadDialog.cpp \
 	$(SRC)/Cloud/weglide/UploadFlight.cpp \
 	$(SRC)/Tracking/SkyLines/Client.cpp \
 	$(SRC)/Tracking/SkyLines/Assemble.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -667,6 +667,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/net/client/tim/Client.cpp \
 	$(SRC)/net/client/tim/Glue.cpp \
 	$(SRC)/Dialogs/Contest/WeGlide/FlightUploadDialog.cpp \
+	$(SRC)/Dialogs/Contest/WeGlide/FlightUploadResponse.cpp \
 	$(SRC)/Cloud/weglide/UploadFlight.cpp \
 	$(SRC)/Tracking/SkyLines/Client.cpp \
 	$(SRC)/Tracking/SkyLines/Assemble.cpp \

--- a/src/Cloud/weglide/GetJsonString.cpp
+++ b/src/Cloud/weglide/GetJsonString.cpp
@@ -1,0 +1,42 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "GetJsonString.hpp"
+#include "util/ConvertString.hpp"
+#include "Language/Language.hpp"
+
+#include <tchar.h>
+
+// Wrapper for getting converted string values of a json string
+const StaticString<0x40>
+GetJsonString(boost::json::value json_value,
+              std::string_view key) noexcept {
+  StaticString<0x40> str;
+  auto value = json_value.as_object().if_contains(key);
+  if (value != nullptr)
+    str = UTF8ToWideConverter(value->get_string().c_str());
+  else
+    str.Format(_T("'%s' %s"), UTF8ToWideConverter(key.data()).c_str(),
+               _("not found"));
+  return str;
+}

--- a/src/Cloud/weglide/GetJsonString.hpp
+++ b/src/Cloud/weglide/GetJsonString.hpp
@@ -1,0 +1,34 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+// #include <boost/json/fwd.hpp>
+#include <boost/json/value.hpp>
+#include "util/StaticString.hxx"
+
+// Wrapper for getting converted string values of a json string
+const StaticString<0x40>
+// GetJsonString(boost::json::standalone::value json_value,
+GetJsonString(boost::json::value json_value,
+              std::string_view key) noexcept;

--- a/src/Cloud/weglide/HttpResponse.hpp
+++ b/src/Cloud/weglide/HttpResponse.hpp
@@ -1,0 +1,36 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+// #include <boost/json/fwd.hpp>
+#include <boost/json/value.hpp>
+
+// namespace WeGlide {
+
+struct HttpResponse {
+  unsigned code = 0;
+  boost::json::value json_value;
+};
+
+// } // namespace WeGlide

--- a/src/Cloud/weglide/UploadFlight.hpp
+++ b/src/Cloud/weglide/UploadFlight.hpp
@@ -23,13 +23,13 @@ Copyright_License {
 
 #pragma once
 
+#include "WeGlideObjects.hpp"
 #include "co/Task.hxx"
 
 #include <boost/json/fwd.hpp>
 
 #include <cstdint>
 
-struct WeGlideSettings;
 class Path;
 class CurlGlobal;
 class ProgressListener;
@@ -37,8 +37,8 @@ class ProgressListener;
 namespace WeGlide {
 
 Co::Task<boost::json::value>
-UploadFlight(CurlGlobal &curl, const WeGlideSettings &settings,
-             uint_least32_t glider_type,
+UploadFlight(CurlGlobal &curl, const User &user,
+             uint_least32_t aircraft_id,
              Path igc_path,
              ProgressListener &progress);
 

--- a/src/Cloud/weglide/UploadFlight.hpp
+++ b/src/Cloud/weglide/UploadFlight.hpp
@@ -26,17 +26,16 @@ Copyright_License {
 #include "WeGlideObjects.hpp"
 #include "co/Task.hxx"
 
-#include <boost/json/fwd.hpp>
-
 #include <cstdint>
 
 class Path;
 class CurlGlobal;
 class ProgressListener;
+struct HttpResponse;
 
 namespace WeGlide {
 
-Co::Task<boost::json::value>
+Co::Task<HttpResponse>
 UploadFlight(CurlGlobal &curl, const User &user,
              uint_least32_t aircraft_id,
              Path igc_path,

--- a/src/Cloud/weglide/WeGlideObjects.hpp
+++ b/src/Cloud/weglide/WeGlideObjects.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "util/StaticString.hxx"
+#include "time/BrokenDate.hpp"
+
+#include <cinttypes>
+#include <tchar.h>
+
+
+namespace WeGlide {
+
+struct User {
+  uint32_t id;
+  BrokenDate birthdate;
+  StaticString<0x80> name;
+
+  constexpr bool IsValid() const noexcept
+  {
+    return id > 0;
+  }
+
+  void Clear() noexcept
+  {
+    id = 0;
+    name.clear();
+    birthdate.Clear();
+  }
+};
+// because it is used in Settings and there it has to be 'trivial' type!
+  static_assert(std::is_trivial<User>::value, "type is not trivial");
+
+struct Aircraft {
+  uint32_t id = 0;
+  StaticString<0x40> name;
+  StaticString<4> kind; // 'MG' - motor aircraft, GL - Glider...
+  StaticString<10> sc_class;
+
+  constexpr bool IsValid() const noexcept
+  {
+    return id > 0;
+  }
+  void Clear() noexcept {
+    id = 0;
+    name.clear();
+    kind.clear();
+    sc_class.clear();
+  }
+};
+
+struct Flight {
+  uint64_t flight_id = 0;
+  User user;
+  Aircraft aircraft;
+  StaticString<0x40> igc_name;
+  StaticString<0x40> scoring_date;
+  StaticString<0x40> registration;
+  StaticString<0x40> competition_id;
+
+  constexpr bool IsValid() const noexcept
+  {
+    return flight_id > 0;
+  }
+};
+
+};

--- a/src/Cloud/weglide/WeGlideSettings.cpp
+++ b/src/Cloud/weglide/WeGlideSettings.cpp
@@ -26,9 +26,7 @@ Copyright_License {
 void
 WeGlideSettings::SetDefaults() noexcept
 {
-  pilot_id = 0;
-  pilot_birthdate.Clear();
-
+  pilot.Clear();
   enabled = false;
   automatic_upload = true;  // after enabling WeGlide!
 }

--- a/src/Cloud/weglide/WeGlideSettings.hpp
+++ b/src/Cloud/weglide/WeGlideSettings.hpp
@@ -24,7 +24,7 @@ Copyright_License {
 #ifndef XCSOAR_CLOUD_WEGLIDE_WEGLIDESETTINGS_HPP
 #define XCSOAR_CLOUD_WEGLIDE_WEGLIDESETTINGS_HPP
 
-#include "time/BrokenDate.hpp"
+#include "WeGlideObjects.hpp"
 
 #include <cstdint>
 
@@ -55,10 +55,11 @@ struct WeGlideSettings {
   static constexpr char gliderlist_uri[] = "https://raw.githubusercontent.com/"
     "weglide/GliderList/master/gliderlist.csv";
 
-  uint32_t pilot_id;
-  BrokenDate pilot_birthdate;
+  WeGlide::User pilot;
 
   void SetDefaults() noexcept;
 };
+
+static_assert(std::is_trivial<WeGlideSettings>::value, "type is not trivial");
 
 #endif  // XCSOAR_CLOUD_WEGLIDE_WEGLIDESETTINGS_HPP

--- a/src/Dialogs/Contest/WeGlide/FlightUploadDialog.cpp
+++ b/src/Dialogs/Contest/WeGlide/FlightUploadDialog.cpp
@@ -1,0 +1,236 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "FlightUploadDialog.hpp"
+#include "Interface.hpp"
+#include "UIGlobals.hpp"
+#include "contest/weglide/UploadIGCFile.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Dialogs/Error.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Form/DataField/File.hpp"
+#include "Form/DataField/Date.hpp"
+#include "Language/Language.hpp"
+#include "Operation/Cancelled.hpp"
+#include "Operation/PopupOperationEnvironment.hpp"
+#include "system/FileUtil.hpp"
+#include "ui/event/KeyCode.hpp"
+#include "Widget/RowFormWidget.hpp"
+
+class UploadDialog final : public WidgetDialog {
+
+public:
+  UploadDialog(Auto style, UI::SingleWindow &parent, const DialogLook &look,
+               const TCHAR *caption, Widget *widget) noexcept
+      : WidgetDialog(style, parent, look, caption, widget) {}
+
+  // take focus setting from here, not the default!
+  void SetDefaultFocus() override {}
+
+private:
+  bool OnAnyKeyDown(unsigned key_code) override;
+};
+
+
+class UploadWidget final : public RowFormWidget, DataFieldListener {
+
+public:
+  UploadWidget(const DialogLook &look, const Path &igc_path,
+               const WeGlide::User &user_, const uint_least32_t glider_id)
+      : RowFormWidget(look), igcpath(igc_path), user(user_),
+        aircraft_id(glider_id) {}
+
+  /* virtual methods from Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
+
+  /* Getter for Widget data */
+  auto GetIGCPath() { return igcpath; }
+  auto GetUser() { return user; }
+  auto GetAircraft() { return aircraft_id; }
+
+  bool ShowUploadDialog();
+private:
+  // DataFieldIndex is the order of AddField in Prepare()!
+  enum DataFieldIndex {
+    SPACER1,
+    IGC_FILE,
+    SPACER2,
+    USER_ID,
+    USER_BIRTH,
+    AIRCRAFT_ID,
+    SPACER3
+  };
+
+  Path igcpath;
+  WeGlide::User user;
+  uint_least32_t aircraft_id;
+
+  Button *ok_button;
+  Button *cancel_button;
+  WndProperty *data_fields[5];
+
+  /* virtual methods from DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
+};
+
+bool 
+UploadWidget::SetFocus() noexcept
+{
+  bool data_ok;
+  RowFormWidget::SetFocus();
+
+  // Parse data and find 1st failure:
+  if (!File::Exists(igcpath)) {
+    data_ok = false;
+    data_fields[0]->SetFocus();
+  } else if (user.id == 0) {
+    data_ok = false;
+    data_fields[1]->SetFocus();
+  } else if (!user.birthdate.IsPlausible()) {
+    data_ok = false;
+    data_fields[2]->SetFocus();
+  } else if (aircraft_id == 0) {
+    data_ok = false;
+    data_fields[3]->SetFocus();
+  } else {
+    data_ok = true;
+    ok_button->SetFocus();  // darkblue
+  }
+
+  ok_button->SetEnabled(data_ok);  // normal or gray
+  ok_button->SetSelected(data_ok);   // lightblue
+  cancel_button->SetSelected(!data_ok);
+
+  return data_ok;
+}
+
+void 
+UploadWidget::OnModified(DataField &df) noexcept
+{
+  if (IsDataField(IGC_FILE, df)) {
+    igcpath = static_cast<FileDataField &>(df).GetValue();
+  } else if (IsDataField(USER_ID, df)) {
+    user.id = df.GetAsInteger();
+  } else if (IsDataField(USER_BIRTH, df)) {
+    user.birthdate = static_cast<DataFieldDate &>(df).GetValue();
+  } else if (IsDataField(AIRCRAFT_ID, df)) {
+    aircraft_id = df.GetAsInteger();
+  }
+  SetFocus(); // with check state of fields!
+}
+
+void
+UploadWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+{
+  RowFormWidget::Prepare(parent, rc);
+
+  const auto settings = CommonInterface::GetComputerSettings(); 
+  if (user.id == 0)
+    user = settings.weglide.pilot;
+  if (aircraft_id == 0)
+    aircraft_id = settings.plane.weglide_glider_type;
+  
+  AddSpacer();
+
+  data_fields[0] =  AddFile(_("IGC File"), nullptr, nullptr,
+    _("*.igc"), FileType::IGC);
+  if (data_fields[0]) {
+    auto file_df = static_cast<FileDataField *>(data_fields[0]->GetDataField());
+    file_df->SetListener(this);
+    if (!File::Exists(igcpath)) {
+      file_df->SetIndex(1);
+      igcpath = file_df->GetValue();
+    } else {
+      file_df->SetValue(igcpath);
+    }
+    data_fields[0]->RefreshDisplay();
+  }
+
+  AddSpacer();
+  data_fields[1] =AddInteger(_("Pilot"),
+             _("Take this from your WeGlide Profile. Or set to 0 if not used."),
+             _T("%u"), _T("%u"), 0, 99999, 1, user.id, this);
+
+  data_fields[2] = AddDate(_("User date of birth"), nullptr, user.birthdate, this);
+
+  data_fields[3] =  AddInteger(_("Aircraft"),
+      _("Take this from your WeGlide Profile. Or set to 0 if not used."),
+      _T("%u"), _T("%u"), 1, 9999, 1, aircraft_id, this);
+
+  AddSpacer();
+
+  AddLabel(_("Do you want to upload this flight to WeGlide?"));
+
+  SetFocus();
+}
+
+bool
+UploadWidget::ShowUploadDialog()
+{
+  UploadDialog dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
+                      UIGlobals::GetDialogLook(), _("Upload Flight"), this);
+  ok_button = dialog.AddButton(_("OK"), mrOK);
+  cancel_button = dialog.AddButton(_("Cancel"), mrCancel);
+ 
+  bool do_upload = dialog.ShowModal() == mrOK;
+
+  /* the caller manages the Widget */
+  dialog.StealWidget();
+
+  if (do_upload) {
+    dialog.Hide();  // dialog is objectionable in the Background
+    return UploadIGCFile(GetIGCPath(), GetUser(), GetAircraft());
+  } else {
+    return false;
+  }
+}
+
+bool
+UploadDialog::OnAnyKeyDown(unsigned key_code)
+{
+  switch (toupper(key_code)) {
+  case 'Q':  // 'Quit
+  case 'X':  // 'eXit
+    WndForm::SetModalResult(mrCancel);
+    return true;
+
+  default:
+    return WidgetDialog::OnAnyKeyDown(key_code);
+  }
+}
+
+
+namespace WeGlide {
+
+int 
+FlightUploadDialog(const Path &igc_path, const WeGlide::User &user,
+                          const uint_least32_t glider_id) noexcept
+{
+  UploadWidget widget(UIGlobals::GetDialogLook(), igc_path,
+                             user, glider_id);
+
+  return widget.ShowUploadDialog();
+}
+
+} // namespace WeGlide

--- a/src/Dialogs/Contest/WeGlide/FlightUploadDialog.hpp
+++ b/src/Dialogs/Contest/WeGlide/FlightUploadDialog.hpp
@@ -1,0 +1,36 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+#include "Cloud/weglide/WeGlideObjects.hpp"
+#include "system/Path.hpp"
+
+namespace WeGlide {
+
+int FlightUploadDialog(const Path &igc_path = Path(),
+                       const WeGlide::User &user = {0},
+                       const uint_least32_t glider_id = 0) noexcept;
+
+}
+

--- a/src/Dialogs/Contest/WeGlide/FlightUploadResponse.cpp
+++ b/src/Dialogs/Contest/WeGlide/FlightUploadResponse.cpp
@@ -1,0 +1,121 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "FlightUploadResponse.hpp"
+#include "LogFile.hpp"
+#include "UIGlobals.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Dialogs/Error.hpp"
+#include "Language/Language.hpp"
+#include "Operation/Cancelled.hpp"
+#include "Operation/PopupOperationEnvironment.hpp"
+#include "Widget/RowFormWidget.hpp"
+
+class ResponseDialog final : public WidgetDialog {
+
+public:
+  ResponseDialog(Auto style, UI::SingleWindow &parent,
+                       const DialogLook &look, const TCHAR *caption,
+                       Widget *widget) noexcept
+      : WidgetDialog(style, parent, look, caption, widget) {}
+
+private:
+  bool OnAnyKeyDown(unsigned key_code) override;
+};
+
+
+class UploadResponseWidget final : public RowFormWidget {
+
+public:
+  UploadResponseWidget(const DialogLook &look,
+                       const WeGlide::Flight &_flightdata, const TCHAR *msg)
+      : RowFormWidget(look), flightdata(_flightdata), update_message(msg) {}
+
+  /* virtual methods from Widget */
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+  bool ShowSuccessDialog();
+  
+private:
+  WeGlide::Flight flightdata;
+  const TCHAR *update_message;
+};
+
+
+void
+UploadResponseWidget::Prepare(ContainerWindow &parent,
+                              const PixelRect &rc) noexcept
+{
+  TCHAR buffer[0x100];
+  AddSpacer();
+  AddReadOnly(_("IGC File"), NULL, flightdata.igc_name.c_str());
+  AddReadOnly(_("Flight ID"), NULL, _T("%.0f"), flightdata.flight_id);
+  AddSpacer();
+  AddReadOnly(_("Date"), NULL, flightdata.scoring_date.c_str());
+  AddReadOnly(_("Pilot"), NULL, flightdata.user.name.c_str());
+  AddReadOnly(_("Aircraft"), NULL, flightdata.aircraft.name.c_str());
+  _stprintf(buffer, _T("%s, %s =  %s"), flightdata.registration.c_str(),
+      _("cid"), flightdata.competition_id.c_str());
+  AddReadOnly(_("Glider"), NULL, buffer);
+
+  AddSpacer();
+  AddLabel(update_message);
+}
+
+bool
+UploadResponseWidget::ShowSuccessDialog()
+{
+  ResponseDialog dialog(WidgetDialog::Auto{},
+                              UIGlobals::GetMainWindow(),
+                              UIGlobals::GetDialogLook(),
+                              _("Upload Flight"), this);
+  // only one 'Close' button
+  dialog.AddButton(_("Close"), mrOK);
+  dialog.ShowModal();
+
+  /* the caller manages the Widget */
+  dialog.StealWidget();
+
+  return true;
+}
+
+bool
+ResponseDialog::OnAnyKeyDown(unsigned key_code)
+{
+  // any key is closing the dialog! 
+  WndForm::SetModalResult(mrOK);
+  return true;
+}
+
+namespace WeGlide {
+
+int 
+FlightUploadResponse(const WeGlide::Flight &flightdata, const TCHAR *msg)
+{
+  LogFormat(_T("%s: %s"), _("WeGlide Upload"), msg);
+  UploadResponseWidget widget(UIGlobals::GetDialogLook(), flightdata, msg);
+
+  return widget.ShowSuccessDialog();
+}
+
+} // namespace WeGlide

--- a/src/Dialogs/Contest/WeGlide/FlightUploadResponse.hpp
+++ b/src/Dialogs/Contest/WeGlide/FlightUploadResponse.hpp
@@ -1,0 +1,33 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+#include "Cloud/weglide/WeGlideObjects.hpp"
+
+namespace WeGlide {
+
+int FlightUploadResponse(const Flight &flightdata, const TCHAR *message);
+
+}
+

--- a/src/Dialogs/DataField.cpp
+++ b/src/Dialogs/DataField.cpp
@@ -73,7 +73,7 @@ EditDataFieldDialog(const TCHAR *caption, DataField &df,
     if (!DateEntryDialog(caption, date, true))
       return false;
 
-    dfd.SetValue(date);
+    dfd.ModifyValue(date);
     return true;
   } else if (df.GetType() == DataField::Type::INTEGER) {
     auto &dfi = static_cast<DataFieldInteger &>(df);

--- a/src/Dialogs/Settings/Panels/WeGlideConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WeGlideConfigPanel.cpp
@@ -94,10 +94,10 @@ WeGlideConfigPanel::Prepare(ContainerWindow &parent,
 
   AddInteger(_("Pilot"),
              _("Take this from your WeGlide Profile. Or set to 0 if not used."),
-             _T("%d"), _T("%d"), 1, 99999, 1, weglide.pilot_id);
+             _T("%d"), _T("%d"), 1, 99999, 1, weglide.pilot.id);
 
   AddDate(_("Pilot date of birth"), nullptr,
-          weglide.pilot_birthdate);
+          weglide.pilot.birthdate);
 
   SetEnabled(weglide.enabled);
 }
@@ -114,11 +114,11 @@ WeGlideConfigPanel::Save(bool &_changed) noexcept
                        weglide.automatic_upload);
 
   changed |= SaveValue(WeGlidePilotID, ProfileKeys::WeGlidePilotID,
-                       weglide.pilot_id);
+                       weglide.pilot.id);
 
   changed |= SaveValue(WeGlidePilotBirthDate,
                        ProfileKeys::WeGlidePilotBirthDate,
-                       weglide.pilot_birthdate);
+                       weglide.pilot.birthdate);
 
   changed |= SaveValue(WeGlideEnabled, ProfileKeys::WeGlideEnabled,
                        weglide.enabled);

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -86,10 +86,9 @@ doc/html/advanced/input/ALL		http://xcsoar.sourceforge.net/advanced/input/
 #include "Formatter/TimeFormatter.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Device/MultipleDevices.hpp"
-
 #include "Form/DataField/File.hpp"
 #include "Dialogs/FilePicker.hpp"
-#include "contest/weglide/UploadIGCFile.hpp"
+#include "Dialogs/Contest/WeGlide/FlightUploadDialog.hpp"
 
 #include <cassert>
 #include <tchar.h>
@@ -744,15 +743,9 @@ InputEvents::eventExchangeFrequencies(const TCHAR *misc)
 }
 
 void
-InputEvents::eventUploadIGCFile(const TCHAR *misc) {
-  FileDataField df;
-  df.ScanMultiplePatterns(_T("*.igc"));
-  df.SetFileType(FileType::IGC);
-  if (FilePicker(_T("IGC-FilePicker"), df)) {
-    auto path = df.GetValue();
-    if (!path.IsEmpty())
-      if (WeGlide::UploadIGCFile(path)) {
-        // success!
-      }
+InputEvents::eventUploadIGCFile(const TCHAR *misc)
+{
+  if (WeGlide::FlightUploadDialog()) {
+      // success!
   }
 }

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -351,10 +351,11 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
     WeGlideSettings weglide_settings =
       CommonInterface::GetComputerSettings().weglide;
     if (weglide_settings.enabled && weglide_settings.automatic_upload &&
-      weglide_settings.pilot_id > 0) {
+      weglide_settings.pilot.id > 0) {
       // ask whether this IGC should be uploaded to WeGlide
       if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
-        _("Upload flight"), MB_YESNO | MB_ICONQUESTION) == IDYES) {
+                         _("Upload flight"),
+                         MB_YESNO | MB_ICONQUESTION) == IDYES) {
         WeGlide::UploadIGCFile(igc_path);
       }
     }

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -348,15 +348,16 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
       ShowError(std::current_exception(), _("Download flight"));
     }
 
-    WeGlideSettings weglide_settings =
-      CommonInterface::GetComputerSettings().weglide;
-    if (weglide_settings.enabled && weglide_settings.automatic_upload &&
-      weglide_settings.pilot.id > 0) {
-      // ask whether this IGC should be uploaded to WeGlide
-      if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
-                         _("Upload flight"),
-                         MB_YESNO | MB_ICONQUESTION) == IDYES) {
-        WeGlide::UploadIGCFile(igc_path);
+    ComputerSettings settings = CommonInterface::GetComputerSettings();
+    if (settings.weglide.enabled && settings.weglide.automatic_upload) {
+      auto weglide_user = settings.weglide.pilot;
+      auto weglide_aircraft = settings.plane.weglide_glider_type;
+      if (weglide_user.id > 0 && weglide_aircraft > 0) {
+        // ask whether this IGC should be uploaded to WeGlide
+        if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
+                           _("Upload flight"),
+                           MB_YESNO | MB_ICONQUESTION) == IDYES)
+          WeGlide::UploadIGCFile(igc_path, weglide_user, weglide_aircraft);
       }
     }
 

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -45,7 +45,7 @@
 #include "Formatter/IGCFilenameFormatter.hpp"
 #include "time/BrokenDate.hpp"
 #include "Interface.hpp"
-#include "contest/weglide/UploadIGCFile.hpp"
+#include "Dialogs/Contest/WeGlide/FlightUploadDialog.hpp"
 
 
 class DeclareJob {
@@ -348,17 +348,10 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
       ShowError(std::current_exception(), _("Download flight"));
     }
 
-    ComputerSettings settings = CommonInterface::GetComputerSettings();
-    if (settings.weglide.enabled && settings.weglide.automatic_upload) {
-      auto weglide_user = settings.weglide.pilot;
-      auto weglide_aircraft = settings.plane.weglide_glider_type;
-      if (weglide_user.id > 0 && weglide_aircraft > 0) {
-        // ask whether this IGC should be uploaded to WeGlide
-        if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
-                           _("Upload flight"),
-                           MB_YESNO | MB_ICONQUESTION) == IDYES)
-          WeGlide::UploadIGCFile(igc_path, weglide_user, weglide_aircraft);
-      }
+    auto settings = 
+      CommonInterface::GetComputerSettings().weglide;
+    if (settings.enabled && settings.automatic_upload) {
+      WeGlide::FlightUploadDialog(igc_path);
     }
 
     if (ShowMessageBox(_("Do you want to download another flight?"),

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -91,13 +91,13 @@ void
 Profile::Load(const ProfileMap &map, WeGlideSettings &settings)
 {
   map.Get(ProfileKeys::WeGlideEnabled, settings.enabled);
-  map.Get(ProfileKeys::WeGlidePilotID, settings.pilot_id);
+  map.Get(ProfileKeys::WeGlidePilotID, settings.pilot.id);
 
   const char *date = map.Get(ProfileKeys::WeGlidePilotBirthDate);
   if (date != nullptr) {
     unsigned day, month, year;
     if (sscanf(date, "%04u-%02u-%02u", &year, &month, &day) == 3)
-      settings.pilot_birthdate = {year, month, day};
+      settings.pilot.birthdate = {year, month, day};
   }
 }
 

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -24,6 +24,7 @@ Copyright_License {
 #include "RowFormWidget.hpp"
 #include "Form/Panel.hpp"
 #include "Form/Button.hpp"
+#include "Form/Frame.hpp"
 #include "Form/HLine.hpp"
 #include "Look/DialogLook.hpp"
 #include "Dialogs/DialogSettings.hpp"
@@ -282,6 +283,19 @@ RowFormWidget::AddSpacer() noexcept
   ContainerWindow &panel = (ContainerWindow &)GetWindow();
   const PixelRect rc = InitialControlRect(Layout::Scale(3));
   window->Create(panel, rc);
+  Add(std::move(window));
+}
+
+void
+RowFormWidget::AddLabel(const TCHAR *text, unsigned lines) noexcept
+{
+  ContainerWindow &panel = (ContainerWindow &)GetWindow();
+  if (lines == 0) lines = 1;
+  const PixelRect rc = InitialControlRect(
+      Layout::Scale(lines * look.text_font.GetHeight()));
+
+  auto window = std::make_unique<WndFrame>(panel, look, rc);
+  window->SetText(text);
   Add(std::move(window));
 }
 

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -460,6 +460,13 @@ public:
   }
 
   /**
+   * Add a label panel control, not editable, only for some explanations,
+   *  descriptions or messages. You can use SetText() to update its text.
+   * the parameter lines controls the height if this panel!
+   */
+  void AddLabel(const TCHAR *label, unsigned lines = 1) noexcept;
+
+  /**
    * Add a read-only multi-line control.  You can use
    * SetMultiLineText() to update its text.
    */

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -30,6 +30,7 @@
 #include "co/InvokeTask.hxx"
 #include "Dialogs/Message.hpp"
 #include "Dialogs/CoDialog.hpp"
+#include "Dialogs/Error.hpp"
 #include "Formatter/TimeFormatter.hpp"
 #include "json/ParserOutputStream.hxx"
 #include "Language/Language.hpp"
@@ -166,7 +167,7 @@ try {
   }
   return false;
 } catch (...) {
-  LogError(std::current_exception());
+  ShowError(std::current_exception(), _T("WeGlide UploadIGCFile"));
   return false;
 }
 

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -28,6 +28,7 @@
 #include "Cloud/weglide/UploadFlight.hpp"
 #include "Cloud/weglide/WeGlideSettings.hpp"
 #include "Cloud/weglide/HttpResponse.hpp"
+#include "Cloud/weglide/GetJsonString.hpp"
 #include "co/InvokeTask.hxx"
 #include "Dialogs/Message.hpp"
 #include "Dialogs/CoDialog.hpp"
@@ -44,20 +45,6 @@
 #include "util/ConvertString.hpp"
 
 #include <cinttypes>
-
-// Wrapper for getting converted string values of a json string
-static const StaticString<0x40>
-GetJsonString(boost::json::standalone::value json_value,
-              std::string_view key) noexcept {
-  StaticString<0x40> str;
-  auto value = json_value.as_object().if_contains(key);
-  if (value != nullptr)
-    str = UTF8ToWideConverter(value->get_string().c_str());
-  else
-    str.Format(_T("'%s' %s"), UTF8ToWideConverter(key.data()).c_str(),
-               _("not found"));
-  return str;
-}
 
 namespace WeGlide {
 

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -146,6 +146,10 @@ try {
   msg.Format(_T("'%s' - %s"), igc_path.c_str(),
     UTF8ToWideConverter(e.what()).c_str());
   return Flight();
+} catch (...) {
+  msg.Format(_T("'%s' - %s"), _("General Exception"), igc_path.c_str());
+  ShowError(std::current_exception(), _T("WeGlide UploadFile"));
+  return Flight();
 }
 
 bool

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -142,7 +142,7 @@ UploadFile(Path igc_path, User user, uint_least32_t aircraft_id,
     return flight_data;  // upload successful!
   }
   catch (const std::exception &e) {
-    msg.Format(_("'%s' - %s"), igc_path.c_str(),
+    msg.Format(_T("'%s' - %s"), igc_path.c_str(),
       UTF8ToWideConverter(e.what()).c_str());
     return flight_data;  // with flight_id = 0!
   }

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -32,6 +32,7 @@
 #include "Dialogs/Message.hpp"
 #include "Dialogs/CoDialog.hpp"
 #include "Dialogs/Error.hpp"
+#include "Dialogs/Contest/WeGlide/FlightUploadResponse.hpp"
 #include "Formatter/TimeFormatter.hpp"
 #include "json/ParserOutputStream.hxx"
 #include "Language/Language.hpp"
@@ -112,27 +113,6 @@ UploadErrorInterpreter(const HttpResponse &http)
   return error_string;
 }
 
-// UploadSuccessDialog is only a preliminary DialogBox to show the 
-// result of this upload
-static void
-UploadSuccessDialog(const Flight &flight_data, const TCHAR *msg)
-{
-  StaticString<0x1000> display_string;
-  // TODO: Create a real Dialog with fields in 'src/Dialogs/Cloud/weglide'!
-  // With this Dialog insert the possibilty to update/patch the flight
-  // f.e. copilot in double seater, scoring class, short comment and so on
-  display_string.Format(_T("%s\n\n%s: %u\n%s: %s\n%s: %s (%d)\n"
-    "%s: %s (%u)\n%s: %s, %s: %s"), msg,
-    _("Flight ID"), flight_data.flight_id,
-    _("Scoring Date"), flight_data.scoring_date.c_str(),
-    _("User"), flight_data.user.name.c_str(), flight_data.user.id,
-    _("Aircraft"), flight_data.aircraft.name.c_str(), flight_data.aircraft.id,
-    _("Reg."), flight_data.registration.c_str(),
-    _("Comp. ID"), flight_data.competition_id.c_str());
-
-  ShowMessageBox(display_string.c_str(), _("WeGlide Upload"), MB_OK);
-}
-
 struct CoInstance {
   HttpResponse http;
   Co::InvokeTask
@@ -195,8 +175,7 @@ try {
   auto flight_data = UploadFile(igc_path, user, aircraft_id, msg);
   if (flight_data.IsValid()) {
     // upload successful!
-    LogFormat(_("%s: %s"), _("WeGlide Upload"), msg.c_str());
-    UploadSuccessDialog(flight_data, msg.c_str());
+    FlightUploadResponse(flight_data, msg.c_str());
     return true;
   } else {
     // upload failed!

--- a/src/contest/weglide/UploadIGCFile.cpp
+++ b/src/contest/weglide/UploadIGCFile.cpp
@@ -109,7 +109,7 @@ struct CoInstance {
 
 static Flight
 UploadFile(Path igc_path, User user, uint_least32_t aircraft_id,
-  StaticString<0x1000> &msg) noexcept
+           StaticString<0x1000> &msg) noexcept
 {
   Flight flight_data;
   try {
@@ -150,25 +150,23 @@ UploadFile(Path igc_path, User user, uint_least32_t aircraft_id,
 
 bool
 UploadIGCFile(Path igc_path, const User &user,
-  uint_least32_t aircraft_id) noexcept
-{ 
-  try {
-    StaticString<0x1000> msg;
-    auto flight_data = UploadFile(igc_path, user, aircraft_id, msg);
-    if (flight_data.flight_id > 0) {
-      // upload successful!
-      LogFormat(_("%s: %s"), _("WeGlide Upload"), msg.c_str());
-      UploadSuccessDialog(flight_data, msg.c_str());
-      return true;
-    } else {
-      // upload failed!
-      LogFormat(_T("%s: %s!"), _("WeGlide Upload Error"), msg.c_str());
-      ShowMessageBox(msg.c_str(), _("WeGlide Upload Error"),
-        MB_ICONEXCLAMATION);
-    }
-  } catch (...) {
-    LogError(std::current_exception());
+              uint_least32_t aircraft_id) noexcept
+try {
+  StaticString<0x1000> msg;
+  auto flight_data = UploadFile(igc_path, user, aircraft_id, msg);
+  if (flight_data.flight_id > 0) {
+    // upload successful!
+    LogFormat(_("%s: %s"), _("WeGlide Upload"), msg.c_str());
+    UploadSuccessDialog(flight_data, msg.c_str());
+    return true;
+  } else {
+    // upload failed!
+    LogFormat(_T("%s: %s!"), _("WeGlide Upload Error"), msg.c_str());
+    ShowMessageBox(msg.c_str(), _("WeGlide Upload Error"), MB_ICONEXCLAMATION);
   }
+  return false;
+} catch (...) {
+  LogError(std::current_exception());
   return false;
 }
 

--- a/src/contest/weglide/UploadIGCFile.hpp
+++ b/src/contest/weglide/UploadIGCFile.hpp
@@ -23,12 +23,15 @@ Copyright_License {
 
 #pragma once
 
+#include "Cloud/weglide/WeGlideObjects.hpp"
+
 #include <cstdint>
 
 class Path;
 
 namespace WeGlide {
 
-bool UploadIGCFile(Path igc_path) noexcept;
+bool UploadIGCFile(Path igc_filepath, const User &user = {0},
+                   uint_least32_t aircraft_id = 0) noexcept;
 
 } // namespace WeGlide


### PR DESCRIPTION
After the 1st PR #612 there a few tasks were still open:

Brief summary of the changes
----------------------------

- Before starting the upload is a new dialog available, where the user can check and change the necessary settings for uploading: IGC file, user and aircraft - or break, if he don't like the upload after the download of logger file.
- Message window at the end of dialog should have a better style (not an multiline MessageBox). This new dialog is prepared for a fast response to the WeGlide server about copilot, (short) message test and - maybe a deleting after a wrong upload.
- The error handling after known http codes (at http code 406 mostly the file is already uploaded, or at 400 a parameter is wrong - this should be displayed)
- Internal: Switch to structures similar and better aligned to the WeGlide objects 'User', 'Aircraft' and 'Flight'!

Related issues and discussions
------------------------------

Continuation of work on PR #612 and Issue #505 (from December 2020, The main points are now solved! With some cherry picks from #866 issues from #612 solved in XCSoar 7.23.

Again some things are still open:
---------------------------------

- (Solved here: _Better pre-upload query with the ability to 'recalibrate' the pilot and aircraft_)
- Simple TaskDownload of any WeGlide task: Either your own task or that of another pilot (See #523)
- (Solved here: _A better selection of user and aircraft_)
- Creation of Lua access to this functionality for event-driven user guidance (keyboard or gestures)
