### PR TITLE
apply USB Interface Class filter on 'Device -> Port' List

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,8 @@ Version 7.29 - not yet released
 * data files
   - reject implausible runway lengths in CUP files
   - fix crash when arc airspace has no center
+* Android
+  - get rid of not usable USB interfaces in the 'Device -> Port' list
 
 Version 7.28 - 2022/10/29
 * data files

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -38,6 +38,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.hardware.usb.UsbConstants;
 import android.os.Build;
 import android.util.Log;
 
@@ -318,9 +319,12 @@ public final class UsbSerialHelper extends BroadcastReceiver {
         /* still exists */
         continue;
 
-      UsbDeviceInterface deviface = new UsbDeviceInterface(device, iface);
-      interfaces.add(deviface);
-      broadcastDetectedDeviceInterface(deviface);
+      int iclass = device.getInterface(iface).getInterfaceClass();
+      if (iclass == UsbConstants.USB_CLASS_VENDOR_SPEC || iclass == UsbConstants.USB_CLASS_CDC_DATA) {
+        UsbDeviceInterface deviface = new UsbDeviceInterface(device, iface);
+        interfaces.add(deviface);
+        broadcastDetectedDeviceInterface(deviface);
+      }
     }
   }
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------

The _(**Android** only)_ PR https://github.com/XCSoar/XCSoar/pull/995 have caused a regression that a **single** USB CDC device has become  appeared as multiple entries in the 'Device -> Port' list.

![](https://user-images.githubusercontent.com/5849637/200782816-c7985a69-b7d2-410d-975f-b57d4f4e71d3.jpg)

The USB device _(member of the XCSoar for Android 'white list')_ has 3 interfaces in total but only the second one is involved in actual 'USB-Serial' data transfers.

This PR applies a filter to avoid appearance of not usable USB interfaces in the 'Port'' list.

Related issues and discussions
------------------------------

I've made a request to the author @henrik1g https://github.com/XCSoar/XCSoar/pull/995#issuecomment-1308471377 of that regressing PR but got no response since then.

There is a similar issue reported by @XCNav user https://github.com/XCSoar/XCSoar/issues/975#issuecomment-1226305153 with USB Ublox-7 GPS device.

![](https://user-images.githubusercontent.com/5849637/200863932-dc5fb243-d62c-46ed-82d2-6133bc20adee.png)

I have most of supported USB-Serial adapters readily available here so I did basic research with assistance of '**lsusb** -v' utility in Linux. 

### FT232

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Vendor Specific Class | 255

### FT4232H

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Vendor Specific Class | 255
1 | Vendor Specific Class | 255
2 | Vendor Specific Class | 255
3 | Vendor Specific Class | 255

### CP210x

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Vendor Specific Class | 255

### PL2303

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Vendor Specific Class | 255

### CH34x

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Vendor Specific Class | 255

### CH9102 , Ublox7 GPS and other CDC ACM compatible devices

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Communications | 2
1 | CDC Data | 10

### SoftRF Dongle, Academy, ES

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Communications | 2
1 | CDC Data | 10

### SoftRF Badge, Lego, Prime Mk3

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Communications | 2
1 | CDC Data | 10
2 | Mass Storage | 8

### SoftRF Balkan

Interface number | Interface Class | decimal Class Value
:---:|:---:|:---:
0 | Communications | 2
1 | CDC Data | 10
2 | Human Interface Device | 3

This PR makes inspection of **bInterfaceClass** value every time we add a device/interface into the list. We accept interfaces with class 255 (Vendor Specific Class) and 10 (CDC Data) but ignore ( skip ) any other ones.

The suggested fix gives a positive effect on XCSoar for Android as follows:

![S21111-001946](https://user-images.githubusercontent.com/5849637/201269785-20c4bd0f-fb2e-4b07-bd2c-0dd2f2dcfc23.jpg)

I've also tested the fix with regular FT2xx , CP210x, PL2303 & etc devices - they remain to operate the same way as before.

### Question: 

Will this PR make other USB devices, such as HID ones,  invisible and/or inoperative with XCSoar for Android ?

### Answer

1) current implementation of USB support in XCSoar for Android uses com.felhr.usbserial.UsbSerialDevice library: https://github.com/felHR85/UsbSerial
This library does not support any of USB devices other than proprietary USB-Serial FT2xx , CP210x , ... and generic CDC ACM ones anyway ;
2) this is the ['white list' of USB devices](https://github.com/XCSoar/XCSoar/blob/master/android/src/UsbSerialHelper.java#L61) supported by XCSoar for Android. It contains USB<->Serial class of devices only.
