### PR TITLE
Navigator widget (rebased; supersedes #1064)

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -530,6 +530,7 @@ event=ArmAdvance toggle
 
 # -------------
 # mode=Nav1
+# (Status / Analysis / Target on keys 2--4.)
 # -------------
 
 mode=Nav1
@@ -538,6 +539,30 @@ data=APP1
 event=Mode Nav2
 label=Nav\nPage 2/2
 location=1
+
+mode=Nav1
+type=key
+data=2
+event=Status all
+event=Mode default
+label=Status
+location=2
+
+mode=Nav1
+type=key
+data=3
+event=Analysis
+event=Mode default
+label=Analysis
+location=3
+
+mode=Nav1
+type=key
+data=4
+event=Setup Target
+event=Mode default
+label=Target Show$(CheckTask)$(CheckTaskResumed)
+location=4
 
 mode=Nav1
 type=key
@@ -616,13 +641,7 @@ event=PilotEvent
 label=Pilot Event Announce
 location=7
 
-mode=Nav2
-type=key
-data=9
-event=Setup Target
-event=Mode default
-label=Target Show$(CheckTask)$(CheckTaskResumed)
-location=8
+# (Target moved to Nav1)
 
 # -------------
 # mode=Display1

--- a/build/liblook.mk
+++ b/build/liblook.mk
@@ -23,6 +23,7 @@ LOOK_SOURCES := \
 	$(SRC)/Look/CrossSectionLook.cpp \
 	$(SRC)/Look/GestureLook.cpp \
 	$(SRC)/Look/HorizonLook.cpp \
+	$(SRC)/Look/NavigatorLook.cpp \
 	$(SRC)/Look/TaskLook.cpp \
 	$(SRC)/Look/TrafficLook.cpp \
 	$(SRC)/Look/InfoBoxLook.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -205,6 +205,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Renderer/TextRowRenderer.cpp \
 	$(SRC)/Renderer/TwoTextRowsRenderer.cpp \
 	$(SRC)/Renderer/HorizonRenderer.cpp \
+	$(SRC)/Renderer/NavigatorRenderer.cpp \
 	$(SRC)/Renderer/GradientRenderer.cpp \
 	$(SRC)/Renderer/GlassRenderer.cpp \
 	$(SRC)/Renderer/TransparentRendererCache.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -285,6 +285,8 @@ XCSOAR_SOURCES := \
 	$(SRC)/Gauge/BigThermalAssistantWidget.cpp \
 	$(SRC)/Gauge/FlarmTrafficWindow.cpp \
 	$(SRC)/Gauge/BigTrafficWidget.cpp \
+	$(SRC)/Gauge/NavigatorWidget.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/Gauge/GaugeFLARM.cpp \
 	$(SRC)/Gauge/GaugeThermalAssistant.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -100,6 +100,7 @@ DIALOG_SOURCES = \
 	\
 	$(SRC)/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GaugesConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/VarioConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WindConfigPanel.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -2248,7 +2248,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
-	$(SRC)/Gauge/NavigatorSettings.cpp \
+  $(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/TeamCode/TeamCode.cpp \
 	$(SRC)/TeamCode/Settings.cpp \
 	$(SRC)/Logger/Settings.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1819,6 +1819,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/MapSettings.cpp \
 	$(SRC)/Computer/Settings.cpp \
 	$(SRC)/Computer/Wind/Settings.cpp \
@@ -2247,6 +2248,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
+	$(SRC)/Gauge/NavigatorSettings.cpp \
 	$(SRC)/TeamCode/TeamCode.cpp \
 	$(SRC)/TeamCode/Settings.cpp \
 	$(SRC)/Logger/Settings.cpp \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -137,6 +137,44 @@ In ``mode=default``, the number row currently uses this grouping:
    - ``ArmAdvance toggle``
    - Task control toggle
 
+**Nav** menu (``Nav1`` / ``Nav2``) — opened with **APP1** from the map
+(``default``) or the main menu, and also by a **short or double tap** on the
+**navigator** strip (same ``Nav1`` / ``Nav2`` modes, no separate navigator
+input modes). ``Nav1`` has **Status**, **Analysis**, and **Target** on keys
+``2``--``4``, then task manager, waypoint arms, list, and alternates. ``Nav2``
+is **abort task**, **marker drop**, and **pilot event**; **Target** is on
+``Nav1`` page~1.
+
+Navigator strip (gestures)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a **navigator** strip is shown above or below the map, touch or mouse
+gestures invoke input events. With no valid task, the strip can show the
+translatable *No task* string (reused from elsewhere in the UI).
+
+- **Short tap** (about 0--200 ms): if there is no valid task, opens the task
+  manager (``Setup`` / ``Task``). Otherwise opens the on-screen **Nav** button
+  overlay and switches to **mode** ``Nav1`` (same idea as **Display1** for the
+  display sidebar).
+- **Double-tap**: same: task manager if no valid task, else overlay and
+  **mode** ``Nav1``.
+- **Medium hold** (about 200--500 ms): ``Status`` with argument ``task``.
+- **Longer hold** (about 500 ms--2 s): ``Analysis`` with argument
+  ``AnalysisPage::TASK`` (task statistics page).
+- **Long hold** (about 2--10 s): ``Setup`` with argument ``Task`` (task
+  editor).
+
+**Swipe gestures** (when a drag is classified as a gesture instead of a tap):
+**left** / **right** call ``AdjustWaypoint`` with ``previouswrap`` or
+``nextwrap`` (see **navigator swipe** in look / UI settings). **RL** opens
+``Setup`` ``Target``; **LR** opens ``Setup`` ``Alternates``. **Up** / **down**
+(and other patterns) may open the **MainMenu** overlay. Unrecognised
+gestures fall through to ``processGesture``.
+
+**Escape** in :file:`Data/Input/default.xci` includes ``Nav1`` and ``Nav2`` on
+the shared key record, so it returns to **mode** ``default`` from the
+overlay, like other button modes.
+
 File format
 -----------
 
@@ -213,7 +251,15 @@ Event list
  * - ``AirspaceWarnings``
    - Opens the airspace warnings dialog.
  * - ``Analysis``
-   - Displays the analysis/statistics dialog.
+   - Displays the analysis/statistics dialog. Optional argument selects the
+     initial tab, e.g. ``AnalysisPage::TASK`` (task), ``AnalysisPage::BAROGRAPH``,
+     ``AnalysisPage::CLIMB``, ``AnalysisPage::VARIO_HISTOGRAM``,
+     ``AnalysisPage::THERMAL_BAND``, ``AnalysisPage::WIND``,
+     ``AnalysisPage::POLAR``, ``AnalysisPage::MACCREADY``,
+     ``AnalysisPage::TEMPTRACE``, ``AnalysisPage::CONTEST``,
+     ``AnalysisPage::TASK_SPEED``, ``AnalysisPage::AIRSPACE``.
+     If the argument is missing or not recognised,
+     the **Contest** page is shown.
  * - ``ArmAdvance``
    - Controls waypoint advance trigger arming. Possible arguments:
      ``on`` (arm), ``off`` (disarm), ``toggle``, ``show``
@@ -312,8 +358,10 @@ Event list
    - Marks the current location and creates a user waypoint marker.
      Use ``reset`` to erase all user markers.
  * - ``Mode M``
-   - Sets the current input event mode. The argument is the label
-     of the mode to activate (e.g. ``default``, ``Menu``).
+   - Sets the current input event mode. The argument is the name of the
+     mode to activate (e.g. ``default``, ``Menu``, ``Nav1``, ``Nav2``,
+     ``Display1``, ``pan``). Mode names are whatever labels
+     appear in ``mode=...`` lines in the active ``.xci`` file.
  * - ``NearestAirspaceDetails``
    - If airspace warnings are active, opens the airspace warnings
      dialog. Otherwise, finds the nearest airspace (within 30

--- a/src/DataGlobals.cpp
+++ b/src/DataGlobals.cpp
@@ -28,7 +28,7 @@ DataGlobals::UnsetTerrain() noexcept
   /* just in case the bottom widget uses the old terrain object
      (e.g. the cross section) */
   main_window.SetBottomWidget(nullptr);
-
+  main_window.SetTopWidget(nullptr);
   main_window.SetTerrain(nullptr);
 
   if (backend_components->glide_computer)

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.cpp
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorConfigPanel.hpp"
+#include "Gauge/NavigatorSettings.hpp"
+#include "Gauge/NavigatorWidget.hpp"
+#include "Profile/Keys.hpp"
+#include "Interface.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "MainWindow.hpp"
+
+enum ControlIndex {
+  NavigatorWidgetLite1LHeight,
+  NavigatorWidgetLite2LHeight,
+  NavigatorWidgetHeight,
+  NavigatorWidgetDetailedHeight,
+  NavigatorWidgetReverseSwipeWaypoint,
+  NavigatorWidgetAltitude
+};
+
+static constexpr StaticEnumChoice navigator_altitude_type_list[] = {
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltReq, N_("WP_AltReq"), N_("Additional altitude required to reach the next turn point.") },
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltDiff, N_("WP_AltDiff"), N_("Next Altitude Difference - Arrival altitude at the next waypoint relative to the safety arrival height.") },
+  { NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltArrival, N_("WP_AltArrival"), N_("Absolute arrival altitude at the next waypoint in final glide.") },
+  nullptr
+};
+
+class NavigatorConfigPanel final : public RowFormWidget {
+public:
+  NavigatorConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+
+void
+NavigatorConfigPanel::Prepare(ContainerWindow &parent,
+                           const PixelRect &rc) noexcept
+{
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  RowFormWidget::Prepare(parent, rc);
+
+  AddInteger(
+    _("Navigator lite one line Height"),
+    _("Select the height of the navigator lite topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 6%"),
+    "%u %%", "%u", 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_lite_1_line_height); 
+
+
+  AddInteger(
+    _("Navigator lite two lines Height"),
+    _("Select the height of the navigator lite topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 8%"),
+    "%u %%", "%u", 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_lite_2_lines_height); 
+
+  AddInteger(
+    _("Navigator Height"),
+    _("Select the height of the navigator topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 9%"),
+    "%u %%", "%u", 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_height);
+
+  AddInteger(
+    _("Navigator detailled Height"),
+    _("Select the height of the navigator detailled topwidget (percentage of the main window).\n"
+      "This widget is set under the settings menu: Look / Pages / Top Area\n"
+      "Warning: an unsuitable height of the navigator widget could lead to a bad presentation of its included flight informations (e.g. name of waypoint, times, ...).\n"
+      "to be setted accordingly to the size of the screen device.\n"
+      "default value: 11%"),
+    "%u %%", "%u", 1, 40, 1,
+    (unsigned)ui_settings.navigator.navigator_detailed_height);
+
+  AddBoolean(_("Reverse swipe movement"),
+             _("Swipe \"On\":\n"
+             "swipe/move the waypoints strip under the window.\n"
+             "Swipe \"Off\":\n"
+             "swipe/move the window over the waypoints strip.\n"
+             "\"The waypoints strip\" is a representation of all waypoints disposed horizontally one after the other."),
+             ui_settings.navigator.navigator_swipe);
+
+  AddEnum(_("Navigator Altitude type"), _("Choose an altitude type to be displayed beside the Waypoint name."),
+          navigator_altitude_type_list,
+          (unsigned)ui_settings.navigator.navigator_altitude_type);
+}
+
+bool
+NavigatorConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+  UISettings &ui_settings = CommonInterface::SetUISettings();
+
+  if ((changed |= SaveValueInteger(NavigatorWidgetHeight, ProfileKeys::NavigatorHeight,
+                                   ui_settings.navigator.navigator_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetLite1LHeight, ProfileKeys::NavigatorLite1LHeight,
+                                   ui_settings.navigator.navigator_lite_1_line_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetLite2LHeight, ProfileKeys::NavigatorLite2LHeight,
+                                   ui_settings.navigator.navigator_lite_2_lines_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+  if ((changed |= SaveValueInteger(NavigatorWidgetDetailedHeight, ProfileKeys::NavigatorDetailedHeight,
+                                   ui_settings.navigator.navigator_detailed_height)))
+    CommonInterface::main_window->ReinitialiseLayout();
+
+  if ((changed |= SaveValue(NavigatorWidgetReverseSwipeWaypoint,
+                            ProfileKeys::NavigatorReverseSwipeWaypointMovement,
+                            ui_settings.navigator.navigator_swipe)))
+    CommonInterface::main_window->ReinitialiseLayout();
+
+  if ((changed |= SaveValueEnum(NavigatorWidgetAltitude,
+                           ProfileKeys::NavigatorAltitudeType,
+                           ui_settings.navigator.navigator_altitude_type)))
+    CommonInterface::main_window->ReinitialiseLayout();
+    
+  _changed |= changed;
+
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateNavigatorConfigPanel()
+{
+  return std::make_unique<NavigatorConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/NavigatorConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/NavigatorConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateNavigatorConfigPanel();

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -388,7 +388,30 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     buffer.AppendFormat(", %s", _("Cross section"));
     break;
 
+  case PageLayout::Bottom::NAVIGATOR:
+  case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+  case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+  case PageLayout::Bottom::NAVIGATOR_DETAILED:
+    /* Labels: extended when navigator settings page is added. */
+    break;
+
   case PageLayout::Bottom::MAX:
+    gcc_unreachable();
+  }
+
+  switch (value.top) {
+  case PageLayout::Top::NOTHING:
+  case PageLayout::Top::CUSTOM:
+    break;
+
+  case PageLayout::Top::NAVIGATOR:
+  case PageLayout::Top::NAVIGATOR_LITE_ONE_LINE:
+  case PageLayout::Top::NAVIGATOR_LITE_TWO_LINES:
+  case PageLayout::Top::NAVIGATOR_DETAILED:
+    /* Labels: extended when navigator settings page is added. */
+    break;
+
+  case PageLayout::Top::MAX:
     gcc_unreachable();
   }
 

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -36,6 +36,7 @@ private:
   enum Controls {
     MAIN,
     INFO_BOX_PANEL,
+    TOP,
     BOTTOM,
   };
 
@@ -215,9 +216,26 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
     ib.AddChoice(i, display_text, display_text, help_text);
   }
 
+  static constexpr StaticEnumChoice top_list[] = {
+    { PageLayout::Top::NOTHING, N_("Nothing") },
+    { PageLayout::Top::NAVIGATOR, N_("T.Navigator") },
+    { PageLayout::Top::NAVIGATOR_LITE_ONE_LINE, N_("T.Navigator lite 1 line") },
+    { PageLayout::Top::NAVIGATOR_LITE_TWO_LINES, N_("T.Navigator lite 2 lines") },
+    { PageLayout::Top::NAVIGATOR_DETAILED, N_("T.Navigator detailed") },
+    nullptr
+  };
+  AddEnum(_("Top area"),
+          _("Specifies what should be displayed above the main area."),
+          top_list,
+          (unsigned)PageLayout::Top::NOTHING, this);
+
   static constexpr StaticEnumChoice bottom_list[] = {
     { PageLayout::Bottom::NOTHING, N_("Nothing") },
     { PageLayout::Bottom::CROSS_SECTION, N_("Cross section") },
+    { PageLayout::Bottom::NAVIGATOR, N_("B.Navigator") },
+    { PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE, N_("B.Navigator lite 1 line") },
+    { PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES, N_("B.Navigator lite 2 lines") },
+    { PageLayout::Bottom::NAVIGATOR_DETAILED, N_("B.Navigator detailed") },
     nullptr
   };
   AddEnum(_("Bottom area"),
@@ -232,6 +250,7 @@ PageLayoutEditWidget::SetValue(const PageLayout &_value)
   value = _value;
 
   LoadValueEnum(MAIN, value.main);
+  LoadValueEnum(TOP, value.top);
   LoadValueEnum(BOTTOM, value.bottom);
 
   unsigned ib = IBP_NONE;
@@ -271,6 +290,9 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
   } else if (&df == &GetDataField(BOTTOM)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.bottom = (PageLayout::Bottom)dfe.GetValue();
+  } else if (&df == &GetDataField(TOP)) {
+    const DataFieldEnum &dfe = (const DataFieldEnum &)df;
+    value.top = (PageLayout::Top)dfe.GetValue();
   } else {
     gcc_unreachable();
   }
@@ -389,10 +411,16 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     break;
 
   case PageLayout::Bottom::NAVIGATOR:
+    buffer.AppendFormat(", %s", _("B.Navigator"));
+    break;
   case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+    buffer.AppendFormat(", %s", _("B.Navigator lite 1 line"));
+    break;
   case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+    buffer.AppendFormat(", %s", _("B.Navigator lite 2 lines"));
+    break;
   case PageLayout::Bottom::NAVIGATOR_DETAILED:
-    /* Labels: extended when navigator settings page is added. */
+    buffer.AppendFormat(", %s", _("B.Navigator detailed"));
     break;
 
   case PageLayout::Bottom::MAX:
@@ -405,15 +433,22 @@ PageListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     break;
 
   case PageLayout::Top::NAVIGATOR:
+    buffer.AppendFormat(", %s", _("T.Navigator"));
+    break;
   case PageLayout::Top::NAVIGATOR_LITE_ONE_LINE:
+    buffer.AppendFormat(", %s", _("T.Navigator lite 1 line"));
+    break;
   case PageLayout::Top::NAVIGATOR_LITE_TWO_LINES:
+    buffer.AppendFormat(", %s", _("T.Navigator lite 2 lines"));
+    break;
   case PageLayout::Top::NAVIGATOR_DETAILED:
-    /* Labels: extended when navigator settings page is added. */
+    buffer.AppendFormat(", %s", _("T.Navigator detailed"));
     break;
 
   case PageLayout::Top::MAX:
     gcc_unreachable();
   }
+
 
   row_renderer.DrawTextRow(canvas, rc, buffer);
 }

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -33,6 +33,7 @@
 #include "Panels/InterfaceConfigPanel.hpp"
 #include "Panels/LayoutConfigPanel.hpp"
 #include "Panels/GaugesConfigPanel.hpp"
+#include "Panels/NavigatorConfigPanel.hpp"
 #include "Panels/VarioConfigPanel.hpp"
 #include "Panels/TaskRulesConfigPanel.hpp"
 #include "Panels/TaskDefaultsConfigPanel.hpp"
@@ -109,11 +110,12 @@ static constexpr TabMenuPage task_pages[] = {
 };
 
 static constexpr TabMenuPage look_pages[] = {
-  { N_("Language, Input"), CreateInterfaceConfigPanel },
-  { N_("Screen Layout"), CreateLayoutConfigPanel },
-  { N_("Pages"), CreatePagesConfigPanel },
-  { N_("InfoBox Sets"), CreateInfoBoxesConfigPanel },
-  { nullptr, nullptr }
+    {N_("Language, Input"), CreateInterfaceConfigPanel},
+    {N_("Screen Layout"), CreateLayoutConfigPanel},
+    {N_("Pages"), CreatePagesConfigPanel},
+    {N_("InfoBox Sets"), CreateInfoBoxesConfigPanel},
+    {N_("Navigator"), CreateNavigatorConfigPanel},
+    {nullptr, nullptr}
 };
 
 static constexpr TabMenuPage setup_pages[] = {

--- a/src/Gauge/NavigatorSettings.cpp
+++ b/src/Gauge/NavigatorSettings.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorSettings.hpp"
+
+void
+NavigatorSettings::SetDefaults() noexcept
+{
+  navigator_lite_1_line_height = 6;
+  navigator_lite_2_lines_height = 8;
+  navigator_height = 9;
+  navigator_detailed_height = 11;
+
+  navigator_swipe = false;
+  navigator_altitude_type = NavigatorWidgetAltitudeType::WP_AltArrival;
+}

--- a/src/Gauge/NavigatorSettings.hpp
+++ b/src/Gauge/NavigatorSettings.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+struct NavigatorSettings {
+  unsigned navigator_height;
+  unsigned navigator_lite_1_line_height;
+  unsigned navigator_lite_2_lines_height;
+  unsigned navigator_detailed_height;
+
+  bool navigator_swipe;
+
+  /** Navigator Widget type */
+  enum class NavigatorWidgetAltitudeType : uint8_t {
+    WP_AltReq,    // e_WP_AltReq
+    WP_AltDiff,   // e_WP_AltDiff
+    WP_AltArrival // e_WP_H
+  } navigator_altitude_type;
+
+  void SetDefaults() noexcept;
+};

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -5,10 +5,13 @@
 
 #include "BackendComponents.hpp"
 #include "Components.hpp"
+#include "Engine/Task/AbstractTask.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/Points/TaskWaypoint.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Input/InputEvents.hpp"
+#include "Language/Language.hpp"
 #include "PageActions.hpp"
 #include "Screen/Layout.hpp"
 #include "Task/ProtectedTaskManager.hpp"
@@ -51,34 +54,45 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
 
   unsigned task_size{};
 
-  auto *protected_task_manager =
-      backend_components->protected_task_manager.get();
-  if (protected_task_manager != nullptr) {
-    ProtectedTaskManager::Lease lease(*protected_task_manager);
-    const auto &stats = lease->GetStats();
+  if (backend_components != nullptr) {
+    auto *protected_task_manager =
+        backend_components->protected_task_manager.get();
+    if (protected_task_manager != nullptr) {
+      ProtectedTaskManager::Lease lease(*protected_task_manager);
+      const auto &stats = lease->GetStats();
 
-    tp = lease->GetMode();
+      tp = lease->GetMode();
 
-    if (stats.task_valid) {
-      if (tp == TaskType::ORDERED) {
+      if (stats.task_valid) {
+        if (tp == TaskType::ORDERED) {
 
-        const OrderedTask &task = lease->GetOrderedTask();
+          const OrderedTask &task = lease->GetOrderedTask();
 
-        task_size = task.TaskSize();
+          task_size = task.TaskSize();
 
-        wp_current = task.GetActiveTaskPoint()->GetWaypointPtr();
+          if (TaskWaypoint *atp = task.GetActiveTaskPoint())
+            wp_current = atp->GetWaypointPtr();
+          else
+            wp_current = nullptr;
 
-        auto i = task.GetActiveIndex();
-        if (i == 0) wp_before = nullptr;
-        else wp_before = task.GetPoint(i - 1).GetWaypointPtr();
+          const auto i = task.GetActiveIndex();
+          if (i == 0) wp_before = nullptr;
+          else wp_before = task.GetPoint(i - 1).GetWaypointPtr();
+        } else {
+          const AbstractTask *const active_task = lease->GetActiveTask();
+          if (active_task != nullptr) {
+            if (TaskWaypoint *atp = active_task->GetActiveTaskPoint())
+              wp_current = atp->GetWaypointPtr();
+            else
+              wp_current = nullptr;
+          } else
+            wp_current = nullptr;
+          wp_before = nullptr;
+        }
       } else {
-        wp_current =
-            lease->GetActiveTask()->GetActiveTaskPoint()->GetWaypointPtr();
+        wp_current = nullptr;
         wp_before = nullptr;
       }
-    } else {
-      wp_current = nullptr;
-      wp_before = nullptr;
     }
   }
 
@@ -96,15 +110,28 @@ NavigatorWindow::OnPaint(Canvas &canvas) noexcept
   case NavType::NAVIGATOR_LITE_ONE_LINE:
   case NavType::NAVIGATOR_LITE_TWO_LINES:
   case NavType::NAVIGATOR:
-    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    renderer.DrawFrame(canvas, frame_navigator, look_nav);
     break;
   case NavType::NAVIGATOR_DETAILED:
-    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
-    renderer.DrawFrame(canvas, frame_navigator_waypoint, look_nav, false);
+    renderer.DrawFrame(canvas, frame_navigator, look_nav);
+    renderer.DrawFrame(canvas, frame_navigator_waypoint, look_nav);
     break;
   default:
-    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    renderer.DrawFrame(canvas, frame_navigator, look_nav);
     break;
+  }
+
+  if (!CommonInterface::Calculated().task_stats.task_valid) {
+    canvas.SetBackgroundTransparent();
+    canvas.Select(look_infobox.value_font);
+    canvas.SetTextColor(look_nav.inverse ? COLOR_WHITE : COLOR_BLACK);
+    const char *const no_task_text = _("No task");
+    const PixelSize text_size = canvas.CalcTextSize(no_task_text);
+    const PixelRect &client = canvas.GetRect();
+    const PixelPoint pt{client.left + (int)(client.GetWidth() - text_size.width) / 2,
+                        client.top + (int)(client.GetHeight() - text_size.height) / 2};
+    canvas.DrawText(pt, no_task_text);
+    return;
   }
 
   const auto task_summary =
@@ -185,8 +212,12 @@ NavigatorWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
   StopDragging();
   ignore_single_click = true;
 
+  if (!CommonInterface::Calculated().task_stats.task_valid) {
+    InputEvents::eventSetup("Task");
+    return true;
+  }
   InputEvents::ShowMenu();
-  InputEvents::setMode("Navigator1");
+  InputEvents::setMode("Nav1");
   return true;
 }
 
@@ -227,8 +258,12 @@ NavigatorWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
 
     if (click_time > std::chrono::milliseconds(0) &&
         click_time <= std::chrono::milliseconds(200)) {
+      if (!CommonInterface::Calculated().task_stats.task_valid) {
+        InputEvents::eventSetup("Task");
+        return true;
+      }
       InputEvents::ShowMenu();
-      InputEvents::setMode("Navigator1");
+      InputEvents::setMode("Nav1");
     }
 
     else if (click_time > std::chrono::milliseconds(200) &&

--- a/src/Gauge/NavigatorWidget.cpp
+++ b/src/Gauge/NavigatorWidget.cpp
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Gauge/NavigatorWidget.hpp"
+
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/TaskManager.hpp"
+#include "Input/InputEvents.hpp"
+#include "PageActions.hpp"
+#include "Screen/Layout.hpp"
+#include "Task/ProtectedTaskManager.hpp"
+#include "UIGlobals.hpp"
+#include "Look/InfoBoxLook.hpp"
+
+NavigatorWindow::NavigatorWindow(const NavigatorLook &_look_nav,
+                                 const TaskLook &_look_task,
+                                 const InfoBoxLook &_look_infobox,
+                                 NavType nav_type_param, bool is_nav_top) noexcept
+  : look_nav(_look_nav),
+    look_task(_look_task),
+    look_infobox(_look_infobox),
+    nav_type(nav_type_param),
+    is_navigator_top_position(is_nav_top),
+    dragging(false)
+{
+}
+
+void
+NavigatorWindow::ReadBlackboard(const AttitudeState &_attitude) noexcept
+{
+  attitude = _attitude;
+}
+
+void
+NavigatorWindow::OnPaint(Canvas &canvas) noexcept
+{
+  renderer.Update(canvas);
+
+  if (look_nav.inverse) {
+    canvas.Clear(COLOR_BLACK);
+  } else {
+    canvas.ClearWhite();
+  }
+
+  TaskType tp{TaskType::NONE};
+  WaypointPtr wp_before;
+  WaypointPtr wp_current;
+
+  unsigned task_size{};
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr) {
+    ProtectedTaskManager::Lease lease(*protected_task_manager);
+    const auto &stats = lease->GetStats();
+
+    tp = lease->GetMode();
+
+    if (stats.task_valid) {
+      if (tp == TaskType::ORDERED) {
+
+        const OrderedTask &task = lease->GetOrderedTask();
+
+        task_size = task.TaskSize();
+
+        wp_current = task.GetActiveTaskPoint()->GetWaypointPtr();
+
+        auto i = task.GetActiveIndex();
+        if (i == 0) wp_before = nullptr;
+        else wp_before = task.GetPoint(i - 1).GetWaypointPtr();
+      } else {
+        wp_current =
+            lease->GetActiveTask()->GetActiveTaskPoint()->GetWaypointPtr();
+        wp_before = nullptr;
+      }
+    } else {
+      wp_current = nullptr;
+      wp_before = nullptr;
+    }
+  }
+
+  const PixelRect frame_navigator =
+      canvas.GetRect().WithPadding(Layout::Scale(1));
+
+  const int canvas_height = canvas.GetHeight();
+  const int canvas_width = canvas.GetWidth();
+
+  PixelPoint pt_origin{canvas_width * 18 / 100, canvas_height * 1 / 10};
+  PixelSize frame_size{canvas_width * 8 / 10, canvas_height * 55 / 100};
+  PixelRect frame_navigator_waypoint{pt_origin, frame_size};
+
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+  case NavType::NAVIGATOR:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    break;
+  case NavType::NAVIGATOR_DETAILED:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    renderer.DrawFrame(canvas, frame_navigator_waypoint, look_nav, false);
+    break;
+  default:
+    renderer.DrawFrame(canvas, frame_navigator, look_nav, true);
+    break;
+  }
+
+  const auto task_summary =
+      CommonInterface::Calculated().common_stats.ordered_summary;
+
+  if (tp == TaskType::ORDERED)
+    renderer.DrawProgressTask(task_summary, canvas, canvas.GetRect(), look_nav,
+                              look_task);
+
+  renderer.DrawWaypointsIconsTitle(canvas, wp_before, wp_current, task_size,
+                                   look_nav, nav_type);
+
+  if (wp_current != nullptr)
+    renderer.DrawTaskTextsArrow(canvas, tp, *wp_current, canvas.GetRect(),
+                                nav_type, is_navigator_top_position, look_nav,
+                                look_task, look_infobox);
+}
+
+void
+NavigatorWindow::StopDragging()
+{
+  if (!dragging) return;
+
+  dragging = false;
+  ReleaseCapture();
+}
+
+bool
+NavigatorWindow::OnMouseGesture(const char *gesture) noexcept
+{
+  if (StringIsEqual(gesture, "U")) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, "D")) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  const bool swipe_reversed =
+      CommonInterface::GetUISettings().navigator.navigator_swipe;
+  if (StringIsEqual(gesture, "R")) {
+    swipe_reversed ? InputEvents::eventAdjustWaypoint("previouswrap")
+                   : InputEvents::eventAdjustWaypoint("nextwrap");
+    return true;
+  }
+  if (StringIsEqual(gesture, "L")) {
+    swipe_reversed ? InputEvents::eventAdjustWaypoint("nextwrap")
+                   : InputEvents::eventAdjustWaypoint("previouswrap");
+    return true;
+  }
+  if (StringIsEqual(gesture, "UD")) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, "DR")) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+  if (StringIsEqual(gesture, "RL")) {
+    InputEvents::eventSetup("Target");
+    return true;
+  }
+  if (StringIsEqual(gesture, "LR")) {
+    InputEvents::eventSetup("Alternates");
+    return true;
+  }
+  if (gesture) {
+    InputEvents::ShowMenu();
+    return true;
+  }
+
+  return InputEvents::processGesture(gesture);
+}
+
+bool
+NavigatorWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
+{
+  StopDragging();
+  ignore_single_click = true;
+
+  InputEvents::ShowMenu();
+  InputEvents::setMode("Navigator1");
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseDown(PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) return true;
+
+  mouse_down_clock.Update();
+
+  if (!dragging) {
+    dragging = true;
+    SetCapture();
+    gestures.Start(p, Layout::Scale(20));
+  }
+
+  return true;
+}
+
+bool
+NavigatorWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
+{
+  // Ignore single click event if double click detected
+  if (ignore_single_click) {
+    ignore_single_click = false;
+    return true;
+  }
+
+  const auto click_time = mouse_down_clock.Elapsed();
+  mouse_down_clock.Reset();
+
+  if (dragging) {
+    StopDragging();
+
+    const char *gesture = gestures.Finish();
+    if (gesture && OnMouseGesture(gesture)) return true;
+
+    if (click_time > std::chrono::milliseconds(0) &&
+        click_time <= std::chrono::milliseconds(200)) {
+      InputEvents::ShowMenu();
+      InputEvents::setMode("Navigator1");
+    }
+
+    else if (click_time > std::chrono::milliseconds(200) &&
+             click_time <= std::chrono::milliseconds(500))
+      // quickClick
+      InputEvents::eventStatus("task");
+
+    else if (click_time > std::chrono::milliseconds(500) &&
+             click_time <= std::chrono::milliseconds(2000))
+      // simpleClick
+      InputEvents::eventAnalysis("AnalysisPage::TASK");
+
+    else if (click_time > std::chrono::milliseconds(2000) &&
+             click_time < std::chrono::milliseconds(10000))
+      // longClick
+      InputEvents::eventSetup("Task");
+
+    else return false;
+  }
+
+  return false;
+}
+
+bool
+NavigatorWindow::OnMouseMove(PixelPoint p,
+                             [[maybe_unused]] unsigned keys) noexcept
+{
+  if (dragging) gestures.Update(p);
+
+  return true;
+}
+
+void
+NavigatorWindow::OnCancelMode() noexcept
+{
+#ifndef USE_WINUSER
+  ReleaseCapture();
+#endif
+  StopDragging();
+}
+
+bool
+NavigatorWindow::OnKeyDown(unsigned key_code) noexcept
+{
+  return InputEvents::processKey(key_code);
+}
+
+void
+NavigatorWidget::Update([[maybe_unused]] const MoreData &basic) noexcept
+{
+  navigator_window->ReadBlackboard(basic.attitude);
+}
+
+void
+NavigatorWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+{
+  const Look &look = UIGlobals::GetLook();
+
+  WindowStyle style;
+  style.Hide();
+  style.Disable();
+
+  navigator_window = std::make_unique<NavigatorWindow>(
+      look.navigator, look.map.task, look.info_box, nav_type,
+      is_navigator_top_position);
+  navigator_window->Create(parent, rc, style);
+  navigator_window->Move(rc);
+}
+
+void
+NavigatorWidget::Show([[maybe_unused]] const PixelRect &rc) noexcept
+{
+  Update(CommonInterface::Basic());
+  CommonInterface::GetLiveBlackboard().AddListener(*this);
+  navigator_window->Show();
+}
+
+void
+NavigatorWidget::Hide() noexcept
+{
+  navigator_window->Hide();
+  CommonInterface::GetLiveBlackboard().RemoveListener(*this);
+}
+
+void
+NavigatorWidget::Move(const PixelRect &rc) noexcept
+{
+  navigator_window->Move(rc);
+}
+
+bool
+NavigatorWidget::SetFocus() noexcept
+{
+  return false;
+}
+
+PixelSize
+NavigatorWidget::GetMinimumSize() const noexcept
+{
+  unsigned int navHeight{};
+
+  const auto &navSettings = CommonInterface::GetUISettings().navigator;
+
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    navHeight = navSettings.navigator_lite_1_line_height;
+    break;
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+    navHeight = navSettings.navigator_lite_2_lines_height;
+    break;
+  case NavType::NAVIGATOR:
+    navHeight = navSettings.navigator_height;
+    break;
+  case NavType::NAVIGATOR_DETAILED:
+    navHeight = navSettings.navigator_detailed_height;
+    break;
+  default:
+    navHeight = navSettings.navigator_height;
+    break;
+  }
+
+  return PixelSize{navHeight};
+}
+
+void
+NavigatorWidget::OnGPSUpdate(const MoreData &basic) noexcept
+{
+  Update(basic);
+}
+
+void
+NavigatorWidget::UpdateLayout() noexcept
+{
+  const PixelRect rc = navigator_window->GetClientRect();
+  navigator_window->Move(rc);
+}

--- a/src/Gauge/NavigatorWidget.hpp
+++ b/src/Gauge/NavigatorWidget.hpp
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Blackboard/BlackboardListener.hpp"
+#include "Interface.hpp"
+#include "Look/Look.hpp"
+#include "Look/NavigatorLook.hpp"
+#include "MainWindow.hpp"
+#include "Renderer/NavigatorRenderer.hpp"
+#include "UIUtil/GestureManager.hpp"
+#include "Widget/WindowWidget.hpp"
+
+/**
+ * A Window which renders a Navigator
+ */
+class NavigatorWindow : public PaintWindow {
+  const NavigatorLook &look_nav;
+  const TaskLook &look_task;
+  const InfoBoxLook &look_infobox;
+
+  const NavType nav_type{NavType::NAVIGATOR};
+  const bool is_navigator_top_position{};
+
+  NavigatorRenderer renderer;
+
+  AttitudeState attitude;
+
+  GestureManager gestures;
+  bool dragging{false};
+  bool ignore_single_click{false};
+
+  PeriodClock mouse_down_clock;
+
+public:
+  /**
+   * Constructor. Initializes most class members.
+   */
+  NavigatorWindow(const NavigatorLook &_look_nav, const TaskLook &_look_task,
+                    const InfoBoxLook &_look_infobox, NavType nav_type_param,
+                    bool is_nav_top) noexcept;
+
+  void ReadBlackboard(const AttitudeState &_attitude) noexcept;
+
+protected:
+  void OnPaint(Canvas &canvas) noexcept override;
+
+private:
+  void StopDragging();
+
+public:
+  bool OnMouseGesture(const char *gesture) noexcept;
+  bool OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseDown(PixelPoint p) noexcept override;
+  bool OnMouseUp([[maybe_unused]] PixelPoint p) noexcept override;
+  bool OnMouseMove(PixelPoint p,
+                   [[maybe_unused]] unsigned keys) noexcept override;
+  void OnCancelMode() noexcept override;
+  bool OnKeyDown(unsigned key_code) noexcept override;
+};
+
+class NavigatorWidget final : public NullWidget,
+                              private NullBlackboardListener {
+  std::unique_ptr<NavigatorWindow> navigator_window;
+
+  NavType nav_type{NavType::NAVIGATOR};
+  bool is_navigator_top_position{true};
+
+public:
+  explicit NavigatorWidget(NavType type, bool is_nav_top = true) noexcept
+      : nav_type(type), is_navigator_top_position(is_nav_top) {}
+
+  ~NavigatorWidget() noexcept = default;
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
+  void Move(const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
+
+  PixelSize GetMinimumSize() const noexcept override;
+
+  NavigatorWindow *GetWindow() const noexcept
+  {
+    return navigator_window.get();
+  }
+
+private:
+  void Update(const MoreData &basic) noexcept;
+  void UpdateLayout() noexcept;
+
+  /* virtual methods from class BlackboardListener */
+  void OnGPSUpdate(const MoreData &basic) noexcept override;
+};

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -332,12 +332,45 @@ InputEvents::eventStatus(const char *misc)
 void
 InputEvents::eventAnalysis([[maybe_unused]] const char *misc)
 {
+  AnalysisPage analysis_page;
+
+  if (StringIsEqual(misc, "AnalysisPage::BAROGRAPH")) {
+    analysis_page = AnalysisPage::BAROGRAPH;
+  } else if (StringIsEqual(misc, "AnalysisPage::COUNT")) {
+    analysis_page = AnalysisPage::COUNT;
+  } else if (StringIsEqual(misc, "AnalysisPage::CLIMB")) {
+    analysis_page = AnalysisPage::CLIMB;
+  } else if (StringIsEqual(misc, "AnalysisPage::VARIO_HISTOGRAM")) {
+    analysis_page = AnalysisPage::VARIO_HISTOGRAM;
+  } else if (StringIsEqual(misc, "AnalysisPage::THERMAL_BAND")) {
+    analysis_page = AnalysisPage::THERMAL_BAND;
+  } else if (StringIsEqual(misc, "AnalysisPage::WIND")) {
+    analysis_page = AnalysisPage::WIND;
+  } else if (StringIsEqual(misc, "AnalysisPage::POLAR")) {
+    analysis_page = AnalysisPage::POLAR;
+  } else if (StringIsEqual(misc, "AnalysisPage::MACCREADY")) {
+    analysis_page = AnalysisPage::MACCREADY;
+  } else if (StringIsEqual(misc, "AnalysisPage::TEMPTRACE")) {
+    analysis_page = AnalysisPage::TEMPTRACE;
+  } else if (StringIsEqual(misc, "AnalysisPage::TASK")) {
+    analysis_page = AnalysisPage::TASK;
+  } else if (StringIsEqual(misc, "AnalysisPage::CONTEST")) {
+    analysis_page = AnalysisPage::CONTEST;
+  } else if (StringIsEqual(misc, "AnalysisPage::TASK_SPEED")) {
+    analysis_page = AnalysisPage::TASK_SPEED;
+  } else if (StringIsEqual(misc, "AnalysisPage::AIRSPACE")) {
+    analysis_page = AnalysisPage::AIRSPACE;
+  } else {
+    analysis_page = AnalysisPage::CONTEST;
+  }
+
   dlgAnalysisShowModal(*CommonInterface::main_window,
                        CommonInterface::main_window->GetLook(),
                        CommonInterface::Full(),
                        *backend_components->glide_computer,
                        data_components->airspaces.get(),
-                       data_components->terrain.get());
+                       data_components->terrain.get(),
+                       analysis_page);
 }
 
 // WaypointDetails

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -62,6 +62,7 @@ Look::InitialiseConfigured(const UISettings &settings,
   chart.Initialise(dark_mode);
   terminal.Initialise();
   cross_section.Initialise(map_font);
+  navigator.Initialise(dark_mode);
   horizon.Initialise();
   thermal_band.Initialise(dark_mode,
                           cross_section.sky_color);

--- a/src/Look/Look.hpp
+++ b/src/Look/Look.hpp
@@ -13,6 +13,7 @@
 #include "MapLook.hpp"
 #include "CrossSectionLook.hpp"
 #include "HorizonLook.hpp"
+#include "NavigatorLook.hpp"
 #include "TrafficLook.hpp"
 #include "FlarmTrafficLook.hpp"
 #include "InfoBoxLook.hpp"
@@ -37,6 +38,7 @@ struct Look {
   MapLook map;
   CrossSectionLook cross_section;
   HorizonLook horizon;
+  NavigatorLook navigator;
   TrafficLook traffic;
   FlarmTrafficLook flarm_gauge;
   FlarmTrafficLook flarm_dialog;

--- a/src/Look/NavigatorLook.cpp
+++ b/src/Look/NavigatorLook.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorLook.hpp"
+#include "Screen/Layout.hpp"
+
+void
+NavigatorLook::Initialise(bool _inverse)
+{
+  Color pen_frame_color, brush_frame_color;
+
+  if (!(inverse = _inverse)) {
+    pen_frame_color = color_frame;
+    brush_frame_color = color_background_frame;
+  } else {
+    pen_frame_color = color_frame_inv;
+    brush_frame_color = color_background_frame_inv;
+  }
+  pen_frame.Create(Layout::ScaleFinePenWidth(1), pen_frame_color);
+  brush_frame.Create(brush_frame_color);
+}

--- a/src/Look/NavigatorLook.hpp
+++ b/src/Look/NavigatorLook.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/canvas/Brush.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/Pen.hpp"
+
+class Font;
+
+struct NavigatorLook {
+  bool inverse;
+
+  static constexpr Color color_background_frame{COLOR_WHITE};
+  static constexpr Color color_background_frame_inv{COLOR_BLACK};
+  static constexpr Color color_frame{COLOR_BLACK};
+  static constexpr Color color_frame_inv{COLOR_WHITE};
+
+  Pen pen_frame;
+  Brush brush_frame;
+
+  void Initialise(bool _inverse);
+};

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "Gauge/GaugeFLARM.hpp"
 #include "Gauge/GaugeThermalAssistant.hpp"
 #include "Gauge/GlueGaugeVario.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "Form/Form.hpp"
 #include "Widget/Widget.hpp"
 #include "Look/GlobalFonts.hpp"
@@ -33,6 +34,7 @@
 #include "UIReceiveBlackboard.hpp"
 #include "UISettings.hpp"
 #include "Interface.hpp"
+#include "ui/canvas/Color.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 
@@ -125,54 +127,64 @@ MainWindow::GetShowRotateButtonRect(const PixelRect rc) noexcept
 
 [[gnu::pure]]
 static PixelRect
-GetTopWidgetRect(const PixelRect &rc, const Widget *top_widget) noexcept
+GetTopWidgetRect(const PixelRect &rc_main, const PixelRect &rc_remaining,
+                 const Widget *top_widget) noexcept
 {
   if (top_widget == nullptr) {
     /* no top widget: return empty rectangle, map uses the whole main
        area */
-    PixelRect result = rc;
+    PixelRect result = rc_remaining;
     result.bottom = result.top;
     return result;
   }
 
-  const unsigned requested_height = top_widget->GetMinimumSize().height;
+  const unsigned requested_height =
+      rc_main.GetHeight() * top_widget->GetMinimumSize().height / 100;
   unsigned height;
   if (requested_height > 0) {
-    const unsigned max_height = rc.GetHeight() / 2;
+    const unsigned max_height = rc_remaining.GetHeight() * 40 / 100;
     height = std::min(max_height, requested_height);
   } else {
-    const unsigned recommended_height = rc.GetHeight() / 4;
+    const unsigned recommended_height = rc_remaining.GetHeight() * 17 / 100;
     height = recommended_height;
   }
 
-  PixelRect result = rc;
+  PixelRect result = rc_remaining;
   result.bottom = result.top + height;
   return result;
 }
 
-[[gnu::pure]]
-static PixelRect
-GetBottomWidgetRect(const PixelRect &rc, const Widget *bottom_widget) noexcept
+[[gnu::pure]] static PixelRect
+GetBottomWidgetRect(const PixelRect &rc_main, const PixelRect &rc_remaining,
+                    const Widget *bottom_widget) noexcept
 {
   if (bottom_widget == nullptr) {
     /* no bottom widget: return empty rectangle, map uses the whole
        main area */
-    PixelRect result = rc;
+    PixelRect result = rc_remaining;
     result.top = result.bottom;
     return result;
   }
 
-  const unsigned requested_height = bottom_widget->GetMinimumSize().height;
+  unsigned requested_height{};
+  auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+  if (nav != nullptr) {
+    requested_height =
+        rc_main.GetHeight() * bottom_widget->GetMinimumSize().height / 100;
+  } else {
+    requested_height = bottom_widget->GetMinimumSize().height;
+  }
+
   unsigned height;
   if (requested_height > 0) {
-    const unsigned max_height = rc.GetHeight() / 2;
+    const unsigned max_height = rc_main.GetHeight() / 2;
     height = std::min(max_height, requested_height);
   } else {
-    const unsigned recommended_height = rc.GetHeight() / 3;
+    const unsigned recommended_height = rc_main.GetHeight() / 3;
     height = recommended_height;
   }
 
-  PixelRect result = rc;
+  PixelRect result = rc_remaining;
   result.top = result.bottom - height;
   return result;
 }
@@ -462,22 +474,29 @@ MainWindow::ReinitialiseLayout() noexcept
     else
       InfoBoxManager::Show();
 
-    PixelRect main_rect = GetMainRect();
-    const PixelRect top_rect = GetTopWidgetRect(main_rect,
-                                                top_widget);
-    main_rect = GetMapRectBelow(main_rect, top_rect);
+    PixelRect rc_main = GetClientRect();
+    PixelRect rc_remaining = GetMainRect();
 
-    if (HaveTopWidget())
+    if (HaveTopWidget()) {
+      const PixelRect top_rect =
+          GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+      rc_remaining = GetMapRectBelow(rc_remaining, top_rect);
+
       top_widget->Move(top_rect);
+    }
 
-    const PixelRect bottom_rect = GetBottomWidgetRect(main_rect,
-                                                      bottom_widget);
+    if (HaveBottomWidget()) {
+      const PixelRect bottom_rect =
+          GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+      rc_remaining = GetMapRectAbove(rc_remaining, bottom_rect);
 
-    if (HaveBottomWidget())
       bottom_widget->Move(bottom_rect);
+    }
 
-    PixelRect map_rect_final = GetMapRectAbove(main_rect, bottom_rect);
-    map->Move(map_rect_final);
+    if (popup != nullptr)
+      popup->UpdateLayout(rc_remaining);
+
+    map->Move(rc_remaining);
     map->FullRedraw();
   }
 
@@ -770,6 +789,18 @@ MainWindow::StopDragging() noexcept
 void
 MainWindow::OnCancelMode() noexcept
 {
+  if (HaveTopWidget()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr)
+      nav->GetWindow()->OnCancelMode();
+  }
+
+  if (HaveBottomWidget()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr)
+      nav->GetWindow()->OnCancelMode();
+  }
+
   SingleWindow::OnCancelMode();
   StopDragging();
 }
@@ -777,6 +808,29 @@ MainWindow::OnCancelMode() noexcept
 bool
 MainWindow::OnMouseDown(PixelPoint p) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+  
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDown(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDown(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDown(p))
     return true;
 
@@ -792,6 +846,30 @@ MainWindow::OnMouseDown(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseUp(PixelPoint p) noexcept
 {
+
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseUp(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseUp(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseUp(p))
     return true;
 
@@ -809,6 +887,29 @@ MainWindow::OnMouseUp(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseDouble(PixelPoint p) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDouble(p);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseDouble(p);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseDouble(p))
     return true;
 
@@ -822,6 +923,29 @@ MainWindow::OnMouseDouble(PixelPoint p) noexcept
 bool
 MainWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
 {
+  const PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect top_rect = GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+
+  if (HaveTopWidget() && top_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(top_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseMove(p, keys);
+      return true;
+    }
+  }
+
+  if (HaveBottomWidget() && bottom_rect.Contains(p) && !HasDialog() &&
+      InputEvents::IsDefault()) {
+    auto nav = dynamic_cast<const NavigatorWidget *>(bottom_widget);
+    if (nav != nullptr) {
+      nav->GetWindow()->OnMouseMove(p, keys);
+      return true;
+    }
+  }
+
   if (SingleWindow::OnMouseMove(p, keys))
     return true;
 
@@ -971,13 +1095,14 @@ MainWindow::OnClose() noexcept
 void
 MainWindow::OnPaint(Canvas &canvas) noexcept
 {
-  if (HaveTopWidget() && map != nullptr) {
-    /* draw a separator between top widget and map */
-    PixelRect rc = map->GetPosition();
-    rc.bottom = rc.top;
-    rc.top -= separator_height;
-    canvas.DrawFilledRectangle(rc, COLOR_BLACK);
-  }
+  bool inversed{false};
+  Color color_separator_top{COLOR_BLACK};
+
+  if (look != nullptr)
+    inversed = look->info_box.inverse;
+  /* Dark mode used COLOR_WHITE here, which reads as a bright hairline above
+     the map under the top navigator; use a muted gray instead. */
+  color_separator_top = inversed ? COLOR_DARK_GRAY : COLOR_BLACK;
 
   if (HaveBottomWidget() && map != nullptr) {
     /* draw a separator between main area and bottom area */
@@ -985,6 +1110,14 @@ MainWindow::OnPaint(Canvas &canvas) noexcept
     rc.top = rc.bottom;
     rc.bottom += separator_height;
     canvas.DrawFilledRectangle(rc, COLOR_BLACK);
+  }
+
+  if (HaveTopWidget() && map != nullptr) {
+    /* draw a separator between main area and top area */
+    PixelRect rc = map->GetPosition();
+    rc.bottom = rc.top;
+    rc.top -= separator_height;
+    canvas.DrawFilledRectangle(rc, color_separator_top);
   }
 
   SingleWindow::OnPaint(canvas);
@@ -1073,12 +1206,26 @@ MainWindow::ActivateMap() noexcept
     map->Show();
     map->SetFocus();
 
-    if (bottom_widget != nullptr) {
-      assert(HaveBottomWidget());
-      bottom_widget->Show(GetBottomWidgetRect(GetMainRect(),
-                                              bottom_widget));
+    PixelRect rc_main = GetClientRect();
+    PixelRect rc_remaining = GetMainRect();
+
+    const PixelRect bottom_rect =
+        GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+    if (HaveBottomWidget()) {
+      bottom_widget->Show(bottom_rect);
+      bottom_widget->Move(bottom_rect);
     }
 
+    rc_remaining = GetMapRectAbove(rc_remaining, bottom_rect);
+    const PixelRect top_rect =
+        GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
+    if (HaveTopWidget()) {
+      top_widget->Show(top_rect);
+      top_widget->Move(top_rect);
+    }
+
+    map->Move(GetMapRectBelow(rc_remaining, top_rect));
 #ifndef ENABLE_OPENGL
     if (draw_suspended) {
       draw_suspended = false;
@@ -1121,7 +1268,11 @@ MainWindow::KillTopWidget() noexcept
   if (top_widget == nullptr)
     return;
 
-  top_widget->Hide();
+  if (widget == nullptr)
+    /* the top widget is only visible above the map, but not above
+       a custom main widget; see HaveTopWidget() */
+    top_widget->Hide();
+
   top_widget->Unprepare();
   delete top_widget;
   top_widget = nullptr;
@@ -1130,31 +1281,55 @@ MainWindow::KillTopWidget() noexcept
 void
 MainWindow::SetTopWidget(Widget *_widget) noexcept
 {
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  if (ui_settings.scale != 100)
+    /* call Initialise() again to reload fonts with the new scale */
+    Initialise();
+
+  PixelRect rc = GetClientRect();
+
+  const InfoBoxLayout::Layout ib_layout =
+    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
+
+  assert(look != nullptr);
+  look->InitialiseConfigured(CommonInterface::GetUISettings(), Fonts::map,
+                             Fonts::map_bold, ib_layout.control_size.width);
   if (top_widget == nullptr && _widget == nullptr)
     return;
 
-  KillTopWidget();
+  if (map == nullptr) {
+    /* this doesn't work without a map */
+    delete _widget;
+    return;
+  }
 
+  KillTopWidget();
+  
   top_widget = _widget;
 
-  PixelRect main_rect = GetMainRect();
-  const PixelRect top_rect = GetTopWidgetRect(main_rect,
-                                              top_widget);
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
+  const PixelRect bottom_rect =
+      GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
+  rc_remaining = GetMapRectAbove(rc_remaining, bottom_rect);
+  if (HaveBottomWidget()) 
+    bottom_widget->Move(bottom_rect);
+
+  const PixelRect top_rect =
+      GetTopWidgetRect(rc_main, rc_remaining, top_widget);
+
   if (top_widget != nullptr) {
     top_widget->Initialise(*this, top_rect);
     top_widget->Prepare(*this, top_rect);
-    top_widget->Show(top_rect);
+
+    if (widget == nullptr)
+      /* the top widget is only visible above the map, but not
+         above a custom main widget; see HaveBottomWidget() */
+      top_widget->Show(top_rect);
   }
 
-  main_rect = GetMapRectBelow(main_rect, top_rect);
-
-  const PixelRect bottom_rect = GetBottomWidgetRect(main_rect,
-                                                    bottom_widget);
-
-  if (HaveBottomWidget())
-    bottom_widget->Move(bottom_rect);
-
-  map->Move(GetMapRectAbove(main_rect, bottom_rect));
+  map->Move(GetMapRectBelow(rc_remaining, top_rect));
   map->FullRedraw();
 }
 
@@ -1190,15 +1365,10 @@ MainWindow::SetBottomWidget(Widget *_widget) noexcept
 
   bottom_widget = _widget;
 
-  PixelRect main_rect = GetMainRect();
-  const PixelRect top_rect = GetTopWidgetRect(main_rect,
-                                              top_widget);
-  main_rect = GetMapRectBelow(main_rect, top_rect);
-  if (HaveTopWidget())
-    top_widget->Move(top_rect);
+  PixelRect rc_main = GetClientRect();
+  PixelRect rc_remaining = GetMainRect();
 
-  const PixelRect bottom_rect = GetBottomWidgetRect(main_rect,
-                                                    bottom_widget);
+  const PixelRect bottom_rect = GetBottomWidgetRect(rc_main, rc_remaining, bottom_widget);
 
   if (bottom_widget != nullptr) {
     bottom_widget->Initialise(*this, bottom_rect);
@@ -1210,7 +1380,7 @@ MainWindow::SetBottomWidget(Widget *_widget) noexcept
       bottom_widget->Show(bottom_rect);
   }
 
-  map->Move(GetMapRectAbove(main_rect, bottom_rect));
+  map->Move(GetMapRectAbove(rc_remaining, bottom_rect));
   map->FullRedraw();
 }
 
@@ -1222,6 +1392,7 @@ MainWindow::SetWidget(Widget *_widget) noexcept
   restore_page_pending = false;
 
   const bool have_bottom_widget = HaveBottomWidget();
+  const bool have_top_widget = HaveTopWidget();
 
   /* delete the old widget */
   KillWidget();
@@ -1240,6 +1411,8 @@ MainWindow::SetWidget(Widget *_widget) noexcept
 
   if (have_bottom_widget)
     bottom_widget->Hide();
+  if (have_top_widget)
+    top_widget->Hide();
 
   widget = _widget;
 

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -161,7 +161,11 @@ protected:
   void KillWidget() noexcept;
 
   bool HaveTopWidget() const noexcept {
-    return top_widget != nullptr;
+    /* currently, the top widget is only visible above the map, but
+       not above a custom main widget */
+    /* TODO: eliminate this limitation; don't forget to remove the
+       "widget==nullptr" check from MainWindow::KillTopWidget() */
+    return top_widget != nullptr && widget == nullptr;
   }
 
   /**

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -59,12 +59,14 @@ public:
         manager.AcknowledgeWarning(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("ACK Day"), [this](){
       manager.AcknowledgeDay(airspace);
       monitor.Schedule();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("More"), [this](){
@@ -100,8 +102,11 @@ AirspaceWarningMonitor::Reset() noexcept
 void
 AirspaceWarningMonitor::HideWidget() noexcept
 {
-  if (widget != nullptr)
+  if (widget != nullptr) {
     PageActions::RestoreBottom();
+    PageActions::RestoreTop();
+  }
+  
   assert(widget == nullptr);
 }
 

--- a/src/Monitor/MatTaskMonitor.cpp
+++ b/src/Monitor/MatTaskMonitor.cpp
@@ -40,9 +40,11 @@ public:
     AddButton(_("Add"), [this](){
       OnAdd();
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -173,8 +175,10 @@ MatTaskMonitor::Check()
     last_id = id;
   } else {
     /* no nearby turn point: close the QuestionWidget */
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
 
     last_id = unsigned(-1);
   }

--- a/src/Monitor/TaskAdvanceMonitor.cpp
+++ b/src/Monitor/TaskAdvanceMonitor.cpp
@@ -29,10 +29,12 @@ public:
       }
 
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
 
     AddButton(_("Dismiss"), [](){
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
     });
   }
 
@@ -54,8 +56,10 @@ TaskAdvanceMonitor::Check()
       PageActions::SetCustomBottom(widget);
     }
   } else {
-    if (widget != nullptr)
+    if (widget != nullptr) {
       PageActions::RestoreBottom();
+      PageActions::RestoreTop();
+    }
   }
 
   last_active_index = stats.active_index;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -9,6 +9,7 @@
 #include "MainWindow.hpp"
 #include "CrossSection/CrossSectionWidget.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Gauge/NavigatorWidget.hpp"
 #include "Pan.hpp"
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
@@ -138,6 +139,7 @@ PageActions::Next()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 unsigned
@@ -168,6 +170,7 @@ PageActions::Prev()
 
   Update();
   RestoreMapZoom();
+  CommonInterface::main_window->ReinitialiseLayout();
 }
 
 static void
@@ -209,11 +212,16 @@ LoadBottom(PageLayout::Bottom bottom)
     break;
 
   case PageLayout::Bottom::NAVIGATOR:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(NavType::NAVIGATOR, false));
+    break;
   case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(NavType::NAVIGATOR_LITE_ONE_LINE, false));
+    break;
   case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(NavType::NAVIGATOR_LITE_TWO_LINES, false));
+    break;
   case PageLayout::Bottom::NAVIGATOR_DETAILED:
-    /* Filled in when NavigatorWidget is added; no bottom strip yet. */
-    CommonInterface::main_window->SetBottomWidget(nullptr);
+    CommonInterface::main_window->SetBottomWidget(new NavigatorWidget(NavType::NAVIGATOR_DETAILED, false));
     break;
 
   case PageLayout::Bottom::CUSTOM:
@@ -221,6 +229,39 @@ LoadBottom(PageLayout::Bottom bottom)
     break;
 
   case PageLayout::Bottom::MAX:
+    gcc_unreachable();
+  }
+}
+
+static void
+LoadTop(PageLayout::Top top)
+{
+  switch (top) {
+  case PageLayout::Top::NOTHING:
+    CommonInterface::main_window->SetTopWidget(nullptr);
+    break;
+
+  case PageLayout::Top::NAVIGATOR:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(NavType::NAVIGATOR, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_ONE_LINE:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(NavType::NAVIGATOR_LITE_ONE_LINE, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_LITE_TWO_LINES:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(NavType::NAVIGATOR_LITE_TWO_LINES, true));
+    break;
+  case PageLayout::Top::NAVIGATOR_DETAILED:
+    CommonInterface::main_window->SetTopWidget(
+        new NavigatorWidget(NavType::NAVIGATOR_DETAILED, true));
+    break;
+
+  case PageLayout::Top::CUSTOM:
+    /* don't touch */
+    break;
+  case PageLayout::Top::MAX:
     gcc_unreachable();
   }
 }
@@ -256,6 +297,7 @@ PageActions::LoadLayout(const PageLayout &layout)
 
   LoadInfoBoxes(layout.infobox_config);
   LoadBottom(layout.bottom);
+  LoadTop(layout.top);
   LoadMain(layout.main);
 
   ActionInterface::UpdateDisplayMode();
@@ -308,6 +350,24 @@ PageActions::RestoreBottom()
     special_page.SetUndefined();
 
   LoadBottom(configured_page.bottom);
+}
+
+void
+PageActions::RestoreTop()
+{
+  PageLayout &special_page = CommonInterface::SetUIState().pages.special_page;
+  if (!special_page.IsDefined())
+    return;
+
+  const PageLayout &configured_page = GetConfiguredLayout();
+  if (special_page.top == configured_page.top)
+    return;
+
+  special_page.top = configured_page.top;
+  if (special_page == configured_page)
+    special_page.SetUndefined();
+
+  LoadTop(configured_page.top);
 }
 
 GlueMapWindow *
@@ -386,4 +446,16 @@ PageActions::SetCustomBottom(Widget *widget)
   state.special_page = GetCurrentLayout();
   state.special_page.bottom = PageLayout::Bottom::CUSTOM;
   CommonInterface::main_window->SetBottomWidget(widget);
+}
+
+void
+PageActions::SetCustomTop(Widget *widget)
+{
+  assert(widget != nullptr);
+
+  PagesState &state = CommonInterface::SetUIState().pages;
+
+  state.special_page = GetCurrentLayout();
+  state.special_page.top = PageLayout::Top::CUSTOM;
+  CommonInterface::main_window->SetTopWidget(widget);
 }

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -208,6 +208,14 @@ LoadBottom(PageLayout::Bottom bottom)
     CommonInterface::main_window->SetBottomWidget(new CrossSectionWidget(*data_components));
     break;
 
+  case PageLayout::Bottom::NAVIGATOR:
+  case PageLayout::Bottom::NAVIGATOR_LITE_ONE_LINE:
+  case PageLayout::Bottom::NAVIGATOR_LITE_TWO_LINES:
+  case PageLayout::Bottom::NAVIGATOR_DETAILED:
+    /* Filled in when NavigatorWidget is added; no bottom strip yet. */
+    CommonInterface::main_window->SetBottomWidget(nullptr);
+    break;
+
   case PageLayout::Bottom::CUSTOM:
     /* don't touch */
     break;

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -72,6 +72,11 @@ namespace PageActions
   void RestoreBottom();
 
   /**
+   * Like Restore(), but affects only the top area.
+   */
+  void RestoreTop();
+
+  /**
    * Show a page with the map, or restore the current page if it was
    * configured with a map (for example if the user has activated the
    * FLARM radar page).
@@ -102,4 +107,10 @@ namespace PageActions
    * MainWindow::SetBottomWidget().  Call RestoreBottom() to undo this.
    */
   void SetCustomBottom(Widget *widget);
+
+  /**
+   * Use a custom widget for the "top" area.  This is a wrapper for
+   * MainWindow::SetTopWidget().  Call RestoreTop() to undo this.
+   */
+  void SetCustomTop(Widget *widget);
 };

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -72,7 +72,40 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
       builder.Append(", XS");
       break;
 
+    case Bottom::NAVIGATOR:
+      builder.Append(", NAV_B");
+      break;
+    case Bottom::NAVIGATOR_LITE_ONE_LINE:
+      builder.Append(", NAV_Lite_1L_B");
+      break;
+    case Bottom::NAVIGATOR_LITE_TWO_LINES:
+      builder.Append(", NAV_Lite_2L_B");
+      break;
+    case Bottom::NAVIGATOR_DETAILED:
+      builder.Append(", NAV_Detailed_B");
+      break;
+      
     case Bottom::MAX:
+      gcc_unreachable();
+    }
+
+    switch (top) {
+    case Top::NOTHING:
+    case Top::CUSTOM:
+      break;
+    case Top::NAVIGATOR:
+      builder.Append(", NAV");
+      break;
+    case Top::NAVIGATOR_LITE_ONE_LINE:
+      builder.Append(", NAV_Lite_1L");
+      break;
+    case Top::NAVIGATOR_LITE_TWO_LINES:
+      builder.Append(", NAV_Lite_2L");
+      break;
+    case Top::NAVIGATOR_DETAILED:
+      builder.Append(", NAV_Detailled");
+      break;
+    case Top::MAX:
       gcc_unreachable();
     }
   } catch (BasicStringBuilder<char>::Overflow) {

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -70,6 +70,14 @@ struct PageLayout
     CROSS_SECTION,
 
     /**
+     * Show a Navigator menu below the map.
+     */
+    NAVIGATOR,
+    NAVIGATOR_LITE_ONE_LINE,
+    NAVIGATOR_LITE_TWO_LINES,
+    NAVIGATOR_DETAILED,
+
+    /**
      * A custom #Widget is being displayed.  This is not a
      * user-accessible option, it's only used for runtime state.
      */
@@ -81,17 +89,45 @@ struct PageLayout
     MAX
   } bottom;
 
+  /**
+   * What to show above the main area (i.e. map)?
+   */
+  enum class Top : uint8_t {
+    NOTHING,
+
+    /**
+     * Show a Navigator menu above the map.
+     */
+    NAVIGATOR,
+    NAVIGATOR_LITE_ONE_LINE,
+    NAVIGATOR_LITE_TWO_LINES,
+    NAVIGATOR_DETAILED,
+
+    /**
+     * A custom #Widget is being displayed.  This is not a
+     * user-accessible option, it's only used for runtime state.
+     */
+    CUSTOM,
+
+    /**
+     * A dummy entry that is used for validating profile values.
+     */
+    MAX
+  } top;
+
   PageLayout() = default;
 
   constexpr PageLayout(bool _valid, InfoBoxConfig _infobox_config)
     :valid(_valid), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   constexpr PageLayout(InfoBoxConfig _infobox_config)
     :valid(true), main(Main::MAP),
      infobox_config(_infobox_config),
-     bottom(Bottom::NOTHING) {}
+     bottom(Bottom::NOTHING),
+     top(Top::NOTHING) {}
 
   /**
    * Return an "undefined" page.  Its IsDefined() method will return

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -235,6 +235,13 @@ constexpr std::string_view FlarmAutoZoom = "FlarmRadarAutoZoom";
 constexpr std::string_view FlarmNorthUp = "FlarmRadarNorthUp";
 constexpr std::string_view FlarmRadarZoom = "FlarmRadarZoom";
 
+constexpr std::string_view NavigatorHeight = "NavigatorHeight";
+constexpr std::string_view NavigatorLite1LHeight = "NavigatorLite1LHeight";
+constexpr std::string_view NavigatorLite2LHeight = "NavigatorLite2LHeight";
+constexpr std::string_view NavigatorDetailedHeight = "NavigatorDetailedHeight";
+constexpr std::string_view NavigatorReverseSwipeWaypointMovement = "NavigatorReverseSwipeWaypointMovement";
+constexpr std::string_view NavigatorAltitudeType = "NavigatorAltitudeType";
+
 constexpr std::string_view IgnoreNMEAChecksum = "IgnoreNMEAChecksum";
 constexpr std::string_view MapOrientation = "DisplayOrientation";
 

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -55,6 +55,11 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
       unsigned(pl.bottom) >= unsigned(PageLayout::Bottom::MAX))
     pl.bottom = PageLayout::Bottom::NOTHING;
 
+  strcpy(profileKey + prefixLen, "Top");
+  if (!map.GetEnum(profileKey, pl.top) ||
+      unsigned(pl.top) >= unsigned(PageLayout::Top::MAX))
+    pl.top = PageLayout::Top::NOTHING;
+
   strcpy(profileKey + prefixLen, "Main");
   if (!map.GetEnum(profileKey, pl.main) ||
       unsigned(pl.main) >= unsigned(PageLayout::Main::MAX))
@@ -96,6 +101,9 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
 
   strcpy(profileKey + prefixLen, "Bottom");
   map.Set(profileKey, (unsigned)page.bottom);
+
+  strcpy(profileKey + prefixLen, "Top");
+  map.Set(profileKey, (unsigned)page.top);
 
   strcpy(profileKey + prefixLen, "Main");
   map.Set(profileKey, (unsigned)page.main);

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -14,6 +14,7 @@ namespace Profile {
   static void Load(const ProfileMap &map, DisplaySettings &settings);
   static void Load(const ProfileMap &map, FormatSettings &settings);
   static void Load(const ProfileMap &map, VarioSettings &settings);
+  static void Load(const ProfileMap &map, NavigatorSettings &settings);
   static void Load(const ProfileMap &map, TrafficSettings &settings);
   static void Load(const ProfileMap &map, DialogSettings &settings);
   static void Load(const ProfileMap &map, SoundSettings &settings);
@@ -47,6 +48,18 @@ Profile::Load(const ProfileMap &map, VarioSettings &settings)
   map.Get(ProfileKeys::AppGaugeVarioGross, settings.show_gross);
   map.Get(ProfileKeys::AppAveNeedle, settings.show_average_needle);
   map.Get(ProfileKeys::AppAveThermalNeedle, settings.show_thermal_average_needle);
+}
+
+void
+Profile::Load(const ProfileMap &map, NavigatorSettings &settings) 
+{
+  map.Get(ProfileKeys::NavigatorLite1LHeight, settings.navigator_lite_1_line_height);
+  map.Get(ProfileKeys::NavigatorLite2LHeight, settings.navigator_lite_2_lines_height);
+  map.Get(ProfileKeys::NavigatorHeight, settings.navigator_height);
+  map.Get(ProfileKeys::NavigatorDetailedHeight, settings.navigator_detailed_height);
+
+  map.Get(ProfileKeys::NavigatorReverseSwipeWaypointMovement, settings.navigator_swipe);
+  map.GetEnum(ProfileKeys::NavigatorAltitudeType, settings.navigator_altitude_type);
 }
 
 void
@@ -146,6 +159,7 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
   Load(map, settings.format);
   Load(map, settings.map);
   Load(map, settings.info_boxes);
+  Load(map, settings.navigator);
   Load(map, settings.vario);
   Load(map, settings.traffic);
   Load(map, settings.pages);

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -36,6 +36,7 @@
 #include "util/StaticString.hxx"
 
 // standard
+#include <algorithm>
 #include <cmath>
 
 namespace {
@@ -87,9 +88,6 @@ NavigatorRenderer::Update(const Canvas &canvas) noexcept
       canvas_height != canvas.GetHeight()) {
     canvas_width = canvas.GetWidth();
     canvas_height = canvas.GetHeight();
-    hasCanvasSizeChanged = true;
-  } else {
-    hasCanvasSizeChanged = false;
   }
 
   basic = &CommonInterface::Basic();
@@ -97,61 +95,17 @@ NavigatorRenderer::Update(const Canvas &canvas) noexcept
 
   has_started = calculated->ordered_task_stats.start.HasStarted();
   utc_offset = CommonInterface::GetComputerSettings().utc_offset;
-
-  ratio_dpi = 1.0 / Layout::vdpi * 100;
-}
-
-void
-NavigatorRenderer::GenerateFrame(const PixelRect &rc,
-                                 const bool is_frame_main) noexcept
-{
-  const int rc_height = rc.GetHeight();
-  const int rc_width = rc.GetWidth();
-  const auto rc_top_left = rc.GetTopLeft();
-
-  /* the divisions below are not simplified deliberately to understand frame
-     construction */
-  const PixelPoint pt0 = {rc_top_left.x + rc_height * 5 / 20, rc_top_left.y};
-  const PixelPoint pt1 = {rc_top_left.x + rc_width - rc_height * 4 / 20,
-                          pt0.y};
-  const PixelPoint pt2 = {rc_top_left.x + rc_width - rc_height * 2 / 20,
-                          rc_top_left.y + rc_height * 1 / 20};
-  const PixelPoint pt3 = {rc_top_left.x + rc_width,
-                          rc_top_left.y + rc_height * 10 / 20};
-  const PixelPoint pt4 = {pt2.x, rc_top_left.y + rc_height * 19 / 20};
-  const PixelPoint pt5 = {pt1.x, rc_top_left.y + rc_height};
-  const PixelPoint pt6 = {pt0.x, pt5.y};
-  const PixelPoint pt7 = {rc_top_left.x + rc_height * 2 / 20, pt4.y};
-  const PixelPoint pt8 = {rc_top_left.x, pt3.y};
-  const PixelPoint pt9 = {pt7.x, pt2.y};
-
-  const std::array<BulkPixelPoint, 10> frame{
-      pt0, pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8, pt9,
-  };
-  if (is_frame_main)
-    polygon_frame_main = frame;
-  else
-    polygon_frame_detailed = frame;
 }
 
 void
 NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
-                             const NavigatorLook &look_nav,
-                             const bool is_frame_main) noexcept
+                             const NavigatorLook &look_nav) noexcept
 {
-  if (hasCanvasSizeChanged) {
-    GenerateFrame(rc, is_frame_main);
-  }
-
   canvas.Select(look_nav.pen_frame);
   canvas.Select(look_nav.brush_frame);
 
-  if (is_frame_main) {
-    canvas.DrawPolygon(polygon_frame_main.data(), polygon_frame_main.size());
-  } else {
-    canvas.DrawPolygon(polygon_frame_detailed.data(),
-                       polygon_frame_detailed.size());
-  }
+  const unsigned corner_radius = Layout::Scale(8);
+  canvas.DrawRoundRectangle(rc, {corner_radius * 2, corner_radius * 2});
 }
 
 void
@@ -429,9 +383,11 @@ NavigatorRenderer::DrawWaypointInfoValueUnit(
     const char *text_for_width) noexcept
 {
   unit_height = static_cast<unsigned int>(font_height * 4 / 10);
-  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
   size_text = canvas.CalcTextSize(text_for_width);
-  font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+  font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(unit_height)));
   ascent_height = UnitSymbolRenderer::GetAscentHeight(font, unit);
   pp_pos_unit = pxpt_pos_infos_waypoint.At(
       size_text.width, size_text.height - static_cast<int>(ascent_height * 1.6));
@@ -465,7 +421,8 @@ NavigatorRenderer::DrawWaypointInfos(Canvas &canvas,
     break;
   }
 
-  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
   canvas.Select(font);
 
   text_size_infos_waypoint =
@@ -538,7 +495,8 @@ NavigatorRenderer::DrawCurrentFlightInfos(
                                    : font_height = canvas_height * 30 / 200;
   }
 
-  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
   // grow artificially the current_speed_s string ('format tricks')
   StaticString<7> sz_tmp_current_speed_s;
   sz_tmp_current_speed_s.clear();
@@ -600,7 +558,8 @@ NavigatorRenderer::DrawCurrentFlightInfos(
     // Draw speed units ---------------------------------------------
     unit = Units::GetUserSpeedUnit();
     unit_height = static_cast<unsigned int>(font_height * 38 / 100);
-    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(unit_height)));
     size_text = canvas.CalcTextSize(current_speed_s.c_str());
     pp_pos_unit =
         pxpt_pos_current_speed.At(size_text.width, size_text.height / 10);
@@ -609,7 +568,8 @@ NavigatorRenderer::DrawCurrentFlightInfos(
                              look_infobox.unit_fraction_pen);
 
     // Current Altitude --------------------------------------------
-    font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+    font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
     const PixelPoint pxpt_pos_altitude{pos_x_speed_altitude,
                                        pos_y_current_altitude};
     canvas.Select(font);
@@ -619,7 +579,8 @@ NavigatorRenderer::DrawCurrentFlightInfos(
     // Draw Altitude unit -------------------------------------------
     unit = Units::GetUserAltitudeUnit();
     unit_height = static_cast<unsigned int>(font_height * 0.5);
-    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(unit_height)));
     size_text = canvas.CalcTextSize(current_altitude_s.c_str());
     pp_pos_unit =
         pxpt_pos_altitude.At(size_text.width, size_text.height * 53 / 100);
@@ -652,7 +613,8 @@ NavigatorRenderer::DrawWaypointName(Canvas &canvas,
     break;
   }
 
-  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
   canvas.Select(font);
 
   sz_waypoint_name = canvas.CalcTextSize(waypoint_name_s).width;
@@ -721,10 +683,10 @@ NavigatorRenderer::DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
   if (nav_type == NavType::NAVIGATOR_DETAILED) {
     if (canvas_width > canvas_height * 3.6) {
       font.Load(FontDescription(
-          Layout::VptScale(canvas_height * ratio_dpi * 32 / 200)));
+          Layout::VptScaleFromDesignPixel(canvas_height * 32 / 200)));
     } else {
       font.Load(FontDescription(
-          Layout::VptScale(canvas_height * ratio_dpi * 24 / 200)));
+          Layout::VptScaleFromDesignPixel(canvas_height * 24 / 200)));
     }
 
     size_text = canvas.CalcTextSize(times_local_elapsed_s.c_str());
@@ -778,7 +740,8 @@ NavigatorRenderer::DrawAverageSpeed(Canvas &canvas,
     } else {
       font_height = canvas_height * 24 / 200;
     }
-    font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+    font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(font_height)));
     size_text = canvas.CalcTextSize(waypoint_average_speed_s.c_str());
     PixelPoint pxpt_pos_average_speed{
         static_cast<int>(canvas_width * 5 / 200 + 6),
@@ -790,7 +753,8 @@ NavigatorRenderer::DrawAverageSpeed(Canvas &canvas,
     // Draw average speed unit --------------------------------------
     unit = Units::GetUserTaskSpeedUnit();
     unit_height = static_cast<unsigned int>(font_height * 0.5);
-    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    font.Load(FontDescription(
+      Layout::VptScaleFromDesignPixel(unit_height)));
     pp_pos_unit =
         pxpt_pos_average_speed.At(size_text.width, size_text.height / 10);
     UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
@@ -944,9 +908,10 @@ NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
   const int rc_height = rc.GetHeight();
   const int rc_width = rc.GetWidth();
 
-  // render the progress bar
+  /* Bar must reach rc.bottom: the old margin left a foot strip where the
+     frame stroke (light in dark mode) showed over the clear. */
   PixelRect r{rc_height * 5 / 24, rc_height - rc_height * 5 / 48,
-              rc_width - rc_height * 10 / 48, rc_height - rc_height * 1 / 48};
+              rc_width - rc_height * 10 / 48, rc.bottom};
 
   bool task_has_started =
       CommonInterface::Calculated().task_stats.start.HasStarted();
@@ -955,17 +920,31 @@ NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
 
   unsigned int progression{};
 
-  if (task_has_started && !task_is_finished)
-    progression = 100 * (1 - summary.p_remaining);
-  else if (task_has_started && task_is_finished) progression = 100;
-  else progression = 0;
+  if (task_has_started && !task_is_finished) {
+    double p{1.0 - summary.p_remaining};
+    if (!std::isfinite(p))
+      p = 0.0;
+    p = std::clamp(p, 0.0, 1.0);
+    progression = static_cast<unsigned>(std::lround(100.0 * p));
+  } else if (task_has_started && task_is_finished) {
+    progression = 100;
+  } else {
+    progression = 0;
+  }
 
-  DrawSimpleProgressBar(canvas, r, progression, 0, 100);
+  const Color &progress_bg = look_nav.inverse
+                                 ? NavigatorLook::color_background_frame_inv
+                                 : NavigatorLook::color_background_frame;
+  DrawSimpleProgressBar(canvas, r, progression, 0, 100, &progress_bg);
 
   canvas.Select(look_nav.brush_frame);
 
   // render the waypoints on the progress bar
-  const Pen pen_waypoint(Layout::ScalePenWidth(1), COLOR_BLACK);
+  /* Outlines: avoid color_frame_inv (white) in dark mode here; many small
+     draw_rectangle calls with a white pen read as a bright line on the bar. */
+  const Pen pen_waypoint(Layout::ScalePenWidth(1),
+                         look_nav.inverse ? COLOR_GRAY
+                                          : NavigatorLook::color_frame);
   const Pen pen_indications(Layout::ScalePenWidth(1),
                             look_nav.inverse ? COLOR_GRAY : COLOR_DARK_GRAY);
   canvas.Select(pen_indications);
@@ -1018,7 +997,10 @@ NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
       w = Layout::Scale(2);
     } else {
       if (it->achieved) canvas.Select(look_task.hbGreen);
-      else canvas.Select(look_task.hbLightGray);
+      else
+        /* hbLightGray is near-white; on a dark track it looks like a white band */
+        canvas.Select(look_nav.inverse ? look_task.hbGray
+                                       : look_task.hbLightGray);
 
       w = Layout::Scale(1);
     }
@@ -1058,6 +1040,9 @@ NavigatorRenderer::DrawWaypointsIconsTitle(
   /// without using costing calculation inside renderer
   WaypointReachability wr_before{WaypointReachability::UNREACHABLE};
   WaypointReachability wr_current{WaypointReachability::UNREACHABLE};
+
+  if (backend_components == nullptr)
+    return;
 
   auto *protected_task_manager =
       backend_components->protected_task_manager.get();

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -8,6 +8,7 @@
 #include "Formatter/LocalTimeFormatter.hpp"
 #include "Formatter/Units.hpp"
 #include "Formatter/UserUnits.hpp"
+#include "Gauge/NavigatorSettings.hpp"
 #include "Interface.hpp"
 #include "Look/FontDescription.hpp"
 #include "Look/InfoBoxLook.hpp"
@@ -176,17 +177,60 @@ NavigatorRenderer::GenerateStringsWaypointInfos(NavType nav_type,
   FormatUserDistance(waypoint_distance, waypoint_distance_s.data(), false,
                      precision_waypoint_distance);
 
-  // waypoint_altitude_s; before navigator settings exist, use required
-  // altitude. The widget commit restores configurable WP_AltReq / diff /
-  // arrival modes.
-  const auto waypoint_altitude =
-      (tp == TaskType::ORDERED)
-          ? calculated->ordered_task_stats.current_leg.solution_remaining
-                .GetRequiredAltitude()
-          : calculated->task_stats.current_leg.solution_remaining
-                .GetRequiredAltitude();
-  FormatAltitude(waypoint_altitude_s.data(), waypoint_altitude,
-                 Units::GetUserAltitudeUnit(), false);
+  // waypoint_altitude_s (configurable choice: WP_AltReq WP_AltDiff
+  // WP_AltArrival)
+  auto waypoint_altitude{.0};
+  const auto &navigatorAltitudeType =
+      CommonInterface::GetUISettings().navigator.navigator_altitude_type;
+
+  if (tp == TaskType::ORDERED) {
+    switch (navigatorAltitudeType) {
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltReq:
+      waypoint_altitude = calculated->ordered_task_stats.current_leg
+                              .solution_remaining.GetRequiredAltitude();
+      break;
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltDiff:
+      waypoint_altitude = calculated->ordered_task_stats.current_leg
+                              .solution_remaining.altitude_difference;
+      break;
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltArrival:
+      waypoint_altitude = calculated->ordered_task_stats.current_leg
+                              .solution_remaining.GetArrivalAltitude();
+      break;
+    default:
+      waypoint_altitude = calculated->ordered_task_stats.current_leg
+                              .solution_remaining.GetRequiredAltitude();
+      break;
+    }
+  } else {
+    switch (navigatorAltitudeType) {
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltReq:
+      waypoint_altitude = calculated->task_stats.current_leg.solution_remaining
+                              .GetRequiredAltitude();
+      break;
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltDiff:
+      waypoint_altitude = calculated->task_stats.current_leg.solution_remaining
+                              .altitude_difference;
+      break;
+    case NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltArrival:
+      waypoint_altitude = calculated->task_stats.current_leg.solution_remaining
+                              .GetArrivalAltitude();
+      break;
+    default:
+      waypoint_altitude = calculated->task_stats.current_leg.solution_remaining
+                              .GetRequiredAltitude();
+      break;
+    }
+  }
+
+  if (navigatorAltitudeType !=
+      NavigatorSettings::NavigatorWidgetAltitudeType::WP_AltDiff) {
+    FormatAltitude(waypoint_altitude_s.data(), waypoint_altitude,
+                   Units::GetUserAltitudeUnit(), false);
+  } else {
+    FormatRelativeAltitude(waypoint_altitude_s.data(), waypoint_altitude,
+                           Units::GetUserAltitudeUnit(), false);
+  }
 
   // waypoint_GR_s; // e_WP_GR glide ratio
   auto waypoint_GR{0};

--- a/src/Renderer/NavigatorRenderer.cpp
+++ b/src/Renderer/NavigatorRenderer.cpp
@@ -1,0 +1,1028 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "NavigatorRenderer.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Formatter/LocalTimeFormatter.hpp"
+#include "Formatter/Units.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Interface.hpp"
+#include "Look/FontDescription.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "Look/Look.hpp"
+#include "Look/MapLook.hpp"
+#include "Look/NavigatorLook.hpp"
+#include "Look/WaypointLook.hpp"
+#include "Math/Angle.hpp"
+#include "NextArrowRenderer.hpp"
+#include "PageActions.hpp"
+#include "PageSettings.hpp"
+#include "ProgressBarRenderer.hpp"
+#include "Renderer/TextRenderer.hpp"
+#include "Screen/Layout.hpp"
+#include "UIGlobals.hpp"
+#include "UnitSymbolRenderer.hpp"
+#include "Waypoint/Waypoint.hpp"
+#include "WaypointIconRenderer.hpp"
+#include "WaypointRenderer.hpp"
+#include "WindArrowRenderer.hpp"
+#include "time/RoughTime.hpp"
+#include "time/Stamp.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "util/StaticString.hxx"
+
+// standard
+#include <cmath>
+
+namespace {
+
+/**
+ * Clip rect anchored at the origin; used for DrawClippedText with text drawn
+ * at an arbitrary on-screen #at.
+ */
+[[gnu::const]]
+static PixelRect
+ClipRectFromOrigin(PixelSize size) noexcept
+{
+  return PixelRect{PixelPoint{0, 0}, size};
+}
+
+static void
+DrawClippedTextFullCanvas(Canvas &canvas, PixelPoint at, unsigned width,
+                          unsigned height, const char *text) noexcept
+{
+  canvas.DrawClippedText(
+      at, ClipRectFromOrigin({static_cast<int>(width), static_cast<int>(height)}),
+      text);
+}
+
+static constexpr char kTimeUnknown[] = "--:--";
+
+/**
+ * Write local HH:MM (with UTC offset) into a short buffer.
+ */
+static void
+SetLocalTimeHHMM(StaticString<8> &s, TimeStamp t,
+                 RoughTimeDelta utc_offset) noexcept
+{
+  s.Format("%s", FormatLocalTimeHHMM(t, utc_offset).c_str());
+}
+
+static void
+SetTimeUnknown(StaticString<8> &s) noexcept
+{
+  s.Format("%s", kTimeUnknown);
+}
+
+} // namespace
+
+void
+NavigatorRenderer::Update(const Canvas &canvas) noexcept
+{
+  if (canvas_width != canvas.GetWidth() ||
+      canvas_height != canvas.GetHeight()) {
+    canvas_width = canvas.GetWidth();
+    canvas_height = canvas.GetHeight();
+    hasCanvasSizeChanged = true;
+  } else {
+    hasCanvasSizeChanged = false;
+  }
+
+  basic = &CommonInterface::Basic();
+  calculated = &CommonInterface::Calculated();
+
+  has_started = calculated->ordered_task_stats.start.HasStarted();
+  utc_offset = CommonInterface::GetComputerSettings().utc_offset;
+
+  ratio_dpi = 1.0 / Layout::vdpi * 100;
+}
+
+void
+NavigatorRenderer::GenerateFrame(const PixelRect &rc,
+                                 const bool is_frame_main) noexcept
+{
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+  const auto rc_top_left = rc.GetTopLeft();
+
+  /* the divisions below are not simplified deliberately to understand frame
+     construction */
+  const PixelPoint pt0 = {rc_top_left.x + rc_height * 5 / 20, rc_top_left.y};
+  const PixelPoint pt1 = {rc_top_left.x + rc_width - rc_height * 4 / 20,
+                          pt0.y};
+  const PixelPoint pt2 = {rc_top_left.x + rc_width - rc_height * 2 / 20,
+                          rc_top_left.y + rc_height * 1 / 20};
+  const PixelPoint pt3 = {rc_top_left.x + rc_width,
+                          rc_top_left.y + rc_height * 10 / 20};
+  const PixelPoint pt4 = {pt2.x, rc_top_left.y + rc_height * 19 / 20};
+  const PixelPoint pt5 = {pt1.x, rc_top_left.y + rc_height};
+  const PixelPoint pt6 = {pt0.x, pt5.y};
+  const PixelPoint pt7 = {rc_top_left.x + rc_height * 2 / 20, pt4.y};
+  const PixelPoint pt8 = {rc_top_left.x, pt3.y};
+  const PixelPoint pt9 = {pt7.x, pt2.y};
+
+  const std::array<BulkPixelPoint, 10> frame{
+      pt0, pt1, pt2, pt3, pt4, pt5, pt6, pt7, pt8, pt9,
+  };
+  if (is_frame_main)
+    polygon_frame_main = frame;
+  else
+    polygon_frame_detailed = frame;
+}
+
+void
+NavigatorRenderer::DrawFrame(Canvas &canvas, const PixelRect &rc,
+                             const NavigatorLook &look_nav,
+                             const bool is_frame_main) noexcept
+{
+  if (hasCanvasSizeChanged) {
+    GenerateFrame(rc, is_frame_main);
+  }
+
+  canvas.Select(look_nav.pen_frame);
+  canvas.Select(look_nav.brush_frame);
+
+  if (is_frame_main) {
+    canvas.DrawPolygon(polygon_frame_main.data(), polygon_frame_main.size());
+  } else {
+    canvas.DrawPolygon(polygon_frame_detailed.data(),
+                       polygon_frame_detailed.size());
+  }
+}
+
+void
+NavigatorRenderer::GenerateStringsWaypointInfos(NavType nav_type,
+                                                  const TaskType tp) noexcept
+{
+  // waypoint_distance_s; // e_WP_Distance
+  auto precision_waypoint_distance{0};
+  auto waypoint_distance{.0};
+
+  if (tp == TaskType::ORDERED) {
+    waypoint_distance =
+        calculated->ordered_task_stats.current_leg.vector_remaining.distance;
+  } else {
+    waypoint_distance =
+        calculated->task_stats.current_leg.vector_remaining.distance;
+  }
+
+  if (waypoint_distance < 5000.0) {
+    precision_waypoint_distance = 1;
+  }
+
+  FormatUserDistance(waypoint_distance, waypoint_distance_s.data(), false,
+                     precision_waypoint_distance);
+
+  // waypoint_altitude_s; before navigator settings exist, use required
+  // altitude. The widget commit restores configurable WP_AltReq / diff /
+  // arrival modes.
+  const auto waypoint_altitude =
+      (tp == TaskType::ORDERED)
+          ? calculated->ordered_task_stats.current_leg.solution_remaining
+                .GetRequiredAltitude()
+          : calculated->task_stats.current_leg.solution_remaining
+                .GetRequiredAltitude();
+  FormatAltitude(waypoint_altitude_s.data(), waypoint_altitude,
+                 Units::GetUserAltitudeUnit(), false);
+
+  // waypoint_GR_s; // e_WP_GR glide ratio
+  auto waypoint_GR{0};
+  if (tp == TaskType::ORDERED)
+    waypoint_GR =
+        std::round(calculated->ordered_task_stats.current_leg.gradient);
+  else {
+    waypoint_GR = std::round(calculated->task_stats.current_leg.gradient);
+  }
+  waypoint_GR_s.Format("%d", waypoint_GR);
+
+  // waypoint_direction_s; // e_WP_BearingDiff
+  if (!basic->track_available) {
+    bearing_diff.Zero();
+  } else if (tp == TaskType::ORDERED)
+    bearing_diff =
+        calculated->ordered_task_stats.current_leg.vector_remaining.bearing -
+        basic->track;
+  else {
+    bearing_diff =
+        calculated->task_stats.current_leg.vector_remaining.bearing -
+        basic->track;
+  }
+  const int waypoint_direction = std::round(bearing_diff.AsDelta().Degrees());
+  waypoint_direction_s.Format("%d°", waypoint_direction);
+
+  // infos_next_waypoint_s; // dist + alt + GR
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    infos_waypoint_s.Format("%s   %s", waypoint_distance_s.c_str(),
+                            waypoint_altitude_s.c_str());
+    break;
+
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+    infos_waypoint_s.Format(
+        "%s       %s       %s", waypoint_distance_s.c_str(),
+        waypoint_altitude_s.c_str(), waypoint_GR_s.c_str());
+    break;
+
+  case NavType::NAVIGATOR:
+    if (canvas_width > canvas_height * 8.1) {
+      infos_waypoint_s.Format(
+          "%s   %s  %s  %s", waypoint_distance_s.c_str(),
+          waypoint_altitude_s.c_str(), waypoint_GR_s.c_str(),
+          waypoint_direction_s.c_str());
+    } else if (canvas_width > canvas_height * 4.9) {
+      infos_waypoint_s.Format("%s   %s  %s", waypoint_distance_s.c_str(),
+                              waypoint_altitude_s.c_str(),
+                              waypoint_GR_s.c_str());
+    } else {
+      infos_waypoint_s.Format("%s   %s", waypoint_distance_s.c_str(),
+                              waypoint_altitude_s.c_str());
+    }
+    break;
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    if (canvas_width > canvas_height * 8.1) {
+      infos_waypoint_s.Format(
+          "%s   %s  %s  %s", waypoint_distance_s.c_str(),
+          waypoint_altitude_s.c_str(), waypoint_GR_s.c_str(),
+          waypoint_direction_s.c_str());
+    } else if (canvas_width > canvas_height * 2.9) {
+      infos_waypoint_s.Format("%s   %s  %s", waypoint_distance_s.c_str(),
+                              waypoint_altitude_s.c_str(),
+                              waypoint_GR_s.c_str());
+    } else {
+      infos_waypoint_s.Format("%s   %s", waypoint_distance_s.c_str(),
+                              waypoint_altitude_s.c_str());
+    }
+    break;
+  }
+
+  // infos_next_waypoint_units__dist_alt_s;
+  if (nav_type != NavType::NAVIGATOR_LITE_TWO_LINES) {
+    infos_waypoint_units_dist_alt_s.Format("%s   %s",
+                                           waypoint_distance_s.c_str(),
+                                           waypoint_altitude_s.c_str());
+  } else {
+    infos_waypoint_units_dist_alt_s.Format("%s       %s",
+                                           waypoint_distance_s.c_str(),
+                                           waypoint_altitude_s.c_str());
+  }
+
+  // infos_next_waypoint_units__dist_alt_GR_s;
+  if (nav_type != NavType::NAVIGATOR_LITE_TWO_LINES) {
+    infos_waypoint_units_dist_alt_GR_s.Format(
+        "%s   %s  %s", waypoint_distance_s.c_str(),
+        waypoint_altitude_s.c_str(), waypoint_GR_s.c_str());
+  } else {
+    infos_waypoint_units_dist_alt_GR_s.Format(
+        "%s       %s       %s", waypoint_distance_s.c_str(),
+        waypoint_altitude_s.c_str(), waypoint_GR_s.c_str());
+  }
+}
+
+void
+NavigatorRenderer::GenerateStringsCurrentFlightInfo(const TaskType tp) noexcept
+{
+  // current_speed_s; // e_Speed_GPS
+  FormatUserSpeed(basic->ground_speed, current_speed_s.data(), false, 0);
+
+  // current_altitude_s; // e_HeightGPS
+  FormatUserAltitude(basic->gps_altitude, current_altitude_s.data(), false);
+
+  // waypoint_average_speed_s; // e_SpeedTaskAvg
+  if (tp == TaskType::ORDERED && has_started) {
+    FormatUserSpeed(calculated->task_stats.total.travelled.GetSpeed(),
+                    waypoint_average_speed_s.data(), false, 0);
+  } else {
+    waypoint_average_speed_s.Format("%s", "---");
+  }
+}
+
+void
+NavigatorRenderer::GenerateStringWaypointName(
+    const Waypoint &wp_current) noexcept
+{
+  // waypoint_name_s; // e_WP_Name
+  waypoint_name_s.Format("%s", wp_current.name.c_str());
+}
+
+void
+NavigatorRenderer::GenerateStringsTimesInfo(const TaskType tp) noexcept
+{
+  if (tp == TaskType::ORDERED && has_started && basic->time_available) {
+    const auto time_elapsed = TimeStamp{
+        FloatDuration{calculated->ordered_task_stats.total.time_elapsed}};
+    SetLocalTimeHHMM(time_elapsed_s, time_elapsed, utc_no_offset);
+  } else {
+    SetTimeUnknown(time_elapsed_s);
+  }
+
+  const auto time_start = calculated->ordered_task_stats.start.time;
+  if (tp == TaskType::ORDERED && has_started && basic->time_available)
+    SetLocalTimeHHMM(time_start_s, time_start, utc_offset);
+  else
+    SetTimeUnknown(time_start_s);
+
+  if (basic->time_available)
+    SetLocalTimeHHMM(time_local_s, basic->time, utc_offset);
+  else
+    SetTimeUnknown(time_local_s);
+
+  TimeStamp time_planned{};
+  if (tp == TaskType::ORDERED && has_started && basic->time_available) {
+    time_planned = TimeStamp{
+        FloatDuration{calculated->ordered_task_stats.total.time_planned}};
+    SetLocalTimeHHMM(time_planned_s, time_planned, utc_no_offset);
+  } else if (tp != TaskType::ORDERED && basic->time_available) {
+    time_planned =
+        TimeStamp{FloatDuration{calculated->task_stats.total.time_planned}};
+    SetLocalTimeHHMM(time_planned_s, time_planned, utc_no_offset);
+  } else {
+    SetTimeUnknown(time_planned_s);
+  }
+
+  TimeStamp arrival_planned{};
+  if (tp == TaskType::ORDERED && has_started && basic->time_available) {
+    arrival_planned = TimeStamp{
+        FloatDuration{time_start.ToDuration() + time_planned.ToDuration()}};
+    SetLocalTimeHHMM(arrival_planned_s, arrival_planned, utc_offset);
+  } else if (tp != TaskType::ORDERED && basic->time_available) {
+    arrival_planned = TimeStamp{
+        FloatDuration{basic->time.ToDuration() + time_planned.ToDuration()}};
+    SetLocalTimeHHMM(arrival_planned_s, arrival_planned, utc_offset);
+  } else {
+    SetTimeUnknown(arrival_planned_s);
+  }
+
+  times_local_elapsed_s.Format("%s (%s)", time_local_s.c_str(),
+                               time_elapsed_s.c_str());
+
+  if (canvas_width > canvas_height * 2.8) {
+    times_arrival_planned_s.Format("%s (%s)", arrival_planned_s.c_str(),
+                                   time_planned_s.c_str());
+  } else {
+    times_arrival_planned_s.Format("%s", arrival_planned_s.c_str());
+  }
+}
+
+void
+NavigatorRenderer::SetTextColor(Canvas &canvas,
+                                const NavigatorLook &look_nav) noexcept
+{
+  canvas.SetBackgroundTransparent();
+  if (!look_nav.inverse) {
+    canvas.SetTextColor(COLOR_BLACK);
+  } else {
+    canvas.SetTextColor(COLOR_WHITE);
+  }
+}
+
+void
+NavigatorRenderer::DrawWaypointInfoValueUnit(
+    Canvas &canvas, const InfoBoxLook &look_infobox,
+    const char *text_for_width) noexcept
+{
+  unit_height = static_cast<unsigned int>(font_height * 4 / 10);
+  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  size_text = canvas.CalcTextSize(text_for_width);
+  font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+  ascent_height = UnitSymbolRenderer::GetAscentHeight(font, unit);
+  pp_pos_unit = pxpt_pos_infos_waypoint.At(
+      size_text.width, size_text.height - static_cast<int>(ascent_height * 1.6));
+  canvas.Select(font);
+  UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
+                           look_infobox.unit_fraction_pen);
+}
+
+void
+NavigatorRenderer::DrawWaypointInfos(Canvas &canvas,
+                                     NavType nav_type,
+                                     const InfoBoxLook &look_infobox) noexcept
+{
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    font_height = canvas_height * 85 / 200;
+    break;
+
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+  case NavType::NAVIGATOR:
+    font_height = canvas_height * 63 / 200;
+    break;
+
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    if (canvas_width > canvas_height * 3.7)
+      font_height = canvas_height * 35 / 200;
+    else {
+      font_height = canvas_height * 26 / 200;
+    }
+    break;
+  }
+
+  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  canvas.Select(font);
+
+  text_size_infos_waypoint =
+      canvas.CalcTextSize(infos_waypoint_s.c_str()).width;
+
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    pxpt_pos_infos_waypoint = {static_cast<int>(canvas_width * 96 / 100 -
+                                                text_size_infos_waypoint -
+                                                canvas_height * 40 / 100),
+                               static_cast<int>(canvas_height * 15 / 100)};
+    break;
+
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+    pxpt_pos_infos_waypoint = {
+        static_cast<int>(
+            (canvas_width - 2 * canvas_width * 13 / 200 -
+             canvas.CalcTextSize(infos_waypoint_s.c_str()).width) /
+                2 +
+            canvas_width * 13 / 200),
+        static_cast<int>(canvas_height * 2 / 100)};
+    break;
+
+  case NavType::NAVIGATOR:
+    pxpt_pos_infos_waypoint = {static_cast<int>(canvas_width * 13 / 200),
+                               static_cast<int>(canvas_height * 2 / 100)};
+    break;
+
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    pxpt_pos_infos_waypoint = {static_cast<int>(canvas_width * 40 / 200),
+                               static_cast<int>(canvas_height * 10 / 100)};
+    break;
+  }
+
+  DrawClippedTextFullCanvas(canvas, pxpt_pos_infos_waypoint, canvas_width,
+                            canvas_height, infos_waypoint_s.c_str());
+
+  unit = Units::GetUserDistanceUnit();
+  DrawWaypointInfoValueUnit(canvas, look_infobox, waypoint_distance_s.c_str());
+
+  unit = Units::GetUserAltitudeUnit();
+  DrawWaypointInfoValueUnit(canvas, look_infobox,
+                            infos_waypoint_units_dist_alt_s.c_str());
+
+  if ((canvas_width > canvas_height * 2.9 &&
+       nav_type == NavType::NAVIGATOR_LITE_TWO_LINES) ||
+      (canvas_width > canvas_height * 4.9 && nav_type == NavType::NAVIGATOR) ||
+      (canvas_width > canvas_height * 2.9 &&
+       nav_type == NavType::NAVIGATOR_DETAILED)) {
+    unit = Unit::GRADIENT;
+    DrawWaypointInfoValueUnit(canvas, look_infobox,
+                              infos_waypoint_units_dist_alt_GR_s.c_str());
+  }
+}
+
+void
+NavigatorRenderer::DrawCurrentFlightInfos(
+    Canvas &canvas, NavType nav_type,
+    const InfoBoxLook &look_infobox) noexcept
+{
+  int pos_y_current_altitude{};
+  int pos_y_current_speed{};
+
+  if (canvas_width > canvas_height * 3.2) {
+    nav_type == NavType::NAVIGATOR ? font_height = canvas_height * 55 / 200
+                                   : font_height = canvas_height * 40 / 200;
+  } else {
+    nav_type == NavType::NAVIGATOR ? font_height = canvas_height * 55 / 200
+                                   : font_height = canvas_height * 30 / 200;
+  }
+
+  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  // grow artificially the current_speed_s string ('format tricks')
+  StaticString<7> sz_tmp_current_speed_s;
+  sz_tmp_current_speed_s.clear();
+  sz_tmp_current_speed_s.append("0");
+  sz_tmp_current_speed_s.append(current_speed_s);
+  const auto text_size_current_speed_s =
+      canvas.CalcTextSize(sz_tmp_current_speed_s.c_str());
+  const auto text_size_current_altitude_s =
+      canvas.CalcTextSize(current_altitude_s.c_str());
+
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    size_text = canvas.CalcTextSize(infos_waypoint_s.c_str());
+    pos_x_speed_altitude =
+        canvas_width * 96 / 100 - size_text.width - canvas_height * 16 / 100;
+    pos_y_current_speed = static_cast<int>(canvas_height * 10 / 100);
+    pos_y_current_altitude = static_cast<int>(canvas_height * 35 / 100);
+    break;
+
+  case NavType::NAVIGATOR:
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+    size_text.width = std::max(text_size_current_speed_s.width,
+                               text_size_current_altitude_s.width);
+    pos_x_speed_altitude =
+        canvas_width * 96 / 100 - size_text.width - canvas_height * 16 / 100;
+    pos_y_current_speed = static_cast<int>(canvas_height * 5 / 100);
+    pos_y_current_altitude = static_cast<int>(canvas_height * 45 / 100);
+    break;
+
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    size_text.width = std::max(text_size_current_speed_s.width,
+                               text_size_current_altitude_s.width);
+    if (canvas_width > canvas_height * 3.2) {
+      pos_x_speed_altitude =
+          canvas_width * 96 / 100 - size_text.width - canvas_height * 16 / 100;
+      pos_y_current_speed = static_cast<int>(canvas_height * 10 / 100);
+      pos_y_current_altitude = static_cast<int>(canvas_height * 35 / 100);
+    } else {
+      pos_x_speed_altitude = canvas_width * 103 / 100 - size_text.width -
+                             canvas_height * 29 / 100;
+      pos_y_current_speed = static_cast<int>(canvas_height * 13 / 100);
+      pos_y_current_altitude = static_cast<int>(canvas_height * 42 / 100);
+    }
+    break;
+  }
+
+  if ((nav_type == NavType::NAVIGATOR_DETAILED ||
+       nav_type == NavType::NAVIGATOR) &&
+      canvas_width > canvas_height * 2.3) {
+
+    // Current speed ------------------------------------------------
+    const PixelPoint pxpt_pos_current_speed{pos_x_speed_altitude,
+                                            pos_y_current_speed};
+    canvas.Select(font);
+    DrawClippedTextFullCanvas(canvas, pxpt_pos_current_speed, canvas_width,
+                              canvas_height, current_speed_s.c_str());
+
+    // Draw speed units ---------------------------------------------
+    unit = Units::GetUserSpeedUnit();
+    unit_height = static_cast<unsigned int>(font_height * 38 / 100);
+    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    size_text = canvas.CalcTextSize(current_speed_s.c_str());
+    pp_pos_unit =
+        pxpt_pos_current_speed.At(size_text.width, size_text.height / 10);
+    canvas.Select(font);
+    UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
+                             look_infobox.unit_fraction_pen);
+
+    // Current Altitude --------------------------------------------
+    font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+    const PixelPoint pxpt_pos_altitude{pos_x_speed_altitude,
+                                       pos_y_current_altitude};
+    canvas.Select(font);
+    DrawClippedTextFullCanvas(canvas, pxpt_pos_altitude, canvas_width,
+                              canvas_height, current_altitude_s.c_str());
+
+    // Draw Altitude unit -------------------------------------------
+    unit = Units::GetUserAltitudeUnit();
+    unit_height = static_cast<unsigned int>(font_height * 0.5);
+    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    size_text = canvas.CalcTextSize(current_altitude_s.c_str());
+    pp_pos_unit =
+        pxpt_pos_altitude.At(size_text.width, size_text.height * 53 / 100);
+    UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
+                             look_infobox.unit_fraction_pen);
+  }
+}
+
+void
+NavigatorRenderer::DrawWaypointName(Canvas &canvas,
+                                    NavType nav_type) noexcept
+{
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    font_height = canvas_height * 85 / 200;
+    break;
+
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+  case NavType::NAVIGATOR:
+    font_height = canvas_height * 75 / 200;
+    break;
+
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    if (canvas_width > canvas_height * 3.7) {
+      font_height = canvas_height * 42 / 200;
+    } else {
+      font_height = canvas_height * 30 / 200;
+    }
+    break;
+  }
+
+  font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+  canvas.Select(font);
+
+  sz_waypoint_name = canvas.CalcTextSize(waypoint_name_s).width;
+
+  PixelSize name_clip_size{};
+
+  switch (nav_type) {
+  case NavType::NAVIGATOR_LITE_ONE_LINE:
+    pos_x_waypoint_name = static_cast<int>(canvas_width * 13 / 200);
+    pos_y_waypoint_name = static_cast<int>(canvas_height * 15 / 100);
+
+    pos_x_end_waypoint_name = pos_x_waypoint_name + sz_waypoint_name;
+    name_clip_size = {pxpt_pos_infos_waypoint.x -
+                          static_cast<int>(canvas_height * 95 / 100),
+                      static_cast<int>(canvas_height)};
+    break;
+
+  case NavType::NAVIGATOR_LITE_TWO_LINES:
+    pos_x_waypoint_name = canvas_width * 13 / 200;
+    pos_y_waypoint_name = canvas_height * 38 / 100;
+
+    sz_waypoint_name =
+        std::min(sz_waypoint_name, canvas_width - 2 * pos_x_waypoint_name);
+
+    pos_x_waypoint_name =
+        (canvas_width - 2 * pos_x_waypoint_name - sz_waypoint_name) / 2 +
+        canvas_width * 13 / 200;
+
+    name_clip_size = {static_cast<int>(pos_x_waypoint_name + sz_waypoint_name),
+                      static_cast<int>(font_height)};
+    break;
+
+  case NavType::NAVIGATOR:
+    pos_x_waypoint_name = static_cast<int>(canvas_width * 13 / 200);
+    pos_y_waypoint_name = static_cast<int>(canvas_height * 38 / 100);
+
+    pos_x_end_waypoint_name = pos_x_waypoint_name + sz_waypoint_name;
+    name_clip_size = {static_cast<int>(canvas_height / 2 + pos_x_speed_altitude -
+                                      canvas_height * 130 / 100),
+                      static_cast<int>(canvas_height)};
+    break;
+
+  case NavType::NAVIGATOR_DETAILED:
+  default:
+    pos_x_waypoint_name = pxpt_pos_infos_waypoint.x;
+    pos_y_waypoint_name = static_cast<int>(canvas_height * 31 / 100);
+
+    pos_x_end_waypoint_name = pos_x_waypoint_name + sz_waypoint_name;
+    name_clip_size = {static_cast<int>(canvas_height) / 2 + pos_x_speed_altitude -
+                          static_cast<int>(canvas_height),
+                      static_cast<int>(canvas_height)};
+    break;
+  }
+
+  const PixelRect name_clip{ClipRectFromOrigin(name_clip_size)};
+
+  canvas.DrawClippedText(
+      {static_cast<int>(pos_x_waypoint_name), static_cast<int>(pos_y_waypoint_name)},
+      name_clip, waypoint_name_s);
+}
+
+void
+NavigatorRenderer::DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
+                                 NavType nav_type) noexcept
+{
+  if (nav_type == NavType::NAVIGATOR_DETAILED) {
+    if (canvas_width > canvas_height * 3.6) {
+      font.Load(FontDescription(
+          Layout::VptScale(canvas_height * ratio_dpi * 32 / 200)));
+    } else {
+      font.Load(FontDescription(
+          Layout::VptScale(canvas_height * ratio_dpi * 24 / 200)));
+    }
+
+    size_text = canvas.CalcTextSize(times_local_elapsed_s.c_str());
+    const int pos_y_text_times{
+        static_cast<int>(canvas_height * 183 / 200 - size_text.height)};
+    const PixelRect pxrect_sz_time_start_s{rc.BottomAligned(canvas_width)};
+
+    // Draw text start time -----------------------------------------
+    const PixelPoint pxpt_pos_time_start_s{
+        static_cast<int>(canvas_width * 5 / 200 + 8), pos_y_text_times};
+    canvas.DrawClippedText(pxpt_pos_time_start_s, pxrect_sz_time_start_s,
+                           time_start_s);
+
+    // Draw text current time / elapsed time ------------------------
+    const PixelRect pxlrect_sz_time_elapsed_s{rc.BottomAligned(canvas_width)};
+    int size_text_tmp{};
+    if (canvas_width > canvas_height * 2.8) {
+      size_text_tmp = size_text.width * 3 / 4;
+    } else {
+      size_text_tmp = size_text.width / 2;
+    }
+    const PixelPoint pxpt_pos_time_elapsed_s{
+        static_cast<int>(canvas_width * 100 / 200 - size_text_tmp),
+        pos_y_text_times};
+    canvas.DrawClippedText(pxpt_pos_time_elapsed_s, pxlrect_sz_time_elapsed_s,
+                           times_local_elapsed_s);
+
+    // Draw text planned time ---------------------------------------
+    size_text = canvas.CalcTextSize(times_arrival_planned_s.c_str());
+    const PixelRect pxlrect_sz_arrival_planned_s{
+        rc.BottomAligned(canvas_width)};
+    const PixelPoint pxpt_times_pos_arrival_planned_s{
+        static_cast<int>(canvas_width - (canvas_width * 5 / 200 + 8) -
+                         size_text.width),
+        pos_y_text_times};
+    canvas.DrawClippedText(pxpt_times_pos_arrival_planned_s,
+                           pxlrect_sz_arrival_planned_s,
+                           times_arrival_planned_s);
+  }
+}
+
+void
+NavigatorRenderer::DrawAverageSpeed(Canvas &canvas,
+                                    NavType nav_type,
+                                    const InfoBoxLook &look_infobox) noexcept
+{
+  if (nav_type == NavType::NAVIGATOR_DETAILED) {
+    // Task informations: average speed -----------------------------
+    if (canvas_width > canvas_height * 3.4) {
+      font_height = canvas_height * 35 / 200;
+    } else {
+      font_height = canvas_height * 24 / 200;
+    }
+    font.Load(FontDescription(Layout::VptScale(font_height * ratio_dpi)));
+    size_text = canvas.CalcTextSize(waypoint_average_speed_s.c_str());
+    PixelPoint pxpt_pos_average_speed{
+        static_cast<int>(canvas_width * 5 / 200 + 6),
+        static_cast<int>(canvas_height * 8 / 100)};
+    canvas.Select(font);
+    DrawClippedTextFullCanvas(canvas, pxpt_pos_average_speed, canvas_width,
+                              canvas_height, waypoint_average_speed_s.c_str());
+
+    // Draw average speed unit --------------------------------------
+    unit = Units::GetUserTaskSpeedUnit();
+    unit_height = static_cast<unsigned int>(font_height * 0.5);
+    font.Load(FontDescription(Layout::VptScale(unit_height * ratio_dpi)));
+    pp_pos_unit =
+        pxpt_pos_average_speed.At(size_text.width, size_text.height / 10);
+    UnitSymbolRenderer::Draw(canvas, pp_pos_unit, unit,
+                             look_infobox.unit_fraction_pen);
+  }
+}
+
+void
+NavigatorRenderer::DrawDirectionArrowNorthAnnulus(
+    Canvas &canvas, NavType nav_type,
+    const TaskLook &look_task) noexcept
+{
+  // Draw direction arrow / North direction -------------------------
+  if (nav_type == NavType::NAVIGATOR_LITE_ONE_LINE ||
+      nav_type == NavType::NAVIGATOR_DETAILED ||
+      nav_type == NavType::NAVIGATOR) {
+
+    int pos_x_arrow{};
+    int pos_y_arrow_offset{};
+    int scale__arrow{};
+    int pos_y_annulus{};
+    int small_radius_annulus{};
+    int big_radius_annulus{};
+    int sz_max_waypoint_text{};
+
+    const auto has_finished = calculated->ordered_task_stats.task_finished;
+    if (!has_started) {
+      canvas.Select(look_task.hbLightGray);
+    } else {
+      if (!has_finished) {
+        canvas.Select(look_task.hbOrange);
+      } else {
+        canvas.Select(look_task.hbGreen);
+      }
+    }
+
+    switch (nav_type) {
+    case NavType::NAVIGATOR_LITE_ONE_LINE:
+      pos_x_arrow = pxpt_pos_infos_waypoint.x -
+                    static_cast<int>(canvas_height * 95 / 100);
+      pos_y_arrow_offset = canvas_height * 43 / 200;
+      pos_y_annulus = static_cast<int>(canvas_height * 48 / 100);
+      small_radius_annulus = static_cast<int>(canvas_height) * 26 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height * 40 / 100);
+      scale__arrow = 14;
+
+      if (static_cast<int>(sz_waypoint_name) <
+          pos_x_arrow - static_cast<int>(canvas_height * 60 / 100) / 2) {
+        pos_x_arrow = (pxpt_pos_infos_waypoint.x + sz_waypoint_name) / 2 -
+                      static_cast<int>(canvas_height * 50 / 100) / 2;
+      }
+      break;
+
+    case NavType::NAVIGATOR:
+      pos_x_arrow =
+          pos_x_speed_altitude - static_cast<int>(canvas_height * 90 / 100);
+      pos_y_arrow_offset = canvas_height * 43 / 200;
+      pos_y_annulus = static_cast<int>(canvas_height * 48 / 100);
+      small_radius_annulus = static_cast<int>(canvas_height) * 28 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height) * 36 / 100;
+      scale__arrow = 14;
+      sz_max_waypoint_text = static_cast<int>(
+          std::max(pos_x_end_waypoint_name,
+                   text_size_infos_waypoint + pxpt_pos_infos_waypoint.x));
+      break;
+
+    default:
+      pos_x_arrow =
+          pos_x_speed_altitude - static_cast<int>(canvas_height * 77 / 100);
+      pos_y_arrow_offset = canvas_height * 13 / 100;
+      pos_y_annulus = static_cast<int>(canvas_height * 75 / 200);
+      small_radius_annulus = static_cast<int>(canvas_height) * 18 / 100;
+      big_radius_annulus = static_cast<int>(canvas_height) * 26 / 100;
+      scale__arrow = 21;
+      sz_max_waypoint_text = static_cast<int>(
+          std::max(pos_x_end_waypoint_name,
+                   text_size_infos_waypoint + pxpt_pos_infos_waypoint.x));
+
+      if (sz_max_waypoint_text <
+              pos_x_speed_altitude - big_radius_annulus * 2 &&
+          canvas_width > canvas_height * 4.2) {
+        pos_x_arrow = (pos_x_speed_altitude + sz_max_waypoint_text) / 2 -
+                      2 * big_radius_annulus;
+      }
+      break;
+    }
+
+    canvas.DrawAnnulus(
+        {static_cast<int>(canvas_height) / 2 + pos_x_arrow, pos_y_annulus},
+        small_radius_annulus, big_radius_annulus,
+        -basic->track + Angle::Degrees(50),
+        -basic->track + Angle::Degrees(310));
+
+    canvas.DrawAnnulus(
+        {static_cast<int>(canvas_height) / 2 + pos_x_arrow, pos_y_annulus},
+        small_radius_annulus, big_radius_annulus,
+        -basic->track - Angle::Degrees(8), -basic->track + Angle::Degrees(8));
+
+    NextArrowRenderer next_arrow{UIGlobals::GetLook().next_arrow_info_box};
+
+    const PixelPoint arrow_clip_origin{0, -static_cast<int>(canvas_height / 4)};
+    const PixelSize arrow_clip_size{static_cast<int>(canvas_height),
+                                    static_cast<int>(canvas_height)};
+    PixelRect pixelrect_next_arrow{arrow_clip_origin, arrow_clip_size};
+    pixelrect_next_arrow.Offset(pos_x_arrow, pos_y_arrow_offset);
+
+    next_arrow.DrawArrowScale(canvas, pixelrect_next_arrow, bearing_diff,
+                              scale__arrow);
+  }
+}
+
+void
+NavigatorRenderer::DrawTaskTextsArrow(
+    Canvas &canvas, TaskType tp, [[maybe_unused]] const Waypoint &wp_current,
+    [[maybe_unused]] const PixelRect &rc, NavType nav_type,
+    [[maybe_unused]] const bool is_nav_top_position,
+    const NavigatorLook &look_nav, [[maybe_unused]] const TaskLook &look_task,
+    const InfoBoxLook &look_infobox) noexcept
+{
+  // Generate all strings -------------------------------------------
+  GenerateStringsWaypointInfos(nav_type, tp);
+
+  GenerateStringsCurrentFlightInfo(tp);
+
+  GenerateStringWaypointName(wp_current);
+
+  GenerateStringsTimesInfo(tp);
+
+  // Draw all Strings -----------------------------------------------
+  SetTextColor(canvas, look_nav);
+
+  DrawWaypointInfos(canvas, nav_type, look_infobox);
+
+  DrawCurrentFlightInfos(canvas, nav_type, look_infobox);
+
+  DrawWaypointName(canvas, nav_type);
+
+  DrawTimesInfo(canvas, rc, nav_type);
+
+  DrawAverageSpeed(canvas, nav_type, look_infobox);
+
+  DrawDirectionArrowNorthAnnulus(canvas, nav_type, look_task);
+}
+
+void
+NavigatorRenderer::DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                                    const PixelRect &rc,
+                                    const NavigatorLook &look_nav,
+                                    const TaskLook &look_task) noexcept
+{
+  const int rc_height = rc.GetHeight();
+  const int rc_width = rc.GetWidth();
+
+  // render the progress bar
+  PixelRect r{rc_height * 5 / 24, rc_height - rc_height * 5 / 48,
+              rc_width - rc_height * 10 / 48, rc_height - rc_height * 1 / 48};
+
+  bool task_has_started =
+      CommonInterface::Calculated().task_stats.start.HasStarted();
+  bool task_is_finished =
+      CommonInterface::Calculated().task_stats.task_finished;
+
+  unsigned int progression{};
+
+  if (task_has_started && !task_is_finished)
+    progression = 100 * (1 - summary.p_remaining);
+  else if (task_has_started && task_is_finished) progression = 100;
+  else progression = 0;
+
+  DrawSimpleProgressBar(canvas, r, progression, 0, 100);
+
+  canvas.Select(look_nav.brush_frame);
+
+  // render the waypoints on the progress bar
+  const Pen pen_waypoint(Layout::ScalePenWidth(1), COLOR_BLACK);
+  const Pen pen_indications(Layout::ScalePenWidth(1),
+                            look_nav.inverse ? COLOR_GRAY : COLOR_DARK_GRAY);
+  canvas.Select(pen_indications);
+
+  bool target{true};
+  unsigned i = 0;
+  for (auto it = summary.pts.begin(); it != summary.pts.end(); ++it, ++i) {
+    auto p = it->p;
+
+    const PixelPoint position_waypoint(
+        p * (rc_width - 10 / 24.0 * rc_height) + 5 / 24.0 * rc_height,
+        rc_height - static_cast<int>(1.5 / 24.0 * rc_height));
+
+    int w = Layout::Scale(2);
+
+    /* search for the next Waypoint to reach and draw two horizontal lines
+     * left and right if one Waypoint has been missed, the two lines are also
+     * drawn
+     */
+    if (!it->achieved && target) {
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-w, 0.5 * w),
+                      position_waypoint.At(-2 * w, 0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, 0.5 * w),
+                      position_waypoint.At(2 * w, 0.5 * w));
+
+      canvas.DrawLine(position_waypoint.At(-w, -0.5 * w),
+                      position_waypoint.At(-2 * w, -0.5 * w));
+      canvas.DrawLine(position_waypoint.At(w, -0.5 * w),
+                      position_waypoint.At(2 * w, -0.5 * w));
+
+      target = false;
+    }
+
+    if (i == summary.active) {
+      // search for the Waypoint on which the user is looking for and draw
+      // two vertical lines left and right
+      canvas.Select(pen_indications);
+      canvas.DrawLine(position_waypoint.At(-2 * w, w),
+                      position_waypoint.At(-2 * w, -w));
+      canvas.DrawLine(position_waypoint.At(2 * w, w),
+                      position_waypoint.At(2 * w, -w));
+
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbOrange);
+      w = Layout::Scale(2);
+    } else if (i < summary.active) {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbNotReachableTerrain);
+      w = Layout::Scale(2);
+    } else {
+      if (it->achieved) canvas.Select(look_task.hbGreen);
+      else canvas.Select(look_task.hbLightGray);
+
+      w = Layout::Scale(1);
+    }
+
+    canvas.Select(pen_waypoint);
+    canvas.DrawRectangle(PixelRect{position_waypoint}.WithMargin(w));
+  }
+}
+
+void
+NavigatorRenderer::DrawWaypointsIconsTitle(
+    Canvas &canvas, WaypointPtr waypoint_before, WaypointPtr waypoint_current,
+    unsigned task_size, [[maybe_unused]] const NavigatorLook &look,
+    NavType nav_type) noexcept
+{
+  const int rc_height = canvas_height;
+
+  const WaypointRendererSettings &waypoint_settings =
+      CommonInterface::GetMapSettings().waypoint;
+  const WaypointLook &waypoint_look = UIGlobals::GetMapLook().waypoint;
+
+  WaypointIconRenderer waypoint_icon_renderer{waypoint_settings, waypoint_look,
+                                              canvas};
+  const PixelPoint position_waypoint_left{
+      static_cast<int>(canvas_width * 7 / 200), rc_height * 1 / 2};
+
+  const PixelPoint position_waypoint_right =
+      (nav_type == NavType::NAVIGATOR_DETAILED)
+          ? PixelPoint{static_cast<int>(canvas_width * 98 / 100 -
+                                        rc_height * 15 / 100),
+                       static_cast<int>(rc_height * 38 / 100)}
+          : PixelPoint{static_cast<int>(canvas_width * 193 / 200),
+                       rc_height * 1 / 2};
+
+  // CALCULATE REACHABILITY
+  /// TODO: implement waypoint reachability
+  /// without using costing calculation inside renderer
+  WaypointReachability wr_before{WaypointReachability::UNREACHABLE};
+  WaypointReachability wr_current{WaypointReachability::UNREACHABLE};
+
+  auto *protected_task_manager =
+      backend_components->protected_task_manager.get();
+  if (protected_task_manager != nullptr && task_size > 1) {
+    if (waypoint_before != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_before, position_waypoint_left,
+                                  wr_before, true);
+    if (waypoint_current != nullptr)
+      waypoint_icon_renderer.Draw(*waypoint_current, position_waypoint_right,
+                                  wr_current, true);
+  }
+}

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Engine/Task/TaskType.hpp"
+#include "Engine/Waypoint/Ptr.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
+#include "Units/Unit.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Font.hpp"
+#include "ui/dim/Rect.hpp"
+#include "util/StaticString.hxx"
+
+#include <array>
+#include <cstdint>
+
+struct BulkPixelPoint;
+struct NavigatorLook;
+struct TaskLook;
+struct TaskSummary;
+class Waypoint;
+
+enum class NavType : std::uint8_t {
+  NAVIGATOR_LITE_ONE_LINE,
+  NAVIGATOR_LITE_TWO_LINES,
+  NAVIGATOR,
+  NAVIGATOR_DETAILED,
+};
+
+class NavigatorRenderer {
+  /* ---- layout / Update() cache ------------------------------------ */
+  bool hasCanvasSizeChanged{};
+  unsigned int canvas_width{};
+  unsigned int canvas_height{};
+  double ratio_dpi{};
+
+  std::array<BulkPixelPoint, 10> polygon_frame_main;
+  std::array<BulkPixelPoint, 10> polygon_frame_detailed;
+
+  const MoreData *basic{};
+  const DerivedInfo *calculated{};
+  bool has_started{};
+
+  const RoughTimeDelta utc_no_offset{};
+  RoughTimeDelta utc_offset{};
+
+  /* ---- generated text buffers ------------------------------------ */
+  StaticString<20> waypoint_distance_s;
+  StaticString<20> waypoint_altitude_s;
+  StaticString<20> waypoint_GR_s;
+  Angle bearing_diff{};
+  StaticString<20> waypoint_direction_s;
+  StaticString<100> infos_waypoint_s;
+  StaticString<60> infos_waypoint_units_dist_alt_s;
+  StaticString<60> infos_waypoint_units_dist_alt_GR_s;
+
+  StaticString<20> current_speed_s;
+  StaticString<20> current_altitude_s;
+  StaticString<20> waypoint_average_speed_s;
+
+  StaticString<50> waypoint_name_s;
+
+  StaticString<8> time_elapsed_s;
+  StaticString<8> time_start_s;
+  StaticString<8> time_local_s;
+  StaticString<8> time_planned_s;
+  StaticString<8> arrival_planned_s;
+  StaticString<20> times_local_elapsed_s;
+  StaticString<20> times_arrival_planned_s;
+
+  /* ---- draw state (fonts, positions, clip rects) -------------------- */
+  Font font;
+  unsigned int font_height{};
+  PixelPoint pxpt_pos_infos_waypoint{};
+  unsigned int text_size_infos_waypoint{};
+  PixelSize size_text{};
+  unsigned int unit_height{};
+  unsigned int ascent_height{};
+  PixelPoint pp_pos_unit{};
+  Unit unit{Unit::KILOMETER};
+
+  int pos_x_speed_altitude{};
+
+  unsigned pos_x_waypoint_name{};
+  unsigned pos_y_waypoint_name{};
+  unsigned pos_x_end_waypoint_name{};
+  unsigned sz_waypoint_name{};
+
+  void GenerateFrame(const PixelRect &rc, bool is_frame_main) noexcept;
+
+  void GenerateStringsWaypointInfos(NavType nav_type, TaskType tp) noexcept;
+
+  void GenerateStringsCurrentFlightInfo(TaskType tp) noexcept;
+
+  void GenerateStringWaypointName(const Waypoint &wp_current) noexcept;
+
+  void GenerateStringsTimesInfo(TaskType tp) noexcept;
+
+  void SetTextColor(Canvas &canvas, const NavigatorLook &look_nav) noexcept;
+
+  /**
+   * After #unit is set, draw the unit symbol beside the value row at
+   * #pxpt_pos_infos_waypoint using #text_for_width to measure the value span.
+   */
+  void DrawWaypointInfoValueUnit(Canvas &canvas, const InfoBoxLook &look_infobox,
+                                 const char *text_for_width) noexcept;
+
+  void DrawWaypointInfos(Canvas &canvas, NavType nav_type,
+                         const InfoBoxLook &look_infobox) noexcept;
+
+  void DrawCurrentFlightInfos(Canvas &canvas, NavType nav_type,
+                              const InfoBoxLook &look_infobox) noexcept;
+
+  void DrawWaypointName(Canvas &canvas, NavType nav_type) noexcept;
+
+  void DrawTimesInfo(Canvas &canvas, const PixelRect &rc,
+                     NavType nav_type) noexcept;
+
+  void DrawAverageSpeed(Canvas &canvas, NavType nav_type,
+                        const InfoBoxLook &look_infobox) noexcept;
+
+  void DrawDirectionArrowNorthAnnulus(Canvas &canvas, NavType nav_type,
+                                      const TaskLook &look_task) noexcept;
+
+public:
+  void Update(const Canvas &canvas) noexcept;
+
+  void DrawFrame(Canvas &canvas, const PixelRect &rc,
+                 const NavigatorLook &look_nav, bool is_frame_main) noexcept;
+
+  void DrawTaskTextsArrow(Canvas &canvas, TaskType tp,
+                          const Waypoint &wp_current, const PixelRect &rc,
+                          NavType nav_type,
+                          [[maybe_unused]] const bool is_nav_top_position,
+                          const NavigatorLook &look_nav,
+                          const TaskLook &look_task,
+                          const InfoBoxLook &look_infobox) noexcept;
+
+  void DrawProgressTask(const TaskSummary &summary, Canvas &canvas,
+                        const PixelRect &rc, const NavigatorLook &look_nav,
+                        const TaskLook &look_task) noexcept;
+
+  void DrawWaypointsIconsTitle(Canvas &canvas, WaypointPtr waypoint_before,
+                               WaypointPtr waypoint_current, unsigned task_size,
+                               const NavigatorLook &look_nav,
+                               NavType nav_type) noexcept;
+};

--- a/src/Renderer/NavigatorRenderer.hpp
+++ b/src/Renderer/NavigatorRenderer.hpp
@@ -14,10 +14,8 @@
 #include "ui/dim/Rect.hpp"
 #include "util/StaticString.hxx"
 
-#include <array>
 #include <cstdint>
 
-struct BulkPixelPoint;
 struct NavigatorLook;
 struct TaskLook;
 struct TaskSummary;
@@ -32,13 +30,8 @@ enum class NavType : std::uint8_t {
 
 class NavigatorRenderer {
   /* ---- layout / Update() cache ------------------------------------ */
-  bool hasCanvasSizeChanged{};
   unsigned int canvas_width{};
   unsigned int canvas_height{};
-  double ratio_dpi{};
-
-  std::array<BulkPixelPoint, 10> polygon_frame_main;
-  std::array<BulkPixelPoint, 10> polygon_frame_detailed;
 
   const MoreData *basic{};
   const DerivedInfo *calculated{};
@@ -89,8 +82,6 @@ class NavigatorRenderer {
   unsigned pos_x_end_waypoint_name{};
   unsigned sz_waypoint_name{};
 
-  void GenerateFrame(const PixelRect &rc, bool is_frame_main) noexcept;
-
   void GenerateStringsWaypointInfos(NavType nav_type, TaskType tp) noexcept;
 
   void GenerateStringsCurrentFlightInfo(TaskType tp) noexcept;
@@ -129,7 +120,7 @@ public:
   void Update(const Canvas &canvas) noexcept;
 
   void DrawFrame(Canvas &canvas, const PixelRect &rc,
-                 const NavigatorLook &look_nav, bool is_frame_main) noexcept;
+                 const NavigatorLook &look_nav) noexcept;
 
   void DrawTaskTextsArrow(Canvas &canvas, TaskType tp,
                           const Waypoint &wp_current, const PixelRect &rc,

--- a/src/Renderer/NextArrowRenderer.cpp
+++ b/src/Renderer/NextArrowRenderer.cpp
@@ -67,3 +67,60 @@ NextArrowRenderer::DrawArrow(Canvas &canvas, const PixelRect &rc,
   canvas.Select(look.next_arrow_brush);
   canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
 }
+
+void
+NextArrowRenderer::DrawArrowScale(Canvas &canvas, const PixelRect &rc,
+                             Angle angle, int scale)
+{
+  /*
+   * Define arrow geometry for forward pointing arrow.
+   * These are the coordinates of the corners, relative to the center (o)
+   *
+   *                               +   (0,-head_len)
+   *                              / \
+   *                             /   \
+   *                            /     \
+   * (-head_width,-head_base)  +-+   +-+  (head_width,-head_base)
+   *   (-tail_width,-head_base)  | o |  (tail_width,-head_base)
+   *                             |   |
+   *                             |   |
+   *     (-tail_width,tail_len)  +---+  (tail_width,tail_len)
+   *
+   * The "tail" of the arrow is slightly shorter than the "head" to avoid
+   * the corners of the tail to stick out of the bounding PixelRect.
+   */
+  static constexpr auto head_len = 500;
+  static constexpr auto head_width = 360;
+  static constexpr auto head_base = head_len - head_width;
+  static constexpr auto tail_width = 160;
+  static constexpr auto tail_len = head_len - tail_width / 2;
+
+  // An array of the arrow corner coordinates.
+  BulkPixelPoint arrow[] = {
+    { 0, -head_len/scale },
+    { head_width/scale, -head_base/scale },
+    { tail_width/scale, -head_base/scale },
+    { tail_width/scale, tail_len/scale },
+    { -tail_width/scale, tail_len/scale },
+    { -tail_width/scale, -head_base/scale },
+    { -head_width/scale, -head_base/scale },
+  };
+
+  /*
+   * Rotate the arrow, center it in the bounding rectangle, and scale
+   * it to fill the rectangle.
+   *
+   * Note that PolygonRotateShift scales a polygon with coordinates
+   * in the range -50 to +50 to fill a square with the size of the 'scale'
+   * argument.
+   */
+  const auto size = std::min(rc.GetWidth(), rc.GetHeight());
+  PolygonRotateShift(arrow,
+                     rc.GetCenter(), angle,
+                     size);
+
+  // Draw the arrow.
+  canvas.Select(look.next_arrow_pen);
+  canvas.Select(look.next_arrow_brush);
+  canvas.DrawPolygon(arrow, ARRAY_SIZE(arrow));
+}

--- a/src/Renderer/NextArrowRenderer.hpp
+++ b/src/Renderer/NextArrowRenderer.hpp
@@ -15,4 +15,5 @@ public:
   NextArrowRenderer(const NextArrowLook &_look):look(_look) {}
 
   void DrawArrow(Canvas &canvas, const PixelRect &rc, Angle angle);
+  void DrawArrowScale(Canvas &canvas, const PixelRect &rc, Angle angle, int scale);
 };

--- a/src/Renderer/ProgressBarRenderer.cpp
+++ b/src/Renderer/ProgressBarRenderer.cpp
@@ -7,6 +7,7 @@
 #include "Asset.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 static constexpr unsigned
 CalcProgressBarPosition(unsigned current_value,
@@ -17,7 +18,9 @@ CalcProgressBarPosition(unsigned current_value,
     return 0;
 
   const unsigned value = std::clamp(current_value, min_value, max_value);
-  return (value - min_value) * width / (max_value - min_value);
+  const uint64_t num =
+      uint64_t{value - min_value} * uint64_t{width};
+  return static_cast<unsigned>(num / uint64_t{max_value - min_value});
 }
 
 void
@@ -30,13 +33,20 @@ DrawSimpleProgressBar(Canvas &canvas, const PixelRect &r,
     CalcProgressBarPosition(current_value, min_value, max_value,
                             r.GetWidth());
 
-  auto a = r, b = r;
-  a.right = b.left = a.left + position;
+  const Color &bg = background_color != nullptr ? *background_color
+                                                 : COLOR_WHITE;
+  /* Full track first so the completed segment can sit on top without a gap. */
+  canvas.DrawFilledRectangle(r, bg);
+
+  if (position <= 0)
+    return;
+
+  auto a = r;
+  a.right = a.left + position;
+  if (a.right > r.right)
+    a.right = r.right;
 
   canvas.DrawFilledRectangle(a, IsDithered() ? COLOR_BLACK : COLOR_GREEN);
-  canvas.DrawFilledRectangle(b,
-                             background_color != nullptr
-                             ? *background_color : COLOR_WHITE);
 }
 
 void

--- a/src/Screen/Layout.hpp
+++ b/src/Screen/Layout.hpp
@@ -212,6 +212,20 @@ VptScale(unsigned pt) noexcept
 }
 
 /**
+ * Map a widget-relative "design" pixel (e.g. a fraction of a custom
+ * gauge height) to virtual points for @ref VptScale, using a 100:vdpi
+ * reference. Custom gauges (navigator, etc.) use this instead of
+ * re-implementing 100/vdpi at each call site.
+ */
+[[gnu::const]]
+static inline unsigned
+VptScaleFromDesignPixel(unsigned design_pixel) noexcept
+{
+  const unsigned d = vdpi == 0 ? 1u : vdpi;
+  return VptScale((design_pixel * 100) / d);
+}
+
+/**
  * Scale a font size in points (1/72th inch) to pixels.  Additional
  * scaling factors may be applied to consider small screens
  * (i.e. viewing distance) and user preference.

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -36,6 +36,7 @@ UISettings::SetDefaults() noexcept
   info_boxes.SetDefaults();
   vario.SetDefaults();
   traffic.SetDefaults();
+  navigator.SetDefaults();
   pages.SetDefaults();
   dialog.SetDefaults();
   sound.SetDefaults();

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -8,6 +8,7 @@
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Gauge/VarioSettings.hpp"
 #include "Gauge/TrafficSettings.hpp"
+#include "Gauge/NavigatorSettings.hpp"
 #include "PageSettings.hpp"
 #include "Dialogs/DialogSettings.hpp"
 #include "DisplaySettings.hpp"
@@ -75,6 +76,7 @@ struct UISettings {
   MapSettings map;
   InfoBoxSettings info_boxes;
   VarioSettings vario;
+  NavigatorSettings navigator;
   TrafficSettings traffic;
   PageSettings pages;
   DialogSettings dialog;


### PR DESCRIPTION
Continues the work from #1064 (original author: @threaderic). This branch is **rebased** onto current `master` and split/cleaned so the history is buildable and follows XCSoar conventions (see discussion in #1064).

**Supersedes #1064** because the previous head branch on `threaderic/XCSoar:NavigationWidget` is protected in a way that blocks force-pushes (merge commits in `master` history), so the updated history is published from this fork.

### Summary
- Navigator strip / `NavigatorRenderer`, `NavigatorWidget`, page layout, settings, input, docs, etc. as in the original PR scope.
- Rebased and commit-order fixes for per-step `make` runs; include/layering cleanups.

### Please test
- Flight or sim: navigator strip, top/bottom panes, settings, Nav input modes, task / waypoint display.

Replaces: #1064

Related to #1064
