### PR TITLE
Engine/Task: airfields first for reachable alternates

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -263,6 +263,7 @@ Version 7.44 - 2026-03-22
   - show station names in airspace details dialog
   - show squawk code in airspace details dialog
   - ability to send squawk code from airspace details dialog to transponder
+  - prioritize airfields over outlanding sites for reachable alternates
   - add support for a dedicated north-up map page layout
   - the thermal assistant InfoBox is now clickable
   - nearest airspace InfoBoxes (horizontal and vertical) are now clickable

--- a/src/Engine/Task/Unordered/AbortTask.cpp
+++ b/src/Engine/Task/Unordered/AbortTask.cpp
@@ -227,6 +227,12 @@ AbortTask::UpdateSample(const AircraftState &state,
                                        true, true, true);
 
   /**
+   * Add to the "alternates" list the reachable airfield waypoints just added
+   * to task_points, sorted according to the "Alternates mode" setting.
+   */
+  ClientUpdate(state, true);
+
+  /**
    * Now add to task_points reachable outlanding sites, sorted by arrival
    * altitude.
    */
@@ -234,9 +240,8 @@ AbortTask::UpdateSample(const AircraftState &state,
                                        false, true, true);
 
   /**
-   * Add to the "alternates" list the reachable airfield and outlanding site
-   * waypoints just added to task_points, sorted according to the "Alternates
-   * mode" setting.
+   * Add to the "alternates" list the reachable outlanding site waypoints just
+   * added to task_points, sorted according to the "Alternates mode" setting.
    */
   ClientUpdate(state, true);
 


### PR DESCRIPTION
Prioritize reachable airfields over reachable outlanding sites in the Alternates dialog (like in the task abort waypoint list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reachable alternates now prioritize airfields over outlanding sites.
  - Alternates update in two steps (airfields first, then outlanding sites) for faster, clearer in-flight suggestions.

- Documentation
  - Added changelog entry for Version 7.44 noting the new prioritization of airfields for reachable alternates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->