### PR TITLE
Dialogs/StatusPanels/TaskStatusPanel.cpp: refresh on calculated update

### DIFF
--- a/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TaskStatusPanel.cpp
@@ -36,7 +36,6 @@ TaskStatusPanel::OnModified(DataField &df) noexcept
     const DataFieldFloat &dff = (const DataFieldFloat &)df;
     auto mc = Units::ToSysVSpeed(dff.GetValue());
     ActionInterface::SetManualMacCready(mc);
-    Refresh();
   }
 }
 
@@ -165,4 +164,26 @@ TaskStatusPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
               _("Efficiency of cruise. 100 indicates perfect MacCready performance; greater than 100 indicates better than MacCready performance is achieved through flying in streets. Less than 100 is appropriate if you fly considerably off-track. This value estimates your cruise efficiency according to the current flight history with the set MC value. Calculation begins after task is started."),
               _T("%.0f %%"),
               0);
+}
+
+void
+TaskStatusPanel::Show(const PixelRect &rc) noexcept
+{
+  Refresh();
+  CommonInterface::GetLiveBlackboard().AddListener(rate_limiter);
+  StatusPanel::Show(rc);
+}
+
+void
+TaskStatusPanel::Hide() noexcept
+{
+  StatusPanel::Hide();
+  CommonInterface::GetLiveBlackboard().RemoveListener(rate_limiter);
+  rate_limiter.Cancel();
+}
+
+void
+TaskStatusPanel::OnCalculatedUpdate([[maybe_unused]] const MoreData &basic, [[maybe_unused]] const DerivedInfo &calculated)
+{
+  Refresh();
 }

--- a/src/Dialogs/StatusPanels/TaskStatusPanel.hpp
+++ b/src/Dialogs/StatusPanels/TaskStatusPanel.hpp
@@ -5,19 +5,30 @@
 
 #include "StatusPanel.hpp"
 #include "Form/DataField/Listener.hpp"
+#include "Blackboard/RateLimitedBlackboardListener.hpp"
 
-class TaskStatusPanel : public StatusPanel, DataFieldListener {
+class TaskStatusPanel
+ : public StatusPanel, DataFieldListener,
+   private NullBlackboardListener {
+  RateLimitedBlackboardListener rate_limiter;
+
+
 public:
   explicit TaskStatusPanel(const DialogLook &look) noexcept
-    :StatusPanel(look) {}
+    :StatusPanel(look), rate_limiter(*this, std::chrono::seconds(1),
+                                     std::chrono::milliseconds(500)) {}
 
   /* virtual methods from class StatusPanel */
   void Refresh() noexcept override;
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
 
 private:
   /* virtual methods from DataFieldListener */
   void OnModified(DataField &df) noexcept override;
+  /* virtual methods from class BlackboardListener */
+  void OnCalculatedUpdate(const MoreData &basic, const DerivedInfo &calculated) override;
 };


### PR DESCRIPTION
This closes #556 

Calling refresh immediately after changing MC value is to fast,
calculation has no time to finish hence values are not updated after MC
change.

Now the panel is updated OnCalculatedUpdate().
Addition benefit, panel also updates during flying not just after MC
change.
Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant immediate refreshes to reduce UI flicker and unnecessary work.
  * Hiding the task status panel cancels pending refreshes and unregisters update listeners to prevent stray updates.

* **Improvements**
  * Showing the panel now triggers a refresh and registers for rate-limited calculated updates.
  * Panel refreshes in response to recalculation events, improving update accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->