### PR TITLE
install-debian-packages: add missing texinfo package

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -79,6 +79,7 @@ echo
 
 echo Installing Kobo dependencies...
 apt-get install ${APTOPTS[*]} \
+    texinfo \
     fakeroot \
     python3-setuptools \
     ttf-bitstream-vera


### PR DESCRIPTION
fixes #998 