### PR TITLE
Device/Descriptor: Cancel SlowReopen timer in Close()

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -27,6 +27,8 @@ Version 7.45 - not yet released
   - restore FFVV NetCoupe contest optimisation #2330
 * data files
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
+* devices
+  - fix native crash on device reconnect (stale delayed reopen timer) #2382
 * iOS
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -490,6 +490,11 @@ DeviceDescriptor::Close() noexcept
   assert(InMainThread());
   assert(!IsBorrowed());
 
+  /* Cancel SlowReopen(); otherwise a stale OnReopenTimer could call
+     Open() after the port was opened again (e.g. devRestart). */
+  waiting_to_call_open = false;
+  reopen_timer.Cancel();
+
   CancelAsync();
 
 #ifdef HAVE_INTERNAL_GPS
@@ -550,7 +555,12 @@ void
 DeviceDescriptor::OnReopenTimer() noexcept
 {
   assert(InMainThread());
-  
+
+  if (!waiting_to_call_open)
+    return;
+
+  waiting_to_call_open = false;
+
   // This runs after the 5-second delay
   try {
     static MessageOperationEnvironment env;
@@ -558,7 +568,6 @@ DeviceDescriptor::OnReopenTimer() noexcept
   } catch (...) {
     LogError(std::current_exception(), "Failed to reopen device after delay");
   }
-  waiting_to_call_open = false;
 }
 
 void
@@ -567,9 +576,8 @@ DeviceDescriptor::SlowReopen()
   assert(InMainThread());
   assert(!IsBorrowed());
 
-  waiting_to_call_open = true;
-
   Close();
+  waiting_to_call_open = true;
   // Schedule the Open() call after 5 seconds instead of blocking
   reopen_timer.Schedule(std::chrono::seconds(5));
 }


### PR DESCRIPTION
## Summary

Fixes a native crash (`assert(port == nullptr)` in `DeviceDescriptor::Open`) when a device was reopened before the 5-second `SlowReopen` timer fired (e.g. after USB/Bluetooth reconnect and comm restart).

## Changes

- Cancel `reopen_timer` and clear `waiting_to_call_open` in `Close()`.
- In `SlowReopen()`, call `Close()` before setting the flag and scheduling.
- Guard `OnReopenTimer()` if the delayed reopen was superseded.
- `NEWS.txt` entry for v7.45.

Fixes #2382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a native crash that could occur when reconnecting devices; device reconnection is now more stable.

* **Documentation**
  * Updated release notes for version 7.45 to document the device reconnection fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->