### PR TITLE
Android/USB: Use package name for USB permission action

### DIFF
--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -29,7 +29,7 @@ import com.felhr.usbserial.UsbSerialDevice;
 public final class UsbSerialHelper extends BroadcastReceiver {
 
   private static final String TAG = "UsbSerialHelper";
-  private static final String ACTION_USB_PERMISSION = "org.xcsoar.otg.action.USB_PERMISSION";
+  private final String ACTION_USB_PERMISSION;
 
   private final Context context;
   private final UsbManager usbmanager;
@@ -338,6 +338,7 @@ public final class UsbSerialHelper extends BroadcastReceiver {
 
   private UsbSerialHelper(Context context) throws IOException {
     this.context = context;
+    ACTION_USB_PERMISSION = context.getPackageName() + ".otg.action.USB_PERMISSION";
 
     usbmanager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
     if (usbmanager == null)
@@ -372,7 +373,7 @@ public final class UsbSerialHelper extends BroadcastReceiver {
       : 0;
     PendingIntent pi =
       PendingIntent.getBroadcast(context, 0,
-                                 new Intent(UsbSerialHelper.ACTION_USB_PERMISSION),
+                                 new Intent(ACTION_USB_PERMISSION),
                                  flags);
 
     usbmanager.requestPermission(device, pi);


### PR DESCRIPTION
This is to avoid a TESTING package and a regular package installed on the same Android device to register their permissions with the same package name.

I admit that I do not really know how Android permissions work, but seems like the right thing to do to avoid this?
Or is it better to have the permissions under a common package name?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved USB permission handling implementation with enhanced instance-level control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->