### PR TITLE
cares/Channel.cxx: Only report error if all address resolutions fail

### DIFF
--- a/src/event/net/cares/Channel.cxx
+++ b/src/event/net/cares/Channel.cxx
@@ -173,6 +173,7 @@ private:
     }
 
     if (addressinfo) {
+      success = true;
       for (auto node = addressinfo->nodes; node; node = node->ai_next)
         AsSocketAddress(node, [handler = handler](SocketAddress addr) { handler->OnCaresAddress(addr); });
       if (--pending == 0) {
@@ -183,7 +184,11 @@ private:
     } else {
       // Treat null addressinfo as DNS error, even if status == ARES_SUCCESS
       if (--pending == 0) {
-        handler->OnCaresError(std::make_exception_ptr(Error(status, "ares_getaddrinfo() returned no addresses")));
+        if (!success) {
+          handler->OnCaresError(std::make_exception_ptr(Error(status, "ares_getaddrinfo() returned no addresses")));
+        } else {
+          handler->OnCaresSuccess();
+        }
         self.reset();
       }
       return;


### PR DESCRIPTION
Previously, the DNS handler would call OnCaresError when no addresses were returned, even if a prior callback had already succeeded. This change ensures that OnCaresError is only called if all address resolution attempts fail, preventing spurious error reporting when at least one resolution was successful.

See https://github.com/XCSoar/XCSoar/pull/1915#discussion_r2449047208 for context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS/address resolution handling so a prior successful lookup is preserved even if later responses contain no address data, preventing unnecessary error notifications.
  * Error reporting now occurs only when no successful resolution was ever achieved, reducing spurious errors while keeping genuine failures visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->