### PR TITLE
NOTAM support: fetch, map, settings, and airspace UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ include $(topdir)/build/libio.mk
 include $(topdir)/build/shapelib.mk
 include $(topdir)/build/libwaypoint.mk
 include $(topdir)/build/libairspace.mk
+include $(topdir)/build/libnotam.mk
 include $(topdir)/build/libtask.mk
 include $(topdir)/build/libxml.mk
 include $(topdir)/build/libcupfile.mk

--- a/build/libnotam.mk
+++ b/build/libnotam.mk
@@ -1,0 +1,11 @@
+# Build rules for the NOTAM library
+
+LIBNOTAM_DEPENDS = LIBHTTP LIBBOOST LIBJSON LIBCOROUTINES LIBFMT
+
+LIBNOTAM_SOURCES = \
+	$(SRC)/NOTAM/Client.cpp \
+	$(SRC)/NOTAM/Converter.cpp \
+	$(SRC)/NOTAM/Filter.cpp \
+	$(SRC)/NOTAM/NOTAMGlue.cpp
+
+$(eval $(call link-library,libnotam,LIBNOTAM))

--- a/build/main.mk
+++ b/build/main.mk
@@ -53,6 +53,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Airspace/AirspaceCRendererSettingsDialog.cpp \
 	$(SRC)/Dialogs/Airspace/AirspaceCRendererSettingsPanel.cpp \
 	$(SRC)/Dialogs/Airspace/dlgAirspaceWarnings.cpp \
+	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Airspace/NOTAMList.cpp) \
 	$(SRC)/Dialogs/Settings/WindSettingsPanel.cpp \
 	$(SRC)/Dialogs/Settings/WindSettingsDialog.cpp \
 	$(SRC)/Dialogs/Settings/dlgBasicSettings.cpp \
@@ -98,6 +99,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Waypoint/NearestWaypoint.cpp \
 	\
 	$(SRC)/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp \
+	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp) \
 	$(SRC)/Dialogs/Settings/Panels/GaugesConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/VarioConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp \
@@ -480,6 +482,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Profile/DeviceConfig.cpp \
 	$(SRC)/Profile/InfoBoxConfig.cpp \
 	$(SRC)/Profile/AirspaceConfig.cpp \
+	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Profile/NotamConfig.cpp) \
 	$(SRC)/Profile/TerrainConfig.cpp \
 	$(SRC)/Profile/FlarmProfile.cpp \
 	\
@@ -643,6 +646,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Tracking/LiveTrack24/Glue.cpp \
 	$(SRC)/Tracking/LiveTrack24/Client.cpp
 
+# LIBNOTAM is added to XCSOAR_DEPENDS when HAVE_HTTP=y (see below).
+
 XCSOAR_SOURCES += \
 	$(SRC)/net/client/tim/Glue.cpp \
 	$(SRC)/Tracking/SkyLines/Client.cpp \
@@ -690,7 +695,8 @@ XCSOAR_DEPENDS = \
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_DEPENDS += \
 	LIBHTTP \
-	LIBCLIENT
+	LIBCLIENT \
+	LIBNOTAM
 endif
 
 ifeq ($(TARGET_IS_DARWIN),y)

--- a/build/test.mk
+++ b/build/test.mk
@@ -1859,6 +1859,7 @@ RUN_MAP_WINDOW_SOURCES = \
 
 ifeq ($(HAVE_HTTP),y)
 RUN_MAP_WINDOW_SOURCES += \
+	$(SRC)/Profile/NotamConfig.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/NOAAStore.cpp
 endif

--- a/darwin/XCSoar.xcodeproj/project.pbxproj
+++ b/darwin/XCSoar.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXFileReference section */
+		5C1532E02E92F15E00168360 /* Client.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Client.hpp; sourceTree = "<group>"; };
+		5C1532E12E92F15E00168360 /* Client.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Client.cpp; sourceTree = "<group>"; };
+		5C1532E22E92F15E00168360 /* Converter.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Converter.hpp; sourceTree = "<group>"; };
+		5C1532E32E92F15E00168360 /* Converter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Converter.cpp; sourceTree = "<group>"; };
+		5C1532E62E92F15E00168360 /* NOTAM.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NOTAM.hpp; sourceTree = "<group>"; };
+		5C1532E72E92F15E00168360 /* Settings.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Settings.hpp; sourceTree = "<group>"; };
 		5C263B8C2D7456D30031179E /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
 		5C263B8D2D7456D30031179E /* build.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = build.sh; sourceTree = "<group>"; };
 		5C263B8E2D7456D30031179E /* clean.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = clean.sh; sourceTree = "<group>"; };
@@ -17,6 +23,8 @@
 		5C72EF792E80785B0015A594 /* Services.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Services.cpp; sourceTree = "<group>"; };
 		5C72EF7A2E80785B0015A594 /* SoundUtil.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SoundUtil.hpp; sourceTree = "<group>"; };
 		5C72EF7B2E80785B0015A594 /* SoundUtil.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SoundUtil.cpp; sourceTree = "<group>"; };
+		5C869E032EA459E80078FC69 /* NOTAMList.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NOTAMList.hpp; sourceTree = "<group>"; };
+		5C869E042EA459E80078FC69 /* NOTAMList.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NOTAMList.cpp; sourceTree = "<group>"; };
 		5CBFD0A62D742FA600F05795 /* Android-CI.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "Android-CI.yml"; sourceTree = "<group>"; };
 		5CBFD0A72D742FA600F05795 /* Android-CI-release.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "Android-CI-release.yml"; sourceTree = "<group>"; };
 		5CBFD0A82D742FA600F05795 /* gradle-wrapper-validation.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = "gradle-wrapper-validation.yml"; sourceTree = "<group>"; };
@@ -7043,9 +7051,32 @@
 		5CBFEF2B2D742FA600F05795 /* xci2po.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = xci2po.pl; sourceTree = "<group>"; };
 		5CBFEF2C2D742FA600F05795 /* xcs2cpp.pl */ = {isa = PBXFileReference; lastKnownFileType = text.script.perl; path = xcs2cpp.pl; sourceTree = "<group>"; };
 		5CBFEF2E2D742FA600F05795 /* VERSION.txt */ = {isa = PBXFileReference; lastKnownFileType = text; name = VERSION.txt; path = ../VERSION.txt; sourceTree = SOURCE_ROOT; };
+		5CC968942ED8DFE8003C90FD /* NOTAMConfigPanel.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NOTAMConfigPanel.hpp; sourceTree = "<group>"; };
+		5CC968952ED8DFE8003C90FD /* NOTAMConfigPanel.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NOTAMConfigPanel.cpp; sourceTree = "<group>"; };
+		5CE4B8E52F06E03200DC2994 /* Filter.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Filter.hpp; sourceTree = "<group>"; };
+		5CE4B8E62F06E03200DC2994 /* Filter.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Filter.cpp; sourceTree = "<group>"; };
+		5CE4B8E72F06E03200DC2994 /* NOTAMGlue.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NOTAMGlue.hpp; sourceTree = "<group>"; };
+		5CE4B8E82F06E03200DC2994 /* NOTAMGlue.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NOTAMGlue.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		5C1532E82E92F15E00168360 /* NOTAM */ = {
+			isa = PBXGroup;
+			children = (
+				5CE4B8E52F06E03200DC2994 /* Filter.hpp */,
+				5CE4B8E62F06E03200DC2994 /* Filter.cpp */,
+				5CE4B8E72F06E03200DC2994 /* NOTAMGlue.hpp */,
+				5CE4B8E82F06E03200DC2994 /* NOTAMGlue.cpp */,
+				5C1532E02E92F15E00168360 /* Client.hpp */,
+				5C1532E12E92F15E00168360 /* Client.cpp */,
+				5C1532E22E92F15E00168360 /* Converter.hpp */,
+				5C1532E32E92F15E00168360 /* Converter.cpp */,
+				5C1532E62E92F15E00168360 /* NOTAM.hpp */,
+				5C1532E72E92F15E00168360 /* Settings.hpp */,
+			);
+			path = NOTAM;
+			sourceTree = "<group>";
+		};
 		5C263B902D7456D30031179E /* darwin */ = {
 			isa = PBXGroup;
 			children = (
@@ -15610,6 +15641,8 @@
 		5CBFE1DB2D742FA600F05795 /* Airspace */ = {
 			isa = PBXGroup;
 			children = (
+				5C869E032EA459E80078FC69 /* NOTAMList.hpp */,
+				5C869E042EA459E80078FC69 /* NOTAMList.cpp */,
 				5CBFE1D12D742FA600F05795 /* Airspace.hpp */,
 				5CBFE1D22D742FA600F05795 /* AirspaceCRendererSettingsDialog.cpp */,
 				5CBFE1D32D742FA600F05795 /* AirspaceCRendererSettingsPanel.hpp */,
@@ -15743,6 +15776,8 @@
 		5CBFE25A2D742FA600F05795 /* Panels */ = {
 			isa = PBXGroup;
 			children = (
+				5CC968942ED8DFE8003C90FD /* NOTAMConfigPanel.hpp */,
+				5CC968952ED8DFE8003C90FD /* NOTAMConfigPanel.cpp */,
 				5CBFE2212D742FA600F05795 /* AirspaceConfigPanel.hpp */,
 				5CBFE2222D742FA600F05795 /* AirspaceConfigPanel.cpp */,
 				5CBFE2232D742FA600F05795 /* AudioConfigPanel.hpp */,
@@ -19732,6 +19767,7 @@
 		5CBFEDA72D742FA600F05795 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				5C1532E82E92F15E00168360 /* NOTAM */,
 				5CBFDFA82D742FA600F05795 /* Airspace */,
 				5CBFDFE32D742FA600F05795 /* Android */,
 				5CBFDFE62D742FA600F05795 /* Apple */,

--- a/src/Airspace/AirspaceComputerSettings.cpp
+++ b/src/Airspace/AirspaceComputerSettings.cpp
@@ -9,4 +9,8 @@ AirspaceComputerSettings::SetDefaults()
   enable_warnings = true;
 
   warnings.SetDefaults();
+
+#ifdef HAVE_HTTP
+  notam = NOTAMSettings{};
+#endif
 }

--- a/src/Airspace/AirspaceComputerSettings.hpp
+++ b/src/Airspace/AirspaceComputerSettings.hpp
@@ -4,8 +4,12 @@
 #pragma once
 
 #include "Engine/Airspace/AirspaceWarningConfig.hpp"
-
+#include "net/http/Features.hpp"
 #include <type_traits>
+
+#ifdef HAVE_HTTP
+#include "NOTAM/Settings.hpp"
+#endif
 
 /**
  * Settings for airspace options
@@ -16,7 +20,13 @@ struct AirspaceComputerSettings {
 
   AirspaceWarningConfig warnings;
 
+#ifdef HAVE_HTTP
+  /** NOTAM settings */
+  NOTAMSettings notam;
+#endif
+
   void SetDefaults();
 };
 
-static_assert(std::is_trivial<AirspaceComputerSettings>::value, "type is not trivial");
+// Note: AirspaceComputerSettings is no longer trivial 
+// due to NOTAMSettings containing std::chrono and std::string

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -248,6 +248,3 @@ struct ComputerSettings {
 
   void SetDefaults();
 };
-
-static_assert(std::is_trivial<ComputerSettings>::value,
-              "type is not trivial");

--- a/src/CrossSection/AirspaceXSRenderer.cpp
+++ b/src/CrossSection/AirspaceXSRenderer.cpp
@@ -78,6 +78,7 @@ inline void
 AirspaceIntersectionVisitorSlice::RenderBox(const PixelRect rc,
                                             AirspaceClass type) const
 {
+  const Color text_color = canvas.GetTextColor();
   if (AirspacePreviewRenderer::PrepareFill(canvas, type, airspace_look,
                                            settings)) {
     const auto &class_settings = settings.classes[type];
@@ -110,7 +111,7 @@ AirspaceIntersectionVisitorSlice::RenderBox(const PixelRect rc,
       canvas.DrawRectangle(rc);
     }
 
-    AirspacePreviewRenderer::UnprepareFill(canvas);
+    AirspacePreviewRenderer::UnprepareFill(canvas, text_color);
   }
 
   // Use transparent brush and type-dependent pen for the outlines

--- a/src/Dialogs/Airspace/AirspaceList.cpp
+++ b/src/Dialogs/Airspace/AirspaceList.cpp
@@ -198,7 +198,7 @@ static constexpr StaticEnumChoice type_filter_list[] = {
   { LTA, "Lower Traffic Area" },
   { UTA, "Upper Traffic Area" },
   { ASRA, "Aerial Sporting Or Recreational Activity" },
-  { NOTAM, "NTOAM Affected Area" },
+  { NOTAM, "NOTAM Affected Area" },
   { NONE, "None" },
   { TRAFR, "TRA/TSA Feeding Route" },
   { TRZ, "Transponder Recommended Zone" },

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NOTAMList.hpp"
+#include "LogFile.hpp"
+
+#ifdef HAVE_HTTP
+
+#include "Dialogs/WidgetDialog.hpp"
+#include "Widget/ListWidget.hpp"
+#include "ui/control/List.hpp"
+#include "Renderer/TwoTextRowsRenderer.hpp"
+#include "Look/DialogLook.hpp"
+#include "util/Compiler.h"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "NetComponents.hpp"
+#include "Components.hpp"
+#include "DataComponents.hpp"
+#include "NOTAM/NOTAM.hpp"
+#include "NOTAM/Filter.hpp"
+#include "NOTAM/NOTAMGlue.hpp"
+#include "Interface.hpp"
+#include "util/StringFormat.hpp"
+#include "Operation/Operation.hpp"
+#include "util/UTF8.hpp"
+#include "system/FileUtil.hpp"
+
+#include <array>
+#include <iterator>
+#include <string>
+
+// Use full struct name to avoid collision with AirspaceClass::NOTAM enum
+using NOTAMStruct = struct NOTAM;
+
+#include <cassert>
+#include <algorithm>
+
+// Return UTF-8 text safe for UI, or a placeholder if invalid.
+static std::string
+SafeString(const std::string &input) noexcept
+{
+  if (input.empty()) {
+    return {};
+  }
+  if (!ValidateUTF8(input)) {
+    return std::string(_("[Invalid text]"));
+  }
+  return input;
+}
+
+class NOTAMListWidget final : public ListWidget {
+  static constexpr unsigned HEADER_COUNT = 4;
+  std::vector<NOTAMStruct> items;
+  TwoTextRowsRenderer row_renderer;
+
+public:
+  NOTAMListWidget() = default;
+
+  void UpdateList();
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+
+  void Show(const PixelRect &rc) noexcept override {
+    ListWidget::Show(rc);
+    UpdateList();
+  }
+
+  /* virtual methods from ListItemRenderer */
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned idx) noexcept override;
+
+  /* virtual methods from ListCursorHandler */
+  bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept
+    override {
+    return false; // No activation needed for NOTAM list
+  }
+};
+
+void
+NOTAMListWidget::Prepare(ContainerWindow &parent,
+                         const PixelRect &rc) noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  CreateList(parent, look, rc,
+             row_renderer.CalculateLayout(*look.list.font,
+                                          look.small_font));
+}
+
+void
+NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
+                             unsigned i) noexcept
+{
+  if (items.empty()) {
+    assert(i == 0);
+    row_renderer.DrawFirstRow(canvas, rc, _("No NOTAMs available"));
+    return;
+  }
+
+  assert(i < items.size());
+
+  const auto &notam = items[i];
+  
+  // Check if this is a metadata header (first HEADER_COUNT items)
+  const bool is_header = i < HEADER_COUNT;
+  
+  // Build user-friendly first row: "A1234/24 • EDDF • Active" or
+  // "Future: starts in 2h"
+  StaticString<256> first_row;
+  first_row = SafeString(notam.number).c_str();
+  
+  if (is_header) {
+    // For headers, just show "Label: Value" format
+    first_row += ": ";
+    first_row += SafeString(notam.text).c_str();
+  } else {
+    // For actual NOTAMs, add location if available
+    if (!notam.location.empty()) {
+      first_row += " • ";
+      first_row += SafeString(notam.location).c_str();
+    }
+    
+    // Add status indicator
+    auto now = std::chrono::system_clock::now();
+    const bool is_perm = notam.end_time >= NOTAMTime::PermanentEndTime();
+    if (now < notam.start_time) {
+      auto starts_in =
+        std::chrono::duration_cast<std::chrono::hours>(notam.start_time - now);
+      if (starts_in.count() < 24) {
+        first_row.AppendFormat(" • %s %dh", _("Starts in"),
+                               (int)starts_in.count());
+      } else {
+        first_row.AppendFormat(" • %s %dd", _("Starts in"),
+                               (int)(starts_in.count() / 24));
+      }
+    } else if (!is_perm && now > notam.end_time) {
+      first_row += " • ";
+      first_row += _("Expired");
+    } else {
+      first_row += " • ";
+      first_row += _("Active");
+    }
+    
+    // Add filtered indicator
+    const auto &settings =
+      CommonInterface::GetComputerSettings().airspace.notam;
+    const bool is_filtered =
+      !NOTAMFilter::ShouldDisplay(notam, settings, false);
+    
+    if (is_filtered) {
+      first_row += " • ";
+      first_row += _("Filtered");
+    }
+  }
+  
+  row_renderer.DrawFirstRow(canvas, rc, first_row.c_str());
+  
+  // For headers, skip the second row (text is already shown in first row)
+  if (is_header) {
+    row_renderer.DrawSecondRow(canvas, rc, "");
+    return;
+  }
+  
+  // Build user-friendly second row: truncated text with Q-code if available
+  StaticString<512> second_row;
+  
+  // Add Q-code/feature type if available
+  if (!notam.feature_type.empty()) {
+    second_row = SafeString(notam.feature_type).c_str();
+    second_row += ": ";
+  }
+  
+  // Add text, truncated to fit
+  if (!notam.text.empty()) {
+    std::string text = SafeString(notam.text);
+    // Remove newlines and extra spaces for better display
+    for (auto &ch : text) {
+      if (ch == '\n' || ch == '\r') ch = ' ';
+    }
+    // Truncate if too long
+    const size_t max_len = 120;
+    if (text.length() > max_len) {
+      text = text.substr(0, max_len - 3);
+      text += "...";
+    }
+    second_row += text.c_str();
+  }
+  
+  if (!second_row.empty()) {
+    row_renderer.DrawSecondRow(canvas, rc, second_row.c_str());
+  }
+}
+
+void
+NOTAMListWidget::UpdateList()
+{
+  items.clear();
+
+  if (net_components && net_components->notam) {
+    // Add header items with statistics
+    NOTAMStruct header1, header2, header3, header4;
+    
+    // Last Update time
+    std::time_t last_update = net_components->notam->GetLastUpdateTime();
+    header1.number = _("Last Update");
+    if (last_update > 0) {
+      struct tm tm_buf;
+#ifdef _WIN32
+      const auto *tm =
+        (localtime_s(&tm_buf, &last_update) == 0) ? &tm_buf : nullptr;
+#else
+      const auto *tm = localtime_r(&last_update, &tm_buf);
+#endif
+      if (tm != nullptr) {
+        char time_buffer[64];
+        StringFormat(time_buffer, sizeof(time_buffer),
+                     "%04d-%02d-%02d %02d:%02d",
+                     tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday,
+                     tm->tm_hour, tm->tm_min);
+        header1.text = time_buffer;
+      } else {
+        header1.text = _("Unknown");
+      }
+    } else {
+      header1.text = _("Never");
+    }
+    
+    // Distance from last update
+    const auto &basic = CommonInterface::Basic();
+    GeoPoint last_loc = net_components->notam->GetLastUpdateLocation();
+    header2.number = _("Distance");
+    if (basic.location_available && basic.location.IsValid() &&
+        last_loc.IsValid()) {
+      double dist_m = basic.location.Distance(last_loc);
+      char dist_buffer[64];
+      StringFormat(dist_buffer, sizeof(dist_buffer), "%.1f km",
+                   dist_m / 1000.0);
+      header2.text = dist_buffer;
+    } else {
+      header2.text = _("Unknown");
+    }
+    
+    // NOTAM counts
+    NOTAMGlue::FilterStats stats = net_components->notam->GetFilterStats();
+    char count_buffer[64];
+    header3.number = _("NOTAMs");
+    StringFormat(count_buffer, sizeof(count_buffer), "%u total", stats.total);
+    header3.text = count_buffer;
+    
+    header4.number = _("After Filtering");
+    StringFormat(count_buffer, sizeof(count_buffer), "%u visible",
+                 stats.final_count);
+    header4.text = count_buffer;
+    
+    const std::array<NOTAMStruct, HEADER_COUNT> headers = {
+      header1, header2, header3, header4,
+    };
+    items.insert(items.end(), headers.begin(), headers.end());
+    
+    // Get all NOTAMs (max_count=0 means no limit)
+    auto notams = net_components->notam->GetNOTAMs(0);
+    items.insert(items.end(), notams.begin(), notams.end());
+    LogFormat("NOTAM: UpdateList - received %u NOTAMs",
+              static_cast<unsigned>(notams.size()));
+  } else {
+    LogFormat("NOTAM: UpdateList - net_components or notam is null");
+  }
+
+  LogFormat("NOTAM: UpdateList - final items.size()=%u",
+            static_cast<unsigned>(items.size()));
+  GetList().SetLength(std::max(static_cast<size_t>(1), items.size()));
+  GetList().Invalidate();
+}
+
+void
+ShowNOTAMListDialog(UI::SingleWindow &parent)
+{ 
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  auto list_widget = std::make_unique<NOTAMListWidget>();
+  WidgetDialog dialog(WidgetDialog::Auto{}, parent, look, _("NOTAMs"),
+                      list_widget.release());
+  dialog.AddButton(_("Close"), mrCancel);
+  dialog.ShowModal();
+}
+
+#else // !HAVE_HTTP
+
+void
+ShowNOTAMListDialog(UI::SingleWindow &)
+{
+  // NOTAM support not compiled in - do nothing
+  LogFormat("NOTAM: ShowNOTAMListDialog called, but NOTAM support is not "
+            "available");
+}
+
+#endif

--- a/src/Dialogs/Airspace/NOTAMList.hpp
+++ b/src/Dialogs/Airspace/NOTAMList.hpp
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+namespace UI { class SingleWindow; }
+
+/**
+ * Show a dialog with the current NOTAM list and reload functionality.
+ *
+ * @param parent the parent window
+ */
+void
+ShowNOTAMListDialog(UI::SingleWindow &parent);

--- a/src/Dialogs/Airspace/dlgAirspace.cpp
+++ b/src/Dialogs/Airspace/dlgAirspace.cpp
@@ -77,10 +77,11 @@ AirspaceSettingsListWidget::OnPaintItem(Canvas &canvas, PixelRect rc,
 
     const int padding = Layout::GetTextPadding();
 
+    const Color text_color = canvas.GetTextColor();
     if (AirspacePreviewRenderer::PrepareFill(
         canvas, (AirspaceClass)i, look, renderer)) {
       canvas.DrawRectangle({second_x, rc.top + padding, rc.right - padding, rc.bottom - padding});
-      AirspacePreviewRenderer::UnprepareFill(canvas);
+      AirspacePreviewRenderer::UnprepareFill(canvas, text_color);
     }
     if (AirspacePreviewRenderer::PrepareOutline(
         canvas, (AirspaceClass)i, look, renderer)) {

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -8,17 +8,65 @@
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Formatter/AirspaceFormatter.hpp"
+#include "Formatter/TimeFormatter.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "UIGlobals.hpp"
 #include "Interface.hpp"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "NOTAM/NOTAMGlue.hpp"
+#include "NOTAM/NOTAM.hpp"
 #include "ActionInterface.hpp"
 #include "Language/Language.hpp"
 #include "TransponderMode.hpp"
 #include "util/StaticString.hxx"
+#include "util/StringFormat.hpp"
+
+#include <cstring>
+#include "Geo/AltitudeReference.hpp"
 
 #include <cassert>
 
-class AirspaceDetailsWidget final
+namespace {
+
+
+void
+FormatAltitudeWithReference(char *buffer, size_t buffer_size,
+                             const AirspaceAltitude &altitude,
+                             const std::optional<struct NOTAM> &notam_opt,
+                             bool is_base) noexcept
+{
+  AirspaceFormatter::FormatAltitudeShort(buffer, altitude, true);
+  
+  if (notam_opt) {
+    const size_t current_len = std::strlen(buffer);
+    const size_t remaining = buffer_size > current_len
+      ? buffer_size - current_len - 1
+      : 0;
+    
+    if (remaining > 0) {
+      const char *suffix = nullptr;
+      
+      if (!is_base || !altitude.IsTerrain()) {
+        if (altitude.reference == AltitudeReference::MSL)
+          suffix = " MSL";
+      }
+      
+      if (suffix != nullptr) {
+        const size_t suffix_len = std::strlen(suffix);
+        if (suffix_len <= remaining) {
+          StringFormat(buffer + current_len, remaining + 1, "%s", suffix);
+        }
+      }
+    }
+  }
+}
+
+} // namespace
+
+class AirspaceDetailsWidget
   : public RowFormWidget {
+protected:
   ConstAirspacePtr airspace;
   ProtectedAirspaceWarningManager *warnings;
 
@@ -87,7 +135,8 @@ AirspaceDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     });
   }
 
-  AddReadOnly(_("Class"), nullptr, AirspaceFormatter::GetClassShort(*airspace));
+  AddReadOnly(_("Class"), nullptr,
+              AirspaceFormatter::GetClassShort(*airspace));
   AddReadOnly(_("Type"), nullptr, AirspaceFormatter::GetType(*airspace));
 
   AirspaceFormatter::FormatAltitude(buffer.data(), airspace->GetTop());
@@ -116,15 +165,44 @@ AirspaceDetailsWidget::AckDayOrEnable() noexcept
   dialog->SetModalResult(mrOK);
 }
 
+/**
+ * Extended widget for displaying NOTAM-specific information
+ */
+class NOTAMDetailsWidget final : public AirspaceDetailsWidget {
+public:
+  NOTAMDetailsWidget(ConstAirspacePtr _airspace,
+                     ProtectedAirspaceWarningManager *_warnings)
+    : AirspaceDetailsWidget(std::move(_airspace), _warnings) {}
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+
+private:
+  void AddNOTAMIdentifiers(const char *notam_number,
+                           const std::optional<struct NOTAM> &notam_opt,
+                           StaticString<128> &buffer);
+  void AddNOTAMValidity(const std::optional<struct NOTAM> &notam_opt,
+                        StaticString<128> &buffer);
+  void AddNOTAMAltitudes(const std::optional<struct NOTAM> &notam_opt,
+                         StaticString<128> &buffer);
+};
+
 void
 dlgAirspaceDetails(ConstAirspacePtr airspace,
                    ProtectedAirspaceWarningManager *warnings)
 {
-  AirspaceDetailsWidget *widget =
-    new AirspaceDetailsWidget(airspace, warnings);
+  // Use specialized widget for NOTAMs
+  const bool is_notam = airspace->GetType() == AirspaceClass::NOTAM;
+  
+  AirspaceDetailsWidget *widget = is_notam
+    ? new NOTAMDetailsWidget(airspace, warnings)
+    : new AirspaceDetailsWidget(airspace, warnings);
+  
+  const char *title = is_notam ? _("NOTAM Details") : _("Airspace Details");
+  
   WidgetDialog dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
                       UIGlobals::GetDialogLook(),
-                      _("Airspace Details"), widget);
+                      title, widget);
 
   if (warnings != nullptr) {
     widget->dialog = &dialog;
@@ -135,4 +213,150 @@ dlgAirspaceDetails(ConstAirspacePtr airspace,
   dialog.AddButton(_("Close"), mrOK);
 
   dialog.ShowModal();
+}
+
+void
+NOTAMDetailsWidget::AddNOTAMIdentifiers(const char *notam_number,
+                                        const std::optional<struct NOTAM> &notam_opt,
+                                        StaticString<128> &buffer)
+{
+  // Display NOTAM number
+  if (notam_number && notam_number[0] != '\0') {
+    AddReadOnly(_("NOTAM"), nullptr, notam_number);
+  }
+
+  // Display ICAO location if we found the NOTAM
+  if (notam_opt && !notam_opt->location.empty()) {
+    AddReadOnly(_("Location"), nullptr, notam_opt->location.c_str());
+  }
+
+  // Display Q-code (feature type)
+  if (notam_opt && !notam_opt->feature_type.empty()) {
+    AddReadOnly(_("Q-Code"), nullptr, notam_opt->feature_type.c_str());
+  }
+
+  // NOTAM Series (if available)
+  if (notam_opt && !notam_opt->series.empty()) {
+    buffer.Format("Series %s", notam_opt->series.c_str());
+    AddReadOnly(_("Type"), nullptr, buffer);
+  }
+}
+
+void
+NOTAMDetailsWidget::AddNOTAMValidity(
+    const std::optional<struct NOTAM> &notam_opt,
+    StaticString<128> &buffer)
+{
+  if (!notam_opt)
+    return;
+
+  char time_buffer[64];
+
+  // Effective start - format as friendly date/time
+  BrokenDateTime start_dt(notam_opt->start_time);
+  StringFormat(time_buffer, sizeof(time_buffer),
+               "%04u-%02u-%02u %02u:%02u",
+               start_dt.year, start_dt.month, start_dt.day,
+               start_dt.hour, start_dt.minute);
+  AddReadOnly(_("Valid From"), nullptr, time_buffer);
+
+  // Effective end
+  BrokenDateTime end_dt(notam_opt->end_time);
+  // Check if it's a far future date (PERM = permanent)
+  if (notam_opt->end_time >= NOTAMTime::PermanentEndTime()) {
+    AddReadOnly(_("Valid Until"), nullptr, "PERM");
+  } else {
+    StringFormat(time_buffer, sizeof(time_buffer),
+                 "%04u-%02u-%02u %02u:%02u",
+                 end_dt.year, end_dt.month, end_dt.day,
+                 end_dt.hour, end_dt.minute);
+    AddReadOnly(_("Valid Until"), nullptr, time_buffer);
+  }
+
+  // Status indicator
+  auto now = std::chrono::system_clock::now();
+  StaticString<32> time_str;
+  if (now < notam_opt->start_time) {
+    // Not yet active
+    auto starts_in = std::chrono::duration_cast<std::chrono::hours>(
+      notam_opt->start_time - now);
+    if (starts_in.count() < 48) {
+      time_str.Format("%dh", static_cast<int>(starts_in.count()));
+    } else {
+      auto days = starts_in.count() / 24;
+      time_str.Format("%dd", static_cast<int>(days));
+    }
+    buffer = _("Starts in");
+    buffer += " ";
+    buffer += time_str;
+  } else if (now > notam_opt->end_time) {
+    // Expired
+    auto expired_ago = std::chrono::duration_cast<std::chrono::hours>(
+      now - notam_opt->end_time);
+    if (expired_ago.count() < 48) {
+      time_str.Format("%dh", static_cast<int>(expired_ago.count()));
+    } else {
+      auto days = expired_ago.count() / 24;
+      time_str.Format("%dd", static_cast<int>(days));
+    }
+    buffer = _("Expired");
+    buffer += " ";
+    buffer += time_str;
+    buffer += " ";
+    buffer += _("ago");
+  } else {
+    // Currently active
+    buffer = _("Active");
+  }
+  AddReadOnly(_("Now"), nullptr, buffer);
+}
+
+void
+NOTAMDetailsWidget::AddNOTAMAltitudes(
+    const std::optional<struct NOTAM> &notam_opt,
+    StaticString<128> &buffer)
+{
+  FormatAltitudeWithReference(buffer.data(), buffer.capacity(),
+                              airspace->GetTop(), notam_opt, false);
+  AddReadOnly(_("Top"), nullptr, buffer);
+
+  FormatAltitudeWithReference(buffer.data(), buffer.capacity(),
+                              airspace->GetBase(), notam_opt, true);
+  AddReadOnly(_("Base"), nullptr, buffer);
+}
+
+void
+NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
+                            [[maybe_unused]] const PixelRect &rc) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  StaticString<128> buffer;
+  
+  // Look up the NOTAM data using the number stored in station_name
+  const char *notam_number = airspace->GetStationName();
+  std::optional<struct NOTAM> notam_opt;
+  
+#ifdef HAVE_HTTP
+  if (net_components && net_components->notam && notam_number &&
+      notam_number[0] != '\0') {
+    notam_opt =
+      net_components->notam->FindNOTAMByNumber(notam_number);
+  }
+#endif
+  
+  AddNOTAMIdentifiers(notam_number, notam_opt, buffer);
+  
+  // NOTAM text (stored in name field)
+  AddMultiLine(airspace->GetName());
+
+  AddNOTAMValidity(notam_opt, buffer);
+  AddNOTAMAltitudes(notam_opt, buffer);
+  
+  // Distance calculation
+  if (warnings != nullptr) {
+    const GeoPoint closest =
+      airspace->ClosestPoint(basic.location, warnings->GetProjection());
+    const auto distance = closest.Distance(basic.location);
+    AddReadOnly(_("Distance"), nullptr, FormatUserDistance(distance));
+  }
 }

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -41,6 +41,7 @@ class AirspaceWarningListWidget final
   Button *ack_day_button;
   Button *enable_button;
   Button *radio_button;
+  Button *details_button;
 
   std::vector<AirspaceWarning> warning_list;
 
@@ -67,6 +68,7 @@ public:
     ack_day_button = buttons.AddButton(_("ACK Day"), [this](){ AckDay(); });
     enable_button = buttons.AddButton(_("Enable"), [this](){ Enable(); });
     radio_button = buttons.AddButton(_("Radio"), [this](){ Radio(); });
+    details_button = buttons.AddButton(_("Details"), [this](){ Details(); });
   }
 
   void CopyList();
@@ -129,6 +131,7 @@ AirspaceWarningListWidget::UpdateButtons()
     ack_day_button->SetEnabled(false);
     enable_button->SetEnabled(false);
     radio_button->SetEnabled(false);
+    details_button->SetEnabled(false);
     return;
   }
 
@@ -145,6 +148,7 @@ AirspaceWarningListWidget::UpdateButtons()
   ack_day_button->SetEnabled(!ack_day);
   enable_button->SetEnabled(!ack_expired);
   radio_button->SetEnabled(airspace->GetRadioFrequency().IsDefined());
+  details_button->SetEnabled(true);
 }
 
 void

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -83,6 +83,7 @@ public:
   void AckDay();
   void Enable();
   void Radio() noexcept;
+  void Details() noexcept;
 
   /* virtual methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -262,6 +263,13 @@ AirspaceWarningListWidget::Radio() noexcept
       selected_airspace->GetRadioFrequency().IsDefined())
     ActionInterface::SetActiveFrequency(selected_airspace->GetRadioFrequency(),
                                         selected_airspace->GetName());
+}
+
+void
+AirspaceWarningListWidget::Details() noexcept
+{
+  if (selected_airspace != nullptr)
+    dlgAirspaceDetails(selected_airspace, &airspace_warnings);
 }
 
 void

--- a/src/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp
@@ -31,7 +31,9 @@ enum ControlIndex {
   AcknowledgeTime,
   UseBlackOutline,
   AirspaceFillMode,
-  AirspaceTransparency
+#if defined(HAVE_HATCHED_BRUSH) && defined(HAVE_ALPHA_BLEND)
+  AirspaceTransparency,
+#endif
 };
 
 static constexpr StaticEnumChoice as_display_list[] = {

--- a/src/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NOTAMConfigPanel.hpp"
+#include "LogFile.hpp"
+#include "ConfigPanel.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Form/DataField/Boolean.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Language/Language.hpp"
+#include "Airspace/AirspaceComputerSettings.hpp"
+#include "Interface.hpp"
+#include "UIGlobals.hpp"
+#include "net/http/Features.hpp"
+#include "NetComponents.hpp"
+#include "Components.hpp"
+#include "DataComponents.hpp"
+#include "NOTAM/NOTAMGlue.hpp"
+#include "Dialogs/Airspace/NOTAMList.hpp"
+#include "Dialogs/Message.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Units/Units.hpp"
+#include "Units/Descriptor.hpp"
+#include "ui/event/Notify.hpp"
+#include "util/Macros.hpp"
+#include "util/StringFormat.hpp"
+
+#include <cstring>
+
+enum ControlIndex {
+#ifdef HAVE_HTTP
+  ENABLE_NOTAM,
+  NOTAM_RADIUS,
+  REFRESH_INTERVAL,
+  FILTER_SPACER,
+  SHOW_IFR,
+  IFR_FILTERED,
+  SHOW_ONLY_EFFECTIVE,
+  TIME_FILTERED,
+  MAX_RADIUS,
+  RADIUS_FILTERED,
+  HIDDEN_QCODES,
+  QCODE_FILTERED,
+#endif
+};
+
+class NOTAMConfigPanel : public RowFormWidget, 
+                         public DataFieldListener,
+                         public NOTAMListener {
+  // UI thread notification for async updates
+  UI::Notify notify{[this]() { UpdateFilterCounts(); }};
+
+public:
+  NOTAMConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
+  bool Save(bool &changed) noexcept override;
+
+private:
+  void OnUpdateButton() noexcept;
+  void UpdateVisibility() noexcept;
+  void UpdateFilterCounts() noexcept;
+  void ShowLoadingStatus() noexcept;
+  
+  /* methods from DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
+  
+  /* methods from NOTAMListener */
+  void OnNOTAMsUpdated() noexcept override;
+};
+
+void
+NOTAMConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, 
+                          [[maybe_unused]] const PixelRect &rc) noexcept
+{
+#ifdef HAVE_HTTP
+  const AirspaceComputerSettings &computer =
+    CommonInterface::GetComputerSettings().airspace;
+
+  AddBoolean(_("NOTAM Support"),
+             _("Enable downloading and display of NOTAMs from aviation authorities."),
+             computer.notam.enabled, this);
+
+  Unit distance_unit = Units::GetUserDistanceUnit();
+  double radius_user = Units::ToUserDistance(computer.notam.radius_km * 1000.0);
+  const char *unit_name = Units::GetUnitName(distance_unit);
+
+  char radius_format_display[32], radius_format_edit[32];
+  StringFormat(radius_format_display,
+               ARRAY_SIZE(radius_format_display),
+               "%%.0f %s", unit_name);
+  std::strcpy(radius_format_edit, "%.0f");
+
+  const double min_search_radius_user = Units::ToUserDistance(1000.0);
+  const double max_search_radius_user = Units::ToUserDistance(500000.0);
+  const double step_search_radius_user = Units::ToUserDistance(10000.0);
+
+  AddFloat(_("Search Radius"),
+           _("Radius around current location to fetch NOTAMs."),
+           radius_format_display, radius_format_edit,
+           min_search_radius_user, max_search_radius_user, step_search_radius_user, 0,
+           radius_user);
+
+  AddInteger(_("Auto-Refresh (minutes)"),
+             _("Automatically refresh NOTAMs every X minutes. Set to 0 to disable."),
+             "%d min", "%d", 0, 240, 15,
+             computer.notam.refresh_interval_min);
+
+  // Get NOTAM statistics for filter counts
+  NOTAMGlue::FilterStats stats = {};
+  if (net_components && net_components->notam) {
+    stats = net_components->notam->GetFilterStats();
+  }
+
+  AddSpacer();
+  
+  char buffer[64];
+
+  AddBoolean(_("Show IFR-Only NOTAMs"),
+             _("Include NOTAMs for IFR traffic only."),
+             computer.notam.show_ifr);
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_ifr);
+  AddReadOnly("", nullptr, buffer);
+
+  AddBoolean(_("Show Only Currently Effective"),
+             _("Filter out NOTAMs not currently in effect."),
+             computer.notam.show_only_effective);
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_time);
+  AddReadOnly("", nullptr, buffer);
+
+  // Radius filter with user units
+  double max_radius_user = Units::ToUserDistance(computer.notam.max_radius_m);
+  const double min_max_radius_user = Units::ToUserDistance(0.0);
+  const double max_max_radius_user = max_search_radius_user;
+  const double step_max_radius_user = step_search_radius_user;
+  
+  char format_display[32], format_edit[32];
+  StringFormat(format_display, ARRAY_SIZE(format_display),
+               "%%.0f %s", unit_name);
+  std::strcpy(format_edit, "%.0f");
+  
+  AddFloat(_("Maximum NOTAM Radius"),
+           _("Filter out NOTAMs with radius larger than this. Set to 0 to disable."),
+           format_display, format_edit,
+           min_max_radius_user, max_max_radius_user, step_max_radius_user, 0,
+           max_radius_user);
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_radius);
+  AddReadOnly("", nullptr, buffer);
+
+  AddText(_("Hidden Q-Codes"),
+          _("Space-separated Q-code prefixes to hide (e.g., QA QK QN QOA QOL)."),
+          computer.notam.hidden_qcodes.c_str());
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_qcode);
+  AddReadOnly("", nullptr, buffer);
+
+  UpdateVisibility();
+#endif
+}
+
+void
+NOTAMConfigPanel::Show(const PixelRect &rc) noexcept
+{
+#ifdef HAVE_HTTP
+  // Register as listener for NOTAM updates
+  if (net_components && net_components->notam) {
+    net_components->notam->AddListener(*this);
+  }
+  
+  ConfigPanel::BorrowExtraButton(1, _("Refresh"), [this](){
+    OnUpdateButton();
+  });
+  
+  ConfigPanel::BorrowExtraButton(2, _("List"), [](){
+    ShowNOTAMListDialog(UIGlobals::GetMainWindow());
+  });
+#endif
+
+  RowFormWidget::Show(rc);
+}
+
+void
+NOTAMConfigPanel::Hide() noexcept
+{
+  RowFormWidget::Hide();
+#ifdef HAVE_HTTP
+  // Unregister as listener
+  if (net_components && net_components->notam) {
+    net_components->notam->RemoveListener(*this);
+  }
+  
+  ConfigPanel::ReturnExtraButton(1);
+  ConfigPanel::ReturnExtraButton(2);
+#endif
+}
+
+void
+NOTAMConfigPanel::OnUpdateButton() noexcept
+{
+  LogFormat("NOTAM: Manual update triggered from settings panel");
+#ifdef HAVE_HTTP
+  // Save current settings first so the update uses the new values
+  bool dummy_changed = false;
+  Save(dummy_changed);
+
+  if (net_components && net_components->notam) {
+    // Show loading status
+    ShowLoadingStatus();
+    
+    // Invalidate cache to force fresh fetch with new settings
+    net_components->notam->InvalidateCache();
+    
+    const auto &basic = CommonInterface::Basic();
+    if (basic.location.IsValid()) {
+      // Trigger NOTAM update for current location (async)
+      // Filter counts will update via OnNOTAMsUpdated() callback when complete
+      net_components->notam->UpdateLocation(basic.location);
+    } else {
+      UpdateFilterCounts();
+      ShowMessageBox(_("No valid location."), _("NOTAM"),
+                     MB_OK | MB_ICONEXCLAMATION);
+    }
+  }
+#endif
+}
+
+void
+NOTAMConfigPanel::UpdateFilterCounts() noexcept
+{
+#ifdef HAVE_HTTP
+  if (!net_components || !net_components->notam) {
+    return;
+  }
+
+  // Get current filter statistics
+  NOTAMGlue::FilterStats stats = net_components->notam->GetFilterStats();
+  
+  char buffer[64];
+  
+  // Update each read-only count display
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_ifr);
+  SetText(IFR_FILTERED, buffer);
+  
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_time);
+  SetText(TIME_FILTERED, buffer);
+  
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_radius);
+  SetText(RADIUS_FILTERED, buffer);
+  
+  StringFormat(buffer, ARRAY_SIZE(buffer),
+               "%u filtered", stats.filtered_by_qcode);
+  SetText(QCODE_FILTERED, buffer);
+#endif
+}
+
+void
+NOTAMConfigPanel::ShowLoadingStatus() noexcept
+{
+#ifdef HAVE_HTTP
+  // Show "Loading..." in all filter count displays
+  SetText(IFR_FILTERED, _("Loading..."));
+  SetText(TIME_FILTERED, _("Loading..."));
+  SetText(RADIUS_FILTERED, _("Loading..."));
+  SetText(QCODE_FILTERED, _("Loading..."));
+#endif
+}
+
+void
+NOTAMConfigPanel::OnNOTAMsUpdated() noexcept
+{
+#ifdef HAVE_HTTP
+  // Called from background thread - dispatch UI update to main thread
+  notify.SendNotification();
+#endif
+}
+
+void
+NOTAMConfigPanel::UpdateVisibility() noexcept
+{
+#ifdef HAVE_HTTP
+  const DataFieldBoolean &df =
+    static_cast<const DataFieldBoolean &>(GetDataField(ENABLE_NOTAM));
+  const bool enabled = df.GetValue();
+  
+  SetRowAvailable(NOTAM_RADIUS, enabled);
+  SetRowAvailable(REFRESH_INTERVAL, enabled);
+  SetRowAvailable(SHOW_IFR, enabled);
+  SetRowAvailable(IFR_FILTERED, enabled);
+  SetRowAvailable(SHOW_ONLY_EFFECTIVE, enabled);
+  SetRowAvailable(TIME_FILTERED, enabled);
+  SetRowAvailable(MAX_RADIUS, enabled);
+  SetRowAvailable(RADIUS_FILTERED, enabled);
+  SetRowAvailable(HIDDEN_QCODES, enabled);
+  SetRowAvailable(QCODE_FILTERED, enabled);
+#endif
+}
+
+void
+NOTAMConfigPanel::OnModified(DataField &df) noexcept
+{
+#ifdef HAVE_HTTP
+  if (IsDataField(ENABLE_NOTAM, df)) {
+    UpdateVisibility();
+  }
+#endif
+}
+
+bool
+NOTAMConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+#ifdef HAVE_HTTP
+  AirspaceComputerSettings &computer =
+    CommonInterface::SetComputerSettings().airspace;
+  const bool was_enabled = computer.notam.enabled;
+
+  changed |= SaveValue(ENABLE_NOTAM, ProfileKeys::NOTAMEnabled, computer.notam.enabled);
+  changed |= SaveValueInteger(REFRESH_INTERVAL, ProfileKeys::NOTAMRefreshInterval, computer.notam.refresh_interval_min);
+
+  // Search radius - convert from user units to kilometers
+  double radius_user = GetValueFloat(NOTAM_RADIUS);
+  unsigned radius_km = static_cast<unsigned>(
+    (Units::ToSysDistance(radius_user) / 1000.0) + 0.5);
+  if (radius_km < 1)
+    radius_km = 1;
+  if (radius_km > 500)
+    radius_km = 500;
+  if (computer.notam.radius_km != radius_km) {
+    computer.notam.radius_km = radius_km;
+    Profile::Set(ProfileKeys::NOTAMRadius, radius_km);
+    changed = true;
+  }
+
+  // Filter settings
+  changed |= SaveValue(SHOW_IFR, ProfileKeys::NOTAMShowIFR, computer.notam.show_ifr);
+  changed |= SaveValue(SHOW_ONLY_EFFECTIVE, ProfileKeys::NOTAMShowOnlyEffective, computer.notam.show_only_effective);
+  
+  // Radius filter - convert from user units to meters
+  double max_radius_user = GetValueFloat(MAX_RADIUS);
+  unsigned max_radius_m =
+    static_cast<unsigned>(Units::ToSysDistance(max_radius_user) + 0.5);
+  if (computer.notam.max_radius_m != max_radius_m) {
+    computer.notam.max_radius_m = max_radius_m;
+    Profile::Set(ProfileKeys::NOTAMMaxRadius, max_radius_m);
+    changed = true;
+  }
+  
+  changed |= SaveValue(HIDDEN_QCODES, ProfileKeys::NOTAMHiddenQCodes, computer.notam.hidden_qcodes);
+
+  if (was_enabled && !computer.notam.enabled) {
+    if (net_components != nullptr && net_components->notam != nullptr) {
+      net_components->notam->Clear();
+      net_components->notam->InvalidateCache();
+      if (data_components != nullptr && data_components->airspaces != nullptr)
+        net_components->notam->UpdateAirspaces(*data_components->airspaces);
+    }
+  }
+#endif
+
+  _changed |= changed;
+
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateNOTAMConfigPanel()
+{
+  return std::make_unique<NOTAMConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/NOTAMConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/NOTAMConfigPanel.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+/**
+ * Creates a widget for configuring NOTAM (Notice to Airmen) settings.
+ * @return A unique pointer to the configuration panel widget.
+ */
+std::unique_ptr<Widget>
+CreateNOTAMConfigPanel();

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -21,6 +21,9 @@
 #include "Panels/TimeConfigPanel.hpp"
 #include "Panels/LoggerConfigPanel.hpp"
 #include "Panels/AirspaceConfigPanel.hpp"
+#ifdef HAVE_HTTP
+#include "Panels/NOTAMConfigPanel.hpp"
+#endif
 #include "Panels/SiteConfigPanel.hpp"
 #include "Panels/MapDisplayConfigPanel.hpp"
 #include "Panels/WaypointDisplayConfigPanel.hpp"
@@ -81,6 +84,9 @@ static constexpr TabMenuPage map_pages[] = {
   { N_("Waypoints"), CreateWaypointDisplayConfigPanel },
   { N_("Terrain"), CreateTerrainDisplayConfigPanel },
   { N_("Airspace"), CreateAirspaceConfigPanel },
+#ifdef HAVE_HTTP
+  { N_("NOTAM"), CreateNOTAMConfigPanel },
+#endif
   { nullptr, nullptr }
 };
 

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -5,11 +5,33 @@
 #include "Geo/GeoVector.hpp"
 #include "Airspaces.hpp"
 #include "AbstractAirspace.hpp"
+#include "Engine/Airspace/AirspaceClass.hpp"
 #include "AirspaceIntersectionVisitor.hpp"
 #include "AirspaceAircraftPerformance.hpp"
 #include "Task/Stats/TaskStats.hpp"
 
 static constexpr double CRUISE_FILTER_FACT = 0.5;
+
+[[gnu::const]]
+static bool
+IsNotamAirspace(const AbstractAirspace &airspace) noexcept
+{
+  return airspace.GetClassOrType() == AirspaceClass::NOTAM ||
+         airspace.GetTypeOrClass() == AirspaceClass::NOTAM;
+}
+
+/**
+ * Stable id for NOTAM day-ack: short identifier in #GetStationName().
+ */
+[[gnu::pure]]
+static const char *
+NotamDayAckKey(const AbstractAirspace &airspace) noexcept
+{
+  if (!IsNotamAirspace(airspace))
+    return nullptr;
+  const char *const s = airspace.GetStationName();
+  return (s != nullptr && s[0] != '\0') ? s : nullptr;
+}
 
 AirspaceWarningManager::AirspaceWarningManager(const AirspaceWarningConfig &_config,
                                                const Airspaces &_airspaces)
@@ -435,12 +457,24 @@ void
 AirspaceWarningManager::AcknowledgeDay(ConstAirspacePtr airspace,
                                        const bool set) noexcept
 {
+  if (const char *key = NotamDayAckKey(*airspace); key != nullptr) {
+    if (set)
+      notam_day_ack_by_station.emplace(key);
+    else
+      notam_day_ack_by_station.erase(key);
+  }
+
   GetWarning(std::move(airspace)).AcknowledgeDay(set);
 }
 
 bool
 AirspaceWarningManager::GetAckDay(const AbstractAirspace &airspace) const noexcept
 {
+  if (const char *key = NotamDayAckKey(airspace);
+      key != nullptr &&
+      notam_day_ack_by_station.find(key) != notam_day_ack_by_station.end())
+    return true;
+
   const AirspaceWarning *warning = GetWarningPtr(airspace);
   return warning != nullptr && warning->GetAckDay();
 }

--- a/src/Engine/Airspace/AirspaceWarningManager.hpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.hpp
@@ -10,6 +10,8 @@
 #include "util/Serial.hpp"
 
 #include <list>
+#include <string>
+#include <unordered_set>
 
 class TaskStats;
 class GlidePolar;
@@ -42,6 +44,14 @@ class AirspaceWarningManager {
   using AirspaceWarningList = std::list<AirspaceWarning>;
 
   AirspaceWarningList warnings;
+
+  /**
+   * NOTAM areas are removed and re-created when the NOTAM list is refreshed,
+   * so #warnings cannot match the new #AbstractAirspace by pointer.  "Ack
+   * day" for NOTAM is also keyed by NOTAM number (#GetStationName()) so it
+   * survives updates.
+   */
+  std::unordered_set<std::string> notam_day_ack_by_station;
 
   /**
    * This number is incremented each time this object is modified.

--- a/src/Formatter/AirspaceFormatter.cpp
+++ b/src/Formatter/AirspaceFormatter.cpp
@@ -160,6 +160,13 @@ AirspaceFormatter::GetClassShort(const AbstractAirspace &airspace)
 const char *
 AirspaceFormatter::GetType(const AbstractAirspace &airspace)
 {
+  // For NOTAM airspaces, show the Q-code stored in station_name
+  if (airspace.GetType() == AirspaceClass::NOTAM) {
+    const char *station_name = airspace.GetStationName();
+    if (station_name != nullptr && station_name[0] != '\0') {
+      return station_name;
+    }
+  }
   return GetClass(airspace.GetType());
 }
 

--- a/src/NOTAM/Client.cpp
+++ b/src/NOTAM/Client.cpp
@@ -1,0 +1,546 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Client.hpp"
+
+#ifdef HAVE_HTTP
+#include "NOTAM.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "co/Task.hxx"
+#include "lib/curl/CoRequest.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Slist.hxx"
+#include "lib/curl/Setup.hxx"
+#include "lib/fmt/ToBuffer.hxx"
+#include "Operation/ProgressListener.hpp"
+#include "net/http/Progress.hpp"
+#include "time/Convert.hxx"
+#include "Engine/Airspace/AirspaceAltitude.hpp"
+#include "io/StringOutputStream.hxx"
+#include "json/Serialize.hxx"
+#include "util/StringAPI.hxx"
+#include "util/StringCompare.hxx"
+#include "util/StringParser.hxx"
+#include "util/CharUtil.hxx"
+#include "util/StringStrip.hxx"
+#include "Units/System.hpp"
+#include "Units/Descriptor.hpp"
+#include "Geo/AltitudeReference.hpp"
+#include "LogFile.hpp"
+
+#include <boost/json.hpp>
+#include <stdexcept>
+#include <ctime>
+#include <algorithm>
+
+using std::string_view_literals::operator""sv;
+
+namespace {
+constexpr double NM_TO_METERS = 1852.0;
+constexpr double DEFAULT_NOTAM_RADIUS_METERS = 5000.0;
+}
+
+/**
+ * Parse altitude string to AirspaceAltitude using XCSoar's altitude parsing
+ * logic
+ * Based on ReadAltitude from AirspaceParser.cpp
+ */
+static AirspaceAltitude
+ParseAltitudeString(const std::string &alt_str)
+{
+  if (alt_str.empty()) {
+    // Return unknown/invalid altitude
+    AirspaceAltitude altitude;
+    altitude.reference = AltitudeReference::MSL;
+    altitude.altitude = -1.0; // Invalid marker
+    altitude.flight_level = 0;
+    altitude.altitude_above_terrain = 0;
+    return altitude;
+  }
+
+  // Create a StringParser from our string
+  StringParser<> input{alt_str.c_str()};
+  
+  auto unit = Unit::FEET;
+  enum { MSL, AGL, SFC, FL, STD, UNLIMITED } type = MSL;
+  double value = 0;
+
+  while (true) {
+    input.Strip();
+
+    if (IsDigitASCII(input.front())) {
+      if (auto x = input.ReadDouble())
+        value = *x;
+    } else if (input.SkipMatchIgnoreCase("GND"sv) ||
+               input.SkipMatchIgnoreCase("AGL"sv)) {
+      type = AGL;
+    } else if (input.SkipMatchIgnoreCase("SFC"sv)) {
+      type = SFC;
+    } else if (input.SkipMatchIgnoreCase("FL"sv)) {
+      type = FL;
+    } else if (input.SkipMatchIgnoreCase("FT"sv)) {
+      unit = Unit::FEET;
+    } else if (input.SkipMatchIgnoreCase("MSL"sv)) {
+      type = MSL;
+    } else if (input.front() == 'M' || input.front() == 'm') {
+      unit = Unit::METER;
+      input.Skip();
+    } else if (input.SkipMatchIgnoreCase("STD"sv)) {
+      type = STD;
+    } else if (input.SkipMatchIgnoreCase("UNL"sv)) {
+      type = UNLIMITED;
+    } else if (input.IsEmpty())
+      break;
+    else
+      input.Skip();
+  }
+
+  AirspaceAltitude altitude;
+
+  switch (type) {
+  case FL:
+    altitude.reference = AltitudeReference::STD;
+    altitude.flight_level = value;
+    /* prepare fallback, just in case we have no terrain */
+    altitude.altitude = Units::ToSysUnit(value, Unit::FLIGHT_LEVEL);
+    return altitude;
+
+  case UNLIMITED:
+    altitude.reference = AltitudeReference::MSL;
+    altitude.altitude = 50000;
+    return altitude;
+
+  case SFC:
+    altitude.reference = AltitudeReference::AGL;
+    altitude.altitude_above_terrain = -1;
+    /* prepare fallback, just in case we have no terrain */
+    altitude.altitude = 0;
+    return altitude;
+
+  default:
+    break;
+  }
+
+  // For MSL, AGL and STD we convert the altitude to meters
+  value = Units::ToSysUnit(value, unit);
+  switch (type) {
+  case MSL:
+    altitude.reference = AltitudeReference::MSL;
+    altitude.altitude = value;
+    return altitude;
+
+  case AGL:
+    altitude.reference = AltitudeReference::AGL;
+    altitude.altitude_above_terrain = value;
+    /* prepare fallback, just in case we have no terrain */
+    altitude.altitude = value;
+    return altitude;
+
+  case STD:
+    altitude.reference = AltitudeReference::STD;
+    altitude.flight_level = Units::ToUserUnit(value, Unit::FLIGHT_LEVEL);
+    /* prepare fallback, just in case we have no QNH */
+    altitude.altitude = value;
+    return altitude;
+
+  default:
+    // Default to MSL
+    altitude.reference = AltitudeReference::MSL;
+    altitude.altitude = value;
+    return altitude;
+  }
+}
+
+static AirspaceAltitude
+ParseFlightLevelLimit(const std::string &fl_value)
+{
+  const auto trimmed = Strip(std::string_view{fl_value});
+  if (trimmed.empty()) {
+    return ParseAltitudeString("");
+  }
+
+  if (trimmed == "000"sv) {
+    return ParseAltitudeString("GND");
+  }
+
+  if (trimmed == "999"sv) {
+    return ParseAltitudeString("UNL");
+  }
+
+  std::string fl;
+  fl.reserve(2 + trimmed.size());
+  fl.append("FL");
+  fl.append(trimmed);
+  return ParseAltitudeString(fl);
+}
+
+static auto
+tag_invoke(boost::json::value_to_tag<NOTAMPoint>,
+           const boost::json::value &jv)
+{
+  if (jv.is_array()) {
+    const auto &arr = jv.as_array();
+    if (arr.size() >= 2) {
+      return NOTAMPoint{
+        arr[0].to_number<double>(), // longitude
+        arr[1].to_number<double>()  // latitude  
+      };
+    }
+  }
+  throw std::runtime_error("Invalid coordinate format");
+}
+
+namespace NOTAMClient {
+
+static std::chrono::system_clock::time_point
+ParseISO8601(const std::string &iso_string)
+{
+  // Parse ISO8601 format: YYYY-MM-DDTHH:MM:SS.sssZ or PERM
+  if (iso_string == "PERM") {
+    // Return a far future date for permanent NOTAMs
+    return NOTAMTime::PermanentEndTime();
+  }
+  
+  struct tm tm = {};
+  const char* str = iso_string.c_str();
+  
+  // Parse YYYY-MM-DDTHH:MM:SS format
+  int year, month, day, hour, min, sec;
+  int scanned = sscanf(str, "%d-%d-%dT%d:%d:%d", 
+                       &year, &month, &day, &hour, &min, &sec);
+  
+  if (scanned >= 6) {
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = min;
+    tm.tm_sec = sec;
+    tm.tm_isdst = 0;  // UTC time
+    
+    return TimeGm(tm);
+  }
+  
+  throw std::runtime_error("Failed to parse ISO8601 timestamp: " + iso_string);
+}
+
+static void
+ParseNOTAMProperties(NOTAM &notam, const boost::json::object &notam_obj)
+{
+  bool has_lower_limit = false;
+  bool has_upper_limit = false;
+
+  notam.lower_altitude = ParseAltitudeString("");
+  notam.upper_altitude = ParseAltitudeString("");
+
+  // Parse NOTAM properties from the nested object
+  if (auto it = notam_obj.find("id"); it != notam_obj.end()) {
+    notam.id = boost::json::value_to<std::string>(it->value());
+  }
+
+  if (auto it = notam_obj.find("lastUpdated"); it != notam_obj.end()) {
+    notam.last_updated = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse NOTAM number
+  if (auto it = notam_obj.find("number"); it != notam_obj.end()) {
+    notam.number = boost::json::value_to<std::string>(it->value());
+  }
+  
+  if (auto it = notam_obj.find("text"); it != notam_obj.end()) {
+    notam.text = boost::json::value_to<std::string>(it->value());
+  }
+  
+  if (auto it = notam_obj.find("effectiveStart"); it != notam_obj.end()) {
+    notam.start_time =
+      ParseISO8601(boost::json::value_to<std::string>(it->value()));
+  }
+  
+  if (auto it = notam_obj.find("effectiveEnd"); it != notam_obj.end()) {
+    notam.end_time =
+      ParseISO8601(boost::json::value_to<std::string>(it->value()));
+  }
+  
+  // Parse altitude limits using airspace altitude parsing system
+  if (auto it = notam_obj.find("lowerLimit"); it != notam_obj.end()) {
+    const auto lower_str = boost::json::value_to<std::string>(it->value());
+    notam.lower_altitude = ParseAltitudeString(lower_str);
+    has_lower_limit = true;
+  }
+  
+  if (auto it = notam_obj.find("upperLimit"); it != notam_obj.end()) {
+    const auto upper_str = boost::json::value_to<std::string>(it->value());
+    notam.upper_altitude = ParseAltitudeString(upper_str);
+    has_upper_limit = true;
+  }
+  
+  if (auto it = notam_obj.find("classification"); it != notam_obj.end()) {
+    notam.classification = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse NOTAM series (e.g., F, M, B, W)
+  if (auto it = notam_obj.find("series"); it != notam_obj.end()) {
+    notam.series = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse NOTAM type (R=Replace, N=New, C=Cancel)
+  if (auto it = notam_obj.find("type"); it != notam_obj.end()) {
+    notam.type = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse selection code (ICAO Q-code that indicates NOTAM type)
+  if (auto it = notam_obj.find("selectionCode"); it != notam_obj.end()) {
+    notam.feature_type = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse flight level limits
+  if (auto it = notam_obj.find("minimumFL"); it != notam_obj.end()) {
+    notam.minimum_fl = boost::json::value_to<std::string>(it->value());
+    if (!has_lower_limit)
+      notam.lower_altitude = ParseFlightLevelLimit(notam.minimum_fl);
+  }
+  
+  if (auto it = notam_obj.find("maximumFL"); it != notam_obj.end()) {
+    notam.maximum_fl = boost::json::value_to<std::string>(it->value());
+    if (!has_upper_limit)
+      notam.upper_altitude = ParseFlightLevelLimit(notam.maximum_fl);
+  }
+  
+  // Parse location field (e.g., related airport ICAO code)
+  if (auto it = notam_obj.find("location"); it != notam_obj.end()) {
+    notam.location = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Parse traffic type (I=IFR, V=VFR, IV=both)
+  if (auto it = notam_obj.find("traffic"); it != notam_obj.end()) {
+    notam.traffic = boost::json::value_to<std::string>(it->value());
+  }
+  
+  // Use icaoLocation as source
+  if (auto it = notam_obj.find("icaoLocation"); it != notam_obj.end()) {
+    notam.source = boost::json::value_to<std::string>(it->value());
+  }
+}
+
+static void
+ParseNOTAMGeometry(NOTAM &notam, const boost::json::object &feature,
+                   const boost::json::object &notam_obj)
+{
+  // Parse geometry - the API uses GeometryCollection with Point geometries
+  const auto &geometry = feature.at("geometry").as_object();
+  const auto &geom_type = geometry.at("type").as_string();
+  
+  if (geom_type == "GeometryCollection"sv) {
+    const auto &geometries = geometry.at("geometries").as_array();
+    if (!geometries.empty()) {
+      const auto &first_geom = geometries[0].as_object();
+      const auto &first_type = first_geom.at("type").as_string();
+      
+      if (first_type == "Point"sv) {
+        notam.geometry.type = NOTAM::NOTAMGeometry::Type::POINT;
+        const auto &coords = first_geom.at("coordinates");
+        notam.geometry.center = boost::json::value_to<NOTAMPoint>(coords);
+        
+        // Check if there's a radius in the NOTAM data to make it a circle
+        if (auto it = notam_obj.find("radius"); it != notam_obj.end()) {
+          notam.geometry.type = NOTAM::NOTAMGeometry::Type::CIRCLE;
+          const auto radius_str =
+            boost::json::value_to<std::string>(it->value());
+          try {
+            // Radius is typically in nautical miles, convert to meters
+            double radius_nm = std::stod(radius_str);
+            notam.geometry.radius_meters = radius_nm * NM_TO_METERS;
+          } catch (const std::exception &) {
+            LogFormat("Failed to parse NOTAM radius for %s: %s",
+                      notam.number.c_str(), radius_str.c_str());
+            notam.geometry.radius_meters = DEFAULT_NOTAM_RADIUS_METERS;
+          }
+        }
+      }
+    }
+  } else if (geom_type == "Point"sv) {
+    notam.geometry.type = NOTAM::NOTAMGeometry::Type::POINT;
+    const auto &coords = geometry.at("coordinates");
+    notam.geometry.center = boost::json::value_to<NOTAMPoint>(coords);
+  } else if (geom_type == "Polygon"sv) {
+    notam.geometry.type = NOTAM::NOTAMGeometry::Type::POLYGON;
+    const auto &coords = geometry.at("coordinates").as_array();
+    if (!coords.empty()) {
+      const auto &ring = coords[0].as_array(); // First ring (exterior)
+      if (!ring.empty()) {
+        // First point as reference
+        notam.geometry.center =
+          boost::json::value_to<NOTAMPoint>(ring[0]);
+        
+        for (const auto &coord : ring) {
+          notam.geometry.polygon_points.emplace_back(
+            boost::json::value_to<NOTAMPoint>(coord)
+          );
+        }
+      }
+    }
+  }
+}
+
+static NOTAM
+ParseNOTAMFeature(const boost::json::object &feature)
+{
+  NOTAM notam;
+
+  // Get the nested NOTAM data
+  const auto &props = feature.at("properties").as_object();
+  const auto &core_notam_data = props.at("coreNOTAMData").as_object();
+  const auto &notam_obj = core_notam_data.at("notam").as_object();
+
+  ParseNOTAMProperties(notam, notam_obj);
+  ParseNOTAMGeometry(notam, feature, notam_obj);
+
+  return notam;
+}
+
+static std::vector<NOTAM>
+ParseNOTAMItems(const boost::json::array &items)
+{
+  std::vector<NOTAM> notams;
+  notams.reserve(items.size());
+
+  for (const auto &item_val : items) {
+    const auto &feature = item_val.as_object();
+    try {
+      notams.emplace_back(ParseNOTAMFeature(feature));
+    } catch (const std::exception &e) {
+      // Skip invalid NOTAMs but continue processing others
+      LogDebug("NOTAM: Skipped invalid item: %s", e.what());
+      continue;
+    }
+  }
+  
+  return notams;
+}
+
+std::vector<NOTAM>
+ParseNOTAMGeoJSON(const boost::json::value &json)
+{
+  const auto &root = json.as_object();
+
+  // The API returns items array instead of features
+  const auto &items = root.at("items").as_array();
+
+  return ParseNOTAMItems(items);
+}
+
+static NOTAMResponse
+ParseNOTAMResponse(const boost::json::value &json)
+{
+  NOTAMResponse response;
+
+  const auto &root = json.as_object();
+  if (auto it = root.find("delta");
+      it != root.end() && it->value().is_bool()) {
+    response.is_delta = it->value().as_bool();
+  }
+
+  if (auto it = root.find("removedIds");
+      it != root.end() && it->value().is_array()) {
+    const auto &removed = it->value().as_array();
+    response.removed_ids.reserve(removed.size());
+    for (const auto &entry : removed) {
+      if (entry.is_string())
+        response.removed_ids.emplace_back(entry.as_string().c_str());
+    }
+  }
+
+  if (auto it = root.find("items");
+      it != root.end() && it->value().is_array()) {
+    response.notams = ParseNOTAMItems(it->value().as_array());
+  }
+
+  return response;
+}
+
+std::vector<NOTAM>
+ParseNOTAMGeoJSON(const std::string &json_data)
+{
+  auto json_value = boost::json::parse(json_data);
+  return ParseNOTAMGeoJSON(json_value);
+}
+
+Co::Task<NOTAMResponse>
+FetchNOTAMsResponse(CurlGlobal &curl, const NOTAMSettings &settings,
+                    const GeoPoint &location, ProgressListener &progress,
+                    const KnownMap *known)
+{
+  const char *const base_url = settings.api_base_url.c_str();
+  if (base_url[0] == '\0') {
+    LogFormat("NOTAM: API base URL is empty");
+    co_return NOTAMResponse{};
+  }
+  const double raw_radius_nm = (settings.radius_km * 1000.0) / NM_TO_METERS;
+  constexpr double MAX_RADIUS_NM = 100.0;
+  const double radius_nm = std::clamp(raw_radius_nm, 0.0, MAX_RADIUS_NM);
+  if (raw_radius_nm > MAX_RADIUS_NM)
+    LogFormat("NOTAM: Requested radius %.1f NM clamped to %.1f NM",
+              raw_radius_nm, MAX_RADIUS_NM);
+  const auto url = fmt::format(
+    "{}?locationLongitude={}&locationLatitude={}&locationRadius={:.2f}",
+    base_url,
+    location.longitude.Degrees(),
+    location.latitude.Degrees(),
+    radius_nm);
+
+  LogFormat("NOTAM: Fetching NOTAMs within %.1f NM radius", radius_nm);
+  LogDebug("NOTAM: Request URL: %s", url.c_str());
+
+  CurlEasy easy(url.c_str());
+  Curl::Setup(easy);
+
+  CurlSlist headers;
+  std::string request_body;
+  if (known != nullptr && !known->empty()) {
+    boost::json::object known_obj;
+    for (const auto &entry : *known) {
+      if (!entry.first.empty() && !entry.second.empty())
+        known_obj[entry.first] = entry.second;
+    }
+
+    if (!known_obj.empty()) {
+      boost::json::object payload;
+      payload["known"] = std::move(known_obj);
+      StringOutputStream sos;
+      Json::Serialize(sos, boost::json::value(std::move(payload)));
+      request_body = std::move(sos).GetValue();
+      easy.SetPost();
+      easy.SetRequestBody(request_body);
+      headers.Append("Content-Type: application/json");
+      easy.SetRequestHeaders(headers.Get());
+    }
+  }
+
+  const Net::ProgressAdapter progress_adapter{easy, progress};
+
+  const auto http_response =
+    co_await Curl::CoRequest(curl, std::move(easy));
+
+  LogFormat("NOTAM: Response status=%u, body=%lu bytes",
+            http_response.status, (unsigned long)http_response.body.size());
+
+  if (http_response.status != 200) {
+    if (!http_response.body.empty()) {
+      constexpr size_t max_snippet = 512;
+      std::string snippet = http_response.body.substr(0, max_snippet);
+      LogFormat("NOTAM: Response body (first %lu bytes): %s",
+                (unsigned long)snippet.size(), snippet.c_str());
+    }
+    throw std::runtime_error(
+      fmt::format("Failed to fetch NOTAMs: HTTP {}", http_response.status));
+  }
+
+  auto json_value = boost::json::parse(http_response.body);
+  auto parsed = ParseNOTAMResponse(json_value);
+  parsed.raw_json = http_response.body;
+  co_return parsed;
+}
+
+} // namespace NOTAMClient
+
+#endif // HAVE_HTTP

--- a/src/NOTAM/Client.hpp
+++ b/src/NOTAM/Client.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "NOTAM.hpp"
+#include "Settings.hpp"
+
+#include <boost/json/fwd.hpp>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class CurlGlobal;
+class ProgressListener;
+struct GeoPoint;
+
+namespace Co { template<typename T> class Task; }
+
+namespace NOTAMClient {
+
+using KnownMap = std::unordered_map<std::string, std::string>;
+
+/**
+ * Response structure for NOTAM fetch operations.
+ *
+ * Contains the fetched NOTAMs,
+ * a flag indicating whether it is an incremental (= delta) update,
+ * any removed NOTAM IDs (for delta updates),
+ * and the raw JSON.
+ */
+struct NOTAMResponse {
+  std::vector<NOTAM> notams;
+  bool is_delta = false;
+  std::vector<std::string> removed_ids;
+  std::string raw_json;
+};
+
+/**
+ * Download NOTAMs, optionally using delta updates.
+ *
+ * @param curl HTTP client
+ * @param settings NOTAM configuration
+ * @param location Center point for the search
+ * @param progress Progress reporting interface
+ * @param known Map of NOTAM id -> lastUpdated to request delta updates,
+ *              or nullptr to perform a full fetch.
+ * @return Response containing NOTAMs, removed IDs, and delta status
+ */
+[[nodiscard]]
+Co::Task<NOTAMResponse>
+FetchNOTAMsResponse(
+    CurlGlobal &curl,
+    const NOTAMSettings &settings,
+    const GeoPoint &location,
+    ProgressListener &progress,
+    const KnownMap *known);
+
+/**
+ * Parse GeoJSON NOTAM data from the API response
+ * 
+ * @param json_data Raw JSON response from the API
+ * @return Vector of parsed NOTAM objects
+ */
+[[nodiscard]]
+std::vector<NOTAM>
+ParseNOTAMGeoJSON(const std::string &json_data);
+
+/**
+ * Parse GeoJSON NOTAM data from a JSON value
+ *
+ * @param json Parsed JSON response from the API
+ * @return Vector of parsed NOTAM objects
+ */
+[[nodiscard]]
+std::vector<NOTAM>
+ParseNOTAMGeoJSON(const boost::json::value &json);
+
+} // namespace NOTAMClient

--- a/src/NOTAM/Converter.cpp
+++ b/src/NOTAM/Converter.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Converter.hpp"
+
+#ifdef HAVE_HTTP
+#include "NOTAM.hpp"
+#include "LogFile.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Math/Angle.hpp"
+#include "Engine/Airspace/Airspaces.hpp"
+#include "Engine/Airspace/AirspaceClass.hpp"
+#include "Engine/Airspace/AirspaceAltitude.hpp"
+#include "Geo/AltitudeReference.hpp"
+#include "Engine/Airspace/AirspaceCircle.hpp"
+#include "Engine/Airspace/AirspacePolygon.hpp"
+#include "Engine/Airspace/AbstractAirspace.hpp"
+#include "TransponderCode.hpp"
+#include <memory>
+
+namespace NOTAMConverter {
+
+/** Default radius for NOTAM point geometries */
+static constexpr double DEFAULT_POINT_RADIUS_METERS = 500.0;
+/** Maximum allowed radius for NOTAM circle geometries */
+static constexpr double MAX_CIRCLE_RADIUS_METERS = 1000000.0;
+
+[[gnu::const]]
+GeoPoint
+NOTAMPointToGeoPoint(const NOTAMPoint &point) noexcept
+{
+  return GeoPoint(Angle::Degrees(point.longitude),
+                  Angle::Degrees(point.latitude));
+}
+
+/**
+ * Convert a NOTAM record to an airspace object and add it to the container.
+ *
+ * Converts NOTAM geometry (point/circle/polygon) into airspace shapes,
+ * applies default altitudes when missing/invalid, and maps NOTAM metadata to
+ * airspace properties. Unsupported geometry types or invalid geometry (e.g.
+ * too few polygon points or invalid circle radius) will cause a failure.
+ *
+ * @param notam Input NOTAM with populated geometry and altitude fields.
+ *              Coordinates are expected in degrees (WGS84) for conversion.
+ * @param airspaces Output container that takes ownership of the new airspace
+ *                  on success.
+ * @return true if the NOTAM was converted and added; false on failure.
+ */
+bool
+ConvertNOTAMToAirspace(const struct NOTAM &notam,
+                       Airspaces &airspaces) noexcept
+{
+  try {
+    std::unique_ptr<AbstractAirspace> airspace;
+    
+    // Create airspace based on geometry type
+    switch (notam.geometry.type) {
+      case NOTAM::NOTAMGeometry::POINT:
+        // Treat points as small circles
+        airspace = std::make_unique<AirspaceCircle>(
+          NOTAMPointToGeoPoint(notam.geometry.center),
+          DEFAULT_POINT_RADIUS_METERS
+        );
+        break;
+        
+      case NOTAM::NOTAMGeometry::CIRCLE:
+        // Validate radius before creating circle
+        if (notam.geometry.radius_meters <= 0) {
+          LogFormat("NOTAM: Invalid circle radius %.1f for NOTAM %s/%s, "
+                    "skipping",
+                    notam.geometry.radius_meters, notam.id.c_str(),
+                    notam.number.c_str());
+          return false;
+        }
+        if (notam.geometry.radius_meters > MAX_CIRCLE_RADIUS_METERS) {
+          LogFormat("NOTAM: Circle radius %.1f exceeds max %.0f for "
+                    "NOTAM %s/%s, skipping",
+                    notam.geometry.radius_meters, MAX_CIRCLE_RADIUS_METERS,
+                    notam.id.c_str(), notam.number.c_str());
+          return false;
+        }
+        airspace = std::make_unique<AirspaceCircle>(
+          NOTAMPointToGeoPoint(notam.geometry.center),
+          notam.geometry.radius_meters
+        );
+        break;
+        
+      case NOTAM::NOTAMGeometry::POLYGON:
+        if (notam.geometry.polygon_points.size() >= 3) {
+          std::vector<GeoPoint> points;
+          points.reserve(notam.geometry.polygon_points.size());
+          
+          for (const auto &notam_point : notam.geometry.polygon_points) {
+            points.push_back(NOTAMPointToGeoPoint(notam_point));
+          }
+          
+          airspace = std::make_unique<AirspacePolygon>(std::move(points));
+        } else {
+          LogFormat("NOTAM: Invalid polygon with %u points for NOTAM %s, "
+                    "skipping (minimum 3 required)",
+                    static_cast<unsigned>(
+                      notam.geometry.polygon_points.size()),
+                    notam.number.c_str());
+          return false; // Invalid polygon
+        }
+        break;
+        
+      default:
+        return false; // Unknown geometry type
+    }
+    
+    if (!airspace) {
+      return false;
+    }
+    
+    // Use the altitude objects directly from NOTAM
+    AirspaceAltitude base = notam.lower_altitude;
+    AirspaceAltitude top = notam.upper_altitude;
+    
+    // Use default altitudes if invalid (altitude < 0 indicates invalid)
+    if (base.altitude < 0) {
+      base.altitude = 0; // Ground level
+      base.reference = AltitudeReference::MSL;
+    }
+    
+    if (top.altitude < 0) {
+      top.altitude = 20000; // Default ceiling 20 km MSL
+      top.reference = AltitudeReference::MSL;
+    }
+    
+    // Set airspace properties with all required parameters
+    std::string name = notam.number.empty()
+      ? ("NOTAM " + notam.id)
+      : notam.number;
+    airspace->SetProperties(
+      std::move(name), // name
+      std::string{}, // station_name
+      TransponderCode(), // transponder_code
+      UNCLASSIFIED, // class
+      NOTAM, // type
+      base, // base altitude
+      top // top altitude
+    );
+    
+    // Set radio frequency if available (extract from text/source)
+    // TODO: Parse radio frequency from NOTAM text if available?
+    
+    // Add to airspace database
+    airspaces.Add(std::move(airspace));
+    
+    return true;
+    
+  } catch (const std::exception &e) {
+    LogFormat("NOTAM: Failed to convert NOTAM %s: %s",
+              notam.number.c_str(), e.what());
+    return false;
+  }
+}
+
+/**
+ * Convert all active NOTAMs into airspace objects and append them to the
+ * output.
+ *
+ * @param notams Input list of NOTAMs to consider.
+ * @param airspaces Output container receiving converted airspaces.
+ * @return Number of NOTAMs successfully converted and added.
+ */
+unsigned
+ConvertNOTAMsToAirspaces(const std::vector<struct NOTAM> &notams,
+                         Airspaces &airspaces) noexcept
+{
+  unsigned count = 0;
+  
+  for (const auto &notam : notams) {
+    // Only convert active NOTAMs
+    if (notam.IsActive() && ConvertNOTAMToAirspace(notam, airspaces)) {
+      count++;
+    }
+  }
+  
+  return count;
+}
+
+} // namespace NOTAMConverter
+
+#endif // HAVE_HTTP

--- a/src/NOTAM/Converter.hpp
+++ b/src/NOTAM/Converter.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "NOTAM.hpp"
+
+#include <vector>
+
+class Airspaces;
+struct GeoPoint;
+
+namespace NOTAMConverter {
+
+/**
+ * Convert a NOTAM to XCSoar airspace format
+ * and add it to the airspace database
+ * 
+ * @param notam NOTAM to convert
+ * @param airspaces Target airspace database
+ * @return true if the NOTAM was successfully converted and added
+ */
+[[nodiscard]] bool
+ConvertNOTAMToAirspace(const NOTAM &notam, Airspaces &airspaces) noexcept;
+
+/**
+ * Convert multiple NOTAMs to airspace format
+ * 
+ * @param notams Vector of NOTAMs to convert
+ * @param airspaces Target airspace database
+ * @return Number of NOTAMs successfully converted
+ */
+[[nodiscard]] unsigned
+ConvertNOTAMsToAirspaces(const std::vector<NOTAM> &notams,
+                         Airspaces &airspaces) noexcept;
+
+/**
+ * Convert NOTAM coordinates to GeoPoint
+ *
+ * @param point NOTAM coordinate to convert
+ * @return Converted GeoPoint
+ */
+[[nodiscard]] GeoPoint
+NOTAMPointToGeoPoint(const NOTAMPoint &point) noexcept;
+
+} // namespace NOTAMConverter

--- a/src/NOTAM/Filter.cpp
+++ b/src/NOTAM/Filter.cpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Filter.hpp"
+
+#include "LogFile.hpp"
+
+#include <chrono>
+#include <cctype>
+
+namespace NOTAMFilter {
+
+bool
+IsQCodeHidden(std::string_view qcode,
+              std::string_view hidden_list) noexcept
+{
+  if (qcode.empty() || hidden_list.empty())
+    return false;
+
+  size_t start = hidden_list.find_first_not_of(" \t,");
+  while (start != std::string_view::npos) {
+    const size_t end = hidden_list.find_first_of(" \t,", start);
+    const size_t prefix_len = end == std::string_view::npos
+      ? hidden_list.size() - start
+      : end - start;
+    if (prefix_len > 0 &&
+        qcode.compare(0, prefix_len,
+                      hidden_list.substr(start, prefix_len)) == 0) {
+      return true;
+    }
+
+    if (end == std::string_view::npos)
+      break;
+
+    start = hidden_list.find_first_not_of(" \t,", end + 1);
+  }
+
+  return false;
+}
+
+bool
+ShouldDisplay(const NOTAM &notam, const NOTAMSettings &settings,
+              bool log) noexcept
+{
+  // Check IFR filter (I=IFR-only, V=VFR-only, IV=both)
+  if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I") {
+    if (log) {
+      LogDebug("NOTAM Filter: {} is IFR-only traffic ({}), filtered out",
+               notam.number.c_str(), notam.traffic.c_str());
+    }
+    return false;
+  }
+
+  // Check if currently effective (if filter enabled)
+  if (settings.show_only_effective) {
+    if (!notam.IsActive()) {
+      if (log) {
+        LogDebug("NOTAM Filter: {} not currently effective, filtered out",
+                 notam.number.c_str());
+      }
+      return false;
+    }
+  }
+
+  // Check radius filter
+  if (settings.max_radius_m > 0 &&
+      notam.geometry.radius_meters > settings.max_radius_m) {
+    if (log) {
+      LogDebug("NOTAM Filter: {} radius {:.0f} m exceeds limit {} m, "
+               "filtered out",
+               notam.number.c_str(), notam.geometry.radius_meters,
+               settings.max_radius_m);
+    }
+    return false;
+  }
+
+  const auto &qcode = notam.feature_type;
+  if (qcode.empty())
+    return true;
+
+  if (log) {
+    LogDebug("NOTAM Filter: {} Q-code='{}'", notam.number.c_str(),
+             qcode.c_str());
+  }
+
+  if (IsQCodeHidden(qcode, settings.hidden_qcodes.c_str())) {
+    if (log) {
+      LogDebug("NOTAM Filter: {} Q-code {} is hidden",
+               notam.number.c_str(), qcode.c_str());
+    }
+    return false;
+  }
+
+  return true;
+}
+
+} // namespace NOTAMFilter

--- a/src/NOTAM/Filter.hpp
+++ b/src/NOTAM/Filter.hpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "NOTAM.hpp"
+#include "Settings.hpp"
+
+#include <string_view>
+
+namespace NOTAMFilter {
+
+[[nodiscard]]
+bool IsQCodeHidden(std::string_view qcode,
+                   std::string_view hidden_list) noexcept;
+
+[[nodiscard]]
+bool ShouldDisplay(const NOTAM &notam,
+                   const NOTAMSettings &settings,
+                   bool log) noexcept;
+
+} // namespace NOTAMFilter

--- a/src/NOTAM/NOTAM.hpp
+++ b/src/NOTAM/NOTAM.hpp
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Engine/Airspace/AirspaceAltitude.hpp"
+#include <chrono>
+#include <vector>
+#include <string>
+
+namespace NOTAMTime {
+
+inline std::chrono::system_clock::time_point
+PermanentEndTime() noexcept
+{
+  // 2100-01-01T00:00:00Z, far-future sentinel for PERM without overflow risk
+  return std::chrono::system_clock::time_point{
+    std::chrono::seconds{4102444800LL}
+  };
+}
+
+} // namespace NOTAMTime
+
+/**
+ * Simple geographic point for NOTAM geometry
+ */
+struct NOTAMPoint {
+  double longitude = 0.0; ///< Longitude in degrees
+  double latitude = 0.0;  ///< Latitude in degrees
+};
+
+/**
+ * Represents a single NOTAM (Notice to Airmen)
+ */
+struct NOTAM {
+  /** NOTAM unique identifier */
+  std::string id;
+
+  /** Timestamp of last update (ISO8601 string from API)
+  * Kept as ISO8601 string since it serves as a unique
+  * identifier for delta updates */
+  std::string last_updated;
+  
+  /** NOTAM number (e.g., A1234/24) */
+  std::string number;
+  
+  /** NOTAM series (e.g., F, M, B, W) */
+  std::string series;
+  
+  /** NOTAM type (R=Replace, N=New, C=Cancel) */
+  std::string type;
+  
+  /** Detailed NOTAM text */
+  std::string text;
+  
+  /** Start time of the NOTAM validity */
+  std::chrono::system_clock::time_point start_time;
+  
+  /** End time of the NOTAM validity */
+  std::chrono::system_clock::time_point end_time;
+  
+  /** Geographic area affected by the NOTAM */
+  struct NOTAMGeometry {
+    enum Type {
+      POINT,
+      CIRCLE,
+      POLYGON,
+      COUNT
+    } type = POINT;
+    
+    /** Center point (for POINT and CIRCLE) or first point (for POLYGON) */
+    NOTAMPoint center;
+    
+    /** Radius (only for CIRCLE type) */
+    double radius_meters = 0.0;
+    
+    /** Additional points for polygon */
+    std::vector<NOTAMPoint> polygon_points;
+  } geometry;
+  
+  /** Lower altitude limit */
+  AirspaceAltitude lower_altitude;
+  
+  /** Upper altitude limit */  
+  AirspaceAltitude upper_altitude;
+  
+  /** NOTAM classification/type */
+  std::string classification;
+  
+  /** Feature type (e.g., AIRSPACE, OBST, NAV, COM, MILITARY) */
+  std::string feature_type;
+  
+  /** Minimum flight level (000-999) */
+  std::string minimum_fl;
+  
+  /** Maximum flight level (000-999) */
+  std::string maximum_fl;
+  
+  /** Source of the NOTAM */
+  std::string source;
+  
+  /** ICAO location code (e.g., EDGG) */
+  std::string location;
+  
+  /** Traffic type: I=IFR only, V=VFR only, IV=IFR and VFR */
+  std::string traffic;
+  
+  /**
+   * Check if this NOTAM is currently active
+   */
+  bool IsActive() const noexcept {
+    const auto now = std::chrono::system_clock::now();
+    return now >= start_time && now <= end_time;
+  }
+  
+  /**
+   * Check if this NOTAM affects the given location and altitude
+   */
+  bool AffectsLocation(double longitude, double latitude,
+                       double altitude_meters = -1.0) const noexcept;
+};

--- a/src/NOTAM/NOTAMGlue.cpp
+++ b/src/NOTAM/NOTAMGlue.cpp
@@ -1,0 +1,1639 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NOTAMGlue.hpp"
+#include "NOTAM.hpp"
+#include "Client.hpp"
+#include "Filter.hpp"
+#include "Components.hpp"
+#include "DataComponents.hpp"
+#include "Message.hpp"
+#include "Airspace/Airspaces.hpp"
+#include "Airspace/AirspaceCircle.hpp"
+#include "Airspace/AirspacePolygon.hpp"
+#include "Airspace/AirspaceClass.hpp"
+#include "Airspace/AirspaceAltitude.hpp"
+#include "TransponderCode.hpp"
+#include "Operation/Operation.hpp"
+#include "Operation/ProgressListener.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/FileReader.hxx"
+#include "system/Path.hpp"
+#include "system/FileUtil.hpp"
+#include "LocalPath.hpp"
+#include "LogFile.hpp"
+#include "util/StaticString.hxx"
+#include "util/SpanCast.hxx"
+#include "util/UTF8.hpp"
+#include "Geo/AltitudeReference.hpp"
+#include "thread/Mutex.hxx"
+#include "co/Task.hxx"
+#include "co/InvokeTask.hxx"
+#include "lib/curl/Global.hxx"
+#include "time/Convert.hxx"
+#include "Language/Language.hpp"
+
+#include <optional>
+#include <algorithm>
+#include <charconv>
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <string_view>
+#include <system_error>
+#include <unordered_map>
+#include <unordered_set>
+
+#include <boost/json.hpp>
+#include <boost/json/serializer.hpp>
+
+// Use full struct name to avoid collision with AirspaceClass::NOTAM enum
+using NOTAMStruct = struct NOTAM;
+
+#ifdef HAVE_HTTP
+
+static constexpr std::time_t MIN_NOTAM_REFRESH_ATTEMPT_INTERVAL_SECONDS =
+    120;
+// Sentinel for missing MSL altitude in NOTAM data.
+static constexpr double MISSING_MSL_ALTITUDE = -1.0;
+// Truncate NOTAM text for airspace name display.
+static constexpr size_t NOTAM_TEXT_TRUNCATE_LENGTH = 150;
+
+struct CacheMetadata {
+  std::time_t timestamp = 0;
+  GeoPoint location = GeoPoint::Invalid();
+  unsigned radius_km = 0;
+  bool valid = false;
+};
+
+// Private implementation to avoid template issues  
+struct NOTAMImpl {
+  std::vector<NOTAMStruct> current_notams;
+  NOTAMClient::KnownMap known;
+  GeoPoint known_location = GeoPoint::Invalid();
+  unsigned known_radius_km = 0;
+  boost::json::value cached_api;
+  bool cached_api_valid = false;
+  CacheMetadata last_update;
+  bool last_update_cached = false;
+};
+
+static NOTAMClient::KnownMap
+BuildKnownMap(const std::vector<NOTAMStruct> &notams)
+{
+  NOTAMClient::KnownMap known;
+  known.reserve(notams.size());
+  for (const auto &notam : notams) {
+    if (!notam.id.empty() && !notam.last_updated.empty())
+      known.emplace(notam.id, notam.last_updated);
+  }
+  return known;
+}
+
+static bool
+IsApiResponseValid(const boost::json::value &value)
+{
+  if (!value.is_object())
+    return false;
+
+  const auto &obj = value.as_object();
+  auto it = obj.find("items");
+  return it != obj.end() && it->value().is_array();
+}
+
+static void
+PopulateImplFromCache(NOTAMImpl &impl,
+                      std::vector<NOTAMStruct> &&cached_notams,
+                      const GeoPoint &known_location,
+                      unsigned known_radius_km,
+                      boost::json::value cached_api)
+{
+  const bool cached_api_valid = IsApiResponseValid(cached_api);
+  impl.current_notams = std::move(cached_notams);
+  impl.known = BuildKnownMap(impl.current_notams);
+  impl.known_location = known_location;
+  impl.known_radius_km = known_radius_km;
+  if (cached_api_valid)
+    impl.cached_api = std::move(cached_api);
+  else
+    impl.cached_api = boost::json::value();
+  impl.cached_api_valid = cached_api_valid;
+  impl.last_update = CacheMetadata{};
+  impl.last_update_cached = false;
+}
+
+static bool
+CanUseDelta(const NOTAMImpl &impl, const GeoPoint &location,
+            unsigned radius_km)
+{
+  if (!location.IsValid())
+    return false;
+
+  if (!impl.cached_api_valid)
+    return false;
+
+  if (impl.known.empty() || !impl.known_location.IsValid())
+    return false;
+
+  if (impl.known_radius_km != radius_km)
+    return false;
+
+  const double radius_m = radius_km * 1000.0;
+  const double distance_m = location.Distance(impl.known_location);
+  return distance_m <= (radius_m * 0.5);
+}
+
+static void
+ApplyDeltaUpdates(std::vector<NOTAMStruct> &current,
+                  const std::vector<NOTAMStruct> &updates,
+                  const std::vector<std::string> &removed_ids)
+{
+  if (!removed_ids.empty()) {
+    std::unordered_set<std::string> removed(removed_ids.begin(),
+                                            removed_ids.end());
+    current.erase(std::remove_if(current.begin(), current.end(),
+                                 [&removed](const NOTAMStruct &notam) {
+                                   return !notam.id.empty() &&
+                                     removed.find(notam.id) != removed.end();
+                                 }),
+                  current.end());
+  }
+
+  if (!updates.empty()) {
+    std::unordered_map<std::string, size_t> index;
+    index.reserve(current.size());
+    for (size_t i = 0; i < current.size(); ++i) {
+      if (!current[i].id.empty())
+        index.emplace(current[i].id, i);
+    }
+
+    for (const auto &update : updates) {
+      if (update.id.empty())
+        continue;
+
+      auto it = index.find(update.id);
+      if (it != index.end()) {
+        current[it->second] = update;
+      } else {
+        index.emplace(update.id, current.size());
+        current.push_back(update);
+      }
+    }
+  }
+}
+
+static bool
+GetNotamIdFromItem(const boost::json::value &item, std::string &id)
+{
+  if (!item.is_object())
+    return false;
+
+  const auto &obj = item.as_object();
+  auto it_props = obj.find("properties");
+  if (it_props == obj.end() || !it_props->value().is_object())
+    return false;
+
+  const auto &props = it_props->value().as_object();
+  auto it_core = props.find("coreNOTAMData");
+  if (it_core == props.end() || !it_core->value().is_object())
+    return false;
+
+  const auto &core = it_core->value().as_object();
+  auto it_notam = core.find("notam");
+  if (it_notam == core.end() || !it_notam->value().is_object())
+    return false;
+
+  const auto &notam = it_notam->value().as_object();
+  auto it_id = notam.find("id");
+  if (it_id == notam.end() || !it_id->value().is_string())
+    return false;
+
+  id = it_id->value().as_string().c_str();
+  return !id.empty();
+}
+
+static bool
+ApplyDeltaToApi(boost::json::value &api_response,
+                const boost::json::value &delta_response,
+                const std::vector<std::string> &removed_ids)
+{
+  if (!api_response.is_object() || !delta_response.is_object())
+    return false;
+
+  auto &api_obj = api_response.as_object();
+  auto it_api_items = api_obj.find("items");
+  if (it_api_items == api_obj.end() || !it_api_items->value().is_array())
+    return false;
+
+  auto &api_items = it_api_items->value().as_array();
+
+  std::unordered_set<std::string> removed;
+  if (!removed_ids.empty())
+    removed.insert(removed_ids.begin(), removed_ids.end());
+
+  if (!removed.empty()) {
+    api_items.erase(std::remove_if(api_items.begin(), api_items.end(),
+                                   [&removed](const boost::json::value &item) {
+                                     std::string id;
+                                     return GetNotamIdFromItem(item, id) &&
+                                       removed.find(id) != removed.end();
+                                   }),
+                    api_items.end());
+  }
+
+  std::unordered_map<std::string, std::size_t> index;
+  index.reserve(api_items.size());
+  for (std::size_t i = 0; i < api_items.size(); ++i) {
+    std::string id;
+    if (GetNotamIdFromItem(api_items[i], id))
+      index.emplace(std::move(id), i);
+  }
+
+  const auto &delta_obj = delta_response.as_object();
+  auto it_delta_items = delta_obj.find("items");
+  if (it_delta_items != delta_obj.end() &&
+      it_delta_items->value().is_array()) {
+    const auto &delta_items = it_delta_items->value().as_array();
+    for (const auto &item : delta_items) {
+      std::string id;
+      if (!GetNotamIdFromItem(item, id))
+        continue;
+
+      auto it = index.find(id);
+      if (it != index.end()) {
+        api_items[it->second] = item;
+      } else {
+        index.emplace(std::move(id), api_items.size());
+        api_items.emplace_back(item);
+      }
+    }
+  }
+
+  if (api_obj.find("totalCount") != api_obj.end()) {
+    api_obj["totalCount"] = static_cast<std::uint64_t>(api_items.size());
+  }
+
+  return true;
+}
+
+static bool
+ParseJsonValue(const std::string &json, boost::json::value &value)
+{
+  boost::system::error_code ec;
+  value = boost::json::parse(json, ec);
+  if (ec) {
+    LogFormat("NOTAM: JSON parse error: %s", ec.message().c_str());
+    return false;
+  }
+
+  return true;
+}
+
+static std::string
+SerializeJsonValueReadable(const boost::json::value &value);
+
+static bool
+ParseNOTAMsFromApiValue(const boost::json::value &value,
+                        std::vector<NOTAMStruct> &notams,
+                        const char *context)
+{
+  try {
+    notams = NOTAMClient::ParseNOTAMGeoJSON(value);
+    return true;
+  } catch (const std::exception &e) {
+    LogFormat("NOTAM: %s parse error: %s", context, e.what());
+    return false;
+  }
+}
+
+static void
+AppendJsonString(std::string &out, boost::json::string_view text)
+{
+  boost::json::serializer s;
+  boost::json::value value(text);
+  s.reset(&value);
+
+  while (!s.done()) {
+    char buffer[BOOST_JSON_STACK_BUFFER_SIZE];
+    auto r = s.read(buffer);
+    out.append(r.data(), r.size());
+  }
+}
+
+static void
+AppendJsonInteger(std::string &out, std::int64_t value)
+{
+  char buffer[32];
+  auto result = std::to_chars(buffer, buffer + sizeof(buffer), value);
+  if (result.ec == std::errc()) {
+    out.append(buffer, result.ptr - buffer);
+  } else {
+    LogFormat("NOTAM: Integer conversion error for value %lld",
+              static_cast<long long>(value));
+    out.append("0");
+  }
+}
+
+static void
+AppendJsonUnsigned(std::string &out, std::uint64_t value)
+{
+  char buffer[32];
+  auto result = std::to_chars(buffer, buffer + sizeof(buffer), value);
+  if (result.ec == std::errc()) {
+    out.append(buffer, result.ptr - buffer);
+  } else {
+    LogFormat("NOTAM: Unsigned conversion error for value %llu",
+              static_cast<unsigned long long>(value));
+    out.append("0");
+  }
+}
+
+static void
+AppendJsonDouble(std::string &out, double value)
+{
+  if (!std::isfinite(value)) {
+    out.append("null");
+    return;
+  }
+
+  if (value == 0.0) {
+    out.push_back('0');
+    return;
+  }
+
+  char buffer[128];
+  int length = std::snprintf(buffer, sizeof(buffer), "%.17f", value);
+  if (length <= 0) {
+    out.append("0");
+    return;
+  }
+
+  std::size_t trimmed = static_cast<std::size_t>(length);
+  std::size_t dot = std::string_view(buffer, trimmed).find('.');
+  if (dot != std::string_view::npos) {
+    while (trimmed > dot + 1 && buffer[trimmed - 1] == '0')
+      --trimmed;
+    if (trimmed > dot && buffer[trimmed - 1] == '.')
+      --trimmed;
+  }
+
+  if (trimmed == 0)
+    out.append("0");
+  else
+    out.append(buffer, trimmed);
+}
+
+static void
+AppendJsonValue(std::string &out, const boost::json::value &value)
+{
+  switch (value.kind()) {
+  case boost::json::kind::object: {
+    out.push_back('{');
+    bool first = true;
+    for (const auto &entry : value.as_object()) {
+      if (!first)
+        out.push_back(',');
+      first = false;
+      AppendJsonString(out, entry.key());
+      out.push_back(':');
+      AppendJsonValue(out, entry.value());
+    }
+    out.push_back('}');
+    break;
+  }
+  case boost::json::kind::array: {
+    out.push_back('[');
+    bool first = true;
+    for (const auto &entry : value.as_array()) {
+      if (!first)
+        out.push_back(',');
+      first = false;
+      AppendJsonValue(out, entry);
+    }
+    out.push_back(']');
+    break;
+  }
+  case boost::json::kind::string:
+    AppendJsonString(out, value.as_string());
+    break;
+  case boost::json::kind::int64:
+    AppendJsonInteger(out, value.as_int64());
+    break;
+  case boost::json::kind::uint64:
+    AppendJsonUnsigned(out, value.as_uint64());
+    break;
+  case boost::json::kind::double_:
+    AppendJsonDouble(out, value.as_double());
+    break;
+  case boost::json::kind::bool_:
+    out.append(value.as_bool() ? "true" : "false");
+    break;
+  case boost::json::kind::null:
+    out.append("null");
+    break;
+  }
+}
+
+static std::string
+SerializeJsonValueReadable(const boost::json::value &value)
+{
+  std::string out;
+  out.reserve(4096);
+  AppendJsonValue(out, value);
+  return out;
+}
+
+
+NOTAMGlue::NOTAMGlue(const NOTAMSettings &_settings, CurlGlobal &_curl)
+  : RateLimiter(std::chrono::seconds(30), std::chrono::seconds(30)),
+    settings(_settings), curl(_curl), 
+    current_notams_impl(std::make_unique<NOTAMImpl>()),
+    load_task(curl.GetEventLoop())
+{
+}
+
+NOTAMGlue::~NOTAMGlue() = default;
+
+void
+NOTAMGlue::OnTimer(const GeoPoint &current_location)
+{
+  if (!settings.enabled) {
+    LogDebug("NOTAM: Auto-refresh skipped - disabled in settings");
+    return;
+  }
+
+  if (!current_location.IsValid()) {
+    LogDebug("NOTAM: Auto-refresh skipped - invalid location");
+    return;
+  }
+
+  // Check if manual-only mode (interval = 0)
+  if (settings.refresh_interval_min == 0) {
+    LogDebug("NOTAM: Auto-refresh skipped - manual-only mode");
+    return;
+  }
+
+  // If we're already loading or a retry is pending, skip auto-refresh
+  std::time_t last_attempt_time_snapshot = 0;
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    if (loading || retry_pending) {
+      LogDebug("NOTAM: Auto-refresh skipped - loading={} retry_pending={}",
+               loading, retry_pending);
+      return;
+    }
+    last_attempt_time_snapshot = last_attempt_time;
+  }
+
+  GeoPoint last_loc = GetLastUpdateLocation();
+  std::time_t last_time = GetLastUpdateTime();
+  std::time_t now = std::time(nullptr);
+  
+  // Check if time interval has elapsed since last successful fetch
+  bool time_expired = (last_time == 0) || 
+                      (now - last_time >= static_cast<std::time_t>(
+                                          settings.refresh_interval_min * 60));
+
+  const unsigned last_radius_km = GetLastUpdateRadius();
+  const bool radius_changed =
+    (last_radius_km > 0) && (last_radius_km != settings.radius_km);
+  
+  // Also check if enough time has passed since last attempt (even if it
+  // failed).
+  // This prevents rapid retries when there's no network connection
+  bool enough_time_since_attempt =
+      (now - last_attempt_time_snapshot >=
+       MIN_NOTAM_REFRESH_ATTEMPT_INTERVAL_SECONDS);
+  
+  // Check if location moved outside half the radius
+  bool location_changed = last_loc.IsValid() &&
+                          current_location.Distance(last_loc) >
+                            (settings.radius_km * 1000.0 / 2.0);
+  
+  if (!enough_time_since_attempt) {
+    // Auto-refresh skipped - last attempt too recent
+    return;
+  }
+
+  if (time_expired || location_changed || radius_changed) {
+    UpdateLocation(current_location);
+    return;
+  }
+}
+
+void
+NOTAMGlue::UpdateLocation(const GeoPoint &location)
+{
+  if (!location.IsValid()) {
+    return;
+  }
+
+  // Check if settings are enabled
+  if (!settings.enabled) {
+    return;
+  }
+
+  // Check if already loading
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    if (loading) {
+      return; // Already loading, skip this request
+    }
+    loading = true;
+    retry_pending = false;
+    current_location = location;
+    last_attempt_time = std::time(nullptr);  // Record attempt time
+  }
+  
+  // Log only when we actually start a fetch
+  LogFormat("NOTAM: Auto-refresh starting");
+  
+  // Cancel any pending retry since we're starting a new attempt
+  Cancel();
+
+  // Start async loading
+  load_task.Start(LoadNOTAMsInternal(location), 
+                  BIND_THIS_METHOD(OnLoadComplete));
+}
+
+void
+NOTAMGlue::LoadNOTAMs(const GeoPoint &location,
+                      OperationEnvironment &operation)
+{
+  (void)operation; // Suppress unused parameter warning
+  
+  // Check if NOTAMs are enabled
+  if (!settings.enabled) {
+    return;
+  }
+  
+  // Check if location is valid
+  if (!location.IsValid()) {
+    return;
+  }
+  
+  // Check if already loading
+  {
+    const std::lock_guard lock(mutex);
+    if (loading) {
+      return;
+    }
+    loading = true;
+    retry_pending = false;
+    current_location = location;
+  }
+  
+  // Cancel any pending retry since we're starting a new attempt
+  Cancel();
+  
+  // Start async loading
+  load_task.Start(LoadNOTAMsInternal(location), 
+                  BIND_THIS_METHOD(OnLoadComplete));
+}
+
+std::vector<NOTAMStruct>
+NOTAMGlue::GetNOTAMs(unsigned max_count) const
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  
+  const auto &notams = impl->current_notams;
+  const unsigned available_count = static_cast<unsigned>(notams.size());
+  
+  // If max_count is 0 or greater than available, return all NOTAMs
+  const unsigned count = (max_count == 0 || max_count > available_count) 
+                         ? available_count : max_count;
+  
+  LogDebug("NOTAM: GetNOTAMs max_count={}, available={}, returning={}",
+           max_count, available_count, count);
+  
+  // Return a copy of the requested NOTAMs
+  std::vector<NOTAMStruct> result;
+  result.reserve(count);
+  result.insert(result.end(), notams.begin(), notams.begin() + count);
+  
+  return result;
+}
+
+void
+NOTAMGlue::Clear()
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  impl->current_notams.clear();
+  impl->known.clear();
+  impl->known_location = GeoPoint::Invalid();
+  impl->known_radius_km = 0;
+  impl->cached_api = boost::json::value();
+  impl->cached_api_valid = false;
+  impl->last_update = CacheMetadata{};
+  impl->last_update_cached = false;
+}
+
+// Duplicate method removed
+
+Co::InvokeTask
+NOTAMGlue::LoadNOTAMsInternal(GeoPoint location)
+{
+  LogFormat("NOTAM: Starting LoadNOTAMsInternal for location %.6f,%.6f", 
+            location.latitude.Degrees(), location.longitude.Degrees());
+
+  try {
+    // First, try to load from cache if not expired
+    LogFormat("NOTAM: Checking cache expiration status");
+    if (!IsCacheExpired()) {
+      LogFormat("NOTAM: Cache is still valid, attempting to load from cache");
+      std::vector<NOTAMStruct> cached_notams;
+      GeoPoint cache_location = GeoPoint::Invalid();
+      unsigned cache_radius_km = 0;
+      boost::json::value cached_api;
+      if (LoadNOTAMsFromFile(cached_notams, &cache_location, &cache_radius_km,
+                             &cached_api)) {
+        const unsigned count = static_cast<unsigned>(cached_notams.size());
+        LogFormat("NOTAM: Successfully loaded %u NOTAMs from cache", count);
+
+        const GeoPoint known_location =
+          cache_location.IsValid() ? cache_location : location;
+        const unsigned known_radius_km =
+          cache_radius_km > 0 ? cache_radius_km : settings.radius_km;
+
+        // Store cached results
+        {
+          const std::lock_guard<Mutex> lock(mutex);
+          auto *impl = current_notams_impl.get();
+          PopulateImplFromCache(*impl, std::move(cached_notams),
+                                known_location, known_radius_km,
+                                std::move(cached_api));
+        }
+        LogFormat("NOTAM: Using cached data, fetch complete");
+        co_return; // Use cached data, no need to fetch
+      } else {
+        LogFormat("NOTAM: Failed to load from cache file, will fetch fresh "
+                  "data");
+      }
+    } else {
+      LogFormat("NOTAM: Cache is expired or doesn't exist, fetching fresh "
+                "data");
+    }
+    
+    // Cache is expired or doesn't exist, fetch fresh data from API
+    LogFormat("NOTAM: Starting API fetch for radius %u km",
+              settings.radius_km);
+
+    // Use a null progress listener
+    NullOperationEnvironment progress;
+
+    NOTAMClient::KnownMap known_copy;
+    {
+      const std::lock_guard<Mutex> lock(mutex);
+      auto *impl = current_notams_impl.get();
+      if (CanUseDelta(*impl, location, settings.radius_km))
+        known_copy = impl->known;
+    }
+
+    if (!known_copy.empty()) {
+      try {
+        LogFormat("NOTAM: Attempting delta fetch with %u known IDs",
+                  static_cast<unsigned>(known_copy.size()));
+        auto delta_response =
+          co_await NOTAMClient::FetchNOTAMsResponse(curl, settings, location,
+                                                    progress, &known_copy);
+
+        if (delta_response.is_delta) {
+          boost::json::value delta_json;
+          if (!ParseJsonValue(delta_response.raw_json, delta_json)) {
+            LogFormat("NOTAM: Delta response JSON parse failed, falling back");
+          } else {
+            boost::json::value api_snapshot;
+            unsigned total = 0;
+            bool applied = false;
+            {
+              const std::lock_guard<Mutex> lock(mutex);
+              auto *impl = current_notams_impl.get();
+              if (impl->cached_api_valid &&
+                  ApplyDeltaToApi(impl->cached_api, delta_json,
+                                  delta_response.removed_ids)) {
+                ApplyDeltaUpdates(impl->current_notams, delta_response.notams,
+                                  delta_response.removed_ids);
+                impl->known = BuildKnownMap(impl->current_notams);
+                impl->known_location = location;
+                impl->known_radius_km = settings.radius_km;
+                impl->last_update.timestamp = std::time(nullptr);
+                impl->last_update.location = location;
+                impl->last_update.radius_km = settings.radius_km;
+                impl->last_update.valid = true;
+                impl->last_update_cached = true;
+                api_snapshot = impl->cached_api;
+                total = static_cast<unsigned>(impl->current_notams.size());
+                applied = true;
+              }
+            }
+
+            if (applied) {
+              SaveNOTAMsToFile(api_snapshot, location);
+
+              LogFormat("NOTAM: Delta applied (updates=%u, removed=%u, "
+                        "total=%u)",
+                        static_cast<unsigned>(delta_response.notams.size()),
+                        static_cast<unsigned>(
+                          delta_response.removed_ids.size()),
+                        total);
+
+              StaticString<100> msg;
+              msg.Format(_("Loaded %u NOTAMs"),
+                         total);
+              Message::AddMessage(msg.c_str());
+
+              co_return;
+            }
+
+            LogFormat("NOTAM: Delta merge failed, falling back to full fetch");
+          }
+        } else {
+          boost::json::value api_value;
+          if (ParseJsonValue(delta_response.raw_json, api_value) &&
+              IsApiResponseValid(api_value)) {
+            unsigned total = 0;
+            {
+              const std::lock_guard<Mutex> lock(mutex);
+              auto *impl = current_notams_impl.get();
+              impl->current_notams = std::move(delta_response.notams);
+              impl->known = BuildKnownMap(impl->current_notams);
+              impl->known_location = location;
+              impl->known_radius_km = settings.radius_km;
+              impl->cached_api = api_value;
+              impl->cached_api_valid = true;
+              impl->last_update.timestamp = std::time(nullptr);
+              impl->last_update.location = location;
+              impl->last_update.radius_km = settings.radius_km;
+              impl->last_update.valid = true;
+              impl->last_update_cached = true;
+              total = static_cast<unsigned>(impl->current_notams.size());
+            }
+
+            SaveNOTAMsToFile(api_value, location);
+
+            LogFormat("NOTAM: Full response accepted (total=%u)",
+                      total);
+
+            StaticString<100> msg;
+            msg.Format(_("Loaded %u NOTAMs"),
+                       total);
+            Message::AddMessage(msg.c_str());
+
+            co_return;
+          }
+
+          LogFormat("NOTAM: Delta response missing full API payload");
+        }
+
+        LogFormat("NOTAM: Delta not applied, falling back to full fetch");
+        {
+          const std::lock_guard<Mutex> lock(mutex);
+          auto *impl = current_notams_impl.get();
+          impl->known.clear();
+          impl->known_location = GeoPoint::Invalid();
+          impl->known_radius_km = 0;
+        }
+      } catch (const std::exception &e) {
+        LogFormat("NOTAM: Delta fetch failed: %s", e.what());
+        {
+          const std::lock_guard<Mutex> lock(mutex);
+          auto *impl = current_notams_impl.get();
+          impl->known.clear();
+          impl->known_location = GeoPoint::Invalid();
+          impl->known_radius_km = 0;
+        }
+      }
+    }
+
+    LogFormat("NOTAM: Performing full fetch");
+    auto full_response =
+      co_await NOTAMClient::FetchNOTAMsResponse(curl, settings, location,
+                                                progress, nullptr);
+    boost::json::value api_value;
+    const bool api_valid =
+      ParseJsonValue(full_response.raw_json, api_value) &&
+      IsApiResponseValid(api_value);
+    auto notams = std::move(full_response.notams);
+    const unsigned count = static_cast<unsigned>(notams.size());
+    LogFormat("NOTAM: Parsed %u NOTAMs from response", count);
+
+    {
+      const std::lock_guard<Mutex> lock(mutex);
+      auto *impl = current_notams_impl.get();
+      impl->current_notams = std::move(notams);
+      impl->known = BuildKnownMap(impl->current_notams);
+      impl->known_location = location;
+      impl->known_radius_km = settings.radius_km;
+      if (api_valid) {
+        impl->cached_api = api_value;
+        impl->cached_api_valid = true;
+      } else {
+        impl->cached_api = boost::json::value();
+        impl->cached_api_valid = false;
+      }
+      impl->last_update.timestamp = std::time(nullptr);
+      impl->last_update.location = location;
+      impl->last_update.radius_km = settings.radius_km;
+      impl->last_update.valid = true;
+      impl->last_update_cached = true;
+    }
+
+    if (api_valid) {
+      SaveNOTAMsToFile(api_value, location);
+      LogFormat("NOTAM: Cache file saved successfully");
+    } else {
+      LogFormat("NOTAM: Skipping cache save (invalid API payload)");
+    }
+
+    LogFormat("NOTAM: Successfully completed fetch with %u NOTAMs", count);
+
+    StaticString<100> msg;
+    msg.Format(_("Loaded %u NOTAMs"), count);
+    Message::AddMessage(msg.c_str());
+    
+  } catch (const std::exception &e) {
+    LogFormat("NOTAM: Error during fetch: %s", e.what());
+    
+    // Keep existing NOTAMs on fetch failure - stale data is better than no
+    // data.
+    LogFormat("NOTAM: Keeping existing NOTAMs after fetch error");
+    
+    // Notify user of error
+    Message::AddMessage(_("Failed to load NOTAMs"));
+  }
+}
+
+void
+NOTAMGlue::OnLoadComplete(std::exception_ptr error) noexcept
+{
+  // Reset loading flag
+  bool schedule_retry = false;
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    loading = false;
+    if (error) {
+      retry_pending = true;
+      schedule_retry = true;
+    } else {
+      retry_pending = false;
+    }
+  }
+  
+  if (schedule_retry) {
+    // Failed - schedule retry with fixed 30-second delay
+    LogFormat("NOTAM: Fetch failed, scheduling retry in 30 seconds");
+    Trigger();
+  } else {
+    // Success - cancel any pending retry
+    Cancel();
+    
+    // Update the airspace database
+    if (data_components && data_components->airspaces) {
+      try {
+        LogFormat("NOTAM: Updating airspace database with loaded NOTAMs");
+        UpdateAirspaces(*data_components->airspaces);
+        LogFormat("NOTAM: Airspace database updated successfully");
+      } catch (const std::exception &e) {
+        LogFormat("NOTAM: Error updating airspace database: %s", e.what());
+      }
+    }
+    
+    // Notify listeners that NOTAMs have been updated
+    NotifyListeners();
+  }
+}
+
+void
+NOTAMGlue::AddListener(NOTAMListener &listener)
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  listeners.push_back(&listener);
+}
+
+void
+NOTAMGlue::RemoveListener(NOTAMListener &listener) noexcept
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto it = std::find(listeners.begin(), listeners.end(), &listener);
+  if (it != listeners.end()) {
+    listeners.erase(it);
+  }
+}
+
+void
+NOTAMGlue::NotifyListeners() noexcept
+{
+  std::vector<NOTAMListener *> listeners_copy;
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    listeners_copy = listeners;
+  }
+  
+  for (auto *listener : listeners_copy) {
+    listener->OnNOTAMsUpdated();
+  }
+}
+
+void
+NOTAMGlue::Run()
+{
+  LogFormat("NOTAM: Retry timer fired, attempting fetch again");
+  
+  GeoPoint location;
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    retry_pending = false;
+    if (loading || !current_location.IsValid()) {
+      return;
+    }
+    location = current_location;
+  }
+  
+  // Trigger a new fetch attempt (outside the lock)
+  UpdateLocation(location);
+}
+
+unsigned
+NOTAMGlue::LoadCachedNOTAMs()
+{
+  std::vector<NOTAMStruct> cached_notams;
+  GeoPoint cache_location = GeoPoint::Invalid();
+  unsigned cache_radius_km = 0;
+  boost::json::value cached_api;
+  
+  // Log the cache file path for debugging
+  auto file_path = GetNOTAMCacheFilePath();
+  LogFormat("NOTAM: Attempting to load cache from: %s",
+            file_path.ToUTF8().c_str());
+  
+  // Try to load from cache file
+  if (LoadNOTAMsFromFile(cached_notams, &cache_location, &cache_radius_km,
+                         &cached_api)) {
+    const unsigned count = static_cast<unsigned>(cached_notams.size());
+    
+    // Store cached results in memory
+    {
+      const std::lock_guard<Mutex> lock(mutex);
+      auto *impl = current_notams_impl.get();
+      PopulateImplFromCache(
+        *impl, std::move(cached_notams),
+        cache_location.IsValid() ? cache_location : GeoPoint::Invalid(),
+        cache_radius_km, std::move(cached_api));
+    }
+        
+    LogFormat("NOTAM: Loaded %u NOTAMs from cache", count);
+    return count;
+  }
+  
+  LogFormat("NOTAM: No cached NOTAMs found at: %s",
+            file_path.ToUTF8().c_str());
+  return 0;
+}
+
+bool
+NOTAMGlue::LoadCachedNOTAMsAndUpdate(Airspaces &airspaces)
+{
+  if (!settings.enabled) {
+    LogDebug("NOTAM: Startup cache load skipped - disabled in settings");
+    return false;
+  }
+
+  std::vector<NOTAMStruct> cached_notams;
+  GeoPoint cache_location = GeoPoint::Invalid();
+  unsigned cache_radius_km = 0;
+  boost::json::value cached_api;
+  if (!LoadNOTAMsFromFile(cached_notams, &cache_location, &cache_radius_km,
+                          &cached_api)) {
+    LogFormat("NOTAM: No cached NOTAMs to apply");
+    return false;
+  }
+
+  const unsigned count = static_cast<unsigned>(cached_notams.size());
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    auto *impl = current_notams_impl.get();
+    PopulateImplFromCache(
+      *impl, std::move(cached_notams),
+      cache_location.IsValid() ? cache_location : GeoPoint::Invalid(),
+      cache_radius_km, std::move(cached_api));
+  }
+
+  LogFormat("NOTAM: Loaded %u NOTAMs from cache for startup", count);
+
+  UpdateAirspaces(airspaces);
+  NotifyListeners();
+
+  return true;
+}
+
+void
+NOTAMGlue::InvalidateCache()
+{
+  auto file_path = GetNOTAMCacheFilePath();
+  
+  if (File::Exists(file_path)) {
+    LogFormat("NOTAM: Invalidating cache file: %s",
+              file_path.ToUTF8().c_str());
+    File::Delete(file_path);
+    LogFormat("NOTAM: Cache invalidated successfully");
+  } else {
+    LogFormat("NOTAM: No cache file to invalidate at: %s",
+              file_path.ToUTF8().c_str());
+  }
+
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    auto *impl = current_notams_impl.get();
+    impl->known.clear();
+    impl->known_location = GeoPoint::Invalid();
+    impl->known_radius_km = 0;
+    impl->cached_api = boost::json::value();
+    impl->cached_api_valid = false;
+    impl->last_update = CacheMetadata{};
+    impl->last_update_cached = false;
+  }
+}
+
+unsigned
+NOTAMGlue::GetTotalCount() const
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  return static_cast<unsigned>(impl->current_notams.size());
+}
+
+unsigned
+NOTAMGlue::GetFilteredCount() const
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  
+  unsigned count = 0;
+  for (const auto &notam : impl->current_notams) {
+    if (NOTAMFilter::ShouldDisplay(notam, settings, true)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+NOTAMGlue::FilterStats
+NOTAMGlue::GetFilterStats() const
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  
+  FilterStats stats;
+  stats.total = static_cast<unsigned>(impl->current_notams.size());
+  stats.filtered_by_ifr = 0;
+  stats.filtered_by_time = 0;
+  stats.filtered_by_qcode = 0;
+  stats.filtered_by_radius = 0;
+  stats.final_count = 0;
+
+  const char *hidden_list = settings.hidden_qcodes.c_str();
+  
+  for (const auto &notam : impl->current_notams) {
+    // Count how many fail IFR filter (independently)
+    if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I") {
+      stats.filtered_by_ifr++;
+    }
+    
+    // Count how many fail time filter (independently)
+    if (settings.show_only_effective) {
+      auto now = std::chrono::system_clock::now();
+      if (now < notam.start_time || now > notam.end_time) {
+        stats.filtered_by_time++;
+      }
+    }
+    
+    // Count how many fail Q-code filter (independently)
+    const auto &qcode = notam.feature_type;
+    if (!qcode.empty() && NOTAMFilter::IsQCodeHidden(qcode, hidden_list)) {
+      stats.filtered_by_qcode++;
+    }
+    
+    // Count how many fail radius filter (independently)
+    if (settings.max_radius_m > 0) {
+      if (notam.geometry.radius_meters > settings.max_radius_m) {
+        stats.filtered_by_radius++;
+      }
+    }
+    
+    // Use the main filter function for final count
+    if (NOTAMFilter::ShouldDisplay(notam, settings, true)) {
+      stats.final_count++;
+    }
+  }
+  
+  return stats;
+}
+
+std::optional<struct NOTAM>
+NOTAMGlue::FindNOTAMByNumber(const std::string &number) const
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  
+  for (const auto &notam : impl->current_notams) {
+    if (notam.number == number) {
+      return notam; // Return a copy while holding the lock
+    }
+  }
+  
+  return std::nullopt;
+}
+
+void
+NOTAMGlue::UpdateAirspaces(Airspaces &airspaces)
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  auto *impl = current_notams_impl.get();
+  
+  LogFormat("NOTAM: UpdateAirspaces - converting %u NOTAMs to airspaces", 
+            static_cast<unsigned>(impl->current_notams.size()));
+
+  // Save all non-NOTAM airspaces
+  // ToDo: Optimize by removing only existing NOTAM airspaces
+  std::vector<AirspacePtr> saved_airspaces;
+  for (const auto &airspace : airspaces.QueryAll()) {
+    const auto &current = airspace.GetAirspace();
+    if (current.GetClassOrType() != AirspaceClass::NOTAM) {
+      saved_airspaces.push_back(airspace.GetAirspacePtr());
+    }
+  }
+  
+  LogFormat("NOTAM: Saved %u non-NOTAM airspaces", 
+            static_cast<unsigned>(saved_airspaces.size()));
+  
+  // Clear all airspaces
+  airspaces.Clear();
+  
+  // Restore non-NOTAM airspaces
+  for (const auto &airspace : saved_airspaces) {
+    airspaces.Add(airspace);
+  }
+  
+  LogFormat("NOTAM: Restored %u non-NOTAM airspaces", 
+            static_cast<unsigned>(saved_airspaces.size()));
+  
+  // Add filtered NOTAM airspaces
+  unsigned added_count = 0;
+  unsigned filtered_count = 0;
+  
+  for (const auto &notam : impl->current_notams) {
+    try {
+      // Apply filtering
+      if (!NOTAMFilter::ShouldDisplay(notam, settings, true)) {
+        filtered_count++;
+        continue;
+      }
+      
+      // Create airspace based on NOTAM geometry
+      AirspacePtr airspace_ptr;
+      
+      switch (notam.geometry.type) {
+        case NOTAM::NOTAMGeometry::Type::CIRCLE: {
+          auto circle = std::make_shared<AirspaceCircle>(
+            GeoPoint{Angle::Degrees(notam.geometry.center.longitude), 
+                     Angle::Degrees(notam.geometry.center.latitude)},
+            notam.geometry.radius_meters);
+          airspace_ptr = circle;
+          break;
+        }
+        
+        case NOTAM::NOTAMGeometry::Type::POLYGON: {
+          // Build vector of GeoPoints for the polygon
+          std::vector<GeoPoint> polygon_points;
+          for (const auto &point : notam.geometry.polygon_points) {
+            polygon_points.emplace_back(Angle::Degrees(point.longitude), 
+                                        Angle::Degrees(point.latitude));
+          }
+          
+          if (!polygon_points.empty()) {
+            auto polygon = std::make_shared<AirspacePolygon>(polygon_points);
+            airspace_ptr = polygon;
+          }
+          break;
+        }
+        
+        case NOTAM::NOTAMGeometry::Type::POINT:
+        default: {
+          // For points, create a small circle (1000m radius)
+          auto circle = std::make_shared<AirspaceCircle>(
+            GeoPoint{Angle::Degrees(notam.geometry.center.longitude), 
+                     Angle::Degrees(notam.geometry.center.latitude)},
+            1000.0); // 1km radius
+          airspace_ptr = circle;
+          break;
+        }
+      }
+      
+      if (airspace_ptr) {
+        // Create the airspace main name, truncate if too long
+        std::string main_text = notam.text;
+        if (main_text.empty()) {
+          main_text = "NOTAM";
+        }
+        if (main_text.length() > NOTAM_TEXT_TRUNCATE_LENGTH) {
+          main_text =
+            main_text.substr(0, NOTAM_TEXT_TRUNCATE_LENGTH - 3) + "...";
+        }
+        
+        std::string notam_name = std::move(main_text);
+        std::string notam_station = notam.number;
+
+        // Use the parsed AirspaceAltitude objects directly
+        AirspaceAltitude base = notam.lower_altitude;
+        AirspaceAltitude top = notam.upper_altitude;
+        
+        const auto is_invalid_altitude = [](const AirspaceAltitude &altitude) {
+          return altitude.reference != AltitudeReference::AGL &&
+                 altitude.reference != AltitudeReference::MSL &&
+                 altitude.reference != AltitudeReference::STD;
+        };
+
+        const auto is_missing_msl = [](const AirspaceAltitude &altitude) {
+          return altitude.reference == AltitudeReference::MSL &&
+                 altitude.altitude == MISSING_MSL_ALTITUDE;
+        };
+
+        // Set reasonable defaults if altitudes are invalid
+        if (is_invalid_altitude(base) || is_missing_msl(base)) {
+          // Uninitialized or invalid - set to ground level
+          base.reference = AltitudeReference::AGL;
+          base.altitude_above_terrain = 0;
+          base.altitude = 0;
+          base.flight_level = 0;
+        }
+        
+        if (is_invalid_altitude(top) || is_missing_msl(top)) {
+          // Uninitialized or invalid - set to high MSL altitude
+          top.reference = AltitudeReference::MSL;
+          top.altitude = 9999;
+          top.altitude_above_terrain = 0;
+          top.flight_level = 0;
+        }
+        
+        // Set airspace properties using SetProperties method
+        airspace_ptr->SetProperties(
+          std::move(notam_name),        // name: NOTAM detailed text
+          std::move(notam_station),     // station_name: short identifier  
+          TransponderCode::Null(), // transponder_code
+          AirspaceClass::NOTAM, // class
+          AirspaceClass::NOTAM, // type
+          base,
+          top
+        );
+        
+        // Add to airspace database
+        airspaces.Add(airspace_ptr);
+        added_count++;
+        
+        LogDebug("NOTAM: Added airspace for NOTAM '{}' (type={}, "
+                 "radius={:.0f}m)",
+                 notam.number.c_str(), static_cast<int>(notam.geometry.type),
+                 notam.geometry.radius_meters);
+      }
+    } catch (const std::exception &e) {
+      LogFormat("NOTAM: Error creating airspace for NOTAM '%s': %s",
+                notam.number.c_str(), e.what());
+    }
+  }
+  
+  // Optimize the airspace tree after adding NOTAMs
+  airspaces.Optimise();
+  
+  LogFormat("NOTAM: UpdateAirspaces completed - added %u NOTAMs, "
+            "filtered %u NOTAMs",
+            added_count, filtered_count);
+}
+
+AllocatedPath
+NOTAMGlue::GetNOTAMCacheFilePath() const
+{
+  // Use fixed filename in main XCSoarData directory
+  // Keep a single cache file to simplify delta handling.
+  return LocalPath("notams.json");
+}
+
+static bool
+GetJsonNumber(const boost::json::value &value, double &out) noexcept
+{
+  if (value.is_double()) {
+    out = value.as_double();
+    return true;
+  }
+  if (value.is_int64()) {
+    out = static_cast<double>(value.as_int64());
+    return true;
+  }
+  if (value.is_uint64()) {
+    out = static_cast<double>(value.as_uint64());
+    return true;
+  }
+  return false;
+}
+
+static void
+ExtractCacheMetadata(const boost::json::object &obj,
+                     CacheMetadata &meta) noexcept
+{
+  meta = CacheMetadata{};
+
+  double timestamp = 0;
+  if (auto it = obj.find("xcsoar_timestamp");
+      it != obj.end() && GetJsonNumber(it->value(), timestamp)) {
+    meta.timestamp = static_cast<std::time_t>(timestamp);
+    meta.valid = true;
+  }
+
+  double lat = 0;
+  double lon = 0;
+  if (auto it_lat = obj.find("xcsoar_location_lat");
+      it_lat != obj.end() && GetJsonNumber(it_lat->value(), lat)) {
+    if (auto it_lon = obj.find("xcsoar_location_lon");
+        it_lon != obj.end() && GetJsonNumber(it_lon->value(), lon)) {
+      meta.location = GeoPoint(Angle::Degrees(lon), Angle::Degrees(lat));
+      meta.valid = true;
+    }
+  }
+
+  double radius = 0;
+  if (auto it_radius = obj.find("xcsoar_radius_km");
+      it_radius != obj.end() && GetJsonNumber(it_radius->value(), radius)) {
+    meta.radius_km = radius >= 0
+      ? static_cast<unsigned>(radius)
+      : 0u;
+    meta.valid = true;
+  }
+}
+
+static void
+ParseCacheMetadata(const boost::json::object &obj,
+                   GeoPoint *location, unsigned *radius_km)
+{
+  CacheMetadata meta;
+  ExtractCacheMetadata(obj, meta);
+
+  if (location != nullptr)
+    *location = meta.location;
+
+  if (radius_km != nullptr)
+    *radius_km = meta.radius_km;
+}
+
+static bool
+LoadCacheJsonValue(const AllocatedPath &file_path, boost::json::value &root)
+{
+  try {
+    FileReader file(Path(file_path.c_str()));
+
+    std::string json_content;
+    char buffer[4096];
+    while (true) {
+      size_t bytes_read = file.Read(std::as_writable_bytes(std::span{buffer}));
+      if (bytes_read == 0)
+        break;
+      json_content.append(buffer, bytes_read);
+    }
+
+    if (json_content.empty())
+      return false;
+
+    boost::system::error_code ec;
+    root = boost::json::parse(json_content, ec);
+    return !ec;
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+static bool
+LoadCacheMetadataFromFile(const AllocatedPath &file_path,
+                          CacheMetadata &meta)
+{
+  boost::json::value root;
+  if (!LoadCacheJsonValue(file_path, root) || !root.is_object()) {
+    meta = CacheMetadata{};
+    return false;
+  }
+
+  ExtractCacheMetadata(root.as_object(), meta);
+  return meta.valid;
+}
+
+static CacheMetadata
+GetCachedMetadata(NOTAMImpl &impl, Mutex &mutex,
+                  const AllocatedPath &file_path)
+{
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    if (impl.last_update_cached)
+      return impl.last_update;
+  }
+
+  CacheMetadata meta;
+  LoadCacheMetadataFromFile(file_path, meta);
+
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    impl.last_update = meta;
+    impl.last_update_cached = true;
+  }
+
+  return meta;
+}
+
+void
+NOTAMGlue::SaveNOTAMsToFile(const boost::json::value &api_response,
+                            const GeoPoint &location) const
+{
+  try {
+    if (!IsApiResponseValid(api_response)) {
+      LogFormat("NOTAM: Skipping cache save (invalid API response)");
+      return;
+    }
+
+    auto file_path = GetNOTAMCacheFilePath();
+    LogFormat("NOTAM: Saving NOTAM cache: %s", file_path.c_str());
+
+    boost::json::object wrapper;
+    const auto now = std::time(nullptr);
+    wrapper["xcsoar_timestamp"] = static_cast<std::int64_t>(now);
+    wrapper["xcsoar_location_lat"] = location.latitude.Degrees();
+    wrapper["xcsoar_location_lon"] = location.longitude.Degrees();
+    wrapper["xcsoar_radius_km"] = settings.radius_km;
+    wrapper["xcsoar_refresh_interval_min"] = settings.refresh_interval_min;
+    wrapper["api"] = api_response;
+
+    std::string json_with_metadata =
+      SerializeJsonValueReadable(boost::json::value(std::move(wrapper)));
+    
+    // Write to file
+    FileOutputStream file(Path(file_path.c_str()));
+    file.Write(std::as_bytes(std::span{json_with_metadata}));
+    file.Commit();
+    
+    LogFormat("NOTAM: Saved %u bytes of NOTAM cache",
+              static_cast<unsigned>(json_with_metadata.size()));
+  } catch (const std::exception &e) {
+    LogFormat("NOTAM: Error saving NOTAM cache to file: %s", e.what());
+  }
+}
+
+bool
+NOTAMGlue::LoadNOTAMsFromFile(std::vector<NOTAMStruct> &notams,
+                              GeoPoint *location,
+                              unsigned *radius_km,
+                              boost::json::value *api_response) const
+{
+  try {
+    auto file_path = GetNOTAMCacheFilePath();
+    LogFormat("NOTAM: LoadNOTAMsFromFile attempting to load: %s",
+              file_path.c_str());
+
+    std::string json_content;
+    try {
+      FileReader file(Path(file_path.c_str()));
+
+      // Read the entire file to get the JSON data
+      char buffer[4096];
+      while (true) {
+        size_t bytes_read =
+          file.Read(std::as_writable_bytes(std::span{buffer}));
+        if (bytes_read == 0) break;
+        json_content.append(buffer, bytes_read);
+      }
+    } catch (const std::exception &e) {
+      LogFormat("NOTAM: LoadNOTAMsFromFile failed to open file: %s - %s",
+                file_path.c_str(), e.what());
+      return false; // File doesn't exist or can't be opened
+    }
+
+    LogFormat("NOTAM: LoadNOTAMsFromFile read %u bytes from file",
+              static_cast<unsigned>(json_content.size()));
+
+    if (json_content.empty()) {
+      LogFormat("NOTAM: LoadNOTAMsFromFile file is empty");
+      return false;
+    }
+
+    if (location != nullptr)
+      *location = GeoPoint::Invalid();
+    if (radius_km != nullptr)
+      *radius_km = 0;
+    if (api_response != nullptr)
+      *api_response = boost::json::value();
+
+    boost::system::error_code ec;
+    boost::json::value root = boost::json::parse(json_content, ec);
+    if (ec) {
+      LogFormat("NOTAM: LoadNOTAMsFromFile JSON parse error: %s",
+                ec.message().c_str());
+      return false;
+    }
+
+    notams.clear();
+
+    if (root.is_object()) {
+      const auto &obj = root.as_object();
+      ParseCacheMetadata(obj, location, radius_km);
+
+      if (auto it = obj.find("api"); it != obj.end()) {
+        const auto &api_value = it->value();
+        if (api_response != nullptr)
+          *api_response = api_value;
+        if (!IsApiResponseValid(api_value)) {
+          LogFormat("NOTAM: LoadNOTAMsFromFile invalid api payload");
+          return false;
+        }
+        if (!ParseNOTAMsFromApiValue(api_value, notams, "api"))
+          return false;
+
+        LogFormat("NOTAM: LoadNOTAMsFromFile parsed %u NOTAMs from api",
+                  static_cast<unsigned>(notams.size()));
+        return true;
+      }
+    }
+
+    LogFormat("NOTAM: LoadNOTAMsFromFile missing api payload");
+    return false;
+  } catch (const std::exception &e) {
+    LogFormat("NOTAM: LoadNOTAMsFromFile exception: %s", e.what());
+    return false;
+  }
+}
+
+std::time_t
+NOTAMGlue::GetLastUpdateTime() const
+{
+  const auto file_path = GetNOTAMCacheFilePath();
+  const auto meta =
+    GetCachedMetadata(*current_notams_impl, mutex, file_path);
+  return meta.timestamp;
+}
+
+GeoPoint
+NOTAMGlue::GetLastUpdateLocation() const
+{
+  const auto file_path = GetNOTAMCacheFilePath();
+  const auto meta =
+    GetCachedMetadata(*current_notams_impl, mutex, file_path);
+  return meta.location;
+}
+
+unsigned
+NOTAMGlue::GetLastUpdateRadius() const
+{
+  const auto file_path = GetNOTAMCacheFilePath();
+  const auto meta =
+    GetCachedMetadata(*current_notams_impl, mutex, file_path);
+  return meta.radius_km;
+}
+
+bool
+NOTAMGlue::IsCacheExpired() const
+{
+  try {
+    const auto file_path = GetNOTAMCacheFilePath();
+    const auto meta =
+      GetCachedMetadata(*current_notams_impl, mutex, file_path);
+
+    if (meta.timestamp <= 0)
+      return true;
+
+    if (!meta.location.IsValid())
+      return true;
+
+    std::time_t current_time = std::time(nullptr);
+    std::time_t max_age_seconds = settings.refresh_interval_min * 60;
+
+    if ((current_time - meta.timestamp) > max_age_seconds)
+      return true;
+
+    if (meta.radius_km > 0 && meta.radius_km != settings.radius_km)
+      return true;
+
+    GeoPoint location_copy;
+    {
+      const std::lock_guard<Mutex> lock(mutex);
+      location_copy = current_location;
+    }
+
+    if (location_copy.IsValid()) {
+      double distance_m = location_copy.Distance(meta.location);
+      double radius_m = settings.radius_km * 1000.0;
+      if (distance_m > radius_m)
+        return true;
+    }
+
+    return false;
+  } catch (const std::exception &e) {
+    return true; // Error means treat as expired
+  }
+}
+
+#endif // HAVE_HTTP

--- a/src/NOTAM/NOTAMGlue.hpp
+++ b/src/NOTAM/NOTAMGlue.hpp
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Settings.hpp"
+#include "NOTAM.hpp"
+#include "co/InjectTask.hxx"
+#include "thread/Mutex.hxx"
+#include "Geo/GeoPoint.hpp"
+#include "system/Path.hpp"
+#include "RateLimiter.hpp"
+#include <boost/json/fwd.hpp>
+#include <vector>
+#include <memory>
+#include <ctime>
+#include <optional>
+
+class CurlGlobal;
+class Airspaces;
+class OperationEnvironment;
+struct NOTAMImpl; // Forward declaration for pimpl
+
+/**
+ * Listener interface for NOTAM updates
+ */
+class NOTAMListener {
+public:
+  virtual ~NOTAMListener() = default;
+  
+  /**
+   * Called when NOTAMs have been successfully loaded and filtered
+   */
+  virtual void OnNOTAMsUpdated() noexcept = 0;
+};
+
+/**
+ * NOTAM manager that handles loading and refreshing NOTAMs
+ */
+class NOTAMGlue final : public RateLimiter {
+  const NOTAMSettings &settings;
+  CurlGlobal &curl;
+  
+  mutable Mutex mutex;
+  
+  /** Current location for NOTAM searches */
+  GeoPoint current_location = GeoPoint::Invalid();
+  
+  /** Currently loaded NOTAMs (pimpl pattern for encapsulation) */
+  std::unique_ptr<NOTAMImpl> current_notams_impl;
+  
+  /** Background task for loading NOTAMs */
+  Co::InjectTask load_task;
+  
+  /** Whether NOTAMs are currently being loaded */
+  bool loading = false;
+  
+  /** Whether a retry is pending (waiting for RateLimiter timer) */
+  bool retry_pending = false;
+  
+  /**
+   * Timestamp of last fetch attempt (success or failure) to prevent rapid
+   * retries.
+   */
+  std::time_t last_attempt_time = 0;
+  
+  /** Registered listeners for NOTAM updates */
+  std::vector<NOTAMListener *> listeners;
+
+public:
+  NOTAMGlue(const NOTAMSettings &_settings, CurlGlobal &_curl);
+  virtual ~NOTAMGlue();
+  
+  /**
+   * Register a listener for NOTAM update notifications
+   */
+  void AddListener(NOTAMListener &listener);
+  
+  /**
+   * Unregister a listener
+   */
+  void RemoveListener(NOTAMListener &listener) noexcept;
+
+  /**
+   * Update the current location and trigger NOTAM refresh if needed
+   */
+  void UpdateLocation(const GeoPoint &location);
+  
+  /**
+   * Periodic timer callback - checks if NOTAMs need to be refreshed
+   * based on time interval and location change.
+   * Called from ProcessTimer.
+   */
+  void OnTimer(const GeoPoint &current_location);
+  
+  /**
+   * Load NOTAMs for the given location
+   */
+  void LoadNOTAMs(const GeoPoint &location, OperationEnvironment &operation);
+  
+  /**
+   * Get currently loaded NOTAMs (thread-safe)
+   * Returns a copy of the NOTAMs, limited to max_count if specified
+   * (0 = no limit).
+   */
+  std::vector<struct NOTAM> GetNOTAMs(unsigned max_count = 0) const;
+  
+  /**
+   * Clear all loaded NOTAMs
+   */
+  void Clear();
+  
+  /**
+   * Check if NOTAMs are currently being loaded
+   */
+  [[nodiscard]] bool IsLoading() const {
+    const std::lock_guard<Mutex> lock(mutex);
+    return loading;
+  }
+
+  /** Generate cache file path for NOTAMs */
+  AllocatedPath GetNOTAMCacheFilePath() const;
+
+  /**
+   * Load NOTAMs from cache and return count
+   * @return Number of NOTAMs loaded from cache
+   */
+  unsigned LoadCachedNOTAMs();
+
+  /**
+   * Load cached NOTAMs and update airspaces if cache is available.
+   * @return True if the cache was loaded and applied.
+   */
+  bool LoadCachedNOTAMsAndUpdate(Airspaces &airspaces);
+
+  /**
+   * Update the airspace database with NOTAM data
+   * @param airspaces The airspace database to update
+   */
+  void UpdateAirspaces(Airspaces &airspaces);
+
+  /**
+   * Get the timestamp of the last NOTAM update from cache file
+   * @return Timestamp in seconds since epoch, or 0 if no cache exists
+   */
+  [[nodiscard]] std::time_t GetLastUpdateTime() const;
+
+  /**
+   * Get the location (latitude/longitude) that was used for the last NOTAM
+   * fetch as stored in the cache file metadata.
+   * @return GeoPoint of last update, or Invalid() if not available
+   */
+  [[nodiscard]] GeoPoint GetLastUpdateLocation() const;
+
+  /**
+   * Invalidate the NOTAM cache by deleting the cache file
+   * This will force a fresh fetch on the next update
+   */
+  void InvalidateCache();
+
+  /**
+   * Statistics about filter results
+   */
+  struct FilterStats {
+    unsigned total;              // Total NOTAMs loaded
+    unsigned filtered_by_ifr;    // Count filtered by IFR filter
+    unsigned filtered_by_time;   // Count filtered by time filter
+    unsigned filtered_by_qcode;  // Count filtered by Q-code filter
+    unsigned filtered_by_radius; // Count filtered by radius filter
+    unsigned final_count;        // Final count after all filters
+  };
+
+  /**
+   * Get the total number of currently loaded NOTAMs
+   */
+  [[nodiscard]] unsigned GetTotalCount() const;
+
+  /**
+   * Get the number of NOTAMs that pass the current filters
+   */
+  [[nodiscard]] unsigned GetFilteredCount() const;
+
+  /**
+   * Get detailed filter statistics showing how many NOTAMs each filter removes
+   */
+  [[nodiscard]] FilterStats GetFilterStats() const;
+
+  /**
+   * Find a NOTAM by its number (e.g., "A1234/24")
+   * @param number The NOTAM number to search for
+   * @return NOTAM if found, std::nullopt otherwise
+   */
+  [[nodiscard]] std::optional<struct NOTAM>
+  FindNOTAMByNumber(const std::string &number) const;
+
+private:
+  Co::InvokeTask LoadNOTAMsInternal(GeoPoint location);
+  void OnLoadComplete(std::exception_ptr error) noexcept;
+  
+  /** Notify all registered listeners that NOTAMs have been updated */
+  void NotifyListeners() noexcept;
+  
+  /** RateLimiter callback for delayed retry */
+  void Run() override;
+  
+  /** Save raw API response to file */
+  void SaveNOTAMsToFile(const boost::json::value &api_response,
+                        const GeoPoint &location) const;
+  
+  /**
+   * Load NOTAMs from cache file if available
+   * @param notams Vector to store loaded NOTAMs
+   * @param location Optional output for the location from cache metadata
+   * @param radius_km Optional output for the radius from cache metadata
+   * @param api_response Optional output for the raw API response from cache
+   * @return True if cache was loaded successfully, false otherwise
+   */
+  bool LoadNOTAMsFromFile(std::vector<struct NOTAM> &notams,
+                          GeoPoint *location = nullptr,
+                          unsigned *radius_km = nullptr,
+                          boost::json::value *api_response = 
+                              nullptr) const;
+  
+  /** Check if cached data is expired based on settings */
+  bool IsCacheExpired() const;
+
+  /**
+   * Get the radius (km) that was used for the last NOTAM fetch
+   * as stored in the cache file metadata.
+   * @return Radius in kilometers, or 0 if not available
+   */
+  [[nodiscard]] unsigned GetLastUpdateRadius() const;
+};

--- a/src/NOTAM/Settings.hpp
+++ b/src/NOTAM/Settings.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StaticString.hxx"
+
+/**
+ * Settings for NOTAM (Notice to Airmen) support
+ */
+struct NOTAMSettings {
+  /** Enable/disable NOTAM loading */
+  bool enabled = false;
+  
+  /** Radius around current location to fetch NOTAMs for */
+  unsigned radius_km = 50;
+  
+  /** Refresh interval - 0 = manual only */
+  unsigned refresh_interval_min = 30;
+  
+  /** Base URL for the NOTAM API */
+  StaticString<128> api_base_url{
+    "https://notam.yorickreum.de/notam.php"
+  };
+
+  /** Show only currently effective NOTAMs */
+  bool show_only_effective = true;
+  
+  /** Show IFR-only NOTAMs ("traffic" == "I") */
+  bool show_ifr = false;
+  
+  /** 
+   * Maximum NOTAM radius to show (in meters). 
+   * NOTAMs with larger radius are filtered out.
+   * Default: 100000 meters (100 km, hides very large area NOTAMs)
+   * Set to 0 to disable this filter.
+   * Displayed to user in their preferred distance unit.
+   */
+  unsigned max_radius_m = 100000;
+  
+  /** 
+   * Comma-separated list of Q-code prefixes to hide.
+   * Default: "QA QK QN QOL QOA QOBTT" 
+   * (hide administrative, checklist/admin, navaids, obstacle lights,
+   *  obstacle admin)
+   * See: faa.gov/air_traffic/publications/atpubs/notam_html/appendix_b.html
+   */
+  StaticString<64> hidden_qcodes{"QA QK QN QOL QOA QOBTT"};
+};

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -2,15 +2,33 @@
 // Copyright The XCSoar Project
 
 #include "NetComponents.hpp"
+#ifdef HAVE_TRACKING
 #include "Tracking/TrackingGlue.hpp"
+#endif
+#ifdef HAVE_HTTP
 #include "net/client/tim/Glue.hpp"
+#include "NOTAM/NOTAMGlue.hpp"
+#endif
 
 NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
-                             const TrackingSettings &tracking_settings) noexcept
-  :tracking(new TrackingGlue(event_loop, curl)),
-   tim(new TIM::Glue(curl))
+                             const TrackingSettings &tracking_settings,
+                             const NOTAMSettings &notam_settings) noexcept
+#ifdef HAVE_TRACKING
+  :tracking(new TrackingGlue(event_loop, curl))
+#endif
+#ifdef HAVE_HTTP
+# ifdef HAVE_TRACKING
+  ,tim(new TIM::Glue(curl)),
+   notam(new NOTAMGlue(notam_settings, curl))
+# else
+  :tim(new TIM::Glue(curl)),
+   notam(new NOTAMGlue(notam_settings, curl))
+# endif
+#endif
 {
+#ifdef HAVE_TRACKING
   tracking->SetSettings(tracking_settings);
+#endif
 }
 
 NetComponents::~NetComponents() noexcept = default;

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -9,10 +9,12 @@
 #include <memory>
 
 struct TrackingSettings;
+struct NOTAMSettings;
 class EventLoop;
 class CurlGlobal;
 class TrackingGlue;
 namespace TIM { class Glue; }
+class NOTAMGlue;
 
 /**
  * This singleton manages global networking-related objects.
@@ -24,10 +26,12 @@ struct NetComponents {
 
 #ifdef HAVE_HTTP
   const std::unique_ptr<TIM::Glue> tim;
+  const std::unique_ptr<NOTAMGlue> notam;
 #endif
 
   NetComponents(EventLoop &event_loop, CurlGlobal &curl,
-                const TrackingSettings &tracking_settings) noexcept;
+                const TrackingSettings &tracking_settings,
+                const NOTAMSettings &notam_settings) noexcept;
   ~NetComponents() noexcept;
 
   NetComponents(const NetComponents &) = delete;

--- a/src/ProcessTimer.cpp
+++ b/src/ProcessTimer.cpp
@@ -13,6 +13,10 @@
 #include "PopupMessage.hpp"
 #include "Simulator.hpp"
 #include "Replay/Replay.hpp"
+
+#ifdef HAVE_HTTP
+#include "NOTAM/NOTAMGlue.hpp"
+#endif
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "BallastDumpManager.hpp"
@@ -259,6 +263,12 @@ ProcessTimer() noexcept
     if (net_components->tim != nullptr &&
         CommonInterface::GetComputerSettings().weather.enable_tim)
       net_components->tim->OnTimer(CommonInterface::Basic());
+    
+    const NMEAInfo &basic = CommonInterface::Basic();
+    if (net_components->notam != nullptr &&
+        CommonInterface::GetComputerSettings().airspace.notam.enabled &&
+        basic.location_available)
+      net_components->notam->OnTimer(basic.location);
 #endif
   }
 }

--- a/src/Profile/AirspaceConfig.cpp
+++ b/src/Profile/AirspaceConfig.cpp
@@ -2,6 +2,9 @@
 // Copyright The XCSoar Project
 
 #include "AirspaceConfig.hpp"
+#ifdef HAVE_HTTP
+#include "NotamConfig.hpp"
+#endif
 #include "Map.hpp"
 #include "Keys.hpp"
 #include "ui/canvas/Features.hpp"
@@ -129,6 +132,11 @@ Profile::Load(const ProfileMap &map, AirspaceComputerSettings &settings)
         settings.warnings.class_warnings[i] = (value & 0x2) != 0;
     }
   }
+
+#ifdef HAVE_HTTP
+  // Load NOTAM settings via NotamConfig
+  Profile::LoadNotamSettings(map, settings.notam);
+#endif
 }
 
 void

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -278,6 +278,15 @@ constexpr std::string_view PCMetFtpPassword = "PCMetFtpPassword";
 
 constexpr std::string_view EnableThermalInformationMap = "EnableThermalInformationMap";
 
+constexpr std::string_view NOTAMEnabled = "NOTAMEnabled";
+constexpr std::string_view NOTAMRadius = "NOTAMRadius";
+constexpr std::string_view NOTAMRefreshInterval = "NOTAMRefreshInterval";
+constexpr std::string_view NOTAMShowIFR = "NOTAMShowIFR";
+constexpr std::string_view NOTAMShowOnlyEffective = 
+  "NOTAMShowOnlyEffective";
+constexpr std::string_view NOTAMMaxRadius = "NOTAMMaxRadius";
+constexpr std::string_view NOTAMHiddenQCodes = "NOTAMHiddenQCodes";
+
 constexpr std::string_view EnableLocationMapItem = "EnableLocationMapItem";
 constexpr std::string_view EnableArrivalAltitudeMapItem = "EnableArrivalAltitudeMapItem";
 

--- a/src/Profile/NotamConfig.cpp
+++ b/src/Profile/NotamConfig.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NotamConfig.hpp"
+#include "Map.hpp"
+#include "Keys.hpp"
+#include "NOTAM/Settings.hpp"
+
+void
+Profile::LoadNotamSettings(const ProfileMap &map, NOTAMSettings &settings)
+{
+  // Basic NOTAM settings
+  map.Get(ProfileKeys::NOTAMEnabled, settings.enabled);
+  map.Get(ProfileKeys::NOTAMRadius, settings.radius_km);
+  map.Get(ProfileKeys::NOTAMRefreshInterval, settings.refresh_interval_min);
+
+  // Filter settings
+  map.Get(ProfileKeys::NOTAMShowIFR, settings.show_ifr);
+  map.Get(ProfileKeys::NOTAMShowOnlyEffective, settings.show_only_effective);
+  map.Get(ProfileKeys::NOTAMMaxRadius, settings.max_radius_m);
+  map.Get(ProfileKeys::NOTAMHiddenQCodes, settings.hidden_qcodes);
+}

--- a/src/Profile/NotamConfig.hpp
+++ b/src/Profile/NotamConfig.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+class ProfileMap;
+struct NOTAMSettings;
+
+namespace Profile
+{
+/**
+ * Load NOTAM-related settings from the profile.
+ */
+void LoadNotamSettings(const ProfileMap &map, NOTAMSettings &settings);
+}

--- a/src/Renderer/AirspaceListRenderer.cpp
+++ b/src/Renderer/AirspaceListRenderer.cpp
@@ -16,7 +16,7 @@
 static void
 Draw(Canvas &canvas, PixelRect rc,
      const AbstractAirspace &airspace,
-     const char *comment,
+     const char *comment, const char *name,
      const TwoTextRowsRenderer &row_renderer,
      const AirspaceLook &look,
      const AirspaceRendererSettings &renderer_settings)
@@ -47,7 +47,7 @@ Draw(Canvas &canvas, PixelRect rc,
   row_renderer.DrawSecondRow(canvas, rc, comment);
 
   // Draw airspace name
-  row_renderer.DrawFirstRow(canvas, rc, airspace.GetName());
+  row_renderer.DrawFirstRow(canvas, rc, name);
 }
 
 void
@@ -57,8 +57,16 @@ AirspaceListRenderer::Draw(Canvas &canvas, const PixelRect rc,
                            const AirspaceLook &look,
                            const AirspaceRendererSettings &renderer_settings)
 {
-  ::Draw(canvas, rc, airspace, AirspaceFormatter::GetClassOrType(airspace),
-         row_renderer, look, renderer_settings);
+  const char *class_or_type = AirspaceFormatter::GetClassOrType(airspace);
+  // NOTAMs: display type (e.g., "NOTAM") as primary, name as secondary
+  // Others: display name as primary, class/type as secondary
+  if (airspace.GetClassOrType() == AirspaceClass::NOTAM) {
+    ::Draw(canvas, rc, airspace, airspace.GetName(), class_or_type,
+           row_renderer, look, renderer_settings);
+  } else {
+    ::Draw(canvas, rc, airspace, class_or_type, airspace.GetName(),
+           row_renderer, look, renderer_settings);
+  }
 }
 
 void
@@ -69,12 +77,20 @@ AirspaceListRenderer::Draw(Canvas &canvas, const PixelRect rc,
                            const AirspaceLook &look,
                            const AirspaceRendererSettings &renderer_settings)
 {
-  StaticString<256> comment(AirspaceFormatter::GetClassOrType(airspace));
+  const char *class_or_type = AirspaceFormatter::GetClassOrType(airspace);
+  StaticString<256> comment(class_or_type);
 
   comment.AppendFormat(" - %s - %s",
                        FormatUserDistanceSmart(vector.distance).c_str(),
                        FormatBearing(vector.bearing).c_str());
 
-  ::Draw(canvas, rc, airspace, comment,
-         row_renderer, look, renderer_settings);
+  const char *name = airspace.GetName();
+  if (airspace.GetClassOrType() == AirspaceClass::NOTAM) {
+    // NOTAMs: name is primary, class/type + distance + bearing as secondary
+    ::Draw(canvas, rc, airspace, name, comment,
+           row_renderer, look, renderer_settings);
+  } else {
+    ::Draw(canvas, rc, airspace, comment, name,
+           row_renderer, look, renderer_settings);
+  }
 }

--- a/src/Renderer/AirspacePreviewRenderer.cpp
+++ b/src/Renderer/AirspacePreviewRenderer.cpp
@@ -79,13 +79,14 @@ AirspacePreviewRenderer::PrepareFill(
 }
 
 void
-AirspacePreviewRenderer::UnprepareFill([[maybe_unused]] Canvas &canvas)
+AirspacePreviewRenderer::UnprepareFill([[maybe_unused]] Canvas &canvas,
+                                       [[maybe_unused]] Color text_color) noexcept
 {
 #ifdef ENABLE_OPENGL
   ::glDisable(GL_BLEND);
 #elif defined(USE_GDI)
-  canvas.SetTextColor(COLOR_BLACK);
   canvas.SetMixCopy();
+  canvas.SetTextColor(text_color);
 #endif
 }
 
@@ -133,9 +134,10 @@ AirspacePreviewRenderer::Draw(Canvas &canvas, const AbstractAirspace &airspace,
   if (shape == AbstractAirspace::Shape::POLYGON)
     GetPolygonPoints(pts, (const AirspacePolygon &)airspace, pt, radius);
 
+  const Color text_color = canvas.GetTextColor();
   if (PrepareFill(canvas, as_type_or_class, look, settings)) {
     DrawShape(canvas, shape, pt, radius, pts);
-    UnprepareFill(canvas);
+    UnprepareFill(canvas, text_color);
   }
 
   if (PrepareOutline(canvas, as_type_or_class, look, settings))

--- a/src/Renderer/AirspacePreviewRenderer.hpp
+++ b/src/Renderer/AirspacePreviewRenderer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Engine/Airspace/AirspaceClass.hpp"
+#include "ui/canvas/Color.hpp"
 
 struct PixelPoint;
 class Canvas;
@@ -17,7 +18,11 @@ namespace AirspacePreviewRenderer
                    const AirspaceLook &look,
                    const AirspaceRendererSettings &settings);
 
-  void UnprepareFill(Canvas &canvas);
+  /**
+   * Restore GDI text drawing after #PrepareFill. Pass the text color that
+   * was active before #PrepareFill (e.g. from Canvas::GetTextColor()).
+   */
+  void UnprepareFill(Canvas &canvas, Color text_color) noexcept;
 
   bool PrepareOutline(Canvas &canvas, AirspaceClass type,
                       const AirspaceLook &look,

--- a/src/Renderer/AirspaceRendererSettings.cpp
+++ b/src/Renderer/AirspaceRendererSettings.cpp
@@ -84,6 +84,7 @@ AirspaceRendererSettings::SetDefaults()
   classes[FIS_SECTOR].brush = 2;
   classes[LTA].brush = 3;
   classes[UTA].brush = 3;
+  classes[NOTAM].brush = 3;
   classes[AIRSPACECLASSCOUNT].brush = 3;
 #endif
 
@@ -134,5 +135,6 @@ AirspaceRendererSettings::SetDefaults()
   classes[FIS_SECTOR].SetColors(RGB8_BLUE);
   classes[LTA].SetColors(RGB8_BLUE);
   classes[UTA].SetColors(RGB8_BLUE);
+  classes[NOTAM].SetColors(RGB8_GRAYISH_VIOLET);
   classes[AIRSPACECLASSCOUNT].SetColors(RGB8_MAGENTA);
 }

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -49,6 +49,9 @@
 #include "Audio/VolumeController.hpp"
 #include "CommandLine.hpp"
 #include "MainWindow.hpp"
+#ifdef HAVE_HTTP
+#include "NOTAM/NOTAMGlue.hpp"
+#endif
 #include "Computer/GlideComputer.hpp"
 #include "Computer/GlideComputerInterface.hpp"
 #include "Computer/Events.hpp"
@@ -175,6 +178,18 @@ AfterStartup()
   InfoBoxManager::SetDirty();
 
   ForceCalculation();
+
+#ifdef HAVE_HTTP
+  if (net_components != nullptr && net_components->notam != nullptr &&
+      data_components != nullptr && data_components->airspaces != nullptr) {
+    try {
+      const ScopeSuspendAllThreads suspend;
+      net_components->notam->LoadCachedNOTAMsAndUpdate(*data_components->airspaces);
+    } catch (...) {
+      LogError(std::current_exception());
+    }
+  }
+#endif
 }
 
 void
@@ -629,9 +644,8 @@ Startup(UI::Display &display)
 
 #ifdef HAVE_HTTP
   net_components = new NetComponents(*asio_thread, *Net::curl,
-                                     computer_settings.tracking);
-#endif
-#ifdef HAVE_HTTP
+                                     computer_settings.tracking,
+                                     computer_settings.airspace.notam);
 #ifdef HAVE_SKYLINES_TRACKING
   if (map_window != nullptr)
     map_window->SetSkyLinesData(&net_components->tracking->GetSkyLinesData());


### PR DESCRIPTION
## Summary
Adds NOTAM fetching, filtering, map/airspace integration, and configuration UI, with follow-up fixes for UTF-8 text paths, Windows GDI list rendering, and airspace warning acknowledgement when NOTAM geometry is refreshed.

## Commits
- `src/NOTAM,build/libnotam.mk`: Implement fetching, filtering and displaying of NOTAMs (includes UTF-8 `char` cleanup for NOTAM UI paths and NTOAM→NOTAM filter label fix)
- `src/Dialogs/dlgAirspaceWarnings`: Add Details button
- `Renderer/AirspacePreviewRenderer`: Restore list text color after GDI preview fill (dark mode)
- `Engine/Airspace/AirspaceWarningManager`: Preserve NOTAM day-ack across refresh (stable key by NOTAM number)

## Testing
- `make TARGET=UNIX` and `TARGET=WIN64` built successfully locally.

Supersedes / relates to prior NOTAM PR discussion as applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added NOTAM (Notice to Airmen) support with dedicated configuration panel and list display dialog.
  * Implemented NOTAM filtering by radius, effective time, IFR status, and Q-codes.
  * Enabled NOTAM caching and automatic refresh with configurable intervals.
  * Integrated NOTAMs into airspace display and warning system.

* **Bug Fixes**
  * Fixed typo in NOTAM airspace label display.
  * Fixed text color preservation during airspace rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->