### PR TITLE
build: Sync Android APK/AAB resource PNG lists

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -304,8 +304,8 @@ PNG8a := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_SPLASH_3
 $(PNG8a): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 
-####### white title for dark mode (RGBA PNGs with alpha)
-PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
+####### title PNGs with alpha (normal + white)
+PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_320_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
 $(PNG8): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -280,7 +280,7 @@ $(PNG6): $(DRAWABLE_DIR)/gesture_%.png: doc/manual/figures/gesture_%.svg | $(DRA
 	$(Q)rsvg-convert --width=82 --height=82 $< -o $@
 
 ####### permission disclosure graphics from SVG sources
-PNG7 := $(DRAWABLE_DIR)/location_pin.png $(DRAWABLE_DIR)/notification_bell.png $(DRAWABLE_DIR)/bluetooth.png $(DRAWABLE_DIR)/warning_triangle.png
+PNG7 := $(DRAWABLE_DIR)/location_pin.png $(DRAWABLE_DIR)/notification_bell.png $(DRAWABLE_DIR)/bluetooth.png $(DRAWABLE_DIR)/warning_triangle.png $(DRAWABLE_DIR)/rotate.png
 $(PNG7): $(DRAWABLE_DIR)/%.png: Data/graphics/%.svg | $(DRAWABLE_DIR)/dirstamp
 	$(Q)rsvg-convert --width=80 --height=80 $< -o $@
 
@@ -289,8 +289,8 @@ PNG8a := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_SPLASH_3
 $(PNG8a): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 
-####### white title for dark mode (RGBA PNGs with alpha)
-PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
+####### title PNGs with alpha (normal + white)
+PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_320_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
 $(PNG8): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 


### PR DESCRIPTION
## Summary
- keep Android APK and Android App Bundle drawable lists in sync for shared PNG resource groups
- include `rotate.png` in the AAB `PNG7` list so the Android rotate button resource resolves in bundle builds
- include `title_320_rgba` in both APK/AAB `PNG8` lists to match `IDB_TITLE_HD_RGBA` resource usage

## Test plan
- [x] inspect `build/android.mk` and `build/android_bundle.mk` variable parity for `PNG7` and `PNG8`
- [ ] run `make -j$(nproc) TARGET=ANDROIDFAT ANDROID_BUNDLE_BUILD=y PLAY=y DEBUG=y USE_CCACHE=y`
- [ ] install and launch the bundle build on device; verify no `Resource not found: drawable/rotate` or `Resource not found: drawable/title_320_rgba` in logcat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Android build configurations to expand asset processing for title PNG variants and permission graphics in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->