### PR TITLE
Engine/Task: fix calculation of achieved task distance

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,11 @@ Version 7.43-rc1 - not yet released
 Version 7.43-rc0 - 2024-06-02
 * map
   - reachable map labels show correct altitude with head wind #1424
+* calculations
+  - Fix calculation of achieved task distance (making it total planned task
+    distance minus task distance remaining), thus fixing the values "Speed
+    task achieved", "Speed task average", and "Speed task last hour" shown in
+    infoboxes and/or Status-Task panel fields.
 * ui
   - TC 30s Infobox shows now climb rate since start of thermal
   - TL Gain Infobox shows now the overall climb rate of last thermal

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -770,6 +770,11 @@ Version 7.43-rc1 - not yet released
 Version 7.43-rc0 - 2024-06-02
 * map
   - reachable map labels show correct altitude with head wind #1424
+* calculations
+  - Fix calculation of achieved task distance (making it total planned task
+    distance minus task distance remaining), thus fixing the values "Speed
+    task achieved", "Speed task average", and "Speed task last hour" shown in
+    infoboxes and/or Status-Task panel fields.
 * ui
   - TC 30s Infobox shows now climb rate since start of thermal
   - TL Gain Infobox shows now the overall climb rate of last thermal

--- a/src/Engine/Task/AbstractTask.cpp
+++ b/src/Engine/Task/AbstractTask.cpp
@@ -133,8 +133,8 @@ AbstractTask::UpdateStatsDistances(const GeoPoint &location,
   ScanDistanceMinMax(location, full_update,
                        &stats.distance_min, &stats.distance_max);
 
-  stats.total.travelled.SetDistance(ScanDistanceTravelled(location));
   stats.total.planned.SetDistance(ScanDistancePlanned());
+  stats.total.travelled.SetDistance(ScanDistanceTravelled());
 
   if (IsScored()) {
     if (!stats.start.HasStarted())

--- a/src/Engine/Task/AbstractTask.cpp
+++ b/src/Engine/Task/AbstractTask.cpp
@@ -135,8 +135,8 @@ AbstractTask::UpdateStatsDistances(const GeoPoint &location,
   ScanDistanceMinMax(location, full_update,
                        &stats.distance_min, &stats.distance_max);
 
-  stats.total.travelled.SetDistance(ScanDistanceTravelled(location));
   stats.total.planned.SetDistance(ScanDistancePlanned());
+  stats.total.travelled.SetDistance(ScanDistanceTravelled());
 
   if (IsScored()) {
     if (!stats.start.HasStarted())

--- a/src/Engine/Task/AbstractTask.hpp
+++ b/src/Engine/Task/AbstractTask.hpp
@@ -295,16 +295,12 @@ protected:
   virtual double ScanDistanceScored(const GeoPoint &ref) noexcept = 0;
 
   /**
-   * Calculate distance of achieved part of task.
-   * For previous taskpoints, the sum of distances of maximum distance
-   * points; for current, the distance from previous max distance point to
-   * the aircraft.
-   *
-   * @param ref Location of aircraft
+   * Calculate achieved task distance:
+   *   total planned task distance minus task distance remaining
    *
    * @return Distance (m) achieved
    */
-  virtual double ScanDistanceTravelled(const GeoPoint &ref) noexcept = 0;
+  virtual double ScanDistanceTravelled() noexcept = 0;
 
   /**
    * Calculate maximum and minimum distances for task, achievable

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -387,11 +387,9 @@ OrderedTask::ScanDistanceRemaining(const GeoPoint &location) noexcept
 }
 
 double
-OrderedTask::ScanDistanceTravelled(const GeoPoint &location) noexcept
+OrderedTask::ScanDistanceTravelled() noexcept
 {
-  return task_points.empty()
-    ? 0
-    : task_points.front()->ScanDistanceTravelled(location);
+  return stats.total.planned.GetDistance() - stats.total.remaining.GetDistance();
 }
 
 double

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -418,11 +418,9 @@ OrderedTask::ScanDistanceRemaining(const GeoPoint &location) noexcept
 }
 
 double
-OrderedTask::ScanDistanceTravelled(const GeoPoint &location) noexcept
+OrderedTask::ScanDistanceTravelled() noexcept
 {
-  return task_points.empty()
-    ? 0
-    : task_points.front()->ScanDistanceTravelled(location);
+  return stats.total.planned.GetDistance() - stats.total.remaining.GetDistance();
 }
 
 double

--- a/src/Engine/Task/Ordered/OrderedTask.hpp
+++ b/src/Engine/Task/Ordered/OrderedTask.hpp
@@ -676,7 +676,7 @@ protected:
   double ScanDistancePlanned() noexcept override;
   double ScanDistanceRemaining(const GeoPoint &ref) noexcept override;
   double ScanDistanceScored(const GeoPoint &ref) noexcept override;
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept override;
+  double ScanDistanceTravelled() noexcept override;
   void ScanDistanceMinMax(const GeoPoint &ref, bool full,
                           double *dmin, double *dmax) noexcept override;
   void GlideSolutionRemaining(const AircraftState &state_now,

--- a/src/Engine/Task/Ordered/OrderedTask.hpp
+++ b/src/Engine/Task/Ordered/OrderedTask.hpp
@@ -711,7 +711,7 @@ protected:
   double ScanDistancePlanned() noexcept override;
   double ScanDistanceRemaining(const GeoPoint &ref) noexcept override;
   double ScanDistanceScored(const GeoPoint &ref) noexcept override;
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept override;
+  double ScanDistanceTravelled() noexcept override;
   void ScanDistanceMinMax(const GeoPoint &ref, bool full,
                           double *dmin, double *dmax) noexcept override;
   double ScanDistanceMaxTotal() noexcept override;

--- a/src/Engine/Task/Points/ScoredTaskPoint.hpp
+++ b/src/Engine/Task/Points/ScoredTaskPoint.hpp
@@ -113,15 +113,6 @@ public:
   [[gnu::pure]]
   const GeoPoint &GetLocationScored() const noexcept;
 
-  /**
-   * Retrieve location to be used for the task already travelled.
-   * This is always the scored best location for prior-active task points.
-   */
-  [[gnu::pure]]
-  const GeoPoint &GetLocationTravelled() const noexcept {
-    return GetLocationMin();
-  }
-
 protected:
   /**
    * Check if aircraft has transitioned to inside sector

--- a/src/Engine/Task/Points/TaskLeg.cpp
+++ b/src/Engine/Task/Points/TaskLeg.cpp
@@ -67,53 +67,6 @@ TaskLeg::GetRemainingVector(const GeoPoint &ref) const noexcept
   return GeoVector::Invalid();
 }
 
-inline GeoVector
-TaskLeg::GetTravelledVector(const GeoPoint &ref) const noexcept
-{
-  switch (destination.GetActiveState()) {
-  case OrderedTaskPoint::BEFORE_ACTIVE:
-    if (!GetOrigin())
-      return GeoVector::Zero();
-
-    // this leg totally included
-    return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                               destination.GetLocationTravelled());
-
-  case OrderedTaskPoint::CURRENT_ACTIVE:
-    // this leg partially included
-    if (!GetOrigin())
-      return GeoVector(0,
-                       ref.IsValid()
-                       ? ref.Bearing(destination.GetLocationRemaining())
-                       : Angle::Zero());
-
-    if (destination.HasEntered())
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                                 destination.GetLocationTravelled());
-    else if (!ref.IsValid())
-      return GeoVector::Zero();
-    else
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(), ref);
-
-  case OrderedTaskPoint::AFTER_ACTIVE:
-    if (!GetOrigin())
-      return GeoVector::Zero();
-
-    // this leg may be partially included
-    if (GetOrigin()->HasEntered())
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                                 ref.IsValid()
-                                 ? ref
-                                 : destination.GetLocationTravelled());
-
-    return GeoVector::Zero();
-  }
-
-  gcc_unreachable();
-  assert(false);
-  return GeoVector::Invalid();
-}
-
 inline double
 TaskLeg::GetScoredDistance(const GeoPoint &ref) const noexcept
 {
@@ -181,14 +134,6 @@ TaskLeg::GetMinimumLegDistance() const noexcept
     return memo_min.Distance(GetOrigin()->GetLocationMin(),
                              destination.GetLocationMin());
   return 0;
-}
-
-double
-TaskLeg::ScanDistanceTravelled(const GeoPoint &ref) noexcept
-{
-  vector_travelled = GetTravelledVector(ref);
-  return vector_travelled.distance +
-    (GetNext() ? GetNext()->ScanDistanceTravelled(ref) : 0);
 }
 
 double

--- a/src/Engine/Task/Points/TaskLeg.cpp
+++ b/src/Engine/Task/Points/TaskLeg.cpp
@@ -67,53 +67,6 @@ TaskLeg::GetRemainingVector(const GeoPoint &ref) const noexcept
   return GeoVector::Invalid();
 }
 
-inline GeoVector
-TaskLeg::GetTravelledVector(const GeoPoint &ref) const noexcept
-{
-  switch (destination.GetActiveState()) {
-  case OrderedTaskPoint::BEFORE_ACTIVE:
-    if (!GetOrigin())
-      return GeoVector::Zero();
-
-    // this leg totally included
-    return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                               destination.GetLocationTravelled());
-
-  case OrderedTaskPoint::CURRENT_ACTIVE:
-    // this leg partially included
-    if (!GetOrigin())
-      return GeoVector(0,
-                       ref.IsValid()
-                       ? ref.Bearing(destination.GetLocationRemaining())
-                       : Angle::Zero());
-
-    if (destination.HasEntered())
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                                 destination.GetLocationTravelled());
-    else if (!ref.IsValid())
-      return GeoVector::Zero();
-    else
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(), ref);
-
-  case OrderedTaskPoint::AFTER_ACTIVE:
-    if (!GetOrigin())
-      return GeoVector::Zero();
-
-    // this leg may be partially included
-    if (GetOrigin()->HasEntered())
-      return memo_travelled.calc(GetOrigin()->GetLocationTravelled(),
-                                 ref.IsValid()
-                                 ? ref
-                                 : destination.GetLocationTravelled());
-
-    return GeoVector::Zero();
-  }
-
-  gcc_unreachable();
-  assert(false);
-  return GeoVector::Invalid();
-}
-
 inline double
 TaskLeg::GetScoredDistance(const GeoPoint &ref) const noexcept
 {
@@ -190,14 +143,6 @@ TaskLeg::GetMinimumLegDistance() const noexcept
     return memo_min.Distance(GetOrigin()->GetLocationMin(),
                              destination.GetLocationMin());
   return 0;
-}
-
-double
-TaskLeg::ScanDistanceTravelled(const GeoPoint &ref) noexcept
-{
-  vector_travelled = GetTravelledVector(ref);
-  return vector_travelled.distance +
-    (GetNext() ? GetNext()->ScanDistanceTravelled(ref) : 0);
 }
 
 double

--- a/src/Engine/Task/Points/TaskLeg.hpp
+++ b/src/Engine/Task/Points/TaskLeg.hpp
@@ -106,18 +106,6 @@ public:
   double ScanDistanceScored(const GeoPoint &ref) const noexcept;
 
   /**
-   * Calculate distance of achieved part of task.
-   * For previous taskpoints, the sum of distances of maximum distance
-   * points; for current, the distance from previous max distance point to
-   * the aircraft.
-   *
-   * @param ref Location of aircraft
-   *
-   * @return Distance (m) achieved
-   */
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept;
-
-  /**
    * Retrieve maximum possible leg distance
    *
    * @return Distance (m)
@@ -170,10 +158,7 @@ public:
 private:
   [[gnu::pure]]
   GeoVector GetPlannedVector() const noexcept;
-  
-  [[gnu::pure]]
-  GeoVector GetTravelledVector(const GeoPoint &ref) const noexcept;
-  
+
   [[gnu::pure]]
   GeoVector GetRemainingVector(const GeoPoint &ref) const noexcept;
 

--- a/src/Engine/Task/Points/TaskLeg.hpp
+++ b/src/Engine/Task/Points/TaskLeg.hpp
@@ -116,25 +116,13 @@ public:
   double ScanDistanceScored(const GeoPoint &ref) const noexcept;
 
   /**
-   * Calculate distance of achieved part of task.
-   * For previous taskpoints, the sum of distances of maximum distance
-   * points; for current, the distance from previous max distance point to
-   * the aircraft.
-   *
-   * @param ref Location of aircraft
-   *
-   * @return Distance (m) achieved
-   */
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept;
-
-  /**
    * Retrieve maximum distance for the task leg
    *
    * @return Distance (m)
    */
   [[gnu::pure]]
   double GetMaximumTotalLegDistance() const noexcept;
-  
+
   /**
    * Retrieve maximum possible leg distance
    *
@@ -188,10 +176,7 @@ public:
 private:
   [[gnu::pure]]
   GeoVector GetPlannedVector() const noexcept;
-  
-  [[gnu::pure]]
-  GeoVector GetTravelledVector(const GeoPoint &ref) const noexcept;
-  
+
   [[gnu::pure]]
   GeoVector GetRemainingVector(const GeoPoint &ref) const noexcept;
 

--- a/src/Engine/Task/Unordered/UnorderedTask.cpp
+++ b/src/Engine/Task/Unordered/UnorderedTask.cpp
@@ -167,7 +167,7 @@ UnorderedTask::ScanDistanceScored([[maybe_unused]] const GeoPoint &location) noe
 }
 
 double
-UnorderedTask::ScanDistanceTravelled([[maybe_unused]] const GeoPoint &location) noexcept
+UnorderedTask::ScanDistanceTravelled() noexcept
 {
   return 0;
 }

--- a/src/Engine/Task/Unordered/UnorderedTask.cpp
+++ b/src/Engine/Task/Unordered/UnorderedTask.cpp
@@ -169,7 +169,7 @@ UnorderedTask::ScanDistanceScored([[maybe_unused]] const GeoPoint &location) noe
 }
 
 double
-UnorderedTask::ScanDistanceTravelled([[maybe_unused]] const GeoPoint &location) noexcept
+UnorderedTask::ScanDistanceTravelled() noexcept
 {
   return 0;
 }

--- a/src/Engine/Task/Unordered/UnorderedTask.hpp
+++ b/src/Engine/Task/Unordered/UnorderedTask.hpp
@@ -35,7 +35,7 @@ public:
   double ScanDistancePlanned() noexcept override;
   double ScanDistanceRemaining(const GeoPoint &ref) noexcept override;
   double ScanDistanceScored(const GeoPoint &ref) noexcept override;
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept override;
+  double ScanDistanceTravelled() noexcept override;
   void ScanDistanceMinMax(const GeoPoint &ref, bool full,
                           double *dmin, double *dmax) noexcept override;
   void GlideSolutionRemaining(const AircraftState &state_now,

--- a/src/Engine/Task/Unordered/UnorderedTask.hpp
+++ b/src/Engine/Task/Unordered/UnorderedTask.hpp
@@ -35,7 +35,7 @@ public:
   double ScanDistancePlanned() noexcept override;
   double ScanDistanceRemaining(const GeoPoint &ref) noexcept override;
   double ScanDistanceScored(const GeoPoint &ref) noexcept override;
-  double ScanDistanceTravelled(const GeoPoint &ref) noexcept override;
+  double ScanDistanceTravelled() noexcept override;
   void ScanDistanceMinMax(const GeoPoint &ref, bool full,
                           double *dmin, double *dmax) noexcept override;
   double ScanDistanceMaxTotal() noexcept override;

--- a/test/src/TestOrderedTask.cpp
+++ b/test/src/TestOrderedTask.cpp
@@ -2,12 +2,15 @@
 // Copyright The XCSoar Project
 
 #include "Engine/GlideSolvers/GlidePolar.hpp"
+#include "Engine/Navigation/Aircraft.hpp"
 #include "Engine/Task/TaskEvents.hpp"
 #include "Engine/Task/Ordered/Settings.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/Points/StartPoint.hpp"
 #include "Engine/Task/Ordered/Points/FinishPoint.hpp"
 #include "Engine/Task/Ordered/Points/ASTPoint.hpp"
+#include "Engine/Task/Ordered/Points/AATPoint.hpp"
+#include "Engine/Task/ObservationZones/CylinderZone.hpp"
 #include "Engine/Task/ObservationZones/LineSectorZone.hpp"
 
 #define ACCURACY 500
@@ -160,6 +163,41 @@ CheckTotal(const AircraftState &aircraft, const TaskStats &stats,
              glide_polar.GetMC() > 0
              ? alt_required_at_aircraft - aircraft.altitude
              : 0));
+}
+
+static constexpr AircraftState
+MakeTimedAircraft(double longitude, double latitude, double altitude,
+                  FloatDuration time) noexcept
+{
+  AircraftState aircraft = MakeAircraft(longitude, latitude, altitude);
+  aircraft.time = TimeStamp{time};
+  aircraft.flying = true;
+  return aircraft;
+}
+
+static void
+ExitStartCylinder(OrderedTask &task, const GeoPoint &center,
+                  double altitude)
+{
+  const auto state_last = MakeTimedAircraft(center.longitude.Degrees(),
+                                            center.latitude.Degrees(),
+                                            altitude, FloatDuration{3600});
+  const auto state_now = MakeTimedAircraft(center.longitude.Degrees(),
+                                           center.latitude.Degrees() + 0.006,
+                                           altitude, FloatDuration{3660});
+  task.Update(state_now, state_last, glide_polar);
+  ok1(task.GetStats().start.HasStarted());
+}
+
+static void
+CheckTravelledDistance(const TaskStats &stats)
+{
+  ok1(stats.total.planned.IsDefined());
+  ok1(stats.total.remaining.IsDefined());
+  ok1(stats.total.travelled.IsDefined());
+  ok1(equals(stats.total.travelled.GetDistance(),
+             stats.total.planned.GetDistance() -
+             stats.total.remaining.GetDistance()));
 }
 
 static void
@@ -388,6 +426,89 @@ TestLowTPFinal()
 }
 
 static void
+TestTravelledDistance()
+{
+  ordered_task_settings.SetDefaults();
+
+  {
+    OrderedTask task(task_behaviour);
+    const StartPoint tp1(std::make_unique<LineSectorZone>(wp1->location),
+                         WaypointPtr(wp1), task_behaviour,
+                         ordered_task_settings.start_constraints);
+    task.Append(tp1);
+    const FinishPoint tp2(std::make_unique<LineSectorZone>(wp2->location),
+                          WaypointPtr(wp2), task_behaviour,
+                          ordered_task_settings.finish_constraints, false);
+    task.Append(tp2);
+    task.SetActiveTaskPoint(1);
+    task.UpdateGeometry();
+    ok1(!IsError(task.CheckTask()));
+
+    const auto aircraft = MakeAircraft(wp1->location, 2000);
+    task.Update(aircraft, aircraft, glide_polar);
+
+    const TaskStats &stats = task.GetStats();
+    CheckTravelledDistance(stats);
+    ok1(equals(stats.total.travelled.GetDistance(), 0));
+  }
+
+  {
+    const double width(1);
+    OrderedTask task(task_behaviour);
+    task.Append(StartPoint(std::make_unique<CylinderZone>(wp1->location, 500),
+                           WaypointPtr(wp1), task_behaviour,
+                           ordered_task_settings.start_constraints));
+    const ASTPoint tp2(std::make_unique<LineSectorZone>(wp3->location, width),
+                       MakeWaypointPtr(*wp3, 1500), task_behaviour);
+    task.Append(tp2);
+    const FinishPoint tp3(std::make_unique<LineSectorZone>(wp4->location, width),
+                          MakeWaypointPtr(*wp4, 100), task_behaviour,
+                          ordered_task_settings.finish_constraints, false);
+    task.Append(tp3);
+    task.SetActiveTaskPoint(1);
+    task.UpdateGeometry();
+    ok1(!IsError(task.CheckTask()));
+
+    ExitStartCylinder(task, wp1->location, 2000);
+
+    const auto state_last = MakeTimedAircraft(0, 45.05, 2000,
+                                              FloatDuration{3720});
+    const auto state_now = MakeTimedAircraft(0, 45.15, 2000,
+                                             FloatDuration{3780});
+    task.Update(state_now, state_last, glide_polar);
+    CheckTravelledDistance(task.GetStats());
+  }
+
+  {
+    OrderedTask task(task_behaviour);
+    task.Append(StartPoint(std::make_unique<CylinderZone>(wp1->location, 500),
+                           WaypointPtr(wp1), task_behaviour,
+                           ordered_task_settings.start_constraints));
+    task.Append(AATPoint(std::make_unique<CylinderZone>(wp2->location, 10000),
+                         WaypointPtr(wp2), task_behaviour));
+    task.Append(FinishPoint(std::make_unique<CylinderZone>(wp3->location, 500),
+                            WaypointPtr(wp3), task_behaviour,
+                            ordered_task_settings.finish_constraints));
+    task.SetActiveTaskPoint(1);
+    task.UpdateGeometry();
+    ok1(!IsError(task.CheckTask()));
+
+    AATPoint &aat = (AATPoint &)task.GetPoint(1);
+    aat.SetTarget(MakeGeoPoint(0, 45.31), true);
+    task.UpdateGeometry();
+
+    ExitStartCylinder(task, wp1->location, 2000);
+
+    const auto state_last = MakeTimedAircraft(0, 45.05, 2000,
+                                              FloatDuration{3720});
+    const auto state_now = MakeTimedAircraft(0, 45.15, 2000,
+                                             FloatDuration{3780});
+    task.Update(state_now, state_last, glide_polar);
+    CheckTravelledDistance(task.GetStats());
+  }
+}
+
+static void
 TestAll()
 {
   TestFlightToFinish(2000);
@@ -401,10 +522,11 @@ TestAll()
 
 int main()
 {
-  plan_tests(728);
+  plan_tests(746);
 
   task_behaviour.SetDefaults();
 
+  TestTravelledDistance();
   TestAll();
 
   glide_polar.SetMC(1);


### PR DESCRIPTION
This change fixes the calculation of achieved task distance, making it total planned task distance minus task distance remaining. Without this fix, achieved task distance is calculated as the sum of completed legs’ distances plus the distance from the start of the current leg to the aircraft’s current location, which is only accurate if the aircraft is exactly on the course line. This calculation affects the values shown in infoboxes “Speed task achieved”, “Speed task average”, and “Speed task last hour” and in the “Speed average” and “Achieved speed” fields on the Status-Task panel. A simple way to see the problem with the current calculation is to start a task and then turn and fly perpendicular to the task line. The “Speed task average” infobox, for example, will show a speed roughly equal to ground speed even though you’re getting no closer to the active task point – and even after you’re farther from the active task point than you were when you started the task.