### PR TITLE
Critical Errors found by Codacy

### DIFF
--- a/src/Airspace/AirspaceParser.cpp
+++ b/src/Airspace/AirspaceParser.cpp
@@ -217,7 +217,7 @@ struct TempAirspaceType
   }
 
   void
-  AppendArc(const GeoPoint start, const GeoPoint end) noexcept
+  AppendArc(const GeoPoint start, const GeoPoint end)
   {
     const auto center = RequireCenter();
 

--- a/src/net/http/Global.cxx
+++ b/src/net/http/Global.cxx
@@ -160,7 +160,7 @@ CurlGlobal::Add(CurlRequest &r)
 }
 
 void
-CurlGlobal::Remove(CurlRequest &r) noexcept
+CurlGlobal::Remove(CurlRequest &r)
 {
 	assert(GetEventLoop().IsInside());
 

--- a/src/net/http/Global.hxx
+++ b/src/net/http/Global.hxx
@@ -55,7 +55,7 @@ public:
 	}
 
 	void Add(CurlRequest &r);
-	void Remove(CurlRequest &r) noexcept;
+	void Remove(CurlRequest &r);
 
 	void Assign(curl_socket_t fd, CurlSocket &cs) noexcept {
 		curl_multi_assign(multi.Get(), fd, &cs);


### PR DESCRIPTION
Two functions that throw runtime errors, that are encapsulated by other function calls, that have noexpect defined.