### PR TITLE
Audio: Fix only first chime playing on ALSA (CM4/PulseAudio)

### DIFF
--- a/src/Audio/PCMResourcePlayer.cpp
+++ b/src/Audio/PCMResourcePlayer.cpp
@@ -29,11 +29,18 @@ PCMResourcePlayer::PlayResource(const TCHAR *resource_name)
 
   const std::lock_guard protect{lock};
 
-  if (1 == buffer_data_source.Add(std::move(pcm_data))) {
+  const unsigned queue_size = buffer_data_source.Add(std::move(pcm_data));
+  if (1 == queue_size) {
     if (!player->Start(buffer_data_source)) {
       buffer_data_source.Clear();
       return false;
     }
+  } else {
+    /* Re-add buffer source to mixer so queued chunks are played after the
+       mixer removed us when the previous chunk finished (GetData returned 0).
+       See GitHub issue #2113. */
+    if (!player->Start(buffer_data_source))
+      LogFormat(_T("PCMResourcePlayer: failed to re-add buffer source"));
   }
 
   return true;


### PR DESCRIPTION
When the first sound finished, PCMMixerDataSource removed the buffer source (GetData returned 0) and ALSAPCMPlayer stopped event handling. Subsequent queued chimes were never played because the buffer was no longer a mixer source and poll events were not re-registered.

- PCMResourcePlayer: when queueing a second or later chunk, call Start() again to re-add the buffer source to the mixer.
- ALSAPCMPlayer: in the Start() resume path, re-register ALSA poll events when they were cleared so that playback callbacks continue.

Closes #2113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable audio resumption after buffer underrun by ensuring device poll events are re-registered so subsequent sounds continue.
  * Ensured queued audio chunks play continuously by fixing queue handling when adding buffers.
  * Improved error reporting for audio device/poll setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->