### PR TITLE
Topography/shapelib/mapserver-config: functions strlcpy and strlcat  have been added to glibc version 2.38

### DIFF
--- a/src/Topography/shapelib/mapserver-config.h
+++ b/src/Topography/shapelib/mapserver-config.h
@@ -9,7 +9,8 @@
 #define HAVE_STRCASESTR 1
 #define HAVE_STRDUP 1
 
-#if !defined(__GLIBC__) && !defined(_WIN32)
+#if (!defined(__GLIBC__) || (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 38))) \
+  && !defined(_WIN32)
 #define HAVE_STRLCAT 1
 #define HAVE_STRLCPY 1
 #endif


### PR DESCRIPTION
The functions strlcpy and strlcat have been added to glibc 2.38. This pull request reflects these changes. 
XCSoar can now be built on Linux box with gcc 13.2.0


