### PR TITLE
ui/window: Fix GDI ContainerWindow GetFocusedWindow; clarify Play fastlane setup

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -804,7 +804,9 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0.3'
-          bundler-cache: true
+          # No Gemfile in-tree; we install fastlane via gem (bundler-cache would
+          # run bundle install to no purpose).
+          bundler-cache: false
 
       - name: Install Fastlane
         run: gem install fastlane

--- a/.github/workflows/update-play-store-metadata.yml
+++ b/.github/workflows/update-play-store-metadata.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '4.0.3'
-          bundler-cache: true
+          bundler-cache: false
 
       - name: Install Fastlane
         run: gem install fastlane

--- a/src/ui/window/ContainerWindow.hpp
+++ b/src/ui/window/ContainerWindow.hpp
@@ -159,5 +159,14 @@ public:
    * If this is a scrollable window, then attempt to make the given
    * rectangle visible in the view port.
    */
-  virtual void ScrollTo(const PixelRect &rc) noexcept;
+  virtual   void ScrollTo(const PixelRect &rc) noexcept;
+
+#ifdef USE_WINUSER
+  /**
+   * Win32 tracks focus via #HWND; walk from @c ::GetFocus() to the deepest
+   * #Window peer under this container.
+   */
+  [[gnu::pure]]
+  Window *GetFocusedWindow() noexcept;
+#endif
 };

--- a/src/ui/window/gdi/ContainerWindow.cpp
+++ b/src/ui/window/gdi/ContainerWindow.cpp
@@ -2,6 +2,28 @@
 // Copyright The XCSoar Project
 
 #include "../ContainerWindow.hpp"
+#include "../Window.hpp"
+
+Window *
+ContainerWindow::GetFocusedWindow() noexcept
+{
+  const HWND h_focus = ::GetFocus();
+  if (h_focus == nullptr)
+    return nullptr;
+
+  for (HWND h = h_focus; h != nullptr; h = ::GetParent(h)) {
+    if (h == hWnd)
+      return GetChecked(hWnd);
+
+    if (!::IsChild(hWnd, h))
+      return nullptr;
+
+    if (Window *const w = GetChecked(h); w != nullptr)
+      return w;
+  }
+
+  return nullptr;
+}
 
 bool
 ContainerWindow::FocusFirstControl() noexcept


### PR DESCRIPTION
## ui/window/gdi/ContainerWindow

`GetFocusedWindow()` was only declared for the non-`USE_WINUSER` `ContainerWindow` API, but shared dialog code (e.g. `TouchTextEntry`) calls it on the client container. That broke **PC** and **WIN64** CI.

Implement it for Win32 by resolving `::GetFocus()` to our `Window` peer via the HWND parent chain under this container.

## .github/workflows

Set `bundler-cache: false` for the Play and Play-metadata jobs: there is no `Gemfile`; fastlane is installed with `gem install fastlane`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to optimize caching behavior for dependency management.

* **Refactor**
  * Enhanced window focus detection capabilities for improved window management handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->