### PR TITLE
default.xci: Inverse sequence in mode=mc

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -170,20 +170,20 @@ location=7
 mode=mc
 type=key
 data=UP
-event=MacCready up
 event=MacCready show
+event=MacCready up
 
 mode=mc
 type=key
 data=DOWN
-event=MacCready down
 event=MacCready show
+event=MacCready down
 
 mode=mc
 type=key
 data=RETURN
-event=MacCready auto toggle
 event=MacCready auto show
+event=MacCready auto toggle
 
 mode=mc
 type=key
@@ -201,24 +201,24 @@ location=1
 mode=mc
 type=key
 data=0
-event=MacCready auto toggle
 event=MacCready auto show
-label=Auto/Man\n(RETURN)
+event=MacCready auto toggle
+label=$(CheckAutoMc)MC $(MacCreadyToggleActionName)\n(RETURN)
 location=6
 
 mode=mc
 type=key
 data=0
-event=MacCready up
 event=MacCready show
+event=MacCready up
 label=MC+\n(UP)
 location=7
 
 mode=mc
 type=key
 data=0
-event=MacCready down
 event=MacCready show
+event=MacCready down
 label=MC-\n(DOWN)
 location=8
 


### PR DESCRIPTION
With PR 2090, an new menu was introduced to improve MC adjustments, but actions and status messages were not in line.

The PR corrects the code sequences in default.xci, and improves the label of the toggle button to show the command to perform.

Issue #2098 will be solved with this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Streamlined MacCready mode stick control bindings for UP, DOWN, and RETURN inputs to enhance interface responsiveness and reduce interaction complexity for an improved user experience.
  * Updated the on-screen auto toggle button with dynamic labeling that continuously displays the current operational status and provides clear visual feedback to the user.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->