### PR TITLE
Device/Driver/LX_EOS: Enable Declare and Logger functionality

### DIFF
--- a/src/Device/Driver/LX_EOS/LXEosRegister.cpp
+++ b/src/Device/Driver/LX_EOS/LXEosRegister.cpp
@@ -13,6 +13,7 @@ LXEosCreateOnPort([[maybe_unused]] const DeviceConfig& config,
 const struct DeviceRegister lx_eos_driver = {
   "LxEos",
   "Lx Eos / Era",
+  DeviceRegister::DECLARE | DeviceRegister::LOGGER |
   DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
   LXEosCreateOnPort,
 };


### PR DESCRIPTION
The Lx Eos / Era driver is missing the `DeviceRegister::DECLARE | DeviceRegister::LOGGER` flags, even though the declare and download functionality is implemented and functional. This fixes it.