### PR TITLE
Widget: Add scrollable large text widget

### DIFF
--- a/build/libwidget.mk
+++ b/build/libwidget.mk
@@ -14,6 +14,7 @@ WIDGET_SOURCES = \
 	$(SRC)/Widget/TabWidget.cpp \
 	$(SRC)/Widget/TextWidget.cpp \
 	$(SRC)/Widget/LargeTextWidget.cpp \
+	$(SRC)/Widget/ScrollableLargeTextWidget.cpp \
 	$(SRC)/Widget/RichTextWidget.cpp \
 	$(SRC)/Widget/OverlappedWidget.cpp \
 	$(SRC)/Widget/TwoWidgets.cpp \

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -4,12 +4,15 @@
 #include "Airspace.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
+#include "Widget/ScrollableLargeTextWidget.hpp"
+#include "Widget/VScrollWidget.hpp"
 #include "Airspace/AbstractAirspace.hpp"
 #include "Airspace/AirspaceClass.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Formatter/AirspaceFormatter.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "Screen/Layout.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "UIGlobals.hpp"
 #include "Interface.hpp"
@@ -28,10 +31,15 @@
 
 #include <cstring>
 #include <cassert>
+#include <algorithm>
 #include <exception>
 #include <string>
 
 namespace {
+
+static constexpr unsigned SCROLLABLE_TEXT_MIN_ROWS = 3;
+static constexpr unsigned SCROLLABLE_TEXT_MAX_ROWS = 10;
+static constexpr unsigned SCROLLABLE_TEXT_PREFERRED_HEIGHT_DIVISOR = 3;
 
 [[nodiscard]]
 static std::string
@@ -73,6 +81,19 @@ FormatAltitudeWithReference(char *buffer, size_t buffer_size,
     if (suffix_len <= remaining)
       std::memcpy(buffer + current_len, suffix, suffix_len + 1);
   }
+}
+
+[[nodiscard]]
+static unsigned
+GetScrollableTextRowMaximumHeight(const PixelRect &rc) noexcept
+{
+  const unsigned row_height = Layout::GetMinimumControlHeight();
+  const unsigned minimum = row_height * SCROLLABLE_TEXT_MIN_ROWS;
+  const unsigned maximum = row_height * SCROLLABLE_TEXT_MAX_ROWS;
+  const unsigned preferred =
+    rc.GetHeight() / SCROLLABLE_TEXT_PREFERRED_HEIGHT_DIVISOR;
+
+  return std::clamp(preferred, minimum, maximum);
 }
 
 } // namespace
@@ -384,7 +405,7 @@ NOTAMDetailsWidget::AddNOTAMAltitudes(StaticString<128> &buffer)
 
 void
 NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
-                            [[maybe_unused]] const PixelRect &rc) noexcept
+                            const PixelRect &rc) noexcept
 {
   const NMEAInfo &basic = CommonInterface::Basic();
   StaticString<128> buffer;
@@ -413,7 +434,9 @@ NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     notam_opt && !notam_opt->text.empty()
     ? SafeString(notam_opt->text)
     : SafeString(airspace_name != nullptr ? airspace_name : "");
-  AddMultiLine(text.c_str());
+  Add(std::make_unique<VScrollWidget>(
+    std::make_unique<ScrollableLargeTextWidget>(GetLook(), text.c_str()),
+    GetLook(), true, GetScrollableTextRowMaximumHeight(rc)));
 
   AddNOTAMValidity(notam_opt, buffer);
   AddNOTAMAltitudes(buffer);

--- a/src/Widget/ScrollableLargeTextWidget.cpp
+++ b/src/Widget/ScrollableLargeTextWidget.cpp
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ScrollableLargeTextWidget.hpp"
+#include "Look/DialogLook.hpp"
+#include "Renderer/TextRenderer.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Font.hpp"
+#include "ui/control/LargeTextWindow.hpp"
+#include "util/UTF8.hpp"
+
+#include <algorithm>
+#include <string_view>
+
+static constexpr unsigned ESTIMATED_LINE_WIDTH_CHARS = 28;
+
+static unsigned
+EstimateLineCount(const std::string &text) noexcept
+{
+  if (text.empty())
+    return 1;
+
+  unsigned line_count = 1;
+  unsigned line_length = 0;
+  for (const char *p = text.c_str(); *p != '\0';) {
+    if (*p == '\n') {
+      ++line_count;
+      line_length = 0;
+      ++p;
+    } else {
+      ++line_length;
+      if (line_length == ESTIMATED_LINE_WIDTH_CHARS) {
+        ++line_count;
+        line_length = 0;
+      }
+
+      const std::size_t sequence_length = SequenceLengthUTF8(p);
+      p += sequence_length > 0 ? sequence_length : 1;
+    }
+  }
+
+  return line_count;
+}
+
+void
+ScrollableLargeTextWidget::SetText(const char *_text)
+{
+  text = _text != nullptr ? _text : "";
+
+  if (IsDefined()) {
+    LargeTextWindow &w = (LargeTextWindow &)GetWindow();
+    w.SetText(text.c_str());
+  }
+}
+
+PixelSize
+ScrollableLargeTextWidget::GetMinimumSize() const noexcept
+{
+  return PixelSize{0u, Layout::GetMinimumControlHeight()};
+}
+
+PixelSize
+ScrollableLargeTextWidget::GetMaximumSize() const noexcept
+{
+  const Font &font = look.text_font;
+  const unsigned padding = Layout::GetTextPadding() * 2;
+
+  if (IsDefined()) {
+    const LargeTextWindow &w = (const LargeTextWindow &)GetWindow();
+    const unsigned width = w.GetSize().width;
+    const unsigned text_width =
+      width > padding * 2 ? width - padding * 2 : width;
+
+    TextRenderer renderer;
+    const unsigned text_height =
+      renderer.GetHeight(font, text_width, std::string_view{text});
+    const unsigned estimated_height =
+      EstimateLineCount(text) * font.GetLineSpacing();
+
+    return PixelSize{0u, std::max(text_height, estimated_height) +
+                     padding * 2};
+  }
+
+  const unsigned line_count = EstimateLineCount(text);
+  return PixelSize{0u, line_count * font.GetLineSpacing() + padding * 2};
+}
+
+void
+ScrollableLargeTextWidget::Prepare(ContainerWindow &parent,
+                                   const PixelRect &rc) noexcept
+{
+  LargeTextWidget::Prepare(parent, rc);
+
+  try {
+    LargeTextWindow &w = (LargeTextWindow &)GetWindow();
+    w.SetText(text.c_str());
+  } catch (...) {
+    /* Preserve the noexcept Prepare() contract if copying text fails. */
+  }
+}

--- a/src/Widget/ScrollableLargeTextWidget.hpp
+++ b/src/Widget/ScrollableLargeTextWidget.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "LargeTextWidget.hpp"
+
+#include <string>
+
+struct DialogLook;
+
+/**
+ * A #LargeTextWidget variant whose height follows its text content.
+ *
+ * This is intended to be wrapped in #VScrollWidget when the caller
+ * wants overflow to be scrollable.
+ */
+class ScrollableLargeTextWidget final : public LargeTextWidget {
+  const DialogLook &look;
+  std::string text;
+
+public:
+  explicit ScrollableLargeTextWidget(const DialogLook &_look,
+                                     const char *_text=nullptr)
+    :LargeTextWidget(_look), look(_look),
+     text(_text != nullptr ? _text : "") {}
+
+  void SetText(const char *_text);
+
+  /* virtual methods from class Widget */
+  PixelSize GetMinimumSize() const noexcept override;
+  PixelSize GetMaximumSize() const noexcept override;
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+};

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -8,6 +8,7 @@
 #include "ui/event/KeyCode.hpp"
 #include "util/StringAPI.hxx"
 
+#include <algorithm>
 #include <cassert>
 
 unsigned
@@ -67,7 +68,20 @@ VScrollWidget::GetMinimumSize() const noexcept
 PixelSize
 VScrollWidget::GetMaximumSize() const noexcept
 {
-  return widget->GetMaximumSize();
+  PixelSize size = widget->GetMaximumSize();
+
+  if (maximum_layout_height > 0) {
+    const unsigned minimum_height = widget->GetMinimumSize().height;
+    const unsigned capped_height =
+      std::max(minimum_height, maximum_layout_height);
+
+    if (size.height == 0)
+      size.height = capped_height;
+    else
+      size.height = std::clamp(size.height, minimum_height, capped_height);
+  }
+
+  return size;
 }
 
 void

--- a/src/Widget/VScrollWidget.hpp
+++ b/src/Widget/VScrollWidget.hpp
@@ -35,6 +35,9 @@ class VScrollWidget final : public WindowWidget, VScrollPanelListener {
   /** Reserve horizontal space for the scrollbar. */
   bool reserve_scrollbar;
 
+  /** Optional maximum height reported to parent layout. */
+  unsigned maximum_layout_height;
+
   /**
    * Optional callback for horizontal swipe gestures.
    * Called with true for swipe-right (next), false for swipe-left
@@ -52,10 +55,12 @@ public:
    */
   explicit VScrollWidget(std::unique_ptr<Widget> &&_widget,
                          const DialogLook &_look,
-                         bool _reserve_scrollbar = false) noexcept
+                         bool _reserve_scrollbar = false,
+                         unsigned _maximum_layout_height = 0) noexcept
     :look(_look),
      widget(std::move(_widget)),
-     reserve_scrollbar(_reserve_scrollbar) {}
+     reserve_scrollbar(_reserve_scrollbar),
+     maximum_layout_height(_maximum_layout_height) {}
 
   Widget &GetWidget() noexcept {
     return *widget;


### PR DESCRIPTION
Title: Widget: Add scrollable large text widget

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Summary

Adds a `ScrollableLargeTextWidget` for large text panes that need to report
their content height to `VScrollWidget`, then uses it for NOTAM text in the
airspace details dialog.

The NOTAM text row now keeps a small minimum height for constrained layouts
such as `-small`, can grow on larger dialogs such as `-portrait`, and scrolls
when the NOTAM text still exceeds the available row height.

## Background

This addresses the NOTAM details overflow request from discussion #2558:
https://github.com/XCSoar/XCSoar/discussions/2558

It also follows the direction explored in the closed draft PR #1869, which
introduced the idea of a size-aware large text widget wrapped by
`VScrollWidget`:
https://github.com/XCSoar/XCSoar/pull/1869

Compared to that draft, this version keeps `LargeTextWidget` unchanged, adds
the scrollable behavior as an explicit separate widget, and lets
`VScrollWidget` cap the height it reports to parent layouts while preserving
the full virtual scroll height.

## Testing

- [x] Manual UI checks with `./output/MACOS/bin/xcsoar`
- [x] Manual UI checks with `./output/MACOS/bin/xcsoar -small`
- [x] Manual UI checks with `./output/MACOS/bin/xcsoar -portrait`
- [x] Manual UI checks with `./output/MACOS/bin/xcsoar -square`
- [x] Manual UI check on iPhone 14 Pro

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NOTAM text in the Airspace Details dialog now uses a dedicated scrollable large-text display for long content.
* **Improvements**
  * Added a new scrollable large-text widget that computes sizing from its content and handles text updates safely.
  * Vertical scroll containers now support an optional maximum height constraint, helping scrollable areas fit more accurately in limited dialog space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->