### PR TITLE
Widget: Add image zoom for waypoint and PC-Met viewers

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -51,6 +51,9 @@ Version 7.45 - not yet released
     ``WaypointImage`` events (magnify, shrink, reset, arrows) so keys
     can be set in the ``.xci`` file without the map's ``default`` key
     fallback
+  - Waypoint details embedded image and PC-Met satellite viewer: zoom and
+    pan with focal-point centering when magnifying; supports +/- buttons,
+    F2/F3, and arrow keys (#1127, #1246)
 * input
   - F2 = zoom in, F3 = zoom out in pan, on the FLARM radar, and in waypoint
     image ``wptimg`` (not on the main non-pan map, where F2/F3 stay Checklist
@@ -157,6 +160,9 @@ Version 7.45 - not yet released
 * weather
   - METAR/TAF station list: accept lowercase ICAO codes when adding a station;
     codes are normalized to upper-case for download and profile storage
+  - pc_met www images: add RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT RAD
+    BLITZ, and Blitzkarte Europa; local radar list uses Borkum instead of
+    the removed Emden site
 * data files
   - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
     is read correctly

--- a/build/libwidget.mk
+++ b/build/libwidget.mk
@@ -33,6 +33,8 @@ WIDGET_SOURCES = \
 	$(SRC)/Widget/KeyboardWidget.cpp \
 	$(SRC)/Widget/QuickGuidePageWidget.cpp \
 	$(SRC)/Widget/ViewImageWidget.cpp \
+	$(SRC)/Widget/ImageZoomView.cpp \
+	$(SRC)/Widget/ImageZoomFrame.cpp \
 	$(SRC)/Widget/MultiSelectListWidget.cpp \
 	$(SRC)/Widget/FileMultiSelectWidget.cpp
 

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -14,6 +14,8 @@
 #include "Renderer/TextRowRenderer.hpp"
 #include "Widget/ManagedWidget.hpp"
 #include "Widget/Widget.hpp"
+#include "Widget/ImageZoomView.hpp"
+#include "Widget/ImageZoomFrame.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "LocalPath.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -48,6 +50,7 @@
 #include "Pan.hpp"
 #include "Input/InputEvents.hpp"
 #include "util/StringAPI.hxx"
+
 #include <functional>
 #include <optional>
 
@@ -115,59 +118,6 @@ WaypointExternalFileListHandler::OnPaintItem(Canvas &canvas,
 }
 #endif
 
-class DrawPanFrame final : public WndOwnerDrawFrame {
-  protected:
-    PixelPoint last_mouse_pos, img_pos, offset;
-    bool is_dragging = false;
-
-  std::function<void(Canvas &canvas, const PixelRect &rc, PixelPoint &offset,
-    PixelPoint &img_pos)> mOnPaintCallback2;
-  std::function<bool(unsigned key_code)> m_try_key_input{};
-
-  public:
-    template<typename CB>
-    void Create(ContainerWindow &parent,
-                PixelRect rc, const WindowStyle style,
-                  CB &&_paint) {
-      mOnPaintCallback2 = std::move(_paint);
-      PaintWindow::Create(parent, rc, style);
-    }
-
-  void
-  SetTryKeyInput(std::function<bool(unsigned key_code)>&& f) noexcept
-  {
-    m_try_key_input = std::move(f);
-  }
-
-  /**
-   * Apply one paint-step nudge the same as an arrow key (50 px equivalent).
-   */
-  void
-  NudgeViewByPixelOffset(PixelPoint o) noexcept
-  {
-    offset = o;
-    Invalidate();
-  }
-
-  protected:
-    /** from class Window */
-    bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override;
-    bool OnMouseDown(PixelPoint p) noexcept override;
-    bool OnMouseUp(PixelPoint p) noexcept override;
-
-    bool OnKeyCheck(unsigned key_code) const noexcept override;
-    bool OnKeyDown(unsigned key_code) noexcept override;
-
-  void
-  OnPaint(Canvas &canvas) noexcept override
-  {
-    if (mOnPaintCallback2 == nullptr)
-      return;
-
-    mOnPaintCallback2(canvas, GetClientRect(), offset, img_pos);
-  }
-};
-
 class WaypointDetailsWidget final
   : public NullWidget {
   struct Layout {
@@ -214,7 +164,7 @@ class WaypointDetailsWidget final
   ManagedWidget info_widget{new WaypointInfoWidget(look, waypoint)};
   PanelControl details_panel;
   ManagedWidget commands_widget;
-  DrawPanFrame image_window;
+  ImageZoomFrame image_window;
 
 #ifdef HAVE_RUN_FILE
   ListControl file_list{look};
@@ -264,10 +214,9 @@ public:
   void OnMagnifyClicked();
   void OnShrinkClicked();
 
-  void OnGotoClicked();
+  void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
 
-  void OnImagePaint(Canvas &canvas, const PixelRect &rc, PixelPoint &offset,
-    PixelPoint &img_pos);
+  void OnGotoClicked();
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -603,11 +552,8 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
   commands_widget.Prepare();
 
   if (!images.empty()) {
-    image_window.Create(parent, layout.main, dock_style,
-                        [this](Canvas &canvas, const PixelRect &rc, PixelPoint offset,
-                          PixelPoint &img_pos) {
-                                 OnImagePaint(canvas, rc, offset, img_pos);
-                        });
+    image_window.Create(parent, layout.main, dock_style);
+    image_window.SetContent(&images[0], &zoom);
 
     waypoint_image_input_target = this;
     const int mode_id = InputEvents::GetModeId("wptimg");
@@ -642,11 +588,13 @@ WaypointDetailsWidget::UpdatePage() noexcept
   details_panel.SetVisible(page == 1);
   commands_widget.SetVisible(page == 2);
 
-  bool image_page = page >= 3;
+  const bool image_page = page >= 3;
   if (!images.empty()) {
     image_window.SetVisible(image_page);
     magnify_button.SetVisible(image_page);
     shrink_button.SetVisible(image_page);
+    if (image_page)
+      image_window.SetContent(&images[page - 3], &zoom);
   }
 
   UpdateCaption();
@@ -655,8 +603,23 @@ WaypointDetailsWidget::UpdatePage() noexcept
 void
 WaypointDetailsWidget::UpdateZoomControls()
 {
-  magnify_button.SetEnabled(zoom < 5);
+  magnify_button.SetEnabled(zoom < ImageZoomView::max_zoom_level);
   shrink_button.SetEnabled(zoom > 0);
+}
+
+void
+WaypointDetailsWidget::AdjustViewForZoomChange(const int old_zoom,
+                                               const int new_zoom) noexcept
+{
+  if (images.empty() || page < 3 || !image_window.IsDefined())
+    return;
+
+  const PixelRect rc = image_window.GetClientRect();
+  ImageZoomView::AdjustImageViewOnZoomChange(old_zoom, new_zoom,
+                                             image_window.GetViewPosition(),
+                                             rc.GetSize(),
+                                             images[page - 3].GetSize());
+  image_window.ClearPendingOffset();
 }
 
 void
@@ -682,7 +645,9 @@ WaypointDetailsWidget::NextPage(int step)
     image_window.Invalidate();
 
   if (page >= 3) {
+    const int old_zoom = zoom;
     zoom = 0;
+    AdjustViewForZoomChange(old_zoom, zoom);
     UpdateZoomControls();
   }
 }
@@ -690,10 +655,13 @@ WaypointDetailsWidget::NextPage(int step)
 void
 WaypointDetailsWidget::OnMagnifyClicked()
 {
-  if (zoom >= 5)
+  if (zoom >= ImageZoomView::max_zoom_level)
     return;
-  zoom++;
 
+  const int old_zoom = zoom;
+  ++zoom;
+  AdjustViewForZoomChange(old_zoom, zoom);
+  image_window.Invalidate();
   UpdateZoomControls();
 }
 
@@ -702,9 +670,71 @@ WaypointDetailsWidget::OnShrinkClicked()
 {
   if (zoom <= 0)
     return;
-  zoom--;
 
+  const int old_zoom = zoom;
+  --zoom;
+  AdjustViewForZoomChange(old_zoom, zoom);
+  image_window.Invalidate();
   UpdateZoomControls();
+}
+
+bool
+WaypointDetailsWidget::TryWaypointImageKey(unsigned key_code) noexcept
+{
+  if (!wptimg_mode.has_value())
+    return false;
+  if (images.empty() || !image_window.IsVisible())
+    return false;
+  return InputEvents::ProcessKeyInMode(*wptimg_mode, key_code);
+}
+
+void
+WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
+{
+  if (images.empty() || !image_window.IsVisible())
+    return;
+
+  if (StringIsEqual(misc, "magnify")) {
+    OnMagnifyClicked();
+    return;
+  }
+  if (StringIsEqual(misc, "shrink")) {
+    OnShrinkClicked();
+    return;
+  }
+  if (StringIsEqual(misc, "reset") && zoom > 0) {
+    const int old_zoom = zoom;
+    zoom = 0;
+    AdjustViewForZoomChange(old_zoom, zoom);
+    UpdateZoomControls();
+    image_window.Invalidate();
+    goto_button.SetFocus();
+    return;
+  }
+
+  if (StringIsEqual(misc, "left")) {
+    if (zoom == 0) {
+      previous_button.SetFocus();
+      NextPage(-1);
+    } else
+      image_window.NudgeViewByPixelOffset({-50, 0});
+    return;
+  }
+  if (StringIsEqual(misc, "right")) {
+    if (zoom == 0) {
+      next_button.SetFocus();
+      NextPage(+1);
+    } else
+      image_window.NudgeViewByPixelOffset({50, 0});
+    return;
+  }
+  if (zoom == 0)
+    return;
+
+  if (StringIsEqual(misc, "up"))
+    image_window.NudgeViewByPixelOffset({0, -50});
+  else if (StringIsEqual(misc, "down"))
+    image_window.NudgeViewByPixelOffset({0, 50});
 }
 
 bool
@@ -754,9 +784,11 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
 
     case KEY_ESCAPE:
       if (!images.empty() && zoom > 0) {
+        const int old_zoom = zoom;
         zoom = 0;
+        AdjustViewForZoomChange(old_zoom, zoom);
         image_window.Invalidate();
-        shrink_button.SetEnabled(false);
+        UpdateZoomControls();
         goto_button.SetFocus();
         return true;
       }
@@ -781,66 +813,6 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
     }
 }
 
-bool
-WaypointDetailsWidget::TryWaypointImageKey(unsigned key_code) noexcept
-{
-  if (!wptimg_mode.has_value())
-    return false;
-  if (images.empty() || !image_window.IsVisible())
-    return false;
-  return InputEvents::ProcessKeyInMode(*wptimg_mode, key_code);
-}
-
-void
-WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
-{
-  if (images.empty() || !image_window.IsVisible())
-    return;
-
-  if (StringIsEqual(misc, "magnify")) {
-    OnMagnifyClicked();
-    image_window.Invalidate();
-    return;
-  }
-  if (StringIsEqual(misc, "shrink")) {
-    OnShrinkClicked();
-    image_window.Invalidate();
-    return;
-  }
-  if (StringIsEqual(misc, "reset") && zoom > 0) {
-    zoom = 0;
-    UpdateZoomControls();
-    image_window.Invalidate();
-    goto_button.SetFocus();
-    return;
-  }
-
-  // Pan / page: match prior behaviour
-  if (StringIsEqual(misc, "left")) {
-    if (zoom == 0) {
-      previous_button.SetFocus();
-      NextPage(-1);
-    } else
-      image_window.NudgeViewByPixelOffset({-50, 0});
-    return;
-  }
-  if (StringIsEqual(misc, "right")) {
-    if (zoom == 0) {
-      next_button.SetFocus();
-      NextPage(+1);
-    } else
-      image_window.NudgeViewByPixelOffset({50, 0});
-    return;
-  }
-  if (zoom == 0)
-    return;
-
-  if (StringIsEqual(misc, "up"))
-    image_window.NudgeViewByPixelOffset({0, -50});
-  else if (StringIsEqual(misc, "down"))
-    image_window.NudgeViewByPixelOffset({0, 50});
-}
-
 void
 WaypointDetailsWidget::OnGotoClicked()
 {
@@ -862,131 +834,6 @@ WaypointDetailsWidget::OnGotoClicked()
   dialog.SetModalResult(mrOK);
 
   CommonInterface::main_window->FullRedraw();
-}
-
-void
-WaypointDetailsWidget::OnImagePaint(Canvas &canvas, [[maybe_unused]] const PixelRect &rc,
-                  PixelPoint &offset, PixelPoint &img_pos)
-{
-  const auto &dlook = UIGlobals::GetDialogLook();
-  canvas.Clear(dlook.background_color);
-
-  if (page < 3 || page >= 3 + static_cast<int>(images.size())) {
-    return;
-  }
-
-  Bitmap &img = images[page - 3];
-  static constexpr int zoom_factors[] = {1, 2, 4, 8, 16, 32};
-  PixelSize img_size = img.GetSize();
-  double scale = std::min(static_cast<double>(canvas.GetWidth()) / img_size.width,
-                          static_cast<double>(canvas.GetHeight()) / img_size.height) *
-                 zoom_factors[zoom];
-
-  PixelPoint screen_pos;
-  PixelSize screen_size;
-
-  // Calculate horizontal scaling and positioning
-  double scaled_width = img_size.width * scale;
-  if (scaled_width <= canvas.GetWidth()) {
-    img_pos.x = zoom == 0 ? 0 : img_pos.x + offset.x / scale;
-    screen_pos.x = (canvas.GetWidth() - static_cast<int>(scaled_width)) / 2;
-    screen_size.width = static_cast<unsigned>(scaled_width);
-  } else {
-    double visible_width = canvas.GetWidth() / scale;
-    img_pos.x = zoom == 0 ? (img_size.width - visible_width) / 2 : img_pos.x + offset.x / scale;
-    img_pos.x = std::clamp(img_pos.x, 0, static_cast<int>(img_size.width - visible_width));
-    img_size.width = static_cast<unsigned>(visible_width);
-    screen_pos.x = 0;
-    screen_size.width = canvas.GetWidth();
-  }
-
-  // Calculate vertical scaling and positioning
-  double scaled_height = img_size.height * scale;
-  if (scaled_height <= canvas.GetHeight()) {
-    img_pos.y = 0;
-    screen_pos.y = (canvas.GetHeight() - static_cast<int>(scaled_height)) / 2;
-    screen_size.height = static_cast<unsigned>(scaled_height);
-  } else {
-    double visible_height = canvas.GetHeight() / scale;
-    img_pos.y = zoom == 0 ? (img_size.height - visible_height) / 2 : img_pos.y + offset.y / scale;
-    img_pos.y = std::clamp(img_pos.y, 0, static_cast<int>(img_size.height - visible_height));
-    img_size.height = static_cast<unsigned>(visible_height);
-    screen_pos.y = 0;
-    screen_size.height = canvas.GetHeight();
-  }
-  canvas.Stretch(screen_pos, screen_size, img, img_pos, img_size);
-}
-
-bool
-DrawPanFrame::OnMouseMove(PixelPoint p, [[maybe_unused]] unsigned keys) noexcept
-{
-  if (!is_dragging)
-    return false;
-
-  offset = last_mouse_pos - p;
-  last_mouse_pos = p;
-  Invalidate();
-  return true;
-}
-
-bool
-DrawPanFrame::OnMouseDown(PixelPoint p) noexcept
-{
-  is_dragging = true;
-  last_mouse_pos = p;
-  return true;
-}
-
-bool
-DrawPanFrame::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
-{
-  is_dragging = false;
-  return true;
-}
-
-bool
-DrawPanFrame::OnKeyCheck(unsigned key_code) const noexcept
-{
-  switch (key_code) {
-    case KEY_LEFT:
-    case KEY_RIGHT:
-    case KEY_UP:
-    case KEY_DOWN:
-    return true;
-
-  default:
-    return false;
-  }
-}
-
-bool
-DrawPanFrame::OnKeyDown(unsigned key_code) noexcept
-{
-  if (m_try_key_input && m_try_key_input(key_code))
-    return true;
-
-  switch (key_code) {
-    case KEY_LEFT: {
-      offset = {-50, 0};
-      break;
-    }
-    case KEY_RIGHT: {
-      offset = {50, 0};
-      break;
-    }
-    case KEY_UP: {
-      offset = {0, -50};
-      break;
-    }
-    case KEY_DOWN: {
-      offset = {0, 50};
-      break;
-    }
-    default:
-      return false;
-  }
-  Invalidate();
-  return true;
 }
 
 /**

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -9,6 +9,7 @@
 #ifdef HAVE_PCMET
 
 #include "UIGlobals.hpp"
+#include "Look/DialogLook.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Dialogs/CoFunctionDialog.hpp"
 #include "Dialogs/Error.hpp"
@@ -16,8 +17,10 @@
 #include "ui/canvas/Canvas.hpp"
 #include "Widget/TwoWidgets.hpp"
 #include "Widget/TextListWidget.hpp"
-#include "Widget/ViewImageWidget.hpp"
 #include "Widget/LargeTextWidget.hpp"
+#include "Widget/ImageZoomView.hpp"
+#include "Widget/ImageZoomFrame.hpp"
+#include "Widget/Widget.hpp"
 #include "Weather/PCMet/Images.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
 #include "co/InvokeTask.hxx"
@@ -25,16 +28,170 @@
 #include "net/http/Init.hpp"
 #include "system/Path.hpp"
 #include "Interface.hpp"
+#include "ui/event/KeyCode.hpp"
+
+class PCMetImageWidget final : public NullWidget {
+  const Bitmap &bitmap;
+  ImageZoomFrame image_window;
+  int zoom = 0;
+
+  Button *magnify_button = nullptr;
+  Button *shrink_button = nullptr;
+
+  void UpdateZoomControls() noexcept
+  {
+    if (magnify_button != nullptr)
+      magnify_button->SetEnabled(zoom < ImageZoomView::max_zoom_level);
+    if (shrink_button != nullptr)
+      shrink_button->SetEnabled(zoom > 0);
+  }
+
+  void AdjustView(const int old_zoom, const int new_zoom) noexcept
+  {
+    if (!image_window.IsDefined())
+      return;
+
+    const PixelRect rc = image_window.GetClientRect();
+    ImageZoomView::AdjustImageViewOnZoomChange(old_zoom, new_zoom,
+                                               image_window.GetViewPosition(),
+                                               rc.GetSize(), bitmap.GetSize());
+    image_window.ClearPendingOffset();
+  }
+
+public:
+  explicit PCMetImageWidget(const Bitmap &_bitmap) noexcept
+    :bitmap(_bitmap) {}
+
+  void SetZoomButtons(Button *magnify, Button *shrink) noexcept
+  {
+    magnify_button = magnify;
+    shrink_button = shrink;
+    UpdateZoomControls();
+  }
+
+  void Magnify() noexcept
+  {
+    if (zoom >= ImageZoomView::max_zoom_level)
+      return;
+
+    const int old_zoom = zoom;
+    ++zoom;
+    AdjustView(old_zoom, zoom);
+    image_window.Invalidate();
+    UpdateZoomControls();
+  }
+
+  void Shrink() noexcept
+  {
+    if (zoom <= 0)
+      return;
+
+    const int old_zoom = zoom;
+    --zoom;
+    AdjustView(old_zoom, zoom);
+    image_window.Invalidate();
+    UpdateZoomControls();
+  }
+
+  bool
+  TryImageKey(unsigned key_code) noexcept
+  {
+    switch (key_code) {
+    case KEY_F2:
+      Magnify();
+      return true;
+
+    case KEY_F3:
+      Shrink();
+      return true;
+
+    case KEY_LEFT:
+      if (zoom == 0)
+        return false;
+      image_window.NudgeViewByPixelOffset({-50, 0});
+      return true;
+
+    case KEY_RIGHT:
+      if (zoom == 0)
+        return false;
+      image_window.NudgeViewByPixelOffset({50, 0});
+      return true;
+
+    case KEY_UP:
+      if (zoom == 0)
+        return false;
+      image_window.NudgeViewByPixelOffset({0, -50});
+      return true;
+
+    case KEY_DOWN:
+      if (zoom == 0)
+        return false;
+      image_window.NudgeViewByPixelOffset({0, 50});
+      return true;
+
+    default:
+      return false;
+    }
+  }
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override
+  {
+    WindowStyle image_style;
+    image_style.Hide();
+    image_style.ControlParent();
+
+    image_window.Create(parent, rc, image_style);
+    image_window.SetContent(&bitmap, &zoom);
+    image_window.SetTryKeyInput(
+      [this](unsigned key_code) { return TryImageKey(key_code); });
+    UpdateZoomControls();
+  }
+
+  void Unprepare() noexcept override
+  {
+    image_window.SetTryKeyInput(nullptr);
+  }
+
+  void Show(const PixelRect &rc) noexcept override
+  {
+    image_window.MoveAndShow(rc);
+    image_window.SetFocus();
+  }
+
+  void Hide() noexcept override
+  {
+    image_window.Hide();
+  }
+
+  bool SetFocus() noexcept override
+  {
+    if (!image_window.IsDefined())
+      return false;
+
+    image_window.SetFocus();
+    return true;
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override
+  {
+    return TryImageKey(key_code);
+  }
+};
 
 static void
 BitmapDialog(const Bitmap &bitmap)
 {
-  TWidgetDialog<ViewImageWidget>
-    dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
-           UIGlobals::GetDialogLook(),
-           "pc_met", new ViewImageWidget(bitmap));
+  WidgetDialog dialog(WidgetDialog::Full{},
+                      UIGlobals::GetMainWindow(),
+                      UIGlobals::GetDialogLook(),
+                      "pc_met", new PCMetImageWidget(bitmap));
+  auto &image = static_cast<PCMetImageWidget &>(dialog.GetWidget());
+
   dialog.AddButton(_("Close"), mrOK);
-//  dialog.SetWidget();
+  image.SetZoomButtons(
+    dialog.AddSymbolButton("+", [&image]() { image.Magnify(); }),
+    dialog.AddSymbolButton("-", [&image]() { image.Shrink(); }));
   dialog.ShowModal();
 }
 

--- a/src/Weather/PCMet/Images.cpp
+++ b/src/Weather/PCMet/Images.cpp
@@ -21,7 +21,7 @@ static constexpr PCMet::ImageArea rad_lokal_areas[] = {
   { "pro", "Prötzel" },
   { "drs", "Dresden" },
   { "eis", "Eisberg" },
-  { "emd", "Emden" },
+  { "asb", "Borkum" },
   { "ess", "Essen" },
   { "fbg", "Feldberg" },
   { "fld", "Flechtdorf" },

--- a/src/Weather/PCMet/Images.cpp
+++ b/src/Weather/PCMet/Images.cpp
@@ -9,11 +9,13 @@
 #include "lib/curl/Setup.hxx"
 #include "LocalPath.hpp"
 #include "system/FileUtil.hpp"
+#include "util/StringAPI.hxx"
 #include "util/StringSplit.hxx"
 
 #include <stdexcept>
 
 #include <stdio.h>
+#include <string>
 
 #define PCMET_URI "https://www.flugwetter.de"
 
@@ -55,8 +57,22 @@ static constexpr PCMet::ImageArea rad_lokal_areas[] = {
 };
 
 static constexpr PCMet::ImageArea rad_areas[] = {
-  { "de", "Deutschland" },
+  { "rx", "Deutschland" },
+  { "rxn", "Deutschland Nord" },
+  { "rxm", "Deutschland Mitte" },
+  { "rxs", "Deutschland Süd" },
   { "eu", "Europa" },
+  { "fa", "Alpen" },
+  { nullptr, nullptr }
+};
+
+static constexpr PCMet::ImageArea satradblitz_areas[] = {
+  { "eh", "Europa" },
+  { nullptr, nullptr }
+};
+
+static constexpr PCMet::ImageArea blitzkarte_areas[] = {
+  { "0", "Europa" },
   { nullptr, nullptr }
 };
 
@@ -82,6 +98,8 @@ static constexpr PCMet::ImageArea sat_areas[] = {
 const PCMet::ImageType PCMet::image_types[] = {
   { "rad_lokal/einzelstandorte.htm", "Lokale RADAR-Bilder", rad_lokal_areas },
   { "rad/index.htm", "RADAR", rad_areas },
+  { "satradblitz/index.htm", "SAT RAD BLITZ", satradblitz_areas },
+  { "blitzkarte_bild.htm", "Blitzkarte", blitzkarte_areas },
   { "sat/index.htm", "Satellitenbilder", sat_areas },
   { nullptr, nullptr, nullptr },
 };
@@ -105,37 +123,109 @@ CoGet(CurlGlobal &curl, const char *url,
   co_return co_await Curl::CoRequest(curl, std::move(easy));
 }
 
+[[gnu::pure]]
+static bool
+IsBlitzkartePage(const char *type) noexcept
+{
+  return StringIsEqual(type, "blitzkarte_bild.htm");
+}
+
+/**
+ * Resolve a pc_met image src attribute to an absolute path (from site root).
+ */
+[[gnu::pure]]
+static std::string
+ResolveImageSrc(std::string_view src) noexcept
+{
+  if (!src.empty() && src.front() == '/')
+    return std::string(src);
+
+  if (src.starts_with("../scripts/"))
+    return std::string("/fw/") + std::string(src.substr(3));
+
+  return std::string(src);
+}
+
+/**
+ * Parse the main image URL from a pc_met HTML page.
+ */
+[[gnu::pure]]
+static std::string_view
+FindImageSrc(const char *html) noexcept
+{
+  static constexpr char bild_needle[] = "<img name=\"bild\" src=\"/";
+  if (const char *img = StringFind(html, bild_needle)) {
+    const char *src = img + sizeof(bild_needle) - 2;
+    const char *end = StringFind(src + 1, '"');
+    if (end != nullptr)
+      return {src, std::size_t(end - src)};
+  }
+
+  static constexpr char karte_needle[] = "src=\"../scripts/karte.php?";
+  if (const char *img = StringFind(html, karte_needle)) {
+    const char *src = img + sizeof("src=\"") - 1;
+    const char *end = StringFind(src, '"');
+    if (end != nullptr)
+      return {src, std::size_t(end - src)};
+  }
+
+  return {};
+}
+
+/**
+ * Derive a safe local cache file name from an image URL path.
+ */
+[[gnu::pure]]
+static std::string
+CacheFileNameFromImageSrc(std::string_view src) noexcept
+{
+  static constexpr char src_param[] = "src=";
+  if (const auto pos = src.find(src_param);
+      pos != std::string_view::npos)
+    src = src.substr(pos + sizeof(src_param) - 1);
+
+  if (const auto q = src.find_first_of("?#");
+      q != std::string_view::npos)
+    src = src.substr(0, q);
+
+  const std::string_view name = SplitLast(src, '/').second;
+  if (name.empty())
+    return {};
+
+  if (name == "karte.php")
+    return "blitzkarte.png";
+
+  return std::string(name);
+}
+
 Co::Task<AllocatedPath>
 PCMet::DownloadLatestImage(const char *type, const char *area,
                            const PCMetSettings &settings,
                            CurlGlobal &curl, ProgressListener &progress)
 {
   char url[256];
-  snprintf(url, sizeof(url),
-           PCMET_URI "/fw/bilder/%s?type=%s",
-           type, area);
+  if (IsBlitzkartePage(type))
+    snprintf(url, sizeof(url),
+             PCMET_URI "/fw/bilder/%s?maxage=%s",
+             type, area);
+  else
+    snprintf(url, sizeof(url),
+             PCMET_URI "/fw/bilder/%s?type=%s",
+             type, area);
 
   // download the HTML page
   const auto response =
     co_await CoGet(curl, url, settings.www_credentials.username,
                    settings.www_credentials.password, progress);
 
-  static constexpr char img_needle[] = "<img name=\"bild\" src=\"/";
-  const char *img = strstr(response.body.c_str(), img_needle);
-  if (img == nullptr)
+  const std::string_view src_view = FindImageSrc(response.body.c_str());
+  if (src_view.empty())
     throw std::runtime_error("No IMG tag found in pc_met HTML");
 
-  const char *_src = img + sizeof(img_needle) - 2;
-  const char *end = strchr(_src + 1, '"');
-  if (end == nullptr)
+  const std::string src = ResolveImageSrc(src_view);
+  const std::string name = CacheFileNameFromImageSrc(src);
+  if (name.empty())
     throw std::runtime_error("Malformed IMG tag in pc_met HTML");
-
-  const std::string_view src{_src, std::size_t(end - _src)};
-  const std::string_view _name = SplitLast(src, '/').second;
-  if (_name.empty())
-    throw std::runtime_error("Malformed IMG tag in pc_met HTML");
-
-  const std::string name{_name};
 
   // TODO: verify file name
 
@@ -144,9 +234,7 @@ PCMet::DownloadLatestImage(const char *type, const char *area,
   auto path = AllocatedPath::Build(cache_path, name.c_str());
 
   if (!File::Exists(path)) {
-    // URI for a single page of a selected 'Satellitenbilder"-page with link
-    // to the latest image and the namelist array of all stored images
-    snprintf(url, sizeof(url), PCMET_URI "%.*s", int(src.size()), src.data());
+    snprintf(url, sizeof(url), PCMET_URI "%s", src.c_str());
 
     const auto ignored_response = co_await
       Net::CoDownloadToFile(curl, url, settings.www_credentials.username,

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ImageZoomFrame.hpp"
+#include "ImageZoomView.hpp"
+#include "UIGlobals.hpp"
+#include "Look/DialogLook.hpp"
+#include "ui/canvas/Bitmap.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Features.hpp"
+#include "ui/event/KeyCode.hpp"
+
+void
+ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
+                       const WindowStyle &style) noexcept
+{
+  PaintWindow::Create(parent, rc, style);
+}
+
+void
+ImageZoomFrame::SetContent(const Bitmap *_bitmap, int *zoom) noexcept
+{
+  bitmap = _bitmap;
+  zoom_level = zoom;
+  view_pos = {};
+  pending_offset = {};
+  if (IsDefined())
+    Invalidate();
+}
+
+void
+ImageZoomFrame::SetTryKeyInput(std::function<bool(unsigned)> &&f) noexcept
+{
+  try_key_input = std::move(f);
+}
+
+void
+ImageZoomFrame::NudgeViewByPixelOffset(const PixelPoint o) noexcept
+{
+  pending_offset += o;
+  Invalidate();
+}
+
+void
+ImageZoomFrame::OnPaint(Canvas &canvas) noexcept
+{
+  const auto &look = UIGlobals::GetDialogLook();
+  if (HaveClipping())
+    canvas.Clear(look.background_color);
+
+  if (bitmap == nullptr || zoom_level == nullptr)
+    return;
+
+  ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_level,
+                                   view_pos, pending_offset);
+}
+
+bool
+ImageZoomFrame::OnMouseMove(const PixelPoint p,
+                             [[maybe_unused]] unsigned keys) noexcept
+{
+  if (!is_dragging)
+    return false;
+
+  pending_offset += last_mouse_pos - p;
+  last_mouse_pos = p;
+  Invalidate();
+  return true;
+}
+
+bool
+ImageZoomFrame::OnMouseDown(const PixelPoint p) noexcept
+{
+  is_dragging = true;
+  last_mouse_pos = p;
+  return true;
+}
+
+bool
+ImageZoomFrame::OnMouseUp([[maybe_unused]] const PixelPoint p) noexcept
+{
+  is_dragging = false;
+  return true;
+}
+
+bool
+ImageZoomFrame::OnKeyCheck(const unsigned key_code) const noexcept
+{
+  if (try_key_input) {
+    switch (key_code) {
+    case KEY_F2:
+    case KEY_F3:
+      return true;
+    }
+  }
+
+  switch (key_code) {
+  case KEY_LEFT:
+  case KEY_RIGHT:
+  case KEY_UP:
+  case KEY_DOWN:
+    return true;
+
+  default:
+    return false;
+  }
+}
+
+bool
+ImageZoomFrame::OnKeyDown(const unsigned key_code) noexcept
+{
+  if (try_key_input && try_key_input(key_code))
+    return true;
+
+  switch (key_code) {
+  case KEY_LEFT:
+    pending_offset.x -= 50;
+    break;
+
+  case KEY_RIGHT:
+    pending_offset.x += 50;
+    break;
+
+  case KEY_UP:
+    pending_offset.y -= 50;
+    break;
+
+  case KEY_DOWN:
+    pending_offset.y += 50;
+    break;
+
+  default:
+    return false;
+  }
+
+  Invalidate();
+  return true;
+}

--- a/src/Widget/ImageZoomFrame.hpp
+++ b/src/Widget/ImageZoomFrame.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Form/Draw.hpp"
+
+#include <functional>
+
+struct PixelPoint;
+struct PixelRect;
+class Bitmap;
+class ContainerWindow;
+class Canvas;
+class WindowStyle;
+
+/**
+ * Owner-draw window for pan/zoom bitmap viewing (drag and arrow nudge).
+ */
+class ImageZoomFrame final : public WndOwnerDrawFrame {
+  PixelPoint last_mouse_pos, view_pos, pending_offset;
+  bool is_dragging = false;
+
+  const Bitmap *bitmap = nullptr;
+  int *zoom_level = nullptr;
+
+  std::function<bool(unsigned key_code)> try_key_input;
+
+public:
+  void Create(ContainerWindow &parent, PixelRect rc,
+              const WindowStyle &style) noexcept;
+
+  void SetContent(const Bitmap *bitmap, int *zoom) noexcept;
+
+  void SetTryKeyInput(std::function<bool(unsigned key_code)> &&f) noexcept;
+
+  void NudgeViewByPixelOffset(PixelPoint o) noexcept;
+
+  PixelPoint &GetViewPosition() noexcept {
+    return view_pos;
+  }
+
+  void ClearPendingOffset() noexcept {
+    pending_offset = {};
+  }
+
+protected:
+  bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override;
+  bool OnMouseDown(PixelPoint p) noexcept override;
+  bool OnMouseUp(PixelPoint p) noexcept override;
+  bool OnKeyCheck(unsigned key_code) const noexcept override;
+  bool OnKeyDown(unsigned key_code) noexcept override;
+  void OnPaint(Canvas &canvas) noexcept override;
+};

--- a/src/Widget/ImageZoomView.cpp
+++ b/src/Widget/ImageZoomView.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ImageZoomView.hpp"
+#include "ui/canvas/Bitmap.hpp"
+#include "ui/canvas/Canvas.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace ImageZoomView {
+
+namespace {
+
+static constexpr int zoom_factors[] = {1, 2, 4, 8, 16, 32};
+
+[[gnu::const]]
+static double
+GetImageScale(const PixelSize canvas_size, const PixelSize bitmap_size,
+              const int zoom_level) noexcept
+{
+  if (bitmap_size.width == 0 || bitmap_size.height == 0 ||
+      canvas_size.width == 0 || canvas_size.height == 0)
+    return 1.0;
+
+  const double fit_scale = std::min(
+    static_cast<double>(canvas_size.width) / bitmap_size.width,
+    static_cast<double>(canvas_size.height) / bitmap_size.height);
+  return fit_scale *
+         zoom_factors[std::clamp(zoom_level, 0, max_zoom_level)];
+}
+
+[[gnu::const]]
+static double
+FocalOnAxis(const double bmp_size, const double canvas_size,
+              const double old_scale, const int old_zoom,
+              const double view_pos) noexcept
+{
+  if (old_zoom == 0 || bmp_size * old_scale <= canvas_size)
+    return bmp_size * 0.5;
+
+  return view_pos + (canvas_size * 0.5) / old_scale;
+}
+
+static void
+RepositionAxis(const double bmp_size, const double canvas_size,
+               const double new_scale, const double focal,
+               double &view_pos) noexcept
+{
+  if (bmp_size * new_scale <= canvas_size) {
+    view_pos = 0;
+    return;
+  }
+
+  const double visible = canvas_size / new_scale;
+  view_pos = focal - (canvas_size * 0.5) / new_scale;
+  view_pos = std::clamp(view_pos, 0.0, std::max(0.0, bmp_size - visible));
+}
+
+} // namespace
+
+void
+AdjustImageViewOnZoomChange(const int old_zoom, const int new_zoom,
+                            PixelPoint &view_pos,
+                            const PixelSize canvas_size,
+                            const PixelSize bitmap_size) noexcept
+{
+  if (bitmap_size.width == 0 || bitmap_size.height == 0 ||
+      canvas_size.width == 0 || canvas_size.height == 0)
+    return;
+
+  if (new_zoom == 0) {
+    view_pos = {0, 0};
+    return;
+  }
+
+  const double old_scale = GetImageScale(canvas_size, bitmap_size, old_zoom);
+  const double new_scale = GetImageScale(canvas_size, bitmap_size, new_zoom);
+
+  const double bmp_w = bitmap_size.width;
+  const double bmp_h = bitmap_size.height;
+
+  double view_x = view_pos.x;
+  double view_y = view_pos.y;
+
+  const double focal_x =
+    FocalOnAxis(bmp_w, canvas_size.width, old_scale, old_zoom, view_x);
+  const double focal_y =
+    FocalOnAxis(bmp_h, canvas_size.height, old_scale, old_zoom, view_y);
+
+  RepositionAxis(bmp_w, canvas_size.width, new_scale, focal_x, view_x);
+  RepositionAxis(bmp_h, canvas_size.height, new_scale, focal_y, view_y);
+
+  view_pos.x = int(std::lround(view_x));
+  view_pos.y = int(std::lround(view_y));
+}
+
+void
+PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, const int zoom,
+                  PixelPoint &view_pos, PixelPoint &pending_offset) noexcept
+{
+  PixelSize img_size = bitmap.GetSize();
+  if (img_size.width == 0 || img_size.height == 0 ||
+      canvas.GetWidth() == 0 || canvas.GetHeight() == 0)
+    return;
+
+  const double scale = GetImageScale(
+    {unsigned(canvas.GetWidth()), unsigned(canvas.GetHeight())},
+    img_size, zoom);
+
+  PixelPoint screen_pos;
+  PixelSize screen_size;
+
+  const double scaled_width = img_size.width * scale;
+  if (scaled_width <= canvas.GetWidth()) {
+    view_pos.x = 0;
+    screen_pos.x = (canvas.GetWidth() - int(scaled_width)) / 2;
+    screen_size.width = unsigned(scaled_width);
+  } else {
+    const double visible_width = canvas.GetWidth() / scale;
+    view_pos.x = zoom == 0
+      ? int((img_size.width - visible_width) / 2)
+      : int(view_pos.x + pending_offset.x / scale);
+    view_pos.x = std::clamp(view_pos.x, 0,
+                            int(img_size.width - visible_width));
+    img_size.width = unsigned(visible_width);
+    screen_pos.x = 0;
+    screen_size.width = unsigned(canvas.GetWidth());
+  }
+
+  const double scaled_height = img_size.height * scale;
+  if (scaled_height <= canvas.GetHeight()) {
+    view_pos.y = 0;
+    screen_pos.y = (canvas.GetHeight() - int(scaled_height)) / 2;
+    screen_size.height = unsigned(scaled_height);
+  } else {
+    const double visible_height = canvas.GetHeight() / scale;
+    view_pos.y = zoom == 0
+      ? int((img_size.height - visible_height) / 2)
+      : int(view_pos.y + pending_offset.y / scale);
+    view_pos.y = std::clamp(view_pos.y, 0,
+                            int(img_size.height - visible_height));
+    img_size.height = unsigned(visible_height);
+    screen_pos.y = 0;
+    screen_size.height = unsigned(canvas.GetHeight());
+  }
+
+  pending_offset = {};
+  canvas.Stretch(screen_pos, screen_size, bitmap, view_pos, img_size);
+}
+
+} // namespace ImageZoomView

--- a/src/Widget/ImageZoomView.hpp
+++ b/src/Widget/ImageZoomView.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/dim/Size.hpp"
+
+class Bitmap;
+class Canvas;
+struct PixelPoint;
+
+/**
+ * Shared fit/zoom/pan math and painting for bitmap viewers.
+ */
+namespace ImageZoomView {
+
+static constexpr int max_zoom_level = 5;
+
+void
+AdjustImageViewOnZoomChange(int old_zoom, int new_zoom,
+                            PixelPoint &view_pos,
+                            PixelSize canvas_size,
+                            PixelSize bitmap_size) noexcept;
+
+/**
+ * Paint a bitmap with discrete zoom levels and pan offset.
+ * @param view_pos Top-left of the visible region in bitmap pixels
+ * @param pending_offset Drag/key nudge in screen pixels (applied once, then cleared)
+ */
+void
+PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, int zoom,
+                    PixelPoint &view_pos,
+                    PixelPoint &pending_offset) noexcept;
+
+} // namespace ImageZoomView

--- a/src/Widget/ViewImageWidget.cpp
+++ b/src/Widget/ViewImageWidget.cpp
@@ -2,68 +2,31 @@
 // Copyright The XCSoar Project
 
 #include "ViewImageWidget.hpp"
-#include "ui/canvas/Canvas.hpp"
+#include "ImageZoomFrame.hpp"
 #include "ui/canvas/Bitmap.hpp"
-#include "ui/canvas/Features.hpp"
-#include "ui/window/PaintWindow.hpp"
-#include "Look/DialogLook.hpp"
-#include "UIGlobals.hpp"
-
-class ViewImageWindow final : public PaintWindow {
-  const Bitmap *bitmap;
-
-public:
-  explicit ViewImageWindow(const Bitmap *_bitmap):bitmap(_bitmap) {}
-
-  void SetBitmap(const Bitmap *_bitmap) {
-    bitmap = _bitmap;
-    Invalidate();
-  }
-
-  /* virtual methods from class PaintWindow */
-  void OnPaint(Canvas &canvas) noexcept override;
-};
 
 void
-ViewImageWidget::SetBitmap(const Bitmap *_bitmap)
+ViewImageWidget::SetBitmap(const Bitmap *_bitmap) noexcept
 {
   bitmap = _bitmap;
 
-  if (IsDefined())
-    ((ViewImageWindow &)GetWindow()).SetBitmap(_bitmap);
+  if (!IsDefined())
+    return;
+
+  auto &frame = (ImageZoomFrame &)GetWindow();
+  frame.SetContent(bitmap, &zoom);
+  frame.Invalidate();
 }
 
 void
-ViewImageWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+ViewImageWidget::Prepare(ContainerWindow &parent,
+                         const PixelRect &rc) noexcept
 {
   WindowStyle hidden;
   hidden.Hide();
 
-  auto w = std::make_unique<ViewImageWindow>(bitmap);
-  w->Create(parent, rc, hidden);
-  SetWindow(std::move(w));
-}
-
-void
-ViewImageWindow::OnPaint(Canvas &canvas) noexcept
-{
-  const auto &look = UIGlobals::GetDialogLook();
-  if (HaveClipping())
-    canvas.Clear(look.background_color);
-
-  if (bitmap == nullptr)
-    return;
-
-  const PixelSize bitmap_size = bitmap->GetSize();
-  const PixelRect rc = GetClientRect();
-  const PixelSize window_size = rc.GetSize();
-
-  PixelSize fit_size(window_size.width,
-                     window_size.width * bitmap_size.height / bitmap_size.width);
-  if (fit_size.height > window_size.height) {
-    fit_size.height = window_size.height;
-    fit_size.width = window_size.height * bitmap_size.width / bitmap_size.height;
-  }
-
-  canvas.Stretch(rc.CenteredTopLeft(fit_size), fit_size, *bitmap);
+  auto frame = std::make_unique<ImageZoomFrame>();
+  frame->Create(parent, rc, hidden);
+  frame->SetContent(bitmap, &zoom);
+  SetWindow(std::move(frame));
 }

--- a/src/Widget/ViewImageWidget.hpp
+++ b/src/Widget/ViewImageWidget.hpp
@@ -13,17 +13,18 @@ class Bitmap;
  */
 class ViewImageWidget : public WindowWidget {
   const Bitmap *bitmap;
+  int zoom = 0;
 
 public:
-  explicit ViewImageWidget(const Bitmap *_bitmap=nullptr)
+  explicit ViewImageWidget(const Bitmap *_bitmap=nullptr) noexcept
     :bitmap(_bitmap) {}
 
-  explicit ViewImageWidget(const Bitmap &_bitmap)
+  explicit ViewImageWidget(const Bitmap &_bitmap) noexcept
     :bitmap(&_bitmap) {}
 
-  void SetBitmap(const Bitmap *_bitmap);
+  void SetBitmap(const Bitmap *_bitmap) noexcept;
 
-  void SetBitmap(const Bitmap &_bitmap) {
+  void SetBitmap(const Bitmap &_bitmap) noexcept {
     SetBitmap(&_bitmap);
   }
 


### PR DESCRIPTION
## Summary

- Add shared `ImageZoomView` / `ImageZoomFrame` for bitmap zoom, pan, and focal-point centering when magnifying.
- Use the shared stack in waypoint details embedded images (extends pan from #1127) and the PC-Met satellite viewer (closes #1246).
- PC-Met viewer: +/- buttons, F2/F3, drag, and arrow-key pan; fixes pan crash after zoom.
- Sync pc_met www image catalog with flugwetter.de: RADAR Nord/Mitte/Süd, Alpen, SAT RAD BLITZ, Blitzkarte; Borkum replaces removed Emden local radar.

## Test plan

- [x] `make TARGET=UNIX USE_CCACHE=y WERROR=y`
- [x] Waypoint details: open image page, zoom with +/- and `wptimg` / F2/F3, pan by drag and arrows; verify focal centering on zoom
- [x] PC-Met: download a satellite image, zoom with +/- and F2/F3, pan by drag and arrows
- [x] PC-Met: verify new RADAR entries (Nord/Mitte/Süd, Alpen), SAT RAD BLITZ, Blitzkarte, and Borkum local radar download
- [x] PC-Met: confirm Emden no longer listed (removed from server)

Closes #1246

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Waypoint image details now support zoom/pan functionality with focal-point centering on magnify and button/key controls
  * PC-Met weather section expanded with additional radar coverage: RADAR Deutschland (Nord/Mitte/Süd), Alpen, SAT RAD BLITZ, and Blitzkarte Europa
  * Weather image viewer supports keyboard controls (F2/F3 for zoom, arrow keys for panning)

* **Bug Fixes**
  * Updated local radar data from Emden to Borkum

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->