### PR TITLE
Android: Fix foreground service not starting after permission grants

### DIFF
--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -91,7 +91,7 @@ class NativeView extends SurfaceView
    * user chooses Fly mode (not called in Simulator mode because
    * IGC logging and safety warnings are not needed in simulation).
    */
-  private void startMyService() {
+  void startMyService() {
     final Context context = getContext();
 
     try {

--- a/android/src/PermissionHelper.java
+++ b/android/src/PermissionHelper.java
@@ -29,6 +29,7 @@ public class PermissionHelper implements PermissionManager {
   private final Activity activity;
   private final Handler mainHandler;
   private final Runnable onLocationPermissionsGranted;
+  private final Runnable onNotificationPermissionGranted;
 
   private final Map<Integer, PermissionHandler> permissionHandlers =
     new TreeMap<Integer, PermissionHandler>();
@@ -77,12 +78,15 @@ public class PermissionHelper implements PermissionManager {
    * @param activity The Activity that will handle permission requests
    * @param mainHandler Handler for posting UI operations to main thread
    * @param onLocationPermissionsGranted Callback to invoke when location permissions are granted
+   * @param onNotificationPermissionGranted Callback to invoke when notification permission is granted
    */
   public PermissionHelper(Activity activity, Handler mainHandler,
-                          Runnable onLocationPermissionsGranted) {
+                          Runnable onLocationPermissionsGranted,
+                          Runnable onNotificationPermissionGranted) {
     this.activity = activity;
     this.mainHandler = mainHandler;
     this.onLocationPermissionsGranted = onLocationPermissionsGranted;
+    this.onNotificationPermissionGranted = onNotificationPermissionGranted;
   }
 
   /**
@@ -593,6 +597,8 @@ public class PermissionHelper implements PermissionManager {
               @Override
               public void onRequestPermissionsResult(boolean granted) {
                 notifyNativePermissionResult(granted);
+                if (granted && onNotificationPermissionGranted != null)
+                  mainHandler.post(onNotificationPermissionGranted);
               }
             });
         }


### PR DESCRIPTION
## Summary

- Fix race condition where `MyService` foreground service fails to start on fresh installs because `startMyService()` is called before QuickGuide obtains `ACCESS_FINE_LOCATION` (required by Android 14+ for `foregroundServiceType=location`)
- Fix invisible foreground service notification when `POST_NOTIFICATIONS` is not yet granted at service start time
- Retry `startMyService()` via `PermissionHelper` callbacks when location or notification permissions are granted

## Details

On a fresh install, the startup sequence calls `startMyService()` early in `Startup.cpp`, before the QuickGuide onboarding has obtained permissions. On Android 14+, `startForeground()` with `foregroundServiceType=location` requires `ACCESS_FINE_LOCATION` at call time, causing a `SecurityException`. The service is killed by Android, and the `START_STICKY` restart fails with `ForegroundServiceStartNotAllowedException` from background, permanently killing the service.

Additionally, when `POST_NOTIFICATIONS` is denied at service start time, the foreground service notification is suppressed by Android. Granting the permission later does not retroactively make the notification visible.

Both issues are fixed by adding permission-granted callbacks in `PermissionHelper` that retry `startMyService()`. Re-calling `startService()` on an already-running service simply triggers another `onStartCommand()`, which re-posts the notification (now visible with the granted permission).

## Test plan

- [ ] Fresh install on Android 14+ device: verify service starts after granting location permissions through QuickGuide
- [ ] Revoke notification permission, launch app, grant notification permission when prompted: verify notification appears
- [ ] Normal startup with all permissions already granted: verify service starts as before (no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service startup reliability following notification permission grants.
  * Enhanced notification permission handling to ensure callbacks execute properly on the main thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->