### PR TITLE
UI: Remove pure attribute of NextChar function

### DIFF
--- a/src/ui/canvas/freetype/Font.cpp
+++ b/src/ui/canvas/freetype/Font.cpp
@@ -75,7 +75,6 @@ FT_CEIL(FT_Long x) noexcept
   return FT_FLOOR(x + 63);
 }
 
-[[gnu::pure]]
 static unsigned
 NextChar(tstring_view &s) noexcept
 {


### PR DESCRIPTION
The NextChar function has the GCC pure attribute annotation while it is not. The function changes the string_view type parameter s. This may cause GCC to generate incorrect code, resulting in the crash of the application. Removing the annotation results in non-crashing code.

Fixes #1635
