### PR TITLE
ACD COM/Active Frequency, QNH Device sync, Polarync register

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -90,6 +90,9 @@ Version 7.45 - not yet released
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
 * devices
   - fix native crash on device reconnect (stale delayed reopen timer) #2382
+  - Polar sync device setting is offered only for drivers that register polar
+    support (currently LXNAV); PutPolar is skipped on other drivers even if an old
+    profile had Polar sync enabled #2457
 * iOS
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380

--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -110,6 +110,12 @@ QNHProcessTimer(OperationEnvironment &env) noexcept
     settings_computer.pressure = basic.settings.qnh;
     settings_computer.pressure_available = basic.settings.qnh_available;
     modified = true;
+
+    /* Propagate to every device that accepts QNH (e.g. LXNAV), not only when
+       DerivedInfo pressure changes.  Without this, QNH learned from one port
+       (e.g. AIR Control Display) updated XCSoar but was never sent to others. */
+    if (backend_components && backend_components->devices)
+      backend_components->devices->PutQNH(settings_computer.pressure, env);
   }
 
   if (calculated.pressure_available.Modified(settings_computer.pressure_available)) {

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -993,6 +993,9 @@ DeviceDescriptor::PutPolar(const GlidePolar &polar,
       config.polar_sync != DeviceConfig::PolarSync::SEND)
     return true;
 
+  if (driver == nullptr || !driver->CanSendPolar())
+    return true;
+
   if (!Borrow())
     return false;
 

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -433,6 +433,18 @@ struct DeviceRegister {
      * #DeviceConfig::send_position.
      */
     SEND_POSITION = 0x400,
+
+    /**
+     * Can adopt a glide polar from the device into XCSoar (device
+     * configuration: PolarSync::RECEIVE).  Distinct from generic
+     * RECEIVE_SETTINGS (MC/bugs/ballast).
+     */
+    RECEIVE_POLAR = 0x800,
+
+    /**
+     * Can accept XCSoar's glide polar via PutPolar (PolarSync::SEND).
+     */
+    SEND_POLAR = 0x1000,
   };
 
   /**
@@ -536,5 +548,19 @@ struct DeviceRegister {
    */
   bool CanSendPosition() const {
     return (flags & SEND_POSITION) != 0;
+  }
+
+  /**
+   * Does this driver support receiving a glide polar from the device?
+   */
+  bool CanReceivePolar() const {
+    return (flags & RECEIVE_POLAR) != 0;
+  }
+
+  /**
+   * Does this driver support PutPolar (send glide polar to device)?
+   */
+  bool CanSendPolar() const {
+    return (flags & SEND_POLAR) != 0;
   }
 };

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -20,10 +20,48 @@
 #include "Operation/Operation.hpp"
 #include "time/PeriodClock.hpp"
 
+#include <cassert>
+
 using std::string_view_literals::operator""sv;
 
-static bool
-ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
+class ACDDevice : public AbstractDevice {
+  friend bool ParsePAAVS(NMEAInputLine &line, NMEAInfo &info,
+                         ACDDevice *dev) noexcept;
+
+  Port &port;
+  PeriodClock status_clock;
+
+  /**
+   * Last COM standby channel (kHz) from the panel or from our own
+   * PutStandbyFrequency.  CHN1 is read-only on the ACD; tuning active uses
+   * CHN2 + swap + restore (see PutActiveFrequency).
+   */
+  unsigned cached_com_standby_khz = 0;
+  bool com_standby_khz_known = false;
+
+public:
+  ACDDevice(Port &_port):port(_port) {}
+
+  /* virtual methods from class Device */
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+  bool PutQNH(const AtmosphericPressure &pres,
+              OperationEnvironment &env) override;
+  bool PutVolume(unsigned volume, OperationEnvironment &env) override;
+  bool PutActiveFrequency(RadioFrequency frequency,
+                          const char *name,
+                          OperationEnvironment &env) override;
+  bool PutStandbyFrequency(RadioFrequency frequency,
+                           const char *name,
+                           OperationEnvironment &env) override;
+  bool ExchangeRadioFrequencies(OperationEnvironment &env,
+                                NMEAInfo &info) override;
+  bool PutTransponderCode(TransponderCode code, OperationEnvironment &env) override;
+  void OnCalculatedUpdate(const MoreData &basic,
+                          [[maybe_unused]] const DerivedInfo &calculated) override;
+};
+
+bool
+ParsePAAVS(NMEAInputLine &line, NMEAInfo &info, ACDDevice *dev) noexcept
 {
   double value;
 
@@ -71,6 +109,10 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
     if (line.ReadChecked(value)) {
       info.settings.has_standby_frequency.Update(info.clock);
       info.settings.standby_frequency = RadioFrequency::FromKiloHertz(value);
+      if (dev != nullptr) {
+        dev->cached_com_standby_khz = uround(value);
+        dev->com_standby_khz_known = true;
+      }
     }
 
     unsigned volume;
@@ -147,28 +189,6 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
   return true;
 }
 
-class ACDDevice : public AbstractDevice {
-  Port &port;
-  PeriodClock status_clock;
-
-public:
-  ACDDevice(Port &_port):port(_port) {}
-
-  /* virtual methods from class Device */
-  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
-  bool PutQNH(const AtmosphericPressure &pres,
-              OperationEnvironment &env) override;
-  bool PutVolume(unsigned volume, OperationEnvironment &env) override;
-  bool PutStandbyFrequency(RadioFrequency frequency,
-                           const char *name,
-                           OperationEnvironment &env) override;
-  bool ExchangeRadioFrequencies(OperationEnvironment &env,
-                                NMEAInfo &info) override;
-  bool PutTransponderCode(TransponderCode code, OperationEnvironment &env) override;
-  void OnCalculatedUpdate(const MoreData &basic,
-                          [[maybe_unused]] const DerivedInfo &calculated) override;
-};
-
 bool
 ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 {
@@ -176,6 +196,36 @@ ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
   unsigned qnh = uround(pres.GetPascal());
   sprintf(buffer, "PAAVC,S,ALT,QNH,%u", qnh);
   PortWriteNMEA(port, buffer, env);
+  return true;
+}
+
+bool
+ACDDevice::PutActiveFrequency(RadioFrequency frequency,
+                              [[maybe_unused]] const char *name,
+                              OperationEnvironment &env)
+{
+  assert(frequency.IsDefined());
+
+  /*
+   Primary COM channel (CHN1) is read-only on the ACD.  Same workaround as
+   LK8000 devAirControlDisplay: load standby (CHN2) with the desired active,
+   swap active/standby, then restore the previous standby on CHN2.
+   */
+  if (!com_standby_khz_known)
+    return false;
+
+  const unsigned old_standby_khz = cached_com_standby_khz;
+  const unsigned new_active_khz = frequency.GetKiloHertz();
+
+  char buffer[100];
+  sprintf(buffer, "PAAVC,S,COM,CHN2,%u", new_active_khz);
+  PortWriteNMEA(port, buffer, env);
+
+  PortWriteNMEA(port, "PAAVX,COM,XCHN", env);
+
+  sprintf(buffer, "PAAVC,S,COM,CHN2,%u", old_standby_khz);
+  PortWriteNMEA(port, buffer, env);
+
   return true;
 }
 
@@ -197,6 +247,8 @@ ACDDevice::PutStandbyFrequency(RadioFrequency frequency,
   unsigned freq = frequency.GetKiloHertz();
   sprintf(buffer, "PAAVC,S,COM,CHN2,%u", freq);
   PortWriteNMEA(port, buffer, env);
+  cached_com_standby_khz = freq;
+  com_standby_khz_known = true;
   return true;
 }
 
@@ -227,7 +279,7 @@ ACDDevice::ParseNMEA(const char *_line, NMEAInfo &info)
   NMEAInputLine line(_line);
 
   if (line.ReadCompare("$PAAVS"))
-    return ParsePAAVS(line, info);
+    return ParsePAAVS(line, info, this);
   else
     return false;
 }

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -20,6 +20,7 @@
 #include "Operation/Operation.hpp"
 #include "time/PeriodClock.hpp"
 
+#include <atomic>
 #include <cassert>
 
 using std::string_view_literals::operator""sv;
@@ -36,8 +37,8 @@ class ACDDevice : public AbstractDevice {
    * PutStandbyFrequency.  CHN1 is read-only on the ACD; tuning active uses
    * CHN2 + swap + restore (see PutActiveFrequency).
    */
-  unsigned cached_com_standby_khz = 0;
-  bool com_standby_khz_known = false;
+  std::atomic<unsigned> cached_com_standby_khz{0};
+  std::atomic<bool> com_standby_khz_known{false};
 
 public:
   ACDDevice(Port &_port):port(_port) {}
@@ -110,8 +111,9 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info, ACDDevice *dev) noexcept
       info.settings.has_standby_frequency.Update(info.clock);
       info.settings.standby_frequency = RadioFrequency::FromKiloHertz(value);
       if (dev != nullptr) {
-        dev->cached_com_standby_khz = uround(value);
-        dev->com_standby_khz_known = true;
+        dev->cached_com_standby_khz.store(uround(value),
+                                          std::memory_order_relaxed);
+        dev->com_standby_khz_known.store(true, std::memory_order_relaxed);
       }
     }
 
@@ -211,10 +213,11 @@ ACDDevice::PutActiveFrequency(RadioFrequency frequency,
    LK8000 devAirControlDisplay: load standby (CHN2) with the desired active,
    swap active/standby, then restore the previous standby on CHN2.
    */
-  if (!com_standby_khz_known)
+  if (!com_standby_khz_known.load(std::memory_order_relaxed))
     return false;
 
-  const unsigned old_standby_khz = cached_com_standby_khz;
+  const unsigned old_standby_khz =
+    cached_com_standby_khz.load(std::memory_order_relaxed);
   const unsigned new_active_khz = frequency.GetKiloHertz();
 
   char buffer[100];
@@ -247,8 +250,8 @@ ACDDevice::PutStandbyFrequency(RadioFrequency frequency,
   unsigned freq = frequency.GetKiloHertz();
   sprintf(buffer, "PAAVC,S,COM,CHN2,%u", freq);
   PortWriteNMEA(port, buffer, env);
-  cached_com_standby_khz = freq;
-  com_standby_khz_known = true;
+  cached_com_standby_khz.store(freq, std::memory_order_relaxed);
+  com_standby_khz_known.store(true, std::memory_order_relaxed);
   return true;
 }
 

--- a/src/Device/Driver/LX/Register.cpp
+++ b/src/Device/Driver/LX/Register.cpp
@@ -25,6 +25,7 @@ const struct DeviceRegister lx_driver = {
   DeviceRegister::DECLARE | DeviceRegister::LOGGER |
   DeviceRegister::PASS_THROUGH |
   DeviceRegister::BULK_BAUD_RATE |
-  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS |
+  DeviceRegister::RECEIVE_POLAR | DeviceRegister::SEND_POLAR,
   LXCreateOnPort,
 };

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -235,6 +235,36 @@ CanPassThrough(const DataField &df) noexcept
   return driver->HasPassThrough();
 }
 
+[[gnu::pure]]
+static bool
+CanReceivePolar(const DataField &df) noexcept
+{
+  const char *driver_name = df.GetAsString();
+  if (driver_name == nullptr)
+    return false;
+
+  const struct DeviceRegister *driver = FindDriverByName(driver_name);
+  if (driver == nullptr)
+    return false;
+
+  return driver->CanReceivePolar();
+}
+
+[[gnu::pure]]
+static bool
+CanSendPolar(const DataField &df) noexcept
+{
+  const char *driver_name = df.GetAsString();
+  if (driver_name == nullptr)
+    return false;
+
+  const struct DeviceRegister *driver = FindDriverByName(driver_name);
+  if (driver == nullptr)
+    return false;
+
+  return driver->CanSendPolar();
+}
+
 void
 DeviceEditWidget::UpdateVisibilities() noexcept
 {
@@ -275,12 +305,18 @@ DeviceEditWidget::UpdateVisibilities() noexcept
                 can_send);
   SetRowVisible(SendPosition, DeviceConfig::UsesDriver(type) &&
                 can_send_position);
-  SetRowVisible(PolarSyncMode, DeviceConfig::UsesDriver(type) &&
-                (can_receive || can_send));
-  if (can_receive || can_send) {
+  const bool can_receive_polar = CanReceivePolar(GetDataField(Driver));
+  const bool can_send_polar = CanSendPolar(GetDataField(Driver));
+  const bool polar_row_applicable = DeviceConfig::UsesDriver(type) &&
+                                    (can_receive_polar || can_send_polar);
+  /* Expert rows still reserve layout unless available is false; hide fully when
+     the driver does not register polar sync. */
+  SetRowAvailable(PolarSyncMode, polar_row_applicable);
+  SetRowVisible(PolarSyncMode, polar_row_applicable);
+  if (can_receive_polar || can_send_polar) {
     auto &polar_df = (DataFieldEnum &)GetDataField(PolarSyncMode);
     const auto prev = polar_df.GetValue();
-    FillPolarSync(polar_df, can_receive, can_send);
+    FillPolarSync(polar_df, can_receive_polar, can_send_polar);
     polar_df.SetValue(prev);
   }
   SetRowAvailable(K6Bt, maybe_bluetooth);
@@ -396,13 +432,14 @@ DeviceEditWidget::Prepare(ContainerWindow &parent,
 
   DataFieldEnum *polar_sync_df = new DataFieldEnum(this);
   FillPolarSync(*polar_sync_df,
-                CanReceiveSettings(*driver_df),
-                CanSendSettings(*driver_df));
+                CanReceivePolar(*driver_df),
+                CanSendPolar(*driver_df));
   polar_sync_df->SetValue(config.polar_sync);
   Add(_("Polar sync"),
-      _("Synchronize the glide polar between XCSoar and the device. "
-        "'Receive' adopts the polar from the device (e.g. for club "
-        "gliders). 'Send' pushes XCSoar's polar to the device."),
+      _("Synchronize the glide polar between XCSoar and the device "
+        "(LXNAV varios). 'Receive' adopts the polar from the device "
+        "(e.g. for club gliders). 'Send' pushes XCSoar's polar to the "
+        "device."),
       polar_sync_df);
   SetExpertRow(PolarSyncMode);
 
@@ -529,8 +566,8 @@ DeviceEditWidget::Save(bool &_changed) noexcept
     if (CanSendPosition(GetDataField(Driver)))
       changed |= SaveValue(SendPosition, config.send_position);
 
-    if (CanReceiveSettings(GetDataField(Driver)) ||
-        CanSendSettings(GetDataField(Driver)))
+    if (CanReceivePolar(GetDataField(Driver)) ||
+        CanSendPolar(GetDataField(Driver)))
       changed |= SaveValueEnum(PolarSyncMode, config.polar_sync);
 
     if (CanPassThrough(GetDataField(Driver))) {


### PR DESCRIPTION
- **ProductName util/CompileDate: URL macros and compile-year helper**
- **test/RunFlyingComputer: PolarStore CLI and standard --help/--version**
- **CommandLine: Add --help and GNU-style --version output**
- **doc: Document desktop xcsoar CLI --help and --version**
- **.cursor/rules/cli-test-utilities.mdc: Add harness CLI conventions**
- **Device/Driver/AirControlDisplay: Tune active COM via CHN2 and swap**
- **ApplyExternalSettings: Forward external QNH to all devices**
- **Device: Gate polar sync on registered driver capability**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized help (`-h`/`--help`) and version (`--version`) command-line output with consistent behavior
  * Added RunFlyingComputer test utility with polar selection and list support

* **Bug Fixes**
  * QNH updates now properly propagate across all compatible devices
  * Polar synchronization restricted to drivers with polar support capability

* **Documentation**
  * Installation guide expanded with CLI options, runtime flags, and examples
  * Added test utility documentation and rebranding configuration for web and bug links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->