### PR TITLE
Implement .xcd archive format support for waypoint data

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -169,6 +169,7 @@ endif
 
 XCSOAR_SOURCES := \
 	$(IO_SRC_DIR)/MapFile.cpp \
+	$(IO_SRC_DIR)/WaypointDataFile.cpp \
 	$(IO_SRC_DIR)/ConfiguredFile.cpp \
 	$(IO_SRC_DIR)/DataFile.cpp \
 	$(SRC)/Airspace/ProtectedAirspaceWarningManager.cpp \

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -19,6 +19,7 @@ enum ControlIndex {
   WaypointFileList,
   WatchedWaypointFileList,
   AirfieldFileList,
+  WaypointDataFileList,
   AirspaceFileList,
   FlarmFile,
   RaspFile,
@@ -76,6 +77,13 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
                    FileType::WAYPOINTDETAILS);
   SetExpertRow(AirfieldFileList);
 
+  AddMultipleFiles(_("Waypoint Data Archives"),
+                   _("Archive files (.xcd) containing waypoints, waypoint "
+                     "details and associated images. These files can be "
+                     "downloaded from the repository."),
+                   ProfileKeys::WaypointDataFileList, _T("*.xcd\0"),
+                   FileType::WAYPOINTDATA);
+
   AddMultipleFiles(_("Selected Airspace Files"),
                    _("List of active airspace files. Use the Add and Remove "
                      "buttons to activate or deactivate"
@@ -115,11 +123,14 @@ SiteConfigPanel::Save(bool &_changed) noexcept
   AirfieldFileChanged = SaveValueMultiFileReader(
       AirfieldFileList, ProfileKeys::AirfieldFileList);
 
+  bool WaypointDataFileChanged = SaveValueMultiFileReader(
+      WaypointDataFileList, ProfileKeys::WaypointDataFileList);
+
   RaspFileChanged = SaveValueFileReader(RaspFile, ProfileKeys::RaspFile);
 
   changed = WaypointFileChanged || AirfieldFileChanged ||
-            AirspaceFileChanged || MapFileChanged || FlarmFileChanged ||
-            RaspFileChanged;
+            WaypointDataFileChanged || AirspaceFileChanged ||
+            MapFileChanged || FlarmFileChanged || RaspFileChanged;
 
   _changed |= changed;
 

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -16,6 +16,10 @@
 #include "Widget/Widget.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "LocalPath.hpp"
+#include "io/WaypointDataFile.hpp"
+#include "io/ZipReader.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Bitmap.hpp"
 #include "Screen/Layout.hpp"
@@ -37,8 +41,11 @@
 #include "LogFile.hpp"
 #include "util/StringPointer.hxx"
 #include "util/AllocatedString.hxx"
+#include "util/StringCompare.hxx"
 #include "BackendComponents.hpp"
 #include "Pan.hpp"
+#include <vector>
+#include <memory>
 
 #ifdef ANDROID
 #include "Android/NativeView.hpp"
@@ -49,6 +56,65 @@ static bool
 ActivatePan(const Waypoint &waypoint)
 {
   return PanTo(waypoint.location);
+}
+
+/**
+ * Try to load an image from waypoint data archives.
+ * Only attempts to load if path starts with "pics/" (archive convention).
+ * Returns true if the image was successfully loaded into the bitmap.
+ * Returns false if path doesn't start with "pics/" or file not found in
+ * archives (caller should fall back to filesystem).
+ */
+static bool
+LoadImageFromWaypointDataArchives(Bitmap &bitmap,
+                                  [[maybe_unused]] const TCHAR *image_path)
+{
+  // Check if path starts with "pics/" (case-insensitive)
+  // Only paths starting with "pics/" are expected in archives.
+  // Other paths (e.g., "wpt_details/") should be loaded from filesystem.
+  // Convert to narrow string for comparison since ZIP paths are narrow
+  const NarrowPathName narrow_path{Path(image_path)};
+  const char *narrow_path_str = narrow_path;
+  if (!StringStartsWithIgnoreCase(narrow_path_str, "pics/"))
+    return false;  // Not an archive path, let caller use filesystem
+
+  // Get list of configured waypoint data files
+  auto archive_paths = Profile::GetMultiplePaths(ProfileKeys::WaypointDataFileList,
+                                                   _T("*.xcd\0"));
+
+  // Try loading from each archive
+  for (const auto &archive_path : archive_paths) {
+    try {
+      if (auto reader = OpenInWaypointDataFile(archive_path, narrow_path_str)) {
+        // Read entire file into memory
+        const auto size = reader->GetSize();
+        if (size == 0 || size > 10 * 1024 * 1024) // Limit to 10MB
+          continue;
+
+        std::vector<std::byte> buffer(static_cast<std::size_t>(size));
+        std::size_t total_read = 0;
+        while (total_read < buffer.size()) {
+          const auto nbytes = reader->Read(
+              std::span{buffer.data() + total_read,
+                        buffer.size() - total_read});
+          if (nbytes == 0)
+            break;
+          total_read += nbytes;
+        }
+
+        if (total_read == buffer.size()) {
+          // Load bitmap from memory
+          if (bitmap.Load(std::span{buffer.data(), buffer.size()}))
+            return true;
+        }
+      }
+    } catch (...) {
+      // Continue to next archive
+      continue;
+    }
+  }
+
+  return false;
 }
 
 #ifdef HAVE_RUN_FILE
@@ -416,7 +482,21 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
       break;
 
     try {
-      if (!images.append().LoadFile(LocalPath(i.c_str())))
+      Bitmap &bitmap = images.append();
+      bool loaded = false;
+
+      // Try loading from waypoint data archives first (for paths starting
+      // with "pics/"). If not found in archives or path doesn't start with
+      // "pics/", fall back to filesystem (XCSoarData directory).
+      if (LoadImageFromWaypointDataArchives(bitmap, i.c_str())) {
+        loaded = true;
+      } else {
+        // Fall back to filesystem - works for all paths including
+        // "wpt_details/", "pics/", or any other relative path
+        loaded = bitmap.LoadFile(LocalPath(i.c_str()));
+      }
+
+      if (!loaded)
         images.shrink(images.size() - 1);
     } catch (const std::exception &e) {
       LogFormat("Failed to load %s: %s",

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -75,6 +75,7 @@ constexpr std::string_view FlarmFile = "FlarmFile";
 constexpr std::string_view PolarFile = "PolarFile"; // pL
 constexpr std::string_view WaypointFileList = "WPFileList";           // pL
 constexpr std::string_view WatchedWaypointFileList = "WatchedWPFileList"; // pL
+constexpr std::string_view WaypointDataFileList = "WaypointDataFileList"; // pL
 constexpr std::string_view LanguageFile = "LanguageFile"; // pL
 constexpr std::string_view InputFile = "InputFile"; // pL
 constexpr std::string_view PilotName = "PilotName";

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -16,4 +16,5 @@ enum class FileType : uint8_t {
   RASP,
   XCI,
   TASK,
+  WAYPOINTDATA,
 };

--- a/src/Repository/Parser.cpp
+++ b/src/Repository/Parser.cpp
@@ -92,6 +92,8 @@ ParseFileRepository(FileRepository &repository, NLineReader &reader)
         file.type = FileType::XCI;
       else if (StringIsEqual(value, "task"))
         file.type = FileType::TASK;
+      else if (StringIsEqual(value, "waypoint-data"))
+        file.type = FileType::WAYPOINTDATA;
     } else if (StringIsEqual(name, "update")) {
       unsigned year, month, day;
       if (sscanf(value, "%04u-%02u-%02u", &year, &month, &day) == 3)

--- a/src/io/WaypointDataFile.cpp
+++ b/src/io/WaypointDataFile.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "WaypointDataFile.hpp"
+#include "ZipArchive.hpp"
+#include "ZipReader.hpp"
+#include "system/ConvertPathName.hpp"
+#include "system/Path.hpp"
+
+std::optional<ZipArchive>
+OpenWaypointDataFile(Path path)
+{
+  if (path == nullptr)
+    return std::nullopt;
+
+  return ZipArchive{path};
+}
+
+std::optional<ZipReader>
+OpenInWaypointDataFile(Path archive_path, const char *filename)
+{
+  auto archive = OpenWaypointDataFile(archive_path);
+  if (!archive)
+    return std::nullopt;
+
+  return std::optional<ZipReader>{std::in_place, archive->get(), filename};
+}

--- a/src/io/WaypointDataFile.hpp
+++ b/src/io/WaypointDataFile.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <optional>
+
+class ZipArchive;
+class ZipReader;
+class Path;
+
+/**
+ * Open a waypoint data archive (.xcd) file as a ZIP archive.
+ *
+ * Throws on error.
+ *
+ * @return std::nullopt if path is invalid
+ */
+std::optional<ZipArchive>
+OpenWaypointDataFile(Path path);
+
+/**
+ * Open a file inside a waypoint data archive.
+ *
+ * Throws on error.
+ *
+ * @return std::nullopt if archive cannot be opened or file not found
+ */
+std::optional<ZipReader>
+OpenInWaypointDataFile(Path archive_path, const char *filename);


### PR DESCRIPTION
Add support for .xcd archive files (non-compressed ZIP) containing waypoints, waypoint details, and associated images/PDFs in a single container file, similar to how .xcm map files work.

Features:
- Add WAYPOINTDATA file type to repository system for downloadable .xcd files
- Create WaypointDataFile module for opening and reading from .xcd archives
- Extend waypoint loading to support multiple .xcd archives
- Extend waypoint details loading from .xcd archives
- Load images from pics/ subfolder in ZIP archives with filesystem fallback
- Add UI support in Site Config panel for selecting .xcd files
- Support multiple .xcd files simultaneously

The implementation maintains backward compatibility - existing filesystem-based waypoint details and images continue to work. Archive support is additive and filesystem loading remains the fallback for all cases.

Fixes #1025

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for waypoint data archives (.xcd format) to organize and manage waypoint information
  * New settings panel to configure waypoint data archives
  * Waypoint details, images, and airfield information can now be loaded from configured archives
  * Supports multiple waypoint data formats from archive sources

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->