### PR TITLE
[mockup] Replay: flight-minute seek (sync fixes)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,7 @@
 Version 7.45 - not yet released
+* replay (mockup / experimental — not release-ready)
+  - Replay dialog: seek to a chosen number of minutes after the first fix,
+    restarting the file and applying every merged fix (dense snail trail)
 * devices
   - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
     ISA logger datum; cleared when strong pressure replaces weak pressure or

--- a/src/CalculationThread.cpp
+++ b/src/CalculationThread.cpp
@@ -49,11 +49,8 @@ CalculationThread::SetScreenDistanceMeters(double new_value) noexcept
   screen_distance_meters = new_value;
 }
 
-/**
- * Main loop of the CalculationThread
- */
 void
-CalculationThread::Tick() noexcept
+CalculationThread::RunTickDirect(bool notify_ui) noexcept
 {
 #ifdef HAVE_CPU_FREQUENCY
   const ScopeLockCPU cpu;
@@ -65,7 +62,9 @@ CalculationThread::Tick() noexcept
   {
     const std::lock_guard lock{device_blackboard.mutex};
 
-    gps_updated = device_blackboard.Basic().location_available.Modified(glide_computer.Basic().location_available);
+    gps_updated =
+      device_blackboard.Basic().location_available.Modified(
+        glide_computer.Basic().location_available);
 
     // Copy data from DeviceBlackboard to GlideComputerBlackboard
     glide_computer.ReadBlackboard(device_blackboard.Basic());
@@ -101,14 +100,22 @@ CalculationThread::Tick() noexcept
   }
 
   // if (new GPS data)
-  if (gps_updated || force)
-    // inform map new data is ready
+  if (notify_ui && (gps_updated || force))
     TriggerCalculatedUpdate();
 
   if (do_idle) {
     // do slow calculations last, to minimise latency
     glide_computer.ProcessIdle();
   }
+}
+
+/**
+ * Main loop of the CalculationThread
+ */
+void
+CalculationThread::Tick() noexcept
+{
+  RunTickDirect(true);
 }
 
 void

--- a/src/CalculationThread.hpp
+++ b/src/CalculationThread.hpp
@@ -56,6 +56,12 @@ public:
 
   void ForceTrigger() noexcept;
 
+  /**
+   * Run one calculation cycle synchronously from the main thread while
+   * this worker is suspended (bulk replay seek).
+   */
+  void RunTickDirect(bool notify_ui) noexcept;
+
 protected:
   void Tick() noexcept override;
 };

--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -3,9 +3,11 @@
 
 #include "ReplayDialog.hpp"
 #include "Dialogs/Error.hpp"
+#include "Dialogs/Message.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
+#include "BackendComponents.hpp"
 #include "Components.hpp"
 #include "Replay/Replay.hpp"
 #include "Form/DataField/Base.hpp"
@@ -17,6 +19,7 @@ class ReplayControlWidget final
   enum Controls {
     FILE,
     RATE,
+    FLIGHT_MINUTES,
   };
 
   Replay &replay;
@@ -29,12 +32,14 @@ public:
     dialog.AddButton(_("Start"), [this](){ OnStartClicked(); });
     dialog.AddButton(_("Stop"), [this](){ OnStopClicked(); });
     dialog.AddButton("+10'", [this](){ OnFastForwardClicked(); });
+    dialog.AddButton(_("Seek"), [this](){ OnSeekClicked(); });
   }
 
 private:
   void OnStopClicked() noexcept;
   void OnStartClicked() noexcept;
   void OnFastForwardClicked() noexcept;
+  void OnSeekClicked() noexcept;
 
 public:
   /* virtual methods from class Widget */
@@ -60,6 +65,12 @@ ReplayControlWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   GetDataField(RATE).SetOnModified([this]{
     replay.SetTimeScale(GetValueFloat(RATE));
   });
+
+  AddInteger(_("Flight min"),
+             _("Minutes after the first fix to seek to. Restarts replay "
+               "and applies every fix up to that time."),
+             "%u", "%u",
+             0, 24 * 60, 1, 0);
 }
 
 inline void
@@ -84,6 +95,23 @@ inline void
 ReplayControlWidget::OnFastForwardClicked() noexcept
 {
   replay.FastForward(std::chrono::minutes{10});
+}
+
+inline void
+ReplayControlWidget::OnSeekClicked() noexcept
+{
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return;
+
+  const unsigned minutes =
+    static_cast<unsigned>(GetValueInteger(FLIGHT_MINUTES));
+
+  if (!replay.SeekToFlightElapsedMinutes(
+        minutes, *backend_components->merge_thread,
+        *backend_components->calculation_thread))
+    ShowMessageBox(_("Could not seek replay."), _("Replay"), MB_OK);
 }
 
 void

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -33,10 +33,8 @@ MergeThread::MergeThread(DeviceBlackboard &_device_blackboard,
 }
 
 void
-MergeThread::Process() noexcept
+MergeThread::ProcessUnlocked() noexcept
 {
-  assert(!IsDefined() || IsInside());
-
   device_blackboard.Merge();
 
   const MoreData &basic = device_blackboard.Basic();
@@ -52,7 +50,7 @@ MergeThread::Process() noexcept
 }
 
 void
-MergeThread::Tick() noexcept
+MergeThread::RunMergeCycle(bool notify_triggers) noexcept
 {
   bool gps_updated, calculated_updated;
 
@@ -68,7 +66,7 @@ MergeThread::Tick() noexcept
   {
     const std::lock_guard lock{device_blackboard.mutex};
 
-    Process();
+    ProcessUnlocked();
 
     const MoreData &basic = device_blackboard.Basic();
     const DerivedInfo &calculated = device_blackboard.Calculated();
@@ -84,8 +82,7 @@ MergeThread::Tick() noexcept
       trail_push_vario = (float)basic.netto_vario;
     }
 
-    /* call Driver::OnSensorUpdate() on all devices */
-    if (devices != nullptr)
+    if (notify_triggers && devices != nullptr)
       devices->NotifySensorUpdate(basic);
 
     /* trigger update if gps has become available or dropped out */
@@ -116,17 +113,27 @@ MergeThread::Tick() noexcept
     trail_vario_sink->PushMergeVarioSample(trail_push_time, trail_push_vario);
 
 #ifdef HAVE_PCM_PLAYER
-  if (vario_available)
-    AudioVarioGlue::SetValue(vario);
-  else
-    AudioVarioGlue::NoValue();
+  if (notify_triggers) {
+    if (vario_available)
+      AudioVarioGlue::SetValue(vario);
+    else
+      AudioVarioGlue::NoValue();
+  }
 #endif
 
-  if (gps_updated)
-    TriggerGPSUpdate();
+  if (notify_triggers) {
+    if (gps_updated)
+      TriggerGPSUpdate();
 
-  if (calculated_updated)
-    TriggerCalculatedUpdate();
+    if (calculated_updated)
+      TriggerCalculatedUpdate();
 
-  TriggerVarioUpdate();
+    TriggerVarioUpdate();
+  }
+}
+
+void
+MergeThread::Tick() noexcept
+{
+  RunMergeCycle(true);
 }

--- a/src/MergeThread.hpp
+++ b/src/MergeThread.hpp
@@ -54,9 +54,20 @@ public:
   void FirstRun() noexcept {
     assert(!IsDefined());
 
-    Process();
+    ProcessUnlocked();
   }
 
+  /**
+   * Run one merge cycle synchronously from the main thread while this
+   * worker thread is suspended.  Omits UI/device triggers when false is
+   * passed (bulk replay seek).
+   */
+  void RunMergeCycle(bool notify_triggers) noexcept;
+
+private:
+  void ProcessUnlocked() noexcept;
+
+public:
   /**
    * Throws on error.
    */
@@ -64,9 +75,6 @@ public:
     WorkerThread::Start(suspended);
     SetLowPriority();
   }
-
-private:
-  void Process() noexcept;
 
 protected:
   void Tick() noexcept override;

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -10,11 +10,34 @@
 #include "Logger/Logger.hpp"
 #include "Interface.hpp"
 #include "CatmullRomInterpolator.hpp"
+#include "CalculationThread.hpp"
+#include "Geo/GeoVector.hpp"
+#include "MergeThread.hpp"
+#include "Protection.hpp"
 #include "time/Cast.hxx"
 
 #include <algorithm> // for std::clamp()
 #include <cassert>
 #include <stdexcept>
+
+namespace {
+
+void
+ApplyReplayFix(DeviceBlackboard &device_blackboard,
+               MergeThread &merge_thread,
+               CalculationThread &calculation_thread,
+               const NMEAInfo &fix) noexcept
+{
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+    device_blackboard.SetReplayState() = fix;
+  }
+
+  merge_thread.RunMergeCycle(false);
+  calculation_thread.RunTickDirect(false);
+}
+
+} // namespace
 
 void
 Replay::Stop()
@@ -67,6 +90,117 @@ Replay::Start(Path _path)
   next_data.Reset();
 
   timer.Schedule(std::chrono::milliseconds(100));
+}
+
+bool
+Replay::SeekToFlightElapsedMinutes(unsigned minutes,
+                                    MergeThread &merge_thread,
+                                    CalculationThread &calculation_thread) noexcept
+{
+  constexpr unsigned MAX_MINUTES = 24 * 60;
+  if (minutes > MAX_MINUTES)
+    return false;
+
+  timer.Cancel();
+
+  const AllocatedPath saved_path{GetFilename()};
+
+  try {
+    Stop();
+    Start(saved_path);
+  } catch (...) {
+    return false;
+  }
+
+  timer.Cancel();
+
+  struct ScopedSuspend final {
+    MergeThread &merge_thread;
+    CalculationThread &calculation_thread;
+
+    ScopedSuspend(MergeThread &m, CalculationThread &c) noexcept
+      :merge_thread(m), calculation_thread(c)
+    {
+      calculation_thread.Suspend();
+      merge_thread.Suspend();
+    }
+
+    ~ScopedSuspend() noexcept
+    {
+      merge_thread.Resume();
+      calculation_thread.Resume();
+    }
+  } suspend{merge_thread, calculation_thread};
+
+  next_data.Reset();
+
+  while (!next_data.time_available) {
+    if (!replay->Update(next_data))
+      return false;
+  }
+
+  const TimeStamp anchor = next_data.time;
+  const TimeStamp target_ts =
+    anchor + FloatDuration{(double)minutes * 60.};
+
+  while (next_data.time_available && next_data.time <= target_ts) {
+    ApplyReplayFix(device_blackboard, merge_thread, calculation_thread,
+                   next_data);
+
+    if (cli != nullptr && next_data.time_available)
+      cli->Update(next_data.time, next_data.location,
+                  next_data.gps_altitude, next_data.pressure_altitude);
+
+    if (!replay->Update(next_data))
+      break;
+  }
+
+  virtual_time = target_ts;
+
+  if (cli != nullptr) {
+    while (cli->NeedData(virtual_time)) {
+      if (!replay->Update(next_data))
+        break;
+
+      if (next_data.time_available)
+        cli->Update(next_data.time, next_data.location,
+                    next_data.gps_altitude, next_data.pressure_altitude);
+    }
+
+    if (cli->Ready()) {
+      const CatmullRomInterpolator::Record r =
+        cli->Interpolate(virtual_time);
+      const GeoVector v = cli->GetVector(virtual_time);
+
+      NMEAInfo data = next_data;
+      data.clock = virtual_time;
+      data.alive.Update(data.clock);
+      data.ProvideTime(virtual_time);
+      data.location = r.location;
+      data.location_available.Update(data.clock);
+      data.ground_speed = v.distance;
+      data.ground_speed_available.Update(data.clock);
+      data.track = v.bearing;
+      data.track_available.Update(data.clock);
+      data.gps_altitude = r.gps_altitude;
+      data.gps_altitude_available.Update(data.clock);
+      data.ProvidePressureAltitude(r.baro_altitude);
+      data.ProvideBaroAltitudeTrue(r.baro_altitude);
+
+      ApplyReplayFix(device_blackboard, merge_thread, calculation_thread,
+                     data);
+    }
+  }
+
+  fast_forward = TimeStamp::Undefined();
+  clock.Update();
+
+  CommonInterface::ReadBlackboardBasic(device_blackboard.Basic());
+  TriggerCalculatedUpdate();
+  TriggerVarioUpdate();
+
+  timer.Schedule(std::chrono::milliseconds(100));
+  return true;
 }
 
 bool

--- a/src/Replay/Replay.hpp
+++ b/src/Replay/Replay.hpp
@@ -14,6 +14,8 @@ class Logger;
 class ProtectedTaskManager;
 class AbstractReplay;
 class CatmullRomInterpolator;
+class MergeThread;
+class CalculationThread;
 class Error;
 
 class Replay final
@@ -117,6 +119,15 @@ public:
   TimeStamp GetVirtualTime() const noexcept {
     return virtual_time;
   }
+
+  /**
+   * Restart the current recording and replay synchronously up to the given
+   * number of minutes after the first fix, merging every fix into the
+   * blackboard.
+   */
+  bool SeekToFlightElapsedMinutes(unsigned minutes,
+                                  MergeThread &merge_thread,
+                                  CalculationThread &calculation_thread) noexcept;
 
 private:
   void OnTimer();

--- a/src/lua/Replay.cpp
+++ b/src/lua/Replay.cpp
@@ -57,6 +57,26 @@ l_replay_fastforward(lua_State *L)
 }
 
 static int
+l_replay_seek_to_flight_minutes(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "Invalid parameters");
+
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return luaL_error(L, "Replay seek unavailable");
+
+  const auto minutes = static_cast<unsigned>(luaL_checkinteger(L, 1));
+  const bool ok =
+    backend_components->replay->SeekToFlightElapsedMinutes(
+      minutes, *backend_components->merge_thread,
+      *backend_components->calculation_thread);
+  Lua::Push(L, ok);
+  return 1;
+}
+
+static int
 l_replay_start(lua_State *L)
 {
   if (lua_gettop(L) != 1)
@@ -85,6 +105,7 @@ l_replay_stop([[maybe_unused]] lua_State *L)
 static constexpr struct luaL_Reg settings_funcs[] = {
   {"set_time_scale", l_replay_settimescale},
   {"fast_forward", l_replay_fastforward},
+  {"seek_to_flight_minutes", l_replay_seek_to_flight_minutes},
   {"start", l_replay_start},
   {"stop", l_replay_stop},
   {nullptr, nullptr}


### PR DESCRIPTION
**Mockup / experimental** — for discussion; not release-ready as-is.

Adds replay dialog control + Lua `seek_to_flight_minutes` to restart the recording and apply every fix synchronously (MergeThread / CalculationThread) up to N minutes after the first fix.

NEWS entry marked mockup.

<!-- linked by maintainer triage: Replay seek (mockup) -->
Related to #933
