### PR TITLE
Engine/Task: sort abort task WPs by arrival altitude not arrival time

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -70,6 +70,9 @@ Version 7.44 - not yet released
   - LS8-15m: default polar, set to values according to flight manual
 * Weglide:
   - add button under config menu to tigger IGC upload
+* Task:
+  - Reachable abort task landable waypoints are now sorted by arrival altitude
+    instead of arrival time.
 
 Version 7.43 - 2024-08-12
 * calculations


### PR DESCRIPTION
This changes the sorting of reachable abort task waypoints: to sorting by arrival ALTITUDE instead of by arrival TIME. Wind and differences in waypoint elevations can make it such that the waypoint with the earliest arrival TIME isn’t necessarily the waypoint with the highest arrival ALTITUDE. I believe the intent – and what’s best – is for the reachable landable waypoint with the highest arrival ALTITUDE to be considered best. UNreachable waypoints are still sorted by arrival TIME, which rightfully takes into account the time it will take to gain the needed altitude and the downwind drift that will occur while climbing (circling in a thermal). This change affects the “alternates” list, too. It doesn’t affect the ultimate sorting within the “alternates” list, but it changes it so that the selection of which reachable waypoints make it into this list is based on arrival ALTITUDE instead of arrival TIME.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reachable abort-task landable waypoints are now prioritized by arrival altitude; unreachable landable waypoints remain sorted by arrival time. Reachable and unreachable scans are processed separately for clearer results.

* **Documentation**
  * Clarified documentation describing the new sorting and scan behavior for abort-task waypoints and how results are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->