### PR TITLE
.github/workflows/build-native.yml: Add workflow_dispatch ref input

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -1,6 +1,14 @@
 ---
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: >
+          Git branch, tag, or commit SHA to check out and build. Leave empty
+          to build the ref selected in "Use workflow from" (same as before).
+        required: false
+        default: ''
+        type: string
   push:
     paths-ignore:
       - '.clang-format'
@@ -74,6 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ (github.event.inputs != null && github.event.inputs.ref) || github.ref }}
           submodules: true
 
       - name: Parse changelog
@@ -219,6 +228,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ (github.event.inputs != null && github.event.inputs.ref) || github.ref }}
           submodules: true
 
       - name: Verify Xcode version
@@ -768,6 +778,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ (github.event.inputs != null && github.event.inputs.ref) || github.ref }}
           submodules: true
 
       - name: Download Android bundle


### PR DESCRIPTION
## Summary

Adds an optional `ref` input to `workflow_dispatch` so CI can check out a specific branch, tag, or commit while using the workflow file from the branch selected in the UI (e.g. rebuild `v7.44` with an updated `build-native.yml` on `master`).

All `actions/checkout` steps use:
```yaml
ref: ${{ (github.event.inputs != null && github.event.inputs.ref) || github.ref }}
```

Push and PR triggers are unchanged (they ignore the empty input and use `github.ref`).

## How to use

Actions → build-native → Run workflow → set **ref** (e.g. `v7.44`) → run from `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build workflow now supports manual triggering with custom Git references (branch, tag, or commit SHA).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->