### PR TITLE
Add engine hours for engine maintenance

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -167,6 +167,7 @@ XCSOAR_SOURCES := \
 	$(IO_SRC_DIR)/MapFile.cpp \
 	$(IO_SRC_DIR)/ConfiguredFile.cpp \
 	$(IO_SRC_DIR)/DataFile.cpp \
+	$(IO_SRC_DIR)/EngineLogAccess.cpp \
 	$(SRC)/Airspace/ProtectedAirspaceWarningManager.cpp \
 	$(SRC)/Airspace/ActivePredicate.cpp \
 	$(SRC)/Task/Serialiser.cpp \

--- a/src/io/EngineLogAccess.cpp
+++ b/src/io/EngineLogAccess.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "EngineLogAccess.hpp"
+#include "io/FileLineReader.hpp"
+#include "io/KeyValueFileReader.hpp"
+#include "io/KeyValueFileWriter.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/BufferedOutputStream.hxx"
+#include "lib/fmt/ToBuffer.hxx"
+#include "util/PrintException.hxx"
+#include "LocalPath.hpp"
+
+bool
+EngineLogAccess::ReadLogFile()
+{
+  try{
+    FileLineReaderA file(LocalPath(log_file_name));
+    KeyValueFileReader kvreader(file);
+    KeyValuePair pair;
+
+    while (kvreader.Read(pair)) {
+      SensorToLog(std::string(pair.key), std::atof(pair.value));
+    }
+  } catch (...){
+    PrintException(std::current_exception());
+    return false;
+  }
+  return true;
+}
+
+bool
+EngineLogAccess::WriteLogFile()
+{
+  try{
+    FileOutputStream file(LocalPath(log_file_name), FileOutputStream::Mode::CREATE);
+    BufferedOutputStream buffered(file);
+    KeyValueFileWriter kvwriter(buffered);
+
+    for (auto const& entry : engine_log) {
+      kvwriter.Write(entry.first.c_str(), std::to_string(entry.second).c_str());
+    }
+
+    buffered.Flush();
+    file.Commit();
+  } catch (...){
+    PrintException(std::current_exception());
+    return false;
+  }
+  return true;
+}
+
+bool
+EngineLogAccess::WriteSingleUpdateToLogFile(std::string bt_mac, double engine_runtime)
+{
+  SensorToLog(bt_mac, engine_runtime);
+
+  try{
+    FileOutputStream file(LocalPath(log_file_name), FileOutputStream::Mode::APPEND_OR_CREATE);
+    const auto line = FmtBuffer<64>("{}={}\n", bt_mac, engine_runtime);
+    file.Write(line, strlen(line)); // @brief is 0 terminated by FmtBuffer implementation.
+    file.Commit();
+  } catch (...){
+    PrintException(std::current_exception());
+    return false;
+  }
+  return true;
+}
+
+void EngineLogAccess::SensorToLog(std::string bt_mac, double engine_runtime)
+{
+  auto result_pair = engine_log.insert({bt_mac, engine_runtime});
+
+  // does entry for bt_mac exist, update entry?
+  if (!result_pair.second) {
+    result_pair.first->second = engine_runtime;
+  }
+}

--- a/src/io/EngineLogAccess.hpp
+++ b/src/io/EngineLogAccess.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+
+#include <tchar.h>
+#include <map>
+#include <string>
+
+/**
+ * @brief Runtime Log Access. For reading and writing engine runtime to a file.
+ * The log file might have duplicated entries for the keys,
+ * with different values. Key is the BT MAC of a engine sensor,
+ * with engine runtime in seconds, as value.
+ */
+class EngineLogAccess{
+
+/**
+ * @brief Filename of the LocalPath file.
+ */
+const TCHAR *log_file_name = _T("engine_runtime.log");
+
+/**
+ * @brief The logfile data. BT Mac is key, engine runtime is value.
+ */
+std::map<std::string, double, std::less<>> engine_log {};
+
+public:
+  explicit EngineLogAccess() noexcept = default;
+
+public:
+  /**
+   * @brief Read the whole engine_runtime.log into the engine_log map.
+   * If there are dublicate entries in the log file, the highest
+   * engine runtime value, for the particular bt mac, gets stored in the map.
+   */
+  bool ReadLogFile();
+
+  /**
+   * @brief Write the whole engine log map into the engine_runtime.log.
+   * Overwrites the existing log.
+   */
+  bool WriteLogFile();
+
+  /**
+   * @brief Write one key value pair to the engine_runtime.log.
+   * Might be a duplicate. Reading the log at app start takes care of
+   * duplicates.
+   * @param[in] bt_mac Bluetooth MAC of the engine sensor.
+   * @param[in] engine_runtime Total runtime of the engine in seconds.
+   */
+  bool WriteSingleUpdateToLogFile(std::string bt_mac, double engine_runtime);
+
+  /**
+   * @brief Add or update engine sensor to the log map, identified by it's BT MAC.
+   * If the sensor is already in the log map, the engine_runtime gets updated.
+   * It does not get written to the engine_runtime.log file. Use
+   * WriteSingleUpdateToLogFile, to get it added and written imediately.
+   * @param[in] bt_mac Bluetooth MAC of the engine sensor.
+   * @param[in] engine_runtime Total runtime of the engine in seconds.
+
+   */
+  void SensorToLog(std::string bt_mac, double engine_runtime);
+};


### PR DESCRIPTION
Count seconds while the engine has rpm/ignitions. Displayed in format hhh:mm.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Add a counter for engine hours, to track maintenance intervals. After engine rebuild, engine hours should be resettable by user of xcs.

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/issues/1178

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
