### PR TITLE
Device/Driver/LX: High-rate vario, filter time sync, and filtered display outputs

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,8 @@ Version 7.45 - not yet released
   - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
     ISA logger datum; cleared when strong pressure replaces weak pressure or
     ignores the sentence
+  - LXNAV: apply device vario filter time ($LXWP3 variofil) to gauge, map
+    vario bar, thermal rose, audio vario and snail-trail colouring
 * ui
   - macOS: thick solid lines now render at their correct pixel width #2545
   - status dialog, Times: flight time matches takeoff and landing after

--- a/build/libairspace.mk
+++ b/build/libairspace.mk
@@ -2,6 +2,7 @@ AIRSPACE_SRC_DIR = $(SRC)/Engine/Airspace
 
 AIRSPACE_SOURCES = \
 	$(ENGINE_SRC_DIR)/Util/AircraftStateFilter.cpp \
+	$(ENGINE_SRC_DIR)/Util/VarioOutputFilter.cpp \
 	$(AIRSPACE_SRC_DIR)/AirspacesTerrain.cpp \
 	$(AIRSPACE_SRC_DIR)/Airspace.cpp \
 	$(AIRSPACE_SRC_DIR)/AirspaceAltitude.cpp \

--- a/build/libcomputer.mk
+++ b/build/libcomputer.mk
@@ -42,6 +42,7 @@ LIBCOMPUTER_SOURCES = \
 	$(SRC)/Computer/GlideComputerInterface.cpp \
 	$(SRC)/Computer/Events.cpp \
 	$(SRC)/Computer/BasicComputer.cpp \
+	$(SRC)/Computer/FilteredVarioComputer.cpp \
 	$(SRC)/Computer/GroundSpeedComputer.cpp \
 	$(SRC)/Computer/AutoQNH.cpp \
 	$(SRC)/Computer/Settings.cpp

--- a/build/test.mk
+++ b/build/test.mk
@@ -1007,8 +1007,10 @@ DEBUG_REPLAY_SOURCES = \
 	$(SRC)/FLARM/Traffic.cpp \
 	$(SRC)/FLARM/List.cpp \
 	$(SRC)/Computer/BasicComputer.cpp \
+	$(SRC)/Computer/FilteredVarioComputer.cpp \
 	$(SRC)/Computer/GroundSpeedComputer.cpp \
 	$(SRC)/Computer/FlyingComputer.cpp \
+	$(ENGINE_SRC_DIR)/Util/VarioOutputFilter.cpp \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(SRC)/Engine/Navigation/Aircraft.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -90,7 +90,7 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
-	TestLogger TestGRecord TestClimbAvCalc \
+	TestLogger TestGRecord TestClimbAvCalc TestFilteredVarioComputer \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestGeoPoint TestDiffFilter \
@@ -520,6 +520,15 @@ TEST_CLIMB_AV_CALC_SOURCES = \
 	$(TEST_SRC_DIR)/TestClimbAvCalc.cpp
 TEST_CLIMB_AV_CALC_DEPENDS = MATH
 $(eval $(call link-program,TestClimbAvCalc,TEST_CLIMB_AV_CALC))
+
+TEST_FILTERED_VARIO_COMPUTER_SOURCES = \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(SRC)/Computer/FilteredVarioComputer.cpp \
+	$(ENGINE_SRC_DIR)/Util/VarioOutputFilter.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestFilteredVarioComputer.cpp
+TEST_FILTERED_VARIO_COMPUTER_DEPENDS = LIBNMEA GEO MATH UTIL UNITS TIME
+$(eval $(call link-program,TestFilteredVarioComputer,TEST_FILTERED_VARIO_COMPUTER))
 
 TEST_PROJECTION_SOURCES = \
 	$(SRC)/Projection/Projection.cpp \

--- a/python/src/Flight/DebugReplayVector.cpp
+++ b/python/src/Flight/DebugReplayVector.cpp
@@ -35,7 +35,8 @@ DebugReplayVector::Compute(const int elevation)
   FeaturesSettings features;
   features.nav_baro_altitude_enabled = true;
   computer.Fill(computed_basic, qnh, features);
-  computer.Compute(computed_basic, last_basic, last_basic, calculated);
+  computer.Compute(computed_basic, last_basic, last_basic, calculated,
+                   ComputerSettings{.polar = {.glide_polar_task = glide_polar}});
 
   if (elevation > -1000) {
     calculated.terrain_valid = true;

--- a/src/Computer/BasicComputer.cpp
+++ b/src/Computer/BasicComputer.cpp
@@ -5,6 +5,7 @@
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
 #include "Settings.hpp"
+#include "Engine/GlideSolvers/GlidePolar.hpp"
 #include "Atmosphere/AirDensity.hpp"
 #include "Geo/Gravity.hpp"
 #include "Math/Util.hpp"
@@ -316,16 +317,36 @@ ComputeBruttoVario(MoreData &basic) noexcept
 }
 
 /**
+ * Glider polar sink [m/s] for netto vario (negative when sinking).
+ */
+static double
+GetGliderSinkRate(const MoreData &basic, const DerivedInfo &calculated,
+                  const ComputerSettings &settings) noexcept
+{
+  if (calculated.flight.flying && basic.airspeed_available &&
+      settings.polar.glide_polar_task.IsValid()) {
+    const double g_load = basic.acceleration.available
+      ? basic.acceleration.g_load
+      : 1.;
+
+    return -settings.polar.glide_polar_task.SinkRate(
+      basic.indicated_airspeed, g_load);
+  }
+
+  return calculated.sink_rate;
+}
+
+/**
  * Compute the NettoVario value if it's unavailable.
  */
 static void
-ComputeNettoVario(MoreData &basic, const VarioInfo &vario) noexcept
+ComputeNettoVario(MoreData &basic, double sink_rate) noexcept
 {
   if (basic.netto_vario_available)
     /* got it already */
     return;
 
-  basic.netto_vario = basic.brutto_vario - vario.sink_rate;
+  basic.netto_vario = basic.brutto_vario - sink_rate;
 }
 
 /**
@@ -391,7 +412,8 @@ BasicComputer::Fill(MoreData &data,
 void
 BasicComputer::Compute(MoreData &data,
                        const MoreData &last, const MoreData &last_gps,
-                       const DerivedInfo &calculated) noexcept
+                       const DerivedInfo &calculated,
+                       const ComputerSettings &settings) noexcept
 {
   ComputeTrack(data, last_gps);
 
@@ -404,6 +426,8 @@ BasicComputer::Compute(MoreData &data,
   ComputeEnergyHeight(data);
   ComputeGPSVario(data, last, last_gps);
   ComputeBruttoVario(data);
-  ComputeNettoVario(data, calculated);
+  const double sink_rate = GetGliderSinkRate(data, calculated, settings);
+  ComputeNettoVario(data, sink_rate);
+  filtered_vario.Compute(data, sink_rate);
   ComputeDynamics(data, calculated);
 }

--- a/src/Computer/BasicComputer.hpp
+++ b/src/Computer/BasicComputer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "GroundSpeedComputer.hpp"
+#include "FilteredVarioComputer.hpp"
 
 struct MoreData;
 struct DerivedInfo;
@@ -18,6 +19,7 @@ struct ComputerSettings;
  */
 class BasicComputer {
   GroundSpeedComputer ground_speed;
+  FilteredVarioComputer filtered_vario;
 
 public:
   /**
@@ -38,5 +40,16 @@ public:
    * @param calculations the most up-to-date version of calculated values
    */
   void Compute(MoreData &data, const MoreData &last, const MoreData &last_gps,
-               const DerivedInfo &calculated) noexcept;
+               const DerivedInfo &calculated,
+               const ComputerSettings &settings) noexcept;
+
+  [[gnu::pure]]
+  bool FilteredVarioSampleUpdated() const noexcept {
+    return filtered_vario.SampleUpdated();
+  }
+
+  [[gnu::pure]]
+  bool FilteredVarioActive() const noexcept {
+    return filtered_vario.FilterActive();
+  }
 };

--- a/src/Computer/FilteredVarioComputer.cpp
+++ b/src/Computer/FilteredVarioComputer.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "FilteredVarioComputer.hpp"
+#include "NMEA/MoreData.hpp"
+
+static double
+GetVarioFilterPeriod(const MoreData &data) noexcept
+{
+  if (!data.settings.vario_filter_period_available)
+    return 0;
+
+  return data.settings.vario_filter_period;
+}
+
+void
+FilteredVarioComputer::Compute(MoreData &data, double sink_rate) noexcept
+{
+  sample_updated = false;
+
+  if (!data.brutto_vario_available) {
+    data.filtered_brutto_vario_available.Clear();
+    data.filtered_netto_vario_available.Clear();
+    return;
+  }
+
+  const double period = GetVarioFilterPeriod(data);
+  if (period != last_period) {
+    filter.Design(period);
+    filter.Reset(data.brutto_vario);
+    last_period = period;
+
+    if (period <= 0) {
+      data.filtered_brutto_vario_available.Clear();
+      data.filtered_netto_vario_available.Clear();
+      sample_updated = true;
+      return;
+    }
+
+    sample_updated = true;
+  } else if (period <= 0) {
+    sample_updated = true;
+    return;
+  } else
+    sample_updated = filter.Update(data.brutto_vario);
+
+  data.filtered_brutto_vario = filter.GetOutput();
+  data.filtered_brutto_vario_available = data.brutto_vario_available;
+
+  data.filtered_netto_vario = data.filtered_brutto_vario - sink_rate;
+  data.filtered_netto_vario_available = data.brutto_vario_available;
+}

--- a/src/Computer/FilteredVarioComputer.hpp
+++ b/src/Computer/FilteredVarioComputer.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Engine/Util/VarioOutputFilter.hpp"
+
+struct MoreData;
+
+/**
+ * Applies device-configured vario filtering to MoreData after raw
+ * brutto/netto have been computed.
+ */
+class FilteredVarioComputer {
+  VarioOutputFilter filter;
+  double last_period = -1;
+  bool sample_updated = false;
+
+public:
+  void Reset() noexcept {
+    filter.Design(0);
+    filter.Reset(0);
+    last_period = -1;
+    sample_updated = false;
+  }
+
+  void Compute(MoreData &data, double sink_rate) noexcept;
+
+  [[gnu::pure]]
+  bool SampleUpdated() const noexcept {
+    return sample_updated;
+  }
+
+  [[gnu::pure]]
+  bool FilterActive() const noexcept {
+    return filter.IsActive();
+  }
+};

--- a/src/Computer/LiftDatabaseComputer.cpp
+++ b/src/Computer/LiftDatabaseComputer.cpp
@@ -89,7 +89,7 @@ LiftDatabaseComputer::Compute(LiftDatabase &lift_database,
        left == (heading - h).AsDelta().IsNegative();
        h += heading_step) {
     unsigned index = heading_to_index(h);
-    lift_database[index] = basic.brutto_vario;
+    lift_database[index] = basic.FilteredBruttoVario();
   }
 
   // detect zero crossing

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -220,6 +220,12 @@ private:
   bool vario_just_detected = false;
 
   /**
+   * Was $PLXVF received?  When set, $LXWP0 vario samples are ignored so
+   * the slower sentence cannot overwrite high-rate total-energy vario.
+   */
+  bool plxvf_received = false;
+
+  /**
    * Has the polar sync notification been shown this session?
    */
   bool polar_sync_notified = false;
@@ -314,6 +320,7 @@ public:
 
   void ResetDeviceDetection() noexcept {
     is_v7 = is_sVario = is_nano = is_lx16xx = is_forwarded_nano = false;
+    plxvf_received = false;
     switch_host_baud_for_direct = true;
     polar_sync_notified = false;
     device_polar.valid = false;

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -50,13 +50,13 @@ namespace LXNAVVario {
    *   when PLXVF is active)
    * - LXWP1 every 60 seconds
    * - LXWP2 every 5 seconds (contains MC, ballast, bugs - more frequent for better sync)
-   * - LXWP3 disabled (we don't parse it)
+   * - LXWP3 every 5 seconds (variofil; changes rarely on the vario)
    * - LXWP5 disabled (we don't parse it)
    */
   static inline void
   SetupNMEA(Port &port, OperationEnvironment &env)
   {
-    PortWriteNMEA(port, "PLXV0,NMEARATE,W,10,5,1,60,5,0,0", env);
+    PortWriteNMEA(port, "PLXV0,NMEARATE,W,10,5,1,60,5,5,0", env);
   }
 
   /**

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -43,9 +43,11 @@ namespace LXNAVVario {
   /**
    * Set up the NMEA sentences sent by the vario:
    *
-   * - PLXVF at 2 Hz
+   * - PLXVF at 10 Hz (total-energy vario, IAS, pressure altitude; spec
+   *   recommends 20, 10, 5, 2, 1)
    * - PLXVS every 5 seconds
-   * - LXWP0 every second
+   * - LXWP0 every second (TAS, altitude, wind; six TE samples ignored
+   *   when PLXVF is active)
    * - LXWP1 every 60 seconds
    * - LXWP2 every 5 seconds (contains MC, ballast, bugs - more frequent for better sync)
    * - LXWP3 disabled (we don't parse it)
@@ -54,7 +56,7 @@ namespace LXNAVVario {
   static inline void
   SetupNMEA(Port &port, OperationEnvironment &env)
   {
-    PortWriteNMEA(port, "PLXV0,NMEARATE,W,2,5,1,60,5,0,0", env);
+    PortWriteNMEA(port, "PLXV0,NMEARATE,W,10,5,1,60,5,0,0", env);
   }
 
   /**

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -240,6 +240,8 @@ LXDevice::OnCalculatedUpdate([[maybe_unused]] const MoreData &basic,
   }
 
   if (should_request_settings) {
+    LXNAVVario::SetupNMEA(port, env);
+
     {
       const std::lock_guard lock{mutex};
       mc_requested = true;

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -77,7 +77,7 @@ ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario)
 }
 
 bool
-LXWP0(NMEAInputLine &line, NMEAInfo &info)
+LXWP0(NMEAInputLine &line, NMEAInfo &info, bool provide_vario)
 {
   /*
   $LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1
@@ -111,8 +111,11 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info)
      */
     info.ProvideTrueAirspeed(Units::ToSysUnit(airspeed, Unit::KILOMETER_PER_HOUR));
 
-  if (ReadFilteredLXWP0Vario(line, value))
-    info.ProvideTotalEnergyVario(value);
+  if (provide_vario) {
+    if (ReadFilteredLXWP0Vario(line, value))
+      info.ProvideTotalEnergyVario(value);
+  } else
+    line.Skip(6);
 
   line.Skip(1); // heading
 
@@ -518,13 +521,15 @@ PLXVC(NMEAInputLine &line, NMEAInfo &info,
 }
 
 /**
- * Parse the $PLXVF sentence (LXNAV sVarios (including V7)).
+ * Parse the $PLXVF sentence (LXNAV sVarios (including V7, S80)).
  *
  * $PLXVF,time ,AccX,AccY,AccZ,Vario,IAS,PressAlt*CS<CR><LF>
  *
  * Example: $PLXVF,,1.00,0.87,-0.12,-0.25,90.2,244.3,*CS<CR><LF>
  *
- * @see http://www.xcsoar.org/trac/raw-attachment/ticket/1666/V7%20dataport%20specification%201.97.pdf
+ * The Vario field carries total-energy vario at the configured rate
+ * (typically 10–20 Hz).  $LXWP0 still sends six TE samples per second,
+ * but those are only used when $PLXVF is unavailable.
  */
 static bool
 PLXVF(NMEAInputLine &line, NMEAInfo &info)
@@ -543,7 +548,7 @@ PLXVF(NMEAInputLine &line, NMEAInfo &info)
 
   double vario;
   if (line.ReadChecked(vario))
-    info.ProvideNettoVario(vario);
+    info.ProvideTotalEnergyVario(vario);
 
   double ias;
   bool have_ias = line.ReadChecked(ias);
@@ -717,7 +722,8 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 
   const auto type = line.ReadView();
   if (type == "$LXWP0"sv)
-    return LX::LXWP0(line, info);
+    return LX::LXWP0(line, info,
+                      !(plxvf_received || IsLXNAVVario()));
 
   if (type == "$LXWP1"sv) {
     DeviceInfo &device_info = mode == Mode::PASS_THROUGH
@@ -757,6 +763,7 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 
   if (type == "$PLXVF"sv) {
     is_colibri = false;
+    plxvf_received = true;
     return PLXVF(line, info);
   }
 

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -220,6 +220,11 @@ LXWP3(NMEAInputLine &line, NMEAInfo &info)
     info.settings.ProvideQNH(qnh, info.clock);
   }
 
+  line.Skip(); // scmode
+
+  if (line.ReadChecked(value))
+    info.settings.ProvideVarioFilterPeriod(value, info.clock);
+
   return true;
 }
 

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -57,6 +57,26 @@ ShouldSwitchHostBaudForNinc(const DeviceInfo &device_info) noexcept
 namespace LX {
 
 bool
+ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario)
+{
+  static constexpr double fir_coefficients[] = {
+    -0.0421, 0.1628, 0.3793, 0.3793, 0.1628, -0.0421,
+  };
+
+  vario = 0;
+  bool vario_ok = true;
+  double value = 0;
+  for (double fir_b : fir_coefficients) {
+    if (!line.ReadChecked(value))
+      vario_ok = false;
+    else
+      vario += value * fir_b;
+  }
+
+  return vario_ok;
+}
+
+bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info)
 {
   /*
@@ -65,7 +85,7 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info)
    0 loger_stored (Y/N)
    1 IAS (kph) ----> Condor uses TAS!
    2 baroaltitude (m)
-   3-8 vario (m/s) (last 6 measurements in last second)
+   3-8 vario (m/s) (last 6 measurements in last second, FIR filtered)
    9 heading of plane
   10 windcourse (deg)
   11 windspeed (kph)
@@ -91,10 +111,10 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info)
      */
     info.ProvideTrueAirspeed(Units::ToSysUnit(airspeed, Unit::KILOMETER_PER_HOUR));
 
-  if (line.ReadChecked(value))
+  if (ReadFilteredLXWP0Vario(line, value))
     info.ProvideTotalEnergyVario(value);
 
-  line.Skip(6);
+  line.Skip(1); // heading
 
   if (SpeedVector wind; line.ReadSpeedVectorKPH(wind))
     info.ProvideExternalWind(wind);

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -22,7 +22,8 @@ bool
 ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario);
 
 bool
-LXWP0(NMEAInputLine &line, NMEAInfo &info);
+LXWP0(NMEAInputLine &line, NMEAInfo &info,
+      bool provide_vario=true);
 
 void
 LXWP1(NMEAInputLine &line, DeviceInfo &device);

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -14,6 +14,13 @@ struct DeviceInfo;
 
 namespace LX {
 
+/**
+ * Read six LXWP0 vario samples and apply the 5th-order low-pass FIR
+ * filter used by LX EOS.
+ */
+bool
+ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario);
+
 bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info);
 

--- a/src/Device/Driver/LX_EOS/LXEosParser.cpp
+++ b/src/Device/Driver/LX_EOS/LXEosParser.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Geo/SpeedVector.hpp"
+#include "Device/Driver/LX/Parsers.hpp"
 #include "LXEosDevice.hpp"
 #include "NMEA/Checksum.hpp"
 #include "NMEA/Info.hpp"
@@ -45,17 +46,8 @@ LXEosDevice::LXWP0(NMEAInputLine& line, NMEAInfo& info)
     info.ProvideTrueAirspeed(
       Units::ToSysUnit(airspeed, Unit::KILOMETER_PER_HOUR));
 
-  double vario = 0;
-  bool vario_ok = true;
-  double value = 0;
-  // Filter the 6 reading using 5th order low-pass FIR filter
-  static const double fir_coefficients[] = { -0.0421, 0.1628, 0.3793, 0.3793, 0.1628, -0.0421 };
-  for (double fir_b : fir_coefficients) {
-    vario_ok = vario_ok && line.ReadChecked(value);
-    vario += value * fir_b;
-  }
-
-  if (vario_ok)
+  double vario;
+  if (LX::ReadFilteredLXWP0Vario(line, vario))
     info.ProvideTotalEnergyVario(vario);
 
   line.Skip(1); // Heading

--- a/src/Engine/Util/VarioOutputFilter.cpp
+++ b/src/Engine/Util/VarioOutputFilter.cpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "VarioOutputFilter.hpp"
+
+#include "Math/LowPassFilter.hpp"
+
+#include <cmath>
+
+using namespace std::chrono_literals;
+
+void
+VarioOutputFilter::Reset(double value) noexcept
+{
+  time_defined = false;
+  output = value;
+}
+
+void
+VarioOutputFilter::Design(double new_period) noexcept
+{
+  period_seconds = new_period;
+  time_defined = false;
+}
+
+bool
+VarioOutputFilter::Update(double vario) noexcept
+{
+  if (period_seconds <= 0) {
+    output = vario;
+    return true;
+  }
+
+  const auto now = Clock::now();
+
+  if (!time_defined) {
+    last_filter_time = last_trail_time = now;
+    time_defined = true;
+    output = vario;
+    return true;
+  }
+
+  const double dt =
+    std::chrono::duration<double>(now - last_filter_time).count();
+  last_filter_time = now;
+
+  if (dt > 0) {
+    const double alpha = 1. - std::exp(-dt / period_seconds);
+    output = LowPassFilter(output, vario, alpha);
+  }
+
+  const double trail_dt =
+    std::chrono::duration<double>(now - last_trail_time).count();
+  if (trail_dt >= 1.) {
+    last_trail_time = now;
+    return true;
+  }
+
+  return false;
+}

--- a/src/Engine/Util/VarioOutputFilter.hpp
+++ b/src/Engine/Util/VarioOutputFilter.hpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <chrono>
+
+/**
+ * Low-pass filter for vario display outputs.  Uses a first-order
+ * exponential smoother with the device variofil time constant.
+ * Updates on every input sample (e.g. 10 Hz PLXVF); GPS time is not
+ * used because it advances too slowly for high-rate vario.
+ */
+class VarioOutputFilter {
+  using Clock = std::chrono::steady_clock;
+
+  Clock::time_point last_filter_time{};
+  Clock::time_point last_trail_time{};
+
+  bool time_defined = false;
+
+  double period_seconds = 0;
+  double output = 0;
+
+public:
+  void Reset(double value) noexcept;
+
+  /**
+   * Configure filter time constant (seconds).  Zero disables filtering
+   * (passthrough).
+   */
+  void Design(double period_seconds) noexcept;
+
+  /**
+   * Update filter state from a new vario sample.
+   *
+   * @return true when a trail/audio push sample should be emitted
+   * (~1 Hz when filtering, every sample when passthrough)
+   */
+  [[nodiscard]]
+  bool Update(double vario) noexcept;
+
+  [[gnu::pure]]
+  double GetOutput() const noexcept {
+    return output;
+  }
+
+  [[gnu::pure]]
+  bool IsActive() const noexcept {
+    return period_seconds > 0;
+  }
+};

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -288,7 +288,11 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
       ival_av_thermal = ValueToNeedlePos(Calculated().current_thermal.lift_rate);
   }
 
-  auto vval = Basic().brutto_vario;
+  auto vval = Basic().VarioOutputFilterActive()
+    ? (Basic().brutto_vario_available
+        ? Basic().FilteredBruttoVario()
+        : 0.)
+    : Basic().brutto_vario;
   ival = ValueToNeedlePos(vval);
   sval = ValueToNeedlePos(Calculated().sink_rate);
   if (Settings().show_average_needle) {

--- a/src/InfoBoxes/Content/Thermal.cpp
+++ b/src/InfoBoxes/Content/Thermal.cpp
@@ -27,13 +27,13 @@ SetVSpeed(InfoBoxData &data, double value) noexcept
 void
 UpdateInfoBoxVario(InfoBoxData &data) noexcept
 {
-  SetVSpeed(data, CommonInterface::Basic().brutto_vario);
+  SetVSpeed(data, CommonInterface::Basic().FilteredBruttoVario());
 }
 
 void
 UpdateInfoBoxVarioNetto(InfoBoxData &data) noexcept
 {
-  SetVSpeed(data, CommonInterface::Basic().netto_vario);
+  SetVSpeed(data, CommonInterface::Basic().FilteredNettoVario());
 }
 
 void

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -33,6 +33,8 @@
 #include "UIReceiveBlackboard.hpp"
 #include "UISettings.hpp"
 #include "Interface.hpp"
+
+#include <utility>
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 
@@ -1004,10 +1006,23 @@ MainWindow::RunTimer() noexcept
 }
 
 void
+MainWindow::SendGPSUpdate(const bool vario_bar_redraw) noexcept
+{
+  vario_bar_redraw_pending = vario_bar_redraw;
+  gps_notify.SendNotification();
+}
+
+void
 MainWindow::OnGpsNotify() noexcept
 {
   PopupOperationEnvironment env;
   UIReceiveSensorData(env);
+
+  if (std::exchange(vario_bar_redraw_pending, false) &&
+      CommonInterface::GetMapSettings().vario_bar_enabled) {
+    if (GlueMapWindow *m = GetMapIfActive())
+      m->InjectRedraw();
+  }
 }
 
 void

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -137,6 +137,7 @@ private:
   bool restore_page_pending = false;
   bool refresh_info_boxes_pending = false;
   bool page_actions_update_pending = false;
+  bool vario_bar_redraw_pending = false;
 
   /**
    * Has "late" initialization been done already?  Those are things
@@ -304,9 +305,7 @@ public:
 
   void SetFullScreen(bool _full_screen) noexcept;
 
-  void SendGPSUpdate() noexcept {
-    gps_notify.SendNotification();
-  }
+  void SendGPSUpdate(bool vario_bar_redraw=false) noexcept;
 
   void SendCalculatedUpdate() noexcept {
     calculated_notify.SendNotification();

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -45,7 +45,7 @@ MergeThread::Process() noexcept
 
   computer.Fill(device_blackboard.SetMoreData(), settings_computer);
   computer.Compute(device_blackboard.SetMoreData(), last_any, last_fix,
-                   device_blackboard.Calculated());
+                   device_blackboard.Calculated(), settings_computer);
 
   flarm_computer.Process(device_blackboard.SetBasic().flarm,
                          last_fix.flarm, basic);
@@ -64,6 +64,7 @@ MergeThread::Tick() noexcept
   TracePoint::Time trail_push_time{};
   float trail_push_vario = 0;
   bool do_trail_vario_push = false;
+  bool vario_output_updated = false;
 
   {
     const std::lock_guard lock{device_blackboard.mutex};
@@ -77,11 +78,19 @@ MergeThread::Tick() noexcept
         basic.time_available &&
         basic.location_available &&
         basic.NavAltitudeAvailable() &&
-        calculated.flight.flying &&
-        basic.netto_vario_available) {
-      do_trail_vario_push = true;
-      trail_push_time = basic.time.Cast<TracePoint::Time>();
-      trail_push_vario = (float)basic.netto_vario;
+        calculated.flight.flying) {
+      if (!computer.FilteredVarioActive()) {
+        if (basic.netto_vario_available) {
+          do_trail_vario_push = true;
+          trail_push_time = basic.time.Cast<TracePoint::Time>();
+          trail_push_vario = (float)basic.netto_vario;
+        }
+      } else if (basic.brutto_vario_available &&
+                 computer.FilteredVarioSampleUpdated()) {
+        do_trail_vario_push = true;
+        trail_push_time = basic.time.Cast<TracePoint::Time>();
+        trail_push_vario = (float)basic.FilteredNettoVario();
+      }
     }
 
     /* call Driver::OnSensorUpdate() on all devices */
@@ -98,9 +107,18 @@ MergeThread::Tick() noexcept
       (bool)last_any.location_available != (bool)basic.location_available;
 
 #ifdef HAVE_PCM_PLAYER
-    vario_available = basic.brutto_vario_available;
-    vario = vario_available ? basic.brutto_vario : 0;
+    if (!computer.FilteredVarioActive()) {
+      vario_available = basic.brutto_vario_available;
+      vario = vario_available ? basic.brutto_vario : 0;
+    } else {
+      vario_available = basic.filtered_brutto_vario_available;
+      vario = vario_available ? basic.FilteredBruttoVario() : 0;
+    }
 #endif
+
+    /* Throttle map vario-bar redraws to ~1 Hz when the LX filter is active. */
+    vario_output_updated = !computer.FilteredVarioActive() ||
+      computer.FilteredVarioSampleUpdated();
 
     /* update last_any in every iteration */
     last_any = basic;
@@ -128,5 +146,5 @@ MergeThread::Tick() noexcept
   if (calculated_updated)
     TriggerCalculatedUpdate();
 
-  TriggerVarioUpdate();
+  TriggerVarioUpdate(vario_output_updated);
 }

--- a/src/NMEA/ExternalSettings.cpp
+++ b/src/NMEA/ExternalSettings.cpp
@@ -13,6 +13,7 @@ ExternalSettings::Clear()
   bugs_available.Clear();
   qnh_available.Clear();
   volume_available.Clear();
+  vario_filter_period_available.Clear();
   elevation_available.Clear();
   has_active_frequency.Clear();
   active_frequency.Clear();
@@ -87,6 +88,12 @@ ExternalSettings::Complement(const ExternalSettings &add)
   if (add.volume_available.Modified(volume_available)) {
     volume = add.volume;
     volume_available = add.volume_available;
+  }
+
+  if (add.vario_filter_period_available.Modified(
+        vario_filter_period_available)) {
+    vario_filter_period = add.vario_filter_period;
+    vario_filter_period_available = add.vario_filter_period_available;
   }
 
   if (add.elevation_available.Modified(elevation_available)) {
@@ -367,6 +374,21 @@ ExternalSettings::ProvideVolume(unsigned value, TimeStamp time) noexcept
 
   volume = value;
   volume_available.Update(time);
+  return true;
+}
+
+bool
+ExternalSettings::ProvideVarioFilterPeriod(double value,
+                                           TimeStamp time) noexcept
+{
+  if (value < 0 || value > 60)
+    return false;
+
+  if (CompareVarioFilterPeriod(value))
+    return false;
+
+  vario_filter_period = value;
+  vario_filter_period_available.Update(time);
   return true;
 }
 

--- a/src/NMEA/ExternalSettings.hpp
+++ b/src/NMEA/ExternalSettings.hpp
@@ -63,6 +63,11 @@ struct ExternalSettings {
   /** the volume of the device [0-100%] */
   unsigned volume;
 
+  Validity vario_filter_period_available;
+
+  /** Vario display filter time constant from device [s] */
+  double vario_filter_period;
+
   Validity elevation_available;
 
   /** the elevation setting [meters] */
@@ -222,6 +227,11 @@ struct ExternalSettings {
     return volume_available && abs(int(volume) - int(value)) < 3;
   }
 
+  bool CompareVarioFilterPeriod(double value) const {
+    return vario_filter_period_available &&
+      fabs(vario_filter_period - value) <= 0.05;
+  }
+
   /**
    * Compare the elevation setting with the specified value.
    *
@@ -277,6 +287,7 @@ struct ExternalSettings {
   bool ProvideBugs(double value, TimeStamp time) noexcept;
   bool ProvideQNH(AtmosphericPressure value, TimeStamp time) noexcept;
   bool ProvideVolume(unsigned value, TimeStamp time) noexcept;
+  bool ProvideVarioFilterPeriod(double value, TimeStamp time) noexcept;
   bool ProvideElevation(int value, TimeStamp time) noexcept;
   bool ProvidePolarCoefficients(double a, double b, double c, TimeStamp time) noexcept;
   bool ProvidePolarLoad(double value, TimeStamp time) noexcept;

--- a/src/NMEA/MoreData.cpp
+++ b/src/NMEA/MoreData.cpp
@@ -18,5 +18,11 @@ MoreData::Reset() noexcept
   brutto_vario = 0;
   brutto_vario_available.Clear();
 
+  filtered_brutto_vario = 0;
+  filtered_brutto_vario_available.Clear();
+
+  filtered_netto_vario = 0;
+  filtered_netto_vario_available.Clear();
+
   NMEAInfo::Reset();
 }

--- a/src/NMEA/MoreData.hpp
+++ b/src/NMEA/MoreData.hpp
@@ -36,10 +36,48 @@ struct MoreData : public NMEAInfo {
 
   Validity brutto_vario_available;
 
+  /** Low-pass filtered brutto vario for output consumers (MergeThread) */
+  double filtered_brutto_vario;
+
+  Validity filtered_brutto_vario_available;
+
+  /** Low-pass filtered netto vario for output consumers (trail colouring) */
+  double filtered_netto_vario;
+
+  Validity filtered_netto_vario_available;
+
   void Reset() noexcept;
 
   constexpr bool NavAltitudeAvailable() const noexcept {
     return baro_altitude_available || gps_altitude_available;
+  }
+
+  [[gnu::pure]]
+  constexpr bool VarioOutputFilterActive() const noexcept {
+    return settings.vario_filter_period_available &&
+      settings.vario_filter_period > 0;
+  }
+
+  /** Brutto vario after the LX output filter; raw brutto otherwise. */
+  [[gnu::pure]]
+  constexpr double FilteredBruttoVario() const noexcept {
+    if (!VarioOutputFilterActive())
+      return brutto_vario;
+
+    return filtered_brutto_vario_available
+      ? filtered_brutto_vario
+      : brutto_vario;
+  }
+
+  /** Netto vario after the LX output filter; raw netto otherwise. */
+  [[gnu::pure]]
+  constexpr double FilteredNettoVario() const noexcept {
+    if (!VarioOutputFilterActive())
+      return netto_vario;
+
+    return filtered_netto_vario_available
+      ? filtered_netto_vario
+      : netto_vario;
   }
 };
 

--- a/src/Protection.cpp
+++ b/src/Protection.cpp
@@ -40,11 +40,11 @@ ForceCalculation() noexcept
 }
 
 void
-TriggerVarioUpdate() noexcept
+TriggerVarioUpdate(const bool vario_bar_redraw) noexcept
 {
   assert(CommonInterface::main_window != nullptr);
 
-  CommonInterface::main_window->SendGPSUpdate();
+  CommonInterface::main_window->SendGPSUpdate(vario_bar_redraw);
 }
 
 void

--- a/src/Protection.hpp
+++ b/src/Protection.hpp
@@ -23,7 +23,7 @@ void
 ForceCalculation() noexcept;
 
 void
-TriggerVarioUpdate() noexcept;
+TriggerVarioUpdate(bool vario_bar_redraw=false) noexcept;
 
 /**
  * Trigger a redraw of the map window.

--- a/src/Renderer/VarioBarRenderer.cpp
+++ b/src/Renderer/VarioBarRenderer.cpp
@@ -62,7 +62,7 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
   int clipping_arrow_av_offset = Layout::Scale(4);
 //  int clipping_arrow_mc_offset = Layout::Scale(4);
 
-  auto vario_gross = basic.brutto_vario;
+  auto vario_gross = basic.FilteredBruttoVario();
 
   FormatUserVerticalSpeed(vario_gross, Value, false, true);
   canvas.Select(*look.font);

--- a/test/src/DebugReplay.cpp
+++ b/test/src/DebugReplay.cpp
@@ -46,7 +46,8 @@ DebugReplay::Compute()
   features.nav_baro_altitude_enabled = true;
   computer.Fill(computed_basic, qnh, features);
 
-  computer.Compute(computed_basic, last_basic, last_basic, calculated);
+  computer.Compute(computed_basic, last_basic, last_basic, calculated,
+                   ComputerSettings{.polar = {.glide_polar_task = glide_polar}});
   flying_computer.Compute(glide_polar.GetVTakeoff(),
                           computed_basic, calculated,
                           calculated.flight);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1296,7 +1296,7 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
   nmea_info.clock = TimeStamp{FloatDuration{1}};
 
   /* airspeed and vario available */
-  ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1*47",
+  ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,1.71,1.71,1.71,1.71,1.71,239,174,10.1*5E",
                         nmea_info));
   ok1((bool)nmea_info.pressure_altitude_available == !condor);
   ok1((bool)nmea_info.baro_altitude_available == condor);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1439,6 +1439,8 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
     ok1(device->ParseNMEA("$LXWP3,47.76,0,2.0,5.0,15,30,2.5,1.0,0,100,0.1,,0*08", nmea_info));
     ok1(nmea_info.settings.qnh_available);
     ok1(equals(nmea_info.settings.qnh.GetHectoPascal(), 1015));
+    ok1(nmea_info.settings.vario_filter_period_available);
+    ok1(equals(nmea_info.settings.vario_filter_period, 2.0));
   }
 
   delete device;
@@ -2908,7 +2910,7 @@ int main()
   plan_tests(1036 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
-             + 107 /* LXNav protocol 1.05 */
+             + 109 /* LXNav protocol 1.05 */
              + 8 /* SubSecond */ + 4 /* MWVStatus */
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1296,8 +1296,12 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
   nmea_info.clock = TimeStamp{FloatDuration{1}};
 
   /* airspeed and vario available */
-  ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,1.71,1.71,1.71,1.71,1.71,239,174,10.1*5E",
-                        nmea_info));
+  if (condor)
+    ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1*47",
+                          nmea_info));
+  else
+    ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,1.71,1.71,1.71,1.71,1.71,239,174,10.1*5E",
+                          nmea_info));
   ok1((bool)nmea_info.pressure_altitude_available == !condor);
   ok1((bool)nmea_info.baro_altitude_available == condor);
   ok1(equals(condor ? nmea_info.baro_altitude : nmea_info.pressure_altitude,
@@ -1576,8 +1580,8 @@ TestLXV7()
   lx_device.ResetDeviceDetection();
 
   ok1(device->ParseNMEA("$PLXVF,,1.00,0.87,-0.12,-0.25,90.2,244.3,*64", basic));
-  ok1(basic.netto_vario_available);
-  ok1(equals(basic.netto_vario, -0.25));
+  ok1(basic.total_energy_vario_available);
+  ok1(equals(basic.total_energy_vario, -0.25));
   ok1(basic.airspeed_available);
   ok1(equals(basic.indicated_airspeed, 90.2));
   ok1(basic.pressure_altitude_available);

--- a/test/src/TestFilteredVarioComputer.cpp
+++ b/test/src/TestFilteredVarioComputer.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Computer/FilteredVarioComputer.hpp"
+#include "NMEA/MoreData.hpp"
+#include "TestUtil.hpp"
+
+#include <thread>
+
+static void
+SetupVario(MoreData &data, double brutto, double netto) noexcept
+{
+  data.Reset();
+  data.clock = TimeStamp{FloatDuration{1}};
+  data.brutto_vario = brutto;
+  data.brutto_vario_available.Update(data.clock);
+  data.netto_vario = netto;
+  data.netto_vario_available.Update(data.clock);
+}
+
+static void
+TestPassthroughWithoutVariofil() noexcept
+{
+  MoreData data;
+  SetupVario(data, 2.5, 1.5);
+
+  FilteredVarioComputer computer;
+  computer.Compute(data, 1.0);
+
+  ok1(!data.VarioOutputFilterActive());
+  ok1(!computer.FilterActive());
+  ok1(!data.filtered_brutto_vario_available);
+  ok1(!data.filtered_netto_vario_available);
+  ok1(equals(data.FilteredBruttoVario(), 2.5));
+  ok1(equals(data.FilteredNettoVario(), 1.5));
+}
+
+static void
+TestPassthroughWithZeroVariofil() noexcept
+{
+  MoreData data;
+  SetupVario(data, 1.2, 0.4);
+  ok1(data.settings.ProvideVarioFilterPeriod(0, data.clock));
+
+  FilteredVarioComputer computer;
+  computer.Compute(data, 0.8);
+
+  ok1(!data.VarioOutputFilterActive());
+  ok1(!computer.FilterActive());
+  ok1(!data.filtered_brutto_vario_available);
+  ok1(!data.filtered_netto_vario_available);
+  ok1(equals(data.FilteredBruttoVario(), 1.2));
+  ok1(equals(data.FilteredNettoVario(), 0.4));
+}
+
+static void
+TestActiveFilter() noexcept
+{
+  MoreData data;
+  SetupVario(data, 1.0, 0.5);
+  ok1(data.settings.ProvideVarioFilterPeriod(2.0, data.clock));
+
+  FilteredVarioComputer computer;
+  constexpr double sink_rate = 0.3;
+
+  computer.Compute(data, sink_rate);
+  ok1(data.VarioOutputFilterActive());
+  ok1(computer.FilterActive());
+  ok1(data.filtered_brutto_vario_available);
+  ok1(data.filtered_netto_vario_available);
+  ok1(equals(data.filtered_brutto_vario, 1.0));
+  ok1(equals(data.filtered_netto_vario, 1.0 - sink_rate));
+  ok1(equals(data.FilteredBruttoVario(), 1.0));
+  ok1(equals(data.FilteredNettoVario(), 1.0 - sink_rate));
+
+  /* Establish wall-clock timing before testing smoothing. */
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  computer.Compute(data, sink_rate);
+
+  data.brutto_vario = 3.0;
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  computer.Compute(data, sink_rate);
+
+  ok1(data.filtered_brutto_vario_available);
+  ok1(data.filtered_brutto_vario > 1.0);
+  ok1(data.filtered_brutto_vario < 3.0);
+  ok1(equals(data.filtered_netto_vario,
+             data.filtered_brutto_vario - sink_rate));
+}
+
+int
+main()
+{
+  plan_tests(26);
+
+  TestPassthroughWithoutVariofil();
+  TestPassthroughWithZeroVariofil();
+  TestActiveFilter();
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary

- Fix LX `$LXWP0` parsing: read all six TE vario samples through the shared 5th-order FIR filter (same as LX EOS), fixing misaligned heading/wind fields.
- Prefer `$PLXVF` for high-rate total-energy vario on sVario devices; request it at 10 Hz via NMEARATE so 1 Hz `$LXWP0` cannot overwrite the fast path.
- Parse `$LXWP3` variofil into device settings and apply a wall-clock output filter so gauge, map vario bar, thermal rose, audio vario, and snail-trail colouring match the vario’s configured damping.

## Test plan

- [ ] Connect an LX sVario (or replay LX NMEA): confirm `$PLXVF` at 10 Hz and `$LXWP3` variofil parsed (check debug log / device settings).
- [ ] Verify vario gauge and audio respond smoothly without 10 Hz UI flicker; map vario bar on e-paper updates ~1 Hz when filter active.
- [ ] Confirm thermal detection/averages still use raw sensor vario, not filtered output.
- [ ] Run `make -j$(nproc) TARGET=UNIX USE_CCACHE=y check` (TestDriver LX cases updated).
- [ ] Test with non-LX vario: filtered fields passthrough when variofil unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LXNAV devices now apply their vario filter time to gauge output, vario bar, thermal rose, audio vario, and snail-trail coloring.
  * Added support for configuring the vario filter period via the LXWP3 variofil parameter.
  * Vario displays and audio now use filtered vario values for smoother, less noisy presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->