### PR TITLE
Renderer: make predict wind drift setting affect waypoint labels

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,9 @@ Version 7.44 - not yet released
   - remove FFVV NetCoupe
   - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
   - update OLC League calculation to latest ruleset
+  - Make the “Predict wind drift” setting affect arrival altitudes shown in
+    waypoint labels on the map – as it affects arrival altitudes shown
+    everywhere else.
 * tracking
   - xcsoar-cloud-service: rebuild service, new domain cloud.xcsoar.org
 * data files


### PR DESCRIPTION
This change makes the "Predict wind drift" setting affect arrival altitudes shown in waypoint labels on the map - as it affects arrival altitudes shown everywhere else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map waypoint labels now respect the “Predict wind drift” setting, matching arrival-altitude values used elsewhere for improved consistency and accuracy.
  * Recalculation of arrival altitudes is now more selective, reducing unnecessary updates.

* **Documentation**
  * Added a Version 7.44 release note describing the updated arrival-altitude behavior with wind drift prediction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->