### PR TITLE
Consistently show ACK status and buttons of airspaces in lists

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -23,6 +23,9 @@ Version 7.45 - not yet released
   - status: show G-load availability in device list and variometer source in
     system status
   - terrain: add new terrain shading orientation "fixed (Top Left)"
+  - airspace list & map item list: grey text for airspaces with a day
+    acknowledgement; map item list adds an "Enable" button to clear it (like the
+    airspace warnings list) #2404
   - Form/DataField/Enum: remove the limit of 128 internal entries (It was
     dropping the newest InfoBoxes, as we have 130 of them now)
 * calculations

--- a/src/Dialogs/Airspace/AirspaceList.cpp
+++ b/src/Dialogs/Airspace/AirspaceList.cpp
@@ -26,6 +26,8 @@
 #include "Blackboard/BlackboardListener.hpp"
 #include "Language/Language.hpp"
 #include "util/StringCompare.hxx"
+#include "Airspace/ProtectedAirspaceWarningManager.hpp"
+#include "ui/canvas/Canvas.hpp"
 
 #include <cassert>
 #include <stdio.h>
@@ -334,6 +336,12 @@ AirspaceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   assert(i < items.size());
 
   const AbstractAirspace &airspace = items[i].GetAirspace();
+
+  if (airspace_warnings != nullptr &&
+      airspace_warnings->GetAckDay(airspace))
+    canvas.SetTextColor(COLOR_GRAY);
+  else
+    canvas.SetTextColor(UIGlobals::GetDialogLook().list.text_color);
 
   AirspaceListRenderer::Draw(
       canvas, rc, airspace,

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -19,6 +19,7 @@
 #include "Weather/Features.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
+#include "Look/DialogLook.hpp"
 #include "Interface.hpp"
 #include "UIGlobals.hpp"
 #include "Components.hpp"
@@ -213,6 +214,16 @@ MapItemListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                                unsigned idx) noexcept
 {
   const MapItem &item = *list[idx];
+
+  if (item.type == MapItem::Type::AIRSPACE &&
+      backend_components != nullptr &&
+      backend_components->GetAirspaceWarnings() != nullptr &&
+      backend_components->GetAirspaceWarnings()->GetAckDay(
+        *static_cast<const AirspaceMapItem &>(item).airspace))
+    canvas.SetTextColor(COLOR_GRAY);
+  else
+    canvas.SetTextColor(dialog_look.list.text_color);
+
   renderer.Draw(canvas, rc, item,
                 &CommonInterface::Basic().flarm.traffic);
 

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -74,7 +74,7 @@ class MapItemListWidget final
   MapItemListRenderer renderer;
 
   Button *settings_button, *details_button, *cancel_button, *goto_button;
-  Button *ack_button;
+  Button *ack_button, *enable_button;
 
 public:
   void CreateButtons(WidgetDialog &dialog);
@@ -101,10 +101,12 @@ protected:
     details_button->SetEnabled(HasDetails(*list[current]));
     goto_button->SetEnabled(CanGotoItem(current));
     ack_button->SetEnabled(CanAckItem(current));
+    enable_button->SetEnabled(CanEnableItem(current));
   }
 
   void OnGotoClicked();
   void OnAckClicked();
+  void OnEnableClicked();
 
 public:
   /* virtual methods from class Widget */
@@ -148,6 +150,21 @@ public:
       !backend_components->GetAirspaceWarnings()->GetAckDay(*as_item.airspace);
   }
 
+  bool CanEnableItem(unsigned index) const noexcept {
+    return CanEnableItem(*list[index]);
+  }
+
+  static bool CanEnableItem(const MapItem &item) noexcept {
+    if (backend_components == nullptr)
+      return false;
+
+    const AirspaceMapItem &as_item = (const AirspaceMapItem &)item;
+
+    return item.type == MapItem::Type::AIRSPACE &&
+      backend_components->GetAirspaceWarnings() != nullptr &&
+      backend_components->GetAirspaceWarnings()->GetAckDay(*as_item.airspace);
+  }
+
   void OnActivateItem(unsigned index) noexcept override;
 };
 
@@ -162,6 +179,10 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog)
 
   ack_button = dialog.AddButton(_("Ack Day"), [this](){
     OnAckClicked();
+  });
+
+  enable_button = dialog.AddButton(_("Enable"), [this](){
+    OnEnableClicked();
   });
 
   settings_button = dialog.AddButton(_("Settings"), [](){
@@ -307,6 +328,16 @@ MapItemListWidget::OnAckClicked()
   const AirspaceMapItem &as_item = *(const AirspaceMapItem *)
     list[GetCursorIndex()];
   backend_components->GetAirspaceWarnings()->AcknowledgeDay(as_item.airspace);
+  UpdateButtons();
+}
+
+inline void
+MapItemListWidget::OnEnableClicked()
+{
+  const AirspaceMapItem &as_item = *(const AirspaceMapItem *)
+    list[GetCursorIndex()];
+  backend_components->GetAirspaceWarnings()->AcknowledgeDay(as_item.airspace,
+                                                            false);
   UpdateButtons();
 }
 


### PR DESCRIPTION
Airspaces are shown in lists in three different places:

1. The airspace warning list
2. The map item list ("what is here")
3. The airspace list (Info->Info->Info->Airspaces)

In the warning list, airspaces that are "acknowledged" (warnings disabled) are shown with grey text color. In the other two the ACK status is not indicated (even though the map item list has a button to ACK the selected airspace.

This PR implements grey rendering for all three lists for ACK'ed airspaces.

In addition, the map item list had a button to set ACK status, but no button to remove that status. This PR also adds an "enable" button to remove ACK status from an airspace, same as the "enable" button in the airspace warning list.

map item list dialog:
<img width="326" height="292" alt="Screenshot1" src="https://github.com/user-attachments/assets/4832d1b1-c9e0-4653-a9f9-86ae002f0ffb" />

airspace list dialog:
<img width="327" height="292" alt="Screenshot2" src="https://github.com/user-attachments/assets/2a79b551-f86b-4e14-ad1e-e260b4508cd7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Enable" button in the map item list to re-enable previously acknowledged airspace items; button is active only for acknowledged airspace.

* **Style**
  * Acknowledged airspace items now display in gray text in lists to indicate acknowledged status.

* **Documentation**
  * Added NEWS entry describing the UI changes above.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->