### PR TITLE
Terrain: Set contrast/brightness according to modern screens

### DIFF
--- a/src/Terrain/TerrainSettings.cpp
+++ b/src/Terrain/TerrainSettings.cpp
@@ -28,8 +28,8 @@ TerrainRendererSettings::SetDefaults()
 {
   enable = true;
   slope_shading = SlopeShading::WIND;
-  contrast = 150;
-  brightness = 36;
+  contrast = 65;
+  brightness = 192;
   ramp = 0;
   contours = Contours::OFF;
 }


### PR DESCRIPTION
I think we are giving XCSoar's Terrain Renderer not enough credit.
This change changes the default setting for the renderer (which is an expert setting)
to a high brightness and lower contrast value. 
The shading is still visible and the appearance is more detailed.

Before:
![2022-08-17-010016_958x351_scrot](https://user-images.githubusercontent.com/407371/185000136-25ec18b8-6960-48b8-b6eb-1bcca290a906.png)
After:
![2022-08-17-010037_958x351_scrot](https://user-images.githubusercontent.com/407371/185000139-4b4c6190-726a-42c1-81f3-77475790568c.png)

