### PR TITLE
net/wifi/WifiBackend: Fix -Wmissing-noreturn on default stubs

### DIFF
--- a/src/net/wifi/WifiBackend.hpp
+++ b/src/net/wifi/WifiBackend.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "WifiData.hpp"
+#include "util/Exception.hxx"
 
 #include <cstdio>
 #include <cstdlib>
@@ -19,12 +20,14 @@ public:
   virtual void Scan() = 0;
   virtual std::size_t ScanResults(WifiVisibleNetwork *, unsigned)
   {
-    throw std::runtime_error{"ScanResults is not supported by this backend"};
+    ThrowException(std::runtime_error{
+        "ScanResults is not supported by this backend"});
   }
 
   virtual std::size_t ListNetworks(WifiConfiguredNetworkInfo *, std::size_t)
   {
-    throw std::runtime_error{"ListNetworks is not supported by this backend"};
+    ThrowException(std::runtime_error{
+        "ListNetworks is not supported by this backend"});
   }
 
   /* Connect using SSID + passphrase; backend handles PSK/PMK derivation. */
@@ -33,14 +36,16 @@ public:
 
   virtual void RemoveNetwork(unsigned)
   {
-    throw std::runtime_error{"RemoveNetwork is not supported by this backend"};
+    ThrowException(std::runtime_error{
+        "RemoveNetwork is not supported by this backend"});
   }
 
   virtual void SaveConfig() {}
 
   virtual void Disconnect()
   {
-    throw std::runtime_error{"Disconnect is not supported by this backend"};
+    ThrowException(std::runtime_error{
+        "Disconnect is not supported by this backend"});
   }
   virtual WifiBackendStatus GetBackendStatus() = 0;
 


### PR DESCRIPTION
## Summary

- Fixes macOS/iOS CI failures on `master` after #2525 (`-Wmissing-noreturn` on `WifiBackend` default stubs).
- Default `ScanResults()`, `ListNetworks()`, `RemoveNetwork()`, and `Disconnect()` now use `ThrowException()` instead of bare `throw`, matching the project pattern and satisfying Clang without marking the virtual methods `[[noreturn]]` (overrides such as `WPASupplicantBackend` return normally).

## Test plan

- [x] `TARGET=UNIX WERROR=y` build succeeds locally
- [x] `clang++ -Wmissing-noreturn -Werror` syntax check with a returning override compiles
- [ ] CI `build-native` macOS (`MACOS`, `IOS64`) matrix legs pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in error handling for WiFi backend operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2530?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->