### PR TITLE
Lxnav list fix

### DIFF
--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -205,7 +205,12 @@ Nano::ReadFlightList(Port &port, RecordedFlightList &flight_list,
 
   env.SetProgressRange(nflights);
 
-  unsigned requested_tail = 1;
+  /* Start download at first flight in logger if capacity of flight_list is
+     enough for all flights in logger. Otherwise, calculate the starting
+     point to fill flight_list to capacity with only the latest flights. */
+  unsigned requested_tail = (unsigned) std::max(1,
+                     (signed) nflights - (signed) flight_list.max_size() + 1);
+
   while (true) {
     const unsigned room = flight_list.max_size() - flight_list.size();
     const unsigned remaining = nflights - requested_tail + 1;

--- a/src/Device/RecordedFlight.hpp
+++ b/src/Device/RecordedFlight.hpp
@@ -51,5 +51,5 @@ struct RecordedFlightInfo : FlightInfo {
   } internal;
 };
 
-class RecordedFlightList : public StaticArray<RecordedFlightInfo, 512u> {
+class RecordedFlightList : public StaticArray<RecordedFlightInfo, 128u> {
 };

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -274,6 +274,9 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
     return;
   }
 
+  /* Reverse flight list so that most recent flights are shown first */
+  std::reverse(flight_list.begin(),flight_list.end());
+
   const auto logs_path = MakeLocalPath(_T("logs"));
 
   while (true) {


### PR DESCRIPTION
Brief summary of the changes
----------------------------

- Display the latest 128 flights in the flight download dialog for LXNav devices, instead of the 512 oldest ones
- Display the list with newest additions first so you do not have to scroll down to the latest flight


Related issues and discussions
------------------------------

Closes #1237 
(this time for good, I hope)

I made the functional test (with an actual lx device) based on version 7.36, and have since rebased to 7.39 for the PR (still compiles and runs, but have not had access to logger since). Hope that is OK,

List reversal happens in driver rather than in UI as different devices/manufacturers might deliver flight lists in different orders.
