### PR TITLE
 Make Flarm gauge disappear when traffic is farther than 4 km away

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,7 @@ Version 7.44 - not yet released
   - apply dark mode to large flarm radar
   - add options to avoid infoboxes to flarm radar widget
   - changed location of setting for flarm radar position
+  - Flarm gauge: when traffic is farther than 4 km away, it disappears
   - add new gesture ULDR to access quick menu
   - add quick menu page buttons in case of touch screen
   - add quit button to quick menu

--- a/doc/manual/de/ch07_airspace_and_flarm.tex
+++ b/doc/manual/de/ch07_airspace_and_flarm.tex
@@ -322,6 +322,7 @@ welches als Mini-\fl-Radar benutzt werden und entsprechend aktiviert vergrößer
 Die dargestellte Entfernung beträgt maximal 2000m. Im Hintergrund sind zwei hellgraue Kreise zu erkennen,
 von denen der erste 1000m Durchmesser angibt, der zweite zeigt 2000m Durchmesser.
 Flugzeuge, die sich jenseits 2000m Entfernung befinden, werden auf dem Kreis liegend dargestellt.
+Wenn sich Flugzeuge weiter als 4000m entfernt befindet, verschwindet das Mini-\fl-Radar.
 
 \marginpar{\includegraphics[angle=0,width=\linewidth,keepaspectratio='true']{figures/flarmrose.png}}
 

--- a/doc/manual/en/ch07_airspace_and_flarm.tex
+++ b/doc/manual/en/ch07_airspace_and_flarm.tex
@@ -325,7 +325,8 @@ This FLARM display is oriented track-up and a small glider icon
 clearly shows that the display is oriented as such.  The scale of the
 display is linear up to maximum distance of 2000~m.  On the
 background there are two rings; the first is a 1000~m radius and the second
-is 2000~m.  Traffic further away than 2000~m is drawn at the 2000~m ring.
+is 2000~m.  Traffic farther away than 2000~m is drawn at the 2000~m ring.
+When traffic is farther than 4000~m away, the small radar view disappears.
 \sketch{figures/flarmrose.png}
 
 All the FLARM displays shows FLARM traffic in colours according to

--- a/doc/manual/fr/ch07_airspace_and_flarm.tex
+++ b/doc/manual/fr/ch07_airspace_and_flarm.tex
@@ -214,6 +214,8 @@ L'affichage sur la carte des données d'identification des FLARMs (numéro de co
 Pour palier à cette situation, quand un trafic FLARM est reçu, \xc{} affiche une petite fenêtre de type FLARM du point de vue de l'aéronef. Le trafic FLARM est représenté de la même façon, mais les trafics menaçants sont rendues plus visibles en étant entourées de un ou deux cercles rouges. Le coin d'affichage de cette vue radar FLARM peut être paramétré\config{flarmradar-place}.
 
 Cette vue de radar FLARM est affichée en mode ``Route en haut'' et un petit planeur, au centre, rappelle ce mode d'affichage. L'échelle est linéaire jusqu'à 2000~mètres. En fond d'écran il y a 2~cercles~: le premier a un rayon de 1000~m et le second de 2000~m. Le trafic distant de plus de 2~km du centre est représenté sur le cercle des 2~km.
+Lorsque le trafic est à plus de 4~km, la petite vue radar disparaît.
+
 \sketch{figures/flarmrose.png}
 
 Tous les affichages du trafic FLARM montrent le trafic avec les mêmes couleurs, symbolisant la menace potentielle ou le vol en équipe. Les couleurs sont~:

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1164,8 +1164,10 @@ MainWindow::UpdateTrafficGaugeVisibility() noexcept
     if (HasDialog())
       return;
 
-    if (!flarm.traffic.InCloseRange())
+    if (!flarm.traffic.InCloseRange()) {
+      traffic_gauge.Hide();
       return;
+    }
 
     if (!traffic_gauge.IsDefined())
       traffic_gauge.Set(new GaugeFLARM(CommonInterface::GetLiveBlackboard(),


### PR DESCRIPTION
Manual updated for en, de and fr. Others pending.

Closes #1641