### PR TITLE
Developer Manual: added missing slash to the osx dependancies

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -273,7 +273,7 @@ Install the required Homebrew packages::
 
   brew install \
     automake autoconf libtool \
-    pkg-config
+    pkg-config \
     quilt \
     librsvg \
     imagemagick gettext sox \


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Added missing slash to dependancies for the osx brew install after pkg-config
<img width="673" alt="Screenshot 2023-05-11 at 21 34 40" src="https://github.com/XCSoar/XCSoar/assets/6553343/b1a0fb15-3984-46a8-9415-1f208670454b">




<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
