### PR TITLE
IMI/Protocol/Protocol.cpp: stop ReadFlightList loop when flight_list is full

### DIFF
--- a/src/Device/Driver/IMI/Protocol/Protocol.cpp
+++ b/src/Device/Driver/IMI/Protocol/Protocol.cpp
@@ -183,9 +183,10 @@ IMI::ReadFlightList(Port &port, RecordedFlightList &flight_list,
       ifi.start_time = start;
       ifi.end_time = ConvertToDateTime(fi->finish);
       ifi.internal.imi = fi->address;
+      if(flight_list.full()) break;
     }
 
-    if (msg.payloadSize == 0 || address == 0xFFFF)
+    if (msg.payloadSize == 0 || address == 0xFFFF || flight_list.full())
       return true;
   }
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------
- Added flight_list.full() check to the loop when downloading the flights from IMI Erixx device, so the flight_list array does not overflow when the device contains more than 128 flight records.
- Added additional condition for success to the function result.



Related issues and discussions
------------------------------
Closes #1225
