### PR TITLE
[mockup] Terrain/OpenGL: shader terrain prototype with perf instrumentation

### DIFF
--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -73,6 +73,9 @@ class GlueMapWindow : public MapWindow {
   KineticManager kinetic_x{std::chrono::milliseconds{700}};
   KineticManager kinetic_y{std::chrono::milliseconds{700}};
   UI::PeriodicTimer kinetic_timer{[this]{ OnKineticTimer(); }};
+  UI::PeriodicTimer terrain_perf_redraw_timer{
+    [this]{ OnTerrainPerfRedrawTimer(); }
+  };
 #endif
 
   /** flag to indicate if the MapItemList should be shown on mouse up */
@@ -306,5 +309,6 @@ private:
 
 #ifdef ENABLE_OPENGL
   void OnKineticTimer() noexcept;
+  void OnTerrainPerfRedrawTimer() noexcept;
 #endif
 };

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -26,12 +26,24 @@
 
 #include <algorithm> // for std::clamp()
 
+#ifdef ENABLE_OPENGL
+/** Temporary perf-testing toggle: force map redraw at 32 Hz. */
+static constexpr bool ENABLE_TERRAIN_PERF_REDRAW_32HZ = true;
+static constexpr auto TERRAIN_PERF_REDRAW_INTERVAL =
+  std::chrono::microseconds{31250};
+#endif
+
 void
 GlueMapWindow::OnCreate()
 {
   MapWindow::OnCreate();
 
   visible_projection.SetScale(CommonInterface::GetMapSettings().cruise_scale);
+
+#ifdef ENABLE_OPENGL
+  if (ENABLE_TERRAIN_PERF_REDRAW_32HZ)
+    terrain_perf_redraw_timer.Schedule(TERRAIN_PERF_REDRAW_INTERVAL);
+#endif
 }
 
 void
@@ -43,6 +55,7 @@ GlueMapWindow::OnDestroy() noexcept
 
 #ifdef ENABLE_OPENGL
   kinetic_timer.Cancel();
+  terrain_perf_redraw_timer.Cancel();
 #endif
 
   map_item_timer.Cancel();
@@ -444,6 +457,13 @@ GlueMapWindow::OnKineticTimer() noexcept
 
   SetLocation(location);
   QuickRedraw();
+}
+
+void
+GlueMapWindow::OnTerrainPerfRedrawTimer() noexcept
+{
+  if (ENABLE_TERRAIN_PERF_REDRAW_32HZ)
+    PartialRedraw();
 }
 
 #endif

--- a/src/Renderer/BackgroundRenderer.cpp
+++ b/src/Renderer/BackgroundRenderer.cpp
@@ -6,6 +6,10 @@
 #include "Projection/WindowProjection.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "NMEA/Derived.hpp"
+#include "LogFile.hpp"
+
+#include <algorithm>
+#include <chrono>
 
 BackgroundRenderer::BackgroundRenderer() noexcept = default;
 BackgroundRenderer::~BackgroundRenderer() noexcept = default;
@@ -29,6 +33,8 @@ BackgroundRenderer::Draw(Canvas& canvas,
                          const WindowProjection& proj,
                          const TerrainRendererSettings &terrain_settings) noexcept
 {
+  using clock = std::chrono::steady_clock;
+
   canvas.ClearWhite();
 
   if (terrain_settings.enable && terrain != nullptr) {
@@ -45,8 +51,57 @@ BackgroundRenderer::Draw(Canvas& canvas,
     }
 
     renderer->SetSettings(terrain_settings);
-    if (renderer->Generate(proj, shading_angle))
+    const auto t0 = clock::now();
+    const bool generated = renderer->Generate(proj, shading_angle);
+    const auto t1 = clock::now();
+
+    const std::uint64_t generate_us =
+      std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+    perf_generate_us_sum += generate_us;
+    perf_generate_us_max = std::max(perf_generate_us_max, generate_us);
+    if (generated)
+      ++perf_generate_true;
+
+    std::uint64_t draw_us = 0;
+    if (generated) {
+      const auto t2 = clock::now();
       renderer->Draw(canvas, proj);
+      const auto t3 = clock::now();
+      draw_us = std::chrono::duration_cast<std::chrono::microseconds>(t3 - t2)
+        .count();
+      perf_draw_us_sum += draw_us;
+      perf_draw_us_max = std::max(perf_draw_us_max, draw_us);
+    }
+
+    ++perf_frames;
+    if (perf_frames >= 120) {
+      const double frames = perf_frames > 0 ? perf_frames : 1;
+      const double draws = perf_generate_true > 0 ? perf_generate_true : 1;
+      LogFmt("Terrain perf: frames={} generate avg={:.3f}ms max={:.3f}ms, "
+             "draw avg={:.3f}ms max={:.3f}ms, draw_calls={}, "
+             "q_pixels={} q_effective={} shader={}",
+             perf_frames,
+             (double)perf_generate_us_sum / frames / 1000.0,
+             (double)perf_generate_us_max / 1000.0,
+             (double)perf_draw_us_sum / draws / 1000.0,
+             (double)perf_draw_us_max / 1000.0,
+             perf_generate_true,
+             renderer->GetQuantisationPixels(),
+             renderer->GetQuantisationEffective(),
+#ifdef ENABLE_OPENGL
+             renderer->IsShaderShadingEnabled() ? "on" : "off"
+#else
+             "off"
+#endif
+      );
+
+      perf_frames = 0;
+      perf_generate_true = 0;
+      perf_generate_us_sum = 0;
+      perf_generate_us_max = 0;
+      perf_draw_us_sum = 0;
+      perf_draw_us_max = 0;
+    }
   }
 }
 
@@ -70,6 +125,14 @@ BackgroundRenderer::SetShadingAngle(const WindowProjection& projection,
     angle = DEFAULT_SHADING_ANGLE;
 
   SetShadingAngle(projection, angle);
+
+#ifdef ENABLE_OPENGL
+  if (settings.slope_shading == SlopeShading::FIXED) {
+    /* Temporary OpenGL mockup: make "Fixed" behave as screen-fixed
+       illumination (lamp attached to the display). */
+    shading_angle = angle - projection.GetScreenAngle();
+  }
+#endif
 }
 
 inline void

--- a/src/Renderer/BackgroundRenderer.cpp
+++ b/src/Renderer/BackgroundRenderer.cpp
@@ -11,6 +11,26 @@
 #include <algorithm>
 #include <chrono>
 
+/**
+ * Temporary perf-testing toggle:
+ * continuously rotate terrain shading to force frequent regenerations.
+ */
+static constexpr bool ENABLE_ROTATING_TERRAIN_SHADING = true;
+static constexpr unsigned ROTATING_TERRAIN_HZ = 32;
+static constexpr double ROTATING_TERRAIN_DEG_PER_TICK = 1.0;
+
+[[gnu::pure]]
+static std::uint64_t
+PercentileFromSorted(const std::uint32_t *sorted,
+                     unsigned count, unsigned p) noexcept
+{
+  if (count == 0)
+    return 0;
+
+  const unsigned index = (count - 1) * p / 100;
+  return sorted[index];
+}
+
 BackgroundRenderer::BackgroundRenderer() noexcept = default;
 BackgroundRenderer::~BackgroundRenderer() noexcept = default;
 
@@ -59,8 +79,25 @@ BackgroundRenderer::Draw(Canvas& canvas,
       std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
     perf_generate_us_sum += generate_us;
     perf_generate_us_max = std::max(perf_generate_us_max, generate_us);
+    perf_generate_samples_us[perf_frames] = (std::uint32_t)
+      std::min<std::uint64_t>(generate_us, UINT32_MAX);
     if (generated)
       ++perf_generate_true;
+    if (generated && renderer->WasLastGenerateCacheHit()) {
+      ++perf_generate_cache_hits;
+    } else if (generated && perf_generate_updates < perf_scan_samples_us.size()) {
+      const std::uint64_t scan_us = renderer->GetLastScanMapUs();
+      const std::uint64_t image_us = renderer->GetLastGenerateImageUs();
+      perf_scan_us_sum += scan_us;
+      perf_scan_us_max = std::max(perf_scan_us_max, scan_us);
+      perf_image_us_sum += image_us;
+      perf_image_us_max = std::max(perf_image_us_max, image_us);
+      perf_scan_samples_us[perf_generate_updates] = (std::uint32_t)
+        std::min<std::uint64_t>(scan_us, UINT32_MAX);
+      perf_image_samples_us[perf_generate_updates] = (std::uint32_t)
+        std::min<std::uint64_t>(image_us, UINT32_MAX);
+      ++perf_generate_updates;
+    }
 
     std::uint64_t draw_us = 0;
     if (generated) {
@@ -77,28 +114,80 @@ BackgroundRenderer::Draw(Canvas& canvas,
     if (perf_frames >= 120) {
       const double frames = perf_frames > 0 ? perf_frames : 1;
       const double draws = perf_generate_true > 0 ? perf_generate_true : 1;
-      LogFmt("Terrain perf: frames={} generate avg={:.3f}ms max={:.3f}ms, "
+      auto sorted_generate = perf_generate_samples_us;
+      std::sort(sorted_generate.begin(), sorted_generate.end());
+      const double generate_p95_ms =
+        (double)PercentileFromSorted(sorted_generate.data(),
+                                     perf_frames, 95) / 1000.0;
+      const double generate_p99_ms =
+        (double)PercentileFromSorted(sorted_generate.data(),
+                                     perf_frames, 99) / 1000.0;
+      const double updates = perf_generate_updates > 0
+        ? perf_generate_updates : 1;
+      auto sorted_scan = perf_scan_samples_us;
+      auto sorted_image = perf_image_samples_us;
+      std::sort(sorted_scan.begin(),
+                sorted_scan.begin() + perf_generate_updates);
+      std::sort(sorted_image.begin(),
+                sorted_image.begin() + perf_generate_updates);
+      const double scan_p95_ms =
+        (double)PercentileFromSorted(sorted_scan.data(),
+                                     perf_generate_updates, 95) / 1000.0;
+      const double scan_p99_ms =
+        (double)PercentileFromSorted(sorted_scan.data(),
+                                     perf_generate_updates, 99) / 1000.0;
+      const double image_p95_ms =
+        (double)PercentileFromSorted(sorted_image.data(),
+                                     perf_generate_updates, 95) / 1000.0;
+      const double image_p99_ms =
+        (double)PercentileFromSorted(sorted_image.data(),
+                                     perf_generate_updates, 99) / 1000.0;
+
+      LogFmt("Terrain perf: frames={} generate avg={:.3f}ms "
+             "p95={:.3f}ms p99={:.3f}ms max={:.3f}ms, "
+             "regen={} cache_hits={}, "
+             "scan avg={:.3f}ms p95={:.3f}ms p99={:.3f}ms max={:.3f}ms, "
+             "image avg={:.3f}ms p95={:.3f}ms p99={:.3f}ms max={:.3f}ms, "
              "draw avg={:.3f}ms max={:.3f}ms, draw_calls={}, "
-             "q_pixels={} q_effective={} shader={}",
+             "q_pixels={} q_effective={} shader={} ramp={}",
              perf_frames,
              (double)perf_generate_us_sum / frames / 1000.0,
+             generate_p95_ms,
+             generate_p99_ms,
              (double)perf_generate_us_max / 1000.0,
+             perf_generate_updates,
+             perf_generate_cache_hits,
+             (double)perf_scan_us_sum / updates / 1000.0,
+             scan_p95_ms,
+             scan_p99_ms,
+             (double)perf_scan_us_max / 1000.0,
+             (double)perf_image_us_sum / updates / 1000.0,
+             image_p95_ms,
+             image_p99_ms,
+             (double)perf_image_us_max / 1000.0,
              (double)perf_draw_us_sum / draws / 1000.0,
              (double)perf_draw_us_max / 1000.0,
              perf_generate_true,
              renderer->GetQuantisationPixels(),
              renderer->GetQuantisationEffective(),
 #ifdef ENABLE_OPENGL
-             renderer->IsShaderShadingEnabled() ? "on" : "off"
+             renderer->IsShaderShadingEnabled() ? "on" : "off",
+             renderer->IsShaderRampEnabled() ? "on" : "off"
 #else
-             "off"
+             "off", "off"
 #endif
       );
 
       perf_frames = 0;
       perf_generate_true = 0;
+      perf_generate_cache_hits = 0;
+      perf_generate_updates = 0;
       perf_generate_us_sum = 0;
       perf_generate_us_max = 0;
+      perf_scan_us_sum = 0;
+      perf_scan_us_max = 0;
+      perf_image_us_sum = 0;
+      perf_image_us_max = 0;
       perf_draw_us_sum = 0;
       perf_draw_us_max = 0;
     }
@@ -110,6 +199,7 @@ BackgroundRenderer::SetShadingAngle(const WindowProjection& projection,
                                     const TerrainRendererSettings &settings,
                                     const DerivedInfo &calculated) noexcept
 {
+  using clock = std::chrono::steady_clock;
   Angle angle;
 
   if (settings.slope_shading == SlopeShading::WIND &&
@@ -123,6 +213,18 @@ BackgroundRenderer::SetShadingAngle(const WindowProjection& projection,
 
   else
     angle = DEFAULT_SHADING_ANGLE;
+
+#ifdef ENABLE_OPENGL
+  if (ENABLE_ROTATING_TERRAIN_SHADING &&
+      settings.slope_shading != SlopeShading::OFF) {
+    static const auto start = clock::now();
+    const auto now = clock::now();
+    const auto elapsed_ms = std::chrono::duration_cast<
+      std::chrono::milliseconds>(now - start).count();
+    const auto ticks = (std::uint64_t)elapsed_ms * ROTATING_TERRAIN_HZ / 1000u;
+    angle += Angle::Degrees((double)ticks * ROTATING_TERRAIN_DEG_PER_TICK);
+  }
+#endif
 
   SetShadingAngle(projection, angle);
 

--- a/src/Renderer/BackgroundRenderer.hpp
+++ b/src/Renderer/BackgroundRenderer.hpp
@@ -5,6 +5,7 @@
 
 #include "Math/Angle.hpp"
 
+#include <cstdint>
 #include <memory>
 
 class Canvas;
@@ -23,6 +24,13 @@ class BackgroundRenderer {
   const RasterTerrain *terrain = nullptr;
   std::unique_ptr<TerrainRenderer> renderer;
   Angle shading_angle = DEFAULT_SHADING_ANGLE;
+
+  unsigned perf_frames = 0;
+  unsigned perf_generate_true = 0;
+  std::uint64_t perf_generate_us_sum = 0;
+  std::uint64_t perf_generate_us_max = 0;
+  std::uint64_t perf_draw_us_sum = 0;
+  std::uint64_t perf_draw_us_max = 0;
 
 #ifdef ENABLE_OPENGL
   /** force full terrain resolution regardless of user idle state */

--- a/src/Renderer/BackgroundRenderer.hpp
+++ b/src/Renderer/BackgroundRenderer.hpp
@@ -5,6 +5,7 @@
 
 #include "Math/Angle.hpp"
 
+#include <array>
 #include <cstdint>
 #include <memory>
 
@@ -27,10 +28,19 @@ class BackgroundRenderer {
 
   unsigned perf_frames = 0;
   unsigned perf_generate_true = 0;
+  unsigned perf_generate_cache_hits = 0;
+  unsigned perf_generate_updates = 0;
   std::uint64_t perf_generate_us_sum = 0;
   std::uint64_t perf_generate_us_max = 0;
   std::uint64_t perf_draw_us_sum = 0;
   std::uint64_t perf_draw_us_max = 0;
+  std::array<std::uint32_t, 120> perf_generate_samples_us{};
+  std::array<std::uint32_t, 120> perf_scan_samples_us{};
+  std::array<std::uint32_t, 120> perf_image_samples_us{};
+  std::uint64_t perf_scan_us_sum = 0;
+  std::uint64_t perf_scan_us_max = 0;
+  std::uint64_t perf_image_us_sum = 0;
+  std::uint64_t perf_image_us_max = 0;
 
 #ifdef ENABLE_OPENGL
   /** force full terrain resolution regardless of user idle state */

--- a/src/Renderer/GeoBitmapRenderer.cpp
+++ b/src/Renderer/GeoBitmapRenderer.cpp
@@ -14,10 +14,11 @@
 #include "ui/canvas/opengl/Program.hpp"
 #include "ui/dim/BulkPoint.hpp"
 
-void
-DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
-              const GeoBounds &bounds,
-              const Projection &projection)
+static void
+DrawGeoBitmapWithShader(const RawBitmap &bitmap, PixelSize bitmap_size,
+                        const GeoBounds &bounds,
+                        const Projection &projection,
+                        GLProgram &shader)
 {
   assert(bounds.IsValid());
 
@@ -48,7 +49,7 @@ DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
     x1, y1,
   };
 
-  OpenGL::texture_shader->Use();
+  shader.Use();
   glEnableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
   glVertexAttribPointer(OpenGL::Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
                         0, coord);
@@ -56,6 +57,35 @@ DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
   glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+}
+
+void
+DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
+              const GeoBounds &bounds,
+              const Projection &projection)
+{
+  DrawGeoBitmapWithShader(bitmap, bitmap_size, bounds, projection,
+                          *OpenGL::texture_shader);
+}
+
+void
+DrawGeoBitmapTerrain(const RawBitmap &bitmap, PixelSize bitmap_size,
+                     const GeoBounds &bounds,
+                     const Projection &projection,
+                     bool shading_enabled,
+                     float light_x, float light_y,
+                     float shading_gain)
+{
+  OpenGL::terrain_texture_shader->Use();
+  glUniform2f(OpenGL::terrain_texture_texel_size,
+              1.0f / bitmap_size.width, 1.0f / bitmap_size.height);
+  glUniform2f(OpenGL::terrain_texture_light_dir, light_x, light_y);
+  glUniform1f(OpenGL::terrain_texture_shading_enabled,
+              shading_enabled ? 1.0f : 0.0f);
+  glUniform1f(OpenGL::terrain_texture_shading_gain, shading_gain);
+
+  DrawGeoBitmapWithShader(bitmap, bitmap_size, bounds, projection,
+                          *OpenGL::terrain_texture_shader);
 }
 
 #endif

--- a/src/Renderer/GeoBitmapRenderer.cpp
+++ b/src/Renderer/GeoBitmapRenderer.cpp
@@ -74,7 +74,8 @@ DrawGeoBitmapTerrain(const RawBitmap &bitmap, PixelSize bitmap_size,
                      const Projection &projection,
                      bool shading_enabled,
                      float light_x, float light_y,
-                     float shading_gain)
+                     float shading_gain,
+                     const RawBitmap *color_ramp_bitmap)
 {
   OpenGL::terrain_texture_shader->Use();
   glUniform2f(OpenGL::terrain_texture_texel_size,
@@ -83,6 +84,14 @@ DrawGeoBitmapTerrain(const RawBitmap &bitmap, PixelSize bitmap_size,
   glUniform1f(OpenGL::terrain_texture_shading_enabled,
               shading_enabled ? 1.0f : 0.0f);
   glUniform1f(OpenGL::terrain_texture_shading_gain, shading_gain);
+  glUniform1f(OpenGL::terrain_texture_use_ramp,
+              color_ramp_bitmap != nullptr ? 1.0f : 0.0f);
+
+  if (color_ramp_bitmap != nullptr) {
+    glActiveTexture(GL_TEXTURE1);
+    color_ramp_bitmap->BindAndGetTexture();
+    glActiveTexture(GL_TEXTURE0);
+  }
 
   DrawGeoBitmapWithShader(bitmap, bitmap_size, bounds, projection,
                           *OpenGL::terrain_texture_shader);

--- a/src/Renderer/GeoBitmapRenderer.hpp
+++ b/src/Renderer/GeoBitmapRenderer.hpp
@@ -29,6 +29,7 @@ DrawGeoBitmapTerrain(const RawBitmap &bitmap, PixelSize bitmap_size,
                      const Projection &projection,
                      bool shading_enabled,
                      float light_x, float light_y,
-                     float shading_gain);
+                     float shading_gain,
+                     const RawBitmap *color_ramp_bitmap);
 
 #endif

--- a/src/Renderer/GeoBitmapRenderer.hpp
+++ b/src/Renderer/GeoBitmapRenderer.hpp
@@ -23,4 +23,12 @@ DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
               const GeoBounds &bounds,
               const Projection &projection);
 
+void
+DrawGeoBitmapTerrain(const RawBitmap &bitmap, PixelSize bitmap_size,
+                     const GeoBounds &bounds,
+                     const Projection &projection,
+                     bool shading_enabled,
+                     float light_x, float light_y,
+                     float shading_gain);
+
 #endif

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -29,6 +29,15 @@ static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
 static constexpr unsigned BOUNDS_SCALE_NUMERATOR = 3;
 static constexpr unsigned BOUNDS_SCALE_DENOMINATOR = 2;
 
+#ifdef ENABLE_OPENGL
+/**
+ * Temporary debug toggle:
+ * - true: OpenGL terrain uses fragment shader hillshade path
+ * - false: OpenGL falls back to legacy CPU slope shading path
+ */
+static constexpr bool ENABLE_OPENGL_TERRAIN_SHADER = true;
+#endif
+
 /**
  * Interpolate between x and y with i/128, i.e. i/(1 << 7).
  *
@@ -245,11 +254,33 @@ RasterRenderer::GenerateImage(bool do_shading,
 
   ContourStart(contour_height_scale);
 
+#ifdef ENABLE_OPENGL
+  if (do_shading && ENABLE_OPENGL_TERRAIN_SHADER) {
+    /* OpenGL path: generate base terrain colors + height alpha;
+       slope shading is applied in fragment shader. */
+    shader_shading_enabled = true;
+    shader_light_x = (float)-sunazimuth.fastsine();
+    shader_light_y = (float)-sunazimuth.fastcosine();
+    const float contrast_gain = std::clamp(contrast / 127.0f, 0.2f, 2.0f);
+    const float brightness_gain = std::clamp(1.0f + brightness / 255.0f,
+                                             0.5f, 1.5f);
+    shader_shading_gain = 0.65f * contrast_gain * brightness_gain;
+    GenerateUnshadedImage(height_scale, contour_height_scale);
+  } else {
+    shader_shading_enabled = false;
+    if (do_shading)
+      GenerateSlopeImage(height_scale, contrast, brightness,
+                         sunazimuth, contour_height_scale);
+    else
+      GenerateUnshadedImage(height_scale, contour_height_scale);
+  }
+#else
   if (do_shading)
     GenerateSlopeImage(height_scale, contrast, brightness,
                        sunazimuth, contour_height_scale);
   else
     GenerateUnshadedImage(height_scale, contour_height_scale);
+#endif
 
   image->SetDirty();
 }
@@ -281,16 +312,28 @@ RasterRenderer::GenerateUnshadedImage(const unsigned height_scale,
         if (contour_interval != contour_row_base ||
             contour_interval != *contour_this_column_base) [[unlikely]] {
           *p++ = oColorBuf[(int)h - 64 * 256];
+#ifdef ENABLE_OPENGL
+          (p - 1)->dummy = h;
+#endif
           *contour_this_column_base = contour_row_base = contour_interval;
         } else {
           *p++ = oColorBuf[h];
+#ifdef ENABLE_OPENGL
+          (p - 1)->dummy = h;
+#endif
         }
       } else if (e.IsWater()) {
         // we're in the water, so look up the color for water
         *p++ = oColorBuf[255];
+#ifdef ENABLE_OPENGL
+        (p - 1)->dummy = 255;
+#endif
       } else {
         /* outside the terrain file bounds: white background */
         *p++ = RawColor(0xff, 0xff, 0xff);
+#ifdef ENABLE_OPENGL
+        (p - 1)->dummy = 0;
+#endif
       }
       contour_this_column_base++;
 
@@ -521,10 +564,13 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
 {
 #ifdef ENABLE_OPENGL
   if (bounds.IsValid() && bounds.Overlaps(projection.GetScreenBounds()))
-    DrawGeoBitmap(*image,
-                  PixelSize{height_matrix.GetSize()},
-                  bounds,
-                  projection);
+    DrawGeoBitmapTerrain(*image,
+                         PixelSize{height_matrix.GetSize()},
+                         bounds,
+                         projection,
+                         shader_shading_enabled,
+                         shader_light_x, shader_light_y,
+                         shader_shading_gain);
 #else
   image->StretchTo(PixelSize{height_matrix.GetSize()},
                    canvas, projection.GetScreenSize(),

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -26,6 +26,8 @@ static constexpr double ZOOM_FACTOR_DIVISOR = 4250.0;
 static constexpr unsigned MAX_QUANTISATION_NEAR = 25;
 static constexpr unsigned MAX_QUANTISATION_LOW_ZOOM = 40;
 static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
+static constexpr unsigned BOUNDS_SCALE_NUMERATOR = 3;
+static constexpr unsigned BOUNDS_SCALE_DENOMINATOR = 2;
 
 /**
  * Interpolate between x and y with i/128, i.e. i/(1 << 7).
@@ -195,11 +197,20 @@ RasterRenderer::ScanMap(const RasterMap &map,
   }
 
 #ifdef ENABLE_OPENGL
+  /* Keep the same terrain pixel density as non-OpenGL builds:
+     if we enlarge the geographic bounds, we must enlarge the sampled
+     bitmap dimensions by the same factor. */
+  const auto screen_size = (UnsignedPoint2D)projection.GetScreenSize();
+  const UnsignedPoint2D scaled_screen_size{
+    (screen_size.x * BOUNDS_SCALE_NUMERATOR + 1) / BOUNDS_SCALE_DENOMINATOR,
+    (screen_size.y * BOUNDS_SCALE_NUMERATOR + 1) / BOUNDS_SCALE_DENOMINATOR,
+  };
+
   bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
   bounds.IntersectWith(map.GetBounds());
 
   height_matrix.Fill(map, bounds,
-                     (UnsignedPoint2D)projection.GetScreenSize() / quantisation_pixels,
+                     scaled_screen_size / quantisation_pixels,
                      true);
 
   last_quantisation_pixels = quantisation_pixels;

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -107,6 +107,9 @@ RasterRenderer::~RasterRenderer() noexcept
   delete[] color_table;
   delete image;
   delete[] contour_column_base;
+#ifdef ENABLE_OPENGL
+  delete shader_color_ramp_image;
+#endif
 }
 
 #ifdef ENABLE_OPENGL
@@ -252,22 +255,25 @@ RasterRenderer::GenerateImage(bool do_shading,
 
   const unsigned contour_height_scale = do_contour? height_scale * 2 : 16;
 
-  ContourStart(contour_height_scale);
-
 #ifdef ENABLE_OPENGL
   if (do_shading && ENABLE_OPENGL_TERRAIN_SHADER) {
     /* OpenGL path: generate base terrain colors + height alpha;
        slope shading is applied in fragment shader. */
     shader_shading_enabled = true;
+    shader_ramp_enabled = !do_contour;
     shader_light_x = (float)-sunazimuth.fastsine();
     shader_light_y = (float)-sunazimuth.fastcosine();
     const float contrast_gain = std::clamp(contrast / 127.0f, 0.2f, 2.0f);
     const float brightness_gain = std::clamp(1.0f + brightness / 255.0f,
                                              0.5f, 1.5f);
     shader_shading_gain = 0.65f * contrast_gain * brightness_gain;
+    if (!shader_ramp_enabled)
+      ContourStart(contour_height_scale);
     GenerateUnshadedImage(height_scale, contour_height_scale);
   } else {
     shader_shading_enabled = false;
+    shader_ramp_enabled = false;
+    ContourStart(contour_height_scale);
     if (do_shading)
       GenerateSlopeImage(height_scale, contrast, brightness,
                          sunazimuth, contour_height_scale);
@@ -275,6 +281,7 @@ RasterRenderer::GenerateImage(bool do_shading,
       GenerateUnshadedImage(height_scale, contour_height_scale);
   }
 #else
+  ContourStart(contour_height_scale);
   if (do_shading)
     GenerateSlopeImage(height_scale, contrast, brightness,
                        sunazimuth, contour_height_scale);
@@ -304,6 +311,16 @@ RasterRenderer::GenerateUnshadedImage(const unsigned height_scale,
       const auto e = *src++;
       if (!e.IsSpecial()) [[likely]] {
         unsigned h = std::max(0, (int)e.GetValue());
+
+#ifdef ENABLE_OPENGL
+        if (shader_ramp_enabled) {
+          h = std::min(254u, h >> height_scale);
+          *p++ = RawColor(0, 0, 0);
+          (p - 1)->dummy = h;
+          contour_this_column_base++;
+          continue;
+        }
+#endif
 
         const unsigned contour_interval =
           ContourInterval(h, contour_height_scale);
@@ -545,6 +562,17 @@ RasterRenderer::PrepareColorTable(const ColorRamp *color_ramp, bool do_water,
       color_table[i + (mag + 64) * 256] = color;
     }
   }
+
+#ifdef ENABLE_OPENGL
+  if (shader_color_ramp_image == nullptr)
+    shader_color_ramp_image = new RawBitmap(PixelSize{256, 1});
+
+  RawColor *ramp = shader_color_ramp_image->GetTopRow();
+  for (unsigned i = 0; i < 256; ++i)
+    ramp[i] = color_table[i + 64 * 256];
+
+  shader_color_ramp_image->SetDirty();
+#endif
 }
 
 void
@@ -570,7 +598,9 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                          projection,
                          shader_shading_enabled,
                          shader_light_x, shader_light_y,
-                         shader_shading_gain);
+                         shader_shading_gain,
+                         shader_ramp_enabled ? shader_color_ramp_image
+                                             : nullptr);
 #else
   image->StretchTo(PixelSize{height_matrix.GetSize()},
                    canvas, projection.GetScreenSize(),

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -52,6 +52,13 @@ class RasterRenderer {
    * texture has to be redrawn.
    */
   GeoBounds bounds = GeoBounds::Invalid();
+
+  /**
+   * OpenGL-only terrain fragment shading parameters.
+   */
+  bool shader_shading_enabled = false;
+  float shader_light_x = 0.0f, shader_light_y = -1.0f;
+  float shader_shading_gain = 1.0f;
 #endif
 
   HeightMatrix height_matrix;
@@ -76,6 +83,14 @@ public:
 
   UnsignedPoint2D GetSize() const noexcept {
     return height_matrix.GetSize();
+  }
+
+  unsigned GetQuantisationPixels() const noexcept {
+    return quantisation_pixels;
+  }
+
+  unsigned GetQuantisationEffective() const noexcept {
+    return quantisation_effective;
   }
 
 #ifdef ENABLE_OPENGL
@@ -105,6 +120,10 @@ public:
 
   const GeoBounds &GetBounds() const noexcept {
     return bounds;
+  }
+
+  bool IsShaderShadingEnabled() const noexcept {
+    return shader_shading_enabled;
   }
 
   const GLTexture &BindAndGetTexture() const noexcept;

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -57,8 +57,11 @@ class RasterRenderer {
    * OpenGL-only terrain fragment shading parameters.
    */
   bool shader_shading_enabled = false;
+  bool shader_ramp_enabled = false;
   float shader_light_x = 0.0f, shader_light_y = -1.0f;
   float shader_shading_gain = 1.0f;
+
+  RawBitmap *shader_color_ramp_image = nullptr;
 #endif
 
   HeightMatrix height_matrix;
@@ -124,6 +127,10 @@ public:
 
   bool IsShaderShadingEnabled() const noexcept {
     return shader_shading_enabled;
+  }
+
+  bool IsShaderRampEnabled() const noexcept {
+    return shader_ramp_enabled;
   }
 
   const GLTexture &BindAndGetTexture() const noexcept;

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -7,7 +7,15 @@
 #include "Projection/WindowProjection.hpp"
 #include "util/Macros.hpp"
 
+#include <chrono>
 #include <cassert>
+
+/**
+ * Temporary perf-testing toggle:
+ * force terrain regeneration while slope shading is enabled by
+ * disabling the sun-azimuth rough-equality cache shortcut.
+ */
+static constexpr bool ENABLE_TERRAIN_PERF_FORCE_REGEN = true;
 
 static constexpr ColorRamp terrain_colors[][NUM_COLOR_RAMP_LEVELS] = {
   {
@@ -326,6 +334,14 @@ bool
 TerrainRenderer::Generate(const WindowProjection &map_projection,
                           const Angle sunazimuth)
 {
+  using clock = std::chrono::steady_clock;
+  last_scan_map_us = 0;
+  last_generate_image_us = 0;
+  bool sunazimuth_unchanged = sunazimuth.CompareRoughly(last_sun_azimuth);
+  if (ENABLE_TERRAIN_PERF_FORCE_REGEN &&
+      settings.slope_shading != SlopeShading::OFF)
+    sunazimuth_unchanged = false;
+
 #ifdef ENABLE_OPENGL
   const GeoBounds &old_bounds = raster_renderer.GetBounds();
   GeoBounds new_bounds = map_projection.GetScreenBounds();
@@ -333,29 +349,36 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
 
   {
     RasterTerrain::Lease map(terrain);
-    if (!new_bounds.IntersectWith(map->GetBounds()))
+    if (!new_bounds.IntersectWith(map->GetBounds())) {
       /* map is outside of visible screen area */
+      last_generate_cache_hit = false;
       return false;
+    }
   }
 
   if (old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
       !IsLargeSizeDifference(old_bounds, new_bounds) &&
       terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth) &&
-      !raster_renderer.UpdateQuantisation())
+      sunazimuth_unchanged &&
+      !raster_renderer.UpdateQuantisation()) {
     /* no change since previous frame */
+    last_generate_cache_hit = true;
     return true;
+  }
 
 #else
   if (compare_projection.Compare(map_projection) &&
       terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth))
+      sunazimuth_unchanged) {
     /* no change since previous frame */
+    last_generate_cache_hit = true;
     return true;
+  }
 
   compare_projection = CompareProjection(map_projection);
 #endif
 
+  last_generate_cache_hit = false;
   terrain_serial = terrain.GetSerial();
 
   last_sun_azimuth = sunazimuth;
@@ -376,14 +399,22 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
     last_color_ramp = color_ramp;
   }
 
+  const auto t0 = clock::now();
   {
     RasterTerrain::Lease map(terrain);
     raster_renderer.ScanMap(map, map_projection);
   }
+  const auto t1 = clock::now();
+  last_scan_map_us = (std::uint32_t)std::chrono::duration_cast<
+    std::chrono::microseconds>(t1 - t0).count();
 
+  const auto t2 = clock::now();
   raster_renderer.GenerateImage(do_shading, height_scale,
                                 settings.contrast, settings.brightness,
                                 sunazimuth,
                                 do_contour);
+  const auto t3 = clock::now();
+  last_generate_image_us = (std::uint32_t)std::chrono::duration_cast<
+    std::chrono::microseconds>(t3 - t2).count();
   return true;
 }

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -82,4 +82,18 @@ public:
   void Draw(Canvas &canvas, const WindowProjection &projection) const {
     raster_renderer.Draw(canvas, projection);
   }
+
+  unsigned GetQuantisationPixels() const noexcept {
+    return raster_renderer.GetQuantisationPixels();
+  }
+
+  unsigned GetQuantisationEffective() const noexcept {
+    return raster_renderer.GetQuantisationEffective();
+  }
+
+#ifdef ENABLE_OPENGL
+  bool IsShaderShadingEnabled() const noexcept {
+    return raster_renderer.IsShaderShadingEnabled();
+  }
+#endif
 };

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -7,6 +7,8 @@
 #include "util/Serial.hpp"
 #include "Terrain/TerrainSettings.hpp"
 
+#include <cstdint>
+
 #ifndef ENABLE_OPENGL
 #include "Projection/CompareProjection.hpp"
 #endif
@@ -31,6 +33,9 @@ protected:
   Angle last_sun_azimuth = Angle::Zero();
 
   const ColorRamp *last_color_ramp = nullptr;
+  bool last_generate_cache_hit = false;
+  std::uint32_t last_scan_map_us = 0;
+  std::uint32_t last_generate_image_us = 0;
 
   RasterRenderer raster_renderer;
 
@@ -91,9 +96,25 @@ public:
     return raster_renderer.GetQuantisationEffective();
   }
 
+  bool WasLastGenerateCacheHit() const noexcept {
+    return last_generate_cache_hit;
+  }
+
+  std::uint32_t GetLastScanMapUs() const noexcept {
+    return last_scan_map_us;
+  }
+
+  std::uint32_t GetLastGenerateImageUs() const noexcept {
+    return last_generate_image_us;
+  }
+
 #ifdef ENABLE_OPENGL
   bool IsShaderShadingEnabled() const noexcept {
     return raster_renderer.IsShaderShadingEnabled();
+  }
+
+  bool IsShaderRampEnabled() const noexcept {
+    return raster_renderer.IsShaderRampEnabled();
   }
 #endif
 };

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -380,6 +380,7 @@ Canvas::DrawCircle(PixelPoint center, unsigned radius) noexcept
   if (brush.IsHollow()) {
     OpenGL::circle_outline_shader->Use();
     pen.GetColor().Uniform(OpenGL::circle_outline_color);
+    glUniform1f(OpenGL::circle_outline_feather, 1.0f);
 
     glUniform2f(OpenGL::circle_outline_center, center.x, center.y);
     glUniform1f(OpenGL::circle_outline_radius2, radius);
@@ -390,6 +391,7 @@ Canvas::DrawCircle(PixelPoint center, unsigned radius) noexcept
     OpenGL::filled_circle_shader->Use();
     pen.GetColor().Uniform(OpenGL::filled_circle_color2);
     brush.BindUniform(OpenGL::filled_circle_color1);
+    glUniform1f(OpenGL::filled_circle_feather, 1.0f);
 
     glUniform2f(OpenGL::filled_circle_center, center.x, center.y);
     glUniform1f(OpenGL::filled_circle_radius2, radius);

--- a/src/ui/canvas/opengl/Shaders.cpp
+++ b/src/ui/canvas/opengl/Shaders.cpp
@@ -18,6 +18,12 @@ GLint solid_projection, solid_modelview, solid_translate;
 GLProgram *texture_shader;
 GLint texture_projection, texture_texture, texture_translate;
 
+GLProgram *terrain_texture_shader;
+GLint terrain_texture_projection, terrain_texture_texture,
+  terrain_texture_translate, terrain_texture_texel_size,
+  terrain_texture_light_dir, terrain_texture_shading_enabled,
+  terrain_texture_shading_gain;
+
 GLProgram *invert_shader;
 GLint invert_projection, invert_texture, invert_translate;
 
@@ -101,6 +107,83 @@ static constexpr char texture_fragment_shader[] =
     varying vec2 texcoordvar;
     void main() {
       gl_FragColor = texture2D(texture, texcoordvar);
+    }
+)glsl";
+
+static const char *const terrain_texture_vertex_shader = texture_vertex_shader;
+static constexpr char terrain_texture_fragment_shader[] =
+  GLSL_VERSION
+  GLSL_PRECISION
+  R"glsl(
+    uniform sampler2D texture;
+    uniform vec2 texel_size;
+    uniform vec2 light_dir;
+    uniform float shading_enabled;
+    uniform float shading_gain;
+    varying vec2 texcoordvar;
+    void main() {
+      vec4 c = texture2D(texture, texcoordvar);
+
+      if (shading_enabled > 0.5) {
+        vec2 tx = vec2(texel_size.x, 0.0);
+        vec2 ty = vec2(0.0, texel_size.y);
+
+        float h00 = texture2D(texture, texcoordvar - tx - ty).a;
+        float h10 = texture2D(texture, texcoordvar      - ty).a;
+        float h20 = texture2D(texture, texcoordvar + tx - ty).a;
+        float h01 = texture2D(texture, texcoordvar - tx     ).a;
+        float h11 = c.a;
+        float h21 = texture2D(texture, texcoordvar + tx     ).a;
+        float h02 = texture2D(texture, texcoordvar - tx + ty).a;
+        float h12 = texture2D(texture, texcoordvar      + ty).a;
+        float h22 = texture2D(texture, texcoordvar + tx + ty).a;
+
+        /* Sobel-like local gradient for smoother shading than simple
+           central differences on quantised height. */
+        vec2 grad = vec2(
+          (h20 + 2.0 * h21 + h22) - (h00 + 2.0 * h01 + h02),
+          (h02 + 2.0 * h12 + h22) - (h00 + 2.0 * h10 + h20)
+        ) * 0.25;
+
+        float grad_mag = abs(grad.x) + abs(grad.y) + abs(h11 - 0.5) * 0.0;
+        if (grad_mag < 0.0005) {
+          /* Fallback for targets where alpha may not carry height. */
+          vec3 c00 = texture2D(texture, texcoordvar - tx - ty).rgb;
+          vec3 c10 = texture2D(texture, texcoordvar      - ty).rgb;
+          vec3 c20 = texture2D(texture, texcoordvar + tx - ty).rgb;
+          vec3 c01 = texture2D(texture, texcoordvar - tx     ).rgb;
+          vec3 c21 = texture2D(texture, texcoordvar + tx     ).rgb;
+          vec3 c02 = texture2D(texture, texcoordvar - tx + ty).rgb;
+          vec3 c12 = texture2D(texture, texcoordvar      + ty).rgb;
+          vec3 c22 = texture2D(texture, texcoordvar + tx + ty).rgb;
+
+          float y00 = dot(c00, vec3(0.299, 0.587, 0.114));
+          float y10 = dot(c10, vec3(0.299, 0.587, 0.114));
+          float y20 = dot(c20, vec3(0.299, 0.587, 0.114));
+          float y01 = dot(c01, vec3(0.299, 0.587, 0.114));
+          float y21 = dot(c21, vec3(0.299, 0.587, 0.114));
+          float y02 = dot(c02, vec3(0.299, 0.587, 0.114));
+          float y12 = dot(c12, vec3(0.299, 0.587, 0.114));
+          float y22 = dot(c22, vec3(0.299, 0.587, 0.114));
+
+          grad = vec2(
+            (y20 + 2.0 * y21 + y22) - (y00 + 2.0 * y01 + y02),
+            (y02 + 2.0 * y12 + y22) - (y00 + 2.0 * y10 + y20)
+          ) * 0.5;
+        } else {
+          grad *= 255.0;
+        }
+
+        float illum = dot(normalize(vec3(-grad.x * shading_gain,
+                                         -grad.y * shading_gain,
+                                         1.0)),
+                          normalize(vec3(light_dir, 0.7)));
+        float shade = smoothstep(-0.35, 0.95, illum);
+        shade = 0.62 + 0.46 * shade;
+        c.rgb *= shade;
+      }
+
+      gl_FragColor = vec4(c.rgb, 1.0);
     }
 )glsl";
 
@@ -307,6 +390,34 @@ OpenGL::InitShaders()
   texture_shader->Use();
   glUniform1i(texture_texture, 0);
 
+  terrain_texture_shader = CompileProgram(terrain_texture_vertex_shader,
+                                          terrain_texture_fragment_shader);
+  terrain_texture_shader->BindAttribLocation(Attribute::POSITION, "position");
+  terrain_texture_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
+  LinkProgram(*terrain_texture_shader);
+
+  terrain_texture_projection =
+    terrain_texture_shader->GetUniformLocation("projection");
+  terrain_texture_texture =
+    terrain_texture_shader->GetUniformLocation("texture");
+  terrain_texture_translate =
+    terrain_texture_shader->GetUniformLocation("translate");
+  terrain_texture_texel_size =
+    terrain_texture_shader->GetUniformLocation("texel_size");
+  terrain_texture_light_dir =
+    terrain_texture_shader->GetUniformLocation("light_dir");
+  terrain_texture_shading_enabled =
+    terrain_texture_shader->GetUniformLocation("shading_enabled");
+  terrain_texture_shading_gain =
+    terrain_texture_shader->GetUniformLocation("shading_gain");
+
+  terrain_texture_shader->Use();
+  glUniform1i(terrain_texture_texture, 0);
+  glUniform2f(terrain_texture_texel_size, 1.0f / 1024.0f, 1.0f / 1024.0f);
+  glUniform2f(terrain_texture_light_dir, 0.0f, -1.0f);
+  glUniform1f(terrain_texture_shading_enabled, 0.0f);
+  glUniform1f(terrain_texture_shading_gain, 1.0f);
+
   invert_shader = CompileProgram(invert_vertex_shader, invert_fragment_shader);
   invert_shader->BindAttribLocation(Attribute::POSITION, "position");
   invert_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
@@ -402,6 +513,8 @@ OpenGL::DeinitShaders() noexcept
   invert_shader = nullptr;
   delete texture_shader;
   texture_shader = nullptr;
+  delete terrain_texture_shader;
+  terrain_texture_shader = nullptr;
   delete solid_shader;
   solid_shader = nullptr;
 }
@@ -419,6 +532,10 @@ OpenGL::UpdateShaderProjectionMatrix() noexcept
 
   texture_shader->Use();
   glUniformMatrix4fv(texture_projection, 1, GL_FALSE,
+                     glm::value_ptr(projection_matrix));
+
+  terrain_texture_shader->Use();
+  glUniformMatrix4fv(terrain_texture_projection, 1, GL_FALSE,
                      glm::value_ptr(projection_matrix));
 
   solid_shader->Use();
@@ -453,6 +570,9 @@ OpenGL::UpdateShaderTranslate() noexcept
 
   texture_shader->Use();
   glUniform2f(texture_translate, t.x, t.y);
+
+  terrain_texture_shader->Use();
+  glUniform2f(terrain_texture_translate, t.x, t.y);
 
   invert_shader->Use();
   glUniform2f(invert_translate, t.x, t.y);

--- a/src/ui/canvas/opengl/Shaders.cpp
+++ b/src/ui/canvas/opengl/Shaders.cpp
@@ -22,7 +22,8 @@ GLProgram *terrain_texture_shader;
 GLint terrain_texture_projection, terrain_texture_texture,
   terrain_texture_translate, terrain_texture_texel_size,
   terrain_texture_light_dir, terrain_texture_shading_enabled,
-  terrain_texture_shading_gain;
+  terrain_texture_shading_gain, terrain_texture_ramp,
+  terrain_texture_use_ramp;
 
 GLProgram *invert_shader;
 GLint invert_projection, invert_texture, invert_translate;
@@ -41,12 +42,12 @@ GLint dashed_projection, dashed_translate,
 GLProgram *circle_outline_shader;
 GLint circle_outline_projection, circle_outline_translate,
   circle_outline_center, circle_outline_radius1, circle_outline_radius2,
-  circle_outline_color;
+  circle_outline_color, circle_outline_feather;
 
 GLProgram *filled_circle_shader;
 GLint filled_circle_projection, filled_circle_translate,
   filled_circle_center, filled_circle_radius1, filled_circle_radius2,
-  filled_circle_color1, filled_circle_color2;
+  filled_circle_color1, filled_circle_color2, filled_circle_feather;
 
 } // namespace OpenGL
 
@@ -116,13 +117,19 @@ static constexpr char terrain_texture_fragment_shader[] =
   GLSL_PRECISION
   R"glsl(
     uniform sampler2D texture;
+    uniform sampler2D terrain_ramp;
     uniform vec2 texel_size;
     uniform vec2 light_dir;
     uniform float shading_enabled;
     uniform float shading_gain;
+    uniform float use_ramp;
     varying vec2 texcoordvar;
     void main() {
       vec4 c = texture2D(texture, texcoordvar);
+      vec3 base_rgb = c.rgb;
+
+      if (use_ramp > 0.5)
+        base_rgb = texture2D(terrain_ramp, vec2(c.a, 0.5)).rgb;
 
       if (shading_enabled > 0.5) {
         vec2 tx = vec2(texel_size.x, 0.0);
@@ -180,10 +187,10 @@ static constexpr char terrain_texture_fragment_shader[] =
                           normalize(vec3(light_dir, 0.7)));
         float shade = smoothstep(-0.35, 0.95, illum);
         shade = 0.62 + 0.46 * shade;
-        c.rgb *= shade;
+        base_rgb *= shade;
       }
 
-      gl_FragColor = vec4(c.rgb, 1.0);
+      gl_FragColor = vec4(base_rgb, 1.0);
     }
 )glsl";
 
@@ -293,12 +300,16 @@ static constexpr char circle_outline_fragment_shader[] =
     uniform vec2 center;
     uniform float radius1;
     uniform float radius2;
+    uniform float feather;
     uniform vec4 color;
     varying highp vec2 vert_pos;
     void main() {
       float distance = distance(center, vert_pos);
-      if (distance < radius1 || distance > radius2) discard;
-      gl_FragColor = color;
+      float a_inner = smoothstep(radius1 - feather, radius1 + feather, distance);
+      float a_outer = 1.0 - smoothstep(radius2 - feather, radius2 + feather, distance);
+      float alpha = a_inner * a_outer;
+      if (alpha <= 0.001) discard;
+      gl_FragColor = vec4(color.rgb, color.a * alpha);
     }
 )glsl";
 
@@ -309,17 +320,18 @@ static constexpr char filled_circle_fragment_shader[] =
     uniform vec2 center;
     uniform float radius1;
     uniform float radius2;
+    uniform float feather;
     uniform vec4 color1;
     uniform vec4 color2;
     varying highp vec2 vert_pos;
     void main() {
       float distance = distance(center, vert_pos);
-      if (distance > radius2) discard;
+      float alpha_outer = 1.0 - smoothstep(radius2 - feather, radius2 + feather, distance);
+      if (alpha_outer <= 0.001) discard;
 
-      if (distance < radius1)
-        gl_FragColor = color1;
-      else
-        gl_FragColor = color2;
+      float mix_ring = smoothstep(radius1 - feather, radius1 + feather, distance);
+      vec4 c = mix(color1, color2, mix_ring);
+      gl_FragColor = vec4(c.rgb, c.a * alpha_outer);
     }
 )glsl";
 
@@ -410,13 +422,19 @@ OpenGL::InitShaders()
     terrain_texture_shader->GetUniformLocation("shading_enabled");
   terrain_texture_shading_gain =
     terrain_texture_shader->GetUniformLocation("shading_gain");
+  terrain_texture_ramp =
+    terrain_texture_shader->GetUniformLocation("terrain_ramp");
+  terrain_texture_use_ramp =
+    terrain_texture_shader->GetUniformLocation("use_ramp");
 
   terrain_texture_shader->Use();
   glUniform1i(terrain_texture_texture, 0);
+  glUniform1i(terrain_texture_ramp, 1);
   glUniform2f(terrain_texture_texel_size, 1.0f / 1024.0f, 1.0f / 1024.0f);
   glUniform2f(terrain_texture_light_dir, 0.0f, -1.0f);
   glUniform1f(terrain_texture_shading_enabled, 0.0f);
   glUniform1f(terrain_texture_shading_gain, 1.0f);
+  glUniform1f(terrain_texture_use_ramp, 0.0f);
 
   invert_shader = CompileProgram(invert_vertex_shader, invert_fragment_shader);
   invert_shader->BindAttribLocation(Attribute::POSITION, "position");
@@ -482,6 +500,10 @@ OpenGL::InitShaders()
   circle_outline_radius1 = circle_outline_shader->GetUniformLocation("radius1");
   circle_outline_radius2 = circle_outline_shader->GetUniformLocation("radius2");
   circle_outline_color = circle_outline_shader->GetUniformLocation("color");
+  circle_outline_feather = circle_outline_shader->GetUniformLocation("feather");
+
+  circle_outline_shader->Use();
+  glUniform1f(circle_outline_feather, 1.0f);
 
   filled_circle_shader = CompileProgram(circle_vertex_shader, filled_circle_fragment_shader);
   filled_circle_shader->BindAttribLocation(Attribute::POSITION, "position");
@@ -494,6 +516,10 @@ OpenGL::InitShaders()
   filled_circle_radius2 = filled_circle_shader->GetUniformLocation("radius2");
   filled_circle_color1 = filled_circle_shader->GetUniformLocation("color1");
   filled_circle_color2 = filled_circle_shader->GetUniformLocation("color2");
+  filled_circle_feather = filled_circle_shader->GetUniformLocation("feather");
+
+  filled_circle_shader->Use();
+  glUniform1f(filled_circle_feather, 1.0f);
 }
 
 void

--- a/src/ui/canvas/opengl/Shaders.hpp
+++ b/src/ui/canvas/opengl/Shaders.hpp
@@ -22,6 +22,15 @@ extern GLProgram *texture_shader;
 extern GLint texture_projection, texture_texture, solid_translate;
 
 /**
+ * A shader dedicated to terrain texture rendering.
+ */
+extern GLProgram *terrain_texture_shader;
+extern GLint terrain_texture_projection, terrain_texture_texture,
+  terrain_texture_translate, terrain_texture_texel_size,
+  terrain_texture_light_dir, terrain_texture_shading_enabled,
+  terrain_texture_shading_gain;
+
+/**
  * A shader that copies the inverted texture.
  */
 extern GLProgram *invert_shader;

--- a/src/ui/canvas/opengl/Shaders.hpp
+++ b/src/ui/canvas/opengl/Shaders.hpp
@@ -28,7 +28,8 @@ extern GLProgram *terrain_texture_shader;
 extern GLint terrain_texture_projection, terrain_texture_texture,
   terrain_texture_translate, terrain_texture_texel_size,
   terrain_texture_light_dir, terrain_texture_shading_enabled,
-  terrain_texture_shading_gain;
+  terrain_texture_shading_gain, terrain_texture_ramp,
+  terrain_texture_use_ramp;
 
 /**
  * A shader that copies the inverted texture.
@@ -63,7 +64,7 @@ extern GLint dashed_projection, dashed_translate,
 extern GLProgram *circle_outline_shader;
 extern GLint circle_outline_projection, circle_outline_translate,
   circle_outline_center, circle_outline_radius1, circle_outline_radius2,
-  circle_outline_color;
+  circle_outline_color, circle_outline_feather;
 
 /**
  * A shader that draws a filled circle.
@@ -71,7 +72,7 @@ extern GLint circle_outline_projection, circle_outline_translate,
 extern GLProgram *filled_circle_shader;
 extern GLint filled_circle_projection, filled_circle_translate,
   filled_circle_center, filled_circle_radius1, filled_circle_radius2,
-  filled_circle_color1, filled_circle_color2;
+  filled_circle_color1, filled_circle_color2, filled_circle_feather;
 
 /**
  * Throws on error.


### PR DESCRIPTION
## Summary
- add OpenGL terrain shader prototype with GPU hillshading and ramp-based color lookup from height alpha
- add detailed terrain performance logging (avg/p95/p99/max), including regeneration/cache-hit and scan/image phase breakdown
- add temporary mockup stress toggles for rotating shading, forced 32 Hz redraw, and forced regeneration to benchmark worst-case behavior

## Test plan
- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- [x] run XCSoar on OpenGL target and confirm `shader=on` and `ramp=on` terrain perf logs
- [x] verify stress mode logs show `regen=120` with stable phase timings
- [ ] validate on lower-end OpenGL ES hardware (e.g. Mali-400 / Cubieboard)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terrain surfaces now support dynamic directional lighting and shading effects
  * Added color mapping for enhanced terrain elevation visualization

* **Improvements**
  * Enhanced circle rendering in the user interface with improved feathering for smoother appearance
  * Added performance monitoring and metrics tracking for terrain rendering operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->