### PR TITLE
lua/Http.cpp: Use common curl settings

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,8 @@ Version 7.43 - not yet released
 * airspace
   - add classes according the OpenAir extended format AY tag
   - coloring is done according to the AC tag, or if present and allowed, according to the AY tag
+* Lua scripting
+  - allow HTTPs client connections by setting project-wide Curl options
 
 Version 7.42 - 2024/03/01
 * ui

--- a/src/lua/Http.cpp
+++ b/src/lua/Http.cpp
@@ -7,6 +7,7 @@
 #include "Class.hxx"
 #include "Error.hxx"
 #include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
 #include "lib/curl/Adapter.hxx"
 #include "lib/curl/Handler.hxx"
 #include "util/SpanCast.hxx"
@@ -34,6 +35,7 @@ public:
   explicit LuaHttpRequest(const char *url)
     :easy(url), adapter(*this)
   {
+    Curl::Setup(easy);
     adapter.Install(easy);
   }
 


### PR DESCRIPTION
Applies the same common Curl options that are used elsewhere in XCSoar for the Lua HTTP client. These currently include disabling host and peer SSL verification on Android to circumvent connection errors due to missing access to Android's own CA certs (#1469)
