### PR TITLE
List nano downloadable flights in reverse order

### DIFF
--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -229,6 +229,9 @@ Nano::ReadFlightList(Port &port, RecordedFlightList &flight_list,
     requested_tail += nrequest;
     env.SetProgressPosition(requested_tail - 1);
   }
+  if (flight_list.size() > 1) {
+    std::reverse(flight_list.begin(), flight_list.end());
+  }
 
   return true;
 }


### PR DESCRIPTION
XCSoar Version 7.44

Issue #1765

This change will list the nano logger flights in date descending order, newest first and oldest last.

This will make the latest flight to download the default, rather then having to scroll to the bottom of the list to select it.
