### PR TITLE
[menu zoom button] large buttons on raspberry pi which has touch screen

### DIFF
--- a/src/Asset.cpp
+++ b/src/Asset.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Asset.hpp"
+#include <fcntl.h>
 
 #if defined(USE_CONSOLE) || defined(USE_WAYLAND)
 #include "ui/event/Globals.hpp"
@@ -20,10 +21,56 @@ HasPointer() noexcept
 
 #if defined(USE_LIBINPUT) || defined(USE_WAYLAND)
 
+#define MAX_EVENT_DEVICES 20
+#define EVENT_SYSFS_PREFIX "/sys/class/input/event"
+#define EVENT_SYSFS_POSTFIX "device/name"
+#define MAX_FNAME 40
+#define MAX_DNAME 80
+#define TS_STRING "TouchScreen"
+
 bool
 HasTouchScreen() noexcept
 {
-  return UI::event_queue->HasTouchScreen();
+  static enum {
+    not_detected,
+    not_attached,
+    attached
+  } touchscreen = not_detected;
+
+  if (touchscreen != not_detected)
+    return touchscreen == attached;
+  if (UI::event_queue->HasTouchScreen()) {
+    touchscreen = attached;
+    return true;
+  }
+  touchscreen = not_attached;
+  for (int i = 0; i <  MAX_EVENT_DEVICES; i++) {
+    char fname[MAX_FNAME], dname[MAX_DNAME];
+    int eventf;
+    ssize_t count;
+
+    snprintf(fname, sizeof(fname),
+	     "%s%d/%s",
+	     EVENT_SYSFS_PREFIX, i, EVENT_SYSFS_POSTFIX);
+    eventf = open(fname, O_RDONLY);
+    if (eventf < 0)
+      break;
+    count = read(eventf, dname, sizeof(dname));
+    if (count <= 0) {
+      close(eventf);
+      break;
+    }
+    if (count >= (ssize_t)sizeof(dname))
+      count = sizeof(dname) - 1;
+    dname[count] = '\0';
+    if (strstr(dname, TS_STRING)) {
+      touchscreen = attached;
+      close(eventf);
+      return true;
+    }
+    close(eventf);
+  }
+  return false;
 }
 
 bool


### PR DESCRIPTION
As the comment below for HasTouchScreen() in Asset.hpp, we need bigger icons for touch screen. 

a touch screen may require bigger areas.

defined(RASPBERRY_PI) does not guarantee whether touch screen is attached. sysfs has an entry for the touch screen as below.
$ cat /sys/class/input/event?/device/name 
.....
1-0014 Goodix Capacitive TouchScreen
There are 2 ways to determine whether a touch screen is attached, C code and
`grep -i TouchScreen /sys/class/input/event?/device/name`
On either cases, we need fairly large amount of code. Let me know your preference, this simple code, C code or run grep.
