### PR TITLE
Android: update android:targetSdkVersion to 33

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -77,7 +77,7 @@
 
   </application>
 
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31"/>
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33"/>
 
   <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
                    android:usesPermissionFlags="neverForLocation"/>

--- a/android/testing/AndroidManifest.xml
+++ b/android/testing/AndroidManifest.xml
@@ -76,7 +76,7 @@
     </provider>
   </application>
 
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31"/>
+  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="33"/>
 
   <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
                    android:usesPermissionFlags="neverForLocation"/>

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -163,7 +163,7 @@ Compiling for Android
 
 For Android, you need:
 
-- `Android SDK level 32 <http://developer.android.com/sdk/>`__
+- `Android SDK level 33 <http://developer.android.com/sdk/>`__
 
 - `Android NDK r26-beta1 <http://developer.android.com/sdk/ndk/>`__
 


### PR DESCRIPTION
Google enforce android-33 now. We won't be able to upload APK version without this. https://developer.android.com/google/play/requirements/target-sdk
https://developer.android.com/about/versions/13/behavior-changes-13

Some dependency is already updated in https://github.com/XCSoar/XCSoar/commit/db34adf9bd4e85d1023098ba0592d2420cb2bafc, but not Manifest file. 

I tested in my fork and it's working fine in my Pixel 7 Pro.