### PR TITLE
Form/VScrollPanel: Fix touch screen tap-vs-drag detection

### DIFF
--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -46,6 +46,12 @@ class VScrollPanel final : public PanelControl {
   bool dragging = false;
 
   /**
+   * Tracks if we're waiting to determine if this is a tap or drag.
+   */
+  bool potential_tap = false;
+  PixelPoint drag_start = {0, 0};
+
+  /**
    * The vertical distance from the start of the drag relative to the
    * top of the list (not the top of the screen)
    */


### PR DESCRIPTION
Add tap-vs-drag detection to distinguish between taps on child widgets and drag gestures for scrolling. When a child widget handles OnMouseDown, the panel enters potential_tap mode and only switches to dragging if movement exceeds threshold (50px on touch screens, 10px on mouse).

This fixes the issue where tapping buttons in config dialogs would start scrolling instead of activating the button. Now:
- Taps on child widgets activate them correctly
- Drags on child widgets scroll the panel
- Drags on empty areas scroll the panel

The threshold detection follows the same pattern used in GlueMapWindow for consistency across the codebase.

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll panel gesture recognition with enhanced movement thresholds to accurately distinguish between taps and drags, preventing accidental drag triggering.
  * Refined mouse and touch event handling for better early event delegation and input responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->