### PR TITLE
Documentation: Allow file tracking

### DIFF
--- a/src/Atmosphere/Pressure.hpp
+++ b/src/Atmosphere/Pressure.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -25,6 +25,7 @@ Copyright_License {
 #define XCSOAR_ATMOSPHERE_PRESSURE_H
 
 /**
+ * @file
  * ICAO Standard Atmosphere calculations (valid in Troposphere, alt<11000m)
  *
  */

--- a/src/Atmosphere/Temperature.hpp
+++ b/src/Atmosphere/Temperature.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -25,6 +25,10 @@ Copyright_License {
 #define XCSOAR_ATMOSPHERE_TEMPERATURE_HPP
 
 #include <cmath>
+
+/**
+ * @file
+ */
 
 /**
  * The offset between 0 Kelvin and 0 degrees Celsius [K].

--- a/src/Computer/BasicComputer.hpp
+++ b/src/Computer/BasicComputer.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -33,7 +33,7 @@ struct FeaturesSettings;
 struct ComputerSettings;
 
 /**
- * A computer which adds missing values to #NMEA_INFO.  It performs
+ * A computer which adds missing values to #NEMAInfo.  It performs
  * simple and fast calculations after every GPS update, cheap enough
  * to run outside of the #CalculationThread.
  */

--- a/src/FLARM/Data.hpp
+++ b/src/FLARM/Data.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -32,6 +32,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * A container for all data received by a FLARM.
  */
 struct FlarmData {

--- a/src/FLARM/Error.hpp
+++ b/src/FLARM/Error.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -36,6 +36,7 @@ Copyright_License {
 #endif
 
 /**
+ * @file
  * The FLARM self-test results read from the PFLAE sentence.
  */
 struct FlarmError {

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -31,6 +31,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * This class keeps track of the traffic objects received from a
  * FLARM.
  */

--- a/src/FLARM/Status.hpp
+++ b/src/FLARM/Status.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -30,6 +30,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * The FLARM operation status read from the PFLAU sentence.
  */
 struct FlarmStatus {

--- a/src/FLARM/Version.hpp
+++ b/src/FLARM/Version.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -31,6 +31,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * The FLARM version read from the PFLAV sentence.
  */
 struct FlarmVersion {

--- a/src/Geo/GeoPoint.hpp
+++ b/src/Geo/GeoPoint.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -33,6 +33,7 @@ Copyright_License {
 struct GeoVector;
 
 /**
+ * @file
  * Geodetic coordinate expressed as Longitude and Latitude angles.
  */
 struct GeoPoint {

--- a/src/Geo/SpeedVector.hpp
+++ b/src/Geo/SpeedVector.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -28,6 +28,7 @@ Copyright_License {
 #include "Math/Angle.hpp"
 
 /**
+ * @file
  * An object describing the speed vector in a two dimensional surface.
  */
 struct SpeedVector {

--- a/src/Math/Angle.hpp
+++ b/src/Math/Angle.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -36,6 +36,10 @@ Copyright_License {
 #include <cmath>
 #include <compare>
 
+/**
+ * @file
+ * Container class for angular variables.
+ */
 class Angle
 {
   double value;

--- a/src/Math/Classify.hpp
+++ b/src/Math/Classify.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -24,6 +24,7 @@ Copyright_License {
 #pragma once
 
 /**
+ * @file
  * A constexpr wrapper for std::isfinite().  This uses the
  * non-standard __builtin_isfinite() function (specific to GCC and
  * clang) because the C++ standard library is not "constexpr".

--- a/src/NMEA/Acceleration.hpp
+++ b/src/NMEA/Acceleration.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -25,6 +25,7 @@ Copyright_License {
 #define XCSOAR_ACCELERATION_HPP
 
 /**
+ * @file
  * State of acceleration of aircraft
  */
 struct AccelerationState

--- a/src/NMEA/Aircraft.hpp
+++ b/src/NMEA/Aircraft.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -28,6 +28,9 @@ struct MoreData;
 struct DerivedInfo;
 struct AircraftState;
 
+/**
+ * @file
+ */
 [[gnu::pure]]
 const AircraftState
 ToAircraftState(const MoreData &info, const DerivedInfo &calculated);

--- a/src/NMEA/Attitude.hpp
+++ b/src/NMEA/Attitude.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -27,6 +27,10 @@ Copyright_License {
 #include "Math/Angle.hpp"
 #include "Validity.hpp"
 
+/**
+ * @file
+ * A container holding the aircraft current attitude state.
+ */
 struct AttitudeState
 {
   /** Estimated bank angle */
@@ -42,6 +46,9 @@ struct AttitudeState
   Validity pitch_angle_available;
   Validity heading_available;
 
+  /**
+   * Invalidate all data held in this object.
+   */
   constexpr void Reset() noexcept {
     bank_angle_available.Clear();
     pitch_angle_available.Clear();

--- a/src/NMEA/Checksum.hpp
+++ b/src/NMEA/Checksum.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -27,6 +27,7 @@ Copyright_License {
 #include <cstdint>
 
 /**
+ * @file
  * Calculates the checksum for the specified line (without the
  * asterisk and the newline character).
  *

--- a/src/NMEA/CirclingInfo.hpp
+++ b/src/NMEA/CirclingInfo.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -31,6 +31,10 @@ Copyright_License {
 #include <type_traits>
 
 #include <cstdint>
+
+/**
+ * @file
+ */
 
 /** Enumeration for cruise/circling mode detection */
 enum class CirclingMode: uint8_t {

--- a/src/NMEA/ClimbHistory.hpp
+++ b/src/NMEA/ClimbHistory.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * Derived climb rate history
  * 
  */

--- a/src/NMEA/ClimbInfo.hpp
+++ b/src/NMEA/ClimbInfo.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -28,7 +28,10 @@ Copyright_License {
 
 #include <type_traits>
 
-/** Information about one thermal that was or is being climbed. */
+/**
+ * @file
+ * Information about one thermal that was or is being climbed.
+ */
 struct OneClimbInfo
 {
   /** Time when circling started. */

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -48,7 +48,9 @@ Copyright_License {
 
 #include <type_traits>
 
-/** Derived terrain altitude information, including glide range */
+/** @file 
+ * Derived terrain altitude information, including glide range
+ */
 struct TerrainInfo
 {
   /** True if terrain is valid, False otherwise */

--- a/src/NMEA/DeviceInfo.hpp
+++ b/src/NMEA/DeviceInfo.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * Some generic information about the connected device.
  *
  * This struct was initially modeled after the $LXWP1 sentence (LXNav

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -33,6 +33,7 @@ Copyright_License {
 #include <math.h>
 
 /**
+ * @file
  * Settings received from an external device.
  */
 struct ExternalSettings {

--- a/src/NMEA/FlyingState.hpp
+++ b/src/NMEA/FlyingState.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -30,6 +30,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * Structure for flying state (takeoff/landing)
  */
 struct FlyingState

--- a/src/NMEA/GPSState.hpp
+++ b/src/NMEA/GPSState.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -41,6 +41,7 @@ enum class FixQuality: uint8_t {
 };
 
 /**
+ * @file
  * State of GPS fix
  */
 struct GPSState

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -24,18 +24,18 @@ Copyright_License {
 #ifndef XCSOAR_NMEA_INFO_H
 #define XCSOAR_NMEA_INFO_H
 
-#include "GPSState.hpp"
+#include "NMEA/GPSState.hpp"
 #include "NMEA/Validity.hpp"
 #include "NMEA/ExternalSettings.hpp"
 #include "NMEA/Acceleration.hpp"
 #include "NMEA/Attitude.hpp"
-#include "SwitchState.hpp"
+#include "NMEA/SwitchState.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "time/Stamp.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "Atmosphere/Pressure.hpp"
 #include "Atmosphere/Temperature.hpp"
-#include "DeviceInfo.hpp"
+#include "NMEA/DeviceInfo.hpp"
 #include "FLARM/Data.hpp"
 #include "Geo/SpeedVector.hpp"
 
@@ -47,6 +47,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * A struct that holds all the parsed data read from the connected devices
  */
 struct NMEAInfo {

--- a/src/NMEA/InputLine.hpp
+++ b/src/NMEA/InputLine.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -27,6 +27,7 @@ Copyright_License {
 #include "io/CSVLine.hpp"
 
 /**
+ * @file
  * A helper class which can dissect a NMEA input line.
  */
 class NMEAInputLine: public CSVLine {

--- a/src/NMEA/LiftDatabase.hpp
+++ b/src/NMEA/LiftDatabase.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -27,6 +27,7 @@ Copyright_License {
 #include <type_traits>
 #include <array>
 
+/** @file */
 class LiftDatabase : public std::array<double, 36> {
 public:
   void Clear() {

--- a/src/NMEA/MoreData.hpp
+++ b/src/NMEA/MoreData.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * A wrapper for NMEA_INFO which adds a few attributes that are cheap
  * to calculate.  They are managed by #BasicComputer inside
  * #MergeThread.

--- a/src/NMEA/SwitchState.hpp
+++ b/src/NMEA/SwitchState.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 #include <cstdint>
 
 /**
+ * @file
  * State of external switch devices (esp Vega)
  */
 struct SwitchState

--- a/src/NMEA/ThermalLocator.hpp
+++ b/src/NMEA/ThermalLocator.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -32,7 +32,10 @@ Copyright_License {
 
 struct SpeedVector;
 
-/** Structure to hold information on identified thermal sources on the ground */
+/**
+ * @file
+ * Structure to hold information on identified thermal sources on the ground
+ */
 struct ThermalSource
 {
   GeoPoint location;

--- a/src/NMEA/Validity.hpp
+++ b/src/NMEA/Validity.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -33,6 +33,7 @@ Copyright_License {
 #include <cstdint>
 
 /**
+ * @file
  * This keeps track when a value was last changed, to check if it was
  * updated recently or to see if it has expired.  Additionally, it can
  * track if the attribute is not set (timestamp is zero).

--- a/src/NMEA/VarioInfo.hpp
+++ b/src/NMEA/VarioInfo.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -28,7 +28,10 @@ Copyright_License {
 
 #include <type_traits>
 
-/** Derived vario data */
+/**
+ * @file
+ * Derived vario data
+ */
 struct VarioInfo
 {
   double sink_rate;

--- a/src/NMEA/VegaSwitchState.hpp
+++ b/src/NMEA/VegaSwitchState.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -24,6 +24,9 @@ Copyright_License {
 #ifndef XCSOAR_VEGA_SWITCH_STATE_HPP
 #define XCSOAR_VEGA_SWITCH_STATE_HPP
 
+/**
+ * @file
+ */
 struct VegaSwitchState {
   static constexpr unsigned INVALID = -1;
 

--- a/src/RadioFrequency.hpp
+++ b/src/RadioFrequency.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -30,7 +30,8 @@ Copyright_License {
 #include <tchar.h>
 
 /**
- * This class tores a VHF radio frequency.
+ * @file
+ * This class stores a VHF radio frequency.
  */
 class RadioFrequency {
   static constexpr unsigned BASE_KHZ = 100000;

--- a/src/time/BrokenDate.hpp
+++ b/src/time/BrokenDate.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 #include <cstdint>
 
 /**
+ * @file
  * A broken-down representation of a date.
  */
 struct BrokenDate {

--- a/src/time/BrokenDateTime.hpp
+++ b/src/time/BrokenDateTime.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -31,6 +31,7 @@ Copyright_License {
 #include <type_traits>
 
 /**
+ * @file
  * A broken-down representation of date and time.
  */
 struct BrokenDateTime : public BrokenDate, public BrokenTime {

--- a/src/time/BrokenTime.hpp
+++ b/src/time/BrokenTime.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -30,6 +30,7 @@ Copyright_License {
 #include <cstdint>
 
 /**
+ * @file
  * A broken-down representation of a time.
  */
 struct BrokenTime {

--- a/src/time/FloatDuration.hxx
+++ b/src/time/FloatDuration.hxx
@@ -33,6 +33,7 @@
 #include <cmath>
 
 /**
+ * @file
  * A specialization of std::chrono::duration which stores the duration
  * in seconds in a double-precision floating point variable.
  */

--- a/src/time/Stamp.hpp
+++ b/src/time/Stamp.hpp
@@ -2,7 +2,7 @@
 Copyright_License {
 
   XCSoar Glide Computer - http://www.xcsoar.org/
-  Copyright (C) 2000-2021 The XCSoar Project
+  Copyright (C) 2000-2022 The XCSoar Project
   A detailed list of copyright holders can be found in the file "AUTHORS".
 
   This program is free software; you can redistribute it and/or
@@ -29,6 +29,7 @@ Copyright_License {
 struct NMEAInfo;
 
 /**
+ * @file
  * This class describes a time point during a flight.  It is used for
  * XCSoar's calculations.  Internally, it is the duration since
  * midnight of the day the flight started.


### PR DESCRIPTION
Modify some, but not all,  headers to track them as files. This allows
header dependency graphs to be produced.