### PR TITLE
Add RPM scaling for different types of engine

### DIFF
--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -119,7 +119,7 @@ public final class BluetoothSensor
 
   /**
    * Data in the characteristic has little endian byteorder.
-   * Lowest bit of flags indicates valid revs_per_sec reading.
+   * Lowest bit of flags indicates valid ignitions_per_sec reading.
    * 0 Kelvin indicates invalid temperatures e.g 
    * no temperature sensor present.
   */
@@ -138,13 +138,13 @@ public final class BluetoothSensor
     if(pressure != 0)
       listener.onBarometricPressureSensor(pressure / 100.0f, 0.01f);
 
-    final int revs_per_sec = c.getIntValue(c.FORMAT_UINT16, 11);
+    final int ignitions_per_second = c.getIntValue(c.FORMAT_UINT16, 11);
     listener.onEngineSensors(cht_temp != 0 ? true : false,
                              cht_temp,
                              egt_temp != 0 ? true : false,
                              egt_temp,
                              (flags&0x01) == 0x01 ? true : false,
-                             revs_per_sec);
+                             ignitions_per_second);
   }
 
   private void readHeartRateMeasurement(BluetoothGattCharacteristic c) {

--- a/android/src/NativeSensorListener.java
+++ b/android/src/NativeSensorListener.java
@@ -38,8 +38,8 @@ final class NativeSensorListener implements SensorListener {
                                      int cht_temp,
                                      boolean has_egt_temp,
                                      int egt_temp,
-                                     boolean has_revs_per_sec,
-                                     float revs_per_sec);
+                                     boolean has_ignitions_per_second,
+                                     float ignitions_per_second);
 
   @Override
   public native void onAccelerationSensor(float ddx, float ddy, float ddz);

--- a/android/src/SensorListener.java
+++ b/android/src/SensorListener.java
@@ -39,15 +39,15 @@ public interface SensorListener {
    * @param[in] cht_temp Engine Cylinder Head Temperature.
    * @param[in] has_egt_temp Is the Engine Exhaust Gas Temperature sensor present?
    * @param[in] egt_temp Engine Exhaust Gas Temperature.
-   * @param[in] has_revs_per_sec Is the Engine Revolutions Per Second sensor present?
-   * @param[in] revs_per_sec Engine Revolutions Per Second, rotations per seconds of the camshaft.
+   * @param[in] has_ignitions_per_second Is the Engine Ignitions Per Second sensor present?
+   * @param[in] ignitions_per_second Engine Ignitions Per Second, firing of the spark plug per second.
    */
   void onEngineSensors(boolean has_cht_temp,
                        int cht_temp,
                        boolean has_egt_temp,
                        int egt_temp,
-                       boolean has_revs_per_sec,
-                       float revs_per_sec);
+                       boolean has_ignitions_per_second,
+                       float ignitions_per_second);
 
   void onVoltageValues(int temp_adc, int voltage_index, int volt_adc);
 

--- a/src/Android/NativeSensorListener.cpp
+++ b/src/Android/NativeSensorListener.cpp
@@ -187,8 +187,8 @@ Java_org_xcsoar_NativeSensorListener_onEngineSensors(JNIEnv *env,
                                                      jint cht_temp,
                                                      jboolean has_egt_temp,
                                                      jint egt_temp,
-                                                     jboolean has_revs_per_sec,
-                                                     jfloat revs_per_sec)
+                                                     jboolean has_ignitions_per_second,
+                                                     jfloat ignitions_per_second)
 {
   jlong ptr = env->GetLongField(obj, NativeSensorListener::ptr_field);
   if (ptr == 0)
@@ -199,8 +199,8 @@ Java_org_xcsoar_NativeSensorListener_onEngineSensors(JNIEnv *env,
                            Temperature::FromKelvin(cht_temp),
                            has_egt_temp,
                            Temperature::FromKelvin(egt_temp),
-                           has_revs_per_sec,
-                           revs_per_sec);
+                           has_ignitions_per_second,
+                           ignitions_per_second);
 }
 
 gcc_visibility_default

--- a/src/Device/AndroidSensors.cpp
+++ b/src/Device/AndroidSensors.cpp
@@ -292,18 +292,19 @@ DeviceDescriptor::OnEngineSensors(bool has_cht,
                                   Temperature cht,
                                   bool has_egt,
                                   Temperature egt,
-                                  bool has_revs_per_sec,
-                                  float revs_per_sec) noexcept
+                                  bool has_ignitions_per_second,
+                                  float ignitions_per_second) noexcept
 {
   const auto e = BeginEdit();
   NMEAInfo &basic = *e;
   basic.UpdateClock();
   basic.alive.Update(basic.clock);
-  if(has_revs_per_sec){
-    basic.engine_state.revs_per_sec = revs_per_sec;
-    basic.engine_state.revs_per_sec_available.Update(basic.clock);
+  if(has_ignitions_per_second && config.engine_type != DeviceConfig::EngineType::NONE){
+    basic.engine_state.revolutions_per_second = ignitions_per_second *
+                                                config.ignitions_to_revolutions_factors[static_cast<unsigned>(config.engine_type)];
+    basic.engine_state.revolutions_per_second_available.Update(basic.clock);
   }else{
-    basic.engine_state.revs_per_sec_available.Clear();
+    basic.engine_state.revolutions_per_second_available.Clear();
   }
   if(has_cht){
     basic.engine_state.cht_temperature = cht;

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -183,6 +183,7 @@ DeviceConfig::Clear() noexcept
   sync_from_device = true;
   sync_to_device = true;
   k6bt = false;
+  engine_type = EngineType::NONE;
 #ifndef NDEBUG
   dump_port = false;
 #endif

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -170,6 +170,25 @@ struct DeviceConfig {
   double sensor_factor;
 
   /**
+   * User choices of engine types supported.
+   * Depending on the engine used (2-stroke, 4-stroke etc.),
+   * ignitions per second have to be scaled to revolutions per second.
+   */
+  enum class EngineType : uint_least8_t{
+    NONE = 0,
+    TWO_STROKE_1_IGN,
+    TWO_STROKE_2_IGN,
+    FOUR_STROKE_1_IGN,
+  } engine_type;
+
+  /**
+   *  Based on user choice of engine type, the measured ignitions of the
+   *  engine used, get scaled to revolutions per second. engine_type[0]
+   *  maps to ignitions_to_revolutions_factors[0] etc.
+   */
+  static constexpr float ignitions_to_revolutions_factors[4] = { 0xAFFE, 1.0f, 0.5f, 2.0f };
+
+  /**
    * Name of the driver.
    */
   StaticString<32> driver_name;

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -624,8 +624,8 @@ private:
                        Temperature cht,
                        bool has_egt,
                        Temperature egt,
-                       bool has_revs_per_sec,
-                       float revs_per_sec) noexcept override;
+                       bool has_ignitions_per_second,
+                       float ignitions_per_second) noexcept override;
   void OnVoltageValues(int temp_adc, unsigned voltage_index,
                        int volt_adc) noexcept override;
   void OnNunchukValues(int joy_x, int joy_y,

--- a/src/Device/SensorListener.hpp
+++ b/src/Device/SensorListener.hpp
@@ -49,15 +49,15 @@ public:
    * @param[in] cht Engine Cylinder Head Temperature.
    * @param[in] has_egt Is the Engine Exhaust Gas Temperature sensor present?
    * @param[in] egt Engine Exhaust Gas Temperature.
-   * @param[in] has_revs_per_sec Is the Engine Revolutions Per Second sensor present?
-   * @param[in] revs_per_sec Engine Revolutions Per Second, rotations per seconds of the camshaft.
+   * @param[in] has_ignitions_per_second Are the measured ignitions valid?
+   * @param[in] ignitions_per_second Engine Ignitions Per Second, firing of the spark plug per second.
    */
   virtual void OnEngineSensors(bool has_cht,
                                Temperature cht,
                                bool has_egt,
                                Temperature egt,
-                               bool has_revs_per_sec,
-                               float revs_per_sec) noexcept = 0;
+                               bool has_ignitions_per_second,
+                               float ignitions_per_second) noexcept = 0;
 
   virtual void OnVoltageValues(int temp_adc, unsigned voltage_index,
                                int volt_adc) noexcept = 0;

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -16,7 +16,7 @@
 #include "Interface.hpp"
 
 enum ControlIndex {
-  Port, BaudRate, BulkBaudRate,
+  Port, EngineTypes, BaudRate, BulkBaudRate,
   IP_ADDRESS,
   TCPPort,
   I2CBus, I2CAddr, PressureUsage, Driver, UseSecondDriver, SecondDriver,
@@ -78,6 +78,22 @@ FillPress(DataFieldEnum &dfe) noexcept
   dfe.addEnumText(_T("Pitot (airspeed)"), (unsigned)DeviceConfig::PressureUse::PITOT);
 }
 
+/**
+ * The user can choose from the following engine types:
+ * None.
+ * 2S1I, 2-stroke one ignition per revolution.
+ * 2S2I, 2-stroke two ignitions per revolution.
+ * 4S1I, 4-stroke one ignition per revolution.
+*/
+static void
+FillEngineType(DataFieldEnum &dfe) noexcept
+{
+  dfe.addEnumText(_T("None"), static_cast<unsigned>(DeviceConfig::EngineType::NONE));
+  dfe.addEnumText(_T("2S1I"), static_cast<unsigned>(DeviceConfig::EngineType::TWO_STROKE_1_IGN));
+  dfe.addEnumText(_T("2S2I"), static_cast<unsigned>(DeviceConfig::EngineType::TWO_STROKE_2_IGN));
+  dfe.addEnumText(_T("4S1I"), static_cast<unsigned>(DeviceConfig::EngineType::FOUR_STROKE_1_IGN));
+}
+
 static bool
 EditPortCallback(const TCHAR *caption, DataField &df,
                  [[maybe_unused]] const TCHAR *help_text) noexcept
@@ -115,6 +131,7 @@ DeviceEditWidget::SetConfig(const DeviceConfig &_config) noexcept
   LoadValue(SyncFromDevice, config.sync_from_device);
   LoadValue(SyncToDevice, config.sync_to_device);
   LoadValue(K6Bt, config.k6bt);
+  LoadValueEnum(EngineTypes, config.engine_type);
 
   UpdateVisibilities();
 }
@@ -188,6 +205,7 @@ DeviceEditWidget::UpdateVisibilities() noexcept
     DeviceConfig::MaybeBluetooth(type, port_df.GetAsString());
   const bool k6bt = maybe_bluetooth && GetValueBoolean(K6Bt);
   const bool uses_speed = DeviceConfig::UsesSpeed(type) || k6bt;
+  const bool engine_sensor = (type == DeviceConfig::PortType::BLE_SENSOR) ? true : false;
 
   SetRowAvailable(BaudRate, uses_speed);
   SetRowAvailable(BulkBaudRate, uses_speed &&
@@ -214,6 +232,7 @@ DeviceEditWidget::UpdateVisibilities() noexcept
   SetRowVisible(SyncToDevice, DeviceConfig::UsesDriver(type) &&
                 CanSendSettings(GetDataField(Driver)));
   SetRowAvailable(K6Bt, maybe_bluetooth);
+  SetRowAvailable(EngineTypes, engine_sensor);
 }
 
 void
@@ -226,6 +245,11 @@ DeviceEditWidget::Prepare(ContainerWindow &parent,
   FillPorts(*port_df, config);
   auto *port_control = Add(_("Port"), nullptr, port_df);
   port_control->SetEditCallback(EditPortCallback);
+
+  DataFieldEnum *engine_type_df = new DataFieldEnum(this);
+  FillEngineType(*engine_type_df);
+  engine_type_df->SetValue(config.engine_type);
+  Add(_("Engine Type"), nullptr, engine_type_df);
 
   DataFieldEnum *baud_rate_df = new DataFieldEnum(this);
   FillBaudRates(*baud_rate_df);
@@ -395,6 +419,8 @@ DeviceEditWidget::Save(bool &_changed) noexcept
   bool changed = false;
 
   changed |= FinishPortField(config, (const DataFieldEnum &)GetDataField(Port));
+
+  changed |= SaveValueEnum(EngineTypes, config.engine_type);
 
   if (config.MaybeBluetooth())
     changed |= SaveValue(K6Bt, config.k6bt);

--- a/src/InfoBoxes/Content/Engine.cpp
+++ b/src/InfoBoxes/Content/Engine.cpp
@@ -29,10 +29,12 @@ void
 UpdateInfoBoxContentEGT(InfoBoxData &data) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
+
   if (!basic.engine_state.egt_temperature_available.IsValid()) {
     data.SetInvalid();
     return;
   }
+
   data.FmtValue(_T("{:3.0f}"), basic.engine_state.egt_temperature.ToUser());
   data.SetValueUnit(Units::current.temperature_unit);
 }
@@ -41,11 +43,12 @@ void
 UpdateInfoBoxContentRPM(InfoBoxData &data) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
-  if (!basic.engine_state.revs_per_sec_available.IsValid()) {
+
+  if (!basic.engine_state.revolutions_per_second_available.IsValid()) {
     data.SetInvalid();
     return;
   }  
 
-  data.FmtValue(_T("{}"), Units::ToUserRotation(basic.engine_state.revs_per_sec));
+  data.FmtValue(_T("{}"), Units::ToUserRotation(basic.engine_state.revolutions_per_second));
   data.SetValueUnit(Units::current.rotation_unit);
 }

--- a/src/NMEA/EngineState.hpp
+++ b/src/NMEA/EngineState.hpp
@@ -11,9 +11,16 @@
 */
 struct EngineState
 {
-  /* The engine box measured revolutions per second on the camshaft. */
-  Validity revs_per_sec_available;
-  float revs_per_sec;
+  /** The engine box measures ignitions per second of the sparkplug.
+  *   Per device setting, the user can change a scaling value to
+  *   scale, based on the engine used, to revolutions per second.
+  */
+  Validity revolutions_per_second_available;
+  float revolutions_per_second;
+
+  /* For future use. */
+  Validity ignitions_per_second_available;
+  float ignitions_per_second;
 
   /* The engine Cylinder Head Temperature (CHT) */
   Validity cht_temperature_available;
@@ -24,7 +31,7 @@ struct EngineState
   Temperature egt_temperature;
 
   void Clear() noexcept{
-    revs_per_sec_available.Clear();
+    revolutions_per_second_available.Clear();
     cht_temperature_available.Clear();
     egt_temperature_available.Clear();
   }
@@ -34,14 +41,14 @@ struct EngineState
   }
 
   void Expire(TimeStamp clock) noexcept {
-    revs_per_sec_available.Expire(clock, std::chrono::seconds(3));
+    revolutions_per_second_available.Expire(clock, std::chrono::seconds(3));
     cht_temperature_available.Expire(clock, std::chrono::seconds(3));
     egt_temperature_available.Expire(clock, std::chrono::seconds(3));
   }
 
   void Complement(const EngineState &add) noexcept {
-    if (revs_per_sec_available.Complement(add.revs_per_sec_available)){
-      revs_per_sec = add.revs_per_sec;
+    if (revolutions_per_second_available.Complement(add.revolutions_per_second_available)){
+      revolutions_per_second = add.revolutions_per_second;
     }
     if (cht_temperature_available.Complement(add.cht_temperature_available)){
       cht_temperature = add.cht_temperature;

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -197,6 +197,11 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
 
   MakeDeviceSettingName(buffer, "Port", n, "SecondDevice");
   map.Get(buffer, config.driver2_name);
+
+  MakeDeviceSettingName(buffer, "Engine", n, "Type");
+  unsigned engine_type;
+  map.Get(buffer, engine_type);
+  config.engine_type = static_cast<DeviceConfig::EngineType>(engine_type);
 }
 
 static const char *
@@ -293,4 +298,7 @@ Profile::SetDeviceConfig(ProfileMap &map,
 
   MakeDeviceSettingName(buffer, "Port", n, "SecondDevice");
   map.Set(buffer, config.driver2_name);
+
+  MakeDeviceSettingName(buffer, "Engine", n, "Type");
+  map.Set(buffer, static_cast<unsigned>(config.engine_type));
 }

--- a/src/Replay/IgcReplay.cpp
+++ b/src/Replay/IgcReplay.cpp
@@ -86,10 +86,10 @@ IgcReplay::Update(NMEAInfo &basic)
     basic.engine_noise_level_available.Clear();
 
   if (fix.rpm >= 0) {
-    basic.engine_state.revs_per_sec = fix.rpm / 60.;
-    basic.engine_state.revs_per_sec_available.Update(basic.clock);
+    basic.engine_state.revolutions_per_second = fix.rpm / 60.;
+    basic.engine_state.revolutions_per_second_available.Update(basic.clock);
   } else
-    basic.engine_state.revs_per_sec_available.Clear();
+    basic.engine_state.revolutions_per_second_available.Clear();
 
   if (fix.trt >= 0) {
     basic.track = Angle::Degrees(fix.trt);


### PR DESCRIPTION
Support for:
2-stroke, one ignition per revolution
2-stroke, two iginitions per revolution
4-stroke, one ignition per two revolutions


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Added scaling factors, based on user choice to support different engine types.
Assuming, that the revolutions of any engine type are derived from ignition pulses.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/1178
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
