### PR TITLE
build/python/libs: fix build error for Android due to CURL 8.4.

### DIFF
--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -224,6 +224,7 @@ curl = CmakeProject(
         '-DCURL_DISABLE_IMAP=ON',
         '-DCMAKE_USE_LIBSSH2=OFF',
         '-DBUILD_TESTING=OFF',
+        '-DHAVE_FSEEKO=0',
     ],
     windows_configure_args=[
         '-DCURL_USE_SCHANNEL=ON',


### PR DESCRIPTION
After upgrading to CURL 8.4, the Android build was broken:
```
 /home/runner/work/XCSoar/XCSoar/output/src/curl-8.4.0/lib/formdata.c:796:10: error: call to undeclared function 'fseeko'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  return fseeko(stream, (off_t)offset, whence);
         ^
```
This PR will fix it.

Build with:
`  make -j$(nproc) TARGET=ANDROID`