### PR TITLE
FLARM: Parse PFLAO alert zones and show warnings

### DIFF
--- a/src/Airspace/AirspaceIteration.hxx
+++ b/src/Airspace/AirspaceIteration.hxx
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Engine/Airspace/Predicate/AirspacePredicate.hpp"
+#include "Engine/Airspace/Airspaces.hpp"
+#include "Engine/Airspace/Ptr.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Projection/WindowProjection.hpp"
+
+#include <span>
+
+/**
+ * Invoke f(const AbstractAirspace &) for each airspace from the R-tree
+ * within range of query_center, then each external airspace, applying
+ * visible() to both sources.
+ */
+template<typename F>
+inline void
+ForEachAirspaceInRange(const Airspaces *airspaces,
+                       std::span<const ConstAirspacePtr> external,
+                       const GeoPoint &query_center, double range_m,
+                       const AirspacePredicate &visible, F &&f)
+{
+  if (airspaces != nullptr) {
+    for (const auto &i : airspaces->QueryWithinRange(query_center, range_m)) {
+      const AbstractAirspace &airspace = i.GetAirspace();
+      if (visible(airspace))
+        f(airspace);
+    }
+  }
+
+  for (const auto &ea : external) {
+    if (visible(*ea))
+      f(*ea);
+  }
+}
+
+/**
+ * Same as ForEachAirspaceInRange() using the projection viewport center
+ * and radius in metres.
+ */
+template<typename F>
+inline void
+ForEachAirspaceInView(const Airspaces *airspaces,
+                      std::span<const ConstAirspacePtr> external,
+                      const WindowProjection &projection,
+                      const AirspacePredicate &visible, F &&f)
+{
+  ForEachAirspaceInRange(airspaces, external,
+                         projection.GetGeoScreenCenter(),
+                         projection.GetScreenDistanceMeters(),
+                         visible, std::forward<F>(f));
+}

--- a/src/Airspace/AirspaceMapVisible.hpp
+++ b/src/Airspace/AirspaceMapVisible.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Airspace/AirspaceVisibility.hpp"
+#include "Airspace/AirspaceWarningCopy.hpp"
+#include "Engine/Navigation/Aircraft.hpp"
+
+/**
+ * Predicate for map drawing: airspace is shown if the renderer visibility
+ * rules say so, or the warning snapshot reports inside/warning for it.
+ */
+class AirspaceMapVisible {
+  const AirspaceVisibility visible_predicate;
+  const AirspaceWarningCopy &warnings;
+
+public:
+  constexpr
+  AirspaceMapVisible(const AirspaceComputerSettings &_computer_settings,
+                     const AirspaceRendererSettings &_renderer_settings,
+                     const AircraftState &_state,
+                     const AirspaceWarningCopy &_warnings) noexcept
+    :visible_predicate(_computer_settings, _renderer_settings, _state),
+     warnings(_warnings) {}
+
+  [[gnu::pure]]
+  bool operator()(const AbstractAirspace &airspace) const noexcept {
+    return visible_predicate(airspace) ||
+           warnings.IsInside(airspace) ||
+           warnings.HasWarning(airspace);
+  }
+};

--- a/src/Airspace/AirspaceWarningCopy.hpp
+++ b/src/Airspace/AirspaceWarningCopy.hpp
@@ -6,12 +6,14 @@
 #include "ProtectedAirspaceWarningManager.hpp"
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Engine/Airspace/AirspaceWarningManager.hpp"
+#include "Engine/Airspace/Ptr.hpp"
 #include "util/StaticArray.hxx"
 #include "Geo/GeoPoint.hpp"
 
 #include <span>
 #include <exception>
 #include <vector>
+
 class AirspaceWarningCopy
 {
 private:

--- a/src/Airspace/AirspaceWarningCopy.hpp
+++ b/src/Airspace/AirspaceWarningCopy.hpp
@@ -9,11 +9,16 @@
 #include "util/StaticArray.hxx"
 #include "Geo/GeoPoint.hpp"
 
+#include <span>
+#include <exception>
+#include <vector>
 class AirspaceWarningCopy
 {
 private:
   StaticArray<const AbstractAirspace *,64> ids_inside, ids_warning, ids_acked;
   StaticArray<GeoPoint,32> locations;
+
+  std::vector<ConstAirspacePtr> external_airspaces;
 
   Serial serial;
 
@@ -40,6 +45,13 @@ public:
 
     for (const auto &i : awm)
       Visit(i);
+
+    const auto ext = awm.GetExternalAirspaces();
+    try {
+      external_airspaces.assign(ext.begin(), ext.end());
+    } catch (const std::exception &) {
+      external_airspaces.clear();
+    }
   }
 
   void Visit(const ProtectedAirspaceWarningManager &awm) noexcept {
@@ -49,6 +61,10 @@ public:
 
   const StaticArray<GeoPoint,32> &GetLocations() const noexcept {
     return locations;
+  }
+
+  std::span<const ConstAirspacePtr> GetExternalAirspaces() const noexcept {
+    return external_airspaces;
   }
 
   bool HasWarning(const AbstractAirspace &as) const noexcept {

--- a/src/Computer/WarningComputer.cpp
+++ b/src/Computer/WarningComputer.cpp
@@ -17,6 +17,22 @@
 
 using namespace std::chrono;
 
+namespace {
+
+[[gnu::const]]
+static AirspaceAltitude
+AirspaceAltitudeMsl(double meters) noexcept
+{
+  AirspaceAltitude a{};
+  a.reference = AltitudeReference::MSL;
+  a.altitude = meters;
+  a.flight_level = 0;
+  a.altitude_above_terrain = 0;
+  return a;
+}
+
+} // namespace
+
 WarningComputer::WarningComputer(const AirspaceWarningConfig &_config,
                                  Airspaces &_airspaces)
   :airspaces(_airspaces),
@@ -110,22 +126,12 @@ WarningComputer::UpdateFlarmZones(const FlarmData &flarm,
       cache.top = zone.top;
       cache.zone_type = zone.zone_type;
 
-      AirspaceAltitude base{}, top{};
-      base.reference = AltitudeReference::MSL;
-      base.altitude = zone.bottom;
-      base.flight_level = 0;
-      base.altitude_above_terrain = 0;
-      top.reference = AltitudeReference::MSL;
-      top.altitude = zone.top;
-      top.flight_level = 0;
-      top.altitude_above_terrain = 0;
-
       cache.airspace->SetProperties(
         fmt::format("FLARM: {}",
                     FlarmAlertZone::GetZoneTypeString(zone.zone_type)),
         std::string{}, TransponderCode::Null(),
         AirspaceClass::ALERT, AirspaceClass::ALERT,
-        base, top);
+        AirspaceAltitudeMsl(zone.bottom), AirspaceAltitudeMsl(zone.top));
     }
 
     external.push_back(cache.airspace);

--- a/src/Computer/WarningComputer.cpp
+++ b/src/Computer/WarningComputer.cpp
@@ -6,8 +6,14 @@
 #include "NMEA/Aircraft.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
+#include "Engine/Airspace/AirspaceCircle.hpp"
 #include "Engine/Airspace/Airspaces.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
+#include "FLARM/AlertZone.hpp"
+#include "FLARM/Data.hpp"
+#include "TransponderCode.hpp"
+
+#include <fmt/format.h>
 
 using namespace std::chrono;
 
@@ -61,9 +67,69 @@ WarningComputer::Update(const ComputerSettings &settings_computer,
     lease->Reset(as);
   }
 
+  {
+    AirspaceWarningManager &mgr = lease;
+    UpdateFlarmZones(basic.flarm, mgr);
+  }
+
   if (lease->Update(as, settings_computer.polar.glide_polar_task,
                     calculated.task_stats,
                     calculated.circling,
                     round<duration<unsigned>>(dt)))
     result.latest.Update(basic.clock);
+}
+
+void
+WarningComputer::UpdateFlarmZones(const FlarmData &flarm,
+                                  AirspaceWarningManager &mgr)
+{
+  const auto &zones = flarm.alert_zones;
+
+  // Remove cached airspaces for zones no longer present
+  std::erase_if(flarm_zone_airspaces, [&](const auto &pair) {
+    return zones.FindZone(pair.first) == nullptr;
+  });
+
+  std::vector<ConstAirspacePtr> external;
+
+  for (const auto &zone : zones.list) {
+    if (!zone.valid.IsValid())
+      continue;
+
+    auto &cache = flarm_zone_airspaces[zone.id];
+    const bool changed = cache.airspace == nullptr ||
+      cache.center != zone.center || cache.radius != zone.radius ||
+      cache.bottom != zone.bottom || cache.top != zone.top ||
+      cache.zone_type != zone.zone_type;
+
+    if (changed) {
+      cache.airspace = std::make_shared<AirspaceCircle>(zone.center, zone.radius);
+      cache.center = zone.center;
+      cache.radius = zone.radius;
+      cache.bottom = zone.bottom;
+      cache.top = zone.top;
+      cache.zone_type = zone.zone_type;
+
+      AirspaceAltitude base{}, top{};
+      base.reference = AltitudeReference::MSL;
+      base.altitude = zone.bottom;
+      base.flight_level = 0;
+      base.altitude_above_terrain = 0;
+      top.reference = AltitudeReference::MSL;
+      top.altitude = zone.top;
+      top.flight_level = 0;
+      top.altitude_above_terrain = 0;
+
+      cache.airspace->SetProperties(
+        fmt::format("FLARM: {}",
+                    FlarmAlertZone::GetZoneTypeString(zone.zone_type)),
+        std::string{}, TransponderCode::Null(),
+        AirspaceClass::ALERT, AirspaceClass::ALERT,
+        base, top);
+    }
+
+    external.push_back(cache.airspace);
+  }
+
+  mgr.SetExternalAirspaces(external);
 }

--- a/src/Computer/WarningComputer.hpp
+++ b/src/Computer/WarningComputer.hpp
@@ -5,10 +5,16 @@
 
 #include "Engine/Airspace/AirspaceWarningManager.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
+#include "Engine/Airspace/Ptr.hpp"
+#include "FLARM/Id.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "time/DeltaTime.hpp"
+
+#include <map>
 
 class Airspaces;
 struct ComputerSettings;
+struct FlarmData;
 struct MoreData;
 struct DerivedInfo;
 struct AirspaceWarningsInfo;
@@ -25,6 +31,22 @@ class WarningComputer {
   ProtectedAirspaceWarningManager protected_manager;
 
   bool initialised;
+
+  /**
+   * Cached AirspaceCircle objects for FLARM alert zones, keyed by
+   * FlarmId.  Reusing the same shared_ptr across ticks preserves
+   * warning acknowledgement state.  Since AirspaceCircle is immutable,
+   * it must be replaced when the zone geometry/metadata changes.
+   */
+  struct FlarmZoneCache {
+    AirspacePtr airspace;
+    GeoPoint center;
+    double radius;
+    int bottom, top;
+    uint8_t zone_type;
+  };
+
+  std::map<FlarmId, FlarmZoneCache> flarm_zone_airspaces;
 
 public:
   WarningComputer(const AirspaceWarningConfig &_config,
@@ -47,4 +69,8 @@ public:
               const MoreData &basic,
               const DerivedInfo &calculated,
               AirspaceWarningsInfo &result);
+
+private:
+  void UpdateFlarmZones(const FlarmData &flarm,
+                        AirspaceWarningManager &mgr);
 };

--- a/src/Computer/WarningComputer.hpp
+++ b/src/Computer/WarningComputer.hpp
@@ -63,6 +63,7 @@ public:
   void Reset() {
     delta_time.Reset();
     initialised = false;
+    flarm_zone_airspaces.clear();
   }
 
   void Update(const ComputerSettings &settings_computer,

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "StaticParser.hpp"
+#include "FLARM/AlertZone.hpp"
 #include "FLARM/Error.hpp"
 #include "FLARM/List.hpp"
 #include "FLARM/Progress.hpp"
@@ -323,6 +324,92 @@ ParsePFLAQ(NMEAInputLine &line, FlarmProgress &progress,
   progress.operation = operation;
   progress.progress = (unsigned)progress_val;
   progress.available.Update(clock);
+}
+
+void
+ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
+           TimeStamp clock) noexcept
+{
+  // PFLAO,<AlarmLevel>,<Inside>,<Latitude>,<Longitude>,<Radius>,
+  //   <Bottom>,<Top>,<ActivityLimit>,<ID>,<ID-Type>,<ZoneType>
+
+  int alarm_level_val;
+  if (!line.ReadChecked(alarm_level_val) ||
+      alarm_level_val < 0 || alarm_level_val > 3)
+    return;
+
+  int inside_val;
+  if (!line.ReadChecked(inside_val))
+    return;
+
+  int lat_e7;
+  if (!line.ReadChecked(lat_e7))
+    return;
+
+  int lon_e7;
+  if (!line.ReadChecked(lon_e7))
+    return;
+
+  if (lat_e7 < -900000000 || lat_e7 > 900000000 ||
+      lon_e7 < -1800000000 || lon_e7 > 1800000000)
+    return;
+
+  int radius_val;
+  if (!line.ReadChecked(radius_val) || radius_val < 0)
+    return;
+
+  int bottom_val;
+  if (!line.ReadChecked(bottom_val))
+    return;
+
+  int top_val;
+  if (!line.ReadChecked(top_val))
+    return;
+
+  unsigned activity_limit_val;
+  if (!line.ReadChecked(activity_limit_val))
+    return;
+
+  char id_string[16];
+  line.Read(id_string, 16);
+  FlarmId id = FlarmId::Parse(id_string, nullptr);
+  if (!id.IsDefined())
+    return;
+
+  int id_type_val;
+  if (line.ReadChecked(id_type_val) &&
+      id_type_val >= 0 && id_type_val <= 2) {
+    // offset by 1 matching PFLAA convention
+  } else {
+    id_type_val = -1;
+  }
+
+  unsigned zone_type_val = line.ReadHex(0);
+  if (zone_type_val < 0x10 || zone_type_val > 0xFF)
+    return;
+
+  FlarmAlertZone *slot = zones.FindZone(id);
+  if (slot == nullptr) {
+    slot = zones.AllocateZone();
+    if (slot == nullptr)
+      return;
+  }
+
+  slot->alarm_level = static_cast<FlarmTraffic::AlarmType>(alarm_level_val);
+  slot->inside = inside_val != 0;
+  slot->center = GeoPoint(Angle::Degrees(double(lon_e7) * 1e-7),
+                          Angle::Degrees(double(lat_e7) * 1e-7));
+  slot->radius = (unsigned)radius_val;
+  slot->bottom = bottom_val;
+  slot->top = top_val;
+  slot->activity_limit = activity_limit_val;
+  slot->id = id;
+  slot->id_type = id_type_val >= 0
+    ? static_cast<FlarmTraffic::IdType>(id_type_val + 1)
+    : FlarmTraffic::IdType::UNKNOWN;
+  slot->zone_type = (uint8_t)zone_type_val;
+  zones.modified.Update(clock);
+  slot->valid.Update(clock);
 }
 
 void

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -339,7 +339,8 @@ ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
     return;
 
   int inside_val;
-  if (!line.ReadChecked(inside_val))
+  if (!line.ReadChecked(inside_val) ||
+      inside_val < 0 || inside_val > 1)
     return;
 
   int lat_e7;
@@ -355,7 +356,8 @@ ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
     return;
 
   int radius_val;
-  if (!line.ReadChecked(radius_val) || radius_val < 0)
+  if (!line.ReadChecked(radius_val) ||
+      radius_val < 0 || radius_val > 2000)
     return;
 
   int bottom_val;
@@ -399,7 +401,7 @@ ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
   }
 
   slot->alarm_level = static_cast<FlarmTraffic::AlarmType>(alarm_level_val);
-  slot->inside = inside_val != 0;
+  slot->inside = inside_val == 1;
   slot->center = GeoPoint(Angle::Degrees(double(lon_e7) * 1e-7),
                           Angle::Degrees(double(lat_e7) * 1e-7));
   slot->radius = (unsigned)radius_val;

--- a/src/Device/Driver/FLARM/StaticParser.cpp
+++ b/src/Device/Driver/FLARM/StaticParser.cpp
@@ -366,6 +366,9 @@ ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
   if (!line.ReadChecked(top_val))
     return;
 
+  if (top_val < bottom_val)
+    return;
+
   unsigned activity_limit_val;
   if (!line.ReadChecked(activity_limit_val))
     return;

--- a/src/Device/Driver/FLARM/StaticParser.hpp
+++ b/src/Device/Driver/FLARM/StaticParser.hpp
@@ -15,6 +15,7 @@ struct FlarmError;
 struct FlarmProgress;
 struct FlarmState;
 struct FlarmVersion;
+struct FlarmAlertZoneList;
 struct FlarmStatus;
 struct TrafficList;
 
@@ -89,6 +90,17 @@ ParsePFLAJ(NMEAInputLine &line, FlarmState &state,
  */
 void
 ParsePFLAQ(NMEAInputLine &line, FlarmProgress &progress,
+           TimeStamp clock) noexcept;
+
+/**
+ * Parses a PFLAO sentence (Alert Zone information).
+ *
+ * @param line The Flarm NMEA record to parse.
+ * @param zones The current alert zone list which will be updated.
+ * @param clock The time now.
+ */
+void
+ParsePFLAO(NMEAInputLine &line, FlarmAlertZoneList &zones,
            TimeStamp clock) noexcept;
 
 /**

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -108,6 +108,11 @@ NMEAParser::ParseLine(const char *string, NMEAInfo &info)
       return true;
     }
 
+    if (type2 == "PFLAO"sv) {
+      ParsePFLAO(line, info.flarm.alert_zones, info.clock);
+      return true;
+    }
+
     if (type2 == "PFLAM"sv) {
       ParsePFLAM(line);
       return true;

--- a/src/Engine/Airspace/AirspaceIntersectionVisitor.hpp
+++ b/src/Engine/Airspace/AirspaceIntersectionVisitor.hpp
@@ -30,7 +30,7 @@ public:
    *
    * @return True if more than one intersection pair
    */
-  bool SetIntersections(AirspaceIntersectionVector &&p) {
+  bool SetIntersections(AirspaceIntersectionVector &&p) noexcept {
     intersections = std::move(p);
     return !intersections.empty();
   }

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -11,6 +11,7 @@
 #include "util/PrintException.hxx"
 #include "LogFileDecl.hpp"
 
+#include <algorithm>
 #include <ranges>
 
 static constexpr double CRUISE_FILTER_FACT = 0.5;

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -167,22 +167,11 @@ AirspaceWarningManager::Update(const AircraftState& state,
   for (auto &w : warnings)
     w.SaveState();
 
-  if (have_airspaces) {
-    // check from strongest to weakest alerts
-    UpdateInside(state, glide_polar);
-    UpdateGlide(state, glide_polar);
-    UpdateFilter(state, circling);
-    UpdateTask(state, glide_polar, task_stats);
-  }
-
-  for (const auto &ea : external_airspaces) {
-    if (ea->Inside(state.location)) {
-      auto &w = GetWarning(ea);
-      if (w.IsStateAccepted(AirspaceWarning::WARNING_INSIDE))
-        w.UpdateSolution(AirspaceWarning::WARNING_INSIDE,
-                         AirspaceInterceptSolution::Invalid());
-    }
-  }
+  // check from strongest to weakest alerts
+  UpdateInside(state, glide_polar);
+  UpdateGlide(state, glide_polar);
+  UpdateFilter(state, circling);
+  UpdateTask(state, glide_polar, task_stats);
 
   // action changes
   for (auto it = warnings.begin(), end = warnings.end(); it != end;) {
@@ -329,6 +318,34 @@ private:
 };
 
 
+template<typename F>
+void
+AirspaceWarningManager::ForEachInside(const GeoPoint &location,
+                                      F &&f) const
+{
+  for (const auto &i : airspaces.QueryInside(location))
+    f(i.GetAirspacePtr());
+
+  for (const auto &ea : external_airspaces)
+    if (ea->Inside(location))
+      f(ea);
+}
+
+void
+AirspaceWarningManager::VisitAllIntersecting(
+  const GeoPoint &a, const GeoPoint &b,
+  AirspaceIntersectionVisitor &visitor) const
+{
+  airspaces.VisitIntersecting(a, b, visitor);
+
+  for (const auto &ea : external_airspaces) {
+    auto intersections = ea->Intersects(a, b, GetProjection());
+    if (!intersections.empty())
+      if (visitor.SetIntersections(std::move(intersections)))
+        visitor.Visit(ea);
+  }
+}
+
 bool 
 AirspaceWarningManager::UpdatePredicted(const AircraftState& state, 
                                         const GeoPoint &location_predicted,
@@ -359,13 +376,13 @@ AirspaceWarningManager::UpdatePredicted(const AircraftState& state,
                                              warning_state, max_time_limit,
                                              ceiling);
 
-  airspaces.VisitIntersecting(state.location, location_predicted, visitor);
+  VisitAllIntersecting(state.location, location_predicted, visitor);
 
   visitor.SetMode(true);
 
-  for (const auto &i : airspaces.QueryInside(state.location)) {
-    visitor.Visit(i.GetAirspacePtr());
-  }
+  ForEachInside(state.location, [&](ConstAirspacePtr ap) {
+    visitor.Visit(std::move(ap));
+  });
 
   return visitor.Found();
 }
@@ -453,15 +470,13 @@ AirspaceWarningManager::UpdateInside(const AircraftState& state,
 
   bool found = false;
 
-  for (const auto &i : airspaces.QueryInside(state.location)) {
-    const auto airspace = i.GetAirspacePtr();
-
+  const auto check_airspace = [&](ConstAirspacePtr airspace) {
     const AltitudeState &altitude = state;
-    if (// ignore inactive airspaces
-        !airspace->IsActive() ||
-        !(config.IsClassEnabled(airspace->GetClassOrType()) || config.IsClassEnabled(airspace->GetTypeOrClass())) ||
+    if (!airspace->IsActive() ||
+        !(config.IsClassEnabled(airspace->GetClassOrType()) ||
+          config.IsClassEnabled(airspace->GetTypeOrClass())) ||
         !airspace->Inside(altitude))
-      continue;
+      return;
 
     AirspaceWarning *warning = GetWarningPtr(*airspace);
 
@@ -478,7 +493,9 @@ AirspaceWarningManager::UpdateInside(const AircraftState& state,
       warning->UpdateSolution(AirspaceWarning::WARNING_INSIDE, solution);
       found = true;
     }
-  }
+  };
+
+  ForEachInside(state.location, check_airspace);
 
   return found;
 }

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -152,10 +152,14 @@ AirspaceWarningManager::Update(const AircraftState& state,
 {
   bool changed = false;
 
-  // update warning states
-  if (airspaces.IsEmpty()) {
-    // no airspaces, no warnings possible
-    assert(warnings.empty());
+  const bool have_airspaces = !airspaces.IsEmpty();
+  const bool have_external = !external_airspaces.empty();
+
+  if (!have_airspaces && !have_external) {
+    if (!warnings.empty()) {
+      warnings.clear();
+      ++serial;
+    }
     return false;
   }
 
@@ -163,11 +167,22 @@ AirspaceWarningManager::Update(const AircraftState& state,
   for (auto &w : warnings)
     w.SaveState();
 
-  // check from strongest to weakest alerts
-  UpdateInside(state, glide_polar);
-  UpdateGlide(state, glide_polar);
-  UpdateFilter(state, circling);
-  UpdateTask(state, glide_polar, task_stats);
+  if (have_airspaces) {
+    // check from strongest to weakest alerts
+    UpdateInside(state, glide_polar);
+    UpdateGlide(state, glide_polar);
+    UpdateFilter(state, circling);
+    UpdateTask(state, glide_polar, task_stats);
+  }
+
+  for (const auto &ea : external_airspaces) {
+    if (ea->Inside(state.location)) {
+      auto &w = GetWarning(ea);
+      if (w.IsStateAccepted(AirspaceWarning::WARNING_INSIDE))
+        w.UpdateSolution(AirspaceWarning::WARNING_INSIDE,
+                         AirspaceInterceptSolution::Invalid());
+    }
+  }
 
   // action changes
   for (auto it = warnings.begin(), end = warnings.end(); it != end;) {

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -11,6 +11,8 @@
 #include "util/PrintException.hxx"
 #include "LogFileDecl.hpp"
 
+#include <ranges>
+
 static constexpr double CRUISE_FILTER_FACT = 0.5;
 
 /**
@@ -62,8 +64,20 @@ AirspaceWarningManager::Reset(const AircraftState &state)
   ++serial;
   warnings.clear();
   notam_day_ack_by_station.clear();
+  external_airspaces.clear();
   cruise_filter.Reset(state);
   circling_filter.Reset(state);
+}
+
+void
+AirspaceWarningManager::SetExternalAirspaces(
+    std::span<const ConstAirspacePtr> airspaces)
+{
+  if (std::ranges::equal(external_airspaces, airspaces))
+    return;
+
+  external_airspaces.assign(airspaces.begin(), airspaces.end());
+  ++serial;
 }
 
 void 
@@ -159,7 +173,9 @@ AirspaceWarningManager::Update(const AircraftState& state,
     if (!warnings.empty()) {
       warnings.clear();
       ++serial;
+      return true;
     }
+
     return false;
   }
 

--- a/src/Engine/Airspace/AirspaceWarningManager.hpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.hpp
@@ -10,9 +10,11 @@
 #include "util/Serial.hpp"
 
 #include <list>
+#include <span>
 #include <string>
 #include <string_view>
 #include <unordered_set>
+#include <vector>
 
 class TaskStats;
 class GlidePolar;
@@ -70,6 +72,13 @@ class AirspaceWarningManager {
    */
   std::unordered_set<std::string, TransparentStringHash,
                      TransparentStringEqual> notam_day_ack_by_station;
+
+  /**
+   * Airspaces provided externally (e.g. FLARM alert zones) that are
+   * not in the main Airspaces R-tree but should be checked by the
+   * same detection passes.
+   */
+  std::vector<ConstAirspacePtr> external_airspaces;
 
   /**
    * This number is incremented each time this object is modified.
@@ -272,6 +281,15 @@ public:
    */
   [[gnu::pure]]
   bool IsActive(const AbstractAirspace &airspace) const noexcept;
+
+  /**
+   * Set externally-provided airspaces (e.g. from FLARM PFLAO).
+   * These are checked by the same detection passes as normal
+   * airspaces during the next Update() cycle.
+   */
+  void SetExternalAirspaces(std::span<const ConstAirspacePtr> airspaces) {
+    external_airspaces.assign(airspaces.begin(), airspaces.end());
+  }
 
 private:
   AirspaceWarning *FindWarningByNotamDayAckKey(std::string_view key) noexcept;

--- a/src/Engine/Airspace/AirspaceWarningManager.hpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.hpp
@@ -205,6 +205,7 @@ public:
     ++serial;
     warnings.clear();
     notam_day_ack_by_station.clear();
+    external_airspaces.clear();
   }
 
   /**
@@ -288,9 +289,7 @@ public:
    * These are checked by the same detection passes as normal
    * airspaces during the next Update() cycle.
    */
-  void SetExternalAirspaces(std::span<const ConstAirspacePtr> airspaces) {
-    external_airspaces.assign(airspaces.begin(), airspaces.end());
-  }
+  void SetExternalAirspaces(std::span<const ConstAirspacePtr> airspaces);
 
   [[gnu::pure]]
   std::span<const ConstAirspacePtr> GetExternalAirspaces() const noexcept {

--- a/src/Engine/Airspace/AirspaceWarningManager.hpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.hpp
@@ -292,6 +292,11 @@ public:
     external_airspaces.assign(airspaces.begin(), airspaces.end());
   }
 
+  [[gnu::pure]]
+  std::span<const ConstAirspacePtr> GetExternalAirspaces() const noexcept {
+    return external_airspaces;
+  }
+
 private:
   AirspaceWarning *FindWarningByNotamDayAckKey(std::string_view key) noexcept;
   const AirspaceWarning *

--- a/src/Engine/Airspace/AirspaceWarningManager.hpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.hpp
@@ -21,6 +21,7 @@ class GlidePolar;
 class Airspaces;
 class FlatProjection;
 class AirspaceAircraftPerformance;
+class AirspaceIntersectionVisitor;
 
 /**
  * Class to detect and track airspace warnings
@@ -307,4 +308,18 @@ private:
                        const AirspaceAircraftPerformance &perf,
                        const AirspaceWarning::State warning_state,
                        FloatDuration max_time) noexcept;
+
+  /**
+   * Call f(ConstAirspacePtr) for every airspace (R-tree and external)
+   * whose horizontal bounds contain the given location.
+   */
+  template<typename F>
+  void ForEachInside(const GeoPoint &location, F &&f) const;
+
+  /**
+   * Visit all airspaces (R-tree and external) that intersect the
+   * line segment [a, b].
+   */
+  void VisitAllIntersecting(const GeoPoint &a, const GeoPoint &b,
+                            AirspaceIntersectionVisitor &visitor) const;
 };

--- a/src/FLARM/AlertZone.hpp
+++ b/src/FLARM/AlertZone.hpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Id.hpp"
+#include "Traffic.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Language/Language.hpp"
+#include "NMEA/Validity.hpp"
+#include "util/TrivialArray.hxx"
+
+#include <type_traits>
+#include <cstdint>
+
+/**
+ * A FLARM Alert Zone (vertical cylinder) received via PFLAO.
+ * @see FTD-012 Data Port ICD, section 8.13
+ */
+struct FlarmAlertZone {
+  FlarmTraffic::AlarmType alarm_level;
+
+  /** True if we are inside the zone's horizontal and vertical limits */
+  bool inside;
+
+  /** Center of the cylinder in WGS84 */
+  GeoPoint center;
+
+  /** Radius of the cylinder in meters (0-2000) */
+  unsigned radius;
+
+  /** Bottom of the cylinder in meters above WGS84 ellipsoid */
+  int bottom;
+
+  /** Top of the cylinder in meters above WGS84 ellipsoid */
+  int top;
+
+  /**
+   * End of activity in seconds since 1970-01-01 00:00 UTC.
+   * 0 = no set end time.
+   */
+  uint32_t activity_limit;
+
+  FlarmId id;
+
+  FlarmTraffic::IdType id_type;
+
+  /** Zone type (hex 0x10-0xFF) */
+  uint8_t zone_type;
+
+  /** When was this zone last received? */
+  Validity valid;
+
+  static constexpr const char *GetZoneTypeString(uint8_t type) noexcept {
+    switch (type) {
+    case 0x41:
+      return N_("Skydiver drop zone");
+    case 0x42:
+      return N_("Aerodrome traffic zone");
+    case 0x43:
+      return N_("Military firing area");
+    case 0x44:
+      return N_("Kite flying zone");
+    case 0x45:
+      return N_("Winch launching area");
+    case 0x46:
+      return N_("RC flying area");
+    case 0x47:
+      return N_("UAS flying area");
+    case 0x48:
+      return N_("Aerobatic box");
+    case 0x7E:
+      return N_("Danger area");
+    case 0x7F:
+      return N_("Prohibited area");
+    default:
+      return N_("Alert zone");
+    }
+  }
+};
+
+/**
+ * Container for FLARM Alert Zones received via PFLAO sentences.
+ */
+struct FlarmAlertZoneList {
+  static constexpr size_t MAX_COUNT = 15;
+
+  Validity modified;
+
+  TrivialArray<FlarmAlertZone, MAX_COUNT> list;
+
+  constexpr void Clear() noexcept {
+    modified.Clear();
+    list.clear();
+  }
+
+  constexpr void Complement(const FlarmAlertZoneList &add) noexcept {
+    if (add.modified.Modified(modified))
+      modified = add.modified;
+
+    if (list.empty() && !add.list.empty()) {
+      list = add.list;
+      return;
+    }
+
+    for (const auto &zone : add.list) {
+      if (FindZone(zone.id) == nullptr) {
+        FlarmAlertZone *slot = AllocateZone();
+        if (slot == nullptr)
+          return;
+        *slot = zone;
+      }
+    }
+  }
+
+  constexpr void Expire(TimeStamp clock) noexcept {
+    modified.Expire(clock, std::chrono::minutes(5));
+
+    for (unsigned i = list.size(); i-- > 0;)
+      list[i].valid.Expire(clock, std::chrono::minutes(5));
+
+    for (unsigned i = list.size(); i-- > 0;)
+      if (!list[i].valid.IsValid())
+        list.quick_remove(i);
+  }
+
+  constexpr FlarmAlertZone *FindZone(FlarmId id) noexcept {
+    for (auto &zone : list)
+      if (zone.id == id)
+        return &zone;
+    return nullptr;
+  }
+
+  constexpr const FlarmAlertZone *FindZone(FlarmId id) const noexcept {
+    for (const auto &zone : list)
+      if (zone.id == id)
+        return &zone;
+    return nullptr;
+  }
+
+  constexpr FlarmAlertZone *AllocateZone() noexcept {
+    return list.full() ? nullptr : &list.append();
+  }
+};
+
+static_assert(std::is_trivial<FlarmAlertZone>::value,
+              "type is not trivial");
+static_assert(std::is_trivial<FlarmAlertZoneList>::value,
+              "type is not trivial");

--- a/src/FLARM/Data.hpp
+++ b/src/FLARM/Data.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "FLARM/AlertZone.hpp"
 #include "FLARM/Error.hpp"
 #include "FLARM/Version.hpp"
 #include "FLARM/Hardware.hpp"
@@ -31,6 +32,8 @@ struct FlarmData {
 
   TrafficList traffic;
 
+  FlarmAlertZoneList alert_zones;
+
   constexpr bool IsDetected() const noexcept {
     return status.available || !traffic.IsEmpty();
   }
@@ -43,6 +46,7 @@ struct FlarmData {
     progress.Clear();
     status.Clear();
     traffic.Clear();
+    alert_zones.Clear();
   }
 
   constexpr void Complement(const FlarmData &add) noexcept {
@@ -53,6 +57,7 @@ struct FlarmData {
     progress.Complement(add.progress);
     status.Complement(add.status);
     traffic.Complement(add.traffic);
+    alert_zones.Complement(add.alert_zones);
   }
 
   constexpr void Expire(TimeStamp clock) noexcept {
@@ -63,6 +68,7 @@ struct FlarmData {
     progress.Expire(clock);
     status.Expire(clock);
     traffic.Expire(clock);
+    alert_zones.Expire(clock);
   }
 };
 

--- a/src/MapWindow/Items/AirspaceBuilder.cpp
+++ b/src/MapWindow/Items/AirspaceBuilder.cpp
@@ -9,9 +9,12 @@
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Engine/Airspace/Airspaces.hpp"
 #include "Engine/Airspace/AirspaceWarningManager.hpp"
+#include "Engine/Airspace/Ptr.hpp"
 #include "Airspace/AirspaceVisibility.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "NMEA/Aircraft.hpp"
+
+#include <vector>
 
 class AirspaceWarningList
 {
@@ -72,8 +75,15 @@ MapItemListBuilder::AddVisibleAirspace(
     const MoreData &basic, const DerivedInfo &calculated)
 {
   AirspaceWarningList warnings;
-  if (warning_manager != nullptr)
-    warnings.Fill(*warning_manager);
+  std::vector<ConstAirspacePtr> external_airspaces;
+
+  if (warning_manager != nullptr) {
+    const ProtectedAirspaceWarningManager::Lease lease(*warning_manager);
+    const AirspaceWarningManager &mgr = lease;
+    warnings.Fill(mgr);
+    const auto ext = mgr.GetExternalAirspaces();
+    external_airspaces.assign(ext.begin(), ext.end());
+  }
 
   const AircraftState aircraft = ToAircraftState(basic, calculated);
   AirspaceAtPointPredicate predicate(computer_settings, renderer_settings,
@@ -87,5 +97,13 @@ MapItemListBuilder::AddVisibleAirspace(
     auto airspace = i.GetAirspacePtr();
     if (predicate(*airspace))
       list.append(new AirspaceMapItem(std::move(airspace)));
+  }
+
+  for (const auto &ea : external_airspaces) {
+    if (list.full())
+      break;
+
+    if (ea->Inside(location))
+      list.append(new AirspaceMapItem(ea));
   }
 }

--- a/src/MapWindow/Items/AirspaceBuilder.cpp
+++ b/src/MapWindow/Items/AirspaceBuilder.cpp
@@ -103,7 +103,7 @@ MapItemListBuilder::AddVisibleAirspace(
     if (list.full())
       break;
 
-    if (ea->Inside(location))
+    if (predicate(*ea))
       list.append(new AirspaceMapItem(ea));
   }
 }

--- a/src/Renderer/AirspaceLabelRenderer.cpp
+++ b/src/Renderer/AirspaceLabelRenderer.cpp
@@ -207,13 +207,22 @@ AirspaceLabelRenderer::Draw(Canvas &canvas,
     settings.show_notam_labels &&
     projection.GetMapScale() <= NOTAM_LABEL_MAX_MAP_SCALE;
 
-  if ((!draw_altitude_labels && !draw_notam_labels) ||
-      airspaces == nullptr || airspaces->IsEmpty())
+  if (!draw_altitude_labels && !draw_notam_labels)
     return;
 
   AirspaceWarningCopy awc;
   if (warning_manager != nullptr)
     awc.Visit(*warning_manager);
+
+  if ((airspaces == nullptr || airspaces->IsEmpty()) &&
+      awc.GetExternalAirspaces().empty()) {
+    if (!draw_notam_labels)
+      return;
+  }
+
+  if (!draw_altitude_labels && draw_notam_labels &&
+      (airspaces == nullptr || airspaces->IsEmpty()))
+    return;
 
   const AircraftState aircraft = ToAircraftState(basic, calculated);
   const AirspaceMapVisible visible(computer_settings, settings,
@@ -221,7 +230,8 @@ AirspaceLabelRenderer::Draw(Canvas &canvas,
 
   DrawInternal(canvas,
                projection, visible, computer_settings.warnings,
-               draw_altitude_labels, draw_notam_labels, label_block);
+               draw_altitude_labels, draw_notam_labels, label_block,
+               awc.GetExternalAirspaces());
 }
 
 inline void
@@ -231,18 +241,26 @@ AirspaceLabelRenderer::DrawInternal(Canvas &canvas,
                                     const AirspaceWarningConfig &config,
                                     const bool draw_altitude_labels,
                                     const bool draw_notam_labels,
-                                    LabelBlock *label_block) noexcept
+                                    LabelBlock *label_block,
+                                    std::span<const ConstAirspacePtr> external_airspaces) noexcept
 {
   AirspaceLabelList labels;
 
   if (draw_altitude_labels) {
-    for (const auto &i : airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                                     projection.GetScreenDistanceMeters())) {
-      const AbstractAirspace &airspace = i.GetAirspace();
-      if (visible(airspace))
-        labels.Add(airspace.GetCenter(), airspace.GetClass(), airspace.GetBase(),
-                   airspace.GetTop());
+    if (airspaces != nullptr) {
+      for (const auto &i : airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
+                                                       projection.GetScreenDistanceMeters())) {
+        const AbstractAirspace &airspace = i.GetAirspace();
+        if (visible(airspace))
+          labels.Add(airspace.GetCenter(), airspace.GetClass(), airspace.GetBase(),
+                     airspace.GetTop());
+      }
     }
+
+    for (const auto &ea : external_airspaces)
+      if (visible(*ea))
+        labels.Add(ea->GetCenter(), ea->GetClass(),
+                   ea->GetBase(), ea->GetTop());
 
     labels.Sort(config);
   }

--- a/src/Renderer/AirspaceLabelRenderer.cpp
+++ b/src/Renderer/AirspaceLabelRenderer.cpp
@@ -7,7 +7,8 @@
 #include "Look/AirspaceLook.hpp"
 #include "Airspace/Airspaces.hpp"
 #include "Airspace/AirspaceComputerSettings.hpp"
-#include "Airspace/AirspaceVisibility.hpp"
+#include "Airspace/AirspaceIteration.hxx"
+#include "Airspace/AirspaceMapVisible.hpp"
 #include "Airspace/AirspaceWarningCopy.hpp"
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Airspace/AirspaceClass.hpp"
@@ -41,27 +42,6 @@ struct NotamLabelCluster {
   PixelPoint anchor;
   unsigned count = 0;
   StaticArray<StaticString<64>, NOTAM_CLUSTER_VISIBLE_LINES> labels;
-};
-
-class AirspaceMapVisible
-{
-  const AirspaceVisibility visible_predicate;
-  const AirspaceWarningCopy &warnings;
-
-public:
-  AirspaceMapVisible(const AirspaceComputerSettings &_computer_settings,
-                     const AirspaceRendererSettings &_renderer_settings,
-                     const AircraftState &_state,
-                     const AirspaceWarningCopy &_warnings) noexcept
-    :visible_predicate(_computer_settings, _renderer_settings, _state),
-     warnings(_warnings) {}
-
-  [[gnu::pure]]
-  bool operator()(const AbstractAirspace& airspace) const noexcept {
-    return visible_predicate(airspace) ||
-      warnings.IsInside(airspace) ||
-      warnings.HasWarning(airspace);
-  }
 };
 
 static StaticString<64>
@@ -247,20 +227,11 @@ AirspaceLabelRenderer::DrawInternal(Canvas &canvas,
   AirspaceLabelList labels;
 
   if (draw_altitude_labels) {
-    if (airspaces != nullptr) {
-      for (const auto &i : airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                                       projection.GetScreenDistanceMeters())) {
-        const AbstractAirspace &airspace = i.GetAirspace();
-        if (visible(airspace))
-          labels.Add(airspace.GetCenter(), airspace.GetClass(), airspace.GetBase(),
-                     airspace.GetTop());
-      }
-    }
-
-    for (const auto &ea : external_airspaces)
-      if (visible(*ea))
-        labels.Add(ea->GetCenter(), ea->GetClass(),
-                   ea->GetBase(), ea->GetTop());
+    ForEachAirspaceInView(airspaces, external_airspaces, projection, visible,
+                          [&](const AbstractAirspace &airspace) {
+                            labels.Add(airspace.GetCenter(), airspace.GetClass(),
+                                       airspace.GetBase(), airspace.GetTop());
+                          });
 
     labels.Sort(config);
   }

--- a/src/Renderer/AirspaceLabelRenderer.hpp
+++ b/src/Renderer/AirspaceLabelRenderer.hpp
@@ -5,6 +5,9 @@
 
 #include "AirspaceLabelList.hpp"
 #include "Engine/Airspace/Predicate/AirspacePredicate.hpp"
+#include "Engine/Airspace/Ptr.hpp"
+
+#include <span>
 
 struct AirspaceLook;
 struct MoreData;
@@ -60,7 +63,8 @@ private:
                     const AirspaceWarningConfig &config,
                     bool draw_altitude_labels,
                     bool draw_notam_labels,
-                    LabelBlock *label_block) noexcept;
+                    LabelBlock *label_block,
+                    std::span<const ConstAirspacePtr> external_airspaces) noexcept;
 
   void DrawLabel(Canvas &canvas, const WindowProjection &projection,
                  const AirspaceLabelList::Label &label) noexcept;

--- a/src/Renderer/AirspaceRenderer.cpp
+++ b/src/Renderer/AirspaceRenderer.cpp
@@ -6,32 +6,12 @@
 #include "Projection/WindowProjection.hpp"
 #include "Look/AirspaceLook.hpp"
 #include "Airspace/Airspaces.hpp"
-#include "Airspace/AirspaceVisibility.hpp"
+#include "Airspace/AirspaceMapVisible.hpp"
 #include "Airspace/AirspaceWarning.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Airspace/AirspaceWarningCopy.hpp"
 #include "Engine/Airspace/AirspaceWarningManager.hpp"
 #include "NMEA/Aircraft.hpp"
-
-class AirspaceMapVisible
-{
-  const AirspaceVisibility visible_predicate;
-  const AirspaceWarningCopy &warnings;
-
-public:
-  AirspaceMapVisible(const AirspaceComputerSettings &_computer_settings,
-                     const AirspaceRendererSettings &_renderer_settings,
-                     const AircraftState& _state,
-                     const AirspaceWarningCopy& _warnings)
-    :visible_predicate(_computer_settings, _renderer_settings, _state),
-     warnings(_warnings) {}
-
-  bool operator()(const AbstractAirspace& airspace) const {
-    return visible_predicate(airspace) ||
-      warnings.IsInside(airspace) ||
-      warnings.HasWarning(airspace);
-  }
-};
 
 void
 AirspaceRenderer::DrawIntersections(Canvas &canvas,

--- a/src/Renderer/AirspaceRenderer.cpp
+++ b/src/Renderer/AirspaceRenderer.cpp
@@ -53,7 +53,8 @@ AirspaceRenderer::Draw(Canvas &canvas,
                        const AirspaceWarningCopy &awc,
                        const AirspacePredicate &visible)
 {
-  if (airspaces == nullptr || airspaces->IsEmpty())
+  if ((airspaces == nullptr || airspaces->IsEmpty()) &&
+      awc.GetExternalAirspaces().empty())
     return;
 
   DrawInternal(canvas,
@@ -73,9 +74,6 @@ AirspaceRenderer::Draw(Canvas &canvas,
                        const WindowProjection &projection,
                        const AirspaceRendererSettings &settings)
 {
-  if (airspaces == nullptr)
-    return;
-
   AirspaceWarningCopy awc;
   if (warning_manager != nullptr)
     awc.Visit(*warning_manager);
@@ -98,9 +96,6 @@ AirspaceRenderer::Draw(Canvas &canvas,
                        const AirspaceComputerSettings &computer_settings,
                        const AirspaceRendererSettings &settings)
 {
-  if (airspaces == nullptr)
-    return;
-
   AirspaceWarningCopy awc;
   if (warning_manager != nullptr)
     awc.Visit(*warning_manager);

--- a/src/Renderer/AirspaceRenderer.hpp
+++ b/src/Renderer/AirspaceRenderer.hpp
@@ -95,6 +95,7 @@ private:
   void DrawOutline(Canvas &canvas,
                    const WindowProjection &projection,
                    const AirspaceRendererSettings &settings,
+                   const AirspaceWarningCopy &awc,
                    const AirspacePredicate &visible) const;
 #endif
 

--- a/src/Renderer/AirspaceRendererGL.cpp
+++ b/src/Renderer/AirspaceRendererGL.cpp
@@ -12,6 +12,7 @@
 #include "Airspace/Airspaces.hpp"
 #include "Airspace/AirspacePolygon.hpp"
 #include "Airspace/AirspaceCircle.hpp"
+#include "Airspace/AirspaceIteration.hxx"
 #include "Airspace/AirspaceWarningCopy.hpp"
 #include "Engine/Airspace/Predicate/AirspacePredicate.hpp"
 #include "ui/canvas/opengl/Scope.hpp"
@@ -301,35 +302,19 @@ AirspaceRenderer::DrawInternal(Canvas &canvas,
       settings.fill_mode == AirspaceRendererSettings::FillMode::NONE) {
     AirspaceFillRenderer renderer(canvas, projection, look, awc, settings);
 
-    if (airspaces != nullptr) {
-      for (const auto &i :
-             airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                         projection.GetScreenDistanceMeters())) {
-        const AbstractAirspace &airspace = i.GetAirspace();
-        if (visible(airspace))
-          renderer.Visit(airspace);
-      }
-    }
-
-    for (const auto &ea : awc.GetExternalAirspaces())
-      if (visible(*ea))
-        renderer.Visit(*ea);
+    ForEachAirspaceInView(airspaces, awc.GetExternalAirspaces(), projection,
+                          visible,
+                          [&](const AbstractAirspace &airspace) {
+                            renderer.Visit(airspace);
+                          });
   } else {
     AirspaceVisitorRenderer renderer(canvas, projection, look, awc, settings);
 
-    if (airspaces != nullptr) {
-      for (const auto &i :
-             airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                         projection.GetScreenDistanceMeters())) {
-        const AbstractAirspace &airspace = i.GetAirspace();
-        if (visible(airspace))
-          renderer.Visit(airspace);
-      }
-    }
-
-    for (const auto &ea : awc.GetExternalAirspaces())
-      if (visible(*ea))
-        renderer.Visit(*ea);
+    ForEachAirspaceInView(airspaces, awc.GetExternalAirspaces(), projection,
+                          visible,
+                          [&](const AbstractAirspace &airspace) {
+                            renderer.Visit(airspace);
+                          });
   }
 }
 

--- a/src/Renderer/AirspaceRendererGL.cpp
+++ b/src/Renderer/AirspaceRendererGL.cpp
@@ -297,25 +297,39 @@ AirspaceRenderer::DrawInternal(Canvas &canvas,
                                const AirspaceWarningCopy &awc,
                                const AirspacePredicate &visible)
 {
-  const auto range =
-    airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                projection.GetScreenDistanceMeters());
-
   if (settings.fill_mode == AirspaceRendererSettings::FillMode::ALL ||
       settings.fill_mode == AirspaceRendererSettings::FillMode::NONE) {
     AirspaceFillRenderer renderer(canvas, projection, look, awc, settings);
-    for (const auto &i : range) {
-      const AbstractAirspace &airspace = i.GetAirspace();
-      if (visible(airspace))
-        renderer.Visit(airspace);
+
+    if (airspaces != nullptr) {
+      for (const auto &i :
+             airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
+                                         projection.GetScreenDistanceMeters())) {
+        const AbstractAirspace &airspace = i.GetAirspace();
+        if (visible(airspace))
+          renderer.Visit(airspace);
+      }
     }
+
+    for (const auto &ea : awc.GetExternalAirspaces())
+      if (visible(*ea))
+        renderer.Visit(*ea);
   } else {
     AirspaceVisitorRenderer renderer(canvas, projection, look, awc, settings);
-    for (const auto &i : range) {
-      const AbstractAirspace &airspace = i.GetAirspace();
-      if (visible(airspace))
-        renderer.Visit(airspace);
+
+    if (airspaces != nullptr) {
+      for (const auto &i :
+             airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
+                                         projection.GetScreenDistanceMeters())) {
+        const AbstractAirspace &airspace = i.GetAirspace();
+        if (visible(airspace))
+          renderer.Visit(airspace);
+      }
     }
+
+    for (const auto &ea : awc.GetExternalAirspaces())
+      if (visible(*ea))
+        renderer.Visit(*ea);
   }
 }
 

--- a/src/Renderer/AirspaceRendererOther.cpp
+++ b/src/Renderer/AirspaceRendererOther.cpp
@@ -201,17 +201,19 @@ AirspaceRenderer::DrawFill(Canvas &buffer_canvas, Canvas &stencil_canvas,
   AirspaceVisitorMap v(helper, awc, settings,
                        look);
 
-  // JMW TODO wasteful to draw twice, can't it be drawn once?
-  // we are using two draws so borders go on top of everything
-
-  const auto range =
-    airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                projection.GetScreenDistanceMeters());
-  for (const auto &i : range) {
-    const AbstractAirspace &airspace = i.GetAirspace();
-    if (visible(airspace))
-      v.Visit(airspace);
+  if (airspaces != nullptr) {
+    for (const auto &i :
+           airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
+                                       projection.GetScreenDistanceMeters())) {
+      const AbstractAirspace &airspace = i.GetAirspace();
+      if (visible(airspace))
+        v.Visit(airspace);
+    }
   }
+
+  for (const auto &ea : awc.GetExternalAirspaces())
+    if (visible(*ea))
+      v.Visit(*ea);
 
   return v.Commit();
 }
@@ -253,18 +255,24 @@ inline void
 AirspaceRenderer::DrawOutline(Canvas &canvas,
                               const WindowProjection &projection,
                               const AirspaceRendererSettings &settings,
+                              const AirspaceWarningCopy &awc,
                               const AirspacePredicate &visible) const
 {
-  const auto range =
-    airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                projection.GetScreenDistanceMeters());
-
   AirspaceOutlineRenderer outline_renderer(canvas, projection, look, settings);
-  for (const auto &i : range) {
-    const AbstractAirspace &airspace = i.GetAirspace();
-    if (visible(airspace))
-      outline_renderer.Visit(airspace);
+
+  if (airspaces != nullptr) {
+    for (const auto &i :
+           airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
+                                       projection.GetScreenDistanceMeters())) {
+      const AbstractAirspace &airspace = i.GetAirspace();
+      if (visible(airspace))
+        outline_renderer.Visit(airspace);
+    }
   }
+
+  for (const auto &ea : awc.GetExternalAirspaces())
+    if (visible(*ea))
+      outline_renderer.Visit(*ea);
 }
 
 void
@@ -277,7 +285,7 @@ AirspaceRenderer::DrawInternal(Canvas &canvas, Canvas &stencil_canvas,
   if (settings.fill_mode != AirspaceRendererSettings::FillMode::NONE)
     DrawFillCached(canvas, stencil_canvas, projection, settings, awc, visible);
 
-  DrawOutline(canvas, projection, settings, visible);
+  DrawOutline(canvas, projection, settings, awc, visible);
 }
 
 #endif /* ENABLE_OPENGL */

--- a/src/Renderer/AirspaceRendererOther.cpp
+++ b/src/Renderer/AirspaceRendererOther.cpp
@@ -13,6 +13,7 @@
 #include "Airspace/Airspaces.hpp"
 #include "Airspace/AirspacePolygon.hpp"
 #include "Airspace/AirspaceCircle.hpp"
+#include "Airspace/AirspaceIteration.hxx"
 #include "Airspace/AirspaceWarningCopy.hpp"
 #include "Engine/Airspace/Predicate/AirspacePredicate.hpp"
 #include "MapWindow/StencilMapCanvas.hpp"
@@ -201,19 +202,11 @@ AirspaceRenderer::DrawFill(Canvas &buffer_canvas, Canvas &stencil_canvas,
   AirspaceVisitorMap v(helper, awc, settings,
                        look);
 
-  if (airspaces != nullptr) {
-    for (const auto &i :
-           airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                       projection.GetScreenDistanceMeters())) {
-      const AbstractAirspace &airspace = i.GetAirspace();
-      if (visible(airspace))
-        v.Visit(airspace);
-    }
-  }
-
-  for (const auto &ea : awc.GetExternalAirspaces())
-    if (visible(*ea))
-      v.Visit(*ea);
+  ForEachAirspaceInView(airspaces, awc.GetExternalAirspaces(), projection,
+                        visible,
+                        [&](const AbstractAirspace &airspace) {
+                          v.Visit(airspace);
+                        });
 
   return v.Commit();
 }
@@ -260,19 +253,11 @@ AirspaceRenderer::DrawOutline(Canvas &canvas,
 {
   AirspaceOutlineRenderer outline_renderer(canvas, projection, look, settings);
 
-  if (airspaces != nullptr) {
-    for (const auto &i :
-           airspaces->QueryWithinRange(projection.GetGeoScreenCenter(),
-                                       projection.GetScreenDistanceMeters())) {
-      const AbstractAirspace &airspace = i.GetAirspace();
-      if (visible(airspace))
-        outline_renderer.Visit(airspace);
-    }
-  }
-
-  for (const auto &ea : awc.GetExternalAirspaces())
-    if (visible(*ea))
-      outline_renderer.Visit(*ea);
+  ForEachAirspaceInView(airspaces, awc.GetExternalAirspaces(), projection,
+                        visible,
+                        [&](const AbstractAirspace &airspace) {
+                          outline_renderer.Visit(airspace);
+                        });
 }
 
 void

--- a/src/Renderer/AirspaceRendererSettings.cpp
+++ b/src/Renderer/AirspaceRendererSettings.cpp
@@ -116,7 +116,7 @@ AirspaceRendererSettings::SetDefaults()
   classes[ATZ].SetColors(RGB8_GRAYISH_VIOLET);
   classes[AWY].SetColors(RGB8_BLUE);
   classes[MTR].SetColors(RGB8_LIGHT_GRAY);
-  classes[ALERT].SetColors(RGB8_DARK_GRAY);
+  classes[ALERT].SetColors(RGB8_RED);
   classes[WARNING].SetColors(RGB8_DARK_GRAY);
   classes[PROTECTED].SetColors(RGB8_GREEN.Darken());
   classes[HTZ].SetColors(RGB8_GREEN.Darken());

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -40,6 +40,7 @@
 #include "Device/Driver/Zander.hpp"
 #include "Device/Parser.hpp"
 #include "Device/Port/NullPort.hpp"
+#include "FLARM/AlertZone.hpp"
 #include "FLARM/Error.hpp"
 #include "FLARM/Progress.hpp"
 #include "FLARM/State.hpp"
@@ -484,6 +485,59 @@ TestFLARM()
   ok1(parser.ParseLine("$PFLAQ,FW,,100*46", nmea_info));
   ok1(nmea_info.flarm.progress.operation.equals("FW"));
   ok1(nmea_info.flarm.progress.progress == 100);
+
+  // PFLAO: Alert Zone (spec example - skydiver drop zone, inside, alarm)
+  ok1(parser.ParseLine("$PFLAO,1,1,471122335,85577812,2000,100,4550,1432832400,DF4738,2,41*4E",
+                        nmea_info));
+  ok1(nmea_info.flarm.alert_zones.modified);
+  ok1(nmea_info.flarm.alert_zones.list.size() == 1);
+  {
+    const auto *zone = nmea_info.flarm.alert_zones.list.begin();
+    ok1(zone->alarm_level == FlarmTraffic::AlarmType::LOW);
+    ok1(zone->inside == true);
+    ok1(equals(zone->center.latitude, 47.1122335));
+    ok1(equals(zone->center.longitude, 8.5577812));
+    ok1(zone->radius == 2000);
+    ok1(zone->bottom == 100);
+    ok1(zone->top == 4550);
+    ok1(zone->activity_limit == 1432832400);
+    ok1(zone->id_type == FlarmTraffic::IdType::FLARM);
+    ok1(zone->zone_type == 0x41);
+  }
+
+  // PFLAO: second zone (ATZ, outside, no alarm)
+  nmea_info.clock = TimeStamp{FloatDuration{2}};
+  ok1(parser.ParseLine("$PFLAO,0,0,470000000,86000000,1500,200,3000,0,A25703,1,42*05",
+                        nmea_info));
+  ok1(nmea_info.flarm.alert_zones.list.size() == 2);
+  {
+    const auto *zone = nmea_info.flarm.alert_zones.FindZone(
+        FlarmId::Parse("A25703", nullptr));
+    ok1(zone != nullptr);
+    ok1(zone->alarm_level == FlarmTraffic::AlarmType::NONE);
+    ok1(zone->inside == false);
+    ok1(equals(zone->center.latitude, 47.0));
+    ok1(equals(zone->center.longitude, 8.6));
+    ok1(zone->radius == 1500);
+    ok1(zone->bottom == 200);
+    ok1(zone->top == 3000);
+    ok1(zone->activity_limit == 0);
+    ok1(zone->id_type == FlarmTraffic::IdType::ICAO);
+    ok1(zone->zone_type == 0x42);
+  }
+
+  // PFLAO: update to first zone (same ID, alarm cleared, still inside)
+  nmea_info.clock = TimeStamp{FloatDuration{3}};
+  ok1(parser.ParseLine("$PFLAO,0,1,471122335,85577812,2000,100,4550,1432832400,DF4738,2,41*4F",
+                        nmea_info));
+  ok1(nmea_info.flarm.alert_zones.list.size() == 2);
+  {
+    const auto *zone = nmea_info.flarm.alert_zones.FindZone(
+        FlarmId::Parse("DF4738", nullptr));
+    ok1(zone != nullptr);
+    ok1(zone->alarm_level == FlarmTraffic::AlarmType::NONE);
+    ok1(zone->inside == true);
+  }
 
   // Ensure a database instance exists before PFLAM messages are parsed
   if (traffic_databases == nullptr)
@@ -2909,7 +2963,7 @@ int main()
 
   plan_tests(1036 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
-             + 16 /* PFLAQ */
+             + 16 /* PFLAQ */ + 31 /* PFLAO */
              + 109 /* LXNav protocol 1.05 */
              + 8 /* SubSecond */ + 4 /* MWVStatus */
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */


### PR DESCRIPTION
## Summary
- Parse FLARM PFLAO alert zone messages and expose them as alert zones.
- Integrate alert zones into the airspace warning pipeline and rendering/labels.
- Add supporting helpers in airspace warning manager and warning computer.

Fixes #742

## Test plan
- [ ] Connect a FLARM source that emits PFLAO alert zones; verify zones appear and warnings trigger.
- [ ] Verify no regressions in normal airspace warnings and labels.
- [ ] Run existing unit tests (if applicable) and verify app starts normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FLARM alert zone support: PFLAO NMEA parsing and in-memory alert-zone data structures
  * External airspaces can be supplied and participate in warning calculation and rendering
  * Shared helpers for iterating airspaces in view/range and a predicate for visibility decisions

* **Updates**
  * Airspace rendering now considers external airspaces; alert-class color changed to red

* **Tests**
  * Added tests covering PFLAO parsing and alert-zone state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->