### PR TITLE
DataFileLayout: Fix ambiguous .txt migration and import

### DIFF
--- a/build/libdbus.mk
+++ b/build/libdbus.mk
@@ -1,4 +1,5 @@
-ifeq ($(TARGET_IS_LINUX)$(USE_POLL_EVENT)$(TARGET_IS_KOBO),yyn)
+ifeq ($(TARGET_IS_LINUX)$(TARGET_IS_KOBO)$(TARGET_IS_ANDROID),ynn)
+
 
 $(eval $(call pkg-config-library,LIBDBUS,dbus-1))
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -215,6 +215,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Engine/ThermalBand/ThermalSlice.cpp \
 	$(SRC)/Engine/ThermalBand/ThermalEncounterBand.cpp \
 	$(SRC)/Engine/ThermalBand/ThermalEncounterCollection.cpp \
+	$(SRC)/DataFileLayout.cpp \
 	$(SRC)/DataLayoutMigration.cpp \
 	$(SRC)/HorizonWidget.cpp \
 	$(SRC)/Renderer/TextRowRenderer.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -742,6 +742,7 @@ TEST_FILE_TYPE_DEPENDS = UTIL
 $(eval $(call link-program,TestFileType,TEST_FILE_TYPE))
 
 TEST_DATA_LAYOUT_MIGRATION_SOURCES = \
+	$(SRC)/DataFileLayout.cpp \
 	$(SRC)/DataLayoutMigration.cpp \
 	$(SRC)/DataFilePath.cpp \
 	$(SRC)/LocalPath.cpp \
@@ -760,13 +761,18 @@ TEST_DATA_LAYOUT_MIGRATION_DEPENDS = PROFILE IO OS UTIL
 $(eval $(call link-program,TestDataLayoutMigration,TEST_DATA_LAYOUT_MIGRATION))
 
 TEST_LOCAL_PATH_RESOLVE_SOURCES = \
+	$(SRC)/DataFileLayout.cpp \
 	$(SRC)/DataFilePath.cpp \
+	$(SRC)/Form/DataField/Base.cpp \
+	$(SRC)/Form/DataField/ComboList.cpp \
+	$(SRC)/Form/DataField/File.cpp \
 	$(SRC)/LocalPath.cpp \
 	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/system/FileUtil.cpp \
 	$(SRC)/system/Path.cpp \
 	$(SRC)/io/FileOutputStream.cxx \
 	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestLocalPathResolve.cpp
 TEST_LOCAL_PATH_RESOLVE_DEPENDS = IO OS UTIL

--- a/src/DataFileLayout.cpp
+++ b/src/DataFileLayout.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DataFileLayout.hpp"
+
+#include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
+#include "Waypoint/WaypointDetailsFormat.hpp"
+#include "io/BufferedReader.hxx"
+#include "io/FileReader.hxx"
+#include "system/FileUtil.hpp"
+#include "util/StringCompare.hxx"
+#include "util/StringStrip.hxx"
+
+#include <string_view>
+
+namespace {
+
+enum class SniffedAirspaceLine {
+  UNKNOWN,
+  OPENAIR,
+  TNP,
+};
+
+[[gnu::pure]]
+SniffedAirspaceLine
+SniffAirspaceLine(std::string_view line) noexcept
+{
+  if (StringStartsWithIgnoreCase(line, "INCLUDE=") ||
+      StringStartsWithIgnoreCase(line, "TYPE=") ||
+      StringStartsWithIgnoreCase(line, "TITLE="))
+    return SniffedAirspaceLine::TNP;
+
+  if (StringStartsWithIgnoreCase(line, "AC")) {
+    const auto rest = line.substr(2);
+    if (rest.size() >= 2 && rest.front() == ' ' &&
+        rest.find_first_not_of(' ', 1) != std::string_view::npos)
+      return SniffedAirspaceLine::OPENAIR;
+  }
+
+  return SniffedAirspaceLine::UNKNOWN;
+}
+
+FileType
+SniffAmbiguousTextFileType(Path path) noexcept
+{
+  try {
+    FileReader reader(path);
+    BufferedReader buffered_reader(reader);
+
+    unsigned airspace_lines = 0;
+    bool details_section = false;
+    bool details_attachment = false;
+    unsigned inspected_lines = 0;
+
+    char *line;
+    while ((line = buffered_reader.ReadLine()) != nullptr &&
+           inspected_lines < 64) {
+      const std::string_view trimmed = Strip(std::string_view{line});
+      if (trimmed.empty())
+        continue;
+
+      ++inspected_lines;
+
+      if (WaypointDetails::IsSectionHeader(trimmed)) {
+        details_section = true;
+        continue;
+      }
+
+      if (WaypointDetails::IsAttachmentLine(trimmed)) {
+        if (details_section)
+          details_attachment = true;
+        continue;
+      }
+
+      const auto airspace_type = SniffAirspaceLine(trimmed);
+      if (airspace_type != SniffedAirspaceLine::UNKNOWN) {
+        ++airspace_lines;
+        if (!details_section && !details_attachment &&
+            (airspace_type == SniffedAirspaceLine::OPENAIR ||
+             airspace_lines >= 2))
+          return FileType::AIRSPACE;
+        continue;
+      }
+
+      if (airspace_lines > 0 && details_section)
+        return FileType::UNKNOWN;
+    }
+
+    if (details_section && details_attachment && airspace_lines == 0)
+      return FileType::WAYPOINTDETAILS;
+  } catch (...) {
+  }
+
+  return FileType::UNKNOWN;
+}
+
+} // namespace
+
+AllocatedPath
+DataFileLayout::GetLayoutSubdirForDataFile(Path path) noexcept
+{
+  if (path == nullptr)
+    return nullptr;
+
+  const auto base = path.GetBase();
+  if (base == nullptr)
+    return nullptr;
+
+  if (!Path(base).EndsWithIgnoreCase(".txt"))
+    return GetLayoutSubdirForFilename(base.c_str());
+
+  const auto special = SpecialFilenameType(base.c_str());
+  if (special != FileType::UNKNOWN)
+    return GetFileTypeDefaultDir(special);
+
+  const auto sniffed = SniffAmbiguousTextFileType(path);
+  return sniffed != FileType::UNKNOWN
+    ? GetFileTypeDefaultDir(sniffed)
+    : nullptr;
+}
+
+AllocatedPath
+DataFileLayout::RelocateRootDataFileToLayoutSubdir(Path path) noexcept
+{
+  if (path == nullptr)
+    return nullptr;
+
+  const auto relative = RelativePath(path);
+  if (relative == nullptr || !relative.IsBase())
+    return AllocatedPath(path);
+
+  const auto base = relative.GetBase();
+  if (base == nullptr)
+    return AllocatedPath(path);
+
+  auto subdir = GetLayoutSubdirForDataFile(path);
+  if (subdir == nullptr)
+    return AllocatedPath(path);
+
+  auto destination = LocalPath(AllocatedPath::Build(subdir, Path(base)));
+  if (destination == nullptr || destination == path || File::ExistsAny(destination))
+    return AllocatedPath(path);
+
+  if (const auto parent = destination.GetParent(); parent != nullptr)
+    Directory::CreateRecursive(parent);
+
+  if (File::Rename(path, destination))
+    return destination;
+
+  return AllocatedPath(path);
+}

--- a/src/DataFileLayout.hpp
+++ b/src/DataFileLayout.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+
+namespace DataFileLayout {
+
+/**
+ * Determine the managed data subdirectory for a candidate data file.
+ * Filename-based layout policy comes from Repository/FileType; ambiguous
+ * root-level .txt files get an additional content sniff.
+ */
+AllocatedPath
+GetLayoutSubdirForDataFile(Path path) noexcept;
+
+/**
+ * Move a root-level data file into its managed subdirectory if the target
+ * location can be identified safely.  Returns the final path.
+ */
+AllocatedPath
+RelocateRootDataFileToLayoutSubdir(Path path) noexcept;
+
+} // namespace DataFileLayout

--- a/src/DataFilePath.cpp
+++ b/src/DataFilePath.cpp
@@ -7,6 +7,8 @@
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
 
+#include <utility>
+
 namespace {
 
 [[gnu::pure]]
@@ -16,6 +18,34 @@ ResolveDataCachePath(const char *filename) noexcept
   return filename != nullptr
     ? LocalPath(AllocatedPath::Build(Path("cache"), Path(filename)))
     : nullptr;
+}
+
+[[gnu::pure]]
+static AllocatedPath
+ResolveUniqueExistingTypedDataFile(const char *filename) noexcept
+{
+  if (filename == nullptr || *filename == '\0')
+    return nullptr;
+
+  AllocatedPath match;
+
+  for (uint8_t i = 1; i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    const auto type = static_cast<FileType>(i);
+    const auto subdir = GetFileTypeDefaultDir(type);
+    if (subdir == nullptr || !FilenameMatchesFileType(filename, type))
+      continue;
+
+    auto candidate = LocalPath(AllocatedPath::Build(subdir, Path(filename)));
+    if (!File::Exists(candidate))
+      continue;
+
+    if (match != nullptr && match != candidate)
+      return nullptr;
+
+    match = std::move(candidate);
+  }
+
+  return match;
 }
 
 } // namespace
@@ -81,8 +111,13 @@ ResolveLocalDataFile(AllocatedPath path, FileType file_type) noexcept
   if (filename == nullptr || !filename.IsValidFilename())
     return path;
 
-  if (file_type == FileType::UNKNOWN)
+  if (file_type == FileType::UNKNOWN) {
+    if (auto resolved = ResolveUniqueExistingTypedDataFile(filename.c_str());
+        resolved != nullptr)
+      return resolved;
+
     file_type = ClassifyDataFilename(filename.c_str());
+  }
 
   if (file_type == FileType::UNKNOWN)
     return path;

--- a/src/DataLayoutMigration.cpp
+++ b/src/DataLayoutMigration.cpp
@@ -3,6 +3,7 @@
 
 #include "DataLayoutMigration.hpp"
 
+#include "DataFileLayout.hpp"
 #include "LocalPath.hpp"
 #include "LogFile.hpp"
 #include "Profile/Keys.hpp"
@@ -45,7 +46,7 @@ BuildMigrationPlan(Path root)
       if (relative_path == nullptr || !relative_path.IsBase())
         return;
 
-      const auto subdir = GetLayoutSubdirForFilename(filename.c_str());
+      const auto subdir = DataFileLayout::GetLayoutSubdirForDataFile(full);
       if (subdir == nullptr) {
         ++plan.skipped_unknown;
         return;

--- a/src/Dialogs/DataManagement/ImportDataPanel.cpp
+++ b/src/Dialogs/DataManagement/ImportDataPanel.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "ImportDataPanel.hpp"
+#include "DataFileLayout.hpp"
 #include "StorageLocationPickerDialog.hpp"
 #include "Dialogs/Message.hpp"
 #include "Dialogs/JobDialog.hpp"
@@ -38,6 +39,10 @@ namespace {
  * Compute the import destination path for a source file.
  * Recognized file types are imported into their typed data
  * subdirectories; unknown files remain in the XCSoar data root.
+ * Ambiguous ``.txt`` files (OpenAir, TNP/SUA content in a ``.txt``
+ * instead of ``.sua``, waypoint details) are sniffed via
+ * DataFileLayout and placed under ``airspace/`` or
+ * ``waypoints/details/`` when recognized.
  */
 static AllocatedPath
 ComputeRelativeDestination(Path src) noexcept
@@ -50,7 +55,7 @@ ComputeRelativeDestination(Path src) noexcept
   if (!base_path.IsValidFilename())
     return nullptr;
 
-  const auto subdir = GetLayoutSubdirForFilename(base.c_str());
+  const auto subdir = DataFileLayout::GetLayoutSubdirForDataFile(src);
   if (subdir != nullptr)
     return AllocatedPath::Build(Path(subdir), base_path);
 
@@ -155,6 +160,7 @@ struct ImportJob : public Job {
         }
 
         device->CopyToLocal(rel, dest, &sub_env);
+        dest = DataFileLayout::RelocateRootDataFileToLayoutSubdir(dest);
 
         ++completed;
       } catch (...) {

--- a/src/Dialogs/DataManagement/StorageLocationPickerDialog.cpp
+++ b/src/Dialogs/DataManagement/StorageLocationPickerDialog.cpp
@@ -76,6 +76,9 @@ class StorageListWidget final : public ListWidget,
   DeviceList options_;
   WndForm *dialog_ = nullptr;
   Button *select_button_ = nullptr;
+#ifdef ANDROID
+  std::string pending_permission_device_id_;
+#endif
 
   void SyncSelectButton() noexcept {
     if (select_button_ != nullptr)
@@ -120,8 +123,34 @@ public:
   }
 
   /* StorageEventListener */
-  void OnStorageEvent(const StorageEventInfo &) noexcept override {
+  void OnStorageEvent([[maybe_unused]] const StorageEventInfo &info) noexcept override {
     Refresh();
+
+#ifdef ANDROID
+    if (info.type != StorageEvent::AccessGranted ||
+        pending_permission_device_id_.empty() ||
+        dialog_ == nullptr)
+      return;
+
+    for (const auto &granted : info.devices) {
+      if (granted == nullptr ||
+          granted->Id() != pending_permission_device_id_)
+        continue;
+
+      const auto it = std::find_if(options_.begin(), options_.end(),
+                                   [&granted](const auto &device) {
+                                     return device != nullptr &&
+                                            device->Id() == granted->Id();
+                                   });
+      if (it == options_.end() || (*it)->NeedsPermission())
+        continue;
+
+      GetList().SetCursorIndex(static_cast<unsigned>(it - options_.begin()));
+      pending_permission_device_id_.clear();
+      dialog_->SetModalResult(mrOK);
+      return;
+    }
+#endif
   }
 
   /* Widget */
@@ -192,9 +221,52 @@ public:
     return true;
   }
 
-  void OnActivateItem([[maybe_unused]] unsigned) noexcept override {
+#ifdef ANDROID
+  void SelectCurrent() noexcept {
+    const unsigned index = GetCursorIndex();
+    if (index >= options_.size())
+      return;
+
+    const auto &device = options_[index];
+    if (device == nullptr)
+      return;
+
+    if (device->NeedsPermission()) {
+      pending_permission_device_id_ = device->Id();
+      device->RequestPermission();
+      return;
+    }
+
+    pending_permission_device_id_.clear();
     if (dialog_ != nullptr)
       dialog_->SetModalResult(mrOK);
+  }
+
+  void ChangeFolder() noexcept {
+    const unsigned index = GetCursorIndex();
+    if (index >= options_.size())
+      return;
+
+    const auto &device = options_[index];
+    if (device == nullptr)
+      return;
+
+    const AllocatedPath name{device->Name().c_str()};
+    if (!IsContentUri(name))
+      return;
+
+    pending_permission_device_id_ = device->Id();
+    device->RequestPermission();
+  }
+#endif
+
+  void OnActivateItem([[maybe_unused]] unsigned) noexcept override {
+#ifdef ANDROID
+    SelectCurrent();
+#else
+    if (dialog_ != nullptr)
+      dialog_->SetModalResult(mrOK);
+#endif
   }
 };
 
@@ -217,58 +289,43 @@ PickStorageLocation() noexcept
 {
   const auto &look = UIGlobals::GetDialogLook();
 
-  while (true) {
-    auto *list_widget = new StorageListWidget();
+  auto *list_widget = new StorageListWidget();
 
-    WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
-                        look, _("Choose location"));
-    list_widget->SetDialog(dialog);
-
-    auto *select_btn = dialog.AddButton(_("Select"), mrOK);
-    list_widget->SetSelectButton(*select_btn);
-#ifdef ANDROID
-    static constexpr int mrChangeFolder = 100;
-    dialog.AddButton(_("Change folder"), mrChangeFolder);
-#endif
-    /* "Scan" is kept for manual refresh; hotplug also triggers Refresh(). */
-    dialog.AddButton(_("Scan"), [list_widget]{ list_widget->ScanAndReport(); });
-    dialog.AddButton(_("Cancel"), mrCancel);
-    dialog.EnableCursorSelection();
-    dialog.FinishPreliminary(list_widget);
-
-    const int result = dialog.ShowModal();
+  WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+                      look, _("Choose location"));
+  list_widget->SetDialog(dialog);
 
 #ifdef ANDROID
-    if (result == mrChangeFolder) {
-      const unsigned sel = list_widget->GetCursorIndex();
-      auto &opts = list_widget->GetOptions();
-      if (sel < opts.size()) {
-        const auto &dev = opts[sel];
-        if (IsContentUri(AllocatedPath(dev->Name().c_str())))
-          dev->RequestPermission();
-      }
-      continue;
-    }
+  auto *select_btn = dialog.AddButton(_("Select"),
+                                      [list_widget]{ list_widget->SelectCurrent(); });
+#else
+  auto *select_btn = dialog.AddButton(_("Select"), mrOK);
 #endif
+  list_widget->SetSelectButton(*select_btn);
+#ifdef ANDROID
+  dialog.AddButton(_("Change folder"),
+                   [list_widget]{ list_widget->ChangeFolder(); });
+#endif
+  /* "Scan" is kept for manual refresh; hotplug also triggers Refresh(). */
+  dialog.AddButton(_("Scan"), [list_widget]{ list_widget->ScanAndReport(); });
+  dialog.AddButton(_("Cancel"), mrCancel);
+  dialog.EnableCursorSelection();
+  dialog.FinishPreliminary(list_widget);
 
-    if (result != mrOK)
-      return AllocatedPath();
+  const int result = dialog.ShowModal();
 
-    const unsigned sel = list_widget->GetCursorIndex();
-    auto &opts = list_widget->GetOptions();
-    if (sel >= opts.size())
-      return AllocatedPath();
+  if (result != mrOK)
+    return AllocatedPath();
 
-    const auto &chosen = opts[sel];
+  const unsigned sel = list_widget->GetCursorIndex();
+  auto &opts = list_widget->GetOptions();
+  if (sel >= opts.size())
+    return AllocatedPath();
 
-    if (chosen->NeedsPermission()) {
-      chosen->RequestPermission();
-      continue;
-    }
+  const auto &chosen = opts[sel];
 
-    AllocatedPath chosen_path{chosen->Name().c_str()};
-    if (chosen_path != nullptr)
-      last_storage_target = Path(chosen_path);
-    return chosen_path;
-  }
+  AllocatedPath chosen_path{chosen->Name().c_str()};
+  if (chosen_path != nullptr)
+    last_storage_target = Path(chosen_path);
+  return chosen_path;
 }

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -87,7 +87,7 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
                    _("List of active airspace files. Use the Add and Remove "
                      "buttons to activate or deactivate"
                      " airspace files respectively. Supported file types are: "
-                     "Openair (.txt /.air), and Tim Newport-Pearce (.sua)."),
+                     "Openair (.openair /.txt /.air), and Tim Newport-Pearce (.sua)."),
                    ProfileKeys::AirspaceFileList,
                    GetFileTypePatterns(FileType::AIRSPACE),
                    FileType::AIRSPACE);

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -100,6 +100,15 @@ FileDataField::ScanDirectoryTop(const char *filter) noexcept
     const auto typed_path = LocalPath(subdir);
     if (typed_path != nullptr && Directory::Exists(typed_path))
       Directory::VisitSpecificFiles(typed_path, filter, fv, true);
+
+    if (file_type == FileType::WAYPOINTDETAILS) {
+      /* Compatibility fallback: an earlier subdir migration could move
+         ambiguous .txt waypoint details into airspace/. */
+      const auto airspace_path =
+        LocalPath(GetFileTypeDefaultDir(FileType::AIRSPACE));
+      if (airspace_path != nullptr && Directory::Exists(airspace_path))
+        Directory::VisitSpecificFiles(airspace_path, filter, fv, true);
+    }
   } else {
     VisitDataFiles(filter, fv);
   }

--- a/src/LogFile.cpp
+++ b/src/LogFile.cpp
@@ -37,11 +37,11 @@ OpenLog()
     initialised = true;
 
     /* delete the obsolete log file */
-    File::Delete(ResolveLogsDataPath("xcsoar-startup.log"));
+    File::Delete(LocalPath("xcsoar-startup.log"));
 
-    path = LogsDataSavePath("xcsoar.log");
+    path = LocalPath("xcsoar.log");
 
-    File::Replace(path, ResolveLogsDataPath("xcsoar-old.log"));
+    File::Replace(path, LocalPath("xcsoar-old.log"));
 
 #ifdef ANDROID
     /* redirect stdout/stderr to xcsoar-startup.log on Android so we

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -14,7 +14,7 @@ GetFileTypePatterns(const FileType file_type) noexcept
 {
   switch (file_type) {
   case FileType::AIRSPACE:
-    return "*.txt\0*.air\0*.sua\0";
+    return "*.openair\0*.txt\0*.air\0*.sua\0";
 
   case FileType::WAYPOINT:
     return "*.dat\0*.xcw\0*.cup\0*.cupx\0*.wpz\0*.wpt\0";

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -31,7 +31,7 @@ AllocatedPath GetFileTypeDefaultDir(const FileType file_type);
 
 /**
  * Return NUL-separated list of file glob patterns for the given
- * type (e.g. "*.txt\0*.air\0*.sua\0").  The list is terminated by
+ * type (e.g. "*.openair\0*.txt\0*.air\0*.sua\0").  The list is terminated by
  * an empty pattern.
  */
 const char *GetFileTypePatterns(const FileType file_type) noexcept;

--- a/src/Waypoint/WaypointDetailsFormat.hpp
+++ b/src/Waypoint/WaypointDetailsFormat.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StringCompare.hxx"
+#include "util/StringStrip.hxx"
+
+#include <string_view>
+
+namespace WaypointDetails {
+
+[[gnu::pure]]
+static inline bool
+IsSectionHeader(std::string_view line) noexcept
+{
+  if (line.size() < 3 || line.front() != '[')
+    return false;
+
+  const auto end = line.find(']');
+  return end != std::string_view::npos && end > 1;
+}
+
+[[gnu::pure]]
+static inline bool
+IsAttachmentLine(std::string_view line) noexcept
+{
+  line = Strip(line);
+  return StringStartsWithIgnoreCase(line, "image=") ||
+         StringStartsWithIgnoreCase(line, "file=");
+}
+
+} // namespace WaypointDetails

--- a/src/Waypoint/WaypointDetailsReader.cpp
+++ b/src/Waypoint/WaypointDetailsReader.cpp
@@ -10,6 +10,7 @@
 #include "Operation/ProgressListener.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
+#include "WaypointDetailsFormat.hpp"
 #include "io/BufferedReader.hxx"
 #include "io/ConfiguredFile.hpp"
 #include "io/FileReader.hxx"
@@ -71,14 +72,15 @@ ReadFile(BufferedReader &reader, Waypoints &way_points)
 {
   StringConverter string_converter;
   WaypointDetailsBuilder builder;
-  const char *filename;
 
   bool in_details = false;
   int i;
 
   char *line;
   while ((line = reader.ReadLine()) != nullptr) {
-    if (line[0] == '[') { // Look for start
+    const auto trimmed = Strip(std::string_view{line});
+
+    if (IsSectionHeader(line)) {
       if (in_details)
         builder.Commit(way_points);
 
@@ -94,11 +96,13 @@ ReadFile(BufferedReader &reader, Waypoints &way_points)
       builder.name[i - 1] = 0;
 
       in_details = true;
-    } else if ((filename =
-                StringAfterPrefixIgnoreCase(line, "image=")) != nullptr) {
+    } else if (const auto filename =
+               StringAfterPrefixIgnoreCase(trimmed, "image=");
+               !filename.empty()) {
       builder.files_embed.emplace_front(string_converter.Convert(filename));
-    } else if ((filename =
-                StringAfterPrefixIgnoreCase(line, "file=")) != nullptr) {
+    } else if (const auto filename =
+               StringAfterPrefixIgnoreCase(trimmed, "file=");
+               !filename.empty()) {
 #ifdef HAVE_RUN_FILE
       builder.files_external.emplace_front(string_converter.Convert(filename));
 #endif

--- a/src/io/TarBackup.cpp
+++ b/src/io/TarBackup.cpp
@@ -3,6 +3,7 @@
 
 #include "TarBackup.hpp"
 
+#include "DataFileLayout.hpp"
 #include "CopyFile.hxx"
 #include "Formatter/ByteSizeFormatter.hpp"
 #include "FileReader.hxx"
@@ -100,6 +101,50 @@ bool
 AcceptEntry(ArchiveExcludePathFn exclude, std::string_view name) noexcept
 {
   return !name.empty() && (exclude == nullptr || !exclude(name));
+}
+
+[[nodiscard]]
+std::string
+MakePortableArchiveName(Path path)
+{
+  std::string name = path.c_str();
+  std::replace(name.begin(), name.end(), '\\', '/');
+  return name;
+}
+
+[[nodiscard]]
+bool
+ArchiveContains(const std::vector<std::string> &names,
+                std::string_view name) noexcept
+{
+  return std::find(names.begin(), names.end(), name) != names.end();
+}
+
+[[nodiscard]]
+AllocatedPath
+ResolveRestoreDestination(Path source, Path destination_root,
+                          const std::string &archive_name,
+                          const std::vector<std::string> &archive_names) noexcept
+{
+  const Path archive_path(archive_name.c_str());
+  auto destination = AllocatedPath::Build(destination_root, archive_path);
+
+  if (!archive_path.IsBase())
+    return destination;
+
+  const auto subdir = DataFileLayout::GetLayoutSubdirForDataFile(source);
+  if (subdir == nullptr)
+    return destination;
+
+  const auto relative = AllocatedPath::Build(subdir, archive_path);
+  if (ArchiveContains(archive_names, MakePortableArchiveName(relative)))
+    return destination;
+
+  auto typed_destination = AllocatedPath::Build(destination_root, Path(relative));
+  if (File::ExistsAny(typed_destination))
+    return destination;
+
+  return typed_destination;
 }
 
 [[nodiscard]]
@@ -382,7 +427,8 @@ try {
     }
 
     AllocatedPath source = AllocatedPath::Build(temp_root, name.c_str());
-    AllocatedPath dest = AllocatedPath::Build(destination_root, name.c_str());
+    AllocatedPath dest = ResolveRestoreDestination(source, destination_root,
+                                                   name, extracted_names);
     Directory::CreateRecursive(dest.GetParent());
 
     try {

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -9,6 +9,7 @@
 #include "lib/curl/Global.hxx"
 #include "Operation/ProgressListener.hpp"
 #include "LocalPath.hpp"
+#include "system/FileUtil.hpp"
 #include "thread/Mutex.hxx"
 #include "thread/SafeList.hxx"
 #include "co/InjectTask.hxx"
@@ -16,6 +17,7 @@
 #include <string>
 #include <list>
 #include <algorithm>
+#include <utility>
 
 #include <string.h>
 
@@ -175,8 +177,12 @@ DownloadManagerThread::Start() noexcept
   const Item &item = queue.front();
   current_position = 0;
 
+  auto destination = LocalPath(item.path_relative.c_str());
+  if (const auto parent = destination.GetParent(); parent != nullptr)
+    Directory::CreateRecursive(parent);
+
   task.Start(DownloadToFile(*Net::curl, item.uri.c_str(),
-                            LocalPath(item.path_relative.c_str()),
+                            std::move(destination),
                             nullptr, *this),
              BIND_THIS_METHOD(OnCompletion));
 }

--- a/test/src/FakeLogFile.cpp
+++ b/test/src/FakeLogFile.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "LogFile.hpp"
+#include "FakeLogFile.hpp"
 #include "util/Exception.hxx"
 
 #include <fmt/format.h>
@@ -11,9 +12,20 @@
 #include <cstdio>
 #include <iterator>
 
+static bool quiet;
+
+void
+SetFakeLogFileQuiet(bool _quiet) noexcept
+{
+  quiet = _quiet;
+}
+
 void
 LogString(std::string_view s) noexcept
 {
+  if (quiet)
+    return;
+
   fprintf(stderr, "%.*s\n",
           int(s.size()), s.data());
 }
@@ -33,6 +45,9 @@ LogVFmt(fmt::string_view format_str, fmt::format_args args) noexcept
 void
 LogFormat(const char *fmt, ...) noexcept
 {
+  if (quiet)
+    return;
+
   va_list ap;
 
   va_start(ap, fmt);

--- a/test/src/FakeLogFile.hpp
+++ b/test/src/FakeLogFile.hpp
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+void
+SetFakeLogFileQuiet(bool quiet) noexcept;

--- a/test/src/TestDataLayoutMigration.cpp
+++ b/test/src/TestDataLayoutMigration.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "DataLayoutMigration.hpp"
+#include "FakeLogFile.hpp"
 #include "LocalPath.hpp"
 #include "Profile/Current.hpp"
 #include "Profile/File.hpp"
@@ -148,11 +149,12 @@ TestDoesNotWriteMarkerWhenAllMovesFail()
   Profile::SetFiles(default_prf);
   Profile::Load();
 
-  ok1(chmod(template_path, 0555) == 0);
+  ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("maps")),
+                    "not a directory"));
+  ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("profiles")),
+                    "not a directory"));
 
   MigrateDataLayoutToSubdirs();
-
-  ok1(chmod(template_path, 0755) == 0);
 
   ok1(!File::Exists(LocalPath(".xcsoar-subdir-layout-v1")));
   ok1(File::Exists(AllocatedPath::Build(data_path, Path("terrain.xcm"))));
@@ -161,6 +163,8 @@ TestDoesNotWriteMarkerWhenAllMovesFail()
 int
 main()
 {
+  SetFakeLogFileQuiet(true);
+
   plan_tests(43);
   TestMigratesFilesAndActiveProfileOnly();
   TestDoesNotWriteMarkerWhenAllMovesFail();

--- a/test/src/TestFileType.cpp
+++ b/test/src/TestFileType.cpp
@@ -89,6 +89,7 @@ TestFilenameMatchesFileType()
 
   // Regular .txt file should still match AIRSPACE (no exact claim)
   ok1(FilenameMatchesFileType("london.txt", FileType::AIRSPACE));
+  ok1(FilenameMatchesFileType("london.openair", FileType::AIRSPACE));
   ok1(FilenameMatchesFileType("gfs-rasp-forecast.dat", FileType::WAYPOINT));
 
   // No match at all
@@ -110,6 +111,7 @@ TestDetectFileTypeByFilename()
   ok1(DetectFileTypeByFilename("waypoints.cup") == FileType::WAYPOINT);
   ok1(DetectFileTypeByFilename("WAYPOINTS.CUP") == FileType::WAYPOINT);
   ok1(DetectFileTypeByFilename("london.txt") == FileType::UNKNOWN);
+  ok1(DetectFileTypeByFilename("london.openair") == FileType::AIRSPACE);
   ok1(DetectFileTypeByFilename("readme.md") == FileType::UNKNOWN);
 }
 
@@ -119,6 +121,7 @@ TestLayoutClassification()
   ok1(ClassifyDataFilename("waypoints.cup") == FileType::WAYPOINT);
   ok1(ClassifyDataFilename("track.igc") == FileType::IGC);
   ok1(GetLayoutSubdirForFilename("waypoints.cup") == Path("waypoints"));
+  ok1(GetLayoutSubdirForFilename("zone.openair") == Path("airspace"));
   ok1(GetLayoutSubdirForFilename("task.tsk") == Path("tasks"));
   ok1(GetLayoutSubdirForFilename("gfs-rasp-forecast.dat") == Path("weather/rasp"));
   ok1(GetLayoutSubdirForFilename("track.igc") == Path("logs"));
@@ -131,7 +134,7 @@ TestLayoutClassification()
 
 int main()
 {
-  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 15 + 8 + 11);
+  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 16 + 9 + 12);
 
   TestDefaultDirs();
   TestPatterns();

--- a/test/src/TestLocalPathResolve.cpp
+++ b/test/src/TestLocalPathResolve.cpp
@@ -2,13 +2,17 @@
 // Copyright The XCSoar Project
 
 #include "DataFilePath.hpp"
+#include "DataFileLayout.hpp"
+#include "Form/DataField/File.hpp"
 #include "LocalPath.hpp"
 #include "Repository/FileType.hpp"
 #include "io/FileOutputStream.hxx"
 #include "system/FileUtil.hpp"
 #include "TestUtil.hpp"
+#include "util/SpanCast.hxx"
 #include "util/StringAPI.hxx"
 
+#include <string_view>
 #include <cstdio>
 #include <stdlib.h>
 
@@ -20,10 +24,20 @@ TouchFile(const AllocatedPath &path) noexcept
   return true;
 }
 
+static bool
+WriteTextFile(Path path, const char *content)
+{
+  FileOutputStream out(path, FileOutputStream::Mode::CREATE);
+  out.Write(AsBytes(std::string_view(content)));
+  out.Commit();
+  return true;
+}
+
 static void
 TestLayoutSubdirForFilename()
 {
   ok1(GetLayoutSubdirForFilename("terrain.xcm") == Path("maps"));
+  ok1(GetLayoutSubdirForFilename("zone.openair") == Path("airspace"));
   ok1(GetLayoutSubdirForFilename("user.cup") == Path("waypoints"));
   ok1(GetLayoutSubdirForFilename("profile.prf") == Path("profiles"));
   ok1(GetLayoutSubdirForFilename("plane.xcp") == Path("profiles/planes"));
@@ -170,6 +184,121 @@ TestTypedDataSavePathCreatesNestedDirs()
 }
 
 static void
+TestTextLayoutSniffing()
+{
+  char template_path[] = "/tmp/xcsoar-layout-sniff-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto airspace_file = LocalPath("known-airspace.txt");
+  const auto tnp_file = LocalPath("known-tnp.txt");
+  const auto single_ac_file = LocalPath("single-ac.txt");
+  const auto bare_ac_file = LocalPath("bare-ac.txt");
+  const auto details_file = LocalPath("known-details.txt");
+  const auto unknown_file = LocalPath("unknown.txt");
+  const auto log_file = LocalPath("xcsoar.log");
+
+  ok1(WriteTextFile(airspace_file,
+                    "AC C\nAN Test\nAL 1000 ft\nAH 2000 ft\n"));
+  ok1(WriteTextFile(tnp_file, "TYPE=T\nTITLE=Test area\n"));
+  ok1(WriteTextFile(single_ac_file, "AC C\nAN Test\nAL 1000 ft\n"));
+  ok1(WriteTextFile(bare_ac_file, "AC\nAN Test\nAL 1000 ft\n"));
+  ok1(WriteTextFile(details_file, "[HOME]\nimage=home.jpg\nRunway notes\n"));
+  ok1(WriteTextFile(unknown_file, "[section]\nfoo=bar\n"));
+  ok1(WriteTextFile(log_file, "log entry\n"));
+
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(airspace_file) == Path("airspace"));
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(tnp_file) == Path("airspace"));
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(single_ac_file) == Path("airspace"));
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(bare_ac_file) == nullptr);
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(details_file) ==
+      Path("waypoints/details"));
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(unknown_file) == nullptr);
+  ok1(DataFileLayout::GetLayoutSubdirForDataFile(log_file) == nullptr);
+
+  const auto normalized_airspace =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(airspace_file);
+  const auto normalized_tnp =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(tnp_file);
+  const auto normalized_details =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(details_file);
+  const auto normalized_unknown =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(unknown_file);
+  const auto normalized_single_ac =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(single_ac_file);
+  const auto normalized_bare_ac =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(bare_ac_file);
+  const auto normalized_log =
+    DataFileLayout::RelocateRootDataFileToLayoutSubdir(log_file);
+  const auto expected_airspace =
+    LocalPath(AllocatedPath::Build(Path("airspace"),
+                                   Path("known-airspace.txt")));
+  const auto expected_tnp =
+    LocalPath(AllocatedPath::Build(Path("airspace"),
+                                   Path("known-tnp.txt")));
+  const auto expected_single_ac =
+    LocalPath(AllocatedPath::Build(Path("airspace"),
+                                   Path("single-ac.txt")));
+  const auto expected_details = LocalPath(
+    AllocatedPath::Build(AllocatedPath::Build(Path("waypoints"),
+                                              Path("details")),
+                         Path("known-details.txt")));
+
+  ok1(normalized_airspace == expected_airspace);
+  ok1(normalized_tnp == expected_tnp);
+  ok1(normalized_details == expected_details);
+  ok1(normalized_unknown == unknown_file);
+  ok1(normalized_single_ac == expected_single_ac);
+  ok1(normalized_bare_ac == bare_ac_file);
+  ok1(normalized_log == log_file);
+  ok1(File::Exists(normalized_airspace));
+  ok1(File::Exists(normalized_tnp));
+  ok1(File::Exists(normalized_details));
+  ok1(File::Exists(normalized_unknown));
+  ok1(File::Exists(normalized_single_ac));
+  ok1(File::Exists(normalized_log));
+  ok1(!File::Exists(airspace_file));
+  ok1(!File::Exists(tnp_file));
+  ok1(!File::Exists(single_ac_file));
+  ok1(File::Exists(bare_ac_file));
+  ok1(!File::Exists(details_file));
+}
+
+static void
+TestWaypointDetailsPickerFindsLegacyAirspaceTxt()
+{
+  char template_path[] = "/tmp/xcsoar-details-picker-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto airspace_dir = LocalPath(Path("airspace"));
+  const auto details_dir = LocalPath(AllocatedPath::Build(Path("waypoints"),
+                                                          Path("details")));
+  Directory::CreateRecursive(airspace_dir);
+  Directory::CreateRecursive(details_dir);
+  ok1(Directory::Exists(airspace_dir));
+  ok1(Directory::Exists(details_dir));
+
+  const auto root_file = LocalPath("root-details.txt");
+  const auto details_file =
+    AllocatedPath::Build(details_dir, Path("typed-details.txt"));
+  const auto legacy_airspace_file =
+    AllocatedPath::Build(airspace_dir, Path("legacy-details.txt"));
+  TouchFile(root_file);
+  TouchFile(details_file);
+  TouchFile(legacy_airspace_file);
+
+  FileDataField df;
+  df.SetFileType(FileType::WAYPOINTDETAILS);
+  df.ScanMultiplePatterns(GetFileTypePatterns(FileType::WAYPOINTDETAILS));
+  ok1(df.GetNumFiles() >= 3);
+
+  ok1(df.Find(root_file) >= 0);
+  ok1(df.Find(details_file) >= 0);
+  ok1(df.Find(legacy_airspace_file) >= 0);
+}
+
+static void
 TestRepositoryDownloadRelativePath()
 {
   const auto relative = RepositoryDownloadRelativePath("repository");
@@ -180,7 +309,7 @@ TestRepositoryDownloadRelativePath()
 int
 main()
 {
-  plan_tests(39);
+  plan_tests(80);
   TestLayoutSubdirForFilename();
   TestResolveTypedDataFilePath();
   TestResolveRepositoryDataPath();
@@ -188,6 +317,8 @@ main()
   TestResolveLogsDataPath();
   TestDefaultTaskPaths();
   TestTypedDataSavePathCreatesNestedDirs();
+  TestTextLayoutSniffing();
+  TestWaypointDetailsPickerFindsLegacyAirspaceTxt();
   TestRepositoryDownloadRelativePath();
   return exit_status();
 }


### PR DESCRIPTION
## Summary

Fixes data-layout migration and import for ambiguous root-level `.txt` files.

- **Content sniffing** (`DataFileLayout`): OpenAir (one `AC` line with class), TNP (two markers), or waypoint details (`[section]` + `image=`/`file=`) are routed to `airspace/` or `waypoints/details/`; everything else stays in the data root
- **Import / migration / restore** use the same layout logic; TarBackup avoids overwriting existing typed destinations
- **`.openair`** extension recognized in file pickers and layout classification (Naviter convention)
- **Debug logs** (`xcsoar.log`, etc.) stay in the data root; `logs/` remains for flight logs
- **DownloadManager** creates parent directories for typed download targets on fresh installs

Sniffing is intentionally conservative and self-contained in `DataFileLayout` — not coupled to `AirspaceParser`. Waypoint-details line detection is shared via `Waypoint/WaypointDetailsFormat.hpp`.

## Test plan

- [x] `TestLocalPathResolve` — OpenAir, TNP, single-AC, bare-AC, waypoint details, unknown `.txt`
- [x] `TestDataLayoutMigration` — legacy flat-file migration
- [x] `TestFileType` — `.openair` classification
- [ ] Manual: import ambiguous `.txt` files via Data Management
- [ ] Manual: restore backup with root-level airspace/details `.txt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intelligent data file organization with automatic layout subdirectories
  * Airspace format support for `.openair` files
  * Enhanced import with automatic detection of ambiguous text files (airspace vs. waypoint details)
  * Android storage permission handling improvements

* **Bug Fixes**
  * Improved waypoint details file parsing
  * File picker compatibility for legacy data files in layout subdirectories

* **Chores**
  * Build system and test infrastructure updates
  * Simplified log file rotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->