### PR TITLE
List dialogs: keyboard focus, action bar, airspace

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -37,7 +37,9 @@ Version 7.45 - not yet released
     filter rows in the same dialog (e.g. waypoint file) still get those keys;
     Left/Right move the action bar with cursor key selection; current
     action uses list-focus colours in the light theme and the bright
-    focus colour in dark, like other dialog focus
+    focus colour in dark, like other dialog focus.  Select Airspace: Details
+    and Close are on the main dialog action bar (bottom/edge) so the same
+    keys can reach them after the list, like other list dialogs
   - alternates: list holds up to 10 options (was 6); if the task only has one
     automatic alternate, Alternate 2 no longer shows the same as Alternate 1.
     Displayed glide is re-solved with the current aircraft state; value colour
@@ -49,6 +51,11 @@ Version 7.45 - not yet released
   - airspace list & map item list: grey text for airspaces with a day
     acknowledgement; map item list adds an "Enable" button to clear it (like the
     airspace warnings list) #2404
+  - airspace warnings: keep the cursor key action in sync with which actions
+    are enabled, and the armed action with keyboard focus (no double
+    highlight when e.g. Close is focused and another is cursor-selected);
+    replace Radio with Details; Up/Down move the list, Left/Right the action
+    row, Up from the action row returns to the list
   - Form/DataField/Enum: remove the limit of 128 internal entries (It was
     dropping the newest InfoBoxes, as we have 130 of them now)
   - encode bundled UI OGG sound assets at Vorbis quality 5 (was 1)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -33,6 +33,11 @@ Version 7.45 - not yet released
     a pilot-chosen field (MANUAL); tap the InfoBox to open the alternates list,
     switch mode, and assign the selected row to that slot (runtime only; AUTO
     clears the pin).  Titles show Altn 1/2 with AUTO or MAN.
+  - list dialogs: Up/Down move the list (when the list is focused) so
+    filter rows in the same dialog (e.g. waypoint file) still get those keys;
+    Left/Right move the action bar with cursor key selection; current
+    action uses list-focus colours in the light theme and the bright
+    focus colour in dark, like other dialog focus
   - alternates: list holds up to 10 options (was 6); if the task only has one
     automatic alternate, Alternate 2 no longer shows the same as Alternate 1.
     Displayed glide is re-solved with the current aircraft state; value colour

--- a/src/Dialogs/Airspace/AirspaceList.cpp
+++ b/src/Dialogs/Airspace/AirspaceList.cpp
@@ -115,28 +115,6 @@ public:
                const PixelRect &rc) noexcept override;
 };
 
-class AirspaceListButtons final : public RowFormWidget {
-  WndForm &dialog;
-  AirspaceListWidget *list;
-
-public:
-  AirspaceListButtons(const DialogLook &look, WndForm &_dialog) noexcept
-    :RowFormWidget(look), dialog(_dialog) {}
-
-  void SetList(AirspaceListWidget *_list) {
-    list = _list;
-  }
-
-  void Prepare([[maybe_unused]] ContainerWindow &parent,
-               [[maybe_unused]] const PixelRect &rc) noexcept override {
-    AddButton(_("Details"), [this](){
-      list->ShowDetails();
-    });
-
-    AddButton(_("Close"), dialog.MakeModalResultCallback(mrCancel));
-  }
-};
-
 /**
  * Special enum integer value for "filter disabled".
  */
@@ -474,17 +452,18 @@ ShowAirspaceListDialog(const Airspaces &_airspaces,
   auto filter_widget = std::make_unique<AirspaceFilterWidget>(look);
 
   auto list_widget = std::make_unique<AirspaceListWidget>(*filter_widget);
+  AirspaceListWidget *const list = list_widget.get();
 
-  auto buttons_widget = std::make_unique<AirspaceListButtons>(look, dialog);
+  filter_widget->SetListener(list);
 
-  filter_widget->SetListener(list_widget.get());
-  buttons_widget->SetList(list_widget.get());
-
-  auto left_widget = std::make_unique<TwoWidgets>(std::move(filter_widget),
-                                                  std::move(buttons_widget),
-                                                  true);
-
-  dialog.FinishPreliminary(new TwoWidgets(std::move(left_widget),
-                                          std::move(list_widget), false));
+  /* Details/Close are in the dialog #ButtonPanel so tab/Up/Down from
+     the list (after the last item) go to the actions, like other list
+     dialogs, instead of wrapping to the name filter. */
+  dialog.FinishPreliminary(
+    new TwoWidgets(std::move(filter_widget), std::move(list_widget), false));
+  dialog.AddButton(_("Details"), [list](){
+    list->ShowDetails();
+  });
+  dialog.AddButton(_("Close"), dialog.MakeModalResultCallback(mrCancel));
   dialog.ShowModal();
 }

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -10,6 +10,7 @@
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Screen/Layout.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "Airspace/AirspaceWarning.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
@@ -18,7 +19,6 @@
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "util/Macros.hpp"
 #include "Interface.hpp"
-#include "ActionInterface.hpp"
 #include "Language/Language.hpp"
 #include "Widget/ListWidget.hpp"
 #include "UIGlobals.hpp"
@@ -35,12 +35,18 @@ class AirspaceWarningListWidget final
 
   ProtectedAirspaceWarningManager &airspace_warnings;
 
+  /**
+   * Non-owning: only valid for the #ShowModal scope after
+   * #CreateButtons.
+   */
+  WidgetDialog *self_dialog{nullptr};
+
   UI::PeriodicTimer update_list_timer{[this]{ UpdateList(); }};
 
   Button *ack_button;
   Button *ack_day_button;
   Button *enable_button;
-  Button *radio_button;
+  Button *details_button;
 
   std::vector<AirspaceWarning> warning_list;
 
@@ -62,11 +68,12 @@ public:
      sound_interval_counter(1)
   {}
 
-  void CreateButtons(WidgetDialog &buttons) {
-    ack_button = buttons.AddButton(_("ACK"), [this](){ Ack(); });
-    ack_day_button = buttons.AddButton(_("ACK Day"), [this](){ AckDay(); });
-    enable_button = buttons.AddButton(_("Enable"), [this](){ Enable(); });
-    radio_button = buttons.AddButton(_("Radio"), [this](){ Radio(); });
+  void CreateButtons(WidgetDialog &dialog) {
+    self_dialog = &dialog;
+    ack_button = dialog.AddButton(_("ACK"), [this](){ Ack(); });
+    ack_day_button = dialog.AddButton(_("ACK Day"), [this](){ AckDay(); });
+    enable_button = dialog.AddButton(_("Enable"), [this](){ Enable(); });
+    details_button = dialog.AddButton(_("Details"), [this](){ Details(); });
   }
 
   void CopyList();
@@ -82,9 +89,10 @@ public:
   void Ack();
   void AckDay();
   void Enable();
-  void Radio() noexcept;
+  void Details() noexcept;
 
   /* virtual methods from Widget */
+  bool KeyPress(unsigned key_code) noexcept override;
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Show(const PixelRect &rc) noexcept override;
   void Hide() noexcept override;
@@ -127,7 +135,7 @@ AirspaceWarningListWidget::UpdateButtons()
     ack_button->SetEnabled(false);
     ack_day_button->SetEnabled(false);
     enable_button->SetEnabled(false);
-    radio_button->SetEnabled(false);
+    details_button->SetEnabled(false);
     return;
   }
 
@@ -143,7 +151,13 @@ AirspaceWarningListWidget::UpdateButtons()
   ack_button->SetEnabled(ack_expired);
   ack_day_button->SetEnabled(!ack_day);
   enable_button->SetEnabled(!ack_expired);
-  radio_button->SetEnabled(airspace->GetRadioFrequency().IsDefined());
+  details_button->SetEnabled(true);
+
+  /* #EnableCursorSelection(0) may leave #selected_index on a disabled
+     #Button when ACK is inactive but ACK Day is not; re-arm the first
+     operable action for KEY_LEFT/KEY_RIGHT/KEY_RETURN. */
+  if (self_dialog != nullptr)
+    self_dialog->ResyncButtonPanelSelection();
 }
 
 void
@@ -154,6 +168,23 @@ AirspaceWarningListWidget::Prepare(ContainerWindow &parent,
 
   CreateList(parent, look, rc,
              row_renderer.CalculateLayout(*look.list.font, *look.list.font));
+}
+
+bool
+AirspaceWarningListWidget::KeyPress(unsigned key_code) noexcept
+{
+  /* Up/Down: list; Left/Right: #ButtonPanel (see #WidgetDialog::OnAnyKeyDown);
+     when focus is on the action bar, Up only returns to the list. */
+  if (key_code == KEY_UP && IsDefined() && !GetList().HasFocus() &&
+      self_dialog != nullptr) {
+    GetList().SetFocus();
+    return true;
+  }
+
+  if (key_code == KEY_UP || key_code == KEY_DOWN)
+    return ListWidget::KeyPress(key_code);
+
+  return false;
 }
 
 void
@@ -255,13 +286,11 @@ AirspaceWarningListWidget::Enable()
   UpdateList();
 }
 
-inline void
-AirspaceWarningListWidget::Radio() noexcept
+void
+AirspaceWarningListWidget::Details() noexcept
 {
-  if (selected_airspace != nullptr &&
-      selected_airspace->GetRadioFrequency().IsDefined())
-    ActionInterface::SetActiveFrequency(selected_airspace->GetRadioFrequency(),
-                                        selected_airspace->GetName());
+  if (selected_airspace != nullptr)
+    dlgAirspaceDetails(selected_airspace, &airspace_warnings);
 }
 
 void

--- a/src/Dialogs/WidgetDialog.hpp
+++ b/src/Dialogs/WidgetDialog.hpp
@@ -126,6 +126,10 @@ public:
     buttons.EnableCursorSelection(_index);
   }
 
+  void ResyncButtonPanelSelection() noexcept {
+    buttons.ReselectToFirstEnabled();
+  }
+
   int ShowModal();
 
   /* virtual methods from class WndForm */

--- a/src/Form/Button.cpp
+++ b/src/Form/Button.cpp
@@ -227,10 +227,13 @@ Button::GetState() const noexcept
     return ButtonState::DISABLED;
   else if (down)
     return ButtonState::PRESSED;
-  else if (HasCursorKeys() && HasFocus())
-    return ButtonState::FOCUSED;
+  /* #ButtonPanel cursor selection uses `look.selected` (bright); that
+     must come before #HasFocus (`look.focused`) so the current action
+     is not downgraded when the list still holds focus. */
   else if (HasCursorKeys() && selected)
     return ButtonState::SELECTED;
+  else if (HasCursorKeys() && HasFocus())
+    return ButtonState::FOCUSED;
   else
     return ButtonState::ENABLED;
 }

--- a/src/Form/Button.cpp
+++ b/src/Form/Button.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Form/Button.hpp"
+#include "Form/ButtonPanel.hpp"
 #include "ui/event/KeyCode.hpp"
 #include "Asset.hpp"
 #include "Renderer/TextButtonRenderer.hpp"
@@ -193,6 +194,8 @@ void
 Button::OnSetFocus() noexcept
 {
   PaintWindow::OnSetFocus();
+  if (cursor_key_group != nullptr)
+    cursor_key_group->OnButtonGainedFocus(*this);
   Invalidate();
 }
 

--- a/src/Form/Button.hpp
+++ b/src/Form/Button.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 enum class ButtonState : int;
 struct ButtonLook;
+class ButtonPanel;
 class ContainerWindow;
 class ButtonRenderer;
 
@@ -34,6 +35,13 @@ private:
    * #ButtonPanel.
    */
   bool selected;
+
+  /**
+   * If non-null, #ButtonPanel::OnButtonGainedFocus keeps
+   * #SetSelected in sync with focus when the user tabs between
+   * #Button s.
+   */
+  ButtonPanel *cursor_key_group{nullptr};
 
 public:
   Button(ContainerWindow &parent, const PixelRect &rc,
@@ -88,6 +96,8 @@ public:
   void SetCaption(const char *caption);
 
   void SetSelected(bool _selected);
+
+  void SetCursorKeyGroup(ButtonPanel *p) noexcept { cursor_key_group = p; }
 
   [[gnu::pure]]
   unsigned GetMinimumWidth() const;

--- a/src/Form/ButtonPanel.cpp
+++ b/src/Form/ButtonPanel.cpp
@@ -49,6 +49,7 @@ ButtonPanel::Add(std::unique_ptr<ButtonRenderer> &&renderer,
 {
   auto *button = new Button(parent, dummy_rc, style,
                             std::move(renderer), std::move(callback));
+  button->SetCursorKeyGroup(this);
   keys[buttons.size()] = 0;
   buttons.append(button);
 
@@ -262,6 +263,53 @@ PixelRect
 ButtonPanel::BottomLayout() noexcept
 {
   return BottomLayout(parent.GetClientRect());
+}
+
+void
+ButtonPanel::ReselectToFirstEnabled() noexcept
+{
+  if (selected_index < 0)
+    return;
+
+  const auto is_usable = [this](unsigned i) {
+    return buttons[i]->IsVisible() && buttons[i]->IsEnabled();
+  };
+
+  if (selected_index < (int)buttons.size() &&
+      is_usable((unsigned)selected_index))
+    return;
+
+  if (selected_index < (int)buttons.size() && selected_index >= 0)
+    buttons[selected_index]->SetSelected(false);
+
+  for (unsigned i = 0; i < buttons.size(); ++i) {
+    if (is_usable(i)) {
+      selected_index = (int)i;
+      buttons[selected_index]->SetSelected(true);
+      return;
+    }
+  }
+}
+
+void
+ButtonPanel::OnButtonGainedFocus(Button &b) noexcept
+{
+  if (selected_index < 0)
+    return;
+
+  unsigned i;
+  for (i = 0; i < buttons.size(); ++i) {
+    if (buttons[i] == &b)
+      break;
+  }
+  if (i >= buttons.size() || (int)i == selected_index)
+    return;
+
+  if (selected_index >= 0 && (unsigned)selected_index < buttons.size())
+    buttons[selected_index]->SetSelected(false);
+
+  selected_index = (int)i;
+  b.SetSelected(true);
 }
 
 void

--- a/src/Form/ButtonPanel.hpp
+++ b/src/Form/ButtonPanel.hpp
@@ -45,6 +45,23 @@ public:
     buttons[selected_index]->SetSelected(true);
   }
 
+  /**
+   * After the enabled/visible state of a button has changed, move
+   * #selected_index to the first enabled one if the current
+   * selection is no longer operable.  (Otherwise KEY_RETURN on the
+   * panel and the "armed" #ButtonState::SELECTED can target a
+   * disabled #Button while the keyboard #FocusNextControl is on
+   * another action.)
+   */
+  void ReselectToFirstEnabled() noexcept;
+
+  /**
+   * Called from #Button::OnSetFocus: move #selected_index to the
+   * focused #Button so only one of #ButtonState::SELECTED / FOCUSED
+   * is visible when cursor key mode is on.
+   */
+  void OnButtonGainedFocus(Button &b) noexcept;
+
   const ButtonLook &GetLook() const noexcept {
     return look;
   }

--- a/src/Look/DialogLook.cpp
+++ b/src/Look/DialogLook.cpp
@@ -96,6 +96,35 @@ DialogLook::Initialise(bool _dark_mode)
   }
 
   button.Initialise(bold_font, dark_mode);
+
+  /* #ButtonState::SELECTED (action bar) matches a focused list row; in dark
+     mode use the same bright `focused` (COLOR_XCSOAR) as dialog/tab focus
+     list.focused in dark is darker (XCSOAR_DARK) */
+  {
+    if (dark_mode) {
+      button.selected.background_color = focused.background_color;
+      button.selected.foreground_color = focused.text_color;
+    } else {
+      const auto &h = list.focused;
+      button.selected.background_color = h.background_color;
+      button.selected.foreground_color = h.text_color;
+    }
+    button.selected.foreground_brush.Create(button.selected.foreground_color);
+    if (dark_mode) {
+      button.selected.CreateBorder(
+        LightColor(button.selected.background_color),
+        DarkColor(button.selected.background_color));
+    } else if (IsDithered()) {
+      button.selected.CreateBorder(COLOR_WHITE, COLOR_WHITE);
+    } else if (!HasColors()) {
+      button.selected.CreateBorder(LightColor(COLOR_DARK_GRAY), COLOR_BLACK);
+    } else {
+      button.selected.CreateBorder(
+        LightColor(button.selected.background_color),
+        DarkColor(button.selected.background_color));
+    }
+  }
+
   check_box.Initialise(text_font, dark_mode);
 
   list.font = &text_font;

--- a/src/Widget/ListWidget.cpp
+++ b/src/Widget/ListWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "ListWidget.hpp"
 #include "ui/window/Window.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "Screen/Layout.hpp"
 
 PixelSize
@@ -20,9 +21,29 @@ ListWidget::GetMaximumSize() const noexcept
   return PixelSize { 4096, 4096 };
 }
 
+bool
+ListWidget::KeyPress(unsigned key_code) noexcept
+{
+  if (key_code != KEY_UP && key_code != KEY_DOWN)
+    return false;
+
+  /* Only when the list has focus: same client area as filter rows, etc. in
+     e.g. `ShowWaypointListDialog` — if we always returned true, Up/Down
+     would never reach the filter (file/enum) or other focused controls. */
+  if (!IsDefined() || !GetList().HasFocus())
+    return false;
+
+  /* Route in #WidgetDialog::OnAnyKeyDown *before* #WndForm maps these
+     keys to tab/FocusNext, and before #ListControl::OnKeyCheck is used
+     to decide.  When #OnKeyDown is false (e.g. at list edge), return
+     false so focus can move to the next/previous control (e.g. action
+     bar or filter).  Left/right: #ButtonPanel::KeyPress. */
+  return GetList().OnKeyFromWidgetParent(key_code);
+}
+
 ListControl &
 ListWidget::CreateList(ContainerWindow &parent, const DialogLook &look,
-                       const PixelRect &rc, unsigned row_height) noexcept
+                      const PixelRect &rc, unsigned row_height) noexcept
 {
   WindowStyle list_style;
   list_style.Hide();

--- a/src/Widget/ListWidget.hpp
+++ b/src/Widget/ListWidget.hpp
@@ -37,4 +37,6 @@ public:
     GetList().SetFocus();
     return true;
   }
+
+  bool KeyPress(unsigned key_code) noexcept override;
 };

--- a/src/ui/control/List.hpp
+++ b/src/ui/control/List.hpp
@@ -265,6 +265,17 @@ public:
    */
   void MoveOrigin(int delta) noexcept;
 
+  /**
+   * Forwards a key to #OnKeyDown from a #ListWidget, before the
+   * dialog's normal key dispatch.  @return the result of
+   * #OnKeyDown; when false, the dialog can move focus (e.g. list
+   * edge, KEY_UP/KEY_DOWN) or dispatch the key.
+   * @see #ListWidget::KeyPress
+   */
+  bool OnKeyFromWidgetParent(unsigned key_code) noexcept {
+    return OnKeyDown(key_code);
+  }
+
 private:
   [[gnu::pure]]
   bool CanActivateItem() const noexcept;


### PR DESCRIPTION
## Summary
- **ListWidget**: Up/Down only when the list has focus; return `OnKeyDown` so at list ends focus can move to filter or the main `ButtonPanel`.
- **ListControl**: `OnKeyFromWidgetParent` returns bool from `OnKeyDown`.
- **Button / DialogLook**: Cursor bar uses `SELECTED` before `FOCUSED` when the list still holds focus; `button.selected` style aligned with list row in light / bright in dark.
- **ButtonPanel**: `ReselectToFirstEnabled`, `OnButtonGainedFocus` (arm matches focus), `SetCursorKeyGroup` on add; **WidgetDialog** `ResyncButtonPanelSelection`.
- **Select Airspace**: Details/Close on the dialog action bar (same focus model as other list+button dialogs).
- **Airspace warnings**: Radio \u2192 **Details**; `Resync` after button `SetEnabled`; `KeyPress` so **Up** from the action bar returns to the list; strict Up/Down on list, Left/Right on bar.
- **NEWS**: user-visible items for the above.

## Testing
- Build: `TARGET=UNIX` (local)
- Suggested: list dialogs (waypoint, airspace, warnings) with keyboard / cursor keys; dark + light theme on action bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Up/Down now scroll and move focus within list-based dialogs while filtering still consumes keys
  * Left/Right reliably moves selection to/from the dialog action bar with consistent theme-focused colors
  * Action-bar selection stays synchronized with enabled/disabled buttons to prevent double-highlighting
  * Airspace warnings dialog: replaced radio control with Details and restored predictable return-to-list navigation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->