### PR TITLE
util/UTF8: harden SuffixUTF8() against malformed input

### DIFF
--- a/src/util/UTF8.cpp
+++ b/src/util/UTF8.cpp
@@ -591,8 +591,8 @@ SuffixUTF8(std::string_view s, std::size_t max_chars) noexcept
   std::size_t char_count = 0;
   for (std::string_view i = s; !i.empty(); ++char_count) {
     const std::size_t sequence = SequenceLengthUTF8(i.data());
-    assert(sequence > 0);
-    assert(sequence <= i.size());
+    if (sequence == 0 || sequence > i.size())
+      break;
     i.remove_prefix(sequence);
   }
 
@@ -602,7 +602,8 @@ SuffixUTF8(std::string_view s, std::size_t max_chars) noexcept
   const char *p = s.data();
   for (std::size_t skip = char_count - max_chars; skip > 0; --skip) {
     const std::size_t sequence = SequenceLengthUTF8(p);
-    assert(sequence > 0);
+    if (sequence == 0 || std::size_t(end - p) < sequence)
+      break;
     p += sequence;
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #2635.  `SuffixUTF8()` in `src/util/UTF8.cpp` has the same
defect class as the `NextChar()` fix that just landed: assert-gated bounds
checks on UTF-8 sequence lengths disappear under `NDEBUG`, leaving release
builds open to undefined behaviour when fed malformed or truncated input.

## Bug

`SuffixUTF8()` has two loops that walk the input using `SequenceLengthUTF8()`:

```cpp
// First loop — count characters
for (std::string_view i = s; !i.empty(); ++char_count) {
    const std::size_t sequence = SequenceLengthUTF8(i.data());
    assert(sequence > 0);
    assert(sequence <= i.size());
    i.remove_prefix(sequence);
}

// Second loop — skip to the suffix start
for (std::size_t skip = ...; skip > 0; --skip) {
    const std::size_t sequence = SequenceLengthUTF8(p);
    assert(sequence > 0);
    p += sequence;
}
```

`SequenceLengthUTF8()` returns `0` for malformed leading bytes (continuation
byte / illegal start byte) and a count larger than the remaining buffer
for truncated trailing sequences. The asserts catch both in debug builds;
under `NDEBUG`:

- `sequence > i.size()` → `remove_prefix(sequence)` is UB. With
  `_GLIBCXX_ASSERTIONS` enabled (Debian Trixie / Ubuntu 24.04+ default for
  optimised builds), the inline `_M_len >= __n` check aborts the program.
- `sequence == 0` → the first loop never advances → infinite loop.
- The second loop has **no** bounds check at all — `p += sequence` happily
  walks past `s.data() + s.size()`.

The function's entry `assert(ValidateUTF8(s))` documents the precondition
but is compiled out under `NDEBUG`, so contract violations from callers
reach the body unchecked. This is the same shape as the `NextChar()` bug
fixed in #2635.

## Reproduction

Same class as #2635 but reached on a narrower path — `SuffixUTF8()` is
only called from `Gauge/FlarmTrafficWindow` to truncate the trailing
portion of a FLARM callsign. A FLARM record with corrupted UTF-8 bytes
(or a bare ASCII NUL byte at the start of `s`) is enough to reach it.
Harder to hit at startup than the splash-screen path that triggered
#2635, but the same defect class with the same fix.

## Fix

Mirror the defensive pattern already used by `TruncateStringUTF8(std::string_view, …)`:

- Replace the inner asserts with `if (sequence == 0 || sequence > i.size()) break;`
  so the first loop stops cleanly on malformed input instead of feeding
  `remove_prefix()` a bogus length.
- Add the same guard to the second loop (`sequence == 0 || end - p < sequence`)
  so it can never advance `p` past `s.data() + s.size()`.
- Keep `assert(ValidateUTF8(s))` at the entry as debug-only documentation
  of the precondition.

The well-formed UTF-8 fast path is unchanged — one extra comparison per
iteration that the branch predictor will eat for free.


While preparing this and #2635 I went through every `remove_prefix` /
`NextUTF8` / `SequenceLengthUTF8` caller in the tree to check for the same
shape:

| Site | Status |
|---|---|
| `ui/canvas/freetype/Font.cpp` — `NextChar()` | Fixed in #2635 |
| `util/UTF8.cpp` — `SuffixUTF8()` | **This PR** |
| `util/UTF8.cpp` — `TruncateStringUTF8(std::string_view, …)` | Already has `if (sequence > s.size()) break;`. Safe |
| `util/UTF8.cpp` — `TruncateStringUTF8(const char *, …)` | NUL-terminated input; safe |
| `util/UTF8.cpp` — `ValidateUTF8(std::string_view)` | Inline `p.size() < N` checks per branch; safe |
| `ui/window/sdl/TopWindow.cpp`, `ui/event/sdl/Event.hpp` — `NextUTF8()` callers | NUL-terminated `event.text.text[32]`; use `{0, nullptr}` sentinel correctly; safe |
| `util/StringCompare.hxx` — `SkipPrefix` / `RemoveSuffix` | Guarded by `starts_with` / `ends_with`; safe |
| `io/StringConverter.cpp` — `DetectStrip` | Guarded by `starts_with`; safe |
| `ui/canvas/TextWrapper.cpp` — `ClampedSequenceLengthUTF8` | Clamps to `max_bytes`, forces ≥1 progress; reference impl |
| `Dialogs/KnobTextEntry.cpp` | Uses `length > 0 ? length : 1` always-progress pattern; safe |

So as far as I can see this should be the last instance of the same
defect on master.

Thanks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of UTF-8 string trimming by adding defensive runtime bounds checks.
  * The trimming logic now exits safely in edge cases instead of relying on strict assertions, reducing the risk of unexpected behavior when encountering malformed or incomplete UTF-8 sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->