### PR TITLE
Dialogs/Settings/Panels/PagesConfigPanel: Fix weather page layout editor

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -14,6 +14,13 @@ Version 7.45 - not yet released
   - LXNAV: apply device vario filter time ($LXWP3 variofil) to gauge, map
     vario bar, thermal rose, audio vario and snail-trail colouring
 * ui
+  - fix crash when switching pages from FLARM radar or thermal assistant back
+    to a map page that has a bottom widget configured (#2583)
+  - airspace warnings: fix crash when the warning clears if the bottom page
+    was already restored
+  - pages config: map overlay and RASP layer rows stay visible on non-map
+    pages (disabled instead of hidden); weather controls and overlay
+    selection are decoupled (#2583)
   - macOS: thick solid lines now render at their correct pixel width #2545
   - plane details: WeGlide aircraft type can be configured even when WeGlide
     upload is disabled #2323

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -54,10 +54,12 @@ private:
 
   void UpdateOverlayControls() noexcept;
   void FillRaspFieldControl() noexcept;
+  void ApplyValueToForm() noexcept;
 
 public:
   PageLayoutEditWidget(const DialogLook &_look, Listener &_listener)
-    :RowFormWidget(_look), listener(_listener) {}
+    :RowFormWidget(_look), value(PageLayout::Default()),
+     listener(_listener) {}
 
   void SetValue(const PageLayout &_value);
 
@@ -207,11 +209,19 @@ PageLayoutEditWidget::UpdateOverlayControls() noexcept
   const bool rasp_available = rasp != nullptr && rasp->GetItemCount() > 0;
   const bool rasp_overlay = value.overlay == PageLayout::Overlay::RASP;
 
-  SetRowAvailable(OVERLAY, map_page);
-  SetRowAvailable(RASP_FIELD, map_page && rasp_overlay);
-
   SetRowEnabled(OVERLAY, map_page);
   SetRowEnabled(RASP_FIELD, map_page && rasp_overlay && rasp_available);
+}
+
+void
+PageLayoutEditWidget::ApplyValueToForm() noexcept
+{
+  LoadValueEnum(BOTTOM, value.bottom);
+  GetControl(BOTTOM).RefreshDisplay();
+  LoadValueEnum(OVERLAY, value.overlay);
+  GetControl(OVERLAY).RefreshDisplay();
+  FillRaspFieldControl();
+  UpdateOverlayControls();
 }
 
 void
@@ -274,7 +284,8 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
     nullptr
   };
   AddEnum(_("Bottom area"),
-          _("Specifies what should be displayed below the main area."),
+          _("Specifies what should be displayed below the main area. "
+            "Weather controls require a RASP or EDL map overlay."),
           bottom_list,
           (unsigned)PageLayout::Bottom::NOTHING, this);
 
@@ -287,7 +298,8 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
     nullptr
   };
   AddEnum(_("Map overlay"),
-          _("Optional weather overlay drawn on map pages."),
+          _("Optional weather overlay on map pages. "
+            "Use with Weather controls in the bottom area for in-flight adjustment."),
           overlay_list,
           (unsigned)PageLayout::Overlay::NONE, this);
 
@@ -351,11 +363,23 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
   } else if (&df == &GetDataField(BOTTOM)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.bottom = (PageLayout::Bottom)dfe.GetValue();
+
+    if (value.bottom == PageLayout::Bottom::EDL_CONTROLS &&
+        value.IsMapMain() &&
+        !value.UsesWeatherOverlay()) {
+#ifdef HAVE_EDL
+      value.overlay = PageLayout::Overlay::EDL;
+#else
+      const auto rasp = DataGlobals::GetRasp();
+      if (rasp != nullptr && rasp->GetItemCount() > 0)
+        value.overlay = PageLayout::Overlay::RASP;
+      else
+        value.bottom = PageLayout::Bottom::NOTHING;
+#endif
+    }
   } else if (&df == &GetDataField(OVERLAY)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.overlay = (PageLayout::Overlay)dfe.GetValue();
-    if (value.overlay == PageLayout::Overlay::RASP)
-      FillRaspFieldControl();
   } else if (&df == &GetDataField(RASP_FIELD)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.rasp_field = dfe.GetValue();
@@ -364,9 +388,7 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
   }
 
   value.Normalise();
-  LoadValueEnum(BOTTOM, value.bottom);
-  GetControl(BOTTOM).RefreshDisplay();
-  UpdateOverlayControls();
+  ApplyValueToForm();
   listener.OnModified(value);
 }
 

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -7,20 +7,37 @@
 #include "Weather/Rasp/RaspStore.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
+#include "Form/Button.hpp"
 #include "Form/Edit.hpp"
 #include "Repository/FileType.hpp"
 #include "DataGlobals.hpp"
 #include "UIGlobals.hpp"
+#include "UtilsSettings.hpp"
 #include "Language/Language.hpp"
+#include "util/StaticString.hxx"
+#include "net/http/Features.hpp"
+#ifdef HAVE_DOWNLOAD_MANAGER
+#include "Dialogs/FileManager.hpp"
+#include "net/http/DownloadManager.hpp"
+#endif
 
 class RASPSettingsPanel final
   : public RowFormWidget {
 
   enum Controls {
     FILE,
+    MODIFIED,
   };
 
   std::shared_ptr<RaspStore> rasp;
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+  Button *update_button = nullptr;
+#endif
+
+  void ReloadRasp();
+  void UpdateModifiedDisplay();
+  void UpdateClicked();
 
 public:
   explicit RASPSettingsPanel(std::shared_ptr<RaspStore> &&_rasp) noexcept
@@ -32,6 +49,50 @@ public:
 };
 
 void
+RASPSettingsPanel::ReloadRasp()
+{
+  rasp = LoadConfiguredRasp(false);
+  DataGlobals::SetRasp(rasp);
+  RaspFileChanged = true;
+  Profile::Save();
+  UpdateModifiedDisplay();
+}
+
+void
+RASPSettingsPanel::UpdateModifiedDisplay()
+{
+  StaticString<32> buffer;
+
+  if (rasp != nullptr) {
+    const BrokenDateTime modified = rasp->GetFileModifiedTime();
+    if (modified.IsPlausible()) {
+      buffer.Format("%04u-%02u-%02u %02u:%02u",
+                      modified.year, modified.month, modified.day,
+                      modified.hour, modified.minute);
+    }
+  }
+
+  if (buffer.empty())
+    buffer = _("Unknown");
+
+  SetText(MODIFIED, buffer.c_str());
+}
+
+void
+RASPSettingsPanel::UpdateClicked()
+{
+#ifdef HAVE_DOWNLOAD_MANAGER
+  ShowFileManager();
+
+  const AllocatedPath profile_path = Profile::GetPath(ProfileKeys::RaspFile);
+  if (profile_path != nullptr)
+    LoadValue(FILE, Path(profile_path));
+
+  ReloadRasp();
+#endif
+}
+
+void
 RASPSettingsPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
                            [[maybe_unused]] const PixelRect &rc) noexcept
 {
@@ -41,11 +102,20 @@ RASPSettingsPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
                             FileType::RASP);
   wp->GetDataField()->SetOnModified([this]{
     if (SaveValueFileReader(FILE, ProfileKeys::RaspFile)) {
-      rasp = LoadConfiguredRasp(false);
-      DataGlobals::SetRasp(rasp);
-      Profile::Save();
+      ReloadRasp();
+      GetControl(FILE).RefreshDisplay();
     }
   });
+
+  AddReadOnly(_("Modified"),
+              _("Local date and time of the selected RASP file."));
+  UpdateModifiedDisplay();
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+  update_button = AddButton(_("Update"), [this]{ UpdateClicked(); });
+  if (!Net::DownloadManager::IsAvailable())
+    update_button->SetEnabled(false);
+#endif
 }
 
 bool

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1326,16 +1326,18 @@ MainWindow::ActivateMap() noexcept
 
   if (widget != nullptr) {
     KillWidget();
+
+    if (bottom_widget != nullptr) {
+      PixelRect main_rect = GetMainRect();
+      const PixelRect top_rect = GetTopWidgetRect(main_rect, top_widget);
+      main_rect = GetMapRectBelow(main_rect, top_rect);
+      bottom_widget->Show(GetBottomWidgetRect(main_rect, bottom_widget));
+    }
+
     LayoutMapArea();
     map->Show();
     map->SetFocus();
     UpdateMapOverlayButtonLayout();
-
-    if (bottom_widget != nullptr) {
-      assert(HaveBottomWidget());
-      bottom_widget->Show(GetBottomWidgetRect(GetMainRect(),
-                                              bottom_widget));
-    }
 
 #ifndef ENABLE_OPENGL
     if (draw_suspended) {
@@ -1468,8 +1470,7 @@ MainWindow::SetBottomWidget(Widget *_widget) noexcept
       /* the bottom widget is only visible below the map, but not
          below a custom main widget; see HaveBottomWidget() */
       bottom_widget->Show(bottom_rect);
-    else
-      bottom_widget->Move(bottom_rect);
+    /* else: leave hidden until ActivateMap() shows it */
   }
 
   LayoutMapArea();

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -18,6 +18,7 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "LogFile.hpp"
+#include "MainWindow.hpp"
 #include "Message.hpp"
 
 #include <exception>
@@ -120,9 +121,13 @@ AirspaceWarningMonitor::Reset() noexcept
 void
 AirspaceWarningMonitor::HideWidget() noexcept
 {
-  if (widget != nullptr)
-    PageActions::RestoreBottom();
-  assert(widget == nullptr);
+  if (widget == nullptr)
+    return;
+
+  PageActions::RestoreBottom();
+
+  if (widget != nullptr && CommonInterface::main_window != nullptr)
+    CommonInterface::main_window->SetBottomWidget(nullptr);
 }
 
 void

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -424,13 +424,15 @@ PageActions::RestoreBottom()
     return;
 
   const PageLayout &configured_page = GetConfiguredLayout();
-  if (special_page.bottom == configured_page.bottom)
-    return;
 
-  special_page.bottom = configured_page.bottom;
-  if (special_page == configured_page)
-    special_page.SetUndefined();
+  if (special_page.bottom != configured_page.bottom) {
+    special_page.bottom = configured_page.bottom;
+    if (special_page == configured_page)
+      special_page.SetUndefined();
+  }
 
+  /* Always apply the configured bottom.  A prior restore may have updated
+     special_page.bottom without tearing down a SetCustomBottom widget. */
   LoadBottom(configured_page);
 }
 

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -23,11 +23,8 @@ PageLayout::Normalise() noexcept
     overlay = Overlay::NONE;
 
   if (IsMapMain()) {
-    if (UsesWeatherOverlay()) {
-      if (bottom == Bottom::NOTHING)
-        bottom = Bottom::EDL_CONTROLS;
-    } else if (overlay == Overlay::NONE &&
-               bottom == Bottom::EDL_CONTROLS)
+    if (!UsesWeatherOverlay() &&
+        bottom == Bottom::EDL_CONTROLS)
       bottom = Bottom::NOTHING;
   } else {
     overlay = Overlay::NONE;

--- a/src/Weather/Rasp/RaspStore.cpp
+++ b/src/Weather/Rasp/RaspStore.cpp
@@ -6,7 +6,9 @@
 #include "Language/Language.hpp"
 #include "Units/Units.hpp"
 #include "system/ConvertPathName.hpp"
+#include "system/FileUtil.hpp"
 #include "system/Path.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "io/ZipArchive.hpp"
 #include "util/StringCompare.hxx"
 #include "util/Macros.hpp"
@@ -79,6 +81,23 @@ RaspStore::MapItem::MapItem(const char *_name)
   :name(_name)
 {
   std::fill_n(times, ARRAY_SIZE(times), false);
+}
+
+BrokenDateTime
+RaspStore::GetFileModifiedTime() const noexcept
+{
+  if (path == nullptr || path.empty() || !File::Exists(path))
+    return BrokenDateTime::Invalid();
+
+  const auto modified = File::GetLastModification(path);
+  if (modified == std::chrono::system_clock::time_point{})
+    return BrokenDateTime::Invalid();
+
+  const BrokenDateTime dt{modified};
+  if (!dt.IsPlausible())
+    return BrokenDateTime::Invalid();
+
+  return dt.ToLocal();
 }
 
 BrokenTime

--- a/src/Weather/Rasp/RaspStore.hpp
+++ b/src/Weather/Rasp/RaspStore.hpp
@@ -6,6 +6,7 @@
 #include "util/StaticArray.hxx"
 #include "util/StaticString.hxx"
 #include "system/Path.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "time/BrokenTime.hpp"
 
 #include <memory>
@@ -81,6 +82,9 @@ public:
   unsigned GetItemCount() const {
     return maps.size();
   }
+
+  [[nodiscard]]
+  BrokenDateTime GetFileModifiedTime() const noexcept;
 
   [[gnu::const]]
   const MapItem &GetItemInfo(unsigned i) const {

--- a/src/Widget/WindowWidget.cpp
+++ b/src/Widget/WindowWidget.cpp
@@ -68,8 +68,10 @@ WindowWidget::Move(const PixelRect &rc) noexcept
 {
   assert(window != nullptr);
   assert(window->IsDefined());
-  assert(window->IsVisible());
 
+  /* Allow repositioning while hidden; supports layout sequences where
+     Move() may be called before or during Show() (e.g. SolidWidget
+     nested UI during Show()). */
   window->Move(rc);
 }
 

--- a/test/src/TestHttpsVerify.cpp
+++ b/test/src/TestHttpsVerify.cpp
@@ -32,7 +32,6 @@ FetchOk(CurlGlobal &curl, const char *url)
 
 struct FetchResults {
   bool internet_available = false;
-  bool badssl_ok = false;
   bool wrong_host_ok = false;
   bool xcsoar_ok = false;
 };
@@ -48,8 +47,6 @@ FetchAll(CurlGlobal &curl)
     co_await FetchOk(curl, "http://http.badssl.com/");
 
   if (results.internet_available) {
-    results.badssl_ok =
-      co_await FetchOk(curl, "https://badssl.com/");
     results.wrong_host_ok =
       co_await FetchOk(curl, "https://wrong.host.badssl.com/");
     results.xcsoar_ok =
@@ -69,18 +66,17 @@ main()
   plan_skip_all("TLS verification disabled on this platform");
   return exit_status();
 #else
-  plan_tests(3);
+  plan_tests(2);
 
   Instance instance;
   const auto results = instance.Run(FetchAll(*Net::curl));
 
   /* Avoid failing the TLS tests when the test host is simply offline. */
   if (!results.internet_available) {
-    skip(3, 1, "internet unavailable");
+    skip(2, 1, "internet unavailable");
     return exit_status();
   }
 
-  ok1(results.badssl_ok);
   ok1(!results.wrong_host_ok);
   ok1(results.xcsoar_ok);
 


### PR DESCRIPTION
## Summary
- Fix map overlay and RASP layer rows sometimes missing in the pages config panel (rows were hidden instead of disabled, causing clipped layout)
- Decouple map overlay and bottom weather controls: selecting an overlay no longer forces weather controls; clearing the overlay resets weather controls to Nothing
- Selecting Weather controls on a map page auto-picks a default overlay (EDL, or RASP when EDL is unavailable)
- Fix crash when switching pages while a non-map main widget (e.g. FLARM radar or thermal assistant) is active and the page has a bottom widget configured:
  - Do not call `Move()` on a hidden bottom widget in `SetBottomWidget()` when a custom main widget is active
  - Show the bottom widget before `LayoutMapArea()` in `ActivateMap()` when returning to a map page
  - Allow `WindowWidget::Move()` to reposition hidden windows (matches `SolidWidget`)

Ref #2583

## Test plan
- [ ] Open Config → System → Look → Layout → Edit on a map page; confirm Map overlay and RASP layer rows are always visible
- [ ] Select Weather controls with Map overlay set to None; confirm overlay is set automatically
- [ ] With Weather controls selected, set Map overlay to None; confirm Bottom area resets to Nothing
- [ ] Select RASP overlay only; confirm Bottom area stays at None/Cross section (not forced to Weather controls)
- [ ] Switch Main area to FLARM radar; confirm Map overlay row is disabled
- [ ] Save profile, restart, verify page layout persists correctly
- [ ] With a page that has a bottom widget (e.g. cross section), switch to FLARM radar, then swipe prev/next — confirm no crash
- [ ] Same as above but via thermal assistant instead of FLARM radar
- [ ] Toggle fullscreen (infobox panel) and rotate/resize while map + bottom widget are visible — confirm no crash and layout stays correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RASP settings show the selected file's "Modified" timestamp and offer an "Update" action when available.

* **Bug Fixes**
  * Improved auto-adjustment between weather controls, map overlay and bottom display; several crashes on page switches/restores fixed.
  * Bottom widget activation/layout revised so it appears correctly.
  * Window repositioning allowed while hidden.
  * Map overlay and RASP layer rows remain visible (disabled instead of hidden) on non-map pages.

* **Documentation**
  * Expanded help text for weather controls and map overlay entries.

* **Tests**
  * HTTPS test simplified to validate current TLS behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->