### PR TITLE
fix track line scaling on high res android devices

### DIFF
--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -53,7 +53,7 @@ MapLook::Initialise(const MapSettings &settings,
   reach_working_pen.Create(Pen::DASH1, Layout::ScalePenWidth(1), clrBlupia);
   reach_working_pen_thick.Create(Pen::DASH1, Layout::ScalePenWidth(2), clrBlupia);
 
-  track_line_pen.Create(3, COLOR_GRAY);
+  track_line_pen.Create(Layout::ScalePenWidth(3), COLOR_GRAY);
 
   contest_pens[0].Create(Layout::ScalePenWidth(1) + 2, COLOR_RED);
   contest_pens[1].Create(Layout::ScalePenWidth(1) + 1, COLOR_ORANGE);

--- a/src/Renderer/TrackLineRenderer.cpp
+++ b/src/Renderer/TrackLineRenderer.cpp
@@ -10,6 +10,7 @@
 #include "MapSettings.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Geo/Math.hpp"
+#include "Screen/Layout.hpp"
 
 static constexpr unsigned ARC_STEPS = 10;
 static constexpr Angle ARC_SWEEP = Angle::Degrees(135.0);
@@ -23,8 +24,9 @@ TrackLineRenderer::Draw(Canvas &canvas, const Angle screen_angle,
   const auto x = sc.first, y = sc.second;
 
   PixelPoint end;
-  end.x = pos.x + iround(x * 400);
-  end.y = pos.y - iround(y * 400);
+  const int scaled_length = Layout::Scale(400);
+  end.x = pos.x + iround(x * scaled_length);
+  end.y = pos.y - iround(y * scaled_length);
 
   canvas.Select(look.track_line_pen);
   canvas.DrawLine(pos, end);


### PR DESCRIPTION
With 7.44 (unsure if other versions) the track line on high resolution android devices is very small. It seems to be scaled down and is the same 3 pixels wide and 400 pixels long but that makes it super tiny on android devices such that its very short and barely visible due to being 3 pixels wide.

This fixes it making it scale with the resolution so it looks the same as it does on other platforms.

Tested on LG G7 thinQ at 1440 x 3120 pixels (picture from same android device)
![image](https://github.com/user-attachments/assets/18ad7854-af98-445b-a912-bc3a37b79afe)
