### PR TITLE
circling wind with optional airspeed compensation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -80,6 +80,7 @@ The following people and organizations have contributed code to XCSoar:
  Wolfgang Drescher <drescher.wolfgang@gmail.com>
  Piotr Gertz <piotr@piopawlu.net>
  Yorick Reum <xcsoar@yorickreum.de>
+ Roland Niederhagen <ronald_niederhagen@freenet.de>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,10 @@ Version 7.44 - not yet released
   - remove FFVV NetCoupe
   - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
   - update OLC League calculation to latest ruleset
+  - improved circling wind algorithm: uses cosine curve fitting with True
+    Airspeed compensation for more accurate wind estimates, angular rate
+    quality assessment for better circle validation, and GPS latency
+    compensation
 * tracking
   - xcsoar-cloud-service: rebuild service, new domain cloud.xcsoar.org
 * data files

--- a/build/test.mk
+++ b/build/test.mk
@@ -1526,7 +1526,8 @@ RUN_CIRCLING_WIND_SOURCES = \
 	$(SRC)/Computer/Wind/CirclingWind.cpp \
 	$(SRC)/TransponderCode.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
-	$(TEST_SRC_DIR)/RunCirclingWind.cpp
+	$(TEST_SRC_DIR)/RunCirclingWind.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp
 RUN_CIRCLING_WIND_DEPENDS = $(DEBUG_REPLAY_DEPENDS) GEO MATH UTIL
 $(eval $(call link-program,RunCirclingWind,RUN_CIRCLING_WIND))
 
@@ -1555,6 +1556,7 @@ RUN_WIND_COMPUTER_SOURCES = \
 	$(SRC)/Formatter/TimeFormatter.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(SRC)/TransponderCode.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/RunWindComputer.cpp
 RUN_WIND_COMPUTER_DEPENDS = $(DEBUG_REPLAY_DEPENDS) GEO MATH UTIL TIME
 $(eval $(call link-program,RunWindComputer,RUN_WIND_COMPUTER))

--- a/src/Computer/Wind/CirclingWind.hpp
+++ b/src/Computer/Wind/CirclingWind.hpp
@@ -4,9 +4,10 @@
 #pragma once
 
 #include "Geo/SpeedVector.hpp"
-#include "util/StaticArray.hxx"
 #include "NMEA/Validity.hpp"
 #include "time/Stamp.hpp"
+
+#include <boost/circular_buffer.hpp>
 
 struct MoreData;
 struct CirclingInfo;
@@ -23,24 +24,34 @@ class CirclingWind
   struct Sample
   {
     TimeStamp time;
-    SpeedVector vector;
+
+    Angle track;        // in degrees, from the GPRMC sentence
+    Angle angular_rate; // in degrees/sample, from GPRMC or IMU
+                        /* positive means right turn
+                         * TO DO: as soon as gyros become available use tehir
+                         * turn rate info
+                         */
+    float ground_speed; // in m/s, from the GPRMC sentence
+    float tas; // true airspeed in m/s; imact on accuracy if unavailable
   };
 
   Validity last_track_available, last_ground_speed_available;
+  bool usable_tas = true;
 
-  // we are counting the number of circles, the first onces are probably not very round
-  int circle_count;
   // active is set to true or false by the slot_newFlightMode slot
   bool active;
+  // after a successful wind calculation suspend for a number of samples
+  int suspend;
 
   /**
    * The angle turned in the current circle.
    */
   Angle current_circle;
 
-  Angle last_track;
+  Angle last_track    = Angle::Zero();
+  Angle last_wind_dir = Angle::Zero();
 
-  StaticArray<Sample, 50> samples;
+  boost::circular_buffer<Sample> samples{80};
 
 public:
   struct Result
@@ -49,11 +60,14 @@ public:
     SpeedVector wind;
 
     Result() {}
-    Result(unsigned _quality):quality(_quality) {}
+    explicit Result(unsigned _quality) : quality(_quality) {}
     Result(unsigned _quality, SpeedVector _wind)
-      :quality(_quality), wind(_wind) {}
+        : quality(_quality), wind(_wind)
+    {
+    }
 
-    bool IsValid() const {
+    bool IsValid() const
+    {
       return quality > 0;
     }
   };
@@ -69,5 +83,20 @@ public:
   Result NewSample(const MoreData &info, const CirclingInfo &circling);
 
 private:
-  Result CalcWind();
+  // remebers the status when circling started
+  bool _airspeed_available = false;
+
+  unsigned int EstimateQuality(const double circle_quality,
+                               const double fitCosine_quality,
+                               const double wind_speed,
+                               const char ar_source);
+  Result CalcWind(const double quality_metric,
+                  const size_t n_samples,
+                  const Angle circle,
+                  const char ar_source);
+  double FitCosine(const size_t n_samples,
+                   const double amplitude,
+                   const double offset,
+                   const Angle phase);
+  void ShowResources(const MoreData &info);
 };


### PR DESCRIPTION
This is mostly a rewrite of CirclingWind, while maintaining the concept. It improves by:
1. estimation the wind vector by using all samples of the circle instead of just the minimum and the maximum
2. if available it uses airspeed to compensate for changes in speed while circling
3. it delivers more wind estimates at a higher quality score so that WindStore can do a better job

TODO: include Gyro data to verify the assumption the pilot flies in perfect circles

Your PR should:
  * all description should be in the commit messages (no text in the pr)
  * your pr should be rebased on the current HEAD
  * one commit per atomic feature (every commit should build)
  * no fixup commits
  * pass all the compile and CI targets

For coding, style guide, architecture information please see our development guide:
https://xcsoar.readthedocs.io/en/latest/index.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved circling-wind estimation with iterative cosine-fit and true airspeed handling; reports airspeed availability and exposes quality-estimation and fitting utilities.

* **Bug Fixes**
  * Better per-sample validation, angular-rate gating, time-uniformity handling and GPS latency compensation for more accurate wind bearing.

* **Refactor**
  * Reworked sample buffering and replaced circle-only detection with accumulated-sample cosine-fit flow; added suspend control to throttle updates.

* **Tests**
  * Added test support for enhanced circling-wind scenarios.

* **Chores**
  * Added contributor entry and release notes update.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->