### PR TITLE
Improvement to Nano flight download

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -742,6 +742,7 @@ TEST_DRIVER_SOURCES = \
 	$(SRC)/TransponderCode.cpp \
 	$(SRC)/TransponderMode.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(ENGINE_SRC_DIR)/Waypoint/Waypoint.cpp \
 	$(SRC)/Engine/GlideSolvers/GlidePolar.cpp \
 	$(TEST_SRC_DIR)/tap.c \
@@ -945,6 +946,7 @@ DEBUG_REPLAY_SOURCES = \
 	$(SRC)/Engine/Task/Stats/TaskStats.cpp \
 	$(SRC)/Engine/Task/Stats/CommonStats.cpp \
 	$(SRC)/Engine/Task/Stats/ElementStat.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/FakeGeoid.cpp \
@@ -1333,6 +1335,7 @@ RUN_DEVICE_DRIVER_SOURCES = \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(SRC)/TransponderCode.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/FakeGeoid.cpp \
@@ -1355,6 +1358,7 @@ RUN_DECLARE_SOURCES = \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(SRC)/TransponderCode.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/FakeGeoid.cpp \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -29,6 +29,7 @@
 #include "Input/InputQueue.hpp"
 #include "LogFile.hpp"
 #include "Job/Job.hpp"
+#include "Operation/MessageOperationEnvironment.hpp"
 
 #ifdef ANDROID
 #include "java/Closeable.hxx"
@@ -543,14 +544,29 @@ DeviceDescriptor::Reopen(OperationEnvironment &env)
 }
 
 void
-DeviceDescriptor::SlowReopen(OperationEnvironment &env)
+DeviceDescriptor::OnReopenTimer() noexcept
+{
+  assert(InMainThread());
+  
+  // This runs after the 5-second delay
+  try {
+    MessageOperationEnvironment env;
+    Open(env);
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to reopen device after delay");
+  }
+  reconnecting = false;
+}
+
+void
+DeviceDescriptor::SlowReopen()
 {
   assert(InMainThread());
   assert(!IsBorrowed());
 
   Close();
-  env.Sleep(std::chrono::seconds(5));
-  Open(env);
+  // Schedule the Open() call after 5 seconds instead of blocking
+  reopen_timer.Schedule(std::chrono::seconds(5));
 }
 
 void

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -543,6 +543,17 @@ DeviceDescriptor::Reopen(OperationEnvironment &env)
 }
 
 void
+DeviceDescriptor::SlowReopen(OperationEnvironment &env)
+{
+  assert(InMainThread());
+  assert(!IsBorrowed());
+
+  Close();
+  env.Sleep(std::chrono::seconds(5));
+  Open(env);
+}
+
+void
 DeviceDescriptor::AutoReopen(OperationEnvironment &env)
 {
   assert(InMainThread());

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -550,12 +550,12 @@ DeviceDescriptor::OnReopenTimer() noexcept
   
   // This runs after the 5-second delay
   try {
-    MessageOperationEnvironment env;
+    static MessageOperationEnvironment env;
     Open(env);
   } catch (...) {
     LogError(std::current_exception(), "Failed to reopen device after delay");
   }
-  reconnecting = false;
+  waiting_to_call_open = false;
 }
 
 void
@@ -563,6 +563,8 @@ DeviceDescriptor::SlowReopen()
 {
   assert(InMainThread());
   assert(!IsBorrowed());
+
+  waiting_to_call_open = true;
 
   Close();
   // Schedule the Open() call after 5 seconds instead of blocking

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -406,6 +406,8 @@ public:
    */
   void Reopen(OperationEnvironment &env);
 
+  void SlowReopen();
+
   /**
    * Call this periodically to auto-reopen a failed device after a
    * certain delay.

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -20,6 +20,7 @@
 #include "thread/Debug.hpp"
 #include "time/FloatDuration.hxx"
 #include "util/StaticFifoBuffer.hxx"
+#include "ui/event/Timer.hpp"
 
 #include <optional>
 
@@ -77,6 +78,11 @@ class DeviceDescriptor final
   DeviceFactory &factory;
 
   UI::Notify job_finished_notify{[this]{ OnJobFinished(); }};
+
+  /**
+   * Timer for delayed device reopening (used by SlowReopen).
+   */
+  UI::Timer reopen_timer{[this]{ OnReopenTimer(); }};
 
   /**
    * This mutex protects modifications of the attribute "device".  If
@@ -605,6 +611,8 @@ private:
 
   /* virtual methods from PortLineHandler */
   bool LineReceived(const char *line) noexcept override;
+
+  void OnReopenTimer() noexcept;
 
 #ifdef HAVE_INTERNAL_GPS
   /* methods from SensorListener */

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -277,6 +277,8 @@ class DeviceDescriptor final
    */
   bool borrowed = false;
 
+  bool waiting_to_call_open = false;
+
 public:
   DeviceDescriptor(DeviceBlackboard &_blackboard,
                    NMEALogger *_nmea_logger,
@@ -455,6 +457,10 @@ public:
 
   bool IsNMEAOut() const noexcept;
   bool IsManageable() const noexcept;
+
+  bool IsWaitingToCallOpen() const noexcept {
+    return waiting_to_call_open;
+  }
 
   bool IsBorrowed() const noexcept {
     return borrowed;

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -283,8 +283,8 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
   unsigned row_count = 0, i = 1;
 
   while (true) {
-    /* read up to 32 lines at a time */
-    unsigned nrequest = row_count == 0 ? 1 : 32;
+    /* read up to 50 lines at a time */
+    unsigned nrequest = row_count == 0 ? 1 : 50;
     if (row_count > 0) {
       assert(i <= row_count);
       const unsigned remaining = row_count - i + 1;

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -307,7 +307,11 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
       }
 
       TimeoutClock timeout(std::chrono::seconds(row_count == 0 ? 20 : 2)); // using row_count to detect first request
-      const char *line = reader.ExpectLine("PLXVC,FLIGHT,A,", timeout);
+      const char *line = nullptr;
+      try {
+        line = reader.ExpectLine("PLXVC,FLIGHT,A,", timeout);
+      } catch (...) {
+      }
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
         if (request_retry_count > 5)
           return false;

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -322,8 +322,9 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
         LogError(std::current_exception(), "Download failing");
       }
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
-        if (request_retry_count > 5)
-          return false;
+        if (request_retry_count > 5) {
+          throw std::runtime_error("Flight download failed: maximum retries exceeded");
+        }
 
         /* Discard data which might still be in-transit, e.g. buffered
            inside a bluetooth dongle */
@@ -362,13 +363,18 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
   FileOutputStream fos(path);
   BufferedOutputStream bos(fos);
 
-  bool success = DownloadFlightInner(port, flight.internal.lx.nano_filename,
-                                     bos, env);
+  try {
+    bool success = DownloadFlightInner(port, flight.internal.lx.nano_filename,
+                                       bos, env);
 
-  if (success) {
-    bos.Flush();
-    fos.Commit();
+    if (success) {
+      bos.Flush();
+      fos.Commit();
+    }
+
+    return success;
+  } catch (...) {
+    /* propagate exception to DeviceDescriptor for proper error handling */
+    throw;
   }
-
-  return success;
 }

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -19,6 +19,7 @@
 #include "io/FileLineReader.hpp"
 #include "util/StaticString.hxx"
 #include "LogFile.hpp"
+#include "Language/Language.hpp"
 
 #include <algorithm>
 #include <stdlib.h>
@@ -28,6 +29,18 @@
 #include <fmt/format.h>
 
 using std::string_view_literals::operator""sv;
+
+static unsigned
+CountLinesInFile(Path path)
+{
+  FileLineReaderA reader(path);
+  unsigned line_count = 0;
+  while (reader.ReadLine() != nullptr) {
+    line_count++;
+  }
+  // Return next line number to download (1-indexed)
+  return line_count + 1;
+}
 
 static void
 RequestLogbookInfo(Port &port, OperationEnvironment &env)
@@ -284,10 +297,20 @@ HandleFlightLine(const char *_line, BufferedOutputStream &os,
 
 static bool
 DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
-                    OperationEnvironment &env)
+                    OperationEnvironment &env, unsigned *resume_row = nullptr)
 {
   PortNMEAReader reader(port, env);
-  unsigned row_count = 0, i = 1;
+  unsigned row_count = 0, i = (resume_row && *resume_row > 0) ? *resume_row : 1;
+  const unsigned FLUSH_INTERVAL = 500;  // Flush to disk every 500 lines
+  unsigned lines_since_last_flush = 0;
+  bool range_set = false;
+
+  StaticString<60> text;
+  if (resume_row && *resume_row > 1) {
+    text.Format("%s: %s.", _("Resumed Download flight log"),
+                    "LXNAV");
+    env.SetText(text);
+  }
 
   while (true) {
     /* read up to 50 lines at a time */
@@ -302,6 +325,7 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
     const unsigned start = i;
     const unsigned end = start + nrequest;
     unsigned request_retry_count = 0;
+    constexpr unsigned MAX_REQUEST_RETRY_COUNT = 2; // based on testing retrying on this lvl has little to no effect
 
     /* read the requested lines and save to file */
 
@@ -321,8 +345,13 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
         LogFormat("Communication with logger timed out, tries: %u, line: %u", request_retry_count, i);
         LogError(std::current_exception(), "Download failing");
       }
+
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
-        if (request_retry_count > 5) {
+        if (request_retry_count > MAX_REQUEST_RETRY_COUNT) {
+          /* Update resume point before throwing - but note that buffered data
+             may not be flushed to disk yet, so resume will restart from last flush */
+          if (resume_row)
+            *resume_row = i - lines_since_last_flush;  // Safe resume point
           throw std::runtime_error("Flight download failed: maximum retries exceeded");
         }
 
@@ -337,17 +366,47 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
           break;
 
         /* No valid reply received (i==start) - request same range again */
+      } else {
+        /* Line was successfully processed and written to buffer */
+        lines_since_last_flush++;
+
+        /* Periodic flush: write buffered data to disk */
+        if (lines_since_last_flush >= FLUSH_INTERVAL) {
+          try {
+            os.Flush();
+            /* Only update resume_row after successful flush to disk */
+            if (resume_row)
+              *resume_row = i;
+            lines_since_last_flush = 0;
+          } catch (...) {
+            /* If flush fails, keep resume_row at previous safe point */
+            LogError(std::current_exception(), "Failed to flush data to disk");
+            throw;
+          }
+        }
       }
     }
 
-    if (i > row_count)
+    if (i > row_count) {
+      /* Download complete - perform final flush */
+      try {
+        os.Flush();
+        if (resume_row)
+          *resume_row = i;
+      } catch (...) {
+        LogError(std::current_exception(), "Failed to flush final data to disk");
+        throw;
+      }
       /* finished successfully */
       return true;
+    }
 
-    if (start == 1)
+    if (!range_set){
       /* configure the range in the first iteration, now that we know
          the length of the file */
       env.SetProgressRange(row_count);
+      range_set = true;
+    }
 
     env.SetProgressPosition(i - 1);
   }
@@ -360,21 +419,66 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
   port.StopRxThread();
   port.FullFlush(env, std::chrono::milliseconds(200), std::chrono::seconds(2));
 
-  FileOutputStream fos(path);
-  BufferedOutputStream bos(fos);
+  const char *filename = flight.internal.lx.nano_filename;
+  /*
+  LXNANO filename length limit nano_filename uses a size 16 buffer
+  but actual are only 12 characters long and i do not know if it is /0 terminated
+  so to be safe we limit to 12 characters since we want to have predictable filenames
+  */ 
+  constexpr int NANO_FILENAME_LEN = 12; 
 
+  char partial_filename[64];
+  snprintf(partial_filename,
+           sizeof(partial_filename),
+           "%.*s.partial",
+           NANO_FILENAME_LEN,
+           filename);
+
+  
+  const auto partial_path = AllocatedPath::Build(path.GetParent(), partial_filename);
+
+  // Check if partial file exists and count lines to determine resume point
+  unsigned calculated_resume_row = 1;
+  if (File::Exists(partial_path)) {
+    try {
+      // Count lines in existing partial file
+      calculated_resume_row = CountLinesInFile(partial_path);
+      if (calculated_resume_row > 1) {
+        LogFormat("Resuming download from line %u", calculated_resume_row);
+      }
+    } catch (...) {
+      LogError(std::current_exception(), "Failed to count lines in partial file, deleting it for clean fresh download.");
+      // If we can't count, delete partial and start fresh
+      File::Delete(partial_path);
+      calculated_resume_row = 1;
+    }
+  }
+
+  // Open file in appropriate mode
+  FileOutputStream fos(partial_path, 
+                      calculated_resume_row > 1 
+                        ? FileOutputStream::Mode::APPEND_OR_CREATE
+                        : FileOutputStream::Mode::CREATE);
+  BufferedOutputStream bos(fos);
   try {
-    bool success = DownloadFlightInner(port, flight.internal.lx.nano_filename,
-                                       bos, env);
+    bool success = DownloadFlightInner(port, filename,
+                                      bos, env, &calculated_resume_row);
 
     if (success) {
       bos.Flush();
       fos.Commit();
-    }
-
-    return success;
+      LogFormat("Download complete, renaming to final filename");
+      File::Rename(partial_path, path);
+      return true;
+    } 
   } catch (...) {
-    /* propagate exception to DeviceDescriptor for proper error handling */
+    try {
+        bos.Flush();
+        fos.Commit();
+      } catch (...) {
+        LogFormat("Failed to flush partial data to disk");
+      }
     throw;
   }
+  return false; //never hapens but compiler does not know DownloadFlightInner throws on failure
 }

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -14,9 +14,16 @@
 #include "NMEA/InputLine.hpp"
 #include "util/SpanCast.hxx"
 #include "util/StringCompare.hxx"
+#include "system/FileUtil.hpp"
+#include "util/TextFile.hxx"
+#include "io/FileLineReader.hpp"
+#include "util/StaticString.hxx"
+#include "LogFile.hpp"
 
 #include <algorithm>
 #include <stdlib.h>
+#include <fstream>
+#include <exception>
 
 #include <fmt/format.h>
 
@@ -311,6 +318,8 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
       try {
         line = reader.ExpectLine("PLXVC,FLIGHT,A,", timeout);
       } catch (...) {
+        LogFormat("Communication with logger timed out, tries: %u, line: %u", request_retry_count, i);
+        LogError(std::current_exception(), "Download failing");
       }
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
         if (request_retry_count > 5)

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -344,6 +344,7 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
                      Path path, OperationEnvironment &env)
 {
   port.StopRxThread();
+  port.FullFlush(env, std::chrono::milliseconds(200), std::chrono::seconds(2));
 
   FileOutputStream fos(path);
   BufferedOutputStream bos(fos);

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -306,7 +306,7 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
         request_retry_count++;
       }
 
-      TimeoutClock timeout(std::chrono::seconds(2));
+      TimeoutClock timeout(std::chrono::seconds(row_count == 0 ? 20 : 2)); // using row_count to detect first request
       const char *line = reader.ExpectLine("PLXVC,FLIGHT,A,", timeout);
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
         if (request_retry_count > 5)

--- a/src/Device/Driver/LX/NanoLogger.cpp
+++ b/src/Device/Driver/LX/NanoLogger.cpp
@@ -6,6 +6,7 @@
 #include "Device/RecordedFlight.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "Device/Util/NMEAReader.hpp"
+#include "Operation/Cancelled.hpp"
 #include "Operation/Operation.hpp"
 #include "system/Path.hpp"
 #include "io/BufferedOutputStream.hxx"
@@ -307,8 +308,8 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
 
   StaticString<60> text;
   if (resume_row && *resume_row > 1) {
-    text.Format("%s: %s.", _("Resumed Download flight log"),
-                    "LXNAV");
+    text.Format("%s: %s.", _("Resuming flight log download"),
+                "LXNAV");
     env.SetText(text);
   }
 
@@ -341,9 +342,12 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
       const char *line = nullptr;
       try {
         line = reader.ExpectLine("PLXVC,FLIGHT,A,", timeout);
+      } catch (const OperationCancelled &) {
+        throw;
       } catch (...) {
-        LogFormat("Communication with logger timed out, tries: %u, line: %u", request_retry_count, i);
-        LogError(std::current_exception(), "Download failing");
+        LogFormat("NanoLogger: communication with logger timed out,"
+                  " tries: %u, line: %u", request_retry_count, i);
+        LogError(std::current_exception(), "NanoLogger: download failing");
       }
 
       if (line == nullptr || !HandleFlightLine(line, os, i, row_count)) {
@@ -380,7 +384,8 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
             lines_since_last_flush = 0;
           } catch (...) {
             /* If flush fails, keep resume_row at previous safe point */
-            LogError(std::current_exception(), "Failed to flush data to disk");
+            LogError(std::current_exception(),
+                     "NanoLogger: failed to flush data to disk");
             throw;
           }
         }
@@ -394,7 +399,8 @@ DownloadFlightInner(Port &port, const char *filename, BufferedOutputStream &os,
         if (resume_row)
           *resume_row = i;
       } catch (...) {
-        LogError(std::current_exception(), "Failed to flush final data to disk");
+        LogError(std::current_exception(),
+                 "NanoLogger: failed to flush final data to disk");
         throw;
       }
       /* finished successfully */
@@ -444,10 +450,13 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
       // Count lines in existing partial file
       calculated_resume_row = CountLinesInFile(partial_path);
       if (calculated_resume_row > 1) {
-        LogFormat("Resuming download from line %u", calculated_resume_row);
+        LogFormat("NanoLogger: resuming download from line %u",
+                  calculated_resume_row);
       }
     } catch (...) {
-      LogError(std::current_exception(), "Failed to count lines in partial file, deleting it for clean fresh download.");
+      LogError(std::current_exception(),
+               "NanoLogger: failed to count lines in partial file,"
+               " deleting it for clean fresh download.");
       // If we can't count, delete partial and start fresh
       File::Delete(partial_path);
       calculated_resume_row = 1;
@@ -467,8 +476,12 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
     if (success) {
       bos.Flush();
       fos.Commit();
-      LogFormat("Download complete, renaming to final filename");
-      File::Rename(partial_path, path);
+      LogFormat("NanoLogger: download complete, renaming to final filename");
+      if (!File::Rename(partial_path, path)) {
+        LogFormat("NanoLogger: failed to rename partial flight log to final"
+                  " filename");
+        return false;
+      }
       return true;
     } 
   } catch (...) {
@@ -476,7 +489,7 @@ Nano::DownloadFlight(Port &port, const RecordedFlightInfo &flight,
         bos.Flush();
         fos.Commit();
       } catch (...) {
-        LogFormat("Failed to flush partial data to disk");
+        LogFormat("NanoLogger: failed to flush partial data to disk");
       }
     throw;
   }

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -564,11 +564,8 @@ DeviceListWidget::ReconnectCurrent()
     return;
   }
 
-  /* this OperationEnvironment instance must be persistent, because
-     DeviceDescriptor::Open() is asynchronous */
-  static MessageOperationEnvironment env;
   device.ResetFailureCounter();
-  device.SlowReopen(env);
+  device.SlowReopen();
 }
 
 inline void

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -350,7 +350,8 @@ DeviceListWidget::UpdateButtons()
   } else {
     const DeviceDescriptor &device = (*devices)[current];
 
-    reconnect_button->SetEnabled(!device.GetConfig().IsDisabled());
+    reconnect_button->SetEnabled(!device.GetConfig().IsDisabled() && 
+                                 !device.IsWaitingToCallOpen());
     flight_button->SetEnabled(device.IsLogger());
     manage_button->SetEnabled(device.IsManageable());
     monitor_button->SetEnabled(device.GetConfig().UsesPort());

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -568,7 +568,7 @@ DeviceListWidget::ReconnectCurrent()
      DeviceDescriptor::Open() is asynchronous */
   static MessageOperationEnvironment env;
   device.ResetFailureCounter();
-  device.Reopen(env);
+  device.SlowReopen(env);
 }
 
 inline void

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -299,7 +299,7 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
       case TriStateJobResult::ERROR:
         ShowMessageBox(_("Failed to download flight."),
                        _("Download flight"), MB_OK | MB_ICONERROR);
-        continue;
+        return;
 
       case TriStateJobResult::CANCELLED:
         continue;
@@ -310,7 +310,7 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
       ShowError(_("Failed to download flight."),
                 std::current_exception(),
                 _("Download flight"));
-      continue;
+      return;
     }
 
     /* read the IGC header and build the final IGC file name with it */


### PR DESCRIPTION
Closes #1252

- [x] General improvements
- [x] Fix first download attempt due to longer lookup
- [x] Slow down reconnect such that it actually works
- [x] Store download progress in uniek file so we can resume failed downloads
- [x] Update splash screen to show we resumed download
- [x] Exit flight list after failed download (since comm is down with device need to go to device list to reconnect)
- [x] Clean up xcsoar log entries
- [ ] Clean up commit history, can still merge the three SlowReconnect commits to one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flight downloads resume from partial files, show resume/progress messages, and finalize partial files on success.
  * Devices gain a delayed reconnect flow; reconnect UI disables while a reopen is pending.

* **Bug Fixes**
  * More resilient flight downloads: larger per-request batches, periodic flushes, safer retry/timeout handling, and early exit on fatal download errors.

* **Tests**
  * Added fake log inputs to test and replay suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->