### PR TITLE
Waypoint search: Type filter cleanup and full CUP type coverage

### DIFF
--- a/.cursor/rules/waypoint-types.mdc
+++ b/.cursor/rules/waypoint-types.mdc
@@ -1,0 +1,44 @@
+---
+description: Where to register a new Waypoint::Type or TypeFilter value across the codebase
+globs:
+  - "src/Engine/Waypoint/Waypoint.hpp"
+  - "src/Waypoint/**"
+  - "src/Renderer/WaypointIconRenderer.cpp"
+  - "src/Look/Waypoint*"
+  - "src/Dialogs/Waypoint/**"
+  - "Data/resources.txt"
+alwaysApply: false
+---
+
+# Waypoint Types
+
+Waypoint type information is duplicated across many sites; the compiler does **not** flag missing cases (the enums have no `default:` fallthrough catch in some sites and most arrays carry no size sentinel). When adding or changing values, walk this checklist or you will silently break round-trip, rendering, or UI.
+
+## Adding a new `Waypoint::Type`
+
+The enum is in `src/Engine/Waypoint/Waypoint.hpp`. Every new value needs:
+
+1. **CUP round-trip** — both directions must agree:
+   - Reader: `src/Waypoint/WaypointReaderSeeYou.cpp` (`case <cup-id>:` → `Waypoint::Type::X`)
+   - Writer: `src/Waypoint/CupWriter.cpp` (`case Waypoint::Type::X:` → `"<cup-id>"sv`)
+2. **Editor dropdown** — `waypoint_types[]` in `src/Dialogs/Waypoint/dlgWaypointEdit.cpp` (`N_("...")` label).
+3. **Details label** — `GetWaypointTypeName()` in `src/Dialogs/Waypoint/WaypointInfoWidget.cpp` (`_("...")` label; **must match** the editor dropdown so po entries are reused).
+4. **Map icon** — only if visually distinct:
+   - `src/Look/WaypointLook.hpp` (declare `Icon foo_icon`)
+   - `src/Look/WaypointLook.cpp` (`foo_icon.LoadResource(IDB_FOO_ALL)`)
+   - `Data/resources.txt` (register `IDB_FOO`)
+   - `src/Renderer/WaypointIconRenderer.cpp` (`case Waypoint::Type::X: return look.foo_icon;`)
+5. **Search filter** — see "Adding a `TypeFilter`" below; the dropdown label must match step 3.
+6. **Visibility threshold** *(rare)* — `src/Projection/MapWindowProjection.cpp` only if the type warrants a non-default scale (e.g. obstacles).
+
+## Adding a `TypeFilter` value
+
+`enum class TypeFilter` lives in `src/Waypoint/WaypointFilter.hpp`. The `static_assert(ARRAY_SIZE(type_filter_choices) == unsigned(TypeFilter::COUNT) - 1, ...)` in `src/Dialogs/Waypoint/WaypointList.cpp` will catch a missing dropdown entry at compile time, but the other sites are silent:
+
+1. Add the value **before `COUNT`** and keep it `< _DYNAMIC_FILE_ID_START` (= 100).
+2. `WaypointFilter::CompareType()` in `src/Waypoint/WaypointFilter.cpp` — add the `case`.
+3. `type_filter_choices[]` in `src/Dialogs/Waypoint/WaypointList.cpp` — add the label (reuse the `GetWaypointTypeName` string verbatim so translations apply).
+
+## Translations
+
+Any new English label introduced in the steps above is exposed via `_()` / `N_()`. Run `make update-po` to refresh `po/*.po` and `po/xcsoar.pot` before committing translation changes (commit them at the **end** of the branch, separately, per `xcsoar-project-rules.mdc`).

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -5,6 +5,18 @@ Version 7.45 - not yet released
     ignores the sentence
 * ui
   - infoboxen: new Altitude IGC InfoBox (logger pressure or ISA pressure only)
+  - waypoint search: Type filter no longer lists the .xcm map archive as a
+    selectable filter when its embedded waypoints are not loaded (e.g. when
+    a separate WPFileList already supplied the database), so the dropdown
+    no longer offers a filter that always yields zero matches #1376
+  - waypoint search: "Recently Used" Type filter entry shows the
+    recently-visited waypoints again; it had been silently aliased to the
+    unrelated "Map file" filter since the multi-file rework (#1994) due to
+    a positional dropdown/enum mismatch
+  - waypoint search: Type filter now lists every CUP waypoint type
+    (Mountain Top/Pass, Bridge, Tunnel, Tower, Power Plant, Obstacle,
+    Thermal Hotspot, Marker, VOR, NDB, Dam, Castle, Intersection,
+    Reporting Point, PG Take Off / Landing Zone) #2485
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -87,7 +87,37 @@ static constexpr TypeFilterChoice type_filter_choices[] = {
   {TypeFilter::USER, "Custom"},
   {TypeFilter::MAP, "Map file"},
   {TypeFilter::LAST_USED, "Recently Used"},
+
+  /* Specific Waypoint::Type filters.  Labels match the strings
+     returned by GetWaypointTypeName() in WaypointInfoWidget so
+     the dropdown matches the "Type" row in the details dialog
+     and reuses existing po entries. */
+  {TypeFilter::MOUNTAIN_TOP, "Mountain Top"},
+  {TypeFilter::MOUNTAIN_PASS, "Mountain Pass"},
+  {TypeFilter::BRIDGE, "Bridge"},
+  {TypeFilter::TUNNEL, "Tunnel"},
+  {TypeFilter::TOWER, "Tower"},
+  {TypeFilter::POWERPLANT, "Power Plant"},
+  {TypeFilter::OBSTACLE, "Transmitter Mast"},
+  {TypeFilter::THERMAL_HOTSPOT, "Thermal hotspot"},
+  {TypeFilter::MARKER, "Marker"},
+  {TypeFilter::VOR, "VOR"},
+  {TypeFilter::NDB, "NDB"},
+  {TypeFilter::DAM, "Dam"},
+  {TypeFilter::CASTLE, "Castle"},
+  {TypeFilter::INTERSECTION, "Intersection"},
+  {TypeFilter::REPORTING_POINT, "Control Point"},
+  {TypeFilter::PG_TAKEOFF, "PG Take Off"},
+  {TypeFilter::PG_LANDING, "PG Landing Zone"},
 };
+
+/* The dropdown table must list every TypeFilter value except
+   FILE (which is only ever set via the dynamic per-file
+   entries inserted in CreateTypeDataField).  Compile-time
+   guard so adding a new TypeFilter value prompts the developer
+   to add a corresponding label here. */
+static_assert(ARRAY_SIZE(type_filter_choices) == unsigned(TypeFilter::COUNT) - 1,
+              "type_filter_choices must cover every TypeFilter value except FILE");
 
 struct WaypointListDialogState
 {

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -59,18 +59,34 @@ static constexpr int direction_filter_items[] = {
   -1, -1, 0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330
 };
 
-static const char *const type_filter_items[] = {
-  "*", "Airport", "Landable",
-  "Turnpoint", 
-  "Start", 
-  "Finish", 
-  "Left FAI Triangle",
-  "Right FAI Triangle",
-  "Custom",
-  // File entries are dynamically added in CreateTypeDataField
-  "Map file",
-  "Recently Used",
-  nullptr
+/* Static dropdown entries for the Type filter, indexed by their
+   own TypeFilter id rather than by array position so the layout
+   of the enum and the layout of the dropdown can evolve
+   independently.  TypeFilter::FILE is intentionally absent --
+   that filter is only meaningful with a concrete file_num and
+   is fed into the dropdown by the dynamic per-file entries
+   added inside CreateTypeDataField (IDs >= _DYNAMIC_FILE_ID_START).
+   TypeFilter::MAP is included here but only added to the
+   dropdown when at least one MAP-origin waypoint is loaded
+   (issue #1376), and its label is replaced with the actual
+   .xcm filename when available. */
+struct TypeFilterChoice {
+  TypeFilter id;
+  const char *label;
+};
+
+static constexpr TypeFilterChoice type_filter_choices[] = {
+  {TypeFilter::ALL, "*"},
+  {TypeFilter::AIRPORT, "Airport"},
+  {TypeFilter::LANDABLE, "Landable"},
+  {TypeFilter::TURNPOINT, "Turnpoint"},
+  {TypeFilter::START, "Start"},
+  {TypeFilter::FINISH, "Finish"},
+  {TypeFilter::FAI_TRIANGLE_LEFT, "Left FAI Triangle"},
+  {TypeFilter::FAI_TRIANGLE_RIGHT, "Right FAI Triangle"},
+  {TypeFilter::USER, "Custom"},
+  {TypeFilter::MAP, "Map file"},
+  {TypeFilter::LAST_USED, "Recently Used"},
 };
 
 struct WaypointListDialogState
@@ -377,48 +393,52 @@ static DataField *
 CreateTypeDataField(DataFieldListener *listener,
                     const Waypoints &waypoints)
 {
+  constexpr unsigned DYNAMIC_FILE_ID_START =
+    (unsigned)TypeFilter::_DYNAMIC_FILE_ID_START;
+
   DataFieldEnum *df = new DataFieldEnum(listener);
-  df->addEnumTexts(type_filter_items);
 
-  // Dynamically add file entries based on loaded waypoint files
-  // Use IDs >= _DYNAMIC_FILE_ID_START to encode file index
-  constexpr unsigned DYNAMIC_FILE_ID_START = (unsigned)TypeFilter::_DYNAMIC_FILE_ID_START;
-  
-  const auto paths = Profile::GetMultiplePaths(ProfileKeys::WaypointFileList,
-                                               nullptr);
-  for (size_t i = 0; i < paths.size(); ++i) {
-    const auto &path = paths[i];
-    const auto filename = path.GetBase();
-    if (filename != nullptr) {
-      // Insert before "Map file" entry with unique ID
-      df->addEnumText(filename.c_str(), DYNAMIC_FILE_ID_START + i);
-    }
-  }
-
-  /* Show the map archive (.xcm) filename in place of the
-     generic "Map file" entry only when waypoints from that
+  /* Only show the MAP entry when waypoints from the .xcm
      archive are actually loaded.  WaypointGlue only loads the
      embedded waypoints.cup/waypoints.xcw when no other waypoint
      file produced any result (see WaypointGlue::LoadWaypoints),
-     so a configured .xcm with WPFileList also configured would
-     otherwise advertise a filter that yields zero matches.
-     Issue #1376. */
-  const auto map_path = Profile::map.GetPathBase(ProfileKeys::MapFile);
+     so a configured .xcm alongside a WPFileList would otherwise
+     advertise a filter that yields zero matches (issue #1376).
+     The label is replaced with the actual .xcm filename below. */
   const bool has_map_waypoints =
     std::any_of(waypoints.begin(), waypoints.end(),
                 [](const auto &wp){
                   return wp->origin == WaypointOrigin::MAP;
                 });
-  if (map_path != nullptr && has_map_waypoints)
-    df->replaceEnumText((unsigned)TypeFilter::MAP, map_path.c_str());
+  const auto map_path = Profile::map.GetPathBase(ProfileKeys::MapFile);
 
-  // Set current value based on type_index and file_num
-  unsigned value;
-  if (dialog_state.type_index == TypeFilter::FILE && dialog_state.file_num >= 0) {
-    value = DYNAMIC_FILE_ID_START + dialog_state.file_num;
-  } else {
-    value = (unsigned)dialog_state.type_index;
+  for (const auto &c : type_filter_choices) {
+    if (c.id == TypeFilter::MAP) {
+      if (!has_map_waypoints)
+        continue;
+      df->addEnumText(map_path != nullptr ? map_path.c_str() : c.label,
+                      unsigned(c.id));
+      continue;
+    }
+    df->addEnumText(c.label, unsigned(c.id));
   }
+
+  // Dynamically add file entries based on loaded waypoint files.
+  // IDs >= _DYNAMIC_FILE_ID_START encode the file index.
+  const auto paths = Profile::GetMultiplePaths(ProfileKeys::WaypointFileList,
+                                               nullptr);
+  for (size_t i = 0; i < paths.size(); ++i) {
+    const auto filename = paths[i].GetBase();
+    if (filename != nullptr)
+      df->addEnumText(filename.c_str(), DYNAMIC_FILE_ID_START + i);
+  }
+
+  // Set current value based on type_index and file_num.
+  unsigned value;
+  if (dialog_state.type_index == TypeFilter::FILE && dialog_state.file_num >= 0)
+    value = DYNAMIC_FILE_ID_START + dialog_state.file_num;
+  else
+    value = (unsigned)dialog_state.type_index;
   df->SetValue(value);
 
   return df;

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -374,7 +374,8 @@ CreateDirectionDataField(DataFieldListener *listener, Angle last_heading)
 }
 
 static DataField *
-CreateTypeDataField(DataFieldListener *listener)
+CreateTypeDataField(DataFieldListener *listener,
+                    const Waypoints &waypoints)
 {
   DataFieldEnum *df = new DataFieldEnum(listener);
   df->addEnumTexts(type_filter_items);
@@ -394,9 +395,21 @@ CreateTypeDataField(DataFieldListener *listener)
     }
   }
 
-  // Replace "Map file" text with actual filename if available
+  /* Show the map archive (.xcm) filename in place of the
+     generic "Map file" entry only when waypoints from that
+     archive are actually loaded.  WaypointGlue only loads the
+     embedded waypoints.cup/waypoints.xcw when no other waypoint
+     file produced any result (see WaypointGlue::LoadWaypoints),
+     so a configured .xcm with WPFileList also configured would
+     otherwise advertise a filter that yields zero matches.
+     Issue #1376. */
   const auto map_path = Profile::map.GetPathBase(ProfileKeys::MapFile);
-  if (map_path != nullptr)
+  const bool has_map_waypoints =
+    std::any_of(waypoints.begin(), waypoints.end(),
+                [](const auto &wp){
+                  return wp->origin == WaypointOrigin::MAP;
+                });
+  if (map_path != nullptr && has_map_waypoints)
     df->replaceEnumText((unsigned)TypeFilter::MAP, map_path.c_str());
 
   // Set current value based on type_index and file_num
@@ -418,7 +431,8 @@ WaypointFilterWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   Add(_("Name"), nullptr, CreateNameDataField(*data_components->waypoints, listener));
   Add(_("Distance"), nullptr, CreateDistanceDataField(listener));
   Add(_("Direction"), nullptr, CreateDirectionDataField(listener, last_heading));
-  Add(_("Type"), nullptr, CreateTypeDataField(listener));
+  Add(_("Type"), nullptr,
+      CreateTypeDataField(listener, *data_components->waypoints));
 }
 
 void

--- a/src/Waypoint/WaypointFilter.cpp
+++ b/src/Waypoint/WaypointFilter.cpp
@@ -48,8 +48,44 @@ WaypointFilter::CompareType(const Waypoint &waypoint, TypeFilter type,
   case TypeFilter::LAST_USED:
     return false;
 
+  case TypeFilter::MOUNTAIN_TOP:
+    return waypoint.type == Waypoint::Type::MOUNTAIN_TOP;
+  case TypeFilter::MOUNTAIN_PASS:
+    return waypoint.type == Waypoint::Type::MOUNTAIN_PASS;
+  case TypeFilter::BRIDGE:
+    return waypoint.type == Waypoint::Type::BRIDGE;
+  case TypeFilter::TUNNEL:
+    return waypoint.type == Waypoint::Type::TUNNEL;
+  case TypeFilter::TOWER:
+    return waypoint.type == Waypoint::Type::TOWER;
+  case TypeFilter::POWERPLANT:
+    return waypoint.type == Waypoint::Type::POWERPLANT;
+  case TypeFilter::OBSTACLE:
+    return waypoint.type == Waypoint::Type::OBSTACLE;
+  case TypeFilter::THERMAL_HOTSPOT:
+    return waypoint.type == Waypoint::Type::THERMAL_HOTSPOT;
+  case TypeFilter::MARKER:
+    return waypoint.type == Waypoint::Type::MARKER;
+  case TypeFilter::VOR:
+    return waypoint.type == Waypoint::Type::VOR;
+  case TypeFilter::NDB:
+    return waypoint.type == Waypoint::Type::NDB;
+  case TypeFilter::DAM:
+    return waypoint.type == Waypoint::Type::DAM;
+  case TypeFilter::CASTLE:
+    return waypoint.type == Waypoint::Type::CASTLE;
+  case TypeFilter::INTERSECTION:
+    return waypoint.type == Waypoint::Type::INTERSECTION;
+  case TypeFilter::REPORTING_POINT:
+    return waypoint.type == Waypoint::Type::REPORTING_POINT;
+  case TypeFilter::PG_TAKEOFF:
+    return waypoint.type == Waypoint::Type::PGTAKEOFF;
+  case TypeFilter::PG_LANDING:
+    return waypoint.type == Waypoint::Type::PGLANDING;
+
+  case TypeFilter::COUNT:
   case TypeFilter::_DYNAMIC_FILE_ID_START:
-    // This is a sentinel value, not an actual filter type
+    // Sentinel values, not actual filter types
     gcc_unreachable();
     return false;
   }

--- a/src/Waypoint/WaypointFilter.hpp
+++ b/src/Waypoint/WaypointFilter.hpp
@@ -25,6 +25,31 @@ enum class TypeFilter : uint8_t {
   MAP,
   LAST_USED,
 
+  /* One filter per Waypoint::Type value not already covered by
+     the categorical filters above (AIRFIELD via AIRPORT,
+     OUTLANDING via LANDABLE, NORMAL effectively via TURNPOINT). */
+  MOUNTAIN_TOP,
+  MOUNTAIN_PASS,
+  BRIDGE,
+  TUNNEL,
+  TOWER,
+  POWERPLANT,
+  OBSTACLE,
+  THERMAL_HOTSPOT,
+  MARKER,
+  VOR,
+  NDB,
+  DAM,
+  CASTLE,
+  INTERSECTION,
+  REPORTING_POINT,
+  PG_TAKEOFF,
+  PG_LANDING,
+
+  /** Sentinel: number of real TypeFilter values (excluding the
+      dynamic file ID range below). */
+  COUNT,
+
   /**
    * Reserved range for dynamic entries in UI:
    * IDs 100+ are used for individual waypoint files in the filter dropdown.
@@ -33,7 +58,7 @@ enum class TypeFilter : uint8_t {
   _DYNAMIC_FILE_ID_START = 100,
 };
 
-static_assert((unsigned)TypeFilter::LAST_USED < (unsigned)TypeFilter::_DYNAMIC_FILE_ID_START,
+static_assert((unsigned)TypeFilter::COUNT < (unsigned)TypeFilter::_DYNAMIC_FILE_ID_START,
               "TypeFilter enum values must be < 100 to avoid collision with dynamic file IDs");
 
 struct WaypointFilter


### PR DESCRIPTION
## Summary

Four small commits that fix two related issues in the Waypoint search dialog's **Type** filter dropdown. Each commit compiles standalone and is internally self-contained.

1. **Hide empty map archive filter** -- `WaypointGlue::LoadWaypoints` only loads the embedded `.cup` / `.xcw` from a configured `.xcm` map when no other waypoint file produced any result. The Type dropdown was nevertheless advertising a *Map file* (or the `.xcm` filename) entry regardless of whether any MAP-origin waypoints had actually been loaded -- so users could pick a filter that always yielded zero matches. The entry is now only shown when at least one waypoint with `WaypointOrigin::MAP` is loaded.

2. **Refactor Type dropdown to explicit IDs** -- the dropdown was populated from a positional `const char *const[]` with the dropdown index implicitly assumed to equal the `TypeFilter` enum value. This was off by two: the static array had no entry for `TypeFilter::FILE`, so the *Map file* entry was actually sitting at the FILE slot, and *Recently Used* was at the MAP slot, where it got overwritten with the `.xcm` filename when one was loaded. `TypeFilter::LAST_USED` had no working dropdown entry at all and the existing `FillLastUsedList` code path was therefore unreachable from the UI. Switch to `addEnumText(text, id)` populated from a structured `TypeFilterChoice` table so dropdown layout and enum values can evolve independently. The MAP gating from commit 1 folds into the loop.

3. **Add type filters for all CUP waypoint types** -- 17 new `TypeFilter` values covering Mountain Top/Pass, Bridge, Tunnel, Tower, Power Plant, Obstacle (Transmitter Mast), Thermal Hotspot, Marker, VOR, NDB, Dam, Castle, Intersection, Reporting Point, PG Take Off and PG Landing Zone. These types have existed in `Waypoint::Type` since the cup-2022 format support landed but the search dialog never exposed them, so users could not filter by them. Labels match the strings returned by `GetWaypointTypeName()` in `WaypointInfoWidget` so the dropdown reads the same as the *Type* row in the waypoint details dialog and existing po translations are reused. A `TypeFilter::COUNT` sentinel + `static_assert` on the dropdown choices array catches future enum/dropdown drift at compile time.

4. **`.cursor/rules`: Add waypoint-types checklist** -- adding a new `Waypoint::Type` silently breaks CUP round-trip (`WaypointReaderSeeYou` ↔ `CupWriter`), the editor dropdown, the details label, the icon chain (`WaypointLook` + `resources.txt` + `WaypointIconRenderer`), the search filter, and (rarely) the visibility threshold -- the compiler does not catch the misses (most sites have neither `default:` nor a `COUNT` sentinel). The new rule documents every site so the checklist surfaces automatically when working in any of the relevant directories.

## Issues addressed

- Closes #1376 -- Waypoint Selection Dialog allows `*.XCM` file to be chosen even when its embedded waypoints are not loaded.
- Closes #2485 -- Waypoint search dialog: Type filter is missing most CUP waypoint types.

## Test plan

- [x] Full unit test suite passes (\`Files=82, Tests=9235\`).
- [x] \`make -j\$(nproc) TARGET=UNIX USE_CCACHE=y\` builds clean after each individual commit.
- [x] Manual: open Waypoint search Type dropdown with no \`.xcm\` configured -- *Map file* entry is absent.
- [x] Manual: configure an \`.xcm\` whose embedded waypoints are loaded -- entry shows the actual \`.xcm\` filename.
- [x] Manual: configure an \`.xcm\` alongside a populated WPFileList -- *Map file* entry is absent (no zero-match filter).
- [x] Manual: select *Recently Used* from the dropdown -- recently-used waypoints appear (was previously dead from this UI path).
- [x] Manual: load a CUP file with various non-airfield waypoint types and filter by each new entry (Mountain Top, VOR, Intersection, PG Take Off, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waypoint search type filter now includes comprehensive filtering for all CUP waypoint types, including mountain tops/passes, bridges, tunnels, towers, power plants, obstacles, thermal hotspots, VOR/NDB stations, dams, castles, intersections, reporting points, and PG takeoff/landing sites.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2487)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->