### PR TITLE
Sprint time update

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,6 +1,7 @@
 Version 7.44 - not yet released
 * calculations
   - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
+  - update OLC League calculation to latest ruleset
 * tracking
   - xcsoar-cloud-service: rebuild service, new domain cloud.xcsoar.org
 * data files

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.44 - not yet released
+* calculations
+  - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
 * tracking
   - xcsoar-cloud-service: rebuild service, new domain cloud.xcsoar.org
 * data files

--- a/build/libcontest.mk
+++ b/build/libcontest.mk
@@ -15,7 +15,6 @@ CONTEST_SOURCES = \
 	$(CONTEST_SRC_DIR)/Solvers/OLCTriangleRules.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/OLCFAI.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/OLCPlus.cpp \
-	$(CONTEST_SRC_DIR)/Solvers/DMStQuad.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/XContestFree.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/XContestTriangle.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/OLCSISAT.cpp \

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -576,7 +576,7 @@ rules. \label{conf:taskrules}\index{Aufgabe!Regeln Voreinstellung}
    {\bf OLC Classic}: Bis zu sieben Punkte einschließlich Start und Ziel, Ankunftshöhe nicht
    mehr als 1000m unter der Abflughöhe. \\
    {\bf OLC League}: Der aktuelle Contest mit Sprint-Wettbewerbsregeln.
-   Aus dem OLC Classic Dreieck wird das 2,5 Stunden Fenster mit dem besten Schnitt herausgschnitten. 
+   Aus dem OLC Classic Dreieck wird das 2 Stunden Fenster mit dem besten Schnitt herausgschnitten. 
    Ankunftshöhe darf nicht unter Abflughöhe liegen.\\
   {\bf OLC Plus}: Kombination aus Classic und FAI Regeln. 30\% der FAI Punkte werden zur
    Classic Wertung dazugezählt \\

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -580,7 +580,7 @@ rules. \label{conf:taskrules}
   {\bf OLC Classic}: Up to seven points including start and finish, finish height
   must not be lower than start height less 1000~m. \\
   {\bf OLC League}: A contest on top of the classic task optimisation, cutting
-  a 2.5~hours segment over max.\ 3 of the turns. Finish height must not be below
+  a 2~hours segment over max.\ 3 of the turns. Finish height must not be below
   start height. \\
   {\bf OLC Plus}: A combination of Classic and FAI rules. 30\% of the FAI score
   are added to the Classic score. \\

--- a/doc/manual/fr/ch11_configuration.tex
+++ b/doc/manual/fr/ch11_configuration.tex
@@ -358,7 +358,7 @@ Les règles du circuit peuvent être utilisées afin de répondre aux règles de
   {\bf OLC FAI}: Conforme aux règles du triangle FAI. Trois points de virage dont départ et arrivée. Pas de branche inférieure à 28\% de la longueur totale, sauf si la longueur totale est de plus de 500 km. Si plus de 500 km alors pas de branche de moins de 25\% ou de plus de 45\%, sinon aucune branche inférieure à 28\% du total. L'altitude d'arrivée ne doit pas être plus basse de l'altitude de départ moins 1000 mètres. \\
   {\bf OLC Classic}: Jusqu'à sept points de virage incluant le départ et l'arrivée. L'altitude d'arrivée ne doit pas être plus basse de l'altitude de départ moins 1000 mètres. \\
   {\bf OLC League}: ??????????????????????? A contest on top of the classic task optimisation, cutting
-  a 2.5 hours segment over max. 3 of the turns. Finish height must not be below
+  a 2 hours segment over max. 3 of the turns. Finish height must not be below
   start height. \\
   {\bf OLC Plus}: ????????????? A combination of Classic and FAI rules. 30\% of the FAI score
   are added to the Classic score. \\

--- a/python/src/Flight/AnalyseFlight.cpp
+++ b/python/src/Flight/AnalyseFlight.cpp
@@ -157,7 +157,7 @@ void AnalyseFlight(DebugReplay &replay,
 {
   Trace full_trace({}, Trace::null_time, full_points);
   Trace triangle_trace({}, Trace::null_time, triangle_points);
-  Trace sprint_trace({}, minutes{150}, sprint_points);
+  Trace sprint_trace({}, minutes{120}, sprint_points);
   FlightPhaseDetector flight_phase_detector;
 
   Run(replay, flight_phase_detector, wind_list,

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -15,7 +15,7 @@ static constexpr auto full_trace_no_thin_time = std::chrono::minutes{2};
 TraceComputer::TraceComputer()
  :full(full_trace_no_thin_time, Trace::null_time, full_trace_size),
   contest({}, Trace::null_time, contest_trace_size),
-  sprint({}, std::chrono::minutes{150}, sprint_trace_size)
+  sprint({}, std::chrono::minutes{120}, sprint_trace_size)
 {
 }
 

--- a/src/Engine/Contest/Solvers/ContestDijkstra.cpp
+++ b/src/Engine/Contest/Solvers/ContestDijkstra.cpp
@@ -353,7 +353,8 @@ OLC league:
 - Sprint arrival height is the altitude at the sprint end point.
 - The average speed (points) of each individual flight is the sum of
   the distances from sprint start, around up to three turnpoints, to the
-  sprint end divided DAeC index increased by 100, multiplied by 200 and
-  divided by 2.5h: [formula: Points = km / 2,5 * 200 / (Index+100)
+  sprint end divided by weighted (75%) DAeC index increased by 100, multiplied by 100 and
+  divided by 2h: [formula: Points = (km / 2.0) * 100 / ((Index-100) * 0.75 + 100)
 
+  https://www.onlinecontest.org/olc-3.0/segelflugszene/cms.html?url=rules_overview/b5_de
 */

--- a/src/Engine/Contest/Solvers/OLCLeague.cpp
+++ b/src/Engine/Contest/Solvers/OLCLeague.cpp
@@ -5,6 +5,10 @@
 #include "Trace/Trace.hpp"
 #include "Cast.hpp"
 
+
+/**
+ * Ruleset: https://www.onlinecontest.org/olc-3.0/segelflugszene/cms.html?url=rules_overview/b5_de
+ */
 OLCLeague::OLCLeague(const Trace &_trace) noexcept
   :AbstractContest(0), trace(_trace)
 {
@@ -81,6 +85,6 @@ OLCLeague::CalculateResult() const noexcept
   result.distance = 0;
   for (unsigned i = 0; i < 4; ++i)
     result.distance += solution[i].DistanceTo(solution[i + 1].GetLocation());
-  result.score = ApplyShiftedHandicap(result.distance / 2500);
+  result.score = ApplyShiftedHandicap(result.distance / 2000);
   return result;
 }

--- a/src/Engine/Contest/Solvers/OLCSprint.cpp
+++ b/src/Engine/Contest/Solvers/OLCSprint.cpp
@@ -44,9 +44,9 @@ OLCSprint::FindStart() const noexcept
 
   unsigned start_index = 0;
   const auto end_time = TraceManager::GetPoint(n_points - 1).GetTime();
-  if (end_time > std::chrono::minutes{150}) {
+  if (end_time > std::chrono::minutes{120}) {
     // fast forward to 2.5 hours before finish
-    const auto start_time = end_time - std::chrono::minutes{150};
+    const auto start_time = end_time - std::chrono::minutes{120};
     assert(start_index < n_points);
     while (TraceManager::GetPoint(start_index).GetTime() < start_time) {
       ++start_index;

--- a/test/src/AnalyseFlight.cpp
+++ b/test/src/AnalyseFlight.cpp
@@ -359,7 +359,7 @@ int main(int argc, char **argv)
 
   static Trace full_trace({}, Trace::null_time, full_max_points);
   static Trace triangle_trace({}, Trace::null_time, triangle_max_points);
-  static Trace sprint_trace({}, minutes{150}, sprint_max_points);
+  static Trace sprint_trace({}, minutes{120}, sprint_max_points);
 
   Result result;
   Run(*replay, result, full_trace, triangle_trace, sprint_trace);

--- a/test/src/RunContestAnalysis.cpp
+++ b/test/src/RunContestAnalysis.cpp
@@ -18,11 +18,11 @@ using namespace std::chrono;
 #ifdef BENCHMARK_LK8000
 static Trace full_trace({}, Trace::null_time, 100);
 static Trace triangle_trace({}, Trace::null_time, 100);
-static Trace sprint_trace({}, minutes{150}, 50);
+static Trace sprint_trace({}, minutes{120}, 50);
 #else
 static Trace full_trace({}, Trace::null_time, 512);
 static Trace triangle_trace({}, Trace::null_time, 1024);
-static Trace sprint_trace({}, minutes{150}, 128);
+static Trace sprint_trace({}, minutes{120}, 128);
 #endif
 
 static ContestManager olc_classic(Contest::OLC_CLASSIC,


### PR DESCRIPTION
Partially fixes #569 - a customizable sprint time would be preferable, but is currently not needed as the two sprint contests known to me both have a 2 hour window now.
