### PR TITLE
Manual: change minimum Android version requirement to 5.0

### DIFF
--- a/doc/manual/en/ch01_introduction.tex
+++ b/doc/manual/en/ch01_introduction.tex
@@ -136,7 +136,7 @@ XCSoar running in landscape orientation.
 \section{Platforms}
 \begin{description}
 \item[Android Devices]
-XCSoar runs on Android 1.6 or newer.
+XCSoar runs on Android 5.0 or newer.
 \item [eBookreader]
 XCSoar runs on several Kobo eReader devices.
 \item[Windows PC]

--- a/doc/manual/en/installation.tex
+++ b/doc/manual/en/installation.tex
@@ -91,9 +91,7 @@ discover/manual.html}.
 XCSoar runs on the following platforms:
 
 \begin{itemize}
-\item Android mobile phones and tablets with Android 1.6 or newer \\
-  Example: Dell Streak, Samsung Galaxy S II, HTC Desire HD,
-  Motorola Xoom
+\item Android mobile phones and tablets with Android 5.0 or newer 
 \item eReader Kobo
 \item Windows 2000 or newer
 \item Linux


### PR DESCRIPTION
Brief summary of the changes
----------------------------

Change Android minimum version to 5.0 and also remove examples of devices, as they are obsolete for this version of Android.


Related issues and discussions
------------------------------

Closes #1250

