### PR TITLE
Better flarm colours

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -26,6 +26,8 @@ Version 7.42 - 2024/03/01
   - new mountain pass and bridge icons
 * Android
   - update 'white list' of USB devices with more PIDs for SoftRF Academy
+*User interface
+  - FLARM: - Add option to show targets according to average climb rate "Colourful FLARM"
 
 Version 7.41 - 2023/12/21
 * data files
@@ -41,7 +43,6 @@ Version 7.41 - 2023/12/21
 Version 7.40 - 2023/11/02
 * user interface
   - Added infobox that combines ETA with AAT dT
-  - FLARM: Add 100m zoom option.
   - hide mouse cursor after 10 seconds of inactivity
   - Move glider icon on thermal assist according to 30s average.
 * Linux

--- a/build/main.mk
+++ b/build/main.mk
@@ -237,6 +237,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/FLARM/Computer.cpp \
 	$(SRC)/FLARM/Global.cpp \
 	$(SRC)/FLARM/Glue.cpp \
+	$(SRC)/FLARM/TrafficClimbAltIndicators.cpp \
 	$(SRC)/BallastDumpManager.cpp \
 	$(SRC)/Logger/Settings.cpp \
 	$(SRC)/Logger/Logger.cpp \

--- a/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
@@ -15,6 +15,7 @@ enum ControlIndex {
   DISPLAY_TRACK_BEARING,
   ENABLE_FLARM_MAP,
   FADE_TRAFFIC,
+  COLORFUL_TRAFFIC,
   TRAIL_LENGTH,
   TRAIL_DRIFT,
   TRAIL_TYPE,
@@ -141,6 +142,10 @@ SymbolsConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddBoolean(_("Fade traffic"), _("Keep showing traffic for a while after it has disappeared."),
              settings_map.fade_traffic);
 
+  AddBoolean(_("Colourful traffic"), _("Show traffic in different colours depending on the climb rate and relative altitude"),
+             settings_map.use_detailed_flarm_colours);
+  SetExpertRow(COLORFUL_TRAFFIC);
+
   AddEnum(_("Trail length"),
           _("Determines whether and how long a snail trail is drawn behind the glider."),
           trail_length_list,
@@ -200,6 +205,9 @@ SymbolsConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValue(FADE_TRAFFIC, ProfileKeys::FadeTraffic,
                        settings_map.fade_traffic);
+  
+  changed |= SaveValue(COLORFUL_TRAFFIC, ProfileKeys::ColorfulTraffic,
+                       settings_map.use_detailed_flarm_colours);
 
   changed |= SaveValueEnum(TRAIL_LENGTH, ProfileKeys::SnailTrail, settings_map.trail.length);
 

--- a/src/FLARM/TrafficClimbAltIndicators.cpp
+++ b/src/FLARM/TrafficClimbAltIndicators.cpp
@@ -1,0 +1,10 @@
+#include "FLARM/TrafficClimbAltIndicators.hpp"
+#include "Interface.hpp"
+
+TrafficClimbAltIndicators
+TrafficClimbAltIndicators::GetClimbAltIndicators(const FlarmTraffic &traffic) noexcept
+{
+   return GetClimbAltIndicators(traffic,
+                                CommonInterface::GetComputerSettings().polar.glide_polar_task.GetMC(),
+                                CommonInterface::Calculated().average);
+}

--- a/src/FLARM/TrafficClimbAltIndicators.hpp
+++ b/src/FLARM/TrafficClimbAltIndicators.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "FLARM/Traffic.hpp"
+#include <cstdint>
+
+class TrafficClimbAltIndicators
+{
+public:
+   TrafficClimbAltIndicators() noexcept
+       : climb(Climb::DOWN),
+         rel_alt(RelAlt::SAME)
+   {
+   }
+
+   static TrafficClimbAltIndicators
+   GetClimbAltIndicators(const FlarmTraffic &traffic) noexcept;
+
+   static TrafficClimbAltIndicators
+   GetClimbAltIndicators(const FlarmTraffic &traffic, const double set_mc,
+                         const double current_30s_vario) noexcept
+   {
+      TrafficClimbAltIndicators indicators;
+
+      const double reference_climb_rate = (set_mc > current_30s_vario) ? set_mc : current_30s_vario; // largest of the set mc or current 30s average vario.
+
+      if (traffic.climb_rate_avg30s >= reference_climb_rate)
+         indicators.climb = Climb::GOOD;
+      else if (traffic.climb_rate_avg30s > 0.0)
+         indicators.climb = Climb::UP;
+      else
+         indicators.climb = Climb::DOWN;
+
+      if (traffic.relative_altitude > (const RoughAltitude)similar_altitude_threshold_meters)
+         indicators.rel_alt = RelAlt::ABOVE;
+      else if (traffic.relative_altitude > (const RoughAltitude)-similar_altitude_threshold_meters)
+         indicators.rel_alt = RelAlt::SAME;
+      else
+         indicators.rel_alt = RelAlt::BELOW;
+
+      return indicators;
+   }
+
+   uint8_t get_climb_indicator() const noexcept { return (uint8_t)climb; }
+   uint8_t get_rel_alt_indicator() const noexcept { return (uint8_t)rel_alt; }
+
+   enum class Climb : uint8_t
+   {
+      GOOD,
+      UP,
+      DOWN,
+   };
+
+   enum class RelAlt : uint8_t
+   {
+      ABOVE,
+      SAME,
+      BELOW,
+   };
+
+private:
+   Climb climb;
+   RelAlt rel_alt;
+
+   static constexpr int similar_altitude_threshold_meters = 50;
+};

--- a/src/Look/TrafficLook.cpp
+++ b/src/Look/TrafficLook.cpp
@@ -13,12 +13,24 @@ constexpr Color TrafficLook::team_color_yellow;
 void
 TrafficLook::Initialise(const Font &_font)
 {
-  safe_above_brush.Create(safe_above_color);
-  safe_below_brush.Create(safe_below_color);
-  warning_brush.Create(warning_color);
-  warning_in_altitude_range_brush.Create(warning_in_altitude_range_color);
-  alarm_brush.Create(alarm_color);
+  colorful_traffic_brushes.above.climb_good.Create(colorful_traffic_colors::above::climb_good);
+  colorful_traffic_brushes.above.climb_up.Create(colorful_traffic_colors::above::climb_up);
+  colorful_traffic_brushes.above.climb_down.Create(colorful_traffic_colors::above::climb_down);
 
+  colorful_traffic_brushes.same.climb_good.Create(colorful_traffic_colors::same::climb_good);
+  colorful_traffic_brushes.same.climb_up.Create(colorful_traffic_colors::same::climb_up);
+  colorful_traffic_brushes.same.climb_down.Create(colorful_traffic_colors::same::climb_down);
+
+  colorful_traffic_brushes.below.climb_good.Create(colorful_traffic_colors::below::climb_good);
+  colorful_traffic_brushes.below.climb_up.Create(colorful_traffic_colors::below::climb_up);
+  colorful_traffic_brushes.below.climb_down.Create(colorful_traffic_colors::below::climb_down);
+
+  basic_traffic_brushes.above.Create(TrafficLookColor::above);
+  basic_traffic_brushes.same.Create(TrafficLookColor::same);
+  basic_traffic_brushes.below.Create(TrafficLookColor::below);
+
+  warning_brush.Create(warning_color);
+  alarm_brush.Create(alarm_color);
   fading_pen.Create(Pen::Style::DASH1, Layout::ScalePenWidth(1), fading_outline_color);
 
 #ifdef ENABLE_OPENGL
@@ -34,4 +46,36 @@ TrafficLook::Initialise(const Font &_font)
   teammate_icon.LoadResource(IDB_TEAMMATE_POS_ALL);
 
   font = &_font;
+}
+
+const Brush& TrafficLook::GetBasicTrafficBrush(const TrafficClimbAltIndicators &indicators) const noexcept
+{
+  switch (indicators.get_rel_alt_indicator()) 
+  {
+    case (int)TrafficClimbAltIndicators::RelAlt::ABOVE:
+      return basic_traffic_brushes.above;
+    case (int)TrafficClimbAltIndicators::RelAlt::SAME:
+      return basic_traffic_brushes.same;
+    case (int)TrafficClimbAltIndicators::RelAlt::BELOW:
+      return basic_traffic_brushes.below;
+    default:
+      return basic_traffic_brushes.same;
+  }
+}
+
+const Brush& TrafficLook::GetColourfulTrafficBrush(const TrafficClimbAltIndicators &indicators) const noexcept
+{
+  auto rel_alt_indicator = indicators.get_rel_alt_indicator();
+  auto climb_indicator = indicators.get_climb_indicator();
+
+  const Climb_Indication_t& climbBrushes = 
+      (rel_alt_indicator == (int)TrafficClimbAltIndicators::RelAlt::ABOVE) ? colorful_traffic_brushes.above :
+      (rel_alt_indicator == (int)TrafficClimbAltIndicators::RelAlt::SAME) ? colorful_traffic_brushes.same :
+      (rel_alt_indicator == (int)TrafficClimbAltIndicators::RelAlt::BELOW) ? colorful_traffic_brushes.below :
+      colorful_traffic_brushes.same; // default value
+
+  return (climb_indicator == (int)TrafficClimbAltIndicators::Climb::GOOD) ? climbBrushes.climb_good :
+          (climb_indicator == (int)TrafficClimbAltIndicators::Climb::UP) ? climbBrushes.climb_up :
+          (climb_indicator == (int)TrafficClimbAltIndicators::Climb::DOWN) ? climbBrushes.climb_down :
+          climbBrushes.climb_good; // default value
 }

--- a/src/Look/TrafficLook.hpp
+++ b/src/Look/TrafficLook.hpp
@@ -7,20 +7,68 @@
 #include "ui/canvas/Pen.hpp"
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Icon.hpp"
+#include "FLARM/TrafficClimbAltIndicators.hpp"
 
 class Font;
 
-struct TrafficLook {
-  static constexpr Color safe_above_color{0x1d,0x9b,0xc5};
-  static constexpr Color safe_below_color{0x1d,0xc5,0x10};
-  static constexpr Color warning_color{0xfe,0x84,0x38};
-  static constexpr Color warning_in_altitude_range_color{0xff,0x00,0xff};
-  static constexpr Color alarm_color{0xfb,0x35,0x2f};
+struct TrafficLook
+{
+  struct colorful_traffic_colors
+  {
+    struct above
+    {
+      static constexpr Color climb_good = {0xff, 0x66, 0x66}; // light red
+      static constexpr Color climb_up = {0xff, 0xff, 0x66};   // light yellow
+      static constexpr Color climb_down = {0x66, 0x66, 0xff}; // light blue
+    };
 
-  Brush safe_above_brush;
-  Brush safe_below_brush;
+    struct same
+    {
+      static constexpr Color climb_good = {0xff, 0x00, 0x00}; // red
+      static constexpr Color climb_up = {0xff, 0xff, 0x00};   // yellow
+      static constexpr Color climb_down = {0x00, 0x00, 0xff}; // blue
+    };
+
+    struct below
+    {
+      static constexpr Color climb_good = {0x99, 0x00, 0x00}; // dark red
+      static constexpr Color climb_up = {0x99, 0x99, 0x00};   // dark yellow
+      static constexpr Color climb_down = {0x00, 0x00, 0x99}; // dark blue
+    };
+  };
+
+  struct TrafficLookColor
+  {
+    static constexpr Color above = {0x1d, 0x9b, 0xc5};
+    static constexpr Color same = {0xff, 0x00, 0xff};
+    static constexpr Color below = {0x1d, 0xc5, 0x10};
+  };
+
+  static constexpr Color warning_color{0xfe, 0x84, 0x38};
+  static constexpr Color warning_in_altitude_range_color{0xff, 0x00, 0xff};
+  static constexpr Color alarm_color{0xfb, 0x35, 0x2f};
+
+  struct basic_traffic_brushes
+  {
+    Brush above;
+    Brush same;
+    Brush below;
+  } basic_traffic_brushes;
+
+  typedef struct Climb_Indication_s {
+      Brush climb_good;
+      Brush climb_up;
+      Brush climb_down;
+  }Climb_Indication_t;
+
+  struct colorful_traffic_brushes
+  {
+    Climb_Indication_t above;
+    Climb_Indication_t same;
+    Climb_Indication_t below;
+  } colorful_traffic_brushes;
+
   Brush warning_brush;
-  Brush warning_in_altitude_range_brush;
   Brush alarm_brush;
 
   static constexpr Color fading_outline_color = ColorWithAlpha({0x60, 0x60, 0x60}, 0xa0);
@@ -46,4 +94,7 @@ struct TrafficLook {
   const Font *font;
 
   void Initialise(const Font &font);
+
+  const Brush& GetBasicTrafficBrush(const TrafficClimbAltIndicators &indicators) const noexcept;
+  const Brush& GetColourfulTrafficBrush(const TrafficClimbAltIndicators &indicators) const noexcept;
 };

--- a/src/MapSettings.cpp
+++ b/src/MapSettings.cpp
@@ -42,6 +42,7 @@ MapSettings::SetDefaults() noexcept
   show_flarm_on_map = true;
   show_flarm_alarm_level = true;
   fade_traffic = true;
+  use_detailed_flarm_colours = false;
   show_thermal_profile = true;
   final_glide_bar_mc0_enabled = true;
   final_glide_bar_display_mode = FinalGlideBarDisplayMode::ON;

--- a/src/MapSettings.hpp
+++ b/src/MapSettings.hpp
@@ -161,6 +161,9 @@ struct MapSettings {
    */
   bool fade_traffic;
 
+  /** Show FLARM according to climb rate and relative altitude */
+  bool use_detailed_flarm_colours;
+
   /** Display climb band on map */
   bool show_thermal_profile;
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -143,6 +143,7 @@ constexpr std::string_view TerrainBrightness = "TerrainBrightness";
 constexpr std::string_view TerrainRamp = "TerrainRamp";
 constexpr std::string_view EnableFLARMMap = "EnableFLARMDisplay";
 constexpr std::string_view FadeTraffic = "FadeTraffic";
+constexpr std::string_view ColorfulTraffic = "ColorfulTraffic";
 constexpr std::string_view EnableFLARMGauge = "EnableFLARMGauge";
 constexpr std::string_view AutoCloseFlarmDialog = "AutoCloseFlarmDialog";
 constexpr std::string_view EnableTAGauge = "EnableTAGauge";

--- a/src/Profile/MapProfile.cpp
+++ b/src/Profile/MapProfile.cpp
@@ -115,7 +115,7 @@ Profile::Load(const ProfileMap &map, MapSettings &settings)
   map.GetEnum(ProfileKeys::MapShiftBias, settings.map_shift_bias);
   map.Get(ProfileKeys::EnableFLARMMap, settings.show_flarm_on_map);
   map.Get(ProfileKeys::FadeTraffic, settings.fade_traffic);
-
+  map.Get(ProfileKeys::ColorfulTraffic, settings.use_detailed_flarm_colours);
   map.Get(ProfileKeys::EnableThermalProfile, settings.show_thermal_profile);
   map.Get(ProfileKeys::EnableFinalGlideBarMC0,
           settings.final_glide_bar_mc0_enabled);

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -34,6 +34,7 @@
 #include "FLARM/List.hpp"
 #include "time/RoughTime.hpp"
 #include "time/BrokenDateTime.hpp"
+#include "FLARM/TrafficClimbAltIndicators.hpp"
 
 #ifdef HAVE_NOAA
 #include "Renderer/NOAAListRenderer.hpp"
@@ -301,7 +302,8 @@ Draw(Canvas &canvas, PixelRect rc,
      const TrafficMapItem &item,
      const TwoTextRowsRenderer &row_renderer,
      const TrafficLook &traffic_look,
-     const TrafficList *traffic_list)
+     const TrafficList *traffic_list,
+     const MapSettings &settings)
 {
   const unsigned line_height = rc.GetHeight();
   const unsigned text_padding = Layout::GetTextPadding();
@@ -312,11 +314,17 @@ Draw(Canvas &canvas, PixelRect rc,
 
   const PixelPoint pt(rc.left + line_height / 2, rc.top + line_height / 2);
 
+  bool colorful_traffic = settings.use_detailed_flarm_colours;
+
   // Render the representation of the traffic icon
   if (traffic != nullptr)
-    TrafficRenderer::Draw(canvas, traffic_look, false,
+  {
+    TrafficClimbAltIndicators climb_alt_ind = TrafficClimbAltIndicators::GetClimbAltIndicators(*traffic);
+
+    TrafficRenderer::Draw(canvas, traffic_look, false, colorful_traffic,
                           *traffic, traffic->track,
-                          item.color, pt);
+                          item.color, pt, climb_alt_ind) ;
+  }
 
   rc.left += line_height + text_padding;
 
@@ -467,7 +475,7 @@ MapItemListRenderer::Draw(Canvas &canvas, const PixelRect rc,
 
   case MapItem::Type::TRAFFIC:
     ::Draw(canvas, rc, (const TrafficMapItem &)item,
-           row_renderer, traffic_look, traffic_list);
+           row_renderer, traffic_look, traffic_list, settings);
     break;
 
 #ifdef HAVE_SKYLINES_TRACKING

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -17,9 +17,10 @@
 
 void
 TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
-                      bool fading,
+                      bool fading, bool colorful_traffic,
                       const FlarmTraffic &traffic, const Angle angle,
-                      const FlarmColor color, const PixelPoint pt) noexcept
+                      const FlarmColor color, const PixelPoint pt, 
+                      const TrafficClimbAltIndicators indicators) noexcept
 {
   // Create point array that will form that arrow polygon
   BulkPixelPoint arrow[] = {
@@ -49,7 +50,8 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
   } else {
     // Select brush depending on AlarmLevel
-    switch (traffic.alarm_level) {
+    switch (traffic.alarm_level)
+    {
     case FlarmTraffic::AlarmType::LOW:
     case FlarmTraffic::AlarmType::INFO_ALERT:
       canvas.Select(traffic_look.warning_brush);
@@ -59,12 +61,11 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
       canvas.Select(traffic_look.alarm_brush);
       break;
     case FlarmTraffic::AlarmType::NONE:
-      if (traffic.relative_altitude > (const RoughAltitude)50) {
-        canvas.Select(traffic_look.safe_above_brush);
-      } else if (traffic.relative_altitude > (const RoughAltitude)-50) {
-        canvas.Select(traffic_look.warning_in_altitude_range_brush);
+      if (colorful_traffic)
+      {
+        canvas.Select(traffic_look.GetColourfulTrafficBrush(indicators));
       } else {
-        canvas.Select(traffic_look.safe_below_brush);
+        canvas.Select(traffic_look.GetBasicTrafficBrush(indicators));
       }
       break;
     }
@@ -112,7 +113,7 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     { 0, 3 },
   };
 
-  canvas.Select(traffic_look.safe_above_brush);
+  canvas.Select(traffic_look.basic_traffic_brushes.same);
 
   // Select black pen
   if (IsDithered())

--- a/src/Renderer/TrafficRenderer.hpp
+++ b/src/Renderer/TrafficRenderer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "FLARM/Color.hpp"
+#include "FLARM/TrafficClimbAltIndicators.hpp"
 
 struct PixelPoint;
 class Canvas;
@@ -16,11 +17,12 @@ namespace TrafficRenderer
 {
 void
 Draw(Canvas &canvas, const TrafficLook &traffic_look,
-     bool fading,
+     bool fading, bool colorful_traffic,
      const FlarmTraffic &traffic, Angle angle,
-     FlarmColor color, PixelPoint pt) noexcept;
-
-void
+     FlarmColor color, PixelPoint pt,
+     TrafficClimbAltIndicators indicators) noexcept;   
+     
+void 
 Draw(Canvas &canvas, const TrafficLook &traffic_look,
      const GliderLinkTraffic &traffic, Angle angle, PixelPoint pt) noexcept;
 }


### PR DESCRIPTION
This PR shows FLARM targets in different colors according to their FLARM rate. 30s climb rates are compared to the largest between 30s average or set MC. 

Red = climbing well (better than your 30s average/ MC)
Yellow = Climbing ok (worse than your 30s average/ MC but still climbing)
Blue = not climbing

light colours = >50 above
normal colours = same level
dark colours = >50m below

Potentially too confusing for most users, but also very powerful for comp pilots. I have been flying with it for a few comps, the main advantages are: 

1) Bubble awareness -> Are gliders climbing better above or below? should you wait for that next pulse to hit?
2) spread of gliders -> who's climbing the best? are you in the best bit? who is actually climbing vs. circling? See if gaggles are centered, and guess where the core is before even getting there.
3) Next thermal -> are they out-climbing you? will you connect when you get there (are they at your level)?
4) Final glide -> Are gliders ahead pulling up in lift?