### PR TITLE
InfoBoxes/Content/Airspace.cpp: add functionality

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,6 +81,7 @@ The following people and organizations have contributed code to XCSoar:
  Piotr Gertz <piotr@piopawlu.net>
  Yorick Reum <xcsoar@yorickreum.de>
  Roland Niederhagen <ronald_niederhagen@freenet.de>
+ kobedegeest <kobedegeest@gmail.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -56,6 +56,8 @@ Version 7.44 - not yet released
   - ability to send squawk code from airspace details dialog to transponder
   - add support for a dedicated north-up map page layout
   - the thermal assistant InfoBox is now clickable
+  - nearest airspace InfoBoxes (horizontal and vertical) are now clickable
+    to open airspace details dialog #406
   - Add support for multiple airspace files in UI
   - Add support for multiple waypoint files in UI
   - Add support for multiple  airfields or details waypoint in UI

--- a/src/InfoBoxes/Content/Airspace.cpp
+++ b/src/InfoBoxes/Content/Airspace.cpp
@@ -9,10 +9,18 @@
 #include "DataComponents.hpp"
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Airspace/NearestAirspace.hpp"
+#include "Dialogs/Airspace/Airspace.hpp"
+#include "Engine/Airspace/Airspaces.hpp"
 
 void
-UpdateInfoBoxNearestAirspaceHorizontal(InfoBoxData &data) noexcept
+InfoBoxNearestAirspaceHorizontal::Update(InfoBoxData &data) noexcept
 {
+  if (backend_components == nullptr || data_components == nullptr ||
+      data_components->airspaces == nullptr) {
+    data.SetInvalid();
+    return;
+  }
+
   NearestAirspace nearest = NearestAirspace::FindHorizontal(CommonInterface::Basic(),
                                                             backend_components->GetAirspaceWarnings(),
                                                             *data_components->airspaces);
@@ -25,9 +33,41 @@ UpdateInfoBoxNearestAirspaceHorizontal(InfoBoxData &data) noexcept
   data.SetComment(nearest.airspace->GetName());
 }
 
-void
-UpdateInfoBoxNearestAirspaceVertical(InfoBoxData &data) noexcept
+bool
+InfoBoxNearestAirspaceHorizontal::HandleClick() noexcept
 {
+  if (backend_components == nullptr || data_components == nullptr ||
+      data_components->airspaces == nullptr)
+    return false;
+
+  NearestAirspace nearest = NearestAirspace::FindHorizontal(CommonInterface::Basic(),
+                                                            backend_components->GetAirspaceWarnings(),
+                                                            *data_components->airspaces);
+
+  if (!nearest.IsDefined())
+    return false;
+
+  for (const auto &i : data_components->airspaces->QueryWithinRange(CommonInterface::Basic().location,
+                                                                      nearest.distance * 1.1)){
+    if (&i.GetAirspace() == nearest.airspace){
+      ConstAirspacePtr airspace = i.GetAirspacePtr();
+      dlgAirspaceDetails(airspace, backend_components->GetAirspaceWarnings());
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void
+InfoBoxNearestAirspaceVertical::Update(InfoBoxData &data) noexcept
+{
+  if (backend_components == nullptr || data_components == nullptr ||
+      data_components->airspaces == nullptr) {
+    data.SetInvalid();
+    return;
+  }
+
   NearestAirspace nearest = NearestAirspace::FindVertical(CommonInterface::Basic(),
                                                           CommonInterface::Calculated(),
                                                           backend_components->GetAirspaceWarnings(),
@@ -39,4 +79,30 @@ UpdateInfoBoxNearestAirspaceVertical(InfoBoxData &data) noexcept
 
   data.SetValueFromArrival(nearest.distance);
   data.SetComment(nearest.airspace->GetName());
+}
+
+bool
+InfoBoxNearestAirspaceVertical::HandleClick() noexcept
+{
+  if (backend_components == nullptr || data_components == nullptr ||
+      data_components->airspaces == nullptr)
+    return false;
+
+  NearestAirspace nearest = NearestAirspace::FindVertical(CommonInterface::Basic(),
+                                                          CommonInterface::Calculated(),
+                                                          backend_components->GetAirspaceWarnings(),
+                                                          *data_components->airspaces);
+
+  if (!nearest.IsDefined())
+    return false;
+
+  for (const auto &i : data_components->airspaces->QueryInside(CommonInterface::Basic().location)){
+    if (&i.GetAirspace() == nearest.airspace){
+      ConstAirspacePtr airspace = i.GetAirspacePtr();
+      dlgAirspaceDetails(airspace, backend_components->GetAirspaceWarnings());
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/src/InfoBoxes/Content/Airspace.hpp
+++ b/src/InfoBoxes/Content/Airspace.hpp
@@ -3,10 +3,21 @@
 
 #pragma once
 
+#include "InfoBoxes/Content/Base.hpp"
+
 struct InfoBoxData;
 
-void
-UpdateInfoBoxNearestAirspaceHorizontal(InfoBoxData &data) noexcept;
 
-void
-UpdateInfoBoxNearestAirspaceVertical(InfoBoxData &data) noexcept;
+class InfoBoxNearestAirspaceHorizontal : public InfoBoxContent
+{
+public:
+  void Update(InfoBoxData &data) noexcept override;
+  bool HandleClick() noexcept override;
+};
+
+class InfoBoxNearestAirspaceVertical : public InfoBoxContent
+{
+public:
+  void Update(InfoBoxData &data) noexcept override;
+  bool HandleClick() noexcept override;
+};

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -844,7 +844,7 @@ static constexpr MetaData meta_data[] = {
     N_("Nearest airspace horizontal"),
     N_("Near AS H"),
     N_("Horizontal distance to the nearest airspace."),
-    UpdateInfoBoxNearestAirspaceHorizontal,
+    IBFHelper<InfoBoxNearestAirspaceHorizontal>::Create,
   },
 
   // e_NearestAirspaceVertical
@@ -852,7 +852,7 @@ static constexpr MetaData meta_data[] = {
     N_("Nearest airspace vertical"),
     N_("Near AS V"),
     N_("Vertical distance to the nearest airspace. A positive value means the airspace is above you; a negative value means the airspace is below you."),
-    UpdateInfoBoxNearestAirspaceVertical,
+    IBFHelper<InfoBoxNearestAirspaceVertical>::Create,
   },
 
   // e_WP_MC0AltDiff


### PR DESCRIPTION
to NearestAirspaceHorizontaly infobox
On click will open airspace details dialog
This improves airspace management allows to easier anticipate upcoming warnings

Closes #406

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nearest-airspace info boxes (horizontal and vertical) are now interactive — clicking opens a detailed airspace dialog when a matching airspace is found.
* **Bug Fixes**
  * Added early validity checks to prevent showing undefined distances or names.
* **Refactor**
  * Nearest-airspace logic reorganized into dedicated, creatable components with explicit update and click handling to support interaction.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->