### PR TITLE
Fix duplicate file display on windows and reduce hard coded file extensions

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -368,6 +368,7 @@ $(eval $(call link-program,TestTaskFileSeeYouParsing,TEST_TASKFILE_SEEYOU_PARSIN
 TEST_PLANES_SOURCES = \
 	$(SRC)/Polar/Parser.cpp \
 	$(SRC)/Plane/PlaneFileGlue.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(TEST_SRC_DIR)/FakeLocalPath.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -959,6 +960,7 @@ $(eval $(call link-program,TestTrace,TEST_TRACE))
 
 FLIGHT_TABLE_SOURCES = \
 	$(SRC)/IGC/IGCParser.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(TEST_SRC_DIR)/FlightTable.cpp
 FLIGHT_TABLE_DEPENDS = GEO MATH IO OS UTIL
 $(eval $(call link-program,FlightTable,FLIGHT_TABLE))

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
@@ -375,7 +375,7 @@ ShowExportFlightsDialog()
   auto logs_path = MakeLocalPath("logs");
   if (logs_path != nullptr && Directory::Exists(logs_path)) {
     ScanFilesIntoDataField(logs_path, *df,
-                           {"*.igc", "*.nmea"}, true);
+                           {FileType::IGC, FileType::NMEA}, true);
   }
 
   auto container = std::make_unique<FlightContainer>(*df);

--- a/src/Dialogs/DataManagement/FileTransferUtil.cpp
+++ b/src/Dialogs/DataManagement/FileTransferUtil.cpp
@@ -7,6 +7,27 @@
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
 
+#include <cstring>
+
+namespace {
+
+static void
+VisitFileTypePatterns(Path path, File::Visitor &visitor,
+                      std::initializer_list<FileType> file_types,
+                      bool recursive) noexcept
+{
+  for (const auto file_type : file_types) {
+    const char *patterns = GetFileTypePatterns(file_type);
+    size_t length;
+    while ((length = strlen(patterns)) > 0) {
+      Directory::VisitSpecificFiles(path, patterns, visitor, recursive);
+      patterns += length + 1;
+    }
+  }
+}
+
+} // namespace
+
 AllocatedPath
 BuildTargetDirectory(Path target, std::string_view subfolder) noexcept
 {
@@ -42,6 +63,26 @@ ScanFilesIntoDataField(const AllocatedPath &path, MultiFileDataField &df,
     std::string pattern_str(pattern);
     Directory::VisitSpecificFiles(path, pattern_str.c_str(), scanner, recursive);
   }
+
+  df.GetFileDataField().Sort(FileDataField::SortOrder::DESCENDING);
+}
+
+void
+ScanFilesIntoDataField(const AllocatedPath &path, MultiFileDataField &df,
+                       std::initializer_list<FileType> file_types,
+                       bool recursive) noexcept
+{
+  struct FileScanner : File::Visitor {
+    MultiFileDataField &df;
+    explicit FileScanner(MultiFileDataField &d) : df(d) {}
+    void Visit(Path file, Path /*filename*/) override {
+      if (file == nullptr)
+        return;
+      df.GetFileDataField().ForceModify(file);
+    }
+  } scanner(df);
+
+  VisitFileTypePatterns(path, scanner, file_types, recursive);
 
   df.GetFileDataField().Sort(FileDataField::SortOrder::DESCENDING);
 }

--- a/src/Dialogs/DataManagement/FileTransferUtil.hpp
+++ b/src/Dialogs/DataManagement/FileTransferUtil.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "system/Path.hpp"
+#include "Repository/FileType.hpp"
 
 #include <initializer_list>
 #include <string_view>
@@ -22,4 +23,9 @@ BuildTargetDirectory(Path target, std::string_view subfolder) noexcept;
 void
 ScanFilesIntoDataField(const AllocatedPath &path, MultiFileDataField &df,
                        std::initializer_list<std::string_view> patterns,
+                       bool recursive = true) noexcept;
+
+void
+ScanFilesIntoDataField(const AllocatedPath &path, MultiFileDataField &df,
+                       std::initializer_list<FileType> file_types,
                        bool recursive = true) noexcept;

--- a/src/Dialogs/FilePicker.cpp
+++ b/src/Dialogs/FilePicker.cpp
@@ -23,18 +23,19 @@ FilePicker(const char *caption, FileDataField &df, const char *help_text,
 
   const char *extra_caption = nullptr;
 #ifdef HAVE_DOWNLOAD_MANAGER
+  const auto file_type = df.GetFileType();
   // with FileType::IGC don't show the 'Download'-Button!
-  if (df.GetFileType() != FileType::IGC &&
-    df.GetFileType() != FileType::UNKNOWN &&
-    Net::DownloadManager::IsAvailable())
-      extra_caption = _("Download");
+  if (file_type != FileType::IGC &&
+      file_type != FileType::UNKNOWN &&
+      Net::DownloadManager::IsAvailable())
+    extra_caption = _("Download");
 #endif
 
   int i = ComboPicker(caption, combo_list, help_text, false, extra_caption);
 
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (i == -2) {
-    const auto path = DownloadFilePicker(df.GetFileType());
+    const auto path = DownloadFilePicker(file_type);
     if (path == nullptr)
       return false;
 

--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -10,6 +10,7 @@
 #include "Replay/Replay.hpp"
 #include "Form/DataField/Base.hpp"
 #include "Language/Language.hpp"
+#include "Repository/FileType.hpp"
 
 class ReplayControlWidget final
   : public RowFormWidget
@@ -49,7 +50,7 @@ ReplayControlWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   AddFile(_("File"),
           _("Name of file to replay. May be an IGC file (.igc) or a raw NMEA log file (.nmea). Leave blank to run the demo."),
           {},
-          "*.nmea\0*.igc\0",
+          {FileType::NMEA, FileType::IGC},
           true);
   LoadValue(FILE, replay.GetFilename());
 

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -55,7 +55,7 @@ public:
 
   void Visit(Path path, Path filename) override {
     bool skip = IsInternalFile(filename.c_str());
-    if (skip && datafield.GetFileType() == FileType::CHECKLIST &&
+    if (skip && datafield.HasFileType(FileType::CHECKLIST) &&
         StringIsEqual(filename.c_str(), "xcsoar-checklist.txt"))
       skip = false;
     if (!skip)
@@ -76,9 +76,45 @@ FileDataField::FileDataField(DataFieldListener *listener) noexcept
   :DataField(Type::FILE, true, listener),
    // Set selection to zero
    current_index(0),
-   file_type(FileType::UNKNOWN),
    loaded(false), postponed_sort(SortOrder::NO_ORDER),
-   postponed_value(nullptr) {}
+   postponed_value(nullptr)
+{
+  file_types.append() = FileType::UNKNOWN;
+}
+
+void
+FileDataField::SetFileTypes(std::initializer_list<FileType> _file_types) noexcept
+{
+  file_types.clear();
+
+  for (const auto type : _file_types) {
+    if (file_types.full())
+      break;
+
+    bool duplicate = false;
+    for (const auto existing : file_types)
+      if (existing == type) {
+        duplicate = true;
+        break;
+      }
+
+    if (!duplicate)
+      file_types.append() = type;
+  }
+
+  if (file_types.empty())
+    file_types.append() = FileType::UNKNOWN;
+}
+
+bool
+FileDataField::HasFileType(FileType type) const noexcept
+{
+  for (const auto candidate : file_types)
+    if (candidate == type)
+      return true;
+
+  return false;
+}
 
 void
 FileDataField::ScanDirectoryTop(const char *filter) noexcept
@@ -94,20 +130,52 @@ FileDataField::ScanDirectoryTop(const char *filter) noexcept
 
   FileVisitor fv(*this);
 
-  const auto subdir = GetFileTypeDefaultDir(file_type);
-  if (file_type != FileType::UNKNOWN && subdir != nullptr) {
+  bool has_typed_dir = false;
+  for (const auto type : file_types) {
+    const auto subdir = GetFileTypeDefaultDir(type);
+    if (type != FileType::UNKNOWN && subdir != nullptr) {
+      has_typed_dir = true;
+      break;
+    }
+  }
+
+  if (has_typed_dir) {
     Directory::VisitSpecificFiles(GetPrimaryDataPath(), filter, fv, false);
 
-    const auto typed_path = LocalPath(subdir);
-    if (typed_path != nullptr && Directory::Exists(typed_path))
+    StaticArray<AllocatedPath, 8> visited_paths;
+    const auto was_visited = [&visited_paths](const AllocatedPath &path) {
+      for (const auto &visited_path : visited_paths)
+        if (visited_path == path)
+          return true;
+
+      return false;
+    };
+
+    for (const auto type : file_types) {
+      const auto subdir = GetFileTypeDefaultDir(type);
+      if (type == FileType::UNKNOWN || subdir == nullptr)
+        continue;
+
+      auto typed_path = LocalPath(subdir);
+      if (typed_path == nullptr || !Directory::Exists(typed_path))
+        continue;
+
+      if (was_visited(typed_path))
+        continue;
+
       Directory::VisitSpecificFiles(typed_path, filter, fv, true);
 
-    if (file_type == FileType::WAYPOINTDETAILS) {
+      if (!visited_paths.full())
+        visited_paths.append() = std::move(typed_path);
+    }
+
+    if (HasFileType(FileType::WAYPOINTDETAILS)) {
       /* Compatibility fallback: an earlier subdir migration could move
          ambiguous .txt waypoint details into airspace/. */
       const auto airspace_path =
         LocalPath(GetFileTypeDefaultDir(FileType::AIRSPACE));
-      if (airspace_path != nullptr && Directory::Exists(airspace_path))
+      if (airspace_path != nullptr && !was_visited(airspace_path) &&
+          Directory::Exists(airspace_path))
         Directory::VisitSpecificFiles(airspace_path, filter, fv, true);
     }
   } else {

--- a/src/Form/DataField/File.hpp
+++ b/src/Form/DataField/File.hpp
@@ -10,6 +10,7 @@
 #include "util/StaticString.hxx"
 
 #include <cstdint>
+#include <initializer_list>
 #include <utility>
 
 /**
@@ -19,6 +20,7 @@
  */
 class FileDataField final : public DataField {
   typedef StaticArray<StaticString<32>, 8> PatternList;
+  typedef StaticArray<FileType, 8> FileTypeList;
 
 public:
   enum class SortOrder : uint8_t {
@@ -62,7 +64,7 @@ private:
   /** FileList item array */
   StaticArray<Item, MAX_FILES> files;
 
-  FileType file_type;
+  FileTypeList file_types;
 
   /**
    * Has the file list already been loaded?  This class tries to
@@ -94,13 +96,25 @@ public:
    */
   explicit FileDataField(DataFieldListener *listener=nullptr) noexcept;
 
+  [[gnu::pure]]
+  bool HasSingleFileType() const noexcept {
+    return file_types.size() == 1;
+  }
+
   FileType GetFileType() const noexcept {
-    return file_type;
+    return HasSingleFileType()
+      ? file_types.front()
+      : FileType::UNKNOWN;
   }
 
   void SetFileType(FileType _file_type) noexcept {
-    file_type = _file_type;
+    SetFileTypes({_file_type});
   }
+
+  void SetFileTypes(std::initializer_list<FileType> _file_types) noexcept;
+
+  [[gnu::pure]]
+  bool HasFileType(FileType type) const noexcept;
 
   /**
    * Adds a filename/filepath couple to the filelist

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -47,6 +47,7 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "Dialogs/dlgQuickGuide.hpp"
 #include "Dialogs/dlgGestureHelp.hpp"
 #include "Message.hpp"
+#include "Repository/FileType.hpp"
 #include "Markers/Markers.hpp"
 #include "MainWindow.hpp"
 #include "PopupMessage.hpp"
@@ -798,7 +799,7 @@ InputEvents::eventExchangeFrequencies([[maybe_unused]] const char *misc)
 void
 InputEvents::eventUploadIGCFile([[maybe_unused]] const char *misc) {
   FileDataField df;
-  df.ScanMultiplePatterns("*.igc\0");
+  df.ScanMultiplePatterns(GetFileTypePatterns(FileType::IGC));
   df.SetFileType(FileType::IGC);
   if (FilePicker("IGC-FilePicker", df)) {
     auto path = df.GetValue();

--- a/src/Plane/PlaneFileGlue.cpp
+++ b/src/Plane/PlaneFileGlue.cpp
@@ -5,6 +5,7 @@
 #include "Plane.hpp"
 #include "Polar/Parser.hpp"
 #include "Engine/GlideSolvers/GlidePolar.hpp"
+#include "Repository/FileType.hpp"
 #include "io/KeyValueFileReader.hpp"
 #include "io/KeyValueFileWriter.hpp"
 #include "io/FileOutputStream.hxx"
@@ -229,7 +230,7 @@ PlaneGlue::FindByRegistration(const char *registration)
     }
   } visitor{match};
 
-  VisitDataFiles("*.xcp", visitor);
+  VisitDataFiles(GetFileTypePatterns(FileType::PLANE), visitor);
   return std::move(match.found_path);
 }
 

--- a/src/Task/TaskStore.cpp
+++ b/src/Task/TaskStore.cpp
@@ -4,6 +4,7 @@
 #include "Task/TaskStore.hpp"
 #include "Task/TaskFile.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Repository/FileType.hpp"
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
 #include "LocalPath.hpp"
@@ -11,6 +12,7 @@
 #include "LogFile.hpp"
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 
 class TaskFileVisitor: public File::Visitor
@@ -57,6 +59,25 @@ public:
   }
 };
 
+namespace {
+
+static constexpr char PRIMARY_TASK_PATTERN[] = "*.tsk";
+
+static void
+VisitPatternList(File::Visitor &visitor, const char *patterns,
+                 const char *skip_pattern = nullptr)
+{
+  size_t length;
+  while ((length = strlen(patterns)) > 0) {
+    if (skip_pattern == nullptr || strcmp(patterns, skip_pattern) != 0)
+      VisitDataFiles(patterns, visitor);
+
+    patterns += length + 1;
+  }
+}
+
+} // namespace
+
 void
 TaskStore::Clear()
 {
@@ -71,12 +92,11 @@ TaskStore::Scan(bool extra)
 
   // scan files
   TaskFileVisitor tfv(store);
-  VisitDataFiles("*.tsk", tfv);
+  VisitDataFiles(PRIMARY_TASK_PATTERN, tfv);
 
-  if (extra) {
-    VisitDataFiles("*.cup", tfv);
-    VisitDataFiles("*.igc", tfv);
-  }
+  if (extra)
+    VisitPatternList(tfv, GetFileTypePatterns(FileType::TASK),
+                     PRIMARY_TASK_PATTERN);
 
   std::sort(store.begin(), store.end());
 }

--- a/src/Waypoint/WaypointDetailsReader.cpp
+++ b/src/Waypoint/WaypointDetailsReader.cpp
@@ -10,6 +10,7 @@
 #include "Operation/ProgressListener.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
+#include "Repository/FileType.hpp"
 #include "WaypointDetailsFormat.hpp"
 #include "io/BufferedReader.hxx"
 #include "io/ConfiguredFile.hpp"
@@ -124,7 +125,8 @@ ReadFileFromProfile(Waypoints &way_points,
                     ProgressListener &progress)
 {
   auto paths =
-      Profile::GetMultiplePaths(ProfileKeys::AirfieldFileList, "*.txt\0");
+      Profile::GetMultiplePaths(ProfileKeys::AirfieldFileList,
+                                GetFileTypePatterns(FileType::WAYPOINTDETAILS));
   for (const auto &path : paths) {
     try {
       auto reader = std::make_unique<FileReader>(Path(path));

--- a/src/Widget/ProfileRowFormWidget.cpp
+++ b/src/Widget/ProfileRowFormWidget.cpp
@@ -35,6 +35,14 @@ FinishFileProperty(RowFormWidget &form, const char *label, const char *help,
   return edit;
 }
 
+static void
+ScanFileTypePatterns(FileDataField &df,
+                     std::initializer_list<FileType> file_types) noexcept
+{
+  for (const auto file_type : file_types)
+    df.ScanMultiplePatterns(GetFileTypePatterns(file_type));
+}
+
 } // namespace
 
 WndProperty *
@@ -51,14 +59,38 @@ RowFormWidget::AddFile(const char *label, const char *help,
 
 WndProperty *
 RowFormWidget::AddFile(const char *label, const char *help,
-                       std::string_view profile_key, const char *filters,
+                       std::string_view profile_key, const char * /*filters*/,
+                       std::initializer_list<FileType> file_types,
+                       bool nullable) noexcept
+{
+  return AddFile(label, help, profile_key, file_types, nullable);
+}
+
+WndProperty *
+RowFormWidget::AddFile(const char *label, const char *help,
+                       std::string_view profile_key,
                        std::initializer_list<FileType> file_types,
                        bool nullable) noexcept
 {
   auto *df = new FileDataField();
   df->SetFileTypes(file_types);
-  return FinishFileProperty(*this, label, help, profile_key, filters, *df,
-                            nullable);
+
+  WndProperty *edit = Add(label, help);
+  edit->SetDataField(df);
+
+  if (nullable)
+    df->AddNull();
+
+  ScanFileTypePatterns(*df, file_types);
+
+  if (profile_key.data() != nullptr) {
+    const auto path = Profile::GetPath(profile_key);
+    if (path != nullptr)
+      df->SetValue(path);
+  }
+
+  edit->RefreshDisplay();
+  return edit;
 }
 
 WndProperty *

--- a/src/Widget/ProfileRowFormWidget.cpp
+++ b/src/Widget/ProfileRowFormWidget.cpp
@@ -10,31 +10,55 @@
 #include "Profile/Profile.hpp"
 #include "RowFormWidget.hpp"
 
+namespace {
+
+static WndProperty *
+FinishFileProperty(RowFormWidget &form, const char *label, const char *help,
+                   std::string_view profile_key, const char *filters,
+                   FileDataField &df, bool nullable) noexcept
+{
+  WndProperty *edit = form.Add(label, help);
+  edit->SetDataField(&df);
+
+  if (nullable)
+    df.AddNull();
+
+  df.ScanMultiplePatterns(filters);
+
+  if (profile_key.data() != nullptr) {
+    const auto path = Profile::GetPath(profile_key);
+    if (path != nullptr)
+      df.SetValue(path);
+  }
+
+  edit->RefreshDisplay();
+  return edit;
+}
+
+} // namespace
+
 WndProperty *
 RowFormWidget::AddFile(const char *label, const char *help,
                        std::string_view profile_key, const char *filters,
                        FileType file_type,
                        bool nullable) noexcept
 {
-  WndProperty *edit = Add(label, help);
   auto *df = new FileDataField();
   df->SetFileType(file_type);
-  edit->SetDataField(df);
+  return FinishFileProperty(*this, label, help, profile_key, filters, *df,
+                            nullable);
+}
 
-  if (nullable)
-    df->AddNull();
-
-  df->ScanMultiplePatterns(filters);
-
-  if (profile_key.data() != nullptr) {
-    const auto path = Profile::GetPath(profile_key);
-    if (path != nullptr)
-      df->SetValue(path);
-  }
-
-  edit->RefreshDisplay();
-
-  return edit;
+WndProperty *
+RowFormWidget::AddFile(const char *label, const char *help,
+                       std::string_view profile_key, const char *filters,
+                       std::initializer_list<FileType> file_types,
+                       bool nullable) noexcept
+{
+  auto *df = new FileDataField();
+  df->SetFileTypes(file_types);
+  return FinishFileProperty(*this, label, help, profile_key, filters, *df,
+                            nullable);
 }
 
 WndProperty *

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -443,6 +443,11 @@ public:
                        bool nullable = true) noexcept;
 
   WndProperty *AddFile(const char *label, const char *help,
+                       std::string_view profile_key,
+                       std::initializer_list<FileType> file_types,
+                       bool nullable = true) noexcept;
+
+  WndProperty *AddFile(const char *label, const char *help,
                        std::string_view profile_key, const char *filters,
                        bool nullable = true) noexcept {
     return AddFile(label, help, profile_key, filters, FileType::UNKNOWN,

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -19,6 +19,7 @@
 #include <concepts>
 #include <cstdint>
 #include <functional>
+#include <initializer_list>
 #include <memory>
 #include <type_traits>
 
@@ -434,6 +435,11 @@ public:
   WndProperty *AddFile(const char *label, const char *help,
                        std::string_view profile_key, const char *filters,
                        FileType file_type,
+                       bool nullable = true) noexcept;
+
+  WndProperty *AddFile(const char *label, const char *help,
+                       std::string_view profile_key, const char *filters,
+                       std::initializer_list<FileType> file_types,
                        bool nullable = true) noexcept;
 
   WndProperty *AddFile(const char *label, const char *help,

--- a/src/system/FileUtil.cpp
+++ b/src/system/FileUtil.cpp
@@ -283,7 +283,9 @@ ScanDirectories(File::Visitor &visitor, bool recursive,
     FileName[0] = 0;
   }
 
-  // Scan for files in "/test/data/something"
+  /* Scan matching files first.  The loop below still enumerates all
+     entries to find subdirectories, but must not visit the same files
+     again through File::Visitor. */
   if (dir_entry_cb == nullptr)
     ScanFiles(visitor, Path(FileName), filter);
 
@@ -316,11 +318,9 @@ ScanDirectories(File::Visitor &visitor, bool recursive,
 
         if (recursive)
           ScanDirectories(visitor, true, Path(FileName), filter, show_dir, dir_entry_cb);
-      } else if (checkFilter(FindFileData.cFileName, filter)) {
-        if (dir_entry_cb)
-          dir_entry_cb->Visit(Path(FileName), Path(FindFileData.cFileName), false);
-        else
-          visitor.Visit(Path(FileName), Path(FindFileData.cFileName));
+      } else if (dir_entry_cb != nullptr &&
+                 checkFilter(FindFileData.cFileName, filter)) {
+        dir_entry_cb->Visit(Path(FileName), Path(FindFileData.cFileName), false);
       }
     }
 

--- a/test/src/FlightTable.cpp
+++ b/test/src/FlightTable.cpp
@@ -4,6 +4,7 @@
 #include "IGC/IGCParser.hpp"
 #include "IGC/IGCFix.hpp"
 #include "IGC/IGCExtensions.hpp"
+#include "Repository/FileType.hpp"
 #include "io/FileLineReader.hpp"
 #include "system/FileUtil.hpp"
 #include "time/FloatDuration.hxx"
@@ -11,6 +12,7 @@
 #include "util/PrintException.hxx"
 
 #include <cstdio>
+#include <cstring>
 #include <stdlib.h>
 
 class FlightCheck {
@@ -140,7 +142,13 @@ IGCFileVisitor::Visit(Path path, Path filename)
 int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 try {
   IGCFileVisitor visitor;
-  Directory::VisitSpecificFiles(Path("."), "*.igc", visitor);
+  const char *patterns = GetFileTypePatterns(FileType::IGC);
+  size_t length;
+  while ((length = strlen(patterns)) > 0) {
+    Directory::VisitSpecificFiles(Path("."), patterns, visitor);
+    patterns += length + 1;
+  }
+
   return 0;
 } catch (...) {
   PrintException(std::current_exception());


### PR DESCRIPTION
- Fixes https://github.com/XCSoar/XCSoar/issues/2625
- Increases usage of FileType API by further reducing hard codes file extensions in the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Upgraded file selection and scanning to use centralized `FileType`-based patterns instead of hardcoded globs across dialogs and file discovery.
  * Enhanced file data fields to support multiple file types, including typed subdirectory scanning and checklist handling.
* **New Features**
  * Added multi-`FileType` support to row-form file inputs, enabling selection and initialization from multiple types.
* **Tests**
  * Updated FlightTable tests to discover IGC inputs via `FileType` patterns.
* **Chores**
  * Adjusted test build sources and expanded test coverage for typed file handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->