### PR TITLE
Add LX Navigation LX160 device driver

### DIFF
--- a/build/driver.mk
+++ b/build/driver.mk
@@ -140,6 +140,7 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/AirControlDisplay.cpp \
 	$(DRIVER_SRC_DIR)/Larus.cpp \
 	$(DRIVER_SRC_DIR)/LoEFGREN.cpp \
+	$(DRIVER_SRC_DIR)/LX160.cpp \
 	$(DRIVER_SRC_DIR)/ATR833/Device.cpp \
 	$(DRIVER_SRC_DIR)/ATR833/Register.cpp
 

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -182,6 +182,7 @@ DeviceConfig::Clear() noexcept
   enabled = true;
   sync_from_device = true;
   sync_to_device = true;
+  send_position = true;
   k6bt = false;
   polar_sync = PolarSync::OFF;
   engine_type = EngineType::NONE;

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -278,6 +278,15 @@ struct DeviceConfig {
   bool sync_from_device;
 
   /**
+   * Should XCSoar send its current GPS position to the device as
+   * $GPGGA / $GPRMC sentences?  Only honored by drivers that advertise
+   * #DeviceRegister::SEND_POSITION (e.g. LX160).  When this is false the
+   * driver still emits navigation context such as $GPRMB.  Defaults to
+   * true; turn off when an upstream GPS source already feeds the device.
+   */
+  bool send_position;
+
+  /**
    * Polar synchronization direction (off, receive, or send).
    */
   PolarSync polar_sync;

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -426,6 +426,13 @@ struct DeviceRegister {
      * EnablePassThrough() is implemented.
      */
     PASS_THROUGH = 0x200,
+
+    /**
+     * Does this driver emit GPGGA/GPRMC position sentences to the
+     * device?  When set, the user can suppress that emission via
+     * #DeviceConfig::send_position.
+     */
+    SEND_POSITION = 0x400,
   };
 
   /**
@@ -522,5 +529,12 @@ struct DeviceRegister {
    */
   bool HasPassThrough() const {
     return (flags & PASS_THROUGH) != 0;
+  }
+
+  /**
+   * Does this driver emit GPGGA/GPRMC position sentences?
+   */
+  bool CanSendPosition() const {
+    return (flags & SEND_POSITION) != 0;
   }
 };

--- a/src/Device/Driver/CaiLNav.cpp
+++ b/src/Device/Driver/CaiLNav.cpp
@@ -8,7 +8,7 @@
 #include "Operation/Operation.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
-#include "Units/Units.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "Formatter/NMEAFormatter.hpp"
 #include "util/SpanCast.hxx"
 
@@ -20,37 +20,6 @@ PortWriteNMEANoChecksum(Port &port, const char *line,
   constexpr auto timeout = std::chrono::seconds(1);
 
   port.FullWrite(AsBytes(std::string_view{line}), env, timeout);
-}
-
-/*
-$GPRMB,<1>,,,,<5>,,,,,<10>,<11>,,<13>*hh<CR><LF>
-
-<1>  Position Valid (A = valid, V = invalid)
-<5>  Destination waypoint identifier, three digits
-     (leading zeros will be transmitted)
-<10> Range from present position to distination waypoint, format XXXX.X,
-     nautical miles (leading zeros will be transmitted)
-<11> Bearing from present position to destination waypoint, format XXX.X,
-     degrees true (leading zeros will be transmitted)
-<13> Arrival flag <A = arrival, V = not arrival)
-*/
-static bool
-FormatGPRMB(char *buffer, size_t buffer_size, const GeoPoint& here,
-            const AGeoPoint &destination)
-{
-  if (!here.IsValid() || !destination.IsValid())
-    return false;
-
-  const GeoVector vector(here, destination);
-  const bool has_arrived = vector.distance < 1000; // < 1km ?
-
-  snprintf(buffer, buffer_size, "GPRMB,%c,,,,,,,,,%06.1f,%04.1f,%c",
-           here.IsValid() ? 'A' : 'V',
-           (double)Units::ToUserUnit(vector.distance, Unit::NAUTICAL_MILES),
-           (double)vector.bearing.Degrees(),
-           has_arrived ? 'A' : 'V');
-
-  return true;
 }
 
 /*

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -452,9 +452,6 @@ public:
 
   bool ReadLXGPSBaudrate(unsigned &baudrate, OperationEnvironment &env);
 
-  // These methods are reused by the LX Eos driver
-  static void LXWP1(NMEAInputLine &line, DeviceInfo &device);
-
 public:
   /* virtual methods from class Device */
   void LinkTimeout() override;

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Internal.hpp"
+#include "Parsers.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/InputLine.hpp"
 #include "NMEA/Info.hpp"
@@ -53,7 +54,9 @@ ShouldSwitchHostBaudForNinc(const DeviceInfo &device_info) noexcept
           device_info.hardware_version.equals("8"));
 }
 
-static bool
+namespace LX {
+
+bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info)
 {
   /*
@@ -99,6 +102,8 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info)
   return true;
 }
 
+} // namespace LX
+
 void
 LXDevice::LXWP1(NMEAInputLine &line, DeviceInfo &device)
 {
@@ -118,7 +123,9 @@ LXDevice::LXWP1(NMEAInputLine &line, DeviceInfo &device)
   device.license = line.ReadView();
 }
 
-static bool
+namespace LX {
+
+bool
 LXWP2(NMEAInputLine &line, NMEAInfo &info)
 {
   /*
@@ -165,7 +172,7 @@ LXWP2(NMEAInputLine &line, NMEAInfo &info)
   return true;
 }
 
-static bool
+bool
 LXWP3(NMEAInputLine &line, NMEAInfo &info)
 {
   /*
@@ -196,6 +203,8 @@ LXWP3(NMEAInputLine &line, NMEAInfo &info)
 
   return true;
 }
+
+} // namespace LX
 
 /**
  * Parse double from a string_view value field.
@@ -692,7 +701,7 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 
   const auto type = line.ReadView();
   if (type == "$LXWP0"sv)
-    return LXWP0(line, info);
+    return LX::LXWP0(line, info);
 
   if (type == "$LXWP1"sv) {
     DeviceInfo &device_info = mode == Mode::PASS_THROUGH
@@ -704,10 +713,10 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
   }
 
   if (type == "$LXWP2"sv)
-    return LXWP2(line, info);
+    return LX::LXWP2(line, info);
 
   if (type == "$LXWP3"sv)
-    return LXWP3(line, info);
+    return LX::LXWP3(line, info);
 
   if (type == "$PLXV0"sv) {
     is_colibri = false;

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -102,10 +102,8 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info)
   return true;
 }
 
-} // namespace LX
-
 void
-LXDevice::LXWP1(NMEAInputLine &line, DeviceInfo &device)
+LXWP1(NMEAInputLine &line, DeviceInfo &device)
 {
   /*
    * $LXWP1,
@@ -122,8 +120,6 @@ LXDevice::LXWP1(NMEAInputLine &line, DeviceInfo &device)
   device.hardware_version = line.ReadView();
   device.license = line.ReadView();
 }
-
-namespace LX {
 
 bool
 LXWP2(NMEAInputLine &line, NMEAInfo &info)
@@ -488,7 +484,7 @@ PLXVC(NMEAInputLine &line, NMEAInfo &info,
 
     const auto name = line.ReadView();
     if (name == "LXWP1"sv) {
-      LXDevice::LXWP1(line, info.secondary_device);
+      LX::LXWP1(line, info.secondary_device);
     } else if (name == "INFO"sv) {
       const auto type2 = line.ReadView();
       if (type2.starts_with('A'))
@@ -707,7 +703,7 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
     DeviceInfo &device_info = mode == Mode::PASS_THROUGH
       ? info.secondary_device
       : info.device;
-    LXWP1(line, device_info);
+    LX::LXWP1(line, device_info);
     UpdateDeviceFlags(device_info, mode == Mode::PASS_THROUGH);
     return true;
   }

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+class NMEAInputLine;
+struct NMEAInfo;
+
+/* LXWP parsers exposed for reuse by sibling drivers (e.g. LX160).
+   The full LX driver wires these into LXDevice::ParseNMEA in Parser.cpp;
+   the same helpers can be invoked directly by simpler drivers that share
+   the LXNAV NMEA dialect but not the rest of the LXDevice surface. */
+
+namespace LX {
+
+bool
+LXWP0(NMEAInputLine &line, NMEAInfo &info);
+
+bool
+LXWP2(NMEAInputLine &line, NMEAInfo &info);
+
+bool
+LXWP3(NMEAInputLine &line, NMEAInfo &info);
+
+} // namespace LX

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -5,6 +5,7 @@
 
 class NMEAInputLine;
 struct NMEAInfo;
+struct DeviceInfo;
 
 /* LXWP parsers exposed for reuse by sibling drivers (e.g. LX160).
    The full LX driver wires these into LXDevice::ParseNMEA in Parser.cpp;
@@ -15,6 +16,9 @@ namespace LX {
 
 bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info);
+
+void
+LXWP1(NMEAInputLine &line, DeviceInfo &device);
 
 bool
 LXWP2(NMEAInputLine &line, NMEAInfo &info);

--- a/src/Device/Driver/LX160.cpp
+++ b/src/Device/Driver/LX160.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/LX160.hpp"
+#include "Device/Driver.hpp"
+#include "Device/Config.hpp"
+#include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAWriter.hpp"
+#include "Device/Driver/LX/Parsers.hpp"
+#include "NMEA/Checksum.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/InputLine.hpp"
+#include "NMEA/MoreData.hpp"
+#include "NMEA/Derived.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Formatter/NMEAFormatter.hpp"
+#include "Operation/Operation.hpp"
+
+#include <string_view>
+
+using std::string_view_literals::operator""sv;
+
+/*
+ * Driver for the LX Navigation LX160 vario / final-glide computer.
+ *
+ * The LX160 has a single bidirectional NMEA port:
+ *
+ *   IN : $GPGGA + $GPRMC (+ optional $GPRMB)
+ *   OUT: $LXWP0/$LXWP1/$LXWP2/$LXWP3
+ *
+ * Read side reuses the LXWPx parsers from src/Device/Driver/LX/Parser.cpp
+ * (exposed via Parsers.hpp).
+ *
+ * Write side mirrors `cai_lnav`: $GPGGA + $GPRMC + $GPRMB are emitted on
+ * each calculation tick (~1 Hz) using the shared NMEAFormatter helpers.
+ *
+ * The LX160 has no NMEA writeback for MC / ballast / bugs / polar (those
+ * are physical panel switches), so this driver does not advertise
+ * SEND_SETTINGS or DECLARE.
+ */
+
+class LX160Device final : public AbstractDevice {
+  Port &port;
+  /* Sampled from DeviceConfig at open time; reconnect required to change. */
+  const bool send_position;
+
+public:
+  LX160Device(Port &_port, bool _send_position) noexcept
+    : port(_port), send_position(_send_position) {}
+
+  bool ParseNMEA(const char *line, NMEAInfo &info) override;
+
+  /* No PutMacCready / PutBallast / PutBugs override: the LX160 has been
+     bench-verified to silently ignore both PFLX2 (LX1600 7-field form
+     and LX MiniMap 6-field form).  Ballast and bugs are physical front-
+     panel switches, and the spring-loaded MC knob means MC sync is
+     RECEIVE-only on this hardware. */
+
+  void OnCalculatedUpdate(const MoreData &basic,
+                          const DerivedInfo &calculated) override;
+};
+
+bool
+LX160Device::ParseNMEA(const char *string, NMEAInfo &info)
+{
+  if (!VerifyNMEAChecksum(string))
+    return false;
+
+  NMEAInputLine line(string);
+  const auto type = line.ReadView();
+
+  if (type == "$LXWP0"sv)
+    return LX::LXWP0(line, info);
+
+  if (type == "$LXWP1"sv) {
+    LX::LXWP1(line, info.device);
+    return true;
+  }
+
+  if (type == "$LXWP2"sv)
+    return LX::LXWP2(line, info);
+
+  if (type == "$LXWP3"sv)
+    return LX::LXWP3(line, info);
+
+  /* The LX160 echoes any $GPGGA/$GPRMC it receives back onto its NMEA
+     OUT line.  When XCSoar is the GPS source (send_position == true)
+     those echoes are our own data bouncing back -- swallow them so
+     they don't show up in the merge thread as a second GPS source.
+     When send_position == false the user has wired an external GPS
+     to the LX160 and the echoed sentences are the only path to GPS
+     in XCSoar -- let the generic parser ingest them. */
+  if (send_position &&
+      (type == "$GPGGA"sv || type == "$GPRMC"sv))
+    return true;
+
+  return false;
+}
+
+void
+LX160Device::OnCalculatedUpdate(const MoreData &basic,
+                                const DerivedInfo &calculated)
+{
+  NullOperationEnvironment env;
+  char buffer[100];
+
+  if (send_position) {
+    FormatGPGGA(buffer, sizeof(buffer), basic);
+    PortWriteNMEA(port, buffer, env);
+
+    FormatGPRMC(buffer, sizeof(buffer), basic);
+    PortWriteNMEA(port, buffer, env);
+  }
+
+  const GeoPoint here = basic.location_available
+    ? basic.location
+    : GeoPoint::Invalid();
+
+  const ElementStat &current_leg = calculated.task_stats.current_leg;
+  const AGeoPoint destination(current_leg.location_remaining,
+                              current_leg.solution_planned.min_arrival_altitude);
+
+  if (FormatGPRMB(buffer, sizeof(buffer), here, destination))
+    PortWriteNMEA(port, buffer, env);
+}
+
+static Device *
+LX160CreateOnPort(const DeviceConfig &config, Port &com_port)
+{
+  return new LX160Device(com_port, config.send_position);
+}
+
+const struct DeviceRegister lx160_driver = {
+  "LX160",
+  "LX160",
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_POSITION,
+  LX160CreateOnPort,
+};

--- a/src/Device/Driver/LX160.hpp
+++ b/src/Device/Driver/LX160.hpp
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+extern const struct DeviceRegister lx160_driver;

--- a/src/Device/Driver/LX_EOS/LXEosDevice.cpp
+++ b/src/Device/Driver/LX_EOS/LXEosDevice.cpp
@@ -4,6 +4,7 @@
 #include "LXEosDevice.hpp"
 #include "Device/Driver.hpp"
 #include "Device/Driver/LX/Internal.hpp"
+#include "Device/Driver/LX/Parsers.hpp"
 #include "Device/Port/Port.hpp"
 #include "Device/Util/NMEAWriter.hpp"
 #include "NMEA/Checksum.hpp"
@@ -114,8 +115,8 @@ LXEosDevice::ParseNMEA(const char* String, NMEAInfo& info)
   if (type == "$LXWP0"sv)
     return LXWP0(line, info);
   else if (type == "$LXWP1"sv) {
-    // LXWP1 sentence is identical to LXNAV, using method from LXNAV driver
-    LXDevice::LXWP1(line, info.device);
+    // LXWP1 sentence is identical to LXNAV, using shared parser
+    LX::LXWP1(line, info.device);
     altitude_offset.reliable = HasReliableAltOffset(info.device);
     return true;
   } else if (type == "$LXWP2"sv)

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -41,6 +41,7 @@
 #include "Device/Driver/ATR833/Register.hpp"
 #include "Device/Driver/XCTracer.hpp"
 #include "Device/Driver/KRT2.hpp"
+#include "Device/Driver/LX160.hpp"
 #include "Device/Driver/Stratux.hpp"
 #include "Device/Driver/LoEFGREN.hpp"
 #include "util/Macros.hpp"
@@ -92,6 +93,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &lx_eos_driver,
   &stratux_driver,
   &loe_fgren_driver,
+  &lx160_driver,
   nullptr
 };
 

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -20,7 +20,7 @@ enum ControlIndex {
   IP_ADDRESS,
   TCPPort,
   I2CBus, I2CAddr, PressureUsage, Driver, UseSecondDriver, SecondDriver,
-  SyncFromDevice, SyncToDevice, PolarSyncMode,
+  SyncFromDevice, SyncToDevice, SendPosition, PolarSyncMode,
   K6Bt,
 };
 
@@ -152,6 +152,7 @@ DeviceEditWidget::SetConfig(const DeviceConfig &_config) noexcept
   LoadValueEnum(Driver, config.driver_name);
   LoadValue(SyncFromDevice, config.sync_from_device);
   LoadValue(SyncToDevice, config.sync_to_device);
+  LoadValue(SendPosition, config.send_position);
   LoadValueEnum(PolarSyncMode, config.polar_sync);
   LoadValue(K6Bt, config.k6bt);
   LoadValueEnum(EngineTypes, config.engine_type);
@@ -206,6 +207,21 @@ CanSendSettings(const DataField &df) noexcept
 
 [[gnu::pure]]
 static bool
+CanSendPosition(const DataField &df) noexcept
+{
+  const char *driver_name = df.GetAsString();
+  if (driver_name == nullptr)
+    return false;
+
+  const struct DeviceRegister *driver = FindDriverByName(driver_name);
+  if (driver == nullptr)
+    return false;
+
+  return driver->CanSendPosition();
+}
+
+[[gnu::pure]]
+static bool
 CanPassThrough(const DataField &df) noexcept
 {
   const char *driver_name = df.GetAsString();
@@ -252,10 +268,13 @@ DeviceEditWidget::UpdateVisibilities() noexcept
 
   const bool can_receive = CanReceiveSettings(GetDataField(Driver));
   const bool can_send = CanSendSettings(GetDataField(Driver));
+  const bool can_send_position = CanSendPosition(GetDataField(Driver));
   SetRowVisible(SyncFromDevice, DeviceConfig::UsesDriver(type) &&
                 can_receive);
   SetRowVisible(SyncToDevice, DeviceConfig::UsesDriver(type) &&
                 can_send);
+  SetRowVisible(SendPosition, DeviceConfig::UsesDriver(type) &&
+                can_send_position);
   SetRowVisible(PolarSyncMode, DeviceConfig::UsesDriver(type) &&
                 (can_receive || can_send));
   if (can_receive || can_send) {
@@ -365,6 +384,15 @@ DeviceEditWidget::Prepare(ContainerWindow &parent,
                "like the MacCready value, bugs and ballast to the device."),
              config.sync_to_device, this);
   SetExpertRow(SyncToDevice);
+
+  AddBoolean(_("Emit GPGGA/GPRMC"),
+             _("Tells XCSoar to send its current GPS position to the "
+               "device as $GPGGA and $GPRMC sentences. Turn off when "
+               "another GPS source is already feeding the device on "
+               "the same line. Changes take effect after reconnecting "
+               "the device."),
+             config.send_position, this);
+  SetExpertRow(SendPosition);
 
   DataFieldEnum *polar_sync_df = new DataFieldEnum(this);
   FillPolarSync(*polar_sync_df,
@@ -497,6 +525,9 @@ DeviceEditWidget::Save(bool &_changed) noexcept
 
     if (CanSendSettings(GetDataField(Driver)))
       changed |= SaveValue(SyncToDevice, config.sync_to_device);
+
+    if (CanSendPosition(GetDataField(Driver)))
+      changed |= SaveValue(SendPosition, config.send_position);
 
     if (CanReceiveSettings(GetDataField(Driver)) ||
         CanSendSettings(GetDataField(Driver)))

--- a/src/Formatter/NMEAFormatter.cpp
+++ b/src/Formatter/NMEAFormatter.cpp
@@ -3,6 +3,15 @@
 
 #include "NMEAFormatter.hpp"
 #include "Units/Units.hpp"
+#include "Geo/GeoVector.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "util/UTF8.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+/** Distance under which GPRMB reports "arrived" (metres). */
+static constexpr double ARRIVAL_RADIUS_M = 1000.0;
 
 void
 FormatGPRMC(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
@@ -68,6 +77,56 @@ FormatGPGGA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept
                  "%s",
                  "GPGGA,,,,,,,,,,M,,,,");
   }
+}
+
+bool
+FormatGPRMB(char *buffer, size_t buffer_size,
+            const GeoPoint &here, const AGeoPoint &destination,
+            std::string_view destination_name) noexcept
+{
+  if (!here.IsValid() || !destination.IsValid())
+    return false;
+
+  const GeoVector vector(here, destination);
+  const bool has_arrived = vector.distance < ARRIVAL_RADIUS_M;
+  const double range_nm =
+    (double)Units::ToUserUnit(vector.distance, Unit::NAUTICAL_MILES);
+  const double bearing_deg = (double)vector.bearing.Degrees();
+  const char arrival = has_arrived ? 'A' : 'V';
+
+  /* NB: legacy `cai_lnav` emits the arrival flag in field 12 (the spec
+     reserves field 12 for closing velocity, field 13 for arrival).
+     We preserve that byte-for-byte so this lift is a pure refactor of
+     CaiLNav's helper.  The LX160 ignores fields beyond 11 anyway. */
+
+  if (destination_name.empty()) {
+    snprintf(buffer, buffer_size,
+             "GPRMB,A,,,,,,,,,%06.1f,%04.1f,%c",
+             range_nm, bearing_deg, arrival);
+    return true;
+  }
+
+  /* truncate the name to a NMEA-friendly size, preserving valid UTF-8
+     and stripping any embedded commas that would forge extra fields */
+  char name_buf[16];
+  const auto name_len =
+    std::min(destination_name.size(), sizeof(name_buf) - 1);
+  std::memcpy(name_buf, destination_name.data(), name_len);
+  name_buf[name_len] = '\0';
+  CropIncompleteUTF8(name_buf);
+  for (char *p = name_buf; *p != '\0'; ++p)
+    if (*p == ',')
+      *p = '_';
+
+  char lat_buffer[20], lon_buffer[20];
+  FormatLatitude(lat_buffer, sizeof(lat_buffer), destination.latitude);
+  FormatLongitude(lon_buffer, sizeof(lon_buffer), destination.longitude);
+
+  snprintf(buffer, buffer_size,
+           "GPRMB,A,,,,%s,%s,%s,%06.1f,%04.1f,%c",
+           name_buf, lat_buffer, lon_buffer,
+           range_nm, bearing_deg, arrival);
+  return true;
 }
 
 void

--- a/src/Formatter/NMEAFormatter.hpp
+++ b/src/Formatter/NMEAFormatter.hpp
@@ -5,6 +5,11 @@
 
 #include "NMEA/Info.hpp"
 
+#include <string_view>
+
+struct GeoPoint;
+struct AGeoPoint;
+
 /**
  * GPRMC,<1>,<2>,<3>,<4>,<5>,<6>,<7>,<8>,<9>,<10>,<11>
  * 
@@ -89,6 +94,40 @@ FormatGPGGA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
  */
 void
 FormatGPGSA(char *buffer, size_t buffer_size, const NMEAInfo &info) noexcept;
+
+/**
+ * GPRMB,<1>,,,,<5>,<6>,<7>,<8>,<9>,<10>,<11>,<12>
+ *
+ * Recommended Minimum Navigation Information (waypoint info)
+ * NMEA 2.00 Standard
+ *
+ * <1>  Position Valid (A = valid, V = invalid)
+ * <5>  Destination waypoint identifier
+ * <6>  Destination latitude, ddmm.mmm
+ * <7>  Destination latitude hemisphere, N or S
+ * <8>  Destination longitude, dddmm.mmm
+ * <9>  Destination longitude hemisphere, E or W
+ * <10> Range from present position to destination, nautical miles XXXX.X
+ * <11> Bearing from present position to destination, degrees true XXX.X
+ * <12> Arrival flag (A = arrival, V = not arrival)
+ *
+ * Note: the NMEA 0183 spec reserves field 12 for closing velocity and
+ * places the arrival flag in field 13.  We deliberately emit the arrival
+ * flag in field 12 (with no closing velocity) to preserve byte-for-byte
+ * compatibility with the long-standing Cambridge L-Nav (cai_lnav) output;
+ * the LX160 (and other consumers of cai_lnav's dialect) ignore fields
+ * beyond 11 anyway.
+ *
+ * If `destination_name` is empty, fields 5-9 are emitted blank, matching
+ * the long-standing output of the Cambridge L-Nav driver.
+ *
+ * Returns false (and leaves @buffer untouched) when @here or @destination
+ * is invalid.
+ */
+bool
+FormatGPRMB(char *buffer, size_t buffer_size,
+            const GeoPoint &here, const AGeoPoint &destination,
+            std::string_view destination_name = {}) noexcept;
 
 /*
  * PGRMZ,<1>,<2>,<3>

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -174,6 +174,9 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
   MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
   map.Get(buffer, config.sync_to_device);
 
+  MakeDeviceSettingName(buffer, "Port", n, "SendPosition");
+  map.Get(buffer, config.send_position);
+
   MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
   map.Get(buffer, config.k6bt);
 
@@ -271,6 +274,9 @@ Profile::SetDeviceConfig(ProfileMap &map,
 
   MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
   map.Set(buffer, config.sync_to_device);
+
+  MakeDeviceSettingName(buffer, "Port", n, "SendPosition");
+  map.Set(buffer, config.send_position);
 
   MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
   map.Set(buffer, config.k6bt);


### PR DESCRIPTION
## Summary

New `LX160` device driver for the LX Navigation LX160 — a legacy vario / final-glide computer (no internal GPS) widely flown in club fleets.

Until now LX160 owners had to choose:

- the `cai_lnav` driver — writes `$GPRMC` / `$GPRMB` but doesn't parse `$LXWP`, or
- the `LX` driver — parses `$LXWP` but doesn't write position sentences.

Both leave one direction of the LX160's bidirectional NMEA port idle. This driver combines both: reuses the LXWP0/2/3 parsers from the LX driver (exposed via a new `LX/Parsers.hpp`) and emits `$GPGGA` + `$GPRMC` + `$GPRMB` on each calculation tick using shared `NMEAFormatter` helpers.

## Commits

1. **`Formatter/NMEAFormatter: Lift FormatGPRMB out of CaiLNav`** — moves the file-static helper to the shared formatter so multiple drivers can share it. Adds an optional `destination_name` parameter (default empty) for future field-5–9 enrichment. CaiLNav byte-for-byte unchanged.

2. **`Device/Config: Add SEND_POSITION capability and send_position toggle`** — new `DeviceRegister::SEND_POSITION` capability flag and matching `DeviceConfig::send_position` bool (default ON), wired through profile load/save and an "Emit GPGGA/GPRMC" expert checkbox in the Edit Device dialog. The row is hidden for drivers that don't advertise the flag, so existing drivers are unaffected.

3. **`Device/Driver/LX: Expose LXWP0/LXWP2/LXWP3 via Parsers.hpp`** — drops `static` from the three helpers in `LX/Parser.cpp` and adds a lightweight forward-declaration header. Sibling drivers can now reuse the LXWP parsing without including the heavy `Internal.hpp` surface that carries the full `LXDevice` declaration / logger / protocol state. No change to the LX driver itself.

4. **`Device/Driver/LX160: New driver for LX Navigation LX160`** — the driver itself.

## Capabilities

| Flag | Reason |
|---|---|
| `RECEIVE_SETTINGS` | LXWP2 carries MC, ballast, bugs read into XCSoar |
| `SEND_POSITION` | gates the new "Emit GPGGA/GPRMC" toggle |
| `PASS_THROUGH` | enables pairing with a second driver (typically FLARM) on the same transport via the existing "Use second device" UI |

`DECLARE`, `LOGGER`, `MANAGE`, `SEND_SETTINGS` are intentionally **not** advertised:

- The LX160 manual (v0212, ch. 9.13 + ch. 11) lists only `$GPGGA` / `$GPRMB` / `$GPRMC` as accepted input sentences — there is no NMEA path for task declaration or logger access.
- Bench-testing `$PFLX2` (the LX1600/MiniMap MC-write form) confirmed the LX160 silently ignores it. Ballast and bugs are physical front-panel switches anyway. So write-side settings sync would be no-ops; better to not advertise them.

## Echo handling

The LX160 echoes any `$GPGGA` / `$GPRMC` it receives back onto its NMEA OUT line (verified on bench). The driver handles both modes of operation:

- **`send_position = ON`** (XCSoar is the GPS source): swallow the echoes silently — they're our own data bouncing back, not a second GPS fix.
- **`send_position = OFF`** (external GPS feeds the LX160 directly): pass the incoming `$GPGGA` / `$GPRMC` through to XCSoar's generic parser — those echoes are then the only GPS path into XCSoar.

This makes one toggle do double duty: it gates both the outbound emission and the inbound swallow, with consistent semantics ("XCSoar provides position").

## Tested

Bench-tested against a real LX160 (firmware sw 2.10) at 4800 bps RS232:

- LXWP0 vario / TAS / pressure altitude → XCSoar info boxes track
- LXWP2 MC, ballast → XCSoar settings track the front-panel state
- LXWP2 bugs → confirmed **not** propagating on LX160 firmware sw 2.10. The existing `LX/Parser.cpp` decoder uses the documented `bugs = 2 − f3` rule for the LX160 quirk, but on sw 2.10 f3 stays hardcoded at 1.0 and the actual bugs value is encoded into the polar `a` coefficient (f4) instead. Not introduced by this PR — same behavior as the existing LX driver. Worth a follow-up to teach the parser to fall back to the polar-`a` shift on this firmware.
- LXWP1 device identity → populated in `info.device`
- `$GPGGA` + `$GPRMC` → LX160 displays position
- `$GPRMB` → LX160 displays distance / bearing / arrival flag for the active task leg
- `send_position = OFF` → echoed `$GPGGA` / `$GPRMC` reach XCSoar's generic parser, no double-source warnings

## Open questions for review

These were flagged in the linked feature-request doc and we'd appreciate maintainer guidance:

1. **Driver name** — chosen here as `LX160` / display `LX160` to mirror the device's marketing name. Other LX drivers use `LX` / display `LXNAV`. Happy to align.
2. **GPRMB field 5–9 enrichment** — the new `FormatGPRMB` already takes an optional `destination_name` parameter so a future patch can fill the active waypoint name + destination lat/lon without further formatter changes. We left the population for a follow-up because reaching the active waypoint name from `OnCalculatedUpdate` requires touching `ElementStat` / `TaskStats` (which currently carry only the location, not the name). Happy to roll that in if preferred, or split.
3. **PASS_THROUGH semantics** — we set this on the LX160 driver to enable the existing "Use second device" UI for muxed transports (LX160 + FLARM on one BLE/serial channel, mirroring the hardware-daisy-chain pattern). The driver doesn't override `EnablePassThrough()` since the muxing happens at the transport layer, not in the device. Let us know if you'd prefer a separate capability flag for the UI gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LX160 device driver is now available for selection.
  * New expert setting "Emit GPGGA/GPRMC" lets compatible drivers emit periodic GPS position output; visibility is gated to drivers that support it.
  * Device profiles now persist the "Emit GPGGA/GPRMC" per-port setting.

* **Improvements**
  * Improved waypoint/navigation sentence formatting (GPRMB) with better range/bearing and destination naming.
  * LX160 suppresses echoed device GPS sentences when position emission is enabled to avoid duplicate position sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->