### PR TITLE
Math/Screen: Fix polygon rendering bug on high-DPI devices

### DIFF
--- a/src/Math/FastRotation.hpp
+++ b/src/Math/FastRotation.hpp
@@ -6,6 +6,10 @@
 #include "Math/Angle.hpp"
 #include "Point2D.hpp"
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
 /**
  * Rotate coordinates around the zero origin.
  */
@@ -66,8 +70,16 @@ public:
     :cost(angle.ifastcosine()), sint(angle.ifastsine()) {}
 
   void Scale(int multiply, int divide=1) noexcept {
-    cost = cost * multiply / divide;
-    sint = sint * multiply / divide;
+    // Use int64_t for intermediate calculations to prevent overflow
+    // This is especially important on high-DPI devices where values can be large
+    const int64_t cost64 = static_cast<int64_t>(cost) * multiply / divide;
+    const int64_t sint64 = static_cast<int64_t>(sint) * multiply / divide;
+
+    // Clamp to int range to prevent overflow
+    constexpr int64_t MAX_INT = static_cast<int64_t>(std::numeric_limits<int>::max());
+    constexpr int64_t MIN_INT = static_cast<int64_t>(std::numeric_limits<int>::min());
+    cost = static_cast<int>(std::clamp(cost64, MIN_INT, MAX_INT));
+    sint = static_cast<int>(std::clamp(sint64, MIN_INT, MAX_INT));
   }
 
   constexpr Point RotateRaw(Point p) const noexcept {


### PR DESCRIPTION
Fixes #1514

## Problem
On Samsung Android devices (Galaxy A55, S22, S24), lines were being drawn from the upper-left corner (0,0) to map elements (traffic symbols and detailed landable waypoints). This occurred during map panning mode, especially when zoomed out showing many airports.

## Root Cause
1. **Zero division**: When `scale < 25`, integer division `scale / 25` becomes 0, causing rotation coefficients to collapse to zero
2. **Integer overflow**: On high-DPI devices, large scale values cause overflow in `FastIntegerRotation::Scale()` calculations, corrupting rotation coefficients
3. **Missing validation**: No checks to detect corrupted coordinates before rendering

## Solution
- Added minimum scale threshold (25) to prevent zero division
- Added polygon input validation (require >= 3 points)
- Used `int64_t` for intermediate calculations in `Scale()` to prevent overflow
- Added coordinate validation to detect corrupted transformations early

## Testing
Please test on Samsung Android devices (especially A55, S22, S24) with:
- Map panning mode enabled
- Detailed landables visible
- Traffic symbols visible
- Zoomed out to show many waypoints

The lines from origin should no longer appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced overflow prevention in scaling and rotation calculations.
  * Added input validation and safeguards for geometric transformations to handle edge cases more robustly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->