### PR TITLE
src/Engine/Airspace/AbstractAirspace.hpp: change GetClassType to GetT…

### DIFF
--- a/src/CrossSection/AirspaceXSRenderer.cpp
+++ b/src/CrossSection/AirspaceXSRenderer.cpp
@@ -122,7 +122,7 @@ AirspaceIntersectionVisitorSlice::RenderBox(const PixelRect rc,
 inline void
 AirspaceIntersectionVisitorSlice::Render(const AbstractAirspace &as) const
 {
-  AirspaceClass asclass = as.GetClassType();
+  AirspaceClass asclass = as.GetTypeOrClass();
 
   // No intersections for this airspace
   if (intersections.empty())

--- a/src/Engine/Airspace/AbstractAirspace.hpp
+++ b/src/Engine/Airspace/AbstractAirspace.hpp
@@ -250,7 +250,7 @@ public:
     *
     * @return  AirspaceClass - The determined airspace class type
     */
-  AirspaceClass GetClassType() const noexcept {
+  AirspaceClass GetTypeOrClass() const noexcept {
     return GetType() == AirspaceClass::OTHER ? GetClass() : GetType();
   }
 

--- a/src/Renderer/AirspacePreviewRenderer.cpp
+++ b/src/Renderer/AirspacePreviewRenderer.cpp
@@ -126,7 +126,7 @@ AirspacePreviewRenderer::Draw(Canvas &canvas, const AbstractAirspace &airspace,
                               const AirspaceLook &look)
 {
   AbstractAirspace::Shape shape = airspace.GetShape();
-  AirspaceClass asclass = airspace.GetClassType();
+  AirspaceClass asclass = airspace.GetTypeOrClass();
 
   // Container for storing the points of a polygon airspace
   std::vector<BulkPixelPoint> pts;

--- a/src/Renderer/AirspaceRendererGL.cpp
+++ b/src/Renderer/AirspaceRendererGL.cpp
@@ -138,7 +138,7 @@ public:
 
 private:
   bool SetupOutline(const AbstractAirspace &airspace) {
-    AirspaceClass type = airspace.GetClassType();
+    AirspaceClass type = airspace.GetTypeOrClass();
 
     if (settings.black_outline)
       canvas.SelectBlackPen();
@@ -258,7 +258,7 @@ public:
 
 private:
   bool SetupOutline(const AbstractAirspace &airspace) {
-    AirspaceClass type = airspace.GetClassType();
+    AirspaceClass type = airspace.GetTypeOrClass();
 
     if (settings.black_outline)
       canvas.SelectBlackPen();


### PR DESCRIPTION
…ypeOrClass

GetClassType is a confusing function name as GetClassOrType also exist

GetClassOrType returns the Class if the class is not unclassified else returns Type

Since GetClassType does the opposite return Type if type is not other else returns class, the new name makes it easier to distinguish both functions