### PR TITLE
Terrain/RasterRenderer: Keep OpenGL terrain sampling density

### DIFF
--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -26,6 +26,8 @@ static constexpr double ZOOM_FACTOR_DIVISOR = 4250.0;
 static constexpr unsigned MAX_QUANTISATION_NEAR = 25;
 static constexpr unsigned MAX_QUANTISATION_LOW_ZOOM = 40;
 static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
+static constexpr unsigned BOUNDS_SCALE_NUMERATOR = 3;
+static constexpr unsigned BOUNDS_SCALE_DENOMINATOR = 2;
 
 /**
  * Interpolate between x and y with i/128, i.e. i/(1 << 7).
@@ -195,11 +197,20 @@ RasterRenderer::ScanMap(const RasterMap &map,
   }
 
 #ifdef ENABLE_OPENGL
+  /* Keep the same terrain pixel density as non-OpenGL builds:
+     if we enlarge the geographic bounds, we must enlarge the sampled
+     bitmap dimensions by the same factor. */
+  const auto screen_size = (UnsignedPoint2D)projection.GetScreenSize();
+  const UnsignedPoint2D scaled_screen_size{
+    (screen_size.x * BOUNDS_SCALE_NUMERATOR + 1) / BOUNDS_SCALE_DENOMINATOR,
+    (screen_size.y * BOUNDS_SCALE_NUMERATOR + 1) / BOUNDS_SCALE_DENOMINATOR,
+  };
+
   bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
   bounds.IntersectWith(map.GetBounds());
 
   height_matrix.Fill(map, bounds,
-                     (UnsignedPoint2D)projection.GetScreenSize() / quantisation_pixels,
+                     scaled_screen_size / quantisation_pixels,
                      true);
 
   last_quantisation_pixels = quantisation_pixels;


### PR DESCRIPTION
## Summary
- keep the OpenGL off-screen terrain bounds expansion (`1.5x`) for rotation/panning cache behavior
- scale the sampled terrain bitmap dimensions by the same factor, so OpenGL texel density matches non-OpenGL builds
- preserve existing shading/orientation behavior while removing the GL-vs-non-GL resolution mismatch

Related issue: #2259

## Test plan
- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/dbg/src/Terrain/RasterRenderer.o output/UNIX/dbg/src/Terrain/TerrainRenderer.o`
- [ ] Run full `make -j$(nproc) TARGET=UNIX USE_CCACHE=y check` (currently blocked in this environment by disk space)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terrain rendering calculations for improved performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related to #2259
