### PR TITLE
update zlib to 1.3

### DIFF
--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -157,9 +157,9 @@ libsodium = AutotoolsProject(
 )
 
 zlib = ZlibProject(
-    'http://zlib.net/zlib-1.2.13.tar.xz',
-    'http://downloads.sourceforge.net/project/libpng/zlib/1.2.13/zlib-1.2.13.tar.xz',
-    'd14c38e313afc35a9a8760dadf26042f51ea0f5d154b0630a31da0540107fb98',
+    'http://zlib.net/zlib-1.3.tar.xz',
+    'https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.xz',
+    '8a9ba2898e1d0d774eca6ba5b4627a11e5588ba85c8851336eb38de4683050a7',
     'lib/libz.a',
 )
 


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
The zlib 1.2.13 is no longer available for download at the URLs defined in libs.py. Replaced by version 1.3
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------
Closes #1288
<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
