### PR TITLE
Repository: Add downloadable checklist support

### DIFF
--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -22,6 +22,7 @@ enum ControlIndex {
   AirspaceFileList,
   FlarmFile,
   RaspFile,
+  ChecklistFile,
 };
 
 class SiteConfigPanel final : public RowFormWidget {
@@ -92,6 +93,11 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
   AddFile(_T("RASP"), nullptr,
           ProfileKeys::RaspFile, _T("*-rasp*.dat\0"),
           FileType::RASP);
+
+  AddFile(_("Checklist"),
+          _("The checklist file containing pre-flight and other checklists."),
+          ProfileKeys::ChecklistFile, _T("*.txt\0"),
+          FileType::CHECKLIST);
 }
 
 bool
@@ -117,9 +123,11 @@ SiteConfigPanel::Save(bool &_changed) noexcept
 
   RaspFileChanged = SaveValueFileReader(RaspFile, ProfileKeys::RaspFile);
 
+  bool ChecklistFileChanged = SaveValueFileReader(ChecklistFile, ProfileKeys::ChecklistFile);
+
   changed = WaypointFileChanged || AirfieldFileChanged ||
             AirspaceFileChanged || MapFileChanged || FlarmFileChanged ||
-            RaspFileChanged;
+            RaspFileChanged || ChecklistFileChanged;
 
   _changed |= changed;
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -77,6 +77,7 @@ constexpr std::string_view WaypointFileList = "WPFileList";           // pL
 constexpr std::string_view WatchedWaypointFileList = "WatchedWPFileList"; // pL
 constexpr std::string_view LanguageFile = "LanguageFile"; // pL
 constexpr std::string_view InputFile = "InputFile"; // pL
+constexpr std::string_view ChecklistFile = "ChecklistFile"; // pL
 constexpr std::string_view PilotName = "PilotName";
 constexpr std::string_view WeGlideEnabled = "WeGlideEnabled";
 constexpr std::string_view WeGlidePilotID = "WeGlidePilotID";

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -16,4 +16,5 @@ enum class FileType : uint8_t {
   RASP,
   XCI,
   TASK,
+  CHECKLIST,
 };

--- a/src/Repository/Parser.cpp
+++ b/src/Repository/Parser.cpp
@@ -92,6 +92,8 @@ ParseFileRepository(FileRepository &repository, NLineReader &reader)
         file.type = FileType::XCI;
       else if (StringIsEqual(value, "task"))
         file.type = FileType::TASK;
+      else if (StringIsEqual(value, "checklist"))
+        file.type = FileType::CHECKLIST;
     } else if (StringIsEqual(name, "update")) {
       unsigned year, month, day;
       if (sscanf(value, "%04u-%02u-%02u", &year, &month, &day) == 3)


### PR DESCRIPTION
Add support for downloading checklist files from the repository and configuring a custom checklist file in the Site Configuration panel.

## Changes

- Add CHECKLIST file type to Repository/FileType enum
- Add checklist type parsing in Repository/Parser
- Add ChecklistFile profile key for storing configured checklist path
- Add checklist file selector to Site Configuration panel with download support via FileType::CHECKLIST
- Update checklist loading to use configured file path with fallback to xcsoar-checklist.txt if no file is configured or configured file fails

## Benefits

This allows users to download checklist files from download.xcsoar.org and select custom checklist files, while maintaining backward compatibility with the default xcsoar-checklist.txt file.

## Testing

- [x] Code compiles successfully
- [x] Checklist file selector appears in Site Configuration panel
- [x] Checklist loading falls back to default file when no custom file is configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure a custom checklist file location in settings. The application will load from your configured path, automatically falling back to the default checklist if the file is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->