### PR TITLE
Clang: enforce policy for clang 12

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -65,7 +65,7 @@ The following is needed for all targets:
 -  GNU make
 
 -  GNU compiler collection (``gcc``), version 10 or later or clang/LLVM
-   10 (with "make CLANG=y")
+   12 (with "make CLANG=y")
 
 -  GNU gettext
 

--- a/src/util/Compiler.h
+++ b/src/util/Compiler.h
@@ -41,8 +41,8 @@
    GCC_VERSION < GCC_MAKE_VERSION(major, minor, 0))
 
 #ifdef __clang__
-#  if CLANG_VERSION < GCC_MAKE_VERSION(10,0,0)
-#    error Sorry, your clang version is too old.  You need at least version 10.
+#  if CLANG_VERSION < GCC_MAKE_VERSION(12,0,0)
+#    error Sorry, your clang version is too old.  You need at least version 12.
 #  endif
 #elif defined(__GNUC__)
 #  if GCC_OLDER_THAN(10,0)


### PR DESCRIPTION
Commit 2c43d6f8 changed policy from clang 10 to clang 12. However, unlike commit 9c968559 and commit 0c061b47, this change was not permeated into other parts of the repository. This commit tries to make things consistent.

With this change we loose building using clang on bullseye (oldstable).