### PR TITLE
thermal assistant icon position based on 30s avg

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,7 @@ Version 7.40 - not yet released
   - Added infobox that combines ETA with AAT dT
   - FLARM: Add 100m zoom option.
   - hide mouse cursor after 10 seconds of inactivity
+  - Move glider icon on thermal assist according to 30s average.
 * Linux
   - fix the /etc/xcsoar data directory
 * Android

--- a/src/Gauge/ThermalAssistantRenderer.cpp
+++ b/src/Gauge/ThermalAssistantRenderer.cpp
@@ -88,6 +88,25 @@ ThermalAssistantRenderer::NormalizeLift(double lift, double max_lift)
   return std::clamp(lift, 0., 1.);
 }
 
+static void
+DrawCircleLabel(Canvas &canvas, PixelPoint p,
+                tstring_view text) noexcept
+{
+  const auto size = canvas.CalcTextSize(text);
+  p.x -= size.width / 2;
+  p.y -= size.height * 3 / 4;
+
+  canvas.DrawText(p, text);
+}
+
+static void
+DrawCircleLabelVSpeed(Canvas &canvas, PixelPoint p, double value) noexcept
+{
+  TCHAR buffer[10];
+  FormatUserVerticalSpeed(value, buffer, ARRAY_SIZE(buffer));
+  DrawCircleLabel(canvas, p, buffer);
+}
+
 void
 ThermalAssistantRenderer::PaintRadarPlane(Canvas &canvas) const
 {
@@ -106,25 +125,6 @@ ThermalAssistantRenderer::PaintRadarPlane(Canvas &canvas) const
                        +Layout::FastScale(small ? 2 : 4)),
                   p.At(-Layout::FastScale(small ? 2 : 4),
                        +Layout::FastScale(small ? 2 : 4)));
-}
-
-static void
-DrawCircleLabel(Canvas &canvas, PixelPoint p,
-                tstring_view text) noexcept
-{
-  const auto size = canvas.CalcTextSize(text);
-  p.x -= size.width / 2;
-  p.y -= size.height * 3 / 4;
-
-  canvas.DrawText(p, text);
-}
-
-static void
-DrawCircleLabelVSpeed(Canvas &canvas, PixelPoint p, double value) noexcept
-{
-  TCHAR buffer[10];
-  FormatUserVerticalSpeed(value, buffer, ARRAY_SIZE(buffer));
-  DrawCircleLabel(canvas, p, buffer);
 }
 
 void

--- a/src/Gauge/ThermalAssistantRenderer.cpp
+++ b/src/Gauge/ThermalAssistantRenderer.cpp
@@ -108,11 +108,13 @@ DrawCircleLabelVSpeed(Canvas &canvas, PixelPoint p, double value) noexcept
 }
 
 void
-ThermalAssistantRenderer::PaintRadarPlane(Canvas &canvas) const
+ThermalAssistantRenderer::PaintRadarPlane(Canvas &canvas, double max_lift) const
 {
+  int normalised_average = NormalizeLift(vario.average, max_lift) * radius;
+
   canvas.Select(look.plane_pen);
 
-  PixelPoint p = mid.At(circling.TurningLeft() ? (int)radius : (int)-radius,
+  PixelPoint p = mid.At(circling.TurningLeft() ? normalised_average : -normalised_average,
                         0);
 
   canvas.DrawLine(p.At(+Layout::FastScale(small ? 5 : 10),
@@ -209,5 +211,5 @@ ThermalAssistantRenderer::Paint(Canvas &canvas)
   PaintPoints(canvas, lift_points);
   PaintAdvisor(canvas, lift_points);
 
-  PaintRadarPlane(canvas);
+  PaintRadarPlane(canvas,max_lift);
 }

--- a/src/Gauge/ThermalAssistantRenderer.hpp
+++ b/src/Gauge/ThermalAssistantRenderer.hpp
@@ -80,7 +80,7 @@ protected:
 
   void CalculateLiftPoints(LiftPoints &lift_points, double max_lift) const;
   double CalculateMaxLift() const;
-  void PaintRadarPlane(Canvas &canvas) const;
+  void PaintRadarPlane(Canvas &canvas, double max_lift) const;
   void PaintRadarBackground(Canvas &canvas, double max_lift) const;
   void PaintPoints(Canvas &canvas, const LiftPoints &lift_points) const;
   void PaintAdvisor(Canvas &canvas, const LiftPoints &lift_points) const;


### PR DESCRIPTION
Adjust the position of the glider icon in the thermal assistant according to the vario average. makes the thermal assistant more intuitive to use. 