### PR TITLE
Increase Message Timeouts to 2.5s

### DIFF
--- a/Data/Status/default.xcs
+++ b/Data/Status/default.xcs
@@ -78,6 +78,10 @@ key=Auto MacCready OFF
 sound=IDR_REMOVE
 delay=2500
 
+key=Task start
+sound=IDR_INSERT
+delay=5000
+
 key=Task aborted
 sound=IDR_REMOVE
 delay=2500

--- a/Data/Status/default.xcs
+++ b/Data/Status/default.xcs
@@ -1,67 +1,67 @@
 key=DEFAULT
 sound=IDR_WAV_DRIP
-delay=1500
+delay=2500
 
 key=Pan mode ON
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Pan mode OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=AutoZoom ON
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=AutoZoom OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Calibrate ON
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Calibrate OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Closest Airfield Changed!
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=SnailTrail OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=SnailTrail ON Long
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=SnailTrail ON Short
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Vario Sounds ON
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Vario Sounds OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Dropped marker
 sound=IDR_WAV_BEEPBWEEP
-delay=1500
+delay=2500
 
 key=Waiting for GPS connection
-delay=1500
+delay=2500
 
 key=Restarting comm. ports
-delay=1500
+delay=2500
 
 key=Waiting for GPS fix
-delay=1500
+delay=2500
 
 key=XCI Error
 delay=30000
@@ -72,19 +72,19 @@ delay=5000
 
 key=Auto MacCready ON
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Auto MacCready OFF
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Task aborted
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Task Resume
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Bugs performance
 delay=5000
@@ -94,11 +94,11 @@ delay=5000
 
 key=Logger ok
 sound=IDR_INSERT
-delay=1500
+delay=2500
 
 key=Logger off
 sound=IDR_REMOVE
-delay=1500
+delay=2500
 
 key=Status
 delay=60000
@@ -112,4 +112,4 @@ delay=1000
 
 # Always leave dummy entry for now (work around issue in parser)
 key=Dummy
-delay=1500
+delay=2500

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,12 @@
 Version 7.24 - not yet released
+* user interface
+  - padding in fields
+  - rework menu labels
+  - increase popup message timeouts
+* file handling 
+  - guard against file corruption in poweroff situations
+* FLARM
+  - timeouts in flight downloads  
 * Linux
   - fix terrain renderer bug
   - allow changing the language at runtime
@@ -8,6 +16,11 @@ Version 7.24 - not yet released
   - add SoftRF Lego into 'white list' of USB devices
 * calculations
   - support for LVZC Charron contest
+  - new asw27 polar from idaflieg
+* Windows
+  - new default fonts
+* XCVario/Borgelt
+  - revert cruise/circling mode change 
 
 Version 7.23 - 2022/02/10
 * user interface


### PR DESCRIPTION
The messages are displayed only 1.5s currently. 
That is too short for any situation, especially in a cockpit. 