### PR TITLE
Show "No Data" text on the horizon page when required data is missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/local-config.mk
 .*.swp
 
 .idea
+.vscode

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,7 @@ Version 7.30 - 2023/05/09
 * fix crash in "ProfileSave" event
 * user interface
   - reload fonts on window resize
+  - display no data text on the artificial horizon page when required data is not available
 * Windows
   - look up serial ports in the registry
 * Android

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,8 @@
 Version 7.31 - not yet released
 * Android
   - fix crash with buggy graphics drivers
+* user interface
+  - display no data text on the artificial horizon page when required data is not available
 
 Version 7.30 - 2023/05/09
 * fix crash in "ProfileSave" event

--- a/src/HorizonWidget.cpp
+++ b/src/HorizonWidget.cpp
@@ -8,6 +8,8 @@
 #include "ui/window/AntiFlickerWindow.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Renderer/HorizonRenderer.hpp"
+#include "Language/Language.hpp"
+#include "Screen/Layout.hpp"
 
 /**
  * A Window which renders a terrain and airspace cross-section
@@ -42,10 +44,27 @@ protected:
       canvas.ClearWhite();
 
     if (!attitude.bank_angle_available && !attitude.pitch_angle_available)
-      // TODO: paint "no data" hint
-      return;
+      PaintNoData(canvas, canvas.GetRect());
+    else
+      HorizonRenderer::Draw(canvas, canvas.GetRect(), look, attitude);
+  }
 
-    HorizonRenderer::Draw(canvas, canvas.GetRect(), look, attitude);
+  /**
+   * @todo languages
+  */
+  void PaintNoData(Canvas &canvas, PixelRect rc) const noexcept {
+    const TCHAR *str = _("No Data");
+    canvas.Select(look.no_data_font);
+    PixelSize textSize = canvas.CalcTextSize(str);
+    canvas.SetTextColor(inverse ? COLOR_WHITE : COLOR_BLACK);
+    
+    const PixelPoint center{
+      int(rc.GetWidth()) / 2 - int(textSize.width) / 2,
+      int(rc.GetHeight()) / 2 - int(textSize.height) / 2
+    };
+
+    canvas.SetBackgroundTransparent();
+    canvas.DrawText(center, str);
   }
 };
 

--- a/src/HorizonWidget.cpp
+++ b/src/HorizonWidget.cpp
@@ -49,22 +49,13 @@ protected:
       HorizonRenderer::Draw(canvas, canvas.GetRect(), look, attitude);
   }
 
-  /**
-   * @todo languages
-  */
   void PaintNoData(Canvas &canvas, PixelRect rc) const noexcept {
     const TCHAR *str = _("No Data");
     canvas.Select(look.no_data_font);
-    PixelSize textSize = canvas.CalcTextSize(str);
+    PixelSize text_size = canvas.CalcTextSize(str);
     canvas.SetTextColor(inverse ? COLOR_WHITE : COLOR_BLACK);
-    
-    const PixelPoint center{
-      int(rc.GetWidth()) / 2 - int(textSize.width) / 2,
-      int(rc.GetHeight()) / 2 - int(textSize.height) / 2
-    };
-
     canvas.SetBackgroundTransparent();
-    canvas.DrawText(center, str);
+    canvas.DrawText(rc.CenteredTopLeft(text_size), str);
   }
 };
 

--- a/src/Look/FlarmTrafficLook.cpp
+++ b/src/Look/FlarmTrafficLook.cpp
@@ -44,7 +44,9 @@ FlarmTrafficLook::Initialise(const TrafficLook &other, bool small, bool inverse)
 
   unit_fraction_pen.Create(1, inverse ? COLOR_WHITE : COLOR_BLACK);
 
-  no_traffic_font.Load(FontDescription(Layout::FontScale(22)));
+  gauge_look.Initialise(Font);
+  Font* no_traffic_font = &gauge_look.no_data_font;
+  
   label_font.Load(FontDescription(Layout::FontScale(12)));
   side_info_font.Load(FontDescription(Layout::FontScale(small ? 8 : 12),
                                       true));

--- a/src/Look/FlarmTrafficLook.hpp
+++ b/src/Look/FlarmTrafficLook.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include "GaugeLook.hpp"
 #include "ui/canvas/Color.hpp"
 #include "ui/canvas/Pen.hpp"
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Font.hpp"
 
 struct TrafficLook;
+struct GaugeLook;
 
 struct FlarmTrafficLook {
   Color warning_color;
@@ -45,7 +47,9 @@ struct FlarmTrafficLook {
 
   Pen unit_fraction_pen;
 
-  Font label_font, side_info_font, no_traffic_font;
+  GaugeLook gauge_look;
+  Font* no_traffic_font;
+  Font label_font, side_info_font;
   Font info_values_font, info_units_font, info_labels_font, call_sign_font;
 
   void Initialise(const TrafficLook &other, bool small, bool inverse = false);

--- a/src/Look/GaugeLook.cpp
+++ b/src/Look/GaugeLook.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "FontDescription.hpp"
+
+
+
+void
+GaugeLook::Initialise(const Font &_font)
+{
+  no_data_font.Load(FontDescription(Layout::FontScale(22)));
+}

--- a/src/Look/GaugeLook.hpp
+++ b/src/Look/GaugeLook.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+#include "ui/canvas/Font.hpp"
+
+class Font;
+
+struct GaugeLook {
+  Font no_data_font;
+
+  // void Initialise();
+  void Initialise(const Font &_font);
+};

--- a/src/Look/HorizonLook.cpp
+++ b/src/Look/HorizonLook.cpp
@@ -3,6 +3,7 @@
 
 #include "HorizonLook.hpp"
 #include "Screen/Layout.hpp"
+#include "FontDescription.hpp"
 
 void
 HorizonLook::Initialise()
@@ -14,4 +15,7 @@ HorizonLook::Initialise()
 
   terrain_brush.Create(terrain_color);
   terrain_pen.Create(Layout::Scale(1), DarkColor(terrain_color));
+
+  no_data_font.Load(FontDescription(Layout::FontScale(22)));
+
 }

--- a/src/Look/HorizonLook.hpp
+++ b/src/Look/HorizonLook.hpp
@@ -9,7 +9,6 @@
 
 struct HorizonLook {
   Pen aircraft_pen;
-  
   static constexpr Color sky_color{0x0a, 0xb9, 0xf3};
   Brush sky_brush;
   Pen sky_pen;

--- a/src/Look/HorizonLook.hpp
+++ b/src/Look/HorizonLook.hpp
@@ -5,10 +5,11 @@
 
 #include "ui/canvas/Pen.hpp"
 #include "ui/canvas/Brush.hpp"
+#include "ui/canvas/Font.hpp"
 
 struct HorizonLook {
   Pen aircraft_pen;
-
+  
   static constexpr Color sky_color{0x0a, 0xb9, 0xf3};
   Brush sky_brush;
   Pen sky_pen;
@@ -16,6 +17,10 @@ struct HorizonLook {
   static constexpr Color terrain_color{0x80, 0x45, 0x15};
   Brush terrain_brush;
   Pen terrain_pen;
+
+  Font no_data_font;
+
+  Color default_color;
 
   void Initialise();
 };


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

Brief summary of the changes
----------------------------
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->

- Added "No Data" text when there is no artificial horizon data available on the horizon screen
- Text adherers to the colour invert function 

<img width="644" alt="Screenshot 2023-05-10 at 20 13 09" src="https://github.com/XCSoar/XCSoar/assets/6553343/d63a4868-dea3-471b-af18-3228f7a32ab1">

