### PR TITLE
remove inequality operator

### DIFF
--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -138,7 +138,6 @@ struct PageLayout
                          const bool concise=false) const noexcept;
 
   constexpr bool operator==(const PageLayout &other) const noexcept = default;
-  constexpr bool operator!=(const PageLayout &other) const noexcept = default;
 };
 
 struct PageSettings {


### PR DESCRIPTION
This is an add-on to PR #1505 where I had missed out this one inequality operator.

The declaration of the inequality operator "operator!=" together with the declaration of the "operator==", be it defaulted or not, may be a problem. The reference manual says "per the rules for operator==, this will also allow inequality testing." In other words declaring the equality operator implicitly declares the inequality operator. The reference manual is not explicit what happens if both operators are declared. Hence the excessive declaration of inequality operator should be removed from the code.
Details are here:
https://en.cppreference.com/w/cpp/language/default_comparisons

