### PR TITLE
Revert "NMEAChecksum: initializer list is ambigous on OSx"

### DIFF
--- a/src/Device/Util/NMEAReader.cpp
+++ b/src/Device/Util/NMEAReader.cpp
@@ -50,11 +50,7 @@ PortNMEAReader::GetLine()
 
   /* verify the checksum following the asterisk (two hex digits) */
 
-#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
-  const uint8_t calculated_checksum = NMEAChecksum(start);
-#else
   const uint8_t calculated_checksum = NMEAChecksum({start, asterisk});
-#endif
 
   const char checksum_buffer[3] = { asterisk[1], asterisk[2], 0 };
   char *endptr;

--- a/src/NMEA/Checksum.cpp
+++ b/src/NMEA/Checksum.cpp
@@ -25,11 +25,7 @@ VerifyNMEAChecksum(const char *p) noexcept
     return false;
 
   uint8_t ReadCheckSum = (unsigned char)ReadCheckSum2;
-#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
-  uint8_t CalcCheckSum = NMEAChecksum(p);
-#else
   uint8_t CalcCheckSum = NMEAChecksum({p, asterisk});
-#endif
 
   return CalcCheckSum == ReadCheckSum;
 }
@@ -41,9 +37,5 @@ AppendNMEAChecksum(char *p) noexcept
 
   const std::size_t length = strlen(p);
 
-#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
-  sprintf(p + length, "*%02X", NMEAChecksum(p));
-#else
   sprintf(p + length, "*%02X", NMEAChecksum({p, length}));
-#endif
 }

--- a/src/NMEA/Checksum.hpp
+++ b/src/NMEA/Checksum.hpp
@@ -25,11 +25,7 @@ NMEAChecksum(std::convertible_to<const char *> auto &&_src) noexcept
   if (*p == '$' || *p == '!')
     ++p;
 
-#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
-  while (*p != 0 && *p != '*')
-#else
   while (*p != 0)
-#endif
     checksum ^= static_cast<uint8_t>(*p++);
 
   return checksum;

--- a/test/src/AddChecksum.cpp
+++ b/test/src/AddChecksum.cpp
@@ -26,12 +26,7 @@ int main()
     }
 
     printf("%.*s*%02x\n", (int)(end - buffer), buffer,
-#if defined(__APPLE__) && (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE)
-           // MacOS workaround
-           NMEAChecksum(start));
-#else  // MacOS
            NMEAChecksum({start, end}));
-#endif // MacOS
   }
 
   return 0;


### PR DESCRIPTION
See https://github.com/XCSoar/XCSoar/issues/1365.