### PR TITLE
CI: Fix VirusTotal Windows paths and iOS sim build output

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -600,7 +600,7 @@ jobs:
         id: tests
         if: ${{ (matrix.target == 'IOS64' || matrix.target == 'MACOS') && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         run: |
-          echo "🧪 Running unit tests..."
+          echo "Running unit tests..."
           if [ ${{ matrix.target }} = 'IOS64' ]; then
             gmake check-ios-sim
           else

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -958,7 +958,10 @@ jobs:
       - name: Prepare files for VirusTotal
         run: |
           mkdir -p vt-scan
+          # download-artifact@v8 extracts into workspace root with the same
+          # paths as upload (not under a virustotal-* directory).
           for c in \
+            output/WIN64/bin/XCSoar.exe \
             virustotal-win64/output/WIN64/bin/XCSoar.exe \
             virustotal-win64/XCSoar.exe; do
             if [ -f "$c" ]; then
@@ -967,6 +970,7 @@ jobs:
             fi
           done
           for c in \
+            output/PC/bin/XCSoar.exe \
             virustotal-pc/output/PC/bin/XCSoar.exe \
             virustotal-pc/XCSoar.exe; do
             if [ -f "$c" ]; then

--- a/darwin/check-ios-sim.py
+++ b/darwin/check-ios-sim.py
@@ -130,7 +130,19 @@ def main() -> int:
     app_test_dir = app_path / "tests"
 
     print(f"check-ios-sim: building simulator app and tests for target {target}")
-    run([make_bin, f"-j{cpu_count()}", f"TARGET={target}", "build-check", "ipa"])
+    # -Oline serializes job output; V=0 reduces noise. Helps avoid gmake
+    # "write error: stdout" on CI when parallel build output is very large.
+    run(
+        [
+            make_bin,
+            "-Oline",
+            f"-j{cpu_count()}",
+            f"TARGET={target}",
+            "V=0",
+            "build-check",
+            "ipa",
+        ]
+    )
 
     if not app_path.is_dir():
         print(f"Error: app bundle not found at {app_path}", file=sys.stderr)


### PR DESCRIPTION
## Summary

Follow-up to merged #2364.

- **VirusTotal**: `download-artifact@v8` extracts under the workspace root (e.g. `output/WIN64/bin/XCSoar.exe`). The prepare step now checks those paths before the older `virustotal-win64/` layout so Windows uploads are found.
- **iOS simulator CI**: Avoid `gmake: write error: stdout` on GitHub Actions by running the inner build with `gmake -Oline` and `V=0` (less log backpressure on inherited stdout).

## Files
- `.github/workflows/build-native.yml`
- `darwin/check-ios-sim.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration for improved artifact handling and build output management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->