### PR TITLE
new infobox showing last turn average.

### DIFF
--- a/src/Computer/GlideComputerAirData.cpp
+++ b/src/Computer/GlideComputerAirData.cpp
@@ -37,7 +37,9 @@ GlideComputerAirData::ResetFlight(DerivedInfo &calculated,
   average_vario.Reset();
 
   lift_database_computer.Reset(calculated.lift_database,
-                               calculated.trace_history.CirclingAverage);
+                               calculated.trace_history.CirclingAverage,
+                               calculated.trace_history.TurnAverage);
+
   calculated.trace_history.circling_available.Clear();
 
   thermallocator.Reset();
@@ -119,6 +121,12 @@ GlideComputerAirData::ProcessVertical(const MoreData &basic,
   lift_database_computer.Compute(calculated.lift_database,
                                  calculated.trace_history.CirclingAverage,
                                  basic, calculated);
+
+  lift_database_computer.Compute(calculated.trace_history.turn_time,
+                                 calculated.trace_history.TurnAverage,
+                                 basic, calculated);
+
+
   calculated.trace_history.circling_available.Update(basic.clock);
 
   circling_computer.MaxHeightGain(basic, calculated.flight, calculated);

--- a/src/Computer/LiftDatabaseComputer.cpp
+++ b/src/Computer/LiftDatabaseComputer.cpp
@@ -8,24 +8,33 @@
 #include "NMEA/CirclingInfo.hpp"
 
 #include <algorithm> // for std::clamp()
+#include <numeric>
+#include <chrono>
 
 void
 LiftDatabaseComputer::Clear(LiftDatabase &lift_database,
                             TraceVariableHistory &circling_average_trace)
 {
   lift_database.Clear();
-
   circling_average_trace.clear();
 }
 
 void
+LiftDatabaseComputer::Clear(TraceVariableHistory &TurnAverage)
+{
+  TurnAverage.clear();
+}
+
+void
 LiftDatabaseComputer::Reset(LiftDatabase &lift_database,
-                            TraceVariableHistory &circling_average_trace)
+                            TraceVariableHistory &circling_average_trace,
+                            TraceVariableHistory &TurnAverage)
 {
   last_circling = false;
   last_heading = Angle::Zero();
 
   Clear(lift_database, circling_average_trace);
+  Clear(TurnAverage);
 }
 
 /**
@@ -108,4 +117,135 @@ LiftDatabaseComputer::Compute(LiftDatabase &lift_database,
 
   last_circling = circling_info.circling;
   last_heading = basic.attitude.heading;
+}
+
+void LiftDatabaseComputer::UpdateLastTurn(const Angle &current_heading,
+                                          double current_time,
+                                          double current_brutto_vario,
+                                          const Angle &smoothed_turn_rate)
+{
+  // Calculate heading delta
+  Angle heading_delta;
+  if (heading_buffer.empty())
+  {
+    heading_delta = Angle::Zero();
+  }
+  else
+  {
+    Angle last_heading = heading_buffer.back();
+    double delta = current_heading.Native() - last_heading.Native();
+    // Adjust delta to be between -pi and pi
+    if (delta > M_PI)
+    {
+      delta -= 2 * M_PI;
+    }
+    else if (delta < -M_PI)
+    {
+      delta += 2 * M_PI;
+    }
+    heading_delta = Angle::Native(delta); // Create Angle object directly
+  }
+
+  printf("current_heading = %f\n", current_heading.Degrees());
+  printf("heading_delta = %f\n", heading_delta.Degrees());
+
+  // Add current values to buffers
+  time_buffer.push_back(current_time);
+  heading_buffer.push_back(current_heading); // Store the current heading
+  heading_delta_buffer.push_back(heading_delta);
+  brutto_vario_buffer.push_back(current_brutto_vario);
+  smoothed_turn_rate_buffer.push_back(smoothed_turn_rate);
+
+ while (!time_buffer.empty() && (time_buffer.back() - time_buffer.front() > 40.0)) {
+    time_buffer.pop_front();
+    heading_delta_buffer.pop_front();
+    brutto_vario_buffer.pop_front();
+    smoothed_turn_rate_buffer.pop_front();
+    heading_buffer.pop_front();
+}
+
+  // Check if a full turn has been made
+  double total_heading_delta = std::accumulate(heading_delta_buffer.begin(), heading_delta_buffer.end(), Angle::Zero()).Degrees();
+  if (total_heading_delta >= 360.0 || total_heading_delta <= -360.0)
+  {
+
+    // Remove oldest values from buffers until less than a full turn remains
+    while (total_heading_delta >= 360.0 || total_heading_delta <= -360.0)
+    {
+      if(total_heading_delta >= 360.0)
+        total_heading_delta -= heading_delta_buffer.front().Degrees();
+      else
+        total_heading_delta += heading_delta_buffer.front().Degrees();
+
+      time_buffer.pop_front();
+      heading_delta_buffer.pop_front();
+      brutto_vario_buffer.pop_front();
+      smoothed_turn_rate_buffer.pop_front();
+      heading_buffer.pop_front();
+    }
+  }
+  else
+  {
+    while (!time_buffer.empty() && smoothed_turn_rate_buffer.front().Degrees() < 10 && (time_buffer.back() - time_buffer.front() > 8.0)) {
+    time_buffer.pop_front();
+    heading_delta_buffer.pop_front();
+    brutto_vario_buffer.pop_front();
+    smoothed_turn_rate_buffer.pop_front();
+    heading_buffer.pop_front();
+    }
+  }
+
+ double recent_heading_delta = 0.0;
+  for (auto it = time_buffer.rbegin(); it != time_buffer.rend() && *it > current_time - 5.0; ++it) {
+      size_t index = std::distance(it, time_buffer.rend()) - 1;
+      recent_heading_delta += heading_delta_buffer[index].Degrees();
+  }
+
+  // If the total heading delta is less than 20 degrees, clear the buffers to 8 seconds long
+  if (recent_heading_delta < 20.0) {
+      while (!time_buffer.empty() && (current_time - time_buffer.front() > 8.0)) {
+          time_buffer.pop_front();
+          heading_delta_buffer.pop_front();
+          brutto_vario_buffer.pop_front();
+          smoothed_turn_rate_buffer.pop_front();
+          heading_buffer.pop_front();
+      }
+  }
+
+  printf("smoothed_turn_rate = %f\n", smoothed_turn_rate.Degrees());
+  printf("total_heading_delta = %f\n", total_heading_delta);
+  printf("recent_heading_delta = %f\n", recent_heading_delta);
+}
+
+void LiftDatabaseComputer::Compute(int &turn_time,
+                                   TraceVariableHistory &TurnAverage,
+                                   const MoreData &basic,
+                                   const CirclingInfo &circling_info)
+{
+  // If we just started circling
+  // -> reset the database because this is a new thermal
+  if (!circling_info.circling && last_circling)
+  {
+    Clear(TurnAverage);
+    
+  }
+
+  Angle heading = basic.attitude.heading;
+
+  // Get current time in seconds
+  auto now = std::chrono::system_clock::now();
+  auto duration = now.time_since_epoch();
+  double current_time = std::chrono::duration<double>(duration).count();
+
+  UpdateLastTurn(heading, current_time, basic.brutto_vario, circling_info.turn_rate_heading_smoothed);
+
+  double last_turn_time = time_buffer.back() - time_buffer.front();
+  double average_brutto_vario = std::accumulate(brutto_vario_buffer.begin(), brutto_vario_buffer.end(), 0.0) / brutto_vario_buffer.size();
+
+  printf("time_buffer.size() = %d\n", time_buffer.size());
+  printf("last turn time = %f\n", last_turn_time);
+  printf("average brutto vario = %f\n", average_brutto_vario);
+
+  TurnAverage.push(average_brutto_vario);
+  turn_time = last_turn_time;
 }

--- a/src/Computer/LiftDatabaseComputer.hpp
+++ b/src/Computer/LiftDatabaseComputer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Math/Angle.hpp"
+#include <deque>
 
 struct MoreData;
 struct CirclingInfo;
@@ -18,6 +19,11 @@ class TraceVariableHistory;
  */
 class LiftDatabaseComputer {
   bool last_circling;
+  std::deque<double> time_buffer;
+  std::deque<Angle> heading_delta_buffer;
+  std::deque<double> brutto_vario_buffer;
+  std::deque<Angle> heading_buffer;
+  std::deque<Angle> smoothed_turn_rate_buffer;
 
   Angle last_heading;
 
@@ -27,14 +33,30 @@ class LiftDatabaseComputer {
   void Clear(LiftDatabase &lift_database,
              TraceVariableHistory &circling_average_trace);
 
+  void Clear(TraceVariableHistory &TurnAverage);
+
 public:
   /**
    * Reset this computer and clear the attributes.
    */
   void Reset(LiftDatabase &lift_database,
-             TraceVariableHistory &circling_average_trace);
+             TraceVariableHistory &circling_average_trace,
+             TraceVariableHistory &TurnAverage);
 
   void Compute(LiftDatabase &lift_database,
                TraceVariableHistory &circling_average_trace,
                const MoreData &basic, const CirclingInfo &circling_info);
+
+  void
+  Compute(int &turn_time,
+          TraceVariableHistory &TurnAverage,
+          const MoreData &basic,
+          const CirclingInfo &circling_info);
+
+private:
+  void
+  UpdateLastTurn(const Angle &current_heading,
+                 double current_time,
+                 double current_brutto_vario,
+                 const Angle &smoothed_turn_rate);
 };

--- a/src/Engine/Navigation/TraceHistory.hpp
+++ b/src/Engine/Navigation/TraceHistory.hpp
@@ -17,6 +17,9 @@ public:
   TraceVariableHistory BruttoVario;
   TraceVariableHistory NettoVario;
   TraceVariableHistory CirclingAverage;
+  TraceVariableHistory TurnAverage;
+
+  int turn_time;
 
   /**
    * Just time stamps describing when the fields above were last

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -137,6 +137,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxThermal30s,
   },
 
+  //e_Thermal_last_turn
+  {
+    N_("Thermal climb last turn"),
+    N_("TC last turn"),
+    N_("Block convolution average, with dynamic time constant according to the last turn."),
+    UpdateInfoBoxThermalTurnAvg,
+  },
+
   // e_Bearing
   {
     N_("Next bearing"),

--- a/src/InfoBoxes/Content/Thermal.cpp
+++ b/src/InfoBoxes/Content/Thermal.cpp
@@ -45,6 +45,18 @@ UpdateInfoBoxThermal30s(InfoBoxData &data) noexcept
   data.SetCommentFromVerticalSpeed(CommonInterface::Calculated().current_thermal.lift_rate);
 }
 
+void UpdateInfoBoxThermalTurnAvg(InfoBoxData &data) noexcept
+{
+  const auto& calculated = CommonInterface::Calculated();
+  if (calculated.trace_history.TurnAverage.empty()) {
+    data.SetInvalid();
+    return;
+  }
+
+  SetVSpeed(data, calculated.trace_history.TurnAverage.last());
+  data.SetCommentFromTimeSeconds(calculated.trace_history.turn_time);
+}
+
 void
 UpdateInfoBoxThermalLastAvg(InfoBoxData &data) noexcept
 {

--- a/src/InfoBoxes/Content/Thermal.hpp
+++ b/src/InfoBoxes/Content/Thermal.hpp
@@ -15,6 +15,9 @@ UpdateInfoBoxVarioNetto(InfoBoxData &data) noexcept;
 void
 UpdateInfoBoxThermal30s(InfoBoxData &data) noexcept;
 
+void 
+UpdateInfoBoxThermalTurnAvg(InfoBoxData &data) noexcept;
+
 void
 UpdateInfoBoxThermalLastAvg(InfoBoxData &data) noexcept;
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -10,6 +10,7 @@ namespace InfoBoxFactory
     e_HeightGPS, /* This is the height above mean sea level reported by the GPS. Touchscreen/PC only: in simulation mode, this value is adjustable with the up/down arrow keys and the right/left arrow keys also cause the glider to turn */
     e_HeightAGL, /* This is the navigation altitude minus the terrain height obtained from the terrain file. The value is coloured red when the glider is below the terrain safety clearance height */
     e_Thermal_30s, /* A 30 second rolling average climb rate based of the reported GPS altitude, or vario if available */
+    e_Thermal_last_turn, /* The average climb rate of the last thermal turn */
     e_Bearing, /* True bearing of the next waypoint.  For AAT tasks, this is the true bearing to the target within the AAT sector */
     e_GR_Instantaneous, /* Instantaneous glide ratio over ground, given by the ground speed divided by the vertical speed (GPS speed) over the last 20 seconds. Negative values indicate climbing cruise. If the vertical speed is close to zero, the displayed value is '---' */
     e_GR_Cruise, /* The distance from the top of the last thermal, divided by the altitude lost since the top of the last thermal. Negative values indicate climbing cruise (height gain since leaving the last thermal). If the vertical speed is close to zero, the displayed value is '---' */

--- a/src/InfoBoxes/Data.hpp
+++ b/src/InfoBoxes/Data.hpp
@@ -211,6 +211,10 @@ struct InfoBoxData {
   void SetCommentFromSpeed(double value, bool precision=true) noexcept;
 
   /**
+   * Set the InfoBox comment toa time in seconds
+   */
+  void SetCommentFromTimeSeconds(int dd) noexcept;
+  /**
    * Set the InfoBox comment to the specified task speed.
    */
   void SetCommentFromTaskSpeed(double value, bool precision=true) noexcept;

--- a/src/InfoBoxes/Format.cpp
+++ b/src/InfoBoxes/Format.cpp
@@ -61,6 +61,11 @@ InfoBoxData::SetCommentFromPercent(double dd) noexcept
   FmtComment(_T("{} %"), (int)(dd));
 }
 
+void  
+InfoBoxData::SetCommentFromTimeSeconds(int dd) noexcept{
+    FmtComment(_T("{} s"), (int)(dd));
+}
+
 void
 InfoBoxData::SetValueFromVoltage(double dd) noexcept
 {


### PR DESCRIPTION
This looks at the time to complete the last turn and then uses that time to calculate an average. This stops the aliasing that you get when in an uneven core, doing 20s turns. similar to clearnav.

thoughts on the idea?