### PR TITLE
net/client/WeGlide/UploadIGCFile: Warn when aircraft type is unset

### DIFF
--- a/src/net/client/WeGlide/UploadIGCFile.cpp
+++ b/src/net/client/WeGlide/UploadIGCFile.cpp
@@ -106,6 +106,13 @@ UploadFile(Path igc_path)
   uint32_t glider_id = CommonInterface::GetComputerSettings().plane
     .weglide_glider_type;
 
+  if (glider_id == 0) {
+    ShowMessageBox(_("Please set WeGlide Aircraft Type in Plane profile "
+                     "before uploading."),
+                   _("WeGlide Upload"), MB_OK | MB_ICONINFORMATION);
+    return {};
+  }
+
   PluggableOperationEnvironment env;
 
   auto value = ShowCoFunctionDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),


### PR DESCRIPTION
## Summary
- show an actionable dialog when WeGlide upload is triggered with `weglide_glider_type == 0`
- abort upload before sending a request with `aircraft_id=0`, avoiding the confusing `400 Aircraft not found` server response
- keep the fix scoped to the upload path and reference issue #2279

## Test plan
- [ ] Configure WeGlide with valid pilot data but leave Plane profile WeGlide type unset (`0`)
- [ ] Trigger flight upload from logger download flow and verify the new warning dialog appears
- [ ] Verify no HTTP upload is attempted in that case
- [ ] Set a valid WeGlide aircraft type (e.g. `492`) and verify upload still succeeds

Closes #2279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent flight uploads when aircraft type is not configured. Users now receive a prompt to set the WeGlide Aircraft Type in their Plane profile before uploading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->