### PR TITLE
Added volume up and volume down keys definitions to input events.

### DIFF
--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -258,9 +258,21 @@ The key type can have the following possible values:
 
 - ``APP1-APP6``: Hardware key on pocket pc
 - ``F1-F12``: Standard function keys
-- ``LEFT, RIGHT, UP, DOWN, RETURN``: Mapped to arrow keys - joystick
-  on organisers
+- ``LEFT, RIGHT, UP, DOWN, RETURN, ESCAPE, MENU, TAB``: Mapped to arrow 
+  keys - joystick on organisers
 - ``A-Z, 0-9``: and other possible keyboard buttons (case is ignored)
+
+Android only:
+
+- ``BUTTON_R1, BUTTON_R2, BUTTON_L1, BUTTON_L2, BUTTON_A, BUTTON_B, 
+  BUTTON_C, BUTTON_X, BUTTON_Y, BUTTON_Z, MEDIA_NEXT, MEDIA_PREVIOUS, 
+  MEDIA_PLAY_PAUSE, VOLUME_UP, VOLUME_DOWN``: intended for Bluetooth
+  keypads, media controllers
+
+Windows only:
+
+- ``F13-F20``: intended for the Triadis-RemoteStick, as well as for
+  expanded keyboards
 
 XXX Review... Input Types
 

--- a/src/Input/InputKeys.cpp
+++ b/src/Input/InputKeys.cpp
@@ -46,6 +46,8 @@ static constexpr struct string_to_key string_to_key[] = {
   { _T("MEDIA_NEXT"), KEYCODE_MEDIA_NEXT},
   { _T("MEDIA_PREVIOUS"), KEYCODE_MEDIA_PREVIOUS},
   { _T("MEDIA_PLAY_PAUSE"), KEYCODE_MEDIA_PLAY_PAUSE},
+  { _T("VOLUME_UP"), KEY_VOLUME_UP },
+  { _T("VOLUME_DOWN"), KEY_VOLUME_DOWN },  
 #endif
 
 #ifdef USE_WINUSER

--- a/src/ui/event/android/KeyCode.hpp
+++ b/src/ui/event/android/KeyCode.hpp
@@ -11,6 +11,8 @@ enum {
   KEY_DOWN = 0x14,
   KEY_LEFT = 0x15,
   KEY_RIGHT = 0x16,
+  KEY_VOLUME_UP = 0x18,
+  KEY_VOLUME_DOWN = 0x19,
   KEY_TAB = 0x3d,
   KEY_SPACE = 0x3e,
   KEY_RETURN = 0x42,


### PR DESCRIPTION
Brief summary of the changes
----------------------------

On Android, when external keyboard is detected the zoom control from volume buttons is disabled. This PR adds volume input definitions, to enable user to configure volume buttons events.

I tried to use Bluetooth remote media controller (with volume up, volume down, previous, next, play/pause buttons), as an external controller for XCSoar. I could configure all buttons except volume buttons. This fixes this issue.


Related issues and discussions
------------------------------

