### PR TITLE
Fixed compatibility with ImageMagick v7

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -210,15 +210,15 @@ $(SOUND_FILES): $(RAW_DIR)/%.ogg: Data/sound/%.wav | $(RAW_DIR)/dirstamp
 PNG1 := $(patsubst Data/bitmaps/%.bmp,$(DRAWABLE_DIR)/%.png,$(BMP_BITMAPS))
 
 $(PNG1): $(DRAWABLE_DIR)/%.png: Data/bitmaps/%.bmp | $(DRAWABLE_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 PNG2 := $(patsubst $(DATA)/graphics/%.bmp,$(DRAWABLE_DIR)/%.png,$(BMP_LAUNCH_ALL))
 $(PNG2): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics/%.bmp | $(DRAWABLE_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 PNG3 := $(patsubst $(DATA)/graphics/%.bmp,$(DRAWABLE_DIR)/%.png,$(BMP_SPLASH_80) $(BMP_SPLASH_160) $(BMP_TITLE_110) $(BMP_TITLE_320))
 $(PNG3): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics/%.bmp | $(DRAWABLE_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 PNG4 := $(patsubst $(DATA)/icons/%.bmp,$(DRAWABLE_DIR)/%.png,$(BMP_ICONS_ALL))
 $(PNG4): $(DRAWABLE_DIR)/%.png: $(DATA)/icons/%.png | $(DRAWABLE_DIR)/dirstamp
@@ -226,7 +226,7 @@ $(PNG4): $(DRAWABLE_DIR)/%.png: $(DATA)/icons/%.png | $(DRAWABLE_DIR)/dirstamp
 
 PNG5 := $(patsubst $(DATA)/graphics/%.bmp,$(DRAWABLE_DIR)/%.png,$(BMP_DIALOG_TITLE) $(BMP_PROGRESS_BORDER))
 $(PNG5): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics/%.bmp | $(DRAWABLE_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 PNG_FILES = $(PNG1) $(PNG1b) $(PNG2) $(PNG3) $(PNG4) $(PNG5) \
 	$(RES_DIR)/drawable-ldpi/icon.png \

--- a/build/imagemagick.mk
+++ b/build/imagemagick.mk
@@ -2,11 +2,11 @@ IM_PREFIX :=
 
 # extract alpha channel
 %_alpha.png: %.png
-	$(Q)$(IM_PREFIX)convert $< -alpha Extract +matte +dither -colors 8 $@
+	$(Q)$(IM_PREFIX)magick $< -alpha Extract -alpha off +dither -colors 8 $@
 
 # extract RGB channels
 %_rgb.png: %.png
-	$(Q)$(IM_PREFIX)convert $< -background white -flatten +matte +dither -colors 64 $@
+	$(Q)$(IM_PREFIX)magick $< -background white -flatten -alpha off +dither -colors 64 $@
 
 # tile both images
 %_tile.png: %_alpha.png %_rgb.png
@@ -19,7 +19,7 @@ define convert-to-bmp
 
 $(1): $(2): $(3) | $$(dir $$(firstword $(1)))/dirstamp
 	@$$(NQ)echo "  BMP     $$@"
-	$$(Q)$$(IM_PREFIX)convert $$< $(4) +dither -compress none -type optimize -colors 256 $(5) bmp3:$$@
+	$$(Q)$$(IM_PREFIX)magick $$< $(4) +dither -compress none -type optimize -colors 256 $(5) bmp3:$$@
 
 endef
 
@@ -30,7 +30,7 @@ define convert-to-bmp-white
 
 $(1): $(2): $(3) | $$(dir $$(firstword $(1)))/dirstamp
 	@$$(NQ)echo "  BMP     $$@"
-	$$(Q)$$(IM_PREFIX)convert $$< $(4) -background white -layers flatten +matte +dither -compress none -type optimize -colors 256 $(5) bmp3:$$@
+	$$(Q)$$(IM_PREFIX)magick $$< $(4) -background white -layers flatten -alpha off +dither -compress none -type optimize -colors 256 $(5) bmp3:$$@
 
 endef
 
@@ -42,6 +42,6 @@ define convert-to-bmp-half
 $(1): $(2): $(3) | $$(dir $$(firstword $(1)))/dirstamp
 	@$$(NQ)echo "  BMP     $$@"
 	@$$(NQ)echo "  BMP     $$(@:1.bmp=2.bmp)"
-	$$(Q)$$(IM_PREFIX)convert $$< $(4) -layers flatten +matte +dither -compress none -type optimize -colors 256 -crop '50%x100%' -scene 1 bmp3:$$(@:1.bmp=%d.bmp)
+	$$(Q)$$(IM_PREFIX)magick $$< $(4) -layers flatten -alpha off +dither -compress none -type optimize -colors 256 -crop '50%x100%' -scene 1 bmp3:$$(@:1.bmp=%d.bmp)
 
 endef

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -47,37 +47,37 @@ IOS_GRAPHICS = \
 	$(IOS_GRAPHICS_DIR)/Icon@2x.png
 
 $(IOS_GRAPHICS_DIR)/Default.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 320x480 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 320x480 $@
 
 $(IOS_GRAPHICS_DIR)/Default@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x960 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x960 $@
 
 $(IOS_GRAPHICS_DIR)/Default-568h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x1136 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x1136 $@
 
 $(IOS_GRAPHICS_DIR)/Default-667h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 750x1334 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 750x1334 $@
 
 $(IOS_GRAPHICS_DIR)/Default-736h@3x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1242x2208 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1242x2208 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Portrait.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 768x1004 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 768x1004 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Landscape.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1024x748 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1024x748 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Portrait@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1536x2008 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1536x2008 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Landscape@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2048x1496 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2048x1496 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Landscape-667h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1334x750 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1334x750 $@
 
 $(IOS_GRAPHICS_DIR)/Default-Landscape-736h@3x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2208x1242 $@
+	$(Q)$(IM_PREFIX)magick $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2208x1242 $@
 
 $(IOS_GRAPHICS_DIR)/Icon.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
 	$(Q)rsvg-convert $< -w 57 -h 57 -a -o $@

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -21,7 +21,7 @@ BMP_BITMAPS = $(wildcard Data/bitmaps/*.bmp)
 PNG_BITMAPS = $(patsubst Data/bitmaps/%.bmp,$(DATA)/bitmaps/%.png,$(BMP_BITMAPS))
 
 $(PNG_BITMAPS): $(DATA)/bitmaps/%.png: Data/bitmaps/%.bmp | $(DATA)/bitmaps/dirstamp
-	$(Q)$(IM_PREFIX)convert +dither -type GrayScale -define png:color-type=0 $< $@
+	$(Q)$(IM_PREFIX)magick +dither -type GrayScale -define png:color-type=0 $< $@
 
 ####### icons
 
@@ -148,7 +148,7 @@ $(BMP_LAUNCH_DLL_SIM_640): $(BMP_LAUNCH_DLL_FLY_640)
 
 PNG_LAUNCH_ALL = $(patsubst %.bmp,%.png,$(BMP_LAUNCH_ALL))
 $(PNG_LAUNCH_ALL): %.png: %.bmp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 ####### sounds
 
@@ -207,10 +207,10 @@ RESOURCE_FILES += $(RAW_SOUNDS)
 ifeq ($(USE_WIN32_RESOURCES),n)
 
 $(patsubst $(DATA)/icons/%.bmp,$(DATA)/icons2/%.png,$(filter $(DATA)/icons/%.bmp,$(RESOURCE_FILES))): $(DATA)/icons2/%.png: $(DATA)/icons/%.bmp | $(DATA)/icons2/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 $(patsubst $(DATA)/graphics/%.bmp,$(DATA)/graphics2/%.png,$(filter $(DATA)/graphics/%.bmp,$(RESOURCE_FILES))): $(DATA)/graphics2/%.png: $(DATA)/graphics/%.bmp | $(DATA)/graphics2/dirstamp
-	$(Q)$(IM_PREFIX)convert $< $@
+	$(Q)$(IM_PREFIX)magick $< $@
 
 RESOURCE_FILES := $(patsubst $(DATA)/graphics/%.bmp,$(DATA)/graphics2/%.png,$(RESOURCE_FILES))
 RESOURCE_FILES := $(patsubst $(DATA)/icons/%.bmp,$(DATA)/icons2/%.png,$(RESOURCE_FILES))


### PR DESCRIPTION
ImageMagick v7 was throwing `WARNING: The convert command is deprecated in IMv7, use "magick"` during compilation, updated the `build/imagemagick.mk` file to obey the new syntax.