### PR TITLE
Dialogs/Plane: Fix polar configuration dialog geometry

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -28,6 +28,7 @@ Version 7.45 - not yet released
     Start reach value colour and comment reflect gate state at leg ETA
     (Too early/Can start/Too late, blue/green/red)
   - infoboxen: new Altitude IGC InfoBox (logger pressure or ISA pressure only)
+  - plane polar dialog: fix polar coefficient grid layout and auto-sized width
   - waypoint search: name filter matches anywhere in the long name and the
     shortname (typically the ICAO code in SeeYou .cup files), not only at
     the start, so e.g. "FIELD" finds "AIRFIELD" and "INGEN" finds

--- a/src/Dialogs/Plane/PolarShapeEditWidget.cpp
+++ b/src/Dialogs/Plane/PolarShapeEditWidget.cpp
@@ -24,6 +24,46 @@ PolarShapeEditWidget::PolarShapeEditWidget(const PolarShape &_shape,
 
 PolarShapeEditWidget::~PolarShapeEditWidget() noexcept = default;
 
+[[gnu::pure]]
+static unsigned
+GetLabelWidth(const DialogLook &look) noexcept
+{
+  const char *v_text = C_("Glider polar coefficient", "Polar V");
+  const char *w_text = C_("Glider polar coefficient", "Polar W");
+
+  return 2 * Layout::GetTextPadding() +
+    std::max(look.text_font.TextSize(v_text).width,
+             look.text_font.TextSize(w_text).width);
+}
+
+[[gnu::pure]]
+static unsigned
+GetMinimumColumnWidth(const DialogLook &look) noexcept
+{
+  const unsigned padding = Layout::GetTextPadding();
+  const Font &font = look.text_font;
+  unsigned width = font.TextSize("-2000").width + 2 * padding;
+  const unsigned min_control = Layout::GetMinimumControlHeight();
+  if (width < min_control)
+    width = min_control;
+
+  return width;
+}
+
+[[gnu::pure]]
+static unsigned
+GetMaximumColumnWidth(const DialogLook &look) noexcept
+{
+  const unsigned padding = Layout::GetTextPadding();
+  const Font &font = look.text_font;
+  unsigned width = font.TextSize("300.00").width + 2 * padding;
+  const unsigned max_control = Layout::GetMaximumControlHeight();
+  if (width < max_control)
+    width = max_control;
+
+  return width;
+}
+
 static void
 LoadValue(WndProperty &e, double value, UnitGroup unit_group) noexcept
 {
@@ -80,41 +120,46 @@ PolarShapeEditWidget::SetPolarShape(const PolarShape &_shape) noexcept
   shape = _shape;
 
   for (unsigned i = 0; i < ARRAY_SIZE(points); ++i)
-    LoadPoint(points[i], shape[i]);
+    if (points[i].v != nullptr)
+      LoadPoint(points[i], shape[i]);
 }
 
 PixelSize
 PolarShapeEditWidget::GetMinimumSize() const noexcept
 {
-  return { Layout::Scale(200u),
-      2 * Layout::GetMinimumControlHeight() };
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  const unsigned width = GetLabelWidth(look) +
+    ARRAY_SIZE(points) * GetMinimumColumnWidth(look);
+
+  return { width, 2 * Layout::GetMinimumControlHeight() };
 }
 
 PixelSize
 PolarShapeEditWidget::GetMaximumSize() const noexcept
 {
-  return { Layout::Scale(400u),
-      2 * Layout::GetMaximumControlHeight() };
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  const unsigned width = GetLabelWidth(look) +
+    ARRAY_SIZE(points) * GetMaximumColumnWidth(look);
+
+  return { width, 2 * Layout::GetMaximumControlHeight() };
 }
 
 void
-PolarShapeEditWidget::Prepare(ContainerWindow &parent,
-                              const PixelRect &_rc) noexcept
+PolarShapeEditWidget::CreateControls(ContainerWindow &panel,
+                                     const PixelRect &rc) noexcept
 {
-  PanelWidget::Prepare(parent, _rc);
   const DialogLook &look = UIGlobals::GetDialogLook();
-  ContainerWindow &panel = (ContainerWindow &)GetWindow();
 
-  const unsigned width = _rc.GetWidth(), height = _rc.GetHeight();
+  const unsigned width = rc.GetWidth(), height = rc.GetHeight();
+  const unsigned row_height = std::max(1U, height / 2);
+  const unsigned label_width = std::min(GetLabelWidth(look), width);
+  const unsigned columns_width = width > label_width ? width - label_width : 1U;
+  const unsigned edit_width =
+    std::max(1U, columns_width / unsigned(ARRAY_SIZE(points)));
+  const unsigned edit_remainder = columns_width - edit_width * ARRAY_SIZE(points);
 
   const char *v_text = C_("Glider polar coefficient", "Polar V");
   const char *w_text = C_("Glider polar coefficient", "Polar W");
-
-  const unsigned row_height = height / 2;
-  const unsigned label_width = 2 * Layout::GetTextPadding() +
-    std::max(look.text_font.TextSize(v_text).width,
-             look.text_font.TextSize(w_text).width);
-  const unsigned edit_width = (width - label_width) / ARRAY_SIZE(points);
 
   WindowStyle style;
   style.TabStop();
@@ -123,19 +168,25 @@ PolarShapeEditWidget::Prepare(ContainerWindow &parent,
   v_label = std::make_unique<WndFrame>(panel, look, label_rc);
   v_label->SetText(v_text);
 
-  PixelRect rc;
-  rc.left = label_width;
-  rc.top = 0;
-  rc.right = rc.left + edit_width;
-  rc.bottom = row_height;
-  for (unsigned i = 0; i < ARRAY_SIZE(points);
-       ++i, rc.left += edit_width, rc.right += edit_width) {
+  PixelRect field_rc;
+  field_rc.left = label_width;
+  field_rc.top = 0;
+  field_rc.right = field_rc.left + edit_width;
+  field_rc.bottom = row_height;
+  for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
+    if (i + 1 == ARRAY_SIZE(points))
+      field_rc.right = width;
+
     points[i].v = std::make_unique<WndProperty>(panel, look, "",
-                                                rc, 0, style);
+                                                field_rc, 0, style);
     DataFieldFloat *df = new DataFieldFloat("%.0f", "%.0f %s",
                                             0, 300, 0, 1, false,
                                             listener);
     points[i].v->SetDataField(df);
+
+    field_rc.left = field_rc.right;
+    field_rc.right = field_rc.left + edit_width +
+      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
   }
 
   label_rc.top += row_height;
@@ -143,10 +194,10 @@ PolarShapeEditWidget::Prepare(ContainerWindow &parent,
   w_label = std::make_unique<WndFrame>(panel, look, label_rc);
   w_label->SetText(w_text);
 
-  rc.left = label_width;
-  rc.top = row_height;
-  rc.right = rc.left + edit_width;
-  rc.bottom = height;
+  field_rc.left = label_width;
+  field_rc.top = row_height;
+  field_rc.right = field_rc.left + edit_width;
+  field_rc.bottom = height;
 
   double step = 0.01, min = -10;
   switch (Units::current.vertical_speed_unit) {
@@ -164,19 +215,98 @@ PolarShapeEditWidget::Prepare(ContainerWindow &parent,
     break;
   }
 
-  for (unsigned i = 0; i < ARRAY_SIZE(points);
-       ++i, rc.left += edit_width, rc.right += edit_width) {
+  for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
+    if (i + 1 == ARRAY_SIZE(points))
+      field_rc.right = width;
+
     points[i].w = std::make_unique<WndProperty>(panel, look, "",
-                                                rc, 0, style);
+                                                field_rc, 0, style);
     DataFieldFloat *df = new DataFieldFloat("%.2f", "%.2f %s",
                                             min, 0, 0, step, false,
                                             listener);
 
     points[i].w->SetDataField(df);
+
+    field_rc.left = field_rc.right;
+    field_rc.right = field_rc.left + edit_width +
+      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
   }
 
   for (unsigned i = 0; i < ARRAY_SIZE(points); ++i)
     LoadPoint(points[i], shape[i]);
+}
+
+void
+PolarShapeEditWidget::UpdateGeometry(const PixelRect &rc) noexcept
+{
+  assert(IsDefined());
+
+  const DialogLook &look = UIGlobals::GetDialogLook();
+
+  const unsigned width = rc.GetWidth(), height = rc.GetHeight();
+  const unsigned row_height = std::max(1U, height / 2);
+  const unsigned label_width = std::min(GetLabelWidth(look), width);
+  const unsigned columns_width = width > label_width ? width - label_width : 1U;
+  const unsigned edit_width =
+    std::max(1U, columns_width / unsigned(ARRAY_SIZE(points)));
+  const unsigned edit_remainder = columns_width - edit_width * ARRAY_SIZE(points);
+
+  PixelRect label_rc(0, 0, label_width, row_height);
+  v_label->Move(label_rc);
+
+  PixelRect field_rc;
+  field_rc.left = label_width;
+  field_rc.top = 0;
+  field_rc.right = field_rc.left + edit_width;
+  field_rc.bottom = row_height;
+  for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
+    if (i + 1 == ARRAY_SIZE(points))
+      field_rc.right = width;
+
+    points[i].v->Move(field_rc);
+
+    field_rc.left = field_rc.right;
+    field_rc.right = field_rc.left + edit_width +
+      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
+  }
+
+  label_rc.top += row_height;
+  label_rc.bottom += row_height;
+  w_label->Move(label_rc);
+
+  field_rc.left = label_width;
+  field_rc.top = row_height;
+  field_rc.right = field_rc.left + edit_width;
+  field_rc.bottom = height;
+
+  for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
+    if (i + 1 == ARRAY_SIZE(points))
+      field_rc.right = width;
+
+    points[i].w->Move(field_rc);
+
+    field_rc.left = field_rc.right;
+    field_rc.right = field_rc.left + edit_width +
+      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
+  }
+}
+
+void
+PolarShapeEditWidget::Prepare(ContainerWindow &parent,
+                              const PixelRect &rc) noexcept
+{
+  PanelWidget::Prepare(parent, rc);
+  ContainerWindow &panel = (ContainerWindow &)GetWindow();
+  CreateControls(panel, rc);
+}
+
+void
+PolarShapeEditWidget::Move(const PixelRect &rc) noexcept
+{
+  WindowWidget::Move(rc);
+
+  if (v_label != nullptr)
+    UpdateGeometry(rc);
 }
 
 bool

--- a/src/Dialogs/Plane/PolarShapeEditWidget.hpp
+++ b/src/Dialogs/Plane/PolarShapeEditWidget.hpp
@@ -45,5 +45,10 @@ public:
   PixelSize GetMinimumSize() const noexcept override;
   PixelSize GetMaximumSize() const noexcept override;
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Move(const PixelRect &rc) noexcept override;
   bool Save(bool &changed) noexcept override;
+
+private:
+  void CreateControls(ContainerWindow &panel, const PixelRect &rc) noexcept;
+  void UpdateGeometry(const PixelRect &rc) noexcept;
 };

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -240,38 +240,6 @@ RowFormWidget::SetExpertRow(unsigned i) noexcept
   row.expert = true;
 }
 
-void
-RowFormWidget::PrepareWidgetRow(Row &row) noexcept
-{
-  assert(row.type == Row::Type::WIDGET);
-  assert(IsDefined());
-
-  ContainerWindow &panel = (ContainerWindow &)GetWindow();
-  const PixelRect rc = panel.GetClientRect();
-
-  if (!row.initialised) {
-    row.initialised = true;
-    row.widget->Initialise(panel, rc);
-  }
-
-  if (!row.prepared) {
-    row.prepared = true;
-    row.widget->Prepare(panel, rc);
-  }
-}
-
-Widget &
-RowFormWidget::Add(std::unique_ptr<Widget> widget) noexcept
-{
-  rows.emplace_back(std::move(widget));
-  Row &row = rows.back();
-
-  if (IsDefined())
-    PrepareWidgetRow(row);
-
-  return *row.widget;
-}
-
 Window &
 RowFormWidget::Add(Row::Type type, std::unique_ptr<Window> window) noexcept
 {
@@ -464,9 +432,18 @@ RowFormWidget::GetMinimumSize() const noexcept
     : (GetRecommendedCaptionWidth() + value_width);
 
   PixelSize size(edit_width, 0u);
-  for (const auto &i : rows)
-    if (i.IsAvailable(expert))
-      size.height += i.GetMinimumHeight(look, vertical);
+  for (const auto &i : rows) {
+    if (!i.IsAvailable(expert))
+      continue;
+
+    size.height += i.GetMinimumHeight(look, vertical);
+
+    if (i.type == Row::Type::WIDGET) {
+      const unsigned width = i.widget->GetMinimumSize().width;
+      if (width > size.width)
+        size.width = width;
+    }
+  }
 
   return size;
 }
@@ -477,13 +454,25 @@ RowFormWidget::GetMaximumSize() const noexcept
   const unsigned value_width =
     look.text_font.TextSize("Foo Bar Foo Bar").width * 2;
 
+  const bool expert = UIGlobals::GetDialogSettings().expert;
+
   const unsigned edit_width = vertical
     ? std::max(GetRecommendedCaptionWidth(), value_width)
     : (GetRecommendedCaptionWidth() + value_width);
 
   PixelSize size(edit_width, 0u);
-  for (const auto &i : rows)
+  for (const auto &i : rows) {
+    if (!i.IsAvailable(expert))
+      continue;
+
     size.height += i.GetMaximumHeight(look, vertical);
+
+    if (i.type == Row::Type::WIDGET) {
+      const unsigned width = i.widget->GetMaximumSize().width;
+      if (width > size.width)
+        size.width = width;
+    }
+  }
 
   return size;
 }

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -294,7 +294,10 @@ public:
   /**
    * Add a #Widget row.  The object will be deleted automatically.
    */
-  Widget &Add(std::unique_ptr<Widget> widget) noexcept;
+  Widget &Add(std::unique_ptr<Widget> widget) noexcept {
+    rows.emplace_back(std::move(widget));
+    return *rows.back().widget;
+  }
 
   Window &Add(std::unique_ptr<Window> window) noexcept {
     Add(Row::Type::GENERIC, std::move(window));
@@ -764,8 +767,6 @@ public:
   bool SaveValueFileReader(unsigned i, std::string_view profile_key) noexcept;
 
 private:
-  void PrepareWidgetRow(Row &row) noexcept;
-
   static void SetProfile(std::string_view profile_key, unsigned value) noexcept;
 
 protected:


### PR DESCRIPTION
## Summary
- Stop `RowFormWidget` from preparing nested widget rows with the full panel rectangle during `Add()`, which mis-sized the polar coefficient grid
- Include nested widget min/max widths when auto-sizing dialogs that embed custom widgets
- Relayout `PolarShapeEditWidget` on `Move()` and compute column widths from font metrics

## Test plan
- [ ] Open Config → Planes → edit a plane → Polar
- [ ] Verify V/W labels and three coefficient columns align without overlap
- [ ] Resize dialog / test on narrow and wide screens
- [ ] Load a built-in polar and confirm values still display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed polar coefficient grid layout and auto-sized width in the plane polar dialog to improve visual presentation and control alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XCSoar/XCSoar/pull/2555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->