### PR TITLE
doc/requirements.txt: Pin setuptools below 81 for Read the Docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -4,12 +4,14 @@ on:
   push:
     paths:
       - 'doc/**'
+      - '.readthedocs.yaml'
       - '.github/workflows/build-docs.yml'
     branches:
       - master
   pull_request:
     paths:
       - 'doc/**'
+      - '.readthedocs.yaml'
       - '.github/workflows/build-docs.yml'
     branches:
       - master
@@ -48,3 +50,20 @@ jobs:
        with:
          name: ${{ env.TARGET_FINAL }}-${{ env.git_hash }}
          path: output/${{ env.DOC_OUTPUT }}/*.${{ env.TARGET_EXT }}
+
+  readthedocs-sphinx:
+    runs-on: ubuntu-24.04
+    steps:
+     - uses: actions/checkout@v6
+       with:
+         submodules: false
+
+     - uses: actions/setup-python@v5
+       with:
+         python-version: '3.12'
+
+     - name: Install Sphinx dependencies
+       run: pip install -r doc/requirements.txt
+
+     - name: Build Sphinx HTML
+       run: sphinx-build -b html doc/ output/sphinx-html

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -20,7 +20,7 @@ env:
   TARGET_FINAL: XCSoar-docs
   TARGET_EXT: pdf
 jobs:
-  xcsoar-compile:
+  manual-pdf:
     runs-on: ubuntu-24.04
     container: debian:trixie-slim
     steps:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-setuptools<83
+setuptools<81
 sphinxcontrib-blockdiag==3.0.0


### PR DESCRIPTION
## Summary

- Revert the Renovate bump from `setuptools<81` to `setuptools<83` in `doc/requirements.txt`
- `sphinxcontrib-blockdiag==3.0.0` (used by Sphinx for architecture diagrams) still imports `pkg_resources`, which was removed in setuptools 82+
- Read the Docs builds have been failing since 2026-03-08; RTD continues to serve the last successful build from that date, so newer documentation (e.g. checklist VHF links) is not published

## Test plan

- [x] Local venv install with `pip install -r doc/requirements.txt` and `sphinx-build -b html doc/` succeeds
- [ ] Read the Docs build succeeds after merge
- [ ] https://xcsoar.readthedocs.io/en/latest/checklist.html shows the VHF section after the next RTD build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build environment dependency constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->