### PR TITLE
iOS: Fix resizing and rendering

### DIFF
--- a/src/ui/canvas/opengl/FBO.hpp
+++ b/src/ui/canvas/opengl/FBO.hpp
@@ -5,6 +5,14 @@
 
 #include "ui/opengl/SystemExt.hpp"
 
+#if (defined(__APPLE__) && defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+#define GL_UNBIND_FRAMEBUFFER 1
+#define GL_UNBIND_RENDERBUFFER 1
+#else 
+#define GL_UNBIND_FRAMEBUFFER 0
+#define GL_UNBIND_RENDERBUFFER 0
+#endif
+
 /**
  * Support for OpenGL framebuffer objects (GL_*_framebuffer_object).
  */

--- a/src/ui/canvas/opengl/FrameBuffer.hpp
+++ b/src/ui/canvas/opengl/FrameBuffer.hpp
@@ -25,7 +25,8 @@ public:
   }
 
   static void Unbind() noexcept {
-    FBO::BindFramebuffer(FBO::FRAMEBUFFER, 0);
+
+    FBO::BindFramebuffer(FBO::FRAMEBUFFER, GL_UNBIND_FRAMEBUFFER);
   }
 
 protected:

--- a/src/ui/canvas/opengl/RenderBuffer.hpp
+++ b/src/ui/canvas/opengl/RenderBuffer.hpp
@@ -25,7 +25,7 @@ public:
   }
 
   static void Unbind() {
-    FBO::BindRenderbuffer(FBO::RENDERBUFFER, 0);
+    FBO::BindRenderbuffer(FBO::RENDERBUFFER, GL_UNBIND_RENDERBUFFER);
   }
 
   static void Storage(GLenum internalformat,
@@ -41,7 +41,7 @@ public:
 
   static void DetachFramebuffer(GLenum attachment) {
     FBO::FramebufferRenderbuffer(FBO::FRAMEBUFFER, attachment,
-                                 FBO::RENDERBUFFER, 0);
+                                 FBO::RENDERBUFFER, GL_UNBIND_RENDERBUFFER);
   }
 
 protected:

--- a/src/ui/window/sdl/TopWindow.cpp
+++ b/src/ui/window/sdl/TopWindow.cpp
@@ -219,8 +219,12 @@ TopWindow::OnEvent(const SDL_Event &event)
           h = real_h;
 #endif
 #ifdef ENABLE_OPENGL
+#if defined __APPLE__
+            Resize(screen->GetSize());
+#else
           if (screen->CheckResize(PixelSize(w, h)))
             Resize(screen->GetSize());
+#endif
 #else
           Resize({w, h});
 #endif


### PR DESCRIPTION
Without the PR, the app effectively gets stuck on the initial loading/progress screen.
As discovered by @piopawlu, this is mostly due to OpenGLES on iOS not having the default framebuffer indexed with 0, making the unbind fail (see e.g., [https://stackoverflow.com/questions/56786676/how-to-unbind-glbindframebuffer-in-c-opengles-ios](https://stackoverflow.com/questions/56786676/how-to-unbind-glbindframebuffer-in-c-opengles-ios)).  