### PR TITLE
ActionInterface: only exchange frequencies when both are defined

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -13,6 +13,7 @@ Version 7.29 - not yet released
   - Fix OTG mode for newer models
 * Polars
   - Add LS-5 polar
+* fix exchange frequencies crash when no frequency was set
 
 Version 7.28 - 2022/10/29
 * data files

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -380,9 +380,12 @@ ActionInterface::ExchangeRadioFrequencies(bool to_devices) noexcept
 {
   const auto radio_settings = SetComputerSettings().radio;
 
-  const auto old_active_freq = radio_settings.active_frequency;
-  const auto old_active_freq_name = radio_settings.active_name;
+  if(radio_settings.active_frequency.IsDefined() &&
+     radio_settings.standby_frequency.IsDefined()) {
+    const auto old_active_freq = radio_settings.active_frequency;
+    const auto old_active_freq_name = radio_settings.active_name;
 
-  ActionInterface::SetActiveFrequency(radio_settings.standby_frequency, radio_settings.standby_name, to_devices);
-  ActionInterface::SetStandbyFrequency(old_active_freq, old_active_freq_name, to_devices);
+    ActionInterface::SetActiveFrequency(radio_settings.standby_frequency, radio_settings.standby_name, to_devices);
+    ActionInterface::SetStandbyFrequency(old_active_freq, old_active_freq_name, to_devices);
+  }
 }


### PR DESCRIPTION
Previously XCSoar would crash if a frequency swap was attempted without either of the frequencies being set.