### PR TITLE
Widget: Fix crashes during Show/Move layout

### DIFF
--- a/src/Widget/SolidWidget.cpp
+++ b/src/Widget/SolidWidget.cpp
@@ -79,9 +79,12 @@ SolidWidget::ReClick() noexcept
 void
 SolidWidget::Show(const PixelRect &rc) noexcept
 {
-  widget->Show(ToOrigin(rc));
-
+  /* Show the container first.  The child Show() may run nested UI (e.g.
+     a modal download dialog); layout code must be able to Move() the
+     container while that runs (OnTerrainLoaded during startup). */
   WindowWidget::Show(rc);
+
+  widget->Show(ToOrigin(rc));
 }
 
 bool
@@ -100,8 +103,14 @@ SolidWidget::Hide() noexcept
 void
 SolidWidget::Move(const PixelRect &rc) noexcept
 {
-  WindowWidget::Move(rc);
-  widget->Move(ToOrigin(rc));
+  if (!IsDefined())
+    return;
+
+  if (GetWindow().IsVisible()) {
+    WindowWidget::Move(rc);
+    widget->Move(ToOrigin(rc));
+  } else
+    GetWindow().Move(rc);
 }
 
 bool

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -154,7 +154,12 @@ VScrollWidget::Hide() noexcept
 void
 VScrollWidget::Move(const PixelRect &rc) noexcept
 {
-  WindowWidget::Move(rc);
+  /* Match Prepare(): the scroll panel may exist but not be shown yet
+     (PagerWidget::Move during layout before Show, or after Hide). */
+  if (visible)
+    WindowWidget::Move(rc);
+  else if (IsDefined())
+    GetWindow().Move(rc);
 
   /* Update virtual height when moved (e.g., when expert mode toggles
      and child widget changes size) */


### PR DESCRIPTION
## Summary

- **SolidWidget:** Show the container window before the child so layout can `Move()` the parent while nested UI runs in the child's `Show()` (e.g. terrain download modal during startup / `OnTerrainLoaded`).
- **SolidWidget:** When not visible yet, `Move()` only updates the native window geometry instead of recursing into the child.
- **VScrollWidget:** Same visibility guard in `Move()` as in `Prepare()` — avoids moving the scroll panel subtree before `Show()` or after `Hide()` (e.g. expert-mode toggle resizing config pages).

## Test plan

- [ ] Cold start with terrain/EDL download dialog; confirm no crash when terrain finishes loading
- [ ] Open map display config, toggle expert mode; confirm no crash and layout updates
- [ ] Scroll config pages with `VScrollWidget` still work after show/hide cycles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved widget display ordering to ensure parent containers render before child elements.
  * Enhanced widget positioning logic to correctly handle visibility states, preventing incorrect movement when widgets are hidden.
  * Refined early-return conditions for undefined widgets during move operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2539?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->