### PR TITLE
Add onFlarmTraffic for Android BLE application

### DIFF
--- a/android/src/NativeSensorListener.java
+++ b/android/src/NativeSensorListener.java
@@ -95,6 +95,11 @@ final class NativeSensorListener implements SensorListener {
                                          double bearing);
 
   @Override
+  public native void onFlarmTraffic(int AlarmLevel,int RelativeNorth,int RelativeEast,int RelativeVertical,
+                                    String ID,int Track,double TurnRate,int GroundSpeed,double ClimbRate,
+                                    int AcftType,boolean Stealth);
+
+  @Override
   public native void onTemperature(double temperature_kelvin);
 
   @Override

--- a/android/src/SensorListener.java
+++ b/android/src/SensorListener.java
@@ -61,6 +61,9 @@ public interface SensorListener {
                            double gspeed, double vspeed,
                            double bearing);
 
+  void onFlarmTraffic(int AlarmLevel,int RelativeNorth,int RelativeEast,int RelativeVertical,
+                      String ID,int Track,double TurnRate,int GroundSpeed,double ClimbRate,
+                      int AcftType,boolean Stealth);
   void onTemperature(double temperature_kelvin);
 
   void onBatteryPercent(double battery_percent);

--- a/src/Android/NativeSensorListener.cpp
+++ b/src/Android/NativeSensorListener.cpp
@@ -285,6 +285,30 @@ Java_org_xcsoar_NativeSensorListener_setGliderLinkInfo(JNIEnv *env,
 
 gcc_visibility_default
 JNIEXPORT void JNICALL
+Java_org_xcsoar_NativeSensorListener_onFlarmTraffic(JNIEnv *env,
+                                                    jobject obj,
+                                                    jint AlarmLevel,
+                                                    jint RelativeNorth,
+                                                    jint RelativeEast,
+                                                    jint RelativeVertical,
+                                                    jstring ID,
+                                                    jint Track,
+                                                    jdouble TurnRate,
+                                                    jint GroundSpeed,
+                                                    jdouble ClimbRate,
+                                                    jint AcftType,
+                                                    jboolean Stealth)
+{
+  jlong ptr = env->GetLongField(obj, NativeSensorListener::ptr_field);
+  if (ptr == 0)
+    return;
+
+  auto &listener = *(SensorListener *)ptr;
+  listener.OnFlarmTraffic(AlarmLevel,RelativeNorth,RelativeEast,RelativeVertical,Java::String::GetUTFChars(env, ID).c_str(),Track,TurnRate,GroundSpeed,ClimbRate,AcftType,Stealth);
+}
+
+gcc_visibility_default
+JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeSensorListener_onTemperature(JNIEnv *env,
                                                    jobject obj,
                                                    jdouble temperature_kelvin)

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -647,6 +647,9 @@ private:
                            GeoPoint location, double altitude,
                            double gspeed, double vspeed,
                            unsigned bearing) noexcept override;
+  void OnFlarmTraffic(int AlarmLevel,int RelativeNorth,int RelativeEast,int RelativeVertical,
+                      const char *ID,int Track,double TurnRate,int GroundSpeed,double ClimbRate,
+                      int AcftType,bool Stealth) noexcept override;
   void OnTemperature(Temperature temperature) noexcept override;
   void OnBatteryPercent(double battery_percent) noexcept override;
   void OnSensorStateChanged() noexcept override;

--- a/src/Device/SensorListener.hpp
+++ b/src/Device/SensorListener.hpp
@@ -77,6 +77,10 @@ public:
                                    double gspeed, double vspeed,
                                    unsigned bearing) noexcept = 0;
 
+  virtual void OnFlarmTraffic(int AlarmLevel,int RelativeNorth,int RelativeEast,int RelativeVertical,
+                              const char *ID,int Track,double TurnRate,int GroundSpeed,double ClimbRate,
+                              int AcftType,bool Stealth) noexcept = 0;
+
   virtual void OnTemperature(Temperature temperature) noexcept = 0;
 
   virtual void OnBatteryPercent(double battery_percent) noexcept = 0;


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Additional function used by NMEA parser and transferring the information over Bluetooth Low Energy(BLE).
Devices which are able to parse the PFLAA message from Flarm devices can use this function to show the aircraft on the map. The function consistently keeps the structure defined by Flarm. The variable types are selected in accordance to Flarm serial data protocoll: flarm.com/wp-content/uploads/man/FTD-012-Data-Port-Interface-Control-Document-ICD.pdf 
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
