### PR TITLE
Add kinetic drag scrolling to VScrollPanel

### DIFF
--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -5,6 +5,8 @@
 
 #include "Panel.hpp"
 #include "ui/control/ScrollBar.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+#include "UIUtil/KineticManager.hpp"
 
 class VScrollPanelListener {
 public:
@@ -37,6 +39,20 @@ class VScrollPanel final : public PanelControl {
    * The top-most virtual pixel line visible in the visible area.
    */
   unsigned origin = 0;
+
+  /**
+   * Tracks active drag gesture and optional kinetic scrolling.
+   */
+  bool dragging = false;
+
+  /**
+   * The vertical distance from the start of the drag relative to the
+   * top of the list (not the top of the screen)
+   */
+  int drag_y = 0;
+
+  KineticManager kinetic;
+  UI::PeriodicTimer kinetic_timer{[this]{ OnKineticTimer(); }};
 
 public:
   VScrollPanel(ContainerWindow &parent, const DialogLook &look,
@@ -78,10 +94,13 @@ public:
 
 private:
   void SetupScrollBar() noexcept;
+  void SetOriginClamped(int new_origin) noexcept;
+  void OnKineticTimer() noexcept;
 
 protected:
   /* virtual methods from class Window */
   void OnResize(PixelSize new_size) noexcept override;
+  void OnDestroy() noexcept override;
 
   bool OnKeyDown(unsigned key_code) noexcept override;
 


### PR DESCRIPTION
Add touch-style kinetic scrolling to `VScrollPanel`, letting users drag the content area itself. Scroll origin updates are clamped and emitted through the listener, with the integration mirroring the approach already used in `src/ui/control/List.cpp`.

Also see: https://github.com/XCSoar/XCSoar/pull/1869#issue-3388700251

> VScrollWidget is bugged and needs to be fixed before this PR can be merged. It is fixed in https://github.com/XCSoar/XCSoar/commit/1d2f16e593e55582727815a2dd134bfcceb206bf (see https://github.com/XCSoar/XCSoar/pull/1867). Please tell me if I should cerry-pick it into this PR.

This is probably a good PR to add 1d2f16e. I no longer think it is necessary to remove `UpdateVirtualHeight(GetWindow().GetClientRect());` in `VScrollWidget::OnVScrollPanelChange`, but the condition if `(max_height <= height)` needs to be adjusted in VScrollWidget::CalcVirtualHeight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Adds kinetic/inertial scrolling with pixel-precise dragging for smoother, more natural vertical scrolling.
  - Enables dragging directly on the content area (not just the scrollbar) to scroll, with proper capture/release handling.
  - Prevents overscroll by clamping to the valid scroll range for a stable experience.
  - Automatically disables pixel-pan behavior on ePaper devices to maintain usability and performance.

- **Bug Fixes**
  - Ensures active drags and inertial scrolling are cleanly cancelled/cleaned up on mode changes or destruction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->