### PR TITLE
Device/DeviceEditWidget - Add TCP port 4000

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -66,6 +66,7 @@ Version 7.44 - not yet released
   - AirControlDisplay: Read-out transponder mode
   - Larus: Protocol 0.1.4 add OAT,GLoad,Circling/Cruise
   - SerialPorts: add 230400 baud support
+  - Add port 4000 to tcp-client
 * Polar:
   - LS8-15m: default polar, set to values according to flight manual
 * Weglide:

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -45,6 +45,7 @@ FillTCPPorts(DataFieldEnum &dfe) noexcept
   dfe.addEnumText(_T("10110"), 10110);
   dfe.addEnumText(_T("4352"), 4352);
   dfe.addEnumText(_T("2000"), 2000);
+  dfe.addEnumText(_T("4000"), 4000);
   dfe.addEnumText(_T("23"), 23);
   dfe.addEnumText(_T("8880"), 8880);
   dfe.addEnumText(_T("8881"), 8881);


### PR DESCRIPTION
The CCAS Android/iOS app (https://ccas.aero) can forward OGN and ADS-B traffic information from a TCP connection to XCSoar over UDP on port 4000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TCP port 4000 as a selectable option in TCP client configuration, allowing connections to services using this port. The option is available in the device editing interface.

* **Documentation**
  * Updated release notes under Version 7.44 (not yet released) to include the new TCP port 4000 entry in the tcp-client section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->