### PR TITLE
ui/canvas/opengl/Canvas: Fix thick solid lines on macOS

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,7 @@ Version 7.45 - not yet released
     ISA logger datum; cleared when strong pressure replaces weak pressure or
     ignores the sentence
 * ui
+  - macOS: thick solid lines now render at their correct pixel width #2545
   - status dialog, Times: flight time matches takeoff and landing after
     minute rounding (including across midnight); landing time clears on a
     new takeoff in the same session #957

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -3,6 +3,7 @@
 
 #include "Canvas.hpp"
 #include "Triangulate.hpp"
+#include "Asset.hpp"
 #include "Globals.hpp"
 #include "Texture.hpp"
 #include "Scope.hpp"
@@ -162,8 +163,18 @@ Canvas::DrawPolyline(const BulkPixelPoint *points, unsigned num_points) noexcept
 
   pen.Bind();
 
-  const ScopeVertexPointer vp(points);
-  glDrawArrays(GL_LINE_STRIP, 0, num_points);
+  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
+  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+    unsigned strip_len = LineToTriangles(points, num_points, vertex_buffer,
+                                         pen.GetWidth(), false, false);
+    if (strip_len > 0) {
+      const ScopeVertexPointer vp{vertex_buffer.data()};
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
+    }
+  } else {
+    const ScopeVertexPointer vp(points);
+    glDrawArrays(GL_LINE_STRIP, 0, num_points);
+  }
 
   pen.Unbind();
 }
@@ -192,7 +203,7 @@ Canvas::DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept
   if (IsPenOverBrush()) {
     pen.Bind();
 
-    if (pen.GetWidth() <= 2) {
+    if (pen.GetWidth() <= (IsMacOSX() ? 1u : 2u)) {
       glDrawArrays(GL_LINE_LOOP, 0, num_points);
     } else {
       unsigned vertices = LineToTriangles(points, num_points, vertex_buffer,
@@ -225,7 +236,7 @@ Canvas::DrawTriangleFan(const BulkPixelPoint *points, unsigned num_points) noexc
   if (IsPenOverBrush()) {
     pen.Bind();
 
-    if (pen.GetWidth() <= 2) {
+    if (pen.GetWidth() <= (IsMacOSX() ? 1u : 2u)) {
       glDrawArrays(GL_LINE_LOOP, 0, num_points);
     } else {
       unsigned vertices = LineToTriangles(points, num_points, vertex_buffer,
@@ -299,8 +310,18 @@ Canvas::DrawLine(PixelPoint a, PixelPoint b) noexcept
   }
 
   const BulkPixelPoint v[] = { a, b };
-  const ScopeVertexPointer vp(v);
-  glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
+  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+    unsigned strip_len = LineToTriangles(v, 2, vertex_buffer, pen.GetWidth(),
+                                         false, true);
+    if (strip_len > 0) {
+      const ScopeVertexPointer vp{vertex_buffer.data()};
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
+    }
+  } else {
+    const ScopeVertexPointer vp(v);
+    glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  }
 
   pen.Unbind();
 }
@@ -312,9 +333,21 @@ Canvas::DrawExactLine(PixelPoint a, PixelPoint b) noexcept
 
   pen.Bind();
 
-  const ExactPixelPoint v[] = { a, b };
-  const ScopeVertexPointer vp(v);
-  glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
+  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+    const BulkPixelPoint v[] = { {(GLvalue)a.x, (GLvalue)a.y},
+                                 {(GLvalue)b.x, (GLvalue)b.y} };
+    unsigned strip_len = LineToTriangles(v, 2, vertex_buffer, pen.GetWidth(),
+                                         false, true);
+    if (strip_len > 0) {
+      const ScopeVertexPointer vp{vertex_buffer.data()};
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
+    }
+  } else {
+    const ExactPixelPoint v[] = { a, b };
+    const ScopeVertexPointer vp(v);
+    glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  }
 
   pen.Unbind();
 }
@@ -331,7 +364,7 @@ Canvas::DrawLinePiece(const PixelPoint a, const PixelPoint b) noexcept
   pen.Bind();
 
   const BulkPixelPoint v[] = { {a.x, a.y}, {b.x, b.y} };
-  if (pen.GetWidth() > 2) {
+  if (pen.GetWidth() > (IsMacOSX() ? 1u : 2u)) {
     unsigned strip_len = LineToTriangles(v, 2, vertex_buffer, pen.GetWidth(),
                                          false, true);
     if (strip_len > 0) {
@@ -354,8 +387,18 @@ Canvas::DrawTwoLines(PixelPoint a, PixelPoint b, PixelPoint c) noexcept
   pen.Bind();
 
   const BulkPixelPoint v[] = { a, b, c };
-  const ScopeVertexPointer vp(v);
-  glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
+  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+    unsigned strip_len = LineToTriangles(v, 3, vertex_buffer, pen.GetWidth(),
+                                         false, false);
+    if (strip_len > 0) {
+      const ScopeVertexPointer vp{vertex_buffer.data()};
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
+    }
+  } else {
+    const ScopeVertexPointer vp(v);
+    glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  }
 
   pen.Unbind();
 }
@@ -367,9 +410,22 @@ Canvas::DrawTwoLinesExact(PixelPoint a, PixelPoint b, PixelPoint c) noexcept
 
   pen.Bind();
 
-  const ExactPixelPoint v[] = { a, b, c };
-  const ScopeVertexPointer vp(v);
-  glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
+  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+    const BulkPixelPoint v[] = { {(GLvalue)a.x, (GLvalue)a.y},
+                                 {(GLvalue)b.x, (GLvalue)b.y},
+                                 {(GLvalue)c.x, (GLvalue)c.y} };
+    unsigned strip_len = LineToTriangles(v, 3, vertex_buffer, pen.GetWidth(),
+                                         false, false);
+    if (strip_len > 0) {
+      const ScopeVertexPointer vp{vertex_buffer.data()};
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
+    }
+  } else {
+    const ExactPixelPoint v[] = { a, b, c };
+    const ScopeVertexPointer vp(v);
+    glDrawArrays(GL_LINE_STRIP, 0, ARRAY_SIZE(v));
+  }
 
   pen.Unbind();
 }


### PR DESCRIPTION
Closes #2545.

>Same class of bug elsewhere in opengl/Canvas.cpp: DrawExactLine, DrawTwoLines, DrawTwoLinesExact; polygon/fan outlines when width <= 2.

> Other visible callers (via DrawLine / DrawPolyline / Arc → DrawPolyline): task bearing line, snail trail (trace + colour segments), sky-wave overlay, map crosshair, many chart lines, OZ/task highlight (width 4), FLARM arcs, etc. Fixing the core Canvas methods covers most map/UI cases.

Please verify if I implemented these suggested improvements correctly.

> This “3 px looks like 1 px” symptom is not expected on HiDPI Linux with the normal OpenGL build: Mesa/GLX typically respects glLineWidth, and ScalePenWidth scales pens up with DPI. Worth verifying on macOS only for the fix.

I changed the condition so the whole change is only affecting macOS with solid pens > 1 (`IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u`).

@yorickreum Could you please verify if this PR is working in your setup?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thick solid lines on macOS so they render at the correct pixel width across various drawing operations.

* **Documentation**
  * Added a macOS UI entry to the release notes noting the rendering fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->