### PR TITLE
Profile: Flush to disk after high-severity dialog actions

### DIFF
--- a/src/Dialogs/Device/Stratux/ConfigurationDialog.cpp
+++ b/src/Dialogs/Device/Stratux/ConfigurationDialog.cpp
@@ -7,6 +7,7 @@
 #include "Dialogs/Message.hpp"
 #include "Dialogs/Error.hpp"
 #include "Language/Language.hpp"
+#include "Profile/Profile.hpp"
 #include "Operation/Cancelled.hpp"
 #include "Operation/PopupOperationEnvironment.hpp"
 #include "UIGlobals.hpp"
@@ -46,6 +47,7 @@ public:
     changed |= SaveValueInteger(VRANGE, settings.vrange);
 
     SaveToProfile(settings);
+    Profile::Save();
 
     _changed |= changed;
     if (_changed) ShowMessageBox(_("Changes to configuration saved. Restart XCSoar to apply changes."),

--- a/src/Dialogs/Plane/PlaneListDialog.cpp
+++ b/src/Dialogs/Plane/PlaneListDialog.cpp
@@ -178,6 +178,7 @@ LoadFile(Path path) noexcept
   PlaneGlue::Synchronize(settings.plane, settings,
                          settings.polar.glide_polar_task);
   backend_components->SetTaskPolar(settings.polar);
+  Profile::Save();
 
   return true;
 }

--- a/src/Dialogs/Traffic/TeamCodeDialog.cpp
+++ b/src/Dialogs/Traffic/TeamCodeDialog.cpp
@@ -138,6 +138,7 @@ TeamCodeWidget::OnSetWaypointClicked()
   if (wp != nullptr) {
     CommonInterface::SetComputerSettings().team_code.team_code_reference_waypoint = wp->id;
     Profile::Set(ProfileKeys::TeamcodeRefWaypoint, wp->id);
+    Profile::Save();
   }
 }
 

--- a/src/Weather/NOAAGlue.cpp
+++ b/src/Weather/NOAAGlue.cpp
@@ -50,4 +50,5 @@ NOAAStore::SaveToProfile()
   *p = _T('\0');
 
   Profile::Set(ProfileKeys::WeatherStations, buffer);
+  Profile::Save();
 }


### PR DESCRIPTION
## Summary

- Add `Profile::Save()` calls after deliberate user actions in dialogs that currently only update the in-memory profile via `Profile::Set()` but never flush to disk
- Affected code paths: team code reference waypoint selection, plane activation, NOAA station add/remove, and Stratux configuration save
- Without this fix, these settings are silently lost if the app crashes, is force-killed (common on Android), or the device loses power

## Details

| File | Function | Setting |
|---|---|---|
| `Dialogs/Traffic/TeamCodeDialog.cpp` | `OnSetWaypointClicked()` | `TeamcodeRefWaypoint` |
| `Dialogs/Plane/PlaneListDialog.cpp` | `LoadFile()` | `PlanePath` |
| `Weather/NOAAGlue.cpp` | `SaveToProfile()` | `WeatherStations` |
| `Dialogs/Device/Stratux/ConfigurationDialog.cpp` | `Save()` | `StratuxHorizontalRange`, `StratuxVerticalRange` |

All four are infrequent, explicit user actions where an immediate flush is appropriate. `Profile::Save()` is a no-op when nothing is modified.

Note: `WaypointCommandsWidget::SetHome()` was listed in #2171 but already has `Profile::Save()`.

Closes #2171

## Test plan

- [ ] Select "Set as team code reference waypoint" — verify setting persists after force-kill
- [ ] Activate a plane from the plane list — verify PlanePath persists after force-kill
- [ ] Add/remove an NOAA weather station — verify stations persist after force-kill
- [ ] Save Stratux configuration — verify range settings persist after force-kill