### PR TITLE
Device/Driver/LX: LXNAV DataPort Protocol v1.05 Implementation

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -742,12 +742,16 @@ TEST_DRIVER_SOURCES = \
 	$(SRC)/TransponderMode.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(ENGINE_SRC_DIR)/Waypoint/Waypoint.cpp \
+	$(SRC)/Engine/GlideSolvers/GlidePolar.cpp \
+	$(SRC)/Interface.cpp \
+	$(SRC)/Blackboard/InterfaceBlackboard.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeGeoid.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/TestDriver.cpp
-TEST_DRIVER_DEPENDS = DRIVER OPERATION LIBNMEA GEO MATH IO OS THREAD UTIL TIME
+TEST_DRIVER_DEPENDS = DRIVER OPERATION LIBNMEA GEO MATH IO OS THREAD UTIL TIME GLIDE COMPUTER TASK LOGGER
 $(eval $(call link-program,TestDriver,TEST_DRIVER))
 
 TEST_WAY_POINT_FILE_SOURCES = \

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -89,11 +89,11 @@ ActionInterface::SendGetComputerSettings() noexcept
 }
 
 void
-ActionInterface::SetBallast(double ballast, bool to_devices) noexcept
+ActionInterface::SetBallast(double ballast_litres, bool to_devices) noexcept
 {
-  // write ballast into settings
+  // write ballast into settings (ballast_litres is in litres)
   GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
-  polar.SetBallast(ballast);
+  polar.SetBallastLitres(ballast_litres);
 
   // send to calculation thread and trigger recalculation
   backend_components->SetTaskPolar(GetComputerSettings().polar);
@@ -103,11 +103,11 @@ ActionInterface::SetBallast(double ballast, bool to_devices) noexcept
     const Plane &plane = GetComputerSettings().plane;
     if (plane.empty_mass > 0) {
       auto dry_mass = plane.empty_mass + polar.GetCrewMass();
-      auto overload = (dry_mass + ballast * plane.max_ballast) /
+      auto overload = (dry_mass + ballast_litres) /
                       plane.polar_shape.reference_mass;
 
       MessageOperationEnvironment env;
-      backend_components->devices->PutBallast(ballast, overload, env);
+      backend_components->devices->PutBallast(0.0, overload, env);
     }
   }
 }
@@ -125,6 +125,40 @@ ActionInterface::SetBugs(double bugs, bool to_devices) noexcept
   if (to_devices && backend_components->devices) {
     MessageOperationEnvironment env;
     backend_components->devices->PutBugs(bugs, env);
+  }
+}
+
+void
+ActionInterface::SetCrewMass(double crew_mass, bool to_devices) noexcept
+{
+  // Write crew mass into settings
+  GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
+  polar.SetCrewMass(crew_mass);
+
+  // send to calculation thread and trigger recalculation
+  backend_components->SetTaskPolar(GetComputerSettings().polar);
+
+  // send to external devices
+  if (to_devices && backend_components->devices) {
+    MessageOperationEnvironment env;
+    backend_components->devices->PutCrewMass(crew_mass, env);
+  }
+}
+
+void
+ActionInterface::SetEmptyMass(double empty_mass, bool to_devices) noexcept
+{
+  // Write empty mass into settings
+  GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
+  polar.SetEmptyMass(empty_mass);
+
+  // send to calculation thread and trigger recalculation
+  backend_components->SetTaskPolar(GetComputerSettings().polar);
+
+  // send to external devices
+  if (to_devices && backend_components->devices) {
+    MessageOperationEnvironment env;
+    backend_components->devices->PutEmptyMass(empty_mass, env);
   }
 }
 

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -100,11 +100,10 @@ ActionInterface::SetBallast(double ballast_litres, bool to_devices) noexcept
 
   // send to external devices
   if (to_devices && backend_components->devices) {
-    const Plane &plane = GetComputerSettings().plane;
-    if (plane.empty_mass > 0) {
-      auto dry_mass = plane.empty_mass + polar.GetCrewMass();
-      auto overload = (dry_mass + ballast_litres) /
-                      plane.polar_shape.reference_mass;
+    const double ref_mass = polar.GetReferenceMass();
+    if (ref_mass > 0) {
+      const double overload =
+        (polar.GetDryMass() + ballast_litres) / ref_mass;
 
       MessageOperationEnvironment env;
       backend_components->devices->PutBallast(0.0, overload, env);

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -20,7 +20,7 @@ using namespace CommonInterface;
  * @param to_devices send the new settings to all devices?
  */
 void
-SetBallast(double ballast, bool to_devices=true) noexcept;
+SetBallast(double ballast_litres, bool to_devices=true) noexcept;
 
 /**
  * Configure a new Bugs setting in #ComputerSettings, and
@@ -39,6 +39,25 @@ SetBugs(double mc, bool to_devices=true) noexcept;
  */
 void
 SetMacCready(double mc, bool to_devices=true) noexcept;
+
+/**
+ * Configure a new Crew Mass setting in #ComputerSettings, and
+ * forward it to all XCSoar modules that want it.
+ *
+ * @param crew_mass the new crew mass value [kg]
+ * @param to_devices send the new settings to all devices?
+ */
+void
+SetCrewMass(double crew_mass, bool to_devices=true) noexcept;
+
+/**
+ * Set the empty mass (empty weight) of the glider.
+ *
+ * @param empty_mass the new empty mass value [kg]
+ * @param to_devices send the new settings to all devices?
+ */
+void
+SetEmptyMass(double empty_mass, bool to_devices=true) noexcept;
 
 /**
  * Configure a new MacCready setting in #ComputerSettings, and

--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -7,6 +7,7 @@
 #include "BackendComponents.hpp"
 #include "ActionInterface.hpp"
 #include "Device/MultipleDevices.hpp"
+#include "Math/Util.hpp"
 
 static bool
 BallastProcessTimer() noexcept
@@ -93,8 +94,14 @@ QNHProcessTimer(OperationEnvironment &env) noexcept
     settings_computer.pressure = calculated.pressure;
     settings_computer.pressure_available = calculated.pressure_available;
 
-    if (backend_components->devices)
+    if (backend_components->devices) {
       backend_components->devices->PutQNH(settings_computer.pressure, env);
+
+      if (calculated.pressure_elevation_available.IsValid()) {
+        int elevation = iround(calculated.pressure_elevation);
+        backend_components->devices->PutElevation(elevation, env);
+      }
+    }
 
     modified = true;
   }

--- a/src/BallastDumpManager.cpp
+++ b/src/BallastDumpManager.cpp
@@ -46,17 +46,38 @@ BallastDumpManager::Update(GlidePolar &glide_polar,
   // Milliseconds since last ballast_clock.Update() call
   const auto dt = ballast_clock.ElapsedUpdate();
 
-  // Calculate the new ballast percentage
-  auto ballast = glide_polar.GetBallast() - ToFloatSeconds(dt) / dump_time;
-
-  // Check if the plane is dry now
-  if (ballast < 0) {
-    Stop();
-    glide_polar.SetBallastLitres(0);
-    return false;
+  // Get current ballast in litres
+  auto ballast_litres = glide_polar.GetBallastLitres();
+  
+  const double max_ballast = glide_polar.GetMaxBallast();
+  
+  if (max_ballast > 0) {
+    // Convert to fraction, subtract dump rate, convert back to litres
+    double ballast_fraction = glide_polar.GetBallastFraction();
+    ballast_fraction -= ToFloatSeconds(dt) / dump_time;
+    
+    // Check if the plane is dry now
+    if (ballast_fraction < 0) {
+      Stop();
+      glide_polar.SetBallastLitres(0);
+      return false;
+    }
+    
+    // Set new ballast using fraction
+    glide_polar.SetBallastFraction(ballast_fraction);
+  } else {
+    // No max ballast - dump directly from litres (assume 1L per second as fallback)
+    ballast_litres -= ToFloatSeconds(dt);
+    
+    // Check if the plane is dry now
+    if (ballast_litres < 0) {
+      Stop();
+      glide_polar.SetBallastLitres(0);
+      return false;
+    }
+    
+    // Set new ballast
+    glide_polar.SetBallastLitres(ballast_litres);
   }
-
-  // Set new ballast
-  glide_polar.SetBallast(ballast);
   return true;
 }

--- a/src/Computer/AutoQNH.cpp
+++ b/src/Computer/AutoQNH.cpp
@@ -62,4 +62,6 @@ AutoQNH::CalculateQNH(const NMEAInfo &basic, DerivedInfo &calculated,
 {
   calculated.pressure = AtmosphericPressure::FindQNHFromPressure(basic.static_pressure, altitude);
   calculated.pressure_available.Update(basic.clock);
+  calculated.pressure_elevation = altitude;
+  calculated.pressure_elevation_available.Update(basic.clock);
 }

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -183,6 +183,7 @@ DeviceConfig::Clear() noexcept
   sync_from_device = true;
   sync_to_device = true;
   k6bt = false;
+  polar_sync = PolarSync::OFF;
   engine_type = EngineType::NONE;
 #ifndef NDEBUG
   dump_port = false;

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -204,6 +204,26 @@ struct DeviceConfig {
   static_assert(std::size(ignitions_to_revolutions_factors) == (std::size_t)EngineType::MAX);
 
   /**
+   * Whether to synchronize the glide polar between XCSoar and the
+   * device.
+   */
+  enum class PolarSync : uint8_t {
+    /** No polar synchronization. */
+    OFF = 0,
+
+    /** Adopt the polar from the device. */
+    RECEIVE,
+
+    /** Push XCSoar's polar to the device. */
+    SEND,
+
+    /**
+     * A dummy entry that is used for validating profile values.
+     */
+    COUNT
+  } polar_sync;
+
+  /**
    * Name of the driver.
    */
   StaticString<32> driver_name;

--- a/src/Device/Declaration.cpp
+++ b/src/Device/Declaration.cpp
@@ -6,8 +6,11 @@
 #include "Plane/Plane.hpp"
 #include "Task/ObservationZones/ObservationZonePoint.hpp"
 #include "Engine/Task/ObservationZones/CylinderZone.hpp"
+#include "Engine/Task/ObservationZones/SymmetricSectorZone.hpp"
+#include "Engine/Task/ObservationZones/KeyholeZone.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/Factory/TaskFactoryType.hpp"
 
 [[gnu::pure]]
 static Declaration::TurnPoint::Shape
@@ -21,7 +24,11 @@ get_shape(const OrderedTaskPoint &tp)
   case ObservationZone::Shape::MAT_CYLINDER:
   case ObservationZone::Shape::CYLINDER:
     return Declaration::TurnPoint::CYLINDER;
+
   case ObservationZone::Shape::DAEC_KEYHOLE:
+  case ObservationZone::Shape::CUSTOM_KEYHOLE:
+  case ObservationZone::Shape::BGAFIXEDCOURSE:
+  case ObservationZone::Shape::BGAENHANCEDOPTION:
     return Declaration::TurnPoint::DAEC_KEYHOLE;
 
   default:
@@ -37,9 +44,71 @@ get_radius(const OrderedTaskPoint &tp)
   return (unsigned)oz.GetRadius();
 }
 
+/**
+ * Extract the half-angle of the observation zone sector.
+ * Returns 180 degrees for cylinders (full circle).
+ */
+[[gnu::pure]]
+static Angle
+get_sector_angle(const OrderedTaskPoint &tp)
+{
+  const ObservationZonePoint &oz = tp.GetObservationZone();
+  switch (oz.GetShape()) {
+  case ObservationZone::Shape::LINE:
+    return Angle::QuarterCircle();
+
+  case ObservationZone::Shape::MAT_CYLINDER:
+  case ObservationZone::Shape::CYLINDER:
+    return Angle::HalfCircle();
+
+  case ObservationZone::Shape::FAI_SECTOR:
+  case ObservationZone::Shape::SYMMETRIC_QUADRANT:
+  case ObservationZone::Shape::DAEC_KEYHOLE:
+  case ObservationZone::Shape::CUSTOM_KEYHOLE:
+  case ObservationZone::Shape::BGAFIXEDCOURSE:
+  case ObservationZone::Shape::BGAENHANCEDOPTION:
+  case ObservationZone::Shape::BGA_START:
+    return static_cast<const SymmetricSectorZone &>(oz).GetSectorAngle();
+
+  case ObservationZone::Shape::SECTOR:
+  case ObservationZone::Shape::ANNULAR_SECTOR: {
+    /* For asymmetric sectors, compute the half-angle from the
+       start/end radials */
+    const auto &sz = static_cast<const SectorZone &>(oz);
+    return (sz.GetEndRadial() - sz.GetStartRadial()).AsBearing() / 2;
+  }
+  }
+
+  return Angle::HalfCircle();
+}
+
+/**
+ * Extract the inner radius for keyhole-type observation zones.
+ * Returns 0 for non-keyhole zones.
+ */
+[[gnu::pure]]
+static unsigned
+get_inner_radius(const OrderedTaskPoint &tp)
+{
+  const ObservationZonePoint &oz = tp.GetObservationZone();
+  switch (oz.GetShape()) {
+  case ObservationZone::Shape::DAEC_KEYHOLE:
+  case ObservationZone::Shape::CUSTOM_KEYHOLE:
+  case ObservationZone::Shape::BGAFIXEDCOURSE:
+  case ObservationZone::Shape::BGAENHANCEDOPTION:
+    return (unsigned)static_cast<const KeyholeZone &>(oz).GetInnerRadius();
+
+  default:
+    return 0;
+  }
+}
+
 Declaration::TurnPoint::TurnPoint(const OrderedTaskPoint &tp)
   :waypoint(tp.GetWaypoint()),
-   shape(get_shape(tp)), radius(get_radius(tp))
+   shape(get_shape(tp)), radius(get_radius(tp)),
+   sector_angle(get_sector_angle(tp)),
+   inner_radius(get_inner_radius(tp)),
+   is_aat(tp.GetType() == TaskPointType::AAT)
 {
 }
 
@@ -52,7 +121,11 @@ Declaration::Declaration(const LoggerSettings &logger_settings,
    aircraft_registration(plane.registration),
    competition_id(plane.competition_id)
 {
-  if (task)
+  if (task) {
+    const auto ft = task->GetFactoryType();
+    is_aat_task = (ft == TaskFactoryType::AAT || ft == TaskFactoryType::MAT);
+
     for (unsigned i = 0; i < task->TaskSize(); i++)
       turnpoints.push_back(task->GetTaskPoint(i));
+  }
 }

--- a/src/Device/Declaration.hpp
+++ b/src/Device/Declaration.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Engine/Waypoint/Waypoint.hpp"
+#include "Math/Angle.hpp"
 #include "util/StaticString.hxx"
 
 #include <vector>
@@ -25,6 +26,24 @@ struct Declaration {
     Shape shape;
     unsigned radius;
 
+    /**
+     * Half-angle of the observation zone sector.
+     * 180 degrees for a cylinder (full circle),
+     * 90 degrees for a FAI quarter-circle sector, etc.
+     */
+    Angle sector_angle = Angle::HalfCircle();
+
+    /**
+     * Inner radius for keyhole-type observation zones (meters).
+     * Zero if not applicable.
+     */
+    unsigned inner_radius = 0;
+
+    /**
+     * Is this an AAT (Assigned Area Task) point?
+     */
+    bool is_aat = false;
+
     TurnPoint(const Waypoint &_waypoint)
       :waypoint(_waypoint), shape(CYLINDER), radius(1500) {}
     TurnPoint(const OrderedTaskPoint &tp);
@@ -36,6 +55,11 @@ struct Declaration {
   StaticString<32> aircraft_registration;
   StaticString<8> competition_id;
   std::vector<TurnPoint> turnpoints;
+
+  /**
+   * Is the overall task an AAT or MAT type?
+   */
+  bool is_aat_task = false;
 
   Declaration(const LoggerSettings &logger_settings, const Plane &plane,
               const OrderedTask* task);

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -1044,6 +1044,58 @@ DeviceDescriptor::PutQNH(const AtmosphericPressure value,
   return true;
 }
 
+bool
+DeviceDescriptor::PutElevation(int elevation, OperationEnvironment &env) noexcept
+{
+  assert(InMainThread());
+
+  if (device == nullptr || !config.sync_to_device)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+
+  try {
+    ScopeReturnDevice restore(*this, env);
+    if (!device->PutElevation(elevation, env))
+      return false;
+  } catch (OperationCancelled) {
+    return false;
+  } catch (...) {
+    LogError(std::current_exception(), "PutElevation() failed");
+    return false;
+  }
+
+  return true;
+}
+
+bool
+DeviceDescriptor::RequestElevation(OperationEnvironment &env) noexcept
+{
+  assert(InMainThread());
+
+  if (device == nullptr)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+
+  try {
+    ScopeReturnDevice restore(*this, env);
+    if (!device->RequestElevation(env))
+      return false;
+  } catch (OperationCancelled) {
+    return false;
+  } catch (...) {
+    LogError(std::current_exception(), "RequestElevation() failed");
+    return false;
+  }
+
+  return true;
+}
+
 static bool
 DeclareToFLARM(const struct Declaration &declaration, Port &port,
                const Waypoint *home, OperationEnvironment &env)

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -867,6 +867,58 @@ DeviceDescriptor::PutBallast(double fraction, double overload,
 }
 
 bool
+DeviceDescriptor::PutCrewMass(double crew_mass, OperationEnvironment &env) noexcept
+{
+  assert(InMainThread());
+
+  if (device == nullptr || !config.sync_to_device)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+
+  try {
+    const ScopeReturnDevice restore(*this, env);
+    if (!device->PutCrewMass(crew_mass, env))
+      return false;
+  } catch (OperationCancelled) {
+    return false;
+  } catch (...) {
+    LogError(std::current_exception(), "PutCrewMass() failed");
+    return false;
+  }
+
+  return true;
+}
+
+bool
+DeviceDescriptor::PutEmptyMass(double empty_mass, OperationEnvironment &env) noexcept
+{
+  assert(InMainThread());
+
+  if (device == nullptr || !config.sync_to_device)
+    return true;
+
+  if (!Borrow())
+    /* TODO: postpone until the borrowed device has been returned */
+    return false;
+
+  try {
+    const ScopeReturnDevice restore(*this, env);
+    if (!device->PutEmptyMass(empty_mass, env))
+      return false;
+  } catch (OperationCancelled) {
+    return false;
+  } catch (...) {
+    LogError(std::current_exception(), "PutEmptyMass() failed");
+    return false;
+  }
+
+  return true;
+}
+
+bool
 DeviceDescriptor::PutVolume(unsigned volume,
                             OperationEnvironment &env) noexcept
 {

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -16,6 +16,7 @@
 #include "NMEA/Info.hpp"
 #include "thread/Mutex.hxx"
 #include "util/StringAPI.hxx"
+#include "util/StringCompare.hxx"
 #include "util/Exception.hxx"
 #include "Logger/NMEALogger.hpp"
 #include "Language/Language.hpp"
@@ -1385,8 +1386,11 @@ DeviceDescriptor::DataReceived(std::span<const std::byte> s) noexcept
 bool
 DeviceDescriptor::LineReceived(const char *line) noexcept
 {
-  if (nmea_logger != nullptr)
-    nmea_logger->Log(line);
+  if (nmea_logger != nullptr) {
+    /* Skip logging high-frequency LXWP2 sentences */
+    if (!StringStartsWith(line, "$LXWP2"))
+      nmea_logger->Log(line);
+  }
 
   if (dispatcher != nullptr)
     dispatcher->LineReceived(line);

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -533,6 +533,8 @@ public:
   bool PutBugs(double bugs, OperationEnvironment &env) noexcept;
   bool PutBallast(double fraction, double overload,
                   OperationEnvironment &env) noexcept;
+  bool PutCrewMass(double crew_mass, OperationEnvironment &env) noexcept;
+  bool PutEmptyMass(double empty_mass, OperationEnvironment &env) noexcept;
   bool PutVolume(unsigned volume, OperationEnvironment &env) noexcept;
   bool PutPilotEvent(OperationEnvironment &env) noexcept;
   bool PutActiveFrequency(RadioFrequency frequency,

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -546,6 +546,8 @@ public:
   bool PutTransponderCode(TransponderCode code, OperationEnvironment &env) noexcept;
   bool PutQNH(AtmosphericPressure pres,
               OperationEnvironment &env) noexcept;
+  bool PutElevation(int elevation, OperationEnvironment &env) noexcept;
+  bool RequestElevation(OperationEnvironment &env) noexcept;
 
   /**
    * Caller is responsible for calling Borrow() and Return().

--- a/src/Device/Driver.cpp
+++ b/src/Device/Driver.cpp
@@ -52,6 +52,18 @@ AbstractDevice::PutQNH([[maybe_unused]] const AtmosphericPressure &pres,
 }
 
 bool
+AbstractDevice::PutElevation([[maybe_unused]] int elevation, [[maybe_unused]] OperationEnvironment &env)
+{
+  return true;
+}
+
+bool
+AbstractDevice::RequestElevation([[maybe_unused]] OperationEnvironment &env)
+{
+  return true;
+}
+
+bool
 AbstractDevice::PutVolume([[maybe_unused]] unsigned volume, [[maybe_unused]] OperationEnvironment &env)
 {
   return true;

--- a/src/Device/Driver.cpp
+++ b/src/Device/Driver.cpp
@@ -45,6 +45,18 @@ AbstractDevice::PutBallast([[maybe_unused]] double fraction, [[maybe_unused]] do
 }
 
 bool
+AbstractDevice::PutCrewMass([[maybe_unused]] double crew_mass, [[maybe_unused]] OperationEnvironment &env)
+{
+  return true;
+}
+
+bool
+AbstractDevice::PutEmptyMass([[maybe_unused]] double empty_mass, [[maybe_unused]] OperationEnvironment &env)
+{
+  return true;
+}
+
+bool
 AbstractDevice::PutQNH([[maybe_unused]] const AtmosphericPressure &pres,
                        [[maybe_unused]] OperationEnvironment &env)
 {

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -81,6 +81,22 @@ public:
                           OperationEnvironment &env) = 0;
 
   /**
+   * Send the new crew mass (pilot weight) to the device.
+   *
+   * @param crew_mass the new crew mass value [kg]
+   * @return true on success
+   */
+  virtual bool PutCrewMass(double crew_mass, OperationEnvironment &env) = 0;
+
+  /**
+   * Send the new empty mass (empty weight) to the device.
+   *
+   * @param empty_mass the new empty mass value [kg]
+   * @return true on success
+   */
+  virtual bool PutEmptyMass(double empty_mass, OperationEnvironment &env) = 0;
+
+  /**
    * Send the new QNH value to the device.
    *
    * @param pressure the new QNH
@@ -266,6 +282,8 @@ public:
   bool PutBugs(double bugs, OperationEnvironment &env) override;
   bool PutBallast(double fraction, double overload,
                   OperationEnvironment &env) override;
+  bool PutCrewMass(double crew_mass, OperationEnvironment &env) override;
+  bool PutEmptyMass(double empty_mass, OperationEnvironment &env) override;
   bool PutQNH(const AtmosphericPressure &pres,
               OperationEnvironment &env) override;
   bool PutElevation(int elevation, OperationEnvironment &env) override;

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -91,6 +91,22 @@ public:
                       OperationEnvironment &env) = 0;
 
   /**
+   * Send the elevation value to the device.
+   *
+   * @param elevation elevation in meters
+   * @return true on success
+   */
+  virtual bool PutElevation(int elevation, OperationEnvironment &env) = 0;
+
+  /**
+   * Request the elevation value from the device.
+   * The device should respond by providing the elevation via ExternalSettings.
+   *
+   * @return true on success
+   */
+  virtual bool RequestElevation(OperationEnvironment &env) = 0;
+
+  /**
    * Set the radio volume.
    *
    * @param volume the new volume (0 - 100%)
@@ -252,6 +268,8 @@ public:
                   OperationEnvironment &env) override;
   bool PutQNH(const AtmosphericPressure &pres,
               OperationEnvironment &env) override;
+  bool PutElevation(int elevation, OperationEnvironment &env) override;
+  bool RequestElevation(OperationEnvironment &env) override;
   bool PutVolume(unsigned volume, OperationEnvironment &env) override;
   bool PutPilotEvent(OperationEnvironment &env) override;
   bool PutActiveFrequency(RadioFrequency frequency,

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -10,6 +10,7 @@
 #include "util/StaticString.hxx"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Info.hpp"
+#include "LogFile.hpp"
 
 #include <atomic>
 #include <cstdint>
@@ -153,10 +154,20 @@ public:
 
   void IdDeviceByName(StaticString<16> productName) noexcept
   {
-    is_v7 = productName.equals("V7");
-    is_sVario = productName.equals("NINC") || productName.equals("S8x");
-    is_nano = productName.equals("NANO") || productName.equals("NANO3") || productName.equals("NANO4");
-    is_lx16xx = productName.equals("1606") || productName.equals("1600");
+    const bool new_v7 = productName.equals("V7");
+    const bool new_sVario = productName.equals("NINC") || productName.equals("S8x");
+    const bool new_nano = productName.equals("NANO") || productName.equals("NANO3") || productName.equals("NANO4");
+    const bool new_lx16xx = productName.equals("1606") || productName.equals("1600");
+
+    if (new_v7 && !is_v7)
+      LogFmt("LXNAV: V7 detected via PLXVC (product: {})", productName.c_str());
+    if (new_sVario && !is_sVario)
+      LogFmt("LXNAV: S series vario detected via PLXVC (product: {})", productName.c_str());
+
+    is_v7 = new_v7;
+    is_sVario = new_sVario;
+    is_nano = new_nano;
+    is_lx16xx = new_lx16xx;
   }
 
   /**

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -166,11 +166,10 @@ public:
 
     if ((new_v7 && !is_v7) || (new_sVario && !is_sVario)) {
       const char *device_type = new_v7 ? "V7" : "S series vario";
-      LogFmt("LXNAV: {} detected via PLXVC (product: {}, firmware: {}, hardware: {})",
+      LogFmt("LXNAV: {} detected via PLXVC (product: {}, firmware: {})",
              device_type,
              productName.c_str(),
-             device_info.software_version.empty() ? "unknown" : device_info.software_version.c_str(),
-             device_info.hardware_version.empty() ? "unknown" : device_info.hardware_version.c_str());
+             device_info.software_version.empty() ? "unknown" : device_info.software_version.c_str());
       if (!device_info.software_version.empty())
         firmware_version_logged = true;
     }

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -153,6 +153,8 @@ class LXDevice: public AbstractDevice
     double max_weight = 0;
     double empty_weight = 0;
     double pilot_weight = 0;
+    std::string name;
+    double stall = 0;
     bool valid = false;
   } device_polar;
 

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -7,6 +7,7 @@
 #include "Device/Config.hpp"
 #include "Device/Driver.hpp"
 #include "Device/SettingsMap.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "thread/Mutex.hxx"
 #include "util/StaticString.hxx"
 #include "NMEA/InputLine.hpp"
@@ -17,6 +18,7 @@
 #include <atomic>
 #include <cstdint>
 #include <optional>
+#include <string>
 
 struct MoreData;
 struct DerivedInfo;
@@ -184,6 +186,17 @@ class LXDevice: public AbstractDevice
    */
   bool polar_sync_notified = false;
 
+  /**
+   * Name of the last navigation target sent to the device via PLXVTARG.
+   * Used to avoid resending unchanged targets.
+   */
+  std::string last_sent_target_name;
+
+  /**
+   * Location of the last navigation target sent to the device.
+   */
+  GeoPoint last_sent_target_location = GeoPoint::Invalid();
+
   Mutex mutex;
   Mode mode = Mode::UNKNOWN;
   unsigned old_baud_rate = 0;
@@ -255,6 +268,8 @@ public:
     is_v7 = is_sVario = is_nano = is_lx16xx = is_forwarded_nano = false;
     polar_sync_notified = false;
     device_polar.valid = false;
+    last_sent_target_name.clear();
+    last_sent_target_location = GeoPoint::Invalid();
   }
 
   void IdDeviceByName(StaticString<16> productName, const DeviceInfo &device_info) noexcept

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -220,6 +220,13 @@ private:
    */
   GeoPoint last_sent_target_location = GeoPoint::Invalid();
 
+  /**
+   * Previous task type, used to detect GoTo→Ordered transitions
+   * so we can send one re-sync target to the vario.
+   * Uses the underlying uint8_t to avoid including TaskType.hpp.
+   */
+  uint8_t last_task_type = 0; /* TaskType::NONE */
+
   Mutex mutex;
   Mode mode = Mode::UNKNOWN;
   unsigned old_baud_rate = 0;
@@ -293,6 +300,7 @@ public:
     device_polar.valid = false;
     last_sent_target_name.clear();
     last_sent_target_location = GeoPoint::Invalid();
+    last_task_type = 0;
   }
 
   void IdDeviceByName(StaticString<16> productName, const DeviceInfo &device_info) noexcept

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -477,26 +477,6 @@ private:
    */
   void TrackPolarChanges(const DerivedInfo &calculated) noexcept;
 
-  /**
-   * Handle MC synchronization with the device.
-   */
-  void SyncMacCready(const MoreData &basic,
-                     const DerivedInfo &calculated,
-                     OperationEnvironment &env) noexcept;
-
-  /**
-   * Handle Ballast synchronization with the device.
-   */
-  void SyncBallast(const MoreData &basic,
-                   const DerivedInfo &calculated,
-                   OperationEnvironment &env) noexcept;
-
-  /**
-   * Handle Bugs synchronization with the device.
-   */
-  void SyncBugs(const MoreData &basic,
-                const DerivedInfo &calculated,
-                OperationEnvironment &env) noexcept;
   void SyncCrewWeight(const MoreData &basic,
                      const DerivedInfo &calculated,
                      OperationEnvironment &env);

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -344,9 +344,15 @@ public:
 
 protected:
   /**
-   * A variant of EnableNMEA() that attempts to put the Nano into NMEA
-   * mode.  If the Nano is connected through a LXNAV V7, it will
-   * enable pass-through mode on the V7.
+   * Prepare the port for communicating with the LXNAV logger.
+   *
+   * For S-series varios (built-in logger): always stays in NMEA
+   * mode so PLXVC commands reach the vario's own logger.  If a
+   * FLARM is behind the vario, its flight downloads are handled
+   * by the FLARM driver on a separate device slot.
+   *
+   * For V7 with a Nano behind it: enables pass-through mode so
+   * PLXVC commands reach the Nano logger.
    */
   bool EnableLoggerNMEA(OperationEnvironment &env);
 

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -158,6 +158,27 @@ class LXDevice: public AbstractDevice
     bool valid = false;
   } device_polar;
 
+public:
+  /**
+   * Declaration H-records read from the device via PLXVC,DECL,R.
+   * Used to match or create a plane profile by registration.
+   */
+  struct DeviceDeclaration {
+    std::string pilot_name;
+    std::string glider_type;
+    std::string registration;
+    std::string competition_id;
+    unsigned lines_received = 0;
+    unsigned total_lines = 0;
+    bool complete = false;
+    bool processed = false;
+  };
+
+private:
+  DeviceDeclaration device_declaration;
+
+  bool declaration_requested = false;
+
   /**
    * Has POLAR been requested from the device?
    */
@@ -503,6 +524,12 @@ private:
    * changes (e.g. due to plane profile switch).
    */
   void TrackPolarChanges(const DerivedInfo &calculated) noexcept;
+
+  /**
+   * Match the device declaration (registration) against existing
+   * plane profiles, or create a new profile if none matches.
+   */
+  void MatchPlaneProfile();
 
   void SyncCrewWeight(const MoreData &basic,
                      const DerivedInfo &calculated,

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -411,6 +411,16 @@ public:
 
   bool PutVolume(unsigned volume, OperationEnvironment &env) override;
   bool PutPilotEvent(OperationEnvironment &env) override;
+  bool PutActiveFrequency(RadioFrequency frequency,
+                          const char *name,
+                          OperationEnvironment &env) override;
+  bool PutStandbyFrequency(RadioFrequency frequency,
+                           const char *name,
+                           OperationEnvironment &env) override;
+  bool ExchangeRadioFrequencies(OperationEnvironment &env,
+                                NMEAInfo &info) override;
+  bool PutTransponderCode(TransponderCode code,
+                          OperationEnvironment &env) override;
 
   bool EnablePassThrough(OperationEnvironment &env) override;
 

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -251,20 +251,23 @@ public:
     const bool new_nano = productName.equals("NANO") || productName.equals("NANO3") || productName.equals("NANO4");
     const bool new_lx16xx = productName.equals("1606") || productName.equals("1600");
 
-    if ((new_v7 && !is_v7) || (new_sVario && !is_sVario)) {
-      const char *device_type = new_v7 ? "V7" : "S series vario";
-      LogFmt("LXNAV: {} detected via PLXVC (product: {}, firmware: {})",
-             device_type,
-             productName.c_str(),
-             device_info.software_version.empty() ? "unknown" : device_info.software_version.c_str());
-      if (!device_info.software_version.empty())
-        firmware_version_logged = true;
-    }
+    {
+      const std::lock_guard lock{mutex};
+      if ((new_v7 && !is_v7) || (new_sVario && !is_sVario)) {
+        const char *device_type = new_v7 ? "V7" : "S series vario";
+        LogFmt("LXNAV: {} detected via PLXVC (product: {}, firmware: {})",
+               device_type,
+               productName.c_str(),
+               device_info.software_version.empty() ? "unknown" : device_info.software_version.c_str());
+        if (!device_info.software_version.empty())
+          firmware_version_logged = true;
+      }
 
-    is_v7 = new_v7;
-    is_sVario = new_sVario;
-    is_nano = new_nano;
-    is_lx16xx = new_lx16xx;
+      is_v7 = new_v7;
+      is_sVario = new_sVario;
+      is_nano = new_nano;
+      is_lx16xx = new_lx16xx;
+    }
   }
 
   /**

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -99,6 +99,18 @@ namespace LXNAVVario {
   }
 
   /**
+   * Set the volume setting of the vario
+   * @param volume 0 - 100 %
+   */
+  static inline void
+  SetVolume(Port &port, OperationEnvironment &env, unsigned volume)
+  {
+    char buffer[32];
+    sprintf(buffer, "PLXV0,VOL,W,%.1f", (double)volume);
+    PortWriteNMEA(port, buffer, env);
+  }
+
+  /**
    * Send pilotevent to vario 
    * (needs S10x/S8x firmware 8.01 or newer)
    */

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -9,10 +9,12 @@
 #include "Units/System.hpp"
 #include "Math/Util.hpp"
 
+#include <fmt/format.h>
+
 /**
  * Code specific to LXNav varios (e.g. V7).
  *
- * Source: LXNav Vario Dataport specification Version 1.03
+ * Source: LXNAV DataPort Specification v1.05
  */
 namespace LXNAVVario {
   /**
@@ -57,9 +59,8 @@ namespace LXNAVVario {
   static inline void
   SetMacCready(Port &port, OperationEnvironment &env, double mc)
   {
-    char buffer[32];
-    sprintf(buffer, "PLXV0,MC,W,%.1f", mc);
-    PortWriteNMEA(port, buffer, env);
+    const auto buffer = fmt::format("PLXV0,MC,W,{:.1f}", mc);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -69,9 +70,8 @@ namespace LXNAVVario {
   static inline void
   SetBallast(Port &port, OperationEnvironment &env, double overload)
   {
-    char buffer[100];
-    sprintf(buffer, "PLXV0,BAL,W,%.2f", overload);
-    PortWriteNMEA(port, buffer, env);
+    const auto buffer = fmt::format("PLXV0,BAL,W,{:.2f}", overload);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -81,21 +81,21 @@ namespace LXNAVVario {
   static inline void
   SetBugs(Port &port, OperationEnvironment &env, unsigned bugs)
   {
-    char buffer[100];
-    sprintf(buffer, "PLXV0,BUGS,W,%u", bugs);
-    PortWriteNMEA(port, buffer, env);
+    const auto buffer = fmt::format("PLXV0,BUGS,W,{}", bugs);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
    * Set the QNH setting of the vario
    */
   static inline void
-  SetQNH(Port &port, OperationEnvironment &env, const AtmosphericPressure &qnh)
+  SetQNH(Port &port, OperationEnvironment &env,
+         const AtmosphericPressure &qnh)
   {
-    char buffer[100];
-    unsigned QNHinPascal = uround(qnh.GetPascal());
-    sprintf(buffer, "PLXV0,QNH,W,%u", QNHinPascal); 
-    PortWriteNMEA(port, buffer, env);
+    const unsigned qnh_pascal = uround(qnh.GetPascal());
+    const auto buffer =
+      fmt::format("PLXV0,QNH,W,{}", qnh_pascal);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -105,9 +105,9 @@ namespace LXNAVVario {
   static inline void
   SetVolume(Port &port, OperationEnvironment &env, unsigned volume)
   {
-    char buffer[32];
-    sprintf(buffer, "PLXV0,VOL,W,%.1f", (double)volume);
-    PortWriteNMEA(port, buffer, env);
+    const auto buffer =
+      fmt::format("PLXV0,VOL,W,{:.1f}", (double)volume);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -117,9 +117,9 @@ namespace LXNAVVario {
   static inline void
   SetElevation(Port &port, OperationEnvironment &env, int elevation)
   {
-    char buffer[32];
-    sprintf(buffer, "PLXV0,ELEVATION,W,%d", elevation);
-    PortWriteNMEA(port, buffer, env);
+    const auto buffer =
+      fmt::format("PLXV0,ELEVATION,W,{}", elevation);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -141,11 +141,13 @@ namespace LXNAVVario {
   static inline void
   SetPilotWeight(Port &port, OperationEnvironment &env, double pilot_weight)
   {
-    char buffer[256];
-    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,<polar weight>,<max weight>,<empty weight>,<pilot weight>,<name>,<stall> */
-    /* Leave all fields empty except pilot_weight (position 10: after empty_weight) */
-    sprintf(buffer, "PLXV0,POLAR,W,,,,,,,,%.2f,,", pilot_weight);
-    PortWriteNMEA(port, buffer, env);
+    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,
+       <polar weight>,<max weight>,<empty weight>,<pilot weight>,
+       <name>,<stall> */
+    /* Leave all fields empty except pilot_weight */
+    const auto buffer =
+      fmt::format("PLXV0,POLAR,W,,,,,,,,{:.2f},,", pilot_weight);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
@@ -155,10 +157,12 @@ namespace LXNAVVario {
   static inline void
   SetEmptyWeight(Port &port, OperationEnvironment &env, double empty_weight)
   {
-    char buffer[256];
-    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,<polar weight>,<max weight>,<empty weight>,<pilot weight>,<name>,<stall> */
-    /* Leave all fields empty except empty_weight (position 9: after max_weight, before pilot_weight) */
-    sprintf(buffer, "PLXV0,POLAR,W,,,,,,,%.2f,,,", empty_weight);
-    PortWriteNMEA(port, buffer, env);
+    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,
+       <polar weight>,<max weight>,<empty weight>,<pilot weight>,
+       <name>,<stall> */
+    /* Leave all fields empty except empty_weight */
+    const auto buffer =
+      fmt::format("PLXV0,POLAR,W,,,,,,,{:.2f},,,", empty_weight);
+    PortWriteNMEA(port, buffer.c_str(), env);
   }
 }

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -40,14 +40,14 @@ namespace LXNAVVario {
    * - PLXVS every 5 seconds
    * - LXWP0 every second
    * - LXWP1 every 60 seconds
-   * - LXWP2 every 30 seconds
+   * - LXWP2 every 5 seconds (contains MC, ballast, bugs - more frequent for better sync)
    * - LXWP3 disabled (we don't parse it)
    * - LXWP5 disabled (we don't parse it)
    */
   static inline void
   SetupNMEA(Port &port, OperationEnvironment &env)
   {
-    PortWriteNMEA(port, "PLXV0,NMEARATE,W,2,5,1,60,30,0,0", env);
+    PortWriteNMEA(port, "PLXV0,NMEARATE,W,2,5,1,60,5,0,0", env);
   }
 
   /**
@@ -132,5 +132,33 @@ namespace LXNAVVario {
     const char *sentence = "PFLAI,PILOTEVENT";
 
     PortWriteNMEA(port, sentence, env);
+  }
+
+  /**
+   * Set only the pilot weight in POLAR command, leaving all other fields empty
+   * @param pilot_weight crew mass (kg)
+   */
+  static inline void
+  SetPilotWeight(Port &port, OperationEnvironment &env, double pilot_weight)
+  {
+    char buffer[256];
+    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,<polar weight>,<max weight>,<empty weight>,<pilot weight>,<name>,<stall> */
+    /* Leave all fields empty except pilot_weight (position 10: after empty_weight) */
+    sprintf(buffer, "PLXV0,POLAR,W,,,,,,,,%.2f,,", pilot_weight);
+    PortWriteNMEA(port, buffer, env);
+  }
+
+  /**
+   * Set only the empty weight in POLAR command, leaving all other fields empty
+   * @param empty_weight empty mass (kg)
+   */
+  static inline void
+  SetEmptyWeight(Port &port, OperationEnvironment &env, double empty_weight)
+  {
+    char buffer[256];
+    /* POLAR format: PLXV0,POLAR,W,<a>,<b>,<c>,<polar load>,<polar weight>,<max weight>,<empty weight>,<pilot weight>,<name>,<stall> */
+    /* Leave all fields empty except empty_weight (position 9: after max_weight, before pilot_weight) */
+    sprintf(buffer, "PLXV0,POLAR,W,,,,,,,%.2f,,,", empty_weight);
+    PortWriteNMEA(port, buffer, env);
   }
 }

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -111,6 +111,18 @@ namespace LXNAVVario {
   }
 
   /**
+   * Set the elevation setting of the vario
+   * @param elevation elevation in meters
+   */
+  static inline void
+  SetElevation(Port &port, OperationEnvironment &env, int elevation)
+  {
+    char buffer[32];
+    sprintf(buffer, "PLXV0,ELEVATION,W,%d", elevation);
+    PortWriteNMEA(port, buffer, env);
+  }
+
+  /**
    * Send pilotevent to vario 
    * (needs S10x/S8x firmware 8.01 or newer)
    */

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -11,6 +11,7 @@
 #include "Math/Util.hpp"
 
 #include <fmt/format.h>
+#include <algorithm>
 #include <cmath>
 
 /**
@@ -56,33 +57,37 @@ namespace LXNAVVario {
 
   /**
    * Set the MC setting of the vario
-   * @param mc in m/s
+   * @param mc in m/s (clamped to [0.0, 5.0] per S80 firmware limits)
    */
   static inline void
   SetMacCready(Port &port, OperationEnvironment &env, double mc)
   {
+    mc = std::clamp(mc, 0.0, 5.0);
     const auto buffer = fmt::format("PLXV0,MC,W,{:.1f}", mc);
     PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
    * Set the ballast setting of the vario
-   * @param overload 1.0 - 1.4 (100 - 140%)
+   * @param overload overload factor (clamped to [1.0, 2.0] per S80
+   *   firmware limits; sub-reference-mass values are not supported)
    */
   static inline void
   SetBallast(Port &port, OperationEnvironment &env, double overload)
   {
+    overload = std::clamp(overload, 1.0, 2.0);
     const auto buffer = fmt::format("PLXV0,BAL,W,{:.2f}", overload);
     PortWriteNMEA(port, buffer.c_str(), env);
   }
 
   /**
    * Set the bugs setting of the vario
-   * @param bugs 0 - 30 %
+   * @param bugs 0 - 50 % (clamped per S80 firmware limits)
    */
   static inline void
   SetBugs(Port &port, OperationEnvironment &env, unsigned bugs)
   {
+    bugs = std::clamp(bugs, 0u, 50u);
     const auto buffer = fmt::format("PLXV0,BUGS,W,{}", bugs);
     PortWriteNMEA(port, buffer.c_str(), env);
   }

--- a/src/Device/Driver/LX/LXNavDeclare.hpp
+++ b/src/Device/Driver/LX/LXNavDeclare.hpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Device/Declaration.hpp"
+#include "IGC/Generator.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Math/Angle.hpp"
+
+#include <fmt/format.h>
+#include <cmath>
+#include <string>
+
+namespace LXNavDeclare {
+
+/**
+ * Compute the A12 bearing for a turnpoint in the LXNAV OZ format.
+ *
+ * - Start: bearing from this toward the next turnpoint
+ * - Intermediate: bisector of (bearing to prev, bearing to next)
+ * - Finish: bearing from this toward the previous turnpoint
+ */
+inline Angle
+ComputeA12(const GeoPoint &prev, const GeoPoint &current,
+           const GeoPoint &next,
+           bool is_start, bool is_finish) noexcept
+{
+  if (is_start)
+    return current.Bearing(next);
+  else if (is_finish)
+    return current.Bearing(prev);
+  else
+    /* HalfAngle returns the outward-facing bisector (used for OZ
+       sector rendering); LXNAV A12 is the inward bisector, so we
+       apply Reciprocal() to flip by 180 degrees */
+    return current.Bearing(prev)
+      .HalfAngle(current.Bearing(next))
+      .Reciprocal();
+}
+
+/**
+ * Map the turnpoint position to the LXNAV OZ Style value.
+ *
+ * ozFixed=0, ozSymmetric=1, ozNext=2, ozPrev=3, ozStart=4
+ */
+constexpr unsigned
+GetOZStyle(bool is_start, bool is_finish) noexcept
+{
+  if (is_start)
+    return 2;
+  else if (is_finish)
+    return 3;
+  else
+    return 1;
+}
+
+/**
+ * Format latitude in LXNAV OZ format: DDMM.mmmN/S
+ */
+inline std::string
+FormatLat(const GeoPoint &location)
+{
+  const double abs_lat = std::abs(location.latitude.Degrees());
+  const int deg = static_cast<int>(abs_lat);
+  const double min = (abs_lat - deg) * 60.0;
+  const char suffix = location.latitude.IsNegative() ? 'S' : 'N';
+  return fmt::format("{:02d}{:06.3f}{}", deg, min, suffix);
+}
+
+/**
+ * Format longitude in LXNAV OZ format: DDDMM.mmmE/W
+ */
+inline std::string
+FormatLon(const GeoPoint &location)
+{
+  const double abs_lon = std::abs(location.longitude.Degrees());
+  const int deg = static_cast<int>(abs_lon);
+  const double min = (abs_lon - deg) * 60.0;
+  const char suffix = location.longitude.IsNegative() ? 'W' : 'E';
+  return fmt::format("{:03d}{:06.3f}{}", deg, min, suffix);
+}
+
+/**
+ * Format an LLXVOZ line for a single turnpoint in the declaration.
+ *
+ * @param declaration The full declaration
+ * @param tp_index Index of the turnpoint within the declaration
+ * @return The formatted LLXVOZ line content
+ */
+inline std::string
+FormatOZLine(const Declaration &declaration, unsigned tp_index)
+{
+  const auto &tp = declaration.turnpoints[tp_index];
+  const unsigned n_tp = declaration.Size();
+  const bool is_start = (tp_index == 0);
+  const bool is_finish = (tp_index == n_tp - 1);
+
+  const int oz_index = static_cast<int>(tp_index) - 1;
+
+  const unsigned style = GetOZStyle(is_start, is_finish);
+  const unsigned r1 = tp.radius;
+  const double a1 = tp.sector_angle.Degrees();
+  const unsigned r2 = tp.inner_radius;
+  const double a2 = (r2 > 0) ? 180.0 : 0.0;
+
+  const GeoPoint &prev_loc = is_start
+    ? tp.waypoint.location
+    : declaration.turnpoints[tp_index - 1].waypoint.location;
+  const GeoPoint &next_loc = is_finish
+    ? tp.waypoint.location
+    : declaration.turnpoints[tp_index + 1].waypoint.location;
+  const double a12 = ComputeA12(prev_loc, tp.waypoint.location,
+                                next_loc, is_start, is_finish)
+    .AsBearing().Degrees();
+
+  const auto lat_str = FormatLat(tp.waypoint.location);
+  const auto lon_str = FormatLon(tp.waypoint.location);
+
+  auto line = fmt::format(
+    "LLXVOZ={},Style={},R1={}m,A1={:.1f},R2={}m,A2={:.1f},"
+    "A12={:.1f},Maxa=0m",
+    oz_index, style, r1, a1, r2, a2, a12);
+
+  if (tp.shape == Declaration::TurnPoint::LINE)
+    line += ",Line=1";
+
+  line += ",Autonext=1";
+
+  if (tp.is_aat)
+    line += ",AAT=1";
+
+  line += fmt::format(",Lat={},Lon={}", lat_str, lon_str);
+
+  line += fmt::format(",Near={}", is_finish ? 1 : 0);
+
+  return line;
+}
+
+/**
+ * Format a C-record turnpoint string with LXNAV elevation extension.
+ *
+ * Format: C<lat><lon><name>::<elevation>
+ */
+inline std::string
+FormatTurnPointCRecord(const Declaration::TurnPoint &tp)
+{
+  char loc_buf[32];
+  char *p = FormatIGCLocation(loc_buf, tp.waypoint.location);
+  *p = '\0';
+
+  const double elevation = tp.waypoint.GetElevationOrZero();
+  return fmt::format("C{}{}{}{:.5f}", loc_buf,
+                     tp.waypoint.name.c_str(),
+                     "::", elevation);
+}
+
+} // namespace LXNavDeclare

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -144,7 +144,14 @@ LXDevice::EnablePassThrough(OperationEnvironment &env)
 bool
 LXDevice::EnableLoggerNMEA(OperationEnvironment &env)
 {
-  return IsLXNAVVario() || UsePassThrough()
+  /* S-series varios have a built-in logger that understands PLXVC
+     commands in normal NMEA mode.  If a FLARM is behind the vario,
+     its flight downloads are handled by the FLARM driver on a
+     separate device slot. */
+  if (IsSVario())
+    return EnableNMEA(env);
+
+  return IsV7() || UsePassThrough()
     ? EnablePassThrough(env)
     : (LXNAVVario::ModeNormal(port, env), true);
 }

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -10,6 +10,11 @@
 #include "NMEA/Derived.hpp"
 #include "NMEA/MoreData.hpp"
 #include "util/NumberParser.hpp"
+#include "Interface.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/GlideSolvers/PolarCoefficients.hpp"
+#include "Plane/Plane.hpp"
 
 void
 LXDevice::LinkTimeout()
@@ -30,15 +35,17 @@ LXDevice::LinkTimeout()
     nano_settings.clear();
   }
 
-  mc_sent = false;
   mc_requested = false;
   last_sent_mc.reset();
-  ballast_sent = false;
   ballast_requested = false;
   last_sent_ballast_overload.reset();
-  bugs_sent = false;
+  last_sent_crew_mass.reset();
   bugs_requested = false;
   last_sent_bugs.reset();
+  polar_requested = false;
+  last_sent_empty_mass.reset();
+  tracked_polar.valid = false;
+  device_polar.valid = false;
   vario_just_detected = false;
 
   mode = Mode::UNKNOWN;
@@ -210,49 +217,240 @@ LXDevice::OnCalculatedUpdate(const MoreData &basic,
       }
       ballast_requested = true;
       bugs_requested = true;
+      polar_requested = true;
     }
     RequestLXNAVVarioSetting("MC", env);
+    RequestLXNAVVarioSetting("POLAR", env);
+    {
+      const std::lock_guard lock{mutex};
+      last_polar_request.Update();
+    }
     
     /* Ballast and bugs come via LXWP2, no need to request separately */
     /* Wait for settings to be received before proceeding with sync */
     return;
   }
 
+  /* Periodically request POLAR from device to detect changes made on the device */
+  bool should_request_polar = false;
+  {
+    const std::lock_guard lock{mutex};
+    if (last_polar_request.CheckUpdate(std::chrono::seconds(30))) {
+      /* Request POLAR every 30 seconds to detect device-side changes */
+      should_request_polar = true;
+    }
+  }
+  
+  if (should_request_polar) {
+    RequestLXNAVVarioSetting("POLAR", env);
+  }
+
+  /* Check if plane profile is active - if default plane (LS-815) is active, read from vario;
+     if plane profile is active, push XCSoar settings to vario */
+  using namespace CommonInterface;
+  const Plane &plane = GetComputerSettings().plane;
+  const bool plane_profile_active = plane.plane_profile_active;
+  
+  if (!plane_profile_active) {
+    /* Default plane (LS-815) is active - read polar from vario and apply to XCSoar */
+    /* Read polar from ExternalSettings (provided by Parser) */
+    const ExternalSettings &ext_settings = basic.settings;
+    
+    if (ext_settings.polar_coefficients_available &&
+        ext_settings.polar_reference_mass_available) {
+      /* LXNAV devices use a format where v == 1 corresponds to 100 km/h (27.78 m/s).
+       * Convert to XCSoar format (m/s) when reading from ExternalSettings. */
+      constexpr double LX_POLAR_V_SCALE = 100.0 / 3.6; // 100 km/h in m/s = 27.78 m/s
+      const double a_device = ext_settings.polar_a;
+      const double b_device = ext_settings.polar_b;
+      const double c_device = ext_settings.polar_c;
+      const double a = a_device / (LX_POLAR_V_SCALE * LX_POLAR_V_SCALE);
+      const double b = b_device / LX_POLAR_V_SCALE;
+      const double c = c_device; // c is already in m/s
+      const double polar_weight = ext_settings.polar_reference_mass;
+      const double polar_load = ext_settings.polar_load_available ? 
+                                ext_settings.polar_load : 0;
+      const double empty_weight = ext_settings.polar_empty_weight_available ? 
+                                  ext_settings.polar_empty_weight : 0;
+      const double pilot_weight = ext_settings.polar_pilot_weight_available ? 
+                                  ext_settings.polar_pilot_weight : 0;
+      
+      /* Check if this is new data */
+      bool should_apply = false;
+      {
+        const std::lock_guard lock{mutex};
+        if (!device_polar.valid) {
+          should_apply = true;
+        } else if (fabs(device_polar.a - a) > 0.001 ||
+                   fabs(device_polar.b - b) > 0.001 ||
+                   fabs(device_polar.c - c) > 0.001 ||
+                   fabs(device_polar.empty_weight - empty_weight) > 0.1 ||
+                   fabs(device_polar.pilot_weight - pilot_weight) > 0.1) {
+          should_apply = true;
+        } else {
+          /* Check if XCSoar's polar actually matches - if not, we should apply */
+          using namespace CommonInterface;
+          const GlidePolar &polar_current = GetComputerSettings().polar.glide_polar_task;
+          if (polar_current.IsValid()) {
+            const PolarCoefficients &ref_coeffs = polar_current.GetCoefficients();
+            const double ref_mass = polar_current.GetReferenceMass();
+            const double empty_mass = polar_current.GetEmptyMass();
+            const double current_crew_mass = polar_current.GetCrewMass();
+            
+            /* Check if XCSoar polar matches device polar (compare reference coefficients, not scaled) */
+            /* Also compare crew mass if device provides a non-zero pilot weight */
+            bool crew_differs = false;
+            if (pilot_weight > 0) {
+              crew_differs = fabs(current_crew_mass - pilot_weight) > 0.1;
+            }
+            /* If device sends 0 for pilot_weight, don't compare - keep XCSoar's current value */
+            
+            if (fabs(ref_coeffs.a - a) > 0.001 ||
+                fabs(ref_coeffs.b - b) > 0.001 ||
+                fabs(ref_coeffs.c - c) > 0.001 ||
+                fabs(ref_mass - polar_weight) > 0.1 ||
+                fabs(empty_mass - empty_weight) > 0.1 ||
+                crew_differs) {
+              should_apply = true;
+            }
+          } else {
+            should_apply = true;
+          }
+        }
+        
+        if (should_apply) {
+          device_polar.a = a;
+          device_polar.b = b;
+          device_polar.c = c;
+          device_polar.polar_load = ext_settings.polar_load_available ? ext_settings.polar_load : 0;
+          device_polar.polar_weight = polar_weight;
+          device_polar.max_weight = ext_settings.polar_maximum_mass_available ? ext_settings.polar_maximum_mass : 0;
+          device_polar.empty_weight = empty_weight;
+          device_polar.pilot_weight = pilot_weight;
+          device_polar.valid = true;
+        }
+      }
+      
+      if (should_apply) {
+        /* Apply full polar from device to XCSoar */
+        GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
+        
+        /* Apply polar coefficients (already converted to XCSoar format above) */
+        PolarCoefficients pc(a, b, c);
+        if (pc.IsValid()) {
+          polar.SetCoefficients(pc, false);
+          
+          /* Apply reference mass (polar_weight) to polar, but don't set plane.polar_shape.reference_mass
+           * when no plane profile is active - it should remain 0 */
+          if (polar_weight > 0) {
+            polar.SetReferenceMass(polar_weight, false);
+          }
+          
+          /* Apply empty mass */
+          if (empty_weight > 0) {
+            polar.SetEmptyMass(empty_weight, false);
+          }
+          
+          /* Apply crew mass (pilot weight) only if device provides a non-zero value.
+           * If device sends 0, keep XCSoar's current/default crew mass */
+          if (pilot_weight > 0) {
+            polar.SetCrewMass(pilot_weight, false);
+          }
+          /* If pilot_weight is 0, don't change crew_mass - keep XCSoar's default or current value */
+          
+          /* Set wing area if not already set, estimated from reference mass and reference wing loading */
+          if (polar.GetWingArea() <= 0 && polar_load > 0 && polar_weight > 0) {
+            const double estimated_wing_area = polar_weight / polar_load;
+            if (estimated_wing_area > 0) {
+              polar.SetWingArea(estimated_wing_area);
+            }
+          }
+          
+          /* Do not set or calculate max_ballast in LXNAV driver */
+          
+          polar.Update();
+
+          /* Trigger recalculation */
+          if (backend_components && backend_components->calculation_thread) {
+            backend_components->SetTaskPolar(GetComputerSettings().polar);
+          }
+        }
+      }
+    }
+  } else {
+    /* Plane profile is active - push XCSoar settings to vario */
+    /* This is handled by the sync functions called at the end of OnCalculatedUpdate */
+  }
+
+  /* Check if polar has changed (e.g., due to plane profile activation) */
+  const GlidePolar &polar = calculated.glide_polar_safety;
+  if (polar.IsValid()) {
+    const PolarCoefficients &current_coeffs = polar.GetCoefficients();
+    const double current_reference_mass = polar.GetReferenceMass();
+    const double current_empty_mass = polar.GetEmptyMass();
+    const double current_crew_mass = polar.GetCrewMass();
+    
+    {
+      const std::lock_guard lock{mutex};
+      if (!tracked_polar.valid ||
+          fabs(tracked_polar.a - current_coeffs.a) > 0.0001 ||
+          fabs(tracked_polar.b - current_coeffs.b) > 0.0001 ||
+          fabs(tracked_polar.c - current_coeffs.c) > 0.0001 ||
+          fabs(tracked_polar.reference_mass - current_reference_mass) > 0.1 ||
+          fabs(tracked_polar.empty_mass - current_empty_mass) > 0.1 ||
+          fabs(tracked_polar.crew_mass - current_crew_mass) > 0.1) {
+        /* Polar has changed (coefficients or masses) - reset last sent values for polar-related settings to trigger re-sync */
+        last_sent_ballast_overload.reset();
+        last_sent_crew_mass.reset();
+        last_sent_empty_mass.reset();
+        tracked_polar.a = current_coeffs.a;
+        tracked_polar.b = current_coeffs.b;
+        tracked_polar.c = current_coeffs.c;
+        tracked_polar.reference_mass = current_reference_mass;
+        tracked_polar.empty_mass = current_empty_mass;
+        tracked_polar.crew_mass = current_crew_mass;
+        tracked_polar.valid = true;
+      }
+    }
+  }
+
   /* Sync all settings */
-  SyncMacCready(basic, calculated, env);
-  SyncBallast(basic, calculated, env);
-  SyncBugs(basic, calculated, env);
+  /* If plane profile is active, push XCSoar settings to vario;
+     if default plane is active, sync functions will handle reading from vario */
+  SyncMacCready(basic, calculated, env, plane_profile_active);
+  SyncBallast(basic, calculated, env, plane_profile_active);
+  SyncBugs(basic, calculated, env, plane_profile_active);
+  SyncCrewWeight(basic, calculated, env, plane_profile_active);
+  SyncEmptyWeight(basic, calculated, env, plane_profile_active);
 }
 
 void
 LXDevice::SyncMacCready(const MoreData &basic,
                         const DerivedInfo &calculated,
-                        OperationEnvironment &env) noexcept
+                        OperationEnvironment &env,
+                        bool plane_profile_active) noexcept
 {
+  if (!plane_profile_active)
+    return;
+
+  const double mc = calculated.glide_polar_safety.GetMC();
+  
+  /* Check if device already has this value (echo) */
   {
     const std::lock_guard lock{mutex};
-    if (mc_sent)
-      return;
+    if (IsMCEcho(basic.settings))
+      return; // Device already has our value
   }
-
-  if (!basic.settings.mac_cready_available.IsValid())
-    return;
-
-  const double device_mc = basic.settings.mac_cready;
-  const bool is_echo = IsMCEcho(basic.settings);
   
-  if (!is_echo && device_mc > 0) {
-    /* Device has non-zero MC that we didn't send, don't override it */
+  /* Check if we already sent this exact value */
+  {
     const std::lock_guard lock{mutex};
-    mc_sent = true;
-    return;
+    if (last_sent_mc.has_value() && fabs(*last_sent_mc - mc) < 0.01)
+      return; // Already sent this value
   }
-
-  /* Device MC is 0, not set, or is echoing our value - send XCSoar's MC */
-  const double mc = calculated.glide_polar_safety.GetMC();
+  
   if (PutMacCready(mc, env)) {
     const std::lock_guard lock{mutex};
-    mc_sent = true;
     last_sent_mc = mc;
   }
 }
@@ -260,28 +458,12 @@ LXDevice::SyncMacCready(const MoreData &basic,
 void
 LXDevice::SyncBallast(const MoreData &basic,
                       const DerivedInfo &calculated,
-                      OperationEnvironment &env) noexcept
+                      OperationEnvironment &env,
+                      bool plane_profile_active) noexcept
 {
-  {
-    const std::lock_guard lock{mutex};
-    if (ballast_sent)
-      return;
-  }
-
-  if (!basic.settings.ballast_overload_available.IsValid())
+  if (!plane_profile_active)
     return;
 
-  const double device_ballast_overload = basic.settings.ballast_overload;
-  const bool is_echo = IsBallastEcho(basic.settings);
-  
-  if (!is_echo && device_ballast_overload > 1.0) {
-    /* Device has ballast that we didn't send, don't override it */
-    const std::lock_guard lock{mutex};
-    ballast_sent = true;
-    return;
-  }
-
-  /* Device has no ballast or is echoing our value - send XCSoar's ballast */
   const GlidePolar &polar = calculated.glide_polar_safety;
   if (!polar.IsValid())
     return;
@@ -289,12 +471,28 @@ LXDevice::SyncBallast(const MoreData &basic,
   const double ballast_litres = polar.GetBallastLitres();
   const double dry_mass = polar.GetDryMass();
   const double reference_mass = polar.GetReferenceMass();
+  if (reference_mass <= 0)
+    return;
+
   const double overload = (dry_mass + ballast_litres) / reference_mass;
-  const double ballast_fraction = polar.GetBallast();
   
-  if (PutBallast(ballast_fraction, overload, env)) {
+  /* Check if device already has this value (echo) */
+  {
     const std::lock_guard lock{mutex};
-    ballast_sent = true;
+    if (IsBallastEcho(basic.settings))
+      return; // Device already has our value
+  }
+  
+  /* Check if we already sent this exact value */
+  {
+    const std::lock_guard lock{mutex};
+    if (last_sent_ballast_overload.has_value() && 
+        fabs(*last_sent_ballast_overload - overload) < 0.01)
+      return; // Already sent this value
+  }
+  
+  if (PutBallast(0.0, overload, env)) {
+    const std::lock_guard lock{mutex};
     last_sent_ballast_overload = overload;
   }
 }
@@ -302,32 +500,110 @@ LXDevice::SyncBallast(const MoreData &basic,
 void
 LXDevice::SyncBugs(const MoreData &basic,
                    const DerivedInfo &calculated,
-                   OperationEnvironment &env) noexcept
+                   OperationEnvironment &env,
+                   bool plane_profile_active) noexcept
 {
+  if (!plane_profile_active)
+    return;
+
+  const double bugs = calculated.glide_polar_safety.GetBugs();
+  
+  /* Check if device already has this value (echo) */
   {
     const std::lock_guard lock{mutex};
-    if (bugs_sent)
+    if (IsBugsEcho(basic.settings))
+      return; // Device already has our value
+  }
+  
+  /* Check if we already sent this exact value */
+  {
+    const std::lock_guard lock{mutex};
+    if (last_sent_bugs.has_value() && fabs(*last_sent_bugs - bugs) < 0.01)
+      return; // Already sent this value
+  }
+  
+  if (PutBugs(bugs, env)) {
+    const std::lock_guard lock{mutex};
+    last_sent_bugs = bugs;
+  }
+}
+
+void
+LXDevice::SyncCrewWeight([[maybe_unused]] const MoreData &basic,
+                         const DerivedInfo &calculated,
+                         OperationEnvironment &env,
+                         bool plane_profile_active)
+{
+  if (!plane_profile_active)
+    return;
+
+  const GlidePolar &polar = calculated.glide_polar_safety;
+  if (!polar.IsValid())
+    return;
+
+  const double crew_mass = polar.GetCrewMass();
+  constexpr double DEFAULT_CREW_MASS = 90.0; // Default crew weight in kg
+
+  /* Check if device already has this value (echo) */
+  {
+    const std::lock_guard lock{mutex};
+    if (IsCrewWeightEcho(basic.settings))
+      return; // Device already has our value
+  }
+
+  /* Check if we already sent this exact value */
+  {
+    const std::lock_guard lock{mutex};
+    if (last_sent_crew_mass.has_value() && 
+        fabs(*last_sent_crew_mass - crew_mass) < 0.1)
+      return; // Already sent this value
+  }
+
+  /* If crew weight is at default, check if device has a pilot weight - if so, don't override it */
+  if (fabs(crew_mass - DEFAULT_CREW_MASS) < 0.1) {
+    if (basic.settings.polar_pilot_weight_available && 
+        basic.settings.polar_pilot_weight > 0) {
+      /* Device has pilot weight, don't override it */
+      return;
+    }
+  }
+
+  /* Crew weight is not default or device has no pilot weight - send XCSoar's crew weight */
+  if (EnableNMEA(env)) {
+    LXNAVVario::SetPilotWeight(port, env, crew_mass);
+    const std::lock_guard lock{mutex};
+    last_sent_crew_mass = crew_mass;
+  }
+}
+
+void
+LXDevice::SyncEmptyWeight([[maybe_unused]] const MoreData &basic,
+                          const DerivedInfo &calculated,
+                          OperationEnvironment &env,
+                          bool plane_profile_active)
+{
+  if (!plane_profile_active)
+    return;
+
+  const GlidePolar &polar = calculated.glide_polar_safety;
+  if (!polar.IsValid())
+    return;
+
+  const double empty_mass = polar.GetEmptyMass();
+  
+  {
+    const std::lock_guard lock{mutex};
+    if (IsEmptyWeightEcho(basic.settings))
+      return;
+
+    if (last_sent_empty_mass.has_value() &&
+        fabs(*last_sent_empty_mass - empty_mass) < 0.1)
       return;
   }
 
-  if (!basic.settings.bugs_available.IsValid())
-    return;
-
-  const double device_bugs = basic.settings.bugs;
-  const bool is_echo = IsBugsEcho(basic.settings);
-  
-  if (!is_echo && device_bugs < 1.0) {
-    /* Device has bugs that we didn't send, don't override it */
+  if (EnableNMEA(env)) {
+    LXNAVVario::SetEmptyWeight(port, env, empty_mass);
     const std::lock_guard lock{mutex};
-    bugs_sent = true;
-    return;
-  }
-
-  /* Device has no bugs or is echoing our value - send XCSoar's bugs */
-  const double bugs = calculated.glide_polar_safety.GetBugs();
-  if (PutBugs(bugs, env)) {
-    const std::lock_guard lock{mutex};
-    bugs_sent = true;
-    last_sent_bugs = bugs;
+    last_sent_empty_mass = empty_mass;
   }
 }

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -14,7 +14,11 @@
 #include "BackendComponents.hpp"
 #include "Components.hpp"
 #include "Engine/GlideSolvers/PolarCoefficients.hpp"
-#include "Plane/Plane.hpp"
+#include "Device/Util/NMEAWriter.hpp"
+#include "Message.hpp"
+#include "Language/Language.hpp"
+
+#include <fmt/format.h>
 
 void
 LXDevice::LinkTimeout()
@@ -225,6 +229,11 @@ LXDevice::OnCalculatedUpdate(const MoreData &basic,
   if (!IsLXNAVVario())
     return;
 
+  const bool do_receive =
+    polar_sync == DeviceConfig::PolarSync::RECEIVE;
+  const bool do_send =
+    polar_sync == DeviceConfig::PolarSync::SEND;
+
   NullOperationEnvironment env;
 
   /* Check if vario was just detected and request settings */
@@ -241,227 +250,295 @@ LXDevice::OnCalculatedUpdate(const MoreData &basic,
     /* Request all settings on detection */
     {
       const std::lock_guard lock{mutex};
-      if (!mc_requested) {
+      if (!mc_requested)
         mc_requested = true;
-      }
       ballast_requested = true;
       bugs_requested = true;
-      polar_requested = true;
     }
     RequestLXNAVVarioSetting("MC", env);
-    RequestLXNAVVarioSetting("POLAR", env);
-    {
-      const std::lock_guard lock{mutex};
-      last_polar_request.Update();
+
+    if (do_receive) {
+      {
+        const std::lock_guard lock{mutex};
+        polar_requested = true;
+        last_polar_request.Update();
+      }
+      RequestLXNAVVarioSetting("POLAR", env);
     }
-    
+
     /* Ballast and bugs come via LXWP2, no need to request separately */
     /* Wait for settings to be received before proceeding with sync */
     return;
   }
 
-  /* Periodically request POLAR from device to detect changes made on the device */
-  bool should_request_polar = false;
-  {
-    const std::lock_guard lock{mutex};
-    if (last_polar_request.CheckUpdate(std::chrono::seconds(30))) {
-      /* Request POLAR every 30 seconds to detect device-side changes */
-      should_request_polar = true;
-    }
-  }
-  
-  if (should_request_polar) {
-    RequestLXNAVVarioSetting("POLAR", env);
-  }
-
-  /* Check if plane profile is active - if default plane (LS-815) is active, read from vario;
-     if plane profile is active, push XCSoar settings to vario */
-  using namespace CommonInterface;
-  const Plane &plane = GetComputerSettings().plane;
-  const bool plane_profile_active = plane.plane_profile_active;
-  
-  if (!plane_profile_active) {
-    /* Default plane (LS-815) is active - read polar from vario and apply to XCSoar */
-    /* Read polar from ExternalSettings (provided by Parser) */
-    const ExternalSettings &ext_settings = basic.settings;
-    
-    if (ext_settings.polar_coefficients_available &&
-        ext_settings.polar_reference_mass_available) {
-      /* LXNAV devices use a format where v == 1 corresponds to 100 km/h (27.78 m/s).
-       * Convert to XCSoar format (m/s) when reading from ExternalSettings. */
-      constexpr double LX_POLAR_V_SCALE = 100.0 / 3.6; // 100 km/h in m/s = 27.78 m/s
-      const double a_device = ext_settings.polar_a;
-      const double b_device = ext_settings.polar_b;
-      const double c_device = ext_settings.polar_c;
-      const double a = a_device / (LX_POLAR_V_SCALE * LX_POLAR_V_SCALE);
-      const double b = b_device / LX_POLAR_V_SCALE;
-      const double c = c_device; // c is already in m/s
-      const double polar_weight = ext_settings.polar_reference_mass;
-      const double polar_load = ext_settings.polar_load_available ? 
-                                ext_settings.polar_load : 0;
-      const double empty_weight = ext_settings.polar_empty_weight_available ? 
-                                  ext_settings.polar_empty_weight : 0;
-      const double pilot_weight = ext_settings.polar_pilot_weight_available ? 
-                                  ext_settings.polar_pilot_weight : 0;
-      
-      /* Check if this is new data */
-      bool should_apply = false;
-      {
-        const std::lock_guard lock{mutex};
-        if (!device_polar.valid) {
-          should_apply = true;
-        } else if (fabs(device_polar.a - a) > 0.001 ||
-                   fabs(device_polar.b - b) > 0.001 ||
-                   fabs(device_polar.c - c) > 0.001 ||
-                   fabs(device_polar.empty_weight - empty_weight) > 0.1 ||
-                   fabs(device_polar.pilot_weight - pilot_weight) > 0.1) {
-          should_apply = true;
-        } else {
-          /* Check if XCSoar's polar actually matches - if not, we should apply */
-          using namespace CommonInterface;
-          const GlidePolar &polar_current = GetComputerSettings().polar.glide_polar_task;
-          if (polar_current.IsValid()) {
-            const PolarCoefficients &ref_coeffs = polar_current.GetCoefficients();
-            const double ref_mass = polar_current.GetReferenceMass();
-            const double empty_mass = polar_current.GetEmptyMass();
-            const double current_crew_mass = polar_current.GetCrewMass();
-            
-            /* Check if XCSoar polar matches device polar (compare reference coefficients, not scaled) */
-            /* Also compare crew mass if device provides a non-zero pilot weight */
-            bool crew_differs = false;
-            if (pilot_weight > 0) {
-              crew_differs = fabs(current_crew_mass - pilot_weight) > 0.1;
-            }
-            /* If device sends 0 for pilot_weight, don't compare - keep XCSoar's current value */
-            
-            if (fabs(ref_coeffs.a - a) > 0.001 ||
-                fabs(ref_coeffs.b - b) > 0.001 ||
-                fabs(ref_coeffs.c - c) > 0.001 ||
-                fabs(ref_mass - polar_weight) > 0.1 ||
-                fabs(empty_mass - empty_weight) > 0.1 ||
-                crew_differs) {
-              should_apply = true;
-            }
-          } else {
-            should_apply = true;
-          }
-        }
-        
-        if (should_apply) {
-          device_polar.a = a;
-          device_polar.b = b;
-          device_polar.c = c;
-          device_polar.polar_load = ext_settings.polar_load_available ? ext_settings.polar_load : 0;
-          device_polar.polar_weight = polar_weight;
-          device_polar.max_weight = ext_settings.polar_maximum_mass_available ? ext_settings.polar_maximum_mass : 0;
-          device_polar.empty_weight = empty_weight;
-          device_polar.pilot_weight = pilot_weight;
-          device_polar.valid = true;
-        }
-      }
-      
-      if (should_apply) {
-        /* Apply full polar from device to XCSoar */
-        GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
-        
-        /* Apply polar coefficients (already converted to XCSoar format above) */
-        PolarCoefficients pc(a, b, c);
-        if (pc.IsValid()) {
-          polar.SetCoefficients(pc, false);
-          
-          /* Apply reference mass (polar_weight) to polar, but don't set plane.polar_shape.reference_mass
-           * when no plane profile is active - it should remain 0 */
-          if (polar_weight > 0) {
-            polar.SetReferenceMass(polar_weight, false);
-          }
-          
-          /* Apply empty mass */
-          if (empty_weight > 0) {
-            polar.SetEmptyMass(empty_weight, false);
-          }
-          
-          /* Apply crew mass (pilot weight) only if device provides a non-zero value.
-           * If device sends 0, keep XCSoar's current/default crew mass */
-          if (pilot_weight > 0) {
-            polar.SetCrewMass(pilot_weight, false);
-          }
-          /* If pilot_weight is 0, don't change crew_mass - keep XCSoar's default or current value */
-          
-          /* Set wing area if not already set, estimated from reference mass and reference wing loading */
-          if (polar.GetWingArea() <= 0 && polar_load > 0 && polar_weight > 0) {
-            const double estimated_wing_area = polar_weight / polar_load;
-            if (estimated_wing_area > 0) {
-              polar.SetWingArea(estimated_wing_area);
-            }
-          }
-          
-          /* Do not set or calculate max_ballast in LXNAV driver */
-          
-          polar.Update();
-
-          /* Trigger recalculation */
-          if (backend_components && backend_components->calculation_thread) {
-            backend_components->SetTaskPolar(GetComputerSettings().polar);
-          }
-        }
-      }
-    }
-  } else {
-    /* Plane profile is active - push XCSoar settings to vario */
-    /* This is handled by the sync functions called at the end of OnCalculatedUpdate */
-  }
-
-  /* Check if polar has changed (e.g., due to plane profile activation) */
-  const GlidePolar &polar = calculated.glide_polar_safety;
-  if (polar.IsValid()) {
-    const PolarCoefficients &current_coeffs = polar.GetCoefficients();
-    const double current_reference_mass = polar.GetReferenceMass();
-    const double current_empty_mass = polar.GetEmptyMass();
-    const double current_crew_mass = polar.GetCrewMass();
-    
+  /* In RECEIVE mode, periodically request POLAR to detect
+     changes made on the device */
+  if (do_receive) {
+    bool should_request_polar = false;
     {
       const std::lock_guard lock{mutex};
-      if (!tracked_polar.valid ||
-          fabs(tracked_polar.a - current_coeffs.a) > 0.0001 ||
-          fabs(tracked_polar.b - current_coeffs.b) > 0.0001 ||
-          fabs(tracked_polar.c - current_coeffs.c) > 0.0001 ||
-          fabs(tracked_polar.reference_mass - current_reference_mass) > 0.1 ||
-          fabs(tracked_polar.empty_mass - current_empty_mass) > 0.1 ||
-          fabs(tracked_polar.crew_mass - current_crew_mass) > 0.1) {
-        /* Polar has changed (coefficients or masses) - reset last sent values for polar-related settings to trigger re-sync */
-        last_sent_ballast_overload.reset();
-        last_sent_crew_mass.reset();
-        last_sent_empty_mass.reset();
-        tracked_polar.a = current_coeffs.a;
-        tracked_polar.b = current_coeffs.b;
-        tracked_polar.c = current_coeffs.c;
-        tracked_polar.reference_mass = current_reference_mass;
-        tracked_polar.empty_mass = current_empty_mass;
-        tracked_polar.crew_mass = current_crew_mass;
-        tracked_polar.valid = true;
+      if (last_polar_request.CheckUpdate(std::chrono::seconds(30)))
+        should_request_polar = true;
+    }
+
+    if (should_request_polar)
+      RequestLXNAVVarioSetting("POLAR", env);
+  }
+
+  using namespace CommonInterface;
+
+  /* RECEIVE mode: adopt device polar into XCSoar */
+  if (do_receive)
+    ReceivePolarFromDevice(basic);
+
+  /* SEND mode: push XCSoar polar to device */
+  if (do_send)
+    SendPolarToDevice(calculated, env);
+
+  /* Track polar changes to reset sent values on change */
+  TrackPolarChanges(calculated);
+
+  /* MC, ballast, bugs: always "last change wins" bidirectional,
+     independent of polar_sync.  The RECEIVE direction is handled
+     by ApplyExternalSettings via sync_from_device. */
+  SyncMacCready(basic, calculated, env);
+  SyncBallast(basic, calculated, env);
+  SyncBugs(basic, calculated, env);
+
+  /* Crew weight is pilot data - always push to device */
+  SyncCrewWeight(basic, calculated, env);
+
+  /* Empty weight only in SEND mode (airframe data) */
+  SyncEmptyWeight(basic, calculated, env, do_send);
+}
+
+void
+LXDevice::ReceivePolarFromDevice(const MoreData &basic) noexcept
+{
+  using namespace CommonInterface;
+  const ExternalSettings &ext_settings = basic.settings;
+
+  if (!ext_settings.polar_coefficients_available ||
+      !ext_settings.polar_reference_mass_available)
+    return;
+
+  /* LXNAV devices use a format where v == 1 corresponds to
+     100 km/h (27.78 m/s).  Convert to XCSoar format (m/s). */
+  constexpr double LX_V =
+    100.0 / 3.6; // 100 km/h in m/s
+  const double a = ext_settings.polar_a / (LX_V * LX_V);
+  const double b = ext_settings.polar_b / LX_V;
+  const double c = ext_settings.polar_c;
+  const double polar_weight = ext_settings.polar_reference_mass;
+  const double polar_load =
+    ext_settings.polar_load_available
+    ? ext_settings.polar_load : 0;
+  const double empty_weight =
+    ext_settings.polar_empty_weight_available
+    ? ext_settings.polar_empty_weight : 0;
+  const double pilot_weight =
+    ext_settings.polar_pilot_weight_available
+    ? ext_settings.polar_pilot_weight : 0;
+
+  /* Check if this is new data compared to what we already applied */
+  bool should_apply = false;
+  {
+    const std::lock_guard lock{mutex};
+    if (!device_polar.valid ||
+        fabs(device_polar.a - a) > 0.001 ||
+        fabs(device_polar.b - b) > 0.001 ||
+        fabs(device_polar.c - c) > 0.001 ||
+        fabs(device_polar.empty_weight - empty_weight) > 0.1 ||
+        fabs(device_polar.pilot_weight - pilot_weight) > 0.1) {
+      should_apply = true;
+    } else {
+      /* Also check if XCSoar's polar actually matches */
+      const GlidePolar &gp =
+        GetComputerSettings().polar.glide_polar_task;
+      if (gp.IsValid()) {
+        const PolarCoefficients &rc = gp.GetCoefficients();
+        bool crew_differs = pilot_weight > 0 &&
+          fabs(gp.GetCrewMass() - pilot_weight) > 0.1;
+        if (fabs(rc.a - a) > 0.001 ||
+            fabs(rc.b - b) > 0.001 ||
+            fabs(rc.c - c) > 0.001 ||
+            fabs(gp.GetReferenceMass() - polar_weight) > 0.1 ||
+            fabs(gp.GetEmptyMass() - empty_weight) > 0.1 ||
+            crew_differs)
+          should_apply = true;
+      } else {
+        should_apply = true;
       }
+    }
+
+    if (should_apply) {
+      device_polar.a = a;
+      device_polar.b = b;
+      device_polar.c = c;
+      device_polar.polar_load = polar_load;
+      device_polar.polar_weight = polar_weight;
+      device_polar.max_weight =
+        ext_settings.polar_maximum_mass_available
+        ? ext_settings.polar_maximum_mass : 0;
+      device_polar.empty_weight = empty_weight;
+      device_polar.pilot_weight = pilot_weight;
+      device_polar.valid = true;
     }
   }
 
-  /* Sync all settings */
-  /* If plane profile is active, push XCSoar settings to vario;
-     if default plane is active, sync functions will handle reading from vario */
-  SyncMacCready(basic, calculated, env, plane_profile_active);
-  SyncBallast(basic, calculated, env, plane_profile_active);
-  SyncBugs(basic, calculated, env, plane_profile_active);
-  SyncCrewWeight(basic, calculated, env, plane_profile_active);
-  SyncEmptyWeight(basic, calculated, env, plane_profile_active);
+  if (!should_apply)
+    return;
+
+  /* Apply the device polar to XCSoar */
+  PolarCoefficients pc(a, b, c);
+  if (!pc.IsValid())
+    return;
+
+  GlidePolar &polar = SetComputerSettings().polar.glide_polar_task;
+  polar.SetCoefficients(pc, false);
+
+  if (polar_weight > 0)
+    polar.SetReferenceMass(polar_weight, false);
+  if (empty_weight > 0)
+    polar.SetEmptyMass(empty_weight, false);
+  if (pilot_weight > 0)
+    polar.SetCrewMass(pilot_weight, false);
+
+  /* Estimate wing area from reference mass and wing loading */
+  if (polar.GetWingArea() <= 0 &&
+      polar_load > 0 && polar_weight > 0) {
+    const double area = polar_weight / polar_load;
+    if (area > 0)
+      polar.SetWingArea(area);
+  }
+
+  polar.Update();
+
+  if (backend_components && backend_components->calculation_thread)
+    backend_components->SetTaskPolar(GetComputerSettings().polar);
+
+  /* One-time notification */
+  bool should_notify = false;
+  {
+    const std::lock_guard lock{mutex};
+    if (!polar_sync_notified) {
+      polar_sync_notified = true;
+      should_notify = true;
+    }
+  }
+  if (should_notify)
+    Message::AddMessage(_("Polar received from device"));
+}
+
+void
+LXDevice::SendPolarToDevice(const DerivedInfo &calculated,
+                            OperationEnvironment &env)
+{
+  using namespace CommonInterface;
+  const GlidePolar &gp = calculated.glide_polar_safety;
+  if (!gp.IsValid())
+    return;
+
+  const PolarCoefficients &coeffs = gp.GetCoefficients();
+  if (!coeffs.IsValid())
+    return;
+
+  /* Convert XCSoar m/s coefficients to LXNAV format
+     (v == 1 corresponds to 100 km/h = 27.78 m/s) */
+  constexpr double LX_V = 100.0 / 3.6;
+  const double a_lx = coeffs.a * (LX_V * LX_V);
+  const double b_lx = coeffs.b * LX_V;
+  const double c_lx = coeffs.c;
+
+  const double ref_mass = gp.GetReferenceMass();
+  const double empty_mass = gp.GetEmptyMass();
+  const double crew_mass = gp.GetCrewMass();
+  const double wing_area = gp.GetWingArea();
+  const double polar_load =
+    (wing_area > 0 && ref_mass > 0) ? ref_mass / wing_area : 0;
+
+  /* Check if we already sent these exact values */
+  {
+    const std::lock_guard lock{mutex};
+    if (device_polar.valid &&
+        fabs(device_polar.a - coeffs.a) < 0.0001 &&
+        fabs(device_polar.b - coeffs.b) < 0.0001 &&
+        fabs(device_polar.c - coeffs.c) < 0.0001 &&
+        fabs(device_polar.polar_weight - ref_mass) < 0.1 &&
+        fabs(device_polar.empty_weight - empty_mass) < 0.1 &&
+        fabs(device_polar.pilot_weight - crew_mass) < 0.1)
+      return;
+  }
+
+  if (!EnableNMEA(env))
+    return;
+
+  /* PLXV0,POLAR,W,a,b,c,polar_load,polar_weight,max_weight,
+     empty_weight,pilot_weight,name,stall */
+  const auto cmd = fmt::format(
+    "PLXV0,POLAR,W,{:.6f},{:.6f},{:.6f},{:.2f},{:.1f},,{:.1f},{:.1f},,",
+    a_lx, b_lx, c_lx, polar_load, ref_mass, empty_mass, crew_mass);
+  PortWriteNMEA(port, cmd.c_str(), env);
+
+  bool notify = false;
+  {
+    const std::lock_guard lock{mutex};
+    device_polar.a = coeffs.a;
+    device_polar.b = coeffs.b;
+    device_polar.c = coeffs.c;
+    device_polar.polar_load = polar_load;
+    device_polar.polar_weight = ref_mass;
+    device_polar.empty_weight = empty_mass;
+    device_polar.pilot_weight = crew_mass;
+    device_polar.valid = true;
+
+    if (!polar_sync_notified) {
+      polar_sync_notified = true;
+      notify = true;
+    }
+  }
+  if (notify)
+    Message::AddMessage(_("Polar sent to device"));
+}
+
+void
+LXDevice::TrackPolarChanges(const DerivedInfo &calculated) noexcept
+{
+  const GlidePolar &polar = calculated.glide_polar_safety;
+  if (!polar.IsValid())
+    return;
+
+  const PolarCoefficients &cc = polar.GetCoefficients();
+  const double rm = polar.GetReferenceMass();
+  const double em = polar.GetEmptyMass();
+  const double cm = polar.GetCrewMass();
+
+  const std::lock_guard lock{mutex};
+  if (!tracked_polar.valid ||
+      fabs(tracked_polar.a - cc.a) > 0.0001 ||
+      fabs(tracked_polar.b - cc.b) > 0.0001 ||
+      fabs(tracked_polar.c - cc.c) > 0.0001 ||
+      fabs(tracked_polar.reference_mass - rm) > 0.1 ||
+      fabs(tracked_polar.empty_mass - em) > 0.1 ||
+      fabs(tracked_polar.crew_mass - cm) > 0.1) {
+    last_sent_ballast_overload.reset();
+    last_sent_crew_mass.reset();
+    last_sent_empty_mass.reset();
+    tracked_polar.a = cc.a;
+    tracked_polar.b = cc.b;
+    tracked_polar.c = cc.c;
+    tracked_polar.reference_mass = rm;
+    tracked_polar.empty_mass = em;
+    tracked_polar.crew_mass = cm;
+    tracked_polar.valid = true;
+  }
 }
 
 void
 LXDevice::SyncMacCready(const MoreData &basic,
                         const DerivedInfo &calculated,
-                        OperationEnvironment &env,
-                        bool plane_profile_active) noexcept
+                        OperationEnvironment &env) noexcept
 {
-  if (!plane_profile_active)
-    return;
-
   const double mc = calculated.glide_polar_safety.GetMC();
   
   /* Check if device already has this value (echo) */
@@ -487,12 +564,8 @@ LXDevice::SyncMacCready(const MoreData &basic,
 void
 LXDevice::SyncBallast(const MoreData &basic,
                       const DerivedInfo &calculated,
-                      OperationEnvironment &env,
-                      bool plane_profile_active) noexcept
+                      OperationEnvironment &env) noexcept
 {
-  if (!plane_profile_active)
-    return;
-
   const GlidePolar &polar = calculated.glide_polar_safety;
   if (!polar.IsValid())
     return;
@@ -529,12 +602,8 @@ LXDevice::SyncBallast(const MoreData &basic,
 void
 LXDevice::SyncBugs(const MoreData &basic,
                    const DerivedInfo &calculated,
-                   OperationEnvironment &env,
-                   bool plane_profile_active) noexcept
+                   OperationEnvironment &env) noexcept
 {
-  if (!plane_profile_active)
-    return;
-
   const double bugs = calculated.glide_polar_safety.GetBugs();
   
   /* Check if device already has this value (echo) */
@@ -560,48 +629,53 @@ LXDevice::SyncBugs(const MoreData &basic,
 void
 LXDevice::SyncCrewWeight([[maybe_unused]] const MoreData &basic,
                          const DerivedInfo &calculated,
-                         OperationEnvironment &env,
-                         bool plane_profile_active)
+                         OperationEnvironment &env)
 {
-  if (!plane_profile_active)
-    return;
-
   const GlidePolar &polar = calculated.glide_polar_safety;
   if (!polar.IsValid())
     return;
 
-  const double crew_mass = polar.GetCrewMass();
-  constexpr double DEFAULT_CREW_MASS = 90.0; // Default crew weight in kg
+  const double xcsoar_crew = polar.GetCrewMass();
+  const double device_crew =
+    basic.settings.polar_pilot_weight_available
+    ? basic.settings.polar_pilot_weight : 0;
 
-  /* Check if device already has this value (echo) */
+  /* If either side is 0 the non-zero value wins;
+     both non-zero → last change wins (bidirectional) */
+
+  if (xcsoar_crew < 0.1 && device_crew < 0.1)
+    return; // both unset
+
+  if (xcsoar_crew < 0.1 && device_crew >= 0.1) {
+    /* Device has a value, XCSoar doesn't → adopt device value */
+    GlidePolar &gp =
+      CommonInterface::SetComputerSettings().polar.glide_polar_task;
+    gp.SetCrewMass(device_crew);
+    if (backend_components && backend_components->calculation_thread)
+      backend_components->SetTaskPolar(
+        CommonInterface::GetComputerSettings().polar);
+    const std::lock_guard lock{mutex};
+    last_sent_crew_mass = device_crew;
+    return;
+  }
+
+  /* XCSoar has a value → push to device (covers both
+     "device is 0" and "both non-zero, last change wins") */
+
   {
     const std::lock_guard lock{mutex};
     if (IsCrewWeightEcho(basic.settings))
-      return; // Device already has our value
-  }
-
-  /* Check if we already sent this exact value */
-  {
-    const std::lock_guard lock{mutex};
-    if (last_sent_crew_mass.has_value() && 
-        fabs(*last_sent_crew_mass - crew_mass) < 0.1)
-      return; // Already sent this value
-  }
-
-  /* If crew weight is at default, check if device has a pilot weight - if so, don't override it */
-  if (fabs(crew_mass - DEFAULT_CREW_MASS) < 0.1) {
-    if (basic.settings.polar_pilot_weight_available && 
-        basic.settings.polar_pilot_weight > 0) {
-      /* Device has pilot weight, don't override it */
       return;
-    }
+
+    if (last_sent_crew_mass.has_value() &&
+        fabs(*last_sent_crew_mass - xcsoar_crew) < 0.1)
+      return;
   }
 
-  /* Crew weight is not default or device has no pilot weight - send XCSoar's crew weight */
   if (EnableNMEA(env)) {
-    LXNAVVario::SetPilotWeight(port, env, crew_mass);
+    LXNAVVario::SetPilotWeight(port, env, xcsoar_crew);
     const std::lock_guard lock{mutex};
-    last_sent_crew_mass = crew_mass;
+    last_sent_crew_mass = xcsoar_crew;
   }
 }
 
@@ -609,9 +683,9 @@ void
 LXDevice::SyncEmptyWeight([[maybe_unused]] const MoreData &basic,
                           const DerivedInfo &calculated,
                           OperationEnvironment &env,
-                          bool plane_profile_active)
+                          bool send_to_device)
 {
-  if (!plane_profile_active)
+  if (!send_to_device)
     return;
 
   const GlidePolar &polar = calculated.glide_polar_safety;

--- a/src/Device/Driver/LX/NanoDeclare.cpp
+++ b/src/Device/Driver/LX/NanoDeclare.cpp
@@ -2,14 +2,19 @@
 // Copyright The XCSoar Project
 
 #include "NanoDeclare.hpp"
+#include "LXNavDeclare.hpp"
 #include "Device/Port/Port.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "Device/Util/NMEAReader.hpp"
 #include "Device/Declaration.hpp"
 #include "IGC/Generator.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "time/TimeoutClock.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "Operation/Operation.hpp"
+
+#include <fmt/format.h>
+#include <cmath>
 
 static bool
 NanoWriteDecl(Port &port, OperationEnvironment &env, PortNMEAReader &reader,
@@ -74,13 +79,14 @@ NanoWriteDeclMeta(Port &port, OperationEnvironment &env,
 static bool
 NanoWriteStartDeclaration(Port &port, OperationEnvironment &env,
                           PortNMEAReader &reader,
-                          [[maybe_unused]] const Declaration &declaration, unsigned total_size)
+                          const Declaration &declaration,
+                          unsigned total_size)
 {
   // TODO: use GPS clock instead?
   const BrokenDateTime date_time = BrokenDateTime::NowUTC();
 
   char buffer[64];
-  FormatIGCTaskTimestamp(buffer, date_time, total_size - 2);
+  FormatIGCTaskTimestamp(buffer, date_time, declaration.Size());
   return NanoWriteDecl(port, env, reader, 7, total_size, buffer);
 }
 
@@ -103,20 +109,66 @@ NanoBeginDeclaration(Port &port, OperationEnvironment &env,
 
 static bool
 NanoWriteLanding(Port &port, OperationEnvironment &env,
-                 PortNMEAReader &reader, unsigned total_size)
+                 PortNMEAReader &reader, unsigned row, unsigned total_size)
 {
-  return NanoWriteDecl(port, env, reader, total_size, total_size,
+  return NanoWriteDecl(port, env, reader, row, total_size,
                        IGCMakeTaskLanding());
+}
+
+static bool
+NanoWriteTurnPoint(Port &port, OperationEnvironment &env,
+                   PortNMEAReader &reader, unsigned row,
+                   unsigned total_size,
+                   const Declaration::TurnPoint &tp)
+{
+  const auto content = LXNavDeclare::FormatTurnPointCRecord(tp);
+  return NanoWriteDecl(port, env, reader, row, total_size, content.c_str());
+}
+
+static bool
+NanoWriteOZ(Port &port, OperationEnvironment &env, PortNMEAReader &reader,
+            unsigned row, unsigned total_size,
+            const Declaration &declaration,
+            unsigned tp_index)
+{
+  const auto line = LXNavDeclare::FormatOZLine(declaration, tp_index);
+  return NanoWriteDecl(port, env, reader, row, total_size, line.c_str());
+}
+
+/**
+ * Write the LLXVTSK task options line.
+ */
+static bool
+NanoWriteTaskOptions(Port &port, OperationEnvironment &env,
+                     PortNMEAReader &reader, unsigned row,
+                     unsigned total_size,
+                     [[maybe_unused]] const Declaration &declaration)
+{
+  return NanoWriteDecl(port, env, reader, row, total_size,
+                       "LLXVTSK,StartOnEntry=false,Short=false,Near=true");
 }
 
 bool
 Nano::Declare(Port &port, const Declaration &declaration,
               OperationEnvironment &env)
 {
-  constexpr unsigned prefix_size = 8;
-  constexpr unsigned suffix_size = 1;
   const unsigned task_size = declaration.Size();
-  const unsigned total_size = prefix_size + task_size + suffix_size;
+
+  /*
+   * Declaration file layout:
+   *   Rows 1-6:          H-records (pilot, glider, etc.)
+   *   Row 7:             C-record timestamp
+   *   Row 8:             C-record takeoff
+   *   Rows 9..8+N:       C-record turnpoints (with elevation)
+   *   Row 9+N:           C-record landing
+   *   Rows 10+N..9+2N:   LLXVOZ observation zone lines
+   *   Row 10+2N:         LLXVTSK task options
+   */
+  constexpr unsigned prefix_size = 8;
+  const unsigned landing_row = prefix_size + task_size + 1;
+  const unsigned oz_start_row = landing_row + 1;
+  const unsigned task_options_row = oz_start_row + task_size;
+  const unsigned total_size = task_options_row;
 
   env.SetProgressRange(total_size);
 
@@ -126,17 +178,29 @@ Nano::Declare(Port &port, const Declaration &declaration,
   if (!NanoBeginDeclaration(port, env, reader, declaration, total_size))
     return false;
 
-  unsigned i = prefix_size + 1;
+  /* Write C-record turnpoints with elevation */
+  unsigned row = prefix_size + 1;
   for (const auto &tp : declaration.turnpoints) {
-    char buffer[128];
-    FormatIGCTaskTurnPoint(buffer, tp.waypoint.location,
-                           tp.waypoint.name.c_str());
-    if (!NanoWriteDecl(port, env, reader, i++, total_size,
-                       buffer))
+    if (!NanoWriteTurnPoint(port, env, reader, row++, total_size, tp))
       return false;
   }
 
-  assert(i == total_size);
+  /* Write C-record landing */
+  if (!NanoWriteLanding(port, env, reader, row++, total_size))
+    return false;
 
-  return NanoWriteLanding(port, env, reader, total_size);
+  assert(row == oz_start_row);
+
+  /* Write LLXVOZ observation zone lines */
+  for (unsigned i = 0; i < task_size; i++) {
+    if (!NanoWriteOZ(port, env, reader, row++, total_size,
+                     declaration, i))
+      return false;
+  }
+
+  assert(row == task_options_row);
+
+  /* Write LLXVTSK task options */
+  return NanoWriteTaskOptions(port, env, reader, row, total_size,
+                              declaration);
 }

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -414,12 +414,14 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
       /* in pass-through mode, we should never clear the V7 flag,
          because the V7 is still there, even though it's "hidden"
          currently */
+      const std::lock_guard lock{mutex};
       is_v7 |= saw_v7;
       is_sVario |= saw_sVario;
       is_nano |= saw_nano;
       is_lx16xx |= saw_lx16xx;
       is_forwarded_nano = saw_nano;
     } else {
+      const std::lock_guard lock{mutex};
       is_v7 = saw_v7;
       is_sVario = saw_sVario;
       is_nano = saw_nano;

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -11,6 +11,7 @@
 #include "util/StringCompare.hxx"
 #include "Math/Util.hpp"
 #include "util/NumberParser.hpp"
+#include "LogFile.hpp"
 
 using std::string_view_literals::operator""sv;
 
@@ -100,17 +101,21 @@ LXWP2(NMEAInputLine &line, NMEAInfo &info)
   }
 
   // Ballast
-  if (line.ReadChecked(value))
+  if (line.ReadChecked(value)) {
     info.settings.ProvideBallastOverload(value, info.clock);
+  }
 
   // Bugs
   if (line.ReadChecked(value)) {
-    if (value <= 1.5 && value >= 1.0)
+    double bugs;
+    if (value <= 1.5 && value >= 1.0) {
       // LX160 (sw 3.04) reports bugs as 1.00, 1.05 or 1.10 (#2167)
-      info.settings.ProvideBugs(2 - value, info.clock);
-    else
+      bugs = 2 - value;
+    } else {
       // All other known LX devices report bugs as 0, 5, 10, 15, ...
-      info.settings.ProvideBugs((100 - value) / 100., info.clock);
+      bugs = (100 - value) / 100.;
+    }
+    info.settings.ProvideBugs(bugs, info.clock);
   }
 
   line.Skip(3);
@@ -166,10 +171,11 @@ PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings,
     return true;
 
   const auto type = line.ReadView();
+  
+  const auto value = line.Rest();
+
   if (!type.starts_with('W'))
     return true;
-
-  const auto value = line.Rest();
 
   const std::lock_guard<Mutex> lock(settings);
   settings.Set(std::string{name}, value);
@@ -192,6 +198,36 @@ PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings,
     double d = ParseDouble(value_str.c_str(), &endptr);
     if (endptr > value_str.c_str()) {
       info.settings.ProvideMacCready(d, info.clock);
+    }
+  }
+
+  /* Parse POLAR response to extract pilot weight and empty weight */
+  /* Note: Device sends "POL" not "POLAR" in the response */
+  if (name == "POLAR"sv || name == "POL"sv) {
+    /* POLAR format: PLXV0,POL,W,<a>,<b>,<c>,<polar load>,<polar weight>,<max weight>,<empty weight>,<pilot weight>,<name>,<stall> */
+    const std::string value_str{value};
+    NMEAInputLine polar_line{value_str.c_str()};
+    double a, b, c, polar_load, polar_weight, max_weight, empty_weight, pilot_weight;
+    if (polar_line.ReadChecked(a) &&
+        polar_line.ReadChecked(b) &&
+        polar_line.ReadChecked(c) &&
+        polar_line.ReadChecked(polar_load) &&
+        polar_line.ReadChecked(polar_weight) &&
+        polar_line.ReadChecked(max_weight) &&
+        polar_line.ReadChecked(empty_weight) &&
+        polar_line.ReadChecked(pilot_weight)) {
+      
+      /* Store POLAR values in blackboard (ExternalSettings) */
+      info.settings.ProvidePolarCoefficients(a, b, c, info.clock);
+      info.settings.ProvidePolarLoad(polar_load, info.clock);
+      info.settings.ProvidePolarReferenceMass(polar_weight, info.clock);
+      info.settings.ProvidePolarMaximumMass(max_weight, info.clock);
+      info.settings.ProvidePolarPilotWeight(pilot_weight, info.clock);
+      info.settings.ProvidePolarEmptyWeight(empty_weight, info.clock);
+      
+      /* Do not calculate or store max_ballast in LXNAV driver */
+    } else {
+      LogFmt("LXNAV: Failed to parse POLAR values from: {}", value);
     }
   }
 

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -76,6 +76,7 @@ LXDevice::LXWP1(NMEAInputLine &line, DeviceInfo &device)
   device.serial = line.ReadView();
   device.software_version = line.ReadView();
   device.hardware_version = line.ReadView();
+  device.license = line.ReadView();
 }
 
 static bool
@@ -357,13 +358,6 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 
     if (saw_v7 || saw_sVario || saw_nano || saw_lx16xx)
       is_colibri = false;
-
-    /* Log firmware version if device was already detected but firmware wasn't logged yet */
-    if (!firmware_version_logged && !device_info.software_version.empty()) {
-      if (is_v7 || is_sVario) {
-        firmware_version_logged = true;
-      }
-    }
 
     return true;
 

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -308,6 +308,26 @@ PLXVS(NMEAInputLine &line, NMEAInfo &info)
     info.voltage_available.Update(info.clock);
   }
 
+  /* IGC press altitude field - pressure altitude used by device for IGC recording */
+  double igc_press_altitude;
+  if (line.ReadChecked(igc_press_altitude)) {
+    info.igc_pressure_altitude = igc_press_altitude;
+    info.igc_pressure_altitude_available.Update(info.clock);
+  }
+
+  /* Parse FlapPosition field (added in protocol v1.03) */
+  const auto flap_str = line.ReadView();
+  if (!flap_str.empty()) {
+    if (flap_str == "L"sv)
+      info.switch_state.flap_position = SwitchState::FlapPosition::LANDING;
+    else
+      /* Other flap position values not yet defined in protocol documentation */
+      info.switch_state.flap_position = SwitchState::FlapPosition::UNKNOWN;
+  }
+
+  /* VP (Vario Priority) flag is available but not currently used */
+  line.Skip();
+
   return true;
 }
 

--- a/src/Device/Driver/LX/Register.cpp
+++ b/src/Device/Driver/LX/Register.cpp
@@ -14,7 +14,9 @@ LXCreateOnPort(const DeviceConfig &config, Port &com_port)
 
   const bool is_nano = config.BluetoothNameStartsWith("LXNAV-NANO");
 
-  return new LXDevice(com_port, baud_rate, bulk_baud_rate, config.use_second_device, is_nano);
+  return new LXDevice(com_port, baud_rate, bulk_baud_rate,
+                      config.use_second_device, config.polar_sync,
+                      is_nano);
 }
 
 const struct DeviceRegister lx_driver = {

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -157,6 +157,13 @@ LXDevice::PutBallast([[maybe_unused]] double fraction, double overload,
     LXNAVVario::SetBallast(port, env, overload);
   else
     LX1600::SetBallast(port, env, overload);
+  
+  /* Track what we sent for feedback loop detection */
+  {
+    const std::lock_guard lock{mutex};
+    last_sent_ballast_overload = overload;
+  }
+  
   return true;
 }
 
@@ -172,6 +179,13 @@ LXDevice::PutBugs(double bugs, OperationEnvironment &env)
     LXNAVVario::SetBugs(port, env, transformed_bugs_value);
   else
     LX1600::SetBugs(port, env, transformed_bugs_value);
+  
+  /* Track what we sent for feedback loop detection */
+  {
+    const std::lock_guard lock{mutex};
+    last_sent_bugs = bugs;
+  }
+  
   return true;
 }
 
@@ -185,6 +199,13 @@ LXDevice::PutMacCready(double mac_cready, OperationEnvironment &env)
     LXNAVVario::SetMacCready(port, env, mac_cready);
   else
     LX1600::SetMacCready(port, env, mac_cready);
+  
+  /* Track what we sent for feedback loop detection */
+  {
+    const std::lock_guard lock{mutex};
+    last_sent_mc = mac_cready;
+  }
+  
   return true;
 }
 

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -202,6 +202,32 @@ LXDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 }
 
 bool
+LXDevice::PutElevation(int elevation, OperationEnvironment &env)
+{
+  if (!EnableNMEA(env))
+    return false;
+
+  if (IsLXNAVVario())
+    LXNAVVario::SetElevation(port, env, elevation);
+  else
+    return false;
+
+  return true;
+}
+
+bool
+LXDevice::RequestElevation(OperationEnvironment &env)
+{
+  if (!EnableNMEA(env))
+    return false;
+
+  if (IsLXNAVVario())
+    return RequestLXNAVVarioSetting("ELEVATION", env);
+
+  return false;
+}
+
+bool
 LXDevice::PutVolume(unsigned volume, OperationEnvironment &env)
 {
   if (!EnableNMEA(env))

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -6,7 +6,7 @@
 #include "LX1600.hpp"
 #include "LXNAVVario.hpp"
 
-#include <cstdio>
+#include <fmt/format.h>
 
 bool
 LXDevice::SendLXNAVVarioSetting(const char *name, const char *value,
@@ -20,9 +20,8 @@ LXDevice::SendLXNAVVarioSetting(const char *name, const char *value,
     lxnav_vario_settings.MarkOld(name);
   }
 
-  char buffer[256];
-  sprintf(buffer, "PLXV0,%s,W,%s", name, value);
-  PortWriteNMEA(port, buffer, env);
+  const auto buffer = fmt::format("PLXV0,{},W,{}", name, value);
+  PortWriteNMEA(port, buffer.c_str(), env);
   return true;
 }
 
@@ -37,9 +36,8 @@ LXDevice::RequestLXNAVVarioSetting(const char *name, OperationEnvironment &env)
     lxnav_vario_settings.MarkOld(name);
   }
 
-  char buffer[256];
-  sprintf(buffer, "PLXV0,%s,R", name);
-  PortWriteNMEA(port, buffer, env);
+  const auto buffer = fmt::format("PLXV0,{},R", name);
+  PortWriteNMEA(port, buffer.c_str(), env);
   return true;
 }
 
@@ -79,9 +77,8 @@ LXDevice::SendNanoSetting(const char *name, const char *value,
     nano_settings.MarkOld(name);
   }
 
-  char buffer[256];
-  sprintf(buffer, "PLXVC,SET,W,%s,%s", name, value);
-  PortWriteNMEA(port, buffer, env);
+  const auto buffer = fmt::format("PLXVC,SET,W,{},{}", name, value);
+  PortWriteNMEA(port, buffer.c_str(), env);
   return true;
 }
 
@@ -89,9 +86,8 @@ bool
 LXDevice::SendNanoSetting(const char *name, unsigned value,
                           OperationEnvironment &env)
 {
-  char buffer[32];
-  sprintf(buffer, "%u", value);
-  return SendNanoSetting(name, buffer, env);
+  const auto str = fmt::format("{}", value);
+  return SendNanoSetting(name, str.c_str(), env);
 }
 
 bool
@@ -105,9 +101,8 @@ LXDevice::RequestNanoSetting(const char *name, OperationEnvironment &env)
     nano_settings.MarkOld(name);
   }
 
-  char buffer[256];
-  sprintf(buffer, "PLXVC,SET,R,%s", name);
-  PortWriteNMEA(port, buffer, env);
+  const auto buffer = fmt::format("PLXVC,SET,R,{}", name);
+  PortWriteNMEA(port, buffer.c_str(), env);
   return true;
 }
 

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -204,10 +204,16 @@ LXDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 bool
 LXDevice::PutVolume(unsigned volume, OperationEnvironment &env)
 {
-  if (!IsLX16xx() || !EnableNMEA(env))
+  if (!EnableNMEA(env))
     return false;
 
-  LX1600::SetVolume(port, env, volume);
+  if (IsLXNAVVario())
+    LXNAVVario::SetVolume(port, env, volume);
+  else if (IsLX16xx())
+    LX1600::SetVolume(port, env, volume);
+  else
+    return false;
+
   return true;
 }
 

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -210,6 +210,50 @@ LXDevice::PutMacCready(double mac_cready, OperationEnvironment &env)
 }
 
 bool
+LXDevice::PutCrewMass(double crew_mass, OperationEnvironment &env)
+{
+  /* Only support crew mass sync for LXNAV varios */
+  if (!IsLXNAVVario())
+    return true;
+
+  if (!EnableNMEA(env))
+    return false;
+
+  /* Send only pilot weight, leaving all other POLAR fields empty */
+  LXNAVVario::SetPilotWeight(port, env, crew_mass);
+  
+  /* Track what we sent */
+  {
+    const std::lock_guard lock{mutex};
+    last_sent_crew_mass = crew_mass;
+  }
+  
+  return true;
+}
+
+bool
+LXDevice::PutEmptyMass(double empty_mass, OperationEnvironment &env)
+{
+  /* Only support empty mass sync for LXNAV varios */
+  if (!IsLXNAVVario())
+    return true;
+
+  if (!EnableNMEA(env))
+    return false;
+
+  /* Send only empty weight, leaving all other POLAR fields empty */
+  LXNAVVario::SetEmptyWeight(port, env, empty_mass);
+  
+  /* Track what we sent */
+  {
+    const std::lock_guard lock{mutex};
+    last_sent_empty_mass = empty_mass;
+  }
+  
+  return true;
+}
+
+bool
 LXDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 {
   if (!EnableNMEA(env))

--- a/src/Device/MultipleDevices.cpp
+++ b/src/Device/MultipleDevices.cpp
@@ -161,6 +161,20 @@ MultipleDevices::PutQNH(AtmosphericPressure pres,
 }
 
 void
+MultipleDevices::PutElevation(int elevation, OperationEnvironment &env) noexcept
+{
+  for (DeviceDescriptor *i : devices)
+    i->PutElevation(elevation, env);
+}
+
+void
+MultipleDevices::RequestElevation(OperationEnvironment &env) noexcept
+{
+  for (DeviceDescriptor *i : devices)
+    i->RequestElevation(env);
+}
+
+void
 MultipleDevices::NotifySensorUpdate(const MoreData &basic) noexcept
 {
   for (DeviceDescriptor *i : devices)

--- a/src/Device/MultipleDevices.cpp
+++ b/src/Device/MultipleDevices.cpp
@@ -102,6 +102,20 @@ MultipleDevices::PutBallast(double fraction, double overload,
 }
 
 void
+MultipleDevices::PutCrewMass(double crew_mass, OperationEnvironment &env) noexcept
+{
+  for (DeviceDescriptor *i : devices)
+    i->PutCrewMass(crew_mass, env);
+}
+
+void
+MultipleDevices::PutEmptyMass(double empty_mass, OperationEnvironment &env) noexcept
+{
+  for (DeviceDescriptor *i : devices)
+    i->PutEmptyMass(empty_mass, env);
+}
+
+void
 MultipleDevices::PutVolume(unsigned volume, OperationEnvironment &env) noexcept
 {
   for (DeviceDescriptor *i : devices)

--- a/src/Device/MultipleDevices.hpp
+++ b/src/Device/MultipleDevices.hpp
@@ -77,6 +77,8 @@ public:
   void PutBugs(double bugs, OperationEnvironment &env) noexcept;
   void PutBallast(double fraction, double overload,
                   OperationEnvironment &env) noexcept;
+  void PutCrewMass(double crew_mass, OperationEnvironment &env) noexcept;
+  void PutEmptyMass(double empty_mass, OperationEnvironment &env) noexcept;
   void PutVolume(unsigned volume, OperationEnvironment &env) noexcept;
   void PutPilotEvent(OperationEnvironment &env) noexcept;
   void PutActiveFrequency(RadioFrequency frequency, const char *name,

--- a/src/Device/MultipleDevices.hpp
+++ b/src/Device/MultipleDevices.hpp
@@ -86,6 +86,8 @@ public:
   void ExchangeRadioFrequencies(OperationEnvironment &env) noexcept;
   void PutTransponderCode(TransponderCode code, OperationEnvironment &env) noexcept;
   void PutQNH(AtmosphericPressure pres, OperationEnvironment &env) noexcept;
+  void PutElevation(int elevation, OperationEnvironment &env) noexcept;
+  void RequestElevation(OperationEnvironment &env) noexcept;
   void NotifySensorUpdate(const MoreData &basic) noexcept;
   void NotifyCalculatedUpdate(const MoreData &basic,
                               const DerivedInfo &calculated) noexcept;

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -36,6 +36,11 @@ FillBaudRates(DataFieldEnum &dfe) noexcept
   dfe.addEnumText("57600", 57600);
   dfe.addEnumText("115200", 115200);
   dfe.addEnumText("230400", 230400);
+  dfe.addEnumText("256000", 256000);
+  dfe.addEnumText("460800", 460800);
+  dfe.addEnumText("500000", 500000);
+  dfe.addEnumText("921600", 921600);
+  dfe.addEnumText("1000000", 1000000);
 }
 
 static void

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp
@@ -10,11 +10,13 @@
 #include "Operation/PopupOperationEnvironment.hpp"
 #include "util/NumberParser.hpp"
 #include "Math/Util.hpp"
+#include "NMEA/InputLine.hpp"
 
 static const char *const lxnav_vario_setting_names[] = {
   "BRGPS",
   "BRPDA",
   "VOL",
+  "ALTOFF",
   NULL
 };
 
@@ -47,6 +49,39 @@ WaitUnsignedValue(LXDevice &device, const char *name,
   return default_value;
 }
 
+static void
+WaitAltoffValues(LXDevice &device, int &error, int &qnh, int &takeoff)
+{
+  PopupOperationEnvironment env;
+  const auto x = device.WaitLXNAVVarioSetting("ALTOFF", env, 500);
+  if (!x.empty()) {
+    NMEAInputLine line(x.c_str());
+    double d;
+
+    /* Parse first value: Alt offset error */
+    if (line.ReadChecked(d))
+      error = iround(d);
+    else
+      error = 0;
+
+    /* Parse second value: Alt offset qnh */
+    if (line.ReadChecked(d))
+      qnh = iround(d);
+    else
+      qnh = 0;
+
+    /* Parse third value: Alt take off */
+    if (line.ReadChecked(d))
+      takeoff = iround(d);
+    else
+      takeoff = 0;
+
+    return;
+  }
+
+  error = qnh = takeoff = 0;
+}
+
 void
 LXNAVVarioConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unused]] const PixelRect &rc) noexcept
 {
@@ -75,6 +110,11 @@ LXNAVVarioConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[mayb
 
   volume = WaitUnsignedValue(device, "VOL", 50);
   AddInteger(_("Volume"), NULL, "%u %%", "%u", 0, 100, 1, volume);
+
+  WaitAltoffValues(device, altoff_error, altoff_qnh, altoff_takeoff);
+  AddInteger(_("Alt offset error"), NULL, "%d m", "%d", -1000, 1000, 1, altoff_error);
+  AddInteger(_("Alt offset QNH"), NULL, "%d m", "%d", -1000, 1000, 1, altoff_qnh);
+  AddInteger(_("Alt take off"), NULL, "%d m", "%d", -1000, 1000, 1, altoff_takeoff);
 }
 
 bool
@@ -99,6 +139,15 @@ try {
   if (SaveValueInteger(VOL, volume)) {
     buffer.UnsafeFormat("%u", volume);
     device.SendLXNAVVarioSetting("VOL", buffer, env);
+    changed = true;
+  }
+
+  bool altoff_changed = SaveValueInteger(ALTOFF_ERROR, altoff_error);
+  altoff_changed |= SaveValueInteger(ALTOFF_QNH, altoff_qnh);
+  altoff_changed |= SaveValueInteger(ALTOFF_TAKEOFF, altoff_takeoff);
+  if (altoff_changed) {
+    buffer.UnsafeFormat("%d,%d,%d", altoff_error, altoff_qnh, altoff_takeoff);
+    device.SendLXNAVVarioSetting("ALTOFF", buffer, env);
     changed = true;
   }
 

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
@@ -14,7 +14,7 @@ class LXNAVVarioConfigWidget final : public RowFormWidget {
     VOL,
     ALTOFF_ERROR,
     ALTOFF_QNH,
-    ALTOFF_TAKEOFF
+    ALTOFF_TAKEOFF,
   };
 
   LXDevice &device;

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
@@ -11,12 +11,16 @@ class LXNAVVarioConfigWidget final : public RowFormWidget {
   enum Controls {
     BRGPS,
     BRPDA,
-    VOL
+    VOL,
+    ALTOFF_ERROR,
+    ALTOFF_QNH,
+    ALTOFF_TAKEOFF
   };
 
   LXDevice &device;
 
   unsigned brgps, brpda, volume;
+  int altoff_error, altoff_qnh, altoff_takeoff;
 
 public:
   LXNAVVarioConfigWidget(const DialogLook &look, LXDevice &_device)

--- a/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
+++ b/src/Dialogs/Device/LX/LXNAVVarioConfigWidget.hpp
@@ -10,16 +10,19 @@ class LXDevice;
 class LXNAVVarioConfigWidget final : public RowFormWidget {
   enum Controls {
     BRGPS,
-    BRPDA
+    BRPDA,
+    VOL
   };
 
   LXDevice &device;
 
-  unsigned brgps, brpda;
+  unsigned brgps, brpda, volume;
 
 public:
   LXNAVVarioConfigWidget(const DialogLook &look, LXDevice &_device)
-    :RowFormWidget(look), device(_device) {}
+      : RowFormWidget(look), device(_device)
+  {
+  }
 
   /* virtual methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Dialogs/Device/LX/ManageLX16xxDialog.cpp
+++ b/src/Dialogs/Device/LX/ManageLX16xxDialog.cpp
@@ -48,6 +48,11 @@ ManageLX16xxWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     buffer.SetASCII(info.software_version.c_str());
     AddReadOnly(_("Firmware version"), NULL, buffer.c_str());
   }
+
+  if (!info.license.empty()) {
+    buffer.SetASCII(info.license.c_str());
+    AddReadOnly(_("License"), NULL, buffer.c_str());
+  }
 }
 
 void

--- a/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
+++ b/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
@@ -58,6 +58,12 @@ ManageLXNAVVarioWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[mayb
     AddReadOnly(_("Firmware version"), NULL, buffer.c_str());
   }
 
+  if (!info.license.empty()) {
+    buffer.clear();
+    buffer.UnsafeAppendASCII(info.license.c_str());
+    AddReadOnly(_("License"), NULL, buffer.c_str());
+  }
+
   AddButton(_("Setup"), [this](){
     LXNAVVarioConfigWidget widget(GetLook(), device);
     DefaultWidgetDialog(UIGlobals::GetMainWindow(), GetLook(),

--- a/src/Dialogs/Device/LX/ManageNanoDialog.cpp
+++ b/src/Dialogs/Device/LX/ManageNanoDialog.cpp
@@ -57,6 +57,12 @@ ManageNanoWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unus
     AddReadOnly(_("Firmware version"), NULL, buffer.c_str());
   }
 
+  if (!info.license.empty()) {
+    buffer.clear();
+    buffer.UnsafeAppendASCII(info.license.c_str());
+    AddReadOnly(_("License"), NULL, buffer.c_str());
+  }
+
   AddButton(_("Setup"), [this](){
     NanoConfigWidget widget(GetLook(), device);
     DefaultWidgetDialog(UIGlobals::GetMainWindow(), GetLook(),

--- a/src/Dialogs/Settings/dlgBasicSettings.cpp
+++ b/src/Dialogs/Settings/dlgBasicSettings.cpp
@@ -62,6 +62,12 @@ public:
     polar_settings.glide_polar_task.SetCrewMass(_crew_mass);
     PublishPolarSettings();
     SetBallast();
+    
+    // Send to external devices
+    if (backend_components->devices != nullptr) {
+      MessageOperationEnvironment env;
+      backend_components->devices->PutCrewMass(_crew_mass, env);
+    }
   }
 
   void SetBallast();
@@ -125,8 +131,16 @@ FlightSetupPanel::SetBallast()
 {
   const bool ballastable = polar_settings.glide_polar_task.IsBallastable();
   SetRowVisible(Ballast, ballastable);
-  if (ballastable)
+  if (ballastable) {
+    /* Update the maximum value of the ballast field to allow up to 400L */
+    WndProperty &control = GetControl(Ballast);
+    DataFieldFloat &df = *(DataFieldFloat *)control.GetDataField();
+    const double db = 5;
+    const double ui_max_ballast = 400.0; /* Allow UI to set up to 400L maximum */
+    const double new_max = db * ceil(ui_max_ballast / db);
+    df.SetMax(new_max);
     LoadValue(Ballast, polar_settings.glide_polar_task.GetBallastLitres());
+  }
 
   const auto wl = polar_settings.glide_polar_task.GetWingLoading();
   SetRowVisible(WingLoading, wl > 0);
@@ -137,12 +151,12 @@ FlightSetupPanel::SetBallast()
     const Plane &plane = CommonInterface::GetComputerSettings().plane;
     if (plane.empty_mass > 0) {
       auto dry_mass = polar_settings.glide_polar_task.GetDryMass();
-      auto fraction = polar_settings.glide_polar_task.GetBallast();
-      auto overload = (dry_mass + fraction * plane.max_ballast) /
+      auto ballast_litres = polar_settings.glide_polar_task.GetBallastLitres();
+      auto overload = (dry_mass + ballast_litres) /
                       plane.polar_shape.reference_mass;
 
       MessageOperationEnvironment env;
-      backend_components->devices->PutBallast(fraction, overload, env);
+      backend_components->devices->PutBallast(0.0, overload, env);
     }
   }
 }

--- a/src/Dialogs/Settings/dlgBasicSettings.cpp
+++ b/src/Dialogs/Settings/dlgBasicSettings.cpp
@@ -148,12 +148,11 @@ FlightSetupPanel::SetBallast()
     LoadValue(WingLoading, wl, UnitGroup::WING_LOADING);
 
   if (backend_components->devices != nullptr) {
-    const Plane &plane = CommonInterface::GetComputerSettings().plane;
-    if (plane.empty_mass > 0) {
-      auto dry_mass = polar_settings.glide_polar_task.GetDryMass();
-      auto ballast_litres = polar_settings.glide_polar_task.GetBallastLitres();
-      auto overload = (dry_mass + ballast_litres) /
-                      plane.polar_shape.reference_mass;
+    const auto &polar = polar_settings.glide_polar_task;
+    const double ref_mass = polar.GetReferenceMass();
+    if (ref_mass > 0) {
+      const double overload =
+        (polar.GetDryMass() + polar.GetBallastLitres()) / ref_mass;
 
       MessageOperationEnvironment env;
       backend_components->devices->PutBallast(0.0, overload, env);

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -675,7 +675,9 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
 inline void
 GaugeVario::RenderBallast(Canvas &canvas) noexcept
 {
-  int ballast = iround(GetGlidePolar().GetBallast() * 100);
+  const GlidePolar &polar = GetGlidePolar();
+  const double ballast_fraction = polar.GetBallastFraction();
+  int ballast = iround(ballast_fraction * 100);
 
   if (!IsPersistent() || ballast != last_ballast) {
     // ballast hase been changed

--- a/src/IGC/IGCFix.cpp
+++ b/src/IGC/IGCFix.cpp
@@ -27,15 +27,20 @@ IGCFix::Apply(const NMEAInfo &basic) noexcept
     ? (int)basic.gps_altitude
     : 0;
 
-  pressure_altitude = basic.pressure_altitude_available
-    ? (int)basic.pressure_altitude
-    : (basic.baro_altitude_available
-       /* if there's only baro altitude and no QNH, assume baro
-          altitude is good enough */
-       ? (int)basic.baro_altitude
-       /* if all else fails, fall back to GPS altitude, to avoid
-          application bugs (SeeYou is known for display errors) */
-       : gps_altitude);
+  /* Use IGC pressure altitude if available (device's IGC recording value),
+     otherwise fall back to standard pressure altitude, then baro altitude,
+     then GPS altitude */
+  pressure_altitude = basic.igc_pressure_altitude_available
+    ? (int)basic.igc_pressure_altitude
+    : (basic.pressure_altitude_available
+       ? (int)basic.pressure_altitude
+       : (basic.baro_altitude_available
+          /* if there's only baro altitude and no QNH, assume baro
+             altitude is good enough */
+          ? (int)basic.baro_altitude
+          /* if all else fails, fall back to GPS altitude, to avoid
+             application bugs (SeeYou is known for display errors) */
+          : gps_altitude));
 
   ClearExtensions();
 

--- a/src/InfoBoxes/Panel/AltitudeSetup.cpp
+++ b/src/InfoBoxes/Panel/AltitudeSetup.cpp
@@ -3,21 +3,29 @@
 
 #include "AltitudeSetup.hpp"
 #include "Interface.hpp"
+#include "ActionInterface.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "Device/MultipleDevices.hpp"
+#include "Blackboard/DeviceBlackboard.hpp"
 #include "Units/Units.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Form/DataField/Float.hpp"
+#include "Form/DataField/Integer.hpp"
 #include "Form/DataField/Listener.hpp"
 #include "Form/Edit.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
+#include "Math/Util.hpp"
+#include "thread/Mutex.hxx"
 
 class AltitudeSetupPanel : public RowFormWidget,
                            private DataFieldListener {
+  WndProperty *qnh_control = nullptr;
+  WndProperty *elevation_control = nullptr;
+
 public:
   AltitudeSetupPanel():RowFormWidget(UIGlobals::GetDialogLook()) {}
 
@@ -31,16 +39,31 @@ private:
 void
 AltitudeSetupPanel::OnModified(DataField &_df) noexcept
 {
-  DataFieldFloat &df = (DataFieldFloat &)_df;
   ComputerSettings &settings =
     CommonInterface::SetComputerSettings();
 
-  settings.pressure = Units::FromUserPressure(df.GetValue());
-  settings.pressure_available.Update(CommonInterface::Basic().clock);
+  DataField *qnh_df = qnh_control ? qnh_control->GetDataField() : nullptr;
+  if (qnh_df && &_df == qnh_df) {
+    DataFieldFloat &df = (DataFieldFloat &)_df;
+    settings.pressure = Units::FromUserPressure(df.GetValue());
+    settings.pressure_available.Update(CommonInterface::Basic().clock);
 
-  if (backend_components->devices) {
-    MessageOperationEnvironment env;
-    backend_components->devices->PutQNH(settings.pressure, env);
+    if (backend_components->devices) {
+      MessageOperationEnvironment env;
+      backend_components->devices->PutQNH(settings.pressure, env);
+    }
+    return;
+  }
+
+  DataField *elevation_df = elevation_control ? elevation_control->GetDataField() : nullptr;
+  if (elevation_df && &_df == elevation_df) {
+    DataFieldInteger &df = (DataFieldInteger &)_df;
+    int elevation = df.GetValue();
+
+    if (backend_components->devices) {
+      MessageOperationEnvironment env;
+      backend_components->devices->PutElevation(elevation, env);
+    }
   }
 }
 
@@ -51,18 +74,55 @@ AltitudeSetupPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
   const ComputerSettings &settings =
     CommonInterface::GetComputerSettings();
 
-  WndProperty *wp;
-  wp = AddFloat(_("QNH"),
-                _("Area pressure for barometric altimeter calibration.  This is set automatically if Vega connected."),
-                GetUserPressureFormat(), GetUserPressureFormat(),
-                Units::ToUserPressure(Units::ToSysUnit(850, Unit::HECTOPASCAL)),
-                Units::ToUserPressure(Units::ToSysUnit(1300, Unit::HECTOPASCAL)),
-                GetUserPressureStep(), false,
-                Units::ToUserPressure(settings.pressure), this);
+  qnh_control = AddFloat(_("QNH"),
+                         _("Area pressure for barometric altimeter calibration.  This is set automatically if Vega connected."),
+                         GetUserPressureFormat(), GetUserPressureFormat(),
+                         Units::ToUserPressure(Units::ToSysUnit(850, Unit::HECTOPASCAL)),
+                         Units::ToUserPressure(Units::ToSysUnit(1300, Unit::HECTOPASCAL)),
+                         GetUserPressureStep(), false,
+                         Units::ToUserPressure(settings.pressure), this);
   {
-    DataFieldFloat &df = *(DataFieldFloat *)wp->GetDataField();
+    DataFieldFloat &df = *(DataFieldFloat *)qnh_control->GetDataField();
     df.SetUnits(Units::GetPressureName());
-    wp->RefreshDisplay();
+    qnh_control->RefreshDisplay();
+  }
+
+  int elevation = 0;
+  bool elevation_available = false;
+
+  /* Request elevation from devices and check if already available */
+  if (backend_components->devices) {
+    MessageOperationEnvironment env;
+    backend_components->devices->RequestElevation(env);
+
+    if (backend_components->device_blackboard) {
+      auto &device_blackboard = *backend_components->device_blackboard;
+      const std::lock_guard lock{device_blackboard.mutex};
+      const NMEAInfo &device_basic = device_blackboard.Basic();
+
+      if (device_basic.settings.elevation_available.IsValid()) {
+        elevation = device_basic.settings.elevation;
+        elevation_available = true;
+      }
+    }
+  }
+
+  /* If not received from device, read from CommonInterface (may have been set earlier) */
+  if (!elevation_available) {
+    const NMEAInfo &basic = CommonInterface::Basic();
+    if (basic.settings.elevation_available.IsValid()) {
+      elevation = basic.settings.elevation;
+      elevation_available = true;
+    }
+  }
+
+  /* Always show elevation control to display device state */
+  if (elevation_available) {
+    elevation_control = AddInteger(_("Elevation"), _("Ground elevation for device calibration (meters)."),
+                                    "%d m", "%d", -500, 9000, 1, elevation, this);
+  } else {
+    AddReadOnly(_("Elevation"), _("Ground elevation for device calibration (meters)."),
+                "N/A");
   }
 }
 

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -206,30 +206,32 @@ InputEvents::eventBallast(const char *misc)
 
   auto &settings = CommonInterface::SetComputerSettings().polar;
   GlidePolar &polar = settings.glide_polar_task;
-  auto BALLAST = polar.GetBallast();
-  auto oldBallast = BALLAST;
+  
+  /* Get current ballast as fraction for UI manipulation */
+  double ballast_fraction = polar.GetBallastFraction();
+  auto oldBallastFraction = ballast_fraction;
 
   if (StringIsEqual(misc, "up")) {
-    BALLAST += 1 / 10.;
-    if (BALLAST >= 1)
-      BALLAST = 1;
+    ballast_fraction += 1 / 10.;
+    if (ballast_fraction >= 1)
+      ballast_fraction = 1;
   } else if (StringIsEqual(misc, "down")) {
-    BALLAST -= 1 / 10.;
-    if (BALLAST < 0)
-      BALLAST = 0;
+    ballast_fraction -= 1 / 10.;
+    if (ballast_fraction < 0)
+      ballast_fraction = 0;
   } else if (StringIsEqual(misc, "max"))
-    BALLAST = 1;
+    ballast_fraction = 1;
   else if (StringIsEqual(misc, "min"))
-    BALLAST = 0;
+    ballast_fraction = 0;
   else if (StringIsEqual(misc, "show")) {
     char Temp[100];
-    StringFormatUnsafe(Temp, "%d", (int)(BALLAST * 100));
+    StringFormatUnsafe(Temp, "%d", (int)(ballast_fraction * 100));
     /* xgettext:no-c-format */
     Message::AddMessage(_("Ballast %"), Temp);
   }
 
-  if (BALLAST != oldBallast) {
-    polar.SetBallast(BALLAST);
+  if (ballast_fraction != oldBallastFraction) {
+    polar.SetBallastFraction(ballast_fraction);
     backend_components->SetTaskPolar(settings);
   }
 }

--- a/src/NMEA/Derived.cpp
+++ b/src/NMEA/Derived.cpp
@@ -45,6 +45,7 @@ DerivedInfo::Reset()
   TeamInfo::Clear();
 
   pressure_available.Clear();
+  pressure_elevation_available.Clear();
 
   climb_history.Clear();
 

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -137,6 +137,10 @@ struct DerivedInfo:
   AtmosphericPressure pressure;
   Validity pressure_available;
 
+  /** Elevation used for auto QNH calculation (meters). */
+  double pressure_elevation;
+  Validity pressure_elevation_available;
+
   ClimbHistory climb_history;
 
   WaveResult wave;

--- a/src/NMEA/DeviceInfo.hpp
+++ b/src/NMEA/DeviceInfo.hpp
@@ -41,11 +41,17 @@ struct DeviceInfo {
    */
   StaticString<16> software_version;
 
+  /**
+   * The license string.
+   */
+  StaticString<32> license;
+
   void Clear() {
     product.clear();
     serial.clear();
     hardware_version.clear();
     software_version.clear();
+    license.clear();
   }
 };
 

--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -13,6 +13,7 @@ ExternalSettings::Clear()
   bugs_available.Clear();
   qnh_available.Clear();
   volume_available.Clear();
+  elevation_available.Clear();
   has_active_frequency.Clear();
   active_frequency.Clear();
   active_freq_name.clear();
@@ -74,6 +75,11 @@ ExternalSettings::Complement(const ExternalSettings &add)
   if (add.volume_available.Modified(volume_available)) {
     volume = add.volume;
     volume_available = add.volume_available;
+  }
+
+  if (add.elevation_available.Modified(elevation_available)) {
+    elevation = add.elevation;
+    elevation_available = add.elevation_available;
   }
 
   if (add.has_active_frequency.Modified(has_active_frequency) &&
@@ -144,6 +150,10 @@ ExternalSettings::EliminateRedundant(const ExternalSettings &other,
   if (volume_available && other.CompareVolume(volume) &&
       !last.CompareVolume(volume))
     volume_available.Clear();
+
+  if (elevation_available && other.CompareElevation(elevation) &&
+      !last.CompareElevation(elevation))
+    elevation_available.Clear();
 }
 
 bool
@@ -265,5 +275,20 @@ ExternalSettings::ProvideVolume(unsigned value, TimeStamp time) noexcept
 
   volume = value;
   volume_available.Update(time);
+  return true;
+}
+
+bool
+ExternalSettings::ProvideElevation(int value, TimeStamp time) noexcept
+{
+  if (value < -500 || value > 9000)
+    /* failed sanity check */
+    return false;
+
+  if (CompareElevation(value))
+    return false;
+
+  elevation = value;
+  elevation_available.Update(time);
   return true;
 }

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -63,6 +63,11 @@ struct ExternalSettings {
   /** the volume of the device [0-100%] */
   unsigned volume;
 
+  Validity elevation_available;
+
+  /** the elevation setting [meters] */
+  int elevation;
+
   /** the radio frequencies of the device */
   Validity has_active_frequency;
   RadioFrequency active_frequency;
@@ -182,6 +187,16 @@ struct ExternalSettings {
   }
 
   /**
+   * Compare the elevation setting with the specified value.
+   *
+   * @return true if the current setting is the same, false if the
+   * value is different or if there is no value
+   */
+  bool CompareElevation(int value) const {
+    return elevation_available && abs(elevation - value) <= 1;
+  }
+
+  /**
    * Sets a new MacCready value, but updates the time stamp only if
    * the value has changed.
    *
@@ -195,4 +210,5 @@ struct ExternalSettings {
   bool ProvideBugs(double value, TimeStamp time) noexcept;
   bool ProvideQNH(AtmosphericPressure value, TimeStamp time) noexcept;
   bool ProvideVolume(unsigned value, TimeStamp time) noexcept;
+  bool ProvideElevation(int value, TimeStamp time) noexcept;
 };

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -68,6 +68,32 @@ struct ExternalSettings {
   /** the elevation setting [meters] */
   int elevation;
 
+  /** POLAR data from device */
+  Validity polar_coefficients_available;
+  double polar_a;
+  double polar_b;
+  double polar_c;
+
+  Validity polar_load_available;
+  /** Polar load (overload) from device POLAR sentence */
+  double polar_load;
+
+  Validity polar_reference_mass_available;
+  /** Reference mass (polar weight) from device POLAR sentence [kg] */
+  double polar_reference_mass;
+
+  Validity polar_maximum_mass_available;
+  /** Maximum mass (max weight) from device POLAR sentence [kg] */
+  double polar_maximum_mass;
+
+  Validity polar_pilot_weight_available;
+  /** Pilot weight from device POLAR sentence [kg] */
+  double polar_pilot_weight;
+
+  Validity polar_empty_weight_available;
+  /** Empty weight from device POLAR sentence [kg] */
+  double polar_empty_weight;
+
   /** the radio frequencies of the device */
   Validity has_active_frequency;
   RadioFrequency active_frequency;
@@ -211,4 +237,30 @@ struct ExternalSettings {
   bool ProvideQNH(AtmosphericPressure value, TimeStamp time) noexcept;
   bool ProvideVolume(unsigned value, TimeStamp time) noexcept;
   bool ProvideElevation(int value, TimeStamp time) noexcept;
+  bool ProvidePolarCoefficients(double a, double b, double c, TimeStamp time) noexcept;
+  bool ProvidePolarLoad(double value, TimeStamp time) noexcept;
+  bool ProvidePolarReferenceMass(double value, TimeStamp time) noexcept;
+  bool ProvidePolarMaximumMass(double value, TimeStamp time) noexcept;
+  bool ProvidePolarPilotWeight(double value, TimeStamp time) noexcept;
+  bool ProvidePolarEmptyWeight(double value, TimeStamp time) noexcept;
+
+  /**
+   * Compare the polar pilot weight with the specified value.
+   *
+   * @return true if the current setting is the same, false if the
+   * value is different or if there is no value
+   */
+  bool ComparePolarPilotWeight(double value) const {
+    return polar_pilot_weight_available && fabs(polar_pilot_weight - value) <= 0.1;
+  }
+
+  /**
+   * Compare the polar empty weight with the specified value.
+   *
+   * @return true if the current setting is the same, false if the
+   * value is different or if there is no value
+   */
+  bool ComparePolarEmptyWeight(double value) const {
+    return polar_empty_weight_available && fabs(polar_empty_weight - value) <= 0.1;
+  }
 };

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -124,6 +124,9 @@ NMEAInfo::Reset() noexcept
   pressure_altitude_available.Clear();
   pressure_altitude = 0;
 
+  igc_pressure_altitude_available.Clear();
+  igc_pressure_altitude = 0;
+
   time_available.Clear();
   time = {};
 

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -169,6 +169,15 @@ struct NMEAInfo {
   Validity pressure_altitude_available;
 
   /**
+   * IGC pressure altitude - the pressure altitude value that the device
+   * uses for IGC recording (if available). This may differ from the live
+   * pressure altitude. Used for IGC file generation to match device records.
+   * @see IGCPressureAltitudeAvailable
+   */
+  double igc_pressure_altitude;
+  Validity igc_pressure_altitude_available;
+
+  /**
    * Is the barometric altitude given by a "weak" source?  This is
    * used to clear the PGRMZ barometric altitude when a FLARM is
    * detected, to switch from barometric altitude to pressure

--- a/src/Plane/Plane.hpp
+++ b/src/Plane/Plane.hpp
@@ -35,4 +35,10 @@ struct Plane
    * https://api.weglide.org/v1/aircraft/$(ID)
    */
   unsigned weglide_glider_type;
+
+  /**
+   * Is a plane profile file active (not the default plane)?
+   * This is set when a plane profile file is loaded from Profile::GetPath("PlanePath").
+   */
+  bool plane_profile_active;
 };

--- a/src/Plane/PlaneFileGlue.cpp
+++ b/src/Plane/PlaneFileGlue.cpp
@@ -136,9 +136,15 @@ PlaneGlue::ReadFile(Plane &plane, Path path) noexcept
 try {
   FileLineReaderA reader(path);
   KeyValueFileReader kvreader(reader);
-  return Read(plane, kvreader);
+  if (Read(plane, kvreader)) {
+    plane.plane_profile_active = true;
+    return true;
+  }
+  plane.plane_profile_active = false;
+  return false;
 } catch (...) {
   LogError(std::current_exception());
+  plane.plane_profile_active = false;
   return false;
 }
 

--- a/src/Plane/PlaneGlue.cpp
+++ b/src/Plane/PlaneGlue.cpp
@@ -19,9 +19,14 @@ PlaneGlue::FromProfile(Plane &plane, const ProfileMap &profile) noexcept
   {
     auto plane_path = profile.GetPath("PlanePath");
     if (plane_path != nullptr &&
-        PlaneGlue::ReadFile(plane, plane_path))
+        PlaneGlue::ReadFile(plane, plane_path)) {
+      plane.plane_profile_active = true;
       return;
+    }
   }
+  
+  /* No plane profile file loaded - default plane is active */
+  plane.plane_profile_active = false;
 
   /* the following is just here to load a pre-6.7 profile */
 

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -202,6 +202,11 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
   if (!map.GetEnum(buffer, config.engine_type) ||
       unsigned(config.engine_type) >= unsigned(DeviceConfig::EngineType::MAX))
     config.engine_type = DeviceConfig::EngineType::NONE;
+
+  MakeDeviceSettingName(buffer, "Port", n, "PolarSync");
+  if (!map.GetEnum(buffer, config.polar_sync) ||
+      unsigned(config.polar_sync) >= unsigned(DeviceConfig::PolarSync::COUNT))
+    config.polar_sync = DeviceConfig::PolarSync::OFF;
 }
 
 static const char *
@@ -301,4 +306,7 @@ Profile::SetDeviceConfig(ProfileMap &map,
 
   MakeDeviceSettingName(buffer, "Port", n, "EngineType");
   map.Set(buffer, static_cast<unsigned>(config.engine_type));
+
+  MakeDeviceSettingName(buffer, "Port", n, "PolarSync");
+  map.Set(buffer, static_cast<unsigned>(config.polar_sync));
 }

--- a/src/lua/Settings.cpp
+++ b/src/lua/Settings.cpp
@@ -40,7 +40,7 @@ l_settings_index(lua_State *L)
       const ComputerSettings &settings_computer =
         CommonInterface::GetComputerSettings();
     
-      Lua::Push(L, settings_computer.polar.glide_polar_task.GetBallast());
+      Lua::Push(L, settings_computer.polar.glide_polar_task.GetBallastFraction());
   } else if (StringIsEqual(name, "qnh")) {
       /* Area pressure for barometric altimeter calibration */
       const ComputerSettings &settings_computer =

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -60,17 +60,33 @@
 
 #include <memory>
 
-// Stubs for BackendComponents used in device drivers
-// These are only needed for linking - the actual calls are guarded by null checks
+// Minimal stub definitions for types held by unique_ptr in
+// BackendComponents.  Only the destructor is needed (unique_ptr
+// calls delete on nullptr which is a no-op).
+class Logger { public: virtual ~Logger() = default; };
+class NMEALogger { public: virtual ~NMEALogger() = default; };
+class GlueFlightLogger { public: virtual ~GlueFlightLogger() = default; };
+class MultipleDevices { public: virtual ~MultipleDevices() = default; };
+class DeviceBlackboard { public: virtual ~DeviceBlackboard() = default; };
+class MergeThread { public: virtual ~MergeThread() = default; };
+class ProtectedTaskManager { public: virtual ~ProtectedTaskManager() = default; };
+class ProtectedAirspaceWarningManager {};
+class GlideComputer { public: virtual ~GlideComputer() = default; };
+class CalculationThread { public: virtual ~CalculationThread() = default; };
+class Replay { public: virtual ~Replay() = default; };
+
 #include "BackendComponents.hpp"
 #include "Computer/Settings.hpp"
 
 BackendComponents::BackendComponents() noexcept = default;
 BackendComponents::~BackendComponents() noexcept = default;
 
-void BackendComponents::SetTaskPolar(const PolarSettings &) noexcept
+void BackendComponents::SetTaskPolar(const PolarSettings &) noexcept {}
+
+ProtectedAirspaceWarningManager *
+BackendComponents::GetAirspaceWarnings() noexcept
 {
-  // Stub implementation for tests - backend_components is null in tests anyway
+  return nullptr;
 }
 
 static const DeviceConfig dummy_config = DeviceConfig();
@@ -1996,7 +2012,7 @@ TestFlightList(const struct DeviceRegister &driver)
 
 int main()
 {
-  plan_tests(1036);
+  plan_tests(1062);
   TestGeneric();
   TestTasman();
   TestFLARM();

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -45,6 +45,7 @@
 #include "Device/RecordedFlight.hpp"
 #include "Device/device.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
+#include "Engine/Waypoint/Ptr.hpp"
 #include "FaultInjectionPort.hpp"
 #include "Input/InputEvents.hpp"
 #include "Logger/Settings.hpp"
@@ -69,7 +70,17 @@ class GlueFlightLogger { public: virtual ~GlueFlightLogger() = default; };
 class MultipleDevices { public: virtual ~MultipleDevices() = default; };
 class DeviceBlackboard { public: virtual ~DeviceBlackboard() = default; };
 class MergeThread { public: virtual ~MergeThread() = default; };
-class ProtectedTaskManager { public: virtual ~ProtectedTaskManager() = default; };
+class ProtectedTaskManager {
+public:
+  virtual ~ProtectedTaskManager() = default;
+  WaypointPtr GetActiveWaypoint() const noexcept;
+};
+
+WaypointPtr
+ProtectedTaskManager::GetActiveWaypoint() const noexcept
+{
+  return nullptr;
+}
 class ProtectedAirspaceWarningManager {};
 class GlideComputer { public: virtual ~GlideComputer() = default; };
 class CalculationThread { public: virtual ~CalculationThread() = default; };

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -37,7 +37,7 @@ GlidePolarTest::Init()
   polar.SetWingArea(9.8);
 
   // No ballast and no bugs on the wings
-  polar.ballast = 0;
+  polar.SetBallastLitres(0);
   polar.bugs = 1;
 
   // MC zero
@@ -71,7 +71,7 @@ GlidePolarTest::TestBasic()
 
   ok1(equals(polar.GetTotalMass(), 318));
   ok1(equals(polar.GetWingLoading(), 32.448979592));
-  ok1(equals(polar.GetBallast(), 0));
+  ok1(equals(polar.GetBallastFraction(), 0));
   ok1(equals(polar.GetBallastLitres(), 0));
   ok1(polar.IsBallastable());
   ok1(!polar.HasBallast());
@@ -80,15 +80,15 @@ GlidePolarTest::TestBasic()
 void
 GlidePolarTest::TestBallast()
 {
-  polar.SetBallast(0.25);
+  polar.SetBallastFraction(0.25);
 
   ok1(equals(polar.GetBallastLitres(), 25));
-  ok1(equals(polar.GetBallast(), 0.25));
+  ok1(equals(polar.GetBallastFraction(), 0.25));
 
   polar.SetBallastLitres(50);
 
   ok1(equals(polar.GetBallastLitres(), 50));
-  ok1(equals(polar.GetBallast(), 0.5));
+  ok1(equals(polar.GetBallastFraction(), 0.5));
   ok1(equals(polar.GetTotalMass(), 368));
   ok1(equals(polar.GetWingLoading(), 37.551020408));
   ok1(polar.HasBallast());
@@ -108,7 +108,7 @@ GlidePolarTest::TestBallast()
   ok1(equals(polar.GetVMin(), 21.44464));
   ok1(equals(polar.GetVBestLD(), 27.78703));
 
-  polar.SetBallast(0);
+  polar.SetBallastLitres(0);
   ok1(!polar.HasBallast());
 }
 

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -25,6 +25,10 @@ private:
 void
 GlidePolarTest::Init()
 {
+  // Set operational parameters before any method that calls Update()
+  polar.bugs = 1;
+  polar.mc = 0;
+
   // Polar 1 from PolarStore (206 Hornet)
   polar.SetCoefficients(PolarCoefficients(0.0022032, -0.08784,
                                           1.47), false);
@@ -36,12 +40,8 @@ GlidePolarTest::Init()
 
   polar.SetWingArea(9.8);
 
-  // No ballast and no bugs on the wings
+  // No ballast
   polar.SetBallastLitres(0);
-  polar.bugs = 1;
-
-  // MC zero
-  polar.mc = 0;
 
   polar.SetVMax(Units::ToSysUnit(200, Unit::KILOMETER_PER_HOUR), false);
 }

--- a/test/src/test_replay_task.cpp
+++ b/test/src/test_replay_task.cpp
@@ -93,7 +93,7 @@ test_replay()
   TaskEventsPrint default_events(verbose);
   task_manager.SetTaskEvents(default_events);
 
-  glide_polar.SetBallast(1.0);
+  glide_polar.SetBallastFraction(1.0);
 
   task_manager.SetGlidePolar(glide_polar);
 


### PR DESCRIPTION
## LXNAV DataPort Protocol v1.05 Implementation

Comprehensive update of the LXNAV device driver to implement the DataPort Specification v1.05, including new features, bug fixes, and improved interoperability with external FLARM devices.

### LXNAV Driver Commits

All details are in the commit messages (see commit list below).

#### Protocol & Communication
- `6bc1e8a1c2` Device/Driver/LX: Implement protocol 1.05
- `f1ede47753` Device/Driver/LX/Parser: Update PLXVF/PLXVS for protocol v1.05
- `5e8cfc80c3` Device/Driver/LX: Add mutex locking to protect direct mode
- `01cfd4708d` Device/Port: Support custom baud rates above 230400 on Linux
- `699722509c` Device/Driver/LX: add license parsing and improve firmware logging
- `271602bfe0` Device/Driver/LX: Replace sprintf with fmt::format

#### Settings Synchronization
- `a8b1487a47` Device/LX: Synchronize MC on startup
- `cef9539a9a` Device/LX: Refactor settings sync to use blackboard pattern
- `88d1194f41` Device/Driver/LX: Add polar synchronization setting
- `af35736f10` Device/Driver/LX: Fix MC/ballast/bugs sync ping-pong
- `033788ffc6` Device/LX: Add VOL (volume) setting support
- `110696076f` Device/LX: Add ALTOFF (altitude offset) setting support
- `e240f72266` Device/Driver: implement elevation setting support
- `89c3f37396` Device/Driver/LX: Use IGC pressure altitude from PLXVS

#### Ballast & Polar
- `a36b523f24` Engine/GlideSolvers/GlidePolar: Refactor to use litres for ballast storage
- `ecbe415c72` ApplyExternalSettings: Fix ballast calculation to handle negative overload values

#### New Features
- `8ed6a0a022` Device/Driver/LX: Send navigation target to LXNAV vario via PLXVTARG
- `6d3a782dc4` Device/Driver/LX: Add radio and transponder support via PLXVC

#### Task Declaration
- `389d68fc5a` Device/Driver/LX: Add LLXVOZ and LLXVTSK to LXNAV task declaration — Fixes #1737
- `a1a544d7d5` Device/Descriptor, Driver/FLARM: Fix FLARM task declaration via LXNAV passthrough — Fixes #1736

#### Flight Download
- `d680bc45a5` Device/Driver/LX/NanoLogger: Fix flight list download with invalid dates — Fixes #1248, #1237
- `16fbe25ba0` Device/Driver/LX: Fix EnableLoggerNMEA for S-series varios

### Issues Resolved

- **#1737** — LXNav S8/80/10/100 varios: Task declaration start/finish point types incorrect
- **#1736** — Task declaration to IGC FLARM fails via S80
- **#1248** — LXNAV S80 Vario: Download of Flight List fails
- **#1237** — Impossible to download newest flight from LXNAV S8/S80/S10/S100 when more than 128 flights in logger

### Test Plan

- [x] LXNAV task declaration with OZ sectors verified on S series vario
- [x] FLARM declaration via LXNAV passthrough verified with external PowerFLARM
- [x] Both LXNAV and FLARM declarations succeed in a single operation
- [x] MC/ballast/bugs sync verified bidirectional without ping-pong
- [x] Radio and transponder sync verified
- [x] Navigation target (PLXVTARG) sync verified
- [x] Unit tests pass for declaration formatting, radio/transponder, and polar handling
- [ ] Bluetooth flight download / declaration (needs tester with BT setup) — #1252
- [ ] PEV start parameters to S100 — #1790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device sync for crew/empty mass and elevation with request/response; Polar send/receive synchronization and new device controls (volume, elevation, pilot/empty weight, target).
  * "Polar sync" option in device settings and display of device license; support for higher baud rates up to 1 Mbps.

* **Improvements**
  * Ballast handling now uses litres/overload for more accurate calculations.
  * Expanded LX parsing (POLAR, radio, transponder), improved declare/export formatting, safer NMEA formatting and logbook handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->