### PR TITLE
Swap InfoBoxes easy in config dialogue

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.34 - not yet released
+* user interface
+  - New InfoBox Swap feature and refurbished the config dialoge.
 
 Version 7.33 - 2023/05/26
 * map display


### PR DESCRIPTION
Brief summary of the changes
----------------------------
This is a proposal.

1. Added a Swap feature to the InfoBox config dialog. Tick the "Swap" checkbox to move the selected box to the next box position clicked on. The selected box position remains to allow you to place the seconds, third etc box in the layout.
Or in other words; click the box you'd like to move, then the box to move it to. Repeat until all boxes are placed.
Finish by unchecking the checkbox, tapping the currently selected box or by double clicking a box (to select a new from the long list).

2. Renamed the "Copy/Paste" buttons to "Copy Set/Paste Set" to clarify they work on whole sets, not individual boxes.

3. Show InfoBox description when a box is selected.


Related issues and discussions
------------------------------
https://forum.xcsoar.org/viewtopic.php?f=2&t=4208