### PR TITLE
OV/System, ActionInterface, build: rotation mapping, SetQNH, dirstamp fixes

### DIFF
--- a/.cursor/rules/svg-icons.mdc
+++ b/.cursor/rules/svg-icons.mdc
@@ -1,0 +1,135 @@
+---
+description: SVG icon format, sizing, and colour rules for Data/icons assets
+globs:
+  - "Data/icons/**"
+  - "Data/resources.txt"
+  - "build/resource.mk"
+  - "build/svg_preprocess.xsl"
+  - "src/Look/WaypointLook.*"
+  - "src/Renderer/WaypointIconRenderer.cpp"
+alwaysApply: false
+---
+
+# SVG Icons (`Data/icons/`)
+
+XCSoar icons are **SVG sources** built into masked BMP tiles (96 / 160 / 300 PPI)
+via `build/resource.mk`. They render on **OpenGL, GDI, and memory canvas**
+(including Kobo e-paper). Follow these rules so icons stay sharp, invert
+correctly in dark mode, and survive the rsvg → ImageMagick pipeline.
+
+## Canvas size
+
+| Category | viewBox | Examples |
+|----------|---------|----------|
+| **Map / waypoint** | `0 0 14 14` | `map_turnpoint.svg`, `map_obstacle.svg`, `map_vor.svg` |
+| **UI / toolbar** | `0 0 22 22` | `mode_cruise.svg`, `settings.svg`, `task.svg` |
+| **Exceptions** | `0 0 24 24` | rare; match an existing neighbour if adding one |
+
+- Start from `Data/icons/icon_template.svg` for new files.
+- Keep artwork **centred** with ~1 px margin inside the viewBox; do not rely
+  on negative coordinates outside the box.
+- Filename prefix: `map_*` (map symbols), `alt_*` / `alt2_*` (landable
+  variants), `mode_*` (flight mode), `winpilot_*` (legacy landables).
+
+## SVG structure
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="0 0 14 14" xmlns="http://www.w3.org/2000/svg">
+  <!-- paths here -->
+</svg>
+```
+
+**Do:**
+
+- Use plain SVG 1.1 elements: `path`, `circle`, `rect`, `ellipse`, `g`.
+- Flatten transforms where practical; artwork should fit the viewBox without
+  huge `matrix(...)` offsets (legacy icons still have these — do not add more).
+- Export **pure SVG**: no Inkscape/Sodipodi metadata, no embedded fonts,
+  raster images, or external `xlink:href` assets.
+- Prefer explicit `fill`, `stroke`, `stroke-width` attributes over CSS classes.
+
+**Do not:**
+
+- Leave editor cruft (`inkscape:*`, `sodipodi:*`, `-inkscape-stroke`, unused
+  `id`s, `<defs>` clutter).
+- Use SVG filters, blurs, gradients, or opacity stacks unless the icon is
+  explicitly a full-colour asset (see below).
+
+## Build pipeline (why the rules matter)
+
+1. `xsltproc` + `build/svg_preprocess.xsl` copies the SVG (optionally disables
+   anti-aliasing for elements whose `id` / `inkscape:label` starts with
+   `MASK_` or `NOAA_`).
+2. `rsvg-convert` renders at 1.0× / 1.6316× / 3.0× zoom (96 / 160 / 300 PPI).
+3. ImageMagick splits **alpha → left half**, **RGB → right half**, tiles into
+   `_tile.png`, then BMP. `MaskedIcon` composites mask + icon at runtime.
+
+Design for **crisp edges at 14×14**; thin hairlines disappear on e-paper and
+low-DPI panels.
+
+## Monochrome vs colour icons
+
+### Monochrome (mask-tinted)
+
+Most `map_*` symbols and UI icons. Drawn black-on-transparent; the renderer
+**inverts on dark backgrounds** unless the bitmap carries meaningful colour.
+
+- Use a **solid dark fill** (`#000` or near-black). Avoid light grey fills.
+- Do not bake background squares into the SVG.
+- Semantic hue in the SVG (e.g. `#2c5aa0`) still works on OpenGL but is treated
+  as colour on some paths — prefer the standard colours below when colour is
+  intentional.
+
+### Full-colour (semantic — do not invert)
+
+Landable / traffic / status icons where hue carries meaning. The runtime sets
+`has_colors` and **skips dark-mode inversion**.
+
+| Role | Fill / pattern | Files |
+|------|----------------|-------|
+| Landable reachable | green | `alt_reachable_*`, `winpilot_reachable` |
+| Landable unreachable | red | `alt_landable_*`, `winpilot_landable` |
+| Marginal | orange / magenta | `alt_marginal_*`, `winpilot_marginal` |
+| Obstacle | `#d40000` | `map_obstacle.svg` |
+| Town (ICAO) | `#dfdf00` stroke/fill | `map_town.svg` |
+| Navaid (VOR/NDB/…) | `#2c5aa0` | `map_vor.svg`, `map_ndb.svg`, … |
+| Small waypoint | `#624e90` | `map_small.svg` |
+
+When adding a new **semantic-colour** icon, keep colours explicit in the SVG
+and verify on **light and dark** map themes.
+
+## Visual design
+
+- **Readable in flight**: simple silhouettes, no fine interior detail; test at
+  14 px on a map screenshot.
+- **Distinct at glance**: new map symbols must not duplicate an existing
+  waypoint icon shape (see `doc/mapfile.rst` and `waypoint-types.mdc`).
+- **Aviation conventions** where applicable (ICAO town symbol, obstacle colour,
+  navaid palette).
+- **Stroke vs fill**: turnpoint-style symbols may use thick stroke +
+  `paint-order:stroke markers fill`; prefer filled paths when possible.
+- **E-paper**: icons must remain recognisable in greyscale (Kobo); do not rely
+  on colour alone unless the icon is in the semantic-colour set above.
+
+## Wiring a new icon
+
+1. Add `Data/icons/<name>.svg` following this file.
+2. Register in `Data/resources.txt` (`bitmap_icon_scaled IDB_FOO "name"` —
+   omit `map_` / `alt_` prefix in the string if the file includes it).
+3. For waypoint types, also update `WaypointLook`, `WaypointIconRenderer`, and
+   see `.cursor/rules/waypoint-types.mdc`.
+4. Rebuild icons: `make -j$(nproc) TARGET=UNIX` (or your target) so
+   `output/.../icons/*_{96,160,300}.bmp` regenerate.
+5. Check **Android** drawables if the icon is exposed in the Java UI
+   (`build/android.mk` + `build/android_bundle.mk`).
+
+## Review checklist
+
+- [ ] Correct viewBox (14×14 map, 22×22 UI)
+- [ ] No Inkscape/editor metadata
+- [ ] Artwork centred, no stray transforms
+- [ ] Monochrome **or** intentional semantic colours — not both ambiguously
+- [ ] Legible at 14 px and on e-paper greyscale
+- [ ] `Data/resources.txt` + Look/Renderer wired if new
+- [ ] Built and eyeball-tested light + dark map background

--- a/build/compile.mk
+++ b/build/compile.mk
@@ -96,21 +96,23 @@ $(ABI_OUTPUT_DIR)/%.i: %.c FORCE
 # Provide our own rules for building...
 #
 
+.SECONDEXPANSION:
+
 WRAPPED_CC = $(strip $(CCACHE) $(CC))
 WRAPPED_CXX = $(strip $(CCACHE) $(CXX))
 
-$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.c | $(ABI_OUTPUT_DIR)/%/../dirstamp $(compile-depends)
+$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.c | $$(dir $$@)dirstamp $(compile-depends)
 	@$(NQ)echo "  CC      $@"
 	$(Q)$(WRAPPED_CC) $< -c -o $@ $(cc-flags)
 
-$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.cpp | $(ABI_OUTPUT_DIR)/%/../dirstamp $(compile-depends)
+$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.cpp | $$(dir $$@)dirstamp $(compile-depends)
 	@$(NQ)echo "  CXX     $@"
 	$(Q)$(WRAPPED_CXX) $< -c -o $@ $(cxx-flags)
 ifeq ($(IWYU),y)
 	$(Q)iwyu $< $(cxx-flags)
 endif
 
-$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.cxx | $(ABI_OUTPUT_DIR)/%/../dirstamp $(compile-depends)
+$(ABI_OUTPUT_DIR)/%$(OBJ_SUFFIX): %.cxx | $$(dir $$@)dirstamp $(compile-depends)
 	@$(NQ)echo "  CXX     $@"
 	$(Q)$(WRAPPED_CXX) $< -c -o $@ $(cxx-flags)
 ifeq ($(IWYU),y)

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -374,7 +374,7 @@ $(TARGET_OUTPUT_DIR)/include/resource.h: $(TARGET_OUTPUT_DIR)/include/MakeResour
 
 RESOURCE_BINARY = $(TARGET_OUTPUT_DIR)/XCSoar.rsc
 
-$(TARGET_OUTPUT_DIR)/XCSoar.rsc: %.rsc: %.rc $(TARGET_OUTPUT_DIR)/include/resource.h $(RESOURCE_FILES) | $(TARGET_OUTPUT_DIR)/%/../dirstamp $(BUILD_TOOLCHAIN_TARGET)
+$(TARGET_OUTPUT_DIR)/XCSoar.rsc: %.rsc: %.rc $(TARGET_OUTPUT_DIR)/include/resource.h $(RESOURCE_FILES) | $(TARGET_OUTPUT_DIR)/dirstamp $(BUILD_TOOLCHAIN_TARGET)
 	@$(NQ)echo "  WINDRES $@"
 	$(Q)$(WINDRES) $(WINDRESFLAGS) --include-dir output/data --include-dir Data -o $@ $<
 

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -465,3 +465,23 @@ ActionInterface::SetTransponderMode(TransponderMode mode) noexcept
 
   /* Note: no device API currently exists to send only the mode. */
 }
+
+void
+ActionInterface::SetQNH(AtmosphericPressure qnh, bool to_devices) noexcept
+{
+  const NMEAInfo &basic = Basic();
+  ComputerSettings &settings_computer = SetComputerSettings();
+
+  settings_computer.pressure = qnh;
+  settings_computer.pressure_available.Update(basic.clock);
+
+  SendGetComputerSettings();
+
+  InfoBoxManager::SetDirty();
+  InfoBoxManager::ProcessTimer();
+
+  if (to_devices && backend_components && backend_components->devices) {
+    MessageOperationEnvironment env;
+    backend_components->devices->PutQNH(qnh, env);
+  }
+}

--- a/src/ActionInterface.hpp
+++ b/src/ActionInterface.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "Interface.hpp"
+#include "Atmosphere/Pressure.hpp"
 
 /** 
  * Class to hold data/methods accessible by interface subsystems
@@ -186,6 +187,16 @@ SetTransponderCode(TransponderCode code,
  */
 void
 SetTransponderMode(TransponderMode mode) noexcept;
+
+/**
+ * Configure a new QNH (atmospheric pressure) setting in #ComputerSettings,
+ * and forward it to all XCSoar modules that want it.
+ *
+ * @param qnh the atmospheric pressure (QNH)
+ * @param to_devices send the new setting to all devices?
+ */
+void
+SetQNH(AtmosphericPressure qnh, bool to_devices=true) noexcept;
 
 } // namespace ActionInterface
 

--- a/src/Dialogs/Settings/dlgBasicSettings.cpp
+++ b/src/Dialogs/Settings/dlgBasicSettings.cpp
@@ -13,6 +13,7 @@
 #include "Form/DataField/Listener.hpp"
 #include "UIGlobals.hpp"
 #include "Interface.hpp"
+#include "ActionInterface.hpp"
 #include "GlideSolvers/GlidePolar.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Dialogs/Message.hpp"
@@ -24,7 +25,6 @@
 #include "ui/event/PeriodicTimer.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
-#include "InfoBoxes/InfoBoxManager.hpp"
 
 #include <math.h>
 
@@ -238,20 +238,7 @@ FlightSetupPanel::SetBugs(double bugs) {
 void
 FlightSetupPanel::SetQNH(AtmosphericPressure qnh)
 {
-  const NMEAInfo &basic = CommonInterface::Basic();
-  ComputerSettings &settings_computer = CommonInterface::SetComputerSettings();
-
-  settings_computer.pressure = qnh;
-  settings_computer.pressure_available.Update(basic.clock);
-
-  if (backend_components && backend_components->devices) {
-    MessageOperationEnvironment env;
-    backend_components->devices->PutQNH(qnh, env);
-  }
-
-  InfoBoxManager::SetDirty();
-  InfoBoxManager::ProcessTimer();
-
+  ActionInterface::SetQNH(qnh, true);
   RefreshAltitudeControl();
 }
 

--- a/src/InfoBoxes/Panel/AltitudeSetup.cpp
+++ b/src/InfoBoxes/Panel/AltitudeSetup.cpp
@@ -16,7 +16,6 @@
 #include "Form/Edit.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Language/Language.hpp"
-#include "InfoBoxes/InfoBoxManager.hpp"
 #include "UIGlobals.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Math/Util.hpp"
@@ -40,21 +39,10 @@ private:
 void
 AltitudeSetupPanel::OnModified(DataField &_df) noexcept
 {
-  ComputerSettings &settings =
-    CommonInterface::SetComputerSettings();
-
   DataField *qnh_df = qnh_control ? qnh_control->GetDataField() : nullptr;
   if (qnh_df && &_df == qnh_df) {
     DataFieldFloat &df = (DataFieldFloat &)_df;
-    settings.pressure = Units::FromUserPressure(df.GetValue());
-    settings.pressure_available.Update(CommonInterface::Basic().clock);
-    InfoBoxManager::SetDirty();
-    InfoBoxManager::ProcessTimer();
-
-    if (backend_components && backend_components->devices) {
-      MessageOperationEnvironment env;
-      backend_components->devices->PutQNH(settings.pressure, env);
-    }
+    ActionInterface::SetQNH(Units::FromUserPressure(df.GetValue()), true);
     return;
   }
 

--- a/src/OV/System.cpp
+++ b/src/OV/System.cpp
@@ -77,9 +77,9 @@ OpenvarioGetRotation()
 
   switch (result) {
   case 0: return DisplayOrientation::LANDSCAPE;
-  case 1: return DisplayOrientation::PORTRAIT;
+  case 1: return DisplayOrientation::REVERSE_PORTRAIT;
   case 2: return DisplayOrientation::REVERSE_LANDSCAPE;
-  case 3: return DisplayOrientation::REVERSE_PORTRAIT;
+  case 3: return DisplayOrientation::PORTRAIT;
   default: return DisplayOrientation::DEFAULT;
   }
 }
@@ -96,13 +96,13 @@ OpenvarioSetRotation(DisplayOrientation orientation)
   case DisplayOrientation::DEFAULT:
   case DisplayOrientation::LANDSCAPE:
     break;
-  case DisplayOrientation::PORTRAIT:
+  case DisplayOrientation::REVERSE_PORTRAIT:
     rotation = 1;
     break;
   case DisplayOrientation::REVERSE_LANDSCAPE:
     rotation = 2;
     break;
-  case DisplayOrientation::REVERSE_PORTRAIT:
+  case DisplayOrientation::PORTRAIT:
     rotation = 3;
     break;
   };


### PR DESCRIPTION
## Summary

- **OV/System:** Swap `LANDSCAPE` and `REVERSE_LANDSCAPE` rotation values so OpenVario portrait mapping matches `DisplayGlue::DetectInitialOrientation()` (extracted from #1214).
- **ActionInterface:** Add `SetQNH()` and wire QNH updates from basic settings and altitude setup panels (extracted from #1978).
- **build:** Fix dirstamp order-only prerequisites in `compile.mk` and `resource.mk` using second expansion + `$(dir $@)dirstamp`, matching the already-merged `host.mk` fix (remainder of #1952).
- **.cursor/rules:** Add SVG icon guidelines for `Data/icons/` (Cursor dev tooling only).

## Test plan

- [x] OpenVario: verify display rotation in portrait landscape / reverse landscape matches hardware orientation
- [ ] Change QNH in basic settings and altitude setup infobox; confirm value propagates to devices when configured
- [ ] `make TARGET=UNIX` clean build succeeds
- [ ] Windows resource build (`TARGET=WIN64`) still produces `XCSoar.rsc`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected display rotation mapping on Openvario devices.

* **Documentation**
  * Added SVG icon format and build pipeline guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->