### PR TITLE
build/test.mk, Data/Input/default.xci: RunAirspaceWarningDialog link and Cancel on Escape

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -146,7 +146,7 @@ event=Pan right
 
 mode=pan
 type=key
-data=APP1
+data=ESCAPE
 event=Pan off
 label=Cancel
 location=1
@@ -588,7 +588,7 @@ location=9
 
 mode=Nav2
 type=key
-data=APP1
+data=ESCAPE
 event=Mode default
 label=Cancel
 location=1
@@ -683,7 +683,7 @@ location=9
 
 mode=Display2
 type=key
-data=APP2
+data=ESCAPE
 event=Mode default
 label=Cancel
 location=2
@@ -830,7 +830,7 @@ location=9
 # -------------
 mode=Config3
 type=key
-data=APP3
+data=ESCAPE
 event=Mode default
 label=Cancel
 location=3
@@ -1050,7 +1050,7 @@ location=9
 # -------------
 mode=Info3
 type=key
-data=APP4
+data=ESCAPE
 event=Mode default
 label=Cancel
 location=4
@@ -1134,6 +1134,13 @@ event=LockScreen
 event=Mode default
 label=Lock Screen
 location=7
+
+mode=Menu
+type=key
+data=ESCAPE
+event=Mode default
+label=Cancel
+location=8
 
 mode=Menu
 type=key

--- a/build/test.mk
+++ b/build/test.mk
@@ -2310,6 +2310,20 @@ RUN_AIRSPACE_WARNING_DIALOG_SOURCES = \
 	$(SRC)/Look/ButtonLook.cpp \
 	$(SRC)/Look/CheckBoxLook.cpp \
 	$(SRC)/Renderer/TwoTextRowsRenderer.cpp \
+	$(SRC)/Renderer/AirspacePreviewRenderer.cpp \
+	$(SRC)/Renderer/AirspaceRendererSettings.cpp \
+	$(SRC)/Projection/Projection.cpp \
+	$(SRC)/Projection/WindowProjection.cpp \
+	$(SRC)/MapSettings.cpp \
+	$(SRC)/UISettings.cpp \
+	$(SRC)/DisplaySettings.cpp \
+	$(SRC)/PageSettings.cpp \
+	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
+	$(SRC)/Gauge/VarioSettings.cpp \
+	$(SRC)/Gauge/TrafficSettings.cpp \
+	$(SRC)/Audio/Settings.cpp \
+	$(SRC)/Audio/VarioSettings.cpp \
+	$(SRC)/Terrain/TerrainSettings.cpp \
 	$(SRC)/Dialogs/Airspace/dlgAirspaceWarnings.cpp \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Dialogs/WidgetDialog.cpp \
@@ -2333,7 +2347,7 @@ RUN_AIRSPACE_WARNING_DIALOG_SOURCES = \
 	$(TEST_SRC_DIR)/Fonts.cpp \
 	$(TEST_SRC_DIR)/RunAirspaceWarningDialog.cpp
 RUN_AIRSPACE_WARNING_DIALOG_LDADD = $(FAKE_LIBS)
-RUN_AIRSPACE_WARNING_DIALOG_DEPENDS = FORM WIDGET OPERATION DATA_FIELD SCREEN AUDIO EVENT RESOURCE ASYNC IO OS THREAD AIRSPACE ZZIP UTIL GEO MATH TIME UNITS
+RUN_AIRSPACE_WARNING_DIALOG_DEPENDS = FORM WIDGET OPERATION DATA_FIELD SCREEN LOOK AUDIO EVENT RESOURCE ASYNC IO OS THREAD AIRSPACE ZZIP UTIL GEO MATH TIME UNITS
 $(eval $(call link-program,RunAirspaceWarningDialog,RUN_AIRSPACE_WARNING_DIALOG))
 
 RUN_PROFILE_LIST_DIALOG_SOURCES = \

--- a/test/src/Main.hpp
+++ b/test/src/Main.hpp
@@ -105,6 +105,12 @@ Main(UI::Display &display);
 
 #ifdef ENABLE_LOOK
 static Look *look;
+
+const MapLook &
+UIGlobals::GetMapLook()
+{
+  return look->map;
+}
 #endif
 
 #ifdef ENABLE_DIALOG_LOOK

--- a/test/src/RunAirspaceWarningDialog.cpp
+++ b/test/src/RunAirspaceWarningDialog.cpp
@@ -3,6 +3,7 @@
 
 #define ENABLE_DIALOG
 #define ENABLE_MAIN_WINDOW
+#define ENABLE_LOOK
 
 #include "ActionInterface.hpp"
 #include "Airspace/AirspaceGlue.hpp"
@@ -62,6 +63,8 @@ LoadFiles(Airspaces &airspace_database)
 static void
 Main([[maybe_unused]] TestMainWindow &main_window)
 {
+  CommonInterface::Private::blackboard.SetUISettings().SetDefaults();
+
   Airspaces airspace_database;
 
   AirspaceWarningConfig airspace_warning_config;


### PR DESCRIPTION
## Summary

- Fix `RunAirspaceWarningDialog` link failure after airspace preview was added to warning list rows (`fb73bc7958`): link LOOK, `AirspacePreviewRenderer`, projection, and map/UI settings in the test harness; stub `UIGlobals::GetMapLook()` for `ENABLE_LOOK` test programs.
- Bind submenu and pan **Cancel** to `ESCAPE` instead of APP keys so keyboard and Android back match on-screen Cancel; restore **Menu Cancel** at location 8 (#2505).

## Test plan

- [ ] `make TARGET=UNIX everything` — `RunAirspaceWarningDialog` links cleanly
- [ ] Run `RunAirspaceWarningDialog` — airspace warning rows show preview icons
- [ ] Keyboard Esc / Android back in pan and Nav/Display/Config/Info submenus — returns to default mode
- [ ] Menu mode — Cancel button visible at location 8; Esc exits menu
- [ ] Touch Cancel buttons unchanged (driven by `location`, not `data`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Keyboard controls streamlined: cancel and exit functions across all interface modes now consistently use the ESCAPE key for improved usability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->