### PR TITLE
Dialogs/Plane: Show WeGlide type when upload is disabled

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,8 @@ Version 7.45 - not yet released
     vario bar, thermal rose, audio vario and snail-trail colouring
 * ui
   - macOS: thick solid lines now render at their correct pixel width #2545
+  - plane details: WeGlide aircraft type can be configured even when WeGlide
+    upload is disabled #2323
   - status dialog, Times: flight time matches takeoff and landing after
     minute rounding (including across midnight); landing time clears on a
     new takeoff in the same session #957

--- a/src/Dialogs/Plane/PlaneDetailsDialog.cpp
+++ b/src/Dialogs/Plane/PlaneDetailsDialog.cpp
@@ -109,9 +109,6 @@ PlaneEditWidget::UpdatePolarButton() noexcept
 void
 PlaneEditWidget::UpdateWeGlideName() noexcept
 {
-  if (!CommonInterface::GetComputerSettings().weglide.enabled)
-    return;
-
   if (plane.weglide_glider_type == 0) {
     SetText(WEGLIDE_NAME, "-");
     return;
@@ -166,15 +163,10 @@ PlaneEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
            "%.0f %s", "%.0f", 0, 300, 5,
            false, UnitGroup::HORIZONTAL_SPEED, plane.max_speed);
 
-  if (CommonInterface::GetComputerSettings().weglide.enabled) {
-    auto *row = AddInteger(_("WeGlide Type"), nullptr, "%u", "%u", 0,
-                           9999, 1, plane.weglide_glider_type, this);
-    row->SetEditCallback(EditWeGlideType);
-    AddReadOnly(_("WeGlide Aircraft"), nullptr, "");
-  } else {
-    AddDummy();
-    AddDummy();
-  }
+  auto *row = AddInteger(_("WeGlide Type"), nullptr, "%u", "%u", 0,
+                         9999, 1, plane.weglide_glider_type, this);
+  row->SetEditCallback(EditWeGlideType);
+  AddReadOnly(_("WeGlide Aircraft"), nullptr, "");
 
   UpdateCaption();
   UpdatePolarButton();
@@ -196,8 +188,7 @@ PlaneEditWidget::Save(bool &_changed) noexcept
   changed |= SaveValueInteger(DUMP_TIME, plane.dump_time);
   changed |= SaveValue(MAX_SPEED, UnitGroup::HORIZONTAL_SPEED,
                        plane.max_speed);
-  if (CommonInterface::GetComputerSettings().weglide.enabled)
-    changed |= SaveValueInteger(WEGLIDE_ID, plane.weglide_glider_type);
+  changed |= SaveValueInteger(WEGLIDE_ID, plane.weglide_glider_type);
 
   _changed |= changed;
   return true;


### PR DESCRIPTION
## Summary
- Always show WeGlide Type and WeGlide Aircraft in plane details, regardless of whether WeGlide upload is enabled
- Always persist `weglide_glider_type` when saving plane details
- Document the change in NEWS.txt

Closes #2323

## Test plan
- [ ] Open plane details with WeGlide upload disabled; confirm WeGlide Type and WeGlide Aircraft rows are visible
- [ ] Set a WeGlide type, save, reopen plane details; confirm the value persists
- [ ] With WeGlide upload enabled, confirm existing behaviour is unchanged
- [ ] Verify the type picker still loads the aircraft list (cache or download)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WeGlide aircraft type can now be configured and edited in the aircraft details dialog even when WeGlide upload is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->