### PR TITLE
Fixed horizon issue for roll clipping

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.32 - not yet released
+* user interface
+  - fix horizon roll, show bank angles greater than 90°
 
 Version 7.31 - 2023/05/12
 * user interface

--- a/src/Renderer/HorizonRenderer.cpp
+++ b/src/Renderer/HorizonRenderer.cpp
@@ -42,10 +42,9 @@ HorizonRenderer::Draw(Canvas &canvas, const PixelRect &rc,
     ? attitude.pitch_angle.Degrees()
     : 0.;
 
-  auto phi = Clamp(bank_degrees, -89., 89.);
   auto alpha = Angle::acos(Clamp(pitch_degrees / 50,
                                  -1., 1.));
-  auto sphi = Angle::HalfCircle() - Angle::Degrees(phi);
+  auto sphi = Angle::HalfCircle() - Angle::Degrees(bank_degrees);
   auto alpha1 = sphi - alpha;
   auto alpha2 = sphi + alpha;
 


### PR DESCRIPTION
- Removed bank angle clamp as this was restricting the visualisation of rolls greater than 90 degrees
- Updated NEWS to include the fix

Before:

https://github.com/XCSoar/XCSoar/assets/6553343/d8b0188f-1a4e-4899-ac22-6733523f54ec


After:

https://github.com/XCSoar/XCSoar/assets/6553343/cdefbf86-3cd4-4e2c-9298-2392f741dea1




<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
https://github.com/XCSoar/XCSoar/discussions/1212
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
