### PR TITLE
build/imagemagick.mk: Fix support for ImageMagick v7

### DIFF
--- a/build/imagemagick.mk
+++ b/build/imagemagick.mk
@@ -7,7 +7,7 @@ IM_MONTAGE_BIN := $(shell command -v montage 2>/dev/null)
 IM_CONVERT := $(if $(IM_BIN),$(IM_BIN),$(IM_CONVERT_BIN))
 IM_MONTAGE := $(if $(IM_BIN),$(IM_BIN) montage,$(IM_MONTAGE_BIN))
 # Use -alpha Off for IM7, +matte for IM6
-IM_DISABLE_ALPHA := $(if $(MAGICK_BIN),-alpha Off,+matte)
+IM_DISABLE_ALPHA := $(if $(IM_BIN),-alpha Off,+matte)
 
 # extract alpha channel
 %_alpha.png: %.png


### PR DESCRIPTION
Fixes a regression from Commit #2bb1f35 - imagemagick V7 not properly called in Unix (causing many warnings during build)

Tested compiling/running, but not in Android, since it currently does not compile for me due to the javac issue.


Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build system configuration updated with refined version detection for image processing. The build process now uses improved logic to determine alpha channel handling, which may enhance consistency when building with different ImageMagick configurations or installation variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->