### PR TITLE
.readthedocs.yaml: Add explicit Sphinx configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,10 @@ build:
   tools:
     python: "latest"
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: doc/conf.py
+
 python:
   install:
     - requirements: doc/requirements.txt


### PR DESCRIPTION
Read the Docs is deprecating automatic detection of Sphinx/MkDocs configuration files. Starting January 20, 2025, projects must explicitly specify the configuration file path in .readthedocs.yaml.

This change adds the required `sphinx.configuration` key pointing to `doc/conf.py` to ensure builds continue to work after the deprecation.

Reference: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation build configuration to explicitly specify the Sphinx configuration path for more reliable documentation builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->