### PR TITLE
Quick Guide: touch checkboxes, command-line override, Getting Started ticks

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -40,6 +40,11 @@ Version 7.45 - not yet released
   - Quick Guide "What's New": release notes are Markdown generated at build time
     from NEWS.txt (headings + merged list lines) instead of truncating the
     gzipped file at runtime
+  - Quick Guide, getting started: "Safety factors" and "Terrain display" lines
+    use live settings vs factory defaults (not hardcoded unchecked) #2324
+  - Quick Guide, help & configuration checklists: list checkboxes use dialog
+    look and min touch row height; keyboard focus frame on the checkbox; override
+    touch autodetection with -touchscreen or -notouchscreen (non-Android) #2325
   - waypoint search: stays open until Esc or a successful GoTo / task / home / pan
     action (pan ends the search so the map is not hidden under the list); same for
     WaypointDetails select and WaypointDetailsPersistent (was: only after closing

--- a/src/Asset.cpp
+++ b/src/Asset.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Asset.hpp"
+#include "CommandLine.hpp"
 
 #if defined(USE_CONSOLE) || defined(USE_WAYLAND)
 #include "ui/event/Globals.hpp"
@@ -20,10 +21,16 @@ HasPointer() noexcept
 
 #if defined(USE_LIBINPUT) || defined(USE_WAYLAND)
 
+static bool
+HasTouchScreenHardware() noexcept
+{
+  return UI::event_queue->HasTouchScreen();
+}
+
 bool
 HasTouchScreen() noexcept
 {
-  return UI::event_queue->HasTouchScreen();
+  return CommandLine::ApplyTouchInputOverride(HasTouchScreenHardware());
 }
 
 bool
@@ -32,4 +39,4 @@ HasKeyboard() noexcept
   return UI::event_queue->HasKeyboard();
 }
 
-#endif
+#endif /* USE_LIBINPUT || USE_WAYLAND */

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -143,20 +143,26 @@ HasPointer() noexcept
 
 #endif
 
+#if !defined(USE_LIBINPUT) && !defined(USE_WAYLAND)
+#include "CommandLine.hpp"
+#endif
+
 /**
  * Does this device have a touch screen?  This is useful to know for
  * sizing controls, as a touch screen may require bigger areas.
+ * The @c -touchscreen and @c -notouchscreen switches (when the host
+ * supports the command line) can override autodetection.
  */
 #if defined(USE_LIBINPUT) || defined(USE_WAYLAND)
 [[gnu::pure]]
 bool
 HasTouchScreen() noexcept;
 #else
-constexpr
 static inline bool
 HasTouchScreen() noexcept
 {
-  return IsAndroid() || IsKobo() || IsIOS();
+  return CommandLine::ApplyTouchInputOverride(
+    IsAndroid() || IsKobo() || IsIOS());
 }
 #endif
 

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -96,6 +96,10 @@ CommandLine::Parse(Args &args)
     } else if (StringIsEqual(s, "-small")) {
       width = 320;
       height = 240;
+    } else if (StringIsEqual(s, "-touchscreen")) {
+      touch_input = TouchInput::Force;
+    } else if (StringIsEqual(s, "-notouchscreen")) {
+      touch_input = TouchInput::Disable;
 #ifdef HAVE_CMDLINE_FULLSCREEN
     } else if (StringIsEqual(s, "-fullscreen")) {
       full_screen = true;

--- a/src/CommandLine.hpp
+++ b/src/CommandLine.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif
@@ -10,6 +12,33 @@
 class Args;
 
 namespace CommandLine {
+
+  /**
+   * If Auto, @ref HasTouchScreen follows device detection.  Force/Disable
+   * come from the @c -touchscreen and @c -notouchscreen switches; if both
+   * are given, the last one wins.
+   */
+  enum class TouchInput : uint8_t { Auto, Force, Disable };
+  inline TouchInput touch_input = TouchInput::Auto;
+
+  /**
+   * Apply the command-line @ref touch_input override to a hardware
+   * detection value.
+   */
+  inline bool
+  ApplyTouchInputOverride(bool from_hardware) noexcept
+  {
+    switch (touch_input) {
+    case TouchInput::Force:
+      return true;
+    case TouchInput::Disable:
+      return false;
+    case TouchInput::Auto:
+    default:
+      return from_hardware;
+    }
+  }
+
   extern unsigned width, height;
 
 #ifdef KOBO

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -211,13 +211,12 @@ protected:
                const PixelRect &rc) noexcept override {
     Layout layout(rc);
 
+    expert.CreateInDialogForm(parent, look, _("Expert"), layout.expert,
+                              [](bool value){ OnUserLevel(value); });
+
     WindowStyle style;
     style.Hide();
     style.TabStop();
-
-    expert.Create(parent, look, _("Expert"),
-                  layout.expert, style,
-                  [](bool value){ OnUserLevel(value); });
 
     button2.Create(parent, look.button, "", layout.button2, style);
     button1.Create(parent, look.button, "", layout.button1, style);

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -29,7 +29,10 @@
 #endif
 #include "util/StringCompare.hxx"
 #include "util/StaticString.hxx"
+#include "MapSettings.hpp"
+#include "Computer/Settings.hpp"
 
+#include <cmath>
 #include <vector>
 
 // Page indices for the can-advance guard
@@ -135,6 +138,54 @@ IsAnyDeviceConfigured() noexcept
   return false;
 }
 
+/**
+ * @return true when safety-related settings have been changed from
+ *         factory defaults (or when we cannot use defaults for comparison).
+ */
+static bool
+SafetyFactorsDifferFromDefaults() noexcept
+{
+  const auto &cs = CommonInterface::GetComputerSettings();
+  const auto &t = cs.task;
+  const auto &p = cs.polar;
+
+  TaskBehaviour d_task;
+  d_task.SetDefaults();
+  PolarSettings d_pol;
+  d_pol.SetDefaults();
+
+  static constexpr double eps = 1e-4;
+  if (std::abs(t.safety_height_arrival - d_task.safety_height_arrival) > eps)
+    return true;
+  if (std::abs(t.route_planner.safety_height_terrain -
+               d_task.route_planner.safety_height_terrain) > eps)
+    return true;
+  if (t.abort_task_mode != d_task.abort_task_mode)
+    return true;
+  if (std::abs(p.degradation_factor - d_pol.degradation_factor) > eps)
+    return true;
+  if (p.auto_bugs != d_pol.auto_bugs)
+    return true;
+  if (std::abs(t.safety_mc - d_task.safety_mc) > eps)
+    return true;
+  if (std::abs(t.risk_gamma - d_task.risk_gamma) > eps)
+    return true;
+  return false;
+}
+
+/**
+ * @return true when terrain or topography display was customized away from
+ *         the default look (ramp, shading, contours, enable flags, …).
+ */
+static bool
+TerrainDisplayDiffersFromDefaults() noexcept
+{
+  MapSettings d;
+  d.SetDefaults();
+  const auto &m = CommonInterface::GetMapSettings();
+  return m.terrain != d.terrain || m.topography_enabled != d.topography_enabled;
+}
+
 static const char *
 GetConfigurationHelpText()
 {
@@ -151,6 +202,9 @@ GetConfigurationHelpText()
 
   bool tim_enabled = false;
   Profile::Get(ProfileKeys::EnableThermalInformationMap, tim_enabled);
+
+  const bool has_safety = SafetyFactorsDifferFromDefaults();
+  const bool has_terrain_display = TerrainDisplayDiffersFromDefaults();
 
   static StaticString<1536> text;
   text.Format(
@@ -169,9 +223,9 @@ GetConfigurationHelpText()
     "Upload flights automatically to WeGlide\n\n"
     "- [%s] [Thermal Information Map](xcsoar://config/weather) - "
     "Show thermal locations from thermalmap.info on the map\n\n"
-    "- [ ] [Safety factors](xcsoar://config/safety) - "
+    "- [%s] [Safety factors](xcsoar://config/safety) - "
     "Set arrival height, terrain clearance and polar degradation\n\n"
-    "- [ ] [Terrain display](xcsoar://config/terrain) - "
+    "- [%s] [Terrain display](xcsoar://config/terrain) - "
     "Choose terrain colors, shading and contour lines\n\n"
     "- [ ] [Live tracking](xcsoar://config/tracking) *(optional)* - "
     "Share your position via SkyLines or LiveTrack24\n\n"
@@ -182,7 +236,9 @@ GetConfigurationHelpText()
     has_pilot ? "x" : " ",
     has_device ? "x" : " ",
     weglide_enabled ? "x" : " ",
-    tim_enabled ? "x" : " ");
+    tim_enabled ? "x" : " ",
+    has_safety ? "x" : " ",
+    has_terrain_display ? "x" : " ");
   return text.c_str();
 }
 

--- a/src/Form/CheckBox.cpp
+++ b/src/Form/CheckBox.cpp
@@ -3,6 +3,7 @@
 
 #include "Form/CheckBox.hpp"
 #include "Look/DialogLook.hpp"
+#include "ui/window/Window.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/event/KeyCode.hpp"
 #include "Screen/Layout.hpp"
@@ -69,6 +70,19 @@ CheckBoxControl::Create(ContainerWindow &parent, const DialogLook &_look,
   callback = std::move(_callback);
 
   PaintWindow::Create(parent, rc, style);
+}
+
+void
+CheckBoxControl::CreateInDialogForm(ContainerWindow &parent,
+                                    const DialogLook &look,
+                                    std::string::const_pointer caption,
+                                    const PixelRect &rc,
+                                    Callback callback) noexcept
+{
+  WindowStyle style;
+  style.Hide();
+  style.TabStop();
+  Create(parent, look, caption, rc, style, std::move(callback));
 }
 
 unsigned

--- a/src/Form/CheckBox.hpp
+++ b/src/Form/CheckBox.hpp
@@ -42,6 +42,16 @@ public:
               const WindowStyle style,
               Callback _callback) noexcept;
 
+  /**
+   * Same as @ref Create, but with the @c WindowStyle that dialog bottom
+   * bars and configuration panels use (@c Hide + @c TabStop) — the pattern
+   * used for the configuration dialog "Expert" check box and the quick
+   * guide.
+   */
+  void CreateInDialogForm(ContainerWindow &parent, const DialogLook &look,
+                          std::string::const_pointer caption, const PixelRect &rc,
+                          Callback callback) noexcept;
+
   [[gnu::pure]]
   static unsigned GetMinimumWidth(const DialogLook &look, unsigned height,
                                   std::string::const_pointer caption) noexcept;

--- a/src/InfoBoxes/Panel/MacCreadySetup.cpp
+++ b/src/InfoBoxes/Panel/MacCreadySetup.cpp
@@ -27,12 +27,9 @@ void
 MacCreadySetupPanel::Prepare(ContainerWindow &parent,
                              const PixelRect &rc) noexcept
 {
-  WindowStyle style;
-  style.Hide();
-  style.TabStop();
-
   auto w = std::make_unique<CheckBoxControl>();
-  w->Create(parent, UIGlobals::GetDialogLook(), _("Auto"), rc, style, [](bool value){
+  w->CreateInDialogForm(parent, UIGlobals::GetDialogLook(), _("Auto"), rc,
+                        [](bool value) {
     TaskBehaviour &task_behaviour = CommonInterface::SetComputerSettings().task;
     task_behaviour.auto_mc = value;
     Profile::Set(ProfileKeys::AutoMc, task_behaviour.auto_mc);

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -375,6 +375,10 @@ Startup(UI::Display &display)
   /* Log device capabilities and features after initialization */
   LogFormat("Device capabilities: HasIOIOLib()=%s",
             HasIOIOLib() ? "yes" : "no");
+  if (CommandLine::touch_input == CommandLine::TouchInput::Force)
+    LogFormat("Touch input mode: forced on (see command line)");
+  else if (CommandLine::touch_input == CommandLine::TouchInput::Disable)
+    LogFormat("Touch input mode: forced off (see command line)");
 #if !defined(NON_INTERACTIVE) && !defined(USE_X11)
   LogFormat("Device capabilities: HasPointer()=%s",
             HasPointer() ? "yes" : "no");

--- a/src/Widget/QuickGuidePageWidget.cpp
+++ b/src/Widget/QuickGuidePageWidget.cpp
@@ -194,8 +194,8 @@ QuickGuidePageWidget::CreateBottomBar(ContainerWindow &parent,
 
   case BottomBarType::CHECKBOX:
     checkbox = std::make_unique<CheckBoxControl>();
-    checkbox->Create(parent, look, checkbox_label.c_str(), rc,
-                     style, checkbox_callback);
+    checkbox->CreateInDialogForm(parent, look, checkbox_label.c_str(), rc,
+                                 checkbox_callback);
     checkbox->SetState(checkbox_initial_state);
     break;
 

--- a/src/Widget/RichTextWidget.cpp
+++ b/src/Widget/RichTextWidget.cpp
@@ -82,6 +82,7 @@ RichTextWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   w->SetFont(dialog_look.text_font, &dialog_look.bold_font,
              &dialog_look.heading1_font, &dialog_look.heading2_font);
   w->SetDarkMode(dialog_look.dark_mode, dialog_look.background_color);
+  w->SetDialogLook(dialog_look);
 
   if (link_return_callback)
     w->SetInternalLinkReturnCallback(link_return_callback);

--- a/src/XCSoar.cpp
+++ b/src/XCSoar.cpp
@@ -59,6 +59,8 @@ static const char *const Usage = "\n"
 #if !defined(ANDROID)
   "  -dpi=DPI        force usage of DPI for pixel density\n"
   "  -dpi=XDPIxYDPI  force usage of XDPI and YDPI for pixel density\n"
+  "  -touchscreen     use touch UI (larger controls); overrides detection\n"
+  "  -notouchscreen   use non-touch UI; overrides touch detection\n"
 #endif
 #ifdef HAVE_CMDLINE_FULLSCREEN
   "  -fullscreen     full-screen mode\n"

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -12,6 +12,7 @@
 #include "Screen/Layout.hpp"
 #include "Look/Colors.hpp"
 #include "ResourceLookup.hpp"
+#include "Form/CheckBox.hpp"
 #include "system/OpenLink.hpp"
 #include "util/StringCompare.hxx"
 #include "util/UriSchemes.hpp"
@@ -38,6 +39,44 @@ IsTouchLayout() noexcept
 {
   return Layout::GetMaximumControlHeight() >
          Layout::GetMinimumControlHeight();
+}
+
+/**
+ * The processed line starts a checkbox span (first line of a list item
+ * with "- [ ]" / "- [x]"), not a wrapped continuation line.
+ */
+[[gnu::pure]]
+static bool
+LineSpanStartsWithCheckbox(const ParsedMarkdown &p,
+                           std::size_t line_start) noexcept
+{
+  for (const auto &span : p.styles) {
+    if ((span.style == TextStyle::Checkbox ||
+         span.style == TextStyle::CheckboxChecked) &&
+        span.start == line_start)
+      return true;
+  }
+  return false;
+}
+
+/**
+ * Pixel size of the square checkbox cell (not including suffix gap).
+ * Touch layouts use at least the standard control row height so
+ * checkboxes are as tappable as buttons in dialogs.
+ */
+[[gnu::pure]]
+static int
+CheckboxBoxSize(const Font &font) noexcept
+{
+  const int text_line_height = font.GetLineSpacing();
+  const int box_margin = static_cast<int>(Layout::ScalePenWidth(2));
+  if (!IsTouchLayout())
+    return text_line_height - 2 * box_margin;
+
+  const int from_text = text_line_height - 2 * box_margin;
+  const int from_row = static_cast<int>(Layout::GetMaximumControlHeight()) -
+                       2 * box_margin;
+  return std::max({from_text, from_row, 4});
 }
 
 /**
@@ -344,6 +383,13 @@ RichTextWindow::EnsureLineLayout() const noexcept
       }
     }
 
+    if (IsTouchLayout() && font != nullptr &&
+        block_img == nullptr &&
+        LineSpanStartsWithCheckbox(parsed, line.start)) {
+      const int need = CheckboxBoxSize(*font) + Layout::Scale(4);
+      line_heights[i] = std::max(line_heights[i], need);
+    }
+
     y += line_heights[i];
   }
 
@@ -538,15 +584,8 @@ MeasureNumberedListPrefixWidth(const Font &font, const std::string &text,
 static int
 CheckboxPrefixWidth(const Font &font) noexcept
 {
-  const int text_line_height = font.GetLineSpacing();
-  const int box_margin = Layout::ScalePenWidth(2);
-  const int box_size =
-    IsTouchLayout()
-      ? std::max(text_line_height - box_margin,
-                 static_cast<int>(Layout::GetMinimumControlHeight()) / 2)
-      : text_line_height - box_margin * 2;
-  const int box_gap = Layout::Scale(4);
-  return box_size + box_gap;
+  const int box_size = CheckboxBoxSize(font);
+  return box_size + Layout::Scale(4);
 }
 
 /**
@@ -869,31 +908,37 @@ RichTextWindow::RenderLinkSegment(Canvas &canvas,
 void
 RichTextWindow::RenderCheckboxSegment(Canvas &canvas,
                                       const TextSegment &seg,
-                                      int &x, int text_y,
-                                      int visible_top,
-                                      int text_line_height) noexcept
+                                      int &x, int y_line, int visible_top,
+                                      int row_height) noexcept
 {
   const std::size_t style_idx = FindCheckboxStyleIndex(seg.start);
-
-  const int box_margin = Layout::ScalePenWidth(2);
-  const int box_size = IsTouchLayout()
-    ? std::max(text_line_height - box_margin,
-               static_cast<int>(
-                 Layout::GetMinimumControlHeight()) / 2)
-    : text_line_height - box_margin * 2;
-  const int box_y = text_y + (text_line_height - box_size) / 2;
+  const int box_size = CheckboxBoxSize(*font);
+  const int box_y = y_line + (row_height - box_size) / 2;
   PixelRect box_rc{x, box_y, x + box_size, box_y + box_size};
 
   bool checked = (style_idx != SIZE_MAX)
     ? IsCheckboxChecked(style_idx)
     : seg.IsCheckboxChecked();
-  bool focused = (style_idx != SIZE_MAX) &&
-                 IsCheckboxFocused(style_idx);
-  DrawSimpleCheckbox(canvas, box_rc, checked, focused, dark_mode);
+  const bool key_focused = (style_idx != SIZE_MAX) &&
+                          IsCheckboxFocused(style_idx);
+  if (dialog_look != nullptr) {
+    /* Outer focus square (same idea as #RenderLinkSegment); DrawCheckBox
+       only changes inner border, not a visible selection frame. */
+    if (key_focused && HasFocus()) {
+      const unsigned focus_w = Layout::ScalePenWidth(2);
+      PixelRect focus_rc = box_rc;
+      focus_rc.Grow((int)focus_w);
+      canvas.Select(Pen(focus_w, COLOR_XCSOAR_LIGHT));
+      canvas.SelectHollowBrush();
+      canvas.DrawRectangle(focus_rc);
+    }
+    DrawCheckBox(canvas, *dialog_look, box_rc, checked, key_focused, false, true);
+  } else
+    DrawSimpleCheckbox(canvas, box_rc, checked, key_focused, dark_mode);
 
   if (style_idx != SIZE_MAX) {
     /* Expand hit area on touch screens for easier tapping */
-    const int cb_expand = IsTouchLayout() ? Layout::Scale(4) : 0;
+    const int cb_expand = IsTouchLayout() ? Layout::Scale(6) : 0;
     PixelRect click_rc{x - cb_expand,
                        box_y + visible_top - cb_expand,
                        x + box_size + cb_expand,
@@ -1072,8 +1117,8 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
                           text_line_height);
       else if (seg.IsCheckbox())
         RenderCheckboxSegment(sub_canvas, seg,
-                              x, text_y, visible_top,
-                              text_line_height);
+                              x, y, visible_top,
+                              cur_line_height);
       else
         RenderPlainSegment(sub_canvas, seg, text_data,
                            x, text_y);
@@ -1248,8 +1293,7 @@ FindCurrentFocusIndex(
 }
 
 void
-RichTextWindow::ScrollToFocusItem(const FocusItem &item,
-                                  int text_line_height) noexcept
+RichTextWindow::ScrollToFocusItem(const FocusItem &item) noexcept
 {
   if (item.is_checkbox) {
     focused_checkbox_style = item.index;
@@ -1268,8 +1312,7 @@ RichTextWindow::ScrollToFocusItem(const FocusItem &item,
 
     /* Convert content-space Y to parent coordinates */
     const int item_top = item.y_pos + window_rect.top;
-    const int item_bottom =
-      item.y_pos + text_line_height + window_rect.top;
+    const int item_bottom = item.y_pos + item.height + window_rect.top;
 
     if (item_top < scroll_margin ||
         item_bottom > parent_height - scroll_margin) {
@@ -1280,7 +1323,7 @@ RichTextWindow::ScrollToFocusItem(const FocusItem &item,
         scroll_rc.top = item.y_pos - scroll_margin;
         scroll_rc.bottom = scroll_rc.top + 1;
       } else {
-        scroll_rc.top = item.y_pos + text_line_height + scroll_margin;
+        scroll_rc.top = item.y_pos + item.height + scroll_margin;
         scroll_rc.bottom = scroll_rc.top + 1;
       }
       parent->ScrollTo(scroll_rc);
@@ -1294,8 +1337,7 @@ bool
 RichTextWindow::AdvanceFocusToNextFrom(
   const std::vector<FocusItem> &items,
   std::optional<std::size_t> current_pos,
-  int max_jump,
-  int text_line_height) noexcept
+  int max_jump) noexcept
 {
   if (!current_pos.has_value())
     return false;
@@ -1313,7 +1355,7 @@ RichTextWindow::AdvanceFocusToNextFrom(
       return false;
     }
     focus_exhausted_up = false;
-    ScrollToFocusItem(next, text_line_height);
+    ScrollToFocusItem(next);
     return true;
   }
 
@@ -1387,14 +1429,13 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
       if (best != nullptr && best->y_pos <= visible_bottom) {
         focus_exhausted_down = false;
         focus_exhausted_up = false;
-        ScrollToFocusItem(*best, text_line_height);
+        ScrollToFocusItem(*best);
         return true;
       }
       /* No suitable item — let scroll widget handle it */
       return false;
     }
-    return AdvanceFocusToNextFrom(items, current_pos, max_jump,
-                                  text_line_height);
+    return AdvanceFocusToNextFrom(items, current_pos, max_jump);
 
   case KEY_UP:
     if (!current_pos.has_value()) {
@@ -1416,7 +1457,7 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
       if (best != nullptr && best->y_pos >= visible_top - text_line_height) {
         focus_exhausted_up = false;
         focus_exhausted_down = false;
-        ScrollToFocusItem(*best, text_line_height);
+        ScrollToFocusItem(*best);
         return true;
       }
       /* No suitable item — let scroll widget handle it */
@@ -1434,7 +1475,7 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
         return false;
       }
       focus_exhausted_down = false;
-      ScrollToFocusItem(prev, text_line_height);
+      ScrollToFocusItem(prev);
       return true;
     } else {
       focused_checkbox_style.reset();
@@ -1449,8 +1490,7 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
   case KEY_RETURN:
     if (focused_checkbox_style.has_value()) {
       ToggleCheckbox(focused_checkbox_style.value());
-      AdvanceFocusToNextFrom(items, current_pos, max_jump,
-                            text_line_height);
+      AdvanceFocusToNextFrom(items, current_pos, max_jump);
       return true;
     }
     if (focused_link.has_value()) {

--- a/src/ui/control/RichTextWindow.hpp
+++ b/src/ui/control/RichTextWindow.hpp
@@ -15,6 +15,7 @@
 #include <vector>
 
 class Font;
+struct DialogLook;
 struct WrappedText;
 struct SegmentedLine;
 struct TextSegment;
@@ -71,6 +72,14 @@ class RichTextWindow : public LinkableWindow {
 
   /** Background color (from DialogLook) */
   Color background_color = COLOR_WHITE;
+
+  /**
+   * When set, Markdown list checkboxes use the same `DrawCheckBox` styling
+   * as `CheckBoxControl` (e.g. quick guide, configuration).  Otherwise
+   * a simple outline is drawn.  The embedding `RichTextWidget` sets this
+   * from the dialog look.
+   */
+  const DialogLook *dialog_look = nullptr;
 
   /** Parsed text with links and styles extracted */
   ParsedMarkdown parsed;
@@ -201,8 +210,8 @@ private:
 
   /** Render a checkbox segment with hit-rect registration. */
   void RenderCheckboxSegment(Canvas &canvas, const TextSegment &seg,
-                             int &x, int text_y, int visible_top,
-                             int text_line_height) noexcept;
+                             int &x, int y_line, int visible_top,
+                             int row_height) noexcept;
 
   /** Render a plain text segment (heading, bold, list item, normal). */
   void RenderPlainSegment(Canvas &canvas, const TextSegment &seg,
@@ -210,8 +219,7 @@ private:
                           int &x, int text_y) const noexcept;
 
   /** Set focus to a FocusItem and scroll to make it visible. */
-  void ScrollToFocusItem(const FocusItem &item,
-                         int text_line_height) noexcept;
+  void ScrollToFocusItem(const FocusItem &item) noexcept;
 
   /**
    * Move focus to the next link or checkbox (same rules as KEY_DOWN when
@@ -219,8 +227,7 @@ private:
    */
   bool AdvanceFocusToNextFrom(const std::vector<FocusItem> &items,
                               std::optional<std::size_t> current_pos,
-                              int max_jump,
-                              int text_line_height) noexcept;
+                              int max_jump) noexcept;
 
 public:
   RichTextWindow() noexcept;
@@ -256,6 +263,10 @@ public:
                    Color _background_color = COLOR_WHITE) noexcept {
     dark_mode = _dark_mode;
     background_color = _background_color;
+  }
+
+  void SetDialogLook(const DialogLook &look) noexcept {
+    dialog_look = &look;
   }
 
   [[gnu::pure]]

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Asset.hpp"
+#include "CommandLine.hpp"
 
 #if (defined(USE_CONSOLE) && !defined(KOBO)) || defined(USE_WAYLAND)
 
@@ -18,7 +19,8 @@ HasPointer() noexcept
 bool
 HasTouchScreen() noexcept
 {
-  return IsAndroid() || IsKobo() || IsIOS();
+  return CommandLine::ApplyTouchInputOverride(
+    IsAndroid() || IsKobo() || IsIOS());
 }
 
 bool


### PR DESCRIPTION
## Summary
- **Command line:** `-touchscreen` / `-notouchscreen` to override `HasTouchScreen()` when autodetection is wrong or for testing; startup log when active; `FakeAsset` aligned for tests.
- **Form / Rich text:** Shared dialog checkbox setup (`CreateInDialogForm`); `RichTextWindow` uses `SetDialogLook` so Markdown list checkboxes match form `DrawCheckBox` styling, larger touch rows, and keyboard focus ring when using the dialog look. Rebased on current `master`.
- **Quick Guide:** Getting Started safety and terrain lines show dynamic `[x]` / `[ ]` from real settings vs defaults (not hardcoded unchecked).

Closes #2324
Closes #2325

## Test plan
- [ ] `TARGET=UNIX` build; open Quick Guide → Configuration help: checkbox size, focus frame (keyboard), tick state for safety/terrain when settings differ from defaults.
- [ ] Optional: `xcsoar -touchscreen` / `-notouchscreen` and confirm UI scale / touch behaviour and startup log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added command-line switches to force or disable touchscreen UI.

* **Improvements**
  * Getting Started guide now shows accurate checklist states for safety and terrain display.
  * Dialog checkboxes and rich-text lists have improved styling, larger touch targets, and better focus rendering.
  * Startup logging now reflects touchscreen override state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->