### PR TITLE
Net/Startup: Stabilise async network tasks and startup UI refresh

### DIFF
--- a/.cursor/rules/xcsoar-project-rules.mdc
+++ b/.cursor/rules/xcsoar-project-rules.mdc
@@ -284,7 +284,7 @@ XCSoar follows a layered architecture with clear separation of concerns:
 **Component Separation:**
 - `BackendComponents`: manages backend resources (devices, computers, threads)
 - `DataComponents`: manages data stores (waypoints, airspaces, terrain)
-- `NetComponents`: manages network resources
+- `NetComponents`: manages network resources (NOTAM, TIM, tracking, EDL `DownloadGlue`, …); long-lived HTTP uses `Net::AsyncTask` and `BeginShutdown()` before UI teardown (see `doc/architecture.rst`, Network thread and background HTTP)
 - Components are accessed through global pointers, not direct dependencies
 
 **Interface Access Patterns:**
@@ -312,6 +312,7 @@ XCSoar follows a layered architecture with clear separation of concerns:
 - Calculation thread: use `GlideComputerBlackboard` or lock `DeviceBlackboard`
 - Map rendering thread: use `MapWindowBlackboard`
 - Device threads: write to `DeviceBlackboard` (per-device slots), then notify merge thread
+- Network (asio) thread: curl and `Co::InjectTask` / `Net::AsyncTask`; never `CommonInterface`, `ActionInterface`, or window/layout code; snapshot UI parameters on main thread before starting work; complete via `UI::Notify` on main thread
 - Never access `InterfaceBlackboard` from non-UI threads
 
 ### Blackboard Usage Guide
@@ -496,6 +497,9 @@ if (data_components != nullptr) {
 - Call `ActionInterface` from device drivers or calculation threads
 - Include `Engine/`, `Computer/`, `Device/`, or `Blackboard/` headers in Foundation or Platform layers
 - Directly show dialogs or message boxes from Backend code (use event queue instead)
+- Call `CommonInterface::*()`, `SetUIState`, `PageActions::Update`, or `InfoBoxManager` from the asio/network thread or from coroutine bodies without marshalling to main thread
+- Destroy `CurlGlobal` on the main thread (`Net::Deinitialise` uses `DrainCurl` on the asio event loop)
+- Start long-lived HTTP from UI without `Net::AsyncTask` and `NetComponents::BeginShutdown()` registration
 
 **DO:**
 - Use `CommonInterface::*()` in UI code
@@ -539,6 +543,24 @@ if (data_components != nullptr) {
   - MapWindow (DrawThread): `MapWindowBlackboard`
   - Device drivers: write to `DeviceBlackboard::per_device_data[i]`, can implement `OnSensorUpdate()` (called from MergeThread) or `OnCalculatedUpdate()` (called from UI thread)
   - CalculationThread: lock `DeviceBlackboard` or use `GlideComputerBlackboard`
+  - Network thread: asio event loop; see `doc/architecture.rst` (Network thread and background HTTP)
+
+### Background HTTP and NetComponents
+
+- **Modal (UI-owned):** `ShowCoDialog` + `Co::InjectTask` — cancelled when the dialog closes
+- **Long-lived:** `Net::AsyncTask` in a `NetComponents` member; `BeginShutdown()` from `NetComponents::BeginShutdown()` before UI teardown
+- **Completion:** coroutine callback on network thread should only `UI::Notify::SendNotification()`; apply UI changes in the notify handler on main thread
+- **Startup:** create `net_components` before `AfterStartup()` when work needs running threads; start merge/calculation threads before NOTAM cache replay; defer `PageActions::Update` / InfoBox refresh via `SchedulePageActionsUpdate` / `ScheduleRefreshInfoBoxes` when called from async terrain or blackboard paths
+- **Shutdown:** `NetComponents::BeginShutdown()` early in `Shutdown()`; `delete net_components` after threads stopped; `Net::Deinitialise()` drains curl on asio thread
+
+### Adding background HTTP work
+
+1. Add `Net::AsyncTask` (or reuse glue with one) on the asio `EventLoop` from `CurlGlobal::GetEventLoop()`
+2. Snapshot any `CommonInterface` / UI state on the **main thread** before `task.Start()`
+3. Run download/parse in the coroutine; store results in glue members
+4. On completion, `UI::Notify` → main thread: update map overlay, status, `SendUIState`, listeners
+5. Implement `BeginShutdown()` (cancel task, clear pending notify); register in `NetComponents::BeginShutdown()`
+6. For GPS/time-driven state, use a `BlackboardListener` on the UI thread separate from download glue (EDL: `Glue` vs `DownloadGlue`)
 
 ### Adding JNI Methods (Android)
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -670,7 +670,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Weather/EDL/StateController.cpp \
 	$(SRC)/Weather/MapOverlay/EdlControlsModel.cpp \
 	$(SRC)/Weather/MapOverlay/RaspControlsModel.cpp \
-	$(SRC)/Weather/EDL/Glue.cpp
+	$(SRC)/Weather/EDL/Glue.cpp \
+	$(SRC)/Weather/EDL/DownloadGlue.cpp
 endif
 else
 XCSOAR_SOURCES += \

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -125,6 +125,71 @@ thread, it is implemented with Java callbacks. For Bluetooth I/O, there
 are two threads implemented in Java (:file:`InputThread.java` and
 :file:`OutputThread.java`, managed by :file:`BluetoothHelper.java`).
 
+Network thread and background HTTP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the sensor and UI threads above, XCSoar runs a dedicated
+**asio event-loop thread** (:file:`io/async/GlobalAsioThread.cpp`,
+started from :file:`XCSoar.cpp`). It hosts :file:`CurlGlobal` and runs
+coroutines injected with :file:`Co::InjectTask` / :file:`Net::AsyncTask`.
+
+Typical uses:
+
+- NOTAM fetches (:file:`NOTAM/NOTAMGlue.cpp`)
+- EDL tile downloads (:file:`Weather/EDL/DownloadGlue.cpp`)
+- TIM thermal index, LiveTrack24, SkyLines, and similar clients in
+  :file:`NetComponents.hpp`
+
+The **UI thread** (main event loop) must not perform blocking network
+I/O during flight. Long-lived background work belongs on the network
+thread; **modal** downloads tied to one dialog may still use
+:file:`ShowCoDialog` on the UI thread.
+
+Thread rules (same as for :file:`Interface.hpp` elsewhere):
+
+- **Do not** call :file:`CommonInterface`, :file:`ActionInterface`, or
+  other UI-only APIs from the network thread. ``InMainThread()`` checks
+  will fail.
+- **Do** read any UI state needed for a download on the **main thread**
+  before starting the coroutine (for example forecast time and isobar
+  for EDL tiles), and pass snapshots into the network work.
+- **Do** report completion to the UI with :file:`UI::Notify`
+  (:file:`ui/event/Notify.cpp`), which queues a callback on the main
+  event loop. Apply overlays, update status labels, and call
+  :file:`ActionInterface::SendUIState` only from that callback.
+
+**NetComponents** (:file:`NetComponents.hpp`) owns long-lived network
+clients. Each client that uses :file:`Net::AsyncTask` should implement
+``BeginShutdown()`` and be stopped from
+``NetComponents::BeginShutdown()`` before the map and other UI are
+torn down. The global pointer is cleared later in :file:`Startup.cpp`
+(``DestroyNetComponents``).
+
+**Shutdown order** (see :file:`Startup.cpp`):
+
+1. ``NetComponents::BeginShutdown()`` — cancel coroutines and queued
+   downloads; clear map pointers to TIM / SkyLines data
+2. Stop merge and calculation threads; destroy UI
+3. ``delete net_components``
+4. On process exit, :file:`Net::Deinitialise` destroys :file:`CurlGlobal`
+   on the **asio** thread (:file:`DrainCurl` in :file:`net/http/Init.cpp`)
+
+**Deferred UI refresh:** callbacks such as async terrain load or
+blackboard updates must not call :file:`PageActions::Update` or
+:file:`ActionInterface::SendUIState` synchronously if that can re-enter
+layout while InfoBoxes are being created. Use
+:file:`MainWindow::SchedulePageActionsUpdate` and
+:file:`ScheduleRefreshInfoBoxes` instead (next event-loop iteration).
+:file:`InfoBoxManager` skips work until ``Create()`` has finished
+(``infoboxes_ready``).
+
+**Weather overlays:** map overlays may combine a **blackboard listener**
+(ongoing GPS/time sync, for example :file:`Weather/EDL/Glue.cpp`) with a
+**download glue** in :file:`NetComponents` (HTTP fetch and cache, for
+example :file:`Weather/EDL/DownloadGlue.cpp`). New providers (such as
+XCTherm) should follow the same split: listener on the UI thread,
+network I/O on the asio thread, UI updates via :file:`UI::Notify`.
+
 Locking
 ~~~~~~~
 

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -335,6 +335,12 @@ ActionInterface::SendUIState() noexcept
 }
 
 void
+ActionInterface::ScheduleSendUIState() noexcept
+{
+  main_window->ScheduleRefreshInfoBoxes();
+}
+
+void
 ActionInterface::SetActiveFrequency(const RadioFrequency freq,
                                     const char *freq_name,
                                     bool to_devices) noexcept

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -125,6 +125,12 @@ void
 SendUIState() noexcept;
 
 /**
+ * Like SendUIState(), but runs on the next event-loop iteration.
+ */
+void
+ScheduleSendUIState() noexcept;
+
+/**
  * Update the Active Radio Frequency in #ComputerSettings, and
  * forward it to all XCSoar modules that want it.
  *

--- a/src/DataGlobals.cpp
+++ b/src/DataGlobals.cpp
@@ -53,7 +53,7 @@ DataGlobals::SetTerrain(std::unique_ptr<RasterTerrain> _terrain) noexcept
   /* re-create the bottom widget if it was deleted by
      UnsetTerrain() */
   if (global_running)
-    PageActions::Update();
+    PageActions::ScheduleUpdate();
 }
 
 std::shared_ptr<RaspStore>

--- a/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
@@ -54,6 +54,9 @@ class MapOverlayControlsWidget final
   Button *precache_day_button = nullptr;
   Button *clean_other_days_button = nullptr;
   bool blackboard_listener_registered = false;
+#ifdef HAVE_EDL
+  EDL::DownloadGlue *edl_listener_glue = nullptr;
+#endif
 
 public:
   MapOverlayControlsWidget(MapOverlay::Usage _usage,
@@ -64,6 +67,9 @@ public:
 
   ~MapOverlayControlsWidget() noexcept override {
     UnregisterBlackboardListener();
+#ifdef HAVE_EDL
+    UnregisterEdlDownloadListener();
+#endif
   }
 
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -74,6 +80,9 @@ public:
 private:
   void RegisterBlackboardListener() noexcept;
   void UnregisterBlackboardListener() noexcept;
+#ifdef HAVE_EDL
+  void UnregisterEdlDownloadListener() noexcept;
+#endif
   void RefreshControls() noexcept;
   void UpdateAutoAdvanceControls() noexcept;
 
@@ -115,6 +124,18 @@ MapOverlayControlsWidget::UnregisterBlackboardListener() noexcept
   CommonInterface::GetLiveBlackboard().RemoveListener(*this);
   blackboard_listener_registered = false;
 }
+
+#ifdef HAVE_EDL
+void
+MapOverlayControlsWidget::UnregisterEdlDownloadListener() noexcept
+{
+  if (edl_listener_glue == nullptr)
+    return;
+
+  edl_listener_glue->RemoveListener(*this);
+  edl_listener_glue = nullptr;
+}
+#endif
 
 void
 MapOverlayControlsWidget::UpdateAutoAdvanceControls() noexcept
@@ -324,8 +345,10 @@ MapOverlayControlsWidget::Show(const PixelRect &rc) noexcept
 
 #ifdef HAVE_EDL
   if (overlay == PageLayout::Overlay::EDL &&
-      net_components != nullptr && net_components->edl != nullptr)
-    net_components->edl->AddListener(*this);
+      net_components != nullptr && net_components->edl != nullptr) {
+    edl_listener_glue = net_components->edl.get();
+    edl_listener_glue->AddListener(*this);
+  }
 #endif
 
   if (refresh_edl)
@@ -339,9 +362,7 @@ MapOverlayControlsWidget::Hide() noexcept
   UnregisterBlackboardListener();
 
 #ifdef HAVE_EDL
-  if (overlay == PageLayout::Overlay::EDL &&
-      net_components != nullptr && net_components->edl != nullptr)
-    net_components->edl->RemoveListener(*this);
+  UnregisterEdlDownloadListener();
 #endif
 
   WindowWidget::Hide();

--- a/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
@@ -22,6 +22,7 @@
 #include "Weather/EDL/StateController.hpp"
 #include "Weather/EDL/TileStore.hpp"
 #ifdef HAVE_EDL
+#include "Weather/EDL/Glue.hpp"
 #include "Weather/EDL/DownloadGlue.hpp"
 #endif
 #include "Widget/RowFormWidget.hpp"
@@ -89,7 +90,7 @@ private:
   void OnGPSUpdate(const MoreData &basic) override;
 
 #ifdef HAVE_EDL
-  void OnDownloadFinished() noexcept override;
+  void OnDownloadFinished(const EDL::DownloadNotification &notification) noexcept override;
 #endif
 };
 
@@ -420,19 +421,15 @@ MapOverlayControlsWidget::RefreshEdlOverlay()
     return;
   }
 
-  if (net_components == nullptr || net_components->edl == nullptr) {
-    RefreshControls();
-    return;
-  }
-
   RefreshControls();
-  net_components->edl->RequestOverlayRefresh();
+  EDL::RequestOverlayRefresh();
 #endif
 }
 
 #ifdef HAVE_EDL
 void
-MapOverlayControlsWidget::OnDownloadFinished() noexcept
+MapOverlayControlsWidget::OnDownloadFinished(
+  const EDL::DownloadNotification &) noexcept
 {
   RefreshControls();
 }
@@ -448,10 +445,7 @@ MapOverlayControlsWidget::PrecacheDay()
   if (!EDL::OverlayEnabled())
     return;
 
-  if (net_components == nullptr || net_components->edl == nullptr)
-    return;
-
-  net_components->edl->RequestPrecacheDay(EDL::GetForecastTime());
+  EDL::RequestPrecacheDay(EDL::GetForecastTime());
 #endif
 }
 

--- a/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayControlsWidget.cpp
@@ -4,9 +4,9 @@
 #include "MapOverlayControlsWidget.hpp"
 
 #include "Blackboard/BlackboardListener.hpp"
-#include "Dialogs/CoFunctionDialog.hpp"
-#include "Dialogs/Error.hpp"
 #include "Dialogs/Message.hpp"
+#include "Components.hpp"
+#include "NetComponents.hpp"
 #include "Form/Button.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Listener.hpp"
@@ -14,7 +14,6 @@
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Look/DialogLook.hpp"
-#include "Operation/PluggableOperationEnvironment.hpp"
 #include "DataGlobals.hpp"
 #include "UIGlobals.hpp"
 #include "Weather/MapOverlay/EdlControlsModel.hpp"
@@ -22,44 +21,24 @@
 #include "Weather/MapOverlay/Usage.hpp"
 #include "Weather/EDL/StateController.hpp"
 #include "Weather/EDL/TileStore.hpp"
+#ifdef HAVE_EDL
+#include "Weather/EDL/DownloadGlue.hpp"
+#endif
 #include "Widget/RowFormWidget.hpp"
 #include "Widget/SolidWidget.hpp"
-#include "co/Task.hxx"
 #include "util/StaticString.hxx"
-
-#ifdef HAVE_HTTP
-#include "net/http/Init.hpp"
-#endif
 
 #include <memory>
 #include <vector>
 
-namespace {
-
-#ifdef HAVE_HTTP
-
-Co::Task<AllocatedPath>
-CoDownloadEdlTile(CurlGlobal &curl, ProgressListener &progress,
-                  EDL::TileRequest request)
-{
-  co_return co_await request.EnsureDownloaded(curl, progress);
-}
-
-Co::Task<unsigned>
-CoPrecacheEdlDay(CurlGlobal &curl, ProgressListener &progress,
-                 BrokenDateTime day)
-{
-  co_return co_await EDL::EnsureDayDownloaded(day, curl, progress);
-}
-
-#endif
-
-} // namespace
-
 class MapOverlayControlsWidget final
   : public RowFormWidget,
     private DataFieldListener,
-    NullBlackboardListener {
+    NullBlackboardListener
+#ifdef HAVE_EDL
+  , private EDL::DownloadListener
+#endif
+{
   const MapOverlay::Usage usage;
   const PageLayout::Overlay overlay;
   MapOverlay::EdlControlsModel edl;
@@ -108,6 +87,10 @@ private:
 
   void OnModified(DataField &df) noexcept override;
   void OnGPSUpdate(const MoreData &basic) override;
+
+#ifdef HAVE_EDL
+  void OnDownloadFinished() noexcept override;
+#endif
 };
 
 void
@@ -338,6 +321,12 @@ MapOverlayControlsWidget::Show(const PixelRect &rc) noexcept
 
   RegisterBlackboardListener();
 
+#ifdef HAVE_EDL
+  if (overlay == PageLayout::Overlay::EDL &&
+      net_components != nullptr && net_components->edl != nullptr)
+    net_components->edl->AddListener(*this);
+#endif
+
   if (refresh_edl)
     RefreshEdlOverlay();
 }
@@ -347,6 +336,13 @@ MapOverlayControlsWidget::Hide() noexcept
 {
   EDL::ClearGpsUiRefreshPending();
   UnregisterBlackboardListener();
+
+#ifdef HAVE_EDL
+  if (overlay == PageLayout::Overlay::EDL &&
+      net_components != nullptr && net_components->edl != nullptr)
+    net_components->edl->RemoveListener(*this);
+#endif
+
   WindowWidget::Hide();
 }
 
@@ -415,7 +411,7 @@ MapOverlayControlsWidget::Unprepare() noexcept
 void
 MapOverlayControlsWidget::RefreshEdlOverlay()
 {
-#if !defined(HAVE_HTTP)
+#if !defined(HAVE_HTTP) || !defined(HAVE_EDL)
   ShowMessageBox(_("HTTP support is not available in this build."),
                  _("Weather"), MB_OK);
 #else
@@ -424,76 +420,38 @@ MapOverlayControlsWidget::RefreshEdlOverlay()
     return;
   }
 
-  try {
-    PluggableOperationEnvironment env;
-    EDL::SetLoadingStatus();
+  if (net_components == nullptr || net_components->edl == nullptr) {
     RefreshControls();
-
-    if (EDL::TryApplyOverlayFromCache()) {
-      ActionInterface::SendUIState(true);
-      RefreshControls();
-      return;
-    }
-
-    const EDL::TileRequest download_request{
-      EDL::GetForecastTime(), EDL::GetIsobar()};
-    auto path = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
-                                     UIGlobals::GetDialogLook(),
-                                     _("Download"),
-                                     CoDownloadEdlTile(*Net::curl, env,
-                                                       download_request),
-                                     &env);
-    if (!path) {
-      EDL::SetIdleStatus();
-      RefreshControls();
-      return;
-    }
-
-    if (usage == MapOverlay::Usage::MAP_BOTTOM &&
-        overlay == PageLayout::Overlay::EDL)
-      EDL::ApplyOverlay(*path);
-    else
-      EDL::SetIdleStatus();
-
-    ActionInterface::SendUIState(true);
-  } catch (...) {
-    EDL::SetErrorStatus();
-    ShowError(std::current_exception(), _("Weather"));
+    return;
   }
 
   RefreshControls();
+  net_components->edl->RequestOverlayRefresh();
 #endif
 }
+
+#ifdef HAVE_EDL
+void
+MapOverlayControlsWidget::OnDownloadFinished() noexcept
+{
+  RefreshControls();
+}
+#endif
 
 void
 MapOverlayControlsWidget::PrecacheDay()
 {
-#if !defined(HAVE_HTTP)
+#if !defined(HAVE_HTTP) || !defined(HAVE_EDL)
   ShowMessageBox(_("HTTP support is not available in this build."),
                  _("Weather"), MB_OK);
 #else
   if (!EDL::OverlayEnabled())
     return;
 
-  try {
-    PluggableOperationEnvironment env;
-    const auto count = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
-                                            UIGlobals::GetDialogLook(),
-                                            _("Precache day"),
-                                            CoPrecacheEdlDay(*Net::curl, env,
-                                                             EDL::GetForecastTime()),
-                                            &env);
-    if (!count)
-      return;
+  if (net_components == nullptr || net_components->edl == nullptr)
+    return;
 
-    RefreshControls();
-
-    StaticString<64> message;
-    message.Format(_("Cached %u files for the selected UTC day."), *count);
-    ShowMessageBox(message, _("Weather"), MB_OK);
-  } catch (...) {
-    ShowError(std::current_exception(), _("Weather"));
-  }
+  net_components->edl->RequestPrecacheDay(EDL::GetForecastTime());
 #endif
 }
 

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -34,6 +34,12 @@ InfoBoxDrawIfDirty() noexcept;
 static bool infoboxes_dirty = false;
 static bool infoboxes_hidden = false;
 
+/* True after Create() finishes and until Destroy() runs.  Startup can
+   re-enter layout (terrain load, PageActions::Update) while windows
+   are half-built; defer refresh via ScheduleRefreshInfoBoxes() and
+   skip work here until the manager is ready. */
+static bool infoboxes_ready = false;
+
 static InfoBoxWindow *infoboxes[InfoBoxSettings::Panel::MAX_CONTENTS];
 
 // TODO locking
@@ -45,8 +51,13 @@ InfoBoxManager::Hide() noexcept
 
   infoboxes_hidden = true;
 
-  for (unsigned i = 0; i < layout.count; i++)
-    infoboxes[i]->FastHide();
+  if (!infoboxes_ready)
+    return;
+
+  for (unsigned i = 0; i < layout.count; i++) {
+    if (infoboxes[i] != nullptr)
+      infoboxes[i]->FastHide();
+  }
 }
 
 void
@@ -57,8 +68,13 @@ InfoBoxManager::Show() noexcept
 
   infoboxes_hidden = false;
 
-  for (unsigned i = 0; i < layout.count; i++)
-    infoboxes[i]->Show();
+  if (!infoboxes_ready)
+    return;
+
+  for (unsigned i = 0; i < layout.count; i++) {
+    if (infoboxes[i] != nullptr)
+      infoboxes[i]->Show();
+  }
 
   SetDirty();
 }
@@ -67,6 +83,12 @@ void
 InfoBoxManager::DisplayInfoBox() noexcept
 {
   static int DisplayTypeLast[InfoBoxSettings::Panel::MAX_CONTENTS];
+  static bool displaying = false;
+
+  if (!infoboxes_ready || displaying)
+    return;
+
+  displaying = true;
 
   // JMW note: this is updated every GPS time step
 
@@ -76,6 +98,9 @@ InfoBoxManager::DisplayInfoBox() noexcept
     CommonInterface::GetUISettings().info_boxes.panels[panel];
 
   for (unsigned i = 0; i < layout.count; i++) {
+    if (infoboxes[i] == nullptr)
+      continue;
+
     // All calculations are made in a separate thread. Slow calculations
     // should apply to the function DoCalculationsSlow()
     // Do not put calculations here!
@@ -84,9 +109,9 @@ InfoBoxManager::DisplayInfoBox() noexcept
     if ((unsigned)DisplayType > (unsigned)InfoBoxFactory::MAX_TYPE_VAL)
       DisplayType = InfoBoxFactory::NavAltitude;
 
-    bool needupdate = ((DisplayType != DisplayTypeLast[i]) || first);
+    const bool needupdate = ((DisplayType != DisplayTypeLast[i]) || first);
 
-    if (needupdate) {
+    if (needupdate || !infoboxes[i]->HasContent()) {
       infoboxes[i]->SetTitle(gettext(InfoBoxFactory::GetCaption(DisplayType)));
       infoboxes[i]->SetContentProvider(InfoBoxFactory::Create(DisplayType));
       DisplayTypeLast[i] = DisplayType;
@@ -96,6 +121,7 @@ InfoBoxManager::DisplayInfoBox() noexcept
   }
 
   first = false;
+  displaying = false;
 }
 
 void
@@ -128,16 +154,27 @@ InfoBoxManager::InvalidateAfterLanguageChange() noexcept
 void
 InfoBoxManager::ScheduleRedraw() noexcept
 {
-  if (infoboxes_hidden)
+  if (infoboxes_hidden || !infoboxes_ready)
     return;
 
-  for (unsigned i = 0; i < layout.count; i++)
-    infoboxes[i]->Invalidate();
+  for (unsigned i = 0; i < layout.count; i++) {
+    if (infoboxes[i] != nullptr)
+      infoboxes[i]->Invalidate();
+  }
+}
+
+bool
+InfoBoxManager::IsReady() noexcept
+{
+  return infoboxes_ready;
 }
 
 void
 InfoBoxManager::ProcessTimer() noexcept
 {
+  if (!infoboxes_ready)
+    return;
+
   InfoBoxDrawIfDirty();
 }
 
@@ -149,8 +186,12 @@ InfoBoxManager::Create(ContainerWindow &parent,
   const InfoBoxSettings &settings =
     CommonInterface::GetUISettings().info_boxes;
 
+  infoboxes_ready = false;
   first = true;
   layout = _layout;
+
+  for (unsigned i = layout.count; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i)
+    infoboxes[i] = nullptr;
 
   WindowStyle style;
   style.Hide();
@@ -171,14 +212,18 @@ InfoBoxManager::Create(ContainerWindow &parent,
   }
 
   infoboxes_hidden = true;
+  infoboxes_ready = true;
 }
 
 void
 InfoBoxManager::Destroy() noexcept
 {
-  for (unsigned i = 0; i < layout.count; i++) {
+  infoboxes_ready = false;
+  first = true;
+
+  for (unsigned i = 0; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i) {
     delete infoboxes[i];
-    infoboxes[i] = NULL;
+    infoboxes[i] = nullptr;
   }
 }
 

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -16,6 +16,9 @@ extern InfoBoxLayout::Layout layout;
 void
 ProcessTimer() noexcept;
 
+[[nodiscard]] bool
+IsReady() noexcept;
+
 void
 SetDirty() noexcept;
 

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -117,6 +117,11 @@ public:
   }
 
   void SetContentProvider(std::unique_ptr<InfoBoxContent> _content);
+
+  [[nodiscard]] bool HasContent() const noexcept {
+    return content != nullptr;
+  }
+
   void UpdateContent();
 
 private:

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -677,6 +677,11 @@ MainWindow::BeginShutdown() noexcept
 {
   timer.Cancel();
 
+  refresh_info_boxes_pending = false;
+  page_actions_update_pending = false;
+  refresh_info_boxes_notify.ClearNotification();
+  page_actions_update_notify.ClearNotification();
+
   KillTopWidget();
   KillBottomWidget();
 }
@@ -914,6 +919,46 @@ void
 MainWindow::OnCalculatedNotify() noexcept
 {
   UIReceiveCalculatedData();
+}
+
+void
+MainWindow::OnRefreshInfoBoxesNotify() noexcept
+{
+  refresh_info_boxes_pending = false;
+
+  if (!InfoBoxManager::IsReady())
+    return;
+
+  InfoBoxManager::SetDirty();
+  InfoBoxManager::ProcessTimer();
+  SetUIState(CommonInterface::GetUIState());
+}
+
+void
+MainWindow::ScheduleRefreshInfoBoxes() noexcept
+{
+  if (refresh_info_boxes_pending)
+    return;
+
+  refresh_info_boxes_pending = true;
+  refresh_info_boxes_notify.SendNotification();
+}
+
+void
+MainWindow::OnPageActionsUpdateNotify() noexcept
+{
+  page_actions_update_pending = false;
+  PageActions::Update();
+}
+
+void
+MainWindow::SchedulePageActionsUpdate() noexcept
+{
+  if (page_actions_update_pending)
+    return;
+
+  page_actions_update_pending = true;
+  page_actions_update_notify.SendNotification();
 }
 
 void

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -116,6 +116,9 @@ private:
    */
   UI::Notify restore_page_notify{[this]{ OnRestorePageNotify(); }};
 
+  UI::Notify refresh_info_boxes_notify{[this]{ OnRefreshInfoBoxesNotify(); }};
+  UI::Notify page_actions_update_notify{[this]{ OnPageActionsUpdateNotify(); }};
+
   UI::PeriodicTimer timer{[this]{ RunTimer(); }};
 
   BatteryTimer battery_timer;
@@ -132,6 +135,8 @@ private:
 #endif
 
   bool restore_page_pending = false;
+  bool refresh_info_boxes_pending = false;
+  bool page_actions_update_pending = false;
 
   /**
    * Has "late" initialization been done already?  Those are things
@@ -356,6 +361,17 @@ public:
   void DeferredRestorePage() noexcept;
 
   /**
+   * Defer InfoBox refresh to the next event-loop iteration (avoids
+   * reentrant layout while InfoBox content is updating).
+   */
+  void ScheduleRefreshInfoBoxes() noexcept;
+
+  /**
+   * Defer PageActions::Update() to the next event-loop iteration.
+   */
+  void SchedulePageActionsUpdate() noexcept;
+
+  /**
    * Show this #Widget above the map.  This replaces (deletes) the
    * previous top widget, if any.  To disable this feature, call this
    * method with widget==nullptr.
@@ -412,6 +428,8 @@ private:
   void OnGpsNotify() noexcept;
   void OnCalculatedNotify() noexcept;
   void OnRestorePageNotify() noexcept;
+  void OnRefreshInfoBoxesNotify() noexcept;
+  void OnPageActionsUpdateNotify() noexcept;
 
   void OnTerrainLoaded() noexcept;
 

--- a/src/NOTAM/NOTAMGlue.cpp
+++ b/src/NOTAM/NOTAMGlue.cpp
@@ -80,14 +80,59 @@ PopulateImplFromCache(NOTAMImpl &impl,
 }
 
 NOTAMGlue::NOTAMGlue(const NOTAMSettings &_settings, CurlGlobal &_curl)
-  : RateLimiter(std::chrono::seconds(30), std::chrono::seconds(30)),
-    settings(_settings), curl(_curl), 
+  :settings(_settings), curl(_curl),
     current_notams_impl(std::make_unique<NOTAMImpl>()),
     load_task(curl.GetEventLoop())
 {
 }
 
-NOTAMGlue::~NOTAMGlue() = default;
+NOTAMGlue::~NOTAMGlue()
+{
+  BeginShutdown();
+}
+
+void
+NOTAMGlue::BeginShutdown() noexcept
+{
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    if (shutting_down)
+      return;
+
+    shutting_down = true;
+    loading = false;
+    retry_pending = false;
+    force_refresh_pending = false;
+    manual_refresh_requested = false;
+    load_complete_pending = false;
+    listener_update_pending = false;
+    listener_load_complete_pending.reset();
+    load_complete_error = {};
+    retry_due = {};
+  }
+
+  CancelRetry();
+  load_task.BeginShutdown();
+  load_complete_notify.ClearNotification();
+  listener_notify.ClearNotification();
+}
+
+void
+NOTAMGlue::CancelRetry() noexcept
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  retry_due = {};
+}
+
+void
+NOTAMGlue::TriggerRetry() noexcept
+{
+  const std::lock_guard<Mutex> lock(mutex);
+  if (shutting_down)
+    return;
+
+  retry_due = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+}
 
 NOTAMSettings
 NOTAMGlue::GetSettingsSnapshot() const noexcept
@@ -137,6 +182,8 @@ NOTAMGlue::OnTimer(const GeoPoint &current_location,
 {
   {
     const std::lock_guard<Mutex> lock(mutex);
+    if (shutting_down)
+      return;
     current_time_utc = current_time;
   }
 
@@ -201,6 +248,17 @@ NOTAMGlue::OnTimer(const GeoPoint &current_location,
     UpdateLocation(current_location);
     return;
   }
+
+  {
+    const std::lock_guard<Mutex> lock(mutex);
+    if (!retry_pending || retry_due == std::chrono::steady_clock::time_point{})
+      return;
+
+    if (std::chrono::steady_clock::now() < retry_due)
+      return;
+  }
+
+  OnRetryTimer();
 }
 
 void
@@ -213,7 +271,7 @@ NOTAMGlue::UpdateLocation(const GeoPoint &location)
   // Check if already loading
   {
     const std::lock_guard<Mutex> lock(mutex);
-    if (!settings.enabled || loading) {
+    if (shutting_down || !settings.enabled || loading) {
       return; // Already loading, skip this request
     }
     loading = true;
@@ -227,7 +285,7 @@ NOTAMGlue::UpdateLocation(const GeoPoint &location)
   LogFmt("NOTAM: Auto-refresh starting");
   
   // Cancel any pending retry since we're starting a new attempt
-  Cancel();
+  CancelRetry();
 
   // Start async loading
   try {
@@ -266,7 +324,7 @@ NOTAMGlue::ForceUpdateLocation(const GeoPoint &location,
 
   {
     const std::lock_guard<Mutex> lock(mutex);
-    if (!settings.enabled) {
+    if (shutting_down || !settings.enabled) {
       manual_refresh_requested = false;
       return false;
     }
@@ -298,7 +356,7 @@ NOTAMGlue::ForceUpdateLocation(const GeoPoint &location,
   }
 
   LogFmt("NOTAM: Manual refresh starting");
-  Cancel();
+  CancelRetry();
   try {
     load_task.Start(LoadNOTAMsInternal(location, true),
                     BIND_THIS_METHOD(OnLoadComplete));
@@ -337,7 +395,7 @@ NOTAMGlue::LoadNOTAMs(const GeoPoint &location)
   // Check if already loading
   {
     const std::lock_guard lock(mutex);
-    if (!settings.enabled || loading) {
+    if (shutting_down || !settings.enabled || loading) {
       return;
     }
     loading = true;
@@ -348,7 +406,7 @@ NOTAMGlue::LoadNOTAMs(const GeoPoint &location)
   }
   
   // Cancel any pending retry since we're starting a new attempt
-  Cancel();
+  CancelRetry();
   
   // Start async loading
   try {
@@ -543,6 +601,8 @@ NOTAMGlue::OnLoadComplete(std::exception_ptr error) noexcept
 {
   {
     const std::lock_guard<Mutex> lock(mutex);
+    if (shutting_down)
+      return;
     load_complete_error = std::move(error);
     load_complete_pending = true;
   }
@@ -556,7 +616,7 @@ NOTAMGlue::OnLoadCompleteNotification() noexcept
   std::exception_ptr error;
   {
     const std::lock_guard<Mutex> lock(mutex);
-    if (!load_complete_pending)
+    if (shutting_down || !load_complete_pending)
       return;
 
     error = std::move(load_complete_error);
@@ -617,7 +677,7 @@ NOTAMGlue::HandleLoadComplete(std::exception_ptr error) noexcept
   const auto apply_committed_load =
     [this, notify_load_complete, start_queued_refresh]() {
     // Success - cancel any pending retry
-    Cancel();
+    CancelRetry();
 
     // Update the airspace database
     if (data_components && data_components->airspaces) {
@@ -667,7 +727,7 @@ NOTAMGlue::HandleLoadComplete(std::exception_ptr error) noexcept
     if (load_committed)
       apply_committed_load();
     else
-      Cancel();
+      CancelRetry();
 
     LogFmt("NOTAM: Starting queued forced refresh");
     try {
@@ -712,12 +772,12 @@ NOTAMGlue::HandleLoadComplete(std::exception_ptr error) noexcept
     if (schedule_retry) {
       // Failed - schedule retry with fixed 30-second delay
       LogFmt("NOTAM: Fetch failed, scheduling retry in 30 seconds");
-      Trigger();
+      TriggerRetry();
     } else {
-      Cancel();
+      CancelRetry();
     }
   } else if (!load_committed) {
-    Cancel();
+    CancelRetry();
   } else {
     apply_committed_load();
   }
@@ -784,8 +844,11 @@ NOTAMGlue::OnListenerNotification() noexcept
 }
 
 void
-NOTAMGlue::Run()
+NOTAMGlue::OnRetryTimer()
 {
+  if (shutting_down)
+    return;
+
   LogFmt("NOTAM: Retry timer fired, attempting fetch again");
   
   GeoPoint location;

--- a/src/NOTAM/NOTAMGlue.hpp
+++ b/src/NOTAM/NOTAMGlue.hpp
@@ -5,13 +5,12 @@
 
 #include "NOTAM.hpp"
 #include "Settings.hpp"
-#include "co/InjectTask.hxx"
+#include "net/AsyncTask.hpp"
 #include "thread/Mutex.hxx"
 #include "thread/SafeList.hxx"
 #include "ui/event/Notify.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "system/Path.hpp"
-#include "RateLimiter.hpp"
 #include <boost/json/fwd.hpp>
 #include <chrono>
 #include <cstdint>
@@ -67,7 +66,7 @@ public:
 /**
  * NOTAM manager that handles loading and refreshing NOTAMs
  */
-class NOTAMGlue final : public RateLimiter {
+class NOTAMGlue final {
   NOTAMSettings settings;
   CurlGlobal &curl;
   
@@ -121,12 +120,20 @@ class NOTAMGlue final : public RateLimiter {
   /** Incremented when data is explicitly cleared/invalidated. */
   uint64_t mutation_generation = 0;
 
+  bool shutting_down = false;
+
+  /** When to retry after a failed fetch (checked from OnTimer()). */
+  std::chrono::steady_clock::time_point retry_due{};
+
   /** Background task for loading NOTAMs.  Declared last so destroyed first. */
-  Co::InjectTask load_task;
+  Net::AsyncTask load_task;
 
 public:
   NOTAMGlue(const NOTAMSettings &_settings, CurlGlobal &_curl);
   ~NOTAMGlue();
+
+  /** Cancel timers/tasks before the UI event loop is torn down. */
+  void BeginShutdown() noexcept;
   
   /**
    * Register a listener for NOTAM update notifications
@@ -288,9 +295,11 @@ private:
   
   /** Notify all registered listeners that NOTAMs have been updated */
   void NotifyListeners() noexcept;
-  
-  /** RateLimiter callback for delayed retry */
-  void Run() override;
+
+  void OnRetryTimer();
+
+  void CancelRetry() noexcept;
+  void TriggerRetry() noexcept;
   
   /** Save raw API response to file */
   void SaveNOTAMsToFile(const boost::json::value &api_response,

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -8,6 +8,10 @@
 #ifdef HAVE_HTTP
 #include "net/client/tim/Glue.hpp"
 #include "NOTAM/NOTAMGlue.hpp"
+#include "net/http/DownloadManager.hpp"
+#ifdef HAVE_EDL
+#include "Weather/EDL/DownloadGlue.hpp"
+#endif
 #endif
 
 NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
@@ -23,6 +27,9 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
 # else
   :tim(new TIM::Glue(curl)),
    notam(new NOTAMGlue(notam_settings, curl))
+# endif
+# ifdef HAVE_EDL
+  ,edl(new EDL::DownloadGlue(curl))
 # endif
 #endif
 {
@@ -41,3 +48,29 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
 }
 
 NetComponents::~NetComponents() noexcept = default;
+
+void
+NetComponents::BeginShutdown() noexcept
+{
+#ifdef HAVE_DOWNLOAD_MANAGER
+  Net::DownloadManager::BeginDeinitialise();
+#endif
+
+#ifdef HAVE_TRACKING
+  if (tracking != nullptr)
+    tracking->BeginShutdown();
+#endif
+
+#ifdef HAVE_HTTP
+  if (tim != nullptr)
+    tim->BeginShutdown();
+
+# ifdef HAVE_EDL
+  if (edl != nullptr)
+    edl->BeginShutdown();
+# endif
+
+  if (notam != nullptr)
+    notam->BeginShutdown();
+#endif
+}

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -5,6 +5,7 @@
 
 #include "Tracking/Features.hpp"
 #include "net/http/Features.hpp"
+#include "Weather/Features.hpp"
 
 #include <memory>
 
@@ -15,9 +16,16 @@ class CurlGlobal;
 class TrackingGlue;
 namespace TIM { class Glue; }
 class NOTAMGlue;
+#ifdef HAVE_EDL
+namespace EDL { class DownloadGlue; }
+#endif
 
 /**
- * This singleton manages global networking-related objects.
+ * Singleton for global networking-related objects.
+ *
+ * Background HTTP/coroutine work uses Net::AsyncTask and is stopped via
+ * BeginShutdown() (also used for Net::DownloadManager and EDL tiles).
+ * Blocking modal downloads use ShowCoDialog() on the UI thread.
  */
 struct NetComponents {
 #ifdef HAVE_TRACKING
@@ -27,12 +35,18 @@ struct NetComponents {
 #ifdef HAVE_HTTP
   const std::unique_ptr<TIM::Glue> tim;
   const std::unique_ptr<NOTAMGlue> notam;
+# ifdef HAVE_EDL
+  const std::unique_ptr<EDL::DownloadGlue> edl;
+# endif
 #endif
 
   NetComponents(EventLoop &event_loop, CurlGlobal &curl,
                 const TrackingSettings &tracking_settings,
                 const NOTAMSettings &notam_settings);
   ~NetComponents() noexcept;
+
+  /** Cancel downloads and background network tasks before UI teardown. */
+  void BeginShutdown() noexcept;
 
   NetComponents(const NetComponents &) = delete;
   NetComponents &operator=(const NetComponents &) = delete;

--- a/src/NetComponentsStub.cpp
+++ b/src/NetComponentsStub.cpp
@@ -16,3 +16,8 @@ NetComponents::NetComponents(EventLoop &, CurlGlobal &,
 }
 
 NetComponents::~NetComponents() noexcept = default;
+
+void
+NetComponents::BeginShutdown() noexcept
+{
+}

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -393,7 +393,7 @@ PageActions::LoadLayout(const PageLayout &layout)
   LoadBottom(active);
 
   ActionInterface::UpdateDisplayMode();
-  ActionInterface::SendUIState(true);
+  ActionInterface::SendUIState(false);
   if (CommonInterface::main_window != nullptr)
     CommonInterface::main_window->ScheduleRefreshInfoBoxes();
 }

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -19,6 +19,8 @@
 #include "ActionInterface.hpp"
 #ifdef HAVE_EDL
 #include "Dialogs/Weather/MapOverlayControlsWidget.hpp"
+#include "NetComponents.hpp"
+#include "Weather/EDL/DownloadGlue.hpp"
 #include "Weather/EDL/StateController.hpp"
 #endif
 
@@ -106,7 +108,9 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
       else
         EDL::EnsureInitialised();
 
-      EDL::TryApplyOverlayFromCache();
+      if (!EDL::TryApplyOverlayFromCache() &&
+          net_components != nullptr && net_components->edl != nullptr)
+        net_components->edl->RequestOverlayRefresh();
     }
 #endif
     break;
@@ -226,6 +230,13 @@ void
 PageActions::Update()
 {
   LoadLayout(GetCurrentLayout());
+}
+
+void
+PageActions::ScheduleUpdate() noexcept
+{
+  if (CommonInterface::main_window != nullptr)
+    CommonInterface::main_window->SchedulePageActionsUpdate();
 }
 
 
@@ -385,7 +396,9 @@ PageActions::LoadLayout(const PageLayout &layout)
   LoadBottom(active);
 
   ActionInterface::UpdateDisplayMode();
-  ActionInterface::SendUIState();
+  ActionInterface::SendUIState(true);
+  if (CommonInterface::main_window != nullptr)
+    CommonInterface::main_window->ScheduleRefreshInfoBoxes();
 }
 
 void

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -19,8 +19,7 @@
 #include "ActionInterface.hpp"
 #ifdef HAVE_EDL
 #include "Dialogs/Weather/MapOverlayControlsWidget.hpp"
-#include "NetComponents.hpp"
-#include "Weather/EDL/DownloadGlue.hpp"
+#include "Weather/EDL/Glue.hpp"
 #include "Weather/EDL/StateController.hpp"
 #endif
 
@@ -108,9 +107,7 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
       else
         EDL::EnsureInitialised();
 
-      if (!EDL::TryApplyOverlayFromCache() &&
-          net_components != nullptr && net_components->edl != nullptr)
-        net_components->edl->RequestOverlayRefresh();
+      EDL::RequestOverlayRefresh();
     }
 #endif
     break;

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -56,6 +56,11 @@ namespace PageActions
   void Update();
 
   /**
+   * Like Update(), but runs on the next event-loop iteration.
+   */
+  void ScheduleUpdate() noexcept;
+
+  /**
    * Restore the current page as it was configured.
    */
   void Restore();

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -159,8 +159,7 @@ AfterStartup()
     if (File::Exists(init_path))
       Lua::StartFile(init_path);
     else
-      LogFormat("cannot open %s: No such file or directory",
-                init_path.c_str());
+      LogDebug("Optional %s not found", init_path.c_str());
   } catch (...) {
     LogError(std::current_exception());
   }

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -60,6 +60,7 @@
 #include "CalculationThread.hpp"
 #include "Replay/Replay.hpp"
 #include "LocalPath.hpp"
+#include "system/FileUtil.hpp"
 #include "io/FileCache.hpp"
 #include "io/async/AsioThread.hpp"
 #include "io/async/GlobalAsioThread.hpp"
@@ -154,9 +155,14 @@ AfterStartup()
 {
   try {
     const auto lua_path = LocalPath("lua");
-    Lua::StartFile(AllocatedPath::Build(lua_path, "init.lua"));
+    const AllocatedPath init_path = AllocatedPath::Build(lua_path, "init.lua");
+    if (File::Exists(init_path))
+      Lua::StartFile(init_path);
+    else
+      LogFormat("cannot open %s: No such file or directory",
+                init_path.c_str());
   } catch (...) {
-      LogError(std::current_exception());
+    LogError(std::current_exception());
   }
 
   if (is_simulator()) {
@@ -658,14 +664,7 @@ Startup(UI::Display &display)
 
   LogString("ProgramStarted");
 
-  // Give focus to the map
   main_window->SetDefaultFocus();
-
-  // Start calculation thread
-  backend_components->merge_thread->Start();
-  backend_components->calculation_thread->Start();
-
-  PageActions::Update();
 
 #ifdef HAVE_HTTP
   net_components = new NetComponents(*asio_thread, *Net::curl,
@@ -673,13 +672,10 @@ Startup(UI::Display &display)
                                      computer_settings.airspace.notam);
   if (net_components->notam != nullptr)
     InstallNOTAMMessageListener(*net_components->notam);
-#ifdef HAVE_SKYLINES_TRACKING
+# ifdef HAVE_SKYLINES_TRACKING
   if (map_window != nullptr)
     map_window->SetSkyLinesData(&net_components->tracking->GetSkyLinesData());
-#endif
-#endif
-
-#ifdef HAVE_HTTP
+# endif
   if (map_window != nullptr)
     map_window->SetThermalInfoMap(net_components->tim.get());
 #endif
@@ -687,14 +683,46 @@ Startup(UI::Display &display)
   assert(!global_running);
   global_running = true;
 
+  /* Threads must run before AfterStartup() (NOTAM cache uses
+     ScopeSuspendAllThreads, which needs a started calculation thread). */
+  backend_components->merge_thread->Start();
+  backend_components->calculation_thread->Start();
+
   AfterStartup();
 
   operation.Hide();
 
   main_window->FinishStartup();
+  main_window->SchedulePageActionsUpdate();
 
   return true;
 }
+
+#ifdef HAVE_HTTP
+static void
+BeginShutdownNetComponents(MainWindow &main_window) noexcept
+{
+  if (net_components == nullptr)
+    return;
+
+  net_components->BeginShutdown();
+  DeinitNOTAMMessageListener();
+
+  if (GlueMapWindow *map = main_window.GetMap()) {
+#ifdef HAVE_SKYLINES_TRACKING
+    map->SetSkyLinesData(nullptr);
+#endif
+    map->SetThermalInfoMap(nullptr);
+  }
+}
+
+static void
+DestroyNetComponents() noexcept
+{
+  delete net_components;
+  net_components = nullptr;
+}
+#endif
 
 void
 Shutdown()
@@ -706,6 +734,11 @@ Shutdown()
 
   // Turn off all displays first to prevent UI operations from blocking
   global_running = false;
+
+#ifdef HAVE_HTTP
+  if (main_window != nullptr)
+    BeginShutdownNetComponents(*main_window);
+#endif
 
   // Show progress dialog
   operation.SetText(_("Shutdown, please wait..."));
@@ -850,12 +883,6 @@ Shutdown()
   noaa_store = nullptr;
 #endif
 
-#ifdef HAVE_HTTP
-  DeinitNOTAMMessageListener();
-  delete net_components;
-  net_components = nullptr;
-#endif
-
 #ifdef HAVE_DOWNLOAD_MANAGER
   Net::DownloadManager::Deinitialise();
 #endif
@@ -878,6 +905,10 @@ Shutdown()
 
   delete file_cache;
   file_cache = nullptr;
+
+#ifdef HAVE_HTTP
+  DestroyNetComponents();
+#endif
 
   LogString("Close Windows - main");
   main_window->Destroy();

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -672,6 +672,10 @@ Startup(UI::Display &display)
                                      computer_settings.airspace.notam);
   if (net_components->notam != nullptr)
     InstallNOTAMMessageListener(*net_components->notam);
+# ifdef HAVE_EDL
+  if (edl_glue != nullptr && net_components->edl != nullptr)
+    edl_glue->AttachDownloadGlue(*net_components->edl);
+# endif
 # ifdef HAVE_SKYLINES_TRACKING
   if (map_window != nullptr)
     map_window->SetSkyLinesData(&net_components->tracking->GetSkyLinesData());
@@ -772,6 +776,7 @@ Shutdown()
 
 #ifdef HAVE_EDL
   if (edl_glue != nullptr) {
+    edl_glue->DetachDownloadGlue();
     live_blackboard.RemoveListener(*edl_glue);
     delete edl_glue;
     edl_glue = nullptr;

--- a/src/Tracking/LiveTrack24/Glue.cpp
+++ b/src/Tracking/LiveTrack24/Glue.cpp
@@ -35,10 +35,16 @@ MapVehicleTypeToLivetrack24(Settings::VehicleType vt)
 
 Glue::Glue(CurlGlobal &curl) noexcept
   :client(curl),
-   inject_task(curl.GetEventLoop())
+   task(curl.GetEventLoop())
 {
   settings.SetDefaults();
   client.SetServer(settings.server);
+}
+
+void
+Glue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
 }
 
 void
@@ -48,7 +54,7 @@ Glue::SetSettings(const Settings &_settings)
       _settings.username != settings.username ||
       _settings.password != settings.password) {
     /* wait for the current job to finish */
-    inject_task.Cancel();
+    task.Cancel();
 
     /* now it's safe to access these variables */
     settings = _settings;
@@ -63,6 +69,9 @@ Glue::SetSettings(const Settings &_settings)
 void
 Glue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
 {
+  if (task.IsShuttingDown())
+    return;
+
   if (!settings.enabled)
     /* disabled by configuration */
     /* note that we are allowed to read "settings" without locking the
@@ -82,7 +91,7 @@ Glue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
     /* later */
     return;
 
-  if (inject_task)
+  if (task.IsRunning())
     /* still running, skip this submission */
     return;
 
@@ -106,7 +115,7 @@ Glue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
   last_flying = flying;
   flying = calculated.flight.flying;
 
-  inject_task.Start(Tick(settings), BIND_THIS_METHOD(OnCompletion));
+  task.Start(Tick(settings), BIND_THIS_METHOD(OnCompletion));
 }
 
 Co::InvokeTask

--- a/src/Tracking/LiveTrack24/Glue.hpp
+++ b/src/Tracking/LiveTrack24/Glue.hpp
@@ -7,7 +7,7 @@
 #include "Client.hpp"
 #include "time/PeriodClock.hpp"
 #include "Geo/GeoPoint.hpp"
-#include "co/InjectTask.hxx"
+#include "net/AsyncTask.hpp"
 #include "time/BrokenDateTime.hpp"
 
 struct MoreData;
@@ -52,10 +52,12 @@ class Glue final {
   Angle track;
   bool flying = false, last_flying;
 
-  Co::InjectTask inject_task;
+  Net::AsyncTask task;
 
 public:
   explicit Glue(CurlGlobal &curl) noexcept;
+
+  void BeginShutdown() noexcept;
 
   void SetSettings(const Settings &_settings);
   void OnTimer(const MoreData &basic, const DerivedInfo &calculated);

--- a/src/Tracking/SkyLines/Glue.cpp
+++ b/src/Tracking/SkyLines/Glue.cpp
@@ -27,7 +27,16 @@ SkyLinesTracking::Glue::Glue(EventLoop &event_loop,
 
 SkyLinesTracking::Glue::~Glue()
 {
+  BeginShutdown();
+}
+
+void
+SkyLinesTracking::Glue::BeginShutdown() noexcept
+{
+  client.Close();
+  cloud_client.Close();
   delete queue;
+  queue = nullptr;
 }
 
 inline bool

--- a/src/Tracking/SkyLines/Glue.hpp
+++ b/src/Tracking/SkyLines/Glue.hpp
@@ -42,6 +42,8 @@ public:
 
   void SetSettings(const Settings &settings);
 
+  void BeginShutdown() noexcept;
+
   void Tick(const NMEAInfo &basic, const DerivedInfo &calculated);
 
   void RequestUserName(uint32_t user_id) {

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -21,8 +21,22 @@ TrackingGlue::SetSettings(const TrackingSettings &_settings)
 }
 
 void
+TrackingGlue::BeginShutdown() noexcept
+{
+  if (shutting_down)
+    return;
+
+  shutting_down = true;
+  skylines.BeginShutdown();
+  livetrack24.BeginShutdown();
+}
+
+void
 TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
 {
+  if (shutting_down)
+    return;
+
   try {
     skylines.Tick(basic, calculated);
   } catch (...) {

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -31,9 +31,12 @@ public:
 
   void SetSettings(const TrackingSettings &_settings);
 
+  void BeginShutdown() noexcept;
+
   void OnTimer(const MoreData &basic, const DerivedInfo &calculated);
 
 private:
+  bool shutting_down = false;
   /* virtual methods from SkyLinesTracking::Handler */
   virtual void OnTraffic(uint32_t pilot_id, unsigned time_of_day_ms,
                          const GeoPoint &location, int altitude) override;

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -26,6 +26,8 @@ class TrackingGlue final
 
   LiveTrack24::Glue livetrack24;
 
+  bool shutting_down = false;
+
 public:
   TrackingGlue(EventLoop &event_loop, CurlGlobal &curl) noexcept;
 
@@ -35,8 +37,11 @@ public:
 
   void OnTimer(const MoreData &basic, const DerivedInfo &calculated);
 
+  const SkyLinesTracking::Data &GetSkyLinesData() const {
+    return skylines_data;
+  }
+
 private:
-  bool shutting_down = false;
   /* virtual methods from SkyLinesTracking::Handler */
   virtual void OnTraffic(uint32_t pilot_id, unsigned time_of_day_ms,
                          const GeoPoint &location, int altitude) override;
@@ -47,11 +52,6 @@ private:
                  const AGeoPoint &bottom, const AGeoPoint &top,
                  double lift) override;
   void OnSkyLinesError(std::exception_ptr e) override;
-
-public:
-  const SkyLinesTracking::Data &GetSkyLinesData() const {
-    return skylines_data;
-  }
 };
 
 #endif /* HAVE_TRACKING */

--- a/src/UIReceiveBlackboard.cpp
+++ b/src/UIReceiveBlackboard.cpp
@@ -102,7 +102,7 @@ UIReceiveCalculatedData()
   XCSoarInterface::ReceiveCalculated();
 
   ActionInterface::UpdateDisplayMode();
-  ActionInterface::SendUIState();
+  ActionInterface::ScheduleSendUIState();
 
   if (backend_components->devices)
     backend_components->devices->NotifyCalculatedUpdate(CommonInterface::Basic(),

--- a/src/Weather/EDL/DownloadGlue.cpp
+++ b/src/Weather/EDL/DownloadGlue.cpp
@@ -5,13 +5,8 @@
 
 #ifdef HAVE_EDL
 
-#include "StateController.hpp"
 #include "TileStore.hpp"
-#include "ActionInterface.hpp"
 #include "Operation/ProgressListener.hpp"
-#include "Message.hpp"
-#include "Language/Language.hpp"
-#include "util/StaticString.hxx"
 #include "LogFile.hpp"
 #include "lib/curl/Global.hxx"
 #include "util/Macros.hpp"
@@ -65,44 +60,39 @@ DownloadGlue::RemoveListener(DownloadListener &listener) noexcept
 }
 
 void
-DownloadGlue::NotifyListeners() noexcept
+DownloadGlue::DeliverNotification(DownloadNotification notification) noexcept
 {
-  listeners.ForEach([](DownloadListener *listener) {
-    listener->OnDownloadFinished();
+  NotifyListeners(notification);
+}
+
+void
+DownloadGlue::NotifyListeners(const DownloadNotification &notification) noexcept
+{
+  listeners.ForEach([&notification](DownloadListener *listener) {
+    listener->OnDownloadFinished(notification);
   });
 }
 
 void
-DownloadGlue::RequestOverlayRefresh() noexcept
+DownloadGlue::StartOverlayDownload(BrokenDateTime forecast_time,
+                                    unsigned isobar) noexcept
 {
   if (shutting_down || task.IsRunning())
     return;
 
-  if (!OverlayEnabled()) {
-    NotifyListeners();
-    return;
-  }
-
-  if (TryApplyOverlayFromCache()) {
-    ActionInterface::SendUIState(true);
-    NotifyListeners();
-    return;
-  }
-
   pending_job = Job::OVERLAY;
   completion_error = {};
   completed_path.reset();
-  overlay_forecast_time = GetForecastTime();
-  overlay_isobar = GetIsobar();
+  overlay_forecast_time = forecast_time;
+  overlay_isobar = isobar;
 
-  SetLoadingStatus();
   task.Start(RunOverlayDownload(), BIND_THIS_METHOD(OnCompletion));
 }
 
 void
-DownloadGlue::RequestPrecacheDay(BrokenDateTime day) noexcept
+DownloadGlue::StartPrecacheDay(BrokenDateTime day) noexcept
 {
-  if (shutting_down || task.IsRunning() || !OverlayEnabled())
+  if (shutting_down || task.IsRunning())
     return;
 
   pending_job = Job::PRECACHE_DAY;
@@ -110,7 +100,6 @@ DownloadGlue::RequestPrecacheDay(BrokenDateTime day) noexcept
   completed_precache_count = 0;
   completed_path.reset();
 
-  SetLoadingStatus();
   task.Start(RunPrecacheDay(day), BIND_THIS_METHOD(OnCompletion));
 }
 
@@ -146,39 +135,30 @@ DownloadGlue::OnCompleteNotify() noexcept
   const Job job = pending_job;
   pending_job = Job::NONE;
 
-  if (job == Job::OVERLAY) {
-    if (completion_error) {
-      LogError(completion_error, "EDL overlay download failed");
-      SetErrorStatus();
-    } else if (completed_path) {
-      if (ShouldMaintainOverlay())
-        ApplyOverlay(*completed_path);
-      else
-        SetIdleStatus();
-    } else {
-      SetIdleStatus();
-    }
+  DownloadNotification notification;
+  if (job == Job::OVERLAY)
+    notification.job = DownloadJob::OVERLAY;
+  else if (job == Job::PRECACHE_DAY)
+    notification.job = DownloadJob::PRECACHE_DAY;
+  else
+    return;
 
-    completed_path.reset();
-    ActionInterface::SendUIState(true);
-  } else if (job == Job::PRECACHE_DAY) {
-    if (completion_error) {
-      LogError(completion_error, "EDL precache failed");
-      SetErrorStatus();
-    } else {
-      SetIdleStatus();
-
-      StaticString<64> message;
-      message.Format(_("Cached %u files for the selected UTC day."),
-                     completed_precache_count);
-      Message::AddMessage(message);
-    }
-
-    completed_precache_count = 0;
+  if (completion_error) {
+    notification.outcome = DownloadOutcome::ERROR;
+    notification.error = completion_error;
+  } else {
+    notification.outcome = DownloadOutcome::SUCCESS;
+    if (job == Job::OVERLAY)
+      notification.overlay_path = std::move(completed_path);
+    else
+      notification.precache_count = completed_precache_count;
   }
 
+  completed_path.reset();
+  completed_precache_count = 0;
   completion_error = {};
-  NotifyListeners();
+
+  NotifyListeners(notification);
 }
 
 } // namespace EDL

--- a/src/Weather/EDL/DownloadGlue.cpp
+++ b/src/Weather/EDL/DownloadGlue.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DownloadGlue.hpp"
+
+#ifdef HAVE_EDL
+
+#include "StateController.hpp"
+#include "TileStore.hpp"
+#include "ActionInterface.hpp"
+#include "Operation/ProgressListener.hpp"
+#include "Message.hpp"
+#include "Language/Language.hpp"
+#include "util/StaticString.hxx"
+#include "LogFile.hpp"
+#include "lib/curl/Global.hxx"
+#include "util/Macros.hpp"
+
+namespace EDL {
+
+namespace {
+
+struct NullProgressListener final : ProgressListener {
+  void SetProgressRange(unsigned) noexcept override {}
+  void SetProgressPosition(unsigned) noexcept override {}
+};
+
+} // namespace
+
+DownloadGlue::DownloadGlue(CurlGlobal &_curl) noexcept
+  :curl(_curl),
+   task(curl.GetEventLoop())
+{
+}
+
+DownloadGlue::~DownloadGlue() noexcept
+{
+  BeginShutdown();
+}
+
+void
+DownloadGlue::BeginShutdown() noexcept
+{
+  if (shutting_down)
+    return;
+
+  shutting_down = true;
+  pending_job = Job::NONE;
+  completion_error = {};
+  completed_path.reset();
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+}
+
+void
+DownloadGlue::AddListener(DownloadListener &listener) noexcept
+{
+  listeners.Add(&listener);
+}
+
+void
+DownloadGlue::RemoveListener(DownloadListener &listener) noexcept
+{
+  listeners.Remove(&listener);
+}
+
+void
+DownloadGlue::NotifyListeners() noexcept
+{
+  listeners.ForEach([](DownloadListener *listener) {
+    listener->OnDownloadFinished();
+  });
+}
+
+void
+DownloadGlue::RequestOverlayRefresh() noexcept
+{
+  if (shutting_down || task.IsRunning())
+    return;
+
+  if (!OverlayEnabled()) {
+    NotifyListeners();
+    return;
+  }
+
+  if (TryApplyOverlayFromCache()) {
+    ActionInterface::SendUIState(true);
+    NotifyListeners();
+    return;
+  }
+
+  pending_job = Job::OVERLAY;
+  completion_error = {};
+  completed_path.reset();
+  overlay_forecast_time = GetForecastTime();
+  overlay_isobar = GetIsobar();
+
+  SetLoadingStatus();
+  task.Start(RunOverlayDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+void
+DownloadGlue::RequestPrecacheDay(BrokenDateTime day) noexcept
+{
+  if (shutting_down || task.IsRunning() || !OverlayEnabled())
+    return;
+
+  pending_job = Job::PRECACHE_DAY;
+  completion_error = {};
+  completed_precache_count = 0;
+  completed_path.reset();
+
+  SetLoadingStatus();
+  task.Start(RunPrecacheDay(day), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+DownloadGlue::RunOverlayDownload()
+{
+  NullProgressListener progress;
+  const TileRequest request(overlay_forecast_time, overlay_isobar);
+  completed_path = co_await request.EnsureDownloaded(curl, progress);
+}
+
+Co::InvokeTask
+DownloadGlue::RunPrecacheDay(BrokenDateTime day)
+{
+  NullProgressListener progress;
+  completed_precache_count =
+    co_await EnsureDayDownloaded(day, curl, progress);
+}
+
+void
+DownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
+
+void
+DownloadGlue::OnCompleteNotify() noexcept
+{
+  if (shutting_down)
+    return;
+
+  const Job job = pending_job;
+  pending_job = Job::NONE;
+
+  if (job == Job::OVERLAY) {
+    if (completion_error) {
+      LogError(completion_error, "EDL overlay download failed");
+      SetErrorStatus();
+    } else if (completed_path) {
+      if (ShouldMaintainOverlay())
+        ApplyOverlay(*completed_path);
+      else
+        SetIdleStatus();
+    } else {
+      SetIdleStatus();
+    }
+
+    completed_path.reset();
+    ActionInterface::SendUIState(true);
+  } else if (job == Job::PRECACHE_DAY) {
+    if (completion_error) {
+      LogError(completion_error, "EDL precache failed");
+      SetErrorStatus();
+    } else {
+      SetIdleStatus();
+
+      StaticString<64> message;
+      message.Format(_("Cached %u files for the selected UTC day."),
+                     completed_precache_count);
+      Message::AddMessage(message);
+    }
+
+    completed_precache_count = 0;
+  }
+
+  completion_error = {};
+  NotifyListeners();
+}
+
+} // namespace EDL
+
+#endif /* HAVE_EDL */

--- a/src/Weather/EDL/DownloadGlue.hpp
+++ b/src/Weather/EDL/DownloadGlue.hpp
@@ -21,15 +21,41 @@ class AllocatedPath;
 
 namespace EDL {
 
+enum class DownloadJob : uint8_t {
+  OVERLAY,
+  PRECACHE_DAY,
+};
+
+enum class DownloadOutcome : uint8_t {
+  SUCCESS,
+  ERROR,
+};
+
+struct DownloadNotification {
+  DownloadJob job = DownloadJob::OVERLAY;
+  DownloadOutcome outcome = DownloadOutcome::SUCCESS;
+  std::exception_ptr error;
+  std::optional<AllocatedPath> overlay_path;
+  unsigned precache_count = 0;
+
+  /** When true, the overlay was applied from cache before notification. */
+  bool overlay_from_cache = false;
+};
+
 class DownloadListener {
 public:
   virtual ~DownloadListener() = default;
 
-  virtual void OnDownloadFinished() noexcept = 0;
+  virtual void
+  OnDownloadFinished(const DownloadNotification &notification) noexcept = 0;
 };
 
 /**
  * Background EDL tile downloads (replaces modal ShowCoDialog usage).
+ *
+ * Performs HTTP work on the network thread and reports results to
+ * #DownloadListener instances on the UI thread.  UI state changes belong
+ * in #Glue or other UI-side listeners.
  */
 class DownloadGlue final {
   enum class Job {
@@ -70,15 +96,21 @@ public:
   void RemoveListener(DownloadListener &listener) noexcept;
 
   /**
-   * Apply a cached tile or download the current forecast/isobar in the
-   * background.
+   * Notify listeners from the UI thread (for example after applying a
+   * cached overlay without starting a download).
    */
-  void RequestOverlayRefresh() noexcept;
+  void DeliverNotification(DownloadNotification notification) noexcept;
+
+  /**
+   * Download the overlay for the given forecast/isobar in the background.
+   */
+  void StartOverlayDownload(BrokenDateTime forecast_time,
+                            unsigned isobar) noexcept;
 
   /**
    * Download all hours and isobars for one UTC day in the background.
    */
-  void RequestPrecacheDay(BrokenDateTime day) noexcept;
+  void StartPrecacheDay(BrokenDateTime day) noexcept;
 
 private:
   Co::InvokeTask RunOverlayDownload();
@@ -87,7 +119,7 @@ private:
   void OnCompletion(std::exception_ptr error) noexcept;
   void OnCompleteNotify() noexcept;
 
-  void NotifyListeners() noexcept;
+  void NotifyListeners(const DownloadNotification &notification) noexcept;
 };
 
 } // namespace EDL

--- a/src/Weather/EDL/DownloadGlue.hpp
+++ b/src/Weather/EDL/DownloadGlue.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Weather/Features.hpp"
+
+#ifdef HAVE_EDL
+
+#include "net/AsyncTask.hpp"
+#include "thread/SafeList.hxx"
+#include "time/BrokenDateTime.hpp"
+#include "ui/event/Notify.hpp"
+#include "system/Path.hpp"
+
+#include <exception>
+#include <optional>
+
+class CurlGlobal;
+class AllocatedPath;
+
+namespace EDL {
+
+class DownloadListener {
+public:
+  virtual ~DownloadListener() = default;
+
+  virtual void OnDownloadFinished() noexcept = 0;
+};
+
+/**
+ * Background EDL tile downloads (replaces modal ShowCoDialog usage).
+ */
+class DownloadGlue final {
+  enum class Job {
+    NONE,
+    OVERLAY,
+    PRECACHE_DAY,
+  };
+
+  CurlGlobal &curl;
+  Net::AsyncTask task;
+  UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
+
+  Job pending_job = Job::NONE;
+  std::exception_ptr completion_error;
+  std::optional<AllocatedPath> completed_path;
+  unsigned completed_precache_count = 0;
+
+  /** Snapshot for overlay download (read on network thread). */
+  BrokenDateTime overlay_forecast_time;
+  unsigned overlay_isobar = 0;
+
+  bool shutting_down = false;
+
+  ThreadSafeList<DownloadListener *> listeners;
+
+public:
+  explicit DownloadGlue(CurlGlobal &_curl) noexcept;
+  ~DownloadGlue() noexcept;
+
+  void BeginShutdown() noexcept;
+
+  [[nodiscard]]
+  bool IsBusy() const noexcept {
+    return task.IsRunning();
+  }
+
+  void AddListener(DownloadListener &listener) noexcept;
+  void RemoveListener(DownloadListener &listener) noexcept;
+
+  /**
+   * Apply a cached tile or download the current forecast/isobar in the
+   * background.
+   */
+  void RequestOverlayRefresh() noexcept;
+
+  /**
+   * Download all hours and isobars for one UTC day in the background.
+   */
+  void RequestPrecacheDay(BrokenDateTime day) noexcept;
+
+private:
+  Co::InvokeTask RunOverlayDownload();
+  Co::InvokeTask RunPrecacheDay(BrokenDateTime day);
+
+  void OnCompletion(std::exception_ptr error) noexcept;
+  void OnCompleteNotify() noexcept;
+
+  void NotifyListeners() noexcept;
+};
+
+} // namespace EDL
+
+#endif /* HAVE_EDL */

--- a/src/Weather/EDL/Glue.cpp
+++ b/src/Weather/EDL/Glue.cpp
@@ -6,6 +6,133 @@
 #include "StateController.hpp"
 #include "NMEA/MoreData.hpp"
 
+#ifdef HAVE_EDL
+
+#include "ActionInterface.hpp"
+#include "Language/Language.hpp"
+#include "LogFile.hpp"
+#include "Message.hpp"
+#include "util/StaticString.hxx"
+
+namespace EDL {
+
+static Glue *registered_glue = nullptr;
+
+void
+RequestOverlayRefresh() noexcept
+{
+  if (registered_glue != nullptr)
+    registered_glue->RequestOverlayRefresh();
+}
+
+void
+RequestPrecacheDay(BrokenDateTime day) noexcept
+{
+  if (registered_glue != nullptr)
+    registered_glue->RequestPrecacheDay(day);
+}
+
+void
+Glue::AttachDownloadGlue(DownloadGlue &download) noexcept
+{
+  download_glue = &download;
+  download.AddListener(*this);
+  registered_glue = this;
+}
+
+void
+Glue::DetachDownloadGlue() noexcept
+{
+  if (download_glue != nullptr) {
+    download_glue->RemoveListener(*this);
+    download_glue = nullptr;
+  }
+
+  if (registered_glue == this)
+    registered_glue = nullptr;
+}
+
+void
+Glue::RequestOverlayRefresh() noexcept
+{
+  if (download_glue == nullptr)
+    return;
+
+  if (!OverlayEnabled()) {
+    download_glue->DeliverNotification(DownloadNotification{
+      .job = DownloadJob::OVERLAY,
+      .outcome = DownloadOutcome::SUCCESS,
+    });
+    return;
+  }
+
+  if (TryApplyOverlayFromCache()) {
+    ActionInterface::ScheduleSendUIState();
+    download_glue->DeliverNotification(DownloadNotification{
+      .job = DownloadJob::OVERLAY,
+      .outcome = DownloadOutcome::SUCCESS,
+      .overlay_from_cache = true,
+    });
+    return;
+  }
+
+  SetLoadingStatus();
+  download_glue->StartOverlayDownload(GetForecastTime(), GetIsobar());
+}
+
+void
+Glue::RequestPrecacheDay(BrokenDateTime day) noexcept
+{
+  if (download_glue == nullptr || !OverlayEnabled())
+    return;
+
+  SetLoadingStatus();
+  download_glue->StartPrecacheDay(day);
+}
+
+void
+Glue::OnDownloadFinished(const DownloadNotification &notification) noexcept
+{
+  if (notification.overlay_from_cache)
+    return;
+
+  switch (notification.job) {
+  case DownloadJob::OVERLAY:
+    if (notification.outcome == DownloadOutcome::ERROR) {
+      LogError(notification.error, "EDL overlay download failed");
+      SetErrorStatus();
+    } else if (notification.overlay_path) {
+      if (ShouldMaintainOverlay())
+        ApplyOverlay(*notification.overlay_path);
+      else
+        SetIdleStatus();
+    } else {
+      SetIdleStatus();
+    }
+
+    ActionInterface::ScheduleSendUIState();
+    break;
+
+  case DownloadJob::PRECACHE_DAY:
+    if (notification.outcome == DownloadOutcome::ERROR) {
+      LogError(notification.error, "EDL precache failed");
+      SetErrorStatus();
+    } else {
+      SetIdleStatus();
+
+      StaticString<64> message;
+      message.Format(_("Cached %u files for the selected UTC day."),
+                     notification.precache_count);
+      Message::AddMessage(message);
+    }
+    break;
+  }
+}
+
+} // namespace EDL
+
+#endif /* HAVE_EDL */
+
 namespace EDL {
 
 void

--- a/src/Weather/EDL/Glue.hpp
+++ b/src/Weather/EDL/Glue.hpp
@@ -4,16 +4,48 @@
 #pragma once
 
 #include "Blackboard/BlackboardListener.hpp"
+#include "Weather/Features.hpp"
+#include "time/BrokenDateTime.hpp"
+
+#ifdef HAVE_EDL
+#include "Weather/EDL/DownloadGlue.hpp"
+#endif
 
 namespace EDL {
 
 /**
  * Keeps the shared EDL forecast hour aligned with GPS time while an
- * overlay is being maintained.
+ * overlay is being maintained, and applies download results on the UI
+ * thread.
  */
-class Glue final : public NullBlackboardListener {
+class Glue final
+#ifdef HAVE_EDL
+  : public NullBlackboardListener,
+    private DownloadListener
+#else
+  : public NullBlackboardListener
+#endif
+{
 public:
   void OnGPSUpdate(const MoreData &basic) override;
+
+#ifdef HAVE_EDL
+  void AttachDownloadGlue(DownloadGlue &download_glue) noexcept;
+  void DetachDownloadGlue() noexcept;
+
+  void RequestOverlayRefresh() noexcept;
+  void RequestPrecacheDay(BrokenDateTime day) noexcept;
+
+private:
+  void OnDownloadFinished(const DownloadNotification &notification) noexcept override;
+
+  DownloadGlue *download_glue = nullptr;
+#endif
 };
+
+#ifdef HAVE_EDL
+void RequestOverlayRefresh() noexcept;
+void RequestPrecacheDay(BrokenDateTime day) noexcept;
+#endif
 
 } // namespace EDL

--- a/src/net/AsyncTask.hpp
+++ b/src/net/AsyncTask.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/InjectTask.hxx"
+
+class EventLoop;
+
+namespace Net {
+
+/**
+ * Runs one coroutine on the network #EventLoop.
+ *
+ * Long-lived components (NOTAM, TIM, LiveTrack24, …) use this type and
+ * call BeginShutdown() from NetComponents::BeginShutdown() before the
+ * UI or parent object is destroyed.  Modal UI (ShowCoDialog) uses
+ * Co::InjectTask directly and cancels when the dialog closes.
+ */
+class AsyncTask final {
+  Co::InjectTask task;
+  bool shutting_down = false;
+
+public:
+  explicit AsyncTask(EventLoop &event_loop) noexcept
+    :task(event_loop) {}
+
+  ~AsyncTask() noexcept {
+    BeginShutdown();
+  }
+
+  AsyncTask(const AsyncTask &) = delete;
+  AsyncTask &operator=(const AsyncTask &) = delete;
+
+  [[nodiscard]]
+  bool IsShuttingDown() const noexcept {
+    return shutting_down;
+  }
+
+  [[nodiscard]]
+  bool IsRunning() const noexcept {
+    return !shutting_down && task;
+  }
+
+  void BeginShutdown() noexcept {
+    if (shutting_down)
+      return;
+
+    shutting_down = true;
+    task.Cancel();
+  }
+
+  void Start(Co::InvokeTask invoke_task,
+             Co::InvokeTask::Callback callback) noexcept {
+    if (shutting_down)
+      return;
+
+    task.Start(std::move(invoke_task), std::move(callback));
+  }
+
+  void Cancel() noexcept {
+    task.Cancel();
+  }
+};
+
+} // namespace Net

--- a/src/net/client/tim/Glue.cpp
+++ b/src/net/client/tim/Glue.cpp
@@ -13,11 +13,20 @@ namespace TIM {
 
 Glue::Glue(CurlGlobal &_curl) noexcept
   :curl(_curl),
-   inject_task(curl.GetEventLoop())
+   task(curl.GetEventLoop())
 {
 }
 
-Glue::~Glue() noexcept = default;
+Glue::~Glue() noexcept
+{
+  BeginShutdown();
+}
+
+void
+Glue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+}
 
 void
 Glue::OnTimer(const NMEAInfo &basic) noexcept
@@ -30,7 +39,7 @@ Glue::OnTimer(const NMEAInfo &basic) noexcept
     /* no link; do not start ThermalInfoMap request (see SkyLines Glue) */
     return;
 
-  if (inject_task)
+  if (task.IsRunning())
     /* still running */
     return;
 
@@ -39,7 +48,7 @@ Glue::OnTimer(const NMEAInfo &basic) noexcept
     return;
 
   // TODO for some privacy, don't transmit exact location
-  inject_task.Start(Start(basic.location), BIND_THIS_METHOD(OnCompletion));
+  task.Start(Start(basic.location), BIND_THIS_METHOD(OnCompletion));
 }
 
 Co::InvokeTask

--- a/src/net/client/tim/Glue.cpp
+++ b/src/net/client/tim/Glue.cpp
@@ -31,6 +31,9 @@ Glue::BeginShutdown() noexcept
 void
 Glue::OnTimer(const NMEAInfo &basic) noexcept
 {
+  if (task.IsShuttingDown())
+    return;
+
   if (!basic.gps.real || !basic.location_available)
     /* we need a real GPS location */
     return;

--- a/src/net/client/tim/Glue.hpp
+++ b/src/net/client/tim/Glue.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "co/InjectTask.hxx"
+#include "net/AsyncTask.hpp"
 #include "thread/Mutex.hxx"
 #include "event/DeferEvent.hxx"
 #include "time/PeriodClock.hpp"
@@ -30,11 +30,13 @@ class Glue {
 
   std::vector<Thermal> thermals;
 
-  Co::InjectTask inject_task;
+  Net::AsyncTask task;
 
 public:
   explicit Glue(CurlGlobal &_curl) noexcept;
   ~Glue() noexcept;
+
+  void BeginShutdown() noexcept;
 
   auto Lock() const noexcept {
     return std::lock_guard{mutex};

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -57,7 +57,10 @@ class DownloadManagerThread final
 
   ThreadSafeList<Net::DownloadListener *> listeners;
 
+  bool shutting_down = false;
+
 public:
+  void BeginShutdown() noexcept;
   void AddListener(Net::DownloadListener &listener) noexcept {
     listeners.Add(&listener);
   }
@@ -82,6 +85,9 @@ public:
   }
 
   void Enqueue(const char *uri, Path path_relative) noexcept {
+    if (shutting_down)
+      return;
+
     queue.emplace_back(uri, path_relative);
 
     listeners.ForEach([path_relative](auto *listener){
@@ -145,8 +151,22 @@ DownloadToFile(CurlGlobal &curl,
 }
 
 void
+DownloadManagerThread::BeginShutdown() noexcept
+{
+  if (shutting_down)
+    return;
+
+  shutting_down = true;
+  task.Cancel();
+  queue.clear();
+  current_size = current_position = -1;
+}
+
+void
 DownloadManagerThread::Start() noexcept
 {
+  if (shutting_down)
+    return;
   assert(!queue.empty());
   assert(!task);
   assert(current_size == -1);
@@ -201,6 +221,8 @@ Net::DownloadManager::Initialise() noexcept
 void
 Net::DownloadManager::BeginDeinitialise() noexcept
 {
+  if (thread != nullptr)
+    thread->BeginShutdown();
 }
 
 void

--- a/src/net/http/DownloadManager.hpp
+++ b/src/net/http/DownloadManager.hpp
@@ -44,6 +44,7 @@ namespace Net::DownloadManager {
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 bool Initialise() noexcept;
+/** Cancel queued and in-flight downloads (safe to call more than once). */
 void BeginDeinitialise() noexcept;
 void Deinitialise() noexcept;
 

--- a/src/net/http/Init.cpp
+++ b/src/net/http/Init.cpp
@@ -3,10 +3,38 @@
 
 #include "Init.hpp"
 #include "lib/curl/Global.hxx"
+#include "event/Call.hxx"
+#include "event/Loop.hxx"
 
 #include <curl/curl.h>
 
 CurlGlobal *Net::curl;
+
+namespace {
+
+void
+DrainCurl() noexcept
+{
+  CurlGlobal *const instance = Net::curl;
+  if (instance == nullptr)
+    return;
+
+  EventLoop &loop = instance->GetEventLoop();
+  if (loop.IsInside()) {
+    delete instance;
+    Net::curl = nullptr;
+    return;
+  }
+
+  BlockingCall(loop, [instance]() noexcept {
+    if (Net::curl == instance) {
+      delete Net::curl;
+      Net::curl = nullptr;
+    }
+  });
+}
+
+} // namespace
 
 void
 Net::Initialise(EventLoop &event_loop)
@@ -17,9 +45,8 @@ Net::Initialise(EventLoop &event_loop)
 }
 
 void
-Net::Deinitialise()
+Net::Deinitialise() noexcept
 {
-  delete curl;
-
+  DrainCurl();
   curl_global_cleanup();
 }

--- a/src/net/http/Init.hpp
+++ b/src/net/http/Init.hpp
@@ -20,7 +20,7 @@ extern CurlGlobal *curl;
 void
 Initialise(EventLoop &event_loop);
 
-void Deinitialise();
+void Deinitialise() noexcept;
 
 #else
 


### PR DESCRIPTION
## Summary

Single commit on current `master` (NOTAM integration is already upstream). This adds shared background-network lifecycle handling and fixes startup/shutdown crashes seen with NOTAM + EDL overlays.

- **`Net::AsyncTask`** — common wrapper for NOTAM, TIM, LiveTrack24, and EDL downloads; cancelled from `NetComponents::BeginShutdown()`.
- **`EDL::DownloadGlue`** — background overlay/precache instead of modal `ShowCoDialog`; UI completion on the main thread via `UI::Notify`; forecast/isobar snapshotted before the network coroutine runs.
- **Startup / shutdown** — `net_components` ordering, deferred `PageActions` / InfoBox refresh, split network teardown, `DrainCurl()` on the asio event loop.
- **InfoBoxes** — `infoboxes_ready` guard against reentrancy during terrain load.
- **NOTAM** — retry without the undersized `RateLimiter` / `make_unique` allocation that corrupted the heap at startup.

## Test plan

- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y` and `make check`
- [ ] `output/UNIX/bin/xcsoar -simulator` with NOTAM enabled: startup, map use, quit (no assert)
- [ ] Enable EDL map overlay + weather controls after NOTAM fetch
- [ ] NOTAM fetch failure / offline: retry after ~30s
- [ ] Profile with async terrain load at startup
- [ ] Builds without `HAVE_HTTP` / `HAVE_EDL` still compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deferred scheduling for InfoBox refreshes and page action updates to improve UI responsiveness.
  * Enhanced weather overlay and EDL tile download management with coordinated background task handling.

* **Improvements**
  * Strengthened shutdown coordination for background network tasks including downloads, tracking, and NOTAM updates.
  * Added InfoBox readiness tracking to prevent operations during partial initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->