### PR TITLE
Change BLE java driver for EngineState

### DIFF
--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -136,7 +136,7 @@ public final class BluetoothSensor
 
     // Just guessing the sensor_noise_variance.
     if(pressure != 0)
-      listener.onBarometricPressureSensor(c.getIntValue(c.FORMAT_UINT32, 7), 0.01f);
+      listener.onBarometricPressureSensor(pressure / 100.0f, 0.01f);
 
     final int revs_per_sec = c.getIntValue(c.FORMAT_UINT16, 11);
     listener.onEngineSensors(cht_temp != 0 ? true : false,

--- a/android/src/SensorListener.java
+++ b/android/src/SensorListener.java
@@ -25,12 +25,16 @@ public interface SensorListener {
   void onAccelerationSensor(float ddx, float ddy, float ddz);
   void onRotationSensor(float dtheta_x, float dtheta_y, float dtheta_z);
   void onMagneticFieldSensor(float h_x, float h_y, float h_z);
+  /**
+   * @param[in] pressure Atmospheric static pressure in Hecto Pascal.
+   * @param[in] sensor_noise_variance Sensor noise variance for Kalman filtering of pressure.
+   */
   void onBarometricPressureSensor(float pressure, float sensor_noise_variance);
   void onPressureAltitudeSensor(float altitude);
   void onI2CbaroSensor(int index, int sensorType, int pressure);
   void onVarioSensor(float vario);
   void onHeartRateSensor(int bpm);
-    /**
+  /**
    * @param[in] has_cht_temp Is the Engine Cylinder Head Temperature sensor present?
    * @param[in] cht_temp Engine Cylinder Head Temperature.
    * @param[in] has_egt_temp Is the Engine Exhaust Gas Temperature sensor present?


### PR DESCRIPTION
Change parameter to onBarometricPressureSensor from Pascal to Hecto Pascal. Add comment for onBarometricPressureSensor


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Wrong scaled value to `onBarometricPressureSensor`. Needs to be Hecto Pascal, passed Pascal.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/1178

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
