### PR TITLE
po: Deduplicate translatable strings and complete v7.45 catalogs

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -912,7 +912,7 @@ type=key
 data=7
 event=UploadIGCFile
 event=Mode default
-label=WeGlide Upload$(CheckWeGlide)
+label=WeGlide Upload
 location=6
 
 mode=Config2
@@ -1663,7 +1663,7 @@ type=key
 data=0
 event=UploadIGCFile
 event=Mode default
-label=WeGlide Upload$(CheckWeGlide)
+label=WeGlide Upload
 location=43
 
 mode=RemoteStick

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1082,7 +1082,7 @@ type=key
 data=6
 event=FlarmTraffic
 event=Mode default
-label=FLARM Radar$(CheckFLARM)
+label=FLARM Radar
 location=5
 
 mode=Info1
@@ -1541,7 +1541,7 @@ mode=RemoteStick
 type=key
 data=0
 event=FlarmTraffic
-label=FLARM Radar$(CheckFLARM)
+label=FLARM Radar
 location=28
 
 mode=RemoteStick
@@ -1592,7 +1592,7 @@ type=key
 data=0
 event=ThermalAssistant
 event=Mode default
-label=Thermal Assistant$(CheckCircling)
+label=Thermal Assistant
 location=34
 
 mode=RemoteStick

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -732,7 +732,7 @@ type=key
 data=9
 event=Setup Target
 event=Mode default
-label=Target Show$(CheckTask)$(CheckTaskResumed)
+label=Target$(CheckTask)$(CheckTaskResumed)
 location=8
 
 # -------------
@@ -854,7 +854,7 @@ type=key
 data=6
 event=Setup System
 event=Mode default
-label=System
+label=Configuration
 location=5
 
 mode=Config1
@@ -862,7 +862,7 @@ type=key
 data=7
 event=Setup Plane
 event=Mode default
-label=Plane
+label=Planes
 location=6
 
 mode=Config1
@@ -878,7 +878,7 @@ type=key
 data=9
 event=Setup Basic
 event=Mode default
-label=Flight
+label=Flight Setup
 location=8
 
 mode=Config1
@@ -1090,7 +1090,7 @@ type=key
 data=7
 event=Weather
 event=Mode default
-label=Weather Setup
+label=Weather
 location=6
 
 mode=Info1
@@ -1156,7 +1156,7 @@ type=key
 data=9
 event=FlarmDetails
 event=Mode default
-label=Traffic List
+label=Traffic
 location=8
 
 mode=Info2
@@ -1335,7 +1335,7 @@ type=key
 data=0
 event=Setup Wind
 event=Mode default
-label=Setup Wind
+label=Wind
 location=2
 
 mode=RemoteStick
@@ -1343,7 +1343,7 @@ type=key
 data=0
 event=Setup System
 event=Mode default
-label=Setup System
+label=Configuration
 location=3
 
 mode=RemoteStick
@@ -1351,7 +1351,7 @@ type=key
 data=0
 event=Setup Airspace
 event=Mode default
-label=Settings Airspace$(CheckAirspace)
+label=Airspace$(CheckAirspace)
 location=4
 
 mode=RemoteStick
@@ -1359,7 +1359,7 @@ type=key
 data=0
 event=Setup Plane
 event=Mode default
-label=Setup Plane
+label=Planes
 location=5
 
 mode=RemoteStick
@@ -1429,7 +1429,7 @@ type=key
 data=0
 event=Calculator
 event=Mode default
-label=Task
+label=Task Manager
 location=14
 
 mode=RemoteStick
@@ -1464,7 +1464,7 @@ type=key
 data=0
 event=Setup Target
 event=Mode default
-label=Target Show$(CheckTask)$(CheckTaskResumed)
+label=Target$(CheckTask)$(CheckTaskResumed)
 location=18
 
 mode=RemoteStick
@@ -1526,7 +1526,7 @@ type=key
 data=0
 event=Weather
 event=Mode default
-label=Weather Setup
+label=Weather
 location=26
 
 mode=RemoteStick
@@ -1655,7 +1655,7 @@ type=key
 data=0
 event=DistanceRings show
 event=DistanceRings toggle
-label=Dist. Rings\n$(DistanceRingsToggleActionName)
+label=Distance Rings\n$(DistanceRingsToggleActionName)
 location=42
 
 mode=RemoteStick
@@ -1670,7 +1670,7 @@ mode=RemoteStick
 type=key
 data=0
 event=Exit
-label=Quit XCSoar
+label=Quit
 location=44
 
 mode=RemoteStick

--- a/build/gettext.mk
+++ b/build/gettext.mk
@@ -14,6 +14,7 @@ GETTEXT_SOURCES = $(XCSOAR_SOURCES) \
 	$(LIBMAPWINDOW_SOURCES) \
 	$(LIBCOMPUTER_SOURCES) \
 	$(wildcard $(SRC)/Dialogs/Device/Vega/*Parameters.hpp) \
+	$(SRC)/Language/FormatText.hpp \
 	$(SRC)/Weather/Rasp/RaspStore.cpp
 GETTEXT_EVENTS = Data/Input/default.xci
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -801,7 +801,7 @@ When editing a page, the following options are available for map pages:
   \emph{RASP}, \emph{EDL}, or \emph{XCTherm}.  RASP requires a loaded RASP
   file; EDL and XCTherm require network-capable builds with the respective
   weather provider configured.
-\item[Layer / level]  When \emph{Map overlay} is \emph{RASP}, selects
+\item[Layer / Level]  When \emph{Map overlay} is \emph{RASP}, selects
   which RASP field is displayed on this page.  When the overlay is
   \emph{EDL}, selects the pressure level (altitude band): \emph{Auto}
   follows aircraft altitude when the page is opened; a fixed level is

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -16,6 +16,7 @@
 #include "Look/DialogLook.hpp"
 #include "util/Compiler.h"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "UIGlobals.hpp"
 #include "NetComponents.hpp"
 #include "Components.hpp"
@@ -482,7 +483,7 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       if (now < notam.start_time) {
         const auto starts_in = FormatRelativeNotamTime(notam.start_time - now);
         StaticString<64> status;
-        status.Format(_("Starts in %s"), starts_in.c_str());
+        FormatStartsIn(status, starts_in.c_str());
         first_row_text += " • ";
         first_row_text += status.c_str();
       } else if (!is_perm && now > notam.end_time) {

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -24,6 +24,7 @@
 #include <Message.hpp>
 #include "Geo/AltitudeReference.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "TransponderMode.hpp"
 #include "LogFile.hpp"
 #include "util/StaticString.hxx"
@@ -362,7 +363,7 @@ NOTAMDetailsWidget::AddNOTAMValidity(
         time_str.Format(_("%dd"), static_cast<int>(days));
       }
     }
-    buffer.Format(_("Starts in %s"), time_str.c_str());
+    FormatStartsIn(buffer, time_str.c_str());
   } else if (!notam_opt->end_time_permanent && now > notam_opt->end_time) {
     // Expired
     const auto expired_ago =

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -80,7 +80,7 @@ public:
   void CreateButtons(WidgetDialog &dialog) {
     self_dialog = &dialog;
     ack_button = dialog.AddButton(_("ACK"), [this](){ Ack(); });
-    ack_day_button = dialog.AddButton(_("ACK Day"), [this](){ AckDay(); });
+    ack_day_button = dialog.AddButton(_("Ack Day"), [this](){ AckDay(); });
     enable_button = dialog.AddButton(_("Enable"), [this](){ Enable(); });
     radio_button = dialog.AddButton(_("Radio"), [this](){ Radio(); });
     details_button = dialog.AddButton(_("Details"), [this](){ Details(); });

--- a/src/Dialogs/DataManagement/BackupRestorePanel.cpp
+++ b/src/Dialogs/DataManagement/BackupRestorePanel.cpp
@@ -18,6 +18,7 @@
 #include "Widget/ListWidget.hpp"
 #include "util/StaticString.hxx"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "LocalPath.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "time/BrokenDateTime.hpp"
@@ -82,7 +83,9 @@ struct BackupJob final : public Job {
     auto dev = FindDeviceByName(target_device);
     if (!dev) {
       aborted = true;
-      error_message = _("Target device not found.");
+      StaticString<64> message;
+      FormatDeviceNotFound(message, N_("Target"));
+      error_message = message;
       return;
     }
 
@@ -129,7 +132,9 @@ struct RestoreJob final : public Job {
     auto dev = FindDeviceByName(device_path);
     if (!dev) {
       aborted = true;
-      error_message = _("Source device not found.");
+      StaticString<64> message;
+      FormatDeviceNotFound(message, N_("Source"));
+      error_message = message;
       return;
     }
 
@@ -413,7 +418,9 @@ ShowBackupManagerDialogWithTarget(const AllocatedPath &initial_target)
 
     auto dev = FindDeviceByName(container_ptr->target_device_path);
     if (!dev) {
-      ShowMessageBox(_("Target device not found."), _("Delete backup"), MB_OK | MB_ICONERROR);
+      StaticString<64> message;
+      FormatDeviceNotFound(message, N_("Target"));
+      ShowMessageBox(message, _("Delete backup"), MB_OK | MB_ICONERROR);
       return;
     }
 

--- a/src/Dialogs/DataManagement/DataManagement.cpp
+++ b/src/Dialogs/DataManagement/DataManagement.cpp
@@ -24,7 +24,7 @@ public:
 
   void Prepare([[maybe_unused]] ContainerWindow &parent,
                [[maybe_unused]] const PixelRect &rc) noexcept override {
-    AddButton(_("Navigation & Flight Resources"), [](){ ShowConfigPanel(_("Site files"), CreateSiteConfigPanel); });
+    AddButton(_("Navigation & Flight Resources"), [](){ ShowConfigPanel(_("Site Files"), CreateSiteConfigPanel); });
     AddButton(_("Download manager"), [](){ ShowFileManager(); });
     AddButton(_("Export flights"), [](){ ShowExportFlightsDialog(); });
     AddButton(_("Import data"), [](){ ShowImportDataDialog(); });

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
@@ -18,15 +18,16 @@
 #include "Storage/StorageDevice.hpp"
 #include "system/FileUtil.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "Form/CheckBox.hpp"
 #include "Screen/Layout.hpp"
 #include "IGC/IgcMetaCache.hpp"
 #include "Job/Job.hpp"
 #include "Operation/Operation.hpp"
+#include "util/StaticString.hxx"
 #include "net/client/WeGlide/UploadIGCFile.hpp"
 #include "net/client/WeGlide/Settings.hpp"
 #include "Interface.hpp"
-#include "util/StaticString.hxx"
 #include "ui/event/Notify.hpp"
 
 #include <vector>
@@ -146,7 +147,9 @@ PerformExport(FileMultiSelectWidget *file_widget)
 
   auto device = FindDeviceByName(target);
   if (!device) {
-    ShowMessageBox(_("Target device not found."),
+    StaticString<64> message;
+    FormatDeviceNotFound(message, N_("Target"));
+    ShowMessageBox(message,
                    _("Export flights"), MB_OK | MB_ICONERROR);
     return;
   }

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
@@ -40,19 +40,6 @@ static constexpr char EXPORT_FLIGHTS_SUBFOLDER[] = "xcsoar_flights";
 
 static IgcMetaCache igc_cache;
 
-/**
- * Check if WeGlide is properly configured for uploads.
- * Requires pilot ID and birthdate to be set.
- */
-static bool
-IsWeGlideConfigured() noexcept
-{
-  const WeGlideSettings &settings = CommonInterface::GetComputerSettings().weglide;
-  return settings.enabled &&
-         settings.pilot_id != 0 &&
-         settings.pilot_birthdate.IsPlausible();
-}
-
 // Export job that runs in background thread
 struct ExportJob final : public Job {
   std::vector<Path> selected_files;
@@ -180,7 +167,7 @@ PerformExport(FileMultiSelectWidget *file_widget)
 static void
 PerformWeGlideUpload(FileMultiSelectWidget *file_widget)
 {
-  if (!IsWeGlideConfigured()) {
+  if (!CommonInterface::GetComputerSettings().weglide.IsConfigured()) {
     ShowMessageBox(_("WeGlide is not configured. Please set your pilot ID and birthdate in the settings."),
                    _("WeGlide Upload"), MB_OK | MB_ICONERROR);
     return;

--- a/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
+++ b/src/Dialogs/Device/FLARM/RangeConfigWidget.cpp
@@ -64,7 +64,7 @@ FLARMRangeConfigWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
 
   if (hardware.isPowerFlarm()) {
     vrange = GetUnsignedValue(device, "VRANGE", 500);
-    AddInteger(_("Vertical range"), NULL, "%d m", "%d", 100, 2000, 100, vrange);
+    AddInteger(_("Vertical Range"), NULL, "%d m", "%d", 100, 2000, 100, vrange);
   }
 
   if (hardware.hasADSB()) {

--- a/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
+++ b/src/Dialogs/Device/LX/ManageLXNAVVarioDialog.cpp
@@ -50,7 +50,7 @@ ManageLXNAVVarioWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[mayb
   if (!info.hardware_version.empty())
     buffer.UnsafeAppendASCII(info.hardware_version.c_str());
   else
-    buffer.SetASCII(_("unknown"));
+    buffer.SetASCII(_("Unknown"));
   AddReadOnly(_("Hardware version"), NULL, buffer.c_str());
 
   if (!info.software_version.empty()) {

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -276,7 +276,7 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
     OnDetailsClicked();
   });
 
-  goto_button = dialog.AddButton(_("Goto"), [this](){
+  goto_button = dialog.AddButton(_("GoTo"), [this](){
     OnGotoClicked();
   });
 

--- a/src/Dialogs/MultiFilePicker.cpp
+++ b/src/Dialogs/MultiFilePicker.cpp
@@ -29,7 +29,7 @@ GetFileName(const FileMultiSelectWidget::FileItem &item) noexcept
 
   /* file configured in profile but not found on disk */
   static StaticString<256> buffer;
-  buffer.Format("%s [%s]", name, _("not found"));
+  buffer.Format("%s [%s]", name, _("Not found"));
   return buffer.c_str();
 }
 

--- a/src/Dialogs/Settings/Panels/AudioVarioConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/AudioVarioConfigPanel.cpp
@@ -57,7 +57,7 @@ AudioVarioConfigPanel::Prepare(ContainerWindow &parent,
 
   const auto &settings = CommonInterface::GetUISettings().sound.vario;
 
-  AddBoolean(_("Audio vario"),
+  AddBoolean(_("Audio Vario"),
              _("Emulate the sound of an electronic vario."),
              settings.enabled);
 

--- a/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/GaugesConfigPanel.cpp
@@ -132,7 +132,7 @@ GaugesConfigPanel::Prepare(ContainerWindow &parent,
 
   RowFormWidget::Prepare(parent, rc);
 
-  AddBoolean(_("FLARM radar"),
+  AddBoolean(_("FLARM Radar"),
              _("This enables the display of the FLARM radar gauge. The track bearing of the target relative to the track bearing of the aircraft is displayed as an arrow head, and a triangle pointing up or down shows the relative altitude of the target relative to you. In all modes, the color of the target indicates the threat level."),
              ui_settings.traffic.enable_gauge);
 
@@ -146,13 +146,13 @@ GaugesConfigPanel::Prepare(ContainerWindow &parent,
           (unsigned)ui_settings.traffic.gauge_location);
   SetExpertRow(AppFlarmLocation);
 
-  AddEnum(_("Thermal assistant"),
+  AddEnum(_("Thermal Assistant"),
             _("Enable and select the position of the thermal assistant when overlayed on the main screen."),
             thermal_assistant_position_list,
             (unsigned)ui_settings.thermal_assistant_position,
             this);
 
-  AddBoolean(_("Thermal band"),
+  AddBoolean(_("Thermal Band"),
              _("This enables the display of the thermal profile (climb band) display on the map."),
              map_settings.show_thermal_profile);
 

--- a/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LoggerConfigPanel.cpp
@@ -85,7 +85,7 @@ LoggerConfigPanel::Prepare(ContainerWindow &parent,
           auto_logger_list, (unsigned)logger.auto_logger);
   SetExpertRow(DisableAutoLogger);
 
-  AddBoolean(_("NMEA logger"),
+  AddBoolean(_("NMEA Logger"),
              _("Enable the NMEA logger on startup? If this option is disabled, "
                  "the NMEA logger can still be started manually."),
              logger.enable_nmea_logger);

--- a/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NetworkConfigPanel.cpp
@@ -6,6 +6,7 @@
 #include "Dialogs/WifiDialog.hpp"
 #include "Form/DataField/Listener.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "UIGlobals.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "net/State.hpp"
@@ -138,7 +139,10 @@ GetBackendHelp() noexcept
 #if defined(KOBO) || defined(HAVE_LINUX_NET_WIFI) || defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)
   return _("WiFi service used by the device.");
 #else
-  return _("Platform/backend information is not available in this build.");
+  static StaticString<128> message;
+  FormatFeatureNotAvailableInThisBuild(message,
+                                       N_("Platform/backend information"));
+  return message.c_str();
 #endif
 }
 
@@ -243,8 +247,11 @@ OpenPlatformWifiList(std::function<void()> refresh) noexcept
                  _("Connectivity"), MB_OK);
 #else
   (void)refresh;
-  ShowMessageBox(_("WiFi management is not available in this build."),
-                 _("Connectivity"), MB_OK);
+  {
+    StaticString<128> message;
+    FormatFeatureNotAvailableInThisBuild(message, N_("WiFi management"));
+    ShowMessageBox(message, _("Connectivity"), MB_OK);
+  }
 #endif
 
 #if defined(ANDROID) || defined(_WIN32) || (defined(__APPLE__) && TARGET_OS_IPHONE)

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -191,7 +191,7 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
 
   switch (value.overlay) {
   case PageLayout::Overlay::RASP: {
-    control.SetCaption(_("RASP layer"));
+    control.SetCaption(_("RASP Layer"));
     control.SetHelpText(
       _("RASP weather layer to display on this map page."));
 
@@ -214,7 +214,7 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
 
 #ifdef HAVE_EDL
   case PageLayout::Overlay::EDL:
-    control.SetCaption(_("EDL level"));
+    control.SetCaption(_("EDL Level"));
     control.SetHelpText(
       _("EDL pressure level / altitude band for this map page. "
         "Auto follows aircraft altitude when the page is opened."));
@@ -250,11 +250,11 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
   case PageLayout::Overlay::EDL:
 #endif
   case PageLayout::Overlay::MAX:
-    control.SetCaption(_("Layer / level"));
+    control.SetCaption(_("Layer / Level"));
     control.SetHelpText(
       _("Select a RASP or EDL map overlay to configure its "
         "layer or level for this page."));
-    df.AddChoice(-1, _("n/a"));
+    df.AddChoice(-1, _("N/A"));
     df.SetValue(-1);
     break;
   }
@@ -314,8 +314,8 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
   static constexpr StaticEnumChoice main_list[] = {
     { PageLayout::Main::MAP, N_("Map") },
     { PageLayout::Main::MAP_NORTH_UP, N_("Map (north-up)") },
-    { PageLayout::Main::FLARM_RADAR, N_("FLARM radar") },
-    { PageLayout::Main::THERMAL_ASSISTANT, N_("Thermal assistant") },
+    { PageLayout::Main::FLARM_RADAR, N_("FLARM Radar") },
+    { PageLayout::Main::THERMAL_ASSISTANT, N_("Thermal Assistant") },
     { PageLayout::Main::HORIZON, N_("Horizon") },
     nullptr
   };
@@ -388,7 +388,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
           overlay_list,
           (unsigned)PageLayout::Overlay::NONE, this);
 
-  AddEnum(_("Layer / level"),
+  AddEnum(_("Layer / Level"),
           _("Select a RASP or EDL map overlay to configure its "
             "layer or level for this page."),
           this);

--- a/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
@@ -107,7 +107,7 @@ static constexpr StaticEnumChoice  aircraft_symbol_list[] = {
     N_("Detailed rendered aircraft graphics.") },
   { AircraftSymbol::HANGGLIDER, N_("HangGlider"),
     N_("Simplified hang glider as line graphics, white with black contours.") },
-  { AircraftSymbol::PARAGLIDER, N_("ParaGlider"),
+  { AircraftSymbol::PARAGLIDER, N_("Paraglider"),
     N_("Simplified para glider as line graphics, white with black contours.") },
   nullptr
 };
@@ -136,7 +136,7 @@ SymbolsConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
           _("Display the ground track as a grey line on the map."),
           ground_track_mode_list, (unsigned)settings_map.display_ground_track);
 
-  AddBoolean(_("FLARM traffic"), _("This enables the display of FLARM traffic on the map window."),
+  AddBoolean(_("FLARM Traffic"), _("This enables the display of FLARM traffic on the map window."),
              settings_map.show_flarm_on_map);
 
   AddBoolean(_("Fade traffic"), _("Keep showing traffic for a while after it has disappeared."),

--- a/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
@@ -228,7 +228,7 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
   const MapSettings &settings_map = CommonInterface::GetMapSettings();
   const TerrainRendererSettings &terrain = settings_map.terrain;
 
-  AddBoolean(_("Terrain display"),
+  AddBoolean(_("Terrain Display"),
              _("Draw a digital elevation terrain on the map."),
              terrain.enable);
   GetDataField(EnableTerrain).SetListener(this);

--- a/src/Dialogs/Settings/Panels/UnitsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/UnitsConfigPanel.cpp
@@ -185,7 +185,7 @@ UnitsConfigPanel::Prepare(ContainerWindow &parent,
     { Unit::METER_PER_SECOND, "m/s" },
     nullptr
   };
-  AddEnum(_("Task speed"), _("Units used for task speeds."),
+  AddEnum(_("Task Speed"), _("Units used for task speeds."),
           units_taskspeed_list,
           (unsigned)config.task_speed_unit, this);
   SetExpertRow(UnitsTaskSpeed);

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -387,7 +387,7 @@ void dlgConfigurationShowModal()
   if (dialog.GetChanged()) {
     Profile::Save();
     if (require_restart)
-      ShowMessageBox(_("Changes to configuration saved.  Restart XCSoar to apply changes."),
+      ShowMessageBox(_("Changes to configuration saved. Restart XCSoar to apply changes."),
                   "", MB_OK);
   }
 }

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -182,7 +182,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
                                     Waypoints *waypoints_for_details) noexcept
 {
   if (!select_mode) {
-    goto_button = dialog.AddButton(_("Goto"), [this](){
+    goto_button = dialog.AddButton(_("GoTo"), [this](){
       if (!HasValidSelection())
         return;
 

--- a/src/Dialogs/Task/Manager/WeGlideTasksPanel.cpp
+++ b/src/Dialogs/Task/Manager/WeGlideTasksPanel.cpp
@@ -4,6 +4,7 @@
 #include "WeGlideTasksPanel.hpp"
 #include "Widget/TextWidget.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 
 #ifdef HAVE_HTTP
 #include "Internal.hpp"
@@ -366,7 +367,9 @@ CreateWeGlideTasksPanel([[maybe_unused]] TaskManagerDialog &dialog,
                         [[maybe_unused]] bool *task_modified) noexcept
 {
   auto widget = std::make_unique<TextWidget>();
-  widget->SetText(_("WeGlide is not available in this build."));
+  StaticString<128> message;
+  FormatFeatureNotAvailableInThisBuild(message, "WeGlide");
+  widget->SetText(message);
   return widget;
 }
 

--- a/src/Dialogs/Traffic/TeamCodeDialog.cpp
+++ b/src/Dialogs/Traffic/TeamCodeDialog.cpp
@@ -77,7 +77,7 @@ TeamCodeWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddReadOnly(_("Range"));
   AddReadOnly(_("Bearing"));
   AddReadOnly(_("Rel. bearing"));
-  AddReadOnly(_("Flarm lock"));
+  AddReadOnly(_("Flarm Lock"));
 }
 
 void
@@ -187,7 +187,7 @@ TeamCodeWidget::OnFlarmLockClicked()
 
   if (count == 0) {
     ShowMessageBox(_("Unknown Competition Number"),
-                   _("Not Found"), MB_OK | MB_ICONINFORMATION);
+                   _("Not found"), MB_OK | MB_ICONINFORMATION);
     return;
   }
 

--- a/src/Dialogs/Weather/EdlSettingsWidget.cpp
+++ b/src/Dialogs/Weather/EdlSettingsWidget.cpp
@@ -12,6 +12,7 @@
 #include "Form/Edit.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "PageSettings.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
@@ -414,8 +415,9 @@ void
 EdlSettingsWidget::PrecacheDay()
 {
 #if !defined(HAVE_HTTP) || !defined(HAVE_EDL)
-  ShowMessageBox(_("HTTP support is not available in this build."),
-                 _("Weather"), MB_OK);
+  StaticString<128> message;
+  FormatFeatureNotAvailableInThisBuild(message, N_("HTTP support"));
+  ShowMessageBox(message, _("Weather"), MB_OK);
 #else
   EDL::EnsureInitialised();
   EDL::RequestPrecacheDay(EDL::GetForecastTime());

--- a/src/Dialogs/Weather/NOAADetails.cpp
+++ b/src/Dialogs/Weather/NOAADetails.cpp
@@ -4,6 +4,7 @@
 #include "NOAADetails.hpp"
 #include "Dialogs/Message.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "Weather/Features.hpp"
 
 #ifdef HAVE_NOAA
@@ -94,8 +95,7 @@ inline void
 NOAADetailsWidget::RemoveClicked()
 {
   StaticString<256> tmp;
-  tmp.Format(_("Do you want to remove station %s?"),
-             station_iterator->GetCodeT());
+  FormatRemoveStationPrompt(tmp, station_iterator->GetCodeT());
 
   if (ShowMessageBox(tmp, _("Remove"), MB_YESNO) == IDNO)
     return;

--- a/src/Dialogs/Weather/NOAAList.cpp
+++ b/src/Dialogs/Weather/NOAAList.cpp
@@ -5,6 +5,7 @@
 #include "NOAADetails.hpp"
 #include "Dialogs/Message.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "Weather/Features.hpp"
 
 #ifdef HAVE_NOAA
@@ -216,8 +217,7 @@ NOAAListWidget::RemoveClicked()
   assert(index < stations.size());
 
   StaticString<256> tmp;
-  tmp.Format(_("Do you want to remove station %s?"),
-             stations[index].code.c_str());
+  FormatRemoveStationPrompt(tmp, stations[index].code.c_str());
 
   if (ShowMessageBox(tmp, _("Remove"), MB_YESNO) == IDNO)
     return;

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -26,6 +26,7 @@
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "Interface.hpp"
 #include "util/StaticString.hxx"
 
@@ -76,8 +77,10 @@ public:
 static std::unique_ptr<Widget>
 CreateEDLUnavailableWidget() noexcept
 {
-  return std::make_unique<EDLUnavailableWidget>(
-    _("EDL weather is not available because this build has no OpenGL renderer."));
+  static StaticString<128> message;
+  FormatFeatureNotAvailableInThisBuildWithoutOpenGLRenderer(
+    message, N_("EDL weather"));
+  return std::make_unique<EDLUnavailableWidget>(message.c_str());
 }
 #endif
 

--- a/src/Dialogs/WifiDialog.cpp
+++ b/src/Dialogs/WifiDialog.cpp
@@ -15,6 +15,7 @@
 #include "Screen/Layout.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "util/Exception.hxx"
+#include "Language/FormatText.hpp"
 #include "Widget/ListWidget.hpp"
 #include "net/wifi/WifiBackend.hpp"
 #include "net/wifi/WifiError.hpp"
@@ -487,7 +488,7 @@ WifiListWidget::UpdateList()
     networks.clear();
   } catch (...) {
     LogFormat("WiFi dialog refresh failed: unknown exception");
-    refresh_error = _("The operation failed.");
+    refresh_error = OperationFailedText();
     networks.clear();
   }
 

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -244,7 +244,7 @@ GetConfigurationHelpText()
     "Show thermal locations from thermalmap.info on the map\n\n"
     "- [%s] [Safety factors](xcsoar://config/safety) - "
     "Set arrival height, terrain clearance and polar degradation\n\n"
-    "- [%s] [Terrain display](xcsoar://config/terrain) - "
+    "- [%s] [Terrain Display](xcsoar://config/terrain) - "
     "Choose terrain colors, shading and contour lines\n\n"
     "- [ ] [Live tracking](xcsoar://config/tracking) *(optional)* - "
     "Share your position via SkyLines or LiveTrack24\n\n"

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -479,7 +479,7 @@ FileDataField::CreateComboList([[maybe_unused]] const char *reference) const noe
       display_string = buffer;
     } else if (is_not_found) {
       /* file configured in profile does not exist on disk */
-      buffer.Format("%s [%s]", path.c_str(), _("not found"));
+      buffer.Format("%s [%s]", path.c_str(), _("Not found"));
       display_string = buffer;
     }
 

--- a/src/Form/DataField/MultiFile.cpp
+++ b/src/Form/DataField/MultiFile.cpp
@@ -155,7 +155,7 @@ MultiFileDataField::UpdateDisplayString()
       auto base = path.GetBase();
       display_string += (base != nullptr) ? base.c_str() : path.c_str();
       display_string += " [";
-      display_string += _("not found");
+      display_string += _("Not found");
       display_string += "]";
     }
   }

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -915,7 +915,7 @@ static constexpr MetaData meta_data[] = {
   },
 
   {
-    N_("Thermal assistant"),
+    N_("Thermal Assistant"),
     N_("Thermal"),
     N_("Circular thermal assistant that shows the lift distribution over each part of the circle."),
     IBFHelper<InfoBoxContentThermalAssistant>::Create,

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -75,6 +75,7 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "Device/MultipleDevices.hpp"
 #include "Form/DataField/File.hpp"
 #include "Dialogs/FilePicker.hpp"
+#include "Dialogs/InternalLink.hpp"
 #include "net/client/WeGlide/UploadIGCFile.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
@@ -813,6 +814,11 @@ InputEvents::eventExchangeFrequencies([[maybe_unused]] const char *misc)
 
 void
 InputEvents::eventUploadIGCFile([[maybe_unused]] const char *misc) {
+  if (!CommonInterface::GetComputerSettings().weglide.IsConfigured()) {
+    HandleInternalLink("xcsoar://config/weglide");
+    return;
+  }
+
   FileDataField df;
   df.ScanMultiplePatterns(GetFileTypePatterns(FileType::IGC));
   df.SetFileType(FileType::IGC);

--- a/src/Input/InputEventsTask.cpp
+++ b/src/Input/InputEventsTask.cpp
@@ -185,7 +185,8 @@ InputEvents::eventMacCready(const char *misc)
       Message::AddMessage(_("Auto. MacCready off"));
     }
   } else if (StringIsEqual(misc, "show")) {
-    Message::AddMessage(_("MacCready "), FormatUserVerticalSpeed(mc, false));
+    Message::AddMessage(_("MacCready"),
+                        FormatUserVerticalSpeed(mc, false));
   }
 }
 
@@ -383,7 +384,7 @@ InputEvents::eventTaskTransition(const char *misc)
     }
     Message::AddMessage(_("Task start"), TempAll.c_str());
   } else if (StringIsEqual(misc, "next")) {
-    Message::AddMessage(_("Next turnpoint"));
+    Message::AddMessage(_("Next Turnpoint"));
   } else if (StringIsEqual(misc, "finish")) {
     Message::AddMessage(_("Task finished"));
   }

--- a/src/Language/FormatText.hpp
+++ b/src/Language/FormatText.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Language/Language.hpp"
+#include "util/StaticString.hxx"
+
+/**
+ * Format "Feature is not available in this build." for a translatable
+ * feature name (N_() marker).
+ */
+template<std::size_t N>
+void
+FormatFeatureNotAvailableInThisBuild(StaticString<N> &dest,
+                                     const char *feature) noexcept
+{
+  dest.Format(_("%s is not available in this build."), _(feature));
+}
+
+/**
+ * Format "... because the OpenGL renderer is not available." for a
+ * translatable feature name (N_() marker).
+ */
+template<std::size_t N>
+void
+FormatFeatureNotAvailableInThisBuildWithoutOpenGLRenderer(
+  StaticString<N> &dest, const char *feature) noexcept
+{
+  dest.Format(_("%s is not available in this build because the OpenGL "
+               "renderer is not available."),
+              _(feature));
+}
+
+/**
+ * Format "Target device not found." / "Source device not found." for a
+ * translatable role name (N_() marker, e.g. N_("Target")).
+ */
+template<std::size_t N>
+void
+FormatDeviceNotFound(StaticString<N> &dest,
+                     const char *role) noexcept
+{
+  dest.Format(_("%s device not found."), _(role));
+}
+
+/**
+ * Format "Do you want to remove station CODE?"
+ */
+template<std::size_t N>
+void
+FormatRemoveStationPrompt(StaticString<N> &dest,
+                          const char *station) noexcept
+{
+  dest.Format(_("Do you want to remove station %s?"), station);
+}
+
+/**
+ * Format "Starts in 2h" / "Starts in 3d" for a pre-formatted relative time.
+ */
+template<std::size_t N>
+void
+FormatStartsIn(StaticString<N> &dest,
+               const char *time) noexcept
+{
+  dest.Format(_("Starts in %s"), time);
+}
+
+/**
+ * Format "5 minutes ago".
+ */
+template<std::size_t N>
+void
+FormatMinutesAgo(StaticString<N> &dest,
+                 unsigned minutes) noexcept
+{
+  dest.UnsafeFormat(_("%u minutes ago"), minutes);
+}
+
+/**
+ * Generic failure message for WiFi and similar operations.
+ */
+[[nodiscard]] [[gnu::pure]]
+inline const char *
+OperationFailedText() noexcept
+{
+  return _("The operation failed.");
+}
+
+/**
+ * Format RASP dwcrit/hwcrit help text (height qualifier differs).
+ */
+template<std::size_t N>
+void
+FormatRaspHeightCritHelp(StaticString<N> &dest,
+                         bool above_ground) noexcept
+{
+  dest.Format(_("This parameter estimates the height%s at which the "
+                "average dry updraft strength drops below 225 fpm and is "
+                "expected to give better quantitative numbers for the "
+                "maximum cloudless thermalling height than the BL Top "
+                "height, especially when mixing results from vertical "
+                "wind shear rather than thermals. (Note: the present "
+                "assumptions tend to underpredict the max. thermalling "
+                "height for dry conditions.) In the presence of clouds "
+                "the maximum thermalling height may instead be limited by "
+                "the cloud base. Being for \"dry\" thermals, this "
+                "parameter omits the effect of \"cloudsuck\"."),
+              above_ground ? _(N_(" above ground")) : "");
+}

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -358,7 +358,7 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
       weglide_settings.pilot_id > 0) {
       // ask whether this IGC should be uploaded to WeGlide
       if (ShowMessageBox(_("Do you want to upload this flight to WeGlide?"),
-        _("Upload flight"), MB_YESNO | MB_ICONQUESTION) == IDYES) {
+        _("Upload Flight"), MB_YESNO | MB_ICONQUESTION) == IDYES) {
         WeGlide::UploadIGCFile(igc_path);
       }
     }

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -113,8 +113,8 @@ GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
     TerrainHeight elevation = terrain->GetTerrainHeight(location);
     if (!elevation.IsSpecial()) {
       StaticString<64> elevation_long;
-      elevation_long = _("Elevation: ");
-      elevation_long += FormatUserAltitude(elevation.GetValue()).c_str();
+      elevation_long.Format("%s: %s", _("Elevation"),
+                            FormatUserAltitude(elevation.GetValue()).c_str());
 
       TextInBox(canvas, elevation_long, p, mode,
                 render_projection.GetScreenSize());

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -178,7 +178,7 @@ public:
       PageActions::RestoreBottom();
     });
 
-    AddButton(_("ACK Day"), [this](){
+    AddButton(_("Ack Day"), [this](){
       try {
         manager.AcknowledgeDay(airspace);
       } catch (...) {

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -27,10 +27,10 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
     break;
 
   case PageLayout::Main::FLARM_RADAR:
-    return _("FLARM radar");
+    return _("FLARM Radar");
 
   case PageLayout::Main::THERMAL_ASSISTANT:
-    return _("Thermal assistant");
+    return _("Thermal Assistant");
 
   case PageLayout::Main::HORIZON:
     return _("Horizon");

--- a/src/Weather/MapOverlay/EdlControlsModel.cpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.cpp
@@ -8,6 +8,8 @@
 #include "Dialogs/Message.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
+#include "util/StaticString.hxx"
 #include "NetComponents.hpp"
 #include "UIState.hpp"
 #include "Weather/EDL/FieldControls.hpp"
@@ -198,8 +200,9 @@ void
 EdlControlsModel::RefreshOverlay() noexcept
 {
 #if !defined(HAVE_HTTP)
-  ShowMessageBox(_("HTTP support is not available in this build."),
-                 _("Weather"), MB_OK);
+  StaticString<128> message;
+  FormatFeatureNotAvailableInThisBuild(message, N_("HTTP support"));
+  ShowMessageBox(message, _("Weather"), MB_OK);
 #else
   if (!EDL::OverlayEnabled())
     return;

--- a/src/Weather/NOAAFormatter.cpp
+++ b/src/Weather/NOAAFormatter.cpp
@@ -247,7 +247,7 @@ NOAAFormatter::Format(const NOAAStore::Item &station, std::string &output)
   output.reserve(2048);
 
   if (!station.metar_available) {
-    output += _("No METAR available!");
+    output += _("No METAR available");
   } else {
     if (station.parsed_metar_available)
       FormatDecodedMETAR(station.metar, station.parsed_metar, output);

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -10,6 +10,7 @@
 #include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "PageActions.hpp"
 #include "PageSettings.hpp"
 #include "UIState.hpp"
@@ -19,6 +20,7 @@
 #include "Weather/MapOverlay/TimePicker.hpp"
 #include "util/Compiler.h"
 #include "util/StaticString.hxx"
+#include "util/StringCompare.hxx"
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Weather/Rasp/DownloadGlue.hpp"
@@ -60,9 +62,17 @@ FillFieldChoices(DataFieldEnum &field, const RaspStore *rasp,
 
   for (unsigned i = 0; i < rasp->GetItemCount(); ++i) {
     const auto &item = rasp->GetItemInfo(i);
-    const char *help = item.help != nullptr
-      ? gettext(item.help)
-      : nullptr;
+    StaticString<512> help_buffer;
+    const char *help = nullptr;
+    if (StringIsEqual(item.name.c_str(), "dwcrit")) {
+      FormatRaspHeightCritHelp(help_buffer, true);
+      help = help_buffer.c_str();
+    } else if (StringIsEqual(item.name.c_str(), "hwcrit")) {
+      FormatRaspHeightCritHelp(help_buffer, false);
+      help = help_buffer.c_str();
+    } else if (item.help != nullptr) {
+      help = gettext(item.help);
+    }
 
     field.AddChoice(i, item.name, GetFieldLabel(item), help);
   }

--- a/src/Weather/Rasp/RaspStore.cpp
+++ b/src/Weather/Rasp/RaspStore.cpp
@@ -24,16 +24,19 @@
 
 #define RASP_FORMAT "%s.curr.%02u%02ulst.d2.jp2"
 
+static constexpr const char *WSTAR_HELP =
+  N_("Average dry thermal updraft strength near mid-BL height. Subtract glider descent rate to get average vario reading for cloudless thermals. Updraft strengths will be stronger than this forecast if convective clouds are present, since cloud condensation adds buoyancy aloft (i.e. this neglects \"cloudsuck\"). W* depends upon both the surface heating and the BL depth.");
+
 static constexpr RaspStore::MapInfo WeatherDescriptors[] = {
   {
     "wstar",
     N_("W*"),
-    N_("Average dry thermal updraft strength near mid-BL height. Subtract glider descent rate to get average vario reading for cloudless thermals. Updraft strengths will be stronger than this forecast if convective clouds are present, since cloud condensation adds buoyancy aloft (i.e. this neglects \"cloudsuck\"). W* depends upon both the surface heating and the BL depth."),
+    WSTAR_HELP,
   },
   {
     "wstar_bsratio",
     N_("W*"),
-    N_("Average dry thermal updraft strength near mid-BL height. Subtract glider descent rate to get average vario reading for cloudless thermals. Updraft strengths will be stronger than this forecast if convective clouds are present, since cloud condensation adds buoyancy aloft (i.e. this neglects \"cloudsuck\"). W* depends upon both the surface heating and the BL depth."),
+    WSTAR_HELP,
   },
   {
     "blwindspd",
@@ -48,7 +51,7 @@ static constexpr RaspStore::MapInfo WeatherDescriptors[] = {
   {
     "dwcrit",
     N_("dwcrit"),
-    N_("This parameter estimates the height above ground at which the average dry updraft strength drops below 225 fpm and is expected to give better quantitative numbers for the maximum cloudless thermalling height than the BL Top height, especially when mixing results from vertical wind shear rather than thermals. (Note: the present assumptions tend to underpredict the max. thermalling height for dry conditions.) In the presence of clouds the maximum thermalling height may instead be limited by the cloud base. Being for \"dry\" thermals, this parameter omits the effect of \"cloudsuck\"."),
+    nullptr,
   },
   {
     "blcloudpct",
@@ -63,7 +66,7 @@ static constexpr RaspStore::MapInfo WeatherDescriptors[] = {
   {
     "hwcrit",
     N_("hwcrit"),
-    N_("This parameter estimates the height at which the average dry updraft strength drops below 225 fpm and is expected to give better quantitative numbers for the maximum cloudless thermalling height than the BL Top height, especially when mixing results from vertical wind shear rather than thermals. (Note: the present assumptions tend to underpredict the max. thermalling height for dry conditions.) In the presence of clouds the maximum thermalling height may instead be limited by the cloud base. Being for \"dry\" thermals, this parameter omits the effect of \"cloudsuck\"."),
+    nullptr,
   },
   {
     "wblmaxmin",

--- a/src/net/client/WeGlide/Settings.hpp
+++ b/src/net/client/WeGlide/Settings.hpp
@@ -37,6 +37,14 @@ struct WeGlideSettings {
   uint32_t pilot_id;
   BrokenDate pilot_birthdate;
 
+  /**
+   * True when WeGlide is enabled and upload credentials are set.
+   */
+  [[nodiscard]] [[gnu::pure]]
+  constexpr bool IsConfigured() const noexcept {
+    return enabled && pilot_id != 0 && pilot_birthdate.IsPlausible();
+  }
+
   void SetDefaults() noexcept {
     pilot_id = 0;
     pilot_birthdate.Clear();

--- a/src/net/wifi/WifiError.cpp
+++ b/src/net/wifi/WifiError.cpp
@@ -3,6 +3,7 @@
 
 #include "WifiError.hpp"
 #include "Language/Language.hpp"
+#include "Language/FormatText.hpp"
 #include "util/Exception.hxx"
 
 #include <string>
@@ -83,7 +84,7 @@ FormatCodeForUser(WifiError::Code code)
     return {_("WiFi service is not running.")};
   }
 
-  return {_("The operation failed.")};
+  return {OperationFailedText()};
 }
 
 } // namespace
@@ -96,7 +97,7 @@ static std::string
 FormatWhatForUser(const char *what)
 {
   if (what == nullptr) {
-    return {_("The operation failed.")};
+    return {OperationFailedText()};
   }
   const std::string_view w{what};
 
@@ -136,7 +137,7 @@ std::string
 WifiError::Format(std::exception_ptr e)
 {
   if (e == nullptr)
-    return {_("The operation failed.")};
+    return {OperationFailedText()};
 
   if (const auto *wifi_error = FindNested<WifiError::Exception>(e);
       wifi_error != nullptr)
@@ -147,6 +148,6 @@ WifiError::Format(std::exception_ptr e)
   } catch (const std::exception &ex) {
     return WifiError::Format(ex);
   } catch (...) {
-    return {_("The operation failed.")};
+    return {OperationFailedText()};
   }
 }


### PR DESCRIPTION
Closes #2601

## Summary

- Deduplicate and standardize translatable strings (capitalization, punctuation, shared format helpers via `FormatText.hpp`)
- Align `default.xci` button labels with C++ dialog titles
- Update all 33 `.po` catalogs with manual translations for changed and new strings
- Add translation tooling (`apply_manual_translations.py`, `reformat_po_layout.py`) that writes via `update_po_low_churn.py` to minimize layout churn

## Test plan

- [ ] `msgfmt --check` passes on all `po/*.po` files
- [ ] `make update-po` produces minimal diff against this branch
- [ ] Spot-check UI in English and at least one non-Latin language (e.g. German, Japanese)
- [ ] Verify renamed button labels in `default.xci` match their dialogs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WeGlide uploads now guide you to configuration when setup is incomplete.
  * Improved RASP weather help text for height-critical fields.
  * More consistent localized messages for unavailable features, missing devices, failed operations, and station removal.

* **Improvements**
  * Updated keybinding, menu, dialog, settings, and info-box labels for clearer, consistent capitalization.
  * Improved formatting for airspace NOTAM start times and weather status messages.
  * Refined backup, restore, WiFi, and weather error feedback.

* **Documentation**
  * Updated configuration guidance to match revised display labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->