### PR TITLE
InfoBoxes/Content/Places: Add Active Waypoint InfoBox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -43,6 +43,9 @@ Version 7.45 - not yet released
     (Mountain Top/Pass, Bridge, Tunnel, Tower, Power Plant, Obstacle,
     Thermal Hotspot, Marker, VOR, NDB, Dam, Castle, Intersection,
     Reporting Point, PG Take Off / Landing Zone) #2485
+  - infoboxen: new "Active Waypoint" InfoBox (next task waypoint, or Goto
+    waypoint when no task is loaded; shows name, arrival height above safety,
+    and distance; tap to pick a different task leg or set a new Goto)
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -240,7 +240,9 @@ altitude difference relative to the safety arrival height, and distance. The
 active waypoint is the next task waypoint when an ordered task is loaded, or
 the Goto waypoint otherwise. Tap to choose a different waypoint: when a task is
 loaded, selecting a task waypoint advances the active task point to that leg;
-without a task, the selection becomes the new Goto.}
+without a task, the selection becomes the new Goto. If a task is loaded and
+you select a non-task waypoint from the list, the selection becomes the new
+Goto.}
 
 
 %%%%%%%%%%%

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -235,6 +235,12 @@ relative to the safety arrival height.}
 \ibi{Home}{Home}{Displays the home waypoint name, arrival altitude difference
 relative to the safety arrival height, and distance to the home waypoint. Tap to
 select or change the home waypoint.}
+\ibi{Active Waypoint}{Active WP}{Displays the active waypoint name, arrival
+altitude difference relative to the safety arrival height, and distance. The
+active waypoint is the next task waypoint when an ordered task is loaded, or
+the Goto waypoint otherwise. Tap to choose a different waypoint: when a task is
+loaded, selecting a task waypoint advances the active task point to that leg;
+without a task, the selection becomes the new Goto.}
 
 
 %%%%%%%%%%%

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -23,12 +23,19 @@ class OrderedTask;
  * state was left by the previous invocation, except the name field
  * which is always cleared.  Used by ``event=GotoLookup <misc>`` to
  * jump straight to a category.
+ *
+ * @param prepopulate_with_task If true and @p ordered_task is non-null,
+ * open the list pre-populated with the task's waypoints in task order
+ * (with a leading "Choose a filter" prompt row), instead of the
+ * filter-driven full database.  Used by the Active Waypoint InfoBox
+ * tap action.
  */
 WaypointPtr
 ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &location,
                        OrderedTask *ordered_task = nullptr,
                        unsigned ordered_task_index = 0,
-                       std::optional<TypeFilter> initial_type = std::nullopt);
+                       std::optional<TypeFilter> initial_type = std::nullopt,
+                       bool prepopulate_with_task = false);
 void
 ShowWaypointListPersistentDialog(
   const GeoPoint &location, bool allow_navigation = true,

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -20,6 +20,8 @@
 #include "Waypoint/WaypointListBuilder.hpp"
 #include "Waypoint/WaypointFilter.hpp"
 #include "Waypoint/Waypoints.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "util/StringPointer.hxx"
 #include "util/AllocatedString.hxx"
@@ -166,18 +168,21 @@ private:
   Angle last_heading;
   OrderedTask *const ordered_task;
   const unsigned ordered_task_index;
+  const bool prepopulate_with_task;
 
 public:
   WaypointListWidget(Waypoints &_way_points, WndForm &_dialog,
                      WaypointFilterWidget &_filter_widget,
                      GeoPoint _location, Angle _heading,
                      OrderedTask *_ordered_task,
-                     unsigned _ordered_task_index)
+                     unsigned _ordered_task_index,
+                     bool _prepopulate_with_task)
     :way_points(_way_points), dialog(_dialog),
      filter_widget(_filter_widget),
      location(_location), last_heading(_heading),
      ordered_task(_ordered_task),
-     ordered_task_index(_ordered_task_index) {}
+     ordered_task_index(_ordered_task_index),
+     prepopulate_with_task(_prepopulate_with_task) {}
 
   void UpdateList();
 
@@ -234,7 +239,7 @@ public:
                                GeoPoint _location, Angle _heading,
                                bool _allow_navigation, bool _allow_edit)
     :WaypointListWidget(_way_points, _dialog, _filter_widget, _location, _heading,
-                        nullptr, 0),
+                        nullptr, 0, false),
      allow_navigation(_allow_navigation), allow_edit(_allow_edit) {}
 
   void OnWaypointListEnter() override;
@@ -351,6 +356,16 @@ FillLastUsedList(WaypointList &list,
   }
 }
 
+static void
+FillTaskWaypointsList(WaypointList &list, const OrderedTask &task)
+{
+  for (unsigned i = 0; i < task.TaskSize(); ++i) {
+    auto wp = task.GetPoint(i).GetWaypointPtr();
+    if (wp != nullptr)
+      list.emplace_back(std::move(wp));
+  }
+}
+
 
 void
 WaypointListWidget::UpdateList()
@@ -360,6 +375,9 @@ WaypointListWidget::UpdateList()
   if (dialog_state.type_index == TypeFilter::LAST_USED)
     FillLastUsedList(items, LastUsedWaypoints::GetList(),
                      way_points);
+  else if (prepopulate_with_task && ordered_task != nullptr &&
+           !dialog_state.IsDefined())
+    FillTaskWaypointsList(items, *ordered_task);
   else
     FillList(items, way_points, location, last_heading,
              dialog_state,
@@ -603,8 +621,10 @@ WaypointListWidget::OnGPSUpdate([[maybe_unused]] const MoreData &basic)
 
 WaypointPtr
 ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
-                       OrderedTask *_ordered_task, unsigned _ordered_task_index,
-                       std::optional<TypeFilter> initial_type)
+                       OrderedTask *_ordered_task,
+                       unsigned _ordered_task_index,
+                       std::optional<TypeFilter> initial_type,
+                       bool _prepopulate_with_task)
 {
   const DialogLook &look = UIGlobals::GetDialogLook();
 
@@ -638,7 +658,8 @@ ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
   auto list_widget =
     std::make_unique<WaypointListWidget>(waypoints, dialog, filter_widget,
                                          _location, heading,
-                                         _ordered_task, _ordered_task_index);
+                                         _ordered_task, _ordered_task_index,
+                                         _prepopulate_with_task);
   const auto &list_widget_ = *list_widget;
 
   filter_widget.SetListener(list_widget.get());

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -660,7 +660,7 @@ ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
 
   const Angle heading = CommonInterface::Basic().attitude.heading;
 
-  dialog_state.name.clear();
+  dialog_state = {};
 
   /* When the caller forces an initial Type filter (e.g. via
      ``event=GotoLookup recent``), also reset the other filter

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -169,6 +169,7 @@ private:
   OrderedTask *const ordered_task;
   const unsigned ordered_task_index;
   const bool prepopulate_with_task;
+  bool has_filter_prompt_row = false;
 
 public:
   WaypointListWidget(Waypoints &_way_points, WndForm &_dialog,
@@ -189,9 +190,17 @@ public:
   virtual void OnWaypointListEnter();
 
   WaypointPtr GetCursorObject() const {
-    return items.empty()
-      ? nullptr
-      : items[GetList().GetCursorIndex()].waypoint;
+    if (items.empty())
+      return nullptr;
+    unsigned i = GetList().GetCursorIndex();
+    if (has_filter_prompt_row) {
+      if (i == 0)
+        return nullptr;
+      --i;
+    }
+    if (i >= items.size())
+      return nullptr;
+    return items[i].waypoint;
   }
 
   /* virtual methods from class Widget */
@@ -383,10 +392,15 @@ WaypointListWidget::UpdateList()
              dialog_state,
              ordered_task, ordered_task_index);
 
+  has_filter_prompt_row = prepopulate_with_task && ordered_task != nullptr &&
+                          !dialog_state.IsDefined() && !items.empty();
+
   auto &list = GetList();
-  list.SetLength(std::max(1u, (unsigned)items.size()));
+  const unsigned extra = has_filter_prompt_row ? 1u : 0u;
+  list.SetLength(std::max(1u, (unsigned)items.size() + extra));
   list.SetOrigin(0);
-  list.SetCursorIndex(0);
+  // Skip the prompt row by default so the cursor lands on the first task wp.
+  list.SetCursorIndex(has_filter_prompt_row ? 1u : 0u);
   list.Invalidate();
 }
 
@@ -563,7 +577,15 @@ WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     return;
   }
 
-  assert(i < items.size());
+  if (has_filter_prompt_row) {
+    if (i == 0) {
+      // prompt row prepended above task waypoints
+      row_renderer.DrawFirstRow(canvas, rc,
+                                _("Choose a filter or click here"));
+      return;
+    }
+    --i;
+  }
 
   const struct WaypointListItem &info = items[i];
 
@@ -577,10 +599,18 @@ WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 void
 WaypointListWidget::OnWaypointListEnter()
 {
-  if (!items.empty())
-    dialog.SetModalResult(mrOK);
-  else
+  if (items.empty()) {
     filter_widget.GetControl(NAME).BeginEditing();
+    return;
+  }
+
+  if (has_filter_prompt_row && GetList().GetCursorIndex() == 0) {
+    // user activated the leading "Choose a filter" prompt row
+    filter_widget.GetControl(NAME).BeginEditing();
+    return;
+  }
+
+  dialog.SetModalResult(mrOK);
 }
 
 void

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1195,6 +1195,14 @@ static constexpr MetaData meta_data[] = {
     altitude_infobox_panels,
   },
 
+  // e_ActiveWaypoint
+  {
+    N_("Active Waypoint"),
+    N_("Active WP"),
+    N_("Active waypoint: shows the next task waypoint when an ordered task is loaded, otherwise the Goto waypoint. Displays the waypoint name, arrival altitude difference relative to the safety arrival height, and distance. Click to choose a different waypoint (a task waypoint to skip to that leg, or any waypoint to set as Goto when no task is loaded)."),
+    IBFHelper<InfoBoxContentActiveWaypoint>::Create,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -16,9 +16,12 @@
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
+#include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
+#include "Task/ProtectedTaskManager.hpp"
 #include "Waypoint/WaypointGlue.hpp"
 #include "Protection.hpp"
 #include "Profile/Current.hpp"
@@ -149,6 +152,106 @@ InfoBoxContentHome::HandleClick() noexcept
   }
 
   Profile::Save();
+  return true;
+}
+
+static GlideResult
+ComputeActiveWaypointGlide(const MoreData &basic,
+                           const ComputerSettings &settings,
+                           const DerivedInfo &calculated,
+                           const Waypoint &waypoint) noexcept
+{
+  const GlideState glide_state(
+    basic.location.DistanceBearing(waypoint.location),
+    waypoint.elevation + settings.task.safety_height_arrival,
+    basic.nav_altitude,
+    calculated.GetWindOrZero());
+
+  return MacCready::Solve(settings.task.glide,
+                          settings.polar.glide_polar_task,
+                          glide_state);
+}
+
+void
+InfoBoxContentActiveWaypoint::Update(InfoBoxData &data) noexcept
+{
+  const MoreData &basic = CommonInterface::Basic();
+  const ComputerSettings &settings = CommonInterface::GetComputerSettings();
+  const DerivedInfo &calculated = CommonInterface::Calculated();
+
+  data.SetTitle(_("Active WP"));
+
+  const auto waypoint =
+    (backend_components && backend_components->protected_task_manager)
+    ? backend_components->protected_task_manager->GetActiveWaypoint()
+    : nullptr;
+
+  if (!waypoint ||
+      !basic.location_available ||
+      !basic.NavAltitudeAvailable() ||
+      !settings.polar.glide_polar_task.IsValid()) {
+    data.SetInvalid();
+    data.SetCommentInvalid();
+    return;
+  }
+
+  data.SetTitle(waypoint->name.c_str());
+
+  const GlideResult result =
+    ComputeActiveWaypointGlide(basic, settings, calculated, *waypoint);
+  data.SetValueFromArrival(result.SelectAltitudeDifference(settings.task.glide));
+  data.SetCommentFromDistance(basic.location.DistanceS(waypoint->location));
+}
+
+bool
+InfoBoxContentActiveWaypoint::HandleClick() noexcept
+{
+  if (!data_components || !data_components->waypoints)
+    return false;
+  if (!backend_components || !backend_components->protected_task_manager)
+    return false;
+
+  auto &waypoints = *data_components->waypoints;
+  auto &ptm = *backend_components->protected_task_manager;
+  const GeoPoint location = CommonInterface::Basic().location;
+
+  std::unique_ptr<OrderedTask> task_clone = ptm.TaskClone();
+  const bool has_ordered_task = task_clone && task_clone->TaskSize() > 0;
+  const unsigned ordered_task_index =
+    has_ordered_task ? task_clone->GetActiveIndex() : 0;
+
+  WaypointPtr selected;
+  try {
+    selected = ShowWaypointListDialog(waypoints, location,
+                                      has_ordered_task ? task_clone.get()
+                                                       : nullptr,
+                                      ordered_task_index);
+  } catch (...) {
+    return false;
+  }
+  if (!selected)
+    return true;
+
+  if (has_ordered_task) {
+    int target_index = -1;
+    for (unsigned i = 0; i < task_clone->TaskSize(); ++i) {
+      if (task_clone->GetPoint(i).GetWaypoint() == *selected) {
+        target_index = (int)i;
+        break;
+      }
+    }
+
+    if (target_index >= 0 &&
+        (unsigned)target_index != ordered_task_index)
+      ptm.IncrementActiveTaskPoint(target_index - (int)ordered_task_index);
+  } else {
+    {
+      ScopeSuspendAllThreads suspend;
+      waypoints.EraseTempGoto();
+    }
+    ptm.DoGoto(std::move(selected));
+  }
+
   return true;
 }
 

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -18,9 +18,11 @@
 #include "Engine/Waypoint/Waypoints.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
+#include "Engine/Task/TaskType.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
+#include "Engine/Task/TaskManager.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Waypoint/WaypointGlue.hpp"
 #include "Protection.hpp"
@@ -216,34 +218,51 @@ InfoBoxContentActiveWaypoint::HandleClick() noexcept
   const GeoPoint location = CommonInterface::Basic().location;
 
   std::unique_ptr<OrderedTask> task_clone = ptm.TaskClone();
-  const bool has_ordered_task = task_clone && task_clone->TaskSize() > 0;
-  const unsigned ordered_task_index =
-    has_ordered_task ? task_clone->GetActiveIndex() : 0;
+
+  bool task_mode_ordered = false;
+  unsigned ordered_task_index = 0;
+  {
+    ProtectedTaskManager::Lease lease(ptm);
+    task_mode_ordered = lease->GetMode() == TaskType::ORDERED;
+    if (task_mode_ordered)
+      ordered_task_index = lease->GetActiveTaskPointIndex();
+  }
+
+  const bool prepopulate_with_task = task_mode_ordered && task_clone &&
+                                     task_clone->TaskSize() > 0;
 
   WaypointPtr selected;
   try {
     selected = ShowWaypointListDialog(waypoints, location,
-                                      has_ordered_task ? task_clone.get()
-                                                       : nullptr,
-                                      ordered_task_index);
+                                      prepopulate_with_task ? task_clone.get()
+                                                            : nullptr,
+                                      ordered_task_index,
+                                      std::nullopt,
+                                      prepopulate_with_task);
   } catch (...) {
     return false;
   }
   if (!selected)
     return true;
 
-  if (has_ordered_task) {
-    int target_index = -1;
+  int target_index = -1;
+  if (prepopulate_with_task) {
     for (unsigned i = 0; i < task_clone->TaskSize(); ++i) {
-      if (task_clone->GetPoint(i).GetWaypoint() == *selected) {
+      if (task_clone->GetPoint(i).GetWaypointPtr() == selected) {
         target_index = (int)i;
         break;
       }
     }
+  }
 
-    if (target_index >= 0 &&
-        (unsigned)target_index != ordered_task_index)
-      ptm.IncrementActiveTaskPoint(target_index - (int)ordered_task_index);
+  if (target_index >= 0) {
+    std::unique_ptr<OrderedTask> current_task = ptm.TaskClone();
+    const unsigned current_active_index =
+      (current_task && current_task->TaskSize() > 0)
+        ? current_task->GetActiveIndex()
+        : ordered_task_index;
+    if ((unsigned)target_index != current_active_index)
+      ptm.IncrementActiveTaskPoint(target_index - (int)current_active_index);
   } else {
     {
       ScopeSuspendAllThreads suspend;

--- a/src/InfoBoxes/Content/Places.hpp
+++ b/src/InfoBoxes/Content/Places.hpp
@@ -20,6 +20,13 @@ public:
   bool HandleClick() noexcept override;
 };
 
+class InfoBoxContentActiveWaypoint : public InfoBoxContent
+{
+public:
+  void Update(InfoBoxData &data) noexcept override;
+  bool HandleClick() noexcept override;
+};
+
 void
 UpdateInfoBoxTakeoffDistance(InfoBoxData &data) noexcept;
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -153,6 +153,7 @@ namespace InfoBoxFactory
     e_Home, /* Combined home waypoint infobox: shows waypoint name, arrival altitude diff, and distance */
     e_AltitudeIGC, /* Logger or ISA pressure altitude only (no QNH baro / GPS) */
     e_QNH, /* Current QNH pressure setting; tap to adjust manually */
+    e_ActiveWaypoint, /* Active waypoint: next task WP or Goto; arrival diff and distance */
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
# Active Waypoint Infobox

The Active Waypoint InfoBox collapses those two cases/infoboxes into a single, mode-aware infobox:

 - Always shows the waypoint that actually matters right now — the next task turnpoint when an ordered task is loaded, or the Goto waypoint when there isn't one. The pilot doesn't have to think about which InfoBox is "live" in the current flight mode.
 - One-tap retargeting — tapping the box opens a waypoint picker that does the right thing for the current mode: jump to a different task leg if a task is loaded, or set/replace the Goto otherwise. This removes a multi-step menu dive that pilots currently do in the air.
 - Frees a panel slot — pilots running tight 4- or 6-box layouts no longer need to dedicate two slots to "next/goto" coverage.
 - Reduces in-flight cognitive load — name + arrival-height-above-safety + distance is the canonical "am I going to make it?" triple, presented consistently whether you're flying a task or free-roaming.


<img width="214" height="188" alt="image" src="https://github.com/user-attachments/assets/c6de5f61-65e6-4186-9467-ec955fa09566" />
<img width="850" height="275" alt="image" src="https://github.com/user-attachments/assets/54c7841d-8a8c-4772-9020-616b86815b97" />

## Summary

- New **Active Waypoint** InfoBox in `Places.cpp` (`e_ActiveWaypoint`,
  `InfoBoxContentActiveWaypoint`). Title shows the waypoint name, value
  shows arrival altitude difference relative to the safety arrival
  height, and the comment shows distance. The "active waypoint" is the
  next ordered task waypoint when a task is loaded, or the Goto
  waypoint otherwise — mirrors the unified Home InfoBox layout and
  computes its own glide via a small `ComputeActiveWaypointGlide`
  helper so behavior is consistent across `ORDERED`, `GOTO` and
  `ABORT` task modes.
- Tap to choose a different waypoint:
  - **Task loaded:** dialog opens with the task's waypoints listed in
    task order, with a leading **"Choose a filter or click here"** row
    that focuses the filter input. Selecting a task waypoint advances
    or rewinds the active task point to that leg via
    `IncrementActiveTaskPoint`. Filtering and picking a non-task
    waypoint switches to Goto mode via `DoGoto`.
  - **No task:** dialog opens with the standard filter-driven
    full-database picker. Selection becomes the new Goto.
- `ShowWaypointListDialog` gains an opt-in `prepopulate_with_task`
  parameter (default `false`) so existing callers (e.g. the
  task-point relocate flow in `TaskPointDialog`) are unchanged.
- Docs: new `\ibi{Active Waypoint}{Active WP}{...}` entry in
  `doc/manual/en/ch10_infobox_reference.tex` next to the Home entry,
  and a NEWS bullet under v7.45.

## Test plan

- [x] No task loaded, no Goto: InfoBox title reads "Active Waypoint",
      value/comment invalid.
- [x] No task loaded: tap → full filter picker → select a waypoint →
      InfoBox updates with name / arrival above safety / distance, map
      shows Goto vector.
- [x] Ordered task with ≥3 turnpoints: InfoBox shows the current
      active turnpoint name, arrival diff, distance.
- [x] Tap with task loaded: dialog opens with task waypoints in task
      order, "Choose a filter or click here" row at the top, cursor
      defaulted to the first task waypoint.
- [x] Select a non-active task waypoint → active task point
      advances/rewinds to that leg (verify against the existing "Next
      Waypoint" InfoBox or the task panel).
- [x] Tap the "Choose a filter or click here" row or any filter
      control → list switches to filtered full-database results; the
      prompt row is hidden once filtering is active.
- [x] Pick a non-task waypoint after filtering while a task is loaded
      → switches to Goto mode for that waypoint.
- [x] Existing "Relocate" task-point flow (`OnRelocateClicked` in
      `TaskPointDialog`) is unchanged: no task-waypoint
      pre-population.
- [x] Toggle `safety_height_arrival` (Settings → Glide Computer →
      Safety factors) → arrival diff in the InfoBox shifts by the
      expected amount.
- [x] Build clean: `make TARGET=MACOS app -j$(nproc)` (built locally
      on Apple Silicon with no new warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Active Waypoint" InfoBox showing the next task waypoint (or Goto) name, arrival altitude relative to safety arrival height, and distance.
  * Tapping the InfoBox opens a waypoint picker to advance the active task leg or choose/set a new Goto; the picker can be prepopulated with task waypoints when relevant.

* **Documentation**
  * User manual and release notes updated to describe the Active Waypoint InfoBox and its interaction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->