### PR TITLE
Adding Logbook and the system info script to the new x-menu for OpenVario

### DIFF
--- a/src/OV/OpenVarioMenu.cpp
+++ b/src/OV/OpenVarioMenu.cpp
@@ -245,15 +245,23 @@ SystemMenuWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   });
 
   AddButton("System Settings", [this](){
-    const UI::ScopeDropMaster drop_master{display};
-    const UI::ScopeSuspendEventQueue suspend_event_queue{event_queue};
-    Run("/usr/lib/openvario/libexec/system_settings.sh");
-  });
+      
+    TWidgetDialog<SystemSettingsWidget>
+      sub_dialog(WidgetDialog::Full{}, dialog.GetMainWindow(),
+                 GetLook(), "OpenVario System Settings");
+    sub_dialog.SetWidget(display, event_queue, sub_dialog); 
+    sub_dialog.AddButton(_("Close"), mrOK);
+    return sub_dialog.ShowModal();
+  });   
 
-  AddButton("System Info", [this](){
-    const UI::ScopeDropMaster drop_master{display};
-    const UI::ScopeSuspendEventQueue suspend_event_queue{event_queue};
-    Run("/usr/lib/openvario/libexec/system_info.sh");
+  AddButton("System Info", [](){
+    static constexpr const char *argv[] = {
+      "/usr/bin/system-info.sh", nullptr
+    };
+
+    RunProcessDialog(UIGlobals::GetMainWindow(),
+                     UIGlobals::GetDialogLook(),
+                     "System Info", argv);
   });
 }
 

--- a/src/OV/OpenVarioMenu.cpp
+++ b/src/OV/OpenVarioMenu.cpp
@@ -262,6 +262,7 @@ class MainMenuWidget final
 {
   enum Controls {
     XCSOAR,
+    LOGBOOK,
     FILE,
     SYSTEM,
     SHELL,
@@ -346,6 +347,17 @@ MainMenuWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddButton("Start XCSoar", [this](){
     CancelTimer();
     StartXCSoar();
+  });
+
+  AddButton("Logbook", [this](){
+    CancelTimer();
+    static constexpr const char *argv[] = {
+      "/usr/bin/logbook.sh", nullptr
+    };
+
+    RunProcessDialog(UIGlobals::GetMainWindow(),
+                     UIGlobals::GetDialogLook(),
+                     "Logbook", argv);
   });
 
   AddButton("File", [this](){


### PR DESCRIPTION
This PR is adding the menu button "Logbook" to the new x-menu for OpenVario to use the logbook script and it includes the new system info script.
It also prepares the menu button "System Settings" for the new settings option at the menu. 

