### PR TITLE
Android/NativeView: Use getRealMetrics() for startup DPI #1784

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -16,6 +16,8 @@ Version 7.45 - not yet released
     Displayed glide is re-solved with the current aircraft state; value colour
     encodes not reachable, final glide, need climb, and MANUAL on/below glide.
     Manual updated en/de/fr/pt_BR #2347
+  - android: use physical display metrics for startup DPI (getRealMetrics)
+    #1784
   - android/ios: configure built-in GPS & sensors in the last device slot by
     default
   - status: show G-load availability in device list and variometer source in

--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -252,7 +252,10 @@ class NativeView extends SurfaceView
     android.graphics.Rect r = getHolder().getSurfaceFrame();
     android.util.Log.d(TAG, "runNative: getSurfaceFrame() size=" + r.width() + "x" + r.height());
     DisplayMetrics metrics = new DisplayMetrics();
-    ((Activity)context).getWindowManager().getDefaultDisplay().getMetrics(metrics);
+    /* Physical display size and xdpi/ydpi; getMetrics() can follow reduced
+       application window metrics on some devices (XCSoar #1784). */
+    ((Activity)context).getWindowManager().getDefaultDisplay()
+      .getRealMetrics(metrics);
 
     try {
       /* Clear the shutdown flag from any previous session so the


### PR DESCRIPTION
Fixes #1784

## Summary

Use `Display.getRealMetrics()` instead of `getMetrics()` when reading `DisplayMetrics` for the values passed to native code as startup DPI (`xdpi` / `ydpi` → `Display::ProvideDPI()`).

## Rationale

`getRealMetrics()` reflects the physical display. `getMetrics()` can follow reduced application window metrics on some devices or modes. XCSoar uses the default display density for global UI scaling (fonts, line widths, touch sizing).

This mitigates part of the scaling problems discussed in #1784. Boards that misreport `xdpi`/`ydpi` vs `densityDpi` may still need a follow-up (e.g. sanity check or manual override).

## Testing

- `make TARGET=ANDROID` (debug APK)
- Pixel 6: cold start log reports `Display dpi` consistent with `wm density` / `dumpsys`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved Android display DPI handling during startup to use physical display metrics, ensuring more accurate rendering calculations for device displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

