### PR TITLE
Input/InputEventsActions: end pattern list with \0

### DIFF
--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -746,7 +746,7 @@ InputEvents::eventExchangeFrequencies(const TCHAR *misc)
 void
 InputEvents::eventUploadIGCFile(const TCHAR *misc) {
   FileDataField df;
-  df.ScanMultiplePatterns(_T("*.igc"));
+  df.ScanMultiplePatterns(_T("*.igc\0"));
   df.SetFileType(FileType::IGC);
   if (FilePicker(_T("IGC-FilePicker"), df)) {
     auto path = df.GetValue();


### PR DESCRIPTION
Pointer gets out of bounds in `ScanMultiplePatterns` if pattern list isn't terminated by empty string. This results in picking up extra undefined patterns and misbehaviour.