### PR TITLE
FLARM/MessagingRecord: sanitize field values (filter "undefined")

### DIFF
--- a/src/FLARM/MessagingDatabase.cpp
+++ b/src/FLARM/MessagingDatabase.cpp
@@ -13,8 +13,11 @@ FlarmMessagingDatabase::Insert(const MessagingRecord &record) noexcept
   if (!record.id.IsDefined())
     return;
 
+  MessagingRecord sanitized = record;
+  sanitized.SanitizeTextFields();
+
   const std::lock_guard<SharedMutex> lock(mutex);
-  map.insert(std::make_pair(record.id, record));
+  map.insert(std::make_pair(sanitized.id, std::move(sanitized)));
 }
 
 void
@@ -42,13 +45,18 @@ FlarmMessagingDatabase::Update(const MessagingRecord &record) noexcept
     auto f = static_cast<MessagingRecord::Field>(i);
     if (!record.GetFieldValueConst(f).empty()) {
       field = f;
-      existing.GetFieldValue(f) = record.GetFieldValueConst(f);
       break;
     }
   }
 
   if (field == MessagingRecord::Field::Count)
     return;  // No field to process
+
+  const std::string &incoming_value = record.GetFieldValueConst(field);
+  if (MessagingRecord::IsMissingFieldValue(incoming_value))
+    existing.GetFieldValue(field).clear();
+  else
+    existing.GetFieldValue(field) = incoming_value;
 
   /*
     Epoch-based cycle detection: repeating the same field within the

--- a/src/FLARM/MessagingRecord.cpp
+++ b/src/FLARM/MessagingRecord.cpp
@@ -2,10 +2,35 @@
 // Copyright The XCSoar Project
 
 #include "MessagingRecord.hpp"
+#include "util/StringCompare.hxx"
+#include "util/StringStrip.hxx"
 #include "util/StaticString.hxx"
 
+bool
+MessagingRecord::IsMissingFieldValue(std::string_view value) noexcept
+{
+  const std::string_view stripped = Strip(value);
+  return stripped.empty() ||
+    StringIsEqualIgnoreCase(stripped, std::string_view{"undefined"});
+}
+
+void
+MessagingRecord::SanitizeFieldValue(Field f) noexcept
+{
+  auto &value = GetFieldValue(f);
+  if (IsMissingFieldValue(value))
+    value.clear();
+}
+
+void
+MessagingRecord::SanitizeTextFields() noexcept
+{
+  for (uint8_t i = 0; i < GetFieldCount(); ++i)
+    SanitizeFieldValue(static_cast<Field>(i));
+}
+
 const char *MessagingRecord::Format(StaticString<256> &buffer, const std::string &value) const noexcept {
-  if (value.empty())
+  if (IsMissingFieldValue(value))
     return nullptr;
   return buffer.SetUTF8(value.c_str()) ? buffer.c_str() : nullptr;
 }

--- a/src/FLARM/MessagingRecord.hpp
+++ b/src/FLARM/MessagingRecord.hpp
@@ -9,6 +9,7 @@
 #include "util/Macros.hpp"
 
 #include <string>
+#include <string_view>
 #include <cstdint>
 
 struct MessagingRecord {
@@ -84,6 +85,21 @@ struct MessagingRecord {
    * Number of fields tracked in `kFields`.
    */
   static inline constexpr uint8_t GetFieldCount() noexcept { return kFieldCount; }
+
+  /**
+   * Returns true if a field value should be treated as missing.
+   */
+  static bool IsMissingFieldValue(std::string_view value) noexcept;
+
+  /**
+   * Clears one text field if it contains only a missing-value sentinel.
+   */
+  void SanitizeFieldValue(Field f) noexcept;
+
+  /**
+   * Clears all text fields that contain missing-value sentinels.
+   */
+  void SanitizeTextFields() noexcept;
 
   /**
    * Format a UTF-8 value into the provided buffer; returns nullptr if empty/invalid. 

--- a/test/src/TestFlarmMessaging.cpp
+++ b/test/src/TestFlarmMessaging.cpp
@@ -226,6 +226,43 @@ TestFlarmMessagingCycle()
 }
 
 static void
+TestFlarmMessagingUndefinedValue()
+{
+  FlarmMessagingDatabase db;
+  MessagingRecord base;
+  base.id = FlarmId::Parse("F00BAA", nullptr);
+
+  UpdateMessagingRecord(db, base, nullptr, "Orville");
+
+  auto mr = db.FindRecordById(base.id);
+  if (!ok1(mr.has_value()))
+    return;
+
+  ok1(StringIsEqual(mr->pilot.c_str(), "Orville"));
+
+  MessagingRecord clear = base;
+  clear.pilot = " undefined ";
+  db.Update(clear);
+
+  mr = db.FindRecordById(base.id);
+  if (!ok1(mr.has_value()))
+    return;
+
+  ok1(mr->pilot.empty());
+
+  InsertMessaging(db, "F00BAB", "Undefined", "LS8", " undefined ", "N1");
+
+  auto inserted = FindMessagingRecord(db, "F00BAB");
+  if (!ok1(inserted.has_value()))
+    return;
+
+  ok1(inserted->pilot.empty());
+  ok1(inserted->registration.empty());
+  ok1(StringIsEqual(inserted->plane_type.c_str(), "LS8"));
+  ok1(StringIsEqual(inserted->callsign.c_str(), "N1"));
+}
+
+static void
 TestFlarmMessagingThreadSafety()
 {
   // Scenario 1: Concurrent reads and writes
@@ -362,11 +399,12 @@ TestFlarmMessagingResolveInfo()
 
 int main()
 {
-  plan_tests(41);
+  plan_tests(50);
 
   TestFlarmMessagingIO();
   TestFlarmMessagingFile();
   TestFlarmMessagingCycle();
+  TestFlarmMessagingUndefinedValue();
   TestFlarmMessagingThreadSafety();
   TestFlarmMessagingResolveInfo();
 


### PR DESCRIPTION
Real world data shows considerable amount of messages that send "undefined" for a field, rather than not sending the field at all. To not display and store "undefined", those values can be ignored and displayed as empty.

I've opted to include a sanitizer, even though it might seem a bit overdone, but this can easily be extended later if other "unwanted" data appears regularly later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data validation in FLARM messaging to properly handle missing or undefined field values, including empty strings and variations with whitespace.
  * Enhanced message record sanitization to clean and validate incoming data before processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->