### PR TITLE
MainWindow: Draw separator between top widget and map

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -906,6 +906,14 @@ MainWindow::OnClose() noexcept
 void
 MainWindow::OnPaint(Canvas &canvas) noexcept
 {
+  if (HaveTopWidget() && map != nullptr) {
+    /* draw a separator between top widget and map */
+    PixelRect rc = map->GetPosition();
+    rc.bottom = rc.top;
+    rc.top -= separator_height;
+    canvas.DrawFilledRectangle(rc, COLOR_BLACK);
+  }
+
   if (HaveBottomWidget() && map != nullptr) {
     /* draw a separator between main area and bottom area */
     PixelRect rc = map->GetPosition();


### PR DESCRIPTION
Draw a separator line between the top widget (e.g., progress bar) and the map to prevent flickering when map redraws are paused during terrain loading. This matches the existing pattern used for the bottom widget separator.

Fixes flickering issue where a 1-pixel line would alternate between white and black when loading a second terrain map while a map is already displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a visual separator line between the top widget and map when both are present, enhancing the interface's visual clarity and component separation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->