### PR TITLE
Android/UsbSerialHelper: Fix multi-port USB serial labels (#2481)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,7 @@
 Version 7.45 - not yet released
 * devices
+  - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
+    suffixes (#0, #1) in both the port list and device list #2481
   - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
     ISA logger datum; cleared when strong pressure replaces weak pressure or
     ignores the sentence

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -86,13 +86,28 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     return id;
   }
 
+  /**
+   * Counts USB interfaces we treat as serial (same filter as addAvailable()).
+   */
+  private static int countSerialInterfaces(UsbDevice device) {
+    int n = 0;
+    for (int i = 0; i < device.getInterfaceCount(); ++i) {
+      int iclass = device.getInterface(i).getInterfaceClass();
+      if (iclass == UsbConstants.USB_CLASS_VENDOR_SPEC ||
+          iclass == UsbConstants.USB_CLASS_CDC_DATA)
+        ++n;
+    }
+    return n;
+  }
+
   private static String makePortId(UsbDevice device, int iface,
-                                   boolean withSerialNumber) {
+                                   boolean withSerialNumber,
+                                   boolean multiSerial) {
     String id = makeDeviceId(device, withSerialNumber);
 
-    if (iface > 0)
-      /* a secondary interface on the same device: append the
-         interface index */
+    if (multiSerial)
+      /* 0-based port index, consistent with IOIO UART numbering and with
+         getDisplayName() */
       id += "#" + iface;
 
     return id;
@@ -110,17 +125,24 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     public final String oldId;
 
     /**
+     * More than one serial-capable interface on this device (same notion as
+     * addAvailable()).
+     */
+    private final boolean multiSerial;
+
+    /**
      * If not null, then this port instance is currently being used by
      * native code.  It may be waiting for permission from the
      * UsbManager, or it may already be open.
      */
     public UsbSerialPort port;
 
-    public UsbDeviceInterface(UsbDevice dev_,int iface_) {
+    public UsbDeviceInterface(UsbDevice dev_, int iface_) {
       device = dev_;
       iface = iface_;
-      id = makePortId(device, iface, true);
-      oldId = makePortId(device, iface, false);
+      multiSerial = countSerialInterfaces(device) > 1;
+      id = makePortId(device, iface, true, multiSerial);
+      oldId = makePortId(device, iface, false, multiSerial);
     }
 
     public boolean isDevice(UsbDevice otherDevice) {
@@ -137,7 +159,9 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     public String getDisplayName() {
       String name = device.getProductName();
       if (name == null)
-        name = id;
+        /* makeDeviceId only: id includes #port for multi-serial and would
+           duplicate the suffix appended below */
+        name = makeDeviceId(device, true);
 
       String manufacturer = device.getManufacturerName();
       if (manufacturer != null)
@@ -148,9 +172,8 @@ public final class UsbSerialHelper extends BroadcastReceiver {
         name += " [" + serialNumber + "]";
       }
 
-      // add interface number to name only when more than one interface
-      if (device.getInterfaceCount() > 1)
-        name += "#" + (iface + 1);
+      if (multiSerial)
+        name += "#" + iface;
 
       return name;
     }


### PR DESCRIPTION
## Summary
Fixes #2481.

On Android, dual-port FTDI (and similar) adapters showed **1-based** port numbers in the port picker (`#1` / `#2`) while the stored profile id used **no suffix** on the first interface and `#1` on the second—so the **Devices** list (`USB serial: …` from `path`) did not match the picker.

## Change
- `UsbSerialHelper`: when more than one serial-capable interface exists (same class filter as `addAvailable()`), append **0-based** `#0`, `#1`, … to both the internal id and `getDisplayName()`, so the port list and device list agree (aligned with IOIO UART numbering).
- `NEWS.txt`: note under 7.45 devices.

## Note
Profiles that stored the **first** port of a multi-serial adapter **without** a `#0` suffix will need the port re-selected once (no legacy id matching).