### PR TITLE
doc: Pin Read the Docs build environment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,9 +2,9 @@
 version: 2
 
 build:
-  os: ubuntu-lts-latest
+  os: ubuntu-24.04
   tools:
-    python: "latest"
+    python: "3.12"
 
 sphinx:
   # Path to your Sphinx configuration file.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
-sphinxcontrib-blockdiag
+setuptools<81
+sphinxcontrib-blockdiag==3.0.0


### PR DESCRIPTION
## Summary
- Pin Read the Docs build OS/Python versions in `.readthedocs.yaml`
- Pin `doc/requirements.txt` dependencies to avoid breakage from floating updates
- Restore stable Sphinx/RTD builds affected by `sphinxcontrib-blockdiag`/`pkg_resources` compatibility

## Test plan
- [x] Verify branch contains only `.readthedocs.yaml` and `doc/requirements.txt`
- [x] Verify commit history contains only the RTD/Sphinx fix commit
- [ ] Confirm Read the Docs build passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build environment to Ubuntu 24.04 and Python 3.12.
  * Pinned documentation build dependencies to specific versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->