### PR TITLE
.cursor/rules: Add NMEA, testing, and platform display guidance

### DIFF
--- a/.cursor/rules/nmea-validity-patterns.mdc
+++ b/.cursor/rules/nmea-validity-patterns.mdc
@@ -1,0 +1,93 @@
+---
+description: NMEAInfo Validity patterns, TimeStamp/FloatDuration/BrokenTime usage, device driver data conventions
+globs: src/NMEA/**,src/Device/**,src/time/**,src/Computer/**
+alwaysApply: false
+---
+
+# NMEA Data Validity and Time Patterns
+
+## Validity vs bool for Availability Flags
+
+All sensor availability flags in `NMEAInfo` must use `Validity`, never `bool`:
+
+```cpp
+// BAD: bool never expires, breaks Complement()
+bool temperature_available;
+temperature_available = true;
+
+// GOOD: Validity tracks timestamps, expires, complements correctly
+Validity temperature_available;
+temperature_available.Update(info.clock);  // mark valid
+temperature_available.Clear();              // mark invalid
+```
+
+### Validity Lifecycle in Device Drivers
+
+```cpp
+// Setting data available (in a device parser):
+if (line.ReadChecked(value)) {
+  info.temperature = Temperature::FromCelsius(value);
+  info.temperature_available.Update(info.clock);  // NOT = true
+}
+
+// Clearing data (when device reports no data):
+info.temperature_available.Clear();  // NOT = false
+```
+
+### Validity in Expire()
+
+Every `Validity` field in `NMEAInfo` must have a corresponding `Expire()` call:
+
+```cpp
+void NMEAInfo::Expire() noexcept {
+  temperature_available.Expire(clock, std::chrono::seconds(30));
+  // ...
+}
+```
+
+### Validity in Complement()
+
+Always use `Validity::Complement()`, never the manual pattern:
+
+```cpp
+// BAD: doesn't update the Validity timestamp, breaks subsequent Complement/Expire
+if (!x_available && add.x_available) {
+  x = add.x;
+  x_available = add.x_available;
+}
+
+// GOOD: atomically checks and copies the Validity, returns true if copied
+if (x_available.Complement(add.x_available))
+  x = add.x;
+```
+
+## Time Types
+
+- **`TimeStamp`**: Point in time (wraps `FloatDuration`). Use for GPS time, fix timestamps.
+- **`FloatDuration`** (`std::chrono::duration<double>`): Duration in seconds with sub-second precision. Use for time arithmetic.
+- **`BrokenTime`**: Integer hour/minute/second for display only. `DurationSinceMidnight()` returns `std::chrono::seconds` (integer) — do NOT use it for precise time calculations.
+
+```cpp
+// BAD: loses sub-second precision
+time_of_day_s = TimeStamp{broken_time.DurationSinceMidnight()};
+
+// GOOD: preserves fractional seconds from NMEA parsing
+time_of_day_s = TimeStamp{FloatDuration{hour * 3600 + minute * 60 + second}};
+```
+
+## NMEA Parser Return Convention
+
+- Return `true` = sentence recognized and parsed (even if data was not used/updated)
+- Return `false` = sentence unrecognized, malformed, or failed checksum
+
+Example: MWV with relative wind reference returns `true` (recognized) but doesn't update `external_wind`.
+
+## Null Safety in Parsing
+
+Always check `strchr`/`strstr` results before pointer arithmetic:
+
+```cpp
+char *dot = strchr(buffer, '.');
+if (dot == nullptr || dot < buffer + 3)  // check nullptr FIRST
+  return false;
+```

--- a/.cursor/rules/xcsoar-project-rules.mdc
+++ b/.cursor/rules/xcsoar-project-rules.mdc
@@ -599,6 +599,23 @@ Adding a new method callable between Java and C++ requires updating three files:
 
 ## GUI Guidelines
 
+### Rendering Backends — Always Consider All Three
+
+XCSoar has three canvas backends in `src/ui/canvas/`. **Every renderer implementation must work on all three:**
+
+| Backend | Define | Platform | Capabilities |
+|---------|--------|----------|-------------|
+| **OpenGL** | `ENABLE_OPENGL` | Linux/Android/macOS | Full color, alpha blending, gradients, hardware-accelerated |
+| **Memory canvas** | `USE_MEMORY_CANVAS` | Kobo e-ink, headless (`VFB=y`) | Software rendering, greyscale on e-ink, no GPU |
+| **GDI** | `USE_GDI` | Windows | Win32 GDI API, full color but no alpha on all surfaces |
+
+When writing or modifying renderer code (`src/Renderer/`, `src/Look/`, `MapWindow/`):
+- **E-ink (memory canvas)**: No color, no gradients, no alpha blending. Use `IsDithered()` and `HasColors()` from `Asset.hpp`. Fall back to `COLOR_WHITE`/`COLOR_BLACK` with clear contrast.
+- **OpenGL**: Can use `AlphaBlendEnable`/`Disable`, textures, and smooth anti-aliased rendering.
+- **GDI**: Has color but limited alpha support. `Canvas::StretchMono()` and some blending operations differ.
+- Use `#ifdef ENABLE_OPENGL` / `#ifdef USE_MEMORY_CANVAS` / `#ifdef USE_GDI` when backend-specific code is unavoidable.
+- **Test with**: `TARGET=UNIX` (OpenGL default), `TARGET=UNIX OPENGL=n` (memory canvas), `TARGET=WIN64` (GDI).
+
 ### UI Scaling and DPI Support
 - UI must scale from low-DPI devices (e.g., CGA resolution ~96 DPI) to very high-DPI devices (e.g., modern phones with 400+ DPI)
 - Use `Layout::Scale()` for general UI element scaling (based on 240x320 base resolution)
@@ -611,6 +628,28 @@ Adding a new method callable between Java and C++ requires updating three files:
 - Small screens (< 5 inch) automatically get adjusted scaling for viewing distance
 - Touch screens get larger hit areas and control heights
 - Test UI changes on both low-DPI and high-DPI devices when possible
+
+### Display and DPI — Consider All Targets
+
+DPI detection, screen size queries, and display setup differ across targets. When implementing display-related features (DPI scaling, screen rotation, fullscreen, window management), ensure they work on all platforms:
+
+| Target | Display | DPI detection | Notes |
+|--------|---------|---------------|-------|
+| **Android** | Native `SurfaceView` | System-provided density (`DisplayMetrics`) | Variable DPI (120–640), runtime rotation |
+| **Linux/Wayland** | `wl_surface` | Compositor scale factor (`wl_output`) | HiDPI via integer/fractional scaling |
+| **Linux/X11** | `XWindow` | `Xft.dpi` resource or fallback | May be inaccurate; `xrandr` for physical size |
+| **Kobo** | Framebuffer (`/dev/fb0`) | Hardcoded per model | Fixed resolution, no rotation, no DPI query API |
+| **Windows** | `HWND` (GDI) | `GetDpiForWindow()` / `GetDeviceCaps()` | Per-monitor DPI on Win10+ |
+| **macOS/iOS** | Native view | `backingScaleFactor` / `UIScreen.scale` | Retina 2x/3x scaling |
+| **SDL** | `SDL_Window` | `SDL_GetDisplayDPI()` | Cross-platform fallback, may be inaccurate |
+
+Key rules:
+- **Never assume a specific DPI or resolution** — always use `Layout::` scaling functions
+- Platform-specific display code goes in `src/ui/window/<platform>/` and `src/ui/display/`
+- Use `IsEmbedded()`, `IsKobo()`, `IsAndroid()` from `Asset.hpp` for target-specific branches
+- **Kobo has no runtime DPI query** — screen parameters are hardcoded in device-specific setup
+- **Android provides reliable DPI** but beware of foldables and external displays changing at runtime
+- When adding a new display feature, check that it compiles with at least: `TARGET=UNIX`, `TARGET=ANDROID`, `TARGET=KOBO`, `TARGET=WIN64`
 
 ### UI Operability
 - UI must be operable via multiple input methods: touch, keyboard, and gestures
@@ -887,7 +926,7 @@ make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y
 
 ### Platform Code Organization Patterns
 
-XCSoar uses a consistent pattern for platform-specific implementations:
+**Core principle: maximize shared code, isolate platform differences through components and overloads.** Most logic (layout, data processing, rendering algorithms) should be cross-platform. Only the thin platform-specific layer (window creation, DPI query, input handling) needs per-platform code.
 
 **Directory Structure:**
 - `src/ui/window/custom/` - Shared base implementations (fallback/common code)
@@ -895,32 +934,42 @@ XCSoar uses a consistent pattern for platform-specific implementations:
 - `src/ui/window/wayland/` - Wayland-specific implementations  
 - `src/ui/window/x11/` - X11-specific implementations
 - `src/ui/window/sdl/` - SDL-specific implementations
-- Similar patterns exist in `src/ui/canvas/`, `src/ui/event/`, etc.
+- Similar patterns exist in `src/ui/canvas/`, `src/ui/event/`, `src/ui/display/`, etc.
 
-**Implementation Pattern:**
-1. **Shared base** in `custom/` provides default/common implementation
-2. **Platform directories** override specific methods for that platform
-3. Build system conditionally compiles appropriate files based on `USE_*` defines
-4. Example: `TopWindow.cpp` exists in multiple directories, each compiled for its platform
+**Code Reuse Strategy:**
+1. **Put shared logic in `custom/`** — this is the default implementation compiled for all platforms that don't have a specific override. Maximize what lives here.
+2. **Platform directories only override what differs** — a platform file should only contain the platform-specific parts, calling back into shared code for everything else.
+3. Build system conditionally compiles appropriate files based on `USE_*` defines — only one implementation of each `.cpp` is compiled per target.
+4. **Prefer method overloads and virtual dispatch over `#ifdef`** — when a class needs platform-specific behavior, implement the method in the platform directory rather than scattering `#ifdef` blocks in shared code.
+5. **Use `#ifdef` in shared code only for small, isolated differences** — e.g., a single extra call or a type alias. If the `#ifdef` block grows beyond a few lines, extract it into a platform-specific file.
 
-**When adding platform code:**
-- Check if platform-specific directory exists (e.g., `wayland/`, `gdi/`)
-- If yes, add implementation there (not in `custom/`)
-- If implementing cross-platform feature, add to `custom/` with platform overrides as needed
-- Use `#ifdef USE_WAYLAND`, `#ifdef USE_GDI`, etc. for conditional compilation in shared files
-- Don't duplicate code - extract common logic to base classes or utility functions
+**When adding a new feature:**
+- Start by implementing it entirely in `custom/` (cross-platform)
+- Only create platform-specific overrides when something genuinely can't be done portably
+- If a platform has a better/native API for the same thing, override just that method in the platform directory — keep the algorithm and data flow in shared code
+- Check if platform-specific directory exists (e.g., `wayland/`, `gdi/`) before creating `#ifdef` blocks
 
-**Common pattern:**
+**Good vs bad isolation:**
 ```cpp
-// In custom/TopWindow.cpp - base implementation
-void TopWindow::SomeMethod() {
-  // Default implementation for platforms without specific override
+// BAD: scattering platform logic throughout shared code
+void TopWindow::SetFullScreen(bool full) {
+#ifdef USE_WAYLAND
+  xdg_toplevel_set_fullscreen(toplevel, nullptr);
+#elif defined(USE_X11)
+  XChangeProperty(display, window, ...);
+#elif defined(USE_GDI)
+  SetWindowLong(hwnd, GWL_STYLE, ...);
+#else
+  // fallback?
+#endif
 }
 
-// In wayland/TopWindow.cpp - Wayland-specific override
-void TopWindow::SomeMethod() {
-  // Wayland-specific implementation using Wayland APIs
-}
+// GOOD: each platform overrides the same method in its own file
+// custom/TopWindow.cpp — shared base (may be empty or have a fallback)
+// wayland/TopWindow.cpp — Wayland-specific SetFullScreen()
+// x11/TopWindow.cpp — X11-specific SetFullScreen()
+// gdi/TopWindow.cpp — GDI-specific SetFullScreen()
+// All share the same class, same header, same interface
 ```
 
 ### Finding Platform-Specific Implementations

--- a/.cursor/rules/xcsoar-testing.mdc
+++ b/.cursor/rules/xcsoar-testing.mdc
@@ -1,0 +1,140 @@
+---
+description: XCSoar unit testing patterns, NMEA test conventions, build and check workflow
+globs: test/**
+alwaysApply: false
+---
+
+# XCSoar Testing Conventions
+
+## Test Framework (TAP)
+
+Tests use the TAP (Test Anything Protocol) framework with `ok1()` assertions:
+
+```cpp
+#include "TestUtil.hpp"  // provides ok1(), equals(), plan_tests()
+
+plan_tests(N);         // declare total assertion count upfront
+ok1(condition);        // boolean assertion
+ok1(equals(a, b));     // floating-point comparison with tolerance
+```
+
+## Test Count Discipline
+
+`plan_tests(N)` must exactly match the total number of `ok1()` calls. When adding tests:
+1. Count all new `ok1()` assertions
+2. Add to the `plan_tests()` expression (use addition for clarity: `1032 + 8 + 4`)
+3. Build and verify — TAP reports mismatches
+
+## NMEA Parser Test Pattern
+
+```cpp
+static void TestMyFeature()
+{
+  NMEAParser parser;
+  NMEAInfo nmea_info;
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};  // non-zero clock required
+  nmea_info.alive.Update(nmea_info.clock);         // heartbeat required
+
+  // Advance time first (TimeHasAdvanced check)
+  ok1(parser.ParseLine("$GPRMC,082310.00,...*XX", nmea_info));
+
+  // Test your sentence
+  ok1(parser.ParseLine("$GPGLL,...*XX", nmea_info));
+  ok1(nmea_info.location_available);
+}
+```
+
+### Key Setup Requirements
+
+- `clock` must be non-zero for `Validity::Update()` to produce valid timestamps
+- `alive` must be set for `NMEAInfo::Complement()` (it returns early if `!add.alive`)
+- Time must advance between sentences (parser ignores sentences with same/earlier time)
+
+## NMEA Checksum Calculation
+
+Every test sentence needs a valid checksum. Calculate with:
+
+```python
+import functools, operator
+def nmea_cs(s):
+    body = s.split('$')[1].split('*')[0]
+    return f"{functools.reduce(operator.xor, (ord(c) for c in body), 0):02X}"
+```
+
+The checksum is XOR of all bytes between `$` and `*` (exclusive), formatted as 2-digit hex.
+
+## Test Data Directory
+
+Test fixtures and sample data live in `test/data/`:
+
+| Path | Contents |
+|------|----------|
+| `test/data/driver/` | NMEA recordings from real devices |
+| `test/data/driver/FLARM/` | FLARM simulation scenarios (`pflaf01-05.nmea`) and real traffic (`rl-traffic.nmea`) |
+| `test/data/driver/Flytec.nmea` | Flytec device NMEA recording |
+| `test/data/driver/Leonardo.nmea` | Leonardo device NMEA recording |
+| `test/data/airspace/` | Airspace files (OpenAir `.txt`, TNP `.sua`) |
+| `test/data/wp_parser/` | Waypoint files in multiple formats (`.cup`, `.dat`, `.da4`, `.wpt`, `.st2`, `.wpz`) |
+| `test/data/flarmnet/` | FlarmNet database file (`.fln`) |
+| `test/data/flarmmessaging/` | FLARM messaging test data (`.csv`) |
+| `test/data/lxn_to_igc/` | LXN binary to IGC conversion test pairs |
+| `test/data/*.igc` | IGC flight recordings for replay/scoring/GRecord tests |
+| `test/data/*.xcp` | Polar files for aircraft performance tests |
+| `test/data/*.xcm` | Map container files |
+| `test/data/*.prf` | Profile files for settings round-trip tests |
+
+When adding test data for a new device driver, place NMEA recordings in `test/data/driver/<DeviceName>.nmea`. For FLARM-specific scenarios, use `test/data/driver/FLARM/`.
+
+Note: `TestDriver.cpp` embeds NMEA sentences as string literals (no external files). The `test/data/driver/` recordings are used by replay/harness tools, not directly by unit tests.
+
+## Build and Run Tests
+
+```bash
+# Build and run all unit tests
+make -j$(nproc) TARGET=UNIX check
+
+# Build everything including tests and tools
+make -j$(nproc) TARGET=UNIX everything
+```
+
+## Testing Validity Expiry
+
+```cpp
+// Set up with valid data
+info.temperature_available.Update(info.clock);
+
+// Advance clock past the expiry timeout
+info.clock = TimeStamp{FloatDuration{60}};  // well past 30s
+info.Expire();
+ok1(!info.temperature_available);  // expired
+```
+
+## Testing Complement
+
+```cpp
+NMEAInfo a, b;
+a.Reset(); b.Reset();
+a.clock = TimeStamp{FloatDuration{1}};
+b.clock = TimeStamp{FloatDuration{1}};
+b.alive.Update(b.clock);  // required! Complement returns early without it
+
+b.some_value = 42;
+b.some_available.Update(b.clock);
+
+a.Complement(b);
+ok1(a.some_available);
+ok1(equals(a.some_value, 42));
+```
+
+## Floating-Point Comparison
+
+The `equals()` helper in `TestUtil.hpp` uses ratio-based tolerance (`ACCURACY=10000`). For small absolute values (e.g., sub-second time deltas), use direct comparison:
+
+```cpp
+// For large values where ratio tolerance works
+ok1(equals(nmea_info.location.latitude, 51.059));
+
+// For small deltas where ratio tolerance is too loose
+ok1(fabs(actual - expected) < 0.01);
+```


### PR DESCRIPTION
## Summary

- Add two new Cursor rule files for AI-assisted development:
  - `nmea-validity-patterns.mdc`: Validity vs bool patterns, TimeStamp/FloatDuration/BrokenTime usage, parser return conventions, null safety — applies when editing `src/NMEA/`, `src/Device/`, `src/time/`, `src/Computer/`
  - `xcsoar-testing.mdc`: TAP framework conventions, plan_tests discipline, NMEA test boilerplate, checksum calculation, `test/data/` directory layout, Validity expiry/Complement test patterns — applies when editing `test/`
- Update `xcsoar-project-rules.mdc` with:
  - Rendering backends table (OpenGL, memory canvas, GDI) with defines, platforms, and testing guidance
  - Display/DPI targets table covering all platforms (Android, Wayland, X11, Kobo, Windows, macOS, SDL)
  - Rewritten platform code organization section emphasizing code reuse through components and overloads rather than `#ifdef` proliferation

## Context

These rules capture patterns and lessons learned from fixing NMEA parser issues (#2207, #2209, #2210) in PR #2211, where recurring bug patterns (bool instead of Validity, manual Complement instead of `Validity::Complement()`, sub-second time truncation) were found across many files.

## Test plan

- [ ] Rules are `.mdc` format with correct frontmatter
- [ ] Glob patterns match intended files
- [ ] Content is actionable and includes concrete examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added development guidelines for data handling, sensor compatibility, and time management
  * Updated project rules covering rendering optimization and cross-platform display considerations
  * Introduced standardized testing conventions and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->