### PR TITLE
Task/TaskFileSeeYou: Fix CUP task header string_view lifetime

### DIFF
--- a/src/Task/TaskFileSeeYou.cpp
+++ b/src/Task/TaskFileSeeYou.cpp
@@ -27,6 +27,8 @@
 
 #include <stdlib.h>
 
+#include <string>
+
 using std::string_view_literals::operator""sv;
 
 static constexpr std::size_t CUP_MAX_TPS = 30;
@@ -475,11 +477,15 @@ try {
   if (line == nullptr)
     return nullptr;
 
+  /* CupSplitColumns stores string_views into its input; further
+     BufferedReader::ReadLine calls can reuse that memory (#2496). */
+  const std::string task_line_storage(line);
+
   // Read waypoint list
   // e.g. "Club day 4 Racing task","085PRI","083BOJ","170D_K","065SKY","0844YY", "0844YY"
   //       TASK NAME              , TAKEOFF, START  , TP1    , TP2    , FINISH ,  LANDING
   std::array<std::string_view, CUP_MAX_TPS> wps;
-  CupSplitColumns(line, wps);
+  CupSplitColumns(std::string_view(task_line_storage), wps);
 
   std::size_t n_waypoints = 0;
   for (std::size_t i = 0; i < wps.size(); ++i)
@@ -490,7 +496,7 @@ try {
   if (n_waypoints < 5)
     return nullptr;
 
-  // Remove taskname, start point and landing point from count
+  // Remove taskname, takeoff and landing from count
   n_waypoints -= 3;
 
   SeeYouTaskInformation task_info;


### PR DESCRIPTION
## Problem

SeeYou `.cup` tasks could fail to resolve waypoints in a position-dependent way (GitHub #2496): `CupSplitColumns` stores `string_view`s into the `BufferedReader` line buffer, then `ParseCUTaskDetails` calls `ReadLine()` again and the FIFO can reuse that memory before `LookupName` runs.

## Fix

Copy the task header line into `std::string` before splitting so column views stay valid for the rest of `GetTask()`.

Also clarify the `n_waypoints -= 3` comment (takeoff vs start).

Fixes #2496.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory safety issue in task file parsing that could cause instability when reading waypoint lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2497)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->