### PR TITLE
Device/Condor3Spectate: Add Condor 3 Spectate multiplayer traffic driver

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -107,6 +107,8 @@ Version 7.45 - not yet released
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude
     on the selected target (info panel already shows them) #2718
+  - FLARM radar: rotate track-up targets on cardinal bearings (due
+    north/south or east/west)
   - Add XCTherm to the pages config map overlay choices (alongside RASP
     and EDL) #2705
   - Add Weather Setup to the weather overlay menu (opens Info → Weather
@@ -188,6 +190,10 @@ Version 7.45 - not yet released
   - fix crash opening the log list when replay filenames contain
     non-ASCII characters (Unicode directory listing and file open)
 * devices
+  - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
+    shows other gliders on the FLARM radar and map
+  - Condor3UDP: stop deriving track from ground-velocity vx/vy (caused
+    spurious ~120° FLARM radar bearing jumps after compass expiry)
   - support $LK8EX1 (LK8000 external instrument) on all device ports:
     pressure, QNE altitude, vario, temperature, and battery voltage
     or percentage #2772

--- a/build/driver.mk
+++ b/build/driver.mk
@@ -125,6 +125,8 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/CaiLNav.cpp \
 	$(DRIVER_SRC_DIR)/Condor.cpp \
 	$(DRIVER_SRC_DIR)/Condor3UDP.cpp \
+	$(DRIVER_SRC_DIR)/Condor3Spectate.cpp \
+	$(SRC)/Device/Port/SpectateFilePort.cpp \
 	$(DRIVER_SRC_DIR)/CProbe.cpp \
 	$(DRIVER_SRC_DIR)/EW.cpp \
 	$(DRIVER_SRC_DIR)/EWMicroRecorder.cpp \
@@ -150,6 +152,6 @@ DRIVER_SOURCES = \
 	$(DRIVER_SRC_DIR)/ATR833/Device.cpp \
 	$(DRIVER_SRC_DIR)/ATR833/Register.cpp
 
-DRIVER_DEPENDS = TIME LIBNMEA GEO OPERATION UNITS FMT PROFILE FLARM GLIDE
+DRIVER_DEPENDS = TIME LIBNMEA GEO OPERATION UNITS FMT PROFILE FLARM GLIDE JSON
 
 $(eval $(call link-library,driver,DRIVER))

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -52,6 +52,7 @@ DeviceConfig::IsAvailable() const noexcept
 
   case PortType::TCP_LISTENER:
   case PortType::UDP_LISTENER:
+  case PortType::SPECTATE_FILE:
     return true;
 
   case PortType::PTY:
@@ -98,9 +99,8 @@ DeviceConfig::ShouldReopenOnTimeout() const noexcept
 
   case PortType::TCP_LISTENER:
   case PortType::UDP_LISTENER:
-    /* this is a server, and if no data gets received, this can just
-       mean that nobody connected to it, but reopening it periodically
-       doesn't help */
+  case PortType::SPECTATE_FILE:
+    /* local file polling; reopening does not help */
     return false;
 
   case PortType::PTY:
@@ -164,6 +164,13 @@ DeviceConfig::BluetoothNameStartsWith([[maybe_unused]] const char *prefix) const
 #else
   return false;
 #endif
+}
+
+void
+DeviceConfig::ApplySpectateDefaults() noexcept
+{
+  if (path.empty())
+    path = DEFAULT_SPECTATE_PATH;
 }
 
 void
@@ -296,6 +303,10 @@ DeviceConfig::GetPortName(char *buffer, size_t max_size) const noexcept
   case PortType::ANDROID_USB_SERIAL:
     StringFormat(buffer, max_size, "%s: %s",
                  _("USB serial"), path.c_str());
+    return buffer;
+
+  case PortType::SPECTATE_FILE:
+    StringFormat(buffer, max_size, "%s", path.c_str());
     return buffer;
   }
 

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -104,6 +104,11 @@ struct DeviceConfig {
      * USB serial port on Android.
      */
     ANDROID_USB_SERIAL,
+
+    /**
+     * Poll a Condor 3 Spectate.json file for multiplayer traffic.
+     */
+    SPECTATE_FILE,
   };
 
   /**
@@ -351,6 +356,7 @@ struct DeviceConfig {
     case PortType::PTY:
     case PortType::UDP_LISTENER:
     case PortType::ANDROID_USB_SERIAL:
+    case PortType::SPECTATE_FILE:
       break;
     }
 
@@ -406,6 +412,7 @@ struct DeviceConfig {
     case PortType::PTY:
     case PortType::UDP_LISTENER:
     case PortType::ANDROID_USB_SERIAL:
+    case PortType::SPECTATE_FILE:
       return true;
     }
 
@@ -490,6 +497,17 @@ struct DeviceConfig {
   constexpr bool UsesCalibration() const noexcept {
     return UsesCalibration(port_type);
   }
+
+  /**
+   * Default Condor 3 Spectate.json location on Windows.
+   */
+  static constexpr const char *DEFAULT_SPECTATE_PATH =
+    "c:\\condor3\\logs\\spectate.json";
+
+  /**
+   * Apply default Spectate file path when none is configured.
+   */
+  void ApplySpectateDefaults() noexcept;
 
   void Clear() noexcept;
 

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -215,14 +215,15 @@ try {
     parser.DisableGeoid();
 
   if (driver->CreateOnPort != nullptr) {
-    Device *new_device = driver->CreateOnPort(config, *port);
+    Device *new_device = driver->CreateOnPort(config, port->GetImplementationPort());
 
     const std::lock_guard lock{mutex};
     device = new_device;
 
     if (driver->HasPassThrough() && config.use_second_device &&
         second_driver->CreateOnPort != nullptr)
-      second_device = second_driver->CreateOnPort(config, *port);
+      second_device = second_driver->CreateOnPort(config,
+                                                  port->GetImplementationPort());
   } else
     port->StartRxThread();
 

--- a/src/Device/Driver/Condor3Spectate.cpp
+++ b/src/Device/Driver/Condor3Spectate.cpp
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Condor3Spectate.hpp"
+#include "Device/Port/SpectateFilePort.hpp"
+#include "NMEA/MoreData.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/Checksum.hpp"
+#include "Units/System.hpp"
+#include "io/FileReader.hxx"
+#include "util/NumberParser.hpp"
+#include "util/StringCompare.hxx"
+#include "util/StringFormat.hpp"
+#include "util/StringStrip.hxx"
+#include "util/StringUtil.hpp"
+#include "util/TruncateString.hpp"
+
+#include <boost/json/value.hpp>
+#include <boost/json/parse.hpp>
+
+#include "Geo/WGS84.hpp"
+#include "Math/Angle.hpp"
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+using std::string_view_literals::operator""sv;
+
+namespace {
+
+constexpr std::size_t max_file_size = 1024 * 1024;
+constexpr std::size_t max_players = 64;
+constexpr std::size_t max_hex_payload = 17;
+
+void
+AppendNMEALine(Condor3SpectateBuilder::Lines &lines,
+               const char *body_without_checksum) noexcept
+{
+  if (lines.full())
+    return;
+
+  Condor3SpectateBuilder::LineBuffer &line = lines.append();
+  line = body_without_checksum;
+  AppendNMEAChecksum(line.buffer());
+}
+
+bool
+ParseCondorCoord(std::string_view text, double &value) noexcept
+{
+  text = StripLeft(text);
+  if (text.size() < 2)
+    return false;
+
+  const char hemi = text.front();
+  text.remove_prefix(1);
+
+  /* ParseDouble requires a null-terminated C string; string_view::data()
+     is not guaranteed to be null-terminated. */
+  const std::string num{text};
+  char *endptr = nullptr;
+  const double v = ParseDouble(num.c_str(), &endptr);
+  if (endptr == num.c_str())
+    return false;
+
+  if (hemi == 'S' || hemi == 'W')
+    value = -v;
+  else if (hemi == 'N' || hemi == 'E')
+    value = v;
+  else
+    return false;
+
+  return true;
+}
+
+bool
+JsonDouble(const boost::json::value &v, double &out) noexcept
+{
+  if (v.is_number()) {
+    out = v.to_number<double>();
+    return true;
+  }
+
+  if (!v.is_string())
+    return false;
+
+  char *endptr = nullptr;
+  const double d = ParseDouble(v.as_string().c_str(), &endptr);
+  if (endptr == v.as_string().c_str())
+    return false;
+
+  out = d;
+  return true;
+}
+
+void
+RelativeNE(double ref_lat, double ref_lon,
+           double lat, double lon,
+           double &north, double &east) noexcept
+{
+  const double lat_rad = Angle::Degrees(lat).Radians();
+  const double d_lat = Angle::Degrees(lat - ref_lat).Radians();
+  const double d_lon = Angle::Degrees(lon - ref_lon).Radians();
+  north = d_lat * WGS84::EQUATOR_RADIUS;
+  east = d_lon * WGS84::EQUATOR_RADIUS * std::cos(lat_rad);
+}
+
+unsigned
+FlarmHexId(const boost::json::object &player) noexcept
+{
+  const auto id = player.if_contains("ID");
+  if (id == nullptr || !id->is_string())
+    return 1;
+
+  const auto s = id->as_string();
+  char *endptr = nullptr;
+  unsigned long n = std::strtoul(s.c_str(), &endptr, 10);
+  if (endptr == s.c_str()) {
+    /* fallback hash for non-numeric ids */
+    n = static_cast<unsigned long>(std::hash<std::string_view>{}(s));
+  }
+
+  n &= 0xFFFFFF;
+  return n != 0 ? unsigned(n) : 1;
+}
+
+void
+FormatFlarmPflaaId(const boost::json::object &player, unsigned hex_id,
+                   char *buffer, std::size_t buffer_size) noexcept
+{
+  StaticString<16> hex;
+  hex.Format("%06X", hex_id);
+
+  const auto cn = player.if_contains("CN");
+  if (cn != nullptr && cn->is_string() && !cn->as_string().empty()) {
+    StringFormat(buffer, buffer_size, "%s!%s",
+                 hex.c_str(), cn->as_string().c_str());
+    return;
+  }
+
+  const auto rn = player.if_contains("RN");
+  if (rn != nullptr && rn->is_string() && !rn->as_string().empty()) {
+    StringFormat(buffer, buffer_size, "%s!%s",
+                 hex.c_str(), rn->as_string().c_str());
+    return;
+  }
+
+  CopyString(buffer, buffer_size, hex);
+}
+
+void
+HexPayload(std::string_view text, char *dest, std::size_t dest_size) noexcept
+{
+  if (dest_size == 0)
+    return;
+
+  StaticString<max_hex_payload + 1> truncated;
+  CopyTruncateString(truncated.buffer(), truncated.capacity(),
+                     text.data(), text.size());
+
+  char *p = dest;
+  const char *const end = dest + dest_size - 1;
+  for (const char ch : truncated) {
+    if (p + 2 >= end)
+      break;
+
+    const int n = StringFormat(p, end - p, "%02X", (unsigned char)ch);
+    if (n <= 0)
+      break;
+
+    p += n;
+  }
+
+  *p = '\0';
+}
+
+void
+AppendPflam(Condor3SpectateBuilder::Lines &lines, unsigned hex_id,
+            const char *msg_type, const char *hex_payload) noexcept
+{
+  char body[128];
+  StringFormat(body, sizeof(body),
+               "$PFLAM,U,2,%06X,%s,%s", hex_id, msg_type, hex_payload);
+  AppendNMEALine(lines, body);
+}
+
+void
+AppendPflamForPlayer(Condor3SpectateBuilder::Lines &lines,
+                     const boost::json::object &player,
+                     unsigned hex_id) noexcept
+{
+  char payload[64];
+
+  const auto first = player.if_contains("firstname");
+  const auto last = player.if_contains("lastname");
+  if (first != nullptr && first->is_string() &&
+      last != nullptr && last->is_string()) {
+    StaticString<64> pilot;
+    pilot.Format("%s %s", first->as_string().c_str(),
+                 last->as_string().c_str());
+    StripRight(pilot.buffer());
+    if (!pilot.empty()) {
+      HexPayload(pilot, payload, sizeof(payload));
+      AppendPflam(lines, hex_id, "PNAME", payload);
+    }
+  }
+
+  const auto cn = player.if_contains("CN");
+  if (cn != nullptr && cn->is_string() && !cn->as_string().empty()) {
+    HexPayload(cn->as_string(), payload, sizeof(payload));
+    AppendPflam(lines, hex_id, "ACALL", payload);
+  }
+
+  const auto rn = player.if_contains("RN");
+  if (rn != nullptr && rn->is_string() && !rn->as_string().empty()) {
+    HexPayload(rn->as_string(), payload, sizeof(payload));
+    AppendPflam(lines, hex_id, "AREG", payload);
+  }
+
+  const auto plane = player.if_contains("plane");
+  if (plane != nullptr && plane->is_string() && !plane->as_string().empty()) {
+    HexPayload(plane->as_string(), payload, sizeof(payload));
+    AppendPflam(lines, hex_id, "ATYPE", payload);
+  }
+}
+
+void
+AppendPflaa(Condor3SpectateBuilder::Lines &lines,
+            const boost::json::object &player,
+            double rel_n, double rel_e, double rel_v) noexcept
+{
+  const unsigned hex_id = FlarmHexId(player);
+
+  int track = 0;
+  if (const auto heading = player.if_contains("heading");
+      heading != nullptr) {
+    double track_deg = 0;
+    if (JsonDouble(*heading, track_deg))
+      track = int(std::fmod(track_deg, 360.0));
+  }
+  if (track < 0)
+    track += 360;
+
+  /* Condor Spectate speed is km/h; FTD-012 PFLAA GroundSpeed is m/s. */
+  double speed_ms = 0;
+  if (const auto speed = player.if_contains("speed");
+      speed != nullptr) {
+    double speed_kmh = 0;
+    if (JsonDouble(*speed, speed_kmh))
+      speed_ms = Units::ToSysUnit(std::max(0.0, speed_kmh),
+                                  Unit::KILOMETER_PER_HOUR);
+  }
+
+  double climb = 0;
+  if (const auto vario = player.if_contains("vario");
+      vario != nullptr)
+    JsonDouble(*vario, climb);
+
+  char id_field[32];
+  FormatFlarmPflaaId(player, hex_id, id_field, sizeof(id_field));
+
+  char body[160];
+  StringFormat(body, sizeof(body),
+                 "$PFLAA,0,%d,%d,%d,1,%s,%d,0,%.0f,%.1f,1",
+                 int(std::lround(rel_n)), int(std::lround(rel_e)),
+                 int(std::lround(rel_v)), id_field, track, speed_ms, climb);
+  AppendNMEALine(lines, body);
+}
+
+void
+AppendPflau(Condor3SpectateBuilder::Lines &lines,
+            unsigned traffic_count) noexcept
+{
+  char body[64];
+  StringFormat(body, sizeof(body),
+               "$PFLAU,%u,1,2,1,0,,0,,,", traffic_count);
+  AppendNMEALine(lines, body);
+}
+
+const boost::json::object *
+FindOwnShip(const boost::json::array &players,
+            std::string_view own_cn) noexcept
+{
+  if (own_cn.empty())
+    return nullptr;
+
+  for (const auto &item : players) {
+    if (!item.is_object())
+      continue;
+
+    const auto &player = item.as_object();
+    const auto cn = player.if_contains("CN");
+    if (cn == nullptr || !cn->is_string())
+      continue;
+
+    if (StringIsEqual(cn->as_string(), own_cn))
+      return &player;
+  }
+
+  return nullptr;
+}
+
+bool
+IsOwnShip(const boost::json::object &player,
+          const boost::json::object *own) noexcept
+{
+  if (own == nullptr)
+    return false;
+
+  const auto id = player.if_contains("ID");
+  const auto own_id = own->if_contains("ID");
+  if (id == nullptr || own_id == nullptr)
+    return false;
+
+  if (id->is_string() && own_id->is_string())
+    return StringIsEqual(id->as_string(), own_id->as_string());
+
+  return *id == *own_id;
+}
+
+bool
+PlayerCoords(const boost::json::object &player,
+             double &lat, double &lon, double &alt) noexcept
+{
+  const auto lat_v = player.if_contains("latitude");
+  const auto lon_v = player.if_contains("longitude");
+  if (lat_v == nullptr || lon_v == nullptr ||
+      !lat_v->is_string() || !lon_v->is_string())
+    return false;
+
+  if (!ParseCondorCoord(lat_v->as_string(), lat) ||
+      !ParseCondorCoord(lon_v->as_string(), lon))
+    return false;
+
+  alt = 0;
+  if (const auto alt_v = player.if_contains("altitude");
+      alt_v != nullptr)
+    JsonDouble(*alt_v, alt);
+
+  return true;
+}
+
+} // namespace
+
+bool
+Condor3SpectateBuilder::Build(Path path, const char *own_cn,
+                               Lines &lines,
+                               const Condor3SpectateReference *live_ref) noexcept
+{
+  lines.clear();
+
+  try {
+    FileReader reader(path);
+    const auto size = reader.GetSize();
+    if (size == 0 || size > max_file_size) {
+      AppendPflau(lines, 0);
+      return true;
+    }
+
+    std::string content(size, '\0');
+    const std::size_t nbytes = reader.Read(
+      std::span{reinterpret_cast<std::byte *>(content.data()), content.size()});
+    content.resize(nbytes);
+
+    if (content.size() >= 3 &&
+        (unsigned char)content[0] == 0xEF &&
+        (unsigned char)content[1] == 0xBB &&
+        (unsigned char)content[2] == 0xBF)
+      content.erase(0, 3);
+
+    const boost::json::value jv = boost::json::parse(content);
+    boost::json::array players;
+    if (jv.is_array())
+      players = jv.as_array();
+    else if (jv.is_object())
+      players.emplace_back(jv);
+    else
+      return false;
+
+    if (players.empty()) {
+      AppendPflau(lines, 0);
+      return true;
+    }
+
+    const std::string_view own_cn_view{own_cn != nullptr ? own_cn : ""};
+    const boost::json::object *own = FindOwnShip(players, own_cn_view);
+
+    double ref_lat = 0, ref_lon = 0, ref_alt = 0;
+    if (live_ref != nullptr && live_ref->defined) {
+      ref_lat = live_ref->latitude;
+      ref_lon = live_ref->longitude;
+      ref_alt = live_ref->altitude;
+    } else if (own != nullptr) {
+      if (!PlayerCoords(*own, ref_lat, ref_lon, ref_alt))
+        return false;
+    } else {
+      bool found_ref = false;
+      for (const auto &item : players) {
+        if (!item.is_object())
+          continue;
+
+        if (PlayerCoords(item.as_object(), ref_lat, ref_lon, ref_alt)) {
+          found_ref = true;
+          break;
+        }
+      }
+
+      if (!found_ref)
+        return false;
+    }
+
+    unsigned traffic_count = 0;
+    for (const auto &item : players) {
+      if (!item.is_object())
+        continue;
+
+      const auto &player = item.as_object();
+      if (IsOwnShip(player, own))
+        continue;
+
+      double lat, lon, alt;
+      if (!PlayerCoords(player, lat, lon, alt))
+        continue;
+
+      double rel_n, rel_e;
+      RelativeNE(ref_lat, ref_lon, lat, lon, rel_n, rel_e);
+      const double rel_v = alt - ref_alt;
+
+      const unsigned hex_id = FlarmHexId(player);
+      AppendPflamForPlayer(lines, player, hex_id);
+      AppendPflaa(lines, player, rel_n, rel_e, rel_v);
+      ++traffic_count;
+
+      if (traffic_count >= max_players)
+        break;
+    }
+
+    AppendPflau(lines, traffic_count);
+    return true;
+  } catch (...) {
+    AppendPflau(lines, 0);
+    return true;
+  }
+}
+
+void
+Condor3SpectateDevice::OnCalculatedUpdate(const MoreData &basic,
+                                         [[maybe_unused]] const DerivedInfo &calculated)
+{
+  if (!basic.location_available || !basic.location.IsValid()) {
+    live_ref.defined = false;
+    return;
+  }
+
+  live_ref.latitude = basic.location.latitude.Degrees();
+  live_ref.longitude = basic.location.longitude.Degrees();
+  if (basic.gps_altitude_available)
+    live_ref.altitude = basic.gps_altitude;
+  else if (basic.baro_altitude_available)
+    live_ref.altitude = basic.baro_altitude;
+  else
+    live_ref.altitude = 0;
+  live_ref.defined = true;
+}
+
+static Device *
+Condor3SpectateCreateOnPort([[maybe_unused]] const DeviceConfig &config,
+                           Port &com_port)
+{
+  auto *device = new Condor3SpectateDevice();
+  if (auto *spectate = dynamic_cast<SpectateFilePort *>(&com_port))
+    spectate->SetDevice(device);
+  return device;
+}
+
+const struct DeviceRegister condor3_spectate_driver = {
+  "Condor3Spectate",
+  "Condor Soaring Simulator 3 (Spectate multiplayer)",
+  0,
+  Condor3SpectateCreateOnPort,
+};

--- a/src/Device/Driver/Condor3Spectate.hpp
+++ b/src/Device/Driver/Condor3Spectate.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Device/Driver.hpp"
+#include "system/Path.hpp"
+#include "util/StaticArray.hxx"
+#include "util/StaticString.hxx"
+
+struct MoreData;
+struct DerivedInfo;
+
+struct Condor3SpectateReference {
+  double latitude = 0;
+  double longitude = 0;
+  double altitude = 0;
+  bool defined = false;
+};
+
+/**
+ * Build FLARM NMEA sentences from a Condor 3 Spectate.json snapshot.
+ */
+class Condor3SpectateBuilder {
+  /* Up to max_players × (4×PFLAM + PFLAA) + PFLAU. */
+  static constexpr std::size_t max_lines = 384;
+  static constexpr std::size_t max_line_length = 128;
+
+public:
+  using LineBuffer = StaticString<max_line_length>;
+  using Lines = StaticArray<LineBuffer, max_lines>;
+
+  /**
+   * Read @p path and append NMEA lines to @p lines.
+   *
+   * @param own_cn if non-empty, exclude this competition number from
+   * traffic list
+   * @param live_ref when defined, use Condor3UDP position as the
+   * coordinate reference instead of own-ship from Spectate.json
+   */
+  static bool Build(Path path, const char *own_cn, Lines &lines,
+                    const Condor3SpectateReference *live_ref=nullptr) noexcept;
+};
+
+class Condor3SpectateDevice final : public AbstractDevice {
+  Condor3SpectateReference live_ref;
+
+public:
+  void OnCalculatedUpdate(const MoreData &basic,
+                          const DerivedInfo &calculated) override;
+
+  [[gnu::pure]]
+  const Condor3SpectateReference &GetLiveReference() const noexcept {
+    return live_ref;
+  }
+};
+
+extern const struct DeviceRegister condor3_spectate_driver;

--- a/src/Device/Driver/Condor3UDP.cpp
+++ b/src/Device/Driver/Condor3UDP.cpp
@@ -66,11 +66,10 @@ class Condor3UDPDevice final : public AbstractDevice {
     const double h = std::hypot(vx, vy);
     info.ground_speed = h;
     info.ground_speed_available.Update(info.clock);
-    if (h > 0.2 && !info.attitude.heading_available) {
-      /* Ground velocity track; compass heading is preferred when sent. */
-      info.track = Angle::Radians(std::atan2(vx, vy));
-      info.track_available.Update(info.clock);
-    }
+    /* Do not derive track from Condor vx/vy: Condor documents them as
+       ground velocity but they are not reliable earth-frame N/E (see
+       compass handler comment).  Using them after compass expires made
+       the FLARM traffic radar bearing jump by ~120°. */
   }
 
   bool

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -4,6 +4,7 @@
 #include "ConfiguredPort.hpp"
 #include "UDPPort.hpp"
 #include "TCPPort.hpp"
+#include "SpectateFilePort.hpp"
 #include "K6BtPort.hpp"
 #include "Device/Config.hpp"
 #include "LogFile.hpp"
@@ -174,6 +175,16 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
   case DeviceConfig::PortType::UDP_LISTENER:
     return std::make_unique<UDPPort>(event_loop, config.tcp_port,
                                      listener, handler);
+
+  case DeviceConfig::PortType::SPECTATE_FILE: {
+    const char *spectate_path = config.path.empty()
+      ? DeviceConfig::DEFAULT_SPECTATE_PATH
+      : config.path.c_str();
+
+    return std::make_unique<SpectateFilePort>(Path(spectate_path),
+                                              config.port_name,
+                                              listener, handler);
+  }
 
   case DeviceConfig::PortType::PTY: {
 #if defined(HAVE_POSIX) && !defined(ANDROID)

--- a/src/Device/Port/DumpPort.hpp
+++ b/src/Device/Port/DumpPort.hpp
@@ -52,6 +52,18 @@ public:
     return until > std::chrono::steady_clock::time_point{};
   }
 
+  Port &GetInnerPort() noexcept {
+    return *port;
+  }
+
+  const Port &GetInnerPort() const noexcept {
+    return *port;
+  }
+
+  Port &GetImplementationPort() noexcept override {
+    return port->GetImplementationPort();
+  }
+
 private:
   /**
    * Determine whether dumping is currently enabled.

--- a/src/Device/Port/Port.hpp
+++ b/src/Device/Port/Port.hpp
@@ -259,6 +259,13 @@ public:
     return WaitForByte(static_cast<std::byte>(token), env, timeout);
   }
 
+  /**
+   * Return the underlying port when this instance wraps another port.
+   */
+  virtual Port &GetImplementationPort() noexcept {
+    return *this;
+  }
+
 protected:
   /**
    * Implementations should call this method whenever the return value

--- a/src/Device/Port/SpectateFilePort.cpp
+++ b/src/Device/Port/SpectateFilePort.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SpectateFilePort.hpp"
+#include "Device/Driver/Condor3Spectate.hpp"
+#include "io/DataHandler.hpp"
+
+#include <stdexcept>
+
+SpectateFilePort::SpectateFilePort(Path _path, const char *_own_cn,
+                                   PortListener *listener,
+                                   DataHandler &handler) noexcept
+  :Port(listener, handler), path(_path)
+{
+  if (_own_cn != nullptr)
+    own_cn = _own_cn;
+}
+
+PortState
+SpectateFilePort::GetState() const noexcept
+{
+  return PortState::READY;
+}
+
+std::size_t
+SpectateFilePort::Write(std::span<const std::byte> src)
+{
+  return src.size();
+}
+
+bool
+SpectateFilePort::Drain()
+{
+  return true;
+}
+
+void
+SpectateFilePort::Flush()
+{
+}
+
+unsigned
+SpectateFilePort::GetBaudrate() const noexcept
+{
+  return 0;
+}
+
+void
+SpectateFilePort::SetBaudrate(unsigned)
+{
+}
+
+bool
+SpectateFilePort::StopRxThread()
+{
+  running = false;
+  timer.Cancel();
+  return true;
+}
+
+bool
+SpectateFilePort::StartRxThread()
+{
+  running = true;
+  Poll();
+  timer.Schedule(std::chrono::seconds(1));
+  return true;
+}
+
+std::size_t
+SpectateFilePort::Read(std::span<std::byte>)
+{
+  return 0;
+}
+
+[[noreturn]] void
+SpectateFilePort::WaitRead(std::chrono::steady_clock::duration)
+{
+  throw std::runtime_error("Cannot read from SpectateFilePort");
+}
+
+void
+SpectateFilePort::Poll() noexcept
+{
+  Condor3SpectateBuilder::Lines lines;
+  const Condor3SpectateReference *ref = nullptr;
+  if (device != nullptr) {
+    const Condor3SpectateReference &live_ref = device->GetLiveReference();
+    if (live_ref.defined)
+      ref = &live_ref;
+  }
+
+  if (!Condor3SpectateBuilder::Build(path, own_cn, lines, ref))
+    return;
+
+  for (const auto &line : lines) {
+    handler.DataReceived(std::span{
+      reinterpret_cast<const std::byte *>(line.c_str()), line.length()});
+    handler.DataReceived(std::span{
+      reinterpret_cast<const std::byte *>("\r\n"), 2});
+  }
+}
+
+void
+SpectateFilePort::OnTimer() noexcept
+{
+  if (!running)
+    return;
+
+  Poll();
+  timer.Schedule(std::chrono::seconds(1));
+}

--- a/src/Device/Port/SpectateFilePort.hpp
+++ b/src/Device/Port/SpectateFilePort.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Port.hpp"
+#include "system/Path.hpp"
+#include "ui/event/Timer.hpp"
+#include "util/StaticString.hxx"
+
+class Condor3SpectateDevice;
+
+/**
+ * Poll a Condor Spectate.json file and inject FLARM NMEA into the
+ * device pipeline.
+ */
+class SpectateFilePort final : public Port {
+  const Path path;
+  StaticString<128> own_cn;
+  Condor3SpectateDevice *device = nullptr;
+
+  UI::Timer timer{[this]{ OnTimer(); }};
+  bool running = false;
+
+  void OnTimer() noexcept;
+  void Poll() noexcept;
+
+public:
+  SpectateFilePort(Path _path, const char *_own_cn,
+                   PortListener *listener, DataHandler &handler) noexcept;
+
+  void SetDevice(Condor3SpectateDevice *_device) noexcept {
+    device = _device;
+  }
+
+  /* virtual methods from class Port */
+  PortState GetState() const noexcept override;
+  std::size_t Write(std::span<const std::byte> src) override;
+  bool Drain() override;
+  void Flush() override;
+  unsigned GetBaudrate() const noexcept override;
+  void SetBaudrate(unsigned baud_rate) override;
+  bool StopRxThread() override;
+  bool StartRxThread() override;
+  std::size_t Read(std::span<std::byte> dest) override;
+
+  [[noreturn]]
+  void WaitRead(std::chrono::steady_clock::duration timeout) override;
+};

--- a/src/Device/Register.cpp
+++ b/src/Device/Register.cpp
@@ -26,6 +26,7 @@
 #include "Device/Driver/XCOM760.hpp"
 #include "Device/Driver/Condor.hpp"
 #include "Device/Driver/Condor3UDP.hpp"
+#include "Device/Driver/Condor3Spectate.hpp"
 #include "Device/Driver/Leonardo.hpp"
 #include "Device/Driver/Flytec.hpp"
 #include "Device/Driver/ILEC.hpp"
@@ -93,6 +94,7 @@ static const struct DeviceRegister *const driver_list[] = {
   &acd_driver,
   &condor3_driver,
   &condor3_udp_driver,
+  &condor3_spectate_driver,
   &lx_eos_driver,
   &stratux_driver,
   &loe_fgren_driver,

--- a/src/Device/device.cpp
+++ b/src/Device/device.cpp
@@ -34,6 +34,7 @@ DeviceConfigOverlaps(const DeviceConfig &a, const DeviceConfig &b)
   case DeviceConfig::PortType::SERIAL:
   case DeviceConfig::PortType::PTY:
   case DeviceConfig::PortType::ANDROID_USB_SERIAL:
+  case DeviceConfig::PortType::SPECTATE_FILE:
     return a.path.equals(b.path);
 
   case DeviceConfig::PortType::RFCOMM:

--- a/src/Dialogs/Device/DeviceEditWidget.cpp
+++ b/src/Dialogs/Device/DeviceEditWidget.cpp
@@ -19,6 +19,8 @@ enum ControlIndex {
   Port, EngineTypes, BaudRate, BulkBaudRate,
   IP_ADDRESS,
   TCPPort,
+  SpectatePath,
+  OwnCallsign,
   I2CBus, I2CAddr, PressureUsage, Driver, UseSecondDriver, SecondDriver,
   SyncFromDevice, SyncToDevice, SendPosition, PolarSyncMode,
   K6Bt,
@@ -138,6 +140,9 @@ DeviceEditWidget::SetConfig(const DeviceConfig &_config) noexcept
        flag and re-enable the device */
     config.enabled = true;
 
+  if (config.port_type == DeviceConfig::PortType::SPECTATE_FILE)
+    config.ApplySpectateDefaults();
+
   WndProperty &port_control = GetControl(Port);
   DataFieldEnum &port_df = *(DataFieldEnum *)port_control.GetDataField();
   SetPort(port_df, config);
@@ -147,6 +152,8 @@ DeviceEditWidget::SetConfig(const DeviceConfig &_config) noexcept
   LoadValueEnum(BulkBaudRate, config.bulk_baud_rate);
   LoadValueEnum(IP_ADDRESS, config.ip_address);
   LoadValueEnum(TCPPort, config.tcp_port);
+  LoadValue(SpectatePath, config.path);
+  LoadValue(OwnCallsign, config.port_name);
   LoadValueEnum(I2CBus, config.i2c_bus);
   LoadValueEnum(I2CAddr, config.i2c_addr);
   LoadValueEnum(PressureUsage, config.press_use);
@@ -285,6 +292,8 @@ DeviceEditWidget::UpdateVisibilities() noexcept
                 SupportsBulkBaudRate(GetDataField(Driver)));
   SetRowAvailable(IP_ADDRESS, DeviceConfig::UsesIPAddress(type));
   SetRowAvailable(TCPPort, DeviceConfig::UsesTCPPort(type));
+  SetRowAvailable(SpectatePath, type == DeviceConfig::PortType::SPECTATE_FILE);
+  SetRowAvailable(OwnCallsign, type == DeviceConfig::PortType::SPECTATE_FILE);
   SetRowAvailable(I2CBus, DeviceConfig::UsesI2C(type));
   SetRowAvailable(I2CAddr, DeviceConfig::UsesI2C(type) &&
                 type != DeviceConfig::PortType::NUNCHUCK);
@@ -360,6 +369,20 @@ DeviceEditWidget::Prepare(ContainerWindow &parent,
   FillTCPPorts(*tcp_port_df);
   tcp_port_df->SetValue(config.tcp_port);
   Add(_("TCP port"), nullptr, tcp_port_df);
+
+  DataFieldString *spectate_path_df = new DataFieldString("", this);
+  spectate_path_df->SetValue(config.path);
+  Add(_("Spectate file"),
+      _("Full path to Condor 3 Spectate.json. "
+        "Default: c:\\condor3\\logs\\spectate.json"),
+      spectate_path_df);
+
+  DataFieldString *own_callsign_df = new DataFieldString("", this);
+  own_callsign_df->SetValue(config.port_name);
+  Add(_("Own callsign"),
+      _("Competition number of your glider in Spectate.json "
+        "(excluded from traffic, used as position reference)."),
+      own_callsign_df);
 
   DataFieldEnum *i2c_bus_df = new DataFieldEnum(this);
   FillI2CBus(*i2c_bus_df);
@@ -476,10 +499,18 @@ FinishPortField(DeviceConfig &config, const DataFieldEnum &df) noexcept
   case DeviceConfig::PortType::UDP_LISTENER:
   case DeviceConfig::PortType::RFCOMM_SERVER:
   case DeviceConfig::PortType::GLIDER_LINK:
+  case DeviceConfig::PortType::SPECTATE_FILE:
     if (new_type == config.port_type)
       return false;
 
+    /* Drop a stale serial path (e.g. COMx:) before applying Spectate
+       defaults; otherwise ApplySpectateDefaults leaves it unchanged. */
+    if (new_type == DeviceConfig::PortType::SPECTATE_FILE)
+      config.path.clear();
+
     config.port_type = new_type;
+    if (new_type == DeviceConfig::PortType::SPECTATE_FILE)
+      config.ApplySpectateDefaults();
     return true;
 
   case DeviceConfig::PortType::SERIAL:
@@ -547,6 +578,11 @@ DeviceEditWidget::Save(bool &_changed) noexcept
   if (config.UsesTCPPort())
     changed |= SaveValueEnum(TCPPort, config.tcp_port);
 
+  if (config.port_type == DeviceConfig::PortType::SPECTATE_FILE) {
+    changed |= SaveValue(SpectatePath, config.path);
+    changed |= SaveValue(OwnCallsign, config.port_name);
+  }
+
   if (config.UsesI2C()) {
     changed |= SaveValueEnum(I2CBus, config.i2c_bus);
     changed |= SaveValueEnum(I2CAddr, config.i2c_addr);
@@ -586,6 +622,16 @@ DeviceEditWidget::Save(bool &_changed) noexcept
 void
 DeviceEditWidget::OnModified(DataField &df) noexcept
 {
+  if (IsDataField(Port, df)) {
+    const auto type = GetPortType((const DataFieldEnum &)df);
+    if (type == DeviceConfig::PortType::SPECTATE_FILE) {
+      if (config.port_type != DeviceConfig::PortType::SPECTATE_FILE)
+        config.path.clear();
+      config.ApplySpectateDefaults();
+      LoadValue(SpectatePath, config.path);
+    }
+  }
+
   if (IsDataField(Port, df) || IsDataField(Driver, df) ||
       IsDataField(UseSecondDriver, df) || IsDataField(K6Bt, df))
     UpdateVisibilities();

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -51,6 +51,8 @@ static constexpr struct {
   { DeviceConfig::PortType::TCP_LISTENER, N_("TCP port") },
   { DeviceConfig::PortType::UDP_LISTENER, N_("UDP port") },
 
+  { DeviceConfig::PortType::SPECTATE_FILE, N_("Condor 3 Spectate file") },
+
   { DeviceConfig::PortType::SERIAL, nullptr } /* sentinel */
 };
 
@@ -300,6 +302,7 @@ SetPort(DataFieldEnum &df, const DeviceConfig &config) noexcept
   case DeviceConfig::PortType::PTY:
   case DeviceConfig::PortType::RFCOMM_SERVER:
   case DeviceConfig::PortType::GLIDER_LINK:
+  case DeviceConfig::PortType::SPECTATE_FILE:
     break;
 
   case DeviceConfig::PortType::SERIAL:

--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -347,8 +347,8 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
     p.y = 0;
   }
 
-  if ((!enable_north_up) && traffic.relative_east && traffic.relative_north) {
-    // Rotate x and y to have a track up display
+  if (!enable_north_up) {
+    // Track-up: rotate even when east or north is zero (cardinal bearing).
     p = fr.Rotate(p);
   }
 

--- a/src/Profile/DeviceConfig.cpp
+++ b/src/Profile/DeviceConfig.cpp
@@ -38,6 +38,7 @@ static const char *const port_type_strings[] = {
   "ble_hm10",
   "glider_link",
   "android_usb_serial",
+  "spectate_file",
   NULL
 };
 
@@ -149,11 +150,20 @@ Profile::GetDeviceConfig(const ProfileMap &map, unsigned n,
     config.tcp_port = 4353;
 
   config.path.clear();
-  if ((!have_port_type ||
-       config.port_type == DeviceConfig::PortType::ANDROID_USB_SERIAL ||
-       config.port_type == DeviceConfig::PortType::SERIAL) &&
-      !LoadPath(map, config, n) && LoadPortIndex(map, config, n))
+  if (config.port_type == DeviceConfig::PortType::SPECTATE_FILE) {
+    /* Spectate uses Path directly; no COM-index compatibility fallback. */
+    LoadPath(map, config, n);
+  } else if ((!have_port_type ||
+              config.port_type == DeviceConfig::PortType::ANDROID_USB_SERIAL ||
+              config.port_type == DeviceConfig::PortType::SERIAL) &&
+             !LoadPath(map, config, n) && LoadPortIndex(map, config, n))
     config.port_type = DeviceConfig::PortType::SERIAL;
+
+  if (const char *name = make_port_name("PortName"); name != nullptr)
+    map.Get(name, config.port_name);
+
+  if (config.port_type == DeviceConfig::PortType::SPECTATE_FILE)
+    config.ApplySpectateDefaults();
 
   if (const char *name = make_port_name("BaudRate");
       name == nullptr || !map.Get(name, config.baud_rate)) {
@@ -276,6 +286,9 @@ Profile::SetDeviceConfig(ProfileMap &map,
 
   if (const char *name = make_port_name("Path"); name != nullptr)
     map.Set(name, config.path);
+
+  if (const char *name = make_port_name("PortName"); name != nullptr)
+    map.Set(name, config.port_name);
 
   if (const char *name = make_port_name("BaudRate"); name != nullptr)
     map.Set(name, config.baud_rate);


### PR DESCRIPTION
## Summary

- Add native **Condor3Spectate** driver and **spectate_file** port type that polls `Spectate.json` and injects FLARM NMEA (`$PFLAA`, `$PFLAM`, `$PFLAU`) for Condor 3 multiplayer traffic
- Use live merged GPS (Condor3UDP) as coordinate reference for relative N/E when available, keeping track-up FLARM radar aligned during turns
- Parse Condor JSON numeric fields delivered as strings (heading, speed, vario, altitude); convert Spectate speed from km/h to m/s for PFLAA (FTD-012)
- Add `Port::GetImplementationPort()` so `CreateOnPort` hooks work through `DumpPort` (fixes silent no-data after reconnect)
- Fix Condor3UDP spurious track fallback from vx/vy (~120° bearing jumps)
- Fix FLARM track-up rotation at cardinal bearings (`FlarmTrafficWindow`)

## Known limitations

- **Spectate.json path must be entered manually** in Config → Devices → Spectate file field (plain text, no file picker yet). Example: `c:\condor3\logs\spectate.json`
- No translation update in this PR (`make update-po` deferred)

## Setup (typical)

| Port | Driver | Type | Setting |
|------|--------|------|---------|
| A | Condor3UDP | UDP listener | 55278 |
| C | Condor3Spectate | Condor 3 Spectate file | path + own CN (e.g. `I8`) |

## Test plan

- [ ] Build `TARGET=UNIX` and `TARGET=WIN64` with `WERROR=y`
- [ ] Condor 3 multiplayer: enable Spectate, configure device with own competition number
- [ ] Manually enter Spectate.json path and verify traffic appears on FLARM radar
- [ ] Verify bearing, heading arrow, and displayed speed (~120–260 km/h)
- [ ] Enable NMEA logger; confirm `$PFLAA` ground-speed field is m/s (≈ km/h ÷ 3.6) and track matches Spectate.json heading
- [ ] Turn/sim reconnect: Spectate device should not show persistent "No data"
- [ ] Track-up radar: traffic due north/south or east/west draws in the correct place
- [ ] Condor3UDP alone: track follows compass; no vx/vy-derived jumps after compass expiry