### PR TITLE
Doc: Define proper git command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,21 @@ downloaded via the [XCSoar home page](https://xcsoar.org/discover/manual.html).
 
 ## Getting the source
 
-The XCSoar source code is managed with [git](http://git-scm.com/). It can be
-downloaded with the following command:
+The XCSoar source code is managed with git. It can be fetched with the
+following command:
 
 ```bash
-git clone --recursive https://github.com/XCSoar/XCSoar
+git clone --recurse-submodules https://github.com/XCSoar/XCSoar
 ```
 
-To update your repository, type:
+To update your repository, use the following command:
 
 ```bash
-git pull
+git pull --recurse-submodules
 ```
 
-For more information, please refer to the git documentation.
+For more information, please refer to the [git
+documentation](http://git-scm.com/).
 
 ## Compiling from source
 

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -44,11 +44,11 @@ Getting the Source Code
 The XCSoar source code is managed with `git <http://git-scm.com/>`__. It
 can be downloaded with the following command::
 
-  git clone https://github.com/XCSoar/XCSoar
+  git clone --recurse-submodules https://github.com/XCSoar/XCSoar
 
 To update your repository, type::
 
-  git pull
+  git pull --recurse-submodules
 
 To update third-party libraries used by XCSoar (such as `Boost
 <http://www.boost.org/>`__), type::

--- a/doc/devsetup.rst
+++ b/doc/devsetup.rst
@@ -23,7 +23,7 @@ To download the XCSoar source code, make sure you have git installed::
 Download the source code of XCSoar by executing ``git`` in the
 following way in your project directory::
 
- git clone --recursive https://github.com/XCSoar/XCSoar
+ git clone --recurse-submodules https://github.com/XCSoar/XCSoar
 
 Use provisioning scripts
 ========================


### PR DESCRIPTION
The '--recursive' option works on the 'git submodule' subcommand only. For 'git clone' et al. the proper option is '--recurse-submodules'.

Also, give the reference to the git documentation there where the text goes into 'more information about git'.
