### PR TITLE
Stratux driver: extract call-sign from PFLAA record traffic-id field

### DIFF
--- a/build/flarm.mk
+++ b/build/flarm.mk
@@ -13,6 +13,10 @@ FLARM_SOURCES = \
 	$(SRC)/FLARM/Computer.cpp \
 	$(SRC)/FLARM/Global.cpp \
 	$(SRC)/FLARM/Glue.cpp \
+    $(SRC)/FLARM/Details.cpp \
+    $(SRC)/FLARM/TrafficDatabases.cpp \
+    $(SRC)/FLARM/NameDatabase.cpp \
+    $(SRC)/FLARM/NameFile.cpp
 
 FLARM_DEPENDS = FMT
 

--- a/src/Device/Driver/Stratux/Driver.cpp
+++ b/src/Device/Driver/Stratux/Driver.cpp
@@ -8,6 +8,8 @@
 #include "Profile/ProfileMap.hpp"
 #include "Device/Driver/FLARM/StaticParser.hpp"
 #include "Device/Driver/LevilAHRS_G.hpp"
+#include "FLARM/Details.hpp"
+#include "util/ConvertString.hpp"
 
 StratuxDevice::StratuxSettings settings;
 
@@ -49,9 +51,47 @@ StratuxDevice::ParseNMEA(const char *line, NMEAInfo &info)
     range.horizontal = settings.hrange;
     range.vertical = settings.vrange;
     ParsePFLAA(input_line, info.flarm.traffic, info.clock, range);
+    ExtractAndSetCallSign(line, info);
     return true;
   } else
     return false;
+}
+
+void StratuxDevice::ExtractAndSetCallSign(const char *line, NMEAInfo &info)
+{
+  NMEAInputLine input_line(line);
+
+/* Extract traffic-id field from PFLAA sentence.
+   Skip 6 fields: $PFLAA, alarm-level, relative-north, relative-east,
+   relative-vertical, id-type, and read the traffic-id field. */
+  input_line.Skip(6);
+  char id_string[16];
+  input_line.Read(id_string, 16);
+
+/* get the actual traffic list entry with the traffic-id */
+  FlarmId id = FlarmId::Parse(id_string, nullptr);
+  if (!id.IsDefined())
+    return;
+
+  FlarmTraffic *flarm_slot = info.flarm.traffic.FindTraffic(id);
+
+/* Extract callsign from traffic-id field (after '!') if present. */
+  if (flarm_slot) {
+    char *ptr = strchr(id_string, '!');
+
+    if (ptr && ptr[1] != '\0' && flarm_slot->name.empty()) {
+      UTF8ToWideConverter callsign(ptr + 1);
+      if (callsign.IsValid())
+        flarm_slot->name.append(callsign.c_str());
+    }
+
+    /* Callsign from own list always overwrites. */
+    const TCHAR *cs = FlarmDetails::LookupCallsign(id);
+    if (cs != nullptr && cs[0] != 0) {
+      flarm_slot->name.clear();
+      flarm_slot->name.append(cs);
+    }
+  }
 }
 
 static Device *

--- a/src/Device/Driver/Stratux/Driver.hpp
+++ b/src/Device/Driver/Stratux/Driver.hpp
@@ -23,6 +23,10 @@ class StratuxDevice : public AbstractDevice {
     };
 
     bool ParseNMEA(const char *line, NMEAInfo &info) override;
+
+  private:
+
+    void ExtractAndSetCallSign(const char *line, NMEAInfo &info);
 };
 
 void LoadFromProfile(StratuxDevice::StratuxSettings &settings) noexcept;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Traffic display now extracts and applies call signs for PFLAA entries automatically.
  * When a local name is missing, a designator from the traffic ID is appended if available.
  * Official call signs are looked up and used when found.
  * Expanded FLARM name database support for improved call-sign resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->