### PR TITLE
macOS: Fix Clang warnings and enable command line replay

### DIFF
--- a/src/Audio/PCMMixer.hpp
+++ b/src/Audio/PCMMixer.hpp
@@ -24,7 +24,7 @@ class PCMMixer final {
 
 public:
   PCMMixer(unsigned sample_rate, std::unique_ptr<PCMPlayer> &&player);
-  virtual ~PCMMixer() = default;
+  ~PCMMixer() = default;
 
   PCMMixer(PCMMixer &) = delete;
   PCMMixer &operator=(PCMMixer &) = delete;

--- a/src/CommandLine.hpp
+++ b/src/CommandLine.hpp
@@ -3,6 +3,10 @@
 
 #pragma once
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 class Args;
 
 namespace CommandLine {
@@ -17,7 +21,8 @@ namespace CommandLine {
   static constexpr bool full_screen = false;
 #endif
 
-#if defined(__linux__) && !defined(ANDROID)
+#if (defined(__linux__) && !defined(ANDROID)) || \
+    (defined(__APPLE__) && !TARGET_OS_IPHONE)
 #define HAVE_CMDLINE_REPLAY
   extern const char *replay_path;
 #endif

--- a/src/Computer/Wind/CirclingWind.hpp
+++ b/src/Computer/Wind/CirclingWind.hpp
@@ -49,7 +49,6 @@ class CirclingWind {
   Angle current_circle;
 
   Angle last_track = Angle::Zero();
-  Angle last_wind_dir = Angle::Zero();
 
   boost::circular_buffer<Sample> samples{80};
 

--- a/src/Dialogs/Device/PortMonitor.cpp
+++ b/src/Dialogs/Device/PortMonitor.cpp
@@ -32,7 +32,7 @@ class PortTerminalBridge final : public DataHandler {
 public:
   PortTerminalBridge(TerminalWindow &_terminal)
     :terminal(_terminal) {}
-  virtual ~PortTerminalBridge() {}
+  ~PortTerminalBridge() {}
 
   bool DataReceived(std::span<const std::byte> s) noexcept {
     {

--- a/src/MapWindow/OverlayBitmap.cpp
+++ b/src/MapWindow/OverlayBitmap.cpp
@@ -29,7 +29,11 @@ using ClippedPolygon = boost::geometry::model::polygon<DoublePoint2D>;
 using ClippedMultiPolygon =
   boost::geometry::model::multi_polygon<ClippedPolygon>;
 
+#ifdef USE_GEOTIFF
 MapOverlayBitmap::MapOverlayBitmap(Path path)
+#else
+[[noreturn]] MapOverlayBitmap::MapOverlayBitmap(Path path)
+#endif
   :label((path.GetBase() != nullptr ? path.GetBase() : path).c_str())
 {
   bounds = bitmap.LoadGeoFile(path);

--- a/src/MapWindow/OverlayBitmap.hpp
+++ b/src/MapWindow/OverlayBitmap.hpp
@@ -44,7 +44,11 @@ public:
    *
    * Throws on error.
    */
+#ifdef USE_GEOTIFF
   MapOverlayBitmap(Path path);
+#else
+  [[noreturn]] MapOverlayBitmap(Path path);
+#endif
 
   /**
    * Move an existing #Bitmap with a geo reference.

--- a/src/io/ZipReader.hpp
+++ b/src/io/ZipReader.hpp
@@ -19,7 +19,7 @@ public:
    */
   ZipReader(struct zzip_dir *dir, const char *path);
 
-  virtual ~ZipReader();
+  ~ZipReader();
 
   [[gnu::pure]]
   uint_least64_t GetSize() const;

--- a/src/ui/canvas/Bitmap.hpp
+++ b/src/ui/canvas/Bitmap.hpp
@@ -183,7 +183,11 @@ public:
    * Load a georeferenced image (e.g. GeoTIFF) and return its bounds.
    * Throws a std::runtime_error on error.
    */
+#ifdef USE_GEOTIFF
   GeoQuadrilateral LoadGeoFile(Path path);
+#else
+  [[noreturn]] GeoQuadrilateral LoadGeoFile(Path path);
+#endif
 
   void Reset() noexcept;
 

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -12,14 +12,10 @@
 
 #include <stdexcept>
 
-#if !defined(USE_GEOTIFF) && defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=noreturn"
-#endif
-
-GeoQuadrilateral
-Bitmap::LoadGeoFile([[maybe_unused]] Path path)
-{
 #ifdef USE_GEOTIFF
+GeoQuadrilateral
+Bitmap::LoadGeoFile(Path path)
+{
   if (path.EndsWithIgnoreCase(".tif") ||
       path.EndsWithIgnoreCase(".tiff")) {
     auto result = LoadGeoTiff(path);
@@ -30,7 +26,13 @@ Bitmap::LoadGeoFile([[maybe_unused]] Path path)
 
     return result.second;
   }
-#endif
 
   throw std::runtime_error("Unsupported geo image file");
 }
+#else
+[[noreturn]] GeoQuadrilateral
+Bitmap::LoadGeoFile([[maybe_unused]] Path)
+{
+  throw std::runtime_error("Unsupported geo image file");
+}
+#endif


### PR DESCRIPTION
## Title

macOS: Fix Clang warnings and enable command line replay

## Summary

This PR contains three macOS and toolchain maintenance fixes.

It includes:
1. Clang warning fixes needed for Apple Clang 21 (Xcode 16.4).
2. Removal of redundant virtual specifiers on final classes.
3. Enabling command line replay startup on macOS desktop builds.

## Changes

### 1. Drop redundant virtual on final classes

- Removes unnecessary virtual keywords from final classes that trigger -Wunnecessary-virtual-specifier on Apple Clang 21 (Xcode 16.4).
- Keeps behavior unchanged.

Affected areas:
- Audio
- Dialogs device monitor
- IO zip reader

### 2. Fix new Clang warnings

- Removes an unused private field in CirclingWind.
- Marks non-GeoTIFF throwing stubs as [[noreturn]] where appropriate.
- Keeps existing runtime behavior while making intent explicit for the compiler.

Affected areas:
- Computer wind
- MapWindow overlay bitmap
- UI canvas bitmap and custom geobitmap

### 3. Enable -replay on macOS

- Extends command line replay availability to macOS desktop builds.
- iOS remains excluded.
- Startup path already supports replay when replay_path is set.

Affected area:
- CommandLine option guards

## Motivation

These fixes are broadly useful and improve build reliability and local testing on current macOS toolchains.
They are kept together here because they are closely related and low risk.

## Testing

- Local build check passed:
  - make -j8 TARGET=MACOS

## Commit Scope

Included commits in this branch:
- src,Audio,Dialogs/io: Drop redundant virtual on final classes
- Computer,MapWindow,ui: Fix new Clang warnings
- CommandLine: Enable -replay on macOS

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current master
- [x] Commit history cleaned up (atomic commits, no fixups)

#### Commit Format & Messages
- [x] Commits follow Component: Summary
- [x] Present tense used
- [x] Messages explain intent

#### Commit Structure
- [x] One logical change per commit
- [x] No duplicate, WIP, or testing commits

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded command-line replay support to Apple platforms (macOS).

* **Refactor**
  * Optimized internal class hierarchies by removing unnecessary virtual destructors.
  * Removed unused internal state tracking from wind calculations.
  * Enhanced conditional compilation structure for better modularity across different feature configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->