### PR TITLE
Dialogs/Weather/RaspDialog.cpp: initialize TIME DataFieldEnum with at

### DIFF
--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -126,7 +126,14 @@ RASPSettingsPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
   wp->GetDataField()->EnableItemHelp(true);
   FillItemControl();
 
-  AddEnum(_("Time"), nullptr);
+  wp = AddEnum(_("Time"), nullptr);
+  // Initialize TIME field with at least "Now" to prevent assertion failures
+  // when GetValue() is called before UpdateTimeControl() completes
+  {
+    DataFieldEnum &time_df = (DataFieldEnum &)GetDataField(TIME);
+    time_df.ClearChoices();
+    time_df.addEnumText(_("Now"));
+  }
   wp->GetDataField()->SetOnModified([this]{
     const unsigned value = GetValueEnum(TIME);
     time = value > 0


### PR DESCRIPTION
least NOW

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an initialization issue in the Weather dialog that prevented proper time selection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->