### PR TITLE
increase font size and waypoint landable size

### DIFF
--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -70,7 +70,7 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
 
   AddInteger(_("Text size"),
              nullptr,
-             _T("%d %%"), _T("%d"), 75, 200, 5,
+             _T("%d %%"), _T("%d"), 75, 300, 5,
              settings.scale);
 
   WndProperty *wp_dpi = AddEnum(_("Display Resolution"),

--- a/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
@@ -176,7 +176,7 @@ WaypointDisplayConfigPanel::Prepare(ContainerWindow &parent,
 
   AddInteger(_("Landable size"),
              _("A percentage to select the size landables are displayed on the map."),
-             _T("%u %%"), _T("%u"), 50, 200, 10, settings.landable_rendering_scale);
+             _T("%u %%"), _T("%u"), 50, 300, 10, settings.landable_rendering_scale);
   SetExpertRow(AppLandableRenderingScale);
 
   AddBoolean(_("Scale runway length"),

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -106,7 +106,7 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
   map.Get(ProfileKeys::MenuTimeout, settings.menu_timeout);
 
   map.Get(ProfileKeys::UIScale, settings.scale);
-  if (settings.scale < 50 || settings.scale > 200)
+  if (settings.scale < 50 || settings.scale > 300)
     settings.scale = 100;
 
   map.Get(ProfileKeys::CustomDPI, settings.custom_dpi);


### PR DESCRIPTION
font size and waypoint landable size is scalable up to 300%. Is necessary for some displays with a high resolution at Android boards
