### PR TITLE
Show Flarm ID in config dialog

### DIFF
--- a/src/Device/Driver/FLARM/Parser.cpp
+++ b/src/Device/Driver/FLARM/Parser.cpp
@@ -20,7 +20,7 @@ FlarmDevice::ParsePFLAC(NMEAInputLine &line)
     // ignore error responses...
     return true;
 
-  const auto value = line.ReadView();
+  const auto value = line.Rest();
 
   const std::lock_guard<Mutex> lock(settings);
   settings.Set(std::string{name}, value);

--- a/src/Dialogs/Device/ManageFlarmDialog.cpp
+++ b/src/Dialogs/Device/ManageFlarmDialog.cpp
@@ -38,6 +38,7 @@ public:
 static const char *const flarm_config_names[] = {
   "DEVTYPE",
   "CAP",
+  "RADIOID",
   NULL
 };
 
@@ -53,6 +54,12 @@ ManageFLARMWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     if (const auto x = device.GetSetting("CAP"))
       hardware.capabilities = *x;
 
+    if (const auto x = device.GetSetting("RADIOID")) {
+      if (const char *id = strchr(x->c_str(), ',')) {
+        hardware.radio_id = FlarmId::Parse(id + 1, nullptr);
+      }
+    }
+
     hardware.available.Update(TimeStamp{FloatDuration{1}});
   }
 
@@ -63,6 +70,13 @@ ManageFLARMWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
       buffer.clear();
       buffer.UnsafeAppendASCII(hardware.device_type.c_str());
       AddReadOnly(_("Hardware type"), NULL, buffer.c_str());
+    }
+
+    if (hardware.radio_id.IsDefined()) {
+      char tmp_id[10];    
+      buffer.clear();
+      buffer.UnsafeAppendASCII(hardware.radio_id.Format(tmp_id));
+      AddReadOnly(_("Flarm ID"), NULL, buffer.c_str());
     }
   }
 

--- a/src/FLARM/Hardware.hpp
+++ b/src/FLARM/Hardware.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "FLARM/Id.hpp"
 #include "NMEA/Validity.hpp"
 #include "util/StaticString.hxx"
 
@@ -16,6 +17,7 @@ struct FlarmHardware {
 
   NarrowString<32> device_type;
   NarrowString<64> capabilities;
+  FlarmId radio_id;
 
   bool isPowerFlarm() noexcept {
     return device_type.Contains("PowerFLARM");


### PR DESCRIPTION
Small amendment to #1715.

@lordfolken can you check with a classic FLARM device? Also, using line.Rest() is a bigger change which puts more responsibility to the caller. Haven't found a regression for existing implementations though.