### PR TITLE
Provisioning script - guard to prevent accidentally running with sudo

### DIFF
--- a/ide/provisioning/install-android-tools.sh
+++ b/ide/provisioning/install-android-tools.sh
@@ -11,6 +11,11 @@ ANDROID_REPO_URL=https://dl.google.com/android/repository
 ANDROID_SDK_DIR=~/opt/android-sdk-linux
 ANDROID_NDK_DIR=~/opt/android-ndk-${ANDROID_NDK_VERSION}
 
+if [ "$(id -u)" -eq 0 ];
+    then echo "Do not run as root. Android SDK is meant to be installed locally to a user." >&2
+    exit 1
+fi
+
 if [ -d "${ANDROID_SDK_DIR}"/build-tools/"${ANDROID_BUILD_TOOLS_VERSION}" ]
 then
   echo "Not installing Android SDK, because ${ANDROID_SDK_DIR}/build-tools/${ANDROID_BUILD_TOOLS_VERSION} exists already"


### PR DESCRIPTION

<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------

As title says, prevent manually running the script incorrectly

