### PR TITLE
build/android: Zip only *.so files in Play native symbols archive

### DIFF
--- a/build/android.mk
+++ b/build/android.mk
@@ -426,9 +426,10 @@ compile: $(ANDROID_LIB_BUILD)
 
 # Generate symbols.zip (native debug symbols) for Google Play, which
 # allows Google Play to symbolicate native crash stack traces.
-# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...)
+# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...).
+# Only *.so: zipping "." also picked up Make dirstamps and failed Play validation.
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_SYMBOLICATION_BUILD)
-	cd $(ANDROID_BUILD)/symbols/lib && $(ZIP) -r $(abspath $@) .
+	cd $(ANDROID_BUILD)/symbols/lib && find . -name '*.so' -print | $(ZIP) -r $(abspath $@) -@
 
 else # !FAT_BINARY
 
@@ -454,7 +455,7 @@ $(ANDROID_BUILD)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(ABI_
 	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
-	cd $(ANDROID_BUILD)/native-debug-symbols/lib && $(ZIP) -r $(abspath $@) .
+	cd $(ANDROID_BUILD)/native-debug-symbols/lib && find . -name '*.so' -print | $(ZIP) -r $(abspath $@) -@
 
 endif # !FAT_BINARY
 

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -440,9 +440,10 @@ compile: $(ANDROID_LIB_BUILD)
 
 # Generate symbols.zip (native debug symbols) for Google Play, which
 # allows Google Play to symbolicate native crash stack traces.
-# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...)
+# Zip from inside lib/ so entries are <ABI>/lib*.so (Play rejects lib/<ABI>/...).
+# Only *.so: zipping "." also picked up Make dirstamps and failed Play validation.
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_SYMBOLICATION_BUILD)
-	cd $(BUNDLE_BUILD_DIR)/symbols/lib && $(ZIP) -r $(abspath $@) .
+	cd $(BUNDLE_BUILD_DIR)/symbols/lib && find . -name '*.so' -print | $(ZIP) -r $(abspath $@) -@
 
 else # !FAT_BINARY
 
@@ -469,7 +470,7 @@ $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib/$(ANDROID_APK_LIB_ABI)/lib%.so: $(A
 	$(Q)cp $(ABI_BIN_DIR)/lib$*-ns.so $@
 
 $(TARGET_OUTPUT_DIR)/symbols.zip: $(ANDROID_NATIVE_SYMBOL_LIBS)
-	cd $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib && $(ZIP) -r $(abspath $@) .
+	cd $(BUNDLE_BUILD_DIR)/native-debug-symbols/lib && find . -name '*.so' -print | $(ZIP) -r $(abspath $@) -@
 
 endif # !FAT_BINARY
 


### PR DESCRIPTION
## Summary

Google Play rejected uploaded `symbols.zip` with **400 Validation of uploaded file failed** when the archive included extra files beside unstripped shared libraries — notably **Makefile `dirstamp`** entries created next to each `.so` when zipping the whole `lib/` tree.

## Change

- Build `symbols.zip` by piping `find . -name '*.so'` into `zip -r ... -@` for both fat and single-ABI paths in `build/android.mk` and `build/android_bundle.mk`.

This matches the intent of Google’s documented layout (ABI folders containing `.so` files only) and avoids non-ELF junk in the upload.

## Testing

- `make ... output/ANDROID_BUNDLE/symbols.zip` and `unzip -l` shows only `arm64-v8a/libxcsoar.so` (or one entry per ABI), no `dirstamp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android symbol file packaging to resolve Google Play validation issues. Symbol archives now contain only native library files, ensuring smoother app builds and store submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->