### PR TITLE
debian/control: Add ca-certificates dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Homepage: https://xcsoar.org/
 Package: xcsoar
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
+ ca-certificates,
  fonts-dejavu | fonts-roboto | fonts-droid | ttf-dejavu
 Suggests: vali-xcs
 Description: tactical glide computer


### PR DESCRIPTION
The xcsoar package uses libcurl for HTTPS connections (weather downloads, tracking services, etc.), but libcurl4 only Recommends ca-certificates, not Depends on it. This means ca-certificates may not be installed, causing HTTPS connections to fail.

Add ca-certificates as an explicit dependency to ensure SSL certificate verification works properly.

This ensures that users who install the xcsoar package will have the necessary CA certificates for HTTPS functionality to work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ca-certificates as a package dependency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->