### PR TITLE
Renderer/MapItemListRenderer: Use "---" for invalid values

### DIFF
--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -62,14 +62,14 @@ Draw(Canvas &canvas, const PixelRect rc,
                        FormatBearing(item.vector.bearing).c_str());
   else
     StringFormatUnsafe(info_buffer, _T("%s: %s, %s: %s"),
-                       _("Distance"), _T("???"), _("Direction"), _T("???"));
+                       _("Distance"), _T("---"), _("Direction"), _T("---"));
 
   row_renderer.DrawFirstRow(canvas, rc, info_buffer);
 
   StringFormatUnsafe(info_buffer, _T("%s: %s"), _("Elevation"),
                      item.HasElevation()
                      ? FormatUserAltitude(item.elevation).c_str()
-                     : _T("???"));
+                     : _T("---"));
   row_renderer.DrawSecondRow(canvas, rc, info_buffer);
 }
 


### PR DESCRIPTION
## Summary
- Display "---" instead of "???" for invalid distance, direction, and elevation in the "Map elements at this location" dialog
- Consistent with the InfoBox convention for unavailable data

## Test plan
- Open map, long-press on a location without valid distance/direction/elevation data
- Verify the dialog shows "---" instead of "???"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated placeholder text for Distance, Direction, and Elevation fields from "???" to "---" when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->