### PR TITLE
Bug fix and extension of Windows serial ports

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -33,6 +33,10 @@ Version 7.29 - not yet released
   - extend QuickMenu to maximum of 64 entries
   - add PEV,FlarmTraffic,FileManager to joystick QuickMenu
   - add transponder code infobox
+* Serial ports on Windows
+  - bug fix in port search to find all installed ports
+  - allow connection to COM port COM10 to COM255 (f.e. for BlueTooth
+    and VSPE user)
 
 Version 7.28 - 2022/10/29
 * data files

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -78,8 +78,16 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
   case DeviceConfig::PortType::SERIAL:
     if (config.path.empty())
       throw std::runtime_error("No port path configured");
-
+#ifdef _WIN32 
+    {
+      // the usual windows style of device names:
+      auto *endp = CopyString(buffer, MAX_PATH, _T("\\\\.\\"));
+      CopyString(endp, MAX_PATH - (endp-buffer), config.path.c_str());
+      path = buffer;  // set path to the begin of the buffer
+    }
+#else
     path = config.path.c_str();
+#endif
     break;
 
   case DeviceConfig::PortType::BLE_HM10:

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -115,10 +115,8 @@ FillDefaultSerialPorts(DataFieldEnum &df) noexcept
   for (unsigned i = 1; i <= 10; ++i) {
     TCHAR buffer[64];
     _stprintf(buffer, _T("COM%u"), i);
-    if (DosDeviceExists(buffer)) {
-      _tcscat(buffer, _T(":"));  // add the colon to the path string
+    if (DosDeviceExists(buffer))
       AddPort(df, DeviceConfig::PortType::SERIAL, buffer);
-    }
   }
 }
 

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -114,9 +114,11 @@ FillDefaultSerialPorts(DataFieldEnum &df) noexcept
 {
   for (unsigned i = 1; i <= 10; ++i) {
     TCHAR buffer[64];
-    _stprintf(buffer, _T("COM%u:"), i);
-    if (DosDeviceExists(buffer))
-       AddPort(df, DeviceConfig::PortType::SERIAL, buffer);
+    _stprintf(buffer, _T("COM%u"), i);
+    if (DosDeviceExists(buffer)) {
+      _tcscat(buffer, _T(":"));  // add the colon to the path string
+      AddPort(df, DeviceConfig::PortType::SERIAL, buffer);
+    }
   }
 }
 

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -112,7 +112,7 @@ DosDeviceExists(const TCHAR *path) noexcept
 static void
 FillDefaultSerialPorts(DataFieldEnum &df) noexcept
 {
-  for (unsigned i = 1; i <= 10; ++i) {
+  for (unsigned i = 1; i <= 255; ++i) {
     TCHAR buffer[64];
     _stprintf(buffer, _T("COM%u"), i);
     if (DosDeviceExists(buffer))

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -80,7 +80,16 @@ LoadPath(const ProfileMap &map, DeviceConfig &config, unsigned n)
 {
   char buffer[64];
   MakeDeviceSettingName(buffer, "Port", n, "Path");
-  return map.Get(buffer, config.path);
+  bool retvalue = map.Get(buffer, config.path);
+#ifdef _WIN32
+  // the usual windows port names have no colon at the end
+  if (retvalue && (config.path.back() == TCHAR(':')) &&
+      config.path.StartsWith(_T("COM"))) {
+    // replace colon with '\0', so the path name has the correct length
+    config.path[config.path.length() - 1] = TCHAR('\0');
+  }
+#endif
+  return retvalue;
 }
 
 static bool

--- a/src/SystemSettings.cpp
+++ b/src/SystemSettings.cpp
@@ -15,7 +15,7 @@ SystemSettings::SetDefaults()
   } else {
     devices[0].port_type = DeviceConfig::PortType::SERIAL;
 #ifdef _WIN32
-    devices[0].path = _T("COM1:");
+    devices[0].path = _T("\\\\.\\COM1");
 #else
     devices[0].path = _T("/dev/tty0");
 #endif

--- a/src/util/StaticString.hxx
+++ b/src/util/StaticString.hxx
@@ -15,7 +15,7 @@
 #include <string_view>
 
 #ifdef _UNICODE
-#include <wchar.h>
+#include "util/WStringCompare.hxx"
 #endif
 
 bool


### PR DESCRIPTION
Brief summary of the changes
----------------------------

* Fix bug:  remove unnecessary trailing colon in the search for the active serial ports of Windows.
* Allow connection to COM port 10 to 255 (f.e. for BlueTooth or VSPE user)

Related issues and discussions
------------------------------

* Repetition or revision of PR #934 - all requirements of Max's code review incorporated.
