### PR TITLE
Revert "ui/event/sdl/Queue: Stripped EventQueue::Wait..."

### DIFF
--- a/src/ui/event/sdl/Queue.cpp
+++ b/src/ui/event/sdl/Queue.cpp
@@ -50,19 +50,29 @@ EventQueue::Pop(Event &event) noexcept
 bool
 EventQueue::Wait(Event &event) noexcept
 {
+  /* this busy loop is ugly, and I wish we could do better than that,
+     but SDL_WaitEvent() is just as bad; however copying this busy
+     loop allows us to plug in more event sources */
+
   if (quit)
     return false;
-  
-  FlushClockCaches();
 
   while (true) {
     if (Generate(event))
       return true;
-    
-    int result = SDL_WaitEvent(&event.event);
-    
+
+    ::SDL_PumpEvents();
+
+    const auto timeout = timers.GetTimeout(SteadyNow());
+
+    int result = timeout.count() >= 0
+      ? SDL_WaitEventTimeout(&event.event,
+                             std::chrono::duration_cast<std::chrono::milliseconds>(timeout).count())
+      : SDL_WaitEvent(&event.event);
     if (result != 0)
       return result > 0;
+
+    FlushClockCaches();
   }
 }
 


### PR DESCRIPTION
This reverts commit 1c9ce78e639e3f7a97cea55e0d81a048d6f72ebc.

See discussion in https://github.com/XCSoar/XCSoar/issues/1807.

I probably missed something in the depths of how XCSoar works when I moved the `FlushClockCaches()` call out of the loop, and doing so seems to at least break the SIM feature partially. Sorry.

We can safely revert, since the overheating / CPU load issue was fixed properly in #1833. Also after reverting the commit, the CPU load in the iOS simulator stays below < 30% (appears a tiny bit higher than with the commit, but it is hard to judge and insignificant compared to the changes brought by #1833).

The original event loop still looks a bit like black magic to me; in particular, I now have two questions:

- When/why exactly is this flush cache call needed? It is flushed quite often.

- Why do we use `SDL_WaitEventTimeout()`? I still believe this spins the loop more often than needed.

If someone understands this more fully, I would appreciate a couple comments in the code that fully explain what's going on and why here. 

But for now I recommend we just revert my changes here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event waiting now honors timeouts, reducing idle CPU usage and power consumption.
  * Improved responsiveness to timers and scheduled actions.
  * Eliminated unnecessary busy loops when no events are available.
  * Smoother behavior when the app is inactive or minimized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->