### PR TITLE
SkyLines: Honor usage conditions of FileDescriptor

### DIFF
--- a/src/Tracking/SkyLines/Client.cpp
+++ b/src/Tracking/SkyLines/Client.cpp
@@ -82,7 +82,8 @@ SkyLinesTracking::Client::Open(SocketAddress _address)
 void
 SkyLinesTracking::Client::InternalClose() noexcept
 {
-  socket.Close();
+  if (socket.IsDefined())
+    socket.Close();
   socket_event.Abandon();
 
   const std::lock_guard<Mutex> lock(mutex);


### PR DESCRIPTION
The documentation for FileDescriptor::Close() states that it should
only be called if File::Descriptor::IsDefined() is true. So do that.
