### PR TITLE
Look/InfoBoxLook: Calc AutoFont to realistic no. Chars

### DIFF
--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -62,13 +62,8 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
 void
 InfoBoxLook::ReinitialiseLayout(unsigned width)
 {
-  const unsigned max_font_height = Layout::FontScale(12);
-
   FontDescription title_font_d(8);
-  AutoSizeFont(title_font_d, width, _T("0123456789"));
-  if (title_font_d.GetHeight() > max_font_height)
-    title_font_d.SetHeight(max_font_height);
-
+  AutoSizeFont(title_font_d, width, _T("0123456789ABCD"));
   title_font.Load(title_font_d);
 
   FontDescription value_font_d(10, true);
@@ -76,7 +71,7 @@ InfoBoxLook::ReinitialiseLayout(unsigned width)
   value_font.Load(value_font_d);
 
   FontDescription small_value_font_d(10);
-  AutoSizeFont(small_value_font_d, width, _T("12345m"));
+  AutoSizeFont(small_value_font_d, width, _T("0123456789ABCDEFG"));
   small_value_font.Load(small_value_font_d);
 
   unsigned unit_font_height = std::max(value_font_d.GetHeight() * 2u / 5u, 7u);


### PR DESCRIPTION
Autofont was only using 4 chars to calculate the font size. This gave a bad look on small and large displays.

Removing also the upper Limit with the fontscale introduced in 663c7825aeb as this breaks the autoscaling when resizing a window.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
