### PR TITLE
dlgConfigInfoboxes.cpp: Update description on InfoBox click

### DIFF
--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -297,6 +297,7 @@ void
 InfoBoxesConfigWidget::RefreshEditContent()
 {
   LoadValueEnum(CONTENT, data.contents[current_preview]);
+  RefreshEditContentDescription();
 }
 
 void


### PR DESCRIPTION
When editing an InfoBox set, the current behavior is that the InfoBox description is only updated when the "Content" field is changed. If you then select another InfoBox in the layout, the description of the previously selected InfoBox remains visible, which can lead to confusing results. With this PR, the correct description is always shown for the currently selected InfoBox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The description text in Settings > InfoBoxes now refreshes correctly when loading or previewing different content. This includes updates triggered programmatically (e.g., switching the current InfoBox), not just manual edits. Descriptions stay in sync with the selected content, improving clarity and consistency during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->