### PR TITLE
InfoBoxes/Content: add Home Altitude Difference infobox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -6,6 +6,7 @@ Version 7.43-rc1 - not yet released
   - fix reachability calculation with older compilers (OpenVario,..)
 * ui
   - Airspace filter list can filter by type
+  - Add new Infobox “Home altitude difference” (Home AltD)
 * data files
   - reworked sgs-233 polar
   - new topology available from mapgen (incl rivers)

--- a/src/Computer/Settings.cpp
+++ b/src/Computer/Settings.cpp
@@ -20,6 +20,7 @@ PlacesOfInterestSettings::ClearHome()
 {
   home_waypoint = -1;
   home_location_available = false;
+  home_elevation_available = false;
 }
 
 void
@@ -28,6 +29,11 @@ PlacesOfInterestSettings::SetHome(const Waypoint &wp)
   home_waypoint = wp.id;
   home_location = wp.location;
   home_location_available = true;
+  if (wp.has_elevation) {
+    home_elevation = wp.elevation;
+    home_elevation_available = true;
+  } else
+    home_elevation_available = false;
 }
 
 void

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -95,6 +95,16 @@ struct PlacesOfInterestSettings {
   GeoPoint atc_reference;
   Angle magnetic_declination;
 
+  /**
+   * elevation of home waypoint is available
+   */
+  bool home_elevation_available;
+
+  /**
+   * elevation (if available) of home waypoint
+   */
+  double home_elevation;
+
   void SetDefaults() {
     ClearHome();
     atc_reference.SetInvalid();

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1136,6 +1136,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxTaskSpeedEst,
   },
 
+  // e_Home_AltDiff
+  {
+    N_("Home altitude difference"),
+    N_("Home AltD"),
+    N_("Arrival altitude at the home waypoint relative to the safety arrival height."),
+    UpdateInfoBoxHomeAltitudeDiff,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -9,6 +9,8 @@
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Formatter/Units.hpp"
+#include "Engine/GlideSolvers/GlideState.hpp"
+#include "Engine/GlideSolvers/MacCready.hpp"
 
 void
 UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept
@@ -29,6 +31,42 @@ UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept
     data.SetCommentFromBearingDifference(bd);
   } else
     data.SetCommentInvalid();
+}
+
+void
+UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  const ComputerSettings &settings = CommonInterface::GetComputerSettings();
+  const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
+  const MoreData &more_data = CommonInterface::Basic();
+  const DerivedInfo &calculated = CommonInterface::Calculated();
+
+  if (!basic.location_available ||
+      !more_data.NavAltitudeAvailable() ||
+      !settings.polar.glide_polar_task.IsValid() ||
+      !common_stats.vector_home.IsValid() ||
+      !settings.poi.home_location_available ||
+      !settings.poi.home_elevation_available) {
+    data.SetInvalid();
+    data.SetCommentInvalid();
+    return;
+  }
+
+  const GlideState glide_state(
+    basic.location.DistanceBearing(settings.poi.home_location),
+    settings.poi.home_elevation + settings.task.safety_height_arrival,
+    more_data.nav_altitude,
+    calculated.GetWindOrZero());
+
+  const GlideResult &result =
+    MacCready::Solve(settings.task.glide,
+                     settings.polar.glide_polar_task,
+                     glide_state);
+
+  // Display altitude difference and distance.
+  data.SetValueFromArrival(result.pure_glide_altitude_difference);
+  data.SetCommentFromDistance(common_stats.vector_home.distance);
 }
 
 void

--- a/src/InfoBoxes/Content/Places.hpp
+++ b/src/InfoBoxes/Content/Places.hpp
@@ -9,6 +9,9 @@ void
 UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept;
 
 void
+UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept;
+
+void
 UpdateInfoBoxTakeoffDistance(InfoBoxData &data) noexcept;
 
 extern const struct InfoBoxPanel atc_infobox_panels[];

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -138,13 +138,14 @@ namespace InfoBoxFactory
     e_Thermal_Time, /* Time in Thermal*/
     e_Alternate_2_GR, /* Geometric gradient to the arrival height above the second alternate. This is not adjusted for total energy */
     e_HeartRate,
-    /* 120..126 */
+    /* 120..127 */
     e_TransponderCode, /* Transponder code */
     e_EngineCHT,  /* Engine Cylinder Head Temperature */
     e_EngineEGT,  /* Engine Exhaust Gas Temperature */
     e_EngineRPM,  /* Engine Revolutions Per Minute */
     e_AAT_dT_or_ETA, /* Delta time in AAT task and ETA in racing task */
     e_SpeedTaskEst, /* Estimated (predicted) whole-task average cross-country speed for current task. Affected by MC setting. */
+    e_Home_AltDiff, /* Arrival altitude at the home waypoint (if defined) relative to the safety arrival height */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/Waypoint/HomeGlue.cpp
+++ b/src/Waypoint/HomeGlue.cpp
@@ -27,6 +27,13 @@ FindHomeId(Waypoints &waypoints,
 
   settings.home_location = wp->location;
   settings.home_location_available = true;
+
+  if (wp->has_elevation) {
+    settings.home_elevation = wp->elevation;
+    settings.home_elevation_available = true;
+  } else
+    settings.home_elevation_available = false;
+
   waypoints.SetHome(wp->id);
   return wp;
 }
@@ -35,14 +42,23 @@ WaypointPtr
 FindHomeLocation(Waypoints &waypoints,
                  PlacesOfInterestSettings &settings) noexcept
 {
-  if (!settings.home_location_available)
+  if (!settings.home_location_available) {
+    settings.home_elevation_available = false;
     return nullptr;
+  }
 
   auto wp = waypoints.LookupLocation(settings.home_location, 100);
   if (wp == nullptr || !wp->IsAirport()) {
     settings.home_location_available = false;
+    settings.home_elevation_available = false;
     return nullptr;
   }
+
+  if (wp->has_elevation) {
+    settings.home_elevation = wp->elevation;
+    settings.home_elevation_available = true;
+  } else
+    settings.home_elevation_available = false;
 
   settings.home_waypoint = wp->id;
   waypoints.SetHome(wp->id);


### PR DESCRIPTION
This change adds a “Home altitude difference” (arrival altitude to home waypoint) infobox. This idea came from discussion 1464 (https://github.com/XCSoar/XCSoar/discussions/1464). Top Hat has had this infobox for 11 years. I agree with the requestor (a Top Hat user wanting to switch to XCSoar) in the discussion that the most important thing a flight computer can do is inform you about your reach to a safe landing place, and having this info in an infobox makes the info easier to get. Currently, one typically needs to pan and zoom or visit the alternates list or waypoints list in order to get this info while flying a task.