### PR TITLE
Clang: add lld to llvm installation target

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -93,7 +93,7 @@ install_debian() {
 
 install_llvm() {
   echo Installing dependencies for compiling with LLVM / Clang...
-  apt-get install ${APTOPTS[*]} llvm clang libc++-dev libc++abi-dev
+  apt-get install ${APTOPTS[*]} llvm clang libc++-dev libc++abi-dev lld
   echo
 }
 


### PR DESCRIPTION
To be able to build the executable with llvm the lld linker is also required. Add this missing package to the apt-get install command.