### PR TITLE
Add 100m Zoom option for Flarm Radar

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.40 - not yet released
+* Flarm Radar
+  - Add 100m zoom option.
 
 Version 7.39 - 2023/07/28
 * Android

--- a/src/Gauge/BigTrafficWidget.cpp
+++ b/src/Gauge/BigTrafficWidget.cpp
@@ -32,6 +32,7 @@ class FlarmTrafficControl : public FlarmTrafficWindow {
 protected:
   bool enable_auto_zoom = true, dragging = false;
   unsigned zoom = 2;
+  const unsigned num_zoom_options = 5;
   Angle task_direction = Angle::Degrees(-1);
   GestureManager gestures;
 
@@ -76,7 +77,7 @@ public:
   }
 
   bool CanZoomOut() const {
-    return zoom < 4;
+    return zoom < num_zoom_options;
   }
 
   bool CanZoomIn() const {
@@ -139,14 +140,16 @@ FlarmTrafficControl::GetZoomDistance(unsigned zoom)
 {
   switch (zoom) {
   case 0:
-    return 500;
+    return 100;
   case 1:
-    return 1000;
-  case 3:
-    return 5000;
-  case 4:
-    return 10000;
+    return 500;
   case 2:
+    return 1000;
+  case 4:
+    return 5000;
+  case 5:
+    return 10000;
+  case 3:
   default:
     return 2000;
   }
@@ -185,8 +188,8 @@ FlarmTrafficControl::CalcAutoZoom()
   }
 
   double zoom_dist2 = zoom_dist;
-  for (unsigned i = 0; i <= 4; i++) {
-    if (i == 4 || GetZoomDistance(i) >= zoom_dist2) {
+  for (unsigned i = 0; i <= num_zoom_options; i++) {
+    if (i == num_zoom_options || GetZoomDistance(i) >= zoom_dist2) {
       SetZoom(i);
       break;
     }
@@ -221,7 +224,7 @@ FlarmTrafficControl::ZoomOut()
   if (WarningMode())
     return;
 
-  if (zoom < 4)
+  if (zoom < num_zoom_options)
     SetZoom(zoom + 1);
 
   SetAutoZoom(false);


### PR DESCRIPTION
Add 100m Radius Flarm Radar Option:

-Makes it easier to Identify teammates and tag bandits during a grid squat.