### PR TITLE
Rework Menu to fit action->newstate paradigm

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -479,7 +479,7 @@ mode=Display1
 type=key
 data=9
 event=ScreenModes cycle
-label=$(NextPageName)
+label=Page Show\n$(NextPageName)
 location=8
 
 mode=Display1

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -430,7 +430,7 @@ event=Mode default
 event=StatusMessage Pilot event announced
 event=Logger note PEV
 event=PilotEvent
-label=Pilot\nEvent
+label=Pilot Event\nAnnounce
 location=7
 
 mode=Nav2

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -361,7 +361,7 @@ type=key
 data=6
 event=Calculator
 event=Mode default
-label=Task
+label=Task Manager
 location=5
 
 mode=Nav1
@@ -420,7 +420,7 @@ event=Mode default
 event=StatusMessage Dropped marker
 event=Logger note Mark
 event=MarkLocation
-label=Mark\nDrop
+label=Marker Drop
 location=6
 
 mode=Nav2
@@ -610,7 +610,7 @@ type=key
 data=8
 event=WaypointEditor
 event=Mode default
-label=Waypoints Editor
+label=Waypoint Editor
 location=7
 
 mode=Config2
@@ -796,7 +796,7 @@ type=key
 data=9
 event=Checklist
 event=Mode default
-label=Check\nlist
+label=Checklist
 location=8
 
 mode=Info1
@@ -822,7 +822,7 @@ type=key
 data=6
 event=Status all
 event=Mode default
-label=Status
+label=Flight Status
 location=5
 
 mode=Info2
@@ -1062,7 +1062,7 @@ event=Mode default
 event=StatusMessage Dropped marker
 event=Logger note Mark
 event=MarkLocation
-label=Mark\nDrop
+label=Marker Drop
 location=10
 
 mode=RemoteStick
@@ -1202,7 +1202,7 @@ type=key
 data=0
 event=Checklist
 event=Mode default
-label=Check\nlist
+label=Checklist
 location=28
 
 mode=RemoteStick
@@ -1218,7 +1218,7 @@ type=key
 data=0
 event=Status all
 event=Mode default
-label=Status
+label=Flight Status
 location=30
 
 mode=RemoteStick

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -118,7 +118,7 @@ mode=pan
 type=key
 data=APP1
 event=Pan off
-label=Pan\nOff
+label=Cancel
 location=1
 
 mode=pan
@@ -486,7 +486,7 @@ mode=Display1
 type=key
 data=0
 event=Pan on
-label=Pan\nOn
+label=Pan\nMode
 location=9
 
 # -------------
@@ -1069,7 +1069,7 @@ mode=RemoteStick
 type=key
 data=0
 event=Pan on
-label=Pan\nOn
+label=Pan\nMode
 location=11
 
 mode=RemoteStick

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -125,14 +125,14 @@ mode=pan
 type=key
 data=APP2
 event=Zoom in
-label=Zoom\nIn
+label=Zoom\n+
 location=2
 
 mode=pan
 type=key
 data=APP3
 event=Zoom out
-label=Zoom\nOut
+label=Zoom\n-
 location=3
 
 mode=pan
@@ -353,7 +353,7 @@ mode=Nav1
 type=key
 data=APP1
 event=Mode Nav2
-label=Nav\n1/2
+label=Nav\nPage 2/2
 location=1
 
 mode=Nav1
@@ -402,7 +402,7 @@ mode=Nav2
 type=key
 data=APP1
 event=Mode default
-label=Nav\n2/2
+label=Cancel
 location=1
 
 mode=Nav2
@@ -449,7 +449,7 @@ mode=Display1
 type=key
 data=APP2
 event=Mode Display2
-label=Display\n1/2
+label=Display\nPage 2/2
 location=2
 
 
@@ -457,14 +457,14 @@ mode=Display1
 type=key
 data=6
 event=Zoom in
-label=Zoom\nIn
+label=Zoom\n+
 location=5
 
 mode=Display1
 type=key
 data=7
 event=Zoom out
-label=Zoom\nOut
+label=Zoom\n-
 location=6
 
 mode=Display1
@@ -497,7 +497,7 @@ mode=Display2
 type=key
 data=APP2
 event=Mode default
-label=Display\n2/2
+label=Cancel
 location=2
 
 mode=Display2
@@ -544,7 +544,7 @@ mode=Config1
 type=key
 data=APP3
 event=Mode Config2
-label=Config\n1/3
+label=Config\nPage 2/3
 location=3
 
 mode=Config1
@@ -594,7 +594,7 @@ mode=Config2
 type=key
 data=APP3
 event=Mode Config3
-label=Config\n2/3
+label=Config\nPage 3/3
 location=3
 
 mode=Config2
@@ -636,7 +636,7 @@ mode=Config3
 type=key
 data=APP3
 event=Mode default
-label=Config\n3/3
+label=Cancel
 location=3
 
 mode=Config3
@@ -677,7 +677,7 @@ mode=Vario1
 type=key
 data=APP3
 event=Mode Vario2
-label=Vega\n1/2
+label=Vega\nPage 2/2
 location=3
 
 mode=Vario1
@@ -764,7 +764,7 @@ mode=Info1
 type=key
 data=APP4
 event=Mode Info2
-label=Info\n1/3
+label=Info\nPage 2/3
 location=4
 
 mode=Info1
@@ -814,7 +814,7 @@ mode=Info2
 type=key
 data=APP4
 event=Mode Info3
-label=Info\n2/3
+label=Info\nPage 3/3
 location=4
 
 mode=Info2
@@ -856,9 +856,8 @@ mode=Info3
 type=key
 data=APP4
 event=Mode default
-label=Info\n3/3
+label=Cancel
 location=4
-
 
 mode=Info3
 type=key
@@ -950,14 +949,14 @@ mode=Display1.Traffic
 type=key
 data=6
 event=Traffic zoom in
-label=Zoom\nIn
+label=Zoom\n+
 location=5
 
 mode=Display1.Traffic
 type=key
 data=7
 event=Traffic zoom out
-label=Zoom\nOut
+label=Zoom\n-
 location=6
 
 mode=Display1.Traffic

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -438,7 +438,7 @@ type=key
 data=9
 event=Setup Target
 event=Mode default
-label=Target$(CheckTask)$(CheckTaskResumed)
+label=Target\nShow$(CheckTask)$(CheckTaskResumed)
 location=8
 
 # -------------
@@ -1043,7 +1043,7 @@ type=key
 data=0
 event=Setup Target
 event=Mode default
-label=Target Show$(CheckTask)$(CheckTaskResumed)
+label=Target\nShow$(CheckTask)$(CheckTaskResumed)
 location=7
 
 

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -368,14 +368,14 @@ mode=Nav1
 type=key
 data=7
 event=AdjustWaypoint previousarm
-label=$(WaypointPreviousArm)
+label=$(WaypointPreviousArm)\nSelect
 location=6
 
 mode=Nav1
 type=key
 data=8
 event=AdjustWaypoint nextarm
-label=$(WaypointNextArm)
+label=$(WaypointNextArm)\nSelect
 location=7
 
 mode=Nav1
@@ -391,7 +391,7 @@ type=key
 data=0
 event=Setup Alternates
 event=Mode default
-label=Alternates$(CheckWaypointFile)
+label=Alternates\nList$(CheckWaypointFile)
 location=9
 
 # -------------
@@ -1019,7 +1019,7 @@ type=key
 data=0
 event=Setup Alternates
 event=Mode default
-label=Alternates$(CheckWaypointFile)
+label=Alternates\nList$(CheckWaypointFile)
 location=4
 
 mode=RemoteStick
@@ -1043,7 +1043,7 @@ type=key
 data=0
 event=Setup Target
 event=Mode default
-label=Target$(CheckTask)$(CheckTaskResumed)
+label=Target Show$(CheckTask)$(CheckTaskResumed)
 location=7
 
 

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -80,26 +80,26 @@ ExpandTaskMacros(const TCHAR *name,
     if (StringIsEqual(name, _T("WaypointNext")) ||
         StringIsEqual(name, _T("WaypointNextArm"))) {
       invalid = true;
-      return _("Next Turnpoint");
+      return _("Turnpoint Next");
     } else if (StringIsEqual(name, _T("WaypointPrevious")) ||
                StringIsEqual(name, _T("WaypointPreviousArm"))) {
       invalid = true;
-      return _("Previous Turnpoint");
+      return _("Turnpoint Previous");
     }
   } else if (common_stats.task_type == TaskType::ABORT) {
     if (StringIsEqual(name, _T("WaypointNext")) ||
         StringIsEqual(name, _T("WaypointNextArm"))) {
       invalid |= !common_stats.active_has_next;
       return common_stats.next_is_last
-        ? _("Furthest Landpoint")
-        : _("Next Landpoint");
+        ? _("Landpoint Furthest ")
+        : _("Landpoint Next");
     } else if (StringIsEqual(name, _T("WaypointPrevious")) ||
                StringIsEqual(name, _T("WaypointPreviousArm"))) {
       invalid |= !common_stats.active_has_previous;
 
       return common_stats.previous_is_first
-        ? _("Closest Landpoint")
-        : _("Previous Landpoint");
+        ? _("Landpoint Closest")
+        : _("Landpoint Previous");
     }
 
   } else { // ordered task mode
@@ -112,16 +112,16 @@ ExpandTaskMacros(const TCHAR *name,
       // Waypoint\nNext
       invalid |= !common_stats.active_has_next;
       return next_is_final
-        ? _("Finish Turnpoint")
-        : _("Next Turnpoint");
+        ? _("Turnpoint Finish")
+        : _("Turnpoint Next");
     } else if (StringIsEqual(name, _T("WaypointPrevious"))) {
       if (has_optional_starts && !common_stats.active_has_previous) {
-        return _("Next Startpoint");
+        return _("Startpoint Next");
       } else {
         invalid |= !common_stats.active_has_previous;
         return previous_is_start
-          ? _("Start Turnpoint")
-          : _("Previous Turnpoint");
+          ? _("Turnpoint Start")
+          : _("Turnpoint Previous");
       }
 
     } else if (StringIsEqual(name, _T("WaypointNextArm"))) {
@@ -134,8 +134,8 @@ ExpandTaskMacros(const TCHAR *name,
       case TaskAdvance::TURN_ARMED:
         invalid |= !common_stats.active_has_next;
         return next_is_final
-          ? _("Finish Turnpoint")
-          : _("Next Turnpoint");
+          ? _("Turnpoint Finish")
+          : _("Turnpoint Next");
 
       case TaskAdvance::START_DISARMED:
         return _("Arm start");
@@ -153,12 +153,12 @@ ExpandTaskMacros(const TCHAR *name,
       case TaskAdvance::TURN_DISARMED:
 
         if (has_optional_starts && !common_stats.active_has_previous) {
-          return _("Next Startpoint");
+          return _("Startpoint Next");
         } else {
           invalid |= !common_stats.active_has_previous;
           return previous_is_start
-            ? _("Start Turnpoint")
-            : _("Previous Turnpoint");
+            ? _("Turnpoint Start")
+            : _("Turnpoint Previous");
         }
 
       case TaskAdvance::START_ARMED:


### PR DESCRIPTION
Rework menus to make clear that an action is following a button press, that pressing the button will get you to the state on the label of the button. 

Note: the windows font change would not be required, but i still think we should change the font on windows to whats currently default on the platform. 

![2022-04-27-223053_681x741_scrot](https://user-images.githubusercontent.com/407371/165625857-56f73143-c5bc-41af-bc8d-7fabb40f8188.png)
![2022-04-27-222915_681x718_scrot](https://user-images.githubusercontent.com/407371/165625547-b54f20c6-9b98-4f04-9756-deabd3cef0dc.png)
![2022-04-27-222921_681x718_scrot](https://user-images.githubusercontent.com/407371/165625564-3bad595e-ed10-43c5-9328-1ecadbae4d60.png)

