### PR TITLE
Revert "Invert Cruise/Circling mode in NMEA parsing of Borgelt B50 dr…

### DIFF
--- a/src/Device/Driver/BorgeltB50.cpp
+++ b/src/Device/Driver/BorgeltB50.cpp
@@ -104,11 +104,11 @@ PBB50(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
   }
 

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -102,11 +102,11 @@ PXCV(NMEAInputLine &line, NMEAInfo &info)
   // inclimb/incruise 1=cruise,0=climb, OAT
   switch (line.Read(-1)) {
   case 0:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
     break;
 
   case 1:
-    info.switch_state.flight_mode = SwitchState::FlightMode::CRUISE;
+    info.switch_state.flight_mode = SwitchState::FlightMode::CIRCLING;
     break;
   }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -353,7 +353,7 @@ TestBorgeltB50()
   ok1(equals(nmea_info.settings.bugs, 0.9));
   ok1(nmea_info.settings.ballast_overload_available);
   ok1(equals(nmea_info.settings.ballast_overload, 1.3));
-  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CRUISE);
+  ok1(nmea_info.switch_state.flight_mode == SwitchState::FlightMode::CIRCLING);
   ok1(nmea_info.temperature_available);
   ok1(equals(nmea_info.temperature.ToKelvin(), 245.15));
 


### PR DESCRIPTION
This reverts commit d1125e1f6c265365f2e511a6e16ca1efe8b64092.

Brief summary of the changes
This will revert a change that came in as of an issue in Borgelt documentation (inverted cruise bit in $PB50 NMEA protocol), and so in turn will fix issue referenced below.

Related issues and discussions
Closes #812
https://github.com/XCSoar/XCSoar/issues/812
