### PR TITLE
Input: Add MacCready adjustment mode

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1215,9 +1215,8 @@ location=17
 mode=RemoteStick
 type=key
 data=0
-event=MacCready auto show
-event=MacCready auto toggle
-label=$(CheckAutoMc)MC\n$(MacCreadyToggleActionName)
+event=Mode mc
+label=MacCready
 location=18
 
 mode=RemoteStick


### PR DESCRIPTION
Cherry-picked commit 13306366fd to add MacCready adjustment mode to quickmenu.

This commit adds:
- A dedicated MacCready (mc) mode that allows continuous adjustment of MacCready settings without repeatedly entering the quick menu
- MC mode controls:
  - UP/DOWN: Increase/decrease MacCready value (shows value after change)
  - RETURN: Toggle between auto and manual MacCready mode
  - ESCAPE: Exit back to default mode
- Entry point: Select "MacCready" from quick menu (location 18)

This provides a much more efficient way to adjust MacCready during flight, similar to how Pan mode works.