### PR TITLE
InfoBoxes/Content: add Alternate 1 & 2 Altitude Difference InfoBoxes

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -28,7 +28,9 @@ Version 7.44 - not yet released
   - infoboxen: new setting, allow scaling of title/comment font
   - Radar / Thermalassistant Gauges: Placement to avoid InfoBoxen and Overlap
   - Thermal assistant: New positions on top of map to avoid hiding airspace warnings
-  - Add new Infobox “Home altitude difference” (Home AltD)
+  - Add new InfoBox 'Home altitude difference' (Home AltD)
+  - Add new InfoBox 'Alternate 1 altitude difference' (Altn 1 AltD)
+  - Add new InfoBox 'Alternate 2 altitude difference' (Altn 2 AltD)
   - Show transponder mode (if available) in transponder code InfoBox
   - add helpers on infoboxes for Argentinean contests 95% distance rule
   - Popup messages now appear at the top of the map

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -328,12 +328,17 @@ reported team code.}
 
 \ibi{Alternate 1}{Altn 1}{Name and bearing to the best alternate
 landing location.}
-\ibi{Alternate 2}{Altn 2}{Name and bearing to the second alternate
+\ibi{Alternate 2}{Altn 2}{Name and bearing to the second-best alternate
 landing location.}
-\ibi{Alternate 1 GR}{Altn1 GR}{Geometric gradient to the arrival height above
-the best alternate. This is not adjusted for total energy.}
-\ibi{Alternate 2 GR}{Altn2 GR}{Geometric gradient to the arrival height above
-the second alternate. This is not adjusted for total energy.}
+\ibi{Alternate 1 GR}{Altn 1 GR}{Geometric gradient to the arrival height above
+the best alternate landing location. This is not adjusted for total energy.}
+\ibi{Alternate 2 GR}{Altn 2 GR}{Geometric gradient to the arrival height above
+the second-best alternate landing location. This is not adjusted for total
+energy.}
+\ibi{Alternate 1 altitude difference}{Altn 1 AltD}{Arrival altitude at the best
+alternate landing location relative to the safety arrival height.}
+\ibi{Alternate 2 altitude difference}{Altn 2 AltD}{Arrival altitude at the
+second-best alternate landing location relative to the safety arrival height.}
 
 %%%%%%%%%%%
 \section{Obstacles}

--- a/src/InfoBoxes/Content/Alternate.cpp
+++ b/src/InfoBoxes/Content/Alternate.cpp
@@ -133,3 +133,45 @@ InfoBoxContentAlternateGR::GetDialogContent() noexcept
 {
   return alternate_infobox_panels;
 }
+
+void
+InfoBoxContentAlternateAltDiff::Update(InfoBoxData &data) noexcept
+{
+  if (!backend_components->protected_task_manager) {
+    data.SetInvalid();
+    return;
+  }
+
+  ProtectedTaskManager::Lease lease{*backend_components->protected_task_manager};
+  const AlternateList &alternates = lease->GetAlternates();
+
+  const AlternatePoint *alternate;
+  if (!alternates.empty()) {
+    if (index >= alternates.size())
+      index = alternates.size() - 1;
+
+    alternate = &alternates[index];
+  } else {
+    alternate = NULL;
+  }
+
+  data.FmtTitle(_T("Altn {} AltD"), index + 1);
+
+  if (alternate == NULL) {
+    data.SetInvalid();
+    return;
+  }
+
+  data.SetComment(alternate->waypoint->name.c_str());
+
+  const auto &settings = CommonInterface::GetComputerSettings();
+  auto altitude_difference =
+    alternate->solution.SelectAltitudeDifference(settings.task.glide);
+  data.SetValueFromArrival(altitude_difference);
+}
+
+const InfoBoxPanel *
+InfoBoxContentAlternateAltDiff::GetDialogContent() noexcept
+{
+  return alternate_infobox_panels;
+}

--- a/src/InfoBoxes/Content/Alternate.hpp
+++ b/src/InfoBoxes/Content/Alternate.hpp
@@ -30,3 +30,16 @@ public:
 private:
   unsigned index;
 };
+
+class InfoBoxContentAlternateAltDiff : public InfoBoxContent
+{
+public:
+  explicit InfoBoxContentAlternateAltDiff(const unsigned _index) noexcept
+    :index(_index) {}
+
+  void Update(InfoBoxData &data) noexcept override;
+  const InfoBoxPanel *GetDialogContent() noexcept override;
+
+private:
+  unsigned index;
+};

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -663,7 +663,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Alternate 1"),
     N_("Altn 1"),
-    N_("Displays name and bearing to the best alternate landing location."),
+    N_("Name and bearing to the best alternate landing location."),
     IBFHelperInt<InfoBoxContentAlternateName, 0>::Create,
   },
 
@@ -671,15 +671,15 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Alternate 2"),
     N_("Altn 2"),
-    N_("Displays name and bearing to the second alternate landing location."),
+    N_("Name and bearing to the second-best alternate landing location."),
     IBFHelperInt<InfoBoxContentAlternateName, 1>::Create,
   },
 
   // e_Alternate_1_GR
   {
     N_("Alternate 1 GR"),
-    N_("Altn1 GR"),
-    N_("Geometric gradient to the arrival height above the best alternate. This is not adjusted for total energy."),
+    N_("Altn 1 GR"),
+    N_("Geometric gradient to the arrival height above the best alternate landing location. This is not adjusted for total energy."),
     IBFHelperInt<InfoBoxContentAlternateGR, 0>::Create,
   },
 
@@ -1075,8 +1075,8 @@ static constexpr MetaData meta_data[] = {
   // e_Alternate_2_GR
   {
     N_("Alternate 2 GR"),
-    N_("Altn2 GR"),
-    N_("Geometric gradient to the arrival height above the second alternate. This is not adjusted for total energy."),
+    N_("Altn 2 GR"),
+    N_("Geometric gradient to the arrival height above the second-best alternate landing location. This is not adjusted for total energy."),
     IBFHelperInt<InfoBoxContentAlternateGR, 1>::Create,
   },
 
@@ -1150,6 +1150,22 @@ static constexpr MetaData meta_data[] = {
     N_("V Task Leg"),
     N_("Average cross country speed while on current task leg, not compensated for altitude."),
     UpdateInfoBoxTaskSpeedLeg,
+  },
+
+  // e_Alternate_1_AltDiff
+  {
+    N_("Alternate 1 altitude difference"),
+    N_("Altn 1 AltD"),
+    N_("Arrival altitude at the best alternate landing location relative to the safety arrival height."),
+    IBFHelperInt<InfoBoxContentAlternateAltDiff, 0>::Create,
+  },
+
+  // e_Alternate_2_AltDiff
+  {
+    N_("Alternate 2 altitude difference"),
+    N_("Altn 2 AltD"),
+    N_("Arrival altitude at the second-best alternate landing location relative to the safety arrival height."),
+    IBFHelperInt<InfoBoxContentAlternateAltDiff, 1>::Create,
   },
 
 };

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -138,7 +138,7 @@ namespace InfoBoxFactory
     e_Thermal_Time, /* Time in Thermal*/
     e_Alternate_2_GR, /* Geometric gradient to the arrival height above the second alternate. This is not adjusted for total energy */
     e_HeartRate,
-    /* 120..128 */
+    /* 120..129 */
     e_TransponderCode, /* Transponder code */
     e_EngineCHT,  /* Engine Cylinder Head Temperature */
     e_EngineEGT,  /* Engine Exhaust Gas Temperature */
@@ -147,6 +147,9 @@ namespace InfoBoxFactory
     e_SpeedTaskEst, /* Estimated (predicted) whole-task average cross-country speed for current task. Affected by MC setting. */
     e_Home_AltDiff, /* Arrival altitude at the home waypoint (if defined) relative to the safety arrival height */
     e_SpeedTaskLeg, /* Average cross country speed while on current task leg, not compensated for altitude */
+    e_Alternate_1_AltDiff, /* Arrival altitude at the best alternate landing location relative to the safety arrival height */
+    e_Alternate_2_AltDiff, /* Arrival altitude at the second-best alternate landing location relative to the safety arrival height */
+    /* 130 */
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
add InfoBoxes for alternate 1 and 2 altitude difference (arrival altitudes to best and second-best alternate landing location waypoints)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added two InfoBoxes: “Alternate 1 altitude difference” (Altn 1 AltD) and “Alternate 2 altitude difference” (Altn 2 AltD) showing arrival altitude relative to the safety arrival height for the best and second-best alternates.

* Documentation
  * Clarified manual wording to refer to the “second-best” alternate, improved Alternate Name and GR captions/descriptions, standardized labels (e.g., “Altn 1 GR”, “Altn 2 GR”).
  * NEWS updated to use “InfoBox” and list the new AltD entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->