### PR TITLE
InfoBoxes/Content/Places: Add Previous Waypoint InfoBox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -52,6 +52,11 @@ Version 7.45 - not yet released
   - infoboxen: new "Active Waypoint" InfoBox (next task waypoint, or Goto
     waypoint when no task is loaded; shows name, arrival height above safety,
     and distance; tap to pick a different task leg or set a new Goto)
+  - infoboxen: new "Previous Waypoint" InfoBox (task waypoint before the active
+    leg, or the start waypoint while on the first leg; shows name, arrival
+    height above safety, and distance; tap to display a different waypoint
+    without advancing the task or setting a Goto, or "Resume auto tracking" to
+    revert)
 * desktop
   - command-line: -h/--help and -version/--version print to stdout and exit;
     unknown options print a short usage line on stderr

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -243,6 +243,16 @@ loaded, selecting a task waypoint advances the active task point to that leg;
 without a task, the selection becomes the new Goto. If a task is loaded and
 you select a non-task waypoint from the list, the selection becomes the new
 Goto.}
+\ibi{Previous Waypoint}{Prev WP}{Displays the waypoint name, arrival altitude
+difference relative to the safety arrival height, and distance for the task
+waypoint before the active leg. While on the first leg (no prior point) the
+start waypoint is shown instead. Tap to choose a different waypoint to
+display: with an ordered task loaded the popup is prepopulated with task
+waypoints; without a task the full waypoint list is shown. The selection is
+informational only \textemdash{} it never advances the task and never sets a
+Goto. The override is sticky across leg advances. With a task loaded, tap
+again and choose ``Resume auto tracking'' at the top of the list to return to
+automatic tracking of the task.}
 
 
 %%%%%%%%%%%

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -29,13 +29,23 @@ class OrderedTask;
  * (with a leading "Choose a filter" prompt row), instead of the
  * filter-driven full database.  Used by the Active Waypoint InfoBox
  * tap action.
+ *
+ * @param action_row_label Optional non-waypoint row rendered at the top of
+ * the list (using the same style as the filter prompt). When set, it
+ * replaces the "Choose a filter or click here" prompt.
+ * @param action_selected Optional out-param. When non-null and the user
+ * activated the action row, set to true; on return, @p action_selected
+ * lets the caller distinguish "user picked the action row" from
+ * "user picked a waypoint" / "cancelled".
  */
 WaypointPtr
 ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &location,
                        OrderedTask *ordered_task = nullptr,
                        unsigned ordered_task_index = 0,
                        std::optional<TypeFilter> initial_type = std::nullopt,
-                       bool prepopulate_with_task = false);
+                       bool prepopulate_with_task = false,
+                       const char *action_row_label = nullptr,
+                       bool *action_selected = nullptr);
 void
 ShowWaypointListPersistentDialog(
   const GeoPoint &location, bool allow_navigation = true,

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -169,7 +169,10 @@ private:
   OrderedTask *const ordered_task;
   const unsigned ordered_task_index;
   const bool prepopulate_with_task;
+  const char *const action_row_label;
+  bool *const action_selected_out;
   bool has_filter_prompt_row = false;
+  bool has_action_row = false;
 
 public:
   WaypointListWidget(Waypoints &_way_points, WndForm &_dialog,
@@ -177,28 +180,34 @@ public:
                      GeoPoint _location, Angle _heading,
                      OrderedTask *_ordered_task,
                      unsigned _ordered_task_index,
-                     bool _prepopulate_with_task)
+                     bool _prepopulate_with_task,
+                     const char *_action_row_label = nullptr,
+                     bool *_action_selected_out = nullptr)
     :way_points(_way_points), dialog(_dialog),
      filter_widget(_filter_widget),
      location(_location), last_heading(_heading),
      ordered_task(_ordered_task),
      ordered_task_index(_ordered_task_index),
-     prepopulate_with_task(_prepopulate_with_task) {}
+     prepopulate_with_task(_prepopulate_with_task),
+     action_row_label(_action_row_label),
+     action_selected_out(_action_selected_out) {}
 
   void UpdateList();
 
   virtual void OnWaypointListEnter();
 
   WaypointPtr GetCursorObject() const {
-    if (items.empty())
-      return nullptr;
     unsigned i = GetList().GetCursorIndex();
-    if (has_filter_prompt_row) {
+    if (has_action_row) {
+      if (i == 0)
+        return nullptr;
+      --i;
+    } else if (has_filter_prompt_row) {
       if (i == 0)
         return nullptr;
       --i;
     }
-    if (i >= items.size())
+    if (items.empty() || i >= items.size())
       return nullptr;
     return items[i].waypoint;
   }
@@ -392,15 +401,21 @@ WaypointListWidget::UpdateList()
              dialog_state,
              ordered_task, ordered_task_index);
 
-  has_filter_prompt_row = prepopulate_with_task && ordered_task != nullptr &&
+  has_action_row = action_row_label != nullptr;
+  has_filter_prompt_row = !has_action_row &&
+                          prepopulate_with_task && ordered_task != nullptr &&
                           !dialog_state.IsDefined() && !items.empty();
 
   auto &list = GetList();
-  const unsigned extra = has_filter_prompt_row ? 1u : 0u;
-  list.SetLength(std::max(1u, (unsigned)items.size() + extra));
+  const unsigned extra = (has_action_row || has_filter_prompt_row) ? 1u : 0u;
+  const unsigned length = std::max(1u, (unsigned)items.size() + extra);
+  list.SetLength(length);
   list.SetOrigin(0);
-  // Skip the prompt row by default so the cursor lands on the first task wp.
-  list.SetCursorIndex(has_filter_prompt_row ? 1u : 0u);
+  // Skip the prompt row by default so the cursor lands on the first task wp,
+  // but clamp so a list containing only the action row stays activatable.
+  const unsigned desired_cursor =
+    (has_action_row || has_filter_prompt_row) ? 1u : 0u;
+  list.SetCursorIndex(std::min(desired_cursor, length - 1u));
   list.Invalidate();
 }
 
@@ -567,7 +582,15 @@ void
 WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                                 unsigned i) noexcept
 {
+  if (has_action_row && i == 0) {
+    // caller-supplied action row prepended above the list
+    row_renderer.DrawFirstRow(canvas, rc, action_row_label);
+    return;
+  }
+
   if (items.empty()) {
+    // has_action_row + empty items is handled above; can only land here
+    // when there is no action row.
     assert(i == 0);
 
     const auto *text = dialog_state.IsDefined() || way_points.IsEmpty()
@@ -577,7 +600,9 @@ WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     return;
   }
 
-  if (has_filter_prompt_row) {
+  if (has_action_row) {
+    --i;
+  } else if (has_filter_prompt_row) {
     if (i == 0) {
       // prompt row prepended above task waypoints
       row_renderer.DrawFirstRow(canvas, rc,
@@ -599,6 +624,14 @@ WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 void
 WaypointListWidget::OnWaypointListEnter()
 {
+  if (has_action_row && GetList().GetCursorIndex() == 0) {
+    // user activated the caller-supplied action row
+    if (action_selected_out != nullptr)
+      *action_selected_out = true;
+    dialog.SetModalResult(mrOK);
+    return;
+  }
+
   if (items.empty()) {
     filter_widget.GetControl(NAME).BeginEditing();
     return;
@@ -654,8 +687,15 @@ ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
                        OrderedTask *_ordered_task,
                        unsigned _ordered_task_index,
                        std::optional<TypeFilter> initial_type,
-                       bool _prepopulate_with_task)
+                       bool _prepopulate_with_task,
+                       const char *_action_row_label,
+                       bool *_action_selected)
 {
+  /* Initialise the out-parameter up front so callers never observe
+     stale state: only the action-row path below sets it true. */
+  if (_action_selected != nullptr)
+    *_action_selected = false;
+
   const DialogLook &look = UIGlobals::GetDialogLook();
 
   const Angle heading = CommonInterface::Basic().attitude.heading;
@@ -689,7 +729,9 @@ ShowWaypointListDialog(Waypoints &waypoints, const GeoPoint &_location,
     std::make_unique<WaypointListWidget>(waypoints, dialog, filter_widget,
                                          _location, heading,
                                          _ordered_task, _ordered_task_index,
-                                         _prepopulate_with_task);
+                                         _prepopulate_with_task,
+                                         _action_row_label,
+                                         _action_selected);
   const auto &list_widget_ = *list_widget;
 
   filter_widget.SetListener(list_widget.get());

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1203,6 +1203,14 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentActiveWaypoint>::Create,
   },
 
+  // e_PreviousWaypoint
+  {
+    N_("Previous Waypoint"),
+    N_("Prev WP"),
+    N_("Previous waypoint: when an ordered task is loaded, automatically tracks the task waypoint before the active leg (the start waypoint when on the first leg). Displays the waypoint name, arrival altitude difference relative to the safety arrival height, and distance. Click to choose a different waypoint to display (task waypoints when a task is loaded, otherwise the full waypoint list); selection is informational only and never advances the task or sets a Goto. With a task loaded, choose \"Resume auto tracking\" at the top of the list to revert to automatic tracking."),
+    IBFHelper<InfoBoxContentPreviousWaypoint>::Create,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Places.cpp
+++ b/src/InfoBoxes/Content/Places.cpp
@@ -174,6 +174,22 @@ ComputeActiveWaypointGlide(const MoreData &basic,
                           glide_state);
 }
 
+/* Shared by the Active and Previous Waypoint InfoBoxes so the "place"
+   InfoBoxes display name / arrival height / distance consistently. */
+static void
+SetInfoBoxWaypointGlideData(InfoBoxData &data, const MoreData &basic,
+                            const ComputerSettings &settings,
+                            const DerivedInfo &calculated,
+                            const Waypoint &waypoint) noexcept
+{
+  data.SetTitle(waypoint.name.c_str());
+
+  const GlideResult result =
+    ComputeActiveWaypointGlide(basic, settings, calculated, waypoint);
+  data.SetValueFromArrival(result.SelectAltitudeDifference(settings.task.glide));
+  data.SetCommentFromDistance(basic.location.DistanceS(waypoint.location));
+}
+
 void
 InfoBoxContentActiveWaypoint::Update(InfoBoxData &data) noexcept
 {
@@ -197,12 +213,7 @@ InfoBoxContentActiveWaypoint::Update(InfoBoxData &data) noexcept
     return;
   }
 
-  data.SetTitle(waypoint->name.c_str());
-
-  const GlideResult result =
-    ComputeActiveWaypointGlide(basic, settings, calculated, *waypoint);
-  data.SetValueFromArrival(result.SelectAltitudeDifference(settings.task.glide));
-  data.SetCommentFromDistance(basic.location.DistanceS(waypoint->location));
+  SetInfoBoxWaypointGlideData(data, basic, settings, calculated, *waypoint);
 }
 
 bool
@@ -270,6 +281,99 @@ InfoBoxContentActiveWaypoint::HandleClick() noexcept
     }
     ptm.DoGoto(std::move(selected));
   }
+
+  return true;
+}
+
+void
+InfoBoxContentPreviousWaypoint::Update(InfoBoxData &data) noexcept
+{
+  const MoreData &basic = CommonInterface::Basic();
+  const ComputerSettings &settings = CommonInterface::GetComputerSettings();
+  const DerivedInfo &calculated = CommonInterface::Calculated();
+
+  data.SetTitle(_("Prev WP"));
+
+  WaypointPtr waypoint = override_waypoint;
+  if (waypoint == nullptr && backend_components &&
+      backend_components->protected_task_manager) {
+    /* Read the active task point under a lease instead of cloning the
+       whole task on every tick: we only need a single waypoint pointer. */
+    ProtectedTaskManager::Lease lease{*backend_components->protected_task_manager};
+    if (lease->GetMode() == TaskType::ORDERED) {
+      const OrderedTask &task = lease->GetOrderedTask();
+      if (task.TaskSize() > 0) {
+        const unsigned active_index = task.GetActiveIndex();
+        const unsigned target_index = active_index > 0 ? active_index - 1 : 0;
+        waypoint = task.GetPoint(target_index).GetWaypointPtr();
+      }
+    }
+  }
+
+  if (!waypoint ||
+      !basic.location_available ||
+      !basic.NavAltitudeAvailable() ||
+      !settings.polar.glide_polar_task.IsValid()) {
+    data.SetInvalid();
+    data.SetCommentInvalid();
+    return;
+  }
+
+  SetInfoBoxWaypointGlideData(data, basic, settings, calculated, *waypoint);
+}
+
+bool
+InfoBoxContentPreviousWaypoint::HandleClick() noexcept
+{
+  if (!data_components || !data_components->waypoints)
+    return false;
+  if (!backend_components || !backend_components->protected_task_manager)
+    return false;
+
+  auto &waypoints = *data_components->waypoints;
+  auto &ptm = *backend_components->protected_task_manager;
+  const GeoPoint location = CommonInterface::Basic().location;
+
+  std::unique_ptr<OrderedTask> task_clone = ptm.TaskClone();
+
+  bool task_mode_ordered = false;
+  {
+    ProtectedTaskManager::Lease lease(ptm);
+    task_mode_ordered = lease->GetMode() == TaskType::ORDERED;
+  }
+
+  const bool has_ordered_task = task_mode_ordered && task_clone &&
+                                task_clone->TaskSize() > 0;
+  const unsigned ordered_task_index =
+    has_ordered_task ? task_clone->GetActiveIndex() : 0;
+
+  /* "Resume auto tracking" only makes sense when a task is loaded *and*
+     we currently have a manual override to clear. */
+  const char *const action_label =
+    (has_ordered_task && override_waypoint != nullptr)
+      ? _("Resume auto tracking")
+      : nullptr;
+  bool action_selected = false;
+
+  WaypointPtr selected;
+  try {
+    selected = ShowWaypointListDialog(waypoints, location,
+                                      has_ordered_task ? task_clone.get()
+                                                       : nullptr,
+                                      ordered_task_index,
+                                      std::nullopt,
+                                      has_ordered_task,
+                                      action_label,
+                                      &action_selected);
+  } catch (...) {
+    return false;
+  }
+
+  if (action_selected)
+    override_waypoint.reset();
+  else if (selected)
+    override_waypoint = std::move(selected);
+  /* else: cancelled - leave override_waypoint unchanged. */
 
   return true;
 }

--- a/src/InfoBoxes/Content/Places.hpp
+++ b/src/InfoBoxes/Content/Places.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "InfoBoxes/Content/Base.hpp"
+#include "Engine/Waypoint/Ptr.hpp"
 
 struct InfoBoxData;
 
@@ -22,6 +23,17 @@ public:
 
 class InfoBoxContentActiveWaypoint : public InfoBoxContent
 {
+public:
+  void Update(InfoBoxData &data) noexcept override;
+  bool HandleClick() noexcept override;
+};
+
+class InfoBoxContentPreviousWaypoint : public InfoBoxContent
+{
+  /* User override. nullptr = "auto": track the task waypoint before
+     the active leg (or task[0] when on the first leg). */
+  WaypointPtr override_waypoint;
+
 public:
   void Update(InfoBoxData &data) noexcept override;
   bool HandleClick() noexcept override;

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -153,7 +153,8 @@ namespace InfoBoxFactory
     e_Home, /* Combined home waypoint infobox: shows waypoint name, arrival altitude diff, and distance */
     e_AltitudeIGC, /* Logger or ISA pressure altitude only (no QNH baro / GPS) */
     e_QNH, /* Current QNH pressure setting; tap to adjust manually */
-    e_ActiveWaypoint, /* Active waypoint: next task WP or Goto; arrival diff and distance */
+    e_ActiveWaypoint, /* Active waypoint infobox: shows the current task's next waypoint name (or Goto waypoint if no task), arrival altitude diff, and distance */
+    e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
     e_NUM_TYPES /* Last item */
   };
 


### PR DESCRIPTION
Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Summary

Follow-up to the Active Waypoint InfoBox (#2462). Where "Active Waypoint" answers *"am I going to make the point I'm flying to?"*, the **Previous Waypoint** InfoBox answers *"where did I just come from, and could I get back?"* — useful for judging glide back to the last turnpoint or start, evaluating a return after rounding a point, and keeping situational awareness of the leg just flown.

It reuses the same name / arrival-height-above-safety / distance layout as the Active Waypoint and Home InfoBoxes, so the three read consistently side by side.

- New **Previous Waypoint** InfoBox in `Places.cpp` (`e_PreviousWaypoint`, `InfoBoxContentPreviousWaypoint`). Title shows the waypoint name, value shows arrival altitude difference relative to the safety arrival height, and the comment shows distance. Reuses `ComputeActiveWaypointGlide` so glide behaviour matches the Active Waypoint InfoBox.
- The "previous waypoint" is, by default, the ordered-task waypoint **before the active leg** (active index − 1). While on the first leg (no prior point), the **start waypoint** is shown instead.
- Tap to override which waypoint is displayed:
  - **Task loaded:** picker prepopulated with task waypoints in task order. If an override is active, a leading **"Resume auto tracking"** row clears it.
  - **No task:** standard filter-driven full-database picker.
  - Selection is **informational only** — never advances the task or sets Goto. Override is **sticky across leg advances** until resumed.
- `ShowWaypointListDialog` gains opt-in `action_row_label` and `action_selected` parameters, generalizing the filter-prompt row. Existing callers unchanged.
- Docs: `\ibi{Previous Waypoint}{Prev WP}{...}` in `doc/manual/en/ch10_infobox_reference.tex` and NEWS bullet under v7.45.

## Test plan

- [x] No task loaded, no override: InfoBox title reads "Prev WP", value / comment invalid.
- [x] No task loaded: tap → full filter picker → select a waypoint → InfoBox updates; task not modified, no Goto set.
- [x] Ordered task with ≥3 turnpoints, active leg ≥ 2: shows turnpoint before active leg with arrival diff and distance.
- [x] On first leg (active index 0): shows start waypoint.
- [x] Advance active task point without override: previous waypoint follows automatically.
- [x] Tap with task loaded: task waypoints in order; select different one → displays it; active point unchanged.
- [x] Override sticky across leg advances.
- [x] "Resume auto tracking" clears override and reverts to auto.
- [x] Toggle `safety_height_arrival` → arrival diff shifts as expected.
- [x] Build clean: `make TARGET=MACOS app -j$(nproc)`

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Previous Waypoint" infobox displaying the waypoint before the active leg, showing arrival height above safety and distance. Tap to select a different waypoint or resume auto tracking.

* **Documentation**
  * Updated infobox reference guide with details on the new Previous Waypoint infobox feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
