### PR TITLE
Fixed deprecation compilation warnings on cares.

### DIFF
--- a/src/event/net/cares/Channel.hxx
+++ b/src/event/net/cares/Channel.hxx
@@ -32,6 +32,7 @@ class Channel {
 
   class Socket;
 
+  std::forward_list<Socket> sockets;
 
   class Request;
 
@@ -60,11 +61,11 @@ public:
 
 private:
   void UpdateSockets() noexcept;
-
   void ScheduleUpdateSockets() noexcept { defer_update_sockets.Schedule(); }
-
   void OnSocket(SocketDescriptor fd, unsigned events) noexcept;
   void OnTimeout() noexcept;
+  static void sock_state_cb(void *data, ares_socket_t socket_fd, int readable, int writable);
+
 };
 
 } // namespace Cares

--- a/src/event/net/cares/Channel.hxx
+++ b/src/event/net/cares/Channel.hxx
@@ -32,7 +32,6 @@ class Channel {
 
   class Socket;
 
-  std::forward_list<Socket> sockets;
 
   class Request;
 


### PR DESCRIPTION
C-ares has deprecated some of the functions used:
- ares_init -> substituted by ares_init_options
- ares_gethostbyname -> substituted by ares_getaddrinfo, had to change some types and auxiliary functions but should work ok
- ares_getsock -> Basically limited to 16 sockets, while the library can do much more, there's no easy substitute and fixing it would require wrting a callback that's called each time a socket has a change of state and maintain a list of sockets pending to do something (what was done, basically). I started to write such callback, but then noticed that the forward_list of pending sockets is maintained, but actually never used ; so removed the list altogether

Should close  #1520 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a family-aware DNS lookup overload; default lookup now queries both IPv4 and IPv6.

* **Performance**
  * DNS resolution now leverages event-driven socket notifications, reducing unnecessary wakeups and improving responsiveness.

* **Refactor**
  * DNS flow migrated to addrinfo-based handling and simplified watcher/timeout management for more reliable and maintainable resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->