### PR TITLE
lua/Task: fix returned eta times

### DIFF
--- a/doc/lua.rst
+++ b/doc/lua.rst
@@ -334,8 +334,9 @@ The following attributes are provided by ``xcsoar.task``:
    - Estimated time [s] required to reach next waypoint, assuming
      performance of ideal MacCready cruise/climb cycle.
  * - ``next_eta``
-   - Estimated arrival local time at next waypoint,
-     assuming performance of ideal MacCready cruise/climb cycle.
+   - Estimated arrival local time, since midnight of the day of arrival,
+     at next waypoint, assuming performance of ideal MacCready cruise/climb
+     cycle [s].
  * - ``next_altitude_diff``
    - Arrival altitude at the next waypoint relative to the safety
      arrival height.
@@ -357,8 +358,9 @@ The following attributes are provided by ``xcsoar.task``:
    - Estimated time required to complete task, assuming performance of
      ideal MacCready cruise/climb cycle.
  * - ``final_eta``
-   - Estimated arrival local time at task completion, assuming
-     performance of ideal MacCready cruise/climb cycle.
+   - Estimated arrival local time, since midnight of the day of arrival,
+     at task completion, assuming performance of ideal MacCready cruise/climb
+     cycle [s].
  * - ``final_altitude_diff``
    - Arrival altitude at the final task turn point relative to the
      safety arrival height.

--- a/src/lua/Task.cpp
+++ b/src/lua/Task.cpp
@@ -87,9 +87,8 @@ l_task_index(lua_State *L)
 
       const BrokenTime t = now_local +
         duration_cast<seconds>(task_stats.current_leg.solution_remaining.time_elapsed);
-      float time = t.hour + (float)(t.second/60);
 
-      Lua::Push(L, time);
+      Lua::Push(L, t.DurationSinceMidnight());
   } else if (StringIsEqual(name, "next_altitude_diff")) {    
       const auto &task_stats = CommonInterface::Calculated().task_stats;
       const auto &next_solution = task_stats.current_leg.solution_remaining;
@@ -166,8 +165,7 @@ l_task_index(lua_State *L)
       const BrokenTime t = now_local +
         duration_cast<seconds>(task_stats.total.solution_remaining.time_elapsed);
 
-      float time = t.hour + (float)(t.minute/60);
-      Lua::Push(L, time);
+      Lua::Push(L, t.DurationSinceMidnight());
   } else if (StringIsEqual(name, "final_altitude_diff")) {
       const TaskStats &task_stats = CommonInterface::Calculated().task_stats;
       const auto &settings = CommonInterface::GetComputerSettings();


### PR DESCRIPTION
Fixes ETA times returned via `next_eta` and `final_eta` variables, now returning number of seconds since midnight of the day of arrival. Previous values did not make sense, at least by my level of understanding of the code.