### PR TITLE
Set AAT task type "Arm start manually" default to "Off"

### DIFF
--- a/src/Engine/Task/Factory/AATTaskFactory.cpp
+++ b/src/Engine/Task/Factory/AATTaskFactory.cpp
@@ -10,7 +10,7 @@ static constexpr TaskFactoryConstraints aat_constraints = {
   false,
   false,
   false,
-  true,
+  false,  // Arm start manually
   2, 13,
 };
 


### PR DESCRIPTION
This change makes the "Arm start manually" default consistent across all task types. 