### PR TITLE
ui/canvas/opengl/Init: Limit zoom to 250km for Mali-400 GPU

### DIFF
--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -109,12 +109,17 @@ OpenGL::SetupContext()
   if (auto s = (const char *)glGetString(GL_RENDERER)) {
     LogFormat("GL renderer: %s", s);
 
-    if (strstr(s, "PowerVR Rogue GE8300") != nullptr)
+    if (strstr(s, "Mali400") == s) {
+      /* Allwinner A20 SoC has a Mali-400 GPU. Limit the map scale to
+         250 km. */
+      max_map_scale = 251*1000*2;
+    } else if (strstr(s, "PowerVR Rogue GE8300") != nullptr) {
       /* PowerVR Rogue GE8300 (MediaTek MT8166) crashes in the driver
          when rendering large topography polygons at extreme zoom-out.
          Limit the maximum map scale to avoid triggering the bug.
          See https://github.com/XCSoar/XCSoar/issues/1235 */
       max_map_scale = 300000;
+    }
   }
 
   if (auto s = (const char *)glGetString(GL_EXTENSIONS))


### PR DESCRIPTION
This is intended to prevent zoom related freezes on OpenVario with Cubie2. Cubie2 uses Allwinner SoC with a Mali-400 GPU.
250km seem to be the maximum zoom level w/o causing freeze.

It addresses Issue #2172 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GPU detection for Mali400-based devices
  * Optimized rendering performance scaling for improved compatibility on Mali400 hardware

<!-- end of auto-generated comment: release notes by coderabbit.ai -->