### PR TITLE
Flarm bugfix reading flightlist

### DIFF
--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or

--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -23,6 +23,7 @@ Copyright_License {
 
 #include "Device.hpp"
 #include "CRC16.hpp"
+#include "Device/Error.hpp"
 #include "Device/Port/Port.hpp"
 #include "time/TimeoutClock.hpp"
 
@@ -268,7 +269,7 @@ FlarmDevice::WaitForACK(uint16_t sequence_number,
 bool
 FlarmDevice::BinaryPing(OperationEnvironment &env,
                         std::chrono::steady_clock::duration _timeout)
-{
+try {
   const TimeoutClock timeout(_timeout);
 
   // Create header for sending a binary ping request
@@ -279,6 +280,8 @@ FlarmDevice::BinaryPing(OperationEnvironment &env,
   SendStartByte();
   SendFrameHeader(header, env, timeout.GetRemainingOrZero());
   return WaitForACK(header.sequence_number, env, timeout.GetRemainingOrZero());
+} catch (const DeviceTimeout &) {
+  return false;
 }
 
 void

--- a/src/Device/Driver/FLARM/BinaryProtocol.hpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or

--- a/src/Device/Driver/FLARM/BinaryProtocol.hpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.hpp
@@ -21,8 +21,7 @@ Copyright_License {
 }
 */
 
-#ifndef XCSOAR_FLARM_BINARY_PROTOCOL_HPP
-#define XCSOAR_FLARM_BINARY_PROTOCOL_HPP
+#pragma once
 
 #include "util/ByteOrder.hxx"
 #include "util/Compiler.h"
@@ -136,5 +135,3 @@ namespace FLARM {
                       OperationEnvironment &env,
                       std::chrono::steady_clock::duration timeout);
 };
-
-#endif


### PR DESCRIPTION
Brief summary of the changes
----------------------------

With catching of exception(s) and extension of a timeout period it is possible to get all downloadable flights of a flarm device in a list - and not the wrong message 'flightlist is empty'

Related issues and discussions
------------------------------

This changes should be solve the described problem (There was mostly a difference in the view of recorded flights between reading with FlarmTool and XCSoar)

This issue is not only linked to XCSoar itself: I observed this in the last year very often only with the PowerMouse! But with the new Flarm update 7.06 I observed this on all other devices (PowerFlarm, normal Flarm, ...) I think, Flarm changed something on the timing... ;-(