### PR TITLE
ui/canvas/apple/ImageDecoder.cpp: Proper zero-initialization

### DIFF
--- a/src/ui/canvas/apple/ImageDecoder.cpp
+++ b/src/ui/canvas/apple/ImageDecoder.cpp
@@ -55,7 +55,7 @@ CGImageToUncompressedImage(CGImageRef image) noexcept
     }
   }
 
-  std::unique_ptr<uint8_t[]> uncompressed(new uint8_t[height * row_size]);
+  std::unique_ptr<uint8_t[]> uncompressed(new uint8_t[height * row_size]());
 
   CGContextRef bitmap = CGBitmapContextCreate(uncompressed.get(), width, height,
                                               8, row_size, bitmap_colorspace,


### PR DESCRIPTION
Fixes https://github.com/XCSoar/XCSoar/issues/1695. 

When loading the icon bitmaps, the memory was not zero-initialized. This caused garbage (earlier loaded icons) to be displayed at transparent pixels on newer iOS devices.