### PR TITLE
build/cmake: Restrict CMAKE_FIND_ROOT_PATH for Windows cross-compilation

### DIFF
--- a/build/python/build/cmake.py
+++ b/build/python/build/cmake.py
@@ -63,6 +63,15 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 """)
+    elif cmake_system_name == 'Windows':
+        # For Windows cross-compilation, restrict cmake to only search in
+        # the sysroot to avoid picking up host libraries like Homebrew's c-ares
+        f.write(f"""
+set(CMAKE_FIND_ROOT_PATH "{toolchain.install_prefix}")
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+""")
 
 def configure(toolchain: AnyToolchain, src: str, build: str, args: list[str]=[], env: Optional[Mapping[str, str]]=None) -> None:
     cross_args: list[str] = []


### PR DESCRIPTION
Set CMAKE_FIND_ROOT_PATH_MODE_INCLUDE to ONLY when cross-compiling for Windows to prevent cmake from searching host system paths like /opt/homebrew/include. This ensures dependencies are resolved only from the target sysroot, fixing issues where macOS Homebrew packages (e.g., c-ares) were being incorrectly found during Windows builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows cross-compilation configuration in the build system to align with cross-platform handling practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->