### PR TITLE
Bugfix PR 1809; Profile parameter NoPositionTargetDistanceRing not lo…

### DIFF
--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -58,6 +58,7 @@ Profile::Load(const ProfileMap &map, TrafficSettings &settings)
   map.Get(ProfileKeys::FlarmNorthUp, settings.north_up);
   map.GetEnum(ProfileKeys::FlarmLocation, settings.gauge_location);
   map.Get(ProfileKeys::FlarmRadarZoom, settings.radar_zoom);
+  map.Get(ProfileKeys::NoPositionTargetDistanceRing, settings.no_position_target_distance_ring);
 }
 
 void


### PR DESCRIPTION
Load profile parameter NoPositionTargetDistanceRing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Traffic setting: “No Position Target Distance Ring.” This preference is now loaded from user profiles, allowing users to customize the distance ring behavior when no position target is set.

* **Chores**
  * Internal loading logic updated to recognize the new profile preference without affecting existing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->