### PR TITLE
Canvas/MemoryCanvas: Fix buffer resize on Window resize

### DIFF
--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <atomic>
+
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif
@@ -219,6 +221,27 @@ public:
 
 #if defined(ENABLE_SDL) && defined(USE_MEMORY_CANVAS)
   void OnResize(PixelSize new_size) noexcept;
+
+  /**
+   * Request a resize operation, called from event thread.
+   * This does not immediately reallocate
+   * the buffer, but flags it for processing in the draw thread.
+   */
+  void RequestResize(PixelSize new_size) noexcept;
+
+  /**
+   * Process any pending resize request. Should be called from the
+   * draw thread before locking the canvas.
+   * @return true if a resize was processed
+   */
+  bool ProcessPendingResize() noexcept;
+
+private:
+  std::atomic<bool> resize_pending{false};
+  std::atomic<unsigned> pending_width{0};
+  std::atomic<unsigned> pending_height{0};
+
+public:
 #endif
 
 #if defined(USE_MEMORY_CANVAS) && (defined(GREYSCALE) || !defined(ENABLE_SDL))

--- a/src/ui/window/BufferWindow.hpp
+++ b/src/ui/window/BufferWindow.hpp
@@ -6,6 +6,10 @@
 #include "PaintWindow.hpp"
 #include "ui/canvas/BufferCanvas.hpp"
 
+#ifdef USE_MEMORY_CANVAS
+#include <atomic>
+#endif
+
 /**
  * A #PaintWindow with buffered painting, to avoid flickering.
  */
@@ -17,6 +21,18 @@ class BufferWindow : public PaintWindow {
    * OnPaintBuffer()?
    */
   bool dirty;
+
+#ifdef USE_MEMORY_CANVAS
+  /**
+   * Is there a pending resize request?
+   * If true, the buffer will be resized during the next OnPaint() call.
+   * Thread-safe atomic flag.
+   */
+  std::atomic<bool> resize_pending{false};
+  
+  std::atomic<unsigned> pending_width{0};
+  std::atomic<unsigned> pending_height{0};
+#endif
 
 public:
   void Invalidate() noexcept

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -146,6 +146,11 @@ TopWindow::Expose() noexcept
   const ScopeLockCPU cpu;
 #endif
 
+#if defined(ENABLE_SDL) && defined(USE_MEMORY_CANVAS)
+  // Process any pending resize BEFORE locking the canvas
+  screen->ProcessPendingResize();
+#endif
+
   if (auto canvas = screen->Lock(); canvas.IsDefined()) {
     OnPaint(canvas);
 

--- a/src/ui/window/sdl/TopWindow.cpp
+++ b/src/ui/window/sdl/TopWindow.cpp
@@ -266,7 +266,9 @@ TopWindow::OnResize(PixelSize new_size) noexcept
   ContainerWindow::OnResize(new_size);
 
 #ifdef USE_MEMORY_CANVAS
-  screen->OnResize(new_size);
+  // Request resize instead of doing it immediately
+  // The actual resize will happen in the draw thread (Expose)
+  screen->RequestResize(new_size);
 #endif
 }
 

--- a/src/ui/window/wayland/TopWindow.cpp
+++ b/src/ui/window/wayland/TopWindow.cpp
@@ -308,7 +308,10 @@ TopWindow::OnResize(PixelSize new_size) noexcept
   ContainerWindow::OnResize(new_size);
 
 #ifdef USE_MEMORY_CANVAS
-  screen->OnResize(new_size);
+  // Request resize instead of doing it immediately
+  // The actual resize will happen in the draw thread (Expose)
+  if (screen != nullptr)
+    screen->RequestResize(new_size);
 #endif
 }
 


### PR DESCRIPTION
This tries to fix a segmentation fault crash that happens when resizing the application window with software rendering (OPENGL=n). Found on UNIX target. This fix seems to solve the issue in practice. 

Re-wrote the PR, now it uses the vent queue to defer resize events that come in from the vent queue, to be processed in the beginning of the actual draw loop in the drawing thread.

Uses atomic read/write in the flag logic to make it safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented thread-safe asynchronous canvas resizing to improve stability and prevent rendering conflicts during window resize operations.

* **Bug Fixes**
  * Fixed an arithmetic error in greyscale image rendering calculations.

* **Performance**
  * Optimized window resize handling by deferring operations to the rendering cycle for smoother performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->