### PR TITLE
Allow racing tasks to use the FAI finish height rules for final glide calculations

### DIFF
--- a/src/Engine/Task/Factory/TaskFactoryType.hpp
+++ b/src/Engine/Task/Factory/TaskFactoryType.hpp
@@ -43,5 +43,6 @@ IsFai(TaskFactoryType ftype)
   return ftype == TaskFactoryType::FAI_GENERAL ||
     ftype == TaskFactoryType::FAI_GOAL ||
     ftype == TaskFactoryType::FAI_OR ||
-    ftype == TaskFactoryType::FAI_TRIANGLE;
+    ftype == TaskFactoryType::FAI_TRIANGLE ||
+    ftype == TaskFactoryType::RACING;
 }


### PR DESCRIPTION
Some weglide competitions allow maximum points for a declared task that finishes within 1000 meters below the start height.
This change will facilitate that requirement.
