### PR TITLE
Fix/tab background

### DIFF
--- a/src/Form/TabDisplay.cpp
+++ b/src/Form/TabDisplay.cpp
@@ -233,14 +233,15 @@ TabDisplay::OnPaint(Canvas &canvas) noexcept
                ? DarkColor(look.background_color)
                : COLOR_BLACK);
 
-  const bool is_focused = !HasCursorKeys() || HasFocus();
   for (unsigned i = 0; i < buttons.size(); i++) {
     const auto &button = *buttons[i];
 
     const bool is_down = dragging && i == down_index && !drag_off_button;
     const bool is_selected = i == current_index;
 
-    button.Draw(canvas, look, is_focused, is_down, is_selected);
+    /* don't pass focus state to button drawing; the colored indicator
+       line below marks the selected tab independently */
+    button.Draw(canvas, look, false, is_down, is_selected);
   }
 
   if (!buttons.empty()) {

--- a/src/Form/TabDisplay.cpp
+++ b/src/Form/TabDisplay.cpp
@@ -8,7 +8,6 @@
 #include "ui/event/KeyCode.hpp"
 #include "ui/canvas/Icon.hpp"
 #include "ui/canvas/Canvas.hpp"
-#include "ui/canvas/Features.hpp"
 #include "Screen/Layout.hpp"
 #include "util/StaticString.hxx"
 #include "Asset.hpp"
@@ -230,10 +229,9 @@ TabDisplay::OnResize(PixelSize new_size) noexcept
 void
 TabDisplay::OnPaint(Canvas &canvas) noexcept
 {
-  if (HaveClipping())
-    canvas.Clear(look.dark_mode
-                 ? DarkColor(look.background_color)
-                 : COLOR_BLACK);
+  canvas.Clear(look.dark_mode
+               ? DarkColor(look.background_color)
+               : COLOR_BLACK);
 
   const bool is_focused = !HasCursorKeys() || HasFocus();
   for (unsigned i = 0; i < buttons.size(); i++) {


### PR DESCRIPTION
Pre- 8e95715f
<img width="414" height="466" alt="pre-8e95715f" src="https://github.com/user-attachments/assets/c526649e-d2a5-4223-ab3e-246ab513cfeb" />

Post- 8e95715f
<img width="393" height="505" alt="post-8e95715f" src="https://github.com/user-attachments/assets/e1bcce86-59c2-40d7-9556-9f76682cc071" />

This PR:
<img width="399" height="473" alt="fix" src="https://github.com/user-attachments/assets/b7f5562a-567a-49a5-aac0-fc436bc54f62" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined tab display rendering to improve canvas clearing behavior with dark-mode support.

* **Style**
  * Updated tab button appearance; focus state indicators removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->