### PR TITLE
Max. selectable value for crew weight increased to 500.

### DIFF
--- a/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
@@ -13,6 +13,7 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "Units/Group.hpp"
+#include "Units/Units.hpp"
 
 using namespace std::chrono;
 
@@ -61,7 +62,7 @@ LoggerConfigPanel::Prepare(ContainerWindow &parent,
             _("Default for all weight loaded to the glider beyond the empty weight and besides "
                 "the water ballast."),
             _T("%.0f %s"), _T("%.0f"),
-            0, 300, 5, false, UnitGroup::MASS,
+            0, Units::ToUserMass(300), 5, false, UnitGroup::MASS,
             logger.crew_mass_template);
 
   AddDuration(_("Time step cruise"),

--- a/src/Dialogs/Settings/dlgBasicSettings.cpp
+++ b/src/Dialogs/Settings/dlgBasicSettings.cpp
@@ -265,7 +265,7 @@ FlightSetupPanel::Prepare(ContainerWindow &parent,
   AddFloat(_("Crew"),
            _("All masses loaded to the glider beyond the empty weight including pilot and copilot, but not water ballast."),
            _T("%.0f %s"), _T("%.0f"),
-           0, 300, 5, false, UnitGroup::MASS,
+           0, Units::ToUserMass(300), 5, false, UnitGroup::MASS,
            polar_settings.glide_polar_task.GetCrewMass(),
            this);
 


### PR DESCRIPTION
Max. selectable value for crew weight increased to 500 (both in "Flight Setup" and "Logger Setup").

Reason:
The drop-down selection for "Crew Weight" was limited to a value of 300, regardless of unit for mass. 
If the user has selected "lb" as unit, the max. possible crew weight would be 300 lb (=136 kg), which is easily exceeded if both seats are occupied. 
Most gliders are limited to a max. seat weight of 242 lb, so using 500 as max. value should
cover all use cases (2 * 242 lb = 484 lb). I am not aware of a glider with a useful load of more than 500 lbs anyway.
