### PR TITLE
NM distance and compass point in "what is there" dialog

### DIFF
--- a/src/Formatter/AngleFormatter.cpp
+++ b/src/Formatter/AngleFormatter.cpp
@@ -54,3 +54,25 @@ FormatVerticalAngleDelta(TCHAR *buffer, size_t size, Angle value)
   else
     _tcscpy(buffer, _T("--"));
 }
+
+void
+FormatBearingCompass(TCHAR *buffer, size_t size, unsigned angle, int level)
+{
+  assert(buffer != NULL);
+  assert (size >= 4 );
+
+  const TCHAR* table[3][16]={
+                            {"N","E","S","W"},
+                            {"N","NE","E","SE","S","SW","W","NW"},
+                            {"N","NNE","NE","ENE","E","ESE","SE","SSE",
+		             "S","SSW","SW","WSW","W","WNW","NW","NNW"}};
+
+_tcscpy(buffer, table[level][(int) (fmod((angle + 45/pow(2,level)),360 ) / 
+			                             (90/pow(2,level)))]);
+}
+
+void
+FormatBearingCompass(TCHAR *buffer, size_t size, Angle angle, int level)
+{
+  FormatBearingCompass(buffer, size, angle.AsBearing().Degrees(),level);
+}

--- a/src/Formatter/AngleFormatter.hpp
+++ b/src/Formatter/AngleFormatter.hpp
@@ -52,3 +52,37 @@ FormatAngleDelta(Angle value)
 
 void
 FormatVerticalAngleDelta(TCHAR *buffer, size_t size, Angle value);
+
+/**
+ * Format bearing as a point of the compass
+ *
+ * This formats a bearing or azimut to a point of the compass. The 4 cardinal
+ * points are complemented by 4 or 12 intermediate points according to the 
+ * level parameter.
+ *
+ * @param level number of intermediate compass points (0, 1 or 2).
+ */
+
+void
+FormatBearingCompass(TCHAR *buffer, size_t size, unsigned angle, int level);
+
+void
+FormatBearingCompass(TCHAR *buffer, size_t size, Angle angle, int level);
+
+[[gnu::const]]
+static inline BasicStringBuffer<TCHAR, 4>
+FormatBearingCompass(Angle value, int level)
+{
+  BasicStringBuffer<TCHAR, 4> buffer;
+  FormatBearingCompass(buffer.data(), buffer.capacity(), value, level);
+  return buffer;
+}
+
+[[gnu::const]]
+static inline BasicStringBuffer<TCHAR,4>
+FormatBearingCompass(unsigned value, int level)
+{
+  BasicStringBuffer<TCHAR, 4> buffer;
+  FormatBearingCompass(buffer.data(), buffer.capacity(), value, level);
+  return buffer;
+}

--- a/src/Formatter/Units.hpp
+++ b/src/Formatter/Units.hpp
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "Units/Unit.hpp"
+#include "util/StringBuffer.hxx"
+
 
 #include <tchar.h>
 
@@ -69,6 +71,16 @@ FormatRelativeAltitude(TCHAR *buffer, double value, Unit unit,
 void
 FormatDistance(TCHAR *buffer, double value, const Unit unit,
                bool include_unit = true, int precision = 0);
+
+[[gnu::const]]
+static inline auto
+FormatDistance(double value,  const Unit unit,
+               bool include_unit = true, int precision = 0) noexcept
+{
+  BasicStringBuffer<TCHAR, 32> buffer;
+  FormatDistance(buffer.data(),value, unit, include_unit, precision);
+  return buffer;
+}
 
 /**
  * Converts a distance into a formatted string using the smaller version

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -14,6 +14,7 @@
 #include "Renderer/WaypointListRenderer.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "Formatter/UserUnits.hpp"
+#include "Formatter/Units.hpp"
 #include "Formatter/UserGeoPointFormatter.hpp"
 #include "Formatter/TimeFormatter.hpp"
 #include "Formatter/LocalTimeFormatter.hpp"
@@ -55,11 +56,13 @@ Draw(Canvas &canvas, const PixelRect rc,
 {
   TCHAR info_buffer[256];
   if (item.vector.IsValid())
-    StringFormatUnsafe(info_buffer, _T("%s: %s, %s: %s"),
+    StringFormatUnsafe(info_buffer, _T("%s: %s (%s), %s: %s (%s)"),
                        _("Distance"),
                        FormatUserDistanceSmart(item.vector.distance).c_str(),
+                       FormatDistance(item.vector.distance,Unit::NAUTICAL_MILES).c_str(),
                        _("Direction"),
-                       FormatBearing(item.vector.bearing).c_str());
+                       FormatBearing(item.vector.bearing).c_str(),
+                       FormatBearingCompass(item.vector.bearing,2).c_str());
   else
     StringFormatUnsafe(info_buffer, _T("%s: %s, %s: %s"),
                        _("Distance"), _T("???"), _("Direction"), _T("???"));


### PR DESCRIPTION
This set of commits add the distance in nautical miles and the heading as a point of the compass to  the Map item dialog aka "what is there" dialog.
Mainly for ease of position reporting with ATC. There is a toolbox for that but I find it's wasting real estate for the occasional use.
