### PR TITLE
Dialogs/FilePicker: rename Download button to Repository

### DIFF
--- a/src/Dialogs/FilePicker.cpp
+++ b/src/Dialogs/FilePicker.cpp
@@ -27,7 +27,7 @@ FilePicker(const char *caption, FileDataField &df, const char *help_text,
   if (df.GetFileType() != FileType::IGC &&
     df.GetFileType() != FileType::UNKNOWN &&
     Net::DownloadManager::IsAvailable())
-      extra_caption = _("Download");
+      extra_caption = _("Repository");
 #endif
 
   int i = ComboPicker(caption, combo_list, help_text, false, extra_caption);


### PR DESCRIPTION
 It's a nit, but I think naming this Button "Repository" is
 much closer to what it really does: it takes you to the
 repository. It doesn’t start a Download.

 Addressing Issue #2227 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the file picker dialog label text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->