### PR TITLE
Kobo: fix Wifi connection status not visible

### DIFF
--- a/src/Kobo/WPASupplicant.cpp
+++ b/src/Kobo/WPASupplicant.cpp
@@ -73,9 +73,9 @@ ParseStatusLine(WifiStatus &status, std::string_view src) noexcept
   if (value.data() == nullptr)
     return false;
 
-  if (src == "bssid"sv)
+  if (name == "bssid"sv)
     status.bssid = value;
-  else if (src == "ssid"sv)
+  else if (name == "ssid"sv)
     status.ssid = value;
   return true;
 }

--- a/src/Kobo/WPASupplicant.cpp
+++ b/src/Kobo/WPASupplicant.cpp
@@ -136,8 +136,9 @@ ParseScanResultsLine(WifiVisibleNetwork &dest, std::string_view line) noexcept
 
   dest.bssid = bssid;
 
-  if (const auto value = ParseInteger<unsigned>(signal_level))
-    dest.signal_level = *value;
+  if (const auto value = ParseInteger<signed>(signal_level))
+    // TODO: The signal level is in decibels (dBm), we should treat it that way
+    dest.signal_level = std::abs(*value);
   else
     return false;
 


### PR DESCRIPTION
This PR fixes the issue where the WiFi connection status is not visible on KOBO.

Closes #1309