### PR TITLE
Reactivate 'build-macos'

### DIFF
--- a/src/co/Compat.hxx
+++ b/src/co/Compat.hxx
@@ -34,7 +34,7 @@
 
 #include <utility>
 
-#if defined(_LIBCPP_VERSION) && defined(__clang__) && (__clang_major__ < 14 || defined(ANDROID))
+#if defined(_LIBCPP_VERSION) && defined(__clang__) && !__has_include(<coroutine>)
 /* libc++ until 14 has the coroutine definitions in the
    std::experimental namespace */
 

--- a/src/ui/canvas/apple/ImageDecoder.cpp
+++ b/src/ui/canvas/apple/ImageDecoder.cpp
@@ -112,10 +112,12 @@ LoadJPEGFile(Path path) noexcept
 }
 
 UncompressedImage
-LoadPNG(const void *data, size_t size) noexcept
+LoadPNG(std::span<const std::byte> raw)
 {
+  assert(raw.data() != nullptr);
+
   CGDataProviderRef data_provider = CGDataProviderCreateWithData(
-      nullptr, data, size, nullptr);
+      nullptr, raw.data(), raw.size(), nullptr);
   if (nullptr == data_provider)
     return {};
 

--- a/src/ui/canvas/apple/ImageDecoder.hpp
+++ b/src/ui/canvas/apple/ImageDecoder.hpp
@@ -24,6 +24,7 @@ Copyright_License {
 #pragma once
 
 #include <cstddef>
+#include <span>
 
 class Path;
 class UncompressedImage;
@@ -32,7 +33,7 @@ UncompressedImage
 LoadJPEGFile(Path path) noexcept;
 
 UncompressedImage
-LoadPNG(const void *data, size_t size) noexcept;
+LoadPNG(std::span<const std::byte> buffer);
 
 UncompressedImage
 LoadPNG(Path path) noexcept;


### PR DESCRIPTION
Brief summary of the changes
----------------------------

Since around mid of october the GitHub actions goes fail, probably since there is used clang version 14.0, but the coroutines of the STL are still in the <experimental/coroutine> - folder (similar to Android). For this the preprocessor switch in Compat.hxx didn't work correctly!

With commit 'c6ec4fdab' an additional issue was hided with this failure on MacOS too: The call of LoadPNG was used with `std::span<const std::byte>` instead of `const void *data`, so this has to be changed in apple/ImageDecoder too.

Related issues and discussions
------------------------------

Only MacOS is affected by the bug, but it also prevents a green tick on any new PR