### PR TITLE
build: Avoid tempfile races in generated resource files

### DIFF
--- a/build/generate.mk
+++ b/build/generate.mk
@@ -1,23 +1,24 @@
 INCLUDES += -I$(OUT)/include
 
 PERL = perl
+RANDOM_NUMBER := $(shell od -vAn -N4 -tu4 < /dev/urandom| tr -d ' ')
 
 $(OUT)/include/MathTables.h: $(HOST_OUTPUT_DIR)/tools/GenerateSineTables$(HOST_EXEEXT) | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
 	# Generate into a temporary file to avoid leaving a truncated/empty header on interruption
-	$(Q)$(HOST_OUTPUT_DIR)/tools/GenerateSineTables$(HOST_EXEEXT) >$@.tmp
+	$(Q)$(HOST_OUTPUT_DIR)/tools/GenerateSineTables$(HOST_EXEEXT) >$@.$(RANDOM_NUMBER).tmp
 	# Basic validation: file must be non-empty and contain an expected token.
-	@if [ ! -s "$@.tmp" ]; then \
-	  echo "Generation failed: $@.tmp is empty" >&2; \
-	  rm -f "$@.tmp"; \
+	@if [ ! -s "$@.$(RANDOM_NUMBER).tmp" ]; then \
+	  echo "Generation failed: $@.$(RANDOM_NUMBER).tmp is empty" >&2; \
+	  rm -f "$@.$(RANDOM_NUMBER).tmp"; \
 	  exit 1; \
 	fi
-	@if ! grep -q 'THERMALRECENCY{' "$@.tmp"; then \
-	  echo "Generation failed: expected token THERMALRECENCY{ not found in $@.tmp" >&2; \
-	  rm -f "$@.tmp"; \
+	@if ! grep -q 'THERMALRECENCY{' "$@.$(RANDOM_NUMBER).tmp"; then \
+	  echo "Generation failed: expected token THERMALRECENCY{ not found in $@.$(RANDOM_NUMBER).tmp" >&2; \
+	  rm -f "$@.$(RANDOM_NUMBER).tmp"; \
 	  exit 1; \
 	fi
-	@mv $@.tmp $@
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(call SRC_TO_OBJ,$(SRC)/Math/FastMath.cpp): $(OUT)/include/MathTables.h
 $(call SRC_TO_OBJ,$(SRC)/Math/FastTrig.cpp): $(OUT)/include/MathTables.h
@@ -26,32 +27,32 @@ $(call SRC_TO_OBJ,$(SRC)/Computer/ThermalRecency.cpp): $(OUT)/include/MathTables
 $(OUT)/include/InputEvents_Text2Event.cpp: $(SRC)/Input/InputEvents.hpp \
 	$(topdir)/tools/Text2Event.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/Text2Event.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/Text2Event.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(OUT)/include/InputEvents_Text2GCE.cpp: $(SRC)/Input/InputQueue.hpp \
 	$(topdir)/tools/Text2GCE.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/Text2GCE.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/Text2GCE.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(OUT)/include/InputEvents_Text2NE.cpp: $(SRC)/Input/InputQueue.hpp \
 	$(topdir)/tools/Text2NE.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/Text2NE.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/Text2NE.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(OUT)/include/InputEvents_Char2GCE.cpp: $(SRC)/Input/InputQueue.hpp \
 	$(topdir)/tools/Char2GCE.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/Char2GCE.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/Char2GCE.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(OUT)/include/InputEvents_Char2NE.cpp: $(SRC)/Input/InputQueue.hpp \
 	$(topdir)/tools/Char2NE.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/Char2NE.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/Char2NE.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 XCI_LIST = default
 XCI_HEADERS = $(patsubst %,$(OUT)/include/InputEvents_%.cpp,$(XCI_LIST))
@@ -60,8 +61,8 @@ $(OUT)/include/InputEvents_default.cpp: $(topdir)/Data/Input/default.xci \
 	$(topdir)/tools/xci2cpp.pl \
 	| $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) $(topdir)/tools/xci2cpp.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) $(topdir)/tools/xci2cpp.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(call SRC_TO_OBJ,$(SRC)/Input/InputDefaults.cpp): $(XCI_HEADERS)
 $(call SRC_TO_OBJ,$(SRC)/Input/InputLookup.cpp): $(OUT)/include/InputEvents_Text2Event.cpp $(OUT)/include/InputEvents_Text2GCE.cpp $(OUT)/include/InputEvents_Text2NE.cpp
@@ -71,8 +72,8 @@ $(call SRC_TO_OBJ,$(SRC)/lua/InputEvent.cpp): $(OUT)/include/InputEvents_Char2GC
 $(OUT)/include/Status_defaults.cpp: Data/Status/default.xcs \
 	tools/xcs2cpp.pl | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) tools/xcs2cpp.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) tools/xcs2cpp.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 SM_OBJ = $(call SRC_TO_OBJ,$(SRC)/StatusMessage.cpp)
 $(SM_OBJ): $(OUT)/include/Status_defaults.cpp
@@ -92,8 +93,8 @@ $(TARGET_OUTPUT_DIR)/include/resource_data.h: $(TARGET_OUTPUT_DIR)/resources.txt
 	$(RESOURCE_FILES) \
 	tools/GenerateResources.pl | $(TARGET_OUTPUT_DIR)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) tools/GenerateResources.pl $< >$@.tmp
-	@mv $@.tmp $@
+	$(Q)$(PERL) tools/GenerateResources.pl $< >$@.$(RANDOM_NUMBER).tmp
+	@mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(call SRC_TO_OBJ,$(SRC)/ResourceLoader.cpp): $(TARGET_OUTPUT_DIR)/include/resource_data.h
 

--- a/build/host.mk
+++ b/build/host.mk
@@ -16,11 +16,13 @@ host-ld-libs = -lm -lstdc++
 WRAPPED_HOST_CC = $(CCACHE) $(HOSTCC)
 WRAPPED_HOST_CXX = $(CCACHE) $(HOSTCXX)
 
-$(HOST_OUTPUT_DIR)/%.o: %.c | $(HOST_OUTPUT_DIR)/%/../dirstamp
+.SECONDEXPANSION:
+
+$(HOST_OUTPUT_DIR)/%.o: %.c | $$(dir $$@)dirstamp
 	@$(NQ)echo "  HOSTCC  $@"
 	$(Q)$(WRAPPED_HOST_CC) -c $(host-cc-flags) -o $@ $^
 
-$(HOST_OUTPUT_DIR)/%.o: %.cpp | $(HOST_OUTPUT_DIR)/%/../dirstamp
+$(HOST_OUTPUT_DIR)/%.o: %.cpp | $$(dir $$@)dirstamp
 	@$(NQ)echo "  HOSTCXX $@"
 	$(Q)$(WRAPPED_HOST_CXX) -c $(host-cxx-flags) -o $@ $^
 

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -220,8 +220,8 @@ TEXT_FILES = AUTHORS COPYING NEWS.txt
 TEXT_COMPRESSED = $(patsubst %,$(DATA)/%.gz,$(TEXT_FILES))
 $(TEXT_COMPRESSED): $(DATA)/%.gz: % | $(DATA)/dirstamp
 	@$(NQ)echo "  GZIP    $@"
-	$(Q)gzip --best <$< >$@.tmp
-	$(Q)mv $@.tmp $@
+	$(Q)gzip --best <$< >$@.$(RANDOM_NUMBER).tmp
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 RESOURCE_FILES =
 
@@ -244,12 +244,14 @@ $(RESOURCE_FLAGS_STAMP): FORCE | $(TARGET_OUTPUT_DIR)/dirstamp
 		value=$(TESTING); \
 	fi; \
 	if [ ! -f $@ ] || [ "$$(cat $@ 2>/dev/null)" != "XCSOAR_TESTING=$$value" ]; then \
-		echo "XCSOAR_TESTING=$$value" > $@.tmp && mv $@.tmp $@; \
+		echo "XCSOAR_TESTING=$$value" > $@.$(RANDOM_NUMBER).tmp && \
+			mv $@.$(RANDOM_NUMBER).tmp $@; \
 	fi
 
 $(TARGET_OUTPUT_DIR)/resources.txt: Data/resources.txt $(RESOURCE_FLAGS_STAMP) | $(TARGET_OUTPUT_DIR)/dirstamp $(BUILD_TOOLCHAIN_TARGET)
 	@$(NQ)echo "  CPP     $@"
-	$(Q)cat $< |$(CC) -E -o $@ -I$(OUT)/include $(TARGET_CPPFLAGS) $(OPENGL_CPPFLAGS) $(GDI_CPPFLAGS) -
+	$(Q)cat $< |$(CC) -E -o $@.$(RANDOM_NUMBER).tmp -I$(OUT)/include $(TARGET_CPPFLAGS) $(OPENGL_CPPFLAGS) $(GDI_CPPFLAGS) -
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 RANDOM_NUMBER := $(shell od -vAn -N4 -tu4 < /dev/urandom| tr -d ' ')
 
@@ -260,8 +262,8 @@ $(TARGET_OUTPUT_DIR)/include/MakeResource.hpp: $(TARGET_OUTPUT_DIR)/resources.tx
 
 $(TARGET_OUTPUT_DIR)/include/ResourceLookup_entries.cpp: $(TARGET_OUTPUT_DIR)/resources.txt tools/GenerateResourceLookup.pl | $(TARGET_OUTPUT_DIR)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) tools/GenerateResourceLookup.pl <$< >$@.tmp
-	$(Q)mv $@.tmp $@
+	$(Q)$(PERL) tools/GenerateResourceLookup.pl <$< >$@.$(RANDOM_NUMBER).tmp
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(call SRC_TO_OBJ,$(SRC)/ResourceLookup.cpp): $(TARGET_OUTPUT_DIR)/include/ResourceLookup_entries.cpp $(TARGET_OUTPUT_DIR)/include/MakeResource.hpp
 
@@ -361,14 +363,14 @@ ifeq ($(USE_WIN32_RESOURCES),y)
 
 $(TARGET_OUTPUT_DIR)/XCSoar.rc: $(TARGET_OUTPUT_DIR)/resources.txt Data/XCSoar.rc tools/GenerateWindowsResources.pl
 	@$(NQ)echo "  GEN     $@"
-	$(Q)cp Data/XCSoar.rc $@.tmp
-	$(Q)$(PERL) tools/GenerateWindowsResources.pl $< >>$@.tmp
-	$(Q)mv $@.tmp $@
+	$(Q)cp Data/XCSoar.rc $@.$(RANDOM_NUMBER).tmp
+	$(Q)$(PERL) tools/GenerateWindowsResources.pl $< >>$@.$(RANDOM_NUMBER).tmp
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 $(TARGET_OUTPUT_DIR)/include/resource.h: $(TARGET_OUTPUT_DIR)/include/MakeResource.hpp | $(OUT)/include/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) -ne 'print "#define $$1 $$2\n" if /^MAKE_RESOURCE\((\w+), \S+, (\d+)\);/;' $< >$@.tmp
-	$(Q)mv $@.tmp $@
+	$(Q)$(PERL) -ne 'print "#define $$1 $$2\n" if /^MAKE_RESOURCE\((\w+), \S+, (\d+)\);/;' $< >$@.$(RANDOM_NUMBER).tmp
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 RESOURCE_BINARY = $(TARGET_OUTPUT_DIR)/XCSoar.rsc
 
@@ -382,8 +384,8 @@ $(TARGET_OUTPUT_DIR)/resources.c: export TARGET_IS_ANDROID:=$(TARGET_IS_ANDROID)
 $(TARGET_OUTPUT_DIR)/resources.c: export ENABLE_OPENGL:=$(OPENGL)
 $(TARGET_OUTPUT_DIR)/resources.c: $(TARGET_OUTPUT_DIR)/resources.txt $(RESOURCE_FILES) tools/LinkResources.pl tools/BinToC.pm | $(TARGET_OUTPUT_DIR)/resources/dirstamp
 	@$(NQ)echo "  GEN     $@"
-	$(Q)$(PERL) tools/LinkResources.pl <$< >$@.tmp
-	$(Q)mv $@.tmp $@
+	$(Q)$(PERL) tools/LinkResources.pl <$< >$@.$(RANDOM_NUMBER).tmp
+	$(Q)mv $@.$(RANDOM_NUMBER).tmp $@
 
 RESOURCES_SOURCES = $(TARGET_OUTPUT_DIR)/resources.c
 $(eval $(call link-library,resources,RESOURCES))


### PR DESCRIPTION
## Summary
- replace fixed `\$@.tmp` temporary paths with per-process temporary names in `build/resource.mk` and `build/generate.mk`
- harden resource/generation rules used by parallel `ANDROIDFAT` builds to avoid collisions in shared output directories
- fix intermittent missing generated files (notably `ResourceLookup_entries.cpp`) seen in F-Droid build failures

## Test plan
- [ ] `rm -rf output/ANDROID`
- [ ] `make TARGET=ANDROIDFAT DEBUG=n TESTING=n -j$(nproc)`
- [ ] repeat the same build multiple times to stress parallel generation paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build generation now uses randomized temporary filenames for intermediate outputs.
  * Build dependency handling updated to use per-target directory stamps with second-expansion semantics.
  * Overall improvements that enhance build robustness and reduce transient conflicts during generation and resource compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->