### PR TITLE
darwin: Remove symlink hack, use separate Xcode schemes

### DIFF
--- a/darwin/XCSoar.xcodeproj/project.pbxproj
+++ b/darwin/XCSoar.xcodeproj/project.pbxproj
@@ -7042,12 +7042,14 @@
 		5CBFEF2B2D742FA600F05795 /* xci2po.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = xci2po.pl; sourceTree = "<group>"; };
 		5CBFEF2C2D742FA600F05795 /* xcs2cpp.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = xcs2cpp.pl; sourceTree = "<group>"; };
 		5CBFEF2E2D742FA600F05795 /* VERSION.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = VERSION.txt; path = ../VERSION.txt; sourceTree = SOURCE_ROOT; };
+		5CD39CC52EA67484003C7BA6 /* sign.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = sign.sh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
 		5C263B902D7456D30031179E /* darwin */ = {
 			isa = PBXGroup;
 			children = (
+				5CD39CC52EA67484003C7BA6 /* sign.sh */,
 				5C263B8C2D7456D30031179E /* .gitignore */,
 				5C263B8D2D7456D30031179E /* build.sh */,
 				5C263B8E2D7456D30031179E /* clean.sh */,

--- a/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Device.xcscheme
+++ b/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Device.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "2.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "if [ &quot;$ACTION&quot; = &quot;clean&quot; ]; then&#10;  $WORKSPACE_PATH/../../clean.sh&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CBFD0922D742E1000F05795"
+               BuildableName = "XCSoar"
+               BlueprintName = "XCSoar"
+               ReferencedContainer = "container:XCSoar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         BundleIdentifier = "XCSoar-testing"
+         Location = "workspace"
+         FilePath = "../output/IOS64/ipa/Payload/XCSoar.app">
+      </PathRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         Location = "workspace"
+         FilePath = "../output/IOS64/ipa/Payload/XCSoar.app">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CBFD0922D742E1000F05795"
+            BuildableName = "XCSoar"
+            BlueprintName = "XCSoar"
+            ReferencedContainer = "container:XCSoar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Mac.xcscheme
+++ b/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Mac.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "2.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "if [ &quot;$ACTION&quot; = &quot;clean&quot; ]; then&#10;  $WORKSPACE_PATH/../../clean.sh&#10;fi&#10;">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5CBFD0922D742E1000F05795"
+               BuildableName = "XCSoar"
+               BlueprintName = "XCSoar"
+               ReferencedContainer = "container:XCSoar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         Location = "workspace"
+         FilePath = "../output/MACOS/bin/xcsoar">
+      </PathRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <PathRunnable
+         runnableDebuggingMode = "0"
+         Location = "workspace"
+         FilePath = "../output/MACOS/bin/xcsoar">
+      </PathRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5CBFD0922D742E1000F05795"
+            BuildableName = "XCSoar"
+            BlueprintName = "XCSoar"
+            ReferencedContainer = "container:XCSoar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Simulator.xcscheme
+++ b/darwin/XCSoar.xcodeproj/xcshareddata/xcschemes/XCSoar-Simulator.xcscheme
@@ -52,7 +52,7 @@
       <PathRunnable
          runnableDebuggingMode = "0"
          Location = "workspace"
-         FilePath = "XCSoarExecutable">
+         FilePath = "../output/IOS64SIM/ipa/Payload/XCSoar.app">
       </PathRunnable>
    </LaunchAction>
    <ProfileAction
@@ -64,7 +64,7 @@
       <PathRunnable
          runnableDebuggingMode = "0"
          Location = "workspace"
-         FilePath = "XCSoarExecutable">
+         FilePath = "../output/IOS64SIM/ipa/Payload/XCSoar.app">
       </PathRunnable>
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Addresses https://github.com/XCSoar/XCSoar/issues/1885.

The previous symlink-based executable switching was unreliable with recent Xcode versions. Now, separate Xcode schemes directly launch the correct app bundle for simulator, device, and macOS. This resolves issues with Xcode failing to launch the app due to missing or misidentified executables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and updated Xcode schemes to standardize device, simulator, and Mac build/test/launch/profile/analyze/archive workflows.
  * Simplified build flow by removing fragile symlink/temp-dir steps and enabling testing during builds.
  * Improved signing flow with configurable inputs, in-place signing using extracted entitlements, clearer validation/error/status messages, and stable output locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->