### PR TITLE
NOTAM: Improve list dialog

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1120,6 +1120,14 @@ location=5
 
 mode=Info2
 type=key
+data=7
+event=NOTAMList
+event=Mode default
+label=NOTAMs
+location=6
+
+mode=Info2
+type=key
 data=8
 event=Setup Teamcode
 event=Mode default

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -7,6 +7,7 @@
 #ifdef HAVE_HTTP
 
 #include "Dialogs/WidgetDialog.hpp"
+#include "Dialogs/Message.hpp"
 #include "Form/Button.hpp"
 #include "Widget/ListWidget.hpp"
 #include "ui/control/List.hpp"
@@ -23,15 +24,20 @@
 #include "NOTAM/Filter.hpp"
 #include "NOTAM/NOTAMGlue.hpp"
 #include "NOTAM/Converter.hpp"
+#include "Airspace/AirspaceGlue.hpp"
 #include "Airspace.hpp"
 #include "BackendComponents.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Interface.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
+#include "Protection.hpp"
 #include "util/StringFormat.hpp"
 #include "util/TruncateString.hpp"
 #include "Operation/Operation.hpp"
 #include "util/UTF8.hpp"
+#include "util/StringAPI.hxx"
 #include "system/FileUtil.hpp"
 
 #include <array>
@@ -92,6 +98,136 @@ SafeString(const std::string &input)
     return std::string(_("[Invalid text]"));
   }
   return input;
+}
+
+[[nodiscard]]
+static bool
+HasHiddenQCodeToken(std::string_view hidden_list,
+                    std::string_view qcode) noexcept
+{
+  if (qcode.empty())
+    return false;
+
+  size_t start = hidden_list.find_first_not_of(" \t,");
+  while (start != std::string_view::npos) {
+    const size_t end = hidden_list.find_first_of(" \t,", start);
+    const size_t token_len = end == std::string_view::npos
+      ? hidden_list.size() - start
+      : end - start;
+
+    if (token_len == qcode.size() &&
+        StringIsEqualIgnoreCase(hidden_list.data() + start,
+                                qcode.data(), qcode.size()))
+      return true;
+
+    if (end == std::string_view::npos)
+      break;
+
+    start = hidden_list.find_first_not_of(" \t,", end + 1);
+  }
+
+  return false;
+}
+
+[[nodiscard]]
+static unsigned
+CountNOTAMsWithQCodePrefix(std::string_view qcode) noexcept
+{
+  if (qcode.empty() || net_components == nullptr ||
+      net_components->notam == nullptr)
+    return 0;
+
+  unsigned count = 0;
+  try {
+    const auto snapshot = net_components->notam->GetSnapshot();
+    for (const auto &notam : snapshot.notams)
+      if (NOTAMFilter::IsQCodeHidden(notam.feature_type, qcode))
+        ++count;
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to count NOTAM Q-code");
+  }
+
+  return count;
+}
+
+static bool
+AddHiddenQCode(NOTAMSettings &settings, std::string_view qcode) noexcept
+{
+  if (qcode.empty() || HasHiddenQCodeToken(settings.hidden_qcodes, qcode))
+    return true;
+
+  const size_t length = settings.hidden_qcodes.length();
+  const size_t separator = length > 0 ? 1 : 0;
+  if (length + separator + qcode.size() + 1 >
+      settings.hidden_qcodes.capacity())
+    return false;
+
+  if (separator > 0)
+    settings.hidden_qcodes += ' ';
+
+  settings.hidden_qcodes += qcode;
+  return true;
+}
+
+static bool
+RemoveHiddenQCode(NOTAMSettings &settings, std::string_view qcode) noexcept
+{
+  if (qcode.empty())
+    return false;
+
+  StaticString<256> remaining;
+  bool removed = false;
+  std::string_view hidden_list = settings.hidden_qcodes;
+  size_t start = hidden_list.find_first_not_of(" \t,");
+  while (start != std::string_view::npos) {
+    const size_t end = hidden_list.find_first_of(" \t,", start);
+    const auto token = hidden_list.substr(start, end == std::string_view::npos
+                                          ? hidden_list.size() - start
+                                          : end - start);
+    const bool matches = token.size() <= qcode.size() &&
+      StringIsEqualIgnoreCase(token.data(), qcode.data(), token.size());
+
+    if (matches) {
+      removed = true;
+    } else {
+      if (!remaining.empty())
+        remaining += ' ';
+      remaining += token;
+    }
+
+    if (end == std::string_view::npos)
+      break;
+
+    start = hidden_list.find_first_not_of(" \t,", end + 1);
+  }
+
+  if (removed)
+    settings.hidden_qcodes = remaining;
+
+  return removed;
+}
+
+static void
+ApplyNOTAMFilterSettings(const NOTAMSettings &settings) noexcept
+{
+  Profile::Set(ProfileKeys::NOTAMHiddenQCodes, settings.hidden_qcodes);
+
+  if (net_components != nullptr && net_components->notam != nullptr)
+    net_components->notam->SetSettings(settings);
+
+  if (net_components != nullptr && net_components->notam != nullptr &&
+      data_components != nullptr && data_components->airspaces != nullptr) {
+    try {
+      const ScopeSuspendAllThreads suspend;
+      net_components->notam->UpdateAirspaces(*data_components->airspaces);
+      if (data_components->terrain != nullptr)
+        SetAirspaceGroundLevels(*data_components->airspaces,
+                                *data_components->terrain);
+    } catch (...) {
+      LogError(std::current_exception(),
+               "Failed to apply NOTAM Q-code filter");
+    }
+  }
 }
 
 
@@ -177,6 +313,7 @@ class NOTAMListWidget final : public ListWidget {
   std::vector<NOTAMStruct> items;
   TwoTextRowsRenderer row_renderer;
   Button *details_button = nullptr;
+  Button *filter_qcode_button = nullptr;
 
 public:
   NOTAMListWidget() = default;
@@ -189,13 +326,37 @@ public:
       details_button->SetEnabled(false);
   }
 
+  void SetFilterQCodeButton(Button *_filter_qcode_button) noexcept {
+    filter_qcode_button = _filter_qcode_button;
+    if (filter_qcode_button != nullptr)
+      filter_qcode_button->SetEnabled(false);
+  }
+
   void ShowDetails() noexcept {
     OnActivateItem(GetList().GetCursorIndex());
   }
 
+  void FilterSelectedQCode() noexcept;
+
   void UpdateButtons() noexcept {
+    const unsigned index = GetList().GetCursorIndex();
+
     if (details_button != nullptr)
-      details_button->SetEnabled(CanActivateItem(GetList().GetCursorIndex()));
+      details_button->SetEnabled(CanActivateItem(index));
+
+    if (filter_qcode_button != nullptr) {
+      const auto *notam = GetSelectableNOTAM(index);
+      const auto &settings =
+        CommonInterface::GetComputerSettings().airspace.notam;
+      const bool has_qcode = notam != nullptr && !notam->feature_type.empty();
+      filter_qcode_button->SetEnabled(has_qcode);
+      if (has_qcode)
+        filter_qcode_button->SetCaption(
+          NOTAMFilter::IsQCodeHidden(notam->feature_type,
+                                     settings.hidden_qcodes)
+          ? _("Show Q-code")
+          : _("Hide Q-code"));
+    }
   }
 
   /* virtual methods from class Widget */
@@ -208,10 +369,7 @@ public:
       UpdateList();
     } catch (...) {
       LogError(std::current_exception(), "Failed to update NOTAM list");
-      items.clear();
-      GetList().SetLength(1);
-      GetList().Invalidate();
-      UpdateButtons();
+      ResetListAfterUpdateFailure();
     }
   }
 
@@ -229,6 +387,18 @@ public:
   }
 
   void OnActivateItem(unsigned index) noexcept override;
+
+private:
+  void ResetListAfterUpdateFailure() noexcept {
+    items.clear();
+    GetList().SetLength(1);
+    GetList().Invalidate();
+    UpdateButtons();
+  }
+
+  const NOTAMStruct *GetSelectableNOTAM(unsigned index) const noexcept {
+    return CanActivateItem(index) ? &items[index] : nullptr;
+  }
 };
 
 void
@@ -391,6 +561,68 @@ NOTAMListWidget::OnActivateItem(unsigned i) noexcept
 }
 
 void
+NOTAMListWidget::FilterSelectedQCode() noexcept
+{
+  const auto *notam = GetSelectableNOTAM(GetList().GetCursorIndex());
+  if (notam == nullptr || notam->feature_type.empty())
+    return;
+
+  const auto qcode = std::string_view{notam->feature_type};
+  auto &settings = CommonInterface::SetComputerSettings().airspace.notam;
+
+  if (NOTAMFilter::IsQCodeHidden(qcode, settings.hidden_qcodes)) {
+    StaticString<512> message;
+    message.Format(_("Show Q-code %s?\n"
+                     "This will remove matching Q-code filters, which may "
+                     "also show other NOTAMs."),
+                   notam->feature_type.c_str());
+
+    if (ShowMessageBox(message.c_str(), _("NOTAM"),
+                       MB_YESNO | MB_ICONQUESTION) != IDYES)
+      return;
+
+    if (!RemoveHiddenQCode(settings, qcode))
+      return;
+
+    ApplyNOTAMFilterSettings(settings);
+    try {
+      UpdateList();
+    } catch (...) {
+      LogError(std::current_exception(), "Failed to refresh NOTAM list");
+      ResetListAfterUpdateFailure();
+    }
+    return;
+  }
+
+  const unsigned affected_count = CountNOTAMsWithQCodePrefix(qcode);
+  StaticString<512> message;
+  message.Format(_("Hide Q-code %s?\n"
+                   "This will hide %u currently loaded NOTAM(s) with a "
+                   "matching Q-code prefix from the map and mark them as "
+                   "filtered in the NOTAM list."),
+                 notam->feature_type.c_str(), affected_count);
+
+  if (ShowMessageBox(message.c_str(), _("NOTAM"),
+                     MB_YESNO | MB_ICONQUESTION) != IDYES)
+    return;
+
+  if (!AddHiddenQCode(settings, qcode)) {
+    ShowMessageBox(_("The hidden Q-code list is full. Remove unused filters "
+                     "in NOTAM settings first."),
+                   _("NOTAM"), MB_OK | MB_ICONEXCLAMATION);
+    return;
+  }
+
+  ApplyNOTAMFilterSettings(settings);
+  try {
+    UpdateList();
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to refresh NOTAM list");
+    ResetListAfterUpdateFailure();
+  }
+}
+
+void
 NOTAMListWidget::UpdateList()
 {
   items.clear();
@@ -492,6 +724,9 @@ ShowNOTAMListDialog(UI::SingleWindow &parent)
                       list_widget.release());
   list->SetDetailsButton(dialog.AddButton(_("Details"),
                                           [list](){ list->ShowDetails(); }));
+  list->SetFilterQCodeButton(
+    dialog.AddButton(_("Hide Q-code"),
+                     [list](){ list->FilterSelectedQCode(); }));
   dialog.AddButton(_("Close"), mrCancel);
   dialog.ShowModal();
 }

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -7,8 +7,10 @@
 #ifdef HAVE_HTTP
 
 #include "Dialogs/WidgetDialog.hpp"
+#include "Form/Button.hpp"
 #include "Widget/ListWidget.hpp"
 #include "ui/control/List.hpp"
+#include "ui/canvas/Canvas.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "Look/DialogLook.hpp"
 #include "util/Compiler.h"
@@ -20,6 +22,10 @@
 #include "NOTAM/NOTAM.hpp"
 #include "NOTAM/Filter.hpp"
 #include "NOTAM/NOTAMGlue.hpp"
+#include "NOTAM/Converter.hpp"
+#include "Airspace.hpp"
+#include "BackendComponents.hpp"
+#include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Interface.hpp"
 #include "util/StringFormat.hpp"
@@ -34,9 +40,45 @@
 #include <ctime>
 #include <iterator>
 #include <string>
+#include <string_view>
 
 // Use full struct name to avoid collision with AirspaceClass::NOTAM enum
 using NOTAMStruct = struct NOTAM;
+
+static void
+AppendFilterReason(std::string &text, const char *reason)
+{
+  if (!text.empty())
+    text += ", ";
+
+  text += reason;
+}
+
+[[nodiscard]]
+static std::string
+GetFilterReasons(const NOTAMStruct &notam,
+                 const NOTAMSettings &settings,
+                 std::chrono::system_clock::time_point now)
+{
+  std::string reasons;
+
+  if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I")
+    AppendFilterReason(reasons, _("IFR-only"));
+
+  if (settings.show_only_effective && !notam.IsActive(now))
+    AppendFilterReason(reasons, _("not effective"));
+
+  if (settings.max_radius_m > 0 &&
+      notam.geometry.radius_meters > settings.max_radius_m)
+    AppendFilterReason(reasons, _("radius"));
+
+  const auto &qcode = notam.feature_type;
+  if (!qcode.empty() &&
+      NOTAMFilter::IsQCodeHidden(qcode, settings.hidden_qcodes))
+    AppendFilterReason(reasons, _("Q-Code"));
+
+  return reasons;
+}
 
 // Return UTF-8 text safe for UI, or a placeholder if invalid.
 [[nodiscard]]
@@ -83,15 +125,78 @@ GetCurrentNOTAMTimeUTC() noexcept
     : std::chrono::system_clock::now();
 }
 
+[[nodiscard]]
+static std::string
+EllipsizeText(Canvas &canvas, const std::string &text,
+              const unsigned max_width)
+{
+  if (max_width == 0)
+    return {};
+
+  if (canvas.CalcTextWidth(text) <= max_width)
+    return text;
+
+  constexpr std::string_view ellipsis = "...";
+  const unsigned ellipsis_width = canvas.CalcTextWidth(ellipsis);
+  if (ellipsis_width >= max_width)
+    return std::string{ellipsis};
+
+  std::string result;
+  result.reserve(text.size());
+
+  for (std::string_view remaining = text; !remaining.empty();) {
+    const std::size_t sequence = SequenceLengthUTF8(remaining.front());
+    if (sequence == 0 || sequence > remaining.size())
+      break;
+
+    std::string candidate = result;
+    candidate.append(remaining.substr(0, sequence));
+    candidate += ellipsis;
+
+    if (canvas.CalcTextWidth(candidate) > max_width)
+      break;
+
+    result.append(remaining.substr(0, sequence));
+    remaining.remove_prefix(sequence);
+  }
+
+  result += ellipsis;
+  return result;
+}
+
+[[nodiscard]]
+static unsigned
+GetTextWidth(const PixelRect &rc, const TwoTextRowsRenderer &row_renderer)
+{
+  const int width = rc.GetWidth() - row_renderer.GetX();
+  return width > 0 ? unsigned(width) : 0u;
+}
+
 class NOTAMListWidget final : public ListWidget {
   static constexpr unsigned HEADER_COUNT = 4;
   std::vector<NOTAMStruct> items;
   TwoTextRowsRenderer row_renderer;
+  Button *details_button = nullptr;
 
 public:
   NOTAMListWidget() = default;
 
   void UpdateList();
+
+  void SetDetailsButton(Button *_details_button) noexcept {
+    details_button = _details_button;
+    if (details_button != nullptr)
+      details_button->SetEnabled(false);
+  }
+
+  void ShowDetails() noexcept {
+    OnActivateItem(GetList().GetCursorIndex());
+  }
+
+  void UpdateButtons() noexcept {
+    if (details_button != nullptr)
+      details_button->SetEnabled(CanActivateItem(GetList().GetCursorIndex()));
+  }
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent,
@@ -106,6 +211,7 @@ public:
       items.clear();
       GetList().SetLength(1);
       GetList().Invalidate();
+      UpdateButtons();
     }
   }
 
@@ -114,10 +220,15 @@ public:
                    unsigned idx) noexcept override;
 
   /* virtual methods from ListCursorHandler */
-  bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept
-    override {
-    return false; // No activation needed for NOTAM list
+  void OnCursorMoved([[maybe_unused]] unsigned index) noexcept override {
+    UpdateButtons();
   }
+
+  bool CanActivateItem(unsigned index) const noexcept override {
+    return index >= HEADER_COUNT && index < items.size();
+  }
+
+  void OnActivateItem(unsigned index) noexcept override;
 };
 
 void
@@ -194,10 +305,19 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       if (is_filtered) {
         first_row_text += " • ";
         first_row_text += _("Filtered");
+        const auto reasons = GetFilterReasons(notam, settings, now);
+        if (!reasons.empty()) {
+          first_row_text += ": ";
+          first_row_text += reasons;
+        }
       }
     }
 
-    StaticString<256> first_row;
+    canvas.Select(row_renderer.GetFirstFont());
+    first_row_text =
+      EllipsizeText(canvas, first_row_text, GetTextWidth(rc, row_renderer));
+
+    StaticString<512> first_row;
     CopyTruncateStringUTF8({first_row.buffer(), first_row.capacity()},
                  first_row_text.c_str(),
                  first_row.capacity() - 1);
@@ -225,19 +345,14 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       for (auto &ch : text) {
         if (ch == '\n' || ch == '\r') ch = ' ';
       }
-      // Truncate if too long (byte-limited, UTF-8 safe)
-      constexpr std::size_t max_bytes = 120;
-      static_assert(max_bytes >= 3, "max_bytes must leave room for ellipsis");
-      if (text.length() > max_bytes) {
-        const std::size_t truncate_at =
-          TruncateStringUTF8(text.c_str(), max_bytes - 3, max_bytes - 3);
-        text.resize(truncate_at);
-        text += "...";
-      }
       second_row_text += text;
     }
 
     if (!second_row_text.empty()) {
+      canvas.Select(row_renderer.GetSecondFont());
+      second_row_text =
+        EllipsizeText(canvas, second_row_text, GetTextWidth(rc, row_renderer));
+
       StaticString<512> second_row;
       CopyTruncateStringUTF8({second_row.buffer(), second_row.capacity()},
                              second_row_text.c_str(),
@@ -252,6 +367,26 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 #endif
     row_renderer.DrawFirstRow(canvas, rc, _("NOTAM render error"));
     row_renderer.DrawSecondRow(canvas, rc, "");
+  }
+}
+
+void
+NOTAMListWidget::OnActivateItem(unsigned i) noexcept
+{
+  if (!CanActivateItem(i))
+    return;
+
+  try {
+    auto airspace = NOTAMConverter::BuildNOTAMAirspace(items[i], true);
+    if (!airspace)
+      return;
+
+    dlgAirspaceDetails(std::move(airspace),
+                       backend_components != nullptr
+                       ? backend_components->GetAirspaceWarnings()
+                       : nullptr);
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to show NOTAM details");
   }
 }
 
@@ -344,6 +479,7 @@ NOTAMListWidget::UpdateList()
 #endif
   GetList().SetLength(std::max(static_cast<size_t>(1), items.size()));
   GetList().Invalidate();
+  UpdateButtons();
 }
 
 void
@@ -351,8 +487,11 @@ ShowNOTAMListDialog(UI::SingleWindow &parent)
 {
   const DialogLook &look = UIGlobals::GetDialogLook();
   auto list_widget = std::make_unique<NOTAMListWidget>();
+  NOTAMListWidget *const list = list_widget.get();
   WidgetDialog dialog(WidgetDialog::Auto{}, parent, look, _("NOTAMs"),
                       list_widget.release());
+  list->SetDetailsButton(dialog.AddButton(_("Details"),
+                                          [list](){ list->ShowDetails(); }));
   dialog.AddButton(_("Close"), mrCancel);
   dialog.ShowModal();
 }

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -314,6 +314,8 @@ class NOTAMListWidget final : public ListWidget {
   TwoTextRowsRenderer row_renderer;
   Button *details_button = nullptr;
   Button *filter_qcode_button = nullptr;
+  Button *toggle_filter_button = nullptr;
+  bool show_all = false;
 
 public:
   NOTAMListWidget() = default;
@@ -332,11 +334,27 @@ public:
       filter_qcode_button->SetEnabled(false);
   }
 
+  void SetToggleFilterButton(Button *_toggle_filter_button) noexcept {
+    toggle_filter_button = _toggle_filter_button;
+    UpdateToggleFilterButton();
+  }
+
   void ShowDetails() noexcept {
     OnActivateItem(GetList().GetCursorIndex());
   }
 
   void FilterSelectedQCode() noexcept;
+
+  void ToggleFilter() noexcept {
+    show_all = !show_all;
+    UpdateToggleFilterButton();
+    try {
+      UpdateList();
+    } catch (...) {
+      LogError(std::current_exception(), "Failed to toggle NOTAM filter");
+      ResetListAfterUpdateFailure();
+    }
+  }
 
   void UpdateButtons() noexcept {
     const unsigned index = GetList().GetCursorIndex();
@@ -394,6 +412,13 @@ private:
     GetList().SetLength(1);
     GetList().Invalidate();
     UpdateButtons();
+  }
+
+  void UpdateToggleFilterButton() noexcept {
+    if (toggle_filter_button != nullptr)
+      toggle_filter_button->SetCaption(show_all
+                                       ? _("Hide Filtered")
+                                       : _("Show All"));
   }
 
   const NOTAMStruct *GetSelectableNOTAM(unsigned index) const noexcept {
@@ -696,7 +721,15 @@ NOTAMListWidget::UpdateList()
     };
     items.insert(items.end(), headers.begin(), headers.end());
     
-    items.insert(items.end(), notams.begin(), notams.end());
+    if (!show_all) {
+      std::copy_if(notams.begin(), notams.end(), std::back_inserter(items),
+                   [&](const auto &notam) {
+                     return NOTAMFilter::ShouldDisplay(notam, settings, now,
+                                                       false);
+                   });
+    } else {
+      items.insert(items.end(), notams.begin(), notams.end());
+    }
   } else {
     LogFmt("NOTAM: UpdateList - net_components or notam is null");
   }
@@ -727,6 +760,9 @@ ShowNOTAMListDialog(UI::SingleWindow &parent)
   list->SetFilterQCodeButton(
     dialog.AddButton(_("Hide Q-code"),
                      [list](){ list->FilterSelectedQCode(); }));
+  list->SetToggleFilterButton(
+    dialog.AddButton(_("Show All"),
+                     [list](){ list->ToggleFilter(); }));
   dialog.AddButton(_("Close"), mrCancel);
   dialog.ShowModal();
 }

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -451,7 +451,7 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 
       // Add status indicator
       const auto now = GetCurrentNOTAMTimeUTC();
-      const bool is_perm = notam.end_time >= NOTAMTime::PermanentEndTime();
+      const bool is_perm = notam.end_time_permanent;
       if (now < notam.start_time) {
         const auto starts_in = FormatRelativeNotamTime(notam.start_time - now);
         StaticString<64> status;

--- a/src/Dialogs/Airspace/NOTAMList.cpp
+++ b/src/Dialogs/Airspace/NOTAMList.cpp
@@ -62,25 +62,27 @@ AppendFilterReason(std::string &text, const char *reason)
 
 [[nodiscard]]
 static std::string
-GetFilterReasons(const NOTAMStruct &notam,
-                 const NOTAMSettings &settings,
-                 std::chrono::system_clock::time_point now)
+FormatFilterReasons(const NOTAMStruct &notam,
+                    const NOTAMSettings &settings,
+                    std::chrono::system_clock::time_point now)
 {
   std::string reasons;
+  const auto filter_reasons = NOTAMFilter::Evaluate(notam, settings, now);
 
-  if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I")
+  if (NOTAMFilter::HasFilterReason(filter_reasons,
+                                   NOTAMFilter::FilterReason::IFR))
     AppendFilterReason(reasons, _("IFR-only"));
 
-  if (settings.show_only_effective && !notam.IsActive(now))
+  if (NOTAMFilter::HasFilterReason(filter_reasons,
+                                   NOTAMFilter::FilterReason::TIME))
     AppendFilterReason(reasons, _("not effective"));
 
-  if (settings.max_radius_m > 0 &&
-      notam.geometry.radius_meters > settings.max_radius_m)
+  if (NOTAMFilter::HasFilterReason(filter_reasons,
+                                   NOTAMFilter::FilterReason::RADIUS))
     AppendFilterReason(reasons, _("radius"));
 
-  const auto &qcode = notam.feature_type;
-  if (!qcode.empty() &&
-      NOTAMFilter::IsQCodeHidden(qcode, settings.hidden_qcodes))
+  if (NOTAMFilter::HasFilterReason(filter_reasons,
+                                   NOTAMFilter::FilterReason::QCODE))
     AppendFilterReason(reasons, _("Q-Code"));
 
   return reasons;
@@ -500,7 +502,7 @@ NOTAMListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       if (is_filtered) {
         first_row_text += " • ";
         first_row_text += _("Filtered");
-        const auto reasons = GetFilterReasons(notam, settings, now);
+      const auto reasons = FormatFilterReasons(notam, settings, now);
         if (!reasons.empty()) {
           first_row_text += ": ";
           first_row_text += reasons;

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -329,7 +329,7 @@ NOTAMDetailsWidget::AddNOTAMValidity(
   AddReadOnly(_("Valid From"), nullptr, time_buffer);
 
   // Check if it's a far future date (PERM = permanent)
-  if (notam_opt->end_time >= NOTAMTime::PermanentEndTime()) {
+  if (notam_opt->end_time_permanent) {
     AddReadOnly(_("Valid Until"), nullptr, "PERM");
   } else {
     BrokenDateTime end_dt(notam_opt->end_time);
@@ -363,7 +363,7 @@ NOTAMDetailsWidget::AddNOTAMValidity(
       }
     }
     buffer.Format(_("Starts in %s"), time_str.c_str());
-  } else if (now > notam_opt->end_time) {
+  } else if (!notam_opt->end_time_permanent && now > notam_opt->end_time) {
     // Expired
     const auto expired_ago =
       std::chrono::duration_cast<std::chrono::minutes>(

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -159,6 +159,7 @@ void eventMarkLocation(const char *misc);
 void eventPilotEvent(const char *misc);
 void eventMode(const char *misc);
 void eventNearestAirspaceDetails(const char *misc);
+void eventNOTAMList(const char *misc);
 void eventNearestWaypointDetails(const char *misc);
 void eventNearestMapItems(const char *misc);
 void eventNull(const char *misc);

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -33,6 +33,9 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "Dialogs/Error.hpp"
 #include "Dialogs/Device/Vega/SwitchesDialog.hpp"
 #include "Dialogs/Airspace/Airspace.hpp"
+#ifdef HAVE_HTTP
+#include "Dialogs/Airspace/NOTAMList.hpp"
+#endif
 #include "Dialogs/Task/TaskDialogs.hpp"
 #include "Dialogs/Traffic/TrafficDialogs.hpp"
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
@@ -533,6 +536,18 @@ void
 InputEvents::eventGestureHelp([[maybe_unused]] const char *misc)
 {
   dlgGestureHelpShowModal();
+}
+
+// NOTAMList
+// Opens the list of loaded NOTAMs
+void
+InputEvents::eventNOTAMList([[maybe_unused]] const char *misc)
+{
+#ifdef HAVE_HTTP
+  ShowNOTAMListDialog(*CommonInterface::main_window);
+#else
+  Message::AddMessage(_("NOTAM list requires HTTP support"));
+#endif
 }
 
 // NearestWaypointDetails

--- a/src/NOTAM/Client.cpp
+++ b/src/NOTAM/Client.cpp
@@ -127,16 +127,8 @@ ParseFlightLevelLimit(const std::string &fl_value)
 namespace NOTAMClient {
 
 static std::chrono::system_clock::time_point
-ParseNOTAMTime(const std::string &iso_string, const bool allow_permanent)
+ParseNOTAMTime(const std::string &iso_string)
 {
-  if (iso_string == "PERM") {
-    if (!allow_permanent)
-      throw std::runtime_error("Invalid ISO8601 timestamp '" + iso_string +
-                               "': PERM is only valid as an end time");
-
-    return NOTAMTime::PermanentEndTime();
-  }
-
   return ParseISO8601Utc(iso_string);
 }
 
@@ -169,12 +161,16 @@ ParseNOTAMProperties(NOTAM &notam, const boost::json::object &notam_obj)
   
   if (auto it = notam_obj.find("effectiveStart"); it != notam_obj.end()) {
     notam.start_time =
-      ParseNOTAMTime(boost::json::value_to<std::string>(it->value()), false);
+      ParseNOTAMTime(boost::json::value_to<std::string>(it->value()));
   }
   
   if (auto it = notam_obj.find("effectiveEnd"); it != notam_obj.end()) {
-    notam.end_time =
-      ParseNOTAMTime(boost::json::value_to<std::string>(it->value()), true);
+    const auto value = boost::json::value_to<std::string>(it->value());
+    if (value == "PERM") {
+      notam.end_time_permanent = true;
+    } else {
+      notam.end_time = ParseNOTAMTime(value);
+    }
   }
   
   // Parse altitude limits using airspace altitude parsing system

--- a/src/NOTAM/Converter.cpp
+++ b/src/NOTAM/Converter.cpp
@@ -49,7 +49,8 @@ ConvertNOTAMToAirspace(const struct NOTAM &notam,
 }
 
 AirspacePtr
-BuildNOTAMAirspace(const struct NOTAM &notam)
+BuildNOTAMAirspace(const struct NOTAM &notam,
+                   const bool allow_oversized_circles)
 {
   try {
     std::unique_ptr<AbstractAirspace> airspace;
@@ -70,7 +71,7 @@ BuildNOTAMAirspace(const struct NOTAM &notam)
         );
         break;
         
-      case NOTAM::NOTAMGeometry::Type::CIRCLE:
+      case NOTAM::NOTAMGeometry::Type::CIRCLE: {
         // Validate radius before creating circle
         if (!std::isfinite(notam.geometry.radius_meters) ||
             notam.geometry.radius_meters <= 0) {
@@ -80,12 +81,21 @@ BuildNOTAMAirspace(const struct NOTAM &notam)
                  notam.number.c_str());
           return {};
         }
-        if (notam.geometry.radius_meters > MAX_CIRCLE_RADIUS_METERS) {
+        double radius_meters = notam.geometry.radius_meters;
+        if (radius_meters > MAX_CIRCLE_RADIUS_METERS) {
+          if (!allow_oversized_circles) {
+            LogFmt("NOTAM: Circle radius {:.1f} exceeds max {:.0f} for "
+                   "NOTAM {}/{}, skipping",
+                   radius_meters, MAX_CIRCLE_RADIUS_METERS,
+                   notam.id.c_str(), notam.number.c_str());
+            return {};
+          }
+
           LogFmt("NOTAM: Circle radius {:.1f} exceeds max {:.0f} for "
-                 "NOTAM {}/{}, skipping",
-                 notam.geometry.radius_meters, MAX_CIRCLE_RADIUS_METERS,
+                 "NOTAM {}/{}, capping for details",
+                 radius_meters, MAX_CIRCLE_RADIUS_METERS,
                  notam.id.c_str(), notam.number.c_str());
-          return {};
+          radius_meters = MAX_CIRCLE_RADIUS_METERS;
         }
         if (!notam.geometry.center.Check()) {
           LogFmt("NOTAM: Invalid circle coordinates for NOTAM {}/{}, skipping",
@@ -95,9 +105,10 @@ BuildNOTAMAirspace(const struct NOTAM &notam)
 
         airspace = std::make_unique<AirspaceCircle>(
           notam.geometry.center,
-          notam.geometry.radius_meters
+          radius_meters
         );
         break;
+      }
         
       case NOTAM::NOTAMGeometry::Type::POLYGON:
         if (notam.geometry.polygon_points.size() >= 3) {

--- a/src/NOTAM/Converter.hpp
+++ b/src/NOTAM/Converter.hpp
@@ -33,10 +33,14 @@ ConvertNOTAMToAirspace(const struct NOTAM &notam, Airspaces &airspaces);
  * Convert a NOTAM to an airspace object.
  *
  * @param notam NOTAM to convert
+ * @param allow_oversized_circles true to cap circles larger than
+ * MAX_CIRCLE_RADIUS_METERS instead of rejecting them; intended for temporary
+ * details display, not airspace database injection
  * @return AirspacePtr on success, empty on failure
  */
 [[nodiscard]] AirspacePtr
-BuildNOTAMAirspace(const struct NOTAM &notam);
+BuildNOTAMAirspace(const struct NOTAM &notam,
+                   bool allow_oversized_circles = false);
 
 /**
  * Convert multiple NOTAMs to airspace format

--- a/src/NOTAM/Filter.cpp
+++ b/src/NOTAM/Filter.cpp
@@ -47,13 +47,37 @@ IsQCodeHidden(std::string_view qcode,
   return false;
 }
 
+FilterReasons
+Evaluate(const struct NOTAM &notam, const NOTAMSettings &settings,
+         std::chrono::system_clock::time_point now) noexcept
+{
+  FilterReasons reasons = 0;
+
+  if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I")
+    reasons |= static_cast<FilterReasons>(FilterReason::IFR);
+
+  if (settings.show_only_effective && !notam.IsActive(now))
+    reasons |= static_cast<FilterReasons>(FilterReason::TIME);
+
+  if (settings.max_radius_m > 0 &&
+      notam.geometry.radius_meters > settings.max_radius_m)
+    reasons |= static_cast<FilterReasons>(FilterReason::RADIUS);
+
+  if (!notam.feature_type.empty() &&
+      IsQCodeHidden(notam.feature_type, settings.hidden_qcodes))
+    reasons |= static_cast<FilterReasons>(FilterReason::QCODE);
+
+  return reasons;
+}
+
 bool
 ShouldDisplay(const struct NOTAM &notam, const NOTAMSettings &settings,
               std::chrono::system_clock::time_point now,
               bool log) noexcept
 {
-  // Check IFR filter (I=IFR-only, V=VFR-only, IV=both)
-  if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I") {
+  const auto reasons = Evaluate(notam, settings, now);
+
+  if (HasFilterReason(reasons, FilterReason::IFR)) {
     if (log) {
       LogDebug("NOTAM Filter: {} is IFR-only traffic ({}), filtered out",
                notam.number.c_str(), notam.traffic.c_str());
@@ -61,20 +85,15 @@ ShouldDisplay(const struct NOTAM &notam, const NOTAMSettings &settings,
     return false;
   }
 
-  // Check if currently effective (if filter enabled)
-  if (settings.show_only_effective) {
-    if (!notam.IsActive(now)) {
-      if (log) {
-        LogDebug("NOTAM Filter: {} not currently effective, filtered out",
-                 notam.number.c_str());
-      }
-      return false;
+  if (HasFilterReason(reasons, FilterReason::TIME)) {
+    if (log) {
+      LogDebug("NOTAM Filter: {} not currently effective, filtered out",
+               notam.number.c_str());
     }
+    return false;
   }
 
-  // Check radius filter
-  if (settings.max_radius_m > 0 &&
-      notam.geometry.radius_meters > settings.max_radius_m) {
+  if (HasFilterReason(reasons, FilterReason::RADIUS)) {
     if (log) {
       LogDebug("NOTAM Filter: {} radius {:.0f} m exceeds limit {} m, "
                "filtered out",
@@ -85,15 +104,12 @@ ShouldDisplay(const struct NOTAM &notam, const NOTAMSettings &settings,
   }
 
   const auto &qcode = notam.feature_type;
-  if (qcode.empty())
-    return true;
-
-  if (log) {
+  if (!qcode.empty() && log) {
     LogDebug("NOTAM Filter: {} Q-code='{}'", notam.number.c_str(),
              qcode.c_str());
   }
 
-  if (IsQCodeHidden(qcode, settings.hidden_qcodes)) {
+  if (HasFilterReason(reasons, FilterReason::QCODE)) {
     if (log) {
       LogDebug("NOTAM Filter: {} Q-code {} is hidden",
                notam.number.c_str(), qcode.c_str());
@@ -101,7 +117,7 @@ ShouldDisplay(const struct NOTAM &notam, const NOTAMSettings &settings,
     return false;
   }
 
-  return true;
+  return reasons == 0;
 }
 
 unsigned
@@ -125,25 +141,21 @@ ComputeStats(const std::vector<struct NOTAM> &notams,
   FilterStats stats;
   stats.total = static_cast<unsigned>(notams.size());
 
-  const char *const hidden_list = settings.hidden_qcodes.c_str();
-
   for (const auto &notam : notams) {
-    if (!settings.show_ifr && !notam.traffic.empty() && notam.traffic == "I")
+    const auto reasons = Evaluate(notam, settings, now);
+    if (HasFilterReason(reasons, FilterReason::IFR))
       ++stats.filtered_by_ifr;
 
-    if (settings.show_only_effective && !notam.IsActive(now))
+    if (HasFilterReason(reasons, FilterReason::TIME))
       ++stats.filtered_by_time;
 
-    const auto &qcode = notam.feature_type;
-    if (!qcode.empty() &&
-        IsQCodeHidden(qcode, hidden_list))
+    if (HasFilterReason(reasons, FilterReason::QCODE))
       ++stats.filtered_by_qcode;
 
-    if (settings.max_radius_m > 0 &&
-        notam.geometry.radius_meters > settings.max_radius_m)
+    if (HasFilterReason(reasons, FilterReason::RADIUS))
       ++stats.filtered_by_radius;
 
-    if (ShouldDisplay(notam, settings, now, false))
+    if (reasons == 0)
       ++stats.final_count;
   }
 

--- a/src/NOTAM/Filter.hpp
+++ b/src/NOTAM/Filter.hpp
@@ -12,6 +12,22 @@
 
 namespace NOTAMFilter {
 
+enum class FilterReason : unsigned {
+  IFR = 1u << 0,
+  TIME = 1u << 1,
+  QCODE = 1u << 2,
+  RADIUS = 1u << 3,
+};
+
+using FilterReasons = unsigned;
+
+[[nodiscard]]
+constexpr bool
+HasFilterReason(FilterReasons reasons, FilterReason reason) noexcept
+{
+  return (reasons & static_cast<FilterReasons>(reason)) != 0;
+}
+
 struct FilterStats {
   unsigned total = 0;
   unsigned filtered_by_ifr = 0;
@@ -30,6 +46,14 @@ struct FilterStats {
 [[gnu::pure]]
 bool IsQCodeHidden(std::string_view qcode,
                    std::string_view hidden_list) noexcept;
+
+/**
+ * Evaluates all active filters and returns the matching suppression reasons.
+ */
+[[nodiscard]]
+FilterReasons Evaluate(const struct NOTAM &notam,
+                       const NOTAMSettings &settings,
+                       std::chrono::system_clock::time_point now) noexcept;
 
 /**
  * Returns false when @p notam is suppressed by IFR, effective-time, radius or

--- a/src/NOTAM/NOTAM.hpp
+++ b/src/NOTAM/NOTAM.hpp
@@ -6,24 +6,8 @@
 #include "Engine/Airspace/AirspaceAltitude.hpp"
 #include "Geo/GeoPoint.hpp"
 #include <chrono>
-#include <cstdint>
 #include <vector>
 #include <string>
-
-namespace NOTAMTime {
-
-/// Seconds since Unix epoch for 2100-01-01T00:00:00Z.
-constexpr std::int64_t PERMANENT_END_EPOCH_SECONDS = 4102444800LL;
-
-constexpr std::chrono::system_clock::time_point
-PermanentEndTime() noexcept
-{
-  return std::chrono::system_clock::time_point{
-    std::chrono::seconds{PERMANENT_END_EPOCH_SECONDS}
-  };
-}
-
-} // namespace NOTAMTime
 
 namespace NOTAMAltitude {
 
@@ -67,6 +51,9 @@ struct NOTAM {
   
   /** End time of the NOTAM validity */
   std::chrono::system_clock::time_point end_time;
+
+  /** Whether the API specified a permanent ("PERM") end time. */
+  bool end_time_permanent = false;
   
   /** Geographic area affected by the NOTAM */
   struct NOTAMGeometry {
@@ -118,9 +105,8 @@ struct NOTAM {
    * Check if this NOTAM is currently active
    */
   bool IsActive(std::chrono::system_clock::time_point now) const noexcept {
-    const auto permanent_end = NOTAMTime::PermanentEndTime();
     return now >= start_time &&
-      (end_time >= permanent_end || now <= end_time);
+      (end_time_permanent || now <= end_time);
   }
   
 };

--- a/test/src/TestNOTAM.cpp
+++ b/test/src/TestNOTAM.cpp
@@ -89,7 +89,7 @@ main()
       R"({"type":"GeometryCollection","geometries":[{"type":"Point","coordinates":[8.522111,47.973519]}]})")));
 
     ok1(notams.size() == 1);
-    ok1(notams.size() == 1 && notams[0].end_time == NOTAMTime::PermanentEndTime());
+    ok1(notams.size() == 1 && notams[0].end_time_permanent);
   }
 
   {
@@ -295,7 +295,7 @@ main()
   {
     NOTAM notam{};
     notam.start_time = now - hours(1);
-    notam.end_time = NOTAMTime::PermanentEndTime() + seconds(1);
+    notam.end_time_permanent = true;
 
     ok1(notam.IsActive(now));
   }

--- a/test/src/TestNOTAM.cpp
+++ b/test/src/TestNOTAM.cpp
@@ -67,7 +67,7 @@ MetadataValid(std::string_view json)
 int
 main()
 {
-  plan_tests(62);
+  plan_tests(64);
 
   const auto now = system_clock::now();
 
@@ -268,6 +268,11 @@ main()
     notam.feature_type = "QMRLC";
     notam.geometry.radius_meters = 1000;
 
+    const auto reasons = NOTAMFilter::Evaluate(notam, settings, now);
+    ok1(NOTAMFilter::HasFilterReason(reasons,
+                                     NOTAMFilter::FilterReason::IFR));
+    ok1(NOTAMFilter::HasFilterReason(reasons,
+                                     NOTAMFilter::FilterReason::QCODE));
     ok1(!NOTAMFilter::ShouldDisplay(notam, settings, now, false));
 
     notam.feature_type = "QWERT";


### PR DESCRIPTION
Expose the NOTAM list from the Info menu and allow rows to open their details. Filtered rows now show the filter reason so suppressed NOTAMs can still be inspected from the list.

Use a details-only conversion mode for oversized circles so the details dialog can open without changing the stricter map injection behavior.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Info-view shortcut to open the full NOTAM list (requires HTTP support).
  * Enhanced the NOTAM list with richer “why filtered” explanations, a show-all toggle, and improved Q-code show/hide controls (including persistence).
  * Improved **Details** for the selected NOTAM with safer, more accurate selection/activation behavior.
* **Bug Fixes**
  * Corrected permanent (“PERM”) NOTAM handling end-to-end (parsing, active/expired status, and “Valid Until” display).
  * Improved NOTAM list text sizing/truncation (UTF-8-safe) and refined activation so only actual NOTAM rows are actionable.
* **Maintenance**
  * Improved handling of oversized circle NOTAMs by capping radii for temporary display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->