### PR TITLE
Android: Play native symbols, CI: PR iOS/macOS tests, VirusTotal paths

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -70,6 +70,10 @@ permissions:
 env:
   DEBUG: y
   BOOST: boost_1_87_0
+  # Names in the run Artifacts list; must match upload + download in
+  # "Upload artifact for VirusTotal" and the upload-to-virustotal job.
+  VT_ARTIFACT_WIN64: virustotal-win64
+  VT_ARTIFACT_PC: virustotal-pc
 
 jobs:
   release:
@@ -703,14 +707,14 @@ jobs:
         if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.target == 'WIN64' }}
         uses: actions/upload-artifact@v7
         with:
-          name: virustotal-win64
+          name: ${{ env.VT_ARTIFACT_WIN64 }}
           path: output/WIN64/bin/XCSoar.exe
 
       - name: Upload artifact for VirusTotal (PC)
         if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && matrix.target == 'PC' }}
         uses: actions/upload-artifact@v7
         with:
-          name: virustotal-pc
+          name: ${{ env.VT_ARTIFACT_PC }}
           path: output/PC/bin/XCSoar.exe
 
       - name: Upload Release Asset
@@ -978,11 +982,28 @@ jobs:
         run: |
           echo "::warning::No iOS or macOS TestFlight artifacts from the build job; skipping TestFlight uploads."
 
+  virustotal-gate:
+    name: Check VirusTotal API key
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
+    outputs:
+      has_key: ${{ steps.set.outputs.has_key }}
+    steps:
+      - id: set
+        run: |
+          if [ -n "$KEY" ]; then
+            echo "has_key=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_key=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          KEY: ${{ secrets.VT_API_KEY }}
+
   upload-to-virustotal:
     name: Upload to VirusTotal (Windows)
     runs-on: ubuntu-latest
-    needs: [build]
-    if: ${{ github.repository == 'XCSoar/XCSoar' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) }}
+    needs: [build, virustotal-gate]
+    if: ${{ !cancelled() && needs.virustotal-gate.result == 'success' && needs.virustotal-gate.outputs.has_key == 'true' }}
     env:
       VT_API_KEY: ${{ secrets.VT_API_KEY }}
     steps:
@@ -991,58 +1012,21 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: virustotal-win64
+          name: ${{ env.VT_ARTIFACT_WIN64 }}
+          path: vt-scan/w64
 
       - name: Download PC executable
         id: pc
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: virustotal-pc
-
-      - name: Prepare files for VirusTotal
-        run: |
-          mkdir -p vt-scan
-          # download-artifact@v8 extracts into workspace root with the same
-          # paths as upload (not under a virustotal-* directory).
-          for c in \
-            output/WIN64/bin/XCSoar.exe \
-            virustotal-win64/output/WIN64/bin/XCSoar.exe \
-            virustotal-win64/XCSoar.exe; do
-            if [ -f "$c" ]; then
-              cp "$c" vt-scan/XCSoar-WIN64.exe
-              break
-            fi
-          done
-          for c in \
-            output/PC/bin/XCSoar.exe \
-            virustotal-pc/output/PC/bin/XCSoar.exe \
-            virustotal-pc/XCSoar.exe; do
-            if [ -f "$c" ]; then
-              cp "$c" vt-scan/XCSoar-PC.exe
-              break
-            fi
-          done
-          n=0
-          for f in vt-scan/XCSoar-WIN64.exe vt-scan/XCSoar-PC.exe; do
-            [ -f "$f" ] && n=$((n + 1))
-          done
-          if [ "$n" -eq 0 ]; then
-            echo "No Windows executables found for VirusTotal"
-            exit 1
-          fi
-          ls -la vt-scan/
+          name: ${{ env.VT_ARTIFACT_PC }}
+          path: vt-scan/pc
 
       - name: VirusTotal scan
-        if: ${{ env.VT_API_KEY != '' }}
         uses: crazy-max/ghaction-virustotal@v5
         with:
           vt_api_key: ${{ env.VT_API_KEY }}
           request_rate: 4
           files: |
-            vt-scan/*.exe
-
-      - name: VirusTotal API key not configured
-        if: ${{ env.VT_API_KEY == '' }}
-        run: |
-          echo "::warning::VT_API_KEY is not set; skipping VirusTotal upload."
+            vt-scan/**/*.exe

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -616,7 +616,7 @@ jobs:
 
       - name: Run tests before signing
         id: tests
-        if: ${{ (matrix.target == 'IOS64' || matrix.target == 'MACOS') && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
+        if: ${{ (matrix.target == 'IOS64' || matrix.target == 'MACOS') && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'pull_request') }}
         run: |
           echo "Running unit tests..."
           if [ ${{ matrix.target }} = 'IOS64' ]; then

--- a/build/android.mk
+++ b/build/android.mk
@@ -403,12 +403,10 @@ $$(TARGET_OUTPUT_DIR)/$(2)/thirdparty.stamp: FORCE
 $$(TARGET_OUTPUT_DIR)/$(2)/$$(XCSOAR_ABI)/bin/lib$(1).so: $(NATIVE_HEADERS) generate boost FORCE
 	$$(Q)$$(MAKE) TARGET_OUTPUT_DIR=$$(TARGET_OUTPUT_DIR) TARGET=$(3) DEBUG=$$(DEBUG) USE_CCACHE=$$(USE_CCACHE) $$@
 
-# extract symbolication files for Google Play (paths lib/<ABI>/ must match
-# the APK and Play Console native debug symbols upload format)
-# Depend on lib$(1).so (submake) not lib$(1)-ns.so — see android_bundle.mk.
+# Unstripped .so for Google Play; same -ns rationale as android_bundle.mk.
 ANDROID_SYMBOLICATION_BUILD += $$(ANDROID_BUILD)/symbols/lib/$(2)/lib$(1).so
 $$(ANDROID_BUILD)/symbols/lib/$(2)/lib$(1).so: $$(TARGET_OUTPUT_DIR)/$(2)/$$(XCSOAR_ABI)/bin/lib$(1).so | $$(ANDROID_BUILD)/symbols/lib/$(2)/dirstamp
-	$$(Q)$$(TCPREFIX)objcopy$$(EXE) --strip-debug $$(dir $$<)lib$(1)-ns.so $$@
+	$$(Q)cp $$(dir $$<)lib$(1)-ns.so $$@
 
 endef
 
@@ -452,7 +450,7 @@ $(ANDROID_LIB_BUILD): $(ANDROID_ABI_DIR)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(AND
 # Native debug symbols for Google Play (single-ABI builds).
 ANDROID_NATIVE_SYMBOL_LIBS = $(foreach N,$(ANDROID_LIB_NAMES),$(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib$(N).so)
 $(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/dirstamp
-	$(Q)$(TCPREFIX)objcopy$(EXE) --strip-debug $(ABI_BIN_DIR)/lib$*-ns.so $@
+	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
 	cd $(ANDROID_BUILD)/native-debug-symbols && $(ZIP) -r $(abspath $@) lib

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -414,14 +414,13 @@ $$(TARGET_OUTPUT_DIR)/$(2)/thirdparty.stamp: FORCE
 $$(TARGET_OUTPUT_DIR)/$(2)/$$(XCSOAR_ABI)/bin/lib$(1).so: $(NATIVE_HEADERS) generate boost FORCE
 	$$(Q)$$(MAKE) TARGET_OUTPUT_DIR=$$(TARGET_OUTPUT_DIR) TARGET=$(3) DEBUG=$$(DEBUG) USE_CCACHE=$$(USE_CCACHE) $$@
 
-# extract symbolication files for Google Play (paths lib/<ABI>/ must match
-# the APK/AAB and Play Console native debug symbols upload format)
-# Depend on lib$(1).so (submake) not lib$(1)-ns.so: FAT_BINARY builds omit
-# main.mk, so the parent Make has no rule for -ns; the submake still leaves
-# the unstripped sibling next to the stripped .so when lib$(1).so is built.
+# Unstripped .so (paths lib/<ABI>/) for Google Play; must retain debug info.
+# Rely on lib$(1).so (submake) not lib$(1)-ns.so: fat-binary build omits -ns in
+# the parent graph; the submake still leaves the unstripped sibling when the
+# stripped .so is built.
 ANDROID_SYMBOLICATION_BUILD += $$(BUNDLE_BUILD_DIR)/symbols/lib/$(2)/lib$(1).so
 $$(BUNDLE_BUILD_DIR)/symbols/lib/$(2)/lib$(1).so: $$(TARGET_OUTPUT_DIR)/$(2)/$$(XCSOAR_ABI)/bin/lib$(1).so | $$(BUNDLE_BUILD_DIR)/symbols/lib/$(2)/dirstamp
-	$$(Q)$$(TCPREFIX)objcopy$$(EXE) --strip-debug $$(dir $$<)lib$(1)-ns.so $$@
+	$$(Q)cp $$(dir $$<)lib$(1)-ns.so $$@
 
 endef
 
@@ -463,11 +462,10 @@ ANDROID_LIB_BUILD = $(patsubst %,$(ANDROID_ABI_DIR)/lib%.so,$(ANDROID_LIB_NAMES)
 $(ANDROID_LIB_BUILD): $(ANDROID_ABI_DIR)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_ABI_DIR)/dirstamp
 	$(Q)cp $< $@
 
-# Native debug symbols for Google Play (single-ABI builds).  Same lib/<ABI>/
-# layout as the fat-binary symbols.zip.
+# Native debug symbols for Google Play (single-ABI).  Same lib/<ABI>/ layout.
 ANDROID_NATIVE_SYMBOL_LIBS = $(foreach N,$(ANDROID_LIB_NAMES),$(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib$(N).so)
 $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/dirstamp
-	$(Q)$(TCPREFIX)objcopy$(EXE) --strip-debug $(ABI_BIN_DIR)/lib$*-ns.so $@
+	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
 	cd $(BUNDLE_BUILD_DIR)/native-debug-symbols && $(ZIP) -r $(abspath $@) lib

--- a/darwin/check-ios-sim.py
+++ b/darwin/check-ios-sim.py
@@ -29,9 +29,14 @@ def cpu_count() -> int:
     return os.cpu_count() or 4
 
 
-def find_simulator_udid(device_name: str) -> str:
+def _simctl_devices_payload() -> dict:
     proc = run(["xcrun", "simctl", "list", "devices", "available", "--json"], capture_output=True)
-    payload = json.loads(proc.stdout)
+    return json.loads(proc.stdout)
+
+
+def find_simulator_udid(device_name: str, payload: dict | None = None) -> str:
+    if payload is None:
+        payload = _simctl_devices_payload()
 
     matches: list[tuple[bool, str, str]] = []
     for runtime, devices in payload.get("devices", {}).items():
@@ -54,6 +59,55 @@ def find_simulator_udid(device_name: str) -> str:
     # Prefer already booted device; otherwise prefer highest runtime key.
     matches.sort(key=lambda item: (item[0], item[1]))
     return matches[-1][2]
+
+
+def find_any_available_iphone_simulator(payload: dict) -> tuple[str, str] | None:
+    """Pick any available iPhone-class simulator, newest runtime if possible."""
+
+    matches: list[tuple[bool, str, str, str]] = []
+    for runtime, devices in payload.get("devices", {}).items():
+        for device in devices:
+            if not device.get("isAvailable"):
+                continue
+            name = device.get("name", "")
+            if not name.startswith("iPhone "):
+                continue
+            udid = device.get("udid")
+            if not udid:
+                continue
+            is_booted = device.get("state", "") == "Booted"
+            matches.append((is_booted, runtime, name, udid))
+
+    if not matches:
+        return None
+
+    matches.sort(key=lambda item: (item[0], item[1], item[2]))
+    best = matches[-1]
+    return (best[2], best[3])
+
+
+def resolve_simulator_udid() -> tuple[str, str] | None:
+    """Return (device name, udid) for a usable simulator, or None.
+
+    simctl has no single portable default name (device labels change with Xcode
+    and installed runtimes). The implicit default is: an available
+    iPhone-class simulator, preferring booted then newest iOS in the list.
+    Optional env SIM_DEVICE_NAME requests a specific model; if that name is
+    not present, the same auto pick is used and a line is written to stderr.
+    """
+
+    payload = _simctl_devices_payload()
+    env_name = (os.environ.get("SIM_DEVICE_NAME") or "").strip()
+    if env_name:
+        udid = find_simulator_udid(env_name, payload)
+        if udid:
+            return (env_name, udid)
+        print(
+            f"check-ios-sim: simulator {env_name!r} is not available; using any iPhone",
+            file=sys.stderr,
+        )
+
+    return find_any_available_iphone_simulator(payload)
 
 
 def collect_all_test_names(bin_dir: Path) -> list[str]:
@@ -119,7 +173,6 @@ def main() -> int:
 
     make_bin = os.environ.get("MAKE_BIN", "gmake")
     target = os.environ.get("TARGET", "IOS64SIM")
-    sim_device_name = os.environ.get("SIM_DEVICE_NAME", "iPhone 16 Pro")
     sim_tests_mode = os.environ.get("SIM_TESTS_MODE", "all")
     smoke_tests_env = os.environ.get("SIM_SMOKE_TESTS", "TestCRC8 TestCRC16 TestHexString")
     sim_skip_tests_env = os.environ.get("SIM_SKIP_TESTS", "TestWrapText")
@@ -176,12 +229,14 @@ def main() -> int:
         print("Error: no tests left after applying SIM_SKIP_TESTS", file=sys.stderr)
         return 1
 
-    device_udid = find_simulator_udid(sim_device_name)
-    if not device_udid:
-        print(f"Error: could not find an available simulator named '{sim_device_name}'", file=sys.stderr)
-        print("Hint: set SIM_DEVICE_NAME to one from 'xcrun simctl list devices available --json'", file=sys.stderr)
+    resolved = resolve_simulator_udid()
+    if resolved is None:
+        print("Error: could not find any available iPhone simulator", file=sys.stderr)
+        print("Hint: install an iOS Simulator runtime in Xcode, or set SIM_DEVICE_NAME to a", file=sys.stderr)
+        print("name from: xcrun simctl list devices available --json", file=sys.stderr)
         return 1
 
+    sim_device_name, device_udid = resolved
     print(f"check-ios-sim: using simulator {sim_device_name} ({device_udid})")
     run(["xcrun", "simctl", "boot", device_udid], check=False)
     run(["xcrun", "simctl", "bootstatus", device_udid, "-b"])

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -268,8 +268,11 @@ To build and run simulator tests automatically, run::
   make check-ios-sim
 
 This target builds simulator artifacts (``TARGET=IOS64SIM``), installs
-``XCSoar.app`` into an available simulator (default: ``iPhone 16 Pro``), and
-executes selected test binaries in the simulator runtime.
+``XCSoar.app`` into an available iPhone simulator, and runs selected test
+binaries. There is no fixed default device name (``simctl`` depends on
+installed runtimes and Xcode). With ``SIM_DEVICE_NAME`` unset, the script
+picks an available iPhone from ``simctl list``; you can set ``SIM_DEVICE_NAME``
+to require a specific model.
 
 Implementation note: the runner uses a Python script
 (``darwin/check-ios-sim.py``) and discovers simulators via
@@ -279,7 +282,7 @@ Execution is delegated to the existing Perl TAP harness
 
 Optional environment variables::
 
-  SIM_DEVICE_NAME="iPhone 16"      # Choose simulator model
+  SIM_DEVICE_NAME="iPhone 16"      # Optional: require this model; else any iPhone
   SIM_TESTS_MODE=all               # Default mode: run all test_* / Test* binaries
   SIM_TESTS_MODE=smoke             # Run only smoke subset from SIM_SMOKE_TESTS
   SIM_SMOKE_TESTS="TestCRC8 ..."  # Override smoke test selection


### PR DESCRIPTION
## Summary
Three related CI/build improvements (one commit per topic).

### 1. Google Play native debug symbols (`build/android.mk`, `build/android_bundle.mk`)
Play API returned 400 *Validation of uploaded file failed* for `symbols.zip` because `objcopy --strip-debug` removed useful debug data. Copy the unstripped `lib*-ns.so` into the zip instead.

### 2. Run iOS sim + macOS checks on pull requests (`build-native.yml`)
Add `github.event_name == 'pull_request'` to the *Run tests before signing* step so PRs to `master` run `check-ios-sim` and `gmake TARGET=MACOS check`. Signing/TestFlight stay limited to `master` / `apple-testing` / tags.

### 3. VirusTotal Windows artifacts (`build-native.yml`)
`VT_ARTIFACT_WIN64` / `VT_ARTIFACT_PC` in workflow `env`, used for upload and download; simplify the prepare step to the paths `download-artifact@v8` restores (no old nested fallbacks).

## Test plan
- **Play:** upload `symbols.zip` with a release/internal track and confirm deobfuscation accepts the file.
- **PR:** open a test PR and confirm the iOS/macOS *Run tests* step runs and passes.
- **VirusTotal:** `master` or tag run: `upload-to-virustotal` job finds the exes and scans.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing to run on pull requests in addition to main branches and releases.
  * Improved native debug symbol generation for Android builds by streamlining artifact handling.
  * Parameterized build configuration for improved maintainability and flexibility in artifact processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->