### PR TITLE
Dialogs/dlgQuickGuide: Show confirmation when closing without accepting disclaimer

### DIFF
--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -119,8 +119,12 @@ ArrowPagerWidget::Prepare(ContainerWindow &parent,
                        if (CanAdvance())
                          Next(false);
                      });
-  close_button.Create(parent, look, _("Close"), layout.close_button,
+  close_button.Create(parent, look,
+                      pending_close_caption ? pending_close_caption
+                                            : _("Close"),
+                      layout.close_button,
                       style, close_callback);
+  pending_close_caption = nullptr;
 }
 
 void

--- a/src/Widget/ArrowPagerWidget.hpp
+++ b/src/Widget/ArrowPagerWidget.hpp
@@ -56,6 +56,9 @@ private:
   Button previous_button, next_button;
   Button close_button;
 
+  /** Caption for the close button, applied during Prepare(). */
+  const TCHAR *pending_close_caption = nullptr;
+
   /** Optional guard that blocks forward page navigation */
   CanAdvanceCallback can_advance_callback;
 
@@ -111,6 +114,18 @@ public:
    * prerequisite checkbox was toggled).
    */
   void UpdateNextButtonState() noexcept;
+
+  /**
+   * Change the label of the close button.  If the button has not
+   * been created yet, the caption is stored and applied during
+   * Prepare().
+   */
+  void SetCloseButtonCaption(const TCHAR *caption) noexcept {
+    if (close_button.IsDefined())
+      close_button.SetCaption(caption);
+    else
+      pending_close_caption = caption;
+  }
 
 protected:
   void OnPageFlipped() noexcept override;


### PR DESCRIPTION
## Summary

- Show a Yes/No confirmation dialog when the user tries to close the Quick Guide without accepting the safety disclaimer, instead of silently exiting
- Close button label changes dynamically between "Quit" (disclaimer not accepted) and "Close" (accepted) to communicate the consequence
- Add `ArrowPagerWidget::SetCloseButtonCaption()` to allow changing the close button label at runtime

Fixes #2179

## Test plan

- [x] Launch XCSoar in FLY mode (with disclaimer not yet acknowledged)
- [x] Verify the close button shows "Quit" on startup
- [x] Try pressing "Quit" without accepting the disclaimer — a confirmation dialog should appear
- [x] Press "No" — the dialog stays open on the same page
- [x] Navigate to the disclaimer page and check the checkbox — button should change to "Close"
- [x] Uncheck the checkbox — button should change back to "Quit"
- [x] Accept the disclaimer and close — XCSoar should start normally
- [x] Launch again in SIM mode — no disclaimer page, button should say "Close" as normal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Quick Guide dialog now asks for confirmation if you attempt to exit without accepting warranty terms, preventing accidental progression.
  * The close button label now dynamically updates to reflect your warranty acceptance status (Close vs Quit).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->