### PR TITLE
Dialogs/Waypoint: change "Waypoints Editor" to "Waypoint Editor"

### DIFF
--- a/src/Dialogs/Waypoint/Manager.cpp
+++ b/src/Dialogs/Waypoint/Manager.cpp
@@ -283,7 +283,7 @@ dlgConfigWaypointsShowModal(Waypoints &waypoints) noexcept
   const DialogLook &look = UIGlobals::GetDialogLook();
   TWidgetDialog<WaypointManagerWidget>
     dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
-           look, _("Waypoints Editor"));
+           look, _("Waypoint Editor"));
   dialog.SetWidget(waypoints);
   dialog.GetWidget().CreateButtons(dialog);
   dialog.AddButton(_("Close"), mrCancel);


### PR DESCRIPTION
Change the title from "Waypoints Editor" to "Waypoint Editor" to match the label on the button that takes the user to the waypoint editor dialog and to be more consistent with other similar titles... like "Task Manager" (not "Tasks Manager") and "Waypoint List" (not "Waypoints List").