### PR TITLE
Form/DataField/Enum: Remove limitation of 128 values for internal array of Enum entries

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ The following people and organizations have contributed code to XCSoar:
  Piotr Gertz <piotr@piopawlu.net>
  Yorick Reum <xcsoar@yorickreum.de>
  kobedegeest <kobedegeest@gmail.com>
+ B-4pt <bapt80@proton.me>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -8,6 +8,8 @@ Version 7.45 - not yet released
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
     distance; tap to change home waypoint) #2320
   - terrain: add new terrain shading orientation "fixed (Top Left)"
+  - Form/DataField/Enum: remove the limit of 128 internal entries (It was
+    dropping the newest InfoBoxes, as we have 130 of them now)
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330
 

--- a/src/Form/DataField/Enum.cpp
+++ b/src/Form/DataField/Enum.cpp
@@ -70,18 +70,15 @@ DataFieldEnum::replaceEnumText(std::size_t i, const char *Text) noexcept
 bool
 DataFieldEnum::AddChoice(unsigned id, const char *text,
                          const char *display_string,
-                         const char *help) noexcept
+                         const char *help)
 {
-  if (entries.full())
-    return false;
-
-  Entry &entry = entries.append();
+  Entry &entry = entries.emplace_back();
   entry.Set(id, text, display_string, help);
   return true;
 }
 
 void
-DataFieldEnum::AddChoices(const StaticEnumChoice *p) noexcept
+DataFieldEnum::AddChoices(const StaticEnumChoice *p)
 {
   while (p->display_string != nullptr) {
     const char *help = p->help;
@@ -95,19 +92,16 @@ DataFieldEnum::AddChoices(const StaticEnumChoice *p) noexcept
 
 unsigned
 DataFieldEnum::addEnumText(const char *Text, const char *display_string,
-                           const char *_help) noexcept
+                           const char *_help)
 {
-  if (entries.full())
-    return 0;
-
   unsigned i = entries.size();
-  Entry &entry = entries.append();
+  Entry &entry = entries.emplace_back();
   entry.Set(i, Text, display_string, _help);
   return i;
 }
 
 void
-DataFieldEnum::addEnumTexts(const char *const*list) noexcept
+DataFieldEnum::addEnumTexts(const char *const*list)
 {
   while (*list != nullptr)
     addEnumText(*list++);
@@ -190,7 +184,7 @@ DataFieldEnum::ModifyValue(const char *text) noexcept
 }
 
 int
-DataFieldEnum::SetStringAutoAdd(const char *text) noexcept
+DataFieldEnum::SetStringAutoAdd(const char *text)
 {
   int index = Find(text);
   if (index >= 0) {

--- a/src/Form/DataField/Enum.cpp
+++ b/src/Form/DataField/Enum.cpp
@@ -8,8 +8,6 @@
 
 #include <algorithm>
 
-#include <stdlib.h>
-
 DataFieldEnum::Entry::~Entry() noexcept
 {
   free(string);
@@ -23,6 +21,9 @@ DataFieldEnum::Entry::~Entry() noexcept
 void
 DataFieldEnum::Entry::SetString(const char *_string) noexcept
 {
+  if (_string == nullptr)
+    _string = "";
+
   free(string);
   if (display_string != string)
     free(display_string);
@@ -35,7 +36,11 @@ DataFieldEnum::Entry::SetDisplayString(const char *_string) noexcept
 {
   if (display_string != string)
     free(display_string);
-  display_string = strdup(_string);
+
+  if (_string == nullptr)
+    display_string = string;
+  else
+    display_string = strdup(_string);
 }
 
 void
@@ -72,6 +77,9 @@ DataFieldEnum::AddChoice(unsigned id, const char *text,
                          const char *display_string,
                          const char *help)
 {
+  if (text == nullptr)
+    return false;
+
   Entry &entry = entries.emplace_back();
   entry.Set(id, text, display_string, help);
   return true;
@@ -80,12 +88,17 @@ DataFieldEnum::AddChoice(unsigned id, const char *text,
 void
 DataFieldEnum::AddChoices(const StaticEnumChoice *p)
 {
+  if (p == nullptr)
+    return;
+
   while (p->display_string != nullptr) {
     const char *help = p->help;
     if (help != nullptr)
       help = gettext(help);
 
-    AddChoice(p->id, gettext(p->display_string), nullptr, help);
+    if (p->display_string[0] != '\0')
+      AddChoice(p->id, gettext(p->display_string), nullptr, help);
+
     ++p;
   }
 }
@@ -94,6 +107,9 @@ unsigned
 DataFieldEnum::addEnumText(const char *Text, const char *display_string,
                            const char *_help)
 {
+  if (Text == nullptr)
+    return entries.size();
+
   unsigned i = entries.size();
   Entry &entry = entries.emplace_back();
   entry.Set(i, Text, display_string, _help);
@@ -103,8 +119,15 @@ DataFieldEnum::addEnumText(const char *Text, const char *display_string,
 void
 DataFieldEnum::addEnumTexts(const char *const*list)
 {
-  while (*list != nullptr)
-    addEnumText(*list++);
+  if (list == nullptr)
+    return;
+
+  while (*list != nullptr) {
+    if ((*list)[0] != '\0')
+      addEnumText(*list);
+
+    ++list;
+  }
 }
 
 const char *
@@ -186,6 +209,9 @@ DataFieldEnum::ModifyValue(const char *text) noexcept
 int
 DataFieldEnum::SetStringAutoAdd(const char *text)
 {
+  if (text == nullptr || text[0] == '\0')
+    return -1;
+
   int index = Find(text);
   if (index >= 0) {
     SetIndex(index, false);

--- a/src/Form/DataField/Enum.hpp
+++ b/src/Form/DataField/Enum.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "Base.hpp"
-#include "util/StaticArray.hxx"
 
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 /**
  * A struct that is used for static initialisation of the enum list.
@@ -87,7 +87,7 @@ public:
   };
 
 private:
-  StaticArray<Entry, 128> entries;
+  std::vector<Entry> entries;
   std::size_t value = 0;
 
 public:
@@ -119,23 +119,23 @@ public:
 
   bool AddChoice(unsigned id, const char *text,
                  const char *display_string=nullptr,
-                 const char *help=nullptr) noexcept;
+                 const char *help=nullptr);
 
   /**
    * Add choices from the specified nullptr-terminated list (the last
    * entry has a nullptr display_string).  All display strings and help
    * texts are translated with gettext() by this method.
    */
-  void AddChoices(const StaticEnumChoice *list) noexcept;
+  void AddChoices(const StaticEnumChoice *list);
 
   bool addEnumText(const char *text, unsigned id,
-                   const char *help=nullptr) noexcept {
+                   const char *help=nullptr) {
     return AddChoice(id, text, nullptr, help);
   }
 
   unsigned addEnumText(const char *Text, const char *display_string=nullptr,
-                       const char *ItemHelpText=nullptr) noexcept;
-  void addEnumTexts(const char *const*list) noexcept;
+                       const char *ItemHelpText=nullptr);
+  void addEnumTexts(const char *const*list);
 
   /**
    * @return help of current enum item or nullptr if current item has no help
@@ -183,7 +183,7 @@ public:
    *
    * @return the new integer value
    */
-  int SetStringAutoAdd(const char *text) noexcept;
+  int SetStringAutoAdd(const char *text);
 
   void Sort(std::size_t startindex = 0) noexcept;
 


### PR DESCRIPTION
While working on an evolution of Alternates 1/2 InfoBoxes, I was unable to see in the list of InfoBoxes the last two added about a year ago: **Alternate 1 altitude difference** & **Alternate 1 altitude difference**.

After some investigations, we had a limit of 128 entries in the class `Enum.hpp`, and those two InfoBoxes were the 129th&130th added.

With this fix, those InfoBoxes are now available:

![xcsoar_after_fix_enum_infobox](https://github.com/user-attachments/assets/96bda8eb-cae3-485e-b88d-76ba5ccbd08c)


## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ x] PR is rebased on current `master`
- [ x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ x] Commit messages explain *why* the change was made, not just
  *what* changed
- [ x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ x] Each commit is atomic and builds successfully (every commit
  must compile)
- [ x] One commit per logical change (don't mix refactoring with
  feature changes)
- [ x] Self-contained commits (each commit changes one thing)
- [x ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x ] No duplicate commits (check with `git log --oneline`)
- [x ] No "WIP" or "testing" commits (clean up before PR)

---

- [x ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the fixed 128-entry cap for form enum/InfoBox lists — adding items beyond that limit no longer drops the newest entries (large lists, 130+ items, are preserved).
  * Improved handling of null/empty choice and display text so blank entries are ignored, display text falls back appropriately, and automated string-add operations reject invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->