### PR TITLE
Add support for Kobo Clara 2E

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,7 @@ Version 7.29 - not yet released
   - get rid of not usable USB interfaces in the 'Device -> Port' list
 * Kobo
   - Add support for Libra H2O
+  - Add support for Clara 2E
 
 Version 7.28 - 2022/10/29
 * data files

--- a/kobo/rcS
+++ b/kobo/rcS
@@ -90,7 +90,7 @@ sleep 1
 # but missing modules. Also put ClaraHD and Libra2 in the right mode
 model=`dd if=/dev/mmcblk0 bs=8 count=1 skip=64`
 if [ `expr substr $model 1 7` = SN-N418 ] || [ `expr substr $model 1 7` = SN-N249 ] \
-    [ `expr substr $model 1 7` = SN-N873 ]; then
+    [ `expr substr $model 1 7` = SN-N873 ] || [ `expr substr $model 1 7` = SN-N506 ]; then
     insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/usbserial.ko"
     insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/aircable.ko"
     insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/ch341.ko"
@@ -125,7 +125,7 @@ fi
 # workaround for Kobo Touch N905B kernel bug: the mxc_fb driver
 # crashes when KoboMenu tries to rotate the display too early after
 # boot
-if [ `dd if=/dev/mmcblk0 bs=8 count=1 skip=64` = "SN-N905B" ]; then
+if [ $model = "SN-N905B" ]; then
     sleep 1
 fi
 

--- a/src/Hardware/Battery.cpp
+++ b/src/Hardware/Battery.cpp
@@ -43,10 +43,11 @@ GetInfo() noexcept
   Info info;
   auto &battery = info.battery;
   auto &external = info.external;
+  KoboModel kobo_model = DetectKoboModel();
 
   char line[256];
 
-  if (DetectKoboModel() == KoboModel::GLO_HD) {
+  if (kobo_model == KoboModel::GLO_HD) {
     if (File::ReadString(Path("/sys/class/power_supply/mc13892_bat/status"),
                          line, sizeof(line))) {
       if (StringIsEqual(line,"Not charging\n") ||
@@ -61,7 +62,7 @@ GetInfo() noexcept
       int rem = atoi(line);
       battery.remaining_percent = rem;
     }
-  } else if (DetectKoboModel() == KoboModel::LIBRA2) {
+  } else if (kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::CLARA_2E) {
     if (File::ReadString(Path("/sys/class/power_supply/battery/status"),
                          line, sizeof(line))) {
       if (StringIsEqual(line,"Not charging\n") ||

--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -71,6 +71,7 @@ GetDPI()
   switch (DetectKoboModel()) {
   case KoboModel::GLO_HD:
   case KoboModel::CLARA_HD:
+  case KoboModel::CLARA_2E:
   case KoboModel::LIBRA2:
   case KoboModel::LIBRA_H2O:
     return 300;

--- a/src/Kobo/Kernel.cpp
+++ b/src/Kobo/Kernel.cpp
@@ -112,10 +112,11 @@ IsKoboCustomKernel()
 try {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
-  /* All Kobo except Clara HD, Libra 2 and Libra H2O have a factory kernel without OTG mode so
+  /* All Kobo except Clara HD, Clara 2E, Libra 2 and Libra H2O have a factory kernel without OTG mode so
      a custom kernel is installed for OTG. */
-  if (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::LIBRA2
-      || kobo_model == KoboModel::LIBRA_H2O) return false;
+  if (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
+      || kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::LIBRA_H2O)
+        return false;
 
   FileReader file(Path("/proc/config.gz"));
   GunzipReader gunzip(file);
@@ -137,8 +138,9 @@ IsKoboOTGHostMode()
 {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
-  if (kobo_model != KoboModel::CLARA_HD && kobo_model != KoboModel::LIBRA2
-      && kobo_model != KoboModel::LIBRA_H2O) return IsKoboCustomKernel();
+  if (kobo_model != KoboModel::CLARA_HD && kobo_model != KoboModel::CLARA_2E
+      && kobo_model != KoboModel::LIBRA2 && kobo_model != KoboModel::LIBRA_H2O)
+        return IsKoboCustomKernel();
   /* for Clara HD, Libra 2 and Libra H2O read the mode from the debugfs */
   char buffer[5];
   bool success = File::ReadString(Path("/sys/kernel/debug/ci_hdrc.0/role"),

--- a/src/Kobo/Model.cpp
+++ b/src/Kobo/Model.cpp
@@ -66,6 +66,7 @@ static constexpr struct {
   { "SN-N437", KoboModel::GLO_HD },
   { "SN-RN437", KoboModel::GLO_HD },
   { "SN-N249", KoboModel::CLARA_HD },
+  { "SN-N506", KoboModel::CLARA_2E },
   { "SN-N306", KoboModel::NIA },
   { "SN-N418", KoboModel::LIBRA2 },
   { "SN-N873", KoboModel::LIBRA_H2O },
@@ -94,5 +95,13 @@ DetectKoboModel() noexcept
 const char *
 GetKoboWifiInterface() noexcept
 {
-  return DetectKoboModel() == KoboModel::LIBRA2 ? "wlan0" : "eth0";
+  switch (DetectKoboModel())
+  {
+    case KoboModel::LIBRA2:
+      return "wlan0";
+    case KoboModel::CLARA_2E:
+      return "mlan0";
+    default:
+      return "eth0";
+  }
 }

--- a/src/Kobo/Model.hpp
+++ b/src/Kobo/Model.hpp
@@ -37,6 +37,7 @@ enum class KoboModel {
   GLO,
   GLO_HD,
   CLARA_HD,
+  CLARA_2E,
   NIA,
   LIBRA2,
   LIBRA_H2O,

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -72,8 +72,8 @@ KoboReboot()
 {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
-  if  (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::LIBRA2
-      || kobo_model == KoboModel::LIBRA_H2O)
+  if  (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
+      || kobo_model == KoboModel::LIBRA2|| kobo_model == KoboModel::LIBRA_H2O)
   {
     /* some models require the -f option for reboot to work */
     return Run("/sbin/reboot", "-f");
@@ -154,6 +154,7 @@ KoboExportUSBStorage()
     break;
 
   case KoboModel::CLARA_HD:
+  case KoboModel::CLARA_2E:
   case KoboModel::LIBRA2:
   case KoboModel::LIBRA_H2O:
     InsMod("/drivers/mx6sll-ntx/usb/gadget/configfs.ko");
@@ -184,8 +185,8 @@ KoboUnexportUSBStorage()
 {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
-  if(kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::LIBRA2
-      || kobo_model == KoboModel::LIBRA_H2O)
+  if(kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
+      || kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::LIBRA_H2O)
   {
     RmMod("g_file_storage");
     RmMod("usb_f_mass_storage");
@@ -255,16 +256,24 @@ KoboWifiOn()
     InsMod("/drivers/mx6sll-ntx/wifi/sdio_wifi_pwr.ko");
     InsMod("/drivers/mx6sll-ntx/wifi/8723ds.ko");
     break;
+
+  case KoboModel::CLARA_2E:
+    InsMod("/drivers/mx6sll-ntx/wifi/sdio_wifi_pwr.ko");
+    InsMod("/drivers/mx6sll-ntx/wifi/mlan.ko");
+    InsMod("/drivers/mx6sll-ntx/wifi/moal.ko", "mod_para=nxp/wifi_mod_para_sd8987.conf");
+    break;
   }
 
   Sleep(2000);
 
   const char *interface = GetKoboWifiInterface();
-  const char *driver = DetectKoboModel() == KoboModel::LIBRA2 ? "nl80211" : "wext";
+  const char *driver = (DetectKoboModel() == KoboModel::LIBRA2
+    || DetectKoboModel() == KoboModel::CLARA_2E) ? "nl80211" : "wext";
 
   Run("/sbin/ifconfig", interface, "up");
   Run("/sbin/iwconfig", interface, "power", "off");
-  Run("/bin/wlarm_le", "-i", interface, "up");
+  if (DetectKoboModel() != KoboModel::CLARA_2E)
+    Run("/bin/wlarm_le", "-i", interface, "up");
   Run("/bin/wpa_supplicant", "-i", interface,
       "-c", "/etc/wpa_supplicant/wpa_supplicant.conf",
       "-C", "/var/run/wpa_supplicant", "-B", "-D", driver);
@@ -287,7 +296,8 @@ KoboWifiOff()
 #ifdef KOBO
   const char *interface =  GetKoboWifiInterface();
   Run("/usr/bin/killall", "wpa_supplicant", "udhcpc");
-  Run("/bin/wlarm_le", "-i", interface, "down");
+  if (DetectKoboModel() != KoboModel::CLARA_2E)
+    Run("/bin/wlarm_le", "-i", interface, "down");
   Run("/sbin/ifconfig", interface, "down");
 
   RmMod("dhd");
@@ -358,6 +368,7 @@ KoboCanChangeBacklightBrightness()
   switch (DetectKoboModel()) {
     case KoboModel::GLO_HD:
     case KoboModel::LIBRA2:
+    case KoboModel::CLARA_2E:
       return true;
     default:
       return false;
@@ -380,6 +391,7 @@ KoboGetBacklightBrightness()
       }
       break;
     case KoboModel::LIBRA2:
+    case KoboModel::CLARA_2E:
       if (File::ReadString(Path("/sys/class/backlight/mxc_msp430.0/brightness"), line, sizeof(line))) {
         result = atoi(line);
       }
@@ -407,6 +419,7 @@ KoboSetBacklightBrightness([[maybe_unused]] int percent)
       File::WriteExisting(Path("/sys/class/backlight/mxc_msp430_fl.0/brightness"), std::to_string(percent).c_str());
       break;
     case KoboModel::LIBRA2:
+    case KoboModel::CLARA_2E:
       File::WriteExisting(Path("/sys/class/backlight/mxc_msp430.0/brightness"), std::to_string(percent).c_str());
       break;
     default:

--- a/src/Kobo/SystemDialog.cpp
+++ b/src/Kobo/SystemDialog.cpp
@@ -95,8 +95,8 @@ SystemWidget::SwitchOTGMode()
 {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
-  if (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::LIBRA2
-      || kobo_model == KoboModel::LIBRA_H2O) {
+  if (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
+      || kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::LIBRA_H2O) {
     bool success;
     if (IsKoboOTGHostMode()) {
       success = File::WriteExisting(Path("/sys/kernel/debug/ci_hdrc.0/role"),

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -179,6 +179,7 @@ TopCanvas::TopCanvas(UI::Display &_display)
   case KoboModel::GLO_HD:
   case KoboModel::AURA2:
   case KoboModel::CLARA_HD:
+  case KoboModel::CLARA_2E:
   case KoboModel::LIBRA2:
   case KoboModel::LIBRA_H2O:
     frame_sync = true;
@@ -297,7 +298,8 @@ TopCanvas::Flip()
               kobo_model == KoboModel::AURA2 ||
               kobo_model == KoboModel::LIBRA2 ||
               kobo_model == KoboModel::LIBRA_H2O ||
-              kobo_model == KoboModel::CLARA_HD)
+              kobo_model == KoboModel::CLARA_HD ||
+              kobo_model == KoboModel::CLARA_2E)
              ? WAVEFORM_MODE_A2
              : WAVEFORM_MODE_AUTO),
     UPDATE_MODE_FULL, // PARTIAL


### PR DESCRIPTION
Brief summary of the changes
----------------------------
This PR adds support for the Kobo Clara 2E. No Bluetooth support yet.
