### PR TITLE
net/client/WeGlide/ListTasks: Fix dangling URL pointer in coroutine

### DIFF
--- a/src/net/client/WeGlide/ListTasks.cpp
+++ b/src/net/client/WeGlide/ListTasks.cpp
@@ -171,10 +171,9 @@ tag_invoke(boost::json::value_to_tag<TaskInfo>,
 }
 
 static Co::Task<std::vector<TaskInfo>>
-FetchTaskList(CurlGlobal &curl, const char *url,
+FetchTaskList(CurlGlobal &curl, CurlEasy easy,
               ProgressListener &progress)
 {
-  CurlEasy easy{url};
   Curl::Setup(easy);
   const Net::ProgressAdapter progress_adapter{easy, progress};
 
@@ -194,36 +193,41 @@ ListTasksByUser(CurlGlobal &curl, const WeGlideSettings &settings,
                 uint_least64_t user_id,
                 ProgressListener &progress)
 {
-  const auto url = FmtBuffer<256>("{}/task?user_id_in={}",
-                                  settings.default_url, user_id);
-  return FetchTaskList(curl, url, progress);
+  return FetchTaskList(curl,
+                       CurlEasy{FmtBuffer<256>("{}/task?user_id_in={}",
+                                               settings.default_url,
+                                               user_id)},
+                       progress);
 }
 
 Co::Task<std::vector<TaskInfo>>
 ListDeclaredTasks(CurlGlobal &curl, const WeGlideSettings &settings,
                   ProgressListener &progress)
 {
-  const auto url = FmtBuffer<256>("{}/task/declaration",
-                                  settings.default_url);
-  return FetchTaskList(curl, url, progress);
+  return FetchTaskList(curl,
+                       CurlEasy{FmtBuffer<256>("{}/task/declaration",
+                                               settings.default_url)},
+                       progress);
 }
 
 Co::Task<std::vector<TaskInfo>>
 ListDailyCompetitions(CurlGlobal &curl, const WeGlideSettings &settings,
                       ProgressListener &progress)
 {
-  const auto url = FmtBuffer<256>("{}/task/competitions/today",
-                                  settings.default_url);
-  return FetchTaskList(curl, url, progress);
+  return FetchTaskList(curl,
+                       CurlEasy{FmtBuffer<256>("{}/task/competitions/today",
+                                               settings.default_url)},
+                       progress);
 }
 
 Co::Task<std::vector<TaskInfo>>
 ListRecentTaskScores(CurlGlobal &curl, const WeGlideSettings &settings,
                      ProgressListener &progress)
 {
-  const auto url = FmtBuffer<256>("{}/task/score/recent",
-                                  settings.default_url);
-  return FetchTaskList(curl, url, progress);
+  return FetchTaskList(curl,
+                       CurlEasy{FmtBuffer<256>("{}/task/score/recent",
+                                               settings.default_url)},
+                       progress);
 }
 
 } // namespace WeGlide


### PR DESCRIPTION
## Summary

- Fix use-after-free in WeGlide task list coroutines causing "URL rejected: Malformed input to a URL function" on all WeGlide task buttons
- `FetchTaskList` is a lazy `Co::Task` that suspends at `initial_suspend` before executing its body. The callers created temporary `FmtBuffer` URL strings and passed a `const char*`, which became dangling by the time the coroutine body ran.
- Fix by constructing `CurlEasy` in the callers (which copies the URL into the curl handle immediately), matching the pattern already used in `DownloadTask.cpp`.

Fixes #2215

## Test plan

- [ ] Enable WeGlide in System Setup with a valid pilot ID
- [ ] Navigate to Nav → Task Manager → Manage
- [ ] Tap "My Tasks" — should load task list without error
- [ ] Tap "Declared Tasks" — should load without error
- [ ] Tap "Competitions Today" — should load without error
- [ ] Tap "Recent Scores" — should load without error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to enhance maintainability and flexibility of task list retrieval mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->