### PR TITLE
WeGlide 'Automatic Upload' not persistent

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.28 - not yet released
+* user interface
+  - fix WeGlide 'Automatic Upload' not persistent
 
 Version 7.27 - 2022/09/23
 * user interface

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -91,6 +91,7 @@ void
 Profile::Load(const ProfileMap &map, WeGlideSettings &settings)
 {
   map.Get(ProfileKeys::WeGlideEnabled, settings.enabled);
+  map.Get(ProfileKeys::WeGlideAutomaticUpload, settings.automatic_upload);
   map.Get(ProfileKeys::WeGlidePilotID, settings.pilot_id);
 
   const char *date = map.Get(ProfileKeys::WeGlidePilotBirthDate);


### PR DESCRIPTION
Brief summary of the changes
----------------------------
In Setup → WeGlide the 'Automatic Upload' field is saved to the profile but never loaded.
This PR will fix it.