### PR TITLE
test: Cleanup UTF8 test

### DIFF
--- a/test/src/TestUTF8.cpp
+++ b/test/src/TestUTF8.cpp
@@ -132,12 +132,12 @@ int main()
   plan_tests(2 * ARRAY_SIZE(valid) +
              2 * ARRAY_SIZE(invalid) +
              2 * ARRAY_SIZE(length) +
-             4 * ARRAY_SIZE(crop) +
              ARRAY_SIZE(latin1_chars) +
+             4 * ARRAY_SIZE(crop) +
 #ifndef _UNICODE
              ARRAY_SIZE(truncate_string_tests) +
 #endif
-             9 + 27);
+             10 + 27);
 
   for (auto i : valid) {
     ok1(ValidateUTF8(i));
@@ -174,6 +174,7 @@ int main()
   TestTruncateString();
 #endif
 
+  /* test NextUTF8() */
   {
     const char *p = "foo\xe7\x9b\xae";
     auto n = NextUTF8(p);
@@ -194,45 +195,47 @@ int main()
 
     n = NextUTF8(p + 6);
     ok1(n.first == 0);
+    ok1(n.second == nullptr);
   }
 
   /* test UnicodeToUTF8() */
+  {
+    buffer[0] = 1;
+    ok1(UnicodeToUTF8(0, buffer) == buffer + 1);
+    ok1(buffer[0] == 0);
 
-  buffer[0] = 1;
-  ok1(UnicodeToUTF8(0, buffer) == buffer + 1);
-  ok1(buffer[0] == 0);
+    ok1(UnicodeToUTF8(' ', buffer) == buffer + 1);
+    ok1(buffer[0] == ' ');
 
-  ok1(UnicodeToUTF8(' ', buffer) == buffer + 1);
-  ok1(buffer[0] == ' ');
+    ok1(UnicodeToUTF8(0x7f, buffer) == buffer + 1);
+    ok1(buffer[0] == 0x7f);
 
-  ok1(UnicodeToUTF8(0x7f, buffer) == buffer + 1);
-  ok1(buffer[0] == 0x7f);
+    ok1(UnicodeToUTF8(0xa2, buffer) == buffer + 2);
+    ok1(buffer[0] == char(0xc2));
+    ok1(buffer[1] == char(0xa2));
 
-  ok1(UnicodeToUTF8(0xa2, buffer) == buffer + 2);
-  ok1(buffer[0] == char(0xc2));
-  ok1(buffer[1] == char(0xa2));
+    ok1(UnicodeToUTF8(0x6fb3, buffer) == buffer + 3);
+    ok1(buffer[0] == char(0xe6));
+    ok1(buffer[1] == char(0xbe));
+    ok1(buffer[2] == char(0xb3));
 
-  ok1(UnicodeToUTF8(0x6fb3, buffer) == buffer + 3);
-  ok1(buffer[0] == char(0xe6));
-  ok1(buffer[1] == char(0xbe));
-  ok1(buffer[2] == char(0xb3));
+    ok1(UnicodeToUTF8(0xffff, buffer) == buffer + 3);
+    ok1(buffer[0] == char(0xef));
+    ok1(buffer[1] == char(0xbf));
+    ok1(buffer[2] == char(0xbf));
 
-  ok1(UnicodeToUTF8(0xffff, buffer) == buffer + 3);
-  ok1(buffer[0] == char(0xef));
-  ok1(buffer[1] == char(0xbf));
-  ok1(buffer[2] == char(0xbf));
+    ok1(UnicodeToUTF8(0x10000, buffer) == buffer + 4);
+    ok1(buffer[0] == char(0xf0));
+    ok1(buffer[1] == char(0x90));
+    ok1(buffer[2] == char(0x80));
+    ok1(buffer[3] == char(0x80));
 
-  ok1(UnicodeToUTF8(0x10000, buffer) == buffer + 4);
-  ok1(buffer[0] == char(0xf0));
-  ok1(buffer[1] == char(0x90));
-  ok1(buffer[2] == char(0x80));
-  ok1(buffer[3] == char(0x80));
-
-  ok1(UnicodeToUTF8(0x10ffff, buffer) == buffer + 4);
-  ok1(buffer[0] == char(0xf4));
-  ok1(buffer[1] == char(0x8f));
-  ok1(buffer[2] == char(0xbf));
-  ok1(buffer[3] == char(0xbf));
+    ok1(UnicodeToUTF8(0x10ffff, buffer) == buffer + 4);
+    ok1(buffer[0] == char(0xf4));
+    ok1(buffer[1] == char(0x8f));
+    ok1(buffer[2] == char(0xbf));
+    ok1(buffer[3] == char(0xbf));
+  }
 
   return exit_status();
 }


### PR DESCRIPTION
- Order the test length calculation according to tests
- Identify NextUTF8 test block with comment
- Add additional test on NextUTF8 End-of-String behavior
- Encapsulate UnicodeToUTF8 tests in block also