### PR TITLE
Chore: Replace sprintf in UI, profile, and renderer code

### DIFF
--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -25,6 +25,7 @@
 #include "Widget/ListWidget.hpp"
 #include "UIGlobals.hpp"
 #include "Audio/Sound.hpp"
+#include "util/StringFormat.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -366,20 +367,26 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
 
   if (const auto &solution = warning.GetSolution();
       warning.IsWarning() && !warning.IsInside() && solution.IsValid()) {
+    StringFormat(buffer, ARRAY_SIZE(buffer), _("%d secs"),
+                 (int)solution.elapsed_time.count());
 
-    sprintf(buffer, "%d secs",
-              (int)solution.elapsed_time.count());
-
-    if (solution.distance > 0)
-      sprintf(buffer + strlen(buffer), " dist %d m",
-                (int)solution.distance);
-    else {
+    if (solution.distance > 0) {
+      const size_t len = strlen(buffer);
+      StringFormat(buffer + len, ARRAY_SIZE(buffer) - len,
+                   _(" dist %d m"), (int)solution.distance);
+    } else {
       /* the airspace is right above or below us - show the vertical
          distance */
-      strcat(buffer, " vertical ");
+      const size_t len = strlen(buffer);
+      StringFormat(buffer + len, ARRAY_SIZE(buffer) - len,
+                   "%s", _(" vertical "));
 
+      const size_t len2 = strlen(buffer);
       auto delta = solution.altitude - CommonInterface::Basic().nav_altitude;
-      FormatRelativeUserAltitude(delta, buffer + strlen(buffer), true);
+      char relative_altitude[ARRAY_SIZE(buffer)];
+      FormatRelativeUserAltitude(delta, relative_altitude, true);
+      StringFormat(buffer + len2, ARRAY_SIZE(buffer) - len2,
+                   "%s", relative_altitude);
     }
 
     row_renderer.DrawSecondRow(canvas, text_rc, buffer);

--- a/src/Dialogs/Device/Vega/AudioParameters.hpp
+++ b/src/Dialogs/Device/Vega/AudioParameters.hpp
@@ -9,7 +9,7 @@
 #include "Language/Language.hpp"
 #include "util/StaticString.hxx"
 
-#include <stdio.h>
+#include <array>
 
 static constexpr StaticEnumChoice beep_types[] = {
   { 0, "Silence" },
@@ -61,7 +61,7 @@ static constexpr StaticEnumChoice pitch_and_period_scales[] = {
 class VegaAudioParametersWidget : public VegaParametersWidget {
   const char *mode;
 
-  char names[5][64];
+  std::array<StaticString<64>, 5> names;
 
 public:
   VegaAudioParametersWidget(const DialogLook &look, VegaDevice &device,
@@ -81,19 +81,23 @@ public:
                const PixelRect &rc) noexcept override {
     VegaParametersWidget::Prepare(parent, rc);
 
-    sprintf(names[0], "Tone%sBeepType", mode);
-    AddEnum(names[0], _("Beep type"), NULL, beep_types);
+    const char *safe_mode = (mode != nullptr && mode[0] != '\0')
+      ? mode
+      : "DefaultMode";
 
-    sprintf(names[1], "Tone%sPitchScheme", mode);
-    AddEnum(names[1], _("Pitch scheme"), NULL, pitch_schemes);
+    names[0].Format("Tone%sBeepType", safe_mode);
+    AddEnum(names[0].c_str(), _("Beep type"), NULL, beep_types);
 
-    sprintf(names[2], "Tone%sPitchScale", mode);
-    AddEnum(names[2], _("Pitch scale"), NULL, pitch_and_period_scales);
+    names[1].Format("Tone%sPitchScheme", safe_mode);
+    AddEnum(names[1].c_str(), _("Pitch scheme"), NULL, pitch_schemes);
 
-    sprintf(names[3], "Tone%sPeriodScheme", mode);
-    AddEnum(names[3], _("Period scheme"), NULL, period_schemes);
+    names[2].Format("Tone%sPitchScale", safe_mode);
+    AddEnum(names[2].c_str(), _("Pitch scale"), NULL, pitch_and_period_scales);
 
-    sprintf(names[4], "Tone%sPeriodScale", mode);
-    AddEnum(names[4], _("Period scale"), NULL, pitch_and_period_scales);
+    names[3].Format("Tone%sPeriodScheme", safe_mode);
+    AddEnum(names[3].c_str(), _("Period scheme"), NULL, period_schemes);
+
+    names[4].Format("Tone%sPeriodScale", safe_mode);
+    AddEnum(names[4].c_str(), _("Period scale"), NULL, pitch_and_period_scales);
   }
 };

--- a/src/Dialogs/Device/Vega/VegaDemoDialog.cpp
+++ b/src/Dialogs/Device/Vega/VegaDemoDialog.cpp
@@ -17,6 +17,10 @@
 #include "Math/Util.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "LogFile.hpp"
+
+#include <fmt/format.h>
+#include <exception>
 
 static double VegaDemoW = 0;
 static double VegaDemoV = 0;
@@ -29,13 +33,21 @@ VegaWriteDemo()
   if (!last_time.CheckUpdate(std::chrono::milliseconds(250)))
     return;
 
-  char dbuf[100];
-  sprintf(dbuf, "PDVDD,%d,%d",
-            iround(VegaDemoW * 10),
-            iround(VegaDemoV * 10));
+  std::string payload;
+  try {
+    payload = fmt::format("PDVDD,{},{}",
+                          iround(VegaDemoW * 10),
+                          iround(VegaDemoV * 10));
+  } catch (const std::exception &e) {
+    LogFmt("VegaDemo: failed to format payload: {}", e.what());
+    return;
+  } catch (...) {
+    LogFmt("VegaDemo: failed to format payload");
+    return;
+  }
 
   PopupOperationEnvironment env;
-  backend_components->devices->VegaWriteNMEA(dbuf, env);
+  backend_components->devices->VegaWriteNMEA(payload.c_str(), env);
 }
 
 class VegaDemoWidget final

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -7,6 +7,7 @@
 #include "Form/DataField/Enum.hpp"
 #include "Dialogs/Dialogs.h"
 #include "util/StringCompare.hxx"
+#include "util/StaticString.hxx"
 #include "Interface.hpp"
 #include "Language/Table.hpp"
 #include "Asset.hpp"
@@ -86,8 +87,8 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
     DataFieldEnum &df = *(DataFieldEnum *)wp_dpi->GetDataField();
     df.AddChoice(0, _("Automatic"));
     for (const unsigned *dpi = dpi_choices; dpi != dpi_choices_end; ++dpi) {
-      char buffer[20];
-      sprintf(buffer, _("%d dpi"), *dpi);
+      StaticString<20> buffer;
+      buffer.Format(_("%u dpi"), *dpi);
       df.AddChoice(*dpi, buffer);
     }
     df.SetValue(settings.custom_dpi);

--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -23,6 +23,7 @@
 #include "util/StaticArray.hxx"
 
 #include <cassert>
+#include <fmt/format.h>
 
 using namespace UI;
 
@@ -222,9 +223,8 @@ InfoBoxesConfigWidget::Prepare(ContainerWindow &parent,
 
   DataFieldEnum *dfe = new DataFieldEnum(this);
   for (unsigned i = 0; i < layout.info_boxes.count; ++i) {
-    char label[32];
-    sprintf(label, "%u", i + 1);
-    dfe->addEnumText(label, i);
+    const auto label = fmt::format_int(i + 1);
+    dfe->addEnumText(label.c_str(), i);
   }
 
   Add(_("InfoBox"), nullptr, dfe);

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -17,7 +17,8 @@
 #include "ActionInterface.hpp"
 #include "Language/Language.hpp"
 
-#include <stdio.h>
+#include <algorithm>
+#include <fmt/format.h>
 
 class RASPSettingsPanel final
   : public RowFormWidget {
@@ -86,8 +87,11 @@ RASPSettingsPanel::UpdateTimeControl() noexcept
     time_df.addEnumText(_("Now"));
 
     rasp->ForEachTime(item_index, [&time_df](BrokenTime t){
-        char timetext[10];
-        sprintf(timetext, "%02u:%02u", t.hour, t.minute);
+        char timetext[8];
+        const auto result = fmt::format_to_n(timetext, sizeof(timetext) - 1,
+                                             "{:02}:{:02}", t.hour, t.minute);
+        const size_t length = std::min(result.size, sizeof(timetext) - 1);
+        timetext[length] = '\0';
         time_df.addEnumText(timetext, t.GetMinuteOfDay());
       });
 

--- a/src/Dialogs/dlgAnalysis.cpp
+++ b/src/Dialogs/dlgAnalysis.cpp
@@ -469,7 +469,7 @@ AnalysisWidget::Update()
     StringFormatUnsafe(sTmp, "%s: %s", _("Analysis"),
                        _("Barograph"));
     dialog.SetCaption(sTmp);
-    BarographCaption(sTmp, glide_computer.GetFlightStats());
+    BarographCaption(sTmp, sizeof(sTmp), glide_computer.GetFlightStats());
     info.SetText(sTmp);
     SetCalcCaption(_("Settings"));
     break;
@@ -478,7 +478,7 @@ AnalysisWidget::Update()
     StringFormatUnsafe(sTmp, "%s: %s", _("Analysis"),
                        _("Climb"));
     dialog.SetCaption(sTmp);
-    ClimbChartCaption(sTmp, glide_computer.GetFlightStats());
+    ClimbChartCaption(sTmp, sizeof(sTmp), glide_computer.GetFlightStats());
     info.SetText(sTmp);
     SetCalcCaption(_("Task Calc"));
     break;
@@ -487,7 +487,7 @@ AnalysisWidget::Update()
     StringFormatUnsafe(sTmp, "%s: %s", _("Analysis"),
                        _("Thermal Band"));
     dialog.SetCaption(sTmp);
-    ClimbChartCaption(sTmp, glide_computer.GetFlightStats());
+    ClimbChartCaption(sTmp, sizeof(sTmp), glide_computer.GetFlightStats());
     info.SetText(sTmp);
     SetCalcCaption("");
     break;
@@ -513,7 +513,7 @@ AnalysisWidget::Update()
                        _("Glide Polar"), _("Mass"),
                        (int)settings_computer.polar.glide_polar_task.GetTotalMass());
     dialog.SetCaption(sTmp);
-    GlidePolarCaption(sTmp, settings_computer.polar.glide_polar_task);
+    GlidePolarCaption(sTmp, sizeof(sTmp), settings_computer.polar.glide_polar_task);
     info.SetText(sTmp);
     SetCalcCaption(_("Settings"));
     break;
@@ -522,7 +522,7 @@ AnalysisWidget::Update()
     StringFormatUnsafe(sTmp, "%s: %s", _("Analysis"),
                        _("MacCready Speeds"));
     dialog.SetCaption(sTmp);
-    MacCreadyCaption(sTmp, settings_computer.polar.glide_polar_task);
+    MacCreadyCaption(sTmp, sizeof(sTmp), settings_computer.polar.glide_polar_task);
     info.SetText(sTmp);
     SetCalcCaption(_("Settings"));
     break;
@@ -540,7 +540,7 @@ AnalysisWidget::Update()
     StringFormatUnsafe(sTmp, "%s: %s", _("Analysis"),
                        _("Task Speed"));
     dialog.SetCaption(sTmp);
-    TaskSpeedCaption(sTmp, glide_computer.GetFlightStats(),
+    TaskSpeedCaption(sTmp, sizeof(sTmp), glide_computer.GetFlightStats(),
                      settings_computer.polar.glide_polar_task);
     info.SetText(sTmp);
     SetCalcCaption(_("Task Calc"));

--- a/src/Form/DataField/Angle.cpp
+++ b/src/Form/DataField/Angle.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Angle.hpp"
+#include "util/StringFormat.hpp"
 #include "ComboList.hpp"
 #include "util/Macros.hpp"
 
@@ -53,14 +54,14 @@ AngleDataField::ModifyValue(Angle _value) noexcept
 const char *
 AngleDataField::GetAsString() const noexcept
 {
-  sprintf(string_buffer, "%u", GetIntegerValue());
+  StringFormat(string_buffer, sizeof(string_buffer), "%u", GetIntegerValue());
   return string_buffer;
 }
 
 const char *
 AngleDataField::GetAsDisplayString() const noexcept
 {
-  sprintf(string_buffer, "%u°", GetIntegerValue());
+  StringFormat(string_buffer, sizeof(string_buffer), "%u°", GetIntegerValue());
   return string_buffer;
 }
 
@@ -89,8 +90,8 @@ static void
 AppendComboValue(ComboList &combo_list, unsigned value) noexcept
 {
   char buffer1[16], buffer2[16];
-  sprintf(buffer1, "%u", value);
-  sprintf(buffer2, "%u°", value);
+  StringFormat(buffer1, sizeof(buffer1), "%u", value);
+  StringFormat(buffer2, sizeof(buffer2), "%u°", value);
   combo_list.Append(value, buffer1, buffer2);
 }
 

--- a/src/Form/DataField/Float.cpp
+++ b/src/Form/DataField/Float.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Float.hpp"
+#include "util/StringFormat.hpp"
 #include "ComboList.hpp"
 #include "Math/Util.hpp"
 #include "util/NumberParser.hpp"
@@ -13,14 +14,14 @@ static bool DataFieldKeyUp = false;
 const char *
 DataFieldFloat::GetAsString() const noexcept
 {
-  sprintf(mOutBuf, edit_format, (double)mValue);
+  StringFormat(mOutBuf, sizeof(mOutBuf), edit_format, (double)mValue);
   return mOutBuf;
 }
 
 const char *
 DataFieldFloat::GetAsDisplayString() const noexcept
 {
-  sprintf(mOutBuf, display_format, (double)mValue, unit.c_str());
+  StringFormat(mOutBuf, sizeof(mOutBuf), display_format, (double)mValue, unit.c_str());
   return mOutBuf;
 }
 
@@ -94,8 +95,8 @@ DataFieldFloat::AppendComboValue(ComboList &combo_list,
                                  double value) const noexcept
 {
   char a[decltype(edit_format)::capacity()], b[decltype(display_format)::capacity()];
-  sprintf(a, edit_format, (double)value);
-  sprintf(b, display_format, (double)value, unit.c_str());
+  StringFormat(a, sizeof(a), edit_format, (double)value);
+  StringFormat(b, sizeof(b), display_format, (double)value, unit.c_str());
   combo_list.Append(a, b);
 }
 

--- a/src/Form/DataField/Integer.cpp
+++ b/src/Form/DataField/Integer.cpp
@@ -4,8 +4,7 @@
 #include "Integer.hpp"
 #include "ComboList.hpp"
 #include "util/NumberParser.hpp"
-
-#include <stdio.h>
+#include "util/StringFormat.hpp"
 
 static bool datafield_key_up = false;
 
@@ -19,14 +18,14 @@ ParseString(const char *s) noexcept
 const char *
 DataFieldInteger::GetAsString() const noexcept
 {
-  sprintf(output_buffer, edit_format, value);
+  StringFormat(output_buffer, sizeof(output_buffer), edit_format, value);
   return output_buffer;
 }
 
 const char *
 DataFieldInteger::GetAsDisplayString() const noexcept
 {
-  sprintf(output_buffer, display_format, value);
+  StringFormat(output_buffer, sizeof(output_buffer), display_format, value);
   return output_buffer;
 }
 
@@ -84,8 +83,8 @@ DataFieldInteger::AppendComboValue(ComboList &combo_list,
                                    int value) const noexcept
 {
   char a[decltype(edit_format)::capacity()], b[decltype(display_format)::capacity()];
-  sprintf(a, edit_format, value);
-  sprintf(b, display_format, value);
+  StringFormat(a, sizeof(a), edit_format, value);
+  StringFormat(b, sizeof(b), display_format, value);
   combo_list.Append(combo_list.size(), a, b);
 }
 

--- a/src/Form/DataField/RoughTime.cpp
+++ b/src/Form/DataField/RoughTime.cpp
@@ -2,9 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "RoughTime.hpp"
+#include "util/StringFormat.hpp"
 #include "time/BrokenDateTime.hpp"
-
-#include <stdio.h>
 
 static char buffer[8];
 
@@ -24,7 +23,7 @@ RoughTimeDataField::GetAsString() const noexcept
   if (!value.IsValid())
     return "";
 
-  sprintf(buffer, "%02u:%02u", value.GetHour(), value.GetMinute());
+  StringFormat(buffer, sizeof(buffer), "%02u:%02u", value.GetHour(), value.GetMinute());
   return buffer;
 }
 
@@ -35,8 +34,8 @@ RoughTimeDataField::GetAsDisplayString() const noexcept
     return "";
 
   RoughTime local_value = value + time_zone;
-  sprintf(buffer, "%02u:%02u",
-            local_value.GetHour(), local_value.GetMinute());
+  StringFormat(buffer, sizeof(buffer), "%02u:%02u",
+           local_value.GetHour(), local_value.GetMinute());
   return buffer;
 }
 

--- a/src/Form/DigitEntry.cpp
+++ b/src/Form/DigitEntry.cpp
@@ -17,10 +17,9 @@
 #include "Geo/CoordinateFormat.hpp"
 #include "Formatter/TimeFormatter.hpp"
 #include "Asset.hpp"
+#include "util/StringFormat.hpp"
 
 #include <algorithm>
-
-#include <stdio.h>
 
 DigitEntry::DigitEntry(const DialogLook &_look)
   :look(_look),
@@ -1021,17 +1020,17 @@ DigitEntry::OnPaint(Canvas &canvas) noexcept
 
     case Column::Type::HOUR:
       assert(c.value < 24);
-      sprintf(buffer, "%02u", c.value);
+      StringFormat(buffer, sizeof(buffer), "%02u", c.value);
       break;
 
     case Column::Type::DIGIT36:
       assert(c.value < 36);
-      sprintf(buffer, "%02u", c.value);
+      StringFormat(buffer, sizeof(buffer), "%02u", c.value);
       break;
 
     case Column::Type::DIGIT19:
       assert(c.value < 19);
-      sprintf(buffer, "%02u", c.value);
+      StringFormat(buffer, sizeof(buffer), "%02u", c.value);
       break;
 
     case Column::Type::SIGN:
@@ -1067,13 +1066,13 @@ DigitEntry::OnPaint(Canvas &canvas) noexcept
       break;
 
     case Column::Type::DAY:
-      sprintf(buffer, "%02u", c.value + 1);
+      StringFormat(buffer, sizeof(buffer), "%02u", c.value + 1);
       break;
     case Column::Type::MONTH:
-      sprintf(buffer, "%02u", c.value + 1);
+      StringFormat(buffer, sizeof(buffer), "%02u", c.value + 1);
       break;
     case Column::Type::YEAR:
-      sprintf(buffer, "%04u", c.value + 1900);
+      StringFormat(buffer, sizeof(buffer), "%04u", c.value + 1900);
       break;
 
     case Column::Type::UNIT:

--- a/src/Formatter/TimeFormatter.cpp
+++ b/src/Formatter/TimeFormatter.cpp
@@ -4,6 +4,7 @@
 #include "TimeFormatter.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "Math/Util.hpp"
+#include "util/StringFormat.hpp"
 #include "util/StringCompare.hxx"
 #include "util/StaticString.hxx"
 
@@ -13,16 +14,16 @@
 void
 FormatISO8601(char *buffer, const BrokenDate &date) noexcept
 {
-  sprintf(buffer, "%04u-%02u-%02u",
-          date.year, date.month, date.day);
+  StringFormat(buffer, 11, "%04u-%02u-%02u",
+               date.year, date.month, date.day);
 }
 
 void
 FormatISO8601(char *buffer, const BrokenDateTime &stamp) noexcept
 {
-  sprintf(buffer, "%04u-%02u-%02uT%02u:%02u:%02uZ",
-          stamp.year, stamp.month, stamp.day,
-          stamp.hour, stamp.minute, stamp.second);
+  StringFormat(buffer, 21, "%04u-%02u-%02uT%02u:%02u:%02uZ",
+               stamp.year, stamp.month, stamp.day,
+               stamp.hour, stamp.minute, stamp.second);
 }
 
 
@@ -35,8 +36,8 @@ FormatTime(char *buffer, FloatDuration _time) noexcept
   }
 
   const BrokenTime time = BrokenTime::FromSinceMidnightChecked(_time);
-  sprintf(buffer, "%02u:%02u:%02u",
-            time.hour, time.minute, time.second);
+  StringFormat(buffer, 9, "%02u:%02u:%02u",
+               time.hour, time.minute, time.second);
 }
 
 void
@@ -47,13 +48,18 @@ FormatTimeLong(char *buffer, FloatDuration _time) noexcept
     _time = -_time;
   }
 
-  const BrokenTime time = BrokenTime::FromSinceMidnightChecked(_time);
+  auto time = BrokenTime::FromSinceMidnightChecked(_time);
 
   _time -= FloatDuration{trunc(_time.count())};
   unsigned millisecond = uround(_time.count() * 1000);
 
-  sprintf(buffer, "%02u:%02u:%02u.%03u",
-            time.hour, time.minute, time.second, millisecond);
+  if (millisecond == 1000) {
+    millisecond = 0;
+    time = time + std::chrono::seconds{1};
+  }
+
+  StringFormat(buffer, 13, "%02u:%02u:%02u.%03u",
+               time.hour, time.minute, time.second, millisecond);
 }
 
 void
@@ -65,7 +71,7 @@ FormatSignedTimeHHMM(char *buffer, std::chrono::seconds _time) noexcept
   }
 
   const BrokenTime time = BrokenTime::FromSinceMidnightChecked(_time);
-  sprintf(buffer, "%02u:%02u", time.hour, time.minute);
+  StringFormat(buffer, 6, "%02u:%02u", time.hour, time.minute);
 }
 
 void
@@ -90,10 +96,10 @@ FormatTimeTwoLines(char *buffer1, char *buffer2, std::chrono::seconds _time) noe
 
   if (time.hour > 0) { // hh:mm, ss
     // Set Value
-    sprintf(buffer1, "%02u:%02u", time.hour, time.minute);
-    sprintf(buffer2, "%02u", time.second);
+    StringFormat(buffer1, 6, "%02u:%02u", time.hour, time.minute);
+    StringFormat(buffer2, 3, "%02u", time.second);
   } else { // mm'ss
-    sprintf(buffer1, "%02u'%02u", time.minute, time.second);
+    StringFormat(buffer1, 6, "%02u'%02u", time.minute, time.second);
     buffer2[0] = '\0';
   }
 }

--- a/src/Formatter/Units.cpp
+++ b/src/Formatter/Units.cpp
@@ -31,17 +31,20 @@ FormatMass(char *buffer, double value, Unit unit,
 }
 
 void
-FormatWingLoading(char *buffer, double value, Unit unit,
+FormatWingLoading(char *buffer, size_t buffer_size, double value, Unit unit,
                   bool include_unit)
 {
+  if (buffer == nullptr || buffer_size == 0)
+    return;
+
   const auto uvalue = Units::ToUserUnit(value, unit);
   int precision = uvalue > 20 ? 0 : 1;
 
-    if (include_unit)
-      sprintf(buffer, "%.*f %s", precision, (double)uvalue,
-                Units::GetUnitName(unit));
-    else
-      sprintf(buffer, "%.*f", precision, (double)uvalue);
+  if (include_unit)
+    StringFormat(buffer, buffer_size, "%.*f %s", precision, (double)uvalue,
+                 Units::GetUnitName(unit));
+  else
+    StringFormat(buffer, buffer_size, "%.*f", precision, (double)uvalue);
 }
 
 void

--- a/src/Formatter/Units.hpp
+++ b/src/Formatter/Units.hpp
@@ -5,6 +5,8 @@
 
 #include "Units/Unit.hpp"
 
+#include <cstddef>
+
 class AtmosphericPressure;
 
 /**
@@ -34,13 +36,13 @@ FormatMass(char *buffer, double value, Unit unit,
 /**
  * Converts a wing loading into a formatted string
  * @param buffer buffer string to write to (pointer)
- * @param size Size of the buffer
+ * @param buffer_size size of the buffer in bytes
  * @param value the wing loading
  * @param unit the wing loading unit (e.g. kg/m2, ...)
  * @param include_unit include the unit into the string?
  */
 void
-FormatWingLoading(char *buffer, double value, Unit unit,
+FormatWingLoading(char *buffer, size_t buffer_size, double value, Unit unit,
                   bool include_unit = true);
 
 /**

--- a/src/Formatter/UserUnits.cpp
+++ b/src/Formatter/UserUnits.cpp
@@ -9,9 +9,10 @@
 #include <stdio.h>
 
 void
-FormatUserWingLoading(double value, char *buffer, bool include_unit) noexcept
+FormatUserWingLoading(double value, char *buffer, size_t size,
+                      bool include_unit) noexcept
 {
-  FormatWingLoading(buffer, value, Units::GetUserWingLoadingUnit(),
+  FormatWingLoading(buffer, size, value, Units::GetUserWingLoadingUnit(),
                     include_unit);
 }
 

--- a/src/Formatter/UserUnits.hpp
+++ b/src/Formatter/UserUnits.hpp
@@ -7,6 +7,8 @@
 #include "util/StringBuffer.hxx"
 #include "util/Compiler.h"
 
+#include <cstddef>
+
 class AtmosphericPressure;
 
 /**
@@ -16,7 +18,7 @@ class AtmosphericPressure;
  * @param size Size of the buffer
  */
 void
-FormatUserWingLoading(double value, char *buffer,
+FormatUserWingLoading(double value, char *buffer, size_t size,
                       bool include_unit = true) noexcept;
 
 /**

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -9,6 +9,7 @@
 #include "Math/FastRotation.hpp"
 #include "Units/Units.hpp"
 #include "Units/Descriptor.hpp"
+#include "lib/fmt/ToBuffer.hxx"
 
 #include <algorithm> // for std::clamp()
 
@@ -515,12 +516,11 @@ GaugeVario::RenderValue(Canvas &canvas, const LabelValueGeometry &g,
   }
 
   if (!IsPersistent() || (dirty && di.value.last_value != value)) {
-    char buffer[18];
+    const auto buffer = FmtBuffer<18>("{:.1f}", value);
     canvas.SetBackgroundColor(look.background_color);
     canvas.SetTextColor(look.text_color);
-    sprintf(buffer, "%.1f", (double)value);
     canvas.Select(look.value_font);
-    const unsigned width = canvas.CalcTextSize(buffer).width;
+    const unsigned width = canvas.CalcTextSize(buffer.c_str()).width;
 
     const PixelPoint text_position{g.value_right - (int)width, g.value_y};
 
@@ -531,12 +531,12 @@ GaugeVario::RenderValue(Canvas &canvas, const LabelValueGeometry &g,
       rc.right = g.value_right;
       rc.bottom = g.value_bottom;
 
-      canvas.DrawOpaqueText(text_position, rc, buffer);
+      canvas.DrawOpaqueText(text_position, rc, buffer.c_str());
 
       di.value.last_width = width;
       di.value.last_value = value;
     } else {
-      canvas.DrawText(text_position, buffer);
+      canvas.DrawText(text_position, buffer.c_str());
     }
   }
 
@@ -706,14 +706,13 @@ GaugeVario::RenderBallast(Canvas &canvas) noexcept
 
     // new ballast 0, hide value
     if (ballast > 0) {
-      char buffer[18];
-      sprintf(buffer, "%u%%", ballast);
+      const auto buffer = FmtBuffer<18>("{}%", ballast);
       canvas.SetTextColor(look.text_color);
 
       if (IsPersistent())
-        canvas.DrawOpaqueText(g.value_pos, g.value_rect, buffer);
+        canvas.DrawOpaqueText(g.value_pos, g.value_rect, buffer.c_str());
       else
-        canvas.DrawText(g.value_pos, buffer);
+        canvas.DrawText(g.value_pos, buffer.c_str());
     } else if (IsPersistent())
       canvas.DrawFilledRectangle(g.value_rect, look.background_color);
 
@@ -749,13 +748,12 @@ GaugeVario::RenderBugs(Canvas &canvas) noexcept
     }
 
     if (bugs > 0) {
-      char buffer[18];
-      sprintf(buffer, "%d%%", bugs);
+      const auto buffer = FmtBuffer<18>("{}%", bugs);
       canvas.SetTextColor(look.text_color);
       if (IsPersistent())
-        canvas.DrawOpaqueText(g.value_pos, g.value_rect, buffer);
+        canvas.DrawOpaqueText(g.value_pos, g.value_rect, buffer.c_str());
       else
-        canvas.DrawText(g.value_pos, buffer);
+        canvas.DrawText(g.value_pos, buffer.c_str());
     } else if (IsPersistent())
       canvas.DrawFilledRectangle(g.value_rect, look.background_color);
 

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -179,8 +179,8 @@ bool
 IsKoboWifiOn()
 {
 #ifdef KOBO
-  char path[64];
-  sprintf(path, "/sys/class/net/%s", GetKoboWifiInterface());
+  StaticString<64> path;
+  path.Format("/sys/class/net/%s", GetKoboWifiInterface());
   return Directory::Exists(Path{path});
 #else
   return false;

--- a/src/MapWindow/MapWindowTask.cpp
+++ b/src/MapWindow/MapWindowTask.cpp
@@ -13,6 +13,8 @@
 #include "Math/Screen.hpp"
 #include "Look/MapLook.hpp"
 
+#include <fmt/format.h>
+
 void
 MapWindow::DrawTask(Canvas &canvas) noexcept
 {
@@ -129,11 +131,10 @@ MapWindow::DrawTaskOffTrackIndicator(Canvas &canvas) noexcept
     int idist = iround((distance - 1) * 100);
     
     if ((idist != ilast) && (idist > 0) && (idist < 1000)) {
-      char Buffer[5];
-      sprintf(Buffer, "%d", idist);
+      const fmt::format_int text{idist};
       auto sc = render_projection.GeoToScreen(dloc);
-      PixelSize tsize = canvas.CalcTextSize(Buffer);
-      canvas.DrawText(sc - tsize / 2u, Buffer);
+      PixelSize tsize = canvas.CalcTextSize(text.c_str());
+      canvas.DrawText(sc - tsize / 2u, text.c_str());
       ilast = idist;
     }
   }

--- a/src/Profile/AirspaceConfig.cpp
+++ b/src/Profile/AirspaceConfig.cpp
@@ -9,15 +9,21 @@
 #include "Renderer/AirspaceRendererSettings.hpp"
 #include "Airspace/AirspaceComputerSettings.hpp"
 #include "util/Macros.hpp"
+#include "util/StringFormat.hpp"
 
-#include <string.h>
-#include <stdio.h>
+#include <cassert>
 
+template <size_t N>
 static const char *
-MakeAirspaceSettingName(char *buffer, const char *prefix, unsigned n)
+MakeAirspaceSettingName(char (&buffer)[N], const char *prefix, unsigned n)
 {
-  strcpy(buffer, prefix);
-  sprintf(buffer + strlen(buffer), "%u", n);
+  if (prefix == nullptr || prefix[0] == '\0')
+    prefix = "";
+
+  const int written = StringFormat(buffer, N, "%s%u", prefix, n);
+  assert(written > 0 && written < (int)N);
+  if (written <= 0 || static_cast<size_t>(written) >= N)
+    buffer[0] = '\0';
 
   return buffer;
 }
@@ -25,8 +31,6 @@ MakeAirspaceSettingName(char *buffer, const char *prefix, unsigned n)
 /**
  * This function and the "ColourXX" profile keys are deprecated and
  * are only used as a fallback for old profiles.
- *
- * @see Load(unsigned, AirspaceClassRendererSettings &)
  */
 static bool
 GetAirspaceColor(const ProfileMap &map, unsigned i, RGB8Color &color)

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -4,6 +4,7 @@
 #include "DeviceConfig.hpp"
 #include "Map.hpp"
 #include "util/Macros.hpp"
+#include "util/StringFormat.hpp"
 #include "Interface.hpp"
 #include "Device/Config.hpp"
 
@@ -37,16 +38,23 @@ static const char *const port_type_strings[] = {
   NULL
 };
 
+[[nodiscard]]
 static const char *
-MakeDeviceSettingName(char *buffer, const char *prefix, unsigned n,
+MakeDeviceSettingName(char *buffer, size_t buffer_size,
+                      const char *prefix, unsigned n,
                       const char *suffix)
 {
-  strcpy(buffer, prefix);
+  if (prefix == nullptr)
+    prefix = "";
+  if (suffix == nullptr)
+    suffix = "";
 
-  if (n > 0)
-    sprintf(buffer + strlen(buffer), "%u", n + 1);
+  const int written = n > 0
+    ? StringFormat(buffer, buffer_size, "%s%u%s", prefix, n + 1, suffix)
+    : StringFormat(buffer, buffer_size, "%s%s", prefix, suffix);
 
-  strcat(buffer, suffix);
+  if (written < 0 || (size_t)written >= buffer_size)
+    return nullptr;
 
   return buffer;
 }
@@ -69,7 +77,8 @@ ReadPortType(const ProfileMap &map, unsigned n, DeviceConfig::PortType &type)
 {
   char name[64];
 
-  MakeDeviceSettingName(name, "Port", n, "Type");
+  if (MakeDeviceSettingName(name, sizeof(name), "Port", n, "Type") == nullptr)
+    return false;
 
   const char *value = map.Get(name);
   return value != NULL && StringToPortType(value, type);
@@ -79,7 +88,9 @@ static bool
 LoadPath(const ProfileMap &map, DeviceConfig &config, unsigned n)
 {
   char buffer[64];
-  MakeDeviceSettingName(buffer, "Port", n, "Path");
+  if (MakeDeviceSettingName(buffer, sizeof(buffer), "Port", n, "Path") == nullptr)
+    return false;
+
   return map.Get(buffer, config.path);
 }
 
@@ -87,7 +98,8 @@ static bool
 LoadPortIndex(const ProfileMap &map, DeviceConfig &config, unsigned n)
 {
   char buffer[64];
-  MakeDeviceSettingName(buffer, "Port", n, "Index");
+  if (MakeDeviceSettingName(buffer, sizeof(buffer), "Port", n, "Index") == nullptr)
+    return false;
 
   unsigned index;
   if (!map.Get(buffer, index))
@@ -100,7 +112,10 @@ LoadPortIndex(const ProfileMap &map, DeviceConfig &config, unsigned n)
     index = 0;
 
   char path[64];
-  sprintf(path, "COM%u:", index);
+  const int written = StringFormat(path, sizeof(path), "COM%u:", index);
+  if (written < 0 || static_cast<size_t>(written) >= sizeof(path))
+    return false;
+
   config.path = path;
   return true;
 }
@@ -110,21 +125,24 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
                          DeviceConfig &config)
 {
   char buffer[64];
+  const auto make_port_name = [&](const char *suffix) {
+    return MakeDeviceSettingName(buffer, sizeof(buffer), "Port", n, suffix);
+  };
 
   bool have_port_type = ReadPortType(map, n, config.port_type);
 
-  MakeDeviceSettingName(buffer, "Port", n, "BluetoothMAC");
-  map.Get(buffer, config.bluetooth_mac);
+  if (const char *name = make_port_name("BluetoothMAC"); name != nullptr)
+    map.Get(name, config.bluetooth_mac);
 
-  MakeDeviceSettingName(buffer, "Port", n, "IOIOUartID");
-  map.Get(buffer, config.ioio_uart_id);
+  if (const char *name = make_port_name("IOIOUartID"); name != nullptr)
+    map.Get(name, config.ioio_uart_id);
 
-  MakeDeviceSettingName(buffer, "Port", n, "IPAddress");
-  if (!map.Get(buffer, config.ip_address))
+  if (const char *name = make_port_name("IPAddress");
+      name == nullptr || !map.Get(name, config.ip_address))
     config.ip_address.clear();
 
-  MakeDeviceSettingName(buffer, "Port", n, "TCPPort");
-  if (!map.Get(buffer, config.tcp_port))
+  if (const char *name = make_port_name("TCPPort");
+      name == nullptr || !map.Get(name, config.tcp_port))
     config.tcp_port = 4353;
 
   config.path.clear();
@@ -134,8 +152,8 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
       !LoadPath(map, config, n) && LoadPortIndex(map, config, n))
     config.port_type = DeviceConfig::PortType::SERIAL;
 
-  MakeDeviceSettingName(buffer, "Port", n, "BaudRate");
-  if (!map.Get(buffer, config.baud_rate)) {
+  if (const char *name = make_port_name("BaudRate");
+      name == nullptr || !map.Get(name, config.baud_rate)) {
     /* XCSoar before 6.2 used to store a "speed index", not the real
        baud rate - try to import the old settings */
 
@@ -150,64 +168,65 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
       115200
     };
 
-    MakeDeviceSettingName(buffer, "Speed", n, "Index");
     unsigned speed_index;
-    if (map.Get(buffer, speed_index) &&
+    if (const char *speed_name =
+          MakeDeviceSettingName(buffer, sizeof(buffer), "Speed", n, "Index");
+        speed_name != nullptr && map.Get(speed_name, speed_index) &&
         speed_index < ARRAY_SIZE(speed_index_table))
       config.baud_rate = speed_index_table[speed_index];
   }
 
-  MakeDeviceSettingName(buffer, "Port", n, "BulkBaudRate");
-  if (!map.Get(buffer, config.bulk_baud_rate))
+  if (const char *name = make_port_name("BulkBaudRate");
+      name == nullptr || !map.Get(name, config.bulk_baud_rate))
     config.bulk_baud_rate = 0;
 
   strcpy(buffer, "DeviceA");
   buffer[strlen(buffer) - 1] += n;
   map.Get(buffer, config.driver_name);
 
-  MakeDeviceSettingName(buffer, "Port", n, "Enabled");
-  map.Get(buffer, config.enabled);
+  if (const char *name = make_port_name("Enabled"); name != nullptr)
+    map.Get(name, config.enabled);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SyncFromDevice");
-  map.Get(buffer, config.sync_from_device);
+  if (const char *name = make_port_name("SyncFromDevice"); name != nullptr)
+    map.Get(name, config.sync_from_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
-  map.Get(buffer, config.sync_to_device);
+  if (const char *name = make_port_name("SyncToDevice"); name != nullptr)
+    map.Get(name, config.sync_to_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SendPosition");
-  map.Get(buffer, config.send_position);
+  if (const char *name = make_port_name("SendPosition"); name != nullptr)
+    map.Get(name, config.send_position);
 
-  MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
-  map.Get(buffer, config.k6bt);
+  if (const char *name = make_port_name("K6Bt"); name != nullptr)
+    map.Get(name, config.k6bt);
 
-  MakeDeviceSettingName(buffer, "Port", n, "I2C_Bus");
-  map.Get(buffer, config.i2c_bus);
+  if (const char *name = make_port_name("I2C_Bus"); name != nullptr)
+    map.Get(name, config.i2c_bus);
 
-  MakeDeviceSettingName(buffer, "Port", n, "I2C_Addr");
-  map.Get(buffer, config.i2c_addr);
+  if (const char *name = make_port_name("I2C_Addr"); name != nullptr)
+    map.Get(name, config.i2c_addr);
 
-  MakeDeviceSettingName(buffer, "Port", n, "PressureUse");
-  map.GetEnum(buffer, config.press_use);
+  if (const char *name = make_port_name("PressureUse"); name != nullptr)
+    map.GetEnum(name, config.press_use);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SensorOffset");
-  map.Get(buffer, config.sensor_offset);
+  if (const char *name = make_port_name("SensorOffset"); name != nullptr)
+    map.Get(name, config.sensor_offset);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SensorFactor");
-  map.Get(buffer, config.sensor_factor);
+  if (const char *name = make_port_name("SensorFactor"); name != nullptr)
+    map.Get(name, config.sensor_factor);
 
-  MakeDeviceSettingName(buffer, "Port", n, "UseSecondDevice");
-  map.Get(buffer, config.use_second_device);
+  if (const char *name = make_port_name("UseSecondDevice"); name != nullptr)
+    map.Get(name, config.use_second_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SecondDevice");
-  map.Get(buffer, config.driver2_name);
+  if (const char *name = make_port_name("SecondDevice"); name != nullptr)
+    map.Get(name, config.driver2_name);
 
-  MakeDeviceSettingName(buffer, "Port", n, "EngineType");
-  if (!map.GetEnum(buffer, config.engine_type) ||
+  if (const char *name = make_port_name("EngineType");
+      name == nullptr || !map.GetEnum(name, config.engine_type) ||
       unsigned(config.engine_type) >= unsigned(DeviceConfig::EngineType::MAX))
     config.engine_type = DeviceConfig::EngineType::NONE;
 
-  MakeDeviceSettingName(buffer, "Port", n, "PolarSync");
-  if (!map.GetEnum(buffer, config.polar_sync) ||
+  if (const char *name = make_port_name("PolarSync");
+      name == nullptr || !map.GetEnum(name, config.polar_sync) ||
       unsigned(config.polar_sync) >= unsigned(DeviceConfig::PolarSync::COUNT))
     config.polar_sync = DeviceConfig::PolarSync::OFF;
 }
@@ -229,7 +248,9 @@ WritePortType(ProfileMap &map, unsigned n, DeviceConfig::PortType type)
     return;
 
   char name[64];
-  MakeDeviceSettingName(name, "Port", n, "Type");
+  if (MakeDeviceSettingName(name, sizeof(name), "Port", n, "Type") == nullptr)
+    return;
+
   map.Set(name, value);
 }
 
@@ -238,81 +259,84 @@ Profile::SetDeviceConfig(ProfileMap &map,
                          unsigned n, const DeviceConfig &config)
 {
   char buffer[64];
+  const auto make_port_name = [&](const char *suffix) {
+    return MakeDeviceSettingName(buffer, sizeof(buffer), "Port", n, suffix);
+  };
 
   WritePortType(map, n, config.port_type);
 
-  MakeDeviceSettingName(buffer, "Port", n, "BluetoothMAC");
-  map.Set(buffer, config.bluetooth_mac);
+  if (const char *name = make_port_name("BluetoothMAC"); name != nullptr)
+    map.Set(name, config.bluetooth_mac);
 
-  MakeDeviceSettingName(buffer, "Port", n, "IOIOUartID");
-  map.Set(buffer, config.ioio_uart_id);
+  if (const char *name = make_port_name("IOIOUartID"); name != nullptr)
+    map.Set(name, config.ioio_uart_id);
 
-  MakeDeviceSettingName(buffer, "Port", n, "Path");
-  map.Set(buffer, config.path);
+  if (const char *name = make_port_name("Path"); name != nullptr)
+    map.Set(name, config.path);
 
-  MakeDeviceSettingName(buffer, "Port", n, "BaudRate");
-  map.Set(buffer, config.baud_rate);
+  if (const char *name = make_port_name("BaudRate"); name != nullptr)
+    map.Set(name, config.baud_rate);
 
-  MakeDeviceSettingName(buffer, "Port", n, "BulkBaudRate");
-  map.Set(buffer, config.bulk_baud_rate);
+  if (const char *name = make_port_name("BulkBaudRate"); name != nullptr)
+    map.Set(name, config.bulk_baud_rate);
 
-  MakeDeviceSettingName(buffer, "Port", n, "IPAddress");
-  map.Set(buffer, config.ip_address);
+  if (const char *name = make_port_name("IPAddress"); name != nullptr)
+    map.Set(name, config.ip_address);
 
-  MakeDeviceSettingName(buffer, "Port", n, "TCPPort");
-  map.Set(buffer, config.tcp_port);
+  if (const char *name = make_port_name("TCPPort"); name != nullptr)
+    map.Set(name, config.tcp_port);
 
   strcpy(buffer, "DeviceA");
   buffer[strlen(buffer) - 1] += n;
   map.Set(buffer, config.driver_name);
 
-  MakeDeviceSettingName(buffer, "Port", n, "Enabled");
-  map.Set(buffer, config.enabled);
+  if (const char *name = make_port_name("Enabled"); name != nullptr)
+    map.Set(name, config.enabled);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SyncFromDevice");
-  map.Set(buffer, config.sync_from_device);
+  if (const char *name = make_port_name("SyncFromDevice"); name != nullptr)
+    map.Set(name, config.sync_from_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SyncToDevice");
-  map.Set(buffer, config.sync_to_device);
+  if (const char *name = make_port_name("SyncToDevice"); name != nullptr)
+    map.Set(name, config.sync_to_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SendPosition");
-  map.Set(buffer, config.send_position);
+  if (const char *name = make_port_name("SendPosition"); name != nullptr)
+    map.Set(name, config.send_position);
 
-  MakeDeviceSettingName(buffer, "Port", n, "K6Bt");
-  map.Set(buffer, config.k6bt);
+  if (const char *name = make_port_name("K6Bt"); name != nullptr)
+    map.Set(name, config.k6bt);
 
-  MakeDeviceSettingName(buffer, "Port", n, "I2C_Bus");
-  map.Set(buffer, config.i2c_bus);
+  if (const char *name = make_port_name("I2C_Bus"); name != nullptr)
+    map.Set(name, config.i2c_bus);
 
-  MakeDeviceSettingName(buffer, "Port", n, "I2C_Addr");
-  map.Set(buffer, config.i2c_addr);
+  if (const char *name = make_port_name("I2C_Addr"); name != nullptr)
+    map.Set(name, config.i2c_addr);
 
-  MakeDeviceSettingName(buffer, "Port", n, "PressureUse");
-  map.SetEnum(buffer, config.press_use);
+  if (const char *name = make_port_name("PressureUse"); name != nullptr)
+    map.SetEnum(name, config.press_use);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SensorOffset");
   auto offset = DeviceConfig::UsesCalibration(config.port_type) ? config.sensor_offset : 0;
   // Has new calibration data been delivered ?
   if (CommonInterface::Basic().sensor_calibration_available)
     offset = CommonInterface::Basic().sensor_calibration_offset;
-  map.Set(buffer, offset);
+  if (const char *name = make_port_name("SensorOffset"); name != nullptr)
+    map.Set(name, offset);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SensorFactor");
   auto factor = DeviceConfig::UsesCalibration(config.port_type) ? config.sensor_factor : 0;
   // Has new calibration data been delivered ?
   if (CommonInterface::Basic().sensor_calibration_available)
     factor = CommonInterface::Basic().sensor_calibration_factor;
-  map.Set(buffer, factor);
+  if (const char *name = make_port_name("SensorFactor"); name != nullptr)
+    map.Set(name, factor);
 
-  MakeDeviceSettingName(buffer, "Port", n, "UseSecondDevice");
-  map.Set(buffer, config.use_second_device);
+  if (const char *name = make_port_name("UseSecondDevice"); name != nullptr)
+    map.Set(name, config.use_second_device);
 
-  MakeDeviceSettingName(buffer, "Port", n, "SecondDevice");
-  map.Set(buffer, config.driver2_name);
+  if (const char *name = make_port_name("SecondDevice"); name != nullptr)
+    map.Set(name, config.driver2_name);
 
-  MakeDeviceSettingName(buffer, "Port", n, "EngineType");
-  map.Set(buffer, static_cast<unsigned>(config.engine_type));
+  if (const char *name = make_port_name("EngineType"); name != nullptr)
+    map.SetEnum(name, config.engine_type);
 
-  MakeDeviceSettingName(buffer, "Port", n, "PolarSync");
-  map.Set(buffer, static_cast<unsigned>(config.polar_sync));
+  if (const char *name = make_port_name("PolarSync"); name != nullptr)
+    map.SetEnum(name, config.polar_sync);
 }

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -5,6 +5,9 @@
 #include "Keys.hpp"
 #include "Map.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "util/StringFormat.hpp"
+
+#include <cstring>
 
 using namespace InfoBoxFactory;
 
@@ -17,7 +20,10 @@ GetV60InfoBoxManagerConfig(const ProfileMap &map, InfoBoxSettings &settings)
   strcpy(profileKey, "Info");
 
   for (unsigned i = 0; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i) {
-    sprintf(profileKey + 4, "%u", i);
+    const int n = StringFormat(profileKey + 4, sizeof(profileKey) - 4, "%u", i);
+    if (n < 0 || static_cast<size_t>(n) >= sizeof(profileKey) - 4)
+      continue;
+
     unsigned int temp = 0;
     if (map.Get(profileKey, temp)) {
       settings.panels[0].contents[i] = (Type)( temp       & 0xFF);
@@ -125,14 +131,26 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
     InfoBoxSettings::Panel &panel = settings.panels[i];
 
     if (i >= settings.PREASSIGNED_PANELS) {
-      sprintf(profileKey, "InfoBoxPanel%uName", i);
-      map.Get(profileKey, panel.name);
-      if (panel.name.empty())
-        sprintf(panel.name.buffer(), "AUX-%u", i-2);
+      const int n = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uName", i);
+      if (n >= 0 && static_cast<size_t>(n) < sizeof(profileKey))
+        map.Get(profileKey, panel.name);
+
+      if (panel.name.empty()) {
+        const unsigned aux_index = i - settings.PREASSIGNED_PANELS + 1;
+        const int written = StringFormat(panel.name.buffer(),
+                                         panel.name.capacity(),
+                                         "AUX-%u", aux_index);
+        if (written < 0 ||
+            static_cast<size_t>(written) >= panel.name.capacity())
+          panel.name.clear();
+      }
     }
 
     for (unsigned j = 0; j < panel.MAX_CONTENTS; ++j) {
-      sprintf(profileKey, "InfoBoxPanel%uBox%u", i, j);
+      const int n = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uBox%u", i, j);
+      if (n < 0 || static_cast<size_t>(n) >= sizeof(profileKey))
+        continue;
+
       GetIBType(map, profileKey, panel.contents[j]);
     }
   }
@@ -145,12 +163,14 @@ Profile::Save(ProfileMap &map,
   char profileKey[32];
 
   if (index >= InfoBoxSettings::PREASSIGNED_PANELS) {
-    sprintf(profileKey, "InfoBoxPanel%uName", index);
-    map.Set(profileKey, panel.name);
+    const int n = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uName", index);
+    if (n >= 0 && static_cast<size_t>(n) < sizeof(profileKey))
+      map.Set(profileKey, panel.name);
   }
 
   for (unsigned j = 0; j < panel.MAX_CONTENTS; ++j) {
-    sprintf(profileKey, "InfoBoxPanel%uBox%u", index, j);
-    map.Set(profileKey, panel.contents[j]);
+    const int n = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uBox%u", index, j);
+    if (n >= 0 && static_cast<size_t>(n) < sizeof(profileKey))
+      map.Set(profileKey, panel.contents[j]);
   }
 }

--- a/src/Profile/NumericValue.cpp
+++ b/src/Profile/NumericValue.cpp
@@ -3,6 +3,7 @@
 
 #include "Map.hpp"
 #include "util/NumberParser.hpp"
+#include "util/StringFormat.hpp"
 
 bool
 ProfileMap::Get(std::string_view key, int &value) const noexcept
@@ -119,7 +120,10 @@ void
 ProfileMap::Set(std::string_view key, int value) noexcept
 {
   char tmp[50];
-  sprintf(tmp, "%d", value);
+  const int written = StringFormat(tmp, sizeof(tmp), "%d", value);
+  if (written < 0 || written >= (int)sizeof(tmp))
+    return;
+
   Set(key, tmp);
 }
 
@@ -127,7 +131,10 @@ void
 ProfileMap::Set(std::string_view key, long value) noexcept
 {
   char tmp[50];
-  sprintf(tmp, "%ld", value);
+  const int written = StringFormat(tmp, sizeof(tmp), "%ld", value);
+  if (written < 0 || written >= (int)sizeof(tmp))
+    return;
+
   Set(key, tmp);
 }
 
@@ -135,7 +142,10 @@ void
 ProfileMap::Set(std::string_view key, unsigned value) noexcept
 {
   char tmp[50];
-  sprintf(tmp, "%u", value);
+  const int written = StringFormat(tmp, sizeof(tmp), "%u", value);
+  if (written < 0 || written >= (int)sizeof(tmp))
+    return;
+
   Set(key, tmp);
 }
 
@@ -143,6 +153,9 @@ void
 ProfileMap::Set(std::string_view key, double value) noexcept
 {
   char tmp[50];
-  sprintf(tmp, "%f", value);
+  const int written = StringFormat(tmp, sizeof(tmp), "%.17g", value);
+  if (written < 0 || written >= (int)sizeof(tmp))
+    return;
+
   Set(key, tmp);
 }

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -6,6 +6,9 @@
 #include "Map.hpp"
 #include "PageSettings.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "util/StringFormat.hpp"
+
+#include <stdio.h>
 
 /**
  * Old enum moved from PageSettings.
@@ -20,8 +23,8 @@ static void
 Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
 {
   char profileKey[32];
-  unsigned prefixLen = sprintf(profileKey, "Page%u", page);
-  if (prefixLen <= 0)
+  int prefixLen = StringFormat(profileKey, sizeof(profileKey), "Page%u", page);
+  if (prefixLen <= 0 || (size_t)prefixLen >= sizeof(profileKey))
     return;
 
   PageLayout pl = PageLayout::Default();
@@ -78,8 +81,8 @@ void
 Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
 {
   char profileKey[32];
-  unsigned prefixLen = sprintf(profileKey, "Page%u", i);
-  if (prefixLen <= 0)
+  int prefixLen = StringFormat(profileKey, sizeof(profileKey), "Page%u", i);
+  if (prefixLen <= 0 || (size_t)prefixLen >= sizeof(profileKey))
     return;
   strcpy(profileKey + prefixLen, "InfoBoxMode");
   map.Set(profileKey, page.infobox_config.auto_switch);

--- a/src/Renderer/BarographRenderer.cpp
+++ b/src/Renderer/BarographRenderer.cpp
@@ -15,28 +15,40 @@
 #include "Engine/Task/TaskManager.hpp"
 #include "TaskLegRenderer.hpp"
 #include "GradientRenderer.hpp"
+#include "util/UTF8.hpp"
+
+#include <fmt/format.h>
 
 void
-BarographCaption(char *sTmp, const FlightStatistics &fs)
+BarographCaption(char *sTmp, size_t buffer_size, const FlightStatistics &fs)
 {
+  if (sTmp == nullptr || buffer_size == 0)
+    return;
+
   const std::lock_guard lock{fs.mutex};
+
   if (!fs.altitude_ceiling.HasResult() || fs.altitude_base.IsEmpty()) {
     sTmp[0] = '\0';
   } else if (fs.altitude_ceiling.GetCount() < 4) {
-    StringFormatUnsafe(sTmp, "%s:\r\n  %.0f-%.0f %s",
-                       _("Working band"),
-                       (double)Units::ToUserAltitude(fs.GetMinWorkingHeight()),
-                       (double)Units::ToUserAltitude(fs.GetMaxWorkingHeight()),
-                       Units::GetAltitudeName());
+    auto result = fmt::format_to_n(sTmp, buffer_size - 1, "{}:\r\n  {:.0f}-{:.0f} {}",
+                                   _("Working band"),
+                                   (double)Units::ToUserAltitude(fs.GetMinWorkingHeight()),
+                                   (double)Units::ToUserAltitude(fs.GetMaxWorkingHeight()),
+                                   Units::GetAltitudeName());
+    *result.out = '\0';
+    CropIncompleteUTF8(sTmp);
   } else {
-    StringFormatUnsafe(sTmp, "%s:\r\n  %.0f-%.0f %s\r\n\r\n%s:\r\n  %.0f %s/hr",
-                       _("Working band"),
-                       (double)Units::ToUserAltitude(fs.GetMinWorkingHeight()),
-                       (double)Units::ToUserAltitude(fs.GetMaxWorkingHeight()),
-                       Units::GetAltitudeName(),
-                       _("Ceiling trend"),
-                       (double)Units::ToUserAltitude(fs.altitude_ceiling.GetGradient()),
-                       Units::GetAltitudeName());
+    auto result = fmt::format_to_n(sTmp, buffer_size - 1,
+                                   "{}:\r\n  {:.0f}-{:.0f} {}\r\n\r\n{}:\r\n  {:.0f} {}/hr",
+                                   _("Working band"),
+                                   (double)Units::ToUserAltitude(fs.GetMinWorkingHeight()),
+                                   (double)Units::ToUserAltitude(fs.GetMaxWorkingHeight()),
+                                   Units::GetAltitudeName(),
+                                   _("Ceiling trend"),
+                                   (double)Units::ToUserAltitude(fs.altitude_ceiling.GetGradient()),
+                                   Units::GetAltitudeName());
+    *result.out = '\0';
+    CropIncompleteUTF8(sTmp);
   }
 }
 

--- a/src/Renderer/BarographRenderer.hpp
+++ b/src/Renderer/BarographRenderer.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 struct PixelRect;
 class Canvas;
 struct ChartLook;
@@ -14,7 +16,7 @@ class ProtectedTaskManager;
 class TaskManager;
 
 void
-BarographCaption(char *buffer, const FlightStatistics &fs);
+BarographCaption(char *buffer, size_t buffer_size, const FlightStatistics &fs);
 
 void
 RenderBarographSpark(Canvas &canvas, const PixelRect rc,

--- a/src/Renderer/ClimbChartRenderer.cpp
+++ b/src/Renderer/ClimbChartRenderer.cpp
@@ -14,28 +14,36 @@
 #include "Engine/Task/TaskManager.hpp"
 #include "TaskLegRenderer.hpp"
 #include "GradientRenderer.hpp"
+#include "util/UTF8.hpp"
 
 void
-ClimbChartCaption(char *sTmp,
+ClimbChartCaption(char *sTmp, size_t buffer_size,
                   const FlightStatistics &fs)
 {
+  if (sTmp == nullptr || buffer_size == 0)
+    return;
+
   const std::lock_guard lock{fs.mutex};
+
   if (fs.thermal_average.IsEmpty()) {
     sTmp[0] = '\0';
+    return;
   } else if (fs.thermal_average.GetCount() == 1) {
-    StringFormatUnsafe(sTmp, "%s:\r\n  %3.1f %s",
-                       _("Avg. climb"),
-                       (double)Units::ToUserVSpeed(fs.thermal_average.GetAverageY()),
-                       Units::GetVerticalSpeedName());
+    StringFormat(sTmp, buffer_size, "%s:\r\n  %3.1f %s",
+                 _("Avg. climb"),
+                 (double)Units::ToUserVSpeed(fs.thermal_average.GetAverageY()),
+                 Units::GetVerticalSpeedName());
   } else {
-    StringFormatUnsafe(sTmp, "%s:\r\n  %3.1f %s\r\n\r\n%s:\r\n  %3.2f %s/hr",
-                       _("Avg. climb"),
-                       (double)Units::ToUserVSpeed(fs.thermal_average.GetAverageY()),
-                       Units::GetVerticalSpeedName(),
-                       _("Climb trend"),
-                       (double)Units::ToUserVSpeed(fs.thermal_average.GetGradient()),
-                       Units::GetVerticalSpeedName());
+    StringFormat(sTmp, buffer_size, "%s:\r\n  %3.1f %s\r\n\r\n%s:\r\n  %3.2f %s/hr",
+                 _("Avg. climb"),
+                 (double)Units::ToUserVSpeed(fs.thermal_average.GetAverageY()),
+                 Units::GetVerticalSpeedName(),
+                 _("Climb trend"),
+                 (double)Units::ToUserVSpeed(fs.thermal_average.GetGradient()),
+                 Units::GetVerticalSpeedName());
   }
+
+  CropIncompleteUTF8(sTmp);
 }
 
 void

--- a/src/Renderer/ClimbChartRenderer.hpp
+++ b/src/Renderer/ClimbChartRenderer.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 struct PixelRect;
 class Canvas;
 struct ChartLook;
@@ -13,7 +15,7 @@ struct DerivedInfo;
 class TaskManager;
 
 void
-ClimbChartCaption(char *buffer,
+ClimbChartCaption(char *buffer, size_t buffer_size,
                   const FlightStatistics &fs);
 
 void

--- a/src/Renderer/GlidePolarInfoRenderer.cpp
+++ b/src/Renderer/GlidePolarInfoRenderer.cpp
@@ -33,7 +33,7 @@ RenderGlidePolarInfo(Canvas &canvas, const PixelRect rc,
 
   double wl = glide_polar.GetWingLoading();
   if (wl != 0) {
-    FormatUserWingLoading(wl, value.buffer(), true);
+    FormatUserWingLoading(wl, value.buffer(), value.capacity(), true);
 
     text.Format("%s: %s", _("Wing loading"), value.c_str());
 

--- a/src/Renderer/GlidePolarRenderer.cpp
+++ b/src/Renderer/GlidePolarRenderer.cpp
@@ -11,30 +11,39 @@
 #include "NMEA/ClimbHistory.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "util/StaticString.hxx"
+#include "util/UTF8.hpp"
 #include "GlidePolarInfoRenderer.hpp"
 
-#include <stdio.h>
+#include <fmt/format.h>
 
 void
-GlidePolarCaption(char *sTmp, const GlidePolar &glide_polar)
+GlidePolarCaption(char *sTmp, size_t buffer_size,
+                  const GlidePolar &glide_polar)
 {
+  if (sTmp == nullptr || buffer_size == 0)
+    return;
+
   if (!glide_polar.IsValid()) {
     *sTmp = '\0';
     return;
   }
 
-  sprintf(sTmp, Layout::landscape ?
-                  "%s:\r\n  %d\r\n  at %d %s\r\n\r\n%s:\r\n  %3.2f %s\r\n  at %d %s" :
-                  "%s:\r\n  %d at %d %s\r\n%s:\r\n  %3.2f %s at %d %s",
-            _("L/D"),
-            (int)glide_polar.GetBestLD(),
-            (int)Units::ToUserSpeed(glide_polar.GetVBestLD()),
-            Units::GetSpeedName(),
-            _("Min. sink"),
-            (double)Units::ToUserVSpeed(glide_polar.GetSMin()),
-            Units::GetVerticalSpeedName(),
-            (int)Units::ToUserSpeed(glide_polar.GetVMin()),
-            Units::GetSpeedName());
+  const char *const format = Layout::landscape
+    ? "{}:\r\n  {}\r\n  at {} {}\r\n\r\n{}:\r\n  {:.2f} {}\r\n  at {} {}"
+    : "{}:\r\n  {} at {} {}\r\n{}:\r\n  {:.2f} {} at {} {}";
+
+  auto result = fmt::format_to_n(sTmp, buffer_size - 1, fmt::runtime(format),
+                                 _("L/D"),
+                                 (int)glide_polar.GetBestLD(),
+                                 (int)Units::ToUserSpeed(glide_polar.GetVBestLD()),
+                                 Units::GetSpeedName(),
+                                 _("Min. sink"),
+                                 (double)Units::ToUserVSpeed(glide_polar.GetSMin()),
+                                 Units::GetVerticalSpeedName(),
+                                 (int)Units::ToUserSpeed(glide_polar.GetVMin()),
+                                 Units::GetSpeedName());
+  *result.out = '\0';
+  CropIncompleteUTF8(sTmp);
 }
 
 void

--- a/src/Renderer/GlidePolarRenderer.hpp
+++ b/src/Renderer/GlidePolarRenderer.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 struct PixelRect;
 class Canvas;
 struct ChartLook;
@@ -10,7 +12,8 @@ class ClimbHistory;
 class GlidePolar;
 
 void
-GlidePolarCaption(char *buffer, const GlidePolar &glide_polar);
+GlidePolarCaption(char *buffer, size_t buffer_size,
+                  const GlidePolar &glide_polar);
 
 void
 RenderGlidePolar(Canvas &canvas, const PixelRect rc,

--- a/src/Renderer/MacCreadyRenderer.cpp
+++ b/src/Renderer/MacCreadyRenderer.cpp
@@ -10,27 +10,33 @@
 #include "Language/Language.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "util/StaticString.hxx"
+#include "util/UTF8.hpp"
 #include "GlidePolarInfoRenderer.hpp"
 
 static constexpr double MAX_MACCREADY = 5.2;
 static constexpr unsigned STEPS_MACCREADY = 25;
 
 void
-MacCreadyCaption(char *sTmp, const GlidePolar &glide_polar)
+MacCreadyCaption(char *sTmp, size_t buffer_size,
+                 const GlidePolar &glide_polar)
 {
+  if (sTmp == nullptr || buffer_size == 0)
+    return;
+
   if (!glide_polar.IsValid()) {
     *sTmp = '\0';
     return;
   }
 
-  sprintf(sTmp,
-            "%s: %d %s\r\n%s: %d %s",
-            _("Vopt"),
-            (int)Units::ToUserSpeed(glide_polar.GetVBestLD()),
-            Units::GetSpeedName(),
-            C_("Average velocity abbreviation", "Vave"),
-            (int)Units::ToUserTaskSpeed(glide_polar.GetAverageSpeed()),
-            Units::GetTaskSpeedName());
+  StringFormat(sTmp, buffer_size,
+               "%s: %d %s\r\n%s: %d %s",
+               _("Vopt"),
+               (int)Units::ToUserSpeed(glide_polar.GetVBestLD()),
+               Units::GetSpeedName(),
+               C_("Average velocity abbreviation", "Vave"),
+               (int)Units::ToUserTaskSpeed(glide_polar.GetAverageSpeed()),
+               Units::GetTaskSpeedName());
+  CropIncompleteUTF8(sTmp);
 }
 
 

--- a/src/Renderer/MacCreadyRenderer.hpp
+++ b/src/Renderer/MacCreadyRenderer.hpp
@@ -3,13 +3,16 @@
 
 #pragma once
 
+#include <cstddef>
+
 struct PixelRect;
 class Canvas;
 struct ChartLook;
 class GlidePolar;
 
 void
-MacCreadyCaption(char *sTmp, const GlidePolar &glide_polar);
+MacCreadyCaption(char *sTmp, size_t buffer_size,
+                 const GlidePolar &glide_polar);
 
 void
 RenderMacCready(Canvas &canvas, const PixelRect rc,

--- a/src/Renderer/TaskSpeedRenderer.cpp
+++ b/src/Renderer/TaskSpeedRenderer.cpp
@@ -13,25 +13,33 @@
 #include "TaskLegRenderer.hpp"
 #include "GradientRenderer.hpp"
 #include "Engine/GlideSolvers/GlidePolar.hpp"
+#include "util/UTF8.hpp"
+
+#include <fmt/format.h>
 
 void
-TaskSpeedCaption(char *sTmp,
+TaskSpeedCaption(char *s_tmp, size_t buffer_size,
                  const FlightStatistics &fs,
                  const GlidePolar &glide_polar)
 {
+  if (s_tmp == nullptr || buffer_size == 0)
+    return;
+
   if (!glide_polar.IsValid() || fs.task_speed.IsEmpty()) {
-    *sTmp = '\0';
+    *s_tmp = '\0';
     return;
   }
 
-  sprintf(sTmp,
-            "%s: %d %s\r\n%s: %d %s",
-            C_("Average velocity abbreviation", "Vave"),
-            (int)Units::ToUserTaskSpeed(fs.task_speed.GetAverageY()),
-            Units::GetTaskSpeedName(),
-            _("Vest"),
-            (int)Units::ToUserTaskSpeed(glide_polar.GetAverageSpeed()),
-            Units::GetTaskSpeedName());
+  auto result = fmt::format_to_n(s_tmp, buffer_size - 1,
+                                 "{}: {} {}\r\n{}: {} {}",
+                                 C_("Average velocity abbreviation", "Vave"),
+                                 (int)Units::ToUserTaskSpeed(fs.task_speed.GetAverageY()),
+                                 Units::GetTaskSpeedName(),
+                                 _("Vest"),
+                                 (int)Units::ToUserTaskSpeed(glide_polar.GetAverageSpeed()),
+                                 Units::GetTaskSpeedName());
+  *result.out = '\0';
+  CropIncompleteUTF8(s_tmp);
 }
 
 void

--- a/src/Renderer/TaskSpeedRenderer.hpp
+++ b/src/Renderer/TaskSpeedRenderer.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 struct PixelRect;
 class Canvas;
 struct ChartLook;
@@ -13,7 +15,7 @@ class TaskManager;
 class GlidePolar;
 
 void
-TaskSpeedCaption(char *sTmp,
+TaskSpeedCaption(char *s_tmp, size_t buffer_size,
                  const FlightStatistics &fs,
                  const GlidePolar &glide_polar);
 

--- a/src/Weather/Rasp/RaspCache.cpp
+++ b/src/Weather/Rasp/RaspCache.cpp
@@ -79,21 +79,20 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
     // no change, quick exit.
     return;
 
-  last_time = effective_time;
+  const unsigned requested_time = effective_time;
 
   effective_time = store.GetNearestTime(parameter, effective_time);
   if (effective_time == RaspStore::MAX_WEATHER_TIMES)
     return;
-
-  map.reset();
 
   auto archive = store.OpenArchive();
   if (!archive)
     return;
 
   char new_name[MAX_PATH];
-  store.WeatherFilename(new_name, Path(store.GetItemInfo(parameter).name),
-                              effective_time);
+  if (!store.WeatherFilename(new_name, Path(store.GetItemInfo(parameter).name),
+                             effective_time))
+    return;
 
   auto new_map = std::make_unique<RasterMap>();
   try {
@@ -108,4 +107,5 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
   new_map->UpdateProjection();
 
   map = std::move(new_map);
+  last_time = requested_time;
 }

--- a/src/Weather/Rasp/RaspStore.cpp
+++ b/src/Weather/Rasp/RaspStore.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "RaspStore.hpp"
+#include "util/StringFormat.hpp"
 #include "Language/Language.hpp"
 #include "Units/Units.hpp"
 #include "system/ConvertPathName.hpp"
@@ -108,13 +109,23 @@ bool
 RaspStore::WeatherFilename(char *filename, Path name,
                                           unsigned time_index)
 {
+  if (filename == nullptr || MAX_PATH <= 0)
+    return false;
+
+  filename[0] = '\0';
+
   const NarrowPathName narrow_name(name);
   if (!narrow_name.IsDefined())
     return false;
 
   const BrokenTime t = IndexToTime(time_index);
-  sprintf(filename, RASP_FORMAT,
-          (const char *)narrow_name, t.hour, t.minute);
+  const int n = StringFormat(filename, MAX_PATH, RASP_FORMAT,
+                         (const char *)narrow_name, t.hour, t.minute);
+  if (n < 0 || n >= MAX_PATH) {
+    filename[0] = '\0';
+    return false;
+  }
+
   return true;
 }
 

--- a/src/Widget/OffsetButtonsWidget.cpp
+++ b/src/Widget/OffsetButtonsWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "OffsetButtonsWidget.hpp"
 #include "Screen/Layout.hpp"
+#include "util/StringFormat.hpp"
 
 #include <algorithm>  // for std::any_of
 #include <stdio.h>
@@ -42,7 +43,11 @@ OffsetButtonsWidget::MakeButton(ContainerWindow &parent, const PixelRect &r,
                                 unsigned i) noexcept
 {
   char caption[16];
-  sprintf(caption, format, offsets[i]);
+  const int n = StringFormat(caption, sizeof(caption), format, offsets[i]);
+  if (n < 0 || n >= (int)sizeof(caption)) {
+    caption[0] = '?';
+    caption[1] = '\0';
+  }
 
   WindowStyle style;
   style.TabStop();

--- a/src/net/Resolver.cxx
+++ b/src/net/Resolver.cxx
@@ -3,6 +3,7 @@
 // author: Max Kellermann <mk@cm4all.com>
 
 #include "Resolver.hxx"
+#include "util/StringFormat.hpp"
 #include "AddressInfo.hxx"
 #include "HostParser.hxx"
 #include "lib/fmt/RuntimeError.hxx"
@@ -17,6 +18,7 @@
 #endif
 
 #include <cstring>
+#include <stdexcept>
 
 #include <stdio.h>
 
@@ -69,7 +71,10 @@ FindAndResolveInterfaceName(char *host, size_t size)
 	if (i == 0)
 		throw FmtRuntimeError("No such interface: {}", interface);
 
-	sprintf(interface, "%u", i);
+	const size_t remaining = host + size - interface;
+	const int n = StringFormat(interface, remaining, "%u", i);
+	if (n < 0 || static_cast<size_t>(n) >= remaining)
+		throw std::runtime_error("Interface index formatting failed");
 }
 
 #endif
@@ -80,6 +85,14 @@ Resolve(const char *host_and_port, int default_port,
 {
 	const char *host, *port;
 	char buffer[256], port_string[16];
+
+	auto make_default_port = [&]() {
+		const int n = StringFormat(port_string, sizeof(port_string), "%d",
+					  default_port);
+		if (n < 0 || n >= (int)sizeof(port_string))
+			throw std::runtime_error("Default port formatting failed");
+		return port_string;
+	};
 
 	if (host_and_port != nullptr) {
 		const auto eh = ExtractHost(host_and_port);
@@ -102,8 +115,7 @@ Resolve(const char *host_and_port, int default_port,
 			++port;
 		} else if (*port == 0) {
 			/* no port specified */
-			snprintf(port_string, sizeof(port_string), "%d", default_port);
-			port = port_string;
+			port = make_default_port();
 		} else
 			throw std::runtime_error("Garbage after host name");
 
@@ -111,8 +123,7 @@ Resolve(const char *host_and_port, int default_port,
 			host = nullptr;
 	} else {
 		host = nullptr;
-		snprintf(port_string, sizeof(port_string), "%d", default_port);
-		port = port_string;
+		port = make_default_port();
 	}
 
 	return Resolve(host, port, hints);

--- a/src/util/MD5.cpp
+++ b/src/util/MD5.cpp
@@ -3,9 +3,9 @@
 
 #include "util/MD5.hpp"
 #include "util/ByteOrder.hxx"
+#include "util/HexFormat.hxx"
 
 #include <algorithm>
-#include <stdio.h>
 
 static constexpr uint32_t k[64] = {
   // k[i] := floor(abs(sin(i)) * (2 pow 32))
@@ -215,7 +215,13 @@ MD5::Process512() noexcept
 char *
 MD5::GetDigest(char *buffer) const noexcept
 {
-  sprintf(buffer, "%08x%08x%08x%08x",
-          ByteSwap32(state.a), ByteSwap32(state.b), ByteSwap32(state.c), ByteSwap32(state.d));
-  return buffer + DIGEST_LENGTH;
+  if (buffer == nullptr)
+    return nullptr;
+
+  char *p = HexFormatUint32Fixed(buffer, ByteSwap32(state.a));
+  p = HexFormatUint32Fixed(p, ByteSwap32(state.b));
+  p = HexFormatUint32Fixed(p, ByteSwap32(state.c));
+  p = HexFormatUint32Fixed(p, ByteSwap32(state.d));
+  *p = '\0';
+  return p;
 }


### PR DESCRIPTION
## Summary

Cherry-picks the low-risk, self-contained commits from #2377 that replace
deprecated `sprintf`/`snprintf` with bounded formatting (`StringFormat`,
`FmtBuffer`, `fmt::format_to_n`).

This is a subset of the full sprintf cleanup: it hardens display, profile,
and analysis code paths without touching device-driver protocols, IGC
generation, or the NMEA checksum API.

**Included (16 commits, 41 files):**
- Dialogs (Airspace, Vega, Settings, Weather, Analysis captions)
- Form / DataField widgets
- Formatter + Renderer (picked together due to `FormatUserWingLoading` API)
- Gauge, MapWindow, Widget, Kobo, Weather/Rasp, net, util (MD5)

**Excluded from #2377 (higher behavioral risk / API coupling):**
- `IGC` — `FormatIGCLocation` / `FormatIGCTaskTimestamp` span API changes
- `Device/Driver` — serial protocol output
- `Device/Util` + `NMEA` — `AppendNMEAChecksum()` signature change
- `test` — follows NMEA API change

Original work by @yorickreum in #2377.

## Test plan

- [x] `make TARGET=UNIX` builds cleanly
- [ ] Open Analysis dialog (barograph, climb, glide polar, MacCready, task speed captions)
- [ ] Edit numeric Form fields (angle, float, integer, rough time)
- [ ] Load/save device profile settings (Port*, DeviceA keys)
- [ ] Gauge vario value/ballast/bugs display on embedded target if available