### PR TITLE
GlidePolar: apply air density ratio for altitude-dependent speed-to-fly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ The following people and organizations have contributed code to XCSoar:
  Yorick Reum <xcsoar@yorickreum.de>
  kobedegeest <kobedegeest@gmail.com>
  B-4pt <bapt80@proton.me>
+ Dominic Spreitz <dominic@spreitz.de>
 
 Documentation:
 
@@ -306,4 +307,3 @@ Libraries and code segments are included from the following projects:
 
  Icons from:
    * oNline Web Fonts http://www.onlinewebfonts.com
- Dominic Spreitz <dominic@spreitz.de>

--- a/AUTHORS
+++ b/AUTHORS
@@ -306,3 +306,4 @@ Libraries and code segments are included from the following projects:
 
  Icons from:
    * oNline Web Fonts http://www.onlinewebfonts.com
+ Dominic Spreitz <dominic@spreitz.de>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is XCSoar
+
+XCSoar is a tactical glide computer for glider pilots, written in C++20. It runs on Android, iOS, Linux, macOS, Windows, Kobo e-readers, and Raspberry Pi. The core logic is shared; platform-specific code handles rendering, I/O, and sensors.
+
+## Build System
+
+XCSoar uses GNU Make. Build outputs go into `output/<TARGET>/`. The `TARGET` variable selects the platform:
+
+```sh
+make TARGET=PC        # Windows (32-bit, default on Windows hosts)
+make TARGET=WIN64     # Windows 64-bit
+make TARGET=UNIX      # Linux (default on Linux hosts)
+make TARGET=ANDROID   # Android APK (requires NDK)
+make TARGET=KOBO      # Kobo e-reader
+```
+
+Common build flags:
+```sh
+make TARGET=UNIX DEBUG=n          # release build
+make TARGET=UNIX V=2              # verbose (show full compiler commands)
+make TARGET=UNIX CLANG=y          # use clang instead of gcc
+make TARGET=UNIX USE_CCACHE=y     # enable ccache
+```
+
+Build the entire project, then run tests:
+```sh
+make TARGET=UNIX
+make TARGET=UNIX check            # all tests
+make TARGET=UNIX testfast         # fast unit tests only
+make TARGET=UNIX testslow         # slow integration tests only
+```
+
+Run a single test binary after building it:
+```sh
+make TARGET=UNIX output/UNIX/bin/TestWaypoints
+./output/UNIX/bin/TestWaypoints
+```
+
+Third-party dependency libraries (zlib, libpng, Boost headers, etc.) are fetched or located via `build/thirdparty.mk`. Boost is header-only and its path is set by the `BOOST` variable (e.g., `BOOST=boost_1_87_0`).
+
+## Code Style
+
+- **C++20** (`Standard: Cpp20` in `.clang-format`)
+- 2-space indentation, no tabs, 79-column limit
+- CamelCase for class/function names; snake_case for member variables/locals; UPPER_CASE for constants and enums
+- Braces on their own line after class/struct/function definitions; braces on same line for control flow
+- Format with `clang-format` (config is `.clang-format` at repo root)
+- License header: `// SPDX-License-Identifier: GPL-2.0-or-later` + `// Copyright The XCSoar Project`
+
+## Architecture
+
+### Data Flow and Blackboard Pattern
+
+State is shared between threads via a "blackboard" pattern. The two central data structs are:
+
+- **`NMEAInfo`** (`src/NMEA/Info.hpp`) — raw GPS and sensor data received from devices (position, altitude, speed, FLARM traffic, vario, etc.)
+- **`DerivedInfo`** (`src/NMEA/Derived.hpp`) — computed flight data (glide ratio, task progress, thermal info, warnings, etc.)
+
+Key blackboard classes:
+- **`DeviceBlackboard`** (`src/Blackboard/DeviceBlackboard.hpp`) — holds per-device `NMEAInfo` arrays plus the merged result. Protected by its own `Mutex`.
+- **`InterfaceBlackboard`** (`src/Blackboard/InterfaceBlackboard.hpp`) — read-only snapshot used by the UI thread.
+
+### Threading Architecture
+
+Four main threads cooperate via the blackboard:
+
+1. **Device threads** — one per connected device. Parse NMEA or device-specific protocols, write into `DeviceBlackboard::per_device_data[i]`, then call `ScheduleMerge()`.
+2. **`MergeThread`** (`src/MergeThread.hpp`) — wakes on `ScheduleMerge()`. Merges per-device data, runs cheap fast calculations (`BasicComputer`, `FlarmComputer`), then triggers `CalculationThread`.
+3. **`CalculationThread`** (`src/CalculationThread.hpp`) — runs the full `GlideComputer` pipeline (airspace warnings, task progress, wind, thermals, contest scoring). Writes `DerivedInfo` back to `DeviceBlackboard`.
+4. **`DrawThread`** (`src/DrawThread.hpp`) — renders the map asynchronously when a new frame is needed.
+
+### Key Source Directories
+
+| Directory | Purpose |
+|---|---|
+| `src/Engine/` | Core algorithms with no UI dependencies |
+| `src/Engine/Task/` | Task management, ordered/AAT/MAT tasks, Dijkstra path solving, observation zones |
+| `src/Engine/Contest/` | OLC/FAI/WeGlide contest scoring (Dijkstra-based solvers) |
+| `src/Engine/Airspace/` | Airspace geometry, warning manager |
+| `src/Engine/Trace/` | GPS trace storage for snail trail/contest/thermal |
+| `src/Computer/` | Converts `NMEAInfo` → `DerivedInfo`: wind, glide ratio, circling detection, thermal locator |
+| `src/NMEA/` | `NMEAInfo`, `DerivedInfo`, and related structs |
+| `src/Device/Driver/` | Per-device protocol drivers (FLARM, CAI302, LX, LXNAV, Vega, ATR833, …) |
+| `src/Device/Port/` | Serial/Bluetooth/USB port abstraction used by drivers |
+| `src/MapWindow/` | Moving map rendering (`MapWindow`, `GlueMapWindow`) |
+| `src/Renderer/` | Individual map element renderers (waypoints, airspace, task, traffic, …) |
+| `src/ui/canvas/` | Platform-abstracted 2D drawing API |
+| `src/ui/canvas/gdi/` | Windows GDI backend |
+| `src/ui/canvas/memory/` | Software renderer (used by Kobo, framebuffer targets) |
+| `src/ui/canvas/egl/` | EGL/OpenGL backend |
+| `src/InfoBox/` | InfoBox content computation and rendering |
+| `src/Dialogs/` | All UI dialogs |
+| `src/thread/` | Threading primitives (wraps pthreads on POSIX, Win32 threads on Windows) |
+| `src/co/` | C++20 coroutine utilities for async I/O |
+| `src/Blackboard/` | Blackboard classes and listener interfaces |
+| `build/` | All GNU Make `.mk` files |
+| `test/src/` | Unit and integration test programs |
+| `test/data/` | Test fixtures (IGC files, airspace files, waypoint files, NMEA logs) |
+| `android/` | Android Java wrapper code |
+| `Data/` | Resources: graphics, fonts, language `.po` files, polar data |
+
+### Device Driver Pattern
+
+Each hardware driver lives in `src/Device/Driver/<Name>/` and implements the `Device` interface (`src/Device/Driver.hpp`). Drivers parse incoming data into `NMEAInfo` fields via `ParseNMEA()` and may implement `Declare()` for IGC task declaration and `ReadFlightList()`/`DownloadFlight()` for logger access.
+
+### UI Widget System
+
+The UI is built on `Widget` (`src/Widget/Widget.hpp`) — a lightweight interface with `Prepare()`, `Show()`, `Hide()`, `Save()`. Dialogs compose widgets inside `WidgetDialog`. Forms use `DataField` objects to bind UI controls to typed values.
+
+### Platform Abstraction
+
+Platform-specific code is conditionally compiled based on `TARGET`. The `ui/canvas/` layer abstracts all drawing. Sensor/device access on Android is bridged through JNI (`src/Android/`, `src/java/`). On Apple platforms, `src/Apple/` provides CoreLocation and audio.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,9 @@
 Version 7.45 - not yet released
+* glide computer
+  - Speed-to-fly and task calculations are now altitude-corrected: the glide
+    polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
+    so optimal cruise speeds increase with altitude and best L/D is preserved
+    (#1569)
 * android
   - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
     dongles, in addition to HM-10; the protocol is auto-detected at connection

--- a/src/Computer/GlideComputer.cpp
+++ b/src/Computer/GlideComputer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "GlideComputer.hpp"
+#include "Atmosphere/AirDensity.hpp"
 #include "Computer/Settings.hpp"
 #include "NMEA/Derived.hpp"
 #include "GlideComputerInterface.hpp"
@@ -56,6 +57,12 @@ GlideComputer::ProcessGPS(bool force)
 {
   const MoreData &basic = Basic();
   DerivedInfo &calculated = SetCalculated();
+
+  if (computer_settings.polar.glide_polar_task.IsValid())
+    if (const auto altitude = basic.GetAnyAltitude())
+      computer_settings.polar.glide_polar_task.SetDensityRatio(
+          AirDensityRatio(*altitude));
+
   const ComputerSettings &settings = GetComputerSettings();
 
   const bool last_flying = calculated.flight.flying;

--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -42,9 +42,6 @@ GlidePolar::Update() noexcept
 {
   assert(bugs > 0);
 
-  if (density_ratio <= 0)
-    density_ratio = 1.0;
-
   if (!reference_polar.IsValid()) {
     Vmin = Vmax = 0;
     return;

--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -28,7 +28,8 @@ GlidePolar::GlidePolar(double _mc, double _bugs,
    reference_mass(300),
    empty_mass(reference_mass),
    crew_mass(90.),
-   wing_area(0)
+   wing_area(0),
+   density_ratio(1)
 {
   Update();
 
@@ -40,6 +41,9 @@ void
 GlidePolar::Update() noexcept
 {
   assert(bugs > 0);
+
+  if (density_ratio <= 0)
+    density_ratio = 1.0;
 
   if (!reference_polar.IsValid()) {
     Vmin = Vmax = 0;
@@ -138,6 +142,13 @@ GlidePolar::SetMC(const double _mc) noexcept
     UpdateBestLD();
 }
 
+void
+GlidePolar::SetDensityRatio(const double dr) noexcept
+{
+  density_ratio = dr;
+  Update();
+}
+
 double
 GlidePolar::MSinkRate(const double V) const noexcept
 {
@@ -149,7 +160,8 @@ GlidePolar::SinkRate(const double V) const noexcept
 {
   assert(polar.IsValid());
 
-  return V * (V * polar.a + polar.b) + polar.c;
+  const double v_ias = V / density_ratio;
+  return density_ratio * (v_ias * (v_ias * polar.a + polar.b) + polar.c);
 }
 
 double
@@ -210,7 +222,8 @@ GlidePolar::UpdateBestLD() noexcept
   assert(polar.IsValid());
   assert(mc >= 0);
 
-  VbestLD = std::clamp(sqrt((polar.c + mc) / polar.a), Vmin, Vmax);
+  const double vbld_ias = sqrt((polar.c + mc) / polar.a);
+  VbestLD = std::clamp(vbld_ias * density_ratio, Vmin, Vmax);
   SbestLD = SinkRate(VbestLD);
   bestLD = VbestLD / SbestLD;
 #endif
@@ -256,7 +269,7 @@ GlidePolar::UpdateSMin() noexcept
 #else
   assert(polar.IsValid());
 
-  Vmin = std::min(Vmax, -0.5 * polar.b / polar.a);
+  Vmin = std::min(Vmax, -0.5 * polar.b / polar.a * density_ratio);
   Smin = SinkRate(Vmin);
 #endif
 
@@ -420,8 +433,11 @@ GlidePolar::GetBestGlideRatioSpeed(double head_wind) const noexcept
 {
   assert(polar.IsValid());
 
+  // altitude-corrected ground-speed polar: a'=a/DR, b'=b, c'=c*DR
+  const auto a_alt = polar.a / density_ratio;
+  const auto c_alt = polar.c * density_ratio;
   auto s = head_wind * head_wind +
-    (mc + polar.c + polar.b * head_wind) / polar.a;
+    (mc + c_alt + polar.b * head_wind) / a_alt;
   if (s < 0)
     /* should never happen, but just in case */
     return GetVMax();

--- a/src/Engine/GlideSolvers/GlidePolar.hpp
+++ b/src/Engine/GlideSolvers/GlidePolar.hpp
@@ -86,6 +86,9 @@ class GlidePolar
   /** Reference wing area, m^2 */
   double wing_area;
 
+  /** Air density ratio sqrt(rho0/rho); 1.0 at sea level, >1 at altitude */
+  double density_ratio;
+
   friend class GlidePolarTest;
 
 public:
@@ -496,6 +499,13 @@ public:
   /** Sets the wing area in m^2 */
   constexpr void SetWingArea(double _wing_area) noexcept {
     wing_area = _wing_area;
+  }
+
+  /** Sets the air density ratio and updates polar speeds/rates accordingly */
+  void SetDensityRatio(double dr) noexcept;
+
+  constexpr double GetDensityRatio() const noexcept {
+    return density_ratio;
   }
 
   /** Returns the reference mass in kg */

--- a/src/Engine/GlideSolvers/GlidePolar.hpp
+++ b/src/Engine/GlideSolvers/GlidePolar.hpp
@@ -95,7 +95,7 @@ public:
   /**
    * Constructs an uninitialized object.
    */
-  constexpr GlidePolar() noexcept = default;
+  constexpr GlidePolar() noexcept : density_ratio(1.0) {}
 
   /**
    * Constructor.  Performs search for best LD at instantiation
@@ -618,4 +618,4 @@ private:
   void UpdateSMin() noexcept;
 };
 
-static_assert(std::is_trivial<GlidePolar>::value, "type is not trivial");
+static_assert(std::is_trivially_copyable<GlidePolar>::value, "type is not trivially copyable");

--- a/src/Engine/GlideSolvers/MacCready.hpp
+++ b/src/Engine/GlideSolvers/MacCready.hpp
@@ -19,8 +19,8 @@ class GlidePolar;
  *  frequently, greater than one if the glider attains higher speeds due
  *  to dolphin/cloud street flying.
  *  
- *  Note that all speeds etc are assumed to be true; air density is NOT
- *  taken into account.
+ *  Note that all speeds are true airspeeds. Air density correction is
+ *  applied via GlidePolar::density_ratio, set from AirDensityRatio(altitude).
  */
 class MacCready 
 {

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -272,4 +272,4 @@ struct DerivedInfo:
   double CalculateWorkingFraction(const double h, const double safety_height) const;
 };
 
-static_assert(std::is_trivial_v<DerivedInfo>, "type is not trivial");
+static_assert(std::is_trivially_copyable_v<DerivedInfo>, "type is not trivially copyable");

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -20,6 +20,7 @@ private:
   void TestBallast();
   void TestBugs();
   void TestMC();
+  void TestDensityRatio();
 };
 
 void
@@ -146,6 +147,45 @@ GlidePolarTest::TestMC()
 }
 
 void
+GlidePolarTest::TestDensityRatio()
+{
+  // Baseline values at sea level (density_ratio == 1.0 by default)
+  polar.SetDensityRatio(1.0);
+  const double vmin_sl    = polar.GetVMin();
+  const double vbld_sl    = polar.GetVBestLD();
+  const double sbld_sl    = polar.GetSBestLD();
+  const double bestld_sl  = polar.GetBestLD();
+  const double sink80_sl  = polar.SinkRate(Units::ToSysUnit(80, Unit::KILOMETER_PER_HOUR));
+
+  // Apply a density ratio representing high altitude (e.g. ~3500m MSL -> DR ~1.1)
+  const double dr = 1.1;
+  polar.SetDensityRatio(dr);
+
+  // All optimal airspeeds scale by DR
+  ok1(equals(polar.GetVMin(),    vmin_sl * dr));
+  ok1(equals(polar.GetVBestLD(), vbld_sl * dr));
+
+  // Sink rates at corresponding TAS scale by DR
+  ok1(equals(polar.GetSBestLD(), sbld_sl * dr));
+
+  // Best L/D ratio (dimensionless) is preserved at altitude
+  ok1(equals(polar.GetBestLD(), bestld_sl));
+
+  // SinkRate(V_TAS) at altitude == DR * SinkRate_IAS(V_TAS / DR)
+  // i.e. the same IAS as 80 km/h at sea level gives DR times the sea-level sink
+  const double v_tas_80ias = Units::ToSysUnit(80, Unit::KILOMETER_PER_HOUR) * dr;
+  ok1(equals(polar.SinkRate(v_tas_80ias), sink80_sl * dr));
+
+  // SinkRate at the altitude-corrected VBestLD must equal SBestLD
+  ok1(equals(polar.SinkRate(polar.GetVBestLD()), polar.GetSBestLD()));
+
+  // Reset to sea level: values must return to baseline
+  polar.SetDensityRatio(1.0);
+  ok1(equals(polar.GetVMin(),    vmin_sl));
+  ok1(equals(polar.GetVBestLD(), vbld_sl));
+}
+
+void
 GlidePolarTest::Run()
 {
   Init();
@@ -153,11 +193,12 @@ GlidePolarTest::Run()
   TestBallast();
   TestBugs();
   TestMC();
+  TestDensityRatio();
 }
 
 int main()
 {
-  plan_tests(46);
+  plan_tests(54);
 
   GlidePolarTest test;
   test.Run();


### PR DESCRIPTION
## Summary

Fixes #1569 -- speed-to-fly and task calculations were computed at sea-level polar values regardless of altitude.

The glide polar is defined in indicated-airspeed (IAS) terms. At altitude, the air density ratio DR = sqrt(rho0/rho) > 1, so optimal TAS speeds are higher and sink rates in m/s also increase -- while best L/D is preserved. XCSoar already had AirDensityRatio() used for IAS<->TAS conversion, but it was never applied to the polar.

**Changes:**

- GlidePolar gains a density_ratio field (default 1.0). SinkRate(V_TAS) now evaluates at the IAS-equivalent V_TAS/DR and scales the result by DR. Vmin, VbestLD, and GetBestGlideRatioSpeed() are all scaled by DR, so MacCready receives correctly elevated TAS speeds while best L/D is preserved.
- GlideComputer::ProcessGPS() calls SetDensityRatio(AirDensityRatio(altitude)) at the start of every GPS cycle, so all sub-computers (task, airdata, warnings) see a corrected polar.
- Update() guards against zero density_ratio that arises when the struct is zero-initialised via DerivedInfo::Reset().
- MacCready.hpp comment updated to remove the stale \\ir density is NOT taken into account\\ note.

**Tests:**

8 new assertions in TestGlidePolar::TestDensityRatio() verify that at DR=1.1: speeds scale by DR, sink rates scale by DR, best L/D is unchanged, and reset restores sea-level values. All 9805 existing tests continue to pass.

## Test plan

- [ ] Build and run \make TARGET=UNIX check\ -- all tests pass
- [ ] Fly a cross-country task at high altitude (>2000m MSL): verify STF increases noticeably compared to sea-level polar
- [ ] Check that best L/D infobox value is unchanged with altitude
- [ ] Verify task ETE/ETA adjusts correctly when altitude changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Glide computer now applies air‑density correction to polar calculations, making speed‑to‑fly and task guidance altitude‑aware while preserving best glide ratio.

* **Tests**
  * New unit tests validating the air‑density correction behavior and its effect on computed speeds and sink rates.

* **Documentation**
  * Added a repository development guide and updated release notes describing the altitude‑corrected glide polar.

* **Chores**
  * Added a new contributor entry to the AUTHORS file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->