### PR TITLE
Fix transponder code

### DIFF
--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -97,11 +97,13 @@ ExternalSettings::Complement(const ExternalSettings &add)
   if (add.has_transponder_code.Modified(has_transponder_code) &&
       add.transponder_code.IsDefined()) {
     has_transponder_code = add.has_transponder_code;
+    transponder_code = add.transponder_code;
   }
 
   if (add.has_transponder_mode.Modified(has_transponder_mode) &&
       add.transponder_mode.IsDefined()) {
     has_transponder_mode = add.has_transponder_mode;
+    transponder_mode = add.transponder_mode;
   }
 }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1635,8 +1635,9 @@ TestACD()
   nmea_info.Reset();
   nmea_info.clock = TimeStamp{FloatDuration{1}};
 
-  ok1(!(device->ParseNMEA("$PAAVS,XPDR,9999,1,0,1697,0,0*6F",nmea_info)));
+  ok1(!(device->ParseNMEA("$PAAVS,XPDR,9999,,,1697,,*6E",nmea_info)));
   ok1(!(nmea_info.settings.transponder_code.IsDefined()));
+  ok1(!(nmea_info.settings.transponder_mode.IsDefined()));
 
   nmea_info.Reset();
   nmea_info.clock = TimeStamp{FloatDuration{1}};
@@ -1754,7 +1755,7 @@ TestFlightList(const struct DeviceRegister &driver)
 
 int main()
 {
-  plan_tests(953);
+  plan_tests(954);
   TestGeneric();
   TestTasman();
   TestFLARM();


### PR DESCRIPTION
#1703 introduced a bug in the transponder code and mode settings by accidentally deleting lines during a force-push.