### PR TITLE
Dialog for setting user-defined frequencies

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1030,6 +1030,11 @@ event=Mode default
 label=Quick Guide
 location=9
 
+event=Frequencies
+event=Mode default
+label=Frequencies
+location=8
+
 # -------------
 # mode=Menu
 # -------------
@@ -1447,6 +1452,13 @@ event=Exit
 label=Quit XCSoar
 location=41
 
+mode=RemoteStick
+type=key
+data=0
+event=Frequencies
+label=Frequencies
+location=36
+
 # -------------
 # Define gesture to open Quickmenu without keyboard or remote
 # ("Draw a button on the screen")
@@ -1455,4 +1467,3 @@ location=41
 mode=default
 type=gesture
 data=ULDR
-event=QuickMenu

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -951,6 +951,14 @@ location=5
 mode=Info2
 type=key
 data=8
+event=Frequencies
+event=Mode default
+label=Frequencies
+location=6
+
+mode=Info2
+type=key
+data=8
 event=Setup Teamcode
 event=Mode default
 label=Team Code

--- a/build/datafield.mk
+++ b/build/datafield.mk
@@ -11,6 +11,7 @@ DATA_FIELD_SOURCES = \
 	$(DATA_FIELD_SRC_DIR)/MultiFile.cpp \
 	$(DATA_FIELD_SRC_DIR)/Number.cpp \
 	$(DATA_FIELD_SRC_DIR)/Float.cpp \
+	$(DATA_FIELD_SRC_DIR)/Frequency.cpp \
 	$(DATA_FIELD_SRC_DIR)/Angle.cpp \
 	$(DATA_FIELD_SRC_DIR)/GeoPoint.cpp \
 	$(DATA_FIELD_SRC_DIR)/RoughTime.cpp \

--- a/build/libwidget.mk
+++ b/build/libwidget.mk
@@ -26,6 +26,7 @@ WIDGET_SOURCES = \
 	$(SRC)/Widget/PagerWidget.cpp \
 	$(SRC)/Widget/ArrowPagerWidget.cpp \
 	$(SRC)/Widget/OffsetButtonsWidget.cpp \
+	$(SRC)/Widget/RadioEditWidget.cpp \
 	$(SRC)/Widget/ButtonPanelWidget.cpp \
 	$(SRC)/Widget/ButtonWidget.cpp \
 	$(SRC)/Widget/DrawWidget.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -65,6 +65,8 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Traffic/TeamCodeDialog.cpp \
 	$(SRC)/Dialogs/dlgAnalysis.cpp \
 	$(SRC)/Dialogs/dlgChecklist.cpp \
+	$(SRC)/Dialogs/Frequency/dlgUserFrequencyList.cpp \
+	$(SRC)/Dialogs/Frequency/dlgFrequencyEdit.cpp \
 	$(SRC)/Dialogs/ProfileListDialog.cpp \
 	$(SRC)/Dialogs/Plane/PlaneListDialog.cpp \
 	$(SRC)/Dialogs/Plane/PlaneDetailsDialog.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -19,6 +19,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/JobDialog.cpp \
 	$(SRC)/Dialogs/WidgetDialog.cpp \
 	$(SRC)/Dialogs/FileManager.cpp \
+    $(SRC)/Dialogs/RadioFrequencyEntry.cpp \
 	$(SRC)/Dialogs/Device/PortDataField.cpp \
 	$(SRC)/Dialogs/Device/PortPicker.cpp \
 	$(SRC)/Dialogs/Device/DeviceEditWidget.cpp \
@@ -42,6 +43,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Device/Vega/SwitchesDialog.cpp \
 	$(SRC)/Dialogs/Device/FLARM/ConfigWidget.cpp \
 	$(SRC)/Dialogs/Device/FLARM/RangeConfigWidget.cpp \
+	$(SRC)/Dialogs/Frequency/dlgFrequencyEdit.cpp \
 	$(SRC)/Dialogs/MapItemListDialog.cpp \
 	$(SRC)/Dialogs/MapItemListSettingsDialog.cpp \
 	$(SRC)/Dialogs/MapItemListSettingsPanel.cpp \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -271,6 +271,8 @@ Event list
      of the automatic radar display.
  * - ``FlarmTraffic``
    - Opens the full-screen FLARM traffic radar page.
+ * - ``Frequencies``
+   - Displays the frequency dialog
  * - ``GestureHelp``
    - Opens the gesture help dialog showing available touch gestures.
  * - ``GotoLookup``

--- a/doc/manual/en/installation.tex
+++ b/doc/manual/en/installation.tex
@@ -286,6 +286,7 @@ will be placed in the  \texttt{XCSoarData} directory (Windows PC,
 Windows and Android mobile devices), or the \texttt{.xcsoar} directory (Unix/Linux
 PC).  From the first run, XCSoar will create and maintain the files
 \texttt{user.cup} (user-edited waypoints),
+\texttt{user.freq} (user-edited radio frequency list),
 \texttt{Default.tsk} (Default Task),  
 \texttt{default.prf} 
 (configuration settings),

--- a/src/Dialogs/DataField.cpp
+++ b/src/Dialogs/DataField.cpp
@@ -8,6 +8,7 @@
 #include "Form/DataField/Prefix.hpp"
 #include "Form/DataField/Date.hpp"
 #include "Form/DataField/Integer.hpp"
+#include "Form/DataField/Frequency.hpp"
 #include "ComboPicker.hpp"
 #include "Dialogs/TextEntry.hpp"
 #include "Dialogs/TimeEntry.hpp"
@@ -16,6 +17,7 @@
 #include "Dialogs/NumberEntry.hpp"
 #include "MultiFilePicker.hpp"
 #include "Form/DataField/MultiFile.hpp"
+#include "Dialogs/RadioFrequencyEntry.hpp"
 
 #ifdef ANDROID
 #include "java/Global.hxx"
@@ -121,6 +123,14 @@ EditDataFieldDialog(const char *caption, DataField &df,
       return false;
 
     sdf.ModifyValue(buffer);
+    return true;
+  } else if (type == DataField::Type::RADIO_FREQUENCY) {
+    RadioFrequencyDataField &fdf = (RadioFrequencyDataField &)df;
+    RadioFrequency value = fdf.GetValue();
+    if (!RadioFrequencyEntryDialog(caption, value, false))
+      return false;
+
+    fdf.ModifyValue(value);
     return true;
   } else
     // don't know how to edit this

--- a/src/Dialogs/Frequency/dlgFrequencyEdit.cpp
+++ b/src/Dialogs/Frequency/dlgFrequencyEdit.cpp
@@ -1,0 +1,42 @@
+#include "dlgFrequencyEdit.hpp"
+
+FrequencyEditResult
+dlgFrequencyEditShowModal(FrequencyListItem &freq)
+{
+    const DialogLook &look = UIGlobals::GetDialogLook();
+    TWidgetDialog<FrequencyEditWidget>
+        dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
+               look, _("Frequency Editor"));
+    dialog.AddButton(_("OK"), mrOK);
+    dialog.AddButton(_("Cancel"), mrCancel);
+    dialog.SetWidget(look, freq);
+    const int result = dialog.ShowModal();
+
+    if (result != mrOK)
+        return FrequencyEditResult::CANCEL;
+
+    if (!dialog.GetChanged())
+        return FrequencyEditResult::UNMODIFIED;
+
+    freq = dialog.GetWidget().GetValue();
+    return FrequencyEditResult::MODIFIED;
+}
+
+void FrequencyEditWidget::Prepare(ContainerWindow &, const PixelRect &) noexcept
+{
+    AddText(_("Name"), nullptr, value.name.c_str(), this);
+    AddText(_("Short Name"), nullptr, value.short_name.c_str(), this);
+    AddFrequency(_("Frequency"), nullptr, value.freq, this);
+}
+
+bool FrequencyEditWidget::Save(bool &_changed) noexcept
+{
+    value.name = GetValueString(NAME);
+    value.short_name = GetValueString(SHORTNAME);
+    value.freq = GetValueRadioFrequency(FREQ);
+    if(!value.freq.IsDefined())
+        return false;
+
+    _changed |= modified;
+    return true;
+}

--- a/src/Dialogs/Frequency/dlgFrequencyEdit.hpp
+++ b/src/Dialogs/Frequency/dlgFrequencyEdit.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Dialogs/WidgetDialog.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "UIGlobals.hpp"
+#include "Waypoint/Waypoint.hpp"
+#include "FormatSettings.hpp"
+#include "Language/Language.hpp"
+#include "dlgUserFrequencyList.hpp"
+
+enum FrequencyEditResult
+{
+    CANCEL,
+    UNMODIFIED,
+    MODIFIED
+};
+
+class FrequencyEditWidget final : public RowFormWidget, DataFieldListener
+{
+    enum Rows
+    {
+        NAME,
+        SHORTNAME,
+        FREQ
+    };
+
+    FrequencyListItem value;
+
+    bool modified;
+
+public:
+    FrequencyEditWidget(const DialogLook &look, const FrequencyListItem &_value) noexcept
+        : RowFormWidget(look), value(_value), modified(false) {}
+
+    const FrequencyListItem &GetValue() const
+    {
+        return value;
+    }
+
+private:
+    /* virtual methods from Widget */
+    void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+    bool Save(bool &changed) noexcept override;
+
+    /* virtual methods from DataFieldListener */
+    void OnModified(DataField &) noexcept override
+    {
+        modified = true;
+    }
+};
+
+FrequencyEditResult
+dlgFrequencyEditShowModal(FrequencyListItem &way_point);

--- a/src/Dialogs/Frequency/dlgUserFrequencyList.cpp
+++ b/src/Dialogs/Frequency/dlgUserFrequencyList.cpp
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "dlgUserFrequencyList.hpp"
+#include "LogFile.hpp"
+#include "system/Path.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/BufferedCsvReader.hpp"
+#include "io/FileReader.hxx"
+#include "io/BufferedOutputStream.hxx"
+#include "io/BufferedReader.hxx"
+#include "LocalPath.hpp"
+#include "io/DataFile.hpp"
+#include "io/StringConverter.hpp"
+#include "ActionInterface.hpp"
+#include "UIGlobals.hpp"
+#include "dlgFrequencyEdit.hpp"
+#include "Dialogs/Message.hpp"
+#include <string_view>
+
+void UserFrequencyListWidget::ReadFile()
+{
+  std::unique_ptr<Reader> reader;
+  list.clear();
+  try
+  {
+    reader = OpenDataFile(file_name);
+  }
+  catch (...)
+  {
+    // file does not exist, list stays empty
+    ListUpdated();
+    return;
+  }
+
+  BufferedReader buffered_reader{*reader};
+  StringConverter string_converter(Charset::UTF8);
+
+  std::array<std::string_view, 4> params;
+
+  int line = 0;
+  bool has_invalids = false;
+  while (1)
+  {
+    size_t fields_parsed = ReadCsvRecord(buffered_reader, params);
+    if (fields_parsed == 0)
+      break;
+    line++;
+    try
+    {
+      if (fields_parsed != 3)
+        throw std::runtime_error("Invalid number of fields");
+
+      RadioFrequency freq = RadioFrequency::Parse(params.at(2));
+      if (freq.IsDefined() == false)
+        throw std::runtime_error("Invalid frequency");
+
+      std::string_view name = string_converter.Convert(params.at(0));
+      std::string_view short_name = string_converter.Convert(params.at(1));
+      list.emplace_back(name, short_name, freq);
+    }
+    catch (std::exception &e)
+    {
+      has_invalids = true;
+      if (dialog_mode == DialogMode::MANAGE)
+      {
+        StaticString<256> error;
+        error.Format(_("Error in frequencies file (%s) at line %d: %s"),
+                     file_name, line, e.what());
+        ShowMessageBox(error.buffer(), _("Error reading frequencies file"),
+                       MB_OK | MB_ICONERROR);
+      }
+    }
+  }
+
+  if (has_invalids)
+  {
+    if (dialog_mode == DialogMode::MANAGE)
+    {
+      ShowMessageBox(_("Invalid entries will be deleted if you save changes."),
+                     _("Error reading frequencies file"),
+                     MB_OK | MB_ICONWARNING);
+      modified = true;
+    }
+    else
+    {
+      StaticString<256> message;
+      message.Format(_("Invalid entries were found in the %s file. Got to %s for details"),
+                     file_name, _("Manage"));
+      ShowMessageBox(message, _("Error reading frequencies file"), MB_OK | MB_ICONWARNING);
+    }
+  }
+
+  ListUpdated();
+}
+
+void UserFrequencyListWidget::ListUpdated()
+{
+  if (dialog_mode == DialogMode::MANAGE)
+  {
+    edit_button->SetEnabled(list.size() > 0);
+    delete_button->SetEnabled(list.size() > 0);
+    duplicate_button->SetEnabled(list.size() > 0);
+    up_button->SetEnabled(list.size() > 1);
+    down_button->SetEnabled(list.size() > 1);
+  }
+  else
+  {
+    set_button->SetEnabled(list.size() > 0);
+    set_standby_button->SetEnabled(list.size() > 0);
+  }
+
+  ListControl &list_control = GetList();
+  list_control.SetLength(list.size());
+  list_control.Invalidate();
+}
+
+void UserFrequencyListWidget::PromptSaveChanges() noexcept
+{
+  if (IsModified() &&
+      ShowMessageBox(_("Save changes?"), _("Frequency list modified"),
+                     MB_YESNO | MB_ICONQUESTION) == IDYES)
+    UpdateFile();
+}
+
+void UserFrequencyListWidget::CloseClicked()
+{
+  PromptSaveChanges();
+  modified = false;
+  form->SetModalResult(mrOK);
+}
+
+void UserFrequencyListWidget::UpdateFile()
+{
+  const auto path = LocalPath(file_name);
+
+  FileOutputStream file(path);
+  BufferedOutputStream writer(file);
+
+  for (const auto &item : list)
+  {
+    StaticString<8> freq_str;
+    assert(item.freq.IsDefined());
+    item.freq.Format(freq_str.buffer(), freq_str.capacity());
+
+    writer.Write(item.name);
+    writer.Write(_(","));
+    writer.Write(item.short_name);
+    writer.Write(_(","));
+    writer.Write(freq_str);
+    writer.Write(_("\n"));
+  }
+
+  writer.Flush();
+  file.Commit();
+
+  LogFormat(_("Frequencies file '%s' saved"), path.c_str());
+}
+
+void UserFrequencyListWidget::CreateButtons(WidgetDialog &dialog)
+{
+  form = &dialog;
+  if (dialog_mode == DialogMode::MANAGE)
+  {
+    dialog.AddButton(_("New"), [this]()
+                     { NewClicked(); });
+    edit_button = dialog.AddButton(_("Edit"), [this]()
+                                   { EditClicked(); });
+    duplicate_button = dialog.AddButton(_("Duplicate"), [this]()
+                                        { DuplicateClicked(); });
+    delete_button = dialog.AddButton(_("Delete"), [this]()
+                                     { DeleteClicked(); });
+    up_button = dialog.AddSymbolButton(_("^"), [this]()
+                                       { UpClicked(); });
+    down_button = dialog.AddSymbolButton(_("v"), [this]()
+                                         { DownClicked(); });
+  }
+  else
+  {
+    if (dialog_mode == DialogMode::SELECT_ACTIVE || dialog_mode == DialogMode::BROWSE)
+    {
+      set_button = dialog.AddButton(_("Set Active"), [this]()
+                                    { SetClicked(true); });
+      set_standby_button = dialog.AddButton(_("Set Standby"), [this]()
+                                            { SetClicked(false); });
+    }
+    else if (dialog_mode == DialogMode::SELECT_STANDBY)
+    {
+      // Buttons are swapped if opened in SELECT_STANDBY mode
+      set_standby_button = dialog.AddButton(_("Set Standby"), [this]()
+                                            { SetClicked(false); });
+      set_button = dialog.AddButton(_("Set Active"), [this]()
+                                    { SetClicked(true); });
+    }
+
+    manage_button = dialog.AddButton(_("Manage"), [this]()
+                                     { dlgUserFrequencyListWidgetShowModal(DialogMode::MANAGE); 
+                                      this->ReadFile(); });
+  }
+
+  dialog.AddButton(_("Close"), [this]()
+                   { CloseClicked(); });
+}
+
+void UserFrequencyListWidget::Prepare(ContainerWindow &parent,
+                                      const PixelRect &rc) noexcept
+{
+  TextListWidget::Prepare(parent, rc);
+  ReadFile();
+}
+
+void dlgUserFrequencyListWidgetShowModal(UserFrequencyListWidget::DialogMode mode)
+{
+  auto title = (mode == UserFrequencyListWidget::DialogMode::MANAGE) ? _("Manage Frequencies") : _("Frequencies");
+  TWidgetDialog<UserFrequencyListWidget>
+      dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+             UIGlobals::GetDialogLook(), title);
+  dialog.SetWidget(mode);
+  dialog.GetWidget().CreateButtons(dialog);
+  dialog.EnableCursorSelection();
+
+  dialog.ShowModal();
+
+  dialog.GetWidget().PromptSaveChanges();
+}
+
+inline void
+UserFrequencyListWidget::SetClicked(bool as_active)
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  const auto &item = list[GetList().GetCursorIndex()];
+
+  if (as_active)
+    ActionInterface::SetActiveFrequency(item.freq, item.short_name);
+  else
+    ActionInterface::SetStandbyFrequency(item.freq, item.short_name);
+
+  if (dialog_mode == DialogMode::SELECT_ACTIVE && as_active == true) 
+    form->SetModalResult(mrOK);
+  if(dialog_mode == DialogMode::SELECT_STANDBY && as_active == false)
+    form->SetModalResult(mrOK);
+}
+
+void UserFrequencyListWidget::NewClicked()
+{
+  FrequencyListItem new_item(_(""), _(""), RadioFrequency::Null());
+
+  if (dlgFrequencyEditShowModal(new_item) == FrequencyEditResult::MODIFIED)
+  {
+    list.emplace_back(new_item);
+    ListUpdated();
+    modified = true;
+  }
+}
+
+void UserFrequencyListWidget::EditClicked()
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  FrequencyListItem item = list[GetList().GetCursorIndex()];
+
+  if (dlgFrequencyEditShowModal(item) == FrequencyEditResult::MODIFIED)
+  {
+    list[GetList().GetCursorIndex()] = item;
+    ListUpdated();
+    modified = true;
+  }
+}
+
+void UserFrequencyListWidget::DeleteClicked()
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  list.erase(list.begin() + GetList().GetCursorIndex());
+  ListUpdated();
+  modified = true;
+}
+
+void UserFrequencyListWidget::UpClicked()
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  if (GetList().GetCursorIndex() > 0)
+  {
+    std::swap(list[GetList().GetCursorIndex()],
+              list[GetList().GetCursorIndex() - 1]);
+    ListUpdated();
+    modified = true;
+    GetList().SetCursorIndex(GetList().GetCursorIndex() - 1);
+  }
+}
+
+void UserFrequencyListWidget::DownClicked()
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  if (GetList().GetCursorIndex() < list.size() - 1)
+  {
+    std::swap(list[GetList().GetCursorIndex()],
+              list[GetList().GetCursorIndex() + 1]);
+    ListUpdated();
+    modified = true;
+    GetList().SetCursorIndex(GetList().GetCursorIndex() + 1);
+  }
+}
+
+void UserFrequencyListWidget::DuplicateClicked()
+{
+  assert(GetList().GetCursorIndex() < list.size());
+
+  list.insert(list.begin() + GetList().GetCursorIndex(),
+              list[GetList().GetCursorIndex()]);
+  modified = true;
+  ListUpdated();
+}

--- a/src/Dialogs/Frequency/dlgUserFrequencyList.hpp
+++ b/src/Dialogs/Frequency/dlgUserFrequencyList.hpp
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Widget/TextListWidget.hpp"
+#include "RadioFrequency.hpp"
+#include "util/StaticString.hxx"
+#include "Form/Button.hpp"
+#include "Form/Form.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Language/Language.hpp"
+#include <vector>
+
+struct FrequencyListItem
+{
+  StaticString<64> name;
+  StaticString<16> short_name;
+  RadioFrequency freq;
+
+  FrequencyListItem(const std::basic_string_view<char> &_name, const std::basic_string_view<char> &_short_name,
+                    const RadioFrequency &_freq)
+      : name(_name), short_name(_short_name), freq(_freq)
+  {
+  }
+
+  StaticString<128> &getTitle() const
+  {
+    StaticString<8> freq_str;
+    freq.Format(freq_str.buffer(), freq_str.capacity());
+    bool has_short_name = short_name.length() > 0;
+    bool has_name = name.length() > 0;
+    if (has_name && has_short_name)
+      title.Format(_("%s (%s): %s"), name.c_str(), short_name.c_str(), freq_str.buffer());
+    else if (has_name)
+      title.Format(_("%s: %s"), name.c_str(), freq_str.buffer());
+    else if (has_short_name)
+      title.Format(_("%s: %s"), short_name.c_str(), freq_str.buffer());
+    else
+      title.Format(_("%s"), freq_str.buffer());
+    return title;
+  }
+
+private:
+  mutable StaticString<128> title;
+};
+
+class UserFrequencyListWidget final
+    : public TextListWidget
+{
+
+  const char *file_name = _("user.freq");
+
+  WndForm *form;
+
+  Button *set_button, *set_standby_button, *manage_button;
+  Button *edit_button, *delete_button, *duplicate_button;
+  Button *up_button, *down_button;
+
+  bool modified = false;
+
+  std::vector<FrequencyListItem> list;
+
+public:
+  enum DialogMode
+  {
+    BROWSE,
+    MANAGE,
+    SELECT_ACTIVE,
+    SELECT_STANDBY
+  } const dialog_mode;
+
+  explicit UserFrequencyListWidget(enum DialogMode _mode) : dialog_mode(_mode) {}
+
+  void CreateButtons(WidgetDialog &dialog);
+
+  /**
+   * @brief Update the user.freq file with the current list of frequencies
+   */
+  void UpdateFile();
+
+  /**
+   * @brief Check if the list has been modified
+   * @note Ignoring invalid entries also counts as modification
+   */
+  bool IsModified() const noexcept
+  {
+    if (dialog_mode != DialogMode::MANAGE)
+    {
+      assert(modified == false);
+      return false;
+    }
+    return modified;
+  }
+
+private:
+  void ReadFile();
+  void ListUpdated();
+  void SetClicked(bool as_active);
+  void NewClicked();
+  void EditClicked();
+  void DeleteClicked();
+  void UpClicked();
+  void DownClicked();
+  void DuplicateClicked();
+  void CloseClicked();
+
+public:
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+
+  void PromptSaveChanges() noexcept;
+
+protected:
+  /* virtual methods from TextListWidget */
+  const char *GetRowText(unsigned i) const noexcept override
+  {
+    return list[i].getTitle();
+  }
+
+  /* virtual methods from ListCursorHandler */
+  bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept override
+  {
+    return dialog_mode != DialogMode::BROWSE;
+  }
+
+  void OnActivateItem([[maybe_unused]] unsigned index) noexcept override
+  {
+    if (dialog_mode == DialogMode::SELECT_ACTIVE)
+      SetClicked(true);
+    else if (dialog_mode == DialogMode::SELECT_STANDBY)
+      SetClicked(false);
+    else if (dialog_mode == DialogMode::MANAGE)
+      EditClicked();
+  }
+};
+
+void dlgUserFrequencyListWidgetShowModal(UserFrequencyListWidget::DialogMode mode);

--- a/src/Dialogs/RadioFrequencyEntry.cpp
+++ b/src/Dialogs/RadioFrequencyEntry.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RadioFrequencyEntry.hpp"
+#include "Dialogs/GeoPointEntry.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Widget/FixedWindowWidget.hpp"
+#include "Widget/TwoWidgets.hpp"
+#include "Form/DigitEntry.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "RadioFrequency.hpp"
+
+bool RadioFrequencyEntryDialog(const char *caption,
+                               RadioFrequency &value,
+                               bool nullable)
+{
+  /* create the dialog */
+
+  const DialogLook &look = UIGlobals::GetDialogLook();
+
+  TWidgetDialog<FixedWindowWidget>
+    dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(), look, caption);
+
+  ContainerWindow &client_area = dialog.GetClientAreaWindow();
+
+  /* create the input control */
+
+  WindowStyle control_style;
+  control_style.Hide();
+  control_style.TabStop();
+
+  auto frequency_entry = std::make_unique<DigitEntry>(look);
+  frequency_entry->CreateRadioFrequency(client_area, client_area.GetClientRect(),
+                                 control_style);
+  frequency_entry->Resize(frequency_entry->GetRecommendedSize());
+  frequency_entry->SetCallback(dialog.MakeModalResultCallback(mrOK));
+
+  if (value.IsDefined())
+    frequency_entry->SetValue(value);
+  else
+    frequency_entry->SetInvalid();
+
+  /* create buttons */
+
+  dialog.AddButton(_("OK"), mrOK);
+  dialog.AddButton(_("Cancel"), mrCancel);
+
+  if (nullable)
+    dialog.AddButton(_("Clear"), [&frequency_entry = *frequency_entry]()
+                     {
+      frequency_entry.SetInvalid();});
+
+  /* run it */
+
+  dialog.SetWidget(std::move(frequency_entry));
+
+  if (dialog.ShowModal() != mrOK)
+    return false;
+
+  auto &entry = ((DigitEntry &)dialog.GetWidget().GetWindow());
+  value = RadioFrequency(entry.GetRadioFrequency());
+  
+  return true;
+}

--- a/src/Dialogs/RadioFrequencyEntry.hpp
+++ b/src/Dialogs/RadioFrequencyEntry.hpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+class RadioFrequency;
+
+bool
+RadioFrequencyEntryDialog(const char *caption, RadioFrequency &value,
+                    bool nullable=false);

--- a/src/Form/DataField/Base.hpp
+++ b/src/Form/DataField/Base.hpp
@@ -35,6 +35,7 @@ public:
     PREFIX,
     GEOPOINT,
     DATE,
+    RADIO_FREQUENCY,
   };
 
   using ModifiedCallback = std::function<void()>;

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -34,6 +34,7 @@ IsInternalFile(const char *str) noexcept
     "xcsoar.log",
     "xcsoar-rasp.dat",
     "user.cup",
+    "user.freq",
     nullptr
   };
 

--- a/src/Form/DataField/Frequency.cpp
+++ b/src/Form/DataField/Frequency.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Frequency.hpp"
+#include "RadioFrequency.hpp"
+#include <cstdio>
+
+void
+RadioFrequencyDataField::ModifyValue(RadioFrequency _value) noexcept
+{
+  if (_value == value)
+    return;
+
+  value = _value;
+  Modified();
+}
+
+const char *
+RadioFrequencyDataField::GetAsString() const noexcept
+{
+  if (!value.IsDefined())
+    return ("");
+
+  unsigned int mhz = value.GetKiloHertz()/1000;
+  unsigned int khz = value.GetKiloHertz()%1000;
+  assert(mhz < 1000);
+  std::sprintf(string_buffer,("%d.%03d"), mhz, khz);
+  return string_buffer;
+}

--- a/src/Form/DataField/Frequency.hpp
+++ b/src/Form/DataField/Frequency.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Base.hpp"
+#include "RadioFrequency.hpp"
+
+/**
+ * This #DataField implementation stores a #RadioFrequency.
+ */
+class RadioFrequencyDataField final : public DataField
+{
+  RadioFrequency value;
+
+  /**
+   * For GetAsString().  Must be mutable because the method is const.
+   */
+  mutable char string_buffer[8];
+
+public:
+  explicit RadioFrequencyDataField(RadioFrequency _value,
+                     DataFieldListener *listener = nullptr) noexcept
+      : DataField(Type::RADIO_FREQUENCY, false, listener),
+        value(_value) {}
+
+  RadioFrequency GetValue() const noexcept
+  {
+    return value;
+  }
+
+  void SetValue(RadioFrequency _value) noexcept
+  {
+    value = _value;
+  }
+
+  void ModifyValue(RadioFrequency _value) noexcept;
+
+  /* virtual methods from class DataField */
+  const char *GetAsString() const noexcept override;
+};

--- a/src/Form/DigitEntry.cpp
+++ b/src/Form/DigitEntry.cpp
@@ -16,6 +16,7 @@
 #include "Renderer/SymbolRenderer.hpp"
 #include "Geo/CoordinateFormat.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "RadioFrequency.hpp"
 #include "Asset.hpp"
 
 #include <algorithm>
@@ -201,6 +202,19 @@ DigitEntry::CreateLongitude(ContainerWindow &parent, const PixelRect &rc,
     break;
   }
 
+  cursor = 0;
+
+  CalculateLayout();
+}
+
+void DigitEntry::CreateRadioFrequency(ContainerWindow &parent, const PixelRect &rc, const WindowStyle style)
+{
+  Create(parent, rc, style, 4);
+  columns[0].type = Column::Type::RADIO_FREQURENCY_MHZ_OFFSET;
+  columns[1].type = Column::Type::DECIMAL_POINT;
+  columns[2].type = Column::Type::DIGIT;
+  columns[3].type = Column::Type::RADIO_FREQURENCY_KHZ_SCALED;
+  
   cursor = 0;
 
   CalculateLayout();
@@ -442,6 +456,19 @@ DigitEntry::SetValue(BrokenDate value)
   columns[4].value = value.day - 1;
 
   Invalidate();
+}
+
+void DigitEntry::SetValue(RadioFrequency value)
+{
+  assert(length == 4);
+  assert(columns[0].type == Column::Type::RADIO_FREQURENCY_MHZ_OFFSET);
+  assert(columns[1].type == Column::Type::DECIMAL_POINT);
+  assert(columns[2].type == Column::Type::DIGIT);
+  assert(columns[3].type == Column::Type::RADIO_FREQURENCY_KHZ_SCALED);
+
+  columns[0].value = (value.GetKiloHertz() / 1000) - 118;
+  columns[2].value = value.GetKiloHertz() % 1000 / 100;
+  columns[3].value = value.GetKiloHertz() % 100 / 5;
 }
 
 unsigned
@@ -783,6 +810,21 @@ DigitEntry::GetLongitude(CoordinateFormat format) const
   return GetGeoAngle(format);
 }
 
+RadioFrequency 
+DigitEntry::GetRadioFrequency() const
+{
+  assert(length == 4);
+  assert(columns[0].type == Column::Type::RADIO_FREQURENCY_MHZ_OFFSET);
+  assert(columns[1].type == Column::Type::DECIMAL_POINT);
+  assert(columns[2].type == Column::Type::DIGIT);
+  assert(columns[3].type == Column::Type::RADIO_FREQURENCY_KHZ_SCALED);
+
+  unsigned int megaHertz = 118 + columns[0].value;
+  unsigned int kiloHertz = columns[2].value * 100 + columns[3].value * 5;
+
+  return RadioFrequency::FromMegaKiloHertz(megaHertz, kiloHertz);
+}
+
 void
 DigitEntry::IncrementColumn(unsigned i)
 {
@@ -1032,6 +1074,16 @@ DigitEntry::OnPaint(Canvas &canvas) noexcept
     case Column::Type::DIGIT19:
       assert(c.value < 19);
       sprintf(buffer, "%02u", c.value);
+      break;
+
+    case Column::Type::RADIO_FREQURENCY_MHZ_OFFSET:
+      assert(c.value <= 19);
+      sprintf(buffer, "%03u", c.value + 118);
+      break;
+
+    case Column::Type::RADIO_FREQURENCY_KHZ_SCALED:
+      assert(c.value <= 19);
+      sprintf(buffer, "%02u", c.value * 5);
       break;
 
     case Column::Type::SIGN:

--- a/src/Form/DigitEntry.hpp
+++ b/src/Form/DigitEntry.hpp
@@ -16,6 +16,7 @@ class Angle;
 struct BrokenDate;
 class ContainerWindow;
 struct DialogLook;
+class RadioFrequency;
 
 /**
  * A control that allows entering numbers or other data types digit by
@@ -43,6 +44,8 @@ class DigitEntry : public PaintWindow {
       DAY,
       MONTH,
       YEAR,
+      RADIO_FREQURENCY_MHZ_OFFSET, // Actual value minus 118
+      RADIO_FREQURENCY_KHZ_SCALED, // Last 2 digits divided by 5
     };
 
     Type type;
@@ -68,7 +71,9 @@ class DigitEntry : public PaintWindow {
         type == Type::HOUR ||
         type == Type::DAY ||
         type == Type::MONTH ||
-        type == Type::YEAR;
+        type == Type::YEAR ||
+        type == Type::RADIO_FREQURENCY_MHZ_OFFSET ||
+        type == Type::RADIO_FREQURENCY_KHZ_SCALED;
     }
 
     constexpr bool NoOverflow() const {
@@ -98,8 +103,14 @@ class DigitEntry : public PaintWindow {
       case Type::DIGIT19:
         return 18;
 
+      case Type::RADIO_FREQURENCY_MHZ_OFFSET:
+        return 18;
+
+      case Type::RADIO_FREQURENCY_KHZ_SCALED:
+        return 19;
+
       case Type::DIGIT36:
-        return 35;
+        return 35;   
 
       default:
         return 9;
@@ -200,6 +211,9 @@ public:
   void CreateLongitude(ContainerWindow &parent, const PixelRect &rc,
                        const WindowStyle style, CoordinateFormat format);
 
+  void CreateRadioFrequency(ContainerWindow &parent, const PixelRect &rc,
+                             const WindowStyle style);
+
   void CalculateLayout();
 
   [[gnu::pure]]
@@ -225,6 +239,7 @@ public:
   void SetValue(RoughTime value);
   void SetValue(Angle value);
   void SetValue(BrokenDate value);
+  void SetValue(RadioFrequency value);
 
   [[gnu::pure]]
   int GetIntegerValue() const;
@@ -255,6 +270,9 @@ public:
 
   [[gnu::pure]]
   Angle GetLongitude(CoordinateFormat format) const;
+  
+  [[gnu::pure]]
+  RadioFrequency GetRadioFrequency() const;
 
 protected:
   [[gnu::pure]]

--- a/src/InfoBoxes/Panel/RadioEdit.cpp
+++ b/src/InfoBoxes/Panel/RadioEdit.cpp
@@ -3,43 +3,64 @@
 
 #include "RadioEdit.hpp"
 #include "Look/DialogLook.hpp"
-#include "Widget/OffsetButtonsWidget.hpp"
+#include "Widget/RadioEditWidget.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "ActionInterface.hpp"
 #include "UIGlobals.hpp"
+#include "Dialogs/Frequency/dlgUserFrequencyList.hpp"
 
-class RadioOffsetButtons final : public OffsetButtonsWidget {
+class RadioEdit final : public RadioEditWidget
+{
 public:
-  RadioOffsetButtons(bool active_freq) noexcept
-    :OffsetButtonsWidget(UIGlobals::GetDialogLook().button, "%.0f kHz", 5, 1000),set_active_freq(active_freq) {}
+  explicit RadioEdit(bool active_freq) noexcept
+      : RadioEditWidget(UIGlobals::GetDialogLook()), set_active_freq(active_freq) {}
 
 protected:
   /* virtual methods from OffsetButtonsWidget */
-  void OnOffset(double offset) noexcept override;
+  void OnFrequencyChanged(RadioFrequency new_freq) noexcept override;
+  void OnOpenList() noexcept override;
+  RadioFrequency GetCurrentFrequency() const noexcept override;
 
 private:
-  bool set_active_freq;
+  const bool set_active_freq;
 };
-
-void
-RadioOffsetButtons::OnOffset(double offset) noexcept
-{
-  if(set_active_freq) {
-    ActionInterface::OffsetActiveFrequency(offset, true);
-  } else {
-    ActionInterface::OffsetStandbyFrequency(offset, true);
-  }
-
-}
 
 std::unique_ptr<Widget>
 LoadActiveRadioFrequencyEditPanel([[maybe_unused]] unsigned id)
 {
-  return std::make_unique<RadioOffsetButtons>(true);
+  return std::make_unique<RadioEdit>(true);
 }
 
 std::unique_ptr<Widget>
 LoadStandbyRadioFrequencyEditPanel([[maybe_unused]] unsigned id)
 {
-  return std::make_unique<RadioOffsetButtons>(false);
+  return std::make_unique<RadioEdit>(false);
+}
+
+void RadioEdit::OnFrequencyChanged(RadioFrequency new_freq) noexcept
+{
+  if (set_active_freq)
+    ActionInterface::SetActiveFrequency(new_freq, _(""));
+  else
+    ActionInterface::SetStandbyFrequency(new_freq, _(""));
+}
+
+RadioFrequency RadioEdit::GetCurrentFrequency() const noexcept
+{
+  ComputerSettings &settings =
+      CommonInterface::SetComputerSettings();
+  if (set_active_freq)
+    return settings.radio.active_frequency;
+  else
+    return settings.radio.standby_frequency;
+}
+
+void RadioEdit::OnOpenList() noexcept
+{
+  auto mode = UserFrequencyListWidget::DialogMode::SELECT_ACTIVE;
+  if (!set_active_freq)
+    mode = UserFrequencyListWidget::DialogMode::SELECT_STANDBY;
+  dlgUserFrequencyListWidgetShowModal(mode);
+
+  UpdateFrequencyField(GetCurrentFrequency());
 }

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -195,6 +195,7 @@ void eventExchangeFrequencies(const char *misc);
 void eventUploadIGCFile(const char *misc);
 void eventOrientationCruise(const char *misc);
 void eventOrientationCircling(const char *misc);
+void eventFrequencies(const char *misc);
 // -------
 
 } // namespace InputEvents

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -74,6 +74,7 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
 #include "Terrain/RasterTerrain.hpp"
+#include "Dialogs/Frequency/dlgUserFrequencyList.hpp"
 
 #include <cassert>
 #include <algorithm>
@@ -302,6 +303,13 @@ void
 InputEvents::eventChecklist([[maybe_unused]] const char *misc)
 {
   dlgChecklistShowModal();
+}
+
+// User Frequencies List
+void
+InputEvents::eventFrequencies([[maybe_unused]] const char *misc)
+{
+  dlgUserFrequencyListWidgetShowModal(UserFrequencyListWidget::DialogMode::BROWSE);
 }
 
 // Status

--- a/src/Widget/EditRowFormWidget.cpp
+++ b/src/Widget/EditRowFormWidget.cpp
@@ -14,6 +14,7 @@
 #include "Form/DataField/Date.hpp"
 #include "Form/DataField/Time.hpp"
 #include "Form/DataField/RoughTime.hpp"
+#include "Form/DataField/Frequency.hpp"
 #include "time/RoughTime.hpp"
 #include "time/BrokenDate.hpp"
 #include "Language/Language.hpp"
@@ -146,6 +147,17 @@ RowFormWidget::AddAngle(const char *label, const char *help,
 {
   WndProperty *edit = Add(label, help);
   AngleDataField *df = new AngleDataField(value, step, fine, listener);
+  edit->SetDataField(df);
+  return edit;
+} 
+
+WndProperty *
+RowFormWidget::AddFrequency(const char *label, const char *help,
+                        RadioFrequency value,
+                        DataFieldListener *listener) noexcept
+{
+  WndProperty *edit = Add(label, help);
+  RadioFrequencyDataField *df = new RadioFrequencyDataField(value, listener);
   edit->SetDataField(df);
   return edit;
 }
@@ -356,6 +368,16 @@ RowFormWidget::GetValueFloat(unsigned i) const noexcept
   const DataFieldFloat &df =
     (const DataFieldFloat &)GetDataField(i);
   assert(df.GetType() == DataField::Type::REAL);
+  return df.GetValue();
+}
+
+RadioFrequency RowFormWidget::GetValueRadioFrequency(unsigned i) const noexcept
+{
+  const RadioFrequencyDataField &df =
+    (const RadioFrequencyDataField &)GetDataField(i);
+  assert(df.GetType() == DataField::Type::RADIO_FREQUENCY);
+  if(df.GetType() != DataField::Type::RADIO_FREQUENCY)
+    return RadioFrequency::Null();
   return df.GetValue();
 }
 

--- a/src/Widget/RadioEditWidget.cpp
+++ b/src/Widget/RadioEditWidget.cpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RadioEditWidget.hpp"
+
+void RadioEditWidget::OnModified(DataField &df) noexcept
+{
+  OnFrequencyChanged(dynamic_cast<RadioFrequencyDataField &>(df).GetValue());
+}
+
+PixelSize
+RadioEditWidget::GetMinimumSize() const noexcept
+{
+  return {2u * Layout::GetMinimumControlHeight(),
+          Layout::GetMinimumControlHeight()};
+}
+
+PixelSize
+RadioEditWidget::GetMaximumSize() const noexcept
+{
+  return {2u * Layout::GetMaximumControlHeight(),
+          Layout::GetMaximumControlHeight()};
+}
+
+static constexpr std::array<PixelRect, 2>
+CalculateLayout(const PixelRect &total_rc) noexcept
+{
+  PixelRect freq_rc(total_rc);
+  PixelRect btn_rc(total_rc);
+
+  int border = total_rc.left + (total_rc.GetWidth() / 2);
+  freq_rc.right = border;
+  btn_rc.left = border;
+
+  return {
+      freq_rc,
+      btn_rc};
+}
+
+void RadioEditWidget::Prepare(ContainerWindow &parent,
+                                     const PixelRect &total_rc) noexcept
+{
+  const auto rc = CalculateLayout(total_rc);
+
+  WindowStyle style;
+  style.TabStop();
+  style.Hide();
+
+  freq_edit = std::make_unique<WndProperty>(parent, look, _(""), rc[0], 0, style);
+  RadioFrequencyDataField *df = new RadioFrequencyDataField(GetCurrentFrequency(), this);
+  freq_edit->SetDataField(df);
+  list_button = std::make_unique<Button>(parent, look.button, _("Select from list"),
+                                         rc[1], style, [this]()
+                                         { OnOpenList(); });
+}
+
+void RadioEditWidget::Show(const PixelRect &total_rc) noexcept
+{
+  const auto rc = CalculateLayout(total_rc);
+
+  freq_edit->MoveAndShow(rc[0]);
+  list_button->MoveAndShow(rc[1]);
+}
+
+void RadioEditWidget::Hide() noexcept
+{
+  list_button->Hide();
+  freq_edit->Hide();
+}
+
+void RadioEditWidget::Move(const PixelRect &total_rc) noexcept
+{
+  const auto rc = CalculateLayout(total_rc);
+
+  freq_edit->Move(rc[0]);
+  list_button->Move(rc[1]);
+}
+
+bool RadioEditWidget::SetFocus() noexcept
+{
+  list_button->SetFocus();
+  return true;
+}
+
+bool RadioEditWidget::HasFocus() const noexcept
+{
+  return (list_button->HasFocus() || freq_edit->HasFocus());
+}
+
+void RadioEditWidget::UpdateFrequencyField(RadioFrequency freq)
+{
+  assert(freq_edit != nullptr);
+  auto *df = freq_edit->GetDataField();
+  dynamic_cast<RadioFrequencyDataField *>(df)->SetValue(freq);
+  freq_edit->RefreshDisplay();
+}

--- a/src/Widget/RadioEditWidget.hpp
+++ b/src/Widget/RadioEditWidget.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Widget.hpp"
+#include "Form/Button.hpp"
+#include "Form/DigitEntry.hpp"
+#include "Look/DialogLook.hpp"
+#include "Screen/Layout.hpp"
+#include "Form/DigitEntry.hpp"
+#include "Form/DataField/Frequency.hpp"
+#include "Interface.hpp"
+#include "Components.hpp"
+#include "BackendComponents.hpp"
+#include "Device/MultipleDevices.hpp"
+#include "Units/Units.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Form/Edit.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "Operation/MessageOperationEnvironment.hpp"
+
+#include <array>
+#include <memory>
+
+class Button;
+
+class RadioEditWidget : public NullWidget,
+                               private DataFieldListener
+{
+  const DialogLook &look;
+  std::unique_ptr<Button> list_button;
+  std::unique_ptr<WndProperty> freq_edit;
+
+public:
+  RadioEditWidget(const DialogLook &_look) noexcept
+      : look(_look){};
+
+private:
+  void OnModified(DataField &df) noexcept override;
+
+public:
+  /* virtual methods from Widget */
+  PixelSize GetMinimumSize() const noexcept override;
+  PixelSize GetMaximumSize() const noexcept override;
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
+  void Move(const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
+  bool HasFocus() const noexcept override;
+
+protected:
+  virtual void OnFrequencyChanged(RadioFrequency new_freq) noexcept = 0;
+  virtual void OnOpenList() noexcept = 0;
+  virtual RadioFrequency GetCurrentFrequency() const noexcept = 0;
+  void UpdateFrequencyField(RadioFrequency freq);
+};

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -11,6 +11,7 @@
 #include "time/BrokenDate.hpp"
 #include "time/FloatDuration.hxx"
 #include "time/RoughTimeDecl.hpp"
+#include "RadioFrequency.hpp"
 
 #include <boost/container/static_vector.hpp>
 
@@ -374,6 +375,10 @@ public:
                         UnitGroup unit_group, double value,
                         DataFieldListener *listener=nullptr) noexcept;
 
+  WndProperty *AddFrequency(const char *label, const char *help, 
+                        RadioFrequency value, 
+                        DataFieldListener *listener) noexcept;
+
   WndProperty *AddAngle(const char *label, const char *help,
                         Angle value, unsigned step, bool fine,
                         DataFieldListener *listener=nullptr) noexcept;
@@ -614,6 +619,9 @@ public:
 
   [[gnu::pure]]
   double GetValueFloat(unsigned i) const noexcept;
+
+  [[gnu::pure]]
+  RadioFrequency GetValueRadioFrequency(unsigned i) const noexcept;
 
   [[gnu::pure]]
   Angle GetValueAngle(unsigned i) const noexcept;


### PR DESCRIPTION
XCSoar can set the frequency of a radio. However, this is currently only possible for frequencies that are tied to an airfield (defined in a waypoints file). This PR proposes a dialog that shows a list of user-defined frequencies. the frequency list is editable via GUI and stored in user.freq file in XCSoar's root directory.

This will be particularly useful for frequencies like:
- glider air-to-air
- FIC
- emergency

![image](https://github.com/XCSoar/XCSoar/assets/20001367/bd7f12d7-00df-495c-af9d-20322267027c)

![image](https://github.com/XCSoar/XCSoar/assets/20001367/586474bc-a266-45d2-bcba-24016a214d2c)

![image](https://github.com/XCSoar/XCSoar/assets/20001367/907d1f2a-9e6f-42d4-b99d-dbda5e5d36b8)

![image](https://github.com/XCSoar/XCSoar/assets/20001367/b21b30d5-ed3c-49fc-8c60-47f2bca811d6)








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added frequency list management dialog to browse, create, edit, and manage custom radio frequencies
  * Added radio frequency entry dialog for editing individual frequency values
  * Added new "Frequencies" input event to access the frequency management interface
  * Support for saving and loading custom frequency lists to a persistent user file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->