### PR TITLE
Waypoint: Fix crashes and filter issues

### DIFF
--- a/src/Waypoint/WaypointFilter.cpp
+++ b/src/Waypoint/WaypointFilter.cpp
@@ -39,7 +39,10 @@ WaypointFilter::CompareType(const Waypoint &waypoint, TypeFilter type,
     return waypoint.origin == WaypointOrigin::USER;
 
   case TypeFilter::FILE:
-    return waypoint.origin == WaypointOrigin::PRIMARY;
+    // Include waypoints from both primary and watched waypoint files
+    // (both are configured waypoint files, not user-created or map-based)
+    return waypoint.origin == WaypointOrigin::PRIMARY ||
+           waypoint.origin == WaypointOrigin::WATCHED;
 
   case TypeFilter::MAP:
     return waypoint.origin == WaypointOrigin::MAP;

--- a/src/Waypoint/WaypointList.cpp
+++ b/src/Waypoint/WaypointList.cpp
@@ -15,6 +15,13 @@ WaypointListItem::ResetVector() noexcept
 const GeoVector &
 WaypointListItem::GetVector(const GeoPoint &location) const noexcept
 {
+  if (waypoint == nullptr) {
+    // Return invalid vector if waypoint is null
+    if (vec.IsValid())
+      vec.SetInvalid();
+    return vec;
+  }
+
   if (!vec.IsValid())
     vec = GeoVector(location, waypoint->location);
 


### PR DESCRIPTION
- Fix crash when selecting "Recently Used" filter by adding proper
  index-to-enum mapping (array has 13 items but enum has 12 values)
- Fix crash in WaypointListWidget::OnPaintItem and
  WaypointListItem::GetVector by adding null checks
- Fix FILE filter to include both PRIMARY and WATCHED waypoint origins
  (handles multiple configured waypoint files)
- Add defensive check in UpdateList() to ensure widget is defined
  before accessing list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened waypoint list handling with validation checks for empty lists and invalid entries.
  * Expanded waypoint filtering to include watched configuration sources alongside primary sources.
  * Added safety guards to prevent rendering errors when waypoint data is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->