### PR TITLE
MaskedIcon: dark-mode inversion, scaled list icons, UHD textures

### DIFF
--- a/build/screen.mk
+++ b/build/screen.mk
@@ -132,6 +132,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/opengl/VertexArray.cpp \
 	$(CANVAS_SRC_DIR)/opengl/ConstantAlpha.cpp \
 	$(CANVAS_SRC_DIR)/opengl/Bitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/opengl/RawBitmap.cpp \
 	$(CANVAS_SRC_DIR)/opengl/Canvas.cpp \
 	$(CANVAS_SRC_DIR)/opengl/BufferCanvas.cpp \
@@ -153,6 +154,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_FILES_CPP) \
 	$(CANVAS_SRC_DIR)/custom/Bitmap.cpp \
 	$(CANVAS_SRC_DIR)/custom/ResourceBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/sdl/TopCanvas.cpp \
 	$(WINDOW_SRC_DIR)/sdl/Window.cpp \
 	$(WINDOW_SRC_DIR)/sdl/TopWindow.cpp \
@@ -167,6 +169,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_FILES_CPP) \
 	$(CANVAS_SRC_DIR)/custom/Bitmap.cpp \
 	$(CANVAS_SRC_DIR)/custom/ResourceBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/egl/TopCanvas.cpp \
 	$(SRC)/ui/display/egl/ConfigChooser.cpp \
 	$(SRC)/ui/display/egl/Display.cpp \
@@ -180,6 +183,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_FILES_CPP) \
 	$(CANVAS_SRC_DIR)/custom/Bitmap.cpp \
 	$(CANVAS_SRC_DIR)/custom/ResourceBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/glx/TopCanvas.cpp \
 	$(WINDOW_SRC_DIR)/poll/TopWindow.cpp \
 	$(WINDOW_SRC_DIR)/fb/Window.cpp \
@@ -191,6 +195,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_FILES_CPP) \
 	$(CANVAS_SRC_DIR)/custom/Bitmap.cpp \
 	$(CANVAS_SRC_DIR)/custom/ResourceBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/fb/TopCanvas.cpp \
 	$(WINDOW_SRC_DIR)/poll/TopWindow.cpp \
 	$(WINDOW_SRC_DIR)/fb/Window.cpp \
@@ -203,6 +208,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_FILES_CPP) \
 	$(CANVAS_SRC_DIR)/custom/Bitmap.cpp \
 	$(CANVAS_SRC_DIR)/custom/ResourceBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/memory/Export.cpp \
 	$(WINDOW_SRC_DIR)/poll/TopWindow.cpp \
 	$(WINDOW_SRC_DIR)/fb/TopWindow.cpp \

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -612,7 +612,7 @@ ifeq ($(TARGET),UNIX)
 endif
 
 ifeq ($(TARGET),ANDROID)
-  TARGET_LDLIBS += -llog -landroid
+  TARGET_LDLIBS += -llog -landroid -ljnigraphics
 endif
 
 ######## output files

--- a/src/Renderer/WaypointIconRenderer.cpp
+++ b/src/Renderer/WaypointIconRenderer.cpp
@@ -134,13 +134,23 @@ WaypointIconRenderer::DrawLandable(const Waypoint &waypoint,
         ? &look.airport_unreachable_icon
         : &look.field_unreachable_icon;
 
-    icon->Draw(canvas, point);
+    if (icon_size > 0)
+      icon->Draw(canvas, point, icon_size);
+    else
+      icon->Draw(canvas, point);
     return;
   }
 
   // SW rendering of landables
   double scale = std::max(Layout::VptScale(settings.landable_rendering_scale),
                           110u) / 177.;
+
+  /* The vector landable is drawn with radius = 10 * scale and the
+     reachable ring at 1.5 * radius, giving a total diameter of
+     30 * scale.  Derive scale so the full icon fits icon_size. */
+  if (icon_size > 0)
+    scale = icon_size / 30.;
+
   double radius = 10 * scale;
 
   canvas.SelectBlackPen();
@@ -205,7 +215,8 @@ WaypointIconRenderer::Draw(const Waypoint &waypoint, const PixelPoint &point,
 {
   if (waypoint.IsLandable())
     DrawLandable(waypoint, point, reachable);
+  else if (icon_size > 0)
+    GetWaypointIcon(look, waypoint, small_icons, in_task).Draw(canvas, point, icon_size);
   else
-    // non landable turnpoint
     GetWaypointIcon(look, waypoint, small_icons, in_task).Draw(canvas, point);
 }

--- a/src/Renderer/WaypointIconRenderer.hpp
+++ b/src/Renderer/WaypointIconRenderer.hpp
@@ -20,6 +20,11 @@ class WaypointIconRenderer
   bool small_icons;
   Angle screen_rotation;
 
+  /**
+   * Target icon height in pixels.  0 means native (map) size.
+   */
+  unsigned icon_size = 0;
+
 public:
   WaypointIconRenderer(const WaypointRendererSettings &_settings,
                        const WaypointLook &_look,
@@ -28,6 +33,10 @@ public:
     :settings(_settings), look(_look),
      canvas(_canvas), small_icons(_small_icons),
      screen_rotation(_screen_rotation) {}
+
+  void SetIconSize(unsigned _icon_size) noexcept {
+    icon_size = _icon_size;
+  }
 
   void Draw(const Waypoint &waypoint, const PixelPoint &point,
             WaypointReachability reachable=WaypointReachability::UNREACHABLE,

--- a/src/Renderer/WaypointListRenderer.cpp
+++ b/src/Renderer/WaypointListRenderer.cpp
@@ -46,9 +46,13 @@ Draw(Canvas &canvas, PixelRect rc,
   const unsigned padding = Layout::GetTextPadding();
   const unsigned line_height = rc.GetHeight();
 
+  const unsigned icon_size =
+    line_height > 4 * padding ? line_height - 4 * padding : 0;
+
   // Draw icon
   const PixelPoint pt(rc.left + line_height / 2, rc.top + line_height / 2);
   WaypointIconRenderer wir(settings, look, canvas);
+  wir.SetIconSize(icon_size);
   wir.Draw(waypoint, pt);
 
   rc.left += line_height + padding;
@@ -113,6 +117,9 @@ WaypointListRenderer::Draw(Canvas &canvas, PixelRect rc,
   const unsigned padding = Layout::GetTextPadding();
   const unsigned line_height = rc.GetHeight();
 
+  const unsigned icon_size =
+    line_height > 4 * padding ? line_height - 4 * padding : 0;
+
   // Draw icon
   const PixelPoint pt(rc.left + line_height / 2,
                       rc.top + line_height / 2);
@@ -122,6 +129,7 @@ WaypointListRenderer::Draw(Canvas &canvas, PixelRect rc,
     : WaypointReachability::UNREACHABLE;
 
   WaypointIconRenderer wir(settings, look, canvas);
+  wir.SetIconSize(icon_size);
   wir.Draw(waypoint, pt, reachable);
 
   rc.left += line_height + padding;

--- a/src/ui/canvas/Bitmap.hpp
+++ b/src/ui/canvas/Bitmap.hpp
@@ -72,6 +72,13 @@ protected:
   HBITMAP bitmap = nullptr;
 #endif
 
+  /**
+   * True if the decoded image contained non-grayscale pixels.
+   * Set during Load() on platforms that go through UncompressedImage.
+   * Always false on GDI (icons are monochrome there).
+   */
+  bool has_colors = false;
+
 public:
   Bitmap() = default;
   explicit Bitmap(ResourceId id);
@@ -96,6 +103,13 @@ public:
 #else
     return bitmap != nullptr;
 #endif
+  }
+
+  /**
+   * Did the decoded image contain non-grayscale (coloured) pixels?
+   */
+  bool HasColors() const noexcept {
+    return has_colors;
   }
 
 #ifdef USE_MEMORY_CANVAS

--- a/src/ui/canvas/Icon.cpp
+++ b/src/ui/canvas/Icon.cpp
@@ -61,9 +61,21 @@ MaskedIcon::LoadResource(ResourceId id, ResourceId big_id,
                          bool center)
 {
 #ifdef ENABLE_OPENGL
-  unsigned stretch = 1024;
-#endif
+  /* On OpenGL the GPU scales textures efficiently, so always load
+     the highest-resolution variant for maximum quality (especially
+     beneficial when icons are scaled up in list views). */
+  unsigned source_dpi = 96;
+  if (ultra_id.IsDefined()) {
+    id = ultra_id;
+    source_dpi = 300;
+  } else if (big_id.IsDefined()) {
+    id = big_id;
+    source_dpi = 192;
+  }
 
+  const unsigned stretch = IconStretchFixed10(source_dpi);
+  bitmap.Load(id);
+#else
   if (Layout::vdpi >= 120) {
     /* switch to larger 160dpi icons at 120dpi */
 
@@ -76,14 +88,10 @@ MaskedIcon::LoadResource(ResourceId id, ResourceId big_id,
       source_dpi = 192;
     }
 
-#ifdef ENABLE_OPENGL
-    stretch = IconStretchFixed10(source_dpi);
-    bitmap.Load(id);
-#else
     bitmap.LoadStretch(id, IconStretchInteger(source_dpi));
-#endif
   } else
     bitmap.Load(id);
+#endif
 
   assert(IsDefined());
 

--- a/src/ui/canvas/Icon.cpp
+++ b/src/ui/canvas/Icon.cpp
@@ -15,6 +15,22 @@
 
 #include <algorithm>
 
+/**
+ * Heuristic: if the caller's text colour is light, the background
+ * is probably dark.  Threshold: average channel > 128.
+ */
+[[gnu::const]]
+static bool
+IsDarkBackground(Color text_color) noexcept
+{
+#ifdef GREYSCALE
+  return text_color.GetLuminosity() > 128;
+#else
+  return (text_color.Red() + text_color.Green() +
+          text_color.Blue()) > 384;
+#endif
+}
+
 [[gnu::const]]
 static unsigned
 IconStretchFixed10(unsigned source_dpi) noexcept
@@ -69,6 +85,8 @@ MaskedIcon::LoadResource(ResourceId id, ResourceId big_id,
 
   assert(IsDefined());
 
+  has_colors = bitmap.HasColors();
+
   size = bitmap.GetSize();
 #ifdef ENABLE_OPENGL
   /* let the GPU stretch on-the-fly */
@@ -105,33 +123,17 @@ MaskedIcon::Draw([[maybe_unused]] Canvas &canvas, PixelPoint p) const noexcept
   texture.Draw(PixelRect(p, size), texture.GetRect());
 #else
 
-  /* detect dark backgrounds: if the caller has set a light text color
-     (e.g. COLOR_WHITE for dark-mode lists), the standard mask+icon
-     approach would create a visible white rectangle.  Use the inverse
-     path instead so icon shapes appear white on the dark background. */
-  const Color old_text_color = canvas.GetTextColor();
-#ifdef GREYSCALE
-  const bool inverse = old_text_color.GetLuminosity() > 128;
-#else
-  const bool inverse =
-    (old_text_color.Red() + old_text_color.Green() +
-     old_text_color.Blue()) > 384;
-#endif
-
 #ifdef USE_GDI
   /* GDI uses current HDC colors when blitting from a monochrome
      bitmap; ensure black foreground / white background */
+  const Color old_text_color = canvas.GetTextColor();
   const Color old_bg_color = canvas.GetBackgroundColor();
   canvas.SetTextColor(COLOR_BLACK);
   canvas.SetBackgroundColor(COLOR_WHITE);
 #endif
 
-  if (inverse) {
-    canvas.CopyNotOr(p, size, bitmap, {(int)size.width, 0});
-  } else {
-    canvas.CopyOr(p, size, bitmap, {0, 0});
-    canvas.CopyAnd(p, size, bitmap, {(int)size.width, 0});
-  }
+  canvas.CopyOr(p, size, bitmap, {0, 0});
+  canvas.CopyAnd(p, size, bitmap, {(int)size.width, 0});
 
 #ifdef USE_GDI
   canvas.SetTextColor(old_text_color);
@@ -141,13 +143,21 @@ MaskedIcon::Draw([[maybe_unused]] Canvas &canvas, PixelPoint p) const noexcept
 }
 
 void
-MaskedIcon::Draw([[maybe_unused]] Canvas &canvas, const PixelRect &rc,
+MaskedIcon::Draw(Canvas &canvas, const PixelRect &rc,
                  [[maybe_unused]] bool inverse) const noexcept
 {
   const PixelPoint position = rc.CenteredTopLeft(size);
 
 #ifdef ENABLE_OPENGL
-  if (inverse)
+  /* detect dark backgrounds from the caller's text color rather than
+     relying on the "inverse" parameter, which may not reflect the
+     actual background (e.g. TabRenderer passes "selected" as
+     inverse, but in dark mode *all* tabs have dark backgrounds).
+     Skip inversion for colour icons (has_colors). */
+  const bool dark_bg = !has_colors &&
+    IsDarkBackground(canvas.GetTextColor());
+
+  if (dark_bg)
     OpenGL::invert_shader->Use();
   else
     OpenGL::texture_shader->Use();
@@ -162,15 +172,11 @@ MaskedIcon::Draw([[maybe_unused]] Canvas &canvas, const PixelRect &rc,
   /* detect dark backgrounds from the caller's text color rather than
      relying on the "inverse" parameter, which may not reflect the
      actual background (e.g. TabRenderer passes "selected" as
-     inverse, but in dark mode *all* tabs have dark backgrounds). */
+     inverse, but in dark mode *all* tabs have dark backgrounds).
+     Skip inversion for colour icons (has_colors). */
   const Color old_text_color = canvas.GetTextColor();
-#ifdef GREYSCALE
-  const bool dark_bg = old_text_color.GetLuminosity() > 128;
-#else
-  const bool dark_bg =
-    (old_text_color.Red() + old_text_color.Green() +
-     old_text_color.Blue()) > 384;
-#endif
+  const bool dark_bg = !has_colors &&
+    IsDarkBackground(old_text_color);
 
 #ifdef USE_GDI
   /* GDI uses current HDC colors when blitting from a monochrome
@@ -180,10 +186,12 @@ MaskedIcon::Draw([[maybe_unused]] Canvas &canvas, const PixelRect &rc,
   canvas.SetBackgroundColor(COLOR_WHITE);
 #endif
 
-  if (dark_bg)
+  if (dark_bg) {
     canvas.CopyNotOr(position, size, bitmap, {(int)size.width, 0});
-  else
+  } else {
+    canvas.CopyOr(position, size, bitmap, {0, 0});
     canvas.CopyAnd(position, size, bitmap, {(int)size.width, 0});
+  }
 
 #ifdef USE_GDI
   canvas.SetTextColor(old_text_color);

--- a/src/ui/canvas/Icon.hpp
+++ b/src/ui/canvas/Icon.hpp
@@ -22,6 +22,13 @@ protected:
 
   PixelPoint origin;
 
+  /**
+   * True if the icon contains meaningful colours (e.g. green/red
+   * landable icons).  Dark-mode inversion is skipped for such icons
+   * because inverting the colour channels would produce wrong colours.
+   */
+  bool has_colors = false;
+
 public:
   const PixelSize &GetSize() const noexcept {
     return size;

--- a/src/ui/canvas/Icon.hpp
+++ b/src/ui/canvas/Icon.hpp
@@ -48,5 +48,16 @@ public:
 
   void Draw(Canvas &canvas, PixelPoint p) const noexcept;
 
+  /**
+   * Draw the icon centred on @p p, uniformly scaled so its height
+   * matches @p target_height.  If target_height is 0 the icon is
+   * drawn at native size.
+   *
+   * On memory-canvas targets (Kobo) this falls back to the unscaled
+   * Draw() because no stretch+blend primitives exist.
+   */
+  void Draw(Canvas &canvas, PixelPoint p,
+            unsigned target_height) const noexcept;
+
   void Draw(Canvas &canvas, const PixelRect &rc, bool inverse) const noexcept;
 };

--- a/src/ui/canvas/custom/ResourceBitmap.cpp
+++ b/src/ui/canvas/custom/ResourceBitmap.cpp
@@ -54,6 +54,8 @@ Bitmap::LoadStretch(ResourceId id, unsigned zoom)
   if (!Load(id))
     return false;
 
+  const bool _has_colors = has_colors;
+
   Bitmap stretched;
   stretched.Create(GetSize() * zoom);
 
@@ -64,6 +66,7 @@ Bitmap::LoadStretch(ResourceId id, unsigned zoom)
   }
 
   *this = std::move(stretched);
+  has_colors = _has_colors;
   return true;
 }
 

--- a/src/ui/canvas/custom/UncompressedImage.cpp
+++ b/src/ui/canvas/custom/UncompressedImage.cpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "UncompressedImage.hpp"
+
+#include <cstdint>
+
+bool
+UncompressedImage::HasNonGrayscalePixels() const noexcept
+{
+  if (format == Format::GRAY || format == Format::INVALID)
+    return false;
+
+  const auto *p = static_cast<const uint8_t *>(GetData());
+  const unsigned bpp = (format == Format::RGBA) ? 4 : 3;
+
+  for (unsigned y = 0; y < height; y++) {
+    const auto *row = p + y * pitch;
+    for (unsigned x = 0; x < width; x++) {
+      const unsigned off = x * bpp;
+      if (row[off] != row[off + 1] || row[off] != row[off + 2])
+        return true;
+    }
+  }
+
+  return false;
+}

--- a/src/ui/canvas/custom/UncompressedImage.hpp
+++ b/src/ui/canvas/custom/UncompressedImage.hpp
@@ -92,4 +92,12 @@ public:
   const void *GetData() const {
     return data.get();
   }
+
+  /**
+   * Scan pixel data to determine whether the image contains
+   * non-grayscale (coloured) pixels.  Returns false for
+   * Format::GRAY and Format::INVALID.
+   */
+  [[gnu::pure]]
+  bool HasNonGrayscalePixels() const noexcept;
 };

--- a/src/ui/canvas/gdi/Bitmap.cpp
+++ b/src/ui/canvas/gdi/Bitmap.cpp
@@ -13,7 +13,8 @@
 #include <winuser.h>
 
 Bitmap::Bitmap(Bitmap &&src) noexcept
-  :bitmap(std::exchange(src.bitmap, nullptr))
+  :bitmap(std::exchange(src.bitmap, nullptr)),
+   has_colors(src.has_colors)
 {
 }
 
@@ -21,6 +22,7 @@ Bitmap &Bitmap::operator=(Bitmap &&src) noexcept
 {
   using std::swap;
   swap(bitmap, src.bitmap);
+  swap(has_colors, src.has_colors);
   return *this;
 }
 

--- a/src/ui/canvas/memory/Bitmap.cpp
+++ b/src/ui/canvas/memory/Bitmap.cpp
@@ -10,7 +10,8 @@
 #include <utility> // for std::exchange()
 
 Bitmap::Bitmap(Bitmap &&src) noexcept
-  :buffer(std::exchange(src.buffer, WritableImageBuffer<BitmapPixelTraits>::Empty()))
+  :buffer(std::exchange(src.buffer, WritableImageBuffer<BitmapPixelTraits>::Empty())),
+   has_colors(src.has_colors)
 {
 }
 
@@ -18,6 +19,7 @@ Bitmap &Bitmap::operator=(Bitmap &&src) noexcept
 {
   using std::swap;
   swap(buffer, src.buffer);
+  swap(has_colors, src.has_colors);
   return *this;
 }
 
@@ -29,6 +31,7 @@ Bitmap::Load(UncompressedImage &&uncompressed, Type)
 
   Reset();
 
+  has_colors = uncompressed.HasNonGrayscalePixels();
   ImportSurface(buffer, uncompressed);
   return true;
 }

--- a/src/ui/canvas/memory/Canvas.hpp
+++ b/src/ui/canvas/memory/Canvas.hpp
@@ -378,6 +378,11 @@ public:
   void CopyNotOr(PixelPoint dest_position, PixelSize dest_size,
                  const Bitmap &src, PixelPoint src_position) noexcept;
 
+  void CopyNotOr(PixelPoint dest_position, PixelSize dest_size,
+                 const Canvas &src, PixelPoint src_position) noexcept {
+    CopyNotOr(dest_position, dest_size, src.buffer, src_position);
+  }
+
   void CopyAnd(PixelPoint dest_position, PixelSize dest_size,
                ConstImageBuffer src, PixelPoint src_position) noexcept;
 

--- a/src/ui/canvas/opengl/Bitmap.cpp
+++ b/src/ui/canvas/opengl/Bitmap.cpp
@@ -11,7 +11,8 @@
 Bitmap::Bitmap(Bitmap &&src) noexcept
   :texture(std::exchange(src.texture, nullptr)),
    size(src.size),
-   flipped(src.flipped)
+   flipped(src.flipped),
+   has_colors(src.has_colors)
 {
 }
 
@@ -21,6 +22,7 @@ Bitmap &Bitmap::operator=(Bitmap &&src) noexcept
   texture = std::exchange(src.texture, nullptr);
   size = src.size;
   flipped = src.flipped;
+  has_colors = src.has_colors;
   return *this;
 }
 
@@ -46,6 +48,8 @@ Bitmap::Load(UncompressedImage &&_uncompressed, Type _type)
   assert(_uncompressed.IsDefined());
 
   Reset();
+
+  has_colors = _uncompressed.HasNonGrayscalePixels();
 
   size = { _uncompressed.GetWidth(), _uncompressed.GetHeight() };
   flipped = _uncompressed.IsFlipped();


### PR DESCRIPTION

<img width="1288" height="968" alt="image" src="https://github.com/user-attachments/assets/92e16157-1f42-4935-a598-bf6dd5b6bb2d" />

<img width="1288" height="968" alt="image" src="https://github.com/user-attachments/assets/2a9c573e-fe8b-4771-88bb-18ab8f3f070a" />

## Summary

- **Dark-mode inversion**: Automatically detect dark backgrounds via canvas text colour in `MaskedIcon::Draw` and invert monochrome icons (OpenGL invert_shader, GDI/software CopyNotOr). Colour icons are detected at load time by scanning pixel data and left untouched.
- **Scale list icons**: Add a `MaskedIcon::Draw(target_height)` overload that scales icons to fill the available row height in waypoint list dialogs. Works on all three renderers (OpenGL GPU scaling, GDI StretchBlt with raster ops, memory canvas via VirtualCanvas temp buffer). Vector landable icons scale their geometry proportionally.
- **UHD textures on OpenGL**: Always load the highest-resolution icon variant (300 DPI) on OpenGL regardless of screen DPI, since the GPU scales efficiently and the extra resolution produces sharper results when icons are enlarged in list views.

## Test plan

- [ ] OpenGL: verify list icons are scaled, inverted in dark mode, and colour icons retain hues
- [ ] OpenGL: verify map icons are unchanged (same size, no spurious inversion)
- [ ] GDI/Windows: verify list icons scale and invert correctly, map icons are normal
- [ ] Software renderer: verify list icons scale and invert, map icons unchanged
- [ ] Vector landable icons: verify reachable ring fits within row bounds in lists
- [ ] Kobo/embedded: verify no regressions on small screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waypoint icons now scale to target heights based on layout and support explicit size requests.
  * Icons detect whether they contain meaningful colors and choose appropriate rendering/variant quality.
  * New draw option to render icons centered and scaled to a specified target height.

* **Bug Fixes**
  * More consistent icon appearance across rendering backends.
  * Improved dark-background handling to avoid incorrect inversion for colored icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->