### PR TITLE
No position targets in FLARM radar page

### DIFF
--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -90,10 +90,12 @@ ParsePFLAA(NMEAInputLine &line, TrafficList &flarm, TimeStamp clock, RangeFilter
     return;
   traffic.relative_north = value;
 
-  if (!line.ReadChecked(value))
-    // Relative East is required !
-    return;
-  traffic.relative_east = value;
+  if (line.ReadChecked(value))
+    // Relative East
+    traffic.relative_east = value;
+  else
+    // No position target
+    traffic.relative_east = 0;
 
   if (!line.ReadChecked(value))
     // Relative Altitude is required !

--- a/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
@@ -19,7 +19,8 @@ enum ControlIndex {
   EnableThermalProfile,
   FinalGlideBarDisplayModeControl,
   EnableFinalGlideBarMC0,
-  EnableVarioBar
+  EnableVarioBar,
+  NoPositionTargetDistanceRing
 };
 
 static constexpr StaticEnumChoice final_glide_bar_display_mode_list[] = {
@@ -139,7 +140,7 @@ GaugesConfigPanel::Prepare(ContainerWindow &parent,
              _("Setting this to \"On\" will automatically close the FLARM dialog if there is no traffic. \"Off\" will keep the dialog open even without current traffic."),
              ui_settings.traffic.auto_close_dialog);
   SetExpertRow(AutoCloseFlarmDialog);
-  
+
   AddEnum(_("FLARM display"), _("Choose a location for the FLARM display."),
           flarm_display_location_list,
           (unsigned)ui_settings.traffic.gauge_location);
@@ -176,6 +177,10 @@ GaugesConfigPanel::Prepare(ContainerWindow &parent,
              _("If set to ON the vario bar will be shown"),
              map_settings.vario_bar_enabled);
 
+  AddBoolean(_("No Position Target Distance Ring"),
+             _("This parameter enables or disables the No Position Target Distance Ring in Flarm Radar"),
+             ui_settings.traffic.no_position_target_distance_ring);
+
   SetExpertRow(EnableVarioBar);
 }
 
@@ -194,7 +199,7 @@ GaugesConfigPanel::Save(bool &_changed) noexcept
                        ui_settings.traffic.auto_close_dialog);
 
   if (SaveValueEnum(TAPosition, ProfileKeys::TAPosition,
-                    ui_settings.thermal_assistant_position) || 
+                    ui_settings.thermal_assistant_position) ||
       SaveValueEnum(AppFlarmLocation, ProfileKeys::FlarmLocation,
                     ui_settings.traffic.gauge_location))
     CommonInterface::main_window->ReinitialiseLayout();
@@ -211,6 +216,10 @@ GaugesConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValue(EnableVarioBar, ProfileKeys::EnableVarioBar,
                        map_settings.vario_bar_enabled);
+
+  changed |= SaveValue(NoPositionTargetDistanceRing, ProfileKeys::NoPositionTargetDistanceRing,
+                       ui_settings.traffic.no_position_target_distance_ring);
+
   _changed |= changed;
 
   return true;

--- a/src/Gauge/FlarmTrafficWindow.hpp
+++ b/src/Gauge/FlarmTrafficWindow.hpp
@@ -8,6 +8,8 @@
 #include "FLARM/List.hpp"
 #include "TeamCode/Settings.hpp"
 #include "Math/FastRotation.hpp"
+#include "Renderer/TextInBox.hpp"
+#include "ui/canvas/Pen.hpp"
 
 #include <cstdint>
 
@@ -113,4 +115,18 @@ protected:
 
   /* virtual methods from class PaintWindow */
   void OnPaint(Canvas &canvas) noexcept override;
+
+private:
+  /**
+   * Renders a FLARM target that has no position data.
+   * Draws an optional distance ring, a dot, and an exclamation mark.
+   */
+  void PaintNoPositionTarget(Canvas &canvas,
+                           const PixelPoint &target_point,
+                           const PixelPoint &radar_center,
+                           double scale,
+                           bool small,
+                           const PixelSize &sx,
+                           const Pen *target_pen,
+                           const Color *text_color) const noexcept;
 };

--- a/src/Gauge/TrafficSettings.cpp
+++ b/src/Gauge/TrafficSettings.cpp
@@ -12,4 +12,5 @@ TrafficSettings::SetDefaults() noexcept
   north_up = false;
   radar_zoom = 4;
   gauge_location = GaugeLocation::BOTTOM_RIGHT_AVOID_IB;
+  no_position_target_distance_ring = true;
 }

--- a/src/Gauge/TrafficSettings.hpp
+++ b/src/Gauge/TrafficSettings.hpp
@@ -18,6 +18,9 @@ struct TrafficSettings {
 
   unsigned radar_zoom;
 
+  /** Show distance ring for FLARM targets without position data? */
+  bool no_position_target_distance_ring;
+
   /** Location of Flarm radar */
   enum class GaugeLocation : uint8_t {
     AUTO,

--- a/src/MapWindow/MapWindowTraffic.cpp
+++ b/src/MapWindow/MapWindowTraffic.cpp
@@ -100,16 +100,20 @@ MapWindow::DrawFLARMTraffic(Canvas &canvas,
     if (!traffic.location_available)
       continue;
 
-    DrawFlarmTraffic(canvas, projection, traffic_look, false,
-                     aircraft_pos, traffic);
+  // No position traffic (relative_east=0) does not make sense in map display
+    if (traffic.relative_east)
+      DrawFlarmTraffic(canvas, projection, traffic_look, false,
+                       aircraft_pos, traffic);
   }
 
   if (const auto &fading = GetFadingFlarmTraffic(); !fading.empty()) {
     for (const auto &[id, traffic] : fading) {
       assert(traffic.location_available);
 
-      DrawFlarmTraffic(canvas, projection, traffic_look, true,
-                       aircraft_pos, traffic);
+  // No position traffic (relative_east=0) does not make sense in map display
+      if (traffic.relative_east)
+        DrawFlarmTraffic(canvas, projection, traffic_look, true,
+                         aircraft_pos, traffic);
     }
   }
 }

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -128,6 +128,7 @@ constexpr std::string_view ShowMenuButton = "ShowMenuButton";
 constexpr std::string_view ShowZoomButton = "ShowZoomButton";
 constexpr std::string_view CursorSize = "CursorSize";
 constexpr std::string_view CursorColorsInverted = "CursorColorsInverted";
+constexpr std::string_view NoPositionTargetDistanceRing = "NoPositionTargetDistanceRing";
 
 constexpr std::string_view AppAveNeedle = "AppAveNeedle";
 constexpr std::string_view AppAveThermalNeedle = "AppAveThermalNeedle";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expert UI setting (enabled by default) to show a distance ring for FLARM targets without precise position.

* **Improvements**
  * Radar now renders a distance ring, dot, and exclamation mark for no-position targets for clearer identification.
  * North indicator placement adjusted for improved readability.
  * Map view omits FLARM entries lacking valid position data for a cleaner display.

* **Bug Fixes**
  * Parsing now tolerates missing Relative East values and continues processing traffic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->