### PR TITLE
FLARM hardware read-out and additional config options

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -40,6 +40,9 @@ Version 7.44 - not yet released
   - Add driver for Condor 3
   - Add driver for LX Navigation Eos / Era variometers
   - Flarm: parse flarm error messages (PFLAE) and display them
+  - Flarm: add support for PowerFlarm configuration
+  - PowerFlarm: make range / vrange configurable for adbs and pcas
+  - PowerFlarm: support additional higher baud rates
   - LXNAV: parse acceleration/g-load from PLXVF sentence
   - LXNAV: Overload formula, use reference mass instead of dry mass
   - OpenVario: Overload formula, use reference mass instead of dry mass
@@ -47,6 +50,7 @@ Version 7.44 - not yet released
   - Devices: Switch to manual MC when set via external Device
   - AirControlDisplay: Read-out transponder mode
   - Larus: Protocol 0.1.4 add OAT,GLoad,Circling/Cruise
+  - SerialPorts: add 230400 baud support
 * Polar:
   - LS8-15m: default polar, set to values according to flight manual
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -36,6 +36,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Device/Vega/VegaDemoDialog.cpp \
 	$(SRC)/Dialogs/Device/Vega/SwitchesDialog.cpp \
 	$(SRC)/Dialogs/Device/FLARM/ConfigWidget.cpp \
+	$(SRC)/Dialogs/Device/FLARM/RangeConfigWidget.cpp \
 	$(SRC)/Dialogs/MapItemListDialog.cpp \
 	$(SRC)/Dialogs/MapItemListSettingsDialog.cpp \
 	$(SRC)/Dialogs/MapItemListSettingsPanel.cpp \

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -51,6 +51,13 @@ public:
                    OperationEnvironment &env);
 
   /**
+   * Request an array of settings from FLARM.
+   * 
+   * @return true if successful.
+   */
+  bool RequestAllSettings(const char* const* settings, OperationEnvironment &env);
+
+  /**
    * Request a setting from the FLARM.  The FLARM will send the value,
    * but this method will not wait for that.
    *

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -60,6 +60,21 @@ public:
   void RequestSetting(const char *name, OperationEnvironment &env);
 
   /**
+   * Wait for FLARM to send a setting.
+   * @timeout the timeout in milliseconds.
+   *
+   * @return true if the settings were received, false if a timeout occured.
+   */
+  bool WaitForSetting(const char *name, unsigned int timeout_ms);
+
+  /**
+   * Check if setting exists
+   * 
+   * @return true if setting exists
+   */
+  bool SettingExists(const char *name) noexcept;
+
+  /**
    * Look up the given setting in the table of received values.  The
    * first element is a "found" flag, and if that is true, the second
    * element is the value.

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -89,6 +89,11 @@ public:
   [[gnu::pure]]
   std::optional<std::string> GetSetting(const char *name) const noexcept;
 
+  /**
+   * Get unsigned value from setting string.
+   */
+  unsigned GetUnsignedValue(const char *name, unsigned default_value);
+
 protected:
   bool TextMode(OperationEnvironment &env);
   bool BinaryMode(OperationEnvironment &env);

--- a/src/Device/Driver/FLARM/Settings.cpp
+++ b/src/Device/Driver/FLARM/Settings.cpp
@@ -25,6 +25,26 @@ FlarmDevice::SendSetting(const char *name, const char *value,
   Send(buffer, env);
 }
 
+bool
+FlarmDevice::RequestAllSettings(const char* const* settings, 
+                                OperationEnvironment &env)
+{
+  try {
+    for (auto i = settings; *i != NULL; ++i)
+      FlarmDevice::RequestSetting(*i, env);
+
+    for (auto i = settings; *i != NULL; ++i)
+      FlarmDevice::WaitForSetting(*i, 500);
+  } catch (OperationCancelled) {
+    return false;
+  } catch (...) {
+    env.SetError(std::current_exception());
+    return false;
+  }
+
+  return true;
+}
+
 void
 FlarmDevice::RequestSetting(const char *name, OperationEnvironment &env)
 {

--- a/src/Device/Driver/FLARM/Settings.cpp
+++ b/src/Device/Driver/FLARM/Settings.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Device.hpp"
+#include "system/Sleep.h"
 
 #include <stdio.h>
 
@@ -30,6 +31,25 @@ FlarmDevice::RequestSetting(const char *name, OperationEnvironment &env)
   char buffer[64];
   sprintf(buffer, "PFLAC,R,%s", name);
   Send(buffer, env);
+}
+
+bool
+FlarmDevice::WaitForSetting(const char *name, unsigned timeout_ms)
+{
+  for (unsigned i = 0; i < timeout_ms / 100; ++i) {
+    if (FlarmDevice::SettingExists(name))
+      return true;
+    Sleep(100);
+  }
+
+  return false;
+}
+
+[[gnu::pure]]
+bool
+FlarmDevice::SettingExists(const char *name) noexcept
+{
+  return (bool)FlarmDevice::GetSetting(name);
 }
 
 std::optional<std::string>

--- a/src/Device/Driver/FLARM/Settings.cpp
+++ b/src/Device/Driver/FLARM/Settings.cpp
@@ -82,3 +82,16 @@ FlarmDevice::GetSetting(const char *name) const noexcept
 
   return *i;
 }
+
+unsigned
+FlarmDevice::GetUnsignedValue(const char *name, unsigned default_value)
+{
+  if (const auto x = FlarmDevice::GetSetting(name)) {
+    char *endptr;
+    unsigned long y = strtoul(x->c_str(), &endptr, 10);
+    if (endptr > x->c_str() && *endptr == 0)
+      return (unsigned)y;
+  }
+
+  return default_value;
+}

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -28,7 +28,8 @@ ParsePFLAE(NMEAInputLine &line, FlarmError &error, TimeStamp clock) noexcept
   StringFormatUnsafe(buffer, _T("%s - %s"),
                      FlarmError::ToString(error.severity),
                      FlarmError::ToString(error.code));
-  Message::AddMessage(_T("FLARM: "), buffer);
+  if (error.severity != FlarmError::Severity::NO_ERROR)
+    Message::AddMessage(_T("FLARM: "), buffer);
 
   error.available.Update(clock);
 }

--- a/src/Device/Port/TTYPort.cpp
+++ b/src/Device/Port/TTYPort.cpp
@@ -53,6 +53,9 @@ speed_t_to_baud_rate(speed_t speed) noexcept
   case B115200:
     return 115200;
 
+  case B230400:
+    return 230400;
+
   default:
     return 0;
   }
@@ -89,6 +92,9 @@ baud_rate_to_speed_t(unsigned baud_rate) noexcept
 
   case 115200:
     return B115200;
+
+  case 230400:
+    return B230400;
 
   default:
     return B0;

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -35,6 +35,7 @@ FillBaudRates(DataFieldEnum &dfe) noexcept
   dfe.addEnumText(_T("38400"), 38400);
   dfe.addEnumText(_T("57600"), 57600);
   dfe.addEnumText(_T("115200"), 115200);
+  dfe.addEnumText(_T("230400"), 230400);
 }
 
 static void

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -680,6 +680,7 @@ DeviceListWidget::ManageCurrent()
     ManageCAI302Dialog(UIGlobals::GetMainWindow(), look, *device);
   else if (descriptor.IsDriver(_T("FLARM"))) {
     FlarmVersion version;
+    FlarmHardware hardware;
 
     {
       const std::lock_guard lock{device_blackboard.mutex};
@@ -687,7 +688,7 @@ DeviceListWidget::ManageCurrent()
       version = basic.flarm.version;
     }
 
-    ManageFlarmDialog(*device, version);
+    ManageFlarmDialog(*device, version, hardware);
   } else if (descriptor.IsDriver(_T("LX"))) {
     DeviceInfo info, secondary_info;
 

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -34,7 +34,8 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   device.RequestAllSettings(flarm_setting_names, env);
 
   baud = device.GetUnsignedValue("BAUD", 2);
-  thre = device.GetUnsignedValue("THRE", 1);
+  unsigned thre_default = hardware.isPowerFlarm() ? 255 : 1;
+  thre = device.GetUnsignedValue("THRE", thre_default);
   acft = device.GetUnsignedValue("ACFT", 0);
   log_int = device.GetUnsignedValue("LOGINT", 2);
   priv = device.GetUnsignedValue("PRIV", 0) == 1;

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -22,15 +22,15 @@ static const char *const flarm_setting_names[] = {
 };
 
 static bool
-RequestAllSettings(FlarmDevice &device)
+RequestAllSettings(FlarmDevice &device, const char* const* settings)
 {
   PopupOperationEnvironment env;
 
   try {
-    for (auto i = flarm_setting_names; *i != NULL; ++i)
+    for (auto i = settings; *i != NULL; ++i)
       device.RequestSetting(*i, env);
 
-    for (auto i = flarm_setting_names; *i != NULL; ++i)
+    for (auto i = settings; *i != NULL; ++i)
       device.WaitForSetting(*i, 500);
   } catch (OperationCancelled) {
     return false;
@@ -60,7 +60,7 @@ void
 FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
                            [[maybe_unused]] const PixelRect &rc) noexcept
 {
-  RequestAllSettings(device);
+  RequestAllSettings(device, flarm_setting_names);
 
   baud = GetUnsignedValue(device, "BAUD", 2);
   priv = GetUnsignedValue(device, "PRIV", 0) == 1;

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -65,9 +65,21 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     nullptr
   };
 
+  static constexpr StaticEnumChoice baud_list_pf[] = {
+    { 0, _T("4800") },
+    { 1, _T("9600") },
+    { 2, _T("19200") },
+    { 4, _T("38400") },
+    { 5, _T("57600") },
+    { 6, _T("115200") },
+    { 7, _T("230400") },
+    nullptr
+  };
+
+
   if (hardware.isPowerFlarm()) {
-    AddEnum(_("Baud rate port 1"), NULL, baud_list, baud1);
-    AddEnum(_("Baud rate port 2"), NULL, baud_list, baud2);
+    AddEnum(_("Baud rate port 1"), NULL, baud_list_pf, baud1);
+    AddEnum(_("Baud rate port 2"), NULL, baud_list_pf, baud2);
   } else {
     AddEnum(_("Baud rate"), NULL, baud_list, baud);
     AddDummy();

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -34,7 +34,7 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   device.RequestAllSettings(flarm_setting_names, env);
 
   baud = device.GetUnsignedValue("BAUD", 2);
-  thre = device.GetUnsignedValue("THRE", 2);
+  thre = device.GetUnsignedValue("THRE", 1);
   acft = device.GetUnsignedValue("ACFT", 0);
   log_int = device.GetUnsignedValue("LOGINT", 2);
   priv = device.GetUnsignedValue("PRIV", 0) == 1;

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -21,27 +21,6 @@ static const char *const flarm_setting_names[] = {
   NULL
 };
 
-static bool
-RequestAllSettings(FlarmDevice &device, const char* const* settings)
-{
-  PopupOperationEnvironment env;
-
-  try {
-    for (auto i = settings; *i != NULL; ++i)
-      device.RequestSetting(*i, env);
-
-    for (auto i = settings; *i != NULL; ++i)
-      device.WaitForSetting(*i, 500);
-  } catch (OperationCancelled) {
-    return false;
-  } catch (...) {
-    env.SetError(std::current_exception());
-    return false;
-  }
-
-  return true;
-}
-
 static unsigned
 GetUnsignedValue(const FlarmDevice &device, const char *name,
                  unsigned default_value)
@@ -60,7 +39,8 @@ void
 FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
                            [[maybe_unused]] const PixelRect &rc) noexcept
 {
-  RequestAllSettings(device, flarm_setting_names);
+  PopupOperationEnvironment env; 
+  device.RequestAllSettings(flarm_setting_names, env);
 
   baud = GetUnsignedValue(device, "BAUD", 2);
   priv = GetUnsignedValue(device, "PRIV", 0) == 1;

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -9,7 +9,6 @@
 #include "Language/Language.hpp"
 #include "Operation/Cancelled.hpp"
 #include "Operation/PopupOperationEnvironment.hpp"
-#include "system/Sleep.h"
 
 static const char *const flarm_setting_names[] = {
   "BAUD",
@@ -22,28 +21,6 @@ static const char *const flarm_setting_names[] = {
   NULL
 };
 
-[[gnu::pure]]
-static bool
-SettingExists(FlarmDevice &device, const char *name) noexcept
-{
-  return (bool)device.GetSetting(name);
-}
-
-/**
- * Wait for a setting to be received from the FLARM.
- */
-static bool
-WaitForSetting(FlarmDevice &device, const char *name, unsigned timeout_ms)
-{
-  for (unsigned i = 0; i < timeout_ms / 100; ++i) {
-    if (SettingExists(device, name))
-      return true;
-    Sleep(100);
-  }
-
-  return false;
-}
-
 static bool
 RequestAllSettings(FlarmDevice &device)
 {
@@ -54,7 +31,7 @@ RequestAllSettings(FlarmDevice &device)
       device.RequestSetting(*i, env);
 
     for (auto i = flarm_setting_names; *i != NULL; ++i)
-      WaitForSetting(device, *i, 500);
+      device.WaitForSetting(*i, 500);
   } catch (OperationCancelled) {
     return false;
   } catch (...) {

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -15,6 +15,8 @@
 #include "Dialogs/WidgetDialog.hpp"
 #include "lib/fmt/ToBuffer.hxx"
 
+#include <fmt/format.h>
+
 FlarmHardware hardware;
 
 static const char *const flarm_setting_names[] = {
@@ -106,41 +108,34 @@ FLARMConfigWidget::Save(bool &_changed) noexcept
 try {
   PopupOperationEnvironment env;
   bool changed = false;
-  NarrowString<32> buffer;
 
   if (SaveValueEnum(Baud, baud)) {
-    buffer.UnsafeFormat("%u", baud);
-    device.SendSetting("BAUD", buffer, env);
+    device.SendSetting("BAUD", fmt::format_int{baud}.c_str(), env);
     changed = true;
   }
 
   if (SaveValueEnum(Thre, thre)) {
-    buffer.UnsafeFormat("%u", thre);
-    device.SendSetting("THRE", buffer, env);
+    device.SendSetting("THRE", fmt::format_int{thre}.c_str(), env);
     changed = true;
   }
 
   if (SaveValueEnum(Acft, acft)) {
-    buffer.UnsafeFormat("%u", acft);
-    device.SendSetting("ACFT", buffer, env);
+    device.SendSetting("ACFT",  fmt::format_int{acft}.c_str(), env);
     changed = true;
   }
 
   if (SaveValueInteger(LogInt, log_int)) {
-    buffer.UnsafeFormat("%u", log_int);
-    device.SendSetting("LOGINT", buffer, env);
+    device.SendSetting("LOGINT", fmt::format_int{log_int}.c_str(), env);
     changed = true;
   }
 
   if (SaveValue(Priv, priv)) {
-    buffer.UnsafeFormat("%u", priv);
-    device.SendSetting("PRIV", buffer, env);
+    device.SendSetting("PRIV", fmt::format_int{priv}.c_str(), env);
     changed = true;
   }
 
   if (SaveValue(NoTrack, notrack)) {
-    buffer.UnsafeFormat("%u", notrack);
-    device.SendSetting("NOTRACK", buffer, env);
+    device.SendSetting("NOTRACK", fmt::format_int{notrack}.c_str(), env);
     changed = true;
   }
 

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -31,7 +31,8 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   baud = device.GetUnsignedValue("BAUD", 2);
   priv = device.GetUnsignedValue("PRIV", 0) == 1;
   thre = device.GetUnsignedValue("THRE", 2);
-  range = device.GetUnsignedValue("RANGE", 3000);
+  unsigned max_range = hardware.isPowerFlarm() ? 65535 : 25500;
+  range = device.GetUnsignedValue("RANGE", max_range);
   acft = device.GetUnsignedValue("ACFT", 0);
   log_int = device.GetUnsignedValue("LOGINT", 2);
   notrack = device.GetUnsignedValue("NOTRACK", 0) == 1;
@@ -48,7 +49,7 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddEnum(_("Baud rate"), NULL, baud_list, baud);
   AddBoolean(_("Stealth mode"), NULL, priv);
   AddInteger(_("Threshold"), NULL, _T("%d m/s"), _T("%d"), 1, 10, 1, thre);
-  AddInteger(_("Range"), NULL, _T("%d m"), _T("%d"), 2000, 25500, 250, range);
+  AddInteger(_("Range"), NULL, _T("%d m"), _T("%d"), 2000, max_range, 250, range);
 
   static constexpr StaticEnumChoice acft_list[] = {
     { FlarmTraffic::AircraftType::UNKNOWN, N_("Unknown") },

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -15,11 +15,11 @@ FlarmHardware hardware;
 
 static const char *const flarm_setting_names[] = {
   "BAUD",
-  "PRIV",
   "THRE",
   "RANGE",
   "ACFT",
   "LOGINT",
+  "PRIV",
   "NOTRACK",
   NULL
 };
@@ -49,12 +49,12 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     device.RequestAllSettings(adsb_setting_names, env);
 
   baud = device.GetUnsignedValue("BAUD", 2);
-  priv = device.GetUnsignedValue("PRIV", 0) == 1;
   thre = device.GetUnsignedValue("THRE", 2);
   unsigned max_range = hardware.isPowerFlarm() ? 65535 : 25500;
   range = device.GetUnsignedValue("RANGE", max_range);
   acft = device.GetUnsignedValue("ACFT", 0);
   log_int = device.GetUnsignedValue("LOGINT", 2);
+  priv = device.GetUnsignedValue("PRIV", 0) == 1;
   notrack = device.GetUnsignedValue("NOTRACK", 0) == 1;
 
   static constexpr StaticEnumChoice baud_list[] = {
@@ -67,7 +67,6 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   };
 
   AddEnum(_("Baud rate"), NULL, baud_list, baud);
-  AddBoolean(_("Stealth mode"), NULL, priv);
   AddInteger(_("Threshold"), NULL, _T("%d m/s"), _T("%d"), 1, 10, 1, thre);
   AddInteger(_("Range"), NULL, _T("%d m"), _T("%d"), 2000, max_range, 250, range);
 
@@ -108,6 +107,7 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddEnum(_("Type"), NULL, acft_list, acft);
   AddInteger(_("Logger interval"), NULL, _T("%d s"), _T("%d"),
              1, 8, 1, log_int);
+  AddBoolean(_("Stealth mode"), NULL, priv);
   AddBoolean(_("No tracking mode"), NULL, notrack);
 
 }
@@ -122,12 +122,6 @@ try {
   if (SaveValueEnum(Baud, baud)) {
     buffer.UnsafeFormat("%u", baud);
     device.SendSetting("BAUD", buffer, env);
-    changed = true;
-  }
-
-  if (SaveValue(Priv, priv)) {
-    buffer.UnsafeFormat("%u", priv);
-    device.SendSetting("PRIV", buffer, env);
     changed = true;
   }
 
@@ -186,6 +180,12 @@ try {
   if (SaveValueInteger(LogInt, log_int)) {
     buffer.UnsafeFormat("%u", log_int);
     device.SendSetting("LOGINT", buffer, env);
+    changed = true;
+  }
+
+  if (SaveValue(Priv, priv)) {
+    buffer.UnsafeFormat("%u", priv);
+    device.SendSetting("PRIV", buffer, env);
     changed = true;
   }
 

--- a/src/Dialogs/Device/FLARM/ConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.cpp
@@ -21,20 +21,6 @@ static const char *const flarm_setting_names[] = {
   NULL
 };
 
-static unsigned
-GetUnsignedValue(const FlarmDevice &device, const char *name,
-                 unsigned default_value)
-{
-  if (const auto x = device.GetSetting(name)) {
-    char *endptr;
-    unsigned long y = strtoul(x->c_str(), &endptr, 10);
-    if (endptr > x->c_str() && *endptr == 0)
-      return (unsigned)y;
-  }
-
-  return default_value;
-}
-
 void
 FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
                            [[maybe_unused]] const PixelRect &rc) noexcept
@@ -42,13 +28,13 @@ FLARMConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   PopupOperationEnvironment env; 
   device.RequestAllSettings(flarm_setting_names, env);
 
-  baud = GetUnsignedValue(device, "BAUD", 2);
-  priv = GetUnsignedValue(device, "PRIV", 0) == 1;
-  thre = GetUnsignedValue(device, "THRE", 2);
-  range = GetUnsignedValue(device, "RANGE", 3000);
-  acft = GetUnsignedValue(device, "ACFT", 0);
-  log_int = GetUnsignedValue(device, "LOGINT", 2);
-  notrack = GetUnsignedValue(device, "NOTRACK", 0) == 1;
+  baud = device.GetUnsignedValue("BAUD", 2);
+  priv = device.GetUnsignedValue("PRIV", 0) == 1;
+  thre = device.GetUnsignedValue("THRE", 2);
+  range = device.GetUnsignedValue("RANGE", 3000);
+  acft = device.GetUnsignedValue("ACFT", 0);
+  log_int = device.GetUnsignedValue("LOGINT", 2);
+  notrack = device.GetUnsignedValue("NOTRACK", 0) == 1;
 
   static constexpr StaticEnumChoice baud_list[] = {
     { 0, _T("4800") },

--- a/src/Dialogs/Device/FLARM/ConfigWidget.hpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.hpp
@@ -6,6 +6,7 @@
 #include "Widget/RowFormWidget.hpp"
 
 class FlarmDevice;
+struct FlarmHardware;
 
 class FLARMConfigWidget final : public RowFormWidget {
   enum Controls {
@@ -13,20 +14,26 @@ class FLARMConfigWidget final : public RowFormWidget {
     Priv,
     Thre,
     Range,
+    VRange,
+    PCASRange,
+    PCASVRange,
+    ADSBRange,
+    ADSBVrange,
     Acft,
     LogInt,
     NoTrack,
   };
 
   FlarmDevice &device;
+  FlarmHardware &hardware;
 
-  unsigned baud, thre, range, acft, log_int;
+  unsigned baud, thre, range, vrange, pcas_range, pcas_vrange, adsb_range, adsb_vrange, acft, log_int;
 
   bool priv, notrack;
 
 public:
-  FLARMConfigWidget(const DialogLook &look, FlarmDevice &_device)
-    :RowFormWidget(look), device(_device) {}
+  FLARMConfigWidget(const DialogLook &look, FlarmDevice &_device, FlarmHardware &_hardware)
+    :RowFormWidget(look), device(_device), hardware(_hardware) {}
 
   /* virtual methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Dialogs/Device/FLARM/ConfigWidget.hpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.hpp
@@ -10,7 +10,8 @@ struct FlarmHardware;
 
 class FLARMConfigWidget final : public RowFormWidget {
   enum Controls {
-    Baud,
+    Baud1,
+    Baud2,
     Thre,
     Acft,
     LogInt,
@@ -21,7 +22,7 @@ class FLARMConfigWidget final : public RowFormWidget {
   FlarmDevice &device;
   FlarmHardware &hardware;
 
-  unsigned baud, thre, acft, log_int;
+  unsigned baud, baud1, baud2, thre, acft, log_int;
 
   bool priv, notrack;
 

--- a/src/Dialogs/Device/FLARM/ConfigWidget.hpp
+++ b/src/Dialogs/Device/FLARM/ConfigWidget.hpp
@@ -11,7 +11,6 @@ struct FlarmHardware;
 class FLARMConfigWidget final : public RowFormWidget {
   enum Controls {
     Baud,
-    Priv,
     Thre,
     Range,
     VRange,
@@ -21,6 +20,7 @@ class FLARMConfigWidget final : public RowFormWidget {
     ADSBVrange,
     Acft,
     LogInt,
+    Priv,
     NoTrack,
   };
 

--- a/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
@@ -13,6 +13,8 @@
 #include "UIGlobals.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 
+#include <fmt/format.h>
+
 static const char *const flarm_setting_names[] = {
   "RANGE",
   NULL
@@ -82,43 +84,36 @@ FLARMRangeConfigWidget::Save(bool &_changed) noexcept
 try {
   PopupOperationEnvironment env;
   bool changed = false;
-  NarrowString<32> buffer;
 
   if (SaveValueInteger(Range, range)) {
-    buffer.UnsafeFormat("%u", range);
-    device.SendSetting("RANGE", buffer, env);
+    device.SendSetting("RANGE", fmt::format_int{range}.c_str(), env);
     changed = true;
   }
   if (hardware.hasADSB()) {
     if (SaveValueInteger(VRange, vrange)) {
-      buffer.UnsafeFormat("%u", vrange);
-      device.SendSetting("VRANGE", buffer, env);
+      device.SendSetting("VRANGE", fmt::format_int{vrange}.c_str(), env);
       changed = true;
     }
   }
 
   if (hardware.hasADSB()) {
     if (SaveValueInteger(PCASRange, pcas_range)) {
-      buffer.UnsafeFormat("%u", pcas_range);
-      device.SendSetting("PCASRANGE", buffer, env);
+      device.SendSetting("PCASRANGE", fmt::format_int{pcas_range}.c_str(), env);
       changed = true;
     }
 
     if (SaveValueInteger(PCASVRange, pcas_vrange)) {
-      buffer.UnsafeFormat("%u", pcas_vrange);
-      device.SendSetting("PCASVRANGE", buffer, env);
+      device.SendSetting("PCASVRANGE", fmt::format_int{pcas_vrange}.c_str(), env);
       changed = true;
     }
 
     if (SaveValueInteger(ADSBRange, adsb_range)) {
-      buffer.UnsafeFormat("%u", adsb_range);
-      device.SendSetting("ADSBRANGE", buffer, env);
+      device.SendSetting("ADSBRANGE", fmt::format_int{adsb_range}.c_str(), env);
       changed = true;
     }
 
     if (SaveValueInteger(ADSBVrange, adsb_vrange)) {
-      buffer.UnsafeFormat("%u", adsb_vrange);
-      device.SendSetting("ADSBVRANGE", buffer, env);
+      device.SendSetting("ADSBVRANGE", fmt::format_int{adsb_vrange}.c_str(), env);
       changed = true;
     }
   }

--- a/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RangeConfigWidget.hpp"
+#include "Dialogs/Error.hpp"
+#include "Device/Driver/FLARM/Device.hpp"
+#include "FLARM/Traffic.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Language/Language.hpp"
+#include "Operation/Cancelled.hpp"
+#include "Operation/PopupOperationEnvironment.hpp"
+#include "FLARM/Hardware.hpp"
+#include "UIGlobals.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+
+static const char *const flarm_setting_names[] = {
+  "RANGE",
+  NULL
+};
+
+static const char *const pf_setting_names[] = {
+  "VRANGE",
+  NULL
+};
+
+static const char *const adsb_setting_names[] = {
+  "PCASRANGE",
+  "PCASVRANGE",
+  "ADSBRANGE",
+  "ADSBVRANGE",
+  NULL
+};
+
+static unsigned
+GetUnsignedValue(const FlarmDevice &device, const char *name,
+                 unsigned default_value)
+{
+  if (const auto x = device.GetSetting(name)) {
+    char *endptr;
+    unsigned long y = strtoul(x->c_str(), &endptr, 10);
+    if (endptr > x->c_str() && *endptr == 0)
+      return (unsigned)y;
+  }
+
+  return default_value;
+}
+
+void
+FLARMRangeConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
+                           [[maybe_unused]] const PixelRect &rc) noexcept
+{
+  PopupOperationEnvironment env; 
+  device.RequestAllSettings(flarm_setting_names, env);
+  if (hardware.isPowerFlarm())
+    device.RequestAllSettings(pf_setting_names, env);
+  if (hardware.hasADSB())
+    device.RequestAllSettings(adsb_setting_names, env);
+
+  unsigned max_range = hardware.isPowerFlarm() ? 65535 : 25500;
+  range = GetUnsignedValue(device, "RANGE", max_range);
+  AddInteger(_("Range"), NULL, _T("%d m"), _T("%d"), 2000, max_range, 250, range);
+
+  if (hardware.isPowerFlarm()) {
+    vrange = GetUnsignedValue(device, "VRANGE", 500);
+    AddInteger(_("Vertical range"), NULL, _T("%d m"), _T("%d"), 100, 2000, 100, vrange);
+  }
+
+  if (hardware.hasADSB()) {
+    pcas_range = GetUnsignedValue(device, "PCASRANGE", 7408);
+    pcas_vrange = GetUnsignedValue(device, "PCASVRANGE", 610);
+    adsb_range = GetUnsignedValue(device, "ADSBRANGE", 65535);
+    adsb_vrange = GetUnsignedValue(device, "ADSBVRANGE", 65535);
+    AddInteger(_("PCAS range"), NULL, _T("%d m"), _T("%d"), 500, 9260, 500, pcas_range);
+    AddInteger(_("PCAS vertical range"), NULL, _T("%d m"), _T("%d"), 250, 65535, 250, pcas_vrange);
+    AddInteger(_("ADSB range"), NULL, _T("%d m"), _T("%d"), 500, 65535, 500, adsb_range);
+    AddInteger(_("ADSB vertical range"), NULL, _T("%d m"), _T("%d"), 250, 65535, 250, adsb_vrange);
+  }
+}
+
+bool
+FLARMRangeConfigWidget::Save(bool &_changed) noexcept
+try {
+  PopupOperationEnvironment env;
+  bool changed = false;
+  NarrowString<32> buffer;
+
+  if (SaveValueInteger(Range, range)) {
+    buffer.UnsafeFormat("%u", range);
+    device.SendSetting("RANGE", buffer, env);
+    changed = true;
+  }
+  if (hardware.hasADSB()) {
+    if (SaveValueInteger(VRange, vrange)) {
+      buffer.UnsafeFormat("%u", vrange);
+      device.SendSetting("VRANGE", buffer, env);
+      changed = true;
+    }
+  }
+
+  if (hardware.hasADSB()) {
+    if (SaveValueInteger(PCASRange, pcas_range)) {
+      buffer.UnsafeFormat("%u", pcas_range);
+      device.SendSetting("PCASRANGE", buffer, env);
+      changed = true;
+    }
+
+    if (SaveValueInteger(PCASVRange, pcas_vrange)) {
+      buffer.UnsafeFormat("%u", pcas_vrange);
+      device.SendSetting("PCASVRANGE", buffer, env);
+      changed = true;
+    }
+
+    if (SaveValueInteger(ADSBRange, adsb_range)) {
+      buffer.UnsafeFormat("%u", adsb_range);
+      device.SendSetting("ADSBRANGE", buffer, env);
+      changed = true;
+    }
+
+    if (SaveValueInteger(ADSBVrange, adsb_vrange)) {
+      buffer.UnsafeFormat("%u", adsb_vrange);
+      device.SendSetting("ADSBVRANGE", buffer, env);
+      changed = true;
+    }
+  }
+
+  _changed |= changed;
+  return true;
+} catch (OperationCancelled) {
+  return false;
+} catch (...) {
+  ShowError(std::current_exception(), _T("FLARM"));
+  return false;
+}

--- a/src/Dialogs/Device/FLARM/RangeConfigWidget.hpp
+++ b/src/Dialogs/Device/FLARM/RangeConfigWidget.hpp
@@ -8,25 +8,23 @@
 class FlarmDevice;
 struct FlarmHardware;
 
-class FLARMConfigWidget final : public RowFormWidget {
+class FLARMRangeConfigWidget final : public RowFormWidget {
   enum Controls {
-    Baud,
-    Thre,
-    Acft,
-    LogInt,
-    Priv,
-    NoTrack,
+    Range,
+    VRange,
+    PCASRange,
+    PCASVRange,
+    ADSBRange,
+    ADSBVrange,
   };
 
   FlarmDevice &device;
   FlarmHardware &hardware;
 
-  unsigned baud, thre, acft, log_int;
-
-  bool priv, notrack;
+  unsigned range, vrange, pcas_range, pcas_vrange, adsb_range, adsb_vrange;
 
 public:
-  FLARMConfigWidget(const DialogLook &look, FlarmDevice &_device, FlarmHardware &_hardware)
+  FLARMRangeConfigWidget(const DialogLook &look, FlarmDevice &_device, FlarmHardware &_hardware)
     :RowFormWidget(look), device(_device), hardware(_hardware) {}
 
   /* virtual methods from Widget */

--- a/src/Dialogs/Device/ManageFlarmDialog.cpp
+++ b/src/Dialogs/Device/ManageFlarmDialog.cpp
@@ -89,7 +89,7 @@ ManageFLARMWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   }
 
   AddButton(_("Setup"), [this](){
-    FLARMConfigWidget widget(GetLook(), device);
+    FLARMConfigWidget widget(GetLook(), device, hardware);
     DefaultWidgetDialog(UIGlobals::GetMainWindow(), GetLook(),
                         _T("FLARM"), widget);
   });

--- a/src/Dialogs/Device/ManageFlarmDialog.hpp
+++ b/src/Dialogs/Device/ManageFlarmDialog.hpp
@@ -5,6 +5,7 @@
 
 class Device;
 struct FlarmVersion;
+struct FlarmHardware;
 
 void
-ManageFlarmDialog(Device &device, const FlarmVersion &version);
+ManageFlarmDialog(Device &device, const FlarmVersion &version, FlarmHardware &hardware);

--- a/src/FLARM/Data.hpp
+++ b/src/FLARM/Data.hpp
@@ -5,6 +5,7 @@
 
 #include "FLARM/Error.hpp"
 #include "FLARM/Version.hpp"
+#include "FLARM/Hardware.hpp"
 #include "FLARM/Status.hpp"
 #include "FLARM/List.hpp"
 
@@ -18,6 +19,8 @@ struct FlarmData {
 
   FlarmVersion version;
 
+  FlarmHardware hardware;
+
   FlarmStatus status;
 
   TrafficList traffic;
@@ -29,6 +32,7 @@ struct FlarmData {
   constexpr void Clear() noexcept {
     error.Clear();
     version.Clear();
+    hardware.Clear();
     status.Clear();
     traffic.Clear();
   }
@@ -36,6 +40,7 @@ struct FlarmData {
   constexpr void Complement(const FlarmData &add) noexcept {
     error.Complement(add.error);
     version.Complement(add.version);
+    hardware.Complement(add.hardware);
     status.Complement(add.status);
     traffic.Complement(add.traffic);
   }
@@ -43,6 +48,7 @@ struct FlarmData {
   constexpr void Expire(TimeStamp clock) noexcept {
     error.Expire(clock);
     version.Expire(clock);
+    hardware.Expire(clock);
     status.Expire(clock);
     traffic.Expire(clock);
   }

--- a/src/FLARM/Hardware.hpp
+++ b/src/FLARM/Hardware.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "NMEA/Validity.hpp"
+#include "util/StaticString.hxx"
+
+#include <type_traits>
+
+/**
+ * The FLARM hardware read-out from PFLAC config sentences.
+ */
+struct FlarmHardware {
+  Validity available;
+
+  NarrowString<32> device_type;
+  NarrowString<64> capabilities;
+
+  bool isPowerFlarm() noexcept {
+    return device_type.Contains("PowerFLARM");
+  }
+
+  bool hasADSB() noexcept {
+    return capabilities.Contains("XPDR");
+  }
+
+  constexpr void Clear() noexcept {
+    available.Clear();
+  }
+
+  constexpr void Complement(const FlarmHardware &add) noexcept {
+    if (!available && add.available)
+      *this = add;
+  }
+
+  constexpr void Expire([[maybe_unused]] TimeStamp clock) noexcept {
+    /* no expiry; this object will be cleared only when the device
+       connection is lost */
+  }
+};
+
+static_assert(std::is_trivial<FlarmHardware>::value, "type is not trivial");


### PR DESCRIPTION
This is how I would do the hardware read-out and optional config items based on it, but I'm not sure, if it is the best way. I think there are more possibilities to make stuff re-usable and more maintainable. 
Code is tested and based on official FLARM interface documents.

Ref: #1647 