### PR TITLE
Fix for custom DPI value not being applied.

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -219,7 +219,7 @@ MainWindow::InitialiseConfigured()
 {
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 
-  if ((ui_settings.scale != 100) || (ui_settings.info_boxes.scale_title_font != 100))
+  if ((ui_settings.scale != 100) || (ui_settings.info_boxes.scale_title_font != 100) || (ui_settings.custom_dpi != 0))
     /* call Initialise() again to reload fonts with the new scale */
     Initialise();
 


### PR DESCRIPTION
Check on custom DPI value added to the condition for main window re-initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fonts now refresh immediately when a custom DPI value is applied, ensuring consistent sizing.
  * UI reinitializes font rendering on DPI changes, complementing existing scaling options.
  * Improves readability and visual consistency on high-DPI displays by updating both general and title fonts after changing custom DPI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->