### PR TITLE
po: Fix duplications in German InfoBox names

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3995,7 +3995,7 @@ msgstr "Verbleibende Distanz"
 
 #: src/Dialogs/StatusPanels/TaskStatusPanel.cpp:133
 msgid "Speed estimated"
-msgstr "Geschätze Geschwindigkeit"
+msgstr "Geschätzte Geschwindigkeit"
 
 #: src/Dialogs/StatusPanels/TaskStatusPanel.cpp:134
 msgid "Speed average"
@@ -10408,7 +10408,7 @@ msgstr "Zeigt AAT-Delta-Zeit und geschätzte Ankunftszeit bei einer AAT-Aufgabe 
 #: src/InfoBoxes/Content/Factory.cpp:1130
 #, no-c-format
 msgid "Speed task estimated"
-msgstr "Geschätze Geschwindigkeit"
+msgstr "Geschätzte Geschwindigkeit"
 
 #: src/InfoBoxes/Content/Factory.cpp:1131
 #, no-c-format
@@ -10423,7 +10423,7 @@ msgstr "Geschätzte Lokalzeit nach Vollendung der Aufgabe, basierend auf dem ide
 #: src/InfoBoxes/Content/Factory.cpp:1138
 #, no-c-format
 msgid "Home altitude difference"
-msgstr "Nächster Wegpunkt - relative Ankunftshöhe"
+msgstr "Höhendifferenz zum Heimatplatz"
 
 #: src/InfoBoxes/Content/Factory.cpp:1139
 #, no-c-format
@@ -10438,7 +10438,7 @@ msgstr "Ankunftshöhe am letzten Wendepunkt der Aufgabe, relativ zur eingestellt
 #: src/InfoBoxes/Content/Factory.cpp:1146
 #, no-c-format
 msgid "Speed task leg"
-msgstr "Aufgabe - Durchschnittsgeschwindigkeit"
+msgstr "Schenkel - Durchschnittsgeschwindigkeit"
 
 #: src/InfoBoxes/Content/Factory.cpp:1147
 #, no-c-format
@@ -10453,7 +10453,7 @@ msgstr "Mittlere Geschwindigkeit über die Aufgabe, nicht höhenkompensiert."
 #: src/InfoBoxes/Content/Factory.cpp:1154
 #, no-c-format
 msgid "Alternate 1 altitude difference"
-msgstr "Nächster Wegpunkt - relative Ankunftshöhe"
+msgstr "Alternative 1 - Höhendifferenz"
 
 #: src/InfoBoxes/Content/Factory.cpp:1155
 #, no-c-format
@@ -10468,7 +10468,7 @@ msgstr "Ankunftshöhe am letzten Wendepunkt der Aufgabe, relativ zur eingestellt
 #: src/InfoBoxes/Content/Factory.cpp:1164
 #, no-c-format
 msgid "Alternate 2 altitude difference"
-msgstr "Nächster Wegpunkt - relative Ankunftshöhe"
+msgstr "Alternative 2 - Höhendifferenz"
 
 #: src/InfoBoxes/Content/Factory.cpp:1165
 #, no-c-format


### PR DESCRIPTION
This PR fixes incorrect translations in `de.po`, where multiple occurrences of `Nächster Wegpunkt - relative Ankunftshöhe` appear in the translation file. They seem to be correct in Weblate, but are incorrect in the source code.

I noticed some inconsistencies in the current German, but also English, names and captions of the `MetaData` translations for the InfoBoxes. Changing the labels would make them easier to find in the list of all InfoBoxes.

Here are some examples:

`names`:

* `Endanflug MC0 Höhendifferenz` → `Endanflug - MC0 Höhendifferenz`
* `Geschwindigkeitsaufgabe letzte Stunde` → `Aufgabe – Geschwindig letzte Stunde`
* `Geschätze Geschwindigkeit` → `Aufgabe - Geschätzte Geschwindigkeit` / `Aufgabe - Geschwindigkeit Geschätzt`
* `Heimdistanz` → `Heimat - Distanz`
* `Letzte Thermikdauer` → `Letzte Thermik - Dauer`
* `Nächster Wendepunkt-Pfeil` → `Nächster Wegpunkt - Pfeil`
* `Team-Code` → `Team - Code` (at. al.)
* `Thermikdauer` → `Thermik - Dauer`
* `Thermik …` → `Aktuelle Thermik …`

* `Speed task leg` → `Task - leg - speed` / `Task - leg - speed avgaverage` ???
* `Estimated task time` → `Task estimated time`
* …

`captions`:

* `EndA H Diff` (`Fin AltD`) vs. `EndA MC0 Höhe` (`Fin MC0 AltD`) → `EndA MC0 D Diff`
* `Alt Baro` (`Höhe (Auto)`) vs. `Höhe Baro` → is for some reason not translated
* …

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected German translations in the InfoBoxes section for home altitude difference, speed task leg measurements, and alternate location altitude differences. Four translation entries were updated with more precise language variants, replacing previously inaccurate or generic translations that did not properly reflect the intended meaning of these essential aviation-related terms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->