### PR TITLE
InfoBoxes/Content/Places: Add home waypoint selector to home altitude diff InfoBox

### DIFF
--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1124,7 +1124,7 @@ static constexpr MetaData meta_data[] = {
     N_("Home altitude difference"),
     N_("Home AltD"),
     N_("Arrival altitude at the home waypoint relative to the safety arrival height."),
-    UpdateInfoBoxHomeAltitudeDiff,
+    IBFHelper<InfoBoxContentHomeAltitudeDiff>::Create,
   },
 
   // e_SpeedTaskLeg

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -90,16 +90,20 @@ InfoBoxContentHomeAltitudeDiff::HandleClick() noexcept
     return false;
 
   const GeoPoint location = CommonInterface::Basic().location;
-  WaypointPtr waypoint =
-    ShowWaypointListDialog(*data_components->waypoints, location);
+  WaypointPtr waypoint;
+  try {
+    waypoint = ShowWaypointListDialog(*data_components->waypoints, location);
+  } catch (...) {
+    return false;
+  }
   if (!waypoint)
     return true;
 
   ComputerSettings &settings_computer = CommonInterface::SetComputerSettings();
-  settings_computer.poi.SetHome(*waypoint);
 
   {
     ScopeSuspendAllThreads suspend;
+    settings_computer.poi.SetHome(*waypoint);
     WaypointGlue::SetHome(*data_components->waypoints,
                           data_components->terrain.get(),
                           settings_computer.poi, settings_computer.team_code,

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -11,6 +11,16 @@
 #include "Formatter/Units.hpp"
 #include "Engine/GlideSolvers/GlideState.hpp"
 #include "Engine/GlideSolvers/MacCready.hpp"
+#include "Dialogs/Waypoint/WaypointDialogs.hpp"
+#include "Engine/Waypoint/Waypoint.hpp"
+#include "Engine/Waypoint/Waypoints.hpp"
+#include "Components.hpp"
+#include "BackendComponents.hpp"
+#include "DataComponents.hpp"
+#include "Waypoint/WaypointGlue.hpp"
+#include "Protection.hpp"
+#include "Profile/Current.hpp"
+#include "Profile/Profile.hpp"
 
 void
 UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept
@@ -34,16 +44,15 @@ UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept
 }
 
 void
-UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept
+InfoBoxContentHomeAltitudeDiff::Update(InfoBoxData &data) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
   const ComputerSettings &settings = CommonInterface::GetComputerSettings();
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
-  const MoreData &more_data = CommonInterface::Basic();
   const DerivedInfo &calculated = CommonInterface::Calculated();
 
   if (!basic.location_available ||
-      !more_data.NavAltitudeAvailable() ||
+      !basic.NavAltitudeAvailable() ||
       !settings.polar.glide_polar_task.IsValid() ||
       !common_stats.vector_home.IsValid() ||
       !settings.poi.home_location_available ||
@@ -56,7 +65,7 @@ UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept
   const GlideState glide_state(
     basic.location.DistanceBearing(settings.poi.home_location),
     settings.poi.home_elevation + settings.task.safety_height_arrival,
-    more_data.nav_altitude,
+    basic.nav_altitude,
     calculated.GetWindOrZero());
 
   const GlideResult &result =
@@ -68,6 +77,38 @@ UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept
   data.SetValueFromArrival(result.
                            SelectAltitudeDifference(settings.task.glide));
   data.SetCommentFromDistance(common_stats.vector_home.distance);
+}
+
+bool
+InfoBoxContentHomeAltitudeDiff::HandleClick() noexcept
+{
+  if (!data_components || !data_components->waypoints)
+    return false;
+
+  if (!backend_components || !backend_components->device_blackboard)
+    return false;
+
+  const GeoPoint location = CommonInterface::Basic().location;
+  WaypointPtr waypoint =
+    ShowWaypointListDialog(*data_components->waypoints, location);
+  if (!waypoint)
+    return true;
+
+  ComputerSettings &settings_computer = CommonInterface::SetComputerSettings();
+  settings_computer.poi.SetHome(*waypoint);
+
+  {
+    ScopeSuspendAllThreads suspend;
+    WaypointGlue::SetHome(*data_components->waypoints,
+                          data_components->terrain.get(),
+                          settings_computer.poi, settings_computer.team_code,
+                          backend_components->device_blackboard.get(), false);
+    WaypointGlue::SaveHome(Profile::map,
+                           settings_computer.poi, settings_computer.team_code);
+  }
+
+  Profile::Save();
+  return true;
 }
 
 void

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -46,13 +46,14 @@ UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept
 void
 InfoBoxContentHomeAltitudeDiff::Update(InfoBoxData &data) noexcept
 {
+  const MoreData &more_data = CommonInterface::Basic();
   const NMEAInfo &basic = CommonInterface::Basic();
   const ComputerSettings &settings = CommonInterface::GetComputerSettings();
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
   const DerivedInfo &calculated = CommonInterface::Calculated();
 
   if (!basic.location_available ||
-      !basic.NavAltitudeAvailable() ||
+      !more_data.NavAltitudeAvailable() ||
       !settings.polar.glide_polar_task.IsValid() ||
       !common_stats.vector_home.IsValid() ||
       !settings.poi.home_location_available ||
@@ -65,7 +66,7 @@ InfoBoxContentHomeAltitudeDiff::Update(InfoBoxData &data) noexcept
   const GlideState glide_state(
     basic.location.DistanceBearing(settings.poi.home_location),
     settings.poi.home_elevation + settings.task.safety_height_arrival,
-    basic.nav_altitude,
+    more_data.nav_altitude,
     calculated.GetWindOrZero());
 
   const GlideResult &result =

--- a/src/InfoBoxes/Content/Places.hpp
+++ b/src/InfoBoxes/Content/Places.hpp
@@ -3,13 +3,19 @@
 
 #pragma once
 
+#include "InfoBoxes/Content/Base.hpp"
+
 struct InfoBoxData;
 
 void
 UpdateInfoBoxHomeDistance(InfoBoxData &data) noexcept;
 
-void
-UpdateInfoBoxHomeAltitudeDiff(InfoBoxData &data) noexcept;
+class InfoBoxContentHomeAltitudeDiff : public InfoBoxContent
+{
+public:
+  void Update(InfoBoxData &data) noexcept override;
+  bool HandleClick() noexcept override;
+};
 
 void
 UpdateInfoBoxTakeoffDistance(InfoBoxData &data) noexcept;


### PR DESCRIPTION
This pull request refactors and enhances the handling of the "Home Altitude Difference" InfoBox content. The main changes involve converting the old function-based implementation into a dedicated class, improving encapsulation and maintainability, and adding support for user interaction to select a new home waypoint directly from the InfoBox.

**Refactoring and encapsulation:**

* Replaced the standalone `UpdateInfoBoxHomeAltitudeDiff` function with a new `InfoBoxContentHomeAltitudeDiff` class that inherits from `InfoBoxContent`, moving the update logic into the `Update` method and registering it in the InfoBox meta data. [[1]](diffhunk://#diff-6d23c5d4ea25ab9ab538462308fb07db78d1c75a22681dc02bc5fd51bcb1fe4dR6-R18) [[2]](diffhunk://#diff-6f354ba38528840b719de7ac5ed9ba711d76aa3637f4759b3e6add1767b947a0L1127-R1127) [[3]](diffhunk://#diff-e050015629f9827ee22c4183902ecb59491ff0012040b2161efb0cc72aae198bL37-R55)

**User interaction enhancements:**

* Added a `HandleClick` method to `InfoBoxContentHomeAltitudeDiff` that allows users to select a new home waypoint via a dialog, updates the settings, and saves the new home location. [[1]](diffhunk://#diff-6d23c5d4ea25ab9ab538462308fb07db78d1c75a22681dc02bc5fd51bcb1fe4dR6-R18) [[2]](diffhunk://#diff-e050015629f9827ee22c4183902ecb59491ff0012040b2161efb0cc72aae198bR82-R110)

**Code correctness and cleanup:**

* Fixed usage of navigation altitude by replacing references to `more_data.nav_altitude` with the correct `basic.nav_altitude`, ensuring accurate calculations. [[1]](diffhunk://#diff-e050015629f9827ee22c4183902ecb59491ff0012040b2161efb0cc72aae198bL37-R55) [[2]](diffhunk://#diff-e050015629f9827ee22c4183902ecb59491ff0012040b2161efb0cc72aae198bL59-R68)
* Added missing includes for waypoint and dialog functionality to support the new interaction features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Home altitude-difference info box is now interactive: click to open a waypoint picker, select a waypoint to set it as home, and the change is saved automatically.

* **Refactor**
  * Altitude-difference content has been reorganized for more direct instantiation and clearer component responsibilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->