### PR TITLE
Make UsbSerial work with multi-interface devices. (e.g. FTDI4232)

### DIFF
--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Iterator;
 import java.io.IOException;
 
 import android.annotation.TargetApi;
@@ -51,7 +52,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
   private final Context context;
   private final UsbManager usbmanager;
 
-  private HashMap<String, UsbDevice> _AvailableDevices = new HashMap<>();
+  private HashMap<String, UsbDeviceInterface> _AvailableInterfaces = new HashMap<>();
   private HashMap<UsbDevice, UsbSerialPort> _PendingConnection = new HashMap<>();
 
   private final Collection<DetectDeviceListener> detectListeners =
@@ -77,6 +78,22 @@ public class UsbSerialHelper extends BroadcastReceiver {
 
     createDevice(0x067B, 0x2303) // PL2303
   );
+
+  static class UsbDeviceInterface {
+    public final UsbDevice device;
+    public final int iface;
+    public final String id;
+    public UsbDeviceInterface(UsbDevice dev_,int iface_) {
+      device=dev_;
+      iface=iface_;
+
+      if (device.getInterfaceCount() > 1) {
+        id=String.format("%04X:%04X:%02d", device.getVendorId(), device.getProductId(),iface);
+      } else {
+        id=String.format("%04X:%04X", device.getVendorId(), device.getProductId());
+      }
+    }
+  }
 
   static long createDevice(int vendorId, int productId) {
     return ((long) vendorId) << 32 | (productId & 0xFFFF_FFFFL);
@@ -128,27 +145,41 @@ public class UsbSerialHelper extends BroadcastReceiver {
 
       if (exists(supported_ids, vid, pid)) {
         Log.v(TAG, "UsbDevice Found : " + device);
-        _AvailableDevices.put(device.getDeviceName(), device);
-        broadcastDetectedDevice(device);
+        for (int iface=0; iface < device.getInterfaceCount(); iface++) {
+          UsbDeviceInterface deviface = new UsbDeviceInterface(device, iface);
+          _AvailableInterfaces.put(deviface.id, deviface);
+          broadcastDetectedDeviceInterface(deviface);
+        }
       } else {
         Log.v(TAG, "Unsupported UsbDevice : " + device);
       }
     }
   }
 
-  private synchronized UsbDevice GetAvailable(String name) {
-    for (Map.Entry<String, UsbDevice> entry : _AvailableDevices.entrySet()) {
-      if(name.contentEquals(getDeviceId(entry.getValue()))) {
+
+  private synchronized UsbDeviceInterface GetAvailable(String id) {
+    for (Map.Entry<String, UsbDeviceInterface> entry : _AvailableInterfaces.entrySet()) {
+      if(id.contentEquals(entry.getValue().id)) {
         return entry.getValue();
       }
     }
     return null;
   }
 
-  private synchronized void RemoveAvailable(UsbDevice device) {
-    Log.v(TAG,"UsbDevice disconnected : " + device);
-    _AvailableDevices.remove(device.getDeviceName());
-  }
+  private synchronized void RemoveAvailable(UsbDevice removeddevice) {
+    Log.v(TAG,"UsbDevice disconnected : " + removeddevice);
+    // Below line not possible with the current java version
+    //_AvailableInterfaces.entrySet().removeIf(entry -> removeddevice.getDeviceName().equals(entry.getValue().device.getDeviceName()));
+    // Therefore this longer alternative:
+    Iterator<Map.Entry<String,UsbDeviceInterface>> iter = _AvailableInterfaces.entrySet().iterator();
+    while (iter.hasNext()) {
+      Map.Entry<String,UsbDeviceInterface> entry = iter.next();
+      if (removeddevice.getDeviceName().equals(entry.getValue().device.getDeviceName())) {
+        iter.remove();
+      }
+    }
+}
+
 
   private UsbSerialHelper(Context context) throws IOException {
     this.context = context;
@@ -180,59 +211,60 @@ public class UsbSerialHelper extends BroadcastReceiver {
     context.unregisterReceiver(this);
   }
 
-  private synchronized AndroidPort connect(String name, int baud)
+  private synchronized AndroidPort connect(String id, int baud)
     throws IOException
   {
-    UsbDevice device = GetAvailable(name);
-    if (device == null)
+    Log.v(TAG,"Incoming Port connection request:"+id+"@"+baud);
+    UsbDeviceInterface deviface = GetAvailable(id);
+    if (deviface == null)
       throw new IOException("USB serial device not found");
 
-    UsbSerialPort port = new UsbSerialPort(device,baud);
-    if (usbmanager.hasPermission(device)) {
+    UsbSerialPort port = new UsbSerialPort(deviface.device,baud,deviface.iface);
+    if (usbmanager.hasPermission(deviface.device)) {
       port.open(usbmanager);
     } else {
-      _PendingConnection.put(device, port);
+      _PendingConnection.put(deviface.device, port);
       PendingIntent pi = PendingIntent.getBroadcast(context, 0, new Intent(UsbSerialHelper.ACTION_USB_PERMISSION), 0);
-      usbmanager.requestPermission(device, pi);
+      usbmanager.requestPermission(deviface.device, pi);
     }
 
     return port;
   }
 
-  private synchronized void broadcastDetectedDevice(UsbDevice device) {
+  private synchronized void broadcastDetectedDeviceInterface(UsbDeviceInterface deviface) {
     if (detectListeners.isEmpty())
       return;
 
-    final String id = getDeviceId(device);
-    final String name = getDeviceDisplayName(device);
+    final String name = getDeviceInterfaceDisplayName(deviface);
 
     for (DetectDeviceListener l : detectListeners)
-      l.onDeviceDetected(DetectDeviceListener.TYPE_USB_SERIAL, id, name, 0);
+      l.onDeviceDetected(DetectDeviceListener.TYPE_USB_SERIAL, deviface.id, name, 0);
   }
 
   public synchronized void addDetectDeviceListener(DetectDeviceListener l) {
     detectListeners.add(l);
-
-    for (Map.Entry<String, UsbDevice> entry : _AvailableDevices.entrySet())
-      broadcastDetectedDevice(entry.getValue());
+    for (Map.Entry<String, UsbDeviceInterface> entry : _AvailableInterfaces.entrySet()) {
+      broadcastDetectedDeviceInterface(entry.getValue());
+    }
   }
 
   public synchronized void removeDetectDeviceListener(DetectDeviceListener l) {
     detectListeners.remove(l);
   }
 
-  static String getDeviceId(UsbDevice device) {
-    return String.format("%04X:%04X", device.getVendorId(), device.getProductId());
-  }
 
-  static String getDeviceDisplayName(UsbDevice device) {
-    String name = device.getProductName();
+  static String getDeviceInterfaceDisplayName(UsbDeviceInterface deviface) {
+    String name = deviface.device.getProductName();
     if (name == null)
-      name = getDeviceId(device);
+      name = deviface.id;
 
-    String manufacturer = device.getManufacturerName();
+    String manufacturer = deviface.device.getManufacturerName();
     if (manufacturer != null)
       name += " (" + manufacturer + ")";
+
+    //add interface number to name only when more than one interface
+    if (deviface.device.getInterfaceCount() > 1)
+      name += "#"+deviface.iface;
 
     return name;
   }

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -121,9 +121,9 @@ public class UsbSerialHelper extends BroadcastReceiver {
         return;
       }
       if (UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) {
-        AddAvailable(device);
+        addAvailable(device);
       } else if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
-        RemoveAvailable(device);
+        removeAvailable(device);
       } else if (ACTION_USB_PERMISSION.equals(action)) {
         if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
           Log.d(TAG, "permission granted for device " + device);
@@ -145,7 +145,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
     }
   }
 
-  private synchronized void AddAvailable(UsbDevice device) {
+  private synchronized void addAvailable(UsbDevice device) {
     if (UsbSerialDevice.isSupported(device)) {
       int vid = device.getVendorId();
       int pid = device.getProductId();
@@ -164,7 +164,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
   }
 
 
-  private synchronized UsbDeviceInterface GetAvailable(String id) {
+  private synchronized UsbDeviceInterface getAvailable(String id) {
     for (Map.Entry<String, UsbDeviceInterface> entry : _AvailableInterfaces.entrySet()) {
       if(id.contentEquals(entry.getValue().id)) {
         return entry.getValue();
@@ -173,7 +173,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
     return null;
   }
 
-  private synchronized void RemoveAvailable(UsbDevice removeddevice) {
+  private synchronized void removeAvailable(UsbDevice removeddevice) {
     Log.v(TAG,"UsbDevice disconnected : " + removeddevice);
     // Below line not possible with the current java version
     //_AvailableInterfaces.entrySet().removeIf(entry -> removeddevice.getDeviceName().equals(entry.getValue().device.getDeviceName()));
@@ -197,7 +197,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
 
     HashMap<String, UsbDevice> devices = usbmanager.getDeviceList();
     for (Map.Entry<String, UsbDevice> entry : devices.entrySet()) {
-      AddAvailable(entry.getValue());
+      addAvailable(entry.getValue());
     }
 
     registerReceiver();
@@ -222,7 +222,7 @@ public class UsbSerialHelper extends BroadcastReceiver {
     throws IOException
   {
     Log.v(TAG,"Incoming Port connection request:"+id+"@"+baud);
-    UsbDeviceInterface deviface = GetAvailable(id);
+    UsbDeviceInterface deviface = getAvailable(id);
     if (deviface == null)
       throw new IOException("USB serial device not found");
 

--- a/android/src/UsbSerialPort.java
+++ b/android/src/UsbSerialPort.java
@@ -38,19 +38,24 @@ import java.util.Arrays;
 public final class UsbSerialPort
   implements AndroidPort, UsbSerialInterface.UsbReadCallback
 {
-  public UsbSerialPort(UsbDevice device,int baud) {
-    _UsbDevice = device;
-    _baudRate = baud;
-  }
-
   private UsbDevice _UsbDevice;
   private UsbDeviceConnection _UsbConnection;
+  private int _UsbInterface;
   private UsbSerialDevice _SerialPort;
   private PortListener portListener;
   private InputListener inputListener;
   private int _baudRate;
   private int state = STATE_LIMBO;
   private final SafeDestruct safeDestruct = new SafeDestruct();
+
+  public UsbSerialPort(UsbDevice device,int baud,int iface) {
+    _UsbDevice = device;
+    _baudRate = baud;
+    _UsbInterface = iface;
+  }
+  public UsbSerialPort(UsbDevice device,int baud) {
+    this(device, baud, -1);
+  }
 
   public synchronized void open(UsbManager manager) {
     _UsbConnection = manager.openDevice(_UsbDevice);
@@ -59,7 +64,7 @@ public final class UsbSerialPort
       return;
     }
 
-    _SerialPort = UsbSerialDevice.createUsbSerialDevice(_UsbDevice, _UsbConnection);
+    _SerialPort = UsbSerialDevice.createUsbSerialDevice(_UsbDevice, _UsbConnection, _UsbInterface);
     if (_SerialPort == null) {
       setState(STATE_FAILED);
       return;


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
UsbSerial fully supports multi interface devices. This change makes UsbSerialHelper.java capable providing this functionality to the main program. Some changes were necessary since the code of UsbSerialHelper assumed a one to one relationship of device and port, which is not the case for multiport devices.
Although quite some lines needed changing, the behaviour for single Port devices should not have changed at all.
For multiport devices however entries for each port (=interface) will be available and managed with this change.
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/968
Closes #968 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
