### PR TITLE
Fix imports to enable Docker Android build

### DIFF
--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -35,7 +35,6 @@
 #include "java/Closeable.hxx"
 #include "java/Global.hxx"
 #include "Android/InternalSensors.hpp"
-#include "Android/Sensor.hpp"
 #endif
 
 #ifdef __APPLE__

--- a/src/Device/Util/LineSplitter.hpp
+++ b/src/Device/Util/LineSplitter.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "io/DataHandler.hpp"
-#include "LineHandler.hpp"
+#include "Device/Util/LineHandler.hpp"
 #include "util/StaticFifoBuffer.hxx"
 
 class PortLineSplitter : public DataHandler, protected PortLineHandler {


### PR DESCRIPTION
During a fresh Android build on Windows 10 using the Docker image, errors occurred due to the same file being included multiple times using different include paths.

This fixes these errors:

`In file src/Device/Descriptor.cpp:38:10: error: non-portable path to file '"android/Sensor.hpp"'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path] #include "Android/Sensor.hpp"`

`In file src/Device/Dispatcher.hpp:6:10: error: non-portable path to file '"Device/util/LineHandler.hpp"'; specified path differs in case from file name on disk [-Werror,-Wnonportable-include-path]#include "Device/Util/LineHandler.hpp"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and cleanup updates to improve codebase organization.

---

**Note:** These changes are internal technical improvements with no impact on user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->