### PR TITLE
doc/manual: Document XCSoar task and waypoint file formats

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,9 @@ Version 7.44 - not yet released
   - remove FFVV NetCoupe
   - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
   - update OLC League calculation to latest ruleset
+  - Make the “Predict wind drift” setting affect arrival altitudes shown in
+    waypoint labels on the map – as it affects arrival altitudes shown
+    everywhere else.
 * tracking
   - xcsoar-cloud-service: rebuild service, new domain cloud.xcsoar.org
 * data files


### PR DESCRIPTION
Add comprehensive documentation for XCSoar's task (.tsk) and waypoint (.xcw) file formats.

## Changes

### Waypoint Format Documentation
- Added detailed documentation for WinPilot/Cambridge format (.dat, .xcw)
- Documented all 7 fields: Index, Latitude, Longitude, Altitude, Flags, Name, Description
- Explained coordinate formats (DD:MM.mmm and DD:MM:SS)
- Listed all waypoint flags (A, T, L, H, S, F, R, W) with meanings
- Added example file
- Noted that .xcw extension is used in map database files
- Added CompeGPS to supported formats list

### Task Format Documentation
- Expanded Tasks section with complete XML format documentation
- Documented task structure and root element
- Listed all 9 task types (RT, AAT, MAT, FAI variants, etc.)
- Documented all 13 task settings attributes
- Documented task point structure (Start, OptionalStart, Turn, Area, Finish)
- Documented waypoint element structure within task points
- Documented all 12 observation zone types with their specific attributes
- Added complete example XML task file

This addresses the under-documented file formats that were identified in the codebase review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Predict wind drift" setting now affects arrival altitudes displayed in waypoint labels on the map, ensuring consistency across all altitude displays.

* **Documentation**
  * Added support information for CompeGPS waypoint format.
  * Expanded WinPilot/Cambridge waypoint format documentation (.dat, .xcw files).
  * Added XCSoar task file format documentation (.tsk files).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->