### PR TITLE
Allow users to select a default setting for "Arm start manually"

### DIFF
--- a/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
@@ -24,6 +24,8 @@ enum ControlIndex {
   spacer_3,
   PEVStartWaitTime,
   PEVStartWindow,
+  spacer_4,
+  ArmStartManually,
 };
 
 class TaskRulesConfigPanel final : public RowFormWidget {
@@ -119,6 +121,13 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
               task_behaviour.ordered_defaults.start_constraints.pev_start_window);
   SetExpertRow(PEVStartWindow);
 
+  AddSpacer();
+  SetExpertRow(spacer_4);
+
+  AddBoolean(_("Arm start manually"),
+             _("Configure whether the start must be armed manually or automatically."),
+             task_behaviour.ordered_defaults.start_constraints.require_arm);
+  SetExpertRow(ArmStartManually);
 }
 
 
@@ -162,6 +171,10 @@ TaskRulesConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValue(PEVStartWindow,
                        ProfileKeys::PEVStartWindow,
                        otb.start_constraints.pev_start_window);
+
+  changed |= SaveValue(ArmStartManually,
+                       ProfileKeys::ArmStartManually,
+                       otb.start_constraints.require_arm);
 
   _changed |= changed;
 

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -52,6 +52,7 @@ TaskPropertiesPanel::RefreshView()
   SetRowVisible(MIN_TIME, aat_types);
   LoadValueDuration(MIN_TIME, p.aat_min_time);
 
+  SetRowVisible(START_REQUIRES_ARM, !fai_start_finish);
   LoadValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
   LoadValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 
@@ -105,8 +106,7 @@ TaskPropertiesPanel::ReadValues()
 
   changed |= SaveValue(MIN_TIME, p.aat_min_time);
 
-  if (SaveValue(START_REQUIRES_ARM, p.start_constraints.require_arm))
-    changed = true;
+  changed |= SaveValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
 
   changed |= SaveValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 

--- a/src/Engine/Task/Factory/AbstractTaskFactory.cpp
+++ b/src/Engine/Task/Factory/AbstractTaskFactory.cpp
@@ -586,7 +586,6 @@ AbstractTaskFactory::GetOrderedTaskSettings() const noexcept
 void
 AbstractTaskFactory::UpdateOrderedTaskSettings(OrderedTaskSettings &to) noexcept
 {
-  to.start_constraints.require_arm = constraints.start_requires_arm;
   to.finish_constraints.fai_finish = constraints.fai_finish;
 }
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -170,6 +170,7 @@ constexpr std::string_view AATMinTime = "AATMinTime";
 constexpr std::string_view AATTimeMargin = "AATTimeMargin";
 constexpr std::string_view PEVStartWaitTime = "PEVStartWaitTime";
 constexpr std::string_view PEVStartWindow = "PEVStartWindow";
+constexpr std::string_view ArmStartManually = "ArmStartManually";
 
 constexpr std::string_view EnableNavBaroAltitude = "EnableNavBaroAltitude";
 

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -48,6 +48,7 @@ Profile::Load(const ProfileMap &map, StartConstraints &constraints)
   map.Get(ProfileKeys::StartMaxSpeed, constraints.max_speed);
   map.Get(ProfileKeys::PEVStartWaitTime, constraints.pev_start_wait_time);
   map.Get(ProfileKeys::PEVStartWindow, constraints.pev_start_window);
+  map.Get(ProfileKeys::ArmStartManually, constraints.require_arm);
 }
 
 void


### PR DESCRIPTION
This update adds a new option "Arm start manually" to the list of default task rules.

It can be set in Config->System->Task Defaults->Task Rules->Arm start manually to either "On" of "Off"

Previously the default setting when creating a new task was "On" for AAT tasks and "Off" for all other task types.