### PR TITLE
Device/NMEA refactor and string helper tests

### DIFF
--- a/build/coverage.mk
+++ b/build/coverage.mk
@@ -35,3 +35,7 @@ covend:	FORCE | $(COVERAGE_DATA_DIR)/dirstamp $(COVERAGE_HTML_DIR)/dirstamp
 	@$(Q)$(COVMERGE)
 	@$(Q)$(COVCLEAN)
 	@$(Q)$(COVPROC)
+
+coverage-check: covstart check covend
+
+coverage-check-no-build: covstart check-no-build covend

--- a/build/test.mk
+++ b/build/test.mk
@@ -105,7 +105,8 @@ TEST_NAMES = \
 	TestAirspaceParser \
 	TestMETARParser \
 	TestIGCParser \
-	TestStrings TestUTF8 TestWrapText \
+	TestStrings TestStringParser TestUTF8 TestWrapText \
+	TestStringHelpers \
 	TestInputConfig \
 	TestCRC16 TestCRC8 \
 	TestUnitsFormatter \
@@ -552,6 +553,20 @@ TEST_STRINGS_SOURCES = \
 	$(TEST_SRC_DIR)/TestStrings.cpp
 TEST_STRINGS_DEPENDS = UTIL
 $(eval $(call link-program,TestStrings,TEST_STRINGS))
+
+TEST_STRING_PARSER_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestStringParser.cpp
+TEST_STRING_PARSER_DEPENDS = UTIL
+$(eval $(call link-program,TestStringParser,TEST_STRING_PARSER))
+
+TEST_STRING_HELPERS_SOURCES = \
+	$(SRC)/util/StringCompare.cxx \
+	$(SRC)/util/StringStrip.cxx \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestStringHelpers.cpp
+TEST_STRING_HELPERS_DEPENDS = UTIL
+$(eval $(call link-program,TestStringHelpers,TEST_STRING_HELPERS))
 
 TEST_UTF8_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/AirControlDisplay.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -277,15 +278,12 @@ ACDDevice::ExchangeRadioFrequencies(OperationEnvironment &env,
 bool
 ACDDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  if (line.ReadCompare("$PAAVS"))
-    return ParsePAAVS(line, info, this);
-  else
-    return false;
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    if (line.ReadCompare("$PAAVS"))
+      return ParsePAAVS(line, info, this);
+    else
+      return false;
+  });
 }
 
 void

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -196,10 +196,8 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info, ACDDevice *dev) noexcept
 bool
 ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 {
-  char buffer[100];
   unsigned qnh = uround(pres.GetPascal());
-  sprintf(buffer, "PAAVC,S,ALT,QNH,%u", qnh);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PAAVC,S,ALT,QNH,%u", qnh);
   return true;
 }
 
@@ -237,9 +235,7 @@ ACDDevice::PutActiveFrequency(RadioFrequency frequency,
 bool
 ACDDevice::PutVolume(unsigned volume, OperationEnvironment &env)
 {
-  char buffer[100];
-  sprintf(buffer, "PAAVC,S,COM,RXVOL1,%u", volume);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PAAVC,S,COM,RXVOL1,%u", volume);
   return true;
 }
 
@@ -248,10 +244,8 @@ ACDDevice::PutStandbyFrequency(RadioFrequency frequency,
                                    [[maybe_unused]] const char *name,
                                    OperationEnvironment &env)
 {
-  char buffer[100];
   unsigned freq = frequency.GetKiloHertz();
-  sprintf(buffer, "PAAVC,S,COM,CHN2,%u", freq);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PAAVC,S,COM,CHN2,%u", freq);
   cached_com_standby_khz.store(freq, std::memory_order_relaxed);
   com_standby_khz_known.store(true, std::memory_order_release);
   return true;
@@ -260,9 +254,7 @@ ACDDevice::PutStandbyFrequency(RadioFrequency frequency,
 bool
 ACDDevice::PutTransponderCode(TransponderCode code, OperationEnvironment &env)
 {
-  char buffer[100];
-  sprintf(buffer, "PAAVC,S,XPDR,SQUAWK,%04o", code.GetCode());
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PAAVC,S,XPDR,SQUAWK,%04o", code.GetCode());
   return true;
 }
 

--- a/src/Device/Driver/AltairPro.cpp
+++ b/src/Device/Driver/AltairPro.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/AltairPro.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "Device/Port/Port.hpp"
 #include "Device/Declaration.hpp"
@@ -94,25 +95,22 @@ PTFRS(NMEAInputLine &line, NMEAInfo &info)
 bool
 AltairProDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+
+    // no propriatary sentence
+
+    if (type == "$PGRMZ"sv) {
+      double value;
+      if (ReadAltitude(line, value))
+        info.ProvidePressureAltitude(value);
+
+      return true;
+    } else if (type == "$PTFRS"sv)
+      return PTFRS(line, info);
+
     return false;
-
-  NMEAInputLine line(String);
-  const auto type = line.ReadView();
-
-  // no propriatary sentence
-
-  if (type == "$PGRMZ"sv) {
-    double value;
-    if (ReadAltitude(line, value))
-      info.ProvidePressureAltitude(value);
-
-    return true;
-  } else if (type == "$PTFRS"sv) {
-    return PTFRS(line, info);
-  }
-
-  return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/BlueFly/Settings.cpp
+++ b/src/Device/Driver/BlueFly/Settings.cpp
@@ -29,12 +29,9 @@ void
 BlueFlyDevice::WriteDeviceSetting(const char *name, int value,
                                   OperationEnvironment &env)
 {
-  char buffer[64];
-
   assert(strlen(name) == 3);
 
-  sprintf(buffer, "%s %d", name, value);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "%s %d", name, value);
 }
 
 void

--- a/src/Device/Driver/BorgeltB50.cpp
+++ b/src/Device/Driver/BorgeltB50.cpp
@@ -4,6 +4,7 @@
 #include "Device/Driver/BorgeltB50.hpp"
 #include "Device/Driver/CAI302/PocketNav.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Units/System.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -106,16 +107,13 @@ PBB50(NMEAInputLine &line, NMEAInfo &info)
 bool
 B50Device::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$PBB50"sv)
-    return PBB50(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PBB50"sv)
+      return PBB50(line, info);
+    else
+      return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/CAI302/Parser.cpp
+++ b/src/Device/Driver/CAI302/Parser.cpp
@@ -6,6 +6,7 @@
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
+#include "Device/Util/NMEAParser.hpp"
 
 using std::string_view_literals::operator""sv;
 
@@ -126,18 +127,15 @@ cai_w(NMEAInputLine &line, NMEAInfo &info)
 bool
 CAI302Device::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$PCAIB"sv)
-    return cai_PCAIB(line, info);
-  else if (type == "$PCAID"sv)
-    return cai_PCAID(line, info);
-  else if (type == "!w"sv)
-    return cai_w(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PCAIB"sv)
+      return cai_PCAIB(line, info);
+    else if (type == "$PCAID"sv)
+      return cai_PCAID(line, info);
+    else if (type == "!w"sv)
+      return cai_w(line, info);
+    else
+      return false;
+  });
 }

--- a/src/Device/Driver/CAI302/PocketNav.cpp
+++ b/src/Device/Driver/CAI302/PocketNav.cpp
@@ -8,35 +8,33 @@
 
 #include <stdio.h>
 
+static bool
+PutGCommand(Port &port, const char *command, unsigned value,
+            OperationEnvironment &env)
+{
+  char buffer[32];
+  sprintf(buffer, "!g,%s%u\r", command, value);
+  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
+  return true;
+}
+
 bool
 CAI302::PutMacCready(Port &port, double mc, OperationEnvironment &env)
 {
   unsigned mac_cready = uround(Units::ToUserUnit(mc * 10, Unit::KNOTS));
-
-  char buffer[32];
-  sprintf(buffer, "!g,m%u\r", mac_cready);
-  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
-  return true;
+  return PutGCommand(port, "m", mac_cready, env);
 }
 
 bool
 CAI302::PutBugs(Port &port, double bugs, OperationEnvironment &env)
 {
   unsigned bugs2 = uround(bugs * 100);
-
-  char buffer[32];
-  sprintf(buffer, "!g,u%u\r", bugs2);
-  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
-  return true;
+  return PutGCommand(port, "u", bugs2, env);
 }
 
 bool
 CAI302::PutBallast(Port &port, double fraction, OperationEnvironment &env)
 {
   unsigned ballast = uround(fraction * 10);
-
-  char buffer[32];
-  sprintf(buffer, "!g,b%u\r", ballast);
-  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
-  return true;
+  return PutGCommand(port, "b", ballast, env);
 }

--- a/src/Device/Driver/Condor.cpp
+++ b/src/Device/Driver/Condor.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/Condor.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Units/System.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -72,15 +73,13 @@ cLXWP0(NMEAInputLine &line, NMEAInfo &info, bool reciprocal_wind)
 bool
 CondorDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$LXWP0"sv) return cLXWP0(line, info, reciprocal_wind);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$LXWP0"sv)
+      return cLXWP0(line, info, reciprocal_wind);
+    else
+      return false;
+  });
 }
 
 static Device *

--- a/src/Device/Driver/EWMicroRecorder.cpp
+++ b/src/Device/Driver/EWMicroRecorder.cpp
@@ -10,6 +10,7 @@
 #include "Device/Driver.hpp"
 #include "Device/Port/Port.hpp"
 #include "Device/Declaration.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
@@ -68,27 +69,24 @@ ReadAltitude(NMEAInputLine &line, double &value_r)
 bool
 EWMicroRecorderDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PGRMZ"sv) {
+      double value;
 
-  NMEAInputLine line(String);
+      /* The normal Garmin $PGRMZ line contains the "true" barometric
+         altitude above MSL (corrected with QNH), but EWMicroRecorder
+         differs here slightly: it emits the uncorrected barometric
+         altitude.  That is the only reason why we catch this sentence
+         in the driver instead of letting the generic class NMEAParser
+         do it. */
+      if (ReadAltitude(line, value))
+        info.ProvidePressureAltitude(value);
 
-  const auto type = line.ReadView();
-  if (type == "$PGRMZ"sv) {
-    double value;
-
-    /* The normal Garmin $PGRMZ line contains the "true" barometric
-       altitude above MSL (corrected with QNH), but EWMicroRecorder
-       differs here slightly: it emits the uncorrected barometric
-       altitude.  That is the only reason why we catch this sentence
-       in the driver instead of letting the generic class NMEAParser
-       do it. */
-    if (ReadAltitude(line, value))
-      info.ProvidePressureAltitude(value);
-
-    return true;
-  } else
-    return false;
+      return true;
+    } else
+      return false;
+  });
 }
 
 static bool

--- a/src/Device/Driver/Eye.cpp
+++ b/src/Device/Driver/Eye.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/Eye.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -27,18 +28,15 @@ protected:
 bool
 EyeDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  const auto type = line.ReadView();
-  if (type == "$PEYA"sv)
-    return PEYA(line, info);
-  else if (type == "$PEYI"sv)
-    return PEYI(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PEYA"sv)
+      return PEYA(line, info);
+    else if (type == "$PEYI"sv)
+      return PEYI(line, info);
+    else
+      return false;
+  });
 }
 
 inline bool

--- a/src/Device/Driver/FLARM/Parser.cpp
+++ b/src/Device/Driver/FLARM/Parser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Device.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
 
@@ -31,14 +32,11 @@ FlarmDevice::ParsePFLAC(NMEAInputLine &line)
 bool
 FlarmDevice::ParseNMEA(const char *_line, [[maybe_unused]] NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  const auto type = line.ReadView();
-  if (type == "$PFLAC"sv)
-    return ParsePFLAC(line);
-  else
-    return false;
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PFLAC"sv)
+      return ParsePFLAC(line);
+    else
+      return false;
+  });
 }

--- a/src/Device/Driver/FlymasterF1.cpp
+++ b/src/Device/Driver/FlymasterF1.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/FlymasterF1.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -71,16 +72,13 @@ VARIO(NMEAInputLine &line, NMEAInfo &info)
 bool
 FlymasterF1Device::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$VARIO"sv)
-    return VARIO(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$VARIO"sv)
+      return VARIO(line, info);
+    else
+      return false;
+  });
 }
 
 static Device *

--- a/src/Device/Driver/Flytec/Logger.cpp
+++ b/src/Device/Driver/Flytec/Logger.cpp
@@ -5,6 +5,7 @@
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
 #include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAWriter.hpp"
 #include "Device/RecordedFlight.hpp"
 #include "time/TimeoutClock.hpp"
 #include "util/Macros.hpp"
@@ -155,11 +156,7 @@ FlytecDevice::ReadFlightList(RecordedFlightList &flight_list,
   port.StopRxThread();
 
   char buffer[256];
-  strcpy(buffer, "$PBRTL,");
-  AppendNMEAChecksum(buffer);
-  strcat(buffer, "\r\n");
-
-  port.Write(buffer);
+  PortFullWriteNMEA(port, "PBRTL,", env, std::chrono::seconds{1});
   ExpectXOff(port, env, std::chrono::seconds{1});
 
   unsigned tracks = 0;

--- a/src/Device/Driver/Flytec/Parser.cpp
+++ b/src/Device/Driver/Flytec/Parser.cpp
@@ -3,6 +3,7 @@
 
 #include "Device.hpp"
 #include "Device/Parser.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
@@ -227,18 +228,15 @@ FlytecDevice::ParseFLYSEN(NMEAInputLine &line, NMEAInfo &info)
 bool
 FlytecDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  const auto type = line.ReadView();
-  if (type == "$BRSF"sv)
-    return FlytecParseBRSF(line, info);
-  else if (type == "$VMVABD"sv)
-    return FlytecParseVMVABD(line, info);
-  else if (type == "$FLYSEN"sv)
-    return ParseFLYSEN(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$BRSF"sv)
+      return FlytecParseBRSF(line, info);
+    else if (type == "$VMVABD"sv)
+      return FlytecParseVMVABD(line, info);
+    else if (type == "$FLYSEN"sv)
+      return ParseFLYSEN(line, info);
+    else
+      return false;
+  });
 }

--- a/src/Device/Driver/ILEC.cpp
+++ b/src/Device/Driver/ILEC.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/ILEC.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -47,20 +48,17 @@ ParsePDA1(NMEAInputLine &line, NMEAInfo &info)
 bool
 ILECDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  auto type = line.ReadView();
-  if (type == "$PILC"sv) {
-    type = line.ReadView();
-    if (type == "PDA1"sv)
-      return ParsePDA1(line, info);
-    else
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    auto type = line.ReadView();
+    if (type == "$PILC"sv) {
+      type = line.ReadView();
+      if (type == "PDA1"sv)
+        return ParsePDA1(line, info);
+      else
+        return false;
+    } else
       return false;
-  } else
-    return false;
+  });
 }
 
 static Device *

--- a/src/Device/Driver/IMI/Internal.cpp
+++ b/src/Device/Driver/IMI/Internal.cpp
@@ -3,6 +3,7 @@
 
 #include "Internal.hpp"
 #include "Protocol/Protocol.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "Units/Unit.hpp"
@@ -47,26 +48,23 @@ ReadAltitude(NMEAInputLine &line, double &value_r)
 bool
 IMIDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PGRMZ"sv) {
+      double value;
 
-  NMEAInputLine line(String);
+      /* The normal Garmin $PGRMZ line contains the "true" barometric
+         altitude above MSL (corrected with QNH), but IMIDevice differs:
+         it emits the uncorrected barometric altitude (i.e. pressure
+         altitude). That is the only reason why we catch this sentence
+         in the driver instead of letting the generic class NMEAParser
+         do it. (solution inspired by EWMicroRecorderDevice, and
+         AltairProDevice. ) */
+      if (ReadAltitude(line, value))
+        info.ProvidePressureAltitude(value);
 
-  const auto type = line.ReadView();
-  if (type == "$PGRMZ"sv) {
-    double value;
-
-    /* The normal Garmin $PGRMZ line contains the "true" barometric
-       altitude above MSL (corrected with QNH), but IMIDevice differs:
-       it emits the uncorrected barometric altitude (i.e. pressure
-       altitude). That is the only reason why we catch this sentence
-       in the driver instead of letting the generic class NMEAParser
-       do it. (solution inspired by EWMicroRecorderDevice, and
-       AltairProDevice. ) */
-    if (ReadAltitude(line, value))
-      info.ProvidePressureAltitude(value);
-
-    return true;
-  } else
-    return false;
+      return true;
+    } else
+      return false;
+  });
 }

--- a/src/Device/Driver/LX/LX1600.hpp
+++ b/src/Device/Driver/LX/LX1600.hpp
@@ -68,9 +68,7 @@ namespace LX1600 {
   {
     assert(mc >= 0.0 && mc <= 5.0);
 
-    char buffer[32];
-    sprintf(buffer, "PFLX2,%1.1f,,,,,,", mc);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,%1.1f,,,,,,", mc);
   }
 
   /**
@@ -85,9 +83,7 @@ namespace LX1600 {
     // This is a copy of the routine done in LK8000 for LX MiniMap, realized
     // by Lx developers.
 
-    char buffer[100];
-    sprintf(buffer, "PFLX2,,%.2f,,,,", overload);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,,%.2f,,,,", overload);
   }
 
   /**
@@ -102,9 +98,7 @@ namespace LX1600 {
     // This is a copy of the routine done in LK8000 for LX MiniMap, realized
     // by Lx developers.
 
-    char buffer[100];
-    sprintf(buffer, "PFLX2,,,%u,,,", bugs);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,,,%u,,,", bugs);
   }
 
   /**
@@ -115,9 +109,7 @@ namespace LX1600 {
   SetAltitudeOffset(Port &port, OperationEnvironment &env,
                     double altitude_offset)
   {
-    char buffer[100];
-    sprintf(buffer, "PFLX3,%.2f,,,,,,,,,,,,", altitude_offset);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX3,%.2f,,,,,,,,,,,,", altitude_offset);
   }
 
   /**
@@ -144,9 +136,7 @@ namespace LX1600 {
   static inline void
   SetPolar(Port &port, OperationEnvironment &env, double a, double b, double c)
   {
-    char buffer[100];
-    sprintf(buffer, "PFLX2,,,,%.2f,%.2f,%.2f,", a, b, c);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,,,,%.2f,%.2f,%.2f,", a, b, c);
   }
 
   /**
@@ -176,9 +166,7 @@ namespace LX1600 {
     if (volume > 99)
       volume = 99;
 
-    char buffer[100];
-    sprintf(buffer, "PFLX2,,,,,,,%u", volume);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,,,,,,,%u", volume);
   }
 
   /**
@@ -197,10 +185,8 @@ namespace LX1600 {
     assert(te_filter >= 0.1 && te_filter <= 2.0);
     assert((te_level >= 50 && te_level <= 150) || te_level == 0);
 
-    char buffer[100];
-    sprintf(buffer, "PFLX3,,,%.1f,%.1f,%u",
-            vario_filter, te_filter, te_level);
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX3,,,%.1f,%.1f,%u",
+                        vario_filter, te_filter, te_level);
   }
 
   /**
@@ -224,16 +210,14 @@ namespace LX1600 {
     assert(mode != SCMode::AUTO_IAS ||
            (threshold_speed >= 50 && threshold_speed <= 150));
 
-    char buffer[100];
     if (mode == SCMode::AUTO_IAS)
-      sprintf(buffer, "PFLX3,,%u,,,,,,%.1f,%u,%.0f",
-              (unsigned)mode, deadband, (unsigned)control_mode,
-              threshold_speed);
+      PortWriteNMEAFormat(port, env, "PFLX3,,%u,,,,,,%.1f,%u,%.0f",
+                          (unsigned)mode, deadband,
+                          (unsigned)control_mode, threshold_speed);
     else
-      sprintf(buffer, "PFLX3,,%u,,,,,,%.1f,%u",
-              (unsigned)mode, deadband, (unsigned)control_mode);
-
-    PortWriteNMEA(port, buffer, env);
+      PortWriteNMEAFormat(port, env, "PFLX3,,%u,,,,,,%.1f,%u",
+                          (unsigned)mode, deadband,
+                          (unsigned)control_mode);
   }
 
   /**
@@ -250,10 +234,7 @@ namespace LX1600 {
     assert(avg_time >= 5 && avg_time <= 30);
     assert(range >= 2.5 && range <= 10);
 
-    char buffer[100];
-    sprintf(buffer, "PFLX3,,,,,,%u,%.1f", avg_time, range);
-
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX3,,,,,,%u,%.1f", avg_time, range);
   }
 
   /**
@@ -263,10 +244,7 @@ namespace LX1600 {
   static inline void
   SetSmartDiffFilter(Port &port, OperationEnvironment &env, double filter)
   {
-    char buffer[100];
-    sprintf(buffer, "PFLX3,,,,,,,,,,,%.1f", filter);
-
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX3,,,,,,,,,,,%.1f", filter);
   }
 
   /**
@@ -278,9 +256,6 @@ namespace LX1600 {
   {
     assert(offset >= -14 && offset <= 14);
 
-    char buffer[100];
-    sprintf(buffer, "PFLX3,,,,,,,,,,,,,%d", offset);
-
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX3,,,,,,,,,,,,,%d", offset);
   }
 }

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -3,6 +3,7 @@
 
 #include "Internal.hpp"
 #include "Parsers.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Info.hpp"
@@ -690,60 +691,57 @@ LXDevice::UpdateDeviceFlags(const DeviceInfo &device_info,
 bool
 LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$LXWP0"sv)
+      return LX::LXWP0(line, info);
 
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$LXWP0"sv)
-    return LX::LXWP0(line, info);
-
-  if (type == "$LXWP1"sv) {
-    DeviceInfo &device_info = mode == Mode::PASS_THROUGH
-      ? info.secondary_device
-      : info.device;
-    LX::LXWP1(line, device_info);
-    UpdateDeviceFlags(device_info, mode == Mode::PASS_THROUGH);
-    return true;
-  }
-
-  if (type == "$LXWP2"sv)
-    return LX::LXWP2(line, info);
-
-  if (type == "$LXWP3"sv)
-    return LX::LXWP3(line, info);
-
-  if (type == "$PLXV0"sv) {
-    is_colibri = false;
-    return PLXV0(line, lxnav_vario_settings, info);
-  }
-
-  if (type == "$PLXVC"sv) {
-    is_colibri = false;
-    PLXVC(line, info, nano_settings, device_declaration, mutex);
-
-    {
-      const std::lock_guard lock{mutex};
-      is_forwarded_nano =
-        IsNanoProduct(info.secondary_device.product);
-      const bool was_vario = IsLXNAVVario();
-      IdDeviceByNameLocked(info.device.product, info.device);
-      if (!was_vario && IsLXNAVVario())
-        vario_just_detected = true;
+    if (type == "$LXWP1"sv) {
+      DeviceInfo &device_info = mode == Mode::PASS_THROUGH
+        ? info.secondary_device
+        : info.device;
+      LX::LXWP1(line, device_info);
+      UpdateDeviceFlags(device_info, mode == Mode::PASS_THROUGH);
+      return true;
     }
-    return true;
-  }
 
-  if (type == "$PLXVF"sv) {
-    is_colibri = false;
-    return PLXVF(line, info);
-  }
+    if (type == "$LXWP2"sv)
+      return LX::LXWP2(line, info);
 
-  if (type == "$PLXVS"sv) {
-    is_colibri = false;
-    return PLXVS(line, info);
-  }
+    if (type == "$LXWP3"sv)
+      return LX::LXWP3(line, info);
 
-  return false;
+    if (type == "$PLXV0"sv) {
+      is_colibri = false;
+      return PLXV0(line, lxnav_vario_settings, info);
+    }
+
+    if (type == "$PLXVC"sv) {
+      is_colibri = false;
+      PLXVC(line, info, nano_settings, device_declaration, mutex);
+
+      {
+        const std::lock_guard lock{mutex};
+        is_forwarded_nano =
+          IsNanoProduct(info.secondary_device.product);
+        const bool was_vario = IsLXNAVVario();
+        IdDeviceByNameLocked(info.device.product, info.device);
+        if (!was_vario && IsLXNAVVario())
+          vario_just_detected = true;
+      }
+      return true;
+    }
+
+    if (type == "$PLXVF"sv) {
+      is_colibri = false;
+      return PLXVF(line, info);
+    }
+
+    if (type == "$PLXVS"sv) {
+      is_colibri = false;
+      return PLXVS(line, info);
+    }
+
+    return false;
+  });
 }

--- a/src/Device/Driver/LX_EOS/LXEosDevice.cpp
+++ b/src/Device/Driver/LX_EOS/LXEosDevice.cpp
@@ -129,15 +129,10 @@ bool
 LXEosDevice::SendNewSettings(OperationEnvironment& env)
 {
   if (vario_settings.uptodate == true) {
-    char buffer[64];
-    snprintf(buffer,
-             64,
-             "PFLX2,%.1f,%.2f,%.0f,,,,,",
-             vario_settings.mc,
-             vario_settings.bal,
-             vario_settings.bugs);
-
-    PortWriteNMEA(port, buffer, env);
+    PortWriteNMEAFormat(port, env, "PFLX2,%.1f,%.2f,%.0f,,,,,",
+                        vario_settings.mc,
+                        vario_settings.bal,
+                        vario_settings.bugs);
     return true;
   } else
     return false;

--- a/src/Device/Driver/LX_EOS/LXEosDevice.cpp
+++ b/src/Device/Driver/LX_EOS/LXEosDevice.cpp
@@ -6,6 +6,7 @@
 #include "Device/Driver/LX/Internal.hpp"
 #include "Device/Driver/LX/Parsers.hpp"
 #include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Derived.hpp"
@@ -106,25 +107,22 @@ LXEosDevice::PutBugs(double bugs, OperationEnvironment& env)
 bool
 LXEosDevice::ParseNMEA(const char* String, NMEAInfo& info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$LXWP0"sv)
-    return LXWP0(line, info);
-  else if (type == "$LXWP1"sv) {
-    // LXWP1 sentence is identical to LXNAV, using shared parser
-    LX::LXWP1(line, info.device);
-    altitude_offset.reliable = HasReliableAltOffset(info.device);
-    return true;
-  } else if (type == "$LXWP2"sv)
-    return LXWP2(line, info);
-  else if (type == "$LXWP3"sv)
-    return LXWP3(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$LXWP0"sv)
+      return LXWP0(line, info);
+    else if (type == "$LXWP1"sv) {
+      // LXWP1 sentence is identical to LXNAV, using shared parser
+      LX::LXWP1(line, info.device);
+      altitude_offset.reliable = HasReliableAltOffset(info.device);
+      return true;
+    } else if (type == "$LXWP2"sv)
+      return LXWP2(line, info);
+    else if (type == "$LXWP3"sv)
+      return LXWP3(line, info);
+    else
+      return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/Larus.cpp
+++ b/src/Device/Driver/Larus.cpp
@@ -11,6 +11,7 @@
 #include "Device/Driver/Larus.hpp"
 #include "Device/Driver.hpp"
 #include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -70,33 +71,30 @@ ReadBearing(NMEAInputLine &line, Angle &value_r)
 bool
 LarusDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type.starts_with("$PLAR"sv)) {
+      switch (type[5]) {
+      case 'A':
+        return PLARA(line, info);
+      case 'B':
+        return PLARB(line, info);
+      case 'D':
+        return PLARD(line, info);
+      case 'V':
+        return PLARV(line, info);
+      case 'W':
+        return PLARW(line, info);
+      case 'S':
+        return PLARS(line, info);
+      default:
+        break;
+      }
+    } else if (type == "$HCHDT"sv)
+      return HCHDT(line, info);
+
     return false;
-
-  NMEAInputLine line(_line);
-  const auto type = line.ReadView();
-  if (type.starts_with("$PLAR"sv)) {
-    switch (type[5]) {
-    case 'A':
-      return PLARA(line, info);
-    case 'B':
-      return PLARB(line, info);
-    case 'D':
-      return PLARD(line, info);
-    case 'V':
-      return PLARV(line, info);
-    case 'W':
-      return PLARW(line, info);
-    case 'S':
-      return PLARS(line, info);
-    default:
-      break;
-    }
-  }
-  else if (type == "$HCHDT"sv)
-    return HCHDT(line, info);
-
-  return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/Larus.cpp
+++ b/src/Device/Driver/Larus.cpp
@@ -401,9 +401,8 @@ bool
 LarusDevice::PutBugs(double bugs, OperationEnvironment &env)
 {
   // $PLARS,H,BUGS,0*0B
-  char buffer[50];
-  sprintf(buffer, "PLARS,H,BUGS,%0.0f", (1.0-bugs) * 100.0);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PLARS,H,BUGS,%0.0f",
+                      (1.0 - bugs) * 100.0);
   return true;
 }
 
@@ -411,9 +410,7 @@ bool
 LarusDevice::PutMacCready(double mc, OperationEnvironment &env)
 {
   // $PLARS,H,MC,2.1*1B
-  char buffer[50];
-  sprintf(buffer, "PLARS,H,MC,%0.1f", mc);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PLARS,H,MC,%0.1f", mc);
   return true;
 }
 
@@ -422,9 +419,7 @@ LarusDevice::PutBallast(double fraction, [[maybe_unused]] double overload,
                         OperationEnvironment &env)
 { 
   // $PLARS,H,BAL,1.00*68
-  char buffer[50];
-  sprintf(buffer, "PLARS,H,BAL,%0.3f", fraction);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PLARS,H,BAL,%0.3f", fraction);
   return true;
 }
 
@@ -433,9 +428,8 @@ LarusDevice::PutQNH(const AtmosphericPressure &pres,
                           OperationEnvironment &env) 
 { 
   // $PLARS,H,QNH,1031.4*76
-  char buffer[50];
-  sprintf(buffer, "PLARS,H,QNH,%0.1f", pres.GetHectoPascal());
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PLARS,H,QNH,%0.1f",
+                      pres.GetHectoPascal());
   return true;
 }
 

--- a/src/Device/Driver/LoEFGREN.cpp
+++ b/src/Device/Driver/LoEFGREN.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/LoEFGREN.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -59,16 +60,13 @@ LoEFGRENDevice::ParseNMEA(const char *line, NMEAInfo &info)
   if (line == nullptr)
     return false;
 
-  if (!VerifyNMEAChecksum(line))
+  return ParseNMEAWithChecksum(line, [&](NMEAInputLine &input){
+    const auto type = input.ReadView();
+    if (type == "$PLOF"sv)
+      return PLOF(input, info);
+
     return false;
-
-  NMEAInputLine input(line);
-  const auto type = input.ReadView();
-
-  if (type == "$PLOF"sv)
-    return PLOF(input, info);
-
-  return false;
+  });
 }
 
 static Device *

--- a/src/Device/Driver/OpenVario.cpp
+++ b/src/Device/Driver/OpenVario.cpp
@@ -93,10 +93,9 @@ OpenVarioDevice::ComposeWrite(const char p_type,PolarCoefficients &p,
   if (!EnableNMEA(env))
     return false;
 
-  char buffer[50];
   // Compose Polar String
-  sprintf(buffer,"POV,C,%cPO,%f,%f,%f", p_type, p.a, p.b, p.c);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "POV,C,%cPO,%f,%f,%f",
+                      p_type, p.a, p.b, p.c);
   return true;
 }
 
@@ -106,15 +105,7 @@ OpenVarioDevice::InformUnavailable(const char *obj, OperationEnvironment &env)
   if (!EnableNMEA(env))
     return false;
 
-  char buffer[20];
-  const char preamble[] = "POV,C,NA,";
-
-  if (sizeof(preamble) + strlen(obj) >= sizeof(buffer)) return false;
-
-  strcpy(buffer,preamble);
-  strcat(buffer,obj);
-
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "POV,C,NA,%s", obj);
   return true;
 }
 
@@ -192,9 +183,7 @@ OpenVarioDevice::RepeatMacCready(OperationEnvironment &env)
     return InformUnavailable("MC", env);
   }
   
-  char buffer[20];
-  sprintf(buffer,"POV,C,MC,%0.2f", (double)_mc);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "POV,C,MC,%0.2f", (double)_mc);
   return true;
 }
 
@@ -213,9 +202,7 @@ OpenVarioDevice::RepeatBallast(OperationEnvironment &env)
     return InformUnavailable("WL", env);
   }
   
-  char buffer[20];
-  sprintf(buffer,"POV,C,WL,%1.3f",(float)_overload);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "POV,C,WL,%1.3f", (float)_overload);
   return true;
 }
 
@@ -234,9 +221,7 @@ OpenVarioDevice::RepeatBugs(OperationEnvironment &env)
     return InformUnavailable("BU", env);
   }
   
-  char buffer[32];
-  sprintf(buffer, "POV,C,BU,%0.2f",(float)_bugs);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "POV,C,BU,%0.2f", (float)_bugs);
   return true;
 }
 

--- a/src/Device/Driver/OpenVario.cpp
+++ b/src/Device/Driver/OpenVario.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/OpenVario.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -236,14 +237,12 @@ OpenVarioDevice::PutBugs(double bugs, OperationEnvironment &env)
 bool
 OpenVarioDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    if (line.ReadCompare("$POV"))
+      return POV(line, info);
+
     return false;
-
-  NMEAInputLine line(_line);
-  if (line.ReadCompare("$POV"))
-    return POV(line, info);
-
-  return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/Vaulter.cpp
+++ b/src/Device/Driver/Vaulter.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/Vaulter.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -139,20 +140,17 @@ VaulterDevice::PutBallast(double fraction, [[maybe_unused]] double overload, Ope
 bool
 VaulterDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(_line))
-    return false;
-
-  NMEAInputLine line(_line);
-
-  const auto type = line.ReadView();
-  if (type == "$PITV3"sv)
-    return ParsePITV3(line, info);
-  else if (type == "$PITV4"sv)
-    return ParsePITV4(line, info);
-  else if (type == "$PITV5"sv)
-    return ParsePITV5(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(_line, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PITV3"sv)
+      return ParsePITV3(line, info);
+    else if (type == "$PITV4"sv)
+      return ParsePITV4(line, info);
+    else if (type == "$PITV5"sv)
+      return ParsePITV5(line, info);
+    else
+      return false;
+  });
 }
 
 static Device *

--- a/src/Device/Driver/Vaulter.cpp
+++ b/src/Device/Driver/Vaulter.cpp
@@ -121,9 +121,7 @@ VaulterDevice::PutMacCready(double mc, OperationEnvironment &env)
 {
   if (!EnableNMEA(env))
     return false;
-  char buffer[30];
-  sprintf(buffer,"PITV1,MC=%0.2f", mc);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PITV1,MC=%0.2f", mc);
   return true;
 }
 
@@ -132,11 +130,9 @@ VaulterDevice::PutBallast(double fraction, [[maybe_unused]] double overload, Ope
 {
   if (!EnableNMEA(env))
     return false;
-  char buffer[30];
   // vaulter defines the wing loading factor as ratio of no-ballast to weight
   fraction = fraction + 1;
-  sprintf(buffer,"PITV1,WL=%0.2f", fraction);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PITV1,WL=%0.2f", fraction);
   return true;
 }
 

--- a/src/Device/Driver/Vega/Misc.cpp
+++ b/src/Device/Driver/Vega/Misc.cpp
@@ -30,14 +30,11 @@ VegaDevice::OnCalculatedUpdate([[maybe_unused]] const MoreData &basic,
 
 #ifdef UAV_APPLICATION
   const ThermalLocatorInfo &t = calculated.thermal_locator;
-  char tbuf[100];
-  sprintf(tbuf, "PTLOC,%d,%3.5f,%3.5f,%g,%g",
-          (int)(t.estimate_valid),
-          t.estimate_location.Longitude.Degrees(),
-          t.estimate_location.Latitude.Degrees(),
-          0.,
-          0.);
-
-  PortWriteNMEA(port, tbuf);
+  PortWriteNMEAFormat(port, env, "PTLOC,%d,%3.5f,%3.5f,%g,%g",
+                      (int)(t.estimate_valid),
+                      t.estimate_location.Longitude.Degrees(),
+                      t.estimate_location.Latitude.Degrees(),
+                      0.,
+                      0.);
 #endif
 }

--- a/src/Device/Driver/Vega/Settings.cpp
+++ b/src/Device/Driver/Vega/Settings.cpp
@@ -18,17 +18,13 @@ VegaDevice::SendSetting(const char *name, int value, OperationEnvironment &env)
       settings.erase(name);
   }
 
-  char buffer[64];
-  sprintf(buffer, "PDVSC,S,%s,%d", name, value);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PDVSC,S,%s,%d", name, value);
 }
 
 void
 VegaDevice::RequestSetting(const char *name, OperationEnvironment &env)
 {
-  char buffer[64];
-  sprintf(buffer, "PDVSC,R,%s", name);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PDVSC,R,%s", name);
 }
 
 std::optional<int>

--- a/src/Device/Driver/Vega/Volatile.cpp
+++ b/src/Device/Driver/Vega/Volatile.cpp
@@ -19,8 +19,6 @@ Vega::VolatileData::CopyFrom(const DerivedInfo &calculated)
 void
 Vega::VolatileData::SendTo(Port &port, OperationEnvironment &env) const
 {
-  char buffer[100];
-  sprintf(buffer, "PDVMC,%u,%u,%u,%d,%u",
-          mc, stf, circling, terrain_altitude, qnh);
-  PortWriteNMEA(port, buffer, env);
+  PortWriteNMEAFormat(port, env, "PDVMC,%u,%u,%u,%d,%u",
+                      mc, stf, circling, terrain_altitude, qnh);
 }

--- a/src/Device/Driver/Volkslogger/Parser.cpp
+++ b/src/Device/Driver/Volkslogger/Parser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Internal.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
@@ -44,14 +45,11 @@ vl_PGCS1(NMEAInputLine &line, NMEAInfo &info)
 bool
 VolksloggerDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$PGCS"sv)
-    return vl_PGCS1(line, info);
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PGCS"sv)
+      return vl_PGCS1(line, info);
+    else
+      return false;
+  });
 }

--- a/src/Device/Driver/Westerboer.cpp
+++ b/src/Device/Driver/Westerboer.cpp
@@ -4,6 +4,7 @@
 #include "Device/Driver/Westerboer.hpp"
 #include "Device/Driver.hpp"
 #include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Units/System.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -118,20 +119,15 @@ PWES1(NMEAInputLine &line, NMEAInfo &info)
 bool
 WesterboerDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
-
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-  if (type == "$PWES0"sv)
-    return PWES0(line, info);
-
-  else if (type == "$PWES1"sv)
-    return PWES1(line, info);
-
-  else
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PWES0"sv)
+      return PWES0(line, info);
+    else if (type == "$PWES1"sv)
+      return PWES1(line, info);
+    else
+      return false;
+  });
 }
 
 bool

--- a/src/Device/Driver/Westerboer.cpp
+++ b/src/Device/Driver/Westerboer.cpp
@@ -5,6 +5,7 @@
 #include "Device/Driver.hpp"
 #include "Device/Port/Port.hpp"
 #include "Device/Util/NMEAParser.hpp"
+#include "Device/Util/NMEAWriter.hpp"
 #include "Units/System.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
@@ -136,11 +137,8 @@ WesterboerDevice::PutMacCready(double _mac_cready, OperationEnvironment &env)
   /* 0 .. 60 -> 0.0 .. 6.0 m/s */
   unsigned mac_cready = std::min(uround(_mac_cready * 10), 60u);
 
-  char buffer[64];
-  sprintf(buffer, "$PWES4,,%02u,,,,,,,", mac_cready);
-  AppendNMEAChecksum(buffer);
-  strcat(buffer, "\r\n");
-  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
+  PortFullWriteNMEAFormat(port, env, std::chrono::milliseconds{100},
+                          "PWES4,,%02u,,,,,,,", mac_cready);
 
   return true;
 }
@@ -151,11 +149,8 @@ WesterboerDevice::PutBugs(double _bugs, OperationEnvironment &env)
   // Dirtyness from 0 until 20 %
   unsigned bugs = 100 - (unsigned)(_bugs * 100);
 
-  char buffer[64];
-  sprintf(buffer, "$PWES4,,,,,%02u,,,,", bugs);
-  AppendNMEAChecksum(buffer);
-  strcat(buffer, "\r\n");
-  port.FullWrite(buffer, env, std::chrono::milliseconds{100});
+  PortFullWriteNMEAFormat(port, env, std::chrono::milliseconds{100},
+                          "PWES4,,,,,%02u,,,,", bugs);
 
   return true;
 }

--- a/src/Device/Driver/XCTracer/Parser.cpp
+++ b/src/Device/Driver/XCTracer/Parser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "../XCTracer/Internal.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Info.hpp"
@@ -249,18 +250,13 @@ XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
 bool
 XCTracerDevice::ParseNMEA(const char *string, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(string))
-    return false;
-
-  NMEAInputLine line(string);
-
-  const auto type = line.ReadView();
-  if (type == "$LXWP0"sv)
-    return LXWP0(line, info);
-
-  else if (type == "$XCTRC"sv)
-    return XCTRC(line, info);
-
-  else
-    return false;
+  return ParseNMEAWithChecksum(string, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$LXWP0"sv)
+      return LXWP0(line, info);
+    else if (type == "$XCTRC"sv)
+      return XCTRC(line, info);
+    else
+      return false;
+  });
 }

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -4,6 +4,7 @@
 #include "Device/Driver/XCVario.hpp"
 #include "Device/Driver/CAI302/PocketNav.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "Units/System.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -194,20 +195,19 @@ bool XVCDevice::EnableNMEA([[maybe_unused]] OperationEnvironment &env)
 bool
 XVCDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
+    if (type == "$PXCV"sv) { // cyclic data from device useful for channel supervision
+      xcvario_protocol_up = true;
+      if (protocol_version != XCV_VERSION_UNKNOWN) // only parse NMEA once protocol version is set
+        return PXCV(line, info);
+
+      return true;
+    } else if (type == "!xcv"sv)
+      return XCV(line, info);
+
     return false;
-  NMEAInputLine line(String);
-  const auto type = line.ReadView();
-  if (type == "$PXCV"sv) {                // cyclic data from device useful for channel supervision
-    xcvario_protocol_up = true;
-    if (protocol_version != XCV_VERSION_UNKNOWN) {   // only parse NMEA once protocol version is set
-      return PXCV(line, info);
-    }
-    return true;
-  } else if (type == "!xcv"sv) {
-    return XCV(line, info);
-  }
-  return false;
+  });
 }
 
 // For documentation refer to chapter 10.1.3 Device Driver/XCVario in mulilingual handbook: https://xcvario.de/handbuch

--- a/src/Device/Driver/Zander.cpp
+++ b/src/Device/Driver/Zander.cpp
@@ -3,6 +3,7 @@
 
 #include "Device/Driver/Zander.hpp"
 #include "Device/Driver.hpp"
+#include "Device/Util/NMEAParser.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Checksum.hpp"
@@ -109,30 +110,22 @@ PZAN5(NMEAInputLine &line, NMEAInfo &info)
 bool
 ZanderDevice::ParseNMEA(const char *String, NMEAInfo &info)
 {
-  if (!VerifyNMEAChecksum(String))
-    return false;
+  return ParseNMEAWithChecksum(String, [&](NMEAInputLine &line){
+    const auto type = line.ReadView();
 
-  NMEAInputLine line(String);
-
-  const auto type = line.ReadView();
-
-  if (type == "$PZAN1"sv)
-    return PZAN1(line, info);
-
-  else if (type == "$PZAN2"sv)
-    return PZAN2(line, info);
-
-  else if (type == "$PZAN3"sv)
-    return PZAN3(line, info);
-
-  else if (type == "$PZAN4"sv)
-    return PZAN4(line, info);
-
-  else if (type == "$PZAN5"sv)
-    return PZAN5(line, info);
-
-  else
-    return false;
+    if (type == "$PZAN1"sv)
+      return PZAN1(line, info);
+    else if (type == "$PZAN2"sv)
+      return PZAN2(line, info);
+    else if (type == "$PZAN3"sv)
+      return PZAN3(line, info);
+    else if (type == "$PZAN4"sv)
+      return PZAN4(line, info);
+    else if (type == "$PZAN5"sv)
+      return PZAN5(line, info);
+    else
+      return false;
+  });
 }
 
 static Device *

--- a/src/Device/Util/NMEAParser.hpp
+++ b/src/Device/Util/NMEAParser.hpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "NMEA/Checksum.hpp"
+#include "NMEA/InputLine.hpp"
+
+#include <utility>
+
+/**
+ * Helper for Device driver ParseNMEA() implementations.
+ *
+ * Performs checksum verification and constructs a #NMEAInputLine, then
+ * invokes the callback to parse the sentence.
+ */
+template<typename F>
+[[nodiscard]] static inline bool
+ParseNMEAWithChecksum(const char *line, F &&f) noexcept(noexcept(f(
+                                     std::declval<NMEAInputLine &>())))
+{
+  if (!VerifyNMEAChecksum(line))
+    return false;
+
+  NMEAInputLine input_line(line);
+  return f(input_line);
+}
+

--- a/src/Device/Util/NMEAWriter.cpp
+++ b/src/Device/Util/NMEAWriter.cpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdarg.h>
 
 void
 PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env)
@@ -25,4 +26,28 @@ PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env)
   char checksum[16];
   sprintf(checksum, "*%02X\r\n", NMEAChecksum(line));
   port.FullWrite(checksum, env, timeout);
+}
+
+void
+PortWriteNMEAFormat(Port &port, OperationEnvironment &env,
+                    const char *format, ...)
+{
+  assert(format != nullptr);
+
+  char line[256];
+
+  va_list ap;
+  va_start(ap, format);
+  const int n = vsnprintf(line, sizeof(line), format, ap);
+  va_end(ap);
+
+  if (n <= 0)
+    return;
+
+  if ((size_t)n >= sizeof(line)) {
+    /* truncated; refuse to send incomplete payload */
+    return;
+  }
+
+  PortWriteNMEA(port, line, env);
 }

--- a/src/Device/Util/NMEAWriter.cpp
+++ b/src/Device/Util/NMEAWriter.cpp
@@ -12,13 +12,10 @@
 #include <stdarg.h>
 
 void
-PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env)
+PortFullWriteNMEA(Port &port, const char *line, OperationEnvironment &env,
+                  std::chrono::steady_clock::duration timeout)
 {
   assert(line != nullptr);
-
-  /* reasonable hard-coded timeout; do we need to make this a
-     parameter? */
-  static constexpr auto timeout = std::chrono::seconds(1);
 
   port.Write('$');
   port.FullWrite(line, env, timeout);
@@ -26,6 +23,40 @@ PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env)
   char checksum[16];
   sprintf(checksum, "*%02X\r\n", NMEAChecksum(line));
   port.FullWrite(checksum, env, timeout);
+}
+
+void
+PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env)
+{
+  /* reasonable hard-coded timeout; do we need to make this a
+     parameter? */
+  static constexpr auto timeout = std::chrono::seconds(1);
+  PortFullWriteNMEA(port, line, env, timeout);
+}
+
+void
+PortFullWriteNMEAFormat(Port &port, OperationEnvironment &env,
+                        std::chrono::steady_clock::duration timeout,
+                        const char *format, ...)
+{
+  assert(format != nullptr);
+
+  char line[256];
+
+  va_list ap;
+  va_start(ap, format);
+  const int n = vsnprintf(line, sizeof(line), format, ap);
+  va_end(ap);
+
+  if (n <= 0)
+    return;
+
+  if ((size_t)n >= sizeof(line)) {
+    /* truncated; refuse to send incomplete payload */
+    return;
+  }
+
+  PortFullWriteNMEA(port, line, env, timeout);
 }
 
 void

--- a/src/Device/Util/NMEAWriter.hpp
+++ b/src/Device/Util/NMEAWriter.hpp
@@ -10,6 +10,8 @@
 
 #include "util/Compiler.h"
 
+#include <chrono>
+
 class Port;
 class OperationEnvironment;
 
@@ -34,3 +36,20 @@ PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env);
 void
 PortWriteNMEAFormat(Port &port, OperationEnvironment &env,
                     const char *format, ...) gcc_printf(3, 4);
+
+/**
+ * Like PortWriteNMEA(), but uses a caller-specified timeout.
+ */
+void
+PortFullWriteNMEA(Port &port, const char *line, OperationEnvironment &env,
+                  std::chrono::steady_clock::duration timeout);
+
+/**
+ * Formats and writes one line of NMEA data with a caller-specified timeout.
+ *
+ * The formatted line is without asterisk, checksum and newline.
+ */
+void
+PortFullWriteNMEAFormat(Port &port, OperationEnvironment &env,
+                        std::chrono::steady_clock::duration timeout,
+                        const char *format, ...) gcc_printf(4, 5);

--- a/src/Device/Util/NMEAWriter.hpp
+++ b/src/Device/Util/NMEAWriter.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "util/Compiler.h"
+
 class Port;
 class OperationEnvironment;
 
@@ -21,3 +23,14 @@ class OperationEnvironment;
  */
 void
 PortWriteNMEA(Port &port, const char *line, OperationEnvironment &env);
+
+/**
+ * Formats and writes one line of NMEA data.
+ *
+ * The formatted line is without asterisk, checksum and newline.
+ *
+ * Throws on error.
+ */
+void
+PortWriteNMEAFormat(Port &port, OperationEnvironment &env,
+                    const char *format, ...) gcc_printf(3, 4);

--- a/test/src/TestStringHelpers.cpp
+++ b/test/src/TestStringHelpers.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "util/StringCompare.hxx"
+#include "util/StringStrip.hxx"
+#include "TestUtil.hpp"
+
+#include <string.h>
+
+int
+main()
+{
+  plan_tests(34);
+
+  /* StringIsEqualIgnoreCase(std::string_view) */
+  ok1(StringIsEqualIgnoreCase("a", "A"));
+  ok1(StringIsEqualIgnoreCase("", ""));
+  ok1(!StringIsEqualIgnoreCase("a", ""));
+  ok1(!StringIsEqualIgnoreCase("", "A"));
+  ok1(!StringIsEqualIgnoreCase("aa", "a"));
+  ok1(!StringIsEqualIgnoreCase("a", "aa"));
+  ok1(StringIsEqualIgnoreCase("AbC", "aBc"));
+
+  /* StringStartsWithIgnoreCase() */
+  ok1(StringStartsWithIgnoreCase("foobar", "FOO"));
+  ok1(StringStartsWithIgnoreCase("foo", "FOO"));
+  ok1(StringStartsWithIgnoreCase("foo", ""));
+  ok1(!StringStartsWithIgnoreCase("", "FOO"));
+  ok1(!StringStartsWithIgnoreCase("bar", "FOO"));
+
+  /* StringAfterPrefixIgnoreCase() */
+  ok1(StringIsEqual(StringAfterPrefixIgnoreCase("foobar", "FOO"), "bar"));
+  ok1(StringIsEqual(StringAfterPrefixIgnoreCase("foo", "FOO"), ""));
+  ok1(StringAfterPrefixIgnoreCase("bar", "FOO") == nullptr);
+
+  /* StringEndsWith() / StringEndsWithIgnoreCase() */
+  ok1(StringEndsWith("foobar", "bar"));
+  ok1(StringEndsWith("foobar", ""));
+  ok1(StringEndsWith("", ""));
+  ok1(!StringEndsWith("foo", "foobar"));
+  ok1(StringEndsWithIgnoreCase("FOOBAR", "bar"));
+  ok1(StringEndsWithIgnoreCase("foobar", "BAR"));
+  ok1(!StringEndsWithIgnoreCase("foo", "BAR"));
+
+  /* FindStringSuffix() */
+  {
+    const char *p = "foobar";
+    ok1(FindStringSuffix(p, "bar") == p + 3);
+    ok1(FindStringSuffix(p, "") == p + strlen(p));
+    ok1(FindStringSuffix(p, "foobar") == p);
+    ok1(FindStringSuffix(p, "baz") == nullptr);
+    ok1(FindStringSuffix("foo", "foobar") == nullptr);
+  }
+
+  /* StripLeft(const char *) */
+  {
+    ok1(StringIsEqual(StripLeft(""), ""));
+    ok1(StringIsEqual(StripLeft("   \t"), ""));
+    ok1(StringIsEqual(StripLeft(" \tfoo"), "foo"));
+  }
+
+  /* StripRight(char *) */
+  {
+    char buffer[32];
+    strcpy(buffer, "");
+    StripRight(buffer);
+    ok1(StringIsEqual(buffer, ""));
+
+    strcpy(buffer, " \t");
+    StripRight(buffer);
+    ok1(StringIsEqual(buffer, ""));
+
+    strcpy(buffer, "foo \t");
+    StripRight(buffer);
+    ok1(StringIsEqual(buffer, "foo"));
+  }
+
+  /* Strip(char *) */
+  {
+    char buffer[32];
+    strcpy(buffer, "  foo \t");
+    ok1(StringIsEqual(Strip(buffer), "foo"));
+  }
+
+  return exit_status();
+}
+

--- a/test/src/TestStringParser.cpp
+++ b/test/src/TestStringParser.cpp
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "util/StringCompare.hxx"
+#include "util/StringParser.hxx"
+#include "TestUtil.hpp"
+
+#include <math.h>
+
+int
+main()
+{
+  plan_tests(30);
+
+  /* Strip() */
+  {
+    StringParser p{"  \tfoo"};
+    p.Strip();
+    ok1(p.MatchAll("foo"));
+  }
+
+  /* Match()/SkipMatch() */
+  {
+    StringParser p{"hello world"};
+    ok1(p.Match("hello"));
+    ok1(p.SkipMatch("hello"));
+    ok1(p.Match(' '));
+    ok1(p.SkipMatch(' '));
+    ok1(p.MatchAll("world"));
+  }
+
+  /* MatchIgnoreCase()/SkipMatchIgnoreCase() */
+  {
+    StringParser p{"FoOBar"};
+    ok1(p.MatchIgnoreCase("foo"));
+    ok1(p.SkipMatchIgnoreCase("fOo"));
+    ok1(p.MatchIgnoreCase("bar"));
+    ok1(p.SkipMatchIgnoreCase("BAR"));
+    ok1(p.IsEmpty());
+  }
+
+  /* ReadUnsigned() basic */
+  {
+    StringParser p{"123x"};
+    const auto value = p.ReadUnsigned();
+    ok1(value.has_value());
+    ok1(*value == 123);
+    ok1(p.MatchAll("x"));
+  }
+
+  /* ReadUnsigned() base 16 */
+  {
+    StringParser p{"ff "};
+    const auto value = p.ReadUnsigned(16);
+    ok1(value.has_value());
+    ok1(*value == 255);
+    ok1(p.Match(' '));
+  }
+
+  /* ReadUnsigned() failure must not advance */
+  {
+    StringParser p{"x123"};
+    const auto value = p.ReadUnsigned();
+    ok1(!value.has_value());
+    ok1(p.MatchAll("x123"));
+  }
+
+  /* ReadDouble() basic */
+  {
+    StringParser p{"-1.25,"};
+    const auto value = p.ReadDouble();
+    ok1(value.has_value());
+    ok1(fabs(*value - (-1.25)) < 1e-12);
+    ok1(p.Match(','));
+  }
+
+  /* ReadDouble() failure must not advance */
+  {
+    StringParser p{"foo"};
+    const auto value = p.ReadDouble();
+    ok1(!value.has_value());
+    ok1(p.MatchAll("foo"));
+  }
+
+  /* SkipWord() */
+  {
+    StringParser p{"one two\tthree"};
+    ok1(p.SkipWord());
+    ok1(p.MatchAll("two\tthree"));
+    ok1(p.SkipWord());
+    ok1(p.MatchAll("three"));
+    ok1(!p.SkipWord());
+    ok1(p.MatchAll(""));
+  }
+
+  return exit_status();
+}
+


### PR DESCRIPTION
## Summary

Rebased onto current `master`. Keeps only:

- **Device/NMEA**: `PortWriteNMEAFormat` / `PortFullWriteNMEAFormat`, `ParseNMEAWithChecksum`, CAI302 `!g` refactor, and driver call-site updates
- **Tests**: `TestStringParser`, `TestStringHelpers`, and `coverage-check` targets

Dropped from the previous bundle:

- EDL weather (separate feature branch)
- Sun/time normalization ([#2361](https://github.com/XCSoar/XCSoar/pull/2361))
- `Form/DataField/Format.hpp` (superseded on `master` by `StringFormat` in DataFields)
- `io/DirectoryUtil`, MBTiles/Sqlite extraction, MainWindow bottom-widget fix

## Test plan

- [x] `make TARGET=UNIX output/UNIX/bin/TestStringParser output/UNIX/bin/TestStringHelpers`
- [x] Run both test binaries (all TAP tests pass)
- [ ] `make TARGET=UNIX USE_CCACHE=y WERROR=y` full build on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced NMEA message handling infrastructure for improved device communication across multiple aviation hardware drivers.
  * Added string utility testing and parsing capabilities for improved reliability.

* **Chores**
  * Updated build system with new coverage checking targets.
  * Refactored device driver NMEA message processing for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->