### PR TITLE
Device: Default internal GPS to last slot

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,8 @@ Version 7.45 - not yet released
     distance; tap to change home waypoint) #2320
   - android/ios: configure built-in GPS & sensors in the last device slot by
     default
+  - status: show G-load availability in device list and variometer source in
+    system status
   - terrain: add new terrain shading orientation "fixed (Top Left)"
   - Form/DataField/Enum: remove the limit of 128 internal entries (It was
     dropping the newest InfoBoxes, as we have 130 of them now)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -7,6 +7,8 @@ Version 7.45 - not yet released
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
     distance; tap to change home waypoint) #2320
+  - android/ios: configure built-in GPS & sensors in the last device slot by
+    default
   - terrain: add new terrain shading orientation "fixed (Top Left)"
   - Form/DataField/Enum: remove the limit of 128 internal entries (It was
     dropping the newest InfoBoxes, as we have 130 of them now)

--- a/src/Device/Features.hpp
+++ b/src/Device/Features.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 static constexpr unsigned NUMDEV = 6;
+static constexpr unsigned INTERNAL_DEVICE_SLOT = NUMDEV - 1;
 
 #if defined(ANDROID) || defined(__APPLE__)
 #define HAVE_INTERNAL_GPS

--- a/src/Device/device.cpp
+++ b/src/Device/device.cpp
@@ -114,7 +114,7 @@ devStartup(MultipleDevices &devices, const SystemSettings &settings)
     config.Clear();
     config.port_type = DeviceConfig::PortType::INTERNAL;
 
-    DeviceDescriptor &device = devices[0];
+    DeviceDescriptor &device = devices[INTERNAL_DEVICE_SLOT];
     devInitOne(device, config);
 #endif
   }

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -65,6 +65,7 @@ class DeviceListWidget final
     bool temperature:1;
     bool humidity:1;
     bool imu:1;
+    bool accel:1;
     bool radio:1, transponder:1;
     bool engine:1;
     bool debug:1;
@@ -115,6 +116,7 @@ class DeviceListWidget final
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;
       imu = basic.gyroscope.available;
+      accel = basic.acceleration.available;
       debug = device != nullptr && device->IsDumpEnabled();
       radio = basic.settings.has_active_frequency ||
         basic.settings.has_standby_frequency;
@@ -438,6 +440,9 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       buffer.append("; ");
       buffer.append(_("IMU"));
     }
+
+    if (flags.accel)
+      buffer.append("; G");
 
     if (flags.radio) {
       buffer.append("; ");

--- a/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
@@ -72,8 +72,14 @@ SystemStatusPanel::Refresh() noexcept
     // valid but unknown number of sats
     SetText(NumSat, _("Unknown"));
 
-  SetText(Vario, basic.total_energy_vario_available
-          ? _("Connected") : _("Disconnected"));
+  if (basic.netto_vario_available)
+    SetText(Vario, _("Netto"));
+  else if (basic.total_energy_vario_available)
+    SetText(Vario, _("Total energy"));
+  else if (basic.noncomp_vario_available)
+    SetText(Vario, _("Uncompensated"));
+  else
+    SetText(Vario, _("Disconnected"));
 
   Temp = basic.flarm.status.available
     ? _("Connected")

--- a/src/SystemSettings.cpp
+++ b/src/SystemSettings.cpp
@@ -3,6 +3,7 @@
 
 #include "SystemSettings.hpp"
 #include "Asset.hpp"
+#include "Device/Features.hpp"
 
 void
 SystemSettings::SetDefaults()
@@ -11,7 +12,7 @@ SystemSettings::SetDefaults()
     devices[i].Clear();
 
   if (IsAndroid() || IsApple()) {
-    devices[0].port_type = DeviceConfig::PortType::INTERNAL;
+    devices[INTERNAL_DEVICE_SLOT].port_type = DeviceConfig::PortType::INTERNAL;
   } else {
     devices[0].port_type = DeviceConfig::PortType::SERIAL;
 #ifdef _WIN32


### PR DESCRIPTION
## Summary
- On Android/iOS, default the built-in GPS & sensors device to the last device slot.
- When no configured device is available, fallback to built-in GPS & sensors in the last slot.

## Rationale
Keeping the internal GPS in the last slot preserves early slots for external devices.

## Test plan
- Built: TARGET=UNIX
- Built: TARGET=ANDROID (TESTING=y)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android/iOS devices now automatically configure built-in GPS and sensors in the last device slot by default
  * Device list displays G-load availability for each device
  * System status now shows the active variometer source (Netto, Total Energy, Uncompensated, or Disconnected)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->