### PR TITLE
src/Waypoint: restore check for header in user.cup

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,8 @@
 Version 7.44 - not yet released
+* data files
+  - fix problem (introduced in v7.42) of first waypoint in user.cup waypoint
+    file being ignored or being overwritten by any Waypoint Editor dialog
+    function.
 
 Version 7.43 - 2024-08-12
 * calculations

--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -200,26 +200,34 @@ bool ParseSeeYou(WaypointFactory factory, Waypoints &waypoints, BufferedReader &
   std::array<std::string_view,14> params;
 
   bool tasks { false };
+  bool first_line = true;
 
-  // Headers
-  {
-    params_num = ReadCsvRecord(reader, params);
-
-    // Empty file
-    if (params_num == 0)
-      return false;
-
-    // Newer cup/cupx specification adds rwwidth, shifts freq and desc right, and adds userdata, and pics
-    if ( params_num > iRWWidth &&
-         params[iRWWidth] == "rwwidth"sv ) {
-      iFrequency = 10;
-      iDescription = 11;
-    }
-  }
-
-  // Waypoints
   while ( true ) {
     params_num = ReadCsvRecord(reader, params);
+
+    // first line of file
+    if (first_line) {
+      first_line = false;
+
+      // Empty file
+      if (params_num == 0)
+        return false;
+
+      // Check whether this is a header (a line with only field names).
+      if (StringIsEqualIgnoreCase(params[iLatitude],"lat"sv)) {
+
+        /*
+         * Newer cup/cupx specification adds rwwidth, shifts freq and desc
+         * right, and adds userdata and pics.
+         */
+        if ( params_num > iRWWidth &&
+             params[iRWWidth] == "rwwidth"sv ) {
+          iFrequency = 10;
+          iDescription = 11;
+        }
+        continue;
+      }
+    }
 
     // Tasks section
     tasks = params_num == 1 &&


### PR DESCRIPTION
(This is a redo of PR #1499, which was closed and inadvertently left out of the v7.43 release.)

This change restores the check for a header (a line containing only field names) in a CUP-format waypoint file when reading the file. This fixes a problem introduced in v7.42 via PR #1305, part of which was the removal of such a check. This (probably inadvertently) made it so that XCSoar now assumes there to always be a header. The XCSoar-created user.cup file, though, historically hasn’t had a header – and currently isn’t given one when XCSoar creates the file. So the changes in PR #1305 made it so that the first record (waypoint) in user.cup is ignored. If a new waypoint is added via the Waypoint Editor’s “New” or “Import” function, the result is worse: the first waypoint in user.cup is deleted. Each time the Waypoint Editor is exited after creating a new waypoint or importing a waypoint, another existing waypoint in user.cup is deleted. Restoring the check for a header fixes these problems.