### PR TITLE
iOS: Fix permanent audio ducking of other apps after playing a sound

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -268,6 +268,8 @@ Version 7.45 - not yet released
   - fix audio vario playback through the device speaker
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380
+  - fix audio session never being deactivated after playing a sound, which
+    left other apps' audio (e.g. music) permanently ducked #2609
 * kobo
   - memory canvas: fix painting when list rows or edit fields are partially
     off-screen while scrolling (no black squares; safer clipping of subcanvas

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -269,7 +269,8 @@ Version 7.45 - not yet released
   - disable Core Location distance filter for built-in GPS so fixes are not
     suppressed while stationary #2380
   - fix audio session never being deactivated after playing a sound, which
-    left other apps' audio (e.g. music) permanently ducked #2609
+    left other apps' audio (e.g. music) permanently ducked; re-apply session
+    config on audio vario device (re-)open to prevent ducking #2609
 * kobo
   - memory canvas: fix painting when list rows or edit fields are partially
     off-screen while scrolling (no black squares; safer clipping of subcanvas

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,6 +10,8 @@ Version 7.46 - not yet released
     characters and providing a designed bold cut
   - save the settings when the app moves to the background, so they
     survive being swiped away in the app switcher
+  - fix other apps' audio staying ducked after XCSoar plays a sound,
+    and the audio vario cutting out when leaving settings #2609
   - remove the thin white frame around full-screen dialogs (such as
     the Fly/Simulator screen), which no longer stop one pixel short of
     the display edge

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -18,8 +18,7 @@ InitializeAppleServices()
   AVAudioSession *session = [AVAudioSession sharedInstance];
   [session setCategory:AVAudioSessionCategoryPlayback
            withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                 error:&error];
-  [session setActive:YES error:&error];
+           error:&error];
   if (error) {
     LogFormat("AVAudioSession initialize error: %s", [[error localizedDescription] UTF8String]);
   }
@@ -33,7 +32,9 @@ DeinitializeAppleServices()
 #if TARGET_OS_IPHONE
   // Deinitialize AVAudioSession
   NSError *error = nil;
-  [[AVAudioSession sharedInstance] setActive:NO error:&error];
+  [[AVAudioSession sharedInstance] setActive:NO
+                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                   error:&error];
   if (error) {
     LogFormat("AVAudioSession deinitialize error: %s", [[error localizedDescription] UTF8String]);
   }

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -8,20 +8,67 @@
 #include "Services.hpp"
 #import <AVFoundation/AVFoundation.h>
 
+#if TARGET_OS_IPHONE
+
+static bool audio_vario_session_active = false;
+
+void
+SetAudioVarioSessionActive(bool active)
+{
+  audio_vario_session_active = active;
+}
+
+void
+ActivateAudioSession()
+{
+  NSError *error = nil;
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+
+  // (Re-)apply our preferred category and options. SDL's CoreAudio
+  // backend may reset these when it (re-)opens the audio device for the
+  // audio vario, which would otherwise cause XCSoar to duck other apps'
+  // audio.
+  [session setCategory:AVAudioSessionCategoryPlayback
+           withOptions:AVAudioSessionCategoryOptionMixWithOthers
+                 error:&error];
+  if (error) {
+    LogFormat("AVAudioSession setCategory error: %s", [[error localizedDescription] UTF8String]);
+    error = nil;
+  }
+
+  [session setActive:YES error:&error];
+  if (error) {
+    LogFormat("AVAudioSession activate error: %s", [[error localizedDescription] UTF8String]);
+  }
+}
+
+void
+DeactivateAudioSession()
+{
+  if (audio_vario_session_active) {
+    // keep the session active while the audio vario's audio device is
+    // open: deactivating it would also silence the audio vario, which
+    // SDL would not resume on its own
+    return;
+  }
+
+  NSError *error = nil;
+  [[AVAudioSession sharedInstance] setActive:NO
+                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                   error:&error];
+  if (error) {
+    LogFormat("AVAudioSession deactivate error: %s", [[error localizedDescription] UTF8String]);
+  }
+}
+
+#endif
+
 // Initialize apple services - this will be called from the main XCSoar startup
 void
 InitializeAppleServices()
 {
 #if TARGET_OS_IPHONE
-  // Setup AVAudioSession for better audio playback
-  NSError *error = nil;
-  AVAudioSession *session = [AVAudioSession sharedInstance];
-  [session setCategory:AVAudioSessionCategoryPlayback
-           withOptions:AVAudioSessionCategoryOptionMixWithOthers
-           error:&error];
-  if (error) {
-    LogFormat("AVAudioSession initialize error: %s", [[error localizedDescription] UTF8String]);
-  }
+  ActivateAudioSession();
 #endif
 }
 

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -6,23 +6,32 @@
 #include <TargetConditionals.h>
 #include "LogFile.hpp"
 #include "Services.hpp"
+#include "thread/Mutex.hxx"
 #import <AVFoundation/AVFoundation.h>
-
-#include <atomic>
 
 #if TARGET_OS_IPHONE
 
 /**
- * Accessed from the SDL audio thread (SDLPCMPlayer), from the thread
- * calling SoundUtil::Play() and from the AVAudioPlayer delegate
- * callbacks, so it needs to be atomic.
+ * Serialises audio_vario_session_active against the deactivation of the
+ * shared AVAudioSession. Without it, DeactivateAudioSession() could read
+ * the flag as false, then have the audio vario start up (setting the
+ * flag and activating the session) before its own setActive:NO takes
+ * effect, silencing the freshly started vario.
  */
-static std::atomic<bool> audio_vario_session_active{false};
+static Mutex audio_session_mutex;
+
+/**
+ * Protected by #audio_session_mutex: written from the SDL audio thread
+ * (SDLPCMPlayer) and read from the thread calling SoundUtil::Play() and
+ * from the AVAudioPlayer delegate callbacks.
+ */
+static bool audio_vario_session_active = false;
 
 void
 SetAudioVarioSessionActive(bool active)
 {
-  audio_vario_session_active.store(active, std::memory_order_release);
+  const std::lock_guard lock{audio_session_mutex};
+  audio_vario_session_active = active;
 }
 
 void
@@ -52,7 +61,12 @@ ActivateAudioSession()
 void
 DeactivateAudioSession()
 {
-  if (audio_vario_session_active.load(std::memory_order_acquire)) {
+  // hold the lock across the check and the deactivation, so that the
+  // audio vario cannot start up in between and get silenced by our
+  // setActive:NO
+  const std::lock_guard lock{audio_session_mutex};
+
+  if (audio_vario_session_active) {
     // keep the session active while the audio vario's audio device is
     // open: deactivating it would also silence the audio vario, which
     // SDL would not resume on its own

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -48,13 +48,15 @@ ActivateAudioSession()
            withOptions:AVAudioSessionCategoryOptionMixWithOthers
                  error:&error];
   if (error) {
-    LogFormat("AVAudioSession setCategory error: %s", [[error localizedDescription] UTF8String]);
+    LogFmt("AVAudioSession setCategory error: {}",
+           [[error localizedDescription] UTF8String]);
     error = nil;
   }
 
   [session setActive:YES error:&error];
   if (error) {
-    LogFormat("AVAudioSession activate error: %s", [[error localizedDescription] UTF8String]);
+    LogFmt("AVAudioSession activate error: {}",
+           [[error localizedDescription] UTF8String]);
   }
 }
 
@@ -78,7 +80,8 @@ DeactivateAudioSession()
                                    withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
                                    error:&error];
   if (error) {
-    LogFormat("AVAudioSession deactivate error: %s", [[error localizedDescription] UTF8String]);
+    LogFmt("AVAudioSession deactivate error: {}",
+           [[error localizedDescription] UTF8String]);
   }
 }
 
@@ -104,7 +107,8 @@ DeinitializeAppleServices()
                                    withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
                                    error:&error];
   if (error) {
-    LogFormat("AVAudioSession deinitialize error: %s", [[error localizedDescription] UTF8String]);
+    LogFmt("AVAudioSession deinitialize error: {}",
+           [[error localizedDescription] UTF8String]);
   }
 #endif
 }

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -8,14 +8,21 @@
 #include "Services.hpp"
 #import <AVFoundation/AVFoundation.h>
 
+#include <atomic>
+
 #if TARGET_OS_IPHONE
 
-static bool audio_vario_session_active = false;
+/**
+ * Accessed from the SDL audio thread (SDLPCMPlayer), from the thread
+ * calling SoundUtil::Play() and from the AVAudioPlayer delegate
+ * callbacks, so it needs to be atomic.
+ */
+static std::atomic<bool> audio_vario_session_active{false};
 
 void
 SetAudioVarioSessionActive(bool active)
 {
-  audio_vario_session_active = active;
+  audio_vario_session_active.store(active, std::memory_order_release);
 }
 
 void
@@ -45,7 +52,7 @@ ActivateAudioSession()
 void
 DeactivateAudioSession()
 {
-  if (audio_vario_session_active) {
+  if (audio_vario_session_active.load(std::memory_order_acquire)) {
     // keep the session active while the audio vario's audio device is
     // open: deactivating it would also silence the audio vario, which
     // SDL would not resume on its own

--- a/src/Apple/Services.hpp
+++ b/src/Apple/Services.hpp
@@ -5,3 +5,42 @@
 
 void InitializeAppleServices();
 void DeinitializeAppleServices();
+
+#ifdef __APPLE__
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+
+/**
+ * (Re-)applies XCSoar's preferred AVAudioSession category and options
+ * (Playback, MixWithOthers) and activates the session, so that XCSoar's
+ * own audio never ducks or interrupts other apps' audio.
+ *
+ * This must be called again whenever something else (e.g. SDL's
+ * CoreAudio backend, when it (re-)opens the audio device for the audio
+ * vario) may have reset the session's category or options.
+ */
+void ActivateAudioSession();
+
+/**
+ * Deactivates the shared AVAudioSession, notifying other apps so that
+ * any audio they had ducked while ours was playing is restored.
+ *
+ * Does nothing while the audio vario's audio device is marked active
+ * (see SetAudioVarioSessionActive()), because deactivating the session
+ * would also silence the audio vario, which SDL would not resume on its
+ * own.
+ */
+void DeactivateAudioSession();
+
+/**
+ * Tells the shared AVAudioSession helpers whether the audio vario's
+ * audio device is currently open, so DeactivateAudioSession() knows
+ * whether it is safe to deactivate the session after a one-shot sound
+ * has finished playing.
+ */
+void SetAudioVarioSessionActive(bool active);
+
+#endif
+#endif

--- a/src/Apple/SoundUtil.cpp
+++ b/src/Apple/SoundUtil.cpp
@@ -15,7 +15,44 @@
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IPHONE
+
+/**
+ * Deactivates the AVAudioSession once playback has finished, notifying
+ * other apps so that any audio they had ducked or paused while our sound
+ * was playing is restored. Without this, the session stays active
+ * indefinitely and other apps' audio remains ducked forever.
+ */
+@interface XCSoarAudioPlayerDelegate : NSObject <AVAudioPlayerDelegate>
+@end
+
+static void
+DeactivateAudioSession()
+{
+  NSError *error = nil;
+  [[AVAudioSession sharedInstance] setActive:NO
+                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
+                                   error:&error];
+  if (error) {
+    LogFormat("AVAudioSession deactivate error: %s", [[error localizedDescription] UTF8String]);
+  }
+}
+
+@implementation XCSoarAudioPlayerDelegate
+
+- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)audioPlayer successfully:(BOOL)flag
+{
+  DeactivateAudioSession();
+}
+
+- (void)audioPlayerDecodeErrorDidOccur:(AVAudioPlayer *)audioPlayer error:(NSError *)error
+{
+  DeactivateAudioSession();
+}
+
+@end
+
 static AVAudioPlayer *player = nil;
+static XCSoarAudioPlayerDelegate *player_delegate = nil;
 #endif
 
 bool
@@ -63,8 +100,25 @@ SoundUtil::Play(const char *resource_name)
     return false;
   }
 
-  [player prepareToPlay];
-  [player play];
+  // Activate the audio session for the duration of the playback. It is
+  // deactivated again by the player delegate once playback has finished,
+  // so that other apps' audio (e.g. music) is never ducked permanently.
+  NSError *activate_error = nil;
+  [[AVAudioSession sharedInstance] setActive:YES error:&activate_error];
+  if (activate_error) {
+    LogFormat("AVAudioSession activate error: %s", [[activate_error localizedDescription] UTF8String]);
+  }
+
+  if (!player_delegate) {
+    player_delegate = [[XCSoarAudioPlayerDelegate alloc] init];
+  }
+  player.delegate = player_delegate;
+
+  if (![player prepareToPlay] || ![player play]) {
+    LogFormat("Failed to start playback for %s (%s)", resource_name, filename);
+    DeactivateAudioSession();
+    return false;
+  }
 
   return true;
 #else

--- a/src/Apple/SoundUtil.cpp
+++ b/src/Apple/SoundUtil.cpp
@@ -5,6 +5,7 @@
 // Currently for iOS only, not macOS (AVAudioSession is iOS only)
 
 #include "SoundUtil.hpp"
+#include "Services.hpp"
 #include "LogFile.hpp"
 
 #include <TargetConditionals.h>
@@ -21,21 +22,12 @@
  * other apps so that any audio they had ducked or paused while our sound
  * was playing is restored. Without this, the session stays active
  * indefinitely and other apps' audio remains ducked forever.
+ *
+ * (DeactivateAudioSession() skips the deactivation while the audio
+ * vario is active, so it keeps playing.)
  */
 @interface XCSoarAudioPlayerDelegate : NSObject <AVAudioPlayerDelegate>
 @end
-
-static void
-DeactivateAudioSession()
-{
-  NSError *error = nil;
-  [[AVAudioSession sharedInstance] setActive:NO
-                                   withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation
-                                   error:&error];
-  if (error) {
-    LogFormat("AVAudioSession deactivate error: %s", [[error localizedDescription] UTF8String]);
-  }
-}
 
 @implementation XCSoarAudioPlayerDelegate
 
@@ -103,11 +95,7 @@ SoundUtil::Play(const char *resource_name)
   // Activate the audio session for the duration of the playback. It is
   // deactivated again by the player delegate once playback has finished,
   // so that other apps' audio (e.g. music) is never ducked permanently.
-  NSError *activate_error = nil;
-  [[AVAudioSession sharedInstance] setActive:YES error:&activate_error];
-  if (activate_error) {
-    LogFormat("AVAudioSession activate error: %s", [[activate_error localizedDescription] UTF8String]);
-  }
+  ActivateAudioSession();
 
   if (!player_delegate) {
     player_delegate = [[XCSoarAudioPlayerDelegate alloc] init];

--- a/src/Apple/SoundUtil.cpp
+++ b/src/Apple/SoundUtil.cpp
@@ -67,7 +67,7 @@ SoundUtil::Play(const char *resource_name)
   } else if (strcmp(resource_name, "IDR_WAV_DRIP") == 0) {
     filename = "beep_drip";
   } else {
-    LogFormat("Unknown sound resource: %s", resource_name);
+    LogFmt("Unknown sound resource: {}", resource_name);
     return false;
   }
   
@@ -84,10 +84,12 @@ SoundUtil::Play(const char *resource_name)
 
   if (!player) {
     if (error) {
-      LogFormat("Failed to create AVAudioPlayer for %s (%s): %s", resource_name, filename,
-                [[error localizedDescription] UTF8String]);
+      LogFmt("Failed to create AVAudioPlayer for {} ({}): {}",
+             resource_name, filename,
+             [[error localizedDescription] UTF8String]);
     } else {
-      LogFormat("Failed to create AVAudioPlayer for %s (%s): unknown reason", resource_name, filename);
+      LogFmt("Failed to create AVAudioPlayer for {} ({}): unknown reason",
+             resource_name, filename);
     }
     return false;
   }
@@ -103,7 +105,8 @@ SoundUtil::Play(const char *resource_name)
   player.delegate = player_delegate;
 
   if (![player prepareToPlay] || ![player play]) {
-    LogFormat("Failed to start playback for %s (%s)", resource_name, filename);
+    LogFmt("Failed to start playback for {} ({})", resource_name,
+           filename);
     DeactivateAudioSession();
     return false;
   }

--- a/src/Audio/SDLPCMPlayer.cpp
+++ b/src/Audio/SDLPCMPlayer.cpp
@@ -10,6 +10,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
+#include "Apple/Services.hpp"
 #endif
 
 #include <cassert>
@@ -84,6 +85,16 @@ SDLPCMPlayer::Start(PCMDataSource &_source)
   source = &_source;
   SDL_PauseAudioDevice(device, 0);
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  // SDL's CoreAudio backend may reset the AVAudioSession category and
+  // options when (re-)opening the audio device, so re-apply XCSoar's
+  // preferred configuration and mark the audio vario as active so that
+  // one-shot sound effects don't deactivate the shared AVAudioSession
+  // (which would also silence the audio vario).
+  ActivateAudioSession();
+  SetAudioVarioSessionActive(true);
+#endif
+
   return true;
 }
 
@@ -96,6 +107,10 @@ SDLPCMPlayer::Stop()
   device = -1;
   source = nullptr;
   convert_buffer.clear();
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  SetAudioVarioSessionActive(false);
+#endif
 }
 
 inline void

--- a/src/Audio/SDLPCMPlayer.cpp
+++ b/src/Audio/SDLPCMPlayer.cpp
@@ -83,7 +83,6 @@ SDLPCMPlayer::Start(PCMDataSource &_source)
     convert_buffer.resize(actual.samples * channels);
 
   source = &_source;
-  SDL_PauseAudioDevice(device, 0);
 
 #if defined(__APPLE__) && TARGET_OS_IPHONE
   // SDL's CoreAudio backend may reset the AVAudioSession category and
@@ -91,10 +90,15 @@ SDLPCMPlayer::Start(PCMDataSource &_source)
   // preferred configuration and mark the audio vario as active so that
   // one-shot sound effects don't deactivate the shared AVAudioSession
   // (which would also silence the audio vario).
+  //
+  // Both must happen before the device is unpaused: otherwise a one-shot
+  // sound finishing in that window would deactivate the session while the
+  // audio vario is already playing, and SDL would not resume on its own.
   SetAudioVarioSessionActive(true);
   ActivateAudioSession();
-  SDL_PauseAudioDevice(device, 0);
 #endif
+
+  SDL_PauseAudioDevice(device, 0);
 
   return true;
 }

--- a/src/Audio/SDLPCMPlayer.cpp
+++ b/src/Audio/SDLPCMPlayer.cpp
@@ -10,6 +10,7 @@
 
 #if defined(__APPLE__)
 #include <TargetConditionals.h>
+#include "Apple/Services.hpp"
 #endif
 
 #include <cassert>
@@ -84,6 +85,17 @@ SDLPCMPlayer::Start(PCMDataSource &_source)
   source = &_source;
   SDL_PauseAudioDevice(device, 0);
 
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  // SDL's CoreAudio backend may reset the AVAudioSession category and
+  // options when (re-)opening the audio device, so re-apply XCSoar's
+  // preferred configuration and mark the audio vario as active so that
+  // one-shot sound effects don't deactivate the shared AVAudioSession
+  // (which would also silence the audio vario).
+  SetAudioVarioSessionActive(true);
+  ActivateAudioSession();
+  SDL_PauseAudioDevice(device, 0);
+#endif
+
   return true;
 }
 
@@ -96,6 +108,10 @@ SDLPCMPlayer::Stop()
   device = -1;
   source = nullptr;
   convert_buffer.clear();
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+  SetAudioVarioSessionActive(false);
+#endif
 }
 
 inline void

--- a/src/Audio/SDLPCMPlayer.cpp
+++ b/src/Audio/SDLPCMPlayer.cpp
@@ -33,8 +33,10 @@ SDLPCMPlayer::Start(PCMDataSource &_source)
       source = &_source;
       SDL_PauseAudioDevice(device, 0);
       SDL_UnlockAudioDevice(device);
+      return true;
     }
 
+    /* the sample rate has changed, so the device needs to be reopened */
     Stop();
   }
 


### PR DESCRIPTION
@yorickreum Can you confirm that this also works for you?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * iOS: Fixed audio handling so other apps’ audio is no longer left muted or ducked after playback.
  * iOS: Audio sessions now deactivate correctly when playback finishes or fails, restoring system audio.
  * iOS: Audio session settings are reapplied when reopening an audio-vario device, improving playback reliability.
  * iOS: Audio-vario playback no longer unnecessarily closes and reopens an already correctly configured audio device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->