### PR TITLE
Dialogs/WidgetDialog: re-run button layout after widget.Show()

### DIFF
--- a/src/Dialogs/WidgetDialog.cpp
+++ b/src/Dialogs/WidgetDialog.cpp
@@ -176,6 +176,13 @@ WidgetDialog::ShowModal()
     widget.Move(buttons.UpdateLayout());
 
   widget.Show();
+  if (!auto_size) {
+    /* Ensure button layout is recalculated with any metrics that may have
+       become available when the widget was shown (fixes caption clipping on
+       some scaled/font configurations).  Keep this non-auto dialogs only,
+       so AutoSize()'s LeftLayout()/BottomLayout() decision remains intact. */
+    widget.Move(buttons.UpdateLayout());
+  }
   int result = WndForm::ShowModal();
   widget.Hide();
   return result;


### PR DESCRIPTION
ShowModal() already lays out buttons before showing the widget, but with scaled fonts some text metrics are only fully available after show, causing initial button captions to clip until resize. Run a second buttons.UpdateLayout() immediately after widget.Show() so initial button widths are correct on first draw.

fixes #2176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog button layout so captions render correctly after dialogs are shown, addressing clipping issues under certain scaling or font settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->