### PR TITLE
Fix/data file loading

### DIFF
--- a/src/Dialogs/MultiFilePicker.cpp
+++ b/src/Dialogs/MultiFilePicker.cpp
@@ -5,6 +5,7 @@
 #include "Form/DataField/MultiFile.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
+#include "util/StaticString.hxx"
 #include "Widget/FileMultiSelectWidget.hpp"
 #include "Widget/StaticHelpTextWidget.hpp"
 #include "WidgetDialog.hpp"
@@ -21,7 +22,15 @@ static const char *
 GetFileName(const FileMultiSelectWidget::FileItem &item) noexcept
 {
   const auto base = item.path.GetBase();
-  return (base != nullptr) ? base.c_str() : item.path.c_str();
+  const char *name = (base != nullptr) ? base.c_str() : item.path.c_str();
+
+  if (item.exists)
+    return name;
+
+  /* file configured in profile but not found on disk */
+  static StaticString<256> buffer;
+  buffer.Format("%s [%s]", name, _("not found"));
+  return buffer.c_str();
 }
 
 bool

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -3,13 +3,15 @@
 
 #include "File.hpp"
 #include "ComboList.hpp"
+#include "Language/Language.hpp"
 #include "LocalPath.hpp"
 #include "util/StringAPI.hxx"
+#include "util/StringCompare.hxx"
+#include "util/StaticString.hxx"
 #include "system/FileUtil.hpp"
 
 #include <algorithm>
 
-#include <windef.h> /* for MAX_PATH */
 #include <cassert>
 #include <stdlib.h>
 
@@ -124,8 +126,17 @@ FileDataField::SetValue(Path text) noexcept
   }
 
   auto i = Find(text);
-  if (i >= 0)
+  if (i >= 0) {
     current_index = i;
+  } else if (text != nullptr && !StringIsEmpty(text.c_str())) {
+    /* file configured in profile but not found on disk - add it to
+       the list so the user can see what's configured */
+    if (!files.full()) {
+      auto &item = files.append();
+      item.Set(text);
+      current_index = files.size() - 1;
+    }
+  }
 }
 
 void
@@ -319,11 +330,19 @@ FileDataField::CreateComboList([[maybe_unused]] const char *reference) const noe
 
   ComboList combo_list;
 
-  char buffer[MAX_PATH];
+  StaticString<1024> buffer;
 
+  unsigned combo_index = 0;
   for (unsigned i = 0; i < files.size(); i++) {
     const Path path = files[i].filename;
     assert(path != nullptr);
+
+    const bool is_not_found = !StringIsEmpty(path.c_str()) &&
+                              !File::Exists(files[i].path);
+
+    /* hide not-found files that are no longer selected */
+    if (is_not_found && i != current_index)
+      continue;
 
     /* is a file with the same base name present in another data
        directory? */
@@ -340,17 +359,19 @@ FileDataField::CreateComboList([[maybe_unused]] const char *reference) const noe
     if (found) {
       /* yes - append the absolute path to allow the user to see the
          difference */
-      strcpy(buffer, path.c_str());
-      strcat(buffer, " (");
-      strcat(buffer, files[i].path.c_str());
-      strcat(buffer, ")");
+      buffer.Format("%s (%s)", path.c_str(), files[i].path.c_str());
+      display_string = buffer;
+    } else if (is_not_found) {
+      /* file configured in profile does not exist on disk */
+      buffer.Format("%s [%s]", path.c_str(), _("not found"));
       display_string = buffer;
     }
 
-    combo_list.Append(display_string);
+    if (i == current_index)
+      combo_list.current_index = combo_index;
+    combo_index++;
+    combo_list.Append(i, display_string);
   }
-
-  combo_list.current_index = current_index;
 
   return combo_list;
 }

--- a/src/Form/DataField/MultiFile.cpp
+++ b/src/Form/DataField/MultiFile.cpp
@@ -4,7 +4,6 @@
 #include "MultiFile.hpp"
 #include "ComboList.hpp"
 #include "Language/Language.hpp"
-#include "system/FileUtil.hpp"
 
 #include <algorithm>
 
@@ -139,8 +138,14 @@ MultiFileDataField::UpdateDisplayString()
     auto index = file_datafield.Find(path);
     if (index >= 0)
       display_string += file_datafield.GetItem(index).filename.c_str();
-    else
-      display_string += path.c_str();
+    else {
+      /* file configured in profile but not found on disk */
+      auto base = path.GetBase();
+      display_string += (base != nullptr) ? base.c_str() : path.c_str();
+      display_string += " [";
+      display_string += _("not found");
+      display_string += "]";
+    }
   }
 }
 

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -243,6 +243,8 @@ try {
   SetAirspaceGroundLevels(*data_components->airspaces,
                           *data_components->terrain);
 } catch (...) {
+  SetTopWidget(nullptr);
+  terrain_loader_env.reset();
   LogError(std::current_exception(), "LoadTerrain failed");
 }
 

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -17,6 +17,8 @@
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "Terrain/RasterTerrain.hpp"
 #include "Terrain/AsyncLoader.hpp"
+#include "io/ZipArchive.hpp"
+#include "Message.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
 #include "Weather/Rasp/Configured.hpp"
 #include "Input/InputEvents.hpp"
@@ -186,6 +188,18 @@ MainWindow::LoadTerrain() noexcept
   if (const auto path = Profile::GetPath(ProfileKeys::MapFile);
       path != nullptr) {
     LogFormat("Loading terrain: %s", path.c_str());
+
+    /* Quick synchronous validation: try opening the ZIP archive
+       before launching the async loader to fail fast on missing or
+       unreadable files. */
+    try {
+      ZipArchive test_archive{path};
+    } catch (...) {
+      LogFormat("Failed to open map file: %s", path.c_str());
+      Message::AddMessage(_("Failed to open configured map file"));
+      return;
+    }
+
     terrain_loader = new AsyncTerrainOverviewLoader();
 
     terrain_loader_env = std::make_unique<PluggableOperationEnvironment>();

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -11,6 +11,9 @@
 #include "Topography/TopographyStore.hpp"
 #include "Topography/TopographyGlue.hpp"
 #include "Dialogs/Dialogs.h"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "system/FileUtil.hpp"
 #include "Device/device.hpp"
 #include "Interface.hpp"
 #include "ActionInterface.hpp"
@@ -103,6 +106,16 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   if (TerrainFileChanged)
     main_window.LoadTerrain();
+
+  /* If the terrain wasn't changed via the settings UI but no terrain is
+     currently loaded (e.g. a previous automated load failed), attempt
+     to load the configured map file when it now exists. */
+  if (!TerrainFileChanged && data_components->terrain == nullptr) {
+    if (const auto path = Profile::GetPath(ProfileKeys::MapFile); path != nullptr) {
+      if (File::Exists(path))
+        main_window.LoadTerrain();
+    }
+  }
 
   auto &way_points = *data_components->waypoints;
 

--- a/src/Widget/FileMultiSelectWidget.cpp
+++ b/src/Widget/FileMultiSelectWidget.cpp
@@ -53,7 +53,7 @@ FileMultiSelectWidget::LoadFiles() noexcept
   items_.clear();
   FileDataField &file_field = df_.GetFileDataField();
   for (unsigned i = 0; i < file_field.size(); ++i)
-    items_.push_back({AllocatedPath(Path(file_field.GetItem(i).path))}); 
+    items_.push_back({AllocatedPath(Path(file_field.GetItem(i).path)), true});
 }
 
 void
@@ -74,7 +74,7 @@ FileMultiSelectWidget::MergePaths(const std::vector<Path> &paths) noexcept
 {
   for (const auto &path : paths) {
     if (!ContainsPath(items_, path))
-      items_.push_back({AllocatedPath(path)});
+      items_.push_back({AllocatedPath(path), false});
   }
 }
 

--- a/src/Widget/FileMultiSelectWidget.cpp
+++ b/src/Widget/FileMultiSelectWidget.cpp
@@ -53,7 +53,7 @@ FileMultiSelectWidget::LoadFiles() noexcept
   items_.clear();
   FileDataField &file_field = df_.GetFileDataField();
   for (unsigned i = 0; i < file_field.size(); ++i)
-    items_.push_back({file_field.GetItem(i).path});
+    items_.push_back({AllocatedPath(Path(file_field.GetItem(i).path))}); 
 }
 
 void
@@ -74,7 +74,7 @@ FileMultiSelectWidget::MergePaths(const std::vector<Path> &paths) noexcept
 {
   for (const auto &path : paths) {
     if (!ContainsPath(items_, path))
-      items_.push_back({path});
+      items_.push_back({AllocatedPath(path)});
   }
 }
 
@@ -82,7 +82,14 @@ void
 FileMultiSelectWidget::Refresh() noexcept
 {
   const auto saved_selection = refreshed_ ? GetSelectedPaths() : std::vector<Path>{};
-  const auto previous_items = refreshed_ ? items_ : std::vector<FileItem>{};
+  auto previous_items = refreshed_ ? std::move(items_) : std::vector<FileItem>{};
+
+  /* capture paths before moving items (move leaves AllocatedPath in
+     an unspecified state) */
+  std::vector<AllocatedPath> previous_paths;
+  previous_paths.reserve(previous_items.size());
+  for (const auto &item : previous_items)
+    previous_paths.emplace_back(item.path.c_str());
 
   LoadFiles();
   auto current_items = df_.GetPathFiles();
@@ -92,9 +99,9 @@ FileMultiSelectWidget::Refresh() noexcept
 
   // Merge previous items to preserve user's deselections
   if (refreshed_) {
-    for (const auto &item : previous_items) {
+    for (auto &item : previous_items) {
       if (!ContainsPath(items_, item.path))
-        items_.push_back(item);
+        items_.push_back(std::move(item));
     }
   }
 
@@ -104,7 +111,7 @@ FileMultiSelectWidget::Refresh() noexcept
   ClearSelection();
 
   if (refreshed_) {
-    RestoreSelection(saved_selection, previous_items, current_items);
+    RestoreSelection(saved_selection, previous_paths, current_items);
   } else {
     ApplySelection(current_items);
   }
@@ -142,7 +149,7 @@ FileMultiSelectWidget::SetSelectionChangedCallback(std::function<void()> cb) noe
 
 void
 FileMultiSelectWidget::RestoreSelection(const std::vector<Path> &saved_selection,
-                                        const std::vector<FileItem> &previous_items,
+                                        const std::vector<AllocatedPath> &previous_paths,
                                         const std::vector<Path> &current_items) noexcept
 {
   for (unsigned i = 0; i < items_.size(); ++i) {
@@ -154,8 +161,10 @@ FileMultiSelectWidget::RestoreSelection(const std::vector<Path> &saved_selection
       continue;
     }
 
-    // Auto-select new items from current_items that weren't in previous_items
-    if (ContainsPath(current_items, p) && !ContainsPath(previous_items, p))
+    // Auto-select new items from current_items that weren't in the previous list
+    if (ContainsPath(current_items, p) &&
+        std::none_of(previous_paths.begin(), previous_paths.end(),
+                     [p](const AllocatedPath &pp) { return pp == p; }))
       SetSelected(i, true);
   }
 }

--- a/src/Widget/FileMultiSelectWidget.hpp
+++ b/src/Widget/FileMultiSelectWidget.hpp
@@ -23,7 +23,7 @@ class Canvas;
 class FileMultiSelectWidget : public MultiSelectListWidget {
 public:
   struct FileItem {
-    Path path;
+    AllocatedPath path;
   };
 
   using TextProvider = std::function<const char*(const FileItem&)>;
@@ -86,6 +86,6 @@ private:
   void ApplySelection(const std::vector<Path> &paths) noexcept;
   void MergePaths(const std::vector<Path> &paths) noexcept;
   void RestoreSelection(const std::vector<Path> &saved_selection,
-                        const std::vector<FileItem> &previous_items,
+                        const std::vector<AllocatedPath> &previous_paths,
                         const std::vector<Path> &current_items) noexcept;
 };

--- a/src/Widget/FileMultiSelectWidget.hpp
+++ b/src/Widget/FileMultiSelectWidget.hpp
@@ -24,6 +24,9 @@ class FileMultiSelectWidget : public MultiSelectListWidget {
 public:
   struct FileItem {
     AllocatedPath path;
+
+    /** true if the file was found on disk during scanning */
+    bool exists = true;
   };
 
   using TextProvider = std::function<const char*(const FileItem&)>;


### PR DESCRIPTION
There are some issues loading data files in 7.44 / current master:
- If maps defined in the profile are not found on disk, the loader gets stuck and cannot be recovered (e.g. by selecting another map in settings). No error message is being emitted.
- When non-existent files are not de-selected in a FileMultiSelectWidget (e.g. waypoints or airspaces defined in profile but not found on disk), an assertion error gets thrown (crashes debug builds)
- Files not found are generally not marked as such, confusing the user.

This PR attempts to fix those issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File pickers mark missing items with " [not found]" and show clearer names/paths for duplicates.
  * Startup validates configured map files at load time and notifies on errors.
  * App attempts to reload a previously configured map file automatically when appropriate.

* **Bug Fixes**
  * Multi-file selection preserves and restores previous selections correctly after refresh, with improved handling of missing and moved entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->