### PR TITLE
Display/PageActions: Keep RASP overlay visible in pan mode (fixes #2629)

### DIFF
--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -69,7 +69,8 @@ void
 PageActions::ClearPageOverlays() noexcept
 {
   WeatherUIState &weather = CommonInterface::SetUIState().weather;
-  weather.map = -1;
+  if (!weather.IsRaspSuspendedForPan())
+    weather.map = -1;
 
 #ifdef HAVE_EDL
   if (!EDL::IsDedicatedPageSuspendedForPan())
@@ -134,8 +135,10 @@ PageActions::LeavePage()
     }
 #endif
   } else if (layout.overlay == PageLayout::Overlay::RASP) {
-    ClearPageOverlays();
-    CommonInterface::SetUIState().weather.rasp_page_entered = false;
+    if (!CommonInterface::GetUIState().weather.IsRaspSuspendedForPan()) {
+      ClearPageOverlays();
+      CommonInterface::SetUIState().weather.rasp_page_entered = false;
+    }
   }
 
   if (state.special_page.IsDefined())
@@ -166,8 +169,10 @@ PageActions::Restore()
     }
 #endif
   } else if (special_page.overlay == PageLayout::Overlay::RASP) {
-    ClearPageOverlays();
-    CommonInterface::SetUIState().weather.rasp_page_entered = false;
+    if (!CommonInterface::GetUIState().weather.IsRaspSuspendedForPan()) {
+      ClearPageOverlays();
+      CommonInterface::SetUIState().weather.rasp_page_entered = false;
+    }
   }
 
   special_page.SetUndefined();

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -175,6 +175,13 @@ struct PageLayout
 
   [[gnu::const]]
   constexpr bool
+  UsesRaspOverlay() const noexcept
+  {
+    return IsMapMain() && overlay == Overlay::RASP;
+  }
+
+  [[gnu::const]]
+  constexpr bool
   UsesWeatherOverlay() const noexcept
   {
     return IsMapMain() &&

--- a/src/Pan.cpp
+++ b/src/Pan.cpp
@@ -33,12 +33,19 @@ EnterPan()
     EDL::SuspendDedicatedPageForPan();
 #endif
 
+  const bool suspending_rasp_page =
+    PageActions::GetCurrentLayout().UsesRaspOverlay();
+  if (suspending_rasp_page)
+    CommonInterface::SetUIState().weather.SuspendRaspForPan();
+
   GlueMapWindow *map = PageActions::ShowOnlyMap();
   if (map == nullptr || map->IsPanning()) {
 #ifdef HAVE_EDL
     if (suspending_edl_page)
       EDL::ResumeDedicatedPageAfterPan();
 #endif
+    if (suspending_rasp_page)
+      CommonInterface::SetUIState().weather.ResumeRaspAfterPan();
     return;
   }
 
@@ -60,12 +67,19 @@ PanTo(const GeoPoint &location)
     EDL::SuspendDedicatedPageForPan();
 #endif
 
+  const bool suspending_rasp_page =
+    PageActions::GetCurrentLayout().UsesRaspOverlay();
+  if (suspending_rasp_page)
+    CommonInterface::SetUIState().weather.SuspendRaspForPan();
+
   GlueMapWindow *map = PageActions::ShowOnlyMap();
   if (map == nullptr) {
 #ifdef HAVE_EDL
     if (suspending_edl_page)
       EDL::ResumeDedicatedPageAfterPan();
 #endif
+    if (suspending_rasp_page)
+      CommonInterface::SetUIState().weather.ResumeRaspAfterPan();
     return false;
   }
 
@@ -89,6 +103,7 @@ DisablePan()
 #ifdef HAVE_EDL
   EDL::ResumeDedicatedPageAfterPan();
 #endif
+  CommonInterface::SetUIState().weather.ResumeRaspAfterPan();
 }
 
 void
@@ -105,6 +120,7 @@ LeavePan()
 #ifdef HAVE_EDL
   EDL::ResumeDedicatedPageAfterPan();
 #endif
+  CommonInterface::SetUIState().weather.ResumeRaspAfterPan();
 }
 
 void

--- a/src/Weather/WeatherUIState.hpp
+++ b/src/Weather/WeatherUIState.hpp
@@ -83,6 +83,13 @@ struct WeatherUIState {
 
   bool rasp_page_entered;
 
+  /**
+   * When true, the RASP dedicated-page overlay is preserved across a
+   * temporary pan (full-screen map) instead of being cleared.  Mirrors
+   * EDLWeatherUIState::dedicated_page_suspended_for_pan.
+   */
+  bool rasp_page_suspended_for_pan;
+
   EDLWeatherUIState edl;
 
   void Clear() noexcept {
@@ -90,6 +97,7 @@ struct WeatherUIState {
     time = BrokenTime::Invalid();
     time_auto_advance = true;
     rasp_page_entered = false;
+    rasp_page_suspended_for_pan = false;
     edl.Clear();
   }
 
@@ -113,5 +121,23 @@ struct WeatherUIState {
   void ResetRaspForDedicatedPage() noexcept {
     if (time_auto_advance)
       time = BrokenTime::Invalid();
+  }
+
+  /**
+   * Suspend the RASP dedicated page while panning, so the overlay is
+   * kept instead of being torn down.  Only takes effect if a RASP page
+   * is currently entered.
+   */
+  void SuspendRaspForPan() noexcept {
+    rasp_page_suspended_for_pan = rasp_page_entered;
+  }
+
+  void ResumeRaspAfterPan() noexcept {
+    rasp_page_suspended_for_pan = false;
+  }
+
+  [[gnu::pure]]
+  bool IsRaspSuspendedForPan() const noexcept {
+    return rasp_page_suspended_for_pan;
   }
 };


### PR DESCRIPTION
With the introduction of EDL, overlay handling in pan mode was changed. Overlays are removed by default, with EDL being excepted. This provides the same exception for the RASP weather layer, so it stays visible while in panning mode.

Fixes #2629 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RASP weather overlay behavior during map panning: the overlay is now correctly suspended when panning operations begin and automatically restored when panning ends or is cancelled. This prevents the weather layer from interfering with navigation interactions, providing a smoother and more responsive panning experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->