### PR TITLE
build/WAYLAND: fix missing HasTouchScreen() and xdg_wm_base_interface

### DIFF
--- a/build/libevent.mk
+++ b/build/libevent.mk
@@ -25,7 +25,9 @@ VFB_CPPFLAGS = -DNON_INTERACTIVE
 else ifeq ($(USE_X11),y)
 EVENT_SOURCES += $(SRC)/ui/event/poll/X11Queue.cpp
 else ifeq ($(USE_WAYLAND),y)
-EVENT_SOURCES += $(SRC)/ui/event/poll/WaylandQueue.cpp
+EVENT_SOURCES += \
+	$(WAYLAND_GENERATED)/xdg-shell-public.c \
+	$(SRC)/ui/event/poll/WaylandQueue.cpp
 else ifeq ($(USE_CONSOLE),y)
 EVENT_SOURCES += \
 	$(SRC)/ui/event/poll/InputQueue.cpp

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -13,7 +13,7 @@ HasPointer() noexcept
 
 #endif
 
-#ifdef USE_LIBINPUT
+#if defined(USE_LIBINPUT) || defined(USE_WAYLAND)
 
 bool
 HasTouchScreen() noexcept


### PR DESCRIPTION
- Add HasTouchScreen() and HasKeyboard() definitions for WAYLAND builds
- Include xdg-shell-public.c in libevent sources for WAYLAND
- Fixes linker errors in WAYLAND test builds

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Wayland build configuration with enhanced source file handling
* **Tests**
  * Updated test conditions to support broader input system compatibility detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->