### PR TITLE
Update DEPFLAGS format for dependency handling

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -64,7 +64,7 @@ SRC_TO_OBJ = $(subst /./,/,$(patsubst %.cpp,%$(OBJ_SUFFIX),$(patsubst %.cxx,%$(O
 ####### dependency handling
 
 DEPFILE = $(@:$(OBJ_SUFFIX)=.d)
-DEPFLAGS = -Wp,-MD,$(DEPFILE),-MT,$@
+DEPFLAGS = -MD -MF $(DEPFILE) -MT $@
 cc-flags = $(DEPFLAGS) $(ALL_CFLAGS) $(ALL_CPPFLAGS) $(TARGET_ARCH) $(FLAGS_COVERAGE)  $(EXTRA_CPPFLAGS)  $(EXTRA_CFLAGS)
 cxx-flags = $(DEPFLAGS) $(ALL_CXXFLAGS) $(ALL_CPPFLAGS) $(TARGET_ARCH) $(FLAGS_COVERAGE)  $(EXTRA_CPPFLAGS)  $(EXTRA_CXXFLAGS)
 


### PR DESCRIPTION
Apparently, the old -Wp flag is no longer required since GCC 10+, we can now use the -MF flag just like for clang. This helps ccache to manage dependencies better.

While researching slow rebasing performance for Windows targets, I stumbled upon this. According to the internet this should be a drop-in replacement.


Any advice by the build system specialists?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build system configuration to improve dependency file generation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->