### PR TITLE
UsbSerialhelper: Set package to permission intent

### DIFF
--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -371,10 +371,10 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     int flags = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
       ? PendingIntent.FLAG_IMMUTABLE
       : 0;
+    Intent intent = new Intent(ACTION_USB_PERMISSION);
+    intent.setPackage(context.getPackageName());
     PendingIntent pi =
-      PendingIntent.getBroadcast(context, 0,
-                                 new Intent(ACTION_USB_PERMISSION),
-                                 flags);
+      PendingIntent.getBroadcast(context, 0, intent, flags);
 
     usbmanager.requestPermission(device, pi);
   }


### PR DESCRIPTION
As requested by @lordfolken 

While checking this I realized there are more things off.  I will make a separate PR for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB permission request handling on Android to enhance security and reliability when accessing connected devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->