### PR TITLE
Lua: Add is_active property to replay bindings

### DIFF
--- a/doc/lua.rst
+++ b/doc/lua.rst
@@ -654,6 +654,8 @@ The following attributes are provided by ``xcsoar.replay``:
    - Gets replay clock rate.
  * - ``virtual_time``
    - Gets replay virtual time [s].
+ * - ``is_active``
+   - Returns true if replay is currently active, false otherwise.
 
 .. _lua.timer:
 

--- a/src/lua/Replay.cpp
+++ b/src/lua/Replay.cpp
@@ -25,6 +25,8 @@ l_replay_index(lua_State *L)
     Lua::Push(L, (lua_Integer)backend_components->replay->GetTimeScale());
   } else if (StringIsEqual(name, "virtual_time")) {
     Lua::Push(L, backend_components->replay->GetVirtualTime());
+  } else if (StringIsEqual(name, "is_active")) {
+    Lua::Push(L, backend_components->replay->IsActive());
   } else
     return 0;
 


### PR DESCRIPTION
Expose Replay::IsActive() to Lua scripts via xcsoar.replay.is_active.

This allows scripts to check if replay is currently active without relying on workarounds like checking virtual_time.

Fixes missing Lua binding for replay state query.

References: #2065

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Lua API documentation with the new `is_active` attribute for the Replay interface, describing its behavior and return values.

* **New Features**
  * Exposed `is_active` property in the Lua Replay interface. Returns true when replay functionality is active and false otherwise, allowing users to check replay status through scripts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->