### PR TITLE
iOS simulator and local paths

### DIFF
--- a/Data/iOS/Info.plist.in.xml
+++ b/Data/iOS/Info.plist.in.xml
@@ -18,6 +18,8 @@
         <string>6.0</string>
         <key>CFBundleVersion</key>
         <string>VERSION_PLACEHOLDER</string>
+        <key>CFBundleShortVersionString</key>
+        <string>VERSION_PLACEHOLDER</string>
         <key>LSRequiresIPhoneOS</key>
         <true />
         <key>UIRequiredDeviceCapabilities</key>

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -14,6 +14,7 @@ IOS_SPLASH_BASE_IMG=$(DATA)/graphics/logo_red_320.png
 IOS_GRAPHICS_DIR=$(DATA)/ios-graphics-testing
 else
 IPA_NAME = xcsoar.ipa
+IOS_APP_VERSION = 1.0.0
 IOS_APP_DIR_NAME = XCSoar.app
 IOS_APP_BUNDLE_IDENTIFIER = XCSoar
 IOS_APP_DISPLAY_NAME = XCSoar

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -6,7 +6,7 @@ TARGETS = PC WIN64 \
 	ANDROID ANDROID7 ANDROID86 \
 	ANDROIDAARCH64 ANDROIDX64 \
 	ANDROIDFAT \
-	OSX64 MACOS IOS32 IOS64
+	OSX64 MACOS IOS32 IOS64 IOS64SIM
 
 ifeq ($(TARGET),)
   ifeq ($(HOST_IS_UNIX),y)
@@ -276,6 +276,21 @@ ifeq ($(TARGET),IOS64)
   endif
   CLANG = y
   TARGET_ARCH += -miphoneos-version-min=$(IOS_MIN_SUPPORTED_VERSION) -arch arm64
+  ASFLAGS += -arch arm64
+endif
+
+ifeq ($(TARGET),IOS64SIM)
+  override TARGET = UNIX
+  TARGET_IS_DARWIN = y
+  TARGET_IS_IOS = y
+  IOS_MIN_SUPPORTED_VERSION = 10.0
+  HOST_TRIPLET = aarch64-apple-darwin
+  LLVM_TARGET = $(HOST_TRIPLET)
+  ifeq ($(HOST_IS_DARWIN),y)
+    DARWIN_SDK ?= /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
+  endif
+  CLANG = y
+  TARGET_ARCH += -mios-simulator-version-min=$(IOS_MIN_SUPPORTED_VERSION) -arch arm64
   ASFLAGS += -arch arm64
 endif
 

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -39,6 +39,10 @@
 #include <unistd.h>
 #endif
 
+#ifdef __APPLE__
+#import <Foundation/Foundation.h>
+#endif
+
 #define XCSDATADIR "XCSoarData"
 
 /**
@@ -263,7 +267,7 @@ FindDataPaths() noexcept
        folder can also be accessed via iTunes, if
        UIFileSharingEnabled is set to YES in Info.plist */
 #if (TARGET_OS_IPHONE)
-    constexpr const char *in_home = "Documents" XCSDATADIR;
+    constexpr const char *in_home = "Documents/" XCSDATADIR;
 #else
     constexpr const char *in_home = XCSDATADIR;
 #endif
@@ -278,6 +282,11 @@ FindDataPaths() noexcept
   /* Linux (and others): allow global configuration in /etc/xcsoar */
   if (Directory::Exists(Path{"/etc/xcsoar"}))
     result.emplace_back(Path{"/etc/xcsoar"});
+#else
+  if (!Directory::Exists(Path{result.back()})) {
+    id fileManager = [NSFileManager defaultManager];
+      [fileManager createDirectoryAtPath:[NSString stringWithCString:result.back().c_str()] withIntermediateDirectories:YES attributes:nil error:nil];
+  }
 #endif // !APPLE
 #endif // HAVE_POSIX
 


### PR DESCRIPTION
Adds an additional build target using the iOS simulator SDK to be able to run the app in the simulator and fixes a missing slash in local paths. Mostly adapted from the work by @piopawlu.