### PR TITLE
Improve readability and fix airspace coloring bugs

### DIFF
--- a/src/Renderer/AirspacePreviewRenderer.cpp
+++ b/src/Renderer/AirspacePreviewRenderer.cpp
@@ -126,7 +126,7 @@ AirspacePreviewRenderer::Draw(Canvas &canvas, const AbstractAirspace &airspace,
                               const AirspaceLook &look)
 {
   AbstractAirspace::Shape shape = airspace.GetShape();
-  AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+  AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
 
   // Container for storing the points of a polygon airspace
   std::vector<BulkPixelPoint> pts;

--- a/src/Renderer/AirspaceRendererGL.cpp
+++ b/src/Renderer/AirspaceRendererGL.cpp
@@ -43,7 +43,7 @@ public:
 
 private:
   void VisitCircle(const AirspaceCircle &airspace) {
-	AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+	AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     const AirspaceClassRendererSettings &class_settings =
       settings.classes[as_type_or_class];
     const AirspaceClassLook &class_look = look.classes[as_type_or_class];
@@ -81,7 +81,7 @@ private:
   }
 
   void VisitPolygon(const AirspacePolygon &airspace) {
-	AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+	AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     if (!PreparePolygon(airspace.GetPoints()))
       return;
 
@@ -140,7 +140,7 @@ public:
 
 private:
   bool SetupOutline(const AbstractAirspace &airspace) {
-    AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+    AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
 
     if (settings.black_outline)
       canvas.SelectBlackPen();
@@ -162,7 +162,7 @@ private:
 
   void SetupInterior(const AbstractAirspace &airspace,
                      bool check_fillstencil = false) {
-	AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+	AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     const AirspaceClassLook &class_look = look.classes[as_type_or_class];
 
     // restrict drawing area and don't paint over previously drawn outlines
@@ -261,7 +261,7 @@ public:
 
 private:
   bool SetupOutline(const AbstractAirspace &airspace) {
-    AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+    AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
 
     if (settings.black_outline)
       canvas.SelectBlackPen();
@@ -277,7 +277,7 @@ private:
   }
 
   bool SetupInterior(const AbstractAirspace &airspace) {
-	AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+	AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     if (settings.fill_mode == AirspaceRendererSettings::FillMode::NONE)
       return false;
 

--- a/src/Renderer/AirspaceRendererOther.cpp
+++ b/src/Renderer/AirspaceRendererOther.cpp
@@ -67,7 +67,7 @@ public:
     if (warnings.IsAcked(airspace))
       return;
 
-    AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+    AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     if (settings.fill_mode == AirspaceRendererSettings::FillMode::NONE ||
         settings.classes[as_type_or_class].fill_mode ==
         AirspaceClassRendererSettings::FillMode::NONE)
@@ -89,7 +89,7 @@ public:
 
 private:
   void SetBufferPens(const AbstractAirspace &airspace) {
-    AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+    AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
 
 #ifndef HAVE_HATCHED_BRUSH
     buffer.Select(look.classes[as_type_or_class].solid_brush);
@@ -153,7 +153,7 @@ protected:
     if (settings.black_outline)
       return true;
 
-    AirspaceClass as_type_or_class = airspace.GetTypeOrClass();
+    AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
     if (settings.classes[as_type_or_class].border_width == 0)
       // Don't draw outlines if border_width == 0
       return false;


### PR DESCRIPTION

I believe that with this all the initial bugs with the coloring of the new extended format are fixed. 
But maybe we should add some documentation somewhere about what is used type vs class and how to ignore the type.

Also i find this a logical way of dealing with it but that is just based on my use case.

So to summarize the logic:
If an AY tag is present (which is not other) and that type has its display setting to true the color settings of that airspace type will be used 

If an AY tag is present (which is not other) and that type has its display setting to false the color settings of that airspace class will be used instead allowing to basically ignore certain/all airspace types based on user preferences as the type is not always relevant TMA's for example.

If no AY tag is present or the AY tag is 'other' the airspace class will be used for the colors of the airspace.