### PR TITLE
build/python: improve source download resiliency and refresh broken mirrors

### DIFF
--- a/build/python/build/download.py
+++ b/build/python/build/download.py
@@ -2,7 +2,6 @@ from typing import Sequence, Union
 import os
 from tempfile import NamedTemporaryFile
 import urllib.request
-import sys
 
 from .verify import verify_file_digest
 from .lockfile import lockfile
@@ -28,14 +27,38 @@ def __download(urls: Sequence[str], path: str) -> None:
         try:
             __download_one(url, path)
             return
-        except:
-            print("download error:", sys.exc_info()[0])
+        except Exception as e:
+            print("download error:", type(e).__name__)
     __download_one(urls[-1], path)
 
 def __download_and_verify_to(urls: Sequence[str], md5: str, path: str) -> None:
-    __download(urls, path)
-    if not verify_file_digest(path, md5):
-        raise RuntimeError("Digest mismatch")
+    had_download_error = False
+    had_digest_mismatch = False
+    last_download_error: Exception = RuntimeError("download failed")
+
+    for url in urls:
+        try:
+            __download_one(url, path)
+        except Exception as e:
+            print("download error:", type(e).__name__)
+            had_download_error = True
+            last_download_error = e
+            continue
+
+        try:
+            if verify_file_digest(path, md5):
+                return
+            print("digest mismatch:", url)
+            had_digest_mismatch = True
+        except Exception as e:
+            print("digest verification error:", type(e).__name__)
+            had_digest_mismatch = True
+
+    if had_download_error and had_digest_mismatch:
+        raise RuntimeError("All download URLs failed: download errors and digest mismatches") from last_download_error
+    if had_download_error:
+        raise RuntimeError("All download URLs failed due to download errors") from last_download_error
+    raise RuntimeError("Digest mismatch")
 
 def download_basename(urls: Union[str, Sequence[str]]) -> str:
     return os.path.basename(__get_any(urls))

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -13,7 +13,7 @@ from build.musl import MuslProject
 
 binutils = BinutilsProject(
     (
-        "https://ftpmirror.gnu.org/binutils/binutils-2.42.tar.xz",
+        "https://ftp.gnu.org/gnu/binutils/binutils-2.42.tar.xz",
         "https://sourceware.org/pub/binutils/releases/binutils-2.42.tar.xz",
     ),
     "f6e4d41fd5fc778b06b7891457b3620da5ecea1006c6a4a41ae998109f85a800",

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -29,7 +29,7 @@ binutils = BinutilsProject(
 
 linux_headers = SabotageLinuxHeadersProject(
     (
-        "http://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88.tar.xz",
+        "https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88.tar.xz",
         "https://mirrors.2f30.org/sabotage/tarballs/linux-headers-4.19.88.tar.xz",
     ),
     "5a975ba49b577869f2338aa80f44efd4e94f76e5b4bda11a6a1761a6d646848fdeaad7c820339b2c1c20d55f9bbf0e686121d621ac1cfa1dfc6cd71a166ade3a",

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -325,7 +325,7 @@ libpng = CmakeProject(
 libjpeg = CmakeProject(
     (
         "http://downloads.sourceforge.net/project/libjpeg-turbo/3.0.1/libjpeg-turbo-3.0.1.tar.gz",
-        "https://netcologne.dl.sourceforge.net/project/libjpeg-turbo/3.0.1/libjpeg-turbo-3.0.1.tar.gz",
+        "https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.0.1/libjpeg-turbo-3.0.1.tar.gz",
     ),
     "22429507714ae147b3acacd299e82099fce5d9f456882fc28e252e4579ba2a75",
     "lib/libjpeg.a",

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -176,10 +176,10 @@ libsodium = AutotoolsProject(
 
 zlib = ZlibProject(
     (
-        "http://zlib.net/zlib-1.3.1.tar.xz",
-        "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.xz",
+        "http://zlib.net/zlib-1.3.2.tar.xz",
+        "https://github.com/madler/zlib/releases/download/v1.3.2/zlib-1.3.2.tar.xz",
     ),
-    "38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32",
+    "d7a0654783a4da529d1bb793b7ad9c3318020af77667bcae35f95d0e42a792f3",
     "lib/libz.a",
 )
 

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -476,8 +476,8 @@ lua = LuaProject(
 
 libsalsa = AutotoolsProject(
     (
+        "https://ftp.suse.com/pub/people/tiwai/salsa-lib/salsa-lib-0.1.6.tar.bz2",
         "ftp://ftp.suse.com/pub/people/tiwai/salsa-lib/salsa-lib-0.1.6.tar.bz2",
-        "https://mirror.linux-ia64.org/ftp_suse_com/people/tiwai/salsa-lib/salsa-lib-0.1.6.tar.bz2",
     ),
     "08a6481cdbf4c79e05a9cba3b6c48375",
     "lib/libsalsa.a",


### PR DESCRIPTION
## Summary

This PR improves source download resiliency in the Python build tooling and updates stale/failing mirrors so checksum verification is more reliable in CI and local runs.

## What changed

- Improved mirror retry and digest verification behavior.
- Replaced broad exception handling with safer exception handling and clearer failure causes.
- Updated zlib from 1.3.1 to 1.3.2 (URL + checksum).
- Replaced dead/flaky mirrors:
  - salsa-lib dead mirror replaced and HTTPS preferred before FTP fallback
  - binutils flaky `ftpmirror` replaced with canonical GNU source
  - libjpeg-turbo dead fallback replaced with official GitHub release asset (same checksum)
  - linux-headers mirror switched from HTTP to HTTPS

## Why

- Checksum verification runs showed intermittent/permanent failures from dead or flaky mirrors.
- Error reporting in the downloader was ambiguous for download failures vs checksum mismatches.
- These changes reduce false-negative CI noise and improve diagnosis of real source-fetch issues.

## Validation

- Ran checksum verification in verbose mode after updates:
  - `python3 build/python/build/verify_sources.py --checksum --verbose`
- Previously failing entries for zlib, salsa-lib, binutils, libjpeg-turbo, and linux-headers were addressed.
- Remaining known issue:
  - secondary `simple_usbmodeswitch` fallback URL is still dead
  - primary GitHub release URL is healthy

## Scope

- `build/python/build/download.py`
- `build/python/build/libs.py`

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [x] Commit messages explain *why* the change was made, not just *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [x] Each commit is atomic and builds successfully
- [x] One commit per logical change
- [x] Self-contained commits
- [x] No fixup commits
- [x] No duplicate commits
- [x] No "WIP" or "testing" commits

---

- [x] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust download and verification: per-source attempts, clearer error messages distinguishing download vs. verification failures, and improved retry behavior.

* **Chores**
  * Updated primary download mirrors and source URLs for build dependencies: binutils, linux_headers, libjpeg (switched to official GitHub tarball), libsalsa (mirror list updated), and zlib bumped to 1.3.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->