### PR TITLE
Fix/flarm messaging

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -446,7 +446,13 @@ TEST_FLARM_MESSAGING_SOURCES = \
 	$(SRC)/FLARM/MessagingRecord.cpp \
 	$(SRC)/FLARM/MessagingDatabase.cpp \
 	$(SRC)/FLARM/MessagingFile.cpp \
+	$(SRC)/FLARM/Details.cpp \
+	$(SRC)/FLARM/Global.cpp \
+	$(SRC)/FLARM/TrafficDatabases.cpp \
+	$(SRC)/FLARM/FlarmNetDatabase.cpp \
+	$(SRC)/FLARM/NameDatabase.cpp \
 	$(SRC)/thread/Thread.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestFlarmMessaging.cpp
 TEST_FLARM_MESSAGING_DEPENDS = IO OS MATH UTIL THREAD

--- a/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
+++ b/src/Dialogs/Traffic/FlarmTrafficDetails.cpp
@@ -220,14 +220,14 @@ FlarmTrafficDetailsWidget::Update()
   const ResolvedInfo info = FlarmDetails::ResolveInfo(target_id);
 
   // Shared fields: pilot/plane/airfield direct from resolver
-  SetText(PILOT, info.pilot != nullptr ? info.pilot : "--");
+  SetText(PILOT, !info.pilot.empty() ? info.pilot.c_str() : "--");
 
-  const char *plane_value = info.plane_type;
+  const char *plane_value = !info.plane_type.empty() ? info.plane_type.c_str() : nullptr;
   if (plane_value == nullptr && target != nullptr)
     plane_value = FlarmTraffic::GetTypeString(target->type);
   SetText(PLANE, plane_value != nullptr ? plane_value : "--");
 
-  SetText(AIRPORT, info.airfield != nullptr ? info.airfield : "--");
+  SetText(AIRPORT, !info.airfield.empty() ? info.airfield.c_str() : "--");
 
   char fbuf[16];
   const char *freq = info.frequency.Format(fbuf, 16);
@@ -237,16 +237,15 @@ FlarmTrafficDetailsWidget::Update()
   // Fill the callsign field (+ registration)
   // note: don't use target->Name here since it is not updated
   //       yet if it was changed
-  const char* cs = info.callsign;
-  if (cs != nullptr && cs[0] != 0) {
+  if (!info.callsign.empty()) {
     try {
       BasicStringBuilder<char> builder(tmp, ARRAY_SIZE(tmp));
-      builder.Append(cs);
-      if (info.registration != nullptr)
-        builder.Append(" (", info.registration, ")");
+      builder.Append(info.callsign.c_str());
+      if (!info.registration.empty())
+        builder.Append(" (", info.registration.c_str(), ")");
       value = tmp;
     } catch (BasicStringBuilder<char>::Overflow) {
-      value = cs;
+      value = info.callsign.c_str();
     }
   } else
     value = "--";

--- a/src/Dialogs/Traffic/TrafficList.cpp
+++ b/src/Dialogs/Traffic/TrafficList.cpp
@@ -587,11 +587,11 @@ TrafficListWidget::OnPaintItem(Canvas &canvas, PixelRect rc,
   StaticString<256> tmp;
 
   if (item.IsFlarm()) {
-    if (info.callsign != nullptr && info.registration != nullptr)
+    if (!info.callsign.empty() && !info.registration.empty())
       tmp.Format("%s - %s - %s",
-                 info.callsign, info.registration, tmp_id);
-    else if (info.callsign != nullptr)
-      tmp.Format("%s - %s", info.callsign, tmp_id);
+                 info.callsign.c_str(), info.registration.c_str(), tmp_id);
+    else if (!info.callsign.empty())
+      tmp.Format("%s - %s", info.callsign.c_str(), tmp_id);
     else
       tmp.Format("%s", tmp_id);
 #ifdef HAVE_SKYLINES_TRACKING
@@ -650,21 +650,21 @@ TrafficListWidget::OnPaintItem(Canvas &canvas, PixelRect rc,
   if (!info.IsEmpty()) {
     tmp.clear();
 
-    if (info.pilot != nullptr)
-      tmp = info.pilot;
+    if (!info.pilot.empty())
+      tmp = info.pilot.c_str();
 
-    if (info.plane_type != nullptr) {
+    if (!info.plane_type.empty()) {
       if (!tmp.empty())
         tmp.append(" - ");
 
-      tmp.append(info.plane_type);
+      tmp.append(info.plane_type.c_str());
     }
 
-    if (info.airfield != nullptr) {
+    if (!info.airfield.empty()) {
       if (!tmp.empty())
         tmp.append(" - ");
 
-      tmp.append(info.airfield);
+      tmp.append(info.airfield.c_str());
     }
 
     if (!tmp.empty())

--- a/src/FLARM/Details.cpp
+++ b/src/FLARM/Details.cpp
@@ -78,7 +78,7 @@ FindIdsByCallSign(const char *cn, FlarmId array[], unsigned size) noexcept
 }
 
 ResolvedInfo
-ResolveInfo(FlarmId id) noexcept
+ResolveInfo(FlarmId id)
 {
   ResolvedInfo out;
   if (traffic_databases == nullptr)
@@ -87,29 +87,29 @@ ResolveInfo(FlarmId id) noexcept
   const auto msg = std::as_const(traffic_databases->flarm_messages).FindRecordById(id);
   const auto *net = traffic_databases->flarm_net.FindRecordById(id);
 
-  out.callsign = traffic_databases->FindNameById(id);
-
-  static thread_local StaticString<256> pilot_buf, plane_buf, reg_buf, airfield_buf;
+  const char *name = traffic_databases->FindNameById(id);
+  if (name != nullptr)
+    out.callsign = name;
 
   if (msg.has_value()) {
     out.source = ResolvedSource::MESSAGING;
 
-    out.pilot = msg->Format(pilot_buf, msg->pilot);
-    out.plane_type = msg->Format(plane_buf, msg->plane_type);
-    out.registration = msg->Format(reg_buf, msg->registration);
+    out.pilot = msg->pilot;
+    out.plane_type = msg->plane_type;
+    out.registration = msg->registration;
 
     if (msg->frequency.IsDefined())
       out.frequency = msg->frequency;
   } else if (net != nullptr) {
     out.source = ResolvedSource::FLARMNET;
 
-    out.pilot = net->Format(pilot_buf, net->pilot.c_str());
-    out.plane_type = net->Format(plane_buf, net->plane_type.c_str());
-    out.registration = net->Format(reg_buf, net->registration.c_str());
+    if (!net->pilot.empty()) out.pilot = net->pilot.c_str();
+    if (!net->plane_type.empty()) out.plane_type = net->plane_type.c_str();
+    if (!net->registration.empty()) out.registration = net->registration.c_str();
 
-    const char *af = net->Format(airfield_buf, net->airfield.c_str());
-    if (af != nullptr && (out.registration == nullptr || !StringIsEqual(af, out.registration)))
-      out.airfield = af;
+    if (!net->airfield.empty() &&
+        (out.registration.empty() || net->airfield != out.registration.c_str()))
+      out.airfield = net->airfield.c_str();
 
     if (net->frequency.IsDefined())
       out.frequency = net->frequency;

--- a/src/FLARM/Details.hpp
+++ b/src/FLARM/Details.hpp
@@ -4,6 +4,9 @@
 #pragma once
 
 #include "RadioFrequency.hpp"
+
+#include <string>
+
 class FlarmId;
 struct FlarmNetRecord;
 struct MessagingRecord;
@@ -17,16 +20,15 @@ enum class ResolvedSource : unsigned char {
 
 /**
  * Resolved human-readable FLARM fields plus metadata about their origin.
- * NOTE: returned pointers reference thread-local buffers owned by the resolver
- * call. They remain valid only until the next ResolveInfo() invocation on the
- * same thread and must not be cached or shared across threads.
+ * All string fields are owned copies that remain valid for the lifetime
+ * of this object.
  */
 struct ResolvedInfo {
-  const char *pilot = nullptr;
-  const char *plane_type = nullptr;
-  const char *registration = nullptr;
-  const char *callsign = nullptr;
-  const char *airfield = nullptr;  // FLARMnet-only
+  std::string pilot;
+  std::string plane_type;
+  std::string registration;
+  std::string callsign;
+  std::string airfield;  // FLARMnet-only
   RadioFrequency frequency = RadioFrequency::Null();
   ResolvedSource source = ResolvedSource::NONE;
 
@@ -34,11 +36,11 @@ struct ResolvedInfo {
    * Checks if any resolved information fields are available.
    */
   bool IsEmpty() const noexcept {
-    return pilot == nullptr &&
-           plane_type == nullptr &&
-           registration == nullptr &&
-           callsign == nullptr &&
-           airfield == nullptr;
+    return pilot.empty() &&
+           plane_type.empty() &&
+           registration.empty() &&
+           callsign.empty() &&
+           airfield.empty();
   }
 };
 
@@ -101,7 +103,7 @@ FindIdsByCallSign(const char *cn, FlarmId array[], unsigned size) noexcept;
  */
 [[gnu::pure]]
 ResolvedInfo
-ResolveInfo(FlarmId id) noexcept;
+ResolveInfo(FlarmId id);
 
 /**
  * Retrieves the localized string corresponding to the resolved source enum.

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -325,23 +325,22 @@ Draw(Canvas &canvas, PixelRect rc,
   const ResolvedInfo info = FlarmDetails::ResolveInfo(item.id);
 
   StaticString<256> title_string;
-  if (info.pilot != nullptr)
-    title_string = info.pilot;
+  if (!info.pilot.empty())
+    title_string = info.pilot.c_str();
   else
     title_string = _("FLARM Traffic");
 
   // Append name to the title, if it exists
-  const char *callsign = info.callsign;
-  if (callsign != nullptr && !StringIsEmpty(callsign)) {
+  if (!info.callsign.empty()) {
     title_string.append(", ");
-    title_string.append(callsign);
+    title_string.append(info.callsign.c_str());
   }
 
   row_renderer.DrawFirstRow(canvas, rc, title_string);
 
   StaticString<256> info_string;
-  if (info.plane_type != nullptr)
-    info_string = info.plane_type;
+  if (!info.plane_type.empty())
+    info_string = info.plane_type.c_str();
   else if (traffic != nullptr)
     info_string = FlarmTraffic::GetTypeString(traffic->type);
   else

--- a/test/src/TestFlarmMessaging.cpp
+++ b/test/src/TestFlarmMessaging.cpp
@@ -4,6 +4,9 @@
 #include "FLARM/MessagingFile.hpp"
 #include "FLARM/MessagingDatabase.hpp"
 #include "FLARM/MessagingRecord.hpp"
+#include "FLARM/Details.hpp"
+#include "FLARM/Global.hpp"
+#include "FLARM/TrafficDatabases.hpp"
 #include "FLARM/Id.hpp"
 #include "system/Path.hpp"
 #include "system/FileUtil.hpp"
@@ -57,6 +60,20 @@ UpdateMessagingRecord(FlarmMessagingDatabase &db, const MessagingRecord &base,
   if (callsign != nullptr)
     record.callsign = callsign;
   db.Update(record);
+}
+
+static void
+InsertMessaging(FlarmMessagingDatabase &db, const char *hex,
+                const char *pilot, const char *plane_type,
+                const char *registration, const char *callsign)
+{
+  MessagingRecord r;
+  r.id = FlarmId::Parse(hex, nullptr);
+  r.pilot = pilot;
+  r.plane_type = plane_type;
+  r.registration = registration;
+  r.callsign = callsign;
+  db.Insert(r);
 }
 
 static void
@@ -304,14 +321,48 @@ TestFlarmMessagingThreadSafety()
   }
 }
 
+static void
+TestFlarmMessagingResolveInfo()
+{
+  TrafficDatabases dbs;
+  traffic_databases = &dbs;
+
+  InsertMessaging(dbs.flarm_messages, "AA0001",
+                  "Orville", "ASW 28", "D-1111", "AA");
+  InsertMessaging(dbs.flarm_messages, "BB0002",
+                  "Wilbur", "Discus 2", "D-2222", "BB");
+
+  const ResolvedInfo info1 = FlarmDetails::ResolveInfo(FlarmId::Parse("AA0001", nullptr));
+  const ResolvedInfo info2 = FlarmDetails::ResolveInfo(FlarmId::Parse("BB0002", nullptr));
+
+  /* info1 must still carry Orville's data, not Wilbur's */
+  ok1(info1.pilot == "Orville");
+  ok1(info1.plane_type == "ASW 28");
+  ok1(info1.registration == "D-1111");
+  ok1(info1.callsign == "AA");
+  ok1(info1.source == ResolvedSource::MESSAGING);
+
+  ok1(info2.pilot == "Wilbur");
+  ok1(info2.plane_type == "Discus 2");
+  ok1(info2.registration == "D-2222");
+  ok1(info2.callsign == "BB");
+
+  /* unknown ID returns empty */
+  const ResolvedInfo empty = FlarmDetails::ResolveInfo(FlarmId::Parse("999999", nullptr));
+  ok1(empty.IsEmpty());
+
+  traffic_databases = nullptr;
+}
+
 int main()
 {
-  plan_tests(31);
+  plan_tests(41);
 
   TestFlarmMessagingIO();
   TestFlarmMessagingFile();
   TestFlarmMessagingCycle();
   TestFlarmMessagingThreadSafety();
+  TestFlarmMessagingResolveInfo();
 
   return exit_status();
 }

--- a/test/src/TestWrapText.cpp
+++ b/test/src/TestWrapText.cpp
@@ -4,7 +4,6 @@
 #include "ui/canvas/TextWrapper.hpp"
 #include "ui/canvas/AnyCanvas.hpp"
 #include "ui/canvas/Font.hpp"
-#include "ui/window/Init.hpp"
 #include "util/UTF8.hpp"
 #include "Screen/Layout.hpp"
 #include "Fonts.hpp"
@@ -157,8 +156,22 @@ TestLongUTF8Line(const Font &font) noexcept
 
 int main()
 {
-  ScreenGlobalInit screen_init;
-  Layout::Initialise(screen_init.GetDisplay(), {100, 100});
+  /* Avoid creating a full UI Display (and OpenGL/EGL) for this unit
+     test.  Initialise the minimal Layout globals and the font
+     subsystem directly. */
+  Layout::scale_1024 = 1024;
+  Layout::scale = 1;
+  Layout::font_scale = 1024;
+  Layout::vdpi = 72;
+  Layout::pt_scale = 1024;
+  Layout::vpt_scale = 1024;
+
+  /* mark screen initialized so components that assert on it succeed */
+  ScreenInitialized();
+
+#ifdef USE_FREETYPE
+  Font::Initialise();
+#endif
 
   InitialiseFonts();
 
@@ -179,6 +192,12 @@ int main()
   TestLongUTF8Line(normal_font);
 
   DeinitialiseFonts();
+
+#ifdef USE_FREETYPE
+  Font::Deinitialise();
+#endif
+
+  ScreenDeinitialized();
 
   return exit_status();
 }


### PR DESCRIPTION
I think going to std::string is the easiest way, even with the added overhead, which is probably negligible with the infrequent calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust FLARM traffic text handling: empty/missing fields are detected reliably and fallbacks/placeholder ("--") are used consistently in lists, maps, and detail views.

* **Tests**
  * Added unit tests covering FLARM messaging resolution and detail retrieval.

* **Chores**
  * Updated test build setup and internal data handling to support the above improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->