### PR TITLE
Dialogs/StatusPanels: on Task panel, make two times blank when spd rem is blank

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,7 +5,8 @@ Version 7.43 - not yet released
   - TC 30s Infobox shows now climb rate since start of thermal
   - TL Gain Infobox shows now the overall climb rate of last thermal
   - add new Infobox V Task Est (Speed task estimated)
-  - Status-Task panel “Speed estimated” now blank if MC>0 & can't finish task
+  - Status-Task panel: "Estimated task time", "Remaining time", and "Speed
+    estimated" now blank if MC>0 & can't finish task
   - add missing airspace to Select Airspace filter
   - NumberEntry dialog value can now be accepted by enter
   - Vario center gross label

--- a/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
@@ -54,11 +54,15 @@ TaskStatusPanel::Refresh() noexcept
     SetText(TaskTime,
             FormatTimeHHMM(backend_components->protected_task_manager->GetOrderedTaskSettings().aat_min_time));
 
-  SetText(ETETime,
-          FormatSignedTimeHHMM(task_stats.GetEstimatedTotalTime()));
-
-  SetText(RemainingTime,
-          FormatSignedTimeHHMM(task_stats.total.time_remaining_now));
+  if (task_stats.total.remaining_effective.IsDefined()) {
+    SetText(ETETime,
+            FormatSignedTimeHHMM(task_stats.GetEstimatedTotalTime()));
+    SetText(RemainingTime,
+            FormatSignedTimeHHMM(task_stats.total.time_remaining_now));
+  } else {
+    ClearText(ETETime);
+    ClearText(RemainingTime);
+  }
 
   if (task_stats.total.planned.IsDefined())
     SetText(TaskDistance,


### PR DESCRIPTION
This change makes “Estimated task time” and “Remaining time” on the Task-Status panel blank when “Speed estimated” and “Speed remaining” on that panel are blank. These speeds are blank if MC>0 but the task can’t be finished due to either too much wind or MC setting being too low given the amount of wind. Like these speeds, “Estimated task time” (the predicted start-to-finish task time) and “Remaining time” (the predicted time required to fly the remainder of the task) have no meaning if the task can’t be finished. This also makes these fields more like infoboxes that show “---” in this can’t-finish-task scenario (e.g., “V Task Est” and “Fin ETA”). The new logical test used to control whether “Estimated task time” and “Remaining time” are shown (task_stats.total.remaining_effective.IsDefined()) is the same as the one used to control whether “Speed estimated” and “Speed remaining” are shown.