### PR TITLE
Device: Add GDL90 traffic input

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -27,6 +27,10 @@ Version 7.45 - not yet released
   - restore FFVV NetCoupe contest optimisation #2330
 * data files
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
+* devices
+  - add GDL 90 input driver (standard ADS-B traffic and ownship over serial or
+    UDP; optional ForeFlight geometric altitude and AHRS; horizontal/vertical
+    traffic filters) #2356
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -98,6 +98,10 @@ THERMALEXPRESS_SOURCES = \
 STRATUX_SOURCES = \
 	$(DRIVER_SRC_DIR)/Stratux/Driver.cpp
 
+GDL90_SOURCES = \
+	$(DRIVER_SRC_DIR)/GDL90/GDL90Driver.cpp \
+	$(DRIVER_SRC_DIR)/GDL90/Register.cpp
+
 DRIVER_SOURCES = \
 	$(SRC)/Device/Driver.cpp \
 	$(SRC)/Device/Register.cpp \
@@ -113,6 +117,7 @@ DRIVER_SOURCES = \
 	$(XCTRACER_SOURCES) \
 	$(THERMALEXPRESS_SOURCES) \
 	$(STRATUX_SOURCES) \
+	$(GDL90_SOURCES) \
 	$(DRIVER_SRC_DIR)/AltairPro.cpp \
 	$(DRIVER_SRC_DIR)/BorgeltB50.cpp \
 	$(DRIVER_SRC_DIR)/XCVario.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -30,6 +30,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Device/ManageFlarmDialog.cpp \
 	$(SRC)/Dialogs/Device/BlueFly/BlueFlyConfigurationDialog.cpp \
 	$(SRC)/Dialogs/Device/Stratux/ConfigurationDialog.cpp \
+	$(SRC)/Dialogs/Device/GDL90/ConfigurationDialog.cpp \
 	$(SRC)/Dialogs/Device/ManageI2CPitotDialog.cpp \
 	$(SRC)/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp \
 	$(SRC)/Dialogs/Device/LX/LXNAVVarioConfigWidget.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -115,6 +115,8 @@ TEST_NAMES = \
 	TestTimeFormatter \
 	TestIGCFilenameFormatter \
 	TestNMEAFormatter \
+	TestGDL90 \
+	TestGDL90Driver \
 	TestLXNToIGC \
 	TestLeastSquares \
 	TestHexString \
@@ -154,6 +156,23 @@ TEST_CRC8_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestCRC8.cpp
 $(eval $(call link-program,TestCRC8,TEST_CRC8))
+
+TEST_GDL90_SOURCES = \
+	$(SRC)/util/CRC16CCITT.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestGDL90.cpp
+$(eval $(call link-program,TestGDL90,TEST_GDL90))
+
+TEST_GDL90_DRIVER_SOURCES = \
+	$(SRC)/util/CRC16CCITT.cpp \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(SRC)/Computer/ClimbAverageCalculator.cpp \
+	$(TEST_SRC_DIR)/FakeGeoidNonZero.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestGDL90Driver.cpp
+TEST_GDL90_DRIVER_DEPENDS = DRIVER NMEA FLARM GLIDE GEO TIME MATH UTIL UNITS
+$(eval $(call link-program,TestGDL90Driver,TEST_GDL90_DRIVER))
 
 TEST_LEASTSQUARES_SOURCES = \
 	$(SRC)/Math/LeastSquares.cpp \
@@ -1471,6 +1490,7 @@ RUN_FLIGHT_LIST_SOURCES = \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeDialogs.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/FakeGeoid.cpp \
 	$(TEST_SRC_DIR)/DebugPort.cpp \
 	$(TEST_SRC_DIR)/RunFlightList.cpp
 RUN_FLIGHT_LIST_DEPENDS = DRIVER PORT LIBNMEA ASYNC LIBNET OPERATION IO OS THREAD GEO TIME MATH UTIL
@@ -1494,6 +1514,7 @@ RUN_DOWNLOAD_FLIGHT_SOURCES = \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
 	$(TEST_SRC_DIR)/FakeDialogs.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/FakeGeoid.cpp \
 	$(TEST_SRC_DIR)/DebugPort.cpp \
 	$(TEST_SRC_DIR)/RunDownloadFlight.cpp
 RUN_DOWNLOAD_FLIGHT_DEPENDS = DRIVER PORT ASYNC LIBNMEA LIBNET OPERATION IO OS THREAD GEO TIME MATH UTIL

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -5,7 +5,7 @@
 
 #include "Features.hpp"
 #include "Config.hpp"
-#include "Device/Util/LineSplitter.hpp"
+#include "Util/LineSplitter.hpp"
 #include "Port/State.hpp"
 #include "Port/Listener.hpp"
 #include "Device/Parser.hpp"

--- a/src/Device/Dispatcher.hpp
+++ b/src/Device/Dispatcher.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "Device/Util/LineHandler.hpp"
+#include "Util/LineHandler.hpp"
 
 class MultipleDevices;
 

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -131,7 +131,7 @@ ParsePFLAA(NMEAInputLine &line, TrafficList &flarm, TimeStamp clock, RangeFilter
 
   // PFLAA,<AlarmLevel>,<RelativeNorth>,<RelativeEast>,<RelativeVertical>,
   //   <IDType>,<ID>,<Track>,<TurnRate>,<GroundSpeed>,<ClimbRate>,<AcftType>
-  FlarmTraffic traffic;
+  FlarmTraffic traffic{};
   traffic.alarm_level = (FlarmTraffic::AlarmType)
     line.Read((int)FlarmTraffic::AlarmType::NONE);
 

--- a/src/Device/Driver/GDL90.hpp
+++ b/src/Device/Driver/GDL90.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+extern const struct DeviceRegister gdl90_driver;
+

--- a/src/Device/Driver/GDL90/Driver.cpp
+++ b/src/Device/Driver/GDL90/Driver.cpp
@@ -1,0 +1,850 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Driver.hpp"
+
+#include "FLARM/List.hpp"
+#include "FLARM/Id.hpp"
+#include "Geo/Geoid.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Geo/GeoVector.hpp"
+#include "NMEA/Info.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/ProfileMap.hpp"
+#include "Units/System.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "util/CRC16CCITT.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdio>
+
+/*
+ * GDL90 driver — see Protocol.md in this directory for framing, endianness,
+ * and payload byte maps.
+ *
+ * References:
+ * - Garmin "GDL 90 Data Interface Specification", 560-1058-00 Rev A (2007-06-05)
+ *   (a.k.a. the public GDL90 ICD)
+ *   - §2.2.1 framing / byte-stuffing: 0x7E flag, 0x7D escape, XOR 0x20
+ *   - §2.2.2 message id: MSB reserved, must be zero
+ *   - §2.2.3 CRC: CRC-CCITT, table-driven update shown in the document
+ *   - §3.1 Heartbeat (msg id 0x00)
+ *   - §3.4 Ownship Report (msg id 0x0A), format per §3.5.1
+ *   - §3.5 Traffic Report (msg id 0x14), format per §3.5.1
+ *
+ * Note: Multi-byte fields in report payloads are big-endian unless stated
+ * otherwise (ICD §3, "multi-byte fields are transmitted most-significant
+ * byte first"). The CRC field itself is little-endian (ICD §2.2.1/§2.2.3).
+ */
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+static constexpr std::size_t GDL90_MAX_FRAME = 1024;
+static constexpr std::size_t GDL90_BUFFER_TRIM_SIZE = 4096;
+static constexpr std::size_t GDL90_UNESCAPED_INITIAL_CAPACITY = 256;
+
+/* Message identifiers (ICD §2.2.2, §3) */
+static constexpr uint8_t GDL90_MSG_HEARTBEAT = 0x00;
+static constexpr uint8_t GDL90_MSG_OWNSHIP = 0x0a;
+static constexpr uint8_t GDL90_MSG_OWNSHIP_GEOM_ALT = 0x0b;
+static constexpr uint8_t GDL90_MSG_TRAFFIC = 0x14;
+static constexpr uint8_t GDL90_MSG_FOREFLIGHT = 0x65;
+
+/* Minimum logical frame: message id + 2-byte little-endian CRC (payload may
+   be empty). Same lower bound applies to stuffed bytes when no escapes. */
+static constexpr std::size_t GDL90_MIN_FRAME_BYTES = 3;
+
+static constexpr uint8_t GDL90_MSG_ID_RESERVED_BIT = 0x80;
+
+/* Heartbeat payload (ICD §3.1): status1, status2, LE sec16, msg counts = 6 */
+static constexpr std::size_t GDL90_HEARTBEAT_MIN_PAYLOAD = 6;
+static constexpr uint8_t GDL90_HEARTBEAT_UTC_VALID_MASK = 0x01;
+static constexpr unsigned GDL90_HEARTBEAT_SECONDS_BIT16_SHIFT = 7;
+static constexpr unsigned GDL90_HEARTBEAT_SECONDS_HIGH_BIT_MASK = 0x01u;
+static constexpr unsigned GDL90_SECONDS_PER_DAY = 24u * 60u * 60u;
+
+/* Traffic / Ownship report payload (ICD §3.5.1), 27 bytes */
+static constexpr std::size_t GDL90_REPORT_PAYLOAD_BYTES = 27;
+/* Callsign field starts at byte 18 (ICD §3.5.1.11) */
+static constexpr std::size_t GDL90_REPORT_CALLSIGN_OFFSET = 18;
+/* Callsign is 8 bytes → minimum payload size 26 (last index 25) */
+static constexpr std::size_t GDL90_TRAFFIC_MIN_PAYLOAD_FOR_CALLSIGN = 26;
+
+/* Pressure altitude in report (ICD §3.5.1): 25 ft steps, −1000 ft offset */
+static constexpr int GDL90_PRESSURE_ALT_FT_LSB = 25;
+static constexpr int GDL90_PRESSURE_ALT_FT_OFFSET = 1000;
+static constexpr uint16_t GDL90_PRESSURE_ALT_INVALID = 0xfff;
+static constexpr unsigned GDL90_ALT_WORD_CODE_SHIFT = 4;
+static constexpr uint16_t GDL90_ALT_WORD_MISC_MASK = 0x0f;
+
+/* Ownship Geometric Altitude (ICD §3.6): int16, 5 ft per LSB */
+static constexpr int GDL90_GEOM_ALT_FT_RESOLUTION = 5;
+static constexpr std::size_t GDL90_GEOM_ALT_PAYLOAD_BYTES = 4;
+
+static constexpr double GDL90_LAT_MIN_DEG = -90;
+static constexpr double GDL90_LAT_MAX_DEG = 90;
+static constexpr double GDL90_LON_MIN_DEG = -180;
+static constexpr double GDL90_LON_MAX_DEG = 180;
+
+/* 24-bit semicircle fraction (ICD §3.5.1.3) */
+static constexpr unsigned GDL90_SEMICIRCLE_FRACTION_BITS = 23;
+
+static constexpr uint32_t GDL90_SIGN_EXT24_VALUE_MASK = 0x00ffffff;
+static constexpr uint32_t GDL90_SIGN_EXT24_SIGN_BIT = 0x00800000;
+static constexpr uint32_t GDL90_SIGN_EXT24_OR_MASK = 0xff000000;
+
+/* Velocity triplet (BE24): upper 12 bits = knots, lower 12 = vert rate. */
+static constexpr unsigned GDL90_VEL_HORIZONTAL_SHIFT = 12;
+static constexpr uint16_t GDL90_VEL_HORIZONTAL_MASK = 0x0fff;
+static constexpr uint16_t GDL90_VEL_HORIZONTAL_INVALID = 0x0fff;
+static constexpr uint16_t GDL90_VEL_VERTICAL_MASK = 0x0fff;
+/* Vertical field 0x800 = no vertical rate information (ICD §3.5.1) */
+static constexpr uint16_t GDL90_VEL_VERTICAL_NO_INFO = 0x0800;
+static constexpr uint16_t GDL90_VEL12_SIGN_BIT = 0x0800;
+static constexpr int GDL90_VEL12_SIGN_EXTEND = 0x1000;
+static constexpr int GDL90_VERTICAL_RATE_FPM_PER_LSB = 64;
+static constexpr double GDL90_FPM_TO_METERS_PER_SECOND = 0.00508;
+
+/* Track: byte scale 256/360° (ICD §3.5.1); status in altitude word low bits */
+static constexpr uint8_t GDL90_TRACK_BYTE_INVALID = 0xff;
+static constexpr uint8_t GDL90_TRACK_STATUS_MASK = 0x03;
+static constexpr double GDL90_TRACK_DEG_PER_BYTE = 360.0 / 256.0;
+
+/* Callsign field (ICD §3.5.1.11) */
+static constexpr std::size_t GDL90_CALLSIGN_CHAR_COUNT = 8;
+static constexpr uint8_t GDL90_CALLSIGN_ASCII_MIN = 0x20;
+static constexpr uint8_t GDL90_CALLSIGN_ASCII_MAX = 0x7f;
+
+static constexpr uint32_t GDL90_ICAO_ADDRESS_MASK = 0xffffff;
+
+/* Default traffic filter limits if profile missing (metres) */
+static constexpr uint16_t GDL90_DEFAULT_FILTER_HRANGE_M = 20000;
+static constexpr uint16_t GDL90_DEFAULT_FILTER_VRANGE_M = 2000;
+
+/* Participant address type high nibble (ICD §3.5.1.2) */
+static constexpr uint8_t GDL90_ADDR_ADSB_ICAO = 0;
+static constexpr uint8_t GDL90_ADDR_ADSB_SELF_ASSIGNED = 1;
+static constexpr uint8_t GDL90_ADDR_TISB_ICAO = 2;
+static constexpr uint8_t GDL90_ADDR_TISB_TRACK_FILE = 3;
+static constexpr uint8_t GDL90_ADDR_TISB_SURFACE_VEHICLE = 4;
+static constexpr uint8_t GDL90_ADDR_ADSR_ICAO = 6;
+
+/* ForeFlight GDL90 extensions (sub-ids, not in public Garmin ICD) */
+static constexpr uint8_t GDL90_FOREFLIGHT_SUB_ID_MSG = 0x00;
+static constexpr uint8_t GDL90_FOREFLIGHT_SUB_AHRS = 0x01;
+static constexpr uint8_t GDL90_FOREFLIGHT_ID_VERSION = 1;
+static constexpr std::size_t GDL90_FOREFLIGHT_ID_MIN_PAYLOAD = 38;
+static constexpr std::size_t GDL90_FOREFLIGHT_CAPABILITIES_OFFSET = 34;
+static constexpr uint32_t GDL90_FOREFLIGHT_CAP_GEO_ALT_IS_MSL = 0x00000001u;
+static constexpr std::size_t GDL90_FOREFLIGHT_AHRS_MIN_PAYLOAD = 11;
+static constexpr uint16_t GDL90_FOREFLIGHT_ANGLE_INVALID = 0x7fff;
+static constexpr uint16_t GDL90_FOREFLIGHT_HEADING_INVALID = 0xffff;
+static constexpr uint16_t GDL90_FOREFLIGHT_HEADING_VALUE_MASK = 0x7fff;
+static constexpr uint16_t GDL90_FOREFLIGHT_AIRSPEED_INVALID = 0xffff;
+
+#ifdef RASPBERRY_PI
+static constexpr bool GDL90_DEFAULT_USE_SYSTEM_UTC_DATE = false;
+#else
+static constexpr bool GDL90_DEFAULT_USE_SYSTEM_UTC_DATE = true;
+#endif
+
+GDL90Device::GDL90Settings gdl90_settings{
+  GDL90_DEFAULT_FILTER_HRANGE_M,
+  GDL90_DEFAULT_FILTER_VRANGE_M,
+  GDL90_DEFAULT_USE_SYSTEM_UTC_DATE,
+};
+
+void
+LoadFromProfile(GDL90Device::GDL90Settings &settings) noexcept
+{
+  settings.hrange = GDL90_DEFAULT_FILTER_HRANGE_M;
+  settings.vrange = GDL90_DEFAULT_FILTER_VRANGE_M;
+  settings.use_system_utc_date = GDL90_DEFAULT_USE_SYSTEM_UTC_DATE;
+
+  Profile::Get(ProfileKeys::GDL90HorizontalRange, settings.hrange);
+  Profile::Get(ProfileKeys::GDL90VerticalRange, settings.vrange);
+  Profile::Get(ProfileKeys::GDL90UseSystemUtcDate, settings.use_system_utc_date);
+}
+
+void
+SaveToProfile(GDL90Device::GDL90Settings &settings) noexcept
+{
+  Profile::Set(ProfileKeys::GDL90HorizontalRange, settings.hrange);
+  Profile::Set(ProfileKeys::GDL90VerticalRange, settings.vrange);
+  Profile::Set(ProfileKeys::GDL90UseSystemUtcDate, settings.use_system_utc_date);
+}
+
+/**
+ * Safe byte read for constexpr parsers: out-of-range index yields 0 so
+ * ReadBE16/24 never read past the span end when the caller already checked
+ * minimum length.
+ */
+static constexpr uint8_t
+ReadU8(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return i < s.size() ? s[i] : 0;
+}
+
+/** Big-endian uint16 starting at `i` (high byte first on the wire). */
+static constexpr uint16_t
+ReadBE16(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return (uint16_t(ReadU8(s, i)) << 8) | uint16_t(ReadU8(s, i + 1));
+}
+
+/** Big-endian 24-bit value starting at `i` (ICD multi-byte field order). */
+static constexpr uint32_t
+ReadBE24(std::span<const uint8_t> s, std::size_t i) noexcept
+{
+  return (uint32_t(ReadU8(s, i)) << 16) |
+    (uint32_t(ReadU8(s, i + 1)) << 8) |
+    uint32_t(ReadU8(s, i + 2));
+}
+
+/**
+ * Interpret `value` as a signed 24-bit integer (latitude/longitude raw).
+ * Bit 23 is the sign; upper 8 bits of the 32-bit word are discarded then
+ * replicated if negative (two's complement).
+ */
+static constexpr int32_t
+SignExtend24(uint32_t value) noexcept
+{
+  value &= GDL90_SIGN_EXT24_VALUE_MASK;
+  if ((value & GDL90_SIGN_EXT24_SIGN_BIT) != 0)
+    return int32_t(value | GDL90_SIGN_EXT24_OR_MASK);
+  return int32_t(value);
+}
+
+/**
+ * GDL90 §3.5.1.3: position is a signed fraction of a semicircle
+ * (−2^23 … 2^23−1 maps to −180° … +180°).
+ */
+static constexpr double
+SemiCircles24ToDegrees(int32_t value) noexcept
+{
+  return double(value) *
+    (180.0 / double(1u << GDL90_SEMICIRCLE_FRACTION_BITS));
+}
+
+/** CRC-CCITT over `data` using the ICD §2.2.3 table-driven update. */
+static uint16_t
+Gdl90Crc16(std::span<const uint8_t> data) noexcept
+{
+  uint16_t crc = 0;
+
+  for (uint8_t b : data)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ b;
+
+  return crc;
+}
+
+/**
+ * Invert GDL90 byte stuffing: 0x7D means “next byte XOR 0x20”.
+ * Malformed input (escape as last byte) returns false.
+ */
+static bool
+UnescapeGdl90(std::span<const uint8_t> src,
+              std::vector<uint8_t> &dest) noexcept
+{
+  dest.clear();
+  dest.reserve(src.size());
+
+  for (std::size_t i = 0; i < src.size(); ++i) {
+    const uint8_t b = src[i];
+    if (b != GDL90_ESCAPE) {
+      dest.push_back(b);
+      continue;
+    }
+
+    if (++i >= src.size())
+      return false;
+
+    dest.push_back(src[i] ^ GDL90_ESCAPE_XOR);
+  }
+
+  return true;
+}
+
+/** Reject ids with MSB set (reserved in ICD §2.2.2). */
+static constexpr bool
+IsGdl90MessageId(uint8_t id) noexcept
+{
+  return (id & GDL90_MSG_ID_RESERVED_BIT) == 0;
+}
+
+/** Six-digit hex ICAO address for FLARM traffic id matching. */
+static FlarmId
+MakeIcaoFlarmId(uint32_t icao) noexcept
+{
+  char buffer[16];
+  snprintf(buffer, sizeof(buffer), "%06X",
+           (unsigned)(icao & GDL90_ICAO_ADDRESS_MASK));
+  return FlarmId::Parse(buffer, nullptr);
+}
+
+/**
+ * Copy 8-byte ICD callsign field: printable ASCII 0x20–0x7E, else space;
+ * trim trailing spaces for display.
+ */
+static void
+ExtractCallsign(std::span<const uint8_t, GDL90_CALLSIGN_CHAR_COUNT> src,
+                StaticString<10> &dest) noexcept
+{
+  char tmp[GDL90_CALLSIGN_CHAR_COUNT + 1];
+  for (std::size_t i = 0; i < GDL90_CALLSIGN_CHAR_COUNT; ++i) {
+    const uint8_t ch = src[i];
+    tmp[i] = ch >= GDL90_CALLSIGN_ASCII_MIN && ch < GDL90_CALLSIGN_ASCII_MAX
+      ? (char)ch
+      : ' ';
+  }
+  tmp[GDL90_CALLSIGN_CHAR_COUNT] = 0;
+
+  /* trim trailing spaces */
+  unsigned n = GDL90_CALLSIGN_CHAR_COUNT;
+  while (n > 0 && tmp[n - 1] == ' ')
+    --n;
+  tmp[n] = 0;
+
+  dest.SetASCII(tmp);
+  dest.CleanASCII();
+}
+
+static constexpr FlarmTraffic::AircraftType
+ToFlarmAircraftType(uint8_t emitter_category) noexcept
+{
+  /* GDL90 ICD §3.5.1.10 "Emitter Category".  We map a subset to the
+     existing FLARM aircraft type enum to populate UI fields. */
+  switch (emitter_category) {
+  case 1: /* Light */
+  case 2: /* Small */
+    return FlarmTraffic::AircraftType::POWERED_AIRCRAFT;
+
+  case 3: /* Large */
+  case 4: /* High vortex */
+  case 5: /* Heavy */
+  case 6: /* High performance */
+    return FlarmTraffic::AircraftType::JET_AIRCRAFT;
+
+  case 7: /* Rotorcraft */
+    return FlarmTraffic::AircraftType::HELICOPTER;
+
+  case 9: /* Glider / sailplane */
+    return FlarmTraffic::AircraftType::GLIDER;
+
+  case 10: /* Lighter-than-air */
+    return FlarmTraffic::AircraftType::BALLOON;
+
+  case 11: /* Parachutist / skydiver */
+    return FlarmTraffic::AircraftType::PARACHUTE;
+
+  case 12: /* Ultralight / hang glider / paraglider */
+    return FlarmTraffic::AircraftType::HANG_GLIDER;
+
+  case 14: /* UAV */
+    return FlarmTraffic::AircraftType::UAV;
+
+  case 15: /* Space / trans-atmospheric */
+  default:
+    return FlarmTraffic::AircraftType::UNKNOWN;
+  }
+}
+
+void
+GDL90Device::ParseHeartbeat(std::span<const uint8_t> payload,
+                            NMEAInfo &info) noexcept
+{
+  /* ICD §3.1 heartbeat (payload after message id): [0] status1, [1] status2,
+     [2:3] UTC seconds since midnight LE (bits 0..15), bit 16 in status2 bit7.
+     Stratux sets UTC-valid in status2 bit0 (see gen_gdl90 makeHeartbeat). */
+  if (payload.size() < GDL90_HEARTBEAT_MIN_PAYLOAD)
+    return;
+
+  const uint8_t status2 = payload[1];
+  if ((status2 & GDL90_HEARTBEAT_UTC_VALID_MASK) == 0)
+    return;
+
+  /* 17-bit second count: low 16 LE at [2:3], bit 16 in status2 bit7. */
+  const unsigned seconds16 = unsigned(payload[2]) | (unsigned(payload[3]) << 8);
+  const unsigned seconds =
+    (((status2 >> GDL90_HEARTBEAT_SECONDS_BIT16_SHIFT) &
+      GDL90_HEARTBEAT_SECONDS_HIGH_BIT_MASK)
+     << 16) |
+    seconds16;
+
+  if (seconds >= GDL90_SECONDS_PER_DAY)
+    return;
+
+  info.ProvideTime(TimeStamp{FloatDuration{double(seconds)}});
+
+  /* Heartbeat ICD §3.1 carries TOD only; optional host UTC calendar. */
+  if (gdl90_settings.use_system_utc_date) {
+    const BrokenDateTime now = BrokenDateTime::NowUTC();
+    if (now.IsDatePlausible())
+      info.ProvideDate(now);
+  }
+}
+
+void
+GDL90Device::ParseOwnshipReport(std::span<const uint8_t> payload,
+                                NMEAInfo &info) noexcept
+{
+  /* Ownship Report (ICD §3.4 / §3.5.1) */
+  if (payload.size() < GDL90_REPORT_PAYLOAD_BYTES)
+    return;
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload, 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload, 7));
+  const double lat_deg = SemiCircles24ToDegrees(lat_raw);
+  const double lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg) ||
+      lat_deg < GDL90_LAT_MIN_DEG || lat_deg > GDL90_LAT_MAX_DEG ||
+      lon_deg < GDL90_LON_MIN_DEG || lon_deg > GDL90_LON_MAX_DEG)
+    return;
+
+  info.location = GeoPoint(Angle::Degrees(lon_deg), Angle::Degrees(lat_deg));
+  info.location_available.Update(info.clock);
+
+  /* Altitude word: bits 15–4 = pressure altitude code; bits 3–0 = misc
+     (track-valid flags in low 2 bits per ICD §3.5.1). */
+  const uint16_t alt_word = ReadBE16(payload, 10);
+  const uint16_t altitude_code = alt_word >> GDL90_ALT_WORD_CODE_SHIFT;
+  const uint8_t misc = uint8_t(alt_word & GDL90_ALT_WORD_MISC_MASK);
+  if (altitude_code != GDL90_PRESSURE_ALT_INVALID) {
+    const int altitude_ft = int(altitude_code) * GDL90_PRESSURE_ALT_FT_LSB -
+      GDL90_PRESSURE_ALT_FT_OFFSET;
+    const double pressure_altitude =
+      Units::ToSysUnit(altitude_ft, Unit::FEET);
+    info.ProvidePressureAltitude(pressure_altitude);
+  }
+
+  /* 24-bit BE velocity: top 12 bits = ground speed (kt), bottom 12 = vert
+     rate; ownship uses horizontal component only here. */
+  const uint32_t vel = ReadBE24(payload, 13);
+  const uint16_t h_code = uint16_t((vel >> GDL90_VEL_HORIZONTAL_SHIFT) &
+                                    GDL90_VEL_HORIZONTAL_MASK);
+  if (h_code != GDL90_VEL_HORIZONTAL_INVALID) {
+    info.ground_speed = Units::ToSysUnit(h_code, Unit::KNOTS);
+    info.ground_speed_available.Update(info.clock);
+  }
+
+  const uint8_t track_byte = payload[16];
+  const bool track_valid = (misc & GDL90_TRACK_STATUS_MASK) != 0;
+  if (track_valid && track_byte != GDL90_TRACK_BYTE_INVALID) {
+    info.track =
+      Angle::Degrees(double(track_byte) * GDL90_TRACK_DEG_PER_BYTE);
+    info.track_available.Update(info.clock);
+  }
+
+  /* Basic fix quality (optional but helps status panels) */
+  info.gps.fix_quality = FixQuality::GPS;
+  info.gps.fix_quality_available.Update(info.clock);
+  info.gps.real = true;
+}
+
+void
+GDL90Device::ParseOwnshipGeometricAltitude(std::span<const uint8_t> payload,
+                                           NMEAInfo &info) noexcept
+{
+  /* Ownship Geometric Altitude (ICD §3.6): int16, 5 ft per LSB */
+  if (payload.size() < GDL90_GEOM_ALT_PAYLOAD_BYTES)
+    return;
+
+  const int16_t alt5 = int16_t(ReadBE16(payload, 0));
+  const double altitude_ft =
+    double(alt5) * double(GDL90_GEOM_ALT_FT_RESOLUTION);
+  double altitude = Units::ToSysUnit(altitude_ft, Unit::FEET);
+
+  /* ForeFlight's 0x65 ID message can declare that 0x0B is MSL.
+     If the sender uses ellipsoid altitude, convert to MSL using EGM96. */
+  if (!geo_altitude_is_msl && info.location_available)
+    altitude -= EGM96::LookupSeparation(info.location);
+
+  info.gps_altitude = altitude;
+  info.gps_altitude_available.Update(info.clock);
+}
+
+void
+GDL90Device::ParseForeFlight(std::span<const uint8_t> payload,
+                             NMEAInfo &info) noexcept
+{
+  /*
+   * ForeFlight 0x65: first payload byte is sub-id (not in Garmin ICD).
+   * https://foreflight.com/connect/spec/
+   *
+   * ID (0x00): version at [1], capabilities BE32 at [34..37]; bit0 selects
+   * ellipsoid vs MSL for message 0x0B.
+   * AHRS (0x01): BE16 fields at [1],[3],[5],[7],[9] — roll, pitch, heading,
+   * IAS, TAS (see Protocol.md).
+   */
+  if (payload.empty())
+    return;
+
+  const uint8_t sub_id = payload[0];
+
+  if (sub_id == GDL90_FOREFLIGHT_SUB_ID_MSG) {
+    if (payload.size() < 2)
+      return;
+
+    const uint8_t version = payload[1];
+    if (version != GDL90_FOREFLIGHT_ID_VERSION)
+      return;
+
+    if (payload.size() < GDL90_FOREFLIGHT_ID_MIN_PAYLOAD)
+      return;
+
+    const std::size_t cap_o = GDL90_FOREFLIGHT_CAPABILITIES_OFFSET;
+    const uint32_t capabilities =
+      (uint32_t(payload[cap_o]) << 24) |
+      (uint32_t(payload[cap_o + 1]) << 16) |
+      (uint32_t(payload[cap_o + 2]) << 8) |
+      uint32_t(payload[cap_o + 3]);
+
+    geo_altitude_is_msl =
+      (capabilities & GDL90_FOREFLIGHT_CAP_GEO_ALT_IS_MSL) != 0;
+
+    if (info.device.license.empty())
+      info.device.license = "ForeFlight";
+
+    return;
+  }
+
+  if (sub_id == GDL90_FOREFLIGHT_SUB_AHRS) {
+    /* AHRS layout per ForeFlight spec (0.1° except as noted) */
+    if (payload.size() < GDL90_FOREFLIGHT_AHRS_MIN_PAYLOAD)
+      return;
+
+    const uint16_t roll_u = ReadBE16(payload, 1);
+    if (roll_u != GDL90_FOREFLIGHT_ANGLE_INVALID) {
+      info.attitude.bank_angle = Angle::Degrees(int16_t(roll_u) / 10.);
+      info.attitude.bank_angle_available.Update(info.clock);
+    }
+
+    const uint16_t pitch_u = ReadBE16(payload, 3);
+    if (pitch_u != GDL90_FOREFLIGHT_ANGLE_INVALID) {
+      info.attitude.pitch_angle = Angle::Degrees(int16_t(pitch_u) / 10.);
+      info.attitude.pitch_angle_available.Update(info.clock);
+    }
+
+    const uint16_t heading_u = ReadBE16(payload, 5);
+    if (heading_u != GDL90_FOREFLIGHT_HEADING_INVALID) {
+      /* bit15 indicates magnetic vs true heading; XCSoar's attitude heading
+         does not track this distinction, store the numeric value. */
+      const unsigned heading_tenths =
+        unsigned(heading_u & GDL90_FOREFLIGHT_HEADING_VALUE_MASK);
+      info.attitude.heading = Angle::Degrees(heading_tenths / 10.);
+      info.attitude.heading_available.Update(info.clock);
+    }
+
+    const uint16_t ias_u = ReadBE16(payload, 7);
+    const uint16_t tas_u = ReadBE16(payload, 9);
+    const bool ias_valid = ias_u != GDL90_FOREFLIGHT_AIRSPEED_INVALID;
+    const bool tas_valid = tas_u != GDL90_FOREFLIGHT_AIRSPEED_INVALID;
+
+    if (ias_valid && tas_valid) {
+      info.ProvideBothAirspeeds(Units::ToSysUnit(ias_u, Unit::KNOTS),
+                                Units::ToSysUnit(tas_u, Unit::KNOTS));
+    } else if (ias_valid) {
+      info.ProvideIndicatedAirspeed(Units::ToSysUnit(ias_u, Unit::KNOTS));
+    } else if (tas_valid) {
+      info.ProvideTrueAirspeed(Units::ToSysUnit(tas_u, Unit::KNOTS));
+    }
+
+    return;
+  }
+}
+
+void
+GDL90Device::ParseTrafficReport(std::span<const uint8_t> payload,
+                                NMEAInfo &info) noexcept
+{
+  /* Traffic Report (ICD §3.5 / §3.5.1) */
+  if (payload.size() < GDL90_REPORT_PAYLOAD_BYTES)
+    return;
+
+  /* byte 0: low nibble = alert status, high nibble = address type
+     bytes 1-3: participant address (24-bit) */
+  const uint8_t b0 = payload[0];
+  const uint8_t address_type = b0 >> 4;
+
+  const uint32_t participant_address = ReadBE24(payload, 1);
+  if (participant_address == 0)
+    return;
+
+  const FlarmId id = MakeIcaoFlarmId(participant_address);
+  if (!id.IsDefined())
+    return;
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload, 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload, 7));
+  const double lat_deg = SemiCircles24ToDegrees(lat_raw);
+  const double lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  if (!std::isfinite(lat_deg) || !std::isfinite(lon_deg) ||
+      lat_deg < GDL90_LAT_MIN_DEG || lat_deg > GDL90_LAT_MAX_DEG ||
+      lon_deg < GDL90_LON_MIN_DEG || lon_deg > GDL90_LON_MAX_DEG)
+    return;
+
+  /* Same altitude / misc layout as ownship (ICD §3.5.1). */
+  const uint16_t alt_word = ReadBE16(payload, 10);
+  const uint16_t altitude_code = alt_word >> GDL90_ALT_WORD_CODE_SHIFT;
+  const uint8_t misc = uint8_t(alt_word & GDL90_ALT_WORD_MISC_MASK);
+
+  bool altitude_available = altitude_code != GDL90_PRESSURE_ALT_INVALID;
+  double altitude = 0;
+  if (altitude_available) {
+    const int altitude_ft = int(altitude_code) * GDL90_PRESSURE_ALT_FT_LSB -
+      GDL90_PRESSURE_ALT_FT_OFFSET;
+    altitude = Units::ToSysUnit(altitude_ft, Unit::FEET);
+  }
+
+  if (gdl90_settings.hrange > 0 && info.location_available) {
+    const GeoPoint target_location(Angle::Degrees(lon_deg),
+                                   Angle::Degrees(lat_deg));
+    const GeoVector vec{info.location, target_location};
+    if (vec.distance > gdl90_settings.hrange)
+      return;
+  }
+
+  /* Traffic reports carry pressure altitude (ICD §3.5.1). Compare only to
+     ownship pressure — not GPS/geometric (0x0B), or a bogus delta can exceed
+     vrange and drop every target (e.g. Stratux with geom alt but no baro). */
+  if (gdl90_settings.vrange > 0 && altitude_available &&
+      info.pressure_altitude_available) {
+    if (fabs(altitude - info.pressure_altitude) > gdl90_settings.vrange)
+      return;
+  }
+
+  const uint8_t nacp_nic = payload[12];
+  (void)nacp_nic; /* not used yet */
+
+  const uint32_t vel = ReadBE24(payload, 13);
+  const uint16_t h_code = uint16_t((vel >> GDL90_VEL_HORIZONTAL_SHIFT) &
+                                    GDL90_VEL_HORIZONTAL_MASK);
+  const uint16_t v_code = uint16_t(vel & GDL90_VEL_VERTICAL_MASK);
+
+  bool speed_received = h_code != GDL90_VEL_HORIZONTAL_INVALID;
+  double speed = 0;
+  if (speed_received)
+    speed = Units::ToSysUnit(h_code, Unit::KNOTS);
+
+  /* Lower 12 bits: vertical speed; 0x800 means “no information”. */
+  bool climb_rate_received = v_code != GDL90_VEL_VERTICAL_NO_INFO;
+  double climb_rate = 0;
+  if (climb_rate_received) {
+    /* Sign-extend 12-bit two's complement to 16 bits. */
+    int16_t v_signed = int16_t(v_code);
+    if ((v_signed & int16_t(GDL90_VEL12_SIGN_BIT)) != 0)
+      v_signed = int16_t(v_signed - GDL90_VEL12_SIGN_EXTEND);
+
+    climb_rate = double(v_signed) * double(GDL90_VERTICAL_RATE_FPM_PER_LSB) *
+      GDL90_FPM_TO_METERS_PER_SECOND;
+  }
+
+  const uint8_t track_byte = payload[16];
+  const bool track_valid = (misc & GDL90_TRACK_STATUS_MASK) != 0;
+  bool track_received = track_valid;
+  Angle track = Angle::Zero();
+  if (track_received && track_byte != GDL90_TRACK_BYTE_INVALID)
+    track = Angle::Degrees(double(track_byte) * GDL90_TRACK_DEG_PER_BYTE);
+  else
+    track_received = false;
+
+  FlarmTraffic *slot = info.flarm.traffic.FindTraffic(id);
+  if (slot == nullptr) {
+    slot = info.flarm.traffic.AllocateTraffic();
+    if (slot == nullptr)
+      return;
+
+    slot->Clear();
+    slot->id = id;
+    info.flarm.traffic.new_traffic.Update(info.clock);
+  }
+
+  info.flarm.traffic.modified.Update(info.clock);
+  slot->valid.Update(info.clock);
+
+  if (payload.size() >= GDL90_TRAFFIC_MIN_PAYLOAD_FOR_CALLSIGN) {
+    const std::span<const uint8_t, GDL90_CALLSIGN_CHAR_COUNT> callsign{
+      payload.data() + GDL90_REPORT_CALLSIGN_OFFSET,
+      GDL90_CALLSIGN_CHAR_COUNT};
+    ExtractCallsign(callsign, slot->name);
+  }
+
+  slot->alarm_level = FlarmTraffic::AlarmType::NONE;
+  slot->type = ToFlarmAircraftType(payload[17]);
+
+  /* id_type: ICAO for stable 24-bit addresses; RANDOM for self-assigned /
+     track-file IDs so FlarmComputer skips callsign DB lookup (see FTD-012). */
+  switch (address_type) {
+  case GDL90_ADDR_ADSB_ICAO:
+    slot->source = FlarmTraffic::SourceType::ADSB;
+    slot->id_type = FlarmTraffic::IdType::ICAO;
+    break;
+
+  case GDL90_ADDR_ADSB_SELF_ASSIGNED:
+    slot->source = FlarmTraffic::SourceType::ADSB;
+    slot->id_type = FlarmTraffic::IdType::RANDOM;
+    break;
+
+  case GDL90_ADDR_TISB_ICAO:
+  case GDL90_ADDR_TISB_SURFACE_VEHICLE:
+    slot->source = FlarmTraffic::SourceType::TISB;
+    slot->id_type = FlarmTraffic::IdType::ICAO;
+    break;
+
+  case GDL90_ADDR_TISB_TRACK_FILE:
+    slot->source = FlarmTraffic::SourceType::TISB;
+    slot->id_type = FlarmTraffic::IdType::RANDOM;
+    break;
+
+  case GDL90_ADDR_ADSR_ICAO:
+    slot->source = FlarmTraffic::SourceType::ADSR;
+    slot->id_type = FlarmTraffic::IdType::ICAO;
+    break;
+
+  default:
+    slot->source = FlarmTraffic::SourceType::ADSB;
+    slot->id_type = FlarmTraffic::IdType::ICAO;
+    break;
+  }
+
+  slot->location = GeoPoint(Angle::Degrees(lon_deg), Angle::Degrees(lat_deg));
+  slot->location_available = true;
+  slot->absolute_location = true;
+
+  if (altitude_available) {
+    slot->altitude = altitude;
+    slot->altitude_available = true;
+    slot->absolute_altitude = true;
+  } else {
+    slot->altitude = 0;
+    slot->altitude_available = false;
+    slot->absolute_altitude = false;
+  }
+
+  if (track_received) {
+    slot->track = track;
+    slot->track_received = true;
+  } else
+    slot->track_received = false;
+
+  if (speed_received) {
+    slot->speed = speed;
+    slot->speed_received = true;
+  } else
+    slot->speed_received = false;
+
+  if (climb_rate_received) {
+    slot->climb_rate = climb_rate;
+    slot->climb_rate_received = true;
+  } else
+    slot->climb_rate_received = false;
+
+  /* not available / not conveyed by basic Traffic Report */
+  slot->relative_north = 0;
+  slot->relative_east = 0;
+  slot->relative_altitude = 0;
+  slot->stealth = false;
+  slot->no_track = false;
+  slot->rssi_available = false;
+  slot->turn_rate_received = false;
+  slot->climb_rate_avg30s_available = false;
+}
+
+bool
+GDL90Device::DataReceived(std::span<const std::byte> s,
+                          NMEAInfo &info) noexcept
+{
+  /* Accumulate bytes, split on 0x7E, unstuff, CRC-check, then dispatch on
+     message id. Payload passed to Parse* is everything after id, before CRC. */
+  const auto *p = reinterpret_cast<const uint8_t *>(s.data());
+  buffer.insert(buffer.end(), p, p + s.size());
+
+  unescaped.reserve(GDL90_UNESCAPED_INITIAL_CAPACITY);
+
+  while (true) {
+    auto start = std::find(buffer.begin(), buffer.end(), GDL90_FLAG);
+    if (start == buffer.end()) {
+      buffer.clear();
+      break;
+    }
+
+    buffer.erase(buffer.begin(), start);
+    if (buffer.size() < 2)
+      break;
+
+    auto end = std::find(buffer.begin() + 1, buffer.end(), GDL90_FLAG);
+    if (end == buffer.end()) {
+      /* keep current partial frame */
+      if (buffer.size() > GDL90_BUFFER_TRIM_SIZE)
+        buffer.erase(buffer.begin(),
+                     buffer.end() -
+                       static_cast<std::ptrdiff_t>(GDL90_BUFFER_TRIM_SIZE));
+      break;
+    }
+
+    /* Copy stuffed payload before buffer.erase: span into buffer is
+       invalidated by erase (reallocation / invalid pointers). */
+    escaped_frame.assign(buffer.begin() + 1, end);
+
+    buffer.erase(buffer.begin(), end + 1);
+
+    if (escaped_frame.size() < GDL90_MIN_FRAME_BYTES)
+      continue;
+
+    if (escaped_frame.size() > GDL90_MAX_FRAME)
+      continue;
+
+    if (!UnescapeGdl90(escaped_frame, unescaped))
+      continue;
+
+    if (unescaped.size() < GDL90_MIN_FRAME_BYTES)
+      continue;
+
+    const uint8_t msg_id = unescaped[0];
+    if (!IsGdl90MessageId(msg_id))
+      continue;
+
+    const std::size_t payload_len = unescaped.size() - 1 - 2;
+    const uint16_t rx_crc = uint16_t(unescaped[unescaped.size() - 2]) |
+      (uint16_t(unescaped[unescaped.size() - 1]) << 8);
+    const uint16_t calc_crc = Gdl90Crc16({unescaped.data(),
+                                          1 + payload_len});
+    if (rx_crc != calc_crc)
+      continue;
+
+    const std::span<const uint8_t> payload{
+      unescaped.data() + 1, payload_len};
+
+    /* Any valid GDL90 frame indicates the device is alive. */
+    info.alive.Update(info.clock);
+
+    switch (msg_id) {
+    case GDL90_MSG_HEARTBEAT:
+      ParseHeartbeat(payload, info);
+      break;
+
+    case GDL90_MSG_OWNSHIP:
+      ParseOwnshipReport(payload, info);
+      break;
+
+    case GDL90_MSG_OWNSHIP_GEOM_ALT:
+      ParseOwnshipGeometricAltitude(payload, info);
+      break;
+
+    case GDL90_MSG_TRAFFIC:
+      ParseTrafficReport(payload, info);
+      break;
+
+    case GDL90_MSG_FOREFLIGHT:
+      ParseForeFlight(payload, info);
+      break;
+    }
+  }
+
+  return true;
+}

--- a/src/Device/Driver/GDL90/Driver.hpp
+++ b/src/Device/Driver/GDL90/Driver.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * GDL90 serial device (Garmin ICD + optional ForeFlight 0x65 extensions).
+ * Wire format and payload layouts: see Protocol.md in this directory.
+ */
+
+#include "Device/Driver.hpp"
+#include <cstdint>
+#include <span>
+#include <vector>
+
+struct NMEAInfo;
+
+class GDL90Device final : public AbstractDevice {
+public:
+  struct GDL90Settings {
+    uint16_t hrange;
+    uint16_t vrange;
+    /** Fill calendar date from host UTC after heartbeat TOD (see ParseHeartbeat). */
+    bool use_system_utc_date;
+  };
+
+private:
+  std::vector<uint8_t> buffer;
+  /** Bytes between 0x7E flags (still stuffed); copy before mutating buffer. */
+  std::vector<uint8_t> escaped_frame;
+  std::vector<uint8_t> unescaped;
+
+  /**
+   * ForeFlight 0x65 ID message capability bit 0:
+   * geometric altitude datum used in 0x0B.
+   *
+   * false = WGS-84 ellipsoid (per GDL90 ICD)
+   * true  = MSL (per ForeFlight extension)
+   */
+  bool geo_altitude_is_msl = false;
+
+  void ParseTrafficReport(std::span<const uint8_t> payload,
+                          NMEAInfo &info) noexcept;
+
+  void ParseOwnshipReport(std::span<const uint8_t> payload,
+                          NMEAInfo &info) noexcept;
+
+  void ParseOwnshipGeometricAltitude(std::span<const uint8_t> payload,
+                                     NMEAInfo &info) noexcept;
+
+  void ParseHeartbeat(std::span<const uint8_t> payload,
+                      NMEAInfo &info) noexcept;
+
+  void ParseForeFlight(std::span<const uint8_t> payload,
+                       NMEAInfo &info) noexcept;
+
+public:
+  bool DataReceived(std::span<const std::byte> s,
+                    NMEAInfo &info) noexcept override;
+};
+
+extern GDL90Device::GDL90Settings gdl90_settings;
+
+void LoadFromProfile(GDL90Device::GDL90Settings &settings) noexcept;
+
+void SaveToProfile(GDL90Device::GDL90Settings &settings) noexcept;

--- a/src/Device/Driver/GDL90/GDL90Driver.cpp
+++ b/src/Device/Driver/GDL90/GDL90Driver.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+/* This file exists to avoid an object name collision in driver.a:
+   multiple drivers had a translation unit named "Driver.cpp", which
+   becomes "Driver.o" and breaks static linking. */
+
+#include "Driver.cpp"
+

--- a/src/Device/Driver/GDL90/Protocol.md
+++ b/src/Device/Driver/GDL90/Protocol.md
@@ -1,0 +1,100 @@
+# GDL90 protocol (XCSoar driver)
+
+This note describes what the **GDL90** device driver implements. Authoritative
+sources:
+
+- **Garmin GDL 90 Data Interface Specification** (560-1058-00 Rev A, 2007),
+  public ICD (e.g. FAA archival PDF).
+- **ForeFlight GDL 90 Extended Specification**
+  (<https://foreflight.com/connect/spec/>) for message id `0x65`.
+
+## Serial framing (ICD §2.2)
+
+- Frames are delimited by flag byte **`0x7E`**.
+- Between flags, **`0x7D`** is an escape: the next byte is XORed with **`0x20`**
+  to recover the real value (so literal `0x7E` / `0x7D` can appear in payload).
+- After unescaping, a logical message is:
+  **`[message_id][payload…][crc_lo][crc_hi]`**
+- **CRC-16-CCITT** (polynomial as in ICD §2.2.3) is computed over
+  `message_id` + `payload`. The CRC is stored **little-endian** (low byte
+  first on the wire).
+- The **top bit** of `message_id` is reserved and must be zero (ICD §2.2.2).
+
+## Endianness
+
+- **Payload fields** in standard messages are **big-endian** (MSB first), unless
+  the ICD says otherwise.
+- **CRC** is **little-endian**.
+- **Heartbeat** time-of-day uses a **little-endian** 16-bit second count
+  (plus one high bit in a status byte); see below.
+
+## Message id `0x00` — Heartbeat (ICD §3.1)
+
+**Payload** (6 bytes minimum after stripping `message_id`):
+
+| Offset | Content |
+|--------|---------|
+| 0 | Status byte 1 |
+| 1 | Status byte 2 (Stratux: bit 0 = UTC time valid; bit 7 = second count bit 16) |
+| 2–3 | Seconds since midnight UTC, **little-endian**, bits 0–15 |
+| 4–5 | Uplink / basic message counts (ignored by XCSoar for time) |
+
+
+
+## Message ids `0x0A` / `0x14` — Ownship / Traffic (ICD §3.4 / §3.5, body §3.5.1)
+
+Both use the same **27-byte** payload layout (**indices after `message_id`**):
+
+| Offset | Size | Field |
+|--------|------|--------|
+| 0 | 1 | Status: alert (low nibble), address type (high nibble) |
+| 1–3 | 3 | Participant address (24-bit big-endian) |
+| 4–6 | 3 | Latitude: signed 24-bit semicircles (ICD §3.5.1.3) |
+| 7–9 | 3 | Longitude: same encoding |
+| 10–11 | 2 | Altitude word: 12-bit pressure altitude code (25 ft LSB, −1000 ft offset), high nibble of word; low 4 bits misc / track validity |
+| 12 | 1 | NACp / NIC supplement |
+| 13–15 | 3 | Velocity: upper 12 bits ground speed (kt), lower 12 bits vertical rate (64 fpm LSB, sign-extended 12-bit); `0xFFF` / `0x800` = invalid / N/A per ICD |
+| 16 | 1 | Track heading: `floor(track_deg / 360 * 256)`; `0xFF` = invalid |
+| 17 | 1 | Emitter category (ICD §3.5.1.10) |
+| 18–25 | 8 | Callsign ASCII (space-padded) |
+| 26 | 1 | Emergency / priority (not interpreted in basic path) |
+
+Ownship handling uses position, altitude word, horizontal speed, and track;
+traffic handling fills **FLARM** traffic slots from the same offsets.
+
+**Address type (high nibble of byte 0)** maps to `FlarmTraffic::source` for
+traffic reports: ADS-B (0, 1), TIS-B (2, 3, 4 surface vehicle), ADS-R (6),
+other values default to ADS-B. Details: ICD §3.5.1.2; some receivers place the
+qualifier in the low nibble instead—those targets may be misclassified until
+the sender follows the ICD layout (`tools/gdl90_send.py` uses the high nibble).
+
+## Message id `0x0B` — Ownship geometric altitude (ICD §3.6)
+
+**Payload:** signed altitude in **5 ft** steps as **big-endian int16** at
+offset **0**, then **2 bytes** vertical metrics (VFOM etc.). XCSoar reads the
+first **4** bytes; altitude datum (ellipsoid vs MSL) can follow ForeFlight’s
+ID message capability bit (see below).
+
+## Message id `0x65` — ForeFlight extensions
+
+Sub-id is **first payload byte** after `0x65`:
+
+### Sub-id `0x00` — ID message
+
+- Byte 1: version (must be **1** for supported layout).
+- Bytes 2–33: serial, short name, long name (see ForeFlight spec).
+- Bytes **34–37**: **capabilities mask**, **big-endian** 32-bit.
+  - **Bit 0:** if set, ownship geometric altitude (`0x0B`) is **MSL**; if clear,
+    **WGS-84 ellipsoid** (default GDL90 meaning).
+
+### Sub-id `0x01` — AHRS
+
+All multi-byte numeric fields **big-endian**, 0.1° for attitude/heading where
+applicable; airspeeds in knots; `0x7FFF` / `0xFFFF` = invalid per field (see
+ForeFlight spec table).
+
+## Tools and tests
+
+- `tools/gdl90_send.py` builds sample frames for local testing.
+- `test/src/TestGDL90.cpp` and `test/src/TestGDL90Driver.cpp` exercise CRC,
+  unescape, and driver behaviour.

--- a/src/Device/Driver/GDL90/Register.cpp
+++ b/src/Device/Driver/GDL90/Register.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/GDL90.hpp"
+#include "Driver.hpp"
+
+static Device *
+GDL90CreateOnPort([[maybe_unused]] const DeviceConfig &config,
+                  [[maybe_unused]] Port &com_port)
+{
+  LoadFromProfile(gdl90_settings);
+  return new GDL90Device();
+}
+
+const struct DeviceRegister gdl90_driver = {
+  "GDL90",
+  "GDL90",
+  DeviceRegister::MANAGE | DeviceRegister::RAW_GPS_DATA,
+  GDL90CreateOnPort,
+};
+

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -42,6 +42,7 @@
 #include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/KRT2.hpp"
 #include "Device/Driver/Stratux.hpp"
+#include "Device/Driver/GDL90.hpp"
 #include "Device/Driver/LoEFGREN.hpp"
 #include "util/Macros.hpp"
 #include "util/StringAPI.hxx"
@@ -92,6 +93,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &lx_eos_driver,
   &stratux_driver,
   &loe_fgren_driver,
+  &gdl90_driver,
   nullptr
 };
 

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -6,6 +6,7 @@
 #include "Vega/VegaDialogs.hpp"
 #include "BlueFly/BlueFlyDialogs.hpp"
 #include "Stratux/ConfigurationDialog.hpp"
+#include "GDL90/ConfigurationDialog.hpp"
 #include "ManageI2CPitotDialog.hpp"
 #include "ManageCAI302Dialog.hpp"
 #include "ManageFlarmDialog.hpp"
@@ -62,6 +63,9 @@ class DeviceListWidget final
     bool duplicate:1;
     bool open:1, error:1;
     bool alive:1, location:1, gps:1, baro:1, pitot:1, airspeed:1, vario:1, traffic:1;
+    bool gdl90:1;
+    bool foreflight_id:1;
+    bool foreflight_ahrs:1;
     bool temperature:1;
     bool humidity:1;
     bool imu:1;
@@ -113,6 +117,13 @@ class DeviceListWidget final
         basic.dyn_pressure_available;
       vario = basic.total_energy_vario_available;
       traffic = basic.flarm.IsDetected();
+      gdl90 = traffic && config.UsesDriver() && config.driver_name == "GDL90";
+      foreflight_id = config.UsesDriver() && config.driver_name == "GDL90" &&
+        basic.device.license.equals("ForeFlight");
+      foreflight_ahrs = config.UsesDriver() && config.driver_name == "GDL90" &&
+        (basic.attitude.bank_angle_available ||
+         basic.attitude.pitch_angle_available ||
+         basic.attitude.heading_available);
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;
       imu = basic.gyroscope.available;
@@ -429,7 +440,13 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     }
 
     if (flags.traffic)
-      buffer.append("; FLARM");
+      buffer.append(flags.gdl90 ? "; GDL90" : "; FLARM");
+
+    if (flags.foreflight_ahrs)
+      buffer.append("; ForeFlight AHRS");
+
+    if (flags.foreflight_id)
+      buffer.append("; ForeFlight ID");
 
     if (flags.temperature || flags.humidity) {
       buffer.append("; ");
@@ -668,6 +685,11 @@ DeviceListWidget::ManageCurrent()
     return;
   }
 #endif
+
+  if (descriptor.IsDriver("GDL90")) {
+    ManageGDL90Dialog();
+    return;
+  }
 
   if (descriptor.GetState() != PortState::READY) {
     ShowMessageBox(_("Device is not connected"), _("Manage"),

--- a/src/Dialogs/Device/GDL90/ConfigurationDialog.cpp
+++ b/src/Dialogs/Device/GDL90/ConfigurationDialog.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ConfigurationDialog.hpp"
+#include "Device/Driver/GDL90/Driver.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Dialogs/Message.hpp"
+#include "Language/Language.hpp"
+#include "Profile/Profile.hpp"
+#include "UIGlobals.hpp"
+#include "Units/Units.hpp"
+#include "Widget/RowFormWidget.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+class GDL90ConfigurationWidget final : public RowFormWidget {
+  enum Controls {
+    USE_SYSTEM_UTC_DATE,
+    HRANGE,
+    VRANGE,
+  };
+
+  GDL90Device::GDL90Settings settings;
+
+  /* Stored in profile as metres; limits match previous integer dialog. */
+  static constexpr double HRANGE_MIN_M = 4000;
+  static constexpr double HRANGE_MAX_M = 40000;
+  static constexpr double HRANGE_STEP_M = 1000;
+  static constexpr double VRANGE_MIN_M = 1000;
+  static constexpr double VRANGE_MAX_M = 10000;
+  static constexpr double VRANGE_STEP_M = 1000;
+
+public:
+  explicit GDL90ConfigurationWidget(const DialogLook &look)
+    :RowFormWidget(look) {}
+
+  void Prepare([[maybe_unused]] ContainerWindow &parent,
+               [[maybe_unused]] const PixelRect &rc) noexcept override
+  {
+    LoadFromProfile(settings);
+
+    const Unit distance_u = Units::GetUserDistanceUnit();
+    const Unit altitude_u = Units::GetUserAltitudeUnit();
+
+    AddBoolean(_("Use system date for UTC"),
+               _("The GDL90 protocol sends time-of-day only, not calendar date. "
+                 "When this is on, XCSoar sets the date from this device's "
+                 "clock after a valid heartbeat. Turn it off if the system "
+                 "date is unreliable (e.g. no RTC); use NMEA or set the clock "
+                 "manually instead."),
+               settings.use_system_utc_date);
+
+    AddFloat(_("Horizontal Range"), nullptr,
+             "%.0f %s", "%.0f",
+             Units::ToUserUnit(HRANGE_MIN_M, distance_u),
+             Units::ToUserUnit(HRANGE_MAX_M, distance_u),
+             Units::ToUserUnit(HRANGE_STEP_M, distance_u),
+             false,
+             UnitGroup::DISTANCE,
+             double(settings.hrange));
+
+    AddFloat(_("Vertical Range"), nullptr,
+             "%.0f %s", "%.0f",
+             Units::ToUserUnit(VRANGE_MIN_M, altitude_u),
+             Units::ToUserUnit(VRANGE_MAX_M, altitude_u),
+             Units::ToUserUnit(VRANGE_STEP_M, altitude_u),
+             false,
+             UnitGroup::ALTITUDE,
+             double(settings.vrange));
+  }
+
+  bool Save(bool &_changed) noexcept override
+  {
+    bool changed = false;
+
+    if (SaveValue(USE_SYSTEM_UTC_DATE, settings.use_system_utc_date))
+      changed = true;
+
+    double h_m = double(settings.hrange);
+    if (SaveValue(HRANGE, UnitGroup::DISTANCE, h_m)) {
+      settings.hrange = static_cast<uint16_t>(std::clamp(
+        std::lround(h_m), long(HRANGE_MIN_M), long(HRANGE_MAX_M)));
+      changed = true;
+    }
+
+    double v_m = double(settings.vrange);
+    if (SaveValue(VRANGE, UnitGroup::ALTITUDE, v_m)) {
+      settings.vrange = static_cast<uint16_t>(std::clamp(
+        std::lround(v_m), long(VRANGE_MIN_M), long(VRANGE_MAX_M)));
+      changed = true;
+    }
+
+    SaveToProfile(settings);
+    Profile::Save();
+
+    _changed |= changed;
+    if (_changed)
+      ShowMessageBox(_("Changes to configuration saved. Restart XCSoar to apply changes."),
+                     "", MB_OK);
+
+    return true;
+  }
+};
+
+void
+ManageGDL90Dialog() noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+
+  WidgetDialog dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(),
+                      look, _("GDL90 Setup"),
+                      new GDL90ConfigurationWidget(look));
+
+  dialog.AddButton(_("Close"), mrOK);
+  dialog.ShowModal();
+}
+

--- a/src/Dialogs/Device/GDL90/ConfigurationDialog.hpp
+++ b/src/Dialogs/Device/GDL90/ConfigurationDialog.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+void ManageGDL90Dialog() noexcept;
+

--- a/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
+++ b/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
@@ -20,6 +20,7 @@
 #include "FLARM/Details.hpp"
 #include "FLARM/Friends.hpp"
 #include "FLARM/Glue.hpp"
+#include "Geo/GeoVector.hpp"
 #include "Renderer/ColorButtonRenderer.hpp"
 #include "UIGlobals.hpp"
 #include "Components.hpp"
@@ -160,10 +161,20 @@ FlarmTrafficDetailsWidget::UpdateChanging(const MoreData &basic)
 
   // Fill distance/direction field
   if (target_ok) {
-    FormatUserDistanceSmart(target->distance, tmp, true, 20, 1000);
+    RoughDistance distance = target->distance;
+    Angle bearing = target->Bearing();
+
+    if (target->absolute_location && target->location.IsValid() &&
+        basic.location_available) {
+      const GeoVector vec{basic.location, target->location};
+      distance = vec.distance;
+      bearing = vec.bearing;
+    }
+
+    FormatUserDistanceSmart(distance, tmp, true, 20, 1000);
     char *p = tmp + strlen(tmp);
     *p++ = ' ';
-    FormatAngleDelta(p, 20, target->Bearing() - basic.track);
+    FormatAngleDelta(p, 20, bearing - basic.track);
     value = tmp;
   } else
     value = "--";
@@ -179,7 +190,22 @@ FlarmTrafficDetailsWidget::UpdateChanging(const MoreData &basic)
       *p++ = ' ';
     }
 
-    Angle dir = Angle::FromXY(target->distance, target->relative_altitude);
+    RoughAltitude relative_altitude = target->relative_altitude;
+    if (target->absolute_altitude && target->altitude_available &&
+        (basic.pressure_altitude_available || basic.gps_altitude_available)) {
+      const double ownship_altitude = basic.pressure_altitude_available
+        ? basic.pressure_altitude
+        : basic.gps_altitude;
+
+      relative_altitude = target->altitude - RoughAltitude(ownship_altitude);
+    }
+
+    RoughDistance distance = target->distance;
+    if (target->absolute_location && target->location.IsValid() &&
+        basic.location_available)
+      distance = GeoVector{basic.location, target->location}.distance;
+
+    Angle dir = Angle::FromXY(distance, relative_altitude);
     FormatVerticalAngleDelta(p, 20, dir);
 
     value = tmp;
@@ -211,7 +237,7 @@ FlarmTrafficDetailsWidget::Update()
 
   // Set the dialog caption
   StringFormatUnsafe(tmp, "%s (%s)",
-                     _("FLARM Traffic Details"), target_id.Format(tmp_id));
+                     _("Traffic Details"), target_id.Format(tmp_id));
   dialog.SetCaption(tmp);
 
   const FlarmTraffic* target =
@@ -235,9 +261,11 @@ FlarmTrafficDetailsWidget::Update()
   SetText(RADIO, value);
 
   // Fill the callsign field (+ registration)
-  // note: don't use target->Name here since it is not updated
-  //       yet if it was changed
-  const char* cs = info.callsign;
+  const char *cs = info.callsign;
+  if ((cs == nullptr || cs[0] == 0) &&
+      target != nullptr && target->HasName() && !StringIsEmpty(target->name))
+    cs = target->name.c_str();
+
   if (cs != nullptr && cs[0] != 0) {
     try {
       BasicStringBuilder<char> builder(tmp, ARRAY_SIZE(tmp));
@@ -252,7 +280,10 @@ FlarmTrafficDetailsWidget::Update()
     value = "--";
   SetText(CALLSIGN, value);
 
-  SetText(SOURCE, FlarmDetails::ToString(info.source));
+  const char *data_source = FlarmDetails::ToString(info.source);
+  if (info.source == ResolvedSource::NONE && target != nullptr)
+    data_source = FlarmTraffic::GetSourceString(target->source);
+  SetText(SOURCE, data_source);
 
   // Traffic source type (FLARM, ADS-B, Mode-S, etc.) and signal strength
   if (target != nullptr) {
@@ -344,7 +375,7 @@ dlgFlarmTrafficDetailsShowModal(FlarmId id)
   const DialogLook &look = UIGlobals::GetDialogLook();
 
   WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
-                      look, _("FLARM Traffic Details"));
+                      look, _("Traffic Details"));
 
   FlarmTrafficDetailsWidget *widget =
     new FlarmTrafficDetailsWidget(dialog, id);

--- a/src/FLARM/Computer.cpp
+++ b/src/FLARM/Computer.cpp
@@ -11,9 +11,10 @@ void
 FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
                        const NMEAInfo &basic) noexcept
 {
+  const TimeStamp now = basic.time_available ? basic.time : basic.clock;
+
   // Cleanup old calculation instances
-  if (basic.time_available)
-    flarm_calculations.CleanUp(basic.time);
+  flarm_calculations.CleanUp(now);
 
   // if (FLARM data is available)
   if (!flarm.IsDetected())
@@ -44,6 +45,13 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
 
   // for each item in traffic
   for (auto &traffic : flarm.traffic.list) {
+    const bool ownship_altitude_available = basic.pressure_altitude_available ||
+      basic.gps_altitude_available;
+
+    const RoughAltitude ownship_altitude = basic.pressure_altitude_available
+      ? RoughAltitude(basic.pressure_altitude)
+      : RoughAltitude(basic.gps_altitude);
+
     // Keep the cached display name (callsign) in sync with current sources.
     // Skip for no_track targets and random IDs: they must not be resolved
     // against databases (FTD-012 NoTrack / random ID semantics).
@@ -55,12 +63,22 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
         traffic.name = fname;
     }
 
+    if (traffic.absolute_location && traffic.location.IsValid() &&
+        basic.location_available) {
+      const GeoVector vec{basic.location, traffic.location};
+      traffic.relative_north = vec.distance * vec.bearing.cos();
+      traffic.relative_east = vec.distance * vec.bearing.sin();
+    }
+
     // Calculate distance
     traffic.distance = hypot(traffic.relative_north, traffic.relative_east);
 
     // Calculate Location
-    traffic.location_available = basic.location_available;
-    if (traffic.location_available) {
+    traffic.location_available = traffic.absolute_location
+      ? traffic.location.IsValid()
+      : basic.location_available;
+
+    if (!traffic.absolute_location && traffic.location_available) {
       traffic.location.latitude =
           Angle::Degrees(traffic.relative_north * north_to_latitude) +
           basic.location.latitude;
@@ -71,15 +89,20 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
     }
 
     // Calculate absolute altitude
-    traffic.altitude_available = basic.gps_altitude_available;
-    if (traffic.altitude_available)
-      traffic.altitude = traffic.relative_altitude + RoughAltitude(basic.gps_altitude);
+    if (!traffic.absolute_altitude) {
+      traffic.altitude_available = ownship_altitude_available;
+      if (traffic.altitude_available)
+        traffic.altitude = traffic.relative_altitude +
+          ownship_altitude;
+    } else if (ownship_altitude_available && traffic.altitude_available) {
+      traffic.relative_altitude = traffic.altitude - ownship_altitude;
+    }
 
     // Calculate average climb rate
     traffic.climb_rate_avg30s_available = traffic.altitude_available;
     if (traffic.climb_rate_avg30s_available)
       traffic.climb_rate_avg30s =
-        flarm_calculations.Average30s(traffic.id, basic.time, traffic.altitude);
+        flarm_calculations.Average30s(traffic.id, now, traffic.altitude);
 
     // The following calculations are only relevant for targets
     // where information is missing

--- a/src/FLARM/Traffic.cpp
+++ b/src/FLARM/Traffic.cpp
@@ -73,4 +73,6 @@ FlarmTraffic::Update(const FlarmTraffic &other) noexcept
   rssi = other.rssi;
   rssi_available = other.rssi_available;
   no_track = other.no_track;
+  absolute_location = other.absolute_location;
+  absolute_altitude = other.absolute_altitude;
 }

--- a/src/FLARM/Traffic.hpp
+++ b/src/FLARM/Traffic.hpp
@@ -137,6 +137,15 @@ struct FlarmTraffic {
   /** Has the geographical location been calculated yet? */
   bool location_available;
 
+  /**
+   * Does this target have an absolute geographic location that was
+   * received from an external traffic source (e.g. ADS-B)?
+   *
+   * If true, FLARM post-processing must not overwrite #location from
+   * #relative_north/#relative_east.
+   */
+  bool absolute_location;
+
   /** Was the direction of the target received from the flarm or calculated? */
   bool track_received;
 
@@ -145,6 +154,15 @@ struct FlarmTraffic {
 
   /** Has the absolute altitude of the target been calculated yet? */
   bool altitude_available;
+
+  /**
+   * Does this target have an absolute altitude received from an
+   * external traffic source?
+   *
+   * If true, FLARM post-processing must not overwrite #altitude from
+   * #relative_altitude and ownship GPS altitude.
+   */
+  bool absolute_altitude;
 
   /** Was the turn rate of the target received from the flarm or calculated? */
   bool turn_rate_received;
@@ -182,6 +200,8 @@ struct FlarmTraffic {
     rssi = 0;
     rssi_available = false;
     no_track = false;
+    absolute_location = false;
+    absolute_altitude = false;
   }
 
   Angle Bearing() const noexcept {

--- a/src/MapWindow/MapWindowTraffic.cpp
+++ b/src/MapWindow/MapWindowTraffic.cpp
@@ -95,13 +95,16 @@ MapWindow::DrawFLARMTraffic(Canvas &canvas,
 
   canvas.Select(*traffic_look.font);
 
-  // Circle through the FLARM targets
+  // Circle through the traffic targets
   for (const auto &traffic : flarm.list) {
     if (!traffic.location_available)
       continue;
 
-  // No position traffic (relative_east=0) does not make sense in map display
-    if (traffic.relative_east)
+    /* Historically, we skipped targets with relative vectors == 0 to
+       avoid drawing "no position" FLARM targets.  Absolute-position
+       traffic (e.g. ADS-B) may legitimately have relative vectors not
+       computed yet, so allow those as well. */
+    if (traffic.relative_east != 0 || traffic.absolute_location)
       DrawFlarmTraffic(canvas, projection, traffic_look, false,
                        aircraft_pos, traffic);
   }
@@ -110,8 +113,7 @@ MapWindow::DrawFLARMTraffic(Canvas &canvas,
     for (const auto &[id, traffic] : fading) {
       assert(traffic.location_available);
 
-  // No position traffic (relative_east=0) does not make sense in map display
-      if (traffic.relative_east)
+      if (traffic.relative_east != 0 || traffic.absolute_location)
         DrawFlarmTraffic(canvas, projection, traffic_look, true,
                          aircraft_pos, traffic);
     }

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -301,6 +301,10 @@ constexpr std::string_view RaspFile = "RaspFile";
 constexpr std::string_view StratuxHorizontalRange = "StratuxHorizontalRange";
 constexpr std::string_view StratuxVerticalRange = "StratuxVerticalRange";
 
+constexpr std::string_view GDL90HorizontalRange = "GDL90HorizontalRange";
+constexpr std::string_view GDL90VerticalRange = "GDL90VerticalRange";
+constexpr std::string_view GDL90UseSystemUtcDate = "GDL90UseSystemUtcDate";
+
 constexpr std::string_view HideQuickGuideDialogOnStartup =
   "HideQuickGuideDialogOnStartup";
 constexpr std::string_view DisclaimerAcknowledgedVersion =

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -328,10 +328,15 @@ Draw(Canvas &canvas, PixelRect rc,
   if (info.pilot != nullptr)
     title_string = info.pilot;
   else
-    title_string = _("FLARM Traffic");
+    title_string = _("Traffic");
 
   // Append name to the title, if it exists
   const char *callsign = info.callsign;
+  if ((callsign == nullptr || StringIsEmpty(callsign)) &&
+      traffic != nullptr && traffic->HasName() &&
+      !StringIsEmpty(traffic->name))
+    callsign = traffic->name.c_str();
+
   if (callsign != nullptr && !StringIsEmpty(callsign)) {
     title_string.append(", ");
     title_string.append(callsign);

--- a/test/src/FakeGeoidNonZero.cpp
+++ b/test/src/FakeGeoidNonZero.cpp
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Geo/Geoid.hpp"
+#include "Geo/GeoPoint.hpp"
+
+double
+EGM96::LookupSeparation(const GeoPoint &)
+{
+  /* Non-zero so tests can verify datum conversion logic. */
+  return 30;
+}
+

--- a/test/src/TestGDL90.cpp
+++ b/test/src/TestGDL90.cpp
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "util/CRC16CCITT.hpp"
+#include "TestUtil.hpp"
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+
+static bool
+Unescape(const uint8_t *src, std::size_t size,
+         std::vector<uint8_t> &dest) noexcept
+{
+  dest.clear();
+  dest.reserve(size);
+
+  for (std::size_t i = 0; i < size; ++i) {
+    uint8_t b = src[i];
+    if (b != GDL90_ESCAPE) {
+      dest.push_back(b);
+      continue;
+    }
+
+    if (++i >= size)
+      return false;
+
+    dest.push_back(src[i] ^ GDL90_ESCAPE_XOR);
+  }
+
+  return true;
+}
+
+static uint16_t
+Gdl90Crc16(const uint8_t *data, std::size_t size) noexcept
+{
+  /* CRC-CCITT update function per GDL90 ICD 2.2.3 (table-driven). */
+  uint16_t crc = 0;
+
+  for (std::size_t i = 0; i < size; ++i)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ data[i];
+
+  return crc;
+}
+
+static constexpr uint16_t
+ReadLE16(const uint8_t *p) noexcept
+{
+  return uint16_t(p[0]) | (uint16_t(p[1]) << 8);
+}
+
+static constexpr uint16_t
+ReadBE16(const uint8_t *p) noexcept
+{
+  return (uint16_t(p[0]) << 8) | uint16_t(p[1]);
+}
+
+static constexpr uint32_t
+ReadBE24(const uint8_t *p) noexcept
+{
+  return (uint32_t(p[0]) << 16) | (uint32_t(p[1]) << 8) | uint32_t(p[2]);
+}
+
+static constexpr int32_t
+SignExtend24(uint32_t value) noexcept
+{
+  value &= 0x00ffffff;
+  if ((value & 0x00800000) != 0)
+    return int32_t(value | 0xff000000);
+  return int32_t(value);
+}
+
+static constexpr double
+SemiCircles24ToDegrees(int32_t value) noexcept
+{
+  return double(value) * (180.0 / double(1u << 23));
+}
+
+static void
+AppendEscaped(std::vector<uint8_t> &out, uint8_t b)
+{
+  if (b == GDL90_FLAG || b == GDL90_ESCAPE) {
+    out.push_back(GDL90_ESCAPE);
+    out.push_back(b ^ GDL90_ESCAPE_XOR);
+  } else
+    out.push_back(b);
+}
+
+static std::vector<uint8_t>
+BuildFrame(uint8_t msg_id, const uint8_t *payload, std::size_t payload_size)
+{
+  std::vector<uint8_t> body;
+  body.reserve(1 + payload_size + 2);
+
+  body.push_back(msg_id);
+  body.insert(body.end(), payload, payload + payload_size);
+
+  const uint16_t crc = Gdl90Crc16(body.data(), body.size());
+  body.push_back(uint8_t(crc & 0xff));
+  body.push_back(uint8_t(crc >> 8));
+
+  std::vector<uint8_t> framed;
+  framed.reserve(2 + body.size() * 2);
+  framed.push_back(GDL90_FLAG);
+  for (uint8_t b : body)
+    AppendEscaped(framed, b);
+  framed.push_back(GDL90_FLAG);
+  return framed;
+}
+
+struct DecodedTraffic {
+  uint8_t address_type;
+  uint32_t participant_address;
+  double lat_deg, lon_deg;
+  int altitude_ft;
+  char callsign[9];
+};
+
+static bool
+DecodeTraffic27(const uint8_t *payload, std::size_t size,
+                DecodedTraffic &out) noexcept
+{
+  if (size < 27)
+    return false;
+
+  out.address_type = payload[0] >> 4;
+  out.participant_address = ReadBE24(payload + 1);
+
+  const int32_t lat_raw = SignExtend24(ReadBE24(payload + 4));
+  const int32_t lon_raw = SignExtend24(ReadBE24(payload + 7));
+  out.lat_deg = SemiCircles24ToDegrees(lat_raw);
+  out.lon_deg = SemiCircles24ToDegrees(lon_raw);
+
+  const uint16_t alt_word = ReadBE16(payload + 10);
+  const uint16_t altitude_code = alt_word >> 4;
+  if (altitude_code == 0xfff)
+    return false;
+
+  out.altitude_ft = int(altitude_code) * 25 - 1000;
+
+  for (unsigned i = 0; i < 8; ++i)
+    out.callsign[i] = (char)payload[18 + i];
+  out.callsign[8] = 0;
+
+  return true;
+}
+
+static void
+TestHeartbeatExample() noexcept
+{
+  /* ICD 2.2.4 example (framed + CRC): 7E 00 81 41 DB D0 08 02 B3 8B 7E
+     CRC is little endian: 0x8BB3 (bytes B3 8B) */
+  static constexpr uint8_t frame[] = {
+    0x7e, 0x00, 0x81, 0x41, 0xdb, 0xd0, 0x08, 0x02, 0xb3, 0x8b, 0x7e,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(frame[0] == GDL90_FLAG);
+  ok1(frame[std::size(frame) - 1] == GDL90_FLAG);
+
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+  ok1(unescaped.size() == 1 + 6 + 2);
+  ok1(unescaped[0] == 0x00);
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+}
+
+static void
+TestTrafficExample() noexcept
+{
+  /* Example Traffic frame from a known-good implementation (includes one
+     escaped byte 0x7D 0x5D -> 0x7D in payload). */
+  static constexpr uint8_t frame[] = {
+    0x7E, 0x14, 0x00, 0x00, 0x00, 0x00, 0x18, 0x7D, 0x5D, 0xF5,
+    0xBD, 0x1F, 0xB4, 0x09, 0x49, 0x88, 0x27, 0x40, 0x00, 0x82,
+    0x01, 0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00,
+    0x5E, 0x66, 0x7E,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x14);
+  const uint8_t *payload = unescaped.data() + 1;
+  const std::size_t payload_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic t{};
+  ok1(DecodeTraffic27(payload, payload_len, t));
+
+  ok1(between(t.lat_deg, 34.0, 35.0));
+  ok1(between(t.lon_deg, -95.0, -93.0));
+  ok1(t.altitude_ft == 2700);
+}
+
+static void
+TestTrafficExampleFromIcd() noexcept
+{
+  /* GDL90 Public ICD Rev A, §3.5.2 / Table 12 "Traffic Report Example".
+     This table provides byte values (including Message ID) but not a framed
+     example; we compute CRC and build a framed message here. */
+  static constexpr uint8_t payload[] = {
+    0x00,             // st
+    0xAB, 0x45, 0x49, // aa aa aa
+    0x1F, 0xEF, 0x15, // ll ll ll
+    0xA8, 0x89, 0x78, // nn nn nn
+    0x0F,             // dd
+    0x09,             // dm
+    0xA9,             // ia
+    0x07,             // hh
+    0xB0,             // hv
+    0x01,             // vv
+    0x20,             // tt
+    0x01,             // ee
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20, // cc.. (N825V   )
+    0x00,             // px
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  std::vector<uint8_t> unescaped;
+  ok1(frame.front() == GDL90_FLAG);
+  ok1(frame.back() == GDL90_FLAG);
+  ok1(Unescape(frame.data() + 1, frame.size() - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x14);
+  const uint8_t *pl = unescaped.data() + 1;
+  const std::size_t pl_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic t{};
+  ok1(DecodeTraffic27(pl, pl_len, t));
+
+  ok1(t.participant_address == 0xAB4549);
+  ok1(between(t.lat_deg, 44.90, 44.92));
+  ok1(between(t.lon_deg, -123.01, -122.98));
+  ok1(t.altitude_ft == 5000);
+  ok1(std::string_view(t.callsign, 5) == "N825V");
+}
+
+static void
+TestOwnshipExample() noexcept
+{
+  /* Ownship Report sample frame (framed + CRC).
+     Known-good vector from a GDL90 implementation test suite. */
+  static constexpr uint8_t frame[] = {
+    0x7E, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x15, 0xA7, 0xE5, 0xBA,
+    0x47, 0x99, 0x08, 0xC9, 0x88, 0xFF, 0xE0, 0x00, 0x80, 0x01,
+    0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00, 0x7B,
+    0xE5, 0x7E,
+  };
+
+  std::vector<uint8_t> unescaped;
+  ok1(Unescape(frame + 1, std::size(frame) - 2, unescaped));
+
+  const uint16_t rx_crc = ReadLE16(unescaped.data() + unescaped.size() - 2);
+  const uint16_t calc_crc = Gdl90Crc16(unescaped.data(), unescaped.size() - 2);
+  ok1(rx_crc == calc_crc);
+
+  ok1(unescaped[0] == 0x0A);
+  const uint8_t *payload = unescaped.data() + 1;
+  const std::size_t payload_len = unescaped.size() - 1 - 2;
+
+  DecodedTraffic o{};
+  ok1(DecodeTraffic27(payload, payload_len, o));
+
+  ok1(between(o.lat_deg, 30.0, 31.0));
+  ok1(between(o.lon_deg, -99.0, -98.0));
+  ok1(o.altitude_ft == 2500);
+}
+
+int main()
+{
+  plan_tests(4 + 9 + 2 + 9 + 7);
+
+  TestHeartbeatExample();
+  TestTrafficExample();
+  TestTrafficExampleFromIcd();
+  TestOwnshipExample();
+
+  return exit_status();
+}
+

--- a/test/src/TestGDL90Driver.cpp
+++ b/test/src/TestGDL90Driver.cpp
@@ -1,0 +1,909 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/GDL90/Driver.hpp"
+#include "FLARM/Computer.hpp"
+#include "FLARM/Id.hpp"
+#include "Geo/Geoid.hpp"
+#include "NMEA/Info.hpp"
+#include "TestUtil.hpp"
+#include "Units/System.hpp"
+#include "util/CRC16CCITT.hpp"
+
+#include <cstdint>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+static constexpr uint8_t GDL90_FLAG = 0x7e;
+static constexpr uint8_t GDL90_ESCAPE = 0x7d;
+static constexpr uint8_t GDL90_ESCAPE_XOR = 0x20;
+
+static constexpr uint8_t OWNERSHIP_FRAME[] = {
+  0x7E, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x15, 0xA7, 0xE5, 0xBA,
+  0x47, 0x99, 0x08, 0xC9, 0x88, 0xFF, 0xE0, 0x00, 0x80, 0x01,
+  0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20, 0x00, 0x7B,
+  0xE5, 0x7E,
+};
+
+static NMEAInfo
+MakeBlankNMEAInfo() noexcept
+{
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+  return info;
+}
+
+static void
+FeedOwnship(GDL90Device &dev, NMEAInfo &info) noexcept
+{
+  dev.DataReceived({reinterpret_cast<const std::byte *>(OWNERSHIP_FRAME),
+                    sizeof(OWNERSHIP_FRAME)}, info);
+}
+
+static uint16_t
+Gdl90Crc16(const uint8_t *data, std::size_t size) noexcept
+{
+  /* CRC-CCITT update function per GDL90 ICD 2.2.3 (table-driven). */
+  uint16_t crc = 0;
+  for (std::size_t i = 0; i < size; ++i)
+    crc = crc16ccitt_table[crc >> 8] ^ (crc << 8) ^ data[i];
+
+  return crc;
+}
+
+static void
+AppendEscaped(std::vector<uint8_t> &out, uint8_t b)
+{
+  if (b == GDL90_FLAG || b == GDL90_ESCAPE) {
+    out.push_back(GDL90_ESCAPE);
+    out.push_back(b ^ GDL90_ESCAPE_XOR);
+  } else
+    out.push_back(b);
+}
+
+static std::vector<uint8_t>
+BuildFrame(uint8_t msg_id, const uint8_t *payload, std::size_t payload_size)
+{
+  std::vector<uint8_t> body;
+  body.reserve(1 + payload_size + 2);
+
+  body.push_back(msg_id);
+  body.insert(body.end(), payload, payload + payload_size);
+
+  const uint16_t crc = Gdl90Crc16(body.data(), body.size());
+  body.push_back(uint8_t(crc & 0xff));
+  body.push_back(uint8_t(crc >> 8));
+
+  std::vector<uint8_t> framed;
+  framed.reserve(2 + body.size() * 2);
+  framed.push_back(GDL90_FLAG);
+  for (uint8_t b : body)
+    AppendEscaped(framed, b);
+  framed.push_back(GDL90_FLAG);
+  return framed;
+}
+
+static int32_t
+DegreesToSemiCircles24(double deg) noexcept
+{
+  long value = lround(deg * (double(1u << 23) / 180.0));
+  if (value < -(1l << 23))
+    value = -(1l << 23);
+  if (value > (1l << 23) - 1)
+    value = (1l << 23) - 1;
+  return int32_t(value);
+}
+
+static void
+WriteBE24(uint8_t *dest, int32_t value) noexcept
+{
+  const uint32_t u = uint32_t(value) & 0x00ffffff;
+  dest[0] = uint8_t(u >> 16);
+  dest[1] = uint8_t(u >> 8);
+  dest[2] = uint8_t(u);
+}
+
+static std::vector<uint8_t>
+BuildTrafficFrame(uint32_t icao, double lat_deg, double lon_deg,
+                  bool altitude_available, unsigned altitude_ft) noexcept
+{
+  uint8_t payload[27]{};
+  payload[0] = 0x00; /* address_type=0, alert=0 */
+  payload[1] = uint8_t((icao >> 16) & 0xff);
+  payload[2] = uint8_t((icao >> 8) & 0xff);
+  payload[3] = uint8_t(icao & 0xff);
+
+  WriteBE24(payload + 4, DegreesToSemiCircles24(lat_deg));
+  WriteBE24(payload + 7, DegreesToSemiCircles24(lon_deg));
+
+  const uint8_t misc = 0x01;
+  const uint16_t alt_code = altitude_available
+    ? uint16_t((altitude_ft + 1000) / 25)
+    : 0x0fff;
+  const uint16_t alt_word = uint16_t((alt_code << 4) | misc);
+  payload[10] = uint8_t(alt_word >> 8);
+  payload[11] = uint8_t(alt_word & 0xff);
+
+  payload[16] = 0xff; /* track N/A */
+  payload[17] = 0x01; /* emitter category */
+  payload[26] = 0x00;
+
+  return BuildFrame(0x14, payload, sizeof(payload));
+}
+
+static std::vector<uint8_t>
+BuildForeFlightIdFrame(bool geo_altitude_is_msl) noexcept
+{
+  /* ForeFlight 0x65 ID message (sub-id 0, version 1):
+     https://foreflight.com/connect/spec/ */
+  uint8_t payload[38]{};
+  payload[0] = 0x00; /* sub-id */
+  payload[1] = 0x01; /* version */
+
+  /* capabilities mask (big-endian) at payload[34..37], bit0 = datum */
+  payload[37] = geo_altitude_is_msl ? 0x01 : 0x00;
+
+  return BuildFrame(0x65, payload, sizeof(payload));
+}
+
+static std::vector<uint8_t>
+BuildForeFlightAhrsFrame(int roll_tenths_deg, int pitch_tenths_deg,
+                         unsigned heading_tenths_deg,
+                         bool heading_magnetic,
+                         unsigned ias_kt,
+                         unsigned tas_kt) noexcept
+{
+  uint8_t payload[11]{};
+  payload[0] = 0x01; /* sub-id (AHRS) */
+
+  payload[1] = uint8_t((roll_tenths_deg >> 8) & 0xff);
+  payload[2] = uint8_t(roll_tenths_deg & 0xff);
+
+  payload[3] = uint8_t((pitch_tenths_deg >> 8) & 0xff);
+  payload[4] = uint8_t(pitch_tenths_deg & 0xff);
+
+  uint16_t heading = uint16_t(heading_tenths_deg & 0x7fff);
+  if (heading_magnetic)
+    heading |= 0x8000;
+  payload[5] = uint8_t(heading >> 8);
+  payload[6] = uint8_t(heading & 0xff);
+
+  payload[7] = uint8_t((ias_kt >> 8) & 0xff);
+  payload[8] = uint8_t(ias_kt & 0xff);
+
+  payload[9] = uint8_t((tas_kt >> 8) & 0xff);
+  payload[10] = uint8_t(tas_kt & 0xff);
+
+  return BuildFrame(0x65, payload, sizeof(payload));
+}
+
+static std::vector<uint8_t>
+BuildFrameBadCrc(uint8_t msg_id, const uint8_t *payload,
+                 std::size_t payload_size)
+{
+  auto frame = BuildFrame(msg_id, payload, payload_size);
+
+  /* flip one byte inside the frame body to make CRC invalid */
+  if (frame.size() >= 4)
+    frame[2] ^= 0x01;
+
+  return frame;
+}
+
+static void
+Feed(GDL90Device &dev, NMEAInfo &info, const std::vector<uint8_t> &bytes)
+{
+  const auto *p = reinterpret_cast<const std::byte *>(bytes.data());
+  dev.DataReceived({p, bytes.size()}, info);
+}
+
+static void
+TestBadCrcIgnored() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B','A','D','C','R','C',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrameBadCrc(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(!info.alive);
+  ok1(info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestHeartbeatTimeOfDay() noexcept
+{
+  /* Heartbeat payload with UTC time-of-day. */
+  static constexpr unsigned seconds = 12345;
+  static_assert(seconds < 24u * 60u * 60u);
+
+  uint8_t payload[6]{};
+  payload[0] = 0x01; /* status1 */
+  payload[1] = uint8_t(((seconds >> 16) & 0x01) << 7) | 0x01; /* status2 */
+  payload[2] = uint8_t(seconds & 0xff);
+  payload[3] = uint8_t((seconds >> 8) & 0xff);
+
+  const auto frame = BuildFrame(0x00, payload, sizeof(payload));
+
+  const bool saved_use_system_utc_date = gdl90_settings.use_system_utc_date;
+  gdl90_settings.use_system_utc_date = true;
+
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  Feed(dev, info, frame);
+
+  gdl90_settings.use_system_utc_date = saved_use_system_utc_date;
+
+  ok1(info.time_available);
+  ok1(fabs(info.time.ToDuration().count() - double(seconds)) < 0.01);
+  ok1(info.date_time_utc.IsDatePlausible());
+}
+
+static void
+TestResyncAfterBadCrc() noexcept
+{
+  static constexpr uint8_t payload_bad[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B','A','D',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  static constexpr uint8_t payload_good[] = {
+    0x00,
+    0x0A, 0x0B, 0x0C,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'G','O','O','D',' ',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrameBadCrc(0x14, payload_bad, sizeof(payload_bad));
+  const auto good = BuildFrame(0x14, payload_good, sizeof(payload_good));
+  bytes.insert(bytes.end(), good.begin(), good.end());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestNoisePrefix() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x11, 0x22, 0x33,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'N','O','I','S','E',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrame(0x14, payload, sizeof(payload));
+  bytes.insert(bytes.begin(), {0x00, 0x01, 0x02, 0x7d, 0x20, 0x55});
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestTwoFramesOneChunk() noexcept
+{
+  static constexpr uint8_t payload_a[] = {
+    0x00,
+    0x01, 0x02, 0x03,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'A',' ',' ',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  static constexpr uint8_t payload_b[] = {
+    0x00,
+    0x04, 0x05, 0x06,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'B',' ',' ',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  auto bytes = BuildFrame(0x14, payload_a, sizeof(payload_a));
+  const auto b = BuildFrame(0x14, payload_b, sizeof(payload_b));
+  bytes.insert(bytes.end(), b.begin(), b.end());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, bytes);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+}
+
+static void
+TestEscapingInPayload() noexcept
+{
+  /* Force escaping via participant_address bytes 0x7e and 0x7d. */
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x7E, 0x7D, 0x01,
+    0x20, 0x00, 0x00,
+    0x20, 0x00, 0x00,
+    0x03, 0xC0,
+    0x00,
+    0x00, 0x10, 0x00,
+    0x00,
+    0x01,
+    'E','S','C',' ',' ',' ',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+  const FlarmId expected = FlarmId::Parse("7E7D01", nullptr);
+  ok1(info.flarm.traffic.FindTraffic(expected) != nullptr);
+}
+
+static void
+TestOwnshipDriver() noexcept
+{
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  FeedOwnship(dev, info);
+
+  ok1(info.alive);
+  ok1(info.location_available);
+  ok1(between(info.location.latitude.Degrees(), 30.0, 31.0));
+  ok1(between(info.location.longitude.Degrees(), -99.0, -98.0));
+  ok1(info.pressure_altitude_available);
+  ok1(between(info.pressure_altitude,
+              Units::ToSysUnit(2495, Unit::FEET),
+              Units::ToSysUnit(2505, Unit::FEET)));
+}
+
+static void
+TestOwnshipGeometricAltitude() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x03, 0xE8, /* 1000 * 5ft = 5000ft */
+    0x00, 0x00, /* FOM (ignored) */
+  };
+
+  const auto frame = BuildFrame(0x0b, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  Feed(dev, info, frame);
+
+  ok1(info.gps_altitude_available);
+  ok1(between(info.gps_altitude,
+              Units::ToSysUnit(4990, Unit::FEET),
+              Units::ToSysUnit(5010, Unit::FEET)));
+}
+
+static void
+TestOwnshipGeometricAltitudeDatum() noexcept
+{
+  static constexpr uint8_t payload[] = {
+    0x03, 0xE8, /* 1000 * 5ft = 5000ft */
+    0x00, 0x00,
+  };
+
+  const auto id_ellipsoid = BuildForeFlightIdFrame(false);
+  const auto id_msl = BuildForeFlightIdFrame(true);
+  const auto geo_alt = BuildFrame(0x0b, payload, sizeof(payload));
+
+  {
+    GDL90Device dev;
+    NMEAInfo info = MakeBlankNMEAInfo();
+
+    info.location = GeoPoint(Angle::Degrees(11), Angle::Degrees(48));
+    info.location_available.Update(info.clock);
+
+    Feed(dev, info, id_ellipsoid);
+    Feed(dev, info, geo_alt);
+
+    const double expected = Units::ToSysUnit(5000, Unit::FEET) -
+      EGM96::LookupSeparation(info.location);
+
+    ok1(info.gps_altitude_available);
+    ok1(between(info.gps_altitude, expected - 1, expected + 1));
+  }
+
+  {
+    GDL90Device dev;
+    NMEAInfo info = MakeBlankNMEAInfo();
+
+    info.location = GeoPoint(Angle::Degrees(11), Angle::Degrees(48));
+    info.location_available.Update(info.clock);
+
+    Feed(dev, info, id_msl);
+    Feed(dev, info, geo_alt);
+
+    const double expected = Units::ToSysUnit(5000, Unit::FEET);
+    ok1(info.gps_altitude_available);
+    ok1(between(info.gps_altitude, expected - 1, expected + 1));
+  }
+}
+
+static void
+TestForeFlightAhrs() noexcept
+{
+  const auto frame = BuildForeFlightAhrsFrame(123, -45, 2000, false, 70, 75);
+
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  Feed(dev, info, frame);
+
+  ok1(info.attitude.bank_angle_available);
+  ok1(between(info.attitude.bank_angle.Degrees(), 12.2, 12.4));
+
+  ok1(info.attitude.pitch_angle_available);
+  ok1(between(info.attitude.pitch_angle.Degrees(), -4.6, -4.4));
+
+  ok1(info.attitude.heading_available);
+  ok1(between(info.attitude.heading.Degrees(), 199.9, 200.1));
+
+  ok1(info.airspeed_available);
+  ok1(between(info.indicated_airspeed,
+              Units::ToSysUnit(69.5, Unit::KNOTS),
+              Units::ToSysUnit(70.5, Unit::KNOTS)));
+  ok1(between(info.true_airspeed,
+              Units::ToSysUnit(74.5, Unit::KNOTS),
+              Units::ToSysUnit(75.5, Unit::KNOTS)));
+}
+
+static void
+TestTrafficDriver() noexcept
+{
+  /* Traffic Report payload (27 bytes) with ICAO = 0xAB4549.
+     The bytes are from the GDL90 report layout examples. */
+  static constexpr uint8_t payload[] = {
+    0x00,             // status/address type nibble
+    0xAB, 0x45, 0x49, // participant address (big-endian 24-bit)
+    0x1F, 0xEF, 0x15, // latitude
+    0xA8, 0x89, 0x78, // longitude
+    0x0F, 0x09,       // altitude/misc (big-endian)
+    0xA9,             // NACp/NIC
+    0x07, 0xB0, 0x01, // velocity
+    0x20,             // track
+    0x01,             // emitter category
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20, // callsign
+    0x00,             // emergency/reserved
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(info.alive);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("AB4549", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+  ok1(t != nullptr && t->location_available);
+  ok1(t != nullptr && t->name.equals("N825V"));
+  ok1(t != nullptr && t->type == FlarmTraffic::AircraftType::POWERED_AIRCRAFT);
+  ok1(t != nullptr && t->source == FlarmTraffic::SourceType::ADSB);
+  ok1(t != nullptr && t->id_type == FlarmTraffic::IdType::ICAO);
+  ok1(t != nullptr && t->altitude_available);
+  ok1(t != nullptr && between(t->altitude,
+                              Units::ToSysUnit(4990, Unit::FEET),
+                              Units::ToSysUnit(5010, Unit::FEET)));
+}
+
+static void
+TestTrafficAddressTypeSource() noexcept
+{
+  /* Same geometry as TestTrafficDriver; only address-type nibble changes. */
+  static constexpr uint8_t base_payload[] = {
+    0x00,             // replaced per case
+    0xAB, 0x45, 0x49,
+    0x1F, 0xEF, 0x15,
+    0xA8, 0x89, 0x78,
+    0x0F, 0x09,
+    0xA9,
+    0x07, 0xB0, 0x01,
+    0x20,
+    0x01,
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20,
+    0x00,
+  };
+
+  struct Case {
+    uint8_t status_byte;
+    FlarmTraffic::SourceType expect_source;
+    FlarmTraffic::IdType expect_id_type;
+  };
+
+  static constexpr Case cases[] = {
+    {0x10, FlarmTraffic::SourceType::ADSB, FlarmTraffic::IdType::RANDOM},
+    {0x20, FlarmTraffic::SourceType::TISB, FlarmTraffic::IdType::ICAO},
+    {0x30, FlarmTraffic::SourceType::TISB, FlarmTraffic::IdType::RANDOM},
+    {0x40, FlarmTraffic::SourceType::TISB, FlarmTraffic::IdType::ICAO},
+    {0x60, FlarmTraffic::SourceType::ADSR, FlarmTraffic::IdType::ICAO},
+  };
+
+  for (const Case &c : cases) {
+    uint8_t payload[sizeof(base_payload)];
+    memcpy(payload, base_payload, sizeof(payload));
+    payload[0] = c.status_byte;
+
+    const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+    GDL90Device dev;
+    NMEAInfo info;
+    info.Reset();
+    info.clock = TimeStamp{FloatDuration{1}};
+
+    Feed(dev, info, frame);
+
+    const FlarmId expected = FlarmId::Parse("AB4549", nullptr);
+    const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+    ok1(t != nullptr);
+    ok1(t != nullptr && t->source == c.expect_source);
+    ok1(t != nullptr && t->id_type == c.expect_id_type);
+  }
+}
+
+static void
+TestRelativeAltitudeFromPressureAltitude() noexcept
+{
+  static constexpr uint8_t traffic_payload[] = {
+    0x00,             // status/address type nibble
+    0xAB, 0x45, 0x49, // participant address (big-endian 24-bit)
+    0x1F, 0xEF, 0x15, // latitude
+    0xA8, 0x89, 0x78, // longitude
+    0x0F, 0x09,       // altitude/misc (big-endian): 5000ft
+    0xA9,             // NACp/NIC
+    0x07, 0xB0, 0x01, // velocity
+    0x20,             // track
+    0x01,             // emitter category
+    0x4E, 0x38, 0x32, 0x35, 0x56, 0x20, 0x20, 0x20, // callsign
+    0x00,             // emergency/reserved
+  };
+
+  const auto traffic_frame = BuildFrame(0x14, traffic_payload,
+                                        sizeof(traffic_payload));
+
+  const uint16_t saved_hrange = gdl90_settings.hrange;
+  const uint16_t saved_vrange = gdl90_settings.vrange;
+  gdl90_settings.hrange = 0;
+  gdl90_settings.vrange = 0;
+
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  FeedOwnship(dev, info);
+  Feed(dev, info, traffic_frame);
+
+  gdl90_settings.hrange = saved_hrange;
+  gdl90_settings.vrange = saved_vrange;
+
+  ok1(info.pressure_altitude_available);
+
+  const FlarmId expected = FlarmId::Parse("AB4549", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+  ok1(t != nullptr && t->absolute_altitude);
+  ok1(t != nullptr && t->altitude_available);
+
+  FlarmComputer computer;
+  FlarmData last_flarm{};
+  computer.Process(info.flarm, last_flarm, info);
+
+  /* Ownship (2500ft) vs traffic (5000ft) => +2500ft (~762m). */
+  const FlarmTraffic *t2 = info.flarm.traffic.FindTraffic(expected);
+  ok1(t2 != nullptr &&
+      between(t2->relative_altitude, 760.0, 764.0));
+}
+
+static void
+TestHorizontalRangeFilter() noexcept
+{
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  FeedOwnship(dev, info);
+  ok1(info.location_available);
+
+  gdl90_settings.hrange = 100; /* 100m */
+  gdl90_settings.vrange = 0;
+
+  const auto far = BuildTrafficFrame(0x010203,
+                                     info.location.latitude.Degrees() + 0.02,
+                                     info.location.longitude.Degrees(),
+                                     false, 0);
+  Feed(dev, info, far);
+  ok1(info.flarm.traffic.IsEmpty());
+
+  const auto near = BuildTrafficFrame(0x010204,
+                                      info.location.latitude.Degrees(),
+                                      info.location.longitude.Degrees(),
+                                      false, 0);
+  Feed(dev, info, near);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  gdl90_settings.hrange = 20000;
+  gdl90_settings.vrange = 2000;
+}
+
+static void
+TestVerticalRangeFilter() noexcept
+{
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  FeedOwnship(dev, info);
+  ok1(info.pressure_altitude_available);
+
+  gdl90_settings.hrange = 0;
+  gdl90_settings.vrange = 100; /* 100m */
+
+  const auto high = BuildTrafficFrame(0x010205,
+                                      info.location.latitude.Degrees(),
+                                      info.location.longitude.Degrees(),
+                                      true, 6000);
+  Feed(dev, info, high);
+  ok1(info.flarm.traffic.IsEmpty());
+
+  const auto close = BuildTrafficFrame(0x010206,
+                                       info.location.latitude.Degrees(),
+                                       info.location.longitude.Degrees(),
+                                       true, 2800);
+  Feed(dev, info, close);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  gdl90_settings.hrange = 20000;
+  gdl90_settings.vrange = 2000;
+}
+
+static void
+TestVerticalFilterSkippedWithoutOwnshipPressure() noexcept
+{
+  /* Traffic altitude is pressure; vertical filter must not use GPS MSL as
+     reference when baro is missing (else vrange rejects all targets). */
+  const uint16_t saved_h = gdl90_settings.hrange;
+  const uint16_t saved_v = gdl90_settings.vrange;
+  gdl90_settings.hrange = 0;
+  gdl90_settings.vrange = 100;
+
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+  FeedOwnship(dev, info);
+  ok1(info.pressure_altitude_available);
+  info.pressure_altitude_available.Clear();
+  info.gps_altitude = Units::ToSysUnit(12000, Unit::FEET);
+  info.gps_altitude_available.Update(info.clock);
+
+  const auto frame = BuildTrafficFrame(0x010208,
+                                       info.location.latitude.Degrees(),
+                                       info.location.longitude.Degrees(),
+                                       true, 2800);
+  Feed(dev, info, frame);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  gdl90_settings.hrange = saved_h;
+  gdl90_settings.vrange = saved_v;
+}
+
+static void
+TestChunkedOwnshipFrame() noexcept
+{
+  /* Feed one framed Ownship Report in small chunks to validate buffering. */
+  GDL90Device dev;
+  NMEAInfo info = MakeBlankNMEAInfo();
+
+  const auto *bytes = reinterpret_cast<const std::byte *>(OWNERSHIP_FRAME);
+  dev.DataReceived({bytes, 3}, info);
+  ok1(!info.location_available);
+
+  dev.DataReceived({bytes + 3, 5}, info);
+  ok1(!info.location_available);
+
+  dev.DataReceived({bytes + 8, sizeof(OWNERSHIP_FRAME) - 8}, info);
+  ok1(info.location_available);
+  ok1(between(info.location.latitude.Degrees(), 30.0, 31.0));
+}
+
+static void
+TestNegativeCoordinates() noexcept
+{
+  /* Validate sign-extension (ICD §3.5.1.3) using -45° lat/lon (0xE0 00 00). */
+  static constexpr uint8_t payload[] = {
+    0x00,             // status/address type nibble
+    0x01, 0x02, 0x03, // participant address (big-endian 24-bit)
+    0xE0, 0x00, 0x00, // latitude  -45.0
+    0xE0, 0x00, 0x00, // longitude -45.0
+    0x03, 0xC0,       // altitude/misc (big-endian): 500ft => (500+1000)/25=60 => 0x03C, +m=0
+    0x00,             // NACp/NIC
+    0x00, 0x10, 0x00, // velocity (arbitrary, valid)
+    0x00,             // track
+    0x01,             // emitter category
+    'T','E','S','T',' ',' ',' ',' ', // callsign
+    0x00,             // emergency/reserved
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("010203", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+
+  ok1(between(t->location.latitude.Degrees(), -46.0, -44.0));
+  ok1(between(t->location.longitude.Degrees(), -46.0, -44.0));
+}
+
+static void
+TestUnavailableFields() noexcept
+{
+  /* Exercise special values: altitude=0xFFF (invalid), hvel=0xFFF (N/A),
+     vvel=0x800 (N/A), track=0xFF (N/A). */
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x0A, 0x0B, 0x0C,
+    0x20, 0x00, 0x00, // lat +45
+    0x20, 0x00, 0x00, // lon +45
+    0xFF, 0xF0,       // altitude_code=0xFFF, m=0
+    0x00,
+    0xFF, 0xF8, 0x00, // h=0xFFF, v=0x800
+    0xFF,             // track unavailable
+    0x01,
+    'N','O','N','E',' ',' ',' ',' ',
+    0x00,
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+  ok1(!info.flarm.traffic.IsEmpty());
+
+  const FlarmId expected = FlarmId::Parse("0A0B0C", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+
+  ok1(t != nullptr && !t->altitude_available);
+  ok1(t != nullptr && !t->speed_received);
+  ok1(t != nullptr && !t->climb_rate_received);
+  ok1(t != nullptr && !t->track_received);
+}
+
+static void
+TestOversizeFrameDropped() noexcept
+{
+  /* Ensure pathological frames don't cause excessive work/allocations. */
+  std::vector<uint8_t> payload(2000, 0);
+  const auto frame = BuildFrame(0x14, payload.data(), payload.size());
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  ok1(!info.alive);
+  ok1(info.flarm.traffic.IsEmpty());
+}
+
+int main()
+{
+  plan_tests(89);
+
+  TestBadCrcIgnored();
+  TestHeartbeatTimeOfDay();
+  TestResyncAfterBadCrc();
+  TestNoisePrefix();
+  TestTwoFramesOneChunk();
+  TestEscapingInPayload();
+  TestOwnshipDriver();
+  TestOwnshipGeometricAltitude();
+  TestOwnshipGeometricAltitudeDatum();
+  TestForeFlightAhrs();
+  TestTrafficDriver();
+  TestTrafficAddressTypeSource();
+  TestRelativeAltitudeFromPressureAltitude();
+  TestHorizontalRangeFilter();
+  TestVerticalRangeFilter();
+  TestVerticalFilterSkippedWithoutOwnshipPressure();
+  TestChunkedOwnshipFrame();
+  TestNegativeCoordinates();
+  TestUnavailableFields();
+  TestOversizeFrameDropped();
+
+  return exit_status();
+}
+

--- a/tools/gdl90_send.py
+++ b/tools/gdl90_send.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# Generate synthetic GDL90 traffic and send via UDP.
+#
+# Usage example:
+#   python3 tools/gdl90_send.py --host 127.0.0.1 --port 4352 --n-targets 8
+#
+# Configure XCSoar device:
+#   Driver: GDL90
+#   Port: UDP listener on the same port (e.g. 4352)
+
+from __future__ import annotations
+
+import argparse
+import math
+import random
+import socket
+import struct
+import time
+from datetime import datetime, timezone
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+
+GDL90_FLAG = 0x7E
+GDL90_ESCAPE = 0x7D
+GDL90_ESCAPE_XOR = 0x20
+
+
+def _crc16_ccitt_table() -> list[int]:
+    """
+    CRC-CCITT table (poly 0x1021), matching XCSoar's CRC16-CCITT.
+    """
+    table: list[int] = []
+    for i in range(256):
+        crc = i << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) if (crc & 0x8000) else (crc << 1)
+            crc &= 0xFFFF
+        table.append(crc)
+    return table
+
+
+_CRC_TABLE = _crc16_ccitt_table()
+
+
+def gdl90_crc16(data: bytes) -> int:
+    """
+    Table-driven CRC update in the style used by XCSoar's driver/tests:
+      crc = table[crc >> 8] ^ (crc << 8) ^ b
+    """
+    crc = 0
+    for b in data:
+        crc = _CRC_TABLE[(crc >> 8) & 0xFF] ^ ((crc << 8) & 0xFFFF) ^ b
+    return crc & 0xFFFF
+
+
+def gdl90_escape(body: bytes) -> bytes:
+    out = bytearray()
+    for b in body:
+        if b in (GDL90_FLAG, GDL90_ESCAPE):
+            out.append(GDL90_ESCAPE)
+            out.append(b ^ GDL90_ESCAPE_XOR)
+        else:
+            out.append(b)
+    return bytes(out)
+
+
+def gdl90_frame(msg_id: int, payload: bytes) -> bytes:
+    body = bytes([msg_id & 0x7F]) + payload
+    crc = gdl90_crc16(body)
+    body += struct.pack("<H", crc)  # little-endian CRC per ICD
+    return bytes([GDL90_FLAG]) + gdl90_escape(body) + bytes([GDL90_FLAG])
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+def degrees_to_semicircles24(deg: float) -> int:
+    """
+    Convert degrees to signed 24-bit semicircle fraction:
+      deg = raw * 180 / 2^23
+      raw = deg * 2^23 / 180
+    """
+    raw = int(round(deg * (1 << 23) / 180.0))
+    raw = max(-(1 << 23), min((1 << 23) - 1, raw))
+    return raw
+
+
+def pack_be24_signed(value: int) -> bytes:
+    value &= 0xFFFFFF
+    return bytes([(value >> 16) & 0xFF, (value >> 8) & 0xFF, value & 0xFF])
+
+
+def altitude_ft_to_code(altitude_ft: float) -> int:
+    """
+    GDL90 altitude code: 25ft steps, offset -1000ft, 12-bit.
+    """
+    code = int(round((altitude_ft + 1000.0) / 25.0))
+    return max(0, min(0xFFE, code))
+
+
+def callsign8(s: str) -> bytes:
+    s = "".join(ch for ch in s.upper() if 0x20 <= ord(ch) < 0x7F)
+    s = s[:8].ljust(8, " ")
+    return s.encode("ascii", errors="replace")
+
+
+def build_heartbeat(*, include_tod: bool = True) -> bytes:
+    """
+    Heartbeat payload (6 bytes). If include_tod is false, all zeros (no UTC
+    time-of-day, status2 bit0 clear). If true, encode UTC seconds since
+    midnight with UTC-valid bit (Stratux-compatible layout).
+    """
+    payload = bytearray(6)
+    if include_tod:
+        now = datetime.now(timezone.utc)
+        seconds = now.hour * 3600 + now.minute * 60 + now.second
+        # Match ICD §3.1 / Stratux: [0] status1, [1] status2 (UTC OK bit0,
+        # seconds bit16 in bit7), [2:3] seconds LE, [4:5] message counts.
+        payload[0] = 0x01
+        payload[1] = 0x01 | (((seconds >> 16) & 0x01) << 7)
+        payload[2] = seconds & 0xFF
+        payload[3] = (seconds >> 8) & 0xFF
+    return bytes(payload)
+
+
+def build_foreflight_id(*, geo_altitude_is_msl: bool) -> bytes:
+    """
+    ForeFlight GDL90 extension ID message (0x65, sub-id 0, version 1).
+
+    Capabilities mask bit 0 declares the datum for Ownship Geometric Altitude
+    (0x0B): 0=WGS-84 ellipsoid, 1=MSL.
+    """
+    payload = bytearray(38)
+    payload[0] = 0x00  # sub-id (ID)
+    payload[1] = 0x01  # version
+
+    # payload[34..37] capabilities mask (big-endian)
+    capabilities = 0x00000001 if geo_altitude_is_msl else 0x00000000
+    payload[34:38] = struct.pack(">I", capabilities)
+    return bytes(payload)
+
+
+def build_foreflight_ahrs(*, roll_deg: Optional[float], pitch_deg: Optional[float],
+                          heading_deg: Optional[float], heading_is_magnetic: bool,
+                          ias_kt: Optional[float], tas_kt: Optional[float]) -> bytes:
+    """
+    ForeFlight GDL90 extension AHRS message (0x65, sub-id 0x01).
+
+    Roll/Pitch/Heading use 0.1° resolution. IAS/TAS use knots. 0x7fff/0xffff
+    represent invalid values depending on the field.
+    """
+    payload = bytearray(11)
+    payload[0] = 0x01  # sub-id (AHRS)
+
+    def pack_i16_tenths(x: Optional[float]) -> bytes:
+        if x is None:
+            return struct.pack(">h", 0x7FFF)
+        v = int(round(_clamp(x, -180.0, 180.0) * 10.0))
+        return struct.pack(">h", v)
+
+    payload[1:3] = pack_i16_tenths(roll_deg)
+    payload[3:5] = pack_i16_tenths(pitch_deg)
+
+    if heading_deg is None:
+        payload[5:7] = struct.pack(">H", 0xFFFF)
+    else:
+        h10 = int(round((_clamp(heading_deg, 0.0, 359.9)) * 10.0)) & 0x7FFF
+        h = h10 | (0x8000 if heading_is_magnetic else 0x0000)
+        payload[5:7] = struct.pack(">H", h)
+
+    def pack_u16(x: Optional[float]) -> bytes:
+        if x is None:
+            return struct.pack(">H", 0xFFFF)
+        v = int(round(_clamp(x, 0.0, 65534.0)))
+        return struct.pack(">H", v)
+
+    payload[7:9] = pack_u16(ias_kt)
+    payload[9:11] = pack_u16(tas_kt)
+    return bytes(payload)
+
+
+def build_ownship(lat_deg: float, lon_deg: float, altitude_ft: float,
+                  ground_speed_kt: float, track_deg: float) -> bytes:
+    payload = bytearray(27)
+    # bytes 0..3 reserved/status: leave 0
+    payload[4:7] = pack_be24_signed(degrees_to_semicircles24(lat_deg))
+    payload[7:10] = pack_be24_signed(degrees_to_semicircles24(lon_deg))
+
+    misc = 0x01  # set track_valid bits (driver checks (misc&0x03)!=0)
+    alt_code = altitude_ft_to_code(altitude_ft)
+    alt_word = (alt_code << 4) | (misc & 0x0F)
+    payload[10:12] = struct.pack(">H", alt_word)
+
+    payload[12] = 0x00  # NACp/NIC (unused)
+
+    h = int(round(_clamp(ground_speed_kt, 0.0, 4094.0)))
+    v = 0x0800  # vertical N/A
+    vel = ((h & 0x0FFF) << 12) | (v & 0x0FFF)
+    payload[13:16] = bytes([(vel >> 16) & 0xFF, (vel >> 8) & 0xFF, vel & 0xFF])
+
+    track_byte = int(round((_clamp(track_deg, 0.0, 359.0) / 360.0) * 256.0)) & 0xFF
+    payload[16] = track_byte
+
+    payload[17] = 0x01  # emitter category (unused)
+    payload[18:26] = callsign8("OWN")
+    payload[26] = 0x00
+    return bytes(payload)
+
+
+def build_ownship_geo_altitude(*, altitude_ft: float) -> bytes:
+    """
+    Ownship Geometric Altitude message payload (0x0B).
+    Signed int16 with 5ft resolution; followed by 2 bytes of vertical metrics.
+    """
+    alt5 = int(round(altitude_ft / 5.0))
+    alt5 = max(-32768, min(32767, alt5))
+    return struct.pack(">hH", alt5, 0x0000)
+
+def build_ownship_test_vector() -> bytes:
+    """
+    Ownship report payload taken from XCSoar's unit tests (unescaped frame
+    between msg_id and CRC). Useful to verify receiver setup.
+    """
+    return bytes([
+        0x00, 0x00, 0x00, 0x00,
+        0x15, 0xA7, 0xE5,
+        0xBA, 0x47, 0x99,
+        0x08, 0xC9,
+        0x88,
+        0xFF, 0xE0, 0x00,
+        0x80,
+        0x01,
+        0x4E, 0x31, 0x32, 0x33, 0x34, 0x35, 0x20, 0x20,
+        0x00,
+    ])
+
+
+def build_traffic(icao: int, lat_deg: float, lon_deg: float,
+                  altitude_ft: Optional[float],
+                  ground_speed_kt: Optional[float],
+                  track_deg: Optional[float],
+                  callsign: str,
+                  address_type: int = 0) -> bytes:
+    payload = bytearray(27)
+    alert_status = 0
+    payload[0] = ((address_type & 0x0F) << 4) | (alert_status & 0x0F)
+    payload[1:4] = bytes([(icao >> 16) & 0xFF, (icao >> 8) & 0xFF, icao & 0xFF])
+    payload[4:7] = pack_be24_signed(degrees_to_semicircles24(lat_deg))
+    payload[7:10] = pack_be24_signed(degrees_to_semicircles24(lon_deg))
+
+    misc = 0x01  # track_valid bits
+    if altitude_ft is None:
+        alt_code = 0xFFF
+    else:
+        alt_code = altitude_ft_to_code(altitude_ft)
+    alt_word = (alt_code << 4) | (misc & 0x0F)
+    payload[10:12] = struct.pack(">H", alt_word)
+
+    payload[12] = 0x00  # NACp/NIC (unused)
+
+    if ground_speed_kt is None:
+        h = 0x0FFF
+    else:
+        h = int(round(_clamp(ground_speed_kt, 0.0, 4094.0)))
+    v = 0x0800  # vertical N/A
+    vel = ((h & 0x0FFF) << 12) | (v & 0x0FFF)
+    payload[13:16] = bytes([(vel >> 16) & 0xFF, (vel >> 8) & 0xFF, vel & 0xFF])
+
+    if track_deg is None:
+        payload[16] = 0xFF
+    else:
+        track_byte = int(round((_clamp(track_deg, 0.0, 359.0) / 360.0) * 256.0)) & 0xFF
+        payload[16] = track_byte
+
+    payload[17] = 0x01  # emitter category
+    payload[18:26] = callsign8(callsign)
+    payload[26] = 0x00
+    return bytes(payload)
+
+
+@dataclass
+class Target:
+    icao: int
+    callsign: str
+    radius_m: float
+    altitude_ft: float
+    speed_kt: float
+    alt_phase: float
+    north_m: float
+    east_m: float
+    vn_mps: float
+    ve_mps: float
+
+
+def step_targets(rng: random.Random, targets: list[Target],
+                 dt: float) -> None:
+    # Simple bounded random walk with damping (stable + smooth).
+    # Acceleration noise (m/s^2):
+    a_sigma = 2.0
+    # Damping (1/s):
+    damping = 0.15
+
+    for t in targets:
+        an = rng.gauss(0.0, a_sigma)
+        ae = rng.gauss(0.0, a_sigma)
+
+        t.vn_mps += (an - damping * t.vn_mps) * dt
+        t.ve_mps += (ae - damping * t.ve_mps) * dt
+
+        t.north_m += t.vn_mps * dt
+        t.east_m += t.ve_mps * dt
+
+        r = math.hypot(t.north_m, t.east_m)
+        if r > t.radius_m and r > 1e-3:
+            # Clamp and reflect velocity at boundary.
+            scale = t.radius_m / r
+            t.north_m *= scale
+            t.east_m *= scale
+            t.vn_mps = -0.5 * t.vn_mps
+            t.ve_mps = -0.5 * t.ve_mps
+
+
+def _offset_lat_lon_m(lat0_deg: float, lon0_deg: float,
+                      north_m: float, east_m: float) -> tuple[float, float]:
+    # Small-angle approximation: good enough for synthetic local traffic.
+    lat0 = math.radians(lat0_deg)
+    dlat = north_m / 111_320.0
+    dlon = east_m / (111_320.0 * max(0.2, math.cos(lat0)))
+    return lat0_deg + dlat, lon0_deg + dlon
+
+
+def iter_messages(now: float, own_lat: float, own_lon: float,
+                  own_alt_ft: float, own_track_deg: float,
+                  targets: Iterable[Target],
+                  send_ownship: bool,
+                  ownship_test_vector: bool,
+                  send_foreflight_id: bool,
+                  foreflight_geo_altitude_is_msl: bool,
+                  send_foreflight_ahrs: bool,
+                  foreflight_ahrs_heading_is_magnetic: bool,
+                  foreflight_ahrs_ias_kt: Optional[float],
+                  foreflight_ahrs_tas_kt: Optional[float],
+                  foreflight_ahrs_roll_amp_deg: float,
+                  foreflight_ahrs_roll_period_s: float,
+                  foreflight_ahrs_pitch_amp_deg: float,
+                  foreflight_ahrs_pitch_period_s: float,
+                  send_geo_altitude: bool,
+                  target_alt_amp_ft: float,
+                  target_alt_period_s: float,
+                  traffic_before_ownship: bool,
+                  heartbeat_include_tod: bool) -> list[bytes]:
+    out: list[bytes] = []
+
+    if send_foreflight_id:
+        out.append(gdl90_frame(
+            0x65,
+            build_foreflight_id(geo_altitude_is_msl=foreflight_geo_altitude_is_msl),
+        ))
+
+    if send_foreflight_ahrs:
+        roll = None
+        if foreflight_ahrs_roll_amp_deg > 0 and foreflight_ahrs_roll_period_s > 0:
+            roll = foreflight_ahrs_roll_amp_deg * math.sin(
+                now * 2.0 * math.pi / foreflight_ahrs_roll_period_s
+            )
+
+        pitch = None
+        if foreflight_ahrs_pitch_amp_deg > 0 and foreflight_ahrs_pitch_period_s > 0:
+            pitch = foreflight_ahrs_pitch_amp_deg * math.sin(
+                now * 2.0 * math.pi / foreflight_ahrs_pitch_period_s
+            )
+
+        out.append(gdl90_frame(
+            0x65,
+            build_foreflight_ahrs(
+                roll_deg=roll,
+                pitch_deg=pitch,
+                heading_deg=own_track_deg,
+                heading_is_magnetic=foreflight_ahrs_heading_is_magnetic,
+                ias_kt=foreflight_ahrs_ias_kt,
+                tas_kt=foreflight_ahrs_tas_kt,
+            ),
+        ))
+
+    out.append(gdl90_frame(
+        0x00, build_heartbeat(include_tod=heartbeat_include_tod)))
+
+    def append_traffic() -> None:
+        for t in targets:
+            lat, lon = _offset_lat_lon_m(own_lat, own_lon, t.north_m, t.east_m)
+
+            track = None
+            if abs(t.vn_mps) > 0.5 or abs(t.ve_mps) > 0.5:
+                track = (math.degrees(math.atan2(t.ve_mps, t.vn_mps)) + 360.0) % 360.0
+
+            if target_alt_amp_ft > 0 and target_alt_period_s > 0:
+                alt_wave = math.sin((now * 2.0 * math.pi / target_alt_period_s) + t.alt_phase)
+                alt_ft = t.altitude_ft + target_alt_amp_ft * alt_wave
+            else:
+                alt_ft = t.altitude_ft
+
+            out.append(gdl90_frame(
+                0x14,
+                build_traffic(
+                    t.icao,
+                    lat,
+                    lon,
+                    altitude_ft=alt_ft,
+                    ground_speed_kt=t.speed_kt,
+                    track_deg=track,
+                    callsign=t.callsign,
+                    address_type=0,
+                ),
+            ))
+
+    def append_ownship() -> None:
+        if not send_ownship:
+            return
+
+        payload = build_ownship_test_vector() if ownship_test_vector else \
+            build_ownship(own_lat, own_lon, own_alt_ft, 40.0, own_track_deg)
+        out.append(gdl90_frame(0x0A, payload))
+
+        if send_geo_altitude:
+            out.append(gdl90_frame(
+                0x0B,
+                build_ownship_geo_altitude(altitude_ft=own_alt_ft),
+            ))
+
+    # Optionally send traffic frames before ownship to simulate "no position"
+    # targets briefly (relative vectors not computed until ownship is known).
+    if traffic_before_ownship:
+        append_traffic()
+        append_ownship()
+    else:
+        append_ownship()
+        append_traffic()
+
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Send synthetic GDL90 via UDP")
+    ap.add_argument("--host", default="127.0.0.1", help="XCSoar host/IP")
+    ap.add_argument("--port", type=int, default=4352, help="XCSoar UDP port")
+    ap.add_argument("--rate", type=float, default=1.0, help="Packets per second")
+    ap.add_argument("--n-targets", type=int, default=6, help="Number of traffic targets")
+    ap.add_argument("--seed", type=int, default=1, help="RNG seed (stable target IDs)")
+    ap.add_argument("--own-lat", type=float, default=50.0, help="Ownship latitude (deg)")
+    ap.add_argument("--own-lon", type=float, default=8.0, help="Ownship longitude (deg)")
+    ap.add_argument("--own-alt-ft", type=float, default=1500.0, help="Ownship altitude (ft)")
+    ap.add_argument("--target-alt-amp-ft", type=float, default=200.0,
+                    help="Target altitude oscillation amplitude (ft, 0=disabled)")
+    ap.add_argument("--target-alt-period", type=float, default=60.0,
+                    help="Target altitude oscillation period (s)")
+    ap.add_argument("--traffic-before-ownship", action="store_true",
+                    help="Send traffic (0x14) before ownship (0x0A) each cycle")
+    ap.add_argument("--no-heartbeat-tod", action="store_true",
+                    help="Heartbeat (0x00): omit UTC time-of-day (six zero "
+                         "payload bytes; XCSoar will not set GPS time from it)")
+    ap.add_argument("--foreflight-id", action="store_true",
+                    help="Send ForeFlight ID (0x65 sub-id 0, version 1) each cycle")
+    ap.add_argument("--foreflight-geo-altitude-msl", action="store_true",
+                    help="In ForeFlight ID, set capability bit0: 0x0B datum is MSL (default: ellipsoid)")
+    ap.add_argument("--foreflight-ahrs", action="store_true",
+                    help="Send ForeFlight AHRS (0x65 sub-id 1) each cycle")
+    ap.add_argument("--foreflight-ahrs-heading-magnetic", action="store_true",
+                    help="Mark ForeFlight AHRS heading as magnetic (default: true heading)")
+    ap.add_argument("--foreflight-ahrs-ias-kt", type=float, default=60.0,
+                    help="ForeFlight AHRS IAS value (knots)")
+    ap.add_argument("--foreflight-ahrs-tas-kt", type=float, default=65.0,
+                    help="ForeFlight AHRS TAS value (knots)")
+    ap.add_argument("--foreflight-ahrs-roll-amp-deg", type=float, default=20.0,
+                    help="ForeFlight AHRS roll oscillation amplitude (deg, 0=invalid)")
+    ap.add_argument("--foreflight-ahrs-roll-period", type=float, default=12.0,
+                    help="ForeFlight AHRS roll oscillation period (s)")
+    ap.add_argument("--foreflight-ahrs-pitch-amp-deg", type=float, default=8.0,
+                    help="ForeFlight AHRS pitch oscillation amplitude (deg, 0=invalid)")
+    ap.add_argument("--foreflight-ahrs-pitch-period", type=float, default=9.0,
+                    help="ForeFlight AHRS pitch oscillation period (s)")
+    ap.add_argument("--geo-altitude", action="store_true",
+                    help="Send Ownship Geometric Altitude (0x0B) each cycle")
+    ap.add_argument("--no-ownship", action="store_true",
+                    help="Do not send Ownship (0x0A) reports")
+    ap.add_argument("--ownship-test-vector", action="store_true",
+                    help="Send the unit-test Ownship vector (for receiver setup)")
+    ap.add_argument("--packet-mode", choices=["concat", "single"], default="single",
+                    help="UDP packetization: 'single' sends one GDL90 frame per packet; "
+                         "'concat' concatenates all frames into one packet")
+    ap.add_argument("--stdout-hex", action="store_true",
+                    help="Print frames as hex instead of sending")
+    args = ap.parse_args()
+
+    rng = random.Random(args.seed)
+
+    targets: list[Target] = []
+    for i in range(max(0, args.n_targets)):
+        icao = (0xA00000 + i + rng.randrange(0, 0x0FFF)) & 0xFFFFFF
+        callsign = f"T{i+1:02d}"
+        radius_m = 800.0 + 200.0 * i
+        ang = rng.random() * 2.0 * math.pi
+        north = radius_m * math.cos(ang)
+        east = radius_m * math.sin(ang)
+        targets.append(Target(
+            icao=icao,
+            callsign=callsign,
+            radius_m=radius_m,
+            altitude_ft=args.own_alt_ft + 300.0 + 100.0 * i,
+            speed_kt=55.0,
+            alt_phase=rng.random() * 2.0 * math.pi,
+            north_m=north,
+            east_m=east,
+            vn_mps=rng.uniform(-5.0, 5.0),
+            ve_mps=rng.uniform(-5.0, 5.0),
+        ))
+
+    if args.stdout_hex:
+        now = time.monotonic()
+        msgs = iter_messages(now, args.own_lat, args.own_lon, args.own_alt_ft,
+                             own_track_deg=0.0, targets=targets,
+                             send_ownship=not args.no_ownship,
+                             ownship_test_vector=args.ownship_test_vector,
+                             send_foreflight_id=args.foreflight_id,
+                             foreflight_geo_altitude_is_msl=args.foreflight_geo_altitude_msl,
+                             send_foreflight_ahrs=args.foreflight_ahrs,
+                             foreflight_ahrs_heading_is_magnetic=args.foreflight_ahrs_heading_magnetic,
+                             foreflight_ahrs_ias_kt=args.foreflight_ahrs_ias_kt,
+                             foreflight_ahrs_tas_kt=args.foreflight_ahrs_tas_kt,
+                             foreflight_ahrs_roll_amp_deg=args.foreflight_ahrs_roll_amp_deg,
+                             foreflight_ahrs_roll_period_s=args.foreflight_ahrs_roll_period,
+                             foreflight_ahrs_pitch_amp_deg=args.foreflight_ahrs_pitch_amp_deg,
+                             foreflight_ahrs_pitch_period_s=args.foreflight_ahrs_pitch_period,
+                             send_geo_altitude=args.geo_altitude,
+                             target_alt_amp_ft=args.target_alt_amp_ft,
+                             target_alt_period_s=args.target_alt_period,
+                             traffic_before_ownship=args.traffic_before_ownship,
+                             heartbeat_include_tod=not args.no_heartbeat_tod)
+        for m in msgs:
+            print(m.hex())
+        return 0
+
+    addr = (args.host, args.port)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    period = 1.0 / max(0.1, args.rate)
+    next_t = time.monotonic()
+    own_track = 0.0
+    last_now = None
+
+    try:
+        while True:
+            now = time.monotonic()
+            if now < next_t:
+                time.sleep(next_t - now)
+                continue
+
+            if last_now is None:
+                last_now = now
+            dt = now - last_now
+            last_now = now
+            step_targets(rng, targets, dt)
+
+            own_track = (own_track - 2.0) % 360.0
+            msgs = iter_messages(now, args.own_lat, args.own_lon, args.own_alt_ft,
+                                 own_track_deg=own_track, targets=targets,
+                                 send_ownship=not args.no_ownship,
+                                 ownship_test_vector=args.ownship_test_vector,
+                                 send_foreflight_id=args.foreflight_id,
+                                 foreflight_geo_altitude_is_msl=args.foreflight_geo_altitude_msl,
+                                 send_foreflight_ahrs=args.foreflight_ahrs,
+                                 foreflight_ahrs_heading_is_magnetic=args.foreflight_ahrs_heading_magnetic,
+                                 foreflight_ahrs_ias_kt=args.foreflight_ahrs_ias_kt,
+                                 foreflight_ahrs_tas_kt=args.foreflight_ahrs_tas_kt,
+                                 foreflight_ahrs_roll_amp_deg=args.foreflight_ahrs_roll_amp_deg,
+                                 foreflight_ahrs_roll_period_s=args.foreflight_ahrs_roll_period,
+                                 foreflight_ahrs_pitch_amp_deg=args.foreflight_ahrs_pitch_amp_deg,
+                                 foreflight_ahrs_pitch_period_s=args.foreflight_ahrs_pitch_period,
+                                 send_geo_altitude=args.geo_altitude,
+                                 target_alt_amp_ft=args.target_alt_amp_ft,
+                                 target_alt_period_s=args.target_alt_period,
+                                 traffic_before_ownship=args.traffic_before_ownship,
+                                 heartbeat_include_tod=not args.no_heartbeat_tod)
+
+            if args.packet_mode == "concat":
+                sock.sendto(b"".join(msgs), addr)
+            else:
+                for m in msgs:
+                    sock.sendto(m, addr)
+
+            next_t += period
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- Add a new GDL90 device driver (heartbeat/ownship/traffic) and wire it into the build and device registry.
- Decode GDL90 traffic into XCSoar's traffic list with ADS-B/TIS-B source tagging and callsign extraction.
- Preserve absolute-position traffic in FLARM post-processing and adjust UI labels/callsign fallbacks for non-FLARM traffic sources.

## Test plan
- Build: `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- Unit tests: `output/UNIX/bin/TestGDL90` and `output/UNIX/bin/TestGDL90Driver`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GDL90 device support with a "GDL90 Setup" dialog and configurable horizontal/vertical ranges; device appears in device lists.
  * Added a GDL90 traffic generator CLI tool.

* **Improvements**
  * Enhanced traffic handling: accepts absolute position/altitude, ForeFlight AHRS/airspeed, better distance/bearing and relative-altitude calculations, stronger resync/tolerance for fragmented or noisy input.
  * UI: generic "Traffic" labels and improved callsign fallbacks.

* **Tests**
  * New validation tests exercising framing, CRC, parsing and driver behavior.

* **Documentation**
  * Added GDL90 protocol documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->