### PR TITLE
External logger flight download: Reverse flight list

### DIFF
--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -274,6 +274,9 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
     return;
   }
 
+  /* Reverse flight list so that most recent flights are shown first */
+  std::reverse(flight_list.begin(),flight_list.end());
+
   const auto logs_path = MakeLocalPath(_T("logs"));
 
   while (true) {


### PR DESCRIPTION
This PR reverses the list of flights available in an external logger such as Flarm, Nano, or LX Nav and LX Navigation devices. These typically show up with the oldest flights first on the list, as opposed to the typical way they are displayed, e.g. in the device screen.
By reversing the list scrolling and searching for the latest flight is usually not necessary any more.

Further discussion in #1296 - In that older PR the current implementation (in the UI) was present but not tested on an actual device in a glider. In this version, the commit has been fully tested on the current version of the Master branch.
