### PR TITLE
Increase maximum number of flights in the Logger flight list to 512

### DIFF
--- a/src/Device/RecordedFlight.hpp
+++ b/src/Device/RecordedFlight.hpp
@@ -51,5 +51,5 @@ struct RecordedFlightInfo : FlightInfo {
   } internal;
 };
 
-class RecordedFlightList : public StaticArray<RecordedFlightInfo, 128u> {
+class RecordedFlightList : public StaticArray<RecordedFlightInfo, 512u> {
 };


### PR DESCRIPTION
Increases maximum length of the flights list for logger downloads from LXNAV to 512 (from 128)

Assuming that the maximum number of flights stored in the LXNAV devices is smaller than 512, this fixes issue #1237 forever. If the LXNAV maximum is larger, then this solves the issue temporarily for a few years (for most pilots...).