### PR TITLE
build/lua: Fix Homebrew pkg-config module name on Darwin

### DIFF
--- a/build/lua.mk
+++ b/build/lua.mk
@@ -6,7 +6,12 @@ ifeq ($(USE_THIRDPARTY_LIBS),y)
 LIBLUA_LDLIBS = -llua
 LIBLUA_CPPFLAGS =
 else
+# Homebrew provides pkg-config module "lua"; Debian/Ubuntu use "lua5.4".
+ifeq ($(TARGET_IS_DARWIN),y)
+$(eval $(call pkg-config-library,LIBLUA,lua))
+else
 $(eval $(call pkg-config-library,LIBLUA,lua5.4))
+endif
 endif
 
 LUA_SOURCES = \

--- a/ide/provisioning/install-darwin-packages.sh
+++ b/ide/provisioning/install-darwin-packages.sh
@@ -38,7 +38,8 @@ install_ios() {
   echo Installing dependencies for the iOS target...
   brew install automake autoconf \
     libtool \
-    cmake ninja
+    cmake ninja \
+    lua
   echo
 }
 


### PR DESCRIPTION
## Problem

GitHub Actions `build-native.yml` fails on **macOS** with:

```
Package 'lua5.4' not found
build/compile.mk: *** library not found: lua5.4.  Stop.
```

Homebrew's `lua` formula installs `lua.pc` (module name `lua`), not `lua5.4` as on Debian/Ubuntu.

## Changes

- **`build/lua.mk`**: Use `pkg-config-library(..., lua)` when `TARGET_IS_DARWIN`; keep `lua5.4` elsewhere.
- **`ide/provisioning/install-darwin-packages.sh`**: Add `lua` to the iOS provisioning `brew install` list so jobs that only run the IOS section (BASE + IOS) still install Lua if the host needs it.

## Note

iOS targets use `USE_THIRDPARTY_LIBS=y`, so they already link Lua from the third-party build without hitting this pkg-config path; the provisioning change is for consistency and future-proofing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS build system support with optimized Lua library selection and added Lua package installation to development environment provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->