### PR TITLE
NEWS.txt: fix note about non-airport home waypoint fix

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,8 +10,8 @@ Version 7.43 - 2024-08-12
 * data files
   - new topology available from mapgen (including airport runways and rivers)
   - fix loss of "home" waypoint designation in certain situations for a
-  - reworked sgs-233 polar
     non-airport home waypoint
+  - reworked sgs-233 polar
 * documentation
   - clarify task speed calculation section
   - lua reference updated


### PR DESCRIPTION
This fixes the note for v7.43 about the fix of an issue with a non-airport home waypoint. A note about a reworked polar somehow was put between the two lines of the two-line note about the home waypoint issue fix. I just moved the polar-related note down one line.