### PR TITLE
AUTHORS: Remove misspelled name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -81,7 +81,6 @@ The following people and organizations have contributed code to XCSoar:
  Wolfgang Drescher <drescher.wolfgang@gmail.com>
  Piotr Gertz <piotr@piopawlu.net>
  Yorick Reum <xcsoar@yorickreum.de>
- Roland Niederhagen <ronald_niederhagen@freenet.de>
  kobedegeest <kobedegeest@gmail.com>
 
 Documentation:


### PR DESCRIPTION
 misspelled:
 Roland Niederhagen <ronald_niederhagen@freenet.de>

keep:
 Ronald Niederhagen <ronald_niederhagen@freenet.de>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor information in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->