### PR TITLE
Weather: Rename pc_met user-facing strings to Flugwetter

### DIFF
--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -364,7 +364,7 @@ WeatherMapOverlayListWidget::UseClicked(unsigned i)
         item.path = std::move(overlay->path);
         UpdatePreview(item.path);
       } catch (...) {
-        ShowError(std::current_exception(), "pc_met");
+        ShowError(std::current_exception(), "Flugwetter");
       }
     }
   }
@@ -399,7 +399,7 @@ WeatherMapOverlayListWidget::UpdateClicked()
           SetOverlay(overlay->path, info.label.c_str());
         item.path = std::move(overlay->path);
       } catch (...) {
-        ShowError(std::current_exception(), "pc_met");
+        ShowError(std::current_exception(), "Flugwetter");
         break;
       }
     }

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -185,7 +185,7 @@ BitmapDialog(const Bitmap &bitmap)
   WidgetDialog dialog(WidgetDialog::Full{},
                       UIGlobals::GetMainWindow(),
                       UIGlobals::GetDialogLook(),
-                      "pc_met", new PCMetImageWidget(bitmap));
+                      "Flugwetter", new PCMetImageWidget(bitmap));
   auto &image = static_cast<PCMetImageWidget &>(dialog.GetWidget());
 
   dialog.AddButton(_("Close"), mrOK);
@@ -217,7 +217,7 @@ BitmapDialog(const PCMet::ImageType &type, const PCMet::ImageArea &area)
     bitmap.LoadFile(*path);
     BitmapDialog(bitmap);
   } catch (...) {
-    ShowError(std::current_exception(), "pc_met");
+    ShowError(std::current_exception(), "Flugwetter");
   }
 }
 

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -92,7 +92,7 @@ ShowWeatherDialog(const char *page)
   if (page != nullptr && StringIsEqual(page, "pc_met"))
     start_page = widget.GetSize();
 
-  widget.AddTab(CreatePCMetWidget(), "pc_met");
+  widget.AddTab(CreatePCMetWidget(), "Flugwetter");
 #endif
 
 #if 0


### PR DESCRIPTION
## Summary

- Rename user-visible "pc_met" labels to "Flugwetter" in the weather dialog tab, image viewer title, and error captions
- Internal page ids and profile keys remain `pc_met`
- Split out from #2607

## Test plan

- [ ] Open Weather dialog → Flugwetter tab shows correct title
- [ ] Open a Flugwetter image; verify viewer title and error captions use "Flugwetter"
- [ ] Confirm deep links / profile keys using `pc_met` still work