### PR TITLE
Cloud: Refactor xcsoar-cloud-server glue and batch sender

### DIFF
--- a/build/cloud.mk
+++ b/build/cloud.mk
@@ -6,6 +6,7 @@ CLOUD_SERVER_SOURCES = \
 	$(SRC)/Cloud/Thermal.cpp \
 	$(SRC)/Cloud/Data.cpp \
 	$(SRC)/Cloud/Sender.cpp \
+	$(SRC)/Cloud/CloudGlue.cpp \
 	$(SRC)/Cloud/Main.cpp
 CLOUD_SERVER_DEPENDS = ASYNC LIBNET IO OS GEO MATH UTIL
 $(eval $(call link-program,xcsoar-cloud-server,CLOUD_SERVER))

--- a/src/Cloud/Client.cpp
+++ b/src/Cloud/Client.cpp
@@ -156,7 +156,7 @@ CloudClient::Save(Serialiser &s) const
   if (altitude != -1)
     flags |= SkyLinesTracking::FixPacket::FLAG_ALTITUDE;
 
-  s.WriteT(SkyLinesTracking::MakeFix(key, flags, 0,
+  s.WriteT(SkyLinesTracking::MakeFix(key, flags, traffic_time_ms,
                                      location, Angle::Zero(), 0, 0,
                                      altitude, 0, 0));
 
@@ -186,6 +186,10 @@ CloudClient::Load(Deserialiser &s)
                      SkyLinesTracking::ImportGeoPoint(fix.location),
                      (int16_t)FromBE16(fix.altitude));
   client.stamp = stamp;
+  const auto t = SkyLinesTracking::ImportTimeMs(fix.time).count();
+  client.traffic_time_ms =
+    t <= 0 ? 0
+           : (t >= 86400000LL ? 86399999U : static_cast<uint32_t>(t));
   return client;
 }
 

--- a/src/Cloud/Client.hpp
+++ b/src/Cloud/Client.hpp
@@ -74,6 +74,12 @@ struct CloudClient
    */
   int altitude;
 
+  /**
+   * UTC milliseconds since midnight from the client's last submitted fix
+   * (#TrafficResponsePacket::Traffic::time).
+   */
+  uint32_t traffic_time_ms = 0;
+
   struct KeyHash {
     constexpr std::size_t operator()(uint64_t key) const {
       return key;

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "CloudGlue.hpp"
+#include "Data.hpp"
+#include "Dump.hpp"
+#include "Sender.hpp"
+
+#include <iostream>
+#include <iomanip>
+
+using std::cout;
+using std::endl;
+
+void
+CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
+                 std::chrono::milliseconds time_of_day,
+                 const GeoPoint &location, int altitude,
+                 std::chrono::steady_clock::time_point now,
+                 bool &schedule_expire)
+{
+  (void)time_of_day; // TODO: use this parameter
+
+  CloudClient *client;
+  schedule_expire = false;
+
+  auto &clients = data.clients;
+
+  if (location.IsValid()) {
+    const bool was_empty = clients.empty();
+
+    client = &clients.Make(c.address, c.key, location, altitude);
+
+    cout << "FIX\t"
+         << client->address << '\t'
+         << std::hex << client->key << std::dec << '\t'
+         << client->id << '\t'
+         << client->location << '\t'
+         << client->altitude << 'm'
+         << endl;
+
+    if (was_empty)
+      schedule_expire = true;
+  } else {
+    client = clients.Find(c.key);
+    if (client != nullptr)
+      clients.Refresh(*client, c.address);
+  }
+
+  for (const auto &i : clients.QueryWithinRange(location,
+                                                 policy.traffic_query_range_m)) {
+    if (i->key == c.key)
+      continue;
+
+    if (now > i->wants_traffic)
+      continue;
+
+    TrafficResponseSender s(server, i->address, i->key);
+    s.Add(client->id, 0, // TODO: time?
+          client->location, client->altitude);
+    s.Flush();
+  }
+}
+
+void
+CloudGlue::OnTrafficRequest(const SkyLinesTracking::Server::Client &c,
+                            bool near,
+                            std::chrono::steady_clock::time_point now)
+{
+  if (!near)
+    return;
+
+  auto &clients = data.clients;
+
+  auto *client = clients.Find(c.key);
+  if (client == nullptr)
+    return;
+
+  client->wants_traffic = now + policy.subscription_ttl;
+
+  const auto min_stamp = now - policy.live_max_traffic_age;
+
+  TrafficResponseSender s(server, c.address, c.key);
+
+  unsigned n = 0;
+  for (const auto &traffic :
+       clients.QueryWithinRange(client->location,
+                                policy.traffic_query_range_m)) {
+    if (traffic.get() == client)
+      continue;
+
+    if (traffic->stamp < min_stamp)
+      continue;
+
+    s.Add(traffic->id, 0, // TODO: time?
+          traffic->location, traffic->altitude);
+
+    if (++n > policy.max_traffic_per_response)
+      break;
+  }
+
+  s.Flush();
+}
+
+void
+CloudGlue::OnWaveSubmit(const SkyLinesTracking::Server::Client &c,
+                        [[maybe_unused]] std::chrono::milliseconds time_of_day,
+                        const GeoPoint &a, const GeoPoint &b,
+                        int bottom_altitude,
+                        int top_altitude,
+                        double lift)
+{
+  auto *client = data.clients.Find(c.key);
+  if (client == nullptr)
+    return;
+
+  cout << "WAVE\t"
+       << client->address << '\t'
+       << std::hex << client->key << std::dec << '\t'
+       << client->id << '\t'
+       << a << '\t'
+       << b << '\t'
+       << bottom_altitude << '-' << top_altitude << "m\t"
+       << lift << "m/s"
+       << endl;
+}
+
+void
+CloudGlue::OnThermalSubmit(const SkyLinesTracking::Server::Client &c,
+                           [[maybe_unused]] std::chrono::milliseconds time_of_day,
+                           const GeoPoint &bottom_location,
+                           int bottom_altitude,
+                           const GeoPoint &top_location,
+                           int top_altitude,
+                           double lift,
+                           std::chrono::steady_clock::time_point now)
+{
+  auto *client = data.clients.Find(c.key);
+  if (client == nullptr)
+    return;
+
+  cout << "THERMAL\t"
+       << client->address << '\t'
+       << std::hex << client->key << std::dec << '\t'
+       << client->id << '\t'
+       << top_location << '\t'
+       << bottom_altitude << '-' << top_altitude << "m\t"
+       << lift << "m/s"
+       << endl;
+
+  auto &thermals = data.thermals;
+  auto &clients = data.clients;
+
+  const auto &thermal =
+    thermals.Make(c.key,
+                  AGeoPoint(bottom_location, bottom_altitude),
+                  AGeoPoint(top_location, top_altitude),
+                  lift);
+
+  for (const auto &i : clients.QueryWithinRange(bottom_location,
+                                                policy.thermal_query_range_m)) {
+    if (i->key == c.key)
+      continue;
+
+    if (now > i->wants_thermals)
+      continue;
+
+    ThermalResponseSender s(server, i->address, i->key);
+    s.Add(thermal.Pack());
+    s.Flush();
+  }
+}
+
+void
+CloudGlue::OnThermalRequest(const SkyLinesTracking::Server::Client &c,
+                            std::chrono::steady_clock::time_point now)
+{
+  auto &clients = data.clients;
+  auto &thermals = data.thermals;
+
+  auto *client = clients.Find(c.key);
+  if (client == nullptr)
+    return;
+
+  client->wants_thermals = now + policy.subscription_ttl;
+
+  const auto min_time = now - policy.live_max_thermal_age;
+
+  ThermalResponseSender s(server, c.address, c.key);
+
+  unsigned n = 0;
+  for (const auto &thermal :
+       thermals.QueryWithinRange(client->location,
+                                 policy.thermal_query_range_m)) {
+    if (thermal->client_key == c.key)
+      continue;
+
+    if (thermal->time < min_time)
+      continue;
+
+    s.Add(thermal->Pack());
+
+    if (++n > policy.max_thermal_per_response)
+      break;
+  }
+
+  s.Flush();
+}

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -12,6 +12,22 @@
 using std::cout;
 using std::endl;
 
+namespace {
+
+/**
+ * Tab-separated address, hex SkyLines key, decimal public id (matches
+ * FIX/WAVE/THERMAL log lines).
+ */
+inline std::ostream &
+FormatCloudClientPrefix(std::ostream &os, const CloudClient &client)
+{
+  return os << client.address << '\t'
+            << std::hex << client.key << std::dec << '\t'
+            << client.id << '\t';
+}
+
+} // namespace
+
 void
 CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
                  std::chrono::milliseconds time_of_day,
@@ -31,13 +47,11 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
 
     client = &clients.Make(c.address, c.key, location, altitude);
 
-    cout << "FIX\t"
-         << client->address << '\t'
-         << std::hex << client->key << std::dec << '\t'
-         << client->id << '\t'
-         << client->location << '\t'
-         << client->altitude << 'm'
-         << endl;
+    cout << "FIX\t";
+    FormatCloudClientPrefix(cout, *client)
+      << client->location << '\t'
+      << client->altitude << 'm'
+      << endl;
 
     if (was_empty)
       schedule_expire = true;
@@ -114,15 +128,13 @@ CloudGlue::OnWaveSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  cout << "WAVE\t"
-       << client->address << '\t'
-       << std::hex << client->key << std::dec << '\t'
-       << client->id << '\t'
-       << a << '\t'
-       << b << '\t'
-       << bottom_altitude << '-' << top_altitude << "m\t"
-       << lift << "m/s"
-       << endl;
+  cout << "WAVE\t";
+  FormatCloudClientPrefix(cout, *client)
+    << a << '\t'
+    << b << '\t'
+    << bottom_altitude << '-' << top_altitude << "m\t"
+    << lift << "m/s"
+    << endl;
 }
 
 void
@@ -139,14 +151,12 @@ CloudGlue::OnThermalSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  cout << "THERMAL\t"
-       << client->address << '\t'
-       << std::hex << client->key << std::dec << '\t'
-       << client->id << '\t'
-       << top_location << '\t'
-       << bottom_altitude << '-' << top_altitude << "m\t"
-       << lift << "m/s"
-       << endl;
+  cout << "THERMAL\t";
+  FormatCloudClientPrefix(cout, *client)
+    << top_location << '\t'
+    << bottom_altitude << '-' << top_altitude << "m\t"
+    << lift << "m/s"
+    << endl;
 
   auto &thermals = data.thermals;
   auto &clients = data.clients;

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -21,7 +21,7 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
 {
   (void)time_of_day; // TODO: use this parameter
 
-  CloudClient *client;
+  CloudClient *client = nullptr;
   schedule_expire = false;
 
   auto &clients = data.clients;
@@ -46,6 +46,9 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
     if (client != nullptr)
       clients.Refresh(*client, c.address);
   }
+
+  if (client == nullptr)
+    return;
 
   for (const auto &i : clients.QueryWithinRange(location,
                                                  policy.traffic_query_range_m)) {

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -12,6 +12,25 @@
 
 #include <cstdio>
 
+namespace {
+
+/** SkyLines traffic time is ms since UTC midnight; clamp to one day. */
+constexpr uint32_t
+MsSinceMidnightUtc(std::chrono::milliseconds time_of_day) noexcept
+{
+  const auto c = time_of_day.count();
+  if (c <= 0)
+    return 0;
+
+  constexpr auto day_ms = 86400000LL;
+  if (c >= day_ms)
+    return static_cast<uint32_t>(day_ms - 1);
+
+  return static_cast<uint32_t>(c);
+}
+
+} // namespace
+
 void
 CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
                  std::chrono::milliseconds time_of_day,
@@ -19,8 +38,6 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
                  std::chrono::steady_clock::time_point now,
                  bool &schedule_expire)
 {
-  (void)time_of_day; // TODO: use this parameter
-
   CloudClient *client = nullptr;
   schedule_expire = false;
 
@@ -30,6 +47,7 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
     const bool was_empty = clients.empty();
 
     client = &clients.Make(c.address, c.key, location, altitude);
+    client->traffic_time_ms = MsSinceMidnightUtc(time_of_day);
 
     fmt::print(stdout,
                "FIX\t{}\t{:x}\t{}\t{}\t{}m\n",
@@ -59,7 +77,7 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
       continue;
 
     TrafficResponseSender s(server, i->address, i->key);
-    s.Add(client->id, 0, // TODO: time?
+    s.Add(client->id, client->traffic_time_ms,
           client->location, client->altitude);
     s.Flush();
   }
@@ -95,7 +113,7 @@ CloudGlue::OnTrafficRequest(const SkyLinesTracking::Server::Client &c,
     if (traffic->stamp < min_stamp)
       continue;
 
-    s.Add(traffic->id, 0, // TODO: time?
+    s.Add(traffic->id, traffic->traffic_time_ms,
           traffic->location, traffic->altitude);
 
     if (++n > policy.max_traffic_per_response)

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -29,6 +29,25 @@ MsSinceMidnightUtc(std::chrono::milliseconds time_of_day) noexcept
   return static_cast<uint32_t>(c);
 }
 
+/**
+ * One stdout line for this client: TAG, address, hex key, public id
+ * (tab-separated), then tail_fmt / tail_args. fflush when stdout is piped.
+ */
+inline void
+PrintCloudClientLogLine(const CloudClient &client, std::string_view tag,
+                        fmt::string_view tail_fmt,
+                        fmt::format_args tail_args)
+{
+  fmt::print(stdout,
+             "{}\t{}\t{:x}\t{}\t",
+             tag,
+             ToString(client.address),
+             client.key,
+             client.id);
+  fmt::vprint(stdout, tail_fmt, tail_args);
+  fflush(stdout);
+}
+
 } // namespace
 
 void
@@ -49,13 +68,11 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
     client = &clients.Make(c.address, c.key, location, altitude);
     client->traffic_time_ms = MsSinceMidnightUtc(time_of_day);
 
-    fmt::print(stdout,
-               "FIX\t{}\t{:x}\t{}\t{}\t{}m\n",
-               ToString(client->address),
-               client->key,
-               client->id,
-               fmt::streamed(client->location),
-               client->altitude);
+    const auto location_fmt = fmt::streamed(client->location);
+    PrintCloudClientLogLine(*client, "FIX",
+                           "{}\t{}m\n",
+                           fmt::make_format_args(location_fmt,
+                                                 client->altitude));
 
     if (was_empty)
       schedule_expire = true;
@@ -135,16 +152,15 @@ CloudGlue::OnWaveSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  fmt::print(stdout,
-             "WAVE\t{}\t{:x}\t{}\t{}\t{}\t{}-{}m\t{}m/s\n",
-             ToString(client->address),
-             client->key,
-             client->id,
-             fmt::streamed(a),
-             fmt::streamed(b),
-             bottom_altitude,
-             top_altitude,
-             lift);
+  const auto a_fmt = fmt::streamed(a);
+  const auto b_fmt = fmt::streamed(b);
+  PrintCloudClientLogLine(*client, "WAVE",
+                         "{}\t{}\t{}-{}m\t{}m/s\n",
+                         fmt::make_format_args(a_fmt,
+                                               b_fmt,
+                                               bottom_altitude,
+                                               top_altitude,
+                                               lift));
 }
 
 void
@@ -161,15 +177,13 @@ CloudGlue::OnThermalSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  fmt::print(stdout,
-             "THERMAL\t{}\t{:x}\t{}\t{}\t{}-{}m\t{}m/s\n",
-             ToString(client->address),
-             client->key,
-             client->id,
-             fmt::streamed(top_location),
-             bottom_altitude,
-             top_altitude,
-             lift);
+  const auto top_fmt = fmt::streamed(top_location);
+  PrintCloudClientLogLine(*client, "THERMAL",
+                         "{}\t{}-{}m\t{}m/s\n",
+                         fmt::make_format_args(top_fmt,
+                                               bottom_altitude,
+                                               top_altitude,
+                                               lift));
 
   auto &thermals = data.thermals;
   auto &clients = data.clients;

--- a/src/Cloud/CloudGlue.cpp
+++ b/src/Cloud/CloudGlue.cpp
@@ -5,28 +5,12 @@
 #include "Data.hpp"
 #include "Dump.hpp"
 #include "Sender.hpp"
+#include "net/ToString.hxx"
 
-#include <iostream>
-#include <iomanip>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
-using std::cout;
-using std::endl;
-
-namespace {
-
-/**
- * Tab-separated address, hex SkyLines key, decimal public id (matches
- * FIX/WAVE/THERMAL log lines).
- */
-inline std::ostream &
-FormatCloudClientPrefix(std::ostream &os, const CloudClient &client)
-{
-  return os << client.address << '\t'
-            << std::hex << client.key << std::dec << '\t'
-            << client.id << '\t';
-}
-
-} // namespace
+#include <cstdio>
 
 void
 CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
@@ -47,11 +31,13 @@ CloudGlue::OnFix(const SkyLinesTracking::Server::Client &c,
 
     client = &clients.Make(c.address, c.key, location, altitude);
 
-    cout << "FIX\t";
-    FormatCloudClientPrefix(cout, *client)
-      << client->location << '\t'
-      << client->altitude << 'm'
-      << endl;
+    fmt::print(stdout,
+               "FIX\t{}\t{:x}\t{}\t{}\t{}m\n",
+               ToString(client->address),
+               client->key,
+               client->id,
+               fmt::streamed(client->location),
+               client->altitude);
 
     if (was_empty)
       schedule_expire = true;
@@ -128,13 +114,16 @@ CloudGlue::OnWaveSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  cout << "WAVE\t";
-  FormatCloudClientPrefix(cout, *client)
-    << a << '\t'
-    << b << '\t'
-    << bottom_altitude << '-' << top_altitude << "m\t"
-    << lift << "m/s"
-    << endl;
+  fmt::print(stdout,
+             "WAVE\t{}\t{:x}\t{}\t{}\t{}\t{}-{}m\t{}m/s\n",
+             ToString(client->address),
+             client->key,
+             client->id,
+             fmt::streamed(a),
+             fmt::streamed(b),
+             bottom_altitude,
+             top_altitude,
+             lift);
 }
 
 void
@@ -151,12 +140,15 @@ CloudGlue::OnThermalSubmit(const SkyLinesTracking::Server::Client &c,
   if (client == nullptr)
     return;
 
-  cout << "THERMAL\t";
-  FormatCloudClientPrefix(cout, *client)
-    << top_location << '\t'
-    << bottom_altitude << '-' << top_altitude << "m\t"
-    << lift << "m/s"
-    << endl;
+  fmt::print(stdout,
+             "THERMAL\t{}\t{:x}\t{}\t{}\t{}-{}m\t{}m/s\n",
+             ToString(client->address),
+             client->key,
+             client->id,
+             fmt::streamed(top_location),
+             bottom_altitude,
+             top_altitude,
+             lift);
 
   auto &thermals = data.thermals;
   auto &clients = data.clients;

--- a/src/Cloud/CloudGlue.hpp
+++ b/src/Cloud/CloudGlue.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "CloudPolicy.hpp"
+
+#include "Tracking/SkyLines/Server.hpp"
+
+#include <chrono>
+
+struct CloudData;
+struct GeoPoint;
+
+/**
+ * Connects SkyLinesTracking::Server callbacks to #CloudData and outbound
+ * datagram responses.
+ */
+class CloudGlue {
+  CloudData &data;
+  const CloudPolicy &policy;
+  SkyLinesTracking::Server &server;
+
+public:
+  constexpr
+  CloudGlue(CloudData &_data, const CloudPolicy &_policy,
+            SkyLinesTracking::Server &_server) noexcept
+    :data(_data), policy(_policy), server(_server) {}
+
+  /** Register or refresh a client and fan out immediate traffic updates. */
+  void OnFix(const SkyLinesTracking::Server::Client &client,
+             std::chrono::milliseconds time_of_day,
+             const GeoPoint &location, int altitude,
+             std::chrono::steady_clock::time_point now,
+             bool &schedule_expire);
+
+  /** Answer a NEAR traffic request from a known client. */
+  void OnTrafficRequest(const SkyLinesTracking::Server::Client &client,
+                        bool near,
+                        std::chrono::steady_clock::time_point now);
+
+  /** Log wave submissions (no shared storage). */
+  void OnWaveSubmit(const SkyLinesTracking::Server::Client &client,
+                    std::chrono::milliseconds time_of_day,
+                    const GeoPoint &a, const GeoPoint &b,
+                    int bottom_altitude, int top_altitude, double lift);
+
+  /** Store a thermal and notify subscribers in range. */
+  void OnThermalSubmit(const SkyLinesTracking::Server::Client &client,
+                       std::chrono::milliseconds time_of_day,
+                       const GeoPoint &bottom_location,
+                       int bottom_altitude,
+                       const GeoPoint &top_location,
+                       int top_altitude,
+                       double lift,
+                       std::chrono::steady_clock::time_point now);
+
+  /** Send thermals near the requesting client. */
+  void OnThermalRequest(const SkyLinesTracking::Server::Client &client,
+                        std::chrono::steady_clock::time_point now);
+};

--- a/src/Cloud/CloudPolicy.hpp
+++ b/src/Cloud/CloudPolicy.hpp
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <chrono>
+
+/**
+ * Tunables for xcsoar-cloud-server and related tools.
+ *
+ * Live-response ages apply to UDP traffic/thermal replies. Export ages apply
+ * to KML generation (longer window so maps stay useful offline).
+ */
+struct CloudPolicy {
+  static constexpr double traffic_query_range_m = 50000;
+  static constexpr double thermal_query_range_m = 50000;
+
+  static constexpr std::chrono::steady_clock::duration live_max_traffic_age =
+    std::chrono::minutes(15);
+  static constexpr std::chrono::steady_clock::duration live_max_thermal_age =
+    std::chrono::minutes(30);
+
+  static constexpr std::chrono::steady_clock::duration subscription_ttl =
+    std::chrono::minutes(5);
+
+  /** Clients older than this relative to Expire() \a before are removed. */
+  static constexpr std::chrono::steady_clock::duration client_expire_cutoff =
+    std::chrono::minutes(10);
+
+  static constexpr unsigned max_traffic_per_response = 64;
+  static constexpr unsigned max_thermal_per_response = 256;
+
+  static constexpr std::chrono::steady_clock::duration save_interval =
+    std::chrono::minutes(1);
+  static constexpr std::chrono::steady_clock::duration expire_timer_interval =
+    std::chrono::minutes(5);
+
+  static constexpr std::chrono::steady_clock::duration export_max_traffic_age =
+    std::chrono::hours(12);
+  static constexpr std::chrono::steady_clock::duration export_max_thermal_age =
+    std::chrono::hours(12);
+};
+
+inline constexpr CloudPolicy cloud_policy{};

--- a/src/Cloud/Data.cpp
+++ b/src/Cloud/Data.cpp
@@ -6,12 +6,10 @@
 #include "Serialiser.hpp"
 #include "net/ToString.hxx"
 
-#include <iostream>
-#include <iomanip>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
-using std::cout;
-using std::cerr;
-using std::endl;
+#include <cstdio>
 
 static constexpr uint32_t CLOUD_MAGIC = 0x5753f60f;
 static constexpr uint32_t CLOUD_VERSION = 1;
@@ -20,14 +18,16 @@ void
 CloudData::DumpClients()
 {
   for (const auto &client : clients) {
-    cout << ToString(client.address) << '\t'
-         << std::hex << client.key << std::dec << '\t'
-         << client.id << '\t'
-         << client.location << '\t'
-         << client.altitude << "m\n";
+    fmt::print(stdout,
+               "{}\t{:x}\t{}\t{}\t{}m\n",
+               ToString(client.address),
+               client.key,
+               client.id,
+               fmt::streamed(client.location),
+               client.altitude);
   }
 
-  cout.flush();
+  fflush(stdout);
 }
 
 void

--- a/src/Cloud/Data.cpp
+++ b/src/Cloud/Data.cpp
@@ -25,9 +25,8 @@ CloudData::DumpClients()
                client.id,
                fmt::streamed(client.location),
                client.altitude);
+    fflush(stdout);
   }
-
-  fflush(stdout);
 }
 
 void

--- a/src/Cloud/Main.cpp
+++ b/src/Cloud/Main.cpp
@@ -2,12 +2,11 @@
 // Copyright The XCSoar Project
 
 #include "Data.hpp"
+#include "CloudPolicy.hpp"
 #include "Dump.hpp"
 #include "Sender.hpp"
 #include "Serialiser.hpp"
 #include "Tracking/SkyLines/Server.hpp"
-#include "Tracking/SkyLines/Protocol.hpp"
-#include "util/ByteOrder.hxx"
 #include "event/Loop.hxx"
 #include "event/CoarseTimerEvent.hxx"
 #include "event/SignalMonitor.hxx"
@@ -19,20 +18,10 @@
 #include "util/Compiler.h"
 #include "util/ScopeExit.hxx"
 
-#include <array>
 #include <iostream>
 #include <iomanip>
 
 #include <signal.h>
-
-// TODO: review these settings
-static constexpr double TRAFFIC_RANGE = 50000;
-static constexpr double THERMAL_RANGE = 50000;
-
-static constexpr std::chrono::steady_clock::duration MAX_TRAFFIC_AGE = std::chrono::minutes(15);
-static constexpr std::chrono::steady_clock::duration MAX_THERMAL_AGE = std::chrono::minutes(30);
-
-static constexpr std::chrono::steady_clock::duration REQUEST_EXPIRY = std::chrono::minutes(5);
 
 using std::cout;
 using std::cerr;
@@ -75,17 +64,18 @@ private:
   }
 
   void ScheduleSave() {
-    save_timer.Schedule(std::chrono::minutes(1));
+    save_timer.Schedule(cloud_policy.save_interval);
   }
 
   void OnExpireTimer() noexcept {
-    clients.Expire(GetEventLoop().SteadyNow() - std::chrono::minutes(10));
+    clients.Expire(GetEventLoop().SteadyNow() -
+                   cloud_policy.client_expire_cutoff);
     if (!clients.empty())
       ScheduleExpire();
   }
 
   void ScheduleExpire() {
-    expire_timer.Schedule(std::chrono::minutes(5));
+    expire_timer.Schedule(cloud_policy.expire_timer_interval);
   }
 
 protected:
@@ -172,8 +162,8 @@ CloudServer::OnFix(const Client &c,
 
   /* send this new traffic location to all interested clients
      immediately */
-  const auto now = std::chrono::steady_clock::now();
-  for (const auto &i : clients.QueryWithinRange(location, TRAFFIC_RANGE)) {
+  const auto now = GetEventLoop().SteadyNow();
+  for (const auto &i : clients.QueryWithinRange(location, cloud_policy.traffic_query_range_m)) {
     if (i->key == c.key)
       /* ignore this client's own submissions - he knows them
          already */
@@ -203,17 +193,17 @@ CloudServer::OnTrafficRequest(const Client &c, bool near)
        us yet */
     return;
 
-  const auto now = std::chrono::steady_clock::now();
+  const auto now = GetEventLoop().SteadyNow();
 
-  client->wants_traffic = now + REQUEST_EXPIRY;
+  client->wants_traffic = now + cloud_policy.subscription_ttl;
 
-  const auto min_stamp = now - MAX_TRAFFIC_AGE;
+  const auto min_stamp = now - cloud_policy.live_max_traffic_age;
 
   TrafficResponseSender s(*this, c.address, c.key);
 
   unsigned n = 0;
   for (const auto &traffic : clients.QueryWithinRange(client->location,
-                                                      TRAFFIC_RANGE)) {
+                                                      cloud_policy.traffic_query_range_m)) {
     if (traffic.get() == client)
       continue;
 
@@ -224,7 +214,7 @@ CloudServer::OnTrafficRequest(const Client &c, bool near)
     s.Add(traffic->id, 0, //TODO: time?
           traffic->location, traffic->altitude);
 
-    if (++n > 64)
+    if (++n > cloud_policy.max_traffic_per_response)
       break;
   }
 
@@ -287,9 +277,9 @@ CloudServer::OnThermalSubmit(const Client &c,
                   lift);
 
   /* send this new thermal to all interested clients immediately */
-  const auto now = std::chrono::steady_clock::now();
+  const auto now = GetEventLoop().SteadyNow();
   for (const auto &i : clients.QueryWithinRange(bottom_location,
-                                                THERMAL_RANGE)) {
+                                                cloud_policy.thermal_query_range_m)) {
     if (i->key == c.key)
       /* ignore this client's own submissions - he knows them
          already */
@@ -314,17 +304,17 @@ CloudServer::OnThermalRequest(const Client &c)
        us yet */
     return;
 
-  const auto now = std::chrono::steady_clock::now();
+  const auto now = GetEventLoop().SteadyNow();
 
-  client->wants_thermals = now + REQUEST_EXPIRY;
+  client->wants_thermals = now + cloud_policy.subscription_ttl;
 
-  const auto min_time = now - MAX_THERMAL_AGE;
+  const auto min_time = now - cloud_policy.live_max_thermal_age;
 
   ThermalResponseSender s(*this, c.address, c.key);
 
   unsigned n = 0;
   for (const auto &thermal : thermals.QueryWithinRange(client->location,
-                                                       THERMAL_RANGE)) {
+                                                       cloud_policy.thermal_query_range_m)) {
     if (thermal->client_key == c.key)
       /* ignore this client's own submissions - he knows them
          already */
@@ -336,7 +326,7 @@ CloudServer::OnThermalRequest(const Client &c)
 
     s.Add(thermal->Pack());
 
-    if (++n > 256)
+    if (++n > cloud_policy.max_thermal_per_response)
       break;
   }
 

--- a/src/Cloud/Main.cpp
+++ b/src/Cloud/Main.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
-#include "Data.hpp"
+#include "CloudGlue.hpp"
 #include "CloudPolicy.hpp"
+#include "Data.hpp"
 #include "Dump.hpp"
-#include "Sender.hpp"
 #include "Serialiser.hpp"
 #include "Tracking/SkyLines/Server.hpp"
 #include "event/Loop.hxx"
@@ -19,7 +19,6 @@
 #include "util/ScopeExit.hxx"
 
 #include <iostream>
-#include <iomanip>
 
 #include <signal.h>
 
@@ -27,10 +26,11 @@ using std::cout;
 using std::cerr;
 using std::endl;
 
-class CloudServer final
-  : public SkyLinesTracking::Server, CloudData
-{
+class CloudServer final : public SkyLinesTracking::Server {
   const AllocatedPath db_path;
+
+  CloudData data;
+  CloudGlue glue;
 
   CoarseTimerEvent save_timer, expire_timer;
 
@@ -39,6 +39,7 @@ public:
               SocketAddress bind_address)
     :SkyLinesTracking::Server(event_loop, bind_address),
      db_path(std::move(_db_path)),
+     glue(data, cloud_policy, *this),
      save_timer(event_loop, BIND_THIS_METHOD(OnSaveTimer)),
      expire_timer(event_loop, BIND_THIS_METHOD(OnExpireTimer))
   {
@@ -57,6 +58,8 @@ public:
   void Load();
   void Save();
 
+  void DumpClients() { data.DumpClients(); }
+
 private:
   void OnSaveTimer() noexcept {
     Save();
@@ -68,9 +71,9 @@ private:
   }
 
   void OnExpireTimer() noexcept {
-    clients.Expire(GetEventLoop().SteadyNow() -
-                   cloud_policy.client_expire_cutoff);
-    if (!clients.empty())
+    data.clients.Expire(GetEventLoop().SteadyNow() -
+                        cloud_policy.client_expire_cutoff);
+    if (!data.clients.empty())
       ScheduleExpire();
   }
 
@@ -79,13 +82,11 @@ private:
   }
 
 protected:
-  /* virtual methods from class SkyLinesTracking::Server */
   void OnFix(const Client &client,
              std::chrono::milliseconds time_of_day,
              const ::GeoPoint &location, int altitude) override;
 
-  void OnTrafficRequest(const Client &client,
-                        bool near) override;
+  void OnTrafficRequest(const Client &client, bool near) override;
 
   void OnWaveSubmit(const Client &client,
                     std::chrono::milliseconds time_of_day,
@@ -132,205 +133,54 @@ protected:
 };
 
 void
-CloudServer::OnFix(const Client &c,
+CloudServer::OnFix(const Client &client,
                    std::chrono::milliseconds time_of_day,
                    const ::GeoPoint &location, int altitude)
 {
-  (void)time_of_day; // TODO: use this parameter
-
-  CloudClient *client;
-  if (location.IsValid()) {
-    bool was_empty = clients.empty();
-
-    client = &clients.Make(c.address, c.key, location, altitude);
-
-    cout << "FIX\t"
-         << client->address << '\t'
-         << std::hex << client->key << std::dec << '\t'
-         << client->id << '\t'
-         << client->location << '\t'
-         << client->altitude << 'm'
-         << endl;
-
-    if (was_empty)
-      ScheduleExpire();
-  } else {
-    client = clients.Find(c.key);
-    if (client != nullptr)
-      clients.Refresh(*client, c.address);
-  }
-
-  /* send this new traffic location to all interested clients
-     immediately */
-  const auto now = GetEventLoop().SteadyNow();
-  for (const auto &i : clients.QueryWithinRange(location, cloud_policy.traffic_query_range_m)) {
-    if (i->key == c.key)
-      /* ignore this client's own submissions - he knows them
-         already */
-      continue;
-
-    if (now > i->wants_traffic)
-      /* not interested (anymore) */
-      continue;
-
-    TrafficResponseSender s(*this, i->address, i->key);
-    s.Add(client->id, 0, //TODO: time?
-          client->location, client->altitude);
-    s.Flush();
-  }
+  bool schedule_expire = false;
+  glue.OnFix(client, time_of_day, location, altitude,
+             GetEventLoop().SteadyNow(), schedule_expire);
+  if (schedule_expire)
+    ScheduleExpire();
 }
 
 void
-CloudServer::OnTrafficRequest(const Client &c, bool near)
+CloudServer::OnTrafficRequest(const Client &client, bool near)
 {
-  if (!near)
-    /* "near" is the only selection flag we know */
-    return;
-
-  auto *client = clients.Find(c.key);
-  if (client == nullptr)
-    /* we don't send our data to clients who didn't sent anything to
-       us yet */
-    return;
-
-  const auto now = GetEventLoop().SteadyNow();
-
-  client->wants_traffic = now + cloud_policy.subscription_ttl;
-
-  const auto min_stamp = now - cloud_policy.live_max_traffic_age;
-
-  TrafficResponseSender s(*this, c.address, c.key);
-
-  unsigned n = 0;
-  for (const auto &traffic : clients.QueryWithinRange(client->location,
-                                                      cloud_policy.traffic_query_range_m)) {
-    if (traffic.get() == client)
-      continue;
-
-    if (traffic->stamp < min_stamp)
-      /* don't send stale traffic, it's probably not there anymore */
-      continue;
-
-    s.Add(traffic->id, 0, //TODO: time?
-          traffic->location, traffic->altitude);
-
-    if (++n > cloud_policy.max_traffic_per_response)
-      break;
-  }
-
-  s.Flush();
+  glue.OnTrafficRequest(client, near, GetEventLoop().SteadyNow());
 }
 
 void
-CloudServer::OnWaveSubmit(const Client &c,
-                          [[maybe_unused]] std::chrono::milliseconds time_of_day,
+CloudServer::OnWaveSubmit(const Client &client,
+                          std::chrono::milliseconds time_of_day,
                           const ::GeoPoint &a, const ::GeoPoint &b,
                           int bottom_altitude,
                           int top_altitude,
                           double lift)
 {
-  auto *client = clients.Find(c.key);
-  if (client == nullptr)
-    /* we don't trust the client if he didn't sent anything to us
-       yet */
-    return;
-
-  cout << "WAVE\t"
-       << client->address << '\t'
-       << std::hex << client->key << std::dec << '\t'
-       << client->id << '\t'
-       << a << '\t'
-       << b << '\t'
-       << bottom_altitude << '-' << top_altitude << "m\t"
-       << lift << "m/s"
-       << endl;
+  glue.OnWaveSubmit(client, time_of_day, a, b,
+                    bottom_altitude, top_altitude, lift);
 }
 
 void
-CloudServer::OnThermalSubmit(const Client &c,
-                             [[maybe_unused]] std::chrono::milliseconds time_of_day,
+CloudServer::OnThermalSubmit(const Client &client,
+                             std::chrono::milliseconds time_of_day,
                              const ::GeoPoint &bottom_location,
                              int bottom_altitude,
                              const ::GeoPoint &top_location,
                              int top_altitude,
                              double lift)
 {
-  auto *client = clients.Find(c.key);
-  if (client == nullptr)
-    /* we don't trust the client if he didn't sent anything to us
-       yet */
-    return;
-
-  cout << "THERMAL\t"
-       << client->address << '\t'
-       << std::hex << client->key << std::dec << '\t'
-       << client->id << '\t'
-       << top_location << '\t'
-       << bottom_altitude << '-' << top_altitude << "m\t"
-       << lift << "m/s"
-       << endl;
-
-  const auto &thermal =
-    thermals.Make(c.key,
-                  AGeoPoint(bottom_location, bottom_altitude),
-                  AGeoPoint(top_location, top_altitude),
-                  lift);
-
-  /* send this new thermal to all interested clients immediately */
-  const auto now = GetEventLoop().SteadyNow();
-  for (const auto &i : clients.QueryWithinRange(bottom_location,
-                                                cloud_policy.thermal_query_range_m)) {
-    if (i->key == c.key)
-      /* ignore this client's own submissions - he knows them
-         already */
-      continue;
-
-    if (now > i->wants_thermals)
-      /* not interested (anymore) */
-      continue;
-
-    ThermalResponseSender s(*this, i->address, i->key);
-    s.Add(thermal.Pack());
-    s.Flush();
-  }
+  glue.OnThermalSubmit(client, time_of_day,
+                       bottom_location, bottom_altitude,
+                       top_location, top_altitude, lift,
+                       GetEventLoop().SteadyNow());
 }
 
 void
-CloudServer::OnThermalRequest(const Client &c)
+CloudServer::OnThermalRequest(const Client &client)
 {
-  auto *client = clients.Find(c.key);
-  if (client == nullptr)
-    /* we don't send our data to clients who didn't sent anything to
-       us yet */
-    return;
-
-  const auto now = GetEventLoop().SteadyNow();
-
-  client->wants_thermals = now + cloud_policy.subscription_ttl;
-
-  const auto min_time = now - cloud_policy.live_max_thermal_age;
-
-  ThermalResponseSender s(*this, c.address, c.key);
-
-  unsigned n = 0;
-  for (const auto &thermal : thermals.QueryWithinRange(client->location,
-                                                       cloud_policy.thermal_query_range_m)) {
-    if (thermal->client_key == c.key)
-      /* ignore this client's own submissions - he knows them
-         already */
-      continue;
-
-    if (thermal->time < min_time)
-      /* don't send old thermals, they're useless */
-      continue;
-
-    s.Add(thermal->Pack());
-
-    if (++n > cloud_policy.max_thermal_per_response)
-      break;
-  }
-
-  s.Flush();
+  glue.OnThermalRequest(client, GetEventLoop().SteadyNow());
 }
 
 void
@@ -338,7 +188,7 @@ CloudServer::Load()
 {
   FileReader fr(db_path);
   Deserialiser s(fr);
-  CloudData::Load(s);
+  data.Load(s);
 }
 
 void
@@ -350,7 +200,7 @@ CloudServer::Save()
 
   {
     Serialiser s(fos);
-    CloudData::Save(s);
+    data.Save(s);
     s.Flush();
   }
 

--- a/src/Cloud/Main.cpp
+++ b/src/Cloud/Main.cpp
@@ -195,6 +195,7 @@ void
 CloudServer::Save()
 {
   fmt::print(stdout, "Saving data to {}\n", db_path.c_str());
+  fflush(stdout);
 
   FileOutputStream fos(db_path);
 

--- a/src/Cloud/Main.cpp
+++ b/src/Cloud/Main.cpp
@@ -18,13 +18,12 @@
 #include "util/Compiler.h"
 #include "util/ScopeExit.hxx"
 
-#include <iostream>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <cstdio>
 
 #include <signal.h>
-
-using std::cout;
-using std::cerr;
-using std::endl;
 
 class CloudServer final : public SkyLinesTracking::Server {
   const AllocatedPath db_path;
@@ -107,13 +106,14 @@ protected:
 
   void OnSendError(SocketAddress address,
                    std::exception_ptr e) noexcept override {
-    cerr << "Failed to send to " << address
-         << ": " << GetFullMessage(e)
-         << endl;
+    fmt::print(stderr,
+               "Failed to send to {}: {}\n",
+               fmt::streamed(address),
+               GetFullMessage(e));
   }
 
   void OnError(std::exception_ptr e) override {
-    cerr << GetFullMessage(e) << endl;
+    fmt::print(stderr, "{}\n", GetFullMessage(e));
     GetEventLoop().Break();
   }
 
@@ -194,7 +194,7 @@ CloudServer::Load()
 void
 CloudServer::Save()
 {
-  cout << "Saving data to " << db_path.c_str() << endl;
+  fmt::print(stdout, "Saving data to {}\n", db_path.c_str());
 
   FileOutputStream fos(db_path);
 
@@ -211,7 +211,7 @@ int
 main(int argc, char **argv)
 try {
   if (argc != 2) {
-    cerr << "Usage: " << argv[0] << " DBPATH" << endl;
+    fmt::print(stderr, "Usage: {} DBPATH\n", argv[0]);
     return EXIT_FAILURE;
   }
 
@@ -227,7 +227,7 @@ try {
   try {
     server.Load();
   } catch (const std::runtime_error &e) {
-    cerr << "Failed to load database" << endl;
+    fmt::print(stderr, "Failed to load database\n");
     PrintException(e);
   }
 

--- a/src/Cloud/Sender.cpp
+++ b/src/Cloud/Sender.cpp
@@ -6,13 +6,32 @@
 #include "Geo/GeoPoint.hpp"
 #include "util/CRC16CCITT.hpp"
 
+template<typename Traits>
+void
+SkyLinesBatchResponseSender<Traits>::Flush() noexcept
+{
+  if (n_items == 0)
+    return;
+
+  const size_t size =
+    sizeof(data.header) + sizeof(typename Traits::Item) * n_items;
+
+  Traits::SetCount(data.header, n_items);
+  n_items = 0;
+
+  data.header.header.crc = 0;
+  data.header.header.crc = ToBE16(UpdateCRC16CCITT(&data, size, 0));
+  server.SendBuffer(address, {(const std::byte *)&data, size});
+}
+
+template class SkyLinesBatchResponseSender<CloudSenderTraits::ThermalBatch>;
+template class SkyLinesBatchResponseSender<CloudSenderTraits::TrafficBatch>;
+
 void
 TrafficResponseSender::Add(uint32_t pilot_id, uint32_t time,
-                           GeoPoint location, int altitude)
+                             GeoPoint location, int altitude)
 {
-  assert(n_traffic < MAX_TRAFFIC);
-
-  auto &traffic = data.traffic[n_traffic++];
+  typename CloudSenderTraits::TrafficBatch::Item traffic{};
   traffic.pilot_id = ToBE32(pilot_id);
   traffic.time = ToBE32(time);
   traffic.location = SkyLinesTracking::ExportGeoPoint(location);
@@ -20,49 +39,5 @@ TrafficResponseSender::Add(uint32_t pilot_id, uint32_t time,
   traffic.reserved = 0;
   traffic.reserved2 = 0;
 
-  if (n_traffic == MAX_TRAFFIC)
-    Flush();
-}
-
-void
-TrafficResponseSender::Flush()
-{
-  if (n_traffic == 0)
-    return;
-
-  size_t size = sizeof(data.header) + sizeof(data.traffic[0]) * n_traffic;
-
-  data.header.traffic_count = n_traffic;
-  n_traffic = 0;
-
-  data.header.header.crc = 0;
-  data.header.header.crc = ToBE16(UpdateCRC16CCITT(&data, size, 0));
-  server.SendBuffer(address, {(const std::byte *)&data, size});
-}
-
-void
-ThermalResponseSender::Add(SkyLinesTracking::Thermal t)
-{
-  assert(n_thermal < MAX_THERMAL);
-
-  data.thermal[n_thermal++] = t;
-
-  if (n_thermal == MAX_THERMAL)
-    Flush();
-}
-
-void
-ThermalResponseSender::Flush()
-{
-  if (n_thermal == 0)
-    return;
-
-  size_t size = sizeof(data.header) + sizeof(data.thermal[0]) * n_thermal;
-
-  data.header.thermal_count = n_thermal;
-  n_thermal = 0;
-
-  data.header.header.crc = 0;
-  data.header.header.crc = ToBE16(UpdateCRC16CCITT(&data, size, 0));
-  server.SendBuffer(address, {(const std::byte *)&data, size});
+  SkyLinesBatchResponseSender::Add(traffic);
 }

--- a/src/Cloud/Sender.hpp
+++ b/src/Cloud/Sender.hpp
@@ -9,70 +9,114 @@
 #include "net/StaticSocketAddress.hxx"
 
 #include <array>
+#include <cassert>
+#include <cstddef>
 
 struct GeoPoint;
 
-class TrafficResponseSender {
-  SkyLinesTracking::Server &server;
-  const SocketAddress address;
+namespace CloudSenderTraits {
 
-  static constexpr size_t MAX_TRAFFIC_SIZE = 1024;
-  static constexpr size_t MAX_TRAFFIC =
-    MAX_TRAFFIC_SIZE / sizeof(SkyLinesTracking::TrafficResponsePacket::Traffic);
+struct TrafficBatch {
+  using Item = SkyLinesTracking::TrafficResponsePacket::Traffic;
+  using HeaderPrefix = SkyLinesTracking::TrafficResponsePacket;
+  static constexpr SkyLinesTracking::Type PACKET_TYPE =
+    SkyLinesTracking::Type::TRAFFIC_RESPONSE;
 
-  struct Packet {
-    SkyLinesTracking::TrafficResponsePacket header;
-    std::array<SkyLinesTracking::TrafficResponsePacket::Traffic, MAX_TRAFFIC> traffic;
-  } data;
-
-  unsigned n_traffic = 0;
-
-public:
-  TrafficResponseSender(SkyLinesTracking::Server &_server,
-                        SocketAddress client_address, uint64_t key)
-    :server(_server), address(client_address) {
-    data.header.header.magic = ToBE32(SkyLinesTracking::MAGIC);
-    data.header.header.type = ToBE16(SkyLinesTracking::Type::TRAFFIC_RESPONSE);
-    data.header.header.key = ToBE64(key);
-
-    data.header.reserved = 0;
-    data.header.reserved2 = 0;
-    data.header.reserved3 = 0;
+  static void
+  InitHeader(HeaderPrefix &h, uint64_t key) noexcept
+  {
+    h.header.magic = ToBE32(SkyLinesTracking::MAGIC);
+    h.header.type = ToBE16(PACKET_TYPE);
+    h.header.key = ToBE64(key);
+    h.reserved = 0;
+    h.reserved2 = 0;
+    h.reserved3 = 0;
   }
 
-  void Add(uint32_t pilot_id, uint32_t time,
-           GeoPoint location, int altitude);
-  void Flush();
+  static void
+  SetCount(HeaderPrefix &h, unsigned n) noexcept
+  {
+    h.traffic_count = static_cast<uint8_t>(n);
+  }
 };
 
-class ThermalResponseSender {
+struct ThermalBatch {
+  using Item = SkyLinesTracking::Thermal;
+  using HeaderPrefix = SkyLinesTracking::ThermalResponsePacket;
+  static constexpr SkyLinesTracking::Type PACKET_TYPE =
+    SkyLinesTracking::Type::THERMAL_RESPONSE;
+
+  static void
+  InitHeader(HeaderPrefix &h, uint64_t key) noexcept
+  {
+    h.header.magic = ToBE32(SkyLinesTracking::MAGIC);
+    h.header.type = ToBE16(PACKET_TYPE);
+    h.header.key = ToBE64(key);
+    h.reserved1 = 0;
+    h.reserved2 = 0;
+    h.reserved3 = 0;
+  }
+
+  static void
+  SetCount(HeaderPrefix &h, unsigned n) noexcept
+  {
+    h.thermal_count = static_cast<uint8_t>(n);
+  }
+};
+
+} // namespace CloudSenderTraits
+
+/**
+ * Batches SkyLines variable-length TRAFFIC_RESPONSE / THERMAL_RESPONSE
+ * datagrams (CRC16, MTU-sized chunks).
+ */
+template<typename Traits>
+class SkyLinesBatchResponseSender {
   SkyLinesTracking::Server &server;
   const SocketAddress address;
 
-  static constexpr size_t MAX_THERMAL_SIZE = 1024;
-  static constexpr size_t MAX_THERMAL =
-    MAX_THERMAL_SIZE / sizeof(SkyLinesTracking::Thermal);
+  static constexpr size_t MAX_PACKET_BYTES = 1024;
+  static constexpr size_t MAX_ITEMS =
+    MAX_PACKET_BYTES / sizeof(typename Traits::Item);
 
   struct Packet {
-    SkyLinesTracking::ThermalResponsePacket header;
-    std::array<SkyLinesTracking::Thermal, MAX_THERMAL> thermal;
+    typename Traits::HeaderPrefix header;
+    std::array<typename Traits::Item, MAX_ITEMS> items;
   } data;
 
-  unsigned n_thermal = 0;
+  unsigned n_items = 0;
 
 public:
-  ThermalResponseSender(SkyLinesTracking::Server &_server,
-                        SocketAddress client_address, uint64_t key) noexcept
-    :server(_server), address(client_address) {
-    data.header.header.magic = ToBE32(SkyLinesTracking::MAGIC);
-    data.header.header.type = ToBE16(SkyLinesTracking::Type::THERMAL_RESPONSE);
-    data.header.header.key = ToBE64(key);
-
-    data.header.reserved1 = 0;
-    data.header.reserved2 = 0;
-    data.header.reserved3 = 0;
+  SkyLinesBatchResponseSender(SkyLinesTracking::Server &_server,
+                              SocketAddress client_address,
+                              uint64_t key) noexcept
+    :server(_server), address(client_address)
+  {
+    Traits::InitHeader(data.header, key);
   }
 
-  void Add(SkyLinesTracking::Thermal t);
-  void Flush();
+  void
+  Add(const typename Traits::Item &item) noexcept
+  {
+    assert(n_items < MAX_ITEMS);
+    data.items[n_items++] = item;
+
+    if (n_items == MAX_ITEMS)
+      Flush();
+  }
+
+  void
+  Flush() noexcept;
+};
+
+using ThermalResponseSender =
+  SkyLinesBatchResponseSender<CloudSenderTraits::ThermalBatch>;
+
+class TrafficResponseSender
+  : public SkyLinesBatchResponseSender<CloudSenderTraits::TrafficBatch> {
+public:
+  using SkyLinesBatchResponseSender::SkyLinesBatchResponseSender;
+
+  void
+  Add(uint32_t pilot_id, uint32_t time, GeoPoint location, int altitude);
 };

--- a/src/Cloud/ToKML.cpp
+++ b/src/Cloud/ToKML.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
+#include "CloudPolicy.hpp"
 #include "Data.hpp"
 #include "Serialiser.hpp"
 #include "io/FileOutputStream.hxx"
@@ -10,9 +11,6 @@
 #include "util/Compiler.h"
 
 #include <iostream>
-
-static constexpr std::chrono::steady_clock::duration MAX_TRAFFIC_AGE = std::chrono::hours(12);
-static constexpr std::chrono::steady_clock::duration MAX_THERMAL_AGE = std::chrono::hours(12);
 
 using std::cout;
 using std::cerr;
@@ -61,7 +59,8 @@ ToKML(BufferedOutputStream &os, const CloudClientContainer &clients)
   os.Write("    <Folder>\n"
            "      <name>Traffic</name>\n");
 
-  const auto min_stamp = std::chrono::steady_clock::now() - MAX_TRAFFIC_AGE;
+  const auto min_stamp =
+    std::chrono::steady_clock::now() - cloud_policy.export_max_traffic_age;
 
   for (const auto &client : clients)
     if (client.stamp >= min_stamp)
@@ -99,7 +98,8 @@ ToKML(BufferedOutputStream &os, const CloudThermalContainer &thermals)
   os.Write("    <Folder>\n"
            "      <name>Thermals</name>\n");
 
-  const auto min_time = std::chrono::steady_clock::now() - MAX_THERMAL_AGE;
+  const auto min_time =
+    std::chrono::steady_clock::now() - cloud_policy.export_max_thermal_age;
 
   for (const auto &thermal : thermals)
     if (thermal.time >= min_time)


### PR DESCRIPTION
## Summary

- Extract `CloudGlue` from `xcsoar-cloud-server` `Main.cpp` so SkyLines callbacks and fan-out live in one place
- Add `CloudPolicy` for shared tunables (ranges, TTLs, caps) used by the server and `ToKML`
- Unify `TrafficResponseSender` / `ThermalResponseSender` via `SkyLinesBatchResponseSender` (shared CRC/MTU batching)
- Propagate fix UTC time into traffic responses; skip traffic fan-out when `OnFix` has no `CloudClient`
- Use `fmt::print` for server logging and factor client stdout log lines

This prepares the cloud server for OGN ingest (`feature/cloud-ogn-server`) without changing protocol behaviour for apps.

## Test plan

- [ ] `make TARGET=UNIX` builds `xcsoar-cloud-server`
- [ ] Run server with a test DB; verify FIX, NEAR traffic, and thermal submit/request still work
- [ ] `xcsoar-cloud-to-kml` export still uses `CloudPolicy` ages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cloud server thermal and traffic data handling with improved propagation to nearby clients
  * Added configurable policies for data filtering, response limits, and subscription management
  
* **Improvements**
  * Refactored cloud server architecture for better maintainability and extensibility
  * Updated data retention and export filtering based on policy-driven thresholds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->