### PR TITLE
GaugeFLARM: Show only when traffic is within 4Km

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -14,6 +14,8 @@ Version 7.29 - not yet released
 * Polars
   - Add LS-5 polar
 * fix exchange frequencies crash when no frequency was set
+* user interface
+  - show FLARMGauge only when traffic is within 4Km
 
 Version 7.28 - 2022/10/29
 * data files

--- a/src/FLARM/List.cpp
+++ b/src/FLARM/List.cpp
@@ -40,3 +40,10 @@ TrafficList::FindMaximumAlert() const noexcept
 
   return alert;
 }
+
+bool
+TrafficList::InCloseRange() const noexcept
+{
+  return std::any_of(list.begin(), list.end(), [](const auto &traffic)
+    { return traffic.distance < (RoughDistance)4000; });
+}

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -199,6 +199,11 @@ struct TrafficList {
   constexpr unsigned TrafficIndex(const FlarmTraffic *t) const noexcept {
     return t - list.begin();
   }
+
+  /**
+   * Is set if traffic is present and closer than 4Km.
+   */
+  bool InCloseRange() const noexcept;
 };
 
 static_assert(std::is_trivial<TrafficList>::value, "type is not trivial");

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1079,6 +1079,9 @@ MainWindow::UpdateTrafficGaugeVisibility() noexcept
     if (HasDialog())
       return;
 
+    if (!flarm.traffic.InCloseRange())
+      return;
+
     if (!traffic_gauge.IsDefined())
       traffic_gauge.Set(new GaugeFLARM(CommonInterface::GetLiveBlackboard(),
                                        GetLook().flarm_gauge));


### PR DESCRIPTION
A proposal to implement #481
Presently when an ADS-B capable receiver is hooked up, such as PowerFLARM, the GaugeFLARM is always on display, as ADS-B displays traffic from 200km away.

This change limits that to a 4Km range.

**Note:** This only affects the FLARM Gauge. All traffic is still displayed on the map as before with the distance configured in the FLARM device.

Some Questions:
 * Do we need to make this distance configurable? 4Km is the typical Flarm Range
 * The gauge seems to show 2k max.
 * The implementation recalculates the traffic targets on every GPS Update. Is this efficient enough?

This can be simulated without a FLARM, by changing the range to for example 2000m, and setting a tcp-client to 4353 localhost.
```
./output/UNIX/bin/FeedNMEA tcp 4353 < ./test/data/driver/FLARM/pflaf01.nmea
```
(recording with 2000M filtering)




https://user-images.githubusercontent.com/407371/201847606-ffabe54e-fd4d-49e5-b77a-5dfef9f230ee.mp4

