### PR TITLE
FLARM: send active VHF to device via PFLAM

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -85,6 +85,9 @@ Version 7.45 - not yet released
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
 * devices
   - fix native crash on device reconnect (stale delayed reopen timer) #2382
+  - FLARM: when "Sync to device" is enabled, the active VHF frequency is sent to
+    the unit as $PFLAM,S,VHF (FTD-109); frequency exchange sends the new active
+    only
 * iOS
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -68,7 +68,8 @@ FLARM_SOURCES = \
 	$(DRIVER_SRC_DIR)/FLARM/Logger.cpp \
 	$(DRIVER_SRC_DIR)/FLARM/CRC16.cpp \
 	$(DRIVER_SRC_DIR)/FLARM/BinaryProtocol.cpp \
-	$(DRIVER_SRC_DIR)/FLARM/TextProtocol.cpp
+	$(DRIVER_SRC_DIR)/FLARM/TextProtocol.cpp \
+	$(DRIVER_SRC_DIR)/FLARM/Pflam.cpp
 
 FLYTEC_SOURCES = \
 	$(DRIVER_SRC_DIR)/Flytec/Register.cpp \

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -7,6 +7,7 @@
 #include "util/AllocatedArray.hxx"
 #include "Device/Driver.hpp"
 #include "Device/SettingsMap.hpp"
+#include "RadioFrequency.hpp"
 
 #include <cstdint>
 #include <optional>
@@ -17,6 +18,7 @@ struct Declaration;
 class OperationEnvironment;
 class RecordedFlightList;
 struct RecordedFlightInfo;
+struct NMEAInfo;
 class NMEAInputLine;
 
 class FlarmDevice: public AbstractDevice
@@ -109,6 +111,10 @@ public:
   bool Declare(const Declaration &declaration, const Waypoint *home,
                OperationEnvironment &env) override;
   bool PutPilotEvent(OperationEnvironment &env) override;
+  bool PutActiveFrequency(RadioFrequency frequency, const char *name,
+                          OperationEnvironment &env) override;
+  bool ExchangeRadioFrequencies(OperationEnvironment &env,
+                                NMEAInfo &info) override;
 
   bool GetPilot(char *buffer, size_t length, OperationEnvironment &env);
   bool SetPilot(const char *pilot_name, OperationEnvironment &env);
@@ -147,10 +153,14 @@ public:
   void RunSimulation(unsigned scenario, OperationEnvironment &env);
 
 private:
+  /// Last active frequency for $PFLAM,S VHF (single channel, see FTD-109).
+  RadioFrequency pflam_vhf{RadioFrequency::Null()};
+
   /**
    * Sends the supplied sentence with a $ prepended and a line break appended
    */
   void Send(const char *sentence, OperationEnvironment &env);
+  void SendPflamVhf(OperationEnvironment &env);
   bool Receive(const char *prefix, char *buffer, size_t length,
                OperationEnvironment &env,
                std::chrono::steady_clock::duration timeout);

--- a/src/Device/Driver/FLARM/Pflam.cpp
+++ b/src/Device/Driver/FLARM/Pflam.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device.hpp"
+#include "NMEA/Info.hpp"
+#include "Operation/Operation.hpp"
+
+#include <fmt/format.h>
+
+void
+FlarmDevice::SendPflamVhf(OperationEnvironment &env)
+{
+  if (!pflam_vhf.IsDefined())
+    return;
+
+  char mhz[32];
+  pflam_vhf.Format(mhz, sizeof(mhz));
+  /* FTD-109: one mandatory VHF channel; optional B/C/D left empty. */
+  Send(fmt::format("PFLAM,S,VHF,{0},,,", mhz).c_str(), env);
+}
+
+bool
+FlarmDevice::PutActiveFrequency(RadioFrequency frequency,
+                                [[maybe_unused]] const char *name,
+                                OperationEnvironment &env)
+{
+  if (!EnableNMEA(env))
+    return false;
+
+  pflam_vhf = frequency;
+  SendPflamVhf(env);
+  return true;
+}
+
+bool
+FlarmDevice::ExchangeRadioFrequencies(OperationEnvironment &env,
+                                     NMEAInfo &info)
+{
+  auto &s = info.settings;
+  if (!s.has_active_frequency.IsValid() || !s.has_standby_frequency.IsValid())
+    return true;
+
+  std::swap(s.active_frequency, s.standby_frequency);
+  std::swap(s.active_freq_name, s.standby_freq_name);
+  s.has_active_frequency.Update(info.clock);
+  s.has_standby_frequency.Update(info.clock);
+  s.swap_frequencies.Update(info.clock);
+
+  pflam_vhf = s.active_frequency;
+  if (!EnableNMEA(env))
+    return false;
+  SendPflamVhf(env);
+  return true;
+}


### PR DESCRIPTION
When a FLARM port has **Sync to device** enabled, the active COM frequency is emitted as NMEA `$PFLAM,S,VHF,<MHz>,,,` per FTD-109 (single mandatory channel; optional B/C/D empty). `ExchangeRadioFrequencies` sends the new active after swap.

- New `Pflam.cpp` with `PutActiveFrequency` / `ExchangeRadioFrequencies`
- `EnableNMEA` before send so the link is not left in binary mode
- `NEWS.txt` under 7.45 *devices*

<!-- linked by maintainer triage: PFLAM VHF -->
Related to #1725
