### PR TITLE
build/libdbus: Fix non-OpenGL UNIX builds

### DIFF
--- a/build/libdbus.mk
+++ b/build/libdbus.mk
@@ -1,4 +1,5 @@
-ifeq ($(TARGET_IS_LINUX)$(USE_POLL_EVENT)$(TARGET_IS_KOBO),yyn)
+ifeq ($(TARGET_IS_LINUX)$(TARGET_IS_KOBO)$(TARGET_IS_ANDROID),ynn)
+
 
 $(eval $(call pkg-config-library,LIBDBUS,dbus-1))
 


### PR DESCRIPTION
For the Wifi control that was recently introduced, libdbus is used. libdbus was gated on USE POLLING, which in turn depends on OpenGL=y, making the non-OpenGL UNIX builds fail (except KOBO, which has special handling).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to properly support Android devices with libdbus library configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->