### PR TITLE
ui/canvas/opengl/Canvas: Fix spurious outline lines on Android

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -37,6 +37,7 @@ Version 7.45 - not yet released
     pages (disabled instead of hidden); weather controls and overlay
     selection are decoupled (#2583)
   - macOS: thick solid lines now render at their correct pixel width #2545
+  - Android: fix spurious outline lines on high-DPI OpenGL displays #1514
   - plane details: WeGlide aircraft type can be configured even when WeGlide
     upload is disabled #2323
   - status dialog, Times: flight time matches takeoff and landing after

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -34,6 +34,21 @@
 
 AllocatedArray<BulkPixelPoint> Canvas::vertex_buffer;
 
+/**
+ * OpenGL ES only guarantees 1px line width.  On Android (Adreno),
+ * GL_LINE_LOOP with glLineWidth() > 1 produces spurious lines on
+ * high-DPI devices (#1514).
+ */
+[[gnu::const]]
+static bool
+UseOpenGLLineLoopOutline(unsigned pen_width) noexcept
+{
+  if (IsAndroid())
+    return false;
+
+  return pen_width <= (IsMacOSX() ? 1u : 2u);
+}
+
 static void
 GLDrawRectangle(const PixelRect r) noexcept
 {
@@ -49,6 +64,49 @@ GLDrawRectangle(const PixelRect r) noexcept
 
   const ScopeVertexPointer vp{vertices};
   glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+}
+
+static void
+GLDrawOutlineRectangleEdges(PixelRect r, unsigned width,
+                            const Color &color) noexcept
+{
+  if (r.IsEmpty() || width == 0)
+    return;
+
+  const int left = r.left;
+  const int top = r.top;
+  const int right = r.right;
+  const int bottom = r.bottom;
+  const int w = int(width);
+
+  if (right - left <= w || bottom - top <= w)
+    return;
+
+  OpenGL::solid_shader->Use();
+  color.Bind();
+
+  GLDrawRectangle({left, top, right, top + w});
+  GLDrawRectangle({left, bottom - w, right, bottom});
+  GLDrawRectangle({left, top + w, left + w, bottom - w});
+  GLDrawRectangle({right - w, top + w, right, bottom - w});
+}
+
+static void
+GLDrawLineLoopOutline(ScopeVertexPointer &vp,
+                      const BulkPixelPoint *points, unsigned num_points,
+                      unsigned pen_width,
+                      AllocatedArray<BulkPixelPoint> &buffer) noexcept
+{
+  if (UseOpenGLLineLoopOutline(pen_width))
+    glDrawArrays(GL_LINE_LOOP, 0, num_points);
+  else {
+    unsigned vertices = LineToTriangles(points, num_points, buffer,
+                                        pen_width, true);
+    if (vertices > 0) {
+      vp.Update(buffer.data());
+      glDrawArrays(GL_TRIANGLE_STRIP, 0, vertices);
+    }
+  }
 }
 
 void
@@ -105,39 +163,19 @@ Canvas::DrawFilledRectangle(PixelRect r, const Color color) noexcept
 void
 Canvas::DrawOutlineRectangleGL(PixelRect r) noexcept
 {
-  --r.right;
-  --r.bottom;
-
-  const ExactPixelPoint vertices[] = {
-    r.GetTopLeft(),
-    r.GetTopRight(),
-    r.GetBottomRight(),
-    r.GetBottomLeft(),
-  };
-
-  const ScopeVertexPointer vp(vertices);
-  glDrawArrays(GL_LINE_LOOP, 0, 4);
+  GLDrawOutlineRectangleEdges(r, pen.GetWidth(), pen.GetColor());
 }
 
 void
 Canvas::DrawOutlineRectangle(PixelRect r) noexcept
 {
-  OpenGL::solid_shader->Use();
-
-  pen.Bind();
-  DrawOutlineRectangleGL(r);
-  pen.Unbind();
+  GLDrawOutlineRectangleEdges(r, pen.GetWidth(), pen.GetColor());
 }
 
 void
 Canvas::DrawOutlineRectangle(PixelRect r, Color color) noexcept
 {
-  OpenGL::solid_shader->Use();
-
-  color.Bind();
-  glLineWidth(1);
-
-  DrawOutlineRectangleGL(r);
+  GLDrawOutlineRectangleEdges(r, 1, color);
 }
 
 void
@@ -202,18 +240,8 @@ Canvas::DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept
 
   if (IsPenOverBrush()) {
     pen.Bind();
-
-    if (pen.GetWidth() <= (IsMacOSX() ? 1u : 2u)) {
-      glDrawArrays(GL_LINE_LOOP, 0, num_points);
-    } else {
-      unsigned vertices = LineToTriangles(points, num_points, vertex_buffer,
-                                          pen.GetWidth(), true);
-      if (vertices > 0) {
-        vp.Update(vertex_buffer.data());
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, vertices);
-      }
-    }
-
+    GLDrawLineLoopOutline(vp, points, num_points, pen.GetWidth(),
+                          vertex_buffer);
     pen.Unbind();
   }
 }
@@ -235,18 +263,8 @@ Canvas::DrawTriangleFan(const BulkPixelPoint *points, unsigned num_points) noexc
 
   if (IsPenOverBrush()) {
     pen.Bind();
-
-    if (pen.GetWidth() <= (IsMacOSX() ? 1u : 2u)) {
-      glDrawArrays(GL_LINE_LOOP, 0, num_points);
-    } else {
-      unsigned vertices = LineToTriangles(points, num_points, vertex_buffer,
-                                          pen.GetWidth(), true);
-      if (vertices > 0) {
-        vp.Update(vertex_buffer.data());
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, vertices);
-      }
-    }
-
+    GLDrawLineLoopOutline(vp, points, num_points, pen.GetWidth(),
+                          vertex_buffer);
     pen.Unbind();
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1514.

On high-DPI Samsung/Adreno phones, spurious black diagonals appeared from the top-left of the content area to each outlined UI element (e.g. `WndProperty` value boxes in config dialogs) and map symbols (vector landables, traffic arrows).

The root cause is reliance on `GL_LINE_LOOP` with DPI-scaled pen widths (`ScaleFinePenWidth(1)` → often 2px on 400+ DPI devices). OpenGL ES only guarantees 1px line width; wider `GL_LINE_LOOP` outlines are unreliable on Adreno drivers.

This change:

- Draws **rectangle outlines** as filled edge quads (`GL_TRIANGLE_STRIP`) instead of `GL_LINE_LOOP`
- On **Android**, draws **polygon and triangle-fan outlines** via `LineToTriangles` instead of line primitives

Desktop/Linux OpenGL behaviour is unchanged for polygon/fan outlines (still uses `GL_LINE_LOOP` for pens ≤2px).

## Test plan

Could someone with an affected Samsung device (S22/S24 or similar, Adreno, 400+ DPI) please test an Android build from this branch?

- [x] Open a config panel with many rows (e.g. Task Manager → Rules, or Configuration → any page with `WndProperty` rows) — confirm no spurious diagonals from the top-left corner
- [x] Value box borders still look correct (thin black outline, white fill)
- [x] On the map with **Detailed landables** enabled, pan with traffic visible — confirm no lines from the corner to symbols
- [x] Traffic arrows and vector landable icons still render correctly (shape and outline)
- [x] No visible regression on a non-Samsung Android device, if available

Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outline rendering quality on Android and macOS platforms
  * Enhanced outline rendering consistency across varying pen widths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->