### PR TITLE
Fix EGL glitch in UNIX with nvidia

### DIFF
--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -194,10 +194,12 @@ TopWindow::Expose() noexcept
 
   screen->Flip();
 
-#if defined(ENABLE_OPENGL) && defined(GL_EXT_discard_framebuffer)
-  /* tell the GPU that we won't be needing the frame buffer contents
-     again which can increase rendering performance; see
-     https://registry.khronos.org/OpenGL/extensions/EXT/EXT_discard_framebuffer.txt */
+#if defined(ENABLE_OPENGL) && defined(GL_EXT_discard_framebuffer) && \
+  (defined(ANDROID) || defined(MESA_KMS))
+  /* On mobile/KMS style backends, discarding the previous window
+     contents can save bandwidth.  Desktop EGL/GLX compositors may
+     still read from the just-swapped window surface, so avoid this
+     optimisation there. */
   if (GLExt::discard_framebuffer != nullptr) {
     static constexpr GLenum attachments[3] = {
       GL_COLOR_EXT,


### PR DESCRIPTION
Hello,

On my machine running Ubuntu 24.04 with the latest NVIDIA driver, I experienced black glitches when using the OpenGL renderer, which made XCSoar unusable.

After several hours of debugging with Codex, it suggested this fix. I do not have much experience with OpenGL, so I cannot confirm whether this is the correct approach, but it resolves the rendering issue on my machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized OpenGL rendering on Android and MESA_KMS platforms to reduce bandwidth consumption and improve rendering efficiency on mobile and embedded systems. These platform-specific improvements enhance overall rendering performance while maintaining full compatibility with desktop graphics systems and compositors, with no impact on existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->