### PR TITLE
Fix per-page weather overlay crashes

### DIFF
--- a/src/Blackboard/LiveBlackboard.cpp
+++ b/src/Blackboard/LiveBlackboard.cpp
@@ -23,7 +23,8 @@ LiveBlackboard::RemoveListener(BlackboardListener &listener) noexcept
   assert(!calling_listeners);
 
   auto i = std::find(listeners.begin(), listeners.end(), &listener);
-  assert(i != listeners.end());
+  if (i == listeners.end())
+    return;
 
   listeners.erase(i);
 }

--- a/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
@@ -82,6 +82,10 @@ public:
      usage(_usage),
      overlay(_overlay) {}
 
+  ~MapOverlayControlsWidget() noexcept override {
+    UnregisterBlackboardListener();
+  }
+
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Show(const PixelRect &rc) noexcept override;
   void Hide() noexcept override;

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -6,6 +6,7 @@
 #include "Look/MapLook.hpp"
 #include "Weather/Rasp/RaspRenderer.hpp"
 #include "Weather/Rasp/RaspCache.hpp"
+#include "Weather/Rasp/RaspStore.hpp"
 #include "Topography/CachedTopographyRenderer.hpp"
 #include "Renderer/AircraftRenderer.hpp"
 #include "Renderer/WaveRenderer.hpp"
@@ -39,7 +40,10 @@ MapWindow::RenderRasp(Canvas &canvas) noexcept
     return;
 
   const WeatherUIState &state = GetUIState().weather;
-  if (rasp_renderer && state.map != (int)rasp_renderer->GetParameter()) {
+  if (rasp_renderer &&
+      (state.map < 0 ||
+       unsigned(state.map) >= rasp_store->GetItemCount() ||
+       state.map != (int)rasp_renderer->GetParameter())) {
 #ifndef ENABLE_OPENGL
     const std::lock_guard lock{mutex};
 #endif
@@ -47,7 +51,8 @@ MapWindow::RenderRasp(Canvas &canvas) noexcept
     rasp_renderer.reset();
   }
 
-  if (state.map < 0)
+  if (state.map < 0 ||
+      unsigned(state.map) >= rasp_store->GetItemCount())
     return;
 
   if (!rasp_renderer) {

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -15,6 +15,7 @@
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Components.hpp"
 #include "DataGlobals.hpp"
+#include "Weather/Rasp/RaspStore.hpp"
 #include "ActionInterface.hpp"
 #ifdef HAVE_EDL
 #include "Dialogs/Weather/MapOverlayControlsWidget.hpp"
@@ -86,7 +87,10 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
 
   case PageLayout::Overlay::RASP: {
     WeatherUIState &weather = CommonInterface::SetUIState().weather;
-    if (layout.rasp_field >= 0)
+    weather.map = -1;
+    const auto rasp = DataGlobals::GetRasp();
+    if (rasp != nullptr && layout.rasp_field >= 0 &&
+        unsigned(layout.rasp_field) < rasp->GetItemCount())
       weather.map = layout.rasp_field;
 
     if (weather.EnterRaspDedicatedPage())

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -4,6 +4,7 @@
 #include "RaspControlsModel.hpp"
 
 #include "ActionInterface.hpp"
+#include "DataGlobals.hpp"
 #include "Interface.hpp"
 #include "PageActions.hpp"
 #include "UIState.hpp"
@@ -20,7 +21,12 @@ RaspControlsModel::SyncFromPageLayout() noexcept
   if (layout.overlay != PageLayout::Overlay::RASP)
     return;
 
-  CommonInterface::SetUIState().weather.map = GetFieldIndex();
+  auto &weather = CommonInterface::SetUIState().weather;
+  weather.map = -1;
+
+  const int field_index = GetFieldIndex();
+  if (field_index >= 0)
+    weather.map = field_index;
 }
 
 int
@@ -30,10 +36,15 @@ RaspControlsModel::GetFieldIndex() const noexcept
   if (layout.overlay != PageLayout::Overlay::RASP)
     return -1;
 
-  if (layout.rasp_field >= 0)
+  const auto rasp = DataGlobals::GetRasp();
+  if (rasp == nullptr || rasp->GetItemCount() == 0)
+    return -1;
+
+  if (layout.rasp_field >= 0 &&
+      unsigned(layout.rasp_field) < rasp->GetItemCount())
     return layout.rasp_field;
 
-  return 0;
+  return rasp->GetItemCount() > 0 ? 0 : -1;
 }
 
 void

--- a/src/Weather/Rasp/RaspCache.cpp
+++ b/src/Weather/Rasp/RaspCache.cpp
@@ -27,12 +27,18 @@ ToQuarterHours(BrokenTime t)
 const char *
 RaspCache::GetMapName() const
 {
+  if (parameter >= store.GetItemCount())
+    return "";
+
   return store.GetItemInfo(parameter).name;
 }
 
 const char *
 RaspCache::GetMapLabel() const
 {
+  if (parameter >= store.GetItemCount())
+    return "";
+
   const auto &info = store.GetItemInfo(parameter);
   return info.label != nullptr
     ? gettext(info.label)
@@ -63,6 +69,9 @@ RaspCache::IsInside(GeoPoint p) const
 void
 RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
 {
+  if (parameter >= store.GetItemCount())
+    return;
+
   unsigned effective_time = time;
   if (effective_time == 0) {
     // "Now" time, so find time in half hours

--- a/src/Weather/Rasp/RaspStore.cpp
+++ b/src/Weather/Rasp/RaspStore.cpp
@@ -90,7 +90,9 @@ RaspStore::IndexToTime(unsigned index)
 unsigned
 RaspStore::GetNearestTime(unsigned item_index, unsigned time_index) const
 {
-  assert(item_index < maps.size());
+  if (item_index >= maps.size() || time_index >= MAX_WEATHER_TIMES)
+    return MAX_WEATHER_TIMES;
+
   assert(time_index < MAX_WEATHER_TIMES);
 
   // scan forward to next valid time

--- a/src/Weather/Rasp/RaspStore.hpp
+++ b/src/Weather/Rasp/RaspStore.hpp
@@ -93,15 +93,16 @@ public:
   void ScanAll();
 
   bool IsTimeAvailable(unsigned item_index, unsigned time_index) const {
-    assert(item_index < maps.size());
-    assert(time_index < MAX_WEATHER_TIMES);
+    if (item_index >= maps.size() || time_index >= MAX_WEATHER_TIMES)
+      return false;
 
     return maps[item_index].times[time_index];
   }
 
   template<typename C>
   void ForEachTime(unsigned item_index, C &&c) {
-    assert(item_index < maps.size());
+    if (item_index >= maps.size())
+      return;
 
     const auto &mi = maps[item_index];
 


### PR DESCRIPTION
## Summary

Fixes stability issues in the per-page weather overlay feature (RASP/EDL on map pages):

- **Configuration dialog**: avoid abort when closing settings without opening the Weather tab (`LiveBlackboard::RemoveListener` / `MapOverlayControlsWidget` listener lifecycle).
- **Empty RASP store**: guard `GetNearestTime()` and related paths when no RASP file is loaded but a page still has RASP overlay with `rasp_field = 0`.
- **Runtime**: only set `weather.map` and create `RaspRenderer` when the configured layer exists in the loaded store.

## Test plan

- [ ] Open Configuration, close without visiting Setup → Weather (no crash)
- [ ] Map page with RASP overlay, no RASP file configured (no assert in `GetNearestTime`)
- [ ] Load RASP file, verify overlay and layer selection still work
- [ ] Switch pages with EDL/RASP overlays after loading data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing blackboard listeners to prevent crashes.
  * Added proper bounds validation in weather overlay data access to prevent invalid memory reads.
  * Enhanced RASP weather data validation when loading and displaying overlays.
  * Fixed listener cleanup in weather widgets to prevent resource leaks on shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->