### PR TITLE
ui/event/poll: KMS system-rotated input mode and startup sync

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -76,6 +76,7 @@ TEST_NAMES = \
 	TestWaypoints \
 	test_pressure \
 	test_task \
+	TestInputTransformMode \
 	TestOverwritingRingBuffer \
 	TestDateTime TestRoughTime TestWrapClock \
 	TestPolylineDecoder \
@@ -579,6 +580,12 @@ TEST_INPUT_CONFIG_SOURCES = \
 TEST_INPUT_CONFIG_CPPFLAGS = $(SCREEN_CPPFLAGS)
 TEST_INPUT_CONFIG_DEPENDS = IO OS UTIL
 $(eval $(call link-program,TestInputConfig,TEST_INPUT_CONFIG))
+
+TEST_INPUT_TRANSFORM_MODE_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestInputTransformMode.cpp
+TEST_INPUT_TRANSFORM_MODE_DEPENDS = UTIL
+$(eval $(call link-program,TestInputTransformMode,TEST_INPUT_TRANSFORM_MODE))
 
 TEST_POLARS_SOURCES = \
 	$(SRC)/Polar/Shape.cpp \

--- a/src/Hardware/DisplayGlue.cpp
+++ b/src/Hardware/DisplayGlue.cpp
@@ -26,6 +26,13 @@ Display::LoadOrientation(VerboseOperationEnvironment &env)
   DisplayOrientation orientation =
     CommonInterface::GetUISettings().display.orientation;
 
+#ifdef MESA_KMS
+  /* In KMS mode, DEFAULT follows the detected initial orientation so
+     DEFAULT still runs through the orientation pipeline. */
+  if (orientation == DisplayOrientation::DEFAULT)
+    orientation = DetectInitialOrientation();
+#endif
+
 #ifdef KOBO
   /* on the Kobo, the display orientation must be loaded explicitly
      (portrait), because the hardware default is landscape */

--- a/src/ui/event/poll/InputQueue.cpp
+++ b/src/ui/event/poll/InputQueue.cpp
@@ -9,14 +9,14 @@ namespace UI {
 
 InputEventQueue::InputEventQueue(EventQueue &queue) noexcept
   :
-#ifdef KOBO
+#ifndef USE_LIBINPUT
    keyboard(queue, merge_mouse),
    mouse(queue, merge_mouse)
 #else
    libinput_handler(queue)
 #endif
 {
-#ifdef KOBO
+#ifndef USE_LIBINPUT
   /* power button */
   keyboard.Open("/dev/input/event0");
 
@@ -32,7 +32,7 @@ InputEventQueue::~InputEventQueue() noexcept = default;
 bool
 InputEventQueue::Generate([[maybe_unused]] Event &event) noexcept
 {
-#ifdef KOBO
+#ifndef USE_LIBINPUT
   event = merge_mouse.Generate();
   if (event.type != Event::Type::NOP)
     return true;

--- a/src/ui/event/poll/InputQueue.hpp
+++ b/src/ui/event/poll/InputQueue.hpp
@@ -42,11 +42,13 @@ public:
   #endif
   }
 
-#ifndef USE_LIBINPUT
   void SetDisplayOrientation(DisplayOrientation orientation) {
+#ifdef USE_LIBINPUT
+    libinput_handler.SetDisplayOrientation(orientation);
+#else
     merge_mouse.SetDisplayOrientation(orientation);
-  }
 #endif
+  }
 
   bool HasPointer() const noexcept {
 #ifdef USE_LIBINPUT

--- a/src/ui/event/poll/InputQueue.hpp
+++ b/src/ui/event/poll/InputQueue.hpp
@@ -50,6 +50,14 @@ public:
 #endif
   }
 
+  bool UsesSystemRotatedInput() const noexcept {
+#ifdef USE_LIBINPUT
+    return libinput_handler.UsesSystemRotatedInput();
+#else
+    return false;
+#endif
+  }
+
   bool HasPointer() const noexcept {
 #ifdef USE_LIBINPUT
     return libinput_handler.HasPointer();

--- a/src/ui/event/poll/InputQueue.hpp
+++ b/src/ui/event/poll/InputQueue.hpp
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#ifdef KOBO
+#ifdef USE_LIBINPUT
+#include "libinput/LibInputHandler.hpp"
+#else
 #include "linux/MergeMouse.hpp"
 #include "linux/Input.hpp"
-#else
-#include "libinput/LibInputHandler.hpp"
 #endif
 
 #include "ui/dim/Point.hpp"
@@ -22,13 +22,13 @@ class EventQueue;
 struct Event;
 
 class InputEventQueue final {
-#ifdef KOBO
+#ifdef USE_LIBINPUT
+  LibInputHandler libinput_handler;
+#else
   MergeMouse merge_mouse;
   LinuxInputDevice keyboard;
   LinuxInputDevice mouse;
-#else
-  LibInputHandler libinput_handler;
-#endif /* !USE_LIBINPUT */
+#endif
 
 public:
   explicit InputEventQueue(EventQueue &queue) noexcept;

--- a/src/ui/event/poll/Queue.hpp
+++ b/src/ui/event/poll/Queue.hpp
@@ -131,6 +131,14 @@ public:
 #endif
   }
 
+  bool UsesSystemRotatedInput() const noexcept {
+#if !defined(NON_INTERACTIVE) && !defined(USE_X11) && !defined(USE_WAYLAND) && defined(USE_LIBINPUT)
+    return input_queue.UsesSystemRotatedInput();
+#else
+    return false;
+#endif
+  }
+
 #if !defined(NON_INTERACTIVE) && !defined(USE_X11)
   bool HasPointer() const noexcept {
     return input_queue.HasPointer();

--- a/src/ui/event/poll/Queue.hpp
+++ b/src/ui/event/poll/Queue.hpp
@@ -126,7 +126,7 @@ public:
   }
 
   void SetDisplayOrientation([[maybe_unused]] DisplayOrientation orientation) noexcept {
-#if !defined(NON_INTERACTIVE) && !defined(USE_X11) && !defined(USE_WAYLAND) && !defined(USE_LIBINPUT)
+#if !defined(NON_INTERACTIVE) && !defined(USE_X11) && !defined(USE_WAYLAND)
     input_queue.SetDisplayOrientation(orientation);
 #endif
   }

--- a/src/ui/event/poll/libinput/InputTransform.hpp
+++ b/src/ui/event/poll/libinput/InputTransform.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "DisplayOrientation.hpp"
+#include "ui/dim/Point.hpp"
+#include "ui/dim/Size.hpp"
+
+#include <cstdint>
+
+namespace UI {
+
+enum class InputTransformMode : uint8_t {
+  XCSOAR_ROTATED,
+  SYSTEM_ROTATED,
+  COUNT,
+};
+
+[[gnu::pure]]
+inline PixelPoint
+TransformInputPointForMode(PixelPoint p, PixelSize screen_size,
+                           DisplayOrientation orientation,
+                           InputTransformMode mode) noexcept
+{
+  if (mode == InputTransformMode::SYSTEM_ROTATED)
+    return p;
+
+  switch (TranslateDefaultDisplayOrientation(orientation)) {
+  case DisplayOrientation::DEFAULT:
+  case DisplayOrientation::LANDSCAPE:
+    return p;
+
+  case DisplayOrientation::PORTRAIT:
+    return PixelPoint(screen_size.height - p.y, p.x);
+
+  case DisplayOrientation::REVERSE_LANDSCAPE:
+    return PixelPoint(screen_size.width - p.x,
+                      screen_size.height - p.y);
+
+  case DisplayOrientation::REVERSE_PORTRAIT:
+    return PixelPoint(p.y, screen_size.width - p.x);
+  }
+
+  return p;
+}
+
+[[gnu::pure]]
+inline PixelSize
+GetLogicalInputSizeForMode(PixelSize screen_size,
+                           DisplayOrientation orientation,
+                           InputTransformMode mode) noexcept
+{
+  if (mode == InputTransformMode::XCSOAR_ROTATED &&
+      AreAxesSwapped(orientation))
+    return PixelSize(screen_size.height, screen_size.width);
+
+  return screen_size;
+}
+
+} // namespace UI

--- a/src/ui/event/poll/libinput/LibInputHandler.cpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.cpp
@@ -20,8 +20,39 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <termios.h>
+#include <cstdlib>
+#include <cstring>
 
 namespace UI {
+
+[[gnu::pure]]
+static InputTransformMode
+ParseInputTransformMode() noexcept
+{
+  const char *value = std::getenv("XCSOAR_KMS_INPUT_TRANSFORM");
+  if (value != nullptr &&
+      (std::strcmp(value, "system") == 0 ||
+       std::strcmp(value, "native") == 0 ||
+       std::strcmp(value, "none") == 0))
+    return InputTransformMode::SYSTEM_ROTATED;
+
+  if (value != nullptr &&
+      (std::strcmp(value, "xcsoar") == 0 ||
+       std::strcmp(value, "software") == 0))
+    return InputTransformMode::XCSOAR_ROTATED;
+
+#ifdef MESA_KMS
+  return InputTransformMode::SYSTEM_ROTATED;
+#else
+  return InputTransformMode::XCSOAR_ROTATED;
+#endif
+}
+
+void
+LibInputHandler::SetDisplayOrientation(DisplayOrientation orientation) noexcept
+{
+  display_orientation = orientation;
+}
 
 PixelPoint
 LibInputHandler::GetPosition() const noexcept
@@ -33,14 +64,16 @@ PixelPoint
 LibInputHandler::MaybeTransformPoint(PixelPoint p) const noexcept
 {
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-  p = TransformCoordinates(p, screen_size);
+  if (input_transform_mode == InputTransformMode::XCSOAR_ROTATED)
+    p = TransformCoordinates(p, screen_size, display_orientation);
 #else
   return p;
 #endif
 
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
   PixelSize logical_size = screen_size;
-  if (AreAxesSwapped(OpenGL::display_orientation))
+  if (input_transform_mode == InputTransformMode::XCSOAR_ROTATED &&
+      AreAxesSwapped(display_orientation))
     logical_size = PixelSize(screen_size.height, screen_size.width);
 
   if (logical_size.width > 0 && unsigned(p.x) >= logical_size.width)
@@ -54,7 +87,8 @@ LibInputHandler::MaybeTransformPoint(PixelPoint p) const noexcept
 
 LibInputHandler::LibInputHandler(EventQueue &_queue) noexcept
   :queue(_queue),
-   fd(queue.GetEventLoop(), BIND_THIS_METHOD(OnSocketReady)) {}
+   fd(queue.GetEventLoop(), BIND_THIS_METHOD(OnSocketReady)),
+   input_transform_mode(ParseInputTransformMode()) {}
 
 bool
 LibInputHandler::Open() noexcept

--- a/src/ui/event/poll/libinput/LibInputHandler.cpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.cpp
@@ -7,10 +7,6 @@
 #include "ui/event/shared/Event.hpp"
 #include "ui/event/poll/linux/Translate.hpp"
 
-#if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-#include "ui/event/shared/TransformCoordinates.hpp"
-#endif
-
 #include <libinput.h>
 
 #include <algorithm> // for std::clamp()
@@ -64,17 +60,16 @@ PixelPoint
 LibInputHandler::MaybeTransformPoint(PixelPoint p) const noexcept
 {
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-  if (input_transform_mode == InputTransformMode::XCSOAR_ROTATED)
-    p = TransformCoordinates(p, screen_size, display_orientation);
+  p = TransformInputPointForMode(p, screen_size, display_orientation,
+                                 input_transform_mode);
 #else
   return p;
 #endif
 
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-  PixelSize logical_size = screen_size;
-  if (input_transform_mode == InputTransformMode::XCSOAR_ROTATED &&
-      AreAxesSwapped(display_orientation))
-    logical_size = PixelSize(screen_size.height, screen_size.width);
+  PixelSize logical_size = GetLogicalInputSizeForMode(screen_size,
+                                                      display_orientation,
+                                                      input_transform_mode);
 
   if (logical_size.width > 0 && unsigned(p.x) >= logical_size.width)
     p.x = logical_size.width - 1;

--- a/src/ui/event/poll/libinput/LibInputHandler.hpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.hpp
@@ -6,6 +6,7 @@
 #include "event/PipeEvent.hxx"
 #include "ui/dim/Size.hpp"
 #include "ui/dim/Point.hpp"
+#include "DisplayOrientation.hpp"
 
 #include <cassert>
 
@@ -18,6 +19,11 @@ class UdevContext;
 namespace UI {
 
 class EventQueue;
+
+enum class InputTransformMode : uint8_t {
+  XCSOAR_ROTATED,
+  SYSTEM_ROTATED,
+};
 
 /**
  * A driver for handling libinput events.
@@ -35,6 +41,8 @@ class LibInputHandler final {
   double x = -1.0, y = -1.0;
 
   PixelSize screen_size{0, 0};
+  DisplayOrientation display_orientation = DisplayOrientation::DEFAULT;
+  InputTransformMode input_transform_mode = InputTransformMode::XCSOAR_ROTATED;
 
   /**
    * The number of pointer input devices, touch screens ans keyboards.
@@ -96,6 +104,12 @@ public:
 
   bool HasKeyboard() const noexcept {
     return n_keyboards > 0;
+  }
+
+  void SetDisplayOrientation(DisplayOrientation orientation) noexcept;
+
+  bool UsesSystemRotatedInput() const noexcept {
+    return input_transform_mode == InputTransformMode::SYSTEM_ROTATED;
   }
 
 private:

--- a/src/ui/event/poll/libinput/LibInputHandler.hpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "event/PipeEvent.hxx"
+#include "InputTransform.hpp"
 #include "ui/dim/Size.hpp"
 #include "ui/dim/Point.hpp"
 #include "DisplayOrientation.hpp"
@@ -19,11 +20,6 @@ class UdevContext;
 namespace UI {
 
 class EventQueue;
-
-enum class InputTransformMode : uint8_t {
-  XCSOAR_ROTATED,
-  SYSTEM_ROTATED,
-};
 
 /**
  * A driver for handling libinput events.

--- a/src/ui/event/shared/TransformCoordinates.hpp
+++ b/src/ui/event/shared/TransformCoordinates.hpp
@@ -19,10 +19,9 @@ namespace UI {
  */
 [[gnu::pure]]
 inline PixelPoint
-TransformCoordinates(PixelPoint p, PixelSize physical_size) noexcept
+TransformCoordinates(PixelPoint p, PixelSize physical_size,
+                     DisplayOrientation orientation) noexcept
 {
-  const auto orientation = OpenGL::display_orientation;
-
   switch (TranslateDefaultDisplayOrientation(orientation)) {
   case DisplayOrientation::DEFAULT:
   case DisplayOrientation::LANDSCAPE:
@@ -40,6 +39,13 @@ TransformCoordinates(PixelPoint p, PixelSize physical_size) noexcept
   }
 
   return p;
+}
+
+[[gnu::pure]]
+inline PixelPoint
+TransformCoordinates(PixelPoint p, PixelSize physical_size) noexcept
+{
+  return TransformCoordinates(p, physical_size, OpenGL::display_orientation);
 }
 
 } // namespace UI

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -74,6 +74,10 @@ TopWindow::Create([[maybe_unused]] const char *text, PixelSize size,
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   size = screen->SetDisplayOrientation(style.GetInitialOrientation());
+#ifdef USE_POLL_EVENT
+  if (event_queue != nullptr)
+    event_queue->SetDisplayOrientation(style.GetInitialOrientation());
+#endif
 #elif defined(USE_MEMORY_CANVAS)
   size = screen->GetSize();
 #elif defined(ENABLE_OPENGL)

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -75,8 +75,16 @@ TopWindow::Create([[maybe_unused]] const char *text, PixelSize size,
 #ifdef SOFTWARE_ROTATE_DISPLAY
   size = screen->SetDisplayOrientation(style.GetInitialOrientation());
 #ifdef USE_POLL_EVENT
-  if (event_queue != nullptr)
+  if (event_queue != nullptr) {
     event_queue->SetDisplayOrientation(style.GetInitialOrientation());
+    PixelSize native_size = size;
+#if defined(ENABLE_OPENGL) && defined(USE_LIBINPUT)
+    if (!event_queue->UsesSystemRotatedInput() &&
+        AreAxesSwapped(style.GetInitialOrientation()))
+      native_size = {size.height, size.width};
+#endif
+    event_queue->SetScreenSize(native_size);
+  }
 #endif
 #elif defined(USE_MEMORY_CANVAS)
   size = screen->GetSize();

--- a/src/ui/window/poll/TopWindow.cpp
+++ b/src/ui/window/poll/TopWindow.cpp
@@ -29,7 +29,8 @@ TopWindow::OnResize(PixelSize new_size) noexcept
 
   PixelSize native_size = new_size;
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY) && defined(USE_LIBINPUT)
-  if (AreAxesSwapped(OpenGL::display_orientation))
+  if (!event_queue->UsesSystemRotatedInput() &&
+      AreAxesSwapped(OpenGL::display_orientation))
     native_size = PixelSize(new_size.height, new_size.width);
 #endif
 

--- a/test/src/TestInputTransformMode.cpp
+++ b/test/src/TestInputTransformMode.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ui/event/poll/libinput/InputTransform.hpp"
+#include "TestUtil.hpp"
+
+int
+main()
+{
+  plan_tests(6);
+
+  const PixelSize screen_size{1800, 2880};
+  const PixelPoint raw{900, 1440};
+
+  const PixelPoint system_mapped =
+    UI::TransformInputPointForMode(raw, screen_size,
+                                   DisplayOrientation::PORTRAIT,
+                                   UI::InputTransformMode::SYSTEM_ROTATED);
+  ok1(system_mapped == raw);
+
+  const PixelSize system_size =
+    UI::GetLogicalInputSizeForMode(screen_size,
+                                   DisplayOrientation::PORTRAIT,
+                                   UI::InputTransformMode::SYSTEM_ROTATED);
+  ok1(system_size == screen_size);
+
+  const PixelPoint xcsoar_portrait =
+    UI::TransformInputPointForMode(raw, screen_size,
+                                   DisplayOrientation::PORTRAIT,
+                                   UI::InputTransformMode::XCSOAR_ROTATED);
+  ok1(xcsoar_portrait == PixelPoint(1440, 900));
+
+  const PixelSize xcsoar_portrait_size =
+    UI::GetLogicalInputSizeForMode(screen_size,
+                                   DisplayOrientation::PORTRAIT,
+                                   UI::InputTransformMode::XCSOAR_ROTATED);
+  ok1(xcsoar_portrait_size == PixelSize(2880, 1800));
+
+  const PixelPoint xcsoar_reverse_landscape =
+    UI::TransformInputPointForMode(raw, screen_size,
+                                   DisplayOrientation::REVERSE_LANDSCAPE,
+                                   UI::InputTransformMode::XCSOAR_ROTATED);
+  ok1(xcsoar_reverse_landscape == PixelPoint(900, 1440));
+
+  const PixelPoint system_reverse_landscape =
+    UI::TransformInputPointForMode(raw, screen_size,
+                                   DisplayOrientation::REVERSE_LANDSCAPE,
+                                   UI::InputTransformMode::SYSTEM_ROTATED);
+  ok1(system_reverse_landscape == raw);
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- route startup display orientation and screen-size state through the poll queue so libinput has initialized rotation/geometry before first interactions
- add a selectable libinput transform mode and prefer `system` mode on `MESA_KMS`, while keeping an env override to force XCSoar software transform for debugging/compatibility
- add focused unit coverage for both system-rotated and XCSoar-rotated coordinate/size mapping behavior

## Test plan
- [x] Build with `make -j$(nproc) TARGET=UNIX USE_CCACHE=y ENABLE_MESA_KMS=y`
- [x] Run `./output/UNIX/bin/TestInputTransformMode`
- [x] Manual KMS check with `fbcon/rotate` in portrait/reverse-portrait (startup screen + post-profile-load)
- [x] Verify no regressions in X11/Wayland paths (changes are limited to poll/libinput/KMS wiring)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input transformation modes for flexible handling of rotated display input and improved propagation of display orientation through the input event system.

* **Tests**
  * Added comprehensive tests covering input transformation behavior across modes and orientations.
  * Added a new test build target and harness to run the input-transform-mode tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->