### PR TITLE
UI color params

### DIFF
--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -38,6 +38,7 @@ enum ControlIndex {
   AppFlarmLocation,
   TabDialogStyle,
   AppStatusMessageAlignment,
+  AppInfoBoxContrast,
   AppInfoBoxColors,
   AppInfoBoxBorder,
 #ifdef KOBO
@@ -215,6 +216,11 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
           (unsigned)ui_settings.popup_message_position);
   SetExpertRow(AppStatusMessageAlignment);
 
+  AddInteger(_("InfoBox contrast"), _("Set InfoBox contrast from 0 (low) to 5 (high)."),
+             _T("%d"), _T("%d"),
+             0, 5, 1, ui_settings.info_boxes.contrast);
+  SetExpertRow(AppInfoBoxContrast);
+
   if (HasColors()) {
     AddBoolean(_("Colored InfoBoxes"),
                _("If true, certain InfoBoxes will have coloured text.  For example, the active waypoint "
@@ -288,6 +294,9 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   if (HasColors())
     changed |= SaveValue(AppInfoBoxColors, ProfileKeys::AppInfoBoxColors,
                          ui_settings.info_boxes.use_colors);
+
+  changed |= SaveValueInteger(AppInfoBoxContrast, ProfileKeys::AppInfoBoxContrast,
+                              ui_settings.info_boxes.contrast);
 
 #ifdef KOBO
   if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,ui_settings.show_menu_button))

--- a/src/InfoBoxes/InfoBoxSettings.cpp
+++ b/src/InfoBoxes/InfoBoxSettings.cpp
@@ -34,6 +34,7 @@ InfoBoxSettings::SetDefaults() noexcept
   geometry = Geometry::SPLIT_8;
 
   use_colors = true;
+  contrast = 5;
   border_style = BorderStyle::SHADED;
 
   for (unsigned i = 0; i < MAX_PANELS; ++i)

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -6,6 +6,7 @@
 #include "util/StaticString.hxx"
 #include "util/Compiler.h"
 #include "InfoBoxes/Content/Type.hpp"
+#include "ui/canvas/Color.hpp"
 
 #include <cstdint>
 
@@ -110,6 +111,8 @@ struct InfoBoxSettings {
   } geometry;
 
   bool use_colors;
+  uint8_t contrast;
+  Color background_color;
 
   enum class BorderStyle : uint8_t {
     BOX,

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -21,15 +21,15 @@
 #define COLOR_INVERSE_GREEN COLOR_GREEN
 #define COLOR_INVERSE_MAGENTA COLOR_MAGENTA
 
+
 void
-InfoBoxLook::Initialise(bool _inverse, bool use_colors,
+InfoBoxLook::Initialise(const UISettings &settings,
                         unsigned width)
 {
-  inverse = _inverse;
 
-  value.fg_color = title.fg_color = comment.fg_color =
-    inverse ? COLOR_WHITE : COLOR_BLACK;
-  background_color = inverse ? COLOR_BLACK : COLOR_WHITE;
+  bool use_colors = settings.info_boxes.use_colors;
+  inverse = UISettings::GetDarkMode(settings);
+
   caption_background_color = inverse
     ? Color(0x40, 0x40, 0x40)
     : Color(0xe0, 0xe0, 0xe0);
@@ -44,9 +44,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
   Color border_color = Color(128, 128, 128);
   border_pen.Create(BORDER_WIDTH, border_color);
 
-  ReinitialiseLayout(width);
-
-  unit_fraction_pen.Create(1, value.fg_color);
+  ReinitialiseLayout(settings, width);
 
   colors[0] = border_color;
   if (HasColors() && use_colors) {
@@ -60,8 +58,17 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
 }
 
 void
-InfoBoxLook::ReinitialiseLayout(unsigned width)
+InfoBoxLook::ReinitialiseLayout(const UISettings &settings,
+      unsigned width)
 {
+
+  uint8_t bg = UISettings::GetBgColor(settings);
+  background_color = Color(bg,bg,bg);
+
+  uint8_t fg = inverse ? 255 : 0;
+  value.fg_color = title.fg_color = comment.fg_color = Color(fg,fg,fg);
+  unit_fraction_pen.Create(1, value.fg_color);
+
   const unsigned max_font_height = Layout::FontScale(12);
 
   FontDescription title_font_d(8);

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -28,7 +28,7 @@ InfoBoxLook::Initialise(const UISettings &settings,
 {
 
   bool use_colors = settings.info_boxes.use_colors;
-  inverse = UISettings::GetDarkMode(settings);
+  inverse = settings.GetDarkMode();
 
   caption_background_color = inverse
     ? Color(0x40, 0x40, 0x40)
@@ -62,7 +62,7 @@ InfoBoxLook::ReinitialiseLayout(const UISettings &settings,
       unsigned width)
 {
 
-  uint8_t bg = UISettings::GetBgColor(settings);
+  uint8_t bg = settings.GetBgColorVal();
   background_color = Color(bg,bg,bg);
 
   uint8_t fg = inverse ? 255 : 0;

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -18,8 +18,7 @@ struct InfoBoxLook {
   bool inverse;
 
   Pen border_pen;
-  Color foreground_color, background_color,
-        focused_background_color, pressed_background_color;
+  Color background_color, focused_background_color, pressed_background_color;
 
   /**
    * Used only by #InfoBoxSettings::BorderStyle::SHADED.

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -7,6 +7,8 @@
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Font.hpp"
 #include "util/Macros.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
+#include "UISettings.hpp"
 
 class Font;
 
@@ -16,7 +18,8 @@ struct InfoBoxLook {
   bool inverse;
 
   Pen border_pen;
-  Color background_color, focused_background_color, pressed_background_color;
+  Color foreground_color, background_color,
+        focused_background_color, pressed_background_color;
 
   /**
    * Used only by #InfoBoxSettings::BorderStyle::SHADED.
@@ -40,10 +43,9 @@ struct InfoBoxLook {
 
   Color colors[6];
 
-  void Initialise(bool inverse, bool use_colors,
-                  unsigned width);
+  void Initialise(const UISettings &settings, unsigned infobox_width);
 
-  void ReinitialiseLayout(unsigned width);
+  void ReinitialiseLayout(const UISettings &settings, unsigned width);
 
   Color GetColor(int i, Color default_color) const {
     if (i < 0)

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -3,7 +3,6 @@
 
 #include "Look.hpp"
 #include "UISettings.hpp"
-#include "GlobalSettings.hpp"
 
 void
 Look::Initialise(const Font &map_font)
@@ -16,30 +15,12 @@ Look::Initialise(const Font &map_font)
   chart.Initialise();
 }
 
-[[gnu::pure]]
-static bool
-GetDarkMode(const UISettings &settings) noexcept
-{
-  switch (settings.dark_mode) {
-  case UISettings::DarkMode::OFF:
-    break;
-
-  case UISettings::DarkMode::ON:
-    return true;
-
-  case UISettings::DarkMode::AUTO:
-    return GlobalSettings::dark_mode;
-  }
-
-  return false;
-}
-
 void
 Look::InitialiseConfigured(const UISettings &settings,
                            const Font &map_font, const Font &map_bold_font,
                            unsigned infobox_width)
 {
-  const bool dark_mode = GetDarkMode(settings);
+  const bool dark_mode = UISettings::GetDarkMode(settings);
 
   dialog.Initialise();
   terminal.Initialise();
@@ -47,17 +28,17 @@ Look::InitialiseConfigured(const UISettings &settings,
   horizon.Initialise();
   thermal_band.Initialise(dark_mode,
                           cross_section.sky_color);
+
   trace_history.Initialise(dark_mode);
-  info_box.Initialise(dark_mode,
-                      settings.info_boxes.use_colors,
-                      infobox_width);
-  vario.Initialise(dark_mode,
-                   settings.info_boxes.use_colors,
+  info_box.Initialise(settings, infobox_width);
+  vario.Initialise(settings,
                    infobox_width,
                    info_box.title_font);
+
   wind_arrow_info_box.Initialise(map_bold_font, dark_mode);
   flarm_gauge.Initialise(traffic, true, dark_mode);
   thermal_assistant_gauge.Initialise(true, dark_mode);
+
   final_glide_bar.Initialise(map_bold_font);
   vario_bar.Initialise(map_bold_font);
   map.Initialise(settings.map, map_font, map_bold_font);
@@ -66,12 +47,12 @@ Look::InitialiseConfigured(const UISettings &settings,
 }
 
 void
-Look::ReinitialiseLayout(unsigned infobox_width)
+Look::ReinitialiseLayout(const UISettings &settings, unsigned infobox_width)
 {
   /* dialog fonts have an upper bound depending on the window size,
      and thus they might need to be reloaded */
   dialog.LoadFonts();
 
-  info_box.ReinitialiseLayout(infobox_width);
+  info_box.ReinitialiseLayout(settings, infobox_width);
   vario.ReinitialiseLayout(infobox_width);
 }

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -20,7 +20,7 @@ Look::InitialiseConfigured(const UISettings &settings,
                            const Font &map_font, const Font &map_bold_font,
                            unsigned infobox_width)
 {
-  const bool dark_mode = UISettings::GetDarkMode(settings);
+  const bool dark_mode = settings.GetDarkMode();
 
   dialog.Initialise();
   terminal.Initialise();

--- a/src/Look/Look.hpp
+++ b/src/Look/Look.hpp
@@ -53,5 +53,5 @@ struct Look {
                             const Font &map_font, const Font &map_bold_font,
                             unsigned infobox_width);
 
-  void ReinitialiseLayout(unsigned infobox_width);
+  void ReinitialiseLayout(const UISettings &settings, unsigned infobox_width);
 };

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -20,8 +20,8 @@ VarioLook::Initialise(const UISettings &settings,
                       const Font &_text_font)
 
 {
-  inverse = UISettings::GetDarkMode(settings);
-  uint8_t bg_color_val = UISettings::GetBgColor(settings);
+  inverse = settings.GetDarkMode();
+  uint8_t bg_color_val = settings.GetBgColorVal();
   colors = settings.info_boxes.use_colors;
 
   if (inverse) {

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -15,21 +15,23 @@
 #include <algorithm>
 
 void
-VarioLook::Initialise(bool _inverse, bool _colors,
+VarioLook::Initialise(const UISettings &settings,
                       unsigned width,
                       const Font &_text_font)
+
 {
-  inverse = _inverse;
-  colors = _colors;
+  inverse = UISettings::GetDarkMode(settings);
+  uint8_t bg_color_val = UISettings::GetBgColor(settings);
+  colors = settings.info_boxes.use_colors;
 
   if (inverse) {
-    background_color = COLOR_BLACK;
+    background_color = Color(bg_color_val, bg_color_val, bg_color_val); //COLOR_BLACK;
     text_color = COLOR_WHITE;
     dimmed_text_color = Color(0xa0, 0xa0, 0xa0);
     sink_color = Color(0xc4, 0x80, 0x1e);
     lift_color = Color(0x1e, 0xf1, 0x73);
   } else {
-    background_color = COLOR_WHITE;
+    background_color = Color(bg_color_val, bg_color_val, bg_color_val); // COLOR_WHITE;
     text_color = COLOR_BLACK;
     dimmed_text_color = Color((uint8_t)~0xa0, (uint8_t)~0xa0, (uint8_t)~0xa0);
     sink_color = Color(0xa3,0x69,0x0d);

--- a/src/Look/VarioLook.hpp
+++ b/src/Look/VarioLook.hpp
@@ -8,6 +8,7 @@
 #include "ui/canvas/Pen.hpp"
 #include "ui/canvas/Bitmap.hpp"
 #include "ui/canvas/Font.hpp"
+#include "UISettings.hpp"
 
 class Font;
 
@@ -33,7 +34,7 @@ struct VarioLook {
   Font unit_font;
   Pen unit_fraction_pen;
 
-  void Initialise(bool inverse, bool colors,
+  void Initialise(const UISettings &settings,
                   unsigned width,
                   const Font &text_font);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -314,7 +314,7 @@ MainWindow::ReinitialiseLayout() noexcept
   const InfoBoxLayout::Layout ib_layout =
     InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
 
-  look->ReinitialiseLayout(ib_layout.control_size.width);
+  look->ReinitialiseLayout(ui_settings, ib_layout.control_size.width);
 
   InfoBoxManager::Create(*this, ib_layout, look->info_box);
   InfoBoxManager::ProcessTimer();

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -110,6 +110,7 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
     break;
   }
 
+  map.Get(ProfileKeys::AppInfoBoxContrast, settings.contrast);
   map.Get(ProfileKeys::AppInfoBoxColors, settings.use_colors);
 
   map.GetEnum(ProfileKeys::AppInfoBoxBorder, settings.border_style);

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -107,6 +107,7 @@ constexpr std::string_view AppIndLandable = "AppIndLandable";
 constexpr std::string_view AppUseSWLandablesRendering = "AppUseSWLandablesRendering";
 constexpr std::string_view AppLandableRenderingScale = "AppLandableRenderingScale";
 constexpr std::string_view AppScaleRunwayLength = "AppScaleRunwayLength";
+constexpr std::string_view AppInfoBoxContrast = "AppInfoBoxContrast";
 
 /** deprecated, use #DarkMode */
 constexpr std::string_view AppInverseInfoBox = "AppInverseInfoBox";

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -38,10 +38,9 @@ UISettings::SetDefaults() noexcept
 }
 
 
-[[gnu::pure]]
-bool UISettings::GetDarkMode(const UISettings &settings) noexcept
+bool UISettings::GetDarkMode() const noexcept
 {
-  switch (settings.dark_mode) {
+  switch (this->dark_mode) {
   case UISettings::DarkMode::OFF:
     break;
 
@@ -55,12 +54,12 @@ bool UISettings::GetDarkMode(const UISettings &settings) noexcept
   return false;
 }
 
-uint8_t UISettings::GetBgColor(const UISettings &settings) noexcept
+uint8_t UISettings::GetBgColorVal() const noexcept
 {
   /* Get background (brightness) color value for infoboxes, vario etc.
   Contrast is any integer 0 to 5 (max contrast). */
-  uint8_t contrast = settings.info_boxes.contrast;
+  uint8_t contrast = this->info_boxes.contrast;
   uint8_t bg = (contrast>5) ? 0 : 16*(5-contrast);
-  bool dark_mode = UISettings::GetDarkMode(settings);
+  bool dark_mode = this->GetDarkMode();
   return dark_mode ? bg : 255-bg;
 }

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "UISettings.hpp"
+#include "GlobalSettings.hpp"
 
 void
 UISettings::SetDefaults() noexcept
@@ -34,4 +35,32 @@ UISettings::SetDefaults() noexcept
   pages.SetDefaults();
   dialog.SetDefaults();
   sound.SetDefaults();
+}
+
+
+[[gnu::pure]]
+bool UISettings::GetDarkMode(const UISettings &settings) noexcept
+{
+  switch (settings.dark_mode) {
+  case UISettings::DarkMode::OFF:
+    break;
+
+  case UISettings::DarkMode::ON:
+    return true;
+
+  case UISettings::DarkMode::AUTO:
+    return GlobalSettings::dark_mode;
+  }
+
+  return false;
+}
+
+uint8_t UISettings::GetBgColor(const UISettings &settings) noexcept
+{
+  /* Get background (brightness) color value for infoboxes, vario etc.
+  Contrast is any integer 0 to 5 (max contrast). */
+  uint8_t contrast = settings.info_boxes.contrast;
+  uint8_t bg = (contrast>5) ? 0 : 16*(5-contrast);
+  bool dark_mode = UISettings::GetDarkMode(settings);
+  return dark_mode ? bg : 255-bg;
 }

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -79,10 +79,9 @@ struct UISettings {
     return scale;
   }
 
-  [[gnu::pure]]
-  static bool GetDarkMode(const UISettings &settings) noexcept;
+  bool GetDarkMode() const noexcept;
 
-  static uint8_t GetBgColor(const UISettings &settings) noexcept;
+  uint8_t GetBgColorVal() const noexcept;
 
 };
 

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -78,6 +78,12 @@ struct UISettings {
   constexpr unsigned GetPercentScale() const noexcept {
     return scale;
   }
+
+  [[gnu::pure]]
+  static bool GetDarkMode(const UISettings &settings) noexcept;
+
+  static uint8_t GetBgColor(const UISettings &settings) noexcept;
+
 };
 
 static_assert(std::is_trivial<UISettings>::value, "type is not trivial");

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -170,6 +170,7 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   if (ui_settings.dark_mode != old_ui_settings.dark_mode ||
       ui_settings.info_boxes.use_colors != old_ui_settings.info_boxes.use_colors ||
+      ui_settings.info_boxes.contrast != old_ui_settings.info_boxes.contrast   ||
       settings_map.trail.type != old_settings_map.trail.type ||
       settings_map.trail.scaling_enabled != old_settings_map.trail.scaling_enabled ||
       settings_map.waypoint.landable_style != old_settings_map.waypoint.landable_style)


### PR DESCRIPTION
Brief summary of the changes
----------------------------
Added a contrast option for InfoBoxes. 6 levels 0-5 can be selected. 5 is default and highest contrast. At 5, foreground is black (0x00) and background white (0xFF). At 0, foreground is dark gray (0x64) and background light gray (0x9B).


Related issues and discussions
------------------------------
Proposal for issue #910.