### PR TITLE
Waypoint Editor dialog: load saved waypoint type

### DIFF
--- a/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointEdit.cpp
@@ -104,7 +104,7 @@ WaypointEditWidget::Prepare(ContainerWindow &, const PixelRect &) noexcept
            0, 30000, 5, false,
            UnitGroup::ALTITUDE, value.elevation);
   AddEnum(_("Type"), nullptr, waypoint_types,
-          value.IsAirport() ? 1u : (value.IsLandable() ? 2u : 0u),
+          (unsigned)value.type,
           this);
 }
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------
On the editing dialog for an individual waypoint, the _unchanged_ value for _Type_  it can be only  "Airport", "Landable" or "Turnpoint" (catch-all).

This PR aims to fix this by displaying the correct value for the "Type" waypoint.
