### PR TITLE
Projection/MapWindowProjection: Limit zoom-out on PowerVR GE8300

### DIFF
--- a/src/Input/InputEventsMap.cpp
+++ b/src/Input/InputEventsMap.cpp
@@ -17,6 +17,10 @@
 #include "Math/Constants.hpp"
 #include "Screen/Layout.hpp"
 
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
+#endif
+
 #include <algorithm> // for std::clamp()
 
 // eventAutoZoom - Turn on|off|toggle AutoZoom
@@ -192,7 +196,14 @@ InputEvents::sub_SetZoom(double value)
   auto vmin = CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
   auto scale_2min_distance = vmin * 12;
   const double scale_100m = 10;
-  const double scale_1600km = 1600*100;
+  double scale_1600km = 1600*100;
+
+#ifdef ENABLE_OPENGL
+  if (OpenGL::max_map_scale > 0)
+    scale_1600km = std::min(scale_1600km,
+                            double(OpenGL::max_map_scale));
+#endif
+
   auto minreasonable = displayMode == DisplayMode::CIRCLING
     ? scale_100m
     : std::max(scale_100m, scale_2min_distance);

--- a/src/lua/Map.cpp
+++ b/src/lua/Map.cpp
@@ -17,6 +17,10 @@
 #include "Profile/Keys.hpp"
 #include "Math/Constants.hpp"
 
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
+#endif
+
 extern "C" {
 #include <lauxlib.h>
 }
@@ -176,7 +180,14 @@ l_map_zoom(lua_State *L)
   auto vmin = CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
   auto scale_2min_distance = vmin * 12;
   constexpr double scale_100m = 10;
-  constexpr double scale_1600km = 1600 * 100;
+  double scale_1600km = 1600 * 100;
+
+#ifdef ENABLE_OPENGL
+  if (OpenGL::max_map_scale > 0)
+    scale_1600km = std::min(scale_1600km,
+                            double(OpenGL::max_map_scale));
+#endif
+
   auto minreasonable = displayMode == DisplayMode::CIRCLING
     ? scale_100m
     : std::max(scale_100m, scale_2min_distance);

--- a/src/ui/canvas/opengl/Globals.cpp
+++ b/src/ui/canvas/opengl/Globals.cpp
@@ -25,6 +25,8 @@ PixelPoint translate;
 
 glm::mat4 projection_matrix;
 
+unsigned max_map_scale;
+
 #ifndef NDEBUG
 pthread_t thread;
 #endif

--- a/src/ui/canvas/opengl/Globals.hpp
+++ b/src/ui/canvas/opengl/Globals.hpp
@@ -69,4 +69,10 @@ extern PixelPoint translate;
 
 extern glm::mat4 projection_matrix;
 
+/**
+ * Maximum map scale in meters for zoom-out, to work around
+ * GPU driver bugs.  0 means no GPU-imposed limit.
+ */
+extern unsigned max_map_scale;
+
 } // namespace OpenGL

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -106,8 +106,16 @@ OpenGL::SetupContext()
   if (auto s = (const char *)glGetString(GL_VERSION))
     LogFormat("GL version: %s", s);
 
-  if (auto s = (const char *)glGetString(GL_RENDERER))
+  if (auto s = (const char *)glGetString(GL_RENDERER)) {
     LogFormat("GL renderer: %s", s);
+
+    if (strstr(s, "PowerVR Rogue GE8300") != nullptr)
+      /* PowerVR Rogue GE8300 (MediaTek MT8166) crashes in the driver
+         when rendering large topography polygons at extreme zoom-out.
+         Limit the maximum map scale to avoid triggering the bug.
+         See https://github.com/XCSoar/XCSoar/issues/1235 */
+      max_map_scale = 300000;
+  }
 
   if (auto s = (const char *)glGetString(GL_EXTENSIONS))
     LogFormat("GL extensions: %s", s);


### PR DESCRIPTION
## Summary

- Work around a SIGSEGV crash in the MediaTek PowerVR Rogue GE8300 GPU driver (`libGLESv2_mtk.so`) that occurs when rendering large topography polygons via `glDrawElements()` at extreme zoom-out levels
- Detect the GPU renderer string at OpenGL init and enforce a maximum map scale at multiple levels: `FindMapScale()`, `StepMapScale()`, `SetFreeMapScale()`, `RestoreMapScale()`, `sub_SetZoom()`, and `l_map_zoom()`
- Affects Lenovo Tab M7 tablets (TB-7206F, TB-7306F) with MediaTek MT8166 SoC

Fixes #1235

## Test plan

- [x] Built for Android armeabi-v7a
- [x] Installed on Lenovo TB-7306F (PowerVR Rogue GE8300)
- [x] Verified zoom stops at ~30 km and does not crash
- [x] Verify on a non-PowerVR device that the limit does not apply

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential application crashes when zooming out to extreme levels on certain graphics hardware.
  * Improved map zoom stability under OpenGL by enforcing dynamic maximum scale limits based on graphics hardware capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->