### PR TITLE
Turn back marker - new feature

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -620,6 +620,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/DownloadFilePicker.cpp \
 	$(SRC)/Repository/Glue.cpp \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
+	$(SRC)/Renderer/TurnBackPointRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -24,6 +24,7 @@ enum ControlIndex {
   AutoBugs,
   SafetyMC,
   RiskFactor,
+  TurnBackMarker,
 };
 
 class SafetyFactorsConfigPanel final : public RowFormWidget {
@@ -98,7 +99,11 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
            _T("%.1f %s"), _T("%.1f"),
            0, 1, 0.1, false,
            task_behaviour.risk_gamma);
-  SetExpertRow(RiskFactor);
+ SetExpertRow(RiskFactor);
+
+ AddBoolean(_("Turn back marker"),
+            _("Show a marker indicating the point of no return based on current conditions."),
+            task_behaviour.turn_back_marker_enabled);
 }
 
 bool
@@ -143,6 +148,11 @@ SafetyFactorsConfigPanel::Save(bool &_changed) noexcept
   if (SaveValue(RiskFactor, task_behaviour.risk_gamma)) {
     Profile::Set(ProfileKeys::RiskGamma,
                  iround(task_behaviour.risk_gamma * 10));
+    changed = true;
+  }
+
+  if (SaveValue(TurnBackMarker, task_behaviour.turn_back_marker_enabled)) {
+    Profile::Set(ProfileKeys::TurnBackMarkerEnabled, task_behaviour.turn_back_marker_enabled);
     changed = true;
   }
 

--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -43,6 +43,7 @@ TaskBehaviour::SetDefaults()
   sector_defaults.SetDefaults();
   ordered_defaults.SetDefaults();
   route_planner.SetDefaults();
+  turn_back_marker_enabled = false;
   abort_task_mode = AbortTaskMode::SIMPLE;
 }
 

--- a/src/Engine/Task/TaskBehaviour.hpp
+++ b/src/Engine/Task/TaskBehaviour.hpp
@@ -123,6 +123,9 @@ struct TaskBehaviour {
   /** Route and reach planning */
   RoutePlannerConfig route_planner;
 
+  /** Show a marker indicating the point of no return */
+  bool turn_back_marker_enabled;
+
   void SetDefaults();
 
   /**

--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -54,6 +54,10 @@ MapLook::Initialise(const MapSettings &settings,
   reach_working_pen_thick.Create(Pen::DASH1, Layout::ScalePenWidth(2), clrBlupia);
 
   track_line_pen.Create(3, COLOR_GRAY);
+  
+  // Create green pen and brush for the Turn Back Point (TBP)
+  tbp_pen.Create(Layout::ScalePenWidth(2), COLOR_GREEN);
+  tbp_brush.Create(COLOR_GREEN);
 
   contest_pens[0].Create(Layout::ScalePenWidth(1) + 2, COLOR_RED);
   contest_pens[1].Create(Layout::ScalePenWidth(1) + 1, COLOR_ORANGE);

--- a/src/Look/MapLook.hpp
+++ b/src/Look/MapLook.hpp
@@ -59,6 +59,10 @@ struct MapLook {
   Pen reach_working_pen_thick;
 
   Pen track_line_pen;
+  
+  /** Pen and brush for the Turn Back Point (TBP) */
+  Pen tbp_pen;
+  Brush tbp_brush;
 
   Pen contest_pens[3];
 

--- a/src/MapWindow/GlueMapWindow.cpp
+++ b/src/MapWindow/GlueMapWindow.cpp
@@ -18,6 +18,7 @@ GlueMapWindow::GlueMapWindow(const Look &look) noexcept
    thermal_band_renderer(look.thermal_band, look.chart),
    final_glide_bar_renderer(look.final_glide_bar, look.map.task),
    vario_bar_renderer(look.vario_bar),
+   turn_back_point_renderer(look.map),
    gesture_look(look.gesture)
 {
 }

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -10,6 +10,7 @@
 #include "Renderer/ThermalBandRenderer.hpp"
 #include "Renderer/FinalGlideBarRenderer.hpp"
 #include "Renderer/VarioBarRenderer.hpp"
+#include "Renderer/TurnBackPointRenderer.hpp"
 #include "ui/event/Timer.hpp"
 #include "ui/event/Notify.hpp"
 #include "ui/window/Features.hpp"
@@ -118,6 +119,7 @@ class GlueMapWindow : public MapWindow {
   ThermalBandRenderer thermal_band_renderer;
   FinalGlideBarRenderer final_glide_bar_renderer;
   VarioBarRenderer vario_bar_renderer;
+  TurnBackPointRenderer turn_back_point_renderer;
 
   const GestureLook &gesture_look;
 
@@ -250,6 +252,7 @@ private:
   void DrawThermalBand(Canvas &canvas, const PixelRect &rc) const noexcept;
   void DrawFinalGlide(Canvas &canvas, const PixelRect &rc) const noexcept;
   void DrawVario(Canvas &canvas, const PixelRect &rc) const noexcept;
+  void DrawTurnBackPoint(Canvas &canvas, const PixelPoint aircraft_pos) const noexcept override;
   void DrawStallRatio(Canvas &canvas, const PixelRect &rc) const noexcept;
 
   void SwitchZoomClimb() noexcept;

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -460,3 +460,19 @@ GlueMapWindow::DrawStallRatio(Canvas &canvas,
     canvas.DrawLine(p.At(-1, -m), p.At(-11, -m));
   }
 }
+
+void
+GlueMapWindow::DrawTurnBackPoint(Canvas &canvas,
+                                const PixelPoint aircraft_pos) const noexcept
+{
+  if (!Basic().location_available || !Basic().track_available)
+    return;
+
+  // Only draw when we're not circling
+  if (Calculated().circling)
+    return;
+
+ turn_back_point_renderer.Draw(canvas, render_projection,
+                              aircraft_pos, Basic(), Calculated(),
+                              GetComputerSettings()); // Pass ComputerSettings
+}

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -361,6 +361,14 @@ private:
    * @param canvas The drawing canvas
    */
   void RenderFinalGlideShading(Canvas &canvas) noexcept;
+  
+  /**
+   * Draw the Turn Back Point (TBP) on the track line
+   * @param canvas The drawing canvas
+   * @param aircraft_pos The aircraft position on screen
+   */
+  virtual void DrawTurnBackPoint([[maybe_unused]] Canvas &canvas,
+                                [[maybe_unused]] const PixelPoint aircraft_pos) const noexcept {}
 
   /**
    * Renders the airspace

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -251,6 +251,10 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc) noexcept
   // Render track bearing (projected track ground/air relative)
   draw_sw.Mark("DrawTrackBearing");
   RenderTrackBearing(canvas, aircraft_pos);
+  
+  // Draw the Turn Back Point (TBP) on the track line
+  if (IsNearSelf() && !Calculated().circling)
+    DrawTurnBackPoint(canvas, aircraft_pos);
 
   draw_sw.Mark("RenderMisc2");
   DrawBestCruiseTrack(canvas, aircraft_pos);

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -64,6 +64,7 @@ constexpr std::string_view SnailTrail = "SnailTrail";
 constexpr std::string_view TrailDrift = "TrailDrift";
 constexpr std::string_view DetourCostMarker = "DetourCostMarker";
 constexpr std::string_view DisplayTrackBearing = "DisplayTrackBearing";
+constexpr std::string_view TurnBackMarkerEnabled = "TurnBackMarkerEnabled";
 constexpr std::string_view SpeedUnitsValue = "SpeedUnit";
 constexpr std::string_view TaskSpeedUnitsValue = "TaskSpeedUnit";
 constexpr std::string_view WarningTime = "WarnTime";

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -90,5 +90,7 @@ Profile::Load(const ProfileMap &map, TaskBehaviour &settings)
 
   map.GetEnum(ProfileKeys::AbortTaskMode, settings.abort_task_mode);
 
+  map.Get(ProfileKeys::TurnBackMarkerEnabled, settings.turn_back_marker_enabled);
+
   Load(map, settings.route_planner);
 }

--- a/src/Renderer/TurnBackPointRenderer.cpp
+++ b/src/Renderer/TurnBackPointRenderer.cpp
@@ -1,0 +1,141 @@
+#include "TurnBackPointRenderer.hpp"
+#include "Look/MapLook.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "Math/Angle.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/Derived.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "Geo/Math.hpp"
+#include "Screen/Layout.hpp"
+#include "Math/Screen.hpp"
+#include "Computer/Settings.hpp" // Added for ComputerSettings
+#include <cmath>
+#include <limits>
+
+// Small value to avoid division by zero and floating point issues
+constexpr double TBP_EPSILON = 1e-6;
+
+void
+TurnBackPointRenderer::Draw(Canvas &canvas,
+                            const WindowProjection &projection,
+                            [[maybe_unused]] const PixelPoint pos,
+                            const NMEAInfo &basic,
+                            const DerivedInfo &calculated,
+                            const ComputerSettings &settings) const noexcept
+{
+  // Check if the feature is enabled in settings
+  if (!settings.task.turn_back_marker_enabled)
+    return;
+
+  // Check if we have a valid task and solution data structure
+  const TaskStats &task_stats = calculated.task_stats;
+  if (!task_stats.task_valid)
+    return;
+
+  const ElementStat &total = task_stats.total;
+  const GlideResult &solution = total.solution_remaining;
+
+  // Need a valid solution to proceed (even if below glide for the *old* TBP)
+  if (!solution.IsOk())
+      return;
+
+  // Check if we have a valid track
+  if (!basic.track_available)
+    return;
+
+  // Get the current task waypoint location
+  const GeoPoint &waypoint_location = task_stats.current_leg.location_remaining;
+  if (!waypoint_location.IsValid())
+    return;
+
+  // Calculate direct distance (C) and bearing to waypoint from current position
+  const GeoVector direct_vector = basic.location.DistanceBearing(waypoint_location);
+  if (!direct_vector.IsValid() || direct_vector.distance < TBP_EPSILON) // Avoid issues if already at WP
+    return;
+  const double C_direct_distance = direct_vector.distance;
+
+  // Calculate angle (theta) between current track and direct path to waypoint
+  const Angle track_to_waypoint_angle = (basic.track - direct_vector.bearing).AsDelta();
+  const double cos_theta = track_to_waypoint_angle.cos();
+
+  // --- NEW TBP CALCULATION ---
+
+  // Estimate total altitude available above the target arrival point at the waypoint
+  // This assumes solution targets waypoint altitude correctly.
+  const double Alt_Total = solution.height_glide + solution.altitude_difference;
+
+  // We need positive altitude relative to the waypoint to glide there
+  if (Alt_Total <= TBP_EPSILON) {
+      return; // Cannot reach waypoint even directly, let alone via TBP
+  }
+
+  // Calculate the effective glide ratio *required* for the direct leg
+  // Use this as an estimate for the detour legs. Need valid height_glide.
+  if (solution.height_glide <= TBP_EPSILON) {
+      // Cannot reliably calculate required glide ratio
+      return;
+  }
+  const double glide_ratio = C_direct_distance / solution.height_glide;
+  if (glide_ratio <= TBP_EPSILON) {
+      // Invalid glide ratio
+      return;
+  }
+
+  // Calculate D_Total: Total horizontal distance achievable with Alt_Total
+  const double D_Total = Alt_Total * glide_ratio;
+
+  // Calculate the denominator for the solution of x
+  const double denominator = 2.0 * (D_Total - C_direct_distance * cos_theta);
+
+  // Check for degenerate case (denominator close to zero)
+  if (std::abs(denominator) < TBP_EPSILON) {
+      // Geometric configuration prevents a stable solution here
+      return;
+  }
+
+  // Calculate distance_to_tbp (x)
+  // x = (D_Total^2 - C^2) / (2 * (D_Total - C * cos(theta)))
+  const double distance_to_tbp = (D_Total * D_Total - C_direct_distance * C_direct_distance) / denominator;
+
+  // --- Validity Checks for the solution x ---
+
+  // 1. TBP must be ahead of the aircraft.
+  if (distance_to_tbp < 0.0) {
+    // The calculated point is behind the current position.
+    return;
+  }
+
+  // 2. The geometry requires D_Total - x >= 0 (from sqrt step)
+  //    This means x <= D_Total. If x > D_Total, the geometry is impossible.
+  if (distance_to_tbp > D_Total + TBP_EPSILON) { // Add epsilon for float tolerance
+     // This implies the required distance from TBP to WP would be negative.
+     return;
+  }
+
+  // --- TBP Calculation Successful ---
+
+  // Find the GEOGRAPHIC LOCATION of the TBP
+  GeoPoint tbp_location = FindLatitudeLongitude(basic.location,
+                                                basic.track,
+                                                distance_to_tbp);
+
+  // Convert the geographic TBP location to screen coordinates
+  auto tbp_screen = projection.GeoToScreenIfVisible(tbp_location);
+  if (!tbp_screen) {
+    // TBP is calculated but currently off-screen
+    return;
+  }
+
+  // --- Draw the TBP Symbol ---
+  BulkPixelPoint triangle[3];
+  triangle[0].x = 0;                      triangle[0].y = -Layout::Scale(5);
+  triangle[1].x = -Layout::Scale(4);      triangle[1].y = Layout::Scale(3);
+  triangle[2].x = Layout::Scale(4);       triangle[2].y = Layout::Scale(3);
+
+  PolygonRotateShift(std::span<BulkPixelPoint>(triangle, 3), *tbp_screen,
+                     basic.track - projection.GetScreenAngle());
+
+  canvas.Select(look.tbp_pen);
+  canvas.Select(look.tbp_brush);
+  canvas.DrawPolygon(triangle, 3);
+}

--- a/src/Renderer/TurnBackPointRenderer.hpp
+++ b/src/Renderer/TurnBackPointRenderer.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+struct PixelPoint;
+class Canvas;
+class Angle;
+class WindowProjection;
+struct MapLook;
+struct NMEAInfo;
+struct DerivedInfo;
+struct MapSettings;
+struct ComputerSettings;
+
+/**
+ * Renderer for the Turn Back Point (TBP)
+ * Displays a green triangle on the track line at the point where
+ * the aircraft would reach zero altitude difference to the task.
+ */
+class TurnBackPointRenderer {
+  const MapLook &look;
+
+public:
+  constexpr TurnBackPointRenderer(const MapLook &_look) noexcept:look(_look) {}
+
+  /**
+   * Draw the TBP on the track line
+   * @param canvas The canvas to draw on
+   * @param projection The map projection
+   * @param pos The aircraft position on screen
+   * @param basic Basic NMEA info
+   * @param calculated Calculated info including task stats
+   * @param settings Computer settings
+   */
+  void Draw(Canvas &canvas,
+            const WindowProjection &projection,
+            const PixelPoint pos,
+            const NMEAInfo &basic,
+            const DerivedInfo &calculated,
+            const ComputerSettings &settings) const noexcept;
+};


### PR DESCRIPTION
Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [ ] Commit messages explain *why* the change was made, not just *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit must compile)
- [x] One commit per logical change (don't mix refactoring with feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge

### Maintainer review follow-ups (from [review](https://github.com/XCSoar/XCSoar/pull/1741#pullrequestreview-4358476408))

- [ ] Align TBM glide data with Next WP infobox (`current_leg`, `SelectAltitudeDifference`)
- [ ] Hide marker when arrival altitude ≤ 0 (explicit check)
- [ ] `NEWS.txt` entry for unreleased version
- [ ] `make update-po` + translation commit
- [ ] SPDX header on `TurnBackPointRenderer.cpp`
- [ ] Restore 2-space indent on touched lines in `SafetyFactorsConfigPanel.cpp`

---

## Description

A new feature called the "Turn Back Marker" — a green triangle on the track line that indicates where along the track your arrival altitude will equal 0 if you maintained that track (and had still air). You can use this information to indicate where you will need to "turn back" to your goto waypoint.

The assumptions that go into arrival altitude go into the TBM calculation (MC setting, etc).

### In use

Pic below shows the TBM as a green triangle. Leg A can be flown until arrival alt (2243) is equal to 0 — at that point you'll have just enough altitude to fly leg B (0 arrival altitude still).

![image](https://github.com/user-attachments/assets/32c59717-d2a1-4bc6-b3a2-5b67baf77978)

Pic below shows another example of overflying your goto waypoint maybe to get a few more OLC points. TBM is again circled and indicates where on your current track (leg A) your arrival alt (2543) would equal 0 and you would have to turn back and fly leg B to arrive at Valence.

![image](https://github.com/user-attachments/assets/f08f1fd2-9970-4b10-adbe-03ac66d61bb9)

- TBM is only shown when arrival alt is > 0.
- The idea is to visually indicate on the map how far you'll be able to deviate or overshoot and still make it back to your goto waypoint.
- On/Off under **Configuration → Glide Computer → Safety Factors → Turn back marker**
- Defaults **OFF** but remembers **ON** over power cycle

Closes #1740
