### PR TITLE
Save/Restore FLARM radar zoom on page change

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,8 @@ Version 7.44 - not yet released
   - add helpers on infoboxes for Argentinean contests 95% distance rule
   - Popup messages now appear at the top of the map
   - FlarmTrafficWindow: align colors of FlarmTraffic with map for consistency
+  - BigTrafficWidget: Save/Restore FLARM radar zoom on page change
+  - BigTrafficWidget: zoom range to 5km when opening big radar via the FlarmGauge
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy

--- a/src/Gauge/BigTrafficWidget.cpp
+++ b/src/Gauge/BigTrafficWidget.cpp
@@ -33,7 +33,7 @@ protected:
   bool enable_auto_zoom = true, dragging = false;
   bool init_defaults = false;
   unsigned zoom = 3;
-  unsigned last_zoom = 4;
+  unsigned last_zoom;
   static constexpr unsigned num_zoom_options = 5;
   Angle task_direction = Angle::Degrees(-1);
   GestureManager gestures;
@@ -73,6 +73,8 @@ public:
   }
 
   void SetAutoZoom(bool enabled);
+
+  void SaveZoom(unsigned value);
 
   void ToggleAutoZoom() {
     SetAutoZoom(!GetAutoZoom());
@@ -135,6 +137,8 @@ FlarmTrafficControl::OnCreate() noexcept
   Profile::GetEnum(ProfileKeys::FlarmSideData, side_display_type);
   enable_auto_zoom = settings.auto_zoom;
   enable_north_up = settings.north_up;
+  last_zoom = settings.radar_zoom;
+
   SetZoom(last_zoom);
 }
 
@@ -176,6 +180,17 @@ FlarmTrafficControl::SetAutoZoom(bool enabled)
   //auto_zoom->SetState(enabled);
 }
 
+/**
+ * save the zoom range in TrafficSettings and profile
+ */
+void
+FlarmTrafficControl::SaveZoom(unsigned zoom_value)
+{
+  TrafficSettings &settings = CommonInterface::SetUISettings().traffic;
+  settings.radar_zoom = zoom_value;
+  Profile::Set(ProfileKeys::FlarmRadarZoom, zoom_value);
+}
+
 void
 FlarmTrafficControl::CalcAutoZoom()
 {
@@ -207,7 +222,7 @@ FlarmTrafficControl::Update(Angle new_direction, const TrafficList &new_data,
 
   if (enable_auto_zoom || WarningMode()) {
     if (!init_defaults)
-      last_zoom = zoom;
+      SaveZoom(zoom);
     CalcAutoZoom();
     init_defaults = true;
   } else {
@@ -236,10 +251,11 @@ FlarmTrafficControl::ZoomOut()
   if (WarningMode())
     return;
 
-  init_defaults = false;
   if (zoom < num_zoom_options)
     SetZoom(zoom + 1);
 
+  SaveZoom(zoom);
+  init_defaults = false;
   SetAutoZoom(false);
 }
 
@@ -252,10 +268,11 @@ FlarmTrafficControl::ZoomIn()
   if (WarningMode())
     return;
 
-  init_defaults = false;
   if (zoom > 0)
     SetZoom(zoom - 1);
 
+  SaveZoom(zoom);
+  init_defaults = false;
   SetAutoZoom(false);
 }
 

--- a/src/Gauge/BigTrafficWidget.hpp
+++ b/src/Gauge/BigTrafficWidget.hpp
@@ -38,6 +38,7 @@ public:
   bool GetAutoZoom() const noexcept;
   void SetAutoZoom(bool value) noexcept;
   void ToggleAutoZoom() noexcept;
+  void SaveZoom(unsigned value) noexcept;
 
   [[gnu::pure]]
   bool GetNorthUp() const noexcept;

--- a/src/Gauge/GaugeFLARM.cpp
+++ b/src/Gauge/GaugeFLARM.cpp
@@ -7,6 +7,7 @@
 #include "Blackboard/LiveBlackboard.hpp"
 #include "Computer/Settings.hpp"
 #include "PageActions.hpp"
+#include "Interface.hpp"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
@@ -95,8 +96,11 @@ SmallTrafficWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
 
     ReleaseCapture();
 
-    if (was_pressed)
+    if (was_pressed) {
+      TrafficSettings &settings = CommonInterface::SetUISettings().traffic;
+      settings.radar_zoom = 4;
       PageActions::ShowTrafficRadar();
+    }
 
     return true;
   }

--- a/src/Gauge/TrafficSettings.cpp
+++ b/src/Gauge/TrafficSettings.cpp
@@ -10,5 +10,6 @@ TrafficSettings::SetDefaults() noexcept
   auto_close_dialog = false;
   auto_zoom = true;
   north_up = false;
+  radar_zoom = 4;
   gauge_location = GaugeLocation::BOTTOM_RIGHT_AVOID_IB;
 }

--- a/src/Gauge/TrafficSettings.hpp
+++ b/src/Gauge/TrafficSettings.hpp
@@ -16,6 +16,8 @@ struct TrafficSettings {
 
   bool north_up;
 
+  unsigned radar_zoom;
+
   /** Location of Flarm radar */
   enum class GaugeLocation : uint8_t {
     AUTO,

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -224,6 +224,7 @@ constexpr std::string_view InfoBoxTitleScale = "InfoBoxTitleScale";
 constexpr std::string_view FlarmSideData = "FlarmRadarSideData";
 constexpr std::string_view FlarmAutoZoom = "FlarmRadarAutoZoom";
 constexpr std::string_view FlarmNorthUp = "FlarmRadarNorthUp";
+constexpr std::string_view FlarmRadarZoom = "FlarmRadarZoom";
 
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";
@@ -287,5 +288,4 @@ constexpr std::string_view WaveAssistant = "WaveAssistant";
 constexpr std::string_view MasterAudioVolume = "MasterAudioVolume";
 
 constexpr std::string_view RaspFile = "RaspFile";
-
 }

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -57,6 +57,7 @@ Profile::Load(const ProfileMap &map, TrafficSettings &settings)
   map.Get(ProfileKeys::FlarmAutoZoom, settings.auto_zoom);
   map.Get(ProfileKeys::FlarmNorthUp, settings.north_up);
   map.GetEnum(ProfileKeys::FlarmLocation, settings.gauge_location);
+  map.Get(ProfileKeys::FlarmRadarZoom, settings.radar_zoom);
 }
 
 void


### PR DESCRIPTION
To save/restore the zoom range over pages and XCSoar restart it was necessary to add a new paramater in the profile. If this paramter is not known in the profile the default 5km is used.

By this enhancement the change between pages becomes more consitent. See the description in

https://github.com/XCSoar/XCSoar/issues/1681

In addition the zoom range on the big radar is set to 5 km when clicking on the small radar on the map. This makes sense because the small radar appears when an object comes into the 4km range. see the following screenshots.

![sc1](https://github.com/user-attachments/assets/1a1ab57f-3815-45dc-b26c-37f1a36bd073)

