### PR TITLE
hide mouse cursor after 10 seconds of inactivity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ The following people and organizations have contributed code to XCSoar:
  Keith Laidlaw <laidlaw1546@gmail.com>
  Tim Stuhler <thermalmap@stuhler.de>
  Dave Spragg <dave.spragg@gmail.com>
+ Remco Derksen <remco@viperlook.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,7 @@
 Version 7.40 - not yet released
-
+* user interface
+  - hide mouse cursor after 10 seconds of inactivity
+  
 Version 7.39 - 2023/07/28
 * Android
   - fix Bluetooth device list on Android versions older than 12

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -139,8 +139,8 @@ class TopWindow : public ContainerWindow {
 #ifdef DRAW_MOUSE_CURSOR
   uint8_t cursor_size = 1;
   bool invert_cursor_colors = false;
+  std::chrono::steady_clock::time_point cursor_visible_until = std::chrono::steady_clock::now();
 #endif
-
 #ifndef USE_WINUSER
   TopCanvas *screen = nullptr;
 

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -138,7 +138,8 @@ TopWindow::Expose() noexcept
     OnPaint(canvas);
 
 #ifdef DRAW_MOUSE_CURSOR
-    DrawMouseCursor(canvas);
+    if(cursor_visible_until > std::chrono::steady_clock::now())
+      DrawMouseCursor(canvas);
 #endif
 
     screen->Unlock();

--- a/src/ui/window/poll/TopWindow.cpp
+++ b/src/ui/window/poll/TopWindow.cpp
@@ -51,6 +51,7 @@ TopWindow::OnEvent(const Event &event)
 
   case Event::MOUSE_MOTION:
 #ifdef DRAW_MOUSE_CURSOR
+    cursor_visible_until = std::chrono::steady_clock::now() + std::chrono::seconds(10);
     /* redraw to update the mouse cursor position */
     Invalidate();
 #endif


### PR DESCRIPTION
Brief summary of the changes
----------------------------
On builds like OpenVario based on Cubieboard the rendering of a mouse cursor is enabled. But even when no mouse is attached the mouse cursor is rendered on screen. With this contribution the mouse cursor will be hidden when there is no mouse activity for 10 seconds. On the event of new mouse activity the mouse will be displayed again for 10 seconds.

Related issues and discussions
------------------------------
For now this is hardcoded for 10 seconds. It is open for debate if this is acceptable or a higher/lower value should be used. 
And if an extra settings should be introduced to let te user decide to use this feature or not.
