### PR TITLE
Fix UI rendering issues: dark mode, DPI scaling, GDI compatibility

### DIFF
--- a/src/Dialogs/ColorListDialog.cpp
+++ b/src/Dialogs/ColorListDialog.cpp
@@ -33,7 +33,8 @@ OnPaintListItem(Canvas &canvas, const PixelRect rc, unsigned i) noexcept
 #endif
 
   const auto &look = UIGlobals::GetDialogLook();
-  canvas.Select(Pen(1, look.dark_mode ? COLOR_LIGHT_GRAY : COLOR_BLACK));
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
+                    look.dark_mode ? COLOR_LIGHT_GRAY : COLOR_BLACK));
   canvas.DrawRectangle(rc2);
 }
 

--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -381,7 +381,8 @@ InfoBoxPreview::OnPaint(Canvas &canvas) noexcept
     canvas.Clear(dlook.background_color);
 
   canvas.SelectHollowBrush();
-  canvas.Select(Pen(1, dlook.dark_mode ? COLOR_GRAY : COLOR_BLACK));
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
+                    dlook.dark_mode ? COLOR_GRAY : COLOR_BLACK));
   canvas.DrawRectangle(PixelRect{PixelSize{canvas.GetWidth() - 1, canvas.GetHeight() - 1}});
 
   InfoBoxFactory::Type type = parent->GetContents(i);

--- a/src/Dialogs/SimulatorPromptWindow.cpp
+++ b/src/Dialogs/SimulatorPromptWindow.cpp
@@ -98,6 +98,7 @@ SimulatorPromptWindow::OnResize(PixelSize new_size) noexcept
 void
 SimulatorPromptWindow::OnPaint(Canvas &canvas) noexcept
 {
+#ifdef ENABLE_OPENGL
   DrawVerticalGradient(canvas, GetClientRect(),
                        COLOR_XCSOAR, COLOR_XCSOAR_DARK,
                        COLOR_XCSOAR_DARK);
@@ -105,6 +106,18 @@ SimulatorPromptWindow::OnPaint(Canvas &canvas) noexcept
 
   canvas.Select(look.text_font);
   canvas.SetTextColor(COLOR_WHITE);
+#else
+  /* Without OpenGL there is no alpha blending — GDI uses BMP
+     resources and the software renderer uses pre-composited PNGs,
+     both with opaque white backgrounds.  A dark/gradient background
+     would show visible white rectangles around every bitmap.
+     Use a plain white background instead. */
+  canvas.ClearWhite();
+  logo_view.draw(canvas, logo_rect);
+
+  canvas.Select(look.text_font);
+  canvas.SetTextColor(COLOR_BLACK);
+#endif
   canvas.SetBackgroundTransparent();
   canvas.DrawText(label_position, _("What do you want to do?"));
 

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -480,11 +480,11 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
 
   details_panel.Create(parent, look, layout.main, dock_style);
   details_text.Create(details_panel, layout.details_text);
-  details_text.SetFont(look.text_font);
 #ifndef USE_WINUSER
+  details_text.SetFont(look.text_font);
+#endif
   details_text.SetColors(look.background_color, look.text_color,
                          look.dark_mode ? COLOR_GRAY : COLOR_BLACK);
-#endif
   details_text.SetText(waypoint->details.c_str());
 
 #ifdef HAVE_RUN_FILE

--- a/src/Dialogs/WidgetDialog.cpp
+++ b/src/Dialogs/WidgetDialog.cpp
@@ -176,6 +176,13 @@ WidgetDialog::ShowModal()
     widget.Move(buttons.UpdateLayout());
 
   widget.Show();
+  if (!auto_size) {
+    /* Ensure button layout is recalculated with any metrics that may have
+       become available when the widget was shown (fixes caption clipping on
+       some scaled/font configurations).  Keep this non-auto dialogs only,
+       so AutoSize()'s LeftLayout()/BottomLayout() decision remains intact. */
+    widget.Move(buttons.UpdateLayout());
+  }
   int result = WndForm::ShowModal();
   widget.Hide();
   return result;

--- a/src/Form/CheckBox.cpp
+++ b/src/Form/CheckBox.cpp
@@ -206,14 +206,12 @@ CheckBoxControl::OnPaint(Canvas &canvas) noexcept
 
   const bool focused = HasCursorKeys() && HasFocus();
 
-  if (HaveClipping()) {
+  if (focused)
+    canvas.Clear(cb_look.focus_background_brush);
+  else if (HaveClipping())
     /* with clipping, the parent's background does not extend into
        child windows, so we must fill the background ourselves */
-    if (focused)
-      canvas.Clear(cb_look.focus_background_brush);
-    else
-      canvas.Clear(look->background_brush);
-  }
+    canvas.Clear(look->background_brush);
 
   const auto &state_look = IsEnabled()
     ? (pressed

--- a/src/Form/Edit.cpp
+++ b/src/Form/Edit.cpp
@@ -301,16 +301,14 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
   const bool focused = HasCursorKeys() && HasFocus();
 
   /* background and selector */
-  if (HaveClipping()) {
+  if (pressed)
+    canvas.Clear(look.list.pressed.background_color);
+  else if (focused)
+    canvas.Clear(look.focused.background_color);
+  else if (HaveClipping())
     /* with clipping, the parent's background does not extend into
        child windows, so we must fill the background ourselves */
-    if (pressed)
-      canvas.Clear(look.list.pressed.background_color);
-    else if (focused)
-      canvas.Clear(look.focused.background_color);
-    else
-      canvas.Clear(look.background_color);
-  }
+    canvas.Clear(look.background_color);
 
   if (!caption.empty()) {
     canvas.SetTextColor(focused && !pressed
@@ -369,7 +367,8 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
   canvas.DrawFilledRectangle(edit_rc, background_color);
 
   canvas.SelectHollowBrush();
-  canvas.Select(Pen(1, look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
+                    look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
   canvas.DrawRectangle(edit_rc);
 
   if (!value.empty()) {

--- a/src/Form/HLine.cpp
+++ b/src/Form/HLine.cpp
@@ -4,6 +4,7 @@
 #include "HLine.hpp"
 #include "Look/DialogLook.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "Screen/Layout.hpp"
 
 void
 HLine::OnPaint(Canvas &canvas) noexcept
@@ -16,6 +17,7 @@ HLine::OnPaint(Canvas &canvas) noexcept
   const unsigned height = canvas.GetHeight();
   const int middle = height / 2;
 
-  canvas.Select(Pen(1, look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
+                    look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
   canvas.DrawLine({0, middle}, {width, middle});
 }

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -303,16 +303,16 @@ InfoBoxWindow::OnResize(PixelSize new_size) noexcept
   PixelRect rc = GetClientRect();
 
   if (border_kind & BORDERLEFT)
-    rc.left += look.BORDER_WIDTH;
+    rc.left += look.border_width;
 
   if (border_kind & BORDERRIGHT)
-    rc.right -= look.BORDER_WIDTH;
+    rc.right -= look.border_width;
 
   if (border_kind & BORDERTOP)
-    rc.top += look.BORDER_WIDTH;
+    rc.top += look.border_width;
 
   if (border_kind & BORDERBOTTOM)
-    rc.bottom -= look.BORDER_WIDTH;
+    rc.bottom -= look.border_width;
 
   title_rect = rc;
   title_rect.bottom = rc.top + look.title_font.GetHeight();

--- a/src/Look/ButtonLook.hpp
+++ b/src/Look/ButtonLook.hpp
@@ -6,6 +6,7 @@
 #include "ui/canvas/Color.hpp"
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Pen.hpp"
+#include "Screen/Layout.hpp"
 
 class Font;
 
@@ -21,9 +22,9 @@ struct ButtonLook {
     Brush light_border_brush, dark_border_brush;
 
     void CreateBorder(Color light, Color dark) {
-      light_border_pen.Create(1, light);
+      light_border_pen.Create(Layout::ScaleFinePenWidth(1), light);
       light_border_brush.Create(light);
-      dark_border_pen.Create(1, dark);
+      dark_border_pen.Create(Layout::ScaleFinePenWidth(1), dark);
       dark_border_brush.Create(dark);
     }
   } standard, selected, focused;

--- a/src/Look/ChartLook.cpp
+++ b/src/Look/ChartLook.cpp
@@ -25,8 +25,8 @@ ChartLook::Initialise(bool dark_mode)
   pens[STYLE_GREENDASH].Create(Pen::DASH2, width_normal, COLOR_GREEN);
   pens[STYLE_GREEN].Create(width_normal, COLOR_GREEN);
 
-  pens[STYLE_GRID].Create(Pen::DASH1, 1, Color(0xB0, 0xB0, 0xB0));
-  pens[STYLE_GRIDMINOR].Create(1, Color(0xB0, 0xB0, 0xB0));
+  pens[STYLE_GRID].Create(Pen::DASH1, width_thin, Color(0xB0, 0xB0, 0xB0));
+  pens[STYLE_GRIDMINOR].Create(width_thin, Color(0xB0, 0xB0, 0xB0));
   pens[STYLE_GRIDZERO].Create(width_normal, Color(0xB0, 0xB0, 0xB0));
 
   bar_brush.Create(COLOR_GREEN);

--- a/src/Look/CheckBoxLook.cpp
+++ b/src/Look/CheckBoxLook.cpp
@@ -3,54 +3,57 @@
 
 #include "CheckBoxLook.hpp"
 #include "Colors.hpp"
+#include "Screen/Layout.hpp"
 
 void
 CheckBoxLook::Initialise(const Font &_font, bool dark_mode)
 {
   font = &_font;
 
+  const unsigned pen_width = Layout::ScaleFinePenWidth(1);
+
   if (dark_mode) {
     focus_background_brush.Create(COLOR_XCSOAR);
 
     standard.box_brush.Create(COLOR_DARK_THEME_LIST);
-    standard.box_pen.Create(1, COLOR_LIGHT_GRAY);
+    standard.box_pen.Create(pen_width, COLOR_LIGHT_GRAY);
     standard.check_brush.Create(COLOR_WHITE);
     standard.text_color = COLOR_WHITE;
 
     focused.box_brush.Create(COLOR_DARK_THEME_LIST);
-    focused.box_pen.Create(1, COLOR_WHITE);
+    focused.box_pen.Create(pen_width, COLOR_WHITE);
     focused.check_brush.Create(COLOR_WHITE);
     focused.text_color = COLOR_WHITE;
 
     pressed.box_brush.Create(DarkColor(COLOR_XCSOAR_LIGHT));
-    pressed.box_pen.Create(1, COLOR_WHITE);
+    pressed.box_pen.Create(pen_width, COLOR_WHITE);
     pressed.check_brush.Create(COLOR_WHITE);
     pressed.text_color = COLOR_WHITE;
 
     disabled.box_brush.Create(COLOR_DARK_THEME_LIST);
-    disabled.box_pen.Create(1, COLOR_GRAY);
+    disabled.box_pen.Create(pen_width, COLOR_GRAY);
     disabled.check_brush.Create(COLOR_GRAY);
     disabled.text_color = COLOR_GRAY;
   } else {
     focus_background_brush.Create(COLOR_XCSOAR_DARK);
 
     standard.box_brush.Create(COLOR_WHITE);
-    standard.box_pen.Create(1, COLOR_BLACK);
+    standard.box_pen.Create(pen_width, COLOR_BLACK);
     standard.check_brush.Create(COLOR_BLACK);
     standard.text_color = COLOR_BLACK;
 
     focused.box_brush.Create(COLOR_WHITE);
-    focused.box_pen.Create(1, COLOR_BLACK);
+    focused.box_pen.Create(pen_width, COLOR_BLACK);
     focused.check_brush.Create(COLOR_BLACK);
     focused.text_color = COLOR_WHITE;
 
     pressed.box_brush.Create(COLOR_XCSOAR_LIGHT);
-    pressed.box_pen.Create(1, COLOR_BLACK);
+    pressed.box_pen.Create(pen_width, COLOR_BLACK);
     pressed.check_brush.Create(COLOR_BLACK);
     pressed.text_color = COLOR_WHITE;
 
     disabled.box_brush.Create(COLOR_WHITE);
-    disabled.box_pen.Create(1, COLOR_GRAY);
+    disabled.box_pen.Create(pen_width, COLOR_GRAY);
     disabled.check_brush.Create(COLOR_GRAY);
     disabled.text_color = COLOR_GRAY;
   }

--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -51,4 +51,10 @@ static constexpr Color COLOR_ADMONITION_IMPORTANT_DARK =
 static constexpr Color COLOR_ADMONITION_TIP =
   Color(0x00, 0x80, 0x00);
 
+/**
+ * A muted green readable on light backgrounds.
+ * Standard COLOR_GREEN (0,255,0) is too bright on white.
+ */
+static constexpr Color COLOR_LIGHT_GREEN = Color(0x00, 0xc0, 0x00);
+
 static constexpr uint8_t ALPHA_OVERLAY = 0xA0;

--- a/src/Look/CrossSectionLook.cpp
+++ b/src/Look/CrossSectionLook.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "CrossSectionLook.hpp"
+#include "Screen/Layout.hpp"
 
 void
 CrossSectionLook::Initialise(const Font &_grid_font)
@@ -15,7 +16,8 @@ CrossSectionLook::Initialise(const Font &_grid_font)
   sea_color = Color(0xbd, 0xc5, 0xd5); // ICAO open water area
   sea_brush.Create(sea_color);
 
-  grid_pen.Create(Pen::DASH2, 1, Color(0x60, 0x60, 0x60));
+  grid_pen.Create(Pen::DASH2, Layout::ScaleFinePenWidth(1),
+                  Color(0x60, 0x60, 0x60));
   aircraft_brush.Create(text_color);
 
   grid_font = &_grid_font;

--- a/src/Look/FlarmTrafficLook.cpp
+++ b/src/Look/FlarmTrafficLook.cpp
@@ -47,9 +47,10 @@ FlarmTrafficLook::Initialise(const TrafficLook &other, bool small, bool inverse)
   team_pen_magenta.Create(width, other.team_color_magenta);
 
   plane_pen.Create(width, radar_color);
-  radar_pen.Create(1, radar_color);
+  radar_pen.Create(Layout::ScaleFinePenWidth(1), radar_color);
 
-  unit_fraction_pen.Create(1, inverse ? COLOR_WHITE : COLOR_BLACK);
+  unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1),
+                           inverse ? COLOR_WHITE : COLOR_BLACK);
 
   no_traffic_font.Load(FontDescription(Layout::FontScale(22)));
   label_font.Load(FontDescription(Layout::FontScale(12)));

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -37,14 +37,9 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
     pressed_background_color = DarkColor(pressed_background_color);
   }
 
-  Color border_color = Color(128, 128, 128);
-  border_pen.Create(BORDER_WIDTH, border_color);
-
   ReinitialiseLayout(width, scale_title_font);
 
-  unit_fraction_pen.Create(1, value.fg_color);
-
-  colors[0] = border_color;
+  colors[0] = COLOR_GRAY;
   if (HasColors() && use_colors) {
     colors[1] = inverse ? COLOR_INVERSE_RED : COLOR_RED;
     colors[2] = inverse ? COLOR_INVERSE_BLUE : COLOR_BLUE;
@@ -58,6 +53,12 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
 void
 InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
 {
+  border_width = Layout::ScaleFinePenWidth(1);
+
+  Color border_color = COLOR_GRAY;
+  border_pen.Create(border_width, border_color);
+  unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), value.fg_color);
+
   FontDescription title_font_d(8);
   AutoSizeFont(title_font_d, (width * scale_title_font) / 100U,
                _T("1234567890A"));

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -43,7 +43,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
   if (HasColors() && use_colors) {
     colors[1] = inverse ? COLOR_INVERSE_RED : COLOR_RED;
     colors[2] = inverse ? COLOR_INVERSE_BLUE : COLOR_BLUE;
-    colors[3] = inverse ? COLOR_INVERSE_GREEN : Color(0, 192, 0);
+    colors[3] = inverse ? COLOR_INVERSE_GREEN : COLOR_LIGHT_GREEN;
     colors[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_YELLOW;
     colors[5] = inverse ? COLOR_INVERSE_MAGENTA : COLOR_MAGENTA;
   } else

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -11,7 +11,7 @@
 class Font;
 
 struct InfoBoxLook {
-  static constexpr unsigned BORDER_WIDTH = 1;
+  unsigned border_width;
 
   bool inverse;
 

--- a/src/Look/ThermalAssistantLook.cpp
+++ b/src/Look/ThermalAssistantLook.cpp
@@ -22,8 +22,9 @@ ThermalAssistantLook::Initialise(bool small, bool inverse)
 #else /* !OPENGL */
   polygon_pen.Create(width, polygon_border_color);
 #endif /* !OPENGL */
-  inner_circle_pen.Create(1, circle_color);
-  outer_circle_pen.Create(Pen::DASH2, 1, circle_color);
+  inner_circle_pen.Create(Layout::ScaleFinePenWidth(1), circle_color);
+  outer_circle_pen.Create(Pen::DASH2, Layout::ScaleFinePenWidth(1),
+                          circle_color);
   plane_pen.Create(width, inverse? COLOR_WHITE: COLOR_BLACK);
 
   overlay_font.Load(FontDescription(Layout::FontScale(22)));

--- a/src/Look/TraceHistoryLook.cpp
+++ b/src/Look/TraceHistoryLook.cpp
@@ -2,12 +2,14 @@
 // Copyright The XCSoar Project
 
 #include "TraceHistoryLook.hpp"
+#include "Screen/Layout.hpp"
 
 void
 TraceHistoryLook::Initialise(bool _inverse)
 {
   inverse = _inverse;
 
-  axis_pen.Create(1, COLOR_GRAY);
-  line_pen.Create(2, inverse ? COLOR_WHITE : COLOR_BLACK);
+  axis_pen.Create(Layout::ScaleFinePenWidth(1), COLOR_GRAY);
+  line_pen.Create(Layout::ScalePenWidth(2),
+                  inverse ? COLOR_WHITE : COLOR_BLACK);
 }

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -68,7 +68,7 @@ VarioLook::ReinitialiseLayout(unsigned width)
   FontDescription unit_font_d(8);
   AutoSizeFont(unit_font_d, width / 4.22, _T("00.0m"));
   unit_font.Load(unit_font_d);
-  unit_fraction_pen.Create(1, COLOR_GRAY);
+  unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), COLOR_GRAY);
 
   FontDescription label_font_d(8);
   AutoSizeFont(label_font_d, width / 2, _T("Auto MC"));

--- a/src/Renderer/TabRenderer.cpp
+++ b/src/Renderer/TabRenderer.cpp
@@ -23,6 +23,13 @@ TabRenderer::Draw(Canvas &canvas, const PixelRect &rc,
   if (icon != nullptr) {
     icon->Draw(canvas, rc, selected);
   } else {
-    text_renderer.Draw(canvas, rc, caption);
+    /* draw single-line text centered in the tab button; avoid
+       DrawFormattedText / TextRenderer which word-wrap at spaces,
+       causing multi-word labels like "Turn Points" to break across
+       lines or disappear entirely on GDI */
+    const PixelSize size = canvas.CalcTextSize(caption);
+    const int x = (rc.left + rc.right - (int)size.width) / 2;
+    const int y = (rc.top + rc.bottom - (int)size.height) / 2;
+    canvas.DrawClippedText({x, y}, rc, caption);
   }
 }

--- a/src/Renderer/TabRenderer.hpp
+++ b/src/Renderer/TabRenderer.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "TextRenderer.hpp"
-
 #include <tchar.h>
 
 struct DialogLook;
@@ -16,18 +14,8 @@ class MaskedIcon;
  * Render #TabDisplay / #TabMenuDisplay buttons.
  */
 class TabRenderer {
-  TextRenderer text_renderer;
-
 public:
-  constexpr TabRenderer() noexcept {
-    text_renderer.SetCenter();
-    text_renderer.SetVCenter();
-    text_renderer.SetControl();
-  }
-
-  void InvalidateLayout() noexcept {
-    text_renderer.InvalidateLayout();
-  }
+  void InvalidateLayout() noexcept {}
 
   void Draw(Canvas &canvas, const PixelRect &rc,
             const DialogLook &look,

--- a/src/ui/control/LargeTextWindow.hpp
+++ b/src/ui/control/LargeTextWindow.hpp
@@ -45,13 +45,25 @@ class LargeTextWindow : public NativeWindow {
   unsigned origin;
 
   TextRenderer renderer;
+#endif
 
   Color background_color = COLOR_WHITE;
   Color text_color = COLOR_BLACK;
   Color border_color = COLOR_BLACK;
+
+#ifdef USE_WINUSER
+  /**
+   * Background brush for WM_CTLCOLORSTATIC; lazily created by
+   * SetColors().
+   */
+  HBRUSH background_brush = nullptr;
 #endif
 
 public:
+#ifdef USE_WINUSER
+  ~LargeTextWindow() noexcept;
+#endif
+
   void Create(ContainerWindow &parent, PixelRect rc,
               const LargeTextWindowStyle style=LargeTextWindowStyle());
 
@@ -82,13 +94,7 @@ public:
   }
 #endif
 
-#ifndef USE_WINUSER
-  void SetColors(Color _background, Color _text, Color _border) noexcept {
-    background_color = _background;
-    text_color = _text;
-    border_color = _border;
-  }
-#endif
+  void SetColors(Color _background, Color _text, Color _border) noexcept;
 
   void SetText(const TCHAR *text);
 
@@ -109,5 +115,8 @@ protected:
   bool OnKeyCheck(unsigned key_code) const noexcept override;
   bool OnKeyDown(unsigned key_code) noexcept override;
   bool OnMouseDown(PixelPoint p) noexcept override;
+#else
+protected:
+  LRESULT OnChildColor(HDC hdc) noexcept override;
 #endif /* !USE_WINUSER */
 };

--- a/src/ui/control/custom/LargeTextWindow.cpp
+++ b/src/ui/control/custom/LargeTextWindow.cpp
@@ -17,6 +17,16 @@ LargeTextWindow::Create(ContainerWindow &parent, PixelRect rc,
   NativeWindow::Create(&parent, rc, style);
 }
 
+void
+LargeTextWindow::SetColors(Color _background, Color _text,
+                            Color _border) noexcept
+{
+  background_color = _background;
+  text_color = _text;
+  border_color = _border;
+  Invalidate();
+}
+
 unsigned
 LargeTextWindow::GetVisibleRows() const
 {

--- a/src/ui/control/gdi/LargeTextWindow.cpp
+++ b/src/ui/control/gdi/LargeTextWindow.cpp
@@ -9,11 +9,47 @@
 #include <commctrl.h>
 #include <windowsx.h>
 
+LargeTextWindow::~LargeTextWindow() noexcept
+{
+  if (background_brush != nullptr)
+    ::DeleteObject(background_brush);
+}
+
 void
 LargeTextWindow::Create(ContainerWindow &parent, PixelRect rc,
                         const LargeTextWindowStyle style)
 {
   Window::Create(&parent, WC_EDIT, nullptr, rc, style);
+
+  /* store the Window pointer so the parent can find us when
+     reflecting WM_CTLCOLORSTATIC */
+  SetUserData(this);
+}
+
+void
+LargeTextWindow::SetColors(Color _background, Color _text,
+                            Color _border) noexcept
+{
+  background_color = _background;
+  text_color = _text;
+  border_color = _border;
+
+  if (background_brush != nullptr)
+    ::DeleteObject(background_brush);
+
+  background_brush = ::CreateSolidBrush(_background);
+  ::InvalidateRect(hWnd, nullptr, true);
+}
+
+LRESULT
+LargeTextWindow::OnChildColor(HDC hdc) noexcept
+{
+  if (background_brush == nullptr)
+    return 0;
+
+  ::SetTextColor(hdc, text_color);
+  ::SetBkColor(hdc, background_color);
+  return (LRESULT)background_brush;
 }
 
 void

--- a/src/ui/window/Window.hpp
+++ b/src/ui/window/Window.hpp
@@ -916,6 +916,15 @@ public:
 #ifdef USE_WINUSER
   virtual bool OnUser(unsigned id) noexcept;
 
+  /**
+   * Called when the parent receives WM_CTLCOLORSTATIC or
+   * WM_CTLCOLOREDIT for this child control.  Override to set
+   * text/background colors on the HDC and return a background brush.
+   *
+   * @return a HBRUSH cast to LRESULT, or 0 to use defaults
+   */
+  virtual LRESULT OnChildColor(HDC hdc) noexcept;
+
   virtual LRESULT OnMessage(HWND hWnd, UINT message,
                             WPARAM wParam, LPARAM lParam) noexcept;
 #endif /* USE_WINUSER */

--- a/src/ui/window/gdi/Window.cpp
+++ b/src/ui/window/gdi/Window.cpp
@@ -163,6 +163,12 @@ Window::OnUser([[maybe_unused]] unsigned id) noexcept
 }
 
 LRESULT
+Window::OnChildColor([[maybe_unused]] HDC hdc) noexcept
+{
+  return 0;
+}
+
+LRESULT
 Window::OnMessage([[maybe_unused]] HWND _hWnd, UINT message,
                   WPARAM wParam, LPARAM lParam) noexcept
 {
@@ -278,6 +284,17 @@ Window::OnMessage([[maybe_unused]] HWND _hWnd, UINT message,
     /* pass on to DefWindowProc() so the underlying window class knows
        it's not focused anymore */
     break;
+
+  case WM_CTLCOLORSTATIC:
+  case WM_CTLCOLOREDIT: {
+    Window *child = GetUnchecked((HWND)lParam);
+    if (child != nullptr) {
+      LRESULT result = child->OnChildColor((HDC)wParam);
+      if (result != 0)
+        return result;
+    }
+    break;
+  }
 
   case WM_GETDLGCODE:
     if (OnKeyCheck(wParam))


### PR DESCRIPTION
## Summary

- Fix dark mode rendering on non-OpenGL renderers (GDI and software renderer): icons, text controls, tab labels, and the simulator prompt dialog
- Scale hardcoded 1-pixel pen widths with `Layout::ScaleFinePenWidth()` so UI elements remain visible on high-DPI displays
- Fix focused/pressed background not drawing on non-clipping platforms, causing white-on-light text (#2177)
- Fix `SimulatorPromptWindow` gradient background showing white rectangles around bitmaps on non-OpenGL (#2170)

Fixes #2170
Fixes #2177

## Changes

1. **Form/Edit, Form/CheckBox**: Always draw focused/pressed backgrounds regardless of `HaveClipping()`, fixing invisible white text on light backgrounds
2. **Look (13 files)**: Replace hardcoded `Pen(1,...)` and `.Create(1,...)` with `Layout::ScaleFinePenWidth(1)` across all UI controls, gauges, and chart elements
3. **ui/canvas/Icon**: Auto-detect dark backgrounds from text color luminosity; render white icon shapes on dark backgrounds; fix GDI color bleed by saving/restoring HDC colors
4. **ui/control/LargeTextWindow**: Enable `SetColors()` on GDI via `WM_CTLCOLORSTATIC`/`WM_CTLCOLOREDIT` message reflection, fixing waypoint details text in dark mode on Windows
5. **Renderer/TabRenderer**: Replace word-wrapping `TextRenderer` with single-line centered `DrawClippedText`, fixing "Turn Points" label disappearing on GDI
6. **Dialogs/SimulatorPromptWindow**: Use plain white background with black text on non-OpenGL renderers where alpha blending is unavailable
7. **Dialogs/WidgetDialog**: Re-run button layout after `widget.Show()` to fix caption clipping (from PR #2183)

## Test plan

- [ ] Verify dark mode rendering on Android (OpenGL) — icons, lists, dialogs
- [ ] Verify dark mode on Windows (GDI) — waypoint details, tab labels, icons in lists
- [ ] Verify pen widths are visible on high-DPI devices (400+ DPI)
- [ ] Verify simulator prompt dialog renders correctly on non-OpenGL builds
- [ ] Verify "Turn Points" tab label renders as single line on all platforms
- [ ] Verify RowFormWidget focused items show correct background (#2177)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recalculated dialog layouts after showing to prevent caption clipping
  * Added non‑OpenGL fallback ensuring readable logo and dark text
  * Fixed icon rendering to adapt automatically to background brightness

* **UI Improvements**
  * Borders, lines and grids now scale with display settings for sharper rendering
  * Improved tab label rendering with centered single‑line text
  * Enhanced button/checkbox focus and infobox border visuals
  * Added a muted light green color for better contrast on light backgrounds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->