### PR TITLE
Device: Add GDL90 traffic input

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ The following people and organizations have contributed code to XCSoar:
  Alexander Lehmann <a.lehm@gmx.de>
  Christian Körner <christian_koerner@web.de>
  Mindaugas Milasauskas <mindmil@gmail.com>
+ Baptiste <48515764+B-apt@users.noreply.github.com>
  Benjamin Tissoires <benjamin.tissoires@gmail.com>
  Florian Mösch <florian@moesch.org>
  Lloyd Bailey <3dairspace@lloydbailey.net>

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -7,11 +7,11 @@ Version 7.45 - not yet released
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
     distance; tap to change home waypoint) #2320
+  - infoboxen: InfoBox setup is no longer limited to 128 types; you can select
+    every available type (XCSoar now has more than 128) #2343
   - terrain: add new terrain shading orientation "fixed (Top Left)"
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330
-* bug fixes
-  - Form/DataField/Enum: remove the limit of 128 internal entries (It was dropping the newest InfoBoxes, as we have 130 of them now)
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,6 +10,8 @@ Version 7.45 - not yet released
   - terrain: add new terrain shading orientation "fixed (Top Left)"
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330
+* bug fixes
+  - Form/DataField/Enum: remove the limit of 128 internal entries (It was dropping the newest InfoBoxes, as we have 130 of them now)
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -9,6 +9,8 @@ Version 7.45 - not yet released
     distance; tap to change home waypoint) #2320
   - infoboxen: InfoBox setup is no longer limited to 128 types; you can select
     every available type (XCSoar now has more than 128) #2343
+  - android/ios: configure built-in GPS & sensors in the last device slot by
+    default
   - terrain: add new terrain shading orientation "fixed (Top Left)"
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,8 @@ Version 7.45 - not yet released
     every available type (XCSoar now has more than 128) #2343
   - android/ios: configure built-in GPS & sensors in the last device slot by
     default
+  - status: show G-load availability in device list and variometer source in
+    system status
   - terrain: add new terrain shading orientation "fixed (Top Left)"
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -98,6 +98,10 @@ THERMALEXPRESS_SOURCES = \
 STRATUX_SOURCES = \
 	$(DRIVER_SRC_DIR)/Stratux/Driver.cpp
 
+GDL90_SOURCES = \
+	$(DRIVER_SRC_DIR)/GDL90/Driver.cpp \
+	$(DRIVER_SRC_DIR)/GDL90/Register.cpp
+
 DRIVER_SOURCES = \
 	$(SRC)/Device/Driver.cpp \
 	$(SRC)/Device/Register.cpp \
@@ -113,6 +117,7 @@ DRIVER_SOURCES = \
 	$(XCTRACER_SOURCES) \
 	$(THERMALEXPRESS_SOURCES) \
 	$(STRATUX_SOURCES) \
+	$(GDL90_SOURCES) \
 	$(DRIVER_SRC_DIR)/AltairPro.cpp \
 	$(DRIVER_SRC_DIR)/BorgeltB50.cpp \
 	$(DRIVER_SRC_DIR)/XCVario.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -115,6 +115,8 @@ TEST_NAMES = \
 	TestTimeFormatter \
 	TestIGCFilenameFormatter \
 	TestNMEAFormatter \
+	TestGDL90 \
+	TestGDL90Driver \
 	TestLXNToIGC \
 	TestLeastSquares \
 	TestHexString \
@@ -154,6 +156,20 @@ TEST_CRC8_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestCRC8.cpp
 $(eval $(call link-program,TestCRC8,TEST_CRC8))
+
+TEST_GDL90_SOURCES = \
+	$(SRC)/util/CRC16CCITT.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestGDL90.cpp
+$(eval $(call link-program,TestGDL90,TEST_GDL90))
+
+TEST_GDL90_DRIVER_SOURCES = \
+	$(SRC)/util/CRC16CCITT.cpp \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestGDL90Driver.cpp
+TEST_GDL90_DRIVER_DEPENDS = DRIVER NMEA GEO TIME MATH UTIL UNITS FLARM
+$(eval $(call link-program,TestGDL90Driver,TEST_GDL90_DRIVER))
 
 TEST_LEASTSQUARES_SOURCES = \
 	$(SRC)/Math/LeastSquares.cpp \

--- a/src/Audio/ALSAEnv.cpp
+++ b/src/Audio/ALSAEnv.cpp
@@ -20,6 +20,7 @@ static constexpr char ALSA_LATENCY_ENV[] = "ALSA_LATENCY";
 
 static constexpr char DEFAULT_ALSA_DEVICE[] = "default";
 static constexpr unsigned DEFAULT_ALSA_LATENCY = 100000;
+static constexpr unsigned MIN_ALSA_LATENCY = 20000;
 
 
 static const char *InitALSADeviceName()
@@ -44,9 +45,13 @@ static unsigned InitALSALatency()
     latency = ParseUnsigned(latency_env_value, &p);
     if (*p != '\0') {
       LogFormat("Invalid %s value: %s", ALSA_LATENCY_ENV, latency_env_value);
-      return false;
+      latency = DEFAULT_ALSA_LATENCY;
     }
   }
+
+  if (latency < MIN_ALSA_LATENCY)
+    latency = MIN_ALSA_LATENCY;
+
   LogFormat("Using ALSA PCM latency: %u μs (use environment variable %s to override)",
             latency, ALSA_LATENCY_ENV);
   return latency;

--- a/src/Audio/ALSAEnv.hpp
+++ b/src/Audio/ALSAEnv.hpp
@@ -26,7 +26,7 @@ namespace ALSAEnv
    * underruns.
    *
    * @return Value of the environment variable "ALSA_LATENCY", parsed as
-   * unsigned, or 10000 if not set, or unparsable. The unit is μs.
+   * unsigned, or 100000 if not set, or unparsable. The unit is μs.
    */
   unsigned GetALSALatency();
 }

--- a/src/Audio/ToneSynthesiser.cpp
+++ b/src/Audio/ToneSynthesiser.cpp
@@ -9,7 +9,7 @@
 void
 ToneSynthesiser::SetTone(unsigned tone_hz)
 {
-  increment = ISINETABLE.size() * tone_hz / sample_rate;
+  target_increment = ISINETABLE.size() * tone_hz / sample_rate;
 }
 
 void
@@ -18,6 +18,16 @@ ToneSynthesiser::Synthesise(int16_t *buffer, size_t n)
   assert(angle < ISINETABLE.size());
 
   for (int16_t *end = buffer + n; buffer != end; ++buffer) {
+    if (increment != target_increment) {
+      if (increment < target_increment) {
+        const unsigned diff = target_increment - increment;
+        increment += std::max(1u, diff / slew_divisor);
+      } else {
+        const unsigned diff = increment - target_increment;
+        increment -= std::max(1u, diff / slew_divisor);
+      }
+    }
+
     *buffer = ISINETABLE[angle] * (32767 / 1024) * (int)volume / 100;
     angle = (angle + increment) & (ISINETABLE.size() - 1);
   }

--- a/src/Audio/ToneSynthesiser.hpp
+++ b/src/Audio/ToneSynthesiser.hpp
@@ -5,15 +5,28 @@
 
 #include "PCMSynthesiser.hpp"
 
+#include <algorithm>
+
 /**
  * This class generates tones with a sine wave.
  */
 class ToneSynthesiser : public PCMSynthesiser {
-  unsigned volume = 100, angle = 0, increment = 0;
+  unsigned volume = 100;
+  unsigned angle = 0;
+  unsigned increment = 0, target_increment = 0;
+
+  /**
+   * Higher value means slower pitch changes.
+   *
+   * This smoothes the tone when input updates are low-rate/noisy
+   * (e.g. GPS vario).
+   */
+  unsigned slew_divisor;
 
 public:
-  explicit ToneSynthesiser(unsigned _sample_rate) : sample_rate(_sample_rate) {
-  }
+  explicit ToneSynthesiser(unsigned _sample_rate)
+    :slew_divisor(std::max(64u, _sample_rate / 4u)),
+     sample_rate(_sample_rate) {}
 
   unsigned GetSampleRate() const {
     return sample_rate;

--- a/src/Audio/VarioGlue.cpp
+++ b/src/Audio/VarioGlue.cpp
@@ -69,7 +69,7 @@ AudioVarioGlue::Configure(const VarioSoundSettings &settings)
   assert(synthesiser != nullptr);
 
   if (settings.enabled) {
-    synthesiser->SetVolume(settings.volume);
+    synthesiser->SetVarioVolume(settings.volume);
     synthesiser->SetDeadBand(settings.dead_band_enabled);
     synthesiser->SetFrequencies(settings.min_frequency, settings.zero_frequency,
                                 settings.max_frequency);

--- a/src/Audio/VarioSynthesiser.cpp
+++ b/src/Audio/VarioSynthesiser.cpp
@@ -2,15 +2,9 @@
 // Copyright The XCSoar Project
 
 #include "VarioSynthesiser.hpp"
-#include "Math/FastMath.hpp"
 
 #include <algorithm>
 #include <cassert>
-
-/**
- * The minimum and maximum vario range for the constants below [cm/s].
- */
-static constexpr int min_vario = -500, max_vario = 500;
 
 unsigned
 VarioSynthesiser::VarioToFrequency(int ivario)
@@ -18,7 +12,44 @@ VarioSynthesiser::VarioToFrequency(int ivario)
   return ivario > 0
     ? (zero_frequency + (unsigned)ivario * (max_frequency - zero_frequency)
        / (unsigned)max_vario)
-    : (zero_frequency - (unsigned)(ivario * (int)(zero_frequency - min_frequency) / min_vario));
+    : (zero_frequency -
+       (unsigned)(ivario * (int)(zero_frequency - min_frequency) / min_vario));
+}
+
+void
+VarioSynthesiser::UpdateEnvelopeParameters()
+{
+  env_attack_samples = std::max(1u, sample_rate * ATTACK_MS / 1000);
+  env_release_samples = std::max(1u, sample_rate * RELEASE_MS / 1000);
+}
+
+void
+VarioSynthesiser::UpdateGateFromVario(int ivario)
+{
+  if (ivario <= 0) {
+    /* sink/neutral: continuous */
+    gate_on = true;
+    gate_on_samples = 1;
+    gate_off_samples = 0;
+    gate_remaining = 0;
+    return;
+  }
+
+  const unsigned period_samples = sample_rate *
+    (min_period_ms + (max_vario - (unsigned)ivario) *
+     (max_period_ms - min_period_ms) / (unsigned)max_vario) / 1000;
+
+  /* 2/3 on, 1/3 off */
+  const unsigned off = std::max(1u, period_samples / 3);
+  const unsigned on = std::max(1u, period_samples - off);
+
+  gate_on_samples = on;
+  gate_off_samples = off;
+
+  if (gate_remaining == 0) {
+    gate_on = true;
+    gate_remaining = gate_on_samples;
+  }
 }
 
 void
@@ -26,64 +57,27 @@ VarioSynthesiser::SetVario(double vario)
 {
   const std::lock_guard lock{mutex};
 
+  UpdateEnvelopeParameters();
+
   const int ivario = std::clamp((int)(vario * 100), min_vario, max_vario);
 
   if (dead_band_enabled && InDeadBand(ivario)) {
-    /* inside the "dead band" */
-    UnsafeSetSilence();
+    env_target = 0;
     return;
   }
 
-  /* update the ToneSynthesiser base class */
   SetTone(VarioToFrequency(ivario));
+  UpdateGateFromVario(ivario);
 
-  if (ivario > 0) {
-    /* while climbing, the vario sound gets interrupted by silence
-       periodically */
-
-    const unsigned period_ms = sample_rate
-      * (min_period_ms + (max_vario - ivario)
-         * (max_period_ms - min_period_ms) / max_vario)
-      / 1000;
-
-    silence_count = period_ms / 3;
-    audible_count = period_ms - silence_count;
-
-    /* preserve the old "_remaining" values as much as possible, to
-       avoid chopping off the previous tone */
-
-    if (audible_remaining > audible_count)
-      audible_remaining = audible_count;
-
-    if (silence_remaining > silence_count)
-      silence_remaining = silence_count;
-  } else {
-    /* continuous tone while sinking */
-    audible_count = 1;
-    silence_count = 0;
-  }
+  /* set target based on gate */
+  env_target = gate_on ? ENV_MAX : 0;
 }
 
 void
 VarioSynthesiser::SetSilence()
 {
   const std::lock_guard lock{mutex};
-  UnsafeSetSilence();
-}
-
-void
-VarioSynthesiser::UnsafeSetSilence()
-{
-  audible_count = 0;
-  silence_count = 1;
-
-  if (audible_remaining > 0)
-    /* quit the current period as early as possible; the method
-       Synthesise() will take care for finishing the current sine
-       wave to avoid clicking noise */
-    audible_remaining = 1;
-
-  silence_remaining = 0;
+  env_target = 0;
 }
 
 
@@ -92,49 +86,35 @@ VarioSynthesiser::Synthesise(int16_t *buffer, size_t n)
 {
   const std::lock_guard lock{mutex};
 
-  assert(audible_count > 0 || silence_count > 0);
+  assert(env_attack_samples > 0);
+  assert(env_release_samples > 0);
 
-  if (silence_count == 0) {
-    /* magic value for "continuous tone" */
-    ToneSynthesiser::Synthesise(buffer, n);
-    return;
-  }
+  ToneSynthesiser::Synthesise(buffer, n);
 
-  while (n > 0) {
-    if (audible_remaining > 0) {
-      /* generate a period of audible tone */
-
-      unsigned o = silence_count > 0
-        ? std::min(n, audible_remaining)
-        : n;
-      ToneSynthesiser::Synthesise(buffer, o);
-      buffer += o;
-      n -= o;
-      audible_remaining -= o;
-
-      if (audible_remaining == 0 && silence_remaining > 0) {
-        /* finish the current sine wave to avoid clicking noise */
-        audible_remaining = ToZero();
-        if (audible_remaining == 0)
-          /* finished, we can now emit a period of silence */
-          Restart();
+  for (size_t i = 0; i < n; ++i) {
+    /* gate timing (climb beep mode) */
+    if (gate_off_samples > 0) {
+      if (gate_remaining == 0) {
+        gate_on = !gate_on;
+        gate_remaining = gate_on ? gate_on_samples : gate_off_samples;
+        env_target = gate_on ? ENV_MAX : 0;
       }
-    } else if (silence_remaining > 0) {
-      /* generate a period of silence (climbing) */
 
-      unsigned o = audible_count > 0
-        ? std::min(n, silence_remaining)
-        : n;
-      /* the "silence" PCM sample value is zero */
-      std::fill_n(buffer, o, 0);
-      buffer += o;
-      n -= o;
-      silence_remaining -= o;
-    } else {
-      /* period finished, begin next one */
-
-      audible_remaining = audible_count;
-      silence_remaining = silence_count;
+      --gate_remaining;
     }
+
+    /* envelope */
+    if (env < env_target) {
+      const int step = std::max(1, ENV_MAX / (int)env_attack_samples);
+      env = std::min(env_target, env + step);
+    } else if (env > env_target) {
+      const int step = std::max(1, ENV_MAX / (int)env_release_samples);
+      env = std::max(env_target, env - step);
+    }
+
+    buffer[i] = (int16_t)((int)buffer[i] * env / ENV_MAX);
   }
+
+  if (env == 0)
+    Restart();
 }

--- a/src/Audio/VarioSynthesiser.cpp
+++ b/src/Audio/VarioSynthesiser.cpp
@@ -5,15 +5,23 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 
 unsigned
 VarioSynthesiser::VarioToFrequency(int ivario)
 {
-  return ivario > 0
-    ? (zero_frequency + (unsigned)ivario * (max_frequency - zero_frequency)
-       / (unsigned)max_vario)
-    : (zero_frequency -
-       (unsigned)(ivario * (int)(zero_frequency - min_frequency) / min_vario));
+  if (ivario > 0) {
+    const double x = (double)ivario / (double)max_vario;
+    const double f = (double)zero_frequency +
+      x * (double)(max_frequency - zero_frequency);
+    return (unsigned)std::lround(f);
+  } else if (ivario < 0) {
+    const double x = (double)ivario / (double)min_vario; // both negative
+    const double f = (double)zero_frequency -
+      x * (double)(zero_frequency - min_frequency);
+    return (unsigned)std::lround(f);
+  } else
+    return zero_frequency;
 }
 
 void
@@ -59,7 +67,7 @@ VarioSynthesiser::SetVario(double vario)
 
   UpdateEnvelopeParameters();
 
-  const int ivario = std::clamp((int)(vario * 100), min_vario, max_vario);
+  const int ivario = std::clamp((int)lround(vario * 100), min_vario, max_vario);
 
   if (dead_band_enabled && InDeadBand(ivario)) {
     env_target = 0;

--- a/src/Audio/VarioSynthesiser.hpp
+++ b/src/Audio/VarioSynthesiser.hpp
@@ -11,28 +11,29 @@
  */
 class VarioSynthesiser final : public ToneSynthesiser {
   /**
-   * This mutex protects all atttributes below.  It is locked
-   * automatically by all public methods.
+   * This mutex protects all attributes below. It is locked automatically
+   * by all public methods.
    */
   Mutex mutex;
 
-  /**
-   * The number of audible samples in each period.
-   */
-  size_t audible_count;
+  static constexpr int min_vario = -500, max_vario = 500;
+
+  /* envelope (Q15: 0..32767) */
+  static constexpr int ENV_MAX = 32767;
+  static constexpr unsigned ATTACK_MS = 3;
+  static constexpr unsigned RELEASE_MS = 5;
+
+  int env = 0;
+  int env_target = 0;
+  unsigned env_attack_samples = 1;
+  unsigned env_release_samples = 1;
 
   /**
-   * The number of silent samples in each period.  If this is zero,
-   * then no silence will be generated (continuous tone).
+   * Gating for climb "beep" mode.
    */
-  size_t silence_count;
-
-  /**
-   * The number of audible/silence samples remaining in the current
-   * period.  These two attributes will be reset to the according
-   * _count value when both reach zero.
-   */
-  size_t audible_remaining, silence_remaining;
+  unsigned gate_on_samples = 1, gate_off_samples = 1;
+  unsigned gate_remaining = 0;
+  bool gate_on = true;
 
   bool dead_band_enabled;
 
@@ -70,12 +71,21 @@ class VarioSynthesiser final : public ToneSynthesiser {
 public:
   explicit VarioSynthesiser(unsigned sample_rate)
     :ToneSynthesiser(sample_rate),
-     audible_count(0), silence_count(1),
-     audible_remaining(0), silence_remaining(0),
      dead_band_enabled(false),
      min_frequency(200), zero_frequency(500), max_frequency(1500),
      min_period_ms(150), max_period_ms(600),
      min_dead(-30), max_dead(10) {}
+
+  /**
+   * Set the (software) volume of the generated tone.
+   *
+   * This method is thread-safe and may be called while playback is
+   * running.
+   */
+  void SetVarioVolume(unsigned volume) {
+    const std::lock_guard lock{mutex};
+    ToneSynthesiser::SetVolume(volume);
+  }
 
   /**
    * Update the vario value.  This calculates a new tone frequency and
@@ -94,6 +104,7 @@ public:
    * Enable/disable the dead band silence
    */
   void SetDeadBand(bool enabled) {
+    const std::lock_guard lock{mutex};
     dead_band_enabled = enabled;
   }
 
@@ -101,6 +112,7 @@ public:
    * Set the base frequencies for minimum, zero and maximum lift
    */
   void SetFrequencies(unsigned min, unsigned zero, unsigned max) {
+    const std::lock_guard lock{mutex};
     min_frequency = min;
     zero_frequency = zero;
     max_frequency = max;
@@ -110,6 +122,7 @@ public:
    * Set the time periods for minimum and maximum lift
    */
   void SetPeriods(unsigned min, unsigned max) {
+    const std::lock_guard lock{mutex};
     min_period_ms = min;
     max_period_ms = max;
   }
@@ -118,6 +131,7 @@ public:
    * Set the vario range of the "dead band" during which no sound is emitted
    */
   void SetDeadBandRange(double min, double max) {
+    const std::lock_guard lock{mutex};
     min_dead = (int)(min * 100);
     max_dead = (int)(max * 100);
   }
@@ -126,10 +140,7 @@ public:
   virtual void Synthesise(int16_t *buffer, size_t n);
 
 private:
-  /**
-   * Same as SetSilence(), but doesn't lock the mutex.
-   */
-  void UnsafeSetSilence();
+  void UpdateEnvelopeParameters();
 
   /**
    * Convert a vario value to a tone frequency.
@@ -142,4 +153,6 @@ private:
   bool InDeadBand(int ivario) {
     return ivario >= min_dead && ivario <= max_dead;
   }
+
+  void UpdateGateFromVario(int ivario);
 };

--- a/src/Device/Driver/GDL90.hpp
+++ b/src/Device/Driver/GDL90.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+extern const struct DeviceRegister gdl90_driver;
+

--- a/src/Device/Driver/GDL90/Driver.cpp
+++ b/src/Device/Driver/GDL90/Driver.cpp
@@ -310,13 +310,16 @@ GDL90Device::ParseTrafficReport(std::span<const uint8_t> payload,
 
   slot->location = GeoPoint(Angle::Degrees(lon_deg), Angle::Degrees(lat_deg));
   slot->location_available = true;
+  slot->absolute_location = true;
 
   if (altitude_available) {
     slot->altitude = altitude;
     slot->altitude_available = true;
+    slot->absolute_altitude = true;
   } else {
     slot->altitude = 0;
     slot->altitude_available = false;
+    slot->absolute_altitude = false;
   }
 
   if (track_received) {

--- a/src/Device/Driver/GDL90/Driver.cpp
+++ b/src/Device/Driver/GDL90/Driver.cpp
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Driver.hpp"
+
+#include "FLARM/List.hpp"
+#include "FLARM/Id.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "NMEA/Info.hpp"
+#include "Units/System.hpp"
+#include "util/CRC16CCITT.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cmath>
+
+/*
+ * References:
+ * - Garmin "GDL 90 Data Interface Specification", 560-1058-00 Rev A (2007-06-05)
+ *   (a.k.a. the public GDL90 ICD)
+ *   - §2.2.1 framing / byte-stuffing: 0x7E flag, 0x7D escape, XOR 0x20
+ *   - §2.2.2 message id: MSB reserved, must be zero
+ *   - §2.2.3 CRC: CRC-CCITT, table-driven update shown in the document
+ *   - §3.1 Heartbeat (msg id 0x00)
+ *   - §3.4 Ownship Report (msg id 0x0A), format per §3.5.1
+ *   - §3.5 Traffic Report (msg id 0x14), format per §3.5.1
+ *
+ * Note: Multi-byte fields in report payloads are big-endian unless stated
+ * otherwise (ICD §3, "multi-byte fields are transmitted most-significant
+ * byte first"). The CRC field itself is little-endian (ICD §2.2.1/§2.2.3).
+ */
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+static constexpr std::size_t GDL90_MAX_FRAME = 1024;
+
+static constexpr uint8_t
+ReadU8(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return i < s.size() ? s[i] : 0;
+}
+
+static constexpr uint16_t
+ReadBE16(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return (uint16_t(ReadU8(s, i)) << 8) | uint16_t(ReadU8(s, i + 1));
+}
+
+static constexpr uint32_t
+ReadBE24(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return (uint32_t(ReadU8(s, i)) << 16) |
+    (uint32_t(ReadU8(s, i + 1)) << 8) |
+    uint32_t(ReadU8(s, i + 2));
+}
+
+static constexpr int32_t
+SignExtend24(uint32_t value) noexcept
+{
+  value &= 0x00ffffff;
+  if ((value & 0x00800000) != 0)
+    return int32_t(value | 0xff000000);
+  return int32_t(value);
+}
+
+static constexpr double
+SemiCircles24ToDegrees(int32_t value) noexcept
+{
+  /* 24-bit signed semicircle fraction; see GDL90 ICD §3.5.1.3 */
+  return double(value) * (180.0 / double(1u << 23));
+}
+
+static uint16_t
+Gdl90Crc16(std::span<const uint8_t> data) noexcept
+{
+  /* CRC-CCITT update function per GDL90 ICD §2.2.3 (table-driven). */
+  uint16_t crc = 0;
+
+  for (uint8_t b : data)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ b;
+
+  return crc;
+}
+
+static bool
+UnescapeGdl90(std::span<const uint8_t> src,
+              std::vector<uint8_t> &dest) noexcept
+{
+  dest.clear();
+  dest.reserve(src.size());
+
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    const uint8_t b = src[i];
+    if (b != GDL90_ESCAPE) {
+      dest.push_back(b);
+      continue;
+    }
+
+    if (++i >= src.size())
+      return false;
+
+    dest.push_back(src[i] ^ GDL90_ESCAPE_XOR);
+  }
+
+  return true;
+}
+
+static constexpr bool
+IsGdl90MessageId(uint8_t id) noexcept
+{
+  /* MSB is reserved for future addressing; drop if set (ICD §2.2.2) */
+  return (id & 0x80) == 0;
+}
+
+static FlarmId
+MakeIcaoFlarmId(uint32_t icao) noexcept
+{
+  char buffer[16];
+  snprintf(buffer, sizeof(buffer), "%06X", (unsigned)(icao & 0xffffff));
+  return FlarmId::Parse(buffer, nullptr);
+}
+
+static void
+ExtractCallsign(std::span<const uint8_t, 8> src,
+                StaticString<10> &dest) noexcept
+{
+  /* ICD §3.5.1.11: 8 ASCII chars, space is trailing pad */
+  char tmp[9];
+  for (unsigned i = 0; i < 8; ++i) {
+    const uint8_t ch = src[i];
+    tmp[i] = ch >= 0x20 && ch < 0x7f ? (char)ch : ' ';
+  }
+  tmp[8] = 0;
+
+  /* trim trailing spaces */
+  unsigned n = 8;
+  while (n > 0 && tmp[n - 1] == ' ')
+    --n;
+  tmp[n] = 0;
+
+  dest.SetASCII(tmp);
+  dest.CleanASCII();
+}
+
+void
+GDL90Device::ParseOwnshipReport(std::span<const uint8_t> payload,
+                                NMEAInfo &info) noexcept
+{
+  /* Ownship Report message payload is 27 bytes (ICD 3.4 / 3.5.1) */
+  if (payload.size() < 27)
+    return;
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload, 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload, 7));
+  const double lat_deg = SemiCircles24ToDegrees(lat_raw);
+  const double lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg) ||
+      lat_deg < -90 || lat_deg > 90 || lon_deg < -180 || lon_deg > 180)
+    return;
+
+  info.location = GeoPoint(Angle::Degrees(lon_deg), Angle::Degrees(lat_deg));
+  info.location_available.Update(info.clock);
+
+  /* Ownship altitude is pressure altitude (25ft steps, offset -1000ft) */
+  const uint16_t alt_word = ReadBE16(payload, 10);
+  const uint16_t altitude_code = alt_word >> 4;
+  const uint8_t misc = alt_word & 0x0f;
+  if (altitude_code != 0xfff) {
+    const int altitude_ft = int(altitude_code) * 25 - 1000;
+    const double pressure_altitude =
+      Units::ToSysUnit(altitude_ft, Unit::FEET);
+    info.ProvidePressureAltitude(pressure_altitude);
+  }
+
+  /* velocity: 12-bit horizontal (knots), 12-bit vertical (64 fpm) */
+  const uint32_t vel = ReadBE24(payload, 13);
+  const uint16_t h_code = uint16_t((vel >> 12) & 0x0fff);
+  if (h_code != 0x0fff) {
+    info.ground_speed = Units::ToSysUnit(h_code, Unit::KNOTS);
+    info.ground_speed_available.Update(info.clock);
+  }
+
+  const uint8_t track_byte = payload[16];
+  const bool track_valid = (misc & 0x03) != 0;
+  if (track_valid && track_byte != 0xff) {
+    info.track = Angle::Degrees(double(track_byte) * (360.0 / 256.0));
+    info.track_available.Update(info.clock);
+  }
+
+  /* Basic fix quality (optional but helps status panels) */
+  info.gps.fix_quality = FixQuality::GPS;
+  info.gps.fix_quality_available.Update(info.clock);
+  info.gps.real = true;
+}
+
+void
+GDL90Device::ParseTrafficReport(std::span<const uint8_t> payload,
+                                NMEAInfo &info) noexcept
+{
+  /* Traffic Report message payload is 27 bytes (ICD 3.5) */
+  if (payload.size() < 27)
+    return;
+
+  /* byte 0: low nibble = alert status, high nibble = address type
+     bytes 1-3: participant address (24-bit) */
+  const uint8_t b0 = payload[0];
+  const uint8_t address_type = b0 >> 4;
+
+  const uint32_t participant_address = ReadBE24(payload, 1);
+  if (participant_address == 0)
+    return;
+
+  const FlarmId id = MakeIcaoFlarmId(participant_address);
+  if (!id.IsDefined())
+    return;
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload, 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload, 7));
+  const double lat_deg = SemiCircles24ToDegrees(lat_raw);
+  const double lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg) ||
+      lat_deg < -90 || lat_deg > 90 || lon_deg < -180 || lon_deg > 180)
+    return;
+
+  const uint16_t alt_word = ReadBE16(payload, 10);
+  const uint16_t altitude_code = alt_word >> 4;
+  const uint8_t misc = alt_word & 0x0f;
+
+  bool altitude_available = altitude_code != 0xfff;
+  double altitude = 0;
+  if (altitude_available) {
+    const int altitude_ft = int(altitude_code) * 25 - 1000;
+    altitude = Units::ToSysUnit(altitude_ft, Unit::FEET);
+  }
+
+  const uint8_t nacp_nic = payload[12];
+  (void)nacp_nic; /* not used yet */
+
+  /* velocity: 24 bits, 12-bit horizontal (knots), 12-bit vertical (64 fpm) */
+  const uint32_t vel = ReadBE24(payload, 13);
+  const uint16_t h_code = uint16_t((vel >> 12) & 0x0fff);
+  const uint16_t v_code = uint16_t(vel & 0x0fff);
+
+  bool speed_received = h_code != 0x0fff;
+  double speed = 0;
+  if (speed_received)
+    speed = Units::ToSysUnit(h_code, Unit::KNOTS);
+
+  bool climb_rate_received = v_code != 0x0800;
+  double climb_rate = 0;
+  if (climb_rate_received) {
+    int16_t v_signed = v_code;
+    if (v_signed & 0x0800)
+      v_signed -= 0x1000;
+
+    /* 64 feet per minute, convert to m/s */
+    constexpr double FPM_TO_MS = 0.00508;
+    climb_rate = double(v_signed) * 64 * FPM_TO_MS;
+  }
+
+  const uint8_t track_byte = payload[16];
+  const bool track_valid = (misc & 0x03) != 0;
+  bool track_received = track_valid;
+  Angle track = Angle::Zero();
+  if (track_received && track_byte != 0xff)
+    track = Angle::Degrees(double(track_byte) * (360.0 / 256.0));
+  else
+    track_received = false;
+
+  FlarmTraffic *slot = info.flarm.traffic.FindTraffic(id);
+  if (slot == nullptr) {
+    slot = info.flarm.traffic.AllocateTraffic();
+    if (slot == nullptr)
+      return;
+
+    slot->Clear();
+    slot->id = id;
+    info.flarm.traffic.new_traffic.Update(info.clock);
+  }
+
+  info.flarm.traffic.modified.Update(info.clock);
+  slot->valid.Update(info.clock);
+
+  if (payload.size() >= 26) {
+    const std::span<const uint8_t, 8> callsign{payload.data() + 18, 8};
+    ExtractCallsign(callsign, slot->name);
+  }
+
+  slot->alarm_level = FlarmTraffic::AlarmType::NONE;
+  slot->id_type = FlarmTraffic::IdType::ICAO;
+
+  switch (address_type) {
+  case 0: /* ADS-B with ICAO address */
+  case 1: /* ADS-B with self-assigned address */
+    slot->source = FlarmTraffic::SourceType::ADSB;
+    break;
+
+  case 2: /* TIS-B with ICAO address */
+  case 3: /* TIS-B with track file ID */
+    slot->source = FlarmTraffic::SourceType::TISB;
+    break;
+
+  default:
+    slot->source = FlarmTraffic::SourceType::ADSB;
+    break;
+  }
+
+  slot->location = GeoPoint(Angle::Degrees(lon_deg), Angle::Degrees(lat_deg));
+  slot->location_available = true;
+
+  if (altitude_available) {
+    slot->altitude = altitude;
+    slot->altitude_available = true;
+  } else {
+    slot->altitude = 0;
+    slot->altitude_available = false;
+  }
+
+  if (track_received) {
+    slot->track = track;
+    slot->track_received = true;
+  } else
+    slot->track_received = false;
+
+  if (speed_received) {
+    slot->speed = speed;
+    slot->speed_received = true;
+  } else
+    slot->speed_received = false;
+
+  if (climb_rate_received) {
+    slot->climb_rate = climb_rate;
+    slot->climb_rate_received = true;
+  } else
+    slot->climb_rate_received = false;
+
+  /* not available / not conveyed by basic Traffic Report */
+  slot->relative_north = 0;
+  slot->relative_east = 0;
+  slot->relative_altitude = 0;
+  slot->stealth = false;
+  slot->no_track = false;
+  slot->rssi_available = false;
+  slot->turn_rate_received = false;
+  slot->climb_rate_avg30s_available = false;
+}
+
+bool
+GDL90Device::DataReceived(std::span<const std::byte> s,
+                          NMEAInfo &info) noexcept
+{
+  const auto *p = reinterpret_cast<const uint8_t *>(s.data());
+  buffer.insert(buffer.end(), p, p + s.size());
+
+  unescaped.reserve(256);
+
+  while (true) {
+    auto start = std::find(buffer.begin(), buffer.end(), GDL90_FLAG);
+    if (start == buffer.end()) {
+      buffer.clear();
+      break;
+    }
+
+    buffer.erase(buffer.begin(), start);
+    if (buffer.size() < 2)
+      break;
+
+    auto end = std::find(buffer.begin() + 1, buffer.end(), GDL90_FLAG);
+    if (end == buffer.end()) {
+      /* keep current partial frame */
+      if (buffer.size() > 4096)
+        buffer.erase(buffer.begin(), buffer.end() - 4096);
+      break;
+    }
+
+    const std::span<const uint8_t> frame{
+      buffer.data() + 1, std::size_t(end - buffer.begin() - 1)};
+
+    buffer.erase(buffer.begin(), end + 1);
+
+    if (frame.size() < 4)
+      continue;
+
+    if (frame.size() > GDL90_MAX_FRAME)
+      continue;
+
+    if (!UnescapeGdl90(frame, unescaped))
+      continue;
+
+    if (unescaped.size() < 4)
+      continue;
+
+    const uint8_t msg_id = unescaped[0];
+    if (!IsGdl90MessageId(msg_id))
+      continue;
+
+    if (unescaped.size() < 1 + 2)
+      continue;
+
+    const std::size_t payload_len = unescaped.size() - 1 - 2;
+    const uint16_t rx_crc = uint16_t(unescaped[unescaped.size() - 2]) |
+      (uint16_t(unescaped[unescaped.size() - 1]) << 8);
+    const uint16_t calc_crc = Gdl90Crc16({unescaped.data(),
+                                          1 + payload_len});
+    if (rx_crc != calc_crc)
+      continue;
+
+    const std::span<const uint8_t> payload{
+      unescaped.data() + 1, payload_len};
+
+    /* Any valid GDL90 frame indicates the device is alive. */
+    info.alive.Update(info.clock);
+
+    switch (msg_id) {
+    case 0x00: /* Heartbeat */
+      break;
+
+    case 0x0a: /* Ownship Report */
+      ParseOwnshipReport(payload, info);
+      break;
+
+    case 0x14: /* Traffic Report */
+      ParseTrafficReport(payload, info);
+      break;
+    }
+  }
+
+  return true;
+}
+

--- a/src/Device/Driver/GDL90/Driver.hpp
+++ b/src/Device/Driver/GDL90/Driver.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Device/Driver.hpp"
+
+#include <cstdint>
+#include <span>
+#include <vector>
+
+struct NMEAInfo;
+
+class GDL90Device final : public AbstractDevice {
+  std::vector<uint8_t> buffer;
+  std::vector<uint8_t> unescaped;
+
+  void ParseTrafficReport(std::span<const uint8_t> payload,
+                          NMEAInfo &info) noexcept;
+
+  void ParseOwnshipReport(std::span<const uint8_t> payload,
+                          NMEAInfo &info) noexcept;
+
+public:
+  bool DataReceived(std::span<const std::byte> s,
+                    NMEAInfo &info) noexcept override;
+};

--- a/src/Device/Driver/GDL90/Driver.hpp
+++ b/src/Device/Driver/GDL90/Driver.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "Device/Driver.hpp"
-
 #include <cstdint>
 #include <span>
 #include <vector>

--- a/src/Device/Driver/GDL90/Register.cpp
+++ b/src/Device/Driver/GDL90/Register.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/GDL90.hpp"
+#include "Driver.hpp"
+
+static Device *
+GDL90CreateOnPort([[maybe_unused]] const DeviceConfig &config,
+                  [[maybe_unused]] Port &com_port)
+{
+  return new GDL90Device();
+}
+
+const struct DeviceRegister gdl90_driver = {
+  "GDL90",
+  "GDL90",
+  DeviceRegister::RAW_GPS_DATA,
+  GDL90CreateOnPort,
+};
+

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -42,6 +42,7 @@
 #include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/KRT2.hpp"
 #include "Device/Driver/Stratux.hpp"
+#include "Device/Driver/GDL90.hpp"
 #include "Device/Driver/LoEFGREN.hpp"
 #include "util/Macros.hpp"
 #include "util/StringAPI.hxx"
@@ -92,6 +93,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &lx_eos_driver,
   &stratux_driver,
   &loe_fgren_driver,
+  &gdl90_driver,
   nullptr
 };
 

--- a/src/Device/device.cpp
+++ b/src/Device/device.cpp
@@ -114,7 +114,7 @@ devStartup(MultipleDevices &devices, const SystemSettings &settings)
     config.Clear();
     config.port_type = DeviceConfig::PortType::INTERNAL;
 
-    DeviceDescriptor &device = devices[0];
+    DeviceDescriptor &device = devices[NUMDEV - 1];
     devInitOne(device, config);
 #endif
   }

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -65,6 +65,7 @@ class DeviceListWidget final
     bool temperature:1;
     bool humidity:1;
     bool imu:1;
+    bool accel:1;
     bool radio:1, transponder:1;
     bool engine:1;
     bool debug:1;
@@ -115,6 +116,7 @@ class DeviceListWidget final
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;
       imu = basic.gyroscope.available;
+      accel = basic.acceleration.available;
       debug = device != nullptr && device->IsDumpEnabled();
       radio = basic.settings.has_active_frequency ||
         basic.settings.has_standby_frequency;
@@ -438,6 +440,9 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       buffer.append("; ");
       buffer.append(_("IMU"));
     }
+
+    if (flags.accel)
+      buffer.append("; G");
 
     if (flags.radio) {
       buffer.append("; ");

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -62,6 +62,7 @@ class DeviceListWidget final
     bool duplicate:1;
     bool open:1, error:1;
     bool alive:1, location:1, gps:1, baro:1, pitot:1, airspeed:1, vario:1, traffic:1;
+    bool gdl90:1;
     bool temperature:1;
     bool humidity:1;
     bool imu:1;
@@ -113,6 +114,7 @@ class DeviceListWidget final
         basic.dyn_pressure_available;
       vario = basic.total_energy_vario_available;
       traffic = basic.flarm.IsDetected();
+      gdl90 = traffic && config.UsesDriver() && config.driver_name == "GDL90";
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;
       imu = basic.gyroscope.available;
@@ -429,7 +431,7 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     }
 
     if (flags.traffic)
-      buffer.append("; FLARM");
+      buffer.append(flags.gdl90 ? "; GDL90" : "; FLARM");
 
     if (flags.temperature || flags.humidity) {
       buffer.append("; ");

--- a/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/SystemStatusPanel.cpp
@@ -72,8 +72,14 @@ SystemStatusPanel::Refresh() noexcept
     // valid but unknown number of sats
     SetText(NumSat, _("Unknown"));
 
-  SetText(Vario, basic.total_energy_vario_available
-          ? _("Connected") : _("Disconnected"));
+  if (basic.netto_vario_available)
+    SetText(Vario, _("Netto"));
+  else if (basic.total_energy_vario_available)
+    SetText(Vario, _("Total energy"));
+  else if (basic.noncomp_vario_available)
+    SetText(Vario, _("Uncompensated"));
+  else
+    SetText(Vario, _("Disconnected"));
 
   Temp = basic.flarm.status.available
     ? _("Connected")

--- a/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
+++ b/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
@@ -211,7 +211,7 @@ FlarmTrafficDetailsWidget::Update()
 
   // Set the dialog caption
   StringFormatUnsafe(tmp, "%s (%s)",
-                     _("FLARM Traffic Details"), target_id.Format(tmp_id));
+                     _("Traffic Details"), target_id.Format(tmp_id));
   dialog.SetCaption(tmp);
 
   const FlarmTraffic* target =
@@ -344,7 +344,7 @@ dlgFlarmTrafficDetailsShowModal(FlarmId id)
   const DialogLook &look = UIGlobals::GetDialogLook();
 
   WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
-                      look, _("FLARM Traffic Details"));
+                      look, _("Traffic Details"));
 
   FlarmTrafficDetailsWidget *widget =
     new FlarmTrafficDetailsWidget(dialog, id);

--- a/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
+++ b/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
@@ -235,9 +235,11 @@ FlarmTrafficDetailsWidget::Update()
   SetText(RADIO, value);
 
   // Fill the callsign field (+ registration)
-  // note: don't use target->Name here since it is not updated
-  //       yet if it was changed
-  const char* cs = info.callsign;
+  const char *cs = info.callsign;
+  if ((cs == nullptr || cs[0] == 0) &&
+      target != nullptr && target->HasName() && !StringIsEmpty(target->name))
+    cs = target->name.c_str();
+
   if (cs != nullptr && cs[0] != 0) {
     try {
       BasicStringBuilder<char> builder(tmp, ARRAY_SIZE(tmp));

--- a/src/FLARM/Computer.cpp
+++ b/src/FLARM/Computer.cpp
@@ -55,12 +55,22 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
         traffic.name = fname;
     }
 
+    if (traffic.absolute_location && traffic.location.IsValid() &&
+        basic.location_available) {
+      const GeoVector vec{basic.location, traffic.location};
+      traffic.relative_north = vec.distance * vec.bearing.cos();
+      traffic.relative_east = vec.distance * vec.bearing.sin();
+    }
+
     // Calculate distance
     traffic.distance = hypot(traffic.relative_north, traffic.relative_east);
 
     // Calculate Location
-    traffic.location_available = basic.location_available;
-    if (traffic.location_available) {
+    traffic.location_available = traffic.absolute_location
+      ? traffic.location.IsValid()
+      : basic.location_available;
+
+    if (!traffic.absolute_location && traffic.location_available) {
       traffic.location.latitude =
           Angle::Degrees(traffic.relative_north * north_to_latitude) +
           basic.location.latitude;
@@ -71,9 +81,14 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
     }
 
     // Calculate absolute altitude
-    traffic.altitude_available = basic.gps_altitude_available;
-    if (traffic.altitude_available)
-      traffic.altitude = traffic.relative_altitude + RoughAltitude(basic.gps_altitude);
+    if (!traffic.absolute_altitude) {
+      traffic.altitude_available = basic.gps_altitude_available;
+      if (traffic.altitude_available)
+        traffic.altitude = traffic.relative_altitude +
+          RoughAltitude(basic.gps_altitude);
+    } else if (basic.gps_altitude_available && traffic.altitude_available) {
+      traffic.relative_altitude = traffic.altitude - RoughAltitude(basic.gps_altitude);
+    }
 
     // Calculate average climb rate
     traffic.climb_rate_avg30s_available = traffic.altitude_available;

--- a/src/FLARM/Traffic.cpp
+++ b/src/FLARM/Traffic.cpp
@@ -73,4 +73,6 @@ FlarmTraffic::Update(const FlarmTraffic &other) noexcept
   rssi = other.rssi;
   rssi_available = other.rssi_available;
   no_track = other.no_track;
+  absolute_location = other.absolute_location;
+  absolute_altitude = other.absolute_altitude;
 }

--- a/src/FLARM/Traffic.hpp
+++ b/src/FLARM/Traffic.hpp
@@ -137,6 +137,15 @@ struct FlarmTraffic {
   /** Has the geographical location been calculated yet? */
   bool location_available;
 
+  /**
+   * Does this target have an absolute geographic location that was
+   * received from an external traffic source (e.g. ADS-B)?
+   *
+   * If true, FLARM post-processing must not overwrite #location from
+   * #relative_north/#relative_east.
+   */
+  bool absolute_location;
+
   /** Was the direction of the target received from the flarm or calculated? */
   bool track_received;
 
@@ -145,6 +154,15 @@ struct FlarmTraffic {
 
   /** Has the absolute altitude of the target been calculated yet? */
   bool altitude_available;
+
+  /**
+   * Does this target have an absolute altitude received from an
+   * external traffic source?
+   *
+   * If true, FLARM post-processing must not overwrite #altitude from
+   * #relative_altitude and ownship GPS altitude.
+   */
+  bool absolute_altitude;
 
   /** Was the turn rate of the target received from the flarm or calculated? */
   bool turn_rate_received;
@@ -182,6 +200,8 @@ struct FlarmTraffic {
     rssi = 0;
     rssi_available = false;
     no_track = false;
+    absolute_location = false;
+    absolute_altitude = false;
   }
 
   Angle Bearing() const noexcept {

--- a/src/Form/DataField/Enum.cpp
+++ b/src/Form/DataField/Enum.cpp
@@ -70,18 +70,15 @@ DataFieldEnum::replaceEnumText(std::size_t i, const char *Text) noexcept
 bool
 DataFieldEnum::AddChoice(unsigned id, const char *text,
                          const char *display_string,
-                         const char *help) noexcept
+                         const char *help)
 {
-  if (entries.full())
-    return false;
-
-  Entry &entry = entries.append();
+  Entry &entry = entries.emplace_back();
   entry.Set(id, text, display_string, help);
   return true;
 }
 
 void
-DataFieldEnum::AddChoices(const StaticEnumChoice *p) noexcept
+DataFieldEnum::AddChoices(const StaticEnumChoice *p)
 {
   while (p->display_string != nullptr) {
     const char *help = p->help;
@@ -95,19 +92,16 @@ DataFieldEnum::AddChoices(const StaticEnumChoice *p) noexcept
 
 unsigned
 DataFieldEnum::addEnumText(const char *Text, const char *display_string,
-                           const char *_help) noexcept
+                           const char *_help)
 {
-  if (entries.full())
-    return 0;
-
   unsigned i = entries.size();
-  Entry &entry = entries.append();
+  Entry &entry = entries.emplace_back();
   entry.Set(i, Text, display_string, _help);
   return i;
 }
 
 void
-DataFieldEnum::addEnumTexts(const char *const*list) noexcept
+DataFieldEnum::addEnumTexts(const char *const*list)
 {
   while (*list != nullptr)
     addEnumText(*list++);
@@ -190,7 +184,7 @@ DataFieldEnum::ModifyValue(const char *text) noexcept
 }
 
 int
-DataFieldEnum::SetStringAutoAdd(const char *text) noexcept
+DataFieldEnum::SetStringAutoAdd(const char *text)
 {
   int index = Find(text);
   if (index >= 0) {

--- a/src/Form/DataField/Enum.cpp
+++ b/src/Form/DataField/Enum.cpp
@@ -8,8 +8,6 @@
 
 #include <algorithm>
 
-#include <stdlib.h>
-
 DataFieldEnum::Entry::~Entry() noexcept
 {
   free(string);
@@ -23,6 +21,9 @@ DataFieldEnum::Entry::~Entry() noexcept
 void
 DataFieldEnum::Entry::SetString(const char *_string) noexcept
 {
+  if (_string == nullptr)
+    _string = "";
+
   free(string);
   if (display_string != string)
     free(display_string);
@@ -35,7 +36,11 @@ DataFieldEnum::Entry::SetDisplayString(const char *_string) noexcept
 {
   if (display_string != string)
     free(display_string);
-  display_string = strdup(_string);
+
+  if (_string == nullptr)
+    display_string = string;
+  else
+    display_string = strdup(_string);
 }
 
 void
@@ -72,6 +77,9 @@ DataFieldEnum::AddChoice(unsigned id, const char *text,
                          const char *display_string,
                          const char *help)
 {
+  if (text == nullptr)
+    return false;
+
   Entry &entry = entries.emplace_back();
   entry.Set(id, text, display_string, help);
   return true;
@@ -80,12 +88,17 @@ DataFieldEnum::AddChoice(unsigned id, const char *text,
 void
 DataFieldEnum::AddChoices(const StaticEnumChoice *p)
 {
+  if (p == nullptr)
+    return;
+
   while (p->display_string != nullptr) {
     const char *help = p->help;
     if (help != nullptr)
       help = gettext(help);
 
-    AddChoice(p->id, gettext(p->display_string), nullptr, help);
+    if (p->display_string[0] != '\0')
+      AddChoice(p->id, gettext(p->display_string), nullptr, help);
+
     ++p;
   }
 }
@@ -94,6 +107,9 @@ unsigned
 DataFieldEnum::addEnumText(const char *Text, const char *display_string,
                            const char *_help)
 {
+  if (Text == nullptr)
+    return entries.size();
+
   unsigned i = entries.size();
   Entry &entry = entries.emplace_back();
   entry.Set(i, Text, display_string, _help);
@@ -103,8 +119,15 @@ DataFieldEnum::addEnumText(const char *Text, const char *display_string,
 void
 DataFieldEnum::addEnumTexts(const char *const*list)
 {
-  while (*list != nullptr)
-    addEnumText(*list++);
+  if (list == nullptr)
+    return;
+
+  while (*list != nullptr) {
+    if ((*list)[0] != '\0')
+      addEnumText(*list);
+
+    ++list;
+  }
 }
 
 const char *
@@ -186,6 +209,9 @@ DataFieldEnum::ModifyValue(const char *text) noexcept
 int
 DataFieldEnum::SetStringAutoAdd(const char *text)
 {
+  if (text == nullptr || text[0] == '\0')
+    return -1;
+
   int index = Find(text);
   if (index >= 0) {
     SetIndex(index, false);

--- a/src/Form/DataField/Enum.hpp
+++ b/src/Form/DataField/Enum.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "Base.hpp"
-#include "util/StaticArray.hxx"
 
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 /**
  * A struct that is used for static initialisation of the enum list.
@@ -87,7 +87,7 @@ public:
   };
 
 private:
-  StaticArray<Entry, 128> entries;
+  std::vector<Entry> entries;
   std::size_t value = 0;
 
 public:
@@ -119,23 +119,23 @@ public:
 
   bool AddChoice(unsigned id, const char *text,
                  const char *display_string=nullptr,
-                 const char *help=nullptr) noexcept;
+                 const char *help=nullptr);
 
   /**
    * Add choices from the specified nullptr-terminated list (the last
    * entry has a nullptr display_string).  All display strings and help
    * texts are translated with gettext() by this method.
    */
-  void AddChoices(const StaticEnumChoice *list) noexcept;
+  void AddChoices(const StaticEnumChoice *list);
 
   bool addEnumText(const char *text, unsigned id,
-                   const char *help=nullptr) noexcept {
+                   const char *help=nullptr) {
     return AddChoice(id, text, nullptr, help);
   }
 
   unsigned addEnumText(const char *Text, const char *display_string=nullptr,
-                       const char *ItemHelpText=nullptr) noexcept;
-  void addEnumTexts(const char *const*list) noexcept;
+                       const char *ItemHelpText=nullptr);
+  void addEnumTexts(const char *const*list);
 
   /**
    * @return help of current enum item or nullptr if current item has no help
@@ -183,7 +183,7 @@ public:
    *
    * @return the new integer value
    */
-  int SetStringAutoAdd(const char *text) noexcept;
+  int SetStringAutoAdd(const char *text);
 
   void Sort(std::size_t startindex = 0) noexcept;
 

--- a/src/MapWindow/MapWindowTraffic.cpp
+++ b/src/MapWindow/MapWindowTraffic.cpp
@@ -95,13 +95,16 @@ MapWindow::DrawFLARMTraffic(Canvas &canvas,
 
   canvas.Select(*traffic_look.font);
 
-  // Circle through the FLARM targets
+  // Circle through the traffic targets
   for (const auto &traffic : flarm.list) {
     if (!traffic.location_available)
       continue;
 
-  // No position traffic (relative_east=0) does not make sense in map display
-    if (traffic.relative_east)
+    /* Historically, we skipped targets with relative vectors == 0 to
+       avoid drawing "no position" FLARM targets.  Absolute-position
+       traffic (e.g. ADS-B) may legitimately have relative vectors not
+       computed yet, so allow those as well. */
+    if (traffic.relative_east != 0 || traffic.absolute_location)
       DrawFlarmTraffic(canvas, projection, traffic_look, false,
                        aircraft_pos, traffic);
   }
@@ -110,8 +113,7 @@ MapWindow::DrawFLARMTraffic(Canvas &canvas,
     for (const auto &[id, traffic] : fading) {
       assert(traffic.location_available);
 
-  // No position traffic (relative_east=0) does not make sense in map display
-      if (traffic.relative_east)
+      if (traffic.relative_east != 0 || traffic.absolute_location)
         DrawFlarmTraffic(canvas, projection, traffic_look, true,
                          aircraft_pos, traffic);
     }

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -328,10 +328,15 @@ Draw(Canvas &canvas, PixelRect rc,
   if (info.pilot != nullptr)
     title_string = info.pilot;
   else
-    title_string = _("FLARM Traffic");
+    title_string = _("Traffic");
 
   // Append name to the title, if it exists
   const char *callsign = info.callsign;
+  if ((callsign == nullptr || StringIsEmpty(callsign)) &&
+      traffic != nullptr && traffic->HasName() &&
+      !StringIsEmpty(traffic->name))
+    callsign = traffic->name.c_str();
+
   if (callsign != nullptr && !StringIsEmpty(callsign)) {
     title_string.append(", ");
     title_string.append(callsign);

--- a/src/SystemSettings.cpp
+++ b/src/SystemSettings.cpp
@@ -3,6 +3,7 @@
 
 #include "SystemSettings.hpp"
 #include "Asset.hpp"
+#include "Device/Features.hpp"
 
 void
 SystemSettings::SetDefaults()
@@ -11,7 +12,7 @@ SystemSettings::SetDefaults()
     devices[i].Clear();
 
   if (IsAndroid() || IsApple()) {
-    devices[0].port_type = DeviceConfig::PortType::INTERNAL;
+    devices[NUMDEV - 1].port_type = DeviceConfig::PortType::INTERNAL;
   } else {
     devices[0].port_type = DeviceConfig::PortType::SERIAL;
 #ifdef _WIN32

--- a/test/src/TestGDL90.cpp
+++ b/test/src/TestGDL90.cpp
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "util/CRC16CCITT.hpp"
+#include "TestUtil.hpp"
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+
+static bool
+Unescape(const uint8_t *src, std::size_t size,
+         std::vector<uint8_t> &dest) noexcept
+{
+  dest.clear();
+  dest.reserve(size);
+
+  for (std::size_t i = 0; i < size; ++i) {
+    uint8_t b = src[i];
+    if (b != GDL90_ESCAPE) {
+      dest.push_back(b);
+      continue;
+    }
+
+    if (++i >= size)
+      return false;
+
+    dest.push_back(src[i] ^ GDL90_ESCAPE_XOR);
+  }
+
+  return true;
+}
+
+static uint16_t
+Gdl90Crc16(const uint8_t *data, std::size_t size) noexcept
+{
+  /* CRC-CCITT update function per GDL90 ICD 2.2.3 (table-driven). */
+  uint16_t crc = 0;
+
+  for (std::size_t i = 0; i < size; ++i)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ data[i];
+
+  return crc;
+}
+
+static constexpr uint16_t
+ReadLE16(const uint8_t *p) noexcept
+{
+  return uint16_t(p[0]) | (uint16_t(p[1]) << 8);
+}
+
+static constexpr uint16_t
+ReadBE16(const uint8_t *p) noexcept
+{
+  return (uint16_t(p[0]) << 8) | uint16_t(p[1]);
+}
+
+static constexpr uint32_t
+ReadBE24(const uint8_t *p) noexcept
+{
+  return (uint32_t(p[0]) << 16) | (uint32_t(p[1]) << 8) | uint32_t(p[2]);
+}
+
+static constexpr int32_t
+SignExtend24(uint32_t value) noexcept
+{
+  value &= 0x00ffffff;
+  if ((value & 0x00800000) != 0)
+    return int32_t(value | 0xff000000);
+  return int32_t(value);
+}
+
+static constexpr double
+SemiCircles24ToDegrees(int32_t value) noexcept
+{
+  return double(value) * (180.0 / double(1u << 23));
+}
+
+static void
+AppendEscaped(std::vector<uint8_t> &out, uint8_t b)
+{
+  if (b == GDL90_FLAG || b == GDL90_ESCAPE) {
+    out.push_back(GDL90_ESCAPE);
+    out.push_back(b ^ GDL90_ESCAPE_XOR);
+  } else
+    out.push_back(b);
+}
+
+static std::vector<uint8_t>
+BuildFrame(uint8_t msg_id, const uint8_t *payload, std::size_t payload_size)
+{
+  std::vector<uint8_t> body;
+  body.reserve(1 + payload_size + 2);
+
+  body.push_back(msg_id);
+  body.insert(body.end(), payload, payload + payload_size);
+
+  const uint16_t crc = Gdl90Crc16(body.data(), body.size());
+  body.push_back(uint8_t(crc & 0xff));
+  body.push_back(uint8_t(crc >> 8));
+
+  std::vector<uint8_t> framed;
+  framed.reserve(2 + body.size() * 2);
+  framed.push_back(GDL90_FLAG);
+  for (uint8_t b : body)
+    AppendEscaped(framed, b);
+  framed.push_back(GDL90_FLAG);
+  return framed;
+}
+
+struct DecodedTraffic {
+  uint8_t address_type;
+  uint32_t participant_address;
+  double lat_deg, lon_deg;
+  int altitude_ft;
+  char callsign[9];
+};
+
+static bool
+DecodeTraffic27(const uint8_t *payload, std::size_t size,
+                DecodedTraffic &out) noexcept
+{
+  if (size < 27)
+    return false;
+
+  out.address_type = payload[0] >> 4;
+  out.participant_address = ReadBE24(payload + 1);
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload + 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload + 7));
+  out.lat_deg = SemiCircles24ToDegrees(lat_raw);
+  out.lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  const uint16_t alt_word = ReadBE16(payload + 10);
+  const uint16_t altitude_code = alt_word >> 4;
+  if (altitude_code == 0xfff)
+    return false;
+
+  out.altitude_ft = int(altitude_code) * 25 - 1000;
+
+  for (unsigned i = 0; i < 8; ++i)
+    out.callsign[i] = (char)payload[18 + i];
+  out.callsign[8] = 0;
+
+  return true;
+}
+
+static void
+TestHeartbeatExample() noexcept
+{
+  /* ICD 2.2.4 example (framed + CRC): 7E 00 81 41 DB D0 08 02 B3 8B 7E
+     CRC is little endian: 0x8BB3 (bytes B3 8B) */
+  static constexpr uint8_t frame[] = {
+    0x7e, 0x00, 0x81, 0x41, 0xdb, 0xd0, 0x08, 0x02, 0xb3, 0x8b, 0x7e,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(frame[0] == GDL90_FLAG);
+  ok1(frame[std::size(frame) - 1] == GDL90_FLAG);
+
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+  ok1(unescaped.size() == 1 + 6 + 2);
+  ok1(unescaped[0] == 0x00);
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+}
+
+static void
+TestTrafficExample() noexcept
+{
+  /* Example Traffic frame from a known-good implementation (includes one
+     escaped byte 0x7D 0x5D -> 0x7D in payload). */
+  static constexpr uint8_t frame[] = {
+    0x7E, 0x14, 0x00, 0x00, 0x00, 0x00, 0x18, 0x7D, 0x5D, 0xF5,
+    0xBD, 0x1F, 0xB4, 0x09, 0x49, 0x88, 0x27, 0x40, 0x00, 0x82,
+    0x01, 0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00,
+    0x5E, 0x66, 0x7E,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x14);
+  const uint8_t *payload = unescaped.data() + 1;
+  const std::size_t payload_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic t{};
+  ok1(DecodeTraffic27(payload, payload_len, t));
+
+  ok1(between(t.lat_deg, 34.0, 35.0));
+  ok1(between(t.lon_deg, -95.0, -93.0));
+  ok1(t.altitude_ft == 2700);
+}
+
+static void
+TestTrafficExampleFromIcd() noexcept
+{
+  /* GDL90 Public ICD Rev A, §3.5.2 / Table 12 "Traffic Report Example".
+     This table provides byte values (including Message ID) but not a framed
+     example; we compute CRC and build a framed message here. */
+  static constexpr uint8_t payload[] = {
+    0x00,             // st
+    0xAB, 0x45, 0x49, // aa aa aa
+    0x1F, 0xEF, 0x15, // ll ll ll
+    0xA8, 0x89, 0x78, // nn nn nn
+    0x0F,             // dd
+    0x09,             // dm
+    0xA9,             // ia
+    0x07,             // hh
+    0xB0,             // hv
+    0x01,             // vv
+    0x20,             // tt
+    0x01,             // ee
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20, // cc.. (N825V   )
+    0x00,             // px
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  std::vector<uint8_t> unescaped;
+  ok1(frame.front() == GDL90_FLAG);
+  ok1(frame.back() == GDL90_FLAG);
+  ok1(Unescape(frame.data() + 1, frame.size() - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x14);
+  const uint8_t *pl = unescaped.data() + 1;
+  const std::size_t pl_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic t{};
+  ok1(DecodeTraffic27(pl, pl_len, t));
+
+  ok1(t.participant_address == 0xAB4549);
+  ok1(between(t.lat_deg, 44.90, 44.92));
+  ok1(between(t.lon_deg, -123.01, -122.98));
+  ok1(t.altitude_ft == 5000);
+  ok1(std::string_view(t.callsign, 5) == "N825V");
+}
+
+static void
+TestOwnshipExample() noexcept
+{
+  /* Ownship Report sample frame (framed + CRC).
+     Known-good vector from a GDL90 implementation test suite. */
+  static constexpr uint8_t frame[] = {
+    0x7E, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x15, 0xA7, 0xE5, 0xBA,
+    0x47, 0x99, 0x08, 0xC9, 0x88, 0xFF, 0xE0, 0x00, 0x80, 0x01,
+    0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00, 0x7B,
+    0xE5, 0x7E,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x0A);
+  const uint8_t *payload = unescaped.data() + 1;
+  const std::size_t payload_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic o{};
+  ok1(DecodeTraffic27(payload, payload_len, o));
+
+  ok1(between(o.lat_deg, 30.0, 31.0));
+  ok1(between(o.lon_deg, -99.0, -98.0));
+  ok1(o.altitude_ft == 2500);
+}
+
+int main()
+{
+  plan_tests(4 + 9 + 2 + 9 + 7);
+
+  TestHeartbeatExample();
+  TestTrafficExample();
+  TestTrafficExampleFromIcd();
+  TestOwnshipExample();
+
+  return exit_status();
+}
+

--- a/test/src/TestGDL90Driver.cpp
+++ b/test/src/TestGDL90Driver.cpp
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/GDL90/Driver.hpp"
+#include "FLARM/Id.hpp"
+#include "NMEA/Info.hpp"
+#include "TestUtil.hpp"
+#include "util/CRC16CCITT.hpp"
+
+#include <cstdint>
+#include <vector>
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+
+static uint16_t
+Gdl90Crc16(const uint8_t *data, std::size_t size) noexcept
+{
+  /* CRC-CCITT update function per GDL90 ICD 2.2.3 (table-driven). */
+  uint16_t crc = 0;
+  for (std::size_t i = 0; i < size; ++i)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ data[i];
+
+  return crc;
+}
+
+static void
+AppendEscaped(std::vector<uint8_t> &out, uint8_t b)
+{
+  if (b == GDL90_FLAG || b == GDL90_ESCAPE) {
+    out.push_back(GDL90_ESCAPE);
+    out.push_back(b ^ GDL90_ESCAPE_XOR);
+  } else
+    out.push_back(b);
+}
+
+static std::vector<uint8_t>
+BuildFrame(uint8_t msg_id, const uint8_t *payload, std::size_t payload_size)
+{
+  std::vector<uint8_t> body;
+  body.reserve(1 + payload_size + 2);
+
+  body.push_back(msg_id);
+  body.insert(body.end(), payload, payload + payload_size);
+
+  const uint16_t crc = Gdl90Crc16(body.data(), body.size());
+  body.push_back(uint8_t(crc & 0xff));
+  body.push_back(uint8_t(crc >> 8));
+
+  std::vector<uint8_t> framed;
+  framed.reserve(2 + body.size() * 2);
+  framed.push_back(GDL90_FLAG);
+  for (uint8_t b : body)
+    AppendEscaped(framed, b);
+  framed.push_back(GDL90_FLAG);
+  return framed;
+}
+
+static std::vector<uint8_t>
+BuildFrameBadCrc(uint8_t msg_id, const uint8_t *payload,
+                 std::size_t payload_size)
+{
+  auto frame = BuildFrame(msg_id, payload, payload_size);
+
+  /* flip one byte inside the frame body to make CRC invalid */
+  if (frame.size() >= 4)
+    frame[2] ^= 0x01;
+
+  return frame;
+}
+
+static void
+Feed(GDL90Device &dev, NMEAInfo &info, const std::vector<uint8_t> &bytes)
+{
+  const auto *p = reinterpret_cast<const std::byte *>(bytes.data());
+  dev.DataReceived({p, bytes.size()}, info);
+}
+
+static void
+TestBadCrcIgnored() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B','A','D','C','R','C',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrameBadCrc(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(!info.alive);
+  ok1(info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestResyncAfterBadCrc() noexcept
+{
+  static constexpr uint8_t payload_bad[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B','A','D',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  static constexpr uint8_t payload_good[] = {
+    0x00,
+    0x0A, 0x0B, 0x0C,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'G','O','O','D',' ',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrameBadCrc(0x14, payload_bad, sizeof(payload_bad));
+  const auto good = BuildFrame(0x14, payload_good, sizeof(payload_good));
+  bytes.insert(bytes.end(), good.begin(), good.end());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestNoisePrefix() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x11, 0x22, 0x33,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'N','O','I','S','E',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrame(0x14, payload, sizeof(payload));
+  bytes.insert(bytes.begin(), {0x00, 0x01, 0x02, 0x7d, 0x20, 0x55});
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestTwoFramesOneChunk() noexcept
+{
+  static constexpr uint8_t payload_a[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'A',' ',' ',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  static constexpr uint8_t payload_b[] = {
+    0x00,
+    0x04, 0x05, 0x06,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B',' ',' ',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrame(0x14, payload_a, sizeof(payload_a));
+  const auto b = BuildFrame(0x14, payload_b, sizeof(payload_b));
+  bytes.insert(bytes.end(), b.begin(), b.end());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestEscapingInPayload() noexcept
+{
+  /* Force escaping via participant_address bytes 0x7e and 0x7d. */
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x7E, 0x7D, 0x01,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'E','S','C',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+  const FlarmId expected = FlarmId::Parse("7E7D01", nullptr);
+  ok1(info.flarm.traffic.FindTraffic(expected) != nullptr);
+}
+
+static void
+TestOwnshipDriver() noexcept
+{
+  /* Ownship Report framed vector (same as TestGDL90). */
+  static constexpr uint8_t ownship_frame[] = {
+    0x7E, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x15, 0xA7, 0xE5, 0xBA,
+    0x47, 0x99, 0x08, 0xC9, 0x88, 0xFF, 0xE0, 0x00, 0x80, 0x01,
+    0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00, 0x7B,
+    0xE5, 0x7E,
+  };
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  const auto *p = reinterpret_cast<const std::byte *>(ownship_frame);
+  dev.DataReceived({p, sizeof(ownship_frame)}, info);
+
+  ok1(info.alive);
+  ok1(info.location_available);
+  ok1(between(info.location.latitude.Degrees(), 30.0, 31.0));
+  ok1(between(info.location.longitude.Degrees(), -99.0, -98.0));
+  ok1(info.pressure_altitude_available);
+}
+
+static void
+TestTrafficDriver() noexcept
+{
+  /* Traffic Report payload (27 bytes) with ICAO = 0xAB4549.
+     The bytes are from the GDL90 report layout examples. */
+  static constexpr uint8_t payload[] = {
+    0x00,             // status/address type nibble
+    0xAB, 0x45, 0x49, // participant address (big-endian 24-bit)
+    0x1F, 0xEF, 0x15, // latitude
+    0xA8, 0x89, 0x78, // longitude
+    0x0F, 0x09,       // altitude/misc (big-endian)
+    0xA9,             // NACp/NIC
+    0x07, 0xB0, 0x01, // velocity
+    0x20,             // track
+    0x01,             // emitter category
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20, // callsign
+    0x00,             // emergency/reserved
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("AB4549", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+  ok1(t != nullptr && t->location_available);
+  ok1(t != nullptr && t->name.equals("N825V"));
+}
+
+static void
+TestChunkedOwnshipFrame() noexcept
+{
+  /* Feed one framed Ownship Report in small chunks to validate buffering. */
+  static constexpr uint8_t ownship_frame[] = {
+    0x7E, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x15, 0xA7, 0xE5, 0xBA,
+    0x47, 0x99, 0x08, 0xC9, 0x88, 0xFF, 0xE0, 0x00, 0x80, 0x01,
+    0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00, 0x7B,
+    0xE5, 0x7E,
+  };
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  const auto *bytes = reinterpret_cast<const std::byte *>(ownship_frame);
+  dev.DataReceived({bytes, 3}, info);
+  ok1(!info.location_available);
+
+  dev.DataReceived({bytes + 3, 5}, info);
+  ok1(!info.location_available);
+
+  dev.DataReceived({bytes + 8, sizeof(ownship_frame) - 8}, info);
+  ok1(info.location_available);
+  ok1(between(info.location.latitude.Degrees(), 30.0, 31.0));
+}
+
+static void
+TestNegativeCoordinates() noexcept
+{
+  /* Validate sign-extension (ICD §3.5.1.3) using -45° lat/lon (0xE0 00 00). */
+  static constexpr uint8_t payload[] = {
+    0x00,             // status/address type nibble
+    0x01, 0x02, 0x03, // participant address (big-endian 24-bit)
+    0xE0, 0x00, 0x00, // latitude  -45.0
+    0xE0, 0x00, 0x00, // longitude -45.0
+    0x03, 0xC0,       // altitude/misc (big-endian): 500ft => (500+1000)/25=60 => 0x03C, +m=0
+    0x00,             // NACp/NIC
+    0x00, 0x10, 0x00, // velocity (arbitrary, valid)
+    0x00,             // track
+    0x01,             // emitter category
+    'T','E','S','T',' ',' ',' ',' ', // callsign
+    0x00,             // emergency/reserved
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("010203", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+
+  ok1(between(t->location.latitude.Degrees(), -46.0, -44.0));
+  ok1(between(t->location.longitude.Degrees(), -46.0, -44.0));
+}
+
+static void
+TestUnavailableFields() noexcept
+{
+  /* Exercise special values: altitude=0xFFF (invalid), hvel=0xFFF (N/A),
+     vvel=0x800 (N/A), track=0xFF (N/A). */
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x0A, 0x0B, 0x0C,
+    0x20, 0x00, 0x00, // lat +45
+    0x20, 0x00, 0x00, // lon +45
+    0xFF, 0xF0,       // altitude_code=0xFFF, m=0
+    0x00,
+    0xFF, 0xF8, 0x00, // h=0xFFF, v=0x800
+    0xFF,             // track unavailable
+    0x01,
+    'N','O','N','E',' ',' ',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("0A0B0C", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+
+  ok1(t != nullptr && !t->altitude_available);
+  ok1(t != nullptr && !t->speed_received);
+  ok1(t != nullptr && !t->climb_rate_received);
+  ok1(t != nullptr && !t->track_received);
+}
+
+static void
+TestOversizeFrameDropped() noexcept
+{
+  /* Ensure pathological frames don't cause excessive work/allocations. */
+  std::vector<uint8_t> payload(2000, 0);
+  const auto frame = BuildFrame(0x14, payload.data(), payload.size());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(!info.alive);
+  ok1(info.flarm.traffic.IsEmpty());
+}
+
+int main()
+{
+  plan_tests(2 + 2 + 2 + 2 + 3 + 5 + 5 + 4 + 4 + 6 + 2);
+
+  TestBadCrcIgnored();
+  TestResyncAfterBadCrc();
+  TestNoisePrefix();
+  TestTwoFramesOneChunk();
+  TestEscapingInPayload();
+  TestOwnshipDriver();
+  TestTrafficDriver();
+  TestChunkedOwnshipFrame();
+  TestNegativeCoordinates();
+  TestUnavailableFields();
+  TestOversizeFrameDropped();
+
+  return exit_status();
+}
+


### PR DESCRIPTION
## Summary
- Add a new GDL90 device driver (heartbeat/ownship/traffic) and wire it into the build and device registry.
- Decode GDL90 traffic into XCSoar's traffic list with ADS-B/TIS-B source tagging and callsign extraction.
- Preserve absolute-position traffic in FLARM post-processing and improve UI labels/callsign fallbacks for non-FLARM traffic sources.

## Test plan
- Build: `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- Unit tests: `output/UNIX/bin/TestGDL90` and `output/UNIX/bin/TestGDL90Driver`
- Manual: Configure a UDP listener device with driver `GDL90` and verify ownship + traffic are displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for GDL90 device driver for additional traffic data integration.
  * InfoBox setup now supports all available types without limitation.
  * Smoother audio frequency transitions for improved variometer feedback.

* **Enhancements**
  * Status display now shows G-load availability and specific variometer source type.
  * Traffic details dialog provides improved callsign fallback information.
  * Android/iOS default device configuration updated for built-in sensors.
  * Variometer display distinguishes between Netto, Total Energy, and Uncompensated sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->