### PR TITLE
Task/Deserialiser: Normalize loaded task points to task type

### DIFF
--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -313,4 +313,12 @@ LoadTask(OrderedTask &task, const ConstDataNode &node,
   for (const auto &i : children) {
     DeserialiseTaskpoint(fact, *i, waypoints);
   }
+
+  /* 
+    Normalize deserialized taskpoint types to match the task factory type.
+    Some exporters (e.g., WeGlide) may serialize intermediate points with
+    generic types (e.g., "turn") even when the task is declared as AAT.
+  */
+  if (fact.MutateTPsToTaskType())
+    fact.UpdateGeometry();
 }


### PR DESCRIPTION
In short: Downloaded Weglide AAT tasks were not recognized as AAT, even when the task rules said it was (due to WeGlide reporting TP types as "turn" instead of "area" for AAT). In any case WeGlide just showed a shortcoming here: Incorrect TP types "override" set task type which causes infoboxes not showing AAT times and other issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task deserialization process to properly configure taskpoints according to their assigned type and refresh task geometry for accurate representation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->