### PR TITLE
ATC Radial infobox show magnetic bearings

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 Version 7.28 - not yet released
 * user interface
   - fix WeGlide 'Automatic Upload' not persistent
+  - ATC Radial infobox can display magnetic radial with configurable declination
 * waypoint editor
   - add more SeeYou waypoint types
 * Android

--- a/build/infobox.mk
+++ b/build/infobox.mk
@@ -33,6 +33,7 @@ LIBINFOBOX_SOURCES = \
 	$(SRC)/InfoBoxes/Panel/MacCreadySetup.cpp \
 	$(SRC)/InfoBoxes/Panel/WindEdit.cpp \
 	$(SRC)/InfoBoxes/Panel/ATCReference.cpp \
+	$(SRC)/InfoBoxes/Panel/ATCSetup.cpp \
 	$(SRC)/InfoBoxes/Panel/RadioEdit.cpp
 
 LIBINFOBOX_CPPFLAGS_INTERNAL = $(SCREEN_CPPFLAGS)

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -109,13 +109,15 @@ struct PlacesOfInterestSettings {
   GeoPoint home_location;
 
   /**
-   * The reference location for the "ATC radial" InfoBox.
+   * The reference location & declination for the "ATC radial" InfoBox.
    */
   GeoPoint atc_reference;
+  Angle magnetic_declination;
 
   void SetDefaults() {
     ClearHome();
     atc_reference.SetInvalid();
+    magnetic_declination = Angle::Zero();
   }
 
   void ClearHome();

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -973,7 +973,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("ATC radial"),
     N_("ATC radial"),
-    N_("True bearing from the selected reference location to your position.  The distance is displayed in nautical miles for communication with ATC."),
+    N_("Bearing from the selected reference location to your position. The distance is displayed in nautical miles for communication with ATC. If declination is entered, magnetic bearing is given to match VOR radials."),
     UpdateInfoBoxATCRadial,
     atc_infobox_panels,
   },

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -88,6 +88,9 @@ UpdateInfoBoxATCRadial(InfoBoxData &data) noexcept
   const NMEAInfo &basic = CommonInterface::Basic();
   const GeoPoint &reference =
     CommonInterface::GetComputerSettings().poi.atc_reference;
+  const Angle &declination =
+    CommonInterface::GetComputerSettings().poi.magnetic_declination;
+
   if (!basic.location_available || !reference.IsValid()) {
     data.SetInvalid();
     return;
@@ -95,7 +98,9 @@ UpdateInfoBoxATCRadial(InfoBoxData &data) noexcept
 
   const GeoVector vector(reference, basic.location);
 
-  data.SetValue(vector.bearing);
+  const Angle mag_bearing = vector.bearing - declination;
+  data.SetValue(mag_bearing);
+
   FormatDistance(data.comment.buffer(), vector.distance,
                  Unit::NAUTICAL_MILES, true, 1);
 }

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -25,6 +25,7 @@ Copyright_License {
 #include "InfoBoxes/Data.hpp"
 #include "InfoBoxes/Panel/Panel.hpp"
 #include "InfoBoxes/Panel/ATCReference.hpp"
+#include "InfoBoxes/Panel/ATCSetup.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Formatter/Units.hpp"
@@ -77,6 +78,7 @@ constexpr
 #endif
 const InfoBoxPanel atc_infobox_panels[] = {
   { N_("Reference"), LoadATCReferencePanel },
+  { N_("Setup"), LoadATCSetupPanel },
   { nullptr, nullptr }
 };
 

--- a/src/InfoBoxes/Panel/ATCSetup.cpp
+++ b/src/InfoBoxes/Panel/ATCSetup.cpp
@@ -1,0 +1,48 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2021 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "ATCSetup.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "UIGlobals.hpp"
+
+class ATCSetupPanel : public RowFormWidget {
+public:
+  ATCSetupPanel() noexcept
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  /* virtual methods from Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+};
+
+void
+ATCSetupPanel::Prepare(ContainerWindow &parent,
+                       const PixelRect &rc) noexcept
+{
+  RowFormWidget::Prepare(parent, rc);
+}
+
+std::unique_ptr<Widget>
+LoadATCSetupPanel([[maybe_unused]] unsigned id)
+{
+  return std::make_unique<ATCSetupPanel>();
+}

--- a/src/InfoBoxes/Panel/ATCSetup.cpp
+++ b/src/InfoBoxes/Panel/ATCSetup.cpp
@@ -22,16 +22,25 @@ Copyright_License {
 */
 
 #include "ATCSetup.hpp"
+#include "Form/DataField/Float.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
 
-class ATCSetupPanel : public RowFormWidget {
+class ATCSetupPanel : public RowFormWidget,
+                      private DataFieldListener {
 public:
   ATCSetupPanel() noexcept
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
 
   /* virtual methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+
+private:
+  /* virtual methods from class DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
 };
 
 void
@@ -39,6 +48,26 @@ ATCSetupPanel::Prepare(ContainerWindow &parent,
                        const PixelRect &rc) noexcept
 {
   RowFormWidget::Prepare(parent, rc);
+
+  const Angle &declination =
+    CommonInterface::GetComputerSettings().poi.magnetic_declination;
+
+  AddFloat(_("Mag declination"),
+           _("Magnetic declination used to calculate radial to reference. Negative values are W declination, positive is E."),
+           _T("%.0f°"), _T("%.0f°"), // unfortunately AngleDataField does not
+           -30.0, +30.0, 1.0, false, // support negative values to handle
+           declination.Degrees(),    // this formatting more gracefully
+           this);
+}
+
+void
+ATCSetupPanel::OnModified(DataField &_df) noexcept
+{
+  DataFieldFloat &df = (DataFieldFloat &)_df;
+  ComputerSettings &settings =
+    CommonInterface::SetComputerSettings();
+
+  settings.poi.magnetic_declination = Angle::Degrees(df.GetValue());
 }
 
 std::unique_ptr<Widget>

--- a/src/InfoBoxes/Panel/ATCSetup.hpp
+++ b/src/InfoBoxes/Panel/ATCSetup.hpp
@@ -1,0 +1,31 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2022 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+LoadATCSetupPanel(unsigned id);


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

Added a "Setup" panel to the ATC Radial info box to configure a magnetic declination value.
This allows the display of magnetic bearings to match VOR radials, which is what ATC expects.


Related issues and discussions
------------------------------
#1010 

