### PR TITLE
FLARM: Parse AircraftType field as hex in PLFAA

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,7 @@ Version 7.32 - not yet released
   - support waypoints without elevation data
 * devices
   - IMI: fix crash when there are more than 128 recorded flights
+  - FLARM: parse AircraftType hex values correctly in PFLAA
 * Linux
   - Wayland XDG_WM_BASE support
   - Wayland keyboard support

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -150,7 +150,7 @@ ParsePFLAA(NMEAInputLine &line, TrafficList &flarm, TimeStamp clock) noexcept
 
   traffic.stealth = stealth;
 
-  unsigned type = line.Read(0);
+  unsigned type = line.ReadHex(0);
   if (type > 15 || type == 14)
     traffic.type = FlarmTraffic::AircraftType::UNKNOWN;
   else

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -209,7 +209,7 @@ TestFLARM()
     skip(12, 0, "traffic == NULL");
   }
 
-  ok1(parser.ParseLine("$PFLAA,0,1206,574,21,2,DDAED5,196,,32,1.0,1*10",
+  ok1(parser.ParseLine("$PFLAA,0,1206,574,21,2,DDAED5,196,,32,1.0,C*62",
                        nmea_info));
   ok1(nmea_info.flarm.traffic.GetActiveTrafficCount() == 3);
 
@@ -228,7 +228,7 @@ TestFLARM()
     ok1(traffic->speed_received);
     ok1(equals(traffic->climb_rate, 1.0));
     ok1(traffic->climb_rate_received);
-    ok1(traffic->type == FlarmTraffic::AircraftType::GLIDER);
+    ok1(traffic->type == FlarmTraffic::AircraftType::AIRSHIP);
     ok1(!traffic->stealth);
   } else {
     skip(15, 0, "traffic == NULL");


### PR DESCRIPTION
Beware: I wasn't able to test this with a real flarm yet.
