### PR TITLE
Infoboxes/Content: add estimated task speed infobox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,7 @@ Version 7.43 - not yet released
 * ui
   - TC 30s Infobox shows now climb rate since start of thermal
   - TL Gain Infobox shows now the overall climb rate of last thermal
+  - add new Infobox V Task Est (Speed task estimated)
   - add missing airspace to Select Airspace filter
   - NumberEntry dialog value can now be accepted by enter
   - Vario center gross label

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1128,6 +1128,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoTaskETAorAATdT,
   },
 
+  // e_SpeedTaskEst
+  {
+    N_("Speed task estimated"),
+    N_("V Task Est"),
+    N_("Estimated average cross-country speed for current task as of task completion, assuming performance of ideal MacCready cruise/climb cycle."),
+    UpdateInfoBoxTaskSpeedEst,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -497,6 +497,20 @@ UpdateInfoBoxTaskSpeedHour(InfoBoxData &data) noexcept
 }
 
 void
+UpdateInfoBoxTaskSpeedEst(InfoBoxData &data) noexcept
+{
+  const TaskStats &task_stats = CommonInterface::Calculated().task_stats;
+  if (!task_stats.task_valid || !task_stats.total.planned.IsDefined() ||
+      !task_stats.total.IsAchievable()) {
+    data.SetInvalid();
+    return;
+  }
+
+  // Set Value and unit
+  data.SetValueFromTaskSpeed(task_stats.total.planned.GetSpeed());
+}
+
+void
 UpdateInfoBoxFinalGR(InfoBoxData &data) noexcept
 {
   const TaskStats &task_stats = CommonInterface::Calculated().task_stats;

--- a/src/InfoBoxes/Content/Task.hpp
+++ b/src/InfoBoxes/Content/Task.hpp
@@ -84,6 +84,9 @@ void
 UpdateInfoBoxTaskSpeedHour(InfoBoxData &data) noexcept;
 
 void
+UpdateInfoBoxTaskSpeedEst(InfoBoxData &data) noexcept;
+
+void
 UpdateInfoBoxTaskAATime(InfoBoxData &data) noexcept;
 
 void

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -159,7 +159,7 @@ namespace InfoBoxFactory
     e_EngineRPM,  /* Engine Revolutions Per Minute */
 
     e_AAT_dT_or_ETA, /* Delta time in AAT task and ETA in racing task */
-
+    e_SpeedTaskEst, /* Estimated (predicted) whole-task average cross-country speed for current task. Affected by MC setting. */
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
This change adds estimated task speed (the value currently shown as "Speed estimated" on the Status-Task panel) to the list of available infoboxes. This could be a desirable infobox in a speed record attempt flight. I recently missed such a record by less than the duration of one circle, and I'd have probably left the last thermal at least one circle sooner (and gotten the record) had I been able to see this value without having to go back and forth to the Status-Task panel to see it.

This change also changes "cross country" to "cross-country" in every infobox description that contained "cross country". Previously, infobox descriptions were inconsistent regarding whether "cross country" or "cross-country" was used. It also tidies up the Type enum in Type.hpp (to make the most recent additions look like the earlier ones - just whitespace and comment changes), since a new item was being added here, anyway.