### PR TITLE
Android: Add SDK 35 compatibility for Google Play

### DIFF
--- a/android/src/WindowUtil.java
+++ b/android/src/WindowUtil.java
@@ -31,12 +31,23 @@ class WindowUtil {
    */
   static void enableImmersiveMode(Window window) {
     View decorView = window.getDecorView();
-    decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN|
-                                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION|
-                                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY|
-                                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN|
-                                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION|
-                                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      /* Android 11+ (API 30+): Use WindowInsetsController */
+      WindowInsetsController controller = decorView.getWindowInsetsController();
+      if (controller != null) {
+        controller.hide(WindowInsets.Type.systemBars());
+        controller.setSystemBarsBehavior(
+          WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE);
+      }
+    } else {
+      /* Android 10 and below: Use deprecated setSystemUiVisibility */
+      decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN|
+                                      View.SYSTEM_UI_FLAG_HIDE_NAVIGATION|
+                                      View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY|
+                                      View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN|
+                                      View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION|
+                                      View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+    }
   }
 
   static void disableImmersiveMode(Window window) {
@@ -77,26 +88,19 @@ class WindowUtil {
     enableImmersiveMode(window);
 
     /* Enable display cutout mode (notch support) for Android P (API 28) and above.
-       LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES allows content to extend into
-       the cutout area on the short edges of the screen (top/bottom in portrait,
-       left/right in landscape). This gives true edge-to-edge fullscreen. */
+       For SDK 35+, use LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS as the SHORT_EDGES mode
+       is deprecated. For older versions, use SHORT_EDGES which allows content to
+       extend into the cutout area on the short edges of the screen. */
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       WindowManager.LayoutParams lp = window.getAttributes();
-      lp.layoutInDisplayCutoutMode =
-        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
-      window.setAttributes(lp);
-    }
-
-    /* Opt out of Android 15's edge-to-edge enforcement. This tells Android 15
-       that we handle edge-to-edge ourselves, preventing letterboxing in
-       horizontal mode. */
-    if (Build.VERSION.SDK_INT >= 35) {
-      try {
-        java.lang.reflect.Method method = Window.class.getMethod("setOptOutEdgeToEdgeEnforcement", boolean.class);
-        method.invoke(window, true);
-      } catch (Exception e) {
-        /* Method not available or reflection failed - ignore */
+      if (Build.VERSION.SDK_INT >= 35) {
+        lp.layoutInDisplayCutoutMode =
+          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+      } else {
+        lp.layoutInDisplayCutoutMode =
+          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
       }
+      window.setAttributes(lp);
     }
   }
 
@@ -104,13 +108,19 @@ class WindowUtil {
     disableImmersiveMode(window);
     window.clearFlags(FULL_SCREEN_WINDOW_FLAGS & ~preserveFlags);
 
-    /* Set display cutout mode to SHORT_EDGES in non-fullscreen mode to respect the notch.
-       This allows content to extend into the cutout area while still accounting for it
-       in safe area calculations. */
+    /* Set display cutout mode in non-fullscreen mode to respect the notch.
+       For SDK 35+, use LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS as the SHORT_EDGES mode
+       is deprecated. This allows content to extend into the cutout area while still
+       accounting for it in safe area calculations. */
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
       WindowManager.LayoutParams lp = window.getAttributes();
-      lp.layoutInDisplayCutoutMode =
-        WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+      if (Build.VERSION.SDK_INT >= 35) {
+        lp.layoutInDisplayCutoutMode =
+          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS;
+      } else {
+        lp.layoutInDisplayCutoutMode =
+          WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES;
+      }
       window.setAttributes(lp);
     }
   }

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -106,6 +106,14 @@ public class XCSoar extends Activity implements PermissionManager {
     final Window window = getWindow();
     window.requestFeature(Window.FEATURE_NO_TITLE);
 
+    /* Enable edge-to-edge display for SDK 30+. This is what EdgeToEdge.enable()
+       does under the hood and is required for proper edge-to-edge support on
+       Android 15+. The existing inset handling in applyFullScreen() handles
+       the layout margins correctly. */
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      window.setDecorFitsSystemWindows(false);
+    }
+
     TextView tv = new TextView(this);
     tv.setText("Loading XCSoar...");
     setContentView(tv);

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -593,6 +593,8 @@ endif
 
 ifeq ($(TARGET),ANDROID)
   TARGET_LDFLAGS += -Wl,--no-undefined
+  # Support 16KB memory pages (required for Android 15+ devices)
+  TARGET_LDFLAGS += -Wl,-z,max-page-size=16384
 
   ifeq ($(ARMV7),y)
     TARGET_LDFLAGS += -Wl,--fix-cortex-a8


### PR DESCRIPTION
## Summary

- Add 16KB memory page alignment support for Android 15+ devices
- Replace deprecated `LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES` with `LAYOUT_IN_DISPLAY_CUTOUT_MODE_ALWAYS` on SDK 35+
- Use `WindowInsetsController` instead of deprecated `setSystemUiVisibility()` on API 30+
- Properly implement edge-to-edge display with `setDecorFitsSystemWindows(false)`

These changes address the Google Play Console recommendations for Android 15 compatibility:
- Fixes #2145 (16KB page alignment)
- Fixes #2146 (deprecated cutout mode)
- Fixes #2147 (edge-to-edge implementation)

## Test plan

- [ ] Build Android APK/AAB and verify it installs on Android 15+ devices
- [ ] Test fullscreen mode on devices with notches/cutouts
- [ ] Test non-fullscreen mode with status bar visible
- [ ] Verify no visual regressions on older Android versions (API 28-34)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added edge-to-edge display support for Android 11 and above, improving screen utilization.

* **Improvements**
  * Enhanced fullscreen immersive mode with improved compatibility across Android versions.

* **Chores**
  * Optimized Android build linker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->