### PR TITLE
ui/canvas/freetpe/Font: harden NextChar() against malformed input

### DIFF
--- a/src/ui/canvas/freetype/Font.cpp
+++ b/src/ui/canvas/freetype/Font.cpp
@@ -76,10 +76,25 @@ FT_CEIL(FT_Long x) noexcept
 static unsigned
 NextChar(std::string_view &s) noexcept
 {
-  assert(!s.empty());
+  if (s.empty())
+    return 0;
 
   auto n = NextUTF8(s.data());
-  s.remove_prefix(n.second - s.data());
+  if (n.second == nullptr) {
+    /* NextUTF8() returns {0, nullptr} when the first byte is NUL;
+       pointer arithmetic with nullptr would be undefined behaviour
+       (and trips _GLIBCXX_ASSERTIONS on Debian/Ubuntu).  Consume the
+       rest of the view and report end-of-string instead. */
+    s = {};
+    return n.first;
+  }
+
+  /* Defensively clamp the step in case the UTF-8 sequence at the end
+     of the buffer is truncated and NextUTF8() walked past s.end(). */
+  std::size_t consumed = std::size_t(n.second - s.data());
+  if (consumed > s.size())
+    consumed = s.size();
+  s.remove_prefix(consumed);
   return n.first;
 }
 


### PR DESCRIPTION
## Summary

`NextChar()` in `src/ui/canvas/freetype/Font.cpp` performs pointer arithmetic
between `nullptr` and `s.data()` when the input `std::string_view` starts with
a NUL byte. The undefined behaviour normally manifests as `remove_prefix()`
wrapping the view's length and the next iteration of `ForEachChar()` reading
past the buffer end. On distributions that ship libstdc++ with
`_GLIBCXX_ASSERTIONS` enabled by default for optimised builds — Debian Trixie
and Ubuntu 24.04+ at `-O ≥ 1` — the violation is caught at runtime by the
inline `_M_len >= __n` check in `<string_view>` and the program aborts:

```
/usr/include/c++/14/string_view:297: ... remove_prefix: Assertion 'this->_M_len >= __n' failed.
Aborted
```

This is reachable on the very first text-render at startup (splash/logo,
profile-selector dialog, error toasts), making a release build effectively
unusable on these toolchains.

## Reproduction

- Toolchain: Debian Trixie's GCC 14 (default `_GLIBCXX_ASSERTIONS`).
- Build: `make TARGET=UNIX DEBUG=n LTO=y` (or `OPT`).
- Trigger: any `Font::TextSize()` / `Font::Render()` call site that hands the
  function an empty-or-NUL-prefixed `std::string_view`. `ForEachChar()`'s
  existing `assert(ValidateUTF8(text))` is compiled out with NDEBUG, so such
  input reaches `NextChar()` unchecked.

## Fix

`NextChar()` now:

1. Treats `s.empty()` as a no-op returning `0` instead of `assert`ing, so the
   release-build semantics match the previous debug-build expectations.
2. Detects the `NextUTF8() == {0, nullptr}` case and clears the view, instead
   of doing pointer arithmetic with `nullptr`.
3. Clamps the computed step to `s.size()`, defensive against a truncated
   multi-byte sequence at the end of the buffer.

The well-formed UTF-8 fast path is unchanged — one comparison and one branch
that are easy for the branch predictor.

Thanks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of UTF-8 text processing to safely handle truncated or edge-case character sequences, preventing potential crashes or incorrect rendering during text display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->