### PR TITLE
gh: build-native only upload artifact on push

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -83,6 +83,7 @@ jobs:
           make -j$(nproc) TARGET=${{env.TARGET }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 everything check
 
       - name: upload artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.TARGET_FINAL }}-${{ env.git_hash }}${{ env.TARGET_EXT }}


### PR DESCRIPTION
Currently PR builds fail, as it tries to upload the android binary to XCSoar, which of course isn't permitted and the secrets aren't available.