### PR TITLE
Various wifi setup panel improvements

### DIFF
--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -24,6 +24,7 @@ import android.content.res.Resources;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.provider.Settings;
 import android.webkit.MimeTypeMap;
 
 class EGLException extends Exception {
@@ -450,6 +451,27 @@ class NativeView extends SurfaceView
   }
 
   /**
+   * Opens Android Wi-Fi settings or the connectivity panel.
+   */
+  private boolean openWifiSettings() {
+    try {
+      Intent intent;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        intent = new Intent(Settings.Panel.ACTION_INTERNET_CONNECTIVITY);
+      } else {
+        intent = new Intent(Settings.ACTION_WIFI_SETTINGS);
+      }
+
+      intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      getContext().startActivity(intent);
+      return true;
+    } catch (Exception e) {
+      Log.e(TAG, "openWifiSettings() error", e);
+      return false;
+    }
+  }
+
+  /**
    * Starts a VIEW intent for a given file
    */
   private void openWaypointFile(int id, String filename) {
@@ -480,6 +502,10 @@ class NativeView extends SurfaceView
 
   private int getNetState() {
     return NetUtil.getNetState();
+  }
+
+  private String getWifiIpAddress() {
+    return NetUtil.getWifiIpAddress();
   }
 
   @Override public boolean onTouchEvent(final MotionEvent event)

--- a/android/src/NetUtil.java
+++ b/android/src/NetUtil.java
@@ -5,8 +5,14 @@ package org.xcsoar;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
+import android.net.LinkAddress;
+import android.net.LinkProperties;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.util.Log;
+
+import java.net.Inet4Address;
 
 /**
  * Utilities for dealing with networking.
@@ -45,5 +51,38 @@ final class NetUtil {
       Log.d(TAG, "ConnectivityManager failed", e);
       return STATE_UNKNOWN;
     }
+  }
+
+  public static String getWifiIpAddress() {
+    if (cm == null)
+      return null;
+
+    try {
+      Network network = cm.getActiveNetwork();
+      if (network == null)
+        return null;
+
+      NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+      if (capabilities == null)
+        return null;
+
+      // Only return IP if this is a WiFi network
+      if (!capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI))
+        return null;
+
+      LinkProperties properties = cm.getLinkProperties(network);
+      if (properties == null)
+        return null;
+
+      for (LinkAddress address : properties.getLinkAddresses()) {
+        if (address.getAddress() instanceof Inet4Address &&
+            !address.getAddress().isLoopbackAddress())
+          return address.getAddress().getHostAddress();
+      }
+    } catch (Exception e) {
+      Log.d(TAG, "Failed to query WiFi IP address", e);
+    }
+
+    return null;
   }
 }

--- a/src/Android/NativeView.cpp
+++ b/src/Android/NativeView.cpp
@@ -20,8 +20,10 @@ jmethodID NativeView::loadFileBitmap_method;
 jmethodID NativeView::bitmapToTexture_method;
 jmethodID NativeView::shareText_method;
 jmethodID NativeView::openURL_method;
+jmethodID NativeView::openWifiSettings_method;
 jmethodID NativeView::openWaypointFile_method;
 jmethodID NativeView::getNetState_method;
+jmethodID NativeView::getWifiIpAddress_method;
 jmethodID NativeView::isAutoRotateEnabled_method;
 jmethodID NativeView::getPhysicalOrientation_method;
 jmethodID NativeView::startMyService_method;
@@ -64,11 +66,17 @@ NativeView::Initialise(JNIEnv *env)
   openURL_method = env->GetMethodID(cls, "openURL",
                                     "(Ljava/lang/String;)Z");
 
+  openWifiSettings_method = env->GetMethodID(cls, "openWifiSettings",
+                                             "()Z");
+
   openWaypointFile_method =
     env->GetMethodID(cls, "openWaypointFile",
                      "(ILjava/lang/String;)V");
 
   getNetState_method = env->GetMethodID(cls, "getNetState", "()I");
+
+  getWifiIpAddress_method = env->GetMethodID(cls, "getWifiIpAddress",
+                                             "()Ljava/lang/String;");
 
   isAutoRotateEnabled_method =
     env->GetMethodID(cls, "isAutoRotateEnabled", "()Z");
@@ -172,6 +180,25 @@ NativeView::OpenURL(JNIEnv *env, const char *url) noexcept
 {
   return env->CallBooleanMethod(obj, openURL_method,
                                 Java::String{env, url}.Get());
+}
+
+bool
+NativeView::OpenWifiSettings(JNIEnv *env) noexcept
+{
+  return env->CallBooleanMethod(obj, openWifiSettings_method);
+}
+
+bool
+NativeView::GetWifiIpAddress(JNIEnv *env, char *buffer,
+                             size_t max_size) const noexcept
+{
+  const auto string = (jstring)env->CallObjectMethod(obj, getWifiIpAddress_method);
+  if (string == nullptr)
+    return false;
+
+  const bool success = Java::String::CopyTo(env, string, buffer, max_size) != nullptr;
+  env->DeleteLocalRef(string);
+  return success;
 }
 
 void

--- a/src/Android/NativeView.hpp
+++ b/src/Android/NativeView.hpp
@@ -34,8 +34,10 @@ class NativeView {
   static jmethodID bitmapToTexture_method;
   static jmethodID shareText_method;
   static jmethodID openURL_method;
+  static jmethodID openWifiSettings_method;
   static jmethodID openWaypointFile_method;
   static jmethodID getNetState_method;
+  static jmethodID getWifiIpAddress_method;
   static jmethodID isAutoRotateEnabled_method;
   static jmethodID getPhysicalOrientation_method;
   static jmethodID startMyService_method;
@@ -169,6 +171,11 @@ public:
    */
   bool OpenURL(JNIEnv *env, const char *url) noexcept;
 
+  /**
+   * Open Android Wi-Fi settings or connectivity controls.
+   */
+  bool OpenWifiSettings(JNIEnv *env) noexcept;
+
   void OpenWaypointFile(JNIEnv *env, unsigned id, const char *filename) {
     env->CallVoidMethod(obj, openWaypointFile_method, id,
                         Java::String(env, filename).Get());
@@ -178,6 +185,13 @@ public:
   int GetNetState(JNIEnv *env) const noexcept {
     return env->CallIntMethod(obj, getNetState_method);
   }
+
+  /**
+   * Retrieve the current Wi-Fi IP address.
+   * @return true if an address was copied to the buffer
+   */
+  bool GetWifiIpAddress(JNIEnv *env, char *buffer,
+                        size_t max_size) const noexcept;
 
   /**
    * Start the foreground service (only in fly mode).

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -162,9 +162,9 @@ BackendName(LinuxWifiBackendKind b) noexcept
   case LinuxWifiBackendKind::None:
     return _("None");
   case LinuxWifiBackendKind::NetworkManager:
-    return _("NetworkManager");
+    return "NetworkManager";
   case LinuxWifiBackendKind::ConnMan:
-    return _("ConnMan");
+    return "ConnMan";
   }
 
   return _("Unknown");

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -2,16 +2,18 @@
 // Copyright The XCSoar Project
 
 #include "NetworkConfigPanel.hpp"
-#include "UIGlobals.hpp"
-#include "Dialogs/WifiDialog.hpp"
-#include "Widget/RowFormWidget.hpp"
-#include "Language/Language.hpp"
 #include "Dialogs/Message.hpp"
+#include "Dialogs/WifiDialog.hpp"
 #include "Form/DataField/Listener.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "net/State.hpp"
+#include "util/StaticString.hxx"
 
+#include <functional>
 #include <memory>
 #include <stdexcept>
-#include <string>
 
 #if defined(KOBO)
 #include "Kobo/PlatformWifiBackend.hpp"
@@ -20,145 +22,29 @@
 #endif
 
 #if defined(HAVE_LINUX_NET_WIFI)
-#include "net/State.hpp"
 #include "net/wifi/LinuxWifiBackend.hpp"
 #include "net/wifi/WifiError.hpp"
 #endif
 
-#if defined(KOBO)
-
-class KoboNetworkConfigWidget final
-  : public RowFormWidget, public DataFieldListener {
-  unsigned row_status{0}, row_ip{0}, row_backend{0}, row_radio{0};
-
-public:
-  KoboNetworkConfigWidget()
-    :RowFormWidget(UIGlobals::GetDialogLook()) {}
-
-  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
-  bool Save(bool &changed) noexcept override;
-
-private:
-  void OnRefresh() noexcept;
-  void OnModified(DataField &df) noexcept override;
+struct NetworkConfigRows {
+  unsigned status{0}, connectivity{0}, ip{0}, backend{0}, radio{0};
+  bool have_radio{false};
 };
 
-void
-KoboNetworkConfigWidget::Prepare(ContainerWindow &parent,
-                                 const PixelRect &rc) noexcept
-{
-  RowFormWidget::Prepare(parent, rc);
-
-  unsigned n = 0U;
-  row_status = n++;
-  AddReadOnly(
-    _("Status"),
-    _("This page shows Kobo WiFi status. Open WiFi list to scan and connect."),
-    _("Checking WiFi..."));
-  row_ip = n++;
-  AddReadOnly(
-    _("IP address"),
-    _("IPv4 address of the active WiFi interface."),
-    _("Unknown"));
-  row_backend = n++;
-  AddReadOnly(
-    _("Backend"),
-    _("WiFi on Kobo is managed by wpa_supplicant."),
-    "wpa_supplicant");
-  row_radio = n++;
-  AddBoolean(
-    _("WiFi Enabled"),
-    _("Turns the Kobo WiFi interface on or off."),
-    IsKoboWifiOn(), this);
-
-  AddButton(_("WiFi List"), [this]() {
-    try {
-      auto backend = CreatePlatformWifiBackend();
-      if (backend == nullptr) {
-        ShowMessageBox(
-          _("WiFi backend is not available in this Kobo build."),
-          _("Network"), MB_OK);
-        return;
-      }
-
-      ShowWifiDialog(std::move(backend));
-      OnRefresh();
-    } catch (...) {
-      const auto message = WifiError::Format(std::current_exception());
-      ShowMessageBox(message.c_str(), _("Network"), MB_OK);
-    }
-  });
-
-  OnRefresh();
-}
-
-void
-KoboNetworkConfigWidget::OnRefresh() noexcept
-{
-  SetText(row_backend, "wpa_supplicant");
-  LoadValue(row_radio, IsKoboWifiOn());
-
-  if (!IsKoboWifiOn()) {
-    SetText(row_status, _("Disabled"));
-    SetText(row_ip, _("Unknown"));
-    return;
-  }
-
-  try {
-    auto backend = CreatePlatformWifiBackend();
-    if (backend == nullptr) {
-      SetText(row_status, _("WiFi backend is not available in this Kobo build."));
-      SetText(row_ip, _("Unknown"));
-      return;
-    }
-
-    const auto status = backend->GetBackendStatus();
-    SetText(row_status, WifiBackendStatus::Format(status));
-    SetText(row_ip, WifiBackendStatus::FormatIpAddress(status));
-  } catch (...) {
-    const auto message = WifiError::Format(std::current_exception());
-    SetText(row_status, message.c_str());
-    SetText(row_ip, _("Unknown"));
-  }
-}
-
-void
-KoboNetworkConfigWidget::OnModified(DataField &df) noexcept
-{
-  if (!IsDataField(row_radio, df))
-    return;
-
-  try {
-    const bool enabled = GetValueBoolean(row_radio);
-    const bool success = enabled ? KoboWifiOn() : KoboWifiOff();
-    if (!success)
-      throw std::runtime_error{enabled
-        ? _("Failed to enable WiFi.")
-        : _("Failed to disable WiFi.")};
-
-    OnRefresh();
-  } catch (...) {
-    const auto message = WifiError::Format(std::current_exception());
-    ShowMessageBox(message.c_str(), _("Network"), MB_OK);
-    OnRefresh();
-  }
-}
-
-bool
-KoboNetworkConfigWidget::Save(bool &changed) noexcept
-{
-  (void)changed;
-  return true;
-}
-
-#endif
+struct NetworkConfigState {
+  NetState connectivity{NetState::UNKNOWN};
+  StaticString<256> status{_("Unknown")};
+  StaticString<64> ip{_("Unknown")};
+  StaticString<64> backend{_("Unknown")};
+  bool have_radio_enabled{false};
+  bool radio_enabled{false};
+};
 
 #if defined(HAVE_LINUX_NET_WIFI)
-
 static const char *
-BackendName(LinuxWifiBackendKind b) noexcept
+LinuxBackendName(LinuxWifiBackendKind backend_kind) noexcept
 {
-  switch (b) {
+  switch (backend_kind) {
   case LinuxWifiBackendKind::None:
     return _("None");
   case LinuxWifiBackendKind::NetworkManager:
@@ -169,140 +55,304 @@ BackendName(LinuxWifiBackendKind b) noexcept
 
   return _("Unknown");
 }
+#endif
+
+static const char *
+GetStatusHelp() noexcept
+{
+#if defined(KOBO)
+  return _("This page shows Kobo WiFi status. Open WiFi list to scan and connect.");
+#elif defined(HAVE_LINUX_NET_WIFI)
+  return _("This page shows WiFi status when NetworkManager or ConnMan is on "
+           "D-Bus (e.g. Linux with Wayland or KMS). Open WiFi list to scan "
+           "and connect when a service is available.");
+#else
+  return _("Network details are not available in this build.");
+#endif
+}
+
+static const char *
+GetBackendHelp() noexcept
+{
+#if defined(KOBO)
+  return _("WiFi on Kobo is managed by wpa_supplicant.");
+#elif defined(HAVE_LINUX_NET_WIFI)
+  return _("D-Bus provider used for WiFi (see WiFi list to manage networks).");
+#else
+  return _("Platform/backend information is not available in this build.");
+#endif
+}
+
+static const char *
+GetInitialBackendName() noexcept
+{
+#if defined(KOBO)
+  return "wpa_supplicant";
+#elif defined(HAVE_LINUX_NET_WIFI)
+  return LinuxBackendName(LinuxWifiBackendKind::None);
+#else
+  return _("Unavailable");
+#endif
+}
+
+static void
+PreparePlatformRows(RowFormWidget &widget, unsigned &n, NetworkConfigRows &rows,
+                    DataFieldListener &listener) noexcept
+{
+#if defined(KOBO)
+  rows.radio = n++;
+  rows.have_radio = true;
+  widget.AddBoolean(_("WiFi Enabled"),
+                    _("Turns the Kobo WiFi interface on or off."),
+                    IsKoboWifiOn(), &listener);
+#elif defined(HAVE_LINUX_NET_WIFI)
+  try {
+    const auto backend_kind = QueryLinuxWifiBackendKind();
+    rows.have_radio = HasLinuxWifiRadioToggle(backend_kind);
+  } catch (...) {
+    rows.have_radio = false;
+  }
+
+  if (rows.have_radio) {
+    rows.radio = n++;
+    widget.AddBoolean(_("WiFi Enabled"), nullptr, false, &listener);
+  }
+#else
+  (void)widget;
+  (void)n;
+  (void)rows;
+  (void)listener;
+#endif
+}
+
+static void
+OpenPlatformWifiList(std::function<void()> refresh) noexcept
+{
+#if defined(KOBO)
+  try {
+    auto backend = CreatePlatformWifiBackend();
+    if (backend == nullptr) {
+      ShowMessageBox(
+        _("WiFi backend is not available in this Kobo build."),
+        _("Network"), MB_OK);
+      return;
+    }
+
+    ShowWifiDialog(std::move(backend));
+    refresh();
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    ShowMessageBox(message.c_str(), _("Network"), MB_OK);
+  }
+#elif defined(HAVE_LINUX_NET_WIFI)
+  try {
+    auto backend = CreateLinuxWifiBackend();
+    if (backend == nullptr) {
+      ShowMessageBox(
+        _("No network service (NetworkManager or ConnMan) found on D-Bus."),
+        _("Network"), MB_OK);
+      return;
+    }
+
+    ShowWifiDialog(std::move(backend));
+    refresh();
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    ShowMessageBox(message.c_str(), _("Network"), MB_OK);
+  }
+#else
+  (void)refresh;
+  ShowMessageBox(_("WiFi management is not available in this build."),
+                 _("Connectivity"), MB_OK);
+#endif
+}
+
+static void
+BuildPlatformState(NetworkConfigState &state,
+                   const NetworkConfigRows &rows) noexcept
+{
+#if defined(KOBO)
+  state.connectivity = GetNetState();
+  state.backend = "wpa_supplicant";
+  state.have_radio_enabled = true;
+  state.radio_enabled = IsKoboWifiOn();
+
+  if (!state.radio_enabled) {
+    state.status = _("Disabled");
+    return;
+  }
+
+  try {
+    auto backend = CreatePlatformWifiBackend();
+    if (backend == nullptr) {
+      state.status = _("WiFi backend is not available in this Kobo build.");
+      return;
+    }
+
+    const auto status = backend->GetBackendStatus();
+    state.status = WifiBackendStatus::Format(status);
+    state.ip = WifiBackendStatus::FormatIpAddress(status);
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    state.status = message.c_str();
+  }
+#elif defined(HAVE_LINUX_NET_WIFI)
+  try {
+    const auto backend_kind = QueryLinuxWifiBackendKind();
+    state.connectivity = GetNetState();
+    state.backend = LinuxBackendName(backend_kind);
+
+    auto backend = CreateLinuxWifiBackend(backend_kind);
+    if (backend == nullptr) {
+      state.status = _("No network service (NetworkManager or ConnMan) found on D-Bus.");
+    } else {
+      const auto status = backend->GetBackendStatus();
+      state.status = WifiBackendStatus::Format(status);
+      state.ip = WifiBackendStatus::FormatIpAddress(status);
+    }
+
+    if (rows.have_radio) {
+      state.have_radio_enabled = true;
+      state.radio_enabled = GetLinuxWifiRadioEnabled(backend_kind);
+    }
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    state.status = message.c_str();
+  }
+#else
+  (void)rows;
+  state.status = _("In-app network settings are not available in this build.");
+#endif
+
+#if defined(KOBO)
+  (void)rows;
+#endif
+}
+
+static void
+HandlePlatformModified(RowFormWidget &widget, const NetworkConfigRows &rows,
+                       DataField &df,
+                       std::function<void()> refresh) noexcept
+{
+#if defined(KOBO)
+  if (!widget.IsDataField(rows.radio, df))
+    return;
+
+  try {
+    const bool enabled = widget.GetValueBoolean(rows.radio);
+    const bool success = enabled ? KoboWifiOn() : KoboWifiOff();
+    if (!success)
+      throw std::runtime_error{enabled
+        ? _("Failed to enable WiFi.")
+        : _("Failed to disable WiFi.")};
+
+    refresh();
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    ShowMessageBox(message.c_str(), _("Network"), MB_OK);
+    refresh();
+  }
+#elif defined(HAVE_LINUX_NET_WIFI)
+  if (!rows.have_radio || !widget.IsDataField(rows.radio, df))
+    return;
+
+  try {
+    const auto backend_kind = QueryLinuxWifiBackendKind();
+    if (backend_kind == LinuxWifiBackendKind::None) {
+      refresh();
+      return;
+    }
+
+    SetLinuxWifiRadioEnabled(backend_kind, widget.GetValueBoolean(rows.radio));
+    refresh();
+  } catch (...) {
+    const auto message = WifiError::Format(std::current_exception());
+    ShowMessageBox(message.c_str(), _("Network"), MB_OK);
+    refresh();
+  }
+#else
+  (void)widget;
+  (void)rows;
+  (void)df;
+  (void)refresh;
+#endif
+}
 
 class NetworkConfigWidget final
   : public RowFormWidget, public DataFieldListener {
-  LinuxWifiBackendKind backend_kind = LinuxWifiBackendKind::None;
-
-  unsigned row_status{0}, row_connectivity{0}, row_ip{0};
-  unsigned row_backend{0}, row_radio{0};
-  bool have_radio{false};
+  NetworkConfigRows rows;
 
 public:
   NetworkConfigWidget()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
 
-  /* virtual methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
   bool Save(bool &changed) noexcept override;
 
 private:
   void OnRefresh() noexcept;
-
-  /* DataFieldListener */
   void OnModified(DataField &df) noexcept override;
 };
 
 void
-NetworkConfigWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
+NetworkConfigWidget::Prepare(ContainerWindow &parent,
+                             const PixelRect &rc) noexcept
 {
   RowFormWidget::Prepare(parent, rc);
 
   unsigned n = 0U;
-  row_status = n++;
-  AddReadOnly(
-    _("Status"),
-    _("This page shows WiFi status when NetworkManager or ConnMan is on "
-      "D-Bus (e.g. Linux with Wayland or KMS). Open WiFi list to scan and "
-      "connect when a service is available."),
-    _("Checking network services..."));
-  row_connectivity = n++;
-  AddReadOnly(
-    _("Connectivity"),
-    _("Current network connectivity state."),
-    NetStateText::ToString(NetState::UNKNOWN));
-  row_ip = n++;
-  AddReadOnly(
-    _("IP address"),
-    _("IPv4 address of the active WiFi interface."),
-    _("Unknown"));
-  row_backend = n++;
-  AddReadOnly(
-    _("Backend"),
-    _("D-Bus provider used for WiFi (see WiFi list to manage networks)."),
-    BackendName(LinuxWifiBackendKind::None));
+  rows.status = n++;
+  AddReadOnly(_("Status"), GetStatusHelp(), _("Checking network services..."));
 
-  try {
-    backend_kind = QueryLinuxWifiBackendKind();
-    have_radio = HasLinuxWifiRadioToggle(backend_kind);
-  } catch (...) {
-    backend_kind = LinuxWifiBackendKind::None;
-    have_radio = false;
-  }
+  rows.connectivity = n++;
+  AddReadOnly(_("Connectivity"),
+              _("Current network connectivity state."),
+              NetStateText::ToString(NetState::UNKNOWN));
+  rows.ip = n++;
+  AddReadOnly(_("IP address"),
+              _("IPv4 address of the active WiFi interface."),
+              _("Unknown"));
+  rows.backend = n++;
+  AddReadOnly(_("Backend"),
+              GetBackendHelp(),
+              GetInitialBackendName());
 
-  if (have_radio) {
-    row_radio = n++;
-    AddBoolean(_("WiFi Enabled"), nullptr, false, this);
-  }
+  PreparePlatformRows(*this, n, rows, *this);
 
   AddButton(_("WiFi List"), [this]() {
-    try {
-      auto backend = CreateLinuxWifiBackend();
-      if (backend == nullptr) {
-        ShowMessageBox(
-          _("No network service (NetworkManager or ConnMan) found on D-Bus."),
-          _("Network"), MB_OK);
-        return;
-      }
-
-      ShowWifiDialog(std::move(backend));
-      OnRefresh();
-    } catch (...) {
-      const auto message = WifiError::Format(std::current_exception());
-      ShowMessageBox(message.c_str(), _("Network"), MB_OK);
-    }
+    OpenPlatformWifiList([this]() { OnRefresh(); });
   });
 
   OnRefresh();
 }
 
 void
+NetworkConfigWidget::Show(const PixelRect &rc) noexcept
+{
+  RowFormWidget::Show(rc);
+  OnRefresh();
+}
+
+void
 NetworkConfigWidget::OnRefresh() noexcept
 {
-  const auto set_error_state = [this](const char *status) {
-    SetText(row_status, status);
-    SetText(row_connectivity, NetStateText::ToString(NetState::UNKNOWN));
-    SetText(row_ip, _("Unknown"));
-    SetText(row_backend, _("Unknown"));
-  };
+  NetworkConfigState state;
+  BuildPlatformState(state, rows);
 
-  try {
-    backend_kind = QueryLinuxWifiBackendKind();
-    SetText(row_backend, BackendName(backend_kind));
-    SetText(row_connectivity, NetStateText::ToString(GetNetState()));
+  SetText(rows.status, state.status.c_str());
+  SetText(rows.connectivity, NetStateText::ToString(state.connectivity));
+  SetText(rows.ip, state.ip.c_str());
+  SetText(rows.backend, state.backend.c_str());
 
-    auto backend = CreateLinuxWifiBackend(backend_kind);
-    if (backend == nullptr) {
-      SetText(row_status,
-              _("No network service (NetworkManager or ConnMan) found on D-Bus."));
-      SetText(row_ip, _("Unknown"));
-    } else {
-      const auto status = backend->GetBackendStatus();
-      SetText(row_status, WifiBackendStatus::Format(status));
-      SetText(row_ip, WifiBackendStatus::FormatIpAddress(status));
-    }
-
-    if (have_radio)
-      LoadValue(row_radio, GetLinuxWifiRadioEnabled(backend_kind));
-  } catch (...) {
-    const auto message = WifiError::Format(std::current_exception());
-    set_error_state(message.c_str());
-  }
+  if (rows.have_radio && state.have_radio_enabled)
+    LoadValue(rows.radio, state.radio_enabled);
 }
 
 void
 NetworkConfigWidget::OnModified(DataField &df) noexcept
 {
-  if (have_radio && IsDataField(row_radio, df) &&
-      backend_kind != LinuxWifiBackendKind::None) {
-    try {
-      SetLinuxWifiRadioEnabled(backend_kind, GetValueBoolean(row_radio));
-      OnRefresh();
-    } catch (...) {
-      const auto message = WifiError::Format(std::current_exception());
-      ShowMessageBox(message.c_str(), _("Network"), MB_OK);
-    }
-  }
+  HandlePlatformModified(*this, rows, df, [this]() { OnRefresh(); });
 }
 
 bool
@@ -312,33 +362,8 @@ NetworkConfigWidget::Save(bool &changed) noexcept
   return true;
 }
 
-#endif /* HAVE_LINUX_NET_WIFI */
-
-#if !defined(HAVE_LINUX_NET_WIFI) && !defined(KOBO)
-class NetworkConfigStub final : public RowFormWidget {
-public:
-  explicit NetworkConfigStub()
-    :RowFormWidget(UIGlobals::GetDialogLook()) {}
-
-  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override
-  {
-    RowFormWidget::Prepare(parent, rc);
-    AddReadOnly(
-      _("Status"),
-      nullptr,
-      _("In-app network settings are not available in this build."));
-  }
-};
-#endif
-
 std::unique_ptr<Widget>
 CreateNetworkConfigPanel()
 {
-#if defined(KOBO)
-  return std::make_unique<KoboNetworkConfigWidget>();
-#elif defined(HAVE_LINUX_NET_WIFI)
   return std::make_unique<NetworkConfigWidget>();
-#else
-  return std::make_unique<NetworkConfigStub>();
-#endif
 }

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -9,11 +9,13 @@
 #include "UIGlobals.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "net/State.hpp"
+#include "system/OpenLink.hpp"
 #include "util/StaticString.hxx"
 
 #include <functional>
 #include <memory>
 #include <stdexcept>
+#include <string>
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
@@ -111,6 +113,8 @@ GetStatusHelp() noexcept
            "and connect when a service is available.");
 #elif defined(ANDROID)
   return _("WiFi on Android is managed by the system settings. Use WiFi list to open them.");
+#elif defined(_WIN32)
+  return _("WiFi on Windows is managed by the Settings app. Use WiFi list to open it.");
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
   return _("WiFi on iOS is managed by the Settings app. Use WiFi list for instructions.");
 #else
@@ -125,7 +129,7 @@ GetBackendHelp() noexcept
   return _("WiFi on Kobo is managed by wpa_supplicant.");
 #elif defined(HAVE_LINUX_NET_WIFI)
   return _("D-Bus provider used for WiFi (see WiFi list to manage networks).");
-#elif defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+#elif defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   return _("Platform backend used for WiFi management.");
 #else
   return _("Platform/backend information is not available in this build.");
@@ -141,6 +145,8 @@ GetInitialBackendName() noexcept
   return LinuxBackendName(LinuxWifiBackendKind::None);
 #elif defined(ANDROID)
   return "Android";
+#elif defined(_WIN32)
+  return "Windows";
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
   return "iOS";
 #else
@@ -224,7 +230,12 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
 
   ShowMessageBox(_("Failed to open Android WiFi settings."),
                  _("Connectivity"), MB_OK);
-  (void)refresh;
+#elif defined(_WIN32)
+  if (OpenLink("ms-settings:network-wifi"))
+    return;
+
+  ShowMessageBox(_("Failed to open Windows WiFi settings."),
+                 _("Connectivity"), MB_OK);
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
   ShowMessageBox(_("Open the Settings app on the iPhone or iPad, then go to Wi-Fi to scan and connect."),
                  _("Connectivity"), MB_OK);
@@ -234,7 +245,7 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
                  _("Connectivity"), MB_OK);
 #endif
 
-#if defined(__APPLE__) && TARGET_OS_IPHONE
+#if defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   (void)refresh;
 #endif
 }
@@ -301,6 +312,10 @@ BuildPlatformState(NetworkConfigState &state,
   const auto android_ip = GetPlatformWifiIpAddress();
   if (!android_ip.empty())
     state.ip = android_ip;
+#elif defined(_WIN32)
+  state.connectivity = GetNetState();
+  state.backend = "Windows";
+  state.status = _("Managed by Windows Settings app.");
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
   state.connectivity = GetNetState();
   state.backend = "iOS";
@@ -313,7 +328,7 @@ BuildPlatformState(NetworkConfigState &state,
   state.status = _("In-app network settings are not available in this build.");
 #endif
 
-#if defined(KOBO) || defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+#if defined(KOBO) || defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   (void)rows;
 #endif
 }

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -26,6 +26,12 @@
 #include "net/wifi/WifiError.hpp"
 #endif
 
+#ifdef ANDROID
+#include "Android/Main.hpp"
+#include "Android/NativeView.hpp"
+#include "java/Global.hxx"
+#endif
+
 struct NetworkConfigRows {
   unsigned status{0}, connectivity{0}, ip{0}, backend{0}, radio{0},
     persist_wifi{0};
@@ -61,6 +67,23 @@ LinuxBackendName(LinuxWifiBackendKind backend_kind) noexcept
 }
 #endif
 
+#ifdef ANDROID
+static StaticString<64>
+GetPlatformWifiIpAddress() noexcept
+{
+  StaticString<64> text;
+  text.clear();
+
+  if (native_view == nullptr)
+    return text;
+
+  native_view->GetWifiIpAddress(Java::GetEnv(),
+                                text.buffer(), text.capacity());
+
+  return text;
+}
+#endif
+
 static const char *
 GetStatusHelp() noexcept
 {
@@ -70,6 +93,8 @@ GetStatusHelp() noexcept
   return _("This page shows WiFi status when NetworkManager or ConnMan is on "
            "D-Bus (e.g. Linux with Wayland or KMS). Open WiFi list to scan "
            "and connect when a service is available.");
+#elif defined(ANDROID)
+  return _("WiFi on Android is managed by the system settings. Use WiFi list to open them.");
 #else
   return _("Network details are not available in this build.");
 #endif
@@ -82,6 +107,8 @@ GetBackendHelp() noexcept
   return _("WiFi on Kobo is managed by wpa_supplicant.");
 #elif defined(HAVE_LINUX_NET_WIFI)
   return _("D-Bus provider used for WiFi (see WiFi list to manage networks).");
+#elif defined(ANDROID)
+  return _("Platform backend used for WiFi management.");
 #else
   return _("Platform/backend information is not available in this build.");
 #endif
@@ -94,6 +121,8 @@ GetInitialBackendName() noexcept
   return "wpa_supplicant";
 #elif defined(HAVE_LINUX_NET_WIFI)
   return LinuxBackendName(LinuxWifiBackendKind::None);
+#elif defined(ANDROID)
+  return "Android";
 #else
   return _("Unavailable");
 #endif
@@ -169,6 +198,13 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
     const auto message = WifiError::Format(std::current_exception());
     ShowMessageBox(message.c_str(), _("Network"), MB_OK);
   }
+#elif defined(ANDROID)
+  if (native_view != nullptr && native_view->OpenWifiSettings(Java::GetEnv()))
+    return;
+
+  ShowMessageBox(_("Failed to open Android WiFi settings."),
+                 _("Connectivity"), MB_OK);
+  (void)refresh;
 #else
   (void)refresh;
   ShowMessageBox(_("WiFi management is not available in this build."),
@@ -230,12 +266,20 @@ BuildPlatformState(NetworkConfigState &state,
     const auto message = WifiError::Format(std::current_exception());
     state.status = message.c_str();
   }
+#elif defined(ANDROID)
+  state.connectivity = GetNetState();
+  state.backend = "Android";
+  state.status = _("Managed by Android system settings.");
+
+  const auto android_ip = GetPlatformWifiIpAddress();
+  if (!android_ip.empty())
+    state.ip = android_ip;
 #else
   (void)rows;
   state.status = _("In-app network settings are not available in this build.");
 #endif
 
-#if defined(KOBO)
+#if defined(KOBO) || defined(ANDROID)
   (void)rows;
 #endif
 }

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -15,6 +15,10 @@
 #include <memory>
 #include <stdexcept>
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 #if defined(KOBO)
 #include "Kobo/PlatformWifiBackend.hpp"
 #include "Kobo/System.hpp"
@@ -30,6 +34,10 @@
 #include "Android/Main.hpp"
 #include "Android/NativeView.hpp"
 #include "java/Global.hxx"
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+#include "net/IPv4Address.hxx"
 #endif
 
 struct NetworkConfigRows {
@@ -67,18 +75,26 @@ LinuxBackendName(LinuxWifiBackendKind backend_kind) noexcept
 }
 #endif
 
-#ifdef ANDROID
+#if defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
 static StaticString<64>
 GetPlatformWifiIpAddress() noexcept
 {
   StaticString<64> text;
   text.clear();
 
+#ifdef ANDROID
   if (native_view == nullptr)
     return text;
 
   native_view->GetWifiIpAddress(Java::GetEnv(),
                                 text.buffer(), text.capacity());
+#else
+  char buffer[64];
+  const auto address = IPv4Address::GetDeviceAddress("en0");
+  if (address.IsDefined() &&
+      address.ToString(buffer, sizeof(buffer)) != nullptr)
+    text = buffer;
+#endif
 
   return text;
 }
@@ -95,6 +111,8 @@ GetStatusHelp() noexcept
            "and connect when a service is available.");
 #elif defined(ANDROID)
   return _("WiFi on Android is managed by the system settings. Use WiFi list to open them.");
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+  return _("WiFi on iOS is managed by the Settings app. Use WiFi list for instructions.");
 #else
   return _("Network details are not available in this build.");
 #endif
@@ -107,7 +125,7 @@ GetBackendHelp() noexcept
   return _("WiFi on Kobo is managed by wpa_supplicant.");
 #elif defined(HAVE_LINUX_NET_WIFI)
   return _("D-Bus provider used for WiFi (see WiFi list to manage networks).");
-#elif defined(ANDROID)
+#elif defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   return _("Platform backend used for WiFi management.");
 #else
   return _("Platform/backend information is not available in this build.");
@@ -123,6 +141,8 @@ GetInitialBackendName() noexcept
   return LinuxBackendName(LinuxWifiBackendKind::None);
 #elif defined(ANDROID)
   return "Android";
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+  return "iOS";
 #else
   return _("Unavailable");
 #endif
@@ -205,10 +225,17 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
   ShowMessageBox(_("Failed to open Android WiFi settings."),
                  _("Connectivity"), MB_OK);
   (void)refresh;
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+  ShowMessageBox(_("Open the Settings app on the iPhone or iPad, then go to Wi-Fi to scan and connect."),
+                 _("Connectivity"), MB_OK);
 #else
   (void)refresh;
   ShowMessageBox(_("WiFi management is not available in this build."),
                  _("Connectivity"), MB_OK);
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  (void)refresh;
 #endif
 }
 
@@ -274,12 +301,19 @@ BuildPlatformState(NetworkConfigState &state,
   const auto android_ip = GetPlatformWifiIpAddress();
   if (!android_ip.empty())
     state.ip = android_ip;
+#elif defined(__APPLE__) && TARGET_OS_IPHONE
+  state.connectivity = GetNetState();
+  state.backend = "iOS";
+  state.status = _("Managed by iOS Settings app.");
+  const auto ios_ip = GetPlatformWifiIpAddress();
+  if (!ios_ip.empty())
+    state.ip = ios_ip;
 #else
   (void)rows;
   state.status = _("In-app network settings are not available in this build.");
 #endif
 
-#if defined(KOBO) || defined(ANDROID)
+#if defined(KOBO) || defined(ANDROID) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   (void)rows;
 #endif
 }

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -27,8 +27,10 @@
 #endif
 
 struct NetworkConfigRows {
-  unsigned status{0}, connectivity{0}, ip{0}, backend{0}, radio{0};
+  unsigned status{0}, connectivity{0}, ip{0}, backend{0}, radio{0},
+    persist_wifi{0};
   bool have_radio{false};
+  bool have_persist_wifi{false};
 };
 
 struct NetworkConfigState {
@@ -38,6 +40,8 @@ struct NetworkConfigState {
   StaticString<64> backend{_("Unknown")};
   bool have_radio_enabled{false};
   bool radio_enabled{false};
+  bool have_persist_wifi_enabled{false};
+  bool persist_wifi_enabled{false};
 };
 
 #if defined(HAVE_LINUX_NET_WIFI)
@@ -105,6 +109,11 @@ PreparePlatformRows(RowFormWidget &widget, unsigned &n, NetworkConfigRows &rows,
   widget.AddBoolean(_("WiFi Enabled"),
                     _("Turns the Kobo WiFi interface on or off."),
                     IsKoboWifiOn(), &listener);
+  rows.persist_wifi = n++;
+  rows.have_persist_wifi = true;
+  widget.AddBoolean(_("Auto WiFi"),
+                    _("Enable WiFi automatically at startup."),
+                    IsKoboWifiAutoOn(), &listener);
 #elif defined(HAVE_LINUX_NET_WIFI)
   try {
     const auto backend_kind = QueryLinuxWifiBackendKind();
@@ -176,6 +185,8 @@ BuildPlatformState(NetworkConfigState &state,
   state.backend = "wpa_supplicant";
   state.have_radio_enabled = true;
   state.radio_enabled = IsKoboWifiOn();
+  state.have_persist_wifi_enabled = true;
+  state.persist_wifi_enabled = IsKoboWifiAutoOn();
 
   if (!state.radio_enabled) {
     state.status = _("Disabled");
@@ -235,6 +246,16 @@ HandlePlatformModified(RowFormWidget &widget, const NetworkConfigRows &rows,
                        std::function<void()> refresh) noexcept
 {
 #if defined(KOBO)
+  if (rows.have_persist_wifi && widget.IsDataField(rows.persist_wifi, df)) {
+    if (!SetKoboWifiAutoOn(widget.GetValueBoolean(rows.persist_wifi))) {
+      ShowMessageBox(_("Failed to store the WiFi startup setting."),
+                     _("Network"), MB_OK);
+      refresh();
+    }
+
+    return;
+  }
+
   if (!widget.IsDataField(rows.radio, df))
     return;
 
@@ -347,6 +368,9 @@ NetworkConfigWidget::OnRefresh() noexcept
 
   if (rows.have_radio && state.have_radio_enabled)
     LoadValue(rows.radio, state.radio_enabled);
+
+  if (rows.have_persist_wifi && state.have_persist_wifi_enabled)
+    LoadValue(rows.persist_wifi, state.persist_wifi_enabled);
 }
 
 void

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -102,21 +102,31 @@ GetPlatformWifiIpAddress() noexcept
 }
 #endif
 
+#if defined(KOBO) || defined(HAVE_LINUX_NET_WIFI)
+static const char *
+GetWifiServiceUnavailableText() noexcept
+{
+  return _("WiFi service is not available.");
+}
+#endif
+
+#if defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+static const char *
+GetManagedBySystemSettingsText() noexcept
+{
+  return _("Managed by system settings.");
+}
+#endif
+
 static const char *
 GetStatusHelp() noexcept
 {
-#if defined(KOBO)
-  return _("This page shows Kobo WiFi status. Open WiFi list to scan and connect.");
-#elif defined(HAVE_LINUX_NET_WIFI)
-  return _("This page shows WiFi status when NetworkManager or ConnMan is on "
-           "D-Bus (e.g. Linux with Wayland or KMS). Open WiFi list to scan "
-           "and connect when a service is available.");
-#elif defined(ANDROID)
-  return _("WiFi on Android is managed by the system settings. Use WiFi list to open them.");
-#elif defined(_WIN32)
-  return _("WiFi on Windows is managed by the Settings app. Use WiFi list to open it.");
+#if defined(KOBO) || defined(HAVE_LINUX_NET_WIFI)
+  return _("This page shows WiFi status. Use WiFi list to scan and connect.");
+#elif defined(ANDROID) || defined(_WIN32)
+  return _("WiFi is managed by the system settings. Use WiFi list to open them.");
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
-  return _("WiFi on iOS is managed by the Settings app. Use WiFi list for instructions.");
+  return _("WiFi is managed by the system settings. Use WiFi list for instructions.");
 #else
   return _("Network details are not available in this build.");
 #endif
@@ -125,12 +135,8 @@ GetStatusHelp() noexcept
 static const char *
 GetBackendHelp() noexcept
 {
-#if defined(KOBO)
-  return _("WiFi on Kobo is managed by wpa_supplicant.");
-#elif defined(HAVE_LINUX_NET_WIFI)
-  return _("D-Bus provider used for WiFi (see WiFi list to manage networks).");
-#elif defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
-  return _("Platform backend used for WiFi management.");
+#if defined(KOBO) || defined(HAVE_LINUX_NET_WIFI) || defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
+  return _("WiFi service used by the device.");
 #else
   return _("Platform/backend information is not available in this build.");
 #endif
@@ -196,9 +202,7 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
   try {
     auto backend = CreatePlatformWifiBackend();
     if (backend == nullptr) {
-      ShowMessageBox(
-        _("WiFi backend is not available in this Kobo build."),
-        _("Network"), MB_OK);
+      ShowMessageBox(GetWifiServiceUnavailableText(), _("Network"), MB_OK);
       return;
     }
 
@@ -212,9 +216,7 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
   try {
     auto backend = CreateLinuxWifiBackend();
     if (backend == nullptr) {
-      ShowMessageBox(
-        _("No network service (NetworkManager or ConnMan) found on D-Bus."),
-        _("Network"), MB_OK);
+      ShowMessageBox(GetWifiServiceUnavailableText(), _("Network"), MB_OK);
       return;
     }
 
@@ -228,16 +230,16 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
   if (native_view != nullptr && native_view->OpenWifiSettings(Java::GetEnv()))
     return;
 
-  ShowMessageBox(_("Failed to open Android WiFi settings."),
+  ShowMessageBox(_("Failed to open system settings."),
                  _("Connectivity"), MB_OK);
 #elif defined(_WIN32)
   if (OpenLink("ms-settings:network-wifi"))
     return;
 
-  ShowMessageBox(_("Failed to open Windows WiFi settings."),
+  ShowMessageBox(_("Failed to open system settings."),
                  _("Connectivity"), MB_OK);
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
-  ShowMessageBox(_("Open the Settings app on the iPhone or iPad, then go to Wi-Fi to scan and connect."),
+  ShowMessageBox(_("Open the Settings app, then go to Wi-Fi."),
                  _("Connectivity"), MB_OK);
 #else
   (void)refresh;
@@ -270,7 +272,7 @@ BuildPlatformState(NetworkConfigState &state,
   try {
     auto backend = CreatePlatformWifiBackend();
     if (backend == nullptr) {
-      state.status = _("WiFi backend is not available in this Kobo build.");
+      state.status = GetWifiServiceUnavailableText();
       return;
     }
 
@@ -289,7 +291,7 @@ BuildPlatformState(NetworkConfigState &state,
 
     auto backend = CreateLinuxWifiBackend(backend_kind);
     if (backend == nullptr) {
-      state.status = _("No network service (NetworkManager or ConnMan) found on D-Bus.");
+      state.status = GetWifiServiceUnavailableText();
     } else {
       const auto status = backend->GetBackendStatus();
       state.status = WifiBackendStatus::Format(status);
@@ -307,19 +309,18 @@ BuildPlatformState(NetworkConfigState &state,
 #elif defined(ANDROID)
   state.connectivity = GetNetState();
   state.backend = "Android";
-  state.status = _("Managed by Android system settings.");
-
+  state.status = GetManagedBySystemSettingsText();
   const auto android_ip = GetPlatformWifiIpAddress();
   if (!android_ip.empty())
     state.ip = android_ip;
 #elif defined(_WIN32)
   state.connectivity = GetNetState();
   state.backend = "Windows";
-  state.status = _("Managed by Windows Settings app.");
+  state.status = GetManagedBySystemSettingsText();
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
   state.connectivity = GetNetState();
   state.backend = "iOS";
-  state.status = _("Managed by iOS Settings app.");
+  state.status = GetManagedBySystemSettingsText();
   const auto ios_ip = GetPlatformWifiIpAddress();
   if (!ios_ip.empty())
     state.ip = ios_ip;
@@ -417,7 +418,7 @@ NetworkConfigWidget::Prepare(ContainerWindow &parent,
 
   unsigned n = 0U;
   rows.status = n++;
-  AddReadOnly(_("Status"), GetStatusHelp(), _("Checking network services..."));
+  AddReadOnly(_("Status"), GetStatusHelp(), _("Checking WiFi..."));
 
   rows.connectivity = n++;
   AddReadOnly(_("Connectivity"),

--- a/src/Dialogs/WifiDialog.cpp
+++ b/src/Dialogs/WifiDialog.cpp
@@ -6,6 +6,7 @@
 #include "Dialogs/Message.hpp"
 #include "Dialogs/Error.hpp"
 #include "Dialogs/TextEntry.hpp"
+#include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
 #include "LogFile.hpp"
@@ -14,7 +15,6 @@
 #include "Screen/Layout.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "util/Exception.hxx"
-#include "Language/Language.hpp"
 #include "Widget/ListWidget.hpp"
 #include "net/wifi/WifiBackend.hpp"
 #include "net/wifi/WifiError.hpp"
@@ -240,6 +240,7 @@ public:
         ShowWifiError(std::current_exception(), _("Error"));
       }
     });
+
   }
 
   void UpdateButtons();
@@ -356,6 +357,7 @@ WifiListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 
   if (info.is_visible) {
     StaticString<64> text;
+    text.clear();
     switch (info.signal_unit) {
     case WifiSignalUnit::Dbm:
       text.UnsafeFormat("%s %d dBm", auth, info.signal_level);
@@ -454,6 +456,9 @@ WifiListWidget::UpdateList()
 
   try {
     std::array<WifiNetworkEntry, 64> buffer;
+    for (auto &entry : buffer)
+      entry.Clear();
+
     const auto n = backend_->GetNetworks(buffer.data(), buffer.size());
     std::stable_sort(buffer.begin(), buffer.begin() + n, NetworkEntrySortLess);
 

--- a/src/Kobo/KoboMenu.cpp
+++ b/src/Kobo/KoboMenu.cpp
@@ -157,6 +157,8 @@ Main()
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 {
+  ApplyKoboWifiAutoOn();
+
   while (true) {
     int action = Main();
 

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -18,6 +18,24 @@
 #include <sys/mount.h>
 #include <errno.h>
 
+static bool
+WaitForPath(const char *path, unsigned timeout_ms) noexcept
+{
+  if (path == nullptr)
+    return false;
+
+  constexpr unsigned step_ms = 100;
+
+  for (unsigned elapsed = 0; elapsed < timeout_ms; elapsed += step_ms) {
+    if (File::Exists(Path(path)))
+      return true;
+
+    Sleep(step_ms);
+  }
+
+  return File::Exists(Path(path));
+}
+
 template<typename... Args>
 static bool
 InsMod(const char *path, Args... args)
@@ -251,11 +269,13 @@ KoboWifiOn()
       "-c", "/etc/wpa_supplicant/wpa_supplicant.conf",
       "-C", "/var/run/wpa_supplicant", "-B", "-D", driver);
 
-  Sleep(2000);
+  StaticString<128> control_path;
+  control_path.Format("/var/run/wpa_supplicant/%s", interface);
+  WaitForPath(control_path.c_str(), 3000);
 
-  Start("/sbin/udhcpc", "-S", "-i", interface,
-        "-s", "/etc/udhcpc.d/default.script",
-        "-t15", "-T10", "-A3", "-f", "-q");
+  Run("/sbin/udhcpc", "-S", "-i", interface,
+      "-s", "/etc/udhcpc.d/default.script",
+      "-t15", "-T10", "-A3", "-f", "-q");
 
   return true;
 #else

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -18,6 +18,10 @@
 #include <sys/mount.h>
 #include <errno.h>
 
+static constexpr const char *kobo_config_dir = "/mnt/onboard/XCSoarData/kobo";
+static constexpr const char *kobo_wifi_auto_on_path =
+  "/mnt/onboard/XCSoarData/kobo/wifi_auto_on";
+
 static bool
 WaitForPath(const char *path, unsigned timeout_ms) noexcept
 {
@@ -202,6 +206,50 @@ IsKoboWifiOn()
   return Directory::Exists(Path{path});
 #else
   return false;
+#endif
+}
+
+bool
+IsKoboWifiAutoOn()
+{
+#ifdef KOBO
+  return File::Exists(Path(kobo_wifi_auto_on_path));
+#else
+  return false;
+#endif
+}
+
+bool
+SetKoboWifiAutoOn(bool enabled)
+{
+#ifdef KOBO
+  if (mkdir("/mnt/onboard/XCSoarData", 0777) != 0 && errno != EEXIST)
+    return false;
+  if (mkdir(kobo_config_dir, 0777) != 0 && errno != EEXIST)
+    return false;
+
+  if (enabled)
+    return File::CreateExclusive(Path(kobo_wifi_auto_on_path)) ||
+      File::Exists(Path(kobo_wifi_auto_on_path));
+
+  return File::Delete(Path(kobo_wifi_auto_on_path)) ||
+    !File::Exists(Path(kobo_wifi_auto_on_path));
+#else
+  (void)enabled;
+  return false;
+#endif
+}
+
+void
+ApplyKoboWifiAutoOn()
+{
+#ifdef KOBO
+  if (IsKoboWifiAutoOn()) {
+    if (!IsKoboWifiOn())
+      KoboWifiOn();
+  } else if (IsKoboWifiOn()) {
+    KoboWifiOff();
+  }
 #endif
 }
 

--- a/src/Kobo/System.hpp
+++ b/src/Kobo/System.hpp
@@ -26,6 +26,15 @@ bool
 IsKoboWifiOn();
 
 bool
+IsKoboWifiAutoOn();
+
+bool
+SetKoboWifiAutoOn(bool enabled);
+
+void
+ApplyKoboWifiAutoOn();
+
+bool
 KoboWifiOn();
 
 bool

--- a/src/Kobo/WPASupplicant.cpp
+++ b/src/Kobo/WPASupplicant.cpp
@@ -83,7 +83,11 @@ ParseStatusLine(WifiBackendStatus &status, std::string_view src) noexcept
 static bool
 ParseStatus(WifiBackendStatus &status, std::string_view src) noexcept
 {
-  status = {};
+  /* Preserve fields pre-filled by the backend (e.g. interface_name,
+     signal_unit) and only refresh values returned by STATUS. */
+  status.state = WifiConnectionState::Unknown;
+  status.bssid.clear();
+  status.ssid.clear();
 
   for (const auto line : IterableSplitString(src, '\n'))
     ParseStatusLine(status, line);

--- a/src/Kobo/WPASupplicantBackend.cpp
+++ b/src/Kobo/WPASupplicantBackend.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "WPASupplicantBackend.hpp"
+#include "Kobo/Model.hpp"
 #include "lib/fmt/ToBuffer.hxx"
 #include "net/wifi/WifiError.hpp"
 #include "system/Error.hxx"
@@ -177,6 +178,14 @@ WPASupplicantBackend::GetBackendStatus()
   status.state = !status.bssid.empty()
     ? WifiConnectionState::Connected
     : WifiConnectionState::Disconnected;
+
+  /* Preserve the old Kobo behavior: if STATUS does not provide an IP address,
+     look it up from the Kobo WiFi interface directly. */
+  if (status.ip_address.empty() &&
+      status.state == WifiConnectionState::Connected)
+    (void)TryFormatWifiInterfaceAddress(GetKoboWifiInterface(),
+                                        status.ip_address);
+
   return status;
 }
 

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -119,6 +119,10 @@
 #include "Android/NativeView.hpp"
 #endif
 
+#ifdef KOBO
+#include "Kobo/System.hpp"
+#endif
+
 #ifdef __APPLE__
 #include "Apple/Services.hpp"
 #endif
@@ -399,6 +403,10 @@ Startup(UI::Display &display)
 
   /* create XCSoarData on the first start */
   CreateDataPath();
+
+#ifdef KOBO
+  ApplyKoboWifiAutoOn();
+#endif
 
 #ifdef ANDROID
   {

--- a/src/net/wifi/ConnmanClient.cpp
+++ b/src/net/wifi/ConnmanClient.cpp
@@ -433,6 +433,16 @@ FindTechnology(ODBus::Connection &c, const char *type)
   return {};
 }
 
+static TechnologyEntry
+RequireWifiTechnology(ODBus::Connection &c)
+{
+  const auto technology = FindTechnology(c, "wifi");
+  if (technology.path.empty())
+    throw WifiError::Exception{WifiError::Code::NoInterface};
+
+  return technology;
+}
+
 template<typename T>
 static void
 SetProperty(ODBus::Connection &c, const char *path,
@@ -496,20 +506,14 @@ CmClient::Remove(ODBus::Connection &c, const char *path)
 bool
 CmClient::IsWifiTechnologyPowered(ODBus::Connection &c)
 {
-  const auto technology = FindTechnology(c, "wifi");
-  if (technology.path.empty())
-    throw std::runtime_error{"No Wi-Fi technology available"};
-
+  const auto technology = RequireWifiTechnology(c);
   return technology.powered;
 }
 
 void
 CmClient::SetWifiTechnologyPowered(ODBus::Connection &c, bool enabled)
 {
-  const auto technology = FindTechnology(c, "wifi");
-  if (technology.path.empty())
-    throw std::runtime_error{"No Wi-Fi technology available"};
-
+  const auto technology = RequireWifiTechnology(c);
   SetTechnologyPowered(c, technology.path.c_str(), enabled);
 }
 
@@ -531,10 +535,7 @@ CmClient::EnableWifiTechnology(ODBus::Connection &c)
 void
 CmClient::ScanWifiTechnology(ODBus::Connection &c)
 {
-  const auto technology = FindTechnology(c, "wifi");
-  if (technology.path.empty())
-    throw std::runtime_error{"No Wi-Fi technology available"};
-
+  const auto technology = RequireWifiTechnology(c);
   ScanTechnology(c, technology.path.c_str());
 }
 

--- a/src/net/wifi/ConnmanWifiBackend.cpp
+++ b/src/net/wifi/ConnmanWifiBackend.cpp
@@ -9,11 +9,28 @@
 #include "lib/dbus/Connection.hxx"
 
 #include <algorithm>
+#include <exception>
 #include <stdexcept>
 
 namespace {
 
 static constexpr const char *CONNMAN_NAME = "net.connman";
+
+static ODBus::Connection
+GetSystemConnection()
+{
+  try {
+    auto c = ODBus::Connection::GetSystem();
+    if (!c)
+      throw WifiError::Exception{WifiError::Code::NoDbusConnection};
+
+    return c;
+  } catch (const WifiError::Exception &) {
+    throw;
+  } catch (...) {
+    std::throw_with_nested(WifiError::Exception{WifiError::Code::NoDbusConnection});
+  }
+}
 
 static void
 RequireWifiInterface(ODBus::Connection &c)
@@ -38,10 +55,7 @@ CanForgetService(const CmClient::ServiceEntry &service) noexcept
 void
 ConnmanWifiBackend::EnsureConnected()
 {
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
 }
 
@@ -50,10 +64,7 @@ ConnmanWifiBackend::Scan()
 {
   EnsureConnected();
 
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   CmClient::EnableWifiTechnology(c);
   CmClient::ScanWifiTechnology(c);
 }
@@ -72,10 +83,7 @@ ConnmanWifiBackend::Connect(const char *ssid, const char *passphrase,
 void
 ConnmanWifiBackend::Connect(const WifiConnectRequest &request)
 {
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
   CmClient::EnableWifiTechnology(c);
 
@@ -108,10 +116,7 @@ ConnmanWifiBackend::Connect(const WifiConnectRequest &request)
 void
 ConnmanWifiBackend::Disconnect()
 {
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
   for (const auto &service : CmClient::ListServices(c))
     if (CmClient::IsActiveServiceState(service.state))
@@ -121,10 +126,7 @@ ConnmanWifiBackend::Disconnect()
 WifiBackendStatus
 ConnmanWifiBackend::GetBackendStatus()
 {
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
 
   WifiBackendStatus status;
@@ -150,10 +152,7 @@ ConnmanWifiBackend::GetNetworks(WifiNetworkEntry *dest, std::size_t max)
   if (dest == nullptr || max == 0)
     return 0;
 
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
 
   const auto services = CmClient::ListServices(c);
@@ -194,10 +193,7 @@ ConnmanWifiBackend::GetNetworks(WifiNetworkEntry *dest, std::size_t max)
 void
 ConnmanWifiBackend::ForgetNetwork(const char *profile_id)
 {
-  auto c = ODBus::Connection::GetSystem();
-  if (!c)
-    throw WifiError::Exception{WifiError::Code::NoDbusConnection};
-
+  auto c = GetSystemConnection();
   RequireWifiInterface(c);
   CmClient::Remove(c, profile_id);
 }

--- a/src/net/wifi/WifiBackend.hpp
+++ b/src/net/wifi/WifiBackend.hpp
@@ -127,6 +127,7 @@ public:
         dest[i].kind = WifiNetworkKind::ConnectedNetwork;
         dest[i].can_connect = false;
         dest[i].can_disconnect = true;
+        dest[i].ip_address = status.ip_address;
         dest[i].interface_name = status.interface_name;
       }
 

--- a/src/net/wifi/WifiData.hpp
+++ b/src/net/wifi/WifiData.hpp
@@ -42,6 +42,7 @@ struct WifiConfiguredNetworkInfo {
 struct WifiBackendStatus {
   WifiConnectionState state = WifiConnectionState::Unknown;
   WifiSignalUnit signal_unit = WifiSignalUnit::Unknown;
+  StaticString<64> ip_address;
   StaticString<32> interface_name;
   StaticString<32> bssid;
   StaticString<256> ssid;
@@ -76,6 +77,11 @@ struct WifiBackendStatus {
       return text;
     }
 
+    if (!status.ip_address.empty()) {
+      text = status.ip_address;
+      return text;
+    }
+
     if (status.interface_name.empty()) {
       text = _("Unknown");
       return text;
@@ -94,6 +100,7 @@ struct WifiBackendStatus {
   void Clear() {
     state = WifiConnectionState::Unknown;
     signal_unit = WifiSignalUnit::Unknown;
+    ip_address.clear();
     interface_name.clear();
     bssid.clear();
     ssid.clear();
@@ -102,6 +109,7 @@ struct WifiBackendStatus {
 
 struct WifiNetworkEntry {
   StaticString<256> profile_id;
+  StaticString<64> ip_address;
   StaticString<32> bssid;
   StaticString<32> interface_name;
   StaticString<256> ssid;
@@ -119,6 +127,11 @@ struct WifiNetworkEntry {
     StaticString<64> text;
 
     if (entry.kind == WifiNetworkKind::ConnectedNetwork) {
+      if (!entry.ip_address.empty()) {
+        text.Format("%s (%s)", _("Connected"), entry.ip_address.c_str());
+        return text;
+      }
+
       if (!entry.interface_name.empty()) {
         StaticString<64> address;
         if (TryFormatWifiInterfaceAddress(entry.interface_name.c_str(),
@@ -149,6 +162,7 @@ struct WifiNetworkEntry {
 
   void Clear() {
     profile_id.clear();
+    ip_address.clear();
     bssid.clear();
     interface_name.clear();
     ssid.clear();

--- a/src/net/wifi/WifiData.hpp
+++ b/src/net/wifi/WifiData.hpp
@@ -27,28 +27,29 @@ TryFormatWifiInterfaceAddress(const char *interface_name,
 }
 
 struct WifiVisibleNetwork {
-  StaticString<32> bssid;
-  StaticString<256> ssid;
-  signed signal_level;
+  StaticString<32> bssid{};
+  StaticString<256> ssid{};
+  signed signal_level = 0;
   WifiSecurity security = WifiSecurity::Unknown;
 };
 
 struct WifiConfiguredNetworkInfo {
-  unsigned id;
-  StaticString<256> ssid;
-  StaticString<32> bssid;
+  unsigned id = 0;
+  StaticString<256> ssid{};
+  StaticString<32> bssid{};
 };
 
 struct WifiBackendStatus {
   WifiConnectionState state = WifiConnectionState::Unknown;
   WifiSignalUnit signal_unit = WifiSignalUnit::Unknown;
-  StaticString<64> ip_address;
-  StaticString<32> interface_name;
-  StaticString<32> bssid;
-  StaticString<256> ssid;
+  StaticString<64> ip_address{};
+  StaticString<32> interface_name{};
+  StaticString<32> bssid{};
+  StaticString<256> ssid{};
 
   static StaticString<256> Format(const WifiBackendStatus &status) {
     StaticString<256> text;
+    text.clear();
 
     switch (status.state) {
     case WifiConnectionState::Connected:
@@ -71,6 +72,7 @@ struct WifiBackendStatus {
 
   static StaticString<64> FormatIpAddress(const WifiBackendStatus &status) {
     StaticString<64> text;
+    text.clear();
 
     if (status.state != WifiConnectionState::Connected) {
       text = FormatWifiConnectionStateLabel(status.state);
@@ -108,11 +110,11 @@ struct WifiBackendStatus {
 };
 
 struct WifiNetworkEntry {
-  StaticString<256> profile_id;
-  StaticString<64> ip_address;
-  StaticString<32> bssid;
-  StaticString<32> interface_name;
-  StaticString<256> ssid;
+  StaticString<256> profile_id{};
+  StaticString<64> ip_address{};
+  StaticString<32> bssid{};
+  StaticString<32> interface_name{};
+  StaticString<256> ssid{};
   signed signal_level = 0;
   WifiSecurity security = WifiSecurity::Unknown;
   WifiSignalUnit signal_unit = WifiSignalUnit::Unknown;
@@ -125,6 +127,7 @@ struct WifiNetworkEntry {
 
   static StaticString<64> FormatState(const WifiNetworkEntry &entry) {
     StaticString<64> text;
+    text.clear();
 
     if (entry.kind == WifiNetworkKind::ConnectedNetwork) {
       if (!entry.ip_address.empty()) {
@@ -179,9 +182,9 @@ struct WifiNetworkEntry {
 };
 
 struct WifiConnectRequest {
-  StaticString<256> profile_id;
-  StaticString<256> ssid;
-  StaticString<64> secret;
+  StaticString<256> profile_id{};
+  StaticString<256> ssid{};
+  StaticString<64> secret{};
   WifiSecurity security = WifiSecurity::Unknown;
 
   void Clear() {

--- a/src/net/wifi/WifiError.cpp
+++ b/src/net/wifi/WifiError.cpp
@@ -10,6 +10,18 @@
 
 namespace {
 
+static const char *
+GetWifiServiceUnavailableText() noexcept
+{
+  return _("WiFi service is not available.");
+}
+
+static const char *
+GetWifiServiceNotRespondingText() noexcept
+{
+  return _("Could not contact the WiFi service.");
+}
+
 [[gnu::const]]
 static constexpr const char *
 DebugMessage(WifiError::Code code) noexcept
@@ -59,16 +71,16 @@ FormatCodeForUser(WifiError::Code code)
     return {_("No Wi-Fi interface available")};
 
   case Code::NoDbusConnection:
-    return {_("No D-Bus connection")};
+    return {GetWifiServiceNotRespondingText()};
 
   case Code::ConnmanUnavailable:
-    return {_("ConnMan is not available")};
+    return {_("WiFi service is not running.")};
 
   case Code::NoBackendAvailable:
-    return {_("No Wi-Fi backend available")};
+    return {GetWifiServiceUnavailableText()};
 
   case Code::NetworkManagerUnavailable:
-    return {_("NetworkManager is not available")};
+    return {_("WiFi service is not running.")};
   }
 
   return {_("The operation failed.")};
@@ -94,13 +106,11 @@ FormatWhatForUser(const char *what)
               "network.")};
   }
   if (w.find("org.freedesktop.") != std::string_view::npos) {
-    return {_("A D-Bus error occurred. Is NetworkManager or ConnMan running "
-              "on the bus?")};
+    return {GetWifiServiceNotRespondingText()};
   }
   if (w.find("DBus.Error") != std::string_view::npos ||
       w.find("DBus:") != std::string_view::npos) {
-    return {_("A D-Bus error occurred. Is NetworkManager or ConnMan running "
-              "on the bus?")};
+    return {GetWifiServiceNotRespondingText()};
   }
   if (w.find("secret") != std::string_view::npos && w.length() < 200U) {
     return {_("A passphrase is required, or a saved network for this "


### PR DESCRIPTION
- added partial functionality for Android, Windows and iOS
  - @yorickreum Can you check if IP address is shown on iOS?
- fixed IP display for Kobo
- added "Auto Wifi" setting for Kobo (closes #2531)
- improved status fetch for Kobo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WiFi IP address display now available across platforms
  * Kobo devices can enable automatic WiFi power-on at startup
  * Android users can access WiFi settings directly from the app

* **Bug Fixes**
  * Improved WiFi status display and rendering
  * Better handling of WiFi connection state preservation

* **Improvements**
  * Unified WiFi configuration interface across platforms
  * Enhanced error messages for WiFi service failures
  * More reliable WiFi backend status reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->