### PR TITLE
MapWindow/MapWindowRender.cpp: Draw the detour cost markers after the…

### DIFF
--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -244,13 +244,13 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc) noexcept
   draw_sw.Mark("RenderGlide");
   RenderGlide(canvas);
 
-  draw_sw.Mark("RenderMisc1");
-  // Render weather/terrain max/min values
-  DrawTaskOffTrackIndicator(canvas);
-
   // Render track bearing (projected track ground/air relative)
   draw_sw.Mark("DrawTrackBearing");
   RenderTrackBearing(canvas, aircraft_pos);
+  
+  // Render Detour cost markers
+  draw_sw.Mark("RenderMisc1");
+  DrawTaskOffTrackIndicator(canvas);
 
   draw_sw.Mark("RenderMisc2");
   DrawBestCruiseTrack(canvas, aircraft_pos);


### PR DESCRIPTION
… ground track line is rendered

Rendering the ground track line last covers the detour markers making the numbers unreadable


