### PR TITLE
User- / Club-defined repositories

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -136,6 +136,7 @@ Version 7.44 - 2026-03-22
   - checklists: add Markdown support (bold, links, checkboxes)
   - fix home waypoint lost on restart due to async terrain loading #2169
   - fix profile migration ordering of old waypoint/airspace keys
+  - add ability to configure user-defined repositories
 * ui
   - enable goto and waypoint details for location map items (clicking on empty map locations)
   - streamlined, and optimized icons

--- a/build/main.mk
+++ b/build/main.mk
@@ -623,6 +623,7 @@ endif
 
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
+	$(SRC)/Dialogs/DownloadFileModal.cpp \
 	$(SRC)/Dialogs/DownloadFilePicker.cpp \
 	$(SRC)/Repository/Glue.cpp \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -98,10 +98,16 @@ configured when flying at a new site.
   airspaces are loaded from the map file (if available).
 \item[Airfields or Waypoint details*]  The airfields file may contain extracts from
   Enroute Supplements or other contributed information about individual airfields.
+\item[User repositories*] List of user repository URLs, separated by the character `|'.
+  The URL for each repository must point to the repository's manifest file. 
+  The content listed in that manifest is then included in the file download 
+  selectors. The manifest needs to use the same format as that of the XCSoar repository
+  (See \url{https://github.com/XCSoar/xcsoar-data-content}).
+  
 \end{description}
 
 
-Multiple files can be selected to be used simultaneously.
+Multiple airspace and waypoint files can be selected to be used simultaneously.
 \sketch{figures/config-site.png}
 
 The XCM map database concept is the current way to setup a site to fly.

--- a/doc/manual/xcsoar-headers.sty
+++ b/doc/manual/xcsoar-headers.sty
@@ -1,6 +1,9 @@
 \usepackage{calc}
 \usepackage{fancyhdr}
 
+\setlength{\headheight}{15.0pt}
+\addtolength{\topmargin}{-3.0pt}
+
 \newcommand{\xcsoarheader}[1]{
   \pagestyle{fancy}
 

--- a/src/Dialogs/DownloadFileModal.cpp
+++ b/src/Dialogs/DownloadFileModal.cpp
@@ -69,7 +69,7 @@ private:
         got_size = true;
         set_range = true;
       }
-      set_position = got_size;
+      set_position = got_size && position >= 0;
     }
 
     if (set_range)

--- a/src/Dialogs/DownloadFileModal.cpp
+++ b/src/Dialogs/DownloadFileModal.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DownloadFileModal.hpp"
+#include "ProgressDialog.hpp"
+#include "UIGlobals.hpp"
+#include "Look/DialogLook.hpp"
+#include "LocalPath.hpp"
+#include "net/http/DownloadManager.hpp"
+#include "Operation/ThreadedOperationEnvironment.hpp"
+#include "thread/Mutex.hxx"
+#include "ui/event/Notify.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+
+#include <cassert>
+#include <exception>
+
+/**
+ * Tracks a single file download and updates a #ProgressDialog.
+ * Register before calling Net::DownloadManager::Enqueue().
+ */
+class DownloadProgress final : Net::DownloadListener {
+  ProgressDialog &dialog;
+  ThreadedOperationEnvironment env;
+  const Path path_relative;
+
+  UI::PeriodicTimer update_timer{[this]{ Net::DownloadManager::Enumerate(*this); }};
+
+  UI::Notify download_complete_notify{[this]{ OnDownloadCompleteNotification(); }};
+
+  mutable Mutex mutex;
+
+  std::exception_ptr error;
+
+  bool got_size = false, complete = false, success = false;
+
+public:
+  DownloadProgress(ProgressDialog &_dialog,
+                   const Path _path_relative)
+    :dialog(_dialog), env(_dialog), path_relative(_path_relative) {
+    update_timer.Schedule(std::chrono::seconds(1));
+    Net::DownloadManager::AddListener(*this);
+  }
+
+  ~DownloadProgress() {
+    Net::DownloadManager::RemoveListener(*this);
+  }
+
+  void Rethrow() const {
+    std::exception_ptr e;
+    {
+      const std::lock_guard lock{mutex};
+      e = error;
+    }
+    if (e)
+      std::rethrow_exception(e);
+  }
+
+private:
+  /* virtual methods from class Net::DownloadListener */
+  void OnDownloadAdded(Path _path_relative,
+                       int64_t size, int64_t position) noexcept override {
+    bool set_range = false, set_position = false;
+    {
+      const std::lock_guard lock{mutex};
+      if (complete || path_relative != _path_relative)
+        return;
+      if (!got_size && size >= 0) {
+        got_size = true;
+        set_range = true;
+      }
+      set_position = got_size;
+    }
+
+    if (set_range)
+      env.SetProgressRange(uint64_t(size) / 1024u);
+    if (set_position)
+      env.SetProgressPosition(uint64_t(position) / 1024u);
+  }
+
+  void OnDownloadComplete(Path _path_relative) noexcept override {
+    {
+      const std::lock_guard lock{mutex};
+      if (complete || path_relative != _path_relative)
+        return;
+      complete = true;
+      success = true;
+    }
+    download_complete_notify.SendNotification();
+  }
+
+  void OnDownloadError(Path _path_relative,
+                       std::exception_ptr _error) noexcept override {
+    {
+      const std::lock_guard lock{mutex};
+      if (complete || path_relative != _path_relative)
+        return;
+      complete = true;
+      success = false;
+      error = std::move(_error);
+    }
+    download_complete_notify.SendNotification();
+  }
+
+  void OnDownloadCompleteNotification() noexcept {
+    bool s;
+    {
+      const std::lock_guard lock{mutex};
+      assert(complete);
+      s = success;
+    }
+    dialog.SetModalResult(s ? mrOK : mrCancel);
+  }
+};
+
+AllocatedPath
+DownloadFileModal(const char *caption, const char *uri, const char *base)
+{
+  assert(Net::DownloadManager::IsAvailable());
+
+  if (uri == nullptr || base == nullptr || uri[0] == '\0' || base[0] == '\0')
+    return nullptr;
+
+  ProgressDialog dialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
+                        caption);
+
+  const auto display_name = Path(base).GetBase();
+  dialog.SetText(display_name != nullptr ? display_name.c_str() : base);
+
+  dialog.AddCancelButton();
+
+  DownloadProgress dp(dialog, Path(base));
+  Net::DownloadManager::Enqueue(uri, Path(base));
+
+  int result = dialog.ShowModal();
+  if (result != mrOK) {
+    Net::DownloadManager::Cancel(Path(base));
+    dp.Rethrow();
+    return nullptr;
+  }
+
+  return LocalPath(base);
+}

--- a/src/Dialogs/DownloadFileModal.hpp
+++ b/src/Dialogs/DownloadFileModal.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+
+class AllocatedPath;
+
+/**
+ * Download a file showing a modal #ProgressDialog with a cancel
+ * button.  The message shown in the dialog body is the filename
+ * portion of #base.
+ *
+ * Throws on error.
+ *
+ * @param caption the dialog window caption
+ * @param uri the URI to download
+ * @param base the local filename to store the download as
+ * @return the full local path on success, nullptr on cancel
+ */
+AllocatedPath
+DownloadFileModal(const char *caption, const char *uri, const char *base);

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -23,6 +23,7 @@
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
+#include "util/StringCompare.hxx"
 #include "util/StringFormat.hpp"
 
 #include <vector>
@@ -236,7 +237,10 @@ DownloadFilePickerWidget::OnDownloadComplete(Path path_relative) noexcept
   if (name == nullptr)
     return;
 
-  if (name == Path("repository")) {
+  const bool is_main = name == Path("repository");
+  const bool is_user = StringStartsWith(name.c_str(), "user_repository_");
+
+  if (is_main || is_user) {
     const std::lock_guard lock{mutex};
     repository_failed = false;
     repository_modified = true;
@@ -258,6 +262,9 @@ DownloadFilePickerWidget::OnDownloadError(Path path_relative,
     repository_failed = true;
     repository_error = std::move(error);
   }
+
+  /* user repository download errors are silently ignored 
+     one warning is enough on network loss */
 
   download_complete_notify.SendNotification();
 }

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -24,6 +24,7 @@
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
 #include "Operation/ThreadedOperationEnvironment.hpp"
+#include "util/StringFormat.hpp"
 
 #include <vector>
 
@@ -256,6 +257,21 @@ try {
   FileLineReaderA reader(path);
 
   ParseFileRepository(repository, reader);
+
+  // add user repository contents
+  const std::vector<std::string> uris = GetUserRepositoryURIs();
+  int file_number = 1;
+  for (const auto &uri : uris) {
+    if (uri.empty())
+      continue;
+
+    char filename[32];
+    StringFormat(filename, std::size(filename), "user_repository_%d",
+                 file_number++);
+    const auto user_path = LocalPath(filename);
+    FileLineReaderA user_reader(user_path);
+    ParseFileRepository(repository, user_reader);
+  }
 
   items.clear();
   for (auto &i : repository)

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -12,12 +12,9 @@
 #include "Form/Button.hpp"
 #include "Widget/ListWidget.hpp"
 #include "Language/Language.hpp"
-#include "LocalPath.hpp"
 #include "system/Path.hpp"
-#include "io/FileLineReader.hpp"
-#include "Repository/Glue.hpp"
 #include "Repository/FileRepository.hpp"
-#include "Repository/Parser.hpp"
+#include "Repository/Glue.hpp"
 #include "net/http/Features.hpp"
 #include "net/http/DownloadManager.hpp"
 #include "ui/event/Notify.hpp"
@@ -147,23 +144,7 @@ DownloadFilePickerWidget::RefreshList()
   }
 
   FileRepository repository;
-
-  try {
-    FileLineReaderA reader(LocalPath("repository"));
-    ParseFileRepository(repository, reader);
-  } catch (const std::runtime_error &) {
-    /* not yet downloaded - ignore */
-  }
-
-  // add user repository contents
-  for (const auto &repo : GetUserRepositories()) {
-    try {
-      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
-      ParseFileRepository(repository, reader);
-    } catch (const std::runtime_error &) {
-      /* not yet downloaded - ignore */
-    }
-  }
+  LoadAllRepositories(repository);
 
   items.clear();
   for (auto &i : repository)

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -4,7 +4,7 @@
 #include "DownloadFilePicker.hpp"
 #include "Error.hpp"
 #include "WidgetDialog.hpp"
-#include "ProgressDialog.hpp"
+#include "DownloadFileModal.hpp"
 #include "Message.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
@@ -23,116 +23,12 @@
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
-#include "Operation/ThreadedOperationEnvironment.hpp"
 #include "util/StringFormat.hpp"
 
 #include <vector>
 
 #include <cassert>
 
-/**
- * This class tracks a download and updates a #ProgressDialog.
- */
-class DownloadProgress final : Net::DownloadListener {
-  ProgressDialog &dialog;
-  ThreadedOperationEnvironment env;
-  const Path path_relative;
-
-  UI::PeriodicTimer update_timer{[this]{ Net::DownloadManager::Enumerate(*this); }};
-
-  UI::Notify download_complete_notify{[this]{ OnDownloadCompleteNotification(); }};
-
-  std::exception_ptr error;
-
-  bool got_size = false, complete = false, success;
-
-public:
-  DownloadProgress(ProgressDialog &_dialog,
-                   const Path _path_relative)
-    :dialog(_dialog), env(_dialog), path_relative(_path_relative) {
-    update_timer.Schedule(std::chrono::seconds(1));
-    Net::DownloadManager::AddListener(*this);
-  }
-
-  ~DownloadProgress() {
-    Net::DownloadManager::RemoveListener(*this);
-  }
-
-  void Rethrow() const {
-    if (error)
-      std::rethrow_exception(error);
-  }
-
-private:
-  /* virtual methods from class Net::DownloadListener */
-  void OnDownloadAdded(Path _path_relative,
-                       int64_t size, int64_t position) noexcept override {
-    if (!complete && path_relative == _path_relative) {
-      if (!got_size && size >= 0) {
-        got_size = true;
-        env.SetProgressRange(uint64_t(size) / 1024u);
-      }
-
-      if (got_size)
-        env.SetProgressPosition(uint64_t(position) / 1024u);
-    }
-  }
-
-  void OnDownloadComplete(Path _path_relative) noexcept override {
-    if (!complete && path_relative == _path_relative) {
-      complete = true;
-      success = true;
-      download_complete_notify.SendNotification();
-    }
-  }
-
-  void OnDownloadError(Path _path_relative,
-                       std::exception_ptr _error) noexcept override {
-    if (!complete && path_relative == _path_relative) {
-      complete = true;
-      success = false;
-      error = std::move(_error);
-      download_complete_notify.SendNotification();
-    }
-  }
-
-  void OnDownloadCompleteNotification() noexcept {
-    assert(complete);
-    dialog.SetModalResult(success ? mrOK : mrCancel);
-  }
-};
-
-/**
- * Throws on error.
- */
-static AllocatedPath
-DownloadFile(const char *uri, const char *base)
-{
-  assert(Net::DownloadManager::IsAvailable());
-
-  if (base == nullptr)
-    return nullptr;
-
-  ProgressDialog dialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
-                        _("Download"));
-  const auto display_name = Path(base).GetBase();
-  dialog.SetText(display_name != nullptr ? display_name.c_str() : base);
-
-  dialog.AddCancelButton();
-
-  const DownloadProgress dp(dialog, Path(base));
-
-  Net::DownloadManager::Enqueue(uri, Path(base));
-
-  int result = dialog.ShowModal();
-  if (result != mrOK) {
-    Net::DownloadManager::Cancel(Path(base));
-    dp.Rethrow();
-    return nullptr;
-  }
-
-  return LocalPath(base);
-}
 
 class DownloadFilePickerWidget final
   : public ListWidget,
@@ -314,7 +210,7 @@ DownloadFilePickerWidget::Download()
   const auto &file = items[current];
 
   try {
-    path = DownloadFile(file.GetURI(), file.GetName());
+    path = DownloadFileModal(_("Download"), file.GetURI(), file.GetName());
     if (path != nullptr)
       dialog.SetModalResult(mrOK);
   } catch (...) {

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -23,8 +23,6 @@
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
-#include "util/StringCompare.hxx"
-#include "util/StringFormat.hpp"
 
 #include <vector>
 
@@ -158,17 +156,9 @@ DownloadFilePickerWidget::RefreshList()
   }
 
   // add user repository contents
-  const std::vector<std::string> uris = GetUserRepositoryURIs();
-  int file_number = 1;
-  for (const auto &uri : uris) {
-    if (uri.empty())
-      continue;
-
-    char filename[32];
-    StringFormat(filename, std::size(filename), "user_repository_%d",
-                 file_number++);
+  for (const auto &repo : GetUserRepositories()) {
     try {
-      FileLineReaderA reader(LocalPath(filename));
+      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
       ParseFileRepository(repository, reader);
     } catch (const std::runtime_error &) {
       /* not yet downloaded - ignore */
@@ -238,7 +228,7 @@ DownloadFilePickerWidget::OnDownloadComplete(Path path_relative) noexcept
     return;
 
   const bool is_main = name == Path("repository");
-  const bool is_user = StringStartsWith(name.c_str(), "user_repository_");
+  const bool is_user = IsUserRepositoryFile(name.c_str());
 
   if (is_main || is_user) {
     const std::lock_guard lock{mutex};

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -213,7 +213,8 @@ DownloadFilePickerWidget::OnDownloadComplete(Path path_relative) noexcept
 
   if (is_main || is_user) {
     const std::lock_guard lock{mutex};
-    repository_failed = false;
+    if (is_main)
+      repository_failed = false;
     repository_modified = true;
   }
 
@@ -259,7 +260,8 @@ DownloadFilePickerWidget::OnDownloadCompleteNotification() noexcept
   else if (repository_failed2)
     ShowMessageBox(_("Failed to download the repository index."),
                    _("Error"), MB_OK);
-  else if (repository_modified2)
+
+  if (repository_modified2)
     RefreshList();
 }
 

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -13,14 +13,12 @@
 #include "LocalPath.hpp"
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
-#include "io/FileLineReader.hpp"
 #include "Formatter/ByteSizeFormatter.hpp"
 #include "Formatter/TimeFormatter.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "net/http/Features.hpp"
 #include "util/Macros.hpp"
 #include "Repository/FileRepository.hpp"
-#include "Repository/Parser.hpp"
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Repository/Glue.hpp"
@@ -328,24 +326,7 @@ ManagedFileListWidget::LoadRepositoryFile()
 #endif
 
   repository.Clear();
-
-  try {
-    FileLineReaderA reader(LocalPath("repository"));
-    ParseFileRepository(repository, reader);
-  } catch (const std::runtime_error &) {
-    /* not yet downloaded - ignore */
-  }
-
-#ifdef HAVE_DOWNLOAD_MANAGER
-  for (const auto &repo : GetUserRepositories()) {
-    try {
-      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
-      ParseFileRepository(repository, reader);
-    } catch (const std::runtime_error &) {
-      /* not yet downloaded - ignore */
-    }
-  }
-#endif
+  LoadAllRepositories(repository);
 }
 
 void

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -30,8 +30,6 @@
 #include "ui/event/Notify.hpp"
 #include "thread/Mutex.hxx"
 #include "ui/event/PeriodicTimer.hpp"
-#include "util/StringCompare.hxx"
-#include "util/StringFormat.hpp"
 
 #include <map>
 #include <set>
@@ -339,17 +337,9 @@ ManagedFileListWidget::LoadRepositoryFile()
   }
 
 #ifdef HAVE_DOWNLOAD_MANAGER
-  const std::vector<std::string> uris = GetUserRepositoryURIs();
-  int file_number = 1;
-  for (const auto &uri : uris) {
-    if (uri.empty())
-      continue;
-
-    char filename[32];
-    StringFormat(filename, std::size(filename), "user_repository_%d",
-                 file_number++);
+  for (const auto &repo : GetUserRepositories()) {
     try {
-      FileLineReaderA reader(LocalPath(filename));
+      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
       ParseFileRepository(repository, reader);
     } catch (const std::runtime_error &) {
       /* not yet downloaded - ignore */
@@ -704,7 +694,7 @@ ManagedFileListWidget::OnDownloadComplete(Path path_relative) noexcept
     downloads.erase(name.c_str());
 
     if (name.c_str() == "repository"sv ||
-        StringStartsWith(name.c_str(), "user_repository_")) {
+        IsUserRepositoryFile(name.c_str())) {
       repository_failed = false;
       repository_modified = true;
     }

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -30,6 +30,8 @@
 #include "ui/event/Notify.hpp"
 #include "thread/Mutex.hxx"
 #include "ui/event/PeriodicTimer.hpp"
+#include "util/StringCompare.hxx"
+#include "util/StringFormat.hpp"
 
 #include <map>
 #include <set>
@@ -318,7 +320,7 @@ ManagedFileListWidget::FindItem(const char *name) const noexcept
 
 void
 ManagedFileListWidget::LoadRepositoryFile()
-try {
+{
 #ifdef HAVE_DOWNLOAD_MANAGER
   {
     const std::lock_guard lock{mutex};
@@ -329,10 +331,31 @@ try {
 
   repository.Clear();
 
-  const auto path = LocalPath("repository");
-  FileLineReaderA reader(path);
-  ParseFileRepository(repository, reader);
-} catch (const std::runtime_error &e) {
+  try {
+    FileLineReaderA reader(LocalPath("repository"));
+    ParseFileRepository(repository, reader);
+  } catch (const std::runtime_error &) {
+    /* not yet downloaded - ignore */
+  }
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+  const std::vector<std::string> uris = GetUserRepositoryURIs();
+  int file_number = 1;
+  for (const auto &uri : uris) {
+    if (uri.empty())
+      continue;
+
+    char filename[32];
+    StringFormat(filename, std::size(filename), "user_repository_%d",
+                 file_number++);
+    try {
+      FileLineReaderA reader(LocalPath(filename));
+      ParseFileRepository(repository, reader);
+    } catch (const std::runtime_error &) {
+      /* not yet downloaded - ignore */
+    }
+  }
+#endif
 }
 
 void
@@ -680,7 +703,8 @@ ManagedFileListWidget::OnDownloadComplete(Path path_relative) noexcept
 
     downloads.erase(name.c_str());
 
-    if (name.c_str() == "repository"sv) {
+    if (name.c_str() == "repository"sv ||
+        StringStartsWith(name.c_str(), "user_repository_")) {
       repository_failed = false;
       repository_modified = true;
     }

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -674,9 +674,10 @@ ManagedFileListWidget::OnDownloadComplete(Path path_relative) noexcept
 
     downloads.erase(name.c_str());
 
-    if (name.c_str() == "repository"sv ||
-        IsUserRepositoryFile(name.c_str())) {
+    if (name.c_str() == "repository"sv) {
       repository_failed = false;
+      repository_modified = true;
+    } else if (IsUserRepositoryFile(name.c_str())) {
       repository_modified = true;
     }
   }

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -7,6 +7,7 @@
 #include "Language/Language.hpp"
 #include "LocalPath.hpp"
 #include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
 #include "UIGlobals.hpp"
 #include "UtilsSettings.hpp"
 #include "Waypoint/Patterns.hpp"
@@ -23,6 +24,7 @@ enum ControlIndex {
   FlarmFile,
   RaspFile,
   ChecklistFile,
+  UserRepositoriesList
 };
 
 class SiteConfigPanel final : public RowFormWidget {
@@ -104,6 +106,13 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
           _("The checklist file containing pre-flight and other checklists."),
           ProfileKeys::ChecklistFile, "*.xcc\0xcsoar-checklist.txt\0",
           FileType::CHECKLIST);
+  
+  const char *user_repositories_list_value = Profile::Get(ProfileKeys::UserRepositoriesList, "");
+
+  AddText(_("User repositories"),
+          _("List of additional user repository URIs, separated by '|' character."),
+          user_repositories_list_value);
+  SetExpertRow(UserRepositoriesList);
 }
 
 bool
@@ -131,9 +140,14 @@ SiteConfigPanel::Save(bool &_changed) noexcept
 
   ChecklistFileChanged = SaveValueFileReader(ChecklistFile, ProfileKeys::ChecklistFile);
 
+  std::string buffer{Profile::Get(ProfileKeys::UserRepositoriesList, "")};
+  UserRepositoriesListChanged = SaveValue(
+      UserRepositoriesList, ProfileKeys::UserRepositoriesList, buffer);
+
   changed = WaypointFileChanged || AirfieldFileChanged ||
             AirspaceFileChanged || MapFileChanged || FlarmFileChanged ||
-            RaspFileChanged || ChecklistFileChanged;
+            RaspFileChanged || ChecklistFileChanged ||
+            UserRepositoriesListChanged;
 
   _changed |= changed;
 

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -9,6 +9,7 @@
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "UIGlobals.hpp"
+#include "Repository/Glue.hpp"
 #include "UtilsSettings.hpp"
 #include "Waypoint/Patterns.hpp"
 #include "Widget/RowFormWidget.hpp"
@@ -140,9 +141,12 @@ SiteConfigPanel::Save(bool &_changed) noexcept
 
   ChecklistFileChanged = SaveValueFileReader(ChecklistFile, ProfileKeys::ChecklistFile);
 
-  std::string buffer{Profile::Get(ProfileKeys::UserRepositoriesList, "")};
+  const std::string old_repos{Profile::Get(ProfileKeys::UserRepositoriesList, "")};
+  std::string new_repos = old_repos;
   UserRepositoriesListChanged = SaveValue(
-      UserRepositoriesList, ProfileKeys::UserRepositoriesList, buffer);
+      UserRepositoriesList, ProfileKeys::UserRepositoriesList, new_repos);
+  if (UserRepositoriesListChanged)
+    PurgeChangedUserRepositoryFiles(old_repos.c_str(), new_repos.c_str());
 
   changed = WaypointFileChanged || AirfieldFileChanged ||
             AirspaceFileChanged || MapFileChanged || FlarmFileChanged ||

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -78,6 +78,7 @@ constexpr std::string_view WatchedWaypointFileList = "WatchedWPFileList"; // pL
 constexpr std::string_view LanguageFile = "LanguageFile"; // pL
 constexpr std::string_view InputFile = "InputFile"; // pL
 constexpr std::string_view ChecklistFile = "ChecklistFile"; // pL
+constexpr std::string_view UserRepositoriesList = "UserRepositoriesList";
 constexpr std::string_view PilotName = "PilotName";
 constexpr std::string_view WeGlideEnabled = "WeGlideEnabled";
 constexpr std::string_view WeGlidePilotID = "WeGlidePilotID";

--- a/src/Profile/Map.hpp
+++ b/src/Profile/Map.hpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <cstdint>
+#include <new>
 #include <vector>
 
 struct GeoPoint;
@@ -87,6 +88,8 @@ public:
 
   void Set(std::string_view key, const char *value) noexcept;
 
+  // Getters for non-(char *) data types
+
   // char string values
 
   /**
@@ -101,6 +104,28 @@ public:
   bool Get(std::string_view key,
            BasicStringBuffer<char, max> &value) const noexcept {
     return Get(key, std::span{value.data(), value.capacity()});
+  }
+
+  // std::string values
+
+  /**
+   * Reads a value from the profile map
+   *
+   * @param key name of the value that should be read
+   * @param value Reference to the output string
+   */
+  bool Get(std::string_view key, std::string &value) const noexcept {
+    const char *p = Get(key);
+    if (p == nullptr)
+      return false;
+
+    try {
+      value = p;
+    } catch (const std::bad_alloc &) {
+      return false;
+    }
+
+    return true;
   }
 
   // numeric values
@@ -128,6 +153,15 @@ public:
     if (result)
       value = std::chrono::duration<unsigned>{_value};
     return result;
+  }
+
+  // Value setters for non-(char *) data types
+
+  /**
+   * Sets a value to the profile map from std::string.
+   */
+  void Set(std::string_view key, const std::string &value) noexcept {
+    Set(key, value.c_str());
   }
 
   void Set(std::string_view key, bool value) noexcept {

--- a/src/Profile/ProfileMap.cpp
+++ b/src/Profile/ProfileMap.cpp
@@ -30,6 +30,12 @@ Profile::Get(std::string_view key, std::span<char> value) noexcept
 }
 
 bool
+Profile::Get(std::string_view key, std::string &value) noexcept
+{
+  return map.Get(key, value);
+}
+
+bool
 Profile::Get(std::string_view key, int &value) noexcept
 {
   return map.Get(key, value);
@@ -77,6 +83,11 @@ Profile::Set(std::string_view key, const char *value) noexcept
   map.Set(key, value);
 }
 
+void
+Profile::Set(std::string_view key, const std::string &value) noexcept
+{
+  map.Set(key, value);
+}
 
 void
 Profile::Set(std::string_view key, int value) noexcept

--- a/src/Profile/ProfileMap.hpp
+++ b/src/Profile/ProfileMap.hpp
@@ -41,13 +41,20 @@ const char *
 Get(std::string_view key, const char *default_value=nullptr) noexcept;
 
 /**
- * Reads a value from the profile map
+ * Reads a string value from the profile map into a span buffer
  * @param key Name of the value that should be read
  * @param value Pointer to the output buffer
- * @param max_size Maximum size of the output buffer
  */
 bool
 Get(std::string_view key, std::span<char> value) noexcept;
+
+/**
+ * Reads a string value from the profile map as std::string
+ * @param key Name of the value that should be read
+ * @param value Reference to the output string
+ */
+bool
+Get(std::string_view key, std::string &value) noexcept;
 
 /**
  * Writes a value to the profile map
@@ -56,6 +63,9 @@ Get(std::string_view key, std::span<char> value) noexcept;
  */
 void
 Set(std::string_view key, const char *value) noexcept;
+
+void
+Set(std::string_view key, const std::string &value) noexcept;
 
 bool
 Get(std::string_view key, int &value) noexcept;

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -2,12 +2,19 @@
 // Copyright The XCSoar Project
 
 #include "Glue.hpp"
+#include "net/http/Features.hpp"
 #include "net/http/DownloadManager.hpp"
 #include "system/Path.hpp"
 #include "util/StringFormat.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "util/IterableSplitString.hxx"
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+#include "Dialogs/DownloadFileModal.hpp"
+#include "Dialogs/Error.hpp"
+#include "Language/Language.hpp"
+#endif
 
 #include <vector>
 
@@ -32,23 +39,62 @@ std::vector<std::string> GetUserRepositoryURIs()
 }
 
 void
-EnqueueRepositoryDownload(bool force)
+EnqueueRepositoryDownload(bool force, bool main_repo, bool user_repo)
 {
-  if (repository_downloaded && !force)
-    return;
-
-  repository_downloaded = true;
-  Net::DownloadManager::Enqueue(REPOSITORY_URI, Path("repository"));
+  if (main_repo) {
+    if (!repository_downloaded || force) {
+      repository_downloaded = true;
+      Net::DownloadManager::Enqueue(REPOSITORY_URI, Path("repository"));
+    }
+  }
 
   // Enqueue additional user-defined repository URIs, if set
-  char filename[32];
-  std::vector<std::string> uris = GetUserRepositoryURIs();
-  int user_repository_index = 1;
-  for (const auto &uri : uris) {
-    if (uri.empty())
-      continue;
-    StringFormat(filename, std::size(filename), "user_repository_%d",
-                 user_repository_index++);
-    Net::DownloadManager::Enqueue(uri.c_str(), Path(filename));
+  if (user_repo) {
+    char filename[32];
+    std::vector<std::string> uris = GetUserRepositoryURIs();
+    int user_repository_index = 1;
+    for (const auto &uri : uris) {
+      if (uri.empty())
+        continue;
+      StringFormat(filename, std::size(filename), "user_repository_%d",
+                   user_repository_index++);
+      Net::DownloadManager::Enqueue(uri.c_str(), Path(filename));
+    }
   }
 }
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+
+void
+DownloadRepositoriesModal(bool main_repo, bool user_repo)
+{
+  if (main_repo) {
+    try {
+      if (DownloadFileModal(_("Updating repository"), REPOSITORY_URI, "repository") == nullptr)
+        return; /* cancelled */
+      repository_downloaded = true;
+    } catch (...) {
+      ShowError(std::current_exception(), _("Updating repository"));
+    }
+  }
+
+  if (user_repo) {
+    const std::vector<std::string> uris = GetUserRepositoryURIs();
+    char filename[32];
+    int user_repository_index = 1;
+    for (const auto &uri : uris) {
+      if (uri.empty())
+        continue;
+      StringFormat(filename, std::size(filename), "user_repository_%d",
+                   user_repository_index++);
+      try {
+        if (DownloadFileModal(_("Updating repository"), uri.c_str(), filename) == nullptr)
+          return; /* cancelled */
+      } catch (...) {
+        ShowError(std::current_exception(), _("Updating repository"));
+      }
+    }
+  }
+}
+
+#endif

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -4,10 +4,32 @@
 #include "Glue.hpp"
 #include "net/http/DownloadManager.hpp"
 #include "system/Path.hpp"
+#include "util/StringFormat.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "util/IterableSplitString.hxx"
+
+#include <vector>
 
 #define REPOSITORY_URI "https://download.xcsoar.org/repository"
 
 static bool repository_downloaded = false;
+
+std::vector<std::string> GetUserRepositoryURIs()
+{
+  std::vector<std::string> uris;
+
+  const char *src = Profile::Get(ProfileKeys::UserRepositoriesList);
+  if (src == nullptr) return uris;
+  if (*src == '\0') return uris;
+
+  for (auto i : TIterableSplitString(src, '|')) {
+    if (i.empty()) continue;
+    uris.emplace_back(i.data(), i.size());
+  }
+
+  return uris;
+}
 
 void
 EnqueueRepositoryDownload(bool force)
@@ -17,4 +39,16 @@ EnqueueRepositoryDownload(bool force)
 
   repository_downloaded = true;
   Net::DownloadManager::Enqueue(REPOSITORY_URI, Path("repository"));
+
+  // Enqueue additional user-defined repository URIs, if set
+  char filename[32];
+  std::vector<std::string> uris = GetUserRepositoryURIs();
+  int user_repository_index = 1;
+  for (const auto &uri : uris) {
+    if (uri.empty())
+      continue;
+    StringFormat(filename, std::size(filename), "user_repository_%d",
+                 user_repository_index++);
+    Net::DownloadManager::Enqueue(uri.c_str(), Path(filename));
+  }
 }

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -6,6 +6,7 @@
 #include "net/http/DownloadManager.hpp"
 #include "system/Path.hpp"
 #include "util/StringFormat.hpp"
+#include "util/StringCompare.hxx"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "util/IterableSplitString.hxx"
@@ -16,26 +17,41 @@
 #include "Language/Language.hpp"
 #endif
 
+#include <string_view>
 #include <vector>
 
 #define REPOSITORY_URI "https://download.xcsoar.org/repository"
 
+static constexpr std::string_view USER_REPOSITORY_FILE_PREFIX{
+    "user_repository_"};
+
 static bool repository_downloaded = false;
 
-std::vector<std::string> GetUserRepositoryURIs()
+std::vector<RepositoryLink>
+GetUserRepositories()
 {
-  std::vector<std::string> uris;
+  std::vector<RepositoryLink> result;
 
   const char *src = Profile::Get(ProfileKeys::UserRepositoriesList);
-  if (src == nullptr) return uris;
-  if (*src == '\0') return uris;
+  if (src == nullptr || *src == '\0') return result;
 
+  int index = 1;
   for (auto i : TIterableSplitString(src, '|')) {
     if (i.empty()) continue;
-    uris.emplace_back(i.data(), i.size());
+    char filename[32];
+    StringFormat(filename, std::size(filename), "user_repository_%d", index++);
+    result.push_back({std::string{i}, std::string{filename}});
   }
 
-  return uris;
+  return result;
+}
+
+bool
+IsUserRepositoryFile(std::string_view name) noexcept
+{
+  return name.size() >= USER_REPOSITORY_FILE_PREFIX.size() &&
+         StringIsEqual(name.data(), USER_REPOSITORY_FILE_PREFIX.data(),
+                       USER_REPOSITORY_FILE_PREFIX.size());
 }
 
 void
@@ -50,16 +66,8 @@ EnqueueRepositoryDownload(bool force, bool main_repo, bool user_repo)
 
   // Enqueue additional user-defined repository URIs, if set
   if (user_repo) {
-    char filename[32];
-    std::vector<std::string> uris = GetUserRepositoryURIs();
-    int user_repository_index = 1;
-    for (const auto &uri : uris) {
-      if (uri.empty())
-        continue;
-      StringFormat(filename, std::size(filename), "user_repository_%d",
-                   user_repository_index++);
-      Net::DownloadManager::Enqueue(uri.c_str(), Path(filename));
-    }
+    for (const auto &repo : GetUserRepositories())
+      Net::DownloadManager::Enqueue(repo.uri.c_str(), Path(repo.filename.c_str()));
   }
 }
 
@@ -79,16 +87,10 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
   }
 
   if (user_repo) {
-    const std::vector<std::string> uris = GetUserRepositoryURIs();
-    char filename[32];
-    int user_repository_index = 1;
-    for (const auto &uri : uris) {
-      if (uri.empty())
-        continue;
-      StringFormat(filename, std::size(filename), "user_repository_%d",
-                   user_repository_index++);
+    for (const auto &repo : GetUserRepositories()) {
       try {
-        if (DownloadFileModal(_("Updating repository"), uri.c_str(), filename) == nullptr)
+        if (DownloadFileModal(_("Updating repository"),
+                              repo.uri.c_str(), repo.filename.c_str()) == nullptr)
           return; /* cancelled */
       } catch (...) {
         ShowError(std::current_exception(), _("Updating repository"));

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -55,22 +55,34 @@ void
 PurgeChangedUserRepositoryFiles(const char *old_list,
                                 const char *new_list) noexcept
 {
-  std::vector<std::string_view> old_entries, new_entries;
+  const auto next_token = [](std::string_view &s) noexcept -> std::string_view {
+    while (!s.empty()) {
+      const auto pos = s.find('|');
+      std::string_view token;
+      if (pos == std::string_view::npos) {
+        token = s;
+        s = {};
+      } else {
+        token = s.substr(0, pos);
+        s = s.substr(pos + 1);
+      }
+      if (!token.empty())
+        return token;
+    }
+    return {};
+  };
 
-  if (old_list != nullptr)
-    for (auto e : TIterableSplitString(old_list, '|'))
-      if (!e.empty())
-        old_entries.push_back(e);
+  std::string_view old_remaining{old_list != nullptr ? old_list : ""};
+  std::string_view new_remaining{new_list != nullptr ? new_list : ""};
 
-  if (new_list != nullptr)
-    for (auto e : TIterableSplitString(new_list, '|'))
-      if (!e.empty())
-        new_entries.push_back(e);
-
-  for (int i = 0; i < (int)old_entries.size(); ++i) {
-    if (i >= (int)new_entries.size() || old_entries[i] != new_entries[i]) {
+  for (int i = 1; ; ++i) {
+    const auto old_entry = next_token(old_remaining);
+    if (old_entry.empty())
+      break;
+    const auto new_entry = next_token(new_remaining);
+    if (old_entry != new_entry) {
       char filename[32];
-      StringFormat(filename, std::size(filename), "user_repository_%d", i + 1);
+      StringFormat(filename, std::size(filename), "user_repository_%d", i);
       File::Delete(LocalPath(filename));
     }
   }

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -2,9 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "Glue.hpp"
+#include "Parser.hpp"
 #include "net/http/Features.hpp"
 #include "net/http/DownloadManager.hpp"
 #include "system/Path.hpp"
+#include "io/FileLineReader.hpp"
+#include "LocalPath.hpp"
+
 #include "util/StringFormat.hpp"
 #include "util/StringCompare.hxx"
 #include "Profile/Keys.hpp"
@@ -52,6 +56,26 @@ IsUserRepositoryFile(std::string_view name) noexcept
   return name.size() >= USER_REPOSITORY_FILE_PREFIX.size() &&
          StringIsEqual(name.data(), USER_REPOSITORY_FILE_PREFIX.data(),
                        USER_REPOSITORY_FILE_PREFIX.size());
+}
+
+void
+LoadAllRepositories(FileRepository &repository)
+{
+  try {
+    FileLineReaderA reader(LocalPath("repository"));
+    ParseFileRepository(repository, reader);
+  } catch (const std::runtime_error &) {
+    /* not yet downloaded - ignore */
+  }
+
+  for (const auto &repo : GetUserRepositories()) {
+    try {
+      FileLineReaderA reader(LocalPath(repo.filename.c_str()));
+      ParseFileRepository(repository, reader);
+    } catch (const std::runtime_error &) {
+      /* not yet downloaded - ignore */
+    }
+  }
 }
 
 void

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -6,6 +6,7 @@
 #include "net/http/Features.hpp"
 #include "net/http/DownloadManager.hpp"
 #include "system/Path.hpp"
+#include "system/FileUtil.hpp"
 #include "io/FileLineReader.hpp"
 #include "LocalPath.hpp"
 
@@ -48,6 +49,31 @@ GetUserRepositories()
   }
 
   return result;
+}
+
+void
+PurgeChangedUserRepositoryFiles(const char *old_list,
+                                const char *new_list) noexcept
+{
+  std::vector<std::string_view> old_entries, new_entries;
+
+  if (old_list != nullptr)
+    for (auto e : TIterableSplitString(old_list, '|'))
+      if (!e.empty())
+        old_entries.push_back(e);
+
+  if (new_list != nullptr)
+    for (auto e : TIterableSplitString(new_list, '|'))
+      if (!e.empty())
+        new_entries.push_back(e);
+
+  for (int i = 0; i < (int)old_entries.size(); ++i) {
+    if (i >= (int)new_entries.size() || old_entries[i] != new_entries[i]) {
+      char filename[32];
+      StringFormat(filename, std::size(filename), "user_repository_%d", i + 1);
+      File::Delete(LocalPath(filename));
+    }
+  }
 }
 
 bool

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "net/http/Features.hpp"
+
 #include <vector>
 #include <string>
 
@@ -18,4 +20,15 @@ std::vector<std::string> GetUserRepositoryURIs();
  * believes it is still fresh
  */
 void
-EnqueueRepositoryDownload(bool force=false);
+EnqueueRepositoryDownload(bool force=false, bool main_repo=true, bool user_repo=true);
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+/**
+ * Download the main repository and all user-defined repositories
+ * modally, showing a #ProgressDialog for each one.  Errors are
+ * reported to the user.  Call this after the user changes the
+ * repository URL list in the configuration.
+ */
+void
+DownloadRepositoriesModal(bool main_repo=true, bool user_repo=true);
+#endif

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -3,6 +3,14 @@
 
 #pragma once
 
+#include <vector>
+#include <string>
+
+/**
+ * Get list of URIs of user repositories
+ */
+std::vector<std::string> GetUserRepositoryURIs();
+
 /**
  * Download the repository file.
  *

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -9,6 +9,8 @@
 #include <string_view>
 #include <vector>
 
+struct FileRepository;
+
 struct RepositoryLink {
   std::string uri;
   std::string filename;
@@ -24,6 +26,12 @@ std::vector<RepositoryLink> GetUserRepositories();
  * (i.e. matches the "user_repository_*" pattern).
  */
 [[gnu::pure]] bool IsUserRepositoryFile(std::string_view name) noexcept;
+
+/**
+ * Load the main repository file and all user repository files into
+ * @a repository.  Files not yet downloaded are silently skipped.
+ */
+void LoadAllRepositories(FileRepository &repository);
 
 /**
  * Download the repository file.

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -5,13 +5,25 @@
 
 #include "net/http/Features.hpp"
 
-#include <vector>
 #include <string>
+#include <string_view>
+#include <vector>
+
+struct RepositoryLink {
+  std::string uri;
+  std::string filename;
+};
 
 /**
- * Get list of URIs of user repositories
+ * Get list of user repositories with their local filenames.
  */
-std::vector<std::string> GetUserRepositoryURIs();
+std::vector<RepositoryLink> GetUserRepositories();
+
+/**
+ * Returns true if the given filename is a user repository file
+ * (i.e. matches the "user_repository_*" pattern).
+ */
+[[gnu::pure]] bool IsUserRepositoryFile(std::string_view name) noexcept;
 
 /**
  * Download the repository file.

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -28,6 +28,14 @@ std::vector<RepositoryLink> GetUserRepositories();
 [[gnu::pure]] bool IsUserRepositoryFile(std::string_view name) noexcept;
 
 /**
+ * Delete cached repository files for user repository entries that have
+ * changed position or been removed, comparing @a old_list with @a new_list.
+ * Call this before downloading new user repositories when the URL list changes.
+ */
+void PurgeChangedUserRepositoryFiles(const char *old_list,
+                                     const char *new_list) noexcept;
+
+/**
  * Load the main repository file and all user repository files into
  * @a repository.  Files not yet downloaded are silently skipped.
  */

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -46,6 +46,7 @@
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
 #include "DataGlobals.hpp"
+#include "Repository/Glue.hpp"
 
 bool DevicePortChanged = false;
 bool MapFileChanged = false;
@@ -57,6 +58,7 @@ bool RaspFileChanged = false;
 bool ChecklistFileChanged = false;
 bool InputFileChanged = false;
 bool LanguageChanged = false;
+bool UserRepositoriesListChanged = false;
 bool require_restart;
 
 void
@@ -77,6 +79,7 @@ SettingsEnter() noexcept
   InputFileChanged = false;
   DevicePortChanged = false;
   LanguageChanged = false;
+  UserRepositoriesListChanged = false;
   require_restart = false;
 }
 
@@ -193,6 +196,9 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   if (ChecklistFileChanged)
     dlgChecklistNotifySiteFileChanged();
+
+  if (UserRepositoriesListChanged)
+    EnqueueRepositoryDownload(true);
 
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -47,6 +47,7 @@
 #include "DataComponents.hpp"
 #include "DataGlobals.hpp"
 #include "Repository/Glue.hpp"
+#include "net/http/Features.hpp"
 
 bool DevicePortChanged = false;
 bool MapFileChanged = false;
@@ -197,8 +198,15 @@ SettingsLeave(const UISettings &old_ui_settings)
   if (ChecklistFileChanged)
     dlgChecklistNotifySiteFileChanged();
 
-  if (UserRepositoriesListChanged)
-    EnqueueRepositoryDownload(true);
+#ifdef HAVE_HTTP
+  if (UserRepositoriesListChanged) {
+#ifdef HAVE_DOWNLOAD_MANAGER
+    DownloadRepositoriesModal(false, true);
+#else
+    EnqueueRepositoryDownload(true, false, true);
+#endif
+  }
+#endif
 
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 

--- a/src/UtilsSettings.hpp
+++ b/src/UtilsSettings.hpp
@@ -14,6 +14,7 @@ extern bool MapFileChanged;
 extern bool FlarmFileChanged;
 extern bool RaspFileChanged;
 extern bool ChecklistFileChanged;
+extern bool UserRepositoriesListChanged;
 extern bool LanguageChanged;
 extern bool require_restart;
 

--- a/src/Widget/EditRowFormWidget.cpp
+++ b/src/Widget/EditRowFormWidget.cpp
@@ -18,10 +18,12 @@
 #include "time/BrokenDate.hpp"
 #include "Language/Language.hpp"
 #include "Math/Angle.hpp"
+#include "LogFile.hpp"
 #include "util/StringAPI.hxx"
 #include "util/TruncateString.hpp"
 
 #include <cassert>
+#include <new>
 
 std::unique_ptr<WndProperty>
 RowFormWidget::CreateEdit(const char *label, const char *help,
@@ -477,7 +479,7 @@ RowFormWidget::SaveValue(unsigned i,
 
 bool
 RowFormWidget::SaveValue(unsigned i,
-                         std::string &string) const
+                         std::string &string) const noexcept
 {
   const char *new_value = GetDataField(i).GetAsString();
   assert(new_value != nullptr);
@@ -485,6 +487,12 @@ RowFormWidget::SaveValue(unsigned i,
   if (string == new_value)
     return false;
 
-  string = new_value;
+  try {
+    string = new_value;
+  } catch (const std::bad_alloc &) {
+    LogFmt("SaveValue: allocation failed storing string value");
+    return false;
+  }
+
   return true;
 }

--- a/src/Widget/EditRowFormWidget.cpp
+++ b/src/Widget/EditRowFormWidget.cpp
@@ -474,3 +474,17 @@ RowFormWidget::SaveValue(unsigned i,
   CopyTruncateString(string, max_size, new_value);
   return true;
 }
+
+bool
+RowFormWidget::SaveValue(unsigned i,
+                         std::string &string) const
+{
+  const char *new_value = GetDataField(i).GetAsString();
+  assert(new_value != nullptr);
+
+  if (string == new_value)
+    return false;
+
+  string = new_value;
+  return true;
+}

--- a/src/Widget/ProfileRowFormWidget.cpp
+++ b/src/Widget/ProfileRowFormWidget.cpp
@@ -84,6 +84,17 @@ RowFormWidget::SaveValue(unsigned i, std::string_view profile_key,
 
 bool
 RowFormWidget::SaveValue(unsigned i, std::string_view profile_key,
+                         std::string &string) const noexcept
+{
+  if (!SaveValue(i, string))
+    return false;
+
+  Profile::Set(profile_key, string);
+  return true;
+}
+
+bool
+RowFormWidget::SaveValue(unsigned i, std::string_view profile_key,
                          bool &value, bool negated) const noexcept
 {
   if (!SaveValue(i, value, negated))

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -673,6 +673,7 @@ public:
 
   bool SaveValue(unsigned i, RoughTime &value_r) const noexcept;
   bool SaveValue(unsigned i, char *string, size_t max_size) const noexcept;
+  bool SaveValue(unsigned i, std::string &string) const;
 
   template<size_t max>
   bool SaveValue(unsigned i, BasicStringBuffer<char, max> &value) const noexcept {
@@ -681,6 +682,9 @@ public:
 
   bool SaveValue(unsigned i, std::string_view profile_key,
                  char *string, size_t max_size) const noexcept;
+
+  bool SaveValue(unsigned i, std::string_view profile_key,
+                 std::string &string) const noexcept;
 
   template<size_t max>
   bool SaveValue(unsigned i, std::string_view profile_key,

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -673,7 +673,7 @@ public:
 
   bool SaveValue(unsigned i, RoughTime &value_r) const noexcept;
   bool SaveValue(unsigned i, char *string, size_t max_size) const noexcept;
-  bool SaveValue(unsigned i, std::string &string) const;
+  bool SaveValue(unsigned i, std::string &string) const noexcept;
 
   template<size_t max>
   bool SaveValue(unsigned i, BasicStringBuffer<char, max> &value) const noexcept {

--- a/src/net/http/CoDownloadToFile.cpp
+++ b/src/net/http/CoDownloadToFile.cpp
@@ -33,6 +33,8 @@ CoDownloadToFile(CurlGlobal &curl, const char *url,
 
   CurlEasy easy{url};
   Curl::Setup(easy);
+  easy.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+  easy.SetOption(CURLOPT_MAXREDIRS, 10L);
   const Net::ProgressAdapter progress_adapter{easy, progress};
   easy.SetFailOnError();
 


### PR DESCRIPTION
This started as a tool to help with developing and debugging repository-related things, but I actually started to like it. 
And I think it could be really useful to have something like this in a variety of circumstances, such as clubs or competitions.

It allows to expand the repository to your own server or that of your club. So if your club operates a web site, you can store your clubs' checklists, special airspace files, turnpoints, tasks etc. on your web site for direct download and direct update into XCSoar using the usual "Download" / "File Manager" mechanism.

This even works if you do not have your own server but use web share links from cloud providers such as dropbox, nextcloud etc.

All you see is another (expert) option in site config:
<img width="329" height="259" alt="Screenshot 2026-02-12 232510-userrepo" src="https://github.com/user-attachments/assets/8b746bd8-ff5d-434a-a33f-4fba7a6a4f5b" />

Which adds additional files to the repository list:

<img width="330" height="260" alt="Screenshot 2026-02-12 234427-userrep2" src="https://github.com/user-attachments/assets/1055ba33-ab95-47a4-bfb8-ad6432f1de2e" />

Other than the actual functionality, the branch has a few fixes, refactors and improvements related to settings, downloads and repos (for example scrollable input boxes), in the first couple of commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure multiple custom user repositories (pipe-separated) and download them alongside the main repository.
  * Modal, cancellable file-download UI with progress; modal repository-download flow for main and user repos.
  * Settings now trigger optional user-repository updates and purge changed repository files.
  * Profile API extended to read/write std::string values.

* **Bug Fixes**
  * Downloads now follow HTTP redirects automatically.
  * User-repository errors no longer mark the main repository as failed.

* **Documentation**
  * Configuration guide and NEWS updated with User Repositories details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->