### PR TITLE
Add QNH InfoBox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -140,6 +140,7 @@ Version 7.45 - not yet released
     details) #749
   - waypoint list & alternates: waypoint details open above the list; Close without
     a committed action returns to the list, not the map #620
+  - Added QNH InfoBox displaying current QNH pressure setting in hectopascals #2521
 * android
   - use physical display metrics for startup DPI (getRealMetrics) #1784
   - UI sounds via preloaded SoundPool (MediaPlayer fallback for early play or

--- a/src/Dialogs/Settings/dlgBasicSettings.cpp
+++ b/src/Dialogs/Settings/dlgBasicSettings.cpp
@@ -24,6 +24,7 @@
 #include "ui/event/PeriodicTimer.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
 
 #include <math.h>
 
@@ -247,6 +248,9 @@ FlightSetupPanel::SetQNH(AtmosphericPressure qnh)
     MessageOperationEnvironment env;
     backend_components->devices->PutQNH(qnh, env);
   }
+
+  InfoBoxManager::SetDirty();
+  InfoBoxManager::ProcessTimer();
 
   RefreshAltitudeControl();
 }

--- a/src/InfoBoxes/Content/Altitude.cpp
+++ b/src/InfoBoxes/Content/Altitude.cpp
@@ -208,3 +208,30 @@ UpdateInfoBoxAltitudeFlightLevel(InfoBoxData &data) noexcept
     data.SetInvalid();
   }
 }
+
+void
+UpdateInfoBoxAltitudeQNH(InfoBoxData &data) noexcept
+{
+  const ComputerSettings &settings_computer =
+    CommonInterface::GetComputerSettings();
+
+  if (!settings_computer.pressure_available) {
+    data.SetInvalid();
+    data.SetComment(_("no QNH"));
+    return;
+  }
+
+  const AtmosphericPressure &qnh = settings_computer.pressure;
+  const Unit unit = Units::current.pressure_unit;
+  const double value = Units::ToUserPressure(qnh);
+
+  data.SetCommentInvalid();
+
+  if (unit == Unit::INCH_MERCURY) {
+    data.FmtValue("{:.2f}", value);
+  } else {
+    data.FmtValue("{}", iround(value));
+  }
+
+  data.SetValueUnit(unit);
+}

--- a/src/InfoBoxes/Content/Altitude.hpp
+++ b/src/InfoBoxes/Content/Altitude.hpp
@@ -36,3 +36,6 @@ UpdateInfoBoxAltitudeQFE(InfoBoxData &data) noexcept;
 
 void
 UpdateInfoBoxAltitudeFlightLevel(InfoBoxData &data) noexcept;
+
+void
+UpdateInfoBoxAltitudeQNH(InfoBoxData &data) noexcept;

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1186,6 +1186,15 @@ static constexpr MetaData meta_data[] = {
     altitude_infobox_panels,
   },
 
+  // e_QNH
+  {
+    N_("QNH"),
+    N_("QNH"),
+    N_("Current QNH pressure setting used for barometric altitude calculation. Tap the infobox to open the setup panel and adjust QNH manually."),
+    UpdateInfoBoxAltitudeQNH,
+    altitude_infobox_panels,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -152,6 +152,7 @@ namespace InfoBoxFactory
     /* 130 */
     e_Home, /* Combined home waypoint infobox: shows waypoint name, arrival altitude diff, and distance */
     e_AltitudeIGC, /* Logger or ISA pressure altitude only (no QNH baro / GPS) */
+    e_QNH, /* Current QNH pressure setting; tap to adjust manually */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/Panel/AltitudeSetup.cpp
+++ b/src/InfoBoxes/Panel/AltitudeSetup.cpp
@@ -16,6 +16,7 @@
 #include "Form/Edit.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Language/Language.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
 #include "UIGlobals.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Math/Util.hpp"
@@ -47,6 +48,8 @@ AltitudeSetupPanel::OnModified(DataField &_df) noexcept
     DataFieldFloat &df = (DataFieldFloat &)_df;
     settings.pressure = Units::FromUserPressure(df.GetValue());
     settings.pressure_available.Update(CommonInterface::Basic().clock);
+    InfoBoxManager::SetDirty();
+    InfoBoxManager::ProcessTimer();
 
     if (backend_components && backend_components->devices) {
       MessageOperationEnvironment env;


### PR DESCRIPTION
I'm working on an InfoBox that shows the current `QNH` Setting as a InfoBox. I noticed that by default the value of `CommonInterface::GetComputerSettings().pressure` seems to be invalid (`---`) even if it looks like the value should be set to `1013` when you go to `Setting` -> `Config` -> `Flight` -> `QNH`. Is this intentional?

I have tested this on macOS without a GPS signal and on macOS with a `.igc` file of a flight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a QNH info box that shows the current QNH pressure in the user's pressure unit.
  * Tapping the info box opens settings to manually adjust QNH.
  * Info boxes refresh automatically when QNH or altitude settings change.

* **Documentation**
  * Release notes updated to announce the QNH info box in Version 7.45.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->