### PR TITLE
Terrain/RasterRenderer: More aggressive use of interpolation

### DIFF
--- a/src/Terrain/RasterBuffer.cpp
+++ b/src/Terrain/RasterBuffer.cpp
@@ -124,7 +124,7 @@ RasterBuffer::ScanHorizontalLine(unsigned ax, unsigned bx, unsigned y,
      axis, which can have a different scale, making the factor some
      sort of ugly kludge to avoid horizontal shading stripes */
   if (interpolate &&
-      (unsigned)abs(dx) < (2 * size << RasterTraits::SUBPIXEL_BITS)) {
+      (unsigned)abs(dx) < (3 * size << RasterTraits::SUBPIXEL_BITS)) {
     /* interpolate */
 
     const auto [cy, iy] = RasterTraits::CalcSubpixel(y);


### PR DESCRIPTION
Reduces the visibility of line artifacts for intermediate zoom values. Improves, but does not fully eliminate #2268

This comes at the cost of slightly different-looking artifacts (but less distracting, I think).
Also at the cost of a higher CPU load at the relevant zoom levels.

It similarly improves (but does not fully remove) the artifacts from the OpenGL version, which appear once the factor 1.5 resolution bug in the OpenGL path is fixed (#2259).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted terrain interpolation logic for improved rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->