### PR TITLE
Tracking/PureTrack: Add Insert API integration

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -641,6 +641,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Tracking/LiveTrack24/SessionID.cpp \
 	$(SRC)/Tracking/LiveTrack24/Glue.cpp \
 	$(SRC)/Tracking/LiveTrack24/Client.cpp \
+	$(SRC)/Tracking/PureTrack/Protocol.cpp \
 	$(SRC)/Tracking/PureTrack/Glue.cpp \
 	$(SRC)/Tracking/PureTrack/Client.cpp
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -640,7 +640,9 @@ XCSOAR_SOURCES += \
 XCSOAR_SOURCES += \
 	$(SRC)/Tracking/LiveTrack24/SessionID.cpp \
 	$(SRC)/Tracking/LiveTrack24/Glue.cpp \
-	$(SRC)/Tracking/LiveTrack24/Client.cpp
+	$(SRC)/Tracking/LiveTrack24/Client.cpp \
+	$(SRC)/Tracking/PureTrack/Glue.cpp \
+	$(SRC)/Tracking/PureTrack/Client.cpp
 
 XCSOAR_SOURCES += \
 	$(SRC)/net/client/tim/Glue.cpp \

--- a/src/Dialogs/Settings/Panels/TrackingConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TrackingConfigPanel.cpp
@@ -40,7 +40,20 @@ enum ControlIndex {
   LT24_VEHICLE_NAME,
   LT24_SERVER,
   LT24_USERNAME,
-  LT24_PASSWORD
+  LT24_PASSWORD,
+#endif
+#if (defined(HAVE_SKYLINES_TRACKING) || defined(HAVE_LIVETRACK24)) && \
+  defined(HAVE_PURETRACK)
+  PT_SPACER,
+#endif
+#ifdef HAVE_PURETRACK
+  PT_ENABLED,
+  PT_INTERVAL,
+  PT_VEHICLE_TYPE,
+  PT_LABEL,
+  PT_ENDPOINT,
+  PT_APP_KEY,
+  PT_DEVICE_ID,
 #endif
 };
 
@@ -57,6 +70,10 @@ public:
 
 #ifdef HAVE_LIVETRACK24
   void SetLiveTrack24Enabled(bool enabled);
+#endif
+
+#ifdef HAVE_PURETRACK
+  void SetPureTrackEnabled(bool enabled);
 #endif
 
   /* methods from Widget */
@@ -102,6 +119,21 @@ TrackingConfigPanel::SetLiveTrack24Enabled(bool enabled)
 
 #endif
 
+#ifdef HAVE_PURETRACK
+
+void
+TrackingConfigPanel::SetPureTrackEnabled(bool enabled)
+{
+  SetRowEnabled(PT_INTERVAL, enabled);
+  SetRowEnabled(PT_VEHICLE_TYPE, enabled);
+  SetRowEnabled(PT_LABEL, enabled);
+  SetRowEnabled(PT_ENDPOINT, enabled);
+  SetRowEnabled(PT_APP_KEY, enabled);
+  SetRowEnabled(PT_DEVICE_ID, enabled);
+}
+
+#endif
+
 void
 TrackingConfigPanel::OnModified(DataField &df) noexcept
 {
@@ -123,6 +155,13 @@ TrackingConfigPanel::OnModified(DataField &df) noexcept
   if (IsDataField(LT24_ENABLED, df)) {
     const DataFieldBoolean &dfb = (const DataFieldBoolean &)df;
     SetLiveTrack24Enabled(dfb.GetValue());
+  }
+#endif
+
+#ifdef HAVE_PURETRACK
+  if (IsDataField(PT_ENABLED, df)) {
+    const DataFieldBoolean &dfb = (const DataFieldBoolean &)df;
+    SetPureTrackEnabled(dfb.GetValue());
   }
 #endif
 }
@@ -171,6 +210,24 @@ static constexpr StaticEnumChoice vehicle_type_list[] = {
   { LiveTrack24::Settings::VehicleType::HOT_AIR_BALLOON, N_("Hot-air balloon") },
   { LiveTrack24::Settings::VehicleType::HANGGLIDER_FLEX, N_("Hangglider (Flex/FAI1)") },
   { LiveTrack24::Settings::VehicleType::HANGGLIDER_RIGID, N_("Hangglider (Rigid/FAI5)") },
+  nullptr,
+};
+
+#endif
+
+#ifdef HAVE_PURETRACK
+
+static constexpr StaticEnumChoice puretrack_vehicle_type_list[] = {
+  { PureTrack::Settings::VehicleType::GLIDER, N_("Glider") },
+  { PureTrack::Settings::VehicleType::PARAGLIDER, N_("Paraglider") },
+  { PureTrack::Settings::VehicleType::POWERED_AIRCRAFT,
+    N_("Powered aircraft") },
+  { PureTrack::Settings::VehicleType::HOT_AIR_BALLOON,
+    N_("Hot-air balloon") },
+  { PureTrack::Settings::VehicleType::HANGGLIDER_FLEX,
+    N_("Hangglider (Flex/FAI1)") },
+  { PureTrack::Settings::VehicleType::HANGGLIDER_RIGID,
+    N_("Hangglider (Rigid/FAI5)") },
   nullptr,
 };
 
@@ -240,12 +297,38 @@ TrackingConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexc
   AddPassword(_("Password"), "", settings.livetrack24.password);
 #endif
 
+#if (defined(HAVE_SKYLINES_TRACKING) || defined(HAVE_LIVETRACK24)) && \
+  defined(HAVE_PURETRACK)
+  AddSpacer();
+#endif
+
+#ifdef HAVE_PURETRACK
+  AddBoolean("PureTrack", "", settings.puretrack.enabled, this);
+  AddEnum(_("Tracking Interval"), nullptr, tracking_intervals,
+          FindClosestTrackingInterval(settings.puretrack.interval));
+  AddEnum(_("Vehicle Type"), _("Type of vehicle used."),
+          puretrack_vehicle_type_list,
+          (unsigned)settings.puretrack.vehicle_type);
+  AddText(_("Vehicle Name"), "Name shown by PureTrack.",
+          settings.puretrack.label);
+  AddText(_("Server"), "PureTrack Insert API endpoint URL.",
+          settings.puretrack.endpoint);
+  AddText("Key", "PureTrack Insert API application key.",
+          settings.puretrack.app_key);
+  AddText(_("Username"), "Unique device identifier sent to PureTrack.",
+          settings.puretrack.device_id);
+#endif
+
 #ifdef HAVE_SKYLINES_TRACKING
   SetSkyLinesEnabled(settings.skylines.enabled);
 #endif
 
 #ifdef HAVE_LIVETRACK24
   SetLiveTrack24Enabled(settings.livetrack24.enabled);
+#endif
+
+#ifdef HAVE_PURETRACK
+  SetPureTrackEnabled(settings.puretrack.enabled);
 #endif
 }
 
@@ -316,6 +399,24 @@ TrackingConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValue(LT24_PASSWORD, ProfileKeys::LiveTrack24Password,
                        settings.livetrack24.password);
+#endif
+
+#ifdef HAVE_PURETRACK
+  changed |= SaveValue(PT_ENABLED, ProfileKeys::PureTrackEnabled,
+                       settings.puretrack.enabled);
+  changed |= SaveValueEnum(PT_INTERVAL, ProfileKeys::PureTrackInsertInterval,
+                           settings.puretrack.interval);
+  changed |= SaveValueEnum(PT_VEHICLE_TYPE,
+                           ProfileKeys::PureTrackInsertVehicleType,
+                           settings.puretrack.vehicle_type);
+  changed |= SaveValue(PT_LABEL, ProfileKeys::PureTrackInsertLabel,
+                       settings.puretrack.label);
+  changed |= SaveValue(PT_ENDPOINT, ProfileKeys::PureTrackInsertEndpoint,
+                       settings.puretrack.endpoint);
+  changed |= SaveValue(PT_APP_KEY, ProfileKeys::PureTrackInsertAppKey,
+                       settings.puretrack.app_key);
+  changed |= SaveValue(PT_DEVICE_ID, ProfileKeys::PureTrackInsertDeviceID,
+                       settings.puretrack.device_id);
 #endif
 
   _changed |= changed;

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -264,6 +264,16 @@ constexpr std::string_view LiveTrack24TrackingInterval = "TrackingInterval";
 constexpr std::string_view LiveTrack24TrackingVehicleType = "TrackingVehicleType";
 constexpr std::string_view LiveTrack24TrackingVehicleName = "TrackingVehicleName";
 
+constexpr std::string_view PureTrackEnabled = "PureTrackEnabled";
+constexpr std::string_view PureTrackInsertEndpoint = "PureTrackInsertEndpoint";
+constexpr std::string_view PureTrackInsertInterval = "PureTrackInsertInterval";
+constexpr std::string_view PureTrackInsertAppKey = "PureTrackInsertAppKey";
+constexpr std::string_view PureTrackInsertDeviceID = "PureTrackInsertDeviceID";
+constexpr std::string_view PureTrackInsertLabel = "PureTrackInsertLabel";
+constexpr std::string_view PureTrackInsertRego = "PureTrackInsertRego";
+constexpr std::string_view PureTrackInsertVehicleType =
+  "PureTrackInsertVehicleType";
+
 constexpr std::string_view PCMetUsername = "PCMetUsername";
 constexpr std::string_view PCMetPassword = "PCMetPassword";
 constexpr std::string_view PCMetFtpUsername = "PCMetFtpUsername";

--- a/src/Profile/TrackingProfile.cpp
+++ b/src/Profile/TrackingProfile.cpp
@@ -57,6 +57,18 @@ static void Load(const ProfileMap &map,
   map.GetEnum(ProfileKeys::LiveTrack24TrackingVehicleType, settings.vehicleType);
   map.Get(ProfileKeys::LiveTrack24TrackingVehicleName, settings.vehicle_name);
 }
+
+static void Load(const ProfileMap &map,
+                 PureTrack::Settings &settings) {
+  map.Get(ProfileKeys::PureTrackEnabled, settings.enabled);
+  map.Get(ProfileKeys::PureTrackInsertEndpoint, settings.endpoint);
+  map.Get(ProfileKeys::PureTrackInsertInterval, settings.interval);
+  map.Get(ProfileKeys::PureTrackInsertAppKey, settings.app_key);
+  map.Get(ProfileKeys::PureTrackInsertDeviceID, settings.device_id);
+  map.Get(ProfileKeys::PureTrackInsertLabel, settings.label);
+  map.Get(ProfileKeys::PureTrackInsertRego, settings.rego);
+  map.GetEnum(ProfileKeys::PureTrackInsertVehicleType, settings.vehicle_type);
+}
 }
 
 void
@@ -64,6 +76,7 @@ Profile::Load(const ProfileMap &map, TrackingSettings &settings)
 {
   Load(map, settings.skylines);
   Load(map, settings.livetrack24);
+  Load(map, settings.puretrack);
 }
 
 #endif /* HAVE_TRACKING */

--- a/src/Tracking/Features.hpp
+++ b/src/Tracking/Features.hpp
@@ -9,8 +9,10 @@
 /* live tracking requires networking */
 #ifdef HAVE_HTTP
 #define HAVE_LIVETRACK24
+#define HAVE_PURETRACK
 #endif
 
-#if defined(HAVE_SKYLINES_TRACKING) || defined(HAVE_LIVETRACK24)
+#if defined(HAVE_SKYLINES_TRACKING) || defined(HAVE_LIVETRACK24) || \
+  defined(HAVE_PURETRACK)
 #define HAVE_TRACKING
 #endif

--- a/src/Tracking/PureTrack/Client.cpp
+++ b/src/Tracking/PureTrack/Client.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Client.hpp"
+#include "Settings.hpp"
+
+#include "co/Task.hxx"
+
+namespace PureTrack {
+
+Co::Task<void>
+Client::Insert([[maybe_unused]] const Settings &settings,
+               [[maybe_unused]] const Sample &sample)
+{
+  co_return;
+}
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Client.cpp
+++ b/src/Tracking/PureTrack/Client.cpp
@@ -2,16 +2,56 @@
 // Copyright The XCSoar Project
 
 #include "Client.hpp"
+#include "Protocol.hpp"
 #include "Settings.hpp"
 
+#include "json/ParserOutputStream.hxx"
+#include "lib/curl/CoStreamRequest.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
+#include "lib/curl/Slist.hxx"
 #include "co/Task.hxx"
+
+#include <stdexcept>
 
 namespace PureTrack {
 
 Co::Task<void>
-Client::Insert([[maybe_unused]] const Settings &settings,
-               [[maybe_unused]] const Sample &sample)
+Client::Insert(const Settings &settings, const Sample &sample)
 {
+  if (settings.endpoint.empty())
+    throw std::invalid_argument("PureTrack endpoint missing");
+
+  if (settings.app_key.empty())
+    throw std::invalid_argument("PureTrack app key missing");
+
+  if (settings.device_id.empty())
+    throw std::invalid_argument("PureTrack device id missing");
+
+  const auto body_string = BuildInsertRequestBody(settings, sample);
+
+  CurlEasy easy{settings.endpoint.c_str()};
+  Curl::Setup(easy);
+  easy.SetPost();
+  easy.SetTimeout(25);
+
+  CurlSlist headers;
+  headers.Append("Accept: application/json");
+  headers.Append("Content-Type: application/json");
+  easy.SetRequestHeaders(headers.Get());
+  easy.SetRequestBody(body_string);
+
+  Json::ParserOutputStream parser;
+  const auto response =
+    co_await Curl::CoStreamRequest(curl, std::move(easy), parser);
+  const auto response_body = parser.Finish();
+
+  if (response.status != 200)
+    throw ResponseToException(response.status, response_body);
+
+  if (!ParseInsertResponse(response.status, response_body).success)
+    throw ResponseToException(response.status, response_body);
+
   co_return;
 }
 

--- a/src/Tracking/PureTrack/Client.hpp
+++ b/src/Tracking/PureTrack/Client.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "Geo/GeoPoint.hpp"
-#include "time/BrokenDateTime.hpp"
 
 #include <chrono>
 

--- a/src/Tracking/PureTrack/Client.hpp
+++ b/src/Tracking/PureTrack/Client.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+
+#include <chrono>
+
+namespace Co {
+template<typename T> class Task;
+}
+
+class CurlGlobal;
+
+namespace PureTrack {
+
+struct Settings;
+
+struct Sample {
+  std::chrono::system_clock::time_point timestamp;
+  GeoPoint location;
+  double altitude = 0;
+  double speed = 0;
+  double course = 0;
+  double vertical_speed = 0;
+};
+
+class Client final {
+  CurlGlobal &curl;
+
+public:
+  explicit Client(CurlGlobal &_curl) noexcept
+    :curl(_curl) {}
+
+  Co::Task<void> Insert(const Settings &settings, const Sample &sample);
+};
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Glue.cpp
+++ b/src/Tracking/PureTrack/Glue.cpp
@@ -22,7 +22,11 @@ Glue::Glue(CurlGlobal &curl) noexcept
 void
 Glue::OnTimer(const MoreData &basic, [[maybe_unused]] const DerivedInfo &calculated)
 {
-  if (!settings.enabled || !basic.time_available || !basic.location_available)
+  if (!settings.enabled || settings.app_key.empty() ||
+      settings.device_id.empty())
+    return;
+
+  if (!basic.time_available || !basic.gps.real || !basic.location_available)
     return;
 
   if (!clock.CheckUpdate(std::chrono::seconds(settings.interval)))
@@ -32,8 +36,22 @@ Glue::OnTimer(const MoreData &basic, [[maybe_unused]] const DerivedInfo &calcula
     return;
 
   Sample sample;
-  sample.timestamp = basic.date_time_utc.ToTimePoint();
+  sample.timestamp = basic.date_time_utc.IsDatePlausible()
+    ? basic.date_time_utc.ToTimePoint()
+    : std::chrono::system_clock::now();
   sample.location = basic.location;
+  sample.altitude = basic.NavAltitudeAvailable() && basic.nav_altitude > 0
+    ? basic.nav_altitude
+    : 0;
+  sample.speed = basic.ground_speed_available
+    ? basic.ground_speed
+    : 0;
+  sample.course = basic.track_available
+    ? basic.track.AsBearing().Degrees()
+    : 0;
+  sample.vertical_speed = basic.brutto_vario_available
+    ? basic.brutto_vario
+    : 0;
 
   inject_task.Start(Tick(settings, sample), BIND_THIS_METHOD(OnCompletion));
 }

--- a/src/Tracking/PureTrack/Glue.cpp
+++ b/src/Tracking/PureTrack/Glue.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Glue.hpp"
+
+#include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
+#include "LogFile.hpp"
+#include "co/Task.hxx"
+#include "lib/curl/Global.hxx"
+#include "util/Macros.hpp"
+
+namespace PureTrack {
+
+Glue::Glue(CurlGlobal &curl) noexcept
+  :client(curl),
+   inject_task(curl.GetEventLoop())
+{
+  settings.SetDefaults();
+}
+
+void
+Glue::OnTimer(const MoreData &basic, [[maybe_unused]] const DerivedInfo &calculated)
+{
+  if (!settings.enabled || !basic.time_available || !basic.location_available)
+    return;
+
+  if (!clock.CheckUpdate(std::chrono::seconds(settings.interval)))
+    return;
+
+  if (inject_task)
+    return;
+
+  Sample sample;
+  sample.timestamp = basic.date_time_utc.ToTimePoint();
+  sample.location = basic.location;
+
+  inject_task.Start(Tick(settings, sample), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+Glue::Tick(Settings _settings, Sample sample)
+{
+  co_await client.Insert(_settings, sample);
+}
+
+void
+Glue::OnCompletion(std::exception_ptr error) noexcept
+{
+  if (error)
+    LogError(error, "PureTrack error");
+}
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Glue.hpp
+++ b/src/Tracking/PureTrack/Glue.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Settings.hpp"
+#include "Client.hpp"
+#include "time/PeriodClock.hpp"
+#include "co/InjectTask.hxx"
+
+struct MoreData;
+struct DerivedInfo;
+class CurlGlobal;
+
+namespace PureTrack {
+
+class Glue final {
+  PeriodClock clock;
+  Settings settings;
+  Client client;
+  Co::InjectTask inject_task;
+
+public:
+  explicit Glue(CurlGlobal &curl) noexcept;
+
+  void SetSettings(const Settings &_settings) noexcept {
+    settings = _settings;
+  }
+
+  void OnTimer(const MoreData &basic, const DerivedInfo &calculated);
+
+private:
+  Co::InvokeTask Tick(Settings settings, Sample sample);
+  void OnCompletion(std::exception_ptr error) noexcept;
+};
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Protocol.cpp
+++ b/src/Tracking/PureTrack/Protocol.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Protocol.hpp"
+#include "Settings.hpp"
+#include "Client.hpp"
+
+#include "io/StringOutputStream.hxx"
+#include "json/Serialize.hxx"
+#include "lib/fmt/RuntimeError.hxx"
+
+#include <boost/json.hpp>
+
+using std::string_view_literals::operator""sv;
+
+namespace PureTrack {
+
+static boost::json::object
+BuildPoint(const Sample &sample)
+{
+  boost::json::object point;
+  point.emplace("ts",
+                (std::int64_t)std::chrono::system_clock::to_time_t(
+                  sample.timestamp));
+  point.emplace("lat", sample.location.latitude.Degrees());
+  point.emplace("lng", sample.location.longitude.Degrees());
+  point.emplace("alt", sample.altitude);
+  point.emplace("speed", sample.speed);
+  point.emplace("course", sample.course);
+  point.emplace("vspeed", sample.vertical_speed);
+
+  return point;
+}
+
+std::string
+BuildInsertRequestBody(const Settings &settings, const Sample &sample)
+{
+  boost::json::object request;
+  request.emplace("key", std::string_view{settings.app_key});
+  request.emplace("deviceID", std::string_view{settings.device_id});
+
+  if (!settings.label.empty())
+    request.emplace("label", std::string_view{settings.label});
+
+  if (!settings.rego.empty())
+    request.emplace("rego", std::string_view{settings.rego});
+
+  boost::json::array points;
+  points.emplace_back(BuildPoint(sample));
+  request.emplace("points", std::move(points));
+
+  StringOutputStream os;
+  Json::Serialize(os, request);
+  return std::move(os).GetValue();
+}
+
+static unsigned
+GetUnsigned(const boost::json::object &o, std::string_view key) noexcept
+{
+  auto i = o.find(key);
+  if (i == o.end() || !i->value().is_int64())
+    return 0;
+
+  const auto value = i->value().as_int64();
+  return value >= 0 ? (unsigned)value : 0;
+}
+
+InsertResponse
+ParseInsertResponse(unsigned status, const boost::json::value &body)
+{
+  InsertResponse response;
+  response.http_code = status;
+
+  if (!body.is_object())
+    return response;
+
+  const auto &o = body.as_object();
+  if (auto i = o.find("success"sv); i != o.end() && i->value().is_bool())
+    response.success = i->value().as_bool();
+
+  response.http_code = GetUnsigned(o, "http_code"sv);
+  response.trackers_received = GetUnsigned(o, "trackers_received"sv);
+  response.total_points_received = GetUnsigned(o, "total_points_recieved"sv);
+  response.total_points_inserted = GetUnsigned(o, "total_points_inserted"sv);
+  return response;
+}
+
+std::runtime_error
+ResponseToException(unsigned status, const boost::json::value &body)
+{
+  if (!body.is_object())
+    return FmtRuntimeError("PureTrack status {}", status);
+
+  const auto &o = body.as_object();
+
+  if (auto i = o.find("message"sv); i != o.end() && i->value().is_string())
+    return FmtRuntimeError("PureTrack status {}: {}",
+                           status,
+                           (std::string_view)i->value().as_string());
+
+  if (auto i = o.find("error"sv); i != o.end() && i->value().is_string())
+    return FmtRuntimeError("PureTrack status {}: {}",
+                           status,
+                           (std::string_view)i->value().as_string());
+
+  return FmtRuntimeError("PureTrack status {}", status);
+}
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Protocol.cpp
+++ b/src/Tracking/PureTrack/Protocol.cpp
@@ -15,6 +15,28 @@ using std::string_view_literals::operator""sv;
 
 namespace PureTrack {
 
+static unsigned
+MapVehicleType(Settings::VehicleType type) noexcept
+{
+  switch (type) {
+  case Settings::VehicleType::GLIDER:
+    return 1;
+  case Settings::VehicleType::PARAGLIDER:
+    return 7;
+  case Settings::VehicleType::POWERED_AIRCRAFT:
+    return 8;
+  case Settings::VehicleType::HOT_AIR_BALLOON:
+    return 11;
+  case Settings::VehicleType::HANGGLIDER_FLEX:
+  case Settings::VehicleType::HANGGLIDER_RIGID:
+    return 6;
+  case Settings::VehicleType::COUNT:
+    break;
+  }
+
+  return 1;
+}
+
 static boost::json::object
 BuildPoint(const Sample &sample)
 {
@@ -38,6 +60,7 @@ BuildInsertRequestBody(const Settings &settings, const Sample &sample)
   boost::json::object request;
   request.emplace("key", std::string_view{settings.app_key});
   request.emplace("deviceID", std::string_view{settings.device_id});
+  request.emplace("type", MapVehicleType(settings.vehicle_type));
 
   if (!settings.label.empty())
     request.emplace("label", std::string_view{settings.label});

--- a/src/Tracking/PureTrack/Protocol.hpp
+++ b/src/Tracking/PureTrack/Protocol.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <boost/json/fwd.hpp>
+
+#include <string>
+#include <stdexcept>
+
+namespace PureTrack {
+
+struct Settings;
+struct Sample;
+
+struct InsertResponse {
+  bool success = false;
+  unsigned http_code = 0;
+  unsigned trackers_received = 0;
+  unsigned total_points_received = 0;
+  unsigned total_points_inserted = 0;
+};
+
+std::string
+BuildInsertRequestBody(const Settings &settings, const Sample &sample);
+
+InsertResponse
+ParseInsertResponse(unsigned status, const boost::json::value &body);
+
+std::runtime_error
+ResponseToException(unsigned status, const boost::json::value &body);
+
+} // namespace PureTrack

--- a/src/Tracking/PureTrack/Settings.hpp
+++ b/src/Tracking/PureTrack/Settings.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StaticString.hxx"
+
+#include <cstdint>
+
+namespace PureTrack {
+
+struct Settings {
+  enum class VehicleType : uint8_t {
+    GLIDER,
+    PARAGLIDER,
+    POWERED_AIRCRAFT,
+    HOT_AIR_BALLOON,
+    HANGGLIDER_FLEX,
+    HANGGLIDER_RIGID,
+    COUNT,
+  };
+
+  bool enabled;
+
+  /**
+   * Insert API endpoint URL.
+   */
+  StaticString<128> endpoint;
+
+  /**
+   * Tracking interval in seconds.
+   */
+  unsigned interval;
+
+  StaticString<64> app_key;
+  StaticString<64> device_id;
+  StaticString<64> label;
+  StaticString<32> rego;
+
+  VehicleType vehicle_type;
+
+  void SetDefaults() {
+    enabled = false;
+    endpoint = "https://puretrack.io/api/insert";
+    interval = 60;
+    app_key.clear();
+    device_id.clear();
+    label.clear();
+    rego.clear();
+    vehicle_type = VehicleType::GLIDER;
+  }
+};
+
+} // namespace PureTrack

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -9,7 +9,8 @@
 TrackingGlue::TrackingGlue(EventLoop &event_loop,
                            CurlGlobal &curl) noexcept
   :skylines(event_loop, this),
-   livetrack24(curl)
+   livetrack24(curl),
+   puretrack(curl)
 {
 }
 
@@ -18,6 +19,7 @@ TrackingGlue::SetSettings(const TrackingSettings &_settings)
 {
   skylines.SetSettings(_settings.skylines);
   livetrack24.SetSettings(_settings.livetrack24);
+  puretrack.SetSettings(_settings.puretrack);
 }
 
 void
@@ -30,6 +32,7 @@ TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
   }
 
   livetrack24.OnTimer(basic, calculated);
+  puretrack.OnTimer(basic, calculated);
 }
 
 void

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -11,6 +11,7 @@
 #include "Tracking/SkyLines/Glue.hpp"
 #include "Tracking/SkyLines/Data.hpp"
 #include "Tracking/LiveTrack24/Glue.hpp"
+#include "Tracking/PureTrack/Glue.hpp"
 
 struct TrackingSettings;
 struct MoreData;
@@ -25,6 +26,7 @@ class TrackingGlue final
   SkyLinesTracking::Data skylines_data;
 
   LiveTrack24::Glue livetrack24;
+  PureTrack::Glue puretrack;
 
 public:
   TrackingGlue(EventLoop &event_loop, CurlGlobal &curl) noexcept;

--- a/src/Tracking/TrackingSettings.hpp
+++ b/src/Tracking/TrackingSettings.hpp
@@ -10,6 +10,7 @@
 #include "Tracking/SkyLines/Features.hpp"
 #include "Tracking/SkyLines/Settings.hpp"
 #include "Tracking/LiveTrack24/Settings.hpp"
+#include "Tracking/PureTrack/Settings.hpp"
 
 #include "util/StaticString.hxx"
 
@@ -17,10 +18,12 @@
 struct TrackingSettings {
   SkyLinesTracking::Settings skylines;
   LiveTrack24::Settings livetrack24;
+  PureTrack::Settings puretrack;
 
   void SetDefaults() {
     skylines.SetDefaults();
     livetrack24.SetDefaults();
+    puretrack.SetDefaults();
   }
 };
 


### PR DESCRIPTION
## Summary
- add initial PureTrack tracking integration with settings, runtime glue, and `/api/insert` client implementation
- implement JSON request/response handling for Insert API, including vehicle type mapping and telemetry payload fields
- wire profile load/save and the Tracking configuration panel for PureTrack options

## Issue reference
Refs #1626.

## Current status
This implementation is currently **untested against a live PureTrack backend**, but should work based on the published API contract and existing XCSoar tracking architecture.

## Open questions
- final default/send interval to use for production
- canonical server endpoint URL to ship as default
- app key and device-id provisioning workflow (who generates, where entered, validation constraints)

## Test plan
- [x] `make -j$(nproc) TARGET=UNIX OPENGL=y USE_CCACHE=y check`
- [ ] Manual end-to-end test with valid PureTrack credentials and backend
- [ ] Verify UI behavior in `Setup -> Tracking` for enable/disable and field persistence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PureTrack tracking service integration with full configuration support
  * New settings panel controls for enabling, configuring endpoint, API credentials, device identification, vehicle type, and tracking interval
  * Settings are now saved and persist across sessions
  * Automatic position tracking via PureTrack service at configurable intervals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->