### PR TITLE
Dialogs: Improve empty file lists with download hint

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -83,6 +83,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/DataField.cpp \
 	$(SRC)/Dialogs/ComboPicker.cpp \
 	$(SRC)/Dialogs/FilePicker.cpp \
+	$(SRC)/Dialogs/EmptyDownloadList.cpp \
 	$(SRC)/Dialogs/MultiFilePicker.cpp \
 	$(SRC)/Dialogs/HelpDialog.cpp \
 	$(SRC)/Dialogs/WifiDialog.cpp \

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -2,6 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "DownloadFilePicker.hpp"
+#include "EmptyDownloadList.hpp"
+#include "Renderer/TextRowRenderer.hpp"
 #include "Error.hpp"
 #include "WidgetDialog.hpp"
 #include "DownloadFileModal.hpp"
@@ -77,9 +79,10 @@ public:
 
 protected:
   void RefreshList();
+  void RefreshRepository() noexcept;
 
   void UpdateButtons() {
-      download_button->SetEnabled(!items.empty());
+    download_button->SetEnabled(true);
   }
 
   void Download();
@@ -100,7 +103,11 @@ public:
   }
 
   void OnActivateItem([[maybe_unused]] unsigned index) noexcept override {
-    Download();
+    if (items.empty()) {
+      assert(index == 0);
+      RefreshRepository();
+    } else
+      Download();
   }
 
   /* virtual methods from class Net::DownloadListener */
@@ -119,8 +126,11 @@ DownloadFilePickerWidget::Prepare(ContainerWindow &parent,
 {
   const DialogLook &look = UIGlobals::GetDialogLook();
 
-  CreateList(parent, look, rc,
-             row_renderer.CalculateLayout(*look.list.font));
+  unsigned row_height = row_renderer.CalculateLayout(*look.list.font);
+  if (items.empty())
+    row_height = LayoutEmptyDownloadRow(row_renderer);
+
+  CreateList(parent, look, rc, row_height);
   RefreshList();
 
   Net::DownloadManager::AddListener(*this);
@@ -153,10 +163,16 @@ DownloadFilePickerWidget::RefreshList()
       items.emplace_back(std::move(i));
 
   ListControl &list = GetList();
-  list.SetLength(items.size());
+  list.SetLength(std::max(items.size(), size_t{1}));
   list.Invalidate();
 
   UpdateButtons();
+}
+
+void
+DownloadFilePickerWidget::RefreshRepository() noexcept
+{
+  EnqueueRepositoryDownload(true);
 }
 
 void
@@ -171,6 +187,12 @@ void
 DownloadFilePickerWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                                       unsigned i) noexcept
 {
+  if (items.empty()) {
+    assert(i == 0);
+    DrawEmptyDownloadHint(row_renderer, canvas, rc);
+    return;
+  }
+
   const auto &file = items[i];
 
   row_renderer.DrawTextRow(canvas, rc, file.GetName());
@@ -180,6 +202,11 @@ void
 DownloadFilePickerWidget::Download()
 {
   assert(Net::DownloadManager::IsAvailable());
+
+  if (items.empty()) {
+    RefreshRepository();
+    return;
+  }
 
   const unsigned current = GetList().GetCursorIndex();
   assert(current < items.size());
@@ -298,6 +325,7 @@ DownloadFilePicker(FileType file_type)
   dialog.AddButton(_("Cancel"), mrCancel);
   dialog.SetWidget(dialog, file_type);
   dialog.GetWidget().CreateButtons();
+  dialog.EnableCursorSelection();
   dialog.ShowModal();
 
   return dialog.GetWidget().GetPath();

--- a/src/Dialogs/EmptyDownloadList.cpp
+++ b/src/Dialogs/EmptyDownloadList.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "EmptyDownloadList.hpp"
+
+#include "Language/Language.hpp"
+#include "Look/DialogLook.hpp"
+#include "UIGlobals.hpp"
+#include "ui/canvas/Canvas.hpp"
+
+void
+DrawEmptyDownloadHint(TextRowRenderer &renderer, Canvas &canvas,
+                      PixelRect rc) noexcept
+{
+  renderer.DrawTextRow(canvas, rc, _("Press here to download"));
+}
+
+unsigned
+LayoutEmptyDownloadRow(TextRowRenderer &renderer) noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  return renderer.CalculateLayout(*look.list.font);
+}
+
+void
+DrawEmptyDownloadHint(TwoTextRowsRenderer &renderer, Canvas &canvas,
+                      PixelRect rc) noexcept
+{
+  renderer.DrawFirstRow(canvas, rc, _("None"));
+  renderer.DrawSecondRow(canvas, rc, _("Press here to download"));
+}
+
+unsigned
+LayoutEmptyDownloadRow(TwoTextRowsRenderer &renderer) noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  return renderer.CalculateLayout(*look.list.font, look.small_font);
+}

--- a/src/Dialogs/EmptyDownloadList.hpp
+++ b/src/Dialogs/EmptyDownloadList.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Renderer/TextRowRenderer.hpp"
+#include "Renderer/TwoTextRowsRenderer.hpp"
+
+class Canvas;
+struct PixelRect;
+
+/** Empty placeholder for single-row lists. */
+void DrawEmptyDownloadHint(TextRowRenderer &renderer, Canvas &canvas,
+                           PixelRect rc) noexcept;
+
+/** Lay out @p renderer for #DrawEmptyDownloadHint and return row height. */
+unsigned LayoutEmptyDownloadRow(TextRowRenderer &renderer) noexcept;
+
+/** Empty placeholder for two-row lists (None / Press here to download). */
+void DrawEmptyDownloadHint(TwoTextRowsRenderer &renderer, Canvas &canvas,
+                           PixelRect rc) noexcept;
+
+/** Lay out @p renderer for #DrawEmptyDownloadHint and return row height. */
+unsigned LayoutEmptyDownloadRow(TwoTextRowsRenderer &renderer) noexcept;

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "FileManager.hpp"
+#include "EmptyDownloadList.hpp"
 #include "WidgetDialog.hpp"
 #include "Message.hpp"
 #include "UIGlobals.hpp"
@@ -269,6 +270,17 @@ public:
   unsigned OnListResized() noexcept override;
   void OnCursorMoved(unsigned index) noexcept override;
 
+  /* virtual methods from ListCursorHandler */
+  bool CanActivateItem(unsigned index) const noexcept override {
+#ifdef HAVE_DOWNLOAD_MANAGER
+    if (items.empty())
+      return Net::DownloadManager::IsAvailable() && index == 0;
+#endif
+    return index < items.size();
+  }
+
+  void OnActivateItem(unsigned index) noexcept override;
+
 #ifdef HAVE_DOWNLOAD_MANAGER
   void OnTimer();
 
@@ -389,7 +401,12 @@ ManagedFileListWidget::RefreshList()
   }
 
   ListControl &list = GetList();
+#ifdef HAVE_DOWNLOAD_MANAGER
+  list.SetLength(items.empty() && Net::DownloadManager::IsAvailable()
+                 ? size_t{1} : items.size());
+#else
   list.SetLength(items.size());
+#endif
   list.Invalidate();
 
 #ifdef HAVE_DOWNLOAD_MANAGER
@@ -420,13 +437,32 @@ ManagedFileListWidget::UpdateButtons()
 {
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (Net::DownloadManager::IsAvailable()) {
+    if (items.empty()) {
+      download_button->SetEnabled(false);
+      cancel_button->SetEnabled(false);
+      update_button->SetEnabled(false);
+      return;
+    }
+
     const unsigned current = GetList().GetCursorIndex();
 
-    download_button->SetEnabled(!items.empty() &&
-                                CanDownload(repository, items[current].name));
-    cancel_button->SetEnabled(!items.empty() && items[current].downloading);
-    update_button->SetEnabled(!items.empty() && some_out_of_date);
+    download_button->SetEnabled(CanDownload(repository, items[current].name));
+    cancel_button->SetEnabled(items[current].downloading);
+    update_button->SetEnabled(some_out_of_date);
   }
+#endif
+}
+
+void
+ManagedFileListWidget::OnActivateItem(unsigned index) noexcept
+{
+#ifdef HAVE_DOWNLOAD_MANAGER
+  if (items.empty()) {
+    assert(index == 0);
+    Add();
+  }
+#else
+  (void)index;
 #endif
 }
 
@@ -434,6 +470,14 @@ void
 ManagedFileListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                                    unsigned i) noexcept
 {
+#ifdef HAVE_DOWNLOAD_MANAGER
+  if (items.empty() && Net::DownloadManager::IsAvailable()) {
+    assert(i == 0);
+    DrawEmptyDownloadHint(row_renderer, canvas, rc);
+    return;
+  }
+#endif
+
   const FileItem &file = items[i];
 
   row_renderer.DrawFirstRow(canvas, rc, file.name.c_str());

--- a/src/Dialogs/FilePicker.cpp
+++ b/src/Dialogs/FilePicker.cpp
@@ -3,14 +3,15 @@
 
 #include "FilePicker.hpp"
 #include "ComboPicker.hpp"
+#include "Repository/Glue.hpp"
 #include "Form/DataField/ComboList.hpp"
 #include "Form/DataField/File.hpp"
+#include "Form/Form.hpp"
 #include "Language/Language.hpp"
 #include "net/http/Features.hpp"
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "DownloadFilePicker.hpp"
-#include "net/http/DownloadManager.hpp"
 #endif
 
 bool
@@ -18,23 +19,22 @@ FilePicker(const char *caption, FileDataField &df, const char *help_text,
            bool nullable)
 {
   ComboList combo_list = df.CreateComboList(nullptr);
-  // if nullable it's mean that combo_list must have at least a null element
-  if (combo_list.size() == 0 && nullable) return false;
 
   const char *extra_caption = nullptr;
 #ifdef HAVE_DOWNLOAD_MANAGER
   const auto file_type = df.GetFileType();
-  // with FileType::IGC don't show the 'Download'-Button!
-  if (file_type != FileType::IGC &&
-      file_type != FileType::UNKNOWN &&
-      Net::DownloadManager::IsAvailable())
+  if (FileTypeSupportsDownload(file_type))
     extra_caption = _("Download");
 #endif
 
-  int i = ComboPicker(caption, combo_list, help_text, false, extra_caption);
+  if (combo_list.size() == 0 && nullable && extra_caption == nullptr)
+    return false;
+
+  const int i = ComboPicker(caption, combo_list, help_text, false,
+                            extra_caption);
 
 #ifdef HAVE_DOWNLOAD_MANAGER
-  if (i == -2) {
+  if (i == mrExtra) {
     const auto path = DownloadFilePicker(file_type);
     if (path == nullptr)
       return false;

--- a/src/Dialogs/ListPicker.cpp
+++ b/src/Dialogs/ListPicker.cpp
@@ -2,8 +2,10 @@
 // Copyright The XCSoar Project
 
 #include "Dialogs/ListPicker.hpp"
+#include "EmptyDownloadList.hpp"
 #include "HelpDialog.hpp"
 #include "Language/Language.hpp"
+#include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 #include "Widget/ListWidget.hpp"
 #include "Widget/StaticHelpTextWidget.hpp"
@@ -14,6 +16,42 @@
 #include "ui/event/Timer.hpp"
 
 #include <cassert>
+
+void
+ListPickerWidget::Prepare(ContainerWindow &parent,
+                          const PixelRect &rc) noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  unsigned height = row_height;
+  if (num_items == 0 && empty_extra_action)
+    height = LayoutEmptyDownloadRow(empty_row_renderer);
+
+  ListControl &list = CreateList(parent, look, rc, height);
+  list.SetLength(num_items > 0 ? num_items : (empty_extra_action ? 1u : 0u));
+  list.SetCursorIndex(initial_value);
+}
+
+unsigned
+ListPickerWidget::OnListResized() noexcept
+{
+  if (num_items == 0 && empty_extra_action)
+    return LayoutEmptyDownloadRow(empty_row_renderer);
+
+  return item_renderer.OnListResized();
+}
+
+void
+ListPickerWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
+                              unsigned idx) noexcept
+{
+  if (num_items == 0 && empty_extra_action) {
+    assert(idx == 0);
+    DrawEmptyDownloadHint(empty_row_renderer, canvas, rc);
+    return;
+  }
+
+  item_renderer.OnPaintItem(canvas, rc, idx);
+}
 
 int
 ListPicker(const char *caption,
@@ -31,9 +69,13 @@ ListPicker(const char *caption,
   WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
                       UIGlobals::GetDialogLook(), caption);
 
+  const bool empty_extra_action =
+    num_items == 0 && extra_caption != nullptr;
+
   ListPickerWidget *const list_widget =
     new ListPickerWidget(num_items, initial_value, item_height,
-                         item_renderer, dialog, caption, help_text);
+                         item_renderer, dialog, caption, help_text,
+                         empty_extra_action);
 
   std::unique_ptr<Widget> widget(list_widget);
 
@@ -55,7 +97,7 @@ ListPicker(const char *caption,
     dialog.AddButton(_("Select"), mrOK);
 
   if (extra_caption != nullptr)
-    dialog.AddButton(extra_caption, -2);
+    dialog.AddButton(extra_caption, mrExtra);
 
   /* only show a Help button when item help is active (the general
      help text complements the per-item help); for pickers without
@@ -80,7 +122,7 @@ ListPicker(const char *caption,
   int result = dialog.ShowModal();
   if (result == mrOK)
     result = (int)list_widget->GetList().GetCursorIndex();
-  else if (result != -2)
+  else if (result != mrExtra)
     result = -1;
 
   return result;

--- a/src/Dialogs/ListPicker.hpp
+++ b/src/Dialogs/ListPicker.hpp
@@ -6,6 +6,7 @@
 #include "Form/Form.hpp"
 #include "HelpDialog.hpp"
 #include "UIGlobals.hpp"
+#include "Renderer/TextRowRenderer.hpp"
 #include "Widget/ListWidget.hpp"
 #include "Widget/TextWidget.hpp"
 #include "Widget/TwoWidgets.hpp"
@@ -39,11 +40,15 @@ class ListPickerWidget : public ListWidget {
   TextWidget *help_widget;
   TwoWidgets *two_widgets;
 
+  /** When the list is empty but an extra action (e.g. Download) exists. */
+  bool empty_extra_action;
+  TextRowRenderer empty_row_renderer;
+
 public:
   ListPickerWidget(unsigned _num_items, unsigned _initial_value,
                    unsigned _row_height, ListItemRenderer &_item_renderer,
                    WndForm &_dialog, const char *_caption,
-                   const char *_help_text) noexcept
+                   const char *_help_text, bool _empty_extra_action) noexcept
       : num_items(_num_items),
         initial_value(_initial_value),
         row_height(_row_height),
@@ -52,7 +57,8 @@ public:
         dialog(_dialog),
         caption(_caption),
         help_text(_help_text),
-        item_help_callback(nullptr)
+        item_help_callback(nullptr),
+        empty_extra_action(_empty_extra_action)
   {
   }
 
@@ -79,13 +85,7 @@ public:
 
   /* virtual methods from class Widget */
 
-  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override
-  {
-    ListControl &list =
-        CreateList(parent, UIGlobals::GetDialogLook(), rc, row_height);
-    list.SetLength(num_items);
-    list.SetCursorIndex(initial_value);
-  }
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
 
   void Show(const PixelRect &rc) noexcept override
   {
@@ -104,16 +104,10 @@ public:
 
   /* virtual methods from class ListControl::Handler */
 
-  unsigned OnListResized() noexcept override
-  {
-    return item_renderer.OnListResized();
-  }
+  unsigned OnListResized() noexcept override;
 
   void OnPaintItem(Canvas &canvas, const PixelRect rc,
-                   unsigned idx) noexcept override
-  {
-    item_renderer.OnPaintItem(canvas, rc, idx);
-  }
+                   unsigned idx) noexcept override;
 
   void OnCursorMoved(unsigned index) noexcept override { UpdateHelp(index); }
 
@@ -124,7 +118,10 @@ public:
 
   void OnActivateItem([[maybe_unused]] unsigned index) noexcept override
   {
-    dialog.SetModalResult(mrOK);
+    if (num_items == 0 && empty_extra_action)
+      dialog.SetModalResult(mrExtra);
+    else
+      dialog.SetModalResult(mrOK);
   }
 };
 
@@ -141,7 +138,7 @@ public:
  * @param itemhelp_callback Callback to return string for current item help
  * @param extra_caption caption of another button that closes the
  * dialog (nullptr disables it)
- * @return the list index, -1 if the user cancelled the dialog, -2 if
+ * @return the list index, -1 if the user cancelled the dialog, mrExtra if
  * the user clicked the "extra" button
  */
 int

--- a/src/Dialogs/MultiFilePicker.cpp
+++ b/src/Dialogs/MultiFilePicker.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "MultiFilePicker.hpp"
+#include "Repository/Glue.hpp"
 #include "Form/DataField/MultiFile.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
@@ -15,7 +16,6 @@
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "DownloadFilePicker.hpp"
-#include "net/http/DownloadManager.hpp"
 #endif
 
 static const char *
@@ -54,8 +54,8 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
   dialog.AddButton(_("OK"), mrOK);
 
 #ifdef HAVE_DOWNLOAD_MANAGER
-  if (Net::DownloadManager::IsAvailable()) {
-    dialog.AddButton(_("Download"), [file_widget, &df]() {
+  if (FileTypeSupportsDownload(df.GetFileDataField().GetFileType())) {
+    const auto download = [file_widget, &df]() {
       const auto path = DownloadFilePicker(df.GetFileDataField().GetFileType());
       if (path != nullptr) {
         df.ForceModify(path);
@@ -63,7 +63,9 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
 
         file_widget->Refresh();
       }
-    });
+    };
+    dialog.AddButton(_("Download"), download);
+    file_widget->EnableEmptyDownloadHint(download);
   }
 #endif
 
@@ -88,6 +90,7 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
   UpdateButtons();
   file_widget->SetSelectionChangedCallback(UpdateButtons);
 
+  dialog.EnableCursorSelection();
   dialog.FinishPreliminary(std::move(widget));
 
   int result = dialog.ShowModal();

--- a/src/Dialogs/Plane/WeGlideTypePicker.cpp
+++ b/src/Dialogs/Plane/WeGlideTypePicker.cpp
@@ -110,7 +110,7 @@ SelectWeGlideAircraftType(unsigned &aircraft_id,
       return aircraft_id != old_aircraft_id;
     }
 
-    if (result == -2) {
+    if (result == mrExtra) {
       auto refreshed = DownloadAircraftTypes(settings);
       if (refreshed.empty()) {
         ShowMessageBox(_("Could not load WeGlide aircraft list."),

--- a/src/Dialogs/Weather/NOAAList.cpp
+++ b/src/Dialogs/Weather/NOAAList.cpp
@@ -129,7 +129,7 @@ NOAAListWidget::UpdateList()
   std::sort(stations.begin(), stations.end());
 
   ListControl &list = GetList();
-  list.SetLength(stations.size());
+  list.SetLength(std::max(stations.size(), size_t{1}));
   list.Invalidate();
 
   const bool empty = stations.empty(), full = stations.full();
@@ -143,6 +143,14 @@ void
 NOAAListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                             unsigned index) noexcept
 {
+  if (stations.empty()) {
+    assert(index == 0);
+    row_renderer.DrawFirstRow(canvas, rc, _("None"));
+    row_renderer.DrawSecondRow(canvas, rc,
+                               _("Press here to add a station"));
+    return;
+  }
+
   assert(index < stations.size());
 
   NOAAListRenderer::Draw(canvas, rc, *stations[index].iterator,
@@ -238,6 +246,12 @@ NOAAListWidget::DetailsClicked()
 void
 NOAAListWidget::OnActivateItem(unsigned index) noexcept
 {
+  if (stations.empty()) {
+    assert(index == 0);
+    AddClicked();
+    return;
+  }
+
   OpenDetails(index);
 }
 

--- a/src/Form/Form.hpp
+++ b/src/Form/Form.hpp
@@ -15,6 +15,8 @@ class PeriodClock;
 enum ModalResult {
   mrOK = 2,
   mrCancel = 3,
+  /** Extra dialog button (e.g. ListPicker download action). */
+  mrExtra = -2,
 };
 
 /**

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -287,4 +287,11 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
   }
 }
 
+bool
+FileTypeSupportsDownload(FileType type) noexcept
+{
+  return type != FileType::IGC && type != FileType::UNKNOWN &&
+         Net::DownloadManager::IsAvailable();
+}
+
 #endif

--- a/src/Repository/Glue.hpp
+++ b/src/Repository/Glue.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "AvailableFile.hpp"
+#include "Repository/FileType.hpp"
 #include "net/http/Features.hpp"
 #include "system/Path.hpp"
 
@@ -113,4 +114,9 @@ EnqueueConfiguredRaspDownload(const FileRepository &repository) noexcept;
 void
 DownloadRepositoriesModal(bool main_repo=true, bool user_repo=true);
 
+/**
+ * Whether the download manager can offer repository files for @p type.
+ */
+[[gnu::pure]] bool
+FileTypeSupportsDownload(FileType type) noexcept;
 #endif /* HAVE_DOWNLOAD_MANAGER */

--- a/src/Widget/FileMultiSelectWidget.cpp
+++ b/src/Widget/FileMultiSelectWidget.cpp
@@ -17,6 +17,7 @@
 #include "util/StaticString.hxx"
 #include "util/UTF8.hpp"
 #include "Dialogs/HelpDialog.hpp"
+#include "Dialogs/EmptyDownloadList.hpp"
 #include "Form/CheckBox.hpp"
 
 #include <algorithm>
@@ -162,7 +163,9 @@ FileMultiSelectWidget::Refresh() noexcept
   if (df_)
     MergePaths(current_items);
 
-  SetLengthWithSelection(items_.size());
+  SetLengthWithSelection(ShouldShowEmptyDownloadHint()
+                         ? 1u : unsigned(items_.size()));
+  GetList().SetItemHeight(ComputeRowHeight());
   ClearSelection();
 
   RestoreAfterRefresh(saved_selection, previous_paths, current_items);
@@ -291,6 +294,15 @@ void
 FileMultiSelectWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                                    unsigned idx) noexcept
 {
+  if (ShouldShowEmptyDownloadHint()) {
+    assert(idx == 0);
+    if (use_two_rows_)
+      DrawEmptyDownloadHint(two_text_rows_renderer_, canvas, rc);
+    else
+      DrawEmptyDownloadHint(text_row_renderer_, canvas, rc);
+    return;
+  }
+
   if (idx >= items_.size())
     return;
 
@@ -412,6 +424,13 @@ FileMultiSelectWidget::SetNavigateCallback(std::function<void(AllocatedPath)> cb
 void
 FileMultiSelectWidget::OnActivateItem(unsigned index) noexcept
 {
+  if (ShouldShowEmptyDownloadHint()) {
+    assert(index == 0);
+    if (empty_download_activate_)
+      empty_download_activate_();
+    return;
+  }
+
   if (index >= items_.size())
     return;
 
@@ -438,6 +457,11 @@ FileMultiSelectWidget::OnListResized() noexcept
 unsigned
 FileMultiSelectWidget::ComputeRowHeight() noexcept
 {
+  if (ShouldShowEmptyDownloadHint())
+    return use_two_rows_
+      ? LayoutEmptyDownloadRow(two_text_rows_renderer_)
+      : LayoutEmptyDownloadRow(text_row_renderer_);
+
   const DialogLook &look = UIGlobals::GetDialogLook();
   /* Row height is driven purely by font metrics so that it adapts
      when Layout scale factors change on window resize.  The folder

--- a/src/Widget/FileMultiSelectWidget.hpp
+++ b/src/Widget/FileMultiSelectWidget.hpp
@@ -98,6 +98,14 @@ public:
     default-constructed or empty, all files are shown. */
   void SetFilter(std::function<bool(const Path &)> filter) noexcept;
 
+  /**
+   * When the list is empty, show a download hint row; @p activate runs
+   * when the user activates that row (e.g. open the download picker).
+   */
+  void EnableEmptyDownloadHint(std::function<void()> activate) noexcept {
+    empty_download_activate_ = std::move(activate);
+  }
+
   // MultiSelectListWidget virtual methods
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Show(const PixelRect &rc) noexcept override;
@@ -130,6 +138,7 @@ private:
   std::function<void()> selection_changed_callback_;
   std::function<bool(const Path &)> filter_;
   std::function<void(AllocatedPath)> navigate_callback_;
+  std::function<void()> empty_download_activate_;
   MaskedIcon folder_icon_;
 
   void LoadFiles() noexcept;
@@ -148,4 +157,9 @@ private:
   void RestoreSelection(const std::vector<Path> &saved_selection,
                         const std::vector<AllocatedPath> &previous_items_paths,
                         const std::vector<Path> &current_items) noexcept;
+
+  [[gnu::pure]]
+  bool ShouldShowEmptyDownloadHint() const noexcept {
+    return empty_download_activate_ && items_.empty();
+  }
 };


### PR DESCRIPTION
## Summary

- When no local files exist but repository download is supported, file pickers show "None" / "Press here for more" and tapping the row opens download
- Adds shared `EmptyDownloadList` helper used by single-file, multi-file, and list picker paths
- Updates `FileManager`, `NOAAList`, and related pickers consistently

Split out from #2607 so the XCTherm integration PR stays focused.

## Test plan

- [ ] Open a file picker for a type with no local files but an available repository (e.g. RASP, NOAA)
- [ ] Verify empty list shows "None" / "Press here for more"
- [ ] Tap the row and confirm download/add flow opens
- [ ] Verify non-empty lists and multi-file pickers still behave as before
- [ ] Build: `TARGET=UNIX`, `TARGET=WIN64`, `TARGET=KOBO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added empty-state UI rows to several file/list pickers, showing clear prompts to add or download when no items are available.
  * Improved download option behavior so download is offered only for supported file types.

* **Bug Fixes**
  * Fixed empty-list interactions so the empty-state row remains selectable and activates the correct action (instead of doing nothing).
  * Standardized “extra button” dialog results so downstream flows refresh/handle actions reliably.

* **Chores**
  * Updated the build to include the new empty-state dialog support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->