### PR TITLE
Replace old RASP data file after download

### DIFF
--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -14,6 +14,8 @@
 #include "UIState.hpp"
 #include "ActionInterface.hpp"
 #include "Language/Language.hpp"
+#include "system/FileUtil.hpp"
+#include "LocalPath.hpp"
 
 #include <stdio.h>
 
@@ -115,11 +117,16 @@ RASPSettingsPanel::OnTimeModified(const DataFieldEnum &df) noexcept
 void
 RASPSettingsPanel::Download() noexcept
 {
-  auto path = DownloadFilePicker(FileType::RASP);
-  if (path == nullptr)
+  auto downloaded_file_path = DownloadFilePicker(FileType::RASP);
+  if (downloaded_file_path == nullptr)
     return;
+  
+  auto rasp_file_path = LocalPath(_T(RASP_FILENAME));
+  
+  // Update RASP data file
+  File::Replace(downloaded_file_path, rasp_file_path);
 
-  rasp = std::make_shared<RaspStore>(std::move(path));
+  rasp = std::make_shared<RaspStore>(std::move(rasp_file_path));
   rasp->ScanAll();
 
   DataGlobals::SetRasp(std::shared_ptr<RaspStore>(rasp));


### PR DESCRIPTION
Replaces the previously downloaded RASP data file with the just downloaded file. Fixes https://github.com/XCSoar/XCSoar/issues/1051

I am not quite sure if this is an accepted way to solve this issue but it works for me and I wanted to share it.
This solution of course also has the drawback of users no longer being able to download multiple RASP .dat files for different regions.