### PR TITLE
tools/polar_import.py: Correcting an incorrect comparison string length

### DIFF
--- a/tools/polar_import.py
+++ b/tools/polar_import.py
@@ -116,7 +116,8 @@ def get_current_xc_polar(glider, weight=0.0):
         return None
     ret = None
     for line in f:
-        if line[0:7] != "  { " : continue
+        if not line.startswith('  { ') :
+            continue
         if glider in line:
             ##357, 165, 108.8, -0.64, 156.4, -1.18, 211.13, -2.5, 9.0, 0.0, 114
             ret = polar()


### PR DESCRIPTION
Removing the '_T(' shortens the comparison length by 3 characters.

- [x ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and parsing of polar data entries in the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->