### PR TITLE
InfoBoxes: Altitude IGC; FLARM $PGRMZ feeds igc_pressure_altitude

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,9 @@
 Version 7.45 - not yet released
+* devices
+  - FLARM $PGRMZ (when FLARM is detected) also feeds igc_pressure_altitude for
+    the same ISA pressure datum as weak pressure altitude
+* ui
+  - infoboxen: new Altitude IGC InfoBox (logger / IGC altitude chain)
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -658,6 +658,18 @@ NMEAParser::RMZ(NMEAInputLine &line, NMEAInfo &info)
          here */
       info.ProvideWeakPressureAltitude(value);
 
+      /* Mirror logger altitude only when this sentence fed weak pressure
+         altitude.  Stale igc when strong pressure replaces weak is cleared in
+         NMEAInfo::ProvidePressureAltitude (same NMEAInfo / mux feed). */
+      if (info.pressure_altitude_weak) {
+        info.igc_pressure_altitude = value;
+        info.igc_pressure_altitude_available.Update(info.clock);
+      }
+
+      /* Same datum precedence as IGCFix::Apply when igc_pressure_altitude is
+         valid. Multiple devices: merged Basic() first valid igc wins (port
+         order). */
+
       /* when a FLARM gets detected too late, the previous call to
          this function may have filled the PGRMZ value into
          "barometric altitude"; that was a misapprehension, and the

--- a/src/InfoBoxes/Content/Altitude.cpp
+++ b/src/InfoBoxes/Content/Altitude.cpp
@@ -8,9 +8,12 @@
 #include "InfoBoxes/Panel/AltitudeInfo.hpp"
 #include "InfoBoxes/Panel/AltitudeSimulator.hpp"
 #include "InfoBoxes/Panel/AltitudeSetup.hpp"
+#include "NMEA/Info.hpp"
 #include "Units/Units.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+
+#include <optional>
 
 /*
  * Subpart callback function pointers
@@ -33,6 +36,42 @@ InfoBoxContentAltitude::GetDialogContent() noexcept
   return altitude_infobox_panels;
 }
 
+namespace {
+
+/**
+ * Altitude used for IGC / logger display.  Keep in sync with
+ * IGCFix::Apply (NMEAInfo field order).
+ */
+[[gnu::pure]] std::optional<double>
+LoggerAltitudeOrInvalid(const NMEAInfo &basic) noexcept
+{
+  if (basic.igc_pressure_altitude_available)
+    return basic.igc_pressure_altitude;
+  if (basic.pressure_altitude_available)
+    return basic.pressure_altitude;
+  if (basic.baro_altitude_available)
+    return basic.baro_altitude;
+  if (basic.gps_altitude_available)
+    return basic.gps_altitude;
+  return std::nullopt;
+}
+
+} // namespace
+
+void
+UpdateInfoBoxAltitudeIGC(InfoBoxData &data) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  const auto a = LoggerAltitudeOrInvalid(basic);
+  if (!a) {
+    data.SetInvalid();
+    return;
+  }
+
+  data.SetValueFromAltitude(*a);
+  data.SetCommentFromAlternateAltitude(*a);
+}
+
 void
 UpdateInfoBoxAltitudeNav(InfoBoxData &data) noexcept
 {
@@ -47,7 +86,8 @@ UpdateInfoBoxAltitudeNav(InfoBoxData &data) noexcept
     return;
   }
 
-  const ComputerSettings &settings_computer = CommonInterface::GetComputerSettings();
+  const ComputerSettings &settings_computer =
+      CommonInterface::GetComputerSettings();
 
   if (basic.baro_altitude_available &&
       settings_computer.features.nav_baro_altitude_enabled)

--- a/src/InfoBoxes/Content/Altitude.hpp
+++ b/src/InfoBoxes/Content/Altitude.hpp
@@ -16,6 +16,9 @@ public:
 void
 UpdateInfoBoxAltitudeNav(InfoBoxData &data) noexcept;
 
+void
+UpdateInfoBoxAltitudeIGC(InfoBoxData &data) noexcept;
+
 class InfoBoxContentAltitudeGPS : public InfoBoxContentAltitude
 {
 public:

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1171,6 +1171,15 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentHome>::Create,
   },
 
+  // e_AltitudeIGC
+  {
+    N_("Altitude IGC"),
+    N_("Alt IGC"),
+    N_("ISA / logger pressure altitude used for IGC recording (igc_pressure_altitude when available, else the same fallback as the internal IGC writer: pressure altitude, barometric altitude, GPS altitude). When this shows ISA pressure (e.g. FLARM), it is not QNH-corrected; airspace and navigation altitude use barometric height from your setup (merged device order). Task and glide logic use GPS altitude where applicable."),
+    UpdateInfoBoxAltitudeIGC,
+    altitude_infobox_panels,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -151,6 +151,7 @@ namespace InfoBoxFactory
     e_Alternate_2_AltDiff, /* Arrival altitude at the second-best alternate landing location relative to the safety arrival height */
     /* 130 */
     e_Home, /* Combined home waypoint infobox: shows waypoint name, arrival altitude diff, and distance */
+    e_AltitudeIGC, /* Logger / IGC pressure altitude (same chain as IGC file writer) */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -425,6 +425,13 @@ struct NMEAInfo {
    * the previous altitude was not present or the same/lower priority.
    */
   constexpr void ProvidePressureAltitude(double value) noexcept {
+    /* Replacing weak pressure (e.g. FLARM $PGRMZ) with strong pressure drops
+       the FLARM igc mirror so IGCFix does not prefer stale igc_pressure_altitude.
+       Logger igc from another sentence (e.g. $PLXVS) is set after strong
+       pressure and is preserved. */
+    if (pressure_altitude_available && pressure_altitude_weak)
+      igc_pressure_altitude_available.Clear();
+
     pressure_altitude = value;
     pressure_altitude_weak = false;
     pressure_altitude_available.Update(clock);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -2021,6 +2021,8 @@ TestVega()
   ok1(parser.ParseLine("$PGRMZ,2447,F,2*0F", nmea_info));
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 745.845));
+  ok1(nmea_info.igc_pressure_altitude_available);
+  ok1(equals(nmea_info.igc_pressure_altitude, nmea_info.pressure_altitude));
 
   ok1(device->ParseNMEA("$PDSWC,0,1002000,100,115*54", nmea_info));
   ok1(nmea_info.settings.mac_cready_available);
@@ -2038,11 +2040,13 @@ TestVega()
   ok1(!nmea_info.baro_altitude_available);
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 762));
+  ok1(!nmea_info.igc_pressure_altitude_available);
 
   /* parse $PGRMZ again, it should be ignored */
   ok1(parser.ParseLine("$PGRMZ,2447,F,2*0F", nmea_info));
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 762));
+  ok1(!nmea_info.igc_pressure_altitude_available);
 
   delete device;
 }
@@ -2897,7 +2901,7 @@ int main()
   SetSingleDataPath(data_path);
   CreateDataPath();
 
-  plan_tests(1032 /* drivers */ + 29 /* PFLAU extended */
+  plan_tests(1036 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 107 /* LXNav protocol 1.05 */


### PR DESCRIPTION
## Summary

- **FLARM `$PGRMZ`** (when FLARM is detected): mirror **`igc_pressure_altitude`** together with weak pressure altitude (ISA / 1013.25 hPa), aligned with **`IGCFix::Apply`** precedence for the IGC pressure column.
- **`NMEAInfo::ProvidePressureAltitude`**: clear **`igc_pressure_altitude`** when **strong** pressure replaces **weak** (e.g. Vega/LX mux), so **`IGCFix`** does not keep stale FLARM logger altitude; LX **`$PLXVS`** can still set logger altitude afterwards on the same feed.
- New **Altitude IGC** InfoBox (`e_AltitudeIGC`): displays the same chain as **`IGCFix::Apply`** (`igc_pressure_altitude` → pressure → baro → GPS). Factory help text states this is **not QNH-corrected** when showing ISA/logger pressure and that **navigation / airspace** use barometric setup where applicable.
- **Tests:** `TestVega` asserts **`igc_pressure_altitude`** after first `$PGRMZ`; cleared after strong Vega pressure; **`plan_tests`** bumped.

## Related

- Documentation / pilot-facing overview: **#2458**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Altitude IGC" Infobox for displaying logger/IGC pressure altitude
  * Enhanced FLARM altitude data handling to support IGC pressure altitude metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->