### PR TITLE
Dialogs/ReplayDialog: Auto-close after starting replay to allow UI updates

### DIFF
--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -20,15 +20,17 @@ class ReplayControlWidget final
   };
 
   Replay &replay;
+  WidgetDialog *dialog = nullptr;
 
 public:
   ReplayControlWidget(Replay &_replay, const DialogLook &look) noexcept
     :RowFormWidget(look), replay(_replay) {}
 
-  void CreateButtons(WidgetDialog &dialog) noexcept {
-    dialog.AddButton(_("Start"), [this](){ OnStartClicked(); });
-    dialog.AddButton(_("Stop"), [this](){ OnStopClicked(); });
-    dialog.AddButton(_T("+10'"), [this](){ OnFastForwardClicked(); });
+  void CreateButtons(WidgetDialog &_dialog) noexcept {
+    dialog = &_dialog;
+    dialog->AddButton(_("Start"), [this](){ OnStartClicked(); });
+    dialog->AddButton(_("Stop"), [this](){ OnStopClicked(); });
+    dialog->AddButton(_T("+10'"), [this](){ OnFastForwardClicked(); });
   }
 
 private:
@@ -75,6 +77,10 @@ ReplayControlWidget::OnStartClicked() noexcept
 
   try {
     replay.Start(path);
+    // Close dialog after starting replay to allow UI updates
+    // User can reopen dialog via menu to stop/control replay
+    if (dialog != nullptr)
+      dialog->SetModalResult(mrOK);
   } catch (...) {
     ShowError(std::current_exception(), _("Replay"));
   }


### PR DESCRIPTION
## Problem

The replay dialog was blocking the main event loop, preventing UI updates (thermal gauge, takeoff messages, etc.) from being displayed while the dialog was open. Users reported that these updates only appeared after closing the dialog.

## Solution

This change makes the dialog automatically close after starting replay, allowing all UI updates to work normally. The user can reopen the dialog via the menu to stop or control replay (change rate, fast-forward, etc.).

This matches the manual's statement that "The logger replay dialogue does not need to be open during replay."

## Changes

- Modified `ReplayControlWidget` to store a reference to the dialog
- Added auto-close behavior in `OnStartClicked()` after successfully starting replay
- Dialog closes automatically, allowing main event loop to process UI updates normally

## Testing

- Start replay from dialog - dialog should close automatically
- UI updates (thermal gauge, takeoff messages) should appear immediately
- Reopen dialog via menu to verify stop/control functionality still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed replay dialog closing behavior when initiating playback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->