### PR TITLE
WeGlide: Add cached aircraft type picker and lookup

### DIFF
--- a/build/libclient.mk
+++ b/build/libclient.mk
@@ -4,6 +4,8 @@ ifeq ($(HAVE_HTTP),y)
 
 LIBCLIENT_SOURCES = \
 	$(SRC)/net/client/tim/Client.cpp \
+	$(SRC)/net/client/WeGlide/AircraftCache.cpp \
+	$(SRC)/net/client/WeGlide/AircraftList.cpp \
 	$(SRC)/net/client/WeGlide/Error.cpp \
 	$(SRC)/net/client/WeGlide/DownloadTask.cpp \
 	$(SRC)/net/client/WeGlide/ListTasks.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -66,6 +66,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/ProfileListDialog.cpp \
 	$(SRC)/Dialogs/Plane/PlaneListDialog.cpp \
 	$(SRC)/Dialogs/Plane/PlaneDetailsDialog.cpp \
+	$(SRC)/Dialogs/Plane/WeGlideTypePicker.cpp \
 	$(SRC)/Dialogs/Plane/PlanePolarDialog.cpp \
 	$(SRC)/Dialogs/Plane/PolarShapeEditWidget.cpp \
 	$(SRC)/Dialogs/DataField.cpp \

--- a/src/Dialogs/Plane/PlaneDetailsDialog.cpp
+++ b/src/Dialogs/Plane/PlaneDetailsDialog.cpp
@@ -2,10 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "PlaneDialogs.hpp"
+#include "WeGlideTypePicker.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Form/Button.hpp"
+#include "Form/DataField/Integer.hpp"
 #include "Form/DataField/Listener.hpp"
+#include "net/client/WeGlide/AircraftList.hpp"
 #include "Plane/Plane.hpp"
 #include "Language/Language.hpp"
 #include "Interface.hpp"
@@ -26,6 +29,7 @@ class PlaneEditWidget final
     DUMP_TIME,
     MAX_SPEED,
     WEGLIDE_ID,
+    WEGLIDE_NAME,
   };
 
   WndForm *dialog;
@@ -43,6 +47,7 @@ public:
 
   void UpdateCaption() noexcept;
   void UpdatePolarButton() noexcept;
+  void UpdateWeGlideName() noexcept;
   void PolarButtonClicked() noexcept;
 
   /* virtual methods from Widget */
@@ -53,6 +58,28 @@ private:
   /* methods from DataFieldListener */
   void OnModified(DataField &df) noexcept override;
 };
+
+static bool
+EditWeGlideType([[maybe_unused]] const char *caption, DataField &df,
+                [[maybe_unused]] const char *help_text)
+{
+  if (df.GetType() != DataField::Type::INTEGER)
+    return false;
+
+  auto &integer = static_cast<DataFieldInteger &>(df);
+  const int current_value = integer.GetValue();
+  unsigned weglide_type = current_value > 0
+    ? static_cast<unsigned>(current_value)
+    : 0;
+
+  if (!SelectWeGlideAircraftType(weglide_type,
+                                 CommonInterface::GetComputerSettings()
+                                   .weglide))
+    return false;
+
+  integer.ModifyValue(static_cast<int>(weglide_type));
+  return true;
+}
 
 void
 PlaneEditWidget::UpdateCaption() noexcept
@@ -80,10 +107,32 @@ PlaneEditWidget::UpdatePolarButton() noexcept
 }
 
 void
+PlaneEditWidget::UpdateWeGlideName() noexcept
+{
+  if (!CommonInterface::GetComputerSettings().weglide.enabled)
+    return;
+
+  if (plane.weglide_glider_type == 0) {
+    SetText(WEGLIDE_NAME, "-");
+    return;
+  }
+
+  StaticString<96> name;
+  if (WeGlide::LookupAircraftTypeName(plane.weglide_glider_type, name))
+    SetText(WEGLIDE_NAME, name.c_str());
+  else
+    SetText(WEGLIDE_NAME, _("Unknown"));
+}
+
+void
 PlaneEditWidget::OnModified(DataField &df) noexcept
 {
   if (IsDataField(REGISTRATION, df))
     UpdateCaption();
+  else if (IsDataField(WEGLIDE_ID, df)) {
+    SaveValueInteger(WEGLIDE_ID, plane.weglide_glider_type);
+    UpdateWeGlideName();
+  }
 }
 
 void
@@ -117,16 +166,19 @@ PlaneEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
            "%.0f %s", "%.0f", 0, 300, 5,
            false, UnitGroup::HORIZONTAL_SPEED, plane.max_speed);
 
-  /* TODO: this should be a select list from
-     https://api.weglide.org/v1/aircraft */
-  if (CommonInterface::GetComputerSettings().weglide.enabled)
-    AddInteger(_("WeGlide Type"), nullptr, "%d", "%d", 1, 999,
-               1, plane.weglide_glider_type);
-  else
+  if (CommonInterface::GetComputerSettings().weglide.enabled) {
+    auto *row = AddInteger(_("WeGlide Type"), nullptr, "%u", "%u", 0,
+                           9999, 1, plane.weglide_glider_type, this);
+    row->SetEditCallback(EditWeGlideType);
+    AddReadOnly(_("WeGlide Aircraft"), nullptr, "");
+  } else {
     AddDummy();
+    AddDummy();
+  }
 
   UpdateCaption();
   UpdatePolarButton();
+  UpdateWeGlideName();
 }
 
 bool
@@ -144,7 +196,6 @@ PlaneEditWidget::Save(bool &_changed) noexcept
   changed |= SaveValueInteger(DUMP_TIME, plane.dump_time);
   changed |= SaveValue(MAX_SPEED, UnitGroup::HORIZONTAL_SPEED,
                        plane.max_speed);
-
   if (CommonInterface::GetComputerSettings().weglide.enabled)
     changed |= SaveValueInteger(WEGLIDE_ID, plane.weglide_glider_type);
 

--- a/src/Dialogs/Plane/WeGlideTypePicker.cpp
+++ b/src/Dialogs/Plane/WeGlideTypePicker.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "WeGlideTypePicker.hpp"
+
+#include "Dialogs/CoFunctionDialog.hpp"
+#include "Dialogs/ListPicker.hpp"
+#include "Dialogs/Message.hpp"
+#include "Language/Language.hpp"
+#include "Look/DialogLook.hpp"
+#include "Operation/PluggableOperationEnvironment.hpp"
+#include "Renderer/TextRowListItemRenderer.hpp"
+#include "UIGlobals.hpp"
+#include "net/client/WeGlide/AircraftList.hpp"
+#ifdef HAVE_HTTP
+#include "net/http/Init.hpp"
+#endif
+
+#include <cinttypes>
+#include <algorithm>
+#include <vector>
+
+class WeGlideAircraftRenderer final : public TextRowListItemRenderer {
+  const std::vector<WeGlide::AircraftType> &list;
+
+public:
+  explicit WeGlideAircraftRenderer(
+      const std::vector<WeGlide::AircraftType> &_list) noexcept
+    :list(_list) {}
+
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned i) noexcept override {
+    StaticString<128> label;
+    label.Format("%s (%" PRIu32 ")", list[i].name.c_str(), list[i].id);
+    row_renderer.DrawTextRow(canvas, rc, label);
+  }
+};
+
+static std::vector<WeGlide::AircraftType>
+DownloadAircraftTypes([[maybe_unused]] const WeGlideSettings &settings)
+{
+#ifdef HAVE_HTTP
+  if (Net::curl == nullptr)
+    return {};
+
+  PluggableOperationEnvironment env;
+  const auto value = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
+                                          UIGlobals::GetDialogLook(),
+                                          _("Download"),
+                                          WeGlide::DownloadAircraftList(
+                                            *Net::curl, settings, env),
+                                          &env);
+  if (!value)
+    return {};
+
+  return *value;
+#else
+  return {};
+#endif
+}
+
+bool
+LookupWeGlideAircraftTypeName(unsigned aircraft_id,
+                              StaticString<96> &name)
+{
+  return WeGlide::LookupAircraftTypeName(aircraft_id, name);
+}
+
+bool
+SelectWeGlideAircraftType(unsigned &aircraft_id,
+                          const WeGlideSettings &settings)
+{
+  auto list = WeGlide::LoadAircraftListCache();
+  if (list.empty())
+    list = DownloadAircraftTypes(settings);
+
+  if (list.empty()) {
+    ShowMessageBox(_("Could not load WeGlide aircraft list."),
+                   _("WeGlide Type"), MB_OK | MB_ICONEXCLAMATION);
+    return false;
+  }
+
+  const unsigned old_aircraft_id = aircraft_id;
+
+  const auto find_index = [&list](unsigned id) -> unsigned {
+    const auto i = std::find_if(list.begin(), list.end(),
+                                [id](const auto &item){
+                                  return item.id == id;
+                                });
+    return i != list.end()
+      ? static_cast<unsigned>(std::distance(list.begin(), i))
+      : 0;
+  };
+
+  unsigned initial_index = find_index(aircraft_id);
+
+  WeGlideAircraftRenderer renderer(list);
+  while (true) {
+    const int result = ListPicker(_("Select WeGlide Type"),
+                                  list.size(), initial_index,
+                                  renderer.CalculateLayout(
+                                    UIGlobals::GetDialogLook()),
+                                  renderer, false,
+                                  nullptr,
+                                  nullptr,
+                                  _("Refresh"));
+
+    if (result >= 0) {
+      aircraft_id = list[result].id;
+      return aircraft_id != old_aircraft_id;
+    }
+
+    if (result == -2) {
+      auto refreshed = DownloadAircraftTypes(settings);
+      if (refreshed.empty()) {
+        ShowMessageBox(_("Could not load WeGlide aircraft list."),
+                       _("WeGlide Type"), MB_OK | MB_ICONEXCLAMATION);
+        continue;
+      }
+
+      list = std::move(refreshed);
+      initial_index = find_index(aircraft_id);
+      continue;
+    }
+
+    return false;
+  }
+}

--- a/src/Dialogs/Plane/WeGlideTypePicker.hpp
+++ b/src/Dialogs/Plane/WeGlideTypePicker.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StaticString.hxx"
+
+struct WeGlideSettings;
+
+bool
+SelectWeGlideAircraftType(unsigned &aircraft_id,
+                          const WeGlideSettings &settings);
+
+bool
+LookupWeGlideAircraftTypeName(unsigned aircraft_id,
+                              StaticString<96> &name);

--- a/src/net/client/WeGlide/AircraftCache.cpp
+++ b/src/net/client/WeGlide/AircraftCache.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "AircraftCache.hpp"
+
+#include "LocalPath.hpp"
+#include "io/FileLineReader.hpp"
+#include "io/FileOutputStream.hxx"
+#include "system/FileUtil.hpp"
+#include "json/Serialize.hxx"
+
+#include <boost/json.hpp>
+
+#include <string>
+
+namespace WeGlide {
+
+static constexpr auto kAircraftCacheFile = "weglide-aircraft-v1.json";
+
+static AllocatedPath
+GetAircraftCachePath() noexcept
+{
+  return AllocatedPath::Build(GetCachePath(), kAircraftCacheFile);
+}
+
+bool
+LoadAircraftListCacheValue(boost::json::value &value)
+{
+  std::string json;
+
+  try {
+    FileLineReaderA reader(GetAircraftCachePath());
+    const char *line;
+    while ((line = reader.ReadLine()) != nullptr) {
+      json += line;
+      json += '\n';
+    }
+  } catch (...) {
+    return false;
+  }
+
+  if (json.empty())
+    return false;
+
+  try {
+    value = boost::json::parse(json);
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+void
+StoreAircraftListCacheValue(const boost::json::value &value)
+{
+  Directory::Create(GetCachePath());
+  FileOutputStream file(GetAircraftCachePath());
+  Json::Serialize(file, value);
+  file.Commit();
+}
+
+} // namespace WeGlide

--- a/src/net/client/WeGlide/AircraftCache.hpp
+++ b/src/net/client/WeGlide/AircraftCache.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <boost/json/fwd.hpp>
+
+namespace WeGlide {
+
+bool
+LoadAircraftListCacheValue(boost::json::value &value);
+
+void
+StoreAircraftListCacheValue(const boost::json::value &value);
+
+} // namespace WeGlide

--- a/src/net/client/WeGlide/AircraftList.cpp
+++ b/src/net/client/WeGlide/AircraftList.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "AircraftList.hpp"
+#include "AircraftCache.hpp"
+#include "Settings.hpp"
+#include "LogFile.hpp"
+#include "util/StringCompare.hxx"
+
+#ifdef HAVE_HTTP
+#include "Error.hpp"
+#include "json/ParserOutputStream.hxx"
+#include "net/http/Progress.hpp"
+#include "lib/curl/CoStreamRequest.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
+#include "lib/fmt/ToBuffer.hxx"
+#endif
+
+#include <boost/json.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <string_view>
+
+using std::string_view_literals::operator""sv;
+
+namespace WeGlide {
+
+static std::vector<AircraftType>
+ParseAircraftList(const boost::json::value &value)
+{
+  std::vector<AircraftType> list;
+  if (!value.is_array())
+    return list;
+
+  list.reserve(value.as_array().size());
+  for (const auto &entry : value.as_array()) {
+    if (!entry.is_object())
+      continue;
+
+    const auto &obj = entry.as_object();
+    auto *id = obj.if_contains("id"sv);
+    auto *name = obj.if_contains("name"sv);
+    if (id == nullptr || name == nullptr ||
+        !id->is_number() || !name->is_string())
+      continue;
+
+    AircraftType item;
+    item.id = id->to_number<uint32_t>();
+    item.name = name->as_string().c_str();
+    list.push_back(item);
+  }
+
+  std::sort(list.begin(), list.end(),
+            [](const auto &a, const auto &b){
+              return StringCollate(a.name, b.name) < 0;
+            });
+  return list;
+}
+
+std::vector<AircraftType>
+LoadAircraftListCache()
+{
+  boost::json::value value;
+  if (!LoadAircraftListCacheValue(value))
+    return {};
+
+  return ParseAircraftList(value);
+}
+
+bool
+LookupAircraftTypeName(unsigned aircraft_id,
+                       StaticString<96> &name)
+{
+  const auto list = LoadAircraftListCache();
+  auto i = std::find_if(list.begin(), list.end(),
+                        [aircraft_id](const auto &item){
+                          return item.id == aircraft_id;
+                        });
+  if (i == list.end())
+    return false;
+
+  name = i->name;
+  return true;
+}
+
+#ifdef HAVE_HTTP
+
+Co::Task<std::vector<AircraftType>>
+DownloadAircraftList(::CurlGlobal &curl, const WeGlideSettings &settings,
+                     ProgressListener &progress)
+{
+  const auto url = FmtBuffer<256>("{}/aircraft", settings.default_url);
+  CurlEasy easy{url};
+
+  Curl::Setup(easy);
+  easy.SetTimeout(25);
+  const Net::ProgressAdapter progress_adapter{easy, progress};
+
+  Json::ParserOutputStream parser;
+  const auto response =
+    co_await Curl::CoStreamRequest(curl, std::move(easy), parser);
+  auto body = parser.Finish();
+
+  if (response.status != 200)
+    throw ResponseToException(response.status, body);
+
+  auto parsed = ParseAircraftList(body);
+  if (!parsed.empty()) {
+    try {
+      StoreAircraftListCacheValue(body);
+    } catch (const std::exception &e) {
+      LogFmt("WeGlide: failed to update aircraft cache: {}", e.what());
+    }
+  }
+
+  co_return parsed;
+}
+
+#endif
+
+} // namespace WeGlide

--- a/src/net/client/WeGlide/AircraftList.hpp
+++ b/src/net/client/WeGlide/AircraftList.hpp
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StaticString.hxx"
+
+#ifdef HAVE_HTTP
+#include "co/Task.hxx"
+#endif
+
+#include <cstdint>
+#include <vector>
+
+struct WeGlideSettings;
+class ProgressListener;
+class CurlGlobal;
+
+namespace WeGlide {
+
+struct AircraftType {
+  uint32_t id = 0;
+  StaticString<96> name;
+};
+
+#ifdef HAVE_HTTP
+
+std::vector<AircraftType>
+LoadAircraftListCache();
+
+bool
+LookupAircraftTypeName(unsigned aircraft_id,
+                       StaticString<96> &name);
+
+Co::Task<std::vector<AircraftType>>
+DownloadAircraftList(::CurlGlobal &curl, const WeGlideSettings &settings,
+                     ProgressListener &progress);
+
+#else
+
+inline std::vector<AircraftType>
+LoadAircraftListCache()
+{
+  return {};
+}
+
+inline bool
+LookupAircraftTypeName([[maybe_unused]] unsigned aircraft_id,
+                       [[maybe_unused]] StaticString<96> &name)
+{
+  return false;
+}
+
+#endif
+
+} // namespace WeGlide

--- a/src/net/client/WeGlide/UploadIGCFile.cpp
+++ b/src/net/client/WeGlide/UploadIGCFile.cpp
@@ -7,6 +7,7 @@
 #ifdef HAVE_HTTP
 
 #include "UploadFlight.hpp"
+#include "AircraftList.hpp"
 #include "Settings.hpp"
 #include "Interface.hpp"
 #include "UIGlobals.hpp"
@@ -25,10 +26,10 @@
 #include <cinttypes>
 
 // Wrapper for getting converted string values of a json string
-static const std::string_view
-GetJsonString(boost::json::value json_value, std::string_view key)
+static std::string_view
+GetJsonString(const boost::json::object &json_object, std::string_view key)
 {
-  return json_value.at(key).get_string().c_str();
+  return json_object.at(key).as_string().c_str();
 }
 
 namespace WeGlide {
@@ -50,6 +51,8 @@ struct FlightData {
   uint64_t flight_id = 0;
   User user;
   Aircraft aircraft;
+  uint32_t uploaded_aircraft_id = 0;
+  StaticString<0x40> uploaded_aircraft_name;
   StaticString<0x40> scoring_date;
   StaticString<0x40> registration;
   StaticString<0x40> competition_id;
@@ -60,17 +63,17 @@ UploadJsonInterpreter(const boost::json::value &json)
 {
   FlightData flight_data;
   // flight is the 1st flight object in this array ('at(0)')
-  auto flight = json.as_array().at(0);
+  const auto &flight = json.as_array().at(0).as_object();
   flight_data.scoring_date = GetJsonString(flight, "scoring_date").data();
   flight_data.flight_id = flight.at("id").to_number<int64_t>();
   flight_data.registration = GetJsonString(flight, "registration").data();
   flight_data.competition_id = GetJsonString(flight, "competition_id").data();
 
-  auto user = flight.at("user").as_object();
+  const auto &user = flight.at("user").as_object();
   flight_data.user.id = user.at("id").to_number<uint32_t>();
   flight_data.user.name = GetJsonString(user, "name").data();
 
-  auto aircraft = flight.at("aircraft").as_object();
+  const auto &aircraft = flight.at("aircraft").as_object();
   flight_data.aircraft.id = aircraft.at("id").to_number<uint32_t>();
   flight_data.aircraft.name = GetJsonString(aircraft, "name").data();
   flight_data.aircraft.kind = GetJsonString(aircraft, "kind").data();
@@ -87,12 +90,18 @@ UploadSuccessDialog(const FlightData &flight_data) noexcept
   // TODO: Create a real Dialog with fields in 'src/Dialogs/Cloud/weglide'!
   // With this Dialog insert the possibilty to update/patch the flight
   // f.e. copilot in double seater, scoring class, short comment and so on
+  const auto uploaded_aircraft_name =
+    flight_data.uploaded_aircraft_name.empty()
+    ? "-"
+    : flight_data.uploaded_aircraft_name.c_str();
   const auto display_string = fmt::format("{}: {}\n{}: {}\n{}: {} ({})\n"
-                                             "{}: {} ({})\n{}: {}, {}: {}",
+                                             "{}: {} ({}) / {} ({})\n"
+                                             "{}: {}, {}: {}",
     "Flight ID", flight_data.flight_id,
     _("Date"), flight_data.scoring_date.c_str(),
     _("Username"), flight_data.user.name.c_str(), flight_data.user.id,
     _("Plane"), flight_data.aircraft.name.c_str(), flight_data.aircraft.id,
+    uploaded_aircraft_name, flight_data.uploaded_aircraft_id,
     _("Registration"), flight_data.registration.c_str(),
     _("Comp. ID"), flight_data.competition_id.c_str());
 
@@ -124,7 +133,15 @@ UploadFile(Path igc_path)
     return {};
 
   // read the important data from json in a structure
-  return UploadJsonInterpreter(*value);
+  auto flight_data = UploadJsonInterpreter(*value);
+  flight_data.uploaded_aircraft_id = glider_id;
+  StaticString<96> long_name;
+  if (LookupAircraftTypeName(glider_id, long_name))
+    flight_data.uploaded_aircraft_name = long_name.c_str();
+  else
+    flight_data.uploaded_aircraft_name.clear();
+
+  return flight_data;
 }
 
 bool


### PR DESCRIPTION
## Summary
- add a WeGlide aircraft-list client with cache support and centralized ID-to-name lookup
- wire the plane profile `WeGlide Type` field to a list picker while keeping the integer ID as canonical
- show a read-only resolved aircraft name in plane details and include selected glider name/id in upload feedback

References: WeGlide failed upload issue.

## Test plan
- [x] Build with `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- [x] Open Plane Details, click `WeGlide Type`, verify picker opens and ID updates
- [x] Verify read-only `WeGlide Aircraft` updates with ID changes
- [x] Verify cache is stored under cache path (`GetCachePath()`)
- [x] Verify upload success message includes selected glider name/id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a WeGlide aircraft type picker dialog for selecting aircraft.
  * Implemented local caching of WeGlide aircraft data for faster access and offline use.
  * Enhanced Plane Details dialog to show and edit WeGlide aircraft type and display the aircraft name.
  * Upload flow now records and shows the selected/uploaded aircraft name and ID in the upload summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->