### PR TITLE
Math/SunEphemeris: Normalize hour-of-day and daylight formatting

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -16,6 +16,8 @@ Version 7.45 - not yet released
   - status dialog, Times: flight time matches takeoff and landing after
     minute rounding (including across midnight); landing time clears on a
     new takeoff in the same session #957
+  - status dialog, Times and waypoint details: daylight time range handles
+    extreme time zones; sunset-arrival warning handles midnight wrap-around
   - status dialog, Rules: after a valid start, show PEV offset at start (time
     from PEV window start to the crossing) when known, as a duration (e.g.
     "45 sec", "2 min") not HH:MM so sub-minute offsets are not shown as 00:00

--- a/build/test.mk
+++ b/build/test.mk
@@ -568,6 +568,7 @@ $(eval $(call link-program,TestByteSizeFormatter,TEST_BYTE_SIZE_FORMATTER))
 
 TEST_TIME_FORMATTER_SOURCES = \
 	$(SRC)/Formatter/TimeFormatter.cpp \
+	$(SRC)/Math/SunEphemeris.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestTimeFormatter.cpp
 TEST_TIME_FORMATTER_DEPENDS = MATH UTIL TIME

--- a/src/Computer/ConditionMonitor/ConditionMonitorSunset.cpp
+++ b/src/Computer/ConditionMonitor/ConditionMonitorSunset.cpp
@@ -38,7 +38,16 @@ ConditionMonitorSunset::CheckCondition(const NMEAInfo &basic,
   const auto d1 = (time_local + res.time_elapsed).Cast<Hours>();
   const auto d0 = time_local.Cast<Hours>();
 
-  bool past_sunset = (d1.count() > sun.time_of_sunset) && (d0.count() < sun.time_of_sunset);
+  const double sunset = SunEphemeris::NormalizeHourOfDay(sun.time_of_sunset);
+  const double t0 = SunEphemeris::NormalizeHourOfDay(d0.count());
+  const double t1 = SunEphemeris::NormalizeHourOfDay(d1.count());
+
+  /* Detect crossing the sunset time-of-day; this works even if the
+     local time range crosses midnight (t1 wraps to a smaller value). */
+  const bool past_sunset = t1 >= t0
+    ? (t0 < sunset && t1 >= sunset)
+    : (t0 < sunset || t1 >= sunset);
+
   return past_sunset;
 }
 

--- a/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
@@ -34,13 +34,10 @@ TimesStatusPanel::Refresh() noexcept
       SunEphemeris::CalcSunTimes(basic.location, basic.date_time_utc,
                                  settings.utc_offset);
 
-    const unsigned sunrisehours = (int)sun.time_of_sunrise;
-    const unsigned sunrisemins = (int)((sun.time_of_sunrise - double(sunrisehours)) * 60);
-    const unsigned sunsethours = (int)sun.time_of_sunset;
-    const unsigned sunsetmins = (int)((sun.time_of_sunset - double(sunsethours)) * 60);
-
-    temp.Format("%02u:%02u - %02u:%02u", sunrisehours, sunrisemins, sunsethours, sunsetmins);
-    SetText(Daylight, temp);
+    char buffer[32];
+    FormatDaylightTimeRangeHHMM(buffer, sun.time_of_sunrise,
+                                sun.time_of_sunset);
+    SetText(Daylight, buffer);
   } else {
     ClearText(Daylight);
   }

--- a/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
@@ -17,6 +17,7 @@
 #include "Interface.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Formatter/AngleFormatter.hpp"
+#include "Formatter/TimeFormatter.hpp"
 #include "Formatter/UserGeoPointFormatter.hpp"
 
 static const char *
@@ -102,26 +103,6 @@ WaypointInfoWidget::AddGlideResult(const char *label,
                                 result, settings.task.glide));
 }
 
-[[gnu::const]]
-static BrokenTime
-BreakHourOfDay(double t) noexcept
-{
-  /* depending on the time zone, the SunEphemeris library may return a
-     negative time of day; the following check catches this before we
-     cast the value to "unsigned" */
-  if (t < 0)
-    t += 24;
-
-  unsigned i = uround(t * 3600);
-
-  BrokenTime result;
-  result.hour = i / 3600;
-  i %= 3600;
-  result.minute = i / 60;
-  result.second = i % 60;
-  return result;
-}
-
 void
 WaypointInfoWidget::Prepare(ContainerWindow &parent,
                             const PixelRect &rc) noexcept
@@ -189,13 +170,10 @@ WaypointInfoWidget::Prepare(ContainerWindow &parent,
       SunEphemeris::CalcSunTimes(waypoint->location, basic.date_time_utc,
                                  settings.utc_offset);
 
-    const BrokenTime sunrise = BreakHourOfDay(sun.time_of_sunrise);
-    const BrokenTime sunset = BreakHourOfDay(sun.time_of_sunset);
-
-    buffer.UnsafeFormat("%02u:%02u - %02u:%02u",
-                        sunrise.hour, sunrise.minute,
-                        sunset.hour, sunset.minute);
-    AddReadOnly(_("Daylight time"), nullptr, buffer);
+    char daylight_buffer[32];
+    FormatDaylightTimeRangeHHMM(daylight_buffer, sun.time_of_sunrise,
+                                sun.time_of_sunset);
+    AddReadOnly(_("Daylight time"), nullptr, daylight_buffer);
   }
 
   if (basic.location_available) {

--- a/src/Formatter/TimeFormatter.cpp
+++ b/src/Formatter/TimeFormatter.cpp
@@ -6,6 +6,7 @@
 #include "time/Calendar.hxx"
 #include "time/Convert.hxx"
 #include "Math/Util.hpp"
+#include "Math/SunEphemeris.hpp"
 #include "util/CharUtil.hxx"
 #include "util/StringFormat.hpp"
 #include "util/StringCompare.hxx"
@@ -177,6 +178,30 @@ FormatTimeTwoLines(char *buffer1, char *buffer2, std::chrono::seconds _time) noe
     StringFormat(buffer1, 6, "%02u'%02u", time.minute, time.second);
     buffer2[0] = '\0';
   }
+}
+
+[[gnu::const]]
+static BrokenTime
+BreakHourOfDay(double t) noexcept
+{
+  unsigned i = uround(SunEphemeris::NormalizeHourOfDay(t) * 3600);
+
+  BrokenTime result;
+  result.hour = i / 3600;
+  i %= 3600;
+  result.minute = i / 60;
+  result.second = 0;
+  return result;
+}
+
+void
+FormatDaylightTimeRangeHHMM(char *buffer, double sunrise,
+                            double sunset) noexcept
+{
+  const BrokenTime a = BreakHourOfDay(sunrise);
+  const BrokenTime b = BreakHourOfDay(sunset);
+  sprintf(buffer, "%02u:%02u - %02u:%02u",
+          a.hour, a.minute, b.hour, b.minute);
 }
 
 static void

--- a/src/Formatter/TimeFormatter.hpp
+++ b/src/Formatter/TimeFormatter.hpp
@@ -95,6 +95,15 @@ void
 FormatTimeTwoLines(char *buffer1, char *buffer2,
                    std::chrono::seconds time) noexcept;
 
+/**
+ * Format a daylight time range based on hours since midnight
+ * (SunEphemeris output), as "HH:MM - HH:MM". The inputs may be negative
+ * depending on time zone.
+ */
+void
+FormatDaylightTimeRangeHHMM(char *buffer, double sunrise,
+                            double sunset) noexcept;
+
 void
 FormatTimespanSmart(char *buffer, std::chrono::seconds timespan,
                     unsigned max_tokens = 1,

--- a/src/Math/SunEphemeris.cpp
+++ b/src/Math/SunEphemeris.cpp
@@ -203,11 +203,13 @@ CalcSunTimes(const GeoPoint &location, const BrokenDateTime &date_time,
     + time_zone.AsMinutes() / 60.
     - location.longitude.Degrees() / 15. + equation / 60.;
 
-  if (result.time_of_sunrise > 24)
-    result.time_of_sunrise -= 24;
-
-  result.time_of_sunset = result.time_of_sunrise + result.day_length;
-  result.time_of_noon = result.time_of_sunrise + hour_angle.Hours();
+  /* These are "hours since midnight" and may wrap around depending on
+     the time zone; normalise to [0,24) to simplify downstream code. */
+  result.time_of_sunrise = NormalizeHourOfDay(result.time_of_sunrise);
+  result.time_of_sunset = NormalizeHourOfDay(result.time_of_sunrise +
+                                             result.day_length);
+  result.time_of_noon = NormalizeHourOfDay(result.time_of_sunrise +
+                                           hour_angle.Hours());
 
   // morning twilight begin
   result.morning_twilight = result.time_of_sunrise - twilight_hours;

--- a/src/Math/SunEphemeris.cpp
+++ b/src/Math/SunEphemeris.cpp
@@ -12,6 +12,7 @@
 #include "time/RoughTime.hpp"
 
 #include <cstdint>
+#include <cmath>
 
 /** Sun radius in degrees (?) */
 static constexpr double SUN_DIAMETER = 0.53;
@@ -20,6 +21,16 @@ static constexpr double SUN_DIAMETER = 0.53;
 static constexpr double AIR_REFRACTION = 34.0 / 60.0;
 
 namespace SunEphemeris {
+
+double
+NormalizeHourOfDay(double t) noexcept
+{
+  t = std::fmod(t, 24.);
+  if (t < 0)
+    t += 24;
+
+  return t;
+}
 
 /**
  * Get the days to J2000

--- a/src/Math/SunEphemeris.hpp
+++ b/src/Math/SunEphemeris.hpp
@@ -15,6 +15,13 @@ class RoughTimeDelta;
  */
 namespace SunEphemeris {
 
+/**
+ * Normalize "hours since midnight" to the interval [0, 24).
+ */
+[[gnu::const]]
+double
+NormalizeHourOfDay(double t) noexcept;
+
 struct Result {
   double day_length, morning_twilight, evening_twilight;
   double time_of_noon, time_of_sunset, time_of_sunrise;


### PR DESCRIPTION
## Summary

- Add `SunEphemeris::NormalizeHourOfDay()` and use it from time formatting and the sunset condition monitor.
- Add `FormatDaylightTimeRangeHHMM()` and use it from status/waypoint dialogs instead of duplicated logic.
- Normalize `CalcSunTimes()` sunrise/sunset/noon to `[0,24)`.

## Commits

1. `Math/SunEphemeris: Normalize hour-of-day handling`
2. `Math/SunEphemeris: Normalize CalcSunTimes outputs`

(Rebased onto current `master`; excludes unrelated branch work.)

## Testing

- Built touched objects with `TARGET=UNIX`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sunset threshold validation to correctly handle time windows that cross midnight, resolving edge cases in daylight calculations.

* **Refactor**
  * Consolidated daylight time range formatting across multiple components into a single formatter function, ensuring consistent time display throughout the application and reducing code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->