### PR TITLE
Device/Driver/LoEFGREN: Fix temperature scale parsing

### DIFF
--- a/src/Device/Driver/LoEFGREN.cpp
+++ b/src/Device/Driver/LoEFGREN.cpp
@@ -22,11 +22,11 @@ static bool
 PLOF(NMEAInputLine &line, NMEAInfo &info)
 {
   /* $PLOF,<TE compensated climb/sink in cm/s>,<indicated airspeed km/h>,
-   * <temperature in deg c>*
+   * <temperature in deg c x 10>*
    *
    * TE compensated climb/sink = variometer in cm/s (up positive)
    * indicated airspeed = indicated airspeed in km/h
-   * temperature = temperature in degrees Celsius
+   * temperature = temperature in degrees Celsius x 10 (e.g., 15.2°C = 152)
    *
    * Protocol documentation:
    * https://www.lofgren-electronics.fr/Lofgren%20Variometer%20User%20Manual%20EN%20.pdf
@@ -44,9 +44,9 @@ PLOF(NMEAInputLine &line, NMEAInfo &info)
     info.ProvideIndicatedAirspeed(Units::ToSysUnit(value,
                                                     Unit::KILOMETER_PER_HOUR));
 
-  // Parse temperature (°C)
+  // Parse temperature (°C x 10 -> °C)
   if (line.ReadChecked(value)) {
-    info.temperature = Temperature::FromCelsius(value);
+    info.temperature = Temperature::FromCelsius(value / 10);
     info.temperature_available = true;
   }
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -768,7 +768,7 @@ TestLoEFGREN()
   nmea_info.clock = TimeStamp{FloatDuration{1}};
 
   // Test positive vario (climb)
-  ok1(device->ParseNMEA("$PLOF,250,80,15*02", nmea_info));
+  ok1(device->ParseNMEA("$PLOF,250,80,150*32", nmea_info));
   ok1(nmea_info.total_energy_vario_available);
   ok1(equals(nmea_info.total_energy_vario, 2.5));
   ok1(nmea_info.airspeed_available);
@@ -781,7 +781,7 @@ TestLoEFGREN()
   // Test negative vario (sink) and negative temperature
   nmea_info.Reset();
   nmea_info.clock = TimeStamp{FloatDuration{2}};
-  ok1(device->ParseNMEA("$PLOF,-150,60,-5*3E", nmea_info));
+  ok1(device->ParseNMEA("$PLOF,-150,60,-50*0E", nmea_info));
   ok1(equals(nmea_info.total_energy_vario, -1.5));
   ok1(equals(nmea_info.temperature.ToKelvin(),
              Temperature::FromCelsius(-5).ToKelvin()));
@@ -790,7 +790,7 @@ TestLoEFGREN()
   nmea_info.Reset();
   nmea_info.clock = TimeStamp{FloatDuration{3}};
   ok1(!device->ParseNMEA("$VARIO,999.98,-12*66", nmea_info));
-  ok1(!device->ParseNMEA("$PLOF,250,80,15*FF", nmea_info));
+  ok1(!device->ParseNMEA("$PLOF,250,80,150*FF", nmea_info));
   ok1(!nmea_info.total_energy_vario_available);
 
   delete device;


### PR DESCRIPTION
The LoEFGREN variometer protocol sends temperature as (temp deg C) x 10, so 15.2°C is transmitted as 152. The driver was incorrectly parsing this as 152°C instead of dividing by 10 to get 15.2°C.

This fix divides the received value by 10 before converting to Temperature, matching the protocol specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected temperature interpretation in PLOF NMEA sentence parsing so reported temperatures are accurate (now handles temperature encoded as °C × 10).

* **Tests**
  * Updated test cases to match the revised PLOF payload encoding and ensure consistent vario and temperature parsing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->