### PR TITLE
Filter pseudo terminals from serial port list

### DIFF
--- a/src/Device/Port/TTYEnumerator.cpp
+++ b/src/Device/Port/TTYEnumerator.cpp
@@ -26,32 +26,69 @@ Copyright_License {
 #include "util/StringCompare.hxx"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <tchar.h>
+#include <libgen.h>
+
+static bool
+IsDirectory(const char *path) noexcept
+{
+    struct stat st;
+    return stat(path, &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+static bool
+IsSymlink(const char *path) noexcept
+{
+    struct stat st;
+    /* use lstat() to get stat() of link not of linked target */
+    return lstat(path, &st) == 0 && S_ISLNK(st.st_mode);
+}
 
 [[gnu::pure]]
 static bool
 CheckTTYName(const char *name) noexcept
 {
-  /* filter "/dev/tty*" */
-  if (const char *t = StringAfterPrefix(name, "tty"); t != nullptr) {
-    if (*t == 0)
-      /* ignore /dev/tty */
-      return false;
-
-    /* ignore virtual internal ports on Mac OS X (and probably other
-       BSDs) */
-    if (*t >= 'p' && *t <= 'w')
-      return false;
-
-    /* filter out "/dev/tty0", ... (valid integer after "tty") */
-    if (IsDigitASCII(*t))
-      return false;
-
+  /*
+   * rfcomm devices do not have a 'device/driver' file that is used
+   * to exclude virtual/pseudo terminals
+   */
+  if (StringStartsWith(name, "rfcomm"))
     return true;
-  } else if (StringStartsWith(name, "rfcomm"))
-    return true;
-  else
+
+  /*
+   * we assume only entries with existing 'device/driver' folder
+   * aren't virtual/pseudo terminals, as they are associated with a
+   * kernel driver
+   */
+  const char *driver_format = "/sys/class/tty/%s/device/driver";
+  char driver[128];
+  if (snprintf(driver, sizeof(driver), driver_format, name) >= (int)sizeof(driver))
+	  /* ignore truncated file path */
     return false;
+
+  if (IsDirectory(driver))
+    return true;
+
+  return false;
+}
+
+[[gnu::pure]]
+static bool
+CheckTTYDevice(const char *device, struct dirent *ent) noexcept
+{
+  if(!IsSymlink(device))
+    return CheckTTYName(ent->d_name);
+
+  char* real_path = realpath(device, nullptr);
+  if (real_path == nullptr)
+    return false;
+
+  bool result = CheckTTYName(basename(real_path));
+  free(real_path);
+  return result;
 }
 
 const char *
@@ -59,11 +96,11 @@ TTYEnumerator::Next() noexcept
 {
   struct dirent *ent;
   while ((ent = readdir(dir)) != nullptr) {
-    if (!CheckTTYName(ent->d_name))
-      continue;
-
     if (snprintf(path, sizeof(path), "/dev/%s", ent->d_name) >= (int)sizeof(path))
       /* truncated - ignore */
+      continue;
+
+    if (!CheckTTYDevice(path, ent))
       continue;
 
     if (access(path, R_OK|W_OK) == 0 && access(path, X_OK) < 0)

--- a/src/Device/Port/TTYEnumerator.hpp
+++ b/src/Device/Port/TTYEnumerator.hpp
@@ -28,26 +28,17 @@ Copyright_License {
 
 /**
  * A class that can enumerate TTY devices on Linux and other POSIX
- * systems, by reading directory entries in /dev/.
+ * systems, by reading directory entries in /dev.
+ * Reading /sys/class/tty would also haven been possible
+ * but symlink created by udev rules are only visible in /dev.
  */
 class TTYEnumerator {
   DIR *dir;
   char path[64];
 
 public:
-#ifdef __linux__
-  /* on Linux, enumerate /sys/class/tty/ which is faster than /dev/
-     (searches only the TTY character devices) and shows only the
-     ports that really exist */
-  /* but use /dev because there is no noticable downside, and it
-   * allows for custom port mapping using udev file
-   */
   TTYEnumerator() noexcept
     :dir(opendir("/dev")) {}
-#else
-  TTYEnumerator() noexcept
-    :dir(opendir("/dev")) {}
-#endif
 
   ~TTYEnumerator() noexcept {
     if (dir != nullptr)


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Set a higher limit for the enumeration list.
This makes the list longer but at least the important ports entries show up again.

Related issues and discussions
------------------------------
Closes #888 
