### PR TITLE
Waypoint, Settings: Store home waypoint name instead id in profile.

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -19,6 +19,8 @@ Version 7.29 - not yet released
   - Add Silene E78 polar
   - updated handicap factors for 2023
 * fix exchange frequencies crash when no frequency was set
+* configuration
+  - Fixes changing number of markers changes home field (#1122)
 
 Version 7.28 - 2022/10/29
 * data files

--- a/src/Computer/Settings.cpp
+++ b/src/Computer/Settings.cpp
@@ -38,14 +38,14 @@ PolarSettings::SetDefaults()
 void
 PlacesOfInterestSettings::ClearHome()
 {
-  home_waypoint = -1;
+  home_waypoint_name.clear();
   home_location_available = false;
 }
 
 void
 PlacesOfInterestSettings::SetHome(const Waypoint &wp)
 {
-  home_waypoint = wp.id;
+  home_waypoint_name = wp.name;
   home_location = wp.location;
   home_location_available = true;
 }

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -101,8 +101,8 @@ struct PolarSettings {
  * Options for tracking places of interest as alternates
  */
 struct PlacesOfInterestSettings {
-  /** Array index of the home waypoint */
-  int home_waypoint;
+  /** Name of the home waypoint */
+  StaticString<32> home_waypoint_name;
 
   bool home_location_available;
 

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -111,7 +111,7 @@ Profile::Load(const ProfileMap &map, TeamCodeSettings &settings)
 void
 Profile::Load(const ProfileMap &map, PlacesOfInterestSettings &settings)
 {
-  map.Get(ProfileKeys::HomeWaypoint, settings.home_waypoint);
+  map.Get(ProfileKeys::HomeWaypoint, settings.home_waypoint_name);
   settings.home_location_available =
     map.GetGeoPoint(ProfileKeys::HomeLocation, settings.home_location);
 }


### PR DESCRIPTION
Fixes changing number of markers changes home field #1122.


Brief summary of the changes
----------------------------
This PR resolves the issue where changing the number of markers caused the home field to change.


Related issues and discussions
------------------------------

Closes #1122