### PR TITLE
manual: make capitalization of InfoBox(es) consistent

### DIFF
--- a/doc/manual/en/ch01_introduction.tex
+++ b/doc/manual/en/ch01_introduction.tex
@@ -23,7 +23,7 @@ for doing this from a pilot's perspective (and honestly hope for having
 succeeded).
 
 The authors highly encourage you to take your time reading the entire manual 
-chapter by chapter (with exception of the reference chapters Infoboxes and 
+chapter by chapter (with exception of the reference chapters InfoBoxes and
 Configuration). Feel assured, the time you will have spent will pay off as a 
 manifold in understanding. On your way reading you might feel blue once in a 
 while. That is why the authors introduced some blueish things: links and 

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -7,7 +7,7 @@
 This chapter describes the fundamental user interface concepts used by 
 XCSoar, and is intended as an overview. The \emph{main screen} covers much of 
 the information needed during normal flight.  Typically, the main screen is 
-composed of the moving map and infoboxes. For several reasons - not being the 
+composed of the moving map and InfoBoxes. For several reasons - not being the
 scope of an introduction - you have a choice of using several main screens 
 in-flight, named \emph{screen pages}.
 
@@ -82,9 +82,9 @@ the map area.
 
 \subsection*{Classic vario gauge}
 As said above, gauges might be displayed in different ways, either as an 
-infobox, overlay, or even in the main area. The traditional variometer gauge is 
-different. This needle-style gauge is invoked permanently by choosing an infobox 
-layout including the variometer on the right side of the other infoboxes. 
+InfoBox, overlay, or even in the main area. The traditional variometer gauge is
+different. This needle-style gauge is invoked permanently by choosing an InfoBox
+layout including the variometer on the right side of the other InfoBoxes.
 
 \section{Interaction}
 There are several ways to interact with XCSoar:
@@ -435,11 +435,11 @@ A typical landscape layout has 9 InfoBoxes and the variometer gauge
 to the right of the map display. 
 For larger displays up to 24 InfoBoxes may be displayed simultaneously.  
 
-In order to gain clarity, the less infoboxes you choose to be displayed at once, 
+In order to gain clarity, the less InfoBoxes you choose to be displayed at once,
 the faster your reading will be. On the other hand, there are much too many 
 InfoBox options a pilot would hardly reject. The number of possible InfoBox 
 options already exceeded one hundred. That is why XCSoar offers two ways of 
-managing even more options than Info\emph{boxes} count.
+managing even more options than InfoBoxes count.
 
 Depending on your flight's state, whether you are circling or cruising, you can 
 let XCSoar change the content of each single InfoBox. As an example you might 
@@ -449,21 +449,21 @@ when cruising. The switch is derived automatically by entering different
 another \emph{InfoBox set}.
 
 Further, you can use screen pages to change InfoBox content manually, by 
-assigning different Infobox sets to different pages (see following section).
+assigning different InfoBox sets to different pages (see following section).
 
 To gain access to automatic switching InfoBoxes dependent on the flight mode, 
 just let XCSoar run with its pre-configured setup from installation. To set up 
-your personal version of Infoboxes go through the following procedure.
+your personal version of InfoBoxes go through the following procedure.
 \begin{description}
-\item[InfoBox geometry] Choose a basic Infobox geometry or layout.  This basic 
+\item[InfoBox geometry] Choose a basic InfoBox geometry or layout.  This basic
 layout is maintained through any changes in-flight, affecting InfoBox content 
 only.\config{interface-appearance}
-\item[Choose Infobox set ``Auto''] Configure at least one screen page with the
-choice of Infoboxes ``Auto''. As can be seen on the corresponding configuration
+\item[Choose InfoBox set ``Auto''] Configure at least one screen page with the
+choice of InfoBoxes ``Auto''. As can be seen on the corresponding configuration
 screen, there are more screen pages pre-defined. \config{screenpages}  These 
 others are not needed to gain automatic switches by flight mode. They are for \emph{manually} turning through the screens defined by pages. 
-\item[Define InfoBox sets] Put together the Infobox content you want to be 
-displayed in three Infobox sets called ``Circling'', ``Cruise'', and ``FinalGlide''
+\item[Define InfoBox sets] Put together the InfoBox content you want to be
+displayed in three InfoBox sets called ``Circling'', ``Cruise'', and ``FinalGlide''
 respectively.\config{infobox_sets}
 \end{description}  
 
@@ -472,7 +472,7 @@ respectively.\config{infobox_sets}
 
 XCSoar allows the pilot to define various sets of InfoBoxes that are 
 appropriate for ``normal'' states of flight.  Assuming circling,
-cruising, or final glide as normal, XCSoar can switch corresponding Infobox 
+cruising, or final glide as normal, XCSoar can switch corresponding InfoBox
 sets automatically.
 
 As you might imagine, there are countless cases, you wished you had another 
@@ -485,7 +485,7 @@ introduced by the concept of screen pages, a few use cases are given.
 \item[Familiarisation] Especially if you are a beginner, you might study 
 computed values in-flight in advance of placing them in your ``normal'' InfoBox
 ensemble - just to get familiar with the reading. To do so, create a new 
-Infobox named ``test'' to be placed on an additional screen page brought in. In
+InfoBox named ``test'' to be placed on an additional screen page brought in. In
 any case you can go back to the screen you know by ``turning a page''
 \item[Competition] If you are a pilot scratching the edge, you might want to 
 gain benefit of XCSoar's numerous task- and competition-related computations. 

--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -433,7 +433,7 @@ In order to start a task when \emph{Pilot Event Start} is used, press the \emph
 start line within \emph{PEV start window} minutes.
 
 \tip It may be useful to have \emph{Start open} and/or \emph{Start reach}
- infoboxes visible to effectively use the \emph{PEV Start} procedure.
+ InfoBoxes visible to effectively use the \emph{PEV Start} procedure.
 
 
 \section{Thermals}
@@ -497,7 +497,7 @@ landable waypoints on the map.
 
 Note that task calculations are otherwise unaffected by reach
 calculations --- for example, altitudes required as shown in the final
-glide bar or task data as displayed in infoboxes do not take reach into account.
+glide bar or task data as displayed in InfoBoxes do not take reach into account.
 
 Furthermore, the reach calculations are used for footprint, landable
 waypoint arrival heights, abort mode and the alternates dialogue.  The glider

--- a/doc/manual/en/ch05_glide_computer.tex
+++ b/doc/manual/en/ch05_glide_computer.tex
@@ -121,7 +121,7 @@ attention to it, because the flight mode concept is one of XCSoar's
 fundamental basics. Another very basic scheme deals with how to structure 
 information to be displayed together. This information is grouped in
 \emph{screen pages}. Further details are given in Section~\ref{sec:infoboxandpages}
-``Infoboxes and screen pages''.\config{screenpages}
+``InfoBoxes and screen pages''.\config{screenpages}
 
 
 \section{MacCready setting}
@@ -289,7 +289,7 @@ according to the continuously changing Dolphin speed value.
 
 A configuration option `Block speed to fly' (see
 Section~\ref{sec:final-glide}) can be used to specify whether dolphin
-or block speed to fly is used.  The infobox `V Opt' shows the optimum
+or block speed to fly is used.  The InfoBox `V Opt' shows the optimum
 speed according to whichever mode is selected.  When connected to the
 Vega intelligent variometer, the speed command sounds are based on
 this optimum speed value.
@@ -679,7 +679,7 @@ glide it adjusts the setting to give minimum time to arrival.
 The method that is used is defined in the configuration settings dialogue as the
 field ``Auto MC Mode''.  The default setting is ``Both''.
 
-When Auto MacCready is enabled, the MacCready infobox displays `MC auto'
+When Auto MacCready is enabled, the MacCready InfoBox displays `MC auto'
 instead of `MC manual'; and the MacCready indicator in the variometer
 gauge displays `AutoMC' instead of `MC'.
 To benefit the most from the automatic MC adjustment XCSoar propagates the MC

--- a/doc/manual/en/ch13_history.tex
+++ b/doc/manual/en/ch13_history.tex
@@ -109,7 +109,7 @@ constructive criticism are all very welcome and helpful.
 \item[Setup suggestions]
 Because XCSoar is so configurable, we rely to some extent on users to
 think about how they would like the program to be set up.  Selection
-of infobox layouts, button menus and button assignments require some
+of InfoBox layouts, button menus and button assignments require some
 design thought, and making these available to the developers and other
 users will help us provide good default settings.
 \item[Data integrity]

--- a/doc/manual/en/installation.tex
+++ b/doc/manual/en/installation.tex
@@ -388,17 +388,17 @@ causes the glider to move in the direction of the drag, the
 speed being proportional to the length of the drag.
 
 With buttons, the aircraft
-speed, altitude and direction may be changed using the Infoboxes.
+speed, altitude and direction may be changed using the InfoBoxes.
 The following may not be available in total on every hardware platform, but on 
 any of the platforms XCSoar supports, a full set of inputs needed for 
 simulation purposes is possible.
 
-By pushing an Infobox, you select a value to be altered by buttons, either 
+By pushing an InfoBox, you select a value to be altered by buttons, either
  hardware or menu buttons.
 The aircraft altitude can be adjusted by selecting the GPS altitude
 InfoBox \bmenuw{Alt GPS}, and touching the up or down key or buttons on the 
 touchscreen.
-The airspeed can be adjusted by selecting the Infobox ground speed
+The airspeed can be adjusted by selecting the InfoBox ground speed
 \bmenuw{V Gnd}, touching up or down key or menu buttons.
 The glider's track  can be adjusted by selecting the track InfoBox
 \bmenuw{Track}, and touching up/down buttons.


### PR DESCRIPTION
Capitalize I and B in InfoBox(es) everywhere it isn't so already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Standardized UI terminology from “Infobox/infoboxes” to “InfoBox/InfoBoxes” across multiple manual chapters.
  * Updated Flight Modes, Speed to Fly, and Auto MacCready sections with consistent InfoBox wording and clarified MC value propagation to supported variometers.
  * Improved Installation/SIM mode instructions: consistent control names, corrected phrasing, and a new note on changing direction with left/right keys when Alt GPS or V Gnd is selected.
  * Minor capitalization and wording refinements in Navigation and History chapters.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->