### PR TITLE
ui/event/Notify: Guard queue access during shutdown

### DIFF
--- a/src/ui/event/Notify.cpp
+++ b/src/ui/event/Notify.cpp
@@ -24,7 +24,8 @@ Notify::SendNotification() noexcept
 #ifdef USE_WINUSER
   SendUser(0);
 #else
-  event_queue->InjectCall(Callback, this);
+  if (event_queue != nullptr)
+    event_queue->InjectCall(Callback, this);
 #endif
 }
 
@@ -35,7 +36,8 @@ Notify::ClearNotification() noexcept
     return;
 
 #ifndef USE_WINUSER
-  event_queue->Purge(Callback, this);
+  if (event_queue != nullptr)
+    event_queue->Purge(Callback, this);
 #endif
 }
 


### PR DESCRIPTION
## Summary

- Guard `UI::Notify` against null `event_queue` during application teardown
- Prevents crashes when notify users (e.g. background download progress) outlive the UI event loop
- Split out from #2607; the `BackgroundDownloadProgress::ForceHide()` portion of the original commit remains in #2607 until that class lands on master

## Test plan

- [ ] Normal startup/shutdown on `TARGET=UNIX`
- [ ] Trigger a background download, exit app during/after download
- [ ] Release build (`DEBUG=n`) shutdown path