### PR TITLE
build: indicate debug builds by red theme

### DIFF
--- a/build/debug.mk
+++ b/build/debug.mk
@@ -2,6 +2,7 @@ DEBUG ?= y
 DEBUG_GLIBCXX ?= n
 
 ifeq ($(DEBUG),y)
+  TARGET_CPPFLAGS += -DXCSOAR_TESTING
   OPTIMIZE := -Og
   ifeq ($(CLANG),n)
     OPTIMIZE += -funit-at-a-time


### PR DESCRIPTION
Unless DEBUG=n is explicitly set, use the red theme of xcsoar. 
(As XCSoar isn't using the testing branch anylonger, it can be used to differentiate debug from  builds that fly.)