### PR TITLE
Renderer/InfoBoxes: Add outline to infobox values and units for non-b…

### DIFF
--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -19,6 +19,18 @@
 /** timeout of infobox focus */
 static constexpr std::chrono::steady_clock::duration FOCUS_TIMEOUT_MAX = std::chrono::seconds(20);
 
+/**
+ * Determine outline color based on background color
+ */
+static Color
+GetOutlineColor(Color background_color) noexcept
+{
+  // White for dark backgrounds, black for light backgrounds
+  return (background_color == COLOR_BLACK ||
+          background_color.Red() + background_color.Green() + background_color.Blue() < 384)
+    ? COLOR_WHITE : COLOR_BLACK;
+}
+
 InfoBoxWindow::InfoBoxWindow(ContainerWindow &parent, PixelRect rc,
                              unsigned border_flags,
                              const InfoBoxSettings &_settings,
@@ -94,12 +106,13 @@ InfoBoxWindow::PaintTitle(Canvas &canvas)
 }
 
 void
-InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_color)
+InfoBoxWindow::PaintValue(Canvas &canvas, Color background_color)
 {
   if (data.value.empty())
     return;
 
-  canvas.SetTextColor(look.GetValueColor(data.value_color));
+  const Color value_color = look.GetValueColor(data.value_color);
+  canvas.SetTextColor(value_color);
 
   canvas.Select(look.value_font);
   int ascent_height = look.value_font.GetAscentHeight();
@@ -117,7 +130,15 @@ InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_colo
   if (value_p.x < 0)
     value_p.x = 0;
 
-  canvas.TextAutoClipped(value_p, data.value);
+  // Draw outline if color is not black or white
+  const bool needs_outline = (value_color != COLOR_BLACK && value_color != COLOR_WHITE);
+  if (needs_outline) {
+    const Color outline_color = GetOutlineColor(background_color);
+    // Draw text at original position and size, with outline applied around it
+    RenderShadowedText(canvas, data.value, value_p, value_color, outline_color);
+  } else {
+    canvas.TextAutoClipped(value_p, data.value);
+  }
 
   if (unit_width != 0) {
     const int unit_height =
@@ -127,8 +148,17 @@ InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_colo
                                    ascent_height - unit_height);
 
     canvas.Select(look.unit_font);
-    UnitSymbolRenderer::Draw(canvas, unit_p,
-                             data.value_unit, look.unit_fraction_pen);
+    
+    // Apply outline to unit if value color needs outline
+    if (needs_outline) {
+      const Color outline_color = GetOutlineColor(background_color);
+      UnitSymbolRenderer::Draw(canvas, unit_p, data.value_unit,
+                              look.unit_fraction_pen,
+                              value_color, outline_color);
+    } else {
+      UnitSymbolRenderer::Draw(canvas, unit_p,
+                               data.value_unit, look.unit_fraction_pen);
+    }
   }
 }
 

--- a/src/Renderer/TextInBox.hpp
+++ b/src/Renderer/TextInBox.hpp
@@ -11,7 +11,14 @@ struct PixelPoint;
 struct PixelSize;
 struct PixelRect;
 class Canvas;
+class Color;
 class LabelBlock;
+
+void
+RenderShadowedText(Canvas &canvas, const TCHAR *text,
+                   PixelPoint p,
+                   Color text_color, Color outline_color) noexcept;
+
 void
 RenderShadowedText(Canvas &canvas, const TCHAR *text,
                    PixelPoint p,

--- a/src/Renderer/UnitSymbolRenderer.hpp
+++ b/src/Renderer/UnitSymbolRenderer.hpp
@@ -8,6 +8,7 @@
 struct PixelPoint;
 struct PixelSize;
 class Canvas;
+class Color;
 class Font;
 class Pen;
 
@@ -24,4 +25,8 @@ namespace UnitSymbolRenderer
 
   void Draw(Canvas &canvas, PixelPoint pos, Unit unit,
             const Pen &unit_fraction_pen) noexcept;
+
+  void Draw(Canvas &canvas, PixelPoint pos, Unit unit,
+            const Pen &unit_fraction_pen,
+            Color text_color, Color outline_color) noexcept;
 }


### PR DESCRIPTION
…lack/white colors

Add outline rendering support for infobox values and units when their colors are not black or white. This improves readability of colored text on various backgrounds.

Changes:
- Extended RenderShadowedText() to accept custom text and outline colors
- Added outline support to infobox values in PaintValue()
- Added outline support to infobox units via UnitSymbolRenderer::Draw()
- Outline thickness is adaptive: thicker for small fonts (≤16px) for better visibility, thinner for larger fonts
- Outline color is automatically chosen based on background brightness
- All changes are DPI-aware using font height calculations

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text rendering with improved outlines for better readability and visual contrast in info boxes and unit symbols.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->