### PR TITLE
Arrival time ring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ build/local-config.mk
 
 .idea
 .ccache
+
+*.zip

--- a/build/android.mk
+++ b/build/android.mk
@@ -267,7 +267,7 @@ $(GEN_DIR)/org/xcsoar/R.java: $(ANDROID_OUTPUT_DIR)/resources.apk
 $(ANDROID_OUTPUT_DIR)/classes.zip: $(JAVA_SOURCES) $(GEN_DIR)/org/xcsoar/R.java | $(JAVA_CLASSFILES_DIR)/dirstamp
 	@$(NQ)echo "  JAVAC   $(JAVA_CLASSFILES_DIR)"
 	$(Q)$(JAVAC) \
-		-source 1.7 -target 1.7 \
+		-source 1.8 -target 1.8 \
 		-Xlint:all \
 		-Xlint:-deprecation \
 		-Xlint:-options \

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -23,6 +23,7 @@
 #include "UIGlobals.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "MainWindow.hpp"
 
 #ifdef HAVE_NOAA
 #include "Dialogs/Weather/NOAADetails.hpp"
@@ -51,6 +52,10 @@ HasDetails(const MapItem &item)
   case MapItem::Type::OVERLAY:
   case MapItem::Type::RASP:
     return true;
+
+  case MapItem::Type::ARRIVAL_TIME_RING:
+    // This item type has no details view.
+    return false;
   }
 
   return false;
@@ -214,6 +219,7 @@ MapItemListWidget::OnGotoClicked()
   auto waypoint = ((const WaypointMapItem &)item).waypoint;
   backend_components->protected_task_manager->DoGoto(std::move(waypoint));
   cancel_button->Click();
+  CommonInterface::main_window->FullRedraw();
 }
 
 inline void
@@ -290,7 +296,11 @@ ShowMapItemDialog(const MapItem &item,
   case MapItem::Type::RASP:
     ShowWeatherDialog(_T("rasp"));
     break;
-  }
+
+ case MapItem::Type::ARRIVAL_TIME_RING:
+   // This item type has no details view.
+   break;
+ }
 }
 
 void

--- a/src/Dialogs/Settings/Panels/TaskDefaultsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskDefaultsConfigPanel.cpp
@@ -27,7 +27,8 @@ enum ControlIndex {
   spacer_3,
   TaskType,
   AATMinTime,
-  AATTimeMargin
+  AATTimeMargin,
+  ArrivalRingAAT
 };
 
 class TaskDefaultsConfigPanel final
@@ -185,6 +186,10 @@ TaskDefaultsConfigPanel::Prepare(ContainerWindow &parent,
               task_behaviour.optimise_targets_margin);
   SetExpertRow(AATTimeMargin);
 
+  AddBoolean(_("Arrival ring AAT"),
+             _("Show the arrival time ring based on AAT time remaining."),
+             task_behaviour.arrival_ring_aat_enabled);
+
   SetStartLabel();
   SetFinishLabel();
 }
@@ -220,7 +225,10 @@ TaskDefaultsConfigPanel::Save(bool &_changed) noexcept
                        task_behaviour.ordered_defaults.aat_min_time);
 
   changed |= SaveValue(AATTimeMargin, ProfileKeys::AATTimeMargin,
-                       task_behaviour.optimise_targets_margin);
+                        task_behaviour.optimise_targets_margin);
+
+  changed |= SaveValue(ArrivalRingAAT, ProfileKeys::ArrivalRingAATEnabled,
+                       task_behaviour.arrival_ring_aat_enabled);
 
   _changed |= changed;
   return true;

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -16,6 +16,7 @@
 #include "Renderer/WaypointListRenderer.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "Language/Language.hpp"
+#include "MainWindow.hpp"
 #include "ActionInterface.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
@@ -103,6 +104,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog)
   goto_button = dialog.AddButton(_("Goto"), [this](){
     backend_components->protected_task_manager->DoGoto(GetSelectedWaypointPtr());
     cancel_button->Click();
+    CommonInterface::main_window->FullRedraw();
   });
 
   details_button = dialog.AddButton(_("Details"), mrOK);

--- a/src/Dialogs/TimeEntry.cpp
+++ b/src/Dialogs/TimeEntry.cpp
@@ -21,10 +21,9 @@ TimeEntryDialog(const TCHAR *caption, RoughTime &value,
   /* create the dialog */
 
   const DialogLook &look = UIGlobals::GetDialogLook();
-
   TWidgetDialog<FixedWindowWidget> dialog(WidgetDialog::Auto{},
-                                          UIGlobals::GetMainWindow(),
-                                          look, caption);
+                                         UIGlobals::GetMainWindow(),
+                                         look, caption);
 
   ContainerWindow &client_area = dialog.GetClientAreaWindow();
 
@@ -45,11 +44,6 @@ TimeEntryDialog(const TCHAR *caption, RoughTime &value,
   dialog.AddButton(_("OK"), mrOK);
   dialog.AddButton(_("Cancel"), mrCancel);
 
-  dialog.AddButton(_("Now"), [&entry = *entry, time_zone](){
-    const BrokenTime bt = BrokenDateTime::NowUTC();
-    RoughTime now_utc = RoughTime(bt.hour, bt.minute);
-    entry.SetValue(now_utc + time_zone);
-  });
 
   if (nullable)
     dialog.AddButton(_("Clear"), [&entry=*entry](){

--- a/src/Engine/Task/Ordered/OrderedTask.hpp
+++ b/src/Engine/Task/Ordered/OrderedTask.hpp
@@ -103,6 +103,16 @@ public:
   const TaskFactoryConstraints &GetFactoryConstraints() const noexcept;
 
   /**
+   * Accessor for the task-specific ordered task settings.
+   *
+   * @return Const reference to the OrderedTaskSettings for this task.
+   */
+  [[gnu::pure]]
+  const OrderedTaskSettings &GetOrderedTaskSettings() const noexcept {
+    return ordered_settings;
+  }
+
+  /**
    * Set type of task factory to be used for constructing tasks
    *
    * @param _factory Type of task
@@ -551,14 +561,6 @@ public:
     return factory_mode;
   }
 
-  /**
-   * Retrieve (const) the #OrderedTaskSettings used by this task
-   *
-   * @return Read-only #OrderedTaskSettings
-   */
-  const OrderedTaskSettings &GetOrderedTaskSettings() const noexcept {
-    return ordered_settings;
-  }
 
   /**
    * Copy #OrderedTaskSettings to this task

--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -31,6 +31,7 @@ TaskBehaviour::SetDefaults()
   optimise_targets_margin = std::chrono::minutes{5};
   auto_mc = false;
   auto_mc_mode = AutoMCMode::CLIMBAVERAGE;
+  arrival_ring_aat_enabled = true;
   calc_cruise_efficiency = true;
   calc_effective_mc = true;
   calc_glide_required = true;

--- a/src/Engine/Task/TaskBehaviour.hpp
+++ b/src/Engine/Task/TaskBehaviour.hpp
@@ -69,6 +69,8 @@ struct TaskBehaviour {
   std::chrono::duration<unsigned> optimise_targets_margin;
   /** Option to enable calculation and setting of auto MacCready */
   bool auto_mc;
+  /** Option to enable drawing the AAT arrival time ring */
+  bool arrival_ring_aat_enabled;
 
   /** Enumeration of auto MC modes */
   enum class AutoMCMode: uint8_t {

--- a/src/MapWindow/Items/List.cpp
+++ b/src/MapWindow/Items/List.cpp
@@ -76,6 +76,7 @@ CompareMapItems(const MapItem *a, const MapItem *b)
   case MapItem::Type::SKYLINES_TRAFFIC:
   case MapItem::Type::OVERLAY:
   case MapItem::Type::RASP:
+  case MapItem::Type::ARRIVAL_TIME_RING:
     break;
   }
 

--- a/src/MapWindow/Items/MapItem.hpp
+++ b/src/MapWindow/Items/MapItem.hpp
@@ -46,6 +46,7 @@ struct MapItem
 #endif
     OVERLAY,
     RASP,
+    ARRIVAL_TIME_RING,
   } type;
 
 protected:
@@ -212,4 +213,14 @@ struct ThermalMapItem: public MapItem
 
   ThermalMapItem(const ThermalSource &_thermal)
     :MapItem(Type::THERMAL), thermal(_thermal) {}
+};
+
+
+// A ring drawn around a specific waypoint representing arrival time.
+struct ArrivalTimeRingMapItem: public MapItem
+{
+  GeoPoint center;
+
+  ArrivalTimeRingMapItem(const GeoPoint &_center)
+    :MapItem(Type::ARRIVAL_TIME_RING), center(_center) {}
 };

--- a/src/MapWindow/MapWindowWaypoints.cpp
+++ b/src/MapWindow/MapWindowWaypoints.cpp
@@ -11,5 +11,6 @@ MapWindow::DrawWaypoints(Canvas &canvas) noexcept
                            GetComputerSettings().polar,
                            GetComputerSettings().task,
                            Basic(), Calculated(),
-                           task, route_planner);
+                           task, route_planner,
+                           GetComputerSettings());
 }

--- a/src/MapWindow/TargetMapWindow.cpp
+++ b/src/MapWindow/TargetMapWindow.cpp
@@ -156,7 +156,8 @@ TargetMapWindow::DrawWaypoints(Canvas &canvas) noexcept
                             GetComputerSettings().polar,
                             GetComputerSettings().task,
                             Basic(), Calculated(),
-                            task, nullptr);
+                            task, nullptr,
+                            GetComputerSettings());
 }
 
 inline void

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -168,6 +168,7 @@ constexpr std::string_view FinishRadius = "FinishRadius";
 constexpr std::string_view TaskType = "TaskType";
 constexpr std::string_view AATMinTime = "AATMinTime";
 constexpr std::string_view AATTimeMargin = "AATTimeMargin";
+constexpr std::string_view ArrivalRingAATEnabled = "ArrivalRingAATEnabled";
 constexpr std::string_view PEVStartWaitTime = "PEVStartWaitTime";
 constexpr std::string_view PEVStartWindow = "PEVStartWindow";
 
@@ -217,6 +218,7 @@ constexpr std::string_view FontAirspacePressFont = "AirspacePressFont";
 constexpr std::string_view FontAirspaceColourDlgFont = "AirspaceColourDlgFont";
 constexpr std::string_view FontTeamCodeFont = "TeamCodeFont";
 constexpr std::string_view Show95PercentRuleHelpers = "Show95PercentRuleHelpers";
+constexpr std::string_view ArrivalTimeRingTime = "ArrivalTimeRingTime";
 
 constexpr std::string_view UseFinalGlideDisplayMode = "UseFinalGlideDisplayMode";
 constexpr std::string_view InfoBoxGeometry = "InfoBoxGeometry";

--- a/src/Profile/MapProfile.cpp
+++ b/src/Profile/MapProfile.cpp
@@ -7,6 +7,7 @@
 #include "AirspaceConfig.hpp"
 #include "Map.hpp"
 #include "Keys.hpp"
+#include "RoughTimeProfile.hpp"
 #include "MapSettings.hpp"
 
 #include <algorithm> // for std::clamp()

--- a/src/Profile/RoughTimeProfile.cpp
+++ b/src/Profile/RoughTimeProfile.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RoughTimeProfile.hpp"
+#include "Map.hpp"
+#include "time/RoughTime.hpp"
+
+bool
+Profile::Get(const ProfileMap &map, std::string_view key, RoughTime &value) noexcept
+{
+  int minutes_of_day;
+  if (!map.Get(key, minutes_of_day))
+    return false;
+
+  if (minutes_of_day < 0 || minutes_of_day >= 24 * 60)
+    return false;
+
+  value = RoughTime::FromMinuteOfDay(minutes_of_day);
+  return true;
+}
+
+void
+Profile::Set(std::string_view key, const RoughTime &value) noexcept
+{
+  if (!value.IsValid())
+    return;
+
+  Profile::Set(key, value.GetMinuteOfDay());
+}

--- a/src/Profile/RoughTimeProfile.hpp
+++ b/src/Profile/RoughTimeProfile.hpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <string_view>
+
+class ProfileMap;
+class RoughTime;
+
+namespace Profile {
+  /**
+   * Load a RoughTime from the profile.
+   */
+  bool Get(const ProfileMap &map, std::string_view key, RoughTime &value) noexcept;
+
+  /**
+   * Save a RoughTime to the profile.
+   */
+  void Set(std::string_view key, const RoughTime &value) noexcept;
+}

--- a/src/Profile/RouteProfile.cpp
+++ b/src/Profile/RouteProfile.cpp
@@ -16,3 +16,14 @@ Profile::Load(const ProfileMap &map, RoutePlannerConfig &settings)
   map.GetEnum(ProfileKeys::TurningReach, settings.reach_calc_mode);
   map.GetEnum(ProfileKeys::ReachPolarMode, settings.reach_polar_mode);
 }
+
+void
+Profile::Save(ProfileMap &map, const RoutePlannerConfig &settings)
+{
+  map.Set(ProfileKeys::SafetyAltitudeTerrain, settings.safety_height_terrain);
+  map.SetEnum(ProfileKeys::RoutePlannerMode, settings.mode);
+  map.Set(ProfileKeys::RoutePlannerAllowClimb, settings.allow_climb);
+  map.Set(ProfileKeys::RoutePlannerUseCeiling, settings.use_ceiling);
+  map.SetEnum(ProfileKeys::TurningReach, settings.reach_calc_mode);
+  map.SetEnum(ProfileKeys::ReachPolarMode, settings.reach_polar_mode);
+}

--- a/src/Profile/RouteProfile.hpp
+++ b/src/Profile/RouteProfile.hpp
@@ -8,4 +8,5 @@ class ProfileMap;
 
 namespace Profile {
   void Load(const ProfileMap &map, RoutePlannerConfig &settings);
+  void Save(ProfileMap &map, const RoutePlannerConfig &settings);
 };

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -2,10 +2,10 @@
 // Copyright The XCSoar Project
 
 #include "TaskProfile.hpp"
-#include "RouteProfile.hpp"
+#include "RouteProfile.hpp" // Ensure this is included for Save(..., RoutePlannerConfig)
 #include "Map.hpp"
 #include "Keys.hpp"
-#include "Task/TaskBehaviour.hpp"
+#include "Task/TaskBehaviour.hpp" // Correct include path
 
 namespace Profile {
   static void Load(const ProfileMap &map, GlideSettings &settings);
@@ -72,6 +72,7 @@ Profile::Load(const ProfileMap &map, TaskBehaviour &settings)
 
   map.Get(ProfileKeys::AATTimeMargin, settings.optimise_targets_margin);
   map.Get(ProfileKeys::AutoMc, settings.auto_mc);
+  map.Get(ProfileKeys::ArrivalRingAATEnabled, settings.arrival_ring_aat_enabled); // Remove default value argument
   map.GetEnum(ProfileKeys::AutoMcMode, settings.auto_mc_mode);
 
   unsigned Temp;
@@ -92,3 +93,4 @@ Profile::Load(const ProfileMap &map, TaskBehaviour &settings)
 
   Load(map, settings.route_planner);
 }
+

--- a/src/Profile/TaskProfile.hpp
+++ b/src/Profile/TaskProfile.hpp
@@ -8,4 +8,5 @@ class ProfileMap;
 
 namespace Profile {
   void Load(const ProfileMap &map, TaskBehaviour &settings);
+  void Save(ProfileMap &map, const TaskBehaviour &settings);
 };

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -456,7 +456,11 @@ MapItemListRenderer::Draw(Canvas &canvas, const PixelRect rc,
     ::Draw(canvas, rc, (const TaskOZMapItem &)item,
            row_renderer, look.task, look.airspace,
            settings.airspace);
-    break;
+   break;
+
+ case MapItem::Type::ARRIVAL_TIME_RING:
+   // This item type is not displayed in lists, only on the map.
+   break;
 
 #ifdef HAVE_NOAA
   case MapItem::Type::WEATHER:

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -15,13 +15,22 @@
 #include "Engine/GlideSolvers/GlideResult.hpp"
 #include "Engine/GlideSolvers/MacCready.hpp"
 #include "Engine/Task/TaskManager.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/AbstractTask.hpp"
+#include "Engine/Task/Points/TaskPoint.hpp"
 #include "Engine/Task/Unordered/UnorderedTaskPoint.hpp"
 #include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/Unordered/GotoTask.hpp"
+#include "time/BrokenTime.hpp"
+#include "time/RoughTime.hpp"
+#include "time/LocalTime.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Task/ProtectedRoutePlanner.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Pen.hpp"
+#include "ui/canvas/Color.hpp"
 #include "Units/Units.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "util/TruncateString.hpp"
 #include "util/StaticArray.hxx"
 #include "util/Macros.hpp"
@@ -29,8 +38,10 @@
 #include "NMEA/Derived.hpp"
 #include "Engine/Route/ReachResult.hpp"
 #include "Look/WaypointLook.hpp"
+#include "Profile/Profile.hpp"
 
 #include <cassert>
+#include <cmath> // Needed for std::isfinite
 #include <stdio.h>
 
 /**
@@ -150,6 +161,7 @@ class WaypointVisitorMap final
 
 public:
   WaypointLabelList labels;
+  WaypointPtr last_task_waypoint = nullptr;
 
 public:
   WaypointVisitorMap(Canvas &_canvas,
@@ -379,17 +391,24 @@ public:
   }
 
   void Visit(const TaskPoint &tp) override {
+    WaypointPtr current_wp = nullptr;
     switch (tp.GetType()) {
     case TaskPointType::UNORDERED:
-      AddWaypoint(((const UnorderedTaskPoint &)tp).GetWaypointPtr(), true);
+      current_wp = static_cast<const UnorderedTaskPoint &>(tp).GetWaypointPtr();
+      AddWaypoint(current_wp, true);
       break;
 
     case TaskPointType::START:
     case TaskPointType::AST:
     case TaskPointType::AAT:
     case TaskPointType::FINISH:
-      AddWaypoint(((const OrderedTaskPoint &)tp).GetWaypointPtr(), true);
+      current_wp = static_cast<const OrderedTaskPoint &>(tp).GetWaypointPtr();
+      AddWaypoint(current_wp, true);
       break;
+    }
+    // Update the last visited task waypoint
+    if (current_wp) {
+        last_task_waypoint = current_wp;
     }
   }
 
@@ -459,6 +478,111 @@ MapWaypointLabelRender(Canvas &canvas, PixelSize clip_size,
   }
 }
 
+// Helper function to draw a time ring on the map
+static void DrawMapRing(Canvas &canvas,
+                        const MapWindowProjection &projection,
+                        const PixelPoint &center_px,
+                        double radius_meters,
+                        const Color &ring_color,
+                        const TCHAR *label_text,
+                        const PixelPoint &aircraft_pos) noexcept
+{
+  // Convert radius to pixels using the correct method
+  const double radius_pixels_d = projection.DistanceMetersToPixels(radius_meters);
+
+  // Define line width
+  constexpr unsigned line_width = 4; // Increased line width for better visibility
+
+  // Draw the circle
+  if (radius_pixels_d >= 1.0) { // Only draw if radius is at least 1 pixel
+    const unsigned radius_pixels = static_cast<unsigned>(radius_pixels_d);
+
+    // Select the pen and brush for the ring
+    // Force the line style to be SOLID to ensure consistent appearance across platforms
+    canvas.Select(Pen(line_width, ring_color));
+    canvas.SelectHollowBrush();
+
+    // Draw the circle
+    canvas.DrawCircle(center_px, radius_pixels);
+
+    // Set up the text box mode for the label
+    TextInBoxMode text_mode;
+    text_mode.shape = LabelShape::OUTLINED;  // Use outlined style
+    text_mode.move_in_view = true;           // Move the label in view if needed
+
+    // Calculate 8 possible positions around the circle (at 45-degree intervals)
+    const int label_offset = radius_pixels + 5;  // 5 pixels from the circle edge
+
+    // Define the 8 possible positions
+    PixelPoint positions[8];
+    TextInBoxMode::Alignment alignments[8];
+    TextInBoxMode::VerticalPosition vert_positions[8];
+
+    // North (top)
+    positions[0] = { center_px.x, center_px.y - label_offset };
+    alignments[0] = TextInBoxMode::Alignment::CENTER;
+    vert_positions[0] = TextInBoxMode::VerticalPosition::ABOVE;
+
+    // Northeast
+    positions[1] = { center_px.x + (int)(label_offset * 0.7071), center_px.y - (int)(label_offset * 0.7071) }; // Use 0.7071 for sqrt(2)/2
+    alignments[1] = TextInBoxMode::Alignment::LEFT;
+    vert_positions[1] = TextInBoxMode::VerticalPosition::ABOVE;
+
+    // East (right)
+    positions[2] = { center_px.x + label_offset, center_px.y };
+    alignments[2] = TextInBoxMode::Alignment::LEFT;
+    vert_positions[2] = TextInBoxMode::VerticalPosition::CENTERED;
+
+    // Southeast
+    positions[3] = { center_px.x + (int)(label_offset * 0.7071), center_px.y + (int)(label_offset * 0.7071) };
+    alignments[3] = TextInBoxMode::Alignment::LEFT;
+    vert_positions[3] = TextInBoxMode::VerticalPosition::BELOW;
+
+    // South (bottom)
+    positions[4] = { center_px.x, center_px.y + label_offset };
+    alignments[4] = TextInBoxMode::Alignment::CENTER;
+    vert_positions[4] = TextInBoxMode::VerticalPosition::BELOW;
+
+    // Southwest
+    positions[5] = { center_px.x - (int)(label_offset * 0.7071), center_px.y + (int)(label_offset * 0.7071) };
+    alignments[5] = TextInBoxMode::Alignment::RIGHT;
+    vert_positions[5] = TextInBoxMode::VerticalPosition::BELOW;
+
+    // West (left)
+    positions[6] = { center_px.x - label_offset, center_px.y };
+    alignments[6] = TextInBoxMode::Alignment::RIGHT;
+    vert_positions[6] = TextInBoxMode::VerticalPosition::CENTERED;
+
+    // Northwest
+    positions[7] = { center_px.x - (int)(label_offset * 0.7071), center_px.y - (int)(label_offset * 0.7071) };
+    alignments[7] = TextInBoxMode::Alignment::RIGHT;
+    vert_positions[7] = TextInBoxMode::VerticalPosition::ABOVE;
+
+    // Find the position closest to the aircraft
+    int closest_idx = 0;
+    int min_distance_squared = INT_MAX;
+
+    for (int i = 0; i < 8; i++) {
+      int dx = positions[i].x - aircraft_pos.x;
+      int dy = positions[i].y - aircraft_pos.y;
+      int distance_squared = dx * dx + dy * dy;
+
+      if (distance_squared < min_distance_squared) {
+        min_distance_squared = distance_squared;
+        closest_idx = i;
+      }
+    }
+
+    // Set the alignment and vertical position for the closest position
+    text_mode.align = alignments[closest_idx];
+    text_mode.vertical_position = vert_positions[closest_idx];
+
+    // Draw the label at the closest position
+    TextInBox(canvas, label_text, positions[closest_idx], text_mode, projection.GetScreenSize());
+  }
+}
+
+
 void
 WaypointRenderer::Render(Canvas &canvas, LabelBlock &label_block,
                          const MapWindowProjection &projection,
@@ -467,36 +591,191 @@ WaypointRenderer::Render(Canvas &canvas, LabelBlock &label_block,
                          const TaskBehaviour &task_behaviour,
                          const MoreData &basic, const DerivedInfo &calculated,
                          const ProtectedTaskManager *task,
-                         const ProtectedRoutePlanner *route_planner) noexcept
+                         const ProtectedRoutePlanner *route_planner,
+                         const ComputerSettings &computer_settings) noexcept
 {
   if (way_points == nullptr || way_points->IsEmpty())
     return;
 
   WaypointVisitorMap v(canvas, projection, settings, look, task_behaviour, basic);
 
+  GeoPoint ring_center; // Variable to store ring center
+  bool draw_ring = false; // Flag to indicate if ring should be drawn
+
+
+  WaypointPtr goto_wp = nullptr; // Store GOTO waypoint if applicable
+
   if (task != nullptr) {
     ProtectedTaskManager::Lease task_manager(*task);
 
     const TaskStats &task_stats = task_manager->GetStats();
 
-    // task items come first, this is the only way we know that an item is in task,
-    // and we won't add it if it is already there
     if (task_stats.task_valid)
       v.SetTaskValid();
 
     const AbstractTask *atask = task_manager->GetActiveTask();
-    if (atask != nullptr)
+    if (atask != nullptr) {
+      // Check if it's a GOTO task first
+      if (atask->GetType() == TaskType::GOTO) {
+          const GotoTask* goto_task = static_cast<const GotoTask*>(atask);
+          // Get the active (and only) point in a GotoTask
+          const TaskWaypoint* goto_task_point = goto_task->GetActiveTaskPoint();
+          if (goto_task_point != nullptr) {
+              // GetActiveTaskPoint in GotoTask returns the internal UnorderedTaskPoint*
+              const UnorderedTaskPoint* utp = static_cast<const UnorderedTaskPoint*>(goto_task_point);
+              goto_wp = utp->GetWaypointPtr();
+              // Add other TaskWaypoint derived types if necessary
+          }
+      }
+
+      // Visit all task points (needed for drawing them anyway,
+      // and populates v.last_task_waypoint for non-GOTO tasks)
       atask->AcceptTaskPointVisitor(v);
+
+      // Determine ring center
+      if (goto_wp) {
+          // GOTO task takes precedence
+          ring_center = goto_wp->location;
+          draw_ring = true;
+      } else if (v.last_task_waypoint) {
+          // Fallback to last waypoint of the current task
+          ring_center = v.last_task_waypoint->location;
+          draw_ring = true;
+      }
+    }
   }
+
 
   way_points->VisitWithinRange(projection.GetGeoScreenCenter(),
                                projection.GetScreenDistanceMeters(),
                                [&v](const auto &w){ v.Add(w); });
 
+
   v.Calculate(route_planner, polar_settings, task_behaviour, calculated);
 
+  // Draw waypoint icons and symbols
   v.Draw();
 
+  // Draw time rings if a center was determined
+  if (draw_ring) {
+    // Always convert center to screen coordinates regardless of visibility
+    auto center_px = projection.GeoToScreen(ring_center);
+    // Get aircraft position for label placement optimization
+    PixelPoint aircraft_pos = projection.GeoToScreen(basic.location);
+
+    // Get the common speed from the FIN ETE calculation
+    const TaskStats &task_stats = calculated.task_stats;
+    double fin_ete_speed = 0;
+    if (task_stats.task_valid && task_stats.total.remaining_effective.IsDefined()) {
+      fin_ete_speed = task_stats.total.remaining_effective.GetSpeed() * 3.6; // m/s to km/h
+    }
+    // If speed is not available or zero, use a default value
+    if (fin_ete_speed <= 0) {
+      fin_ete_speed = 100; // Default 100 km/h
+    }
+
+    // --- Draw Original ArrivalTimeRing (User-defined time) ---
+    {
+      double radius_meters_arrival = 0;
+      unsigned minutes_of_day = 17 * 60 + 0; // Default to 5:00 PM (1700)
+      Profile::Get(ProfileKeys::ArrivalTimeRingTime, minutes_of_day);
+
+      bool draw_original_ring = false; // Flag to control drawing
+
+      if (basic.time_available) {
+        RoughTimeDelta utc_offset = computer_settings.utc_offset;
+        TimeStamp local_time = TimeLocal(basic.time, utc_offset);
+        BrokenTime target_time(minutes_of_day / 60, minutes_of_day % 60, 0);
+        BrokenTime current_broken_time = BrokenTime::FromSecondOfDayChecked(
+            (unsigned)local_time.ToDuration().count());
+
+        int current_seconds = current_broken_time.GetSecondOfDay();
+        int target_seconds = target_time.GetSecondOfDay();
+        int seconds_diff = target_seconds - current_seconds;
+        if (seconds_diff < 0) {
+          seconds_diff += 24 * 3600; // Add 24 hours if target is next day
+        }
+        double hours_to_target = seconds_diff / 3600.0;
+
+        // *** Only calculate radius and set flag if time delta is <= 6 hours ***
+        if (hours_to_target <= 6.0) {
+            radius_meters_arrival = fin_ete_speed * hours_to_target * 1000; // km/h * h * 1000 = m
+            draw_original_ring = true;
+        }
+      } else {
+        // Fallback: Draw if time is not available (using default radius)
+        constexpr double radius_miles = 10.0;
+        constexpr double meters_per_mile = 1609.34;
+        radius_meters_arrival = radius_miles * meters_per_mile;
+        draw_original_ring = true;
+      }
+
+      // Only draw the original ring if the flag is set
+      if (draw_original_ring) {
+          // Format the label
+          TCHAR arrival_label[32];
+      _stprintf(arrival_label, _T("Arrival %02u:%02u"),
+                minutes_of_day / 60, minutes_of_day % 60);
+
+      // Define color
+      constexpr Color arrival_ring_color = Color(255, 0, 255); // Magenta
+
+          // Draw the ring using the helper function
+          DrawMapRing(canvas, projection, center_px, radius_meters_arrival,
+                      arrival_ring_color, arrival_label, aircraft_pos);
+      }
+    }
+
+    // --- Draw New "Arrival Ring AAT" (AAT time remaining, if enabled) ---
+    if (task_behaviour.arrival_ring_aat_enabled) { // Check if the setting is enabled
+      const CommonStats &common_stats = calculated.common_stats;
+      // Check if AAT time remaining is valid and we have an ordered task
+      // (AAT time only makes sense for ordered tasks like AAT)
+      if (task_stats.task_valid && task_stats.has_targets &&
+          std::isfinite(common_stats.aat_time_remaining.count())) {
+
+        // Get the active task to retrieve task-specific settings
+        const AbstractTask *atask_ptr = nullptr;
+        if (task != nullptr) {
+            ProtectedTaskManager::Lease task_manager(*task);
+            atask_ptr = task_manager->GetActiveTask();
+        }
+
+        // Convert AAT time remaining (seconds) to hours
+        double hours_aat = common_stats.aat_time_remaining.count() / 3600.0;
+
+        // Calculate radius based on AAT time remaining
+        // Only draw if time remaining is positive
+        if (hours_aat > 0) {
+            double radius_meters_aat = fin_ete_speed * hours_aat * 1000; // km/h * h * 1000 = m
+
+            // Format the AAT minimum time label
+            TCHAR aat_label[32];
+            // Default to global setting
+            auto min_time_duration = task_behaviour.ordered_defaults.aat_min_time;
+
+            // Try to get task-specific setting if it's an OrderedTask
+            if (atask_ptr != nullptr && atask_ptr->GetType() == TaskType::ORDERED) {
+                const OrderedTask* ordered_task_ptr = static_cast<const OrderedTask*>(atask_ptr);
+                min_time_duration = ordered_task_ptr->GetOrderedTaskSettings().aat_min_time;
+            }
+            const unsigned total_minutes = static_cast<unsigned>(min_time_duration.count() / 60.0); // Assuming duration is in seconds
+            const unsigned aat_hours = total_minutes / 60;
+            const unsigned aat_minutes = total_minutes % 60;
+            _stprintf(aat_label, _T("AAT %u:%02u"), aat_hours, aat_minutes);
+
+            // Define color
+            constexpr Color aat_ring_color = Color(0, 255, 255); // Cyan
+
+            // Draw the ring using the helper function
+            DrawMapRing(canvas, projection, center_px, radius_meters_aat,
+                        aat_ring_color, aat_label, aircraft_pos);
+        }
+      }
+    }
+  }
+
+  // Draw waypoint labels 
   MapWaypointLabelRender(canvas, projection.GetScreenSize(),
                          label_block, v.labels, look);
 }

--- a/src/Renderer/WaypointRenderer.hpp
+++ b/src/Renderer/WaypointRenderer.hpp
@@ -7,6 +7,7 @@
 
 struct WaypointRendererSettings;
 struct WaypointLook;
+struct ComputerSettings;
 class Canvas;
 class LabelBlock;
 class MapWindowProjection;
@@ -40,11 +41,12 @@ public:
   }
 
   void Render(Canvas &canvas, LabelBlock &label_block,
-              const MapWindowProjection &projection,
-              const WaypointRendererSettings &settings,
-              const PolarSettings &polar_settings,
-              const TaskBehaviour &task_behaviour,
-              const MoreData &basic, const DerivedInfo &calculated,
-              const ProtectedTaskManager *task,
-              const ProtectedRoutePlanner *route_planner) noexcept;
+               const MapWindowProjection &projection,
+               const WaypointRendererSettings &settings,
+               const PolarSettings &polar_settings,
+               const TaskBehaviour &task_behaviour,
+               const MoreData &basic, const DerivedInfo &calculated,
+               const ProtectedTaskManager *task,
+               const ProtectedRoutePlanner *route_planner,
+               const ComputerSettings &computer_settings) noexcept;
 };


### PR DESCRIPTION
Implements a feature called Arrival Time Ring - a visual ring around the GOTO waypoint or last waypoint of the task. The ring radius is set by [ ( the difference between Arrival Time and local time ) * (the climb/cruise cross crountry speed used in the infobox FIN ETE) ].

Arrival time is set by a new menu item under Configuration > Map Display > Elements
The new field is called Arrival time ring and it is clickable to set a new time.

In use, the arrival time ring will be drawn on the map and will give a visual cue of your expected arrival time. Do you know the lift will die at 5pm (17:00). Set the arrival time to 1700 and if you are inside the ring, you'll make it home before 1700. If you are outside the ring you wont make it home by 1700. Again, radius and speeds are set by the same drivers of the FIN ETE infobox so the same assumptions to into the ring as that box (ie MC setting and all that).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Arrival Time Ring on the map with configurable target time.
  - Added optional AAT-based arrival ring (enabled by default).
  - New settings: configure arrival time in Symbols; toggle Arrival Ring AAT in Task Defaults.
- Bug Fixes
  - Main map now refreshes after Goto actions from relevant dialogs.
- Chores
  - Updated Android build to Java 8.
  - Added *.zip to .gitignore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->