### PR TITLE
InfoBoxes/Content: make predict wind drift affect home alt diff IB

### DIFF
--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -65,7 +65,8 @@ UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept
                      glide_state);
 
   // Display altitude difference and distance.
-  data.SetValueFromArrival(result.pure_glide_altitude_difference);
+  data.SetValueFromArrival(result.
+                           SelectAltitudeDifference(settings.task.glide));
   data.SetCommentFromDistance(common_stats.vector_home.distance);
 }
 


### PR DESCRIPTION
Make the "Predict wind drift" setting affect the new Home Altitude Difference infobox the same way it affects the similar "Next" and "Final" altitude difference infoboxes. When this setting is "On" and the altitude difference is negative (i.e., more altitude is needed), the displayed value will now reflect drifting with the wind while climbing to gain the needed altitude. This is to be consistent with the behavior of the existing similar infoboxes.