### PR TITLE
manual: add "Home AltD" InfoBox

### DIFF
--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -229,7 +229,9 @@ point. For AAT tasks, the target within the AAT sector is used.}
 turn point relative to the safety arrival height.}
 \ibi{Final altitude required}{Fin AltR}{Additional altitude required to finish the task.}
 \ibi{Final distance}{Final Dist}{Distance to finish around remaining turn points.}
-\ibi{Distance home}{Home Dist}{Distance to the home waypoint (if defined).}
+\ibi{Distance home}{Home Dist}{Distance to the home waypoint.}
+\ibi{Home altitude difference}{Home AltD}{Arrival altitude at the home waypoint
+relative to the safety arrival height.}
 
 
 %%%%%%%%%%%


### PR DESCRIPTION
Add new (PR #1510) "Home altitude difference" InfoBox to "INFOBOX REFERENCE" chapter in manual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Navigation InfoBox reference: simplified the description of “Distance home (Home Dist)” to clearly state it shows the distance to the home waypoint.
  * Added a new entry for “Home altitude difference (Home AltD)” describing the arrival altitude at the home waypoint relative to the safety arrival height.
  * Improved clarity and consistency across the InfoBox descriptions to help users quickly understand available metrics and their meanings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->