### PR TITLE
Device/Driver/LoEFGREN: Add driver for LöFGREN variometer

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -69,6 +69,7 @@ Version 7.44 - not yet released
   - Improve audio support: prevent ducking and enable sound playback even when the phone is muted
 * devices
   - Add driver for Condor 3
+  - Add driver for LöFGREN variometer
   - Add driver for LX Navigation Eos / Era variometers
   - Add driver for Stratux
   - Flarm: parse flarm error messages (PFLAE) and display them

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -139,6 +139,7 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/KRT2.cpp \
 	$(DRIVER_SRC_DIR)/AirControlDisplay.cpp \
 	$(DRIVER_SRC_DIR)/Larus.cpp \
+	$(DRIVER_SRC_DIR)/LoEFGREN.cpp \
 	$(DRIVER_SRC_DIR)/ATR833/Device.cpp \
 	$(DRIVER_SRC_DIR)/ATR833/Register.cpp
 

--- a/src/Device/Driver/LoEFGREN.cpp
+++ b/src/Device/Driver/LoEFGREN.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/LoEFGREN.hpp"
+#include "Device/Driver.hpp"
+#include "NMEA/Checksum.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/InputLine.hpp"
+#include "Units/System.hpp"
+
+using std::string_view_literals::operator""sv;
+
+class LoEFGRENDevice : public AbstractDevice {
+public:
+  LoEFGRENDevice() = default;
+
+  /* virtual methods from class Device */
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+};
+
+static bool
+PLOF(NMEAInputLine &line, NMEAInfo &info)
+{
+  /* $PLOF,<TE compensated climb/sink in cm/s>,<indicated airspeed km/h>,
+   * <temperature in deg c>*
+   *
+   * TE compensated climb/sink = variometer in cm/s (up positive)
+   * indicated airspeed = indicated airspeed in km/h
+   * temperature = temperature in degrees Celsius
+   *
+   * Protocol documentation:
+   * https://www.lofgren-electronics.fr/Lofgren%20Variometer%20User%20Manual%20EN%20.pdf
+   * Section "NMEA output"
+   */
+
+  double value;
+
+  // Parse TE compensated variometer (cm/s -> m/s)
+  if (line.ReadChecked(value))
+    info.ProvideTotalEnergyVario(value / 100);
+
+  // Parse indicated airspeed (km/h -> m/s)
+  if (line.ReadChecked(value))
+    info.ProvideIndicatedAirspeed(Units::ToSysUnit(value,
+                                                    Unit::KILOMETER_PER_HOUR));
+
+  // Parse temperature (°C)
+  if (line.ReadChecked(value)) {
+    info.temperature = Temperature::FromCelsius(value);
+    info.temperature_available = true;
+  }
+
+  return true;
+}
+
+bool
+LoEFGRENDevice::ParseNMEA(const char *line, NMEAInfo &info)
+{
+  if (line == nullptr)
+    return false;
+
+  if (!VerifyNMEAChecksum(line))
+    return false;
+
+  NMEAInputLine input(line);
+  const auto type = input.ReadView();
+
+  if (type == "$PLOF"sv)
+    return PLOF(input, info);
+
+  return false;
+}
+
+static Device *
+LoEFGRENCreateOnPort([[maybe_unused]] const DeviceConfig &config,
+                     [[maybe_unused]] Port &port)
+{
+  return new LoEFGRENDevice();
+}
+
+const struct DeviceRegister loe_fgren_driver = {
+  _T("LoEFGREN"),
+  _T("LöFGREN Variometer"),
+  0,
+  LoEFGRENCreateOnPort,
+};
+

--- a/src/Device/Driver/LoEFGREN.hpp
+++ b/src/Device/Driver/LoEFGREN.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+extern const struct DeviceRegister loe_fgren_driver;
+

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -42,6 +42,7 @@
 #include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/KRT2.hpp"
 #include "Device/Driver/Stratux.hpp"
+#include "Device/Driver/LoEFGREN.hpp"
 #include "util/Macros.hpp"
 #include "util/StringAPI.hxx"
 
@@ -90,6 +91,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &condor3_driver,
   &lx_eos_driver,
   &stratux_driver,
+  &loe_fgren_driver,
   nullptr
 };
 


### PR DESCRIPTION
This PR adds support for the LöFGREN variometer device.

## Changes
- New receive-only driver for LöFGREN variometer
- Parses $PLOF NMEA sentence with TE compensated vario, indicated airspeed, and temperature
- Comprehensive test suite with 33 test cases

## Protocol Documentation
Protocol specification from:
https://www.lofgren-electronics.fr/Lofgren%20Variometer%20User%20Manual%20EN%20.pdf
Section "NMEA output"

## Technical Details
- Sentence format: $PLOF,<vario_cm_s>,<ias_km_h>,<temp_c>*
- Baud rate: 9600, 8N1, no flow control
- Receive-only (no commands sent to device)

## Testing
All tests pass. Test suite includes:
- Valid sentence parsing (positive/negative/zero vario, various temperatures)
- Invalid sentence rejection (wrong type, bad checksum)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for LoEFGREN (LöFGREN) variometer devices with NMEA protocol integration.
  * Extracts and processes total energy variometer data, indicated airspeed measurements, and temperature readings from compatible variometer hardware in real-time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->