### PR TITLE
bugfixes clang build

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -60,7 +60,7 @@ apt-get install ${APTOPTS[*]} dpkg-dev \
 echo
 
 echo Installing dependencies for compiling with LLVM / Clang...
-apt-get install ${APTOPTS[*]} llvm clang libc++-dev
+apt-get install ${APTOPTS[*]} llvm clang libc++-dev libc++abi-dev
 echo
 
 echo Installing dependencies for compiling targets which need libinput or GBM...

--- a/src/util/Concepts.hxx
+++ b/src/util/Concepts.hxx
@@ -30,13 +30,12 @@
 #pragma once
 
 #include <concepts>
-#include <util/Compiler.h>
 
 /**
  * Compatibility wrapper for std::invocable which is unavailable in
  * the Android NDK r25b and Apple Xcode.
  */
-#if !defined(ANDROID) && !defined(__APPLE__) && (CLANG_VERSION >= GCC_MAKE_VERSION(14,0,0))
+#if !defined(ANDROID) && !defined(__APPLE__) && (!defined __clang__ || __clang_major__ >=14)
 template<typename F, typename... Args>
 concept Invocable = std::invocable<F, Args...>;
 #else
@@ -50,7 +49,7 @@ concept Invocable = requires(F f, Args... args) {
  * Compatibility wrapper for std::predicate which is unavailable in
  * the Android NDK r25b and Apple Xcode.
  */
-#if !defined(ANDROID) && !defined(__APPLE__) && (CLANG_VERSION >= GCC_MAKE_VERSION(14,0,0))
+#if !defined(ANDROID) && !defined(__APPLE__) && (!defined __clang__ || __clang_major__ >=14)
 template<typename F, typename... Args>
 concept Predicate = std::predicate<F, Args...>;
 #else


### PR DESCRIPTION
this is related to #1133, but also adresses some issues when building on debian with older clang version (11)

- Driver KRT2: fix "error: case value not in enumerated type 'std::byte'" when building with clang on debian
- Concepts.hxx: check clang version before using std::invocable and std::predicate (because of build failure on debian with clang11)
- install-debian-packages: add libc++abi-dev, because of linker failure
- flags.mk: disable -Wno-deprecated-experimental-coroutine, we can't use this option if the minimum clang version required is 10 (according to developer manual).