### PR TITLE
Infobox that combines ETA with AAT dT

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,6 +64,7 @@ The following people and organizations have contributed code to XCSoar:
  Keith Laidlaw <laidlaw1546@gmail.com>
  Tim Stuhler <thermalmap@stuhler.de>
  Dave Spragg <dave.spragg@gmail.com>
+ Jiri Maier <jiri.maier.x@gmail.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.40 - not yet released
+* user interface
+  - Added infobox that combines ETA with AAT dT
 
 Version 7.39 - 2023/07/28
 * Android

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1120,6 +1120,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxContentRPM,
   },
 
+  // e_AAT_dT_or_ETA
+  {
+    N_("AAT dT and task ETA"),
+    N_("AATdeltaOrETA"),
+    N_("Shows AAT delta time and estimated time of arrival in case of AAT task, and estimated time of arrival in case of racing task"),
+    UpdateInfoTaskETAorAATdT,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -927,3 +927,26 @@ InfoBoxContentNextArrow::OnCustomPaint(Canvas &canvas,
   NextArrowRenderer renderer(UIGlobals::GetLook().wind_arrow_info_box);
   renderer.DrawArrow(canvas, rc, bd);
 }
+
+/*
+ * This infobox shows either AAT dT + ETA, or only ETA depending on task type
+ */
+void
+UpdateInfoTaskETAorAATdT(InfoBoxData& data) noexcept
+{
+  const auto& calculated = CommonInterface::Calculated();
+  const TaskStats& task_stats = calculated.ordered_task_stats;
+
+  // Always call the ETA infobox function. If task is AAT, the value of
+  // ETA infobox will be used as the comment of AATdT infobox
+  UpdateInfoBoxFinalETA(data);
+  if (task_stats.has_targets) { // Is AAT
+    // save the HH:MM ETA to use it as a comment of AATdT infobox
+    auto eta_text = data.value;
+    UpdateInfoBoxTaskAATimeDelta(data);
+    data.SetComment(eta_text);
+
+    data.SetTitle(_T("AAT delta time"));
+  } else
+    data.SetTitle(_T("Task arrival time"));
+}

--- a/src/InfoBoxes/Content/Task.hpp
+++ b/src/InfoBoxes/Content/Task.hpp
@@ -134,3 +134,6 @@ public:
   void Update(InfoBoxData &data) noexcept override;
   void OnCustomPaint(Canvas &canvas, const PixelRect &rc) noexcept override;
 };
+
+void
+UpdateInfoTaskETAorAATdT(InfoBoxData &data) noexcept;

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -158,6 +158,8 @@ namespace InfoBoxFactory
     e_EngineEGT,  /* Engine Exhaust Gas Temperature */
     e_EngineRPM,  /* Engine Revolutions Per Minute */
 
+    e_AAT_dT_or_ETA, /* Delta time in AAT task and ETA in racing task */
+
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Added an infobox that shows ETA and Delta time during AAT task and only ETA in case of a racing task.
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Automatically replace AAT delta time infobox by something else for racing task #970
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
