### PR TITLE
Change order in which waypoint files are read

### DIFF
--- a/src/Waypoint/WaypointGlue.cpp
+++ b/src/Waypoint/WaypointGlue.cpp
@@ -76,10 +76,6 @@ LoadWaypoints(Waypoints &way_points, const RasterTerrain *terrain,
   // Delete old waypoints
   way_points.Clear();
 
-  LoadWaypointFile(way_points, LocalPath(_T("user.cup")),
-                   WaypointFileType::SEEYOU,
-                   WaypointOrigin::USER, terrain, progress);
-
   // ### FIRST FILE ###
   auto path = Profile::GetPath(ProfileKeys::WaypointFile);
   if (path != nullptr)
@@ -119,7 +115,10 @@ LoadWaypoints(Waypoints &way_points, const RasterTerrain *terrain,
                "Failed to load waypoints from map file");
     }
   }
-
+  //Load user.cup
+  LoadWaypointFile(way_points, LocalPath(_T("user.cup")),
+                   WaypointFileType::SEEYOU,
+                   WaypointOrigin::USER, terrain, progress);
   // Optimise the waypoint list after attaching new waypoints
   way_points.Optimise();
 


### PR DESCRIPTION
this closes issue #1122 because now markers will be last in the waypointlist meaning the id of the other waypoints does not change.


<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
Moved loading the user.cup file (which contains the markers) down to after all the other waypoint files have been read. 
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Closes #1122 
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
