### PR TITLE
ui/canvas/opengl/Init: Fix projection matrix for software-rotated displays

### DIFF
--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -221,11 +221,12 @@ OpenGL::SetupViewport(UnsignedPoint2D size) noexcept
   window_size = size;
 
   glViewport(0, 0, size.x, size.y);
-  projection_matrix = glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   OrientationSwap(size, display_orientation);
 #endif
+
+  projection_matrix = glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   glm::mat4 rot_matrix = glm::rotate(
@@ -235,7 +236,6 @@ OpenGL::SetupViewport(UnsignedPoint2D size) noexcept
   projection_matrix = rot_matrix * projection_matrix;
 #endif
 
-  /* viewport_size is the EGL surface size (which is already the safe area in non-fullscreen) */
   viewport_size = size;
 
   UpdateShaderProjectionMatrix();


### PR DESCRIPTION
## Summary

- Fix portrait display scaling broken on OpenVario (and all `SOFTWARE_ROTATE_DISPLAY` platforms) caused by commit 1e4b8fee4f moving the `projection_matrix` computation before `OrientationSwap()`
- The ortho projection must use the swapped (virtual screen) dimensions, not the native EGL surface dimensions

## Root Cause

In `OpenGL::SetupViewport()`, the `projection_matrix` was moved before `OrientationSwap()` by commit 1e4b8fee4f. This meant the orthographic projection used the native surface dimensions (e.g. 480×800 for portrait) instead of the virtual screen dimensions (800×480 after swap). The rotation matrix then operated on the wrong base projection, causing the rendering to be distorted and misaligned.

Android was unaffected because it does not define `SOFTWARE_ROTATE_DISPLAY`. All other OpenGL platforms (Linux/MESA_KMS, X11, Wayland) with portrait orientation were broken.

On the OpenVario specifically, `DetectInitialOrientation()` reads `/sys/class/graphics/fbcon/rotate` and feeds externally-rotated framebuffer orientations into the software rotation pipeline, so even external rotation triggered the bug.

## Test plan

- [ ] @bomilkar: Please test on OpenVario Cubie2 in portrait orientation (external framebuffer rotation) and verify the display renders correctly
- [ ] Test with XCSoar "Display orientation" set to Portrait (with landscape external rotation)
- [ ] Verify landscape orientation still works correctly

Fixes #2163

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the order of display viewport initialization to ensure screen orientation adjustments are properly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->