### PR TITLE
Debian: replace transition package libfreetype6-dev

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -129,7 +129,7 @@ The following command installs these on Debian::
       libfmt-dev \
       libdbus-1-dev \
       libsodium-dev \
-      libfreetype6-dev \
+      libfreetype-dev \
       libpng-dev libjpeg-dev \
       libtiff5-dev libgeotiff-dev \
       libc-ares-dev \

--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -56,7 +56,7 @@ install_linux() {
     libfmt-dev \
     libdbus-1-dev \
     libsodium-dev \
-    libfreetype6-dev \
+    libfreetype-dev \
     libpng-dev libjpeg-dev \
     libtiff5-dev libgeotiff-dev \
     libssl-dev \


### PR DESCRIPTION
For the last two Debian releases the libfreetype6-dev package has been a transition package to libfreetype-dev. Replace the transition package with the target package.
