### PR TITLE
system/RunFile: Open local files on iOS

### DIFF
--- a/src/system/RunFile.cpp
+++ b/src/system/RunFile.cpp
@@ -3,6 +3,91 @@
 
 #include "RunFile.hpp"
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+
+@interface XCSoarDocumentInteractionDelegate
+  : NSObject <UIDocumentInteractionControllerDelegate>
+@end
+
+static XCSoarDocumentInteractionDelegate *document_interaction_delegate;
+static UIDocumentInteractionController *document_interaction_controller;
+
+static UIWindow *
+GetApplicationWindow() noexcept
+{
+  if (@available(iOS 13.0, *)) {
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+      if (scene.activationState != UISceneActivationStateForegroundActive ||
+          ![scene isKindOfClass:UIWindowScene.class])
+        continue;
+
+      for (UIWindow *window in ((UIWindowScene *)scene).windows)
+        if (window.isKeyWindow)
+          return window;
+    }
+  }
+
+  return nil;
+}
+
+static UIViewController *
+GetTopViewController() noexcept
+{
+  UIWindow *window = GetApplicationWindow();
+  UIViewController *controller = window.rootViewController;
+  while (controller.presentedViewController != nil)
+    controller = controller.presentedViewController;
+
+  return controller;
+}
+
+@implementation XCSoarDocumentInteractionDelegate
+
+- (UIViewController *)documentInteractionControllerViewControllerForPreview:
+  (UIDocumentInteractionController *)controller
+{
+  (void)controller;
+  return GetTopViewController();
+}
+
+- (void)documentInteractionControllerDidEndPreview:
+  (UIDocumentInteractionController *)controller
+{
+  (void)controller;
+  document_interaction_controller = nil;
+}
+
+@end
+
+static bool
+RunFileIOS(NSURL *url) noexcept
+{
+  UIViewController *controller = GetTopViewController();
+  if (controller == nil)
+    return false;
+
+  if (document_interaction_delegate == nil)
+    document_interaction_delegate =
+      [[XCSoarDocumentInteractionDelegate alloc] init];
+
+  document_interaction_controller =
+    [UIDocumentInteractionController interactionControllerWithURL:url];
+  document_interaction_controller.delegate = document_interaction_delegate;
+
+  if (![document_interaction_controller presentPreviewAnimated:YES]) {
+    document_interaction_controller = nil;
+    return false;
+  }
+
+  return true;
+}
+#endif
+
 #ifdef ANDROID
 // replaced by NativeView::OpenWaypointFile()
 #elif defined(HAVE_POSIX) && !defined(_WIN32) && !defined(KOBO)
@@ -12,7 +97,28 @@
 bool
 RunFile(const char *path) noexcept
 {
-#if defined(__APPLE__)
+  if (path == nullptr || path[0] == '\0') {
+    return false;
+  }
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  NSString *ns_path = [NSString stringWithUTF8String:path];
+  if (ns_path == nil)
+    return false;
+
+  NSURL *url = [NSURL fileURLWithPath:ns_path];
+  if (url == nil)
+    return false;
+
+  if (NSThread.isMainThread)
+    return RunFileIOS(url);
+
+  __block bool result = false;
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    result = RunFileIOS(url);
+  });
+  return result;
+#elif defined(__APPLE__)
   return Start("/usr/bin/open", path);
 #else
   return Start("/usr/bin/xdg-open", path);


### PR DESCRIPTION
Addresses https://github.com/XCSoar/XCSoar/issues/2501.

The POSIX fallback used /usr/bin/open for all Apple targets, which works on macOS but is not available from iOS apps. This made waypoint details file= entries fail silently on iOS.

Use UIDocumentInteractionController on iOS to preview the local file URL directly. Keep the controller alive while the preview is active, clear it when the preview ends, and return the actual preview result when dispatching to the main thread.

Keep the existing /usr/bin/open path for macOS and xdg-open for other POSIX targets.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native document preview support for opening files on iOS using the platform’s standard preview UI.
  * Ensures preview presentation is performed on the main UI thread for consistent display.

* **Bug Fixes**
  * Improved file-opening reliability on iOS with input validation and safer handling when presentation or view lookup fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->