### PR TITLE
Fix for the problem with IMI Erixx declaration.

### DIFF
--- a/src/Device/Driver/IMI/Protocol/Protocol.cpp
+++ b/src/Device/Driver/IMI/Protocol/Protocol.cpp
@@ -166,7 +166,7 @@ IMI::DeclarationWrite(Port &port, const Declaration &decl,
 
   // send declaration for current task
   SendRet(port, env, MSG_DECLARATION, &imiDecl, sizeof(imiDecl),
-          MSG_ACK_SUCCESS, 2000, -1);
+          MSG_ACK_SUCCESS, 0, -1);
 }
 
 bool


### PR DESCRIPTION
Brief summary of the changes
----------------------------
`return SendRet(port, env, MSG_DECLARATION, &imiDecl, sizeof(imiDecl), MSG_ACK_SUCCESS, 2000, -1) != nullptr;`
introduced in e3c23f22a2 was causing a problem with declaration on IMI Erixx logger.
The parameter "2000" was probably meant as a value for timeout, but it was put in the position of the parameter `retPayloadSize`.

Related issues and discussions
------------------------------
Closes #876