### PR TITLE
iOS: Use native scale for correct scaling on all iPhone models

### DIFF
--- a/src/UtilsSystem.cpp
+++ b/src/UtilsSystem.cpp
@@ -59,13 +59,13 @@ SystemWindowSize() noexcept
   if (!window) {
     // Fallback to main screen dimensions if no window is available
     CGRect screenBounds = [UIScreen mainScreen].bounds;
-    CGFloat scale = [UIScreen mainScreen].scale;
+    CGFloat scale = [UIScreen mainScreen].nativeScale;
     return PixelSize{(int)(screenBounds.size.width * scale), (int)(screenBounds.size.height * scale)};
   }
   
   
   CGRect bounds = window.bounds;
-  CGFloat scale = window.screen.scale;
+  CGFloat scale = window.screen.nativeScale;
 
   CGFloat width = bounds.size.width;
   CGFloat height = bounds.size.height;


### PR DESCRIPTION
Some iPhones (e.g., Plus and mini models) have a difference between UIScreen.scale and UIScreen.nativeScale due to downsampling. This change ensures correct rendering across all devices.

Motivated by TestFlight feedback I got for improper safe area accounting and button positioning on an iPhone 13 mini. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window and client area sizing on iOS for more accurate layouts.
  * Correct handling of iOS safe areas (notches, home indicator) to prevent clipped or misaligned content.
  * Sharper rendering on high‑density displays by using the device’s native pixel scale.
  * Reduced inconsistencies when no app window is available (e.g., startup or background states).

* **Refactor**
  * Streamlined iOS sizing calculations to align reported size with actual client dimensions and safe area insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->