### PR TITLE
More extended airspace fixes

### DIFF
--- a/src/Dialogs/Airspace/AirspaceList.cpp
+++ b/src/Dialogs/Airspace/AirspaceList.cpp
@@ -149,7 +149,7 @@ static Angle last_heading;
 
 static constexpr StaticEnumChoice type_filter_list[] = {
   { WILDCARD, _T("*") },
-  { OTHER, _T("Other") },
+  { OTHER, _T("Unknown") },
   { RESTRICTED, _T("Restricted areas") },
   { PROHIBITED, _T("Prohibited areas") },
   { DANGER, _T("Danger areas") },


### PR DESCRIPTION
some minor changes. In the airspace list have the filter option be listed as Unknown since it is Unknown anywhere else in the app (it is other in the code) 
and have AY Unclassified change to unknown as Unclassified is used for AC field makes it better to set the correct colors and filters for the map display this way.
