### PR TITLE
Windows port adjust

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,9 @@ Version 7.25 - not yet released
   - fix crash when GPS access was rejected by user
   - fix deadlock while quitting XCSoar
   - add U-BLOX 7 USB GPS into 'white list' of USB devices
+* Windows serial ports
+  - allow connection to COM port 10 to 254 (f.e. for BlueTooth user)
+  - remove index based COM port setting (obsolete since XCSoar 5)
 
 Version 7.24 - 2022/07/22
 * user interface

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -99,7 +99,19 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
     if (config.path.empty())
       throw std::runtime_error("No port path configured");
 
+#ifdef _WIN32
+    StaticString<0x20> port_path;
+    // use the windows style of device names:
+    port_path.Format(_T("\\\\.\\%s"), config.path.c_str());
+    if (!port_path.empty() && port_path.back() == TCHAR(':')) {
+      /* On Windows strip the trailing colon if the port name setting
+      has the old style 'COMx:' instead of 'COMx' */
+      port_path.Truncate(port_path.length() - 1);
+    }
+    path = port_path.c_str();
+#else
     path = config.path.c_str();
+#endif
     break;
 
   case DeviceConfig::PortType::BLE_HM10:

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -132,7 +132,7 @@ DosDeviceExists(const TCHAR *path) noexcept
 static void
 FillDefaultSerialPorts(DataFieldEnum &df) noexcept
 {
-  for (unsigned i = 1; i <= 10; ++i) {
+  for (unsigned i = 1; i <= 255; ++i) {
     TCHAR buffer[64];
     _stprintf(buffer, _T("COM%u"), i);
     if (DosDeviceExists(buffer))

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -134,7 +134,7 @@ FillDefaultSerialPorts(DataFieldEnum &df) noexcept
 {
   for (unsigned i = 1; i <= 10; ++i) {
     TCHAR buffer[64];
-    _stprintf(buffer, _T("COM%u:"), i);
+    _stprintf(buffer, _T("COM%u"), i);
     if (DosDeviceExists(buffer))
        AddPort(df, DeviceConfig::PortType::SERIAL, buffer);
   }


### PR DESCRIPTION
Reactivation of closed PR #934

Brief summary of the changes
------------------------------
  - allow connection to COM port 10 to 255 (f.e. for BlueTooth user)
  - remove index based COM port setting (obsolet since XCSoar 5)

Related issues and discussions
------------------------------
  - no