### PR TITLE
Android: Play native symbols zip layout; CI ccache keys and restore

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -242,22 +242,20 @@ jobs:
         run: |
           xcodebuild -version
 
-      # APK and AAB matrix legs both compile ANDROIDFAT; a single shared key made
-      # parallel jobs race on save and duplicate work. Use one key per leg.
       - name: Cache ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.target == 'ANDROID_BUNDLE' && 'ANDROID_BUNDLE-ccache' || (matrix.target == 'ANDROID' && 'ANDROIDFAT-ccache') || format('{0}-ccache', matrix.target) }}
+          key: ${{ matrix.target == 'ANDROID_BUNDLE' && format('ANDROID_BUNDLE-{0}-ccache', env.DEBUG) || (matrix.target == 'ANDROID' && format('ANDROIDFAT-{0}-ccache', env.DEBUG)) || format('{0}-{1}-ccache', matrix.target, env.DEBUG) }}
+          restore-keys: |
+            ${{ matrix.target == 'ANDROID_BUNDLE' && 'ANDROID_BUNDLE-ccache' || (matrix.target == 'ANDROID' && 'ANDROIDFAT-ccache' || format('{0}-ccache', matrix.target)) }}
           max-size: 3G
 
       - name: Configure ccache for cross-compilation
-        if: ${{ matrix.target == 'KOBO' || matrix.target == 'ANDROID' || matrix.target == 'ANDROID_BUNDLE' }}
+        if: ${{ matrix.target == 'KOBO' || matrix.target == 'ANDROID' || matrix.target == 'ANDROID_BUNDLE' || matrix.target == 'WIN64' || matrix.target == 'PC' }}
         run: |
-          # Configure ccache to ignore compiler path for cross-compilation
-          # This is important because cross-compilers have different paths
-          # but produce the same output, so we want to cache based on content
           ccache --set-config compiler_check=content
           ccache --set-config hard_link=false
+          ccache --set-config compression=true
 
       - name: "Cache common downloads"
         uses: actions/cache@v5
@@ -375,11 +373,6 @@ jobs:
               ./ide/provisioning/install-android-tools.sh BUNDLETOOL
             fi
             ./ide/provisioning/install-debian-packages.sh CLEAN
-          elif [ ${{ matrix.os }} = 'macos-12' ] ; then
-            ./ide/provisioning/install-darwin-packages.sh BASE
-            if [ ${{ matrix.target }} = 'OSX64' ]; then
-              ./ide/provisioning/install-darwin-packages.sh OSX64
-            fi
           elif [ ${{ matrix.os }} = 'macos-14' ] || [ ${{ matrix.os }} = 'macos-15' ] || [ ${{ matrix.os }} = 'macos-26' ] ; then
             ./ide/provisioning/install-darwin-packages.sh BASE
             if [ ${{ matrix.target }} = 'MACOS' ]; then
@@ -539,8 +532,6 @@ jobs:
             make -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 everything
           elif [ ${{ matrix.target }} = "KOBO" ]; then
             make -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 output/${{ matrix.target }}/${{ matrix.target_bin }}${{ matrix.target_ext }}
-          elif [ ${{ matrix.target }} = "OSX64" ]; then
-            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 OPTIMIZE="-O0"
           elif [ ${{ matrix.target }} = "MACOS" ]; then
             gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=y OPTIMIZE="-O0" dmg pkg
           elif [ ${{ matrix.target }} = "IOS64" ]; then
@@ -594,8 +585,6 @@ jobs:
             make -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 everything
           elif [ ${{ matrix.target }} = "KOBO" ]; then
             make -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 output/${{ matrix.target }}/${{ matrix.target_bin }}${{ matrix.target_ext }}
-          elif [ ${{ matrix.target }} = "OSX64" ]; then
-            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 OPTIMIZE="-O0" dmg pkg
           elif [ ${{ matrix.target }} = "MACOS" ]; then
             gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 dmg pkg
           elif [ ${{ matrix.target }} = "IOS64" ]; then

--- a/build/android.mk
+++ b/build/android.mk
@@ -426,8 +426,9 @@ compile: $(ANDROID_LIB_BUILD)
 
 # Generate symbols.zip (native debug symbols) for Google Play, which
 # allows Google Play to symbolicate native crash stack traces.
+# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...)
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_SYMBOLICATION_BUILD)
-	cd $(ANDROID_BUILD)/symbols && $(ZIP) -r $(abspath $@) lib
+	cd $(ANDROID_BUILD)/symbols/lib && $(ZIP) -r $(abspath $@) .
 
 else # !FAT_BINARY
 
@@ -447,13 +448,13 @@ ANDROID_LIB_BUILD = $(patsubst %,$(ANDROID_ABI_DIR)/lib%.so,$(ANDROID_LIB_NAMES)
 $(ANDROID_LIB_BUILD): $(ANDROID_ABI_DIR)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_ABI_DIR)/dirstamp
 	$(Q)cp $< $@
 
-# Native debug symbols for Google Play (single-ABI builds).
+# Native debug symbols for Google Play (single-ABI builds).  Staged under lib/<ABI>/.
 ANDROID_NATIVE_SYMBOL_LIBS = $(foreach N,$(ANDROID_LIB_NAMES),$(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib$(N).so)
 $(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/dirstamp
 	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
-	cd $(ANDROID_BUILD)/native-debug-symbols && $(ZIP) -r $(abspath $@) lib
+	cd $(ANDROID_BUILD)/native-debug-symbols/lib && $(ZIP) -r $(abspath $@) .
 
 endif # !FAT_BINARY
 

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -440,8 +440,9 @@ compile: $(ANDROID_LIB_BUILD)
 
 # Generate symbols.zip (native debug symbols) for Google Play, which
 # allows Google Play to symbolicate native crash stack traces.
+# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...)
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_SYMBOLICATION_BUILD)
-	cd $(BUNDLE_BUILD_DIR)/symbols && $(ZIP) -r $(abspath $@) lib
+	cd $(BUNDLE_BUILD_DIR)/symbols/lib && $(ZIP) -r $(abspath $@) .
 
 else # !FAT_BINARY
 
@@ -462,13 +463,13 @@ ANDROID_LIB_BUILD = $(patsubst %,$(ANDROID_ABI_DIR)/lib%.so,$(ANDROID_LIB_NAMES)
 $(ANDROID_LIB_BUILD): $(ANDROID_ABI_DIR)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_ABI_DIR)/dirstamp
 	$(Q)cp $< $@
 
-# Native debug symbols for Google Play (single-ABI).  Same lib/<ABI>/ layout.
+# Native debug symbols for Google Play (single-ABI).  Staged under lib/<ABI>/.
 ANDROID_NATIVE_SYMBOL_LIBS = $(foreach N,$(ANDROID_LIB_NAMES),$(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib$(N).so)
 $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/dirstamp
 	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
-	cd $(BUNDLE_BUILD_DIR)/native-debug-symbols && $(ZIP) -r $(abspath $@) lib
+	cd $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib && $(ZIP) -r $(abspath $@) .
 
 endif # !FAT_BINARY
 


### PR DESCRIPTION
## Summary

### Native debug symbols (`symbols.zip`) for Play
Google Play rejects `nativeCode` deobfuscation uploads when the zip nests libraries under `lib/<ABI>/`. ZIP is now created from inside `lib/` so entries are `<ABI>/libxcsoar.so`, which matches Play API validation.

**Files:** `build/android.mk`, `build/android_bundle.mk`

### CI (`build-native.yml`)
- Include `env.DEBUG` in ccache primary keys so master (debug) and tag (release) builds do not evict each other from the 3G cache.
- Add `restore-keys` for legacy names (`UNIX-ccache`, `ANDROIDFAT-ccache`, etc.) so restored GitHub caches still match after the key rename.
- Apply `compiler_check=content` for WIN64/PC MinGW cross builds (same rationale as NDK/Kobo).
- Remove unreachable `OSX64` / `macos-12` branches from the workflow.

## Testing
- Local/CI: `make` targets that produce `symbols.zip`; verify with `unzip -l symbols.zip` shows `arm64-v8a/` at root, not `lib/arm64-v8a/`.
- CI ccache: next runs should restore old caches via `restore-keys`, then save under DEBUG-scoped keys.

Refs: Google Play `nativeCode` upload flow; `hendrikmuhs/ccache-action` key prefix behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized Android build caching strategy with improved fallback options for faster builds.
  * Adjusted native debug symbol packaging structure for proper compatibility with Google Play distribution.
  * Removed macOS 12 support from the build pipeline.
  * Expanded support for additional build targets in the compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->