### PR TITLE
src/Waypoint: allow non-airport home waypoint

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -17,6 +17,9 @@ Version 7.43-rc0 - 2024-06-02
   - infobox management page rename buttons for copying sets
   - consistent naming of ok/close buttons and placement
   - add PanTo button to waypoints dialog if opened from task related infoboxen
+* data files
+  - fix loss of "home" waypoint designation in certain situations for a 
+    non-airport home waypoint
 * devices
   - add Larus driver
 * windows

--- a/src/Waypoint/HomeGlue.cpp
+++ b/src/Waypoint/HomeGlue.cpp
@@ -39,7 +39,7 @@ FindHomeLocation(Waypoints &waypoints,
     return nullptr;
 
   auto wp = waypoints.LookupLocation(settings.home_location, 100);
-  if (wp == nullptr || !wp->IsAirport()) {
+  if (wp == nullptr) {
     settings.home_location_available = false;
     return nullptr;
   }


### PR DESCRIPTION
This changes the FindHomeLocation function to be like the FindHomeId and FindFlaggedHome functions in not requiring the home waypoint to be an airport. For reference, it’s also possible for the user to manually designate (via the “Set as New Home” button) a non-airport waypoint as the home waypoint. For many hang glider and paraglider pilots, the home waypoint is a mountaintop launch where landing isn’t possible.

Without this change, in certain scenarios, the “home” designation of a non-airport waypoint can be unexpectedly lost. For example, if a non-airport waypoint that exists in the “Waypoints” file has been set as “home” and the user changes which file is selected for “More waypoints”, the “home” designation of the user-desired waypoint is lost.