### PR TITLE
Add ScrollableLargeTextWidget and use it in dlgCredits

### DIFF
--- a/build/libwidget.mk
+++ b/build/libwidget.mk
@@ -14,6 +14,7 @@ WIDGET_SOURCES = \
 	$(SRC)/Widget/TabWidget.cpp \
 	$(SRC)/Widget/TextWidget.cpp \
 	$(SRC)/Widget/LargeTextWidget.cpp \
+	$(SRC)/Widget/ScrollableLargeTextWidget.cpp \
 	$(SRC)/Widget/OverlappedWidget.cpp \
 	$(SRC)/Widget/TwoWidgets.cpp \
 	$(SRC)/Widget/RowFormWidget.cpp \

--- a/src/Dialogs/dlgCredits.cpp
+++ b/src/Dialogs/dlgCredits.cpp
@@ -6,6 +6,8 @@
 #include "Widget/CreateWindowWidget.hpp"
 #include "Widget/ArrowPagerWidget.hpp"
 #include "Widget/LargeTextWidget.hpp"
+#include "Widget/ScrollableLargeTextWidget.hpp"
+#include "Widget/VScrollWidget.hpp"
 #include "Look/FontDescription.hpp"
 #include "Look/DialogLook.hpp"
 #include "Look/Colors.hpp"
@@ -147,9 +149,18 @@ dlgCreditsShowModal([[maybe_unused]] UI::SingleWindow &parent)
   auto pager = std::make_unique<ArrowPagerWidget>(look.button,
                                                   dialog.MakeModalResultCallback(mrOK));
   pager->Add(std::make_unique<CreateWindowWidget>(CreateLogoPage));
-  pager->Add(std::make_unique<LargeTextWidget>(look, authors2));
-  pager->Add(std::make_unique<LargeTextWidget>(look, news2));
-  pager->Add(std::make_unique<LargeTextWidget>(look, license2));
+  
+  auto authorInner = std::make_unique<ScrollableLargeTextWidget>(look, authors2);
+  auto authorScroll = std::make_unique<VScrollWidget>(std::move(authorInner), look);
+  pager->Add(std::move(authorScroll));
+
+  auto newsInner = std::make_unique<ScrollableLargeTextWidget>(look, news2);
+  auto newsScroll = std::make_unique<VScrollWidget>(std::move(newsInner), look);
+  pager->Add(std::move(newsScroll));
+
+  auto licenseInner = std::make_unique<ScrollableLargeTextWidget>(look, license2);
+  auto licenseScroll = std::make_unique<VScrollWidget>(std::move(licenseInner), look);
+  pager->Add(std::move(licenseScroll));
 
   dialog.FinishPreliminary(std::move(pager));
   dialog.ShowModal();

--- a/src/Widget/ScrollableLargeTextWidget.cpp
+++ b/src/Widget/ScrollableLargeTextWidget.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Widget/ScrollableLargeTextWidget.hpp"
+#include "Screen/Layout.hpp"
+
+ScrollableLargeTextWidget::ScrollableLargeTextWidget(const DialogLook &dlgLook,
+                                                     const TCHAR *t)
+    : LargeTextWidget(dlgLook, t), look(dlgLook), text(t)
+{
+}
+
+PixelSize
+ScrollableLargeTextWidget::GetMinimumSize() const noexcept
+{
+  return {Layout::FastScale(200), Layout::FastScale(200)};
+}
+
+PixelSize
+ScrollableLargeTextWidget::GetMaximumSize() const noexcept
+{
+  long lines = 1;
+  for (auto ch : text) {
+    if (ch == _T('\n')) ++lines;
+  }
+
+  unsigned line_height = look.text_font.GetHeight();
+  unsigned total_height = lines * line_height + Layout::FastScale(10);
+
+  return {static_cast<unsigned>(Layout::FastScale(300)), total_height};
+}

--- a/src/Widget/ScrollableLargeTextWidget.cpp
+++ b/src/Widget/ScrollableLargeTextWidget.cpp
@@ -26,6 +26,8 @@ ScrollableLargeTextWidget::GetMaximumSize() const noexcept
 
   unsigned line_height = look.text_font.GetHeight();
   unsigned total_height = lines * line_height + Layout::FastScale(10);
+  
+  const unsigned max_height = Layout::FastScale(6500);
 
-  return {static_cast<unsigned>(Layout::FastScale(300)), total_height};
+  return {static_cast<unsigned>(Layout::FastScale(300)), std::min(total_height, max_height)};
 }

--- a/src/Widget/ScrollableLargeTextWidget.hpp
+++ b/src/Widget/ScrollableLargeTextWidget.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Look/DialogLook.hpp"
+#include "Widget/LargeTextWidget.hpp"
+
+class ScrollableLargeTextWidget final : public LargeTextWidget {
+  const DialogLook &look;
+  std::basic_string<TCHAR> text;
+
+public:
+  ScrollableLargeTextWidget(const DialogLook &dlgLook, const TCHAR *t);
+
+  PixelSize GetMinimumSize() const noexcept override;
+  PixelSize GetMaximumSize() const noexcept override;
+};


### PR DESCRIPTION
Add a `ScrollableLargeTextWidget` that automatically calculates the height of the `WindowWidget` based on the number of lines of the text. This can be wrapped by `VScrollWidget`. E.g.:

```cpp
auto pager = std::make_unique<ArrowPagerWidget>(look.button, dialog.MakeModalResultCallback(mrOK));
auto authorInner = std::make_unique<ScrollableLargeTextWidget>(look, authors2);
auto authorScroll = std::make_unique<VScrollWidget>(std::move(authorInner), look);
pager->Add(std::move(authorScroll));
```

`VScrollWidget` is bugged and needs to be fixed before this PR can be merged. It is fixed in 1d2f16e (see #1867). Please tell me if I should cerry-pick it into this PR.