### PR TITLE
FLARM igc_pressure_altitude, Altitude IGC InfoBox; polar/QNH/ACD device fixes

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,8 @@ Version 7.45 - not yet released
   - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
     ISA logger datum; cleared when strong pressure replaces weak pressure or
     ignores the sentence
+* ui
+  - infoboxen: new Altitude IGC InfoBox (logger pressure or ISA pressure only)
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -90,6 +90,9 @@ Version 7.45 - not yet released
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
 * devices
   - fix native crash on device reconnect (stale delayed reopen timer) #2382
+  - Polar sync device setting is offered only for drivers that register polar
+    support (currently LXNAV); PutPolar is skipped on other drivers even if an old
+    profile had Polar sync enabled #2457
 * iOS
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,8 @@
 Version 7.45 - not yet released
+* devices
+  - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
+    ISA logger datum; cleared when strong pressure replaces weak pressure or
+    ignores the sentence
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -110,6 +110,12 @@ QNHProcessTimer(OperationEnvironment &env) noexcept
     settings_computer.pressure = basic.settings.qnh;
     settings_computer.pressure_available = basic.settings.qnh_available;
     modified = true;
+
+    /* Propagate to every device that accepts QNH (e.g. LXNAV), not only when
+       DerivedInfo pressure changes.  Without this, QNH learned from one port
+       (e.g. AIR Control Display) updated XCSoar but was never sent to others. */
+    if (backend_components && backend_components->devices)
+      backend_components->devices->PutQNH(settings_computer.pressure, env);
   }
 
   if (calculated.pressure_available.Modified(settings_computer.pressure_available)) {

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -993,6 +993,9 @@ DeviceDescriptor::PutPolar(const GlidePolar &polar,
       config.polar_sync != DeviceConfig::PolarSync::SEND)
     return true;
 
+  if (driver == nullptr || !driver->CanSendPolar())
+    return true;
+
   if (!Borrow())
     return false;
 

--- a/src/Device/Driver.hpp
+++ b/src/Device/Driver.hpp
@@ -433,6 +433,18 @@ struct DeviceRegister {
      * #DeviceConfig::send_position.
      */
     SEND_POSITION = 0x400,
+
+    /**
+     * Can adopt a glide polar from the device into XCSoar (device
+     * configuration: PolarSync::RECEIVE).  Distinct from generic
+     * RECEIVE_SETTINGS (MC/bugs/ballast).
+     */
+    RECEIVE_POLAR = 0x800,
+
+    /**
+     * Can accept XCSoar's glide polar via PutPolar (PolarSync::SEND).
+     */
+    SEND_POLAR = 0x1000,
   };
 
   /**
@@ -536,5 +548,19 @@ struct DeviceRegister {
    */
   bool CanSendPosition() const {
     return (flags & SEND_POSITION) != 0;
+  }
+
+  /**
+   * Does this driver support receiving a glide polar from the device?
+   */
+  bool CanReceivePolar() const {
+    return (flags & RECEIVE_POLAR) != 0;
+  }
+
+  /**
+   * Does this driver support PutPolar (send glide polar to device)?
+   */
+  bool CanSendPolar() const {
+    return (flags & SEND_POLAR) != 0;
   }
 };

--- a/src/Device/Driver/AirControlDisplay.cpp
+++ b/src/Device/Driver/AirControlDisplay.cpp
@@ -20,10 +20,49 @@
 #include "Operation/Operation.hpp"
 #include "time/PeriodClock.hpp"
 
+#include <atomic>
+#include <cassert>
+
 using std::string_view_literals::operator""sv;
 
-static bool
-ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
+class ACDDevice : public AbstractDevice {
+  friend bool ParsePAAVS(NMEAInputLine &line, NMEAInfo &info,
+                         ACDDevice *dev) noexcept;
+
+  Port &port;
+  PeriodClock status_clock;
+
+  /**
+   * Last COM standby channel (kHz) from the panel or from our own
+   * PutStandbyFrequency.  CHN1 is read-only on the ACD; tuning active uses
+   * CHN2 + swap + restore (see PutActiveFrequency).
+   */
+  std::atomic<unsigned> cached_com_standby_khz{0};
+  std::atomic<bool> com_standby_khz_known{false};
+
+public:
+  ACDDevice(Port &_port):port(_port) {}
+
+  /* virtual methods from class Device */
+  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
+  bool PutQNH(const AtmosphericPressure &pres,
+              OperationEnvironment &env) override;
+  bool PutVolume(unsigned volume, OperationEnvironment &env) override;
+  bool PutActiveFrequency(RadioFrequency frequency,
+                          const char *name,
+                          OperationEnvironment &env) override;
+  bool PutStandbyFrequency(RadioFrequency frequency,
+                           const char *name,
+                           OperationEnvironment &env) override;
+  bool ExchangeRadioFrequencies(OperationEnvironment &env,
+                                NMEAInfo &info) override;
+  bool PutTransponderCode(TransponderCode code, OperationEnvironment &env) override;
+  void OnCalculatedUpdate(const MoreData &basic,
+                          [[maybe_unused]] const DerivedInfo &calculated) override;
+};
+
+bool
+ParsePAAVS(NMEAInputLine &line, NMEAInfo &info, ACDDevice *dev) noexcept
 {
   double value;
 
@@ -71,6 +110,12 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
     if (line.ReadChecked(value)) {
       info.settings.has_standby_frequency.Update(info.clock);
       info.settings.standby_frequency = RadioFrequency::FromKiloHertz(value);
+      if (dev != nullptr) {
+        dev->cached_com_standby_khz.store(uround(value),
+                                          std::memory_order_relaxed);
+        dev->com_standby_khz_known.store(true,
+                                         std::memory_order_release);
+      }
     }
 
     unsigned volume;
@@ -147,28 +192,6 @@ ParsePAAVS(NMEAInputLine &line, NMEAInfo &info)
   return true;
 }
 
-class ACDDevice : public AbstractDevice {
-  Port &port;
-  PeriodClock status_clock;
-
-public:
-  ACDDevice(Port &_port):port(_port) {}
-
-  /* virtual methods from class Device */
-  bool ParseNMEA(const char *line, struct NMEAInfo &info) override;
-  bool PutQNH(const AtmosphericPressure &pres,
-              OperationEnvironment &env) override;
-  bool PutVolume(unsigned volume, OperationEnvironment &env) override;
-  bool PutStandbyFrequency(RadioFrequency frequency,
-                           const char *name,
-                           OperationEnvironment &env) override;
-  bool ExchangeRadioFrequencies(OperationEnvironment &env,
-                                NMEAInfo &info) override;
-  bool PutTransponderCode(TransponderCode code, OperationEnvironment &env) override;
-  void OnCalculatedUpdate(const MoreData &basic,
-                          [[maybe_unused]] const DerivedInfo &calculated) override;
-};
-
 bool
 ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
 {
@@ -176,6 +199,37 @@ ACDDevice::PutQNH(const AtmosphericPressure &pres, OperationEnvironment &env)
   unsigned qnh = uround(pres.GetPascal());
   sprintf(buffer, "PAAVC,S,ALT,QNH,%u", qnh);
   PortWriteNMEA(port, buffer, env);
+  return true;
+}
+
+bool
+ACDDevice::PutActiveFrequency(RadioFrequency frequency,
+                              [[maybe_unused]] const char *name,
+                              OperationEnvironment &env)
+{
+  assert(frequency.IsDefined());
+
+  /*
+   Primary COM channel (CHN1) is read-only on the ACD.  Same workaround as
+   LK8000 devAirControlDisplay: load standby (CHN2) with the desired active,
+   swap active/standby, then restore the previous standby on CHN2.
+   */
+  if (!com_standby_khz_known.load(std::memory_order_acquire))
+    return false;
+
+  const unsigned old_standby_khz =
+    cached_com_standby_khz.load(std::memory_order_relaxed);
+  const unsigned new_active_khz = frequency.GetKiloHertz();
+
+  char buffer[100];
+  sprintf(buffer, "PAAVC,S,COM,CHN2,%u", new_active_khz);
+  PortWriteNMEA(port, buffer, env);
+
+  PortWriteNMEA(port, "PAAVX,COM,XCHN", env);
+
+  sprintf(buffer, "PAAVC,S,COM,CHN2,%u", old_standby_khz);
+  PortWriteNMEA(port, buffer, env);
+
   return true;
 }
 
@@ -197,6 +251,8 @@ ACDDevice::PutStandbyFrequency(RadioFrequency frequency,
   unsigned freq = frequency.GetKiloHertz();
   sprintf(buffer, "PAAVC,S,COM,CHN2,%u", freq);
   PortWriteNMEA(port, buffer, env);
+  cached_com_standby_khz.store(freq, std::memory_order_relaxed);
+  com_standby_khz_known.store(true, std::memory_order_release);
   return true;
 }
 
@@ -227,7 +283,7 @@ ACDDevice::ParseNMEA(const char *_line, NMEAInfo &info)
   NMEAInputLine line(_line);
 
   if (line.ReadCompare("$PAAVS"))
-    return ParsePAAVS(line, info);
+    return ParsePAAVS(line, info, this);
   else
     return false;
 }

--- a/src/Device/Driver/LX/Register.cpp
+++ b/src/Device/Driver/LX/Register.cpp
@@ -25,6 +25,7 @@ const struct DeviceRegister lx_driver = {
   DeviceRegister::DECLARE | DeviceRegister::LOGGER |
   DeviceRegister::PASS_THROUGH |
   DeviceRegister::BULK_BAUD_RATE |
-  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS |
+  DeviceRegister::RECEIVE_POLAR | DeviceRegister::SEND_POLAR,
   LXCreateOnPort,
 };

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -656,7 +656,15 @@ NMEAParser::RMZ(NMEAInputLine &line, NMEAInfo &info)
          altitude above 1013.25 hPa - since the don't have a "FLARM"
          device driver, we use the auto-detected "isFlarm" flag
          here */
+      info.igc_pressure_altitude = value;
+      info.igc_pressure_altitude_available.Update(info.clock);
       info.ProvideWeakPressureAltitude(value);
+      if (!info.pressure_altitude_weak)
+        info.igc_pressure_altitude_available.Clear();
+
+      /* One parsed value: logger igc + weak pressure_altitude; strong pressure
+         skips weak (see NMEAInfo::ProvidePressureAltitude). Complement merge:
+         first valid igc wins across devices. */
 
       /* when a FLARM gets detected too late, the previous call to
          this function may have filled the PGRMZ value into

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -235,6 +235,36 @@ CanPassThrough(const DataField &df) noexcept
   return driver->HasPassThrough();
 }
 
+[[gnu::pure]]
+static bool
+CanReceivePolar(const DataField &df) noexcept
+{
+  const char *driver_name = df.GetAsString();
+  if (driver_name == nullptr)
+    return false;
+
+  const struct DeviceRegister *driver = FindDriverByName(driver_name);
+  if (driver == nullptr)
+    return false;
+
+  return driver->CanReceivePolar();
+}
+
+[[gnu::pure]]
+static bool
+CanSendPolar(const DataField &df) noexcept
+{
+  const char *driver_name = df.GetAsString();
+  if (driver_name == nullptr)
+    return false;
+
+  const struct DeviceRegister *driver = FindDriverByName(driver_name);
+  if (driver == nullptr)
+    return false;
+
+  return driver->CanSendPolar();
+}
+
 void
 DeviceEditWidget::UpdateVisibilities() noexcept
 {
@@ -275,12 +305,17 @@ DeviceEditWidget::UpdateVisibilities() noexcept
                 can_send);
   SetRowVisible(SendPosition, DeviceConfig::UsesDriver(type) &&
                 can_send_position);
-  SetRowVisible(PolarSyncMode, DeviceConfig::UsesDriver(type) &&
-                (can_receive || can_send));
-  if (can_receive || can_send) {
+  const bool can_receive_polar = CanReceivePolar(GetDataField(Driver));
+  const bool can_send_polar = CanSendPolar(GetDataField(Driver));
+  const bool polar_row_applicable = DeviceConfig::UsesDriver(type) &&
+                                    (can_receive_polar || can_send_polar);
+  /* Hide when the driver does not register polar receive/send capability. */
+  SetRowAvailable(PolarSyncMode, polar_row_applicable);
+  SetRowVisible(PolarSyncMode, polar_row_applicable);
+  if (can_receive_polar || can_send_polar) {
     auto &polar_df = (DataFieldEnum &)GetDataField(PolarSyncMode);
     const auto prev = polar_df.GetValue();
-    FillPolarSync(polar_df, can_receive, can_send);
+    FillPolarSync(polar_df, can_receive_polar, can_send_polar);
     polar_df.SetValue(prev);
   }
   SetRowAvailable(K6Bt, maybe_bluetooth);
@@ -396,15 +431,15 @@ DeviceEditWidget::Prepare(ContainerWindow &parent,
 
   DataFieldEnum *polar_sync_df = new DataFieldEnum(this);
   FillPolarSync(*polar_sync_df,
-                CanReceiveSettings(*driver_df),
-                CanSendSettings(*driver_df));
+                CanReceivePolar(*driver_df),
+                CanSendPolar(*driver_df));
   polar_sync_df->SetValue(config.polar_sync);
   Add(_("Polar sync"),
-      _("Synchronize the glide polar between XCSoar and the device. "
-        "'Receive' adopts the polar from the device (e.g. for club "
-        "gliders). 'Send' pushes XCSoar's polar to the device."),
+      _("Synchronize the glide polar between XCSoar and the device "
+        "(LXNAV varios). 'Receive' adopts the polar from the device "
+        "(e.g. for club gliders). 'Send' pushes XCSoar's polar to the "
+        "device."),
       polar_sync_df);
-  SetExpertRow(PolarSyncMode);
 
   AddBoolean("K6Bt",
              _("Whether you use a K6Bt to connect the device."),
@@ -529,8 +564,8 @@ DeviceEditWidget::Save(bool &_changed) noexcept
     if (CanSendPosition(GetDataField(Driver)))
       changed |= SaveValue(SendPosition, config.send_position);
 
-    if (CanReceiveSettings(GetDataField(Driver)) ||
-        CanSendSettings(GetDataField(Driver)))
+    if (CanReceivePolar(GetDataField(Driver)) ||
+        CanSendPolar(GetDataField(Driver)))
       changed |= SaveValueEnum(PolarSyncMode, config.polar_sync);
 
     if (CanPassThrough(GetDataField(Driver))) {

--- a/src/InfoBoxes/Content/Altitude.cpp
+++ b/src/InfoBoxes/Content/Altitude.cpp
@@ -8,9 +8,12 @@
 #include "InfoBoxes/Panel/AltitudeInfo.hpp"
 #include "InfoBoxes/Panel/AltitudeSimulator.hpp"
 #include "InfoBoxes/Panel/AltitudeSetup.hpp"
+#include "NMEA/Info.hpp"
 #include "Units/Units.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+
+#include <optional>
 
 /*
  * Subpart callback function pointers
@@ -31,6 +34,37 @@ const InfoBoxPanel *
 InfoBoxContentAltitude::GetDialogContent() noexcept
 {
   return altitude_infobox_panels;
+}
+
+namespace {
+
+/**
+ * Logger / IGC pressure or ISA pressure altitude only (no QNH baro, no GPS).
+ */
+[[gnu::pure]] std::optional<double>
+IgcOrIsaPressureAltitudeOrInvalid(const NMEAInfo &basic) noexcept
+{
+  if (basic.igc_pressure_altitude_available)
+    return basic.igc_pressure_altitude;
+  if (basic.pressure_altitude_available)
+    return basic.pressure_altitude;
+  return std::nullopt;
+}
+
+} // namespace
+
+void
+UpdateInfoBoxAltitudeIGC(InfoBoxData &data) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  const auto a = IgcOrIsaPressureAltitudeOrInvalid(basic);
+  if (!a) {
+    data.SetInvalid();
+    return;
+  }
+
+  data.SetValueFromAltitude(*a);
+  data.SetCommentFromAlternateAltitude(*a);
 }
 
 void

--- a/src/InfoBoxes/Content/Altitude.hpp
+++ b/src/InfoBoxes/Content/Altitude.hpp
@@ -16,6 +16,9 @@ public:
 void
 UpdateInfoBoxAltitudeNav(InfoBoxData &data) noexcept;
 
+void
+UpdateInfoBoxAltitudeIGC(InfoBoxData &data) noexcept;
+
 class InfoBoxContentAltitudeGPS : public InfoBoxContentAltitude
 {
 public:

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1171,6 +1171,15 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentHome>::Create,
   },
 
+  // e_AltitudeIGC
+  {
+    N_("Altitude IGC"),
+    N_("Alt IGC"),
+    N_("Logger pressure altitude when the device provides it (igc_pressure_altitude), otherwise ISA pressure altitude only (1013.25 hPa; not QNH-corrected). Does not show barometric AMSL or GPS height — use other InfoBoxes for navigation."),
+    UpdateInfoBoxAltitudeIGC,
+    altitude_infobox_panels,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -151,6 +151,7 @@ namespace InfoBoxFactory
     e_Alternate_2_AltDiff, /* Arrival altitude at the second-best alternate landing location relative to the safety arrival height */
     /* 130 */
     e_Home, /* Combined home waypoint infobox: shows waypoint name, arrival altitude diff, and distance */
+    e_AltitudeIGC, /* Logger or ISA pressure altitude only (no QNH baro / GPS) */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -425,6 +425,12 @@ struct NMEAInfo {
    * the previous altitude was not present or the same/lower priority.
    */
   constexpr void ProvidePressureAltitude(double value) noexcept {
+    /* Replacing weak pressure (e.g. FLARM $PGRMZ) with strong pressure clears
+       the FLARM igc mirror so IGCFix does not prefer stale igc_pressure_altitude.
+       Logger igc from another sentence (e.g. $PLXVS) can be applied after. */
+    if (pressure_altitude_available && pressure_altitude_weak)
+      igc_pressure_altitude_available.Clear();
+
     pressure_altitude = value;
     pressure_altitude_weak = false;
     pressure_altitude_available.Update(clock);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -2021,6 +2021,8 @@ TestVega()
   ok1(parser.ParseLine("$PGRMZ,2447,F,2*0F", nmea_info));
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 745.845));
+  ok1(nmea_info.igc_pressure_altitude_available);
+  ok1(equals(nmea_info.igc_pressure_altitude, nmea_info.pressure_altitude));
 
   ok1(device->ParseNMEA("$PDSWC,0,1002000,100,115*54", nmea_info));
   ok1(nmea_info.settings.mac_cready_available);
@@ -2038,11 +2040,13 @@ TestVega()
   ok1(!nmea_info.baro_altitude_available);
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 762));
+  ok1(!nmea_info.igc_pressure_altitude_available);
 
   /* parse $PGRMZ again, it should be ignored */
   ok1(parser.ParseLine("$PGRMZ,2447,F,2*0F", nmea_info));
   ok1(nmea_info.pressure_altitude_available);
   ok1(equals(nmea_info.pressure_altitude, 762));
+  ok1(!nmea_info.igc_pressure_altitude_available);
 
   delete device;
 }
@@ -2897,7 +2901,7 @@ int main()
   SetSingleDataPath(data_path);
   CreateDataPath();
 
-  plan_tests(1032 /* drivers */ + 29 /* PFLAU extended */
+  plan_tests(1036 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 107 /* LXNav protocol 1.05 */


### PR DESCRIPTION
## Summary

Replaces #2459 (same FLARM logger + Altitude IGC intent; branch rebased/extended).

### FLARM / IGC
- **`$PGRMZ`** (when FLARM detected): **`igc_pressure_altitude`** + weak **`pressure_altitude`**; clear **`igc`** when strong pressure ignores the sentence or **`ProvidePressureAltitude`** replaces weak pressure.
- **`Altitude IGC`** InfoBox: **`igc_pressure_altitude`** when available, else **ISA `pressure_altitude` only** (no QNH baro / GPS).

### Other commits on this branch
- **Air Control Display**: active COM via standby / CHN2 workaround (#2457 context).
- **ApplyExternalSettings**: forward external QNH to all devices.
- **Polar sync**: UI/driver gating on registered polar capability + DeviceEditWidget tweaks.

## Related

- Supersedes **#2459**
- Docs discussion: **#2458**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polar synchronization limited to drivers that advertise polar support
  * Added "Altitude IGC" info box showing logger or ISA pressure altitude
  * Air-control display: active/standby COM swap using cached standby frequency

* **Bug Fixes**
  * QNH updates now propagate immediately to capable devices
  * Polar sync no longer applied to drivers that don't support it

* **Tests**
  * Updated driver tests to cover FLARM/pressure-altitude behavior and expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->