### PR TITLE
Color MC and Radio Infoboxes according to state

### DIFF
--- a/src/InfoBoxes/Content/MacCready.cpp
+++ b/src/InfoBoxes/Content/MacCready.cpp
@@ -69,6 +69,7 @@ InfoBoxContentMacCready::Update(InfoBoxData &data) noexcept
     CommonInterface::GetComputerSettings();
 
   data.SetTitle(settings_computer.task.auto_mc ? _("MC AUTO") : _("MC MANUAL"));
+  data.SetValueColor(settings_computer.task.auto_mc ? (0): (3));
 
   SetVSpeed(data, settings_computer.polar.glide_polar_task.GetMC());
 

--- a/src/InfoBoxes/Content/Radio.cpp
+++ b/src/InfoBoxes/Content/Radio.cpp
@@ -71,6 +71,7 @@ InfoBoxContentActiveRadioFrequency::Update(InfoBoxData &data) noexcept
 {
   const auto &settings_radio =
     CommonInterface::GetComputerSettings().radio;
+    data.SetValueColor(3);
   UpdateInfoBoxFrequency(data, settings_radio.active_frequency, settings_radio.active_name);
 }
 
@@ -85,5 +86,6 @@ InfoBoxContentStandbyRadioFrequency::Update(InfoBoxData &data) noexcept
 {
   const auto &settings_radio =
     CommonInterface::GetComputerSettings().radio;
+    data.SetValueColor(2);
   UpdateInfoBoxFrequency(data, settings_radio.standby_frequency, settings_radio.standby_name);
 }

--- a/src/InfoBoxes/Data.cpp
+++ b/src/InfoBoxes/Data.cpp
@@ -43,6 +43,7 @@ InfoBoxData::SetInvalid() noexcept
 void
 InfoBoxData::SetValueInvalid() noexcept
 {
+  SetValueColor(0);
   SetValue(_T("---"));
   SetValueUnit(Unit::UNDEFINED);
 }


### PR DESCRIPTION
Sets MC to Green if a value is configured manually. 
Sets Radio Active to Green if a value is configured. 
Sets Radio StandBy to Blue as an armed value. 

According to:
https://www.faa.gov/documentLibrary/media/Advisory_Circular/AC_25-11B.pdf

Table 5-2. Specified Colors for Certain Display Features