### PR TITLE
macOS: build/{android,targets}.mk: Fixes building for Android on arm64

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -13,7 +13,7 @@ ANDROID_BUILD = $(TARGET_OUTPUT_DIR)/$(XCSOAR_ABI)/build
 ANDROID_BIN = $(TARGET_BIN_DIR)
 
 ifeq ($(HOST_IS_DARWIN),y)
-  ANDROID_SDK ?= $(HOME)/opt/android-sdk-macosx
+  ANDROID_SDK ?= $(HOME)/Library/Android/sdk
 else
   ANDROID_SDK ?= $(HOME)/opt/android-sdk-linux
 endif

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -345,7 +345,12 @@ ifeq ($(TARGET),UNIX)
 endif
 
 ifeq ($(TARGET),ANDROID)
-  ANDROID_NDK ?= $(HOME)/opt/android-ndk-r26d
+  ifeq ($(HOST_IS_DARWIN),y)
+    ANDROID_SDK ?= $(HOME)/Library/Android/sdk
+    ANDROID_NDK ?= $(shell ls -d $(ANDROID_SDK)/ndk/26.* 2>/dev/null | head -n 1)
+  else
+    ANDROID_NDK ?= $(HOME)/opt/android-ndk-r26d
+  endif
 
   ANDROID_SDK_PLATFORM = android-33
   ANDROID_NDK_API = 21
@@ -390,7 +395,7 @@ ifeq ($(TARGET),ANDROID)
   override LIBCXX = y
 
   ifeq ($(HOST_IS_DARWIN),y)
-    ifeq ($(UNAME_M),x86_64)
+    ifneq (,$(filter $(UNAME_M),x86_64 arm64))
       ANDROID_HOST_TAG = darwin-x86_64
     else
       ANDROID_HOST_TAG = darwin-x86


### PR DESCRIPTION
Android SDK paths needed some finetuning (it's almost always under `~/Library/Android/` on macOS) and the `ANDROID_HOST_TAG` was not set correctly for `arm64` machines.