### PR TITLE
Android: Activity in front of lockscreen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -73,6 +73,7 @@ The following people and organizations have contributed code to XCSoar:
  Winfried Simon <winfried.simon@gmail.com>
  Jörg Schuon <schuongf@hotmail.com>
  Ulisse Perusin <uli.peru@gmail.com>
+ Moritz Finke <abzicht@gmail.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -21,6 +21,7 @@ Version 7.44 - not yet released
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy
+  - make xcsoar accessible from lock screen
 * Windows
   - Popupmessages are now shown with full text again
 * devices

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -12,6 +12,8 @@
       android:icon="@drawable/icon"
       android:label="@string/app_name">
     <activity android:name=".XCSoar"
+              android:showOnLockScreen="true"
+              android:showWhenLocked="true"
               android:exported="true"
               android:label="@string/app_name"
               android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"

--- a/android/testing/AndroidManifest.xml
+++ b/android/testing/AndroidManifest.xml
@@ -12,6 +12,8 @@
       android:icon="@drawable/icon"
       android:label="@string/app_name">
     <activity android:name="org.xcsoar.XCSoar"
+              android:showOnLockScreen="true"
+              android:showWhenLocked="true"
               android:exported="true"
               android:label="@string/app_name_testing"
               android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|uiMode|screenSize|smallestScreenSize|fontScale"


### PR DESCRIPTION
This PR enables XCSoar to be displayed in front of the Android lockscreen.

The idea of this PR is to remove in-flight distractions during phone unlocking (entering a PIN, drawing a pattern, etc.). Instead, XCSoar is immediately available when powering the phone display. Equally, the lockscreen is easily reached by moving the App to the background (e.g., through an upward gesture or pressing the home button). Note that the feature only applies, if the screen was locked while the App was in foreground.

The PR appends two lines to the Android manifest and, as such, includes the feature by default. In many phones, however, the feature must be manually activated over the system's App settings, as illustrated in the attached screenshot (cf. _Show on Lock screen_).

<img src="https://github.com/user-attachments/assets/243d5469-687e-41c0-b0e7-94754b8abb13" width="70%"> _(Image credit: [Victor Brandalise](https://victorbrandalise.com/how-to-show-activity-on-lock-screen-instead-of-notification/))_

It must be noted that, in some phones, the feature could be activated by default without the possibility of manual configuration through the system's App settings. If this is not desired, the `showWhenLocked` property in the manifest would have to be replaced by a call to [`setShowWhenLocked(boolean)`](https://developer.android.com/reference/android/app/Activity#setShowWhenLocked(boolean)) from within the main activity, based on an in-app configuration made by the user. I have not yet dived deep enough into the repository to implement this configuration option straight away and I don't know, if there even is community interest for this. For now, this PR hence only adds the feature through the manifest.