### PR TITLE
remove redundant inequality comparison operators

### DIFF
--- a/src/Geo/Flat/FlatGeoPoint.hpp
+++ b/src/Geo/Flat/FlatGeoPoint.hpp
@@ -70,7 +70,6 @@ struct FlatGeoPoint : IntPoint2D {
   }
 
   constexpr bool operator==(const FlatGeoPoint &) const noexcept = default;
-  constexpr bool operator!=(const FlatGeoPoint &) const noexcept = default;
 
   [[gnu::pure]]
   bool Sort(const FlatGeoPoint& sp) const noexcept {
@@ -108,7 +107,6 @@ struct AFlatGeoPoint : public FlatGeoPoint {
   }
 
   constexpr bool operator==(const AFlatGeoPoint &) const noexcept = default;
-  constexpr bool operator!=(const AFlatGeoPoint &) const noexcept = default;
 
   /**
    * Ordering operator, used for set ordering.  Uses lexicographic comparison.

--- a/src/Geo/GeoPoint.hpp
+++ b/src/Geo/GeoPoint.hpp
@@ -264,7 +264,6 @@ struct GeoPoint {
   GeoPoint Middle(const GeoPoint &other) const noexcept;
 
   constexpr bool operator==(const GeoPoint &) const noexcept = default;
-  constexpr bool operator!=(const GeoPoint &) const noexcept = default;
 };
 
 static_assert(std::is_trivial<GeoPoint>::value, "type is not trivial");

--- a/src/Math/Point2D.hpp
+++ b/src/Math/Point2D.hpp
@@ -33,7 +33,6 @@ struct Point2D {
      y(static_cast<scalar_type>(src.y)) {}
 
   constexpr bool operator==(const Point2D<T, PT> &) const noexcept = default;
-  constexpr bool operator!=(const Point2D<T, PT> &) const noexcept = default;
 
   constexpr Point2D<T, PT> operator+(Point2D<T, PT> other) const noexcept {
     return { scalar_type(x + other.x), scalar_type(y + other.y) };


### PR DESCRIPTION
This PR addresses a part of Issue #1487 .

The LRM for C++20 says "per the rules for operator==, this will also allow inequality testing." In other words declaring the equality operator implicitly declares the inequality operator. The reference manual is not explicit about what happens if both operators are declared. To avoid ambiguity and inconsistent declarations of inequality operators (be it defaulted or not) I suggest to remove them.
Details to the “default comparisons” are here: https://en.cppreference.com/w/cpp/language/default_comparisons