### PR TITLE
Math/Angle: O(1) wrap for extreme bearing magnitudes (#1292)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -25,6 +25,8 @@ Version 7.45 - not yet released
     dropping the newest InfoBoxes, as we have 130 of them now)
 * calculations
   - restore FFVV NetCoupe contest optimisation #2330
+  - angle bearing/delta normalization uses O(1) wrap (avoids stalls when angles
+    are extremely large; suspected Android freeze #1292)
 * data files
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
 * devices

--- a/src/Math/Angle.cpp
+++ b/src/Math/Angle.cpp
@@ -4,6 +4,32 @@
 #include "Angle.hpp"
 
 #include <cassert>
+#include <cmath>
+
+namespace {
+
+/**
+ * Reduce \a v radians to the half-open interval [0, 2π) in O(1) time.
+ * NaN and infinity map to 0 so callers never spin on pathological values.
+ */
+double
+NormalizeFullCircleRadians(const double v) noexcept
+{
+  if (std::isnan(v) || std::isinf(v))
+    return 0;
+
+  const double two_pi = Angle::FullCircle().Native();
+  double r = std::fmod(v, two_pi);
+  if (r < 0)
+    r += two_pi;
+  return r;
+}
+
+/** Beyond this |radian| magnitude, iterated wrap is too slow on the UI thread. */
+constexpr double kAsBearingFmodThresholdRadians =
+    1024 * Angle::FullCircle().Native();
+
+} // namespace
 
 Angle::DMS
 Angle::ToDMS() const noexcept
@@ -54,22 +80,16 @@ Angle::AbsoluteRadians() const noexcept
 Angle
 Angle::AsBearing() const noexcept
 {
-  assert(!isnan(value));
-  assert(!isinf(value));
-  assert(fabs(value) < 100 * FullCircle().Native());
+  assert(!std::isnan(value));
+  assert(!std::isinf(value));
 
-#ifndef FIXED_MATH
-  /* Workaround for endless loops below; this is only for release
-     builds.  Debug builds will crash due to assertion failure.  Right
-     now, I don't know where those abnormal values come from, but I
-     hope we'll find out soon - until that happens, this workaround
-     reduces some user frustration with XCSoar freezes. */
-  if (!isnormal(value))
-    return Zero();
-#endif
+  const double v = value;
+  if (fabs(v) >= kAsBearingFmodThresholdRadians)
+    return Native(NormalizeFullCircleRadians(v));
 
-  Angle retval(value);
-
+  /* Historic path: repeated ±2π matches prior floating-point rounding in
+     typical ranges (see unit tests). */
+  Angle retval(v);
   while (retval < Zero())
     retval += FullCircle();
 
@@ -82,18 +102,19 @@ Angle::AsBearing() const noexcept
 Angle
 Angle::AsDelta() const noexcept
 {
-  assert(!isnan(value));
-  assert(!isinf(value));
-  assert(fabs(value) < 100 * FullCircle().Native());
+  assert(!std::isnan(value));
+  assert(!std::isinf(value));
 
-#ifndef FIXED_MATH
-  /* same workaround as in AsBearing() */
-  if (!isnormal(value))
-    return Zero();
-#endif
+  const double v = value;
+  if (fabs(v) >= kAsBearingFmodThresholdRadians) {
+    double r = NormalizeFullCircleRadians(v);
+    const double half = HalfCircle().Native();
+    if (r > half)
+      r -= FullCircle().Native();
+    return Native(r);
+  }
 
-  Angle retval(value);
-
+  Angle retval(v);
   while (retval <= -HalfCircle())
     retval += FullCircle();
 

--- a/test/src/TestAngle.cpp
+++ b/test/src/TestAngle.cpp
@@ -4,11 +4,12 @@
 #include "Math/Angle.hpp"
 #include "TestUtil.hpp"
 
+#include <cmath>
 #include <stdio.h>
 
 int main()
 {
-  plan_tests(97);
+  plan_tests(97 + 4);
 
   // Test Native() and Native()
   ok1(equals(Angle::Native(0).Native(), 0));
@@ -79,6 +80,27 @@ int main()
   ok1(equals(Angle::Degrees(179).AsDelta(), 179));
   ok1(equals(Angle::Degrees(-179).AsDelta(), -179));
   ok1(equals(Angle::Degrees(270).AsDelta(), -90));
+
+  /* O(1) normalization: many full turns plus a remainder must match the
+     remainder alone (avoids main-thread stalls from iterated wrap;
+     see issue #1292).  Use moderate turn counts so doubles still hold the
+     added radians. */
+  {
+    const double two_pi = Angle::FullCircle().Native();
+    const Angle ref = Angle::Degrees(42);
+    const double huge = 100 * two_pi + ref.Native();
+    ok1(equals(Angle::Native(huge).AsBearing(), ref.AsBearing()));
+    ok1(equals(Angle::Native(huge).AsDelta(), ref.AsDelta()));
+
+    const Angle ref_neg = Angle::Degrees(-13);
+    const double huge_neg = -100 * two_pi + ref_neg.Native();
+    ok1(equals(Angle::Native(huge_neg).AsDelta(), ref_neg.AsDelta()));
+
+    /* Magnitudes far beyond float precision must still land in [0, 2π). */
+    const Angle extreme = Angle::Native(1e22 * two_pi).AsBearing();
+    ok1(std::isfinite(extreme.Native()) && extreme.Native() >= 0 &&
+         extreme.Native() < two_pi);
+  }
 
   // Test Between()
   ok1(Angle::QuarterCircle().Between(Angle::Zero(), Angle::HalfCircle()));


### PR DESCRIPTION
## Summary
Hardens `Angle::AsBearing()` and `Angle::AsDelta()` so pathological **large finite** angles cannot stall the UI thread (suspected Android ANR in #1292).

## Approach
- For **$|θ| \ge 1024 \times 2π$**: normalize with `std::fmod` in **O(1)** (plus map delta to $(-π, π]$).
- For smaller magnitudes: keep the **existing while-loop** wrap so floating-point rounding matches prior behaviour (avoids regressions such as `TestGeoClip`).
- `NaN` / `Inf` in the fmod path map to **0** (no spin).

## Tests
- Extended `TestAngle` (moderate multi-turn wrap + extreme magnitude sanity check).
- `make check` (TARGET=UNIX) passes.

## NEWS
- v7.45 bullet under *calculations*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of extremely large angle values by switching to a constant-time wrap normalization.

* **Performance**
  * Reduced computation cost for large-magnitude angle normalization.

* **Tests**
  * Added tests verifying normalization correctness and finite, in-range results for very large angle inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->