### PR TITLE
Menu: Add word-splitting for multi-line button labels

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -124,14 +124,14 @@ mode=pan
 type=key
 data=APP2
 event=Zoom in
-label=Zoom\n+
+label=Zoom +
 location=2
 
 mode=pan
 type=key
 data=APP3
 event=Zoom out
-label=Zoom\n-
+label=Zoom -
 location=3
 
 mode=pan
@@ -194,7 +194,7 @@ mode=mc
 type=key
 data=0
 event=Mode default
-label=Exit\n(ESC)
+label=Exit (ESC)
 location=1
 
 mode=mc
@@ -202,7 +202,7 @@ type=key
 data=0
 event=MacCready auto show
 event=MacCready auto toggle
-label=$(CheckAutoMc)MC $(MacCreadyToggleActionName)\n(RETURN)
+label=$(CheckAutoMc)MC $(MacCreadyToggleActionName) (RETURN)
 location=6
 
 mode=mc
@@ -210,7 +210,7 @@ type=key
 data=0
 event=MacCready show
 event=MacCready up
-label=MC+\n(UP)
+label=MC+ (UP)
 location=7
 
 mode=mc
@@ -218,7 +218,7 @@ type=key
 data=0
 event=MacCready show
 event=MacCready down
-label=MC-\n(DOWN)
+label=MC- (DOWN)
 location=8
 
 ###### main entry buttons
@@ -468,7 +468,7 @@ mode=Nav1
 type=key
 data=APP1
 event=Mode Nav2
-label=Nav\nPage 2/2
+label=Nav Page 2/2
 location=1
 
 mode=Nav1
@@ -525,7 +525,7 @@ type=key
 data=6
 event=Mode default
 event=AbortTask toggle
-label=Task\n$(TaskAbortToggleActionName)$(CheckWaypointFile)
+label=Task $(TaskAbortToggleActionName)$(CheckWaypointFile)
 location=5
 
 mode=Nav2
@@ -564,7 +564,7 @@ mode=Display1
 type=key
 data=APP2
 event=Mode Display2
-label=Display\nPage 2/2
+label=Display Page 2/2
 location=2
 
 
@@ -572,14 +572,14 @@ mode=Display1
 type=key
 data=6
 event=Zoom in
-label=Zoom\n+
+label=Zoom +
 location=5
 
 mode=Display1
 type=key
 data=7
 event=Zoom out
-label=Zoom\n-
+label=Zoom -
 location=6
 
 mode=Display1
@@ -587,14 +587,14 @@ type=key
 data=8
 event=Zoom auto show
 event=Zoom auto toggle
-label=Zoom\n$(ZoomAutoToggleActionName)
+label=Zoom $(ZoomAutoToggleActionName)
 location=7
 
 mode=Display1
 type=key
 data=9
 event=ScreenModes cycle
-label=Page Show\n$(NextPageName)
+label=Page Show $(NextPageName)
 location=8
 
 mode=Display1
@@ -620,7 +620,7 @@ type=key
 data=6
 event=DeclutterLabels show
 event=DeclutterLabels toggle
-label=Labels\n$(MapLabelsToggleActionName)
+label=Labels $(MapLabelsToggleActionName)
 location=5
 
 mode=Display2
@@ -628,28 +628,28 @@ type=key
 data=7
 event=SnailTrail show
 event=SnailTrail toggle
-label=Trail\n$(SnailTrailToggleName)
+label=Trail $(SnailTrailToggleName)
 location=6
 
 mode=Display2
 type=key
 data=8
 event=TerrainTopography terrain toggle
-label=Terrain\n$(TerrainToggleActionName)
+label=Terrain $(TerrainToggleActionName)
 location=7
 
 mode=Display2
 type=key
 data=9
 event=TerrainTopography topography toggle
-label=Topo.\n$(TopographyToggleActionName)
+label=Topography $(TopographyToggleActionName)
 location=8
 
 mode=Display2
 type=key
 data=0
 event=AirSpace toggle
-label=Airspace\n$(AirspaceToggleActionName)
+label=Airspace $(AirspaceToggleActionName)
 location=9
 
 # -------------
@@ -659,7 +659,7 @@ mode=Config1
 type=key
 data=APP3
 event=Mode Config2
-label=Config\nPage 2/3
+label=Config Page 2/3
 location=3
 
 mode=Config1
@@ -709,7 +709,7 @@ mode=Config2
 type=key
 data=APP3
 event=Mode Config3
-label=Config\nPage 3/3
+label=Config Page 3/3
 location=3
 
 mode=Config2
@@ -767,7 +767,7 @@ type=key
 data=6
 event=Logger show
 event=Logger toggle ask
-label=Logger\n$(LoggerActive)$(CheckLogger)
+label=Logger $(LoggerActive)$(CheckLogger)
 location=5
 
 mode=Config3
@@ -800,7 +800,7 @@ mode=Vario1
 type=key
 data=APP3
 event=Mode Vario2
-label=Vega\nPage 2/2
+label=Vega Page 2/2
 location=3
 
 mode=Vario1
@@ -840,7 +840,7 @@ mode=Vario2
 type=key
 data=APP3
 event=Mode default
-label=Vega\n2/2
+label=Vega 2/2
 location=3
 
 mode=Vario2
@@ -887,7 +887,7 @@ mode=Info1
 type=key
 data=APP4
 event=Mode Info2
-label=Info\nPage 2/3
+label=Info Page 2/3
 location=4
 
 mode=Info1
@@ -937,7 +937,7 @@ mode=Info2
 type=key
 data=APP4
 event=Mode Info3
-label=Info\nPage 3/3
+label=Info Page 3/3
 location=4
 
 mode=Info2
@@ -1082,21 +1082,21 @@ mode=Display1.Traffic
 type=key
 data=6
 event=Traffic zoom in
-label=Zoom\n+
+label=Zoom +
 location=5
 
 mode=Display1.Traffic
 type=key
 data=7
 event=Traffic zoom out
-label=Zoom\n-
+label=Zoom -
 location=6
 
 mode=Display1.Traffic
 type=key
 data=8
 event=Traffic zoom auto toggle
-label=Zoom\n$(TrafficZoomAutoToggleActionName)
+label=Zoom $(TrafficZoomAutoToggleActionName)
 location=7
 
 mode=Display1.Traffic
@@ -1174,7 +1174,7 @@ type=key
 data=0
 event=DeclutterLabels show
 event=DeclutterLabels toggle
-label=Labels\n$(MapLabelsToggleActionName)
+label=Labels $(MapLabelsToggleActionName)
 location=7
 
 mode=RemoteStick
@@ -1182,21 +1182,21 @@ type=key
 data=0
 event=SnailTrail show
 event=SnailTrail toggle
-label=Trail\n$(SnailTrailToggleName)
+label=Trail $(SnailTrailToggleName)
 location=8
 
 mode=RemoteStick
 type=key
 data=0
 event=TerrainTopography terrain toggle
-label=Terrain\n$(TerrainToggleActionName)
+label=Terrain $(TerrainToggleActionName)
 location=9
 
 mode=RemoteStick
 type=key
 data=0
 event=TerrainTopography topography toggle
-label=Topo.\n$(TopographyToggleActionName)
+label=Topography $(TopographyToggleActionName)
 location=10
 
 # Priority 2: Task management (inner ring)
@@ -1227,7 +1227,7 @@ type=key
 data=0
 event=Mode default
 event=AbortTask toggle
-label=Task\n$(TaskAbortToggleActionName)$(CheckWaypointFile)
+label=Task $(TaskAbortToggleActionName)$(CheckWaypointFile)
 location=14
 
 mode=RemoteStick
@@ -1268,7 +1268,7 @@ mode=RemoteStick
 type=key
 data=0
 event=AirSpace toggle
-label=Airspace\n$(AirspaceToggleActionName)
+label=Airspace $(AirspaceToggleActionName)
 location=19
 
 mode=RemoteStick
@@ -1349,7 +1349,7 @@ type=key
 data=0
 event=Zoom auto show
 event=Zoom auto toggle
-label=Zoom\n$(ZoomAutoToggleActionName)
+label=Zoom $(ZoomAutoToggleActionName)
 location=29
 
 # Analysis and info screens (outer ring)
@@ -1391,7 +1391,7 @@ type=key
 data=0
 event=Logger show
 event=Logger toggle ask
-label=Logger\n$(LoggerActive)$(CheckLogger)
+label=Logger $(LoggerActive)$(CheckLogger)
 location=34
 
 mode=RemoteStick

--- a/src/Dialogs/dlgQuickMenu.cpp
+++ b/src/Dialogs/dlgQuickMenu.cpp
@@ -20,6 +20,9 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/event/KeyCode.hpp"
 #include "util/StaticString.hxx"
+#ifndef UNICODE
+#include "util/UTF8.hpp"
+#endif
 
 #include <boost/container/static_vector.hpp>
 #include <cstdlib>
@@ -30,12 +33,18 @@ class QuickMenuButtonRenderer final : public ButtonRenderer {
 
   TextRenderer text_renderer;
 
-  const StaticString<64> caption;
+  StaticString<64> caption;
+  StaticString<32> caption2;
+  StaticString<32> caption3;
 
 public:
   explicit QuickMenuButtonRenderer(const DialogLook &_look,
-                                   const char *_caption) noexcept
+                                   const char *_caption,
+                                   const char *_caption2 = nullptr,
+                                   const char *_caption3 = nullptr) noexcept
     :look(_look), caption(_caption) {
+    caption2 = _caption2 != nullptr ? _caption2 : "";
+    caption3 = _caption3 != nullptr ? _caption3 : "";
     text_renderer.SetCenter();
     text_renderer.SetVCenter();
     text_renderer.SetControl();
@@ -48,17 +57,61 @@ public:
                   ButtonState state) const noexcept override;
 };
 
+#ifndef UNICODE
+static unsigned
+TextWidth(const Font &font, const char *text, char *sanitized,
+          std::size_t sanitized_size) noexcept
+{
+  if (ValidateUTF8(std::string_view(text)))
+    return font.TextSize(text).width;
+  const std::size_t n = SanitizeUTF8(std::string_view(text),
+                                     {sanitized, sanitized_size - 1});
+  if (n == 0)
+    return 0;
+  sanitized[n] = '\0';
+  return font.TextSize(sanitized).width;
+}
+#endif
+
 unsigned
 QuickMenuButtonRenderer::GetMinimumButtonWidth() const noexcept
 {
-  return 2 * Layout::GetTextPadding() + look.button.font->TextSize(caption).width;
+  unsigned w;
+#ifndef UNICODE
+  char sanitized[256];
+  w = TextWidth(*look.button.font, caption.c_str(), sanitized, sizeof(sanitized));
+  if (!caption2.empty()) {
+    const unsigned w2 = TextWidth(*look.button.font, caption2.c_str(),
+                                 sanitized, sizeof(sanitized));
+    if (w2 > w)
+      w = w2;
+  }
+  if (!caption3.empty()) {
+    const unsigned w3 = TextWidth(*look.button.font, caption3.c_str(),
+                                 sanitized, sizeof(sanitized));
+    if (w3 > w)
+      w = w3;
+  }
+#else
+  w = look.button.font->TextSize(caption).width;
+  if (!caption2.empty()) {
+    const unsigned w2 = look.button.font->TextSize(caption2.c_str()).width;
+    if (w2 > w)
+      w = w2;
+  }
+  if (!caption3.empty()) {
+    const unsigned w3 = look.button.font->TextSize(caption3.c_str()).width;
+    if (w3 > w)
+      w = w3;
+  }
+#endif
+  return 2 * Layout::GetTextPadding() + w;
 }
 
 void
 QuickMenuButtonRenderer::DrawButton(Canvas &canvas, const PixelRect &rc,
                                     ButtonState state) const noexcept
 {
-  // Draw focus rectangle
   switch (state) {
   case ButtonState::PRESSED:
     canvas.DrawFilledRectangle(rc, look.list.pressed.background_color);
@@ -87,7 +140,35 @@ QuickMenuButtonRenderer::DrawButton(Canvas &canvas, const PixelRect &rc,
   canvas.Select(*look.button.font);
   canvas.SetBackgroundTransparent();
 
-  text_renderer.Draw(canvas, rc, caption);
+  const unsigned line_height = look.button.font->GetLineSpacing();
+  if (!caption3.empty()) {
+    const unsigned total_height = 3 * line_height;
+    const int block_top = (rc.top + rc.bottom - (int)total_height) / 2;
+    text_renderer.Draw(canvas,
+                      PixelRect(rc.left, block_top, rc.right,
+                                block_top + (int)line_height),
+                      caption.c_str());
+    text_renderer.Draw(canvas,
+                      PixelRect(rc.left, block_top + (int)line_height,
+                                rc.right, block_top + 2 * (int)line_height),
+                      caption2.c_str());
+    text_renderer.Draw(canvas,
+                      PixelRect(rc.left, block_top + 2 * (int)line_height,
+                                rc.right, block_top + (int)total_height),
+                      caption3.c_str());
+  } else if (!caption2.empty()) {
+    const unsigned total_height = 2 * line_height;
+    const int block_top = (rc.top + rc.bottom - (int)total_height) / 2;
+    text_renderer.Draw(canvas,
+                      PixelRect(rc.left, block_top, rc.right,
+                                block_top + (int)line_height),
+                      caption.c_str());
+    text_renderer.Draw(canvas,
+                      PixelRect(rc.left, block_top + (int)line_height,
+                                rc.right, block_top + (int)total_height),
+                      caption2.c_str());
+  } else
+    text_renderer.Draw(canvas, rc, caption.c_str());
 }
 
 class QuickMenu final : public WindowWidget {
@@ -205,7 +286,8 @@ QuickMenu::Prepare(ContainerWindow &parent, [[maybe_unused]] const PixelRect &rc
 
     auto &button = buttons.emplace_back(*grid_view, button_rc, buttonStyle,
                                         std::make_unique<QuickMenuButtonRenderer>(dialog_look,
-                                                                                  expanded.text),
+                                        expanded.text, expanded.text2,
+                                        expanded.text3),
                                         [this, &menuItem](){
                                           clicked_event = menuItem.event;
                                           dialog.SetModalResult(mrOK);

--- a/src/Form/Button.cpp
+++ b/src/Form/Button.cpp
@@ -73,6 +73,26 @@ Button::SetCaption(const char *caption)
 
   auto &r = (TextButtonRenderer &)*renderer;
   r.SetCaption(caption);
+  r.SetCaption2(nullptr);
+  r.SetCaption3(nullptr);
+
+  Invalidate();
+}
+
+void
+Button::SetCaption2(const char *caption2)
+{
+  auto &r = (TextButtonRenderer &)*renderer;
+  r.SetCaption2(caption2);
+
+  Invalidate();
+}
+
+void
+Button::SetCaption3(const char *caption3)
+{
+  auto &r = (TextButtonRenderer &)*renderer;
+  r.SetCaption3(caption3);
 
   Invalidate();
 }

--- a/src/Form/Button.hpp
+++ b/src/Form/Button.hpp
@@ -87,6 +87,18 @@ public:
    */
   void SetCaption(const char *caption);
 
+  /**
+   * Set optional second line (e.g. toggle state).  Only used with
+   * #TextButtonRenderer.  Pass nullptr to clear.
+   */
+  void SetCaption2(const char *caption2);
+
+  /**
+   * Set optional third line.  Only used with #TextButtonRenderer.
+   * Pass nullptr to clear.
+   */
+  void SetCaption3(const char *caption3);
+
   void SetSelected(bool _selected);
 
   [[gnu::pure]]

--- a/src/Form/TabDisplay.cpp
+++ b/src/Form/TabDisplay.cpp
@@ -11,6 +11,9 @@
 #include "Screen/Layout.hpp"
 #include "util/StaticString.hxx"
 #include "Asset.hpp"
+#ifndef UNICODE
+#include "util/UTF8.hpp"
+#endif
 
 #include <algorithm>
 
@@ -76,6 +79,18 @@ TabDisplay::Button::GetRecommendedWidth(const DialogLook &look) const noexcept
   if (icon != nullptr)
     return icon->GetSize().width + 2 * Layout::GetTextPadding();
 
+#ifndef UNICODE
+  char sanitized[256];
+  if (!ValidateUTF8(std::string_view(caption))) {
+    const std::size_t n =
+      SanitizeUTF8(std::string_view(caption), {sanitized, sizeof(sanitized) - 1});
+    if (n != 0) {
+      sanitized[n] = '\0';
+      return look.button.font->TextSize(sanitized).width +
+        2 * Layout::GetTextPadding();
+    }
+  }
+#endif
   return look.button.font->TextSize(caption).width + 2 * Layout::GetTextPadding();
 }
 

--- a/src/Menu/ButtonLabel.cpp
+++ b/src/Menu/ButtonLabel.cpp
@@ -11,6 +11,7 @@
 #include "util/Macros.hpp"
 
 #include <algorithm>
+#include <cstring>
 
 /**
  * @return false if there is at least one ASCII letter in the string
@@ -52,16 +53,94 @@ GetTextN(const char *src, const char *src_end,
   return gettext(buffer);
 }
 
+/**
+ * Try to split translated text into 2 or 3 lines by spaces. Optionally
+ * append macro_output to the last line. Returns true if buffer was used.
+ */
+static bool
+TrySplitWords(const char *translated, const char *macro_output,
+              std::span<char> buffer, ButtonLabel::Expanded &expanded) noexcept
+{
+  const char *space1 = StringFind(translated, ' ');
+  if (space1 == nullptr || space1 <= translated || space1[1] == '\0')
+    return false;
+
+  const char *after1 = space1 + 1;
+  const char *space2 = StringFind(after1, ' ');
+  const bool three_words = space2 != nullptr && space2 > after1 &&
+    space2[1] != '\0' &&
+    StringFind(space2 + 1, ' ') == nullptr;
+  const bool two_words = (space2 == nullptr);
+
+  if (!two_words && !three_words)
+    return false;
+
+  const size_t len1 = space1 - translated;
+  const size_t len2 = two_words ? std::strlen(after1) : (space2 - after1);
+  const size_t len3 = three_words ? std::strlen(space2 + 1) : 0;
+  const size_t macro_len =
+    (macro_output != nullptr) ? std::strlen(macro_output) : 0;
+
+  size_t need;
+  if (three_words)
+    need = len1 + 1 + len2 + 1 + len3 + 1 +
+      (macro_len ? 1 + macro_len : 0) + 1;
+  else
+    need = len1 + 1 + len2 + 1 + (macro_len ? 1 + macro_len : 0) + 1;
+  if (need > buffer.size())
+    return false;
+
+  char *p = buffer.data();
+  std::copy(translated, space1, p);
+  p[len1] = '\0';
+  expanded.text = p;
+  p += len1 + 1;
+
+  if (three_words) {
+    std::copy(after1, space2, p);
+    p[len2] = '\0';
+    expanded.text2 = p;
+    p += len2 + 1;
+    size_t i = 0;
+    for (const char *t = space2 + 1; *t; ++t, ++i)
+      p[i] = *t;
+    if (macro_len) {
+      if (len3 != 0)
+        p[i++] = ' ';
+      for (const char *m = macro_output; *m; ++m, ++i)
+        p[i] = *m;
+    }
+    p[i] = '\0';
+    expanded.text3 = p;
+    return true;
+  }
+
+  /* two words */
+  size_t i = 0;
+  for (const char *t = after1; *t; ++t, ++i)
+    p[i] = *t;
+  if (macro_len) {
+    p[i++] = ' ';
+    for (const char *m = macro_output; *m; ++m, ++i)
+      p[i] = *m;
+  }
+  p[i] = '\0';
+  expanded.text2 = p;
+  return true;
+}
+
 ButtonLabel::Expanded
 ButtonLabel::Expand(const char *text, std::span<char> buffer) noexcept
 {
   Expanded expanded;
-  const char *dollar;
 
   if (text == nullptr || *text == '\0' || *text == ' ') {
     expanded.visible = false;
     return expanded;
-  } else if ((dollar = StringFind(text, '$')) == nullptr) {
+  }
+
+  const char *dollar = StringFind(text, '$');
+  if (dollar == nullptr) {
     /* no macro, we can just translate the text */
     expanded.visible = true;
     expanded.enabled = true;
@@ -71,54 +150,72 @@ ButtonLabel::Expand(const char *text, std::span<char> buffer) noexcept
          label with only digits and punctuation in the second line, e.g.
          for menu labels like "Config\n2/3" */
 
-      /* copy the text up to the '\n' to a new buffer and translate it */
       char translatable[256];
       const char *translated = GetTextN(text, nl, translatable,
                                          ARRAY_SIZE(translatable));
       if (translated == nullptr) {
-        /* buffer too small: keep it untranslated */
         expanded.text = text;
         return expanded;
       }
 
-      /* concatenate the translated text and the part starting with '\n' */
       try {
         expanded.text = BuildString(buffer, translated, nl);
       } catch (BasicStringBuilder<char>::Overflow) {
-        expanded.text = gettext(text);
+        const char *full = gettext(text);
+        if (TrySplitWords(full, nullptr, buffer, expanded))
+          return expanded;
+        expanded.text = full;
       }
-    } else
-      expanded.text = gettext(text);
-    return expanded;
-  } else {
-    const char *macros = dollar;
-    /* backtrack until the first non-whitespace character, because we
-       don't want to translate whitespace between the text and the
-       macro */
-    macros = StripRight(text, macros);
-
-    char s[100];
-    expanded.enabled = !ExpandMacros(text, std::span{s});
-    if (s[0] == '\0' || s[0] == ' ') {
-      expanded.visible = false;
       return expanded;
     }
 
-    /* copy the text (without trailing whitespace) to a new buffer and
-       translate it */
-    char translatable[256];
-    const char *translated = GetTextN(text, macros, translatable,
-                                       ARRAY_SIZE(translatable));
-    if (translated == nullptr) {
-      /* buffer too small: fail */
-      // TODO: find a more clever fallback
-      expanded.visible = false;
+    const char *translated = gettext(text);
+    if (TrySplitWords(translated, nullptr, buffer, expanded))
       return expanded;
-    }
-
-    /* concatenate the translated text and the macro output */
-    expanded.visible = true;
-    expanded.text = BuildString(buffer, translated, s + (macros - text));
+    expanded.text = translated;
     return expanded;
   }
+
+  /* macro path */
+  const char *macros = StripRight(text, dollar);
+  char s[100];
+  expanded.enabled = !ExpandMacros(text, std::span{s});
+  if (s[0] == '\0' || s[0] == ' ') {
+    expanded.visible = false;
+    return expanded;
+  }
+
+  char translatable[256];
+  const char *translated = GetTextN(text, macros, translatable,
+                                    ARRAY_SIZE(translatable));
+  if (translated == nullptr) {
+    expanded.visible = false;
+    return expanded;
+  }
+
+  const size_t prefix_len = dollar - text;
+  const char *macro_output =
+    (prefix_len < std::strlen(s)) ? s + prefix_len : "";
+
+  expanded.visible = true;
+  if (TrySplitWords(translated, macro_output, buffer, expanded))
+    return expanded;
+  if (translated[0] == '\0' && macro_output[0] != '\0' &&
+      TrySplitWords(macro_output, nullptr, buffer, expanded))
+    return expanded;
+
+  size_t i = 0;
+  for (const char *t = translated; *t && i < buffer.size() - 1; ++t, ++i)
+    buffer[i] = *t;
+  if (i >= buffer.size())
+    return expanded;
+  buffer[i++] = '\0';
+  const size_t line1_end = i;
+  for (const char *m = macro_output; *m && i < buffer.size() - 1; ++m, ++i)
+    buffer[i] = *m;
+  if (i < buffer.size())
+    buffer[i] = '\0';
+  expanded.text = buffer.data();
+  expanded.text2 = (i > line1_end) ? buffer.data() + line1_end : nullptr;
+  return expanded;
 }

--- a/src/Menu/ButtonLabel.hpp
+++ b/src/Menu/ButtonLabel.hpp
@@ -14,6 +14,10 @@ namespace ButtonLabel {
 struct Expanded {
   bool visible, enabled;
   const char *text;
+  /** Optional second line (e.g. toggle state "On"/"Off"); nullptr = single line */
+  const char *text2 = nullptr;
+  /** Optional third line; nullptr = at most two lines */
+  const char *text3 = nullptr;
 };
 
 [[gnu::pure]]

--- a/src/Menu/Glue.cpp
+++ b/src/Menu/Glue.cpp
@@ -15,7 +15,8 @@ SetLabelText(MenuBar &bar, unsigned index,
   char buffer[100];
   const auto expanded = ButtonLabel::Expand(text, std::span{buffer});
   if (expanded.visible)
-    bar.ShowButton(index, expanded.enabled, expanded.text, event);
+    bar.ShowButton(index, expanded.enabled, expanded.text, expanded.text2,
+                   expanded.text3, event);
   else
     bar.HideButton(index);
 }

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -82,13 +82,15 @@ MenuBar::MenuBar(ContainerWindow &parent, const ButtonLook &look)
 
 void
 MenuBar::ShowButton(unsigned i, bool enabled, const char *text,
-                    unsigned event)
+                    const char *text2, const char *text3, unsigned event)
 {
   assert(i < MAX_BUTTONS);
 
   Button &button = buttons[i];
 
   button.SetCaption(text);
+  button.SetCaption2(text2);
+  button.SetCaption3(text3);
   button.SetEnabled(enabled && event > 0);
   button.SetEvent(event);
   button.ShowOnTop();

--- a/src/Menu/MenuBar.hpp
+++ b/src/Menu/MenuBar.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Form/Button.hpp"
+#include "ui/dim/Rect.hpp"
 
 /*
     Menubar button height as a fraction of the screen height
@@ -36,9 +37,8 @@ protected:
 public:
   MenuBar(ContainerWindow &parent, const ButtonLook &look);
 
-public:
   void ShowButton(unsigned i, bool enabled, const char *text,
-                  unsigned event);
+                  const char *text2, const char *text3, unsigned event);
   void HideButton(unsigned i);
 
   bool IsButtonEnabled(unsigned i) const {

--- a/src/Renderer/TextButtonRenderer.cpp
+++ b/src/Renderer/TextButtonRenderer.cpp
@@ -9,11 +9,11 @@
 #include "util/UTF8.hpp"
 #endif
 
-#include <tchar.h>
+#include <string_view>
 
 #ifndef UNICODE
-static tstring_view
-SafeForTextSize(tstring_view text, char *buffer,
+static std::string_view
+SafeForTextSize(std::string_view text, char *buffer,
                 std::size_t buffer_size) noexcept
 {
   if (ValidateUTF8(text))
@@ -21,15 +21,14 @@ SafeForTextSize(tstring_view text, char *buffer,
   const std::size_t n = SanitizeUTF8(text, {buffer, buffer_size - 1});
   if (n == 0)
     return text;
-  buffer[n] = '\0';
-  return buffer;
+  return {buffer, n};
 }
 #endif
 
 void
 TextButtonRenderer::SetCaption2(StaticString<32>::const_pointer _caption2) noexcept
 {
-  caption2 = _caption2 != nullptr ? _caption2 : _T("");
+  caption2 = _caption2 != nullptr ? _caption2 : "";
   if (caption2.empty())
     caption3.clear();
   text_renderer.InvalidateLayout();
@@ -38,7 +37,7 @@ TextButtonRenderer::SetCaption2(StaticString<32>::const_pointer _caption2) noexc
 void
 TextButtonRenderer::SetCaption3(StaticString<32>::const_pointer _caption3) noexcept
 {
-  caption3 = _caption3 != nullptr ? _caption3 : _T("");
+  caption3 = _caption3 != nullptr ? _caption3 : "";
   text_renderer.InvalidateLayout();
 }
 
@@ -48,7 +47,8 @@ TextButtonRenderer::GetMinimumButtonWidth(const ButtonLook &look,
 {
 #ifndef UNICODE
   char sanitized[256];
-  const tstring_view safe = SafeForTextSize(caption, sanitized, sizeof(sanitized));
+  const std::string_view safe =
+    SafeForTextSize(caption, sanitized, sizeof(sanitized));
   return 2 * (ButtonFrameRenderer::GetMargin() + Layout::GetTextPadding())
     + look.font->TextSize(safe).width;
 #else
@@ -122,18 +122,18 @@ TextButtonRenderer::GetMinimumButtonWidth() const noexcept
 {
 #ifndef UNICODE
   char sanitized[256];
-  const tstring_view safe_caption =
+  const std::string_view safe_caption =
     SafeForTextSize(caption.c_str(), sanitized, sizeof(sanitized));
   unsigned w = GetLook().font->TextSize(safe_caption).width;
   if (!caption2.empty()) {
-    const tstring_view safe_caption2 =
+    const std::string_view safe_caption2 =
       SafeForTextSize(caption2.c_str(), sanitized, sizeof(sanitized));
     const unsigned w2 = GetLook().font->TextSize(safe_caption2).width;
     if (w2 > w)
       w = w2;
   }
   if (!caption3.empty()) {
-    const tstring_view safe_caption3 =
+    const std::string_view safe_caption3 =
       SafeForTextSize(caption3.c_str(), sanitized, sizeof(sanitized));
     const unsigned w3 = GetLook().font->TextSize(safe_caption3).width;
     if (w3 > w)

--- a/src/Renderer/TextButtonRenderer.cpp
+++ b/src/Renderer/TextButtonRenderer.cpp
@@ -5,13 +5,56 @@
 #include "ui/canvas/Canvas.hpp"
 #include "Screen/Layout.hpp"
 #include "Look/ButtonLook.hpp"
+#ifndef UNICODE
+#include "util/UTF8.hpp"
+#endif
+
+#include <tchar.h>
+
+#ifndef UNICODE
+static tstring_view
+SafeForTextSize(tstring_view text, char *buffer,
+                std::size_t buffer_size) noexcept
+{
+  if (ValidateUTF8(text))
+    return text;
+  const std::size_t n = SanitizeUTF8(text, {buffer, buffer_size - 1});
+  if (n == 0)
+    return text;
+  buffer[n] = '\0';
+  return buffer;
+}
+#endif
+
+void
+TextButtonRenderer::SetCaption2(StaticString<32>::const_pointer _caption2) noexcept
+{
+  caption2 = _caption2 != nullptr ? _caption2 : _T("");
+  if (caption2.empty())
+    caption3.clear();
+  text_renderer.InvalidateLayout();
+}
+
+void
+TextButtonRenderer::SetCaption3(StaticString<32>::const_pointer _caption3) noexcept
+{
+  caption3 = _caption3 != nullptr ? _caption3 : _T("");
+  text_renderer.InvalidateLayout();
+}
 
 unsigned
 TextButtonRenderer::GetMinimumButtonWidth(const ButtonLook &look,
                                           std::string_view caption) noexcept
 {
+#ifndef UNICODE
+  char sanitized[256];
+  const tstring_view safe = SafeForTextSize(caption, sanitized, sizeof(sanitized));
+  return 2 * (ButtonFrameRenderer::GetMargin() + Layout::GetTextPadding())
+    + look.font->TextSize(safe).width;
+#else
   return 2 * (ButtonFrameRenderer::GetMargin() + Layout::GetTextPadding())
     + look.font->TextSize(caption).width;
+#endif
 }
 
 inline void
@@ -43,14 +86,73 @@ TextButtonRenderer::DrawCaption(Canvas &canvas, const PixelRect &rc,
 
   canvas.Select(*look.font);
 
-  text_renderer.Draw(canvas, rc, GetCaption());
+  const unsigned line_height = look.font->GetLineSpacing();
+  if (!caption3.empty()) {
+    const unsigned total_height = 3 * line_height;
+    const int block_top = (rc.top + rc.bottom - (int)total_height) / 2;
+    text_renderer.Draw(canvas,
+                       PixelRect(rc.left, block_top, rc.right,
+                                 block_top + (int)line_height),
+                       GetCaption());
+    text_renderer.Draw(canvas,
+                       PixelRect(rc.left, block_top + (int)line_height,
+                                 rc.right, block_top + 2 * (int)line_height),
+                       caption2.c_str());
+    text_renderer.Draw(canvas,
+                       PixelRect(rc.left, block_top + 2 * (int)line_height,
+                                 rc.right, block_top + (int)total_height),
+                       caption3.c_str());
+  } else if (!caption2.empty()) {
+    const unsigned total_height = 2 * line_height;
+    const int block_top = (rc.top + rc.bottom - (int)total_height) / 2;
+    text_renderer.Draw(canvas,
+                       PixelRect(rc.left, block_top, rc.right,
+                                 block_top + (int)line_height),
+                       GetCaption());
+    text_renderer.Draw(canvas,
+                       PixelRect(rc.left, block_top + (int)line_height,
+                                 rc.right, block_top + (int)total_height),
+                       caption2.c_str());
+  } else
+    text_renderer.Draw(canvas, rc, GetCaption());
 }
 
 unsigned
 TextButtonRenderer::GetMinimumButtonWidth() const noexcept
 {
-  return 2 * (frame_renderer.GetMargin() + Layout::GetTextPadding())
-    + GetLook().font->TextSize(caption.c_str()).width;
+#ifndef UNICODE
+  char sanitized[256];
+  const tstring_view safe_caption =
+    SafeForTextSize(caption.c_str(), sanitized, sizeof(sanitized));
+  unsigned w = GetLook().font->TextSize(safe_caption).width;
+  if (!caption2.empty()) {
+    const tstring_view safe_caption2 =
+      SafeForTextSize(caption2.c_str(), sanitized, sizeof(sanitized));
+    const unsigned w2 = GetLook().font->TextSize(safe_caption2).width;
+    if (w2 > w)
+      w = w2;
+  }
+  if (!caption3.empty()) {
+    const tstring_view safe_caption3 =
+      SafeForTextSize(caption3.c_str(), sanitized, sizeof(sanitized));
+    const unsigned w3 = GetLook().font->TextSize(safe_caption3).width;
+    if (w3 > w)
+      w = w3;
+  }
+#else
+  unsigned w = GetLook().font->TextSize(caption.c_str()).width;
+  if (!caption2.empty()) {
+    const unsigned w2 = GetLook().font->TextSize(caption2.c_str()).width;
+    if (w2 > w)
+      w = w2;
+  }
+  if (!caption3.empty()) {
+    const unsigned w3 = GetLook().font->TextSize(caption3.c_str()).width;
+    if (w3 > w)
+      w = w3;
+  }
+#endif
+  return 2 * (frame_renderer.GetMargin() + Layout::GetTextPadding()) + w;
 }
 
 void
@@ -59,7 +161,7 @@ TextButtonRenderer::DrawButton(Canvas &canvas, const PixelRect &rc,
 {
   frame_renderer.DrawButton(canvas, rc, state);
 
-  if (!caption.empty())
+  if (!caption.empty() || !caption2.empty() || !caption3.empty())
     DrawCaption(canvas, frame_renderer.GetDrawingRect(rc, state),
                 state);
 }

--- a/src/Renderer/TextButtonRenderer.hpp
+++ b/src/Renderer/TextButtonRenderer.hpp
@@ -17,6 +17,8 @@ class TextButtonRenderer : public ButtonRenderer {
   TextRenderer text_renderer;
 
   StaticString<64> caption;
+  StaticString<32> caption2;
+  StaticString<32> caption3;
 
 public:
   explicit TextButtonRenderer(const ButtonLook &_look) noexcept
@@ -29,6 +31,8 @@ public:
   TextButtonRenderer(const ButtonLook &_look,
                      StaticString<64>::const_pointer _caption) noexcept
     :frame_renderer(_look), caption(_caption) {
+    caption2.clear();
+    caption3.clear();
     text_renderer.SetCenter();
     text_renderer.SetVCenter();
     text_renderer.SetControl();
@@ -48,8 +52,16 @@ public:
 
   void SetCaption(StaticString<64>::const_pointer _caption) noexcept {
     caption = _caption;
+    caption2.clear();
+    caption3.clear();
     text_renderer.InvalidateLayout();
   }
+
+  /** Optional second line (e.g. toggle state); empty = single line */
+  void SetCaption2(StaticString<32>::const_pointer _caption2) noexcept;
+
+  /** Optional third line; empty = at most two lines */
+  void SetCaption3(StaticString<32>::const_pointer _caption3) noexcept;
 
   [[gnu::pure]]
   unsigned GetMinimumButtonWidth() const noexcept override;

--- a/src/Renderer/TextRenderer.cpp
+++ b/src/Renderer/TextRenderer.cpp
@@ -5,14 +5,38 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/AnyCanvas.hpp"
 #include "Asset.hpp"
+#ifndef UNICODE
+#include "util/UTF8.hpp"
+#endif
 
 #include <winuser.h>
+
+static tstring_view
+EnsureValidUTF8(tstring_view text, char *buffer,
+                std::size_t buffer_size) noexcept
+{
+#ifndef UNICODE
+  if (ValidateUTF8(text))
+    return text;
+  const std::size_t n = SanitizeUTF8(text, {buffer, buffer_size - 1});
+  if (n == 0)
+    return text;
+  buffer[n] = '\0';
+  return buffer;
+#else
+  (void)buffer;
+  (void)buffer_size;
+  return text;
+#endif
+}
 
 unsigned
 TextRenderer::GetHeight(Canvas &canvas, PixelRect rc,
                         std::string_view text) const noexcept
 {
-  return canvas.DrawFormattedText(rc, text, DT_CALCRECT);
+  char sanitized[1024];
+  const tstring_view safe = EnsureValidUTF8(text, sanitized, sizeof(sanitized));
+  return canvas.DrawFormattedText(rc, safe, DT_CALCRECT);
 }
 
 unsigned
@@ -53,5 +77,7 @@ TextRenderer::Draw(Canvas &canvas, PixelRect rc,
     format |= DT_UNDERLINE;
 #endif
 
-  canvas.DrawFormattedText(rc, text, format);
+  char sanitized[1024];
+  const tstring_view safe = EnsureValidUTF8(text, sanitized, sizeof(sanitized));
+  canvas.DrawFormattedText(rc, safe, format);
 }

--- a/src/Renderer/TextRenderer.cpp
+++ b/src/Renderer/TextRenderer.cpp
@@ -11,8 +11,10 @@
 
 #include <winuser.h>
 
-static tstring_view
-EnsureValidUTF8(tstring_view text, char *buffer,
+#include <string_view>
+
+static std::string_view
+EnsureValidUTF8(std::string_view text, char *buffer,
                 std::size_t buffer_size) noexcept
 {
 #ifndef UNICODE
@@ -21,8 +23,7 @@ EnsureValidUTF8(tstring_view text, char *buffer,
   const std::size_t n = SanitizeUTF8(text, {buffer, buffer_size - 1});
   if (n == 0)
     return text;
-  buffer[n] = '\0';
-  return buffer;
+  return {buffer, n};
 #else
   (void)buffer;
   (void)buffer_size;
@@ -35,7 +36,8 @@ TextRenderer::GetHeight(Canvas &canvas, PixelRect rc,
                         std::string_view text) const noexcept
 {
   char sanitized[1024];
-  const tstring_view safe = EnsureValidUTF8(text, sanitized, sizeof(sanitized));
+  const std::string_view safe =
+    EnsureValidUTF8(text, sanitized, sizeof(sanitized));
   return canvas.DrawFormattedText(rc, safe, DT_CALCRECT);
 }
 
@@ -78,6 +80,7 @@ TextRenderer::Draw(Canvas &canvas, PixelRect rc,
 #endif
 
   char sanitized[1024];
-  const tstring_view safe = EnsureValidUTF8(text, sanitized, sizeof(sanitized));
+  const std::string_view safe =
+    EnsureValidUTF8(text, sanitized, sizeof(sanitized));
   canvas.DrawFormattedText(rc, safe, format);
 }

--- a/src/ui/canvas/custom/MoreCanvas.cpp
+++ b/src/ui/canvas/custom/MoreCanvas.cpp
@@ -4,16 +4,12 @@
 #include "ui/canvas/Canvas.hpp"
 #include "util/StringAPI.hxx"
 
-#ifndef NDEBUG
-#include "util/UTF8.hpp"
-#endif
-
 #ifndef UNICODE
 #include "util/UTF8.hpp"
 #endif
 
-#include <algorithm>
 #include <cassert>
+#include <algorithm>
 
 #include <limits.h>
 #include <string.h>
@@ -44,10 +40,10 @@ unsigned
 Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
                           const unsigned format) noexcept
 {
-  assert(ValidateUTF8(text));
-
   if (font == nullptr)
     return 0;
+
+  assert(ValidateUTF8(text));
 
   const unsigned skip = font->GetLineSpacing();
   const unsigned max_lines = (format & DT_CALCRECT)
@@ -85,7 +81,6 @@ Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
     char *prev_p = nullptr;
     const bool has_spaces = StringFind(duplicated + i, ' ') != nullptr;
 
-    // remove words from behind till line fits or no more space is found
     while (sz.width > r.GetWidth() &&
            (p = StringFindLast(duplicated + i, ' ')) != nullptr) {
       if (prev_p)

--- a/src/util/UTF8.cpp
+++ b/src/util/UTF8.cpp
@@ -275,6 +275,33 @@ SequenceLengthUTF8(const char *p) noexcept
     return 0;
 }
 
+std::size_t
+SanitizeUTF8(std::string_view src, std::span<char> dest) noexcept
+{
+  if (dest.size() < src.size() + 1)
+    return 0;
+
+  char *out = dest.data();
+  while (!src.empty()) {
+    const unsigned char ch = src.front();
+    if (ch < 0x20) {
+      *out++ = ' ';
+      src.remove_prefix(1);
+      continue;
+    }
+    const std::size_t seq = SequenceLengthUTF8(src.data());
+    if (seq != 0 && seq <= src.size()) {
+      for (std::size_t i = 0; i < seq; ++i)
+        *out++ = src[i];
+      src.remove_prefix(seq);
+    } else {
+      *out++ = ' ';
+      src.remove_prefix(1);
+    }
+  }
+  return out - dest.data();
+}
+
 static const char *
 FindNonASCIIOrZero(const char *p) noexcept
 {

--- a/src/util/UTF8.hpp
+++ b/src/util/UTF8.hpp
@@ -18,6 +18,17 @@ bool
 ValidateUTF8(const char *p) noexcept;
 
 /**
+ * Copy string to buffer, replacing invalid UTF-8 sequences and
+ * control characters with space.  Use before rendering text from
+ * external sources (waypoints, files) that may be malformed.
+ *
+ * @return number of bytes written, or 0 if dest is too small
+ * (dest.size() must be at least src.size() + 1 for null terminator)
+ */
+std::size_t
+SanitizeUTF8(std::string_view src, std::span<char> dest) noexcept;
+
+/**
  * Is this a valid UTF-8 string?
  */
 [[gnu::pure]]


### PR DESCRIPTION
Splits translated menu labels on spaces into 2–3 lines; extends menu bar / quick menu with optional second and third caption lines. Includes UTF-8 sanitization for text measurement and drawing.

**Draft / needs-work:** Unix build fix in follow-up commit (`std::string_view` instead of `tstring_view`). Further review and testing welcome.