### PR TITLE
sync ACD with an other device that could send an external QNH to XCSoar

### DIFF
--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -43,7 +43,7 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
 
     if (line.ReadChecked(value)) {
       auto qnh = AtmosphericPressure::Pascal(value);
-      info.settings.ProvideQNH(qnh,info.clock);
+      info.settings.ProvideQNH(qnh, info.clock);
     }
   } else if (type == "COM"sv) {
     /*
@@ -208,7 +208,7 @@ ACDDevice::OnCalculatedUpdate(const MoreData &basic,[[maybe_unused]] const Deriv
    NullOperationEnvironment env;
 
    if (basic.settings.qnh_available.IsValid()){
-	 char buffer[100];
+     char buffer[100];
      unsigned qnh = basic.settings.qnh.GetPascal();
      sprintf(buffer,"PAAVC,S,ALT,QNH,%u",qnh);
      PortWriteNMEA(port, buffer, env);


### PR DESCRIPTION
if, in addition to the ACD, other devices are connected to XCSoar that can send a QNH to XCSoar, then the ACD synchronizes with this device using OnCalculatedUpdate. This ensures that the ACD does not use a different value for the QNH.