### PR TITLE
Form/Panel: Fix OpenGL panels not clearing background

### DIFF
--- a/src/Form/Panel.cpp
+++ b/src/Form/Panel.cpp
@@ -9,7 +9,7 @@ PanelControl::Create(ContainerWindow &parent, [[maybe_unused]] const DialogLook 
                      const PixelRect &rc,
                      const WindowStyle style)
 {
-#ifdef HAVE_CLIPPING
+#if defined(HAVE_CLIPPING) || defined(ENABLE_OPENGL)
   SolidContainerWindow::Create(parent, rc, look.background_color, style);
 #else
   ContainerWindow::Create(parent, rc, style);

--- a/src/Form/Panel.hpp
+++ b/src/Form/Panel.hpp
@@ -5,7 +5,7 @@
 
 #include "ui/canvas/Features.hpp"
 
-#ifdef HAVE_CLIPPING
+#if defined(HAVE_CLIPPING) || defined(ENABLE_OPENGL)
 #include "ui/window/SolidContainerWindow.hpp"
 #else
 #include "ui/window/ContainerWindow.hpp"
@@ -17,7 +17,8 @@ struct DialogLook;
  * The PanelControl class implements the simplest form of a ContainerControl
  */
 class PanelControl :
-#ifdef HAVE_CLIPPING
+#if defined(HAVE_CLIPPING) || defined(ENABLE_OPENGL)
+  /* need explicit background erasing with clipping or OpenGL rendering */
   public SolidContainerWindow
 #else
   /* don't need to erase the background when it has been done by the


### PR DESCRIPTION
On OpenGL builds, PanelControl used ContainerWindow and didn’t clear the background, so scroll panels could show map content bleeding through, at least on iOS. Use SolidContainerWindow for OpenGL to clear the dialog background before painting children.

This fixes an issue where the map in **Configuration → Map Display → Terrain** leaked into the safe area due to an unnecessary scrollbar being rendered, as reported by @XCNav.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved rendering support for scenarios using OpenGL or hardware clipping features, ensuring consistent background handling across both display modes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->