### PR TITLE
Windows: Tracking - the SkyLines loop doesn't never finished

### DIFF
--- a/src/Tracking/SkyLines/Client.cpp
+++ b/src/Tracking/SkyLines/Client.cpp
@@ -75,6 +75,10 @@ SkyLinesTracking::Client::Open(SocketAddress _address)
     handler->OnSkyLinesReady();
   }
 
+#ifdef _WIN32
+  GetSocket().SetNonBlocking();
+#endif
+
   return true;
 }
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------

In case of the Windows-Target (WIN64 or PC)  their seems to be a blocking call to the skylines server, it is enabled and connected.
On closing XCSoar it hangs in this loop and never came back
The only way to stop XCSoar is to destroy it...

For Windows there is a NonBlocking property needed in the socket Open function (all other OS are doing this with a flag in the callíng function 'Read' or 'Write' itself).
In my opinion, this should solve the problem without any side effects - at least XCSoar behaves properly again under Windows.

Related issues and discussions
------------------------------
This issue also has side effects on enabling and disabling the NMEA ports, which is also fixed with this commit.