### PR TITLE
Make native tty devices usable on Android devices

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -937,7 +937,7 @@ DEBUG_DISPLAY_SOURCES = \
 	$(TEST_SRC_DIR)/FakeAsset.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/DebugDisplay.cpp
-DEBUG_DISPLAY_DEPENDS = SCREEN IO OS MATH UTIL
+DEBUG_DISPLAY_DEPENDS = SCREEN IO OS MATH UTIL OS
 $(eval $(call link-program,DebugDisplay,DEBUG_DISPLAY))
 
 DOWNLOAD_FILE_SOURCES = \
@@ -1232,7 +1232,7 @@ $(eval $(call link-program,RunAirspaceParser,RUN_AIRSPACE_PARSER))
 
 ENUMERATE_PORTS_SOURCES = \
 	$(TEST_SRC_DIR)/EnumeratePorts.cpp
-ENUMERATE_PORTS_DEPENDS = PORT
+ENUMERATE_PORTS_DEPENDS = PORT OS
 $(eval $(call link-program,EnumeratePorts,ENUMERATE_PORTS))
 
 READ_PORT_SOURCES = \
@@ -1456,7 +1456,7 @@ LXN2IGC_SOURCES = \
 	$(SRC)/Device/Driver/LX/Convert.cpp \
 	$(SRC)/Device/Driver/LX/LXN.cpp \
 	$(TEST_SRC_DIR)/lxn2igc.cpp
-LXN2IGC_DEPENDS = IO UTIL
+LXN2IGC_DEPENDS = IO OS UTIL
 $(eval $(call link-program,lxn2igc,LXN2IGC))
 
 RUN_IGC_WRITER_SOURCES = \

--- a/src/Device/Port/TTYEnumerator.cpp
+++ b/src/Device/Port/TTYEnumerator.cpp
@@ -24,6 +24,7 @@ Copyright_License {
 #include "TTYEnumerator.hpp"
 #include "util/CharUtil.hxx"
 #include "util/StringCompare.hxx"
+#include "system/FileUtil.hpp"
 
 #include <stdio.h>
 #include <unistd.h>
@@ -66,7 +67,7 @@ TTYEnumerator::Next() noexcept
       /* truncated - ignore */
       continue;
 
-    if (access(path, R_OK|W_OK) == 0 && access(path, X_OK) < 0)
+    if (access(path, R_OK|W_OK) == 0 && File::IsCharDev(Path(path)) )
       return path;
   }
 

--- a/src/Device/Port/TTYPort.cpp
+++ b/src/Device/Port/TTYPort.cpp
@@ -27,6 +27,7 @@ Copyright_License {
 #include "io/UniqueFileDescriptor.hxx"
 #include "system/Error.hxx"
 #include "system/TTYDescriptor.hxx"
+#include "system/FileUtil.hpp"
 #include "event/Call.hxx"
 #include "util/StringFormat.hpp"
 
@@ -181,21 +182,11 @@ TTYPort::Drain()
   return tty.Drain();
 }
 
-#ifndef __APPLE__
-[[gnu::pure]]
-static bool
-IsCharDev(const char *path) noexcept
-{
-  struct stat st;
-  return stat(path, &st) == 0 && S_ISCHR(st.st_mode);
-}
-#endif
-
 void
 TTYPort::Open(const TCHAR *path, unsigned baud_rate)
 {
 #ifndef __APPLE__
-  if (IsAndroid() && IsCharDev(path)) {
+  if (IsAndroid() && File::IsCharDev(Path(path))) {
     /* attempt to give the XCSoar process permissions to access the
        USB serial adapter; this is mostly relevant to the Nook */
     TCHAR command[MAX_PATH];

--- a/src/system/FileUtil.cpp
+++ b/src/system/FileUtil.cpp
@@ -309,6 +309,15 @@ File::Exists(Path path) noexcept
 #endif
 }
 
+#if !defined(_WIN32)
+bool
+File::IsCharDev(Path path) noexcept
+{
+  struct stat st;
+  return stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode);
+}
+#endif
+
 #if defined(_WIN32) && defined(UNICODE)
 
 bool

--- a/src/system/FileUtil.hpp
+++ b/src/system/FileUtil.hpp
@@ -117,6 +117,15 @@ ExistsAny(Path path) noexcept;
 bool
 Exists(Path path) noexcept;
 
+/**
+ * Returns whether the given file descriptor is a character device e.g. /dev/ttyS<n>
+ * @param path File system path to check
+ * @return True if the character device exists
+ */
+[[gnu::pure]]
+bool
+IsCharDev(Path path) noexcept;
+
 #if defined(_WIN32) && defined(UNICODE)
 [[gnu::pure]]
 bool


### PR DESCRIPTION
Brief summary of the changes
----------------------------

- Move IsCharDev() utility function into FileUtil for reusability
- Improved device file descriptor check to avoid masking on android where executable bit may be set and linker dependencies, closes #1012 

Related issues and discussions
------------------------------
#1012 
#1034  (closed, replaced by this)