### PR TITLE
NEWS.txt: Rewrite v7.45 release notes

### DIFF
--- a/.cursor/rules/news-formatting.mdc
+++ b/.cursor/rules/news-formatting.mdc
@@ -1,0 +1,38 @@
+---
+description: Line wrap, issue refs, and validation for NEWS.txt
+globs:
+  - "NEWS.txt"
+alwaysApply: false
+---
+
+# NEWS.txt — formatting
+
+## Layout
+
+- Max **79 columns** (same as project C++)
+- Bullets: `  - ` then text; continuations indented **4 spaces**
+- Fill lines near 79; do not wrap early leaving short stubs
+- Do not leave a continuation that is only `#1234` — pull a word down with it
+- No tabs; no trailing spaces; no blank lines inside a version block
+- One blank line between version blocks
+
+## Issue references
+
+- Append at the **end** of the bullet: ` #1234` or ` #1234 #5678`
+- Prefer `#1234`, not `(#1234)`
+- Only when tied to a GitHub issue or useful PR number
+
+## Validation
+
+After editing the current unreleased block:
+
+```bash
+python3 tools/news_to_quickguide_md.py NEWS.txt > /dev/null
+```
+
+Quick Guide “What's New” is generated from `NEWS.txt`; keep the parser happy.
+
+## Commits
+
+- Message form: `NEWS.txt: <summary>` (path with extension at repo root)
+- Do not mix NEWS rewrites with unrelated code in the same commit when avoidable

--- a/.cursor/rules/news-sections.mdc
+++ b/.cursor/rules/news-sections.mdc
@@ -1,0 +1,40 @@
+---
+description: How to organise NEWS.txt sections in a release block
+globs:
+  - "NEWS.txt"
+alwaysApply: false
+---
+
+# NEWS.txt — sections
+
+For a large release block, prefer **topic sections** over a long `* ui` dump.
+
+## Splitting
+
+- When ~4+ bullets share a theme, give them a section (`* alternates`,
+  `* weather`, `* Data Management`, `* FLARM radar`, `* checklists`, …)
+- Order roughly: core flight / map → related UI topics → devices → platforms →
+  `* documentation` → `* development`
+- Within a section: group by topic; features before fixes when that stays clear
+  (topic grouping wins over a rigid features-then-fixes split)
+
+## Typical section names (examples)
+
+`tracking`, `calculations`, `task`, `map`, `alternates`, `weather`, `airspace`,
+`devices`, `infoboxes`, `waypoint`, `ui`, `input`, platform names, `documentation`,
+`development`
+
+Use product / dialog names when that is what pilots see (`Quick Guide`,
+`Data Management`, `Thermal Assistant`).
+
+## Keep thin
+
+- `* ui`: cross-cutting chrome (keyboard, focus, colours, sounds) not claimed by
+  a topic section
+- `* input`: keys, gestures, `.xci` — not map gesture features (those → `* map`)
+- Map overlays and gestures → `* map` / `* weather`, not `* ui`
+
+## Platforms
+
+- User platform sections (`* Windows`, `* android`, …): what changes on that OS
+- Prefer “OpenGL Windows version” over renderer-stack names in user bullets

--- a/.cursor/rules/news-wording.mdc
+++ b/.cursor/rules/news-wording.mdc
@@ -1,0 +1,48 @@
+---
+description: Pilot-facing wording for NEWS.txt bullets
+globs:
+  - "NEWS.txt"
+alwaysApply: false
+---
+
+# NEWS.txt — wording
+
+Audience: pilots and installers reading Credits / release notes.
+
+## Tone
+
+- Impersonal: no “you” / “your” (except quoting a UI string, e.g. "Your Position")
+- Plain language; what the user notices, not how it was implemented
+- Bullets start with a verb: `add`, `fix`, `show`, `hide`, `improve`, …
+
+## Prefer
+
+- Dialog / setting titles in quotes when helpful: "Map elements at this location",
+  Select Waypoint, Safety Factors
+- “OpenGL Windows version”, “installer”, “legacy single-file executable”
+- Driver names and file formats the user configures (`LXNAV`, `.openair`)
+
+## Avoid in user-facing bullets
+
+- Build targets: `WIN64OPENGL`, `PC`, `TARGET=…`
+- Internal stack jargon when a plain phrase exists: GDI, NSIS, ANGLE, `USE_*`
+- Source paths, class names, “when merging”, “own-ship”, “gated on …”
+- Second person and chatty phrasing
+
+```text
+# BAD
+- add NSIS installer for OpenGL builds (WIN64OPENGL)
+- how far you can still fly while reaching the turnpoint
+- open waypoint search filtered (…)
+
+# GOOD
+- add installer for the OpenGL Windows version (64-bit and 32-bit)
+- how far one can still fly and still reach the active task waypoint
+- open Select Waypoint filtered (recent, airport, landable, …)
+```
+
+## Release rewrites
+
+- Cover user-facing changes since the previous release, not every commit
+- Drop clear “broken in this release cycle then fixed before ship” items
+- Keep real upgrades from the previous shipped version

--- a/.cursor/rules/news.txt.mdc
+++ b/.cursor/rules/news.txt.mdc
@@ -1,142 +1,49 @@
 ---
-description: Style and audience for NEWS.txt release notes
+description: Structure and audience for NEWS.txt release notes
 globs:
   - "NEWS.txt"
 alwaysApply: false
 ---
 
-# NEWS.txt release notes
+# NEWS.txt — structure
 
-`NEWS.txt` ships with XCSoar (Credits dialog, release packages). It is a
-**cumulative** changelog: the top uses current style; older entries at the
-bottom retain legacy formats (prose lists, “Changes from …”, contributor
-attributions). **New entries** always go at the top under the current
-unreleased version.
+`NEWS.txt` ships with XCSoar (Credits, packages). Cumulative changelog: new
+entries only under the current **`Version X.Y - not yet released`** at the top.
+Do not rewrite older version blocks.
+
+Related: `news-wording.mdc`, `news-formatting.mdc`, `news-sections.mdc`.
+Policy summary: `doc/policy.rst` (Release notes).
 
 ## When to add an entry
 
-- Under **`Version X.Y - not yet released`** at the top of the file
-- **User-visible** changes → platform/feature sections (`* Windows`, `* ui`, …)
-- **Manual / user documentation** users would notice → `* documentation` (see
-  below)
-- **Build, CI, contributor docs, scripting APIs** → `* development` (see below)
-- Pure refactors or CI tweaks with nothing worth noting: omit
+- **User-visible** → feature/platform sections (`* map`, `* Windows`, …)
+- **Pilot-facing docs** (manual, install guide, in-app help) → `* documentation`
+- **Build / CI / contributor docs / hacking APIs** → `* development`
+- Pure refactors or trivial CI: omit
 
-## Structure
+## Shape
 
 ```text
 Version X.Y - not yet released
 * section
   - bullet describing the change
 * documentation
-  - clarify task speed calculation section
+  - clarify …
 * development
-  - build system: ...
-  - documentation: ...
+  - build system: …
+  - documentation: …
 ```
 
-- **Version line**: `Version X.Y - YYYY-MM-DD` or `- not yet released`
-- **Section headers**: `* android`, `* Windows`, `* ui`, … — lowercase after
-  `*` unless a proper noun (Windows, macOS, iOS, Android, Linux, Kobo)
-- **Bullets**: start with a verb (`add`, `fix`, `deprecate`, `support`, …)
-- **Issue references**: append ` #1234` at end when related to a GitHub issue
-  (project practice since 2012)
+- Version line: `Version X.Y - YYYY-MM-DD` or `- not yet released`
+- Section headers: `* name` — lowercase unless a proper noun / product UI name
+  (`Windows`, `macOS`, `Quick Guide`, `Data Management`, `FLARM radar`)
+- Match section names already used in the **current** unreleased block
+- Prefer one topic section over dumping everything into `* ui`
+- Avoid duplicating the same change across sections unless one line is
+  user-facing and another adds separate `* development` detail
 
-### Section naming (historical mess — pick one style per release)
+## `* documentation` vs `* development`
 
-The file mixes `* user interface` and `* ui`, `* android` and `* Android`,
-`* devices` and `* Devices`. For **new** entries in a release block, match the
-sections already used in that block; prefer lowercase generic names (`* ui`,
-`* devices`, `* android`) unless the release already uses another form.
-
-## User-facing sections
-
-Platform and feature sections (`* Windows`, `* ui`, `* devices`, `* map`, …).
-Aim for language pilots understand when **adding new** bullets. Older entries
-often use technical terms (`targetSdkVersion`, driver names) — that is fine to
-leave; do not rewrite history.
-
-### Wording — prefer for new user bullets
-
-- Plain language: “OpenGL Windows version”, “installer”, “legacy
-  single-file executable”
-- What the user gets or should do: “use the OpenGL version instead”
-- Match tone of other bullets in the same release block
-
-### Wording — avoid in new user bullets when a plain phrase exists
-
-- Build target names: `WIN64OPENGL`, `WIN32OPENGL`, `PC`, `WIN64`, `TARGET=…`
-- Internal stack terms users do not see: GDI, NSIS, ANGLE, SDL, `USE_*`
-- Source paths, class names, “targets” in the build-system sense
-
-Driver names, file formats, and platform APIs are OK when that is what the user
-configures or sees.
-
-### Examples
-
-```text
-# BAD (* Windows)
-- add NSIS installer for OpenGL builds (WIN64OPENGL, WIN32OPENGL)
-- deprecate GDI legacy builds (targets PC, WIN64)
-
-# GOOD (* Windows)
-- add installer for the OpenGL Windows version (64-bit and 32-bit)
-- deprecate the legacy single-file Windows executable; use the OpenGL
-  version instead
-```
-
-## `* documentation` section
-
-Use for **end-user or pilot documentation** shipped or maintained with the
-release: manual chapters, installation instructions, Lua reference updates users
-read, clarifications in the built-in help. Established in 7.43+ as a top-level
-section.
-
-```text
-* documentation
-  - clarify task speed calculation section
-  - lua reference updated
-```
-
-Do not use this for `doc/build.rst` or other contributor-only docs — those go
-under `* development` with a `documentation:` prefix.
-
-## `* development` section
-
-Use for people **building** or **hacking on** XCSoar. Introduced in 7.44 as a
-consolidated block; before that, similar items appeared as `* build system`,
-top-level `build system:` bullets, or inside platform sections.
-
-Technical terms and target names are fine here.
-
-- Prefix bullets with a topic: `build system:`, `documentation:`, `iOS:`,
-  `Linux:`, … (match 7.44 style)
-- Examples: new targets, makefile/CI changes, `doc/build.rst`, dev guides,
-  contributor scripting APIs
-
-```text
-* development
-  - build system: add WIN32OPENGL target and NSIS installer target
-  - documentation: document OpenGL Windows cross-compile and outputs
-```
-
-Legacy: a standalone `* build system` section still exists at Version 6.0 in
-the file; prefer `* development` with a `build system:` prefix for new entries.
-
-## Avoid duplication
-
-Do not repeat the same change in multiple sections unless one line is
-user-facing and another adds separate technical detail (e.g. installer in
-`* Windows`, `build system: WIN64OPENGL installer target` in `* development`).
-
-## Deprecations and removals
-
-- User sections: what is going away and what to use instead, in user terms
-- `* development`: target names and flags OK (e.g. deprecate `PC` / `WIN64`
-  GDI targets)
-
-## Platform notes (user sections)
-
-- Prefer “OpenGL Windows version” over naming the renderer stack
-- “Legacy” or “single-file” `.exe` is clearer than “GDI build”
-- Mention installer and zip when both are shipped
+- `* documentation`: end-user / pilot docs
+- `* development`: `build system:`, `documentation:` (contributor-only), …
+  Technical names and targets are fine there

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,7 @@
 SPDX-License-Identifier: GPL-2.0-or-later
 
 XCSoar Glide Computer - https://xcsoar.org/
-Copyright (C) 2000-2025 The XCSoar Project
+Copyright (C) 2000-2026 The XCSoar Project
 
 The following people and organizations have contributed code to XCSoar:
 
@@ -85,6 +85,20 @@ The following people and organizations have contributed code to XCSoar:
  kobedegeest <kobedegeest@gmail.com>
  B-4pt <bapt80@proton.me>
  Dominic Spreitz <dominic@spreitz.de>
+ Benjamin Girard <bgirard@xpdeep.com>
+ bennsch <bennsch.dev@gmail.com>
+ Christian Grøvdal <chrgro@gmail.com>
+ Chris Woolley <woolley@tpg.com.au>
+ DanD222 <48011765+DanD222@users.noreply.github.com>
+ Davis Chappins <davis.chappins@gmail.com>
+ Josef Klein <josef.klein.989@t-online.de>
+ Joe Capra <joe@scientifantastic.com>
+ Linar Yusupov <linar.r.yusupov@gmail.com>
+ Rik Van den Boer <rikvandenboer@gmail.com>
+ si.gr <si-gr1@protonmail.com>
+ Simon GH <groundhog@gmx.net>
+ Mirek Burdych <mirek.burdych@gmail.com>
+ Thomas Maier <thomas04.maier@lindner-group.com>
 
 Documentation:
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,7 +42,7 @@ Version 7.45 - not yet released
   - add optional turn back marker (Safety Factors): green triangle along
     track showing how far you can still fly and reach the active task
     waypoint or Goto; only in cruise when the target is reachable;
-    saved in the profile #1741
+    saved in the profile #1740 #1741
   - support AUTO or MANUAL Alternate 1/2 InfoBoxes: tap to open the
     alternates list, switch mode, and assign a row (AUTO clears a manual
     pin); titles show Altn 1/2 with AUTO or MAN
@@ -66,7 +66,7 @@ Version 7.45 - not yet released
   - enlarge on-map text: waypoint names, map scale, and topography
     labels
   - add "Waypoint icon size" on Configuration → Map display → Waypoints
-    (50–200%, default 100%)
+    (50–200%, default 100%) #1594
   - make the thermal hotspot icon easier to see on dark backgrounds
     #2448
   - hide obstacles at wider map scales than other non-landables
@@ -76,7 +76,7 @@ Version 7.45 - not yet released
   - add terrain shading orientation "fixed (Top Left)"
   - smooth snail trail between fixes; vario colours use high-rate netto
     between GPS points when available #2447
-  - add distance rings around the current location #2522
+  - add distance rings around the current location #1206 #2522
   - match BigTrafficWidget task direction arrow to the map best-cruise
     shape #2027
   - show optional callsign and relative altitude beside BigTrafficWidget
@@ -178,6 +178,8 @@ Version 7.45 - not yet released
   - show glide polar sync in the device dialog only for drivers that
     support it (LXNAV) #2457
   - send QNH changes from external sources to all connected devices
+  - Air Control Display: set active COM frequency via standby swap
+    (AT-01 and similar with read-only active channel) #2454
   - show the Vario flag on the device list for non-compensated and
     netto vario sources as well as total-energy (e.g. BlueFly)
   - increase the number of device slots from 6 to 8
@@ -264,6 +266,7 @@ Version 7.45 - not yet released
     rate, and debounce ComboPicker help updates while scrolling
   - show full callsigns on all registered FLARM radar targets; omit
     duplicate side vario/altitude on the selected target #2718
+  - improve FLARM traffic symbol and label sizing #2708
   - rotate FLARM radar track-up targets on cardinal bearings
   - outline selected targets on the FLARM traffic radar
   - fix crash when opening the map item list on waypoints with long
@@ -319,6 +322,7 @@ Version 7.45 - not yet released
   - disable map overlay buttons on non-map pages (traffic, thermal
     assistant, etc.)
   - raise the InfoBox configuration entry limit so all InfoBoxes appear
+    #2344
   - encode bundled UI sound assets at higher quality
   - show clearer keyboard focus on tab strips in tabbed dialogs
   - advance checklist checkbox focus with Enter like Down #2405
@@ -329,6 +333,7 @@ Version 7.45 - not yet released
   - format Quick Guide "What's New" from NEWS.txt at build time
   - reflect live Safety factors and Terrain display settings in Quick
     Guide getting started #2324
+  - apply Quick Guide terrain file choice immediately (#2322)
   - improve Quick Guide checklist touch targets and checkbox appearance;
     -touchscreen / -notouchscreen override autodetection (non-Android)
     #2325
@@ -386,7 +391,9 @@ Version 7.45 - not yet released
     default
   - update the device list when storage access changes
 * iOS
-  - fix audio vario playback through the device speaker
+  - fix audio vario playback through the device speaker #2474
+  - open waypoint detail PDFs and other local files from the details
+    dialog (was failing silently) #2501
   - disable Core Location distance filter for built-in GPS so fixes are
     not suppressed while stationary #2380
   - configure built-in GPS and sensors in the last device slot by
@@ -394,17 +401,19 @@ Version 7.45 - not yet released
 * macOS
   - fix thick solid lines rendering at incorrect pixel width #2545
 * Linux
-  - add Config → Setup → Network for WiFi (NetworkManager or ConnMan via
-    D-Bus)
+  - add Config → Setup → Network for WiFi status, connect/disconnect,
+    and IP address (NetworkManager or ConnMan via D-Bus)
 * OpenVario
   - show WiFi and ethernet status; support WiFi connect/disconnect and
     ethernet DHCP renew from the Network dialog
 * Windows
   - add installer for the OpenGL Windows version (64-bit and 32-bit);
-    zip download remains available for a portable install
+    zip download remains available for a portable install #2064
   - deprecate the legacy single-file Windows executable; use the OpenGL
     version instead — the legacy build will be removed in a future
     release
+  - reduce Windows Defender false positives on Win64 builds (#2232)
+  - fix duplicate entries in Windows file lists #2625
   - fix crash opening the log list when replay filenames contain
     non-ASCII characters
   - open files in binary mode so embedded ZIP (e.g. CUPX POINTS.CUP) is
@@ -417,6 +426,8 @@ Version 7.45 - not yet released
 * Kobo
   - always start in light mode; dark mode is not supported on e-paper
     displays #2568
+  - add Config → Setup → Network with WiFi status and Auto WiFi (enable
+    WiFi automatically at startup) #2531
   - fix black squares when scrolling lists and edit fields on e-paper
     #2293
 * development

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -121,8 +121,9 @@ Version 7.45 - not yet released
   - add pc_met www images: RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT
     RAD BLITZ, and Blitzkarte Europa; local radar list uses Borkum
     instead of the removed Emden site
-* NOTAM integration #2018
+* NOTAM integration
   - add support for downloading, caching and displaying NOTAM airspaces
+    #2018
   - add manual refresh and auto-refresh with location/time based updates
   - add NOTAM settings and filters (IFR, effective time, max radius,
     hidden Q-codes)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,533 +1,450 @@
 Version 7.45 - not yet released
 * tracking
-  - Untangle XCSoar Cloud settings from SkyLines live tracking: cloud traffic
-    and roaming are independent of SkyLines options
-  - Rename map display setting to "Online traffic on map" (SkyLines and
+  - separate XCSoar Cloud settings from SkyLines live tracking: cloud
+    traffic and roaming no longer depend on SkyLines options
+  - rename map display setting to "Online traffic on map" (SkyLines and
     XCSoar Cloud traffic)
-  - Expire online traffic map icons 5 minutes after the last update
-  - Show OGN and SkyLines traffic on the map, in the traffic list, and in
-    the what-is-here dialog using the same FLARM traffic display as device
+  - expire online traffic map icons 5 minutes after the last update
+  - show OGN and SkyLines traffic on the map, in the traffic list, and in
+    the what-is-here dialog with the same FLARM traffic display as device
     traffic (fixes pan-mode disappearance of online targets)
-  - Configurable XCSoar Cloud server hostname and UDP port in cloud settings
-  - Raise combined FLARM/online traffic list limit to 64 targets (cloud
+  - support configurable XCSoar Cloud server hostname and UDP port in
+    cloud settings
+  - raise combined FLARM/online traffic list limit to 64 targets (cloud
     batch size); device FLARM traffic still typically stays within 25
-  - Drop OGN/cloud online traffic that matches the connected FLARM radio
+  - drop OGN/cloud online traffic that matches the connected FLARM radio
     id so own-ship no longer appears on the traffic display #2693
-  - Add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
+  - add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
     to filter self and additional own aircraft from OGN when the device
     radio id is unavailable (e.g. LX passthrough) #2693
-* documentation
-  - document custom ``.xci`` loading: ``#CLEAR``, merge vs replace,
-    ``type`` values (``key`` / ``gce`` / ``gesture`` / ``ne`` /
-    ``label``), gesture ``data`` format, softkey ``location``,
-    label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
-  - document ``AirspaceLabels`` input event
-  - document map pinch-to-zoom on touchscreens that report both
-    finger positions #2790
-* ui
-  - Add pinch-to-zoom on the map for touchscreens that report both
-    finger positions (Android, iOS): two fingers scale about the
-    pinch centroid and can pan at the same time; a two-finger drag
-    or twist enters pan mode, a pinch that only zooms keeps
-    following the aircraft #2790
-  - Add two-finger twist to temporarily rotate the map; the angle is
-    held while panning and restored when pan mode is left #2790
-  - Animate keyboard and mouse-wheel map zoom on non-e-ink displays
-    so scale steps feel continuous after a pinch; free zoom continues
-    from an off-list (pinched) scale, and snaps to the usual scale
-    list again once the current scale is close to a list value
-  - Keep the north arrow clear of the on-screen menu and zoom buttons
-  - Improve simulator discoverability: startup tip to steer by
-    dragging from the glider or via Altitude / Speed Ground InfoBoxes
-    (5 s); Welcome Quick Guide paragraph in simulator mode; add
-    “Sim: Jump to” on map items and waypoint details; Speed Ground
-    simulator panel for bearing and ground-speed steps; label Set Home
-    as “Set as Startup Location” in simulator mode
-  - Bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
-    (same as AVG/ALT softkey and RL gesture); previous target remains
-    on Down
-  - Draw map GPS status above the map scale / title line so it is not
-    covered by AUTO / Simulator / REPLAY text
-  - Improve soft keyboard text entry: default focus on a key; cursor
-    keys move across the grid (Up from OK/Cancel/Clear enters the
-    keyboard; arrows no longer jump in tab order at row edges); F1 is
-    backspace
-  - Fix profile selection / startup branding: use transparent RGBA logo
-    and title bitmaps on light (parchment) dialog backgrounds #2742
-  - Size the InfoBox panel to the current tab and lift map overlays by
-    that height only (Altitude → Simulator no longer jumps the map
-    title up by the taller Setup tab)
-  - Fix map vario / final-glide value labels: use a rounded rectangle
-    (not a pill) with even text padding and an unbroken outline for the
-    semitransparent background #1438
-  - Swap map overlay sides: vario bar on the left, final glide bar on
-    the right #1210
-  - Add airspace labels toggle: Display page 2, Quick Menu, and
-    ``AirspaceLabels`` input event (on/off, saved to profile) #1243
-  - Add Quick Guide and Replay to the Quick Menu (Replay disabled when
-    moving)
-  - Show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
-  - Allow Left/Right on the simulator prompt to choose Fly / Simulator
-    immediately
-  - Improve the map items dialog: scale “Your Position” aircraft icon
-    to the row; Enter / Details opens Status: Flight; show airspace
-    Inside/Near status like the airspace warnings dialog
-  - Tint the bottom airspace warning banner red (inside) or yellow
-    (near), matching the warnings-list badges (colour displays only)
-  - Show distance and time in the bottom airspace warning banner, on a
-    second line only when the name and current distance/time do not fit
-    on one line
-  - Put WiFi Connect first and Close last (right / bottom)
-  - Put Download before Cancel in the download picker; Left/Right page
-    the list (no armed action-bar dual focus)
-  - Use single keyboard focus in the multi-file picker (no armed action
-    bar); Enter/Space toggles the highlighted file, Up/Down reach
-    OK/Cancel
-  - Use single keyboard focus in the value list picker (ComboPicker);
-    Left/Right page, Enter selects the highlighted value
-  - Draw a thin separator line above list-picker bottom help text
-  - Make Quick Menu Left/Right stay put when the next item is disabled,
-    but still wrap or flip page at a real row edge
-  - Use focus colour for action-bar buttons that have keyboard focus
-    (armed Left/Right selection still uses the selected colour while
-    the list keeps focus — same as Alternates)
-  - Open waypoint details with Details / F1 (Enter still confirms the
-    selection)
-  - Move Task Manager keyboard focus with Manage → Browse (and WeGlide
-    lists) so Up/Down can move the task list again
-  - Fix task point dialog keyboard navigation: Up/Down no longer skip
-    the OZ Radius field; Left/Right change the task point (same as
-    < / >); Type is an AddEnum-style field; in portrait the map and OZ
-    fields are full width and the form only uses height for active OZ
-    settings (landscape keeps the side form)
-  - Fill leftover pixels on the last dialog action-bar button in a row
-    (no empty right strip); landscape side bars stay normal height
-  - Put Reference Mass above the plane polar V/W grid; Up/Down moves
-    within each V/W column
-  - Fix Configuration keyboard navigation: Up/Down again move between
-    settings rows; Up from Close/arrows focuses the last row (Quick
-    Guide chrome path unchanged); opening the dialog focuses the menu,
-    not Close; Up/Down on the menu walk individual items (then
-    Close/arrows); Esc from a settings panel returns to the menu
-  - Speed up long rich-text layout (Quick Guide What's New): estimate
-    scroll height before wrapping, skip FreeType for runs that clearly
-    fit or overflow by character budget, and use one measure for
-    typical bullets
-  - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
-    button are reachable from the keyboard
-  - Add Expert Look → Screen Layout setting "Display type" (LCD /
-    E-ink / Color e-ink); e-ink modes disable kinetic and smooth
-    scrolling. Defaults to E-ink on Kobo and LCD elsewhere
-  - Show the Vario flag on the device list for non-compensated and
-    netto vario
-    sources as well as total-energy (e.g. BlueFly)
-  - E-paper: snap VScrollPanel smooth scrolling instead of animating at
-    ~60 Hz, and debounce ComboPicker per-item help updates while
-    scrolling (InfoBox content list etc.)
-  - FLARM radar: show callsigns on all registered targets again, use the
-    full callsign on target labels, and omit duplicate side vario/altitude
-    on the selected target (info panel already shows them) #2718
-  - FLARM radar: rotate track-up targets on cardinal bearings (due
-    north/south or east/west)
-  - Add XCTherm to the pages config map overlay choices (alongside RASP
-    and EDL) #2705
-  - Add Weather Setup to the weather overlay menu (opens Info → Weather
-    on the active overlay tab); the layer/level/altitude list picker also
-    has a Setup button for the same path #2690
-  - Add Auto update to the RASP weather panel to enable/disable background
-    download of the forecast; it downloads at most once a day and only
-    while the forecast time follows the clock (Auto or Now); Update
-    remains available for a manual refresh
-  - Add Auto update to the EDL weather panel to enable/disable background
-    download of missing overlay tiles; Precache day is disabled while Auto
-    update is on #2690
-  - Add Layer/Time (Level/Altitude) on weather panels for the current map
-    page; Apply to page commits changes when dirty, Add page creates a
-    page with those values, and Pages setup opens Config → Look → Pages
-    #2705 #2690
-  - Store both overlay cursor axes on weather map pages: RASP Layer/Time,
-    EDL Level/Time, and XCTherm Altitude/Time; switching pages restores
-    Auto or manual selections independently #2690 #2705
-  - Show the current map page RASP layer and time on the RASP weather
-    panel; Apply commits them to that page #2690
-  - Allow Precache day on the EDL weather panel without an active EDL map
-    page; add Time and Level using the same pickers as the overlay
-    controls #2690
-  - Align the XCTherm weather panel Time / Altitude layout with RASP and
-    EDL; map Altitude is independent of the download Layer #2690 #2705
-  - Store RASP forecast time per map page (Auto, Now, or fixed slot);
-    selecting a page restores its Layer and Time #2690 #2705
-  - Fix crash when opening Weather Setup from the weather overlay
-    layer/level/altitude list picker #2690
-  - Keep the RASP time cursor when stepping onto all-day layers (single
-    archive time slot such as PFD); grey out the time controls until a
-    multi-slot layer is selected again #2705
-  - Show all tasks by default in Task Browser instead of requiring to click
-    the "More" button first.
-  - Rename to turnpoint observation zone type "Symmetric Quadrant" to
-    "Symmetric Sector", as these zones do not have to be 90 degrees but
-    support any angle.
-  - Outline selected targets on the FLARM traffic radar
-  - Weather cursor bar: narrower stepper buttons on touchscreens and clip
-    long centre labels instead of hiding them when they do not fit
-  - Fix crash when opening the map item list on waypoints with long
-    non-ASCII comments (UTF-8 truncation)
-  - Fix crash wrapping unspaced UTF-8 help text (e.g. Chinese language
-    picker) #2768
-  - add optional map overlay QuickMenu button (Config → Look → Layout),
-    enabled by default when a touch screen is detected #2610
-  - input events: add ``VarioVolume`` to mute/unmute and adjust the
-    internal audio vario volume
-  - audio vario: add manual/automatic Vario/STF sound switching and
-    ``VarioAudioMode`` input events
-* glide computer
+* calculations
   - fix wild T Avg climb rates by preferring the instrument vario when
     available #2754
-  - Speed-to-fly and task calculations are now altitude-corrected: the glide
-    polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
-    so optimal cruise speeds increase with altitude and best L/D is preserved
-    (#1569)
-  - Task manager glide and safety polars use the same density ratio from baro
-    or GPS altitude
-  - Netto vario (when derived from the polar) and vario speed-to-fly
-    push/pull arrows use true airspeed against the density-scaled polar sink
-    and speed-to-fly
-* android
-  - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
-    dongles, in addition to HM-10; the protocol is auto-detected at connection
-    time #2260
-  - BLE serial ports also support Microchip/ISSC transparent UART
-    (e.g. BlueFly Vario over BLE); auto-detected like NUS/HM-10
-  - The saved device port type string for that mode remains ble_hm10 so
-    existing profiles load without migration
-  - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices
-  - Fix crash when the native thread restarts after surface teardown
-    (JNI helper classes were not cleared between runNative calls)
-* Kobo
-  - always start in light mode; dark mode is not supported on e-paper
-    displays #2568
-* Windows
-  - fix crash opening the log list when replay filenames contain
-    non-ASCII characters (Unicode directory listing and file open)
-* devices
-  - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
-    shows other gliders on the FLARM radar and map
-  - Condor3UDP: stop deriving track from ground-velocity vx/vy (caused
-    spurious ~120° FLARM radar bearing jumps after compass expiry)
-  - support $LK8EX1 (LK8000 external instrument) on all device ports:
-    pressure, QNE altitude, vario, temperature, and battery voltage
-    or percentage #2772
-  - $LXWP0 without airspeed publishes uncompensated vario (BlueFly LX
-    mode) instead of labelling it total-energy; with IAS/TAS keep TE
-  - BlueFly Vario: publish battery voltage from BAT telemetry (mV)
-    in addition to the estimated percentage
-  - BlueFly Vario: parse TMP temperature telemetry (deci-degrees C)
-  - BlueFly Vario: parse $BFV/$BFX telemetry and offer BFV/BFX (and
-    None) output modes in the device manage dialog
-  - BlueFly Vario: download onboard IGC flight logs (Devices → Flight
-    download) via $BLF* / $BFF*
-  - BlueFly Vario: add output frequency, lift/sink thresholds, and
-    audio when connected to the device manage dialog
-  - Accept partial $LXWP0 vario samples (e.g. BlueFly LX mode with a
-    single rate) so Status Variometer is not stuck on Disconnected while
-    baro still works; keep the six-sample FIR for full LXNAV sentences #2763
-  - fix LXNAV thermal averages when the device reports conflicting
-    altitude sources #2754
-  - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
-    suffixes (#0, #1) in both the port list and device list #2481
-  - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
-    ISA logger datum; cleared when strong pressure replaces weak pressure or
-    ignores the sentence
-  - LXNAV: apply device vario filter time ($LXWP3 variofil) to gauge, map
-    vario bar, thermal rose, audio vario and snail-trail colouring
-  - Condor 3: new UDP telemetry driver (Condor3UDP) for Simkits generic UDP
-    output (default port 55278); complements TCP/NMEA Condor3 for MacCready,
-    ballast, attitude, radio, and related fields (#2340)
-  - Glide polar sync in the device dialog is only shown for drivers that
-    implement it (LXNAV)
-  - Increase the number of device slots from 6 to 8
-* ui
-  - fix crash when switching pages from FLARM radar or thermal assistant back
-    to a map page that has a bottom widget configured (#2583)
-  - airspace warnings: fix crash when the warning clears if the bottom page
-    was already restored
-  - pages config: map overlay and RASP layer rows stay visible on non-map
-    pages (disabled instead of hidden); weather controls and overlay
-    selection are decoupled (#2583)
-  - macOS: thick solid lines now render at their correct pixel width #2545
-  - Android: fix spurious outline lines on high-DPI OpenGL displays #1514
-  - plane details: WeGlide aircraft type can be configured even when WeGlide
-    upload is disabled #2323
-  - status dialog, Times: flight time matches takeoff and landing after
-    minute rounding (including across midnight); landing time clears on a
-    new takeoff in the same session #957
-  - status dialog, Rules: after a valid start, show PEV offset at start (time
-    from PEV window start to the crossing) when known, as a duration (e.g.
-    "45 sec", "2 min") not HH:MM so sub-minute offsets are not shown as 00:00
-  - infoboxen: Start reach uses remaining distance / ground speed when the
-    MacCready leg solution is not OK, so it matches Start open again in the
-    common MC-too-low / wind cases; Start open shows a signed gate countdown at
-    now instead of a blank value #2502; Start reach main value is time to the
-    start line (leg ETA), not gate countdown at arrival; Start open value colour
-    and comment reflect gate state at now (Waiting/Open/Closed, blue/green/red);
-    Start reach value colour and comment reflect gate state at leg ETA
-    (Too early/Can start/Too late, blue/green/red)
-  - infoboxen: new Altitude IGC InfoBox (logger pressure or ISA pressure only)
-  - BigTrafficWidget: task direction arrow matches map best-cruise shape,
-    drawn as outline between range rings #2027
-  - plane polar dialog: fix polar coefficient grid layout and auto-sized width
-  - waypoint search: name filter matches anywhere in the long name and the
-    shortname (typically the ICAO code in SeeYou .cup files), not only at
-    the start, so e.g. "FIELD" finds "AIRFIELD" and "INGEN" finds
-    "DITTINGEN" #2483
-  - waypoint search: each waypoint appears at most once in the result list,
-    even when the typed substring matches both its long name and its
-    shortname #1316
-  - waypoint search: Type filter no longer lists the .xcm map archive as a
-    selectable filter when its embedded waypoints are not loaded (e.g. when
-    a separate WPFileList already supplied the database), so the dropdown
-    no longer offers a filter that always yields zero matches #1376
-  - waypoint search: "Recently Used" Type filter entry shows the
-    recently-visited waypoints again; it had been silently aliased to the
-    unrelated "Map file" filter since the multi-file rework (#1994) due to
-    a positional dropdown/enum mismatch
-  - large FLARM radar: optional callsign and relative altitude (in hundreds,
-    as on the small gauge) beside targets when side data is in altitude mode;
-    passive targets use default colours when no altitude brush is set
-  - waypoint search: Type filter now lists every CUP waypoint type
-    (Mountain Top/Pass, Bridge, Tunnel, Tower, Power Plant, Obstacle,
-    Thermal Hotspot, Marker, VOR, NDB, Dam, Castle, Intersection,
-    Reporting Point, PG Take Off / Landing Zone) #2485
-  - infoboxen: new "Active Waypoint" InfoBox (next task waypoint, or Goto
-    waypoint when no task is loaded; shows name, arrival height above safety,
-    and distance; tap to pick a different task leg or set a new Goto)
-  - infoboxen: new "Previous Waypoint" InfoBox (task waypoint before the active
-    leg, or the start waypoint while on the first leg; shows name, arrival
-    height above safety, and distance; tap to display a different waypoint
-    without advancing the task or setting a Goto, or "Resume auto tracking" to
-    revert)
-  - new Data Management hub (menu, quick menu, and ``DataManagement`` input
-    event): site files, download manager, export flights, import data,
-    backup manager, and advanced file explorer in one place
-  - storage location picker lists removable and external volumes; the list
-    refreshes when media is plugged or unplugged (Linux udev, Windows
-    volumes, Android storage access framework)
-  - import data: pick files on external storage and copy recognized types
-    into the correct XCSoar data subdirectories (waypoints, airspaces,
-    terrain, and the rest); unknown files can stay in the data root #2289
-  - backup manager: create and restore ``.tar`` backups of the primary data
-    tree on a chosen volume; logs, existing archives, and ``cache/`` are
-    excluded; restore rejects paths outside the data tree
-  - advanced file explorer: browse any storage device, organize loose files
-    into typed subdirectories, transfer selections to another volume, and
-    rename or delete files #2289
-* desktop
-  - command-line: -h/--help and -version/--version print to stdout and exit;
-    unknown options print a short usage line on stderr
-  - flight export and data import use the shared storage picker and hotplug
-    refresh (extends external-storage export/import on Linux and Windows)
-    #1114
-* ui
-  - Waypoint details embedded image: new input mode ``wptimg`` and
-    ``WaypointImage`` events (magnify, shrink, reset, arrows) so keys
-    can be set in the ``.xci`` file without the map's ``default`` key
-    fallback
-  - Waypoint details embedded image and PC-Met satellite viewer: zoom and
-    pan with focal-point centering when magnifying; supports +/- buttons,
-    F2/F3, and arrow keys (#1127, #1246)
-* input
-  - F2 = zoom in, F3 = zoom out in pan, on the FLARM radar, and in waypoint
-    image ``wptimg`` (not on the main non-pan map, where F2/F3 stay Checklist
-    and FLARM as before). Traffic: ``next`` and ``previous`` events; FLARM: UP/DOWN
-    and F4 = next target (with UP/DOWN), F1 = AVG/ALT labels, F2/F3 = zoom.
-    The radar no longer hard-codes d-pad to zoom; bindings come from the
-    ``.xci`` file
-  - ``GotoLookup`` accepts an optional argument to pre-select the Type
-    filter on entry (``recent``/``last_used``, ``airport``, ``landable``,
-    ``turnpoint``, ``start``, ``finish``), so a gesture or key binding can
-    open the waypoint list focused on a category #336
-  - default Left-Up (LU) map gesture opens the Waypoint Selection dialog
-    pre-filtered to recently-used waypoints; listed in the Gesture Help
-    dialog with its own icon #336
+  - support altitude-corrected speed-to-fly and task glide calculations:
+    cruise speeds and best glide stay correct higher up (#1569)
+  - use the same altitude correction for task manager glide and safety
+    calculations
+  - use true airspeed for netto vario and speed-to-fly arrows when the
+    polar supplies netto vario
+  - restore FFVV NetCoupe contest optimisation #2330
+  - prefer netto vario from the variometer in the thermal assistant when
+    available
+  - fix angle bearing and delta normalization so extremely large values
+    no longer stall (suspected Android freeze #1292)
+* task
+  - fix CUP task waypoints that failed to load from a task file without
+    showing an error (#2496)
+  - fix CUP task observation zones with uncommon angles (they were
+    incorrectly parsed as FAI quadrants) #2697
+  - rename turnpoint observation zone type "Symmetric Quadrant" to
+    "Symmetric Sector" (any angle, not only 90 degrees)
+  - show all tasks by default in Task Browser (no "More" click first)
+  - add optional turn back marker (Safety Factors): green triangle along
+    track showing how far you can still fly and reach the active task
+    waypoint or Goto; only in cruise when the target is reachable;
+    saved in the profile #1741
+  - support AUTO or MANUAL Alternate 1/2 InfoBoxes: tap to open the
+    alternates list, switch mode, and assign a row (AUTO clears a manual
+    pin); titles show Altn 1/2 with AUTO or MAN
+  - raise alternates list to 10 options (was 6); if the task has only one
+    automatic alternate, Alternate 2 no longer duplicates Alternate 1;
+    glide values update with current conditions; colours show not
+    reachable, final glide, need climb, and manual on/below glide #2347
+  - list airfields before outlanding sites in the alternates list
+  - clarify alternates AUTO/MANUAL help text in Safety Factors (#555)
+  - open waypoint details above the waypoint list and alternates; Close
+    without a committed action returns to the list, not the map #620
 * map
   - fix black terrain after idle high-resolution sharpening on OpenGL
-    devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
-  - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi
-    1–3 / 3B+, Cubieboard-class), keep the Full snail trail store at 1024
-    points (7.44 size) instead of the larger fast-host capacity #2661
-  - snail trail: reduce long-flight map CPU by clipping the trail to the
-    visible area before spacing-thinning (Full trail no longer walks the
-    whole history every redraw) #2661
-  - dynamically adjust contour line density to zoom factor #2233
-  - provide different contour density profile settings for mountains,
-    low lands, etc. to have sensible contours in a given landscape type
-  - turn back marker: new opt-in overlay (Safety Factors config panel) showing
-    a green triangle along the current track indicating the furthest point from
-    which the active task waypoint or Goto target can still be reached with the
-    current altitude and conditions; only shown during cruise when the target
-    is reachable; persisted via profile key TurnBackMarkerEnabled #1741
-  - larger on-map typography: default waypoint text, map-scale readout, and
-    topography labels
-  - map waypoint icons (bitmap and vector landables): new ``Waypoint icon
-    size`` on Configuration → Map display → Waypoints (50–200%, default 100%)
-  - obstacles hidden at wider map scales than other non-landables (5000 vs 10000)
+    devices with a 2048-pixel texture limit
+  - keep the Full snail trail store at 1024 points on slower hosts
+    (typical e-readers and similar) instead of the larger fast-host
+    capacity #2661
+  - reduce long-flight map CPU by clipping the snail trail to the
+    visible area before thinning #2661
+  - adjust contour line density to the zoom level #2233
+  - add contour density profile settings for mountains, lowlands, and
+    other landscape types
+  - enlarge on-map text: waypoint names, map scale, and topography
+    labels
+  - add "Waypoint icon size" on Configuration → Map display → Waypoints
+    (50–200%, default 100%)
+  - make the thermal hotspot icon easier to see on dark backgrounds
+    #2448
+  - hide obstacles at wider map scales than other non-landables
   - draw up to 1024 waypoints at once (was 256) #2327
-  - terrain: fix fluctuating hill-shading strength #2262
-  - snail trail: Catmull-Rom smoothing between fixes; vario colouring samples
-    high-rate netto from the merge thread between GPS points #2447
-  - Add renderer to display distance rings around the current location #2522
-  - Fix intermittent white-map hang on startup for non-OpenGL builds when
-    drawing began before map bounds were ready #2734
-* ui
-  - infoboxen: refresh titles after changing the interface language #2314
-  - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
-    distance; tap to change home waypoint) #2320
-  - alternates: Alternate 1/2 InfoBoxes can follow the computed list (AUTO) or
-    a pilot-chosen field (MANUAL); tap the InfoBox to open the alternates list,
-    switch mode, and assign the selected row to that slot (runtime only; AUTO
-    clears the pin).  Titles show Altn 1/2 with AUTO or MAN.
-  - list dialogs: Up/Down move the list (when the list is focused) so
-    filter rows in the same dialog (e.g. waypoint file) still get those keys;
-    Left/Right move the action bar with cursor key selection; current
-    action uses list-focus colours in the light theme and the bright
-    focus colour in dark, like other dialog focus.  Select Airspace: Details
-    and Close are on the main dialog action bar (bottom/edge) so the same
-    keys can reach them after the list, like other list dialogs
-  - map item list and airspace list: respect list focus/selection text colours
-    (was unreadable focused row on e-ink: paint reset colour to black on a
-    black focused background) #2495
-  - alternates: list holds up to 10 options (was 6); if the task only has one
-    automatic alternate, Alternate 2 no longer shows the same as Alternate 1.
-    Displayed glide is re-solved with the current aircraft state; value colour
-    encodes not reachable, final glide, need climb, and MANUAL on/below glide.
-    Manual updated en/de/fr/pt_BR #2347
-  - clarify alternates mode help text in Safety Factors config panel (#555)
-  - status: show G-load availability in device list and variometer source in
-    system status
-  - terrain: add new terrain shading orientation "fixed (Top Left)"
-  - airspace list & map item list: grey text for airspaces with a day
-    acknowledgement; map item list adds an "Enable" button to clear it (like the
-    airspace warnings list) #2404
-  - airspace warnings: keep the cursor key action in sync with which actions
-    are enabled, and the armed action with keyboard focus (no double
-    highlight when e.g. Close is focused and another is cursor-selected);
-    replace Radio with Details; Up/Down move the list, Left/Right the action
-    row, Up from the action row returns to the list
-  - Form/DataField/Enum: remove the limit of 128 internal entries (It was
-    dropping the newest InfoBoxes, as we have 130 of them now)
-  - encode bundled UI OGG sound assets at Vorbis quality 5 (was 1)
-  - tabbed dialogs: show list-style focus on the tab strip when the device has
-    cursor keys and the strip has keyboard focus (or always on devices without
-    cursor keys, where the indicator is informational only)
-  - checklist rich text: Enter on a checkbox advances focus like Down #2405
-  - checklist/help markdown: vhf:…#standby / vhf:…#active links set COM standby or
-    active (optional station name in [text](url); label shows name and MHz);
-    confirmation after tap; documented in doc/checklist.rst; example on the
-    default getting-started checklist
-  - checklist, credits, Quick Guide, configuration: horizontal swipe to flip
-    pager pages (same behaviour as arrow keys); wiring lives in
-    ArrowPagerWidget::Prepare; red trail while drawing the swipe; fix crash when
-    swiping (pager change deferred until after mouse-up) #2122 #2414
-  - Quick Guide "What's New": release notes are Markdown generated at build time
-    from NEWS.txt (headings + merged list lines) instead of truncating the
-    gzipped file at runtime
-  - Quick Guide, getting started: "Safety factors" and "Terrain display" lines
-    use live settings vs factory defaults (not hardcoded unchecked) #2324
-  - Quick Guide, help & configuration checklists: list checkboxes use dialog
-    look and min touch row height; keyboard focus frame on the checkbox; override
-    touch autodetection with -touchscreen or -notouchscreen (non-Android) #2325
-  - Quick Guide: "Don't show this guide again" on every informational page;
-    skip Welcome on startup when the guide is hidden; Config → Look →
-    Language, Input controls startup visibility, release notes on next
-    startup, and safety disclaimer acceptance #2648
-  - waypoint search: stays open until Esc or a successful GoTo / task / home / pan
-    action (pan ends the search so the map is not hidden under the list); same for
-    WaypointDetails select and WaypointDetailsPersistent (was: only after closing
-    details) #749
-  - waypoint list & alternates: waypoint details open above the list; Close without
-    a committed action returns to the list, not the map #620
-  - Added QNH InfoBox displaying current QNH pressure setting in hectopascals #2521
-  - Linux: Config → Setup → Network for WiFi (NetworkManager or ConnMan
-    via D-Bus)
-* android
-  - use physical display metrics for startup DPI (getRealMetrics) #1784
-  - UI sounds via preloaded SoundPool (MediaPlayer fallback for early play or
-    external .wav); AudioAttributes before prepare; transient audio focus with
-    flush between SoundPool plays; volume scaled from media/notification streams;
-    log warnings/errors only on failure #2411
-  - native debug symbols for Google Play (symbols.zip), lib/<ABI>/ layout for
-    single-ABI and multi-ABI (AAB) builds; Makefile fix so parallel builds
-    reliably produce the symbol ZIP in CI
-  - configure built-in GPS & sensors in the last device slot by default (same on
-    iOS)
-  - storage enumeration and permission grants update the device list when
-    the user picks a folder or when SAF access changes
-* calculations
-  - BrokenDateTime: unified UTC conversion (rename FromUnixTimeUTC to
-    FromUnixTime); Windows TimeGm uses _mkgmtime
-  - restore FFVV NetCoupe contest optimisation #2330
-  - angle bearing/delta normalization uses O(1) wrap (avoids stalls when angles
-    are extremely large; suspected Android freeze #1292)
+  - fix fluctuating terrain hill-shading strength #2262
+  - keep terrain hill-shading sharp before the first GPS fix #2331
+  - add terrain shading orientation "fixed (Top Left)"
+  - smooth snail trail between fixes; vario colours use high-rate netto
+    between GPS points when available #2447
+  - add distance rings around the current location #2522
+  - fix intermittent white-map hang on startup when drawing began before
+    map bounds were ready #2734
+  - match BigTrafficWidget task direction arrow to the map best-cruise
+    shape #2027
+  - show optional callsign and relative altitude beside BigTrafficWidget
+    targets when side data is in altitude mode
 * weather
-  - METAR/TAF station list: accept lowercase ICAO codes when adding a station;
-    codes are normalized to upper-case for download and profile storage
-  - add EDL weather support with per-page map overlays (None/RASP/EDL),
-    bottom-panel weather controls with auto-advance, day precaching,
-    and simplified RASP configuration (field/time on pages instead of the
-    weather dialog)
-  - add ``WeatherOverlay`` input event and ``mode=weather`` stick/button
-    bindings (via quick menu **Forecast Controls**) to step forecast time
+  - accept lowercase ICAO codes when adding a METAR/TAF station
+  - add EDL weather with per-page map overlays (None/RASP/EDL), bottom
+    panel weather controls with auto-advance, day precaching, and
+    simpler RASP setup (field and time on pages)
+  - show RASP weather dialog file age and open the file manager for the
+    selected field
+  - add XCTherm as a map overlay choice alongside RASP and EDL #2705
+  - add Weather Setup to the weather overlay menu and layer/level/
+    altitude list picker (opens Info → Weather on the active overlay
+    tab) #2690
+  - add Auto update on the RASP panel for once-a-day background download
+    while forecast time follows the clock (Auto or Now); Update remains
+    for a manual refresh
+  - add Auto update on the EDL panel for missing overlay tiles; Precache
+    day is disabled while Auto update is on #2690
+  - add Layer/Time (Level/Altitude) on weather panels for the current map
+    page; Apply to page, Add page, and Pages setup #2705 #2690
+  - store both overlay cursor axes per weather map page (RASP Layer/Time,
+    EDL Level/Time, XCTherm Altitude/Time) #2690 #2705
+  - store RASP forecast time per map page (Auto, Now, or fixed slot) and
+    restore Layer and Time when selecting a page #2690 #2705
+  - show the current map page RASP layer and time on the RASP panel;
+    Apply commits them to that page #2690
+  - allow Precache day on the EDL panel without an active EDL map page;
+    add Time and Level with the same pickers as the overlay controls
+    #2690
+  - align XCTherm Time / Altitude layout with RASP and EDL; map Altitude
+    is independent of the download Layer #2690 #2705
+  - keep the RASP time cursor on all-day layers (single archive slot);
+    grey out time controls until a multi-slot layer is selected again
+    #2705
+  - fix crash when opening Weather Setup from the weather overlay
+    layer/level/altitude list picker #2690
+  - add WeatherOverlay input event and mode=weather stick/button
+    bindings (via quick menu Forecast Controls) to step forecast time
     and altitude/level on weather overlay map pages (#2583)
-  - pc_met www images: add RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT RAD
-    BLITZ, and Blitzkarte Europa; local radar list uses Borkum instead of
-    the removed Emden site
+  - narrow weather cursor bar stepper buttons on touchscreens and clip
+    long centre labels instead of hiding them
+  - add pc_met www images: RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT
+    RAD BLITZ, and Blitzkarte Europa; local radar list uses Borkum
+    instead of the removed Emden site
 * NOTAM integration #2018
   - add support for downloading, caching and displaying NOTAM airspaces
   - add manual refresh and auto-refresh with location/time based updates
-  - add NOTAM settings and filters (IFR, effective time, max radius, hidden Q-codes)
+  - add NOTAM settings and filters (IFR, effective time, max radius,
+    hidden Q-codes)
   - add NOTAM details integration in airspace dialogs
+  - show a briefing disclaimer before the first NOTAM download
 * data files
-  - .cup tasks: More correctly parse SeeYou .cup task files with observation zones
-    with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder.
-    Previously these were incorrectly parsed into FAI Quadrants #2697
-  - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
-    is read correctly
-  - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
-  - XCSoar data layout: waypoints, airspaces, terrain, profiles, logs, and
-    other repository types use typed subdirectories under the data root;
-    built-in and downloaded files save and resolve through the FileType API
-    instead of hard-coded extensions #2289
-  - on first start after upgrade, move legacy flat files in the primary data
-    directory into the matching subdirectories when the destination does not
-    yet exist; migration is marked complete only after at least one file was
-    moved #2289
-  - IGC and NMEA logs are stored under ``logs/`` #2289
+  - map OpenAir AY ASRA to aerial sporting/recreational airspace type
+    #1827
+  - accept ".openair" as an airspace file extension
+  - organise data files in folders by type (waypoints, airspaces,
+    terrain, profiles, logs, and downloads) instead of one flat
+    directory #2289
+  - move existing files into matching subfolders on first start after
+    upgrade when possible #2289
+  - store IGC and NMEA logs under logs/ #2289
+  - create needed folders on a fresh install before the download manager
+    saves files #2580
   - fix crash when queuing many background file downloads while others
-    complete (download manager queue race) #2624
+    complete #2624
 * devices
-  - add GDL 90 input driver (standard ADS-B traffic and ownship over serial or
-    UDP; optional ForeFlight geometric altitude and AHRS; horizontal/vertical
-    traffic filters) #2356
-  - fix native crash on device reconnect (stale delayed reopen timer) #2382
-  - Polar sync device setting is offered only for drivers that register polar
-    support (currently LXNAV); PutPolar is skipped on other drivers even if an old
-    profile had Polar sync enabled #2457
+  - add GDL 90 input driver (ADS-B traffic and ownship over serial or
+    UDP; optional ForeFlight geometric altitude and AHRS;
+    horizontal/vertical traffic filters) #2356
+  - add LX160 driver for LXWPx varios (#2424)
+  - add LX Eos task declaration and logger support (#2433)
+  - fix LX stale vario and misaligned heading/wind from $LXWP0 (#2554)
+  - add Condor 3 Spectate.json multiplayer traffic driver
+    (Condor3Spectate) for other gliders on the FLARM radar and map
+  - add Condor 3 UDP telemetry driver (Condor3UDP) for Simkits generic
+    UDP output (default port 55278); complements TCP/NMEA Condor3 for
+    MacCready, ballast, attitude, radio, and related fields (#2340)
+  - fix Condor3UDP track jumps from ground-velocity vx/vy after compass
+    expiry
+  - support $LK8EX1 (LK8000 external instrument) on all device ports:
+    pressure, QNE altitude, vario, temperature, and battery #2772
+  - treat $LXWP0 without airspeed as uncompensated vario (BlueFly LX
+    mode) instead of total-energy; with IAS/TAS keep TE
+  - accept partial $LXWP0 vario samples so Status Variometer is not stuck
+    on Disconnected while baro still works #2763
+  - publish BlueFly battery voltage from BAT telemetry in addition to
+    estimated percentage
+  - parse BlueFly TMP temperature telemetry
+  - parse BlueFly $BFV/$BFX telemetry and offer BFV/BFX (and None)
+    output modes in the device manage dialog
+  - support BlueFly onboard IGC flight log download (Devices → Flight
+    download)
+  - add BlueFly output frequency, lift/sink thresholds, and audio when
+    connected to the device manage dialog
+  - fix LXNAV thermal averages when the device reports conflicting
+    altitude sources #2754
+  - apply LXNAV device vario filter time to gauge, map vario bar,
+    thermal rose, audio vario, and snail-trail colouring
+  - feed FLARM $PGRMZ barometric altitude into IGC logger pressure
+    altitude when FLARM is detected
+  - show glide polar sync in the device dialog only for drivers that
+    support it (LXNAV) #2457
+  - send QNH changes from external sources to all connected devices
+  - show the Vario flag on the device list for non-compensated and
+    netto vario sources as well as total-energy (e.g. BlueFly)
+  - increase the number of device slots from 6 to 8
+  - fix crash on device reconnect (stale delayed reopen timer) #2382
+* infoboxes
+  - add Altitude IGC InfoBox (logger pressure or ISA pressure only)
+  - fix Start reach and Start open values and colours when MacCready is
+    too low or wind affects the leg; Start open shows gate countdown at
+    now; Start reach shows time to the start line #2502
+  - add Active Waypoint InfoBox (next task waypoint or Goto; tap to pick
+    another leg or set Goto)
+  - add Previous Waypoint InfoBox (waypoint before the active leg; tap
+    to inspect without advancing the task, or resume auto tracking)
+  - add Home InfoBox (name, arrival height at home, distance; tap to
+    change home) #2320
+  - add QNH InfoBox displaying current QNH in hectopascals #2521
+  - refresh InfoBox titles after changing the interface language #2314
+  - scale artificial horizon dial marks with InfoBox size
+* ui
+  - add pinch-to-zoom on the map for touchscreens that report both
+    finger positions (Android, iOS): scale about the pinch centroid and
+    pan at the same time; a two-finger drag or twist enters pan mode; a
+    zoom-only pinch keeps following the aircraft #2790
+  - add two-finger twist to temporarily rotate the map; the angle is
+    held while panning and restored when pan mode is left #2790
+  - animate keyboard and mouse-wheel map zoom on non-e-ink displays so
+    scale steps feel continuous after a pinch; free zoom continues from
+    an off-list scale and snaps to the usual list when close again
+  - keep the north arrow clear of the on-screen menu and zoom buttons
+  - improve simulator discoverability: startup tip to steer by dragging
+    from the glider or via Altitude / Speed Ground InfoBoxes; Welcome
+    Quick Guide paragraph in simulator mode; "Sim: Jump to" on map items
+    and waypoint details; Speed Ground simulator panel; label Set Home
+    as "Set as Startup Location" in simulator mode
+  - bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
+    (same as AVG/ALT softkey and RL gesture)
+  - draw map GPS status above the map scale / title line so it is not
+    covered by AUTO / Simulator / REPLAY text
+  - improve soft keyboard text entry: default focus on a key; cursor
+    keys move across the grid; F1 is backspace
+  - fix profile selection / startup branding on light dialog backgrounds
+    #2742
+  - size the InfoBox panel to the current tab and lift map overlays by
+    that height only
+  - fix map vario / final-glide value labels: rounded rectangle with even
+    padding and an unbroken outline #1438
+  - swap map overlay sides: vario bar on the left, final glide bar on
+    the right #1210
+  - add airspace labels toggle: Display page 2, Quick Menu, and
+    AirspaceLabels input event (on/off, saved to profile) #1243
+  - add Quick Guide and Replay to the Quick Menu (Replay disabled when
+    moving)
+  - show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
+  - allow Left/Right on the simulator prompt to choose Fly / Simulator
+    immediately
+  - improve the map items dialog: scale "Your Position" aircraft icon;
+    Enter / Details opens Status: Flight; show airspace Inside/Near
+    status like the warnings dialog
+  - tint the bottom airspace warning banner red (inside) or yellow
+    (near) on colour displays
+  - show distance and time in the bottom airspace warning banner
+  - put WiFi Connect first and Close last in the WiFi dialog
+  - put Download before Cancel in the download picker; Left/Right page
+    the list
+  - use single keyboard focus in the multi-file picker and value list
+    picker (ComboPicker)
+  - draw a thin separator line above list-picker bottom help text
+  - make Quick Menu Left/Right stay put when the next item is disabled,
+    but still wrap or flip page at a real row edge
+  - use focus colour for action-bar buttons that have keyboard focus
+  - open waypoint details with Details / F1 (Enter still confirms the
+    selection)
+  - move Task Manager keyboard focus with Manage → Browse (and WeGlide
+    lists) so Up/Down can move the task list again
+  - fix task point dialog keyboard navigation: Up/Down no longer skip
+    OZ Radius; Left/Right change the task point; portrait layout uses
+    full width for map and OZ fields
+  - fill leftover pixels on the last dialog action-bar button in a row
+  - put Reference Mass above the plane polar V/W grid; Up/Down moves
+    within each V/W column
+  - fix Configuration keyboard navigation between settings rows, menu,
+    and Close
+  - speed up long rich-text layout (Quick Guide What's New)
+  - fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
+    are reachable from the keyboard
+  - add Expert Look → Screen Layout "Display type" (LCD / E-ink /
+    Color e-ink); e-ink modes disable kinetic and smooth scrolling;
+    defaults to E-ink on Kobo and LCD elsewhere
+  - snap e-paper VScrollPanel scrolling instead of animating at high
+    rate, and debounce ComboPicker help updates while scrolling
+  - show FLARM radar callsigns on all registered targets again, use the
+    full callsign on labels, and omit duplicate side vario/altitude on
+    the selected target #2718
+  - rotate FLARM radar track-up targets on cardinal bearings
+  - outline selected targets on the FLARM traffic radar
+  - fix crash when opening the map item list on waypoints with long
+    non-ASCII comments
+  - fix crash wrapping unspaced UTF-8 help text (e.g. Chinese language
+    picker) #2768
+  - add optional map overlay QuickMenu button (Config → Look → Layout),
+    enabled by default when a touch screen is detected #2610
+  - fix crash when switching pages from FLARM radar or thermal assistant
+    back to a map page that has a bottom widget (#2583)
+  - fix airspace warnings crash when the warning clears if the bottom
+    page was already restored
+  - keep pages config map overlay and RASP layer rows visible on non-map
+    pages (disabled instead of hidden) (#2583)
+  - allow WeGlide aircraft type in plane details even when WeGlide
+    upload is disabled #2323
+  - fix status dialog Times: flight time matches takeoff and landing
+    after minute rounding; landing time clears on a new takeoff #957
+  - show PEV offset at start in status Rules as a duration (e.g.
+    "45 sec", "2 min"), not HH:MM
+  - show G-load availability and variometer source in system status
+  - fix plane polar dialog coefficient grid layout and auto-sized width
+  - use readable text colours for read-only text fields (e.g. waypoint
+    details) #2465
+  - add Data Management hub (menu, quick menu, and DataManagement input
+    event): site files, download manager, export flights, import data,
+    backup manager, and file explorer in one place
+  - list USB sticks and other removable storage in the storage picker;
+    refresh when media is plugged in or removed
+  - import data: copy files from external storage into the correct
+    XCSoar folders (waypoints, airspaces, terrain, and the rest) #2289
+  - backup manager: copy the XCSoar data directory to chosen storage as
+    a dated .tar file (profiles, waypoints, airspaces, terrain, and
+    settings; not logs, other backups, or cache); restore warns before
+    overwriting; restart XCSoar afterward to apply restored settings
+  - file explorer: browse storage, sort files into folders, copy to
+    another drive, rename, and delete #2289
+  - find waypoint search text anywhere in the name or short name #2483
+  - list each waypoint only once in search results #1316
+  - remove useless "map file" type filter when waypoints come from
+    another file #1376
+  - fix "Recently Used" waypoint type filter #1994
+  - list all CUP waypoint types in the waypoint search Type filter
+    #2485
+  - keep waypoint search open until Esc or a successful GoTo, task,
+    home, or pan action #749
+  - zoom and pan waypoint details images and PC-Met satellite viewer
+    with +/- buttons, F2/F3, and arrow keys (#1127, #1246)
+  - improve list dialog keyboard navigation; Select Airspace puts
+    Details and Close on the main button row
+  - fix airspace and map item list focus colours on e-paper #2495
+  - grey out day-acknowledged airspaces in lists; map item list adds
+    Enable to turn warnings back on #2404
+  - remove the map warning triangle for day-acknowledged airspaces
+  - replace Radio with Details in airspace warnings; improve keyboard
+    navigation
+  - disable map overlay buttons on non-map pages (traffic, thermal
+    assistant, etc.)
+  - raise the InfoBox configuration entry limit so all InfoBoxes appear
+  - encode bundled UI sound assets at higher quality
+  - show clearer keyboard focus on tab strips in tabbed dialogs
+  - advance checklist checkbox focus with Enter like Down #2405
+  - support checklist vhf: links to set COM standby or active frequency
+    (optional station name in the link label)
+  - support horizontal swipe to flip checklist, Credits, Quick Guide,
+    and configuration pages #2122 #2414
+  - format Quick Guide "What's New" from NEWS.txt at build time
+  - reflect live Safety factors and Terrain display settings in Quick
+    Guide getting started #2324
+  - improve Quick Guide checklist touch targets and checkbox appearance;
+    -touchscreen / -notouchscreen override autodetection (non-Android)
+    #2325
+  - add "Don't show this guide again" on every Quick Guide informational
+    page; Config → Look → Language, Input controls startup visibility,
+    release notes on next startup, and safety disclaimer acceptance
+    #2648
+  - support manual/automatic Vario/STF sound switching
+* input
+  - add VarioVolume input event to mute/unmute and adjust the internal
+    audio vario volume
+  - add VarioAudioMode input events for Vario/STF sound switching
+  - use F2/F3 for zoom in pan mode, on the FLARM radar, and in waypoint
+    image view (on the main non-pan map F2/F3 stay Checklist and FLARM);
+    traffic: next/previous events; FLARM: UP/DOWN and F4 next target,
+    F1 AVG/ALT labels, F2/F3 zoom; radar bindings come from the input
+    file
+  - open pan mode with Return on the main map (was FLARM radar); F3
+    still opens FLARM traffic
+  - close pan mode and submenu pages with Escape (and Android back);
+    Cancel on the main menu page
+  - replace File Manager with Data Management in the quick menu and
+    Config; add distance rings on/off to the quick menu
+  - accept an optional GotoLookup argument to pre-select the Type filter
+    (recent, airport, landable, turnpoint, start, finish) #336
+  - open recently used waypoints with the default Left-Up (LU) map
+    gesture #336
+  - support WaypointImage / wptimg input mode for waypoint details image
+    keys without falling back to the map default key bindings
+* documentation
+  - document custom .xci loading: #CLEAR, merge vs replace, type values
+    (key / gce / gesture / ne / label), gesture data format, softkey
+    location, label escapes, complete GCE list, and RemoteStick Quick
+    Menu
+  - document AirspaceLabels input event
+  - document map pinch-to-zoom on touchscreens that report both finger
+    positions #2790
+* android
+  - support BLE Nordic UART Service (NUS) for e.g. Naviter dongles, in
+    addition to HM-10; protocol auto-detected at connection #2260
+  - support BLE Microchip/ISSC transparent UART (e.g. BlueFly Vario over
+    BLE); auto-detected like NUS/HM-10
+  - keep the saved device port type string as ble_hm10 so existing
+    profiles load without migration
+  - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as
+    supported USB devices
+  - number multi-port USB serial adapters (e.g. dual FTDI) with
+    suffixes (0, 1) in the port list and device list #2481
+  - fix crash when the native thread restarts after surface teardown
+  - fix spurious outline lines on high-DPI OpenGL displays #1514
+  - use physical display metrics for startup DPI #1784
+  - improve UI sounds via preloaded SoundPool with MediaPlayer fallback
+    #2411
+  - configure built-in GPS and sensors in the last device slot by
+    default
+  - update the device list when storage access changes
 * iOS
   - fix audio vario playback through the device speaker
-  - disable Core Location distance filter for built-in GPS so fixes are not
-    suppressed while stationary #2380
-* kobo
-  - memory canvas: fix painting when list rows or edit fields are partially
-    off-screen while scrolling (no black squares; safer clipping of subcanvas
-    and list blits) #2293
+  - disable Core Location distance filter for built-in GPS so fixes are
+    not suppressed while stationary #2380
+  - configure built-in GPS and sensors in the last device slot by
+    default
+* macOS
+  - fix thick solid lines rendering at incorrect pixel width #2545
+* Linux
+  - add Config → Setup → Network for WiFi (NetworkManager or ConnMan via
+    D-Bus)
+* OpenVario
+  - show WiFi and ethernet status; support WiFi connect/disconnect and
+    ethernet DHCP renew from the Network dialog
 * Windows
-  - add installer for the OpenGL Windows version (64-bit and 32-bit); zip
-    download remains available for a portable install
+  - add installer for the OpenGL Windows version (64-bit and 32-bit);
+    zip download remains available for a portable install
   - deprecate the legacy single-file Windows executable; use the OpenGL
-    version instead — the legacy build will be removed in a future release
+    version instead — the legacy build will be removed in a future
+    release
+  - fix crash opening the log list when replay filenames contain
+    non-ASCII characters
+  - open files in binary mode so embedded ZIP (e.g. CUPX POINTS.CUP) is
+    read correctly
+* desktop
+  - print -h/--help and -version/--version to stdout and exit; unknown
+    options print a short usage line on stderr
+  - use the shared storage picker and hotplug refresh for flight export
+    and data import on Linux and Windows #1114
+* Kobo
+  - always start in light mode; dark mode is not supported on e-paper
+    displays #2568
+  - fix black squares when scrolling lists and edit fields on e-paper
+    #2293
 * development
-  - MapWindow: publish a coherent projection snapshot for the DrawThread on
-    non-OpenGL builds so rendering does not read a live UI projection #2735
+  - MapWindow: publish a coherent projection snapshot for the DrawThread
+    on non-OpenGL builds so rendering does not read a live UI projection
+    #2735
+  - build system: ship native debug symbols for Google Play
+    (symbols.zip) for single-ABI and multi-ABI (AAB) builds; fix parallel
+    builds so CI reliably produces the symbol ZIP
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,433 +1,352 @@
 Version 7.45 - not yet released
 * tracking
-  - separate XCSoar Cloud settings from SkyLines live tracking: cloud
-    traffic and roaming no longer depend on SkyLines options
-  - rename map display setting to "Online traffic on map" (SkyLines and
-    XCSoar Cloud traffic)
-  - expire online traffic map icons 5 minutes after the last update
+  - keep XCSoar Cloud settings separate from SkyLines live tracking
+  - rename the map setting to "Online traffic on map" for SkyLines and
+    XCSoar Cloud traffic
+  - hide online traffic map icons 5 minutes after the last update
   - show OGN and SkyLines traffic on the map, in the traffic list, and in
-    the what-is-here dialog with the same FLARM traffic display as device
-    traffic (fixes pan-mode disappearance of online targets)
-  - support configurable XCSoar Cloud server hostname and UDP port in
-    cloud settings
-  - raise combined FLARM/online traffic list limit to 64 targets; device
-    FLARM traffic still typically stays within 25
-  - drop OGN/cloud online traffic that matches the connected FLARM radio
-    id so own-ship no longer appears on the traffic display #2693
-  - add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
-    to filter self and additional own aircraft from OGN when the device
-    radio id is unavailable (e.g. LX passthrough) #2693
+    what-is-here with the same symbols as FLARM traffic (including while
+    panning)
+  - allow choosing the XCSoar Cloud server address in cloud settings
+  - show up to 64 traffic targets in the combined list (nearby FLARM
+    traffic is usually fewer)
+  - hide your own aircraft when OGN or cloud traffic matches your FLARM
+    id #2693
+  - add expert cloud setting "Own FLARM IDs" to hide yourself and other
+    own aircraft from OGN when the FLARM id is not available (e.g. some
+    LX setups) #2693
 * calculations
-  - prefer the instrument vario for T Avg climb rates when available
-    #2754
-  - support altitude-corrected speed-to-fly and task glide calculations:
-    cruise speeds and best glide stay correct higher up (#1569)
-  - use the same altitude correction for task manager glide and safety
+  - use the instrument vario for average climb (T Avg) when it is
+    available, for steadier values #2754
+  - correct speed-to-fly and task glide for altitude: cruise speeds and
+    best glide stay right higher up (#1569)
+  - use the same altitude correction in the task manager and safety
     calculations
   - use true airspeed for netto vario and speed-to-fly arrows when the
-    polar supplies netto vario
+    polar can provide netto
   - restore FFVV NetCoupe contest optimisation #2330
-  - prefer netto vario from the variometer in the thermal assistant when
+  - prefer netto from the variometer in the thermal assistant when
     available
-  - fix angle bearing and delta normalization so extremely large values
-    no longer stall (suspected Android freeze #1292)
+  - fix rare freezes on Android with extreme compass values #1292
 * task
-  - fix CUP task waypoints that failed to load from a task file without
-    showing an error (#2496)
-  - fix CUP task observation zones with uncommon angles (they were
-    incorrectly parsed as FAI quadrants) #2697
-  - rename turnpoint observation zone type "Symmetric Quadrant" to
-    "Symmetric Sector" (any angle, not only 90 degrees)
-  - show all tasks by default in Task Browser (no "More" click first)
-  - add optional turn back marker (Safety Factors): green triangle along
-    track showing how far you can still fly and reach the active task
-    waypoint or Goto; only in cruise when the target is reachable;
-    saved in the profile #1740 #1741
-  - support AUTO or MANUAL Alternate 1/2 InfoBoxes: tap to open the
-    alternates list, switch mode, and assign a row (AUTO clears a manual
-    pin); titles show Altn 1/2 with AUTO or MAN
-  - raise alternates list to 10 options (was 6); if the task has only one
-    automatic alternate, Alternate 2 no longer duplicates Alternate 1;
-    glide values update with current conditions; colours show not
-    reachable, final glide, need climb, and manual on/below glide #2347
-  - list airfields before outlanding sites in the alternates list
-  - clarify alternates AUTO/MANUAL help text in Safety Factors (#555)
-  - open waypoint details above the waypoint list and alternates; Close
-    without a committed action returns to the list, not the map #620
+  - fix SeeYou CUP tasks where some waypoints failed to load with no
+    error (#2496)
+  - fix CUP observation zones with uncommon angles (they were loaded as
+    FAI quadrants) #2697
+  - rename observation zone type "Symmetric Quadrant" to "Symmetric
+    Sector" (any angle, not only 90 degrees)
+  - show all tasks in Task Browser by default (no need to press More)
+  - add optional turn back marker (Safety Factors): a green triangle on
+    the track showing how far you can still fly and still reach the
+    active task waypoint or Goto; only in cruise when the target is
+    reachable #1740 #1741
+  - let Alternate 1/2 InfoBoxes follow the list automatically (AUTO) or
+    a field you pick (MANUAL); tap the InfoBox to open the list and
+    switch mode
+  - show up to 10 alternates (was 6); clearer colours for reachability;
+    if only one automatic alternate exists, Alternate 2 no longer
+    repeats it #2347
+  - list airfields before outlanding fields in the alternates list
+  - clarify AUTO and MANUAL alternates help in Safety Factors (#555)
+  - open waypoint details above the list; Close returns to the list, not
+    the map #620
 * map
-  - keep the Full snail trail shorter on slower hosts (typical e-readers
-    and similar) so long flights stay responsive #2661
+  - keep long snail trails usable on slower devices (e.g. e-readers)
+    #2661
   - draw only the visible part of a long snail trail to reduce map lag
     #2661
-  - adjust contour line density to the zoom level #2233
-  - add contour density profile settings for mountains, lowlands, and
-    other landscape types
-  - enlarge on-map text: waypoint names, map scale, and topography
-    labels
-  - add "Waypoint icon size" on Configuration → Map display → Waypoints
-    (50–200%, default 100%) #1594
+  - thin contour lines out when zoomed out #2233
+  - add contour density settings for mountains, lowlands, and other
+    landscapes
+  - enlarge waypoint names, map scale text, and topography labels
+  - add "Waypoint icon size" (50–200%) under Map display → Waypoints
+    #1594
   - make the thermal hotspot icon easier to see on dark backgrounds
     #2448
-  - hide obstacles at wider map scales than other non-landables
-  - draw up to 1024 waypoints at once (was 256) #2327
-  - fix fluctuating terrain hill-shading strength #2262
-  - keep terrain hill-shading sharp before the first GPS fix #2331
-  - add terrain shading orientation "fixed (Top Left)"
-  - smooth snail trail between fixes; vario colours use high-rate netto
-    between GPS points when available #2447
-  - add distance rings around the current location #1206 #2522
-  - match the large FLARM radar task direction arrow to the map
-    best-cruise shape #2027
-  - show optional callsign and relative altitude beside targets on the
-    large FLARM radar when side data is in altitude mode
+  - hide obstacles earlier when zoomed out than other non-landable
+    points
+  - show more waypoints at once (up to 1024; was 256) #2327
+  - fix terrain shading that looked too strong or too weak #2262
+  - keep terrain shading sharp before the first GPS fix #2331
+  - add terrain shading direction "fixed (Top Left)"
+  - smooth the snail trail between GPS points; colour from high-rate
+    vario when available #2447
+  - add distance rings around your position #1206 #2522
+  - make the task direction arrow on the large FLARM radar match the
+    map #2027
+  - optionally show callsign and relative altitude next to targets on
+    the large FLARM radar
 * weather
   - accept lowercase ICAO codes when adding a METAR/TAF station
-  - add EDL weather with per-page map overlays (None/RASP/EDL), bottom
-    panel weather controls with auto-advance, day precaching, and
-    simpler RASP setup (field and time on pages)
-  - show RASP weather dialog file age and open the file manager for the
-    selected field
-  - add XCTherm as a map overlay choice alongside RASP and EDL #2705
-  - add Weather Setup to the weather overlay menu and layer/level/
-    altitude list picker (opens Info → Weather on the active overlay
-    tab) #2690
-  - add Auto update on the RASP panel for once-a-day background download
-    while forecast time follows the clock (Auto or Now); Update remains
-    for a manual refresh
-  - add Auto update on the EDL panel for missing overlay tiles; Precache
-    day is disabled while Auto update is on #2690
-  - add Layer/Time (Level/Altitude) on weather panels for the current map
-    page; Apply to page, Add page, and Pages setup #2705 #2690
-  - store both overlay cursor axes per weather map page (RASP Layer/Time,
-    EDL Level/Time, XCTherm Altitude/Time) #2690 #2705
-  - store RASP forecast time per map page (Auto, Now, or fixed slot) and
-    restore Layer and Time when selecting a page #2690 #2705
-  - show the current map page RASP layer and time on the RASP panel;
-    Apply commits them to that page #2690
-  - allow Precache day on the EDL panel without an active EDL map page;
-    add Time and Level with the same pickers as the overlay controls
+  - add EDL weather maps with per-page overlays (None / RASP / EDL),
+    weather controls in the bottom panel, day download, and simpler
+    RASP field and time on each page
+  - show how old the RASP file is and open the file manager from the
+    RASP weather dialog
+  - add XCTherm as a map overlay next to RASP and EDL #2705
+  - open Weather Setup from the weather overlay menu (Info → Weather)
     #2690
-  - align XCTherm Time / Altitude layout with RASP and EDL; map Altitude
-    is independent of the download Layer #2690 #2705
-  - keep the RASP time cursor on all-day layers (single archive slot);
-    grey out time controls until a multi-slot layer is selected again
-    #2705
-  - add WeatherOverlay input event and mode=weather stick/button
-    bindings (via quick menu Forecast Controls) to step forecast time
-    and altitude/level on weather overlay map pages (#2583)
-  - narrow weather cursor bar stepper buttons on touchscreens and clip
-    long centre labels instead of hiding them
-  - add pc_met www images: RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT
-    RAD BLITZ, and Blitzkarte Europa; local radar list uses Borkum
-    instead of the removed Emden site
+  - add Auto update on RASP (at most once a day while time follows the
+    clock); Update still refreshes manually
+  - add Auto update on EDL for missing map tiles #2690
+  - set Layer/Time (or Level/Altitude) per map page; Apply to page, Add
+    page, and Pages setup #2705 #2690
+  - remember RASP, EDL, and XCTherm time and level choices per map page
+    #2690 #2705
+  - show the current page RASP layer and time on the RASP panel #2690
+  - allow downloading a full EDL day without that overlay already on the
+    page #2690
+  - keep XCTherm Time / Altitude controls consistent with RASP and EDL
+    #2690 #2705
+  - keep the chosen RASP time when switching to all-day layers; grey out
+    time until a multi-slot layer is selected again #2705
+  - step forecast time and altitude from the quick menu Forecast
+    Controls (and custom keys) (#2583)
+  - make weather time/level buttons easier to use on touchscreens; clip
+    long labels instead of hiding them
+  - add more pc_met radar and lightning images for Germany and Europe;
+    local radar list uses Borkum instead of Emden
 * NOTAM integration
-  - add support for downloading, caching and displaying NOTAM airspaces
+  - download, cache, and show temporary NOTAM airspaces on the map
     #2018
-  - add manual refresh and auto-refresh with location/time based updates
-  - add NOTAM settings and filters (IFR, effective time, max radius,
-    hidden Q-codes)
-  - add NOTAM details integration in airspace dialogs
-  - show a briefing disclaimer before the first NOTAM download
+  - refresh NOTAMs manually or automatically by location and time
+  - filter NOTAMs (IFR, time window, distance, hidden Q-codes)
+  - show NOTAM details in airspace dialogs
+  - show a short briefing disclaimer before the first download
 * data files
-  - map OpenAir AY ASRA to aerial sporting/recreational airspace type
-    #1827
+  - treat OpenAir ASRA airspace as aerial sporting/recreational #1827
   - accept ".openair" as an airspace file extension
-  - organise data files in folders by type (waypoints, airspaces,
-    terrain, profiles, logs, and downloads) instead of one flat
-    directory #2289
-  - move existing files into matching subfolders on first start after
-    upgrade when possible #2289
+  - store data in folders by type (waypoints, airspaces, terrain,
+    profiles, logs, downloads) instead of one flat folder #2289
+  - on first start after upgrade, move existing files into those folders
+    when possible #2289
   - store IGC and NMEA logs under logs/ #2289
-  - create needed folders on a fresh install before the download manager
-    saves files #2580
-  - fix crash when queuing many background file downloads while others
-    complete #2624
+  - create the needed folders on a fresh install before downloads #2580
+  - fix crash when many downloads finish while more are queued #2624
 * devices
-  - add GDL90 input driver (ADS-B traffic and ownship over serial or
-    UDP; optional ForeFlight geometric altitude and AHRS;
-    horizontal/vertical traffic filters) #2356
-  - add LX160 driver for LXWPx varios (#2424)
-  - add LX Eos task declaration and logger support (#2433)
-  - fix LX stale vario and misaligned heading/wind from $LXWP0 (#2554)
-  - add Condor 3 Spectate.json multiplayer traffic driver
-    (Condor3Spectate) for other gliders on the FLARM radar and map
-  - add Condor 3 UDP telemetry driver (Condor3UDP) for Simkits generic
-    UDP output (default port 55278); complements TCP/NMEA Condor3 for
-    MacCready, ballast, attitude, radio, and related fields (#2340)
-  - support $LK8EX1 (LK8000 external instrument) on all device ports:
-    pressure, QNE altitude, vario, temperature, and battery #2772
-  - treat $LXWP0 without airspeed as uncompensated vario (BlueFly LX
-    mode) instead of total-energy; with IAS/TAS keep TE
-  - accept partial $LXWP0 vario samples so Status Variometer is not stuck
-    on Disconnected while baro still works #2763
-  - publish BlueFly battery voltage from BAT telemetry in addition to
-    estimated percentage
-  - parse BlueFly TMP temperature telemetry
-  - parse BlueFly $BFV/$BFX telemetry and offer BFV/BFX (and None)
-    output modes in the device manage dialog
-  - support BlueFly onboard IGC flight log download (Devices → Flight
-    download)
-  - add BlueFly output frequency, lift/sink thresholds, and audio when
-    connected to the device manage dialog
-  - fix LXNAV thermal averages when the device reports conflicting
-    altitude sources #2754
-  - apply LXNAV device vario filter time to gauge, map vario bar,
-    thermal rose, audio vario, and snail-trail colouring
-  - feed FLARM $PGRMZ barometric altitude into IGC logger pressure
-    altitude when FLARM is detected
-  - show glide polar sync in the device dialog only for drivers that
-    support it (LXNAV) #2457
-  - send QNH changes from external sources to all connected devices
-  - set the active COM frequency on Air Control Display via standby
-    swap (AT-01 and similar with read-only active channel) #2454
-  - show the Vario flag on the device list for non-compensated and
-    netto vario sources as well as total-energy (e.g. BlueFly)
-  - increase the number of device slots from 6 to 8
-  - fix crash on device reconnect (stale delayed reopen timer) #2382
+  - add GDL90 for ADS-B traffic and ownship (serial or network);
+    optional ForeFlight altitude and attitude; traffic distance filters
+    #2356
+  - add LX160 vario driver (#2424)
+  - add LX Eos task declaration and flight log download (#2433)
+  - fix LX vario, heading, and wind that could lag or look wrong (#2554)
+  - add Condor 3 Spectate so other gliders appear on the FLARM radar and
+    map
+  - add Condor 3 UDP driver for Simkits output (default port 55278)
+    alongside the usual Condor TCP connection: MacCready, ballast,
+    attitude, radio, and related fields (#2340)
+  - support LK8000 instrument sentences ($LK8EX1) on all ports: pressure,
+    altitude, vario, temperature, and battery #2772
+  - treat BlueFly LX mode (vario without airspeed) as uncompensated
+    vario, not total-energy; keep total-energy when airspeed is present
+  - keep Status Variometer connected when BlueFly sends a short vario
+    sentence #2763
+  - show BlueFly battery voltage as well as percentage
+  - show BlueFly temperature from the device
+  - choose BlueFly BFV/BFX (or None) output in the device manage dialog
+  - download BlueFly flight logs from Devices → Flight download
+  - set BlueFly beep frequency, lift/sink thresholds, and audio in the
+    manage dialog when connected
+  - fix LXNAV thermal averages when altitude sources disagree #2754
+  - honour the LXNAV vario filter for the gauge, map vario bar, thermal
+    assistant, audio vario, and snail-trail colours
+  - use FLARM pressure altitude for the IGC logger when FLARM is
+    detected
+  - show polar sync in the device dialog only for varios that support it
+    (LXNAV) #2457
+  - send QNH changes from one device to all connected devices
+  - set active COM on Air Control Display (AT-01 and similar) by
+    swapping through standby #2454
+  - show the Vario flag for BlueFly and other non-total-energy varios
+  - allow up to 8 devices (was 6)
+  - fix crash when reconnecting a device #2382
 * infoboxes
-  - add Altitude IGC InfoBox (logger pressure or ISA pressure only)
-  - fix Start reach and Start open values and colours when MacCready is
-    too low or wind affects the leg; Start open shows gate countdown at
-    now; Start reach shows time to the start line #2502
-  - add Active Waypoint InfoBox (next task waypoint or Goto; tap to pick
-    another leg or set Goto)
-  - add Previous Waypoint InfoBox (waypoint before the active leg; tap
-    to inspect without advancing the task, or resume auto tracking)
-  - add Home InfoBox (name, arrival height at home, distance; tap to
-    change home) #2320
-  - add QNH InfoBox displaying current QNH in hectopascals #2521
-  - refresh InfoBox titles after changing the interface language #2314
-  - scale artificial horizon dial marks with InfoBox size
+  - add Altitude IGC (logger pressure altitude)
+  - improve Start reach and Start open when MacCready is too low or wind
+    is strong; Start open shows gate countdown now; Start reach shows
+    time to the start line #2502
+  - add Active Waypoint (next task point or Goto; tap to change)
+  - add Previous Waypoint (earlier task point; tap to inspect without
+    advancing the task)
+  - add Home (name, arrival height, distance; tap to change home) #2320
+  - add QNH (current pressure setting) #2521
+  - refresh InfoBox titles after changing language #2314
+  - scale artificial horizon marks with InfoBox size
 * ui
-  - add pinch-to-zoom on the map for touchscreens that report both
-    finger positions (Android, iOS): scale about the pinch centroid and
-    pan at the same time; a two-finger drag or twist enters pan mode; a
-    zoom-only pinch keeps following the aircraft #2790
-  - add two-finger twist to temporarily rotate the map; the angle is
-    held while panning and restored when pan mode is left #2790
-  - animate keyboard and mouse-wheel map zoom on non-e-ink displays so
-    scale steps feel continuous after a pinch; free zoom continues from
-    an off-list scale and snaps to the usual list when close again
-  - keep the north arrow clear of the on-screen menu and zoom buttons
-  - improve simulator discoverability: startup tip to steer by dragging
-    from the glider or via Altitude / Speed Ground InfoBoxes; Welcome
-    Quick Guide paragraph in simulator mode; "Sim: Jump to" on map items
-    and waypoint details; Speed Ground simulator panel; label Set Home
-    as "Set as Startup Location" in simulator mode
-  - bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
-    (same as AVG/ALT softkey and RL gesture)
-  - draw map GPS status above the map scale / title line so it is not
-    covered by AUTO / Simulator / REPLAY text
-  - improve soft keyboard text entry: default focus on a key; cursor
-    keys move across the grid; F1 is backspace
-  - fix profile selection / startup branding on light dialog backgrounds
-    #2742
-  - size the InfoBox panel to the current tab and lift map overlays by
-    that height only
-  - fix map vario / final-glide value labels: rounded rectangle with even
-    padding and an unbroken outline #1438
-  - swap map overlay sides: vario bar on the left, final glide bar on
-    the right #1210
-  - add airspace labels toggle: Display page 2, Quick Menu, and
-    AirspaceLabels input event (on/off, saved to profile) #1243
-  - add Quick Guide and Replay to the Quick Menu (Replay disabled when
+  - pinch to zoom on the map (Android, iOS); two fingers can pan at the
+    same time; a drag or twist enters pan mode; a zoom-only pinch keeps
+    following the aircraft #2790
+  - twist with two fingers to rotate the map temporarily; the angle
+    stays while panning and resets when you leave pan mode #2790
+  - smooth keyboard and mouse-wheel zoom on colour screens after a
+    pinch
+  - keep the north arrow clear of menu and zoom buttons
+  - make the simulator easier to use: tip to steer by dragging or via
+    Altitude / Speed Ground; Welcome text in simulator mode; "Sim: Jump
+    to" on map items and waypoints; Speed Ground panel; rename Set Home
+    to "Set as Startup Location" in simulator mode
+  - press F1 on the FLARM radar to toggle AVG/ALT side labels
+  - keep GPS status visible above AUTO / Simulator / REPLAY text
+  - improve the soft keyboard: focus a key by default; arrows move
+    across the grid; F1 is backspace
+  - fix logo and title colours on light startup screens #2742
+  - size the InfoBox strip to the current tab so the map title does not
+    jump
+  - improve map vario and final-glide value labels (clearer background)
+    #1438
+  - put the vario bar on the left and final glide on the right #1210
+  - toggle airspace labels from Display page 2, Quick Menu, or a custom
+    key #1243
+  - add Quick Guide and Replay to the Quick Menu (Replay off when
     moving)
-  - show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
-  - allow Left/Right on the simulator prompt to choose Fly / Simulator
-    immediately
-  - improve the map items dialog: scale "Your Position" aircraft icon;
-    Enter / Details opens Status: Flight; show airspace Inside/Near
-    status like the warnings dialog
-  - tint the bottom airspace warning banner red (inside) or yellow
-    (near) on colour displays
-  - show distance and time in the bottom airspace warning banner
-  - put WiFi Connect first and Close last in the WiFi dialog
-  - put Download before Cancel in the download picker; Left/Right page
-    the list
-  - use single keyboard focus in the multi-file picker and value list
-    picker
-  - draw a thin separator line above list-picker bottom help text
-  - make Quick Menu Left/Right stay put when the next item is disabled,
-    but still wrap or flip page at a real row edge
-  - use focus colour for action-bar buttons that have keyboard focus
-  - open waypoint details with Details / F1 (Enter still confirms the
-    selection)
-  - fix task point dialog keyboard navigation: Up/Down no longer skip
-    OZ Radius; Left/Right change the task point; portrait layout uses
-    full width for map and OZ fields
-  - fill leftover pixels on the last dialog action-bar button in a row
-  - put Reference Mass above the plane polar V/W grid; Up/Down moves
-    within each V/W column
-  - speed up long rich-text layout (Quick Guide What's New)
-  - add Expert Look → Screen Layout "Display type" (LCD / E-ink /
-    Color e-ink); e-ink modes disable kinetic and smooth scrolling;
-    defaults to E-ink on Kobo and LCD elsewhere
-  - snap e-paper scrolling instead of animating at high rate, and delay
-    per-item help updates while scrolling long lists
-  - show full callsigns on all registered FLARM radar targets; omit
-    duplicate side vario/altitude on the selected target #2718
-  - improve FLARM traffic symbol and label sizing #2708
-  - rotate FLARM radar track-up targets on cardinal bearings
-  - outline selected targets on the FLARM traffic radar
-  - fix crash when opening the map item list on waypoints with long
-    non-ASCII comments
-  - fix crash wrapping unspaced UTF-8 help text (e.g. Chinese language
-    picker) #2768
-  - add optional map overlay QuickMenu button (Config → Look → Layout),
-    enabled by default when a touch screen is detected #2610
-  - keep pages config map overlay and RASP layer rows visible on non-map
-    pages (disabled instead of hidden) (#2583)
-  - allow WeGlide aircraft type in plane details even when WeGlide
-    upload is disabled #2323
-  - fix status dialog Times: flight time matches takeoff and landing
-    after minute rounding; landing time clears on a new takeoff #957
-  - show PEV offset at start in status Rules as a duration (e.g.
-    "45 sec", "2 min"), not HH:MM
-  - show G-load availability and variometer source in system status
-  - fix plane polar dialog coefficient grid layout and auto-sized width
-  - use readable text colours for read-only text fields (e.g. waypoint
-    details) #2465
-  - add Data Management hub (menu, quick menu, and DataManagement input
-    event): site files, download manager, export flights, import data,
-    backup manager, and file explorer in one place
-  - list USB sticks and other removable storage in the storage picker;
-    refresh when media is plugged in or removed
-  - import data: copy files from external storage into the correct
-    XCSoar folders (waypoints, airspaces, terrain, and the rest) #2289
-  - copy the XCSoar data directory to chosen storage as a dated .tar
-    backup (profiles, waypoints, airspaces, terrain, and settings; not
-    logs, other backups, or cache); restore warns before overwriting;
-    restart XCSoar afterward to apply restored settings
-  - browse storage in the file explorer, sort files into folders, copy
-    to another drive, rename, and delete #2289
-  - find waypoint search text anywhere in the name or short name #2483
-  - list each waypoint only once in search results #1316
-  - remove useless "map file" type filter when waypoints come from
+  - show replay speed on the map (e.g. REPLAY 2x) #2281
+  - choose Fly or Simulator with Left/Right on the startup prompt
+  - improve map items: clearer "Your Position" icon; Details opens
+    Status: Flight; airspace Inside/Near like the warnings list
+  - colour the bottom airspace warning red (inside) or yellow (near)
+  - show distance and time in the bottom airspace warning
+  - put WiFi Connect first and Close last
+  - put Download before Cancel in the download list
+  - simpler keyboard focus in file and value pickers
+  - draw a line above help text in list pickers
+  - keep Quick Menu Left/Right from jumping onto disabled items
+  - highlight focused action buttons clearly
+  - open waypoint details with Details / F1 (Enter still selects)
+  - fix task point dialog keys: Up/Down edit fields; Left/Right change
+    turnpoint; better portrait layout
+  - fill the last button in a dialog button row to the edge
+  - put Reference Mass above the polar speed/sink grid
+  - speed up Quick Guide "What's New" scrolling
+  - add Display type (LCD / E-ink / Color e-ink) under Look → Screen
+    Layout; e-ink modes turn off smooth scrolling
+  - smoother list scrolling on e-paper
+  - show full callsigns on the FLARM radar; hide duplicate side
+    vario/altitude on the selected target #2718
+  - improve FLARM traffic symbol and label size #2708
+  - rotate FLARM radar targets correctly on north/south/east/west
+    headings
+  - outline the selected target on the FLARM radar
+  - fix crash opening map items on waypoints with long non-English
+    comments
+  - fix crash in language lists with long Chinese (and similar) text
+    #2768
+  - optional Quick Menu button over the map on touchscreens #2610
+  - keep weather overlay settings visible (greyed out) on non-map pages
+    (#2583)
+  - allow setting WeGlide aircraft type even when upload is off #2323
+  - fix Status → Times so flight time matches takeoff and landing #957
+  - show PEV start offset as "45 sec" or "2 min", not 00:00
+  - show G-load and variometer source in system status
+  - fix polar editor layout
+  - use clearer colours for read-only text (e.g. waypoint details) #2465
+  - add Data Management: site files, downloads, export flights, import,
+    backup, and file explorer in one place
+  - list USB sticks and other removable storage; refresh when plugged
+    or unplugged
+  - import files from a stick into the right XCSoar folders #2289
+  - back up your XCSoar data to a stick as a dated archive (not logs or
+    cache); restore warns before overwrite; restart after restore
+  - browse, organise, copy, rename, and delete files in the file
+    explorer #2289
+  - find waypoints by text anywhere in the name (e.g. FIELD finds
+    AIRFIELD) #2483
+  - list each waypoint only once in search #1316
+  - remove the useless "map file" type filter when waypoints come from
     another file #1376
-  - fix "Recently Used" waypoint type filter #1994
-  - list all CUP waypoint types in the waypoint search Type filter
-    #2485
+  - fix the "Recently Used" waypoint filter #1994
+  - list all CUP waypoint types in the Type filter #2485
   - keep waypoint search open until Esc or a successful GoTo, task,
-    home, or pan action #749
-  - zoom and pan waypoint details images and PC-Met satellite viewer
-    with +/- buttons, F2/F3, and arrow keys (#1127, #1246)
-  - improve list dialog keyboard navigation; Select Airspace puts
-    Details and Close on the main button row
-  - fix airspace and map item list focus colours on e-paper #2495
-  - grey out day-acknowledged airspaces in lists; map item list adds
-    Enable to turn warnings back on #2404
-  - remove the map warning triangle for day-acknowledged airspaces
-  - replace Radio with Details in airspace warnings; improve keyboard
-    navigation
-  - disable map overlay buttons on non-map pages (traffic, thermal
-    assistant, etc.)
-  - raise the InfoBox configuration entry limit so all InfoBoxes appear
-    #2344
-  - encode bundled UI sound assets at higher quality
-  - show clearer keyboard focus on tab strips in tabbed dialogs
-  - advance checklist checkbox focus with Enter like Down #2405
-  - support checklist vhf: links to set COM standby or active frequency
-    (optional station name in the link label)
-  - support horizontal swipe to flip checklist, Credits, Quick Guide,
-    and configuration pages #2122 #2414
+    home, or pan #749
+  - zoom and pan photos in waypoint details and PC-Met (#1127, #1246)
+  - clearer list keyboard use; Select Airspace puts Details and Close on
+    the main buttons
+  - fix unreadable focused rows on e-paper lists #2495
+  - grey out airspaces acknowledged for the day; Enable turns warnings
+    back on #2404
+  - hide the map warning triangle for day-acknowledged airspaces
+  - replace Radio with Details in airspace warnings
+  - hide map overlay buttons on non-map pages (traffic, thermal
+    assistant)
+  - show all InfoBoxes again in configuration #2344
+  - improve bundled UI sound quality
+  - clearer tab focus in tabbed dialogs
+  - Enter on a checklist box moves like Down #2405
+  - tap checklist radio links (vhf:…) to set COM standby or active
+  - swipe left/right to change page in checklists, Credits, Quick Guide,
+    and configuration #2122 #2414
   - show formatted release notes in Quick Guide "What's New"
-  - reflect live Safety factors and Terrain display settings in Quick
-    Guide getting started #2324
-  - apply Quick Guide terrain file choice immediately (#2322)
-  - improve Quick Guide checklist touch targets and checkbox appearance;
-    -touchscreen / -notouchscreen override autodetection (non-Android)
-    #2325
-  - add "Don't show this guide again" on every Quick Guide informational
-    page; Config → Look → Language, Input controls startup visibility,
-    release notes on next startup, and safety disclaimer acceptance
-    #2648
-  - support manual/automatic Vario/STF sound switching
+  - Quick Guide getting started reflects your Safety and Terrain
+    settings #2324
+  - apply a terrain file chosen in Quick Guide immediately (#2322)
+  - larger checklist touch targets in Quick Guide #2325
+  - "Don't show this guide again" on every informational Quick Guide
+    page; settings for startup guide and release notes #2648
+  - switch audio vario between climb and speed-to-fly sounds manually or
+    automatically
 * input
-  - add VarioVolume input event to mute/unmute and adjust the internal
-    audio vario volume
-  - add VarioAudioMode input events for Vario/STF sound switching
-  - use F2/F3 for zoom in pan mode, on the FLARM radar, and in waypoint
-    image view (on the main non-pan map F2/F3 stay Checklist and FLARM);
-    traffic: next/previous events; FLARM: UP/DOWN and F4 next target,
-    F1 AVG/ALT labels, F2/F3 zoom; radar bindings come from the input
-    file
-  - open pan mode with Return on the main map (was FLARM radar); F3
-    still opens FLARM traffic
-  - close pan mode and submenu pages with Escape (and Android back);
-    Cancel on the main menu page
-  - replace File Manager with Data Management in the quick menu and
-    Config; add distance rings on/off to the quick menu
-  - accept an optional GotoLookup argument to pre-select the Type filter
-    (recent, airport, landable, turnpoint, start, finish) #336
-  - open recently used waypoints with the default Left-Up (LU) map
-    gesture #336
-  - support WaypointImage / wptimg input mode for waypoint details image
-    keys without falling back to the map default key bindings
+  - mute or change internal audio vario volume with a custom key
+  - switch vario/STF sound mode with a custom key
+  - F2/F3 zoom in pan mode, on the FLARM radar, and on waypoint photos
+    (on the main map F2/F3 stay Checklist and FLARM)
+  - Return opens pan mode on the main map (was FLARM); F3 still opens
+    FLARM traffic
+  - Escape (and Android back) closes pan mode and submenus; Cancel on
+    the main menu
+  - Data Management replaces File Manager in the quick menu and Config;
+    quick menu can toggle distance rings
+  - open waypoint search filtered (recent, airport, landable, …) from a
+    gesture or key #336
+  - Left-Up gesture opens recently used waypoints #336
+  - customise keys for zooming waypoint photos without changing map
+    keys
 * documentation
-  - document custom .xci loading: #CLEAR, merge vs replace, type values
-    (key / gce / gesture / ne / label), gesture data format, softkey
-    location, label escapes, complete GCE list, and RemoteStick Quick
-    Menu
-  - document AirspaceLabels input event
-  - document map pinch-to-zoom on touchscreens that report both finger
-    positions #2790
+  - document custom input files (.xci): merge vs replace, keys,
+    gestures, soft keys, and RemoteStick Quick Menu
+  - document the AirspaceLabels input event
+  - document map pinch-to-zoom #2790
 * android
-  - support BLE Nordic UART Service (NUS) for e.g. Naviter dongles, in
-    addition to HM-10; protocol auto-detected at connection #2260
-  - support BLE Microchip/ISSC transparent UART (e.g. BlueFly Vario over
-    BLE); auto-detected like NUS/HM-10
-  - keep existing BLE serial profiles working after adding NUS and
-    Microchip UART support
-  - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as
-    supported USB devices
-  - number multi-port USB serial adapters (e.g. dual FTDI) with
-    suffixes (0, 1) in the port list and device list #2481
-  - fix crash when the app restarts after the display is torn down
-  - fix spurious outline lines on high-DPI OpenGL displays #1514
-  - use physical display metrics for startup DPI #1784
-  - improve bundled UI sound quality and playback reliability #2411
-  - configure built-in GPS and sensors in the last device slot by
-    default
-  - update the device list when storage access changes
+  - connect more Bluetooth dongles (Naviter NUS and BlueFly-style UART)
+    automatically #2260
+  - keep existing Bluetooth serial device settings working
+  - support SoftRF Concorde, Prime Mk4, and Retro Mk2 over USB
+  - number dual USB serial ports clearly (0, 1) #2481
+  - fix crash when the app restarts after the screen is closed
+  - fix stray lines on some high-resolution phones #1514
+  - use the real screen size for startup scaling #1784
+  - improve UI sound quality and reliability #2411
+  - put built-in GPS and sensors in the last device slot by default
+  - refresh the device list when storage access changes
 * iOS
-  - fix audio vario playback through the device speaker #2474
-  - open waypoint detail PDFs and other local files from the details
-    dialog (was failing silently) #2501
-  - disable Core Location distance filter for built-in GPS so fixes are
-    not suppressed while stationary #2380
-  - configure built-in GPS and sensors in the last device slot by
-    default
+  - fix audio vario through the device speaker #2474
+  - open waypoint PDFs and other attached files from details #2501
+  - keep GPS updates while stationary #2380
+  - put built-in GPS and sensors in the last device slot by default
 * macOS
-  - fix thick solid lines rendering at incorrect pixel width #2545
+  - fix thick lines drawn at the wrong width #2545
 * Linux
   - add Config → Setup → Network for WiFi status, connect/disconnect,
-    and IP address (NetworkManager or ConnMan)
+    and IP address
 * OpenVario
-  - show WiFi and ethernet status; support WiFi connect/disconnect and
-    ethernet DHCP renew from the Network dialog
+  - show WiFi and ethernet status; connect or disconnect WiFi and renew
+    ethernet from Network
 * Windows
-  - add installer for the OpenGL Windows version (64-bit and 32-bit);
-    zip download remains available for a portable install #2064
-  - deprecate the legacy single-file Windows executable; use the OpenGL
-    version instead — the legacy build will be removed in a future
-    release
-  - reduce Windows Defender false positives on Win64 builds (#2232)
-  - fix duplicate entries in Windows file lists #2625
-  - fix crash opening the log list when replay filenames contain
-    non-ASCII characters
-  - load CUPX archives with embedded waypoint files correctly
+  - add an installer for the OpenGL Windows version (64- and 32-bit);
+    zip remains for portable use #2064
+  - deprecate the old single-file Windows program; use the OpenGL
+    version instead
+  - fewer false malware warnings from Windows Defender (#2232)
+  - fix duplicate names in Windows file lists #2625
+  - fix crash opening logs with non-English filenames
+  - load CUPX waypoint packs with photos correctly
 * desktop
-  - print -h/--help and -version/--version to stdout and exit; unknown
-    options print a short usage line on stderr
-  - use the shared storage picker and hotplug refresh for flight export
-    and data import on Linux and Windows #1114
+  - support -h/--help and -version/--version on the command line
+  - use the same storage picker for flight export and data import on
+    Linux and Windows #1114
 * Kobo
-  - always start in light mode; dark mode is not supported on e-paper
-    displays #2568
-  - add Config → Setup → Network with WiFi status and Auto WiFi (enable
-    WiFi automatically at startup) #2531
-  - fix black squares when scrolling lists and edit fields on e-paper
-    #2293
+  - always start in light mode (dark mode is not supported on e-paper)
+    #2568
+  - add Network with WiFi status and Auto WiFi at startup #2531
+  - fix black squares when scrolling lists on e-paper #2293
 * development
   - MapWindow: publish a coherent projection snapshot for the DrawThread
     on non-OpenGL builds so rendering does not read a live UI projection

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,361 +1,375 @@
 Version 7.45 - not yet released
 * tracking
-  - keep XCSoar Cloud settings separate from SkyLines live tracking
-  - rename the map setting to "Online traffic on map" for SkyLines and
-    XCSoar Cloud traffic
+  - show OGN and SkyLines traffic on the map, in the traffic list, and in "Map
+    elements at this location" with the same symbols as FLARM traffic
+    (including while panning)
+  - hide own aircraft when OGN or cloud traffic matches the connected FLARM
+    ID #2693
+  - rename the map setting to "Online traffic on map" for SkyLines and XCSoar
+    Cloud traffic
   - hide online traffic map icons 5 minutes after the last update
-  - show OGN and SkyLines traffic on the map, in the traffic list, and in
-    what-is-here with the same symbols as FLARM traffic (including while
-    panning)
+  - ignore OGN ground stations and filter online traffic by altitude band
+  - raise the combined traffic list limit to 64 targets (nearby FLARM traffic
+    is usually fewer)
+* XCSoar Cloud
+  - keep XCSoar Cloud settings separate from SkyLines live tracking
   - allow choosing the XCSoar Cloud server address in cloud settings
-  - show up to 64 traffic targets in the combined list (nearby FLARM
-    traffic is usually fewer)
-  - hide your own aircraft when OGN or cloud traffic matches your FLARM
-    id #2693
-  - add expert cloud setting "Own FLARM IDs" to hide yourself and other
-    own aircraft from OGN when the FLARM id is not available (e.g. some
-    LX setups) #2693
+  - add expert setting "Own FLARM IDs" to hide own aircraft from OGN when the
+    FLARM ID is not available (e.g. some LX setups) #2693
 * calculations
-  - use the instrument vario for average climb (T Avg) when it is
-    available, for steadier values #2754
-  - correct speed-to-fly and task glide for altitude: cruise speeds and
-    best glide stay right higher up (#1569)
+  - use true airspeed (with air density) for netto vario and for the
+    speed-to-fly push/pull arrows, instead of indicated airspeed
+  - use netto vario for the thermal lift rose when available
+  - compensate speed-to-fly and task glide for altitude: cruise speeds and best
+    glide remain correct higher up #1569
   - use the same altitude correction in the task manager and safety
     calculations
-  - use true airspeed for netto vario and speed-to-fly arrows when the
-    polar can provide netto
+  - fix Thermal Average (T Avg) by using the instrument vario when available,
+    instead of GPS altitude changes that could spike #2754
   - restore FFVV NetCoupe contest optimisation #2330
-  - prefer netto from the variometer in the thermal assistant when
-    available
   - fix rare freezes on Android with extreme compass values #1292
 * task
-  - fix SeeYou CUP tasks where some waypoints failed to load with no
-    error (#2496)
-  - fix CUP observation zones with uncommon angles (they were loaded as
-    FAI quadrants) #2697
-  - rename observation zone type "Symmetric Quadrant" to "Symmetric
-    Sector" (any angle, not only 90 degrees)
+  - rename observation zone type "Symmetric Quadrant" to "Symmetric Sector"
+    (any angle, not only 90 degrees)
   - show all tasks in Task Browser by default (no need to press More)
-  - add optional turn back marker (Safety Factors): a green triangle on
-    the track showing how far you can still fly and still reach the
-    active task waypoint or Goto; only in cruise when the target is
-    reachable #1740 #1741
-  - let Alternate 1/2 InfoBoxes follow the list automatically (AUTO) or
-    a field you pick (MANUAL); tap the InfoBox to open the list and
-    switch mode
-  - show up to 10 alternates (was 6); clearer colours for reachability;
-    if only one automatic alternate exists, Alternate 2 no longer
-    repeats it #2347
-  - list airfields before outlanding fields in the alternates list
-  - clarify AUTO and MANUAL alternates help in Safety Factors (#555)
-  - open waypoint details above the list; Close returns to the list, not
-    the map #620
+  - add optional turn back marker (Safety Factors): a green triangle on the
+    track showing how far one can still fly and still reach the active task
+    waypoint or Goto; only in cruise when the target is reachable #1740 #1741
+  - after a PEV start, show how long after the PEV window opened the task was
+    started (e.g. "45 sec" or "2 min") in Status → Rules and the start message
+  - fix SeeYou CUP tasks where some waypoints failed to load with no
+    error #2496
+  - fix CUP observation zones with uncommon angles (they were loaded as FAI
+    quadrants) #2697
+  - fix Symmetric Sector observation zones wider than 180 degrees that could
+    block turnpoint advance
+  - fix imported WeGlide / AAT tasks where turnpoints stayed as Turn points
+    without AAT targets
 * map
-  - keep long snail trails usable on slower devices (e.g. e-readers)
-    #2661
-  - draw only the visible part of a long snail trail to reduce map lag
-    #2661
+  - pinch to zoom on the map (touchscreens, including Android, iOS, and Windows
+    OpenGL); two fingers can pan at the same time; a drag or twist enters pan
+    mode; a zoom-only pinch keeps following the aircraft #2790
+  - twist with two fingers to rotate the map temporarily; the angle stays while
+    panning and resets when leaving pan mode #2790
+  - smooth keyboard and mouse-wheel zoom on colour screens
+  - keep the north arrow clear of menu and zoom buttons
+  - add distance rings around the current position #1206 #2522
+  - smooth the snail trail between GPS points; colour from high-rate vario when
+    available #2447
+  - add "Waypoint icon size" (50–200%) under Map display → Waypoints #1594
   - thin contour lines out when zoomed out #2233
-  - add contour density settings for mountains, lowlands, and other
-    landscapes
+  - add contour density settings (adaptive landscapes, Superfine, and fixed
+    64/128/256 m); show current spacing beside the map scale
+  - keep long snail trails usable on slower devices (e.g. e-readers) #2661
+  - draw only the visible part of a long snail trail to reduce map lag #2661
   - enlarge waypoint names, map scale text, and topography labels
-  - add "Waypoint icon size" (50–200%) under Map display → Waypoints
-    #1594
-  - make the thermal hotspot icon easier to see on dark backgrounds
-    #2448
-  - hide obstacles earlier when zoomed out than other non-landable
-    points
+  - make the thermal hotspot icon easier to see on dark backgrounds #2448
+  - hide obstacles earlier when zoomed out than other non-landable points
   - show more waypoints at once (up to 1024; was 256) #2327
+  - add terrain shading direction "fixed (Top Left)"
+  - improve map vario and final-glide value labels (clearer background) #1438
+  - put the vario bar on the left and final glide on the right #1210
+  - size the InfoBox strip to the current tab so the map title does not jump
+  - hide map overlay buttons on non-map pages (traffic, thermal assistant)
+  - keep weather overlay settings visible (greyed out) on non-map pages #2583
+  - show replay speed on the map (e.g. REPLAY 2x) #2281
+  - add optional Quick Menu button over the map on touchscreens #2610
+  - improve "Map elements at this location": clearer "Your Position" icon;
+    Details opens Status: Flight; airspace Inside/Near like the warnings list
   - fix terrain shading that looked too strong or too weak #2262
   - keep terrain shading sharp before the first GPS fix #2331
-  - add terrain shading direction "fixed (Top Left)"
-  - smooth the snail trail between GPS points; colour from high-rate
-    vario when available #2447
-  - add distance rings around your position #1206 #2522
-  - make the task direction arrow on the large FLARM radar match the
-    map #2027
-  - optionally show callsign and relative altitude next to targets on
-    the large FLARM radar
+  - fix small terrain files stuck at coarse (1/16) resolution
+  - fix crash opening "Map elements at this location" on waypoints with long
+    non-English comments
+* alternates
+  - let Alternate 1/2 InfoBoxes follow the list automatically (AUTO) or a
+    chosen field (MANUAL); tap the InfoBox to open the list and switch mode
+  - show up to 10 alternates (was 6); clearer colours for reachability; if only
+    one automatic alternate exists, Alternate 2 no longer repeats it #2347
+  - list airfields before outlanding fields in the alternates list
+  - clarify AUTO and MANUAL alternates help in Safety Factors #555
+  - open waypoint details above the list; Close returns to the list, not the
+    map #620
+* FLARM radar
+  - make the task direction arrow on the large FLARM radar match the map #2027
+  - show callsign and relative altitude next to targets on the large FLARM
+    radar (optional)
+  - show full callsigns on the FLARM radar; hide duplicate side vario/altitude
+    on the selected target #2718
+  - improve FLARM traffic symbol and label size #2708
+  - outline the selected target on the FLARM radar
+  - press F1 on the FLARM radar to toggle AVG/ALT side labels
+  - rotate FLARM radar targets correctly on north/south/east/west headings
+  - reposition the FLARM gauge on fullscreen toggle
+* Thermal Assistant
+  - prefer netto from the variometer for the thermal assistant when available
+  - reposition the Thermal Assistant gauge on fullscreen toggle
 * weather
-  - accept lowercase ICAO codes when adding a METAR/TAF station
-  - add EDL weather maps with per-page overlays (None / RASP / EDL),
-    weather controls in the bottom panel, day download, and simpler
-    RASP field and time on each page
-  - show how old the RASP file is and open the file manager from the
-    RASP weather dialog
-  - add XCTherm as a map overlay next to RASP and EDL #2705
-  - open Weather Setup from the weather overlay menu (Info → Weather)
-    #2690
-  - add Auto update on RASP (at most once a day while time follows the
+  - add a unified map weather overlay system (choose None / RASP / EDL /
+    XCTherm per map page) #2690 #2705
+  - add EDL wave maps from edl-soaring.com as a map overlay (by UTC hour and
+    pressure level); day download and Auto update for missing tiles #2690
+  - add XCTherm vertical wind maps from xctherm.com as a map overlay (by time
+    and altitude) #2705
+  - add Auto update on RASP (at most once a day while forecast time follows the
     clock); Update still refreshes manually
-  - add Auto update on EDL for missing map tiles #2690
-  - set Layer/Time (or Level/Altitude) per map page; Apply to page, Add
-    page, and Pages setup #2705 #2690
-  - remember RASP, EDL, and XCTherm time and level choices per map page
-    #2690 #2705
-  - show the current page RASP layer and time on the RASP panel #2690
-  - allow downloading a full EDL day without that overlay already on the
-    page #2690
-  - keep XCTherm Time / Altitude controls consistent with RASP and EDL
-    #2690 #2705
-  - keep the chosen RASP time when switching to all-day layers; grey out
-    time until a multi-slot layer is selected again #2705
-  - step forecast time and altitude from the quick menu Forecast
-    Controls (and custom keys) (#2583)
-  - make weather time/level buttons easier to use on touchscreens; clip
-    long labels instead of hiding them
-  - add more pc_met radar and lightning images for Germany and Europe;
+  - add a weather cursor widget in the bottom panel for overlay time and
+    level/altitude across RASP, EDL, and XCTherm; step from the quick menu
+    Forecast Controls (and custom keys) #2583
+  - set and remember Layer/Time (or Level/Altitude) per map page; Apply to
+    page, Add page, and Pages setup #2705 #2690
+  - open Weather Setup from the weather overlay menu (Info → Weather) #2690
+  - show how old the RASP file is and open the file manager from the RASP
+    weather dialog
+  - keep the chosen RASP time when switching to all-day layers; grey out time
+    until a multi-slot layer is selected again #2705
+  - make weather time/level buttons easier to use on touchscreens; clip long
+    labels instead of hiding them
+  - show the active weather layer in the map title
+  - accept lowercase ICAO codes when adding a METAR/TAF station
+  - add more flugwetter.de radar and lightning images for Germany and Europe;
     local radar list uses Borkum instead of Emden
+  - zoom and pan photos in flugwetter.de #1127 #1246
+* airspace
+  - toggle airspace labels from Display page 2, Quick Menu, or a custom
+    key #1243
+  - colour the bottom airspace warning red (inside) or yellow (near)
+  - show distance and time in the bottom airspace warning
+  - grey out airspaces acknowledged for the day; Enable turns warnings on
+    again #2404
+  - hide the map warning triangle for day-acknowledged airspaces
+  - replace Radio with Details in airspace warnings
+  - improve list keyboard use; Select Airspace puts Details and Close on the
+    main buttons
+  - treat OpenAir ASRA airspace as aerial sporting/recreational #1827
+  - accept ".openair" as an airspace file extension
 * NOTAM integration
-  - download, cache, and show temporary NOTAM airspaces on the map
-    #2018
+  - download, cache, and show temporary NOTAM airspaces on the map #2018
   - refresh NOTAMs manually or automatically by location and time
   - filter NOTAMs (IFR, time window, distance, hidden Q-codes)
   - show NOTAM details in airspace dialogs
   - show a short briefing disclaimer before the first download
 * data files
-  - treat OpenAir ASRA airspace as aerial sporting/recreational #1827
-  - accept ".openair" as an airspace file extension
-  - store data in folders by type (waypoints, airspaces, terrain,
-    profiles, logs, downloads) instead of one flat folder #2289
-  - on first start after upgrade, move existing files into those folders
-    when possible #2289
+  - add a new data directory layout with folders by type (waypoints, airspaces,
+    terrain, profiles, logs, downloads) instead of one flat folder #2289
+  - move existing files into those folders on first start after upgrade when
+    possible #2289
   - store IGC and NMEA logs under logs/ #2289
   - create the needed folders on a fresh install before downloads #2580
   - fix crash when many downloads finish while more are queued #2624
+* Data Management
+  - add Data Management UI: site files, downloads, export flights, import,
+    backup, and file explorer in one place #2289
+  - list USB sticks and other removable storage; refresh when plugged or
+    unplugged
+  - import files from external storage into the correct XCSoar folders #2289
+  - back up the XCSoar data directory to a stick as a dated archive (not logs
+    or cache); restore warns before overwriting; restart after restore
+  - browse, organise, copy, rename, and delete files in the file explorer #2289
+  - improve empty file lists with a "Press here to download" hint
+* WeGlide
+  - allow setting WeGlide aircraft type even when upload is off #2323
+  - open WeGlide settings when upload credentials are incomplete
+  - upload IGC flights to WeGlide from Data Management → Export flights
 * devices
-  - add GDL90 for ADS-B traffic and ownship (serial or network);
-    optional ForeFlight altitude and attitude; traffic distance filters
-    #2356
-  - add LX160 vario driver (#2424)
-  - add LX Eos task declaration and flight log download (#2433)
-  - fix LX vario, heading, and wind that could lag or look wrong (#2554)
-  - add Condor 3 Spectate so other gliders appear on the FLARM radar and
-    map
-  - add Condor 3 UDP driver for Simkits output (default port 55278)
-    alongside the usual Condor TCP connection: MacCready, ballast,
-    attitude, radio, and related fields (#2340)
-  - support LK8000 instrument sentences ($LK8EX1) on all ports: pressure,
-    altitude, vario, temperature, and battery #2772
-  - treat BlueFly LX mode (vario without airspeed) as uncompensated
-    vario, not total-energy; keep total-energy when airspeed is present
-  - keep Status Variometer connected when BlueFly sends a short vario
-    sentence #2763
-  - show BlueFly battery voltage as well as percentage
-  - show BlueFly temperature from the device
-  - choose BlueFly BFV/BFX (or None) output in the device manage dialog
-  - download BlueFly flight logs from Devices → Flight download
-  - set BlueFly beep frequency, lift/sink thresholds, and audio in the
-    manage dialog when connected
-  - fix LXNAV thermal averages when altitude sources disagree #2754
-  - honour the LXNAV vario filter for the gauge, map vario bar, thermal
+  - GDL90: add driver for ADS-B traffic and ownship (serial or network);
+    optional ForeFlight altitude and attitude; traffic distance filters #2356
+  - LX160: add vario driver; expert toggle to emit GPGGA/GPRMC #2424
+  - LX Eos: add task declaration and flight log download #2433
+  - LX: fix vario, heading, and wind that could lag or look wrong #2554
+  - LXNAV: use the vario filter time for the gauge, map vario bar, thermal
     assistant, audio vario, and snail-trail colours
-  - use FLARM pressure altitude for the IGC logger when FLARM is
-    detected
-  - show polar sync in the device dialog only for varios that support it
-    (LXNAV) #2457
+  - LXNAV: show polar sync in the device dialog only for varios that support
+    it #2457
+  - LXNAV: prefer high-rate pressure altitude over the slower LXWP0 sentence so
+    conflicting altitudes no longer corrupt T Avg #2754
+  - Condor 3 Spectate: add file driver (Spectate.json) so other gliders appear
+    on the FLARM radar and map
+  - Condor 3 UDP: add driver for Simkits output (default port 55278) alongside
+    the usual Condor TCP connection: MacCready, ballast, attitude, radio, and
+    related fields #2340
+  - LK8000: support instrument sentences ($LK8EX1) on all ports: pressure,
+    altitude, vario, temperature, and battery #2772
+  - BlueFly: improve manage dialog for BFV/BFX output, beep frequency,
+    lift/sink thresholds, and audio; battery voltage and temperature; flight
+    log download; treat LX mode (vario without airspeed) as uncompensated
+    vario; show the Vario flag for BlueFly and other non-total-energy varios
+  - BlueFly: keep Status Variometer connected when a short vario sentence is
+    sent #2763
+  - FLARM: use pressure altitude for the IGC logger when FLARM is detected
+  - Air Control Display: set active COM (AT-01 and similar) by swapping through
+    standby #2454
   - send QNH changes from one device to all connected devices
-  - set active COM on Air Control Display (AT-01 and similar) by
-    swapping through standby #2454
-  - show the Vario flag for BlueFly and other non-total-energy varios
+  - show G-load and variometer source in system status
+  - switch audio vario between climb and speed-to-fly sounds manually or
+    automatically
+  - mute or change internal audio vario volume with a custom key
+  - switch vario/STF sound mode with a custom key
   - allow up to 8 devices (was 6)
   - fix crash when reconnecting a device #2382
 * infoboxes
   - add Altitude IGC (logger pressure altitude)
-  - improve Start reach and Start open when MacCready is too low or wind
-    is strong; Start open shows gate countdown now; Start reach shows
-    time to the start line #2502
+  - improve Start reach and Start open when MacCready is too low or wind is
+    strong; Start open shows gate countdown now; Start reach shows time to the
+    start line #2502
   - add Active Waypoint (next task point or Goto; tap to change)
-  - add Previous Waypoint (earlier task point; tap to inspect without
-    advancing the task)
+  - add Previous Waypoint (earlier task point; tap to inspect without advancing
+    the task)
   - add Home (name, arrival height, distance; tap to change home) #2320
   - add QNH (current pressure setting) #2521
-  - refresh InfoBox titles after changing language #2314
   - scale artificial horizon marks with InfoBox size
-* ui
-  - pinch to zoom on the map (Android, iOS); two fingers can pan at the
-    same time; a drag or twist enters pan mode; a zoom-only pinch keeps
-    following the aircraft #2790
-  - twist with two fingers to rotate the map temporarily; the angle
-    stays while panning and resets when you leave pan mode #2790
-  - smooth keyboard and mouse-wheel zoom on colour screens after a
-    pinch
-  - keep the north arrow clear of menu and zoom buttons
-  - make the simulator easier to use: tip to steer by dragging or via
-    Altitude / Speed Ground; Welcome text in simulator mode; "Sim: Jump
-    to" on map items and waypoints; Speed Ground panel; rename Set Home
-    to "Set as Startup Location" in simulator mode
-  - press F1 on the FLARM radar to toggle AVG/ALT side labels
-  - keep GPS status visible above AUTO / Simulator / REPLAY text
-  - improve the soft keyboard: focus a key by default; arrows move
-    across the grid; F1 is backspace
-  - fix logo and title colours on light startup screens #2742
-  - size the InfoBox strip to the current tab so the map title does not
-    jump
-  - improve map vario and final-glide value labels (clearer background)
-    #1438
-  - put the vario bar on the left and final glide on the right #1210
-  - toggle airspace labels from Display page 2, Quick Menu, or a custom
-    key #1243
-  - add Quick Guide and Replay to the Quick Menu (Replay off when
-    moving)
-  - show replay speed on the map (e.g. REPLAY 2x) #2281
-  - choose Fly or Simulator with Left/Right on the startup prompt
-  - improve map items: clearer "Your Position" icon; Details opens
-    Status: Flight; airspace Inside/Near like the warnings list
-  - colour the bottom airspace warning red (inside) or yellow (near)
-  - show distance and time in the bottom airspace warning
-  - put WiFi Connect first and Close last
-  - put Download before Cancel in the download list
-  - simpler keyboard focus in file and value pickers
-  - draw a line above help text in list pickers
-  - keep Quick Menu Left/Right from jumping onto disabled items
-  - highlight focused action buttons clearly
-  - open waypoint details with Details / F1 (Enter still selects)
-  - fix task point dialog keys: Up/Down edit fields; Left/Right change
-    turnpoint; better portrait layout
-  - fill the last button in a dialog button row to the edge
-  - put Reference Mass above the polar speed/sink grid
-  - speed up Quick Guide "What's New" scrolling
-  - add Display type (LCD / E-ink / Color e-ink) under Look → Screen
-    Layout; e-ink modes turn off smooth scrolling
-  - smoother list scrolling on e-paper
-  - show full callsigns on the FLARM radar; hide duplicate side
-    vario/altitude on the selected target #2718
-  - improve FLARM traffic symbol and label size #2708
-  - rotate FLARM radar targets correctly on north/south/east/west
-    headings
-  - outline the selected target on the FLARM radar
-  - fix crash opening map items on waypoints with long non-English
-    comments
-  - fix crash in language lists with long Chinese (and similar) text
-    #2768
-  - optional Quick Menu button over the map on touchscreens #2610
-  - keep weather overlay settings visible (greyed out) on non-map pages
-    (#2583)
-  - allow setting WeGlide aircraft type even when upload is off #2323
-  - fix Status → Times so flight time matches takeoff and landing #957
-  - show PEV start offset as "45 sec" or "2 min", not 00:00
-  - show G-load and variometer source in system status
-  - fix polar editor layout
-  - use clearer colours for read-only text (e.g. waypoint details) #2465
-  - add Data Management: site files, downloads, export flights, import,
-    backup, and file explorer in one place
-  - list USB sticks and other removable storage; refresh when plugged
-    or unplugged
-  - import files from a stick into the right XCSoar folders #2289
-  - back up your XCSoar data to a stick as a dated archive (not logs or
-    cache); restore warns before overwrite; restart after restore
-  - browse, organise, copy, rename, and delete files in the file
-    explorer #2289
+  - refresh InfoBox titles after changing language #2314
+* waypoint
   - find waypoints by text anywhere in the name (e.g. FIELD finds
     AIRFIELD) #2483
   - list each waypoint only once in search #1316
-  - remove the useless "map file" type filter when waypoints come from
-    another file #1376
-  - fix the "Recently Used" waypoint filter #1994
   - list all CUP waypoint types in the Type filter #2485
-  - keep waypoint search open until Esc or a successful GoTo, task,
-    home, or pan #749
-  - zoom and pan photos in waypoint details and PC-Met (#1127, #1246)
-  - clearer list keyboard use; Select Airspace puts Details and Close on
-    the main buttons
+  - remove the useless "map file" type filter when waypoints come from another
+    file #1376
+  - fix the "Recently Used" waypoint filter #1994
+  - open waypoint details with Details / F1 (Enter still selects)
+  - keep the dialog open until Esc or a successful GoTo, task, home, or
+    pan #749
+  - zoom and pan photos in waypoint details #1127 #1246
+* Quick Guide
+  - add Quick Guide and Replay to the Quick Menu (Replay off when moving)
+  - show formatted release notes in Quick Guide "What's New"
+  - Quick Guide getting started reflects current Safety and Terrain
+    settings #2324
+  - apply a terrain file chosen in Quick Guide immediately #2322
+  - enlarge checklist touch targets in Quick Guide #2325
+  - add "Don't show this guide again" on every informational Quick Guide page;
+    settings for startup guide and release notes #2648
+  - speed up Quick Guide "What's New" scrolling
+* checklists
+  - tap checklist radio links (vhf:…) to set COM standby or active
+  - advance to the next checklist item after Enter #2405
+  - swipe left/right to change page in checklists, Credits, Quick Guide, and
+    configuration #2122 #2414
+* simulator
+  - make the simulator easier to use: tip to steer by dragging or via Altitude
+    / Speed Ground; Welcome text in simulator mode; "Sim: Jump to" in "Map
+    elements at this location" and waypoints; Speed Ground panel; rename Set
+    Home to "Set as Startup Location" in simulator mode
+  - choose Fly or Simulator with Left/Right on the startup prompt
+  - keep GPS status visible above AUTO / Simulator / REPLAY text
+* ui
+  - fix logo and title colours on light startup screens #2742
+  - improve the soft keyboard: focus a key by default; arrows move across the
+    grid; F1 is backspace
+  - simplify keyboard focus in file and value pickers
+  - keep Quick Menu Left/Right from jumping onto disabled items
+  - highlight focused action buttons clearly
+  - improve tab focus in tabbed dialogs
+  - fix task point dialog keys: Up/Down edit fields; Left/Right change
+    turnpoint; better portrait layout
   - fix unreadable focused rows on e-paper lists #2495
-  - grey out airspaces acknowledged for the day; Enable turns warnings
-    back on #2404
-  - hide the map warning triangle for day-acknowledged airspaces
-  - replace Radio with Details in airspace warnings
-  - hide map overlay buttons on non-map pages (traffic, thermal
-    assistant)
+  - draw a line above help text in list pickers
+  - fill the last button in a dialog button row to the edge
+  - put Reference Mass above the polar speed/sink grid
+  - use clearer colours for read-only text (e.g. waypoint details) #2465
+  - fix polar editor layout
+  - fix crash in language lists with long Chinese (and similar) text #2768
+  - add Display type (LCD / E-ink / Color e-ink) under Look → Screen Layout;
+    e-ink modes turn off smooth scrolling
+  - smooth list scrolling on e-paper
+  - fix Status → Times so flight time matches takeoff and landing #957
   - show all InfoBoxes again in configuration #2344
   - improve bundled UI sound quality
-  - clearer tab focus in tabbed dialogs
-  - Enter on a checklist box moves like Down #2405
-  - tap checklist radio links (vhf:…) to set COM standby or active
-  - swipe left/right to change page in checklists, Credits, Quick Guide,
-    and configuration #2122 #2414
-  - show formatted release notes in Quick Guide "What's New"
-  - Quick Guide getting started reflects your Safety and Terrain
-    settings #2324
-  - apply a terrain file chosen in Quick Guide immediately (#2322)
-  - larger checklist touch targets in Quick Guide #2325
-  - "Don't show this guide again" on every informational Quick Guide
-    page; settings for startup guide and release notes #2648
-  - switch audio vario between climb and speed-to-fly sounds manually or
-    automatically
+  - replay the status sound on Message Repeat, not only the text
+  - fix InfoBox crash after a dialog closes and windows are recreated
 * input
-  - mute or change internal audio vario volume with a custom key
-  - switch vario/STF sound mode with a custom key
-  - F2/F3 zoom in pan mode, on the FLARM radar, and on waypoint photos
-    (on the main map F2/F3 stay Checklist and FLARM)
-  - Return opens pan mode on the main map (was FLARM); F3 still opens
-    FLARM traffic
-  - Escape (and Android back) closes pan mode and submenus; Cancel on
-    the main menu
-  - Data Management replaces File Manager in the quick menu and Config;
-    quick menu can toggle distance rings
-  - open waypoint search filtered (recent, airport, landable, …) from a
-    gesture or key #336
+  - F2/F3 zoom in pan mode, on the FLARM radar, and on waypoint photos (on the
+    main map F2/F3 stay Checklist and FLARM)
+  - Return opens pan mode on the main map (was FLARM); F3 still opens FLARM
+    traffic
+  - Escape (and Android back) closes pan mode and submenus; Cancel on the main
+    menu
+  - Data Management replaces File Manager in the quick menu and Config; quick
+    menu can toggle distance rings
+  - open Select Waypoint filtered (recent, airport, landable, …) from a gesture
+    or key #336
   - Left-Up gesture opens recently used waypoints #336
-  - customise keys for zooming waypoint photos without changing map
-    keys
-* documentation
-  - document custom input files (.xci): merge vs replace, keys,
-    gestures, soft keys, and RemoteStick Quick Menu
+  - customise keys for zooming waypoint photos without changing map keys
+  - always show FLARM Radar and Thermal Assistant in the default menus (not
+    only when FLARM is connected or circling)
+  - document custom input files (.xci): merge vs replace, keys, gestures, soft
+    keys, and RemoteStick Quick Menu
   - document the AirspaceLabels input event
+* documentation
   - document map pinch-to-zoom #2790
+  - document weather overlays (RASP, EDL, XCTherm), per-page setup, and weather
+    overlay input events
+  - add a NOTAM section to the manual
+  - document the new data directory layout
+  - document contour line density settings in the manual
+  - document the OpenGL Windows install and deprecate the old single-file
+    Windows program in the install guide
+  - document user repository configuration in the manual
+  - update InfoBox reference for Active / Previous / Home and Alternates
 * android
   - connect more Bluetooth dongles (Naviter NUS and BlueFly-style UART)
     automatically #2260
-  - keep existing Bluetooth serial device settings working
-  - support SoftRF Concorde, Prime Mk4, and Retro Mk2 over USB
+  - support SoftRF Concorde, Prime Mk4, and Retro Mk2 over USB; add CH343 USB
+    serial IDs
   - number dual USB serial ports clearly (0, 1) #2481
-  - fix crash when the app restarts after the screen is closed
-  - fix stray lines on some high-resolution phones #1514
-  - use the real screen size for startup scaling #1784
   - improve UI sound quality and reliability #2411
   - put built-in GPS and sensors in the last device slot by default
   - refresh the device list when storage access changes
+  - keep existing Bluetooth serial device settings working
+  - fix crash when the app restarts after the screen is closed
+  - fix stray lines on some high-resolution phones #1514
+  - use the real screen size for startup scaling #1784
 * iOS
-  - fix audio vario through the device speaker #2474
   - open waypoint PDFs and other attached files from details #2501
-  - keep GPS updates while stationary #2380
   - put built-in GPS and sensors in the last device slot by default
+  - fix audio vario through the device speaker #2474
+  - keep GPS updates while stationary #2380
+  - filter barometer noise for steadier vario
+  - report denied location access as a device error
 * macOS
   - fix thick lines drawn at the wrong width #2545
 * Linux
-  - add Config → Setup → Network for WiFi status, connect/disconnect,
-    and IP address
+  - add Config → Setup → Network for WiFi status, connect/disconnect, and IP
+    address
 * OpenVario
   - show WiFi and ethernet status; connect or disconnect WiFi and renew
     ethernet from Network
 * Windows
-  - add an installer for the OpenGL Windows version (64- and 32-bit);
-    zip remains for portable use #2064
-  - deprecate the old single-file Windows program; use the OpenGL
-    version instead
-  - fewer false malware warnings from Windows Defender (#2232)
+  - switch Windows to OpenGL graphics: installer for 64- and 32-bit; zip
+    remains for portable use #2064
+  - deprecate the old single-file Windows program; use the OpenGL version
+    instead
+  - restore UI sound on the OpenGL Windows version
+  - show the XCSoar icon in the taskbar, window, and .exe for OpenGL
+  - fix list scroll-wheel step on the OpenGL Windows version
+  - open system WiFi settings from the Network panel
+  - reduce false malware warnings from Windows Defender #2232
   - fix duplicate names in Windows file lists #2625
   - fix crash opening logs with non-English filenames
   - load CUPX waypoint packs with photos correctly
 * desktop
   - support -h/--help and -version/--version on the command line
-  - use the same storage picker for flight export and data import on
-    Linux and Windows #1114
+  - use the same storage picker for flight export and data import on Linux and
+    Windows #1114
 * Kobo
-  - always start in light mode (dark mode is not supported on e-paper)
-    #2568
   - add Network with WiFi status and Auto WiFi at startup #2531
+  - always start in light mode (dark mode is not supported on e-paper) #2568
   - fix black squares when scrolling lists on e-paper #2293
 * development
-  - MapWindow: publish a coherent projection snapshot for the DrawThread
-    on non-OpenGL builds so rendering does not read a live UI projection
-    #2735
-  - build system: ship native debug symbols for Google Play
-    (symbols.zip) for single-ABI and multi-ABI (AAB) builds; fix parallel
-    builds so CI reliably produces the symbol ZIP
-  - build system: generate Quick Guide "What's New" markdown from
-    NEWS.txt at build time
+  - MapWindow: publish a coherent projection snapshot for the DrawThread on
+    non-OpenGL builds so rendering does not read a live UI projection #2735
+  - build system: ship native debug symbols for Google Play (symbols.zip) for
+    single-ABI and multi-ABI (AAB) builds; fix parallel builds so CI reliably
+    produces the symbol ZIP
+  - build system: generate Quick Guide "What's New" markdown from NEWS.txt at
+    build time
+  - documentation: refresh build, developer setup, and Docker docs; fix
+    Sphinx/Graphviz builds
+  - documentation: document network thread / background HTTP and storage /
+    background file jobs in architecture.rst
+  - documentation: document weather overlay integration lifecycle
+  - documentation: add NEWS.txt release-notes guidelines to policy.rst
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -18,8 +18,8 @@ Version 7.45 - not yet released
     to filter self and additional own aircraft from OGN when the device
     radio id is unavailable (e.g. LX passthrough) #2693
 * calculations
-  - fix wild T Avg climb rates by preferring the instrument vario when
-    available #2754
+  - prefer the instrument vario for T Avg climb rates when available
+    #2754
   - support altitude-corrected speed-to-fly and task glide calculations:
     cruise speeds and best glide stay correct higher up (#1569)
   - use the same altitude correction for task manager glide and safety
@@ -55,8 +55,6 @@ Version 7.45 - not yet released
   - open waypoint details above the waypoint list and alternates; Close
     without a committed action returns to the list, not the map #620
 * map
-  - fix black terrain after idle high-resolution sharpening on OpenGL
-    devices with a 2048-pixel texture limit
   - keep the Full snail trail store at 1024 points on slower hosts
     (typical e-readers and similar) instead of the larger fast-host
     capacity #2661
@@ -79,8 +77,6 @@ Version 7.45 - not yet released
   - smooth snail trail between fixes; vario colours use high-rate netto
     between GPS points when available #2447
   - add distance rings around the current location #2522
-  - fix intermittent white-map hang on startup when drawing began before
-    map bounds were ready #2734
   - match BigTrafficWidget task direction arrow to the map best-cruise
     shape #2027
   - show optional callsign and relative altitude beside BigTrafficWidget
@@ -117,8 +113,6 @@ Version 7.45 - not yet released
   - keep the RASP time cursor on all-day layers (single archive slot);
     grey out time controls until a multi-slot layer is selected again
     #2705
-  - fix crash when opening Weather Setup from the weather overlay
-    layer/level/altitude list picker #2690
   - add WeatherOverlay input event and mode=weather stick/button
     bindings (via quick menu Forecast Controls) to step forecast time
     and altitude/level on weather overlay map pages (#2583)
@@ -160,8 +154,6 @@ Version 7.45 - not yet released
   - add Condor 3 UDP telemetry driver (Condor3UDP) for Simkits generic
     UDP output (default port 55278); complements TCP/NMEA Condor3 for
     MacCready, ballast, attitude, radio, and related fields (#2340)
-  - fix Condor3UDP track jumps from ground-velocity vx/vy after compass
-    expiry
   - support $LK8EX1 (LK8000 external instrument) on all device ports:
     pressure, QNE altitude, vario, temperature, and battery #2772
   - treat $LXWP0 without airspeed as uncompensated vario (BlueFly LX
@@ -258,27 +250,20 @@ Version 7.45 - not yet released
   - use focus colour for action-bar buttons that have keyboard focus
   - open waypoint details with Details / F1 (Enter still confirms the
     selection)
-  - move Task Manager keyboard focus with Manage → Browse (and WeGlide
-    lists) so Up/Down can move the task list again
   - fix task point dialog keyboard navigation: Up/Down no longer skip
     OZ Radius; Left/Right change the task point; portrait layout uses
     full width for map and OZ fields
   - fill leftover pixels on the last dialog action-bar button in a row
   - put Reference Mass above the plane polar V/W grid; Up/Down moves
     within each V/W column
-  - fix Configuration keyboard navigation between settings rows, menu,
-    and Close
   - speed up long rich-text layout (Quick Guide What's New)
-  - fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
-    are reachable from the keyboard
   - add Expert Look → Screen Layout "Display type" (LCD / E-ink /
     Color e-ink); e-ink modes disable kinetic and smooth scrolling;
     defaults to E-ink on Kobo and LCD elsewhere
   - snap e-paper VScrollPanel scrolling instead of animating at high
     rate, and debounce ComboPicker help updates while scrolling
-  - show FLARM radar callsigns on all registered targets again, use the
-    full callsign on labels, and omit duplicate side vario/altitude on
-    the selected target #2718
+  - show full callsigns on all registered FLARM radar targets; omit
+    duplicate side vario/altitude on the selected target #2718
   - rotate FLARM radar track-up targets on cardinal bearings
   - outline selected targets on the FLARM traffic radar
   - fix crash when opening the map item list on waypoints with long
@@ -287,10 +272,6 @@ Version 7.45 - not yet released
     picker) #2768
   - add optional map overlay QuickMenu button (Config → Look → Layout),
     enabled by default when a touch screen is detected #2610
-  - fix crash when switching pages from FLARM radar or thermal assistant
-    back to a map page that has a bottom widget (#2583)
-  - fix airspace warnings crash when the warning clears if the bottom
-    page was already restored
   - keep pages config map overlay and RASP layer rows visible on non-map
     pages (disabled instead of hidden) (#2583)
   - allow WeGlide aircraft type in plane details even when WeGlide

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,8 +10,8 @@ Version 7.45 - not yet released
     traffic (fixes pan-mode disappearance of online targets)
   - support configurable XCSoar Cloud server hostname and UDP port in
     cloud settings
-  - raise combined FLARM/online traffic list limit to 64 targets (cloud
-    batch size); device FLARM traffic still typically stays within 25
+  - raise combined FLARM/online traffic list limit to 64 targets; device
+    FLARM traffic still typically stays within 25
   - drop OGN/cloud online traffic that matches the connected FLARM radio
     id so own-ship no longer appears on the traffic display #2693
   - add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
@@ -55,11 +55,10 @@ Version 7.45 - not yet released
   - open waypoint details above the waypoint list and alternates; Close
     without a committed action returns to the list, not the map #620
 * map
-  - keep the Full snail trail store at 1024 points on slower hosts
-    (typical e-readers and similar) instead of the larger fast-host
-    capacity #2661
-  - reduce long-flight map CPU by clipping the snail trail to the
-    visible area before thinning #2661
+  - keep the Full snail trail shorter on slower hosts (typical e-readers
+    and similar) so long flights stay responsive #2661
+  - draw only the visible part of a long snail trail to reduce map lag
+    #2661
   - adjust contour line density to the zoom level #2233
   - add contour density profile settings for mountains, lowlands, and
     other landscape types
@@ -77,10 +76,10 @@ Version 7.45 - not yet released
   - smooth snail trail between fixes; vario colours use high-rate netto
     between GPS points when available #2447
   - add distance rings around the current location #1206 #2522
-  - match BigTrafficWidget task direction arrow to the map best-cruise
-    shape #2027
-  - show optional callsign and relative altitude beside BigTrafficWidget
-    targets when side data is in altitude mode
+  - match the large FLARM radar task direction arrow to the map
+    best-cruise shape #2027
+  - show optional callsign and relative altitude beside targets on the
+    large FLARM radar when side data is in altitude mode
 * weather
   - accept lowercase ICAO codes when adding a METAR/TAF station
   - add EDL weather with per-page map overlays (None/RASP/EDL), bottom
@@ -144,7 +143,7 @@ Version 7.45 - not yet released
   - fix crash when queuing many background file downloads while others
     complete #2624
 * devices
-  - add GDL 90 input driver (ADS-B traffic and ownship over serial or
+  - add GDL90 input driver (ADS-B traffic and ownship over serial or
     UDP; optional ForeFlight geometric altitude and AHRS;
     horizontal/vertical traffic filters) #2356
   - add LX160 driver for LXWPx varios (#2424)
@@ -179,8 +178,8 @@ Version 7.45 - not yet released
   - show glide polar sync in the device dialog only for drivers that
     support it (LXNAV) #2457
   - send QNH changes from external sources to all connected devices
-  - Air Control Display: set active COM frequency via standby swap
-    (AT-01 and similar with read-only active channel) #2454
+  - set the active COM frequency on Air Control Display via standby
+    swap (AT-01 and similar with read-only active channel) #2454
   - show the Vario flag on the device list for non-compensated and
     netto vario sources as well as total-energy (e.g. BlueFly)
   - increase the number of device slots from 6 to 8
@@ -246,7 +245,7 @@ Version 7.45 - not yet released
   - put Download before Cancel in the download picker; Left/Right page
     the list
   - use single keyboard focus in the multi-file picker and value list
-    picker (ComboPicker)
+    picker
   - draw a thin separator line above list-picker bottom help text
   - make Quick Menu Left/Right stay put when the next item is disabled,
     but still wrap or flip page at a real row edge
@@ -263,8 +262,8 @@ Version 7.45 - not yet released
   - add Expert Look → Screen Layout "Display type" (LCD / E-ink /
     Color e-ink); e-ink modes disable kinetic and smooth scrolling;
     defaults to E-ink on Kobo and LCD elsewhere
-  - snap e-paper VScrollPanel scrolling instead of animating at high
-    rate, and debounce ComboPicker help updates while scrolling
+  - snap e-paper scrolling instead of animating at high rate, and delay
+    per-item help updates while scrolling long lists
   - show full callsigns on all registered FLARM radar targets; omit
     duplicate side vario/altitude on the selected target #2718
   - improve FLARM traffic symbol and label sizing #2708
@@ -295,12 +294,12 @@ Version 7.45 - not yet released
     refresh when media is plugged in or removed
   - import data: copy files from external storage into the correct
     XCSoar folders (waypoints, airspaces, terrain, and the rest) #2289
-  - backup manager: copy the XCSoar data directory to chosen storage as
-    a dated .tar file (profiles, waypoints, airspaces, terrain, and
-    settings; not logs, other backups, or cache); restore warns before
-    overwriting; restart XCSoar afterward to apply restored settings
-  - file explorer: browse storage, sort files into folders, copy to
-    another drive, rename, and delete #2289
+  - copy the XCSoar data directory to chosen storage as a dated .tar
+    backup (profiles, waypoints, airspaces, terrain, and settings; not
+    logs, other backups, or cache); restore warns before overwriting;
+    restart XCSoar afterward to apply restored settings
+  - browse storage in the file explorer, sort files into folders, copy
+    to another drive, rename, and delete #2289
   - find waypoint search text anywhere in the name or short name #2483
   - list each waypoint only once in search results #1316
   - remove useless "map file" type filter when waypoints come from
@@ -331,7 +330,7 @@ Version 7.45 - not yet released
     (optional station name in the link label)
   - support horizontal swipe to flip checklist, Credits, Quick Guide,
     and configuration pages #2122 #2414
-  - format Quick Guide "What's New" from NEWS.txt at build time
+  - show formatted release notes in Quick Guide "What's New"
   - reflect live Safety factors and Terrain display settings in Quick
     Guide getting started #2324
   - apply Quick Guide terrain file choice immediately (#2322)
@@ -377,17 +376,16 @@ Version 7.45 - not yet released
     addition to HM-10; protocol auto-detected at connection #2260
   - support BLE Microchip/ISSC transparent UART (e.g. BlueFly Vario over
     BLE); auto-detected like NUS/HM-10
-  - keep the saved device port type string as ble_hm10 so existing
-    profiles load without migration
+  - keep existing BLE serial profiles working after adding NUS and
+    Microchip UART support
   - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as
     supported USB devices
   - number multi-port USB serial adapters (e.g. dual FTDI) with
     suffixes (0, 1) in the port list and device list #2481
-  - fix crash when the native thread restarts after surface teardown
+  - fix crash when the app restarts after the display is torn down
   - fix spurious outline lines on high-DPI OpenGL displays #1514
   - use physical display metrics for startup DPI #1784
-  - improve UI sounds via preloaded SoundPool with MediaPlayer fallback
-    #2411
+  - improve bundled UI sound quality and playback reliability #2411
   - configure built-in GPS and sensors in the last device slot by
     default
   - update the device list when storage access changes
@@ -403,7 +401,7 @@ Version 7.45 - not yet released
   - fix thick solid lines rendering at incorrect pixel width #2545
 * Linux
   - add Config → Setup → Network for WiFi status, connect/disconnect,
-    and IP address (NetworkManager or ConnMan via D-Bus)
+    and IP address (NetworkManager or ConnMan)
 * OpenVario
   - show WiFi and ethernet status; support WiFi connect/disconnect and
     ethernet DHCP renew from the Network dialog
@@ -417,8 +415,7 @@ Version 7.45 - not yet released
   - fix duplicate entries in Windows file lists #2625
   - fix crash opening the log list when replay filenames contain
     non-ASCII characters
-  - open files in binary mode so embedded ZIP (e.g. CUPX POINTS.CUP) is
-    read correctly
+  - load CUPX archives with embedded waypoint files correctly
 * desktop
   - print -h/--help and -version/--version to stdout and exit; unknown
     options print a short usage line on stderr
@@ -438,6 +435,8 @@ Version 7.45 - not yet released
   - build system: ship native debug symbols for Google Play
     (symbols.zip) for single-ABI and multi-ABI (AAB) builds; fix parallel
     builds so CI reliably produces the symbol ZIP
+  - build system: generate Quick Guide "What's New" markdown from
+    NEWS.txt at build time
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/doc/policy.rst
+++ b/doc/policy.rst
@@ -118,8 +118,8 @@ are appropriate. Prefix bullets with a topic (``build system:``,
 - Section names in ``NEWS.txt`` are historically inconsistent (``* ui`` vs
   ``* user interface``); match the current unreleased release block.
 
-See also ``.cursor/rules/news.txt.mdc`` for wording examples and a fuller
-checklist.
+See also ``.cursor/rules/news.txt.mdc`` and the related ``news-*.mdc`` rules
+for structure, wording, formatting, and section organisation.
 
 Code Style
 ==========

--- a/tools/news_to_quickguide_md.py
+++ b/tools/news_to_quickguide_md.py
@@ -8,6 +8,12 @@
 # "  - " bullets merge indented continuation lines into one list item so the
 # in-app renderer wraps with correct hanging indent. A blank line is also
 # inserted after the H1.  ``#1234`` issue references become GitHub links.
+#
+# Quick Guide Markdown constraints (validated before code generation):
+# - Use ``* section`` and ``  - `` bullets only; continuations with 4 spaces.
+# - Avoid double backticks; the in-app renderer shows them literally.
+# - Avoid ``[text](url)`` examples; MarkdownParser treats them as real links.
+# - Do not write ``(#0, #1)`` for USB port suffixes; use ``(0, 1)`` instead.
 
 from __future__ import annotations
 
@@ -18,7 +24,8 @@ import sys
 # GitHub issue links for NEWS “#1234” references (same tracker as the repo).
 GITHUB_ISSUE_BASE = "https://github.com/XCSoar/XCSoar/issues"
 # Do not match “#digits” already used as link text in […](…); avoid “##…” headings.
-_ISSUE_REF = re.compile(r"(?<!\[)#(\d+)\b")
+# Skip #0 (not a GitHub issue; used for USB port suffixes in NEWS).
+_ISSUE_REF = re.compile(r"(?<!\[)#(?!0\b)(\d+)\b")
 
 
 def extract_first_version_block(text: str) -> str:
@@ -105,6 +112,31 @@ def convert_news_block_to_markdown(block: str) -> str:
     return linkify_github_issue_refs("\n".join(md) + "\n")
 
 
+def validate_quickguide_markdown(md: str) -> list[str]:
+    """Reject constructs that confuse MarkdownParser or mis-link in the UI."""
+    errors: list[str] = []
+    for i, line in enumerate(md.splitlines(), 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if not stripped.startswith("- "):
+            errors.append(
+                f"line {i}: expected list item or heading, got: {line[:72]!r}"
+            )
+            continue
+        if "[text](url)" in line:
+            errors.append(
+                f"line {i}: literal [text](url) is parsed as a Markdown link"
+            )
+        if "``" in line:
+            errors.append(
+                f"line {i}: double backticks render literally; use quotes instead"
+            )
+    return errors
+
+
 def cxx_escape(s: str) -> str:
     return (
         s.replace("\\", "\\\\")
@@ -165,6 +197,12 @@ def main() -> int:
     md = convert_news_block_to_markdown(block)
     if not md.strip():
         print("news_to_quickguide_md: conversion produced empty markdown", file=sys.stderr)
+        return 1
+
+    errors = validate_quickguide_markdown(md)
+    if errors:
+        for err in errors:
+            print(f"news_to_quickguide_md: {err}", file=sys.stderr)
         return 1
 
     emit_header(md)


### PR DESCRIPTION
## Summary

- Reorganise the v7.45 NEWS block by topic (calculations, task, map, weather, NOTAM, data files, devices, infoboxen, ui, input) and platform sections
- Add missing user-facing items (Data Management, backup manager with USB support, default.xci input changes, Condor3 UDP detail, etc.)
- Remove interim regression fixes that only affected 7.45 development, not upgraders from 7.44
- Use plainer pilot-facing wording; split platform notes (android, iOS, Linux, OpenVario, windows, kobo)
- Extend `tools/news_to_quickguide_md.py` with Quick Guide Markdown validation (no double backticks, no literal link examples, skip `#0` linkify)

## Test plan

- [x] `python3 tools/news_to_quickguide_md.py NEWS.txt` passes
- [ ] Quick Guide "What's New" renders correctly after rebuild

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Version 7.45 release notes with improvements to traffic tracking, flight calculations, tasks, map rendering, weather overlays, NOTAMs, data management, device support, InfoBoxes, input bindings, platform fixes, and packaging.
  * Improved guidance for organizing and writing release notes.
* **Quality Improvements**
  * Added validation to prevent malformed Quick Guide Markdown and incorrect issue links.
* **Chores**
  * Updated copyright information and contributor acknowledgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->