### PR TITLE
Checklist: .xcc extension, no default file, fix empty profile crash (Fixes #2094)

### DIFF
--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -96,7 +96,7 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
 
   AddFile(_("Checklist"),
           _("The checklist file containing pre-flight and other checklists."),
-          ProfileKeys::ChecklistFile, _T("*.txt\0"),
+          ProfileKeys::ChecklistFile, _T("*.xcc\0xcsoar-checklist.txt\0"),
           FileType::CHECKLIST);
 }
 

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -24,6 +24,7 @@ IsInternalFile(const TCHAR *str) noexcept
 {
   static const TCHAR *const ifiles[] = {
     _T("xcsoar-checklist.txt"),
+    _T("xcsoar-checklist.xcc"),
     _T("xcsoar-flarm.txt"),
     _T("xcsoar-marks.txt"),
     _T("xcsoar-persist.log"),
@@ -51,7 +52,11 @@ public:
     : datafield(_datafield) {}
 
   void Visit(Path path, Path filename) override {
-    if (!IsInternalFile(filename.c_str()))
+    bool skip = IsInternalFile(filename.c_str());
+    if (skip && datafield.GetFileType() == FileType::CHECKLIST &&
+        StringIsEqual(filename.c_str(), _T("xcsoar-checklist.txt")))
+      skip = false;
+    if (!skip)
       datafield.AddFile(path);
   }
 };


### PR DESCRIPTION
## Summary

- **Cap checklist at 32 pages** to prevent crash when a non-checklist file (e.g. wpt_details.txt) with many `[bracket]` lines is configured (PagerWidget has static_vector limit 32).
- **Use .xcc extension** for checklist files; filter picker to `*.xcc` and legacy `xcsoar-checklist.txt` only.
- **No default file**: load only when a file is configured in Site Files; check `path==nullptr` before `empty()` to avoid segfault when profile has `ChecklistFile=""`.
- **Clamp current_page** to valid range when opening dialog.
- **FileDataField**: show `xcsoar-checklist.txt` (legacy) in checklist picker only; `xcsoar-checklist.xcc` stays internal/hidden.

Fixes #2094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for additional checklist file formats.

* **Improvements**
  * Hard cap on checklist pages (32) to improve performance with very large checklists.
  * Checklist loading now uses an explicit file choice and shows a clearer prompt when no checklist is configured.
  * Safer pager and caption handling to prevent invalid page access; overflow content is merged into the last page when capped.

* **Bug Fixes**
  * A previously-ignored checklist entry is now correctly included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->