### PR TITLE
Boost: Use non-deprecated version of multi_polygon.h

### DIFF
--- a/src/MapWindow/OverlayBitmap.cpp
+++ b/src/MapWindow/OverlayBitmap.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/geometry/geometries/register/ring.hpp>
 #include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/multi/geometries/multi_polygon.hpp>
+#include <boost/geometry/geometries/multi_polygon.hpp>
 #include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/strategies/strategies.hpp>


### PR DESCRIPTION
The old header for libboost multi polygon class is deprecated (boost/geometry/multi/geometries/multi_polygon.hpp) and will be removed in Boost 1.86. The new one is boost/geometry/geometries/multi_polygon.hpp.