### PR TITLE
src/ui/window/custom/TopWindow: guard macOS HiDPI native size

### DIFF
--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -9,6 +9,10 @@
 #include "ui/event/Globals.hpp"
 #include "Hardware/CPU.hpp"
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #ifdef ANDROID
 #include "Android/Main.hpp"
 #include "Android/NativeView.hpp"
@@ -72,8 +76,8 @@ TopWindow::Create([[maybe_unused]] const TCHAR *text, PixelSize size,
   size = screen->SetDisplayOrientation(style.GetInitialOrientation());
 #elif defined(USE_MEMORY_CANVAS)
   size = screen->GetSize();
-#elif defined(ENABLE_OPENGL)
-  // On HiDPI displays, the drawable size may differ from window size
+#elif defined(ENABLE_OPENGL) && defined(__APPLE__) && TARGET_OS_OSX
+  // macOS HiDPI: drawable size may differ from window size; use native size.
   size = screen->GetNativeSize();
 #endif
   ContainerWindow::Create(nullptr, PixelRect{size}, style);


### PR DESCRIPTION
Limit GetNativeSize() to macOS so Android/EGL doesn't see a zero size before the surface is ready, which triggers `Window::GetClientRect()` assertions on startup (issue #2005).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined OpenGL drawable size handling on macOS to ensure correct HiDPI scaling and more reliable graphics rendering, preserving existing behavior on other platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->