### PR TITLE
black text color in airspace list like all other systems

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.43 - not yet released
+* windows
+ - black text color in airspace list like all other systems
 * Kobo
   - fix Wifi configuration
 

--- a/src/Renderer/AirspacePreviewRenderer.cpp
+++ b/src/Renderer/AirspacePreviewRenderer.cpp
@@ -84,6 +84,7 @@ AirspacePreviewRenderer::UnprepareFill([[maybe_unused]] Canvas &canvas)
 #ifdef ENABLE_OPENGL
   ::glDisable(GL_BLEND);
 #elif defined(USE_GDI)
+  canvas.SetTextColor(COLOR_BLACK);
   canvas.SetMixCopy();
 #endif
 }


### PR DESCRIPTION
black text color in airspace list like all other systems

- solving issue #1371
