### PR TITLE
Restore NetCoupe scoring

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,7 +10,6 @@ Version 7.44 - 2026-03-22
   - Add pan capability to the waypoint details image #1127
   - Show waypoint type and runway width
 * calculations
-  - remove FFVV NetCoupe #1259
   - update sprint/league time window to 2 hours (as per OLC and DMSt rules)
   - update OLC League calculation to latest ruleset
   - improved circling wind algorithm: uses cosine curve fitting with True

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,8 @@ Version 7.45 - not yet released
   - draw up to 1024 waypoints at once (was 256) #2327
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
+* calculations
+  - restore FFVV NetCoupe contest optimisation #2330
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/build/libcontest.mk
+++ b/build/libcontest.mk
@@ -21,6 +21,7 @@ CONTEST_SOURCES = \
 	$(CONTEST_SRC_DIR)/Solvers/XContestFree.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/XContestTriangle.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/OLCSISAT.cpp \
+	$(CONTEST_SRC_DIR)/Solvers/NetCoupe.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/Retrospective.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/WeglideFree.cpp \
 	$(CONTEST_SRC_DIR)/Solvers/WeglideDistance.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -122,6 +122,7 @@ TEST_NAMES = \
 	TestPackedFloat \
 	TestVersionNumber \
 	TestWeglideScoring \
+	TestNetCoupeScoring \
 	TestDMStScoring \
 	TestHttpsVerify
 
@@ -2532,6 +2533,12 @@ TEST_WEGLIDE_SCORING_SOURCES = \
 	$(TEST_SRC_DIR)/TestWeglideScoring.cpp
 TEST_WEGLIDE_SCORING_DEPENDS = MATH
 $(eval $(call link-program,TestWeglideScoring,TEST_WEGLIDE_SCORING))
+
+TEST_NETCOUPE_SCORING_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestNetCoupeScoring.cpp
+TEST_NETCOUPE_SCORING_DEPENDS = MATH
+$(eval $(call link-program,TestNetCoupeScoring,TEST_NETCOUPE_SCORING))
 
 TEST_DMST_SCORING_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -583,7 +583,7 @@ rules. \label{conf:taskrules}\index{Aufgabe!Regeln Voreinstellung}
   {\bf XContest}: \todonum{noch zu schreiben} \\
   {\bf DHV-XC}: \todonum{noch zu schreiben} \\
   {\bf SIS-AT}: \todonum{noch zu schreiben} \\
-  {\bf FFVV NetCoupe}: Der FFVV NetCoupe {\it ''libre''} Wettbewerb.
+  {\bf FFVV NetCoupe}: Der FFVV NetCoupe {\it ''libre''} Wettbewerb. \\
   {\bf WeGlide FREE}: \todonum{noch zu schreiben} \\
   {\bf WeGlide O\&R}: \todonum{noch zu schreiben} \\
 \item[\textit{Wertungs-Vorhersage}]  {\bf Ein / Aus}: Wenn eingeschaltet, wird angenommen, daß der nächste Wegpunkt erreicht wird und

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -583,6 +583,7 @@ rules. \label{conf:taskrules}\index{Aufgabe!Regeln Voreinstellung}
   {\bf XContest}: \todonum{noch zu schreiben} \\
   {\bf DHV-XC}: \todonum{noch zu schreiben} \\
   {\bf SIS-AT}: \todonum{noch zu schreiben} \\
+  {\bf FFVV NetCoupe}: Der FFVV NetCoupe {\it ''libre''} Wettbewerb.
   {\bf WeGlide FREE}: \todonum{noch zu schreiben} \\
   {\bf WeGlide O\&R}: \todonum{noch zu schreiben} \\
 \item[\textit{Wertungs-Vorhersage}]  {\bf Ein / Aus}: Wenn eingeschaltet, wird angenommen, daß der nächste Wegpunkt erreicht wird und

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -624,7 +624,7 @@ rules. \label{conf:taskrules}
   {\bf XContest}: \todonum{tbd.} \\
   {\bf DHV-XC}: \todonum{tbd.} \\
   {\bf SIS-AT}: \todonum{tbd.} \\
-  {\bf FFVV NetCoupe}: The FFVV NetCoupe `{\it libre}' competition.
+  {\bf FFVV NetCoupe}: The FFVV NetCoupe `{\it libre}' competition. \\
   {\bf WeGlide FREE}: WeGlide combines multiple scoring systems in the WeGlide Free contest. The free score is a combination of the free distance score and the area bonus. For the area bonus, the scoring program determines the largest FAI triangle and the largest Out I\& Return distance that can be fitted into the flight route. \\
   {\bf WeGlide O\&R}: A start point, one turn point and a finish point are chosen from the flight path such that the distance between the start point and the turn point is maximized. \\
 \item[Predict Contest]  If enabled, then the next task point is included in the 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -624,6 +624,7 @@ rules. \label{conf:taskrules}
   {\bf XContest}: \todonum{tbd.} \\
   {\bf DHV-XC}: \todonum{tbd.} \\
   {\bf SIS-AT}: \todonum{tbd.} \\
+  {\bf FFVV NetCoupe}: The FFVV NetCoupe `{\it libre}' competition.
   {\bf WeGlide FREE}: WeGlide combines multiple scoring systems in the WeGlide Free contest. The free score is a combination of the free distance score and the area bonus. For the area bonus, the scoring program determines the largest FAI triangle and the largest Out I\& Return distance that can be fitted into the flight route. \\
   {\bf WeGlide O\&R}: A start point, one turn point and a finish point are chosen from the flight path such that the distance between the start point and the turn point is maximized. \\
 \item[Predict Contest]  If enabled, then the next task point is included in the 

--- a/doc/manual/fr/XCSoar-Prise-en-main.tex
+++ b/doc/manual/fr/XCSoar-Prise-en-main.tex
@@ -147,7 +147,7 @@
 
 \subsection*{\textcolor{flashblue}{Faire les vérification post-vol}}
 \begin{compactitem}
-\item Télécharger les enregistrements du vol depuis l'enregistreur, les mettre sur skylines et l'OLC
+\item Télécharger les enregistrements du vol depuis l'enregistreur, les mettre sur skylines, la netcoupe et l'OLC
 \item Récupérer les données statistiques sur le vol.
 \end{compactitem}
 
@@ -620,10 +620,10 @@ Pour avoir accès à plus d'informations statistiques.
 
 \subsection{\textcolor{flashblue}{Mettre en ligne un vol}}
 
-Il y a deux portails qui attendent de voir les enregistrements de vos vols.
-Skylines (\url{https://skylines.aero})
-et OLC (\url{https://www.onlinecontest.org}).
-Si vous voulez y mettre en ligne un vol, probablement avez-vous intérêt à le faire immédiatement après le vol. L'OLC vous donne un délai de 24~heures pour y copier vos enregistrements.
+Il y a trois portails qui attendent de voir les enregistrements de vos vols.
+Skylines (\url{https://skylines.aero}), NetCoupe (\url{http://www.netcoupe.net})
+et OLC (\url{http://www.onlinecontest.org}).
+Si vous voulez y mettre en ligne un vol, probablement avez-vous intérêt à le faire immédiatement après le vol. L'OLC vous donne un délai de 24~heures pour y copier vos enregistrements ;  la NetCoupe deux semaines.
 Skylines est un peu moins restrictif, et est votre portail pour le suivi en temps réel et\textellipsis\
 vos fichiers de vols sont dans un sous-répertoire \texttt{logs}.
 

--- a/doc/manual/fr/XCSoar-Prise-en-main.tex
+++ b/doc/manual/fr/XCSoar-Prise-en-main.tex
@@ -147,7 +147,7 @@
 
 \subsection*{\textcolor{flashblue}{Faire les vérification post-vol}}
 \begin{compactitem}
-\item Télécharger les enregistrements du vol depuis l'enregistreur, les mettre sur skylines, la netcoupe et l'OLC
+\item Télécharger les enregistrements du vol depuis l'enregistreur, les mettre sur Skylines, WeGlide (NetCoupe) et l'OLC
 \item Récupérer les données statistiques sur le vol.
 \end{compactitem}
 
@@ -621,9 +621,9 @@ Pour avoir accès à plus d'informations statistiques.
 \subsection{\textcolor{flashblue}{Mettre en ligne un vol}}
 
 Il y a trois portails qui attendent de voir les enregistrements de vos vols.
-Skylines (\url{https://skylines.aero}), NetCoupe (\url{http://www.netcoupe.net})
-et OLC (\url{http://www.onlinecontest.org}).
-Si vous voulez y mettre en ligne un vol, probablement avez-vous intérêt à le faire immédiatement après le vol. L'OLC vous donne un délai de 24~heures pour y copier vos enregistrements ;  la NetCoupe deux semaines.
+Skylines (\url{https://skylines.aero}), la Coupe Fédérale FFVP (NetCoupe) sur WeGlide (\url{https://ffvp.weglide.org/})
+et OLC (\url{https://www.onlinecontest.org/}).
+Si vous voulez y mettre en ligne un vol, probablement avez-vous intérêt à le faire immédiatement après le vol. L'OLC vous donne un délai de 24~heures pour y copier vos enregistrements ; pour la Coupe Fédérale sur WeGlide, le règlement impose en général un envoi avant midi deux jours après l'atterrissage (détails sur le site).
 Skylines est un peu moins restrictif, et est votre portail pour le suivi en temps réel et\textellipsis\
 vos fichiers de vols sont dans un sous-répertoire \texttt{logs}.
 

--- a/doc/manual/fr/installation.tex
+++ b/doc/manual/fr/installation.tex
@@ -73,7 +73,7 @@ du manuel \texttt{XCSoar-Prise-en-main} et de parcourir la \emph{Checklist d'XCS
 
 \subsection*{Faire les vérification post-vol}
 \begin{itemize}
-\item Télécharger les logs du vol depuis l'enregistreur, les mettre sur skylines et l'OLC
+\item Télécharger les logs du vol depuis l'enregistreur, les mettre sur skylines, la netcoupe et l'OLC
 \item Récupérer les données statistiques sur le vol.
 \end{itemize}
 \newpage

--- a/doc/manual/fr/installation.tex
+++ b/doc/manual/fr/installation.tex
@@ -73,7 +73,7 @@ du manuel \texttt{XCSoar-Prise-en-main} et de parcourir la \emph{Checklist d'XCS
 
 \subsection*{Faire les vérification post-vol}
 \begin{itemize}
-\item Télécharger les logs du vol depuis l'enregistreur, les mettre sur skylines, la netcoupe et l'OLC
+\item Télécharger les logs du vol depuis l'enregistreur, les mettre sur Skylines, WeGlide (NetCoupe) et l'OLC
 \item Récupérer les données statistiques sur le vol.
 \end{itemize}
 \newpage

--- a/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
@@ -96,7 +96,13 @@ ScoringConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
       N_("Austrian online glider contest. Tracks around max. six waypoints are scored. The "
           "bounding box part with 1 km = 1.0 point and the additional zick-zack part with 1 km = 0.5 p.") },
     { Contest::NET_COUPE, ContestToString(Contest::NET_COUPE),
-      N_("The FFVV NetCoupe \"libre\" competiton.") },
+      N_("FFVP Federal Cup (NetCoupe) on WeGlide. The scored path has at most "
+          "three turnpoints between start and finish and at least 25 km total. "
+          "Points are proportional to credited distance, 100 divided by the "
+          "glider handicap (DAeC-style index), and a success factor of 1.0 for "
+          "a free flight or 1.2 for a task declared electronically before "
+          "takeoff. XCSoar live scoring uses a success factor of 1.0 only, not "
+          "the 1.2 multiplier for declared tasks.") },
     { Contest::WEGLIDE_FREE, ContestToString(Contest::WEGLIDE_FREE),
       N_("WeGlide combines multiple scoring systems in the WeGlide Free contest. The free score is a combination "
           "of the free distance score and the area bonus. For the area bonus, the scoring program determines the "

--- a/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
@@ -95,6 +95,8 @@ ScoringConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
     { Contest::SIS_AT, ContestToString(Contest::SIS_AT),
       N_("Austrian online glider contest. Tracks around max. six waypoints are scored. The "
           "bounding box part with 1 km = 1.0 point and the additional zick-zack part with 1 km = 0.5 p.") },
+    { Contest::NET_COUPE, ContestToString(Contest::NET_COUPE),
+      N_("The FFVV NetCoupe \"libre\" competiton.") },
     { Contest::WEGLIDE_FREE, ContestToString(Contest::WEGLIDE_FREE),
       N_("WeGlide combines multiple scoring systems in the WeGlide Free contest. The free score is a combination "
           "of the free distance score and the area bonus. For the area bonus, the scoring program determines the "

--- a/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
@@ -3,6 +3,7 @@
 
 #include "ScoringConfigPanel.hpp"
 #include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Boolean.hpp"
 #include "Form/DataField/Listener.hpp"
@@ -176,6 +177,14 @@ ScoringConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValue(SHOW_95_PERCENT_RULE_HELPERS,
                        ProfileKeys::Show95PercentRuleHelpers,
                        map_settings.show_95_percent_rule_helpers);
+
+  /* Mark profile as using current Contest enum encoding (see ContestProfile). */
+  unsigned contest_enum_layout = 0;
+  if (!Profile::Get(ProfileKeys::ContestEnumLayout, contest_enum_layout) ||
+      contest_enum_layout < 2U) {
+    Profile::Set(ProfileKeys::ContestEnumLayout, 2U);
+    changed = true;
+  }
 
   _changed |= changed;
 

--- a/src/Engine/Contest/ContestManager.cpp
+++ b/src/Engine/Contest/ContestManager.cpp
@@ -21,6 +21,7 @@ ContestManager::ContestManager(const Contest _contest,
    dhv_xc_free(trace_full, true),
    dhv_xc_triangle(trace_triangle, predict_triangle, true),
    sis_at(trace_full),
+   net_coupe(trace_full),
    weglide_distance(trace_full),
    weglide_fai(trace_triangle, predict_triangle),
    weglide_or(trace_full),
@@ -44,6 +45,7 @@ ContestManager::SetIncremental(bool incremental) noexcept
   dhv_xc_free.SetIncremental(incremental);
   dhv_xc_triangle.SetIncremental(incremental);
   sis_at.SetIncremental(incremental);
+  net_coupe.SetIncremental(incremental);
   weglide_distance.SetIncremental(incremental);
   weglide_fai.SetIncremental(incremental);
   weglide_or.SetIncremental(incremental);
@@ -78,7 +80,9 @@ ContestManager::SetPredicted(const TracePoint &predicted) noexcept
         contest == Contest::DMST)
       stats.Reset();
   }
-  
+
+  if (net_coupe.SetPredicted(predicted) && contest == Contest::NET_COUPE)
+    stats.Reset();
   if (weglide_distance.SetPredicted(predicted)) {
     weglide_fai.Reset();
     weglide_or.Reset();
@@ -122,6 +126,7 @@ ContestManager::SetHandicap(unsigned handicap) noexcept
   dhv_xc_free.SetHandicap(handicap);
   dhv_xc_triangle.SetHandicap(handicap);
   sis_at.SetHandicap(handicap);
+  net_coupe.SetHandicap(handicap);
   weglide_free.SetHandicap(handicap);
   weglide_distance.SetHandicap(handicap);
   weglide_fai.SetHandicap(handicap);
@@ -243,6 +248,11 @@ ContestManager::UpdateIdle(bool exhaustive) noexcept
                         stats.solution[0], exhaustive);
     break;
 
+  case Contest::NET_COUPE:
+    retval = RunContest(net_coupe, stats.result[0],
+                        stats.solution[0], exhaustive);
+    break;
+
   case Contest::WEGLIDE_FREE:
     retval = RunContest(weglide_distance, stats.result[0],
                         stats.solution[0], exhaustive);
@@ -311,6 +321,7 @@ ContestManager::Reset() noexcept
   dhv_xc_free.Reset();
   dhv_xc_triangle.Reset();
   sis_at.Reset();
+  net_coupe.Reset();
   weglide_free.Reset();
   weglide_distance.Reset();
   weglide_fai.Reset();

--- a/src/Engine/Contest/ContestManager.hpp
+++ b/src/Engine/Contest/ContestManager.hpp
@@ -16,6 +16,7 @@
 #include "Solvers/XContestFree.hpp"
 #include "Solvers/XContestTriangle.hpp"
 #include "Solvers/OLCSISAT.hpp"
+#include "Solvers/NetCoupe.hpp"
 #include "Solvers/WeglideFree.hpp"
 #include "Solvers/WeglideDistance.hpp"
 #include "Solvers/WeglideFAI.hpp"
@@ -50,6 +51,7 @@ class ContestManager
   XContestFree dhv_xc_free;
   XContestTriangle dhv_xc_triangle;
   OLCSISAT sis_at;
+  NetCoupe net_coupe;
   WeglideFree weglide_free;
   WeglideDistance weglide_distance;
   WeglideFAI weglide_fai;

--- a/src/Engine/Contest/Settings.hpp
+++ b/src/Engine/Contest/Settings.hpp
@@ -19,7 +19,6 @@ enum class Contest : uint8_t {
   XCONTEST,
   DHV_XC,
   SIS_AT,
-  NET_COUPE,
 
   /**
    * Deutsche Meisterschaft im Streckensegelflug (Germany).
@@ -32,6 +31,12 @@ enum class Contest : uint8_t {
   WEGLIDE_OR,
 
   CHARRON,
+
+  /**
+   * FFVP Federal Cup (NetCoupe); placed before #NONE so profile values
+   * 0..13 stay aligned with v7.44 after NET_COUPE was removed from the enum.
+   */
+  NET_COUPE,
 
   NONE,
 };

--- a/src/Engine/Contest/Settings.hpp
+++ b/src/Engine/Contest/Settings.hpp
@@ -19,6 +19,7 @@ enum class Contest : uint8_t {
   XCONTEST,
   DHV_XC,
   SIS_AT,
+  NET_COUPE,
 
   /**
    * Deutsche Meisterschaft im Streckensegelflug (Germany).

--- a/src/Engine/Contest/Solvers/Contests.cpp
+++ b/src/Engine/Contest/Solvers/Contests.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Contests.hpp"
+#include "../Settings.hpp"
 #include "util/Macros.hpp"
 
 static const char *const contest_to_string[] = {
@@ -13,15 +14,19 @@ static const char *const contest_to_string[] = {
   "XContest",
   "DHV-XC",
   "SIS-AT",
-  "FFVV NetCoupe",
   "DMSt",
   "WeGlide FREE",
   "WeGlide Distance",
   "WeGlide FAI",
   "WeGlide O&R",
   "Charron",
+  "FFVV NetCoupe",
   "None",
 };
+
+static_assert(
+    ARRAY_SIZE(contest_to_string) == unsigned(Contest::NONE) + 1,
+    "contest_to_string must follow Contest enum order");
 
 const char*
 ContestToString(Contest contest) noexcept

--- a/src/Engine/Contest/Solvers/Contests.cpp
+++ b/src/Engine/Contest/Solvers/Contests.cpp
@@ -13,6 +13,7 @@ static const char *const contest_to_string[] = {
   "XContest",
   "DHV-XC",
   "SIS-AT",
+  "FFVV NetCoupe",
   "DMSt",
   "WeGlide FREE",
   "WeGlide Distance",

--- a/src/Engine/Contest/Solvers/NetCoupe.cpp
+++ b/src/Engine/Contest/Solvers/NetCoupe.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NetCoupe.hpp"
+
+NetCoupe::NetCoupe(const Trace &_trace) noexcept
+  :ContestDijkstra(_trace, true, 4, 1000) {}
+
+ContestResult
+NetCoupe::CalculateResult() const noexcept
+{
+  ContestResult result = ContestDijkstra::CalculateResult();
+  // 0.8 factor for free distance and 1/1000 m -> km
+  result.score = ApplyHandicap(result.distance * 0.0008);
+  return result;
+}
+

--- a/src/Engine/Contest/Solvers/NetCoupe.cpp
+++ b/src/Engine/Contest/Solvers/NetCoupe.cpp
@@ -10,8 +10,16 @@ ContestResult
 NetCoupe::CalculateResult() const noexcept
 {
   ContestResult result = ContestDijkstra::CalculateResult();
-  // 0.8 factor for free distance and 1/1000 m -> km
-  result.score = ApplyHandicap(result.distance * 0.0008);
+  /**
+   * FFVP Coupe Fédérale (WeGlide):
+   * https://docs.weglide.org/contests/national/ffvp_coupe_federale.html
+   *
+   * Points = Distance_km x (100 / Handicap) x Success_Index
+   *
+   * "Free" flight uses Success_Index = 1.0.  The in-flight optimiser does
+   * not know an electronically declared task, so we do not apply 1.2 here.
+   */
+  result.score = ApplyHandicap(result.distance / 1000.0);
   return result;
 }
 

--- a/src/Engine/Contest/Solvers/NetCoupe.hpp
+++ b/src/Engine/Contest/Solvers/NetCoupe.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ContestDijkstra.hpp"
+
+/**
+ * Specialisation of Contest Dijkstra for FFVV NetCoupe rules
+ */
+class NetCoupe : public ContestDijkstra {
+public:
+  explicit NetCoupe(const Trace &_trace) noexcept;
+
+protected:
+  /* virtual methods from class AbstractContest */
+  ContestResult CalculateResult() const noexcept override;
+};

--- a/src/Profile/ContestProfile.cpp
+++ b/src/Profile/ContestProfile.cpp
@@ -9,10 +9,26 @@
 void
 Profile::Load(const ProfileMap &map, ContestSettings &settings)
 {
+  unsigned contest_enum_layout = 0;
+  const bool have_contest_layout =
+      map.Get(ProfileKeys::ContestEnumLayout, contest_enum_layout);
+
   if (map.GetEnum(ProfileKeys::OLCRules, settings.contest)) {
     /* handle out-dated Sprint rule in profile */
     if (settings.contest == Contest::OLC_SPRINT)
       settings.contest = Contest::OLC_LEAGUE;
+
+    /**
+     * v7.44 removed NET_COUPE from the enum: stored NONE was 14 while CHARRON
+     * was 13, matching the layout again after NET_COUPE was reinserted before
+     * NONE.  Profiles without #ContestEnumLayout still use that encoding for
+     * the last slot only.
+     */
+    if (!have_contest_layout || contest_enum_layout < 2) {
+      const unsigned v = static_cast<unsigned>(settings.contest);
+      if (v == 14U)
+        settings.contest = Contest::NONE;
+    }
   }
 
   map.Get(ProfileKeys::PredictContest, settings.predict);

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -185,6 +185,13 @@ constexpr std::string_view EnableExternalTriggerCruise = "EnableExternalTriggerC
 constexpr std::string_view CruiseToCirclingModeSwitchThreshold = "CruiseToCirclingModeSwitchThreshold";
 constexpr std::string_view CirclingToCruiseModeSwitchThreshold = "CirclingToCruiseModeSwitchThreshold";
 constexpr std::string_view OLCRules = "OLCRules"; // legacy name, key contains contest rules
+/**
+ * Encoding version for #OLCRules numeric values (Contest enum).
+ * Value >= 2: matches current enum (NET_COUPE before NONE).  Missing or < 2:
+ * apply ContestProfile legacy migration for profiles from v7.44 without
+ * NET_COUPE in the enum.
+ */
+constexpr std::string_view ContestEnumLayout = "ContestEnumLayout";
 constexpr std::string_view PredictContest = "PredictContest";
 constexpr std::string_view Handicap = "Handicap";
 constexpr std::string_view SnailWidthScale = "SnailWidthScale";

--- a/src/Renderer/FlightStatisticsRenderer.cpp
+++ b/src/Renderer/FlightStatisticsRenderer.cpp
@@ -150,6 +150,7 @@ FlightStatisticsRenderer::RenderContest(Canvas &canvas, const PixelRect rc,
   case Contest::OLC_SPRINT:
   case Contest::OLC_CLASSIC:
   case Contest::SIS_AT:
+  case Contest::NET_COUPE:
   case Contest::DMST:
     DrawContestSolution(canvas, proj, contest, 0);
     break;

--- a/test/src/RunContestAnalysis.cpp
+++ b/test/src/RunContestAnalysis.cpp
@@ -41,6 +41,8 @@ static ContestManager xcontest(Contest::XCONTEST,
                                full_trace, triangle_trace, sprint_trace);
 static ContestManager sis_at(Contest::SIS_AT,
                              full_trace, triangle_trace, sprint_trace);
+static ContestManager olc_netcoupe(Contest::NET_COUPE,
+                                   full_trace, triangle_trace, sprint_trace);
 static ContestManager weglide_free(Contest::WEGLIDE_FREE,
                                full_trace, triangle_trace, sprint_trace);
 static ContestManager charron(Contest::CHARRON,
@@ -86,6 +88,7 @@ TestContest(DebugReplay &replay)
   dmst.SolveExhaustive();
   xcontest.SolveExhaustive();
   sis_at.SolveExhaustive();
+  olc_netcoupe.SolveExhaustive();
   weglide_free.SolveExhaustive();
   charron.SolveExhaustive();
 
@@ -129,6 +132,8 @@ TestContest(DebugReplay &replay)
   std::cout << "sis_at\n";
   PrintHelper::print(sis_at.GetStats().GetResult(0));
 
+  std::cout << "netcoupe\n";
+  PrintHelper::print(olc_netcoupe.GetStats().GetResult());
 
   std::cout << "weglide\n";
   std::cout << "# distance\n";
@@ -150,6 +155,7 @@ TestContest(DebugReplay &replay)
   olc_league.Reset();
   olc_plus.Reset();
   dmst.Reset();
+  olc_netcoupe.Reset();
   weglide_free.Reset();
   charron.Reset();
   full_trace.clear();

--- a/test/src/TestNetCoupeScoring.cpp
+++ b/test/src/TestNetCoupeScoring.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "TestUtil.hpp"
+
+#include <cmath>
+
+extern "C" {
+#include "tap.h"
+}
+
+/**
+ * FFVP Coupe Fédérale (NetCoupe) scoring per WeGlide documentation:
+ * https://docs.weglide.org/contests/national/ffvp_coupe_federale.html
+ *
+ * Points_Flight = Distance_km x (100 / Handicap_Glider) x Success_Index
+ *
+ * - "Free" flight: Success_Index = 1.0
+ * - "As declared" (tasked): Success_Index = 1.2
+ *
+ * Matches NetCoupe::CalculateResult() for Success_Index = 1.0: raw
+ * points per km = 1.0, then ApplyHandicap (×100/handicap), same pattern
+ * as WeglideDistance.
+ */
+static double
+CalculateFfvpScore(double distance_m, unsigned handicap,
+                   double success_index) noexcept
+{
+  double distance_km = distance_m / 1000.0;
+  return distance_km * (100.0 / handicap) * success_index;
+}
+
+static double
+RoundScore(double score) noexcept
+{
+  return std::round(score * 100.0) / 100.0;
+}
+
+/**
+ * Free-flight cases (Success_Index = 1.0); same numeric checks as
+ * TestWeglideDistance (identical distance handicap scaling).
+ */
+static void
+TestFfvpFreeFlight()
+{
+  double expected = CalculateFfvpScore(149000, 107, 1.0);
+  double rounded = RoundScore(expected);
+  ok1(equals(rounded, 139.25));
+
+  expected = CalculateFfvpScore(100000, 100, 1.0);
+  ok1(equals(expected, 100.0));
+
+  expected = CalculateFfvpScore(200000, 120, 1.0);
+  rounded = RoundScore(expected);
+  ok1(equals(rounded, 166.67));
+
+  expected = CalculateFfvpScore(50000, 107, 1.0);
+  rounded = RoundScore(expected);
+  ok1(equals(rounded, 46.73));
+}
+
+/**
+ * Declared-flight coefficient from the same doc (electronic declaration
+ * before takeoff).  Not applied in XCSoar NetCoupe::CalculateResult().
+ */
+static void
+TestFfvpDeclaredSuccessIndex()
+{
+  double expected = CalculateFfvpScore(100000, 100, 1.2);
+  ok1(equals(expected, 120.0));
+
+  expected = CalculateFfvpScore(200000, 120, 1.2);
+  ok1(equals(expected, 200.0));
+
+  expected = CalculateFfvpScore(149000, 107, 1.2);
+  double rounded = RoundScore(expected);
+  ok1(equals(rounded, 167.10));
+}
+
+int
+main()
+{
+  plan_tests(4 + 3);
+
+  TestFfvpFreeFlight();
+  TestFfvpDeclaredSuccessIndex();
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary

- Restores FFVV NetCoupe contest optimisation and related UI, engine, docs, and translations (#2330).
- Bumps release metadata to **7.44.4** for App Store / Play-style versioning: `VERSION.txt`, Android `versionName`/`versionCode`, and iOS/macOS bundle version handling when `VERSION.txt` is already three-part (avoids `7.44.4.0`).
- `NEWS.txt`: 7.44.4 section added **without** a release date; debian changelog entry can be added at release time.

## Related

Closes / fixes #2330 (as applicable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FFVV NetCoupe contest type in task configuration.
  * Expanded post-flight upload guidance to include WeGlide NetCoupe portal option.

* **Chores**
  * Updated app version to 7.44.4.
  * Updated documentation in multiple languages to reflect new contest option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->