### PR TITLE
PEV Start procedure revamp

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -39,6 +39,7 @@ Version 7.44 - not yet released
   - add head wind component to V GND Infobox #1439
   - add V task leg Infobox #1767
   - PEV start wait/window times now have second accuraccy #1099
+  - PEV start procedure now allows computing a start outside of the window
   - show station names in airspace details dialog
   - show squawk code in airspace details dialog
   - ability to send squawk code from airspace details dialog to transponder

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -177,7 +177,7 @@ see
 see
  & \ref{sec:taskabort}
  & \ref{sec:markers}
- & \ref{sec:markers}
+ & \ref{sec:pilotevent}
  & \ref{sec:waypointdetails}
 \end{tabularx}}
 

--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -419,21 +419,29 @@ mass starts, gaggles and following.}.
 
 \menulabel{\bmenug{Nav 2}\blink\bmenut{Pilot}{Event}}
 
-When pressed, the task start window will be automatically set according to
-configuration defined in Task Rules (See \ref{sec:task-type-racing}): start
+When pressed, XCSoar will internally track the window open and close times, according 
+to configuration defined in Task Rules (See \ref{sec:task-type-racing}): start
 window will open after \emph{PEV start wait time} \config{taskrules} minutes
-and will be open for \emph{PEV start window} minutes.  Also, \emph
-{Pilot Event} will be announced to connected devices, allowing loggers to
+and will be open for \emph{PEV start window} minutes. The start open/close
+countdown will be displayed in the \emph{Start open} and \emph{Start reach} 
+infoboxes. Make sure to have one/both visible to effectively calculate your start.
+
+Also, \emph{Pilot Event} will be announced to connected devices, allowing loggers to
 register it without pilot pressing the physical button on the logger device
 itself. This might be useful when logger is located outside of pilot reach
-(e.g. behind the panel).
+(e.g. behind the panel). It is recommended to check on your device's manual 
+whether it supports external PEV declaration -some older loggers may not-.
 
 In order to start a task when \emph{Pilot Event Start} is used, press the \emph
 {Pilot Event} button, wait for \emph{PEV start wait time} and then cross the
 start line within \emph{PEV start window} minutes.
 
-\tip It may be useful to have \emph{Start open} and/or \emph{Start reach}
- infoboxes visible to effectively use the \emph{PEV Start} procedure.
+\tip Note that the start window created by pressing the \emph{Pilot Event}
+is ``soft'', as it is only informative to the pilot via the infoboxes mentioned above.
+XCSoar will still compute a valid start if one is performed outside of 
+the PEV window -just like it would be scored in a competition-. In contrast,
+the task settings \emph{Start open/close time} in \ref{sec:task-type-racing} define
+a ``hard'' window, outside of which a start will not be computed.
 
 
 \section{Thermals}

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -377,9 +377,9 @@ type allows the pilot to enter the following parameters
   \item [Finish height ref.] This specifies whether the minimum finish height 
     is referenced to ground level of the finish point (``AGL'') or Mean Sea Level (``MSL'')
 
-  \item [PEV start wait time] This specifies an interval in minutes between
-   pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button is
-   pressed and start window opens. If set to 0, the start will open
+  \item [PEV start wait time] This specifies an interval in minutes between the
+   pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button and start 
+   window opens. If set to 0, the start will open
    immediately after \emph{Pilot Event} button is pressed.
 
   \item [PEV start window] This specifies an interval in minutes during which

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -267,9 +267,14 @@ distance according to the configured contest rule set.}
 \ibi{Task progress}{Progress}{Clock-like display of distance remaining along 
 task, showing achieved task points.}
 \ibi{Start open/close countdown}{Start open}{Shows the time left until the start point 
-opens or closes.}
+opens or closes. If the \emph{PEV Start Procedure} (\ref{sec:pilotevent}) is in use, 
+time relative to the PEV window is displayed. Else, the task defined \emph{Start 
+open/close time} (\ref{sec:task-type-racing}) are used. }
 \ibi{Start open/close countdown at reaching}{Start reach}{Shows the time left until the 
-start point opens or closes, compared to the calculated time to reach it.}
+start point opens or closes, compared to the calculated time to reach it. 
+If the \emph{PEV Start Procedure} (\ref{sec:pilotevent}) is in use, 
+time relative to the PEV window is displayed. Else, the task defined \emph{Start 
+open/close time} (\ref{sec:task-type-racing}) are used. }
     
     
 %%%%%%%%%%%

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -563,9 +563,9 @@ rules. \label{conf:taskrules}
   (AGL or MSL) while finishing the task.  Set to 0 for no limit.
 \item[Finish height ref.*]  Reference used for finish min.\ height rule,
   correspondingly to the start rule height reference.
-\item [PEV start wait time*] The default interval in minutes between
- pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button is
- pressed and start window opens. If set to 0, the start will open
+\item [PEV start wait time*] The default interval in minutes between the
+ pilot presses the \emph{Pilot Event} (see \ref{sec:pilotevent}) button and 
+ start window opens. If set to 0, the start will open
  immediately after \emph{Pilot Event} button is pressed.
 \item [PEV start window*] The default interval in minutes during which
  the start window remains open when \emph{Pilot Event} (see \ref

--- a/src/Engine/Task/Ordered/StartConstraints.hpp
+++ b/src/Engine/Task/Ordered/StartConstraints.hpp
@@ -11,7 +11,8 @@ struct TaskStartMargins;
 
 struct StartConstraints {
   /**
-   * The time span during which the start gate is open.
+   * The time span during which a hard start gate is open.
+   * If defined, a valid start can only be made within this window.
    */
   TimeSpan open_time_span;
 

--- a/src/Engine/Task/Stats/CommonStats.cpp
+++ b/src/Engine/Task/Stats/CommonStats.cpp
@@ -4,6 +4,7 @@ void
 CommonStats::ResetTask() noexcept
 {
   start_open_time_span = TimeSpan::Invalid();
+  pev_start_time_span = TimeSpan::Invalid();
   landable_reachable = false;
   TimeUnderStartMaxHeight = TimeStamp::Undefined();
   aat_time_remaining = {};

--- a/src/Engine/Task/Stats/CommonStats.hpp
+++ b/src/Engine/Task/Stats/CommonStats.hpp
@@ -22,8 +22,18 @@ class CommonStats
 public:
   /**
    * A copy of #StartConstraints::open_time_span.
+   * If defined, a valid start can only be made within this window.
    */
   TimeSpan start_open_time_span;
+
+  /**
+   * The start window resulting from the last Pilot Event declared, based on 
+   * the task settings #StartConstraints::pev_start_wait_time and 
+   * #StartConstraints::pev_start_window. 
+   * If defined, it defines a soft start window, which is informative 
+   * to the pilot only and will not be enforced in any way.
+   */
+  TimeSpan pev_start_time_span;
 
   /** Whether the task found landable reachable waypoints (aliases abort) */
   bool landable_reachable;

--- a/src/Engine/Task/TaskManager.cpp
+++ b/src/Engine/Task/TaskManager.cpp
@@ -528,3 +528,9 @@ TaskManager::ResetTask() noexcept
     UpdateCommonStatsTask();
   }
 }
+
+void 
+TaskManager::SetPevStartWindow(const TimeSpan &open_time_span) noexcept
+{
+  common_stats.pev_start_time_span = open_time_span;
+}

--- a/src/Engine/Task/TaskManager.hpp
+++ b/src/Engine/Task/TaskManager.hpp
@@ -418,6 +418,12 @@ public:
 
   void ResetTask() noexcept;
 
+  /**
+   * Updates the start window based on the task StartConstraints.
+   * To be called when PEV has been pressed.
+   */
+  void SetPevStartWindow(const TimeSpan &open_time_span) noexcept;
+
 private:
   TaskType SetMode(const TaskType mode) noexcept;
 

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -835,17 +835,22 @@ void
 UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
-  const auto &calculated = CommonInterface::Calculated();
-  const TaskStats &task_stats = calculated.ordered_task_stats;
+  const TaskStats &task_stats = CommonInterface::Calculated().ordered_task_stats;
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  const TimeSpan &open = common_stats.start_open_time_span;
+  
+  const TimeSpan &task_open_span = common_stats.start_open_time_span;
+  const TimeSpan &pev_open_span = common_stats.pev_start_time_span;
+  
+  // give priority to PEV window
+  const bool have_pev_start = pev_open_span.IsDefined();
+  const TimeSpan &eff_start_window = have_pev_start ? pev_open_span : task_open_span;
 
   /* reset color that may have been set by a previous call */
   data.SetValueColor(0);
 
   if (!basic.time_available || !task_stats.task_valid ||
       common_stats.ordered_summary.active != 0 ||
-      !open.IsDefined()) {
+      !eff_start_window.IsDefined() ) {
     data.SetInvalid();
     return;
   }
@@ -853,12 +858,12 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
   const auto now_s = basic.time;
   const FineTime now{now_s};
 
-  if (open.HasEnded(now)) {
+  if (eff_start_window.HasEnded(now)) {
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
-  } else if (open.HasBegun(now)) {
-    if (open.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(now_s, open.GetEnd());
+  } else if (eff_start_window.HasBegun(now)) {
+    if (eff_start_window.GetEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(now_s, eff_start_window.GetEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -866,7 +871,7 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(now_s, open.GetStart());
+    unsigned seconds = SecondsUntil(now_s, eff_start_window.GetStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));
@@ -877,19 +882,24 @@ void
 UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
-  const auto &calculated = CommonInterface::Calculated();
-  const TaskStats &task_stats = calculated.ordered_task_stats;
+  const TaskStats &task_stats = CommonInterface::Calculated().ordered_task_stats;
   const GlideResult &current_remaining =
     task_stats.current_leg.solution_remaining;
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  const TimeSpan &open = common_stats.start_open_time_span;
+
+  const TimeSpan &task_open_span = common_stats.start_open_time_span;
+  const TimeSpan &pev_open_span = common_stats.pev_start_time_span;
+  
+  // give priority to PEV window
+  const bool have_pev_start = pev_open_span.IsDefined();
+  const TimeSpan &eff_start_window = have_pev_start ? pev_open_span : task_open_span;
 
   /* reset color that may have been set by a previous call */
   data.SetValueColor(0);
 
   if (!basic.time_available || !task_stats.task_valid ||
       common_stats.ordered_summary.active != 0 ||
-      !open.IsDefined() ||
+      !eff_start_window.IsDefined() ||
       !current_remaining.IsOk()) {
     data.SetInvalid();
     return;
@@ -898,12 +908,12 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
   const auto arrival_s = basic.time + current_remaining.time_elapsed;
   const FineTime arrival{arrival_s};
 
-  if (open.HasEnded(arrival)) {
+  if (eff_start_window.HasEnded(arrival)) {
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
-  } else if (open.HasBegun(arrival)) {
-    if (open.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(arrival_s, open.GetEnd());
+  } else if (eff_start_window.HasBegun(arrival)) {
+    if (eff_start_window.GetEnd().IsValid()) {
+      unsigned seconds = SecondsUntil(arrival_s, eff_start_window.GetEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
@@ -911,7 +921,7 @@ UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(arrival_s, open.GetStart());
+    unsigned seconds = SecondsUntil(arrival_s, eff_start_window.GetStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -23,6 +23,9 @@
 
 #include <tchar.h>
 
+static void 
+UpdateStartOpenInfobox(InfoBoxData &data, const TimeStamp &projected_start_time_s) noexcept;
+
 static void
 ShowNextWaypointDetails() noexcept
 {
@@ -834,10 +837,17 @@ SecondsUntil(TimeStamp now, FineTime until) noexcept
 void
 UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 {
+  const auto now_s = CommonInterface::Basic().time;
+  UpdateStartOpenInfobox(data, now_s);
+}
+
+static void
+UpdateStartOpenInfobox(InfoBoxData &data, const TimeStamp &projected_start_time_s ) noexcept
+{
   const NMEAInfo &basic = CommonInterface::Basic();
   const TaskStats &task_stats = CommonInterface::Calculated().ordered_task_stats;
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  
+
   const TimeSpan &task_open_span = common_stats.start_open_time_span;
   const TimeSpan &pev_open_span = common_stats.pev_start_time_span;
   
@@ -855,23 +865,22 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
     return;
   }
 
-  const auto now_s = basic.time;
-  const FineTime now{now_s};
+  const FineTime projected_start_time{projected_start_time_s};
 
-  if (eff_start_window.HasEnded(now)) {
+  if (eff_start_window.HasEnded(projected_start_time)) {
     data.SetValueInvalid();
     data.SetComment(_("Closed"));
-  } else if (eff_start_window.HasBegun(now)) {
+  } else if (eff_start_window.HasBegun(projected_start_time)) {
     if (eff_start_window.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(now_s, eff_start_window.GetEnd());
+      unsigned seconds = SecondsUntil(projected_start_time_s, eff_start_window.GetEnd());
       data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
       data.SetValueColor(3);
     } else
-      data.SetValueInvalid();
+     data.SetValueInvalid();
 
     data.SetComment(_("Open"));
   } else {
-    unsigned seconds = SecondsUntil(now_s, eff_start_window.GetStart());
+    unsigned seconds = SecondsUntil(projected_start_time_s, eff_start_window.GetStart());
     data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
     data.SetValueColor(2);
     data.SetComment(_("Waiting"));
@@ -881,51 +890,18 @@ UpdateInfoBoxStartOpen(InfoBoxData &data) noexcept
 void
 UpdateInfoBoxStartOpenArrival(InfoBoxData &data) noexcept
 {
-  const NMEAInfo &basic = CommonInterface::Basic();
-  const TaskStats &task_stats = CommonInterface::Calculated().ordered_task_stats;
   const GlideResult &current_remaining =
-    task_stats.current_leg.solution_remaining;
-  const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-
-  const TimeSpan &task_open_span = common_stats.start_open_time_span;
-  const TimeSpan &pev_open_span = common_stats.pev_start_time_span;
-  
-  // give priority to PEV window
-  const bool have_pev_start = pev_open_span.IsDefined();
-  const TimeSpan &eff_start_window = have_pev_start ? pev_open_span : task_open_span;
+    CommonInterface::Calculated().ordered_task_stats.current_leg.solution_remaining;
 
   /* reset color that may have been set by a previous call */
-  data.SetValueColor(0);
-
-  if (!basic.time_available || !task_stats.task_valid ||
-      common_stats.ordered_summary.active != 0 ||
-      !eff_start_window.IsDefined() ||
-      !current_remaining.IsOk()) {
+  if (!current_remaining.IsOk() ) {
+    data.SetValueColor(0);
     data.SetInvalid();
     return;
   }
 
-  const auto arrival_s = basic.time + current_remaining.time_elapsed;
-  const FineTime arrival{arrival_s};
-
-  if (eff_start_window.HasEnded(arrival)) {
-    data.SetValueInvalid();
-    data.SetComment(_("Closed"));
-  } else if (eff_start_window.HasBegun(arrival)) {
-    if (eff_start_window.GetEnd().IsValid()) {
-      unsigned seconds = SecondsUntil(arrival_s, eff_start_window.GetEnd());
-      data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
-      data.SetValueColor(3);
-    } else
-      data.SetValueInvalid();
-
-    data.SetComment(_("Open"));
-  } else {
-    unsigned seconds = SecondsUntil(arrival_s, eff_start_window.GetStart());
-    data.FmtValue(_T("{:02}:{:02}"), seconds / 60, seconds % 60);
-    data.SetValueColor(2);
-    data.SetComment(_("Waiting"));
-  }
+  const auto arrival_s = CommonInterface::Basic().time + current_remaining.time_elapsed;
+  UpdateStartOpenInfobox(data, arrival_s);
 }
 
 /*

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -207,7 +207,7 @@ try {
 
   const TimeSpan ts = TimeSpan(new_start, new_end);
 
-  backend_components->protected_task_manager->SetStartTimeSpan(ts);
+  backend_components->protected_task_manager->SetPevStartTimeSpan(ts);
 
   // Log pilot event
   if (backend_components->igc_logger)

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -30,12 +30,10 @@ ProtectedTaskManager::SetGlidePolar(const GlidePolar &glide_polar) noexcept
 }
 
 void
-ProtectedTaskManager::SetStartTimeSpan(const TimeSpan &open_time_span) noexcept
+ProtectedTaskManager::SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept
 {
   ExclusiveLease lease(*this);
-  OrderedTaskSettings otb = lease->GetOrderedTask().GetOrderedTaskSettings();
-  otb.start_constraints.open_time_span = open_time_span;
-  lease->SetOrderedTaskSettings(otb);
+  lease->SetPevStartWindow(open_time_span);
 }
 
 const OrderedTaskSettings

--- a/src/Task/ProtectedTaskManager.hpp
+++ b/src/Task/ProtectedTaskManager.hpp
@@ -51,7 +51,7 @@ public:
   [[gnu::pure]]
   const OrderedTaskSettings GetOrderedTaskSettings() const noexcept;
 
-  void SetStartTimeSpan(const TimeSpan &open_time_span) noexcept;
+  void SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept;
 
   [[gnu::pure]]
   WaypointPtr GetActiveWaypoint() const noexcept;


### PR DESCRIPTION
Ref #1099 - implemented the changes I discussed in the last messages of the thread.

PEV start window is now handled separately from the task Start Open/Close Time setting. This allows computing a start outside of the window if the pilot does so -facing the penalty points-.

Also updated the manual to reflect the changes.

### Testing done
Tested general infoboxes behavior on Linux:  when PEV is pressed with different time settings, when using fixed open/end times, when using both. 