### PR TITLE
FlightStatusPanel: update share button, use geo URI and iOS support

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -549,7 +549,8 @@ endif
 ifeq ($(TARGET_IS_DARWIN),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Device/AndroidSensors.cpp \
-	$(SRC)/Apple/InternalSensors.cpp
+	$(SRC)/Apple/InternalSensors.cpp \
+	$(SRC)/Apple/Share.cpp
 endif
 
 ifeq ($(TARGET),ANDROID)

--- a/src/Apple/Share.cpp
+++ b/src/Apple/Share.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+// iOS implementation for sharing text using UIActivityViewController
+
+#include "Apple/Share.hpp"
+#include "util/ConvertString.hpp"
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#import <dispatch/dispatch.h>
+
+static UIViewController *
+GetTopMostController(UIViewController *controller) noexcept
+{
+  if (controller == nil)
+    return nil;
+
+  while (true) {
+    if ([controller isKindOfClass:[UINavigationController class]]) {
+      controller = ((UINavigationController *)controller).visibleViewController;
+    } else if ([controller isKindOfClass:[UITabBarController class]]) {
+      controller = ((UITabBarController *)controller).selectedViewController;
+    } else if (controller.presentedViewController != nil) {
+      controller = controller.presentedViewController;
+    } else {
+      break;
+    }
+
+    if (controller == nil)
+      break;
+  }
+
+  return controller;
+}
+
+static UIViewController *
+FindActiveController() noexcept
+{
+  UIWindow *activeWindow = nil;
+
+  if (@available(iOS 13.0, *)) {
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+      if (scene.activationState != UISceneActivationStateForegroundActive)
+        continue;
+
+      if (![scene isKindOfClass:[UIWindowScene class]])
+        continue;
+
+      UIWindowScene *windowScene = (UIWindowScene *)scene;
+      for (UIWindow *window in windowScene.windows) {
+        if (window.isHidden)
+          continue;
+
+        if (window.isKeyWindow) {
+          activeWindow = window;
+          break;
+        }
+
+        if (activeWindow == nil)
+          activeWindow = window;
+      }
+
+      if (activeWindow != nil)
+        break;
+    }
+  }
+
+  if (activeWindow == nil)
+    activeWindow = UIApplication.sharedApplication.keyWindow;
+
+  if (activeWindow == nil) {
+    for (UIWindow *window in UIApplication.sharedApplication.windows) {
+      if (window.isHidden)
+        continue;
+
+      activeWindow = window;
+      if (window.isKeyWindow)
+        break;
+    }
+  }
+
+  if (activeWindow == nil)
+    return nil;
+
+  return GetTopMostController(activeWindow.rootViewController);
+}
+
+void
+ShareTextIOS(const TCHAR *text) noexcept
+{
+  if (text == nullptr || *text == _T('\0'))
+    return;
+
+  const WideToUTF8Converter utf8{text};
+  if (!utf8.IsValid())
+    return;
+
+  NSString *const shareString = [[NSString alloc] initWithUTF8String:utf8.c_str()];
+  if (shareString == nil)
+    return;
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    UIViewController *controller = FindActiveController();
+    if (controller == nil)
+      return;
+
+    UIActivityViewController *activityVC =
+      [[UIActivityViewController alloc] initWithActivityItems:@[shareString]
+                                        applicationActivities:nil];
+
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+      activityVC.modalPresentationStyle = UIModalPresentationPopover;
+    }
+
+    UIPopoverPresentationController *popover = activityVC.popoverPresentationController;
+    if (popover != nil) {
+      popover.sourceView = controller.view;
+      popover.sourceRect = CGRectMake(CGRectGetMidX(controller.view.bounds),
+                                      CGRectGetMidY(controller.view.bounds),
+                                      0, 0);
+      popover.permittedArrowDirections = 0;
+    }
+
+    [controller presentViewController:activityVC animated:YES completion:nil];
+  });
+}
+#endif

--- a/src/Apple/Share.hpp
+++ b/src/Apple/Share.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <tchar.h>
+
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+void ShareTextIOS(const TCHAR *text) noexcept;
+#endif

--- a/src/Dialogs/StatusPanels/FlightStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/FlightStatusPanel.cpp
@@ -6,12 +6,20 @@
 #include "Formatter/UserUnits.hpp"
 #include "Formatter/AngleFormatter.hpp"
 #include "Formatter/UserGeoPointFormatter.hpp"
+#include "Formatter/GeoPointFormatter.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "Language/Language.hpp"
 
 #ifdef ANDROID
 #include "Android/Main.hpp"
 #include "Android/NativeView.hpp"
+#endif
+
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_IPHONE
+#include "Apple/Share.hpp"
+#endif
 #endif
 
 enum Controls {
@@ -21,10 +29,35 @@ enum Controls {
   Near,
   Bearing,
   Distance,
-#ifdef ANDROID
-  ShareButton,
+#if defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+  ShareLocationButton,
 #endif
 };
+
+#if defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+static NarrowString<64>
+BuildGeoURI(const GeoPoint &location) noexcept
+{
+  NarrowString<64> uri;
+
+  if (!location.Check())
+    return uri;
+
+  char location_string[32];
+  FormatGeoPoint(location, location_string, sizeof(location_string),
+               CoordinateFormat::PLAIN_DECIMAL, ',');
+
+  char buffer[64];
+  int n = snprintf(buffer, sizeof(buffer), "geo:%s", location_string);
+
+  if (n < 0 || (size_t)n >= uri.capacity())
+    return uri;
+
+  uri.assign(buffer);
+  return uri;
+}
+
+#endif
 
 void
 FlightStatusPanel::Refresh() noexcept
@@ -36,8 +69,8 @@ FlightStatusPanel::Refresh() noexcept
     SetText(Location, FormatGeoPoint(basic.location));
   else
     ClearText(Location);
-#ifdef ANDROID
-  SetRowEnabled(ShareButton, basic.location_available);
+#if defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+  SetRowEnabled(ShareLocationButton, basic.location_available);
 #endif
 
   if (basic.gps_altitude_available)
@@ -74,11 +107,21 @@ FlightStatusPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddReadOnly(_("Bearing"));
   AddReadOnly(_("Distance"));
 
+#if defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+  AddButton(_("Share location"), [](){
+    const auto &basic = CommonInterface::Basic();
+    if (!basic.location_available)
+      return;
+    const auto uri = BuildGeoURI(basic.location);
+    if (uri.empty())
+      return;
 #ifdef ANDROID
-  AddButton(_("Share"), [this](){
-    native_view->ShareText(Java::GetEnv(), GetText(Location));
+    native_view->ShareText(Java::GetEnv(), uri.c_str());
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+    ShareTextIOS(uri.c_str());
+#endif
   });
 
-  SetRowEnabled(ShareButton, false);
+  SetRowEnabled(ShareLocationButton, false);
 #endif
 }

--- a/src/Form/DigitEntry.cpp
+++ b/src/Form/DigitEntry.cpp
@@ -145,6 +145,10 @@ DigitEntry::CreateLatitude(ContainerWindow &parent, const PixelRect &rc,
     columns[7].type = Column::Type::DIGIT6;
     columns[9].type = Column::Type::QUOTE;
     break;
+
+  case CoordinateFormat::PLAIN_DECIMAL:
+    // not supported in DigitEntry
+    break;
   }
 
   cursor = 0;
@@ -198,6 +202,10 @@ DigitEntry::CreateLongitude(ContainerWindow &parent, const PixelRect &rc,
     columns[6].type = Column::Type::APOSTROPHE;
     columns[7].type = Column::Type::DIGIT6;
     columns[9].type = Column::Type::QUOTE;
+    break;
+
+  case CoordinateFormat::PLAIN_DECIMAL:
+    // not supported in DigitEntry
     break;
   }
 
@@ -544,6 +552,10 @@ DigitEntry::SetDigits(double degrees, CoordinateFormat format, bool isLatitude)
     roundingAdjustment = 0.5 * ( (1.0/3600) / 1);
     break;
 
+  case CoordinateFormat::PLAIN_DECIMAL:
+    // not supported in DigitEntry
+    break;
+
   default:
   case CoordinateFormat::UTM:
     /// \todo support UTM format
@@ -634,6 +646,11 @@ DigitEntry::SetDigits(double degrees, CoordinateFormat format, bool isLatitude)
     unsigned remainder = full_hunseconds % 6000u;
     columns[7].value = remainder / 1000;  remainder %= 1000;
     columns[8].value = remainder / 100;   remainder %= 100;
+    break;
+  }
+
+  case CoordinateFormat::PLAIN_DECIMAL: {
+    // not supported in DigitEntry
     break;
   }
   }
@@ -752,6 +769,10 @@ DigitEntry::GetGeoAngle(CoordinateFormat format) const
     // Read minute and second columns
     degrees += (columns[4].value * 10 + columns[5].value) / 60.
       +  (columns[7].value * 10 + columns[8].value) / 3600.;
+    break;
+
+  case CoordinateFormat::PLAIN_DECIMAL:
+    // not supported in DigitEntry
     break;
   }
 

--- a/src/Formatter/GeoPointFormatter.cpp
+++ b/src/Formatter/GeoPointFormatter.cpp
@@ -85,6 +85,10 @@ FormatLongitude(Angle longitude, TCHAR *buffer, size_t size,
     StringFormat(buffer, size, _T("%09.5f" DEG " %c"), mlong, sign);
     break;
 
+  case CoordinateFormat::PLAIN_DECIMAL:
+    StringFormat(buffer, size, _T("%.8f"), longitude.Degrees());
+    break;
+
   case CoordinateFormat::UTM:
     return false;
   }
@@ -152,6 +156,10 @@ FormatLatitude(Angle latitude, TCHAR *buffer, size_t size,
   case CoordinateFormat::DD_DDDDD:
     // Save the string to the buffer
     StringFormat(buffer, size, _T("%08.5f" DEG " %c"), mlat, sign);
+    break;
+
+  case CoordinateFormat::PLAIN_DECIMAL:
+    StringFormat(buffer, size, _T("%.8f"), latitude.Degrees());
     break;
 
   case CoordinateFormat::UTM:

--- a/src/Geo/CoordinateFormat.hpp
+++ b/src/Geo/CoordinateFormat.hpp
@@ -11,4 +11,5 @@ enum class CoordinateFormat: uint8_t {
   DDMM_MMM,
   DD_DDDDD,
   UTM,
+  PLAIN_DECIMAL,
 };


### PR DESCRIPTION
Closes https://github.com/XCSoar/XCSoar/issues/1896.

I also added support for the native iOS share popup. @yorickreum Could you take a look at `Apple/Share.cpp`? ChatGPT helped me with this class, but I'm not entirely sure if the code is correct.

I haven't tested the new geo URI scheme on Android yet.

What exactly do we want to achieve with links like `geo:47.95101864,7.95627518`? My understanding is that the share popup should automatically recognize this as a location link and suggest appropriate apps.

However, on iOS this doesn't improve the suggested apps for sharing (you need to convert it to `NSURL` first). The best workaround I've found is using `https://www.google.com/maps/search/?api=1&query=LAT,LON`, but that's probably not what we want…

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Share Location button on iOS and Android that uses each platform’s native share sheet.
  * Added plain decimal degrees as a new coordinate display option for lat/lon.
  * Enabled general text sharing on iOS via the system share sheet.

* **Notes**
  * Plain decimal is view-only; input/editing for this format is not yet supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->