### PR TITLE
manual: tweaks to description of 'Predict wind drift' setting

### DIFF
--- a/doc/manual/en/ch05_glide_computer.tex
+++ b/doc/manual/en/ch05_glide_computer.tex
@@ -480,15 +480,8 @@ bar is coloured amber.
 \multicolumn{2}{l}{A bar beyond this scale is indicated by a chopped-off tip.}
 \end{tabular}
 \end{center}
-\tip{}
-At this point it must also be mentioned, that the indicated height below the glide
-path is not just a plain difference of glide path and current altitude. Depending 
-on the setting `predict wind drift' (On) the `Below' indicator 
-shows the required height to gain by thermalling. \config{predict-drift}
-The required height might be quite a bit more with headwind, as well as a bit less
-with tailwind. 
-Otherwise (`predict wind drift' set to Off), it is just the plain
-altitude difference.
+The meaning of the height shown is affected by
+the 'Predict wind drift' setting (see Section~\ref{conf:predict-drift}).
 
 
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -428,8 +428,15 @@ This page allows glide computer algorithms to be configured.
   15 seconds. Lower values will give as a result pretty much the same as GR Instant, 
   while higher values will look like GR Cruise. Other commercial instruments and 
   software use 2 minutes.
-\item[Predict wind drift*]  \label{conf:predict-drift}Account for wind drift for the predicted circling 
-  duration. This reduces the arrival height for legs with head wind (on by default).
+\item[Predict wind drift*]  \label{conf:predict-drift} Accounts for drifting with
+  the wind while circling to gain any altitude needed to reach final glide path
+  altitude. On by default. This affects any displayed altitude difference (e.g.,
+  the final glide bar and altitude difference InfoBoxes). For upwind destinations,
+  it makes the displayed altitude difference more negative; for downwind
+  destinations, it makes it less negative (less climbing needed). The assumed
+  circling climb rate equals the current MacCready setting (MC). If the current MC
+  is zero, no circling is assumed, and the value shown is the same as if 'Predict
+  wind drift' were 'Off'.
 \end{description}
 
 


### PR DESCRIPTION
Minor improvements to the manual's discussion of the "Predict wind drift" setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified “Display of required altitude difference” by replacing detailed wind-drift explanation with a cross-reference to configuration.
  * Expanded “Predict wind drift” config details: default On; explains drift while circling, impact on final glide bar and altitude InfoBoxes (more negative upwind, less negative downwind), and dependence on the MacCready setting (no circling when MC=0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->