### PR TITLE
Engine/Task/Stats: clarify comment describing time_remaining_start

### DIFF
--- a/src/Engine/Task/Stats/ElementStat.hpp
+++ b/src/Engine/Task/Stats/ElementStat.hpp
@@ -52,8 +52,8 @@ struct ElementStat
   FloatDuration time_remaining_now;
 
   /**
-   * Time (s) remaining to element completion, counted from the start
-   * of the task.
+   * Time (s) remaining to element completion from now, excluding the
+   * time to reach the start point (if task was not yet started).
    */
   FloatDuration time_remaining_start;
 


### PR DESCRIPTION
Clarify that time_remaining_start starts at the task start only if the task hasn't been started.

The current comment is accurate only if the task hasn't been started. If the task has been started, time_remaining_start counts from NOW, not from when the task was started. Between the variable's somewhat confusing name and this incorrect comment, I was chasing my tail while working on something that involves time_remaining_start. After studying how it's used in the code, I found the error in the comment description. Hopefully this comment correction/clarification will help future developers avoid some confusion.

I made the revised comment exactly like the comment for time_remaining_now except to change "including" to "excluding".