### PR TITLE
Apple/InternalSensors: Disable iOS distance filter

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -27,6 +27,9 @@ Version 7.45 - not yet released
   - restore FFVV NetCoupe contest optimisation #2330
 * data files
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
+* iOS
+  - disable Core Location distance filter for built-in GPS so fixes are not
+    suppressed while stationary #2380
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/src/Apple/InternalSensors.cpp
+++ b/src/Apple/InternalSensors.cpp
@@ -197,7 +197,11 @@ void InternalSensors::Init()
   
 #if TARGET_OS_IPHONE
   // Configure location manager for background operation
-  location_manager.distanceFilter = 10.0; // Update every 10 meters
+  /* XCSoar expires the internal GPS fix after 10 seconds without a
+     fresh location.  A distance filter allows CoreLocation to stay
+     quiet while the GPS is still healthy, which makes the UI fall
+     back to "GPS waiting for fix". */
+  location_manager.distanceFilter = kCLDistanceFilterNone;
   location_manager.pausesLocationUpdatesAutomatically = NO;
   
   if ([location_manager


### PR DESCRIPTION
## Summary

This PR fixes iOS internal GPS fix loss while stationary.

On iOS, CoreLocation may suppress callbacks when the device has not moved enough to pass the distance filter. XCSoar expires GPS location after 10 seconds without fresh location data, which could incorrectly show "GPS waiting for fix" even though GPS was still healthy.

## Changes

### iOS InternalSensors location update policy

- File changed: `src/Apple/InternalSensors.cpp`
- Updated CoreLocation distance filter:
  - from `10.0` meters
  - to `kCLDistanceFilterNone`
- Added a clarifying comment explaining the interaction between callback cadence and XCSoar's 10-second GPS expiry behavior.

Result:
- CoreLocation keeps delivering location updates while stationary.
- XCSoar no longer drops to "GPS waiting for fix" solely because no movement occurred.

## Out Of Scope / Intentional Non-Changes

- No changes to GPS expiry logic outside iOS sensor ingestion.
- No Android behavior changes.
- No build-system or entitlement changes.

## Testing

- Code-level verification of iOS location manager configuration in `InternalSensors::Init()`.
- Manual iOS validation pending on device after Xcode platform content installation.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Commit history cleaned up (atomic commits, no fixups)

#### Commit Format & Messages
- [x] Commits follow `<Component>: <Summary>`
- [x] Present tense used
- [x] Messages explain intent

#### Commit Structure
- [x] One logical change per commit
- [x] No duplicate, WIP, or testing commits

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * iOS: Disabled Core Location distance filtering for the built-in GPS to avoid suppressing fixes while stationary, improving location responsiveness and preventing unintended GPS-fix expiration in location-based features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->