### PR TITLE
doc: Add test and debug utilities documentation

### DIFF
--- a/doc/git_tips.rst
+++ b/doc/git_tips.rst
@@ -1,0 +1,320 @@
+Git Tips and Tricks
+===================
+
+This document provides practical Git tips and tricks for XCSoar development,
+focusing on common workflows and useful commands. For detailed Git documentation,
+see the official Git manual or `git help <command>`.
+
+Interactive Rebase
+------------------
+
+Interactive rebase (``git rebase -i``) is one of the most powerful tools for
+cleaning up commit history before submitting a pull request.
+
+**Starting an interactive rebase**:
+
+.. code-block:: bash
+
+   # Rebase last 5 commits
+   git rebase -i HEAD~5
+   
+   # Rebase from a specific commit
+   git rebase -i <commit-hash>
+   
+   # Rebase from upstream/master
+   git rebase -i upstream/master
+
+**Common rebase operations**:
+
+- ``pick`` (or ``p``): Use the commit as-is
+- ``reword`` (or ``r``): Change the commit message
+- ``edit`` (or ``e``): Stop to amend the commit
+- ``squash`` (or ``s``): Combine with previous commit, keep both messages
+- ``fixup`` (or ``f``): Combine with previous commit, discard this message
+- ``drop`` (or ``d``): Remove the commit entirely
+- ``exec`` (or ``x``): Run a shell command
+
+**Example: Squashing fixup commits**:
+
+.. code-block:: bash
+
+   # Interactive rebase to squash fixups
+   git rebase -i HEAD~10
+   # Change "pick" to "fixup" for commits you want to squash
+   # Save and close editor
+
+**Example: Reordering commits**:
+
+.. code-block:: bash
+
+   git rebase -i HEAD~5
+   # Reorder lines in the editor to change commit order
+   # Git will replay commits in the new order
+
+**Example: Dropping unwanted commits**:
+
+.. code-block:: bash
+
+   git rebase -i HEAD~10
+   # Change "pick" to "drop" (or delete the line) for commits to remove
+
+Fixup Commits
+-------------
+
+Fixup commits are useful for making small corrections without creating a new
+standalone commit.
+
+**Creating a fixup commit**:
+
+.. code-block:: bash
+
+   # Make your changes
+   git add <files>
+   git commit --fixup <commit-hash>
+   
+   # Or use autosquash to automatically fixup the referenced commit
+   git commit --fixup HEAD~2
+
+**Auto-squashing fixups**:
+
+.. code-block:: bash
+
+   # Automatically squash all fixup commits during rebase
+   git rebase -i --autosquash HEAD~10
+   
+   # Or set autosquash as default
+   git config --global rebase.autoSquash true
+
+**Example workflow**:
+
+.. code-block:: bash
+
+   # Make a commit
+   git commit -m "Device/Flarm: Add new feature"
+   
+   # Later, find a typo
+   git commit --fixup HEAD
+   
+   # Before pushing, auto-squash
+   git rebase -i --autosquash HEAD~5
+
+Useful One-Liners
+-----------------
+
+**View commit history**:
+
+.. code-block:: bash
+
+   # Compact one-line log
+   git log --oneline
+   
+   # Last 10 commits with graph
+   git log --oneline --graph -10
+   
+   # Commits in a specific date range
+   git log --oneline --since="2 weeks ago" --until="1 week ago"
+
+**Finding commits**:
+
+.. code-block:: bash
+
+   # Find commits touching a file
+   git log --oneline -- <file>
+   
+   # Find commits with specific text in message
+   git log --oneline --grep="Fix"
+   
+   # Find commits by author
+   git log --oneline --author="John"
+
+**Cleaning up**:
+
+.. code-block:: bash
+
+   # Remove untracked files and directories
+   git clean -fd
+   
+   # Dry run first
+   git clean -fdn
+   
+   # Reset to match remote (discard local changes)
+   git reset --hard origin/branch-name
+
+**Branch management**:
+
+.. code-block:: bash
+
+   # List merged branches
+   git branch --merged
+   
+   # Delete merged branches
+   git branch --merged | grep -v "\*\|master\|main" | xargs git branch -d
+   
+   # Rename current branch
+   git branch -m new-branch-name
+
+**Stashing**:
+
+.. code-block:: bash
+
+   # Stash with message
+   git stash push -m "WIP: working on feature"
+   
+   # Stash including untracked files
+   git stash push -u
+   
+   # List stashes
+   git stash list
+   
+   # Apply and keep stash
+   git stash apply
+   
+   # Apply and drop stash
+   git stash pop
+
+**Viewing changes**:
+
+.. code-block:: bash
+
+   # Show what changed in last commit
+   git show HEAD
+   
+   # Show diff between branches
+   git diff branch1..branch2
+   
+   # Show only file names that changed
+   git diff --name-only branch1..branch2
+
+**Amending commits**:
+
+.. code-block:: bash
+
+   # Amend last commit message
+   git commit --amend
+   
+   # Amend last commit with new changes
+   git add <files>
+   git commit --amend --no-edit
+   
+   # Amend commit date
+   git commit --amend --date="now"
+
+Visual Tools
+------------
+
+**tig** - Text-mode interface for Git:
+
+.. code-block:: bash
+
+   # Install (Debian/Ubuntu)
+   sudo apt install tig
+   
+   # Run tig
+   tig
+   
+   # View specific branch
+   tig branch-name
+   
+   # View file history
+   tig <file>
+
+**lazygit** - Simple terminal UI for Git:
+
+.. code-block:: bash
+
+   # Install (see https://github.com/jesseduffield/lazygit)
+   # Run lazygit
+   lazygit
+
+Both tools provide interactive interfaces for:
+- Viewing commit history
+- Staging/unstaging files
+- Creating commits
+- Managing branches
+- Interactive rebase operations
+
+Common Workflows
+----------------
+
+**Cleaning up before PR**:
+
+.. code-block:: bash
+
+   # 1. Fetch latest from upstream
+   git fetch upstream
+   
+   # 2. Rebase on upstream/master
+   git rebase upstream/master
+   
+   # 3. Squash fixup commits
+   git rebase -i --autosquash upstream/master
+   
+   # 4. Force push to your fork
+   git push mine branch-name --force
+
+**Finding and fixing a commit**:
+
+.. code-block:: bash
+
+   # Find the commit
+   git log --oneline --grep="typo"
+   
+   # Create fixup
+   git commit --fixup <commit-hash>
+   
+   # Auto-squash during rebase
+   git rebase -i --autosquash HEAD~10
+
+**Splitting a large commit**:
+
+.. code-block:: bash
+
+   # Start interactive rebase
+   git rebase -i HEAD~2
+   
+   # Mark commit as "edit"
+   # Git will stop at that commit
+   
+   # Reset to previous commit, keep changes
+   git reset HEAD~1
+   
+   # Stage and commit files in smaller groups
+   git add <some-files>
+   git commit -m "First part"
+   git add <other-files>
+   git commit -m "Second part"
+   
+   # Continue rebase
+   git rebase --continue
+
+**Undoing the last commit (keep changes)**:
+
+.. code-block:: bash
+
+   git reset --soft HEAD~1
+
+**Undoing the last commit (discard changes)**:
+
+.. code-block:: bash
+
+   git reset --hard HEAD~1
+
+Tips
+----
+
+- **Always rebase on upstream/master** before submitting PRs to keep history clean
+- **Use fixup commits** for small corrections, then auto-squash before pushing
+- **Test after rebase** - rebasing rewrites history and can introduce issues
+- **Use ``--force-with-lease``** instead of ``--force`` when pushing rebased branches
+- **Keep commits focused** - one logical change per commit
+- **Write good commit messages** - follow the project's format (see :doc:`gitworkflow`)
+- **Use visual tools** (tig, lazygit) for complex operations - easier than command line
+- **Don't rebase shared branches** - only rebase your local feature branches
+
+Additional Resources
+--------------------
+
+- :doc:`gitworkflow` - XCSoar Git workflow guidelines
+- ``git help <command>`` - Built-in Git documentation
+- `Pro Git book <https://git-scm.com/book>`_ - Comprehensive Git reference
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -15,6 +15,7 @@ XCSoar
    mapfile
    debugging
    test_debug_utilities
+   git_tips
 
 Build system reference: :ref:`build-system-reference`
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ XCSoar
    lua
    mapfile
    debugging
+   test_debug_utilities
 
 Build system reference: :ref:`build-system-reference`
 

--- a/doc/test_debug_utilities.rst
+++ b/doc/test_debug_utilities.rst
@@ -1,0 +1,933 @@
+Test and Debug Utilities
+=========================
+
+The XCSoar test suite includes a collection of standalone utility programs
+for debugging, testing, and interactive exploration of XCSoar components
+without running the full application. Many of these utilities are prefixed
+with ``Run*`` (e.g., ``RunTask``, ``RunAnalysis``, ``RunDeviceDriver``), but
+the suite also includes data conversion tools, device emulators, and other
+development utilities.
+
+Overview
+--------
+
+Run* utilities are standalone programs that exercise specific XCSoar subsystems
+in isolation. They serve several purposes:
+
+- **Debugging**: Test individual components with real or simulated data
+- **Development**: Interactive tools for exploring component behavior
+- **Testing**: Verify functionality with flight data files
+- **Device interaction**: Communicate with hardware devices directly
+
+These utilities are built as part of the XCSoar build system and are available
+in the output directory after compilation. The exact path depends on your build
+target:
+
+- **Unix/Linux**: ``output/UNIX/bin/`` (default, and for flavors like WAYLAND, OPT, FUZZER)
+- **Windows**: ``output/PC/bin/`` (default, and for WIN64 flavor)
+- **macOS**: ``output/OSX64/bin/`` or ``output/MACOS/bin/`` (default)
+
+**Important**: Many build "targets" are actually flavors that override the base
+target. For example, ``TARGET=WAYLAND`` or ``TARGET=OPT`` both build to
+``output/UNIX/bin/`` because they override the TARGET to UNIX internally. The
+debug utilities are built for the base target (UNIX, PC, etc.), not for the
+flavor name.
+
+**Note**: In the examples below, ``output/UNIX/bin/`` is used (typical for Linux
+development). Replace ``UNIX`` with your actual base build target if different
+(e.g., ``PC`` for Windows, ``OSX64`` for macOS). To find your output directory,
+check what was created in the ``output/`` folder after building.
+
+Building Run* Utilities
+------------------------
+
+All Run* utilities are automatically built when you compile XCSoar. They are
+defined in ``build/test.mk`` and compiled as part of the debug programs target.
+
+To build all Run* utilities:
+
+.. code-block:: bash
+
+   make DEBUG
+
+To build a specific utility:
+
+.. code-block:: bash
+
+   make output/UNIX/bin/RunTask
+
+The utilities are built for the host platform (your development machine), not
+for embedded targets like Android or Kobo.
+
+Common Patterns
+---------------
+
+Run* utilities follow several common patterns depending on their purpose:
+
+Pattern 1: DebugReplay-Based Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Many utilities use ``DebugReplay`` to process flight data files (IGC, NMEA).
+This pattern is ideal for testing components that need to process historical
+flight data.
+
+**Example**: ``RunTask.cpp``, ``RunWindComputer.cpp``, ``RunContestAnalysis.cpp``
+
+**Structure**:
+
+.. code-block:: cpp
+
+   #include "system/Args.hpp"
+   #include "DebugReplay.hpp"
+   
+   int main(int argc, char **argv)
+   {
+     Args args(argc, argv, "USAGE");
+     DebugReplay *replay = CreateDebugReplay(args);
+     if (replay == NULL)
+       return EXIT_FAILURE;
+     
+     args.ExpectEnd();
+     
+     while (replay->Next()) {
+       const MoreData &basic = replay->Basic();
+       const DerivedInfo &calculated = replay->Calculated();
+       
+       // Process data here
+     }
+     
+     delete replay;
+     return EXIT_SUCCESS;
+   }
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunTask task.xct test/data/01lz1hq1.igc
+
+``CreateDebugReplay()`` automatically detects the file format (IGC, NMEA) and
+creates an appropriate replay object. It accepts:
+
+- IGC files: ``*.igc``
+- NMEA files: ``*.nmea``, ``*.txt`` (with NMEA sentences)
+- Device driver names: ``FLARM``, ``Vega``, etc. (for driver-specific parsing)
+
+Pattern 2: Main.hpp-Based GUI Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Utilities that need a graphical interface use ``Main.hpp``, which provides
+boilerplate for window creation, event loops, and UI initialization.
+
+**Example**: ``RunAnalysis.cpp``, ``RunCanvas.cpp``, ``RunMapWindow.cpp``
+
+**Structure**:
+
+.. code-block:: cpp
+
+   #define ENABLE_LOOK
+   #define ENABLE_DIALOG
+   #define ENABLE_CMDLINE
+   #define ENABLE_PROFILE
+   #define USAGE "DRIVER FILE"
+   
+   #include "Main.hpp"
+   
+   static void
+   Main(UI::Display &display)
+   {
+     // Create windows, dialogs, etc.
+   }
+
+**Available defines**:
+
+- ``ENABLE_LOOK``: Full Look system (fonts, colors, styles)
+- ``ENABLE_DIALOG``: Dialog system with DialogLook
+- ``ENABLE_CMDLINE``: Command-line argument parsing
+- ``ENABLE_PROFILE``: Profile/configuration file support
+- ``ENABLE_MAIN_WINDOW``: Main window with event loop
+- ``ENABLE_SCREEN``: Screen initialization
+- ``ENABLE_BUTTON_LOOK``: Button rendering support
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunAnalysis FLARM test/data/01lz1hq1.igc
+
+Pattern 3: Simple Command-Line Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Simple utilities that don't need flight data or GUI can use direct command-line
+parsing.
+
+**Example**: ``RunDeviceDriver.cpp``, ``RunMD5.cpp``, ``RunSHA256.cpp``
+
+**Structure**:
+
+.. code-block:: cpp
+
+   #include "system/Args.hpp"
+   
+   int main(int argc, char **argv)
+   {
+     Args args(argc, argv, "USAGE");
+     // Parse arguments
+     args.ExpectEnd();
+     
+     // Process input (stdin, files, etc.)
+     return EXIT_SUCCESS;
+   }
+
+**Usage**:
+
+.. code-block:: bash
+
+   echo "$GPRMC,..." | ./output/UNIX/bin/RunDeviceDriver FLARM
+
+Pattern 4: Device Interaction Utilities
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Utilities that interact with hardware devices use ``DebugPort`` and device
+drivers directly.
+
+**Example**: ``RunFlarmUtils.cpp``, ``RunLX1600Utils.cpp``, ``RunVegaSettings.cpp``
+
+**Structure**:
+
+.. code-block:: cpp
+
+   #include "test/src/DebugPort.hpp"
+   #include "Device/Driver.hpp"
+   
+   int main(int argc, char **argv)
+   {
+     Args args(argc, argv, "PORT BAUD");
+     DebugPort debug_port(args);
+     args.ExpectEnd();
+     
+     ScopeGlobalAsioThread global_asio_thread;
+     NullDataHandler handler;
+     auto port = debug_port.Open(*asio_thread, *global_cares_channel, handler);
+     
+     ConsoleOperationEnvironment env;
+     if (!port->WaitConnected(env)) {
+       return EXIT_FAILURE;
+     }
+     
+     // Interact with device
+     return EXIT_SUCCESS;
+   }
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunFlarmUtils /dev/ttyUSB0 57600
+
+Using DebugReplay
+-----------------
+
+``DebugReplay`` is the primary mechanism for processing flight data in Run*
+utilities. It provides:
+
+- **Automatic format detection**: IGC, NMEA, or device-specific formats
+- **Incremental processing**: ``Next()`` advances through the flight data
+- **Computed data**: ``Basic()`` returns processed ``MoreData``
+- **Calculated data**: ``Calculated()`` returns ``DerivedInfo``
+- **State management**: Tracks previous states for calculations
+
+**Basic usage**:
+
+.. code-block:: cpp
+
+   DebugReplay *replay = CreateDebugReplay(args);
+   if (replay == NULL)
+     return EXIT_FAILURE;
+   
+   while (replay->Next()) {
+     const MoreData &basic = replay->Basic();
+     const DerivedInfo &calculated = replay->Calculated();
+     
+     // Access GPS data
+     if (basic.location_available) {
+       GeoPoint location = basic.location;
+       // ...
+     }
+     
+     // Access calculated values
+     if (calculated.estimated_wind_available) {
+       SpeedVector wind = calculated.estimated_wind;
+       // ...
+     }
+   }
+   
+   delete replay;
+
+**Available data**:
+
+- ``replay->Basic()``: Current ``MoreData`` (GPS, sensors, etc.)
+- ``replay->LastBasic()``: Previous ``MoreData`` (for calculations)
+- ``replay->Calculated()``: Current ``DerivedInfo`` (wind, task stats, etc.)
+- ``replay->SetCalculated()``: Mutable reference for updating calculations
+- ``replay->SetFlyingComputer()``: Access to ``FlyingComputer`` for flight state
+
+**Setting QNH**:
+
+.. code-block:: cpp
+
+   replay->SetQNH(AtmosphericPressure::Standard());
+   // Or from user input:
+   replay->SetQNH(AtmosphericPressure::HectoPascal(1013.25));
+
+Common Utility Examples
+-----------------------
+
+RunTask
+~~~~~~~
+
+Tests task calculation with flight data.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunTask task.xct test/data/01lz1hq1.igc
+
+**What it does**:
+
+- Loads a task file (``.xct``, ``.tsk``, ``.cup``)
+- Replays flight data through the task
+- Reports task start, finish, and statistics
+
+RunWindComputer
+~~~~~~~~~~~~~~~
+
+Tests wind estimation algorithms.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunWindComputer FLARM test/data/01lz1hq1.igc
+
+**What it does**:
+
+- Processes flight data through wind computer
+- Outputs wind estimates over time
+- Useful for debugging wind calculation algorithms
+
+RunDeviceDriver
+~~~~~~~~~~~~~~~
+
+Tests device driver NMEA parsing.
+
+**Usage**:
+
+.. code-block:: bash
+
+   echo "$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A" | \
+     ./output/UNIX/bin/RunDeviceDriver FLARM
+
+**What it does**:
+
+- Parses NMEA sentences through device driver
+- Outputs parsed data fields
+- Useful for testing driver parsing logic
+
+RunAnalysis
+~~~~~~~~~~~
+
+Opens the analysis dialog with flight data.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunAnalysis FLARM test/data/01lz1hq1.igc
+
+**What it does**:
+
+- Loads flight data
+- Opens the analysis dialog window
+- Allows interactive exploration of flight data
+
+RunFlarmUtils
+~~~~~~~~~~~~~
+
+Interactive tool for configuring FLARM devices.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunFlarmUtils /dev/ttyUSB0 57600
+
+**What it does**:
+
+- Connects to FLARM device
+- Provides interactive menu for:
+  - Changing pilot/co-pilot names
+  - Setting competition ID/class
+  - Configuring stealth mode
+  - Adjusting range and baud rate
+
+FeedNMEA
+~~~~~~~~
+
+Feeds NMEA sentences from stdin to a serial port, TCP connection, or UDP
+socket. Useful for testing XCSoar with simulated GPS data, especially when
+running XCSoar under WINE or testing network-based device connections.
+
+**Usage**:
+
+Serial port:
+
+.. code-block:: bash
+
+   cat test.nmea | ./output/UNIX/bin/FeedNMEA /dev/ttyUSB0 57600
+   # Or with a pseudo-TTY for WINE:
+   cat test.nmea | ./output/UNIX/bin/FeedNMEA /tmp/nmea 57600
+
+TCP server (listener):
+
+.. code-block:: bash
+
+   cat test.nmea | ./output/UNIX/bin/FeedNMEA tcp 4353
+
+TCP client (connects to server):
+
+.. code-block:: bash
+
+   cat test.nmea | ./output/UNIX/bin/FeedNMEA tcp_client 192.168.1.100 4353
+
+UDP listener:
+
+.. code-block:: bash
+
+   cat test.nmea | ./output/UNIX/bin/FeedNMEA udp 4353
+
+**What it does**:
+
+- Reads NMEA sentences from stdin (one per line)
+- Writes them to the specified port (serial, TCP, or UDP)
+- Automatically sleeps for 1 second when timestamps change (for realistic timing)
+- Echoes received data to stdout (for bidirectional communication testing)
+
+**Port Types**:
+
+- **Serial ports**: ``/dev/ttyUSB0``, ``/dev/ttyACM0``, ``COM1`` (Windows), etc.
+- **TCP listener**: ``tcp <port>`` - Listens for incoming TCP connections
+- **TCP client**: ``tcp_client <ip_address> <port>`` - Connects to a TCP server
+- **UDP listener**: ``udp <port>`` - Listens for UDP datagrams
+- **Pseudo-TTY**: ``pty <path>`` - Creates a pseudo-terminal
+
+**TCP Server Mode**:
+
+TCP listener mode allows XCSoar (or other clients) to connect and receive NMEA
+data over the network:
+
+.. code-block:: bash
+
+   # Terminal 1: Start FeedNMEA as TCP server
+   cat flight.nmea | ./output/UNIX/bin/FeedNMEA tcp 4353
+   
+   # Terminal 2: XCSoar connects to localhost:4353 to receive NMEA data
+   # Configure XCSoar device port as "TCP Client" with host "localhost" and port 4353
+
+**TCP Client Mode**:
+
+TCP client mode connects to a remote server and sends NMEA data:
+
+.. code-block:: bash
+
+   # Connect to remote NMEA server and feed data
+   cat flight.nmea | ./output/UNIX/bin/FeedNMEA tcp_client 192.168.1.100 4353
+
+This is useful for:
+- Sending NMEA data to a remote XCSoar instance
+- Testing network-based device connections
+- Integrating with network GPS servers
+
+**WINE Integration**:
+
+FeedNMEA is particularly useful for testing XCSoar under WINE:
+
+1. Create a pseudo-TTY: ``./output/UNIX/bin/FeedNMEA /tmp/nmea 57600``
+2. Symlink WINE COM port: ``ln -s /tmp/nmea ~/.wine/dosdevices/com1``
+3. Configure XCSoar to use COM1
+4. Feed NMEA data: ``cat flight.nmea | ./output/UNIX/bin/FeedNMEA /tmp/nmea 57600``
+
+**Example**:
+
+.. code-block:: bash
+
+   # Convert IGC to NMEA and feed to serial port
+   ./output/UNIX/bin/IGC2NMEA test/data/01lz1hq1.igc /tmp/flight.nmea
+   cat /tmp/flight.nmea | ./output/UNIX/bin/FeedNMEA /dev/ttyUSB0 57600
+   
+   # Or feed to TCP server for network testing
+   cat /tmp/flight.nmea | ./output/UNIX/bin/FeedNMEA tcp 4353
+
+EmulateDevice
+~~~~~~~~~~~~~
+
+Emulates device protocols to test XCSoar's device communication without
+actual hardware. Supports Vega, FLARM, and ATR833 devices.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/EmulateDevice FLARM /dev/ttyUSB0 57600
+   ./output/UNIX/bin/EmulateDevice Vega /tmp/nmea 57600
+   ./output/UNIX/bin/EmulateDevice ATR833 /dev/ttyUSB0 9600
+
+**What it does**:
+
+- Creates a device emulator that responds to XCSoar commands
+- Implements device-specific protocols:
+  - **FLARM**: Responds to configuration commands (PFLAC), sends traffic data
+  - **Vega**: Emulates variometer with settings commands
+  - **ATR833**: Emulates radio transponder with frequency commands
+- Runs until the port connection fails
+- Useful for testing device drivers without physical hardware
+
+**Supported Devices**:
+
+- ``FLARM``: FLARM collision avoidance system
+- ``Vega``: Vega variometer
+- ``ATR833``: ATR833 radio transponder
+
+**Use Cases**:
+
+- Testing device driver implementations
+- Debugging device communication protocols
+- Developing new device drivers
+- Automated testing of device interactions
+
+**Example Workflow**:
+
+.. code-block:: bash
+
+   # Terminal 1: Start device emulator
+   ./output/UNIX/bin/EmulateDevice FLARM /tmp/flarm 57600
+   
+   # Terminal 2: Connect XCSoar to /tmp/flarm and test FLARM features
+   # XCSoar will send commands, emulator will respond appropriately
+
+Data Conversion Utilities
+--------------------------
+
+IGC2NMEA
+~~~~~~~~
+
+Converts IGC flight files to NMEA format. Useful for testing device drivers
+or feeding NMEA data to other tools.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/IGC2NMEA test/data/01lz1hq1.igc output.nmea
+
+**What it does**:
+
+- Reads IGC file using DebugReplay
+- Generates NMEA sentences (GPRMC, GPGGA, PGRMZ)
+- Writes NMEA output to file
+- Useful for converting flight data to NMEA format for testing
+
+**Example**:
+
+.. code-block:: bash
+
+   # Convert IGC to NMEA, then feed to device
+   ./output/UNIX/bin/IGC2NMEA flight.igc flight.nmea
+   cat flight.nmea | ./output/UNIX/bin/FeedNMEA /dev/ttyUSB0 57600
+
+lxn2igc
+~~~~~~~
+
+Converts LX Navigation (LXN) binary files to IGC format.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/lxn2igc flight.lxn > flight.igc
+
+**What it does**:
+
+- Reads LX Navigation binary format (``.lxn`` files)
+- Converts to standard IGC format
+- Outputs to stdout
+- Useful for converting old LX device recordings
+
+**Example**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/lxn2igc test/data/lxn_to_igc/18BF14K1.FIL > converted.igc
+
+Flight Analysis Utilities
+-------------------------
+
+AnalyseFlight
+~~~~~~~~~~~~~
+
+Analyzes flight data and outputs JSON with flight phases, takeoff/landing
+times, and contest results.
+
+**Usage**:
+
+.. code-block:: bash
+
+   # For IGC files (driver argument required but ignored):
+   ./output/UNIX/bin/AnalyseFlight FLARM test/data/01lz1hq1.igc
+   
+   # For NMEA files (driver required):
+   ./output/UNIX/bin/AnalyseFlight FLARM test/data/file.nmea
+   
+   # With options:
+   ./output/UNIX/bin/AnalyseFlight --full-points=1024 FLARM test/data/01lz1hq1.igc
+
+**What it does**:
+
+- Processes flight data through flight phase detector
+- Detects takeoff, release, and landing events
+- Calculates contest results (OLC, FAI, etc.)
+- Outputs JSON with flight statistics
+- Useful for automated flight analysis
+
+**Output includes**:
+
+- Takeoff/release/landing times and locations
+- Flight phases (circling, cruise, etc.)
+- Contest scores
+- Circling statistics
+
+**Note**: Available on UNIX/PC platforms only (not Android).
+
+Device and Port Utilities
+--------------------------
+
+EnumeratePorts
+~~~~~~~~~~~~~~
+
+Lists all available serial/TTY ports on the system. Useful for debugging
+device connection issues.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/EnumeratePorts
+
+**What it does**:
+
+- Scans system for available TTY/serial ports
+- Lists port paths (e.g., ``/dev/ttyUSB0``, ``/dev/ttyACM0``)
+- Helps identify which port a device is connected to
+
+**Example output**:
+
+.. code-block:: bash
+
+   /dev/ttyUSB0
+   /dev/ttyUSB1
+   /dev/ttyACM0
+
+**Note**: Only available on POSIX systems (Linux, macOS, not Windows).
+
+CAI302Tool
+~~~~~~~~~~
+
+Interactive tool for CAI302 flight computer devices. Allows reading device
+information, waypoints, and flight data.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/CAI302Tool /dev/ttyUSB0 9600
+
+**What it does**:
+
+- Connects to CAI302 device
+- Reads device information (ID, firmware version)
+- Can read waypoints and flight data
+- Useful for debugging CAI302 device communication
+
+**Note**: Requires CAI302 device connected via serial port.
+
+Scripting Utilities
+--------------------
+
+RunLua
+~~~~~~
+
+Runs Lua scripts with XCSoar Lua bindings. Useful for testing Lua scripts
+or developing Lua-based features.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunLua script.lua
+
+**What it does**:
+
+- Initializes Lua state with XCSoar bindings
+- Loads and executes Lua script
+- Provides access to:
+  - Geo functions (coordinate calculations)
+  - HTTP functions (if HTTP support enabled)
+  - Log functions
+  - Custom ``alert()`` function for output
+
+**Available bindings**:
+
+- ``geo.*``: Geographic calculations
+- ``http.*``: HTTP requests (if enabled)
+- ``log.*``: Logging functions
+- ``alert()``: Print to stderr
+
+**Example script**:
+
+.. code-block:: lua
+
+   local point1 = geo.Point(52.0, 13.0)
+   local point2 = geo.Point(52.1, 13.1)
+   local distance = geo.Distance(point1, point2)
+   alert("Distance: " .. distance)
+
+**Note**: Requires Lua support to be enabled in build (``LUA=y``).
+
+Renderer Utilities
+-------------------
+
+These utilities test and demonstrate various rendering components used in XCSoar's
+UI. They provide interactive visual testing of renderers.
+
+RunRenderOZ
+~~~~~~~~~~~
+
+Tests observation zone (OZ) rendering for different task zone types.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunRenderOZ
+
+**What it does**:
+
+- Displays a window with a list of observation zone types on the left
+- Renders the selected zone type on the right
+- Supports all OZ types: Line, Cylinder, Sector, FAI Sector, Keyhole, etc.
+- Interactive: click on zone type to see it rendered
+- Useful for testing OZ rendering and debugging zone shapes
+
+**Supported zone types**:
+
+- Line, Cylinder, MAT Cylinder
+- Sector, FAI Sector, Annular Sector
+- DAeC Keyhole, BGA Fixed Course, BGA Enhanced Option
+- BGA Start, Symmetric Quadrant, Custom Keyhole
+
+RunChartRenderer
+~~~~~~~~~~~~~~~~
+
+Tests chart/graph rendering capabilities.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunChartRenderer
+
+**What it does**:
+
+- Displays a window with chart types on the left
+- Renders the selected chart on the right
+- Demonstrates line charts, grids, labels
+- Interactive: select chart type from list
+- Useful for testing chart rendering and data visualization
+
+RunWindArrowRenderer
+~~~~~~~~~~~~~~~~~~~~
+
+Tests wind arrow rendering with animated wind display.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunWindArrowRenderer
+
+**What it does**:
+
+- Displays animated wind arrow in center of window
+- Wind direction and speed change automatically
+- Demonstrates wind arrow rendering styles
+- Useful for testing wind visualization
+
+RunHorizonRenderer
+~~~~~~~~~~~~~~~~~~
+
+Tests artificial horizon rendering with animated attitude display.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunHorizonRenderer
+
+**What it does**:
+
+- Displays animated artificial horizon
+- Bank and pitch angles change automatically
+- Demonstrates horizon rendering with attitude indicators
+- Useful for testing attitude visualization
+
+RunFinalGlideBarRenderer
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests final glide bar rendering with animated altitude difference.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunFinalGlideBarRenderer
+
+**What it does**:
+
+- Displays final glide bar with altitude difference
+- Shows MC and MC0 solutions
+- Animated: altitude difference changes over time
+- Useful for testing final glide calculations and rendering
+
+RunFAITriangleSectorRenderer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests FAI triangle sector rendering with interactive point dragging.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunFAITriangleSectorRenderer
+
+**What it does**:
+
+- Displays FAI triangle sector between two points
+- Interactive: drag points A and B to change sector
+- Shows sector boundary and area
+- Useful for testing FAI triangle calculations and rendering
+
+RunFlightListRenderer
+~~~~~~~~~~~~~~~~~~~~~
+
+Tests flight list rendering from a flight log file.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunFlightListRenderer flights.log
+
+**What it does**:
+
+- Reads flight information from log file
+- Renders flight list in a window
+- Displays flight dates, times, and statistics
+- Useful for testing flight list UI rendering
+
+**Note**: Requires a flight log file (``flights.log``) as argument.
+
+Creating a New Run* Utility
+----------------------------
+
+To create a new Run* utility:
+
+1. **Create the source file** in ``test/src/RunYourUtility.cpp``:
+
+.. code-block:: cpp
+
+   // SPDX-License-Identifier: GPL-2.0-or-later
+   // Copyright The XCSoar Project
+   
+   #include "system/Args.hpp"
+   #include "DebugReplay.hpp"
+   
+   #include <stdio.h>
+   #include <stdlib.h>
+   
+   int main(int argc, char **argv)
+   {
+     Args args(argc, argv, "USAGE");
+     DebugReplay *replay = CreateDebugReplay(args);
+     if (replay == NULL)
+       return EXIT_FAILURE;
+     
+     args.ExpectEnd();
+     
+     // Your processing logic here
+     
+     delete replay;
+     return EXIT_SUCCESS;
+   }
+
+2. **Add to build system** in ``build/test.mk``:
+
+Find the ``DEBUG_PROGRAM_NAMES`` list and add your utility:
+
+.. code-block:: makefile
+
+   DEBUG_PROGRAM_NAMES += \
+     RunYourUtility
+
+Then add build rules:
+
+.. code-block:: makefile
+
+   RUN_YOUR_UTILITY_SOURCES = \
+     $(DEBUG_REPLAY_SOURCES) \
+     $(TEST_SRC_DIR)/RunYourUtility.cpp
+   RUN_YOUR_UTILITY_DEPENDS = $(DEBUG_REPLAY_DEPENDS) GEO MATH UTIL
+   $(eval $(call link-program,RunYourUtility,RUN_YOUR_UTILITY))
+
+3. **Build and test**:
+
+.. code-block:: bash
+
+   make output/UNIX/bin/RunYourUtility
+   ./output/UNIX/bin/RunYourUtility FLARM test/data/01lz1hq1.igc
+
+Dependencies
+------------
+
+Common dependencies for Run* utilities:
+
+- ``DEBUG_REPLAY_SOURCES``: For DebugReplay-based utilities
+- ``DEBUG_REPLAY_DEPENDS``: Standard dependencies (GEO, MATH, UTIL, etc.)
+- ``TASK``: For task-related utilities
+- ``WAYPOINT``: For waypoint-related utilities
+- ``AIRSPACE``: For airspace-related utilities
+- ``LOOK``: For GUI utilities
+- ``DIALOG``: For dialog-based utilities
+
+Check existing utilities in ``build/test.mk`` for examples of dependency
+patterns.
+
+Additional Resources
+---------------------
+
+- ``test/src/DebugReplay.hpp``: DebugReplay API documentation
+- ``test/src/Main.hpp``: GUI utility boilerplate
+- ``test/src/DebugPort.hpp``: Device port utilities
+- ``test/data/``: Sample flight data files for testing
+- ``build/test.mk``: Build system definitions for all utilities
+


### PR DESCRIPTION
Add comprehensive developer documentation for the Run* utilities and other test/debug tools in the test suite.

## Changes

- New documentation file: `doc/test_debug_utilities.rst`
- Updated `doc/index.rst` to include the new documentation

## Content

The documentation covers:

- Overview of test utilities and their purposes
- Common patterns (DebugReplay, Main.hpp, command-line, device interaction)
- Detailed usage examples for major utilities:
  - RunTask, RunAnalysis, RunDeviceDriver, RunFlarmUtils
  - FeedNMEA (including TCP/UDP support)
  - EmulateDevice (FLARM, Vega, ATR833)
  - Data conversion utilities (IGC2NMEA, lxn2igc)
  - Flight analysis utilities (AnalyseFlight)
  - Device and port utilities (EnumeratePorts, CAI302Tool)
  - Scripting utilities (RunLua)
- Guide for creating new utilities
- Troubleshooting section

The documentation uses `output/UNIX/bin/` as the default path with notes about other platforms and build target flavors (WAYLAND, OPT, etc. all build to output/UNIX/bin/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for test and debug utilities covering build/workflow patterns, usage examples, and steps to create new utilities.
  * Added a new Git tips & tricks guide with workflows, commands, and best practices.
  * Updated the documentation index to include both new guides so they appear in the main table of contents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->