### PR TITLE
Documentation: Document base and namespace functions

### DIFF
--- a/src/Device/Driver/FLARM/StaticParser.hpp
+++ b/src/Device/Driver/FLARM/StaticParser.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -24,6 +24,11 @@ Copyright_License {
 #ifndef XCSOAR_FLARM_STATIC_PARSER_HPP
 #define XCSOAR_FLARM_STATIC_PARSER_HPP
 
+/** \file 
+ * Specific parsers for Flarm NMEA records.
+ * @see https://flarm.com/wp-content/uploads/man/FTD-012-Data-Port-Interface-Control-Document-ICD.pdf
+ */
+
 class TimeStamp;
 class NMEAInputLine;
 struct FlarmError;
@@ -33,12 +38,21 @@ struct TrafficList;
 
 /**
  * Parses a PFLAE sentence (self-test results).
+ * @param line The Flarm NMEA record to parse.
+ * @param error The current Flarm error state which will be updated by this
+ *              NMEA record.
+ * @param clock The time now.
  */
+
 void
 ParsePFLAE(NMEAInputLine &line, FlarmError &error, TimeStamp clock) noexcept;
 
 /**
  * Parses a PFLAV sentence (version information).
+ * @param line The Flarm NMEA record to parse.
+ * @param version The current Flarm version state which will be updated by
+ *                this NMEA record.
+ * @param clock The time now.
  */
 void
 ParsePFLAV(NMEAInputLine &line, FlarmVersion &version,
@@ -48,8 +62,10 @@ ParsePFLAV(NMEAInputLine &line, FlarmVersion &version,
  * Parses a PFLAU sentence
  * (Operating status and priority intruder and obstacle data)
  *
- * @param line A NMEAInputLine instance that can be used for parsing
- * @see http://flarm.com/support/manual/FLARM_DataportManual_v5.00E.pdf
+ * @param line The Flarm NMEA record to parse.
+ * @param flarm The current Flarm status which will be updated by this NMEA
+ *              record.
+ * @param clock The time now.
  */
 void
 ParsePFLAU(NMEAInputLine &line, FlarmStatus &flarm, TimeStamp clock) noexcept;
@@ -58,8 +74,10 @@ ParsePFLAU(NMEAInputLine &line, FlarmStatus &flarm, TimeStamp clock) noexcept;
  * Parses a PFLAA sentence
  * (Data on other moving objects around)
  *
- * @param line A NMEAInputLine instance that can be used for parsing
- * @see http://flarm.com/support/manual/FLARM_DataportManual_v5.00E.pdf
+ * @param line The Flarm NMEA record to parse.
+ * @param flarm The current Flarm status which will be updated by this NMEA
+ *              record.
+ * @param clock The time now.
  */
 void
 ParsePFLAA(NMEAInputLine &line, TrafficList &flarm, TimeStamp clock) noexcept;

--- a/src/ui/canvas/Color.hpp
+++ b/src/ui/canvas/Color.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_SCREEN_COLOR_HPP
 #define XCSOAR_SCREEN_COLOR_HPP
+
+/** \file */
 
 // IWYU pragma: begin_exports
 #ifdef ENABLE_OPENGL

--- a/src/ui/canvas/Features.hpp
+++ b/src/ui/canvas/Features.hpp
@@ -24,6 +24,8 @@ Copyright_License {
 #ifndef XCSOAR_UI_CANVAS_FEATURES_HPP
 #define XCSOAR_UI_CANVAS_FEATURES_HPP
 
+/** \file */
+
 #ifdef USE_MEMORY_CANVAS
 #include "memory/Features.hpp"
 #endif

--- a/src/ui/canvas/custom/Files.hpp
+++ b/src/ui/canvas/custom/Files.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_SCREEN_CUSTOM_FILES_HPP
 #define XCSOAR_SCREEN_CUSTOM_FILES_HPP
+
+/** \file */
 
 class AllocatedPath;
 

--- a/src/ui/canvas/custom/LibPNG.hpp
+++ b/src/ui/canvas/custom/LibPNG.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_LIBPNG_HPP
 #define XCSOAR_LIBPNG_HPP
+
+/** \file */
 
 #include <cstddef>
 

--- a/src/ui/canvas/custom/LibTiff.hpp
+++ b/src/ui/canvas/custom/LibTiff.hpp
@@ -24,6 +24,8 @@ Copyright_License {
 #ifndef XCSOAR_LIBTIFF_HPP
 #define XCSOAR_LIBTIFF_HPP
 
+/** \file */
+
 #include <utility>
 
 class Path;

--- a/src/ui/canvas/gdi/GdiPlusBitmap.hpp
+++ b/src/ui/canvas/gdi/GdiPlusBitmap.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_UI_CANVAS_GDI_GDIBITMAP_HPP
 #define XCSOAR_UI_CANVAS_GDI_GDIBITMAP_HPP
+
+/** \file */
 
 #if defined(_WIN32) && defined(USE_GDI)
 

--- a/src/ui/canvas/memory/Export.hpp
+++ b/src/ui/canvas/memory/Export.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_SCREEN_MEMORY_EXPORT_HPP
 #define XCSOAR_SCREEN_MEMORY_EXPORT_HPP
+
+/** \file */
 
 #include "Concepts.hpp"
 #include "PixelTraits.hpp"

--- a/src/ui/canvas/opengl/Geo.hpp
+++ b/src/ui/canvas/opengl/Geo.hpp
@@ -23,6 +23,8 @@ Copyright_License {
 
 #pragma once
 
+/** \file */
+
 #include <glm/fwd.hpp>
 
 struct GeoPoint;

--- a/src/ui/canvas/opengl/Triangulate.hpp
+++ b/src/ui/canvas/opengl/Triangulate.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_SCREEN_OPENGL_TRIANGULATE_HPP
 #define XCSOAR_SCREEN_OPENGL_TRIANGULATE_HPP
+
+/** \file */
 
 #include "ui/opengl/System.hpp"
 

--- a/src/ui/canvas/opengl/UncompressedImage.hpp
+++ b/src/ui/canvas/opengl/UncompressedImage.hpp
@@ -24,6 +24,8 @@ Copyright_License {
 #ifndef XCSOAR_OPENGL_UNCOMPRESSED_IMAGE_HPP
 #define XCSOAR_OPENGL_UNCOMPRESSED_IMAGE_HPP
 
+/** \file */
+
 class GLTexture;
 class UncompressedImage;
 

--- a/src/ui/event/Idle.hpp
+++ b/src/ui/event/Idle.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -22,6 +22,8 @@ Copyright_License {
 */
 
 #pragma once
+
+/** \file */
 
 /**
  * Check whether the user is currently inactive.

--- a/src/ui/opengl/Types.hpp
+++ b/src/ui/opengl/Types.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_SCREEN_OPENGL_TYPES_HPP
 #define XCSOAR_SCREEN_OPENGL_TYPES_HPP
+
+/** \file */
 
 #include "System.hpp"
 

--- a/src/util/ASCII.hxx
+++ b/src/util/ASCII.hxx
@@ -30,6 +30,8 @@
 #ifndef ASCII_HXX
 #define ASCII_HXX
 
+/** \file */
+
 #include <cstddef>
 
 #ifdef _UNICODE

--- a/src/util/Algorithm.hpp
+++ b/src/util/Algorithm.hpp
@@ -30,6 +30,8 @@
 #ifndef ALGORITHM_HPP
 #define ALGORITHM_HPP
 
+/** \file */
+
 /**
  * @return true if predicate() returns true for at least one item in
  * the range

--- a/src/util/ByteOrder.hxx
+++ b/src/util/ByteOrder.hxx
@@ -31,6 +31,8 @@
 #ifndef BYTE_ORDER_HXX
 #define BYTE_ORDER_HXX
 
+/** \file */
+
 #include "Compiler.h"
 
 #include <cstdint>

--- a/src/util/CRC.hpp
+++ b/src/util/CRC.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_CRC_HPP
 #define XCSOAR_CRC_HPP
+
+/** \file */
 
 #include "Compiler.h"
 

--- a/src/util/Cast.hxx
+++ b/src/util/Cast.hxx
@@ -30,6 +30,8 @@
 #ifndef CAST_HXX
 #define CAST_HXX
 
+/** \file */
+
 #include "OffsetPointer.hxx"
 
 #include <cstddef>

--- a/src/util/CharUtil.hxx
+++ b/src/util/CharUtil.hxx
@@ -30,6 +30,8 @@
 #ifndef CHAR_UTIL_HXX
 #define CHAR_UTIL_HXX
 
+/** \file */
+
 #ifdef _UNICODE
 #include "WCharUtil.hxx"
 #endif

--- a/src/util/Clamp.hpp
+++ b/src/util/Clamp.hpp
@@ -30,6 +30,8 @@
 #ifndef CLAMP_HPP
 #define CLAMP_HPP
 
+/** \file */
+
 #include "Compiler.h"
 
 /**

--- a/src/util/ContainerCast.hxx
+++ b/src/util/ContainerCast.hxx
@@ -30,6 +30,8 @@
 #ifndef CAST_HXX
 #define CAST_HXX
 
+/** \file */
+
 #include <cstddef>
 
 /**

--- a/src/util/ConvertString.hpp
+++ b/src/util/ConvertString.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_CONVERT_STRING_HPP
 #define XCSOAR_CONVERT_STRING_HPP
+
+/** \file */
 
 #include "UTF8.hpp"
 #include "Compiler.h"

--- a/src/util/DollarExpand.hpp
+++ b/src/util/DollarExpand.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef DOLLAR_EXPAND_HPP
 #define DOLLAR_EXPAND_HPP
+
+/** \file */
 
 #include "StringAPI.hxx"
 #include "TruncateString.hpp"

--- a/src/util/EscapeBackslash.hpp
+++ b/src/util/EscapeBackslash.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_UTIL_ESCAPE_BACKSLASH_HPP
 #define XCSOAR_UTIL_ESCAPE_BACKSLASH_HPP
+
+/** \file */
 
 #include "TStringView.hxx"
 

--- a/src/util/Exception.hxx
+++ b/src/util/Exception.hxx
@@ -30,6 +30,8 @@
 #ifndef EXCEPTION_HXX
 #define EXCEPTION_HXX
 
+/** \file */
+
 #include <exception>
 #include <string>
 #include <utility>

--- a/src/util/ExtractParameters.hpp
+++ b/src/util/ExtractParameters.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef EXTRACT_PARAMETERS_HPP
 #define EXTRACT_PARAMETERS_HPP
+
+/** \file */
 
 #include <tchar.h>
 #include <cstddef>

--- a/src/util/HexFormat.hxx
+++ b/src/util/HexFormat.hxx
@@ -32,6 +32,8 @@
 
 #pragma once
 
+/** \file */
+
 #include <array>
 #include <cstdint>
 

--- a/src/util/HexString.hpp
+++ b/src/util/HexString.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef HEX_STRING_HPP
 #define HEX_STRING_HPP
+
+/** \file */
 
 #include <array>
 #include <string_view>

--- a/src/util/NumberParser.hpp
+++ b/src/util/NumberParser.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_NUMBER_PARSER_HPP
 #define XCSOAR_NUMBER_PARSER_HPP
+
+/** \file */
 
 #include <cstdint>
 #include <stdlib.h>

--- a/src/util/OffsetPointer.hxx
+++ b/src/util/OffsetPointer.hxx
@@ -29,6 +29,8 @@
 
 #pragma once
 
+/** \file */
+
 #include <cstddef>
 
 /**

--- a/src/util/Sanitizer.hxx
+++ b/src/util/Sanitizer.hxx
@@ -32,6 +32,8 @@
 
 #pragma once
 
+/** \file */
+
 constexpr bool
 HaveAddressSanitizer() noexcept
 {

--- a/src/util/SpanCast.hxx
+++ b/src/util/SpanCast.hxx
@@ -29,6 +29,8 @@
 
 #pragma once
 
+/** \file */
+
 #include <cassert>
 #include <cstddef>
 #include <span>

--- a/src/util/StaticString.hxx
+++ b/src/util/StaticString.hxx
@@ -30,6 +30,8 @@
 #ifndef STATIC_STRING_HPP
 #define STATIC_STRING_HPP
 
+/** \file */
+
 #include "StringBuffer.hxx"
 #include "StringAPI.hxx"
 #include "StringUtil.hpp"

--- a/src/util/StringAPI.hxx
+++ b/src/util/StringAPI.hxx
@@ -30,6 +30,8 @@
 #ifndef STRING_API_HXX
 #define STRING_API_HXX
 
+/** \file */
+
 #include <cstring>
 
 #ifdef _UNICODE

--- a/src/util/StringCompare.hxx
+++ b/src/util/StringCompare.hxx
@@ -30,6 +30,8 @@
 #ifndef STRING_COMPARE_HXX
 #define STRING_COMPARE_HXX
 
+/** \file */
+
 #include "StringAPI.hxx"
 
 #ifdef _UNICODE

--- a/src/util/StringFormat.hpp
+++ b/src/util/StringFormat.hpp
@@ -30,6 +30,8 @@
 #ifndef STRING_FORMAT_HPP
 #define STRING_FORMAT_HPP
 
+/** \file */
+
 #ifdef _UNICODE
 #include "WStringFormat.hpp"
 #endif

--- a/src/util/StringStrip.hxx
+++ b/src/util/StringStrip.hxx
@@ -30,6 +30,8 @@
 #ifndef STRING_STRIP_HXX
 #define STRING_STRIP_HXX
 
+/** \file */
+
 #include <cstddef>
 
 #ifdef _UNICODE

--- a/src/util/StringUtil.hpp
+++ b/src/util/StringUtil.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_STRING_UTIL_HPP
 #define XCSOAR_STRING_UTIL_HPP
+
+/** \file */
 
 #include <cstddef>
 

--- a/src/util/TextFile.hxx
+++ b/src/util/TextFile.hxx
@@ -30,6 +30,8 @@
 #ifndef TEXT_FILE_HXX
 #define TEXT_FILE_HXX
 
+/** \file */
+
 #include <cstring>
 
 template<typename B>

--- a/src/util/TriState.hpp
+++ b/src/util/TriState.hpp
@@ -30,6 +30,8 @@
 #ifndef TRI_STATE_HPP
 #define TRI_STATE_HPP
 
+/** \file */
+
 #include <cstdint>
 
 #ifdef _WIN32

--- a/src/util/TruncateString.hpp
+++ b/src/util/TruncateString.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_TRUNCATE_STRING_HPP
 #define XCSOAR_TRUNCATE_STRING_HPP
+
+/** \file */
 
 #include <tchar.h>
 #include <cstddef>

--- a/src/util/TypeTraits.hpp
+++ b/src/util/TypeTraits.hpp
@@ -30,6 +30,8 @@
 #ifndef TYPE_TRAITS_HPP
 #define TYPE_TRAITS_HPP
 
+/** \file */
+
 #include <type_traits>
 
 /**

--- a/src/util/UTF8.hpp
+++ b/src/util/UTF8.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef XCSOAR_UTIL_UTF8_HPP
 #define XCSOAR_UTIL_UTF8_HPP
+
+/** \file */
 
 #include <cstddef>
 #include <string_view>

--- a/src/util/WASCII.hxx
+++ b/src/util/WASCII.hxx
@@ -30,6 +30,8 @@
 #ifndef WASCII_HXX
 #define WASCII_HXX
 
+/** \file */
+
 #include <cstddef>
 
 #include <wchar.h>

--- a/src/util/WCharUtil.hxx
+++ b/src/util/WCharUtil.hxx
@@ -30,6 +30,8 @@
 #ifndef WCHAR_UTIL_HXX
 #define WCHAR_UTIL_HXX
 
+/** \file */
+
 #include <wchar.h>
 
 constexpr bool

--- a/src/util/WStringAPI.hxx
+++ b/src/util/WStringAPI.hxx
@@ -30,6 +30,8 @@
 #ifndef WSTRING_API_HXX
 #define WSTRING_API_HXX
 
+/** \file */
+
 #include <cwchar>
 
 [[gnu::pure]] [[gnu::nonnull]]

--- a/src/util/WStringCompare.hxx
+++ b/src/util/WStringCompare.hxx
@@ -30,6 +30,8 @@
 #ifndef WSTRING_COMPARE_HXX
 #define WSTRING_COMPARE_HXX
 
+/** \file */
+
 #include "WStringAPI.hxx"
 
 #include <string_view>

--- a/src/util/WStringFormat.hpp
+++ b/src/util/WStringFormat.hpp
@@ -30,6 +30,8 @@
 #ifndef WSTRING_FORMAT_HPP
 #define WSTRING_FORMAT_HPP
 
+/** \file */
+
 #include <stdio.h>
 
 #ifdef _WIN32

--- a/src/util/WStringStrip.hxx
+++ b/src/util/WStringStrip.hxx
@@ -30,6 +30,8 @@
 #ifndef WSTRING_STRIP_HXX
 #define WSTRING_STRIP_HXX
 
+/** \file */
+
 #include <wchar.h>
 
 /**

--- a/src/util/WStringUtil.hpp
+++ b/src/util/WStringUtil.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -23,6 +23,8 @@ Copyright_License {
 
 #ifndef WSTRING_UTIL_HPP
 #define WSTRING_UTIL_HPP
+
+/** \file */
 
 #include <wchar.h>
 

--- a/src/util/tstring.hpp
+++ b/src/util/tstring.hpp
@@ -1,6 +1,8 @@
 #ifndef TSTRING_HPP
 #define TSTRING_HPP
 
+/** \file */
+
 #include <string>
 
 #ifdef _UNICODE


### PR DESCRIPTION
Modify some, but not all, of the headers required to begin documentation
by doxygen of base and namespace functions (i.e. non class member functions)

Many of the elements of XCSoar are currently not documented by doxygen which limits its usefulness. This commit goes part way to addressing this deficiency.