### PR TITLE
Dialogs/StatusPanels: On the Status-Task panel, make “Speed estimated” blank when “Speed remaining” is blank.

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,7 @@ Version 7.43 - not yet released
   - TC 30s Infobox shows now climb rate since start of thermal
   - TL Gain Infobox shows now the overall climb rate of last thermal
   - add new Infobox V Task Est (Speed task estimated)
+  - Status-Task panel “Speed estimated” now blank if MC>0 & can't finish task
   - add missing airspace to Select Airspace filter
   - NumberEntry dialog value can now be accepted by enter
   - Vario center gross label

--- a/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
@@ -70,7 +70,7 @@ TaskStatusPanel::Refresh() noexcept
     SetText(RemainingDistance,
             FormatUserDistanceSmart(task_stats.total.remaining.GetDistance()));
 
-  if (task_stats.total.planned.IsDefined())
+  if (task_stats.total.remaining_effective.IsDefined())
     SetText(EstimatedSpeed,
             FormatUserTaskSpeed(task_stats.total.planned.GetSpeed()));
   else


### PR DESCRIPTION
This change makes “Speed estimated” on the Task-Status panel blank when “Speed remaining” on that panel is blank. The latter is blank if MC>0 but the task can’t be finished due to either too much wind or MC setting being too low given the amount of wind. Like “Speed remaining”, “Speed estimated” (the predicted start-to-finish average task speed) has no meaning if the task can’t be finished. This also makes this field more like infoboxes that show “---” in this can’t-finish-task scenario (e.g., “V Task Est” and “Fin ETA”).