### PR TITLE
Weather/Rasp/RaspStore: Skip OpenArchive when no file is configured

### DIFF
--- a/src/Weather/Rasp/RaspStore.cpp
+++ b/src/Weather/Rasp/RaspStore.cpp
@@ -132,6 +132,9 @@ RaspStore::WeatherFilename(char *filename, Path name,
 std::unique_ptr<ZipArchive>
 RaspStore::OpenArchive() const
 {
+  if (path == nullptr || path.empty())
+    return nullptr;
+
   return std::make_unique<ZipArchive>(path);
 }
 


### PR DESCRIPTION
## Summary

- Fix segfault when clearing the RASP file in the Weather dialog (empty file selection).
- `Profile::GetPath(RaspFile)` returns `nullptr` for an empty path; `ScanAll()` still called `OpenArchive()`, which passed that to `zzip_dir_open()` and crashed.
- Return `nullptr` from `OpenArchive()` when the path is missing or empty; `ScanAll()` already treats that as “no archive”.

## Test plan

- [ ] Open Weather → RASP, select a RASP `.dat` file, then clear the file to the empty entry — no crash.
- [ ] Confirm the RASP overlay disappears after clearing (with `LoadConfiguredRasp(false)` on reload).
- [ ] Normal RASP load and field/time selection still work with a valid file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of archive handling by adding path validation to prevent errors when processing archives with invalid or empty paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->