### PR TITLE
iOS: src/Input/InputConfig.cpp: Make key codes uppercase...

### DIFF
--- a/src/Input/InputConfig.cpp
+++ b/src/Input/InputConfig.cpp
@@ -54,6 +54,13 @@ InputConfig::GetKeyEvent(unsigned mode, unsigned key_code) const noexcept
   }
 #endif
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  // On iOS, map lowercase letters to uppercase
+  if (key_code_idx >= 'a' && key_code_idx <= 'z') {
+    key_code_idx -= ('a' - 'A');
+  }
+#endif
+
 #ifdef USE_X11
   if (key_code_idx >= 0xff00) {
     key_code_idx -= 0xff00;


### PR DESCRIPTION
… before event lookup

Addresses https://github.com/XCSoar/XCSoar/issues/1808.

On iOS/SDL2, at least the simulator sends lowercase key codes (e.g., 'c' instead of 'C') even when Shift is pressed, but the mapping and generated code only use uppercase key codes. This caused key events for letters to be missed. Now, key codes are converted to uppercase before event lookup, making the mapping case-insensitive for ASCII letters and fixing the issue where lowercase key presses would not trigger mapped events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling on iOS by implementing proper normalization for letter keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->