### PR TITLE
TimesStatusPanel: Match flight time to rounded takeoff and landing

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,9 @@ Version 7.45 - not yet released
     ISA logger datum; cleared when strong pressure replaces weak pressure or
     ignores the sentence
 * ui
+  - status dialog, Times: flight time matches takeoff and landing after
+    minute rounding (including across midnight); landing time clears on a
+    new takeoff in the same session #957
   - status dialog, Rules: after a valid start, show PEV offset at start (time
     from PEV window start to the crossing) when known, as a duration (e.g.
     "45 sec", "2 min") not HH:MM so sub-minute offsets are not shown as 00:00

--- a/src/Computer/FlyingComputer.cpp
+++ b/src/Computer/FlyingComputer.cpp
@@ -80,6 +80,8 @@ FlyingComputer::Check(FlyingState &state, TimeStamp time) noexcept
       state.release_time = TimeStamp::Undefined();
       state.power_on_time = TimeStamp::Undefined();
       state.power_off_time = TimeStamp::Undefined();
+      state.landing_time = TimeStamp::Undefined();
+      state.landing_location.SetInvalid();
       state.far_location.SetInvalid();
       state.far_distance = -1;
     }

--- a/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
@@ -77,7 +77,14 @@ TimesStatusPanel::Refresh() noexcept
   }
 
   if (flight.flight_time.count() > 0) {
-    SetText(FlightTime, FormatSignedTimeHHMM(flight.flight_time));
+    if (flight.takeoff_time.IsDefined() && flight.landing_time.IsDefined()) {
+      RoughTime rough_takeoff_time = RoughTime::FromSinceMidnight(flight.takeoff_time);
+      RoughTime rough_landing_time = RoughTime::FromSinceMidnight(flight.landing_time);
+      SetText(FlightTime, FormatSignedTimeHHMM(FloatDuration(rough_landing_time-rough_takeoff_time)));
+    }
+    else {
+      SetText(FlightTime, FormatSignedTimeHHMM(flight.flight_time));
+    }
   } else {
     ClearText(FlightTime);
   }

--- a/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
+++ b/src/Dialogs/StatusPanels/TimesStatusPanel.cpp
@@ -7,6 +7,8 @@
 #include "Formatter/LocalTimeFormatter.hpp"
 #include "Math/SunEphemeris.hpp"
 #include "Language/Language.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "time/RoughTime.hpp"
 
 enum Controls {
   LocalTime,
@@ -78,11 +80,31 @@ TimesStatusPanel::Refresh() noexcept
 
   if (flight.flight_time.count() > 0) {
     if (flight.takeoff_time.IsDefined() && flight.landing_time.IsDefined()) {
-      RoughTime rough_takeoff_time = RoughTime::FromSinceMidnight(flight.takeoff_time);
-      RoughTime rough_landing_time = RoughTime::FromSinceMidnight(flight.landing_time);
-      SetText(FlightTime, FormatSignedTimeHHMM(FloatDuration(rough_landing_time-rough_takeoff_time)));
-    }
-    else {
+      bool set = false;
+
+      if (basic.time_available && basic.date_time_utc.IsDatePlausible()) {
+        const BrokenDateTime takeoff_dt =
+          basic.GetDateTimeAt(flight.takeoff_time).FloorToMinute();
+        const BrokenDateTime landing_dt =
+          basic.GetDateTimeAt(flight.landing_time).FloorToMinute();
+
+        if (takeoff_dt.IsPlausible() && landing_dt.IsPlausible()) {
+          const auto duration = landing_dt - takeoff_dt;
+          SetText(FlightTime, FormatSignedTimeHHMM(
+            std::chrono::duration_cast<std::chrono::seconds>(duration)));
+          set = true;
+        }
+      }
+
+      if (!set) {
+        const RoughTime rough_takeoff =
+          RoughTime::FromSinceMidnight(flight.takeoff_time);
+        const RoughTime rough_landing =
+          RoughTime::FromSinceMidnight(flight.landing_time);
+        SetText(FlightTime, FormatSignedTimeHHMM(
+          FloatDuration{rough_landing - rough_takeoff}));
+      }
+    } else {
       SetText(FlightTime, FormatSignedTimeHHMM(flight.flight_time));
     }
   } else {

--- a/src/time/BrokenDateTime.hpp
+++ b/src/time/BrokenDateTime.hpp
@@ -96,6 +96,17 @@ struct BrokenDateTime : public BrokenDate, public BrokenTime {
   }
 
   /**
+   * Returns a copy with seconds set to zero (minute resolution).
+   */
+  constexpr BrokenDateTime FloorToMinute() const noexcept
+  {
+    if (!IsPlausible())
+      return *this;
+
+    return BrokenDateTime(year, month, day, hour, minute, 0);
+  }
+
+  /**
    * Convert a UNIX UTC time stamp (seconds since epoch) to a
    * BrokenDateTime object.
    */

--- a/src/time/RoughTime.hpp
+++ b/src/time/RoughTime.hpp
@@ -64,6 +64,12 @@ public:
   { 
   }
 
+  static constexpr TimeSinceMidnight
+  FromSinceMidnight(TimeStamp since_midnight) noexcept
+  {
+    return TimeSinceMidnight(std::chrono::floor<Duration>(since_midnight.ToDuration()));
+  }
+
   static constexpr TimeSinceMidnight Invalid() noexcept {
     return TimeSinceMidnight(INVALID);
   }
@@ -127,6 +133,10 @@ public:
 
     value = (value + MAX - Duration{1}) % MAX;
     return *this;
+  }
+
+  constexpr Duration operator-(TimeSinceMidnight other) const noexcept {
+    return value - other.value;
   }
 
   constexpr operator TimeStamp() const noexcept {

--- a/test/src/TestRoughTime.cpp
+++ b/test/src/TestRoughTime.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "time/RoughTime.hpp"
+#include "time/Stamp.hpp"
 #include "TestUtil.hpp"
 
 using namespace std::chrono_literals;
@@ -148,6 +149,28 @@ static void test_time_span()
   ok1(!s.IsInside(d));
 }
 
+static void
+test_from_since_midnight()
+{
+  ok1(RoughTime::FromSinceMidnight(TimeStamp{10h + 3min + 30s}) ==
+      RoughTime(10, 3));
+  ok1(RoughTime::FromSinceMidnight(TimeStamp{10h + 3min + 59s + 900ms}) ==
+      RoughTime(10, 3));
+  ok1(RoughTime::FromSinceMidnight(TimeStamp{10h + 4min}) ==
+      RoughTime(10, 4));
+}
+
+static void
+test_rough_time_difference()
+{
+  const RoughTime takeoff = RoughTime::FromSinceMidnight(TimeStamp{10h + 3min + 30s});
+  const RoughTime landing = RoughTime::FromSinceMidnight(TimeStamp{11h + 47min + 29s});
+
+  ok1(takeoff == RoughTime(10, 3));
+  ok1(landing == RoughTime(11, 47));
+  ok1(landing - takeoff == 104min);
+}
+
 static void test_rough_time_delta()
 {
   /* test operator+(RoughTime, RoughTimeDelta) */
@@ -166,12 +189,14 @@ static void test_rough_time_delta()
 
 int main()
 {
-  plan_tests(136);
+  plan_tests(142);
 
   test_time<RoughTime>();
   test_time<FineTime>();
   test_conversions();
   test_time_span();
+  test_from_since_midnight();
+  test_rough_time_difference();
   test_rough_time_delta();
 
   return exit_status();

--- a/test/src/TestTimeFormatter.cpp
+++ b/test/src/TestTimeFormatter.cpp
@@ -2,9 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "Formatter/TimeFormatter.hpp"
+#include "time/RoughTime.hpp"
+#include "time/Stamp.hpp"
 #include "util/Macros.hpp"
 #include "util/StringAPI.hxx"
 #include "TestUtil.hpp"
+
+using namespace std::chrono_literals;
 
 static void
 TestFormat()
@@ -235,15 +239,35 @@ TestSmart()
             "-3 days 19 h 47 min 5 sec");
 }
 
+/**
+ * Regression for #957: flight time must match takeoff/landing after
+ * minute rounding, not raw second-precision duration.
+ */
+static void
+TestFlightTimeFromRoundedTakeoffLanding()
+{
+  const TimeStamp takeoff{10h + 3min + 30s};
+  const TimeStamp landing{11h + 47min + 29s};
+  const FloatDuration raw_flight_time = landing - takeoff;
+
+  ok1(StringIsEqual(FormatSignedTimeHHMM(raw_flight_time).c_str(), "01:43"));
+
+  const RoughTime rough_takeoff = RoughTime::FromSinceMidnight(takeoff);
+  const RoughTime rough_landing = RoughTime::FromSinceMidnight(landing);
+  ok1(StringIsEqual(FormatSignedTimeHHMM(FloatDuration{rough_landing - rough_takeoff}).c_str(),
+                  "01:44"));
+}
+
 int main()
 {
-  plan_tests(111);
+  plan_tests(113);
 
   TestFormat();
   TestFormatLong();
   TestHHMM();
   TestTwoLines();
   TestSmart();
+  TestFlightTimeFromRoundedTakeoffLanding();
 
   return exit_status();
 }

--- a/test/src/TestTimeFormatter.cpp
+++ b/test/src/TestTimeFormatter.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Formatter/TimeFormatter.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "time/RoughTime.hpp"
 #include "time/Stamp.hpp"
 #include "util/Macros.hpp"
@@ -258,9 +259,26 @@ TestFlightTimeFromRoundedTakeoffLanding()
                   "01:44"));
 }
 
+static void
+TestFlightTimeFromRoundedBrokenDateTime()
+{
+  const BrokenDateTime takeoff{2024, 1, 1, 23, 3, 30};
+  const BrokenDateTime landing{2024, 1, 2, 0, 47, 29};
+  const auto raw = landing - takeoff;
+
+  ok1(StringIsEqual(FormatSignedTimeHHMM(
+        std::chrono::duration_cast<std::chrono::seconds>(raw)).c_str(),
+        "01:43"));
+
+  const auto rounded = landing.FloorToMinute() - takeoff.FloorToMinute();
+  ok1(StringIsEqual(FormatSignedTimeHHMM(
+        std::chrono::duration_cast<std::chrono::seconds>(rounded)).c_str(),
+        "01:44"));
+}
+
 int main()
 {
-  plan_tests(113);
+  plan_tests(115);
 
   TestFormat();
   TestFormatLong();
@@ -268,6 +286,7 @@ int main()
   TestTwoLines();
   TestSmart();
   TestFlightTimeFromRoundedTakeoffLanding();
+  TestFlightTimeFromRoundedBrokenDateTime();
 
   return exit_status();
 }


### PR DESCRIPTION
## Summary

Fixes #957: on Status → Times, flight time could disagree with takeoff and landing by ±1 minute because each field was rounded independently while flight time used full second precision.

- Floor takeoff/landing to minutes, then subtract for displayed flight time after landing
- When GPS date is available, use `GetDateTimeAt()` so elapsed time is correct across midnight; fall back to `RoughTime` otherwise
- Clear `landing_time` / `landing_location` on a new takeoff so a second flight in the same session does not reuse the previous landing
- Rebased onto current master (`TimeSinceMidnight`); adds `RoughTime::FromSinceMidnight` and minute `operator-`
- `BrokenDateTime::FloorToMinute()` for shared minute truncation
- Unit tests for #957 and cross-midnight rounding

Based on the original fix by @hjr in #1027 (rebased and extended). Commits use `Co-authored-by` for @hjr and @lordfolken as appropriate.

Closes #957

## Test plan

- [ ] `output/UNIX/bin/TestRoughTime` and `output/UNIX/bin/TestTimeFormatter` pass
- [ ] Fly (or replay), land, open Status → Times: flight time equals landing − takeoff on the minute clock
- [ ] Cross-midnight flight (or replay): flight time still consistent with displayed times
- [ ] Second takeoff in one session: landing field clears until next landing; flight time uses live duration while airborne

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Flight time displayed in the status dialog now correctly reflects minute-rounded takeoff and landing times (including across midnight boundaries).
  * Landing time automatically clears when a new takeoff occurs in the same session.

* **Tests**
  * Added regression tests for flight time formatting accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2533?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->