### PR TITLE
Terrain/RasterRenderer: Fix terrain shading at highest zoom level

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -43,6 +43,7 @@ Version 7.44 - not yet released
   - BigTrafficWidget: Save/Restore FLARM radar zoom on page change
   - BigTrafficWidget: zoom range to 5km when opening big radar via the FlarmGauge
   - terrain: added 2 new terrain ramps for use in very flat countries
+  - terrain: fix terrain shading at highest zoom level and improve DPI scaling #440
   - add head wind component to V GND Infobox #1439
   - add V task leg Infobox #1767
   - PEV start wait/window times now have second accuraccy #1099


### PR DESCRIPTION
Use a large fixed area (25 pixels) for slope calculation when quantisation_effective exceeds 25, instead of disabling terrain shading completely. This ensures terrain shading works at the highest zoom level.

Also improve DPI scaling by using Layout::FastScale() for quantisation caps to ensure consistent behavior across different screen resolutions and DPI settings.

Fixes #440

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terrain shading artifacts at the highest zoom level.

* **Improvements**
  * Smoother shading transitions across near, mid, and far zooms for more consistent visuals.
  * Improved DPI scaling for high‑DPI displays.

* **Performance**
  * Reduced rendering detail at very far zooms to lower unnecessary rendering cost.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->