### PR TITLE
Navigation widget

### DIFF
--- a/build/liblook.mk
+++ b/build/liblook.mk
@@ -22,6 +22,7 @@ LOOK_SOURCES := \
 	$(SRC)/Look/CrossSectionLook.cpp \
 	$(SRC)/Look/GestureLook.cpp \
 	$(SRC)/Look/HorizonLook.cpp \
+	$(SRC)/Look/NavigatorLook.cpp \
 	$(SRC)/Look/TaskLook.cpp \
 	$(SRC)/Look/TrafficLook.cpp \
 	$(SRC)/Look/InfoBoxLook.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -198,6 +198,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Renderer/TextRowRenderer.cpp \
 	$(SRC)/Renderer/TwoTextRowsRenderer.cpp \
 	$(SRC)/Renderer/HorizonRenderer.cpp \
+	$(SRC)/Renderer/NavigatorRenderer.cpp \
 	$(SRC)/Renderer/GradientRenderer.cpp \
 	$(SRC)/Renderer/GlassRenderer.cpp \
 	$(SRC)/Renderer/TransparentRendererCache.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -287,6 +287,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/BigThermalAssistantWidget.cpp \
 	$(SRC)/Gauge/FlarmTrafficWindow.cpp \
 	$(SRC)/Gauge/BigTrafficWidget.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/Gauge/GaugeFLARM.cpp \
 	$(SRC)/Gauge/GaugeThermalAssistant.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -287,6 +287,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/BigThermalAssistantWidget.cpp \
 	$(SRC)/Gauge/FlarmTrafficWindow.cpp \
 	$(SRC)/Gauge/BigTrafficWidget.cpp \
+	$(SRC)/Gauge/NavigatorWidget.cpp \
 	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/Gauge/GaugeFLARM.cpp \
 	$(SRC)/Gauge/GaugeThermalAssistant.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1704,6 +1704,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/MapSettings.cpp \
 	$(SRC)/Computer/Settings.cpp \
 	$(SRC)/Computer/Wind/Settings.cpp \
@@ -2131,6 +2132,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+  $(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/TeamCode/TeamCode.cpp \
 	$(SRC)/TeamCode/Settings.cpp \
 	$(SRC)/Logger/Settings.cpp \

--- a/src/DataGlobals.cpp
+++ b/src/DataGlobals.cpp
@@ -25,7 +25,7 @@ DataGlobals::UnsetTerrain() noexcept
   /* just in case the bottom widget uses the old terrain object
      (e.g. the cross section) */
   main_window.SetBottomWidget(nullptr);
-
+  main_window.SetTopWidget(nullptr);
   main_window.SetTerrain(nullptr);
 
   if (backend_components->glide_computer)

--- a/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
@@ -19,7 +19,9 @@ enum ControlIndex {
   EnableThermalProfile,
   FinalGlideBarDisplayModeControl,
   EnableFinalGlideBarMC0,
-  EnableVarioBar
+  EnableVarioBar,
+  SPACER,
+  NavigatorWidgetHeight
 };
 
 static constexpr StaticEnumChoice final_glide_bar_display_mode_list[] = {
@@ -160,6 +162,19 @@ GaugesConfigPanel::Prepare(ContainerWindow &parent,
              map_settings.vario_bar_enabled);
 
   SetExpertRow(EnableVarioBar);
+
+  AddSpacer();
+  SetExpertRow(SPACER);
+
+  AddInteger(
+    _("Navigator Widget Height"),
+    _("Select the height of the navigator topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"),
+    _T("%u %%"), _T("%u"), 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_height); //settings.min_frequency
+  SetExpertRow(NavigatorWidgetHeight);
 }
 
 bool
@@ -194,6 +209,11 @@ GaugesConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValue(EnableVarioBar, ProfileKeys::EnableVarioBar,
                        map_settings.vario_bar_enabled);
+
+  if ((changed |= SaveValueInteger(NavigatorWidgetHeight, ProfileKeys::NavigatorHeight,
+                                   ui_settings.navigator.navigator_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+
   _changed |= changed;
 
   return true;

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -37,6 +37,7 @@ private:
     MAIN,
     INFO_BOX_PANEL,
     BOTTOM,
+    TOP,
   };
 
   static constexpr unsigned IBP_NONE = 0x7000;
@@ -223,6 +224,15 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
           _("Specifies what should be displayed below the main area."),
           bottom_list,
           (unsigned)PageLayout::Bottom::NOTHING, this);
+
+  static constexpr StaticEnumChoice top_list[] = {
+    { PageLayout::Top::NOTHING, N_("Nothing") },
+    nullptr
+  };
+  AddEnum(_("Top area"),
+          _("Specifies what should be displayed above the main area."),
+          top_list,
+          (unsigned)PageLayout::Top::NOTHING, this);
 }
 
 void
@@ -232,6 +242,7 @@ PageLayoutEditWidget::SetValue(const PageLayout &_value)
 
   LoadValueEnum(MAIN, value.main);
   LoadValueEnum(BOTTOM, value.bottom);
+  LoadValueEnum(TOP, value.top);
 
   unsigned ib = IBP_NONE;
   if (value.infobox_config.enabled) {
@@ -270,6 +281,9 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
   } else if (&df == &GetDataField(BOTTOM)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.bottom = (PageLayout::Bottom)dfe.GetValue();
+  } else if (&df == &GetDataField(TOP)) {
+    const DataFieldEnum &dfe = (const DataFieldEnum &)df;
+    value.top = (PageLayout::Top)dfe.GetValue();
   } else {
     gcc_unreachable();
   }
@@ -386,6 +400,16 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   case PageLayout::Bottom::MAX:
     gcc_unreachable();
   }
+
+  switch (value.top) {
+  case PageLayout::Top::NOTHING:
+  case PageLayout::Top::CUSTOM:
+    break;
+
+  case PageLayout::Top::MAX:
+    gcc_unreachable();
+  }
+
 
   row_renderer.DrawTextRow(canvas, rc, buffer);
 }

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -227,6 +227,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 
   static constexpr StaticEnumChoice top_list[] = {
     { PageLayout::Top::NOTHING, N_("Nothing") },
+    { PageLayout::Top::NAVIGATOR, N_("Navigator") },
     nullptr
   };
   AddEnum(_("Top area"),
@@ -404,6 +405,10 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   switch (value.top) {
   case PageLayout::Top::NOTHING:
   case PageLayout::Top::CUSTOM:
+    break;
+
+  case PageLayout::Top::NAVIGATOR:
+    buffer.AppendFormat(_T(", %s"), _("Navigator"));
     break;
 
   case PageLayout::Top::MAX:

--- a/src/Gauge/NavigatorSettings.cpp
+++ b/src/Gauge/NavigatorSettings.cpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorSettings.hpp"
+
+void
+NavigatorSettings::SetDefaults() noexcept
+{
+  navigator_height = 17;
+}

--- a/src/Gauge/NavigatorSettings.hpp
+++ b/src/Gauge/NavigatorSettings.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+struct NavigatorSettings {
+
+  unsigned navigator_height;
+
+  void SetDefaults() noexcept;
+};

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -96,6 +96,10 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
         CommonInterface::Calculated().common_stats.ordered_summary, canvas,
         canvas.GetRect(), look_nav, look_task);
 
+  if (wp_current != nullptr)
+    NavigatorRenderer::DrawTaskText(canvas, tp, *wp_current, canvas.GetRect(),
+                                    look_nav, look_infobox);
+
   NavigatorRenderer::DrawWaypointsIconsTitle(canvas, wp_before, wp_current,
                                              task_size, look_nav);
 }

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -86,6 +86,11 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
 
   NavigatorRenderer::DrawFrame(canvas, frame_navigator, look_nav);
   NavigatorRenderer::DrawFrame(canvas, frame_navigator_waypoint, look_nav);
+
+  if (tp == TaskType::ORDERED)
+    NavigatorRenderer::DrawProgressTask(
+        CommonInterface::Calculated().common_stats.ordered_summary, canvas,
+        canvas.GetRect(), look_nav, look_task);
 }
 
 void

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -45,6 +45,8 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
   WaypointPtr wp_before;
   WaypointPtr wp_current;
 
+  unsigned task_size{};
+
   auto *protected_task_manager =
       backend_components->protected_task_manager.get();
   if (protected_task_manager != nullptr) {
@@ -57,6 +59,8 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
       if (tp == TaskType::ORDERED) {
 
         const OrderedTask &task = lease->GetOrderedTask();
+
+        task_size = task.TaskSize();
 
         wp_current = task.GetActiveTaskPoint()->GetWaypointPtr();
 
@@ -91,6 +95,9 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
     NavigatorRenderer::DrawProgressTask(
         CommonInterface::Calculated().common_stats.ordered_summary, canvas,
         canvas.GetRect(), look_nav, look_task);
+
+  NavigatorRenderer::DrawWaypointsIconsTitle(canvas, wp_before, wp_current,
+                                             task_size, look_nav);
 }
 
 void

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#ifdef WIN32_LEAN_AND_MEAN
+#include "ui/canvas/gdi/Canvas.hpp"
+#endif
+#include "NavigatorWidget.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/TaskManager.hpp"
+#include "InfoBoxes/InfoBoxWindow.hpp"
+#include "Input/InputEvents.hpp"
+#include "Screen/Layout.hpp"
+#include "Task/ProtectedTaskManager.hpp"
+#include "UIGlobals.hpp"
+
+NavigatorWindow::NavigatorWindow(const TaskLook &_look_task,
+                                 const InfoBoxLook &_look_infobox) noexcept
+    : look_task(_look_task),
+      look_infobox(_look_infobox),
+      dragging(false)
+{
+}
+
+void
+NavigatorWindow::ReadBlackboard(const AttitudeState &_attitude) noexcept
+{
+  attitude = _attitude;
+}
+
+void
+NavigatorWindow::OnPaint(Canvas &canvas) noexcept
+{
+  canvas.Clear(COLOR_BLACK);
+
+  TaskType tp{TaskType::NONE};
+  WaypointPtr wp_before;
+  WaypointPtr wp_current;
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr) {
+    ProtectedTaskManager::Lease lease(*protected_task_manager);
+    const auto &stats = lease->GetStats();
+
+    tp = lease->GetMode();
+
+    if (stats.task_valid) {
+      if (tp == TaskType::ORDERED) {
+
+        const OrderedTask &task = lease->GetOrderedTask();
+
+        wp_current = task.GetActiveTaskPoint()->GetWaypointPtr();
+
+        auto i = task.GetActiveIndex();
+        if (i == 0) wp_before = nullptr;
+        else wp_before = task.GetPoint(i - 1).GetWaypointPtr();
+      } else {
+        wp_current =
+            lease->GetActiveTask()->GetActiveTaskPoint()->GetWaypointPtr();
+        wp_before = nullptr;
+      }
+    } else {
+      wp_current = nullptr;
+      wp_before = nullptr;
+    }
+  }
+
+  const int fnw_height = canvas.GetHeight();
+  const int fnw_width = canvas.GetWidth();
+
+  PixelPoint pt_origin{fnw_width * 18 / 100, fnw_height * 1 / 10};
+  PixelSize frame_size{fnw_width * 8 / 10, fnw_height * 55 / 100};
+  PixelRect frame_navigator_waypoint{pt_origin, frame_size};
+}
+
+void
+NavigatorWindow::StopDragging()
+{
+  if (!dragging) return;
+
+  dragging = false;
+  ReleaseCapture();
+}
+
+bool
+NavigatorWindow::OnMouseGesture(const TCHAR *gesture) noexcept
+{
+  if (StringIsEqual(gesture, _T("U"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("D"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("R"))) {
+    InputEvents::eventAdjustWaypoint(_T("previouswrap"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("L"))) {
+    InputEvents::eventAdjustWaypoint(_T("nextwrap"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("UD"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("DR"))) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("RL"))) {
+    InputEvents::eventSetup(_T("Target"));
+    return true;
+  }
+  if (StringIsEqual(gesture, _T("LR"))) {
+    InputEvents::eventSetup(_T("Alternates"));
+    return true;
+  }
+  if (gesture) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+
+  return InputEvents::processGesture(gesture);
+}
+
+bool
+NavigatorWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
+{
+  StopDragging();
+  ignore_single_click = true;
+  InputEvents::ShowMenu();
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseDown(PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) return true;
+
+  mouse_down_clock.Update();
+
+  if (!dragging) {
+    dragging = true;
+    SetCapture();
+    gestures.Start(p, Layout::Scale(20));
+  }
+
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) {
+    ignore_single_click = false;
+    return true;
+  }
+
+  const auto click_time = mouse_down_clock.Elapsed();
+  mouse_down_clock.Reset();
+
+  if (dragging) {
+    StopDragging();
+
+    const TCHAR *gesture = gestures.Finish();
+    if (gesture && OnMouseGesture(gesture)) return true;
+
+    if (click_time > std::chrono::milliseconds(400) &&
+        click_time < std::chrono::milliseconds(1000))
+      // on gesture mouse up == simpleClick
+      InputEvents::eventAnalysis(_T("AnalysisPage::TASK"));
+
+    else if (click_time > std::chrono::milliseconds(1000) &&
+             click_time < std::chrono::milliseconds(3000))
+      InputEvents::eventSetup(_T("Task"));
+
+    else return false;
+  }
+
+  return false;
+}
+
+bool
+NavigatorWindow::OnMouseMove(PixelPoint p,
+                             [[maybe_unused]] unsigned keys) noexcept
+{
+  if (dragging) gestures.Update(p);
+
+  return true;
+}
+
+void
+NavigatorWindow::OnCancelMode() noexcept
+{
+#ifndef USE_WINUSER
+  ReleaseCapture();
+#endif
+  StopDragging();
+}
+
+bool
+NavigatorWindow::OnKeyDown(unsigned key_code) noexcept
+{
+  return InputEvents::processKey(key_code);
+}
+
+void
+NavigatorWidget::Update([[maybe_unused]] const MoreData &basic) noexcept
+{
+  navigator_window->ReadBlackboard(basic.attitude);
+}
+
+void
+NavigatorWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+{
+  const Look &look = UIGlobals::GetLook();
+
+  WindowStyle style;
+  style.Hide();
+  style.Disable();
+
+  navigator_window = std::make_unique<NavigatorWindow>(
+      look.map.task, look.info_box);
+  navigator_window->Create(parent, rc, style);
+  navigator_window->Move(rc);
+}
+
+void
+NavigatorWidget::Show([[maybe_unused]] const PixelRect &rc) noexcept
+{
+  Update(CommonInterface::Basic());
+  CommonInterface::GetLiveBlackboard().AddListener(*this);
+  navigator_window->Show();
+}
+
+void
+NavigatorWidget::Hide() noexcept
+{
+  navigator_window->Hide();
+  CommonInterface::GetLiveBlackboard().RemoveListener(*this);
+}
+
+void
+NavigatorWidget::Move(const PixelRect &rc) noexcept
+{
+  navigator_window->Move(rc);
+}
+
+bool
+NavigatorWidget::SetFocus() noexcept
+{
+  return false;
+}
+
+PixelSize
+NavigatorWidget::GetMinimumSize() const noexcept
+{
+  return PixelSize{
+      CommonInterface::GetUISettings().navigator.navigator_height};
+}
+
+void
+NavigatorWidget::OnGPSUpdate(const MoreData &basic) noexcept
+{
+  Update(basic);
+}
+
+void
+NavigatorWidget::UpdateLayout() noexcept
+{
+  const PixelRect rc = navigator_window->GetClientRect();
+  navigator_window->Move(rc);
+}

--- a/src/Gauge/NavigatorWidget.hpp
+++ b/src/Gauge/NavigatorWidget.hpp
@@ -6,6 +6,7 @@
 #include "Blackboard/BlackboardListener.hpp"
 #include "Interface.hpp"
 #include "Look/Look.hpp"
+#include "Look/NavigatorLook.hpp"
 #include "MainWindow.hpp"
 #include "UIUtil/GestureManager.hpp"
 #include "Widget/WindowWidget.hpp"
@@ -14,7 +15,7 @@
  * A Window which renders a Navigator
  */
 class NavigatorWindow : public PaintWindow {
-
+  const NavigatorLook &look_nav;
   const TaskLook &look_task;
   const InfoBoxLook &look_infobox;
 
@@ -30,7 +31,7 @@ public:
   /**
    * Constructor. Initializes most class members.
    */
-  NavigatorWindow(const TaskLook &_look_task,
+  NavigatorWindow(const NavigatorLook &_look_nav, const TaskLook &_look_task,
                   const InfoBoxLook &_look_infobox) noexcept;
 
   void ReadBlackboard(const AttitudeState &_attitude) noexcept;

--- a/src/Gauge/NavigatorWidget.hpp
+++ b/src/Gauge/NavigatorWidget.hpp
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Blackboard/BlackboardListener.hpp"
+#include "Interface.hpp"
+#include "Look/Look.hpp"
+#include "MainWindow.hpp"
+#include "UIUtil/GestureManager.hpp"
+#include "Widget/WindowWidget.hpp"
+
+/**
+ * A Window which renders a Navigator
+ */
+class NavigatorWindow : public PaintWindow {
+
+  const TaskLook &look_task;
+  const InfoBoxLook &look_infobox;
+
+  AttitudeState attitude;
+
+  GestureManager gestures;
+  bool dragging{false};
+  bool ignore_single_click{false};
+
+  PeriodClock mouse_down_clock;
+
+public:
+  /**
+   * Constructor. Initializes most class members.
+   */
+  NavigatorWindow(const TaskLook &_look_task,
+                  const InfoBoxLook &_look_infobox) noexcept;
+
+  void ReadBlackboard(const AttitudeState &_attitude) noexcept;
+
+protected:
+  /* virtual methods from AntiFlickerWindow */
+  void OnPaint(Canvas &canvas) noexcept override;
+
+private:
+  void StopDragging();
+
+public:
+  bool OnMouseGesture(const TCHAR *gesture) noexcept;
+  bool OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseDown(PixelPoint p) noexcept override;
+  bool OnMouseUp([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseMove(PixelPoint p, [[maybe_unused]] unsigned keys) noexcept override;
+  void OnCancelMode() noexcept override;
+  bool OnKeyDown(unsigned key_code) noexcept override;
+};
+
+
+class NavigatorWidget final : public NullWidget, private NullBlackboardListener {
+
+  std::unique_ptr<NavigatorWindow> navigator_window;
+  bool enable_auto_zoom = true;
+  unsigned zoom = 2;
+
+public:
+  ~NavigatorWidget() noexcept = default;
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
+  void Move(const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
+
+  PixelSize GetMinimumSize() const noexcept override;
+
+  NavigatorWindow* GetWindow() noexcept {
+    return navigator_window.get();
+  }
+private:
+  void Update(const MoreData &basic) noexcept;
+  void UpdateLayout() noexcept;
+
+  /* virtual methods from class BlackboardListener */
+  void OnGPSUpdate(const MoreData &basic) noexcept override;
+};

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -73,6 +73,8 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "DataComponents.hpp"
 
 #include <cassert>
+#include <map>
+#include <string_view>
 #include <tchar.h>
 #include <algorithm>
 
@@ -335,12 +337,45 @@ InputEvents::eventStatus(const TCHAR *misc)
 void
 InputEvents::eventAnalysis([[maybe_unused]] const TCHAR *misc)
 {
+  AnalysisPage analysis_page;
+
+  if (StringIsEqual(misc, _T("AnalysisPage::BAROGRAPH"))) {
+    analysis_page = AnalysisPage::BAROGRAPH;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::COUNT"))) {
+    analysis_page = AnalysisPage::COUNT;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::CLIMB"))) {
+    analysis_page = AnalysisPage::CLIMB;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::VARIO_HISTOGRAM"))) {
+    analysis_page = AnalysisPage::VARIO_HISTOGRAM;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::THERMAL_BAND"))) {
+    analysis_page = AnalysisPage::THERMAL_BAND;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::WIND"))) {
+    analysis_page = AnalysisPage::WIND;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::POLAR"))) {
+    analysis_page = AnalysisPage::POLAR;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::MACCREADY"))) {
+    analysis_page = AnalysisPage::MACCREADY;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TEMPTRACE"))) {
+    analysis_page = AnalysisPage::TEMPTRACE;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TASK"))) {
+    analysis_page = AnalysisPage::TASK;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::CONTEST"))) {
+    analysis_page = AnalysisPage::CONTEST;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::TASK_SPEED"))) {
+    analysis_page = AnalysisPage::TASK_SPEED;
+  } else if (StringIsEqual(misc, _T("AnalysisPage::AIRSPACE"))) {
+    analysis_page = AnalysisPage::AIRSPACE;
+  } else {
+    analysis_page = AnalysisPage::CONTEST;
+  }
+
   dlgAnalysisShowModal(*CommonInterface::main_window,
                        CommonInterface::main_window->GetLook(),
                        CommonInterface::Full(),
                        *backend_components->glide_computer,
                        data_components->airspaces.get(),
-                       data_components->terrain.get());
+                       data_components->terrain.get(),
+                       analysis_page);
 }
 
 // WaypointDetails

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -42,6 +42,7 @@ Look::InitialiseConfigured(const UISettings &settings,
   dialog.Initialise();
   terminal.Initialise();
   cross_section.Initialise(map_font);
+  navigator.Initialise(dark_mode);
   horizon.Initialise();
   thermal_band.Initialise(dark_mode,
                           cross_section.sky_color);

--- a/src/Look/Look.hpp
+++ b/src/Look/Look.hpp
@@ -13,6 +13,7 @@
 #include "MapLook.hpp"
 #include "CrossSectionLook.hpp"
 #include "HorizonLook.hpp"
+#include "NavigatorLook.hpp"
 #include "TrafficLook.hpp"
 #include "FlarmTrafficLook.hpp"
 #include "InfoBoxLook.hpp"
@@ -36,6 +37,7 @@ struct Look {
   MapLook map;
   CrossSectionLook cross_section;
   HorizonLook horizon;
+  NavigatorLook navigator;
   TrafficLook traffic;
   FlarmTrafficLook flarm_gauge;
   FlarmTrafficLook flarm_dialog;

--- a/src/Look/NavigatorLook.cpp
+++ b/src/Look/NavigatorLook.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorLook.hpp"
+#include "Screen/Layout.hpp"
+
+void
+NavigatorLook::Initialise(bool _inverse)
+{
+  Color pen_frame_color, brush_frame_color;
+
+  if (!(inverse = _inverse)) {
+    pen_frame_color = color_frame;
+    brush_frame_color = color_background_frame;
+  } else {
+    pen_frame_color = color_frame_inv;
+    brush_frame_color = color_background_frame_inv;
+  }
+  pen_frame.Create(Layout::ScaleFinePenWidth(1), pen_frame_color);
+  brush_frame.Create(brush_frame_color);
+}

--- a/src/Look/NavigatorLook.hpp
+++ b/src/Look/NavigatorLook.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/canvas/Brush.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/Pen.hpp"
+
+class Font;
+
+struct NavigatorLook {
+  bool inverse;
+
+  static constexpr Color color_background_frame{COLOR_WHITE};
+  static constexpr Color color_background_frame_inv{COLOR_BLACK};
+  static constexpr Color color_frame{COLOR_BLACK};
+  static constexpr Color color_frame_inv{COLOR_WHITE};
+
+  Pen pen_frame;
+  Brush brush_frame;
+
+  void Initialise(bool _inverse);
+};

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "Gauge/GaugeFLARM.hpp"
 #include "Gauge/GaugeThermalAssistant.hpp"
 #include "Gauge/GlueGaugeVario.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "Form/Form.hpp"
 #include "Widget/Widget.hpp"
 #include "Look/GlobalFonts.hpp"
@@ -648,6 +649,12 @@ MainWindow::StopDragging() noexcept
 void
 MainWindow::OnCancelMode() noexcept
 {
+  if (HaveTopWidget()) {
+    auto nav = dynamic_cast<NavigatorWidget *>(top_widget);
+    if (nav != nullptr)
+      nav->GetWindow()->OnCancelMode();
+  }
+
   SingleWindow::OnCancelMode();
   StopDragging();
 }
@@ -655,6 +662,19 @@ MainWindow::OnCancelMode() noexcept
 bool
 MainWindow::OnMouseDown(PixelPoint p) noexcept
 {
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDown(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDown(p))
     return true;
 
@@ -670,6 +690,19 @@ MainWindow::OnMouseDown(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseUp(PixelPoint p) noexcept
 {
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseUp(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseUp(p))
     return true;
 
@@ -687,6 +720,19 @@ MainWindow::OnMouseUp(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseDouble(PixelPoint p) noexcept
 {
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDouble(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDouble(p))
     return true;
 
@@ -700,6 +746,19 @@ MainWindow::OnMouseDouble(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
 {
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseMove(p, keys);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseMove(p, keys))
     return true;
 

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -145,7 +145,11 @@ protected:
   void KillWidget() noexcept;
 
   bool HaveTopWidget() const noexcept {
-    return top_widget != nullptr;
+    /* currently, the top widget is only visible above the map, but
+       not above a custom main widget */
+    /* TODO: eliminate this limitation; don't forget to remove the
+       "widget==nullptr" check from MainWindow::KillTopWidget() */
+    return top_widget != nullptr && widget == nullptr;
   }
 
   /**

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -59,12 +59,14 @@ public:
         manager.AcknowledgeWarning(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("ACK Day"), [this](){
       manager.AcknowledgeDay(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("More"), [this](){
@@ -100,8 +102,11 @@ AirspaceWarningMonitor::Reset() noexcept
 void
 AirspaceWarningMonitor::HideWidget() noexcept
 {
-  if (widget != nullptr)
+  if (widget != nullptr) {
     PageActions::RestoreBottom();
+    PageActions::RestoreTop();
+  }
+  
   assert(widget == nullptr);
 }
 

--- a/src/Monitor/MatTaskMonitor.cpp
+++ b/src/Monitor/MatTaskMonitor.cpp
@@ -40,9 +40,11 @@ public:
     AddButton(_("Add"), [this](){
       OnAdd();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -173,8 +175,10 @@ MatTaskMonitor::Check()
     last_id = id;
   } else {
     /* no nearby turn point: close the QuestionWidget */
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
 
     last_id = unsigned(-1);
   }

--- a/src/Monitor/TaskAdvanceMonitor.cpp
+++ b/src/Monitor/TaskAdvanceMonitor.cpp
@@ -29,10 +29,12 @@ public:
       }
 
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -54,8 +56,10 @@ TaskAdvanceMonitor::Check()
       PageActions::SetCustomBottom(widget);
     }
   } else {
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
   }
 
   last_active_index = stats.active_index;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "PageActions.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "UIActions.hpp"
 #include "UIState.hpp"
 #include "Interface.hpp"
@@ -13,6 +14,12 @@
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Components.hpp"
+
+#include "Widget/ButtonWidget.hpp"
+#include "Input/InputEvents.hpp"
+#include "Look/DialogLook.hpp"
+#include "Language/Language.hpp"
+#include "Dialogs/FileManager.hpp"
 
 #if defined(ENABLE_SDL) && defined(main)
 /* on some platforms, SDL wraps the main() function and clutters our
@@ -224,6 +231,9 @@ LoadTop(PageLayout::Top top)
   switch (top) {
   case PageLayout::Top::NOTHING:
     CommonInterface::main_window->SetTopWidget(nullptr);
+    break;
+  case PageLayout::Top::NAVIGATOR:
+    CommonInterface::main_window->SetTopWidget(new NavigatorWidget());
     break;
   case PageLayout::Top::CUSTOM:
     /* don't touch */

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -138,6 +138,7 @@ PageActions::Next()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 unsigned
@@ -168,6 +169,7 @@ PageActions::Prev()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 static void
@@ -217,6 +219,21 @@ LoadBottom(PageLayout::Bottom bottom)
 }
 
 static void
+LoadTop(PageLayout::Top top)
+{
+  switch (top) {
+  case PageLayout::Top::NOTHING:
+    CommonInterface::main_window->SetTopWidget(nullptr);
+    break;
+  case PageLayout::Top::CUSTOM:
+    /* don't touch */
+    break;
+  case PageLayout::Top::MAX:
+    gcc_unreachable();
+  }
+}
+
+static void
 LoadInfoBoxes(const PageLayout::InfoBoxConfig &config)
 {
   UIState &ui_state = CommonInterface::SetUIState();
@@ -247,6 +264,7 @@ PageActions::LoadLayout(const PageLayout &layout)
 
   LoadInfoBoxes(layout.infobox_config);
   LoadBottom(layout.bottom);
+  LoadTop(layout.top);
   LoadMain(layout.main);
 
   ActionInterface::UpdateDisplayMode();
@@ -299,6 +317,24 @@ PageActions::RestoreBottom()
     special_page.SetUndefined();
 
   LoadBottom(configured_page.bottom);
+}
+
+void
+PageActions::RestoreTop()
+{
+  PageLayout &special_page = CommonInterface::SetUIState().pages.special_page;
+  if (!special_page.IsDefined())
+    return;
+
+  const PageLayout &configured_page = GetConfiguredLayout();
+  if (special_page.top == configured_page.top)
+    return;
+
+  special_page.top = configured_page.top;
+  if (special_page == configured_page)
+    special_page.SetUndefined();
+
+  LoadTop(configured_page.top);
 }
 
 GlueMapWindow *
@@ -377,4 +413,16 @@ PageActions::SetCustomBottom(Widget *widget)
   state.special_page = GetCurrentLayout();
   state.special_page.bottom = PageLayout::Bottom::CUSTOM;
   CommonInterface::main_window->SetBottomWidget(widget);
+}
+
+void
+PageActions::SetCustomTop(Widget *widget)
+{
+  assert(widget != nullptr);
+
+  PagesState &state = CommonInterface::SetUIState().pages;
+
+  state.special_page = GetCurrentLayout();
+  state.special_page.top = PageLayout::Top::CUSTOM;
+  CommonInterface::main_window->SetTopWidget(widget);
 }

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -72,6 +72,11 @@ namespace PageActions
   void RestoreBottom();
 
   /**
+   * Like Restore(), but affects only the top area.
+   */
+  void RestoreTop();
+
+  /**
    * Show a page with the map, or restore the current page if it was
    * configured with a map (for example if the user has activated the
    * FLARM radar page).
@@ -102,4 +107,10 @@ namespace PageActions
    * MainWindow::SetBottomWidget().  Call RestoreBottom() to undo this.
    */
   void SetCustomBottom(Widget *widget);
+
+  /**
+   * Use a custom widget for the "top" area.  This is a wrapper for
+   * MainWindow::SetTopWidget().  Call RestoreTop() to undo this.
+   */
+  void SetCustomTop(Widget *widget);
 };

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -79,6 +79,9 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
     case Top::NOTHING:
     case Top::CUSTOM:
       break;
+    case Top::NAVIGATOR:
+      builder.Append(_T(", NAV"));
+      break;
     case Top::MAX:
       gcc_unreachable();
     }

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -74,6 +74,14 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
     case Bottom::MAX:
       gcc_unreachable();
     }
+
+    switch (top) {
+    case Top::NOTHING:
+    case Top::CUSTOM:
+      break;
+    case Top::MAX:
+      gcc_unreachable();
+    }
   } catch (BasicStringBuilder<TCHAR>::Overflow) {
   }
 

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -81,17 +81,37 @@ struct PageLayout
     MAX
   } bottom;
 
+  /**
+   * What to show above the main area (i.e. map)?
+   */
+  enum class Top : uint8_t {
+    NOTHING,
+
+    /**
+     * A custom #Widget is being displayed.  This is not a
+     * user-accessible option, it's only used for runtime state.
+     */
+    CUSTOM,
+
+    /**
+     * A dummy entry that is used for validating profile values.
+     */
+    MAX
+  } top;
+
   PageLayout() = default;
 
   constexpr PageLayout(bool _valid, InfoBoxConfig _infobox_config)
     :valid(_valid), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   constexpr PageLayout(InfoBoxConfig _infobox_config)
     :valid(true), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   /**
    * Return an "undefined" page.  Its IsDefined() method will return

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -88,6 +88,11 @@ struct PageLayout
     NOTHING,
 
     /**
+     * Show a Navigator menu above the map.
+     */
+    NAVIGATOR,
+
+    /**
      * A custom #Widget is being displayed.  This is not a
      * user-accessible option, it's only used for runtime state.
      */

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -226,6 +226,8 @@ constexpr std::string_view FlarmAutoZoom = "FlarmRadarAutoZoom";
 constexpr std::string_view FlarmNorthUp = "FlarmRadarNorthUp";
 constexpr std::string_view FlarmRadarZoom = "FlarmRadarZoom";
 
+constexpr std::string_view NavigatorHeight = "NavigatorHeight";
+
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";
 

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -55,6 +55,11 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
       unsigned(pl.bottom) >= unsigned(PageLayout::Bottom::MAX))
     pl.bottom = PageLayout::Bottom::NOTHING;
 
+  strcpy(profileKey + prefixLen, "Top");
+  if (!map.GetEnum(profileKey, pl.top) ||
+      unsigned(pl.top) >= unsigned(PageLayout::Top::MAX))
+    pl.top = PageLayout::Top::NOTHING;
+
   strcpy(profileKey + prefixLen, "Main");
   if (!map.GetEnum(profileKey, pl.main) ||
       unsigned(pl.main) >= unsigned(PageLayout::Main::MAX))
@@ -96,6 +101,9 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
 
   strcpy(profileKey + prefixLen, "Bottom");
   map.Set(profileKey, (unsigned)page.bottom);
+
+  strcpy(profileKey + prefixLen, "Top");
+  map.Set(profileKey, (unsigned)page.top);
 
   strcpy(profileKey + prefixLen, "Main");
   map.Set(profileKey, (unsigned)page.main);

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -14,6 +14,7 @@ namespace Profile {
   static void Load(const ProfileMap &map, DisplaySettings &settings);
   static void Load(const ProfileMap &map, FormatSettings &settings);
   static void Load(const ProfileMap &map, VarioSettings &settings);
+  static void Load(const ProfileMap &map, NavigatorSettings &settings);
   static void Load(const ProfileMap &map, TrafficSettings &settings);
   static void Load(const ProfileMap &map, DialogSettings &settings);
   static void Load(const ProfileMap &map, SoundSettings &settings);
@@ -47,6 +48,12 @@ Profile::Load(const ProfileMap &map, VarioSettings &settings)
   map.Get(ProfileKeys::AppGaugeVarioGross, settings.show_gross);
   map.Get(ProfileKeys::AppAveNeedle, settings.show_average_needle);
   map.Get(ProfileKeys::AppAveThermalNeedle, settings.show_thermal_average_needle);
+}
+
+void
+Profile::Load(const ProfileMap &map, NavigatorSettings &settings) 
+{
+  map.Get(ProfileKeys::NavigatorHeight, settings.navigator_height);
 }
 
 void
@@ -144,6 +151,7 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
   Load(map, settings.format);
   Load(map, settings.map);
   Load(map, settings.info_boxes);
+  Load(map, settings.navigator);
   Load(map, settings.vario);
   Load(map, settings.traffic);
   Load(map, settings.pages);

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -62,3 +62,96 @@ NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
   canvas.Select(look_nav.brush_frame);
   canvas.DrawPolygon(polygone_frame.data(), polygone_frame.size());
 }
+
+void
+NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                                    const PixelRect &rc,
+                                    const NavigatorLook &look_nav,
+                                    const TaskLook &look_task) noexcept
+{
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+
+  // render the progress bar
+  PixelRect r{rc_height * 5 / 24, rc_height - rc_height * 5 / 48,
+              rc_width - rc_height * 10 / 48, rc_height - rc_height * 1 / 48};
+
+  bool task_has_started =
+      CommonInterface::Calculated().task_stats.start.HasStarted();
+  bool task_is_finished =
+      CommonInterface::Calculated().task_stats.task_finished;
+
+  unsigned int progression{};
+
+  if (task_has_started && !task_is_finished)
+    progression = 100 * (1 - summary.p_remaining);
+  else if (task_has_started && task_is_finished) progression = 100;
+  else progression = 0;
+
+  DrawSimpleProgressBar(canvas, r, progression, 0, 100);
+
+  canvas.Select(look_nav.brush_frame);
+
+  // render the waypoints on the progress bar
+  const Pen pen_waypoint(Layout::ScalePenWidth(1), COLOR_BLACK);
+  const Pen pen_indications(Layout::ScalePenWidth(1),
+                            look_nav.inverse ? COLOR_GRAY : COLOR_DARK_GRAY);
+  canvas.Select(pen_indications);
+
+  bool target{true};
+  unsigned i = 0;
+  for (auto it = summary.pts.begin(); it != summary.pts.end(); ++it, ++i) {
+    auto p = it->p;
+
+    const PixelPoint position_waypoint(
+        p * (rc_width - 10 / 24.0 * rc_height) + 5 / 24.0 * rc_height,
+        rc_height - static_cast<int>(1.5 / 24.0 * rc_height));
+
+    int w = Layout::Scale(2);
+
+    /* search for the next Waypoint to reach and draw two horizontal lines
+     * left and right if one Waypoint has been missed, the two lines are also
+     * drawn
+     */
+    if (!it->achieved && target) {
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-w, 0.5 * w),
+                      position_waypoint.At(-2 * w, 0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, 0.5 * w),
+                      position_waypoint.At(2 * w, 0.5 * w));
+
+      canvas.DrawLine(position_waypoint.At(-w, -0.5 * w),
+                      position_waypoint.At(-2 * w, -0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, -0.5 * w),
+                      position_waypoint.At(2 * w, -0.5 * w));
+
+      target = false;
+    }
+
+    if (i == summary.active) {
+      // search for the Waypoint on which the user is looking for and draw
+      // two vertical lines left and right
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-2 * w, w),
+                      position_waypoint.At(-2 * w, -w));
+      canvas.DrawLine(position_waypoint.At(2 * w, w),
+                      position_waypoint.At(2 * w, -w));
+
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbOrange);
+      w = Layout::Scale(2);
+    } else if (i < summary.active) {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbNotReachableTerrain);
+      w = Layout::Scale(2);
+    } else {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbLightGray);
+
+      w = Layout::Scale(1);
+    }
+
+    canvas.Select(pen_waypoint);
+    canvas.DrawRectangle(PixelRect{position_waypoint}.WithMargin(w));
+  }
+}

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -155,3 +155,40 @@ NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
     canvas.DrawRectangle(PixelRect{position_waypoint}.WithMargin(w));
   }
 }
+
+void
+NavigatorRenderer::DrawWaypointsIconsTitle(
+    Canvas &canvas, WaypointPtr waypoint_before, WaypointPtr waypoint_current,
+    unsigned task_size, [[maybe_unused]] const NavigatorLook &look) noexcept
+{
+  const int rc_height = canvas.GetHeight();
+  const int rc_width = canvas.GetWidth();
+
+  const WaypointRendererSettings &waypoint_settings =
+      CommonInterface::GetMapSettings().waypoint;
+  const WaypointLook &waypoint_look = UIGlobals::GetMapLook().waypoint;
+
+  WaypointIconRenderer waypoint_icon_renderer{waypoint_settings, waypoint_look,
+                                              canvas};
+  const PixelPoint position_waypoint_left{rc_width * 7 / 200,
+                                          rc_height * 1 / 2};
+  // const PixelPoint position_waypoint_centered{rc_width*42/200,
+  // rc_height*1/2};
+  const PixelPoint position_waypoint_right{
+      rc_width * 98 / 100 - rc_height * 15 / 100, rc_height * 38 / 100};
+
+  // CALCULATE REACHABILITY
+  WaypointReachability wr_before{WaypointReachability::UNREACHABLE};
+  WaypointReachability wr_current{WaypointReachability::UNREACHABLE};
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr && task_size > 1) {
+    if (waypoint_before != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_before, position_waypoint_left,
+                                  wr_before, true);
+    if (waypoint_current != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_current, position_waypoint_right,
+                                  wr_current, true);
+  }
+}

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -77,6 +77,10 @@ NavigatorRenderer::DrawTaskText(
   const int rc_width = rc.GetWidth();
   const int rc_height = rc.GetHeight();
 
+  // e_WP_Name
+  static StaticString<50> waypoint_name_s;
+  waypoint_name_s.Format(_T("%s"), wp_current.name.c_str());
+
   // e_WP_Distance
   static StaticString<20> waypoint_distance_s;
   auto precision_waypoint_distance{0};
@@ -258,13 +262,38 @@ NavigatorRenderer::DrawTaskText(
     pos_x_speed_altitude =
         rc_width * 103 / 100 - size_text.width - rc_height * 29 / 100;
 
+  // ---- Next waypoint's name
+  int font_height_waypoint{};
+  int font_width_waypoint{};
+  unsigned int pos_x_at_end_of_waypoint{};
+  const int pos_x_text_waypoint{static_cast<int>(rc_width * 40 / 200)};
+
+  if (canvas.GetWidth() > canvas.GetHeight() * 3.7)
+    font_height_waypoint = rc_height * 42 / 200;
+  else
+    font_height_waypoint = rc_height * 30 / 200;
+  font.Load(
+      FontDescription(Layout::VptScale(font_height_waypoint * ratio_dpi)));
+  canvas.Select(font);
+  font_width_waypoint = canvas.CalcTextSize(waypoint_name_s.c_str()).width;
+  pos_x_at_end_of_waypoint = font_width_waypoint + pos_x_text_waypoint;
+  ppOrigin = {0, 0};
+  psSize = {static_cast<int>(rc_height) / 2 + pos_x_speed_altitude -
+      static_cast<int>(rc_height),
+            static_cast<int>(rc_height)};
+  prRect = {ppOrigin, psSize};
+  canvas.DrawClippedText(
+      {pos_x_text_waypoint, static_cast<int>(rc_height * 31 / 100)}, prRect,
+      waypoint_name_s);
+
   // -- Draw direction arrow / North direction
   int pos_x_arrow{pos_x_speed_altitude -
                   static_cast<int>(rc_height * 77 / 100)};
   const int pos_y_annulus{static_cast<int>(rc_height * 75 / 200)};
   const int height_little_frame{static_cast<int>(rc_height) * 26 / 100};
   const int max_sz_waypoint_text{static_cast<int>(
-      sz_waypoint_s + pxpt_pos_infos_next_waypoint.x)};
+      std::max(pos_x_at_end_of_waypoint,
+               sz_waypoint_s + pxpt_pos_infos_next_waypoint.x))};
 
   if (max_sz_waypoint_text < pos_x_speed_altitude - height_little_frame * 2 &&
       canvas.GetWidth() > canvas.GetHeight() * 4.2)

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorRenderer.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Formatter/Units.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Interface.hpp"
+#include "Look/FontDescription.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "Look/Look.hpp"
+#include "Look/MapLook.hpp"
+#include "Look/NavigatorLook.hpp"
+#include "Look/WaypointLook.hpp"
+#include "Math/Angle.hpp"
+#include "NextArrowRenderer.hpp"
+#include "ProgressBarRenderer.hpp"
+#include "Renderer/TextRenderer.hpp"
+#include "Screen/Layout.hpp"
+#include "UIGlobals.hpp"
+#include "UnitSymbolRenderer.hpp"
+#include "Waypoint/Waypoint.hpp"
+#include "WaypointIconRenderer.hpp"
+#include "WaypointRenderer.hpp"
+#include "WindArrowRenderer.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "util/StaticString.hxx"
+
+// standard
+#include <cmath>
+
+void
+NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
+                             const NavigatorLook &look_nav) noexcept
+{
+  const auto top_left = rc.GetTopLeft();
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+
+  /* the divisions below are not simplified deliberately to understand frame
+     construction */
+  const PixelPoint pt0 = {top_left.x + rc_height * 5 / 20, top_left.y};
+  const PixelPoint pt1 = {top_left.x + rc_width - rc_height * 4 / 20, pt0.y};
+  const PixelPoint pt2 = {top_left.x + rc_width - rc_height * 2 / 20,
+                          top_left.y + rc_height * 1 / 20};
+  const PixelPoint pt3 = {top_left.x + rc_width,
+                          top_left.y + rc_height * 10 / 20};
+  const PixelPoint pt4 = {pt2.x, top_left.y + rc_height * 19 / 20};
+  const PixelPoint pt5 = {pt1.x, top_left.y + rc_height};
+  const PixelPoint pt6 = {pt0.x, pt5.y};
+  const PixelPoint pt7 = {top_left.x + rc_height * 2 / 20, pt4.y};
+  const PixelPoint pt8 = {top_left.x, pt3.y};
+  const PixelPoint pt9 = {pt7.x, pt2.y};
+
+  const StaticArray<BulkPixelPoint, 10> polygone_frame = {
+      pt0, pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8, pt9};
+
+  canvas.Select(look_nav.pen_frame);
+  canvas.Select(look_nav.brush_frame);
+  canvas.DrawPolygon(polygone_frame.data(), polygone_frame.size());
+}

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -286,6 +286,29 @@ NavigatorRenderer::DrawTaskText(
       {pos_x_text_waypoint, static_cast<int>(rc_height * 31 / 100)}, prRect,
       waypoint_name_s);
 
+  // -- Task informations: average speed
+  if (canvas.GetWidth() > canvas.GetHeight() * 3.4)
+    font_height = rc_height * 35 / 200;
+  else
+    font_height = rc_height * 24 / 200;
+  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  size_text = canvas.CalcTextSize(waypoint_average_speed_s.c_str());
+  PixelPoint pxpt_pos_average_speed{static_cast<int>(rc_width * 5 / 200 + 6),
+                                    static_cast<int>(rc_height * 8 / 100)};
+  canvas.Select(font);
+  ppOrigin = {0, 0};
+  psSize = {static_cast<int>(rc_width), static_cast<int>(rc_height)};
+  prRect = {ppOrigin, psSize};
+  canvas.DrawClippedText(pxpt_pos_average_speed, prRect,
+                         waypoint_average_speed_s);
+  // Draw average speed unit
+  unit = Units::GetUserTaskSpeedUnit();
+  unit_height = static_cast<unsigned int>(font_height * 0.5);
+  font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+  unit_p = pxpt_pos_average_speed.At(size_text.width, size_text.height / 10);
+  UnitSymbolRenderer::Draw(canvas, unit_p, unit,
+                           look_infobox.unit_fraction_pen);
+
   // -- Draw direction arrow / North direction
   int pos_x_arrow{pos_x_speed_altitude -
                   static_cast<int>(rc_height * 77 / 100)};

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+
+#include "Engine/Waypoint/Ptr.hpp"
+#include "Engine/Task/TaskType.hpp"
+#include "Look/InfoBoxLook.hpp"
+
+struct PixelRect;
+struct PixelPoint;
+struct NavigatorLook;
+struct InfoBoxLook;
+struct AttitudeState;
+class Canvas;
+class TextRenderer;
+class WaypointIconRenderer;
+struct TaskLook;
+struct TaskSummary;
+
+
+namespace NavigatorRenderer {
+/**
+* This function is used to create the frame of the Navigator and
+* also the frame of the waypoint
+*/
+void
+DrawFrame(Canvas &canvas, const PixelRect &rc, const NavigatorLook &look_nav) noexcept;
+}

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -29,6 +29,15 @@ void
 DrawFrame(Canvas &canvas, const PixelRect &rc, const NavigatorLook &look_nav) noexcept;
 
 /**
+* Draw information texts about the current task (ordered task) or 
+* the current target (unordered task) 
+* e.g. waypoint distance, start time, planned duration time, ...
+*/
+void
+DrawTaskText(Canvas &canvas, TaskType tp, const Waypoint &wp_current, const PixelRect &rc,
+         const NavigatorLook &look_nav, const InfoBoxLook &iblook) noexcept;
+
+/**
 * Draw the progress of the current task with presntation of each taskpoint
 */
 void

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -35,4 +35,12 @@ void
 DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
                  const PixelRect &rc, const NavigatorLook &look_nav,
                  const TaskLook &look_task) noexcept;
+
+/**
+* Draw the icon of the current task and of the previous task
+*/
+void
+DrawWaypointsIconsTitle(Canvas &canvas, const WaypointPtr waypoint_before,
+                        const WaypointPtr waypoint_current, unsigned task_size,
+                        const NavigatorLook &look_nav) noexcept;
 }

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -27,4 +27,12 @@ namespace NavigatorRenderer {
 */
 void
 DrawFrame(Canvas &canvas, const PixelRect &rc, const NavigatorLook &look_nav) noexcept;
+
+/**
+* Draw the progress of the current task with presntation of each taskpoint
+*/
+void
+DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                 const PixelRect &rc, const NavigatorLook &look_nav,
+                 const TaskLook &look_task) noexcept;
 }

--- a/src/Renderer/NextArrowRenderer.cpp
+++ b/src/Renderer/NextArrowRenderer.cpp
@@ -67,3 +67,60 @@ NextArrowRenderer::DrawArrow(Canvas &canvas, const PixelRect &rc,
   canvas.Select(look.arrow_brush);
   canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
 }
+
+void
+NextArrowRenderer::DrawArrowScale(Canvas &canvas, const PixelRect &rc,
+                             Angle angle, int scale)
+{
+  /*
+   * Define arrow geometry for forward pointing arrow.
+   * These are the coordinates of the corners, relative to the center (o)
+   *
+   *                               +   (0,-head_len)
+   *                              / \
+   *                             /   \
+   *                            /     \
+   * (-head_width,-head_base)  +-+   +-+  (head_width,-head_base)
+   *   (-tail_width,-head_base)  | o |  (tail_width,-head_base)
+   *                             |   |
+   *                             |   |
+   *     (-tail_width,tail_len)  +---+  (tail_width,tail_len)
+   *
+   * The "tail" of the arrow is slightly shorter than the "head" to avoid
+   * the corners of the tail to stick out of the bounding PixelRect.
+   */
+  static constexpr auto head_len = 500;
+  static constexpr auto head_width = 360;
+  static constexpr auto head_base = head_len - head_width;
+  static constexpr auto tail_width = 160;
+  static constexpr auto tail_len = head_len - tail_width / 2;
+
+  // An array of the arrow corner coordinates.
+  BulkPixelPoint arrow[] = {
+    { 0, -head_len/scale },
+    { head_width/scale, -head_base/scale },
+    { tail_width/scale, -head_base/scale },
+    { tail_width/scale, tail_len/scale },
+    { -tail_width/scale, tail_len/scale },
+    { -tail_width/scale, -head_base/scale },
+    { -head_width/scale, -head_base/scale },
+  };
+
+  /*
+   * Rotate the arrow, center it in the bounding rectangle, and scale
+   * it to fill the rectangle.
+   *
+   * Note that PolygonRotateShift scales a polygon with coordinates
+   * in the range -50 to +50 to fill a square with the size of the 'scale'
+   * argument.
+   */
+  const auto size = std::min(rc.GetWidth(), rc.GetHeight());
+  PolygonRotateShift(arrow,
+                     rc.GetCenter(), angle,
+                     size);
+
+  // Draw the arrow.
+  canvas.Select(look.arrow_pen);
+  canvas.Select(look.arrow_brush);
+  canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
+}

--- a/src/Renderer/NextArrowRenderer.hpp
+++ b/src/Renderer/NextArrowRenderer.hpp
@@ -15,4 +15,5 @@ public:
   NextArrowRenderer(const WindArrowLook &_look):look(_look) {}
 
   void DrawArrow(Canvas &canvas, const PixelRect &rc, Angle angle);
+  void DrawArrowScale(Canvas &canvas, const PixelRect &rc, Angle angle, int scale);
 };

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -31,6 +31,7 @@ UISettings::SetDefaults() noexcept
   info_boxes.SetDefaults();
   vario.SetDefaults();
   traffic.SetDefaults();
+  navigator.SetDefaults();
   pages.SetDefaults();
   dialog.SetDefaults();
   sound.SetDefaults();

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -8,6 +8,7 @@
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Gauge/VarioSettings.hpp"
 #include "Gauge/TrafficSettings.hpp"
+#include "Gauge/NavigatorSettings.hpp"
 #include "PageSettings.hpp"
 #include "Dialogs/DialogSettings.hpp"
 #include "DisplaySettings.hpp"
@@ -68,6 +69,7 @@ struct UISettings {
   MapSettings map;
   InfoBoxSettings info_boxes;
   VarioSettings vario;
+  NavigatorSettings navigator;
   TrafficSettings traffic;
   PageSettings pages;
   DialogSettings dialog;


### PR DESCRIPTION
This PR is the follow-up of https://github.com/XCSoar/XCSoar/pull/1064 as

As my previous comment, I divided threaderic's patch/commit into 13 commits.
https://github.com/CazYokoyama/XCSoar/tree/NavigationWidget
The commits have the following commit messages.

1. Allocate top pane/widget which is enabled by config -> system -> look -> pages -> top area.
2. Add height of Navigator pane/Widget in settings.
3. Configure Navigator pane/widget such as its color.
4. Draw NavigatorWindow on the top pane.
5. Draw 2 rectangular-ish frames by DrawPolygon() in top pane.
6. Show progress bar on bottom of the navigatorwidget/top pane.
7. Show waypoint/turn point icons on far left and right.
8. Draw Waypoint informations: distance, altitude, glide ratio
9. Draw direction arrow to the next waypoint.
10. Draw "Next waypoint's name"
11. show "Task informations: average speed" It appears top far left.
12. Draw Current speed / Current Altitude on right.
13. draw elapsed, start, local, planned, planned arrival time at bottom.
14. Note: Each commit have magic numbers such as rc_height * 40 / 200. I guess they are for locating icons and text in appropriate location in the navigator widget, but I have no idea how they are introduced.

Let me know whether I am OK to forced push to https://github.com/XCSoar/XCSoar(I may not be allowed because I am not a author).
His patch include the code which starts analysis_page by key event, i.e. the code in InputEvents::eventAnalysis(). I dropped it because I suspect it may be a garbage included by mistake.

the demonstration video, https://youtu.be/_m4J8JGlj4E

reverse the swipe gestures for Next Turnpoint and Previous Turnpoint. Swipe to Left should be Next and Swipe to Right should be Previous. 
