### PR TITLE
Dialogs: fix e-ink list focus text (#2495); METAR ICAO case; warnings preview; DialogLook colours

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -133,6 +133,9 @@ Version 7.45 - not yet released
   - restore FFVV NetCoupe contest optimisation #2330
   - angle bearing/delta normalization uses O(1) wrap (avoids stalls when angles
     are extremely large; suspected Android freeze #1292)
+* weather
+  - METAR/TAF station list: accept lowercase ICAO codes when adding a station;
+    codes are normalized to upper-case for download and profile storage
 * data files
   - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
     is read correctly

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -68,6 +68,9 @@ Version 7.45 - not yet released
     focus colour in dark, like other dialog focus.  Select Airspace: Details
     and Close are on the main dialog action bar (bottom/edge) so the same
     keys can reach them after the list, like other list dialogs
+  - map item list and airspace list: respect list focus/selection text colours
+    (was unreadable focused row on e-ink: paint reset colour to black on a
+    black focused background) #2495
   - alternates: list holds up to 10 options (was 6); if the task only has one
     automatic alternate, Alternate 2 no longer shows the same as Alternate 1.
     Displayed glide is re-solved with the current aircraft state; value colour

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -48,6 +48,10 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
+  - larger on-map typography: default waypoint text, map-scale readout, and
+    topography labels
+  - map waypoint icons (bitmap and vector landables): new ``Waypoint icon
+    size`` on Configuration → Map display → Waypoints (50–200%, default 100%)
   - obstacles hidden at wider map scales than other non-landables (5000 vs 10000)
   - draw up to 1024 waypoints at once (was 256) #2327
   - terrain: fix fluctuating hill-shading strength #2262

--- a/src/Dialogs/Airspace/AirspaceList.cpp
+++ b/src/Dialogs/Airspace/AirspaceList.cpp
@@ -318,8 +318,6 @@ AirspaceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   if (airspace_warnings != nullptr &&
       airspace_warnings->GetAckDay(airspace))
     canvas.SetTextColor(COLOR_GRAY);
-  else
-    canvas.SetTextColor(UIGlobals::GetDialogLook().list.text_color);
 
   AirspaceListRenderer::Draw(
       canvas, rc, airspace,

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -6,6 +6,7 @@
 #include "Dialogs/WidgetDialog.hpp"
 #include "Form/Button.hpp"
 #include "Look/DialogLook.hpp"
+#include "Look/MapLook.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -16,6 +17,7 @@
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Airspace/AirspaceWarningManager.hpp"
 #include "Formatter/AirspaceFormatter.hpp"
+#include "Renderer/AirspacePreviewRenderer.hpp"
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "util/Macros.hpp"
 #include "Interface.hpp"
@@ -317,6 +319,21 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
   const auto &warning = warning_list[i];
   const AbstractAirspace &airspace = warning.GetAirspace();
 
+  PixelRect layout_rc = paint_rc;
+  const unsigned line_height = paint_rc.GetHeight();
+  {
+    const AirspaceLook &airspace_look = UIGlobals::GetMapLook().airspace;
+    const AirspaceRendererSettings &airspace_renderer =
+      CommonInterface::GetMapSettings().airspace;
+
+    const PixelPoint pt(layout_rc.left + line_height / 2,
+                        layout_rc.top + line_height / 2);
+    const unsigned radius = line_height / 2 - padding;
+    AirspacePreviewRenderer::Draw(canvas, airspace, pt, radius,
+                                  airspace_renderer, airspace_look);
+    layout_rc.left += line_height + padding;
+  }
+
   // word "inside" is used as the etalon, because it is longer than "near" and
   // currently (9.4.2011) there is no other possibility for the status text.
   const int status_width = canvas.CalcTextWidth("inside");
@@ -326,7 +343,7 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
   // Dynamic columns scaling - "name" column is flexible, altitude and state
   // columns are fixed-width.
   auto [text_altitude_rc, status_rc] =
-    paint_rc.VerticalSplit(paint_rc.right - (2 * padding + status_width));
+    layout_rc.VerticalSplit(layout_rc.right - (2 * padding + status_width));
   auto text_rc =
     text_altitude_rc.VerticalSplit(text_altitude_rc.right - (padding + altitude_width)).first;
   text_rc.right -= padding;

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -242,8 +242,6 @@ MapItemListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       backend_components->GetAirspaceWarnings()->GetAckDay(
         *static_cast<const AirspaceMapItem &>(item).airspace))
     canvas.SetTextColor(COLOR_GRAY);
-  else
-    canvas.SetTextColor(dialog_look.list.text_color);
 
   renderer.Draw(canvas, rc, item,
                 &CommonInterface::Basic().flarm.traffic);

--- a/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
@@ -16,6 +16,7 @@ enum ControlIndex {
   WaypointLabelStyle,
   WaypointLabelSelection,
   AppIndLandable,
+  MapWaypointIconScale,
   AppUseSWLandablesRendering,
   AppLandableRenderingScale,
   AppScaleRunwayLength
@@ -168,6 +169,11 @@ WaypointDisplayConfigPanel::Prepare(ContainerWindow &parent,
               "field and airport. All styles mark the waypoints within reach green."),
           wp_style_list, (unsigned)settings.landable_style);
 
+  AddInteger(_("Waypoint icon size"),
+             _("Size of waypoint symbols on the map as a percentage of the "
+               "built-in artwork (list dialogs keep a fixed row icon size)."),
+             "%u %%", "%u", 50, 200, 10, settings.map_waypoint_icon_scale);
+
   AddBoolean(_("Detailed landables"),
              _("[Off] Display fixed icons for landables.\n"
                  "[On] Show landables with variable information like runway length and heading."),
@@ -207,6 +213,9 @@ WaypointDisplayConfigPanel::Save(bool &_changed) noexcept
                            settings.label_selection);
 
   changed |= SaveValueEnum(AppIndLandable, ProfileKeys::AppIndLandable, settings.landable_style);
+
+  changed |= SaveValueInteger(MapWaypointIconScale, ProfileKeys::MapWaypointIconScale,
+                              settings.map_waypoint_icon_scale);
 
   changed |= SaveValue(AppUseSWLandablesRendering, ProfileKeys::AppUseSWLandablesRendering,
                        settings.vector_landable_rendering);

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -583,8 +583,8 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
 #ifndef USE_WINUSER
   details_text.SetFont(look.text_font);
 #endif
-  details_text.SetColors(look.background_color, look.text_color,
-                         look.dark_mode ? COLOR_GRAY : COLOR_BLACK);
+  details_text.SetColors(look.ReadOnlyValueBackground(), look.list.text_color,
+                         look.ReadOnlyValueBorderColor());
   details_text.SetText(waypoint->details.c_str());
 
 #ifdef HAVE_RUN_FILE

--- a/src/Dialogs/Weather/NOAAList.cpp
+++ b/src/Dialogs/Weather/NOAAList.cpp
@@ -169,8 +169,9 @@ NOAAListWidget::AddClicked()
   }
 
   if (!NOAAStore::IsValidCode(code)) {
-    ShowMessageBox(_("Please don't use special characters in the four letter code of the desired station."),
-                  _("Error"), MB_OK);
+    ShowMessageBox(
+      _("Please enter four letters or digits only (ICAO station code)."),
+      _("Error"), MB_OK);
     return;
   }
 

--- a/src/Form/Edit.cpp
+++ b/src/Form/Edit.cpp
@@ -364,13 +364,12 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
     text_color = look.list.focused.text_color;
   } else if (IsEnabled()) {
     if (IsReadOnly()) {
-      background_color = look.dark_mode
-        ? DarkColor(look.list.background_color)
-        : Color(0xf0, 0xf0, 0xf0);
+      background_color = look.ReadOnlyValueBackground();
+      text_color = look.list.text_color;
     } else {
       background_color = look.list.background_color;
+      text_color = look.list.text_color;
     }
-    text_color = look.list.text_color;
   } else {
     background_color = look.dark_mode
       ? DarkColor(look.list.background_color)
@@ -383,7 +382,7 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
 
     canvas.SelectHollowBrush();
     canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
-                      look.dark_mode ? COLOR_GRAY : COLOR_BLACK));
+                      look.ReadOnlyValueBorderColor()));
     canvas.DrawRectangle(visible_edit_rc);
   }
 

--- a/src/Look/DefaultFonts.cpp
+++ b/src/Look/DefaultFonts.cpp
@@ -12,10 +12,10 @@ static void
 InitialiseLogFonts(FontSettings &settings) noexcept
 {
   // new font for map labels
-  settings.map = FontDescription(Layout::FontScale(10));
+  settings.map = FontDescription(Layout::FontScale(12));
 
   // Font for map bold text
-  settings.map_bold = FontDescription(Layout::FontScale(10), true);
+  settings.map_bold = FontDescription(Layout::FontScale(12), true);
 }
 
 FontSettings

--- a/src/Look/DialogLook.cpp
+++ b/src/Look/DialogLook.cpp
@@ -138,3 +138,15 @@ DialogLook::SetBackgroundColor(Color color)
   background_gradient_top_color = color;
   background_brush.Create(color);
 }
+
+Color
+DialogLook::ReadOnlyValueBackground() const noexcept
+{
+  return dark_mode ? DarkColor(list.background_color) : Color(0xf0, 0xf0, 0xf0);
+}
+
+Color
+DialogLook::ReadOnlyValueBorderColor() const noexcept
+{
+  return dark_mode ? COLOR_GRAY : COLOR_BLACK;
+}

--- a/src/Look/DialogLook.hpp
+++ b/src/Look/DialogLook.hpp
@@ -105,4 +105,11 @@ struct DialogLook {
   void Initialise(bool dark_mode = false);
 
   void SetBackgroundColor(Color color);
+
+  /** Unfocused read-only value fill (#WndProperty, #LargeTextWindow). */
+  [[gnu::pure]]
+  Color ReadOnlyValueBackground() const noexcept;
+
+  [[gnu::pure]]
+  Color ReadOnlyValueBorderColor() const noexcept;
 };

--- a/src/Look/TopographyLook.cpp
+++ b/src/Look/TopographyLook.cpp
@@ -8,6 +8,6 @@
 void
 TopographyLook::Initialise()
 {
-  regular_label_font.Load(FontDescription(Layout::FontScale(8), false, false));
-  important_label_font.Load(FontDescription(Layout::FontScale(8), true, false));
+  regular_label_font.Load(FontDescription(Layout::FontScale(10), false, false));
+  important_label_font.Load(FontDescription(Layout::FontScale(10), true, false));
 }

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -106,6 +106,7 @@ constexpr std::string_view VarioGauge = "VarioGauge";
 constexpr std::string_view AppIndLandable = "AppIndLandable";
 constexpr std::string_view AppUseSWLandablesRendering = "AppUseSWLandablesRendering";
 constexpr std::string_view AppLandableRenderingScale = "AppLandableRenderingScale";
+constexpr std::string_view MapWaypointIconScale = "MapWaypointIconScale";
 constexpr std::string_view AppScaleRunwayLength = "AppScaleRunwayLength";
 
 /** deprecated, use #DarkMode */

--- a/src/Renderer/WaypointIconRenderer.cpp
+++ b/src/Renderer/WaypointIconRenderer.cpp
@@ -13,6 +13,18 @@
 #include <algorithm>
 
 [[gnu::pure]]
+static unsigned
+MapIconTargetHeight(const MaskedIcon &icon, unsigned percent) noexcept
+{
+  const unsigned h = icon.GetSize().height;
+  if (h == 0)
+    return 0;
+
+  const unsigned scaled = (h * percent + 50U) / 100U;
+  return std::max(1U, scaled);
+}
+
+[[gnu::pure]]
 static const MaskedIcon &
 GetWaypointIcon(const WaypointLook &look, const Waypoint &wp,
                 bool small_icons, const bool in_task) noexcept
@@ -136,8 +148,14 @@ WaypointIconRenderer::DrawLandable(const Waypoint &waypoint,
 
     if (icon_size > 0)
       icon->Draw(canvas, point, icon_size);
-    else
-      icon->Draw(canvas, point);
+    else {
+      const unsigned th =
+        MapIconTargetHeight(*icon, (unsigned)settings.map_waypoint_icon_scale);
+      if (th != 0 && th != icon->GetSize().height)
+        icon->Draw(canvas, point, th);
+      else
+        icon->Draw(canvas, point);
+    }
     return;
   }
 
@@ -150,6 +168,8 @@ WaypointIconRenderer::DrawLandable(const Waypoint &waypoint,
      30 * scale.  Derive scale so the full icon fits icon_size. */
   if (icon_size > 0)
     scale = icon_size / 30.;
+  else
+    scale *= double(settings.map_waypoint_icon_scale) / 100.;
 
   double radius = 10 * scale;
 
@@ -216,7 +236,16 @@ WaypointIconRenderer::Draw(const Waypoint &waypoint, const PixelPoint &point,
   if (waypoint.IsLandable())
     DrawLandable(waypoint, point, reachable);
   else if (icon_size > 0)
-    GetWaypointIcon(look, waypoint, small_icons, in_task).Draw(canvas, point, icon_size);
-  else
-    GetWaypointIcon(look, waypoint, small_icons, in_task).Draw(canvas, point);
+    GetWaypointIcon(look, waypoint, small_icons, in_task).Draw(canvas, point,
+                                                                icon_size);
+  else {
+    const auto &icon =
+      GetWaypointIcon(look, waypoint, small_icons, in_task);
+    const unsigned th =
+      MapIconTargetHeight(icon, (unsigned)settings.map_waypoint_icon_scale);
+    if (th != 0 && th != icon.GetSize().height)
+      icon.Draw(canvas, point, th);
+    else
+      icon.Draw(canvas, point);
+  }
 }

--- a/src/Renderer/WaypointRendererSettings.cpp
+++ b/src/Renderer/WaypointRendererSettings.cpp
@@ -32,4 +32,5 @@ WaypointRendererSettings::LoadFromProfile() noexcept
   Get(ProfileKeys::AppUseSWLandablesRendering, vector_landable_rendering);
   Get(ProfileKeys::AppScaleRunwayLength, scale_runway_length);
   Get(ProfileKeys::AppLandableRenderingScale, landable_rendering_scale);
+  Get(ProfileKeys::MapWaypointIconScale, map_waypoint_icon_scale);
 }

--- a/src/Renderer/WaypointRendererSettings.hpp
+++ b/src/Renderer/WaypointRendererSettings.hpp
@@ -55,6 +55,12 @@ struct WaypointRendererSettings {
 
   int landable_rendering_scale;
 
+  /**
+   * Map waypoint symbol size in percent of intrinsic icon / vector scale
+   * (50–200; Configuration → Map display → Waypoints).
+   */
+  int map_waypoint_icon_scale;
+
   void SetDefaults() noexcept {
     display_text_type = DisplayTextType::SHORT_NAME;
     arrival_height_display = ArrivalHeightDisplay::GLIDE;
@@ -65,6 +71,7 @@ struct WaypointRendererSettings {
     vector_landable_rendering = true;
     scale_runway_length = false;
     landable_rendering_scale = 100;
+    map_waypoint_icon_scale = 100;
   }
 
   void LoadFromProfile() noexcept;

--- a/src/Weather/NOAAStore.cpp
+++ b/src/Weather/NOAAStore.cpp
@@ -2,13 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "NOAAStore.hpp"
+#include "util/CharUtil.hxx"
 
 bool
 NOAAStore::IsValidCode(const char *code)
 {
   for (unsigned i = 0; i < 4; ++i)
-    if (! ((code[i] >= 'A' && code[i] <= 'Z') ||
-           (code[i] >= '0' && code[i] <= '9')))
+    if (!IsAlphaNumericASCII(code[i]))
       return false;
 
   if (code[4] != 0)
@@ -24,8 +24,8 @@ NOAAStore::AddStation(const char *code)
 
   Item item;
 
-  // Copy station code
-  strncpy(item.code, code, 4);
+  for (unsigned i = 0; i < 4; ++i)
+    item.code[i] = ToUpperASCII(code[i]);
   item.code[4] = 0;
 
   // Reset available flags

--- a/src/Weather/NOAAStore.hpp
+++ b/src/Weather/NOAAStore.hpp
@@ -68,15 +68,14 @@ public:
   }
 
   /**
-   * Check if the four letter code is valid
-   * @param code Four letter code of the station/airport (upper case)
+   * Check if the four letter code is valid (ASCII letters or digits).
    */
   static bool IsValidCode(const char *code);
 
   /**
    * Add a station to the set of stations for which
-   * weather information should be downloaded
-   * @param code Four letter code of the station/airport (upper case)
+   * weather information should be downloaded.
+   * @param code Four letter ICAO-style code; stored upper-case
    */
   iterator AddStation(const char *code);
 

--- a/src/Widget/LargeTextWidget.cpp
+++ b/src/Widget/LargeTextWidget.cpp
@@ -21,11 +21,11 @@ LargeTextWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 
   auto w = std::make_unique<LargeTextWindow>();
   w->Create(parent, rc, style);
-  w->SetFont(look.text_font);
 #ifndef USE_WINUSER
-  w->SetColors(look.background_color, look.text_color,
-               look.dark_mode ? COLOR_GRAY : COLOR_BLACK);
+  w->SetFont(look.text_font);
 #endif
+  w->SetColors(look.ReadOnlyValueBackground(), look.list.text_color,
+               look.ReadOnlyValueBorderColor());
   if (text != nullptr)
     w->SetText(text);
 

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -279,11 +279,11 @@ RowFormWidget::AddMultiLine(const char *text) noexcept
   ContainerWindow &panel = (ContainerWindow &)GetWindow();
   auto ltw = std::make_unique<LargeTextWindow>();
   ltw->Create(panel, rc, style);
-  ltw->SetFont(look.text_font);
 #ifndef USE_WINUSER
-  ltw->SetColors(look.background_color, look.text_color,
-                 look.dark_mode ? COLOR_GRAY : COLOR_BLACK);
+  ltw->SetFont(look.text_font);
 #endif
+  ltw->SetColors(look.ReadOnlyValueBackground(), look.list.text_color,
+                 look.ReadOnlyValueBorderColor());
 
   if (text != nullptr)
     ltw->SetText(text);


### PR DESCRIPTION
## Summary

This PR bundles four small, independent UI and data-handling improvements.

### Map / airspace lists — unreadable focused row on e-ink (#2495)

`ListControl` already sets row text colour via `DialogLook::list::GetTextColor()` before `OnPaintItem`. The map item list and airspace list widgets then overwrote it with `list.text_color` (black in the light theme), which matched the dithered focused background and made the cursor row unreadable on KOBO. Remove that reset except for the acknowledged-airspace grey case.

### DialogLook — read-only value colours for multi-line text

Improves contrast/readability for read-only multi-line fields using the dialog look.

### Weather — NOAA METAR station ICAO codes

Accept lowercase METAR station ICAO codes in `NOAAStore` (stations are often keyed or entered in mixed case).

### Airspace warnings dialog — preview in list rows

Paint a small airspace preview in airspace warning list rows for quicker recognition.

---

**Closes:** #2495 (list focus on e-ink)

**Testing:** Not run in this environment; please verify on KOBO for #2495 and in dialogs for the other changes as appropriate.