### PR TITLE
Gauge/ThermalAssistantRenderer.cpp: Use MixMask on Windows

### DIFF
--- a/src/Gauge/ThermalAssistantRenderer.cpp
+++ b/src/Gauge/ThermalAssistantRenderer.cpp
@@ -156,7 +156,7 @@ ThermalAssistantRenderer::PaintPoints(Canvas &canvas,
 #ifdef ENABLE_OPENGL
   const ScopeAlphaBlend alpha_blend;
 #elif defined(USE_GDI)
-  canvas.SetMixMask();
+  canvas.SetMixCopy();
 #endif /* GDI */
 
   canvas.Select(look.polygon_brush);


### PR DESCRIPTION
ThermalAssistant in dark mode is readable again.

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html
