### PR TITLE
Add engine sensor box

### DIFF
--- a/src/NMEA/EngineState.hpp
+++ b/src/NMEA/EngineState.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Validity.hpp"
+#include "time/Stamp.hpp"
+#include "Atmosphere/Temperature.hpp"
+
+/** Information about engine sensors.
+*/
+struct EngineState
+{
+  /* The engine box measured revolutions per second on the camshaft. */
+  Validity revs_per_sec_available;
+  uint16_t revs_per_sec;
+
+  /* The engine Cylinder Head Temperature (CHT) */
+  Validity cht_temperature_available;
+  Temperature cht_temperature;
+
+  /* The engine Exhaust Gas Temperature (EGT) */
+  Validity egt_temperature_available;
+  Temperature egt_temperature;
+
+  void Clear() noexcept{
+    revs_per_sec_available.Clear();
+    cht_temperature_available.Clear();
+    egt_temperature_available.Clear();
+  }
+
+  void Reset() noexcept{
+    Clear();
+  }
+
+  void Expire(TimeStamp clock) noexcept {
+    revs_per_sec_available.Expire(clock, std::chrono::seconds(3));
+    cht_temperature_available.Expire(clock, std::chrono::seconds(3));
+    egt_temperature_available.Expire(clock, std::chrono::seconds(3));
+  }
+
+  void Complement(const EngineState &add) noexcept {
+    if (revs_per_sec_available.Complement(add.revs_per_sec_available)){
+      revs_per_sec = add.revs_per_sec;
+    }
+    if (cht_temperature_available.Complement(add.cht_temperature_available)){
+      cht_temperature = add.cht_temperature;
+    }
+    if (egt_temperature_available.Complement(add.egt_temperature_available)){
+      egt_temperature = add.egt_temperature;
+    }
+  }
+
+};

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -155,6 +155,7 @@ NMEAInfo::Reset()
   flarm.Clear();
 
 #ifdef ANDROID
+  engine_state.Reset();
   glink_data.Clear();
 #endif
 }
@@ -222,6 +223,7 @@ NMEAInfo::Expire()
   battery_level_available.Expire(clock, std::chrono::minutes(5));
   flarm.Expire(clock);
 #ifdef ANDROID
+  engine_state.Expire(clock);
   glink_data.Expire(clock);
 #endif
   attitude.Expire(clock);
@@ -341,6 +343,7 @@ NMEAInfo::Complement(const NMEAInfo &add)
   flarm.Complement(add.flarm);
 
 #ifdef ANDROID
+  engine_state.Complement(add.engine_state);
   glink_data.Complement(add.glink_data);
 #endif
 }

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -15,6 +15,7 @@
 #include "Atmosphere/Pressure.hpp"
 #include "Atmosphere/Temperature.hpp"
 #include "DeviceInfo.hpp"
+#include "EngineState.hpp"
 #include "FLARM/Data.hpp"
 #include "Geo/SpeedVector.hpp"
 
@@ -300,6 +301,8 @@ struct NMEAInfo {
    * @see HumidityAvailable
    */
   double humidity;
+
+  EngineState engine_state;
 
   //###########
   //   Other


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

Add support for a Bluetooth LE engine sensor box. 

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

https://github.com/XCSoar/XCSoar/issues/1178

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
