### PR TITLE
Fix/macos app review 2026 04

### DIFF
--- a/Data/OSX/Info.plist.in.xml
+++ b/Data/OSX/Info.plist.in.xml
@@ -27,8 +27,8 @@
     <string>12.0.0</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.navigation</string>
-    <key>NSLocationWhenInUseUsageDescription</key>
-    <string>XCSoar uses your location for navigation and flight logging with GPS devices.</string>
+    <key>NSLocationUsageDescription</key>
+    <string>XCSoar uses your location to provide onboard GPS navigation and to record your flight track.</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
   </dict>

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -116,7 +116,7 @@ ArrowPagerWidget::Prepare(ContainerWindow &parent,
   next_button.Create(parent, layout.next_button, style,
                      std::make_unique<SymbolButtonRenderer>(look, ">"),
                      [this](){
-                       if (CanAdvance())
+                       if (HasNextPage() && CanAdvance())
                          Next(false);
                      });
   close_button.Create(parent, look,
@@ -225,7 +225,7 @@ void
 ArrowPagerWidget::UpdateNextButtonState() noexcept
 {
   if (next_button.IsDefined())
-    next_button.SetEnabled(GetSize() >= 2 && CanAdvance());
+    next_button.SetEnabled(HasNextPage() && CanAdvance());
 }
 
 void
@@ -233,5 +233,5 @@ ArrowPagerWidget::UpdateButtons() noexcept
 {
   const bool enable = GetSize() >= 2;
   previous_button.SetEnabled(enable);
-  next_button.SetEnabled(enable && CanAdvance());
+  next_button.SetEnabled(enable && HasNextPage() && CanAdvance());
 }

--- a/src/Widget/ArrowPagerWidget.hpp
+++ b/src/Widget/ArrowPagerWidget.hpp
@@ -62,6 +62,11 @@ private:
   /** Optional guard that blocks forward page navigation */
   CanAdvanceCallback can_advance_callback;
 
+  [[gnu::pure]]
+  bool HasNextPage() const noexcept {
+    return GetCurrentIndex() + 1 < GetSize();
+  }
+
 public:
   ArrowPagerWidget(const ButtonLook &_look,
                    std::function<void()> _close_callback,


### PR DESCRIPTION
## Summary

This PR fixes two macOS App Review blockers for XCSoar 7.44.

1. Quick Guide pager: prevent a dead-end next interaction on the last page by disabling next when no following page exists.
2. macOS privacy key: use the correct macOS location usage key (`NSLocationUsageDescription`) in the macOS plist template.

Bluetooth entitlement is intentionally unchanged in this PR.

## Changes

### 1. Pager behavior in Quick Guide startup dialog

- Added an explicit last-page check via `HasNextPage()`.
- Next button enable state now requires:
	- At least one following page.
	- `CanAdvance()` guard allowing forward navigation.
- Next button click path also uses explicit next-page plus guard checks.

Result:
- On the final page, the next arrow is disabled instead of appearing active and doing nothing.

### 2. Correct macOS location purpose key

- Replaced `NSLocationWhenInUseUsageDescription` with `NSLocationUsageDescription`.
- Kept a clear purpose string describing onboard GPS navigation and flight track recording.

Result:
- Aligns macOS bundle metadata with Apple review expectations for location permission disclosure.

## Out Of Scope / Intentional Non-Changes

- Kept `com.apple.security.device.bluetooth` entitlement unchanged for planned Apple-platform BLE support.
- No Bluetooth behavior change in this PR.

## Testing

- Manual code inspection of pager logic and plist generation templates.
- Local build check:
	- `make -j8 TARGET=MACOS` passed.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Commit history cleaned up (atomic commits, no fixups)

#### Commit Format & Messages
- [x] Commits follow `<Component>: <Summary>`
- [x] Present tense used
- [x] Messages explain intent

#### Commit Structure
- [x] One logical change per commit
- [x] No duplicate, WIP, or testing commits

---

- [x] I'm ready to merge
