### PR TITLE
Android: Support Nordic UART BLE (e.g. Naviter dongles)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ The following people and organizations have contributed code to XCSoar:
  Roman Stoklasa <rstoki@gmail.com>
  Mateusz Pusz <mateusz.pusz@gmail.com>
  Google Inc., incl. Tom Stepleton <stepleton@google.com>
+ Igor Nazarenko <igor.n.nazarenko@gmail.com>
  James Ward <jamesward22@gmail.com>
  Santiago Berca <santiberca@yahoo.com.ar>
  Winfried Simon <winfried.simon@googlemail.com>

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,7 @@
 Version 7.45 - not yet released
+* android
+  - BLE serial ports now support Nordic UART Service (NUS) in addition to
+    HM-10; the protocol is auto-detected at connection time #2260
 * devices
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,7 +1,10 @@
 Version 7.45 - not yet released
 * android
-  - BLE serial ports now support Nordic UART Service (NUS) in addition to
-    HM-10; the protocol is auto-detected at connection time #2260
+  - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
+    dongles, in addition to HM-10; the protocol is auto-detected at connection
+    time #2260
+  - The saved device port type string for that mode remains ble_hm10 so
+    existing profiles load without migration
 * devices
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481

--- a/android/src/BleSerialPort.java
+++ b/android/src/BleSerialPort.java
@@ -17,15 +17,14 @@ import android.os.Build;
 import android.util.Log;
 
 /**
- * An #AndroidPort implementation for connecting to a HM-10 (Bluetooth
- * LE).
+ * An #AndroidPort implementation for BLE serial bridge devices.
+ * Supports HM-10 and Nordic UART Service, with auto-detection based
+ * on the service UUID.
  */
-public class HM10Port
+public class BleSerialPort
     extends BluetoothGattCallback
     implements AndroidPort  {
   private static final String TAG = "XCSoar";
-
-  private static final int MAX_WRITE_CHUNK_SIZE = 20;
 
   /* Maximum number of milliseconds to wait for disconnected state after
      calling BluetoothGatt.disconnect() in close() */
@@ -36,11 +35,19 @@ public class HM10Port
   private final SafeDestruct safeDestruct = new SafeDestruct();
 
   private BluetoothGatt gatt;
-  private BluetoothGattCharacteristic dataCharacteristic;
+
+  /* For NUS, RX characteristic. For HM-10, RX and TX use the same one. */
+  private BluetoothGattCharacteristic writeCharacteristic;
+
+  private BluetoothGattCharacteristic notifyCharacteristic;
+
+  /* For NUS, stays null. For HM-10, used as a workaround to avoid a
+     race condition. */
   private BluetoothGattCharacteristic deviceNameCharacteristic;
+
   private volatile boolean shutdown = false;
 
-  private final HM10WriteBuffer writeBuffer = new HM10WriteBuffer();
+  private final BleSerialWriteBuffer writeBuffer = new BleSerialWriteBuffer();
 
   private volatile int portState = STATE_LIMBO;
 
@@ -53,20 +60,20 @@ public class HM10Port
    * Private constructor. All fields are initialized to their default values.
    * Use create() factory method to instantiate.
    */
-  private HM10Port() {
+  private BleSerialPort() {
     // All fields are initialized to their default values
   }
 
   /**
-   * Factory method to create and initialize HM10Port.
+   * Factory method to create and initialize BleSerialPort.
    * This pattern avoids the this-escape warning by ensuring
    * the object is fully constructed before passing it to connectGatt().
    */
-  public static HM10Port create(Context context, BluetoothDevice device)
+  public static BleSerialPort create(Context context, BluetoothDevice device)
     throws IOException
   {
-    HM10Port port = new HM10Port();
-    
+    BleSerialPort port = new BleSerialPort();
+
     // Now that the object is fully constructed, we can safely pass it
     BluetoothGatt connectedGatt;
     if (Build.VERSION.SDK_INT >= 23)
@@ -76,42 +83,57 @@ public class HM10Port
 
     if (connectedGatt == null)
       throw new IOException("Bluetooth GATT connect failed");
-    
+
     // Assign to field after successful connection
     port.gatt = connectedGatt;
-    
+
     return port;
   }
 
   private void findCharacteristics() throws Error {
-    dataCharacteristic = null;
+    writeCharacteristic = null;
+    notifyCharacteristic = null;
     deviceNameCharacteristic = null;
 
-    BluetoothGattService service = gatt.getService(BluetoothUuids.HM10_SERVICE);
+    /* Prefer Nordic UART Service if available */
+    BluetoothGattService service = gatt.getService(BluetoothUuids.NORDIC_UART_SERVICE);
     if (service != null) {
-      dataCharacteristic = service.getCharacteristic(BluetoothUuids.HM10_RX_TX_CHARACTERISTIC);
+      writeCharacteristic =
+        service.getCharacteristic(BluetoothUuids.NORDIC_UART_RX_CHARACTERISTIC);
+      notifyCharacteristic =
+        service.getCharacteristic(BluetoothUuids.NORDIC_UART_TX_CHARACTERISTIC);
+      /* deviceNameCharacteristic stays null */
+    } else {
+      service = gatt.getService(BluetoothUuids.HM10_SERVICE);
+      if (service != null) {
+        writeCharacteristic =
+          service.getCharacteristic(BluetoothUuids.HM10_RX_TX_CHARACTERISTIC);
+        notifyCharacteristic = writeCharacteristic;
+
+        BluetoothGattService genericAccess =
+          gatt.getService(BluetoothUuids.GENERIC_ACCESS_SERVICE);
+        if (genericAccess != null) {
+          deviceNameCharacteristic =
+            genericAccess.getCharacteristic(BluetoothUuids.DEVICE_NAME_CHARACTERISTIC);
+        }
+
+        if (deviceNameCharacteristic == null)
+          throw new Error("GATT device name characteristic not found");
+      }
     }
 
-    service = gatt.getService(BluetoothUuids.GENERIC_ACCESS_SERVICE);
-    if (service != null) {
-      deviceNameCharacteristic = service.getCharacteristic(BluetoothUuids.DEVICE_NAME_CHARACTERISTIC);
-    }
-
-    if (dataCharacteristic == null)
-      throw new Error("HM10 data characteristic not found");
-
-    if (deviceNameCharacteristic == null)
-      throw new Error("GATT device name characteristic not found");
+    if (writeCharacteristic == null || notifyCharacteristic == null)
+      throw new Error("BLE serial service not found");
   }
 
   private void setupCharacteristics() throws Error {
     findCharacteristics();
 
-    if (!gatt.setCharacteristicNotification(dataCharacteristic, true))
+    if (!gatt.setCharacteristicNotification(notifyCharacteristic, true))
       throw new Error("Could not enable GATT characteristic notification");
 
     BluetoothGattDescriptor descriptor =
-      dataCharacteristic.getDescriptor(BluetoothUuids.CLIENT_CHARACTERISTIC_CONFIGURATION);
+      notifyCharacteristic.getDescriptor(BluetoothUuids.CLIENT_CHARACTERISTIC_CONFIGURATION);
     descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
     gatt.writeDescriptor(descriptor);
     portState = STATE_READY;
@@ -127,7 +149,8 @@ public class HM10Port
         if (!gatt.discoverServices())
           throw new Error("Discovering GATT services request failed");
       } else {
-        dataCharacteristic = null;
+        writeCharacteristic = null;
+        notifyCharacteristic = null;
         deviceNameCharacteristic = null;
 
         if ((BluetoothProfile.STATE_DISCONNECTED == newState) && !shutdown &&
@@ -169,14 +192,14 @@ public class HM10Port
   @Override
   public void onCharacteristicRead(BluetoothGatt gatt,
       BluetoothGattCharacteristic characteristic, int status) {
-    writeBuffer.beginWriteNextChunk(gatt, dataCharacteristic);
+    writeBuffer.beginWriteNextChunk(gatt, writeCharacteristic);
   }
 
   @Override
   public void onCharacteristicWrite(BluetoothGatt gatt,
       BluetoothGattCharacteristic characteristic, int status) {
     if (BluetoothGatt.GATT_SUCCESS == status) {
-      writeBuffer.beginWriteNextChunk(gatt, dataCharacteristic);
+      writeBuffer.beginWriteNextChunk(gatt, writeCharacteristic);
     } else {
       Log.e(TAG, "GATT characteristic write failed");
       writeBuffer.setError();
@@ -186,8 +209,8 @@ public class HM10Port
   @Override
   public void onCharacteristicChanged(BluetoothGatt gatt,
       BluetoothGattCharacteristic characteristic) {
-    if ((dataCharacteristic != null) &&
-        (dataCharacteristic.getUuid().equals(characteristic.getUuid()))) {
+    if ((notifyCharacteristic != null) &&
+        (notifyCharacteristic.getUuid().equals(characteristic.getUuid()))) {
       if (listener != null && safeDestruct.increment()) {
         try {
           byte[] data = characteristic.getValue();
@@ -287,10 +310,9 @@ public class HM10Port
     if (portState != STATE_READY)
       return 0;
 
-    assert(dataCharacteristic != null);
-    assert(deviceNameCharacteristic != null);
+    assert(writeCharacteristic != null);
 
-    return writeBuffer.write(gatt, dataCharacteristic,
+    return writeBuffer.write(gatt, writeCharacteristic,
                              deviceNameCharacteristic,
                              data, length);
   }

--- a/android/src/BleSerialPort.java
+++ b/android/src/BleSerialPort.java
@@ -134,6 +134,10 @@ public class BleSerialPort
 
     BluetoothGattDescriptor descriptor =
       notifyCharacteristic.getDescriptor(BluetoothUuids.CLIENT_CHARACTERISTIC_CONFIGURATION);
+    if (descriptor == null) {
+      Log.e(TAG, "BLE notify characteristic missing CCCD descriptor");
+      throw new Error("GATT client characteristic configuration descriptor not found");
+    }
     descriptor.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
     gatt.writeDescriptor(descriptor);
     portState = STATE_READY;

--- a/android/src/BleSerialWriteBuffer.java
+++ b/android/src/BleSerialWriteBuffer.java
@@ -12,17 +12,17 @@ import android.os.Build;
 import android.util.Log;
 
 /**
- * This class helps with writing chunked data to a Bluetooth LE HM10
- * device.
+ * This class helps with writing chunked data to a Bluetooth LE serial
+ * bridge device (HM-10 or Nordic UART Service).
  */
-final class HM10WriteBuffer {
+final class BleSerialWriteBuffer {
   private static final String TAG = "XCSoar";
 
   private static final int BUFFER_SIZE = 256;
 
   /**
    * The current mtu.  May be updated by
-   * BluetoothGattCallback.onMtuChanged() (via class HM10Port).
+   * BluetoothGattCallback.onMtuChanged() (via class BleSerialPort).
    */
   private int mtu = 20;
 
@@ -34,7 +34,7 @@ final class HM10WriteBuffer {
   /**
    * Is the BluetoothGatt object currently busy, i.e. did we call
    * readCharacteristic() or writeCharacteristic() and are we waiting
-   * for a beginWriteNextChunk() call from HM10Port?
+   * for a beginWriteNextChunk() call from BleSerialPort?
    *
    * We need to track this because only one pending
    * readCharacteristic()/writeCharacteristic() operation is allowed,
@@ -163,7 +163,6 @@ final class HM10WriteBuffer {
                          BluetoothGattCharacteristic deviceNameCharacteristic,
                          byte[] data, int length) {
     assert(dataCharacteristic != null);
-    assert(deviceNameCharacteristic != null);
     assert(length > 0);
 
     if (!drainSome())
@@ -187,10 +186,18 @@ final class HM10WriteBuffer {
        operation in the read callback so that the write operation is performed
        int the GATT event handling thread. */
     if (!gattBusy) {
-      if (!gatt.readCharacteristic(deviceNameCharacteristic)) {
-        Log.e(TAG, "GATT characteristic read request failed");
-        clear();
-        return 0;
+      if (deviceNameCharacteristic != null) {
+        if (!gatt.readCharacteristic(deviceNameCharacteristic)) {
+          Log.e(TAG, "GATT characteristic read request failed");
+          clear();
+          return 0;
+        }
+      } else {
+        /* NUS path: no workaround needed; start the write right away */
+        if (!beginWriteNextChunk(gatt, dataCharacteristic))
+          return 0;
+        /* already set gattBusy = true */
+        return nbytes;
       }
 
       gattBusy = true;

--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -258,7 +258,7 @@ final class BluetoothHelper
     return new BluetoothSensor(context, device, listener);
   }
 
-  public AndroidPort connectHM10(String address)
+  public AndroidPort connectBleSerial(String address)
     throws IOException {
     if (!hasLe)
       throw new IOException("No Bluetooth adapter found");
@@ -272,7 +272,7 @@ final class BluetoothHelper
 
     Log.d(TAG, String.format("Bluetooth device \"%s\" is a LE device, trying to connect using GATT...",
                              getDisplayString(device)));
-    return HM10Port.create(context, device);
+    return BleSerialPort.create(context, device);
   }
 
   public AndroidPort connect(String address)
@@ -306,7 +306,9 @@ final class BluetoothHelper
     for (ParcelUuid puuid : serviceUuids) {
       UUID uuid = puuid.getUuid();
       if (BluetoothUuids.HM10_SERVICE.equals(uuid))
-        features |= DetectDeviceListener.FEATURE_HM10;
+        features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
+      else if (BluetoothUuids.NORDIC_UART_SERVICE.equals(uuid))
+        features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
       else if (BluetoothUuids.HEART_RATE_SERVICE.equals(uuid))
         features |= DetectDeviceListener.FEATURE_HEART_RATE;
       else if (BluetoothUuids.FLYTEC_SENSBOX_SERVICE.equals(uuid))

--- a/android/src/BluetoothUuids.java
+++ b/android/src/BluetoothUuids.java
@@ -43,6 +43,25 @@ public final class BluetoothUuids {
   static final UUID HM10_RX_TX_CHARACTERISTIC =
     UUID.fromString("0000FFE1-0000-1000-8000-00805F9B34FB");
 
+  /**
+   * Nordic UART Service (NUS) - provides a BLE serial bridge using
+   * separate RX and TX characteristics.
+   */
+  static final UUID NORDIC_UART_SERVICE =
+    UUID.fromString("6E400001-B5A3-F393-E0A9-E50E24DCCA9E");
+
+  /**
+   * Nordic UART RX characteristic - XCSoar writes data to it.
+   */
+  static final UUID NORDIC_UART_RX_CHARACTERISTIC =
+    UUID.fromString("6E400002-B5A3-F393-E0A9-E50E24DCCA9E");
+
+  /**
+   * Nordic UART TX characteristic - XCSoar receives data from here.
+   */
+  static final UUID NORDIC_UART_TX_CHARACTERISTIC =
+    UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
+
   /* Flytec Sensbox */
   static final UUID FLYTEC_SENSBOX_SERVICE =
     UUID.fromString("aba27100-143b-4b81-a444-edcd0000f020");
@@ -65,6 +84,7 @@ public final class BluetoothUuids {
                           HEART_RATE_SERVICE,
                           ENGINE_SENSORS_SERVICE,
                           HM10_SERVICE,
+                          NORDIC_UART_SERVICE,
                           FLYTEC_SENSBOX_SERVICE
                         };
   }
@@ -76,6 +96,8 @@ public final class BluetoothUuids {
                         HEART_RATE_MEASUREMENT_CHARACTERISTIC,
                         ENGINE_SENSORS_CHARACTERISTIC,
                         HM10_RX_TX_CHARACTERISTIC,
+                        NORDIC_UART_RX_CHARACTERISTIC,
+                        NORDIC_UART_TX_CHARACTERISTIC,
                         FLYTEC_SENSBOX_NAVIGATION_SENSOR_CHARACTERISTIC,
                         FLYTEC_SENSBOX_MOVEMENT_SENSOR_CHARACTERISTIC,
                         FLYTEC_SENSBOX_SECOND_GPS_CHARACTERISTIC,

--- a/android/src/DetectDeviceListener.java
+++ b/android/src/DetectDeviceListener.java
@@ -13,7 +13,7 @@ interface DetectDeviceListener {
   static final int TYPE_BLUETOOTH_LE = 3;
   static final int TYPE_USB_SERIAL = 4;
 
-  static final long FEATURE_HM10 = 0x1;
+  static final long FEATURE_BLE_SERIAL = 0x1;
   static final long FEATURE_HEART_RATE = 0x2;
   static final long FEATURE_FLYTEC_SENSBOX = 0x4;
 

--- a/darwin/XCSoar.xcodeproj/project.pbxproj
+++ b/darwin/XCSoar.xcodeproj/project.pbxproj
@@ -706,8 +706,8 @@
 		5CBFD48D2D742FA600F05795 /* GlueIOIOPort.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = GlueIOIOPort.java; sourceTree = "<group>"; };
 		5CBFD48E2D742FA600F05795 /* GlueNunchuck.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = GlueNunchuck.java; sourceTree = "<group>"; };
 		5CBFD48F2D742FA600F05795 /* GlueVoltage.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = GlueVoltage.java; sourceTree = "<group>"; };
-		5CBFD4902D742FA600F05795 /* HM10Port.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = HM10Port.java; sourceTree = "<group>"; };
-		5CBFD4912D742FA600F05795 /* HM10WriteBuffer.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = HM10WriteBuffer.java; sourceTree = "<group>"; };
+		5CBFD4902D742FA600F05795 /* BleSerialPort.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = BleSerialPort.java; sourceTree = "<group>"; };
+		5CBFD4912D742FA600F05795 /* BleSerialWriteBuffer.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = BleSerialWriteBuffer.java; sourceTree = "<group>"; };
 		5CBFD4922D742FA600F05795 /* I2Cbaro.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = I2Cbaro.java; sourceTree = "<group>"; };
 		5CBFD4932D742FA600F05795 /* InputListener.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = InputListener.java; sourceTree = "<group>"; };
 		5CBFD4942D742FA600F05795 /* InputThread.java */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.java; path = InputThread.java; sourceTree = "<group>"; };
@@ -10288,8 +10288,8 @@
 				5CBFD48D2D742FA600F05795 /* GlueIOIOPort.java */,
 				5CBFD48E2D742FA600F05795 /* GlueNunchuck.java */,
 				5CBFD48F2D742FA600F05795 /* GlueVoltage.java */,
-				5CBFD4902D742FA600F05795 /* HM10Port.java */,
-				5CBFD4912D742FA600F05795 /* HM10WriteBuffer.java */,
+				5CBFD4902D742FA600F05795 /* BleSerialPort.java */,
+				5CBFD4912D742FA600F05795 /* BleSerialWriteBuffer.java */,
 				5CBFD4922D742FA600F05795 /* I2Cbaro.java */,
 				5CBFD4932D742FA600F05795 /* InputListener.java */,
 				5CBFD4942D742FA600F05795 /* InputThread.java */,

--- a/src/Android/BluetoothHelper.cpp
+++ b/src/Android/BluetoothHelper.cpp
@@ -20,7 +20,7 @@ static jfieldID hasLe_field;
 static jmethodID isEnabled_method;
 static jmethodID getNameFromAddress_method;
 static jmethodID connect_method, createServer_method;
-static jmethodID hm10connect_method;
+static jmethodID bleSerialConnect_method;
 static jmethodID connectSensor_method;
 static jmethodID addDetectDeviceListener_method;
 static jmethodID removeDetectDeviceListener_method;
@@ -61,9 +61,9 @@ BluetoothHelper::Initialise(JNIEnv *env) noexcept
   createServer_method = env->GetMethodID(cls, "createServer",
                                          "()Lorg/xcsoar/AndroidPort;");
 
-  hm10connect_method = env->GetMethodID(cls, "connectHM10",
-                                        "(Ljava/lang/String;)"
-                                        "Lorg/xcsoar/AndroidPort;");
+  bleSerialConnect_method = env->GetMethodID(cls, "connectBleSerial",
+                                             "(Ljava/lang/String;)"
+                                             "Lorg/xcsoar/AndroidPort;");
   addDetectDeviceListener_method =
     env->GetMethodID(cls, "addDetectDeviceListener",
                      "(Lorg/xcsoar/DetectDeviceListener;)V");
@@ -172,12 +172,12 @@ BluetoothHelper::createServer(JNIEnv *env)
 }
 
 PortBridge *
-BluetoothHelper::connectHM10(JNIEnv *env, const char *address)
+BluetoothHelper::connectBleSerial(JNIEnv *env, const char *address)
 {
-  /* call BluetoothHelper.connectHM10() */
+  /* call BluetoothHelper.connectBleSerial() */
 
   const Java::String address2(env, address);
-  auto obj = Java::CallObjectMethodRethrow(env, Get(), hm10connect_method,
+  auto obj = Java::CallObjectMethodRethrow(env, Get(), bleSerialConnect_method,
                                            address2.Get());
   assert(obj);
 

--- a/src/Android/BluetoothHelper.hpp
+++ b/src/Android/BluetoothHelper.hpp
@@ -60,7 +60,7 @@ public:
 
   PortBridge *connect(JNIEnv *env, const char *address);
 
-  PortBridge *connectHM10(JNIEnv *env, const char *address);
+  PortBridge *connectBleSerial(JNIEnv *env, const char *address);
 
   PortBridge *createServer(JNIEnv *env);
 };

--- a/src/Android/DetectDeviceListener.hpp
+++ b/src/Android/DetectDeviceListener.hpp
@@ -18,7 +18,7 @@ public:
     USB_SERIAL = 4,
   };
 
-  static constexpr uint64_t FEATURE_HM10 = 0x1;
+  static constexpr uint64_t FEATURE_BLE_SERIAL = 0x1;
   static constexpr uint64_t FEATURE_HEART_RATE = 0x2;
   static constexpr uint64_t FEATURE_FLYTEC_SENSBOX = 0x4;
 

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -27,7 +27,7 @@ DeviceConfig::IsAvailable() const noexcept
     return true;
 
   case PortType::RFCOMM:
-  case PortType::BLE_HM10:
+  case PortType::BLE_SERIAL:
   case PortType::BLE_SENSOR:
   case PortType::RFCOMM_SERVER:
   case PortType::GLIDER_LINK:
@@ -80,7 +80,7 @@ DeviceConfig::ShouldReopenOnTimeout() const noexcept
 
   case PortType::RFCOMM:
   case PortType::BLE_SENSOR:
-  case PortType::BLE_HM10:
+  case PortType::BLE_SERIAL:
   case PortType::RFCOMM_SERVER:
   case PortType::ANDROID_USB_SERIAL:
   case PortType::IOIOUART:
@@ -217,7 +217,7 @@ DeviceConfig::GetPortName(char *buffer, size_t max_size) const noexcept
     return buffer;
     }
 
-  case PortType::BLE_HM10: {
+  case PortType::BLE_SERIAL: {
     const char *name = bluetooth_mac.c_str();
 #ifdef ANDROID
     if (bluetooth_helper != nullptr) {

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -85,11 +85,12 @@ struct DeviceConfig {
     BLE_SENSOR,
 
     /**
-     * Bluetooth Low Energy HM10 protocol to a paired device.  Unlike
-     * #BLE_SENSOR, this provides a bidirectional data stream and
-     * XCSoar accesses it through the #Port interface.
+     * Bluetooth Low Energy serial bridge to a paired device (HM-10 or
+     * Nordic UART Service).  Unlike #BLE_SENSOR, this provides a
+     * bidirectional data stream and XCSoar accesses it through the
+     * #Port interface.
      */
-    BLE_HM10,
+    BLE_SERIAL,
 
     /**
      * A GliderLink broadcast receiver. Available on Android only
@@ -303,7 +304,7 @@ struct DeviceConfig {
   static constexpr bool UsesBluetoothMac(PortType port_type) noexcept {
     return port_type == PortType::RFCOMM ||
       port_type == PortType::BLE_SENSOR ||
-      port_type == PortType::BLE_HM10;
+      port_type == PortType::BLE_SERIAL;
   }
 
   constexpr bool IsDisabled() const noexcept {
@@ -327,7 +328,7 @@ struct DeviceConfig {
   constexpr bool IsAndroidBluetooth() const noexcept {
     switch (port_type) {
     case PortType::BLE_SENSOR:
-    case PortType::BLE_HM10:
+    case PortType::BLE_SERIAL:
     case PortType::RFCOMM:
     case PortType::RFCOMM_SERVER:
       return true;
@@ -392,7 +393,7 @@ struct DeviceConfig {
       return false;
 
     case PortType::SERIAL:
-    case PortType::BLE_HM10:
+    case PortType::BLE_SERIAL:
     case PortType::RFCOMM:
     case PortType::RFCOMM_SERVER:
     case PortType::AUTO:

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -89,6 +89,9 @@ struct DeviceConfig {
      * Nordic UART Service).  Unlike #BLE_SENSOR, this provides a
      * bidirectional data stream and XCSoar accesses it through the
      * #Port interface.
+     *
+     * @note The profile stores this mode under the legacy port type string
+     * @c ble_hm10 (see Profile/DeviceConfig.cpp).
      */
     BLE_SERIAL,
 

--- a/src/Device/Port/AndroidBluetoothPort.cpp
+++ b/src/Device/Port/AndroidBluetoothPort.cpp
@@ -30,13 +30,13 @@ OpenAndroidBluetoothServerPort(BluetoothHelper &bluetooth_helper,
 }
 
 std::unique_ptr<Port>
-OpenAndroidBleHm10Port(BluetoothHelper &bluetooth_helper,
-                       const char *address, PortListener *listener,
-                       DataHandler &handler)
+OpenAndroidBleSerialPort(BluetoothHelper &bluetooth_helper,
+                         const char *address, PortListener *listener,
+                         DataHandler &handler)
 {
   assert(address != nullptr);
 
-  PortBridge *bridge = bluetooth_helper.connectHM10(Java::GetEnv(), address);
+  PortBridge *bridge = bluetooth_helper.connectBleSerial(Java::GetEnv(), address);
   assert(bridge != nullptr);
   return std::make_unique<AndroidPort>(listener, handler, bridge);
 }

--- a/src/Device/Port/AndroidBluetoothPort.hpp
+++ b/src/Device/Port/AndroidBluetoothPort.hpp
@@ -21,6 +21,6 @@ OpenAndroidBluetoothServerPort(BluetoothHelper &bluetooth_helper,
                                PortListener *_listener, DataHandler &_handler);
 
 std::unique_ptr<Port>
-OpenAndroidBleHm10Port(BluetoothHelper &bluetooth_helper,
-                       const char *address, PortListener *_listener,
-                       DataHandler &_handler);
+OpenAndroidBleSerialPort(BluetoothHelper &bluetooth_helper,
+                         const char *address, PortListener *_listener,
+                         DataHandler &_handler);

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -86,17 +86,17 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
     path = config.path.c_str();
     break;
 
-  case DeviceConfig::PortType::BLE_HM10:
+  case DeviceConfig::PortType::BLE_SERIAL:
 #ifdef ANDROID
     if (config.bluetooth_mac.empty())
       throw std::runtime_error("No Bluetooth MAC configured");
 
     if (bluetooth_helper == nullptr)
       throw std::runtime_error("Bluetooth not available");
-                         
-    return OpenAndroidBleHm10Port(*bluetooth_helper,
-                                  config.bluetooth_mac,
-                                  listener, handler);
+
+    return OpenAndroidBleSerialPort(*bluetooth_helper,
+                                    config.bluetooth_mac,
+                                    listener, handler);
 #else
     throw std::runtime_error("Bluetooth not available");
 #endif

--- a/src/Device/device.cpp
+++ b/src/Device/device.cpp
@@ -37,7 +37,7 @@ DeviceConfigOverlaps(const DeviceConfig &a, const DeviceConfig &b)
     return a.path.equals(b.path);
 
   case DeviceConfig::PortType::RFCOMM:
-  case DeviceConfig::PortType::BLE_HM10:
+  case DeviceConfig::PortType::BLE_SERIAL:
   case DeviceConfig::PortType::BLE_SENSOR:
     return a.bluetooth_mac.equals(b.bluetooth_mac);
 

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -494,7 +494,7 @@ FinishPortField(DeviceConfig &config, const DataFieldEnum &df) noexcept
     return true;
 
   case DeviceConfig::PortType::RFCOMM:
-  case DeviceConfig::PortType::BLE_HM10:
+  case DeviceConfig::PortType::BLE_SERIAL:
   case DeviceConfig::PortType::BLE_SENSOR:
     /* Bluetooth */
     if (new_type == config.port_type &&

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -554,7 +554,7 @@ DeviceListWidget::ReconnectCurrent()
   const DeviceConfig &config =
     CommonInterface::SetSystemSettings().devices[current];
   if ((config.port_type == DeviceConfig::PortType::RFCOMM ||
-       config.port_type == DeviceConfig::PortType::BLE_HM10 ||
+       config.port_type == DeviceConfig::PortType::BLE_SERIAL ||
        config.port_type == DeviceConfig::PortType::RFCOMM_SERVER) &&
       bluetooth_helper != nullptr &&
       !bluetooth_helper->IsEnabled(Java::GetEnv())) {

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -308,7 +308,7 @@ SetPort(DataFieldEnum &df, const DeviceConfig &config) noexcept
     return;
 
   case DeviceConfig::PortType::BLE_SENSOR:
-  case DeviceConfig::PortType::BLE_HM10:
+  case DeviceConfig::PortType::BLE_SERIAL:
   case DeviceConfig::PortType::RFCOMM:
     SetBluetoothPort(df, config.port_type, config.bluetooth_mac);
     return;

--- a/src/Dialogs/Device/PortPicker.cpp
+++ b/src/Dialogs/Device/PortPicker.cpp
@@ -49,7 +49,7 @@ private:
     case DeviceConfig::PortType::RFCOMM:
       return "Bluetooth";
 
-    case DeviceConfig::PortType::BLE_HM10:
+    case DeviceConfig::PortType::BLE_SERIAL:
       return _("BLE port");
 
     case DeviceConfig::PortType::BLE_SENSOR:
@@ -239,8 +239,8 @@ PortPickerWidget::OnDeviceDetected(Type type, const char *address,
     break;
 
   case Type::BLUETOOTH_LE:
-    port_type = (features & DetectDeviceListener::FEATURE_HM10) != 0
-      ? DeviceConfig::PortType::BLE_HM10
+    port_type = (features & DetectDeviceListener::FEATURE_BLE_SERIAL) != 0
+      ? DeviceConfig::PortType::BLE_SERIAL
       : DeviceConfig::PortType::BLE_SENSOR;
     break;
 

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -31,7 +31,7 @@ static const char *const port_type_strings[] = {
   "udp_listener",
   "pty",
   "ble_sensor",
-  "ble_hm10",
+  "ble_hm10",   // For BLE_SERIAL; using old name to not break user configs.
   "glider_link",
   "android_usb_serial",
   NULL

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -14,6 +14,9 @@
 
 #include <stdio.h>
 
+/* PortType::BLE_SERIAL uses the legacy profile string "ble_hm10" in
+   port_type_strings so existing .prf files keep working. */
+
 static const char *const port_type_strings[] = {
   "disabled",
   "serial",
@@ -31,7 +34,7 @@ static const char *const port_type_strings[] = {
   "udp_listener",
   "pty",
   "ble_sensor",
-  "ble_hm10",   // For BLE_SERIAL; using old name to not break user configs.
+  "ble_hm10",
   "glider_link",
   "android_usb_serial",
   NULL


### PR DESCRIPTION
Tested with:

- Naviter Condor dongle connected to my PC, works as expected.
- Naviter FLARM dongle, works as expected (position/altitude/traffic).

See also: #2260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android Bluetooth LE serial ports now support Nordic UART Service (NUS) in addition to HM-10, with automatic protocol detection at connection time.
  * BLE handling and UI labeling unified under a single "BLE serial" / "BLE port" type for clearer selection and behavior.

* **Documentation**
  * NEWS updated with a forthcoming version entry describing the new BLE serial support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->