### PR TITLE
ui: left-hand padding for Lists/RowForm/LargeTextWin

### DIFF
--- a/src/Form/Edit.cpp
+++ b/src/Form/Edit.cpp
@@ -348,7 +348,7 @@ WndProperty::OnPaint(Canvas &canvas)
     canvas.SetBackgroundTransparent();
     canvas.Select(look.text_font);
 
-    const int x = edit_rc.left + Layout::GetTextPadding();
+    const int x = edit_rc.left + Layout::GetTextPadding() * 2;
     const int canvas_height = edit_rc.GetHeight();
     const int text_height = canvas.GetFontHeight();
     const int y = edit_rc.top + (canvas_height - text_height) / 2;

--- a/src/Form/Form.cpp
+++ b/src/Form/Form.cpp
@@ -449,14 +449,14 @@ WndForm::OnPaint(Canvas &canvas)
     const int size = Layout::VptScale(4);
 
     const BulkPixelPoint vertices[8] = {
-      { rc.left, rc.top },
-      { rc.right, rc.top },
+      { rc.left + size, rc.top + size },
+      { rc.right, rc.top + size },
       { rc.right, rc.bottom },
-      { rc.left, rc.bottom },
-      { rc.left - size, rc.top - size },
-      { rc.right + size, rc.top - size },
+      { rc.left + size, rc.bottom },
+      { rc.left, rc.top + size },
+      { rc.right + size, rc.top + size },
       { rc.right + size, rc.bottom + size },
-      { rc.left - size, rc.bottom + size },
+      { rc.left + size, rc.bottom + size },
     };
 
     const ScopeVertexPointer vp(vertices);

--- a/src/Renderer/TextRowRenderer.cpp
+++ b/src/Renderer/TextRowRenderer.cpp
@@ -36,7 +36,7 @@ TextRowRenderer::CalculateLayout(const Font &font) noexcept
   const unsigned padded_height = font_height + 2 * text_padding;
   const unsigned row_height = std::max(padded_height, max_height);
 
-  left_padding = text_padding;
+  left_padding = text_padding * 2;
   top_padding = (row_height - font_height) / 2;
 
   return row_height;

--- a/src/ui/control/custom/LargeTextWindow.cpp
+++ b/src/ui/control/custom/LargeTextWindow.cpp
@@ -128,7 +128,7 @@ LargeTextWindow::OnPaint(Canvas &canvas)
   if (value.empty())
     return;
 
-  const int padding = Layout::GetTextPadding();
+  const int padding = Layout::GetTextPadding() * 2;
   rc.Grow(-padding);
 
   canvas.SetBackgroundTransparent();


### PR DESCRIPTION
# Layout padding improvements on selected GUI elements
## old:
![2022-04-11-230234_681x718_scrot](https://user-images.githubusercontent.com/407371/162839785-b6089670-156e-4d72-99b2-641f36e60dae.png)
## new:

![2022-04-11-230309_681x718_scrot](https://user-images.githubusercontent.com/407371/162839851-85bd4fa3-495f-408d-a6d9-0869f73914fa.png)

![2022-04-11-235518_501x718_scrot](https://user-images.githubusercontent.com/407371/162840248-cedb1fac-466b-4364-9275-8874af37884e.png)
![2022-04-11-235536_501x718_scrot](https://user-images.githubusercontent.com/407371/162840252-8b61432d-f876-4613-8458-22c323186a99.png)

## Drop Shadows for WndForms
![2022-04-22-002508_681x370_scrot](https://user-images.githubusercontent.com/407371/164561685-0c03640f-c95e-4b26-8131-e601c2a5dc84.png)

