### PR TITLE
Terrain/RasterRenderer: Fix fluctuating shading strength

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,7 @@ Version 7.45 - not yet released
 * map
   - obstacles hidden at wider map scales than other non-landables (5000 vs 10000)
   - draw up to 1024 waypoints at once (was 256) #2327
+  - terrain: fix fluctuating hill-shading strength #2262
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
 * calculations

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -140,15 +140,11 @@ void
 RasterRenderer::ScanMap(const RasterMap &map,
                         const WindowProjection &projection) noexcept
 {
-  // Coordinates of the MapWindow center
-  const auto p = projection.GetScreenCenter();
   // GeoPoint corresponding to the MapWindow center
-  GeoPoint center = projection.ScreenToGeo(p);
-  // GeoPoint "next to" Gmid (depends on terrain resolution)
-  GeoPoint neighbor = projection.ScreenToGeo(p + PixelSize{quantisation_pixels});
+  GeoPoint center = projection.ScreenToGeo(projection.GetScreenCenter());
 
-  // Geographical edge length of pixel in the MapWindow center in meters
-  pixel_size = M_SQRT1_2 * center.DistanceS(neighbor);
+  // Geographical edge length of one height matrix cell in meters
+  pixel_size = quantisation_pixels / projection.GetScale();
 
   // set resolution
 


### PR DESCRIPTION
Eliminates a rounding issue with the determination of pixel size used for slope calculation, and removes unused const symbols. 

Fixes #2262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified terrain rendering calculations for more efficient and consistent map rendering.

* **Bug Fix**
  * Fixed fluctuating hill‑shading strength so terrain shading remains stable and visually consistent (noted for upcoming v7.45).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->