### PR TITLE
Allowing http and insecure https downloads on iOS

### DIFF
--- a/Data/iOS/Info.plist.in.xml
+++ b/Data/iOS/Info.plist.in.xml
@@ -59,6 +59,10 @@
         <string></string>
         <key>UIFileSharingEnabled</key>
         <true/>
+        <key>NSAppTransportSecurity</key>
+        <dict>
+            <key>NSAllowsArbitraryLoads</key>
+        <true/>
+        </dict>
     </dict>
 </plist>
-

--- a/src/lib/curl/Setup.cxx
+++ b/src/lib/curl/Setup.cxx
@@ -23,7 +23,7 @@ Setup(CurlEasy &easy)
 	easy.SetConnectTimeout(10);
 	easy.SetOption(CURLOPT_HTTPAUTH, (long) CURLAUTH_ANY);
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(__APPLE__)
 	/* this is disabled until we figure out how to use Android's
 	   CA certificates with libcurl */
 	easy.SetVerifyHost(false);


### PR DESCRIPTION
Allowing http and not verified https downloads for iOS.