### PR TITLE
ui/canvas: Fix clipped child painting on memory canvas

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -47,6 +47,10 @@ Version 7.45 - not yet released
 * iOS
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380
+* kobo
+  - memory canvas: fix painting when list rows or edit fields are partially
+    off-screen while scrolling (no black squares; safer clipping of subcanvas
+    and list blits) #2293
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/src/Form/Edit.cpp
+++ b/src/Form/Edit.cpp
@@ -299,6 +299,19 @@ WndProperty::DecValue() noexcept
 void
 WndProperty::OnPaint(Canvas &canvas) noexcept
 {
+  PixelRect visible_edit_rc = edit_rc;
+  const int canvas_width = (int)canvas.GetWidth();
+  const int canvas_height = (int)canvas.GetHeight();
+
+  if (visible_edit_rc.left < 0)
+    visible_edit_rc.left = 0;
+  if (visible_edit_rc.top < 0)
+    visible_edit_rc.top = 0;
+  if (visible_edit_rc.right > canvas_width)
+    visible_edit_rc.right = canvas_width;
+  if (visible_edit_rc.bottom > canvas_height)
+    visible_edit_rc.bottom = canvas_height;
+
   const bool focused = HasCursorKeys() && HasFocus();
 
   /* background and selector */
@@ -365,26 +378,28 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
     text_color = look.dark_mode ? COLOR_GRAY : COLOR_DARK_GRAY;
   }
 
-  canvas.DrawFilledRectangle(edit_rc, background_color);
+  if (!visible_edit_rc.IsEmpty()) {
+    canvas.DrawFilledRectangle(visible_edit_rc, background_color);
 
-  canvas.SelectHollowBrush();
-  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
-                    look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
-  canvas.DrawRectangle(edit_rc);
+    canvas.SelectHollowBrush();
+    canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
+                      look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
+    canvas.DrawRectangle(visible_edit_rc);
+  }
 
-  if (!value.empty()) {
+  if (!value.empty() && !visible_edit_rc.IsEmpty()) {
     canvas.SetTextColor(text_color);
     canvas.SetBackgroundTransparent();
     canvas.Select(look.text_font);
 
-    const int x = edit_rc.left + Layout::GetTextPadding() * 2;
-    const int canvas_height = edit_rc.GetHeight();
+    const int x = visible_edit_rc.left + Layout::GetTextPadding() * 2;
+    const int control_height = visible_edit_rc.GetHeight();
     const int text_height = canvas.GetFontHeight();
-    const int y = edit_rc.top + (canvas_height - text_height) / 2;
+    const int y = visible_edit_rc.top + (control_height - text_height) / 2;
 
     // determine available pixel width for text inside edit rect
     const int avail = std::max(0,
-                  static_cast<int>(edit_rc.GetWidth()) -
+                  static_cast<int>(visible_edit_rc.GetWidth()) -
                   static_cast<int>(Layout::GetTextPadding()) * 4);
 
     // measure full text width

--- a/src/ui/canvas/memory/Canvas.hpp
+++ b/src/ui/canvas/memory/Canvas.hpp
@@ -56,6 +56,20 @@ public:
     buffer = _buffer;
   }
 
+  /**
+   * Copy drawing state (pen/brush/font/colors) from another canvas.
+   * This is useful when painting to temporary canvases that should
+   * behave exactly like the caller's canvas.
+   */
+  void CopyStateFrom(const Canvas &other) noexcept {
+    pen = other.pen;
+    brush = other.brush;
+    font = other.font;
+    text_color = other.text_color;
+    background_color = other.background_color;
+    background_mode = other.background_mode;
+  }
+
 protected:
   /**
    * Returns true if the outline should be drawn after the area has

--- a/src/ui/canvas/memory/SubCanvas.cpp
+++ b/src/ui/canvas/memory/SubCanvas.cpp
@@ -16,7 +16,33 @@ SubCanvas::SubCanvas(Canvas &canvas,
                      PixelPoint _offset, PixelSize _size) noexcept
 {
   buffer = canvas.buffer;
-  buffer.data = buffer.At(_offset.x, _offset.y);
-  buffer.size.width = ClipMax(buffer.size.width, _offset.x, _size.width);
-  buffer.size.height = ClipMax(buffer.size.height, _offset.y, _size.height);
+
+  int offset_x = _offset.x;
+  int offset_y = _offset.y;
+  unsigned size_width = _size.width;
+  unsigned size_height = _size.height;
+
+  if (offset_x < 0) {
+    const unsigned clipped = std::min(size_width, unsigned(-offset_x));
+    size_width -= clipped;
+    offset_x = 0;
+  }
+
+  if (offset_y < 0) {
+    const unsigned clipped = std::min(size_height, unsigned(-offset_y));
+    size_height -= clipped;
+    offset_y = 0;
+  }
+
+  buffer.size.width = ClipMax(buffer.size.width, offset_x, size_width);
+  buffer.size.height = ClipMax(buffer.size.height, offset_y, size_height);
+
+  if (buffer.size.width == 0 || buffer.size.height == 0) {
+    /* Do not leave buffer.data pointing at the parent: IsDefined() must be
+       false for a zero-sized subcanvas. */
+    buffer = WritableImageBuffer<ActivePixelTraits>::Empty();
+    return;
+  }
+
+  buffer.data = buffer.At(offset_x, offset_y);
 }

--- a/src/ui/window/custom/WList.cpp
+++ b/src/ui/window/custom/WList.cpp
@@ -221,31 +221,33 @@ WindowList::Paint(Canvas &canvas) noexcept
         WritableImageBuffer<ActivePixelTraits>::Empty();
       scratch.Allocate(child_size);
 
+      const PixelPoint src_pos{
+        std::max(0, -child_pos.x),
+        std::max(0, -child_pos.y),
+      };
+      const PixelPoint dest_pos{
+        std::max(0, child_pos.x),
+        std::max(0, child_pos.y),
+      };
+      /* std::min of signed extents can be negative; PixelSize is unsigned and
+         would wrap to huge values and bypass the > 0 guards below. */
+      const int copy_w = std::max(
+        0, std::min((int)child_size.width - src_pos.x,
+                    (int)canvas.GetWidth() - dest_pos.x));
+      const int copy_h = std::max(
+        0, std::min((int)child_size.height - src_pos.y,
+                    (int)canvas.GetHeight() - dest_pos.y));
+      const PixelSize copy_size{
+        static_cast<unsigned>(copy_w),
+        static_cast<unsigned>(copy_h),
+      };
+
       {
         Canvas offscreen_canvas(scratch);
         offscreen_canvas.CopyStateFrom(canvas);
+        if (copy_size.width > 0 && copy_size.height > 0)
+          offscreen_canvas.Copy(src_pos, copy_size, canvas, dest_pos);
         child.OnPaint(offscreen_canvas);
-
-        const PixelPoint src_pos{
-          std::max(0, -child_pos.x),
-          std::max(0, -child_pos.y),
-        };
-        const PixelPoint dest_pos{
-          std::max(0, child_pos.x),
-          std::max(0, child_pos.y),
-        };
-        /* std::min of signed extents can be negative; PixelSize is unsigned and
-           would wrap to huge values and bypass the > 0 guards below. */
-        const int copy_w = std::max(
-          0, std::min((int)child_size.width - src_pos.x,
-                      (int)canvas.GetWidth() - dest_pos.x));
-        const int copy_h = std::max(
-          0, std::min((int)child_size.height - src_pos.y,
-                      (int)canvas.GetHeight() - dest_pos.y));
-        const PixelSize copy_size{
-          static_cast<unsigned>(copy_w),
-          static_cast<unsigned>(copy_h),
-        };
 
         if (copy_size.width > 0 && copy_size.height > 0)
           canvas.Copy(dest_pos, copy_size, offscreen_canvas, src_pos);

--- a/src/ui/window/custom/WList.cpp
+++ b/src/ui/window/custom/WList.cpp
@@ -223,6 +223,7 @@ WindowList::Paint(Canvas &canvas) noexcept
 
       {
         Canvas offscreen_canvas(scratch);
+        offscreen_canvas.CopyStateFrom(canvas);
         child.OnPaint(offscreen_canvas);
 
         const PixelPoint src_pos{

--- a/src/ui/window/custom/WList.cpp
+++ b/src/ui/window/custom/WList.cpp
@@ -4,7 +4,12 @@
 #include "WList.hpp"
 #include "../ContainerWindow.hpp"
 #include "ui/canvas/SubCanvas.hpp"
+#ifdef USE_MEMORY_CANVAS
+#include "ui/canvas/memory/ActivePixelTraits.hpp"
+#include "ui/canvas/memory/Buffer.hpp"
+#endif
 
+#include <algorithm>
 #include <iterator>
 
 void
@@ -202,6 +207,53 @@ WindowList::Paint(Canvas &canvas) noexcept
     PaintWindow &child = (PaintWindow &)*i;
     if (!child.IsVisible())
       continue;
+
+#ifdef USE_MEMORY_CANVAS
+    const PixelPoint child_pos = child.GetTopLeft();
+    const PixelSize child_size = child.GetSize();
+    const bool partially_outside =
+      child_pos.x < 0 || child_pos.y < 0 ||
+      child_pos.x + (int)child_size.width > (int)canvas.GetWidth() ||
+      child_pos.y + (int)child_size.height > (int)canvas.GetHeight();
+
+    if (partially_outside) {
+      WritableImageBuffer<ActivePixelTraits> scratch =
+        WritableImageBuffer<ActivePixelTraits>::Empty();
+      scratch.Allocate(child_size);
+
+      {
+        Canvas offscreen_canvas(scratch);
+        child.OnPaint(offscreen_canvas);
+
+        const PixelPoint src_pos{
+          std::max(0, -child_pos.x),
+          std::max(0, -child_pos.y),
+        };
+        const PixelPoint dest_pos{
+          std::max(0, child_pos.x),
+          std::max(0, child_pos.y),
+        };
+        /* std::min of signed extents can be negative; PixelSize is unsigned and
+           would wrap to huge values and bypass the > 0 guards below. */
+        const int copy_w = std::max(
+          0, std::min((int)child_size.width - src_pos.x,
+                      (int)canvas.GetWidth() - dest_pos.x));
+        const int copy_h = std::max(
+          0, std::min((int)child_size.height - src_pos.y,
+                      (int)canvas.GetHeight() - dest_pos.y));
+        const PixelSize copy_size{
+          static_cast<unsigned>(copy_w),
+          static_cast<unsigned>(copy_h),
+        };
+
+        if (copy_size.width > 0 && copy_size.height > 0)
+          canvas.Copy(dest_pos, copy_size, offscreen_canvas, src_pos);
+      }
+
+      scratch.Free();
+      continue;
+    }
+#endif
 
     SubCanvas sub_canvas(canvas, child.GetTopLeft(),
                          child.GetSize());


### PR DESCRIPTION
## Summary
- fix memory-canvas subcanvas creation when children are partially outside the parent viewport by clamping negative offsets before calculating the pixel pointer
- preserve scrolling and paint correctness for partially clipped children by using an offscreen scratch path in `WindowList::Paint`
- copy drawing state and prefill scratch content from the parent canvas before child paint to avoid black artifacts and keep text/background rendering consistent

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX OPENGL=n USE_CCACHE=y SANITIZE=address`
- [ ] Reproduce and verify in `Setup -> Tracking` with `OPENGL=n`: no scroll crash and no black square artifacts
- [ ] Smoke test unrelated list/dialog scrolling paths on memory canvas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected rendering of list rows and edit fields when partially off-screen during scrolling.
  * Eliminated "black squares" appearing in display output through improved clipping behavior for visual elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->