### PR TITLE
build: Fix Win64 Defender Banjori.A false positive

### DIFF
--- a/build/debug.mk
+++ b/build/debug.mk
@@ -2,9 +2,15 @@ DEBUG ?= y
 DEBUG_GLIBCXX ?= n
 
 ifeq ($(DEBUG),y)
-  OPTIMIZE := -Og
-  ifeq ($(CLANG),n)
-    OPTIMIZE += -funit-at-a-time
+  ifeq ($(HAVE_WIN32),y)
+    # MinGW -Og builds are often flagged as malware by Windows
+    # Defender (PWS:Win32/Banjori.A); -O0 stays debug-friendly.
+    OPTIMIZE := -O0
+  else
+    OPTIMIZE := -Og
+    ifeq ($(CLANG),n)
+      OPTIMIZE += -funit-at-a-time
+    endif
   endif
 else
   OPTIMIZE := -Os

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -548,8 +548,8 @@ TARGET_LDLIBS =
 TARGET_LDADD =
 
 ifeq ($(TARGET),PC)
-  TARGET_LDFLAGS += -Wl,--major-subsystem-version=5
-  TARGET_LDFLAGS += -Wl,--minor-subsystem-version=00
+  TARGET_LDFLAGS += -Wl,--major-subsystem-version=6
+  TARGET_LDFLAGS += -Wl,--minor-subsystem-version=0
 
   # default to "console"; see SCREEN_LDLIBS
   TARGET_LDFLAGS += -Wl,-subsystem,console

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -553,6 +553,10 @@ ifeq ($(TARGET),PC)
 
   # default to "console"; see SCREEN_LDLIBS
   TARGET_LDFLAGS += -Wl,-subsystem,console
+
+  ifeq ($(X64),y)
+    TARGET_LDFLAGS += -Wl,--high-entropy-va
+  endif
 endif
 
 ifeq ($(HAVE_WIN32),y)


### PR DESCRIPTION
## Summary

- Use `-O0` instead of `-Og` for Windows `DEBUG=y` builds to avoid the `PWS:Win32/Banjori.A` false positive observed on cross-compiled WIN64 binaries
- Raise the Windows PE subsystem version from 5.0 to 6.0 to match `WINVER=0x0600`
- Enable `--high-entropy-va` on Win64 builds for standard x64 ASLR hardening

Fixes #2232

## Background

Windows Defender quarantines MinGW debug builds (`DEBUG=y`, default `-Og`) as `PWS:Win32/Banjori.A`. Testing on c3sim showed:

| Build | Defender |
|-------|----------|
| `DEBUG=y`, `-Og` | Quarantined |
| `DEBUG=y`, `-O0` | OK |
| `DEBUG=n` release | OK |

PE subsystem/high-entropy changes are good practice and align metadata with the supported Windows version, but they did not fix the `-Og` trigger by themselves.

## Test plan

- [ ] Cross-compile `make TARGET=WIN64 DEBUG=y` and verify Defender does not quarantine on Windows
- [ ] Cross-compile `make TARGET=WIN64 DEBUG=n` and verify binary runs
- [ ] Confirm PE headers: subsystem 6.0, high-entropy VA set on WIN64 (`objdump -p`)