### PR TITLE
Dialogs/Plane/PolarShapeEditWidget: increase precision

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -26,6 +26,7 @@ Version 7.29 - not yet released
   - redesigned waypoint type icons
   - fix font resizing in Infobx titles and small values
   - align labels in forms on the left side
+  - increased precision in polar edit dialogue
 
 Version 7.28 - 2022/10/29
 * data files

--- a/src/Dialogs/Plane/PolarShapeEditWidget.cpp
+++ b/src/Dialogs/Plane/PolarShapeEditWidget.cpp
@@ -148,15 +148,15 @@ PolarShapeEditWidget::Prepare(ContainerWindow &parent,
   rc.right = rc.left + edit_width;
   rc.bottom = height;
 
-  double step = 0.05, min = -10;
+  double step = 0.01, min = -10;
   switch (Units::current.vertical_speed_unit) {
   case Unit::FEET_PER_MINUTE:
-    step = 10;
+    step = 2;
     min = -2000;
     break;
 
   case Unit::KNOTS:
-    step = 0.1;
+    step = 0.02;
     min = -20;
     break;
 


### PR DESCRIPTION
The current precision is not sufficient to fine-tune a polar. Step values have been divided by 5 to be able to use a precision common for defining polars.