### PR TITLE
Dialogs/StatusPanels: clear some Task panel fields after task finish

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -7,6 +7,8 @@ Version 7.43-rc0 - 2024-06-02
   - add new Infobox V Task Est (Speed task estimated)
   - Status-Task panel: "Estimated task time", "Remaining time", and "Speed
     estimated" now blank if MC>0 & can't finish task
+  - Status-Task panel: "Remaining time", "Remaining distance", "Speed
+    estimated", and "Speed remaining" now blank after task is finished
   - add missing airspace to Select Airspace filter
   - NumberEntry dialog value can now be accepted by enter
   - Vario center gross label

--- a/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
@@ -54,15 +54,17 @@ TaskStatusPanel::Refresh() noexcept
     SetText(TaskTime,
             FormatTimeHHMM(backend_components->protected_task_manager->GetOrderedTaskSettings().aat_min_time));
 
-  if (task_stats.total.remaining_effective.IsDefined()) {
+  if (task_stats.total.remaining_effective.IsDefined())
     SetText(ETETime,
             FormatSignedTimeHHMM(task_stats.GetEstimatedTotalTime()));
+  else
+    ClearText(ETETime);
+
+  if (task_stats.total.remaining_effective.IsDefined() && !task_stats.task_finished)
     SetText(RemainingTime,
             FormatSignedTimeHHMM(task_stats.total.time_remaining_now));
-  } else {
-    ClearText(ETETime);
+  else
     ClearText(RemainingTime);
-  }
 
   if (task_stats.total.planned.IsDefined())
     SetText(TaskDistance,
@@ -70,11 +72,13 @@ TaskStatusPanel::Refresh() noexcept
   else
     ClearText(TaskDistance);
 
-  if (task_stats.total.remaining.IsDefined())
+  if (task_stats.total.remaining.IsDefined() && !task_stats.task_finished)
     SetText(RemainingDistance,
             FormatUserDistanceSmart(task_stats.total.remaining.GetDistance()));
+  else
+    ClearText(RemainingDistance);
 
-  if (task_stats.total.remaining_effective.IsDefined())
+  if (task_stats.total.remaining_effective.IsDefined() && !task_stats.task_finished)
     SetText(EstimatedSpeed,
             FormatUserTaskSpeed(task_stats.total.planned.GetSpeed()));
   else
@@ -102,7 +106,7 @@ TaskStatusPanel::Refresh() noexcept
   } else
     ClearValue(RANGE);
 
-  if (task_stats.total.remaining_effective.IsDefined())
+  if (task_stats.total.remaining_effective.IsDefined() && !task_stats.task_finished)
     LoadValue(SPEED_REMAINING, task_stats.total.remaining_effective.GetSpeed(),
               UnitGroup::TASK_SPEED);
   else


### PR DESCRIPTION
Make Status-Task panel fields "Remaining time", "Remaining distance", "Speed estimated", and "Speed remaining" blank after task finish. These fields have no meaning after the task is finished. The same could be said for "Estimated task time", by the way, but I left it visible even after task finish as the only way on this panel to see the actual task time after finishing the task.