### PR TITLE
build: Store res/raw ogg uncompressed for Android SoundPool

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -253,6 +253,7 @@ $(RES_DIR)/drawable-xxxhdpi/notification_icon.png: $(ICON_WHITE_SVG) | $(RES_DIR
 # Vorbis -q 5: nominal quality (~160 kb/s class); was 1 for smallest APK
 OGGENC = oggenc --quiet --quality 5
 
+# Uncompressed in resources.apk: see android_bundle.mk (-0 ogg) for why.
 SOUNDS = fail insert remove beep_bweep beep_clear beep_drip
 SOUND_FILES = $(patsubst %,$(RAW_DIR)/%.ogg,$(SOUNDS))
 
@@ -340,7 +341,7 @@ $(RES_DIR)/values/strings.xml: android/res/values/strings.xml | $(RES_DIR)/value
 $(ANDROID_OUTPUT_DIR)/resources.apk: $(PNG_FILES) $(SOUND_FILES) $(ANDROID_XML_RES_COPIES_NO_STRINGS) $(RES_DIR)/values/strings.xml $(MANIFEST) | $(GEN_DIR)/dirstamp
 	@$(NQ)echo "  AAPT"
 	$(Q)find $(RES_DIR) -name dirstamp -type f -delete
-	$(Q)$(AAPT) package -f -m --auto-add-overlay \
+	$(Q)$(AAPT) package -f -m --auto-add-overlay -0 ogg \
 		--custom-package $(JAVA_PACKAGE) \
 		-M $(MANIFEST) \
 		-S $(RES_DIR) \

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -38,6 +38,8 @@ NATIVE_INCLUDE_DIR = $(TARGET_OUTPUT_DIR)/include
 
 BUNDLE_BUILD_DIR = $(TARGET_OUTPUT_DIR)/$(XCSOAR_ABI)/build
 ANDROID_BUNDLE_BASE = $(BUNDLE_BUILD_DIR)/base_module
+# Embedded by bundletool build-bundle; final APKs honor it via the AAB.
+BUNDLE_CONFIG = $(NO_ARCH_OUTPUT_DIR)/BundleConfig.json
 ANDROID_ABI_DIR = $(ANDROID_BUNDLE_BASE)/lib/$(ANDROID_APK_LIB_ABI)
 
 ANDROID_BIN = $(TARGET_BIN_DIR)
@@ -312,7 +314,9 @@ PNG_FILES = $(PNG1) $(PNG1b) $(PNG2) $(PNG3) $(PNG4) $(PNG5) $(PNG6) $(PNG7) $(P
 	$(RES_DIR)/drawable-xxhdpi/notification_icon.png \
 	$(RES_DIR)/drawable-xxxhdpi/notification_icon.png
 
-# Sounds
+# Sounds.  Raw .ogg must be stored uncompressed in the APK (-0 ogg on aapt2
+# link) and in the App Bundle (BUNDLE_CONFIG / build-bundle --config):
+# SoundPool uses openRawResourceFd, which does not work on deflated res/raw ogg.
 SOUNDS = fail insert remove beep_bweep beep_clear beep_drip
 SOUND_FILES = $(patsubst %,$(RAW_DIR)/%.ogg,$(SOUNDS))
 
@@ -339,6 +343,7 @@ $(PROTOBUF_OUT_DIR)/dirstamp: $(PNG_FILES) $(SOUND_FILES) $(ANDROID_XML_RES_COPI
 		--dir $(RES_DIR)
 	$(Q)rm -f $(COMPILED_RES_DIR)/*dirstamp.flat
 	$(Q)$(AAPT2) link --proto-format --auto-add-overlay \
+		-0 ogg \
 		--custom-package $(JAVA_PACKAGE) \
 		--manifest $(MANIFEST) \
 		-R $(COMPILED_RES_DIR)/*.flat \
@@ -502,6 +507,11 @@ endif
 
 ### Bundle and final APK build
 
+$(BUNDLE_CONFIG): | $(NO_ARCH_OUTPUT_DIR)/dirstamp
+	@$(NQ)echo "  GEN     $@"
+	$(Q)printf '%s\n' \
+		'{ "compression": { "uncompressedGlob": ["**/*.ogg"] } }' > $@
+
 $(BUNDLE_BUILD_DIR)/base.zip: $(PROTOBUF_OUT_DIR)/dirstamp $(NO_ARCH_OUTPUT_DIR)/classes.dex $(ANDROID_LIB_BUILD) | $(BUNDLE_BUILD_DIR)/dirstamp
 	@$(NQ)echo "  ZIP     $(notdir $@)"
 	$(Q)mkdir -p $(ANDROID_BUNDLE_BASE) && \
@@ -512,9 +522,10 @@ $(BUNDLE_BUILD_DIR)/base.zip: $(PROTOBUF_OUT_DIR)/dirstamp $(NO_ARCH_OUTPUT_DIR)
 		cp $(NO_ARCH_OUTPUT_DIR)/classes.dex $(ANDROID_BUNDLE_BASE)/dex/
 	$(Q)cd $(ANDROID_BUNDLE_BASE) && $(ZIP) -r $(abspath $@) . --exclude "*/dirstamp"
 
-$(BUNDLE_BUILD_DIR)/unsigned.aab: $(BUNDLE_BUILD_DIR)/base.zip
+$(BUNDLE_BUILD_DIR)/unsigned.aab: $(BUNDLE_BUILD_DIR)/base.zip $(BUNDLE_CONFIG)
 	@$(NQ)echo "  BUNDLE  $(notdir $@)"
-	$(Q)$(BUNDLETOOL) build-bundle --overwrite --modules $< --output $@
+	$(Q)$(BUNDLETOOL) build-bundle --overwrite --config=$(BUNDLE_CONFIG) \
+		--modules $< --output $@
 
 # Debug targets
 .DELETE_ON_ERROR: $(ANDROID_BIN)/XCSoar-debug.aab


### PR DESCRIPTION
## Summary
Play Store (AAB) installs could crash at startup in `SoundUtil.BundledSoundBank` while preloading bundled `res/raw/*.ogg` with `SoundPool`. Logcat shows `Resources$NotFoundException` / `"probably compressed"` because `openRawResourceFd` cannot mmap deflated entries in the APK.

## Related
- [Discussion #2428 — No sound on XCSoar 7.44 on Android?](https://github.com/XCSoar/XCSoar/discussions/2428)
- [#2411](https://github.com/XCSoar/XCSoar/issues/2411) (see that discussion for context and device reports)

## Change
- `aapt2 link`: add `-0 ogg` (App Bundle / Play pipeline).
- `aapt package`: add `-0 ogg` (classic single APK) for consistency.

This only disables **ZIP** compression of `.ogg` entries in the package; it does not re-encode the Vorbis audio.

## Please test (from CI Artifacts)
**Anyone affected:** please test the **Android build produced by this PR’s GitHub Actions run**, not only a future Play Store release.

1. Open the [Actions](https://github.com/XCSoar/XCSoar/actions) tab in this repository.
2. Open the latest workflow run for this pull request (e.g. **Build native** / `build-native` after it completes).
3. At the bottom of the run, under **Artifacts**, download the published Android **artifact** (e.g. bundle/APK zip as uploaded by the workflow), install on your device, and check whether **UI / sim sounds** work as expected.

Please report back in [discussion #2428](https://github.com/XCSoar/XCSoar/discussions/2428) or on [#2411](https://github.com/XCSoar/XCSoar/issues/2411) with **device model**, **Android version**, and **whether you used the Action artifact or another install path** (F-Droid, Play, etc.).

## Test plan
- Rebuild Android AAB, extract or install a device split, and confirm `res/raw` `.ogg` entries are stored (not deflated), or verify startup no longer throws on a device that previously reproduced the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Android packaging so OGG audio files remain uncompressed in both APK and app-bundle outputs, restoring proper playback at runtime.
  * Build now produces and uses a packaging configuration that ensures OGG files are treated as uncompressed throughout the Android build pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
