### PR TITLE
Touch text entry: cursor-key navigation and resize

### DIFF
--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -7,17 +7,98 @@
 #include "Form/Button.hpp"
 #include "Form/Edit.hpp"
 #include "Widget/KeyboardWidget.hpp"
+#include "Asset.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/event/KeyCode.hpp"
 #include "UIGlobals.hpp"
 #include "Language/Language.hpp"
 #include "util/StringCompare.hxx"
 #include "util/TruncateString.hpp"
+#include "ui/window/Window.hpp"
 
 #include <algorithm>
 
+namespace {
+struct TextEntryLayout {
+  PixelRect editor;
+  PixelRect backspace;
+  PixelRect keyboard;
+  PixelRect ok, cancel, clear;
+};
+
+static void
+ComputeTextEntryLayout(const PixelRect &rc, TextEntryLayout &o) noexcept
+{
+  const int client_height = rc.GetHeight();
+  const int padding = Layout::Scale(2);
+  const int backspace_width = Layout::Scale(36);
+  const int backspace_left = rc.right - padding - backspace_width;
+  const int editor_height = Layout::Scale(22);
+  const int editor_bottom = padding + editor_height;
+  const int button_height = Layout::Scale(40);
+  constexpr unsigned keyboard_rows = 5u;
+  const int keyboard_top = editor_bottom + padding;
+  const int keyboard_height = int(keyboard_rows) * button_height;
+  const int keyboard_bottom = keyboard_top + keyboard_height;
+
+  const bool vertical = client_height >= keyboard_bottom + button_height;
+
+  const int button_top = vertical
+    ? rc.bottom - button_height
+    : keyboard_bottom - button_height;
+  const int button_bottom = vertical
+    ? rc.bottom
+    : keyboard_bottom;
+
+  const int ok_left = vertical ? 0 : padding;
+  const int ok_right = vertical
+    ? rc.right / 3
+    : ok_left + Layout::Scale(80);
+
+  const int cancel_left = vertical
+    ? ok_right
+    : Layout::Scale(175);
+  const int cancel_right = vertical
+    ? rc.right * 2 / 3
+    : cancel_left + Layout::Scale(60);
+
+  const int clear_left = vertical
+    ? cancel_right
+    : Layout::Scale(235);
+  const int clear_right = vertical
+    ? rc.right
+    : clear_left + Layout::Scale(50);
+
+  o.editor = {0, padding, backspace_left - padding, editor_bottom};
+  o.backspace = {backspace_left, padding, rc.right - padding, editor_bottom};
+  o.keyboard = {padding, keyboard_top, rc.right - padding, keyboard_bottom};
+  o.ok = {ok_left, button_top, ok_right, button_bottom};
+  o.cancel = {cancel_left, button_top, cancel_right, button_bottom};
+  o.clear = {clear_left, button_top, clear_right, button_bottom};
+}
+
+static void
+ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
+                     Button &cancel, Button &clear, KeyboardWidget &keyboard,
+                     Button &backspace, ContainerWindow &client_area) noexcept
+{
+  editor.Move(L.editor);
+  ok.Move(L.ok);
+  cancel.Move(L.cancel);
+  clear.Move(L.clear);
+  keyboard.Move(L.keyboard);
+  backspace.Move(L.backspace);
+  client_area.Invalidate();
+}
+} // namespace
+
 static WndProperty *editor;
 static KeyboardWidget *kb = NULL;
+static ContainerWindow *textentry_client = NULL;
+static Button *textentry_backspace = NULL;
+static Button *textentry_ok = NULL;
+static Button *textentry_cancel = NULL;
+static Button *textentry_clear = NULL;
 
 static AllowedCharacters AllowedCharactersCallback;
 
@@ -74,14 +155,61 @@ DoCharacter(char character)
 static bool
 FormKeyDown(unsigned key_code)
 {
-  switch (key_code) {
-  case KEY_RIGHT:
+  /* On devices with cursor keys, first let the on-screen keyboard
+     move focus between key buttons; use Backspace for delete.  On
+     others (e.g. Kobo), Left and Back both act as backspace. */
+  if (HasCursorKeys() && kb != nullptr &&
+      kb->KeyPress(key_code, textentry_backspace, textentry_ok))
     return true;
-  case KEY_LEFT:
-  case KEY_BACK:
+
+  if (HasCursorKeys() && textentry_client != nullptr && textentry_ok != nullptr &&
+      textentry_cancel != nullptr && textentry_clear != nullptr) {
+    Window *const w = textentry_client->GetFocusedWindow();
+    if (key_code == KEY_RIGHT) {
+      if (w == static_cast<Window *>(textentry_ok)) {
+        textentry_cancel->SetFocus();
+        return true;
+      }
+      if (w == static_cast<Window *>(textentry_cancel)) {
+        textentry_clear->SetFocus();
+        return true;
+      }
+    } else if (key_code == KEY_LEFT) {
+      if (w == static_cast<Window *>(textentry_clear)) {
+        textentry_cancel->SetFocus();
+        return true;
+      }
+      if (w == static_cast<Window *>(textentry_cancel)) {
+        textentry_ok->SetFocus();
+        return true;
+      }
+    }
+  }
+
+  /* @c KEY_DOWN on @em Clear used to run tab order (e.g. first to @em 1);
+     go to the on-screen back key instead. */
+  if (HasCursorKeys() && key_code == KEY_DOWN &&
+      textentry_client != nullptr && textentry_clear != nullptr &&
+      textentry_backspace != nullptr) {
+    Window *const w = textentry_client->GetFocusedWindow();
+    if (w == static_cast<Window *>(textentry_clear)) {
+      textentry_backspace->SetFocus();
+      return true;
+    }
+  }
+
+  if (key_code == KEY_BACK) {
     DoBackspace();
     return true;
   }
+
+  if (!HasCursorKeys() && key_code == KEY_LEFT) {
+    DoBackspace();
+    return true;
+  }
+
+  if (!HasCursorKeys() && key_code == KEY_RIGHT)
+    return true;
 
   return false;
 }
@@ -126,51 +254,13 @@ TouchTextEntry(char *text, size_t width,
   form.SetCharacterFunction(FormCharacter);
 
   ContainerWindow &client_area = form.GetClientAreaWindow();
-  const PixelRect rc = client_area.GetClientRect();
-
-  const int client_height = rc.GetHeight();
-
-  const int padding = Layout::Scale(2);
-  const int backspace_width = Layout::Scale(36);
-  const int backspace_left = rc.right - padding - backspace_width;
-  const int editor_height = Layout::Scale(22);
-  const int editor_bottom = padding + editor_height;
-  const int button_height = Layout::Scale(40);
-  constexpr unsigned keyboard_rows = 5;
-  const int keyboard_top = editor_bottom + padding;
-  const int keyboard_height = keyboard_rows * button_height;
-  const int keyboard_bottom = keyboard_top + keyboard_height;
-
-  const bool vertical = client_height >= keyboard_bottom + button_height;
-
-  const int button_top = vertical
-    ? rc.bottom - button_height
-    : keyboard_bottom - button_height;
-  const int button_bottom = vertical
-    ? rc.bottom
-    : keyboard_bottom;
-
-  const int ok_left = vertical ? 0 : padding;
-  const int ok_right = vertical
-    ? rc.right / 3
-    : ok_left + Layout::Scale(80);
-
-  const int cancel_left = vertical
-    ? ok_right
-    : Layout::Scale(175);
-  const int cancel_right = vertical
-    ? rc.right * 2 / 3
-    : cancel_left + Layout::Scale(60);
-
-  const int clear_left = vertical
-    ? cancel_right
-    : Layout::Scale(235);
-  const int clear_right = vertical
-    ? rc.right
-    : clear_left + Layout::Scale(50);
+  textentry_client = &client_area;
+  const PixelRect rc0 = client_area.GetClientRect();
+  TextEntryLayout L;
+  ComputeTextEntryLayout(rc0, L);
 
   WndProperty _editor(client_area, look, "",
-                      { 0, padding, backspace_left - padding, editor_bottom },
+                      L.editor,
                       0, WindowStyle());
   _editor.SetReadOnly();
   editor = &_editor;
@@ -180,38 +270,43 @@ TouchTextEntry(char *text, size_t width,
   button_style.TabStop();
 
   Button ok_button(client_area, look.button, _("OK"),
-                   { ok_left, button_top, ok_right, button_bottom },
+                   L.ok,
                    button_style, form.MakeModalResultCallback(mrOK));
+  textentry_ok = &ok_button;
 
   Button cancel_button(client_area, look.button, _("Cancel"),
-                       { cancel_left, button_top,
-                           cancel_right, button_bottom },
+                       L.cancel,
                        button_style, form.MakeModalResultCallback(mrCancel));
+  textentry_cancel = &cancel_button;
 
   Button clear_button(client_area, look.button, _("Clear"),
-                      { clear_left, button_top,
-                          clear_right, button_bottom },
+                      L.clear,
                       button_style,
                       [](){ ClearText(); });
+  textentry_clear = &clear_button;
 
   KeyboardWidget keyboard(look.button, FormCharacter, !accb,
                           default_shift_state);
 
-  const PixelRect keyboard_rc = {
-    padding, keyboard_top,
-    rc.right - padding, keyboard_bottom
-  };
-
-  keyboard.Initialise(client_area, keyboard_rc);
-  keyboard.Prepare(client_area, keyboard_rc);
-  keyboard.Show(keyboard_rc);
+  keyboard.Initialise(client_area, L.keyboard);
+  keyboard.Prepare(client_area, L.keyboard);
+  keyboard.Show(L.keyboard);
 
   kb = &keyboard;
 
   Button backspace_button(client_area, look.button, "<-",
-                          { backspace_left, padding, rc.right - padding,
-                              editor_bottom },
+                          L.backspace,
                           button_style, [](){ OnBackspace(); });
+
+  textentry_backspace = &backspace_button;
+
+  form.SetClientLayoutFunction([&]() {
+    const PixelRect rc = client_area.GetClientRect();
+    TextEntryLayout layout;
+    ComputeTextEntryLayout(rc, layout);
+    ApplyTextEntryLayout(layout, _editor, ok_button, cancel_button, clear_button,
+                        keyboard, backspace_button, client_area);
+  });
 
   AllowedCharactersCallback = accb;
 
@@ -224,7 +319,13 @@ TouchTextEntry(char *text, size_t width,
   }
 
   UpdateTextboxProp();
-  bool result = form.ShowModal() == mrOK;
+  const bool result = form.ShowModal() == mrOK;
+
+  textentry_backspace = NULL;
+  textentry_ok = NULL;
+  textentry_cancel = NULL;
+  textentry_clear = NULL;
+  textentry_client = NULL;
 
   keyboard.Hide();
   keyboard.Unprepare();

--- a/src/Form/Form.cpp
+++ b/src/Form/Form.cpp
@@ -133,6 +133,9 @@ WndForm::OnResize(PixelSize new_size) noexcept
   ContainerWindow::OnResize(new_size);
   UpdateLayout();
   client_area.Move(client_rect);
+
+  if (client_layout_function)
+    client_layout_function();
 }
 
 void

--- a/src/Form/Form.hpp
+++ b/src/Form/Form.hpp
@@ -55,6 +55,12 @@ protected:
   KeyDownFunction key_down_function;
   CharacterFunction character_function;
 
+  /**
+   * If set, invoked from @ref OnResize after the client @ref client_area
+   * is moved, so the dialog can reposition in-dialog controls.
+   */
+  std::function<void()> client_layout_function;
+
   PixelPoint last_drag;
 
   void OnPaint(Canvas &canvas) noexcept override;
@@ -176,6 +182,14 @@ public:
 
   void SetCharacterFunction(CharacterFunction function) {
     character_function = function;
+  }
+
+  void SetClientLayoutFunction(std::function<void()> f) {
+    client_layout_function = std::move(f);
+  }
+
+  void ClearClientLayoutFunction() {
+    client_layout_function = {};
   }
 
   /**

--- a/src/Widget/KeyboardWidget.cpp
+++ b/src/Widget/KeyboardWidget.cpp
@@ -3,25 +3,64 @@
 
 #include "KeyboardWidget.hpp"
 #include "Renderer/SymbolButtonRenderer.hpp"
+#include "Asset.hpp"
 #include "util/StringAPI.hxx"
 #include "util/StringCompare.hxx"
 #include "util/CharUtil.hxx"
+#include "ui/event/KeyCode.hpp"
+#include "ui/window/ContainerWindow.hpp"
+#include "ui/window/Window.hpp"
 #include "Screen/Layout.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <climits>
+#include <cstdlib>
 #include <string.h>
+#include <utility>
 
-static constexpr char keyboard_letters[] =
+namespace {
+
+static constexpr char KEYBOARD_LETTERS[] =
   "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+/** Digits 0-9; matches first keys in @c KEYBOARD_LETTERS order. */
+static constexpr int NUMBER_ROW_KEY_COUNT = 10;
+
+static constexpr int DEFAULT_NUMBER_ROW_PREFER = 4; /* '5' */
+
+static bool
+ArrowToDirection(unsigned key_code, int &dix, int &diy) noexcept
+{
+  dix = diy = 0;
+  switch (key_code) {
+  case KEY_LEFT: dix = -1; return true;
+  case KEY_RIGHT: dix = 1; return true;
+  case KEY_UP: diy = -1; return true;
+  case KEY_DOWN: diy = 1; return true;
+  default: return false;
+  }
+}
+
+} // namespace
+
+void
+KeyboardWidget::Unprepare() noexcept
+{
+  parent_container = nullptr;
+  number_row_before_backspace = -1;
+}
 
 void
 KeyboardWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 {
+  parent_container = &parent;
+
   PrepareSize(rc);
 
   char caption[] = " ";
 
-  for (const char *i = keyboard_letters; !StringIsEmpty(i); ++i) {
+  for (const char *i = KEYBOARD_LETTERS; !StringIsEmpty(i); ++i) {
     caption[0] = *i;
     AddButton(parent, caption, *i);
   }
@@ -34,6 +73,7 @@ KeyboardWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   if (show_shift_button) {
     WindowStyle style;
     style.Hide();
+    style.TabStop();
     shift_button.Create(parent, { 0, 0, 16, 16 }, style,
                         std::make_unique<SymbolButtonRenderer>(look, "v"),
                         [this](){ OnShiftClicked(); });
@@ -74,7 +114,19 @@ KeyboardWidget::SetAllowedCharacters(const char *allowed)
 {
   for (unsigned i = 0; i < num_buttons; ++i)
     buttons[i].SetEnabled(allowed == nullptr ||
-                          StringFind(allowed, buttons[i].GetCharacter()) != nullptr);
+                          StringFind(allowed, buttons[i].GetCharacter()) !=
+                            nullptr);
+}
+
+bool
+KeyboardWidget::FocusSpaceKey() noexcept
+{
+  if (Button *b = FindButton(' ');
+      b != nullptr && b->IsEnabled() && b->IsVisible()) {
+    b->SetFocus();
+    return true;
+  }
+  return false;
 }
 
 Button *
@@ -85,40 +137,20 @@ KeyboardWidget::FindButton(unsigned ch)
       return &buttons[i];
 
   return nullptr;
-
 }
 
-/**
- * Move button to the specified left and top coordinates.
- *
- * The coordinates SHOULD BE in pixels of the screen (i.e. after scaling!)
- *
- * @param ch
- * @param left    Number of pixels from the left (in screen pixels)
- * @param top     Number of pixels from the top (in screen pixels)
- */
 void
 KeyboardWidget::MoveButton(unsigned ch, PixelPoint position) noexcept
 {
-  auto *kb = FindButton(ch);
-  if (kb)
-    kb->Move(position);
+  if (Button *b = FindButton(ch))
+    b->Move(position);
 }
 
-/**
- * Resizes the button to specified width and height values according to display pixels!
- *
- *
- * @param ch
- * @param width   Width measured in display pixels!
- * @param height  Height measured in display pixels!
- */
 void
 KeyboardWidget::ResizeButton(unsigned ch, PixelSize size) noexcept
 {
-  auto *kb = FindButton(ch);
-  if (kb)
-    kb->Resize(size);
+  if (Button *b = FindButton(ch))
+    b->Resize(size);
 }
 
 void
@@ -132,50 +164,49 @@ KeyboardWidget::ResizeButtons()
 }
 
 void
-KeyboardWidget::MoveButtonsToRow(const PixelRect &rc,
-                                 const char *buttons, unsigned row,
-                                 int offset)
+KeyboardWidget::MoveButtonsToRow(const PixelRect &rc, const char *row_keys,
+                                 unsigned row, int offset) noexcept
 {
-  if (StringIsEmpty(buttons))
+  if (StringIsEmpty(row_keys))
     return;
 
-  for (unsigned i = 0; buttons[i] != '\0'; i++) {
-    MoveButton(buttons[i],
+  for (unsigned i = 0; row_keys[i] != '\0'; ++i) {
+    MoveButton(row_keys[i],
                rc.GetTopLeft() + PixelSize(i * button_size.width + offset,
-                                           row * button_size.height));
+                                           int(row) * button_size.height));
   }
 }
 
 void
 KeyboardWidget::MoveButtons(const PixelRect &rc)
 {
-  MoveButtonsToRow(rc, "1234567890", 0);
-  MoveButtonsToRow(rc, "QWERTYUIOP", 1);
-  MoveButtonsToRow(rc, "ASDFGHJKL", 2, button_size.width / 3);
-  MoveButtonsToRow(rc, "ZXCVBNM@.", 3, button_size.width);
+  MoveButtonsToRow(rc, "1234567890", 0, 0);
+  MoveButtonsToRow(rc, "QWERTYUIOP", 1, 0);
+  MoveButtonsToRow(rc, "ASDFGHJKL", 2, int(button_size.width / 3));
+  MoveButtonsToRow(rc, "ZXCVBNM@.", 3, int(button_size.width));
 
   if (IsLandscape(rc)) {
-    MoveButton('-',
-               rc.GetTopLeft() + PixelSize{button_size.width * 9, Layout::Scale(160U)});
-
-    MoveButton(' ',
-               rc.GetTopLeft() + PixelSize{Layout::Scale(80U), Layout::Scale(160U)});
+    MoveButton('-', rc.GetTopLeft() + PixelSize(int(button_size.width) * 9,
+                                                int(Layout::Scale(160U))));
+    MoveButton(' ', rc.GetTopLeft() + PixelSize(int(Layout::Scale(80U)),
+                                                 int(Layout::Scale(160U))));
     ResizeButton(' ', {Layout::Scale(93U), Layout::Scale(40U)});
   } else {
-    MoveButton('-',
-               rc.GetTopLeft() + PixelSize{button_size.width * 8, button_size.height * 4});
-
-    MoveButton(' ',
-               rc.GetTopLeft() + PixelSize{button_size.width * 2, button_size.height * 4});
+    const int h = int(button_size.height);
+    const int w = int(button_size.width);
+    MoveButton('-', rc.GetTopLeft() + PixelSize(w * 8, h * 4));
+    MoveButton(' ', rc.GetTopLeft() + PixelSize(w * 2, h * 4));
     ResizeButton(' ', {button_size.width * 11 / 2, button_size.height});
   }
 
-  if (show_shift_button)
-    shift_button.Move(rc.GetTopLeft() + PixelSize{0U, 3 * button_size.height});
+  if (show_shift_button) {
+    shift_button.Move(
+      rc.GetTopLeft() + PixelSize{0U, 3U * (unsigned)button_size.height});
+  }
 }
 
 void
-KeyboardWidget::PrepareSize(const PixelRect &rc)
+KeyboardWidget::PrepareSize(const PixelRect &rc) noexcept
 {
   const PixelSize new_size = rc.GetSize();
   button_size = {new_size.width / 10, new_size.height / 5};
@@ -190,21 +221,22 @@ KeyboardWidget::OnResize(const PixelRect &rc)
 }
 
 void
-KeyboardWidget::AddButton(ContainerWindow &parent,
-                          const char *caption, unsigned ch)
+KeyboardWidget::AddButton(ContainerWindow &parent, const char *caption,
+                          unsigned ch)
 {
   assert(num_buttons < MAX_BUTTONS);
 
   WindowStyle style;
   style.Hide();
+  style.TabStop();
 
-  CharacterButton &button = buttons[num_buttons++];
-  button.Create(parent, look, caption, PixelRect{button_size},
-                on_character, ch, style);
+  CharacterButton &b = buttons[num_buttons++];
+  b.Create(parent, look, caption, PixelRect{button_size},
+           on_character, ch, style);
 }
 
 void
-KeyboardWidget::UpdateShiftState()
+KeyboardWidget::UpdateShiftState() noexcept
 {
   if (show_shift_button)
     shift_button.SetCaption(shift_state ? "v" : "^");
@@ -212,23 +244,362 @@ KeyboardWidget::UpdateShiftState()
   for (unsigned i = 0; i < num_buttons; ++i) {
     unsigned uch = buttons[i].GetCharacter();
     if (uch < 0x80) {
-      char ch = char(uch);
+      const char c = char(uch);
       if (shift_state) {
-        if (IsLowerAlphaASCII(ch))
-          buttons[i].SetCharacter(ch - 0x20);
+        if (IsLowerAlphaASCII(c))
+          buttons[i].SetCharacter(c - 0x20);
       } else {
-        if (IsUpperAlphaASCII(ch))
-          buttons[i].SetCharacter(ch + 0x20);
+        if (IsUpperAlphaASCII(c))
+          buttons[i].SetCharacter(c + 0x20);
       }
     }
   }
 }
 
 void
-KeyboardWidget::OnShiftClicked()
+KeyboardWidget::OnShiftClicked() noexcept
 {
   assert(show_shift_button);
 
   shift_state = !shift_state;
   UpdateShiftState();
+}
+
+const Button *
+KeyboardWidget::GetByIndex(int idx) const noexcept
+{
+  if (idx >= 0 && (unsigned)idx < num_buttons)
+    return &buttons[(unsigned)idx];
+  if (show_shift_button && idx == (int)num_buttons)
+    return &shift_button;
+  return nullptr;
+}
+
+Button *
+KeyboardWidget::GetByIndex(int idx) noexcept
+{
+  return const_cast<Button *>(
+    std::as_const(*this).GetByIndex(idx));
+}
+
+int
+KeyboardWidget::FindIndexOf(const Window *w) const noexcept
+{
+  for (unsigned i = 0; i < num_buttons; ++i)
+    if (w == (const Window *)&buttons[i])
+      return (int)i;
+  if (show_shift_button && w == (const Window *)&shift_button)
+    return (int)num_buttons;
+  return -1;
+}
+
+int
+KeyboardWidget::GetSpaceKeyIndex() const noexcept
+{
+  for (unsigned i = 0; i < num_buttons; ++i) {
+    if (buttons[i].GetCharacter() == (unsigned)' ')
+      return (int)i;
+  }
+  return -1;
+}
+
+bool
+KeyboardWidget::GetCenterByIndex(int idx, PixelPoint &out) const noexcept
+{
+  const Button *b = GetByIndex(idx);
+  if (b == nullptr || !b->IsDefined() || !b->IsVisible())
+    return false;
+  const PixelRect r = b->GetPosition();
+  out = {(r.left + r.right) / 2, (r.top + r.bottom) / 2};
+  return true;
+}
+
+bool
+KeyboardWidget::TryNavigableKeyCenter(int from_idx, int j, PixelPoint &c_out) const
+  noexcept
+{
+  if (j == from_idx)
+    return false;
+  if (const Button *b = GetByIndex(j);
+      b == nullptr || !b->IsEnabled() || !b->IsVisible())
+    return false;
+  return GetCenterByIndex(j, c_out);
+}
+
+bool
+KeyboardWidget::TrySetFocusToEnabledKey(int j) noexcept
+{
+  if (Button *b = GetByIndex(j);
+      b != nullptr && b->IsEnabled() && b->IsVisible()) {
+    b->SetFocus();
+    return true;
+  }
+  return false;
+}
+
+int
+KeyboardWidget::FindIndexVerticalFrom(int from_idx, int diy) const noexcept
+{
+  assert(diy == 1 || diy == -1);
+
+  PixelPoint cf;
+  if (!GetCenterByIndex(from_idx, cf))
+    return -1;
+
+  const int n = GetNavigableCount();
+  /* Next row in screen space (y grows downward), then closest on that
+     row by @em x — pure geometry, not button / layout order. */
+  const int y_band = (int)std::max(2U, button_size.height / 4U);
+
+  int y_row_target;
+  if (diy < 0) {
+    y_row_target = INT_MIN;
+    for (int j = 0; j < n; ++j) {
+      PixelPoint cj;
+      if (!TryNavigableKeyCenter(from_idx, j, cj))
+        continue;
+      if (cj.y < cf.y)
+        y_row_target = std::max(y_row_target, cj.y);
+    }
+    if (y_row_target == INT_MIN)
+      return -1;
+  } else {
+    y_row_target = INT_MAX;
+    for (int j = 0; j < n; ++j) {
+      PixelPoint cj;
+      if (!TryNavigableKeyCenter(from_idx, j, cj))
+        continue;
+      if (cj.y > cf.y)
+        y_row_target = std::min(y_row_target, cj.y);
+    }
+    if (y_row_target == INT_MAX)
+      return -1;
+  }
+
+  const int space_idx = GetSpaceKeyIndex();
+  const bool up_from_space = diy < 0 && from_idx == space_idx;
+
+  int best = -1;
+  int best_dx2 = INT_MAX;
+  for (int j = 0; j < n; ++j) {
+    /* From @em Space, the key above in @em y is the Z row; the shift
+       key shares that band but is not the next “up” in the QWERTY
+       path (Z → A → Q → row 0). */
+    if (up_from_space && show_shift_button && j == (int)num_buttons)
+      continue;
+    PixelPoint cj;
+    if (!TryNavigableKeyCenter(from_idx, j, cj))
+      continue;
+    if (std::abs(cj.y - y_row_target) > y_band)
+      continue;
+    if (diy < 0 && cj.y >= cf.y)
+      continue;
+    if (diy > 0 && cj.y <= cf.y)
+      continue;
+    const int dx = cj.x - cf.x;
+    const int dx2 = dx * dx;
+    if (dx2 < best_dx2 || (dx2 == best_dx2 && (best < 0 || j < best))) {
+      best_dx2 = dx2;
+      best = j;
+    }
+  }
+  return best;
+}
+
+int
+KeyboardWidget::FindIndexHorizontalFrom(int from_idx, int dix) const
+  noexcept
+{
+  assert(dix == 1 || dix == -1);
+
+  PixelPoint cf;
+  if (!GetCenterByIndex(from_idx, cf))
+    return -1;
+
+  const int n = GetNavigableCount();
+  /* Same key row by @em y only: QWERTY/ASDF are one row height apart, so
+     @c height/2 is too loose (e.g. E can pick A). Use a tight band so we
+     never “wrap” to the adjacent staggered row. */
+  const int y_slop = (int)std::max(2U, button_size.height / 4U);
+  int best = -1;
+
+  if (dix < 0) {
+    int best_x = INT_MIN;
+    for (int j = 0; j < n; ++j) {
+      PixelPoint cj;
+      if (!TryNavigableKeyCenter(from_idx, j, cj))
+        continue;
+      if (std::abs(cj.y - cf.y) > y_slop)
+        continue;
+      if (cj.x >= cf.x)
+        continue;
+      if (cj.x > best_x) {
+        best_x = cj.x;
+        best = j;
+      }
+    }
+  } else {
+    int best_x = INT_MAX;
+    for (int j = 0; j < n; ++j) {
+      PixelPoint cj;
+      if (!TryNavigableKeyCenter(from_idx, j, cj))
+        continue;
+      if (std::abs(cj.y - cf.y) > y_slop)
+        continue;
+      if (cj.x <= cf.x)
+        continue;
+      if (cj.x < best_x) {
+        best_x = cj.x;
+        best = j;
+      }
+    }
+  }
+
+  return best;
+}
+
+bool
+KeyboardWidget::FocusFirstEnabledInNumberRow(int prefer_index) noexcept
+{
+  if (prefer_index >= 0 && prefer_index < NUMBER_ROW_KEY_COUNT &&
+      TrySetFocusToEnabledKey(prefer_index))
+    return true;
+  for (int i = 0; i < NUMBER_ROW_KEY_COUNT; ++i) {
+    if (TrySetFocusToEnabledKey(i))
+      return true;
+  }
+  return false;
+}
+
+bool
+KeyboardWidget::FocusFirstEnabledInGrid() noexcept
+{
+  const int n = GetNavigableCount();
+  for (int j = 0; j < n; ++j) {
+    if (TrySetFocusToEnabledKey(j))
+      return true;
+  }
+  return false;
+}
+
+bool
+KeyboardWidget::RouteSpaceToActionRow(unsigned key_code, Button *action_row,
+                                      Window *w) noexcept
+{
+  if (action_row == nullptr || key_code != KEY_DOWN)
+    return false;
+  Button *const sp = FindButton(' ');
+  if (sp == nullptr || w != static_cast<Window *>(sp))
+    return false;
+  action_row->SetFocus();
+  return true;
+}
+
+bool
+KeyboardWidget::RouteNumberRowAndBackspace(unsigned key_code, Button *back,
+                                           Window *w) noexcept
+{
+  if (back == nullptr)
+    return false;
+
+  if (key_code == KEY_UP) {
+    const int from = FindIndexOf(w);
+    if (from >= 0 && from < NUMBER_ROW_KEY_COUNT) {
+      number_row_before_backspace = from;
+      back->SetFocus();
+      return true;
+    }
+    return false;
+  }
+
+  if (key_code == KEY_DOWN && w == static_cast<Window *>(back)) {
+    int p = number_row_before_backspace;
+    if (p < 0 || p >= NUMBER_ROW_KEY_COUNT)
+      p = DEFAULT_NUMBER_ROW_PREFER;
+    if (FocusFirstEnabledInNumberRow(p))
+      return true;
+    /* e.g. allowed set enables only a letter: number row is all disabled. */
+    return FocusFirstEnabledInGrid();
+  }
+
+  return false;
+}
+
+bool
+KeyboardWidget::MoveByVerticalInGrid(int from, int diy, Button *back,
+                                     Button *action_row_first) noexcept
+{
+  assert(diy == 1 || diy == -1);
+  const int to = FindIndexVerticalFrom(from, diy);
+  if (to >= 0)
+    return TrySetFocusToEnabledKey(to);
+  if (diy < 0 && back != nullptr) {
+    /* No on-screen key @em up: back is the next step (inverse of
+       @c down from that key into the grid, which uses the same
+       @c FindIndexVerticalFrom with <tt>diy == 1</tt>). */
+    number_row_before_backspace = -1;
+    back->SetFocus();
+    return true;
+  }
+  if (diy > 0 && action_row_first != nullptr) {
+    /* No key below in the grid (e.g. all lower rows off): action row. */
+    action_row_first->SetFocus();
+    return true;
+  }
+  return false;
+}
+
+bool
+KeyboardWidget::MoveFocusInGridByArrowKey(unsigned key_code, Window *w,
+                                          Button *back,
+                                          Button *action_row_first) noexcept
+{
+  int dix = 0, diy = 0;
+  if (!ArrowToDirection(key_code, dix, diy))
+    return false;
+
+  const int from = FindIndexOf(w);
+  if (from < 0)
+    return false;
+  if (dix == 0 && (diy == 1 || diy == -1))
+    return MoveByVerticalInGrid(from, diy, back, action_row_first);
+  if (dix != 0 && diy == 0) {
+    const int to = FindIndexHorizontalFrom(from, dix);
+    if (to < 0)
+      return false;
+    return TrySetFocusToEnabledKey(to);
+  }
+  return false;
+}
+
+bool
+KeyboardWidget::KeyPressImpl(unsigned key_code, Button *backspace,
+                             Button *action_row_first) noexcept
+{
+  if (!HasCursorKeys() || parent_container == nullptr)
+    return false;
+  Window *w = parent_container->GetFocusedWindow();
+  if (w == nullptr)
+    return false;
+
+  if (action_row_first != nullptr &&
+      w == static_cast<Window *>(action_row_first) && key_code == KEY_UP) {
+    /* @em OK is outside the grid: first @em up is @em Space, then
+       @c FindIndexVerticalFrom (Z → A → Q → 0…9) and
+       @c RouteNumberRowAndBackspace to on-screen @em backspace. */
+    return FocusSpaceKey();
+  }
+
+  if (RouteSpaceToActionRow(key_code, action_row_first, w))
+    return true;
+  if (backspace != nullptr && action_row_first != nullptr &&
+      w == static_cast<Window *>(backspace) && key_code == KEY_UP) {
+    /* @em backspace is not in the key grid, so
+       @c MoveFocusInGridByArrowKey is never used; send @em up to @em OK. */
+    action_row_first->SetFocus();
+    return true;
+  }
+  if (RouteNumberRowAndBackspace(key_code, backspace, w))
+    return true;
+  return MoveFocusInGridByArrowKey(key_code, w, backspace, action_row_first);
 }

--- a/src/Widget/KeyboardWidget.hpp
+++ b/src/Widget/KeyboardWidget.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
+#include "ui/dim/Point.hpp"
 #include "Widget.hpp"
 #include "Form/CharacterButton.hpp"
 #include "Form/Button.hpp"
 
 struct ButtonLook;
-class WndSymbolButton;
+class ContainerWindow;
+class Window;
 
 class KeyboardWidget : public NullWidget {
 public:
@@ -31,6 +33,19 @@ protected:
 
   const bool show_shift_button;
 
+  /**
+   * Client area of the text-entry dialog; used for focus lookup when
+   * moving between on-screen key buttons with the hardware cursor keys.
+   */
+  ContainerWindow *parent_container = nullptr;
+
+  /**
+   * When @c KEY_UP moves from the number row to the on-screen backspace, we
+   * remember the digit index (0..9) so @c KEY_DOWN from that button can return
+   * to the same key.
+   */
+  int number_row_before_backspace = -1;
+
 public:
   KeyboardWidget(const ButtonLook &_look,
                  OnCharacterCallback_t _on_character,
@@ -45,8 +60,14 @@ public:
    */
   void SetAllowedCharacters(const char *allowed);
 
+  /**
+   * Move focus to the on-screen @em Space key (inverse of @c KEY_DOWN
+   * from that key to the action row in text entry).
+   */
+  bool FocusSpaceKey() noexcept;
+
 private:
-  void PrepareSize(const PixelRect &rc);
+  void PrepareSize(const PixelRect &rc) noexcept;
   void OnResize(const PixelRect &rc);
 
   [[gnu::pure]]
@@ -55,10 +76,8 @@ private:
   void MoveButton(unsigned ch, PixelPoint position) noexcept;
   void ResizeButton(unsigned ch, PixelSize size) noexcept;
   void ResizeButtons();
-  void SetButtonsSize();
-  void MoveButtonsToRow(const PixelRect &rc,
-                        const char *buttons, unsigned row,
-                        int offset_left = 0);
+  void MoveButtonsToRow(const PixelRect &rc, const char *row_keys, unsigned row,
+                        int offset_left = 0) noexcept;
   void MoveButtons(const PixelRect &rc);
 
   [[gnu::pure]]
@@ -66,18 +85,74 @@ private:
     return rc.GetWidth() >= rc.GetHeight();
   }
 
-  /* updates UI based on value of shift_state property */
-  void UpdateShiftState();
-
+  void UpdateShiftState() noexcept;
   void AddButton(ContainerWindow &parent, const char *caption, unsigned ch);
+  void OnShiftClicked() noexcept;
 
 public:
-  /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Show(const PixelRect &rc) noexcept override;
   void Hide() noexcept override;
   void Move(const PixelRect &rc) noexcept override;
+  void Unprepare() noexcept override;
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    return KeyPressImpl(key_code, nullptr, nullptr);
+  }
+
+  /**
+   * @param backspace optional backspace @c Button above the key grid.
+   * @param action_row_first the first of the main row (usually @em OK);
+   *  @c KEY_UP from @em OK focuses @em Space, then further @c KEY_UP
+   *  follows the key grid to on-screen @em backspace; @c KEY_DOWN from
+   *  the @em Space key focuses it; with no on-screen key below the
+   *  focus, @c KEY_DOWN moves here too; @c KEY_UP from on-screen
+   *  @em backspace also focuses it.
+   */
+  bool KeyPress(unsigned key_code, Button *backspace,
+                Button *action_row_first = nullptr) noexcept {
+    return KeyPressImpl(key_code, backspace, action_row_first);
+  }
 
 private:
-  void OnShiftClicked();
+  bool KeyPressImpl(unsigned key_code, Button *backspace,
+                    Button *action_row_first) noexcept;
+
+  bool RouteSpaceToActionRow(unsigned key_code, Button *action_row,
+                            Window *w) noexcept;
+  bool RouteNumberRowAndBackspace(unsigned key_code, Button *back,
+                                  Window *w) noexcept;
+  bool MoveFocusInGridByArrowKey(unsigned key_code, Window *w, Button *back,
+                                 Button *action_row_first) noexcept;
+  bool MoveByVerticalInGrid(int from, int diy, Button *back,
+                            Button *action_row_first) noexcept;
+
+  [[gnu::pure]]
+  int GetNavigableCount() const noexcept {
+    return (int)num_buttons + (show_shift_button ? 1 : 0);
+  }
+
+  const Button *GetByIndex(int idx) const noexcept;
+  Button *GetByIndex(int idx) noexcept;
+
+  bool TryNavigableKeyCenter(int from_idx, int j, PixelPoint &c_out) const
+    noexcept;
+  bool TrySetFocusToEnabledKey(int j) noexcept;
+
+  [[gnu::pure]]
+  int FindIndexOf(const Window *w) const noexcept;
+
+  /** @return index of the @em Space key, or @a -1. */
+  [[gnu::pure]]
+  int GetSpaceKeyIndex() const noexcept;
+
+  bool GetCenterByIndex(int idx, PixelPoint &out) const noexcept;
+
+  [[gnu::pure]]
+  int FindIndexVerticalFrom(int from_idx, int diy) const noexcept;
+  [[gnu::pure]]
+  int FindIndexHorizontalFrom(int from_idx, int dix) const noexcept;
+
+  bool FocusFirstEnabledInNumberRow(int prefer_index) noexcept;
+  bool FocusFirstEnabledInGrid() noexcept;
 };


### PR DESCRIPTION
Fixes #1819

## Summary
- `WndForm`: optional client layout callback after `OnResize` so dialogs can relayout children when the window resizes.
- `TouchTextEntry`: shared layout computation; repositions editor, action row, on-screen backspace, and on-screen keyboard on client resize; keyboard navigation is delegated to `KeyboardWidget::KeyPress`.
- `KeyboardWidget`: hardware cursor key routing between on-screen keys (OK ↔ Space, letter/number rows, on-screen backspace) with geometry-based movement; `Up` from Space skips the shift key so the path follows QWERTY rows.

**Label:** needs-work (WIP / feedback welcome).

## Notes
Unstaged `po/*.po` / `xcsoar.pot` in the working tree were left out of this branch; no new translatable user strings in these commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced cursor-key navigation for on-screen keyboards with improved focus routing
  * Better dialog layout responsiveness when window is resized
  * Refined keyboard navigation logic for text entry dialogs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->