### PR TITLE
Removed force on Kobo reboot

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,7 @@ Version 7.29 - not yet released
   - Add support for Libra H2O
   - Add support for Clara 2E
   - fix truncate wifi list if hidden ssid detected
+  - Reboot without -f (force)
 * Polars
   - Add LS-5 polar
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,6 +10,7 @@ Version 7.29 - not yet released
   - Add support for Clara 2E
   - fix truncate wifi list if hidden ssid detected
   - Reboot without -f (force)
+  - Fix OTG mode for newer models
 * Polars
   - Add LS-5 polar
 

--- a/kobo/rcS
+++ b/kobo/rcS
@@ -89,7 +89,7 @@ sleep 1
 # load kernel modules for ClaraHD, Libra2 and Libra H2O as factory kernel is OTG
 # but missing modules. Also put ClaraHD and Libra2 in the right mode
 model=`dd if=/dev/mmcblk0 bs=8 count=1 skip=64`
-if [ `expr substr $model 1 7` = SN-N418 ] || [ `expr substr $model 1 7` = SN-N249 ] \
+if [ `expr substr $model 1 7` = SN-N418 ] || [ `expr substr $model 1 7` = SN-N249 ] || \
     [ `expr substr $model 1 7` = SN-N873 ] || [ `expr substr $model 1 7` = SN-N506 ]; then
     insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/usbserial.ko"
     insmod "/opt/xcsoar/lib/modules/4.1.15/drivers/usb/serial/aircable.ko"

--- a/kobo/rcS
+++ b/kobo/rcS
@@ -135,7 +135,4 @@ fi
 /opt/xcsoar/bin/simple_usbmodeswitch
 
 # finally, open the menu
-exec /opt/xcsoar/bin/KoboMenu
-
-# just in case launching KoboMenu fails: try xcsoar
-exec /opt/xcsoar/bin/xcsoar
+/opt/xcsoar/bin/KoboMenu &

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -71,13 +71,6 @@ bool
 KoboReboot()
 {
 #ifdef KOBO
-  KoboModel kobo_model = DetectKoboModel();
-  if  (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
-      || kobo_model == KoboModel::LIBRA2|| kobo_model == KoboModel::LIBRA_H2O)
-  {
-    /* some models require the -f option for reboot to work */
-    return Run("/sbin/reboot", "-f");
-  }
   return Run("/sbin/reboot");
 #else
   return false;


### PR DESCRIPTION
Newer busybox firmware required changes to avoid using -f (force) when using the reboot command.
Closes #953


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
