### PR TITLE
Dialogs/Weather/RASP: Fix now time selection

### DIFF
--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -107,7 +107,7 @@ inline void
 RASPSettingsPanel::OnTimeModified(const DataFieldEnum &df) noexcept
 {
   const int value = df.GetValue();
-  time = value >= 0
+  time = value > 0
     ? BrokenTime::FromMinuteOfDay(value)
     : BrokenTime::Invalid();
 }


### PR DESCRIPTION
Selecting "Now" in the RASP weather dialog should result in an invalid BrokenTime object being generated. However, this is only the case right after startup.

This bug is noticeable when selecting a specific time for the RASP data and then switching to "now". The BrokenTime in this case contains a valid 0:0 time but should be invalid.