### PR TITLE
Renderer/DistanceRingsRenderer: Add distance rings around aircraft

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1507,6 +1507,14 @@ location=38
 mode=RemoteStick
 type=key
 data=0
+event=DistanceRings show
+event=DistanceRings toggle
+label=Dist. Rings\n$(DistanceRingsToggleActionName)
+location=39
+
+mode=RemoteStick
+type=key
+data=0
 event=UploadIGCFile
 event=Mode default
 label=WeGlide Upload$(CheckWeGlide)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -83,6 +83,7 @@ Version 7.45 - not yet released
   - terrain: fix fluctuating hill-shading strength #2262
   - snail trail: Catmull-Rom smoothing between fixes; vario colouring samples
     high-rate netto from the merge thread between GPS points #2447
+  - Add renderer to display distance rings around the current location #2522
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/build/main.mk
+++ b/build/main.mk
@@ -418,6 +418,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Renderer/TaskLegRenderer.cpp \
 	$(SRC)/Renderer/TaskSpeedRenderer.cpp \
 	$(SRC)/Renderer/MapScaleRenderer.cpp \
+	$(SRC)/Renderer/DistanceRingsRenderer.cpp \
 	\
 	$(SRC)/Simulator.cpp \
 	$(SRC)/Asset.cpp \

--- a/build/mapwindow.mk
+++ b/build/mapwindow.mk
@@ -15,6 +15,7 @@ LIBMAPWINDOW_SOURCES = \
 	$(SRC)/Projection/MapWindowProjection.cpp \
 	$(SRC)/MapWindow/MapWindowRender.cpp \
 	$(SRC)/MapWindow/MapWindowSymbols.cpp \
+	$(SRC)/MapWindow/MapWindowDistanceRings.cpp \
 	$(SRC)/MapWindow/MapWindowContest.cpp \
 	$(SRC)/MapWindow/MapWindowTask.cpp \
 	$(SRC)/MapWindow/MapWindowThermal.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1824,6 +1824,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Renderer/WaypointLabelList.cpp \
 	$(SRC)/Renderer/WindArrowRenderer.cpp \
 	$(SRC)/Renderer/WaveRenderer.cpp \
+	$(SRC)/Renderer/DistanceRingsRenderer.cpp \
 	$(SRC)/Math/Screen.cpp \
 	$(MORE_SCREEN_SOURCES) \
 	$(SRC)/Renderer/LabelBlock.cpp \

--- a/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
@@ -23,6 +23,7 @@ enum ControlIndex {
   AIRCRAFT_SYMBOL,
   WIND_ARROW_STYLE,
   SKYLINES_TRAFFIC_MAP_MODE,
+  DISTANCE_RINGS_ENABLED,
 };
 
 class SymbolsConfigPanel final
@@ -182,6 +183,10 @@ SymbolsConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
           _("Show the SkyLines traffic symbols/names on the map, downloaded from the SkyLines server."),
           skylines_map_mode_list, (unsigned)settings_map.skylines_traffic_map_mode);
 
+  AddBoolean(_("Distance rings"),
+             _("Display distance rings around the aircraft on the map."),
+             settings_map.distance_rings_enabled);
+
   ShowTrailControls(settings_map.trail.length != TrailSettings::Length::OFF);
 }
 
@@ -219,6 +224,9 @@ SymbolsConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValueEnum(SKYLINES_TRAFFIC_MAP_MODE, ProfileKeys::SkyLinesTrafficMapMode,
                            settings_map.skylines_traffic_map_mode);
+
+  changed |= SaveValue(DISTANCE_RINGS_ENABLED, ProfileKeys::DistanceRingsEnabled,
+                       settings_map.distance_rings_enabled);
 
   _changed |= changed;
 

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -210,6 +210,7 @@ void eventExchangeFrequencies(const char *misc);
 void eventUploadIGCFile(const char *misc);
 void eventOrientationCruise(const char *misc);
 void eventOrientationCircling(const char *misc);
+void eventDistanceRings(const char *misc);
 // -------
 
 } // namespace InputEvents

--- a/src/Input/InputEventsMap.cpp
+++ b/src/Input/InputEventsMap.cpp
@@ -214,6 +214,29 @@ InputEvents::sub_SetZoom(double value)
 }
 
 void
+InputEvents::eventDistanceRings(const char *misc)
+{
+  MapSettings &settings_map = CommonInterface::SetMapSettings();
+
+  if (StringIsEqual(misc, "toggle"))
+    settings_map.distance_rings_enabled = !settings_map.distance_rings_enabled;
+  else if (StringIsEqual(misc, "on"))
+    settings_map.distance_rings_enabled = true;
+  else if (StringIsEqual(misc, "off"))
+    settings_map.distance_rings_enabled = false;
+  else if (StringIsEqual(misc, "show")) {
+    Message::AddMessage(settings_map.distance_rings_enabled
+                        ? _("Distance rings on")
+                        : _("Distance rings off"));
+    return;
+  }
+
+  Profile::Set(ProfileKeys::DistanceRingsEnabled,
+               settings_map.distance_rings_enabled);
+  ActionInterface::SendMapSettings(true);
+}
+
+void
 InputEvents::sub_ScaleZoom(int vswitch)
 {
   const GlueMapWindow *map_window = PageActions::ShowMap();

--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -55,6 +55,8 @@ MapLook::Initialise(const MapSettings &settings,
 
   track_line_pen.Create(Layout::ScalePenWidth(3), COLOR_GRAY);
 
+  distance_rings_pen.Create(Layout::ScalePenWidth(1), COLOR_GRAY);
+
   contest_pens[0].Create(Layout::ScalePenWidth(1) + 2, COLOR_RED);
   contest_pens[1].Create(Layout::ScalePenWidth(1) + 1, COLOR_ORANGE);
   contest_pens[2].Create(Layout::ScalePenWidth(1), COLOR_BLUE);

--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -55,7 +55,8 @@ MapLook::Initialise(const MapSettings &settings,
 
   track_line_pen.Create(Layout::ScalePenWidth(3), COLOR_GRAY);
 
-  distance_rings_pen.Create(Layout::ScalePenWidth(1), COLOR_GRAY);
+  distance_rings_pen.Create(Layout::ScalePenWidth(1),
+                            HasColors() ? COLOR_GRAY : COLOR_BLACK);
 
   contest_pens[0].Create(Layout::ScalePenWidth(1) + 2, COLOR_RED);
   contest_pens[1].Create(Layout::ScalePenWidth(1) + 1, COLOR_ORANGE);

--- a/src/Look/MapLook.hpp
+++ b/src/Look/MapLook.hpp
@@ -60,6 +60,8 @@ struct MapLook {
 
   Pen track_line_pen;
 
+  Pen distance_rings_pen;
+
   Pen contest_pens[3];
 
   MaskedIcon thermal_source_icon;

--- a/src/MapSettings.cpp
+++ b/src/MapSettings.cpp
@@ -43,6 +43,7 @@ MapSettings::SetDefaults() noexcept
   show_flarm_alarm_level = true;
   fade_traffic = true;
   show_thermal_profile = true;
+  distance_rings_enabled = false;
   final_glide_bar_mc0_enabled = true;
   final_glide_bar_display_mode = FinalGlideBarDisplayMode::ON;
   vario_bar_enabled = false;

--- a/src/MapSettings.hpp
+++ b/src/MapSettings.hpp
@@ -164,6 +164,9 @@ struct MapSettings {
   /** Display climb band on map */
   bool show_thermal_profile;
 
+  /** Display distance rings around the aircraft */
+  bool distance_rings_enabled;
+
   /** Show FinalGlideBar mc0 arrow */
   bool final_glide_bar_mc0_enabled;
 

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -286,6 +286,7 @@ protected:
 #endif
 
   void DrawTeammate(Canvas &canvas) const noexcept;
+  void DrawDistanceRings(Canvas &canvas) const noexcept;
   void DrawContest(Canvas &canvas) noexcept;
   void DrawTask(Canvas &canvas) noexcept;
   void DrawRoute(Canvas &canvas) noexcept;

--- a/src/MapWindow/MapWindowDistanceRings.cpp
+++ b/src/MapWindow/MapWindowDistanceRings.cpp
@@ -8,6 +8,9 @@
 void
 MapWindow::DrawDistanceRings(Canvas &canvas) const noexcept
 {
+  if (!GetMapSettings().distance_rings_enabled)
+    return;
+
   const auto &basic = Basic();
   if (!basic.location_available)
     return;

--- a/src/MapWindow/MapWindowDistanceRings.cpp
+++ b/src/MapWindow/MapWindowDistanceRings.cpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "MapWindow.hpp"
+#include "Look/MapLook.hpp"
+#include "Renderer/DistanceRingsRenderer.hpp"
+
+void
+MapWindow::DrawDistanceRings(Canvas &canvas) const noexcept
+{
+  const auto &basic = Basic();
+  if (!basic.location_available)
+    return;
+
+  ::DrawDistanceRings(canvas, render_projection, basic.location, look);
+}

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -220,6 +220,11 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc) noexcept
   draw_sw.Mark("RenderAirspace");
   RenderAirspace(canvas);
 
+  //////////////////////////////////////////////// distance rings
+
+  draw_sw.Mark("DrawDistanceRings");
+  DrawDistanceRings(canvas);
+
   //////////////////////////////////////////////// task
 
   // Render task, waypoints

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -348,6 +348,8 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
     return GetMapSettings().terrain.enable ? _("Hide") : _("Show");
   } else if (name == "AirspaceToggleActionName") {
     return GetMapSettings().airspace.enable ? _("Hide") : _("Show");
+  } else if (name == "DistanceRingsToggleActionName") {
+    return GetMapSettings().distance_rings_enabled ? _("Hide") : _("Show");
   } else if (name == "MapLabelsToggleActionName") {
     static const char *const labels[] = {
       N_("All"),

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -153,6 +153,7 @@ constexpr std::string_view AutoCloseFlarmDialog = "AutoCloseFlarmDialog";
 constexpr std::string_view EnableTAGauge = "EnableTAGauge";
 constexpr std::string_view TAPosition = "TAPosition";
 constexpr std::string_view EnableThermalProfile = "EnableThermalProfile";
+constexpr std::string_view DistanceRingsEnabled = "DistanceRingsEnabled";
 constexpr std::string_view GliderScreenPosition = "GliderScreenPosition";
 constexpr std::string_view SetSystemTimeFromGPS = "SetSystemTimeFromGPS";
 

--- a/src/Profile/MapProfile.cpp
+++ b/src/Profile/MapProfile.cpp
@@ -117,6 +117,7 @@ Profile::Load(const ProfileMap &map, MapSettings &settings)
   map.Get(ProfileKeys::FadeTraffic, settings.fade_traffic);
 
   map.Get(ProfileKeys::EnableThermalProfile, settings.show_thermal_profile);
+  map.Get(ProfileKeys::DistanceRingsEnabled, settings.distance_rings_enabled);
   map.Get(ProfileKeys::EnableFinalGlideBarMC0,
           settings.final_glide_bar_mc0_enabled);
   map.GetEnum(ProfileKeys::FinalGlideBarDisplayMode,

--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -6,8 +6,10 @@
 #include "Projection/WindowProjection.hpp"
 #include "Look/MapLook.hpp"
 #include "util/StringFormat.hpp"
+#include "Units/Units.hpp"
 
 #include <span>
+#include <cmath>
 
 static void
 DrawRingLabel(Canvas &canvas, const char *text, PixelPoint p) noexcept
@@ -33,42 +35,109 @@ DrawRingLabel(Canvas &canvas, const char *text, PixelPoint p) noexcept
 static void
 FormatRingDistance(char *buf, size_t buf_size, double distance_m) noexcept
 {
-  double km = distance_m / 1000.0;
-  if (km == (double)(int)km)
-    StringFormat(buf, buf_size, "%d km", (int)km);
+  const Unit unit = Units::GetUserDistanceUnit();
+  const double value = Units::ToUserUnit(distance_m, unit);
+  const char *unit_name = Units::GetDistanceName();
+
+  const int int_val = (int)(value + 0.5);
+  if (std::abs(value - int_val) < 0.01)
+    StringFormat(buf, buf_size, "%d %s", int_val, unit_name);
   else
-    StringFormat(buf, buf_size, "%.1f km", km);
+    StringFormat(buf, buf_size, "%.1f %s", value, unit_name);
 }
 
-// Ring radius presets in meters for each zoom level tier
-static constexpr double kRingsVeryNarrow[] = {
+// Ring radius presets in meters
+
+// Kilometers: round values in km
+static constexpr double kRingsKmVeryNarrow[] = {
   1000, 2000, 3000, 4000, 5000, 7500, 10000,
 };
-static constexpr double kRingsNarrow[] = {
+static constexpr double kRingsKmNarrow[] = {
   2500, 5000, 7500, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
 };
-static constexpr double kRingsMedium[] = {
+static constexpr double kRingsKmMedium[] = {
   5000, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
 };
-static constexpr double kRingsWide[] = {
+static constexpr double kRingsKmWide[] = {
   10000, 20000, 30000, 40000, 50000, 75000, 100000,
 };
-static constexpr double kRingsVeryWide[] = {
+static constexpr double kRingsKmVeryWide[] = {
   50000, 100000,
+};
+
+// Statute miles: round values in mi (1 mi = 1609.344 m)
+static constexpr double kSmToM = 1609.344;
+static constexpr double kRingsSmVeryNarrow[] = {
+  1*kSmToM, 2*kSmToM, 3*kSmToM, 5*kSmToM,
+};
+static constexpr double kRingsSmNarrow[] = {
+  2*kSmToM, 4*kSmToM, 6*kSmToM, 8*kSmToM, 10*kSmToM, 15*kSmToM,
+};
+static constexpr double kRingsSmMedium[] = {
+  5*kSmToM, 10*kSmToM, 15*kSmToM, 20*kSmToM, 25*kSmToM, 30*kSmToM,
+};
+static constexpr double kRingsSmWide[] = {
+  10*kSmToM, 20*kSmToM, 30*kSmToM, 40*kSmToM, 50*kSmToM, 75*kSmToM,
+};
+static constexpr double kRingsSmVeryWide[] = {
+  50*kSmToM, 100*kSmToM,
+};
+
+// Nautical miles: round values in NM (1 NM = 1852 m)
+static constexpr double kNmToM = 1852.0;
+static constexpr double kRingsNmVeryNarrow[] = {
+  1*kNmToM, 2*kNmToM, 3*kNmToM, 4*kNmToM,
+};
+static constexpr double kRingsNmNarrow[] = {
+  2*kNmToM, 4*kNmToM, 6*kNmToM, 8*kNmToM, 10*kNmToM, 12*kNmToM,
+};
+static constexpr double kRingsNmMedium[] = {
+  5*kNmToM, 10*kNmToM, 15*kNmToM, 20*kNmToM, 25*kNmToM,
+};
+static constexpr double kRingsNmWide[] = {
+  10*kNmToM, 20*kNmToM, 30*kNmToM, 40*kNmToM, 50*kNmToM, 75*kNmToM,
+};
+static constexpr double kRingsNmVeryWide[] = {
+  50*kNmToM, 100*kNmToM,
 };
 
 static std::span<const double>
 SelectRingSet(double screen_distance_m) noexcept
 {
-  if (screen_distance_m <= 8000.0) // 1km steps
-    return kRingsVeryNarrow;
-  if (screen_distance_m <= 25000.0) // 2.5km steps
-    return kRingsNarrow;
-  if (screen_distance_m <= 50000.0) // 5km steps
-    return kRingsMedium;
-  if (screen_distance_m <= 150000.0) // 10km steps
-    return kRingsWide;
-  return kRingsVeryWide; // 50km steps
+  switch (Units::GetUserDistanceUnit()) {
+  case Unit::STATUTE_MILES:
+    if (screen_distance_m <= 8000.0)
+      return kRingsSmVeryNarrow;
+    if (screen_distance_m <= 25000.0)
+      return kRingsSmNarrow;
+    if (screen_distance_m <= 50000.0)
+      return kRingsSmMedium;
+    if (screen_distance_m <= 150000.0)
+      return kRingsSmWide;
+    return kRingsSmVeryWide;
+
+  case Unit::NAUTICAL_MILES:
+    if (screen_distance_m <= 8000.0)
+      return kRingsNmVeryNarrow;
+    if (screen_distance_m <= 25000.0)
+      return kRingsNmNarrow;
+    if (screen_distance_m <= 50000.0)
+      return kRingsNmMedium;
+    if (screen_distance_m <= 150000.0)
+      return kRingsNmWide;
+    return kRingsNmVeryWide;
+
+  default: // KILOMETER and any other unit
+    if (screen_distance_m <= 8000.0)
+      return kRingsKmVeryNarrow;
+    if (screen_distance_m <= 25000.0)
+      return kRingsKmNarrow;
+    if (screen_distance_m <= 50000.0)
+      return kRingsKmMedium;
+    if (screen_distance_m <= 150000.0)
+      return kRingsKmWide;
+    return kRingsKmVeryWide;
+  }
 }
 
 void

--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DistanceRingsRenderer.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "Look/MapLook.hpp"
+#include "util/StringFormat.hpp"
+
+#include <span>
+
+static void
+DrawRingLabel(Canvas &canvas, const char *text, PixelPoint p) noexcept
+{
+  canvas.SetBackgroundTransparent();
+
+  // 8-direction white halo to visually cut the ring line behind the text
+  canvas.SetTextColor(COLOR_WHITE);
+  static constexpr int kOffset = 2;
+  canvas.DrawText({p.x - kOffset, p.y - kOffset}, text);
+  canvas.DrawText({p.x,           p.y - kOffset}, text);
+  canvas.DrawText({p.x + kOffset, p.y - kOffset}, text);
+  canvas.DrawText({p.x - kOffset, p.y           }, text);
+  canvas.DrawText({p.x + kOffset, p.y           }, text);
+  canvas.DrawText({p.x - kOffset, p.y + kOffset}, text);
+  canvas.DrawText({p.x,           p.y + kOffset}, text);
+  canvas.DrawText({p.x + kOffset, p.y + kOffset}, text);
+
+  canvas.SetTextColor(COLOR_BLACK);
+  canvas.DrawText(p, text);
+}
+
+static void
+FormatRingDistance(char *buf, size_t buf_size, double distance_m) noexcept
+{
+  double km = distance_m / 1000.0;
+  if (km == (double)(int)km)
+    StringFormat(buf, buf_size, "%d km", (int)km);
+  else
+    StringFormat(buf, buf_size, "%.1f km", km);
+}
+
+// Ring radius presets in meters for each zoom level tier
+static constexpr double kRingsVeryNarrow[] = {
+  1000, 2000, 3000, 4000, 5000, 7500, 10000,
+};
+static constexpr double kRingsNarrow[] = {
+  2500, 5000, 7500, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
+};
+static constexpr double kRingsMedium[] = {
+  5000, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
+};
+static constexpr double kRingsWide[] = {
+  10000, 20000, 30000, 40000, 50000, 75000, 100000,
+};
+static constexpr double kRingsVeryWide[] = {
+  50000, 100000,
+};
+
+static std::span<const double>
+SelectRingSet(double screen_distance_m) noexcept
+{
+  if (screen_distance_m <= 8000.0) // 1km steps
+    return kRingsVeryNarrow;
+  if (screen_distance_m <= 25000.0) // 2.5km steps
+    return kRingsNarrow;
+  if (screen_distance_m <= 50000.0) // 5km steps
+    return kRingsMedium;
+  if (screen_distance_m <= 150000.0) // 10km steps
+    return kRingsWide;
+  return kRingsVeryWide; // 50km steps
+}
+
+void
+DrawDistanceRings(Canvas &canvas,
+                  const WindowProjection &projection,
+                  const GeoPoint &aircraft_pos,
+                  const MapLook &look) noexcept
+{
+  if (!projection.IsValid() || !aircraft_pos.IsValid())
+    return;
+
+  const auto rings = SelectRingSet(projection.GetScreenDistanceMeters());
+  const PixelPoint aircraft_px = projection.GeoToScreen(aircraft_pos);
+  const PixelRect screen_rect = projection.GetScreenRect();
+
+  canvas.Select(look.distance_rings_pen);
+  canvas.SelectHollowBrush();
+
+  const Font &font = *look.overlay.overlay_font;
+  canvas.Select(font);
+  const int font_height = (int)font.GetHeight();
+
+  for (double radius_m : rings) {
+    const unsigned radius_px = projection.GeoToScreenDistance(radius_m);
+
+    // Skip rings too small to be useful
+    if (radius_px < 20)
+      continue;
+
+    canvas.DrawCircle(aircraft_px, radius_px);
+
+    // Label at topmost point of the ring on screen
+    const int label_center_x = aircraft_px.x;
+    const int label_center_y = aircraft_px.y - (int)radius_px;
+
+    char buf[16];
+    FormatRingDistance(buf, sizeof(buf), radius_m);
+    const PixelSize text_size = canvas.CalcTextSize(buf);
+
+    const PixelPoint label_pos{
+      label_center_x - (int)text_size.width / 2,
+      label_center_y - font_height / 2,
+    };
+
+    // Only draw label if it's within screen bounds
+    if (label_pos.x >= screen_rect.left &&
+        label_pos.x + (int)text_size.width <= screen_rect.right &&
+        label_pos.y >= screen_rect.top &&
+        label_pos.y + font_height <= screen_rect.bottom) {
+      DrawRingLabel(canvas, buf, label_pos);
+    }
+  }
+}

--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -7,25 +7,10 @@
 #include "Projection/WindowProjection.hpp"
 #include "Look/MapLook.hpp"
 #include "Screen/Layout.hpp"
-#include "util/StringFormat.hpp"
+#include "Formatter/UserUnits.hpp"
 #include "Units/Units.hpp"
 
 #include <span>
-#include <cmath>
-
-static void
-FormatRingDistance(char *buf, size_t buf_size, double distance_m) noexcept
-{
-  const Unit unit = Units::GetUserDistanceUnit();
-  const double value = Units::ToUserUnit(distance_m, unit);
-  const char *unit_name = Units::GetDistanceName();
-
-  const int int_val = (int)(value + 0.5);
-  if (std::abs(value - int_val) < 0.01)
-    StringFormat(buf, buf_size, "%d %s", int_val, unit_name);
-  else
-    StringFormat(buf, buf_size, "%.1f %s", value, unit_name);
-}
 
 // Ring radius presets in meters
 
@@ -154,8 +139,9 @@ DrawDistanceRings(Canvas &canvas,
     const int label_center_x = aircraft_px.x;
     const int label_center_y = aircraft_px.y - (int)radius_px;
 
-    char buf[16];
-    FormatRingDistance(buf, sizeof(buf), radius_m);
+    const double user_val = Units::ToUserUnit(radius_m, Units::GetUserDistanceUnit());
+    char buf[32];
+    FormatUserDistance(radius_m, buf, true, (user_val - (int)user_val) < 0.01 ? 0 : 1);
     const PixelSize text_size = canvas.CalcTextSize(buf);
 
     const PixelPoint label_pos{

--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "DistanceRingsRenderer.hpp"
+#include "TextInBox.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Look/MapLook.hpp"
@@ -11,27 +12,6 @@
 
 #include <span>
 #include <cmath>
-
-static void
-DrawRingLabel(Canvas &canvas, const char *text, PixelPoint p) noexcept
-{
-  canvas.SetBackgroundTransparent();
-
-  // 8-direction white halo to visually cut the ring line behind the text
-  canvas.SetTextColor(COLOR_WHITE);
-  static constexpr int HALO_OFFSET = 2;
-  canvas.DrawText({p.x - HALO_OFFSET, p.y - HALO_OFFSET}, text);
-  canvas.DrawText({p.x,               p.y - HALO_OFFSET}, text);
-  canvas.DrawText({p.x + HALO_OFFSET, p.y - HALO_OFFSET}, text);
-  canvas.DrawText({p.x - HALO_OFFSET, p.y              }, text);
-  canvas.DrawText({p.x + HALO_OFFSET, p.y              }, text);
-  canvas.DrawText({p.x - HALO_OFFSET, p.y + HALO_OFFSET}, text);
-  canvas.DrawText({p.x,               p.y + HALO_OFFSET}, text);
-  canvas.DrawText({p.x + HALO_OFFSET, p.y + HALO_OFFSET}, text);
-
-  canvas.SetTextColor(COLOR_BLACK);
-  canvas.DrawText(p, text);
-}
 
 static void
 FormatRingDistance(char *buf, size_t buf_size, double distance_m) noexcept
@@ -188,7 +168,7 @@ DrawDistanceRings(Canvas &canvas,
         label_pos.x + (int)text_size.width <= screen_rect.right &&
         label_pos.y >= screen_rect.top &&
         label_pos.y + (int)text_size.height <= screen_rect.bottom) {
-      DrawRingLabel(canvas, buf, label_pos);
+      RenderShadowedText(canvas, buf, label_pos, false);
     }
   }
 }

--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -5,6 +5,7 @@
 #include "ui/canvas/Canvas.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Look/MapLook.hpp"
+#include "Screen/Layout.hpp"
 #include "util/StringFormat.hpp"
 #include "Units/Units.hpp"
 
@@ -18,15 +19,15 @@ DrawRingLabel(Canvas &canvas, const char *text, PixelPoint p) noexcept
 
   // 8-direction white halo to visually cut the ring line behind the text
   canvas.SetTextColor(COLOR_WHITE);
-  static constexpr int kOffset = 2;
-  canvas.DrawText({p.x - kOffset, p.y - kOffset}, text);
-  canvas.DrawText({p.x,           p.y - kOffset}, text);
-  canvas.DrawText({p.x + kOffset, p.y - kOffset}, text);
-  canvas.DrawText({p.x - kOffset, p.y           }, text);
-  canvas.DrawText({p.x + kOffset, p.y           }, text);
-  canvas.DrawText({p.x - kOffset, p.y + kOffset}, text);
-  canvas.DrawText({p.x,           p.y + kOffset}, text);
-  canvas.DrawText({p.x + kOffset, p.y + kOffset}, text);
+  static constexpr int HALO_OFFSET = 2;
+  canvas.DrawText({p.x - HALO_OFFSET, p.y - HALO_OFFSET}, text);
+  canvas.DrawText({p.x,               p.y - HALO_OFFSET}, text);
+  canvas.DrawText({p.x + HALO_OFFSET, p.y - HALO_OFFSET}, text);
+  canvas.DrawText({p.x - HALO_OFFSET, p.y              }, text);
+  canvas.DrawText({p.x + HALO_OFFSET, p.y              }, text);
+  canvas.DrawText({p.x - HALO_OFFSET, p.y + HALO_OFFSET}, text);
+  canvas.DrawText({p.x,               p.y + HALO_OFFSET}, text);
+  canvas.DrawText({p.x + HALO_OFFSET, p.y + HALO_OFFSET}, text);
 
   canvas.SetTextColor(COLOR_BLACK);
   canvas.DrawText(p, text);
@@ -49,57 +50,59 @@ FormatRingDistance(char *buf, size_t buf_size, double distance_m) noexcept
 // Ring radius presets in meters
 
 // Kilometers: round values in km
-static constexpr double kRingsKmVeryNarrow[] = {
+static constexpr double RINGS_KM_VERY_NARROW[] = {
   1000, 2000, 3000, 4000, 5000, 7500, 10000,
 };
-static constexpr double kRingsKmNarrow[] = {
+static constexpr double RINGS_KM_NARROW[] = {
   2500, 5000, 7500, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
 };
-static constexpr double kRingsKmMedium[] = {
+static constexpr double RINGS_KM_MEDIUM[] = {
   5000, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 100000,
 };
-static constexpr double kRingsKmWide[] = {
+static constexpr double RINGS_KM_WIDE[] = {
   10000, 20000, 30000, 40000, 50000, 75000, 100000,
 };
-static constexpr double kRingsKmVeryWide[] = {
+static constexpr double RINGS_KM_VERY_WIDE[] = {
   50000, 100000,
 };
 
 // Statute miles: round values in mi (1 mi = 1609.344 m)
-static constexpr double kSmToM = 1609.344;
-static constexpr double kRingsSmVeryNarrow[] = {
-  1*kSmToM, 2*kSmToM, 3*kSmToM, 5*kSmToM,
+static constexpr double SM_TO_M = 1609.344;
+static constexpr double RINGS_SM_VERY_NARROW[] = {
+  1*SM_TO_M, 2*SM_TO_M, 3*SM_TO_M, 5*SM_TO_M,
 };
-static constexpr double kRingsSmNarrow[] = {
-  2*kSmToM, 4*kSmToM, 6*kSmToM, 8*kSmToM, 10*kSmToM, 15*kSmToM,
+static constexpr double RINGS_SM_NARROW[] = {
+  2*SM_TO_M, 4*SM_TO_M, 6*SM_TO_M, 8*SM_TO_M, 10*SM_TO_M, 15*SM_TO_M,
 };
-static constexpr double kRingsSmMedium[] = {
-  5*kSmToM, 10*kSmToM, 15*kSmToM, 20*kSmToM, 25*kSmToM, 30*kSmToM,
+static constexpr double RINGS_SM_MEDIUM[] = {
+  5*SM_TO_M, 10*SM_TO_M, 15*SM_TO_M, 20*SM_TO_M, 25*SM_TO_M, 30*SM_TO_M,
 };
-static constexpr double kRingsSmWide[] = {
-  10*kSmToM, 20*kSmToM, 30*kSmToM, 40*kSmToM, 50*kSmToM, 75*kSmToM,
+static constexpr double RINGS_SM_WIDE[] = {
+  10*SM_TO_M, 20*SM_TO_M, 30*SM_TO_M, 40*SM_TO_M, 50*SM_TO_M, 75*SM_TO_M,
 };
-static constexpr double kRingsSmVeryWide[] = {
-  50*kSmToM, 100*kSmToM,
+static constexpr double RINGS_SM_VERY_WIDE[] = {
+  50*SM_TO_M, 100*SM_TO_M,
 };
 
 // Nautical miles: round values in NM (1 NM = 1852 m)
-static constexpr double kNmToM = 1852.0;
-static constexpr double kRingsNmVeryNarrow[] = {
-  1*kNmToM, 2*kNmToM, 3*kNmToM, 4*kNmToM,
+static constexpr double NM_TO_M = 1852.0;
+static constexpr double RINGS_NM_VERY_NARROW[] = {
+  1*NM_TO_M, 2*NM_TO_M, 3*NM_TO_M, 4*NM_TO_M,
 };
-static constexpr double kRingsNmNarrow[] = {
-  2*kNmToM, 4*kNmToM, 6*kNmToM, 8*kNmToM, 10*kNmToM, 12*kNmToM,
+static constexpr double RINGS_NM_NARROW[] = {
+  2*NM_TO_M, 4*NM_TO_M, 6*NM_TO_M, 8*NM_TO_M, 10*NM_TO_M, 12*NM_TO_M,
 };
-static constexpr double kRingsNmMedium[] = {
-  5*kNmToM, 10*kNmToM, 15*kNmToM, 20*kNmToM, 25*kNmToM,
+static constexpr double RINGS_NM_MEDIUM[] = {
+  5*NM_TO_M, 10*NM_TO_M, 15*NM_TO_M, 20*NM_TO_M, 25*NM_TO_M,
 };
-static constexpr double kRingsNmWide[] = {
-  10*kNmToM, 20*kNmToM, 30*kNmToM, 40*kNmToM, 50*kNmToM, 75*kNmToM,
+static constexpr double RINGS_NM_WIDE[] = {
+  10*NM_TO_M, 20*NM_TO_M, 30*NM_TO_M, 40*NM_TO_M, 50*NM_TO_M, 75*NM_TO_M,
 };
-static constexpr double kRingsNmVeryWide[] = {
-  50*kNmToM, 100*kNmToM,
+static constexpr double RINGS_NM_VERY_WIDE[] = {
+  50*NM_TO_M, 100*NM_TO_M,
 };
+
+static constexpr unsigned MIN_RING_RADIUS_PX = 20;
 
 static std::span<const double>
 SelectRingSet(double screen_distance_m) noexcept
@@ -107,36 +110,36 @@ SelectRingSet(double screen_distance_m) noexcept
   switch (Units::GetUserDistanceUnit()) {
   case Unit::STATUTE_MILES:
     if (screen_distance_m <= 8000.0)
-      return kRingsSmVeryNarrow;
+      return RINGS_SM_VERY_NARROW;
     if (screen_distance_m <= 25000.0)
-      return kRingsSmNarrow;
+      return RINGS_SM_NARROW;
     if (screen_distance_m <= 50000.0)
-      return kRingsSmMedium;
+      return RINGS_SM_MEDIUM;
     if (screen_distance_m <= 150000.0)
-      return kRingsSmWide;
-    return kRingsSmVeryWide;
+      return RINGS_SM_WIDE;
+    return RINGS_SM_VERY_WIDE;
 
   case Unit::NAUTICAL_MILES:
     if (screen_distance_m <= 8000.0)
-      return kRingsNmVeryNarrow;
+      return RINGS_NM_VERY_NARROW;
     if (screen_distance_m <= 25000.0)
-      return kRingsNmNarrow;
+      return RINGS_NM_NARROW;
     if (screen_distance_m <= 50000.0)
-      return kRingsNmMedium;
+      return RINGS_NM_MEDIUM;
     if (screen_distance_m <= 150000.0)
-      return kRingsNmWide;
-    return kRingsNmVeryWide;
+      return RINGS_NM_WIDE;
+    return RINGS_NM_VERY_WIDE;
 
   default: // KILOMETER and any other unit
     if (screen_distance_m <= 8000.0)
-      return kRingsKmVeryNarrow;
+      return RINGS_KM_VERY_NARROW;
     if (screen_distance_m <= 25000.0)
-      return kRingsKmNarrow;
+      return RINGS_KM_NARROW;
     if (screen_distance_m <= 50000.0)
-      return kRingsKmMedium;
+      return RINGS_KM_MEDIUM;
     if (screen_distance_m <= 150000.0)
-      return kRingsKmWide;
-    return kRingsKmVeryWide;
+      return RINGS_KM_WIDE;
+    return RINGS_KM_VERY_WIDE;
   }
 }
 
@@ -158,13 +161,11 @@ DrawDistanceRings(Canvas &canvas,
 
   const Font &font = *look.overlay.overlay_font;
   canvas.Select(font);
-  const int font_height = (int)font.GetHeight();
 
   for (double radius_m : rings) {
     const unsigned radius_px = projection.GeoToScreenDistance(radius_m);
 
-    // Skip rings too small to be useful
-    if (radius_px < 20)
+    if (radius_px < Layout::Scale(MIN_RING_RADIUS_PX))
       continue;
 
     canvas.DrawCircle(aircraft_px, radius_px);
@@ -179,14 +180,14 @@ DrawDistanceRings(Canvas &canvas,
 
     const PixelPoint label_pos{
       label_center_x - (int)text_size.width / 2,
-      label_center_y - font_height / 2,
+      label_center_y - (int)text_size.height / 2,
     };
 
     // Only draw label if it's within screen bounds
     if (label_pos.x >= screen_rect.left &&
         label_pos.x + (int)text_size.width <= screen_rect.right &&
         label_pos.y >= screen_rect.top &&
-        label_pos.y + font_height <= screen_rect.bottom) {
+        label_pos.y + (int)text_size.height <= screen_rect.bottom) {
       DrawRingLabel(canvas, buf, label_pos);
     }
   }

--- a/src/Renderer/DistanceRingsRenderer.hpp
+++ b/src/Renderer/DistanceRingsRenderer.hpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+class Canvas;
+class WindowProjection;
+struct GeoPoint;
+struct MapLook;
+
+void
+DrawDistanceRings(Canvas &canvas,
+                  const WindowProjection &projection,
+                  const GeoPoint &aircraft_pos,
+                  const MapLook &look) noexcept;


### PR DESCRIPTION
Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Summary

This PR adds distance rings to the map. You can enable them in `Config` → `System` → `Map Display` → `Elements`. The setting is stored in the profile key `Keys::DistanceRingsEnabled`. The selected user distance unit (km, sm, nm) is supported.

Fixes #1206

<img width="32%" height="924" alt="Bildschirmfoto 2026-05-21 um 21 50 08" src="https://github.com/user-attachments/assets/a5933ff6-264c-4a82-bfbf-f795de151b1d" />
<img width="32%" height="924" alt="Bildschirmfoto 2026-05-21 um 21 51 08" src="https://github.com/user-attachments/assets/e981c0ad-2825-4322-a15a-17e8923f2605" />
<img width="32%" height="924" alt="Bildschirmfoto 2026-05-21 um 21 51 51" src="https://github.com/user-attachments/assets/4da066fd-8266-4e50-809c-891bbbec3b38" />

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Distance rings renderer added to display circular rings around the aircraft on the map.
  * New "Distance rings" toggle setting in the Symbols configuration panel to enable/disable the feature.
  * Rings display with distance labels in user-configured units (kilometers, statute miles, or nautical miles).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->