### PR TITLE
FLARM Target Colours in Radar Display

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -21,6 +21,7 @@ Version 7.44 - not yet released
   - Add new Infobox “Home altitude difference” (Home AltD)
   - add helpers on infoboxes for Argentinean contests 95% distance rule
   - Popup messages now appear at the top of the map
+  - FlarmTrafficWindow: align colors of FlarmTraffic with map for consistency
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy

--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -325,22 +325,21 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
         // unnecessary - prevents "may be used uninitialized" compiler warning
         circle_pen = &look.default_pen;
       }
+      // same colours of FLARM targets as in map display
+      text_color = &look.default_color;
+      target_pen = &look.radar_pen;
+      arrow_brush = &look.default_brush;
 
-      if (!small && static_cast<unsigned> (selection) == i) {
-        text_color = &look.selection_color;
-        target_brush = arrow_brush = &look.selection_brush;
-        target_pen = &look.selection_pen;
+      if (traffic.relative_altitude > (const RoughAltitude)50) {
+        target_brush = &look.safe_above_brush;
+      } else if (traffic.relative_altitude > (const RoughAltitude)-50) {
+        target_brush = &look.warning_in_altitude_range_brush;
       } else {
-        if (traffic.IsPassive()) {
-          text_color = &look.passive_color;
-          target_pen = &look.passive_pen;
-          arrow_brush = &look.passive_brush;
-        } else {
-          text_color = &look.default_color;
-          target_pen = &look.default_pen;
-          arrow_brush = &look.default_brush;
-        }
+        target_brush = &look.safe_below_brush;
       }
+
+      if (!small && static_cast<unsigned> (selection) == i)
+        target_pen = &look.default_pen;
     }
     break;
   }
@@ -426,9 +425,6 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
     sc[i].x + int(Layout::FastScale(11u)),
     sc[i].y - int(sz.height / 2),
   };
-
-  // Draw vertical speed shadow
-  RenderShadowedText(canvas, tmp, tp, false);
 
   // Select color
   canvas.SetTextColor(*text_color);

--- a/src/Look/FlarmTrafficLook.cpp
+++ b/src/Look/FlarmTrafficLook.cpp
@@ -13,9 +13,12 @@ FlarmTrafficLook::Initialise(const TrafficLook &other, bool small, bool inverse)
   warning_color = other.warning_color;
   alarm_color = other.alarm_color;
   default_color = inverse ? COLOR_WHITE : COLOR_BLACK;
-  selection_color = COLOR_BLUE;
+  selection_color = default_color;
   background_color = inverse ? COLOR_BLACK : COLOR_WHITE;
   radar_color = COLOR_GRAY;
+  safe_above_color = Color(0x1d,0x9b,0xc5);
+  safe_below_color = Color(0x1d,0xc5,0x10);
+  warning_in_altitude_range_color = Color(0xff,0x00,0xff);
 
   warning_brush.Create(warning_color);
   alarm_brush.Create(alarm_color);
@@ -27,6 +30,10 @@ FlarmTrafficLook::Initialise(const TrafficLook &other, bool small, bool inverse)
   team_brush_blue.Create(other.team_color_blue);
   team_brush_yellow.Create(other.team_color_yellow);
   team_brush_magenta.Create(other.team_color_magenta);
+  safe_above_brush.Create(safe_above_color);
+  safe_below_brush.Create(safe_below_color);
+  warning_in_altitude_range_brush.Create(warning_in_altitude_range_color);
+
 
   unsigned width = Layout::FastScale(small ? 1u : 2u);
   warning_pen.Create(width, warning_color);

--- a/src/Look/FlarmTrafficLook.hpp
+++ b/src/Look/FlarmTrafficLook.hpp
@@ -18,6 +18,9 @@ struct FlarmTrafficLook {
   Color selection_color;
   Color background_color;
   Color radar_color;
+  Color safe_above_color;
+  Color safe_below_color;
+  Color warning_in_altitude_range_color;
 
   Brush warning_brush;
   Brush alarm_brush;
@@ -29,6 +32,9 @@ struct FlarmTrafficLook {
   Brush team_brush_blue;
   Brush team_brush_yellow;
   Brush team_brush_magenta;
+  Brush safe_above_brush;
+  Brush safe_below_brush;
+  Brush warning_in_altitude_range_brush;
 
   Pen warning_pen;
   Pen alarm_pen;


### PR DESCRIPTION
File:
This commit is based on description and discussion on https://github.com/XCSoar/XCSoar/issues/1643

Within the map FLARM- targets are colour coded. Blue means "above", green means "below" and violet means "same height".

The targets in the radar display (small and big) become now the same colours.

The original colour "blue" in the radar display indicated the selected target (i.e. by tapping on it on the touchscreen). Also the upper left field with the FlarmID or call-sign was displayed within this blue colour. Now this blue colour is no more used.The selected target is visually marked by a bold border line.

The original radar classified the targets into 2 types (passive- with engines) and active (gliders,para-gliders).

The text beside the targets shows height or sink/ascend- rate. It was originally coded in grey colour. Because the used blue and grey colour colour is no more used the text beside the FLARM- target is no more necessary to render with a shadow (it was necessary in "Dark Mode" because grey on a black background is badly visible).

The border of map targets "below" and "above" is originally programmed in /src/Renderer/TrafficRenderer.cpp and is only 50 Meters above and below. This range was now also used within the radar display. This is a bit narrow and should be changed in future.