### PR TITLE
Bug.md - split XCSoar versions having/not having the problem

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -17,14 +17,19 @@ Thanks for understanding, and for contributing to the project!
 -->
 
 
-XCSoar versions having and not having the problem
+XCSoar versions having the problem
 -------------------------------------------------
 
 <!--
 Which XCSoar version are you using when seeing the problem?
-Which XCSoar version is the last one you know that did not show the problem?
 -->
 
+XCSoar versions not having the problem
+-------------------------------------------------
+
+<!--
+Which XCSoar version is the last one you know that did not show the problem?
+-->
 
 System information
 ------------------


### PR DESCRIPTION
In case someone writes just one XCSoar version number, it's not really clear whether they're referring to a version having or not having the problem, if there's a joint category for "having and not having the problem".
