### PR TITLE
Gauge/GaugeVario: Larus-style vario dial mockup

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -922,6 +922,7 @@ DEBUG_PROGRAM_NAMES += \
 	RunWindArrowRenderer \
 	RunHorizonRenderer \
 	RunFinalGlideBarRenderer \
+	RunGaugeVarioRenderer \
 	RunFAITriangleSectorRenderer \
 	RunFlightListRenderer \
 	RunProgressWindow \
@@ -2161,6 +2162,33 @@ RUN_FINAL_GLIDE_BAR_RENDERER_SOURCES = \
 	$(TEST_SRC_DIR)/RunFinalGlideBarRenderer.cpp
 RUN_FINAL_GLIDE_BAR_RENDERER_DEPENDS = FORM SCREEN EVENT RESOURCE ASYNC OS IO THREAD TASK GLIDE LIBNMEA GEO MATH UTIL UNITS
 $(eval $(call link-program,RunFinalGlideBarRenderer,RUN_FINAL_GLIDE_BAR_RENDERER))
+
+RUN_GAUGE_VARIO_RENDERER_SOURCES = \
+	$(MORE_SCREEN_SOURCES) \
+	$(SRC)/Gauge/GaugeVario.cpp \
+	$(SRC)/Renderer/VarioBarRenderer.cpp \
+	$(SRC)/Renderer/GradientRenderer.cpp \
+	$(SRC)/Renderer/UnitSymbolRenderer.cpp \
+	$(SRC)/Renderer/TextInBox.cpp \
+	$(SRC)/Renderer/LabelBlock.cpp \
+	$(SRC)/Look/VarioLook.cpp \
+	$(SRC)/Look/VarioBarLook.cpp \
+	$(SRC)/Look/InfoBoxLook.cpp \
+	$(SRC)/Look/AutoFont.cpp \
+	$(SRC)/Look/ButtonLook.cpp \
+	$(SRC)/InfoBoxes/InfoBoxLayout.cpp \
+	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
+	$(SRC)/Gauge/VarioSettings.cpp \
+	$(SRC)/Blackboard/InterfaceBlackboard.cpp \
+	$(SRC)/Units/Units.cpp \
+	$(SRC)/Units/Settings.cpp \
+	$(SRC)/Formatter/Units.cpp \
+	$(SRC)/Formatter/UserUnits.cpp \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/Fonts.cpp \
+	$(TEST_SRC_DIR)/RunGaugeVarioRenderer.cpp
+RUN_GAUGE_VARIO_RENDERER_DEPENDS = FORM SCREEN EVENT RESOURCE ASYNC OS IO THREAD LIBNMEA GLIDE MATH UTIL UNITS GEO FORMATTER
+$(eval $(call link-program,RunGaugeVarioRenderer,RUN_GAUGE_VARIO_RENDERER))
 
 RUN_FAI_TRIANGLE_SECTOR_RENDERER_SOURCES = \
 	$(SRC)/Look/ButtonLook.cpp \

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -4,7 +4,14 @@
 #include "Gauge/GaugeVario.hpp"
 #include "Look/VarioLook.hpp"
 #include "Look/VarioBarLook.hpp"
+#include "Renderer/GradientRenderer.hpp"
+#include "Look/Colors.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Scope.hpp"
+#endif
 #include "Screen/Layout.hpp"
 #include "Units/Units.hpp"
 #include "NMEA/SwitchState.hpp"
@@ -32,7 +39,7 @@ static constexpr double LARUS_SCALE_MAX_VALUE = 5.0;
 static constexpr double LARUS_SCALE_MAX_ANGLE_DEG =
   LARUS_SCALE_MAX_VALUE * LARUS_SCALE_DEGREES;
 /** Annulus arc extends this % past the ±5 labels (then panel background shows). */
-static constexpr double LARUS_ANNULUS_OVERSHOOT_PERCENT = 2.0;
+static constexpr double LARUS_ANNULUS_OVERSHOOT_PERCENT = 4.0;
 static constexpr double LARUS_INNER_RADIUS_RATIO = 0.80;
 static constexpr double LARUS_NINE_O_CLOCK = 1.5 * M_PI;
 
@@ -244,6 +251,68 @@ DrawNeedlePolygon(Canvas &canvas, PixelPoint center, int length,
   canvas.DrawTriangleFan(points.data(), count);
 }
 
+/** Needle colour faded for the zero-ward trail (alpha or panel blend). */
+[[gnu::const]]
+static Color
+NeedleTrailColor(Color color, uint8_t alpha, Color background) noexcept
+{
+#if defined(ENABLE_OPENGL) || defined(USE_MEMORY_CANVAS)
+  (void)background;
+  return color.WithAlpha(alpha);
+#else
+  if (alpha >= 255)
+    return color;
+  if (alpha <= 0)
+    return background;
+
+#ifdef GREYSCALE
+  const uint8_t l = (unsigned(color.GetLuminosity()) * alpha
+                     + unsigned(background.GetLuminosity()) * (255 - alpha))
+                    / 255;
+  return Color(l);
+#else
+  const uint8_t r = (unsigned(color.Red()) * alpha
+                     + unsigned(background.Red()) * (255 - alpha)) / 255;
+  const uint8_t g = (unsigned(color.Green()) * alpha
+                     + unsigned(background.Green()) * (255 - alpha)) / 255;
+  const uint8_t b = (unsigned(color.Blue()) * alpha
+                     + unsigned(background.Blue()) * (255 - alpha)) / 255;
+  return Color(r, g, b);
+#endif
+#endif
+}
+
+/** Transparent tail swept from scale zero to the needle angle. */
+static void
+DrawNeedleTrail(Canvas &canvas, PixelPoint center, int length,
+                Angle rotation, Color color, Color background,
+                const LarusNeedleCoord *coords, unsigned count,
+                const LarusNeedleLengthMap *length_map) noexcept
+{
+  static constexpr unsigned TRAIL_STEPS = 16;
+  static constexpr uint8_t TRAIL_MAX_ALPHA = ALPHA_OVERLAY;
+
+  const double rot_rad = rotation.Radians();
+  if (std::abs(rot_rad) < 0.02)
+    return;
+
+#ifdef ENABLE_OPENGL
+  const ScopeAlphaBlend alpha_blend;
+#endif
+
+  for (unsigned i = 1; i < TRAIL_STEPS; ++i) {
+    const double t = double(i) / double(TRAIL_STEPS);
+    const Angle angle = Angle::Radians(rot_rad * t);
+    const uint8_t alpha = uint8_t(unsigned(TRAIL_MAX_ALPHA) * t);
+    if (alpha < 8)
+      continue;
+
+    DrawNeedlePolygon(canvas, center, length, angle,
+                      NeedleTrailColor(color, alpha, background),
+                      coords, count, length_map);
+  }
+}
+
 [[gnu::const]]
 static Color
 VarioAccentColor(const VarioLook &look, unsigned index) noexcept
@@ -252,6 +321,21 @@ VarioAccentColor(const VarioLook &look, unsigned index) noexcept
   if (!look.colors)
     return look.inverse ? look.text_color : look.dimmed_text_color;
   return look.accent[index];
+}
+
+/** Gray text legible on #VarioLook::scale_face_color. */
+[[gnu::const]]
+static Color
+ScaleUnitColor(const VarioLook &look) noexcept
+{
+#ifdef GREYSCALE
+  (void)look;
+  return Color(0x80);
+#else
+  return look.inverse
+    ? Color(0x50, 0x50, 0x50)
+    : Color(0xa0, 0xa0, 0xa0);
+#endif
 }
 
 /** MC accent — matches #InfoBoxContentMacCready::Update value color indices. */
@@ -493,10 +577,13 @@ GaugeVario::RecalculateGeometry() noexcept
   look.ReinitialiseLayout(panel_width, scale_title, layout_text_width,
                           row_slot, arc_w);
   geometry = {look, rc};
+  geometry.inner_row_slot = row_slot;
 
   cached_scale_title_font = scale_title;
 
   LayoutValueColumn();
+  LayoutScaleUnit();
+  LayoutMcModeHint();
 
   background_dirty = true;
   dirty = true;
@@ -505,6 +592,7 @@ GaugeVario::RecalculateGeometry() noexcept
   hero_di.Reset();
   gross_di.Reset();
   mc_di.Reset();
+  mc_mode_di.Reset();
 
   last_ballast = -1;
   last_bugs = -1;
@@ -538,6 +626,7 @@ GaugeVario::LayoutValueColumn() noexcept
     geometry.dial_center, geometry.inner_square_side,
     geometry.content_rect, pad);
   geometry.speed_arrows_rect = layout.speed_arrows;
+  geometry.mc_mode_rect = {};
 
   if (visible_count == 0)
     return;
@@ -547,6 +636,8 @@ GaugeVario::LayoutValueColumn() noexcept
                                        look.value_font.GetHeight());
 
   const int square_top = cy - int(geometry.inner_square_side) / 2;
+  const unsigned row_slot = geometry.inner_row_slot;
+
   const int row_left = layout.text_area.left;
   const int row_right = layout.text_area.right;
   const int text_width = row_right - row_left;
@@ -560,9 +651,8 @@ GaugeVario::LayoutValueColumn() noexcept
     if (!spec.visible)
       continue;
 
-    const int slot_y = square_top
-      + int((first_slot + slot_index) * geometry.inner_row_slot);
-    const int y = slot_y + (int(geometry.inner_row_slot) - int(row_height)) / 2;
+    const int slot_y = square_top + int((first_slot + slot_index) * row_slot);
+    const int y = slot_y + (int(row_slot) - int(row_height)) / 2;
     const int row_bottom = y + int(row_height);
 
     spec.row->label_background = {row_left, y, split_x, row_bottom};
@@ -570,6 +660,66 @@ GaugeVario::LayoutValueColumn() noexcept
 
     ++slot_index;
   }
+}
+
+void
+GaugeVario::LayoutMcModeHint() noexcept
+{
+  geometry.mc_mode_rect = {};
+  geometry.mc_mode_center_x = 0;
+
+  if (!Settings().show_mc)
+    return;
+
+  const int pad = Layout::GetTextPadding();
+  const int half = int(geometry.inner_square_side) / 2;
+  const int cx = geometry.dial_center.x;
+  const int big_square_bottom = geometry.dial_center.y + half;
+  const int space_below = std::max(0,
+    geometry.content_rect.bottom - pad - big_square_bottom);
+  const unsigned max_w = std::max(1u, geometry.inner_square_side);
+  const unsigned max_h = std::max(6u, unsigned(space_below));
+
+  look.FitHintFont(max_h, max_w);
+
+  const PixelSize text_size = look.hint_font.TextSize("Vario");
+  if (text_size.width == 0 || text_size.height == 0)
+    return;
+
+  const int top = big_square_bottom;
+  const int bottom = top + int(text_size.height);
+  if (bottom > geometry.content_rect.bottom - pad)
+    return;
+
+  const int left = cx - int(text_size.width) / 2;
+
+  geometry.mc_mode_center_x = cx;
+  geometry.mc_mode_rect = {left, top, left + int(text_size.width), bottom};
+}
+
+void
+GaugeVario::LayoutScaleUnit() noexcept
+{
+  const LarusScaleParams params = GetLarusScaleParams();
+  const unsigned band = geometry.outer_radius - geometry.inner_radius;
+  if (band < 4) {
+    geometry.unit_rect = {};
+    return;
+  }
+
+  const char *unit_text = Units::GetVerticalSpeedName();
+  const PixelSize unit_size = look.scale_unit_font.TextSize(unit_text);
+  if (unit_size.width == 0 || unit_size.height > band) {
+    geometry.unit_rect = {};
+    return;
+  }
+
+  /** Between +4 and +5, mid-lower part of the scale band. */
+  const unsigned unit_radius = geometry.inner_radius + band * 1 / 2;
+  const double scale_value = 4.5 * double(params.tick_step);
+  const PixelPoint anchor =
+    LarusScalePoint(geometry.dial_center, unit_radius, scale_value, params);
+  geometry.unit_rect = PixelRect::Centered(anchor, unit_size);
 }
 
 void
@@ -607,7 +757,8 @@ GaugeVario::RenderScale(Canvas &canvas) noexcept
   const LarusScaleParams params = GetLarusScaleParams();
   const unsigned tick_outer = geometry.outer_radius;
   const unsigned tick_inner = geometry.inner_radius;
-  const unsigned label_radius = tick_inner + (tick_outer - tick_inner) / 2;
+  const unsigned band = tick_outer - tick_inner;
+  const unsigned label_radius = tick_inner + band * 2 / 5;
   const double arc_limit = LarusAnnulusArcEnd(params);
 
   const Angle arc_start =
@@ -620,12 +771,17 @@ GaugeVario::RenderScale(Canvas &canvas) noexcept
   canvas.DrawAnnulus(geometry.dial_center, tick_inner, tick_outer,
                      arc_start, arc_end);
 
-  canvas.Select(Pen(Layout::ScaleFinePenWidth(1), look.scale_ink_color));
+  DrawAnnulusEdgeShadowFade(canvas, geometry.dial_center, tick_inner, tick_outer,
+                            arc_start, arc_end, look.scale_face_color);
+
+  canvas.Select(Pen(Layout::ScalePenWidth(2), look.scale_ink_color));
+  const unsigned tick_len = std::max(1u, band / 5);
+  const unsigned tick_end = tick_outer - tick_len;
   for (int i = -params.n_ticks; i <= params.n_ticks; ++i) {
     const double value = i * params.tick_step;
     canvas.DrawLine(LarusScalePoint(geometry.dial_center, tick_outer,
                                     value, params),
-                    LarusScalePoint(geometry.dial_center, tick_inner,
+                    LarusScalePoint(geometry.dial_center, tick_end,
                                     value, params));
   }
 
@@ -659,18 +815,23 @@ GaugeVario::RenderNeedles(Canvas &canvas) noexcept
   }
 
   const double gross = Units::ToUserVSpeed(classic_value);
+  const Color gross_color = VarioAccentColor(look, VARIO_ACCENT_RED);
+  DrawNeedleTrail(canvas, geometry.dial_center, full_len,
+                  ValueToNeedleAngle(gross), gross_color,
+                  look.background_color,
+                  classic_needle, ARRAY_SIZE(classic_needle),
+                  &larus_classic_needle_map);
   DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
-                    ValueToNeedleAngle(gross),
-                    VarioAccentColor(look, VARIO_ACCENT_RED),
+                    ValueToNeedleAngle(gross), gross_color,
                     classic_needle, ARRAY_SIZE(classic_needle),
                     &larus_classic_needle_map);
 
   if (Settings().show_average_needle) {
     const AverageDisplay average = GetAverageDisplay(Calculated());
     const double average_user = Units::ToUserVSpeed(average.raw);
+    const Color average_color = VarioAccentColor(look, VARIO_ACCENT_BLUE);
     DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
-                      ValueToNeedleAngle(average_user),
-                      VarioAccentColor(look, VARIO_ACCENT_BLUE),
+                      ValueToNeedleAngle(average_user), average_color,
                       simple_needle, ARRAY_SIZE(simple_needle),
                       &larus_simple_needle_map);
   }
@@ -678,9 +839,9 @@ GaugeVario::RenderNeedles(Canvas &canvas) noexcept
   if (Settings().show_mc) {
     const double mc = Units::ToUserVSpeed(GetGlidePolar().GetMC());
     const bool auto_mc = GetComputerSettings().task.auto_mc;
+    const Color mc_color = McAccentColor(look, auto_mc);
     DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
-                      ValueToNeedleAngle(mc),
-                      McAccentColor(look, auto_mc),
+                      ValueToNeedleAngle(mc), mc_color,
                       scale_marker, ARRAY_SIZE(scale_marker),
                       nullptr);
   }
@@ -704,9 +865,11 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
 
   RenderScale(canvas);
   RenderNeedles(canvas);
+  RenderUnit(canvas);
 
   RenderInnerText(canvas);
   RenderSpeedArrows(canvas);
+  RenderMcModeHint(canvas);
 
   if (!Settings().show_speed_to_fly)
     RenderClimb(canvas);
@@ -717,7 +880,64 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
   if (Settings().show_bugs)
     RenderBugs(canvas);
 
+  if (debug_overlay)
+    DrawDebugOverlay(canvas);
+
   dirty = false;
+}
+
+void
+GaugeVario::DrawDebugOverlay(Canvas &canvas) const noexcept
+{
+  const int pad = Layout::GetTextPadding();
+  const InnerHoleTextLayout hole_layout = ComputeInnerHoleTextLayout(
+    geometry.dial_center, geometry.inner_square_side,
+    geometry.content_rect, pad);
+
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1), COLOR_GRAY));
+  canvas.SelectHollowBrush();
+
+  const int half = int(geometry.inner_square_side) / 2;
+  const int cx = geometry.dial_center.x;
+  const int cy = geometry.dial_center.y;
+  const int square_top = cy - half;
+
+  canvas.DrawRectangle({cx - half, cy - half, cx + half, cy + half});
+  canvas.DrawRectangle(hole_layout.text_area);
+
+  if (hole_layout.speed_arrows.GetWidth() > 0 &&
+      hole_layout.speed_arrows.GetHeight() > 0)
+    canvas.DrawRectangle(hole_layout.speed_arrows);
+
+  for (unsigned i = 1; i < 3; ++i) {
+    const int y = square_top + int(i * geometry.inner_row_slot);
+    canvas.DrawLine({hole_layout.text_area.left, y},
+                    {hole_layout.text_area.right, y});
+  }
+
+  const int text_width = hole_layout.text_area.right - hole_layout.text_area.left;
+  const int split_x = hole_layout.text_area.left
+    + text_width * int(VarioLook::INNER_ROW_LABEL_WIDTH_PERCENT) / 100;
+  canvas.DrawLine({split_x, hole_layout.text_area.top},
+                  {split_x, hole_layout.text_area.bottom});
+
+  auto draw_row = [&](const RowGeometry &row) {
+    if (row.label_background.GetWidth() == 0)
+      return;
+
+    canvas.DrawRectangle(row.label_background);
+    canvas.DrawRectangle(row.value_background);
+  };
+
+  draw_row(geometry.hero_row);
+  draw_row(geometry.gross_row);
+  draw_row(geometry.mc_row);
+
+  if (geometry.mc_mode_rect.GetWidth() > 0)
+    canvas.DrawRectangle(geometry.mc_mode_rect);
+
+  if (geometry.unit_rect.GetWidth() > 0)
+    canvas.DrawRectangle(geometry.unit_rect);
 }
 
 void
@@ -749,6 +969,51 @@ GaugeVario::RenderInnerText(Canvas &canvas) noexcept
               "MC", buffer.c_str(),
               McAccentColor(look, GetComputerSettings().task.auto_mc));
   }
+}
+
+void
+GaugeVario::RenderMcModeHint(Canvas &canvas) noexcept
+{
+  if (!Settings().show_mc)
+    return;
+
+  const PixelRect &rc = geometry.mc_mode_rect;
+  if (rc.GetWidth() == 0 || rc.GetHeight() == 0)
+    return;
+
+  const char *text = Settings().show_speed_to_fly ? "SC" : "Vario";
+  const bool text_changed = dirty ||
+    !StringIsEqual(mc_mode_di.last_text, text);
+  if (IsPersistent() && !text_changed)
+    return;
+
+  canvas.Select(look.hint_font);
+  canvas.SetBackgroundColor(look.background_color);
+  canvas.SetTextColor(look.dimmed_text_color);
+
+  if (IsPersistent())
+    canvas.DrawFilledRectangle(rc, look.background_color);
+
+  const PixelSize text_size = canvas.CalcTextSize(text);
+  const int x = geometry.mc_mode_center_x - int(text_size.width) / 2;
+  const int y = RowTextBaselineY(look.hint_font, rc.top, rc.bottom);
+
+  canvas.DrawOpaqueText({x, y}, rc, text);
+  if (IsPersistent())
+    strcpy(mc_mode_di.last_text, text);
+}
+
+void
+GaugeVario::RenderUnit(Canvas &canvas) noexcept
+{
+  const PixelRect &unit_rect = geometry.unit_rect;
+  if (unit_rect.GetWidth() == 0 || unit_rect.GetHeight() == 0)
+    return;
+
+  canvas.Select(look.scale_unit_font);
+  canvas.SetBackgroundTransparent();
+  canvas.SetTextColor(ScaleUnitColor(look));
+  canvas.DrawText(unit_rect.GetTopLeft(), Units::GetVerticalSpeedName());
 }
 
 void

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -3,20 +3,370 @@
 
 #include "Gauge/GaugeVario.hpp"
 #include "Look/VarioLook.hpp"
+#include "Look/VarioBarLook.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Screen/Layout.hpp"
-#include "Renderer/UnitSymbolRenderer.hpp"
-#include "Math/FastRotation.hpp"
 #include "Units/Units.hpp"
-#include "Units/Descriptor.hpp"
+#include "NMEA/SwitchState.hpp"
 #include "lib/fmt/ToBuffer.hxx"
+#include "util/StringUtil.hpp"
+#include "util/Macros.hpp"
 
-#include <algorithm> // for std::clamp()
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
 
-static constexpr double DELTA_V_STEP = 4.0;
-static constexpr double DELTA_V_LIMIT = 16.0;
 #define TEXT_BUG "Bug"
 #define TEXT_BALLAST "Bal"
+
+/** Infobox accent indices — match #InfoBoxLook::colors. */
+static constexpr unsigned VARIO_ACCENT_NEUTRAL = 0;
+static constexpr unsigned VARIO_ACCENT_RED = 1;
+static constexpr unsigned VARIO_ACCENT_BLUE = 2;
+static constexpr unsigned VARIO_ACCENT_GREEN = 3;
+
+/* Larus sw_frontend_rs vario.rs / create_wallpaper_vario.py */
+static constexpr double LARUS_SCALE_DEGREES = 25.0;
+static constexpr double LARUS_SCALE_MAX_VALUE = 5.0;
+static constexpr double LARUS_SCALE_MAX_ANGLE_DEG =
+  LARUS_SCALE_MAX_VALUE * LARUS_SCALE_DEGREES;
+/** Annulus arc extends this % past the ±5 labels (then panel background shows). */
+static constexpr double LARUS_ANNULUS_OVERSHOOT_PERCENT = 2.0;
+static constexpr double LARUS_INNER_RADIUS_RATIO = 0.80;
+static constexpr double LARUS_NINE_O_CLOCK = 1.5 * M_PI;
+
+struct LarusScaleParams {
+  double max_value;
+  double deg_per_unit;
+  int tick_step;
+  int n_ticks;
+};
+
+struct LarusNeedleCoord {
+  double len;
+  double alpha;
+};
+
+static constexpr LarusNeedleCoord classic_needle[] = {
+  {1.0, 0.0},
+  {0.934, 0.0405},
+  {0.703, 0.0538},
+  {0.703, -0.0538},
+  {0.934, -0.0405},
+};
+
+/** Original Larus gross-needle inner extent in SVG coordinates. */
+static constexpr double LARUS_CLASSIC_NEEDLE_INNER_ORIG = 0.703;
+
+static constexpr LarusNeedleCoord simple_needle[] = {
+  {1.223, 0.0},
+  {1.012, -0.107},
+  {1.012, 0.107},
+};
+
+/** Furthest `len_frac` on #simple_needle — tip at outer scale when remapped. */
+static constexpr double LARUS_SIMPLE_NEEDLE_MAX_LEN = 1.223;
+
+/** Original Larus net/average-needle inner extent in SVG coordinates. */
+static constexpr double LARUS_SIMPLE_NEEDLE_INNER_ORIG = 1.012;
+
+struct LarusNeedleLengthMap {
+  double inner_orig;
+  double outer_orig;
+};
+
+static constexpr LarusNeedleLengthMap larus_classic_needle_map{
+  LARUS_CLASSIC_NEEDLE_INNER_ORIG, 1.0,
+};
+
+static constexpr LarusNeedleLengthMap larus_simple_needle_map{
+  LARUS_SIMPLE_NEEDLE_INNER_ORIG, LARUS_SIMPLE_NEEDLE_MAX_LEN,
+};
+
+/** Map SVG needle length so inner base sits on the annulus inner circle. */
+[[gnu::const]]
+static double
+RemapNeedleLength(double len_frac,
+                  const LarusNeedleLengthMap &map) noexcept
+{
+  if (len_frac >= map.outer_orig)
+    return 1.0;
+  if (len_frac <= map.inner_orig)
+    return LARUS_INNER_RADIUS_RATIO;
+  return LARUS_INNER_RADIUS_RATIO +
+    (len_frac - map.inner_orig) * (1.0 - LARUS_INNER_RADIUS_RATIO) /
+    (map.outer_orig - map.inner_orig);
+}
+
+static constexpr LarusNeedleCoord scale_marker[] = {
+  {1.014, -0.058},
+  {1.014, 0.058},
+  {0.878, 0.0},
+};
+
+static_assert(ARRAY_SIZE(classic_needle) == 5,
+              "Larus classic needle coordinate count");
+static_assert(ARRAY_SIZE(simple_needle) == 3,
+              "Larus simple needle coordinate count");
+static_assert(ARRAY_SIZE(scale_marker) == 3,
+              "Larus scale marker coordinate count");
+
+struct AverageDisplay {
+  const char *label;
+  double raw;
+};
+
+[[gnu::pure]]
+static AverageDisplay
+GetAverageDisplay(const DerivedInfo &calculated) noexcept
+{
+  if (calculated.circling)
+    return {"Avg.", calculated.average};
+
+  return {"Net.", calculated.netto_average};
+}
+
+[[gnu::const]]
+static LarusScaleParams
+GetLarusScaleParams() noexcept
+{
+  switch (Units::current.vertical_speed_unit) {
+  case Unit::FEET_PER_MINUTE:
+    return {1020.0, LARUS_SCALE_DEGREES / 200.0, 200, 5};
+
+  case Unit::KNOTS:
+    return {10.2, LARUS_SCALE_DEGREES / 2.0, 2, 5};
+
+  default:
+    return {5.1, LARUS_SCALE_DEGREES, 1, 5};
+  }
+}
+
+/** Scale limit for the annulus arc (±5 plus overshoot; needles use max_value). */
+[[gnu::const]]
+static double
+LarusAnnulusArcEnd(const LarusScaleParams &params) noexcept
+{
+  const double tick_limit = double(params.n_ticks) * params.tick_step;
+  return tick_limit * (1.0 + LARUS_ANNULUS_OVERSHOOT_PERCENT / 100.0);
+}
+
+[[gnu::const]]
+static Angle
+ValueToNeedleAngle(double value) noexcept
+{
+  const LarusScaleParams params = GetLarusScaleParams();
+  value = std::clamp(value, -params.max_value, params.max_value);
+  return Angle::Degrees(value * params.deg_per_unit);
+}
+
+[[gnu::const]]
+static double
+LarusScaleValueRadians(double scale_value,
+                       const LarusScaleParams &params) noexcept
+{
+  return scale_value * params.deg_per_unit * M_PI / 180.0;
+}
+
+[[gnu::const]]
+static PixelPoint
+LarusScalePoint(PixelPoint center, unsigned radius,
+                double scale_value, const LarusScaleParams &params) noexcept
+{
+  const double rad = LarusScaleValueRadians(scale_value, params);
+  return PixelPoint{
+    center.x - int(std::lround(std::cos(rad) * radius)),
+    center.y - int(std::lround(std::sin(rad) * radius)),
+  };
+}
+
+/** Canvas arc angle for a Larus scale value (matches CirclePoint convention). */
+[[gnu::const]]
+static Angle
+LarusScaleValueToCanvasAngle(double scale_value,
+                             const LarusScaleParams &params) noexcept
+{
+  const double rad = LarusScaleValueRadians(scale_value, params);
+  return Angle::Radians(std::atan2(-std::cos(rad), std::sin(rad)));
+}
+
+/** Horizontal extent of ±max scale value past the dial center (toward right). */
+[[gnu::const]]
+static double
+LarusScaleRightExtent() noexcept
+{
+  const double rad = LARUS_SCALE_MAX_ANGLE_DEG * M_PI / 180.0;
+  return -std::cos(rad);
+}
+
+/** Vertical extent of ±max scale value from the dial center. */
+[[gnu::const]]
+static double
+LarusScaleVerticalExtent() noexcept
+{
+  const double rad = LARUS_SCALE_MAX_ANGLE_DEG * M_PI / 180.0;
+  return std::sin(rad);
+}
+
+[[gnu::const]]
+static PixelPoint
+LarusNeedlePoint(PixelPoint center, int length, Angle rotation,
+                 double len_frac, double alpha) noexcept
+{
+  const double rad = LARUS_NINE_O_CLOCK + rotation.Radians() + alpha;
+  const double dist = len_frac * length;
+  return PixelPoint{
+    center.x + int(std::lround(std::sin(rad) * dist)),
+    center.y + int(std::lround(-std::cos(rad) * dist)),
+  };
+}
+
+static void
+DrawNeedlePolygon(Canvas &canvas, PixelPoint center, int length,
+                  Angle rotation, Color color,
+                  const LarusNeedleCoord *coords, unsigned count,
+                  const LarusNeedleLengthMap *length_map) noexcept
+{
+  std::array<BulkPixelPoint, 5> points{};
+  assert(count <= points.size());
+
+  for (unsigned i = 0; i < count; ++i) {
+    const double len_frac = length_map != nullptr
+      ? RemapNeedleLength(coords[i].len, *length_map)
+      : coords[i].len;
+    points[i] = LarusNeedlePoint(center, length, rotation, len_frac,
+                                 coords[i].alpha);
+  }
+
+  canvas.Select(Brush(color));
+  canvas.SelectNullPen();
+  canvas.DrawTriangleFan(points.data(), count);
+}
+
+[[gnu::const]]
+static Color
+VarioAccentColor(const VarioLook &look, unsigned index) noexcept
+{
+  assert(index < ARRAY_SIZE(look.accent));
+  if (!look.colors)
+    return look.inverse ? look.text_color : look.dimmed_text_color;
+  return look.accent[index];
+}
+
+/** MC accent — matches #InfoBoxContentMacCready::Update value color indices. */
+[[gnu::pure]]
+static Color
+McAccentColor(const VarioLook &look, bool auto_mc) noexcept
+{
+  return VarioAccentColor(look,
+                          auto_mc ? VARIO_ACCENT_BLUE : VARIO_ACCENT_GREEN);
+}
+
+/** Side length of the largest square inscribed in the inner hole. */
+[[gnu::const]]
+static unsigned
+InnerHoleInscribedSquareSide(unsigned inner_radius) noexcept
+{
+  return std::max(1u, unsigned(std::lround(double(inner_radius) * M_SQRT2)));
+}
+
+[[gnu::const]]
+static unsigned
+InnerTextWidth(unsigned square_side) noexcept
+{
+  return std::max(1u, square_side * VarioLook::INNER_TEXT_WIDTH_PERCENT / 100u);
+}
+
+/** Baseline that vertically centers capital letters in a row. */
+[[gnu::const]]
+static int
+RowTextBaselineY(const Font &font, int row_top, int row_bottom) noexcept
+{
+  const int cap_top =
+    (row_top + row_bottom - int(font.GetCapitalHeight())) / 2;
+  return cap_top - int(font.GetAscentHeight()) + int(font.GetCapitalHeight());
+}
+
+/** Text area and speed-arrow strip inside the inscribed inner hole. */
+struct InnerHoleTextLayout {
+  PixelRect text_area;
+  PixelRect speed_arrows;
+};
+
+[[gnu::pure]]
+static InnerHoleTextLayout
+ComputeInnerHoleTextLayout(PixelPoint dial_center,
+                           unsigned inner_square_side,
+                           const PixelRect &content_rect,
+                           int pad) noexcept
+{
+  const int cx = dial_center.x;
+  const int cy = dial_center.y;
+  const int half = int(inner_square_side) / 2;
+  const int square_left = cx - half;
+  const int square_top = cy - half;
+  const int square_bottom = square_top + int(inner_square_side);
+  const int text_width = int(InnerTextWidth(inner_square_side));
+  const int square_right = square_left + int(inner_square_side);
+  const int top = square_top + pad;
+  const int bottom = square_bottom - pad;
+  const int strip_gap = Layout::GetTextPadding();
+
+  return {
+    {
+      std::max(content_rect.left + pad, square_left + pad),
+      top,
+      std::min(content_rect.right - pad,
+               square_left + text_width - pad - strip_gap),
+      bottom,
+    },
+    {
+      square_left + text_width + strip_gap,
+      top,
+      std::min(content_rect.right - pad, square_right - pad),
+      bottom,
+    },
+  };
+}
+
+struct DialMetrics {
+  PixelPoint dial_center;
+  unsigned outer_radius;
+  unsigned inner_radius;
+};
+
+[[gnu::pure]]
+static DialMetrics
+ComputeDialMetrics(const PixelRect &rc) noexcept
+{
+  const unsigned panel_width = rc.GetWidth();
+  const unsigned panel_height = rc.GetHeight();
+
+  const double scale_right = LarusScaleRightExtent();
+  const double scale_vertical = LarusScaleVerticalExtent();
+
+  const unsigned max_radius_x =
+    unsigned(double(panel_width) / (1.0 + scale_right));
+  const unsigned max_radius_y =
+    unsigned(double(panel_height) / 2.0 / scale_vertical);
+  const unsigned outer_radius =
+    std::max(1u, std::min(max_radius_x, max_radius_y));
+
+  unsigned inner_radius = std::max(1u, unsigned(double(outer_radius)
+                                                  * LARUS_INNER_RADIUS_RATIO));
+  if (inner_radius >= outer_radius)
+    inner_radius = outer_radius - 1;
+
+  return {
+    {
+      rc.left + int(outer_radius),
+      rc.top + int(panel_height) / 2,
+    },
+    outer_radius,
+    inner_radius,
+  };
+}
 
 inline
 GaugeVario::BallastGeometry::BallastGeometry(const VarioLook &look,
@@ -24,43 +374,35 @@ GaugeVario::BallastGeometry::BallastGeometry(const VarioLook &look,
 {
   PixelSize tSize;
 
-  // position of ballast label
   label_pos.x = 1;
   label_pos.y = rc.top + 2
     + look.label_font.GetCapitalHeight() * 2
     - look.label_font.GetAscentHeight();
 
-  // position of ballast value
   value_pos.x = 1;
   value_pos.y = rc.top + 1
     + look.label_font.GetCapitalHeight()
     - look.label_font.GetAscentHeight();
 
-  // set upper left corner
   label_rect.left = label_pos.x;
   label_rect.top = label_pos.y
     + look.label_font.GetAscentHeight()
     - look.label_font.GetCapitalHeight();
 
-  // set upper left corner
   value_rect.left = value_pos.x;
   value_rect.top = value_pos.y
     + look.label_font.GetAscentHeight()
     - look.label_font.GetCapitalHeight();
 
-  // get max label size
   tSize = look.label_font.TextSize(TEXT_BALLAST);
 
-  // update back rect with max label size
   label_rect.right = label_rect.left + tSize.width;
   label_rect.bottom = label_rect.top +
     look.label_font.GetCapitalHeight();
 
-  // get max value size
   tSize = look.label_font.TextSize("100%");
 
   value_rect.right = value_rect.left + tSize.width;
-  // update back rect with max label size
   value_rect.bottom = value_rect.top +
     look.label_font.GetCapitalHeight();
 }
@@ -92,10 +434,8 @@ GaugeVario::BugsGeometry::BugsGeometry(const VarioLook &look,
   tSize = look.label_font.TextSize(TEXT_BUG);
 
   label_rect.right = label_rect.left + tSize.width;
-  label_rect.bottom = label_rect.top
-    + look.label_font.GetCapitalHeight()
-    + look.label_font.GetHeight()
-    - look.label_font.GetAscentHeight();
+  label_rect.bottom = label_rect.top +
+    look.label_font.GetCapitalHeight();
 
   tSize = look.label_font.TextSize("100%");
 
@@ -105,144 +445,244 @@ GaugeVario::BugsGeometry::BugsGeometry(const VarioLook &look,
 }
 
 inline
-GaugeVario::LabelValueGeometry::LabelValueGeometry(const VarioLook &look,
-                                                   PixelPoint position) noexcept
-  :label_right(position.x),
-   label_top(position.y + Layout::Scale(1)),
-   label_bottom(label_top + look.label_font.GetCapitalHeight()),
-   label_y(label_top + look.label_font.GetCapitalHeight()
-           - look.label_font.GetAscentHeight()),
-   // TODO: update after units got reconfigured?
-   value_right(position.x - UnitSymbolRenderer::GetSize(look.unit_font,
-                                                        Units::current.vertical_speed_unit).width),
-   value_top(label_bottom + Layout::Scale(2)),
-   value_bottom(value_top + look.value_font.GetCapitalHeight()),
-   value_y(value_top + look.value_font.GetCapitalHeight()
-           - look.value_font.GetAscentHeight())
-{
-}
-
-inline unsigned
-GaugeVario::LabelValueGeometry::GetHeight(const VarioLook &look) noexcept
-{
-  return Layout::Scale(4) + look.value_font.GetCapitalHeight()
-    + look.label_font.GetCapitalHeight();
-}
-
-inline
-GaugeVario::Geometry::Geometry(const VarioLook &look, const PixelRect &rc) noexcept
+GaugeVario::Geometry::Geometry(const VarioLook &look,
+                               const PixelRect &rc) noexcept
   :ballast(look, rc), bugs(look, rc)
 {
-  nlength0 = Layout::Scale(15);
-  nlength1 = Layout::Scale(6);
-  nwidth = Layout::Scale(4);
-  nline = Layout::Scale(8);
+  content_rect = rc;
+  row_gap = Layout::Scale(3);
+  speed_arrows_rect = {};
 
-  offset = rc.GetMiddleRight();
-  offset.x -= Layout::GetTextPadding();
-
-  const PixelSize value_offset{0u, LabelValueGeometry::GetHeight(look)};
-
-  const PixelPoint gross_position = offset - value_offset / 2u;
-  gross = {look, gross_position};
-  average = {look, gross_position - value_offset};
-  mc = {look, gross_position + value_offset};
+  const DialMetrics dial = ComputeDialMetrics(rc);
+  dial_center = dial.dial_center;
+  outer_radius = dial.outer_radius;
+  inner_radius = dial.inner_radius;
+  inner_square_side = InnerHoleInscribedSquareSide(inner_radius);
+  inner_row_slot = std::max(1u, inner_square_side / 3u);
 }
 
 GaugeVario::GaugeVario(const FullBlackboard &_blackboard,
-                       ContainerWindow &parent, const VarioLook &_look,
+                       ContainerWindow &parent, VarioLook &_look,
+                       const VarioBarLook &vario_bar_look,
                        PixelRect rc, const WindowStyle style) noexcept
-  :blackboard(_blackboard), look(_look)
+  :blackboard(_blackboard), look(_look),
+   speed_bar_renderer(vario_bar_look)
 {
   Create(parent, rc, style);
 }
 
-static constexpr int
-WidthToHeight(int width) noexcept
+void
+GaugeVario::RecalculateGeometry() noexcept
 {
-  return width * 112 / 100;
+  const PixelRect rc = GetClientRect();
+  const unsigned panel_width = rc.GetWidth();
+  const unsigned scale_title =
+    blackboard.GetUISettings().info_boxes.scale_title_font;
+
+  const DialMetrics dial = ComputeDialMetrics(rc);
+  const unsigned square = InnerHoleInscribedSquareSide(dial.inner_radius);
+  const unsigned row_slot = std::max(1u, square / 3u);
+  const unsigned band = dial.outer_radius - dial.inner_radius;
+  const unsigned arc_w = std::max(4u, band / 2u);
+  const int pad = Layout::GetTextPadding();
+  const InnerHoleTextLayout layout = ComputeInnerHoleTextLayout(
+    dial.dial_center, square, rc, pad);
+  const unsigned layout_text_width =
+    std::max(1u, unsigned(layout.text_area.GetWidth()));
+
+  look.ReinitialiseLayout(panel_width, scale_title, layout_text_width,
+                          row_slot, arc_w);
+  geometry = {look, rc};
+
+  cached_scale_title_font = scale_title;
+
+  LayoutValueColumn();
+
+  background_dirty = true;
+  dirty = true;
+  cached_look_generation = look.layout_generation;
+
+  hero_di.Reset();
+  gross_di.Reset();
+  mc_di.Reset();
+
+  last_ballast = -1;
+  last_bugs = -1;
 }
 
-static constexpr PixelPoint
-TransformRotatedPoint(IntPoint2D pt, IntPoint2D offset) noexcept
+void
+GaugeVario::LayoutValueColumn() noexcept
 {
-  return { pt.x + offset.x, WidthToHeight(pt.y) + offset.y + 1 };
+  const VarioSettings &settings = Settings();
+
+  struct RowSpec {
+    RowGeometry *row;
+    bool visible;
+  };
+
+  const RowSpec rows[] = {
+    {&geometry.hero_row, settings.show_average},
+    {&geometry.gross_row, settings.show_gross},
+    {&geometry.mc_row, settings.show_mc},
+  };
+
+  unsigned visible_count = 0;
+  for (const RowSpec &spec : rows) {
+    if (spec.visible)
+      ++visible_count;
+  }
+
+  const int cy = geometry.dial_center.y;
+  const int pad = Layout::GetTextPadding();
+  const InnerHoleTextLayout layout = ComputeInnerHoleTextLayout(
+    geometry.dial_center, geometry.inner_square_side,
+    geometry.content_rect, pad);
+  geometry.speed_arrows_rect = layout.speed_arrows;
+
+  if (visible_count == 0)
+    return;
+
+  static constexpr unsigned text_slots = 3;
+  const unsigned row_height = std::max(look.label_font.GetHeight(),
+                                       look.value_font.GetHeight());
+
+  const int square_top = cy - int(geometry.inner_square_side) / 2;
+  const int row_left = layout.text_area.left;
+  const int row_right = layout.text_area.right;
+  const int text_width = row_right - row_left;
+  const int split_x = row_left
+    + text_width * int(VarioLook::INNER_ROW_LABEL_WIDTH_PERCENT) / 100;
+
+  const unsigned first_slot = (text_slots - visible_count) / 2;
+  unsigned slot_index = 0;
+
+  for (const RowSpec &spec : rows) {
+    if (!spec.visible)
+      continue;
+
+    const int slot_y = square_top
+      + int((first_slot + slot_index) * geometry.inner_row_slot);
+    const int y = slot_y + (int(geometry.inner_row_slot) - int(row_height)) / 2;
+    const int row_bottom = y + int(row_height);
+
+    spec.row->label_background = {row_left, y, split_x, row_bottom};
+    spec.row->value_background = {split_x, y, row_right, row_bottom};
+
+    ++slot_index;
+  }
 }
 
-inline void
+void
 GaugeVario::RenderBackground(Canvas &canvas, const PixelRect &rc) noexcept
 {
-  canvas.Clear(look.background_color);
+  canvas.DrawFilledRectangle(rc, look.background_color);
+}
 
-  canvas.Select(look.arc_pen);
+void
+GaugeVario::RenderSpeedArrows(Canvas &canvas) noexcept
+{
+  if (!Settings().show_speed_to_fly)
+    return;
 
-  std::array<BulkPixelPoint, 21> arc;
+  const PixelRect &rc = geometry.speed_arrows_rect;
+  if (rc.GetWidth() == 0 || rc.GetHeight() == 0)
+    return;
 
-  const int arc_padding = look.arc_label_font.GetHeight();
+  if (IsPersistent())
+    canvas.DrawFilledRectangle(rc, look.background_color);
 
-  const int x_radius = rc.GetWidth() - arc_padding;
-  const int y_radius = WidthToHeight(x_radius);
+  const int pad = Layout::GetTextPadding();
+  const unsigned max_half = std::max(1u,
+    (geometry.inner_square_side - 2u * unsigned(pad)) / 2u);
 
-  for (std::size_t i = 0; i < arc.size(); ++i) {
-    const unsigned angle = INT_ANGLE_RANGE / 2
-      + i * INT_ANGLE_RANGE / 2 / (arc.size() - 1);
-    const PixelPoint delta(ISINETABLE[NormalizeIntAngle(angle)] * x_radius / 1024,
-                           -ISINETABLE[NormalizeIntAngle(angle + INT_QUARTER_CIRCLE)] * y_radius / 1024);
+  speed_bar_renderer.DrawSpeedToFly(canvas, rc, Basic(), Calculated(),
+                                    max_half,
+                                    VarioAccentColor(look, VARIO_ACCENT_GREEN),
+                                    VarioAccentColor(look, VARIO_ACCENT_BLUE));
+}
 
-    arc[i] = geometry.offset + delta;
+void
+GaugeVario::RenderScale(Canvas &canvas) noexcept
+{
+  const LarusScaleParams params = GetLarusScaleParams();
+  const unsigned tick_outer = geometry.outer_radius;
+  const unsigned tick_inner = geometry.inner_radius;
+  const unsigned label_radius = tick_inner + (tick_outer - tick_inner) / 2;
+  const double arc_limit = LarusAnnulusArcEnd(params);
+
+  const Angle arc_start =
+    LarusScaleValueToCanvasAngle(-arc_limit, params);
+  const Angle arc_end =
+    LarusScaleValueToCanvasAngle(arc_limit, params);
+
+  canvas.Select(Brush(look.scale_face_color));
+  canvas.SelectNullPen();
+  canvas.DrawAnnulus(geometry.dial_center, tick_inner, tick_outer,
+                     arc_start, arc_end);
+
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1), look.scale_ink_color));
+  for (int i = -params.n_ticks; i <= params.n_ticks; ++i) {
+    const double value = i * params.tick_step;
+    canvas.DrawLine(LarusScalePoint(geometry.dial_center, tick_outer,
+                                    value, params),
+                    LarusScalePoint(geometry.dial_center, tick_inner,
+                                    value, params));
   }
 
-  canvas.DrawPolyline(arc.data(), arc.size());
-
-  canvas.Select(look.tick_pen);
   canvas.Select(look.arc_label_font);
-  canvas.SetTextColor(look.dimmed_text_color);
   canvas.SetBackgroundTransparent();
+  canvas.SetTextColor(look.scale_ink_color);
+  for (int i = -params.n_ticks; i <= params.n_ticks; ++i) {
+    const double value = i * params.tick_step;
+    const PixelPoint anchor =
+      LarusScalePoint(geometry.dial_center, label_radius, value, params);
+    const auto label = FmtBuffer<8>("{}", std::abs(i * params.tick_step));
+    const PixelSize text_size = canvas.CalcTextSize(label.c_str());
+    const PixelRect text_rc = PixelRect::Centered(anchor, text_size);
+    if (!geometry.content_rect.OverlapsWith(text_rc))
+      continue;
 
-  int tick_value_step = 1;
-  const auto &unit_descriptor =
-    Units::unit_descriptors[(std::size_t)Units::current.vertical_speed_unit];
-  const double unit_factor = unit_descriptor.factor_to_user;
+    canvas.DrawText(text_rc.GetTopLeft(), label.c_str());
+  }
+}
 
-  switch (Units::current.vertical_speed_unit) {
-  case Unit::FEET_PER_MINUTE:
-    tick_value_step = 200;
-    break;
+void
+GaugeVario::RenderNeedles(Canvas &canvas) noexcept
+{
+  const int full_len = int(geometry.outer_radius);
 
-  default:
-    break;
+  double classic_value = Basic().brutto_vario;
+  if (Settings().show_thermal_average_needle) {
+    classic_value = Calculated().circling
+      ? Calculated().netto_average
+      : Calculated().last_thermal_average_smooth;
   }
 
-  const Angle tick_angle_step = Angle::QuarterCircle() * tick_value_step
-    / unit_factor / GAUGEVARIORANGE;
+  const double gross = Units::ToUserVSpeed(classic_value);
+  DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
+                    ValueToNeedleAngle(gross),
+                    VarioAccentColor(look, VARIO_ACCENT_RED),
+                    classic_needle, ARRAY_SIZE(classic_needle),
+                    &larus_classic_needle_map);
 
-  const int n_ticks = GAUGEVARIORANGE / (tick_value_step / unit_factor);
+  if (Settings().show_average_needle) {
+    const AverageDisplay average = GetAverageDisplay(Calculated());
+    const double average_user = Units::ToUserVSpeed(average.raw);
+    DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
+                      ValueToNeedleAngle(average_user),
+                      VarioAccentColor(look, VARIO_ACCENT_BLUE),
+                      simple_needle, ARRAY_SIZE(simple_needle),
+                      &larus_simple_needle_map);
+  }
 
-  const int tick_length = Layout::GetTextPadding() * 4;
-
-  const IntPoint2D tick_start{1 - x_radius, 0};
-  const IntPoint2D tick_end{-tick_length - x_radius, 0};
-  const IntPoint2D label_center{-x_radius - arc_padding / 2 - tick_length, 0};
-
-  for (int i = -n_ticks; i < n_ticks; ++i) {
-    Angle angle = tick_angle_step * i;
-    const FastIntegerRotation r{angle};
-
-    canvas.DrawLine(TransformRotatedPoint(r.Rotate(tick_start),
-                                          geometry.offset),
-                    TransformRotatedPoint(r.Rotate(tick_end),
-                                          geometry.offset));
-
-    char label[16];
-    StringFormatUnsafe(label, "%d", i * tick_value_step);
-
-    const auto label_size = canvas.CalcTextSize(label);
-
-    const auto label_position = TransformRotatedPoint(r.Rotate(label_center),
-                                                      geometry.offset)
-      - label_size / 2U;
-
-    canvas.DrawText(label_position, label);
+  if (Settings().show_mc) {
+    const double mc = Units::ToUserVSpeed(GetGlidePolar().GetMC());
+    const bool auto_mc = GetComputerSettings().task.auto_mc;
+    DrawNeedlePolygon(canvas, geometry.dial_center, full_len,
+                      ValueToNeedleAngle(mc),
+                      McAccentColor(look, auto_mc),
+                      scale_marker, ARRAY_SIZE(scale_marker),
+                      nullptr);
   }
 }
 
@@ -250,29 +690,25 @@ void
 GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
 {
   const PixelRect rc = GetClientRect();
+  const unsigned scale_title =
+    blackboard.GetUISettings().info_boxes.scale_title_font;
+  if (rc.GetSize() != geometry.content_rect.GetSize() ||
+      look.layout_generation != cached_look_generation ||
+      cached_scale_title_font != scale_title)
+    RecalculateGeometry();
 
   if (!IsPersistent() || background_dirty) {
     RenderBackground(canvas, rc);
     background_dirty = false;
   }
 
-  if (Settings().show_average) {
-    // JMW averager now displays netto average if not circling
-    RenderValue(canvas, geometry.average, average_di,
-                Units::ToUserVSpeed(Calculated().circling ? Calculated().average : Calculated().netto_average),
-                Calculated().circling ? "Avg" : "NetAvg");
-  }
+  RenderScale(canvas);
+  RenderNeedles(canvas);
 
-  if (Settings().show_mc) {
-    auto mc = Units::ToUserVSpeed(GetGlidePolar().GetMC());
-    RenderValue(canvas, geometry.mc, mc_di,
-                mc,
-                GetComputerSettings().task.auto_mc ? "Auto MC" : "MC");
-  }
+  RenderInnerText(canvas);
+  RenderSpeedArrows(canvas);
 
-  if (Settings().show_speed_to_fly)
-    RenderSpeedToFly(canvas, rc.right - 11, (rc.top + rc.bottom) / 2);
-  else
+  if (!Settings().show_speed_to_fly)
     RenderClimb(canvas);
 
   if (Settings().show_ballast)
@@ -282,98 +718,90 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
     RenderBugs(canvas);
 
   dirty = false;
-  int ival, sval, ival_av = 0;
-  int ival_av_thermal = 0;
-  if (Settings().show_thermal_average_needle) {
-      ival_av_thermal = ValueToNeedlePos(Calculated().current_thermal.lift_rate);
-  }
-
-  auto vval = Basic().brutto_vario;
-  ival = ValueToNeedlePos(vval);
-  sval = ValueToNeedlePos(Calculated().sink_rate);
-  if (Settings().show_average_needle) {
-    if (!Calculated().circling)
-      ival_av = ValueToNeedlePos(Calculated().netto_average);
-    else
-      ival_av = ValueToNeedlePos(Calculated().average);
-  }
-
-  // clear items first
-
-  if (Settings().show_average_needle) {
-    if (!IsPersistent() || ival_av != ival_last)
-      RenderNeedle(canvas, ival_last, true, true);
-
-    ival_last = ival_av;
-  }
-
-  if (!IsPersistent() || (sval != sval_last) || (ival != vval_last))
-    RenderVarioLine(canvas, vval_last, sval_last, true);
-
-  sval_last = sval;
-  if (Settings().show_thermal_average_needle) {
-      if (!IsPersistent() || ival_av_thermal != ival_av_last)
-          RenderNeedle(canvas, ival_av_last, false, true);
-
-      ival_av_last = ival_av_thermal;
-  } else {
-      if (!IsPersistent() || ival != vval_last)
-        RenderNeedle(canvas, vval_last, false, true);
-
-      vval_last = ival;
-  }
-
-  // now draw items
-  RenderVarioLine(canvas, ival, sval, false);
-  if (Settings().show_average_needle)
-    RenderNeedle(canvas, ival_av, true, false);
-
-  RenderNeedle(canvas,
-               Settings().show_thermal_average_needle ? ival_av_thermal : ival,
-               false, false);
-
-  if (Settings().show_gross) {
-    auto vvaldisplay = std::clamp(Units::ToUserVSpeed(vval),
-                                  -99.9, 99.9);
-
-    RenderValue(canvas, geometry.gross, gross_di,
-                vvaldisplay,
-                "Gross");
-  }
-
-  RenderZero(canvas);
 }
 
 void
-GaugeVario::MakePolygon(const int i) noexcept
+GaugeVario::RenderInnerText(Canvas &canvas) noexcept
 {
-  auto *bit = getPolygon(i);
-  auto *bline = &lines[i + gmax];
+  if (Settings().show_average) {
+    const AverageDisplay average = GetAverageDisplay(Calculated());
+    const double value =
+      (double)iround(Units::ToUserVSpeed(average.raw) * 10) / 10;
+    const auto buffer = FmtBuffer<18>("{:<+4.1f}", value);
+    RenderRow(canvas, geometry.hero_row, hero_di.label, hero_di.value,
+              average.label, buffer.c_str(), look.text_color);
+  }
 
-  const FastIntegerRotation r(Angle::Degrees(i));
+  if (Settings().show_gross) {
+    const auto vvaldisplay = std::clamp(Units::ToUserVSpeed(Basic().brutto_vario),
+                                        -99.9, 99.9);
+    const auto buffer = FmtBuffer<18>("{:<+4.1f}",
+                                      (double)iround(vvaldisplay * 10) / 10);
+    RenderRow(canvas, geometry.gross_row, gross_di.label, gross_di.value,
+              "Gross", buffer.c_str(), look.text_color);
+  }
 
-  bit[0] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength0, geometry.nwidth}),
-                                 geometry.offset);
-  bit[1] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength1, 0}),
-                                 geometry.offset);
-  bit[2] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength0, -geometry.nwidth}),
-                                 geometry.offset);
-
-  *bline = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nline, 0}),
-                                 geometry.offset);
+  if (Settings().show_mc) {
+    const auto mc = Units::ToUserVSpeed(GetGlidePolar().GetMC());
+    const auto buffer = FmtBuffer<18>("{:<+4.1f}",
+                                      (double)iround(mc * 10) / 10);
+    RenderRow(canvas, geometry.mc_row, mc_di.label, mc_di.value,
+              "MC", buffer.c_str(),
+              McAccentColor(look, GetComputerSettings().task.auto_mc));
+  }
 }
 
-inline BulkPixelPoint *
-GaugeVario::getPolygon(int i) noexcept
+void
+GaugeVario::RenderRow(Canvas &canvas, const RowGeometry &row,
+                      DrawInfo &label_di, DrawInfo &value_di,
+                      const char *label, const char *value_text,
+                      Color value_color) noexcept
 {
-  return polys + (i + gmax) * 3;
-}
+  if (row.label_background.GetWidth() == 0)
+    return;
 
-inline void
-GaugeVario::MakeAllPolygons() noexcept
-{
-  for (int i = gmin; i <= gmax; i++)
-    MakePolygon(i);
+  canvas.SetBackgroundColor(look.background_color);
+
+  const bool value_changed = dirty &&
+    !StringIsEqual(value_di.last_text, value_text);
+  const bool label_changed = dirty &&
+    !StringIsEqual(label_di.last_text, label);
+
+  if (!IsPersistent() || label_changed || value_changed) {
+    const int row_top = row.label_background.top;
+    const int row_bottom = row.label_background.bottom;
+
+    canvas.Select(look.label_font);
+    const PixelPoint label_position{
+      row.label_background.left,
+      RowTextBaselineY(look.label_font, row_top, row_bottom),
+    };
+
+    canvas.SetTextColor(look.dimmed_text_color);
+    canvas.Select(look.label_font);
+    if (IsPersistent()) {
+      canvas.DrawOpaqueText(label_position, row.label_background, label);
+      strcpy(label_di.last_text, label);
+    } else {
+      canvas.DrawText(label_position, label);
+    }
+
+    canvas.Select(look.value_font);
+    const unsigned value_width = canvas.CalcTextSize(value_text).width;
+    const PixelPoint value_position{
+      row.value_background.right - int(value_width),
+      RowTextBaselineY(look.value_font, row_top, row_bottom),
+    };
+
+    canvas.SetTextColor(value_color);
+    canvas.Select(look.value_font);
+    if (IsPersistent()) {
+      canvas.DrawOpaqueText(value_position, row.value_background, value_text);
+      strcpy(value_di.last_text, value_text);
+    } else {
+      canvas.DrawText(value_position, value_text);
+    }
+  }
 }
 
 void
@@ -395,293 +823,13 @@ GaugeVario::RenderClimb(Canvas &canvas) noexcept
                                look.background_color);
 }
 
-inline void
-GaugeVario::RenderZero(Canvas &canvas) noexcept
-{
-  if (look.inverse)
-    canvas.SelectWhitePen();
-  else
-    canvas.SelectBlackPen();
-
-  canvas.DrawLine({0, geometry.offset.y},
-                  {Layout::Scale(17), geometry.offset.y});
-  canvas.DrawLine({0, geometry.offset.y + 1},
-                  {Layout::Scale(17), geometry.offset.y + 1});
-}
-
-int
-GaugeVario::ValueToNeedlePos(double Value) noexcept
-{
-  constexpr double degrees_per_unit =
-    double(GAUGEVARIOSWEEP) / GAUGEVARIORANGE;
-
-  int i;
-
-  if (!needle_initialised){
-    MakeAllPolygons();
-    needle_initialised = true;
-  }
-
-
-  i = iround(Value * degrees_per_unit);
-  i = std::clamp(i, int(gmin), int(gmax));
-  return i;
-}
-
 void
-GaugeVario::RenderVarioLine(Canvas &canvas, int i, int sink,
-                            bool clear) noexcept
-{
-  dirty = true;
-  if (i == sink)
-    return;
-
-  canvas.Select(clear
-                ? look.thick_background_pen
-                : (i > sink ? look.thick_lift_pen : look.thick_sink_pen));
-
-  if (i > sink)
-    canvas.DrawPolyline(lines + gmax + sink, i - sink);
-  else
-    canvas.DrawPolyline(lines + gmax + i, sink - i);
-
-  if (!clear) {
-    canvas.SelectNullPen();
-
-    // clear up naked (sink) edge of polygon, this gives it a nice
-    // taper look
-    if (look.inverse) {
-      canvas.SelectBlackBrush();
-    } else {
-      canvas.SelectWhiteBrush();
-    }
-    canvas.DrawTriangleFan(getPolygon(sink), 3);
-  }
-}
-
-void
-GaugeVario::RenderNeedle(Canvas &canvas, int i, bool average,
-                         bool clear) noexcept
-{
-  dirty = true;
-
-  canvas.SelectNullPen();
-
-  // legacy behaviour
-  if (clear ^ look.inverse) {
-    canvas.SelectWhiteBrush();
-    canvas.SelectWhitePen();
-  } else {
-    canvas.SelectBlackBrush();
-    canvas.SelectBlackPen();
-  }
-
-  if (average)
-    canvas.DrawPolyline(getPolygon(i), 3);
-  else
-    canvas.DrawTriangleFan(getPolygon(i), 3);
-}
-
-// TODO code: Optimise vario rendering, this is slow
-void
-GaugeVario::RenderValue(Canvas &canvas, const LabelValueGeometry &g,
-                        LabelValueDrawInfo &di,
-                        double value, const char *label) noexcept
-{
-  value = (double)iround(value * 10) / 10; // prevent the -0.0 case
-
-  canvas.SetBackgroundTransparent();
-
-  if (!IsPersistent() || (dirty && !StringIsEqual(di.label.last_text, label))) {
-    canvas.SetTextColor(look.dimmed_text_color);
-    canvas.Select(look.label_font);
-    const unsigned width = canvas.CalcTextSize(label).width;
-
-    const PixelPoint text_position{g.label_right - (int)width, g.label_y};
-
-    if (IsPersistent()) {
-      PixelRect rc;
-      rc.left = text_position.x;
-      rc.top = g.label_top;
-      rc.right = g.label_right;
-      rc.bottom = g.label_bottom;
-
-      canvas.SetBackgroundColor(look.background_color);
-      canvas.DrawOpaqueText(text_position, rc, label);
-      di.label.last_width = width;
-      strcpy(di.label.last_text, label);
-    } else {
-      canvas.DrawText(text_position, label);
-    }
-  }
-
-  if (!IsPersistent() || (dirty && di.value.last_value != value)) {
-    const auto buffer = FmtBuffer<18>("{:.1f}", value);
-    canvas.SetBackgroundColor(look.background_color);
-    canvas.SetTextColor(look.text_color);
-    canvas.Select(look.value_font);
-    const unsigned width = canvas.CalcTextSize(buffer.c_str()).width;
-
-    const PixelPoint text_position{g.value_right - (int)width, g.value_y};
-
-    if (IsPersistent()) {
-      PixelRect rc;
-      rc.left = text_position.x;
-      rc.top = g.value_top;
-      rc.right = g.value_right;
-      rc.bottom = g.value_bottom;
-
-      canvas.DrawOpaqueText(text_position, rc, buffer.c_str());
-
-      di.value.last_width = width;
-      di.value.last_value = value;
-    } else {
-      canvas.DrawText(text_position, buffer.c_str());
-    }
-  }
-
-  if (!IsPersistent() ||
-      di.value.last_unit != Units::current.vertical_speed_unit) {
-    auto unit = di.value.last_unit = Units::current.vertical_speed_unit;
-
-    const int ascent_height = look.value_font.GetAscentHeight();
-    const int unit_height =
-      UnitSymbolRenderer::GetAscentHeight(look.unit_font, unit);
-
-    canvas.Select(look.unit_font);
-    canvas.SetTextColor(COLOR_GRAY);
-    UnitSymbolRenderer::Draw(canvas,
-                             PixelPoint(g.value_right,
-                                        g.value_y + ascent_height - unit_height),
-                             unit, look.unit_fraction_pen);
-  }
-}
-
-inline void
-GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
-{
-  if (!Basic().airspeed_available ||
-      !Basic().total_energy_vario_available)
-    return;
-
-  double v_diff;
-
-  const unsigned arrow_y_size = Layout::Scale(3);
-  const unsigned arrow_x_size = Layout::Scale(7);
-
-  const PixelRect rc = GetClientRect();
-
-  int nary = NARROWS * arrow_y_size;
-  int ytop = rc.top + YOFFSET + nary; // JMW
-  int ybottom = rc.bottom - YOFFSET - nary - Layout::FastScale(1);
-
-  ytop += Layout::Scale(14);
-  ybottom -= Layout::Scale(14);
-
-  x = rc.right - 2 * arrow_x_size;
-
-  // only draw speed command if flying and vario is not circling
-  if ((Calculated().flight.flying)
-      && (!Basic().gps.simulator || !Calculated().circling)) {
-    v_diff = Calculated().V_stf - Basic().indicated_airspeed;
-    v_diff = std::clamp(v_diff, -DELTA_V_LIMIT, DELTA_V_LIMIT); // limit it
-    v_diff = iround(v_diff/DELTA_V_STEP) * DELTA_V_STEP;
-  } else
-    v_diff = 0;
-
-  if (!IsPersistent() || last_v_diff != v_diff || dirty) {
-    last_v_diff = v_diff;
-
-    if (IsPersistent()) {
-      const unsigned height = nary + arrow_y_size + Layout::FastScale(2);
-
-      const PixelSize size{arrow_x_size * 2 + 1, height};
-
-      // bottom (too slow)
-      canvas.DrawFilledRectangle({{x, ybottom + YOFFSET}, size},
-                                 look.background_color);
-
-      // top (too fast)
-      canvas.DrawFilledRectangle({{x, ytop - YOFFSET + 1 - (int)height}, size},
-                                 look.background_color);
-    }
-
-    RenderClimb(canvas);
-
-    canvas.SelectNullPen();
-
-    if (look.colors) {
-      if (v_diff > 0) {
-        // too slow
-        canvas.Select(look.sink_brush);
-      } else {
-        canvas.Select(look.lift_brush);
-      }
-    } else {
-      if (look.inverse)
-        canvas.SelectWhiteBrush();
-      else
-        canvas.SelectBlackBrush();
-    }
-
-    if (v_diff > 0) {
-      // too slow
-      y = ybottom;
-      y += YOFFSET;
-
-      const PixelSize size{arrow_x_size * 2 + 1, arrow_y_size - 1};
-      while (v_diff > 0) {
-        if (v_diff > DELTA_V_STEP) {
-          canvas.DrawRectangle({{x, y}, size});
-        } else {
-          BulkPixelPoint arrow[3];
-          arrow[0].x = x;
-          arrow[0].y = y;
-          arrow[1].x = x + arrow_x_size;
-          arrow[1].y = y + arrow_y_size - 1;
-          arrow[2].x = x + 2 * arrow_x_size;
-          arrow[2].y = y;
-          canvas.DrawTriangleFan(arrow, 3);
-        }
-        v_diff -= DELTA_V_STEP;
-        y += arrow_y_size;
-      }
-    } else if (v_diff < 0) {
-      // too fast
-      y = ytop;
-      y -= YOFFSET;
-
-      const PixelSize size{arrow_x_size * 2 + 1, y - arrow_y_size + 1};
-      while (v_diff < 0) {
-        if (v_diff < -DELTA_V_STEP) {
-          canvas.DrawRectangle({{x, y + 1}, size});
-        } else {
-          BulkPixelPoint arrow[3];
-          arrow[0].x = x;
-          arrow[0].y = y;
-          arrow[1].x = x + arrow_x_size;
-          arrow[1].y = y - arrow_y_size + 1;
-          arrow[2].x = x + 2 * arrow_x_size;
-          arrow[2].y = y;
-          canvas.DrawTriangleFan(arrow, 3);
-        }
-        v_diff += DELTA_V_STEP;
-        y -= arrow_y_size;
-      }
-    }
-  }
-}
-
-inline void
 GaugeVario::RenderBallast(Canvas &canvas) noexcept
 {
   const GlidePolar &polar = GetGlidePolar();
-  const double ballast_fraction = polar.GetBallastFraction();
-  int ballast = iround(ballast_fraction * 100);
+  const int ballast = iround(polar.GetBallastFraction() * 100);
 
   if (!IsPersistent() || ballast != last_ballast) {
-    // ballast hase been changed
-
     canvas.Select(look.label_font);
 
     if (IsPersistent())
@@ -692,10 +840,8 @@ GaugeVario::RenderBallast(Canvas &canvas) noexcept
     const auto &g = geometry.ballast;
 
     if (IsPersistent() || last_ballast < 1 || ballast < 1) {
-      // new ballast is 0, hide label
       if (ballast > 0) {
         canvas.SetTextColor(look.dimmed_text_color);
-        // ols ballast was 0, show label
         if (IsPersistent())
           canvas.DrawOpaqueText(g.label_pos, g.label_rect, TEXT_BALLAST);
         else
@@ -704,7 +850,6 @@ GaugeVario::RenderBallast(Canvas &canvas) noexcept
         canvas.DrawFilledRectangle(g.label_rect, look.background_color);
     }
 
-    // new ballast 0, hide value
     if (ballast > 0) {
       const auto buffer = FmtBuffer<18>("{}%", ballast);
       canvas.SetTextColor(look.text_color);
@@ -724,9 +869,9 @@ GaugeVario::RenderBallast(Canvas &canvas) noexcept
 inline void
 GaugeVario::RenderBugs(Canvas &canvas) noexcept
 {
-  int bugs = iround((1 - GetComputerSettings().polar.bugs) * 100);
-  if (!IsPersistent() || bugs != last_bugs) {
+  const int bugs = iround((1 - GetComputerSettings().polar.bugs) * 100);
 
+  if (!IsPersistent() || bugs != last_bugs) {
     canvas.Select(look.label_font);
 
     if (IsPersistent())
@@ -766,14 +911,5 @@ void
 GaugeVario::OnResize(PixelSize new_size) noexcept
 {
   AntiFlickerWindow::OnResize(new_size);
-
-  geometry = {look, GetClientRect()};
-
-  /* trigger reinitialisation */
-  background_dirty = true;
-  needle_initialised = false;
-
-  average_di.Reset();
-  mc_di.Reset();
-  gross_di.Reset();
+  RecalculateGeometry();
 }

--- a/src/Gauge/GaugeVario.hpp
+++ b/src/Gauge/GaugeVario.hpp
@@ -4,27 +4,21 @@
 #pragma once
 
 #include "ui/window/AntiFlickerWindow.hpp"
-#include "ui/dim/BulkPoint.hpp"
+#include "ui/canvas/Color.hpp"
 #include "Blackboard/FullBlackboard.hpp"
-#include "Math/Point2D.hpp"
+#include "Math/Angle.hpp"
+#include "Renderer/VarioBarRenderer.hpp"
 
 struct VarioLook;
+struct VarioBarLook;
 class ContainerWindow;
 
+/**
+ * Vario gauge based on the Larus Breeze frontend
+ * (https://github.com/larus-breeze/sw_frontend_rs).
+ */
 class GaugeVario : public AntiFlickerWindow
 {
-  static constexpr unsigned NARROWS = 3;
-  static constexpr int YOFFSET = 36;
-
-  /** 5 m/s */
-  static constexpr int GAUGEVARIORANGE = 5;
-
-  /** degrees total sweep */
-  static constexpr int GAUGEVARIOSWEEP = 90;
-
-  static constexpr int gmax = GAUGEVARIOSWEEP + 2;
-  static constexpr int gmin = -gmax;
-
   struct BallastGeometry {
     PixelRect label_rect, value_rect;
     PixelPoint label_pos, value_pos;
@@ -41,22 +35,23 @@ class GaugeVario : public AntiFlickerWindow
     BugsGeometry(const VarioLook &look, const PixelRect &rc) noexcept;
   };
 
-  struct LabelValueGeometry {
-    int label_right, label_top, label_bottom, label_y;
-    int value_right, value_top, value_bottom, value_y;
-
-    LabelValueGeometry() = default;
-    LabelValueGeometry(const VarioLook &look, PixelPoint position) noexcept;
-
-    static unsigned GetHeight(const VarioLook &look) noexcept;
+  struct RowGeometry {
+    PixelRect label_background, value_background;
   };
 
   struct Geometry {
-    int nlength0, nlength1, nwidth, nline;
+    PixelRect content_rect;
 
-    PixelPoint offset;
+    PixelPoint dial_center;
+    unsigned outer_radius;
+    unsigned inner_radius;
+    unsigned inner_square_side;
+    unsigned inner_row_slot;
+    unsigned row_gap;
 
-    LabelValueGeometry average, gross, mc;
+    PixelRect speed_arrows_rect;
+
+    RowGeometry hero_row, gross_row, mc_row;
 
     BallastGeometry ballast;
     BugsGeometry bugs;
@@ -91,32 +86,28 @@ class GaugeVario : public AntiFlickerWindow
 
   const FullBlackboard &blackboard;
 
-  const VarioLook &look;
+  VarioLook &look;
+
+  VarioBarRenderer speed_bar_renderer;
 
   bool dirty = true;
 
   bool background_dirty = true;
-  bool needle_initialised = false;
 
-  LabelValueDrawInfo average_di, mc_di, gross_di;
-
-  int ival_av_last = 0;
-  int vval_last = 0;
-  int sval_last = 0;
-  int ival_last = 0;
-
-  double last_v_diff = 0;
+  LabelValueDrawInfo hero_di, gross_di, mc_di;
 
   int last_ballast = -1;
 
   int last_bugs = -1;
 
-  BulkPixelPoint polys[(gmax * 2 + 1) * 3];
-  BulkPixelPoint lines[gmax * 2 + 1];
+  unsigned cached_look_generation = 0;
+
+  unsigned cached_scale_title_font = 0;
 
 public:
   GaugeVario(const FullBlackboard &blackboard,
-             ContainerWindow &parent, const VarioLook &look,
+             ContainerWindow &parent, VarioLook &look,
+             const VarioBarLook &vario_bar_look,
              PixelRect rc, const WindowStyle style=WindowStyle()) noexcept;
 
 protected:
@@ -148,20 +139,19 @@ protected:
   virtual void OnPaintBuffer(Canvas &canvas) noexcept override;
 
 private:
+  void RecalculateGeometry() noexcept;
+  void LayoutValueColumn() noexcept;
+
   void RenderBackground(Canvas &canvas, const PixelRect &rc) noexcept;
-  void RenderZero(Canvas &canvas) noexcept;
-  void RenderValue(Canvas &canvas, const LabelValueGeometry &g,
-                   LabelValueDrawInfo &di,
-                   double Value, const char *Label) noexcept;
-  void RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept;
+  void RenderScale(Canvas &canvas) noexcept;
+  void RenderSpeedArrows(Canvas &canvas) noexcept;
+  void RenderNeedles(Canvas &canvas) noexcept;
+  void RenderInnerText(Canvas &canvas) noexcept;
+  void RenderRow(Canvas &canvas, const RowGeometry &row,
+                 DrawInfo &label_di, DrawInfo &value_di,
+                 const char *label, const char *value_text,
+                 Color value_color) noexcept;
   void RenderBallast(Canvas &canvas) noexcept;
   void RenderBugs(Canvas &canvas) noexcept;
-  int  ValueToNeedlePos(double Value) noexcept;
-  void RenderNeedle(Canvas &canvas, int i, bool average, bool clear) noexcept;
-  void RenderVarioLine(Canvas &canvas, int i, int sink, bool clear) noexcept;
   void RenderClimb(Canvas &canvas) noexcept;
-
-  void MakePolygon(const int i) noexcept;
-  void MakeAllPolygons() noexcept;
-  BulkPixelPoint *getPolygon(const int i) noexcept;
 };

--- a/src/Gauge/GaugeVario.hpp
+++ b/src/Gauge/GaugeVario.hpp
@@ -53,6 +53,11 @@ class GaugeVario : public AntiFlickerWindow
 
     RowGeometry hero_row, gross_row, mc_row;
 
+    PixelRect mc_mode_rect;
+    int mc_mode_center_x = 0;
+
+    PixelRect unit_rect;
+
     BallastGeometry ballast;
     BugsGeometry bugs;
 
@@ -96,6 +101,8 @@ class GaugeVario : public AntiFlickerWindow
 
   LabelValueDrawInfo hero_di, gross_di, mc_di;
 
+  DrawInfo mc_mode_di;
+
   int last_ballast = -1;
 
   int last_bugs = -1;
@@ -104,11 +111,19 @@ class GaugeVario : public AntiFlickerWindow
 
   unsigned cached_scale_title_font = 0;
 
+  bool debug_overlay = false;
+
 public:
   GaugeVario(const FullBlackboard &blackboard,
              ContainerWindow &parent, VarioLook &look,
              const VarioBarLook &vario_bar_look,
              PixelRect rc, const WindowStyle style=WindowStyle()) noexcept;
+
+  /** Layout debug overlay for #RunGaugeVarioRenderer only. */
+  void SetDebugOverlay(bool enable) noexcept {
+    debug_overlay = enable;
+    Invalidate();
+  }
 
 protected:
   const MoreData &Basic() const noexcept {
@@ -141,12 +156,16 @@ protected:
 private:
   void RecalculateGeometry() noexcept;
   void LayoutValueColumn() noexcept;
+  void LayoutScaleUnit() noexcept;
+  void LayoutMcModeHint() noexcept;
 
   void RenderBackground(Canvas &canvas, const PixelRect &rc) noexcept;
   void RenderScale(Canvas &canvas) noexcept;
   void RenderSpeedArrows(Canvas &canvas) noexcept;
   void RenderNeedles(Canvas &canvas) noexcept;
   void RenderInnerText(Canvas &canvas) noexcept;
+  void RenderMcModeHint(Canvas &canvas) noexcept;
+  void RenderUnit(Canvas &canvas) noexcept;
   void RenderRow(Canvas &canvas, const RowGeometry &row,
                  DrawInfo &label_di, DrawInfo &value_di,
                  const char *label, const char *value_text,
@@ -154,4 +173,5 @@ private:
   void RenderBallast(Canvas &canvas) noexcept;
   void RenderBugs(Canvas &canvas) noexcept;
   void RenderClimb(Canvas &canvas) noexcept;
+  void DrawDebugOverlay(Canvas &canvas) const noexcept;
 };

--- a/src/Gauge/GlueGaugeVario.cpp
+++ b/src/Gauge/GlueGaugeVario.cpp
@@ -13,7 +13,7 @@ GlueGaugeVario::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   style.Disable();
 
   SetWindow(std::make_unique<GaugeVario>(blackboard, parent, look,
-                                         rc, style));
+                                         vario_bar_look, rc, style));
 }
 
 void

--- a/src/Gauge/GlueGaugeVario.hpp
+++ b/src/Gauge/GlueGaugeVario.hpp
@@ -7,6 +7,7 @@
 #include "Blackboard/BlackboardListener.hpp"
 
 struct VarioLook;
+struct VarioBarLook;
 class LiveBlackboard;
 
 /**
@@ -16,11 +17,13 @@ class LiveBlackboard;
 class GlueGaugeVario final
   : public WindowWidget, private NullBlackboardListener {
   LiveBlackboard &blackboard;
-  const VarioLook &look;
+  VarioLook &look;
+  const VarioBarLook &vario_bar_look;
 
 public:
-  GlueGaugeVario(LiveBlackboard &_blackboard, const VarioLook &_look) noexcept
-    :blackboard(_blackboard), look(_look) {}
+  GlueGaugeVario(LiveBlackboard &_blackboard, VarioLook &_look,
+                 const VarioBarLook &_vario_bar_look) noexcept
+    :blackboard(_blackboard), look(_look), vario_bar_look(_vario_bar_look) {}
 
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Show(const PixelRect &rc) noexcept override;

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -96,5 +96,7 @@ Look::ReinitialiseLayout(unsigned infobox_width, unsigned scale_title_font)
   dialog.LoadFonts();
 
   info_box.ReinitialiseLayout(infobox_width, scale_title_font);
-  vario.ReinitialiseLayout(infobox_width);
+  vario.ReinitialiseLayout(infobox_width, scale_title_font,
+                           std::max(1u, infobox_width / 2u), 32,
+                           Layout::Scale(8));
 }

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -108,9 +108,9 @@ VarioLook::Initialise(bool _inverse, bool _colors,
 
   accent[0] = COLOR_GRAY;
   if (HasColors() && colors) {
-    accent[1] = inverse ? COLOR_INVERSE_RED : COLOR_INFOBOX_RED;
-    accent[2] = inverse ? COLOR_INFOBOX_BLUE_INVERSE : COLOR_INFOBOX_BLUE;
-    accent[3] = inverse ? COLOR_INFOBOX_GREEN_INVERSE : COLOR_INFOBOX_GREEN;
+    accent[1] = inverse ? COLOR_INVERSE_RED : COLOR_RED;
+    accent[2] = inverse ? COLOR_INVERSE_BLUE : COLOR_BLUE;
+    accent[3] = inverse ? COLOR_INVERSE_GREEN : COLOR_LIGHT_GREEN;
     accent[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_YELLOW;
     accent[5] = inverse ? COLOR_INVERSE_MAGENTA : COLOR_MAGENTA;
   } else

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -37,7 +37,7 @@ ComputeVarioRowFontHeights(unsigned text_width, unsigned row_slot,
   const unsigned value_column_w =
     std::max(1u, text_width - label_column_w);
   const unsigned value_budget = std::max(1u,
-    value_column_w * VarioLook::INNER_ROW_FONT_PERCENT / 100u);
+    value_column_w * VarioLook::INNER_VALUE_FONT_PERCENT / 100u);
   const unsigned label_budget = std::max(1u,
     label_column_w * VarioLook::INNER_ROW_FONT_PERCENT / 100u);
   const unsigned clamped_scale = std::clamp(scale_title_font, 50u, 150u);
@@ -79,7 +79,7 @@ VarioLook::Initialise(bool _inverse, bool _colors,
   text_font = &_text_font;
 
   if (inverse) {
-    background_color = COLOR_BLACK;
+    background_color = COLOR_DARK_THEME_BACKGROUND;
     text_color = COLOR_WHITE;
     dimmed_text_color = Color(0xa0, 0xa0, 0xa0);
     sink_color = Color(0xc4, 0x80, 0x1e);
@@ -151,6 +151,16 @@ VarioLook::ReinitialiseLayout(unsigned /*panel_width*/,
                std::max(6u, arc_label_width), "5");
   arc_label_font.Load(small_value_font_d);
 
+  FontDescription scale_unit_font_d(std::max(6u,
+    arc_label_font.GetCapitalHeight() * SCALE_UNIT_FONT_PERCENT / 100u));
+  AutoSizeFont(scale_unit_font_d,
+               std::max(6u, arc_label_width), "m/s");
+  scale_unit_font_d.SetHeight(std::max(scale_unit_font_d.GetHeight(),
+    arc_label_font.GetCapitalHeight() * SCALE_UNIT_FONT_PERCENT / 100u));
+  scale_unit_font.Load(scale_unit_font_d);
+
+  hint_font.Load(FontDescription(std::max(6u, heights.label_height / 2u)));
+
   const unsigned unit_font_height =
     std::max(heights.value_height * 2u / 5u, 7u);
   unit_font.Load(FontDescription(unit_font_height));
@@ -159,4 +169,27 @@ VarioLook::ReinitialiseLayout(unsigned /*panel_width*/,
 #ifdef HAVE_TEXT_CACHE
   TextCache::Flush();
 #endif
+}
+
+void
+VarioLook::FitHintFont(unsigned max_height, unsigned max_width) noexcept
+{
+  if (max_height < 6 || max_width < 6) {
+    hint_font.Load(FontDescription(6));
+    return;
+  }
+
+  const unsigned cap = std::min(max_height,
+    std::max(6u, label_font.GetCapitalHeight() * HINT_FONT_PERCENT / 100u));
+  unsigned height = cap;
+
+  while (height >= 6) {
+    hint_font.Load(FontDescription(height));
+    if (hint_font.TextSize("Vario").width <= max_width)
+      break;
+    --height;
+  }
+
+  if (height < 6)
+    hint_font.Load(FontDescription(6));
 }

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -2,11 +2,12 @@
 // Copyright The XCSoar Project
 
 #include "VarioLook.hpp"
+#include "Colors.hpp"
+#include "Asset.hpp"
 #include "AutoFont.hpp"
 #include "FontDescription.hpp"
 #include "Resources.hpp"
 #include "Screen/Layout.hpp"
-#include "Units/Units.hpp"
 #include "ui/canvas/Features.hpp" // for HAVE_TEXT_CACHE
 
 #ifdef HAVE_TEXT_CACHE
@@ -15,6 +16,59 @@
 
 #include <algorithm>
 
+namespace {
+
+static constexpr const char *const VARIO_LABEL_PROBE = "Gross";
+static constexpr const char *const VARIO_VALUE_PROBE = "+99.9";
+
+struct VarioRowFontHeights {
+  unsigned value_height;
+  unsigned label_height;
+};
+
+/** Value font fills the row slot; label font is smaller in a narrow column. */
+[[gnu::pure]]
+static VarioRowFontHeights
+ComputeVarioRowFontHeights(unsigned text_width, unsigned row_slot,
+                           unsigned scale_title_font) noexcept
+{
+  const unsigned label_column_w = std::max(1u,
+    text_width * VarioLook::INNER_ROW_LABEL_WIDTH_PERCENT / 100u);
+  const unsigned value_column_w =
+    std::max(1u, text_width - label_column_w);
+  const unsigned value_budget = std::max(1u,
+    value_column_w * VarioLook::INNER_ROW_FONT_PERCENT / 100u);
+  const unsigned label_budget = std::max(1u,
+    label_column_w * VarioLook::INNER_ROW_FONT_PERCENT / 100u);
+  const unsigned clamped_scale = std::clamp(scale_title_font, 50u, 150u);
+  const unsigned desired_value = std::max(6u, row_slot * clamped_scale / 100u);
+
+  unsigned value_height = std::min(row_slot, desired_value);
+  Font value_font;
+  while (value_height > 6) {
+    value_font.Load(FontDescription(value_height, true));
+    if (value_font.TextSize(VARIO_VALUE_PROBE).width <= value_budget)
+      break;
+    --value_height;
+  }
+
+  const unsigned label_cap = std::max(6u,
+    value_height * VarioLook::INNER_LABEL_FONT_PERCENT / 100u);
+  unsigned label_height = std::min(row_slot, label_cap);
+  Font label_font;
+  while (label_height > 6) {
+    label_font.Load(FontDescription(label_height));
+    if (label_font.TextSize(VARIO_LABEL_PROBE).width <= label_budget)
+      break;
+    --label_height;
+  }
+  label_height = std::min(label_height, value_height);
+
+  return {value_height, label_height};
+}
+
+} // namespace
+
 void
 VarioLook::Initialise(bool _inverse, bool _colors,
                       unsigned width,
@@ -22,6 +76,7 @@ VarioLook::Initialise(bool _inverse, bool _colors,
 {
   inverse = _inverse;
   colors = _colors;
+  text_font = &_text_font;
 
   if (inverse) {
     background_color = COLOR_BLACK;
@@ -33,23 +88,36 @@ VarioLook::Initialise(bool _inverse, bool _colors,
     background_color = COLOR_WHITE;
     text_color = COLOR_BLACK;
     dimmed_text_color = Color((uint8_t)~0xa0, (uint8_t)~0xa0, (uint8_t)~0xa0);
-    sink_color = Color(0xa3,0x69,0x0d);
-    lift_color = Color(0x19,0x94,0x03);
+    sink_color = Color(0xa3, 0x69, 0x0d);
+    lift_color = Color(0x19, 0x94, 0x03);
   }
 
+  background_brush.Create(background_color);
   sink_brush.Create(sink_color);
   lift_brush.Create(lift_color);
 
   arc_pen.Create(Layout::ScalePenWidth(2), text_color);
-  tick_pen.Create(Layout::ScalePenWidth(1), text_color);
+  tick_pen.Create(Layout::ScalePenWidth(1), dimmed_text_color);
 
   thick_background_pen.Create(Layout::Scale(5), background_color);
   thick_sink_pen.Create(Layout::Scale(5), sink_color);
   thick_lift_pen.Create(Layout::Scale(5), lift_color);
 
-  climb_bitmap.Load(inverse ? IDB_CLIMBSMALLINV : IDB_CLIMBSMALL);
+  scale_face_color = inverse ? COLOR_WHITE : COLOR_BLACK;
+  scale_ink_color = inverse ? COLOR_BLACK : COLOR_WHITE;
 
-  text_font = &_text_font;
+  accent[0] = COLOR_GRAY;
+  if (HasColors() && colors) {
+    accent[1] = inverse ? COLOR_INVERSE_RED : COLOR_INFOBOX_RED;
+    accent[2] = inverse ? COLOR_INFOBOX_BLUE_INVERSE : COLOR_INFOBOX_BLUE;
+    accent[3] = inverse ? COLOR_INFOBOX_GREEN_INVERSE : COLOR_INFOBOX_GREEN;
+    accent[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_YELLOW;
+    accent[5] = inverse ? COLOR_INVERSE_MAGENTA : COLOR_MAGENTA;
+  } else
+    std::fill(accent + 1, accent + 6,
+              inverse ? COLOR_WHITE : COLOR_BLACK);
+
+  climb_bitmap.Load(inverse ? IDB_CLIMBSMALLINV : IDB_CLIMBSMALL);
 
   ReinitialiseLayout(width);
 }
@@ -57,22 +125,36 @@ VarioLook::Initialise(bool _inverse, bool _colors,
 void
 VarioLook::ReinitialiseLayout(unsigned width)
 {
-  FontDescription arc_label_font_d(8);
-  AutoSizeFont(arc_label_font_d, width / 10, "-5");
-  arc_label_font.Load(arc_label_font_d);
+  ReinitialiseLayout(width, 100, std::max(1u, width / 2u), 32,
+                      Layout::Scale(8));
+}
 
-  FontDescription value_font_d(14);
-  AutoSizeFont(value_font_d, width / 1.5, "-00.0m");
-  value_font.Load(value_font_d);
+void
+VarioLook::ReinitialiseLayout(unsigned /*panel_width*/,
+                              unsigned scale_title_font,
+                              unsigned text_column_width,
+                              unsigned max_row_height,
+                              unsigned arc_label_width) noexcept
+{
+  ++layout_generation;
 
-  FontDescription unit_font_d(8);
-  AutoSizeFont(unit_font_d, width / 4.22, "00.0m");
-  unit_font.Load(unit_font_d);
-  unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), COLOR_GRAY);
+  const unsigned text_width = std::max(1u, text_column_width);
+  const unsigned row_slot = std::max(1u, max_row_height);
+  const VarioRowFontHeights heights =
+    ComputeVarioRowFontHeights(text_width, row_slot, scale_title_font);
 
-  FontDescription label_font_d(8);
-  AutoSizeFont(label_font_d, width / 2, "Auto MC");
-  label_font.Load(label_font_d);
+  label_font.Load(FontDescription(heights.label_height));
+  value_font.Load(FontDescription(heights.value_height, true));
+
+  FontDescription small_value_font_d(10);
+  AutoSizeFont(small_value_font_d,
+               std::max(6u, arc_label_width), "5");
+  arc_label_font.Load(small_value_font_d);
+
+  const unsigned unit_font_height =
+    std::max(heights.value_height * 2u / 5u, 7u);
+  unit_font.Load(FontDescription(unit_font_height));
+  unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), text_color);
 
 #ifdef HAVE_TEXT_CACHE
   TextCache::Flush();

--- a/src/Look/VarioLook.hpp
+++ b/src/Look/VarioLook.hpp
@@ -26,6 +26,8 @@ struct VarioLook {
 
   Pen arc_pen, tick_pen;
   Font arc_label_font;
+  Font scale_unit_font;
+  Font hint_font;
 
   Brush background_brush;
   Brush sink_brush, lift_brush;
@@ -54,8 +56,17 @@ struct VarioLook {
   /** Extra width budget when fitting inner row fonts (110 = 10% larger). */
   static constexpr unsigned INNER_ROW_FONT_PERCENT = 110;
 
+  /** Extra width budget for inner value column (MC, Gross, Net.). */
+  static constexpr unsigned INNER_VALUE_FONT_PERCENT = 130;
+
   /** Label font height as % of value font height. */
   static constexpr unsigned INNER_LABEL_FONT_PERCENT = 72;
+
+  /** Scale unit label height as % of #arc_label_font height. */
+  static constexpr unsigned SCALE_UNIT_FONT_PERCENT = 78;
+
+  /** MC mode hint max height as % of #label_font when space allows. */
+  static constexpr unsigned HINT_FONT_PERCENT = 100;
 
   void Initialise(bool inverse, bool colors,
                   unsigned width,
@@ -67,4 +78,7 @@ struct VarioLook {
                           unsigned text_column_width,
                           unsigned max_row_height,
                           unsigned arc_label_width) noexcept;
+
+  /** Size #hint_font to fit the MC mode strip; does not bump #layout_generation. */
+  void FitHintFont(unsigned max_height, unsigned max_width) noexcept;
 };

--- a/src/Look/VarioLook.hpp
+++ b/src/Look/VarioLook.hpp
@@ -18,9 +18,16 @@ struct VarioLook {
 
   Color sink_color, lift_color;
 
+  /** Infobox palette — same indices as #InfoBoxLook::colors. */
+  Color accent[6];
+
+  Color scale_face_color;
+  Color scale_ink_color;
+
   Pen arc_pen, tick_pen;
   Font arc_label_font;
 
+  Brush background_brush;
   Brush sink_brush, lift_brush;
 
   Pen thick_background_pen, thick_sink_pen, thick_lift_pen;
@@ -35,9 +42,29 @@ struct VarioLook {
 
   Font label_font;
 
+  /** Incremented by ReinitialiseLayout(); gauge uses this to detect font changes. */
+  unsigned layout_generation = 0;
+
+  /** Inner text area width as % of inscribed square (trimmed from the right). */
+  static constexpr unsigned INNER_TEXT_WIDTH_PERCENT = 85;
+
+  /** Label column as % of inner text area width (remainder is values). */
+  static constexpr unsigned INNER_ROW_LABEL_WIDTH_PERCENT = 38;
+
+  /** Extra width budget when fitting inner row fonts (110 = 10% larger). */
+  static constexpr unsigned INNER_ROW_FONT_PERCENT = 110;
+
+  /** Label font height as % of value font height. */
+  static constexpr unsigned INNER_LABEL_FONT_PERCENT = 72;
+
   void Initialise(bool inverse, bool colors,
                   unsigned width,
                   const Font &text_font);
 
   void ReinitialiseLayout(unsigned width);
+
+  void ReinitialiseLayout(unsigned panel_width, unsigned scale_title_font,
+                          unsigned text_column_width,
+                          unsigned max_row_height,
+                          unsigned arc_label_width) noexcept;
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -464,7 +464,7 @@ MainWindow::ReinitialiseLayout_vario(const InfoBoxLayout::Layout &layout) noexce
 
   if (!vario.IsDefined())
     vario.Set(new GlueGaugeVario(CommonInterface::GetLiveBlackboard(),
-                                 look->vario));
+                                 look->vario, look->vario_bar));
 
   vario.Move(layout.vario);
   vario.Show();

--- a/src/Renderer/GradientRenderer.cpp
+++ b/src/Renderer/GradientRenderer.cpp
@@ -2,12 +2,245 @@
 // Copyright The XCSoar Project
 
 #include "GradientRenderer.hpp"
+#include "Asset.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "Math/Angle.hpp"
+#include "Math/FastMath.hpp"
+#include "Math/Point2D.hpp"
+#include "util/Macros.hpp"
+
+#include <algorithm>
+
+[[gnu::const]]
+static Color
+BlendTowardFace(Color shadow, Color face,
+                unsigned step, unsigned steps) noexcept
+{
+  if (steps <= 1 || step >= steps - 1)
+    return step >= steps - 1 ? face : shadow;
+
+#ifdef GREYSCALE
+  const uint8_t l = shadow.GetLuminosity()
+    + (int(face.GetLuminosity()) - int(shadow.GetLuminosity()))
+      * int(step) / int(steps - 1);
+  return Color(l);
+#else
+  const uint8_t r = shadow.Red()
+    + (int(face.Red()) - int(shadow.Red()))
+      * int(step) / int(steps - 1);
+  const uint8_t g = shadow.Green()
+    + (int(face.Green()) - int(shadow.Green()))
+      * int(step) / int(steps - 1);
+  const uint8_t b = shadow.Blue()
+    + (int(face.Blue()) - int(shadow.Blue()))
+      * int(step) / int(steps - 1);
+  return Color(r, g, b);
+#endif
+}
 
 #if defined(EYE_CANDY) && defined(ENABLE_OPENGL)
 
+#include "ui/canvas/opengl/Shaders.hpp"
+#include "ui/canvas/opengl/Program.hpp"
 #include "ui/canvas/opengl/VertexPointer.hpp"
-#include "util/Macros.hpp"
+#include "ui/canvas/opengl/Color.hpp"
+#include "util/AllocatedArray.hxx"
+#include "util/StaticArray.hxx"
+
+static constexpr unsigned CIRCLE_SEGS = 64;
+static constexpr unsigned MAX_ARC_ANGLES = CIRCLE_SEGS + 2;
+static constexpr unsigned GL_RINGS = 24;
+
+[[gnu::const]]
+static PixelPoint
+CirclePoint(int radius, unsigned angle) noexcept
+{
+  assert(angle < ISINETABLE.size());
+
+  return PixelPoint(ISINETABLE[angle] * radius / 1024,
+                    -ISINETABLE[(angle + INT_QUARTER_CIRCLE) & INT_ANGLE_MASK] * radius / 1024);
+}
+
+[[gnu::const]]
+static PixelPoint
+CirclePoint(PixelPoint p, int radius, unsigned angle) noexcept
+{
+  return p + CirclePoint(radius, angle);
+}
+
+/** Collect arc sample angles (same spacing as Canvas::DrawAnnulus). */
+static unsigned
+CollectArcAngles(unsigned istart, unsigned iend,
+                 StaticArray<unsigned, MAX_ARC_ANGLES> &angles) noexcept
+{
+  angles.clear();
+  angles.push_back(istart);
+
+  const unsigned ilast = istart < iend ? iend : iend + INT_ANGLE_RANGE;
+  for (unsigned i = istart + INT_ANGLE_RANGE / CIRCLE_SEGS; i < ilast;
+       i += INT_ANGLE_RANGE / CIRCLE_SEGS) {
+    const unsigned angle = i & INT_ANGLE_MASK;
+    if (angles.back() != angle)
+      angles.push_back(angle);
+  }
+
+  if (angles.back() != iend)
+    angles.push_back(iend);
+
+  return angles.size();
+}
+
+[[gnu::const]]
+static Color
+ShadowColorAtRadius(unsigned radius, unsigned inner_radius,
+                    unsigned outer_radius, Color shadow, Color face,
+                    unsigned fade_depth) noexcept
+{
+  const unsigned edge_dist = std::min(radius - inner_radius,
+                                      outer_radius - radius);
+  if (edge_dist >= fade_depth)
+    return face;
+
+  return BlendTowardFace(shadow, face, edge_dist, fade_depth);
+}
+
+/**
+ * Radial vertex-colour gradient on an annulus arc using a regular quad mesh.
+ * Only the fade zones should be drawn — not the full band centre.
+ */
+static void
+DrawAnnulusShadowGradientMesh(PixelPoint center,
+                              unsigned mesh_inner, unsigned mesh_outer,
+                              unsigned band_inner, unsigned band_outer,
+                              Angle arc_start, Angle arc_end,
+                              Color face_color, Color shadow,
+                              unsigned fade_depth) noexcept
+{
+  if (mesh_outer <= mesh_inner)
+    return;
+
+  const int istart = NATIVE_TO_INT(arc_start.Native());
+  const int iend = NATIVE_TO_INT(arc_end.Native());
+
+  StaticArray<unsigned, MAX_ARC_ANGLES> angles;
+  const unsigned n_angles = CollectArcAngles(istart, iend, angles);
+  if (n_angles < 2)
+    return;
+
+  const unsigned band = mesh_outer - mesh_inner;
+  const unsigned n_rings = std::min(GL_RINGS, std::max(2u, band)) + 1;
+  const unsigned n_vertices = n_rings * n_angles;
+  if (n_vertices < 4)
+    return;
+
+  static AllocatedArray<BulkPixelPoint> vertices;
+  static AllocatedArray<Color> colors;
+  static AllocatedArray<GLushort> indices;
+
+  vertices.GrowDiscard(n_vertices);
+  colors.GrowDiscard(n_vertices);
+
+  for (unsigned r = 0; r < n_rings; ++r) {
+    const unsigned radius = mesh_inner + band * r / (n_rings - 1);
+    const Color color = ShadowColorAtRadius(radius, band_inner, band_outer,
+                                            shadow, face_color, fade_depth);
+
+    for (unsigned a = 0; a < n_angles; ++a) {
+      const unsigned idx = r * n_angles + a;
+      vertices[idx] = CirclePoint(center, int(radius), angles[a]);
+      colors[idx] = color;
+    }
+  }
+
+  const unsigned n_strip_quads = (n_rings - 1) * (n_angles - 1);
+  const unsigned idx_count = n_strip_quads * 6;
+  indices.GrowDiscard(idx_count);
+
+  unsigned ii = 0;
+  for (unsigned r = 0; r + 1 < n_rings; ++r) {
+    for (unsigned a = 0; a + 1 < n_angles; ++a) {
+      const GLushort i0 = GLushort(r * n_angles + a);
+      const GLushort i1 = GLushort(r * n_angles + a + 1);
+      const GLushort i2 = GLushort((r + 1) * n_angles + a + 1);
+      const GLushort i3 = GLushort((r + 1) * n_angles + a);
+
+      indices[ii++] = i0;
+      indices[ii++] = i1;
+      indices[ii++] = i2;
+      indices[ii++] = i0;
+      indices[ii++] = i2;
+      indices[ii++] = i3;
+    }
+  }
+
+  OpenGL::solid_shader->Use();
+
+  const ScopeVertexPointer vp(vertices.data());
+  const ScopeColorPointer cp(colors.data());
+
+  glDrawElements(GL_TRIANGLES, idx_count, GL_UNSIGNED_SHORT, indices.data());
+}
+
+static void
+DrawAnnulusEdgeShadowFadeGL(PixelPoint center,
+                            unsigned inner_radius, unsigned outer_radius,
+                            Angle arc_start, Angle arc_end,
+                            Color face_color, Color shadow,
+                            unsigned fade_depth) noexcept
+{
+  DrawAnnulusShadowGradientMesh(center, inner_radius,
+                                inner_radius + fade_depth,
+                                inner_radius, outer_radius,
+                                arc_start, arc_end,
+                                face_color, shadow, fade_depth);
+
+  if (fade_depth * 2 >= outer_radius - inner_radius)
+    return;
+
+  DrawAnnulusShadowGradientMesh(center, outer_radius - fade_depth,
+                                outer_radius,
+                                inner_radius, outer_radius,
+                                arc_start, arc_end,
+                                face_color, shadow, fade_depth);
+}
+
+#endif
+
+#if !defined(EYE_CANDY) || !defined(ENABLE_OPENGL)
+
+static void
+DrawAnnulusEdgeShadowFadeBanded(Canvas &canvas, PixelPoint center,
+                                unsigned inner_radius, unsigned outer_radius,
+                                Angle arc_start, Angle arc_end,
+                                Color face_color, Color shadow,
+                                unsigned fade_depth) noexcept
+{
+  static constexpr unsigned MAX_STEPS = 4;
+  const unsigned steps = std::min(MAX_STEPS, fade_depth);
+
+  canvas.SelectNullPen();
+
+  for (unsigned i = 0; i < steps; ++i) {
+    const unsigned r0 = inner_radius + i * fade_depth / steps;
+    const unsigned r1 = inner_radius + (i + 1) * fade_depth / steps;
+    if (r1 <= r0)
+      continue;
+
+    canvas.Select(Brush(BlendTowardFace(shadow, face_color, i, steps)));
+    canvas.DrawAnnulus(center, r0, r1, arc_start, arc_end);
+  }
+
+  for (unsigned i = 0; i < steps; ++i) {
+    const unsigned r1 = outer_radius - i * fade_depth / steps;
+    const unsigned r0 = outer_radius - (i + 1) * fade_depth / steps;
+    if (r1 <= r0)
+      continue;
+
+    canvas.Select(Brush(BlendTowardFace(shadow, face_color, i, steps)));
+    canvas.DrawAnnulus(center, r0, r1, arc_start, arc_end);
+  }
+}
 
 #endif
 
@@ -77,4 +310,32 @@ DrawBandedVerticalGradient(Canvas &canvas, const PixelRect &rc,
                                Color(r, g, b));
 #endif
   }
+}
+
+void
+DrawAnnulusEdgeShadowFade([[maybe_unused]] Canvas &canvas, PixelPoint center,
+                          unsigned inner_radius, unsigned outer_radius,
+                          Angle arc_start, Angle arc_end,
+                          Color face_color) noexcept
+{
+  const unsigned band = outer_radius - inner_radius;
+  if (band < 2)
+    return;
+
+  static constexpr unsigned SHADOW_FADE_BAND_PERCENT = 22;
+  const unsigned fade_depth = band * SHADOW_FADE_BAND_PERCENT / 100;
+  if (fade_depth == 0)
+    return;
+
+  const Color shadow = IsDithered() ? COLOR_BLACK : DarkColor(face_color);
+
+#if defined(EYE_CANDY) && defined(ENABLE_OPENGL)
+  DrawAnnulusEdgeShadowFadeGL(center, inner_radius, outer_radius,
+                              arc_start, arc_end, face_color, shadow,
+                              fade_depth);
+#else
+  DrawAnnulusEdgeShadowFadeBanded(canvas, center, inner_radius, outer_radius,
+                                  arc_start, arc_end, face_color, shadow,
+                                  fade_depth);
+#endif
 }

--- a/src/Renderer/GradientRenderer.hpp
+++ b/src/Renderer/GradientRenderer.hpp
@@ -3,9 +3,11 @@
 
 #pragma once
 
+class Angle;
 class Canvas;
 struct PixelRect;
 class Color;
+struct PixelPoint;
 
 /**
  * Fill the specified rectangle with a color gradient.
@@ -25,3 +27,13 @@ void DrawVerticalGradient(Canvas &canvas, const PixelRect &rc,
  */
 void DrawBandedVerticalGradient(Canvas &canvas, const PixelRect &rc,
                                 Color top_color, Color bottom_color);
+
+/**
+ * Sunken shadow on both edges of an annulus arc, fading toward the centre.
+ * Uses smooth OpenGL vertex colours when EYE_CANDY is enabled; otherwise
+ * banded Canvas::DrawAnnulus() strips.
+ */
+void DrawAnnulusEdgeShadowFade(Canvas &canvas, PixelPoint center,
+                               unsigned inner_radius, unsigned outer_radius,
+                               Angle arc_start, Angle arc_end,
+                               Color face_color) noexcept;

--- a/src/Renderer/VarioBarRenderer.cpp
+++ b/src/Renderer/VarioBarRenderer.cpp
@@ -10,6 +10,9 @@
 #include "Look/VarioBarLook.hpp"
 #include "Formatter/UserUnits.hpp"
 
+#include <algorithm>
+#include <cmath>
+
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
 #endif
@@ -213,4 +216,84 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
     TextInBox(canvas, Value, {rc.right, y0}, style, rc);
   } else
     TextInBox(canvas, Value, {rc.right - Layout::Scale(18), y0}, style, rc);
+}
+
+void
+VarioBarRenderer::DrawSpeedToFly(Canvas &canvas, const PixelRect &rc,
+                                 const MoreData &basic,
+                                 const DerivedInfo &calculated,
+                                 unsigned max_bar_half_length,
+                                 Color pull_color, Color push_color) const
+{
+  if (!basic.airspeed_available || !calculated.flight.flying)
+    return;
+
+  const unsigned min_w = Layout::Scale(4u);
+  const unsigned min_h = Layout::Scale(8u);
+  if (rc.GetWidth() < min_w || rc.GetHeight() < min_h)
+    return;
+
+  double speed_cmd = basic.indicated_airspeed - calculated.V_stf;
+  speed_cmd = std::clamp(speed_cmd, -5.0, 5.0);
+
+  const int cx = (rc.left + rc.right) / 2;
+  const int y0 = (rc.top + rc.bottom) / 2;
+
+  const int tri_h = Layout::Scale(5);
+  const int bar_half_w = std::max(1, int(rc.GetWidth()) / 2);
+  const int tri_half_w = bar_half_w;
+  const int center_tick = std::max(2, int(rc.GetHeight()) / 12);
+
+  const int max_half = max_bar_half_length > 0
+    ? int(max_bar_half_length)
+    : int(rc.GetHeight()) / 2;
+  const int max_shaft = std::max(0, max_half - tri_h - center_tick / 2);
+
+  canvas.Select(look.pen_mc);
+  canvas.DrawLine({cx, y0 - center_tick}, {cx, y0 + center_tick});
+
+  if (std::abs(speed_cmd) < 0.05)
+    return;
+
+  const double magnitude = std::abs(speed_cmd) / 5.0;
+  const int bar_length = std::max(0, int(max_shaft * magnitude + 0.5));
+  if (bar_length < 1)
+    return;
+
+  const bool pull_up = speed_cmd > 0;
+  const Color fill = pull_up ? pull_color : push_color;
+  canvas.Select(Brush(fill));
+  canvas.Select(Pen(Layout::ScaleFinePenWidth(1), fill));
+
+  if (pull_up) {
+    const int shaft_top = y0 - bar_length;
+    canvas.DrawFilledRectangle({
+      cx - bar_half_w,
+      shaft_top,
+      cx + bar_half_w,
+      y0,
+    }, fill);
+
+    const BulkPixelPoint tri[] = {
+      { cx - tri_half_w, shaft_top },
+      { cx, shaft_top - tri_h },
+      { cx + tri_half_w, shaft_top },
+    };
+    canvas.DrawPolygon(tri, 3);
+  } else {
+    const int shaft_bottom = y0 + bar_length;
+    canvas.DrawFilledRectangle({
+      cx - bar_half_w,
+      y0,
+      cx + bar_half_w,
+      shaft_bottom,
+    }, fill);
+
+    const BulkPixelPoint tri[] = {
+      { cx - tri_half_w, shaft_bottom },
+      { cx, shaft_bottom + tri_h },
+      { cx + tri_half_w, shaft_bottom },
+    };
+    canvas.DrawPolygon(tri, 3);
+  }
 }

--- a/src/Renderer/VarioBarRenderer.hpp
+++ b/src/Renderer/VarioBarRenderer.hpp
@@ -6,6 +6,7 @@
 struct MoreData;
 struct PixelRect;
 class Canvas;
+struct Color;
 struct DerivedInfo;
 struct VarioBarLook;
 class GlidePolar;
@@ -26,4 +27,11 @@ public:
             const DerivedInfo &calculated,
             const GlidePolar &glide_polar,
             const bool vario_bar_avg_enabled) const;
+
+  /** Speed-to-fly push/pull bar for the panel variometer margin strip. */
+  void DrawSpeedToFly(Canvas &canvas, const PixelRect &rc,
+                      const MoreData &basic,
+                      const DerivedInfo &calculated,
+                      unsigned max_bar_half_length,
+                      Color pull_color, Color push_color) const;
 };

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -3,6 +3,7 @@
 
 #include "ui/canvas/custom/TopCanvas.hpp"
 #include "ui/canvas/opengl/Globals.hpp"
+#include "ui/canvas/opengl/Init.hpp"
 #include "ui/display/Display.hpp"
 #include "ui/dim/Size.hpp"
 #include "system/Error.hxx"
@@ -72,6 +73,8 @@ TopCanvas::CreateSurface(EGLNativeWindowType native_window)
     throw std::runtime_error("eglQuerySurface() failed");
 
   display.MakeCurrent(surface);
+
+  OpenGL::ActivateMultisampling();
 
   SetupViewport(effective_size);
 }

--- a/src/ui/canvas/glx/TopCanvas.cpp
+++ b/src/ui/canvas/glx/TopCanvas.cpp
@@ -3,6 +3,7 @@
 
 #include "ui/canvas/custom/TopCanvas.hpp"
 #include "ui/canvas/opengl/Globals.hpp"
+#include "ui/canvas/opengl/Init.hpp"
 #include "ui/display/Display.hpp"
 #include "ui/dim/Size.hpp"
 
@@ -19,6 +20,8 @@ TopCanvas::TopCanvas(UI::Display &_display,
   if (!glXMakeContextCurrent(display.GetXDisplay(), glx_window, glx_window,
                              display.GetGLXContext()))
     throw std::runtime_error("Failed to attach GLX context to GLX window");
+
+  OpenGL::ActivateMultisampling();
 
   const PixelSize effective_size = GetNativeSize();
   if (effective_size.width == 0 || effective_size.height == 0)

--- a/src/ui/canvas/opengl/BufferCanvas.cpp
+++ b/src/ui/canvas/opengl/BufferCanvas.cpp
@@ -10,30 +10,83 @@
 #include "Init.hpp"
 #include "Shaders.hpp"
 #include "Program.hpp"
+#include "ui/opengl/Features.hpp"
+#include "LogFile.hpp"
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
 #include "DisplayOrientation.hpp"
 #endif
 
+#include <glm/gtc/matrix_transform.hpp>
+
 #include <cassert>
 
-void
-BufferCanvas::Create(PixelSize new_size) noexcept
+static void
+SetupOffscreenViewport(PixelSize render_size,
+                       PixelSize logical_size,
+                       unsigned pixel_scale) noexcept
 {
-  assert(!active);
+  glViewport(0, 0, int(render_size.width), int(render_size.height));
 
+  OpenGL::projection_matrix = glm::ortho<float>(
+    0.f, float(logical_size.width),
+    float(logical_size.height), 0.f, -1.f, 1.f);
+  OpenGL::viewport_size = {logical_size.width, logical_size.height};
+  OpenGL::viewport_pixel_scale = pixel_scale;
+  OpenGL::UpdateShaderProjectionMatrix();
+}
+
+void
+BufferCanvas::CreateRenderTarget(PixelSize render_size) noexcept
+{
   Destroy();
-  texture = new GLTexture(INTERNAL_FORMAT, new_size, FORMAT, TYPE, true);
+  texture = new GLTexture(INTERNAL_FORMAT, render_size, FORMAT, TYPE, true);
   frame_buffer = new GLFrameBuffer();
 
   if (OpenGL::render_buffer_stencil != GL_NONE) {
     stencil_buffer = new GLRenderBuffer();
     stencil_buffer->Bind();
     PixelSize size = texture->GetAllocatedSize();
-    stencil_buffer->Storage(OpenGL::render_buffer_stencil, size.width, size.height);
+    stencil_buffer->Storage(OpenGL::render_buffer_stencil,
+                            size.width, size.height);
     stencil_buffer->Unbind();
   }
+}
 
+void
+BufferCanvas::EnsureRenderTarget(PixelSize render_size) noexcept
+{
+  if (!IsDefined()) {
+    CreateRenderTarget(render_size);
+    return;
+  }
+
+  if (texture->GetSize() == render_size)
+    return;
+
+  texture->ResizeDiscard(INTERNAL_FORMAT, render_size, FORMAT, TYPE);
+
+  if (stencil_buffer != nullptr) {
+    frame_buffer->Bind();
+    if (OpenGL::render_buffer_stencil == OpenGL::render_buffer_depth_stencil)
+      stencil_buffer->DetachFramebuffer(FBO::DEPTH_ATTACHMENT);
+    stencil_buffer->DetachFramebuffer(FBO::STENCIL_ATTACHMENT);
+    frame_buffer->Unbind();
+
+    stencil_buffer->Bind();
+    PixelSize size = texture->GetAllocatedSize();
+    stencil_buffer->Storage(OpenGL::render_buffer_stencil,
+                            size.width, size.height);
+    stencil_buffer->Unbind();
+  }
+}
+
+void
+BufferCanvas::Create(PixelSize new_size) noexcept
+{
+  assert(!active);
+
+  CreateRenderTarget(new_size);
   Canvas::Create(new_size);
 }
 
@@ -59,35 +112,35 @@ BufferCanvas::Resize(PixelSize new_size) noexcept
 {
   assert(IsDefined());
 
-  if (new_size == GetSize())
+  if (new_size == GetSize() && texture->GetSize() == new_size)
     return;
 
-  texture->ResizeDiscard(INTERNAL_FORMAT, new_size, FORMAT, TYPE);
-
-  if (stencil_buffer != nullptr) {
-    /* the stencil buffer must be detached before we resize it */
-    frame_buffer->Bind();
-    if (OpenGL::render_buffer_stencil == OpenGL::render_buffer_depth_stencil)
-      stencil_buffer->DetachFramebuffer(FBO::DEPTH_ATTACHMENT);
-    stencil_buffer->DetachFramebuffer(FBO::STENCIL_ATTACHMENT);
-    frame_buffer->Unbind();
-
-    stencil_buffer->Bind();
-    PixelSize size = texture->GetAllocatedSize();
-    stencil_buffer->Storage(OpenGL::render_buffer_stencil, size.width, size.height);
-    stencil_buffer->Unbind();
-  }
-
+  EnsureRenderTarget(new_size);
   Canvas::Create(new_size);
 }
 
 void
 BufferCanvas::Begin(Canvas &other) noexcept
 {
-  assert(IsDefined());
   assert(!active);
 
-  Resize(other.GetSize());
+  const PixelSize logical_size = other.GetSize();
+  const unsigned scale = SupersampleScale();
+  const PixelSize render_size{
+    logical_size.width * scale,
+    logical_size.height * scale,
+  };
+
+  EnsureRenderTarget(render_size);
+  Canvas::Create(logical_size);
+
+#if OPENGL_BUFFER_SUPERSAMPLE > 1
+  static bool logged_supersample = false;
+  if (!logged_supersample && scale > 1) {
+    LogFormat("OpenGL buffer supersampling: %ux", scale);
+    logged_supersample = true;
+  }
+#endif
 
   /* activate the frame buffer */
   frame_buffer->Bind();
@@ -107,18 +160,17 @@ BufferCanvas::Begin(Canvas &other) noexcept
   glGetIntegerv(GL_VIEWPORT, old_viewport);
 
   old_projection_matrix = OpenGL::projection_matrix;
-  OpenGL::projection_matrix = glm::mat4(1);
-
   old_translate = OpenGL::translate;
   old_size = OpenGL::viewport_size;
+  old_viewport_pixel_scale = OpenGL::viewport_pixel_scale;
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   old_orientation = OpenGL::display_orientation;
   OpenGL::display_orientation = DisplayOrientation::DEFAULT;
 #endif
 
-  /* configure a new viewport */
-  OpenGL::SetupViewport({GetWidth(), GetHeight()});
+  /* logical coordinates, supersampled pixel grid */
+  SetupOffscreenViewport(render_size, logical_size, scale);
   OpenGL::translate = {0, 0};
 
   OpenGL::UpdateShaderTranslate();
@@ -154,6 +206,7 @@ BufferCanvas::Commit(Canvas &other) noexcept
 
   OpenGL::translate = old_translate;
   OpenGL::viewport_size = old_size;
+  OpenGL::viewport_pixel_scale = old_viewport_pixel_scale;
 
   OpenGL::UpdateShaderTranslate();
 
@@ -178,5 +231,5 @@ BufferCanvas::CopyTo(Canvas &other) noexcept
   OpenGL::texture_shader->Use();
 
   texture->Bind();
-  texture->Draw(other.GetRect(), GetRect());
+  texture->Draw(other.GetRect(), PixelRect(texture->GetSize()));
 }

--- a/src/ui/canvas/opengl/BufferCanvas.hpp
+++ b/src/ui/canvas/opengl/BufferCanvas.hpp
@@ -38,6 +38,7 @@ class BufferCanvas : public Canvas {
 
   PixelPoint old_translate;
   UnsignedPoint2D old_size;
+  unsigned old_viewport_pixel_scale = 1;
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   DisplayOrientation old_orientation;
@@ -97,4 +98,18 @@ public:
   void Commit(Canvas &other) noexcept;
 
   void CopyTo(Canvas &other) noexcept;
+
+private:
+  void CreateRenderTarget(PixelSize render_size) noexcept;
+
+  void EnsureRenderTarget(PixelSize render_size) noexcept;
+
+  [[gnu::pure]]
+  static unsigned SupersampleScale() noexcept {
+#if OPENGL_BUFFER_SUPERSAMPLE > 1
+    return OPENGL_BUFFER_SUPERSAMPLE;
+#else
+    return 1;
+#endif
+  }
 };

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -713,10 +713,12 @@ Canvas::CopyToTexture(GLTexture &texture, PixelRect src_rc) const noexcept
   assert(offset == OpenGL::translate);
 
   texture.Bind();
+  const unsigned scale = OpenGL::viewport_pixel_scale;
   glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
-                      OpenGL::translate.x + src_rc.left,
-                      OpenGL::viewport_size.y - OpenGL::translate.y - src_rc.bottom,
-                      src_rc.GetWidth(), src_rc.GetHeight());
+                      (OpenGL::translate.x + src_rc.left) * GLint(scale),
+                      (OpenGL::viewport_size.y - OpenGL::translate.y -
+                       src_rc.bottom) * GLint(scale),
+                      src_rc.GetWidth() * scale, src_rc.GetHeight() * scale);
 
 }
 

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -469,111 +469,12 @@ Canvas::DrawArc(PixelPoint center, unsigned radius,
   ::Arc(*this, center, radius, start, end);
 }
 
-[[gnu::const]]
-static unsigned
-AngleToDonutVertex(Angle angle) noexcept
-{
-  return GLDonutVertices::ImportAngle(NATIVE_TO_INT(angle.Native())
-                                      + ISINETABLE.size() * 3u / 4u,
-                                      ISINETABLE.size());
-}
-
-[[gnu::const]]
-static std::pair<unsigned,unsigned>
-AngleToDonutVertices(Angle start, Angle end) noexcept
-{
-  static constexpr Angle epsilon = Angle::FullCircle()
-    / int(GLDonutVertices::CIRCLE_SIZE * 4u);
-
-  const Angle delta = end - start;
-
-  if (fabs(delta.AsDelta().Native()) <= epsilon.Native())
-    /* full circle */
-    return std::make_pair(0u, unsigned(GLDonutVertices::MAX_ANGLE));
-
-  const unsigned istart = AngleToDonutVertex(start);
-  unsigned iend = AngleToDonutVertex(end);
-
-  if (istart == iend && delta > epsilon) {
-    if (end - start >= Angle::HalfCircle())
-      /* nearly full circle, round down the end */
-      iend = GLDonutVertices::PreviousAngle(iend);
-    else
-      /* slightly larger than epsilon: draw at least two indices */
-      iend = GLDonutVertices::NextAngle(iend);
-  }
-
-  return std::make_pair(istart, iend);
-}
-
 void
 Canvas::DrawAnnulus(PixelPoint center,
                     unsigned small_radius, unsigned big_radius,
                     Angle start, Angle end) noexcept
 {
-  if (1 == 1) {
-    /* TODO: switched to the unoptimised generic implementation due to
-       TRAC #2221, caused by rounding error of start/end radial;
-       should reimplement GLDonutVertices to use the exact start/end
-       radial */
-    ::Annulus(*this, center, big_radius, start, end, small_radius);
-    return;
-  }
-
-  ScopeVertexPointer vp;
-  GLDonutVertices vertices(center.x, center.y, small_radius, big_radius);
-
-  const std::pair<unsigned,unsigned> i = AngleToDonutVertices(start, end);
-  const unsigned istart = i.first;
-  const unsigned iend = i.second;
-
-  if (!brush.IsHollow()) {
-    brush.Bind();
-    vertices.Bind(vp);
-
-    if (istart > iend) {
-      glDrawArrays(GL_TRIANGLE_STRIP, istart,
-                   GLDonutVertices::MAX_ANGLE - istart + 2);
-      glDrawArrays(GL_TRIANGLE_STRIP, 0, iend + 2);
-    } else {
-      glDrawArrays(GL_TRIANGLE_STRIP, istart, iend - istart + 2);
-    }
-  }
-
-  if (IsPenOverBrush()) {
-    pen.Bind();
-
-    if (istart != iend && iend != GLDonutVertices::MAX_ANGLE) {
-      if (brush.IsHollow())
-        vertices.Bind(vp);
-
-      glDrawArrays(GL_LINE_STRIP, istart, 2);
-      glDrawArrays(GL_LINE_STRIP, iend, 2);
-    }
-
-    const unsigned pstart = istart / 2;
-    const unsigned pend = iend / 2;
-
-    vertices.BindInnerCircle(vp);
-    if (pstart < pend) {
-      glDrawArrays(GL_LINE_STRIP, pstart, pend - pstart + 1);
-    } else {
-      glDrawArrays(GL_LINE_STRIP, pstart,
-                   GLDonutVertices::CIRCLE_SIZE - pstart + 1);
-      glDrawArrays(GL_LINE_STRIP, 0, pend + 1);
-    }
-
-    vertices.BindOuterCircle(vp);
-    if (pstart < pend) {
-      glDrawArrays(GL_LINE_STRIP, pstart, pend - pstart + 1);
-    } else {
-      glDrawArrays(GL_LINE_STRIP, pstart,
-                   GLDonutVertices::CIRCLE_SIZE - pstart + 1);
-      glDrawArrays(GL_LINE_STRIP, 0, pend + 1);
-    }
-
-    pen.Unbind();
-  }
+  ::Annulus(*this, center, big_radius, start, end, small_radius);
 }
 
 void

--- a/src/ui/canvas/opengl/Globals.cpp
+++ b/src/ui/canvas/opengl/Globals.cpp
@@ -17,6 +17,8 @@ GLenum render_buffer_depth_stencil, render_buffer_stencil;
 
 UnsignedPoint2D window_size, viewport_size;
 
+unsigned viewport_pixel_scale = 1;
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
 DisplayOrientation display_orientation;
 #endif

--- a/src/ui/canvas/opengl/Globals.hpp
+++ b/src/ui/canvas/opengl/Globals.hpp
@@ -58,6 +58,11 @@ extern UnsignedPoint2D window_size;
  */
 extern UnsignedPoint2D viewport_size;
 
+/**
+ * Ratio of the GL viewport pixel size to #viewport_size (supersampling).
+ */
+extern unsigned viewport_pixel_scale;
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
 extern DisplayOrientation display_orientation;
 #endif

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -190,6 +190,24 @@ OpenGL::SetupContext()
   InitShaders();
 }
 
+void
+OpenGL::ActivateMultisampling() noexcept
+{
+  GLint sample_buffers = 0;
+  GLint samples = 0;
+  glGetIntegerv(GL_SAMPLE_BUFFERS, &sample_buffers);
+  glGetIntegerv(GL_SAMPLES, &samples);
+
+  if (sample_buffers <= 0 || samples <= 1)
+    return;
+
+#ifdef USE_GLX
+  glEnable(GL_MULTISAMPLE);
+#endif
+
+  LogFormat("GL multisampling: %d samples", int(samples));
+}
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
 
 /**
@@ -253,6 +271,7 @@ OpenGL::SetupViewport(UnsignedPoint2D size) noexcept
 #endif
 
   viewport_size = size;
+  viewport_pixel_scale = 1;
 
   UpdateShaderProjectionMatrix();
 

--- a/src/ui/canvas/opengl/Init.hpp
+++ b/src/ui/canvas/opengl/Init.hpp
@@ -26,6 +26,12 @@ void Initialise();
 void SetupContext();
 
 /**
+ * Enable and log multisampling after the context is bound to a
+ * drawable (window/surface).  No-op when MSAA is unavailable.
+ */
+void ActivateMultisampling() noexcept;
+
+/**
  * Set up the viewport and the matrices for 2D drawing.  Apply the
  * #DisplayOrientation via glRotatef() (OpenGL projection matrix).
  *

--- a/src/ui/canvas/opengl/Scissor.hpp
+++ b/src/ui/canvas/opengl/Scissor.hpp
@@ -25,7 +25,19 @@ public:
 private:
   void Scissor(PixelRect rc) noexcept {
     OpenGL::ToViewport(rc);
+    ApplyPixelScale(rc);
     ::glScissor(rc.left, rc.top, rc.GetWidth(), rc.GetHeight());
+  }
+
+  static void ApplyPixelScale(PixelRect &rc) noexcept {
+    const unsigned scale = OpenGL::viewport_pixel_scale;
+    if (scale <= 1)
+      return;
+
+    rc.left *= scale;
+    rc.top *= scale;
+    rc.right *= scale;
+    rc.bottom *= scale;
   }
 };
 
@@ -35,15 +47,33 @@ class GLCanvasScissor : public GLScissor {
 public:
   [[nodiscard]]
   GLCanvasScissor(const Canvas &canvas) noexcept
-    :GLScissor(OpenGL::translate.x,
-               OpenGL::viewport_size.y - OpenGL::translate.y - canvas.GetHeight(),
-               canvas.GetWidth(), canvas.GetHeight()) {}
+    :GLScissor(ScissorX(OpenGL::translate.x),
+               ScissorY(OpenGL::viewport_size.y - OpenGL::translate.y -
+                        canvas.GetHeight()),
+               ScissorSize(canvas.GetWidth()), ScissorSize(canvas.GetHeight())) {}
 
   [[nodiscard]]
   explicit GLCanvasScissor(PixelRect rc) noexcept
-    :GLScissor(OpenGL::translate.x + rc.left,
-               OpenGL::viewport_size.y - OpenGL::translate.y - rc.bottom,
-               rc.GetWidth(), rc.GetHeight()) {}
+    :GLScissor(ScissorX(OpenGL::translate.x + rc.left),
+               ScissorY(OpenGL::viewport_size.y - OpenGL::translate.y -
+                        rc.bottom),
+               ScissorSize(rc.GetWidth()), ScissorSize(rc.GetHeight())) {}
+
+private:
+  [[gnu::const]]
+  static GLint ScissorX(GLint x) noexcept {
+    return x * GLint(OpenGL::viewport_pixel_scale);
+  }
+
+  [[gnu::const]]
+  static GLint ScissorY(GLint y) noexcept {
+    return y * GLint(OpenGL::viewport_pixel_scale);
+  }
+
+  [[gnu::const]]
+  static GLsizei ScissorSize(unsigned size) noexcept {
+    return GLsizei(size * OpenGL::viewport_pixel_scale);
+  }
 };
 
 #endif

--- a/src/ui/canvas/sdl/TopCanvas.cpp
+++ b/src/ui/canvas/sdl/TopCanvas.cpp
@@ -81,17 +81,20 @@ TopCanvas::TopCanvas(UI::Display &_display, SDL_Window *_window)
     throw FmtRuntimeError("SDL_GL_CreateContext({}) has failed: {}",
                           (const void *)window, ::SDL_GetError());
 
-  LogFormat("SDL_GL config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d",
+  LogFormat("SDL_GL config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d samples=%d",
             GetConfigAttrib(SDL_GL_RED_SIZE, 0),
             GetConfigAttrib(SDL_GL_GREEN_SIZE, 0),
             GetConfigAttrib(SDL_GL_BLUE_SIZE, 0),
             GetConfigAttrib(SDL_GL_ALPHA_SIZE, 0),
             GetConfigAttrib(SDL_GL_DEPTH_SIZE, 0),
-            GetConfigAttrib(SDL_GL_STENCIL_SIZE, 0));
+            GetConfigAttrib(SDL_GL_STENCIL_SIZE, 0),
+            GetConfigAttrib(SDL_GL_MULTISAMPLESAMPLES, 0));
 
   /* this is usually done by OpenGL::Display, but libSDL doesn't allow
      that */
   OpenGL::SetupContext();
+
+  OpenGL::ActivateMultisampling();
 
   SetupViewport(GetNativeSize());
 #endif

--- a/src/ui/display/egl/ConfigChooser.cpp
+++ b/src/ui/display/egl/ConfigChooser.cpp
@@ -3,6 +3,7 @@
 
 #include "ConfigChooser.hpp"
 #include "lib/fmt/RuntimeError.hxx"
+#include "ui/opengl/Features.hpp"
 
 #ifdef MESA_KMS
 #include "ui/canvas/egl/GBM.hpp"
@@ -64,8 +65,11 @@ ConfigDistance(EGLDisplay display, EGLConfig config,
   int a = AttribDistance(display, config, EGL_ALPHA_SIZE, want_a);
   int d = AttribDistance(display, config, EGL_DEPTH_SIZE, want_depth);
   int s = AttribDistance(display, config, EGL_STENCIL_SIZE, want_stencil);
+  int ms = AttribDistance(display, config, EGL_SAMPLES, OPENGL_MSAA_SAMPLES);
+  int mb = AttribDistance(display, config, EGL_SAMPLE_BUFFERS,
+                          OPENGL_MSAA_SAMPLES > 0 ? 1 : 0);
 
-  return distance + r + g + b + a + d + s;
+  return distance + r + g + b + a + d + s + ms + mb;
 }
 
 [[gnu::pure]]
@@ -119,48 +123,102 @@ FindConfigWithAttribute(EGLDisplay display,
 
 #endif /* MESA_KMS */
 
+static bool
+QueryConfigs(EGLDisplay display, const EGLint *attributes,
+             std::array<EGLConfig, 64> &configs, EGLint &num_configs)
+{
+  if (!eglChooseConfig(display, attributes, configs.data(), configs.size(),
+                       &num_configs))
+    throw FmtRuntimeError("eglChooseConfig() failed: {:#x}", eglGetError());
+
+  return num_configs > 0;
+}
+
 EGLConfig
 ChooseConfig(EGLDisplay display)
 {
-  static constexpr EGLint attributes[] = {
-#ifdef ANDROID
-    /* EGL_STENCIL_SIZE not listed here because we have a fallback for
-       configurations without stencil (but we prefer native stencil)
-       (maybe we can just require a stencil and get rid of the
-       complicated and slow fallback code eventually?) */
+  std::array<EGLConfig, 64> configs;
+  EGLint num_configs = 0;
 
+#ifdef ANDROID
+  static constexpr EGLint attributes[] = {
     EGL_RED_SIZE, 4,
     EGL_GREEN_SIZE, 4,
     EGL_BLUE_SIZE, 4,
     EGL_ALPHA_SIZE, 4,
-
-#else //  !ANDROID
-
-    EGL_STENCIL_SIZE, 1,
-#ifdef MESA_KMS
-    EGL_RED_SIZE, 1,
-    EGL_GREEN_SIZE, 1,
-    EGL_BLUE_SIZE, 1,
-#ifndef RASPBERRY_PI /* the Raspberry Pi 4 doesn't have an alpha channel */
-    EGL_ALPHA_SIZE, 1,
-#endif
-#endif // MESA_KMS
-
-#endif // !ANDROID
-
     EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
     EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
     EGL_NONE
   };
 
-  std::array<EGLConfig, 64> configs;
-  EGLint num_configs;
-  if (!eglChooseConfig(display, attributes, configs.data(), configs.size(),
-                       &num_configs))
-    throw FmtRuntimeError("eglChooseConfig() failed: {:#x}", eglGetError());
-
-  if (num_configs == 0)
+  if (!QueryConfigs(display, attributes, configs, num_configs))
     throw std::runtime_error("eglChooseConfig() failed");
+
+#elif defined(MESA_KMS)
+
+#if OPENGL_MSAA_SAMPLES > 0
+  static constexpr EGLint attributes_msaa[] = {
+    EGL_STENCIL_SIZE, 1,
+    EGL_RED_SIZE, 1,
+    EGL_GREEN_SIZE, 1,
+    EGL_BLUE_SIZE, 1,
+#ifndef RASPBERRY_PI
+    EGL_ALPHA_SIZE, 1,
+#endif
+    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+    EGL_SAMPLE_BUFFERS, 1,
+    EGL_SAMPLES, OPENGL_MSAA_SAMPLES,
+    EGL_NONE
+  };
+#endif
+
+  static constexpr EGLint attributes[] = {
+    EGL_STENCIL_SIZE, 1,
+    EGL_RED_SIZE, 1,
+    EGL_GREEN_SIZE, 1,
+    EGL_BLUE_SIZE, 1,
+#ifndef RASPBERRY_PI
+    EGL_ALPHA_SIZE, 1,
+#endif
+    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+    EGL_NONE
+  };
+
+#if OPENGL_MSAA_SAMPLES > 0
+  if (!QueryConfigs(display, attributes_msaa, configs, num_configs))
+#endif
+    if (!QueryConfigs(display, attributes, configs, num_configs))
+      throw std::runtime_error("eglChooseConfig() failed");
+
+#else /* !ANDROID && !MESA_KMS */
+
+#if OPENGL_MSAA_SAMPLES > 0
+  static constexpr EGLint attributes_msaa[] = {
+    EGL_STENCIL_SIZE, 1,
+    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+    EGL_SAMPLE_BUFFERS, 1,
+    EGL_SAMPLES, OPENGL_MSAA_SAMPLES,
+    EGL_NONE
+  };
+#endif
+
+  static constexpr EGLint attributes[] = {
+    EGL_STENCIL_SIZE, 1,
+    EGL_SURFACE_TYPE, EGL_WINDOW_BIT,
+    EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+    EGL_NONE
+  };
+
+#if OPENGL_MSAA_SAMPLES > 0
+  if (!QueryConfigs(display, attributes_msaa, configs, num_configs))
+#endif
+    if (!QueryConfigs(display, attributes, configs, num_configs))
+      throw std::runtime_error("eglChooseConfig() failed");
+
+#endif /* platform attribute lists */
 
 #ifdef MESA_KMS
   /* On some GBM targets, such as the Raspberry Pi 4,

--- a/src/ui/display/egl/Display.cpp
+++ b/src/ui/display/egl/Display.cpp
@@ -64,13 +64,14 @@ Display::InitDisplay(EGLNativeDisplayType native_display)
 
   chosen_config = EGL::ChooseConfig(display);
 
-  LogFormat("EGL config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d",
+  LogFormat("EGL config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d samples=%d",
             GetConfigAttrib(display, chosen_config, EGL_RED_SIZE, 0),
             GetConfigAttrib(display, chosen_config, EGL_GREEN_SIZE, 0),
             GetConfigAttrib(display, chosen_config, EGL_BLUE_SIZE, 0),
             GetConfigAttrib(display, chosen_config, EGL_ALPHA_SIZE, 0),
             GetConfigAttrib(display, chosen_config, EGL_DEPTH_SIZE, 0),
-            GetConfigAttrib(display, chosen_config, EGL_STENCIL_SIZE, 0));
+            GetConfigAttrib(display, chosen_config, EGL_STENCIL_SIZE, 0),
+            GetConfigAttrib(display, chosen_config, EGL_SAMPLES, 0));
 }
 
 inline void

--- a/src/ui/display/sdl/Display.cpp
+++ b/src/ui/display/sdl/Display.cpp
@@ -4,6 +4,7 @@
 #include "Display.hpp"
 #include "lib/fmt/RuntimeError.hxx"
 #include "Asset.hpp"
+#include "ui/opengl/Features.hpp"
 
 #include <SDL.h>
 #include <SDL_hints.h>
@@ -34,6 +35,10 @@ Display::Display()
 #if defined(ENABLE_OPENGL)
   ::SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
   ::SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 1);
+#if OPENGL_MSAA_SAMPLES > 0
+  ::SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);
+  ::SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, OPENGL_MSAA_SAMPLES);
+#endif
 #endif
 }
 

--- a/src/ui/display/x11/Display.cpp
+++ b/src/ui/display/x11/Display.cpp
@@ -3,6 +3,7 @@
 
 #include "Display.hpp"
 #include "ui/dim/Size.hpp"
+#include "ui/opengl/Features.hpp"
 
 #ifdef USE_EGL
 #include "ui/egl/System.hpp"
@@ -18,6 +19,50 @@
 namespace X11 {
 
 #ifdef USE_GLX
+
+[[gnu::pure]]
+static GLXFBConfig *
+ChooseFBConfig(_XDisplay *display, int screen, int &fb_cfg_count) noexcept
+{
+#if OPENGL_MSAA_SAMPLES > 0
+  static constexpr int attributes_msaa[] = {
+    GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+    GLX_RENDER_TYPE, GLX_RGBA_BIT,
+    GLX_X_RENDERABLE, true,
+    GLX_DOUBLEBUFFER, true,
+    GLX_RED_SIZE, 1,
+    GLX_GREEN_SIZE, 1,
+    GLX_BLUE_SIZE, 1,
+    GLX_ALPHA_SIZE, 1,
+    GLX_STENCIL_SIZE, 1,
+    GLX_SAMPLE_BUFFERS, 1,
+    GLX_SAMPLES, OPENGL_MSAA_SAMPLES,
+    0
+  };
+#endif
+
+  static constexpr int attributes[] = {
+    GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
+    GLX_RENDER_TYPE, GLX_RGBA_BIT,
+    GLX_X_RENDERABLE, true,
+    GLX_DOUBLEBUFFER, true,
+    GLX_RED_SIZE, 1,
+    GLX_GREEN_SIZE, 1,
+    GLX_BLUE_SIZE, 1,
+    GLX_ALPHA_SIZE, 1,
+    GLX_STENCIL_SIZE, 1,
+    0
+  };
+
+#if OPENGL_MSAA_SAMPLES > 0
+  GLXFBConfig *cfg = glXChooseFBConfig(display, screen,
+                                       attributes_msaa, &fb_cfg_count);
+  if (cfg != nullptr && fb_cfg_count > 0)
+    return cfg;
+#endif
+
+  return glXChooseFBConfig(display, screen, attributes, &fb_cfg_count);
+}
 
 [[gnu::pure]]
 static int
@@ -41,32 +86,19 @@ Display::Display()
 #ifdef USE_GLX
   const auto screen = DefaultScreen(display);
 
-  static constexpr int attributes[] = {
-    GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT,
-    GLX_RENDER_TYPE, GLX_RGBA_BIT,
-    GLX_X_RENDERABLE, true,
-    GLX_DOUBLEBUFFER, true,
-    GLX_RED_SIZE, 1,
-    GLX_GREEN_SIZE, 1,
-    GLX_BLUE_SIZE, 1,
-    GLX_ALPHA_SIZE, 1,
-    GLX_STENCIL_SIZE, 1,
-    0
-  };
-
   int fb_cfg_count;
-  fb_cfg = glXChooseFBConfig(display, screen,
-                             attributes, &fb_cfg_count);
+  fb_cfg = ChooseFBConfig(display, screen, fb_cfg_count);
   if (fb_cfg == nullptr || fb_cfg_count == 0)
     throw std::runtime_error("Failed to retrieve framebuffer configuration for GLX");
 
-  LogFormat("GLX config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d",
+  LogFormat("GLX config: RGB=%d/%d/%d alpha=%d depth=%d stencil=%d samples=%d",
             GetConfigAttrib(display, *fb_cfg, GLX_RED_SIZE, 0),
             GetConfigAttrib(display, *fb_cfg, GLX_GREEN_SIZE, 0),
             GetConfigAttrib(display, *fb_cfg, GLX_BLUE_SIZE, 0),
             GetConfigAttrib(display, *fb_cfg, GLX_ALPHA_SIZE, 0),
             GetConfigAttrib(display, *fb_cfg, GLX_DEPTH_SIZE, 0),
-            GetConfigAttrib(display, *fb_cfg, GLX_STENCIL_SIZE, 0));
+            GetConfigAttrib(display, *fb_cfg, GLX_STENCIL_SIZE, 0),
+            GetConfigAttrib(display, *fb_cfg, GLX_SAMPLES, 0));
 
   glx_context = glXCreateNewContext(display, *fb_cfg,
                                     GLX_RGBA_TYPE,

--- a/src/ui/opengl/Features.hpp
+++ b/src/ui/opengl/Features.hpp
@@ -11,6 +11,16 @@
 #error No OpenGL
 #endif
 
+/** Multisample anti-aliasing sample count (0 disables MSAA). */
+#ifndef OPENGL_MSAA_SAMPLES
+#define OPENGL_MSAA_SAMPLES 4
+#endif
+
+/** Off-screen buffer supersampling factor (1 disables, 2 = 2× render). */
+#ifndef OPENGL_BUFFER_SUPERSAMPLE
+#define OPENGL_BUFFER_SUPERSAMPLE 2
+#endif
+
 #define HAVE_TEXT_CACHE
 
 #if defined(_WIN32) || defined(MESA_KMS) || defined(USE_X11) || defined(ENABLE_SDL) || defined(USE_WAYLAND)

--- a/test/src/RunGaugeVarioRenderer.cpp
+++ b/test/src/RunGaugeVarioRenderer.cpp
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#define ENABLE_MAIN_WINDOW
+#define ENABLE_CLOSE_BUTTON
+
+#include "Main.hpp"
+#include "Asset.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+#include "ui/window/ContainerWindow.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/Pen.hpp"
+#include "Gauge/GaugeVario.hpp"
+#include "Blackboard/InterfaceBlackboard.hpp"
+#include "Engine/GlideSolvers/GlidePolar.hpp"
+#include "InfoBoxes/InfoBoxLayout.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
+#include "NMEA/MoreData.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/SwitchState.hpp"
+#include "Look/VarioLook.hpp"
+#include "Look/VarioBarLook.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "Look/Colors.hpp"
+#include "Screen/Layout.hpp"
+#include "Form/Button.hpp"
+#include "Units/Units.hpp"
+#include "time/Stamp.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+/** Simple cross-country profile for the vario harness. */
+struct FlightSimulator {
+  double time_s = 0;
+
+  /** Smoothed values updated each tick. */
+  double netto_average = 0;
+  double thermal_average = 0;
+  double last_thermal_smooth = 1.6;
+
+  /** Manual MC value when #ComputerSettings::task::auto_mc is false. */
+  double user_mc = 1.5;
+
+  static constexpr double DT = 0.1;
+  static constexpr double CRUISE_DURATION = 38;
+  static constexpr double ENTER_DURATION = 4;
+  static constexpr double THERMAL_DURATION = 42;
+  static constexpr double LEAVE_DURATION = 4;
+  static constexpr double CYCLE = CRUISE_DURATION + ENTER_DURATION +
+    THERMAL_DURATION + LEAVE_DURATION;
+
+  [[gnu::const]]
+  static double SmoothStep(double t) noexcept
+  {
+    t = std::clamp(t, 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+  }
+
+  [[gnu::pure]]
+  static double Turbulence(double time_s) noexcept
+  {
+    return 0.12 * std::sin(time_s * 4.7)
+      + 0.07 * std::sin(time_s * 11.3 + 1.1);
+  }
+
+  void Advance() noexcept
+  {
+    time_s += DT;
+
+    const double phase = std::fmod(time_s, CYCLE);
+    const unsigned thermal_index = unsigned(time_s / CYCLE);
+    const double thermal_lift = 1.4 + 0.9 * std::sin(thermal_index * 1.7 + 0.4);
+
+    enum class Mode {
+      CRUISE,
+      ENTER,
+      THERMAL,
+      LEAVE,
+    };
+
+    Mode mode = Mode::CRUISE;
+    double mode_blend = 0;
+
+    if (phase < CRUISE_DURATION) {
+      mode = Mode::CRUISE;
+    } else if (phase < CRUISE_DURATION + ENTER_DURATION) {
+      mode = Mode::ENTER;
+      mode_blend = SmoothStep((phase - CRUISE_DURATION) / ENTER_DURATION);
+    } else if (phase < CRUISE_DURATION + ENTER_DURATION + THERMAL_DURATION) {
+      mode = Mode::THERMAL;
+    } else {
+      mode = Mode::LEAVE;
+      mode_blend = SmoothStep((phase - CRUISE_DURATION - ENTER_DURATION -
+                               THERMAL_DURATION) / LEAVE_DURATION);
+    }
+
+    const bool circling = mode == Mode::THERMAL ||
+      (mode == Mode::ENTER && mode_blend > 0.35) ||
+      (mode == Mode::LEAVE && mode_blend < 0.65);
+
+    static constexpr double cruise_sink = -0.85;
+    static constexpr double turn_sink = 0.95;
+    const double cruise_ias = 27.5;
+    const double thermal_ias = 22.0;
+
+    double netto = cruise_sink;
+    double brutto = cruise_sink;
+    double ias = cruise_ias;
+    double mc = 1.2 + 0.8 * std::sin(time_s * 0.03);
+    double v_stf = mc * 0.6;
+
+    switch (mode) {
+    case Mode::CRUISE:
+      netto = brutto = cruise_sink + Turbulence(time_s);
+      break;
+
+    case Mode::ENTER:
+      netto = cruise_sink + (thermal_lift - cruise_sink) * mode_blend
+        + Turbulence(time_s);
+      brutto = netto - turn_sink * mode_blend;
+      ias = cruise_ias + (thermal_ias - cruise_ias) * mode_blend;
+      v_stf *= 1.0 - mode_blend;
+      break;
+
+    case Mode::THERMAL:
+      netto = thermal_lift + Turbulence(time_s) * 0.5;
+      brutto = netto - turn_sink;
+      ias = thermal_ias;
+      mc = 0.8;
+      v_stf = -1.2;
+      break;
+
+    case Mode::LEAVE:
+      netto = thermal_lift + (cruise_sink - thermal_lift) * mode_blend
+        + Turbulence(time_s);
+      brutto = netto - turn_sink * (1.0 - mode_blend);
+      ias = thermal_ias + (cruise_ias - thermal_ias) * mode_blend;
+      v_stf = -1.2 + (mc * 0.6 + 1.2) * mode_blend;
+      break;
+    }
+
+    constexpr double avg_alpha = 0.06;
+    if (circling) {
+      thermal_average += (netto - thermal_average) * avg_alpha;
+      netto_average = thermal_average;
+    } else {
+      netto_average += (netto - netto_average) * avg_alpha;
+      last_thermal_smooth += (thermal_average - last_thermal_smooth) * 0.008;
+      thermal_average += (0 - thermal_average) * 0.02;
+    }
+
+    const TimeStamp now{FloatDuration{time_s}};
+
+    MoreData basic{};
+    DerivedInfo calculated{};
+
+    basic.brutto_vario = brutto;
+    basic.brutto_vario_available.Update(now);
+    basic.indicated_airspeed = ias;
+    basic.airspeed_available.Update(now);
+    basic.total_energy_vario = brutto;
+    basic.total_energy_vario_available.Update(now);
+
+    calculated.average = thermal_average;
+    calculated.netto_average = netto_average;
+    calculated.last_thermal_average_smooth = last_thermal_smooth;
+    calculated.current_thermal.lift_rate = circling ? netto : 0;
+    calculated.flight.flying = true;
+    calculated.circling = circling;
+    basic.switch_state.flight_mode = circling
+      ? SwitchState::FlightMode::CIRCLING
+      : SwitchState::FlightMode::CRUISE;
+    calculated.V_stf = v_stf;
+
+    ComputerSettings &computer = blackboard.SetComputerSettings();
+    if (computer.task.auto_mc)
+      computer.polar.glide_polar_task.SetMC(mc);
+    else
+      computer.polar.glide_polar_task.SetMC(user_mc);
+    computer.polar.glide_polar_task.SetBallastFraction(0.18 +
+      0.12 * std::sin(time_s * 0.015));
+    computer.polar.bugs = 0.82 + 0.08 * std::cos(time_s * 0.008);
+
+    blackboard.ReadBlackboardBasic(basic);
+    blackboard.ReadBlackboardCalculated(calculated);
+  }
+
+  InterfaceBlackboard &blackboard;
+
+  explicit FlightSimulator(InterfaceBlackboard &_blackboard) noexcept
+    :blackboard(_blackboard) {}
+
+  void AdjustMC(double delta) noexcept
+  {
+    ComputerSettings &computer = blackboard.SetComputerSettings();
+    computer.task.auto_mc = false;
+    user_mc = std::clamp(user_mc + delta, 0.0, 5.0);
+    computer.polar.glide_polar_task.SetMC(user_mc);
+  }
+
+  void SyncUserMcFromPolar() noexcept
+  {
+    user_mc = blackboard.GetComputerSettings().polar.glide_polar_task.GetMC();
+  }
+};
+
+} // namespace
+
+static void
+InitBlackboard(InterfaceBlackboard &blackboard) noexcept
+{
+  ComputerSettings &computer = blackboard.SetComputerSettings();
+  computer.polar.glide_polar_task = GlidePolar(2.5);
+  computer.polar.glide_polar_task.SetBallastFraction(0.35);
+  computer.polar.bugs = 0.85;
+  computer.polar.glide_polar_task.SetMC(1.5);
+  computer.task.auto_mc = true;
+
+  UISettings &ui = blackboard.SetUISettings();
+  ui.info_boxes.geometry = InfoBoxSettings::Geometry::RIGHT_9_VARIO;
+  ui.info_boxes.scale_title_font = 100;
+  ui.info_boxes.use_colors = true;
+  ui.info_boxes.theme = InfoBoxSettings::Theme::DARK;
+
+  VarioSettings &vario = ui.vario;
+  vario.show_average = true;
+  vario.show_mc = true;
+  vario.show_speed_to_fly = true;
+  vario.show_ballast = true;
+  vario.show_bugs = true;
+  vario.show_gross = true;
+  vario.show_average_needle = true;
+  vario.show_thermal_average_needle = true;
+}
+
+[[gnu::pure]]
+static InfoBoxSettings::Geometry
+SelectVarioGeometry(PixelSize screen_size) noexcept
+{
+  if (screen_size.width > screen_size.height)
+    return InfoBoxSettings::Geometry::RIGHT_9_VARIO;
+
+  return InfoBoxSettings::Geometry::BOTTOM_8_VARIO;
+}
+
+/** Match #Look::InitialiseConfigured vario path for the harness blackboard. */
+static void
+InitialiseVarioLook(VarioLook &vario_look, VarioBarLook &vario_bar_look,
+                    InfoBoxLook &info_box_look,
+                    const UISettings &ui, unsigned infobox_width) noexcept
+{
+  const bool dark = ui.info_boxes.theme == InfoBoxSettings::Theme::DARK;
+
+  info_box_look.Initialise(dark, ui.info_boxes.use_colors, infobox_width,
+                           ui.info_boxes.scale_title_font);
+  vario_look.Initialise(dark, ui.info_boxes.use_colors, infobox_width,
+                        info_box_look.title_font);
+  vario_bar_look.Initialise(vario_look.label_font);
+}
+
+static void
+ReinitialiseVarioLook(VarioLook &vario_look, InfoBoxLook &info_box_look,
+                      const UISettings &ui, unsigned infobox_width) noexcept
+{
+  info_box_look.ReinitialiseLayout(infobox_width, ui.info_boxes.scale_title_font);
+  vario_look.ReinitialiseLayout(infobox_width, ui.info_boxes.scale_title_font,
+                                std::max(1u, infobox_width / 2u), 32,
+                                Layout::Scale(8));
+}
+
+class VarioHarnessWindow final : public ContainerWindow {
+  InterfaceBlackboard &blackboard;
+  FlightSimulator *flight = nullptr;
+  InfoBoxLook info_box_look;
+  VarioLook vario_look;
+  VarioBarLook vario_bar_look;
+  GaugeVario *gauge = nullptr;
+  InfoBoxLayout::Layout layout{};
+  Button mc_down_button;
+  Button mc_up_button;
+  Button mc_mode_button;
+  Button speed_mode_button;
+  Button theme_button;
+  bool buttons_created = false;
+
+  [[gnu::pure]]
+  PixelRect GetVarioArea(PixelRect client) const noexcept
+  {
+    client.bottom -= int(Layout::GetMaximumControlHeight());
+    return client;
+  }
+
+  void LayoutButtons(PixelRect client) noexcept
+  {
+    if (!buttons_created)
+      return;
+
+    const int bar_top = client.bottom - int(Layout::GetMaximumControlHeight());
+    const unsigned button_w = Layout::Scale(56);
+    int x = client.left;
+
+    mc_down_button.Move({x, bar_top, x + int(button_w), client.bottom});
+    x += int(button_w);
+    mc_up_button.Move({x, bar_top, x + int(button_w), client.bottom});
+    x += int(button_w);
+    mc_mode_button.Move({x, bar_top, x + int(button_w), client.bottom});
+    x += int(button_w);
+    speed_mode_button.Move({x, bar_top, x + int(button_w), client.bottom});
+    x += int(button_w);
+    theme_button.Move({x, bar_top, x + int(button_w) * 2, client.bottom});
+  }
+
+  void UpdateControlCaptions() noexcept
+  {
+    if (!buttons_created)
+      return;
+
+    UpdateThemeCaption();
+
+    if (mc_mode_button.IsDefined()) {
+      const bool auto_mc = blackboard.GetComputerSettings().task.auto_mc;
+      mc_mode_button.SetCaption(auto_mc ? "MC manual" : "MC auto");
+    }
+
+    if (speed_mode_button.IsDefined()) {
+      const bool stf = blackboard.GetUISettings().vario.show_speed_to_fly;
+      speed_mode_button.SetCaption(stf ? "Vario" : "SC");
+    }
+  }
+
+  void ApplyTheme() noexcept
+  {
+    const UISettings &ui = blackboard.GetUISettings();
+    const unsigned width = layout.control_size.width > 0
+      ? layout.control_size.width
+      : std::max(1u, unsigned(GetVarioArea(GetClientRect()).GetWidth()));
+    InitialiseVarioLook(vario_look, vario_bar_look, info_box_look, ui, width);
+    UpdateControlCaptions();
+    if (gauge != nullptr)
+      gauge->Invalidate();
+    Invalidate();
+  }
+
+  void OnMCAdjust(double delta) noexcept
+  {
+    if (flight != nullptr)
+      flight->AdjustMC(delta);
+    UpdateControlCaptions();
+    InvalidateGauge();
+  }
+
+  void OnToggleMcMode() noexcept
+  {
+    ComputerSettings &computer = blackboard.SetComputerSettings();
+    computer.task.auto_mc = !computer.task.auto_mc;
+    if (!computer.task.auto_mc && flight != nullptr)
+      flight->SyncUserMcFromPolar();
+    UpdateControlCaptions();
+    InvalidateGauge();
+  }
+
+  void OnToggleSpeedMode() noexcept
+  {
+    VarioSettings &vario = blackboard.SetUISettings().vario;
+    vario.show_speed_to_fly = !vario.show_speed_to_fly;
+    UpdateControlCaptions();
+    InvalidateGauge();
+  }
+
+  void OnToggleTheme() noexcept
+  {
+    UISettings &ui = blackboard.SetUISettings();
+    ui.info_boxes.theme =
+      ui.info_boxes.theme == InfoBoxSettings::Theme::DARK
+      ? InfoBoxSettings::Theme::LIGHT
+      : InfoBoxSettings::Theme::DARK;
+    ApplyTheme();
+  }
+
+  void CreateButtons(PixelRect client) noexcept
+  {
+    if (buttons_created)
+      return;
+
+    const int bar_top = client.bottom - int(Layout::GetMaximumControlHeight());
+    const unsigned button_w = Layout::Scale(56);
+    WindowStyle style;
+    int x = client.left;
+
+    mc_down_button.Create(*this, *button_look, "MC -",
+                          {x, bar_top, x + int(button_w), client.bottom},
+                          style, [this]{ OnMCAdjust(-0.2); });
+    x += int(button_w);
+    mc_up_button.Create(*this, *button_look, "MC +",
+                        {x, bar_top, x + int(button_w), client.bottom},
+                        style, [this]{ OnMCAdjust(+0.2); });
+    x += int(button_w);
+    mc_mode_button.Create(*this, *button_look, "MC auto",
+                          {x, bar_top, x + int(button_w), client.bottom},
+                          style, [this]{ OnToggleMcMode(); });
+    x += int(button_w);
+    speed_mode_button.Create(*this, *button_look, "Vario",
+                             {x, bar_top, x + int(button_w), client.bottom},
+                             style, [this]{ OnToggleSpeedMode(); });
+    x += int(button_w);
+    theme_button.Create(*this, *button_look, "Theme",
+                        {x, bar_top, x + int(button_w) * 2, client.bottom},
+                        style, [this]{ OnToggleTheme(); });
+    buttons_created = true;
+    UpdateControlCaptions();
+  }
+
+  void UpdateThemeCaption() noexcept
+  {
+    if (!theme_button.IsDefined())
+      return;
+
+    const bool dark =
+      blackboard.GetUISettings().info_boxes.theme ==
+      InfoBoxSettings::Theme::DARK;
+    theme_button.SetCaption(dark ? "Light theme" : "Dark theme");
+  }
+
+  void Relayout() noexcept
+  {
+    const PixelRect client = GetClientRect();
+    const UISettings &ui = blackboard.GetUISettings();
+    layout = InfoBoxLayout::Calculate(GetVarioArea(client),
+                                      SelectVarioGeometry(client.GetSize()));
+    assert(layout.HasVario());
+
+    if (gauge == nullptr) {
+      InitialiseVarioLook(vario_look, vario_bar_look, info_box_look, ui,
+                          layout.control_size.width);
+      gauge = new GaugeVario(blackboard, *this, vario_look, vario_bar_look,
+                             layout.vario);
+      gauge->SetDebugOverlay(true);
+      gauge->Show();
+    } else {
+      ReinitialiseVarioLook(vario_look, info_box_look, ui,
+                            layout.control_size.width);
+      gauge->Move(layout.vario);
+    }
+
+    LayoutButtons(client);
+    gauge->Invalidate();
+  }
+
+public:
+  explicit VarioHarnessWindow(InterfaceBlackboard &_blackboard) noexcept
+    :blackboard(_blackboard) {}
+
+  ~VarioHarnessWindow() {
+    delete gauge;
+  }
+
+  void SetFlightSimulator(FlightSimulator &_flight) noexcept
+  {
+    flight = &_flight;
+  }
+
+  void InvalidateGauge() noexcept {
+    if (gauge != nullptr)
+      gauge->Invalidate();
+  }
+
+protected:
+  void OnCreate() override {
+    ContainerWindow::OnCreate();
+    const PixelRect client = GetClientRect();
+    CreateButtons(client);
+    Relayout();
+  }
+
+  void OnResize(PixelSize new_size) noexcept override {
+    ContainerWindow::OnResize(new_size);
+    Relayout();
+  }
+
+  void OnPaint(Canvas &canvas) noexcept override {
+    const bool dark =
+      blackboard.GetUISettings().info_boxes.theme ==
+      InfoBoxSettings::Theme::DARK;
+    canvas.Clear(dark ? COLOR_DARK_THEME_BACKGROUND : COLOR_WHITE);
+
+    canvas.Select(Pen(Layout::ScaleFinePenWidth(1), COLOR_GRAY));
+    canvas.SelectHollowBrush();
+    for (unsigned i = 0; i < layout.count; ++i) {
+      const PixelRect &rc = layout.positions[i];
+      if (rc.GetWidth() > 0 && rc.GetHeight() > 0)
+        canvas.DrawRectangle(rc);
+    }
+
+    ContainerWindow::OnPaint(canvas);
+  }
+};
+
+static void
+Main(TestMainWindow &main_window)
+{
+  InterfaceBlackboard blackboard;
+  InitBlackboard(blackboard);
+
+  VarioHarnessWindow window(blackboard);
+  window.Create(main_window, main_window.GetClientRect());
+  main_window.SetFullWindow(window);
+
+  FlightSimulator flight(blackboard);
+  window.SetFlightSimulator(flight);
+  flight.Advance();
+  window.InvalidateGauge();
+
+  UI::PeriodicTimer timer([&](){
+    flight.Advance();
+    window.InvalidateGauge();
+  });
+  timer.Schedule(std::chrono::milliseconds(100));
+
+  main_window.RunEventLoop();
+}


### PR DESCRIPTION
## Summary

UI mockup / preview PR for a Larus Breeze–style circular vario gauge in XCSoar.

- Replace the legacy tick-bar vario with an annulus scale, rotating needles, and inner text rows
- Red classic needle (gross/TE vario), optional blue averager needle, MC scale marker
- Speed-to-fly strip, SC/Vario mode hint, annulus shadow, needle trail
- `RunGaugeVarioRenderer` interactive harness with flight simulation and layout debug overlay

**This is a draft mockup for review and iteration — not intended for merge as-is.**

## Notes

- OpenGL canvas changes (alpha, scissor, EGL alpha config) support shadow/trail rendering
- Cherry-picked from development branch; accent colours adjusted to build on current `master`

## Test plan

- [ ] Build: `make TARGET=UNIX output/UNIX/bin/RunGaugeVarioRenderer`
- [ ] Run harness: `./output/UNIX/bin/RunGaugeVarioRenderer`
- [ ] Toggle MC, SC/Vario, theme; verify needles and inner rows update
- [ ] Enable debug overlay in harness; check layout of inscribed square, hint, unit label
- [ ] Build `TARGET=UNIX` main binary and open vario page in flight/replay