### PR TITLE
Waypoint: Parse CUP runway width and show waypoint type in details

### DIFF
--- a/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
@@ -105,7 +105,17 @@ WaypointInfoWidget::Prepare(ContainerWindow &parent,
 
     char length_buffer[16];
     FormatSmallUserDistance(length_buffer, waypoint->runway.GetLength());
-    buffer += length_buffer;
+
+    if (waypoint->runway.IsWidthDefined()) {
+      char width_buffer[16];
+      FormatSmallUserDistance(width_buffer, waypoint->runway.GetWidth());
+
+      StaticString<64> runway_size;
+      runway_size.UnsafeFormat("%s x %s", length_buffer, width_buffer);
+      buffer += runway_size;
+    } else {
+      buffer += length_buffer;
+    }
   }
 
   if (!buffer.empty())

--- a/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
@@ -41,6 +41,55 @@ FormatGlideResult(char *buffer, size_t size,
   return nullptr;
 }
 
+static const char *
+GetWaypointTypeName(Waypoint::Type type) noexcept
+{
+  switch (type) {
+  case Waypoint::Type::NORMAL:
+    return _("Turnpoint");
+  case Waypoint::Type::AIRFIELD:
+    return _("Airport");
+  case Waypoint::Type::OUTLANDING:
+    return _("Landable");
+  case Waypoint::Type::MOUNTAIN_PASS:
+    return _("Mountain Pass");
+  case Waypoint::Type::MOUNTAIN_TOP:
+    return _("Mountain Top");
+  case Waypoint::Type::OBSTACLE:
+    return _("Transmitter Mast");
+  case Waypoint::Type::TOWER:
+    return _("Tower");
+  case Waypoint::Type::TUNNEL:
+    return _("Tunnel");
+  case Waypoint::Type::BRIDGE:
+    return _("Bridge");
+  case Waypoint::Type::POWERPLANT:
+    return _("Power Plant");
+  case Waypoint::Type::VOR:
+    return _("VOR");
+  case Waypoint::Type::NDB:
+    return _("NDB");
+  case Waypoint::Type::DAM:
+    return _("Dam");
+  case Waypoint::Type::CASTLE:
+    return _("Castle");
+  case Waypoint::Type::INTERSECTION:
+    return _("Intersection");
+  case Waypoint::Type::MARKER:
+    return _("Marker");
+  case Waypoint::Type::REPORTING_POINT:
+    return _("Control Point");
+  case Waypoint::Type::PGTAKEOFF:
+    return _("PG Take Off");
+  case Waypoint::Type::PGLANDING:
+    return _("PG Landing Zone");
+  case Waypoint::Type::THERMAL_HOTSPOT:
+    return _("Thermal hotspot");
+  }
+
+  return nullptr;
+}
+
 void
 WaypointInfoWidget::AddGlideResult(const char *label,
                                    const GlideResult &result) noexcept
@@ -88,6 +137,20 @@ WaypointInfoWidget::Prepare(ContainerWindow &parent,
   if (!waypoint->comment.empty())
     AddMultiLine(waypoint->comment.c_str());
 
+  AddReadOnly(_("Type"), nullptr, GetWaypointTypeName(waypoint->type));
+
+  if (!waypoint->shortname.empty())
+    AddReadOnly(_("Short Name"), nullptr, waypoint->shortname.c_str());
+
+  if (FormatGeoPoint(waypoint->location,
+                     buffer.buffer(), buffer.capacity()) != nullptr)
+    AddReadOnly(_("Location"), nullptr, buffer);
+
+  if (waypoint->has_elevation)
+    AddReadOnly(_("Elevation"), nullptr, FormatUserAltitude(waypoint->elevation));
+  else
+    AddReadOnly(_("Elevation"), nullptr, "?");
+
   if (waypoint->radio_frequency.Format(buffer.buffer(),
                                       buffer.capacity()) != nullptr) {
     buffer += " MHz";
@@ -120,18 +183,6 @@ WaypointInfoWidget::Prepare(ContainerWindow &parent,
 
   if (!buffer.empty())
     AddReadOnly(_("Runway"), nullptr, buffer);
-
-  if (!waypoint->shortname.empty())
-    AddReadOnly(_("Short Name"), nullptr, waypoint->shortname.c_str());
-
-  if (FormatGeoPoint(waypoint->location,
-                     buffer.buffer(), buffer.capacity()) != nullptr)
-    AddReadOnly(_("Location"), nullptr, buffer);
-
-  if (waypoint->has_elevation)
-    AddReadOnly(_("Elevation"), nullptr, FormatUserAltitude(waypoint->elevation));
-  else
-    AddReadOnly(_("Elevation"), nullptr, "?");
 
   if (basic.time_available && basic.date_time_utc.IsDatePlausible()) {
     const SunEphemeris::Result sun =

--- a/src/Engine/Waypoint/Runway.hpp
+++ b/src/Engine/Waypoint/Runway.hpp
@@ -15,8 +15,11 @@ class Runway {
   /** Main runway length in m (0 for unknown) */
   uint16_t length;
 
-  constexpr Runway(int _direction, unsigned _length)
-    :direction(_direction), length(_length) {}
+  /** Main runway width in m (0 for unknown) */
+  uint16_t width;
+
+  constexpr Runway(int _direction, unsigned _length, unsigned _width)
+    :direction(_direction), length(_length), width(_width) {}
 
 public:
   /**
@@ -29,7 +32,7 @@ public:
    * false.
    */
   static constexpr Runway Null() {
-    return { -1, 0 };
+    return { -1, 0, 0 };
   }
 
   bool IsDirectionDefined() const {
@@ -40,9 +43,14 @@ public:
     return length > 0;
   }
 
+  bool IsWidthDefined() const {
+    return width > 0;
+  }
+
   void Clear() {
     ClearDirection();
     length = 0;
+    width = 0;
   }
 
   void ClearDirection() {
@@ -89,5 +97,16 @@ public:
     assert(IsLengthDefined());
 
     return length;
+  }
+
+  void SetWidth(unsigned _width) {
+    width = _width;
+  }
+
+  [[gnu::pure]]
+  unsigned GetWidth() const {
+    assert(IsWidthDefined());
+
+    return width;
   }
 };

--- a/src/Waypoint/WaypointReaderSeeYou.cpp
+++ b/src/Waypoint/WaypointReaderSeeYou.cpp
@@ -201,6 +201,7 @@ bool ParseSeeYou(WaypointFactory factory, Waypoints &waypoints, BufferedReader &
 
   bool tasks { false };
   bool first_line = true;
+  bool has_rwwidth = false;
 
   while ( true ) {
     params_num = ReadCsvRecord(reader, params);
@@ -222,6 +223,7 @@ bool ParseSeeYou(WaypointFactory factory, Waypoints &waypoints, BufferedReader &
          */
         if ( params_num > iRWWidth &&
              params[iRWWidth] == "rwwidth"sv ) {
+          has_rwwidth = true;
           iFrequency = 10;
           iDescription = 11;
         }
@@ -300,7 +302,16 @@ bool ParseSeeYou(WaypointFactory factory, Waypoints &waypoints, BufferedReader &
            rwlen > 0 && rwlen <= 30000)
         new_waypoint.runway.SetLength(uround(rwlen));
 
-      if ( params_num > iRWLen &&
+      // Runway width (e.g. 15.0m; available in newer CUP formats)
+      double rwwidth = -1;
+      if (has_rwwidth &&
+          params_num > iRWWidth &&
+          !params[iRWWidth].empty() &&
+          ParseDistance(params[iRWWidth], rwwidth) &&
+          rwwidth > 0 && rwwidth <= 30000)
+        new_waypoint.runway.SetWidth(uround(rwwidth));
+
+      if ( params_num > iRWDir &&
            !params[iRWDir].empty()) {
         if (auto value = ParseInteger<unsigned>(params[iRWDir])) {
           unsigned direction = *value;

--- a/test/src/TestWaypointReader.cpp
+++ b/test/src/TestWaypointReader.cpp
@@ -153,6 +153,11 @@ TestSeeYou(const wp_vector &org_wp)
     const auto wp2 = GetWaypoint(i, way_points2);
     TestSeeYouWaypoint(i, wp2.get());
   }
+
+  const auto berg2 = way_points2.LookupName("Bergneustadt");
+  ok1(berg2 != nullptr);
+  ok1(berg2 != nullptr && berg2->runway.IsWidthDefined() &&
+      berg2->runway.GetWidth() == 15);
   // Test a SeeYou waypoint file with userdata and pics fields:
   Waypoints way_points3;
   if (!TestWaypointFile(Path("test/data/waypoints3.cup"), way_points3,
@@ -165,6 +170,11 @@ TestSeeYou(const wp_vector &org_wp)
     const auto wp3 = GetWaypoint(i, way_points3);
     TestSeeYouWaypoint(i, wp3.get());
   }
+
+  const auto berg3 = way_points3.LookupName("Bergneustadt");
+  ok1(berg3 != nullptr);
+  ok1(berg3 != nullptr && berg3->runway.IsWidthDefined() &&
+      berg3->runway.GetWidth() == 15);
 }
 
 static void
@@ -491,7 +501,7 @@ int main()
 {
   wp_vector org_wp = CreateOriginalWaypoints();
 
-  plan_tests(507);
+  plan_tests(511);
 
   TestWinPilot(org_wp);
   TestSeeYou(org_wp);


### PR DESCRIPTION
## Summary
- parse SeeYou/CUP `rwwidth` and store it in the waypoint runway model
- display runway size as `length x width` in waypoint details when width is available
- add a read-only waypoint `Type` field in waypoint details and reorder static fields (keeping comment at top)

## Test plan
- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y check` (on source branch before clean cherry-pick)
- [ ] local `check` rerun on clean PR branch (currently blocked by disk space: "No space left on device")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Type field display in waypoint information
  * Runway information now shows both length and width dimensions when available
  * Enhanced import support for See You format files with runway width data
  * Improved waypoint information layout for better visibility of key fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->