### PR TITLE
src/Dialogs/Device/DeviceListDialog: Show flags on Devices List

### DIFF
--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -64,6 +64,7 @@ class DeviceListWidget final
     bool alive:1, location:1, gps:1, baro:1, pitot:1, airspeed:1, vario:1, traffic:1;
     bool temperature:1;
     bool humidity:1;
+    bool imu:1;
     bool radio:1, transponder:1;
     bool engine:1;
     bool debug:1;
@@ -107,11 +108,13 @@ class DeviceListWidget final
         basic.pressure_altitude_available ||
         basic.static_pressure_available;
       pitot = basic.pitot_pressure_available;
-      airspeed = basic.airspeed_available;
+      airspeed = basic.airspeed_available ||
+        basic.dyn_pressure_available;
       vario = basic.total_energy_vario_available;
       traffic = basic.flarm.IsDetected();
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;
+      imu = basic.gyroscope.available;
       debug = device != nullptr && device->IsDumpEnabled();
       radio = basic.settings.has_active_frequency ||
         basic.settings.has_standby_frequency;
@@ -428,6 +431,11 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     if (flags.temperature || flags.humidity) {
       buffer.append(_T("; "));
       buffer.append(_T("Environment"));
+    }
+
+    if (flags.imu) {
+      buffer.append(_T("; "));
+      buffer.append(_("IMU"));
     }
 
     if (flags.radio) {


### PR DESCRIPTION
Add IMU flag.
dyn_pressure_available sets Airspeed flag, too.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device list now displays IMU (gyroscope) availability for connected devices.
  * Enhanced device status display to include IMU capability information alongside other available device features such as environment and radio capabilities.
  * Device status reporting now provides comprehensive information including inertial measurement unit availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->