### PR TITLE
InfoBoxes/InfoBoxManager: Refresh captions after language change

### DIFF
--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -119,6 +119,13 @@ InfoBoxManager::SetDirty() noexcept
 }
 
 void
+InfoBoxManager::InvalidateAfterLanguageChange() noexcept
+{
+  first = true;
+  SetDirty();
+}
+
+void
 InfoBoxManager::ScheduleRedraw() noexcept
 {
   if (infoboxes_hidden)

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -19,6 +19,14 @@ ProcessTimer() noexcept;
 void
 SetDirty() noexcept;
 
+/**
+ * Call after the UI language was switched (#ReadLanguageFile) so
+ * captions and content use the new gettext catalogue on the next draw
+ * (#2314).
+ */
+void
+InvalidateAfterLanguageChange() noexcept;
+
 void
 ScheduleRedraw() noexcept;
 

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -90,8 +90,10 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   MainWindow &main_window = *CommonInterface::main_window;
 
-  if (LanguageChanged)
+  if (LanguageChanged) {
     ReadLanguageFile();
+    InfoBoxManager::InvalidateAfterLanguageChange();
+  }
 
   bool TerrainFileChanged = false, TopographyFileChanged = false;
   if (MapFileChanged) {


### PR DESCRIPTION
DisplayInfoBox() only called SetTitle(gettext(...)) when the infobox type changed or on first layout, so after ReadLanguageFile() the titles stayed in the old language.

Add InvalidateAfterLanguageChange() to force the next draw to rebuild titles and content providers, and invoke it from SettingsLeave when LanguageChanged is set.

Fixes #2314

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where information boxes would not refresh their content when changing the application language. Language-specific text and captions now update correctly immediately after selecting a new language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->