### PR TITLE
Add BLE driver for EngineState

### DIFF
--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -117,6 +117,36 @@ public final class BluetoothSensor
     }
   }
 
+  /**
+   * Data in the characteristic has little endian byteorder.
+   * Lowest bit of flags indicates valid revs_per_sec reading.
+   * 0 Kelvin indicates invalid temperatures e.g 
+   * no temperature sensor present.
+  */
+  private void engineSensorDataToListeners(BluetoothGattCharacteristic c) {
+    final int flags = c.getIntValue(c.FORMAT_UINT8, 0);
+    final int cht_temp = c.getIntValue(c.FORMAT_UINT16, 1);
+    final int egt_temp = c.getIntValue(c.FORMAT_UINT16, 3);
+    final int outside_air_temperature = c.getIntValue(c.FORMAT_UINT16, 5);
+
+    if(outside_air_temperature != 0)
+      listener.onTemperature(outside_air_temperature);
+
+    final int pressure = c.getIntValue(c.FORMAT_UINT32, 7);
+
+    // Just guessing the sensor_noise_variance.
+    if(pressure != 0)
+      listener.onBarometricPressureSensor(c.getIntValue(c.FORMAT_UINT32, 7), 0.01f);
+
+    final int revs_per_sec = c.getIntValue(c.FORMAT_UINT16, 11);
+    listener.onEngineSensors(cht_temp != 0 ? true : false,
+                             cht_temp,
+                             egt_temp != 0 ? true : false,
+                             egt_temp,
+                             (flags&0x01) == 0x01 ? true : false,
+                             revs_per_sec);
+  }
+
   private void readHeartRateMeasurement(BluetoothGattCharacteristic c) {
     int offset = 0;
     final int flags = c.getIntValue(c.FORMAT_UINT8, offset);
@@ -154,6 +184,11 @@ public final class BluetoothSensor
         if (BluetoothUuids.HEART_RATE_MEASUREMENT_CHARACTERISTIC.equals(c.getUuid())) {
           readHeartRateMeasurement(c);
         }
+      }
+
+      if (BluetoothUuids.ENGINE_SENSORS_SERVICE.equals(c.getService().getUuid()) &&
+          BluetoothUuids.ENGINE_SENSORS_CHARACTERISTIC.equals(c.getUuid())) {
+        engineSensorDataToListeners(c);
       }
 
       if (BluetoothUuids.FLYTEC_SENSBOX_SERVICE.equals(c.getService().getUuid())) {
@@ -239,6 +274,17 @@ public final class BluetoothSensor
     if (service != null) {
       BluetoothGattCharacteristic c =
         service.getCharacteristic(BluetoothUuids.HEART_RATE_MEASUREMENT_CHARACTERISTIC);
+      if (c != null) {
+        setStateSafe(STATE_READY);
+        enableNotification(c);
+      }
+    }
+
+    /* enable notifications for DR Solutions engine sensor box */
+    service = gatt.getService(BluetoothUuids.ENGINE_SENSORS_SERVICE);
+    if (service != null) {
+      BluetoothGattCharacteristic c =
+        service.getCharacteristic(BluetoothUuids.ENGINE_SENSORS_CHARACTERISTIC);
       if (c != null) {
         setStateSafe(STATE_READY);
         enableNotification(c);

--- a/android/src/BluetoothUuids.java
+++ b/android/src/BluetoothUuids.java
@@ -24,6 +24,15 @@ public interface BluetoothUuids {
   UUID HEART_RATE_MEASUREMENT_CHARACTERISTIC =
     UUID.fromString("00002A37-0000-1000-8000-00805F9B34FB");
 
+  /**
+   * @see https://sites.google.com/view/ppgmeter/startpage
+   * Engine sensors service and characteristic
+   */
+  UUID ENGINE_SENSORS_SERVICE =
+    UUID.fromString("D2865ECA-2C07-4610-BF03-8AEEBEF047FB");
+  UUID ENGINE_SENSORS_CHARACTERISTIC =
+    UUID.fromString("D2865ECB-2C07-4610-BF03-8AEEBEF047FB");
+
   UUID HM10_SERVICE =
     UUID.fromString("0000FFE0-0000-1000-8000-00805F9B34FB");
 


### PR DESCRIPTION
The sensor board has additional sensors for atmospheric pressure and outside air temperature. These values are passed to already implemented specific listeners.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Add BLE "driver" for EngineState values with additional atmospheric pressure and outside air temperature.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/1178

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
