### PR TITLE
doc/manual: new infobox and task speed language clarification and correction

### DIFF
--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -276,7 +276,9 @@ that directly changes to the Task Calculator screen.
 \item[Remaining task time]  This field displays the time remaining to complete the task.
 \item[Task distance]  This field displays the total task distance.
 \item[Remaining distance]  This field displays the remaining distance to complete the task.
-\item[Speed estimated]  This field displays the estimated speed  for the remaining of the task considering the provided MacCready setting.
+\item[Speed estimated]  This field displays the estimated average cross-country 
+speed for the task as of task completion, assuming flying the rest of the task 
+at the provided MacCready setting.
 \item[Speed average]  %TODO: To define
 \item[Set MacCready]  Allows the user to adjust the MacCready value and 
   see the effect it has on the estimated task time.

--- a/doc/manual/en/ch05_glide_computer.tex
+++ b/doc/manual/en/ch05_glide_computer.tex
@@ -564,15 +564,19 @@ for altitude differences from the task start altitude.
 for altitude required to complete the task.
 \item[Task speed remaining]  This is the task speed estimated for the
   remainder of the task according to MacCready theory.
+\item[Task speed estimated]  This is the task speed estimated for the entire 
+task, start to finish, assuming flying the remainder of the task according 
+to MacCready theory.
 \item[Task speed instantaneous]  This is the instantaneous estimated speed 
-along the task.  When climbing at the MacCready setting, this number
-will be similar to the estimated task speed.  When climbing slowly or
-flying off-course, this number will be lower than the estimated task
-speed.  In cruise at the optimum speed in zero lift, this number will
-be similar to the estimated task speed.
+along the task.  When climbing at a rate equal to the MacCready setting, this 
+number will be similar to \emph{Task speed remaining}.  When climbing more slowly 
+than this or cruising in a direction other than directly toward the active 
+waypoint, this number will be lower than \emph{Task speed remaining}.  In cruise 
+at the optimum speed directly toward the active waypoint in air that has no 
+vertical motion, this number will be similar to \emph{Task speed remaining}.
 
-This measure, available as an {\InfoBox} is useful as a continuous
-indicator of the cross-country performance.  It is not used in any
+This measure, available as an {\InfoBox}, is useful as a continuous
+indicator of cross-country performance.  It is not used in any
 internal calculations.
 \end{description}
 

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -234,14 +234,16 @@ turn point relative to the safety arrival height.}
 
 %%%%%%%%%%%
 \section{Competition and assigned area tasks}
-\ibi{Speed task average}{V Task Avg}{Average cross country speed while on
+\ibi{Speed task average}{V Task Avg}{Average cross-country speed while on
 current task, not compensated for altitude.}
-\ibi{Speed task instantaneous}{V Task Inst}{Instantaneous cross country speed
+\ibi{Speed task instantaneous}{V Task Inst}{Instantaneous cross-country speed
 while on current task, compensated for altitude.  Equivalent to instantaneous 
 Pirker cross-country speed.}
-\ibi{Speed task achieved}{V Task Ach}{Achieved cross country speed while on
+\ibi{Speed task achieved}{V Task Ach}{Achieved cross-country speed while on
 current task, compensated for altitude.  Equivalent to Pirker cross-country 
 speed remaining.}
+\ibi{Speed task estimated}{V Task Est}{Estimated average cross-country speed
+for current task as of task completion, assuming performance of ideal MacCready cruise/climb cycle.}
 \ibi{AAT time}{AAT Time}{ `Assigned Area Task' time remaining. Goes red when time 
 remaining has expired.}
 \ibi{AAT delta time}{AAT dT}{Difference between estimated task time and 


### PR DESCRIPTION
Add language about new "Speed task estimated" infobox (PR #1429), and correct and clarify some language about task speeds.
