### PR TITLE
ide/provisioning: Remove non-existent file from provisioning script list

### DIFF
--- a/doc/devsetup.rst
+++ b/doc/devsetup.rst
@@ -36,7 +36,6 @@ dependencies for various XCSoar target platforms.
 ::
 
    cd ide/provisioning
-   sudo ./add-debian-unstable.sh
    sudo ./install-debian-packages.sh
    ./install-android-tools.sh
 


### PR DESCRIPTION
Brief summary of the changes
----------------------------

The list of provisioning scripts on the page "Setting up a development environment based on Linux" refers to the script add-debian-unstable.sh which does not exist in ide/provisioning.

