### PR TITLE
Add support for a dedicated north-up map page layout

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,6 +42,7 @@ Version 7.44 - not yet released
   - show station names in airspace details dialog
   - show squawk code in airspace details dialog
   - ability to send squawk code from airspace details dialog to transponder
+  - add support for a dedicated north-up map page layout
 * Android
   - fix crash on startup when loading icons on ldpi screens
   - update 'white list' of USB devices with one more VID/PID pair for SoftRF Academy

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -172,6 +172,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 
   static constexpr StaticEnumChoice main_list[] = {
     { PageLayout::Main::MAP, N_("Map") },
+    { PageLayout::Main::MAP_NORTH_UP, N_("Map (north-up)") },
     { PageLayout::Main::FLARM_RADAR, N_("FLARM radar") },
     { PageLayout::Main::THERMAL_ASSISTANT, N_("Thermal assistant") },
     { PageLayout::Main::HORIZON, N_("Horizon") },
@@ -345,6 +346,10 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   switch (value.main) {
   case PageLayout::Main::MAP:
     buffer = _("Map");
+    break;
+
+  case PageLayout::Main::MAP_NORTH_UP:
+    buffer = _("Map (north-up)");
     break;
 
   case PageLayout::Main::FLARM_RADAR:

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -8,6 +8,7 @@
 #include "Interface.hpp"
 #include "Profile/Profile.hpp"
 #include "Screen/Layout.hpp"
+#include "PageActions.hpp"
 
 #include <algorithm> // for std::clamp()
 
@@ -185,6 +186,15 @@ GlueMapWindow::UpdateScreenAngle() noexcept
   const DerivedInfo &calculated = CommonInterface::Calculated();
   const MapSettings &settings = CommonInterface::GetMapSettings();
   const UIState &ui_state = CommonInterface::GetUIState();
+
+  // force north-up if the current page is MAP_NORTH_UP
+  const PageLayout &layout = PageActions::GetConfiguredLayout();
+  if (layout.main == PageLayout::Main::MAP_NORTH_UP) {
+    visible_projection.SetScreenAngle(Angle::Zero());
+    OnProjectionModified();
+    compass_visible = false;
+    return;
+  }
 
   MapOrientation orientation =
     ui_state.display_mode == DisplayMode::CIRCLING

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -175,6 +175,7 @@ LoadMain(PageLayout::Main main)
 {
   switch (main) {
   case PageLayout::Main::MAP:
+  case PageLayout::Main::MAP_NORTH_UP:
     CommonInterface::main_window->ActivateMap();
     break;
 
@@ -305,10 +306,10 @@ GlueMapWindow *
 PageActions::ShowMap()
 {
   PageLayout layout = GetCurrentLayout();
-  if (layout.main != PageLayout::Main::MAP) {
+  if (layout.main != PageLayout::Main::MAP && layout.main != PageLayout::Main::MAP_NORTH_UP) {
     /* not showing map currently: activate it */
 
-    if (GetConfiguredLayout().main == PageLayout::Main::MAP)
+    if (GetConfiguredLayout().main == PageLayout::Main::MAP || GetConfiguredLayout().main == PageLayout::Main::MAP_NORTH_UP)
       /* the configured page is a map page: restore it */
       Restore();
     else {

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -18,6 +18,7 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
 
   switch (main) {
   case PageLayout::Main::MAP:
+  case PageLayout::Main::MAP_NORTH_UP:
     break;
 
   case PageLayout::Main::FLARM_RADAR:

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -50,6 +50,8 @@ struct PageLayout
 
     HORIZON,
 
+    MAP_NORTH_UP,
+
     /**
      * A dummy entry that is used for validating profile values.
      */


### PR DESCRIPTION
Currently, it is only possible to have the same map orientation for all maps in the main area. This PR makes it possible to always display the map with north at the top on one page (e.g., full screen, without `InfoBoxes`, `Bottom` widget).

The `make update-po` and translations are still missing. However, I am waiting for a merge from https://github.com/XCSoar/XCSoar/pull/1874 so as not to create noise in the commit.