### PR TITLE
Ignore executable rights on tty device file descriptors

### DIFF
--- a/src/Device/Port/TTYEnumerator.cpp
+++ b/src/Device/Port/TTYEnumerator.cpp
@@ -66,7 +66,7 @@ TTYEnumerator::Next() noexcept
       /* truncated - ignore */
       continue;
 
-    if (access(path, R_OK|W_OK) == 0 && access(path, X_OK) < 0)
+    if (access(path, R_OK|W_OK) == 0 )
       return path;
   }
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Ignore tty devices with executable rights on their device file descriptor to make them usable in XCSoar

Related issues and discussions
------------------------------
Closes #1012 