### PR TITLE
Downloads/Maps,Weather: Store maps and weather files in subdirectories

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -494,6 +494,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Profile/FlarmProfile.cpp \
 	\
 	$(SRC)/Repository/FileRepository.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Repository/Parser.cpp \
 	\
 	$(SRC)/Job/Thread.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -435,6 +435,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Language/LanguageGlue.cpp \
 	$(SRC)/Language/Table.cpp \
 	$(SRC)/LocalPath.cpp \
+	$(SRC)/DataLayoutMigration.cpp \
 	$(SRC)/UIActions.cpp \
 	$(SRC)/Interface.cpp \
 	$(SRC)/ActionInterface.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1167,6 +1167,7 @@ $(eval $(call link-program,RunLiveTrack24,RUN_LIVETRACK24))
 
 RUN_REPOSITORY_PARSER_SOURCES = \
 	$(SRC)/Repository/FileRepository.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Repository/Parser.cpp \
 	$(TEST_SRC_DIR)/RunRepositoryParser.cpp
 RUN_REPOSITORY_PARSER_DEPENDS = LIBNET IO OS UTIL
@@ -1902,6 +1903,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Profile/TerrainConfig.cpp \
 	$(SRC)/Profile/Screen.cpp \
 	$(SRC)/Profile/FlarmProfile.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Waypoint/HomeGlue.cpp \
 	$(SRC)/Waypoint/LastUsed.cpp \
 	$(SRC)/Waypoint/WaypointGlue.cpp \
@@ -2311,6 +2313,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/MapSettings.cpp \
 	$(SRC)/Blackboard/InterfaceBlackboard.cpp \
 	$(SRC)/Engine/Navigation/TraceHistory.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Airspace/ActivePredicate.cpp \
 	$(SRC)/Airspace/ProtectedAirspaceWarningManager.cpp \
 	$(SRC)/Airspace/AirspaceParser.cpp \
@@ -2379,6 +2382,7 @@ RUN_AIRSPACE_WARNING_DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Airspace/dlgAirspaceWarnings.cpp \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Dialogs/WidgetDialog.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Airspace/AirspaceParser.cpp \
 	$(SRC)/Airspace/AirspaceGlue.cpp \
 	$(SRC)/TransponderCode.cpp \
@@ -2420,6 +2424,7 @@ RUN_PROFILE_LIST_DIALOG_SOURCES = \
 	$(SRC)/Look/CheckBoxLook.cpp \
 	$(SRC)/LocalPath.cpp \
 	$(SRC)/Formatter/HexColor.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(MORE_SCREEN_SOURCES) \
 	$(TEST_SRC_DIR)/Fonts.cpp \
 	$(TEST_SRC_DIR)/FakeAsset.cpp \
@@ -2474,6 +2479,7 @@ RUN_TASK_EDITOR_DIALOG_SOURCES = \
 	$(SRC)/Units/Settings.cpp \
 	$(SRC)/Units/Descriptor.cpp \
 	$(SRC)/Formatter/Units.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Waypoint/WaypointGlue.cpp \
 	$(SRC)/Waypoint/Factory.cpp \
 	$(TEST_SRC_DIR)/FakeAsset.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -94,7 +94,7 @@ TEST_NAMES = \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestGeoPoint TestDiffFilter \
-	TestFileUtil TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
+	TestFileUtil TestFileType TestRepository TestPath TestPolars TestCSVLine TestGlidePolar \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -689,6 +689,16 @@ TEST_FILE_TYPE_SOURCES = \
 	$(TEST_SRC_DIR)/TestFileType.cpp
 TEST_FILE_TYPE_DEPENDS = UTIL
 $(eval $(call link-program,TestFileType,TEST_FILE_TYPE))
+
+TEST_REPOSITORY_SOURCES = \
+	$(SRC)/Repository/Parser.cpp \
+	$(SRC)/Repository/FileRepository.cpp \
+	$(SRC)/Repository/FileType.cpp \
+	$(SRC)/system/Path.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestRepository.cpp
+TEST_REPOSITORY_DEPENDS = UTIL
+$(eval $(call link-program,TestRepository,TEST_REPOSITORY))
 
 TEST_GEO_POINT_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -94,7 +94,7 @@ TEST_NAMES = \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestGeoPoint TestDiffFilter \
-	TestFileUtil TestPolars TestCSVLine TestGlidePolar \
+	TestFileUtil TestPath TestPolars TestCSVLine TestGlidePolar \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -674,6 +674,13 @@ TEST_FILE_UTIL_SOURCES = \
 	$(TEST_SRC_DIR)/TestFileUtil.cpp
 TEST_FILE_UTIL_DEPENDS = UTIL
 $(eval $(call link-program,TestFileUtil,TEST_FILE_UTIL))
+
+TEST_PATH_SOURCES = \
+	$(SRC)/system/Path.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestPath.cpp
+TEST_PATH_DEPENDS = UTIL
+$(eval $(call link-program,TestPath,TEST_PATH))
 
 TEST_GEO_POINT_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -94,7 +94,7 @@ TEST_NAMES = \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestGeoPoint TestDiffFilter \
-	TestFileUtil TestFileType TestRepository TestPath TestPolars TestCSVLine TestGlidePolar \
+	TestFileUtil TestFileType TestDataLayoutMigration TestLocalPathResolve TestRepository TestPath TestPolars TestCSVLine TestGlidePolar \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -689,6 +689,25 @@ TEST_FILE_TYPE_SOURCES = \
 	$(TEST_SRC_DIR)/TestFileType.cpp
 TEST_FILE_TYPE_DEPENDS = UTIL
 $(eval $(call link-program,TestFileType,TEST_FILE_TYPE))
+
+TEST_DATA_LAYOUT_MIGRATION_SOURCES = \
+	$(SRC)/LocalPath.cpp \
+	$(SRC)/DataLayoutMigration.cpp \
+	$(SRC)/Profile/Profile.cpp \
+	$(SRC)/Repository/FileType.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/TestDataLayoutMigration.cpp
+TEST_DATA_LAYOUT_MIGRATION_DEPENDS = PROFILE IO OS UTIL
+$(eval $(call link-program,TestDataLayoutMigration,TEST_DATA_LAYOUT_MIGRATION))
+
+TEST_LOCAL_PATH_RESOLVE_SOURCES = \
+	$(SRC)/LocalPath.cpp \
+	$(SRC)/Repository/FileType.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestLocalPathResolve.cpp
+TEST_LOCAL_PATH_RESOLVE_DEPENDS = IO OS UTIL
+$(eval $(call link-program,TestLocalPathResolve,TEST_LOCAL_PATH_RESOLVE))
 
 TEST_REPOSITORY_SOURCES = \
 	$(SRC)/Repository/Parser.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -94,7 +94,7 @@ TEST_NAMES = \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestGeoPoint TestDiffFilter \
-	TestFileUtil TestPath TestPolars TestCSVLine TestGlidePolar \
+	TestFileUtil TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -681,6 +681,14 @@ TEST_PATH_SOURCES = \
 	$(TEST_SRC_DIR)/TestPath.cpp
 TEST_PATH_DEPENDS = UTIL
 $(eval $(call link-program,TestPath,TEST_PATH))
+
+TEST_FILE_TYPE_SOURCES = \
+	$(SRC)/Repository/FileType.cpp \
+	$(SRC)/system/Path.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestFileType.cpp
+TEST_FILE_TYPE_DEPENDS = UTIL
+$(eval $(call link-program,TestFileType,TEST_FILE_TYPE))
 
 TEST_GEO_POINT_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/src/Airspace/AirspaceGlue.cpp
+++ b/src/Airspace/AirspaceGlue.cpp
@@ -8,9 +8,9 @@
 #include "Language/Language.hpp"
 #include "LogFile.hpp"
 #include "Operation/Operation.hpp"
-#include "Patterns.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
 #include "io/BufferedReader.hxx"
 #include "io/FileReader.hxx"
 #include "io/MapFile.hpp"
@@ -80,7 +80,7 @@ ReadAirspace(Airspaces &airspaces,
 
   // Read the airspace filenames from the registry
   const auto paths = Profile::GetMultiplePaths(ProfileKeys::AirspaceFileList,
-                                               AIRSPACE_FILE_PATTERNS);
+                                               GetFileTypePatterns(FileType::AIRSPACE));
   for (const auto& path : paths) {
   airspace_ok |= ParseAirspaceFile(airspaces, path, operation);
   }

--- a/src/Airspace/Patterns.hpp
+++ b/src/Airspace/Patterns.hpp
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright The XCSoar Project
-
-#pragma once
-
-#define AIRSPACE_FILE_PATTERNS "*.txt\0*.air\0*.sua\0"

--- a/src/DataLayoutMigration.cpp
+++ b/src/DataLayoutMigration.cpp
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DataLayoutMigration.hpp"
+
+#include "LocalPath.hpp"
+#include "LogFile.hpp"
+#include "Profile/Current.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Map.hpp"
+#include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
+#include "lib/fmt/PathFormatter.hpp"
+#include "io/FileOutputStream.hxx"
+#include "system/FileUtil.hpp"
+#include "system/Path.hpp"
+#include "util/IterableSplitString.hxx"
+#include "util/StringCompare.hxx"
+
+#include <string>
+#include <vector>
+
+#include <windef.h>
+
+static constexpr char MIGRATION_MARKER[] = ".xcsoar-subdir-layout-v1";
+
+struct PathMove {
+  AllocatedPath old_path;
+  AllocatedPath new_path;
+};
+
+static constexpr std::string_view profile_path_keys[] = {
+  ProfileKeys::MapFile,
+  ProfileKeys::WaypointFileList,
+  ProfileKeys::WatchedWaypointFileList,
+  ProfileKeys::AirfieldFileList,
+  ProfileKeys::AirspaceFileList,
+  ProfileKeys::FlarmFile,
+  ProfileKeys::RaspFile,
+  ProfileKeys::ChecklistFile,
+  ProfileKeys::LanguageFile,
+  ProfileKeys::InputFile,
+  ProfileKeys::PolarFile,
+  "PlanePath",
+};
+
+[[gnu::pure]]
+static bool
+IsMigrationMarker(Path filename) noexcept
+{
+  return filename == Path(MIGRATION_MARKER);
+}
+
+static bool
+MoveFileToSubdir(const PathMove &move) noexcept
+{
+  if (File::Exists(move.new_path)) {
+    if (File::Exists(move.old_path))
+      LogFmt("Data layout migration: skip {}, already at {}",
+             move.old_path, move.new_path);
+    return false;
+  }
+
+  if (!File::Exists(move.old_path))
+    return false;
+
+  const auto parent = move.new_path.GetParent();
+  if (parent != nullptr && !parent.empty())
+    Directory::Create(parent);
+
+  if (File::Rename(move.old_path, move.new_path))
+    return true;
+
+  LogFmt("Data layout migration: failed to move {} to {}",
+         move.old_path, move.new_path);
+  return false;
+}
+
+static bool
+RewritePathValue(ProfileMap &map, std::string_view key,
+                 const std::vector<PathMove> &moves) noexcept
+{
+  const auto current = map.GetPath(key);
+  if (current == nullptr)
+    return false;
+
+  for (const auto &move : moves) {
+    if (current == move.old_path) {
+      map.SetPath(key, move.new_path);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static bool
+RewriteMultiPathValue(ProfileMap &map, std::string_view key,
+                      const std::vector<PathMove> &moves) noexcept
+{
+  char buffer[MAX_PATH * 4];
+  if (!map.Get(key, std::span{buffer}))
+    return false;
+
+  if (StringIsEmpty(buffer))
+    return false;
+
+  bool changed = false;
+  std::string result;
+
+  for (const auto segment : TIterableSplitString(buffer, '|')) {
+    if (segment.empty())
+      continue;
+
+    const std::string segment_string(segment);
+    const Path segment_path(segment_string.c_str());
+    AllocatedPath expanded = ExpandLocalPath(segment_path);
+    if (expanded == nullptr)
+      expanded = AllocatedPath(segment_path);
+
+    bool segment_changed = false;
+    for (const auto &move : moves) {
+      if (expanded == move.old_path) {
+        if (!result.empty())
+          result += '|';
+        const auto contracted = ContractLocalPath(move.new_path);
+        result += contracted != nullptr
+          ? contracted.c_str()
+          : move.new_path.c_str();
+        changed = true;
+        segment_changed = true;
+        break;
+      }
+    }
+
+    if (!segment_changed) {
+      if (!result.empty())
+        result += '|';
+      result += segment_string;
+    }
+  }
+
+  if (!changed)
+    return false;
+
+  map.Set(key, result.c_str());
+  return true;
+}
+
+static bool
+RewriteActiveProfile(const std::vector<PathMove> &moves) noexcept
+{
+  if (moves.empty())
+    return false;
+
+  bool changed = false;
+
+  for (const auto key : profile_path_keys) {
+    if (key == ProfileKeys::WaypointFileList ||
+        key == ProfileKeys::WatchedWaypointFileList ||
+        key == ProfileKeys::AirfieldFileList ||
+        key == ProfileKeys::AirspaceFileList)
+      changed |= RewriteMultiPathValue(Profile::map, key, moves);
+    else
+      changed |= RewritePathValue(Profile::map, key, moves);
+  }
+
+  return changed;
+}
+
+class DataRootFileCollector final : public File::Visitor {
+public:
+  std::vector<Path> filenames;
+
+  void Visit(Path path, Path filename) override {
+    (void)path;
+
+    if (IsMigrationMarker(filename))
+      return;
+
+    if (!filename.IsValidFilename())
+      return;
+
+    filenames.emplace_back(filename);
+  }
+};
+
+#ifdef ANDROID
+static void
+TryMigrateCacheFile(const PathMove &move,
+                    std::vector<PathMove> &moves) noexcept
+{
+  if (move.old_path == move.new_path)
+    return;
+
+  if (MoveFileToSubdir(move))
+    moves.push_back(move);
+  else if (File::Exists(move.new_path) && !File::Exists(move.old_path))
+    moves.push_back(move);
+}
+
+static void
+MigrateCacheFilesFromDirectory(const AllocatedPath &dir,
+                               std::vector<PathMove> &moves) noexcept
+{
+  if (!Directory::Exists(dir))
+    return;
+
+  DataRootFileCollector collector;
+  Directory::VisitFiles(dir, collector, false);
+
+  for (const Path filename : collector.filenames) {
+    const char *name = filename.c_str();
+    if (!IsCacheLayoutFilename(name))
+      continue;
+
+    PathMove move;
+    move.old_path = AllocatedPath::Build(dir, filename);
+    move.new_path = CacheDataSavePath(name);
+    TryMigrateCacheFile(move, moves);
+  }
+}
+#endif
+
+static void
+MigrateDataRoot(Path data_path, std::vector<PathMove> &all_moves) noexcept
+{
+  const auto marker = AllocatedPath::Build(data_path, Path(MIGRATION_MARKER));
+  if (File::Exists(marker)) {
+    LogDebug("Data layout migration: already done for {}", data_path);
+    return;
+  }
+
+  DataRootFileCollector collector;
+  Directory::VisitFiles(data_path, collector, false);
+
+  std::vector<PathMove> moves;
+  moves.reserve(collector.filenames.size());
+
+  for (const Path filename : collector.filenames) {
+    const char *name = filename.c_str();
+
+#ifdef ANDROID
+    if (IsCacheLayoutFilename(name)) {
+      PathMove move;
+      move.old_path = AllocatedPath::Build(data_path, filename);
+      move.new_path = CacheDataSavePath(name);
+      TryMigrateCacheFile(move, moves);
+      continue;
+    }
+#endif
+
+    const AllocatedPath subdir = GetLayoutSubdirForFilename(name);
+    if (subdir == nullptr)
+      continue;
+
+    PathMove move;
+    move.old_path = AllocatedPath::Build(data_path, filename);
+    move.new_path =
+      AllocatedPath::Build(AllocatedPath::Build(data_path, subdir),
+                           filename);
+
+    if (move.old_path == move.new_path)
+      continue;
+
+    if (MoveFileToSubdir(move))
+      moves.push_back(std::move(move));
+    else if (File::Exists(move.new_path) && !File::Exists(move.old_path))
+      moves.push_back(std::move(move));
+  }
+
+#ifdef ANDROID
+  MigrateCacheFilesFromDirectory(
+    AllocatedPath::Build(data_path, Path("cache")), moves);
+  MigrateCacheFilesFromDirectory(
+    AllocatedPath::Build(data_path, Path("repository")), moves);
+#endif
+
+  all_moves.insert(all_moves.end(),
+                   std::make_move_iterator(moves.begin()),
+                   std::make_move_iterator(moves.end()));
+
+  {
+    FileOutputStream marker_file(marker, FileOutputStream::Mode::CREATE);
+    marker_file.Commit();
+  }
+
+  LogFmt("Data layout migration: completed for {}", data_path);
+}
+
+static void
+MigrateDataRootCallback(Path data_path, void *ctx) noexcept
+{
+  auto &all_moves = *static_cast<std::vector<PathMove> *>(ctx);
+  MigrateDataRoot(data_path, all_moves);
+}
+
+void
+MigrateDataLayoutToSubdirs() noexcept
+{
+  std::vector<PathMove> all_moves;
+
+  try {
+    VisitDataPaths(MigrateDataRootCallback, &all_moves);
+
+    if (RewriteActiveProfile(all_moves)) {
+      Profile::Save();
+      LogFmt("Data layout migration: updated active profile {}",
+             Profile::GetPath());
+    }
+  } catch (...) {
+    LogError(std::current_exception(), "Data layout migration failed");
+  }
+}

--- a/src/DataLayoutMigration.hpp
+++ b/src/DataLayoutMigration.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * One-time migration of legacy flat XCSoarData files into typed
+ * subdirectories.  On Android, cache-category files (repository,
+ * notams.json, user_repository_*) go to #GetCachePath() instead of
+ * product data cache/.  Rewrites path keys in the active profile only;
+ * other profiles keep legacy paths and rely on ResolveLocalDataFile()
+ * when loading files.
+ *
+ * Call after Profile::Load().  Already-migrated data directories are
+ * skipped via a marker file.
+ */
+void
+MigrateDataLayoutToSubdirs() noexcept;

--- a/src/Dialogs/Device/ManageCAI302Dialog.cpp
+++ b/src/Dialogs/Device/ManageCAI302Dialog.cpp
@@ -16,7 +16,7 @@
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Device/Driver/CAI302/Internal.hpp"
 #include "Device/Driver/CAI302/Protocol.hpp"
-#include "Waypoint/Patterns.hpp"
+#include "Repository/FileType.hpp"
 
 using namespace UI;
 
@@ -53,7 +53,8 @@ EditUnits(const DialogLook &look, CAI302Device &device)
 static void
 UploadWaypoints(const DialogLook &look, CAI302Device &device)
 {
-  const auto path = FilePicker(_("Waypoints"), WAYPOINT_FILE_PATTERNS);
+  const auto path = FilePicker(_("Waypoints"),
+                               GetFileTypePatterns(FileType::WAYPOINT));
   if (path == nullptr)
     return;
 

--- a/src/Dialogs/DownloadFileModal.cpp
+++ b/src/Dialogs/DownloadFileModal.cpp
@@ -139,5 +139,5 @@ DownloadFileModal(const char *caption, const char *uri, const char *base)
     return nullptr;
   }
 
-  return LocalPath(base);
+  return ResolveDownloadDestinationPath(Path(base));
 }

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -20,6 +20,7 @@
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
+#include "system/FileUtil.hpp"
 
 #include <vector>
 
@@ -178,15 +179,35 @@ DownloadFilePickerWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 void
 DownloadFilePickerWidget::Download()
 {
+  const int max_subdir_depth = 3; // Allow subdirectories up to this depth
   assert(Net::DownloadManager::IsAvailable());
 
   const unsigned current = GetList().GetCursorIndex();
   assert(current < items.size());
 
   const auto &file = items[current];
-
   try {
-    path = DownloadFileModal(_("Download"), file.GetURI(), file.GetName());
+    AllocatedPath dest_dir;
+    if (file_type == FileType::RASP) {
+      dest_dir = AllocatedPath::Build("weather", "rasp");
+    } else if (file_type == FileType::MAP) {
+      dest_dir = AllocatedPath("maps");
+    }
+
+    const Path file_path(file.GetName()); //AllocatedPath cannot take nullptr
+
+    if (!file_path.IsValidFilename())
+      throw std::runtime_error("Invalid download filename");
+
+    AllocatedPath relative_path(file_path);
+    if (dest_dir != nullptr) {
+      const auto dest_path = MakeLocalPathRecursively(dest_dir, max_subdir_depth);
+      if (dest_path == nullptr) 
+        throw std::runtime_error("Directory does not exist and could not be created.");
+
+      relative_path = AllocatedPath::Build(Path(dest_dir), file_path);
+    }
+    path = DownloadFileModal(_("Download"), file.GetURI(), relative_path.c_str());
     if (path != nullptr)
       dialog.SetModalResult(mrOK);
   } catch (...) {

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -20,8 +20,7 @@
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
-#include "system/FileUtil.hpp"
-
+#include "LocalPath.hpp"
 #include <vector>
 
 #include <cassert>
@@ -187,12 +186,7 @@ DownloadFilePickerWidget::Download()
 
   const auto &file = items[current];
   try {
-    AllocatedPath dest_dir;
-    if (file_type == FileType::RASP) {
-      dest_dir = AllocatedPath::Build("weather", "rasp");
-    } else if (file_type == FileType::MAP) {
-      dest_dir = AllocatedPath("maps");
-    }
+    AllocatedPath dest_dir = GetFileTypeDefaultDir(file_type);
 
     const Path file_path(file.GetName()); //AllocatedPath cannot take nullptr
 

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -39,13 +39,24 @@
 using std::string_view_literals::operator""sv;
 
 static AllocatedPath
-LocalPath(const AvailableFile &file)
+LocalPathByType(const char *name, FileType type)
 {
-  const Path base(file.GetName());
-  if (base.empty())
+  if (name == nullptr)
     return nullptr;
 
-  return LocalPath(base);
+  const AllocatedPath subdir = GetFileTypeDefaultDir(type);
+  const AllocatedPath path = (subdir == nullptr) ? 
+                                    AllocatedPath(name) : 
+                                    AllocatedPath::Build(subdir, Path(name));
+  return LocalPath(path);
+}
+
+static AllocatedPath
+LocalPathByType(const AvailableFile &file)
+{
+  const char *name = file.GetName();
+
+  return LocalPathByType(name, file.type);
 }
 
 #ifdef HAVE_DOWNLOAD_MANAGER
@@ -74,7 +85,7 @@ UpdateAvailable(const FileRepository &repository, const char *name)
 
   BrokenDate remote_changed = remote_file->update_date;
 
-  const auto path = LocalPath(name);
+  const auto path = LocalPathByType(*remote_file);
   BrokenDate local_changed = BrokenDateTime{File::GetLastModification(path)};
 
   return local_changed < remote_changed;
@@ -95,17 +106,19 @@ class ManagedFileListWidget
     StaticString<64u> name;
     StaticString<32u> size;
     StaticString<32u> last_modified;
+    FileType type = FileType::UNKNOWN;
 
     bool downloading, failed, out_of_date;
 
     DownloadStatus download_status;
 
-    void Set(const char *_name, const DownloadStatus *_download_status,
+    void Set(const char *_name, FileType _type, const DownloadStatus *_download_status,
              bool _failed, bool _out_of_date) {
       name = _name;
+      type = _type;
 
-      const auto path = LocalPath(name);
-
+      const auto path = LocalPathByType(name, type);
+      
       if (File::Exists(path)) {
         FormatByteSize(size.buffer(), size.capacity(),
                        File::GetSize(path));
@@ -246,6 +259,10 @@ protected:
   void Cancel();
   void UpdateAllFiles();
 
+#ifdef HAVE_DOWNLOAD_MANAGER
+  void DownloadRemoteFile(const AvailableFile &remote_file);
+#endif
+
 public:
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -346,11 +363,11 @@ ManagedFileListWidget::RefreshList()
     DownloadStatus download_status;
     const bool is_downloading = IsDownloading(remote_file, download_status);
 
-    const auto path = LocalPath(remote_file);
+    const AllocatedPath path = LocalPathByType(remote_file);
+
     const bool file_exists = File::Exists(path);
 
-    if (path != nullptr &&
-        (is_downloading || file_exists)) {
+    if (path != nullptr && (is_downloading || file_exists)) {
 #ifdef HAVE_DOWNLOAD_MANAGER
       download_active |= is_downloading;
 #endif
@@ -370,7 +387,7 @@ ManagedFileListWidget::RefreshList()
 #endif
       }
 
-      items.append().Set(base.c_str(),
+      items.append().Set(base.c_str(), i->type,
                          is_downloading ? &download_status : nullptr,
                          HasFailed(remote_file), is_out_of_date);
     }
@@ -487,15 +504,40 @@ ManagedFileListWidget::UpdateFile()
     return;
 
   const AvailableFile &remote_file = *remote_file_p;
-  const Path base(remote_file.GetName());
-  if (base.empty())
-    return;
-
-  Net::DownloadManager::Enqueue(remote_file.uri.c_str(), base);
+  DownloadRemoteFile(remote_file);
 #endif
 }
 
 #ifdef HAVE_DOWNLOAD_MANAGER
+
+void
+ManagedFileListWidget::DownloadRemoteFile(const AvailableFile &remote_file)
+{
+  assert(Net::DownloadManager::IsAvailable());
+
+  const int max_subdir_depth = 3; // Allow subdirectories up to this depth
+
+  if (remote_file.GetName() == nullptr)
+    return;
+
+  const AllocatedPath subdir = GetFileTypeDefaultDir(remote_file.type);
+  AllocatedPath path = nullptr;
+  if (subdir != nullptr) {
+    if (MakeLocalPathRecursively(subdir, max_subdir_depth) == nullptr) {
+      ShowMessageBox(_("Subdirectory does not exist and could not be created."),
+                _("Error"), MB_OK);
+      return;
+    }
+    path = AllocatedPath::Build(subdir, Path(remote_file.GetName()));
+  } else {
+    path = AllocatedPath(remote_file.GetName());
+    if (path == nullptr)
+      return;
+  }
+
+  Net::DownloadManager::Enqueue(remote_file.uri.c_str(), path);
+}
+
 
 class AddFileListItemRenderer final : public ListItemRenderer {
   const std::vector<AvailableFile> &list;
@@ -579,11 +621,8 @@ ManagedFileListWidget::Add()
   assert((unsigned)i < list.size());
 
   const AvailableFile &remote_file = list[i];
-  const Path base(remote_file.GetName());
-  if (base.empty())
-    return;
 
-  Net::DownloadManager::Enqueue(remote_file.GetURI(), base);
+  DownloadRemoteFile(remote_file);
 #endif
 }
 

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -241,7 +241,7 @@ protected:
   void RefreshList();
   void UpdateButtons();
 
-  void Download();
+  void UpdateFile();
   void Add();
   void Cancel();
   void UpdateFiles();
@@ -391,7 +391,7 @@ ManagedFileListWidget::CreateButtons(WidgetDialog &dialog) noexcept
 {
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (Net::DownloadManager::IsAvailable()) {
-    download_button = dialog.AddButton(_("Update"), [this](){ Download(); });
+    download_button = dialog.AddButton(_("Update"), [this](){ UpdateFile(); });
     add_button = dialog.AddButton(_("Add"), [this](){ Add(); });
     cancel_button = dialog.AddButton(_("Abort"), [this](){ Cancel(); });
     update_button = dialog.AddButton(_("Update all"), [this](){
@@ -470,7 +470,7 @@ ManagedFileListWidget::OnCursorMoved([[maybe_unused]] unsigned index) noexcept
 }
 
 void
-ManagedFileListWidget::Download()
+ManagedFileListWidget::UpdateFile()
 {
 #ifdef HAVE_DOWNLOAD_MANAGER
   assert(Net::DownloadManager::IsAvailable());

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -46,11 +46,15 @@ GetRelativePathByType(const AvailableFile &file)
   if (base == nullptr)
     return nullptr;
 
+  const Path base_path(base);
+  if (!base_path.IsValidFilename())
+    return nullptr;
+
   const AllocatedPath subdir = GetFileTypeDefaultDir(file.type);
   if (subdir == nullptr)
     return AllocatedPath(base);
 
-  return AllocatedPath::Build(subdir, Path(base));
+  return AllocatedPath::Build(subdir, base_path);
 }
 
 
@@ -61,10 +65,14 @@ LocalPathByType(const char *name, FileType type)
   if (name == nullptr)
     return nullptr;
 
+  const Path name_path(name);
+  if (!name_path.IsValidFilename())
+    return nullptr;
+
   const AllocatedPath subdir = GetFileTypeDefaultDir(type);
   const AllocatedPath path = (subdir == nullptr) ? 
                                     AllocatedPath(name) : 
-                                    AllocatedPath::Build(subdir, Path(name));
+                                    AllocatedPath::Build(subdir, name_path);
   return LocalPath(path);
 }
 
@@ -535,6 +543,9 @@ ManagedFileListWidget::DownloadRemoteFile(const AvailableFile &remote_file)
   const int max_subdir_depth = 3; // Allow subdirectories up to this depth
 
   if (remote_file.GetName() == nullptr)
+    return;
+
+  if (!Path(remote_file.GetName()).IsValidFilename())
     return;
 
   const AllocatedPath subdir = GetFileTypeDefaultDir(remote_file.type);

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -38,6 +38,23 @@
 
 using std::string_view_literals::operator""sv;
 
+[[gnu::pure]]
+static AllocatedPath
+GetRelativePathByType(const AvailableFile &file)
+{
+  const auto base = file.GetName();
+  if (base == nullptr)
+    return nullptr;
+
+  const AllocatedPath subdir = GetFileTypeDefaultDir(file.type);
+  if (subdir == nullptr)
+    return AllocatedPath(base);
+
+  return AllocatedPath::Build(subdir, Path(base));
+}
+
+
+[[gnu::pure]]
 static AllocatedPath
 LocalPathByType(const char *name, FileType type)
 {
@@ -636,11 +653,11 @@ ManagedFileListWidget::UpdateAllFiles() {
       const AvailableFile *remote_file = FindRemoteFile(repository, file.name);
 
       if (remote_file != nullptr) {
-        const Path base(remote_file->GetName());
-        if (base.empty())
+        const auto relative_path = GetRelativePathByType(*remote_file);
+        if (relative_path == nullptr)
           return;
 
-        Net::DownloadManager::Enqueue(remote_file->GetURI(), base);
+        Net::DownloadManager::Enqueue(remote_file->GetURI(), relative_path);
       }
     }
   }
@@ -660,6 +677,15 @@ ManagedFileListWidget::Cancel()
   assert(current < items.size());
 
   const FileItem &item = items[current];
+  const AvailableFile *remote_file = FindRemoteFile(repository, item.name);
+  if (remote_file != nullptr) {
+    if (const auto relative_path = GetRelativePathByType(*remote_file);
+        relative_path != nullptr) {
+      Net::DownloadManager::Cancel(relative_path);
+      return;
+    }
+  }
+
   Net::DownloadManager::Cancel(Path(item.name));
 #endif
 }

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -244,7 +244,7 @@ protected:
   void UpdateFile();
   void Add();
   void Cancel();
-  void UpdateFiles();
+  void UpdateAllFiles();
 
 public:
   /* virtual methods from class Widget */
@@ -395,7 +395,7 @@ ManagedFileListWidget::CreateButtons(WidgetDialog &dialog) noexcept
     add_button = dialog.AddButton(_("Add"), [this](){ Add(); });
     cancel_button = dialog.AddButton(_("Abort"), [this](){ Cancel(); });
     update_button = dialog.AddButton(_("Update all"), [this](){
-      UpdateFiles();
+      UpdateAllFiles();
     });
   }
 #else
@@ -588,7 +588,7 @@ ManagedFileListWidget::Add()
 }
 
 void
-ManagedFileListWidget::UpdateFiles() {
+ManagedFileListWidget::UpdateAllFiles() {
 #ifdef HAVE_DOWNLOAD_MANAGER
   assert(Net::DownloadManager::IsAvailable());
 

--- a/src/Dialogs/Plane/PlaneListDialog.cpp
+++ b/src/Dialogs/Plane/PlaneListDialog.cpp
@@ -14,6 +14,7 @@
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "Profile/Profile.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "UIGlobals.hpp"
@@ -106,7 +107,7 @@ PlaneListWidget::UpdateList() noexcept
   list.clear();
 
   PlaneFileVisitor pfv(list);
-  VisitDataFiles("*.xcp", pfv);
+  VisitDataFiles(GetFileTypePatterns(FileType::PLANE), pfv);
 
   unsigned len = list.size();
 

--- a/src/Dialogs/ProfileListDialog.cpp
+++ b/src/Dialogs/ProfileListDialog.cpp
@@ -14,6 +14,7 @@
 #include "LocalPath.hpp"
 #include "Profile/Map.hpp"
 #include "Profile/File.hpp"
+#include "Repository/FileType.hpp"
 #include "UIGlobals.hpp"
 #include "Language/Language.hpp"
 #include "util/StaticString.hxx"
@@ -109,7 +110,7 @@ ProfileListWidget::UpdateList()
   list.clear();
 
   ProfileFileVisitor pfv(list);
-  VisitDataFiles("*.prf", pfv);
+  VisitDataFiles(GetFileTypePatterns(FileType::PROFILE), pfv);
 
   unsigned len = list.size();
 

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -18,6 +18,7 @@
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Hardware/Vibrator.hpp"
+#include "Repository/FileType.hpp"
 
 using namespace std::chrono;
 
@@ -99,7 +100,9 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
   AddFile(_("Events"),
           _("The Input Events file defines the menu system and how XCSoar responds to "
             "button presses and events from external devices."),
-          ProfileKeys::InputFile, "*.xci\0", FileType::XCI);
+          ProfileKeys::InputFile,
+          GetFileTypePatterns(FileType::XCI),
+          FileType::XCI);
   SetExpertRow(InputFile);
 
 #ifdef HAVE_NLS

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -2,16 +2,15 @@
 // Copyright The XCSoar Project
 
 #include "SiteConfigPanel.hpp"
-#include "Airspace/Patterns.hpp"
 #include "ConfigPanel.hpp"
 #include "Language/Language.hpp"
 #include "LocalPath.hpp"
 #include "Profile/Keys.hpp"
+#include "Repository/FileType.hpp"
 #include "Profile/Profile.hpp"
 #include "UIGlobals.hpp"
 #include "Repository/Glue.hpp"
 #include "UtilsSettings.hpp"
-#include "Waypoint/Patterns.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "system/Path.hpp"
 
@@ -52,13 +51,15 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
   AddFile(_("Map database"),
           _("The name of the file (.xcm) containing terrain, topography, and optionally "
             "waypoints, their details and airspaces."),
-          ProfileKeys::MapFile, "*.xcm\0*.lkm\0", FileType::MAP);
+          ProfileKeys::MapFile, GetFileTypePatterns(FileType::MAP),
+          FileType::MAP);
 
   AddMultipleFiles(_("Waypoints"),
                    _("Primary waypoints files.  Supported file types are "
                      "Cambridge/WinPilot files (.dat), "
                      "Zander files (.wpz) or SeeYou files (.cup)."),
-                   ProfileKeys::WaypointFileList, WAYPOINT_FILE_PATTERNS,
+                   ProfileKeys::WaypointFileList,
+                   GetFileTypePatterns(FileType::WAYPOINT),
                    FileType::WAYPOINT);
 
   AddMultipleFiles(_("Watched WPTs"),
@@ -69,14 +70,16 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
                      "waypoints like known reliable thermal sources (e.g. "
                      "powerplants) or mountain passes."),
                    ProfileKeys::WatchedWaypointFileList,
-                   WAYPOINT_FILE_PATTERNS, FileType::WAYPOINT);
+                   GetFileTypePatterns(FileType::WAYPOINT),
+                   FileType::WAYPOINT);
   SetExpertRow(WatchedWaypointFileList);
 
   AddMultipleFiles(_("WPT A/F details"),
                    _("The files may contain extracts from enroute supplements "
                      "or other contributed "
                      "information about individual waypoints and airfields."),
-                   ProfileKeys::AirfieldFileList, "*.txt\0",
+                   ProfileKeys::AirfieldFileList,
+                   GetFileTypePatterns(FileType::WAYPOINTDETAILS),
                    FileType::WAYPOINTDETAILS);
   SetExpertRow(AirfieldFileList);
 
@@ -85,13 +88,14 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
                      "buttons to activate or deactivate"
                      " airspace files respectively. Supported file types are: "
                      "Openair (.txt /.air), and Tim Newport-Pearce (.sua)."),
-                   ProfileKeys::AirspaceFileList, AIRSPACE_FILE_PATTERNS,
+                   ProfileKeys::AirspaceFileList,
+                   GetFileTypePatterns(FileType::AIRSPACE),
                    FileType::AIRSPACE);
 
   AddFile(_("FLARM database"),
-          _("The name of the file containing information about registered "
-            "FLARM devices."),
-          ProfileKeys::FlarmFile, "*.fln\0",
+          _("The name of the file containing information about registered FLARM devices."),
+          ProfileKeys::FlarmFile,
+          GetFileTypePatterns(FileType::FLARMNET),
           FileType::FLARMNET);
 
   AddFile("RASP",
@@ -100,12 +104,14 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
             "overlays for thermal strength, boundary layer winds, "
             "cloud cover, and other soaring-relevant parameters at "
             "various forecast times throughout the day."),
-          ProfileKeys::RaspFile, "*-rasp*.dat\0",
+          ProfileKeys::RaspFile,
+          GetFileTypePatterns(FileType::RASP),
           FileType::RASP);
 
   AddFile(_("Checklist"),
           _("The checklist file containing pre-flight and other checklists."),
-          ProfileKeys::ChecklistFile, "*.xcc\0xcsoar-checklist.txt\0",
+          ProfileKeys::ChecklistFile,
+          GetFileTypePatterns(FileType::CHECKLIST),
           FileType::CHECKLIST);
   
   const char *user_repositories_list_value = Profile::Get(ProfileKeys::UserRepositoriesList, "");

--- a/src/Dialogs/StartupDialog.cpp
+++ b/src/Dialogs/StartupDialog.cpp
@@ -12,6 +12,7 @@
 #include "LogFile.hpp"
 #include "Look/DialogLook.hpp"
 #include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
 #include "ProfileListDialog.hpp"
 #include "ProfilePasswordDialog.hpp"
 #include "Screen/Layout.hpp"
@@ -192,7 +193,7 @@ dlgStartupShowModal() noexcept
 
   /* scan all profile files */
   auto *dff = new FileDataField();
-  dff->ScanDirectoryTop("*.prf");
+  dff->ScanDirectoryTop(GetFileTypePatterns(FileType::PROFILE));
 
   if (dff->GetNumFiles() == 1) {
     /* skip this dialog if there is only one */

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -8,6 +8,7 @@
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Form/Edit.hpp"
+#include "Repository/FileType.hpp"
 #include "DataGlobals.hpp"
 #include "UIGlobals.hpp"
 #include "Language/Language.hpp"
@@ -35,7 +36,8 @@ RASPSettingsPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
                            [[maybe_unused]] const PixelRect &rc) noexcept
 {
   WndProperty *wp = AddFile(_("File"), nullptr,
-                            ProfileKeys::RaspFile, "*-rasp*.dat\0",
+                            ProfileKeys::RaspFile,
+                            GetFileTypePatterns(FileType::RASP),
                             FileType::RASP);
   wp->GetDataField()->SetOnModified([this]{
     if (SaveValueFileReader(FILE, ProfileKeys::RaspFile)) {

--- a/src/Dialogs/dlgChecklist.cpp
+++ b/src/Dialogs/dlgChecklist.cpp
@@ -15,6 +15,7 @@
 #include "io/BufferedReader.hxx"
 #include "io/StringConverter.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Keys.hpp"
 #include "system/Path.hpp"
@@ -142,7 +143,8 @@ dlgChecklistShowModal()
 
   auto path = Profile::GetPath(ProfileKeys::ChecklistFile);
   if (path == nullptr || path.empty())
-    path = LocalPath("xcsoar-checklist.txt");
+    path = ResolveTypedDataFilePath(FileType::CHECKLIST,
+                                    "xcsoar-checklist.txt");
   auto checklist = LoadChecklist(path);
   if (checklist.empty())
     {

--- a/src/FLARM/Glue.cpp
+++ b/src/FLARM/Glue.cpp
@@ -11,6 +11,7 @@
 #include "BackendComponents.hpp"
 #include "MergeThread.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "io/DataFile.hpp"
 #include "io/Reader.hxx"
 #include "io/BufferedReader.hxx"
@@ -117,7 +118,8 @@ SaveFlarmColors() noexcept
 static void
 SaveSecondary(FlarmNameDatabase &flarm_names) noexcept
 try {
-  FileOutputStream fos(LocalPath("xcsoar-flarm.txt"));
+  FileOutputStream fos(
+    TypedDataSavePath(FileType::FLARMDB, "xcsoar-flarm.txt"));
   BufferedOutputStream bos(fos);
   SaveFlarmNameFile(bos, flarm_names);
   bos.Flush();
@@ -129,7 +131,8 @@ try {
 static void
 SaveMessaging(FlarmMessagingDatabase &flarm_messages) noexcept
 try {
-  FileOutputStream fos(LocalPath("flarm-msg-data.csv"));
+  FileOutputStream fos(
+    TypedDataSavePath(FileType::FLARMDB, "flarm-msg-data.csv"));
   BufferedOutputStream bos(fos);
   SaveFlarmMessagingFile(bos, flarm_messages);
   bos.Flush();

--- a/src/Input/InputEventsLua.cpp
+++ b/src/Input/InputEventsLua.cpp
@@ -8,6 +8,7 @@
 #include "Dialogs/ComboPicker.hpp"
 #include "Language/Language.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "system/Path.hpp"
 #include "system/FileUtil.hpp"
 #include "Form/DataField/ComboList.hpp"
@@ -34,7 +35,9 @@ SelectLuaFile(const char *path)
     /* no parameter: let user select a *.lua file */
     LuaFileVisitor visitor;
 
-    Directory::VisitSpecificFiles(LocalPath("lua"), "*.lua",
+    const auto lua_dir = LocalPath(GetFileTypeDefaultDir(FileType::LUA));
+    Directory::VisitSpecificFiles(lua_dir,
+                                  GetFileTypePatterns(FileType::LUA),
                                   visitor, true);
     if (visitor.combo_list.empty()) {
       ShowMessageBox(_("Not found"), "RunLuaFile",
@@ -51,7 +54,7 @@ SelectLuaFile(const char *path)
     /* *.lua file specified: run this file */
     return Path(path).IsAbsolute()
       ? AllocatedPath(Path(path))
-      : AllocatedPath::Build(LocalPath("lua"), path);
+      : AllocatedPath::Build(LocalPath(GetFileTypeDefaultDir(FileType::LUA)), path);
   } else {
     ShowMessageBox("RunLuaFile expects *.lua parameter",
                    "RunLuaFile", MB_OK|MB_ICONINFORMATION);

--- a/src/Input/InputEventsLua.cpp
+++ b/src/Input/InputEventsLua.cpp
@@ -50,7 +50,7 @@ SelectLuaFile(const char *path)
       return nullptr;
 
     return Path(visitor.combo_list[i].string_value.c_str());
-  } else if (StringEndsWith(path, ".lua")) {
+  } else if (FilenameMatchesFileType(path, FileType::LUA)) {
     /* *.lua file specified: run this file */
     return Path(path).IsAbsolute()
       ? AllocatedPath(Path(path))

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -113,6 +113,12 @@ LocalPath(const char *file) noexcept
 AllocatedPath
 MakeLocalPath(const char *name)
 {
+  return MakeLocalPath(Path(name));
+}
+
+AllocatedPath
+MakeLocalPath(Path name)
+{
   auto path = LocalPath(name);
   Directory::Create(path);
   return path;

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -118,6 +118,54 @@ MakeLocalPath(const char *name)
   return path;
 }
 
+AllocatedPath
+MakeLocalPathRecursively(Path name, int max_creation_depth)
+{
+  assert(name != nullptr);
+  assert(max_creation_depth >= 0);
+
+  AllocatedPath path = LocalPath(name);
+
+  if (Directory::Exists(path))
+    return path;
+
+  if (max_creation_depth == 0)
+    return nullptr;
+
+  // Collect paths from target up to first existing ancestor
+  std::list<AllocatedPath> to_create;
+  to_create.push_back(std::move(path));
+  const Path primary_data_path = GetPrimaryDataPath();
+
+  while (!Directory::Exists(to_create.front())) {
+    if (to_create.size() > static_cast<size_t>(max_creation_depth))
+      return nullptr;
+
+    AllocatedPath parent = to_create.front().GetParent();
+
+    if (parent == primary_data_path)
+      /* reached the data root, which is assumed to exist already */
+      break;
+
+    if (parent == nullptr || parent == Path("."))
+      /* walked past the root without finding primary_data_path - should
+         not happen since all paths here are children of it */
+      return nullptr;
+
+    to_create.push_front(std::move(parent));
+  }
+
+  // Create directories from parent to child
+  for (const auto &dir : to_create) {
+    Directory::Create(dir);
+
+    if (!Directory::Exists(dir))
+      return nullptr;
+  }
+
+  return LocalPath(name);
+}
+
 Path
 RelativePath(Path path) noexcept
 {

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -3,6 +3,7 @@
 
 #include "LocalPath.hpp"
 #include "ProductName.hpp"
+#include "Repository/FileType.hpp"
 #include "system/Path.hpp"
 #include "Compatibility/path.h"
 #include "util/StringCompare.hxx"
@@ -228,6 +229,159 @@ ContractLocalPath(Path src) noexcept
   return Path(local_path_code) + relative.c_str();
 }
 
+AllocatedPath
+ResolveLocalDataFile(AllocatedPath path, FileType file_type) noexcept
+{
+  if (path == nullptr || path.empty())
+    return nullptr;
+
+  if (File::Exists(path))
+    return path;
+
+  const Path base = path.GetBase();
+  if (base == nullptr || base.empty())
+    return path;
+
+  if (file_type == FileType::UNKNOWN)
+    file_type = ClassifyDataFilename(base.c_str());
+
+  const AllocatedPath subdir = GetFileTypeDefaultDir(file_type);
+  if (subdir == nullptr)
+    return path;
+
+  AllocatedPath alt = LocalPath(AllocatedPath::Build(subdir, base));
+  if (alt != nullptr && File::Exists(alt))
+    return alt;
+
+  return path;
+}
+
+AllocatedPath
+TypedDataSavePath(const FileType file_type, const char *filename) noexcept
+{
+  const AllocatedPath subdir = GetFileTypeDefaultDir(file_type);
+  if (subdir == nullptr)
+    return LocalPath(Path(filename));
+
+  return AllocatedPath::Build(MakeLocalPath(subdir), Path(filename));
+}
+
+AllocatedPath
+ResolveTypedDataFilePath(const FileType file_type,
+                         const char *filename) noexcept
+{
+  return ResolveTypedDataFilePath(file_type, filename, {});
+}
+
+AllocatedPath
+ResolveTypedDataFilePath(const FileType file_type, const char *filename,
+                         std::initializer_list<const char *> legacy_names) noexcept
+{
+  const AllocatedPath subdir = GetFileTypeDefaultDir(file_type);
+  if (subdir != nullptr) {
+    AllocatedPath path = LocalPath(AllocatedPath::Build(subdir, Path(filename)));
+    if (File::Exists(path))
+      return path;
+
+    for (const char *legacy : legacy_names) {
+      path = LocalPath(AllocatedPath::Build(subdir, Path(legacy)));
+      if (File::Exists(path))
+        return path;
+    }
+  }
+
+  return ResolveLocalDataFile(LocalPath(Path(filename)), file_type);
+}
+
+AllocatedPath
+CacheDataSavePath(const char *filename) noexcept
+{
+  Directory::Create(GetCachePath());
+  return AllocatedPath::Build(GetCachePath(), Path(filename));
+}
+
+AllocatedPath
+ResolveCacheDataPath(const char *filename) noexcept
+{
+  AllocatedPath path = AllocatedPath::Build(GetCachePath(), Path(filename));
+  if (File::Exists(path))
+    return path;
+
+#ifdef ANDROID
+  path = LocalPath(AllocatedPath::Build(Path("cache"), Path(filename)));
+  if (File::Exists(path))
+    return path;
+#endif
+
+  return ResolveLocalDataFile(LocalPath(Path(filename)));
+}
+
+static constexpr const char repository_legacy_dir[] = "repository";
+
+AllocatedPath
+RepositoryDataSavePath(const char *filename) noexcept
+{
+  return CacheDataSavePath(filename);
+}
+
+AllocatedPath
+RepositoryDownloadRelativePath(const char *filename) noexcept
+{
+  return AllocatedPath::Build(Path("cache"), Path(filename));
+}
+
+AllocatedPath
+RepositoryDownloadDestinationPath(const char *filename) noexcept
+{
+#ifdef ANDROID
+  return CacheDataSavePath(filename);
+#else
+  return LocalPath(RepositoryDownloadRelativePath(filename));
+#endif
+}
+
+AllocatedPath
+ResolveDownloadDestinationPath(Path path) noexcept
+{
+  if (path != nullptr && path.IsAbsolute())
+    return AllocatedPath(path.c_str());
+
+  return LocalPath(path);
+}
+
+AllocatedPath
+ResolveRepositoryDataPath(const char *filename) noexcept
+{
+  AllocatedPath path = CacheDataSavePath(filename);
+  if (File::Exists(path))
+    return path;
+
+#ifdef ANDROID
+  path = LocalPath(AllocatedPath::Build(Path("cache"), Path(filename)));
+  if (File::Exists(path))
+    return path;
+#endif
+
+  path = LocalPath(AllocatedPath::Build(Path(repository_legacy_dir),
+                                        Path(filename)));
+  if (File::Exists(path))
+    return path;
+
+  return ResolveLocalDataFile(LocalPath(Path(filename)));
+}
+
+AllocatedPath
+LogsDataSavePath(const char *filename) noexcept
+{
+  return TypedDataSavePath(FileType::IGC, filename);
+}
+
+AllocatedPath
+ResolveLogsDataPath(const char *filename) noexcept
+{
+  return ResolveTypedDataFilePath(FileType::IGC, filename);
+}
+
 #ifdef _WIN32
 
 /**
@@ -377,6 +531,13 @@ VisitDataFiles(const char* filter, File::Visitor &visitor)
 {
   for (const auto &i : data_paths)
     Directory::VisitSpecificFiles(i, filter, visitor, true);
+}
+
+void
+VisitDataPaths(DataPathCallback callback, void *ctx) noexcept
+{
+  for (const auto &i : data_paths)
+    callback(i, ctx);
 }
 
 Path

--- a/src/LocalPath.hpp
+++ b/src/LocalPath.hpp
@@ -69,6 +69,9 @@ LocalPath(const char *file) noexcept;
 AllocatedPath
 MakeLocalPath(const char *name);
 
+AllocatedPath
+MakeLocalPath(const Path name);
+
 /**
  * Determine absolute path from local path and create this directory
  * and any missing parent directories up to `max_creation_depth` levels.

--- a/src/LocalPath.hpp
+++ b/src/LocalPath.hpp
@@ -96,7 +96,7 @@ RelativePath(Path path) noexcept;
 /**
  * Converts a file path by replacing %LOCAL_PATH% with the full pathname to
  * the XCSoarData folder
- * @param filein Pointer to the string to convert
+ * @param src Pointer to the string to convert
  */
 [[gnu::pure]]
 AllocatedPath
@@ -105,7 +105,7 @@ ExpandLocalPath(Path src) noexcept;
 /**
  * Converts a file path from full pathname to a shorter version with the
  * XCSoarData folder replaced by %LOCAL_PATH%
- * @param filein Pointer to the string to convert
+ * @param src Pointer to the string to convert
  * @return the new path or nullptr if the given path cannot be contracted
  */
 [[gnu::pure]]

--- a/src/LocalPath.hpp
+++ b/src/LocalPath.hpp
@@ -70,6 +70,21 @@ AllocatedPath
 MakeLocalPath(const char *name);
 
 /**
+ * Determine absolute path from local path and create this directory
+ * and any missing parent directories up to `max_creation_depth` levels.
+ * In contrast to MakeLocalPath: returns nullptr on failure
+ * (path does not exist and could not be created), otherwise
+ * the resulting absolute path.
+ * @param name The local (relative to xcsoar dir) path to create.
+ * @param max_creation_depth The maximum number of directory levels to create.
+ *        If 0, only checks if the path exists (no creation).
+ *        If the required depth exceeds this value, returns nullptr.
+ * @return The created (or already existing) absolute path, or nullptr on failure.
+ */
+AllocatedPath
+MakeLocalPathRecursively(Path name, int max_creation_depth = 10);
+
+/**
  * Return the portion of the specified path that is relative to the
  * primary data path.  Returns nullptr on failure (if the path is not
  * inside the primary data path).

--- a/src/LocalPath.hpp
+++ b/src/LocalPath.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#include "Repository/FileType.hpp"
+
+#include <initializer_list>
+
 class Path;
 class AllocatedPath;
 
@@ -115,7 +119,91 @@ ExpandLocalPath(Path src) noexcept;
 AllocatedPath
 ContractLocalPath(Path src) noexcept;
 
+/**
+ * Return @p path if it exists; otherwise, if the basename matches a
+ * typed data subdirectory layout, try that location (for profiles not
+ * updated after a data-layout migration).
+ */
+[[gnu::pure]]
+AllocatedPath
+ResolveLocalDataFile(AllocatedPath path,
+                     FileType file_type = FileType::UNKNOWN) noexcept;
+
+/**
+ * Canonical save path for a typed data file (under #GetFileTypeDefaultDir).
+ */
+AllocatedPath
+TypedDataSavePath(FileType file_type, const char *filename) noexcept;
+
+/**
+ * Resolve a typed data file for reading (subdir first, legacy root fallback).
+ */
+[[gnu::pure]]
+AllocatedPath
+ResolveTypedDataFilePath(FileType file_type,
+                         const char *filename) noexcept;
+
+[[gnu::pure]]
+AllocatedPath
+ResolveTypedDataFilePath(FileType file_type, const char *filename,
+                         std::initializer_list<const char *> legacy_names) noexcept;
+
+/** Canonical path under cache/ for repository manifest files. */
+AllocatedPath
+RepositoryDataSavePath(const char *filename) noexcept;
+
+/** Resolve repository manifest (cache/, legacy repository/, data root). */
+[[gnu::pure]]
+AllocatedPath
+ResolveRepositoryDataPath(const char *filename) noexcept;
+
+/**
+ * Relative path for repository downloads (e.g. cache/repository).
+ * Must be copied into #AllocatedPath before the temporary is destroyed.
+ */
+[[gnu::pure]]
+AllocatedPath
+RepositoryDownloadRelativePath(const char *filename) noexcept;
+
+/**
+ * Destination path for repository downloads (#GetCachePath() on Android,
+ * otherwise under the primary data directory).
+ */
+[[gnu::pure]]
+AllocatedPath
+RepositoryDownloadDestinationPath(const char *filename) noexcept;
+
+/**
+ * Resolve a download queue path (#LocalPath for relative paths).
+ */
+[[gnu::pure]]
+AllocatedPath
+ResolveDownloadDestinationPath(Path path) noexcept;
+
+AllocatedPath
+CacheDataSavePath(const char *filename) noexcept;
+
+[[gnu::pure]]
+AllocatedPath
+ResolveCacheDataPath(const char *filename) noexcept;
+
+AllocatedPath
+LogsDataSavePath(const char *filename) noexcept;
+
+[[gnu::pure]]
+AllocatedPath
+ResolveLogsDataPath(const char *filename) noexcept;
+
 void VisitDataFiles(const char* filter, File::Visitor &visitor);
+
+using DataPathCallback = void (*)(Path data_path, void *ctx) noexcept;
+
+/**
+ * Invoke @p callback once for each configured XCSoar data directory
+ * (primary first).
+ */
+void
+VisitDataPaths(DataPathCallback callback, void *ctx) noexcept;
 
 [[gnu::pure]]
 Path

--- a/src/LogFile.cpp
+++ b/src/LogFile.cpp
@@ -36,11 +36,11 @@ OpenLog()
     initialised = true;
 
     /* delete the obsolete log file */
-    File::Delete(LocalPath("xcsoar-startup.log"));
+    File::Delete(ResolveLogsDataPath("xcsoar-startup.log"));
 
-    path = LocalPath("xcsoar.log");
+    path = LogsDataSavePath("xcsoar.log");
 
-    File::Replace(path, LocalPath("xcsoar-old.log"));
+    File::Replace(path, ResolveLogsDataPath("xcsoar-old.log"));
 
 #ifdef ANDROID
     /* redirect stdout/stderr to xcsoar-startup.log on Android so we

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -13,6 +13,7 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "UIGlobals.hpp"
 #include "Operation/Cancelled.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
@@ -294,7 +295,7 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
     return;
   }
 
-  const auto logs_path = MakeLocalPath("logs");
+  const auto logs_path = MakeLocalPath(GetFileTypeDefaultDir(FileType::IGC));
 
   while (true) {
     // Show list of the flights

--- a/src/Logger/LoggerImpl.cpp
+++ b/src/Logger/LoggerImpl.cpp
@@ -5,6 +5,7 @@
 #include "Logger/Settings.hpp"
 #include "LogFile.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "Device/Declaration.hpp"
 #include "NMEA/Info.hpp"
 #include "Simulator.hpp"
@@ -201,7 +202,7 @@ LoggerImpl::StartLogger(const NMEAInfo &gps_info,
 
   assert(writer == nullptr);
 
-  const auto logs_path = MakeLocalPath("logs");
+  const auto logs_path = MakeLocalPath(GetFileTypeDefaultDir(FileType::IGC));
 
   const BrokenDate today = gps_info.date_time_utc.IsDatePlausible()
     ? gps_info.date_time_utc.GetDate()

--- a/src/Logger/NMEALogger.cpp
+++ b/src/Logger/NMEALogger.cpp
@@ -4,6 +4,7 @@
 #include "Logger/NMEALogger.hpp"
 #include "io/FileOutputStream.hxx"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "system/Path.hpp"
 #include "util/SpanCast.hxx"
@@ -26,7 +27,7 @@ NMEALogger::Start()
               dt.year, dt.month, dt.day,
               dt.hour, dt.minute);
 
-  const auto logs_path = MakeLocalPath("logs");
+  const auto logs_path = MakeLocalPath(GetFileTypeDefaultDir(FileType::NMEA));
 
   const auto path = AllocatedPath::Build(logs_path, name);
   file = std::make_unique<FileOutputStream>(path,

--- a/src/Markers/Markers.cpp
+++ b/src/Markers/Markers.cpp
@@ -8,14 +8,16 @@
 #include "io/BufferedOutputStream.hxx"
 #include "LogFile.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 
 void
 MarkLocation(const GeoPoint &loc, const BrokenDateTime &time)
 try {
   assert(time.IsPlausible());
 
-  FileOutputStream file(LocalPath("xcsoar-marks.txt"),
-                        FileOutputStream::Mode::APPEND_OR_CREATE);
+  FileOutputStream file(
+    TypedDataSavePath(FileType::AIRSPACE, "xcsoar-marks.txt"),
+    FileOutputStream::Mode::APPEND_OR_CREATE);
   BufferedOutputStream os(file);
   os.Fmt("{:02}.{:02}.{:04}\t{:02}:{:02}:{:02}\tLon:{:f}\tLat:{:f}\n",
          time.day, time.month, time.year,

--- a/src/NOTAM/NOTAMCache.cpp
+++ b/src/NOTAM/NOTAMCache.cpp
@@ -43,7 +43,13 @@ GetJsonNumber(const boost::json::value &value, double &out) noexcept
 AllocatedPath
 NOTAMCache::GetFilePath()
 {
-  return LocalPath("notams.json");
+  return CacheDataSavePath("notams.json");
+}
+
+AllocatedPath
+NOTAMCache::ResolveFilePath()
+{
+  return ResolveCacheDataPath("notams.json");
 }
 
 bool

--- a/src/NOTAM/NOTAMCache.hpp
+++ b/src/NOTAM/NOTAMCache.hpp
@@ -26,8 +26,12 @@ struct CacheMetadata {
 
 namespace NOTAMCache {
 
-/** Returns the path to the NOTAM cache file. */
+/** Canonical path for writing the NOTAM cache file. */
 AllocatedPath GetFilePath();
+
+/** Resolve the NOTAM cache file for reading (cache/ or legacy root). */
+[[gnu::pure]]
+AllocatedPath ResolveFilePath();
 
 /**
  * Read and parse the NOTAM cache file into a JSON value using

--- a/src/NOTAM/NOTAMGlue.cpp
+++ b/src/NOTAM/NOTAMGlue.cpp
@@ -1092,7 +1092,7 @@ NOTAMGlue::UpdateAirspaces(Airspaces &airspaces)
 AllocatedPath
 NOTAMGlue::GetNOTAMCacheFilePath() const
 {
-  return NOTAMCache::GetFilePath();
+  return NOTAMCache::ResolveFilePath();
 }
 
 static CacheMetadata
@@ -1143,7 +1143,7 @@ NOTAMGlue::SaveNOTAMsToFile(const boost::json::value &api_response,
 
   LogFmt("NOTAM: Saving NOTAM cache");
   try {
-    NOTAMCache::SaveToFile(GetNOTAMCacheFilePath(), api_response, location,
+    NOTAMCache::SaveToFile(NOTAMCache::GetFilePath(), api_response, location,
                            settings_snapshot.radius_km,
                            settings_snapshot.refresh_interval_min,
                            settings_snapshot.api_base_url.c_str(),

--- a/src/OV/OpenVarioMenu.cpp
+++ b/src/OV/OpenVarioMenu.cpp
@@ -340,7 +340,7 @@ ShowLogbook() noexcept
   FlightListRenderer renderer{look.text_font, look.bold_font};
 
   try {
-    FileLineReaderA file(LocalPath("flights.log"));
+    FileLineReaderA file(ResolveLogsDataPath("flights.log"));
 
     FlightParser parser{file};
     FlightInfo flight;

--- a/src/Profile/PathValue.cpp
+++ b/src/Profile/PathValue.cpp
@@ -30,7 +30,7 @@ ProfileMap::GetPath(std::string_view key) const noexcept
   if (StringIsEmpty(buffer))
     return nullptr;
 
-  return ExpandLocalPath(Path(buffer));
+  return ResolveLocalDataFile(ExpandLocalPath(Path(buffer)));
 }
 
 std::vector<AllocatedPath>
@@ -55,7 +55,8 @@ ProfileMap::GetMultiplePaths(std::string_view key, const char *patterns) const
     size_t length;
     const char *patterns_iterator = patterns;
     if (patterns == nullptr) {
-      paths.push_back(ExpandLocalPath(AllocatedPath(path)));
+      paths.push_back(ResolveLocalDataFile(
+        ExpandLocalPath(AllocatedPath(path))));
       continue;
     }
     while ((length = strlen(patterns_iterator)) > 0) {
@@ -65,7 +66,8 @@ ProfileMap::GetMultiplePaths(std::string_view key, const char *patterns) const
       if (StringEndsWithIgnoreCase(path.c_str(), patterns_iterator + 1))
 #endif
       {
-        paths.push_back(ExpandLocalPath(AllocatedPath(path)));
+        paths.push_back(ResolveLocalDataFile(
+          ExpandLocalPath(AllocatedPath(path))));
         break;
       }
       patterns_iterator += length + 1;

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -9,6 +9,7 @@
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Logger/Logger.hpp"
 #include "Interface.hpp"
+#include "Repository/FileType.hpp"
 #include "CatmullRomInterpolator.hpp"
 #include "time/Cast.hxx"
 
@@ -49,7 +50,8 @@ Replay::Start(Path _path)
 
   if (path == nullptr || path.empty()) {
     replay = new DemoReplayGlue(device_blackboard, task_manager);
-  } else if (path.EndsWithIgnoreCase(".igc")) {
+  } else if (FilenameMatchesFileType(path.GetBase().c_str(),
+                                      FileType::IGC)) {
     replay = new IgcReplay(std::make_unique<FileLineReaderA>(path));
 
     cli = new CatmullRomInterpolator(FloatDuration{0.98});

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "FileType.hpp"
+#include "system/Path.hpp"
+#include "Compatibility/path.h"
+
+AllocatedPath
+GetFileTypeDefaultDir(const FileType file_type)
+{
+  switch (file_type) {
+  case FileType::RASP:
+    return AllocatedPath::Build("weather", "rasp");
+
+  case FileType::MAP:
+    return AllocatedPath("maps");
+
+  case FileType::AIRSPACE:
+    return AllocatedPath("airspace");
+
+  case FileType::WAYPOINT:
+    return AllocatedPath("waypoints");
+
+  case FileType::UNKNOWN:
+  case FileType::WAYPOINTDETAILS:
+  case FileType::FLARMNET:
+  case FileType::IGC:
+  case FileType::XCI:
+  case FileType::TASK:
+  case FileType::CHECKLIST:
+    return nullptr;
+  }
+
+  return nullptr;
+}

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -4,6 +4,9 @@
 #include "FileType.hpp"
 #include "system/Path.hpp"
 #include "Compatibility/path.h"
+#include "util/StringCompare.hxx"
+
+#include <cstring>
 
 const char *
 GetFileTypePatterns(const FileType file_type) noexcept
@@ -111,4 +114,52 @@ GetFileTypeDefaultDir(const FileType file_type)
   }
 
   return nullptr;
+}
+
+FileType
+SpecialFilenameType(const char *filename) noexcept
+{
+  for (uint8_t i = 1; i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    const auto type = static_cast<FileType>(i);
+    const char *p = GetFileTypePatterns(type);
+    size_t length;
+    while ((length = std::strlen(p)) > 0) {
+      if (p[0] != '*' && StringIsEqualIgnoreCase(filename, p))
+        return type;
+      p += length + 1;
+    }
+  }
+
+  return FileType::UNKNOWN;
+}
+
+bool
+FilenameMatchesFileType(const char *filename,
+                        FileType file_type) noexcept
+{
+  bool wildcard_match = false;
+
+  const char *p = GetFileTypePatterns(file_type);
+  size_t length;
+  while ((length = std::strlen(p)) > 0) {
+    if (p[0] == '*') {
+      /* suffix match: "*.lua" matches "init.lua" */
+      if (StringEndsWithIgnoreCase(filename, p + 1))
+        wildcard_match = true;
+    } else {
+      /* exact match: "xcsoar-flarm.txt" — return immediately */
+      if (StringIsEqualIgnoreCase(filename, p))
+        return true;
+    }
+    p += length + 1;
+  }
+
+  if (!wildcard_match)
+    return false;
+
+  /* a wildcard matched, but check whether another type claims this
+     filename with an exact pattern (e.g. "xcsoar-flarm.txt" should
+     not be identified as an airspace file via "*.txt") */
+  const auto special = SpecialFilenameType(filename);
+  return special == FileType::UNKNOWN || special == file_type;
 }

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -39,6 +39,9 @@ GetFileTypePatterns(const FileType file_type) noexcept
   case FileType::XCI:
     return "*.xci\0";
 
+  case FileType::LUA:
+    return "*.lua\0";
+
   case FileType::TASK:
     return "*.tsk\0*.cup\0*.igc\0";
 
@@ -97,6 +100,10 @@ GetFileTypeDefaultDir(const FileType file_type)
 
   case FileType::XCI:
     return AllocatedPath("input");
+
+  case FileType::LUA:
+    return AllocatedPath("lua");
+
   case FileType::PROFILE:
   case FileType::UNKNOWN:
   case FileType::COUNT:

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -82,9 +82,6 @@ GetFileTypeDefaultDir(const FileType file_type)
   case FileType::RASP:
     return AllocatedPath::Build("weather", "rasp");
 
-  case FileType::XCI:
-    return AllocatedPath("input");
-
   case FileType::TASK:
     return AllocatedPath("tasks");
 
@@ -95,8 +92,12 @@ GetFileTypeDefaultDir(const FileType file_type)
   case FileType::NMEA:
     return AllocatedPath("logs");
 
-  case FileType::PROFILE:
   case FileType::PLANE:
+    return AllocatedPath("planes");
+
+  case FileType::XCI:
+    return AllocatedPath("input");
+  case FileType::PROFILE:
   case FileType::UNKNOWN:
   case FileType::COUNT:
     return nullptr;

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -5,29 +5,100 @@
 #include "system/Path.hpp"
 #include "Compatibility/path.h"
 
+const char *
+GetFileTypePatterns(const FileType file_type) noexcept
+{
+  switch (file_type) {
+  case FileType::AIRSPACE:
+    return "*.txt\0*.air\0*.sua\0";
+
+  case FileType::WAYPOINT:
+    return "*.dat\0*.xcw\0*.cup\0*.cupx\0*.wpz\0*.wpt\0";
+
+  case FileType::WAYPOINTDETAILS:
+    return "*.txt\0";
+
+  case FileType::MAP:
+    return "*.xcm\0*.lkm\0";
+
+  case FileType::FLARMNET:
+    return "*.fln\0";
+
+  case FileType::FLARMDB:
+    return "xcsoar-flarm.txt\0flarm-msg-data.csv\0";
+
+  case FileType::IGC:
+    return "*.igc\0";
+
+  case FileType::NMEA:
+    return "*.nmea\0";
+
+  case FileType::RASP:
+    return "*-rasp*.dat\0";
+
+  case FileType::XCI:
+    return "*.xci\0";
+
+  case FileType::TASK:
+    return "*.tsk\0*.cup\0*.igc\0";
+
+  case FileType::CHECKLIST:
+    return "*.xcc\0xcsoar-checklist.txt\0";
+
+  case FileType::PROFILE:
+    return "*.prf\0";
+
+  case FileType::PLANE:
+    return "*.xcp\0";
+
+  case FileType::UNKNOWN:
+  case FileType::COUNT:
+    return "\0";
+  }
+
+  return "\0";
+}
+
 AllocatedPath
 GetFileTypeDefaultDir(const FileType file_type)
 {
   switch (file_type) {
-  case FileType::RASP:
-    return AllocatedPath::Build("weather", "rasp");
-
-  case FileType::MAP:
-    return AllocatedPath("maps");
-
   case FileType::AIRSPACE:
     return AllocatedPath("airspace");
 
   case FileType::WAYPOINT:
     return AllocatedPath("waypoints");
 
-  case FileType::UNKNOWN:
   case FileType::WAYPOINTDETAILS:
+    return AllocatedPath::Build("waypoints", "details");
+
+  case FileType::MAP:
+    return AllocatedPath("maps");
+
+  case FileType::FLARMDB:
   case FileType::FLARMNET:
-  case FileType::IGC:
+    return AllocatedPath("flarm");
+
+  case FileType::RASP:
+    return AllocatedPath::Build("weather", "rasp");
+
   case FileType::XCI:
+    return AllocatedPath("input");
+
   case FileType::TASK:
+    return AllocatedPath("tasks");
+
   case FileType::CHECKLIST:
+    return AllocatedPath("checklists");
+
+  case FileType::IGC:
+  case FileType::NMEA:
+    return AllocatedPath("logs");
+
+  case FileType::PROFILE:
+  case FileType::PLANE:
+  case FileType::UNKNOWN:
+  case FileType::COUNT:
     return nullptr;
   }
 

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -7,6 +7,7 @@
 #include "util/StringCompare.hxx"
 
 #include <cstring>
+#include <string_view>
 
 const char *
 GetFileTypePatterns(const FileType file_type) noexcept
@@ -131,6 +132,69 @@ SpecialFilenameType(const char *filename) noexcept
   }
 
   return FileType::UNKNOWN;
+}
+
+FileType
+ClassifyDataFilename(const char *filename) noexcept
+{
+  const auto special = SpecialFilenameType(filename);
+  if (special != FileType::UNKNOWN &&
+      GetFileTypeDefaultDir(special) != nullptr)
+    return special;
+
+  for (uint8_t i = 1; i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    const auto type = static_cast<FileType>(i);
+    if (GetFileTypeDefaultDir(type) == nullptr)
+      continue;
+
+    if (FilenameMatchesFileType(filename, type))
+      return type;
+  }
+
+  return FileType::UNKNOWN;
+}
+
+static bool
+IsUserRepositoryFilename(const char *filename) noexcept
+{
+  static constexpr std::string_view prefix{"user_repository_"};
+  return filename != nullptr &&
+         StringStartsWith(filename, prefix);
+}
+
+AllocatedPath
+GetLayoutSubdirForFilename(const char *filename) noexcept
+{
+  if (filename == nullptr || *filename == '\0')
+    return nullptr;
+
+  const FileType type = ClassifyDataFilename(filename);
+  if (type != FileType::UNKNOWN) {
+    AllocatedPath dir = GetFileTypeDefaultDir(type);
+    if (dir != nullptr)
+      return dir;
+  }
+
+  if (StringIsEqualIgnoreCase(filename, "notams.json") ||
+      StringIsEqualIgnoreCase(filename, "repository") ||
+      IsUserRepositoryFilename(filename))
+    return AllocatedPath("cache");
+
+  if (StringIsEqualIgnoreCase(filename, "flights.log") ||
+      StringIsEqualIgnoreCase(filename, "xcsoar.log") ||
+      StringIsEqualIgnoreCase(filename, "xcsoar-old.log") ||
+      StringIsEqualIgnoreCase(filename, "xcsoar-startup.log") ||
+      StringIsEqualIgnoreCase(filename, "xcsoar-persist.log"))
+    return AllocatedPath("logs");
+
+  return nullptr;
+}
+
+bool
+IsCacheLayoutFilename(const char *filename) noexcept
+{
+  const AllocatedPath subdir = GetLayoutSubdirForFilename(filename);
+  return subdir != nullptr && subdir == AllocatedPath("cache");
 }
 
 bool

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -143,8 +143,9 @@ FilenameMatchesFileType(const char *filename,
   size_t length;
   while ((length = std::strlen(p)) > 0) {
     if (p[0] == '*') {
-      /* suffix match: "*.lua" matches "init.lua" */
-      if (StringEndsWithIgnoreCase(filename, p + 1))
+      /* wildcard pattern: "*.lua" matches "init.lua",
+         "*-rasp*.dat" matches "SI-RASP-National-ThermalMap.dat" */
+      if (WildcardMatchIgnoreCase(p, filename))
         wildcard_match = true;
     } else {
       /* exact match: "xcsoar-flarm.txt" — return immediately */

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -18,3 +18,7 @@ enum class FileType : uint8_t {
   TASK,
   CHECKLIST,
 };
+
+class AllocatedPath;
+
+AllocatedPath GetFileTypeDefaultDir(const FileType file_type);

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -12,13 +12,25 @@ enum class FileType : uint8_t {
   WAYPOINTDETAILS,
   MAP,
   FLARMNET,
+  FLARMDB,
   IGC,
+  NMEA,
   RASP,
   XCI,
   TASK,
   CHECKLIST,
+  PROFILE,
+  PLANE,
+  COUNT,
 };
 
 class AllocatedPath;
 
 AllocatedPath GetFileTypeDefaultDir(const FileType file_type);
+
+/**
+ * Return NUL-separated list of file glob patterns for the given
+ * type (e.g. "*.txt\0*.air\0*.sua\0").  The list is terminated by
+ * an empty pattern.
+ */
+const char *GetFileTypePatterns(const FileType file_type) noexcept;

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -16,11 +16,11 @@ enum class FileType : uint8_t {
   IGC,
   NMEA,
   RASP,
-  XCI,
   TASK,
   CHECKLIST,
   PROFILE,
   PLANE,
+  XCI,
   COUNT,
 };
 

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -21,6 +21,7 @@ enum class FileType : uint8_t {
   PROFILE,
   PLANE,
   XCI,
+  LUA,
   COUNT,
 };
 

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -8,6 +8,7 @@
 enum class FileType : uint8_t {
   UNKNOWN,
   AIRSPACE,
+  RASP,     // RASP before WAYPOINT, so "-rasp.dat" overrides ".dat"
   WAYPOINT,
   WAYPOINTDETAILS,
   MAP,
@@ -15,7 +16,6 @@ enum class FileType : uint8_t {
   FLARMDB,
   IGC,
   NMEA,
-  RASP,
   TASK,
   CHECKLIST,
   PROFILE,

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -35,3 +35,19 @@ AllocatedPath GetFileTypeDefaultDir(const FileType file_type);
  * an empty pattern.
  */
 const char *GetFileTypePatterns(const FileType file_type) noexcept;
+
+/**
+ * Check whether a filename matches an exact (non-wildcard) pattern
+ * for any #FileType.  Returns that type, or FileType::UNKNOWN if
+ * no exact match exists.
+ */
+[[gnu::pure]]
+FileType SpecialFilenameType(const char *filename) noexcept;
+
+/**
+ * Check whether a filename matches any of the glob patterns
+ * for the given #FileType.
+ */
+[[gnu::pure]]
+bool FilenameMatchesFileType(const char *filename,
+                             FileType file_type) noexcept;

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -51,3 +51,25 @@ FileType SpecialFilenameType(const char *filename) noexcept;
 [[gnu::pure]]
 bool FilenameMatchesFileType(const char *filename,
                              FileType file_type) noexcept;
+
+/**
+ * Guess the #FileType of a data file from its basename, using the same
+ * rules as repository downloads and data-layout migration (enum order
+ * matters, e.g. RASP before WAYPOINT for "*.dat").
+ */
+[[gnu::pure]]
+FileType ClassifyDataFilename(const char *filename) noexcept;
+
+/**
+ * Subdirectory for a data file during layout migration (typed content
+ * plus built-in files such as repository, notams.json, app logs).
+ */
+[[gnu::pure]]
+AllocatedPath GetLayoutSubdirForFilename(const char *filename) noexcept;
+
+/**
+ * True for repository manifests and other files stored under product
+ * cache/ on desktop (Android uses #GetCachePath() instead).
+ */
+[[gnu::pure]]
+bool IsCacheLayoutFilename(const char *filename) noexcept;

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -83,7 +83,7 @@ PurgeChangedUserRepositoryFiles(const char *old_list,
     if (old_entry != new_entry) {
       char filename[32];
       StringFormat(filename, std::size(filename), "user_repository_%d", i);
-      File::Delete(LocalPath(filename));
+      File::Delete(ResolveRepositoryDataPath(filename));
     }
   }
 }
@@ -100,7 +100,7 @@ void
 LoadAllRepositories(FileRepository &repository)
 {
   try {
-    FileLineReaderA reader(LocalPath("repository"));
+    FileLineReaderA reader(ResolveRepositoryDataPath("repository"));
     ParseFileRepository(repository, reader);
   } catch (const std::runtime_error &) {
     /* not yet downloaded - ignore */
@@ -108,7 +108,7 @@ LoadAllRepositories(FileRepository &repository)
 
   for (const auto &repo : GetUserRepositories()) {
     try {
-      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
+      FileLineReaderA reader(ResolveRepositoryDataPath(repo.filename.c_str()));
       ParseFileRepository(repository, reader);
     } catch (const std::runtime_error &) {
       /* not yet downloaded - ignore */
@@ -122,14 +122,20 @@ EnqueueRepositoryDownload(bool force, bool main_repo, bool user_repo)
   if (main_repo) {
     if (!repository_downloaded || force) {
       repository_downloaded = true;
-      Net::DownloadManager::Enqueue(REPOSITORY_URI, Path("repository"));
+      Directory::Create(GetCachePath());
+      const auto path = RepositoryDownloadDestinationPath("repository");
+      Net::DownloadManager::Enqueue(REPOSITORY_URI, Path(path.c_str()));
     }
   }
 
   // Enqueue additional user-defined repository URIs, if set
   if (user_repo) {
-    for (const auto &repo : GetUserRepositories())
-      Net::DownloadManager::Enqueue(repo.uri.c_str(), Path(repo.filename.c_str()));
+    Directory::Create(GetCachePath());
+    for (const auto &repo : GetUserRepositories()) {
+      const auto path =
+        RepositoryDownloadDestinationPath(repo.filename.c_str());
+      Net::DownloadManager::Enqueue(repo.uri.c_str(), Path(path.c_str()));
+    }
   }
 }
 
@@ -140,7 +146,10 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
 {
   if (main_repo) {
     try {
-      if (DownloadFileModal(_("Updating repository"), REPOSITORY_URI, "repository") == nullptr)
+      Directory::Create(GetCachePath());
+      const auto path = RepositoryDownloadDestinationPath("repository");
+      if (DownloadFileModal(_("Updating repository"), REPOSITORY_URI,
+                            path.c_str()) == nullptr)
         return; /* cancelled */
       repository_downloaded = true;
     } catch (...) {
@@ -151,8 +160,11 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
   if (user_repo) {
     for (const auto &repo : GetUserRepositories()) {
       try {
-        if (DownloadFileModal(_("Updating repository"),
-                              repo.uri.c_str(), repo.filename.c_str()) == nullptr)
+        Directory::Create(GetCachePath());
+        const auto path =
+          RepositoryDownloadDestinationPath(repo.filename.c_str());
+        if (DownloadFileModal(_("Updating repository"), repo.uri.c_str(),
+                              path.c_str()) == nullptr)
           return; /* cancelled */
       } catch (...) {
         ShowError(std::current_exception(), _("Updating repository"));

--- a/src/Repository/Parser.cpp
+++ b/src/Repository/Parser.cpp
@@ -6,6 +6,7 @@
 #include "io/LineReader.hpp"
 #include "util/StringStrip.hxx"
 #include "util/HexString.hpp"
+#include "system/Path.hpp"
 
 /**
  * Parses a line of the repository file.
@@ -37,6 +38,10 @@ Commit(FileRepository &repository, AvailableFile &file)
 {
   if (file.IsEmpty())
     return true;
+  
+  const Path path(file.name.c_str());
+  if (!path.IsValidFilename())
+    return false;
 
   if (!file.IsValid())
     return false;

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -100,6 +100,7 @@
 
 #include "lua/StartFile.hpp"
 #include "lua/Background.hpp"
+#include "Repository/FileType.hpp"
 
 #include "util/ScopeExit.hxx"
 
@@ -154,7 +155,7 @@ static void
 AfterStartup()
 {
   try {
-    const auto lua_path = LocalPath("lua");
+    const auto lua_path = LocalPath(GetFileTypeDefaultDir(FileType::LUA));
     const AllocatedPath init_path = AllocatedPath::Build(lua_path, "init.lua");
     if (File::Exists(init_path))
       Lua::StartFile(init_path);

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -59,6 +59,7 @@
 #include "MergeThread.hpp"
 #include "CalculationThread.hpp"
 #include "Replay/Replay.hpp"
+#include "DataLayoutMigration.hpp"
 #include "LocalPath.hpp"
 #include "system/FileUtil.hpp"
 #include "io/FileCache.hpp"
@@ -391,6 +392,8 @@ Startup(UI::Display &display)
   if (!LoadProfile())
     return false;
 
+  MigrateDataLayoutToSubdirs();
+
   operation.SetText(_("Initialising"));
 
   /* create XCSoarData on the first start */
@@ -656,7 +659,7 @@ Startup(UI::Display &display)
 
   if (!is_simulator() && computer_settings.logger.enable_flight_logger) {
     backend_components->flight_logger = std::make_unique<GlueFlightLogger>(live_blackboard);
-    backend_components->flight_logger->SetPath(LocalPath("flights.log"));
+    backend_components->flight_logger->SetPath(LogsDataSavePath("flights.log"));
   }
 
   if (computer_settings.logger.enable_nmea_logger)

--- a/src/Task/DefaultTask.cpp
+++ b/src/Task/DefaultTask.cpp
@@ -4,6 +4,7 @@
 #include "DefaultTask.hpp"
 #include "LoadFile.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "system/Path.hpp"
 
@@ -11,7 +12,7 @@ std::unique_ptr<OrderedTask>
 LoadDefaultTask(const TaskBehaviour &task_behaviour,
                 const Waypoints *waypoints) noexcept
 {
-  const auto path = LocalPath(default_task_path);
+  const auto path = GetDefaultTaskPath();
 
   try {
     return LoadTask(path, task_behaviour, waypoints);
@@ -21,4 +22,17 @@ LoadDefaultTask(const TaskBehaviour &task_behaviour,
     task->SetFactory(task_behaviour.task_type_default);
     return task;
   }
+}
+
+AllocatedPath
+GetDefaultTaskPath() noexcept
+{
+  return ResolveTypedDataFilePath(FileType::TASK, default_task_path,
+                                  {"Default.tsk"});
+}
+
+AllocatedPath
+GetDefaultTaskSavePath() noexcept
+{
+  return TypedDataSavePath(FileType::TASK, default_task_path);
 }

--- a/src/Task/DefaultTask.hpp
+++ b/src/Task/DefaultTask.hpp
@@ -3,21 +3,34 @@
 
 #pragma once
 
+#include "system/Path.hpp"
+
 #include <memory>
 
 struct TaskBehaviour;
 class OrderedTask;
 class Waypoints;
 
-#define default_task_path "Default.tsk"
+#define default_task_path "default.tsk"
 
 /**
- * Creates an ordered task based on the Default.tsk file
+ * Path to default.tsk for loading (tasks/ first, legacy data-root fallback).
+ */
+[[gnu::pure]]
+AllocatedPath GetDefaultTaskPath() noexcept;
+
+/**
+ * Path to default.tsk for saving (always under tasks/).
+ */
+AllocatedPath GetDefaultTaskSavePath() noexcept;
+
+/**
+ * Creates an ordered task based on the default.tsk file
  * Consumer's responsibility to delete task
  *
  * @param waypoints waypoint structure
- * @param failfactory default task type used if Default.tsk is invalid
- * @return OrderedTask from Default.tsk file or if Default.tsk is invalid
+ * @param failfactory default task type used if default.tsk is invalid
+ * @return OrderedTask from default.tsk file or if default.tsk is invalid
  * or non-existent, returns empty task with defaults set by
  * config task defaults
  */

--- a/src/Task/FileProtectedTaskManager.cpp
+++ b/src/Task/FileProtectedTaskManager.cpp
@@ -18,6 +18,5 @@ ProtectedTaskManager::TaskSave(Path path)
 void
 ProtectedTaskManager::TaskSaveDefault()
 {
-  const auto path = LocalPath(default_task_path);
-  TaskSave(path);
+  TaskSave(GetDefaultTaskSavePath());
 }

--- a/src/Waypoint/Patterns.hpp
+++ b/src/Waypoint/Patterns.hpp
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright The XCSoar Project
-
-#pragma once
-
-#define WAYPOINT_FILE_PATTERNS "*.dat\0*.xcw\0*.cup\0*.cupx\0*.wpz\0*.wpt\0"

--- a/src/Waypoint/SaveGlue.cpp
+++ b/src/Waypoint/SaveGlue.cpp
@@ -9,11 +9,12 @@
 #include "io/FileOutputStream.hxx"
 #include "io/BufferedOutputStream.hxx"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 
 void
 WaypointGlue::SaveWaypoints(const Waypoints &way_points)
 {
-  const auto path = LocalPath("user.cup");
+  const auto path = TypedDataSavePath(FileType::WAYPOINT, "user.cup");
 
   FileOutputStream file(path);
   BufferedOutputStream writer(file);
@@ -29,7 +30,7 @@ WaypointGlue::SaveWaypoints(const Waypoints &way_points)
 void
 WaypointGlue::SaveWaypoint(const Waypoint &wp)
 {
-  const auto path = LocalPath("user.cup");
+  const auto path = TypedDataSavePath(FileType::WAYPOINT, "user.cup");
 
   FileOutputStream file(path, FileOutputStream::Mode::APPEND_OR_CREATE);
   BufferedOutputStream writer(file);

--- a/src/Waypoint/WaypointGlue.cpp
+++ b/src/Waypoint/WaypointGlue.cpp
@@ -7,8 +7,8 @@
 #include "LocalPath.hpp"
 #include "LogFile.hpp"
 #include "Operation/Operation.hpp"
-#include "Patterns.hpp"
 #include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
 #include "Waypoint/Waypoints.hpp"
 #include "WaypointFileType.hpp"
 #include "WaypointReader.hpp"
@@ -83,7 +83,7 @@ LoadWaypoints(Waypoints &way_points, const RasterTerrain *terrain,
 
   // ### FIRST FILE ###
   auto paths = Profile::GetMultiplePaths(ProfileKeys::WaypointFileList,
-                                         WAYPOINT_FILE_PATTERNS);
+                                         GetFileTypePatterns(FileType::WAYPOINT));
   uint8_t file_num = 0;
   for (const auto &path : paths) {
     found |= LoadWaypointFile(way_points, path, WaypointOrigin::PRIMARY,
@@ -92,7 +92,7 @@ LoadWaypoints(Waypoints &way_points, const RasterTerrain *terrain,
 
   // ### WATCHED WAYPOINT/THIRD FILE ###
   paths = Profile::GetMultiplePaths(ProfileKeys::WatchedWaypointFileList,
-                                    WAYPOINT_FILE_PATTERNS);
+                                    GetFileTypePatterns(FileType::WAYPOINT));
   file_num = 0;
   for (const auto &path : paths) {
     found |= LoadWaypointFile(way_points, path, WaypointOrigin::WATCHED,

--- a/src/Waypoint/WaypointGlue.cpp
+++ b/src/Waypoint/WaypointGlue.cpp
@@ -121,7 +121,8 @@ LoadWaypoints(Waypoints &way_points, const RasterTerrain *terrain,
     }
   }
   //Load user.cup
-  LoadWaypointFile(way_points, LocalPath("user.cup"),
+  LoadWaypointFile(way_points,
+                   ResolveTypedDataFilePath(FileType::WAYPOINT, "user.cup"),
                    WaypointFileType::SEEYOU,
                    WaypointOrigin::USER, 0, terrain, progress);
   // Optimise the waypoint list after attaching new waypoints

--- a/src/Weather/Rasp/Configured.cpp
+++ b/src/Weather/Rasp/Configured.cpp
@@ -6,6 +6,7 @@
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 
 std::shared_ptr<RaspStore>
 LoadConfiguredRasp(bool legacy_default) noexcept
@@ -14,7 +15,7 @@ LoadConfiguredRasp(bool legacy_default) noexcept
   if (legacy_default && path == nullptr)
     /* if no path is configured, attempt to load xcsoar-rasp.dat
        (XCSoar < 7.29) */
-    path = LocalPath(RASP_FILENAME);
+    path = ResolveTypedDataFilePath(FileType::RASP, RASP_FILENAME);
 
   auto rasp = std::make_shared<RaspStore>(std::move(path));
   rasp->ScanAll();

--- a/src/io/DataFile.cpp
+++ b/src/io/DataFile.cpp
@@ -4,6 +4,7 @@
 #include "DataFile.hpp"
 #include "FileReader.hxx"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "system/Path.hpp"
 #include "util/StringCompare.hxx"
 
@@ -15,6 +16,7 @@ OpenDataFile(const char *name)
   assert(name != nullptr);
   assert(!StringIsEmpty(name));
 
-  const auto path = LocalPath(name);
+  const auto path =
+    ResolveLocalDataFile(LocalPath(name), ClassifyDataFilename(name));
   return std::make_unique<FileReader>(path);
 }

--- a/src/lua/Full.cpp
+++ b/src/lua/Full.cpp
@@ -16,8 +16,8 @@
 #include "Dialogs.hpp"
 #include "Legacy.hpp"
 #include "LocalPath.hpp"
-#include "Compatibility/path.h"
 #include "system/Path.hpp"
+#include "Repository/FileType.hpp"
 #include "Airspace.hpp"
 #include "Task.hpp"
 #include "Settings.hpp"
@@ -57,8 +57,9 @@ Lua::NewFullState()
   InitInputEvent(L);
 
   {
+    const auto lua_dir = GetFileTypeDefaultDir(FileType::LUA);
     SetPackagePath(L,
-                   LocalPath("lua" DIR_SEPARATOR_S "?.lua").c_str());
+                   LocalPath(AllocatedPath::Build(lua_dir, "?.lua")).c_str());
   }
 
   return L;

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -176,7 +176,7 @@ DownloadManagerThread::Start() noexcept
   current_position = 0;
 
   task.Start(DownloadToFile(*Net::curl, item.uri.c_str(),
-                            LocalPath(item.path_relative.c_str()),
+                            ResolveDownloadDestinationPath(item.path_relative),
                             nullptr, *this),
              BIND_THIS_METHOD(OnCompletion));
 }

--- a/src/system/FileUtil.cpp
+++ b/src/system/FileUtil.cpp
@@ -70,15 +70,11 @@ IsDots(const char *str) noexcept
 static bool
 checkFilter(const char *filename, const char *filter) noexcept
 {
-  // filter = e.g. "*.igc" or "config/*.prf"
-  // todo: make filters like "config/*.prf" work
-
-  // if invalid or short filter "*" -> return true
-  // todo: check for asterisk
-  if (!filter || StringIsEmpty(filter + 1))
+  // filter = e.g. "*.igc" or "*-rasp*.dat"
+  if (!filter)
     return true;
 
-  return StringEndsWithIgnoreCase(filename, filter + 1);
+  return WildcardMatchIgnoreCase(filter, filename);
 }
 
 static bool

--- a/src/system/Path.cpp
+++ b/src/system/Path.cpp
@@ -71,6 +71,39 @@ Path::IsBase() const noexcept
 #endif
 }
 
+bool
+Path::IsValidFilename() const noexcept
+{
+  if (*this == nullptr)
+    return false;
+  if (empty())
+    return false;
+
+#ifdef _WIN32  
+  const char *invalid_chars = "<>:\"/\\|?*";
+  size_t len = StringLength(c_str());
+
+  if (c_str()[len - 1] == ' ' || c_str()[len - 1] == '.')
+    return false;
+
+  for (size_t i = 0; i < len; ++i)
+  {
+    unsigned char c = c_str()[i];
+
+    // Control characters
+    if (c < 32)
+      return false;
+
+    if (std::strchr(invalid_chars, c))
+      return false;
+  }
+  return true;
+#else
+  // On Unix-like systems, only '/' is invalid in filenames
+  return IsBase();
+#endif
+}
+
 [[gnu::pure]]
 static Path::const_pointer
 LastSeparator(Path::const_pointer path) noexcept

--- a/src/system/Path.cpp
+++ b/src/system/Path.cpp
@@ -78,8 +78,9 @@ Path::IsValidFilename() const noexcept
     return false;
   if (empty())
     return false;
-
-#ifdef _WIN32  
+  if (StringIsEqual(c_str(), ".") || StringIsEqual(c_str(), ".."))
+    return false;
+#ifdef _WIN32
   const char *invalid_chars = "<>:\"/\\|?*";
   size_t len = StringLength(c_str());
 

--- a/src/system/Path.hpp
+++ b/src/system/Path.hpp
@@ -80,6 +80,13 @@ public:
   [[gnu::pure]]
   bool IsBase() const noexcept;
 
+ /**
+   * Is this path a "valid filename"?
+   * Must be not empty and a base name
+   */
+  [[gnu::pure]]
+  bool IsValidFilename() const noexcept;
+
   /**
    * Returns the parent of the specified path, i.e. the part before
    * the last separator.  Returns "." if there is no directory name.
@@ -248,6 +255,11 @@ public:
   [[gnu::pure]]
   bool IsBase() const noexcept {
     return Path(*this).IsBase();
+  }
+
+  [[gnu::pure]]
+  bool IsValidFilename() const noexcept {
+    return Path(*this).IsValidFilename();
   }
 
   AllocatedPath GetParent() const noexcept {

--- a/src/util/StringCompare.cxx
+++ b/src/util/StringCompare.cxx
@@ -2,6 +2,7 @@
 // author: Max Kellermann <max.kellermann@gmail.com>
 
 #include "StringCompare.hxx"
+#include "CharUtil.hxx"
 
 #include <cstring>
 
@@ -40,4 +41,34 @@ FindStringSuffix(const char *p, const char *suffix) noexcept
 	return std::memcmp(q, suffix, suffix_length) == 0
 		? q
 		: nullptr;
+}
+
+bool
+WildcardMatchIgnoreCase(const char *pattern, const char *s) noexcept
+{
+	while (true) {
+		if (*pattern == '*') {
+			/* collapse runs of '*' */
+			while (pattern[1] == '*')
+				++pattern;
+
+			if (pattern[1] == 0)
+				return true;
+
+			for (; *s != 0; ++s)
+				if (WildcardMatchIgnoreCase(pattern + 1, s))
+					return true;
+			return false;
+		}
+
+		if (*s == 0)
+			return *pattern == 0;
+
+		if (*pattern != '?' &&
+		    ToLowerASCII(*pattern) != ToLowerASCII(*s))
+			return false;
+
+		++pattern;
+		++s;
+	}
 }

--- a/src/util/StringCompare.hxx
+++ b/src/util/StringCompare.hxx
@@ -108,6 +108,15 @@ StringAfterPrefixIgnoreCase(std::string_view haystack,
 const char *
 FindStringSuffix(const char *p, const char *suffix) noexcept;
 
+/**
+ * Match a string against a shell-style wildcard pattern. Supports
+ * "*" (matches any sequence, including empty) and "?" (matches any
+ * single character). Comparison is ASCII case-insensitive.
+ */
+[[gnu::pure]] [[gnu::nonnull]]
+bool
+WildcardMatchIgnoreCase(const char *pattern, const char *s) noexcept;
+
 template<typename T>
 bool
 SkipPrefix(std::basic_string_view<T> &haystack,

--- a/test/src/RunAirspaceWarningDialog.cpp
+++ b/test/src/RunAirspaceWarningDialog.cpp
@@ -8,7 +8,6 @@
 #include "ActionInterface.hpp"
 #include "Airspace/AirspaceGlue.hpp"
 #include "Airspace/AirspaceWarningManager.hpp"
-#include "Airspace/Patterns.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Components.hpp"
 #include "Dialogs/Airspace/Airspace.hpp"
@@ -20,6 +19,7 @@
 #include "Main.hpp"
 #include "Operation/Operation.hpp"
 #include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
 #include "ResourceLoader.hpp"
 #include "UIGlobals.hpp"
 #include "io/BufferedReader.hxx"
@@ -53,7 +53,7 @@ LoadFiles(Airspaces &airspace_database)
 {
   NullOperationEnvironment test_operation_environment;
   const auto paths = Profile::GetMultiplePaths(ProfileKeys::AirspaceFileList,
-                                               AIRSPACE_FILE_PATTERNS);
+                                               GetFileTypePatterns(FileType::AIRSPACE));
   for (auto it = paths.begin(); it < paths.end(); it++) {
     ParseAirspaceFile(airspace_database, *it, test_operation_environment);
   }

--- a/test/src/RunMapWindow.cpp
+++ b/test/src/RunMapWindow.cpp
@@ -8,7 +8,6 @@
 #define ENABLE_CLOSE_BUTTON
 #define ENABLE_LOOK
 #include "Airspace/AirspaceGlue.hpp"
-#include "Airspace/Patterns.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Engine/Airspace/Airspaces.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
@@ -20,6 +19,7 @@
 #include "Profile/Current.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/MapProfile.hpp"
+#include "Repository/FileType.hpp"
 #include "Terrain/Loader.hpp"
 #include "Terrain/RasterTerrain.hpp"
 #include "Topography/TopographyGlue.hpp"
@@ -110,7 +110,7 @@ LoadFiles(PlacesOfInterestSettings &poi_settings,
                         NULL, false);
 
   const auto paths = Profile::GetMultiplePaths(ProfileKeys::AirspaceFileList,
-                                               AIRSPACE_FILE_PATTERNS);
+                                               GetFileTypePatterns(FileType::AIRSPACE));
   for (auto it = paths.begin(); it < paths.end(); it++) {
     ParseAirspaceFile(airspace_database, *it, operation);
   }

--- a/test/src/TestDataLayoutMigration.cpp
+++ b/test/src/TestDataLayoutMigration.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DataLayoutMigration.hpp"
+#include "TestUtil.hpp"
+#include "LocalPath.hpp"
+#include "Profile/File.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Map.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Current.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/OutputStream.hxx"
+#include "system/FileUtil.hpp"
+#include "util/SpanCast.hxx"
+#include "util/StringAPI.hxx"
+
+#include <string_view>
+
+#include <cstdio>
+
+static bool
+WriteTextFile(Path path, const char *content) noexcept
+{
+  FileOutputStream out(path, FileOutputStream::Mode::CREATE);
+  out.Write(AsBytes(std::string_view(content)));
+  out.Commit();
+  return true;
+}
+
+static void
+TestMigratesFilesAndActiveProfileOnly()
+{
+  char template_path[] = "/tmp/xcsoar-migrate-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+
+  const Path data_path(template_path);
+  SetSingleDataPath(data_path);
+
+  ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("terrain.xcm")),
+                     "dummy"));
+  ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("repository")),
+                     "name=test\n"));
+  ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("notams.json")),
+                     "{}\n"));
+  const auto default_prf =
+    AllocatedPath::Build(data_path, Path("default.prf"));
+  const auto competition_prf =
+    AllocatedPath::Build(data_path, Path("competition.prf"));
+  ok1(WriteTextFile(default_prf,
+                     "MapFile=%LOCAL_PATH%\\terrain.xcm\n"));
+  ok1(WriteTextFile(competition_prf,
+                     "MapFile=%LOCAL_PATH%\\terrain.xcm\n"));
+
+  Profile::SetFiles(default_prf);
+  Profile::Load();
+
+  MigrateDataLayoutToSubdirs();
+
+  const auto map_path =
+    AllocatedPath::Build(AllocatedPath::Build(data_path, Path("maps")),
+                         Path("terrain.xcm"));
+  ok1(File::Exists(map_path));
+  ok1(!File::Exists(AllocatedPath::Build(data_path, Path("terrain.xcm"))));
+
+  const auto active_map = Profile::GetPath(ProfileKeys::MapFile);
+  ok1(active_map != nullptr);
+  ok1(StringFind(active_map.c_str(), "maps") != nullptr);
+
+  ProfileMap competition_map;
+  Profile::LoadFile(competition_map, competition_prf);
+  const auto stored =
+    ExpandLocalPath(Path("%LOCAL_PATH%\\terrain.xcm"));
+  ok1(stored != nullptr);
+  ok1(StringFind(stored.c_str(), "maps") == nullptr);
+
+  const auto resolved = competition_map.GetPath(ProfileKeys::MapFile);
+  ok1(resolved != nullptr);
+  ok1(File::Exists(resolved));
+  ok1(StringFind(resolved.c_str(), "maps") != nullptr);
+
+  ok1(File::Exists(AllocatedPath::Build(data_path,
+                                        Path(".xcsoar-subdir-layout-v1"))));
+  ok1(File::Exists(AllocatedPath::Build(AllocatedPath::Build(data_path,
+                                                             Path("cache")),
+                                        Path("repository"))));
+  ok1(!File::Exists(AllocatedPath::Build(data_path, Path("repository"))));
+  ok1(File::Exists(AllocatedPath::Build(AllocatedPath::Build(data_path,
+                                                             Path("cache")),
+                                        Path("notams.json"))));
+  ok1(!File::Exists(AllocatedPath::Build(data_path, Path("notams.json"))));
+}
+
+int
+main()
+{
+  plan_tests(20);
+  TestMigratesFilesAndActiveProfileOnly();
+  return exit_status();
+}

--- a/test/src/TestFileType.cpp
+++ b/test/src/TestFileType.cpp
@@ -50,12 +50,62 @@ TestPatterns()
   ok1(p != nullptr && p[0] == '\0');
 }
 
+static void
+TestSpecialFilenameType()
+{
+  // Exact-match patterns should return their type
+  ok1(SpecialFilenameType("xcsoar-flarm.txt") == FileType::FLARMDB);
+  ok1(SpecialFilenameType("flarm-msg-data.csv") == FileType::FLARMDB);
+  ok1(SpecialFilenameType("xcsoar-checklist.txt") == FileType::CHECKLIST);
+
+  // Case-insensitive
+  ok1(SpecialFilenameType("XCSoar-Flarm.TXT") == FileType::FLARMDB);
+
+  // Wildcard-only patterns should not match
+  ok1(SpecialFilenameType("test.lua") == FileType::UNKNOWN);
+  ok1(SpecialFilenameType("airspace.txt") == FileType::UNKNOWN);
+  ok1(SpecialFilenameType("nonexistent.xyz") == FileType::UNKNOWN);
+}
+
+static void
+TestFilenameMatchesFileType()
+{
+  // Basic wildcard matches
+  ok1(FilenameMatchesFileType("init.lua", FileType::LUA));
+  ok1(FilenameMatchesFileType("test.igc", FileType::IGC));
+  ok1(FilenameMatchesFileType("map.xcm", FileType::MAP));
+  ok1(FilenameMatchesFileType("profile.prf", FileType::PROFILE));
+
+  // Exact-match patterns
+  ok1(FilenameMatchesFileType("xcsoar-flarm.txt", FileType::FLARMDB));
+  ok1(FilenameMatchesFileType("xcsoar-checklist.txt", FileType::CHECKLIST));
+
+  // Key test: wildcard should NOT match if another type has an exact
+  // claim on this filename (xcsoar-flarm.txt matches *.txt for
+  // AIRSPACE, but FLARMDB owns it exactly)
+  ok1(!FilenameMatchesFileType("xcsoar-flarm.txt", FileType::AIRSPACE));
+  ok1(!FilenameMatchesFileType("xcsoar-checklist.txt", FileType::AIRSPACE));
+
+  // Regular .txt file should still match AIRSPACE (no exact claim)
+  ok1(FilenameMatchesFileType("london.txt", FileType::AIRSPACE));
+
+  // No match at all
+  ok1(!FilenameMatchesFileType("readme.md", FileType::LUA));
+  ok1(!FilenameMatchesFileType("photo.jpg", FileType::MAP));
+
+  // Case-insensitive
+  ok1(FilenameMatchesFileType("INIT.LUA", FileType::LUA));
+  ok1(FilenameMatchesFileType("XCSoar-Flarm.TXT", FileType::FLARMDB));
+}
+
 int main()
 {
-  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2);
+  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 13);
 
   TestDefaultDirs();
   TestPatterns();
+  TestSpecialFilenameType();
+  TestFilenameMatchesFileType();
 
   return exit_status();
 }

--- a/test/src/TestFileType.cpp
+++ b/test/src/TestFileType.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Repository/FileType.hpp"
+#include "system/Path.hpp"
+#include "TestUtil.hpp"
+
+#include <cstdint>
+
+static constexpr auto N_CONTENT_TYPES =
+  static_cast<uint8_t>(FileType::COUNT) - 1;
+
+static void
+TestDefaultDirs()
+{
+  // Every content type must return either nullptr or a valid
+  // relative path (never absolute, never empty)
+  for (uint8_t i = 1;
+       i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    auto dir = GetFileTypeDefaultDir(static_cast<FileType>(i));
+    if (dir != nullptr) {
+      ok(!dir.empty() && !dir.IsAbsolute(),
+         "FileType %u dir is relative", unsigned(i));
+    } else {
+      ok(true, "FileType %u has no dir", unsigned(i));
+    }
+  }
+
+  // Sentinel types return nullptr
+  ok1(GetFileTypeDefaultDir(FileType::UNKNOWN) == nullptr);
+  ok1(GetFileTypeDefaultDir(FileType::COUNT) == nullptr);
+}
+
+static void
+TestPatterns()
+{
+  // Every content type should have at least one non-empty pattern
+  for (uint8_t i = 1;
+       i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    const char *p = GetFileTypePatterns(static_cast<FileType>(i));
+    ok(p != nullptr && p[0] != '\0',
+       "FileType %u has patterns", unsigned(i));
+  }
+
+  // Sentinel types return empty pattern
+  const char *p = GetFileTypePatterns(FileType::UNKNOWN);
+  ok1(p != nullptr && p[0] == '\0');
+
+  p = GetFileTypePatterns(FileType::COUNT);
+  ok1(p != nullptr && p[0] == '\0');
+}
+
+int main()
+{
+  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2);
+
+  TestDefaultDirs();
+  TestPatterns();
+
+  return exit_status();
+}

--- a/test/src/TestFileType.cpp
+++ b/test/src/TestFileType.cpp
@@ -96,11 +96,21 @@ TestFilenameMatchesFileType()
   // Case-insensitive
   ok1(FilenameMatchesFileType("INIT.LUA", FileType::LUA));
   ok1(FilenameMatchesFileType("XCSoar-Flarm.TXT", FileType::FLARMDB));
+
+  // RASP pattern has '*' both at the start and in the middle.
+  // Embedded '*' must be honoured as a wildcard, and matching must be
+  // case-insensitive (RASP files in the wild use mixed case).
+  ok1(FilenameMatchesFileType("xcsoar-rasp.dat", FileType::RASP));
+  ok1(FilenameMatchesFileType("SI-RASP-National-ThermalMap.dat",
+                              FileType::RASP));
+  ok1(FilenameMatchesFileType("xcsoar-rasp-eu.dat", FileType::RASP));
+  ok1(!FilenameMatchesFileType("xcsoar-waypoints.dat", FileType::RASP));
+  ok1(!FilenameMatchesFileType("xcsoar-rasp.txt", FileType::RASP));
 }
 
 int main()
 {
-  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 13);
+  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 18);
 
   TestDefaultDirs();
   TestPatterns();

--- a/test/src/TestLocalPathResolve.cpp
+++ b/test/src/TestLocalPathResolve.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
+#include "Task/DefaultTask.hpp"
+#include "io/FileOutputStream.hxx"
+#include "system/FileUtil.hpp"
+#include "TestUtil.hpp"
+#include "util/StringAPI.hxx"
+
+#include <cstdio>
+
+static bool
+TouchFile(const AllocatedPath &path) noexcept
+{
+  FileOutputStream out(path, FileOutputStream::Mode::CREATE);
+  out.Commit();
+  return true;
+}
+
+static void
+TestLayoutSubdirForFilename()
+{
+  ok1(GetLayoutSubdirForFilename("terrain.xcm") == Path("maps"));
+  ok1(GetLayoutSubdirForFilename("user.cup") == Path("waypoints"));
+  ok1(GetLayoutSubdirForFilename("repository") == Path("cache"));
+  ok1(GetLayoutSubdirForFilename("user_repository_3") == Path("cache"));
+  ok1(GetLayoutSubdirForFilename("notams.json") == Path("cache"));
+  ok1(IsCacheLayoutFilename("repository"));
+  ok1(IsCacheLayoutFilename("notams.json"));
+  ok1(!IsCacheLayoutFilename("terrain.xcm"));
+  ok1(GetLayoutSubdirForFilename("xcsoar.log") == Path("logs"));
+  ok1(GetLayoutSubdirForFilename("flights.log") == Path("logs"));
+  ok1(GetLayoutSubdirForFilename("foo.json") == nullptr);
+}
+
+static void
+TestResolveTypedDataFilePath()
+{
+  char template_path[] = "/tmp/xcsoar-resolve-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto root = LocalPath("user.cup");
+  const auto subdir =
+    TypedDataSavePath(FileType::WAYPOINT, "user.cup");
+
+  TouchFile(subdir);
+  ok1(ResolveTypedDataFilePath(FileType::WAYPOINT, "user.cup") == subdir);
+
+  File::Delete(subdir);
+  TouchFile(root);
+  ok1(ResolveTypedDataFilePath(FileType::WAYPOINT, "user.cup") == root);
+
+  TouchFile(subdir);
+  ok1(ResolveTypedDataFilePath(FileType::WAYPOINT, "user.cup") == subdir);
+}
+
+static void
+TestResolveRepositoryDataPath()
+{
+  char template_path[] = "/tmp/xcsoar-repo-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  const Path data_path(template_path);
+  SetSingleDataPath(data_path);
+
+  const auto in_cache = CacheDataSavePath("repository");
+  const auto in_root = LocalPath("repository");
+
+  TouchFile(in_cache);
+  ok1(ResolveRepositoryDataPath("repository") == in_cache);
+
+  File::Delete(in_cache);
+  TouchFile(in_root);
+  ok1(ResolveRepositoryDataPath("repository") == in_root);
+
+  File::Delete(in_root);
+  MakeLocalPath(Path("repository"));
+  const auto in_legacy =
+    LocalPath(AllocatedPath::Build(Path("repository"), Path("repository")));
+  TouchFile(in_legacy);
+  ok1(ResolveRepositoryDataPath("repository") == in_legacy);
+}
+
+static void
+TestResolveCacheDataPath()
+{
+  char template_path[] = "/tmp/xcsoar-notam-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto in_cache = CacheDataSavePath("notams.json");
+  const auto in_root = LocalPath("notams.json");
+
+  TouchFile(in_cache);
+  ok1(ResolveCacheDataPath("notams.json") == in_cache);
+
+  File::Delete(in_cache);
+  TouchFile(in_root);
+  ok1(ResolveCacheDataPath("notams.json") == in_root);
+}
+
+static void
+TestResolveLogsDataPath()
+{
+  char template_path[] = "/tmp/xcsoar-logs-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto in_logs = LogsDataSavePath("xcsoar.log");
+  const auto in_root = LocalPath("xcsoar.log");
+
+  TouchFile(in_logs);
+  ok1(ResolveLogsDataPath("xcsoar.log") == in_logs);
+
+  File::Delete(in_logs);
+  TouchFile(in_root);
+  ok1(ResolveLogsDataPath("xcsoar.log") == in_root);
+}
+
+static void
+TestDefaultTaskPaths()
+{
+  char template_path[] = "/tmp/xcsoar-task-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto save_path = TypedDataSavePath(FileType::TASK, default_task_path);
+  ok1(StringFind(save_path.c_str(), "tasks") != nullptr);
+  ok1(StringFind(save_path.c_str(), default_task_path) != nullptr);
+
+  const auto legacy =
+    TypedDataSavePath(FileType::TASK, "Default.tsk");
+  TouchFile(legacy);
+  const auto resolved =
+    ResolveTypedDataFilePath(FileType::TASK, default_task_path,
+                             {"Default.tsk"});
+  ok1(resolved == legacy);
+
+  File::Delete(legacy);
+  TouchFile(save_path);
+  ok1(ResolveTypedDataFilePath(FileType::TASK, default_task_path,
+                               {"Default.tsk"}) == save_path);
+}
+
+static void
+TestRepositoryDownloadRelativePath()
+{
+  const auto relative = RepositoryDownloadRelativePath("repository");
+  ok1(StringFind(relative.c_str(), "cache") != nullptr);
+  ok1(StringFind(relative.c_str(), "repository") != nullptr);
+
+  /* Same pattern as DownloadManager queue: Path must outlive the copy. */
+  Path path_copy(relative.c_str());
+  const AllocatedPath stored(path_copy);
+  ok1(StringIsEqual(stored.c_str(), relative.c_str()));
+}
+
+int
+main()
+{
+  plan_tests(33);
+  TestLayoutSubdirForFilename();
+  TestResolveTypedDataFilePath();
+  TestResolveRepositoryDataPath();
+  TestResolveCacheDataPath();
+  TestResolveLogsDataPath();
+  TestDefaultTaskPaths();
+  TestRepositoryDownloadRelativePath();
+  return exit_status();
+}

--- a/test/src/TestPath.cpp
+++ b/test/src/TestPath.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "system/Path.hpp"
+
+#include <cstring>
+
+extern "C" {
+#include "tap.h"
+}
+
+int main()
+{
+  plan_tests(58);
+
+  /* IsValidFilename() — valid cases */
+  ok1(Path("file.txt").IsValidFilename());
+  ok1(Path("data.xcm").IsValidFilename());
+  ok1(Path(".hidden").IsValidFilename());
+  ok1(Path("a").IsValidFilename());
+  ok1(Path("file-with-dashes_and_underscores").IsValidFilename());
+
+  /* IsValidFilename() — invalid cases */
+  ok1(!Path(nullptr).IsValidFilename());
+  ok1(!Path("").IsValidFilename());
+  ok1(!Path(".").IsValidFilename());
+  ok1(!Path("..").IsValidFilename());
+  ok1(!Path("sub/file.txt").IsValidFilename());
+  ok1(!Path("../escape").IsValidFilename());
+
+  /* IsBase() */
+  ok1(Path("plain").IsBase());
+  ok1(Path("file.txt").IsBase());
+  ok1(!Path("a/b").IsBase());
+  ok1(!Path("/").IsBase());
+  ok1(!Path("/absolute").IsBase());
+
+  /* IsAbsolute() */
+  ok1(Path("/").IsAbsolute());
+  ok1(Path("/home/user").IsAbsolute());
+  ok1(!Path("relative").IsAbsolute());
+  ok1(!Path("a/b").IsAbsolute());
+
+  /* GetBase() */
+  ok1(Path("file.txt").GetBase() == Path("file.txt"));
+  ok1(Path("/home/file.txt").GetBase() == Path("file.txt"));
+  ok1(Path("a/b/c").GetBase() == Path("c"));
+  ok1(Path("/").GetBase() == nullptr);
+
+  /* GetParent() */
+  ok1(Path("file.txt").GetParent() == Path("."));
+  ok1(Path("/home/file.txt").GetParent() == Path("/home"));
+  ok1(Path("/file.txt").GetParent() == Path("."));
+  ok1(Path("a/b/c").GetParent() == Path("a/b"));
+
+  /* RelativeTo() */
+  ok1(Path("/home/user/file.txt").RelativeTo(Path("/home/user"))
+      == Path("file.txt"));
+  ok1(Path("/home/user/sub/file.txt").RelativeTo(Path("/home/user"))
+      == Path("sub/file.txt"));
+  ok1(Path("/other/file.txt").RelativeTo(Path("/home")) == nullptr);
+  ok1(Path("/home").RelativeTo(Path("/home")) == nullptr);
+
+  /* operator== / operator!= */
+  ok1(Path("abc") == Path("abc"));
+  ok1(Path("abc") != Path("def"));
+  ok1(Path(nullptr) == Path(nullptr));
+  ok1(Path(nullptr) != Path("abc"));
+  ok1(Path("abc") != Path(nullptr));
+  ok1(!(Path(nullptr) == Path("abc")));
+
+  /* empty() */
+  ok1(Path("").empty());
+  ok1(!Path("a").empty());
+
+  /* operator+ */
+  ok1(Path("file") + ".txt" == Path("file.txt"));
+  ok1(Path("/home/user") + "/sub" == Path("/home/user/sub"));
+
+  /* EndsWithIgnoreCase() */
+  ok1(Path("track.igc").EndsWithIgnoreCase(".igc"));
+  ok1(Path("TRACK.IGC").EndsWithIgnoreCase(".igc"));
+  ok1(Path("track.IGC").EndsWithIgnoreCase(".igc"));
+  ok1(!Path("track.cup").EndsWithIgnoreCase(".igc"));
+  ok1(!Path("igc").EndsWithIgnoreCase(".igc"));
+
+  /* GetSuffix() */
+  ok(strcmp(Path("file.txt").GetSuffix(), ".txt") == 0,
+     "GetSuffix .txt");
+  ok(strcmp(Path("archive.tar.gz").GetSuffix(), ".gz") == 0,
+     "GetSuffix .tar.gz");
+  ok1(Path("no_suffix").GetSuffix() == nullptr);
+  ok1(Path(".hidden").GetSuffix() == nullptr);
+
+  /* WithSuffix() */
+  ok1(Path("file.txt").WithSuffix(".igc") == Path("file.igc"));
+  ok1(Path("file").WithSuffix(".igc") == Path("file.igc"));
+  ok1(Path("/home/file.txt").WithSuffix(".cup")
+      == Path("/home/file.cup"));
+
+  /* ToUTF8() */
+  ok1(Path("hello").ToUTF8() == "hello");
+  ok1(Path(nullptr).ToUTF8().empty());
+
+  /* AllocatedPath::Build() */
+  ok1(AllocatedPath::Build(Path("/home"), Path("file"))
+      == Path("/home/file"));
+  ok1(AllocatedPath::Build(Path("a"), Path("b"))
+      == Path("a/b"));
+
+  return exit_status();
+}

--- a/test/src/TestRepository.cpp
+++ b/test/src/TestRepository.cpp
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Repository/Parser.hpp"
+#include "Repository/FileRepository.hpp"
+#include "io/LineReader.hpp"
+#include "TestUtil.hpp"
+
+#include <cstring>
+
+/**
+ * A simple in-memory NLineReader for testing.
+ * Splits input on newlines, returning writable lines.
+ */
+class StringLineReader : public NLineReader {
+  char *p;
+
+public:
+  explicit StringLineReader(char *buffer) noexcept
+    :p(buffer) {}
+
+  char *ReadLine() override {
+    if (p == nullptr || *p == '\0')
+      return nullptr;
+
+    char *line = p;
+    char *nl = strchr(p, '\n');
+    if (nl != nullptr) {
+      *nl = '\0';
+      p = nl + 1;
+    } else {
+      p = nullptr;
+    }
+    return line;
+  }
+};
+
+static void
+TestEmpty()
+{
+  char input[] = "";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+  ok1(repo.FindByName("anything") == nullptr);
+}
+
+static void
+TestCommentsAndBlanks()
+{
+  char input[] =
+    "# This is a comment\n"
+    "\n"
+    "  # indented comment\n"
+    "  \n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+  ok1(repo.FindByName("anything") == nullptr);
+}
+
+static void
+TestSingleFile()
+{
+  char input[] =
+    "name = test.xcw\n"
+    "uri = http://example.com/test.xcw\n"
+    "description = Test waypoints\n"
+    "area = EU\n"
+    "type = waypoint\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.xcw");
+  ok1(f != nullptr);
+  ok1(f->name == "test.xcw");
+  ok1(f->uri == "http://example.com/test.xcw");
+  ok1(f->description == "Test waypoints");
+  ok(strcmp(f->GetArea(), "EU") == 0,
+     "area matches");
+  ok1(f->type == FileType::WAYPOINT);
+  ok1(!f->HasHash());
+}
+
+static void
+TestMultipleFiles()
+{
+  char input[] =
+    "name = airspace.txt\n"
+    "uri = http://example.com/airspace.txt\n"
+    "type = airspace\n"
+    "\n"
+    "name = map.xcm\n"
+    "uri = http://example.com/map.xcm\n"
+    "type = map\n"
+    "\n"
+    "name = flarm.fln\n"
+    "uri = http://example.com/flarm.fln\n"
+    "type = flarmnet\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *a = repo.FindByName("airspace.txt");
+  ok1(a != nullptr);
+  ok1(a->type == FileType::AIRSPACE);
+
+  const auto *m = repo.FindByName("map.xcm");
+  ok1(m != nullptr);
+  ok1(m->type == FileType::MAP);
+
+  const auto *f = repo.FindByName("flarm.fln");
+  ok1(f != nullptr);
+  ok1(f->type == FileType::FLARMNET);
+}
+
+static void
+TestAllTypes()
+{
+  char input[] =
+    "name = a.sua\n"
+    "uri = http://x/a\n"
+    "type = airspace\n"
+    "\n"
+    "name = b.cup\n"
+    "uri = http://x/b\n"
+    "type = waypoint\n"
+    "\n"
+    "name = c.txt\n"
+    "uri = http://x/c\n"
+    "type = waypoint-details\n"
+    "\n"
+    "name = d.xcm\n"
+    "uri = http://x/d\n"
+    "type = map\n"
+    "\n"
+    "name = e.fln\n"
+    "uri = http://x/e\n"
+    "type = flarmnet\n"
+    "\n"
+    "name = f.rasp\n"
+    "uri = http://x/f\n"
+    "type = rasp\n"
+    "\n"
+    "name = g.xci\n"
+    "uri = http://x/g\n"
+    "type = xci\n"
+    "\n"
+    "name = h.tsk\n"
+    "uri = http://x/h\n"
+    "type = task\n"
+    "\n"
+    "name = i.xcl\n"
+    "uri = http://x/i\n"
+    "type = checklist\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  ok1(repo.FindByName("a.sua")->type == FileType::AIRSPACE);
+  ok1(repo.FindByName("b.cup")->type == FileType::WAYPOINT);
+  ok1(repo.FindByName("c.txt")->type == FileType::WAYPOINTDETAILS);
+  ok1(repo.FindByName("d.xcm")->type == FileType::MAP);
+  ok1(repo.FindByName("e.fln")->type == FileType::FLARMNET);
+  ok1(repo.FindByName("f.rasp")->type == FileType::RASP);
+  ok1(repo.FindByName("g.xci")->type == FileType::XCI);
+  ok1(repo.FindByName("h.tsk")->type == FileType::TASK);
+  ok1(repo.FindByName("i.xcl")->type == FileType::CHECKLIST);
+}
+
+static void
+TestUnknownType()
+{
+  char input[] =
+    "name = test.dat\n"
+    "uri = http://x/test.dat\n"
+    "type = bogus\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.dat");
+  ok1(f != nullptr);
+  ok1(f->type == FileType::UNKNOWN);
+}
+
+static void
+TestUpdateDate()
+{
+  char input[] =
+    "name = test.xcw\n"
+    "uri = http://x/test.xcw\n"
+    "update = 2024-06-15\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.xcw");
+  ok1(f != nullptr);
+  ok1(f->update_date.IsPlausible());
+  ok1(f->update_date.year == 2024);
+  ok1(f->update_date.month == 6);
+  ok1(f->update_date.day == 15);
+}
+
+static void
+TestInvalidDate()
+{
+  char input[] =
+    "name = test.xcw\n"
+    "uri = http://x/test.xcw\n"
+    "update = not-a-date\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.xcw");
+  ok1(f != nullptr);
+  /* invalid date format leaves default invalid date */
+  ok1(!f->update_date.IsPlausible());
+}
+
+static void
+TestSha256()
+{
+  char input[] =
+    "name = test.xcw\n"
+    "uri = http://x/test.xcw\n"
+    "sha256 = "
+    "abcdef0123456789abcdef0123456789"
+    "abcdef0123456789abcdef0123456789\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.xcw");
+  ok1(f != nullptr);
+  ok1(f->HasHash());
+  ok1(f->sha256_hash[0] == std::byte{0xab});
+  ok1(f->sha256_hash[1] == std::byte{0xcd});
+  ok1(f->sha256_hash[2] == std::byte{0xef});
+}
+
+static void
+TestInvalidSha256()
+{
+  char input[] =
+    "name = test.xcw\n"
+    "uri = http://x/test.xcw\n"
+    "sha256 = tooshort\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("test.xcw");
+  ok1(f != nullptr);
+  /* invalid hash stays zeroed */
+  ok1(!f->HasHash());
+}
+
+static void
+TestMissingUri()
+{
+  /* a file with name but no uri is not valid and should be rejected */
+  char input[] =
+    "name = test.xcw\n"
+    "description = No URI\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(!ParseFileRepository(repo, reader));
+}
+
+static void
+TestMalformedLine()
+{
+  /* a line without '=' is malformed and should cause parse failure */
+  char input[] =
+    "name = test.xcw\n"
+    "this line has no equals sign\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(!ParseFileRepository(repo, reader));
+}
+
+static void
+TestInvalidFilename()
+{
+  /* filenames with path separators should be rejected */
+  char input[] =
+    "name = ../etc/passwd\n"
+    "uri = http://x/evil\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(!ParseFileRepository(repo, reader));
+}
+
+static void
+TestInvalidFilenameSlash()
+{
+  char input[] =
+    "name = sub/file.xcw\n"
+    "uri = http://x/sub/file.xcw\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(!ParseFileRepository(repo, reader));
+}
+
+static void
+TestWhitespaceHandling()
+{
+  /* parser should strip whitespace around name and value */
+  char input[] =
+    "  name  =  spaced.xcw  \n"
+    "  uri  =  http://x/spaced.xcw  \n"
+    "  area  =  US  \n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  const auto *f = repo.FindByName("spaced.xcw");
+  ok1(f != nullptr);
+  ok1(f->uri == "http://x/spaced.xcw");
+  ok(strcmp(f->GetArea(), "US") == 0,
+     "area whitespace stripped");
+}
+
+static void
+TestFindByName()
+{
+  char input[] =
+    "name = first.xcw\n"
+    "uri = http://x/first\n"
+    "\n"
+    "name = second.xcm\n"
+    "uri = http://x/second\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  ok1(repo.FindByName("first.xcw") != nullptr);
+  ok1(repo.FindByName("second.xcm") != nullptr);
+  ok1(repo.FindByName("nonexistent") == nullptr);
+  ok1(repo.FindByName("FIRST.XCW") == nullptr);
+}
+
+static void
+TestFieldsBeforeName()
+{
+  /* fields appearing before any name= should be ignored */
+  char input[] =
+    "uri = http://x/orphan\n"
+    "type = airspace\n"
+    "\n"
+    "name = real.xcw\n"
+    "uri = http://x/real.xcw\n";
+  StringLineReader reader(input);
+  FileRepository repo;
+
+  ok1(ParseFileRepository(repo, reader));
+
+  ok1(repo.FindByName("real.xcw") != nullptr);
+  /* the orphan uri should not create a file */
+  unsigned count = 0;
+  for ([[maybe_unused]] const auto &f : repo)
+    ++count;
+  ok1(count == 1);
+}
+
+static void
+TestAvailableFile()
+{
+  AvailableFile f;
+  f.Clear();
+
+  ok1(f.IsEmpty());
+  ok1(!f.IsValid());
+  ok1(!f.HasHash());
+
+  f.name = "test.xcw";
+  ok1(!f.IsEmpty());
+  ok1(!f.IsValid()); /* still no uri */
+
+  f.uri = "http://x/test.xcw";
+  ok1(f.IsValid());
+
+  f.sha256_hash[15] = std::byte{0x42};
+  ok1(f.HasHash());
+
+  f.Clear();
+  ok1(f.IsEmpty());
+  ok1(!f.HasHash());
+  ok1(f.type == FileType::UNKNOWN);
+}
+
+int main()
+{
+  plan_tests(
+    2 +   // TestEmpty
+    2 +   // TestCommentsAndBlanks
+    8 +   // TestSingleFile
+    7 +   // TestMultipleFiles
+    10 +  // TestAllTypes
+    3 +   // TestUnknownType
+    6 +   // TestUpdateDate
+    3 +   // TestInvalidDate
+    6 +   // TestSha256
+    3 +   // TestInvalidSha256
+    1 +   // TestMissingUri
+    1 +   // TestMalformedLine
+    1 +   // TestInvalidFilename
+    1 +   // TestInvalidFilenameSlash
+    4 +   // TestWhitespaceHandling
+    5 +   // TestFindByName
+    3 +   // TestFieldsBeforeName
+    10    // TestAvailableFile
+  );
+
+  TestEmpty();
+  TestCommentsAndBlanks();
+  TestSingleFile();
+  TestMultipleFiles();
+  TestAllTypes();
+  TestUnknownType();
+  TestUpdateDate();
+  TestInvalidDate();
+  TestSha256();
+  TestInvalidSha256();
+  TestMissingUri();
+  TestMalformedLine();
+  TestInvalidFilename();
+  TestInvalidFilenameSlash();
+  TestWhitespaceHandling();
+  TestFindByName();
+  TestFieldsBeforeName();
+  TestAvailableFile();
+
+  return exit_status();
+}


### PR DESCRIPTION
I thought this would be an easy one, but then it took a bunch of faffing around with Path / string types and UTF8/ Wide conversions...

Fixes #1384, and should be fairly easily extensible to more directories for other file types.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Downloads stored in per-type subfolders with recursive folder creation (depth-capped).
  * New default target folders for specific file types.

* **Improvements**
  * Client-side filename validation to block invalid downloads.
  * UI: single-item "Update" and "Update All" actions; per-type display of size/modified info.
  * Progress dialogs show base filenames; download failures show clear error dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->