### PR TITLE
Support for Argentinean 95% distance rule & task maximum distance fix

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -18,6 +18,7 @@ Version 7.44 - not yet released
   - infoboxen: new setting, allow scaling of title/comment font
   - Radar / Thermalassistant Gauges: Placement to avoid InfoBoxen and Overlap
   - Add new Infobox “Home altitude difference” (Home AltD)
+  - add helpers on infoboxes for Argentinean contests 95% distance rule
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy

--- a/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
@@ -18,6 +18,8 @@ enum ControlIndex {
   SPACER,
   SHOW_FAI_TRIANGLE_AREAS,
   FAI_TRIANGLE_THRESHOLD,
+  SPACER2,
+  SHOW_95_PERCENT_RULE_HELPERS
 };
 
 class ScoringConfigPanel final
@@ -129,6 +131,16 @@ ScoringConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
           (unsigned)map_settings.fai_triangle_settings.threshold);
   SetExpertRow(FAI_TRIANGLE_THRESHOLD);
 
+  AddSpacer();
+  SetExpertRow(SPACER2);
+
+  AddBoolean(_("95% dist. rule helpers"),
+             _("Show helpers for Argentinean Federation \"95% distance\" rule."
+               "The AAT Distance Around Target infobox will show projected "
+               "distance vs max. and change colors as you approach 95%."),
+             map_settings.show_95_percent_rule_helpers);
+  SetExpertRow(SHOW_95_PERCENT_RULE_HELPERS);
+
   ShowFAITriangleControls(map_settings.show_fai_triangle_areas);
 }
 
@@ -153,6 +165,10 @@ ScoringConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValueEnum(FAI_TRIANGLE_THRESHOLD,
                            ProfileKeys::FAITriangleThreshold,
                            map_settings.fai_triangle_settings.threshold);
+
+  changed |= SaveValue(SHOW_95_PERCENT_RULE_HELPERS,
+                       ProfileKeys::Show95PercentRuleHelpers,
+                       map_settings.show_95_percent_rule_helpers);
 
   _changed |= changed;
 

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "Units/Units.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "Formatter/UserUnits.hpp"
 #include "Language/Language.hpp"
 #include "Widget/CallbackWidget.hpp"
 #include "Renderer/NextArrowRenderer.hpp"
@@ -578,15 +579,32 @@ UpdateInfoBoxTaskAADistance(InfoBoxData &data) noexcept
 {
   const auto &calculated = CommonInterface::Calculated();
   const TaskStats &task_stats = calculated.ordered_task_stats;
+  const MapSettings &map_settings = CommonInterface::GetMapSettings();
 
   if (!task_stats.has_targets ||
       !task_stats.total.planned.IsDefined()) {
     data.SetInvalid();
+    data.SetCommentInvalid();
+    data.SetAllColors(0);
     return;
   }
 
   // Set Value
-  data.SetValueFromDistance(task_stats.total.planned.GetDistance());
+  double distance = task_stats.total.planned.GetDistance();
+  data.SetValueFromDistance(distance);
+
+  if (map_settings.show_95_percent_rule_helpers) {
+    double fractionTotal = distance / task_stats.distance_max_total;
+    data.SetCommentFromPercent(fractionTotal*100.0);
+
+    if (fractionTotal > 0.95) data.SetAllColors(3);       // green
+    else if (fractionTotal > 0.85) data.SetAllColors(4);  // yellow
+    else data.SetAllColors(0);                            // normal
+  }
+  else {
+    data.SetCommentInvalid();
+    data.SetAllColors(0);
+  }
 }
 
 void
@@ -594,14 +612,25 @@ UpdateInfoBoxTaskAADistanceMax(InfoBoxData &data) noexcept
 {
   const auto &calculated = CommonInterface::Calculated();
   const TaskStats &task_stats = calculated.ordered_task_stats;
+  const MapSettings &map_settings = CommonInterface::GetMapSettings();
 
   if (!task_stats.has_targets) {
     data.SetInvalid();
+    data.SetCommentInvalid();
     return;
   }
 
   // Set Value
   data.SetValueFromDistance(task_stats.distance_max);
+
+  if (map_settings.show_95_percent_rule_helpers) {
+    auto distance = FormatUserDistanceSmart(0.95*task_stats.distance_max_total);
+    auto comment = std::basic_string<TCHAR>( _T("95% ") ) + distance.data();
+    data.SetComment(comment.data());
+  }
+  else {
+    data.SetCommentInvalid();
+  }
 }
 
 void

--- a/src/MapSettings.cpp
+++ b/src/MapSettings.cpp
@@ -48,6 +48,7 @@ MapSettings::SetDefaults() noexcept
   vario_bar_enabled = false;
   show_fai_triangle_areas = false;
   skylines_traffic_map_mode = DisplaySkyLinesTrafficMapMode::SYMBOL;
+  show_95_percent_rule_helpers = false;
 
   trail.SetDefaults();
   item_list.SetDefaults();

--- a/src/MapSettings.hpp
+++ b/src/MapSettings.hpp
@@ -188,6 +188,9 @@ struct MapSettings {
   TrailSettings trail;
   MapItemListSettings item_list;
 
+  /** Show 95% distance rule helpers on map and infoboxes */
+  bool show_95_percent_rule_helpers;
+
   void SetDefaults() noexcept;
 };
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -215,6 +215,7 @@ constexpr std::string_view FontBugsBallastFont = "BugsBallastFont";
 constexpr std::string_view FontAirspacePressFont = "AirspacePressFont";
 constexpr std::string_view FontAirspaceColourDlgFont = "AirspaceColourDlgFont";
 constexpr std::string_view FontTeamCodeFont = "TeamCodeFont";
+constexpr std::string_view Show95PercentRuleHelpers = "Show95PercentRuleHelpers";
 
 constexpr std::string_view UseFinalGlideDisplayMode = "UseFinalGlideDisplayMode";
 constexpr std::string_view InfoBoxGeometry = "InfoBoxGeometry";

--- a/src/Profile/MapProfile.cpp
+++ b/src/Profile/MapProfile.cpp
@@ -130,6 +130,9 @@ Profile::Load(const ProfileMap &map, MapSettings &settings)
 
   Load(map, settings.trail);
   Load(map, settings.item_list);
+
+  map.Get(ProfileKeys::Show95PercentRuleHelpers,
+          settings.show_95_percent_rule_helpers);
 }
 
 void


### PR DESCRIPTION
Implementation of feature described in issue #1084 - added comments on two infoboxes as helpers to the AAT target distance being flown, optionally enabled in the profile.

This required refactoring the maximum distance calculation algorithm for re-usability and fixing a minor bug in the distances displayed in the Task Manager ui - see discussion on the issue for more details.

Testing done
-------------
* Added test assertions for the initially calculated min and max distance. Ensured these run ok at every refactor step.
* Added assertions checking min, max & max total distances calculated after flying the task. However these were not committed as test is too heavy to run in the `make check` test suite, and there are few tests presently failing in `make testfast` and `make testslow`. I will fix these and add the test that was left out later (probably inside `test_aat.cpp`)
* Ran AAT tasks in Windows and Android on simulator mode, verified infoboxes run as intended
* On Android, using `adb` and `top`, checked there is no measurable change on CPU usage wrt master due to the added calculations, at all points during the task - using a rather old Moto Z Play phone.