### PR TITLE
add SoftRF Lego into 'white list' of USB devices

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,8 @@ Version 7.24 - not yet released
   - allow changing the language at runtime
 * OpenVario
   - menu: fix bogus clicks after returning from XCSoar
+* Android
+  - add SoftRF Lego into 'white list' of USB devices
 
 Version 7.23 - 2022/02/10
 * user interface

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -64,6 +64,8 @@ public class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x239A, 0x8029), // SoftRF Badge
     createDevice(0x2341, 0x804d), // SoftRF Academy
     createDevice(0x1d50, 0x6089), // SoftRF ES
+    createDevice(0x2e8a, 0x000a), // SoftRF Lego
+    createDevice(0x2e8a, 0xf00a), // SoftRF Lego
 
     createDevice(0x0403, 0x6001), // FT232AM, FT232BM, FT232R FT245R,
     createDevice(0x0403, 0x6010), // FT2232D, FT2232H


### PR DESCRIPTION
Brief summary of the changes
----------------------------

add VID/PID pair(s) for SoftRF Lego into Android 'white list' of USB devices
