### PR TITLE
Device/Driver/FLARM: don't display error message when there is no error

### DIFF
--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -28,7 +28,8 @@ ParsePFLAE(NMEAInputLine &line, FlarmError &error, TimeStamp clock) noexcept
   StringFormatUnsafe(buffer, _T("%s - %s"),
                      FlarmError::ToString(error.severity),
                      FlarmError::ToString(error.code));
-  Message::AddMessage(_T("FLARM: "), buffer);
+  if (error.severity != FlarmError::Severity::NO_ERROR)
+    Message::AddMessage(_T("FLARM: "), buffer);
 
   error.available.Update(clock);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary error messages from being displayed when there is no error detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->