### PR TITLE
Make map Orientation fully configurable by input events

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -8,6 +8,7 @@ Version 7.43 - not yet released
   - NumberEntry dialog value can now be accepted by enter
   - Vario center gross label
   - Vario use AutoFonts for lables and values
+  - Replace eventOrientation by two new events: eventOrientationCruise and eventOrientationCircling
 * devices
   - add Larus driver
 * windows

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -180,7 +180,6 @@ void eventAirspaceDisplayMode(const TCHAR *misc);
 void eventAutoLogger(const TCHAR *misc);
 void eventGotoLookup(const TCHAR *misc);
 void eventAddWaypoint(const TCHAR *misc);
-void eventOrientation(const TCHAR *misc);
 void eventTraffic(const TCHAR *misc);
 void eventFlarmTraffic(const TCHAR *misc);
 void eventFlarmDetails(const TCHAR *misc);

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -193,6 +193,7 @@ void eventResetTask(const TCHAR *misc);
 void eventLockScreen(const TCHAR *misc);
 void eventExchangeFrequencies(const TCHAR *misc);
 void eventUploadIGCFile(const TCHAR *misc);
+void eventOrientationCruise(const TCHAR *misc);
 // -------
 
 } // namespace InputEvents

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -194,6 +194,7 @@ void eventLockScreen(const TCHAR *misc);
 void eventExchangeFrequencies(const TCHAR *misc);
 void eventUploadIGCFile(const TCHAR *misc);
 void eventOrientationCruise(const TCHAR *misc);
+void eventOrientationCircling(const TCHAR *misc);
 // -------
 
 } // namespace InputEvents

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -706,7 +706,6 @@ eventAirspaceWarnings - on, off, time nn, ack nn
 eventTerrain          - see map_window.Event_Terrain
 eventCompass          - on, off, cruise on, crusie off, climb on, climb off
 eventVario            - on, off // JMW what does this do?
-eventOrientation      - north, track,  ???
 eventTerrainRange     - on, off (might be part of eventTerrain)
 eventSounds           - Include Task and Modes sounds along with Vario
                       - Include master nn, deadband nn, netto trigger

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -399,6 +399,26 @@ InputEvents::eventOrientationCruise(const TCHAR *misc)
   ActionInterface::SendMapSettings(true);  
 }
 
+void
+InputEvents::eventOrientationCircling(const TCHAR *misc)
+{
+  MapSettings &settings_map = CommonInterface::SetMapSettings();
+
+  if (StringIsEqual(misc, _T("northup"))) {
+    settings_map.circling_orientation = MapOrientation::NORTH_UP;
+  } else if (StringIsEqual(misc, _T("trackup"))) {
+	settings_map.circling_orientation = MapOrientation::TRACK_UP;
+  } else if (StringIsEqual(misc, _T("headingup"))) {
+    settings_map.circling_orientation = MapOrientation::HEADING_UP;
+  } else if (StringIsEqual(misc, _T("targetup"))) {
+	settings_map.circling_orientation = MapOrientation::TARGET_UP;
+  } else if (StringIsEqual(misc, _T("windup"))) {
+	settings_map.circling_orientation = MapOrientation::WIND_UP;
+  }
+  
+  ActionInterface::SendMapSettings(true);  
+}
+
 /* Event_TerrainToplogy Changes
    0       Show
    1       Topography = ON

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -352,34 +352,6 @@ InputEvents::eventAirspaceDisplayMode(const TCHAR *misc)
 }
 
 void
-InputEvents::eventOrientation(const TCHAR *misc)
-{
-  MapSettings &settings_map = CommonInterface::SetMapSettings();
-
-  if (StringIsEqual(misc, _T("northup"))) {
-    settings_map.cruise_orientation = MapOrientation::NORTH_UP;
-    settings_map.circling_orientation = MapOrientation::NORTH_UP;
-  } else if (StringIsEqual(misc, _T("northcircle"))) {
-    settings_map.cruise_orientation = MapOrientation::TRACK_UP;
-    settings_map.circling_orientation = MapOrientation::NORTH_UP;
-  } else if (StringIsEqual(misc, _T("trackcircle"))) {
-    settings_map.cruise_orientation = MapOrientation::NORTH_UP;
-    settings_map.circling_orientation = MapOrientation::TRACK_UP;
-  } else if (StringIsEqual(misc, _T("trackup"))) {
-    settings_map.cruise_orientation = MapOrientation::TRACK_UP;
-    settings_map.circling_orientation = MapOrientation::TRACK_UP;
-  } else if (StringIsEqual(misc, _T("northtrack"))) {
-    settings_map.cruise_orientation = MapOrientation::TRACK_UP;
-    settings_map.circling_orientation = MapOrientation::TARGET_UP;
-  } else if (StringIsEqual(misc, _T("targetup"))) {
-    settings_map.cruise_orientation = MapOrientation::TARGET_UP;
-    settings_map.circling_orientation = MapOrientation::TARGET_UP;
-  }
-
-  ActionInterface::SendMapSettings(true);
-}
-
-void
 InputEvents::eventOrientationCruise(const TCHAR *misc)
 {
   MapSettings &settings_map = CommonInterface::SetMapSettings();

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -379,6 +379,26 @@ InputEvents::eventOrientation(const TCHAR *misc)
   ActionInterface::SendMapSettings(true);
 }
 
+void
+InputEvents::eventOrientationCruise(const TCHAR *misc)
+{
+  MapSettings &settings_map = CommonInterface::SetMapSettings();
+
+  if (StringIsEqual(misc, _T("northup"))) {
+    settings_map.cruise_orientation = MapOrientation::NORTH_UP;
+  } else if (StringIsEqual(misc, _T("trackup"))) {
+	settings_map.cruise_orientation = MapOrientation::TRACK_UP;
+  } else if (StringIsEqual(misc, _T("headingup"))) {
+    settings_map.cruise_orientation = MapOrientation::HEADING_UP;
+  } else if (StringIsEqual(misc, _T("targetup"))) {
+	settings_map.cruise_orientation = MapOrientation::TARGET_UP;
+  } else if (StringIsEqual(misc, _T("windup"))) {
+	settings_map.cruise_orientation = MapOrientation::WIND_UP;
+  }
+  
+  ActionInterface::SendMapSettings(true);  
+}
+
 /* Event_TerrainToplogy Changes
    0       Show
    1       Topography = ON


### PR DESCRIPTION
Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html
