### PR TITLE
RadioFrequency: ignore unit ("MHz") in Parse(std::string_view)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,8 @@ Version 7.42 - not yet released
   - fix bogus "Latin-1 to UTF-8 conversion failed" error
 * Kobo
   - Wifi setup, display signal level in dBm for new models
+* Windows
+  - fix reading of radio frequency with MHz in the openAir file
 
 Version 7.41 - 2023/12/21
 * data files

--- a/src/RadioFrequency.cpp
+++ b/src/RadioFrequency.cpp
@@ -7,6 +7,7 @@
 #include "util/DecimalParser.hxx"
 #include "util/StringFormat.hpp"
 #include "util/NumberParser.hpp"
+#include "util/StringSplit.hxx"
 
 TCHAR *
 RadioFrequency::Format(TCHAR *buffer, size_t max_size) const noexcept
@@ -41,8 +42,9 @@ RadioFrequency
 RadioFrequency::Parse(std::string_view src) noexcept
 {
   double mhz;
+  const auto [val, _] = Split(src, ' ');
 
-  if (auto value = ParseDecimal(src))
+  if (auto value = ParseDecimal(val))
     mhz = *value;
   else
     return Null();

--- a/src/RadioFrequency.cpp
+++ b/src/RadioFrequency.cpp
@@ -24,21 +24,6 @@ RadioFrequency::Format(TCHAR *buffer, size_t max_size) const noexcept
 }
 
 RadioFrequency
-RadioFrequency::Parse(const TCHAR *p) noexcept
-{
-  TCHAR *endptr;
-  double mhz = ParseDouble(p, &endptr);
-
-  RadioFrequency frequency;
-  if (mhz >= MIN_KHZ / 1000. && mhz <= MAX_KHZ / 1000. &&
-      IsWhitespaceOrNull(*endptr))
-    frequency.SetKiloHertz(uround(mhz * 1000));
-  else
-    frequency.Clear();
-  return frequency;
-}
-
-RadioFrequency
 RadioFrequency::Parse(std::string_view src) noexcept
 {
   double mhz;

--- a/src/RadioFrequency.hpp
+++ b/src/RadioFrequency.hpp
@@ -98,8 +98,5 @@ public:
   TCHAR *Format(TCHAR *buffer, size_t max_size) const noexcept;
 
   [[gnu::pure]]
-  static RadioFrequency Parse(const TCHAR *p) noexcept;
-
-  [[gnu::pure]]
   static RadioFrequency Parse(std::string_view src) noexcept;
 };


### PR DESCRIPTION
This PR fixes the reading of radio frequency with unit "MHz" in the openAir file on Windows os.

Fix for #1345 
