### PR TITLE
Fixed wrong method used to compare ballast liters

### DIFF
--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -120,8 +120,8 @@ ExternalSettings::EliminateRedundant(const ExternalSettings &other,
     ballast_overload_available.Clear();
 
   if (ballast_litres_available &&
-      other.CompareBallastOverload(ballast_litres) &&
-      !last.CompareBallastOverload(ballast_litres))
+      other.CompareBallastLitres(ballast_litres) &&
+      !last.CompareBallastLitres(ballast_litres))
     ballast_litres_available.Clear();
 
   if (wing_loading_available && other.CompareWingLoading(wing_loading) &&


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to XCSoar! Please read the
following information to make it easier for us to review your changes.

We appreciate if you make sure to:

  - Document the changes (in the NEWS.txt file, and the manual when relevant)
  - Enable maintainer edits[1] (in case we need to help with the PR)
  - Check your commits and their messages (so they're all tidy and coherent)

[1] https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->


Brief summary of the changes
----------------------------
CompareBallastOverload method was used on ballast_liters by mistake. This fixes it by using the CompareBallastLitres method.
<!--
Please note that the commit messages is where detailed descriptions of the
changes should be made - this section is just for a brief summary/overview.
-->


Related issues and discussions
------------------------------

<!--
Please link any relevant issues or forum posts here, for reference.

If this PR resolves an existing issue, please write "Closes #1234" so that
the issue is closed automatically when this PR is merged.
-->
