### PR TITLE
test/FakeLocalPath: Remove [[gnu::weak]] attributes

### DIFF
--- a/test/src/FakeLocalPath.cpp
+++ b/test/src/FakeLocalPath.cpp
@@ -4,19 +4,19 @@
 #include "LocalPath.hpp"
 #include "system/Path.hpp"
 
-[[gnu::weak]] AllocatedPath
+AllocatedPath
 LocalPath([[maybe_unused]] Path file) noexcept
 {
   return nullptr;
 }
 
-[[gnu::weak]] AllocatedPath
+AllocatedPath
 LocalPath([[maybe_unused]] const char *file) noexcept
 {
   return nullptr;
 }
 
-[[gnu::weak]] void
+void
 VisitDataFiles([[maybe_unused]] const char *filter,
                [[maybe_unused]] File::Visitor &visitor)
 {


### PR DESCRIPTION
## Summary

- Remove `[[gnu::weak]]` from stub function definitions in `test/src/FakeLocalPath.cpp`
- Fixes `TestPlanes.exe` link failures on PC and WIN64 targets

The `[[gnu::weak]]` attribute on function definitions does not work on PE/COFF targets (MinGW cross-compilation). The MinGW linker leaves weak-defined symbols unresolved, causing "undefined reference" errors for `VisitDataFiles()` and `LocalPath()` when linking `TestPlanes.exe`.

These stubs are only linked into `TestPlanes`, which does not include the real `LocalPath.o`, so there is no symbol conflict requiring weak linkage.

## Test plan

- [x] Verified `TestPlanes.exe` links successfully on PC target
- [x] Verified `TestPlanes.exe` links successfully on WIN64 target
- [x] Verified `TestPlanes` links successfully on UNIX target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure to refine function linkage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->