### PR TITLE
Navigator Widget

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -459,6 +459,140 @@ label=Target Show$(CheckTask)$(CheckTaskResumed)
 location=8
 
 # -------------
+# mode=Navigator1
+# -------------
+
+mode=Navigator1
+type=key
+data=APP1
+event=Mode Navigator2
+label=Navigator\nPage 2/2
+location=1
+
+mode=Navigator1
+type=key
+data=0
+event=Status all
+event=Mode default
+label=Status
+location=2
+
+mode=Navigator1
+type=key
+data=0
+event=Analysis
+event=Mode default
+label=Analysis
+location=3
+
+mode=Navigator1
+type=key
+data=0
+event=Setup Target
+event=Mode default
+label=Target Show$(CheckTask)$(CheckTaskResumed)
+location=4
+
+mode=Navigator1
+type=key
+data=APP1
+event=Mode Navigator2
+label=Navigator\nPage 2/2
+location=5
+
+mode=Navigator1
+type=key
+data=0
+event=AdjustWaypoint previousarm
+label=$(WaypointPreviousArm)
+location=6
+
+mode=Navigator1
+type=key
+data=0
+event=AdjustWaypoint nextarm
+label=$(WaypointNextArm)
+location=7
+
+mode=Navigator1
+type=key
+data=0
+event=Setup Alternates
+event=Mode default
+label=Alternates$(CheckWaypointFile)
+location=8
+
+mode=Navigator1
+type=key
+data=0
+event=Mode default
+event=AbortTask toggle
+label=Task\n$(TaskAbortToggleActionName)$(CheckWaypointFile)
+location=9
+
+# -------------
+# mode=Navigator2
+# -------------
+
+mode=Navigator2
+type=key
+data=APP1
+event=Mode default
+label=Cancel
+location=1
+
+mode=Navigator2
+type=key
+data=7
+event=Mode default
+event=StatusMessage Dropped marker
+event=Logger note Mark
+event=MarkLocation
+label=Marker Drop
+location=3
+
+mode=Navigator2
+type=key
+data=8
+event=Mode default
+event=StatusMessage Pilot event announced
+event=Logger note PEV
+event=PilotEvent
+label=Pilot Event Announce
+location=4
+
+mode=Navigator2
+type=key
+data=APP1
+event=Mode default
+label=Cancel
+location=5
+
+mode=Navigator2
+type=key
+data=6
+event=Setup System
+event=Mode default
+label=Setup System
+location=6
+
+mode=Navigator2
+type=key
+data=0
+event=Calculator
+event=Mode default
+label=Task Manager
+location=7
+
+mode=Navigator2
+type=key
+data=0
+event=WaypointDetails select
+event=Mode default
+label=Waypoint List$(CheckWaypointFile)
+location=8
+
+# -------------
 # mode=Display1
 # -------------
 

--- a/build/liblook.mk
+++ b/build/liblook.mk
@@ -23,6 +23,7 @@ LOOK_SOURCES := \
 	$(SRC)/Look/CrossSectionLook.cpp \
 	$(SRC)/Look/GestureLook.cpp \
 	$(SRC)/Look/HorizonLook.cpp \
+	$(SRC)/Look/NavigatorLook.cpp \
 	$(SRC)/Look/TaskLook.cpp \
 	$(SRC)/Look/TrafficLook.cpp \
 	$(SRC)/Look/InfoBoxLook.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -289,6 +289,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/BigThermalAssistantWidget.cpp \
 	$(SRC)/Gauge/FlarmTrafficWindow.cpp \
 	$(SRC)/Gauge/BigTrafficWidget.cpp \
+	$(SRC)/Gauge/NavigatorWidget.cpp \
 	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/Gauge/GaugeFLARM.cpp \
 	$(SRC)/Gauge/GaugeThermalAssistant.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -200,6 +200,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Renderer/TextRowRenderer.cpp \
 	$(SRC)/Renderer/TwoTextRowsRenderer.cpp \
 	$(SRC)/Renderer/HorizonRenderer.cpp \
+	$(SRC)/Renderer/NavigatorRenderer.cpp \
 	$(SRC)/Renderer/GradientRenderer.cpp \
 	$(SRC)/Renderer/GlassRenderer.cpp \
 	$(SRC)/Renderer/TransparentRendererCache.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -92,6 +92,7 @@ DIALOG_SOURCES = \
 	\
 	$(SRC)/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GaugesConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/VarioConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WindConfigPanel.cpp \
@@ -288,6 +289,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/BigThermalAssistantWidget.cpp \
 	$(SRC)/Gauge/FlarmTrafficWindow.cpp \
 	$(SRC)/Gauge/BigTrafficWidget.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/Gauge/GaugeFLARM.cpp \
 	$(SRC)/Gauge/GaugeThermalAssistant.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1704,6 +1704,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/MapSettings.cpp \
 	$(SRC)/Computer/Settings.cpp \
 	$(SRC)/Computer/Wind/Settings.cpp \
@@ -2131,6 +2132,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+  $(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/TeamCode/TeamCode.cpp \
 	$(SRC)/TeamCode/Settings.cpp \
 	$(SRC)/Logger/Settings.cpp \

--- a/src/DataGlobals.cpp
+++ b/src/DataGlobals.cpp
@@ -25,7 +25,7 @@ DataGlobals::UnsetTerrain() noexcept
   /* just in case the bottom widget uses the old terrain object
      (e.g. the cross section) */
   main_window.SetBottomWidget(nullptr);
-
+  main_window.SetTopWidget(nullptr);
   main_window.SetTerrain(nullptr);
 
   if (backend_components->glide_computer)

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
@@ -18,9 +18,16 @@ enum ControlIndex {
   NavigatorWidgetLite2LHeight,
   NavigatorWidgetHeight,
   NavigatorWidgetDetailedHeight,
-  NavigatorWidgetReverseSwipeWaypoint
+  NavigatorWidgetReverseSwipeWaypoint,
+  NavigatorWidgetAltitude
 };
 
+static constexpr StaticEnumChoice navigator_altitude_type_list[] = {
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltReq, N_("WP_AltReq"), N_("Additional altitude required to reach the next turn point.") },
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltDiff, N_("WP_AltDiff"), N_("Next Altitude Difference - Arrival altitude at the next waypoint relative to the safety arrival height.") },
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltArrival, N_("WP_AltArrival"), N_("Absolute arrival altitude at the next waypoint in final glide.") },
+  nullptr
+};
 
 class NavigatorConfigPanel final : public RowFormWidget {
 public:
@@ -88,6 +95,10 @@ NavigatorConfigPanel::Prepare(ContainerWindow &parent,
              "swipe/move the window over the waypoints strip.\n"
              "\"The waypoints strip\" is a representation of all waypoints disposed horizontally one after the other."),
              ui_settings.navigator.navigator_swipe);
+
+  AddEnum(_("Navigator Altitude type"), _("Choose an altitude type to be displayed beside the Waypoint name."),
+          navigator_altitude_type_list,
+          (unsigned)ui_settings.navigator.navigator_altitude_type);
 }
 
 bool
@@ -115,6 +126,11 @@ NavigatorConfigPanel::Save(bool &_changed) noexcept
                             ui_settings.navigator.navigator_swipe)))
     CommonInterface::main_window->ReinitialiseLayout();
 
+  if ((changed |= SaveValueEnum(NavigatorWidgetAltitude,
+                           ProfileKeys::NavigatorAltitudeType,
+                           ui_settings.navigator.navigator_altitude_type)))
+    CommonInterface::main_window->ReinitialiseLayout();
+    
   _changed |= changed;
 
   return true;

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
@@ -17,7 +17,8 @@ enum ControlIndex {
   NavigatorWidgetLite1LHeight,
   NavigatorWidgetLite2LHeight,
   NavigatorWidgetHeight,
-  NavigatorWidgetDetailedHeight
+  NavigatorWidgetDetailedHeight,
+  NavigatorWidgetReverseSwipeWaypoint
 };
 
 
@@ -80,6 +81,13 @@ NavigatorConfigPanel::Prepare(ContainerWindow &parent,
     _T("%u %%"), _T("%u"), 1, 40, 1,
     (unsigned)ui_settings.navigator.navigator_detailed_height);
 
+  AddBoolean(_("Reverse swipe movement"),
+             _("Swipe \"On\":\n"
+             "swipe/move the waypoints strip under the window.\n"
+             "Swipe \"Off\":\n"
+             "swipe/move the window over the waypoints strip.\n"
+             "\"The waypoints strip\" is a representation of all waypoints disposed horizontally one after the other."),
+             ui_settings.navigator.navigator_swipe);
 }
 
 bool
@@ -100,6 +108,11 @@ NavigatorConfigPanel::Save(bool &_changed) noexcept
     CommonInterface::main_window->ReinitialiseLayout();
   if ((changed |= SaveValueInteger(NavigatorWidgetDetailedHeight, ProfileKeys::NavigatorDetailedHeight,
                                    ui_settings.navigator.navigator_detailed_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+
+  if ((changed |= SaveValue(NavigatorWidgetReverseSwipeWaypoint,
+                            ProfileKeys::NavigatorReverseSwipeWaypointMovement,
+                            ui_settings.navigator.navigator_swipe)))
     CommonInterface::main_window->ReinitialiseLayout();
 
   _changed |= changed;

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorConfigPanel.hpp"
+#include "Gauge/NavigatorSettings.hpp"
+#include "Gauge/NavigatorWidget.hpp"
+#include "Profile/Keys.hpp"
+#include "Interface.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "MainWindow.hpp"
+
+enum ControlIndex {
+  NavigatorWidgetLite1LHeight,
+  NavigatorWidgetLite2LHeight,
+  NavigatorWidgetHeight,
+  NavigatorWidgetDetailedHeight
+};
+
+
+class NavigatorConfigPanel final : public RowFormWidget {
+public:
+  NavigatorConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+
+void
+NavigatorConfigPanel::Prepare(ContainerWindow &parent,
+                           const PixelRect &rc) noexcept
+{
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  RowFormWidget::Prepare(parent, rc);
+
+  AddInteger(
+    _("Navigator lite one line Height"),
+    _("Select the height of the navigator lite topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 6%"),
+    _T("%u %%"), _T("%u"), 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_lite_1_line_height); 
+
+
+  AddInteger(
+    _("Navigator lite two lines Height"),
+    _("Select the height of the navigator lite topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 8%"),
+    _T("%u %%"), _T("%u"), 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_lite_2_lines_height); 
+
+  AddInteger(
+    _("Navigator Height"),
+    _("Select the height of the navigator topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 9%"),
+    _T("%u %%"), _T("%u"), 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_height);
+
+  AddInteger(
+    _("Navigator detailled Height"),
+    _("Select the height of the navigator detailled topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 11%"),
+    _T("%u %%"), _T("%u"), 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_detailed_height);
+
+}
+
+bool
+NavigatorConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+  UISettings &ui_settings = CommonInterface::SetUISettings();
+
+  if ((changed |= SaveValueInteger(NavigatorWidgetHeight, ProfileKeys::NavigatorHeight,
+                                   ui_settings.navigator.navigator_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetLite1LHeight, ProfileKeys::NavigatorLite1LHeight,
+                                   ui_settings.navigator.navigator_lite_1_line_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetLite2LHeight, ProfileKeys::NavigatorLite2LHeight,
+                                   ui_settings.navigator.navigator_lite_2_lines_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetDetailedHeight, ProfileKeys::NavigatorDetailedHeight,
+                                   ui_settings.navigator.navigator_detailed_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+
+  _changed |= changed;
+
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateNavigatorConfigPanel()
+{
+  return std::make_unique<NavigatorConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateNavigatorConfigPanel();

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -218,6 +218,10 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
   static constexpr StaticEnumChoice bottom_list[] = {
     { PageLayout::Bottom::NOTHING, N_("Nothing") },
     { PageLayout::Bottom::CROSS_SECTION, N_("Cross section") },
+    { PageLayout::Bottom::NAVIGATOR, N_("B.Navigator") },
+    { PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE, N_("B.Navigator lite 1 line") },
+    { PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES, N_("B.Navigator lite 2 lines") },
+    { PageLayout::Bottom::NAVIGATOR_DETAILED, N_("B.Navigator detailed") },
     nullptr
   };
   AddEnum(_("Bottom area"),
@@ -227,6 +231,10 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 
   static constexpr StaticEnumChoice top_list[] = {
     { PageLayout::Top::NOTHING, N_("Nothing") },
+    { PageLayout::Top::NAVIGATOR, N_("T.Navigator") },
+    { PageLayout::Top::NAVIGATOR_LITE_ONE_LINE, N_("T.Navigator lite 1 line") },
+    { PageLayout::Top::NAVIGATOR_LITE_TWO_LINES, N_("T.Navigator lite 2 lines") },
+    { PageLayout::Top::NAVIGATOR_DETAILED, N_("T.Navigator detailed") },
     nullptr
   };
   AddEnum(_("Top area"),
@@ -397,6 +405,19 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     buffer.AppendFormat(_T(", %s"), _("Cross section"));
     break;
 
+  case PageLayout::Bottom::NAVIGATOR:
+    buffer.AppendFormat(_T(", %s"), _("B.Navigator"));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+    buffer.AppendFormat(_T(", %s"), _("B.Navigator lite 1 line"));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+    buffer.AppendFormat(_T(", %s"), _("B.Navigator lite 2 lines"));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_DETAILED:
+    buffer.AppendFormat(_T(", %s"), _("B.Navigator detailed"));
+    break;
+
   case PageLayout::Bottom::MAX:
     gcc_unreachable();
   }
@@ -404,6 +425,19 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   switch (value.top) {
   case PageLayout::Top::NOTHING:
   case PageLayout::Top::CUSTOM:
+    break;
+
+  case PageLayout::Top::NAVIGATOR:
+    buffer.AppendFormat(_T(", %s"), _("T.Navigator"));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_ONE_LINE:
+    buffer.AppendFormat(_T(", %s"), _("T.Navigator lite 1 line"));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_TWO_LINES:
+    buffer.AppendFormat(_T(", %s"), _("T.Navigator lite 2 lines"));
+    break;
+  case PageLayout::Top::NAVIGATOR_DETAILED:
+    buffer.AppendFormat(_T(", %s"), _("T.Navigator detailed"));
     break;
 
   case PageLayout::Top::MAX:

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -37,6 +37,7 @@ private:
     MAIN,
     INFO_BOX_PANEL,
     BOTTOM,
+    TOP,
   };
 
   static constexpr unsigned IBP_NONE = 0x7000;
@@ -223,6 +224,15 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
           _("Specifies what should be displayed below the main area."),
           bottom_list,
           (unsigned)PageLayout::Bottom::NOTHING, this);
+
+  static constexpr StaticEnumChoice top_list[] = {
+    { PageLayout::Top::NOTHING, N_("Nothing") },
+    nullptr
+  };
+  AddEnum(_("Top area"),
+          _("Specifies what should be displayed above the main area."),
+          top_list,
+          (unsigned)PageLayout::Top::NOTHING, this);
 }
 
 void
@@ -232,6 +242,7 @@ PageLayoutEditWidget::SetValue(const PageLayout &_value)
 
   LoadValueEnum(MAIN, value.main);
   LoadValueEnum(BOTTOM, value.bottom);
+  LoadValueEnum(TOP, value.top);
 
   unsigned ib = IBP_NONE;
   if (value.infobox_config.enabled) {
@@ -270,6 +281,9 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
   } else if (&df == &GetDataField(BOTTOM)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.bottom = (PageLayout::Bottom)dfe.GetValue();
+  } else if (&df == &GetDataField(TOP)) {
+    const DataFieldEnum &dfe = (const DataFieldEnum &)df;
+    value.top = (PageLayout::Top)dfe.GetValue();
   } else {
     gcc_unreachable();
   }
@@ -386,6 +400,16 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   case PageLayout::Bottom::MAX:
     gcc_unreachable();
   }
+
+  switch (value.top) {
+  case PageLayout::Top::NOTHING:
+  case PageLayout::Top::CUSTOM:
+    break;
+
+  case PageLayout::Top::MAX:
+    gcc_unreachable();
+  }
+
 
   row_renderer.DrawTextRow(canvas, rc, buffer);
 }

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -33,6 +33,7 @@
 #include "Panels/InterfaceConfigPanel.hpp"
 #include "Panels/LayoutConfigPanel.hpp"
 #include "Panels/GaugesConfigPanel.hpp"
+#include "Panels/NavigatorConfigPanel.hpp"
 #include "Panels/VarioConfigPanel.hpp"
 #include "Panels/TaskRulesConfigPanel.hpp"
 #include "Panels/TaskDefaultsConfigPanel.hpp"
@@ -110,11 +111,12 @@ static constexpr TabMenuPage task_pages[] = {
 };
 
 static constexpr TabMenuPage look_pages[] = {
-  { N_("Language, Input"), CreateInterfaceConfigPanel },
-  { N_("Screen Layout"), CreateLayoutConfigPanel },
-  { N_("Pages"), CreatePagesConfigPanel },
-  { N_("InfoBox Sets"), CreateInfoBoxesConfigPanel },
-  { nullptr, nullptr }
+    {N_("Language, Input"), CreateInterfaceConfigPanel},
+    {N_("Screen Layout"), CreateLayoutConfigPanel},
+    {N_("Pages"), CreatePagesConfigPanel},
+    {N_("InfoBox Sets"), CreateInfoBoxesConfigPanel},
+    {N_("Navigator"), CreateNavigatorConfigPanel},
+    {nullptr, nullptr}
 };
 
 static constexpr TabMenuPage setup_pages[] = {

--- a/src/Gauge/NavigatorSettings.cpp
+++ b/src/Gauge/NavigatorSettings.cpp
@@ -12,4 +12,5 @@ NavigatorSettings::SetDefaults() noexcept
   navigator_detailed_height = 11;
 
   navigator_swipe = false;
+  navigator_altitude_type = NavigatorWidgetAltitudeType::WP_AltArrival;
 }

--- a/src/Gauge/NavigatorSettings.cpp
+++ b/src/Gauge/NavigatorSettings.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorSettings.hpp"
+
+void
+NavigatorSettings::SetDefaults() noexcept
+{
+  navigator_lite_1_line_height = 6;
+  navigator_lite_2_lines_height = 8;
+  navigator_height = 9;
+  navigator_detailed_height = 11;
+}

--- a/src/Gauge/NavigatorSettings.cpp
+++ b/src/Gauge/NavigatorSettings.cpp
@@ -10,4 +10,6 @@ NavigatorSettings::SetDefaults() noexcept
   navigator_lite_2_lines_height = 8;
   navigator_height = 9;
   navigator_detailed_height = 11;
+
+  navigator_swipe = false;
 }

--- a/src/Gauge/NavigatorSettings.hpp
+++ b/src/Gauge/NavigatorSettings.hpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+struct NavigatorSettings {
+
+
+  unsigned navigator_height;
+  unsigned navigator_lite_1_line_height;
+  unsigned navigator_lite_2_lines_height;
+  unsigned navigator_detailed_height;
+
+  void SetDefaults() noexcept;
+};

--- a/src/Gauge/NavigatorSettings.hpp
+++ b/src/Gauge/NavigatorSettings.hpp
@@ -6,14 +6,19 @@
 #include <cstdint>
 
 struct NavigatorSettings {
-
-
   unsigned navigator_height;
   unsigned navigator_lite_1_line_height;
   unsigned navigator_lite_2_lines_height;
   unsigned navigator_detailed_height;
 
   bool navigator_swipe;
+
+  /** Navigator Widget type */
+  enum class NavigatorWidgetAltitudeType : uint8_t {
+    WP_AltReq,    // e_WP_AltReq
+    WP_AltDiff,   // e_WP_AltDiff
+    WP_AltArrival // e_WP_H
+  } navigator_altitude_type;
 
   void SetDefaults() noexcept;
 };

--- a/src/Gauge/NavigatorSettings.hpp
+++ b/src/Gauge/NavigatorSettings.hpp
@@ -13,5 +13,7 @@ struct NavigatorSettings {
   unsigned navigator_lite_2_lines_height;
   unsigned navigator_detailed_height;
 
+  bool navigator_swipe;
+
   void SetDefaults() noexcept;
 };

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -122,6 +122,11 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
 
   renderer.DrawWaypointsIconsTitle(canvas, wp_before, wp_current, task_size,
                                    look_nav, nav_type);
+
+  if (wp_current != nullptr)
+    renderer.DrawTaskTextsArrow(canvas, tp, *wp_current, canvas.GetRect(),
+                                nav_type, isNavigatorTopPosition, look_nav,
+                                look_task, look_infobox);
 }
 
 void

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Look/InfoBoxLook.hpp"
+#include "Task/Stats/TaskSummary.hpp"
+#include <cstdint>
+#ifdef WIN32_LEAN_AND_MEAN
+#include "ui/canvas/gdi/Canvas.hpp"
+#endif
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/TaskManager.hpp"
+#include "InfoBoxes/InfoBoxWindow.hpp"
+#include "Input/InputEvents.hpp"
+#include "NavigatorWidget.hpp"
+#include "PageActions.hpp"
+#include "Screen/Layout.hpp"
+#include "Task/ProtectedTaskManager.hpp"
+#include "UIGlobals.hpp"
+
+NavigatorWindow::NavigatorWindow(const NavigatorLook &_look_nav,
+                                 const TaskLook &_look_task,
+                                 const InfoBoxLook &_look_infobox,
+                                 const enum navType _navType,
+                                 const bool _isNavTop) noexcept
+    : look_nav(_look_nav),
+      look_task(_look_task),
+      look_infobox(_look_infobox),
+      nav_type(_navType),
+      isNavigatorTopPosition(_isNavTop),
+      dragging(false)
+{
+}
+
+void
+NavigatorWindow::ReadBlackboard(const AttitudeState &_attitude) noexcept
+{
+  attitude = _attitude;
+}
+
+void
+NavigatorWindow::OnPaint(Canvas &canvas) noexcept
+{
+  if (look_nav.inverse) {
+    canvas.Clear(COLOR_BLACK);
+  } else {
+    canvas.ClearWhite();
+  }
+
+  TaskType tp{TaskType::NONE};
+  WaypointPtr wp_before;
+  WaypointPtr wp_current;
+
+  unsigned task_size{};
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr) {
+    ProtectedTaskManager::Lease lease(*protected_task_manager);
+    const auto &stats = lease->GetStats();
+
+    tp = lease->GetMode();
+
+    if (stats.task_valid) {
+      if (tp == TaskType::ORDERED) {
+
+        const OrderedTask &task = lease->GetOrderedTask();
+
+        task_size = task.TaskSize();
+
+        wp_current = task.GetActiveTaskPoint()->GetWaypointPtr();
+
+        auto i = task.GetActiveIndex();
+        if (i == 0) wp_before = nullptr;
+        else wp_before = task.GetPoint(i - 1).GetWaypointPtr();
+      } else {
+        wp_current =
+            lease->GetActiveTask()->GetActiveTaskPoint()->GetWaypointPtr();
+        wp_before = nullptr;
+      }
+    } else {
+      wp_current = nullptr;
+      wp_before = nullptr;
+    }
+  }
+}
+
+void
+NavigatorWindow::StopDragging()
+{
+  if (!dragging) return;
+
+  dragging = false;
+  ReleaseCapture();
+}
+
+bool
+NavigatorWindow::OnMouseGesture(const TCHAR *gesture) noexcept
+{
+  if (StringIsEqual(gesture, _T("U"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("D"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  const auto &swipeReversed =
+      CommonInterface::GetUISettings().navigator.navigator_swipe;
+  if (StringIsEqual(gesture, _T("R"))) {
+    swipeReversed ? InputEvents::eventAdjustWaypoint(_T("previouswrap"))
+                  : InputEvents::eventAdjustWaypoint(_T("nextwrap"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("L"))) {
+    swipeReversed ? InputEvents::eventAdjustWaypoint(_T("nextwrap"))
+                  : InputEvents::eventAdjustWaypoint(_T("previouswrap"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("UD"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("DR"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("RL"))) {
+    InputEvents::eventSetup(_T("Target"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("LR"))) {
+    InputEvents::eventSetup(_T("Alternates"));
+    return true;
+  }
+  if (gesture) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+
+  return InputEvents::processGesture(gesture);
+}
+
+bool
+NavigatorWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
+{
+  StopDragging();
+  ignore_single_click = true;
+
+  InputEvents::ShowMenu();
+  InputEvents::setMode(_T("Navigator"));
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseDown(PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) return true;
+
+  mouse_down_clock.Update();
+
+  if (!dragging) {
+    dragging = true;
+    SetCapture();
+    gestures.Start(p, Layout::Scale(20));
+  }
+
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) {
+    ignore_single_click = false;
+    return true;
+  }
+
+  const auto click_time = mouse_down_clock.Elapsed();
+  mouse_down_clock.Reset();
+
+  if (dragging) {
+    StopDragging();
+
+    const TCHAR *gesture = gestures.Finish();
+    if (gesture && OnMouseGesture(gesture)) return true;
+
+    if (click_time > std::chrono::milliseconds(0) &&
+        click_time <= std::chrono::milliseconds(200)) {
+      InputEvents::ShowMenu();
+      InputEvents::setMode(_T("Navigator1"));
+    }
+
+    else if (click_time > std::chrono::milliseconds(200) &&
+             click_time <= std::chrono::milliseconds(500))
+      // quickClick
+      InputEvents::eventStatus(_T("task"));
+
+    else if (click_time > std::chrono::milliseconds(500) &&
+             click_time <= std::chrono::milliseconds(2000))
+      // simpleClick
+      InputEvents::eventAnalysis(_T("AnalysisPage::TASK"));
+
+    else if (click_time > std::chrono::milliseconds(2000) &&
+             click_time < std::chrono::milliseconds(10000))
+      // longClick
+      InputEvents::eventSetup(_T("Task"));
+
+    else return false;
+  }
+
+  return false;
+}
+
+bool
+NavigatorWindow::OnMouseMove(PixelPoint p,
+                             [[maybe_unused]] unsigned keys) noexcept
+{
+  if (dragging) gestures.Update(p);
+
+  return true;
+}
+
+void
+NavigatorWindow::OnCancelMode() noexcept
+{
+#ifndef USE_WINUSER
+  ReleaseCapture();
+#endif
+  StopDragging();
+}
+
+bool
+NavigatorWindow::OnKeyDown(unsigned key_code) noexcept
+{
+  return InputEvents::processKey(key_code);
+}
+
+void
+NavigatorWidget::Update([[maybe_unused]] const MoreData &basic) noexcept
+{
+  navigator_window->ReadBlackboard(basic.attitude);
+}
+
+void
+NavigatorWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+{
+  const Look &look = UIGlobals::GetLook();
+
+  WindowStyle style;
+  style.Hide();
+  style.Disable();
+
+  navigator_window = std::make_unique<NavigatorWindow>(
+      look.navigator, look.map.task, look.info_box, nav_type,
+      isNavigatorTopPosition);
+  navigator_window->Create(parent, rc, style);
+  navigator_window->Move(rc);
+}
+
+void
+NavigatorWidget::Show([[maybe_unused]] const PixelRect &rc) noexcept
+{
+  Update(CommonInterface::Basic());
+  CommonInterface::GetLiveBlackboard().AddListener(*this);
+  navigator_window->Show();
+}
+
+void
+NavigatorWidget::Hide() noexcept
+{
+  navigator_window->Hide();
+  CommonInterface::GetLiveBlackboard().RemoveListener(*this);
+}
+
+void
+NavigatorWidget::Move(const PixelRect &rc) noexcept
+{
+  navigator_window->Move(rc);
+}
+
+bool
+NavigatorWidget::SetFocus() noexcept
+{
+  return false;
+}
+
+PixelSize
+NavigatorWidget::GetMinimumSize() const noexcept
+{
+  unsigned int navHeight{};
+
+  const auto &navSettings = CommonInterface::GetUISettings().navigator;
+
+  switch (nav_type) {
+  case navType::NAVIGATOR_LITE_ONE_LINE:
+    navHeight = navSettings.navigator_lite_1_line_height;
+    break;
+  case navType::NAVIGATOR_LITE_TWO_LINES:
+    navHeight = navSettings.navigator_lite_2_lines_height;
+    break;
+  case navType::NAVIGATOR:
+    navHeight = navSettings.navigator_height;
+    break;
+  case navType::NAVIGATOR_DETAILED:
+    navHeight = navSettings.navigator_detailed_height;
+    break;
+  default:
+    navHeight = navSettings.navigator_height;
+    break;
+  }
+
+  return PixelSize{navHeight};
+}
+
+void
+NavigatorWidget::OnGPSUpdate(const MoreData &basic) noexcept
+{
+  Update(basic);
+}
+
+void
+NavigatorWidget::UpdateLayout() noexcept
+{
+  const PixelRect rc = navigator_window->GetClientRect();
+  navigator_window->Move(rc);
+}

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -119,6 +119,9 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
   if (tp == TaskType::ORDERED)
     renderer.DrawProgressTask(task_summary, canvas, canvas.GetRect(), look_nav,
                               look_task);
+
+  renderer.DrawWaypointsIconsTitle(canvas, wp_before, wp_current, task_size,
+                                   look_nav, nav_type);
 }
 
 void

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -112,6 +112,13 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
     renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
     break;
   }
+
+  const auto task_summary =
+      CommonInterface::Calculated().common_stats.ordered_summary;
+
+  if (tp == TaskType::ORDERED)
+    renderer.DrawProgressTask(task_summary, canvas, canvas.GetRect(), look_nav,
+                              look_task);
 }
 
 void

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -43,6 +43,8 @@ NavigatorWindow::ReadBlackboard(const AttitudeState &_attitude) noexcept
 void
 NavigatorWindow::OnPaint(Canvas &canvas) noexcept
 {
+  renderer.Update(canvas);
+
   if (look_nav.inverse) {
     canvas.Clear(COLOR_BLACK);
   } else {
@@ -84,6 +86,31 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
       wp_current = nullptr;
       wp_before = nullptr;
     }
+  }
+
+  const PixelRect frame_navigator =
+      canvas.GetRect().WithPadding(Layout::Scale(1));
+
+  const int canvas_height = canvas.GetHeight();
+  const int canvas_width = canvas.GetWidth();
+
+  PixelPoint pt_origin{canvas_width * 18 / 100, canvas_height * 1 / 10};
+  PixelSize frame_size{canvas_width * 8 / 10, canvas_height * 55 / 100};
+  PixelRect frame_navigator_waypoint{pt_origin, frame_size};
+
+  switch (nav_type) {
+  case navType::NAVIGATOR_LITE_ONE_LINE:
+  case navType::NAVIGATOR_LITE_TWO_LINES:
+  case navType::NAVIGATOR:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    break;
+  case navType::NAVIGATOR_DETAILED:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    renderer.DrawFrame(canvas, frame_navigator_waypoint, look_nav, false);
+    break;
+  default:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    break;
   }
 }
 

--- a/src/Gauge/NavigatorWidget.hpp
+++ b/src/Gauge/NavigatorWidget.hpp
@@ -23,6 +23,8 @@ class NavigatorWindow : public PaintWindow {
   const enum navType nav_type { navType::NAVIGATOR };
   const bool isNavigatorTopPosition{};
 
+  NavigatorRenderer renderer;
+
   AttitudeState attitude;
 
   GestureManager gestures;

--- a/src/Gauge/NavigatorWidget.hpp
+++ b/src/Gauge/NavigatorWidget.hpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Blackboard/BlackboardListener.hpp"
+#include "Interface.hpp"
+#include "Look/Look.hpp"
+#include "Look/NavigatorLook.hpp"
+#include "MainWindow.hpp"
+#include "Renderer/NavigatorRenderer.hpp"
+#include "UIUtil/GestureManager.hpp"
+#include "Widget/WindowWidget.hpp"
+
+/**
+ * A Window which renders a Navigator
+ */
+class NavigatorWindow : public PaintWindow {
+  const NavigatorLook &look_nav;
+  const TaskLook &look_task;
+  const InfoBoxLook &look_infobox;
+
+  const enum navType nav_type { navType::NAVIGATOR };
+  const bool isNavigatorTopPosition{};
+
+  AttitudeState attitude;
+
+  GestureManager gestures;
+  bool dragging{false};
+  bool ignore_single_click{false};
+
+  PeriodClock mouse_down_clock;
+
+public:
+  /**
+   * Constructor. Initializes most class members.
+   */
+  NavigatorWindow(const NavigatorLook &_look_nav, const TaskLook &_look_task,
+                  const InfoBoxLook &_look_infobox,
+                  const enum navType _navType, const bool _isNavTop) noexcept;
+
+  void ReadBlackboard(const AttitudeState &_attitude) noexcept;
+
+protected:
+  /* virtual methods from AntiFlickerWindow */
+  void OnPaint(Canvas &canvas) noexcept override;
+
+private:
+  void StopDragging();
+
+public:
+  bool OnMouseGesture(const TCHAR *gesture) noexcept;
+  bool OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseDown(PixelPoint p) noexcept override;
+  bool OnMouseUp([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseMove(PixelPoint p,
+                   [[maybe_unused]] unsigned keys) noexcept override;
+  void OnCancelMode() noexcept override;
+  bool OnKeyDown(unsigned key_code) noexcept override;
+};
+
+class NavigatorWidget final : public NullWidget,
+                              private NullBlackboardListener {
+
+  std::unique_ptr<NavigatorWindow> navigator_window;
+
+  enum navType nav_type { navType::NAVIGATOR };
+  bool isNavigatorTopPosition{true};
+
+  bool enable_auto_zoom = true;
+  unsigned zoom = 2;
+
+public:
+  NavigatorWidget(const enum navType _navType, const bool _isNavTop = true)
+  {
+    isNavigatorTopPosition = _isNavTop;
+    nav_type = _navType;
+  };
+  ~NavigatorWidget() noexcept = default;
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
+  void Move(const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
+
+  PixelSize GetMinimumSize() const noexcept override;
+
+  NavigatorWindow *GetWindow() const noexcept
+  {
+    return navigator_window.get();
+  }
+
+private:
+  void Update(const MoreData &basic) noexcept;
+  void UpdateLayout() noexcept;
+  void SetNavType() noexcept;
+
+  /* virtual methods from class BlackboardListener */
+  void OnGPSUpdate(const MoreData &basic) noexcept override;
+};

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -335,12 +335,45 @@ InputEvents::eventStatus(const TCHAR *misc)
 void
 InputEvents::eventAnalysis([[maybe_unused]] const TCHAR *misc)
 {
+  AnalysisPage analysis_page;
+
+  if (StringIsEqual(misc, _T("AnalysisPage::BAROGRAPH"))) {
+    analysis_page = AnalysisPage::BAROGRAPH;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::COUNT"))) {
+    analysis_page = AnalysisPage::COUNT;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::CLIMB"))) {
+    analysis_page = AnalysisPage::CLIMB;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::VARIO_HISTOGRAM"))) {
+    analysis_page = AnalysisPage::VARIO_HISTOGRAM;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::THERMAL_BAND"))) {
+    analysis_page = AnalysisPage::THERMAL_BAND;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::WIND"))) {
+    analysis_page = AnalysisPage::WIND;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::POLAR"))) {
+    analysis_page = AnalysisPage::POLAR;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::MACCREADY"))) {
+    analysis_page = AnalysisPage::MACCREADY;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TEMPTRACE"))) {
+    analysis_page = AnalysisPage::TEMPTRACE;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TASK"))) {
+    analysis_page = AnalysisPage::TASK;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::CONTEST"))) {
+    analysis_page = AnalysisPage::CONTEST;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TASK_SPEED"))) {
+    analysis_page = AnalysisPage::TASK_SPEED;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::AIRSPACE"))) {
+    analysis_page = AnalysisPage::AIRSPACE;
+  } else {
+    analysis_page = AnalysisPage::CONTEST;
+  }
+
   dlgAnalysisShowModal(*CommonInterface::main_window,
                        CommonInterface::main_window->GetLook(),
                        CommonInterface::Full(),
                        *backend_components->glide_computer,
                        data_components->airspaces.get(),
-                       data_components->terrain.get());
+                       data_components->terrain.get(),
+                       analysis_page);
 }
 
 // WaypointDetails

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -42,6 +42,7 @@ Look::InitialiseConfigured(const UISettings &settings,
   dialog.Initialise();
   terminal.Initialise();
   cross_section.Initialise(map_font);
+  navigator.Initialise(dark_mode);
   horizon.Initialise();
   thermal_band.Initialise(dark_mode,
                           cross_section.sky_color);

--- a/src/Look/Look.hpp
+++ b/src/Look/Look.hpp
@@ -13,6 +13,7 @@
 #include "MapLook.hpp"
 #include "CrossSectionLook.hpp"
 #include "HorizonLook.hpp"
+#include "NavigatorLook.hpp"
 #include "TrafficLook.hpp"
 #include "FlarmTrafficLook.hpp"
 #include "InfoBoxLook.hpp"
@@ -37,6 +38,7 @@ struct Look {
   MapLook map;
   CrossSectionLook cross_section;
   HorizonLook horizon;
+  NavigatorLook navigator;
   TrafficLook traffic;
   FlarmTrafficLook flarm_gauge;
   FlarmTrafficLook flarm_dialog;

--- a/src/Look/NavigatorLook.cpp
+++ b/src/Look/NavigatorLook.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorLook.hpp"
+#include "Screen/Layout.hpp"
+
+void
+NavigatorLook::Initialise(bool _inverse)
+{
+  Color pen_frame_color, brush_frame_color;
+
+  if (!(inverse = _inverse)) {
+    pen_frame_color = color_frame;
+    brush_frame_color = color_background_frame;
+  } else {
+    pen_frame_color = color_frame_inv;
+    brush_frame_color = color_background_frame_inv;
+  }
+  pen_frame.Create(Layout::ScaleFinePenWidth(1), pen_frame_color);
+  brush_frame.Create(brush_frame_color);
+}

--- a/src/Look/NavigatorLook.hpp
+++ b/src/Look/NavigatorLook.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/canvas/Brush.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/Pen.hpp"
+
+class Font;
+
+struct NavigatorLook {
+  bool inverse;
+
+  static constexpr Color color_background_frame{COLOR_WHITE};
+  static constexpr Color color_background_frame_inv{COLOR_BLACK};
+  static constexpr Color color_frame{COLOR_BLACK};
+  static constexpr Color color_frame_inv{COLOR_WHITE};
+
+  Pen pen_frame;
+  Brush brush_frame;
+
+  void Initialise(bool _inverse);
+};

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "Gauge/GaugeFLARM.hpp"
 #include "Gauge/GaugeThermalAssistant.hpp"
 #include "Gauge/GlueGaugeVario.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "Form/Form.hpp"
 #include "Widget/Widget.hpp"
 #include "Look/GlobalFonts.hpp"
@@ -144,7 +145,15 @@ GetBottomWidgetRect(const PixelRect &rc_main, const PixelRect &rc_remaining,
     return result;
   }
 
-  const unsigned requested_height = bottom_widget->GetMinimumSize().height;
+  unsigned requested_height{};
+  auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+  if (nav != nullptr) {
+    requested_height =
+        rc_main.GetHeight() * bottom_widget->GetMinimumSize().height / 100;
+  } else {
+    requested_height = bottom_widget->GetMinimumSize().height;
+  }
+
   unsigned height;
   if (requested_height > 0) {
     const unsigned max_height = rc_main.GetHeight() / 2;
@@ -699,6 +708,18 @@ MainWindow::StopDragging() noexcept
 void
 MainWindow::OnCancelMode() noexcept
 {
+  if (HaveTopWidget()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr)
+      nav->GetWindow()->OnCancelMode();
+  }
+
+  if (HaveBottomWidget()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr)
+      nav->GetWindow()->OnCancelMode();
+  }
+
   SingleWindow::OnCancelMode();
   StopDragging();
 }
@@ -706,6 +727,29 @@ MainWindow::OnCancelMode() noexcept
 bool
 MainWindow::OnMouseDown(PixelPoint p) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+  
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDown(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDown(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDown(p))
     return true;
 
@@ -721,6 +765,30 @@ MainWindow::OnMouseDown(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseUp(PixelPoint p) noexcept
 {
+
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseUp(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseUp(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseUp(p))
     return true;
 
@@ -738,6 +806,29 @@ MainWindow::OnMouseUp(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseDouble(PixelPoint p) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDouble(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDouble(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDouble(p))
     return true;
 
@@ -751,6 +842,29 @@ MainWindow::OnMouseDouble(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseMove(p, keys);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseMove(p, keys);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseMove(p, keys))
     return true;
 
@@ -1052,7 +1166,7 @@ MainWindow::KillTopWidget() noexcept
   if (widget == nullptr)
     /* the top widget is only visible above the map, but not above
        a custom main widget; see HaveTopWidget() */
-  top_widget->Hide();
+    top_widget->Hide();
 
   top_widget->Unprepare();
   delete top_widget;
@@ -1086,7 +1200,7 @@ MainWindow::SetTopWidget(Widget *_widget) noexcept
   }
 
   KillTopWidget();
-
+  
   top_widget = _widget;
 
   PixelRect rc_main = GetClientRect();
@@ -1094,7 +1208,7 @@ MainWindow::SetTopWidget(Widget *_widget) noexcept
   const PixelRect bottom_rect =
       GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
   rc_remaining = GetMapRectAbove(rc_remaining, bottom_rect);
-  if (HaveBottomWidget())
+  if (HaveBottomWidget()) 
     bottom_widget->Move(bottom_rect);
 
   const PixelRect top_rect =
@@ -1107,7 +1221,7 @@ MainWindow::SetTopWidget(Widget *_widget) noexcept
     if (widget == nullptr)
       /* the top widget is only visible above the map, but not
          above a custom main widget; see HaveBottomWidget() */
-    top_widget->Show(top_rect);
+      top_widget->Show(top_rect);
   }
 
   map->Move(GetMapRectBelow(rc_remaining, top_rect));

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -142,7 +142,11 @@ protected:
   void KillWidget() noexcept;
 
   bool HaveTopWidget() const noexcept {
-    return top_widget != nullptr;
+    /* currently, the top widget is only visible above the map, but
+       not above a custom main widget */
+    /* TODO: eliminate this limitation; don't forget to remove the
+       "widget==nullptr" check from MainWindow::KillTopWidget() */
+    return top_widget != nullptr && widget == nullptr;
   }
 
   /**

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -59,12 +59,14 @@ public:
         manager.AcknowledgeWarning(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("ACK Day"), [this](){
       manager.AcknowledgeDay(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("More"), [this](){
@@ -100,8 +102,11 @@ AirspaceWarningMonitor::Reset() noexcept
 void
 AirspaceWarningMonitor::HideWidget() noexcept
 {
-  if (widget != nullptr)
+  if (widget != nullptr) {
     PageActions::RestoreBottom();
+    PageActions::RestoreTop();
+  }
+  
   assert(widget == nullptr);
 }
 

--- a/src/Monitor/MatTaskMonitor.cpp
+++ b/src/Monitor/MatTaskMonitor.cpp
@@ -40,9 +40,11 @@ public:
     AddButton(_("Add"), [this](){
       OnAdd();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -173,8 +175,10 @@ MatTaskMonitor::Check()
     last_id = id;
   } else {
     /* no nearby turn point: close the QuestionWidget */
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
 
     last_id = unsigned(-1);
   }

--- a/src/Monitor/TaskAdvanceMonitor.cpp
+++ b/src/Monitor/TaskAdvanceMonitor.cpp
@@ -29,10 +29,12 @@ public:
       }
 
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -54,8 +56,10 @@ TaskAdvanceMonitor::Check()
       PageActions::SetCustomBottom(widget);
     }
   } else {
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
   }
 
   last_active_index = stats.active_index;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -138,6 +138,7 @@ PageActions::Next()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 unsigned
@@ -168,6 +169,7 @@ PageActions::Prev()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 static void
@@ -217,6 +219,22 @@ LoadBottom(PageLayout::Bottom bottom)
 }
 
 static void
+LoadTop(PageLayout::Top top)
+{
+  switch (top) {
+  case PageLayout::Top::NOTHING:
+    CommonInterface::main_window->SetTopWidget(nullptr);
+    break;
+
+  case PageLayout::Top::CUSTOM:
+    /* don't touch */
+    break;
+  case PageLayout::Top::MAX:
+    gcc_unreachable();
+  }
+}
+
+static void
 LoadInfoBoxes(const PageLayout::InfoBoxConfig &config)
 {
   UIState &ui_state = CommonInterface::SetUIState();
@@ -247,6 +265,7 @@ PageActions::LoadLayout(const PageLayout &layout)
 
   LoadInfoBoxes(layout.infobox_config);
   LoadBottom(layout.bottom);
+  LoadTop(layout.top);
   LoadMain(layout.main);
 
   ActionInterface::UpdateDisplayMode();
@@ -299,6 +318,24 @@ PageActions::RestoreBottom()
     special_page.SetUndefined();
 
   LoadBottom(configured_page.bottom);
+}
+
+void
+PageActions::RestoreTop()
+{
+  PageLayout &special_page = CommonInterface::SetUIState().pages.special_page;
+  if (!special_page.IsDefined())
+    return;
+
+  const PageLayout &configured_page = GetConfiguredLayout();
+  if (special_page.top == configured_page.top)
+    return;
+
+  special_page.top = configured_page.top;
+  if (special_page == configured_page)
+    special_page.SetUndefined();
+
+  LoadTop(configured_page.top);
 }
 
 GlueMapWindow *
@@ -377,4 +414,16 @@ PageActions::SetCustomBottom(Widget *widget)
   state.special_page = GetCurrentLayout();
   state.special_page.bottom = PageLayout::Bottom::CUSTOM;
   CommonInterface::main_window->SetBottomWidget(widget);
+}
+
+void
+PageActions::SetCustomTop(Widget *widget)
+{
+  assert(widget != nullptr);
+
+  PagesState &state = CommonInterface::SetUIState().pages;
+
+  state.special_page = GetCurrentLayout();
+  state.special_page.top = PageLayout::Top::CUSTOM;
+  CommonInterface::main_window->SetTopWidget(widget);
 }

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -9,6 +9,7 @@
 #include "MainWindow.hpp"
 #include "CrossSection/CrossSectionWidget.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "Pan.hpp"
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
@@ -209,6 +210,19 @@ LoadBottom(PageLayout::Bottom bottom)
     CommonInterface::main_window->SetBottomWidget(new CrossSectionWidget(*data_components));
     break;
 
+  case PageLayout::Bottom::NAVIGATOR:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(navType::NAVIGATOR, false));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(navType::NAVIGATOR_LITE_ONE_LINE, false));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(navType::NAVIGATOR_LITE_TWO_LINES, false));
+    break;
+  case PageLayout::Bottom::NAVIGATOR_DETAILED:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(navType::NAVIGATOR_DETAILED, false));
+    break;
+
   case PageLayout::Bottom::CUSTOM:
     /* don't touch */
     break;
@@ -224,6 +238,23 @@ LoadTop(PageLayout::Top top)
   switch (top) {
   case PageLayout::Top::NOTHING:
     CommonInterface::main_window->SetTopWidget(nullptr);
+    break;
+
+  case PageLayout::Top::NAVIGATOR:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(navType::NAVIGATOR, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_ONE_LINE:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(navType::NAVIGATOR_LITE_ONE_LINE, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_TWO_LINES:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(navType::NAVIGATOR_LITE_TWO_LINES, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_DETAILED:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(navType::NAVIGATOR_DETAILED, true));
     break;
 
   case PageLayout::Top::CUSTOM:

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -72,6 +72,11 @@ namespace PageActions
   void RestoreBottom();
 
   /**
+   * Like Restore(), but affects only the top area.
+   */
+  void RestoreTop();
+
+  /**
    * Show a page with the map, or restore the current page if it was
    * configured with a map (for example if the user has activated the
    * FLARM radar page).
@@ -102,4 +107,10 @@ namespace PageActions
    * MainWindow::SetBottomWidget().  Call RestoreBottom() to undo this.
    */
   void SetCustomBottom(Widget *widget);
+
+  /**
+   * Use a custom widget for the "top" area.  This is a wrapper for
+   * MainWindow::SetTopWidget().  Call RestoreTop() to undo this.
+   */
+  void SetCustomTop(Widget *widget);
 };

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -71,6 +71,19 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
       builder.Append(_T(", XS"));
       break;
 
+    case Bottom::NAVIGATOR:
+      builder.Append(_T(", NAV_B"));
+      break;
+    case Bottom::NAVIGATOR_LITE_ONE_LINE:
+      builder.Append(_T(", NAV_Lite_1L_B"));
+      break;
+    case Bottom::NAVIGATOR_LITE_TWO_LINES:
+      builder.Append(_T(", NAV_Lite_2L_B"));
+      break;
+    case Bottom::NAVIGATOR_DETAILED:
+      builder.Append(_T(", NAV_Detailed_B"));
+      break;
+      
     case Bottom::MAX:
       gcc_unreachable();
     }
@@ -78,6 +91,18 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
     switch (top) {
     case Top::NOTHING:
     case Top::CUSTOM:
+      break;
+    case Top::NAVIGATOR:
+      builder.Append(_T(", NAV"));
+      break;
+    case Top::NAVIGATOR_LITE_ONE_LINE:
+      builder.Append(_T(", NAV_Lite_1L"));
+      break;
+    case Top::NAVIGATOR_LITE_TWO_LINES:
+      builder.Append(_T(", NAV_Lite_2L"));
+      break;
+    case Top::NAVIGATOR_DETAILED:
+      builder.Append(_T(", NAV_Detailled"));
       break;
     case Top::MAX:
       gcc_unreachable();

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -74,6 +74,14 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
     case Bottom::MAX:
       gcc_unreachable();
     }
+
+    switch (top) {
+    case Top::NOTHING:
+    case Top::CUSTOM:
+      break;
+    case Top::MAX:
+      gcc_unreachable();
+    }
   } catch (BasicStringBuilder<TCHAR>::Overflow) {
   }
 

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -81,17 +81,37 @@ struct PageLayout
     MAX
   } bottom;
 
+  /**
+   * What to show above the main area (i.e. map)?
+   */
+  enum class Top : uint8_t {
+    NOTHING,
+
+    /**
+     * A custom #Widget is being displayed.  This is not a
+     * user-accessible option, it's only used for runtime state.
+     */
+    CUSTOM,
+
+    /**
+     * A dummy entry that is used for validating profile values.
+     */
+    MAX
+  } top;
+
   PageLayout() = default;
 
   constexpr PageLayout(bool _valid, InfoBoxConfig _infobox_config)
     :valid(_valid), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   constexpr PageLayout(InfoBoxConfig _infobox_config)
     :valid(true), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   /**
    * Return an "undefined" page.  Its IsDefined() method will return

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -70,6 +70,14 @@ struct PageLayout
     CROSS_SECTION,
 
     /**
+     * Show a Navigator menu below the map.
+     */
+    NAVIGATOR,
+    NAVIGATOR_LITE_ONE_LINE,
+    NAVIGATOR_LITE_TWO_LINES,
+    NAVIGATOR_DETAILED,
+
+    /**
      * A custom #Widget is being displayed.  This is not a
      * user-accessible option, it's only used for runtime state.
      */
@@ -86,6 +94,14 @@ struct PageLayout
    */
   enum class Top : uint8_t {
     NOTHING,
+
+    /**
+     * Show a Navigator menu above the map.
+     */
+    NAVIGATOR,
+    NAVIGATOR_LITE_ONE_LINE,
+    NAVIGATOR_LITE_TWO_LINES,
+    NAVIGATOR_DETAILED,
 
     /**
      * A custom #Widget is being displayed.  This is not a

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -232,6 +232,7 @@ constexpr std::string_view NavigatorLite1LHeight = "NavigatorLite1LHeight";
 constexpr std::string_view NavigatorLite2LHeight = "NavigatorLite2LHeight";
 constexpr std::string_view NavigatorDetailedHeight = "NavigatorDetailedHeight";
 constexpr std::string_view NavigatorReverseSwipeWaypointMovement = "NavigatorReverseSwipeWaypointMovement";
+constexpr std::string_view NavigatorAltitudeType = "NavigatorAltitudeType";
 
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -227,6 +227,11 @@ constexpr std::string_view FlarmAutoZoom = "FlarmRadarAutoZoom";
 constexpr std::string_view FlarmNorthUp = "FlarmRadarNorthUp";
 constexpr std::string_view FlarmRadarZoom = "FlarmRadarZoom";
 
+constexpr std::string_view NavigatorHeight = "NavigatorHeight";
+constexpr std::string_view NavigatorLite1LHeight = "NavigatorLite1LHeight";
+constexpr std::string_view NavigatorLite2LHeight = "NavigatorLite2LHeight";
+constexpr std::string_view NavigatorDetailedHeight = "NavigatorDetailedHeight";
+
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -231,6 +231,7 @@ constexpr std::string_view NavigatorHeight = "NavigatorHeight";
 constexpr std::string_view NavigatorLite1LHeight = "NavigatorLite1LHeight";
 constexpr std::string_view NavigatorLite2LHeight = "NavigatorLite2LHeight";
 constexpr std::string_view NavigatorDetailedHeight = "NavigatorDetailedHeight";
+constexpr std::string_view NavigatorReverseSwipeWaypointMovement = "NavigatorReverseSwipeWaypointMovement";
 
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -55,6 +55,11 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
       unsigned(pl.bottom) >= unsigned(PageLayout::Bottom::MAX))
     pl.bottom = PageLayout::Bottom::NOTHING;
 
+  strcpy(profileKey + prefixLen, "Top");
+  if (!map.GetEnum(profileKey, pl.top) ||
+      unsigned(pl.top) >= unsigned(PageLayout::Top::MAX))
+    pl.top = PageLayout::Top::NOTHING;
+
   strcpy(profileKey + prefixLen, "Main");
   if (!map.GetEnum(profileKey, pl.main) ||
       unsigned(pl.main) >= unsigned(PageLayout::Main::MAX))
@@ -96,6 +101,9 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
 
   strcpy(profileKey + prefixLen, "Bottom");
   map.Set(profileKey, (unsigned)page.bottom);
+
+  strcpy(profileKey + prefixLen, "Top");
+  map.Set(profileKey, (unsigned)page.top);
 
   strcpy(profileKey + prefixLen, "Main");
   map.Set(profileKey, (unsigned)page.main);

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -59,6 +59,7 @@ Profile::Load(const ProfileMap &map, NavigatorSettings &settings)
   map.Get(ProfileKeys::NavigatorDetailedHeight, settings.navigator_detailed_height);
 
   map.Get(ProfileKeys::NavigatorReverseSwipeWaypointMovement, settings.navigator_swipe);
+  map.GetEnum(ProfileKeys::NavigatorAltitudeType, settings.navigator_altitude_type);
 }
 
 void

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -58,6 +58,7 @@ Profile::Load(const ProfileMap &map, NavigatorSettings &settings)
   map.Get(ProfileKeys::NavigatorHeight, settings.navigator_height);
   map.Get(ProfileKeys::NavigatorDetailedHeight, settings.navigator_detailed_height);
 
+  map.Get(ProfileKeys::NavigatorReverseSwipeWaypointMovement, settings.navigator_swipe);
 }
 
 void

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -14,6 +14,7 @@ namespace Profile {
   static void Load(const ProfileMap &map, DisplaySettings &settings);
   static void Load(const ProfileMap &map, FormatSettings &settings);
   static void Load(const ProfileMap &map, VarioSettings &settings);
+  static void Load(const ProfileMap &map, NavigatorSettings &settings);
   static void Load(const ProfileMap &map, TrafficSettings &settings);
   static void Load(const ProfileMap &map, DialogSettings &settings);
   static void Load(const ProfileMap &map, SoundSettings &settings);
@@ -47,6 +48,16 @@ Profile::Load(const ProfileMap &map, VarioSettings &settings)
   map.Get(ProfileKeys::AppGaugeVarioGross, settings.show_gross);
   map.Get(ProfileKeys::AppAveNeedle, settings.show_average_needle);
   map.Get(ProfileKeys::AppAveThermalNeedle, settings.show_thermal_average_needle);
+}
+
+void
+Profile::Load(const ProfileMap &map, NavigatorSettings &settings) 
+{
+  map.Get(ProfileKeys::NavigatorLite1LHeight, settings.navigator_lite_1_line_height);
+  map.Get(ProfileKeys::NavigatorLite2LHeight, settings.navigator_lite_2_lines_height);
+  map.Get(ProfileKeys::NavigatorHeight, settings.navigator_height);
+  map.Get(ProfileKeys::NavigatorDetailedHeight, settings.navigator_detailed_height);
+
 }
 
 void
@@ -145,6 +156,7 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
   Load(map, settings.format);
   Load(map, settings.map);
   Load(map, settings.info_boxes);
+  Load(map, settings.navigator);
   Load(map, settings.vario);
   Load(map, settings.traffic);
   Load(map, settings.pages);

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorRenderer.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Formatter/LocalTimeFormatter.hpp"
+#include "Formatter/Units.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Gauge/NavigatorWidget.hpp"
+#include "Interface.hpp"
+#include "Look/FontDescription.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "Look/Look.hpp"
+#include "Look/MapLook.hpp"
+#include "Look/NavigatorLook.hpp"
+#include "Look/WaypointLook.hpp"
+#include "Math/Angle.hpp"
+#include "NextArrowRenderer.hpp"
+#include "PageActions.hpp"
+#include "PageSettings.hpp"
+#include "ProgressBarRenderer.hpp"
+#include "Renderer/TextRenderer.hpp"
+#include "Screen/Layout.hpp"
+#include "UIGlobals.hpp"
+#include "UnitSymbolRenderer.hpp"
+#include "Waypoint/Waypoint.hpp"
+#include "WaypointIconRenderer.hpp"
+#include "WaypointRenderer.hpp"
+#include "WindArrowRenderer.hpp"
+#include "time/RoughTime.hpp"
+#include "time/Stamp.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "util/StaticString.hxx"
+
+// standard
+#include <cmath>
+
+void
+NavigatorRenderer::Update(const Canvas &canvas) noexcept
+{
+  if (canvas_width != canvas.GetWidth() ||
+      canvas_height != canvas.GetHeight()) {
+    canvas_width = canvas.GetWidth();
+    canvas_height = canvas.GetHeight();
+    hasCanvasSizeChanged = true;
+  } else {
+    hasCanvasSizeChanged = false;
+  }
+
+  basic = &CommonInterface::Basic();
+  calculated = &CommonInterface::Calculated();
+
+  has_started = calculated->ordered_task_stats.start.HasStarted();
+}
+
+void
+NavigatorRenderer::GenerateFrame(const PixelRect &rc,
+                                 const bool is_frame_main) noexcept
+{
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+  const auto rc_top_left = rc.GetTopLeft();
+
+  /* the divisions below are not simplified deliberately to understand frame
+     construction */
+  const PixelPoint pt0 = {rc_top_left.x + rc_height * 5 / 20, rc_top_left.y};
+  const PixelPoint pt1 = {rc_top_left.x + rc_width - rc_height * 4 / 20,
+                          pt0.y};
+  const PixelPoint pt2 = {rc_top_left.x + rc_width - rc_height * 2 / 20,
+                          rc_top_left.y + rc_height * 1 / 20};
+  const PixelPoint pt3 = {rc_top_left.x + rc_width,
+                          rc_top_left.y + rc_height * 10 / 20};
+  const PixelPoint pt4 = {pt2.x, rc_top_left.y + rc_height * 19 / 20};
+  const PixelPoint pt5 = {pt1.x, rc_top_left.y + rc_height};
+  const PixelPoint pt6 = {pt0.x, pt5.y};
+  const PixelPoint pt7 = {rc_top_left.x + rc_height * 2 / 20, pt4.y};
+  const PixelPoint pt8 = {rc_top_left.x, pt3.y};
+  const PixelPoint pt9 = {pt7.x, pt2.y};
+
+  if (is_frame_main) {
+    polygone_frame_main = {pt0, pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8, pt9};
+  } else {
+    polygone_frame_detailed = {pt0, pt1, pt2, pt3, pt4,
+                               pt5, pt6, pt7, pt8, pt9};
+  }
+}
+
+void
+NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
+                             const NavigatorLook &look_nav,
+                             const bool is_frame_main) noexcept
+{
+  if (hasCanvasSizeChanged) {
+    GenerateFrame(rc, is_frame_main);
+  }
+
+  canvas.Select(look_nav.pen_frame);
+  canvas.Select(look_nav.brush_frame);
+
+  if (is_frame_main) {
+    canvas.DrawPolygon(polygone_frame_main.data(), polygone_frame_main.size());
+  } else {
+    canvas.DrawPolygon(polygone_frame_detailed.data(),
+                       polygone_frame_detailed.size());
+  }
+}
+

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -200,3 +200,49 @@ NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
     canvas.DrawRectangle(PixelRect{position_waypoint}.WithMargin(w));
   }
 }
+
+void
+NavigatorRenderer::DrawWaypointsIconsTitle(
+    Canvas &canvas, WaypointPtr waypoint_before, WaypointPtr waypoint_current,
+    unsigned task_size, [[maybe_unused]] const NavigatorLook &look,
+    const enum navType nav_type) noexcept
+{
+  const int rc_height = canvas_height;
+
+  const WaypointRendererSettings &waypoint_settings =
+      CommonInterface::GetMapSettings().waypoint;
+  const WaypointLook &waypoint_look = UIGlobals::GetMapLook().waypoint;
+
+  WaypointIconRenderer waypoint_icon_renderer{waypoint_settings, waypoint_look,
+                                              canvas};
+  const PixelPoint position_waypoint_left{
+      static_cast<int>(canvas_width * 7 / 200), rc_height * 1 / 2};
+
+  static PixelPoint position_waypoint_right{};
+
+  if (nav_type == navType::NAVIGATOR_DETAILED) {
+    position_waypoint_right = {
+        static_cast<int>(canvas_width * 98 / 100 - rc_height * 15 / 100),
+        rc_height * 38 / 100};
+  } else {
+    position_waypoint_right = {static_cast<int>(canvas_width * 193 / 200),
+                               rc_height * 1 / 2};
+  }
+
+  // CALCULATE REACHABILITY
+  /// TODO: implement waypoint reachability
+  /// without using costing calculation inside renderer
+  WaypointReachability wr_before{WaypointReachability::UNREACHABLE};
+  WaypointReachability wr_current{WaypointReachability::UNREACHABLE};
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr && task_size > 1) {
+    if (waypoint_before != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_before, position_waypoint_left,
+                                  wr_before, true);
+    if (waypoint_current != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_current, position_waypoint_right,
+                                  wr_current, true);
+  }
+}

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -108,3 +108,95 @@ NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
   }
 }
 
+void
+NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                                    const PixelRect &rc,
+                                    const NavigatorLook &look_nav,
+                                    const TaskLook &look_task) noexcept
+{
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+
+  // render the progress bar
+  PixelRect r{rc_height * 5 / 24, rc_height - rc_height * 5 / 48,
+              rc_width - rc_height * 10 / 48, rc_height - rc_height * 1 / 48};
+
+  bool task_has_started =
+      CommonInterface::Calculated().task_stats.start.HasStarted();
+  bool task_is_finished =
+      CommonInterface::Calculated().task_stats.task_finished;
+
+  unsigned int progression{};
+
+  if (task_has_started && !task_is_finished)
+    progression = 100 * (1 - summary.p_remaining);
+  else if (task_has_started && task_is_finished) progression = 100;
+  else progression = 0;
+
+  DrawSimpleProgressBar(canvas, r, progression, 0, 100);
+
+  canvas.Select(look_nav.brush_frame);
+
+  // render the waypoints on the progress bar
+  const Pen pen_waypoint(Layout::ScalePenWidth(1), COLOR_BLACK);
+  const Pen pen_indications(Layout::ScalePenWidth(1),
+                            look_nav.inverse ? COLOR_GRAY : COLOR_DARK_GRAY);
+  canvas.Select(pen_indications);
+
+  bool target{true};
+  unsigned i = 0;
+  for (auto it = summary.pts.begin(); it != summary.pts.end(); ++it, ++i) {
+    auto p = it->p;
+
+    const PixelPoint position_waypoint(
+        p * (rc_width - 10 / 24.0 * rc_height) + 5 / 24.0 * rc_height,
+        rc_height - static_cast<int>(1.5 / 24.0 * rc_height));
+
+    int w = Layout::Scale(2);
+
+    /* search for the next Waypoint to reach and draw two horizontal lines
+     * left and right if one Waypoint has been missed, the two lines are also
+     * drawn
+     */
+    if (!it->achieved && target) {
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-w, 0.5 * w),
+                      position_waypoint.At(-2 * w, 0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, 0.5 * w),
+                      position_waypoint.At(2 * w, 0.5 * w));
+
+      canvas.DrawLine(position_waypoint.At(-w, -0.5 * w),
+                      position_waypoint.At(-2 * w, -0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, -0.5 * w),
+                      position_waypoint.At(2 * w, -0.5 * w));
+
+      target = false;
+    }
+
+    if (i == summary.active) {
+      // search for the Waypoint on which the user is looking for and draw
+      // two vertical lines left and right
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-2 * w, w),
+                      position_waypoint.At(-2 * w, -w));
+      canvas.DrawLine(position_waypoint.At(2 * w, w),
+                      position_waypoint.At(2 * w, -w));
+
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbOrange);
+      w = Layout::Scale(2);
+    } else if (i < summary.active) {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbNotReachableTerrain);
+      w = Layout::Scale(2);
+    } else {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbLightGray);
+
+      w = Layout::Scale(1);
+    }
+
+    canvas.Select(pen_waypoint);
+    canvas.DrawRectangle(PixelRect{position_waypoint}.WithMargin(w));
+  }
+}

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -766,6 +766,42 @@ NavigatorRenderer::DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
 }
 
 void
+NavigatorRenderer::DrawAverageSpeed(Canvas &canvas,
+                                    const enum navType nav_type,
+                                    const InfoBoxLook &look_infobox) noexcept
+{
+  if (nav_type == navType::NAVIGATOR_DETAILED) {
+    // Task informations: average speed -----------------------------
+    if (canvas_width > canvas_height * 3.4) {
+      font_height = canvas_height * 35 / 200;
+    } else {
+      font_height = canvas_height * 24 / 200;
+    }
+    font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+    size_text = canvas.CalcTextSize(waypoint_average_speed_s.c_str());
+    PixelPoint pxpt_pos_average_speed{
+        static_cast<int>(canvas_width * 5 / 200 + 6),
+        static_cast<int>(canvas_height * 8 / 100)};
+    canvas.Select(font);
+    pp_drawed_text_origin = {0, 0};
+    ps_drawed_text_size = {static_cast<int>(canvas_width),
+                           static_cast<int>(canvas_height)};
+    pr_drawed_text_rect = {pp_drawed_text_origin, ps_drawed_text_size};
+    canvas.DrawClippedText(pxpt_pos_average_speed, pr_drawed_text_rect,
+                           waypoint_average_speed_s);
+
+    // Draw average speed unit --------------------------------------
+    unit = Units::GetUserTaskSpeedUnit();
+    unit_height = static_cast<unsigned int>(font_height * 0.5);
+    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    pp_pos_unit =
+        pxpt_pos_average_speed.At(size_text.width, size_text.height / 10);
+    UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
+                             look_infobox.unit_fraction_pen);
+  }
+}
+
+void
 NavigatorRenderer::DrawDirectionArrowNorthAnnulus(
     Canvas &canvas, const enum navType nav_type,
     const TaskLook &look_task) noexcept
@@ -895,6 +931,8 @@ NavigatorRenderer::DrawTaskTextsArrow(
   DrawWaypointName(canvas, nav_type);
 
   DrawTimesInfo(canvas, rc, nav_type);
+
+  DrawAverageSpeed(canvas, nav_type, look_infobox);
 
   DrawDirectionArrowNorthAnnulus(canvas, nav_type, look_task);
 }

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -634,6 +634,109 @@ NavigatorRenderer::DrawWaypointName(Canvas &canvas,
 }
 
 void
+NavigatorRenderer::DrawDirectionArrowNorthAnnulus(
+    Canvas &canvas, const enum navType nav_type,
+    const TaskLook &look_task) noexcept
+{
+  // Draw direction arrow / North direction -------------------------
+  if (nav_type == navType::NAVIGATOR_LITE_ONE_LINE ||
+      nav_type == navType::NAVIGATOR_DETAILED ||
+      nav_type == navType::NAVIGATOR) {
+
+    int pos_x_arrow{};
+    int pos_y_arrow_offset{};
+    int scale__arrow{};
+    int pos_y_annulus{};
+    int small_radius_annulus{};
+    int big_radius_annulus{};
+    int sz_max_waypoint_text{};
+
+    const auto has_finished = calculated->ordered_task_stats.task_finished;
+    if (!has_started) {
+      canvas.Select(look_task.hbLightGray);
+    } else {
+      if (!has_finished) {
+        canvas.Select(look_task.hbOrange);
+      } else {
+        canvas.Select(look_task.hbGreen);
+      }
+    }
+
+    switch (nav_type) {
+    case navType::NAVIGATOR_LITE_ONE_LINE:
+      pos_x_arrow = pxpt_pos_infos_waypoint.x -
+                    static_cast<int>(canvas_height * 95 / 100);
+      pos_y_arrow_offset = canvas_height * 43 / 200;
+      pos_y_annulus = static_cast<int>(canvas_height * 48 / 100);
+      small_radius_annulus = static_cast<int>(canvas_height) * 26 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height * 40 / 100);
+      scale__arrow = 14;
+
+      if (static_cast<int>(sz_waypoint_name) <
+          pos_x_arrow - static_cast<int>(canvas_height * 60 / 100) / 2) {
+        pos_x_arrow = (pxpt_pos_infos_waypoint.x + sz_waypoint_name) / 2 -
+                      static_cast<int>(canvas_height * 50 / 100) / 2;
+      }
+      break;
+
+    case navType::NAVIGATOR:
+      pos_x_arrow =
+          pos_x_speed_altitude - static_cast<int>(canvas_height * 90 / 100);
+      pos_y_arrow_offset = canvas_height * 43 / 200;
+      pos_y_annulus = static_cast<int>(canvas_height * 48 / 100);
+      small_radius_annulus = static_cast<int>(canvas_height) * 28 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height) * 36 / 100;
+      scale__arrow = 14;
+      sz_max_waypoint_text = static_cast<int>(
+          std::max(pos_x_end_waypoint_name,
+                   text_size_infos_waypoint + pxpt_pos_infos_waypoint.x));
+      break;
+
+    default:
+      pos_x_arrow =
+          pos_x_speed_altitude - static_cast<int>(canvas_height * 77 / 100);
+      pos_y_arrow_offset = canvas_height * 13 / 100;
+      pos_y_annulus = static_cast<int>(canvas_height * 75 / 200);
+      small_radius_annulus = static_cast<int>(canvas_height) * 18 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height) * 26 / 100;
+      scale__arrow = 21;
+      sz_max_waypoint_text = static_cast<int>(
+          std::max(pos_x_end_waypoint_name,
+                   text_size_infos_waypoint + pxpt_pos_infos_waypoint.x));
+
+      if (sz_max_waypoint_text <
+              pos_x_speed_altitude - big_radius_annulus * 2 &&
+          canvas_width > canvas_height * 4.2) {
+        pos_x_arrow = (pos_x_speed_altitude + sz_max_waypoint_text) / 2 -
+                      2 * big_radius_annulus;
+      }
+      break;
+    }
+
+    canvas.DrawAnnulus(
+        {static_cast<int>(canvas_height) / 2 + pos_x_arrow, pos_y_annulus},
+        small_radius_annulus, big_radius_annulus,
+        -basic->track + Angle::Degrees(50),
+        -basic->track + Angle::Degrees(310));
+
+    canvas.DrawAnnulus(
+        {static_cast<int>(canvas_height) / 2 + pos_x_arrow, pos_y_annulus},
+        small_radius_annulus, big_radius_annulus,
+        -basic->track - Angle::Degrees(8), -basic->track + Angle::Degrees(8));
+
+    NextArrowRenderer next_arrow{UIGlobals::GetLook().next_arrow_info_box};
+    pp_drawed_text_origin = {0, -static_cast<int>(canvas_height / 4)};
+    ps_drawed_text_size = {static_cast<int>(canvas_height),
+                           static_cast<int>(canvas_height)};
+    PixelRect pixelrect_next_arrow{pp_drawed_text_origin, ps_drawed_text_size};
+    pixelrect_next_arrow.Offset(pos_x_arrow, pos_y_arrow_offset);
+
+    next_arrow.DrawArrowScale(canvas, pixelrect_next_arrow, bearing_diff,
+                              scale__arrow);
+  }
+}
+
+void
 NavigatorRenderer::DrawTaskTextsArrow(
     Canvas &canvas, TaskType tp, [[maybe_unused]] const Waypoint &wp_current,
     [[maybe_unused]] const PixelRect &rc, const enum navType nav_type,
@@ -656,6 +759,8 @@ NavigatorRenderer::DrawTaskTextsArrow(
   DrawCurrentFlightInfos(canvas, nav_type, look_infobox);
 
   DrawWaypointName(canvas, nav_type);
+
+  DrawDirectionArrowNorthAnnulus(canvas, nav_type, look_task);
 }
 
 void

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -60,6 +60,9 @@ class NavigatorRenderer {
   StaticString<20> current_altitude_s; // e_HeightGPS
   StaticString<20> waypoint_average_speed_s; // e_SpeedTaskAvg
 
+  // GenerateStringWaypointName() members ---------------------------
+  StaticString<50> waypoint_name_s; // e_WP_Name
+
   // DrawWaypointInfos() members ------------------------------------
   Font font;
   unsigned int font_height{};
@@ -79,6 +82,12 @@ class NavigatorRenderer {
   // DrawCurrentFlightInfos() members -------------------------------
   int pos_x_speed_altitude{}; // also used in DrawWaypointName() /
                               // Arrow placement
+
+  // DrawWaypointName() members -------------------------------------
+  unsigned pos_x_waypoint_name{};
+  unsigned pos_y_waypoint_name{};
+  unsigned pos_x_end_waypoint_name{}; // also used Arrow placement
+  unsigned sz_waypoint_name{}; // also used Arrow placement
 
   ///////////////////////////////////////////////////////////////////
   // generate text --------------------------------------------------
@@ -101,6 +110,11 @@ class NavigatorRenderer {
    */
   void GenerateStringsCurrentFlightInfo(const TaskType tp) noexcept;
 
+  /**
+   * Generate text: waypoint's name
+   */
+  void GenerateStringWaypointName(const Waypoint &wp_current) noexcept;
+
   ///////////////////////////////////////////////////////////////////
   // draw -----------------------------------------------------------
   /**
@@ -119,6 +133,8 @@ class NavigatorRenderer {
    */
   void DrawCurrentFlightInfos(Canvas &canvas, const enum navType nav_type,
                               const InfoBoxLook &look_infobox) noexcept;
+
+  void DrawWaypointName(Canvas &canvas, const enum navType nav_type) noexcept;
 public:
   /**
    * Update all data for generating frame, text and

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -55,6 +55,11 @@ class NavigatorRenderer {
   StaticString<60> infos_waypoint_units_dist_alt_s;
   StaticString<60> infos_waypoint_units_dist_alt_GR_s;
 
+  // GenerateStringsCurrentFlightInfo() members ---------------------
+  StaticString<20> current_speed_s; // e_Speed_GPS
+  StaticString<20> current_altitude_s; // e_HeightGPS
+  StaticString<20> waypoint_average_speed_s; // e_SpeedTaskAvg
+
   // DrawWaypointInfos() members ------------------------------------
   Font font;
   unsigned int font_height{};
@@ -71,6 +76,10 @@ class NavigatorRenderer {
   PixelSize ps_drawed_text_size{};
   PixelRect pr_drawed_text_rect{};
 
+  // DrawCurrentFlightInfos() members -------------------------------
+  int pos_x_speed_altitude{}; // also used in DrawWaypointName() /
+                              // Arrow placement
+
   ///////////////////////////////////////////////////////////////////
   // generate text --------------------------------------------------
   
@@ -86,6 +95,11 @@ class NavigatorRenderer {
   void GenerateStringsWaypointInfos(const enum navType nav_type,
                                  const TaskType tp) noexcept;
 
+  /**
+   * Generate texts:
+   * current speed, altitude and task average speed
+   */
+  void GenerateStringsCurrentFlightInfo(const TaskType tp) noexcept;
 
   ///////////////////////////////////////////////////////////////////
   // draw -----------------------------------------------------------
@@ -99,6 +113,12 @@ class NavigatorRenderer {
    */
   void DrawWaypointInfos(Canvas &canvas, const enum navType nav_type,
                          const InfoBoxLook &look_infobox) noexcept;
+
+  /**
+   * Draw current speed / current Altitude
+   */
+  void DrawCurrentFlightInfos(Canvas &canvas, const enum navType nav_type,
+                              const InfoBoxLook &look_infobox) noexcept;
 public:
   /**
    * Update all data for generating frame, text and

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -3,9 +3,63 @@
 
 #pragma once
 
+#include "Engine/Waypoint/Ptr.hpp"
+#include "Engine/Task/TaskType.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
+#include "Units/Unit.hpp"
+#include "ui/dim/Rect.hpp"
+#include "ui/canvas/Canvas.hpp"
+
+#include <array>
+
+struct PixelPoint;
+struct BulkPixelPoint;
+struct NavigatorLook;
+struct InfoBoxLook;
+struct AttitudeState;
+class Canvas;
+class TextRenderer;
+class WaypointIconRenderer;
+struct TaskLook;
+struct TaskSummary;
+
 enum class navType : uint8_t {
     NAVIGATOR_LITE_ONE_LINE,
     NAVIGATOR_LITE_TWO_LINES,
     NAVIGATOR,
     NAVIGATOR_DETAILED
   };
+
+class NavigatorRenderer {
+  bool hasCanvasSizeChanged{};
+  unsigned int canvas_width{};
+  unsigned int canvas_height{};
+
+  // GenerateFrame() members ----------------------------------------
+  std::array<BulkPixelPoint, 10> polygone_frame_main;
+  std::array<BulkPixelPoint, 10> polygone_frame_detailed;
+
+  const MoreData *basic{};
+  const DerivedInfo *calculated{};
+  bool has_started{};
+
+  /**
+   * Generate the frame(s) of the Navigator and the waypoint.
+   */
+  void GenerateFrame(const PixelRect &rc, const bool is_frame_main) noexcept;
+
+public:
+  /**
+   * Update all data for generating frame, text and
+   */
+  void Update(const Canvas &canvas) noexcept;
+
+  /**
+   * This function is used to draw the frame of the Navigator and
+   * also the frame of the waypoint
+   */
+  void DrawFrame(Canvas &canvas, const PixelRect &rc,
+                 const NavigatorLook &look_nav, const bool is_frame_main) noexcept;
+};

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+enum class navType : uint8_t {
+    NAVIGATOR_LITE_ONE_LINE,
+    NAVIGATOR_LITE_TWO_LINES,
+    NAVIGATOR,
+    NAVIGATOR_DETAILED
+  };

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -69,4 +69,14 @@ public:
   void DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
                         const PixelRect &rc, const NavigatorLook &look_nav,
                         const TaskLook &look_task) noexcept;
+
+  /**
+   * Draw the icon of the current task and of the previous task
+   */
+  void DrawWaypointsIconsTitle(Canvas &canvas,
+                               const WaypointPtr waypoint_before,
+                               const WaypointPtr waypoint_current,
+                               unsigned task_size,
+                               const NavigatorLook &look_nav,
+                               const enum navType nav_type) noexcept;
 };

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -45,11 +45,60 @@ class NavigatorRenderer {
   const DerivedInfo *calculated{};
   bool has_started{};
 
+  // GenerateStringsWaypointInfos() members -------------------------
+  StaticString<20> waypoint_distance_s; // e_WP_Distance
+  StaticString<20> waypoint_altitude_s; // WP_AltReq WP_AltDiff or WP_AltArrival
+  StaticString<20> waypoint_GR_s; // e_WP_GR glide ratio
+  Angle bearing_diff{};
+  StaticString<20> waypoint_direction_s; // e_WP_BearingDiff
+  StaticString<100> infos_waypoint_s; // dist + alt + GR
+  StaticString<60> infos_waypoint_units_dist_alt_s;
+  StaticString<60> infos_waypoint_units_dist_alt_GR_s;
+
+  // DrawWaypointInfos() members ------------------------------------
+  Font font;
+  unsigned int font_height{};
+  double ratio_dpi{};
+  PixelPoint pxpt_pos_infos_waypoint{}; // also used in Waypoint_name /
+                                        // Arrow placement
+  unsigned int text_size_infos_waypoint{};
+  PixelSize size_text{};
+  unsigned int unit_height{};
+  unsigned int ascent_height{};
+  PixelPoint pp_pos_unit{};
+  Unit unit{Unit::KILOMETER};
+  PixelPoint pp_drawed_text_origin{};
+  PixelSize ps_drawed_text_size{};
+  PixelRect pr_drawed_text_rect{};
+
+  ///////////////////////////////////////////////////////////////////
+  // generate text --------------------------------------------------
+  
   /**
    * Generate the frame(s) of the Navigator and the waypoint.
    */
   void GenerateFrame(const PixelRect &rc, const bool is_frame_main) noexcept;
 
+  /**
+   * Generate texts:
+   * distance, altitude, (glide ratio, bearing)
+   */
+  void GenerateStringsWaypointInfos(const enum navType nav_type,
+                                 const TaskType tp) noexcept;
+
+
+  ///////////////////////////////////////////////////////////////////
+  // draw -----------------------------------------------------------
+  /**
+   * Set the text colour of all strings in the navigator widget 
+   */
+  void SetTextColor(Canvas &canvas, const NavigatorLook &look_nav) noexcept;
+
+  /**
+   * Draw infos_waypoint_s: distance, altitude, (glide ratio, bearing)
+   */
+  void DrawWaypointInfos(Canvas &canvas, const enum navType nav_type,
+                         const InfoBoxLook &look_infobox) noexcept;
 public:
   /**
    * Update all data for generating frame, text and
@@ -62,6 +111,19 @@ public:
    */
   void DrawFrame(Canvas &canvas, const PixelRect &rc,
                  const NavigatorLook &look_nav, const bool is_frame_main) noexcept;
+
+  /**
+   * Draw information texts about the current task (ordered task) or
+   * the current target (unordered task) + flight infos
+   * e.g. waypoint distance, start time, planned duration, current speed...
+   */
+  void DrawTaskTextsArrow(Canvas &canvas, TaskType tp,
+                          const Waypoint &wp_current, const PixelRect &rc,
+                          const enum navType nav_type,
+                          [[maybe_unused]] const bool isNavTopPosition,
+                          const NavigatorLook &look_nav,
+                          const TaskLook &look_task,
+                          const InfoBoxLook &look_infobox) noexcept;
 
   /**
    * Draw the progress of the current task with presntation of each taskpoint

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -162,6 +162,12 @@ class NavigatorRenderer {
   void DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
                      const enum navType nav_type) noexcept;
 
+  /**
+   * Draw task average speed
+   */
+  void DrawAverageSpeed(Canvas &canvas, const enum navType nav_type, const InfoBoxLook &look_infobox) noexcept;
+
+
   void DrawDirectionArrowNorthAnnulus(Canvas &canvas,
                                       const enum navType nav_type,const TaskLook &look_task) noexcept;
 

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -135,6 +135,10 @@ class NavigatorRenderer {
                               const InfoBoxLook &look_infobox) noexcept;
 
   void DrawWaypointName(Canvas &canvas, const enum navType nav_type) noexcept;
+
+  void DrawDirectionArrowNorthAnnulus(Canvas &canvas,
+                                      const enum navType nav_type,const TaskLook &look_task) noexcept;
+
 public:
   /**
    * Update all data for generating frame, text and

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -62,4 +62,11 @@ public:
    */
   void DrawFrame(Canvas &canvas, const PixelRect &rc,
                  const NavigatorLook &look_nav, const bool is_frame_main) noexcept;
+
+  /**
+   * Draw the progress of the current task with presntation of each taskpoint
+   */
+  void DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                        const PixelRect &rc, const NavigatorLook &look_nav,
+                        const TaskLook &look_task) noexcept;
 };

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -63,6 +63,17 @@ class NavigatorRenderer {
   // GenerateStringWaypointName() members ---------------------------
   StaticString<50> waypoint_name_s; // e_WP_Name
 
+  // GenerateStringsTimesInfo() members -----------------------------
+  const RoughTimeDelta utc_no_offset{};
+  RoughTimeDelta utc_offset{};
+  StaticString<8> time_elapsed_s;
+  StaticString<8> time_start_s;
+  StaticString<8> time_local_s;
+  StaticString<8> time_planned_s;
+  StaticString<8> arrival_planned_s;
+  StaticString<20> times_local_elapsed_s;
+  StaticString<20> times_arrival_planned_s;
+
   // DrawWaypointInfos() members ------------------------------------
   Font font;
   unsigned int font_height{};
@@ -115,6 +126,13 @@ class NavigatorRenderer {
    */
   void GenerateStringWaypointName(const Waypoint &wp_current) noexcept;
 
+  /**
+   * Generate texts:
+   * start task time, local current time and estimated task time ;   
+   * current task duration and estimated task duration
+   */
+  void GenerateStringsTimesInfo(const TaskType tp) noexcept;
+
   ///////////////////////////////////////////////////////////////////
   // draw -----------------------------------------------------------
   /**
@@ -135,6 +153,14 @@ class NavigatorRenderer {
                               const InfoBoxLook &look_infobox) noexcept;
 
   void DrawWaypointName(Canvas &canvas, const enum navType nav_type) noexcept;
+
+  /**
+   * Draw texts:
+   * start task time, local current time and estimated task time ;
+   * current task duration and estimated task duration
+   */
+  void DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
+                     const enum navType nav_type) noexcept;
 
   void DrawDirectionArrowNorthAnnulus(Canvas &canvas,
                                       const enum navType nav_type,const TaskLook &look_task) noexcept;

--- a/src/Renderer/NextArrowRenderer.cpp
+++ b/src/Renderer/NextArrowRenderer.cpp
@@ -67,3 +67,60 @@ NextArrowRenderer::DrawArrow(Canvas &canvas, const PixelRect &rc,
   canvas.Select(look.next_arrow_brush);
   canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
 }
+
+void
+NextArrowRenderer::DrawArrowScale(Canvas &canvas, const PixelRect &rc,
+                             Angle angle, int scale)
+{
+  /*
+   * Define arrow geometry for forward pointing arrow.
+   * These are the coordinates of the corners, relative to the center (o)
+   *
+   *                               +   (0,-head_len)
+   *                              / \
+   *                             /   \
+   *                            /     \
+   * (-head_width,-head_base)  +-+   +-+  (head_width,-head_base)
+   *   (-tail_width,-head_base)  | o |  (tail_width,-head_base)
+   *                             |   |
+   *                             |   |
+   *     (-tail_width,tail_len)  +---+  (tail_width,tail_len)
+   *
+   * The "tail" of the arrow is slightly shorter than the "head" to avoid
+   * the corners of the tail to stick out of the bounding PixelRect.
+   */
+  static constexpr auto head_len = 500;
+  static constexpr auto head_width = 360;
+  static constexpr auto head_base = head_len - head_width;
+  static constexpr auto tail_width = 160;
+  static constexpr auto tail_len = head_len - tail_width / 2;
+
+  // An array of the arrow corner coordinates.
+  BulkPixelPoint arrow[] = {
+    { 0, -head_len/scale },
+    { head_width/scale, -head_base/scale },
+    { tail_width/scale, -head_base/scale },
+    { tail_width/scale, tail_len/scale },
+    { -tail_width/scale, tail_len/scale },
+    { -tail_width/scale, -head_base/scale },
+    { -head_width/scale, -head_base/scale },
+  };
+
+  /*
+   * Rotate the arrow, center it in the bounding rectangle, and scale
+   * it to fill the rectangle.
+   *
+   * Note that PolygonRotateShift scales a polygon with coordinates
+   * in the range -50 to +50 to fill a square with the size of the 'scale'
+   * argument.
+   */
+  const auto size = std::min(rc.GetWidth(), rc.GetHeight());
+  PolygonRotateShift(arrow,
+                     rc.GetCenter(), angle,
+                     size);
+
+  // Draw the arrow.
+  canvas.Select(look.next_arrow_pen);
+  canvas.Select(look.next_arrow_brush);
+  canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
+}

--- a/src/Renderer/NextArrowRenderer.hpp
+++ b/src/Renderer/NextArrowRenderer.hpp
@@ -15,4 +15,5 @@ public:
   NextArrowRenderer(const NextArrowLook &_look):look(_look) {}
 
   void DrawArrow(Canvas &canvas, const PixelRect &rc, Angle angle);
+  void DrawArrowScale(Canvas &canvas, const PixelRect &rc, Angle angle, int scale);
 };

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -36,6 +36,7 @@ UISettings::SetDefaults() noexcept
   info_boxes.SetDefaults();
   vario.SetDefaults();
   traffic.SetDefaults();
+  navigator.SetDefaults();
   pages.SetDefaults();
   dialog.SetDefaults();
   sound.SetDefaults();

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -8,6 +8,7 @@
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Gauge/VarioSettings.hpp"
 #include "Gauge/TrafficSettings.hpp"
+#include "Gauge/NavigatorSettings.hpp"
 #include "PageSettings.hpp"
 #include "Dialogs/DialogSettings.hpp"
 #include "DisplaySettings.hpp"
@@ -69,6 +70,7 @@ struct UISettings {
   MapSettings map;
   InfoBoxSettings info_boxes;
   VarioSettings vario;
+  NavigatorSettings navigator;
   TrafficSettings traffic;
   PageSettings pages;
   DialogSettings dialog;


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

## **add a new feature --> Navigator widget above the map**
The aim of this new widget is to provide the user a summary of informations about the current task / next waypoint at the same place.


![image](https://github.com/XCSoar/XCSoar/assets/52260863/07bfb7a9-5267-49d3-a158-52a5343228b5)
Brief description / features


## **Features:**
### Main frame for informations about current task
- average task speed
- Icon of previous Waypoint
- Progress bar / time informations for the current task
	- time start
	- current time (current task duration)
	- estimated time end (estimated task duration)

### Included Frame for Next Waypoint informations
- Name
- Distance
- Altitude (Next altitude arrival): Absolute arrival altitude at the next waypoint in final glide
- Next GR (required glide ration over ground to reach the best waypoint)
- Arrow Icon: bearing direction to the next waypoint
- North Ring Icon: bearing direction to the north
- information added:  current speed, current altitude
- Icon of next Waypoint

### functionnalities
- manage different task types:
	- TaskType::ORDERED.
	- TaskType::GOTO
	- TaskType::ABORT
	- TaskType::NONE
	- switch to alternate when there is no task or when the task is suspended (Nav->Task Abort)
- all texts scale according to size of the top widget. if the width of the bar is too small, information disappear accordingly.
- gesture in Navigator Widget:
	-  ⬅️  Left: previous Waypoint
	-  ➡️  Right: next Waypoint
	-  ➡️ ⬅️  Right, Left: Next Target
	-  ⬅️ ➡️  Left, Right: Alternates
	- Double click: Standard menu
	- Quick click (400ms < press < 1000ms): Analysis task
	- Long click (1000ms < press < 3000ms): Task manager
- units (small size) beside data as in infoboxes
(km/h, mp/h, knots, m, ft, ...) according to user unit settings
- data placement in regards to the widget size

### configuration
- save configuration in profile file
- units in frames follow the user setup:
Config->System->Setup->Units
(european, american, australian, british units, ...)
- inversed colors update automatically with user setup ; aka dark / light mode
(inverse Infobox setting in the screen layout menu)
Config->System->Look->Screen Layout->Inverse InfoBoxes
- setup height of the navigator widget (default height set to 17%)
Config->System->Gauges->FLARM, Other

![image](https://github.com/XCSoar/XCSoar/assets/52260863/2ef5db2e-a134-48eb-a970-50f6ae1043b7)
Differents pages setting 

![image](https://github.com/XCSoar/XCSoar/assets/52260863/448895e9-86d0-4be7-982e-9d36aaf2d2f1)
all features 

![image](https://github.com/XCSoar/XCSoar/assets/52260863/d3a0c043-bea5-4fb3-99f0-9e333b09c4d1)
Differents hardware screens (eg. smartphone, e-reader), dark / light modes

![image](https://github.com/XCSoar/XCSoar/assets/52260863/6303eddd-5318-4011-b41e-f31cb718177d)
Focus on Bearing Arrow / Ring North direction icons

![image](https://github.com/XCSoar/XCSoar/assets/52260863/087997e7-cbda-4777-9f66-48e163796f87)
Gestures

![image](https://github.com/XCSoar/XCSoar/assets/52260863/ce952755-103b-42de-bf07-30e52574fcbd)
Pages setting

![image](https://github.com/XCSoar/XCSoar/assets/52260863/e518ed20-f039-4d15-82c8-b7bee7eb3187)
Navigator's height setting


Related issues and discussions
------------------------------

### fixed (?) issues in XCSoar
- update sizes of widgets when change pages : the top and bottom widgets sizes were not updated.
That cause bad heights of both widgets. 

[see PageActions.cpp](https://github.com/XCSoar/XCSoar/pull/1064/commits/79eef1c68febdda2cc2171b62d28c68bdac78c7e)

### TODO:
- correct / improve code
- add documentation / translation / ...
- 

### IDEAS for additional features:
- configuration for data above name of next widget:
	- altitude:
		- WP AltR
		- WP AltA
		- WP AltD
- calculated reachability for the previous and next waypoints in order to know if they are reachable (as on map surround these 2 waypoints by a green circle if reachable)

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Navigator panel with four display modes and optional top or bottom placement; added Navigator settings tab to configure heights, swipe direction, and altitude type.
* **Improvements**
  * Layout updated for simultaneous top/bottom panels, dynamic sizing, separators, and page-layout integration for Navigator.
  * Analysis dialog can open to a specific page.
* **Bug Fixes**
  * Top and bottom panels are reliably restored after alerts and task prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->