### PR TITLE
src/Waypoint: fix comments for SaveWaypoints function

### DIFF
--- a/src/Waypoint/WaypointGlue.hpp
+++ b/src/Waypoint/WaypointGlue.hpp
@@ -93,7 +93,8 @@ LoadWaypoints(Waypoints &way_points,
               ProgressListener &progress);
 
 /**
- * Append one waypoint to the file "user.cup".
+ * Recreate the file "user.cup", putting in it each waypoint in
+ * way_points that is flagged to be saved to "user.cup".
  *
  * Throws std::runtime_error on error;
  */


### PR DESCRIPTION
Correct the comments describing the SaveWaypoints function. It doesn't just add one waypoint to user.cup. It overwrites the file, writing to the new user.cup every waypoint in way_points with an "origin" of "USER" (i.e., every waypoint in memory that's marked as belonging in user.cup). This could happen after the user adds, deletes, or edits any number of waypoints.