### PR TITLE
Airspace/AirspaceWarning: Suppress warning triangle for ACK'ed airspaces

### DIFF
--- a/src/Airspace/AirspaceWarningCopy.hpp
+++ b/src/Airspace/AirspaceWarningCopy.hpp
@@ -27,7 +27,8 @@ public:
       ids_inside.checked_append(&as.GetAirspace());
     } else if (as.IsWarning()) {
       ids_warning.checked_append(&as.GetAirspace());
-      locations.checked_append(as.GetSolution().location);
+      if (as.IsAckExpired())
+        locations.checked_append(as.GetSolution().location);
     }
 
     if (!as.IsAckExpired())


### PR DESCRIPTION
This PR fixes a bug where acknowledging an airspace would up to now suppress the warning sound, the message, and the filling - but not the little yellow warning icon at the expected location of incursion.

This is an old bug, so I am not 100% sure whether it is maybe by design. But I do not really see a particular reason why.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed airspace warning behavior to correctly record solution location only when acknowledgment has expired, preventing improper data recording in other warning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->