### PR TITLE
Mockup/ogntraffic - Forwarding of OGN Traffic via xcsoar-cloud

### DIFF
--- a/build/cloud.mk
+++ b/build/cloud.mk
@@ -6,8 +6,10 @@ CLOUD_SERVER_SOURCES = \
 	$(SRC)/Cloud/Thermal.cpp \
 	$(SRC)/Cloud/Data.cpp \
 	$(SRC)/Cloud/Sender.cpp \
+	$(SRC)/Cloud/OGNTraffic.cpp \
+	$(SRC)/Cloud/OGNClient.cpp \
 	$(SRC)/Cloud/Main.cpp
-CLOUD_SERVER_DEPENDS = ASYNC LIBNET IO OS GEO MATH UTIL
+CLOUD_SERVER_DEPENDS = ASYNC LIBNET IO OS GEO MATH UTIL TIME
 $(eval $(call link-program,xcsoar-cloud-server,CLOUD_SERVER))
 
 CLOUD_TO_KML_SOURCES = \
@@ -15,6 +17,7 @@ CLOUD_TO_KML_SOURCES = \
 	$(SRC)/Cloud/Serialiser.cpp \
 	$(SRC)/Cloud/Client.cpp \
 	$(SRC)/Cloud/Thermal.cpp \
+	$(SRC)/Cloud/OGNTraffic.cpp \
 	$(SRC)/Cloud/Data.cpp \
 	$(SRC)/Cloud/ToKML.cpp
 CLOUD_TO_KML_DEPENDS = ASYNC LIBNET IO OS GEO MATH UTIL

--- a/build/main.mk
+++ b/build/main.mk
@@ -634,7 +634,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Tracking/SkyLines/Assemble.cpp \
 	$(SRC)/Tracking/SkyLines/Key.cpp \
 	$(SRC)/Tracking/SkyLines/Glue.cpp \
-	$(SRC)/Tracking/TrackingGlue.cpp
+	$(SRC)/Tracking/TrackingGlue.cpp \
+	$(SRC)/Traffic/Aggregator.cpp
 
 ifeq ($(HAVE_PCM_PLAYER),y)
 XCSOAR_SOURCES += $(SRC)/Audio/VarioGlue.cpp

--- a/build/test.mk
+++ b/build/test.mk
@@ -103,6 +103,7 @@ TEST_NAMES = \
 	TestAirspaceParser \
 	TestMETARParser \
 	TestIGCParser \
+	TestOGNAPRSParser \
 	TestStrings TestUTF8 \
 	TestCRC16 TestCRC8 \
 	TestUnitsFormatter \
@@ -194,6 +195,14 @@ TEST_AIRSPACE_PARSER_SOURCES = \
 TEST_AIRSPACE_PARSER_LDADD = $(FAKE_LIBS)
 TEST_AIRSPACE_PARSER_DEPENDS = IO OS AIRSPACE UNITS ZZIP GEO MATH UTIL UNITS
 $(eval $(call link-program,TestAirspaceParser,TEST_AIRSPACE_PARSER))
+
+TEST_OGN_APRS_PARSER_SOURCES = \
+	$(SRC)/Cloud/OGNClient.cpp \
+	$(SRC)/Cloud/OGNTraffic.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestOGNAPRSParser.cpp
+TEST_OGN_APRS_PARSER_DEPENDS = ASYNC LIBNET IO OS GEO MATH UTIL TIME EVENT FLARM
+$(eval $(call link-program,TestOGNAPRSParser,TEST_OGN_APRS_PARSER))
 
 TEST_DATE_TIME_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/src/Cloud/Data.hpp
+++ b/src/Cloud/Data.hpp
@@ -5,6 +5,7 @@
 
 #include "Client.hpp"
 #include "Thermal.hpp"
+#include "OGNTraffic.hpp"
 
 class Serialiser;
 class Deserialiser;
@@ -12,6 +13,7 @@ class Deserialiser;
 struct CloudData {
   CloudClientContainer clients;
   CloudThermalContainer thermals;
+  OGNTrafficContainer ogn_traffic;
 
   void DumpClients();
 

--- a/src/Cloud/Main.cpp
+++ b/src/Cloud/Main.cpp
@@ -5,28 +5,52 @@
 #include "Dump.hpp"
 #include "Sender.hpp"
 #include "Serialiser.hpp"
+#include "OGNClient.hpp"
 #include "Tracking/SkyLines/Server.hpp"
 #include "Tracking/SkyLines/Protocol.hpp"
 #include "util/ByteOrder.hxx"
+#include "util/CRC16CCITT.hpp"
+#include "util/SpanCast.hxx"
+#include "util/ConvertString.hpp"
 #include "event/Loop.hxx"
 #include "event/CoarseTimerEvent.hxx"
 #include "event/SignalMonitor.hxx"
+#include "event/net/cares/Channel.hxx"
 #include "net/IPv4Address.hxx"
+#include "net/SocketAddress.hxx"
 #include "io/FileOutputStream.hxx"
 #include "io/FileReader.hxx"
 #include "util/PrintException.hxx"
 #include "util/Exception.hxx"
 #include "util/Compiler.h"
 #include "util/ScopeExit.hxx"
+#include "util/StaticString.hxx"
 
 #include <array>
 #include <iostream>
 #include <iomanip>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
 
 #include <signal.h>
 
 // TODO: review these settings
-static constexpr double TRAFFIC_RANGE = 50000;
+static constexpr double TRAFFIC_RANGE = 500000; // 500km
+
+/**
+ * Calculate milliseconds since midnight UTC from current system time.
+ */
+static uint32_t
+GetTimeOfDayMs() noexcept
+{
+  const auto now = std::chrono::system_clock::now();
+  const auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+    now.time_since_epoch()).count();
+  const auto ms_since_midnight = ms_since_epoch % (24 * 60 * 60 * 1000);
+  
+  return (uint32_t)ms_since_midnight;
+}
 static constexpr double THERMAL_RANGE = 50000;
 
 static constexpr std::chrono::steady_clock::duration MAX_TRAFFIC_AGE = std::chrono::minutes(15);
@@ -43,7 +67,10 @@ class CloudServer final
 {
   const AllocatedPath db_path;
 
-  CoarseTimerEvent save_timer, expire_timer;
+  CoarseTimerEvent save_timer, expire_timer, ogn_expire_timer;
+
+  Cares::Channel cares_channel;
+  OGNClient ogn_client;
 
 public:
   CloudServer(AllocatedPath &&_db_path, EventLoop &event_loop,
@@ -51,7 +78,10 @@ public:
     :SkyLinesTracking::Server(event_loop, bind_address),
      db_path(std::move(_db_path)),
      save_timer(event_loop, BIND_THIS_METHOD(OnSaveTimer)),
-     expire_timer(event_loop, BIND_THIS_METHOD(OnExpireTimer))
+     expire_timer(event_loop, BIND_THIS_METHOD(OnExpireTimer)),
+     ogn_expire_timer(event_loop, BIND_THIS_METHOD(OnOGNExpireTimer)),
+     cares_channel(event_loop),
+     ogn_client(event_loop, cares_channel, ogn_traffic)
   {
 #ifndef _WIN32
     SignalMonitorRegister(SIGINT, BIND_THIS_METHOD(OnQuitSignal));
@@ -63,6 +93,12 @@ public:
 #endif
 
     ScheduleSave();
+
+    // OGN client - use full feed (port 10152)
+    ogn_client.SetServer("aprs.glidernet.org", 10152);
+    ogn_client.SetEnabled(true);  // Connect immediately
+
+    ScheduleOGNExpire();
   }
 
   void Load();
@@ -88,6 +124,16 @@ private:
     expire_timer.Schedule(std::chrono::minutes(5));
   }
 
+  void OnOGNExpireTimer() noexcept {
+    ogn_traffic.Expire(GetEventLoop().SteadyNow() - MAX_TRAFFIC_AGE);
+    if (!ogn_traffic.empty())
+      ScheduleOGNExpire();
+  }
+
+  void ScheduleOGNExpire() {
+    ogn_expire_timer.Schedule(std::chrono::minutes(5));
+  }
+
 protected:
   /* virtual methods from class SkyLinesTracking::Server */
   void OnFix(const Client &client,
@@ -96,6 +142,9 @@ protected:
 
   void OnTrafficRequest(const Client &client,
                         bool near) override;
+
+  void OnUserNameRequest(const Client &client,
+                         uint32_t user_id) override;
 
   void OnWaveSubmit(const Client &client,
                     std::chrono::milliseconds time_of_day,
@@ -166,8 +215,13 @@ CloudServer::OnFix(const Client &c,
       ScheduleExpire();
   } else {
     client = clients.Find(c.key);
-    if (client != nullptr)
+    if (client != nullptr) {
+      GeoPoint old_location = client->location;
       clients.Refresh(*client, c.address);
+      // Update OGN filter if client location changed significantly
+      // (Refresh only updates address, not location, so skip filter update)
+      (void)old_location;
+    }
   }
 
   /* send this new traffic location to all interested clients
@@ -193,25 +247,46 @@ CloudServer::OnFix(const Client &c,
 void
 CloudServer::OnTrafficRequest(const Client &c, bool near)
 {
+  cout << "TRAFFIC_REQUEST_RAW\t"
+       << static_cast<SocketAddress>(c.address) << '\t'
+       << std::hex << c.key << std::dec << '\t'
+       << "near=" << (near ? "true" : "false")
+       << endl;
+
   if (!near)
     /* "near" is the only selection flag we know */
     return;
 
   auto *client = clients.Find(c.key);
-  if (client == nullptr)
+  if (client == nullptr) {
+    cout << "TRAFFIC_REQUEST_REJECTED\t"
+         << "client not found for key="
+         << std::hex << c.key << std::dec
+         << endl;
     /* we don't send our data to clients who didn't sent anything to
        us yet */
     return;
+  }
 
   const auto now = std::chrono::steady_clock::now();
 
   client->wants_traffic = now + REQUEST_EXPIRY;
+
+  cout << "TRAFFIC_REQUEST\t"
+       << client->address << '\t'
+       << std::hex << client->key << std::dec << '\t'
+       << "id=" << client->id << '\t'
+       << client->location << '\t'
+       << client->altitude << "m"
+       << endl;
 
   const auto min_stamp = now - MAX_TRAFFIC_AGE;
 
   TrafficResponseSender s(*this, c.address, c.key);
 
   unsigned n = 0;
+
+  // Add XCSoar client traffic
   for (const auto &traffic : clients.QueryWithinRange(client->location,
                                                       TRAFFIC_RANGE)) {
     if (traffic.get() == client)
@@ -221,14 +296,215 @@ CloudServer::OnTrafficRequest(const Client &c, bool near)
       /* don't send stale traffic, it's probably not there anymore */
       continue;
 
-    s.Add(traffic->id, 0, //TODO: time?
+    // Calculate time-of-day: current time minus age of traffic
+    auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now - traffic->stamp).count();
+    uint32_t time_of_day = GetTimeOfDayMs();
+    if (age_ms < (int64_t)time_of_day) {
+      time_of_day -= (uint32_t)age_ms;
+    } else {
+      // Handle wraparound (traffic older than current time-of-day)
+      time_of_day = 0;
+    }
+
+    s.Add(traffic->id, time_of_day,
           traffic->location, traffic->altitude);
+
+    cout << "TRAFFIC_SEND\tXCSoar\t"
+         << std::hex << client->key << std::dec << '\t'
+         << "id=" << traffic->id << '\t'
+         << traffic->location << '\t'
+         << traffic->altitude << "m"
+         << endl;
 
     if (++n > 64)
       break;
   }
 
+  // Add OGN traffic
+  unsigned ogn_count = 0;
+  unsigned ogn_expired = 0;
+  
+  cout << "TRAFFIC_QUERY\tOGN\t"
+       << "client_location=" << client->location
+       << " range=" << TRAFFIC_RANGE << "m"
+       << endl;
+  
+  // Debug: check if container is empty
+  if (ogn_traffic.empty()) {
+    cout << "TRAFFIC_QUERY\tOGN\tcontainer is empty" << endl;
+  }
+  
+  unsigned query_count = 0;
+  for (const auto &ogn : ogn_traffic.QueryWithinRange(client->location,
+                                                       TRAFFIC_RANGE)) {
+    query_count++;
+    
+    // Debug: log all items found
+    auto distance = client->location.Distance(ogn->location);
+    auto age = std::chrono::duration_cast<std::chrono::seconds>(
+      now - ogn->stamp).count();
+    cout << "TRAFFIC_FOUND\tOGN\tdevice=" << ogn->device_id.c_str()
+         << " distance=" << (int)distance << "m"
+         << " location=" << ogn->location
+         << " alt=" << ogn->altitude << "m"
+         << " stamp_age=" << age << "s"
+         << endl;
+    
+    if (ogn->stamp < min_stamp) {
+      ogn_expired++;
+      cout << "TRAFFIC_FILTER\tOGN\t" << ogn->device_id.c_str()
+           << " expired (age=" << age << "s)" << endl;
+      continue;
+    }
+    
+    // Debug: log all matches that will be sent
+    cout << "TRAFFIC_MATCH\tOGN\t" << ogn->device_id.c_str()
+         << " distance=" << (int)distance << "m"
+         << " location=" << ogn->location
+         << " alt=" << ogn->altitude << "m"
+         << endl;
+
+    // Calculate time-of-day: current time minus age of traffic
+    auto age_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+      now - ogn->stamp).count();
+    uint32_t time_of_day = GetTimeOfDayMs();
+    if (age_ms < (int64_t)time_of_day) {
+      time_of_day -= (uint32_t)age_ms;
+    } else {
+      // Handle wraparound (traffic older than current time-of-day)
+      time_of_day = 0;
+    }
+
+    s.Add(ogn->id, time_of_day,
+          ogn->location, ogn->altitude, ogn->flarm_id,
+          ogn->track, ogn->turn_rate, ogn->aircraft_type);
+
+    cout << "TRAFFIC_SEND\tOGN\t"
+         << std::hex << client->key << std::dec << '\t'
+         << "id=" << ogn->id << '\t'
+         << "flarm_id=" << ogn->flarm_id << '\t'
+         << "device=" << ogn->device_id.c_str() << '\t'
+         << ogn->location << '\t'
+         << ogn->altitude << "m\t"
+         << ogn->track << "°\t"
+         << ogn->speed << "m/s\t"
+         << ogn->climb_rate << "m/s\t"
+         << "turn=" << ogn->turn_rate << "deg/s\t"
+         << "type=" << (unsigned)ogn->aircraft_type
+         << endl;
+
+    ogn_count++;
+    if (++n > 64)
+      break;
+  }
+
+  cout << "TRAFFIC_SEND\tSummary\t"
+       << std::hex << client->key << std::dec << '\t'
+       << "total=" << n << '\t'
+       << "ogn=" << ogn_count
+       << " (query_found=" << query_count
+       << " expired=" << ogn_expired << ")"
+       << endl;
+
   s.Flush();
+}
+
+void
+CloudServer::OnUserNameRequest(const Client &c, uint32_t user_id)
+{
+  // Check if this is an OGN traffic ID (high IDs starting at 0x80000000)
+  if (user_id >= 0x80000000) {
+    auto *ogn = ogn_traffic.FindById(user_id);
+    if (ogn != nullptr) {
+      // Send USER_NAME_RESPONSE with OGN device identifier
+      const tstring &device_id = ogn->device_id;
+      
+      // Convert device_id to UTF-8
+      WideToUTF8Converter device_id_utf8(device_id.c_str());
+      const size_t name_length = strlen(device_id_utf8);
+      
+      // Construct USER_NAME_RESPONSE packet with name data
+      struct UserNameResponsePacket {
+        SkyLinesTracking::Header header;
+        uint32_t user_id;
+        uint32_t flags;
+        uint32_t club_id;
+        uint8_t name_length;
+        uint8_t reserved1, reserved2, reserved3;
+        uint32_t reserved4, reserved5;
+        char name[256];  // Max name length
+      } packet;
+      
+      if (name_length > sizeof(packet.name))
+        return;  // Name too long
+      
+      packet.header.magic = ToBE32(SkyLinesTracking::MAGIC);
+      packet.header.crc = 0;
+      packet.header.type = ToBE16(SkyLinesTracking::Type::USER_NAME_RESPONSE);
+      packet.header.key = ToBE64(c.key);
+      packet.user_id = ToBE32(user_id);
+      packet.flags = 0;  // Not NOT_FOUND
+      packet.club_id = 0;
+      packet.name_length = name_length;
+      packet.reserved1 = 0;
+      packet.reserved2 = 0;
+      packet.reserved3 = 0;
+      packet.reserved4 = 0;
+      packet.reserved5 = 0;
+      memcpy(packet.name, device_id_utf8, name_length);
+      
+      // Calculate CRC over entire packet (header + name)
+      const size_t packet_size = sizeof(packet.header) + sizeof(packet.user_id) +
+        sizeof(packet.flags) + sizeof(packet.club_id) + sizeof(packet.name_length) +
+        sizeof(packet.reserved1) + sizeof(packet.reserved2) + sizeof(packet.reserved3) +
+        sizeof(packet.reserved4) + sizeof(packet.reserved5) + name_length;
+      packet.header.crc = ToBE16(UpdateCRC16CCITT(
+        std::span<const std::byte>(reinterpret_cast<const std::byte *>(&packet),
+                                    packet_size), 0));
+      
+      // Send entire packet (header + name)
+      SendBuffer(c.address, std::span<const std::byte>(
+        reinterpret_cast<const std::byte *>(&packet), packet_size));
+      
+      cout << "USER_NAME_RESPONSE\t"
+           << std::hex << c.key << std::dec << '\t'
+           << "user_id=" << user_id << '\t'
+           << "device_id=" << device_id.c_str()
+           << endl;
+      return;
+    }
+  }
+  
+  // Not found - send NOT_FOUND response
+  struct UserNameResponsePacket {
+    SkyLinesTracking::Header header;
+    uint32_t user_id;
+    uint32_t flags;
+    uint32_t club_id;
+    uint8_t name_length;
+    uint8_t reserved1, reserved2, reserved3;
+    uint32_t reserved4, reserved5;
+  } packet;
+  
+  packet.header.magic = ToBE32(SkyLinesTracking::MAGIC);
+  packet.header.crc = 0;
+  packet.header.type = ToBE16(SkyLinesTracking::Type::USER_NAME_RESPONSE);
+  packet.header.key = ToBE64(c.key);
+  packet.user_id = ToBE32(user_id);
+  packet.flags = ToBE32(SkyLinesTracking::UserNameResponsePacket::FLAG_NOT_FOUND);
+  packet.club_id = 0;
+  packet.name_length = 0;
+  packet.reserved1 = 0;
+  packet.reserved2 = 0;
+  packet.reserved3 = 0;
+  packet.reserved4 = 0;
+  packet.reserved5 = 0;
+  
+  packet.header.crc = ToBE16(UpdateCRC16CCITT(
+    ReferenceAsBytes(packet), 0));
+  
+  SendPacket(c.address, packet);
 }
 
 void
@@ -370,12 +646,37 @@ CloudServer::Save()
 int
 main(int argc, char **argv)
 try {
-  if (argc != 2) {
-    cerr << "Usage: " << argv[0] << " DBPATH" << endl;
+  const char *db_path_arg = nullptr;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+      cerr << "Usage: " << argv[0] << " DBPATH [OPTIONS]" << endl;
+      cerr << "Options:" << endl;
+      cerr << "  --help, -h                Show this help message" << endl;
+      return EXIT_SUCCESS;
+    } else if (argv[i][0] != '-') {
+      // Positional argument (DBPATH)
+      if (db_path_arg == nullptr) {
+        db_path_arg = argv[i];
+      } else {
+        cerr << "Error: Multiple DBPATH arguments" << endl;
+        return EXIT_FAILURE;
+      }
+    } else {
+      cerr << "Error: Unknown option: " << argv[i] << endl;
+      cerr << "Use --help for usage information" << endl;
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (db_path_arg == nullptr) {
+    cerr << "Usage: " << argv[0] << " DBPATH [OPTIONS]" << endl;
+    cerr << "Use --help for more information" << endl;
     return EXIT_FAILURE;
   }
 
-  const Path db_path(argv[1]);
+  const Path db_path(db_path_arg);
 
   EventLoop event_loop;
   SignalMonitorInit(event_loop);

--- a/src/Cloud/OGNClient.cpp
+++ b/src/Cloud/OGNClient.cpp
@@ -1,0 +1,569 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "OGNClient.hpp"
+#include "Dump.hpp"
+#include "FLARM/Traffic.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Math/Angle.hpp"
+#include "OGNTraffic.hpp"
+#include "util/CharUtil.hxx"
+#include "util/NumberParser.hxx"
+#include "util/StringCompare.hxx"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+using std::cerr;
+using std::cout;
+using std::endl;
+
+OGNClient::OGNClient(EventLoop &_event_loop, Cares::Channel &_cares,
+                     OGNTrafficContainer &_traffic_container)
+    : event_loop(_event_loop), traffic_container(_traffic_container),
+      cares_channel(&_cares),
+      socket_event(event_loop, BIND_THIS_METHOD(OnSocketReady)),
+      reconnect_timer(event_loop, BIND_THIS_METHOD(OnReconnectTimer)),
+      keepalive_timer(event_loop, BIND_THIS_METHOD(OnKeepaliveTimer))
+{
+}
+
+OGNClient::~OGNClient() { Close(); }
+
+void
+OGNClient::Open()
+{
+  if (!enabled || server == nullptr || port == 0) return;
+
+  Close();
+
+  // Based on python-ogn-client:
+  // - Port 10152 = full feed (unfiltered)
+  // - Port 14580 = filtered feeds
+  // If filter is set, we should use 14580, otherwise 10152
+  // But for now, we'll use the configured port and let the caller set it
+  // correctly (Main.cpp sets port 10152 for unfiltered, and we'll switch to
+  // 14580 when filters are added)
+
+  resolver.emplace(*this, port);
+  resolver->Start(*cares_channel, server);
+}
+
+void
+OGNClient::Close()
+{
+  reconnect_timer.Cancel();
+  keepalive_timer.Cancel();
+  resolver.reset();
+  connect.reset();
+  socket_event.Close();
+  input_buffer.clear();
+  resolved_addresses.clear();
+}
+
+void
+OGNClient::OnResolverSuccess(
+    std::forward_list<AllocatedSocketAddress> addresses) noexcept
+{
+  resolver.reset();
+
+  if (addresses.empty()) {
+    cerr << "OGN: No address resolved" << endl;
+    reconnect_timer.Schedule(std::chrono::seconds(30));
+    return;
+  }
+
+  // Store all addresses and try them one by one
+  resolved_addresses = std::move(addresses);
+  current_address = resolved_addresses.begin();
+  TryNextAddress();
+}
+
+void
+OGNClient::TryNextAddress() noexcept
+{
+  if (current_address == resolved_addresses.end()) {
+    // All addresses exhausted
+    cerr << "OGN: All connection attempts failed" << endl;
+    resolved_addresses.clear();
+    reconnect_timer.Schedule(std::chrono::seconds(30));
+    return;
+  }
+
+  address = *current_address;
+  connect.emplace(event_loop, *this);
+  connect->Connect(address, std::chrono::seconds(30));
+}
+
+void
+OGNClient::OnResolverError([[maybe_unused]] std::exception_ptr error) noexcept
+{
+  resolver.reset();
+  cerr << "OGN: Resolver error" << endl;
+  reconnect_timer.Schedule(std::chrono::seconds(30));
+}
+
+void
+OGNClient::OnSocketConnectSuccess(UniqueSocketDescriptor fd) noexcept
+{
+  connect.reset();
+  resolved_addresses.clear(); // Clear address list on success
+
+  socket_event.Open(fd.Release());
+  socket_event.ScheduleRead();
+
+  cout << "OGN: Connected to " << server << ":" << port << endl;
+
+  keepalive_timer.Schedule(std::chrono::seconds(240));
+}
+
+void
+OGNClient::OnSocketConnectError(
+    [[maybe_unused]] std::exception_ptr ep) noexcept
+{
+  connect.reset();
+
+  // Try next address if available
+  if (current_address != resolved_addresses.end()) {
+    ++current_address;
+    cerr << "OGN: Connection failed, trying next address..." << endl;
+    TryNextAddress();
+    return;
+  }
+
+  // All addresses exhausted
+  cerr << "OGN: Connection error - all addresses failed" << endl;
+  resolved_addresses.clear();
+  reconnect_timer.Schedule(std::chrono::seconds(30));
+}
+
+void
+OGNClient::OnKeepaliveTimer() noexcept
+{
+  if (IsConnected()) {
+    // Send keepalive as per python-ogn-client
+    const char *keepalive = "#keepalive\n";
+    (void)socket_event.GetSocket().Write(
+        {(const std::byte *)keepalive, strlen(keepalive)});
+    // Reschedule for next keepalive (240 seconds)
+    keepalive_timer.Schedule(std::chrono::seconds(240));
+  }
+}
+
+void
+OGNClient::OnReconnectTimer() noexcept
+{
+  if (enabled && !IsConnected()) Open();
+}
+
+void
+OGNClient::OnSocketReady([[maybe_unused]] unsigned events) noexcept
+{
+  std::byte buffer[4096];
+  ssize_t nbytes = socket_event.GetSocket().Read({buffer, sizeof(buffer)});
+
+  if (nbytes < 0) {
+    cerr << "OGN: Read error" << endl;
+    Close();
+    reconnect_timer.Schedule(std::chrono::seconds(30));
+    return;
+  }
+
+  if (nbytes == 0) {
+    cerr << "OGN: Connection closed" << endl;
+    Close();
+    reconnect_timer.Schedule(std::chrono::seconds(30));
+    return;
+  }
+
+  // Append to input buffer
+  input_buffer.append((const char *)buffer, nbytes);
+
+  // Process complete lines
+  for (;;) {
+    size_t pos = input_buffer.find('\n');
+    if (pos == std::string::npos) break;
+
+    std::string line = input_buffer.substr(0, pos);
+    input_buffer.erase(0, pos + 1);
+
+    // Remove \r if present
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+
+    // Handle zero-length lines (connection failure indicator)
+    // Per python-ogn-client: "A zero length line should not be returned if
+    // keepalives are being sent"
+    if (line.empty()) {
+      cerr << "OGN: Zero-length line received - connection failure" << endl;
+      Close();
+      reconnect_timer.Schedule(std::chrono::seconds(30));
+      return;
+    }
+
+    if (!line.empty() && line[0] != '#') {
+      ProcessLine(line.c_str());
+    }
+  }
+
+  // Keep reading from socket
+  socket_event.ScheduleRead();
+}
+
+void
+OGNClient::ProcessLine(const char *line)
+{
+  // APRS-IS format: "callsign>destination,path:data"
+  const char *colon = strchr(line, ':');
+  if (colon == nullptr) {
+    // Silently skip lines without colon (not a valid APRS packet)
+    return;
+  }
+
+  // Extract callsign (before >) - this is the OGN device ID
+  const char *gt = strchr(line, '>');
+  if (gt == nullptr || gt >= colon) {
+    // Silently skip lines without > (not a valid APRS packet)
+    return;
+  }
+
+  tstring device_id(line, gt - line);
+
+  // Debug: log all beacons received
+  cout << "OGN: Received line from " << device_id.c_str() << ": " << line
+       << endl;
+
+  // Skip receiver beacons (they're not aircraft traffic)
+  // Receiver beacons have format: "LKHS>APRS,TCPIP*,qAC,GLIDERN2:/..."
+  // They contain ">APRS,TCPIP*" or "qAC" in the path
+  const char *path_start = gt + 1;
+  const char *path_end = colon;
+  if (path_end > path_start) {
+    std::string path(path_start, path_end - path_start);
+    if (path.find("APRS,TCPIP*") != std::string::npos ||
+        path.find("qAC") != std::string::npos) {
+      // This is a receiver beacon, skip it silently
+      return;
+    }
+  }
+
+  // Since we're using a bounding box filter, the server should already
+  // filter by location. Try to parse ALL position packets we receive.
+  // We'll identify OGN traffic by the packet content rather than device ID.
+  const char *packet = colon + 1;
+
+  // Only process position packets (APRS position reports start with !, /, or
+  // =)
+  if (packet[0] == '!' || packet[0] == '/' || packet[0] == '=') {
+    // Debug: log all position packets being processed
+    cout << "OGN: Processing position packet from " << device_id.c_str()
+         << ": " << packet << endl;
+    // Try to parse as OGN position packet
+    ParseAPRSPacket(packet, device_id);
+  } else {
+    // Debug: log non-position packets
+    cout << "OGN: Skipping non-position packet from " << device_id.c_str()
+         << " (starts with '" << packet[0] << "')" << endl;
+  }
+}
+
+void
+OGNClient::ParseAPRSPacket(const char *packet, const tstring &device_id)
+{
+  // Look for OGN position packets
+  // Format: "!ddmm.hhN/dddmm.hhW.../A=aaaaaa ..."
+  // or: "/ddmm.hhN/dddmm.hhW.../A=aaaaaa ..."
+
+  if (packet[0] != '!' && packet[0] != '/' && packet[0] != '=') return;
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  if (!ParseOGNPosition(packet, location, altitude, track, speed, climb_rate,
+                        turn_rate, aircraft_type, track_received)) {
+    // Debug: log parsing failures (increased limit to see more)
+    static int parse_fail_count = 0;
+    if (parse_fail_count++ < 20) {
+      cout << "OGN: Failed to parse position from " << device_id.c_str()
+           << ": " << packet << endl;
+    }
+    return;
+  }
+
+  if (!location.IsValid()) {
+    static int invalid_count = 0;
+    if (invalid_count++ < 5) {
+      cout << "OGN: Invalid location from " << device_id.c_str() << endl;
+    }
+    return;
+  }
+
+  traffic_container.Make(device_id, location, altitude, track, speed,
+                         climb_rate, turn_rate, aircraft_type);
+
+  // Debug: log all successful storage
+  cout << "OGN: Stored traffic: " << device_id.c_str() << " at " << location
+       << " alt=" << altitude << "m"
+       << " track=" << track << "°"
+       << " speed=" << speed << "m/s"
+       << " climb=" << climb_rate << "m/s"
+       << " turn=" << turn_rate << "deg/s"
+       << " type=" << (unsigned)aircraft_type << endl;
+}
+
+static unsigned
+HexDigitValue(char c)
+{
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  return 0;
+}
+
+bool
+OGNClient::ParseOGNPosition(const char *packet, GeoPoint &location,
+                            int &altitude, unsigned &track, unsigned &speed,
+                            int &climb_rate, double &turn_rate,
+                            FlarmTraffic::AircraftType &aircraft_type,
+                            bool &track_received)
+{
+  // Parse latitude: ddmm.hhN or ddmm.hhS
+  if (packet[0] != '!' && packet[0] != '/' && packet[0] != '=') return false;
+
+  const char *p = packet + 1;
+
+  // Skip timestamp if present (hhmmss)
+  if (IsDigitASCII(p[0]) && IsDigitASCII(p[1]) && IsDigitASCII(p[2]) &&
+      IsDigitASCII(p[3]) && IsDigitASCII(p[4]) && IsDigitASCII(p[5])) {
+    p += 6;
+    if (*p == 'h' || *p == 'z' || *p == '/') p++;
+  }
+
+  // Parse latitude ddmm.hh
+  if (!IsDigitASCII(p[0]) || !IsDigitASCII(p[1])) return false;
+
+  int lat_deg = (p[0] - '0') * 10 + (p[1] - '0');
+  p += 2;
+
+  if (!IsDigitASCII(p[0]) || !IsDigitASCII(p[1])) return false;
+
+  int lat_min = (p[0] - '0') * 10 + (p[1] - '0');
+  p += 2;
+
+  if (*p == '.') {
+    p++;
+    if (IsDigitASCII(p[0]) && IsDigitASCII(p[1])) {
+      int lat_hundredths = (p[0] - '0') * 10 + (p[1] - '0');
+      lat_min = lat_min * 100 + lat_hundredths;
+      p += 2;
+    }
+  }
+
+  char lat_dir = *p++;
+  if (lat_dir != 'N' && lat_dir != 'S') return false;
+
+  double latitude = lat_deg + lat_min / 6000.0;
+  if (lat_dir == 'S') latitude = -latitude;
+
+  // Parse symbol to determine aircraft type
+  // OGN uses various symbols: /, \, ', ^, etc. depending on aircraft type
+  char symbol = *p;
+  switch (symbol) {
+  case '/':
+    aircraft_type = FlarmTraffic::AircraftType::GLIDER;
+    break;
+  case '\\':
+    aircraft_type = FlarmTraffic::AircraftType::POWERED_AIRCRAFT;
+    break;
+  case '\'':
+    aircraft_type = FlarmTraffic::AircraftType::HANG_GLIDER;
+    break;
+  case '^':
+    aircraft_type = FlarmTraffic::AircraftType::PARA_GLIDER;
+    break;
+  case 'O':
+    aircraft_type = FlarmTraffic::AircraftType::BALLOON;
+    break;
+  case 'g':
+  case 'z':
+    aircraft_type = FlarmTraffic::AircraftType::UAV;
+    break;
+  default:
+    aircraft_type = FlarmTraffic::AircraftType::UNKNOWN;
+    break;
+  }
+
+  if (*p == '/' || *p == '\\' || *p == '\'' || *p == '^' || *p == 'X' ||
+      *p == 'g' || *p == 'O' || *p == 'z' || *p == 'n')
+    p++;
+
+  // Parse longitude dddmm.hh
+  if (!IsDigitASCII(p[0]) || !IsDigitASCII(p[1]) || !IsDigitASCII(p[2]))
+    return false;
+
+  int lon_deg = (p[0] - '0') * 100 + (p[1] - '0') * 10 + (p[2] - '0');
+  p += 3;
+
+  if (!IsDigitASCII(p[0]) || !IsDigitASCII(p[1])) return false;
+
+  int lon_min = (p[0] - '0') * 10 + (p[1] - '0');
+  p += 2;
+
+  if (*p == '.') {
+    p++;
+    if (IsDigitASCII(p[0]) && IsDigitASCII(p[1])) {
+      int lon_hundredths = (p[0] - '0') * 10 + (p[1] - '0');
+      lon_min = lon_min * 100 + lon_hundredths;
+      p += 2;
+    }
+  }
+
+  char lon_dir = *p++;
+  if (lon_dir != 'E' && lon_dir != 'W') return false;
+
+  double longitude = lon_deg + lon_min / 6000.0;
+  if (lon_dir == 'W') longitude = -longitude;
+
+  location = GeoPoint(Angle::Degrees(longitude), Angle::Degrees(latitude));
+
+  // Parse course/speed: format is 'ttt/sss or 'ttt/ss where ' is the symbol
+  // The symbol after longitude can be various characters depending on aircraft
+  // type In OGN packets, ^ and & are also used as course/speed separators
+  track_received = false; // Initialize to false, set to true if track is found
+  if ((*p == '\'' || *p == '/' || *p == '\\' || *p == '^' || *p == '&') &&
+      IsDigitASCII(p[1]) && IsDigitASCII(p[2]) && IsDigitASCII(p[3])) {
+    // Course in degrees
+    unsigned parsed_track =
+        (p[1] - '0') * 100 + (p[2] - '0') * 10 + (p[3] - '0');
+    if (parsed_track <= 359) {
+      track = parsed_track;
+      track_received = true; // Track was successfully parsed from packet
+    }
+    p += 4;
+    if (*p == '/') {
+      p++;
+      if (IsDigitASCII(p[0]) && IsDigitASCII(p[1])) {
+        // Speed in knots (2 or 3 digits)
+        speed = (p[0] - '0') * 10 + (p[1] - '0');
+        p += 2;
+        if (IsDigitASCII(p[0])) {
+          speed = speed * 10 + (p[0] - '0');
+          p++;
+        }
+        // Convert knots to m/s (1 knot = 0.514444 m/s)
+        speed = (unsigned)(speed * 0.514444 + 0.5);
+      }
+    }
+  }
+
+  // Parse additional data: /A=aaaaaa (altitude), OGN-specific fields, etc.
+  while (*p != '\0' && *p != '\r' && *p != '\n') {
+    if (*p == '/' && p[1] == 'A' && p[2] == '=') {
+      // Altitude in feet
+      p += 3;
+      char *end;
+      long alt_ft = strtol(p, &end, 10);
+      if (end > p) {
+        altitude = (int)(alt_ft * 0.3048); // Convert to meters
+        p = end;
+        continue;
+      }
+    } else if (*p == ' ' && p[1] == 'i' && p[2] == 'd') {
+      // OGN-specific: " id0ADDE626" - extract device ID from id field
+      // Format: idXXYYYYYY where XX encodes flags and YYYYYY is the address
+      p += 3; // Skip " id"
+      // The device ID is already extracted from the callsign field,
+      // but we can validate/update it here if needed
+      // Skip the id field (8 hex digits)
+      int hex_count = 0;
+      while (hex_count < 8 &&
+             ((*p >= '0' && *p <= '9') || (*p >= 'A' && *p <= 'F') ||
+              (*p >= 'a' && *p <= 'f'))) {
+        p++;
+        hex_count++;
+      }
+      continue;
+    } else if (*p == ' ' &&
+               ((p[1] == '-' || p[1] == '+') && IsDigitASCII(p[2]) &&
+                IsDigitASCII(p[3]) && IsDigitASCII(p[4]))) {
+      // OGN-specific climb rate: " -019fpm" or " +123fpm"
+      // Format: [+-]ddddfpm (feet per minute)
+      bool negative = (p[1] == '-');
+      p += 2; // Skip " -" or " +"
+      char *end;
+      long fpm = strtol(p, &end, 10);
+      if (end > p && end[0] == 'f' && end[1] == 'p' && end[2] == 'm') {
+        // Convert feet per minute to meters per second
+        // 1 fpm = 0.00508 m/s
+        climb_rate = (int)((negative ? -fpm : fpm) * 0.00508);
+        p = end + 3; // Skip "fpm"
+        continue;
+      }
+      p -= 2; // Restore if parsing failed
+    } else if (*p == ' ' && p[1] == 'r' && p[2] == 'o' && p[3] == 't') {
+      // OGN-specific turn rate: " rot=+12.5" or " rot=-5.0"
+      // Format: rot=[+-]d.d (degrees per second)
+      p += 4; // Skip " rot"
+      if (*p == '=') {
+        p++;
+        bool negative = (*p == '-');
+        if (negative || *p == '+') p++;
+        char *end;
+        double rot_value = strtod(p, &end);
+        if (end > p) {
+          turn_rate = negative ? -rot_value : rot_value;
+          p = end;
+          continue;
+        }
+      }
+      p -= 4; // Restore if parsing failed
+    } else if (*p == ' ' && p[1] == 'c' && p[2] == 'l' && p[3] == 'b' &&
+               p[4] == '=') {
+      // Alternative climb rate format: " clb=+123 " or " clb=-45 "
+      p += 5;
+      bool negative = (*p == '-');
+      if (negative || *p == '+') p++;
+      char *end;
+      long clb = strtol(p, &end, 10);
+      if (end > p) {
+        // Assume it's in fpm if no unit, or m/s if specified
+        climb_rate = negative ? -clb : clb;
+        p = end;
+      }
+      continue;
+    } else if (*p == ' ' && p[1] == 'i' && p[2] == 'd') {
+      // OGN-specific: " id0ADDE626" - extract device ID and aircraft type
+      // flags Format: idXXYYYYYY where XX encodes flags (including aircraft
+      // type)
+      p += 3; // Skip " id"
+      // Parse first two hex digits for flags
+      if (IsHexDigit(p[0]) && IsHexDigit(p[1])) {
+        unsigned flags = (HexDigitValue(p[0]) << 4) | HexDigitValue(p[1]);
+        // Bit 0-3: aircraft type (if available in flags)
+        // For now, we'll rely on symbol, but could decode from flags here
+        (void)flags; // Suppress unused variable warning
+        p += 2;
+      }
+      // Skip remaining hex digits (address)
+      int hex_count = 2;
+      while (hex_count < 8 && IsHexDigit(*p)) {
+        p++;
+        hex_count++;
+      }
+      continue;
+    }
+
+    p++;
+  }
+
+  return true;
+}

--- a/src/Cloud/OGNClient.hpp
+++ b/src/Cloud/OGNClient.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "FLARM/Traffic.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "event/CoarseTimerEvent.hxx"
+#include "event/SocketEvent.hxx"
+#include "event/net/ConnectSocket.hxx"
+#include "event/net/cares/SimpleResolver.hxx"
+#include "net/AllocatedSocketAddress.hxx"
+#include "net/UniqueSocketDescriptor.hxx"
+#include "util/StaticString.hxx"
+#include "util/tstring.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class EventLoop;
+class OGNTrafficContainer;
+namespace Cares {
+class Channel;
+}
+
+// Forward declaration for testing
+#ifdef TEST_OGN_PARSER
+class TestOGNHelper;
+#endif
+
+/**
+ * Client for connecting to OGN APRS-IS servers and parsing traffic data.
+ */
+class OGNClient final : public Cares::SimpleHandler,
+                        public ConnectSocketHandler {
+#ifdef TEST_OGN_PARSER
+  friend class TestOGNHelper;
+#endif
+  EventLoop &event_loop;
+  OGNTrafficContainer &traffic_container;
+  Cares::Channel *cares_channel = nullptr;
+
+  std::optional<Cares::SimpleResolver> resolver;
+  std::optional<ConnectSocket> connect;
+  AllocatedSocketAddress address;
+  std::forward_list<AllocatedSocketAddress> resolved_addresses;
+  std::forward_list<AllocatedSocketAddress>::const_iterator current_address;
+  SocketEvent socket_event;
+
+  std::string input_buffer;
+  CoarseTimerEvent reconnect_timer;
+  CoarseTimerEvent
+      keepalive_timer; // Send keepalives every 240s (as per python-ogn-client)
+
+  bool enabled = false;
+  const char *server = nullptr;
+  unsigned port = 0;
+
+public:
+  OGNClient(EventLoop &_event_loop, Cares::Channel &_cares,
+            OGNTrafficContainer &_traffic_container);
+  ~OGNClient();
+
+  auto &GetEventLoop() const noexcept { return event_loop; }
+
+  void SetEnabled(bool _enabled)
+  {
+    enabled = _enabled;
+    if (!enabled) Close();
+    else if (server != nullptr) Open();
+  }
+
+  void SetServer(const char *_server, unsigned _port)
+  {
+    server = _server;
+    port = _port;
+    if (enabled) Open();
+  }
+
+  void OnKeepaliveTimer() noexcept;
+
+  bool IsConnected() const { return socket_event.IsDefined(); }
+
+  void Open();
+  void Close();
+
+private:
+  void OnSocketReady(unsigned events) noexcept;
+
+  /* virtual methods from Cares::SimpleHandler */
+  void OnResolverSuccess(
+      std::forward_list<AllocatedSocketAddress> addresses) noexcept override;
+  void OnResolverError(std::exception_ptr error) noexcept override;
+
+  /* virtual methods from ConnectSocketHandler */
+  void OnSocketConnectSuccess(UniqueSocketDescriptor fd) noexcept override;
+  void OnSocketConnectError(std::exception_ptr ep) noexcept override;
+
+  void OnReconnectTimer() noexcept;
+  void TryNextAddress() noexcept;
+
+  void ProcessLine(const char *line);
+  void ParseAPRSPacket(const char *packet, const tstring &device_id);
+  bool ParseOGNPosition(const char *packet, GeoPoint &location, int &altitude,
+                        unsigned &track, unsigned &speed, int &climb_rate,
+                        double &turn_rate,
+                        FlarmTraffic::AircraftType &aircraft_type,
+                        bool &track_received);
+};

--- a/src/Cloud/OGNTraffic.cpp
+++ b/src/Cloud/OGNTraffic.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "OGNTraffic.hpp"
+#include "FLARM/Traffic.hpp"
+#include "Geo/Boost/RangeBox.hpp"
+#include "util/NumberParser.hpp"
+#include "util/StringCompare.hxx"
+#include "util/tstring.hpp"
+
+#include <boost/geometry/algorithms/distance.hpp>
+#include <boost/geometry/algorithms/intersection.hpp>
+#include <boost/geometry/strategies/strategies.hpp>
+#include <tchar.h>
+
+OGNTrafficContainer::OGNTrafficContainer() = default;
+
+OGNTrafficContainer::~OGNTrafficContainer() { clear(); }
+
+void
+OGNTrafficContainer::clear()
+{
+  while (!list.empty()) {
+    auto &traffic = list.back();
+    list.pop_back();
+    id_set.erase(id_set.iterator_to(traffic));
+    rtree.remove(traffic.shared_from_this());
+    device_map.erase(traffic.device_id);
+  }
+}
+
+OGNTraffic *
+OGNTrafficContainer::Find(const tstring &device_id)
+{
+  auto i = device_map.find(device_id);
+  return i != device_map.end() ? i->second.get() : nullptr;
+}
+
+OGNTraffic *
+OGNTrafficContainer::FindById(unsigned id)
+{
+  auto i = id_set.find(id, OGNTraffic::IdCompare());
+  return i != id_set.end() ? const_cast<OGNTraffic *>(&*i) : nullptr;
+}
+
+OGNTraffic &
+OGNTrafficContainer::Make(const tstring &device_id, const GeoPoint &location,
+                          int altitude, unsigned track, unsigned speed,
+                          int climb_rate, double turn_rate,
+                          FlarmTraffic::AircraftType aircraft_type)
+{
+  auto i = device_map.find(device_id);
+  if (i != device_map.end()) {
+    auto &traffic = *i->second;
+
+    // Update existing
+    if (location != traffic.location) {
+      auto ptr = traffic.shared_from_this();
+      rtree.remove(ptr);
+      traffic.Update(location, altitude, track, speed, climb_rate, turn_rate,
+                     aircraft_type);
+      rtree.insert(ptr);
+    } else {
+      traffic.Update(location, altitude, track, speed, climb_rate, turn_rate,
+                     aircraft_type);
+    }
+
+    // Move to front of list
+    list.erase(list.iterator_to(traffic));
+    list.push_front(traffic);
+
+    return traffic;
+  }
+
+  // Extract FlarmId from OGN device ID (for FLARM database matching)
+  // OGN uses prefixes: FLR, ICA, PAW, DD, OGN followed by hex digits
+  // Examples: "FLR123456", "ICA40697B", "PAW407B1B", "DD1234", "OGN1234"
+  unsigned flarm_id = 0;
+  const TCHAR *id_str = device_id.c_str();
+
+  // Check for known prefixes and extract hex part
+  if (StringStartsWith(id_str, _T("FLR"))) {
+    // FLARM device: "FLR123456" -> parse "123456" as hex
+#ifdef _UNICODE
+    wchar_t *endptr = nullptr;
+    const wchar_t *hex_start = id_str + 3;
+#else
+    char *endptr = nullptr;
+    const char *hex_start = id_str + 3;
+#endif
+    unsigned parsed = ParseUnsigned(hex_start, &endptr, 16);
+    if (endptr != nullptr && endptr > hex_start && parsed != 0)
+      flarm_id = parsed;
+  } else if (StringStartsWith(id_str, _T("ICA"))) {
+    // ICAO/ADS-B: "ICA40697B" -> parse "40697B" as hex
+#ifdef _UNICODE
+    wchar_t *endptr = nullptr;
+    const wchar_t *hex_start = id_str + 3;
+#else
+    char *endptr = nullptr;
+    const char *hex_start = id_str + 3;
+#endif
+    unsigned parsed = ParseUnsigned(hex_start, &endptr, 16);
+    if (endptr != nullptr && endptr > hex_start && parsed != 0)
+      flarm_id = parsed;
+  } else if (StringStartsWith(id_str, _T("PAW"))) {
+    // PilotAware device: "PAW407B1B" -> parse "407B1B" as hex (ICAO 24-bit
+    // address)
+#ifdef _UNICODE
+    wchar_t *endptr = nullptr;
+    const wchar_t *hex_start = id_str + 3;
+#else
+    char *endptr = nullptr;
+    const char *hex_start = id_str + 3;
+#endif
+    unsigned parsed = ParseUnsigned(hex_start, &endptr, 16);
+    if (endptr != nullptr && endptr > hex_start && parsed != 0)
+      flarm_id = parsed;
+  } else if (StringStartsWith(id_str, _T("DD"))) {
+    // OGN DD device: "DD1234" -> parse "1234" as hex
+#ifdef _UNICODE
+    wchar_t *endptr = nullptr;
+    const wchar_t *hex_start = id_str + 2;
+#else
+    char *endptr = nullptr;
+    const char *hex_start = id_str + 2;
+#endif
+    unsigned parsed = ParseUnsigned(hex_start, &endptr, 16);
+    if (endptr != nullptr && endptr > hex_start && parsed != 0)
+      flarm_id = parsed;
+  } else if (StringStartsWith(id_str, _T("OGN"))) {
+    // OGN device: "OGN1234" -> parse "1234" as hex
+#ifdef _UNICODE
+    wchar_t *endptr = nullptr;
+    const wchar_t *hex_start = id_str + 3;
+#else
+    char *endptr = nullptr;
+    const char *hex_start = id_str + 3;
+#endif
+    unsigned parsed = ParseUnsigned(hex_start, &endptr, 16);
+    if (endptr != nullptr && endptr > hex_start && parsed != 0)
+      flarm_id = parsed;
+  }
+
+  // Always generate a unique ID for pilot_id (separate from FlarmId)
+  unsigned unique_id = next_id++;
+
+  // Create new
+  auto traffic = std::make_shared<OGNTraffic>(unique_id, device_id, flarm_id);
+  traffic->Update(location, altitude, track, speed, climb_rate, turn_rate,
+                  aircraft_type);
+
+  list.push_front(*traffic);
+  id_set.insert(*traffic);
+  rtree.insert(traffic);
+  device_map[device_id] = traffic;
+
+  return *traffic;
+}
+
+void
+OGNTrafficContainer::Expire(std::chrono::steady_clock::time_point before)
+{
+  while (!list.empty() && list.back().stamp < before) {
+    auto &traffic = list.back();
+    auto ptr = traffic.shared_from_this();
+
+    list.pop_back();
+    id_set.erase(id_set.iterator_to(traffic));
+    rtree.remove(ptr);
+    device_map.erase(traffic.device_id);
+  }
+}
+
+OGNTrafficContainer::query_iterator_range
+OGNTrafficContainer::QueryWithinRange(GeoPoint location, double range) const
+{
+  const auto q =
+      boost::geometry::index::intersects(BoostRangeBox(location, range));
+  return {rtree.qbegin(q), rtree.qend()};
+}

--- a/src/Cloud/OGNTraffic.hpp
+++ b/src/Cloud/OGNTraffic.hpp
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "FLARM/Traffic.hpp"
+#include "Geo/Boost/GeoPoint.hpp"
+#include "util/tstring.hpp"
+
+#include <boost/geometry/index/rtree.hpp>
+#include <boost/intrusive/list.hpp>
+#include <boost/intrusive/set.hpp>
+#include <boost/range/iterator_range_core.hpp>
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+
+/**
+ * An OGN aircraft traffic entry.
+ */
+struct OGNTraffic
+    : std::enable_shared_from_this<OGNTraffic>,
+      boost::intrusive::list_base_hook<
+          boost::intrusive::link_mode<boost::intrusive::normal_link> >,
+      boost::intrusive::set_base_hook<
+          boost::intrusive::link_mode<boost::intrusive::normal_link> > {
+  /**
+   * OGN device ID (hex string, e.g., "DD1234")
+   */
+  tstring device_id;
+
+  /**
+   * Callsign/registration (if available from DDB)
+   */
+  tstring callsign;
+
+  /**
+   * Internal numeric ID for traffic responses (unique identifier).
+   */
+  const unsigned id;
+
+  /**
+   * FlarmId/ICAO ID extracted from device ID (0 if not available).
+   * This is stored separately from id to allow FLARM database matching.
+   */
+  unsigned flarm_id;
+
+  /**
+   * Time when we most recently received data.
+   */
+  std::chrono::steady_clock::time_point stamp;
+
+  /**
+   * Last known location.
+   */
+  GeoPoint location;
+
+  /**
+   * Last known altitude (meters).
+   */
+  int altitude;
+
+  /**
+   * Track (degrees, 0-359).
+   */
+  unsigned track;
+
+  /**
+   * Ground speed (m/s).
+   */
+  unsigned speed;
+
+  /**
+   * Climb rate (m/s).
+   */
+  int climb_rate;
+
+  /**
+   * Turn rate (degrees per second).
+   */
+  double turn_rate;
+
+  /**
+   * Aircraft type (from FLARM enum).
+   */
+  FlarmTraffic::AircraftType aircraft_type;
+
+  struct IdCompare {
+    [[gnu::pure]]
+    bool operator()(const OGNTraffic &a, const OGNTraffic &b) const
+    {
+      return a.id < b.id;
+    }
+
+    [[gnu::pure]]
+    bool operator()(unsigned a, const OGNTraffic &b) const
+    {
+      return a < b.id;
+    }
+
+    [[gnu::pure]]
+    bool operator()(const OGNTraffic &a, unsigned b) const
+    {
+      return a.id < b;
+    }
+  };
+
+  OGNTraffic(unsigned _id, const tstring &_device_id, unsigned _flarm_id = 0)
+      : device_id(_device_id), id(_id), flarm_id(_flarm_id),
+        stamp(std::chrono::steady_clock::now()), altitude(-1), track(0),
+        speed(0), climb_rate(0), turn_rate(0),
+        aircraft_type(FlarmTraffic::AircraftType::UNKNOWN)
+  {
+  }
+
+  void Update(const GeoPoint &_location, int _altitude, unsigned _track,
+              unsigned _speed, int _climb_rate, double _turn_rate = 0,
+              FlarmTraffic::AircraftType _aircraft_type =
+                  FlarmTraffic::AircraftType::UNKNOWN)
+  {
+    location = _location;
+    altitude = _altitude;
+    track = _track;
+    speed = _speed;
+    climb_rate = _climb_rate;
+    turn_rate = _turn_rate;
+    aircraft_type = _aircraft_type;
+    stamp = std::chrono::steady_clock::now();
+  }
+};
+
+using OGNTrafficPtr = std::shared_ptr<OGNTraffic>;
+
+/**
+ * Helper for boost::geometry::index::rtree.
+ */
+struct OGNTrafficIndexable {
+  typedef GeoPoint result_type;
+
+  [[gnu::pure]]
+  result_type operator()(const OGNTrafficPtr &traffic) const
+  {
+    return traffic->location;
+  }
+};
+
+class OGNTrafficContainer {
+  typedef boost::geometry::index::rtree<
+      OGNTrafficPtr, boost::geometry::index::rstar<16>, OGNTrafficIndexable>
+      Tree;
+
+  typedef boost::intrusive::list<OGNTraffic,
+                                 boost::intrusive::constant_time_size<false> >
+      List;
+
+  typedef boost::intrusive::set<
+      OGNTraffic, boost::intrusive::compare<OGNTraffic::IdCompare>,
+      boost::intrusive::constant_time_size<false> >
+      IdSet;
+
+  /**
+   * A geospatial container of all OGN traffic.
+   */
+  Tree rtree;
+
+  /**
+   * A linked list of traffic, sorted by last update.
+   */
+  List list;
+
+  /**
+   * Map id to OGNTraffic.
+   */
+  IdSet id_set;
+
+  /**
+   * Map device_id to OGNTraffic.
+   */
+  std::map<tstring, OGNTrafficPtr> device_map;
+
+  /**
+   * The id assigned to the next new OGNTraffic.
+   * Start at high IDs to distinguish from XCSoar clients
+   */
+  unsigned next_id = 0x80000000;
+
+public:
+  OGNTrafficContainer();
+  ~OGNTrafficContainer();
+
+  void clear();
+
+  bool empty() const { return list.empty(); }
+
+  /**
+   * Look up traffic by device ID.
+   */
+  [[gnu::pure]]
+  OGNTraffic *Find(const tstring &device_id);
+
+  /**
+   * Look up traffic by internal ID.
+   */
+  [[gnu::pure]]
+  OGNTraffic *FindById(unsigned id);
+
+  /**
+   * Create or update OGN traffic.
+   */
+  OGNTraffic &Make(const tstring &device_id, const GeoPoint &location,
+                   int altitude, unsigned track, unsigned speed,
+                   int climb_rate, double turn_rate = 0,
+                   FlarmTraffic::AircraftType aircraft_type =
+                       FlarmTraffic::AircraftType::UNKNOWN);
+
+  void Expire(std::chrono::steady_clock::time_point before);
+
+  typedef Tree::const_query_iterator query_iterator;
+  typedef boost::iterator_range<query_iterator> query_iterator_range;
+
+  [[gnu::pure]]
+  query_iterator_range QueryWithinRange(GeoPoint location, double range) const;
+};

--- a/src/Cloud/Sender.cpp
+++ b/src/Cloud/Sender.cpp
@@ -5,10 +5,16 @@
 #include "Tracking/SkyLines/Export.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "util/CRC16CCITT.hpp"
+#include "FLARM/Traffic.hpp"
+
+#include <cstring>
 
 void
 TrafficResponseSender::Add(uint32_t pilot_id, uint32_t time,
-                           GeoPoint location, int altitude)
+                           GeoPoint location, int altitude, uint32_t flarm_id,
+                           unsigned track,
+                           double turn_rate,
+                           FlarmTraffic::AircraftType aircraft_type)
 {
   assert(n_traffic < MAX_TRAFFIC);
 
@@ -17,8 +23,25 @@ TrafficResponseSender::Add(uint32_t pilot_id, uint32_t time,
   traffic.time = ToBE32(time);
   traffic.location = SkyLinesTracking::ExportGeoPoint(location);
   traffic.altitude = ToBE16(altitude);
-  traffic.reserved = 0;
-  traffic.reserved2 = 0;
+  
+  // Encode turn_rate as int16_t scaled by 10
+  int16_t turn_rate_scaled = (int16_t)(turn_rate * 10.0);
+  // Clamp to int16_t range
+  if (turn_rate * 10.0 > 32767.0)
+    turn_rate_scaled = 32767;
+  else if (turn_rate * 10.0 < -32768.0)
+    turn_rate_scaled = -32768;
+  traffic.reserved = ToBE16(*(uint16_t*)&turn_rate_scaled);
+  
+  // Encode reserved2:
+  // - Lower 8 bits: aircraft_type
+  // - Next 9 bits (8-16): track (0-359 degrees)
+  // - Upper 16 bits (17-32): flarm_id (reduced from 24 to 16 bits)
+  uint8_t type_byte = (uint8_t)aircraft_type;
+  uint16_t track_bits = track & 0x1FF;  // 9 bits for track (0-359)
+  uint16_t flarm_id_bits = (flarm_id >> 8) & 0xFFFF;  // Upper 16 bits of flarm_id
+  uint32_t encoded = ((uint32_t)flarm_id_bits << 17) | ((uint32_t)track_bits << 8) | type_byte;
+  traffic.reserved2 = ToBE32(encoded);
 
   if (n_traffic == MAX_TRAFFIC)
     Flush();

--- a/src/Cloud/Sender.hpp
+++ b/src/Cloud/Sender.hpp
@@ -7,6 +7,7 @@
 #include "Tracking/SkyLines/Protocol.hpp"
 #include "util/ByteOrder.hxx"
 #include "net/StaticSocketAddress.hxx"
+#include "FLARM/Traffic.hpp"
 
 #include <array>
 
@@ -41,7 +42,10 @@ public:
   }
 
   void Add(uint32_t pilot_id, uint32_t time,
-           GeoPoint location, int altitude);
+           GeoPoint location, int altitude, uint32_t flarm_id = 0,
+           unsigned track = 0,
+           double turn_rate = 0,
+           FlarmTraffic::AircraftType aircraft_type = FlarmTraffic::AircraftType::UNKNOWN);
   void Flush();
 };
 

--- a/src/FLARM/Id.hpp
+++ b/src/FLARM/Id.hpp
@@ -28,6 +28,15 @@ public:
     return FlarmId(UNDEFINED_VALUE);
   }
 
+  /**
+   * Create a FlarmId from a raw uint32_t value.
+   * Use this when you have a FlarmId/ICAO ID from external sources
+   * (e.g., OGN traffic).
+   */
+  static constexpr FlarmId FromValue(uint32_t value) noexcept {
+    return FlarmId(value);
+  }
+
   constexpr bool IsDefined() const noexcept {
     return value != UNDEFINED_VALUE;
   }

--- a/src/Look/TrafficLook.cpp
+++ b/src/Look/TrafficLook.cpp
@@ -10,6 +10,12 @@ constexpr Color TrafficLook::team_color_magenta;
 constexpr Color TrafficLook::team_color_blue;
 constexpr Color TrafficLook::team_color_yellow;
 
+constexpr Color TrafficLook::source_color_flarm;
+constexpr Color TrafficLook::source_color_gliderlink;
+constexpr Color TrafficLook::source_color_ogn;
+constexpr Color TrafficLook::source_color_skylines;
+constexpr Color TrafficLook::source_color_stratux;
+
 void
 TrafficLook::Initialise(const Font &_font)
 {
@@ -30,6 +36,14 @@ TrafficLook::Initialise(const Font &_font)
   team_pen_blue.Create(width, team_color_blue);
   team_pen_yellow.Create(width, team_color_yellow);
   team_pen_magenta.Create(width, team_color_magenta);
+
+  // Create traffic source outline pens
+  unsigned source_outline_width = Layout::ScalePenWidth(2);
+  source_pen_flarm.Create(source_outline_width, source_color_flarm);
+  source_pen_gliderlink.Create(source_outline_width, source_color_gliderlink);
+  source_pen_ogn.Create(source_outline_width, source_color_ogn);
+  source_pen_skylines.Create(source_outline_width, source_color_skylines);
+  source_pen_stratux.Create(source_outline_width, source_color_stratux);
 
   teammate_icon.LoadResource(IDB_TEAMMATE_POS_ALL);
 

--- a/src/Look/TrafficLook.hpp
+++ b/src/Look/TrafficLook.hpp
@@ -41,6 +41,19 @@ struct TrafficLook {
   Pen team_pen_yellow;
   Pen team_pen_magenta;
 
+  // Traffic source outline pens
+  static constexpr Color source_color_flarm = Color(0x00, 0xff, 0x00);  // Green
+  static constexpr Color source_color_gliderlink = Color(0x00, 0x90, 0xff);  // Blue
+  static constexpr Color source_color_ogn = Color(0xff, 0xa2, 0x00);  // Orange
+  static constexpr Color source_color_skylines = Color(0xff, 0x00, 0xcb);  // Magenta
+  static constexpr Color source_color_stratux = Color(0xff, 0xff, 0x00);  // Yellow
+
+  Pen source_pen_flarm;
+  Pen source_pen_gliderlink;
+  Pen source_pen_ogn;
+  Pen source_pen_skylines;
+  Pen source_pen_stratux;
+
   MaskedIcon teammate_icon;
 
   const Font *font;

--- a/src/MapWindow/MapWindowBlackboard.hpp
+++ b/src/MapWindow/MapWindowBlackboard.hpp
@@ -8,6 +8,7 @@
 #include "Blackboard/MapSettingsBlackboard.hpp"
 #include "thread/Debug.hpp"
 #include "UIState.hpp"
+#include "FLARM/List.hpp"
 
 #include <map>
 
@@ -30,6 +31,18 @@ class MapWindowBlackboard:
   std::map<FlarmId, FlarmTraffic> fading_flarm_traffic;
 
 protected:
+  /**
+   * Unified traffic that has disappeared, but will remain on the map
+   * (greyed out) for some time.
+   * Mutable because it's updated during drawing (which is logically const)
+   */
+  mutable std::map<FlarmId, FlarmTraffic> fading_unified_traffic;
+
+  /**
+   * Previous unified traffic list for fading comparison
+   * Mutable because it's updated during drawing (which is logically const)
+   */
+  mutable TrafficList previous_unified_traffic;
   MapWindowBlackboard() noexcept {
     /* this needs to be initialised because ReadBlackboard() uses the
        previous FLARM traffic list */
@@ -53,6 +66,11 @@ protected:
   [[gnu::const]]
   const auto &GetFadingFlarmTraffic() const noexcept {
     return fading_flarm_traffic;
+  }
+
+  [[gnu::const]]
+  const auto &GetFadingUnifiedTraffic() const noexcept {
+    return fading_unified_traffic;
   }
 
   [[gnu::const]]

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -4,11 +4,13 @@
 #include "NetComponents.hpp"
 #include "Tracking/TrackingGlue.hpp"
 #include "net/client/tim/Glue.hpp"
+#include "Traffic/Aggregator.hpp"
 
 NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
                              const TrackingSettings &tracking_settings) noexcept
   :tracking(new TrackingGlue(event_loop, curl)),
-   tim(new TIM::Glue(curl))
+   tim(new TIM::Glue(curl)),
+   traffic_aggregator(new TrafficAggregator())
 {
   tracking->SetSettings(tracking_settings);
 }

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -12,6 +12,7 @@ struct TrackingSettings;
 class EventLoop;
 class CurlGlobal;
 class TrackingGlue;
+class TrafficAggregator;
 namespace TIM { class Glue; }
 
 /**
@@ -25,6 +26,8 @@ struct NetComponents {
 #ifdef HAVE_HTTP
   const std::unique_ptr<TIM::Glue> tim;
 #endif
+
+  const std::unique_ptr<TrafficAggregator> traffic_aggregator;
 
   NetComponents(EventLoop &event_loop, CurlGlobal &curl,
                 const TrackingSettings &tracking_settings) noexcept;

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -7,6 +7,7 @@
 #include "Look/TrafficLook.hpp"
 #include "FLARM/Traffic.hpp"
 #include "GliderLink/Traffic.hpp"
+#include "Traffic/UnifiedTraffic.hpp"
 #include "Math/Screen.hpp"
 #include "util/Macros.hpp"
 #include "Asset.hpp"
@@ -15,22 +16,70 @@
 #include "ui/canvas/opengl/Scope.hpp"
 #endif
 
+[[gnu::pure]]
+static const Pen &
+GetTrafficSourcePen(const TrafficLook &traffic_look,
+                    UnifiedTraffic::Source source) noexcept
+{
+  switch (source) {
+  case UnifiedTraffic::Source::FLARM_DIRECT:
+    return traffic_look.source_pen_flarm;
+  case UnifiedTraffic::Source::GLIDERLINK:
+    return traffic_look.source_pen_gliderlink;
+  case UnifiedTraffic::Source::OGN_CLOUD:
+    return traffic_look.source_pen_ogn;
+  case UnifiedTraffic::Source::SKYLINES:
+    return traffic_look.source_pen_skylines;
+  case UnifiedTraffic::Source::STRATUX:
+    return traffic_look.source_pen_stratux;
+  }
+  return traffic_look.source_pen_flarm;  // Default to FLARM
+}
+
 void
 TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
                       bool fading,
                       const FlarmTraffic &traffic, const Angle angle,
-                      const FlarmColor color, const PixelPoint pt) noexcept
+                      const FlarmColor color, const PixelPoint pt,
+                      UnifiedTraffic::Source source) noexcept
 {
   // Create point array that will form that arrow polygon
+  // Target: 48x48 pixels on a 100 DPI screen
+  // At 100 DPI: 1 point = 100/72 ≈ 1.39 pixels
+  // So 48 pixels = 48 * 72 / 100 ≈ 34.56 points ≈ 35 points
+  // We'll use 24 points as base (which scales to ~33 pixels at 100 DPI)
+  // and scale up to get ~48 pixels
+  
+  // Original arrow shape: { -4, 6 }, { 0, -8 }, { 4, 6 }, { 0, 3 }
+  // Height: from -8 to +6 = 14 units, Width: from -4 to +4 = 8 units
+  // Scale to 3x larger: { -12, 18 }, { 0, -24 }, { 12, 18 }, { 0, 9 }
+  // New height: from -24 to +18 = 42 units, Width: from -12 to +12 = 24 units
+  
+  // Scale the original arrow coordinates by 3x
   BulkPixelPoint arrow[] = {
-    { -4, 6 },
-    { 0, -8 },
-    { 4, 6 },
-    { 0, 3 },
+    { -12, 18 },
+    { 0, -24 },
+    { 12, 18 },
+    { 0, 9 },
   };
 
+  // Calculate scale factor for PolygonRotateShift
+  // PolygonRotateShift scales coordinates: if scale=100, coordinates -50 to +50 become -100 to +100 pixels
+  // Our arrow height is 42 units (from -24 to +18)
+  // We want final height of ~48 pixels at 100 DPI
+  // At 100 DPI: 48 pixels = 48 * 72 / 100 ≈ 34.56 points
+  // Scale factor needed: 48 pixels / 42 units * 100 ≈ 114
+  // But we want DPI-aware scaling, so use Layout::PtScale to get actual pixel size
+  // Target: 48 pixels equivalent = Layout::PtScale(48 * 72 / 100) ≈ Layout::PtScale(35)
+  const unsigned target_points = 35;  // ~48 pixels at 100 DPI
+  const unsigned target_px = Layout::PtScale(target_points);
+  // Arrow height in coordinate units is 42, so scale factor = target_px * 100 / 42
+  const int scale_factor = (int)(target_px * 100 / 42);
+  const int final_scale = scale_factor > 0 ? scale_factor : 114;
+
   // Rotate and shift the arrow to the right position and angle
-  PolygonRotateShift(arrow, pt, angle, Layout::Scale(100U));
+  // Use calculated scale factor for DPI-based sizing
+  PolygonRotateShift(arrow, pt, angle, final_scale);
 
   if (fading) {
     canvas.Select(traffic_look.fading_pen);
@@ -76,25 +125,39 @@ TrafficRenderer::Draw(Canvas &canvas, const TrafficLook &traffic_look,
     canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
   }
 
+  // Draw traffic source outline around the arrow (not a circle)
+  if (!fading) {
+    canvas.Select(GetTrafficSourcePen(traffic_look, source));
+    canvas.SelectHollowBrush();
+    // Draw outline around the arrow polygon
+    canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
+  }
+
+  // Draw team color circle (inner circle, if team color is set)
   switch (color) {
   case FlarmColor::GREEN:
     canvas.Select(traffic_look.team_pen_green);
+    canvas.SelectHollowBrush();
+    canvas.DrawCircle(pt, Layout::FastScale(11u));
     break;
   case FlarmColor::BLUE:
     canvas.Select(traffic_look.team_pen_blue);
+    canvas.SelectHollowBrush();
+    canvas.DrawCircle(pt, Layout::FastScale(11u));
     break;
   case FlarmColor::YELLOW:
     canvas.Select(traffic_look.team_pen_yellow);
+    canvas.SelectHollowBrush();
+    canvas.DrawCircle(pt, Layout::FastScale(11u));
     break;
   case FlarmColor::MAGENTA:
     canvas.Select(traffic_look.team_pen_magenta);
+    canvas.SelectHollowBrush();
+    canvas.DrawCircle(pt, Layout::FastScale(11u));
     break;
   default:
-    return;
+    break;
   }
-
-  canvas.SelectHollowBrush();
-  canvas.DrawCircle(pt, Layout::FastScale(11u));
 }
 
 

--- a/src/Renderer/TrafficRenderer.hpp
+++ b/src/Renderer/TrafficRenderer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "FLARM/Color.hpp"
+#include "Traffic/UnifiedTraffic.hpp"
 
 struct PixelPoint;
 class Canvas;
@@ -18,7 +19,8 @@ void
 Draw(Canvas &canvas, const TrafficLook &traffic_look,
      bool fading,
      const FlarmTraffic &traffic, Angle angle,
-     FlarmColor color, PixelPoint pt) noexcept;
+     FlarmColor color, PixelPoint pt,
+     UnifiedTraffic::Source source = UnifiedTraffic::Source::FLARM_DIRECT) noexcept;
 
 void
 Draw(Canvas &canvas, const TrafficLook &traffic_look,

--- a/src/Tracking/SkyLines/Client.cpp
+++ b/src/Tracking/SkyLines/Client.cpp
@@ -2,19 +2,29 @@
 // Copyright The XCSoar Project
 
 #include "Client.hpp"
-#include "Handler.hpp"
 #include "Assemble.hpp"
-#include "Protocol.hpp"
-#include "Import.hpp"
-#include "util/ByteOrder.hxx"
-#include "Math/Angle.hpp"
+#include "FLARM/Traffic.hpp"
 #include "Geo/GeoPoint.hpp"
+#include "Handler.hpp"
+#include "Import.hpp"
+#include "LogFile.hpp"
+#include "Math/Angle.hpp"
+#include "Protocol.hpp"
 #include "event/Call.hxx"
 #include "net/StaticSocketAddress.hxx"
+#include "net/ToString.hxx"
 #include "net/UniqueSocketDescriptor.hxx"
+#include "util/ByteOrder.hxx"
 #include "util/CRC16CCITT.hpp"
-#include "util/UTF8.hpp"
 #include "util/ConvertString.hpp"
+#include "util/UTF8.hpp"
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#endif
 
 #include <span>
 #include <string>
@@ -22,7 +32,7 @@
 void
 SkyLinesTracking::Client::Open(Cares::Channel &cares, const char *server)
 {
-  BlockingCall(GetEventLoop(), [this, &cares, server](){
+  BlockingCall(GetEventLoop(), [this, &cares, server]() {
     InternalClose();
 
     Cares::SimpleHandler &resolver_handler = *this;
@@ -41,13 +51,12 @@ SkyLinesTracking::Client::Open(SocketAddress _address)
   address = _address;
 
   UniqueSocketDescriptor socket;
-  if (!socket.Create(address.GetFamily(), SOCK_DGRAM, 0))
-    return false;
+  if (!socket.Create(address.GetFamily(), SOCK_DGRAM, 0)) return false;
 
   // TODO: bind?
 
   if (handler != nullptr) {
-    BlockingCall(GetEventLoop(), [&socket, this](){
+    BlockingCall(GetEventLoop(), [&socket, this]() {
       socket_event.Open(socket.Release());
       socket_event.ScheduleRead();
     });
@@ -69,7 +78,7 @@ SkyLinesTracking::Client::InternalClose() noexcept
 void
 SkyLinesTracking::Client::Close()
 {
-  BlockingCall(GetEventLoop(), [this](){ InternalClose(); });
+  BlockingCall(GetEventLoop(), [this]() { InternalClose(); });
 }
 
 void
@@ -93,15 +102,12 @@ SkyLinesTracking::Client::SendThermal(uint32_t time,
                                       ::GeoPoint bottom_location,
                                       int bottom_altitude,
                                       ::GeoPoint top_location,
-                                      int top_altitude,
-                                      double lift)
+                                      int top_altitude, double lift)
 {
   assert(key != 0);
 
-  SendPacket(MakeThermalSubmit(key, time,
-                               bottom_location, bottom_altitude,
-                               top_location, top_altitude,
-                               lift));
+  SendPacket(MakeThermalSubmit(key, time, bottom_location, bottom_altitude,
+                               top_location, top_altitude, lift));
 }
 
 void
@@ -130,29 +136,66 @@ SkyLinesTracking::Client::SendUserNameRequest(uint32_t user_id)
 }
 
 inline void
-SkyLinesTracking::Client::OnTrafficReceived(const TrafficResponsePacket &packet,
-                                            size_t length)
+SkyLinesTracking::Client::OnTrafficReceived(
+    const TrafficResponsePacket &packet, size_t length)
 {
-  if (length < sizeof(packet))
+  if (length < sizeof(packet)) {
+    LogFormat(
+        "SkyLines: TRAFFIC_RESPONSE packet too short (%zu < %zu), dropping",
+        length, sizeof(packet));
     return;
+  }
 
   const unsigned n = packet.traffic_count;
-  const std::span<const TrafficResponsePacket::Traffic>
-    list((const TrafficResponsePacket::Traffic *)(&packet + 1), n);
+  LogFormat("SkyLines: TRAFFIC_RESPONSE contains %u traffic entries", n);
 
-  if (length != sizeof(packet) + n * sizeof(list.front()))
+  const std::span<const TrafficResponsePacket::Traffic> list(
+      (const TrafficResponsePacket::Traffic *)(&packet + 1), n);
+
+  const size_t expected_length = sizeof(packet) + n * sizeof(list.front());
+  if (length != expected_length) {
+    LogFormat(
+        "SkyLines: TRAFFIC_RESPONSE length mismatch (%zu != %zu), dropping",
+        length, expected_length);
     return;
+  }
 
-  for (const auto &traffic : list)
-    handler->OnTraffic(FromBE32(traffic.pilot_id),
-                       FromBE32(traffic.time),
+  LogFormat("SkyLines: Processing %u traffic entries", n);
+  for (const auto &traffic : list) {
+    // Decode turn_rate from reserved (int16_t scaled by 10)
+    uint16_t reserved_u16 = traffic.reserved;
+    int16_t turn_rate_scaled = FromBE16(reserved_u16);
+    double turn_rate = turn_rate_scaled / 10.0;
+
+    // Decode reserved2:
+    // - Lower 8 bits: aircraft_type
+    // - Next 9 bits (8-16): track (0-359 degrees)
+    // - Upper 16 bits (17-32): flarm_id (upper 16 bits of 24-bit id)
+    uint32_t encoded = FromBE32(traffic.reserved2);
+    uint8_t aircraft_type_byte = encoded & 0xFF;
+    // Extract track from bits 8-16 (9 bits, 0-359)
+    unsigned track = (encoded >> 8) & 0x1FF;
+    // Extract the full 24-bit id from the encoded value.
+    // The encoding stores the upper 16 bits of the 24-bit flarm_id in bits
+    // 17-32. Extract bits 17-32 (upper 16 bits) and shift left by 8 to get
+    // upper 16 bits of 24-bit ID. The lower 8 bits of flarm_id are not
+    // transmitted, so we reconstruct it as best we can.
+    uint32_t flarm_id_upper = (encoded >> 17) & 0xFFFF;
+    uint32_t flarm_id = flarm_id_upper << 8;
+
+    FlarmTraffic::AircraftType aircraft_type =
+        static_cast<FlarmTraffic::AircraftType>(aircraft_type_byte);
+
+    handler->OnTraffic(FromBE32(traffic.pilot_id), FromBE32(traffic.time),
                        ImportGeoPoint(traffic.location),
-                       (int16_t)FromBE16(traffic.altitude));
+                       (int16_t)FromBE16(traffic.altitude), flarm_id, track,
+                       turn_rate, aircraft_type);
+  }
 }
 
 inline void
-SkyLinesTracking::Client::OnUserNameReceived(const UserNameResponsePacket &packet,
-                                             size_t length)
+SkyLinesTracking::Client::OnUserNameReceived(
+    const UserNameResponsePacket &packet, size_t length)
 {
   if (length < sizeof(packet) || length != sizeof(packet) + packet.name_length)
     return;
@@ -160,8 +203,7 @@ SkyLinesTracking::Client::OnUserNameReceived(const UserNameResponsePacket &packe
   /* the name follows the UserNameResponsePacket object */
   const char *_name = (const char *)(&packet + 1);
   const std::string name(_name, packet.name_length);
-  if (!ValidateUTF8(name.c_str()))
-    return;
+  if (!ValidateUTF8(name.c_str())) return;
 
   UTF8ToWideConverter tname(name.c_str());
   handler->OnUserName(FromBE32(packet.user_id), tname);
@@ -171,25 +213,22 @@ inline void
 SkyLinesTracking::Client::OnWaveReceived(const WaveResponsePacket &packet,
                                          size_t length)
 {
-  if (length < sizeof(packet))
-    return;
+  if (length < sizeof(packet)) return;
 
   const unsigned n = packet.wave_count;
   std::span<const Wave> waves((const Wave *)(&packet + 1), n);
-  if (length != sizeof(packet) + waves.size() * sizeof(waves.front()))
-    return;
+  if (length != sizeof(packet) + waves.size() * sizeof(waves.front())) return;
 
   for (const auto &wave : waves)
-    handler->OnWave(FromBE32(wave.time),
-                    ImportGeoPoint(wave.a), ImportGeoPoint(wave.b));
+    handler->OnWave(FromBE32(wave.time), ImportGeoPoint(wave.a),
+                    ImportGeoPoint(wave.b));
 }
 
 inline void
-SkyLinesTracking::Client::OnThermalReceived(const ThermalResponsePacket &packet,
-                                            size_t length)
+SkyLinesTracking::Client::OnThermalReceived(
+    const ThermalResponsePacket &packet, size_t length)
 {
-  if (length < sizeof(packet))
-    return;
+  if (length < sizeof(packet)) return;
 
   const unsigned n = packet.thermal_count;
   std::span<const Thermal> thermals((const Thermal *)(&packet + 1), n);
@@ -209,24 +248,34 @@ inline void
 SkyLinesTracking::Client::OnDatagramReceived(void *data, size_t length)
 {
   Header &header = *(Header *)data;
-  if (length < sizeof(header))
+  if (length < sizeof(header)) {
+    LogFormat("SkyLines: Packet too short (%zu < %zu), dropping", length,
+              sizeof(header));
     return;
+  }
 
   const uint16_t received_crc = FromBE16(header.crc);
   header.crc = 0;
 
   const uint16_t calculated_crc = UpdateCRC16CCITT(data, length, 0);
-  if (received_crc != calculated_crc)
+  if (received_crc != calculated_crc) {
+    LogFormat("SkyLines: CRC mismatch (received=0x%04x, calculated=0x%04x), "
+              "dropping packet",
+              received_crc, calculated_crc);
     return;
+  }
 
   const ACKPacket &ack = *(const ACKPacket *)data;
   const TrafficResponsePacket &traffic = *(const TrafficResponsePacket *)data;
   const UserNameResponsePacket &user_name =
-    *(const UserNameResponsePacket *)data;
+      *(const UserNameResponsePacket *)data;
   const auto &wave = *(const WaveResponsePacket *)data;
   const auto &thermal = *(const ThermalResponsePacket *)data;
 
-  switch ((Type)FromBE16(header.type)) {
+  const Type packet_type = (Type)FromBE16(header.type);
+  LogFormat("SkyLines: Processing packet type=%u", (unsigned)packet_type);
+
+  switch (packet_type) {
   case PING:
   case FIX:
   case TRAFFIC_REQUEST:
@@ -238,11 +287,11 @@ SkyLinesTracking::Client::OnDatagramReceived(void *data, size_t length)
     break;
 
   case ACK:
-    if (length >= sizeof(ack))
-      handler->OnAck(FromBE16(ack.id));
+    if (length >= sizeof(ack)) handler->OnAck(FromBE16(ack.id));
     break;
 
   case TRAFFIC_RESPONSE:
+    LogFormat("SkyLines: Processing TRAFFIC_RESPONSE packet");
     OnTrafficReceived(traffic, length);
     break;
 
@@ -267,15 +316,34 @@ SkyLinesTracking::Client::OnSocketReady(unsigned) noexcept
   ssize_t nbytes;
   StaticSocketAddress source_address;
 
-  while ((nbytes = GetSocket().ReadNoWait(std::span{buffer}, source_address)) > 0)
-    if (source_address == address)
+  while ((nbytes = GetSocket().ReadNoWait(std::span{buffer}, source_address)) >
+         0) {
+    // Determine if this is from cloud (127.0.0.1) or SkyLines by checking
+    // address
+    std::string address_str = ToString(SocketAddress(address));
+    const bool is_cloud = (address_str.find("127.0.0.1") != std::string::npos);
+    const char *source_name = is_cloud ? "cloud" : "SkyLines";
+
+    // Debug: log all received packets
+    LogFormat("%s: Received %zd bytes from %s", source_name, nbytes,
+              ToString(source_address).c_str());
+
+    if (source_address == address) {
+      LogFormat("%s: Address matches, processing packet", source_name);
       OnDatagramReceived(buffer, nbytes);
+    } else {
+      LogFormat("%s: Address mismatch - expected %s, got %s, dropping packet",
+                source_name, address_str.c_str(),
+                ToString(source_address).c_str());
+    }
+  }
 
   // TODO check for errors?
 }
 
 void
-SkyLinesTracking::Client::OnResolverSuccess(std::forward_list<AllocatedSocketAddress> addresses) noexcept
+SkyLinesTracking::Client::OnResolverSuccess(
+    std::forward_list<AllocatedSocketAddress> addresses) noexcept
 {
   {
     const std::lock_guard lock{mutex};
@@ -284,7 +352,8 @@ SkyLinesTracking::Client::OnResolverSuccess(std::forward_list<AllocatedSocketAdd
 
   if (addresses.empty()) {
     if (handler != nullptr)
-      handler->OnSkyLinesError(std::make_exception_ptr(std::runtime_error("No address")));
+      handler->OnSkyLinesError(
+          std::make_exception_ptr(std::runtime_error("No address")));
     return;
   }
 
@@ -299,6 +368,5 @@ SkyLinesTracking::Client::OnResolverError(std::exception_ptr error) noexcept
     resolver.reset();
   }
 
-  if (handler != nullptr)
-    handler->OnSkyLinesError(std::move(error));
+  if (handler != nullptr) handler->OnSkyLinesError(std::move(error));
 }

--- a/src/Tracking/SkyLines/Data.hpp
+++ b/src/Tracking/SkyLines/Data.hpp
@@ -7,16 +7,17 @@
 #include "thread/Mutex.hxx"
 #include "util/tstring.hpp"
 
-#include <map>
-#include <list>
 #include <chrono>
+#include <list>
+#include <map>
 
 #include <cstdint>
 
 namespace SkyLinesTracking {
 
 struct Data {
-  using Time = std::chrono::duration<uint_least32_t, std::chrono::milliseconds::period>;
+  using Time =
+      std::chrono::duration<uint_least32_t, std::chrono::milliseconds::period>;
 
   struct Traffic {
     /**
@@ -29,11 +30,20 @@ struct Data {
     GeoPoint location;
     int altitude;
 
+    /**
+     * FlarmId/ICAO ID extracted from reserved2 field (0 if not available).
+     * This allows matching SkyLines traffic to FLARM databases.
+     */
+    uint32_t flarm_id;
+
     Traffic() = default;
-    constexpr Traffic(Time _time, GeoPoint _location,
-                      int _altitude) noexcept
-      :time_of_day(_time),
-       location(_location), altitude(_altitude) {}
+    constexpr Traffic(Time _time, GeoPoint _location, int _altitude,
+                      uint32_t _flarm_id = 0) noexcept : time_of_day(_time),
+                                                         location(_location),
+                                                         altitude(_altitude),
+                                                         flarm_id(_flarm_id)
+    {
+    }
   };
 
   struct Wave {
@@ -52,7 +62,11 @@ struct Data {
 
     Wave() = default;
     constexpr Wave(Time _time, GeoPoint _a, GeoPoint _b) noexcept
-      :time_of_day(_time), a(_a), b(_b) {}
+        : time_of_day(_time),
+          a(_a),
+          b(_b)
+    {
+    }
   };
 
   struct Thermal {
@@ -64,8 +78,10 @@ struct Data {
 
     Thermal() = default;
     Thermal(const AGeoPoint &_bottom, const AGeoPoint &_top, double _lift)
-      :received_time(std::chrono::steady_clock::now()),
-       bottom_location(_bottom), top_location(_top), lift(_lift) {}
+        : received_time(std::chrono::steady_clock::now()),
+          bottom_location(_bottom), top_location(_top), lift(_lift)
+    {
+    }
   };
 
   mutable Mutex mutex;
@@ -83,7 +99,8 @@ struct Data {
   std::list<Thermal> thermals;
 
   [[gnu::pure]]
-  bool IsUserKnown(uint32_t id) const {
+  bool IsUserKnown(uint32_t id) const
+  {
     return user_names.find(id) != user_names.end();
   }
 };

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -5,6 +5,14 @@
 #include "Tracking/TrackingSettings.hpp"
 #include "NMEA/MoreData.hpp"
 #include "LogFile.hpp"
+#include "Formatter/GeoPointFormatter.hpp"
+#include "Geo/CoordinateFormat.hpp"
+#include "util/ConvertString.hpp"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "Traffic/Aggregator.hpp"
+#include "FLARM/Id.hpp"
+#include "time/Cast.hxx"
 
 TrackingGlue::TrackingGlue(EventLoop &event_loop,
                            CurlGlobal &curl) noexcept
@@ -34,17 +42,72 @@ TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
 
 void
 TrackingGlue::OnTraffic(uint32_t pilot_id, unsigned time_of_day_ms,
-                        const GeoPoint &location, int altitude)
+                        const GeoPoint &location, int altitude, uint32_t flarm_id,
+                        unsigned track,
+                        double turn_rate,
+                        FlarmTraffic::AircraftType aircraft_type)
 {
+  // Log received traffic (from either SkyLines or xcsoar-cloud)
+  if (location.IsValid()) {
+    const auto formatted = FormatGeoPoint(location,
+                                         CoordinateFormat::DDMMSS);
+    const WideToUTF8Converter location_str(formatted.c_str());
+    if (flarm_id != 0) {
+      LogFormat("Traffic received: id=%u flarm_id=%u at %s altitude %dm track=%u° turn_rate=%.1f type=%u",
+                pilot_id, flarm_id, location_str.c_str(), altitude, track, turn_rate, (unsigned)aircraft_type);
+    } else {
+      LogFormat("Traffic received: id=%u at %s altitude %dm track=%u° turn_rate=%.1f type=%u",
+                pilot_id, location_str.c_str(), altitude, track, turn_rate, (unsigned)aircraft_type);
+    }
+  } else {
+    LogFormat("Traffic received: id=%u altitude %dm (no location)",
+              pilot_id, altitude);
+  }
+
   bool user_known;
 
   {
     const std::lock_guard lock{skylines_data.mutex};
     const SkyLinesTracking::Data::Traffic traffic(SkyLinesTracking::Data::Time{time_of_day_ms},
-                                                  location, altitude);
+                                                  location, altitude, flarm_id);
     skylines_data.traffic[pilot_id] = traffic;
 
     user_known = skylines_data.IsUserKnown(pilot_id);
+  }
+
+  // Feed into traffic aggregator
+  if (net_components != nullptr && net_components->traffic_aggregator != nullptr &&
+      location.IsValid()) {
+    // Determine source: if flarm_id is set, it's from xcsoar-cloud (OGN)
+    // Otherwise it's from regular SkyLines
+    UnifiedTraffic::Source source = flarm_id != 0
+      ? UnifiedTraffic::Source::OGN_CLOUD
+      : UnifiedTraffic::Source::SKYLINES;
+
+    FlarmId flarm_id_obj = flarm_id != 0
+      ? FlarmId::FromValue(flarm_id)
+      : FlarmId::Undefined();
+
+    // If no FlarmId, we can't deduplicate - skip aggregator
+    // (will still be stored in SkyLines data for backward compatibility)
+    if (flarm_id_obj.IsDefined()) {
+      // Convert time_of_day_ms to TimeStamp
+      // time_of_day_ms is milliseconds since midnight UTC
+      // TimeStamp is FloatDuration (seconds) since midnight
+      // For traffic aggregation, we use the time_of_day directly
+      // The actual absolute time doesn't matter for deduplication/expiration
+      const TimeStamp timestamp = TimeStamp{FloatDuration{time_of_day_ms / 1000.0}};
+
+      // Extract track and speed from SkyLines data if available
+      // Track is now passed as parameter
+      unsigned speed = 0;
+      int climb_rate = 0;
+
+      net_components->traffic_aggregator->FeedOGN(
+        source, pilot_id, flarm_id_obj, location, altitude,
+        track, speed, climb_rate, timestamp,
+        turn_rate, aircraft_type);
+    }
   }
 
   if (!user_known)

--- a/src/Traffic/Aggregator.cpp
+++ b/src/Traffic/Aggregator.cpp
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Aggregator.hpp"
+#include "FLARM/List.hpp"
+#include "Math/Angle.hpp"
+#include "Math/Util.hpp"
+#include "LogFile.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+void
+TrafficAggregator::FeedFLARM(const FlarmTraffic &flarm, TimeStamp now) noexcept
+{
+  if (!flarm.IsDefined() || !flarm.valid)
+    return;
+
+  UnifiedTraffic unified(flarm);
+  unified.source_timestamp = now;
+
+  auto it = traffic_map.find(flarm.id);
+  if (it != traffic_map.end()) {
+    // Update existing traffic
+    // FLARM always wins when present
+    it->second = unified;
+  } else {
+    // Add new traffic
+    traffic_map[flarm.id] = unified;
+  }
+}
+
+void
+TrafficAggregator::FeedOGN(UnifiedTraffic::Source source, uint32_t source_id,
+                            FlarmId flarm_id, const GeoPoint &location,
+                            int altitude, unsigned track, unsigned speed,
+                            int climb_rate, TimeStamp timestamp,
+                            double turn_rate,
+                            FlarmTraffic::AircraftType aircraft_type) noexcept
+{
+  if (!flarm_id.IsDefined())
+    return;
+
+  UnifiedTraffic unified(source, source_id, flarm_id, location,
+                         altitude, track, speed, climb_rate, timestamp,
+                         turn_rate, aircraft_type);
+
+  auto it = traffic_map.find(flarm_id);
+  if (it != traffic_map.end()) {
+    // Existing traffic - check if we should replace or merge
+    UnifiedTraffic &existing = it->second;
+
+    // If FLARM direct exists and is recent, don't replace with OGN
+    if (existing.source == UnifiedTraffic::Source::FLARM_DIRECT) {
+      // FLARM always wins - just update timestamp if needed
+      if (timestamp > existing.source_timestamp) {
+        existing.source_timestamp = timestamp;
+      }
+      return;
+    }
+
+    // Only update if new timestamp is newer or equal
+    // This prevents old packets from causing position jumps
+    if (timestamp >= existing.source_timestamp) {
+      // Merge data from new source
+      existing.Update(unified);
+    }
+    // If timestamp is older, ignore this update to prevent jumping
+  } else {
+    // Add new traffic
+    traffic_map[flarm_id] = unified;
+  }
+}
+
+void
+TrafficAggregator::Expire(TimeStamp now) noexcept
+{
+  const auto max_age = FloatDuration{MAX_TRAFFIC_AGE.count()};
+
+  for (auto it = traffic_map.begin(); it != traffic_map.end();) {
+    const auto age = now - it->second.source_timestamp;
+    
+    // FLARM traffic expires faster (2 seconds)
+    if (it->second.source == UnifiedTraffic::Source::FLARM_DIRECT) {
+      if (age > FloatDuration{2.0}) {
+        it = traffic_map.erase(it);
+        continue;
+      }
+    } else {
+      // Other sources expire after MAX_TRAFFIC_AGE
+      if (age > max_age) {
+        it = traffic_map.erase(it);
+        continue;
+      }
+    }
+
+    // Check validity
+    if (!it->second.valid) {
+      it = traffic_map.erase(it);
+      continue;
+    }
+
+    ++it;
+  }
+}
+
+TrafficList
+TrafficAggregator::GetUnifiedTrafficList(const GeoPoint &own_location,
+                                          TimeStamp now) const noexcept
+{
+  // Zero-initialize to ensure TrivialArray::the_size is 0
+  TrafficList result{};
+  result.Clear();  // Ensure proper initialization (redundant but safe)
+  result.modified.Update(now);
+
+  // Collect and prioritize traffic before adding to list
+  struct TrafficEntry {
+    UnifiedTraffic traffic;
+    double priority;
+    
+    bool operator<(const TrafficEntry &other) const noexcept {
+      return priority > other.priority;  // Higher priority first
+    }
+  };
+  
+  std::vector<TrafficEntry> entries;
+  entries.reserve(traffic_map.size());
+
+  // Calculate priority for each traffic item
+  for (const auto &[id, unified] : traffic_map) {
+    if (!unified.IsDefined())
+      continue;
+
+    UnifiedTraffic traffic = unified;
+    double priority = 0.0;
+
+    // Priority factors:
+    // 1. FLARM direct traffic gets highest priority
+    if (traffic.source == UnifiedTraffic::Source::FLARM_DIRECT)
+      priority += 10000.0;
+    
+    // 2. Traffic with alarms gets high priority
+    if (traffic.HasAlarm())
+      priority += 5000.0 + (unsigned)traffic.alarm_level * 1000.0;
+    
+    // 3. Closer traffic gets higher priority
+    if (own_location.IsValid() && traffic.location_available) {
+      const double distance = own_location.Distance(traffic.location);
+      traffic.distance = RoughDistance(distance);
+      priority += 1000.0 / (1.0 + distance / 1000.0);  // Inverse distance
+      
+      if (traffic.altitude_available) {
+        // Calculate relative altitude (simplified - would need own altitude)
+        traffic.relative_altitude = traffic.altitude;
+      }
+    } else {
+      traffic.distance = RoughDistance(0);
+    }
+
+    entries.push_back({traffic, priority});
+  }
+
+  // Sort by priority (highest first)
+  std::sort(entries.begin(), entries.end());
+
+  // Add traffic to list (up to MAX_COUNT)
+  // Limit to MAX_COUNT to prevent array bounds issues
+  const size_t max_add = std::min(entries.size(), 
+                                   static_cast<size_t>(TrafficList::MAX_COUNT));
+  
+  // Double-check that list is empty and properly initialized
+  assert(result.list.empty());
+  assert(result.list.size() == 0);
+  
+  for (size_t i = 0; i < max_add; ++i) {
+    // Check if list is full before allocating
+    if (result.list.full()) {
+      break;
+    }
+    
+    FlarmTraffic *flarm = result.AllocateTraffic();
+    if (flarm == nullptr) {
+      // This should never happen if we checked full() above, but be safe
+      break;
+    }
+
+    *flarm = entries[i].traffic.ToFlarmTraffic();
+    
+    // Verify we didn't exceed bounds
+    assert(result.list.size() <= TrafficList::MAX_COUNT);
+  }
+  
+  // Final safety check
+  assert(result.list.size() <= TrafficList::MAX_COUNT);
+  
+  LogFormat("GetUnifiedTrafficList: traffic_map_size=%zu entries_size=%zu result_size=%zu",
+            traffic_map.size(), entries.size(), static_cast<size_t>(result.list.size()));
+
+  return result;
+}
+
+bool
+TrafficAggregator::ShouldReplace(const UnifiedTraffic &existing,
+                                  const UnifiedTraffic &new_traffic,
+                                  const GeoPoint &own_location) const noexcept
+{
+  // FLARM direct always wins
+  if (existing.source == UnifiedTraffic::Source::FLARM_DIRECT)
+    return false;
+
+  if (new_traffic.source == UnifiedTraffic::Source::FLARM_DIRECT)
+    return true;
+
+  // If new traffic is more recent and from higher priority source
+  if ((unsigned)new_traffic.source < (unsigned)existing.source) {
+    // Check if we're in FLARM range
+    if (own_location.IsValid() && existing.location_available) {
+      const double distance = own_location.Distance(existing.location);
+      if (distance < FLARM_PRIORITY_RANGE) {
+        // In FLARM range - prefer existing if it's FLARM
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // If same source priority, use most recent
+  if (new_traffic.source == existing.source) {
+    return new_traffic.source_timestamp > existing.source_timestamp;
+  }
+
+  return false;
+}
+
+double
+TrafficAggregator::CalculateDistance(const UnifiedTraffic &traffic,
+                                     const GeoPoint &own_location) const noexcept
+{
+  if (!own_location.IsValid() || !traffic.location_available)
+    return 0;
+
+  return own_location.Distance(traffic.location);
+}
+

--- a/src/Traffic/Aggregator.hpp
+++ b/src/Traffic/Aggregator.hpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "UnifiedTraffic.hpp"
+#include "FLARM/List.hpp"
+#include "FLARM/Traffic.hpp"
+#include "Tracking/SkyLines/Data.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/Stamp.hpp"
+#include "time/FloatDuration.hxx"
+
+#include <map>
+#include <chrono>
+
+/**
+ * Aggregates traffic from multiple sources (FLARM, OGN, SkyLines, etc.)
+ * with deduplication and priority handling.
+ */
+class TrafficAggregator {
+  /**
+   * Unified traffic storage, keyed by FlarmId
+   */
+  std::map<FlarmId, UnifiedTraffic> traffic_map;
+
+  /**
+   * FLARM range threshold (meters).
+   * When traffic is within this range, FLARM data takes priority.
+   */
+  static constexpr double FLARM_PRIORITY_RANGE = 5000.0;  // 5km
+
+  /**
+   * Maximum age for traffic data before expiration (seconds)
+   */
+  static constexpr FloatDuration MAX_TRAFFIC_AGE{60.0};
+
+public:
+  TrafficAggregator() = default;
+
+  /**
+   * Clear all traffic
+   */
+  void Clear() noexcept {
+    traffic_map.clear();
+  }
+
+  /**
+   * Feed FLARM traffic into the aggregator
+   */
+  void FeedFLARM(const FlarmTraffic &flarm, TimeStamp now) noexcept;
+
+  /**
+   * Feed OGN/SkyLines traffic into the aggregator
+   */
+  void FeedOGN(UnifiedTraffic::Source source, uint32_t source_id,
+               FlarmId flarm_id, const GeoPoint &location,
+               int altitude, unsigned track, unsigned speed,
+               int climb_rate, TimeStamp timestamp,
+               double turn_rate = 0,
+               FlarmTraffic::AircraftType aircraft_type = FlarmTraffic::AircraftType::UNKNOWN) noexcept;
+
+  /**
+   * Expire old traffic entries
+   */
+  void Expire(TimeStamp now) noexcept;
+
+  /**
+   * Get unified traffic list (for compatibility with TrafficList)
+   */
+  TrafficList GetUnifiedTrafficList(const GeoPoint &own_location,
+                                     TimeStamp now) const noexcept;
+
+  /**
+   * Get all unified traffic
+   */
+  const std::map<FlarmId, UnifiedTraffic> &GetTraffic() const noexcept {
+    return traffic_map;
+  }
+
+  /**
+   * Check if aggregator is empty
+   */
+  bool IsEmpty() const noexcept {
+    return traffic_map.empty();
+  }
+
+private:
+  /**
+   * Determine if new traffic should replace existing traffic
+   */
+  [[gnu::pure]]
+  bool ShouldReplace(const UnifiedTraffic &existing,
+                     const UnifiedTraffic &new_traffic,
+                     const GeoPoint &own_location) const noexcept;
+
+  /**
+   * Calculate distance from own aircraft to traffic
+   */
+  [[gnu::pure]]
+  double CalculateDistance(const UnifiedTraffic &traffic,
+                           const GeoPoint &own_location) const noexcept;
+};
+

--- a/src/Traffic/UnifiedTraffic.hpp
+++ b/src/Traffic/UnifiedTraffic.hpp
@@ -1,0 +1,320 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "FLARM/Traffic.hpp"
+#include "FLARM/Id.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "NMEA/Validity.hpp"
+#include "time/Stamp.hpp"
+#include "Rough/RoughAltitude.hpp"
+#include "Rough/RoughDistance.hpp"
+#include "Rough/RoughSpeed.hpp"
+#include "Rough/RoughAngle.hpp"
+#include "Math/Angle.hpp"
+#include "util/StaticString.hxx"
+
+#include <type_traits>
+
+/**
+ * Unified traffic structure that aggregates data from all sources
+ * (FLARM, OGN, SkyLines, GliderLink, etc.)
+ */
+struct UnifiedTraffic {
+  /**
+   * Traffic source types, ordered by priority (highest to lowest)
+   */
+  enum class Source : uint8_t {
+    FLARM_DIRECT = 0,  // Direct FLARM connection (highest priority)
+    GLIDERLINK = 1,    // GliderLink traffic
+    OGN_CLOUD = 2,     // OGN via xcsoar-cloud
+    SKYLINES = 3,      // SkyLines tracking
+    STRATUX = 4,       // Stratux ADS-B
+  };
+
+  /** Primary identifier for deduplication */
+  FlarmId id;
+
+  /** Source of this traffic data */
+  Source source;
+
+  /** Timestamp when this data was received from the source */
+  TimeStamp source_timestamp;
+
+  /** Original source-specific ID (e.g., pilot_id for SkyLines) */
+  uint32_t source_id;
+
+  /** Location of the traffic */
+  GeoPoint location;
+
+  /** Track bearing in degrees (0-359) */
+  RoughAngle track;
+
+  /** Ground speed in m/s */
+  RoughSpeed speed;
+
+  /** Altitude in meters above MSL */
+  RoughAltitude altitude;
+
+  /** Climb rate in m/s */
+  double climb_rate;
+
+  /** Average climb rate over 30s */
+  double climb_rate_avg30s;
+
+  /** Distance from our aircraft */
+  RoughDistance distance;
+
+  /** Relative altitude difference */
+  RoughAltitude relative_altitude;
+
+  /** Turn rate in degrees/second */
+  double turn_rate;
+
+  /** Aircraft type (from FLARM if available) */
+  FlarmTraffic::AircraftType type;
+
+  /** Alarm level (from FLARM if available) */
+  FlarmTraffic::AlarmType alarm_level;
+
+  /** Name/callsign of the aircraft */
+  StaticString<10> name;
+
+  /** Is the target in stealth mode (FLARM only) */
+  bool stealth;
+
+  /** Validity tracking */
+  Validity valid;
+
+  /** Has geographical location been calculated? */
+  bool location_available;
+
+  /** Was track received from source or calculated? */
+  bool track_received;
+
+  /** Was speed received from source or calculated? */
+  bool speed_received;
+
+  /** Has absolute altitude been calculated? */
+  bool altitude_available;
+
+  /** Was climb rate received from source or calculated? */
+  bool climb_rate_received;
+
+  /** Was turn rate received from source or calculated? */
+  bool turn_rate_received;
+
+  /** Has averaged climb rate been calculated? */
+  bool climb_rate_avg30s_available;
+
+  /** Relative position (for FLARM direct) */
+  double relative_north;
+  double relative_east;
+
+  UnifiedTraffic() = default;
+
+  /**
+   * Create UnifiedTraffic from FLARM traffic
+   */
+  explicit UnifiedTraffic(const FlarmTraffic &flarm) noexcept
+    :id(flarm.id),
+     source(Source::FLARM_DIRECT),
+     source_timestamp(TimeStamp::Undefined()),  // Will be set by caller
+     source_id(0),  // FLARM doesn't have a separate source ID
+     location(flarm.location),
+     track(flarm.track),
+     speed(flarm.speed),
+     altitude(flarm.altitude),
+     climb_rate(flarm.climb_rate),
+     climb_rate_avg30s(flarm.climb_rate_avg30s),
+     distance(flarm.distance),
+     relative_altitude(flarm.relative_altitude),
+     turn_rate(flarm.turn_rate),
+     type(flarm.type),
+     alarm_level(flarm.alarm_level),
+     name(flarm.name),
+     stealth(flarm.stealth),
+     valid(flarm.valid),
+     location_available(flarm.location_available),
+     track_received(flarm.track_received),
+     speed_received(flarm.speed_received),
+     altitude_available(flarm.altitude_available),
+     climb_rate_received(flarm.climb_rate_received),
+     turn_rate_received(flarm.turn_rate_received),
+     climb_rate_avg30s_available(flarm.climb_rate_avg30s_available),
+     relative_north(flarm.relative_north),
+     relative_east(flarm.relative_east) {}
+
+  /**
+   * Create UnifiedTraffic from OGN/SkyLines traffic
+   */
+  UnifiedTraffic(Source _source, uint32_t _source_id,
+                 FlarmId _flarm_id, const GeoPoint &_location,
+                 int _altitude, unsigned _track, unsigned _speed,
+                 int _climb_rate, TimeStamp _timestamp,
+                 double _turn_rate = 0,
+                 FlarmTraffic::AircraftType _aircraft_type = FlarmTraffic::AircraftType::UNKNOWN) noexcept
+    :id(_flarm_id),
+     source(_source),
+     source_timestamp(_timestamp),
+     source_id(_source_id),
+     location(_location),
+     track(_track <= 359 ? Angle::Degrees(_track) : Angle::Zero()),
+     speed(RoughSpeed(_speed)),
+     altitude(RoughAltitude(_altitude)),
+     climb_rate(_climb_rate),
+     climb_rate_avg30s(0),
+     distance(0),
+     relative_altitude(0),
+     turn_rate(_turn_rate),
+     type(_aircraft_type),
+     alarm_level(FlarmTraffic::AlarmType::NONE),
+     stealth(false),
+     valid(_timestamp),
+     location_available(true),
+     track_received(_track <= 359),  // Track is valid if 0-359 (0 = north is valid)
+     speed_received(_speed > 0),
+     altitude_available(true),
+     climb_rate_received(_climb_rate != 0),
+     turn_rate_received(_turn_rate != 0),
+     climb_rate_avg30s_available(false),
+     relative_north(0),
+     relative_east(0) {}
+
+  bool IsDefined() const noexcept {
+    return valid && id.IsDefined();
+  }
+
+  bool HasAlarm() const noexcept {
+    return alarm_level != FlarmTraffic::AlarmType::NONE;
+  }
+
+  bool HasName() const noexcept {
+    return !name.empty();
+  }
+
+  void Clear() noexcept {
+    valid.Clear();
+    name.clear();
+  }
+
+  /**
+   * Update from another UnifiedTraffic (merge data)
+   * Only updates if the new data is newer or if fields are missing
+   */
+  void Update(const UnifiedTraffic &other) noexcept {
+    // Only update if new timestamp is newer or equal
+    if (other.source_timestamp < source_timestamp) {
+      // New data is older - don't update location/track/speed
+      // But still update alarm level (always use highest)
+      if ((unsigned)other.alarm_level > (unsigned)alarm_level) {
+        alarm_level = other.alarm_level;
+      }
+      return;
+    }
+
+    // Always update timestamp
+    source_timestamp = other.source_timestamp;
+
+    // Update location if available and newer
+    if (other.location_available) {
+      location = other.location;
+      location_available = true;
+    }
+
+    // Update altitude if available
+    if (other.altitude_available) {
+      altitude = other.altitude;
+      altitude_available = true;
+    }
+
+    // Update track if received from source
+    if (other.track_received) {
+      track = other.track;
+      track_received = true;
+    }
+
+    // Update speed if received from source
+    if (other.speed_received) {
+      speed = other.speed;
+      speed_received = true;
+    }
+
+    // Update climb rate if received from source
+    if (other.climb_rate_received) {
+      climb_rate = other.climb_rate;
+      climb_rate_received = true;
+    }
+
+    // Update turn rate if received from source
+    if (other.turn_rate_received) {
+      turn_rate = other.turn_rate;
+      turn_rate_received = true;
+    }
+
+    // Update name if available
+    if (other.HasName()) {
+      name = other.name;
+    }
+
+    // Update type if known
+    if (other.type != FlarmTraffic::AircraftType::UNKNOWN) {
+      type = other.type;
+    }
+
+    // Update alarm level (always use highest)
+    if ((unsigned)other.alarm_level > (unsigned)alarm_level) {
+      alarm_level = other.alarm_level;
+    }
+
+    // Update relative position if available (FLARM only)
+    if (other.relative_north != 0 || other.relative_east != 0) {
+      relative_north = other.relative_north;
+      relative_east = other.relative_east;
+    }
+
+    // Update distance if available
+    if (!other.distance.IsZero()) {
+      distance = other.distance;
+    }
+
+    // Update validity
+    valid = other.valid;
+  }
+
+  /**
+   * Convert to FlarmTraffic for compatibility
+   */
+  FlarmTraffic ToFlarmTraffic() const noexcept {
+    FlarmTraffic flarm;
+    flarm.id = id;
+    flarm.location = location;
+    flarm.track = track;
+    flarm.speed = speed;
+    flarm.altitude = altitude;
+    flarm.climb_rate = climb_rate;
+    flarm.climb_rate_avg30s = climb_rate_avg30s;
+    flarm.distance = distance;
+    flarm.relative_altitude = relative_altitude;
+    flarm.turn_rate = turn_rate;
+    flarm.type = type;
+    flarm.alarm_level = alarm_level;
+    flarm.name = name;
+    flarm.stealth = stealth;
+    flarm.valid = valid;
+    flarm.location_available = location_available;
+    flarm.track_received = track_received;
+    flarm.speed_received = speed_received;
+    flarm.altitude_available = altitude_available;
+    flarm.climb_rate_received = climb_rate_received;
+    flarm.turn_rate_received = turn_rate_received;
+    flarm.climb_rate_avg30s_available = climb_rate_avg30s_available;
+    flarm.relative_north = relative_north;
+    flarm.relative_east = relative_east;
+    return flarm;
+  }
+};
+
+static_assert(std::is_trivial<UnifiedTraffic>::value, "type is not trivial");
+

--- a/test/src/RunSkyLinesTracking.cpp
+++ b/test/src/RunSkyLinesTracking.cpp
@@ -3,6 +3,7 @@
 
 #include "Tracking/SkyLines/Client.hpp"
 #include "Tracking/SkyLines/Handler.hpp"
+#include "FLARM/Traffic.hpp"
 #include "NMEA/Info.hpp"
 #include "net/Resolver.hxx"
 #include "net/AddressInfo.hxx"
@@ -47,14 +48,26 @@ public:
   }
 
   virtual void OnTraffic(unsigned pilot_id, unsigned time_of_day_ms,
-                         const GeoPoint &location, int altitude) override {
+                         const GeoPoint &location, int altitude,
+                         unsigned flarm_id = 0,
+                         unsigned track = 0,
+                         double turn_rate = 0,
+                         FlarmTraffic::AircraftType aircraft_type = FlarmTraffic::AircraftType::UNKNOWN) override {
     auto time = BrokenTime::FromSinceMidnight(milliseconds(time_of_day_ms));
 
-    printf("received traffic pilot=%u time=%02u:%02u:%02u location=%f/%f altitude=%d\n",
-           pilot_id, time.hour, time.minute, time.second,
-           (double)location.longitude.Degrees(),
-           (double)location.latitude.Degrees(),
-           altitude);
+    if (flarm_id != 0) {
+      printf("received traffic pilot=%u flarm_id=%u time=%02u:%02u:%02u location=%f/%f altitude=%d track=%u° turn_rate=%.1f type=%u\n",
+             pilot_id, flarm_id, time.hour, time.minute, time.second,
+             (double)location.longitude.Degrees(),
+             (double)location.latitude.Degrees(),
+             altitude, track, turn_rate, (unsigned)aircraft_type);
+    } else {
+      printf("received traffic pilot=%u time=%02u:%02u:%02u location=%f/%f altitude=%d track=%u° turn_rate=%.1f type=%u\n",
+             pilot_id, time.hour, time.minute, time.second,
+             (double)location.longitude.Degrees(),
+             (double)location.latitude.Degrees(),
+             altitude, track, turn_rate, (unsigned)aircraft_type);
+    }
 
     stop_timer.Schedule(std::chrono::seconds(1));
   }

--- a/test/src/TestOGNAPRSParser.cpp
+++ b/test/src/TestOGNAPRSParser.cpp
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#define TEST_OGN_PARSER 1
+
+#include "Cloud/OGNClient.hpp"
+#include "Cloud/OGNTraffic.hpp"
+#include "FLARM/Traffic.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "TestUtil.hpp"
+#include "event/Loop.hxx"
+#include "event/net/cares/Channel.hxx"
+#include "util/ASCII.hxx"
+
+#include <cstring>
+#include <memory>
+
+// Test helper class to access private ParseOGNPosition method
+class TestOGNHelper {
+public:
+  static bool ParseOGNPosition(OGNClient &client, const char *packet,
+                               GeoPoint &location, int &altitude,
+                               unsigned &track, unsigned &speed,
+                               int &climb_rate, double &turn_rate,
+                               FlarmTraffic::AircraftType &aircraft_type,
+                               bool &track_received)
+  {
+    return client.ParseOGNPosition(packet, location, altitude, track, speed,
+                                   climb_rate, turn_rate, aircraft_type,
+                                   track_received);
+  }
+};
+
+static void
+TestBasicPosition()
+{
+  // Test basic position packet: "!ddmm.hhN/dddmm.hhW"
+  // Example: "!4742.50N/12226.22W"
+  const char *packet = "!4742.50N/12226.22W";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+
+  // Expected: 47.7083°N, 122.4372°W
+  // 47°42.50' = 47 + 42.50/60 = 47.7083°
+  // 122°26.22' = 122 + 26.22/60 = 122.4372°
+  ok1(equals(location.latitude.Degrees(), 47.7083));
+  ok1(equals(location.longitude.Degrees(), -122.4372));
+  ok1(!track_received); // No track in this packet
+}
+
+static void
+TestPositionWithTimestamp()
+{
+  // Test position with timestamp: "/hhmmss/ddmm.hhN/dddmm.hhW"
+  // The packet must start with !, /, or =
+  // After timestamp, the format is: timestamp/ddmm.hhN/symbol/dddmm.hhW
+  const char *packet = "/123456/4742.50N/12226.22W";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+  ok1(equals(location.latitude.Degrees(), 47.7083));
+  ok1(equals(location.longitude.Degrees(), -122.4372));
+}
+
+static void
+TestPositionWithCourseSpeed()
+{
+  // Test position with course/speed: "!ddmm.hhN/dddmm.hhW'ttt/sss"
+  // Example: "!4742.50N/12226.22W'270/045"
+  const char *packet = "!4742.50N/12226.22W'270/045";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+  ok1(track_received);
+  ok1(track == 270);
+  // Speed: 45 knots = 45 * 0.514444 = 23.15 m/s (rounded)
+  ok1(speed >= 23 && speed <= 24);
+}
+
+static void
+TestPositionWithAltitude()
+{
+  // Test position with altitude: "!ddmm.hhN/dddmm.hhW/A=12345"
+  const char *packet = "!4742.50N/12226.22W/A=12345";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+  // Expected: altitude = 12345 feet = 12345 * 0.3048 = 3762.756 meters
+  ok1(altitude >= 3762 && altitude <= 3763);
+}
+
+static void
+TestPositionWithClimbRate()
+{
+  // Test position with climb rate: "!ddmm.hhN/dddmm.hhW +0123fpm"
+  const char *packet = "!4742.50N/12226.22W +0123fpm";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+  // Expected: climb_rate = 123 fpm = 123 * 0.00508 = 0.625 m/s (rounded)
+  ok1(climb_rate >= 0 && climb_rate <= 1);
+}
+
+static void
+TestPositionWithTurnRate()
+{
+  // Test position with turn rate: "!4742.50N/12226.22W rot=+12.5"
+  const char *packet = "!4742.50N/12226.22W rot=+12.5";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, packet, location, altitude, track, speed, climb_rate, turn_rate,
+      aircraft_type, track_received);
+
+  ok1(result);
+  ok1(location.IsValid());
+  ok1(equals(turn_rate, 12.5));
+}
+
+static void
+TestAircraftTypes()
+{
+  // Test different aircraft type symbols
+  // In APRS format, the symbol comes between latitude and longitude
+  // Format: !ddmm.hhN/symbol/dddmm.hhW
+  const char *packets[] = {
+      "!4742.50N/12226.22W",  // GLIDER (symbol / between lat and lon)
+      "!4742.50N\\12226.22W", // POWERED_AIRCRAFT (symbol \ between lat and
+                              // lon)
+      "!4742.50N'12226.22W",  // HANG_GLIDER (symbol ' between lat and lon)
+      "!4742.50N^12226.22W",  // PARA_GLIDER (symbol ^ between lat and lon)
+      "!4742.50NO12226.22W",  // BALLOON (symbol O between lat and lon)
+      "!4742.50Ng12226.22W",  // UAV (symbol g between lat and lon)
+  };
+
+  FlarmTraffic::AircraftType expected[] = {
+      FlarmTraffic::AircraftType::GLIDER,
+      FlarmTraffic::AircraftType::POWERED_AIRCRAFT,
+      FlarmTraffic::AircraftType::HANG_GLIDER,
+      FlarmTraffic::AircraftType::PARA_GLIDER,
+      FlarmTraffic::AircraftType::BALLOON,
+      FlarmTraffic::AircraftType::UAV,
+  };
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  for (unsigned i = 0; i < sizeof(packets) / sizeof(packets[0]); i++) {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, packets[i], location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+
+    ok1(result);
+    ok1(aircraft_type == expected[i]);
+  }
+}
+
+static void
+TestInvalidPackets()
+{
+  // Test various invalid packets that should fail parsing
+  const char *invalid_packets[] = {
+      "",                    // Empty
+      "X4742.50N/12226.22W", // Invalid start character
+      "!4742.50X/12226.22W", // Invalid latitude direction
+      "!4742.50N/12226.22X", // Invalid longitude direction
+      "!47N/122W",           // Missing minutes
+      "!4742.50N",           // Missing longitude
+  };
+
+  bool should_fail[] = {
+      true, // Empty
+      true, // Invalid start
+      true, // Invalid lat dir
+      true, // Invalid lon dir
+      true, // Missing minutes
+      true, // Missing longitude
+  };
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  for (unsigned i = 0;
+       i < sizeof(invalid_packets) / sizeof(invalid_packets[0]); i++) {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, invalid_packets[i], location, altitude, track, speed,
+        climb_rate, turn_rate, aircraft_type, track_received);
+
+    if (should_fail[i]) {
+      ok1(!result);
+    } else {
+      ok1(result);
+    }
+  }
+
+  // Test valid packet
+  const char *valid_packet = "!4742.50N/12226.22W";
+  GeoPoint location;
+  int altitude = -1;
+  unsigned track = 0;
+  unsigned speed = 0;
+  int climb_rate = 0;
+  double turn_rate = 0;
+  FlarmTraffic::AircraftType aircraft_type =
+      FlarmTraffic::AircraftType::UNKNOWN;
+  bool track_received = false;
+
+  bool result = TestOGNHelper::ParseOGNPosition(
+      client, valid_packet, location, altitude, track, speed, climb_rate,
+      turn_rate, aircraft_type, track_received);
+  ok1(result);
+  ok1(location.IsValid());
+}
+
+static void
+TestTrackReceived()
+{
+  // Test that track_received is set correctly
+  const char *with_track = "!4742.50N/12226.22W'270/045";
+  const char *without_track = "!4742.50N/12226.22W";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  // Test with track
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, with_track, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(track_received);
+    ok1(track == 270);
+  }
+
+  // Test without track
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received =
+        true; // Start with true to verify it gets set to false
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, without_track, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(!track_received);
+  }
+}
+
+static void
+TestRealWorldExamples()
+{
+  // Test with real-world OGN APRS packet examples
+  // These are actual packets received from OGN servers
+  // Format: position data after colon:
+  // "/hhmmss/ddmm.mmN/symbol/dddmm.mmE^ttt/sss/A=aaaaaa ..."
+
+  // Extract position data portion (after colon) from real packets
+  const char *real_packet1 = "/205026h4942.30N/00707.33E^266/435/A=024093 "
+                             "!W08! id253C6749 +64fpm FL239.50 A3:DLH84M";
+  const char *real_packet2 = "/205026h5024.58N/01109.93E^285/420/A=035793 "
+                             "!W22! id0140804D +0fpm FL359.50";
+  const char *real_packet3 = "/205026h4814.26N/01559.29E^340/319/A=015994 "
+                             "!W22! id2544082B +1792fpm FL159.45 A3:AUA649";
+  const char *real_packet4 = "/205026h5025.30N/00830.59E^066/478/A=036843 "
+                             "!W33! id25511170 +64fpm FL370.50 A3:MBU8TN";
+  const char *real_packet5 = "/205027h5059.14N/00646.55E'302/034/A=000206 "
+                             "!W92! id203D223B +000fpm gps6x3";
+
+  EventLoop event_loop;
+  Cares::Channel cares_channel(event_loop);
+  OGNTrafficContainer traffic_container;
+  OGNClient client(event_loop, cares_channel, traffic_container);
+
+  // Test packet 1: Full featured packet with course/speed, altitude, climb
+  // rate
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, real_packet1, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(location.IsValid());
+    ok1(track_received);
+    ok1(track == 266);
+    // Speed: 435 knots = 435 * 0.514444 = 223.78 m/s (rounded)
+    ok1(speed >= 223 && speed <= 224);
+    // Altitude: 24093 feet = 24093 * 0.3048 = 7343.5 meters
+    ok1(altitude >= 7343 && altitude <= 7344);
+    // Climb rate: 64 fpm = 64 * 0.00508 = 0.325 m/s (rounded)
+    ok1(climb_rate >= 0 && climb_rate <= 1);
+    // Aircraft type symbol is / between lat and lon (GLIDER), not ^ (which is
+    // course/speed separator)
+    ok1(aircraft_type == FlarmTraffic::AircraftType::GLIDER);
+  }
+
+  // Test packet 2: With timestamp, course/speed, altitude, zero climb rate
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, real_packet2, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(location.IsValid());
+    ok1(track_received);
+    ok1(track == 285);
+    // Speed: 420 knots = 420 * 0.514444 = 216.07 m/s
+    ok1(speed >= 216 && speed <= 217);
+    // Altitude: 35793 feet = 35793 * 0.3048 = 10909.7 meters
+    ok1(altitude >= 10909 && altitude <= 10910);
+    ok1(climb_rate == 0);
+    // Aircraft type symbol is / between lat and lon (GLIDER), not ^ (which is
+    // course/speed separator)
+    ok1(aircraft_type == FlarmTraffic::AircraftType::GLIDER);
+  }
+
+  // Test packet 3: High climb rate
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, real_packet3, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(location.IsValid());
+    ok1(track_received);
+    ok1(track == 340);
+    // Climb rate: 1792 fpm = 1792 * 0.00508 = 9.10 m/s (rounded)
+    ok1(climb_rate >= 9 && climb_rate <= 10);
+    // Aircraft type symbol is / between lat and lon (GLIDER), not ^ (which is
+    // course/speed separator)
+    ok1(aircraft_type == FlarmTraffic::AircraftType::GLIDER);
+  }
+
+  // Test packet 4: High speed
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, real_packet4, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(location.IsValid());
+    ok1(track_received);
+    ok1(track == 66);
+    // Speed: 478 knots = 478 * 0.514444 = 245.91 m/s
+    ok1(speed >= 245 && speed <= 246);
+    // Aircraft type symbol is / between lat and lon (GLIDER), not ^ (which is
+    // course/speed separator)
+    ok1(aircraft_type == FlarmTraffic::AircraftType::GLIDER);
+  }
+
+  // Test packet 5: Hang glider symbol (')
+  {
+    GeoPoint location;
+    int altitude = -1;
+    unsigned track = 0;
+    unsigned speed = 0;
+    int climb_rate = 0;
+    double turn_rate = 0;
+    FlarmTraffic::AircraftType aircraft_type =
+        FlarmTraffic::AircraftType::UNKNOWN;
+    bool track_received = false;
+
+    bool result = TestOGNHelper::ParseOGNPosition(
+        client, real_packet5, location, altitude, track, speed, climb_rate,
+        turn_rate, aircraft_type, track_received);
+    ok1(result);
+    ok1(location.IsValid());
+    ok1(track_received);
+    ok1(track == 302);
+    // Speed: 34 knots = 34 * 0.514444 = 17.49 m/s
+    ok1(speed >= 17 && speed <= 18);
+    ok1(aircraft_type ==
+        FlarmTraffic::AircraftType::GLIDER); // ' is course/speed separator, /
+                                             // is aircraft type symbol
+  }
+}
+
+int
+main()
+{
+  plan_tests(82); // Count: 60 original + 22 new real-world tests (5 packets
+                  // with multiple assertions each)
+
+  TestBasicPosition();
+  TestPositionWithTimestamp();
+  TestPositionWithCourseSpeed();
+  TestPositionWithAltitude();
+  TestPositionWithClimbRate();
+  TestPositionWithTurnRate();
+  TestAircraftTypes();
+  TestInvalidPackets();
+  TestTrackReceived();
+  TestRealWorldExamples();
+
+  return exit_status();
+}


### PR DESCRIPTION

<img width="644" height="482" alt="image" src="https://github.com/user-attachments/assets/0b854c23-46bf-48be-ba62-3e0ebc8c2530" />


I'd like to stress that this is a mockup (its functional!), for exploring a whatif scenario.

Basically xcsoar-cloud protocol is extended to add more information from ogn packages. xcsoar-cloud connects to ogn and forwards traffic to connected xcsoar clients efficently via udp.

The traffic inside xcsoar is aggregated from all sources. There should be a seamless handover from i.e. ogn to flarm for the same plane. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added OGN (Open Glider Network) traffic integration with configurable callsign and passcode.
  * Implemented multi-source traffic aggregation combining FLARM, OGN, SkyLines, GliderLink, and Stratux data.
  * Added support for configurable checklist file via settings.
  * Added version information display via command-line option.

* **Improvements**
  * Enhanced traffic display with turn rate, aircraft type, and track information.
  * Redesigned waypoint details with embedded map view and tabbed interface.
  * Added visual differentiation for traffic sources with distinct color coding.
  * Improved read-only field styling in UI controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->