### PR TITLE
Provide GPS data to AirControlDisplay

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -7,6 +7,7 @@ Version 7.29 - not yet released
 * devices
   - ATR833: read-out active and standby frequencies
   - AirControlDisplay: Set and readout of transponder code
+  - AirControlDisplay: forward gps data to device
 * Android
   - get rid of not usable USB interfaces in the 'Device -> Port' list
 * Kobo

--- a/build/test.mk
+++ b/build/test.mk
@@ -109,6 +109,7 @@ TEST_NAMES = \
 	TestByteSizeFormatter \
 	TestTimeFormatter \
 	TestIGCFilenameFormatter \
+	TestNMEAFormatter \
 	TestLXNToIGC \
 	TestLeastSquares \
 	TestHexString \
@@ -476,6 +477,21 @@ TEST_IGC_FILENAME_FORMATTER_SOURCES = \
 	$(TEST_SRC_DIR)/TestIGCFilenameFormatter.cpp
 TEST_IGC_FILENAME_FORMATTER_DEPENDS = MATH UTIL TIME
 $(eval $(call link-program,TestIGCFilenameFormatter,TEST_IGC_FILENAME_FORMATTER))
+
+TEST_NMEA_FORMATTER_SOURCES = \
+	$(SRC)/Units/Descriptor.cpp \
+	$(SRC)/Units/System.cpp \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(SRC)/Device/Parser.cpp \
+	$(SRC)/Device/Driver/FLARM/StaticParser.cpp \
+	$(SRC)/FLARM/Traffic.cpp \
+	$(SRC)/FLARM/FlarmId.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/FakeGeoid.cpp \
+	$(TEST_SRC_DIR)/TestNMEAFormatter.cpp
+TEST_NMEA_FORMATTER_DEPENDS = LIBNMEA GEO MATH IO UTIL TIME
+$(eval $(call link-program,TestNMEAFormatter,TEST_NMEA_FORMATTER))
 
 TEST_STRINGS_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -670,6 +670,7 @@ TEST_DRIVER_SOURCES = \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(SRC)/TransponderCode.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(ENGINE_SRC_DIR)/Waypoint/Waypoint.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
@@ -856,6 +857,7 @@ DEBUG_REPLAY_SOURCES = \
 	$(SRC)/IGC/Generator.cpp \
 	$(SRC)/Units/Descriptor.cpp \
 	$(SRC)/Units/System.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(ENGINE_SRC_DIR)/Airspace/AirspaceWarningConfig.cpp \
 	$(ENGINE_SRC_DIR)/ThermalBand/ThermalBand.cpp \
 	$(ENGINE_SRC_DIR)/ThermalBand/ThermalSlice.cpp \
@@ -1366,8 +1368,11 @@ RUN_VEGA_SETTINGS_SOURCES = \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(SRC)/Units/Descriptor.cpp \
+	$(SRC)/Units/System.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -2454,11 +2459,14 @@ EMULATE_DEVICE_SOURCES = \
 	$(SRC)/Device/Util/LineSplitter.cpp \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Device/Util/NMEAReader.cpp \
+	$(SRC)/Units/Descriptor.cpp \
+	$(SRC)/Units/System.cpp \
 	$(SRC)/Device/Driver/FLARM/BinaryProtocol.cpp \
 	$(SRC)/Device/Driver/FLARM/CRC16.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/io/CSVLine.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/DebugPort.cpp \

--- a/src/Formatter/NMEAFormatter.cpp
+++ b/src/Formatter/NMEAFormatter.cpp
@@ -40,6 +40,98 @@ FormatGPRMC(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
 }
 
 void
+FormatGPGGA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
+{
+  const GeoPoint location = info.location;
+  const BrokenDateTime date_time = info.date_time_utc;
+
+  char lat_buffer[20];
+  char long_buffer[20];
+  char time_buffer[20];
+
+  FormatLatitude(lat_buffer, sizeof(lat_buffer), location.latitude);
+  FormatLongitude(long_buffer, sizeof(long_buffer), location.longitude);
+  FormatTime(time_buffer, sizeof(time_buffer), date_time);
+
+  if (info.time_available && info.location_available) {
+    StringFormat(buffer, buffer_size,
+                 "GPGGA,%s,%s,%s,%u,%02u,%.1f,%.3f,M,,,,0000",
+                 time_buffer,
+                 lat_buffer,
+                 long_buffer,
+                 (unsigned)info.gps.fix_quality,
+                 info.gps.satellites_used_available ? info.gps.satellites_used : 0,
+                 info.gps.hdop,
+                 info.gps_altitude);
+  } else {
+    StringFormat(buffer, buffer_size,
+                 "%s",
+                 "GPGGA,,,,,,,,,,M,,,,");
+  }
+}
+
+void
+FormatGPGSA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
+{
+  unsigned gps_status;
+
+  if (!info.location_available)
+    gps_status = 1;
+  else if (!info.gps_altitude_available)
+    gps_status = 2;
+  else
+    gps_status = 3;
+
+  NarrowString<256> sat_ids;
+  sat_ids.clear();
+  for (unsigned i = 0; i < GPSState::MAXSATELLITES; ++i) {
+    if (info.gps.satellite_ids[i] > 0 && info.gps.satellite_ids_available) {
+      sat_ids.AppendFormat("%02u,", info.gps.satellite_ids[i]);
+    } else {
+      sat_ids.append(",");
+    }
+  }
+
+  if (info.gps.satellite_ids_available && info.location_available) {
+    StringFormat(buffer, buffer_size,
+                 "GPGSA,A,%u,%s%.1f,%.1f,%.1f",
+                 gps_status,
+                 sat_ids.c_str(),
+                 info.gps.pdop,
+                 info.gps.hdop,
+                 info.gps.vdop);
+  } else {
+    StringFormat(buffer, buffer_size,
+                 "%s",
+                 "GPGSA,A,1,,,,,,,,,,,,,,,");
+  }
+}
+
+void
+FormatPGRMZ(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
+{
+  unsigned gps_status;
+
+  if (!info.location_available)
+    gps_status = 1;
+  else if (!info.gps_altitude_available)
+    gps_status = 2;
+  else
+    gps_status = 3;
+
+  if (info.baro_altitude_available) {
+    StringFormat(buffer, buffer_size,
+                "PGRMZ,%.0f,m,%u",
+                info.baro_altitude,
+                gps_status);
+  } else {
+    StringFormat(buffer, buffer_size,
+                 "%s",
+                 "PGRMZ,,m,");
+  }
+}
+
+void
 FormatLatitude(char *buffer, size_t buffer_size, Angle latitude) noexcept
 {
   snprintf(buffer, buffer_size,

--- a/src/Formatter/NMEAFormatter.hpp
+++ b/src/Formatter/NMEAFormatter.hpp
@@ -26,6 +26,73 @@
 void
 FormatGPRMC(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
 
+/**
+ * GPGGA,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>
+ * 
+ * <1>  Universal Time Coordinated (UTC), hhmmss.ss
+ * <2>  Latitude,ddmm.mmm format (leading zeros will be transmitted)
+ * <3>  Latitude hemisphere, N or S
+ * <4>  Longitude,dddmm.mmm format (leading zeros will be transmitted)
+ * <5>  Longitude hemisphere, E or W
+ * <6>  GPS Quality Indicator,
+ *      0 - fix not available,
+ *      1 - GPS fix,
+ *      2 - Differential GPS fix
+ *      (values above 2 are 2.3 features)
+ *      3 = PPS fix
+ *      4 = Real Time Kinematic
+ *      5 = Float RTK
+ *      6 = estimated (dead reckoning)
+ *      7 = Manual input mode
+ *      8 = Simulation mode
+ * <7>  Number of satellites in view, 00 - 12
+ * <8>  Horizontal Dilution of precision (meters)
+ * <9>  Antenna Altitude above/below mean-sea-level (geoid) (in meters)
+ * <10> Units of antenna altitude, meters
+ * <11> Geoidal separation, the difference between the WGS-84 earth
+ *      ellipsoid and mean-sea-level (geoid), "-" means mean-sea-level
+ *      below ellipsoid
+ *      (not implemented)
+ * <12> Units of geoidal separation, meters 
+ *      (not implemented)
+ * <13> Age of differential GPS data, time in seconds since last SC104
+ *      type 1 or 9 update, null field when DGPS is not used 
+ *      (not implemented)
+ * <14> Differential reference station ID, 0000-1023
+ */
+void
+FormatGPGGA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
+
+/*
+ * GPGSA,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>,<15>,<16>,<17>
+ * 
+ *  <1> Selection mode
+ *        M=Manual, forced to operate in 2D or 3D
+ *        A=Automatic, 3D/2D
+ *  <2> Mode (1 = no fix, 2 = 2D fix, 3 = 3D fix)
+ *  <3> ID of 1st satellite used for fix
+ *  <4> ID of 2nd satellite used for fix
+ *  ...
+ *  <14> ID of 12th satellite used for fix
+ *  <15> PDOP
+ *  <16> HDOP
+ *  <17> VDOP
+ */
+void
+FormatGPGSA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
+
+/*
+ * PGRMZ,<1>,<2>,<3>
+ *
+ * Garmin proprietary NMEA sentence for altitude information
+ *
+ *  <1> Barometric altitude
+ *  <2> Unit of altitude (f = feet, m = metres)
+ *  <3> Mode (1 = no fix, 2 = 2D fix, 3 = 3D fix)
+ */
+void
+FormatPGRMZ(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
+
 /** Returns latitude, ddmm.mmm format. */
 void
 FormatLatitude(char *buffer, size_t buffer_size, Angle latitude) noexcept;

--- a/src/Formatter/NMEAFormatter.hpp
+++ b/src/Formatter/NMEAFormatter.hpp
@@ -8,11 +8,14 @@
 /**
  * GPRMC,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>
  * 
+ * Recommended Minimum Navigation Information
+ * NMEA 2.00 Standard
+ * 
  * <1>  UTC Time of position fix, hhmmss format
  * <2>  Status, A = Valid position, V = NAV receiver warning
- * <3>  Latitude,ddmm.mmm format (leading zeros will be transmitted)
+ * <3>  Latitude, ddmm.mmm format (leading zeros will be transmitted)
  * <4>  Latitude hemisphere, N or S
- * <5>  Longitude,dddmm.mmm format (leading zeros will be transmitted)
+ * <5>  Longitude, dddmm.mmm format (leading zeros will be transmitted)
  * <6>  Longitude hemisphere, E or W
  * <7>  Speed over ground, 0.0 to 999.9 knots
  * <8>  Course over ground 000.0 to 359.9 degrees, true
@@ -28,6 +31,9 @@ FormatGPRMC(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
 
 /**
  * GPGGA,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>
+ * 
+ * Global Positioning System Fix Data
+ * NMEA 2.00 Standard
  * 
  * <1>  Universal Time Coordinated (UTC), hhmmss.ss
  * <2>  Latitude,ddmm.mmm format (leading zeros will be transmitted)
@@ -65,6 +71,9 @@ FormatGPGGA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
 
 /*
  * GPGSA,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>,<13>,<14>,<15>,<16>,<17>
+ * 
+ * GPS DOP and active satellites
+ * NMEA 2.00 Standard
  * 
  *  <1> Selection mode
  *        M=Manual, forced to operate in 2D or 3D

--- a/test/src/TestNMEAFormatter.cpp
+++ b/test/src/TestNMEAFormatter.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Formatter/NMEAFormatter.hpp"
+#include "util/StringAPI.hxx"
+#include "TestUtil.hpp"
+#include "NMEA/Info.hpp"
+#include "Device/Parser.hpp"
+
+int main()
+{
+  plan_tests(12);
+
+  char buffer[100];
+  NMEAParser parser;
+  NMEAInfo info;
+
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  // test formatter without valid GPS data
+  FormatGPRMC(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer, 
+                    "GPRMC,,V,,,,,,,,,"));
+
+  FormatGPGSA(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer, 
+                    "GPGSA,A,1,,,,,,,,,,,,,,,"));
+
+  FormatGPGGA(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer, 
+                    "GPGGA,,,,,,,,,,M,,,,"));
+
+  FormatPGRMZ(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer,
+                    "PGRMZ,,m,"));
+
+  // parse NMEA sentences to set valid GPS data
+  ok1(parser.ParseLine("$GPRMC,082311,A,5103.5403,N,00741.5742,E,055.3,022.4,230610,000.3,W*6C",
+                       info));
+  ok1(parser.ParseLine("$GPGSA,A,3,01,20,19,13,15,04,,,,,,,40.4,24.4,32.2*0A",
+                       info));
+  ok1(parser.ParseLine("$GPGGA,082311.0,5103.5403,N,00741.5742,E,2,06,24.4,18.893,M,,,,0000*09",
+                       info));
+  ok1(parser.ParseLine("$PGRMZ,2447,F,3*0E",
+                       info));
+
+  FormatGPRMC(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer, 
+                    "GPRMC,082311.00,A,5103.540,N,00741.574,E,055.3,022.4,230610,000.3,W"));
+
+  FormatGPGSA(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer, 
+                    "GPGSA,A,3,01,20,19,13,15,04,,,,,,,40.4,24.4,32.2"));
+
+  FormatGPGGA(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer,
+                    "GPGGA,082311.00,5103.540,N,00741.574,E,2,06,24.4,18.893,M,,,,0000"));
+
+  FormatPGRMZ(buffer, sizeof(buffer), info);
+  ok1(StringIsEqual(buffer,
+                    "PGRMZ,746,m,3"));
+
+  return exit_status();
+}


### PR DESCRIPTION
Brief summary of the changes
----------------------------

~~- added a short format for the DDMM.MMM location format~~
- added NMEAFormatter to format standard NMEA sentences
- updated the AirControlDisplay driver to forward GPS data via NMEA sentences to the device
- updated the CAILNAV driver to also use the new NMEAFormatter

Related issues and discussions
------------------------------

#170 (previous attempt)
#1112 (recent request)
