### PR TITLE
build system upload independent

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -690,82 +690,19 @@ jobs:
 
           echo "✅ macOS package signed successfully"
 
-      - name: Upload to iOS TestFlight
+      - name: Upload artifact for TestFlight (iOS)
         if: ${{ matrix.target == 'IOS64' && steps.tests.outcome == 'success' && steps.sign_ios.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
-          ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
-        run: |
-          IPA_PATH="output/IOS64/xcsoar-signed.ipa"
-          
-          if [ ! -f "$IPA_PATH" ]; then
-            echo "❌ Signed IPA not found: $IPA_PATH"
-            exit 1
-          fi
-          
-          if [ -z "$APPLE_ID" ] || [ -z "$APP_SPECIFIC_PASSWORD" ]; then
-            echo "❌ TestFlight credentials not configured"
-            exit 1
-          fi
-          
-          echo "📱 Uploading to App Store Connect / TestFlight..."
-          
-          # Use altool to upload (matches build-release.sh)
-          if [ -n "$ASC_PROVIDER" ]; then
-            xcrun altool --upload-app \
-              -f "$IPA_PATH" \
-              -t ios \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD" \
-              --asc-provider "$ASC_PROVIDER"
-          else
-            xcrun altool --upload-app \
-              -f "$IPA_PATH" \
-              -t ios \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD"
-          fi
-          
-          echo "✅ Upload completed successfully"
+        uses: actions/upload-artifact@v7
+        with:
+          name: ios-testflight-ipa
+          path: output/IOS64/xcsoar-signed.ipa
 
-      - name: Upload to macOS TestFlight
+      - name: Upload artifact for TestFlight (macOS)
         if: ${{ matrix.target == 'MACOS' && steps.tests.outcome == 'success' && steps.sign_macos.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
-        env:
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
-          ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
-        run: |
-          PKG_PATH="output/MACOS/XCSoar-signed.pkg"
-
-          if [ ! -f "$PKG_PATH" ]; then
-            echo "❌ Signed pkg not found: $PKG_PATH"
-            exit 1
-          fi
-
-          if [ -z "$APPLE_ID" ] || [ -z "$APP_SPECIFIC_PASSWORD" ]; then
-            echo "❌ App Store Connect credentials not configured"
-            exit 1
-          fi
-
-          echo "🖥️  Uploading to App Store Connect / TestFlight..."
-
-          if [ -n "$ASC_PROVIDER" ]; then
-            xcrun altool --upload-app \
-              -f "$PKG_PATH" \
-              -t macos \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD" \
-              --asc-provider "$ASC_PROVIDER"
-          else
-            xcrun altool --upload-app \
-              -f "$PKG_PATH" \
-              -t macos \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD"
-          fi
-
-          echo "✅ Upload completed successfully"
+        uses: actions/upload-artifact@v7
+        with:
+          name: macos-testflight-pkg
+          path: output/MACOS/XCSoar-signed.pkg
 
       - name: Cleanup iOS keychain
         if: ${{ always() && matrix.target == 'IOS64' }}
@@ -905,3 +842,117 @@ jobs:
       - name: Remove key
         if: always()
         run: rm -f play-key.json
+
+  upload-to-testflight:
+    name: Upload to TestFlight (iOS / macOS)
+    runs-on: macos-15
+    needs: [build]
+    if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+    steps:
+      - name: Download iOS IPA
+        id: ios_ipa
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: ios-testflight-ipa
+
+      - name: Download macOS PKG
+        id: macos_pkg
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: macos-testflight-pkg
+
+      - name: Upload iOS to App Store Connect / TestFlight
+        if: steps.ios_ipa.outcome == 'success'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
+        run: |
+          IPA_PATH=""
+          for candidate in \
+            "ios-testflight-ipa/output/IOS64/xcsoar-signed.ipa" \
+            "ios-testflight-ipa/xcsoar-signed.ipa" \
+            "xcsoar-signed.ipa"; do
+            if [ -f "$candidate" ]; then
+              IPA_PATH="$candidate"
+              break
+            fi
+          done
+          if [ -z "$IPA_PATH" ]; then
+            echo "Signed IPA not found after download"
+            exit 1
+          fi
+          echo "Using IPA at: $IPA_PATH"
+
+          if [ -z "$APPLE_ID" ] || [ -z "$APP_SPECIFIC_PASSWORD" ]; then
+            echo "TestFlight credentials not configured"
+            exit 1
+          fi
+
+          echo "Uploading iOS build to App Store Connect / TestFlight..."
+          if [ -n "$ASC_PROVIDER" ]; then
+            xcrun altool --upload-app \
+              -f "$IPA_PATH" \
+              -t ios \
+              -u "$APPLE_ID" \
+              -p "$APP_SPECIFIC_PASSWORD" \
+              --asc-provider "$ASC_PROVIDER"
+          else
+            xcrun altool --upload-app \
+              -f "$IPA_PATH" \
+              -t ios \
+              -u "$APPLE_ID" \
+              -p "$APP_SPECIFIC_PASSWORD"
+          fi
+
+      - name: Upload macOS to App Store Connect / TestFlight
+        if: steps.macos_pkg.outcome == 'success'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+          ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
+        run: |
+          PKG_PATH=""
+          for candidate in \
+            "macos-testflight-pkg/output/MACOS/XCSoar-signed.pkg" \
+            "macos-testflight-pkg/XCSoar-signed.pkg" \
+            "XCSoar-signed.pkg"; do
+            if [ -f "$candidate" ]; then
+              PKG_PATH="$candidate"
+              break
+            fi
+          done
+          if [ -z "$PKG_PATH" ]; then
+            echo "Signed pkg not found after download"
+            exit 1
+          fi
+          echo "Using pkg at: $PKG_PATH"
+
+          if [ -z "$APPLE_ID" ] || [ -z "$APP_SPECIFIC_PASSWORD" ]; then
+            echo "App Store Connect credentials not configured"
+            exit 1
+          fi
+
+          echo "Uploading macOS build to App Store Connect / TestFlight..."
+          if [ -n "$ASC_PROVIDER" ]; then
+            xcrun altool --upload-app \
+              -f "$PKG_PATH" \
+              -t macos \
+              -u "$APPLE_ID" \
+              -p "$APP_SPECIFIC_PASSWORD" \
+              --asc-provider "$ASC_PROVIDER"
+          else
+            xcrun altool --upload-app \
+              -f "$PKG_PATH" \
+              -t macos \
+              -u "$APPLE_ID" \
+              -p "$APP_SPECIFIC_PASSWORD"
+          fi
+
+      - name: Require at least one TestFlight artifact
+        if: ${{ steps.ios_ipa.outcome != 'success' && steps.macos_pkg.outcome != 'success' }}
+        run: |
+          echo "No iOS or macOS TestFlight artifacts were produced by the build job."
+          exit 1

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -120,6 +120,9 @@ jobs:
     needs: release
     permissions:
       contents: write
+    # On push/tag, one failed matrix leg (e.g. iOS/macOS) must not block
+    # upload-to-play / upload-to-virustotal. PRs keep strict failure.
+    continue-on-error: ${{ github.event_name != 'pull_request' }}
     container: ${{ matrix.target_container }}
     strategy:
       fail-fast: false
@@ -727,6 +730,20 @@ jobs:
           name: android-bundle
           path: output/${{ matrix.target }}/${{ matrix.target_bin_path }}/${{ matrix.target_bin }}.aab
 
+      - name: Upload artifact for VirusTotal (Win64)
+        if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.target == 'WIN64' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: virustotal-win64
+          path: output/WIN64/bin/XCSoar.exe
+
+      - name: Upload artifact for VirusTotal (PC)
+        if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.target == 'PC' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: virustotal-pc
+          path: output/PC/bin/XCSoar.exe
+
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -951,8 +968,72 @@ jobs:
               -p "$APP_SPECIFIC_PASSWORD"
           fi
 
-      - name: Require at least one TestFlight artifact
+      - name: No TestFlight artifacts from build
         if: ${{ steps.ios_ipa.outcome != 'success' && steps.macos_pkg.outcome != 'success' }}
         run: |
-          echo "No iOS or macOS TestFlight artifacts were produced by the build job."
-          exit 1
+          echo "::warning::No iOS or macOS TestFlight artifacts from the build job; skipping TestFlight uploads."
+
+  upload-to-virustotal:
+    name: Upload to VirusTotal (Windows)
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
+    env:
+      VT_API_KEY: ${{ secrets.VT_API_KEY }}
+    steps:
+      - name: Download Win64 executable
+        id: win64
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: virustotal-win64
+
+      - name: Download PC executable
+        id: pc
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: virustotal-pc
+
+      - name: Prepare files for VirusTotal
+        run: |
+          mkdir -p vt-scan
+          for c in \
+            virustotal-win64/output/WIN64/bin/XCSoar.exe \
+            virustotal-win64/XCSoar.exe; do
+            if [ -f "$c" ]; then
+              cp "$c" vt-scan/XCSoar-WIN64.exe
+              break
+            fi
+          done
+          for c in \
+            virustotal-pc/output/PC/bin/XCSoar.exe \
+            virustotal-pc/XCSoar.exe; do
+            if [ -f "$c" ]; then
+              cp "$c" vt-scan/XCSoar-PC.exe
+              break
+            fi
+          done
+          n=0
+          for f in vt-scan/XCSoar-WIN64.exe vt-scan/XCSoar-PC.exe; do
+            [ -f "$f" ] && n=$((n + 1))
+          done
+          if [ "$n" -eq 0 ]; then
+            echo "No Windows executables found for VirusTotal"
+            exit 1
+          fi
+          ls -la vt-scan/
+
+      - name: VirusTotal scan
+        if: ${{ env.VT_API_KEY != '' }}
+        uses: crazy-max/ghaction-virustotal@v5
+        with:
+          vt_api_key: ${{ env.VT_API_KEY }}
+          request_rate: 4
+          files: |
+            vt-scan/*.exe
+
+      - name: VirusTotal API key not configured
+        if: ${{ env.VT_API_KEY == '' }}
+        run: |
+          echo "::warning::VT_API_KEY is not set; skipping VirusTotal upload."

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -123,6 +123,10 @@ jobs:
     # On push/tag, one failed matrix leg (e.g. iOS/macOS) must not block
     # upload-to-play / upload-to-virustotal. PRs keep strict failure.
     continue-on-error: ${{ github.event_name != 'pull_request' }}
+    env:
+      # Signing uses env.* in if: (secrets.* in if: is invalid). These are booleans.
+      IOS_SIGNING_CONFIGURED: ${{ secrets.APPLE_CERTIFICATES_BASE64 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.IOS_PROVISIONING_PROFILE_BASE64 != '' && secrets.APPLE_DISTRIBUTION_CERTIFICATE_NAME != '' }}
+      MACOS_SIGNING_CONFIGURED: ${{ secrets.APPLE_CERTIFICATES_BASE64 != '' && secrets.APPLE_CERTIFICATE_PASSWORD != '' && secrets.MACOS_PROVISIONING_PROFILE_BASE64 != '' && secrets.APPLE_DISTRIBUTION_CERTIFICATE_NAME != '' && secrets.MACOS_INSTALLER_CERTIFICATE_NAME != '' }}
     container: ${{ matrix.target_container }}
     strategy:
       fail-fast: false
@@ -430,68 +434,48 @@ jobs:
 
       - name: Prepare iOS signing certificate and provisioning profile
         shell: bash
-        if: ${{ matrix.target == 'IOS64' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ matrix.target == 'IOS64' && env.IOS_SIGNING_CONFIGURED == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          if [ -n "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" ] && [ -n "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" ]; then
-            # Decode and import the certificate
-            echo "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" | base64 -d > ios-cert.p12
-            
-            # Create temporary keychain
-            security create-keychain -p actions ios-build.keychain
-            security default-keychain -s ios-build.keychain
-            security unlock-keychain -p actions ios-build.keychain
-            security set-keychain-settings -t 3600 -u ios-build.keychain
-            
-            # Import certificate to keychain
-            security import ios-cert.p12 -k ios-build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/security
-            security set-key-partition-list -S apple-tool:,apple: -s -k actions ios-build.keychain
-            
-            # Clean up certificate file
-            rm ios-cert.p12
-            
-            echo "✅ iOS certificate imported successfully"
-          fi
-          
-          if [ -n "${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}" ]; then
-            # Decode and install provisioning profile
-            mkdir -p darwin
-            echo "${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}" | base64 -d > darwin/xcsoar.mobileprovision
-            echo "✅ iOS provisioning profile installed successfully"
-          fi
+          echo "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" | base64 -d > ios-cert.p12
+
+          security create-keychain -p actions ios-build.keychain
+          security default-keychain -s ios-build.keychain
+          security unlock-keychain -p actions ios-build.keychain
+          security set-keychain-settings -t 3600 -u ios-build.keychain
+
+          security import ios-cert.p12 -k ios-build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions ios-build.keychain
+
+          rm ios-cert.p12
+          echo "iOS certificate imported successfully"
+
+          mkdir -p darwin
+          echo "${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}" | base64 -d > darwin/xcsoar.mobileprovision
+          echo "iOS provisioning profile installed successfully"
 
       - name: Prepare macOS signing certificate and provisioning profile
         shell: bash
-        if: ${{ matrix.target == 'MACOS' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ matrix.target == 'MACOS' && env.MACOS_SIGNING_CONFIGURED == 'true' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          if [ -n "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" ] && [ -n "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" ]; then
-            # Decode and import the macOS signing bundle
-            echo "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" | base64 -d > macos-cert.p12
+          echo "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" | base64 -d > macos-cert.p12
 
-            # Create temporary keychain
-            security create-keychain -p actions macos-build.keychain
-            security default-keychain -s macos-build.keychain
-            security unlock-keychain -p actions macos-build.keychain
-            security set-keychain-settings -t 3600 -u macos-build.keychain
+          security create-keychain -p actions macos-build.keychain
+          security default-keychain -s macos-build.keychain
+          security unlock-keychain -p actions macos-build.keychain
+          security set-keychain-settings -t 3600 -u macos-build.keychain
 
-            # Import all identities contained in the bundle to the keychain
-            security import macos-cert.p12 -k macos-build.keychain \
-              -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" \
-              -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
+          security import macos-cert.p12 -k macos-build.keychain \
+            -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/productbuild
 
-            security set-key-partition-list -S apple-tool:,apple: -s -k actions macos-build.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions macos-build.keychain
 
-            # Clean up certificate file
-            rm macos-cert.p12
+          rm macos-cert.p12
+          echo "macOS certificate imported successfully"
 
-            echo "✅ macOS certificate imported successfully"
-          fi
-
-          if [ -n "${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}" ]; then
-            # Decode and install provisioning profile
-            mkdir -p darwin
-            echo "${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}" | base64 -d > darwin/xcsoar.macos.provisionprofile
-            echo "✅ macOS provisioning profile installed successfully"
-          fi
+          mkdir -p darwin
+          echo "${{ secrets.MACOS_PROVISIONING_PROFILE_BASE64 }}" | base64 -d > darwin/xcsoar.macos.provisionprofile
+          echo "macOS provisioning profile installed successfully"
 
       - name: Compile XCSoar - PR
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
@@ -625,73 +609,38 @@ jobs:
 
       - name: Sign iOS IPA
         id: sign_ios
-        if: ${{ matrix.target == 'IOS64' && steps.tests.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ matrix.target == 'IOS64' && env.IOS_SIGNING_CONFIGURED == 'true' && steps.tests.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         run: |
           export APPLE_DISTRIBUTION_CERTIFICATE_NAME="${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_NAME }}"
           export IOS_PROFILE_PATH="darwin/xcsoar.mobileprovision"
 
-          if [ -z "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" ] || [ -z "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" ]; then
-            echo "❌ iOS signing certificate not configured"
-            exit 1
-          fi
-
-          if [ -z "$APPLE_DISTRIBUTION_CERTIFICATE_NAME" ]; then
-            echo "❌ APPLE_DISTRIBUTION_CERTIFICATE_NAME not configured"
-            exit 1
-          fi
-
-          if [ ! -f "$IOS_PROFILE_PATH" ]; then
-            echo "❌ iOS provisioning profile not found: $IOS_PROFILE_PATH"
-            exit 1
-          fi
-
-          echo "📝 Signing iOS IPA..."
+          echo "Signing iOS IPA..."
           bash darwin/sign.sh
 
           if [ ! -f "output/IOS64/xcsoar-signed.ipa" ]; then
-            echo "❌ Signed iOS IPA not found after signing"
+            echo "Signed iOS IPA not found after signing"
             exit 1
           fi
 
-          echo "✅ iOS IPA signed successfully"
+          echo "iOS IPA signed successfully"
 
       - name: Sign macOS package
         id: sign_macos
-        if: ${{ matrix.target == 'MACOS' && steps.tests.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ matrix.target == 'MACOS' && env.MACOS_SIGNING_CONFIGURED == 'true' && steps.tests.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         env:
           APPLE_DISTRIBUTION_CERTIFICATE_NAME: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_NAME }}
           MACOS_INSTALLER_CERTIFICATE_NAME: ${{ secrets.MACOS_INSTALLER_CERTIFICATE_NAME }}
           MACOS_PROFILE_PATH: darwin/xcsoar.macos.provisionprofile
         run: |
-          if [ -z "${{ secrets.APPLE_CERTIFICATES_BASE64 }}" ] || [ -z "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" ]; then
-            echo "❌ macOS signing certificate not configured"
-            exit 1
-          fi
-
-          if [ -z "$APPLE_DISTRIBUTION_CERTIFICATE_NAME" ]; then
-            echo "❌ APPLE_DISTRIBUTION_CERTIFICATE_NAME not configured"
-            exit 1
-          fi
-
-          if [ -z "$MACOS_INSTALLER_CERTIFICATE_NAME" ]; then
-            echo "❌ MACOS_INSTALLER_CERTIFICATE_NAME not configured"
-            exit 1
-          fi
-
-          if [ ! -f "$MACOS_PROFILE_PATH" ]; then
-            echo "❌ macOS provisioning profile not found: $MACOS_PROFILE_PATH"
-            exit 1
-          fi
-
-          echo "📝 Signing macOS package..."
+          echo "Signing macOS package..."
           bash darwin/sign-macos.sh
 
           if [ ! -f "output/MACOS/XCSoar-signed.pkg" ]; then
-            echo "❌ Signed macOS package not found after signing"
+            echo "Signed macOS package not found after signing"
             exit 1
           fi
 
-          echo "✅ macOS package signed successfully"
+          echo "macOS package signed successfully"
 
       - name: Upload artifact for TestFlight (iOS)
         if: ${{ matrix.target == 'IOS64' && steps.tests.outcome == 'success' && steps.sign_ios.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
@@ -763,10 +712,21 @@ jobs:
           UNSIGNED_IPA="output/IOS64/xcsoar.ipa"
           if [ -f "$SIGNED_IPA" ]; then
             echo "DEPLOY_SOURCE=$SIGNED_IPA" >> $GITHUB_ENV
+          elif [ "${{ env.IOS_SIGNING_CONFIGURED }}" != "true" ] && \
+               { [ "${{ github.ref }}" = "refs/heads/master" ] || \
+                 [ "${{ github.ref }}" = "refs/heads/apple-testing" ] || \
+                 [[ "${{ github.ref }}" == refs/tags/v* ]]; }; then
+            if [ -f "$UNSIGNED_IPA" ]; then
+              echo "::warning::iOS signing secrets not fully configured; deploying unsigned IPA"
+              echo "DEPLOY_SOURCE=$UNSIGNED_IPA" >> $GITHUB_ENV
+            else
+              echo "Unsigned IPA not found: $UNSIGNED_IPA"
+              exit 1
+            fi
           elif [ "${{ github.ref }}" = "refs/heads/master" ] || \
                [ "${{ github.ref }}" = "refs/heads/apple-testing" ] || \
                [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            echo "❌ Signed IPA required for ${{ github.ref }}, but not found: $SIGNED_IPA"
+            echo "Signed IPA required for ${{ github.ref }} when signing is configured, but not found: $SIGNED_IPA"
             exit 1
           else
             echo "DEPLOY_SOURCE=$UNSIGNED_IPA" >> $GITHUB_ENV


### PR DESCRIPTION
- **.github/workflows/build-native.yml: Move TestFlight uploads to separate job**
- **.github/workflows/build-native.yml: Add VirusTotal upload for Windows builds**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build pipeline now tolerates individual platform job failures for non-PR runs so uploads proceed.
  * iOS and macOS packages are saved and uploaded in a separate release step; uploads are skipped with a warning if missing.
  * Windows executables are saved and scanned in a separate VirusTotal step; scanning is skipped with a warning when the API key is not set.
  * Release flow can deploy unsigned iOS packages with a warning when signing is not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->