### PR TITLE
Handle ellipsoid and geoid altitudes

### DIFF
--- a/src/IGC/IGCFix.cpp
+++ b/src/IGC/IGCFix.cpp
@@ -23,9 +23,13 @@ IGCFix::Apply(const NMEAInfo &basic) noexcept
 
   time = basic.date_time_utc;
 
-  gps_altitude = basic.gps_altitude_available
-    ? (int)basic.gps_altitude
-    : 0;
+  if (basic.gps_altitude_available) {
+    gps_altitude = (int)basic.gps_altitude;
+    gps_ellipsoid_altitude = (int)basic.gps_ellipsoid_altitude;
+  } else {
+    gps_altitude = 0;
+    gps_ellipsoid_altitude = 0;  
+  }
 
   pressure_altitude = basic.pressure_altitude_available
     ? (int)basic.pressure_altitude

--- a/src/IGC/IGCFix.hpp
+++ b/src/IGC/IGCFix.hpp
@@ -16,7 +16,7 @@ struct IGCFix
 
   bool gps_valid;
 
-  int gps_altitude, pressure_altitude;
+  int gps_altitude, gps_ellipsoid_altitude, pressure_altitude;
 
   /* extensions follow */
 

--- a/src/IGC/IGCWriter.cpp
+++ b/src/IGC/IGCWriter.cpp
@@ -2,8 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "IGC/IGCWriter.hpp"
-#include "IGCString.hpp"
 #include "Generator.hpp"
+#include "IGCString.hpp"
 #include "NMEA/Info.hpp"
 #include "Version.hpp"
 #include "system/Path.hpp"
@@ -188,7 +188,8 @@ IGCWriter::LogPoint(const IGCFix &fix, int epe, int satellites)
   sprintf(p, "%c%05d%05d%03d%02d",
           fix.gps_valid ? 'A' : 'V',
           NormalizeIGCAltitude(fix.pressure_altitude),
-          NormalizeIGCAltitude(fix.gps_altitude),
+          // B-records require WGS 84 ellipsoid altitude
+          NormalizeIGCAltitude(fix.gps_ellipsoid_altitude),
           epe, satellites);
 
   WriteLine(b_record);

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -115,6 +115,9 @@ struct NMEAInfo {
   /** GPS altitude AMSL (m) */
   double gps_altitude;
 
+  /** GPS altitude above WGS84 ellipsoid (m) */
+  double gps_ellipsoid_altitude;
+
   /**
    * Static pressure value [Pa].
    */

--- a/src/Replay/IgcReplay.cpp
+++ b/src/Replay/IgcReplay.cpp
@@ -67,6 +67,7 @@ IgcReplay::Update(NMEAInfo &basic)
 
   if (fix.gps_altitude != 0) {
     basic.gps_altitude = fix.gps_altitude;
+    basic.gps_ellipsoid_altitude = fix.gps_ellipsoid_altitude;
     basic.gps_altitude_available.Update(basic.clock);
   } else
     basic.gps_altitude_available.Clear();


### PR DESCRIPTION
Proposed corrected and improved fix for issue #1605:
 * add ellipsoid altitude field to NMEAInfo & IGCFix structs
* fill in the ellipsoid altitude based on the GGA sentence
* output the ellipsoid altitude to the IGC file
* convert B-record altitude to AMSL
* only look up EGM96 approximation when necessary

Appears as 3 commits due to limitations of github web interface - feel free to "squash merge".