### PR TITLE
doc: Improve install script for macOS

### DIFF
--- a/doc/build.rst
+++ b/doc/build.rst
@@ -297,7 +297,9 @@ Compiling for macOS (with Homebrew)
 
 Install the required Homebrew packages via the provisioning script::
 
-  ./ide/provisioning/install-darwin-packages.sh MACOS
+  ./ide/provisioning/install-darwin-packages.sh BASE MACOS
+
+Note that you always need to install the BASE packages and the specific IOS or MACOS packages.
 
 To compile for macOS / ARM64, run::
 


### PR DESCRIPTION
Closes https://github.com/XCSoar/XCSoar/issues/2442.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified macOS build provisioning requirements to specify that BASE packages must be installed alongside target-specific packages.
  * Added explicit guidance clarifying that the BASE provisioning step is a mandatory prerequisite for both iOS and macOS build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->