### PR TITLE
Dialogs, Task/AlternatesList, Input: Waypoint details nesting and browse lists

### DIFF
--- a/.cursor/rules/search-dialog-ux.mdc
+++ b/.cursor/rules/search-dialog-ux.mdc
@@ -1,0 +1,73 @@
+---
+description: Stacked search dialogs (filter + list + optional details) — lifecycle and commit contract
+globs:
+  - "src/Dialogs/**/*.cpp"
+  - "src/Dialogs/**/*.hpp"
+  - "src/Input/InputEvents*.cpp"
+  - "src/Input/InputEvents*.hpp"
+alwaysApply: false
+---
+
+# Search dialog UX (general)
+
+Applies to **modal search UIs**: filter controls + result list, optionally opening a **second modal** (details, preview, editor) on top. Not every list dialog uses this pattern—see **Pick-only** vs **Browse** below.
+
+## Pick-only vs browse (persistent outer dialog)
+
+1. **Pick-only** — User chooses a row and the **outer** dialog closes immediately with a return value (or callback). No nested “return to list after closing child” loop.  
+   *Example:* `ShowWaypointListDialog` for Goto lookup or task relocate.
+
+2. **Browse** — Outer search **stays open** while the user opens and closes a **child** dialog on top. The user can inspect several rows without restarting the search.  
+   *Example:* `ShowWaypointListPersistentDialog` + waypoint details.
+
+Do not mix these casually: pick-only callers expect a single modal lifetime; browse mode requires an explicit **commit** signal to close the outer dialog.
+
+## When the outer search should dismiss
+
+The **outer** dialog should close only when:
+
+- The user **cancels** from the outer UI (**Esc**, outer **Close**), **or**
+- The **child** reports a **committed action** that should end the whole flow (navigation change, task change, data saved, etc.).
+
+Closing the **child** with “no commit” (e.g. **Close** / browse done) must return to the **outer** list **without** dismissing the outer dialog.
+
+## Communicating commit: optional out-parameter
+
+When the child modal is shared between “standalone” and “nested under search” contexts, use an optional trailing **`bool *committed`** (or equivalent name):
+
+- **`nullptr`** — Child behaves as today; no parent search to coordinate.
+- **Non-null** — Reset to **`false`** when opening the child. Set **`true`** only before `SetModalResult` / close when the action should **dismiss the parent search**.
+
+**Child “Close” / browse exit** must set **`false`** (or leave **`false`**).
+
+**Set `true` only on success paths** that actually changed state (avoid **`true`** on validation errors or cancelled sub-dialogs).
+
+## Visibility: parent must not hide the result
+
+If the **outer** dialog is **fullscreen or covers the main map**, and a child action updates something the user must **see on the map** (pan, zoom, centre, obvious map redraw), then that action should typically set **`committed = true`** so the **outer** closes and the map is visible.
+
+If the outer were non-blocking or transparent, a different rule might apply; XCSoar search UIs are usually opaque modals.
+
+## Adding actions on the child
+
+For each new button or flow that closes the child:
+
+- **Browse / cancel / no lasting change** → do **not** set committed (or set **`false`** explicitly on the dismiss path).
+- **Lasting change** the user should see on the underlying app (map, task, profile, list data) → set **`*committed = true`** before closing when the pointer is non-null.
+
+## Input events and aliases
+
+Prefer **one** documented event path for a given browse search (e.g. `WaypointDetails` `select`). Keep **legacy event names** only for **`.xci` / profile compatibility** when they duplicate behaviour; document them as aliases in code comments.
+
+## Reference implementation (waypoint search)
+
+- **Pick-only:** `ShowWaypointListDialog` in `Dialogs/Waypoint/WaypointList.cpp`
+- **Browse + details:** `ShowWaypointListPersistentDialog`, `WaypointListPersistentWidget::OnWaypointListEnter`
+- **Child + flag:** `dlgWaypointDetailsShowModal(..., bool *state_change_committed)` in `Dialogs/Waypoint/dlgWaypointDetails.cpp` and command buttons in `WaypointCommandsWidget`
+- **Input:** `InputEvents::eventWaypointDetails` (`select` vs `current`), `eventWaypointDetailsPersistent` (alias)
+
+Reuse the same **ideas** for other search+details stacks (airspace lists, alternates, map item lists, etc.); reuse **names** only where it stays readable.
+
+## NEWS
+
+User-visible behaviour changes belong in **`NEWS.txt`** under the current unreleased version.

--- a/.cursor/rules/search-dialog-ux.mdc
+++ b/.cursor/rules/search-dialog-ux.mdc
@@ -18,7 +18,7 @@ Applies to **modal search UIs**: filter controls + result list, optionally openi
    *Example:* `ShowWaypointListDialog` for Goto lookup or task relocate.
 
 2. **Browse** — Outer search **stays open** while the user opens and closes a **child** dialog on top. The user can inspect several rows without restarting the search.  
-   *Example:* `ShowWaypointListPersistentDialog` + waypoint details.
+   *Examples:* `ShowWaypointListPersistentDialog` + waypoint details; `dlgAlternatesListShowModal` + details (same nested-modal pattern).
 
 Do not mix these casually: pick-only callers expect a single modal lifetime; browse mode requires an explicit **commit** signal to close the outer dialog.
 
@@ -31,20 +31,21 @@ The **outer** dialog should close only when:
 
 Closing the **child** with “no commit” (e.g. **Close** / browse done) must return to the **outer** list **without** dismissing the outer dialog.
 
-## Communicating commit: optional out-parameter
+## Communicating commit: WaypointDetailsNesting (waypoint details)
 
-When the child modal is shared between “standalone” and “nested under search” contexts, use an optional trailing **`bool *committed`** (or equivalent name):
+`dlgWaypointDetailsShowModal` takes an optional const **`WaypointDetailsNesting *`** (default `nullptr` = no parent; same as all-null). See `Dialogs/Waypoint/WaypointDialogs.hpp`.
 
-- **`nullptr`** — Child behaves as today; no parent search to coordinate.
-- **Non-null** — Reset to **`false`** when opening the child. Set **`true`** only before `SetModalResult` / close when the action should **dismiss the parent search**.
+- **`state_change_committed`** — Dismiss the parent list when a commit completes (GoTo, task, home, edit, pan with default include-pan, …). **Close** on the details dialog must not leave it **`true`**.
 
-**Child “Close” / browse exit** must set **`false`** (or leave **`false`**).
+- **`include_pan_in_parent_dismissal`** (default `true`) — If **`false`**, pan (header and commands) does not set `state_change_committed`.
 
-**Set `true` only on success paths** that actually changed state (avoid **`true`** on validation errors or cancelled sub-dialogs).
+- **`map_pan_from_details`** — If non-null, set to **`true`** when the user panned the map to the waypoint before leaving (for callers that need to know pan vs GoTo).
+
+**Set `*state_change_committed` to `true` only on success paths.**
 
 ## Visibility: parent must not hide the result
 
-If the **outer** dialog is **fullscreen or covers the main map**, and a child action updates something the user must **see on the map** (pan, zoom, centre, obvious map redraw), then that action should typically set **`committed = true`** so the **outer** closes and the map is visible.
+If the **outer** dialog is **fullscreen** and a child action must show a **full map** result, that action should typically set **`*state_change_committed = true`** (default `include_pan_in_parent_dismissal`) so the **outer** closes and the map is visible.
 
 If the outer were non-blocking or transparent, a different rule might apply; XCSoar search UIs are usually opaque modals.
 
@@ -52,8 +53,8 @@ If the outer were non-blocking or transparent, a different rule might apply; XCS
 
 For each new button or flow that closes the child:
 
-- **Browse / cancel / no lasting change** → do **not** set committed (or set **`false`** explicitly on the dismiss path).
-- **Lasting change** the user should see on the underlying app (map, task, profile, list data) → set **`*committed = true`** before closing when the pointer is non-null.
+- **Browse / cancel / no lasting change** → do **not** set `*state_change_committed` to **`true`**.
+- **Lasting change** the user should see on the map or task → set **`*state_change_committed = true`** before closing when the pointer is non-null.
 
 ## Input events and aliases
 
@@ -63,10 +64,12 @@ Prefer **one** documented event path for a given browse search (e.g. `WaypointDe
 
 - **Pick-only:** `ShowWaypointListDialog` in `Dialogs/Waypoint/WaypointList.cpp`
 - **Browse + details:** `ShowWaypointListPersistentDialog`, `WaypointListPersistentWidget::OnWaypointListEnter`
-- **Child + flag:** `dlgWaypointDetailsShowModal(..., bool *state_change_committed)` in `Dialogs/Waypoint/dlgWaypointDetails.cpp` and command buttons in `WaypointCommandsWidget`
+- **Browse + details (alternates list):** `dlgAlternatesListShowModal` keeps the list in `ShowModal`.  **Details** is a button callback to `dlgWaypointDetailsShowModalForBrowseParent` (not a separate modal result that ends the list first).  If details reports a state change, the list is dismissed with `SetModalResult(mrOK)`.
+- **Child + nesting:** `dlgWaypointDetailsShowModal` with `WaypointDetailsNesting` in `dlgWaypointDetails` and `WaypointCommandsWidget`
 - **Input:** `InputEvents::eventWaypointDetails` (`select` vs `current`), `eventWaypointDetailsPersistent` (alias)
+- **Shared helper:** `dlgWaypointDetailsShowModalForBrowseParent` in `WaypointDialogs` / `dlgWaypointDetails` — use from persistent search and the alternates list.  `AlternatesListDialog` passes `Waypoints *` to `CreateButtons` for the details path
 
-Reuse the same **ideas** for other search+details stacks (airspace lists, alternates, map item lists, etc.); reuse **names** only where it stays readable.
+Reuse the same **ideas** for other search+details stacks; reuse **names** only where it stays readable.
 
 ## NEWS
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -40,6 +40,10 @@ Version 7.45 - not yet released
   - Quick Guide "What's New": release notes are Markdown generated at build time
     from NEWS.txt (headings + merged list lines) instead of truncating the
     gzipped file at runtime
+  - waypoint search: stays open until Esc or a successful GoTo / task / home / pan
+    action (pan ends the search so the map is not hidden under the list); same for
+    WaypointDetails select and WaypointDetailsPersistent (was: only after closing
+    details) #749
 * android
   - use physical display metrics for startup DPI (getRealMetrics) #1784
   - UI sounds via preloaded SoundPool (MediaPlayer fallback for early play or
@@ -783,7 +787,6 @@ Version 7.21 - 2021/12/11
   - Control backlight brightness of the Kobo Glo HD
 * Android
   - re-enable background location and comply with Google Play Store policy
-
 Version 7.20 - 2021/10/22
 * map
   - fix crash in the topography loader

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -44,6 +44,8 @@ Version 7.45 - not yet released
     action (pan ends the search so the map is not hidden under the list); same for
     WaypointDetails select and WaypointDetailsPersistent (was: only after closing
     details) #749
+  - waypoint list & alternates: waypoint details open above the list; Close without
+    a committed action returns to the list, not the map #620
 * android
   - use physical display metrics for startup DPI (getRealMetrics) #1784
   - UI sounds via preloaded SoundPool (MediaPlayer fallback for early play or

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -29,8 +29,6 @@
 #include <cassert>
 #include <optional>
 
-static constexpr int DETAILS_MODAL_RESULT = 100;
-
 class AlternatesListWidget final
   : public ListWidget {
   const DialogLook &dialog_look;
@@ -52,7 +50,7 @@ public:
   AlternateList alternates;
 
 public:
-  void CreateButtons(WidgetDialog &dialog);
+  void CreateButtons(WidgetDialog &dialog, Waypoints *waypoints_for_details = nullptr) noexcept;
 
 public:
   explicit
@@ -180,7 +178,8 @@ private:
 };
 
 void
-AlternatesListWidget::CreateButtons(WidgetDialog &dialog)
+AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
+                                    Waypoints *waypoints_for_details) noexcept
 {
   if (!select_mode) {
     goto_button = dialog.AddButton(_("Goto"), [this](){
@@ -225,8 +224,28 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog)
     });
   }
 
-  if (!select_mode)
-    details_button = dialog.AddButton(_("Details"), DETAILS_MODAL_RESULT);
+  if (!select_mode) {
+    details_button = dialog.AddButton(
+      _("Details"),
+      [this, &dialog, waypoints_for_details]() noexcept {
+        if (!HasValidSelection())
+          return;
+
+        Waypoints *wpts = waypoints_for_details;
+        if (wpts == nullptr && data_components != nullptr)
+          wpts = data_components->waypoints.get();
+        if (wpts == nullptr)
+          return;
+
+        WaypointPtr w(GetSelectedWaypointPtr());
+        if (w == nullptr)
+          return;
+
+        if (dlgWaypointDetailsShowModalForBrowseParent(
+              wpts, std::move(w), true, true))
+          dialog.SetModalResult(mrOK);
+      });
+  }
 
   set_active_freq_button = dialog.AddButton(_("Set Active Frequency"), [this](){
     if (!HasValidSelection())
@@ -301,20 +320,11 @@ dlgAlternatesListShowModal(Waypoints *waypoints,
   TWidgetDialog<AlternatesListWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(), dialog_look,
            title);
-  widget->CreateButtons(dialog);
+  widget->CreateButtons(dialog, waypoints);
   dialog.FinishPreliminary(std::move(widget));
   dialog.EnableCursorSelection();
 
-  const int result = dialog.ShowModal();
-  if (result != DETAILS_MODAL_RESULT)
-    return;
-
-  int i = (int)dialog.GetWidget().GetCursorIndex();
-  if (i < 0 || (unsigned)i >= dialog.GetWidget().alternates.size())
-    return;
-
-  dlgWaypointDetailsShowModal(waypoints,
-                              dialog.GetWidget().alternates[i].waypoint, true);
+  dialog.ShowModal();
 }
 
 WaypointPtr

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -241,6 +241,9 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
         if (w == nullptr)
           return;
 
+        /* allow_navigation + allow_edit: like the persistent list;
+         * alternates are task-adjacent; editing user waypoints
+         * (e.g. user.cup) stays available from this entry point. */
         if (dlgWaypointDetailsShowModalForBrowseParent(
               wpts, std::move(w), true, true))
           dialog.SetModalResult(mrOK);

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
@@ -229,34 +229,53 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   RowFormWidget::Prepare(parent, rc);
   
   replace_button = AddButton(_("Replace in Task"), [this](){
-    if (ReplaceInTask(*task_manager, waypoint) && form != nullptr)
+    if (ReplaceInTask(*task_manager, waypoint) && form != nullptr) {
+      if (state_change_committed != nullptr)
+        *state_change_committed = true;
       form->SetModalResult(mrOK);
+    }
   });
 
   insert_button = AddButton(_("Insert in Task"), [this](){
-    if (InsertInTask(*task_manager, waypoint) && form != nullptr)
+    if (InsertInTask(*task_manager, waypoint) && form != nullptr) {
+      if (state_change_committed != nullptr)
+        *state_change_committed = true;
       form->SetModalResult(mrOK);
+    }
   });
 
   append_button = AddButton(_("Append to Task"), [this](){
-    if (AppendToTask(*task_manager, waypoint) && form != nullptr)
+    if (AppendToTask(*task_manager, waypoint) && form != nullptr) {
+      if (state_change_committed != nullptr)
+        *state_change_committed = true;
       form->SetModalResult(mrOK);
+    }
   });
     
   remove_button = AddButton(_("Remove from Task"), [this](){
-      if (RemoveFromTask(*task_manager, *waypoint) && form != nullptr)
+      if (RemoveFromTask(*task_manager, *waypoint) && form != nullptr) {
+        if (state_change_committed != nullptr)
+          *state_change_committed = true;
         form->SetModalResult(mrOK);
+      }
     });
   
   home_button = AddButton(_("Set as New Home"), [this](){
     SetHome(waypoints, *waypoint);
-    if (form != nullptr)
+    if (form != nullptr) {
+      if (state_change_committed != nullptr)
+        *state_change_committed = true;
       form->SetModalResult(mrOK);
+    }
   });
 
   pan_button = AddButton(_("Pan to Waypoint"), [this](){
-    if (ActivatePan(*waypoint) && form != nullptr)
+    /* End parent search too: list dialog is fullscreen and would hide the map. */
+    if (ActivatePan(*waypoint) && form != nullptr) {
+      if (state_change_committed != nullptr)
+        *state_change_committed = true;
       form->SetModalResult(mrOK);
+    }
   });
   
 
@@ -277,7 +296,8 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   wp_copy.origin = WaypointOrigin::USER;
 
   if (dlgWaypointEditShowModal(wp_copy) == WaypointEditResult::MODIFIED) {
-    // TODO: refresh data instead of closing dialog?
+    if (state_change_committed != nullptr)
+      *state_change_committed = true;
     form->SetModalResult(mrOK);
 
     {

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
@@ -222,6 +222,16 @@ WaypointCommandsWidget::UpdateButtons()
 }
 
 void
+WaypointCommandsWidget::CommitParentSearchAndCloseForm() noexcept
+{
+  if (form == nullptr)
+    return;
+  if (nesting.state_change_committed != nullptr)
+    *nesting.state_change_committed = true;
+  form->SetModalResult(mrOK);
+}
+
+void
 WaypointCommandsWidget::Prepare(ContainerWindow &parent,
                                 const PixelRect &rc) noexcept
 {
@@ -229,44 +239,28 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   RowFormWidget::Prepare(parent, rc);
   
   replace_button = AddButton(_("Replace in Task"), [this](){
-    if (ReplaceInTask(*task_manager, waypoint) && form != nullptr) {
-      if (nesting.state_change_committed != nullptr)
-        *nesting.state_change_committed = true;
-      form->SetModalResult(mrOK);
-    }
+    if (ReplaceInTask(*task_manager, waypoint))
+      CommitParentSearchAndCloseForm();
   });
 
   insert_button = AddButton(_("Insert in Task"), [this](){
-    if (InsertInTask(*task_manager, waypoint) && form != nullptr) {
-      if (nesting.state_change_committed != nullptr)
-        *nesting.state_change_committed = true;
-      form->SetModalResult(mrOK);
-    }
+    if (InsertInTask(*task_manager, waypoint))
+      CommitParentSearchAndCloseForm();
   });
 
   append_button = AddButton(_("Append to Task"), [this](){
-    if (AppendToTask(*task_manager, waypoint) && form != nullptr) {
-      if (nesting.state_change_committed != nullptr)
-        *nesting.state_change_committed = true;
-      form->SetModalResult(mrOK);
-    }
+    if (AppendToTask(*task_manager, waypoint))
+      CommitParentSearchAndCloseForm();
   });
     
   remove_button = AddButton(_("Remove from Task"), [this](){
-      if (RemoveFromTask(*task_manager, *waypoint) && form != nullptr) {
-        if (nesting.state_change_committed != nullptr)
-          *nesting.state_change_committed = true;
-        form->SetModalResult(mrOK);
-      }
-    });
+    if (RemoveFromTask(*task_manager, *waypoint))
+      CommitParentSearchAndCloseForm();
+  });
   
   home_button = AddButton(_("Set as New Home"), [this](){
     SetHome(waypoints, *waypoint);
-    if (form != nullptr) {
-      if (nesting.state_change_committed != nullptr)
-        *nesting.state_change_committed = true;
-      form->SetModalResult(mrOK);
-    }
+    CommitParentSearchAndCloseForm();
   });
 
   pan_button = AddButton(_("Pan to Waypoint"), [this](){
@@ -298,9 +292,7 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   wp_copy.origin = WaypointOrigin::USER;
 
   if (dlgWaypointEditShowModal(wp_copy) == WaypointEditResult::MODIFIED) {
-    if (nesting.state_change_committed != nullptr)
-      *nesting.state_change_committed = true;
-    form->SetModalResult(mrOK);
+    CommitParentSearchAndCloseForm();
 
     {
       ScopeSuspendAllThreads suspend;

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
@@ -230,32 +230,32 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   
   replace_button = AddButton(_("Replace in Task"), [this](){
     if (ReplaceInTask(*task_manager, waypoint) && form != nullptr) {
-      if (state_change_committed != nullptr)
-        *state_change_committed = true;
+      if (nesting.state_change_committed != nullptr)
+        *nesting.state_change_committed = true;
       form->SetModalResult(mrOK);
     }
   });
 
   insert_button = AddButton(_("Insert in Task"), [this](){
     if (InsertInTask(*task_manager, waypoint) && form != nullptr) {
-      if (state_change_committed != nullptr)
-        *state_change_committed = true;
+      if (nesting.state_change_committed != nullptr)
+        *nesting.state_change_committed = true;
       form->SetModalResult(mrOK);
     }
   });
 
   append_button = AddButton(_("Append to Task"), [this](){
     if (AppendToTask(*task_manager, waypoint) && form != nullptr) {
-      if (state_change_committed != nullptr)
-        *state_change_committed = true;
+      if (nesting.state_change_committed != nullptr)
+        *nesting.state_change_committed = true;
       form->SetModalResult(mrOK);
     }
   });
     
   remove_button = AddButton(_("Remove from Task"), [this](){
       if (RemoveFromTask(*task_manager, *waypoint) && form != nullptr) {
-        if (state_change_committed != nullptr)
-          *state_change_committed = true;
+        if (nesting.state_change_committed != nullptr)
+          *nesting.state_change_committed = true;
         form->SetModalResult(mrOK);
       }
     });
@@ -263,19 +263,21 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   home_button = AddButton(_("Set as New Home"), [this](){
     SetHome(waypoints, *waypoint);
     if (form != nullptr) {
-      if (state_change_committed != nullptr)
-        *state_change_committed = true;
+      if (nesting.state_change_committed != nullptr)
+        *nesting.state_change_committed = true;
       form->SetModalResult(mrOK);
     }
   });
 
   pan_button = AddButton(_("Pan to Waypoint"), [this](){
-    /* End parent search too: list dialog is fullscreen and would hide the map. */
-    if (ActivatePan(*waypoint) && form != nullptr) {
-      if (state_change_committed != nullptr)
-        *state_change_committed = true;
-      form->SetModalResult(mrOK);
-    }
+    if (!ActivatePan(*waypoint) || form == nullptr)
+      return;
+    if (nesting.map_pan_from_details != nullptr)
+      *nesting.map_pan_from_details = true;
+    if (nesting.include_pan_in_parent_dismissal &&
+        nesting.state_change_committed != nullptr)
+      *nesting.state_change_committed = true;
+    form->SetModalResult(mrOK);
   });
   
 
@@ -296,8 +298,8 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
   wp_copy.origin = WaypointOrigin::USER;
 
   if (dlgWaypointEditShowModal(wp_copy) == WaypointEditResult::MODIFIED) {
-    if (state_change_committed != nullptr)
-      *state_change_committed = true;
+    if (nesting.state_change_committed != nullptr)
+      *nesting.state_change_committed = true;
     form->SetModalResult(mrOK);
 
     {

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "WaypointDialogs.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Engine/Waypoint/Ptr.hpp"
 
@@ -25,13 +26,7 @@ class WaypointCommandsWidget final
 
   const bool allow_edit;
 
-  /**
-   * When not null, set to true if the user completed an action that should
-   * dismiss a parent "search" dialog (GoTo, task change, set home, pan, …).
-   * Pan sets this so the map is visible; otherwise the list stays fullscreen
-   * on top of the panned view.
-   */
-  bool *const state_change_committed;
+  const WaypointDetailsNesting nesting;
 
   bool has_freq;
   enum Buttons {
@@ -48,17 +43,22 @@ class WaypointCommandsWidget final
 
   Button *replace_button, *insert_button, *append_button, *remove_button, *home_button, *pan_button, *set_active_button, *set_standby_button, *edit_button;
 
+  /**
+   * Mark a parent browse-search as committed and close this form (no-op if
+   * #form is null).
+   */
+  void CommitParentSearchAndCloseForm() noexcept;
+
 public:
   WaypointCommandsWidget(const DialogLook &look, WndForm *_form,
                          Waypoints *_waypoints,
                          WaypointPtr _waypoint,
-                         ProtectedTaskManager *_task_manager,
-                         bool _allow_edit,
-                         bool *state_change_committed = nullptr) noexcept
+                         ProtectedTaskManager *_task_manager, bool _allow_edit,
+                         const WaypointDetailsNesting &_nesting) noexcept
     :RowFormWidget(look), form(_form),
      waypoints(_waypoints),
      waypoint(std::move(_waypoint)), task_manager(_task_manager),
-     allow_edit(_allow_edit), state_change_committed(state_change_committed) {}
+     allow_edit(_allow_edit), nesting(_nesting) {}
   void UpdateButtons();
   /* methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
@@ -24,7 +24,15 @@ class WaypointCommandsWidget final
   ProtectedTaskManager *const task_manager;
 
   const bool allow_edit;
-  
+
+  /**
+   * When not null, set to true if the user completed an action that should
+   * dismiss a parent "search" dialog (GoTo, task change, set home, pan, …).
+   * Pan sets this so the map is visible; otherwise the list stays fullscreen
+   * on top of the panned view.
+   */
+  bool *const state_change_committed;
+
   bool has_freq;
   enum Buttons {
     REPLACE_IN_TASK,
@@ -45,11 +53,12 @@ public:
                          Waypoints *_waypoints,
                          WaypointPtr _waypoint,
                          ProtectedTaskManager *_task_manager,
-                         bool _allow_edit) noexcept
+                         bool _allow_edit,
+                         bool *state_change_committed = nullptr) noexcept
     :RowFormWidget(look), form(_form),
      waypoints(_waypoints),
      waypoint(std::move(_waypoint)), task_manager(_task_manager),
-     allow_edit(_allow_edit) {}
+     allow_edit(_allow_edit), state_change_committed(state_change_committed) {}
   void UpdateButtons();
   /* methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -14,6 +14,10 @@ WaypointPtr
 ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &location,
                        OrderedTask *ordered_task = nullptr,
                        unsigned ordered_task_index = 0);
+void
+ShowWaypointListPersistentDialog(
+  const GeoPoint &location, bool allow_navigation = true,
+  bool allow_edit = true);
 
 void
 dlgConfigWaypointsShowModal(Waypoints &waypoints) noexcept;
@@ -36,9 +40,9 @@ WaypointEditResult
 dlgWaypointEditShowModal(Waypoint &way_point);
 
 void
-dlgWaypointDetailsShowModal(Waypoints *waypoints, WaypointPtr waypoint,
-                            bool allow_navigation = true,
-                            bool allow_edit = false);
+dlgWaypointDetailsShowModal(
+  Waypoints *waypoints, WaypointPtr waypoint, bool allow_navigation = true,
+  bool allow_edit = false, bool *state_change_committed = nullptr) noexcept;
 
 bool
 PopupNearestWaypointDetails(Waypoints &waypoints,

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -39,10 +39,44 @@ enum class WaypointEditResult {
 WaypointEditResult
 dlgWaypointEditShowModal(Waypoint &way_point);
 
+/**
+ * Optional coordination between nested \ref dlgWaypointDetailsShowModal and a
+ * parent list dialog. All pointers, when non-null, refer to the caller; on
+ * open, the modal assigns @c false to the locations pointed to by
+ * @c state_change_committed and @c map_pan_from_details when they are
+ * non-null.
+ */
+struct WaypointDetailsNesting {
+  bool *state_change_committed = nullptr;
+
+  /** If false, pan (header or commands) does not set #state_change_committed. */
+  bool include_pan_in_parent_dismissal = true;
+
+  /**
+   * If non-null, set to true when the user panned the map to the waypoint
+   * (Pan To / Pan to Waypoint) before leaving details, regardless of
+   * #include_pan_in_parent_dismissal.
+   */
+  bool *map_pan_from_details = nullptr;
+};
+
 void
 dlgWaypointDetailsShowModal(
   Waypoints *waypoints, WaypointPtr waypoint, bool allow_navigation = true,
-  bool allow_edit = false, bool *state_change_committed = nullptr) noexcept;
+  bool allow_edit = false,
+  const WaypointDetailsNesting *nesting = nullptr) noexcept;
+
+/**
+ * Run #dlgWaypointDetailsShowModal with #WaypointDetailsNesting and only
+ * #state_change_committed set, for a parent list in browse mode.
+ *
+ * @return true if the user committed a state-changing action in details
+ * (the parent may dismiss with #mrOK when so).
+ */
+[[nodiscard]] bool
+dlgWaypointDetailsShowModalForBrowseParent(
+  Waypoints *waypoints, WaypointPtr &&waypoint, bool allow_navigation,
+  bool allow_edit) noexcept;
 
 bool
 PopupNearestWaypointDetails(Waypoints &waypoints,

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -103,22 +103,21 @@ struct WaypointListDialogState
 
 class WaypointFilterWidget;
 
-class WaypointListWidget final
+class WaypointListWidget
   : public ListWidget, public DataFieldListener,
     NullBlackboardListener {
   Waypoints &way_points;
+  TwoTextRowsRenderer row_renderer;
 
+protected:
   WndForm &dialog;
+  WaypointList items;
 
   WaypointFilterWidget &filter_widget;
 
-  WaypointList items;
-
-  TwoTextRowsRenderer row_renderer;
-
+private:
   const GeoPoint location;
   Angle last_heading;
-
   OrderedTask *const ordered_task;
   const unsigned ordered_task_index;
 
@@ -136,7 +135,7 @@ public:
 
   void UpdateList();
 
-  void OnWaypointListEnter();
+  virtual void OnWaypointListEnter();
 
   WaypointPtr GetCursorObject() const {
     return items.empty()
@@ -176,6 +175,23 @@ public:
 private:
   /* virtual methods from BlackboardListener */
   void OnGPSUpdate([[maybe_unused]] const MoreData &basic) override;
+};
+
+class WaypointListPersistentWidget final
+  : public WaypointListWidget {
+  const bool allow_navigation;
+  const bool allow_edit;
+
+public:
+  WaypointListPersistentWidget(Waypoints &_way_points, WndForm &_dialog,
+                               WaypointFilterWidget &_filter_widget,
+                               GeoPoint _location, Angle _heading,
+                               bool _allow_navigation, bool _allow_edit)
+    :WaypointListWidget(_way_points, _dialog, _filter_widget, _location, _heading,
+                        nullptr, 0),
+     allow_navigation(_allow_navigation), allow_edit(_allow_edit) {}
+
+  void OnWaypointListEnter() override;
 };
 
 class WaypointFilterWidget : public RowFormWidget {
@@ -288,6 +304,7 @@ FillLastUsedList(WaypointList &list,
     list.emplace_back(std::move(waypoint));
   }
 }
+
 
 void
 WaypointListWidget::UpdateList()
@@ -478,6 +495,22 @@ WaypointListWidget::OnWaypointListEnter()
 }
 
 void
+WaypointListPersistentWidget::OnWaypointListEnter()
+{
+  if (items.empty()) {
+    filter_widget.GetControl(NAME).BeginEditing();
+    return;
+  }
+
+  bool state_change = false;
+  dlgWaypointDetailsShowModal(data_components->waypoints.get(),
+                              items[GetList().GetCursorIndex()].waypoint,
+                              allow_navigation, allow_edit, &state_change);
+  if (state_change)
+    dialog.SetModalResult(mrOK);
+}
+
+void
 WaypointListWidget::OnActivateItem([[maybe_unused]] unsigned index) noexcept
 {
   OnWaypointListEnter();
@@ -537,3 +570,40 @@ ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
     ? list_widget_.GetCursorObject()
     : nullptr;
 }
+
+void
+ShowWaypointListPersistentDialog(const GeoPoint &_location,
+                                 bool allow_navigation, bool allow_edit)
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+
+  const Angle heading = CommonInterface::Basic().attitude.heading;
+
+  dialog_state.name.clear();
+
+  WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+                      look, _("Select Waypoint"));
+
+  auto left_widget =
+    std::make_unique<TwoWidgets>(std::make_unique<WaypointFilterWidget>(look, heading),
+                                 std::make_unique<WaypointListButtons>(look, dialog),
+                                 true);
+
+  auto &filter_widget = (WaypointFilterWidget &)left_widget->GetFirst();
+  auto &buttons_widget = (WaypointListButtons &)left_widget->GetSecond();
+
+  auto list_widget = std::make_unique<WaypointListPersistentWidget>(
+    *data_components->waypoints, dialog, filter_widget, _location, heading,
+    allow_navigation, allow_edit);
+
+  filter_widget.SetListener(list_widget.get());
+  buttons_widget.SetList(list_widget.get());
+
+  TwoWidgets *widget = new TwoWidgets(std::move(left_widget),
+                                      std::move(list_widget),
+                                      false);
+
+  dialog.FinishPreliminary(widget);
+  dialog.ShowModal();
+}
+

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -574,6 +574,9 @@ void
 ShowWaypointListPersistentDialog(const GeoPoint &_location,
                                  bool allow_navigation, bool allow_edit)
 {
+  if (data_components == nullptr || data_components->waypoints == nullptr)
+    return;
+
   const DialogLook &look = UIGlobals::GetDialogLook();
 
   const Angle heading = CommonInterface::Basic().attitude.heading;

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -502,11 +502,10 @@ WaypointListPersistentWidget::OnWaypointListEnter()
     return;
   }
 
-  bool state_change = false;
-  dlgWaypointDetailsShowModal(data_components->waypoints.get(),
-                              items[GetList().GetCursorIndex()].waypoint,
-                              allow_navigation, allow_edit, &state_change);
-  if (state_change)
+  if (dlgWaypointDetailsShowModalForBrowseParent(
+        data_components->waypoints.get(),
+        WaypointPtr(items[GetList().GetCursorIndex()].waypoint), allow_navigation,
+        allow_edit))
     dialog.SetModalResult(mrOK);
 }
 

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -178,6 +178,8 @@ class WaypointDetailsWidget final
 
   ProtectedTaskManager *const task_manager;
 
+  bool *const state_change_committed;
+
   Button goto_button;
   Button magnify_button, shrink_button;
   Button previous_button, next_button;
@@ -207,12 +209,15 @@ class WaypointDetailsWidget final
 public:
   WaypointDetailsWidget(WidgetDialog &_dialog,
                         Waypoints *waypoints, WaypointPtr _waypoint,
-                        ProtectedTaskManager *_task_manager, bool allow_edit) noexcept
+                        ProtectedTaskManager *_task_manager, bool allow_edit,
+                        bool *state_change_out) noexcept
     :dialog(_dialog),
      waypoint(std::move(_waypoint)),
      task_manager(_task_manager),
+     state_change_committed(state_change_out),
      commands_widget(new WaypointCommandsWidget(look, &dialog, waypoints, waypoint,
-                                                task_manager, allow_edit)) {}
+                                                task_manager, allow_edit,
+                                                state_change_out)) {}
 
   /**
    * Resolve the source file path for this waypoint from its
@@ -493,11 +498,14 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
     goto_button.Create(parent, look.button, _("GoTo"), layout.goto_button,
                        button_style, [this](){ OnGotoClicked(); });
   else {
-	goto_button.Create(parent, look.button, _("Pan To"), layout.goto_button,
-                       button_style, [this](){
-    if (ActivatePan(*waypoint))
-      dialog.SetModalResult(mrOK);
-  });  
+    goto_button.Create(parent, look.button, _("Pan To"), layout.goto_button,
+                       button_style, [this]() {
+                         if (ActivatePan(*waypoint)) {
+                           if (state_change_committed != nullptr)
+                             *state_change_committed = true;
+                           dialog.SetModalResult(mrOK);
+                         }
+                       });
   }
 
   if (!images.empty()) {
@@ -518,7 +526,11 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                      [this](){ NextPage(1); });
 
   close_button.Create(parent, look.button, _("Close"), layout.close_button,
-                      button_style, dialog.MakeModalResultCallback(mrOK));
+                      button_style, [this]() {
+                        if (state_change_committed != nullptr)
+                          *state_change_committed = false;
+                        dialog.SetModalResult(mrOK);
+                      });
 
   info_widget.Initialise(parent, layout.main);
   info_widget.Prepare();
@@ -723,6 +735,8 @@ WaypointDetailsWidget::OnGotoClicked()
   }
 
   task_manager->DoGoto(waypoint);
+  if (state_change_committed != nullptr)
+    *state_change_committed = true;
   dialog.SetModalResult(mrOK);
 
   CommonInterface::main_window->FullRedraw();
@@ -927,17 +941,22 @@ WaypointDetailsWidget::UpdateCaption() noexcept
 
 void
 dlgWaypointDetailsShowModal(Waypoints *waypoints, WaypointPtr _waypoint,
-                            bool allow_navigation, bool allow_edit)
+                            bool allow_navigation, bool allow_edit,
+                            bool *state_change_committed) noexcept
 {
   LastUsedWaypoints::Add(*_waypoint);
+
+  if (state_change_committed != nullptr)
+    *state_change_committed = false;
 
   const DialogLook &look = UIGlobals::GetDialogLook();
   TWidgetDialog<WaypointDetailsWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
            look, nullptr);
-  dialog.SetWidget(dialog, waypoints, _waypoint,
-                   allow_navigation ? backend_components->protected_task_manager.get() : nullptr,
-                   allow_edit);
+  dialog.SetWidget(
+    dialog, waypoints, _waypoint,
+    allow_navigation ? backend_components->protected_task_manager.get() : nullptr,
+    allow_edit, state_change_committed);
 
   dialog.GetWidget().InitCaption();
   dialog.GetWidget().UpdateCaption();

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -178,7 +178,7 @@ class WaypointDetailsWidget final
 
   ProtectedTaskManager *const task_manager;
 
-  bool *const state_change_committed;
+  const WaypointDetailsNesting nesting;
 
   Button goto_button;
   Button magnify_button, shrink_button;
@@ -210,14 +210,14 @@ public:
   WaypointDetailsWidget(WidgetDialog &_dialog,
                         Waypoints *waypoints, WaypointPtr _waypoint,
                         ProtectedTaskManager *_task_manager, bool allow_edit,
-                        bool *state_change_out) noexcept
+                        const WaypointDetailsNesting &_nesting) noexcept
     :dialog(_dialog),
      waypoint(std::move(_waypoint)),
      task_manager(_task_manager),
-     state_change_committed(state_change_out),
+     nesting(_nesting),
      commands_widget(new WaypointCommandsWidget(look, &dialog, waypoints, waypoint,
                                                 task_manager, allow_edit,
-                                                state_change_out)) {}
+                                                _nesting)) {}
 
   /**
    * Resolve the source file path for this waypoint from its
@@ -501,8 +501,11 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
     goto_button.Create(parent, look.button, _("Pan To"), layout.goto_button,
                        button_style, [this]() {
                          if (ActivatePan(*waypoint)) {
-                           if (state_change_committed != nullptr)
-                             *state_change_committed = true;
+                           if (nesting.map_pan_from_details != nullptr)
+                             *nesting.map_pan_from_details = true;
+                           if (nesting.include_pan_in_parent_dismissal &&
+                               nesting.state_change_committed != nullptr)
+                             *nesting.state_change_committed = true;
                            dialog.SetModalResult(mrOK);
                          }
                        });
@@ -527,8 +530,8 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
 
   close_button.Create(parent, look.button, _("Close"), layout.close_button,
                       button_style, [this]() {
-                        if (state_change_committed != nullptr)
-                          *state_change_committed = false;
+                        if (nesting.state_change_committed != nullptr)
+                          *nesting.state_change_committed = false;
                         dialog.SetModalResult(mrOK);
                       });
 
@@ -735,8 +738,8 @@ WaypointDetailsWidget::OnGotoClicked()
   }
 
   task_manager->DoGoto(waypoint);
-  if (state_change_committed != nullptr)
-    *state_change_committed = true;
+  if (nesting.state_change_committed != nullptr)
+    *nesting.state_change_committed = true;
   dialog.SetModalResult(mrOK);
 
   CommonInterface::main_window->FullRedraw();
@@ -942,12 +945,20 @@ WaypointDetailsWidget::UpdateCaption() noexcept
 void
 dlgWaypointDetailsShowModal(Waypoints *waypoints, WaypointPtr _waypoint,
                             bool allow_navigation, bool allow_edit,
-                            bool *state_change_committed) noexcept
+                            const WaypointDetailsNesting *nesting) noexcept
 {
+  if (_waypoint == nullptr)
+    return;
+
   LastUsedWaypoints::Add(*_waypoint);
 
-  if (state_change_committed != nullptr)
-    *state_change_committed = false;
+  const WaypointDetailsNesting k_default;
+  const WaypointDetailsNesting &N = nesting != nullptr ? *nesting : k_default;
+
+  if (N.state_change_committed != nullptr)
+    *N.state_change_committed = false;
+  if (N.map_pan_from_details != nullptr)
+    *N.map_pan_from_details = false;
 
   const DialogLook &look = UIGlobals::GetDialogLook();
   TWidgetDialog<WaypointDetailsWidget>
@@ -956,10 +967,24 @@ dlgWaypointDetailsShowModal(Waypoints *waypoints, WaypointPtr _waypoint,
   dialog.SetWidget(
     dialog, waypoints, _waypoint,
     allow_navigation ? backend_components->protected_task_manager.get() : nullptr,
-    allow_edit, state_change_committed);
+    allow_edit, N);
 
   dialog.GetWidget().InitCaption();
   dialog.GetWidget().UpdateCaption();
 
   dialog.ShowModal();
+}
+
+bool
+dlgWaypointDetailsShowModalForBrowseParent(
+  Waypoints *waypoints, WaypointPtr &&waypoint, bool allow_navigation,
+  bool allow_edit) noexcept
+{
+  bool state_change = false;
+  const WaypointDetailsNesting nesting{
+    .state_change_committed = &state_change,
+  };
+  dlgWaypointDetailsShowModal(waypoints, std::move(waypoint), allow_navigation,
+                                allow_edit, &nesting);
+  return state_change;
 }

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -168,6 +168,7 @@ void eventTaskTransition(const char *misc);
 void eventTerrainTopography(const char *misc);
 void eventTerrainTopology(const char *misc);
 void eventWaypointDetails(const char *misc);
+void eventWaypointDetailsPersistent(const char *misc);
 void eventWaypointEditor(const char *misc);
 void eventZoom(const char *misc);
 void eventBrightness(const char *misc);

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -343,8 +343,9 @@ InputEvents::eventAnalysis([[maybe_unused]] const char *misc)
 // WaypointDetails
 // Displays waypoint details
 //         current: the current active waypoint
-//          select: brings up the waypoint selector, if the user then
-//                  selects a waypoint, then the details dialog is shown.
+//          select: opens waypoint search; details on selection; search stays
+//                  open until Esc or a successful GoTo / task / home / pan in
+//                  details (pan dismisses search so the map is visible).
 //  See the waypoint dialog section of the reference manual
 // for more info.
 void
@@ -373,12 +374,22 @@ InputEvents::eventWaypointDetails(const char *misc)
     allow_navigation = false;
     allow_edit = false;
   } else if (StringIsEqual(misc, "select")) {
-    wp = ShowWaypointListDialog(*data_components->waypoints, basic.location);
+    /* List stays open until Esc or a navigation/task change in details. */
+    ShowWaypointListPersistentDialog(basic.location, true, true);
+    return;
   }
   if (wp)
-    dlgWaypointDetailsShowModal(data_components->waypoints.get(),
-                                std::move(wp),
+    dlgWaypointDetailsShowModal(data_components->waypoints.get(), std::move(wp),
                                 allow_navigation, allow_edit);
+}
+
+// WaypointDetailsPersistent: same list+details flow as "WaypointDetails" select
+// (kept for existing .xci configurations).
+void
+InputEvents::eventWaypointDetailsPersistent(gcc_unused const char *misc)
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  ShowWaypointListPersistentDialog(basic.location, true, true);
 }
 
 void


### PR DESCRIPTION
## Summary

- **Persistent waypoint search** (`ShowWaypointListPersistentDialog`): plumbs optional `WaypointDetailsNesting` so waypoint details can report a *committed* action; the outer list is dismissed on commit (e.g. GoTo, pan) and not when the user only closes details without changing task/navigation.
- **Waypoint details / commands** share the nesting contract in `dlgWaypointDetails` and `WaypointCommandsWidget`.
- **Alternates list** now matches the same *browse* pattern: details opens on top of the list (no separate modal result that finished the list first). On a committed state change from details, the list closes with `SetModalResult(mrOK)`.
- **Input:** documents `eventWaypointDetailsPersistent` as the alias for the persistent list entry (see `InputEvents` / defaults).
- **.cursor:** `search-dialog-ux.mdc` updated to describe this stack.

Supersedes the long-standing #749 (nested list + details flow); see comment there.

Closes #620.

## How to test

- Open the persistent waypoint list, open details, use Close only → you should return to the list. Use GoTo (or a flow that sets `state_change_committed`) → the list should close and the map should reflect the change.
- Open alternates (e.g. from the InfoBox), open **Details** on a row, close details without a commit → you should be back on the alternates list; with a commit → list should close as for the persistent list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waypoint search now stays open until Esc or a successful navigation action (GoTo, task, home, or pan); pan closes the search so the map isn’t obscured. Waypoint Details open without forcing the list to close and only dismiss the list when a details action commits a state change. A persistent waypoint search/list flow is now available via input bindings.

* **Documentation**
  * Updated v7.45 notes to document the new waypoint search lifecycle; minor v7.21 formatting fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
