### PR TITLE
Fix backlight and add colour temperature to certain Kobo models

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,8 @@ Version 7.29 - not yet released
   - Reboot without -f (force)
   - Fix OTG mode for newer models
   - Add an E-ink friendly trail type
+  - Add Brightness control to Clara HD
+  - Support Brightness and Colour for ComfortLight PRO models
 * Polars
   - Add LS-5 polar
   - Add Silene E78 polar

--- a/src/Kobo/System.hpp
+++ b/src/Kobo/System.hpp
@@ -71,3 +71,15 @@ KoboGetBacklightBrightness();
 
 void
 KoboSetBacklightBrightness(int percent);
+
+const char *
+KoboGetBacklightColourFile() noexcept;
+
+bool
+KoboCanChangeBacklightColour() noexcept;
+
+bool
+KoboGetBacklightColour(unsigned int &colour) noexcept;
+
+void
+KoboSetBacklightColour(int colour) noexcept;


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->
Added CLARA HD backlight, CLARAs HD and 2E and LIBRA 2 colour temp

Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
