### PR TITLE
Build System: Add -MP flags to both compilers

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -64,7 +64,7 @@ SRC_TO_OBJ = $(subst /./,/,$(patsubst %.cpp,%$(OBJ_SUFFIX),$(patsubst %.cxx,%$(O
 ####### dependency handling
 
 DEPFILE = $(@:$(OBJ_SUFFIX)=.d)
-DEPFLAGS = -MD -MF $(DEPFILE) -MT $@
+DEPFLAGS = -MD -MP -MF $(DEPFILE) -MT $@
 cc-flags = $(DEPFLAGS) $(ALL_CFLAGS) $(ALL_CPPFLAGS) $(TARGET_ARCH) $(FLAGS_COVERAGE)  $(EXTRA_CPPFLAGS)  $(EXTRA_CFLAGS)
 cxx-flags = $(DEPFLAGS) $(ALL_CXXFLAGS) $(ALL_CPPFLAGS) $(TARGET_ARCH) $(FLAGS_COVERAGE)  $(EXTRA_CPPFLAGS)  $(EXTRA_CXXFLAGS)
 

--- a/build/llvm.mk
+++ b/build/llvm.mk
@@ -2,7 +2,7 @@ LLVM_SUFFIX ?=
 
 ifeq ($(CLANG),y)
 
-DEPFLAGS = -MD -MF $(DEPFILE) -MT $@
+DEPFLAGS = -MD -MP -MF $(DEPFILE) -MT $@
 
 ifeq ($(USE_CCACHE),y)
   # ccache will not use the optimisation of avoiding the 2nd call to the


### PR DESCRIPTION
I stumbled upon this one as well when I looked into the -Wp thing. This should get rid of the "missing header file needed by xxx"-errors of the make command when a file is removed from the tree (due to actual removal or a checkout / branch switch)

This should get rid of 95% of all the "make clean"s I need to do and save tons of time.

However, I am a bit unsure whether there might be some problem with the flag, and this is why it was not introduced years ago? I mean, if this really works as advertised, this would have removed so much pain - there must be some reason for not putting it?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system dependency handling to improve build efficiency and reduce redundant compilation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->