### PR TITLE
build/python/libs.py,cmake.py: Strip OpenSSL building on Darwin...

### DIFF
--- a/build/python/build/cmake.py
+++ b/build/python/build/cmake.py
@@ -124,11 +124,13 @@ class CmakeProject(Project):
     def __init__(self, url: Union[str, Sequence[str]], md5: str, installed: str,
                  configure_args: list[str]=[],
                  windows_configure_args: list[str]=[],
+                 darwin_configure_args: list[str]=[],
                  env: Optional[Mapping[str, str]]=None,
                  **kwargs):
         Project.__init__(self, url, md5, installed, **kwargs)
         self.configure_args = configure_args
         self.windows_configure_args = windows_configure_args
+        self.darwin_configure_args = darwin_configure_args
         self.env = env
 
     def configure(self, toolchain: AnyToolchain) -> str:
@@ -137,6 +139,8 @@ class CmakeProject(Project):
         configure_args = self.configure_args
         if toolchain.is_windows:
             configure_args = configure_args + self.windows_configure_args
+        if toolchain.is_darwin:
+            configure_args = configure_args + self.darwin_configure_args
         configure(toolchain, src, build, configure_args, self.env)
         return build
 

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -245,6 +245,12 @@ curl = CmakeProject(
     windows_configure_args=[
         "-DCURL_USE_SCHANNEL=ON",
     ],
+    # Darwin/iOS: use SecureTransport for SSL
+    darwin_configure_args=[
+        "-DCMAKE_USE_OPENSSL=OFF",
+        "-DCURL_USE_OPENSSL=OFF",
+        "-DCURL_USE_SECTRANSP=ON",
+    ],
     patches=abspath("lib/curl/patches"),
 )
 

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -59,7 +59,6 @@ elif toolchain.is_darwin:
         zlib,
         libfmt,
         libsodium,
-        openssl,
         cares,
         curl,
         lua,


### PR DESCRIPTION
...to speed up compilation

On Darwin (macOS/iOS), OpenSSL is not required for curl and related libraries. This change disables OpenSSL in CMake configuration for Darwin targets, reducing build time and avoiding unnecessary compilation of OpenSSL sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-specific build configuration support for Darwin/macOS/iOS environments, enabling native SSL/TLS handling via Secure Transport for curl builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->