### PR TITLE
Dialogs/MultiFilePicker: move OK button to top

### DIFF
--- a/src/Dialogs/MultiFilePicker.cpp
+++ b/src/Dialogs/MultiFilePicker.cpp
@@ -42,6 +42,8 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
     widget = std::make_unique<StaticHelpTextWidget>(std::move(widget),
                                                     help_text);
 
+  dialog.AddButton(_("OK"), mrOK);
+
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (Net::DownloadManager::IsAvailable()) {
     dialog.AddButton(_("Download"), [file_widget, &df]() {
@@ -71,7 +73,6 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
       file_widget->ClearSelection();
     UpdateButtons();
   });
-  dialog.AddButton(_("OK"), mrOK);
   dialog.AddButton(_("Cancel"), mrCancel);
 
   // Ensure initial caption is correct and register callback.


### PR DESCRIPTION
I realized that using the MultiFilePicker can be quite confusing because the buttons are in a different order than in the other file selection dialogs. Quick change to move the OK button to the top.

Ref #2085 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate button handling in the file picker dialog, ensuring proper dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->