### PR TITLE
Android/NativeView: Fix volume buttons not controlling media volume

### DIFF
--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -498,17 +498,25 @@ class NativeView extends SurfaceView
     pauseNative();
   }
 
-  private static int translateKeyCode(int keyCode) {
-    return keyCode;
+  private static boolean isVolumeKey(int keyCode) {
+    return keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
+           keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
+           keyCode == KeyEvent.KEYCODE_VOLUME_MUTE;
   }
 
   @Override public boolean onKeyDown(int keyCode, final KeyEvent event) {
-    EventBridge.onKeyDown(translateKeyCode(keyCode));
+    if (isVolumeKey(keyCode))
+      return false;
+
+    EventBridge.onKeyDown(keyCode);
     return true;
   }
 
   @Override public boolean onKeyUp(int keyCode, final KeyEvent event) {
-    EventBridge.onKeyUp(translateKeyCode(keyCode));
+    if (isVolumeKey(keyCode))
+      return false;
+
+    EventBridge.onKeyUp(keyCode);
     return true;
   }
 }

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -377,32 +377,18 @@ public class XCSoar extends Activity implements PermissionManager {
     System.exit(0);
   }
 
-  private static boolean isVolumeKey(int keyCode) {
-    return keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
-           keyCode == KeyEvent.KEYCODE_VOLUME_DOWN ||
-           keyCode == KeyEvent.KEYCODE_VOLUME_MUTE;
-  }
-
   @Override public boolean onKeyDown(int keyCode, final KeyEvent event) {
-    if (isVolumeKey(keyCode))
-      return super.onKeyDown(keyCode, event);
-
-    if (nativeView != null) {
-      nativeView.onKeyDown(keyCode, event);
+    if (nativeView != null && nativeView.onKeyDown(keyCode, event))
       return true;
-    } else
-      return super.onKeyDown(keyCode, event);
+
+    return super.onKeyDown(keyCode, event);
   }
 
   @Override public boolean onKeyUp(int keyCode, final KeyEvent event) {
-    if (isVolumeKey(keyCode))
-      return super.onKeyUp(keyCode, event);
-
-    if (nativeView != null) {
-      nativeView.onKeyUp(keyCode, event);
+    if (nativeView != null && nativeView.onKeyUp(keyCode, event))
       return true;
-    } else
-      return super.onKeyUp(keyCode, event);
+
+    return super.onKeyUp(keyCode, event);
   }
 
   @Override public void onWindowFocusChanged(boolean hasFocus) {


### PR DESCRIPTION
## Summary

- Fixes volume buttons doing nothing on Android (#2186)
- The previous fix (45e7c0c3) placed the volume key passthrough at the Activity level, but Android dispatches key events to the focused View first — `NativeView.onKeyDown()` unconditionally consumed all events before they reached the Activity handler
- Moves the volume key check into `NativeView` where events are actually intercepted, and fixes the Activity handlers to respect the View's return value

## Test plan

- [x] Build and deploy debug APK to Android phone
- [x] Verify volume buttons show the Android volume overlay and adjust media volume
- [x] Verify other keys (back, menu, etc.) still work normally in XCSoar