### PR TITLE
Projection/MapWindowProjection: Tighten map scale for obstacle waypoints

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,9 @@
 Version 7.45 - not yet released
+* map
+  - obstacles hidden at wider map scales than other non-landables (5000 vs 10000)
+  - draw up to 1024 waypoints at once (was 256) #2327
+* ui
+  - infoboxen: refresh titles after changing the interface language #2314
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -119,6 +119,13 @@ InfoBoxManager::SetDirty() noexcept
 }
 
 void
+InfoBoxManager::InvalidateAfterLanguageChange() noexcept
+{
+  first = true;
+  SetDirty();
+}
+
+void
 InfoBoxManager::ScheduleRedraw() noexcept
 {
   if (infoboxes_hidden)

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -19,6 +19,14 @@ ProcessTimer() noexcept;
 void
 SetDirty() noexcept;
 
+/**
+ * Call after the UI language was switched (#ReadLanguageFile) so
+ * captions and content use the new gettext catalogue on the next draw
+ * (#2314).
+ */
+void
+InvalidateAfterLanguageChange() noexcept;
+
 void
 ScheduleRedraw() noexcept;
 

--- a/src/Projection/MapWindowProjection.cpp
+++ b/src/Projection/MapWindowProjection.cpp
@@ -36,10 +36,28 @@ static constexpr unsigned ScaleList[] = {
 
 static constexpr unsigned ScaleListCount = std::size(ScaleList);
 
+namespace {
+
+/**
+ * Largest #GetMapScale() at which this waypoint is still drawn (aligned with
+ * #ScaleList steps; lower threshold = hidden sooner when zooming out).
+ */
+static double
+WaypointDrawMaxScale(const Waypoint &wp) noexcept
+{
+  if (wp.IsLandable())
+    return 20000;
+  if (wp.type == Waypoint::Type::OBSTACLE)
+    return 5000;
+  return 10000;
+}
+
+} // namespace
+
 bool
 MapWindowProjection::WaypointInScaleFilter(const Waypoint &way_point) const noexcept
 {
-  return (GetMapScale() <= (way_point.IsLandable() ? 20000 : 10000));
+  return GetMapScale() <= WaypointDrawMaxScale(way_point);
 }
 
 double

--- a/src/Projection/MapWindowProjection.hpp
+++ b/src/Projection/MapWindowProjection.hpp
@@ -33,6 +33,7 @@ public:
   [[gnu::pure]]
   double StepMapScale(double scale, int Step) const noexcept;
 
+  /** Current map scale within draw band for this waypoint type (#GetMapScale units). */
   [[gnu::pure]]
   bool WaypointInScaleFilter(const Waypoint &way_point) const noexcept;
 

--- a/src/Renderer/MapWaypointDrawLimits.hpp
+++ b/src/Renderer/MapWaypointDrawLimits.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstddef>
+
+/**
+ * Maximum number of map waypoint symbols (and matching label slots) prepared
+ * per frame.  #WaypointVisitorMap and #WaypointLabelList must use the same
+ * cap.  Larger values increase DrawThread stack use (~size of #VisibleWaypoint
+ * and #WaypointLabelList::Label per entry).
+ */
+inline constexpr std::size_t MAX_MAP_WAYPOINT_DRAW = 1024;

--- a/src/Renderer/WaypointLabelList.hpp
+++ b/src/Renderer/WaypointLabelList.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "Renderer/MapWaypointDrawLimits.hpp"
 #include "Renderer/TextInBox.hpp"
 #include "ui/dim/Point.hpp"
 #include "ui/dim/Rect.hpp"
@@ -29,7 +30,7 @@ public:
 protected:
   PixelRect clip_rect;
 
-  StaticArray<Label, 256u> labels;
+  StaticArray<Label, MAX_MAP_WAYPOINT_DRAW> labels;
 
 public:
   explicit WaypointLabelList(PixelRect _rect) noexcept

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "WaypointRenderer.hpp"
+#include "Renderer/MapWaypointDrawLimits.hpp"
 #include "WaypointRendererSettings.hpp"
 #include "WaypointIconRenderer.hpp"
 #include "WaypointLabelList.hpp"
@@ -144,7 +145,7 @@ class WaypointVisitorMap final
    * should ensure that the drawing methods don't need to hold a
    * mutex.
    */
-  StaticArray<VisibleWaypoint, 256> waypoints;
+  StaticArray<VisibleWaypoint, MAX_MAP_WAYPOINT_DRAW> waypoints;
 
   WaypointIconRenderer icon_renderer;
 

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -90,8 +90,10 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   MainWindow &main_window = *CommonInterface::main_window;
 
-  if (LanguageChanged)
+  if (LanguageChanged) {
     ReadLanguageFile();
+    InfoBoxManager::InvalidateAfterLanguageChange();
+  }
 
   bool TerrainFileChanged = false, TopographyFileChanged = false;
   if (MapFileChanged) {


### PR DESCRIPTION
## Summary
Obstacle waypoints (e.g. from dense airspace/obstacle files) clutter the map when zoomed out. This change draws them only up to map scale **5000**, while other non-landables stay at **10000** and landables at **20000** (same units as `GetMapScale()` / the map scale list).

## Implementation
- Factor thresholds into `WaypointDrawMaxScale()` so `WaypointInScaleFilter()` stays a single comparison.
- `NEWS.txt`: v7.45 map bullet.

## Related
Dense waypoint files / map clutter (e.g. discussion around #2327); this is a lighter-weight filter-only approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Obstacles now hide at wider map scales (scale threshold increased), reducing clutter at broader zoom levels.
* **Chores**
  * Increased the map waypoint drawing cap to 1024 to support denser waypoint datasets and prevent missed symbols/labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->