### PR TITLE
Vagrantfile: Support Windows explicitely; mount ~/.xcsoar into virtual machine

### DIFF
--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -40,15 +40,30 @@ Vagrant.configure("2") do |config|
             # sysctl returns Bytes and we need to convert to MB
             mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 2
 
+            homedir = "~"
+            xcsoarprofiledir = homedir + "/.xcsoar"
+
+            config.vm.synced_folder xcsoarprofiledir, "/home/vagrant/.xcsoar"
+
         elsif host =~ /linux/
             cpus = `nproc`.to_i
             # meminfo shows KB and we need to convert to MB
             mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 2
 
+            homedir = "~"
+            xcsoarprofiledir = homedir + "/.xcsoar"
+
+            config.vm.synced_folder xcsoarprofiledir, "/home/vagrant/.xcsoar"
+
         elsif Vagrant::Util::Platform.windows?
 
             cpus = `wmic cpu get NumberOfCores`.split("\n")[2].to_i
-            mem = `wmic OS get TotalVisibleMemorySize`.split("\n")[2].to_i / 1024 /4 / 2
+            mem = `wmic OS get TotalVisibleMemorySize`.split("\n")[2].to_i / 1024 / 2
+
+            homedir = ENV['USERPROFILE'] 
+            xcsoarprofiledir = homedir + "\\.xcsoar"
+
+            config.vm.synced_folder xcsoarprofiledir, "/home/vagrant/.xcsoar"
 
         else
             cpus = 4

--- a/ide/vagrant/Vagrantfile
+++ b/ide/vagrant/Vagrantfile
@@ -45,6 +45,11 @@ Vagrant.configure("2") do |config|
             # meminfo shows KB and we need to convert to MB
             mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 2
 
+        elsif Vagrant::Util::Platform.windows?
+
+            cpus = `wmic cpu get NumberOfCores`.split("\n")[2].to_i
+            mem = `wmic OS get TotalVisibleMemorySize`.split("\n")[2].to_i / 1024 /4 / 2
+
         else
             cpus = 4
             mem = 2048


### PR DESCRIPTION
- Support Windows host for Vagrant explicitely (with RAM and CPU determination)
- Mounts ~/.xcsoar into the VM for Windows, Mac and Linux
