### PR TITLE
Csv newlines

### DIFF
--- a/build/libio.mk
+++ b/build/libio.mk
@@ -11,6 +11,7 @@ IO_SOURCES = \
 	$(IO_SRC_DIR)/MemoryReader.cxx \
 	$(IO_SRC_DIR)/BufferedReader.cxx \
 	$(IO_SRC_DIR)/BufferedLineReader.cpp \
+	$(IO_SRC_DIR)/BufferedCsvReader.cpp \
 	$(IO_SRC_DIR)/FileDescriptor.cxx \
 	$(IO_SRC_DIR)/FileMapping.cpp \
 	$(IO_SRC_DIR)/FileReader.cxx \

--- a/build/libwaypointfile.mk
+++ b/build/libwaypointfile.mk
@@ -9,6 +9,6 @@ WAYPOINTFILE_SOURCES = \
 	$(SRC)/Waypoint/WaypointFileType.cpp \
 	$(SRC)/Waypoint/WaypointReader.cpp
 
-WAYPOINTFILE_DEPENDS = WAYPOINT CUPFILE UNITS
+WAYPOINTFILE_DEPENDS = WAYPOINT CUPFILE UNITS IO
 
 $(eval $(call link-library,libwaypointfile,WAYPOINTFILE))

--- a/src/Task/TaskFileSeeYou.cpp
+++ b/src/Task/TaskFileSeeYou.cpp
@@ -3,7 +3,9 @@
 
 #include "Task/TaskFileSeeYou.hpp"
 #include "io/BufferedReader.hxx"
+#include "io/BufferedCsvReader.hpp"
 #include "io/FileReader.hxx"
+#include "io/StringConverter.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
 #include "Waypoint/CupParser.hpp"
 #include "Waypoint/WaypointReaderSeeYou.hpp"
@@ -425,18 +427,8 @@ static bool
 ParseSeeYouWaypoints(BufferedReader &reader, Waypoints &way_points)
 {
   const WaypointFactory factory(WaypointOrigin::NONE);
-  WaypointReaderSeeYou waypoint_file(factory);
 
-  while (true) {
-    char *line = reader.ReadLine();
-    if (line == nullptr)
-      return false;
-
-    if (StringIsEqualIgnoreCase(line, "-----Related Tasks-----"))
-      return true;
-
-    waypoint_file.ParseLine(line, way_points);
-  }
+  return ParseSeeYou(factory, way_points, reader);
 }
 
 static char *

--- a/src/Waypoint/WaypointReader.cpp
+++ b/src/Waypoint/WaypointReader.cpp
@@ -28,7 +28,7 @@ CreateWaypointReader(WaypointFileType type, WaypointFactory factory)
     return new WaypointReaderWinPilot(factory);
 
   case WaypointFileType::SEEYOU:
-    return new WaypointReaderSeeYou(factory);
+    break;
 
   case WaypointFileType::ZANDER:
     return new WaypointReaderZander(factory);
@@ -56,6 +56,9 @@ ReadWaypointFile(Reader &file_reader, WaypointFileType file_type,
   BufferedReader buffered_reader{progress_reader};
 
   switch (file_type) {
+  case WaypointFileType::SEEYOU:
+    ParseSeeYou(factory, way_points, buffered_reader);
+    break;
   default:
     std::unique_ptr<WaypointReaderBase> reader { CreateWaypointReader(file_type,
                                                                       factory) };

--- a/src/Waypoint/WaypointReaderSeeYou.hpp
+++ b/src/Waypoint/WaypointReaderSeeYou.hpp
@@ -3,30 +3,15 @@
 
 #pragma once
 
-#include "WaypointReaderBase.hpp"
-#include "io/StringConverter.hpp"
+#include "Factory.hpp"
+
+class Waypoints;
+class BufferedReader;
 
 /**
- * Parses a SeeYou waypoint file.
+ * @return true if the "Related Tasks" line was found, false if the
+ * file contains no task
  *
- * @see http://data.naviter.si/docs/cup_format.pdf
+ * Throws on error.
  */
-class WaypointReaderSeeYou final : public WaypointReaderBase {
-  StringConverter string_converter;
-
-  bool first = true;
-
-  bool ignore_following = false;
-
-private:
-  /* field positions for typical SeeYou *.cup waypoint file */
-  unsigned iFrequency = 9;
-  unsigned iDescription = 10;
-
-public:
-  explicit WaypointReaderSeeYou(WaypointFactory _factory)
-    :WaypointReaderBase(_factory) {}
-
-  /* virtual methods from class WaypointReaderBase */
-  bool ParseLine(const char *line, Waypoints &way_points) override;
-};
+bool ParseSeeYou(WaypointFactory factory, Waypoints &waypoints, BufferedReader &reader);

--- a/src/io/BufferedCsvReader.cpp
+++ b/src/io/BufferedCsvReader.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BufferedCsvReader.hpp"
+
+#include <vector>
+#include <optional>
+#include <stdexcept>
+
+size_t
+ReadCsvRecord(BufferedReader &reader, std::span<std::string_view> views) {
+
+  bool prior_return  { false };
+  bool prior_quote { false };    // Used to disables double quote on start quote too
+
+  bool field_quoted { false };
+
+  size_t fields_parsed { 0 };
+
+  size_t input_offset { 0 };
+  size_t input_shift { 0 };
+  const std::byte *field_start { nullptr };  // Set on for sure start
+  const std::byte *field_end { nullptr };    // Set on possible end
+
+  std::span<std::byte> input;
+  std::byte *input_data_prev { nullptr };
+  char input_char { 0 };         // Always initialized if used, but keep compiler happy
+
+  // Reader data available
+  while (true) {
+    // Get input and shift pointers if required
+    input = reader.Read();
+
+    if ( input.data() != input_data_prev ) {
+      if ( field_start )
+        field_start = &input[field_start - input_data_prev];
+
+      if ( field_end )
+        field_end = &input[field_end - input_data_prev];
+
+      for ( auto &view : views.subspan(0,fields_parsed) )
+        view = std::string_view(reinterpret_cast<const char*>
+                                (&input[reinterpret_cast<const std::byte*>(view.data()) - input_data_prev]),
+                                view.size());
+
+      input_data_prev = input.data();
+    }
+
+    // Parse input chunk up to end of record
+    while ( input_offset < input.size() ) {
+      input_char = std::to_integer<char>(input[input_offset]);
+
+      // DOS newline and quoted double quote reduction
+      input_shift += ( ( prior_return && input_char == '\n' ) ||
+                       ( prior_quote  && input_char == '"' ) );
+      if ( input_shift )
+        input[input_offset-input_shift] = input[input_offset];
+
+      // Start tagging (set prior_quote so starting quote can't double quote)
+      if ( !field_start && input_char != ' ' ) {
+        field_quoted = prior_quote = input_char == '"';
+        field_start = &input[input_offset - input_shift + field_quoted];
+      }
+
+      // End tagging
+      if ( field_start && !field_end &&
+           ( ( !field_quoted && ( input_char == ' ' || input_char == ',' ||
+                                  input_char == '\n' ) ) ||
+             ( field_quoted  && !prior_quote && input_char == '"' ) ) )
+        // Maybe end
+        field_end = &input[input_offset - input_shift];
+
+      else if ( field_end && ( input_char != ' '  && input_char != ','  &&
+                               input_char != '\r' && input_char != '\n' ) )
+        // Not end
+        field_end = nullptr;
+
+      // Potential DOS newline and quoted double quote
+      prior_return = input_char == '\r';
+      prior_quote = field_quoted && !prior_quote && input_char == '"';
+
+      // Next character
+      ++input_offset;
+
+      // End of field
+      if ( field_end && input_char == ',' ) {
+        // Viems for field (relative to nullptr for now as reader.Fill can shift data)
+        if (fields_parsed < views.size())
+          views[fields_parsed] = std::string_view(reinterpret_cast<const char*>(field_start),
+                                                  field_end - field_start);
+        ++fields_parsed;
+
+        // Next field
+        input_shift = 0;
+        field_start = nullptr;
+        field_end = nullptr;
+      }
+
+      // Record end
+      if ( field_end && input_char == '\n' )
+        break;
+    }
+
+    // Handle end of record or input (queues more input on the side if end of input)
+    if ( (field_end && input_char == '\n') || !reader.Fill(true) ) {
+      // End of file in quotes
+      if ( field_quoted && !field_end )
+        throw std::runtime_error{"CSV file ended in middle of quoted field"};
+
+      // Start tagging (use input.data() as length may be 0)
+      if ( !field_start )
+        field_start = input.data() + (input_offset - input_shift);
+
+      // End tagging (use input.data() as length may be 0)
+      if ( !field_end )
+        field_end = input.data() + (input_offset - input_shift);
+
+      break;
+    }
+  }
+
+  // End of field
+  if ( input_offset && fields_parsed < views.size() ) {
+    views[fields_parsed] = std::string_view(reinterpret_cast<const char*>(field_start),
+                                            field_end - field_start);
+    ++fields_parsed;
+  }
+
+  // Zero remaining views (use input.data() as length may be 0)
+  for ( auto &view : views.last( views.size() - std::min(fields_parsed,views.size()) ) )
+    view = std::string_view(reinterpret_cast<char*>(input.data()) + (input_offset - input_shift), 0);
+
+  // Consume characters
+  reader.Consume(input_offset);
+
+  // Return fields parsed
+  return fields_parsed;
+}

--- a/src/io/BufferedCsvReader.hpp
+++ b/src/io/BufferedCsvReader.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "io/BufferedReader.hxx"
+
+#include <span>
+#include <optional>
+#include <string_view>
+
+/**
+ * Read one record from the CSV file and fills `columns` with pointers to the (unquoted) values of each column.
+ *
+ * @return the number of columns
+ *
+ * @see RFC 4180
+ */
+
+size_t
+ReadCsvRecord(BufferedReader &reader, std::span<std::string_view> columns);


### PR DESCRIPTION
Technically the CSV standard lets you have newlines inside quoted items.

Adding support for this makes some minimal layout formatting of desc and user fields possible, which make them a lot easier to digest at a glance.

Here is an example of using the decs field for multi-line data

![image](https://github.com/XCSoar/XCSoar/assets/787843/b9e70973-f8c9-44ba-889b-2ca3c7e4ae55)
