### PR TITLE
Use a shared folder for ccache when running inside Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ build/local-config.mk
 .*.swp
 
 .idea
+.ccache

--- a/ide/docker/Dockerfile
+++ b/ide/docker/Dockerfile
@@ -15,3 +15,4 @@ WORKDIR /usr/local/bin
 RUN chmod 755 ./*
 
 WORKDIR /opt/xcsoar
+ENV CCACHE_DIR /opt/xcsoar/.ccache


### PR DESCRIPTION
With this env variable set, ccache calls from within Docker containers will work seamlessly, sharing a common db on the repo checkout folder
