### PR TITLE
manual: arrival height and glide ratio in WP labels

### DIFF
--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -129,13 +129,14 @@ position on the map (presuming a touch-screen).
 
 
 \section{Waypoints}\label{sec:waypoint-schemes}
-Waypoints are displayed with different symbols depending on the
+Waypoints are displayed with different symbols and different options for
+waypoint label content depending on the
 waypoint type; the major distinction being landable and non-landable
 waypoints.
 
 \subsection*{Landables}
-The waypoint symbols are drawn as shown below. There are three icon sets for
-landable waypoints. \config{waypointicons}
+Landable waypoint symbols are drawn as shown below. There are three icon sets
+available for landable waypoints. \config{waypointicons}
 
 \begin{tabular}{c|ccc|ccc|}
 Icon set 
@@ -178,9 +179,9 @@ reach, but it is not possible to approach them directly. E.g.\ a mountain prohib
 Waypoints are optionally labelled according to one of several
 abbreviation schemes \config{labels} and visibility.
 
-On top of this landable waypoints can be displayed in more detail. If
-`\emph{Detailed landables}' is switched on you get additional information
-encoded in the appearance of it's icon. 
+On top of this, landable waypoints can be displayed in more detail. If
+`\emph{Detailed landables}' is switched on, you get additional information
+encoded in the appearance of its icon.
 \begin{enumerate}
 \item  Landable fields get a square-shaped icon despite what is shown in the table.
   The square is drawn like a diamond standing on one corner. Airfields stay with the 
@@ -191,38 +192,72 @@ encoded in the appearance of it's icon.
   include this information.  
 \end{enumerate}
 
-\subsection*{Landables in Reach}
-Next to landables an estimated arrival height
-\emph{above the arrival safety height of reachable landable} points is
-displayed next to the waypoint. This feature is one of the most powerful out 
-of XCSoar's capabilities. The arrival height is calculated highly 
-configurable by XCSoar's \emph{glide computer} with parameters taken into 
-account being glider performance (polar), MacCready setting, wind, terrain 
-clearance, and --- obviously --- safety heights' values.
-With all of it being 
-configurable, there is enough room for failure, so please:
-Unless you will have fully understood the glide computer's concepts, you 
+\subsection*{Extra Data in Landables Labels}
+In XCSoar's default configuration, estimated arrival height is shown in the labels
+next to symbols for reachable landable waypoints.
+This is one of XCSoar's most powerful features.
+The displayed arrival height is the arrival height above the
+configured safety 'Arrival height' \config{safetyarrival} (a user setting on
+the 'Glide Computer / Safety Factors' configuration page).
+The arrival height calculation takes several things into account, including
+glider performance (polar), MacCready setting (MC), and wind.
+Given all the user-configurable options that go into this calculation, unless you fully
+understand the glide computer's concepts, it's recommended that you
 \warning
-better stay with XCSoar's pre-configuration (and in no way judge readings as 
-heavenly approved).
-It is up to the pilot to always interpret readings and watch values trending 
+use XCSoar's default configuration. Even then, don't assume
+these calculations are perfect!
+The pilot should always interpret and understand the values shown and watch their trends
 over time.
 
-However, having set up the glide computer following
-Chapter~\ref{cha:glide} the \emph{display} of estimated reach heights, drawn beside 
-landables in reach may take into account terrain or not or display both.
 \config{arrivalheight}
+The 'Arrival height' setting on the 'Map Display / Waypoints' configuration page
+controls the display of this arrival height and gives other options (e.g., none,
+arrival height that accounts for any needed detours around terrain, required glide ratio,
+and certain combinations of these options).
 
-Another option is to display the required glide ratio next to a landable in 
-reach. This calculation is simply derived by the glider's actual distance to 
-landables divided by the height difference between actual altitude and 
-landable's altitude.  Again, the safety height is added to the landable's 
-height, but nothing else taken into account: no wind, no polar, no MacCready 
-settings, just geometry. The concept of required glide ratios is a widely 
-discussed concept, said as to be a very robust one.
+The displayed glide ratio to a waypoint is simply the glider's distance
+from the waypoint divided by how high the glider is above the minimum desired
+arrival height, which is the waypoint elevation plus the
+the configured safety 'Arrival height'.
+Nothing else is taken into account - no polar, no MacCready
+setting, no wind - just simple geometry.
 
-\tip Keep in mind a strong relationship of displays of \emph{reach} and 
-settings in the glide computer.
+In the default configuration, XCSoar only shows this extra data (arrival
+height, in the default configuration) for \emph{reachable} waypoints;
+but if a glide ratio option is chosen,
+glide ratio will be shown even for \emph{un}reachable waypoints. Also, if a waypoint
+file is configured as the 'Watched waypoints' file (selected on the
+\config{watched-wps}
+'Site Files / Site Files' configuration page),
+even arrival height
+will be displayed for unreachable waypoints
+(if an 'Arrival height' option including arrival height is selected).
+
+Which is better, arrival height or glide ratio? This is a common topic of
+discussion among glider pilots. Glide ratio is a more trustworthy value, since
+it's calculated based on simpler, more trustworthy values; but arrival height
+more precisely tells you what you really want to know: how high you'll be
+when you get there. Also, you don't have to watch arrival height as much to
+look for a trend. With glide ratio, you often need to watch for the trend to see
+whether you'll make it. Since wind causes your achieved glide ratio relative to the
+ground to vary with wind speed, wind direction, and flight direction; it's tough
+to know at any given time what glide ratio relative to the ground you can
+expect to \emph{achieve}. Maybe you're
+headed to a landing place where you'd really
+like to arrive higher than your configured safety 'Arrival height'. If all you see is
+glide ratio, the most you can know is simply whether you'll arrive \emph{above} or
+\emph{below}
+your configured safety 'Arrival height' - but not \emph{by how much}. In another
+scenario, maybe all you see is arrival
+height and it's positive but decreasing slowly as you fly toward the landing
+place. It would be difficult to
+figure out whether it's trending downward too quickly for a safe arrival.
+With glide ratio, though, you could much more easily answer this question.
+If glide ratio is holding steady or trending down (i.e., to a steeper glide),
+it looks like you'll make it. More could be said on this subject, but since
+there are cases when glide ratio is better
+and cases when arrival height is better, maybe showing \emph{both} is the best
+option... and is an option XCSoar offers!
 
 \subsection*{Non-Landables}
 As far as your waypoint file contains information on the nature of the 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -76,7 +76,7 @@ all of the parameters marked with an asterisk are only visible in
 expert user level. 
 
 %%%%%%%%%%%%%%%%%%
-\section{Site Files / Site Files}
+\section{Site Files / Site Files}\label{sec:site-files}
 The dialogue specifies most of the important files that must be
 configured when flying at a new site.
 
@@ -90,11 +90,12 @@ configured when flying at a new site.
   from the map file (if available).
 \item[More waypoints*]  Secondary waypoints file.  This may be used to add 
   waypoints for a competition.
-\item[Watched waypoints*]  Waypoint file containing special waypoints for 
-  which additional computations   like calculation of arrival height in map 
-  display always takes place. Useful for waypoints   like known reliable 
-  thermal sources (e.g.\ powerplants) or mountain passes.
-\item[Airspaces]  List of active airspace files that can be selected and used simultaneously.  If left blank,
+\item[Watched waypoints*]  \label{conf:watched-wps} Waypoint file containing
+  waypoints for which arrival height is always displayed in map labels, even
+  when unreachable.  Useful for waypoints like known reliable thermal sources
+  (e.g., powerplants) or mountain passes.
+\item[Airspaces]  List of active airspace files that can be selected and used
+  simultaneously.  If left blank,
   airspaces are loaded from the map file (if available).
 \item[Waypoint details*]  The airfields file may contain extracts from
   Enroute Supplements or other contributed information about individual airfields.
@@ -212,7 +213,7 @@ This page provides options relating to screen elements overlayed to the map disp
 %%%%%%%%%%%%%%%%%%
 \section{Map Display / Waypoints}\label{sec:waypoint-display}
 
-This page provides options relating to the map display.
+This page provides options for how waypoints are displayed on the map.
 
 \begin{description}
 \item[Label format]  This setting \label{conf:labels} determines the label format 
@@ -224,15 +225,47 @@ This page provides options relating to the map display.
   {\bf First 3 letters}: The first 3 letters of the waypoint name are displayed. \\
   {\bf First 5 letters}: The first 5 letters of the waypoint name are displayed. \\
   {\bf None}: No name is displayed with the waypoint.
-\item[Arrival height*] \label{conf:arrivalheight} This enables the arrival height info shown additionally 
-  for landables. \\
-  {\bf None}: No arrival height is displayed. \\
-  {\bf Straight glide}: Straight glide arrival height (no terrain is considered). \\
-  {\bf Terrain avoidance glide}: Arrival height considering terrain avoidance. \\
-  {\bf Straight \& terrain glide}: Both arrival heights are
-  displayed. \\
-  {\bf Required glide ratio}: Show the glide ratio over ground that is
-  required to reach the waypoint.
+
+\item[Arrival height*] \label{conf:arrivalheight} This setting allows arrival height
+and/or required glide ratio to also be shown in labels for landable waypoints. See Section~\ref{sec:waypoint-schemes} for more information.\\
+  {\bf None}: Neither arrival height nor required glide ratio is displayed. \\
+  {\bf Straight glide}: Straight glide arrival height (no terrain is considered). (default option) \\
+  {\bf Terrain avoidance glide}: Arrival height considering any detour needed to avoid terrain. \\
+  {\bf Straight \& terrain glide}: Both arrival heights. \\
+  {\bf Required glide ratio}: Glide ratio over the ground required to reach the waypoint. \\
+  {\bf Required GR \& terrain glide}: Both required glide ratio and terrain avoidance glide arrival height.
+
+  For any option including terrain avoidance glide arrival height, the 'Reach
+  mode' setting (on the 'Glide Computer / Route' configuration page,
+  ~\ref{sec:glide-comp-route}) must be set to 'Turning'.
+
+  Glide ratio will be shown whenever the aircraft is higher than the waypoint
+  regardless of how shallow the glide is and
+  regardless of which configured waypoint file contains the waypoint. Negative
+  straight glide arrival heights, however, will only be shown for
+  waypoints in the 'Watched waypoints' file (selected on the
+  'Site Files / Site Files' configuration page, \ref{sec:site-files}). Negative
+  \emph{terrain avoidance} arrival heights will never be shown for any waypoints.
+
+  \warning
+  Also, if the 'Straight \& terrain glide' option is selected and only one
+  arrival height (a positive one) is shown for a waypoint (e.g.,
+  'Moontown:100m'), either no detour around terrain is needed or there's
+  interfering terrain and no possible detour will get you to the waypoint at
+  an acceptable height (the configured safety 'Arrival height'
+  (\ref{sec:safety-factors}) above the ground at the waypoint). These are two
+  \emph{very different situations} safety-wise!
+  Use other clues, like the reach line or the waypoint
+  appearance (e.g., color), to determine which is the case in this scenario.
+  Both arrival altitudes will be shown only if there's a detour that
+  will get you there at an acceptable height but a direct route is blocked
+  by terrain.
+  For example, 'Moontown:200/50m' means (1) you could reach Moontown 200m above the
+  minimum acceptable height if not for terrain that's in your way but (2) there's a detour
+  that will get you there 50m above the minimum acceptable height. So in this case,
+  you must detour, and the detour will cost you 150m (compared to if there were
+  no terrain in your way).
+
 \item[Label style*]  Labels for landables can be shown on a rounded rectangle with 
   white background, or with outlined letters.
 \item[Waypoint label visibility*]  \label{conf:labelvisibility} Controls which waypoints 
@@ -351,12 +384,12 @@ The filter function is described in Section~\ref{sec:airspace-filter}.
 
 
 %%%%%%%%%%%%%%%%%%
-\section{Glide Computer / Safety Factors}
+\section{Glide Computer / Safety Factors}\label{sec:safety-factors}
 
 This page allows the safety heights and behaviour for the alternates mode to be defined.
 
 \begin{description}
-\item[Arrival height]  The height above terrain that the glider
+\item[Arrival height]  \label{conf:safetyarrival} The height above terrain that the glider
   should arrive at for a safe landing.
 \item[Terrain height]  \label{conf:safetyterrain} The height above terrain that 
   the glider must clear during final glide. \\
@@ -456,7 +489,7 @@ This page sets the base for wind computations.
 
 
 %%%%%%%%%%%%%%%%%%
-\section{Glide Computer / Route}
+\section{Glide Computer / Route}\label{sec:glide-comp-route}
 
 This page allows control over glide reach calculations and route
 optimisations.


### PR DESCRIPTION
Made the manual more complete, correct, and clear regarding the options for showing arrival height and/or glide ratio in landable waypoint labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified waypoint display: distinct landable vs non-landable symbols, three landable icon sets, and optional detailed landable icons.
  * Reworked Arrival height and glide ratio guidance: multiple display modes, default behaviors, reach/unreachable rules, and display controls with safety notes and examples.
  * Documented Watched waypoints always showing arrival height.
  * Added labeled sections for Site Files, Safety Factors, and Glide Computer/Route with new configuration items and cross-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->