### PR TITLE
Airspace/AirspaceVisibilty.cpp: Also check type

### DIFF
--- a/src/Airspace/AirspaceVisibility.cpp
+++ b/src/Airspace/AirspaceVisibility.cpp
@@ -7,10 +7,10 @@
 #include "Renderer/AirspaceRendererSettings.hpp"
 
 bool
-IsAirspaceTypeVisible(const AbstractAirspace &airspace,
+IsAirspaceTypeOrClassVisible(const AbstractAirspace &airspace,
                       const AirspaceRendererSettings &renderer_settings)
 {
-  return renderer_settings.classes[airspace.GetClassOrType()].display;
+  return renderer_settings.classes[airspace.GetClassOrType()].display || renderer_settings.classes[airspace.GetTypeOrClass()].display;
 }
 
 bool
@@ -47,7 +47,7 @@ IsAirspaceAltitudeVisible(const AbstractAirspace &airspace,
 bool
 AirspaceVisibility::operator()(const AbstractAirspace &airspace) const
 {
-  return IsAirspaceTypeVisible(airspace, renderer_settings) &&
+  return IsAirspaceTypeOrClassVisible(airspace, renderer_settings) &&
     IsAirspaceAltitudeVisible(airspace, state,
                               computer_settings, renderer_settings);
 }

--- a/src/Airspace/AirspaceVisibility.hpp
+++ b/src/Airspace/AirspaceVisibility.hpp
@@ -14,7 +14,7 @@ struct AltitudeState;
  */
 [[gnu::pure]]
 bool
-IsAirspaceTypeVisible(const AbstractAirspace &airspace,
+IsAirspaceTypeOrClassVisible(const AbstractAirspace &airspace,
                       const AirspaceRendererSettings &renderer_settings);
 
 /**

--- a/src/CrossSection/AirspaceXSRenderer.cpp
+++ b/src/CrossSection/AirspaceXSRenderer.cpp
@@ -128,7 +128,7 @@ AirspaceIntersectionVisitorSlice::Render(const AbstractAirspace &as) const
   if (intersections.empty())
     return;
 
-  if (!IsAirspaceTypeVisible(as, settings))
+  if (!IsAirspaceTypeOrClassVisible(as, settings))
     return;
 
   PixelRect rcd;


### PR DESCRIPTION
With the extended openair format airspace have at class and type We need to check both of these to know weather or not to draw the airspace

Renamed the boolean to reflect that it now checks both.

closes #1746

