### PR TITLE
PEV Start times with second resolution

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -32,6 +32,7 @@ Version 7.44 - not yet released
   - BigTrafficWidget: zoom range to 5km when opening big radar via the FlarmGauge
   - terrain: added 2 new terrain ramps for use in very flat countries
   - add head wind component to V GND Infobox #1439
+  - PEV start wait/window times now have second accuraccy #1099
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -55,8 +55,8 @@ TaskPropertiesPanel::RefreshView()
   LoadValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
   LoadValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 
-  LoadValue(START_OPEN_TIME, p.start_constraints.open_time_span.GetStart());
-  LoadValue(START_CLOSE_TIME, p.start_constraints.open_time_span.GetEnd());
+  LoadValue(START_OPEN_TIME, p.start_constraints.open_time_span.GetRoughStart());
+  LoadValue(START_CLOSE_TIME, p.start_constraints.open_time_span.GetRoughEnd());
 
   SetRowVisible(START_MAX_SPEED, !fai_start_finish);
   LoadValue(START_MAX_SPEED, p.start_constraints.max_speed,
@@ -110,12 +110,12 @@ TaskPropertiesPanel::ReadValues()
 
   changed |= SaveValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 
-  RoughTime new_open = p.start_constraints.open_time_span.GetStart();
-  RoughTime new_close = p.start_constraints.open_time_span.GetEnd();
+  RoughTime new_open = p.start_constraints.open_time_span.GetRoughStart();
+  RoughTime new_close = p.start_constraints.open_time_span.GetRoughEnd();
   const bool start_open_modified = SaveValue(START_OPEN_TIME, new_open);
   const bool start_close_modified = SaveValue(START_CLOSE_TIME, new_close);
   if (start_open_modified || start_close_modified) {
-    p.start_constraints.open_time_span = RoughTimeSpan(new_open, new_close);
+    p.start_constraints.open_time_span = TimeSpan::FromRoughTimes(new_open, new_close);
     changed = true;
   }
 

--- a/src/Dialogs/TimeEntry.hpp
+++ b/src/Dialogs/TimeEntry.hpp
@@ -5,7 +5,8 @@
 
 #include <tchar.h>
 
-class RoughTime;
+#include "time/RoughTimeDecl.hpp"
+
 class RoughTimeDelta;
 
 bool

--- a/src/Engine/Task/Ordered/Points/StartPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.cpp
@@ -92,11 +92,11 @@ bool
 StartPoint::CheckExitTransition(const AircraftState &ref_now,
                                 const AircraftState &ref_last) const noexcept
 {
-  if (!constraints.open_time_span.HasBegun(RoughTime{ref_last.time}))
+  if (!constraints.open_time_span.HasBegun(FineTime{ref_last.time}))
     /* the start gate is not yet open when we left the OZ */
     return false;
 
-  if (constraints.open_time_span.HasEnded(RoughTime{ref_now.time}))
+  if (constraints.open_time_span.HasEnded(FineTime{ref_now.time}))
     /* the start gate was already closed when we left the OZ */
     return false;
 

--- a/src/Engine/Task/Ordered/StartConstraints.cpp
+++ b/src/Engine/Task/Ordered/StartConstraints.cpp
@@ -8,7 +8,7 @@
 void
 StartConstraints::SetDefaults()
 {
-  open_time_span = RoughTimeSpan::Invalid();
+  open_time_span = TimeSpan::Invalid();
   max_speed = 0;
   max_height = 0;
   max_height_ref = AltitudeReference::AGL;

--- a/src/Engine/Task/Ordered/StartConstraints.hpp
+++ b/src/Engine/Task/Ordered/StartConstraints.hpp
@@ -13,7 +13,7 @@ struct StartConstraints {
   /**
    * The time span during which the start gate is open.
    */
-  RoughTimeSpan open_time_span;
+  TimeSpan open_time_span;
 
   /** Maximum ground speed (m/s) allowed in start sector */
   double max_speed;

--- a/src/Engine/Task/Stats/CommonStats.cpp
+++ b/src/Engine/Task/Stats/CommonStats.cpp
@@ -3,7 +3,7 @@
 void
 CommonStats::ResetTask() noexcept
 {
-  start_open_time_span = RoughTimeSpan::Invalid();
+  start_open_time_span = TimeSpan::Invalid();
   landable_reachable = false;
   TimeUnderStartMaxHeight = TimeStamp::Undefined();
   aat_time_remaining = {};

--- a/src/Engine/Task/Stats/CommonStats.hpp
+++ b/src/Engine/Task/Stats/CommonStats.hpp
@@ -23,7 +23,7 @@ public:
   /**
    * A copy of #StartConstraints::open_time_span.
    */
-  RoughTimeSpan start_open_time_span;
+  TimeSpan start_open_time_span;
 
   /** Whether the task found landable reachable waypoints (aliases abort) */
   bool landable_reachable;

--- a/src/Form/DigitEntry.hpp
+++ b/src/Form/DigitEntry.hpp
@@ -5,13 +5,13 @@
 
 #include "ui/window/PaintWindow.hpp"
 #include "Renderer/ButtonRenderer.hpp"
+#include "time/RoughTimeDecl.hpp"
 
 #include <cassert>
 #include <cstdint>
 #include <functional>
 
 enum class CoordinateFormat : uint8_t;
-class RoughTime;
 class Angle;
 struct BrokenDate;
 class ContainerWindow;

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -836,7 +836,7 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
   const auto &calculated = CommonInterface::Calculated();
   const TaskStats &task_stats = calculated.ordered_task_stats;
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  const RoughTimeSpan &open = common_stats.start_open_time_span;
+  const TimeSpan &open = common_stats.start_open_time_span;
 
   /* reset color that may have been set by a previous call */
   data.SetValueColor(0);
@@ -855,8 +855,8 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
   } else if (open.HasBegun(now)) {
-    if (open.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(now_s, open.GetEnd());
+    if (open.GetRoughEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(now_s, open.GetRoughEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -864,7 +864,7 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(now_s, open.GetStart());
+    unsigned seconds = SecondsUntil(now_s, open.GetRoughStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));
@@ -880,7 +880,7 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
   const GlideResult &current_remaining =
     task_stats.current_leg.solution_remaining;
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  const RoughTimeSpan &open = common_stats.start_open_time_span;
+  const TimeSpan &open = common_stats.start_open_time_span;
 
   /* reset color that may have been set by a previous call */
   data.SetValueColor(0);
@@ -900,8 +900,8 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
   } else if (open.HasBegun(arrival)) {
-    if (open.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(arrival_s, open.GetEnd());
+    if (open.GetRoughEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(arrival_s, open.GetRoughEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -909,7 +909,7 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(arrival_s, open.GetStart());
+    unsigned seconds = SecondsUntil(arrival_s, open.GetRoughStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -821,7 +821,7 @@ UpdateInfoBoxCruiseEfficiency(InfoBoxData &data) noexcept
 }
 
 static constexpr unsigned
-SecondsUntil(TimeStamp now, RoughTime until) noexcept
+SecondsUntil(TimeStamp now, FineTime until) noexcept
 {
   auto d = TimeStamp{until} - now;
   if (d.count() < 0)
@@ -849,14 +849,14 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
   }
 
   const auto now_s = basic.time;
-  const RoughTime now{now_s};
+  const FineTime now{now_s};
 
   if (open.HasEnded(now)) {
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
   } else if (open.HasBegun(now)) {
-    if (open.GetRoughEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(now_s, open.GetRoughEnd());
+    if (open.GetEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(now_s, open.GetEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -864,7 +864,7 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(now_s, open.GetRoughStart());
+    unsigned seconds = SecondsUntil(now_s, open.GetStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));
@@ -894,14 +894,14 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
   }
 
   const auto arrival_s = basic.time + current_remaining.time_elapsed;
-  const RoughTime arrival{arrival_s};
+  const FineTime arrival{arrival_s};
 
   if (open.HasEnded(arrival)) {
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
   } else if (open.HasBegun(arrival)) {
-    if (open.GetRoughEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(arrival_s, open.GetRoughEnd());
+    if (open.GetEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(arrival_s, open.GetEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -909,7 +909,7 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(arrival_s, open.GetRoughStart());
+    unsigned seconds = SecondsUntil(arrival_s, open.GetStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -211,7 +211,7 @@ try {
   if (start.pev_start_window.count() > 0) {
     new_end = new_start + RoughTimeDelta::FromDuration(start.pev_start_window);
   }
-  const RoughTimeSpan ts = RoughTimeSpan(new_start, new_end);
+  const TimeSpan ts = TimeSpan::FromRoughTimes(new_start, new_end);
 
   backend_components->protected_task_manager->SetStartTimeSpan(ts);
 

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -30,7 +30,7 @@ ProtectedTaskManager::SetGlidePolar(const GlidePolar &glide_polar) noexcept
 }
 
 void
-ProtectedTaskManager::SetStartTimeSpan(const RoughTimeSpan &open_time_span) noexcept
+ProtectedTaskManager::SetStartTimeSpan(const TimeSpan &open_time_span) noexcept
 {
   ExclusiveLease lease(*this);
   OrderedTaskSettings otb = lease->GetOrderedTask().GetOrderedTaskSettings();

--- a/src/Task/ProtectedTaskManager.hpp
+++ b/src/Task/ProtectedTaskManager.hpp
@@ -51,7 +51,7 @@ public:
   [[gnu::pure]]
   const OrderedTaskSettings GetOrderedTaskSettings() const noexcept;
 
-  void SetStartTimeSpan(const RoughTimeSpan &open_time_span) noexcept;
+  void SetStartTimeSpan(const TimeSpan &open_time_span) noexcept;
 
   [[gnu::pure]]
   WaypointPtr GetActiveWaypoint() const noexcept;

--- a/src/Task/Serialiser.cpp
+++ b/src/Task/Serialiser.cpp
@@ -252,9 +252,9 @@ Serialise(WritableDataNode &node, const OrderedTaskSettings &data)
   node.SetAttribute("start_max_height_ref",
                     GetHeightRef(data.start_constraints.max_height_ref));
   node.SetAttribute("start_open_time",
-                    data.start_constraints.open_time_span.GetStart());
+                    data.start_constraints.open_time_span.GetRoughStart());
   node.SetAttribute("start_close_time",
-                    data.start_constraints.open_time_span.GetEnd());
+                    data.start_constraints.open_time_span.GetRoughEnd());
   node.SetAttribute("finish_min_height",
                     data.finish_constraints.min_height);
   node.SetAttribute("finish_min_height_ref",

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -8,6 +8,7 @@
 #include "Form/DataField/Base.hpp"
 #include "time/BrokenDate.hpp"
 #include "time/FloatDuration.hxx"
+#include "time/RoughTimeDecl.hpp"
 #include "Repository/FileType.hpp"
 #include "Units/Group.hpp"
 
@@ -24,7 +25,6 @@
 struct DialogLook;
 struct StaticEnumChoice;
 class Angle;
-class RoughTime;
 class RoughTimeDelta;
 class Path;
 class Button;

--- a/src/XML/DataNode.cpp
+++ b/src/XML/DataNode.cpp
@@ -111,12 +111,12 @@ ConstDataNode::GetAttributeRoughTime(const char *name) const noexcept
   return RoughTime(hours, minutes);
 }
 
-RoughTimeSpan
+TimeSpan
 ConstDataNode::GetAttributeRoughTimeSpan(const char *start_name,
                                          const char *end_name) const noexcept
 {
-  return RoughTimeSpan(GetAttributeRoughTime(start_name),
-                       GetAttributeRoughTime(end_name));
+  return TimeSpan::FromRoughTimes(GetAttributeRoughTime(start_name),
+                                  GetAttributeRoughTime(end_name));
 }
 
 WritableDataNode::~WritableDataNode() noexcept

--- a/src/XML/DataNode.hpp
+++ b/src/XML/DataNode.hpp
@@ -4,12 +4,12 @@
 #pragma once
 
 #include "time/FloatDuration.hxx"
+#include "time/RoughTimeDecl.hpp"
 
 #include <list>
 #include <memory>
 
 class Angle;
-class RoughTime;
 class RoughTimeSpan;
 
 /**

--- a/src/XML/DataNode.hpp
+++ b/src/XML/DataNode.hpp
@@ -10,7 +10,7 @@
 #include <memory>
 
 class Angle;
-class RoughTimeSpan;
+class TimeSpan;
 
 /**
  * Class used as generic node for tree-structured data.
@@ -115,8 +115,8 @@ public:
   RoughTime GetAttributeRoughTime(const char *name) const noexcept;
 
   [[gnu::pure]]
-  RoughTimeSpan GetAttributeRoughTimeSpan(const char *start_name,
-                                          const char *end_name) const noexcept;
+  TimeSpan GetAttributeRoughTimeSpan(const char *start_name,
+                                     const char *end_name) const noexcept;
 };
 
 /**

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -37,21 +37,6 @@ public:
   {
   }
 
-  static constexpr RoughTime FromMinuteOfDay(unsigned mod) noexcept {
-    assert(std::chrono::minutes{mod} < MAX);
-
-    return RoughTime(std::chrono::minutes{mod});
-  }
-
-  /**
-   * Construct a #RoughTime object from the specified duration since
-   * midnight.
-   */
-  template<class Rep, class Period>
-  static constexpr RoughTime FromSinceMidnight(const std::chrono::duration<Rep,Period> &since_midnight) noexcept {
-    return FromMinuteOfDay(std::chrono::duration_cast<std::chrono::minutes>(since_midnight).count());
-  }
-
   static constexpr RoughTime FromMinuteOfDayChecked(int mod) noexcept {
     while (mod < 0)
       mod += MAX.count();
@@ -60,8 +45,7 @@ public:
   }
 
   /**
-   * A wrapper for FromSinceMidnight() which allows values bigger than
-   * one day.
+   * Allows values bigger than one day.
    */
   template<class Rep, class Period>
   static constexpr RoughTime FromSinceMidnightChecked(const std::chrono::duration<Rep,Period> &since_midnight) noexcept {
@@ -70,10 +54,6 @@ public:
 
   static constexpr RoughTime FromMinuteOfDayChecked(unsigned mod) noexcept {
     return RoughTime(std::chrono::minutes{mod % MAX.count()});
-  }
-
-  static constexpr RoughTime FromSecondOfDayChecked(unsigned sod) noexcept {
-    return FromMinuteOfDayChecked(sod / 60);
   }
 
   explicit constexpr RoughTime(TimeStamp t) noexcept

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -175,6 +175,14 @@ public:
     return TimeSpan(FineTime::Invalid(), FineTime::Invalid());
   }
 
+  constexpr FineTime GetStart() const noexcept {
+    return start;
+  }
+
+  constexpr FineTime GetEnd() const noexcept {
+    return end;
+  }
+
   constexpr RoughTime GetRoughStart() const noexcept {
     return ToRoughTime(start);
   }

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -41,23 +41,19 @@ public:
     while (mod < 0)
       mod += MAX.count();
 
-    return FromMinuteOfDayChecked(unsigned(mod));
+    return RoughTime(std::chrono::minutes{(unsigned)mod % MAX.count()});
   }
 
-  /**
-   * Allows values bigger than one day.
-   */
-  template<class Rep, class Period>
-  static constexpr RoughTime FromSinceMidnightChecked(const std::chrono::duration<Rep,Period> &since_midnight) noexcept {
-    return FromMinuteOfDayChecked((int)std::chrono::duration_cast<std::chrono::minutes>(since_midnight).count());
-  }
+  explicit constexpr RoughTime(TimeStamp t) noexcept {
+    constexpr auto MAX_FLOAT = std::chrono::duration_cast<FloatDuration>(MAX);
+    
+    FloatDuration since_midnight = t.ToDuration();
+    while (since_midnight < FloatDuration(0))
+      since_midnight += MAX_FLOAT;
+    since_midnight = FloatDuration(std::fmod(since_midnight.count(), MAX_FLOAT.count()));
 
-  static constexpr RoughTime FromMinuteOfDayChecked(unsigned mod) noexcept {
-    return RoughTime(std::chrono::minutes{mod % MAX.count()});
+    value = std::chrono::duration_cast<Duration>(since_midnight);
   }
-
-  explicit constexpr RoughTime(TimeStamp t) noexcept
-    :RoughTime(FromSinceMidnightChecked(t.ToDuration())) {}
 
   static constexpr RoughTime Invalid() noexcept {
     return RoughTime(INVALID);

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -161,11 +161,11 @@ class TimeSpan {
    */
   FineTime end;
 
-  constexpr TimeSpan(FineTime _start, FineTime _end) noexcept
-    :start(_start), end(_end) {}
-
 public:
   TimeSpan() noexcept = default;
+
+  constexpr TimeSpan(FineTime _start, FineTime _end) noexcept
+    :start(_start), end(_end) {}
 
   static constexpr TimeSpan FromRoughTimes(RoughTime _start, RoughTime _end) noexcept {
     return TimeSpan( ToFineTime(_start), ToFineTime(_end) );
@@ -188,18 +188,27 @@ public:
   }
 
   constexpr bool HasBegun(RoughTime now) const noexcept {
+    return HasBegun( ToFineTime(now) );
+  }
+
+  constexpr bool HasBegun(FineTime now) const noexcept {
     /* if start is invalid, we assume the time span has always already
        begun */
-    return !start.IsValid() || ToFineTime(now) >= start;
+    return !start.IsValid() || now >= start;
   }
 
   constexpr bool HasEnded(RoughTime now) const noexcept {
-    /* if end is invalid, the time span is open-ended, i.e. it will
-       never end */
-    return end.IsValid() && ToFineTime(now) >= end;
+    return HasEnded( ToFineTime(now) );
   }
 
-  constexpr bool IsInside(RoughTime now) const noexcept {
+  constexpr bool HasEnded(FineTime now) const noexcept {
+    /* if end is invalid, the time span is open-ended, i.e. it will
+       never end */
+    return end.IsValid() && now >= end;
+  }
+
+  template <typename Time>
+  constexpr bool IsInside(Time now) const noexcept {
     return HasBegun(now) && !HasEnded(now);
   }
 };

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -195,18 +195,10 @@ public:
     return start.IsValid() || end.IsValid();
   }
 
-  constexpr bool HasBegun(RoughTime now) const noexcept {
-    return HasBegun( ToFineTime(now) );
-  }
-
   constexpr bool HasBegun(FineTime now) const noexcept {
     /* if start is invalid, we assume the time span has always already
        begun */
     return !start.IsValid() || now >= start;
-  }
-
-  constexpr bool HasEnded(RoughTime now) const noexcept {
-    return HasEnded( ToFineTime(now) );
   }
 
   constexpr bool HasEnded(FineTime now) const noexcept {
@@ -215,8 +207,7 @@ public:
     return end.IsValid() && now >= end;
   }
 
-  template <typename Time>
-  constexpr bool IsInside(Time now) const noexcept {
+  constexpr bool IsInside(FineTime now) const noexcept {
     return HasBegun(now) && !HasEnded(now);
   }
 };

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Stamp.hpp"
+#include "RoughTimeDecl.hpp"
 
 #include <cassert>
 #include <chrono>
@@ -12,7 +13,7 @@
 /**
  * This data type stores a time of day with minute granularity.
  */
-class RoughTime {
+class TimeSinceMidnight {
   using Duration = std::chrono::duration<uint16_t,
                                          std::chrono::minutes::period>;
 
@@ -25,26 +26,26 @@ class RoughTime {
    */
   Duration value;
 
-  constexpr RoughTime(Duration _value) noexcept
+  constexpr TimeSinceMidnight(Duration _value) noexcept
     :value(_value) {}
 
 public:
-  RoughTime() noexcept = default;
+  TimeSinceMidnight() noexcept = default;
 
-  constexpr RoughTime(unsigned hour, unsigned minute) noexcept
+  constexpr TimeSinceMidnight(unsigned hour, unsigned minute) noexcept
     :value(std::chrono::duration_cast<Duration>(std::chrono::hours{hour}) +
            std::chrono::duration_cast<Duration>(std::chrono::minutes{minute}))
   {
   }
 
-  static constexpr RoughTime FromMinuteOfDayChecked(int mod) noexcept {
+  static constexpr TimeSinceMidnight FromMinuteOfDayChecked(int mod) noexcept {
     while (mod < 0)
       mod += MAX.count();
 
-    return RoughTime(std::chrono::minutes{(unsigned)mod % MAX.count()});
+    return TimeSinceMidnight(std::chrono::minutes{(unsigned)mod % MAX.count()});
   }
 
-  explicit constexpr RoughTime(TimeStamp t) noexcept {
+  explicit constexpr TimeSinceMidnight(TimeStamp t) noexcept {
     constexpr auto MAX_FLOAT = std::chrono::duration_cast<FloatDuration>(MAX);
     
     FloatDuration since_midnight = t.ToDuration();
@@ -55,8 +56,8 @@ public:
     value = std::chrono::duration_cast<Duration>(since_midnight);
   }
 
-  static constexpr RoughTime Invalid() noexcept {
-    return RoughTime(INVALID);
+  static constexpr TimeSinceMidnight Invalid() noexcept {
+    return TimeSinceMidnight(INVALID);
   }
 
   void SetInvalid() noexcept {
@@ -67,28 +68,28 @@ public:
     return value != INVALID;
   }
 
-  constexpr bool operator ==(RoughTime other) const noexcept {
+  constexpr bool operator ==(TimeSinceMidnight other) const noexcept {
     return value == other.value;
   }
 
-  constexpr bool operator !=(RoughTime other) const noexcept {
+  constexpr bool operator !=(TimeSinceMidnight other) const noexcept {
     return value != other.value;
   }
 
-  constexpr bool operator <(RoughTime other) const noexcept {
+  constexpr bool operator <(TimeSinceMidnight other) const noexcept {
     /* this formula supports midnight wraparound */
     return (MAX - Duration{1} + other.value - value) % MAX < MAX / 2;
   }
 
-  constexpr bool operator >(RoughTime other) const noexcept {
+  constexpr bool operator >(TimeSinceMidnight other) const noexcept {
     return other < *this;
   }
 
-  constexpr bool operator <=(RoughTime other) const noexcept {
+  constexpr bool operator <=(TimeSinceMidnight other) const noexcept {
     return !(*this > other);
   }
 
-  constexpr bool operator >=(RoughTime other) const noexcept {
+  constexpr bool operator >=(TimeSinceMidnight other) const noexcept {
     return !(*this < other);
   }
 
@@ -104,7 +105,7 @@ public:
     return value.count();
   }
 
-  RoughTime &operator++() noexcept {
+  TimeSinceMidnight &operator++() noexcept {
     assert(IsValid());
     assert(value < MAX);
 
@@ -112,7 +113,7 @@ public:
     return *this;
   }
 
-  RoughTime &operator--() noexcept {
+  TimeSinceMidnight &operator--() noexcept {
     assert(IsValid());
     assert(value < MAX);
 

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -135,12 +135,11 @@ public:
 };
 
 /**
- * A data type that stores a time span: start end end time of day with
- * minute granularity.  This object may be "undefined", i.e. no time
- * span was specified.  Either start or end may be "invalid",
- * i.e. there is no limitation on that side.
+ * A data type that stores a time span: start and end time of day.
+ * This object may be "undefined", i.e. no time span was specified.
+ * Either start or end may be "invalid", i.e. there is no limitation on that side.
  */
-class RoughTimeSpan {
+class TimeSpan {
   RoughTime start;
 
   /**
@@ -149,21 +148,25 @@ class RoughTimeSpan {
    */
   RoughTime end;
 
-public:
-  RoughTimeSpan() noexcept = default;
-
-  constexpr RoughTimeSpan(RoughTime _start, RoughTime _end) noexcept
+  constexpr TimeSpan(RoughTime _start, RoughTime _end) noexcept
     :start(_start), end(_end) {}
 
-  static constexpr RoughTimeSpan Invalid() noexcept {
-    return RoughTimeSpan(RoughTime::Invalid(), RoughTime::Invalid());
+public:
+  TimeSpan() noexcept = default;
+
+  static constexpr TimeSpan FromRoughTimes(RoughTime _start, RoughTime _end) noexcept {
+    return TimeSpan(_start, _end);
   }
 
-  constexpr const RoughTime &GetStart() const noexcept {
+  static constexpr TimeSpan Invalid() noexcept {
+    return TimeSpan(RoughTime::Invalid(), RoughTime::Invalid());
+  }
+
+  constexpr const RoughTime &GetRoughStart() const noexcept {
     return start;
   }
 
-  constexpr const RoughTime &GetEnd() const noexcept {
+  constexpr const RoughTime &GetRoughEnd() const noexcept {
     return end;
   }
 

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -11,18 +11,18 @@
 #include <cstdint>
 
 /**
- * This data type stores a time of day with minute granularity.
+ * Data type to define a time of day with parameterized granularity.
  */
+template <typename Duration>
 class TimeSinceMidnight {
-  using Duration = std::chrono::duration<uint16_t,
-                                         std::chrono::minutes::period>;
 
   static constexpr auto INVALID = Duration::max();
   static constexpr Duration MAX = std::chrono::hours{24};
 
   /**
-   * Minute of day.  Must be smaller than 24*60.  The only exception
-   * is the special value #INVALID.
+   * std::chrono::duration since midnight.  
+   * Must be smaller than the equivalet of 24 hours.
+   * The only exception is the special value #INVALID.
    */
   Duration value;
 
@@ -39,10 +39,11 @@ public:
   }
 
   static constexpr TimeSinceMidnight FromMinuteOfDayChecked(int mod) noexcept {
+    constexpr auto MAX_MINUTES = std::chrono::duration_cast<std::chrono::minutes>(MAX).count();
     while (mod < 0)
-      mod += MAX.count();
+      mod += MAX_MINUTES;
 
-    return TimeSinceMidnight(std::chrono::minutes{(unsigned)mod % MAX.count()});
+    return TimeSinceMidnight(std::chrono::minutes{mod % MAX_MINUTES});
   }
 
   explicit constexpr TimeSinceMidnight(TimeStamp t) noexcept {
@@ -98,11 +99,11 @@ public:
   }
 
   constexpr unsigned GetMinute() const noexcept {
-    return value.count() % 60;
+    return std::chrono::duration_cast<std::chrono::minutes>(value).count() % 60;
   }
 
   constexpr unsigned GetMinuteOfDay() const noexcept {
-    return value.count();
+    return std::chrono::duration_cast<std::chrono::minutes>(value).count();
   }
 
   TimeSinceMidnight &operator++() noexcept {

--- a/src/time/RoughTimeDecl.hpp
+++ b/src/time/RoughTimeDecl.hpp
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * This data type stores a time of day with minute granularity.
+ */
+class TimeSinceMidnight;
+using RoughTime = TimeSinceMidnight;

--- a/src/time/RoughTimeDecl.hpp
+++ b/src/time/RoughTimeDecl.hpp
@@ -3,8 +3,13 @@
 
 #pragma once
 
+#include <chrono>
+
+template <typename Duration>
+class TimeSinceMidnight;
+
 /**
  * This data type stores a time of day with minute granularity.
  */
-class TimeSinceMidnight;
-using RoughTime = TimeSinceMidnight;
+using UnsignedMinutes = std::chrono::duration<uint16_t,std::chrono::minutes::period>;
+using RoughTime = TimeSinceMidnight<UnsignedMinutes>;

--- a/src/time/RoughTimeDecl.hpp
+++ b/src/time/RoughTimeDecl.hpp
@@ -13,3 +13,9 @@ class TimeSinceMidnight;
  */
 using UnsignedMinutes = std::chrono::duration<uint16_t,std::chrono::minutes::period>;
 using RoughTime = TimeSinceMidnight<UnsignedMinutes>;
+
+/**
+ * This data type stores a time of day with seconds granularity.
+ */
+using UnsignedSeconds = std::chrono::duration<uint32_t,std::chrono::seconds::period>;
+using FineTime = TimeSinceMidnight<UnsignedSeconds>;

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -42,21 +42,15 @@ static void test_rough_time()
   ok1(!(b > a));
 
   /* test factory functions */
-  ok1(RoughTime::FromMinuteOfDay(12*60+1) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((unsigned)(12*60+1)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((unsigned)(12*60+1+24*60)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1+24*60)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1-24*60)) == RoughTime(12,1) );
 
-  ok1(RoughTime::FromSecondOfDayChecked(12*3600+1*60) == RoughTime(12,1) );
-  ok1(RoughTime::FromSecondOfDayChecked(12*3600+1*60-1) == RoughTime(12,0) );
-  ok1(RoughTime::FromSecondOfDayChecked(12*3600+1*60+24*3600) == RoughTime(12,1) );
-  
-  ok1(RoughTime::FromSinceMidnight(12h) == RoughTime(12,0) );
-  ok1(RoughTime::FromSinceMidnight(12h+1min) == RoughTime(12,1) );
-  ok1(RoughTime::FromSinceMidnight(12h+1s) == RoughTime(12,0) );
+  ok1(RoughTime::FromSinceMidnightChecked(12h) == RoughTime(12,0) );
   ok1(RoughTime::FromSinceMidnightChecked(12h+1min) == RoughTime(12,1) );
+  ok1(RoughTime::FromSinceMidnightChecked(12h+1s) == RoughTime(12,0) );
   ok1(RoughTime::FromSinceMidnightChecked(12h+1min+24h) == RoughTime(12,1) );
   ok1(RoughTime::FromSinceMidnightChecked(12h+1min-24h) == RoughTime(12,1) );
   
@@ -160,7 +154,7 @@ static void test_rough_time_delta()
 
 int main()
 {
-  plan_tests(97);
+  plan_tests(92);
 
   test_rough_time();
   test_rough_time_span();

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -42,17 +42,9 @@ static void test_rough_time()
   ok1(!(b > a));
 
   /* test factory functions */
-  ok1(RoughTime::FromMinuteOfDayChecked((unsigned)(12*60+1)) == RoughTime(12,1) );
-  ok1(RoughTime::FromMinuteOfDayChecked((unsigned)(12*60+1+24*60)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1+24*60)) == RoughTime(12,1) );
   ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1-24*60)) == RoughTime(12,1) );
-
-  ok1(RoughTime::FromSinceMidnightChecked(12h) == RoughTime(12,0) );
-  ok1(RoughTime::FromSinceMidnightChecked(12h+1min) == RoughTime(12,1) );
-  ok1(RoughTime::FromSinceMidnightChecked(12h+1s) == RoughTime(12,0) );
-  ok1(RoughTime::FromSinceMidnightChecked(12h+1min+24h) == RoughTime(12,1) );
-  ok1(RoughTime::FromSinceMidnightChecked(12h+1min-24h) == RoughTime(12,1) );
   
   ok1(RoughTime( TimeStamp(12h) ) == RoughTime(12,0) );
   ok1(RoughTime( TimeStamp(12h+1min) ) == RoughTime(12,1) );
@@ -154,7 +146,7 @@ static void test_rough_time_delta()
 
 int main()
 {
-  plan_tests(92);
+  plan_tests(85);
 
   test_rough_time();
   test_rough_time_span();

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -6,18 +6,19 @@
 
 using namespace std::chrono_literals;
 
-static void test_rough_time()
+template <typename TimeType>
+static void test_time()
 {
-  RoughTime a = RoughTime::Invalid();
+  TimeType a = TimeType::Invalid();
   ok1(!a.IsValid());
 
-  a = RoughTime(12, 1);
+  a = TimeType(12, 1);
   ok1(a.IsValid());
   ok1(a.GetHour() == 12);
   ok1(a.GetMinute() == 1);
   ok1(a.GetMinuteOfDay() == 12 * 60 + 1);
 
-  /* compare a RoughTime with itself */
+  /* compare with itself */
   ok1(a == a);
   ok1(!(a != a));
   ok1(a <= a);
@@ -25,8 +26,8 @@ static void test_rough_time()
   ok1(!(a < a));
   ok1(!(a > a));
 
-  /* compare a RoughTime with another one */
-  RoughTime b(11, 59);
+  /* compare with another one */
+  TimeType b(11, 59);
   ok1(b.IsValid());
   ok1(a != b);
   ok1(!(a == b));
@@ -42,19 +43,19 @@ static void test_rough_time()
   ok1(!(b > a));
 
   /* test factory functions */
-  ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1)) == RoughTime(12,1) );
-  ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1+24*60)) == RoughTime(12,1) );
-  ok1(RoughTime::FromMinuteOfDayChecked((int)(12*60+1-24*60)) == RoughTime(12,1) );
-  
-  ok1(RoughTime( TimeStamp(12h) ) == RoughTime(12,0) );
-  ok1(RoughTime( TimeStamp(12h+1min) ) == RoughTime(12,1) );
-  ok1(RoughTime( TimeStamp(12h+1s) ) == RoughTime(12,0) );
-  ok1(RoughTime( TimeStamp(12h+1min+24h) ) == RoughTime(12,1) );
-  ok1(RoughTime( TimeStamp(12h+1min-24h) ) == RoughTime(12,1) );
+  ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1)) == TimeType(12,1) );
+  ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1+24*60)) == TimeType(12,1) );
+  ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1-24*60)) == TimeType(12,1) );
+
+  ok1(TimeType( TimeStamp(12h) ) == TimeType(12,0) );
+  ok1(TimeType( TimeStamp(12h+1min) ) == TimeType(12,1) );
+  ok1(TimeType( TimeStamp(12h+1s) ) == TimeType(12,0) );
+  ok1(TimeType( TimeStamp(12h+1min+24h) ) == TimeType(12,1) );
+  ok1(TimeType( TimeStamp(12h+1min-24h) ) == TimeType(12,1) );
 
   /* test midnight wraparound */
-  a = RoughTime(0, 0);
-  b = RoughTime(23, 59);
+  a = TimeType(0, 0);
+  b = TimeType(23, 59);
   ok1(b.IsValid());
   ok1(a != b);
   ok1(!(a == b));
@@ -148,7 +149,7 @@ int main()
 {
   plan_tests(85);
 
-  test_rough_time();
+  test_time<RoughTime>();
   test_rough_time_span();
   test_rough_time_delta();
 

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -81,63 +81,66 @@ static void test_conversions()
 
 static void test_time_span()
 {
-  RoughTime a(12, 1);
-  RoughTime b(11, 59);
+  RoughTime r_a(12, 1);
+  RoughTime r_b(11, 59);
 
-  TimeSpan s = TimeSpan::FromRoughTimes(a,b);
-  ok1( s.GetRoughStart() == a );
-  ok1( s.GetRoughEnd() == b );
+  TimeSpan s = TimeSpan::FromRoughTimes(r_a,r_b);
+  ok1( s.GetRoughStart() == r_a );
+  ok1( s.GetRoughEnd() == r_b );
 
-  s = TimeSpan(ToFineTime(a), ToFineTime(b));
-  ok1( s.GetRoughStart() == a );
-  ok1( s.GetRoughEnd() == b );
+  s = TimeSpan(ToFineTime(r_a), ToFineTime(r_b));
+  ok1( s.GetRoughStart() == r_a );
+  ok1( s.GetRoughEnd() == r_b );
 
   /* test TimeSpan::IsInside() */
+  FineTime a(12, 1);
+  FineTime b(11, 59);
+
   s = TimeSpan::Invalid();
   ok1(!s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
 
-  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime::Invalid());
+  s = TimeSpan(FineTime(12, 0), FineTime::Invalid());
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(!s.IsInside(b));
 
-  s = TimeSpan::FromRoughTimes(RoughTime::Invalid(), RoughTime(12, 0));
+  s = TimeSpan(FineTime::Invalid(), FineTime(12, 0));
   ok1(s.IsDefined());
   ok1(!s.IsInside(a));
   ok1(s.IsInside(b));
 
-  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime(12, 1));
+  s = TimeSpan(FineTime(12, 0), FineTime(12, 1));
   ok1(s.IsDefined());
   ok1(!s.IsInside(a));
   ok1(!s.IsInside(b));
 
-  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime(12, 30));
+  s = TimeSpan(FineTime(12, 0), FineTime(12, 30));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(!s.IsInside(b));
 
   /* test midnight wraparound */
-  a = RoughTime(0, 0);
-  b = RoughTime(23, 59);
-  RoughTime c(22, 0);
-  RoughTime d(2, 0);
-  s = TimeSpan::FromRoughTimes(RoughTime(23, 0), RoughTime::Invalid());
+  a = FineTime(0, 0);
+  b = FineTime(23, 59);
+  FineTime c(22, 0);
+  FineTime d(2, 0);
+  s = TimeSpan(FineTime(23, 0), FineTime::Invalid());
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
   ok1(!s.IsInside(c));
   ok1(s.IsInside(d));
 
-  s = TimeSpan::FromRoughTimes(RoughTime::Invalid(), RoughTime(1, 0));
+  s = TimeSpan(FineTime::Invalid(), FineTime(1, 0));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
   ok1(s.IsInside(c));
   ok1(!s.IsInside(d));
 
-  s = TimeSpan::FromRoughTimes(RoughTime(23, 1), RoughTime(0, 30));
+  s = TimeSpan(FineTime(23, 1), FineTime(0, 30));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -43,13 +43,12 @@ static void test_time()
   ok1(!(b > a));
 
   /* test factory functions */
-  ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1)) == TimeType(12,1) );
+  ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1))       == TimeType(12,1) );
   ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1+24*60)) == TimeType(12,1) );
   ok1(TimeType::FromMinuteOfDayChecked((int)(12*60+1-24*60)) == TimeType(12,1) );
 
-  ok1(TimeType( TimeStamp(12h) ) == TimeType(12,0) );
-  ok1(TimeType( TimeStamp(12h+1min) ) == TimeType(12,1) );
-  ok1(TimeType( TimeStamp(12h+1s) ) == TimeType(12,0) );
+  ok1(TimeType( TimeStamp(12h) )          == TimeType(12,0) );
+  ok1(TimeType( TimeStamp(12h+1min) )     == TimeType(12,1) );
   ok1(TimeType( TimeStamp(12h+1min+24h) ) == TimeType(12,1) );
   ok1(TimeType( TimeStamp(12h+1min-24h) ) == TimeType(12,1) );
 
@@ -69,6 +68,15 @@ static void test_time()
   ok1(!(b >= a));
   ok1(b < a);
   ok1(!(b > a));
+}
+
+static void test_conversions()
+{
+  ok1( ToFineTime( RoughTime::Invalid() ) == FineTime::Invalid() );
+  ok1( ToFineTime( RoughTime(12,1) )      == FineTime(12,1) );
+
+  ok1( ToRoughTime( FineTime::Invalid() ) == RoughTime::Invalid() );
+  ok1( ToRoughTime( FineTime(12,1) )      == RoughTime(12,1) );
 }
 
 static void test_time_span()
@@ -147,9 +155,11 @@ static void test_rough_time_delta()
 
 int main()
 {
-  plan_tests(85);
+  plan_tests(132);
 
   test_time<RoughTime>();
+  test_time<FineTime>();
+  test_conversions();
   test_time_span();
   test_rough_time_delta();
 

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -71,33 +71,33 @@ static void test_time()
   ok1(!(b > a));
 }
 
-static void test_rough_time_span()
+static void test_time_span()
 {
   RoughTime a(12, 1);
   RoughTime b(11, 59);
 
-  /* test RoughTimeSpan::IsInside() */
-  RoughTimeSpan s = RoughTimeSpan::Invalid();
+  /* test TimeSpan::IsInside() */
+  TimeSpan s = TimeSpan::Invalid();
   ok1(!s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
 
-  s = RoughTimeSpan(RoughTime(12, 0), RoughTime::Invalid());
+  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime::Invalid());
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(!s.IsInside(b));
 
-  s = RoughTimeSpan(RoughTime::Invalid(), RoughTime(12, 0));
+  s = TimeSpan::FromRoughTimes(RoughTime::Invalid(), RoughTime(12, 0));
   ok1(s.IsDefined());
   ok1(!s.IsInside(a));
   ok1(s.IsInside(b));
 
-  s = RoughTimeSpan(RoughTime(12, 0), RoughTime(12, 1));
+  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime(12, 1));
   ok1(s.IsDefined());
   ok1(!s.IsInside(a));
   ok1(!s.IsInside(b));
 
-  s = RoughTimeSpan(RoughTime(12, 0), RoughTime(12, 30));
+  s = TimeSpan::FromRoughTimes(RoughTime(12, 0), RoughTime(12, 30));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(!s.IsInside(b));
@@ -107,21 +107,21 @@ static void test_rough_time_span()
   b = RoughTime(23, 59);
   RoughTime c(22, 0);
   RoughTime d(2, 0);
-  s = RoughTimeSpan(RoughTime(23, 0), RoughTime::Invalid());
+  s = TimeSpan::FromRoughTimes(RoughTime(23, 0), RoughTime::Invalid());
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
   ok1(!s.IsInside(c));
   ok1(s.IsInside(d));
 
-  s = RoughTimeSpan(RoughTime::Invalid(), RoughTime(1, 0));
+  s = TimeSpan::FromRoughTimes(RoughTime::Invalid(), RoughTime(1, 0));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
   ok1(s.IsInside(c));
   ok1(!s.IsInside(d));
 
-  s = RoughTimeSpan(RoughTime(23, 1), RoughTime(0, 30));
+  s = TimeSpan::FromRoughTimes(RoughTime(23, 1), RoughTime(0, 30));
   ok1(s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
@@ -150,7 +150,7 @@ int main()
   plan_tests(85);
 
   test_time<RoughTime>();
-  test_rough_time_span();
+  test_time_span();
   test_rough_time_delta();
 
   return exit_status();

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -84,8 +84,16 @@ static void test_time_span()
   RoughTime a(12, 1);
   RoughTime b(11, 59);
 
+  TimeSpan s = TimeSpan::FromRoughTimes(a,b);
+  ok1( s.GetRoughStart() == a );
+  ok1( s.GetRoughEnd() == b );
+
+  s = TimeSpan(ToFineTime(a), ToFineTime(b));
+  ok1( s.GetRoughStart() == a );
+  ok1( s.GetRoughEnd() == b );
+
   /* test TimeSpan::IsInside() */
-  TimeSpan s = TimeSpan::Invalid();
+  s = TimeSpan::Invalid();
   ok1(!s.IsDefined());
   ok1(s.IsInside(a));
   ok1(s.IsInside(b));
@@ -155,7 +163,7 @@ static void test_rough_time_delta()
 
 int main()
 {
-  plan_tests(132);
+  plan_tests(136);
 
   test_time<RoughTime>();
   test_time<FineTime>();


### PR DESCRIPTION
Ref #1099 - added support for Start Open/Close times represented from a time of day, with seconds resolution.

* The internal representation of times in `OrderedTaskSettings::start_constraints` is upgraded to time of day based on seconds (class `RoughTime` is generalized to support better resolution, keeping all stuff like midnight wraparound logic unmodified).

* When a PEV is launched, the start window is now set precisely. Also fixed a problem where the start window was being calculated from `BrokenDateTime::NowUTC()`, which is based on the system clock and thus can be different from GPS time, which is used for logging and calculations. 

* Infoboxes now show precise time remaining. Other UI (Task Manager) and saving to .tsk drops the seconds, so behavior and file format is unchanged - user can only see and set round-minute times on the task. 
_(There is the minor caveat of setting the start open & close via a PEV and then saving the task, seconds will be truncated. However this use case is not realistic and not worth a change the .tsk file format)_

### Testing done
* Unit tests added/updated.
* Linux: tested general UI input for task values. Launched PEV and checked infobox countdown. Checked midnight wraparound, when start or open times are on the next UTC day.
* Android: with Condor simulator as GPS fix source, tested with system clock different than GPS time, verified start window works as expected.
