### PR TITLE
Engine/Contest: Fix handicap=0 assertion failure

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -96,6 +96,7 @@ TEST_NAMES = \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave\
 	TestPlanes \
+	TestContestHandicap \
 	TestTaskPoint \
 	TestTaskWaypoint \
 	TestTeamCode \
@@ -281,6 +282,13 @@ TEST_PLANES_SOURCES = \
 	$(TEST_SRC_DIR)/TestPlanes.cpp
 TEST_PLANES_DEPENDS = UNITS IO OS MATH UTIL
 $(eval $(call link-program,TestPlanes,TEST_PLANES))
+
+TEST_CONTEST_HANDICAP_SOURCES = \
+	$(SRC)/Engine/Contest/Solvers/AbstractContest.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestContestHandicap.cpp
+TEST_CONTEST_HANDICAP_DEPENDS = UNITS IO OS MATH UTIL ENGINE
+$(eval $(call link-program,TestContestHandicap,TEST_CONTEST_HANDICAP))
 
 TEST_ZEROFINDER_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/src/Dialogs/Plane/PlaneDetailsDialog.cpp
+++ b/src/Dialogs/Plane/PlaneDetailsDialog.cpp
@@ -93,10 +93,12 @@ PlaneEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
   AddText(_("Comp. ID"), nullptr, plane.competition_id);
   AddButton(_("Polar"), [this](){ PolarButtonClicked(); });
   AddText(_("Type"), nullptr, plane.type);
+  // Default handicap to 100 if not set (0)
+  const unsigned handicap = plane.handicap != 0 ? plane.handicap : 100;
   AddInteger(_("Handicap"), nullptr,
              _T("%u %%"), _T("%u"),
              50, 150, 1,
-             plane.handicap);
+             handicap);
   AddFloat(_("Wing Area"), nullptr,
            _T("%.1f m²"), _T("%.1f"),
            0, 40, 0.1,

--- a/src/Engine/Contest/Solvers/AbstractContest.hpp
+++ b/src/Engine/Contest/Solvers/AbstractContest.hpp
@@ -33,7 +33,8 @@ public:
   AbstractContest(const unsigned _finish_alt_diff = 1000) noexcept;
 
   void SetHandicap(unsigned _handicap) noexcept {
-    handicap = _handicap;
+    // Ensure handicap is never 0 (default to 100 if unset)
+    handicap = _handicap != 0 ? _handicap : 100;
   }
 
   /**
@@ -114,7 +115,6 @@ protected:
   [[gnu::pure]]
   double ApplyHandicap(double unhandicapped_score) const noexcept {
     assert(handicap != 0);
-
     return 100 * unhandicapped_score / handicap;
   }
 
@@ -125,7 +125,6 @@ protected:
   [[gnu::pure]]
   double ApplyShiftedHandicap(const double unhandicapped_score) const noexcept {
     assert(handicap != 0);
-
     return 400 * unhandicapped_score / (3 * handicap + 100);
   }
 };

--- a/src/Plane/PlaneGlue.cpp
+++ b/src/Plane/PlaneGlue.cpp
@@ -58,7 +58,8 @@ void
 PlaneGlue::Synchronize(const Plane &plane, ComputerSettings &settings,
                        GlidePolar &gp) noexcept
 {
-  settings.contest.handicap = plane.handicap;
+  // Ensure handicap is never 0 (default to 100 if unset)
+  settings.contest.handicap = plane.handicap != 0 ? plane.handicap : 100;
 
   PolarCoefficients pc = plane.polar_shape.CalculateCoefficients();
   if (!pc.IsValid())

--- a/test/src/TestContestHandicap.cpp
+++ b/test/src/TestContestHandicap.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Engine/Contest/Solvers/AbstractContest.hpp"
+#include "Engine/Contest/ContestResult.hpp"
+#include "Engine/Contest/ContestTrace.hpp"
+#include "PathSolvers/SolverResult.hpp"
+#include "TestUtil.hpp"
+#include "util/PrintException.hxx"
+
+#include <cassert>
+
+static void
+TestSetHandicap()
+{
+  // Create a mock contest class to test SetHandicap
+  class TestContest : public AbstractContest {
+  public:
+    TestContest() : AbstractContest(1000) {}
+    ContestResult CalculateResult() const noexcept override {
+      return ContestResult();
+    }
+    const ContestTraceVector &GetCurrentPath() const noexcept override {
+      static ContestTraceVector empty;
+      return empty;
+    }
+    SolverResult Solve(bool) noexcept override {
+      return SolverResult::FAILED;
+    }
+    
+    // Expose protected methods for testing
+    using AbstractContest::ApplyHandicap;
+    using AbstractContest::ApplyShiftedHandicap;
+  };
+
+  TestContest contest;
+
+  // Test 1: Setting handicap to 0 should default to 100
+  contest.SetHandicap(0);
+  double result1 = contest.ApplyHandicap(1000.0);
+  ok1(equals(result1, 1000.0)); // 100 * 1000 / 100 = 1000
+
+  // Test 2: Setting handicap to valid value should work
+  contest.SetHandicap(120);
+  double result2 = contest.ApplyHandicap(1000.0);
+  ok1(equals(result2, 833.33333333333337)); // 100 * 1000 / 120 ≈ 833.33
+
+  // Test 3: ApplyShiftedHandicap with 0 should default to 100
+  contest.SetHandicap(0);
+  double shifted = contest.ApplyShiftedHandicap(1000.0);
+  ok1(equals(shifted, 1000.0)); // 400 * 1000 / (3 * 100 + 100) = 1000
+
+  // Test 4: ApplyShiftedHandicap with valid value
+  contest.SetHandicap(120);
+  shifted = contest.ApplyShiftedHandicap(1000.0);
+  ok1(equals(shifted, 869.56521739130438)); // 400 * 1000 / (3 * 120 + 100) ≈ 869.57
+}
+
+int main()
+try {
+  plan_tests(4);
+
+  TestSetHandicap();
+
+  return exit_status();
+} catch (...) {
+  PrintException(std::current_exception());
+  return EXIT_FAILURE;
+}


### PR DESCRIPTION
Prevent handicap from being 0 by validating at entry points:

- SetHandicap(): Default to 100 if 0 is passed
- PlaneGlue::Synchronize(): Ensure handicap is never 0 when setting
- PlaneDetailsDialog: Default to 100 if plane.handicap is 0

This fixes the assertion failure in ApplyHandicap() when handicap
becomes 0 due to missing default polar or uninitialized plane data.

The assertion in ApplyHandicap() is kept to document the contract
and catch any remaining bugs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Handicap fields now consistently default to 100 instead of 0 when not explicitly configured, ensuring valid values in plane settings and contest calculations.

* **Tests**
  * Added comprehensive test coverage for contest handicap handling, including default value behavior and calculation accuracy across different scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->