### PR TITLE
doc/manual: correct typos in german manual

### DIFF
--- a/doc/manual/de/ch03_navigation.tex
+++ b/doc/manual/de/ch03_navigation.tex
@@ -414,7 +414,7 @@ Einige Einschränkungen und Limitierung bezüglich des Routenplanungssystems sin
 \begin{itemize}
 \item Wenn Kurbeln notwendig ist, um das Ziel zu erreichen,  wird angenommen, daß das Steigen zu Beginn der Route ist. 
 
-Hintergrund: eine Einstellung von  MacCready gleich 0 bedeutet, daß (streng nach der MC-Theorie) kein Steigen erwartet wird!  Andernfalls würde die Rechenalgorythmen in  die Irre geführt werden!   
+Hintergrund: eine Einstellung von  MacCready gleich 0 bedeutet, daß (streng nach der MC-Theorie) kein Steigen erwartet wird!  Andernfalls würde die Rechenalgorithmen in  die Irre geführt werden!   
 \item Strecken mit Steigen im Geradeausflug werden auf einer konstanten Höhe angenommen, gleichbedeutend mit vielen kleinen Steigen verteilt entlang der Strecke
 \item Kurven und Schlenker zwischen den einzelnen Streckensegmenten mit Ablagen größer 90$^\circ$ sind erlaubt
 \item Fehler des Rechenalgorithmus innerhalb der Route können dazu führen, daß der Anflug in einem direkten Anflug auf das Ziel zurückgeführt wird.

--- a/doc/manual/de/ch04_xc_tasks.tex
+++ b/doc/manual/de/ch04_xc_tasks.tex
@@ -589,7 +589,7 @@ Die angenommene Ankunftshöhe wird unter Berücksichtigung des Windes mittels de
 Der erste Punkt in der Liste  ist der am sichersten Erreichbare.
 \item[\p{Aufgabe}] Zusätzlich zu den oben genannten Bedingungen wird hier die Kursrichtung zum programmierten \textbf{Zielpunkt} berücksichtigt, um im Falle einer
 Wiederaufnahme der Aufgabe optimal weiterfliegen zu können, ohne Haken schlagen zu müssen.
-\item[\p{Heimat}] Der Sortieralgorythmus wird bevorzugt jene Felder auswählen, die auf dem Kurs in Richtung des \textbf{Heimatflugplatzes} liegt.
+\item[\p{Heimat}] Der Sortieralgorithmus wird bevorzugt jene Felder auswählen, die auf dem Kurs in Richtung des \textbf{Heimatflugplatzes} liegt.
 \end{description}
 
 Die Konfigurations-Option \button{Erreichbare Polare} entscheidet darüber,

--- a/doc/manual/de/ch05_glide_computer.tex
+++ b/doc/manual/de/ch05_glide_computer.tex
@@ -468,7 +468,7 @@ DG $\rightarrow$ Dumm Gelaufen \verb":-("
 \vspace{2em}
 \section{Ermittlung der Schnittgeschwindigkeiten}\label{sec:task-speed-estim}
 
-Viele von \textsf{XCSoar's} internen Algorythmen benutzen Annahmen bzw.\ Vorhersagen für die Zeit, um
+Viele von \textsf{XCSoar's} internen Algorithmen benutzen Annahmen bzw.\ Vorhersagen für die Zeit, um
 einen bestimmten Punkt zu erreichen. Dies sind Berechnungen ''in die Zukunft''  aus bisher 
 gesammelten Informationen.
 

--- a/doc/manual/de/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/de/ch06_atmosphere_and_instruments.tex
@@ -131,15 +131,15 @@ eingestellt werden, welcher der Routinen benutzt werden soll
 \end{itemize}
 
 Wenn sich Windrichtung und/oder -stärke ändern, erscheint eine Meldung  auf dem Bildschirm begleitet von einem Ton.
-\subsection*{Kurbel--Algorythmus der Windermittlung}
-\xc ermittelt Windstärke und -richtung während des Kurbelns. Dies geschieht über einen ausgefeilten Algorythmus, welcher den Versatz über Grund während eines ganzen kreises im Bart ermittelt. Ovales Kurbeln mit ständig ändernder Querneigung vermindern die Qualität der Berechnung ganz beträchtlich, da dann der Flugweg extrapoliert werden muß. Die besten ergebnisse gibt es, wenn wirklich kreisrund mit konstanter Querneigung geflogen wird.\index{Wind!Ermittlung}
+\subsection*{Kurbel--Algorithmus der Windermittlung}
+\xc ermittelt Windstärke und -richtung während des Kurbelns. Dies geschieht über einen ausgefeilten Algorithmus, welcher den Versatz über Grund während eines ganzen kreises im Bart ermittelt. Ovales Kurbeln mit ständig ändernder Querneigung vermindern die Qualität der Berechnung ganz beträchtlich, da dann der Flugweg extrapoliert werden muß. Die besten ergebnisse gibt es, wenn wirklich kreisrund mit konstanter Querneigung geflogen wird.\index{Wind!Ermittlung}
 
 Die Berechnung kann nur erfolgen wenn die GPS-Quelle mehr als einen Fix pro zwei Sekunden ausgibt. 
 Da --aus Erfahrung-- immer mit GPS-Ausfällen gerechnte werden muß, wurde dies als Mindestanforderung zur halbwegs glaubwürdigen Windermittluing vorausgesetzt.  
  
-\subsection*{ZickZack--Algorythmus}
+\subsection*{ZickZack--Algorithmus}
 Für Flugzeuge, welche mit einem intelligenten Variometer ausgestattet sind, welches
-an \xc angeschlossen ist, bietet \xc die Möglichkeit, des ZickZack Algorythmus
+an \xc angeschlossen ist, bietet \xc die Möglichkeit, des ZickZack Algorithmus
 zur Ermittlung der Windkomponente.
 
 Mit dieser Methode ist es möglich, den Wind in Stärke und Richtung zu ermitteln, ohne Kurbeln zu müssen.
@@ -150,14 +150,14 @@ Es ist nicht unbedingt ein spezielles Manöver zu fliegen, denn normalerweise  f
 der Suche nach Thermik immer etwas nach links und nach rechts. Normalerweise benötigt diese
 Methode ein Abweichen vom Kurs von ca. 40$^\circ$.
 
-Wenn sich der Wind im Geradeausflug erheblich ändert wird der ZickZack-Algorythmus dazu benutzt
+Wenn sich der Wind im Geradeausflug erheblich ändert wird der ZickZack-Algorithmus dazu benutzt
 um den Wind zu aktualisieren - auch dann wenn sich der Kurs des Flugzeuges kaum oder nur wenig ändert.
 Höhere genauigkeiten sind damit erzielbar.
 
 Die Windermittlungen werden grundsätzlich aktualisiert, wenn sich größere Änderungen zwischen  der
 ermittelten Grundgeschwindigkeit und der wahren Grundgeschwindigkeit (z.B. GPS)
 im Geradeausflug entdeckt wurden.
-\subsection*{Kompaß - Algorythmus}
+\subsection*{Kompaß - Algorithmus}
 Für Flugzeuge, die mit einem intelligenten Variometer und einem Kompaßabgriff der
 Windrichtung ausgestattet sind, ermöglicht  \xc die Benutzung dieser Werte direkt.
 Hierdurch ist es überflüssig, für die Windermittlung zu kurbeln oder zickZack zu fliegen.
@@ -168,9 +168,9 @@ anschließende Aktualisierung bei Bedarf in der Luft.
 Wenn der Dialog geschlossen wird, werden die ermittelten Werte solange benutzt,
  bis neue Werte aus der ZickZack- oder Kurbelmessung vorliegen.
 
-Der automatische Windalgorythmus kann auch abgeschaltet oder aber es können
+Der automatische Windalgorithmus kann auch abgeschaltet oder aber es können
 beide Methoden verwandt werden (s.o. Bild) Siehe Kap.~\ref{sec:wind-estimation}
-\sketch{figures/dialog-wind2.png}zu den Details dieser Algorythmen.
+\sketch{figures/dialog-wind2.png}zu den Details dieser Algorithmen.
 
 Die Windabdrift in der Darstellung des geflogenen Pfades  auf der Karte kann ebenso an-
 oder ausgeschaltet werden. Nähere Details hierzu in Kap.~\ref{sec:trail}.
@@ -191,7 +191,7 @@ wie wichtig es ist, wieder Thermik zu finden\dots
 Wenn der Pfeil sich auf den unteren Rand des Bandes zubewegt, befindet sich das Flugzeug nahe der Aufbruchshöhe und der Pilot sollte sich allmählig damit abfinden, nun auch in schwächerer Thermik kurbeln zu müssen.
 
 \section{Thermikfinder}
-Durch einen Algorythmus wird der Kern der Thermik errechnet und dargestellt.
+Durch einen Algorithmus wird der Kern der Thermik errechnet und dargestellt.
 Das Symbol für das Zentrum ist eine kleine grüne Spirale auf der Karte der moving map.
 \sketch{figures/shot-tlocator-circling.png}
 Der Thermikfinder markiert \textit{fortlaufend  die letzten 20 Bärte} während des Fluges auf der Karte.

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -367,7 +367,7 @@ Die Filterfunktion ist beschrieben in Kap.~\ref{sec:airspace-filter}.
 
 %%%%%%%%%%%%%%%%%%
 \section{Endanflugrechner/Sicherheitsfaktoren}
-Hier werden Einstellungen für die Sicherheitshöhen und deren Verhalten in den Berechnungsalgorythmen vorgenommen.
+Hier werden Einstellungen für die Sicherheitshöhen und deren Verhalten in den Berechnungsalgorithmen vorgenommen.
 
 \begin{description}
 \item[\textit{Ankunftshöhe}] Sicherheitshöhe. \index{Sicherheitshöhe!Einstellung} Diese  gibt die Höhe über Grund am Zielpunkt an, in der das
@@ -402,7 +402,7 @@ Ein Wert von ca. $0.3$ ist empfohlen.  Mehr dazu auch in Kap.~\ref{sec:safety-fa
 Über diese Seite können die Routinen des Endanflugrechners von \xc  beinflußt werden.
 
 \begin{description}
-\item[\textit{MC Optimierung}]  Diese Option setzt fest, welcher MC-Algorythmus verwendet wrd.
+\item[\textit{MC Optimierung}]  Diese Option setzt fest, welcher MC-Algorithmus verwendet wrd.
 Mehr dazu in Kap.~\ref{sec:auto-maccready}. \\
    {\bf Endanflug}: Stellt den MC Wert auf die schnellstmögliche Ankunft ein.
    Bei OLC - Aufgaben werden die Einstellungen  so gewählt, daß \sketch{figures/config-glidecomputer.png} eine möglichst große Strecke innerhalb der verbleibenden Zeit zurückgelegt wird.\\
@@ -429,7 +429,7 @@ aktuellen Wert herankommen, größere Werte immer weiter an den Wert gemittell �
 \item[\textit{Geschätzte Winddrift$^{\textcolor{blue}{\star}}$}]  {\bf Ein / Aus}: Berücksichtigt die Abdrift durch den Wind während des Kurbelns. Dies wird die Ankunftshöhe auf Gegenwindschenkeln reduzieren
 und kann mitunter zu interpretationswürdigen Ergebnissen führen,
 wenn man sich im Endanflug unterhalb des Gleitpfades befindet, MC auf Null gestellt hat, und so also noch kurbeln \textsl{muß}.
-Nach der MC-Theorie heißt MC=0, daß kein Kurbeln mehr stattfindet. Der Algorythmus befindet sich so in einer Zwickmühle, denn einerseits wird mitgeteilt, daß nicht
+Nach der MC-Theorie heißt MC=0, daß kein Kurbeln mehr stattfindet. Der Algorithmus befindet sich so in einer Zwickmühle, denn einerseits wird mitgeteilt, daß nicht
 mehr gekurbelt wird, andererseits tut man es doch\dots
 \achtung Für das ''normale, althergebrachte Verhalten'' anderer Systeme sollte man sich überlegen, dies auf ''Aus'' stehen zu lassen.
 \end{description}
@@ -440,7 +440,7 @@ mehr gekurbelt wird, andererseits tut man es doch\dots
 Auf dieser Seite werden die Windeinstellungen vorgenommen. Details zu den verschiedenen Berechnungen in Kap.~\ref{sec:wind-estimation}
 \begin{description}
 \item[\textit{Windberech}]  \label{conf:autowind}  Auswahl des entsprechenden modus für Ermittlung des Windes in \xc \\
-  {\bf Manuell}: Wenn der Algorythmus ausgeschaltet ist, wird allein die Eingabe des Piloten benutzt. \\
+  {\bf Manuell}: Wenn der Algorithmus ausgeschaltet ist, wird allein die Eingabe des Piloten benutzt. \\
   {\bf beim Kreisen}: Benutzt das GPS zur Ermittlung des Windes durch Berechnung der Abdrift beim Kurbeln.\\
   \sketch{figures/config-wind.png}{\bf ZickZack}: ZickZack-Modus benötigt ein intelligentes Vario  mit einem Ausgang für die TAS.\\
   {\bf Beides}:  Benutzt den ZickZack und GPS-Modus zur Ermittlung des Windes.
@@ -568,7 +568,7 @@ rules. \label{conf:taskrules}\index{Aufgabe!Regeln Voreinstellung}
 \item[\textit{Zielhöhenref.$^{\textcolor{blue}{\star}}$}] Bezugshöhe der Ankunftshöhe:\\
     {\bf MSL}: Ankunftshöhe ist bezogen auf Meereshöhe.\\
     {\bf AGL}: Ankunftshöhe ist bezogen auf Höhe über Grund.
-\item[\textit{Contest}]  Einstellungen zu den Optimierungsalgorythmen des ausgewählten Wettbewerbs. \\
+\item[\textit{Contest}]  Einstellungen zu den Optimierungsalgorithmen des ausgewählten Wettbewerbs. \\
    {\bf OLC FAI}: Gleichlautend zu den FAI-Dreiecksregeln. Zwei Wenden, wobei Star-und Zielpunkt identisch sind.
    Kein Schenkel darf kürzer sein als 28\% der Gesamtstrecke. Bei Dreiecken größer als 500Km
    darf kein Schenkel größer sein als 25\% der Gesamtstrecke und länger als 45\% andernfalls kein
@@ -629,7 +629,7 @@ Gewertet wird das Zentrum des Zylinders.(britisch)\\
 {\bf  FAI Abzeichen / Rekorde}: FAI-Regeln. Erlaubt nur FAI Start-, Ziel- und Wendepunkttypen. Für Abzeichen und Rekorde. Aktiviert die FAI Höhe für die Endanflugbnerechnung.
 \item[\textit{AAT min. Zeit}] Die bei AAT-Aufgaben mindestens zu fliegende Zeit. Vorgabe durch WB-Leitung.
 \item[\textit{Optimierungs-Spielraum$^{\textcolor{blue}{\star}}$}] Sicherheitszeitraum für AAT-Optimierung.
-Als Schutz gegen ''zu früh ankommen''. Der Optimierungsalgorythmus versucht, die Aufgabe innerhalb der vorgegebenen Mindestflugzeit plus dieser Zusatzzeit zu bneenden.
+Als Schutz gegen ''zu früh ankommen''. Der Optimierungsalgorithmus versucht, die Aufgabe innerhalb der vorgegebenen Mindestflugzeit plus dieser Zusatzzeit zu bneenden.
 Im ''Optimiert''-Modus  werden dabei die AAT-Punkte automatisch verschoben, um diese Zeit einhalten zu können..
 \end{description}
 

--- a/doc/manual/de/ch13_history.tex
+++ b/doc/manual/de/ch13_history.tex
@@ -219,7 +219,7 @@ ausgestrahlt werden kann.
 $\star$:  Beiträge zum  LK8000 Projekt (\url{https://lk8000.it/}) hinzugefügt
 
 \vspace{1em}
-{\large\bf Kode und Algorythmen wurden weiterhin integriert von:}
+{\large\bf Kode und Algorithmen wurden weiterhin integriert von:}
 \begin{description}
   \input{contributors_other.tex}
 \end{description}

--- a/po/de.po
+++ b/po/de.po
@@ -4480,7 +4480,7 @@ msgstr "MC Optimierung"
 
 #: src/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp:78
 msgid "This option defines which auto MacCready algorithm is used."
-msgstr "Diese Option legt fest, welcher MacCready Algorythmus benutzt wird."
+msgstr "Diese Option legt fest, welcher MacCready Algorithmus benutzt wird."
 
 #: src/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp:81
 msgid "Block speed to fly"


### PR DESCRIPTION
Replace "Algorythmus" (and any inflections) with "Algorithmus" in German docs.
