### PR TITLE
update 'white list' of USB devices with more PIDs for SoftRF Academy

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,8 @@ Version 7.42 - not yet released
   - Wifi setup, display signal level in dBm for new models
 * user interface
   - new mountain pass and bridge icons
+* Android
+  - update 'white list' of USB devices with more PIDs for SoftRF Academy
 
 Version 7.41 - 2023/12/21
 * data files

--- a/android/res/xml/usb_device_filter.xml
+++ b/android/res/xml/usb_device_filter.xml
@@ -8,6 +8,8 @@
   <usb-device vendor-id="1027" product-id="24597"/> <!-- Digifly AIR (FT X-Series)-->
   <usb-device vendor-id="1155" product-id="22336"/> <!-- SoftRF Dongle -->
   <usb-device vendor-id="9114" product-id="32809"/> <!-- SoftRF Badge -->
+  <usb-device vendor-id="9025" product-id="105"/> <!-- SoftRF Academy -->
+  <usb-device vendor-id="9025" product-id="4098"/> <!-- SoftRF Academy -->
   <usb-device vendor-id="9025" product-id="32845"/> <!-- SoftRF Academy -->
   <usb-device vendor-id="7504" product-id="24713"/> <!-- SoftRF ES -->
   <usb-device vendor-id="11914" product-id="10"/> <!-- SoftRF Lego -->

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -45,6 +45,8 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x0403, 0x6015), // Digifly AIR (FT X-Series)
     createDevice(0x0483, 0x5740), // SoftRF Dongle
     createDevice(0x239A, 0x8029), // SoftRF Badge
+    createDevice(0x2341, 0x0069), // SoftRF Academy
+    createDevice(0x2341, 0x1002), // SoftRF Academy
     createDevice(0x2341, 0x804d), // SoftRF Academy
     createDevice(0x1d50, 0x6089), // SoftRF ES
     createDevice(0x2e8a, 0x000a), // SoftRF Lego


### PR DESCRIPTION
Brief summary of the changes
----------------------------

add more USB VID/PID pairs for SoftRF Academy into (Android) 'white list' of USB devices