### PR TITLE
add SoftRF Balkan and Prime Mk3 into 'white list' of USB devices

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 7.28 - not yet released
 * user interface
   - fix WeGlide 'Automatic Upload' not persistent
+* Android
+  - add SoftRF Balkan and Prime Mk3 into 'white list' of USB devices
 
 Version 7.27 - 2022/09/23
 * user interface

--- a/android/res/xml/usb_device_filter.xml
+++ b/android/res/xml/usb_device_filter.xml
@@ -12,6 +12,8 @@
   <usb-device vendor-id="7504" product-id="24713"/> <!-- SoftRF ES -->
   <usb-device vendor-id="11914" product-id="10"/> <!-- SoftRF Lego -->
   <usb-device vendor-id="11914" product-id="61450"/> <!-- SoftRF Lego -->
+  <usb-device vendor-id="5562" product-id="68"/> <!-- SoftRF Balkan -->
+  <usb-device vendor-id="12346" product-id="33075"/> <!-- SoftRF Prime Mk3 -->
 
   <usb-device vendor-id="1027" product-id="24577"/> <!-- FT232AM, FT232BM, FT232R FT245R -->
   <usb-device vendor-id="1027" product-id="24592"/> <!-- FT2232D, FT2232H -->

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -67,6 +67,8 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x1d50, 0x6089), // SoftRF ES
     createDevice(0x2e8a, 0x000a), // SoftRF Lego
     createDevice(0x2e8a, 0xf00a), // SoftRF Lego
+    createDevice(0x15ba, 0x0044), // SoftRF Balkan
+    createDevice(0x303a, 0x8133), // SoftRF Prime Mk3
 
     createDevice(0x0403, 0x6001), // FT232AM, FT232BM, FT232R FT245R,
     createDevice(0x0403, 0x6010), // FT2232D, FT2232H


### PR DESCRIPTION
Brief summary of the changes
----------------------------

add USB VID/PID pairs for SoftRF Balkan and Prime Mk3 Editions into (Android) 'white list' of USB devices
