### PR TITLE
src/Repository,src/net,src/Android: Add redundancy for downloads

### DIFF
--- a/src/Android/DownloadManager.hpp
+++ b/src/Android/DownloadManager.hpp
@@ -7,6 +7,10 @@
 #include "thread/Mutex.hxx"
 
 #include <list>
+#include <initializer_list>
+#include <map>
+#include <vector>
+#include <string>
 
 class Path;
 class Context;
@@ -16,11 +20,23 @@ class AndroidDownloadManager {
   Java::GlobalCloseable util;
 
   /**
-   * Protects the #listeners attribute.
+   * Protects the #listeners attribute and fallback state.
    */
   Mutex mutex;
 
   std::list<Net::DownloadListener *> listeners;
+
+  /**
+   * Map from relative path to list of fallback URLs.
+   * Protected by #mutex.
+   */
+  std::map<std::string, std::vector<std::string>> fallback_urls;
+
+  /**
+   * Map from relative path to current URL index.
+   * Protected by #mutex.
+   */
+  std::map<std::string, size_t> current_url_index;
 
 public:
   /**
@@ -40,5 +56,7 @@ public:
 
   void Enumerate(JNIEnv *env, Net::DownloadListener &listener) noexcept;
   void Enqueue(JNIEnv *env, const char *uri, Path path_relative) noexcept;
+  void EnqueueWithFallback(JNIEnv *env, std::initializer_list<const char*> urls, 
+                          Path path_relative) noexcept;
   void Cancel(JNIEnv *env, Path path_relative) noexcept;
 };

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -7,8 +7,6 @@
 
 #include <tchar.h>
 
-#define REPOSITORY_URI "http://download.xcsoar.org/repository"
-
 static bool repository_downloaded = false;
 
 void
@@ -18,5 +16,11 @@ EnqueueRepositoryDownload(bool force)
     return;
 
   repository_downloaded = true;
-  Net::DownloadManager::Enqueue(REPOSITORY_URI, Path(_T("repository")));
+  
+  // Use new fallback API with multiple repository URLs
+  Net::DownloadManager::EnqueueWithFallback({
+    "http://download.xcsoar.org/repository", // Primary, managed by @scottp
+    "http://download.xcsoar.net/repository", // Fallback, managed by @lordfolken
+    "http://download.xcsoar.de/repository" // Fallback, managed by @yorickreum
+  }, Path(_T("repository")));
 }

--- a/src/net/http/DownloadManager.hpp
+++ b/src/net/http/DownloadManager.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <exception>
+#include <initializer_list>
 
 class Path;
 
@@ -60,6 +61,16 @@ void RemoveListener(DownloadListener &listener) noexcept;
 void Enumerate(DownloadListener &listener) noexcept;
 
 void Enqueue(const char *uri, Path relative_path) noexcept;
+
+/**
+ * Enqueue a download with fallback URLs.  If the first URL fails,
+ * automatically try the next URL in the list.
+ *
+ * @param urls list of URLs to try in order
+ * @param relative_path the relative path where the file should be saved
+ */
+void EnqueueWithFallback(std::initializer_list<const char*> urls, 
+                        Path relative_path) noexcept;
 
 /**
  * Cancel the download.  The download may however be already


### PR DESCRIPTION
Adds redundancy for downloads, in case xcsoar.org breaks again, see https://github.com/XCSoar/XCSoar/issues/1888.

Still needs to be tested thoroughly, especially on Android. 
We should also complete and merge https://github.com/XCSoar/XCSoar/pull/1915 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads now support automatic fallback URL handling: if a primary URL fails, the system sequentially tries configured fallbacks before reporting an error.
  * Repository downloads now include multiple fallback URLs to improve reliability.

* **Bug Fixes**
  * Improved retry and cleanup behavior on download failure and cancellation to reduce stale state and needless errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->