### PR TITLE
Computer/Wind/CirclingWind: Fix behavior with sub-second GPS fixes

### DIFF
--- a/src/Computer/Wind/CirclingWind.hpp
+++ b/src/Computer/Wind/CirclingWind.hpp
@@ -35,6 +35,9 @@ class CirclingWind {
   bool usable_gyroscope = false;
   bool fixed_and_aligned = false;
 
+  // remembers the TimeStamp of the last sample
+  TimeStamp last_sample_time = TimeStamp::Undefined();
+
   // active is set to true or false by the slot_newFlightMode slot
   bool active;
   // after a successful wind calculation suspend for a number of samples


### PR DESCRIPTION
Skip fixes when time hasn't advanced.
Fixed the comment to reflect the current code.
Applied a change which CodeRabbit suggested with the last PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents processing duplicate sensor samples, resets sample timing on reset, and reduces per-sample work—resulting in more stable and efficient wind estimation.
* **Documentation**
  * Clarified rotation-rate sources (GPS/IMU) and related UI/quality guidance to better interpret wind quality indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->