### PR TITLE
OpenGL: Add runtime e-ink display profile (mockup)

### DIFF
--- a/build/screen.mk
+++ b/build/screen.mk
@@ -87,7 +87,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/android/Font.cpp
 endif
 
-ifeq ($(DITHER),y)
+ifeq ($(call bool_or,$(DITHER),$(OPENGL)),y)
 SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/memory/Dither.cpp
 endif
@@ -141,6 +141,7 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/opengl/UncompressedImage.cpp \
 	$(CANVAS_SRC_DIR)/opengl/Buffer.cpp \
 	$(CANVAS_SRC_DIR)/opengl/Shaders.cpp \
+	$(CANVAS_SRC_DIR)/opengl/DitherPass.cpp \
 	$(CANVAS_SRC_DIR)/opengl/CanvasRotateShift.cpp \
 	$(CANVAS_SRC_DIR)/opengl/Triangulate.cpp
 endif

--- a/src/Asset.cpp
+++ b/src/Asset.cpp
@@ -4,6 +4,10 @@
 #include "Asset.hpp"
 #include "CommandLine.hpp"
 
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/DitherPass.hpp"
+#endif
+
 #if defined(USE_CONSOLE) || defined(USE_WAYLAND)
 #include "ui/event/Globals.hpp"
 #include "ui/event/Queue.hpp"
@@ -40,3 +44,54 @@ HasKeyboard() noexcept
 }
 
 #endif /* USE_LIBINPUT || USE_WAYLAND */
+
+bool
+UseGreyscaleDisplay() noexcept
+{
+#if defined(GREYSCALE)
+  return true;
+#elif defined(ENABLE_OPENGL)
+  return OpenGL::enable_dither_pass;
+#else
+  return false;
+#endif
+}
+
+bool
+HasColors() noexcept
+{
+#if defined(GREYSCALE)
+  return false;
+#elif defined(ENABLE_OPENGL)
+  if (OpenGL::enable_dither_pass)
+    return false;
+  return !IsKobo();
+#else
+  return !IsKobo();
+#endif
+}
+
+bool
+IsDithered() noexcept
+{
+#ifdef DITHER
+  return true;
+#elif defined(ENABLE_OPENGL)
+  return OpenGL::enable_dither_pass;
+#else
+  return false;
+#endif
+}
+
+bool
+HasEPaper() noexcept
+{
+  if (IsKobo())
+    return true;
+
+#ifdef ENABLE_OPENGL
+  return OpenGL::enable_dither_pass;
+#else
+  return false;
+#endif
+}

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -216,28 +216,17 @@ HasCursorKeys() noexcept
 /**
  * Does this device have a display with colors?
  */
-static constexpr bool
-HasColors() noexcept
-{
-#if defined(GREYSCALE)
-  return false;
-#else
-  return !IsKobo();
-#endif
-}
+bool HasColors() noexcept;
 
 /**
  * Is dithering black&white used on the display?
  */
-static constexpr bool
-IsDithered() noexcept
-{
-#ifdef DITHER
-  return true;
-#else
-  return false;
-#endif
-}
+bool IsDithered() noexcept;
+
+/**
+ * Does this device use greyscale luminosity for color adjustments?
+ */
+bool UseGreyscaleDisplay() noexcept;
 
 /**
  * Does this device have an electronic paper screen, such as E-Ink?
@@ -245,8 +234,4 @@ IsDithered() noexcept
  * and show ghosting.  Animations shall be disabled when this function
  * returns true.
  */
-static constexpr bool
-HasEPaper() noexcept
-{
-  return IsKobo();
-}
+bool HasEPaper() noexcept;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -34,6 +34,9 @@ enum ControlIndex {
 #endif
   MapOrientation,
   DarkMode,
+#ifdef ENABLE_OPENGL
+  EInkDisplay,
+#endif
   AppInfoBoxGeom,
   InfoBoxTitleScale,
   TabDialogStyle,
@@ -190,6 +193,14 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
           (unsigned)ui_settings.dark_mode);
   SetExpertRow(DarkMode);
 
+#ifdef ENABLE_OPENGL
+  AddBoolean(_("E-ink display"),
+             _("Enable greyscale high-contrast rendering for monochrome "
+               "e-paper displays."),
+             ui_settings.display.e_ink_display);
+  SetExpertRow(EInkDisplay);
+#endif
+
   AddEnum(_("InfoBox geometry"),
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
@@ -263,6 +274,11 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
                            ui_settings.dark_mode);
+
+#ifdef ENABLE_OPENGL
+  changed |= SaveValue(EInkDisplay, ProfileKeys::EInkDisplay,
+                       ui_settings.display.e_ink_display);
+#endif
 
   bool info_box_geometry_changed = false;
 

--- a/src/DisplaySettings.cpp
+++ b/src/DisplaySettings.cpp
@@ -10,4 +10,5 @@ DisplaySettings::SetDefaults()
   cursor_size = 1;
   invert_cursor_colors = false;
   full_screen = true;
+  e_ink_display = false;
 }

--- a/src/DisplaySettings.hpp
+++ b/src/DisplaySettings.hpp
@@ -15,6 +15,7 @@ struct DisplaySettings {
   uint8_t cursor_size;
   bool invert_cursor_colors;
   bool full_screen;
+  bool e_ink_display;
 
   void SetDefaults();
 };

--- a/src/Look/GestureLook.hpp
+++ b/src/Look/GestureLook.hpp
@@ -9,7 +9,7 @@
 struct GestureLook
 {
   static constexpr Color color = COLOR_RED;
-  static constexpr Color invalid_color = LightColor(color);
+  static inline const Color invalid_color = LightColor(color);
 
   Pen pen, invalid_pen;
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -33,6 +33,9 @@
 #include "UIReceiveBlackboard.hpp"
 #include "UISettings.hpp"
 #include "Interface.hpp"
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/custom/Cache.hpp"
+#endif
 
 #include <utility>
 #include "Components.hpp"
@@ -769,6 +772,20 @@ MainWindow::ReinitialiseLook() noexcept
 
   InfoBoxManager::ScheduleRedraw();
 }
+
+#ifdef ENABLE_OPENGL
+
+void
+MainWindow::SetEInkDisplay(bool enable) noexcept
+{
+  SetEnableDither(enable);
+
+#ifdef HAVE_TEXT_CACHE
+  TextCache::Flush();
+#endif
+}
+
+#endif
 
 #ifdef ANDROID
 

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -304,6 +304,10 @@ public:
    */
   void ReinitialiseLook() noexcept;
 
+#ifdef ENABLE_OPENGL
+  void SetEInkDisplay(bool enable) noexcept;
+#endif
+
   /**
    * Suspend threads that are owned by this object.
    */

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -8,6 +8,7 @@
 namespace ProfileKeys {
 
 constexpr std::string_view FullScreen = "FullScreen";
+constexpr std::string_view EInkDisplay = "EInkDisplay";
 constexpr std::string_view UIScale = "UIScale";
 constexpr std::string_view CustomDPI = "CustomDPI";
 constexpr std::string_view DarkMode = "DarkMode";

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -27,6 +27,7 @@ Profile::Load(const ProfileMap &map, DisplaySettings &settings)
   map.Get(ProfileKeys::CursorSize, settings.cursor_size);
   map.Get(ProfileKeys::CursorColorsInverted, settings.invert_cursor_colors);
   map.Get(ProfileKeys::FullScreen, settings.full_screen);
+  map.Get(ProfileKeys::EInkDisplay, settings.e_ink_display);
 }
 
 void

--- a/src/Renderer/GeoBitmapRenderer.cpp
+++ b/src/Renderer/GeoBitmapRenderer.cpp
@@ -12,6 +12,7 @@
 #include "ui/canvas/opengl/VertexPointer.hpp"
 #include "ui/canvas/opengl/Shaders.hpp"
 #include "ui/canvas/opengl/Program.hpp"
+#include "ui/canvas/opengl/DitherPass.hpp"
 #include "ui/dim/BulkPoint.hpp"
 
 void
@@ -28,34 +29,36 @@ DrawGeoBitmap(const RawBitmap &bitmap, PixelSize bitmap_size,
     projection.GeoToScreen(bounds.GetSouthEast()),
   };
 
-  const ScopeVertexPointer vp(vertices);
-
   const GLTexture &texture = bitmap.BindAndGetTexture();
   const PixelSize allocated = texture.GetAllocatedSize();
 
   const GLfloat src_x = 0, src_y = 0, src_width = bitmap_size.width,
     src_height = bitmap_size.height;
 
-  GLfloat x0 = src_x / allocated.width;
-  GLfloat y0 = src_y / allocated.height;
-  GLfloat x1 = (src_x + src_width) / allocated.width;
-  GLfloat y1 = (src_y + src_height) / allocated.height;
-
-  const GLfloat coord[] = {
-    x0, y0,
-    x1, y0,
-    x0, y1,
-    x1, y1,
+  const GLfloat texcoord[] = {
+    src_x / allocated.width, src_y / allocated.height,
+    (src_x + src_width) / allocated.width, src_y / allocated.height,
+    src_x / allocated.width, (src_y + src_height) / allocated.height,
+    (src_x + src_width) / allocated.width, (src_y + src_height) / allocated.height,
   };
 
-  OpenGL::texture_shader->Use();
-  glEnableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
-  glVertexAttribPointer(OpenGL::Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
-                        0, coord);
+  if (OpenGL::enable_dither_pass &&
+      OpenGL::dither_algorithm != OpenGL::DitherAlgorithm::NONE)
+    OpenGL::DrawGeoBitmapWithDither(texture, bitmap_size, vertices, texcoord);
+  else {
+    const ScopeVertexPointer vp(vertices);
 
-  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    OpenGL::texture_shader->Use();
 
-  glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+    glEnableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+    glVertexAttribPointer(OpenGL::Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
+                          0, texcoord);
+
+    const_cast<GLTexture &>(texture).Bind();
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+    glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+  }
 }
 
 #endif

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -436,6 +436,10 @@ Startup(UI::Display &display)
   LogFormat("Device capabilities: HasCursorKeys()=%s",
             HasCursorKeys() ? "yes" : "no");
 #endif
+#ifdef ENABLE_OPENGL
+  main_window->SetEInkDisplay(ui_settings.display.e_ink_display);
+#endif
+
   LogFormat("Device capabilities: HasColors()=%s",
             HasColors() ? "yes" : "no");
   LogFormat("Device capabilities: HasEPaper()=%s",

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -216,9 +216,21 @@ SettingsLeave(const UISettings &old_ui_settings)
   const MapSettings &old_settings_map = old_ui_settings.map;
   const MapSettings &settings_map = ui_settings.map;
 
+#ifdef ENABLE_OPENGL
+  const bool e_ink_display_changed =
+    ui_settings.display.e_ink_display !=
+    old_ui_settings.display.e_ink_display;
+
+  if (e_ink_display_changed)
+    main_window.SetEInkDisplay(ui_settings.display.e_ink_display);
+#endif
+
   if (ui_settings.dark_mode != old_ui_settings.dark_mode ||
       ui_settings.info_boxes.use_colors != old_ui_settings.info_boxes.use_colors ||
       ui_settings.info_boxes.theme != old_ui_settings.info_boxes.theme ||
+#ifdef ENABLE_OPENGL
+      e_ink_display_changed ||
+#endif
       settings_map.trail.type != old_settings_map.trail.type ||
       settings_map.trail.scaling_enabled != old_settings_map.trail.scaling_enabled ||
       settings_map.waypoint.landable_style != old_settings_map.waypoint.landable_style)

--- a/src/ui/canvas/Color.cpp
+++ b/src/ui/canvas/Color.cpp
@@ -9,7 +9,12 @@ Desaturate(Color c) noexcept
 #ifdef GREYSCALE
   return c;
 #else
-  int a = (c.Red() + c.Green() + c.Blue()) / 3;
+  if (IsDithered() || UseGreyscaleDisplay()) {
+    const uint8_t l = Luminosity8(c.Red(), c.Green(), c.Blue()).GetLuminosity();
+    return Color(l, l, l);
+  }
+
+  const int a = (c.Red() + c.Green() + c.Blue()) / 3;
   return Color((c.Red() + a) / 2, (c.Green() + a) / 2, (c.Blue() + a) / 2);
 #endif
 }

--- a/src/ui/canvas/Color.hpp
+++ b/src/ui/canvas/Color.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include "Asset.hpp"
+#include "PortableColor.hpp"
+
 // IWYU pragma: begin_exports
 #ifdef ENABLE_OPENGL
 #include "opengl/Color.hpp"
@@ -47,12 +50,17 @@ LightColor(uint8_t c) noexcept
  * Returns a lighter version of the specified color, adequate for
  * SRCAND filtering.
  */
-constexpr Color
+inline Color
 LightColor(Color c) noexcept
 {
-#ifdef GREYSCALE
+#if defined(GREYSCALE)
   return Color(LightColor(c.GetLuminosity()));
 #else
+  if (IsDithered()) {
+    const uint8_t l = Luminosity8(c.Red(), c.Green(), c.Blue()).GetLuminosity();
+    const uint8_t v = LightColor(l);
+    return Color(v, v, v);
+  }
   return Color(LightColor(c.Red()), LightColor(c.Green()),
                LightColor(c.Blue()));
 #endif
@@ -67,12 +75,17 @@ DarkColor(uint8_t c) noexcept
 /**
  * Returns a darker version of the specified color.
  */
-constexpr Color
+inline Color
 DarkColor(Color c) noexcept
 {
-#ifdef GREYSCALE
+#if defined(GREYSCALE)
   return Color(DarkColor(c.GetLuminosity()));
 #else
+  if (IsDithered()) {
+    const uint8_t l = Luminosity8(c.Red(), c.Green(), c.Blue()).GetLuminosity();
+    const uint8_t v = DarkColor(l);
+    return Color(v, v, v);
+  }
   return Color(DarkColor(c.Red()), DarkColor(c.Green()),
                DarkColor(c.Blue()));
 #endif

--- a/src/ui/canvas/Luminosity.hpp
+++ b/src/ui/canvas/Luminosity.hpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "PortableColor.hpp"
+
+/**
+ * Perceived luminosity helpers shared by all canvas backends.
+ * Weights match Luminosity8::FromRGB() in PortableColor.hpp and the
+ * luminosity() GLSL function in Shaders.cpp.
+ */
+namespace Luminosity {
+
+constexpr float RED = 2126.f / 10000.f;
+constexpr float GREEN = 7152.f / 10000.f;
+constexpr float BLUE = 722.f / 10000.f;
+
+[[gnu::const]] constexpr uint8_t
+FromRGB(uint8_t r, uint8_t g, uint8_t b) noexcept
+{
+  return Luminosity8(r, g, b).GetLuminosity();
+}
+
+[[gnu::const]] constexpr float
+FromNormalized(float r, float g, float b) noexcept
+{
+  return r * RED + g * GREEN + b * BLUE;
+}
+
+/**
+ * GLSL fragment shader preamble.  Keep weights in sync with FromRGB().
+ */
+#define LUMINOSITY_GLSL_PREAMBLE \
+  "const vec3 LUMINOSITY_WEIGHTS = vec3(0.2126, 0.7152, 0.0722);\n" \
+  "float luminosity(vec3 rgb) {\n" \
+  "  return dot(rgb, LUMINOSITY_WEIGHTS);\n" \
+  "}\n"
+
+} // namespace Luminosity

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -272,6 +272,10 @@ public:
   }
 #endif
 
+#ifdef ENABLE_OPENGL
+  void SetEnableDither(bool _enable_dither) noexcept;
+#endif
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
   PixelSize SetDisplayOrientation(DisplayOrientation orientation) noexcept;
 #endif

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -3,6 +3,8 @@
 
 #include "ui/canvas/custom/TopCanvas.hpp"
 #include "ui/canvas/opengl/Globals.hpp"
+#include "ui/canvas/opengl/DitherPass.hpp"
+#include "ui/canvas/Canvas.hpp"
 #include "ui/display/Display.hpp"
 #include "ui/dim/Size.hpp"
 #include "system/Error.hxx"
@@ -177,6 +179,14 @@ TopCanvas::Flip()
 
     current_bo = next_bo;
     next_bo = nullptr;
+  }
+#endif
+
+#ifdef ENABLE_OPENGL
+  if (OpenGL::enable_dither_pass) {
+    Canvas canvas = Lock();
+    if (canvas.IsDefined())
+      OpenGL::ApplyGreyscalePass(canvas);
   }
 #endif
 

--- a/src/ui/canvas/freetype/Font.cpp
+++ b/src/ui/canvas/freetype/Font.cpp
@@ -56,6 +56,11 @@ IsMono() noexcept
   /* on the Kobo, "mono" mode can be set at runtime; the shutdown
      screen renders in greyscale mode */
   return FreeType::mono;
+#elif defined(ENABLE_OPENGL)
+  /* OpenGL e-ink uses anti-aliased font textures and converts the
+     composited frame to greyscale at display time; mono rendering
+     must match the load/render flags set once in Initialise() */
+  return false;
 #else
   return IsDithered();
 #endif

--- a/src/ui/canvas/glx/TopCanvas.cpp
+++ b/src/ui/canvas/glx/TopCanvas.cpp
@@ -3,6 +3,8 @@
 
 #include "ui/canvas/custom/TopCanvas.hpp"
 #include "ui/canvas/opengl/Globals.hpp"
+#include "ui/canvas/opengl/DitherPass.hpp"
+#include "ui/canvas/Canvas.hpp"
 #include "ui/display/Display.hpp"
 #include "ui/dim/Size.hpp"
 
@@ -47,5 +49,13 @@ TopCanvas::GetNativeSize() const noexcept
 void
 TopCanvas::Flip()
 {
+#ifdef ENABLE_OPENGL
+  if (OpenGL::enable_dither_pass) {
+    Canvas canvas = Lock();
+    if (canvas.IsDefined())
+      OpenGL::ApplyGreyscalePass(canvas);
+  }
+#endif
+
   glXSwapBuffers(display.GetXDisplay(), glx_window);
 }

--- a/src/ui/canvas/opengl/Color.hpp
+++ b/src/ui/canvas/opengl/Color.hpp
@@ -88,6 +88,22 @@ public:
     return Export(a);
   }
 
+  /**
+   * Returns the perceived luminosity (0-255), using the same weights as
+   * Luminosity8.
+   */
+  [[gnu::const]] constexpr uint8_t GetLuminosity() const noexcept {
+    return Luminosity8(Red(), Green(), Blue()).GetLuminosity();
+  }
+
+  /**
+   * Returns a greyscale version of this color.
+   */
+  [[gnu::const]] constexpr Color ToGreyscale() const noexcept {
+    const uint8_t l = GetLuminosity();
+    return Color(Internal{}, Import(l), Import(l), Import(l), a);
+  }
+
   constexpr Color WithAlpha(uint8_t alpha) const noexcept {
     return Color(Internal(), r, g, b, Import(alpha));
   }

--- a/src/ui/canvas/opengl/DitherPass.cpp
+++ b/src/ui/canvas/opengl/DitherPass.cpp
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DitherPass.hpp"
+#include "Shaders.hpp"
+#include "Program.hpp"
+#include "Texture.hpp"
+#include "FrameBuffer.hpp"
+#include "FBO.hpp"
+#include "Globals.hpp"
+#include "Scope.hpp"
+#include "VertexPointer.hpp"
+#include "Attribute.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Luminosity.hpp"
+#include "ui/canvas/memory/Dither.hpp"
+#include "ui/dim/BulkPoint.hpp"
+#include "ui/dim/Rect.hpp"
+#include "util/AllocatedArray.hxx"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+
+namespace OpenGL {
+
+bool enable_dither_pass = false;
+
+DitherAlgorithm dither_algorithm = DitherAlgorithm::SIERRA_LITE;
+
+DitherPassSettings dither_pass_settings;
+
+static Dither sierra_lite_dither;
+
+static std::unique_ptr<GLTexture> capture_texture;
+
+static std::unique_ptr<GLFrameBuffer> terrain_fbo;
+static std::unique_ptr<GLTexture> terrain_render_texture;
+static std::unique_ptr<GLTexture> terrain_result_texture;
+static PixelSize terrain_fbo_size;
+
+static void
+EnsureCaptureTexture(PixelSize size)
+{
+  if (capture_texture == nullptr ||
+      capture_texture->GetSize() != size)
+    capture_texture.reset(new GLTexture(GL_RGB, size, GL_RGB,
+                                        GL_UNSIGNED_BYTE, true));
+}
+
+static void
+EnsureTerrainFBO(PixelSize size)
+{
+  if (terrain_fbo != nullptr && terrain_fbo_size == size)
+    return;
+
+  GLint saved_framebuffer = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &saved_framebuffer);
+
+  terrain_fbo_size = size;
+  terrain_render_texture.reset(new GLTexture(GL_RGB, size, GL_RGB,
+                                             GL_UNSIGNED_BYTE, false));
+  terrain_result_texture.reset(new GLTexture(GL_RGB, size, GL_RGB,
+                                             GL_UNSIGNED_BYTE, false));
+  terrain_fbo = std::make_unique<GLFrameBuffer>();
+  terrain_fbo->Bind();
+  terrain_render_texture->AttachFramebuffer(FBO::COLOR_ATTACHMENT0);
+
+  FBO::BindFramebuffer(FBO::FRAMEBUFFER, GLuint(saved_framebuffer));
+}
+
+static void
+DrawTexturedQuad(const BulkPixelPoint (&vertices)[4],
+                 const GLfloat *texcoord, GLProgram &shader) noexcept
+{
+  const ScopeVertexPointer vp(vertices);
+
+  shader.Use();
+  glEnableVertexAttribArray(Attribute::TEXCOORD);
+  glVertexAttribPointer(Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
+                        0, texcoord);
+  glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  glDisableVertexAttribArray(Attribute::TEXCOORD);
+}
+
+static void
+FlipRowsVertically(uint8_t *data, unsigned width, unsigned height) noexcept
+{
+  const unsigned row_bytes = width * 3;
+  static AllocatedArray<uint8_t> temp_row;
+  temp_row.GrowDiscard(row_bytes);
+
+  for (unsigned y = 0; y < height / 2; ++y) {
+    uint8_t *row_a = data + y * row_bytes;
+    uint8_t *row_b = data + (height - 1 - y) * row_bytes;
+    std::memcpy(temp_row.data(), row_a, row_bytes);
+    std::memcpy(row_a, row_b, row_bytes);
+    std::memcpy(row_b, temp_row.data(), row_bytes);
+  }
+}
+
+static void
+BuildViewportTexcoords(const BulkPixelPoint (&vertices)[4],
+                       const PixelSize &allocated,
+                       GLfloat result[8]) noexcept
+{
+  for (unsigned i = 0; i < 4; ++i) {
+    result[i * 2] = GLfloat(int(vertices[i].x)) / GLfloat(allocated.width);
+    result[i * 2 + 1] =
+      GLfloat(int(vertices[i].y)) / GLfloat(allocated.height);
+  }
+}
+
+void
+ApplyDitherUniforms() noexcept
+{
+  dither_shader->Use();
+  glUniform1f(dither_snap_high, dither_pass_settings.snap_high);
+  glUniform1f(dither_snap_low, dither_pass_settings.snap_low);
+  glUniform1f(dither_gamma, dither_pass_settings.gamma);
+}
+
+static void
+DrawGeoBitmapBayer(const GLTexture &texture,
+                   const BulkPixelPoint (&vertices)[4],
+                   const GLfloat *texcoord) noexcept
+{
+  ApplyDitherUniforms();
+  const_cast<GLTexture &>(texture).Bind();
+  DrawTexturedQuad(vertices, texcoord, *dither_shader);
+}
+
+static void
+DrawGeoBitmapSierraLite(const GLTexture &texture,
+                        const BulkPixelPoint (&vertices)[4],
+                        const GLfloat *texcoord) noexcept
+{
+  GLint saved_framebuffer = 0;
+  glGetIntegerv(GL_FRAMEBUFFER_BINDING, &saved_framebuffer);
+
+  GLint saved_viewport[4];
+  glGetIntegerv(GL_VIEWPORT, saved_viewport);
+  const unsigned viewport_width = unsigned(saved_viewport[2]);
+  const unsigned viewport_height = unsigned(saved_viewport[3]);
+  if (viewport_width == 0 || viewport_height == 0)
+    return;
+
+  const PixelSize viewport_size{viewport_width, viewport_height};
+  EnsureTerrainFBO(viewport_size);
+
+  terrain_fbo->Bind();
+  glViewport(0, 0, viewport_width, viewport_height);
+
+  glClearColor(1.f, 1.f, 1.f, 1.f);
+  glClear(GL_COLOR_BUFFER_BIT);
+
+  const_cast<GLTexture &>(texture).Bind();
+  DrawTexturedQuad(vertices, texcoord, *luminosity_shader);
+
+  const unsigned n_pixels = viewport_width * viewport_height;
+  static AllocatedArray<uint8_t> rgb_buffer;
+  static AllocatedArray<uint8_t> grey_buffer;
+  static AllocatedArray<uint8_t> output_buffer;
+  rgb_buffer.GrowDiscard(n_pixels * 3);
+  grey_buffer.GrowDiscard(n_pixels);
+  output_buffer.GrowDiscard(n_pixels);
+
+  glReadPixels(0, 0, viewport_width, viewport_height,
+               GL_RGB, GL_UNSIGNED_BYTE, rgb_buffer.data());
+
+  FlipRowsVertically(rgb_buffer.data(), viewport_width, viewport_height);
+
+  const uint8_t *src = rgb_buffer.data();
+  uint8_t *grey = grey_buffer.data();
+  for (unsigned i = 0; i < n_pixels; ++i, src += 3)
+    grey[i] = Luminosity::FromRGB(src[0], src[1], src[2]);
+
+  sierra_lite_dither.DitherGreyscale(grey, viewport_width,
+                                     output_buffer.data(), viewport_width,
+                                     viewport_width, viewport_height);
+
+  uint8_t *dest_pixels = rgb_buffer.data();
+  const uint8_t *out = output_buffer.data();
+  for (unsigned i = 0; i < n_pixels; ++i, dest_pixels += 3, ++out) {
+    const uint8_t v = *out ? 0xff : 0x00;
+    dest_pixels[0] = dest_pixels[1] = dest_pixels[2] = v;
+  }
+
+  FBO::BindFramebuffer(FBO::FRAMEBUFFER, GLuint(saved_framebuffer));
+  glViewport(saved_viewport[0], saved_viewport[1],
+             saved_viewport[2], saved_viewport[3]);
+
+  terrain_result_texture->Bind();
+  glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+                 viewport_width, viewport_height,
+                 GL_RGB, GL_UNSIGNED_BYTE, rgb_buffer.data());
+
+  GLfloat result_texcoord[8];
+  BuildViewportTexcoords(vertices,
+                         terrain_result_texture->GetAllocatedSize(),
+                         result_texcoord);
+  const_cast<GLTexture &>(*terrain_result_texture).Bind();
+  DrawTexturedQuad(vertices, result_texcoord, *texture_shader);
+}
+
+void
+DrawGeoBitmapWithDither(const GLTexture &texture, [[maybe_unused]] PixelSize bitmap_size,
+                        const BulkPixelPoint (&vertices)[4],
+                        const GLfloat *texcoord)
+{
+  switch (dither_algorithm) {
+  case DitherAlgorithm::NONE:
+    const_cast<GLTexture &>(texture).Bind();
+    DrawTexturedQuad(vertices, texcoord, *luminosity_shader);
+    break;
+
+  case DitherAlgorithm::BAYER:
+    DrawGeoBitmapBayer(texture, vertices, texcoord);
+    break;
+
+  case DitherAlgorithm::SIERRA_LITE:
+    DrawGeoBitmapSierraLite(texture, vertices, texcoord);
+    break;
+  }
+}
+
+void
+ApplyGreyscalePass(Canvas &canvas)
+{
+  if (!enable_dither_pass)
+    return;
+
+  GLint viewport[4];
+  glGetIntegerv(GL_VIEWPORT, viewport);
+  const PixelSize size{unsigned(viewport[2]), unsigned(viewport[3])};
+  if (size.width == 0 || size.height == 0)
+    return;
+
+  GLFrameBuffer::Unbind();
+  EnsureCaptureTexture(size);
+
+  capture_texture->Bind();
+  glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0,
+                      size.width, size.height);
+
+  canvas.ClearWhite();
+
+  luminosity_shader->Use();
+  capture_texture->Bind();
+  capture_texture->Draw(canvas.GetRect(), capture_texture->GetRect());
+}
+
+} // namespace OpenGL

--- a/src/ui/canvas/opengl/DitherPass.hpp
+++ b/src/ui/canvas/opengl/DitherPass.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/dim/Size.hpp"
+#include "ui/opengl/System.hpp"
+
+struct BulkPixelPoint;
+class Canvas;
+class GLTexture;
+
+namespace OpenGL {
+
+/**
+ * Master switch for the OpenGL e-ink display profile.  When enabled:
+ * - #HasColors() and #UseGreyscaleDisplay() are false/true
+ * - #IsDithered() and #HasEPaper() are true
+ * - Terrain is dithered at draw time (#DrawGeoBitmapWithDither())
+ * - #ApplyGreyscalePass() converts the full frame to greyscale without dither
+ */
+extern bool enable_dither_pass;
+
+enum class DitherAlgorithm {
+  /** Greyscale only on terrain, no dither pattern. */
+  NONE,
+  BAYER,
+  SIERRA_LITE,
+  ERROR_DIFFUSION = SIERRA_LITE,
+};
+
+extern DitherAlgorithm dither_algorithm;
+
+struct DitherPassSettings {
+  float snap_high = 0.93f;
+  float snap_low = 0.07f;
+  float gamma = 0.88f;
+};
+
+extern DitherPassSettings dither_pass_settings;
+
+void ApplyDitherUniforms() noexcept;
+
+/**
+ * Draw a geo-referenced terrain bitmap with dither at screen resolution.
+ */
+void DrawGeoBitmapWithDither(const GLTexture &texture, PixelSize bitmap_size,
+                             const BulkPixelPoint (&vertices)[4],
+                             const GLfloat texcoord[8]);
+
+/**
+ * Capture the default framebuffer and redraw it in greyscale (no dither).
+ * Call from TopCanvas::Flip() before eglSwapBuffers().
+ */
+void ApplyGreyscalePass(Canvas &canvas);
+
+} // namespace OpenGL

--- a/src/ui/canvas/opengl/Shaders.cpp
+++ b/src/ui/canvas/opengl/Shaders.cpp
@@ -5,6 +5,7 @@
 #include "Program.hpp"
 #include "Attribute.hpp"
 #include "Globals.hpp"
+#include "ui/canvas/Luminosity.hpp"
 #include "ui/dim/Point.hpp"
 #include "lib/fmt/RuntimeError.hxx"
 
@@ -17,6 +18,13 @@ GLint solid_projection, solid_modelview, solid_translate;
 
 GLProgram *texture_shader;
 GLint texture_projection, texture_texture, texture_translate;
+
+GLProgram *luminosity_shader;
+GLint luminosity_projection, luminosity_texture, luminosity_translate;
+
+GLProgram *dither_shader;
+GLint dither_projection, dither_texture, dither_translate,
+  dither_snap_high, dither_snap_low, dither_gamma;
 
 GLProgram *invert_shader;
 GLint invert_projection, invert_texture, invert_translate;
@@ -127,6 +135,78 @@ static constexpr char alpha_fragment_shader[] =
     varying vec2 texcoordvar;
     void main() {
       gl_FragColor = vec4(colorvar.rgb, texture2D(texture, texcoordvar).a);
+    }
+)glsl";
+
+static const char *const luminosity_vertex_shader = texture_vertex_shader;
+static constexpr char luminosity_fragment_shader[] =
+  GLSL_VERSION
+  GLSL_PRECISION
+  LUMINOSITY_GLSL_PREAMBLE
+  R"glsl(
+    uniform sampler2D texture;
+    varying vec2 texcoordvar;
+
+    void main() {
+      vec4 color = texture2D(texture, texcoordvar);
+      float l = luminosity(color.rgb);
+      gl_FragColor = vec4(l, l, l, color.a);
+    }
+)glsl";
+
+static const char *const dither_vertex_shader = texture_vertex_shader;
+static constexpr char dither_fragment_shader[] =
+  GLSL_VERSION
+  GLSL_PRECISION
+  LUMINOSITY_GLSL_PREAMBLE
+  R"glsl(
+    uniform sampler2D texture;
+    uniform float snap_high;
+    uniform float snap_low;
+    uniform float gamma;
+    varying vec2 texcoordvar;
+
+    float bayer4(vec2 coord) {
+      float x = mod(floor(coord.x), 4.0);
+      float y = mod(floor(coord.y), 4.0);
+      if (y < 0.5) {
+        if (x < 0.5) return 0.0/16.0;
+        if (x < 1.5) return 8.0/16.0;
+        if (x < 2.5) return 2.0/16.0;
+        return 10.0/16.0;
+      }
+      if (y < 1.5) {
+        if (x < 0.5) return 12.0/16.0;
+        if (x < 1.5) return 4.0/16.0;
+        if (x < 2.5) return 14.0/16.0;
+        return 6.0/16.0;
+      }
+      if (y < 2.5) {
+        if (x < 0.5) return 3.0/16.0;
+        if (x < 1.5) return 11.0/16.0;
+        if (x < 2.5) return 1.0/16.0;
+        return 9.0/16.0;
+      }
+      if (x < 0.5) return 15.0/16.0;
+      if (x < 1.5) return 7.0/16.0;
+      if (x < 2.5) return 13.0/16.0;
+      return 5.0/16.0;
+    }
+
+    void main() {
+      vec4 color = texture2D(texture, texcoordvar);
+      float l = pow(luminosity(color.rgb), gamma);
+      if (l >= snap_high) {
+        gl_FragColor = vec4(1.0, 1.0, 1.0, color.a);
+        return;
+      }
+      if (l <= snap_low) {
+        gl_FragColor = vec4(0.0, 0.0, 0.0, color.a);
+        return;
+      }
+      float threshold = bayer4(gl_FragCoord.xy);
+      float v = l > threshold ? 1.0 : 0.0;
+      gl_FragColor = vec4(v, v, v, color.a);
     }
 )glsl";
 
@@ -307,6 +387,36 @@ OpenGL::InitShaders()
   texture_shader->Use();
   glUniform1i(texture_texture, 0);
 
+  luminosity_shader = CompileProgram(luminosity_vertex_shader,
+                                     luminosity_fragment_shader);
+  luminosity_shader->BindAttribLocation(Attribute::POSITION, "position");
+  luminosity_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
+  LinkProgram(*luminosity_shader);
+
+  luminosity_projection =
+    luminosity_shader->GetUniformLocation("projection");
+  luminosity_texture = luminosity_shader->GetUniformLocation("texture");
+  luminosity_translate =
+    luminosity_shader->GetUniformLocation("translate");
+
+  luminosity_shader->Use();
+  glUniform1i(luminosity_texture, 0);
+
+  dither_shader = CompileProgram(dither_vertex_shader, dither_fragment_shader);
+  dither_shader->BindAttribLocation(Attribute::POSITION, "position");
+  dither_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
+  LinkProgram(*dither_shader);
+
+  dither_projection = dither_shader->GetUniformLocation("projection");
+  dither_texture = dither_shader->GetUniformLocation("texture");
+  dither_translate = dither_shader->GetUniformLocation("translate");
+  dither_snap_high = dither_shader->GetUniformLocation("snap_high");
+  dither_snap_low = dither_shader->GetUniformLocation("snap_low");
+  dither_gamma = dither_shader->GetUniformLocation("gamma");
+
+  dither_shader->Use();
+  glUniform1i(dither_texture, 0);
+
   invert_shader = CompileProgram(invert_vertex_shader, invert_fragment_shader);
   invert_shader->BindAttribLocation(Attribute::POSITION, "position");
   invert_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
@@ -400,6 +510,10 @@ OpenGL::DeinitShaders() noexcept
   alpha_shader = nullptr;
   delete invert_shader;
   invert_shader = nullptr;
+  delete dither_shader;
+  dither_shader = nullptr;
+  delete luminosity_shader;
+  luminosity_shader = nullptr;
   delete texture_shader;
   texture_shader = nullptr;
   delete solid_shader;
@@ -419,6 +533,14 @@ OpenGL::UpdateShaderProjectionMatrix() noexcept
 
   texture_shader->Use();
   glUniformMatrix4fv(texture_projection, 1, GL_FALSE,
+                     glm::value_ptr(projection_matrix));
+
+  luminosity_shader->Use();
+  glUniformMatrix4fv(luminosity_projection, 1, GL_FALSE,
+                     glm::value_ptr(projection_matrix));
+
+  dither_shader->Use();
+  glUniformMatrix4fv(dither_projection, 1, GL_FALSE,
                      glm::value_ptr(projection_matrix));
 
   solid_shader->Use();
@@ -453,6 +575,12 @@ OpenGL::UpdateShaderTranslate() noexcept
 
   texture_shader->Use();
   glUniform2f(texture_translate, t.x, t.y);
+
+  luminosity_shader->Use();
+  glUniform2f(luminosity_translate, t.x, t.y);
+
+  dither_shader->Use();
+  glUniform2f(dither_translate, t.x, t.y);
 
   invert_shader->Use();
   glUniform2f(invert_translate, t.x, t.y);

--- a/src/ui/canvas/opengl/Shaders.hpp
+++ b/src/ui/canvas/opengl/Shaders.hpp
@@ -19,7 +19,20 @@ extern GLint solid_projection, solid_modelview, solid_translate;
  * A shader that copies the texture.
  */
 extern GLProgram *texture_shader;
-extern GLint texture_projection, texture_texture, solid_translate;
+extern GLint texture_projection, texture_texture, texture_translate;
+
+/**
+ * A shader that converts a texture to greyscale using Luminosity weights.
+ */
+extern GLProgram *luminosity_shader;
+extern GLint luminosity_projection, luminosity_texture, luminosity_translate;
+
+/**
+ * A shader that applies 4x4 Bayer ordered dither to a greyscale texture.
+ */
+extern GLProgram *dither_shader;
+extern GLint dither_projection, dither_texture, dither_translate,
+  dither_snap_high, dither_snap_low, dither_gamma;
 
 /**
  * A shader that copies the inverted texture.

--- a/src/ui/canvas/opengl/TopCanvas.cpp
+++ b/src/ui/canvas/opengl/TopCanvas.cpp
@@ -6,6 +6,7 @@
 #include "Globals.hpp"
 #include "Init.hpp"
 #include "Math/Point2D.hpp"
+#include "DitherPass.hpp"
 
 PixelSize
 TopCanvas::GetSize() const noexcept
@@ -78,4 +79,10 @@ TopCanvas::Lock()
 void
 TopCanvas::Unlock() noexcept
 {
+}
+
+void
+TopCanvas::SetEnableDither(bool _enable_dither) noexcept
+{
+  OpenGL::enable_dither_pass = _enable_dither;
 }

--- a/src/ui/canvas/sdl/TopCanvas.cpp
+++ b/src/ui/canvas/sdl/TopCanvas.cpp
@@ -8,8 +8,10 @@
 #include "Asset.hpp"
 
 #ifdef ENABLE_OPENGL
+#include "ui/canvas/Canvas.hpp"
 #include "ui/dim/Rect.hpp"
 #include "ui/canvas/opengl/Init.hpp"
+#include "ui/canvas/opengl/DitherPass.hpp"
 #include "Math/Point2D.hpp"
 #include "LogFile.hpp"
 #else
@@ -308,6 +310,12 @@ void
 TopCanvas::Flip()
 {
 #ifdef ENABLE_OPENGL
+  if (OpenGL::enable_dither_pass) {
+    Canvas canvas = Lock();
+    if (canvas.IsDefined())
+      OpenGL::ApplyGreyscalePass(canvas);
+  }
+
   ::SDL_GL_SwapWindow(window);
 #else
 

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -453,6 +453,10 @@ public:
   void SetDisplayOrientation(DisplayOrientation orientation) noexcept;
 #endif
 
+#ifdef ENABLE_OPENGL
+  void SetEnableDither(bool enable) noexcept;
+#endif
+
 #ifdef DRAW_MOUSE_CURSOR
   void SetCursorSize(const uint8_t &cursorSize) noexcept {
     cursor_size = cursorSize;

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -100,6 +100,17 @@ TopWindow::Create([[maybe_unused]] const char *text, PixelSize size,
   ContainerWindow::Create(nullptr, PixelRect{size}, style);
 }
 
+#ifdef ENABLE_OPENGL
+
+void
+TopWindow::SetEnableDither(bool enable) noexcept
+{
+  if (screen != nullptr)
+    screen->SetEnableDither(enable);
+}
+
+#endif
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
 
 void

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -30,3 +30,39 @@ HasKeyboard() noexcept
 }
 
 #endif
+
+bool
+UseGreyscaleDisplay() noexcept
+{
+#if defined(GREYSCALE)
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool
+HasColors() noexcept
+{
+#if defined(GREYSCALE)
+  return false;
+#else
+  return !IsKobo();
+#endif
+}
+
+bool
+IsDithered() noexcept
+{
+#ifdef DITHER
+  return true;
+#else
+  return false;
+#endif
+}
+
+bool
+HasEPaper() noexcept
+{
+  return IsKobo();
+}


### PR DESCRIPTION
## Summary

- Add a runtime OpenGL e-ink display profile for Android e-readers and similar monochrome devices: terrain is dithered at screen resolution, the full frame is converted to greyscale at flip, and UI text stays anti-aliased.
- Expose `HasColors()`, `IsDithered()`, `HasEPaper()`, and `UseGreyscaleDisplay()` at runtime via `OpenGL::enable_dither_pass`, driven by a new **E-ink display** setting under Look → Screen Layout (persisted in the profile).
- Fix garbled fonts on OpenGL e-ink by not treating the profile as FreeType mono mode.

## Test plan

- [ ] Build `TARGET=UNIX OPENGL=y` and enable **E-ink display** in Look → Screen Layout; verify UI text is readable and terrain shows dither while infoboxes stay smooth greyscale
- [ ] Build `TARGET=ANDROID OPENGL=y`, install on an Onyx/Meebook or similar e-reader, enable the setting, and verify map alignment and contrast in fly mode
- [ ] Toggle the setting at runtime and confirm Look refreshes and text cache is cleared
- [ ] Run `make update-po TARGET=UNIX OPENGL=y` before merge to add translation entries for the new setting strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "E-ink display" preference to optimize rendering for e‑ink/paper-like screens.
  * Toggleable greyscale pass and dither pass with selectable algorithms to improve monochrome rendering.
  * Better grayscale/dithering handling across rendering and font pipelines for improved visual fidelity on compatible displays.
  * Profile/storage of e‑ink preference and sensible default (off).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->