### PR TITLE
Glide polar density altitude correction and Condor3 UDP

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -84,6 +84,7 @@ The following people and organizations have contributed code to XCSoar:
  Yorick Reum <xcsoar@yorickreum.de>
  kobedegeest <kobedegeest@gmail.com>
  B-4pt <bapt80@proton.me>
+ Dominic Spreitz <dominic@spreitz.de>
 
 Documentation:
 
@@ -306,4 +307,3 @@ Libraries and code segments are included from the following projects:
 
  Icons from:
    * oNline Web Fonts http://www.onlinewebfonts.com
- Dominic Spreitz <dominic@spreitz.de>

--- a/AUTHORS
+++ b/AUTHORS
@@ -306,3 +306,4 @@ Libraries and code segments are included from the following projects:
 
  Icons from:
    * oNline Web Fonts http://www.onlinewebfonts.com
+ Dominic Spreitz <dominic@spreitz.de>

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,9 @@
 Version 7.45 - not yet released
+* glide computer
+  - Speed-to-fly and task calculations are now altitude-corrected: the glide
+    polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
+    so optimal cruise speeds increase with altitude and best L/D is preserved
+    (#1569)
 * android
   - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
     dongles, in addition to HM-10; the protocol is auto-detected at connection

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,11 @@ Version 7.45 - not yet released
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
     so optimal cruise speeds increase with altitude and best L/D is preserved
     (#1569)
+  - Task manager glide and safety polars use the same density ratio from baro
+    or GPS altitude
+  - Netto vario (when derived from the polar) and vario speed-to-fly
+    push/pull arrows use true airspeed against the density-scaled polar sink
+    and speed-to-fly
 * android
   - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
     dongles, in addition to HM-10; the protocol is auto-detected at connection
@@ -18,6 +23,11 @@ Version 7.45 - not yet released
     ignores the sentence
   - LXNAV: apply device vario filter time ($LXWP3 variofil) to gauge, map
     vario bar, thermal rose, audio vario and snail-trail colouring
+  - Condor 3: new UDP telemetry driver (Condor3UDP) for Simkits generic UDP
+    output (default port 55278); complements TCP/NMEA Condor3 for MacCready,
+    ballast, attitude, radio, and related fields (#2340)
+  - Glide polar sync in the device dialog is only shown for drivers that
+    implement it (LXNAV)
 * ui
   - macOS: thick solid lines now render at their correct pixel width #2545
   - plane details: WeGlide aircraft type can be configured even when WeGlide
@@ -419,8 +429,6 @@ Version 7.44 - 2026-03-22
   - fix segfault when resizing window with software rendering
 * devices
   - Add driver for Condor 3 #1612
-  - Add Condor3 UDP driver for Condor 3 simkits UDP telemetry (UDP listener)
-  - Devices: show glide polar sync only for drivers that implement it (LXNAV)
   - Add driver for LöFGREN variometer #2080
   - Add driver for LX Navigation Eos / Era variometers #389
   - Add driver for Stratux

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -419,6 +419,8 @@ Version 7.44 - 2026-03-22
   - fix segfault when resizing window with software rendering
 * devices
   - Add driver for Condor 3 #1612
+  - Add Condor3 UDP driver for Condor 3 simkits UDP telemetry (UDP listener)
+  - Devices: show glide polar sync only for drivers that implement it (LXNAV)
   - Add driver for LöFGREN variometer #2080
   - Add driver for LX Navigation Eos / Era variometers #389
   - Add driver for Stratux

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -119,6 +119,7 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/CaiGpsNav.cpp \
 	$(DRIVER_SRC_DIR)/CaiLNav.cpp \
 	$(DRIVER_SRC_DIR)/Condor.cpp \
+	$(DRIVER_SRC_DIR)/Condor3UDP.cpp \
 	$(DRIVER_SRC_DIR)/CProbe.cpp \
 	$(DRIVER_SRC_DIR)/EW.cpp \
 	$(DRIVER_SRC_DIR)/EWMicroRecorder.cpp \

--- a/src/Computer/BasicComputer.cpp
+++ b/src/Computer/BasicComputer.cpp
@@ -329,8 +329,14 @@ GetGliderSinkRate(const MoreData &basic, const DerivedInfo &calculated,
       ? basic.acceleration.g_load
       : 1.;
 
-    return -settings.polar.glide_polar_task.SinkRate(
-      basic.indicated_airspeed, g_load);
+    /* MergeThread runs before CalculationThread updates the shared
+       polar; apply density ratio here so SinkRate() sees TAS at
+       altitude. */
+    GlidePolar polar = settings.polar.glide_polar_task;
+    if (const auto altitude = basic.GetAnyAltitude())
+      polar.SetDensityRatio(AirDensityRatio(*altitude));
+
+    return -polar.SinkRate(basic.true_airspeed, g_load);
   }
 
   return calculated.sink_rate;

--- a/src/Computer/GlideComputer.cpp
+++ b/src/Computer/GlideComputer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "GlideComputer.hpp"
+#include "Atmosphere/AirDensity.hpp"
 #include "Computer/Settings.hpp"
 #include "NMEA/Derived.hpp"
 #include "GlideComputerInterface.hpp"
@@ -56,6 +57,12 @@ GlideComputer::ProcessGPS(bool force)
 {
   const MoreData &basic = Basic();
   DerivedInfo &calculated = SetCalculated();
+
+  if (computer_settings.polar.glide_polar_task.IsValid())
+    if (const auto altitude = basic.GetAnyAltitude())
+      computer_settings.polar.glide_polar_task.SetDensityRatio(
+          AirDensityRatio(*altitude));
+
   const ComputerSettings &settings = GetComputerSettings();
 
   const bool last_flying = calculated.flight.flying;

--- a/src/Computer/GlideComputerAirData.cpp
+++ b/src/Computer/GlideComputerAirData.cpp
@@ -7,6 +7,7 @@
 #include "Terrain/RasterTerrain.hpp"
 #include "ThermalBase.hpp"
 #include "GlideSolvers/GlidePolar.hpp"
+#include "Atmosphere/AirDensity.hpp"
 #include "Math/SunEphemeris.hpp"
 #include "NMEA/Derived.hpp"
 #include "NMEA/MoreData.hpp"
@@ -135,13 +136,16 @@ GlideComputerAirData::NettoVario(const NMEAInfo &basic,
     ? basic.acceleration.g_load
     : 1;
 
-  vario.sink_rate =
-    flight.flying && basic.airspeed_available &&
-    settings_computer.polar.glide_polar_task.IsValid()
-    ? - settings_computer.polar.glide_polar_task.SinkRate(basic.indicated_airspeed,
-                                                          g_load)
+  if (flight.flying && basic.airspeed_available &&
+      settings_computer.polar.glide_polar_task.IsValid()) {
+    GlidePolar polar = settings_computer.polar.glide_polar_task;
+    if (const auto altitude = basic.GetAnyAltitude())
+      polar.SetDensityRatio(AirDensityRatio(*altitude));
+
+    vario.sink_rate = -polar.SinkRate(basic.true_airspeed, g_load);
+  } else
     /* the glider sink rate is useless when not flying */
-    : 0;
+    vario.sink_rate = 0;
 }
 
 inline void

--- a/src/Computer/TaskComputer.cpp
+++ b/src/Computer/TaskComputer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "TaskComputer.hpp"
+#include "Atmosphere/AirDensity.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
@@ -54,6 +55,10 @@ TaskComputer::ProcessBasicTask(const MoreData &basic,
   ProtectedTaskManager::ExclusiveLease _task(task);
 
   _task->SetTaskBehaviour(settings_computer.task);
+
+  if (settings_computer.polar.glide_polar_task.IsValid())
+    if (const auto altitude = basic.GetAnyAltitude())
+      _task->SetDensityRatio(AirDensityRatio(*altitude));
 
   const AircraftState current_as = ToAircraftState(basic, calculated);
 

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -203,8 +203,9 @@ try {
   port = std::move(_port);
 
   parser.Reset();
-  parser.SetReal(!StringIsEqual(driver->name, "Condor"));
-  if (config.IsDriver("Condor"))
+  parser.SetReal(!StringIsEqual(driver->name, "Condor") &&
+                 !StringIsEqual(driver->name, "Condor3UDP"));
+  if (config.IsDriver("Condor") || config.IsDriver("Condor3UDP"))
     parser.DisableGeoid();
 
   if (driver->CreateOnPort != nullptr) {

--- a/src/Device/Driver/Condor3UDP.cpp
+++ b/src/Device/Driver/Condor3UDP.cpp
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Driver/Condor3UDP.hpp"
+#include "Device/Driver.hpp"
+#include "NMEA/Info.hpp"
+#include "Math/Angle.hpp"
+#include "RadioFrequency.hpp"
+#include "util/NumberParser.hpp"
+#include "util/StringCompare.hxx"
+#include "util/StringStrip.hxx"
+
+#include <cmath>
+#include <cstring>
+#include <string_view>
+
+using std::string_view_literals::operator""sv;
+
+/**
+ * Condor 3 generic UDP telemetry (Condor 3 manual, section 14 «Simkits and UDP
+ * outputs», §14.1 «Generic UDP output», subsection «UDP Packet data», PDF
+ * pages 72–73).
+ *
+ * The manual specifies: each UDP datagram is an ASCII stream of
+ * `parameter=value` pairs (one pair per line in practice); all values are
+ * floats with `.` as the decimal separator; SI units.  Parameters marked *
+ * require `ExtendedData=1` in `UDP.ini`; ** require `ExtendedData1=1`.
+ *
+ * XCSoar receives this on a UDP listener port (`UDP.ini` default port is
+ * often 55278).  Input is line-split like a serial stream, then each line is
+ * parsed here (not NMEA `$…*CS` — the method name is the generic device hook).
+ *
+ * Implemented parameters from the manual table: airspeed, altitude, vario,
+ * evario, nettovario, compass, yaw, pitch, bank, vx, vy, rollrate,
+ * pitchrate, yawrate, gforce, radiofrequency (MHz → active radio), MC,
+ * water (**).  Latitude/longitude are not in
+ * the published UDP table; optional keys are accepted if Condor adds them.
+ *
+ * Polar sync (device dialog) is not offered for this driver; Condor UDP does
+ * not carry full polar coefficients, and XCSoar does not send polars to Condor.
+ *
+ * Not mapped (no suitable `NMEAInfo` field or non-float): time, integrator,
+ * slipball, turnrate, yawstringangle, quaternion*, ax/ay/az, height*,
+ * wheelheight*, turbulencestrength*, surfaceroughness*, hudmessages*, flaps**
+ * (integer).
+ */
+class Condor3UDPDevice final : public AbstractDevice {
+  double vx = 0, vy = 0;
+  bool have_vx = false, have_vy = false;
+
+  double roll_rate = 0, pitch_rate = 0, yaw_rate = 0;
+
+  bool have_latitude = false, have_longitude = false;
+
+  void
+  MarkSimulator(NMEAInfo &info) noexcept {
+    info.gps.simulator = true;
+    info.gps.real = false;
+  }
+
+  void
+  UpdateGroundVelocity(NMEAInfo &info) noexcept {
+    if (!have_vx || !have_vy)
+      return;
+
+    const double h = std::hypot(vx, vy);
+    info.ground_speed = h;
+    info.ground_speed_available.Update(info.clock);
+    if (h > 0.2) {
+      /* Assume velocity components in east/north axes (m/s). */
+      info.track = Angle::Radians(std::atan2(vx, vy));
+      info.track_available.Update(info.clock);
+    }
+  }
+
+  bool
+  ApplyKey(std::string_view key, double value, NMEAInfo &info) noexcept {
+    MarkSimulator(info);
+
+    if (StringIsEqualIgnoreCase(key, "airspeed"sv)) {
+      /* Documented as true airspeed (m/s). */
+      info.ProvideTrueAirspeed(value);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "altitude"sv)) {
+      /* Altimeter / pressure altitude indication (m, SI in Condor 3). */
+      info.ProvideBaroAltitudeTrue(value);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "vario"sv)) {
+      info.ProvideNoncompVario(value);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "evario"sv)) {
+      info.ProvideTotalEnergyVario(value);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "nettovario"sv)) {
+      info.ProvideNettoVario(value);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "compass"sv)) {
+      info.attitude.heading = Angle::Degrees(value);
+      info.attitude.heading_available.Update(info.clock);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "bank"sv)) {
+      info.attitude.bank_angle = Angle::Radians(value);
+      info.attitude.bank_angle_available.Update(info.clock);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "pitch"sv)) {
+      info.attitude.pitch_angle = Angle::Radians(value);
+      info.attitude.pitch_angle_available.Update(info.clock);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "rollrate"sv)) {
+      roll_rate = value;
+      PushGyro(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "pitchrate"sv)) {
+      pitch_rate = value;
+      PushGyro(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "yawrate"sv)) {
+      yaw_rate = value;
+      PushGyro(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "vx"sv)) {
+      vx = value;
+      have_vx = true;
+      UpdateGroundVelocity(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "vy"sv)) {
+      vy = value;
+      have_vy = true;
+      UpdateGroundVelocity(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "gforce"sv)) {
+      info.acceleration.ProvideGLoad(value, true);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "MC"sv)) {
+      info.settings.ProvideMacCready(value, info.clock);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "radiofrequency"sv)) {
+      /* Manual: MHz.  XCSoar uses integer kHz internally. */
+      const unsigned khz = (unsigned)std::lround(value * 1000.0);
+      const RadioFrequency freq = RadioFrequency::FromKiloHertz(khz);
+      if (freq.IsDefined()) {
+        info.settings.active_frequency = freq;
+        info.settings.has_active_frequency.Update(info.clock);
+      }
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "water"sv)) {
+      /* ExtendedData1: water ballast [kg] per manual. */
+      info.settings.ProvideBallastLitres(value, info.clock);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "yaw"sv)) {
+      /* Heading from body yaw [rad]; compass [deg] preferred when both sent. */
+      if (!info.attitude.heading_available) {
+        info.attitude.heading = Angle::Radians(value);
+        info.attitude.heading_available.Update(info.clock);
+      }
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "latitude"sv)) {
+      info.location.latitude = Angle::Degrees(value);
+      have_latitude = true;
+      FinishLocationIfComplete(info);
+      return true;
+    }
+
+    if (StringIsEqualIgnoreCase(key, "longitude"sv)) {
+      info.location.longitude = Angle::Degrees(value);
+      have_longitude = true;
+      FinishLocationIfComplete(info);
+      return true;
+    }
+
+    return false;
+  }
+
+  void
+  PushGyro(NMEAInfo &info) noexcept {
+    info.gyroscope.ProvideAngularRates(
+      Angle::Radians(roll_rate), Angle::Radians(pitch_rate),
+      Angle::Radians(yaw_rate), true, true);
+  }
+
+  void
+  FinishLocationIfComplete(NMEAInfo &info) noexcept {
+    if (!have_latitude || !have_longitude)
+      return;
+
+    if (!info.location.Check()) {
+      have_latitude = false;
+      have_longitude = false;
+      return;
+    }
+
+    info.location.Normalize();
+    info.location_available.Update(info.clock);
+    info.gps.fix_quality = FixQuality::SIMULATION;
+    info.gps.fix_quality_available.Update(info.clock);
+    MarkSimulator(info);
+    have_latitude = false;
+    have_longitude = false;
+  }
+
+public:
+  bool
+  ParseNMEA(const char *line, NMEAInfo &info) override {
+    if (line == nullptr || *line == '\0')
+      return false;
+
+    const char *eq = std::strchr(line, '=');
+    if (eq == nullptr || eq == line)
+      return false;
+
+    std::string_view key = StripLeft(std::string_view(line, eq - line));
+    key = StripRight(key);
+    if (key.empty())
+      return false;
+
+    const char *vbegin = StripLeft(eq + 1);
+    char *endptr = nullptr;
+    const double value = ParseDouble(vbegin, &endptr);
+    if (endptr == vbegin)
+      return false;
+
+    if (*StripLeft(endptr) != '\0')
+      return false;
+
+    return ApplyKey(key, value, info);
+  }
+};
+
+static Device *
+Condor3UDPCreateOnPort([[maybe_unused]] const DeviceConfig &config,
+                       [[maybe_unused]] Port &com_port) {
+  return new Condor3UDPDevice();
+}
+
+const struct DeviceRegister condor3_udp_driver = {
+  "Condor3UDP",
+  "Condor Soaring Simulator 3 (UDP telemetry)",
+  DeviceRegister::RECEIVE_SETTINGS,
+  Condor3UDPCreateOnPort,
+};

--- a/src/Device/Driver/Condor3UDP.hpp
+++ b/src/Device/Driver/Condor3UDP.hpp
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+extern const struct DeviceRegister condor3_udp_driver;

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -25,6 +25,7 @@
 #include "Device/Driver/FlymasterF1.hpp"
 #include "Device/Driver/XCOM760.hpp"
 #include "Device/Driver/Condor.hpp"
+#include "Device/Driver/Condor3UDP.hpp"
 #include "Device/Driver/Leonardo.hpp"
 #include "Device/Driver/Flytec.hpp"
 #include "Device/Driver/ILEC.hpp"
@@ -90,6 +91,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &thermalexpress_driver,
   &acd_driver,
   &condor3_driver,
+  &condor3_udp_driver,
   &lx_eos_driver,
   &stratux_driver,
   &loe_fgren_driver,

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -46,6 +46,7 @@ FillBaudRates(DataFieldEnum &dfe) noexcept
 static void
 FillTCPPorts(DataFieldEnum &dfe) noexcept
 {
+  dfe.addEnumText("55278 (Condor UDP)", 55278);
   dfe.addEnumText("4353", 4353);
   dfe.addEnumText("10110", 10110);
   dfe.addEnumText("4352", 4352);

--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -10,6 +10,7 @@
 #include "Navigation/Aircraft.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 #include <cassert>
 
@@ -28,7 +29,8 @@ GlidePolar::GlidePolar(double _mc, double _bugs,
    reference_mass(300),
    empty_mass(reference_mass),
    crew_mass(90.),
-   wing_area(0)
+   wing_area(0),
+   density_ratio(1)
 {
   Update();
 
@@ -40,6 +42,9 @@ void
 GlidePolar::Update() noexcept
 {
   assert(bugs > 0);
+
+  if (density_ratio <= 0)
+    density_ratio = 1.0;
 
   if (!reference_polar.IsValid()) {
     Vmin = Vmax = 0;
@@ -138,6 +143,17 @@ GlidePolar::SetMC(const double _mc) noexcept
     UpdateBestLD();
 }
 
+void
+GlidePolar::SetDensityRatio(const double dr) noexcept
+{
+  const double safe_dr = (dr > 0.0 && std::isfinite(dr)) ? dr : 1.0;
+  if (safe_dr == density_ratio)
+    return;
+
+  density_ratio = safe_dr;
+  Update();
+}
+
 double
 GlidePolar::MSinkRate(const double V) const noexcept
 {
@@ -149,7 +165,8 @@ GlidePolar::SinkRate(const double V) const noexcept
 {
   assert(polar.IsValid());
 
-  return V * (V * polar.a + polar.b) + polar.c;
+  const double v_ias = V / density_ratio;
+  return density_ratio * (v_ias * (v_ias * polar.a + polar.b) + polar.c);
 }
 
 double
@@ -210,7 +227,8 @@ GlidePolar::UpdateBestLD() noexcept
   assert(polar.IsValid());
   assert(mc >= 0);
 
-  VbestLD = std::clamp(sqrt((polar.c + mc) / polar.a), Vmin, Vmax);
+  const double vbld_ias = sqrt((polar.c + mc) / polar.a);
+  VbestLD = std::clamp(vbld_ias * density_ratio, Vmin, Vmax);
   SbestLD = SinkRate(VbestLD);
   bestLD = VbestLD / SbestLD;
 #endif
@@ -256,7 +274,7 @@ GlidePolar::UpdateSMin() noexcept
 #else
   assert(polar.IsValid());
 
-  Vmin = std::min(Vmax, -0.5 * polar.b / polar.a);
+  Vmin = std::min(Vmax, -0.5 * polar.b / polar.a * density_ratio);
   Smin = SinkRate(Vmin);
 #endif
 
@@ -420,8 +438,11 @@ GlidePolar::GetBestGlideRatioSpeed(double head_wind) const noexcept
 {
   assert(polar.IsValid());
 
+  // altitude-corrected ground-speed polar: a'=a/DR, b'=b, c'=c*DR
+  const auto a_alt = polar.a / density_ratio;
+  const auto c_alt = polar.c * density_ratio;
   auto s = head_wind * head_wind +
-    (mc + polar.c + polar.b * head_wind) / polar.a;
+    (mc + c_alt + polar.b * head_wind) / a_alt;
   if (s < 0)
     /* should never happen, but just in case */
     return GetVMax();

--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -43,9 +43,6 @@ GlidePolar::Update() noexcept
 {
   assert(bugs > 0);
 
-  if (density_ratio <= 0)
-    density_ratio = 1.0;
-
   if (!reference_polar.IsValid()) {
     Vmin = Vmax = 0;
     return;

--- a/src/Engine/GlideSolvers/GlidePolar.hpp
+++ b/src/Engine/GlideSolvers/GlidePolar.hpp
@@ -86,6 +86,9 @@ class GlidePolar
   /** Reference wing area, m^2 */
   double wing_area;
 
+  /** Air density ratio sqrt(rho0/rho); 1.0 at sea level, >1 at altitude */
+  double density_ratio;
+
   friend class GlidePolarTest;
 
 public:
@@ -496,6 +499,13 @@ public:
   /** Sets the wing area in m^2 */
   constexpr void SetWingArea(double _wing_area) noexcept {
     wing_area = _wing_area;
+  }
+
+  /** Sets the air density ratio and updates polar speeds/rates accordingly */
+  void SetDensityRatio(double dr) noexcept;
+
+  constexpr double GetDensityRatio() const noexcept {
+    return density_ratio;
   }
 
   /** Returns the reference mass in kg */

--- a/src/Engine/GlideSolvers/GlidePolar.hpp
+++ b/src/Engine/GlideSolvers/GlidePolar.hpp
@@ -95,7 +95,7 @@ public:
   /**
    * Constructs an uninitialized object.
    */
-  constexpr GlidePolar() noexcept = default;
+  constexpr GlidePolar() noexcept : density_ratio(1.0) {}
 
   /**
    * Constructor.  Performs search for best LD at instantiation
@@ -618,4 +618,4 @@ private:
   void UpdateSMin() noexcept;
 };
 
-static_assert(std::is_trivial<GlidePolar>::value, "type is not trivial");
+static_assert(std::is_trivially_copyable<GlidePolar>::value, "type is not trivially copyable");

--- a/src/Engine/GlideSolvers/MacCready.hpp
+++ b/src/Engine/GlideSolvers/MacCready.hpp
@@ -19,8 +19,8 @@ class GlidePolar;
  *  frequently, greater than one if the glider attains higher speeds due
  *  to dolphin/cloud street flying.
  *  
- *  Note that all speeds etc are assumed to be true; air density is NOT
- *  taken into account.
+ *  Note that all speeds are true airspeeds. Air density correction is
+ *  applied via GlidePolar::density_ratio, set from AirDensityRatio(altitude).
  */
 class MacCready 
 {

--- a/src/Engine/Task/TaskManager.cpp
+++ b/src/Engine/Task/TaskManager.cpp
@@ -405,6 +405,16 @@ TaskManager::SetGlidePolar(const GlidePolar &_glide_polar) noexcept
   safety_polar.SetMC(task_behaviour.safety_mc);
 }
 
+void
+TaskManager::SetDensityRatio(const double dr) noexcept
+{
+  if (!glide_polar.IsValid())
+    return;
+
+  glide_polar.SetDensityRatio(dr);
+  safety_polar.SetDensityRatio(dr);
+}
+
 bool
 TaskManager::UpdateAutoMC(const AircraftState &state_now,
                           const double fallback_mc) noexcept

--- a/src/Engine/Task/TaskManager.hpp
+++ b/src/Engine/Task/TaskManager.hpp
@@ -307,6 +307,9 @@ public:
    */
   void SetGlidePolar(const GlidePolar &glide_polar) noexcept;
 
+  /** Update air density ratio on task polars (in place). */
+  void SetDensityRatio(double dr) noexcept;
+
   /**
    * Retrieve copy of safety glide polar used by task system
    *

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -587,7 +587,8 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
   // only draw speed command if flying and vario is not circling
   if ((Calculated().flight.flying)
       && (!Basic().gps.simulator || !Calculated().circling)) {
-    v_diff = Calculated().V_stf - Basic().indicated_airspeed;
+    /* V_stf is TAS (density-compensated); compare to actual TAS */
+    v_diff = Calculated().V_stf - Basic().true_airspeed;
     v_diff = std::clamp(v_diff, -DELTA_V_LIMIT, DELTA_V_LIMIT); // limit it
     v_diff = iround(v_diff/DELTA_V_STEP) * DELTA_V_STEP;
   } else

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -272,4 +272,4 @@ struct DerivedInfo:
   double CalculateWorkingFraction(const double h, const double safety_height) const;
 };
 
-static_assert(std::is_trivial_v<DerivedInfo>, "type is not trivial");
+static_assert(std::is_trivially_copyable_v<DerivedInfo>, "type is not trivially copyable");

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -30,6 +30,13 @@ ProtectedTaskManager::SetGlidePolar(const GlidePolar &glide_polar) noexcept
 }
 
 void
+ProtectedTaskManager::SetDensityRatio(const double dr) noexcept
+{
+  ExclusiveLease lease(*this);
+  lease->SetDensityRatio(dr);
+}
+
+void
 ProtectedTaskManager::SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept
 {
   ExclusiveLease lease(*this);

--- a/src/Task/ProtectedTaskManager.hpp
+++ b/src/Task/ProtectedTaskManager.hpp
@@ -48,6 +48,8 @@ public:
   // common accessors for ui and calc clients
   void SetGlidePolar(const GlidePolar &glide_polar) noexcept;
 
+  void SetDensityRatio(double dr) noexcept;
+
   [[gnu::pure]]
   const OrderedTaskSettings GetOrderedTaskSettings() const noexcept;
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -11,6 +11,7 @@
 #include "Device/Driver/CAI302.hpp"
 #include "Device/Driver/CProbe.hpp"
 #include "Device/Driver/Condor.hpp"
+#include "Device/Driver/Condor3UDP.hpp"
 #include "Device/Driver/EW.hpp"
 #include "Device/Driver/EWMicroRecorder.hpp"
 #include "Device/Driver/Eye.hpp"
@@ -54,6 +55,7 @@
 #include "Input/InputEvents.hpp"
 #include "Logger/Settings.hpp"
 #include "LocalPath.hpp"
+#include "NMEA/GPSState.hpp"
 #include "NMEA/Info.hpp"
 #include "Operation/Operation.hpp"
 #include "Plane/Plane.hpp"
@@ -1442,6 +1444,105 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
     ok1(nmea_info.settings.vario_filter_period_available);
     ok1(equals(nmea_info.settings.vario_filter_period, 2.0));
   }
+
+  delete device;
+}
+
+static void
+TestCondor3UDP()
+{
+  NullPort null_port;
+  Device *device = condor3_udp_driver.CreateOnPort(dummy_config, null_port);
+  ok1(device != nullptr);
+
+  NMEAInfo info;
+  unsigned step = 0;
+
+  auto next_step = [&]() {
+    info.Reset();
+    ++step;
+    info.clock = TimeStamp{FloatDuration{step}};
+    info.alive.Update(info.clock);
+  };
+
+  next_step();
+
+  ok1(!device->ParseNMEA("", info));
+  ok1(!device->ParseNMEA("noline", info));
+  ok1(!device->ParseNMEA("=-1", info));
+  ok1(!device->ParseNMEA("key=", info));
+  ok1(!device->ParseNMEA("x=1 junk", info));
+
+  next_step();
+  ok1(device->ParseNMEA("airspeed=25.5", info));
+  ok1(info.airspeed_available);
+  ok1(equals(info.true_airspeed, 25.5));
+
+  next_step();
+  ok1(device->ParseNMEA("altitude=1234", info));
+  ok1(info.baro_altitude_available);
+  ok1(equals(info.baro_altitude, 1234));
+
+  next_step();
+  ok1(device->ParseNMEA("vario=3.25", info));
+  ok1(info.noncomp_vario_available);
+  ok1(equals(info.noncomp_vario, 3.25));
+
+  next_step();
+  ok1(device->ParseNMEA("evario=-1.5", info));
+  ok1(info.total_energy_vario_available);
+  ok1(equals(info.total_energy_vario, -1.5));
+
+  next_step();
+  ok1(device->ParseNMEA("nettovario=0.75", info));
+  ok1(info.netto_vario_available);
+  ok1(equals(info.netto_vario, 0.75));
+
+  next_step();
+  ok1(device->ParseNMEA("compass=270", info));
+  ok1(info.attitude.heading_available);
+  ok1(equals(info.attitude.heading.Degrees(), 270));
+
+  next_step();
+  ok1(device->ParseNMEA("vx=30", info));
+  ++step;
+  info.clock = TimeStamp{FloatDuration{step}};
+  info.alive.Update(info.clock);
+  ok1(device->ParseNMEA("vy=40", info));
+  ok1(info.ground_speed_available);
+  ok1(equals(info.ground_speed, 50));
+
+  next_step();
+  ok1(device->ParseNMEA("MC=1.75", info));
+  ok1(info.settings.mac_cready_available);
+  ok1(equals(info.settings.mac_cready, 1.75));
+
+  next_step();
+  ok1(device->ParseNMEA("water=42.5", info));
+  ok1(info.settings.ballast_litres_available);
+  ok1(equals(info.settings.ballast_litres, 42.5));
+
+  next_step();
+  ok1(device->ParseNMEA("latitude=50", info));
+  ok1(!info.location_available);
+  ++step;
+  info.clock = TimeStamp{FloatDuration{step}};
+  info.alive.Update(info.clock);
+  ok1(device->ParseNMEA("longitude=7.5", info));
+  ok1(info.location_available);
+  ok1(equals(info.location.latitude.Degrees(), 50));
+  ok1(equals(info.location.longitude.Degrees(), 7.5));
+  ok1(info.gps.fix_quality == FixQuality::SIMULATION);
+
+  next_step();
+  ok1(device->ParseNMEA("gforce=1.5", info));
+  ok1(info.acceleration.available);
+  ok1(equals(info.acceleration.g_load, 1.5));
+
+  next_step();
+  ok1(device->ParseNMEA("radiofrequency=123.5", info));
+  ok1(info.settings.has_active_frequency);
+  ok1(info.settings.active_frequency.GetKiloHertz() == 123500u);
 
   delete device;
 }
@@ -2914,7 +3015,8 @@ int main()
              + 8 /* SubSecond */ + 4 /* MWVStatus */
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */
-             + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */);
+             + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
+             + 47 /* Condor3UDP */);
   TestGeneric();
   TestTasman();
   TestFLARM();
@@ -2932,6 +3034,7 @@ int main()
   TestLX(lx_driver);
   TestLX(condor_driver, true, true);
   TestLX(condor3_driver, true, false);
+  TestCondor3UDP();
   TestLXEos();
   TestLXV7();
   TestLXV7POLAR();

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -20,6 +20,7 @@ private:
   void TestBallast();
   void TestBugs();
   void TestMC();
+  void TestDensityRatio();
 };
 
 void
@@ -146,6 +147,45 @@ GlidePolarTest::TestMC()
 }
 
 void
+GlidePolarTest::TestDensityRatio()
+{
+  // Baseline values at sea level (density_ratio == 1.0 by default)
+  polar.SetDensityRatio(1.0);
+  const double vmin_sl    = polar.GetVMin();
+  const double vbld_sl    = polar.GetVBestLD();
+  const double sbld_sl    = polar.GetSBestLD();
+  const double bestld_sl  = polar.GetBestLD();
+  const double sink80_sl  = polar.SinkRate(Units::ToSysUnit(80, Unit::KILOMETER_PER_HOUR));
+
+  // Apply a density ratio representing high altitude (e.g. ~3500m MSL -> DR ~1.1)
+  const double dr = 1.1;
+  polar.SetDensityRatio(dr);
+
+  // All optimal airspeeds scale by DR
+  ok1(equals(polar.GetVMin(),    vmin_sl * dr));
+  ok1(equals(polar.GetVBestLD(), vbld_sl * dr));
+
+  // Sink rates at corresponding TAS scale by DR
+  ok1(equals(polar.GetSBestLD(), sbld_sl * dr));
+
+  // Best L/D ratio (dimensionless) is preserved at altitude
+  ok1(equals(polar.GetBestLD(), bestld_sl));
+
+  // SinkRate(V_TAS) at altitude == DR * SinkRate_IAS(V_TAS / DR)
+  // i.e. the same IAS as 80 km/h at sea level gives DR times the sea-level sink
+  const double v_tas_80ias = Units::ToSysUnit(80, Unit::KILOMETER_PER_HOUR) * dr;
+  ok1(equals(polar.SinkRate(v_tas_80ias), sink80_sl * dr));
+
+  // SinkRate at the altitude-corrected VBestLD must equal SBestLD
+  ok1(equals(polar.SinkRate(polar.GetVBestLD()), polar.GetSBestLD()));
+
+  // Reset to sea level: values must return to baseline
+  polar.SetDensityRatio(1.0);
+  ok1(equals(polar.GetVMin(),    vmin_sl));
+  ok1(equals(polar.GetVBestLD(), vbld_sl));
+}
+
+void
 GlidePolarTest::Run()
 {
   Init();
@@ -153,11 +193,12 @@ GlidePolarTest::Run()
   TestBallast();
   TestBugs();
   TestMC();
+  TestDensityRatio();
 }
 
 int main()
 {
-  plan_tests(46);
+  plan_tests(54);
 
   GlidePolarTest test;
   test.Run();


### PR DESCRIPTION
## Summary
- Scale glide polar by ISA air density ratio (sqrt(rho0/rho)) for speed-to-fly, sink rates, and task calculations (#1569)
- Wire density ratio into task manager glide and safety polars
- Align netto vario polar sink and vario STF push/pull arrows with density-compensated true airspeed
- Add Condor3UDP driver for Condor 3 Simkits generic UDP telemetry (#2340)
- Fix AirspaceWarningMonitor crash when a warning clears with bottom page already restored

## Test plan
- [ ] `make TARGET=UNIX check` / `TestGlidePolar` passes
- [ ] Fly at altitude: V_stf and netto vario behave vs sea-level baseline
- [ ] Vario gauge STF arrows compare correctly to commanded speed
- [ ] Condor 3: UDP port 55278 + Condor3 TCP NMEA; MC/water sync when enabled
- [ ] Trigger airspace warning enter/clear repeatedly without crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Condor 3 UDP telemetry driver for generic UDP simulator output (default port 55278)
  * Implemented altitude-corrected glide polar calculations with real-time air density ratio updates each GPS cycle

* **Bug Fixes**
  * Fixed airspace warning crash when alerts clear after bottom page restoration

* **Improvements**
  * Vario and speed-to-fly calculations now use altitude-corrected true airspeed
  * Task manager safety polars updated for density-scaled sink rates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->