### PR TITLE
iOS: Cleaned up assets, full screen support

### DIFF
--- a/Data/iOS/Info.plist.in.xml
+++ b/Data/iOS/Info.plist.in.xml
@@ -94,6 +94,8 @@
         <true/>
         <key>UIRequiresFullScreen</key>
         <true/>
+        <key>UILaunchStoryboardName</key>
+        <string>LaunchScreen</string>
         <key>NSAppTransportSecurity</key>
         <dict>
             <key>NSAllowsArbitraryLoads</key>

--- a/Data/iOS/LaunchScreen.storyboard
+++ b/Data/iOS/LaunchScreen.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController extendedLayoutIncludesOpaqueBars="YES" id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" insetsLayoutMarginsFromSafeArea="NO" image="AppIcon" translatesAutoresizingMaskIntoConstraints="NO" id="Mqb-Gf-gPS">
+                                <rect key="frame" x="0.0" y="50" width="375" height="762"/>
+                            </imageView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="Mqb-Gf-gPS" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="-50" id="JSl-Hj-uuT" userLabel="LaunchImage.top = Safe Area.top"/>
+                            <constraint firstItem="Mqb-Gf-gPS" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="QSp-U6-3aa"/>
+                            <constraint firstItem="Mqb-Gf-gPS" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="ikz-1b-760"/>
+                            <constraint firstItem="Mqb-Gf-gPS" firstAttribute="bottom" secondItem="Ze5-6b-2t3" secondAttribute="bottom" id="uEd-jY-ZkF"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="50.399999999999999" y="373.15270935960592"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="AppIcon" width="128" height="128"/>
+    </resources>
+</document>

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -31,82 +31,17 @@ $(error Could not determine correct architecture identifier for Info.plist)
 endif
 
 IOS_GRAPHICS = \
-	$(IOS_GRAPHICS_DIR)/Default.png \
-	$(IOS_GRAPHICS_DIR)/Default@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-568h@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-667h@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-736h@3x.png \
-	$(IOS_GRAPHICS_DIR)/Default-Portrait.png \
-	$(IOS_GRAPHICS_DIR)/Default-Landscape.png \
-	$(IOS_GRAPHICS_DIR)/Default-Portrait@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-Landscape@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-Landscape-667h@2x.png \
-	$(IOS_GRAPHICS_DIR)/Default-Landscape-736h@3x.png \
-	$(IOS_GRAPHICS_DIR)/Icon.png \
-	$(IOS_GRAPHICS_DIR)/Icon-72.png \
-	$(IOS_GRAPHICS_DIR)/Icon-1024.png \
-	$(IOS_GRAPHICS_DIR)/Icon@2x.png \
 	$(IOS_GRAPHICS_DIR)/Assets.car \
 	$(IOS_GRAPHICS_DIR)/AppIcon60x60@2x.png \
-	$(IOS_GRAPHICS_DIR)/AppIcon76x76@2x~ipad.png
-
-$(IOS_GRAPHICS_DIR)/Default.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 320x480 $@
-
-$(IOS_GRAPHICS_DIR)/Default@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x960 $@
-
-$(IOS_GRAPHICS_DIR)/Default-568h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 640x1136 $@
-
-$(IOS_GRAPHICS_DIR)/Default-667h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 750x1334 $@
-
-$(IOS_GRAPHICS_DIR)/Default-736h@3x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1242x2208 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Portrait.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 768x1004 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Landscape.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1024x748 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Portrait@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1536x2008 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Landscape@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2048x1496 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Landscape-667h@2x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 1334x750 $@
-
-$(IOS_GRAPHICS_DIR)/Default-Landscape-736h@3x.png: $(IOS_SPLASH_BASE_IMG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)$(IM_PREFIX)convert $(IOS_SPLASH_BASE_IMG) -background white -gravity center -extent 2208x1242 $@
-
-$(IOS_GRAPHICS_DIR)/Icon.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 57 -h 57 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon-72.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 72 -h 72 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon-76.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 76 -h 76 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon@2x.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 114 -h 114 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon-120.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 120 -h 120 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon-152.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 152 -h 152 -a -o $@
-
-$(IOS_GRAPHICS_DIR)/Icon-1024.png: $(IOS_ICON_SVG) | $(IOS_GRAPHICS_DIR)/dirstamp
-	$(Q)rsvg-convert $< -w 1024 -h 1024 -a -b white -o $@
+	$(IOS_GRAPHICS_DIR)/AppIcon76x76@2x~ipad.png \
+	$(IOS_GRAPHICS_DIR)/LaunchScreen.storyboardc
 
 $(IOS_GRAPHICS_DIR)/Assets.car: $(topdir)/Data/iOS/Assets.xcassets
 # will also generate $(IOS_GRAPHICS_DIR)/AppIcon%.png, but can't combine implicit and explicit rules
 	xcrun actool $< --compile $(dir $@) --platform iphoneos --minimum-deployment-target 8.0 --app-icon AppIcon --output-partial-info-plist $(IOS_GRAPHICS_DIR)/assets-partial.plist
+
+$(IOS_GRAPHICS_DIR)/LaunchScreen.storyboardc: $(topdir)/Data/iOS/LaunchScreen.storyboard
+	ibtool $< --compile $@
 
 HOST_MACOS_VERSION = $(shell sw_vers -buildVersion)
 TARGET_SDK_NAME = $(shell /usr/libexec/PlistBuddy -c 'print CanonicalName' $(DARWIN_SDK)/SDKSettings.plist)
@@ -148,7 +83,7 @@ $(TARGET_OUTPUT_DIR)/$(IPA_NAME): $(TARGET_BIN_DIR)/xcsoar $(TARGET_OUTPUT_DIR)/
 	$(Q)$(MKDIR) -p $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
 	$(Q)cp $(TARGET_BIN_DIR)/xcsoar $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)/XCSoar
 	$(Q)cp $(TARGET_OUTPUT_DIR)/Info.plist $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
-	$(Q)cp $(IOS_GRAPHICS) $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
+	$(Q)cp -r $(IOS_GRAPHICS) $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
 	$(Q)cd $(IPA_TMPDIR) && $(ZIP) -r ../$(IPA_NAME) ./*
 
 ipa: $(TARGET_OUTPUT_DIR)/$(IPA_NAME)

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -32,15 +32,15 @@ endif
 
 IOS_GRAPHICS = \
 	$(IOS_GRAPHICS_DIR)/Assets.car \
-	$(IOS_GRAPHICS_DIR)/AppIcon60x60@2x.png \
-	$(IOS_GRAPHICS_DIR)/AppIcon76x76@2x~ipad.png \
 	$(IOS_GRAPHICS_DIR)/LaunchScreen.storyboardc
 
 $(IOS_GRAPHICS_DIR)/Assets.car: $(topdir)/Data/iOS/Assets.xcassets
 # will also generate $(IOS_GRAPHICS_DIR)/AppIcon%.png, but can't combine implicit and explicit rules
+	mkdir -p $(IOS_GRAPHICS_DIR)
 	xcrun actool $< --compile $(dir $@) --platform iphoneos --minimum-deployment-target 8.0 --app-icon AppIcon --output-partial-info-plist $(IOS_GRAPHICS_DIR)/assets-partial.plist
 
 $(IOS_GRAPHICS_DIR)/LaunchScreen.storyboardc: $(topdir)/Data/iOS/LaunchScreen.storyboard
+	mkdir -p $(IOS_GRAPHICS_DIR)
 	ibtool $< --compile $@
 
 HOST_MACOS_VERSION = $(shell sw_vers -buildVersion)
@@ -83,7 +83,7 @@ $(TARGET_OUTPUT_DIR)/$(IPA_NAME): $(TARGET_BIN_DIR)/xcsoar $(TARGET_OUTPUT_DIR)/
 	$(Q)$(MKDIR) -p $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
 	$(Q)cp $(TARGET_BIN_DIR)/xcsoar $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)/XCSoar
 	$(Q)cp $(TARGET_OUTPUT_DIR)/Info.plist $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
-	$(Q)cp -r $(IOS_GRAPHICS) $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
+	$(Q)cp -r $(IOS_GRAPHICS_DIR)/. $(IPA_TMPDIR)/Payload/$(IOS_APP_DIR_NAME)
 	$(Q)cd $(IPA_TMPDIR) && $(ZIP) -r ../$(IPA_NAME) ./*
 
 ipa: $(TARGET_OUTPUT_DIR)/$(IPA_NAME)

--- a/build/main.mk
+++ b/build/main.mk
@@ -558,7 +558,8 @@ endif
 ifeq ($(TARGET_IS_DARWIN),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Device/AndroidSensors.cpp \
-	$(SRC)/Apple/InternalSensors.cpp
+	$(SRC)/Apple/InternalSensors.cpp \
+	$(SRC)/Apple/Helpers.cpp
 endif
 
 ifeq ($(TARGET),ANDROID)

--- a/src/Apple/Helpers.cpp
+++ b/src/Apple/Helpers.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Apple/Helpers.hpp"
+
+#import <UIKit/UIKit.h>
+
+/* Little helper function to return dimensions for the SafaArea insets
+Needs some manual tweeking, mainly because we don't account for the 'dynamic island' size changes
+ and instead just use a fixed height
+If we update to SDL3, we can just use the built-in function SDL_GetWindowSafeArea instead
+*/
+SafeAreaInsets getSafeAreaInsets(void) {
+    if (@available(iOS 11.0, *)) {
+        UIWindow *keyWindow = UIApplication.sharedApplication.windows.firstObject;
+        if (keyWindow) {
+            UIEdgeInsets dynamicInsets = keyWindow.safeAreaInsets;
+            return (SafeAreaInsets){
+                static_cast<int>(dynamicInsets.top),
+                static_cast<int>(dynamicInsets.left),
+                static_cast<int>(dynamicInsets.bottom),
+                static_cast<int>(dynamicInsets.right)
+            };
+        }
+    }
+    
+    // Fallback to manual insets based on screen size
+    CGSize screenSize = [UIScreen mainScreen].bounds.size;
+    if (screenSize.width > screenSize.height) {
+        CGFloat temp = screenSize.width;
+        screenSize.width = screenSize.height;
+        screenSize.height = temp;
+    }
+    
+    if (CGSizeEqualToSize(screenSize, CGSizeMake(320, 480))) {
+        return (SafeAreaInsets){20, 0, 0, 0}; // iPhone 4s and earlier
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(320, 568))) {
+        return (SafeAreaInsets){20, 0, 0, 0}; // iPhone 5, 5s, SE (1st Gen)
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(375, 667))) {
+        return (SafeAreaInsets){20, 0, 0, 0}; // iPhone 6, 6s, 7, 8, SE (2nd & 3rd Gen)
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(414, 736))) {
+        return (SafeAreaInsets){20, 0, 0, 0}; // iPhone 6 Plus, 6s Plus, 7 Plus, 8 Plus
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(375, 812))) {
+        return (SafeAreaInsets){44, 0, 34, 0}; // iPhone X, XS, 11 Pro, 12 Mini, 13 Mini
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(390, 844))) {
+        return (SafeAreaInsets){47, 0, 34, 0}; // iPhone 12, 12 Pro, 13, 13 Pro, 14
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(393, 852))) {
+        return (SafeAreaInsets){59, 0, 34, 0}; // iPhone 14 Pro
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(414, 896))) {
+        return (SafeAreaInsets){44, 0, 34, 0}; // iPhone XR, XS Max, 11, 11 Pro Max
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(428, 926))) {
+        return (SafeAreaInsets){47, 0, 34, 0}; // iPhone 12 Pro Max, 13 Pro Max
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(430, 932))) {
+        return (SafeAreaInsets){47, 0, 34, 0}; // iPhone 14 Plus
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(430, 932))) {
+        return (SafeAreaInsets){59, 0, 34, 0}; // iPhone 14 Pro Max
+    } else if (CGSizeEqualToSize(screenSize, CGSizeMake(432, 934))) {
+        return (SafeAreaInsets){60, 0, 36, 0}; // iPhone 16
+    }
+    
+    return (SafeAreaInsets){20, 0, 0, 0}; // Default for unknown devices
+}

--- a/src/Apple/Helpers.hpp
+++ b/src/Apple/Helpers.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+// Define a struct to hold the inset values
+struct SafeAreaInsets {
+    int top;
+    int right;
+    int bottom;
+    int left;
+};
+
+SafeAreaInsets getSafeAreaInsets();

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -18,6 +18,10 @@
 #include "Menu/ShowMenuButton.hpp"
 #endif
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 struct ComputerSettings;
 struct MapSettings;
 struct UIState;

--- a/src/ui/event/sdl/Queue.cpp
+++ b/src/ui/event/sdl/Queue.cpp
@@ -56,6 +56,8 @@ EventQueue::Wait(Event &event) noexcept
 
   if (quit)
     return false;
+    
+  FlushClockCaches();
 
   while (true) {
     if (Generate(event))

--- a/src/ui/window/SingleWindow.hpp
+++ b/src/ui/window/SingleWindow.hpp
@@ -8,6 +8,8 @@
 #include <forward_list>
 #include <cassert>
 
+#include "Apple/Helpers.hpp"
+
 class WndForm;
 
 namespace UI {
@@ -90,6 +92,15 @@ public:
    */
   [[gnu::pure]]
   bool FilterEvent(const Event &event, Window *allowed) const noexcept;
+  
+  [[gnu::pure]]
+  const PixelRect GetClientRect() const noexcept override {
+    PixelRect size = ContainerWindow::GetClientRect();
+    SafeAreaInsets safeAreaInsets = getSafeAreaInsets();
+    size.top += safeAreaInsets.top;
+    size.bottom -= safeAreaInsets.bottom;
+    return size;
+  }
 
 protected:
   bool OnClose() noexcept override;

--- a/src/ui/window/Window.hpp
+++ b/src/ui/window/Window.hpp
@@ -673,7 +673,7 @@ public:
   }
 
   [[gnu::pure]]
-  const PixelRect GetClientRect() const noexcept
+  virtual const PixelRect GetClientRect() const noexcept
   {
     assert(IsDefined());
 

--- a/src/ui/window/sdl/TopWindow.cpp
+++ b/src/ui/window/sdl/TopWindow.cpp
@@ -20,6 +20,10 @@
 #include <alloca.h>
 #endif
 
+#ifdef __APPLE__ && TARGET_OS_IPHONE
+#include "apple/Helpers.hpp"
+#endif
+
 namespace UI {
 
 static constexpr Uint32
@@ -43,7 +47,7 @@ MakeSDLFlags([[maybe_unused]] bool full_screen, bool resizable) noexcept
 
 #if defined(__IPHONEOS__) && __IPHONEOS__
   /* Hide status bar on iOS devices */
-  flags |= SDL_WINDOW_BORDERLESS;
+// flags |= SDL_WINDOW_BORDERLESS;
 #endif
 
 #ifdef HAVE_HIGHDPI_SUPPORT
@@ -220,7 +224,12 @@ TopWindow::OnEvent(const SDL_Event &event)
 #endif
 #ifdef ENABLE_OPENGL
 #if defined __APPLE__
-            Resize(screen->GetSize());
+            PixelSize size = screen->GetSize();
+            w, h = size.width, size.height;
+            SafeAreaInsets insets = getSafeAreaInsets();
+            w -= insets.left + insets.right;
+            h -= insets.top + insets.bottom;
+            Resize({w, h});
 #else
           if (screen->CheckResize(PixelSize(w, h)))
             Resize(screen->GetSize());


### PR DESCRIPTION
This PR deals with the black strip issue mentioned in https://github.com/XCSoar/XCSoar/issues/1692.
This stems from no launch screen being available for the correct display aspect ratio, which will somehow cause the SDL main window not to fill the whole screen.
The PR cleans up the assets that are converted during the build, removes the old mostly unused ones  (as requested in https://github.com/XCSoar/XCSoar/pull/1659#discussion_r1938521129), and introduces a storyboard for the launch screen instead.

This draft currently still has two issues that need to be addressed:
- The app now runs in true full screen. That also means the InfoBoxes at the top and the bottom are partially hidden underneath the status bar / rounded corners / the dynamic island. This needs to be addressed somehow. Obtaining the safe area via UIKit was not too successful so far, especially struggles with the dynamic island. SDL3 has a `SDL_GetWindowSafeArea`-function for this purpose, but this was not down-ported to SDL2. I might look into the implementation or build some workaround.
- The dialog windows are somehow higher than the MainWindow, making the progress bar leak out at the bottom. Could not figure out yet why this is the case. Some further debugging to do...