### PR TITLE
Change display of RPM in InfoBox

### DIFF
--- a/src/InfoBoxes/Content/Engine.cpp
+++ b/src/InfoBoxes/Content/Engine.cpp
@@ -45,6 +45,6 @@ UpdateInfoBoxContentRPM(InfoBoxData &data) noexcept
     data.SetInvalid();
     return;
   }  
-  data.SetValue(_T("%d"), basic.engine_state.revs_per_sec * 60);
+  data.SetValue(_T("%.0f"), basic.engine_state.revs_per_sec * 60);
   data.SetComment(_("rpm"));
 }


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Change the representation of the EngineState value RPM in it's InfoBox
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/1178
https://github.com/XCSoar/XCSoar/issues/1193
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
