### PR TITLE
IDE: add missing package for OpenGL math

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -47,7 +47,7 @@ apt-get install ${APTOPTS[*]} make g++ \
   libsdl2-dev \
   librsvg2-bin xsltproc \
   imagemagick gettext \
-  mesa-common-dev libgl1-mesa-dev libegl1-mesa-dev \
+  mesa-common-dev libgl1-mesa-dev libegl1-mesa-dev libglm-dev \
   fonts-dejavu \
   xz-utils
 echo


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Add development package for OpenGL math.

Related issues and discussions
------------------------------
When I build the docker container and compile TARGET=UNIX it complains about this missing package.