### PR TITLE
Build System: Unify CCACHE_CPP2 setting across both compilers

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -1,8 +1,12 @@
 ######## tools
 
-CCACHE := 
+CCACHE :=
 ifeq ($(USE_CCACHE),y)
   CCACHE := ccache$(EXE)
+  # ccache will not use the optimisation of avoiding the 2nd call to the
+  # pre-processor by compiling the pre-processed output that was used for
+  # finding the hash in the case of a cache miss.
+  export CCACHE_CPP2 = yes
 endif
 
 EXE := $(findstring .exe,$(MAKE))

--- a/build/llvm.mk
+++ b/build/llvm.mk
@@ -4,13 +4,6 @@ ifeq ($(CLANG),y)
 
 DEPFLAGS = -MD -MP -MF $(DEPFILE) -MT $@
 
-ifeq ($(USE_CCACHE),y)
-  # ccache will not use the optimisation of avoiding the 2nd call to the
-  # pre-processor by compiling the pre-processed output that was used for
-  # finding the hash in the case of a cache miss.
-  export CCACHE_CPP2 = yes
-endif
-
 ifneq ($(LLVM_TARGET),)
   TARGET_ARCH += -target $(LLVM_TARGET)
 endif


### PR DESCRIPTION
The clang build path was switched to CCACHE_CPP2=yes some years ago, this makes gcc follow the same ccache pattern. This also makes the -MP flag (#2230) work properly with gcc, not just with clang 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated compiler cache behavior across build scripts: unified CPP2 preprocessor handling by centralizing the cache-related export so build targets use consistent cache miss behavior and avoid duplicated settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->