### PR TITLE
ui/display/wayland: Add HiDPI and DPI detection

### DIFF
--- a/build/libevent.mk
+++ b/build/libevent.mk
@@ -25,9 +25,9 @@ VFB_CPPFLAGS = -DNON_INTERACTIVE
 else ifeq ($(USE_X11),y)
 EVENT_SOURCES += $(SRC)/ui/event/poll/X11Queue.cpp
 else ifeq ($(USE_WAYLAND),y)
+# Wayland protocol public.c objects are linked from libscreen only;
+# WaylandQueue resolves symbols against them when linking the executable.
 EVENT_SOURCES += \
-	$(WAYLAND_GENERATED)/xdg-shell-public.c \
-	$(WAYLAND_GENERATED)/xdg-decoration-unstable-v1-public.c \
 	$(SRC)/ui/event/poll/WaylandQueue.cpp
 else ifeq ($(USE_CONSOLE),y)
 EVENT_SOURCES += \

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -154,7 +154,6 @@ HasPointer() noexcept
  * supports the command line) can override autodetection.
  */
 #if defined(USE_LIBINPUT) || defined(USE_WAYLAND)
-[[gnu::pure]]
 bool
 HasTouchScreen() noexcept;
 #else

--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -177,6 +177,10 @@ Display::GetContentScale([[maybe_unused]] const UI::Display &display) noexcept
     const unsigned scale = xft_dpi / 96;
     return scale >= 1 ? scale : 1;
   }
+#elif defined(USE_WAYLAND)
+  const auto &wayland_display = static_cast<const Wayland::Display &>(display);
+  const int scale = wayland_display.GetScale();
+  return scale >= 1 ? static_cast<unsigned>(scale) : 1;
 #endif
   return 1;
 }

--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -2,9 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "DisplayDPI.hpp"
-#include "ui/dim/Size.hpp"
 #include "ui/display/Display.hpp"
-#include "Math/Point2D.hpp"
 
 #ifdef KOBO
 #include "Kobo/Model.hpp"
@@ -27,17 +25,6 @@ static UnsignedPoint2D forced_dpi{};
 
 #ifdef HAVE_DPI_DETECTION
 static UnsignedPoint2D detected_dpi{};
-#endif
-
-#if defined(USE_X11) || defined(MESA_KMS) || defined(USE_WAYLAND) || defined(HAVE_DPI_DETECTION)
-
-static constexpr unsigned
-MMToDPI(unsigned pixels, unsigned mm)
-{
-  /* 1 inch = 25.4 mm */
-  return pixels * 254 / (mm * 10);
-}
-
 #endif
 
 #if !defined(_WIN32) && !defined(USE_X11) && !defined(MESA_KMS) && !defined(USE_WAYLAND)
@@ -104,13 +91,17 @@ Display::ProvideSizeMM(unsigned width_pixels, unsigned height_pixels,
   assert(width_mm > 0);
   assert(height_mm > 0);
 
-  detected_dpi = {
-    MMToDPI(width_pixels, width_mm),
-    MMToDPI(height_pixels, height_mm),
-  };
+  detected_dpi = DisplayMetrics::PhysicalDpiFromSizeMm(
+    width_pixels, height_pixels, width_mm, height_mm);
 }
 
 #endif
+
+UnsignedPoint2D
+Display::PhysicalDpiFromDisplayMm(const UI::Display &display) noexcept
+{
+  return PhysicalDpiFromSizeMm(display.GetSize(), display.GetSizeMM());
+}
 
 UnsignedPoint2D
 Display::GetDPI([[maybe_unused]] const UI::Display &display, unsigned custom_dpi) noexcept
@@ -133,18 +124,9 @@ Display::GetDPI([[maybe_unused]] const UI::Display &display, unsigned custom_dpi
   return display.GetDPI();
 #elif defined(USE_X11) || defined(MESA_KMS) || defined(USE_WAYLAND)
   {
-    /* Physical DPI from pixel size and physical size (mm). On Wayland
-       size comes from wl_output mode, size_mm from geometry
-       physical_width/height (millimeters). */
-    const auto size = display.GetSize();
-    const auto size_mm = display.GetSizeMM();
-    if (size.width > 0 && size.height > 0 &&
-        size_mm.width > 0 && size_mm.height > 0) {
-      return {
-        MMToDPI(size.width, size_mm.width),
-        MMToDPI(size.height, size_mm.height),
-      };
-    }
+    const auto dpi_from_mm = PhysicalDpiFromDisplayMm(display);
+    if (dpi_from_mm.x > 0 && dpi_from_mm.y > 0)
+      return dpi_from_mm;
 #if defined(USE_X11)
     /* X11 fallback: many setups omit physical size (mm); try Xft.dpi
        from the X resource database (e.g. ~/.Xresources, xrdb). */
@@ -179,8 +161,7 @@ Display::GetContentScale([[maybe_unused]] const UI::Display &display) noexcept
   }
 #elif defined(USE_WAYLAND)
   const auto &wayland_display = static_cast<const Wayland::Display &>(display);
-  const int scale = wayland_display.GetScale();
-  return scale >= 1 ? static_cast<unsigned>(scale) : 1;
+  return static_cast<unsigned>(wayland_display.GetBufferScale());
 #endif
   return 1;
 }

--- a/src/Hardware/DisplayDPI.hpp
+++ b/src/Hardware/DisplayDPI.hpp
@@ -47,4 +47,25 @@ ProvideSizeMM(unsigned width_pixels, unsigned height_pixels,
 UnsignedPoint2D
 GetDPI(const UI::Display &display, unsigned custom_dpi=0) noexcept;
 
+/**
+ * Returns the content scale factor when the display uses logical scaling
+ * (e.g. Xft.dpi on X11 when physical size is unavailable). Layout and
+ * canvas use logical size = physical size / scale so that pen/font
+ * scaling matches Wayland. Returns 1 when physical size is known or
+ * when not applicable.
+ */
+[[gnu::const]]
+unsigned
+GetContentScale(const UI::Display &display) noexcept;
+
+}
+
+namespace Hardware {
+
+/** Wrapper for Display::GetContentScale usable from code that may
+ * have Display macro-defined (e.g. X11). */
+[[gnu::const]]
+unsigned
+GetContentScale(const UI::Display &display) noexcept;
+
 }

--- a/src/Hardware/DisplayDPI.hpp
+++ b/src/Hardware/DisplayDPI.hpp
@@ -3,11 +3,13 @@
 
 #pragma once
 
+#include "Math/DisplayMetrics.hpp"
+#include "Math/Point2D.hpp"
+#include "ui/dim/Size.hpp"
+
 #if defined(USE_FB) || defined(ANDROID)
 #define HAVE_DPI_DETECTION
 #endif
-
-struct UnsignedPoint2D;
 
 namespace UI { class Display; }
 
@@ -48,6 +50,24 @@ UnsignedPoint2D
 GetDPI(const UI::Display &display, unsigned custom_dpi=0) noexcept;
 
 /**
+ * Physical DPI from pixel dimensions and physical span in millimetres.
+ * Returns {0,0} when any dimension is zero.
+ */
+[[nodiscard]] constexpr UnsignedPoint2D
+PhysicalDpiFromSizeMm(PixelSize size, PixelSize size_mm) noexcept
+{
+  return DisplayMetrics::PhysicalDpiFromSizeMm(size.width, size.height,
+                                               size_mm.width, size_mm.height);
+}
+
+/**
+ * Same as PhysicalDpiFromSizeMm using the display's reported size and
+ * size in millimetres.
+ */
+UnsignedPoint2D
+PhysicalDpiFromDisplayMm(const UI::Display &display) noexcept;
+
+/**
  * Returns the content scale factor when the display uses logical scaling
  * (e.g. Xft.dpi on X11 when physical size is unavailable). Layout and
  * canvas use logical size = physical size / scale so that pen/font
@@ -62,8 +82,10 @@ GetContentScale(const UI::Display &display) noexcept;
 
 namespace Hardware {
 
-/** Wrapper for Display::GetContentScale usable from code that may
- * have Display macro-defined (e.g. X11). */
+/**
+ * Forwards to Display::GetContentScale().  Use this name in translation
+ * units where the X11 `Display` type macro would shadow UI::Display.
+ */
 [[gnu::const]]
 unsigned
 GetContentScale(const UI::Display &display) noexcept;

--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -212,10 +212,12 @@ InputEvents::drawButtons(Mode mode, bool full) noexcept
        * such as the scale, are not overdrawn by the buttons
        * when in Pan mode. */
       PixelRect screen_rect = map->GetParentClientRect();
+      static constexpr unsigned MENUBAR_MARGIN_FACTOR_PORTRAIT = 6;
+      static constexpr unsigned MENUBAR_MARGIN_FACTOR_LANDSCAPE = 5;
       unsigned factor = (screen_rect.GetHeight() > screen_rect.GetWidth())
-        ? menubar_height_scale_factor
-        : 5;
-      
+        ? MENUBAR_MARGIN_FACTOR_PORTRAIT
+        : MENUBAR_MARGIN_FACTOR_LANDSCAPE;
+
       map->SetBottomMarginFactor(factor);
     } else {
       map->SetBottomMarginFactor(0);

--- a/src/Look/AutoFont.cpp
+++ b/src/Look/AutoFont.cpp
@@ -3,6 +3,7 @@
 
 #include "AutoFont.hpp"
 #include "FontDescription.hpp"
+#include "Screen/Layout.hpp"
 #include "ui/canvas/Font.hpp"
 
 #include <algorithm>
@@ -13,8 +14,12 @@ AutoSizeFont(FontDescription &d, unsigned width, const char *text)
   // JMW algorithm to auto-size info window font.
   // this is still required in case title font property doesn't exist.
 
+  /* Minimum height ~8pt physical (aviation display readability). */
+  const unsigned min_height = std::max(1u, Layout::FontScale(8));
+
   /* reasonable start value (ignoring the original input value) */
-  d.SetHeight(std::max(10u, unsigned(width) / 4u));
+  const unsigned start_height = std::max(10u, unsigned(width) / 4u);
+  d.SetHeight(std::max(min_height, start_height));
 
   Font font;
   font.Load(d);
@@ -32,9 +37,7 @@ AutoSizeFont(FontDescription &d, unsigned width, const char *text)
   /* decrease font size until it fits exactly */
 
   do {
-    if (d.GetHeight() <= 6)
-      /* this is the lower bound; don't go smaller than that, or else
-         the size will underflow eventually */
+    if (d.GetHeight() <= min_height)
       break;
 
     d.SetHeight(d.GetHeight() - 1);

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -59,22 +59,24 @@ InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
   border_pen.Create(border_width, border_color);
   unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), value.fg_color);
 
-  FontDescription title_font_d(8);
+  FontDescription title_font_d(Layout::FontScale(8));
   AutoSizeFont(title_font_d, (width * scale_title_font) / 100U,
                "1234567890A");
 
   title_font.Load(title_font_d);
   title_font_bold.Load(title_font_d.WithBold(true));
 
-  FontDescription value_font_d(10, true);
+  FontDescription value_font_d(Layout::FontScale(10), true);
   AutoSizeFont(value_font_d, width, "1234m");
   value_font.Load(value_font_d);
 
-  FontDescription small_value_font_d(10);
+  FontDescription small_value_font_d(Layout::FontScale(10));
   AutoSizeFont(small_value_font_d, width, "12345m");
   small_value_font.Load(small_value_font_d);
 
-  unsigned unit_font_height = std::max(value_font_d.GetHeight() * 2u / 5u, 7u);
+  const unsigned min_unit_pt_px = Layout::FontScale(8);
+  unsigned unit_font_height =
+    std::max(value_font_d.GetHeight() * 2u / 5u, min_unit_pt_px);
   unit_font.Load(FontDescription(unit_font_height));
 
 #ifdef HAVE_TEXT_CACHE

--- a/src/Math/DisplayMetrics.hpp
+++ b/src/Math/DisplayMetrics.hpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Math/Point2D.hpp"
+
+#include <algorithm>
+
+namespace DisplayMetrics {
+
+/**
+ * Convert pixel count and physical span (millimetres) to DPI.
+ * Uses 25.4 mm per inch (254/10).  Returns 0 if @a mm is zero.
+ */
+[[nodiscard]] constexpr unsigned
+MMToDPI(unsigned pixels, unsigned mm) noexcept
+{
+  if (mm == 0)
+    return 0;
+  return pixels * 254 / (mm * 10);
+}
+
+/**
+ * Physical DPI from pixel dimensions and physical span in millimetres.
+ * Returns {0,0} when any dimension is zero.
+ */
+[[nodiscard]] constexpr UnsignedPoint2D
+PhysicalDpiFromSizeMm(unsigned width, unsigned height,
+                      unsigned width_mm, unsigned height_mm) noexcept
+{
+  if (width == 0 || height == 0 || width_mm == 0 || height_mm == 0)
+    return {0, 0};
+  return {
+    MMToDPI(width, width_mm),
+    MMToDPI(height, height_mm),
+  };
+}
+
+/**
+ * Reference DPI paired with compositor content scale so effective DPI
+ * matches typical X11 Xft.dpi (120) when scaling logical vs physical.
+ */
+inline constexpr unsigned CONTENT_SCALE_DPI_REFERENCE = 120U;
+
+/**
+ * DPI used for fonts and pens when content_scale is greater than 1
+ * (logical vs buffer scale) so we do not double-scale.
+ */
+[[nodiscard]] constexpr UnsignedPoint2D
+EffectiveDpiForContentScale(UnsignedPoint2D physical_dpi,
+                            unsigned content_scale) noexcept
+{
+  if (content_scale <= 1)
+    return physical_dpi;
+  return {
+    std::clamp(physical_dpi.x * CONTENT_SCALE_DPI_REFERENCE /
+                 (content_scale * 100),
+               1u, physical_dpi.x),
+    std::clamp(physical_dpi.y * CONTENT_SCALE_DPI_REFERENCE /
+                 (content_scale * 100),
+               1u, physical_dpi.y),
+  };
+}
+
+/**
+ * Touch control row height in the same logical space as
+ * EffectiveDpiForContentScale when content_scale is greater than 1.
+ */
+[[nodiscard]] constexpr unsigned
+TouchControlHeightForContentScale(unsigned scaled_height,
+                                  unsigned content_scale) noexcept
+{
+  if (content_scale <= 1)
+    return scaled_height;
+  return scaled_height / content_scale *
+         CONTENT_SCALE_DPI_REFERENCE / 100;
+}
+
+} // namespace DisplayMetrics

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -4,31 +4,33 @@
 #include "MenuBar.hpp"
 #include "ui/window/ContainerWindow.hpp"
 #include "Input/InputEvents.hpp"
+#include "Screen/Layout.hpp"
 
-#include <algorithm>
 #include <cassert>
 
 [[gnu::pure]]
 static PixelRect
 GetButtonPosition(unsigned i, PixelRect rc)
 {
-  unsigned hwidth = rc.GetWidth(), hheight = rc.GetHeight();
+  /* Use constant touch height so button size does not change on widget
+     or layout change. */
+  const unsigned touch_height = Layout::GetMaximumControlHeight();
+  unsigned hwidth = rc.GetWidth();
+  unsigned hheight = touch_height;
 
-  if (hheight > hwidth) {
+  if (rc.GetHeight() > rc.GetWidth()) {
     // portrait
-
-    hheight = std::max(1u, hheight / menubar_height_scale_factor);
 
     if (i == 0) {
       rc.left = rc.right;
       rc.top = rc.bottom;
     } else if (i < 5) {
-      hwidth = std::max(1u, hwidth / 4);
+      hwidth /= 4;
 
       rc.left += hwidth * (i - 1);
       rc.top = rc.bottom - hheight;
     } else {
-      hwidth = std::max(1u, hwidth / 3);
+      hwidth /= 3;
 
       rc.left = rc.right - hwidth;
       rc.top += (i - 5) * hheight;
@@ -39,8 +41,7 @@ GetButtonPosition(unsigned i, PixelRect rc)
   } else {
     // landscape
 
-    hwidth = std::max(1u, hwidth / 5);
-    hheight = std::max(1u, hheight / 5);
+    hwidth /= 5;
 
     if (i == 0) {
       rc.left = rc.right;

--- a/src/Screen/Layout.cpp
+++ b/src/Screen/Layout.cpp
@@ -106,6 +106,21 @@ Initialise(const UI::Display &display, PixelSize new_size,
     }
   }
 #endif
+
+  /* When compositor uses content scale (e.g. Wayland buffer scale), we work
+     in logical space: effective_dpi = physical_dpi / content_scale so we do
+     not double-scale. One factor aligns with typical X11 (Xft.dpi 120). */
+  const unsigned content_scale = Display::GetContentScale(display);
+  static constexpr unsigned CONTENT_SCALE_DPI_FACTOR = 120;
+  UnsignedPoint2D effective_dpi = physical_dpi;
+  if (content_scale > 1) {
+    effective_dpi.x = std::clamp(physical_dpi.x * CONTENT_SCALE_DPI_FACTOR /
+                                  (content_scale * 100),
+                                1u, physical_dpi.x);
+    effective_dpi.y = std::clamp(physical_dpi.y * CONTENT_SCALE_DPI_FACTOR /
+                                  (content_scale * 100),
+                                1u, physical_dpi.y);
+  }
   
   const bool is_small_screen = IsSmallScreen(GetDisplaySize(display, new_size),
                                              dpi);
@@ -123,19 +138,18 @@ Initialise(const UI::Display &display, PixelSize new_size,
   scale_1024 = std::max(1024U, min_screen_pixels * 1024 / (square ? 320 : 240));
   scale = scale_1024 / 1024;
 
-  /* Use physical DPI for font scaling to maintain same physical size
-     regardless of forced DPI. Forced DPI should only affect layout scaling,
-     not the physical size of text. */
-  vdpi = SmallScreenAdjust(physical_dpi.y);
+  /* Use effective DPI for font/pen scaling (physical when content_scale is 1,
+     physical/content_scale when compositor scales so we do not double-scale). */
+  vdpi = SmallScreenAdjust(effective_dpi.y);
 
-  pen_width_scale = std::max(1024u, dpi.x * 1024u / 80u);
-  fine_pen_width_scale = std::max(1024u, dpi.x * 1024u / 160u);
+  pen_width_scale = std::max(1024u, effective_dpi.x * 1024u / 80u);
+  fine_pen_width_scale = std::max(1024u, effective_dpi.x * 1024u / 160u);
 
-  pt_scale = 1024 * physical_dpi.y / 72;
+  pt_scale = 1024 * effective_dpi.y / 72;
 
   vpt_scale = SmallScreenAdjust(pt_scale);
 
-  font_scale = SmallScreenAdjust(1024 * physical_dpi.y * ui_scale / 72 / 100);
+  font_scale = SmallScreenAdjust(1024 * effective_dpi.y * ui_scale / 72 / 100);
 
   text_padding = VptScale(2);
 
@@ -143,8 +157,13 @@ Initialise(const UI::Display &display, PixelSize new_size,
                                     min_screen_pixels / 12);
 
   if (HasTouchScreen()) {
-    /* larger rows for touch screens */
-    maximum_control_height = PtScale(30);
+    /* Larger rows for touch; when content_scale > 1 use same logical-space
+       rule and factor as effective_dpi so physical height matches. */
+    unsigned touch_height = Scale(30u);
+    if (content_scale > 1)
+      touch_height = touch_height / content_scale *
+                     CONTENT_SCALE_DPI_FACTOR / 100;
+    maximum_control_height = touch_height;
     if (maximum_control_height < minimum_control_height)
       maximum_control_height = minimum_control_height;
   } else {

--- a/src/Screen/Layout.cpp
+++ b/src/Screen/Layout.cpp
@@ -6,19 +6,11 @@
 #include "ui/display/Display.hpp"
 #include "Hardware/DisplayDPI.hpp"
 #include "Asset.hpp"
+#include "Math/Point2D.hpp"
 
 #include <algorithm>
 
 namespace Layout {
-
-#if defined(USE_X11) || defined(MESA_KMS) || defined(USE_WAYLAND)
-static constexpr unsigned
-MMToDPI(unsigned pixels, unsigned mm) noexcept
-{
-  /* 1 inch = 25.4 mm */
-  return pixels * 254 / (mm * 10);
-}
-#endif
 
 bool landscape = false;
 unsigned min_screen_pixels = 512;
@@ -89,21 +81,15 @@ Initialise(const UI::Display &display, PixelSize new_size,
     return;
 
   const auto dpi = Display::GetDPI(display, custom_dpi);
-  
+
   /* Get physical DPI for font scaling to maintain same physical size
      regardless of forced DPI. */
   UnsignedPoint2D physical_dpi = dpi;
 #if defined(USE_X11) || defined(MESA_KMS) || defined(USE_WAYLAND)
   {
-    const auto size = display.GetSize();
-    const auto size_mm = display.GetSizeMM();
-    if (size.width > 0 && size.height > 0 &&
-        size_mm.width > 0 && size_mm.height > 0) {
-      physical_dpi = {
-        MMToDPI(size.width, size_mm.width),
-        MMToDPI(size.height, size_mm.height),
-      };
-    }
+    const auto from_mm = Display::PhysicalDpiFromDisplayMm(display);
+    if (from_mm.x > 0 && from_mm.y > 0)
+      physical_dpi = from_mm;
   }
 #endif
 
@@ -111,16 +97,8 @@ Initialise(const UI::Display &display, PixelSize new_size,
      in logical space: effective_dpi = physical_dpi / content_scale so we do
      not double-scale. One factor aligns with typical X11 (Xft.dpi 120). */
   const unsigned content_scale = Display::GetContentScale(display);
-  static constexpr unsigned CONTENT_SCALE_DPI_FACTOR = 120;
-  UnsignedPoint2D effective_dpi = physical_dpi;
-  if (content_scale > 1) {
-    effective_dpi.x = std::clamp(physical_dpi.x * CONTENT_SCALE_DPI_FACTOR /
-                                  (content_scale * 100),
-                                1u, physical_dpi.x);
-    effective_dpi.y = std::clamp(physical_dpi.y * CONTENT_SCALE_DPI_FACTOR /
-                                  (content_scale * 100),
-                                1u, physical_dpi.y);
-  }
+  UnsignedPoint2D effective_dpi =
+    DisplayMetrics::EffectiveDpiForContentScale(physical_dpi, content_scale);
   
   const bool is_small_screen = IsSmallScreen(GetDisplaySize(display, new_size),
                                              dpi);
@@ -159,10 +137,8 @@ Initialise(const UI::Display &display, PixelSize new_size,
   if (HasTouchScreen()) {
     /* Larger rows for touch; when content_scale > 1 use same logical-space
        rule and factor as effective_dpi so physical height matches. */
-    unsigned touch_height = Scale(30u);
-    if (content_scale > 1)
-      touch_height = touch_height / content_scale *
-                     CONTENT_SCALE_DPI_FACTOR / 100;
+    unsigned touch_height = DisplayMetrics::TouchControlHeightForContentScale(
+      Scale(30u), content_scale);
     maximum_control_height = touch_height;
     if (maximum_control_height < minimum_control_height)
       maximum_control_height = minimum_control_height;

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -26,8 +26,9 @@ GetMinimumHeight(const WndProperty &control, const DialogLook &look,
     height *= 2;
   height += padding * 2;
 
-  if (!control.IsReadOnly() && height < Layout::GetMinimumControlHeight())
-    height = Layout::GetMinimumControlHeight();
+  /* Editable (tappable) fields use button height for reliable touch targets. */
+  if (!control.IsReadOnly() && height < Layout::GetMaximumControlHeight())
+    height = Layout::GetMaximumControlHeight();
 
   return height;
 }
@@ -64,7 +65,7 @@ RowFormWidget::Row::GetMinimumHeight(const DialogLook &look,
     return ::GetMinimumHeight(GetControl(), look, vertical);
 
   case Type::BUTTON:
-    return Layout::GetMinimumControlHeight();
+    return Layout::GetMaximumControlHeight();
 
   case Type::MULTI_LINE:
     return Layout::GetMinimumControlHeight();

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -188,6 +188,13 @@ public:
    * @return true if the screen has been resized
    */
   bool CheckResize(PixelSize new_native_size) noexcept;
+
+  /**
+   * Same as above, with separate content (logical) size for HiDPI.
+   * When content_size is non-zero, viewport is native_size and
+   * projection uses content_size (logical coords -> physical viewport).
+   */
+  bool CheckResize(PixelSize new_native_size, PixelSize content_size) noexcept;
 #endif
 
 #ifdef USE_FB
@@ -286,6 +293,8 @@ private:
 
 #ifdef ENABLE_OPENGL
   PixelSize SetupViewport(PixelSize native_size) noexcept;
+  PixelSize SetupViewport(PixelSize native_size,
+                         PixelSize content_size) noexcept;
 #endif
 
 #ifdef USE_EGL

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -294,7 +294,7 @@ private:
 #ifdef ENABLE_OPENGL
   PixelSize SetupViewport(PixelSize native_size) noexcept;
   PixelSize SetupViewport(PixelSize native_size,
-                         PixelSize content_size) noexcept;
+                          PixelSize content_size) noexcept;
 #endif
 
 #ifdef USE_EGL

--- a/src/ui/canvas/opengl/BufferCanvas.cpp
+++ b/src/ui/canvas/opengl/BufferCanvas.cpp
@@ -110,7 +110,8 @@ BufferCanvas::Begin(Canvas &other) noexcept
   OpenGL::projection_matrix = glm::mat4(1);
 
   old_translate = OpenGL::translate;
-  old_size = OpenGL::viewport_size;
+  old_viewport_size = OpenGL::viewport_size;
+  old_window_size = OpenGL::window_size;
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   old_orientation = OpenGL::display_orientation;
@@ -153,7 +154,8 @@ BufferCanvas::Commit(Canvas &other) noexcept
   OpenGL::UpdateShaderProjectionMatrix();
 
   OpenGL::translate = old_translate;
-  OpenGL::viewport_size = old_size;
+  OpenGL::viewport_size = old_viewport_size;
+  OpenGL::window_size = old_window_size;
 
   OpenGL::UpdateShaderTranslate();
 

--- a/src/ui/canvas/opengl/BufferCanvas.hpp
+++ b/src/ui/canvas/opengl/BufferCanvas.hpp
@@ -37,7 +37,8 @@ class BufferCanvas : public Canvas {
   glm::mat4 old_projection_matrix;
 
   PixelPoint old_translate;
-  UnsignedPoint2D old_size;
+  UnsignedPoint2D old_viewport_size;
+  UnsignedPoint2D old_window_size;
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   DisplayOrientation old_orientation;

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -814,12 +814,15 @@ Canvas::CopyToTexture(GLTexture &texture, PixelRect src_rc) const noexcept
 {
   assert(offset == OpenGL::translate);
 
+  const int x = OpenGL::translate.x + src_rc.left;
+  const int y = OpenGL::viewport_size.y - OpenGL::translate.y - src_rc.bottom;
+  const int w = src_rc.GetWidth();
+  const int h = src_rc.GetHeight();
+
+  const auto p = OpenGL::ToPhysicalRect(x, y, w, h);
   texture.Bind();
   glCopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
-                      OpenGL::translate.x + src_rc.left,
-                      OpenGL::viewport_size.y - OpenGL::translate.y - src_rc.bottom,
-                      src_rc.GetWidth(), src_rc.GetHeight());
-
+                     p.x, p.y, p.width, p.height);
 }
 
 void

--- a/src/ui/canvas/opengl/Globals.hpp
+++ b/src/ui/canvas/opengl/Globals.hpp
@@ -12,15 +12,16 @@
 
 #include "ui/opengl/Features.hpp"
 #include "ui/opengl/System.hpp"
+#include "Math/Point2D.hpp"
 
 #include <glm/fwd.hpp>
+#include <cmath>
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
 #include <cstdint>
 enum class DisplayOrientation : uint8_t;
 #endif
 
-struct UnsignedPoint2D;
 struct PixelPoint;
 
 namespace OpenGL {
@@ -74,5 +75,46 @@ extern glm::mat4 projection_matrix;
  * GPU driver bugs.  0 means no GPU-imposed limit.
  */
 extern unsigned max_map_scale;
+
+/**
+ * Result of converting logical viewport (x,y,w,h) to physical window
+ * coords for glScissor, glCopyTexSubImage2D, etc.
+ */
+struct PhysicalRect {
+  GLint x, y;
+  GLsizei width, height;
+};
+
+/**
+ * Scale logical viewport (x,y,w,h) to physical window coords when
+ * HiDPI or fractional scaling (window_size != viewport_size).  Use
+ * for glScissor, glCopyTexSubImage2D and other GL APIs that take
+ * window (physical) coordinates.
+ */
+[[gnu::const]]
+inline PhysicalRect
+ToPhysicalRect(int x, int y, int w, int h) noexcept
+{
+  if (window_size.x != viewport_size.x ||
+      window_size.y != viewport_size.y) {
+    const float sx = float(window_size.x) / viewport_size.x;
+    const float sy = float(window_size.y) / viewport_size.y;
+    auto pw = static_cast<int>(std::round(w * sx));
+    auto ph = static_cast<int>(std::round(h * sy));
+    if (pw < 0)
+      pw = 0;
+    if (ph < 0)
+      ph = 0;
+    return {static_cast<GLint>(std::round(x * sx)),
+            static_cast<GLint>(std::round(y * sy)),
+            static_cast<GLsizei>(pw), static_cast<GLsizei>(ph)};
+  }
+  if (w < 0)
+    w = 0;
+  if (h < 0)
+    h = 0;
+  return {static_cast<GLint>(x), static_cast<GLint>(y),
+          static_cast<GLsizei>(w), static_cast<GLsizei>(h)};
+}
 
 } // namespace OpenGL

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -238,29 +238,42 @@ OrientationSwap(UnsignedPoint2D &p, DisplayOrientation orientation) noexcept
 UnsignedPoint2D
 OpenGL::SetupViewport(UnsignedPoint2D size) noexcept
 {
+  return SetupViewport(size, size);
+}
+
+UnsignedPoint2D
+OpenGL::SetupViewport(UnsignedPoint2D size,
+                      UnsignedPoint2D content_size) noexcept
+{
   window_size = size;
 
   glViewport(0, 0, size.x, size.y);
 
+  /* Use content_size for projection when set (HiDPI: logical -> physical) */
+  const bool have_content = content_size.x > 0 && content_size.y > 0;
+  UnsignedPoint2D proj_size = have_content ? content_size : size;
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
-  OrientationSwap(size, display_orientation);
+  OrientationSwap(proj_size, display_orientation);
 #endif
 
-  projection_matrix = glm::ortho<float>(0, size.x, size.y, 0, -1, 1);
+  projection_matrix =
+    glm::ortho<float>(0, proj_size.x, proj_size.y, 0, -1, 1);
 
 #ifdef SOFTWARE_ROTATE_DISPLAY
   glm::mat4 rot_matrix = glm::rotate(
     glm::mat4(1),
-    (GLfloat)Angle::Degrees(OrientationToRotation(display_orientation)).Radians(),
+    (GLfloat)Angle::Degrees(OrientationToRotation(display_orientation))
+      .Radians(),
     glm::vec3(0, 0, 1));
   projection_matrix = rot_matrix * projection_matrix;
 #endif
 
-  viewport_size = size;
+  viewport_size = proj_size;
 
   UpdateShaderProjectionMatrix();
 
-  return size;
+  return proj_size;
 }
 
 void

--- a/src/ui/canvas/opengl/Init.hpp
+++ b/src/ui/canvas/opengl/Init.hpp
@@ -29,10 +29,15 @@ void SetupContext();
  * Set up the viewport and the matrices for 2D drawing.  Apply the
  * #DisplayOrientation via glRotatef() (OpenGL projection matrix).
  *
- * @param size the native screen size in pixels
- * @return the logical screen size (after rotation)
+ * @param size the native (physical) size in pixels
+ * @param content_size when non-zero, the logical size for the
+ * projection (HiDPI: map logical coords to physical viewport)
+ * @return the logical screen size (content_size if set, else size)
  */
 UnsignedPoint2D SetupViewport(UnsignedPoint2D size) noexcept;
+
+UnsignedPoint2D SetupViewport(UnsignedPoint2D size,
+                              UnsignedPoint2D content_size) noexcept;
 
 /**
  * Deinitialize our OpenGL library.  Call before shutdown.

--- a/src/ui/canvas/opengl/Scissor.hpp
+++ b/src/ui/canvas/opengl/Scissor.hpp
@@ -8,6 +8,8 @@
 #include "Canvas.hpp"
 #include "ui/opengl/Features.hpp" // for SOFTWARE_ROTATE_DISPLAY
 
+#include <cmath>
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
 #include "Rotate.hpp"
 
@@ -31,19 +33,62 @@ private:
 
 #else
 
+/**
+ * When HiDPI uses logical coords for projection but glViewport is
+ * physical, glScissor must be in physical coords.  Convert logical
+ * PixelRect to (x, y, width, height) in physical viewport coords.
+ * Needed for List, VScrollPanel, etc. when window_size != viewport_size.
+ */
+struct GLCanvasScissorParams {
+  GLint x, y;
+  GLsizei width, height;
+};
+
+[[gnu::const]]
+static inline GLCanvasScissorParams
+ToPhysicalScissor(PixelRect rc) noexcept
+{
+  const int x = OpenGL::translate.x + rc.left;
+  const int y = OpenGL::viewport_size.y - OpenGL::translate.y - rc.bottom;
+  int w = rc.GetWidth();
+  int h = rc.GetHeight();
+
+  if (OpenGL::window_size.x != OpenGL::viewport_size.x ||
+      OpenGL::window_size.y != OpenGL::viewport_size.y) {
+    const float sx = float(OpenGL::window_size.x) / OpenGL::viewport_size.x;
+    const float sy = float(OpenGL::window_size.y) / OpenGL::viewport_size.y;
+    const auto px = static_cast<GLint>(std::round(x * sx));
+    const auto py = static_cast<GLint>(std::round(y * sy));
+    w = static_cast<int>(std::round(w * sx));
+    h = static_cast<int>(std::round(h * sy));
+    /* glScissor rejects negative width/height */
+    if (w < 0)
+      w = 0;
+    if (h < 0)
+      h = 0;
+    return {px, py, static_cast<GLsizei>(w), static_cast<GLsizei>(h)};
+  }
+  if (w < 0)
+    w = 0;
+  if (h < 0)
+    h = 0;
+  return {static_cast<GLint>(x), static_cast<GLint>(y),
+          static_cast<GLsizei>(w), static_cast<GLsizei>(h)};
+}
+
 class GLCanvasScissor : public GLScissor {
 public:
   [[nodiscard]]
   GLCanvasScissor(const Canvas &canvas) noexcept
-    :GLScissor(OpenGL::translate.x,
-               OpenGL::viewport_size.y - OpenGL::translate.y - canvas.GetHeight(),
-               canvas.GetWidth(), canvas.GetHeight()) {}
+    :GLCanvasScissor(PixelRect(0, 0, canvas.GetWidth(), canvas.GetHeight())) {}
 
   [[nodiscard]]
   explicit GLCanvasScissor(PixelRect rc) noexcept
-    :GLScissor(OpenGL::translate.x + rc.left,
-               OpenGL::viewport_size.y - OpenGL::translate.y - rc.bottom,
-               rc.GetWidth(), rc.GetHeight()) {}
+    :GLCanvasScissor(ToPhysicalScissor(rc)) {}
+
+  [[nodiscard]]
+  GLCanvasScissor(GLCanvasScissorParams p) noexcept
+    :GLScissor(p.x, p.y, p.width, p.height) {}
 };
 
 #endif

--- a/src/ui/canvas/opengl/Scissor.hpp
+++ b/src/ui/canvas/opengl/Scissor.hpp
@@ -27,7 +27,9 @@ public:
 private:
   void Scissor(PixelRect rc) noexcept {
     OpenGL::ToViewport(rc);
-    ::glScissor(rc.left, rc.top, rc.GetWidth(), rc.GetHeight());
+    const auto p = OpenGL::ToPhysicalRect(rc.left, rc.top,
+                                          rc.GetWidth(), rc.GetHeight());
+    ::glScissor(p.x, p.y, p.width, p.height);
   }
 };
 

--- a/src/ui/canvas/opengl/Scissor.hpp
+++ b/src/ui/canvas/opengl/Scissor.hpp
@@ -8,8 +8,6 @@
 #include "Canvas.hpp"
 #include "ui/opengl/Features.hpp" // for SOFTWARE_ROTATE_DISPLAY
 
-#include <cmath>
-
 #ifdef SOFTWARE_ROTATE_DISPLAY
 #include "Rotate.hpp"
 
@@ -38,44 +36,18 @@ private:
 /**
  * When HiDPI uses logical coords for projection but glViewport is
  * physical, glScissor must be in physical coords.  Convert logical
- * PixelRect to (x, y, width, height) in physical viewport coords.
+ * PixelRect to (x, y, width, height) in physical window coords.
  * Needed for List, VScrollPanel, etc. when window_size != viewport_size.
  */
-struct GLCanvasScissorParams {
-  GLint x, y;
-  GLsizei width, height;
-};
-
 [[gnu::const]]
-static inline GLCanvasScissorParams
+static inline OpenGL::PhysicalRect
 ToPhysicalScissor(PixelRect rc) noexcept
 {
   const int x = OpenGL::translate.x + rc.left;
   const int y = OpenGL::viewport_size.y - OpenGL::translate.y - rc.bottom;
-  int w = rc.GetWidth();
-  int h = rc.GetHeight();
-
-  if (OpenGL::window_size.x != OpenGL::viewport_size.x ||
-      OpenGL::window_size.y != OpenGL::viewport_size.y) {
-    const float sx = float(OpenGL::window_size.x) / OpenGL::viewport_size.x;
-    const float sy = float(OpenGL::window_size.y) / OpenGL::viewport_size.y;
-    const auto px = static_cast<GLint>(std::round(x * sx));
-    const auto py = static_cast<GLint>(std::round(y * sy));
-    w = static_cast<int>(std::round(w * sx));
-    h = static_cast<int>(std::round(h * sy));
-    /* glScissor rejects negative width/height */
-    if (w < 0)
-      w = 0;
-    if (h < 0)
-      h = 0;
-    return {px, py, static_cast<GLsizei>(w), static_cast<GLsizei>(h)};
-  }
-  if (w < 0)
-    w = 0;
-  if (h < 0)
-    h = 0;
-  return {static_cast<GLint>(x), static_cast<GLint>(y),
-          static_cast<GLsizei>(w), static_cast<GLsizei>(h)};
+  const int w = rc.GetWidth();
+  const int h = rc.GetHeight();
+  return OpenGL::ToPhysicalRect(x, y, w, h);
 }
 
 class GLCanvasScissor : public GLScissor {
@@ -89,7 +61,7 @@ public:
     :GLCanvasScissor(ToPhysicalScissor(rc)) {}
 
   [[nodiscard]]
-  GLCanvasScissor(GLCanvasScissorParams p) noexcept
+  GLCanvasScissor(OpenGL::PhysicalRect p) noexcept
     :GLScissor(p.x, p.y, p.width, p.height) {}
 };
 

--- a/src/ui/canvas/opengl/TopCanvas.cpp
+++ b/src/ui/canvas/opengl/TopCanvas.cpp
@@ -16,8 +16,16 @@ TopCanvas::GetSize() const noexcept
 PixelSize
 TopCanvas::SetupViewport(PixelSize native_size) noexcept
 {
-  auto new_size = OpenGL::SetupViewport(UnsignedPoint2D(native_size.width,
-                                                        native_size.height));
+  return SetupViewport(native_size, PixelSize(0, 0));
+}
+
+PixelSize
+TopCanvas::SetupViewport(PixelSize native_size,
+                         PixelSize content_size) noexcept
+{
+  auto new_size = OpenGL::SetupViewport(
+    UnsignedPoint2D(native_size.width, native_size.height),
+    UnsignedPoint2D(content_size.width, content_size.height));
   return PixelSize{new_size.x, new_size.y};
 }
 
@@ -49,12 +57,23 @@ TopCanvas::CheckResize(PixelSize new_native_size) noexcept
     return true;
   }
 #endif
-  
+
+  return CheckResize(new_native_size, PixelSize(0, 0));
+}
+
+bool
+TopCanvas::CheckResize(PixelSize new_native_size,
+                       PixelSize content_size) noexcept
+{
   if (new_native_size.width == OpenGL::window_size.x &&
       new_native_size.height == OpenGL::window_size.y)
     return false;
 
-  SetupViewport(new_native_size);
+  const auto effective_content =
+    (content_size.width > 0 && content_size.height > 0)
+      ? content_size
+      : new_native_size;
+  SetupViewport(new_native_size, effective_content);
   return true;
 }
 

--- a/src/ui/display/wayland/Display.cpp
+++ b/src/ui/display/wayland/Display.cpp
@@ -79,6 +79,20 @@ static constexpr struct wl_output_listener output_listener = {
 };
 
 void
+SeatCapabilities(void *data, struct wl_seat *wl_seat,
+                 [[maybe_unused]] uint32_t caps) noexcept
+{
+  auto *d = static_cast<Display *>(data);
+  if (d->seat == wl_seat) {
+    d->has_touchscreen = (caps & WL_SEAT_CAPABILITY_TOUCH) != 0;
+  }
+}
+
+static constexpr struct wl_seat_listener seat_listener = {
+  .capabilities = SeatCapabilities,
+};
+
+void
 RegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
                const char *interface, uint32_t version)
 {
@@ -89,6 +103,11 @@ RegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
       wl_registry_bind(registry, id, &wl_output_interface, output_version));
     if (d->output != nullptr)
       wl_output_add_listener(d->output, &output_listener, d);
+  } else if (StringIsEqual(interface, "wl_seat") && d->seat == nullptr) {
+    d->seat = static_cast<wl_seat *>(
+      wl_registry_bind(registry, id, &wl_seat_interface, 1));
+    if (d->seat != nullptr)
+      wl_seat_add_listener(d->seat, &seat_listener, d);
   }
 }
 
@@ -112,11 +131,46 @@ Display::InitOutput() const noexcept
   wl_registry_add_listener(registry, &registry_listener,
                            const_cast<Display *>(this));
 
-  /* First roundtrip: get registry events (output global) */
+  /* First roundtrip: get registry events (output and seat globals) */
   wl_display_roundtrip(display);
 
-  /* Second roundtrip: get output events (geometry, mode, done) */
-  if (output != nullptr)
+  /* Second roundtrip: get output events (geometry, mode, done) and
+     seat capabilities */
+  if (output != nullptr || seat != nullptr)
+    wl_display_roundtrip(display);
+
+  /* If seat was detected during output initialization, mark it as initialized */
+  if (seat != nullptr)
+    seat_initialized = true;
+
+  wl_registry_destroy(registry);
+}
+
+void
+Display::InitSeat() const noexcept
+{
+  if (seat_initialized)
+    return;
+
+  seat_initialized = true;
+
+  /* If output is already initialized, seat should be too since they
+     share the same registry listener */
+  if (output_initialized)
+    return;
+
+  auto registry = wl_display_get_registry(display);
+  if (registry == nullptr)
+    return;
+
+  wl_registry_add_listener(registry, &registry_listener,
+                           const_cast<Display *>(this));
+
+  /* Roundtrip to get registry events (seat global) */
+  wl_display_roundtrip(display);
+
+  /* If we got a seat, do another roundtrip to get seat capabilities */
+  if (seat != nullptr)
     wl_display_roundtrip(display);
 
   wl_registry_destroy(registry);
@@ -133,6 +187,8 @@ Display::~Display() noexcept
 {
   if (output != nullptr)
     wl_output_destroy(output);
+  if (seat != nullptr)
+    wl_seat_destroy(seat);
   wl_display_disconnect(display);
 }
 
@@ -148,6 +204,13 @@ Display::GetSizeMM() const noexcept
 {
   InitOutput();
   return size_mm;
+}
+
+bool
+Display::HasTouchScreen() const noexcept
+{
+  InitSeat();
+  return has_touchscreen;
 }
 
 } // namespace Wayland

--- a/src/ui/display/wayland/Display.cpp
+++ b/src/ui/display/wayland/Display.cpp
@@ -80,12 +80,13 @@ static constexpr struct wl_output_listener output_listener = {
 
 void
 RegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
-               const char *interface, [[maybe_unused]] uint32_t version)
+               const char *interface, uint32_t version)
 {
   auto *d = static_cast<Display *>(data);
   if (StringIsEqual(interface, "wl_output") && d->output == nullptr) {
+    const uint32_t output_version = version < 2 ? version : 2;
     d->output = static_cast<wl_output *>(
-      wl_registry_bind(registry, id, &wl_output_interface, 2));
+      wl_registry_bind(registry, id, &wl_output_interface, output_version));
     if (d->output != nullptr)
       wl_output_add_listener(d->output, &output_listener, d);
   }

--- a/src/ui/display/wayland/Display.cpp
+++ b/src/ui/display/wayland/Display.cpp
@@ -3,6 +3,8 @@
 
 #include "Display.hpp"
 #include "Hardware/DisplayDPI.hpp"
+#include "ui/dim/Size.hpp"
+#include "util/StringAPI.hxx"
 
 #ifdef USE_EGL
 #include "ui/egl/System.hpp"
@@ -12,10 +14,112 @@
 #include "ui/glx/System.hpp"
 #endif
 
+#include <wayland-client.h>
+
 #include <cassert>
 #include <stdexcept>
 
 namespace Wayland {
+
+void
+OutputGeometry(void *data, struct wl_output *wl_output,
+               [[maybe_unused]] int32_t x,
+               [[maybe_unused]] int32_t y,
+               int32_t physical_width,
+               int32_t physical_height,
+               [[maybe_unused]] int32_t subpixel,
+               [[maybe_unused]] const char *make,
+               [[maybe_unused]] const char *model,
+               [[maybe_unused]] int32_t transform) noexcept
+{
+  auto *d = static_cast<Display *>(data);
+  if (d->output == wl_output && physical_width > 0 && physical_height > 0) {
+    d->size_mm = {static_cast<unsigned>(physical_width),
+                   static_cast<unsigned>(physical_height)};
+  }
+}
+
+void
+OutputMode(void *data, struct wl_output *wl_output,
+           [[maybe_unused]] uint32_t flags,
+           int32_t width, int32_t height,
+           [[maybe_unused]] int32_t refresh) noexcept
+{
+  auto *d = static_cast<Display *>(data);
+  if (d->output == wl_output && width > 0 && height > 0) {
+    /* Always prefer the current mode (flags & WL_OUTPUT_MODE_CURRENT).
+       If no current mode has been received yet, use the first mode. */
+    if ((flags & WL_OUTPUT_MODE_CURRENT) || d->size.width == 0) {
+      d->size = {static_cast<unsigned>(width),
+                  static_cast<unsigned>(height)};
+    }
+  }
+}
+
+void
+OutputDone([[maybe_unused]] void *data,
+           [[maybe_unused]] struct wl_output *wl_output) noexcept
+{
+}
+
+void
+OutputScale([[maybe_unused]] void *data,
+            [[maybe_unused]] struct wl_output *wl_output,
+            [[maybe_unused]] int32_t factor) noexcept
+{
+  /* Scale factor is provided by the compositor but we calculate DPI
+     from physical dimensions, so we don't need to track it. */
+}
+
+static constexpr struct wl_output_listener output_listener = {
+  .geometry = OutputGeometry,
+  .mode = OutputMode,
+  .done = OutputDone,
+  .scale = OutputScale,
+};
+
+void
+RegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
+               const char *interface, [[maybe_unused]] uint32_t version)
+{
+  auto *d = static_cast<Display *>(data);
+  if (StringIsEqual(interface, "wl_output") && d->output == nullptr) {
+    d->output = static_cast<wl_output *>(
+      wl_registry_bind(registry, id, &wl_output_interface, 2));
+    if (d->output != nullptr)
+      wl_output_add_listener(d->output, &output_listener, d);
+  }
+}
+
+static constexpr struct wl_registry_listener registry_listener = {
+  .global = RegistryGlobal,
+  .global_remove = nullptr,
+};
+
+void
+Display::InitOutput() const noexcept
+{
+  if (output_initialized)
+    return;
+
+  output_initialized = true;
+
+  auto registry = wl_display_get_registry(display);
+  if (registry == nullptr)
+    return;
+
+  wl_registry_add_listener(registry, &registry_listener,
+                           const_cast<Display *>(this));
+
+  /* First roundtrip: get registry events (output global) */
+  wl_display_roundtrip(display);
+
+  /* Second roundtrip: get output events (geometry, mode, done) */
+  if (output != nullptr)
+    wl_display_roundtrip(display);
+
+  wl_registry_destroy(registry);
+}
 
 Display::Display()
   :display(wl_display_connect(nullptr))
@@ -26,7 +130,23 @@ Display::Display()
 
 Display::~Display() noexcept
 {
+  if (output != nullptr)
+    wl_output_destroy(output);
   wl_display_disconnect(display);
+}
+
+PixelSize
+Display::GetSize() const noexcept
+{
+  InitOutput();
+  return size;
+}
+
+PixelSize
+Display::GetSizeMM() const noexcept
+{
+  InitOutput();
+  return size_mm;
 }
 
 } // namespace Wayland

--- a/src/ui/display/wayland/Display.cpp
+++ b/src/ui/display/wayland/Display.cpp
@@ -32,8 +32,6 @@ OutputGeometry(void *data, struct wl_output *wl_output,
                [[maybe_unused]] const char *model,
                [[maybe_unused]] int32_t transform) noexcept
 {
-  /* physical_width / physical_height are in millimeters (Wayland protocol).
-     Used with mode width/height (pixels) to compute physical DPI. */
   auto *d = static_cast<Display *>(data);
   if (d->output == wl_output && physical_width > 0 && physical_height > 0) {
     d->size_mm = {static_cast<unsigned>(physical_width),
@@ -95,13 +93,12 @@ static constexpr struct wl_seat_listener seat_listener = {
 
 void
 RegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
-               const char *interface, uint32_t version)
+               const char *interface, [[maybe_unused]] uint32_t version)
 {
   auto *d = static_cast<Display *>(data);
   if (StringIsEqual(interface, "wl_output") && d->output == nullptr) {
-    const uint32_t output_version = version < 2 ? version : 2;
     d->output = static_cast<wl_output *>(
-      wl_registry_bind(registry, id, &wl_output_interface, output_version));
+      wl_registry_bind(registry, id, &wl_output_interface, 2));
     if (d->output != nullptr)
       wl_output_add_listener(d->output, &output_listener, d);
   } else if (StringIsEqual(interface, "wl_seat") && d->seat == nullptr) {

--- a/src/ui/display/wayland/Display.hpp
+++ b/src/ui/display/wayland/Display.hpp
@@ -31,6 +31,7 @@ class Display {
   mutable struct wl_output *output = nullptr;
   mutable PixelSize size{0, 0};
   mutable PixelSize size_mm{0, 0};
+  mutable int output_scale = 1;  /* set by wl_output scale event */
   mutable bool output_initialized = false;
 
   mutable struct wl_seat *seat = nullptr;
@@ -61,6 +62,12 @@ public:
    * Returns the display size in mm.
    */
   PixelSize GetSizeMM() const noexcept;
+
+  /**
+   * Returns the wl_output scale factor (1, 2, 3, ...). Used for
+   * wl_surface_set_buffer_scale and buffer sizing on HiDPI.
+   */
+  int GetScale() const noexcept;
 
   /**
    * Returns whether a touch screen is available.

--- a/src/ui/display/wayland/Display.hpp
+++ b/src/ui/display/wayland/Display.hpp
@@ -3,12 +3,35 @@
 
 #pragma once
 
+#include "ui/dim/Size.hpp"
+
+#include <cstdint>
+
 struct wl_display;
+struct wl_output;
+struct wl_registry;
 
 namespace Wayland {
 
 class Display {
+  friend void OutputGeometry(void *, struct wl_output *, int32_t, int32_t,
+                             int32_t, int32_t, int32_t, const char *,
+                             const char *, int32_t) noexcept;
+  friend void OutputMode(void *, struct wl_output *, uint32_t, int32_t,
+                         int32_t, int32_t) noexcept;
+  friend void OutputDone(void *, struct wl_output *) noexcept;
+  friend void OutputScale(void *, struct wl_output *, int32_t) noexcept;
+  friend void RegistryGlobal(void *, struct wl_registry *, uint32_t,
+                             const char *, uint32_t);
+
   struct wl_display *const display;
+
+  mutable struct wl_output *output = nullptr;
+  mutable PixelSize size{0, 0};
+  mutable PixelSize size_mm{0, 0};
+  mutable bool output_initialized = false;
+
+  void InitOutput() const noexcept;
 
 public:
   /**
@@ -21,6 +44,16 @@ public:
   auto GetWaylandDisplay() noexcept {
     return display;
   }
+
+  /**
+   * Returns the display size in pixels.
+   */
+  PixelSize GetSize() const noexcept;
+
+  /**
+   * Returns the display size in mm.
+   */
+  PixelSize GetSizeMM() const noexcept;
 };
 
 } // namespace Wayland

--- a/src/ui/display/wayland/Display.hpp
+++ b/src/ui/display/wayland/Display.hpp
@@ -10,6 +10,7 @@
 struct wl_display;
 struct wl_output;
 struct wl_registry;
+struct wl_seat;
 
 namespace Wayland {
 
@@ -23,6 +24,7 @@ class Display {
   friend void OutputScale(void *, struct wl_output *, int32_t) noexcept;
   friend void RegistryGlobal(void *, struct wl_registry *, uint32_t,
                              const char *, uint32_t);
+  friend void SeatCapabilities(void *, struct wl_seat *, uint32_t) noexcept;
 
   struct wl_display *const display;
 
@@ -31,7 +33,12 @@ class Display {
   mutable PixelSize size_mm{0, 0};
   mutable bool output_initialized = false;
 
+  mutable struct wl_seat *seat = nullptr;
+  mutable bool has_touchscreen = false;
+  mutable bool seat_initialized = false;
+
   void InitOutput() const noexcept;
+  void InitSeat() const noexcept;
 
 public:
   /**
@@ -54,6 +61,11 @@ public:
    * Returns the display size in mm.
    */
   PixelSize GetSizeMM() const noexcept;
+
+  /**
+   * Returns whether a touch screen is available.
+   */
+  bool HasTouchScreen() const noexcept;
 };
 
 } // namespace Wayland

--- a/src/ui/display/wayland/Display.hpp
+++ b/src/ui/display/wayland/Display.hpp
@@ -70,6 +70,15 @@ public:
   int GetScale() const noexcept;
 
   /**
+   * Integer scale for buffer sizing and wl_surface_set_buffer_scale,
+   * never below 1 (matches compositor output scale).
+   */
+  int GetBufferScale() const noexcept {
+    const int s = GetScale();
+    return s < 1 ? 1 : s;
+  }
+
+  /**
    * Returns whether a touch screen is available.
    */
   bool HasTouchScreen() const noexcept;

--- a/src/ui/display/x11/Display.cpp
+++ b/src/ui/display/x11/Display.cpp
@@ -13,6 +13,8 @@
 #include "LogFile.hpp"
 #endif
 
+#include <X11/Xlib.h>
+#include <cstdlib>
 #include <stdexcept>
 
 namespace X11 {
@@ -98,6 +100,16 @@ PixelSize
 Display::GetSizeMM() const noexcept
 {
   return {DisplayWidthMM(display, 0), DisplayHeightMM(display, 0)};
+}
+
+unsigned
+Display::GetXftDPI() const noexcept
+{
+  if (const char *dpi_str = XGetDefault(display, "Xft", "dpi")) {
+    const int dpi = atoi(dpi_str);
+    return dpi >= 48 && dpi <= 480 ? static_cast<unsigned>(dpi) : 0;
+  }
+  return 0;
 }
 
 } // namespace X11

--- a/src/ui/display/x11/Display.hpp
+++ b/src/ui/display/x11/Display.hpp
@@ -37,8 +37,18 @@ public:
   /**
    * Returns the display size in mm.
    */
+  /**
+   * Returns the display size in mm.
+   */
   [[gnu::pure]]
   PixelSize GetSizeMM() const noexcept;
+
+  /**
+   * Returns Xft.dpi from the X resource database when physical size (mm)
+   * is unavailable; 0 otherwise. Used as DPI fallback on X11.
+   */
+  [[gnu::pure]]
+  unsigned GetXftDPI() const noexcept;
 
 #ifdef USE_GLX
   auto *GetFBConfig() const noexcept {

--- a/src/ui/display/x11/Display.hpp
+++ b/src/ui/display/x11/Display.hpp
@@ -37,9 +37,6 @@ public:
   /**
    * Returns the display size in mm.
    */
-  /**
-   * Returns the display size in mm.
-   */
   [[gnu::pure]]
   PixelSize GetSizeMM() const noexcept;
 

--- a/src/ui/event/poll/WaylandQueue.cpp
+++ b/src/ui/event/poll/WaylandQueue.cpp
@@ -38,10 +38,10 @@ namespace UI {
 
 static void
 WaylandRegistryGlobal(void *data, struct wl_registry *registry, uint32_t id,
-                      const char *interface, [[maybe_unused]] uint32_t version)
+                      const char *interface, uint32_t version)
 {
   auto &q = *(WaylandEventQueue *)data;
-  q.RegistryHandler(registry, id, interface);
+  q.RegistryHandler(registry, id, interface, version);
 }
 
 static void
@@ -423,11 +423,15 @@ WaylandEventQueue::OnFlush() noexcept
 
 inline void
 WaylandEventQueue::RegistryHandler(struct wl_registry *registry, uint32_t id,
-                                   const char *interface) noexcept
+                                   const char *interface,
+                                   uint32_t version) noexcept
 {
-  if (StringIsEqual(interface, "wl_compositor"))
+  if (StringIsEqual(interface, "wl_compositor")) {
+    const uint32_t compositor_version = version < 3 ? version : 3;
     compositor = (wl_compositor *)
-      wl_registry_bind(registry, id, &wl_compositor_interface, 1);
+      wl_registry_bind(registry, id, &wl_compositor_interface,
+                      compositor_version);
+  }
   else if (StringIsEqual(interface, "wl_seat")) {
     seat = (wl_seat *)wl_registry_bind(registry, id,
                                          &wl_seat_interface, 1);
@@ -636,18 +640,22 @@ WaylandEventQueue::KeyboardKey(uint32_t key, uint32_t state) noexcept
   }
 }
 
-#ifdef SOFTWARE_ROTATE_DISPLAY
-
 void
 WaylandEventQueue::SetScreenSize(PixelSize new_size) noexcept
 {
   screen_size = new_size;
+#ifdef SOFTWARE_ROTATE_DISPLAY
   if (AreAxesSwapped(OpenGL::display_orientation)) {
     physical_screen_size = PixelSize(new_size.height, new_size.width);
   } else {
     physical_screen_size = new_size;
   }
+#else
+  physical_screen_size = new_size;
+#endif
 }
+
+#ifdef SOFTWARE_ROTATE_DISPLAY
 
 void
 WaylandEventQueue::SetDisplayOrientation([[maybe_unused]] DisplayOrientation orientation) noexcept

--- a/src/ui/event/poll/WaylandQueue.cpp
+++ b/src/ui/event/poll/WaylandQueue.cpp
@@ -83,16 +83,18 @@ static constexpr struct wl_seat_listener seat_listener = {
 
 static void
 WaylandPointerEnter(void *data,
-                    [[maybe_unused]] struct wl_pointer *wl_pointer,
-                    [[maybe_unused]] uint32_t serial,
+                    struct wl_pointer *wl_pointer,
+                    uint32_t serial,
                     [[maybe_unused]] struct wl_surface *surface,
                     wl_fixed_t surface_x,
                     wl_fixed_t surface_y)
 {
   auto &queue = *(WaylandEventQueue *)data;
-
+  queue.SetPointerSerial(serial);
   queue.PointerMotion(IntPoint2D(wl_fixed_to_int(surface_x),
                                  wl_fixed_to_int(surface_y)));
+  queue.UpdateCursorForPosition();
+  queue.SetCursor(wl_pointer, serial);
 }
 
 static void
@@ -105,14 +107,16 @@ WaylandPointerLeave([[maybe_unused]] void *data,
 
 static void
 WaylandPointerMotion(void *data,
-                     [[maybe_unused]] struct wl_pointer *wl_pointer,
+                     struct wl_pointer *wl_pointer,
                      [[maybe_unused]] uint32_t time,
                      wl_fixed_t surface_x, wl_fixed_t surface_y)
 {
   auto &queue = *(WaylandEventQueue *)data;
-
   queue.PointerMotion(IntPoint2D(wl_fixed_to_int(surface_x),
                                  wl_fixed_to_int(surface_y)));
+  queue.UpdateCursorForPosition();
+  if (wl_pointer != nullptr && queue.GetPointerSerial() != 0)
+    queue.SetCursor(wl_pointer, queue.GetPointerSerial());
 }
 
 static void
@@ -281,12 +285,27 @@ WaylandEventQueue::WaylandEventQueue(UI::Display &_display, EventQueue &_queue)
   }
   cursor_theme = wl_cursor_theme_load(nullptr, cursor_size, shm);
   if (cursor_theme != nullptr) {
-    cursor_pointer = wl_cursor_theme_get_cursor(cursor_theme, "left_ptr");
-    if (cursor_pointer == nullptr) {
-      /* Fallback to default cursor name */
-      cursor_pointer = wl_cursor_theme_get_cursor(cursor_theme, "default");
-    }
-    if (cursor_pointer != nullptr && compositor != nullptr) {
+    /* Load default arrow cursor */
+    cursor_arrow = wl_cursor_theme_get_cursor(cursor_theme, "left_ptr");
+    if (cursor_arrow == nullptr)
+      cursor_arrow = wl_cursor_theme_get_cursor(cursor_theme, "default");
+
+    /* Load resize cursors for edge detection - use horizontal/vertical only */
+    cursor_resize_horizontal = wl_cursor_theme_get_cursor(cursor_theme, "sb_h_double_arrow");
+    if (cursor_resize_horizontal == nullptr)
+      cursor_resize_horizontal = wl_cursor_theme_get_cursor(cursor_theme, "h_double_arrow");
+    if (cursor_resize_horizontal == nullptr)
+      cursor_resize_horizontal = wl_cursor_theme_get_cursor(cursor_theme, "left_side");
+
+    cursor_resize_vertical = wl_cursor_theme_get_cursor(cursor_theme, "sb_v_double_arrow");
+    if (cursor_resize_vertical == nullptr)
+      cursor_resize_vertical = wl_cursor_theme_get_cursor(cursor_theme, "v_double_arrow");
+    if (cursor_resize_vertical == nullptr)
+      cursor_resize_vertical = wl_cursor_theme_get_cursor(cursor_theme, "top_side");
+
+    current_cursor = cursor_arrow;
+
+    if (current_cursor != nullptr && compositor != nullptr) {
       cursor_surface = wl_compositor_create_surface(compositor);
     }
   }
@@ -620,24 +639,73 @@ WaylandEventQueue::KeyboardKey(uint32_t key, uint32_t state) noexcept
 #ifdef SOFTWARE_ROTATE_DISPLAY
 
 void
-WaylandEventQueue::SetScreenSize(PixelSize screen_size) noexcept
+WaylandEventQueue::SetScreenSize(PixelSize new_size) noexcept
 {
-  physical_screen_size = screen_size;
+  screen_size = new_size;
+  if (AreAxesSwapped(OpenGL::display_orientation)) {
+    physical_screen_size = PixelSize(new_size.height, new_size.width);
+  } else {
+    physical_screen_size = new_size;
+  }
+}
+
+void
+WaylandEventQueue::SetDisplayOrientation([[maybe_unused]] DisplayOrientation orientation) noexcept
+{
 }
 
 #endif
 
 void
+WaylandEventQueue::UpdateCursorForPosition() noexcept
+{
+  if (screen_size.width == 0 || screen_size.height == 0 || cursor_theme == nullptr) {
+    current_cursor = cursor_arrow;
+    return;
+  }
+
+  static constexpr unsigned EDGE_THRESHOLD = 5;
+  const unsigned x = pointer_position.x;
+  const unsigned y = pointer_position.y;
+  const unsigned w = screen_size.width;
+  const unsigned h = screen_size.height;
+
+  const bool near_horizontal = (x < EDGE_THRESHOLD) || (x + EDGE_THRESHOLD >= w);
+  const bool near_vertical = (y < EDGE_THRESHOLD) || (y + EDGE_THRESHOLD >= h);
+
+  current_cursor = SelectCursorForEdge(near_horizontal, near_vertical);
+}
+
+struct wl_cursor *
+WaylandEventQueue::SelectCursorForEdge(bool near_horizontal, bool near_vertical) const noexcept
+{
+  /* If near both edges (corner), prefer vertical cursor */
+  if (near_horizontal && near_vertical)
+    return cursor_resize_vertical ?: cursor_arrow;
+
+  /* Horizontal edge */
+  if (near_horizontal)
+    return cursor_resize_horizontal ?: cursor_arrow;
+
+  /* Vertical edge */
+  if (near_vertical)
+    return cursor_resize_vertical ?: cursor_arrow;
+
+  /* Default arrow cursor */
+  return cursor_arrow;
+}
+
+void
 WaylandEventQueue::SetCursor(struct wl_pointer *wl_pointer, uint32_t serial) noexcept
 {
-  if (cursor_surface == nullptr || cursor_pointer == nullptr)
+  if (cursor_surface == nullptr || current_cursor == nullptr)
     return;
 
   /* wl_cursor contains an images array of wl_cursor_image structs */
-  if (cursor_pointer->image_count == 0)
+  if (current_cursor->image_count == 0)
     return;
 
-  struct wl_cursor_image *image = cursor_pointer->images[0];
+  struct wl_cursor_image *image = current_cursor->images[0];
   if (image == nullptr)
     return;
 

--- a/src/ui/event/poll/WaylandQueue.hpp
+++ b/src/ui/event/poll/WaylandQueue.hpp
@@ -13,6 +13,8 @@
 
 #include <cstdint>
 
+enum class DisplayOrientation : uint8_t;
+
 struct xkb_context;
 struct xkb_keymap;
 struct xkb_state;
@@ -60,10 +62,15 @@ class WaylandEventQueue final {
 
   /* Cursor support */
   struct wl_cursor_theme *cursor_theme = nullptr;
-  struct wl_cursor *cursor_pointer = nullptr;
+  struct wl_cursor *cursor_arrow = nullptr;
+  struct wl_cursor *cursor_resize_horizontal = nullptr;
+  struct wl_cursor *cursor_resize_vertical = nullptr;
+  struct wl_cursor *current_cursor = nullptr;
   struct wl_surface *cursor_surface = nullptr;
 
   IntPoint2D pointer_position = {0, 0};
+  PixelSize screen_size{0, 0};
+  uint32_t pointer_serial = 0;
 
   struct xkb_context *xkb_context = nullptr;
   struct xkb_keymap *xkb_keymap = nullptr;
@@ -129,8 +136,9 @@ public:
 
   bool Generate(Event &event) noexcept;
 
-#ifdef SOFTWARE_ROTATE_DISPLAY
   void SetScreenSize(PixelSize new_size) noexcept;
+#ifdef SOFTWARE_ROTATE_DISPLAY
+  void SetDisplayOrientation(DisplayOrientation orientation) noexcept;
 #endif
 
   void RegistryHandler(struct wl_registry *registry, uint32_t id,
@@ -154,8 +162,16 @@ public:
                          uint32_t mods_locked, uint32_t group) noexcept;
 
   void SetCursor(struct wl_pointer *wl_pointer, uint32_t serial) noexcept;
+  void UpdateCursorForPosition() noexcept;
+  void SetPointerSerial(uint32_t serial) noexcept {
+    pointer_serial = serial;
+  }
+  uint32_t GetPointerSerial() const noexcept {
+    return pointer_serial;
+  }
 
 private:
+  struct wl_cursor *SelectCursorForEdge(bool near_horizontal, bool near_vertical) const noexcept;
   void OnSocketReady(unsigned events) noexcept;
   void OnFlush() noexcept;
 };

--- a/src/ui/event/poll/WaylandQueue.hpp
+++ b/src/ui/event/poll/WaylandQueue.hpp
@@ -142,7 +142,7 @@ public:
 #endif
 
   void RegistryHandler(struct wl_registry *registry, uint32_t id,
-                       const char *interface) noexcept;
+                       const char *interface, uint32_t version) noexcept;
 
   void SeatHandleCapabilities(bool pointer, bool keyboard, bool touch) noexcept;
 

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -93,8 +93,15 @@ TopWindow::Create([[maybe_unused]] const char *text, PixelSize size,
   PixelSize native_size = screen->GetNativeSize();
   // On Android, surface might not be ready yet, so GetNativeSize() may return 0x0
   // In that case, use the size passed to Create() (which should have a fallback)
-  if (native_size.width > 0 && native_size.height > 0)
+  if (native_size.width > 0 && native_size.height > 0) {
+#if defined(USE_WAYLAND)
+    /* Wayland: set viewport to (physical, logical) from first frame; keep
+       logical size for window so compositor buffer scale does not double-scale. */
+    screen->CheckResize(native_size, size);
+#else
     size = native_size;
+#endif
+  }
   // else keep the original size (which should be from SystemWindowSize() with fallback)
 #endif
   ContainerWindow::Create(nullptr, PixelRect{size}, style);

--- a/src/ui/window/poll/TopWindow.cpp
+++ b/src/ui/window/poll/TopWindow.cpp
@@ -19,6 +19,10 @@
 #include "ui/canvas/custom/TopCanvas.hpp"
 #endif
 
+#ifdef USE_X11
+#include "Hardware/DisplayDPI.hpp"
+#endif
+
 namespace UI {
 
 void
@@ -98,13 +102,26 @@ TopWindow::OnEvent(const Event &event)
     return OnMouseWheel(event.point, (int)event.param);
 
 #ifdef USE_X11
-  case Event::RESIZE:
+  case Event::RESIZE: {
     if (event.point.x <= 0 || event.point.y <= 0)
       return true;
 
-    if (screen->CheckResize(PixelSize(event.point.x, event.point.y)))
+    const PixelSize physical(event.point.x, event.point.y);
+    const unsigned scale = Hardware::GetContentScale(GetDisplay());
+    const PixelSize content =
+      (scale > 1)
+        ? PixelSize(physical.width / scale, physical.height / scale)
+        : physical;
+
+    if (!screen->CheckResize(physical))
+      return true;
+
+    if (scale > 1)
+      Resize(content);
+    else
       Resize(screen->GetSize());
     return true;
+  }
 #endif
 
 #if defined(USE_X11) || defined(MESA_KMS)

--- a/src/ui/window/wayland/TopWindow.cpp
+++ b/src/ui/window/wayland/TopWindow.cpp
@@ -16,7 +16,6 @@
 #include "ui/canvas/opengl/Globals.hpp"
 #endif
 
-#include <algorithm>
 #include <chrono>
 #include <stdexcept>
 
@@ -146,7 +145,7 @@ TopWindow::CreateNative(const char *text, PixelSize size,
   /* Use buffer scale only when wl_surface has version >= 3 (set_buffer_scale);
    * otherwise stick to scale 1 for compatibility with older compositors. */
   const int scale = (wl_proxy_get_version((struct wl_proxy *)wl_surface) >= 3)
-    ? std::max(1, display.GetScale())
+    ? display.GetBufferScale()
     : 1;
   if (scale > 1)
     wl_surface_set_buffer_scale(wl_surface, scale);
@@ -280,7 +279,7 @@ TopWindow::OnResize(PixelSize new_size) noexcept
     return;
 
   /* new_size is logical; buffer and viewport use physical (logical * scale) */
-  const int scale = std::max(1, display.GetScale());
+  const int scale = display.GetBufferScale();
   const auto physical_size =
     PixelSize(new_size.width * scale, new_size.height * scale);
 

--- a/src/ui/window/wayland/TopWindow.cpp
+++ b/src/ui/window/wayland/TopWindow.cpp
@@ -16,8 +16,9 @@
 #include "ui/canvas/opengl/Globals.hpp"
 #endif
 
-#include <stdexcept>
+#include <algorithm>
 #include <chrono>
+#include <stdexcept>
 
 namespace UI {
 
@@ -142,6 +143,14 @@ TopWindow::CreateNative(const char *text, PixelSize size,
   if (wl_surface == nullptr)
     throw std::runtime_error("Failed to create Wayland surface");
 
+  /* Use buffer scale only when wl_surface has version >= 3 (set_buffer_scale);
+   * otherwise stick to scale 1 for compatibility with older compositors. */
+  const int scale = (wl_proxy_get_version((struct wl_proxy *)wl_surface) >= 3)
+    ? std::max(1, display.GetScale())
+    : 1;
+  if (scale > 1)
+    wl_surface_set_buffer_scale(wl_surface, scale);
+
   if (auto wm_base = event_queue->GetWmBase()) {
     xdg_wm_base_add_listener(wm_base, &wm_base_listener, nullptr);
 
@@ -195,7 +204,9 @@ TopWindow::CreateNative(const char *text, PixelSize size,
   wl_surface_set_opaque_region(wl_surface, region);
   wl_region_destroy(region);
 
-  native_window = wl_egl_window_create(wl_surface, size.width, size.height);
+  const unsigned buffer_width = size.width * scale;
+  const unsigned buffer_height = size.height * scale;
+  native_window = wl_egl_window_create(wl_surface, buffer_width, buffer_height);
   if (native_window == nullptr)
     throw std::runtime_error("Failed to create Wayland EGL window");
 }
@@ -255,7 +266,7 @@ TopWindow::OnResize(PixelSize new_size) noexcept
   /* Skip initial resize from ContainerWindow::Create if we haven't received
    * the first configure event yet. This prevents the window from being
    * resized to the requested size before the compositor sends actual dimensions. */
-  if (!received_first_configure && 
+  if (!received_first_configure &&
       new_size.width == initial_requested_size.width &&
       new_size.height == initial_requested_size.height) {
     return;
@@ -263,28 +274,44 @@ TopWindow::OnResize(PixelSize new_size) noexcept
 
   BumpRenderStateToken();
 
+  /* Reject zero size (compositor may send 0x0 when fractional scale changes
+   * before sending the next configure with actual dimensions). */
+  if (new_size.width == 0 || new_size.height == 0)
+    return;
+
+  /* new_size is logical; buffer and viewport use physical (logical * scale) */
+  const int scale = std::max(1, display.GetScale());
+  const auto physical_size =
+    PixelSize(new_size.width * scale, new_size.height * scale);
+
+  /* When fractional scale changes, output scale changes; keep surface
+   * buffer_scale in sync so the compositor interprets our buffer correctly. */
+  if (wl_surface != nullptr &&
+      wl_proxy_get_version((struct wl_proxy *)wl_surface) >= 3) {
+    wl_surface_set_buffer_scale(wl_surface, scale);
+  }
+
+  /* Use logical size for input, swapped when only GL is rotated (software path). */
   PixelSize native_size = new_size;
 #ifdef SOFTWARE_ROTATE_DISPLAY
   if (AreAxesSwapped(OpenGL::display_orientation))
     native_size = PixelSize(new_size.height, new_size.width);
 #endif
-
-  /* Use native size for input coordinate transformation. */
   event_queue->SetScreenSize(native_size);
 
   if (native_window != nullptr) {
-    /* Update EGL window size */
-    wl_egl_window_resize(native_window,
-                         native_size.width, native_size.height, 0, 0);
+    /* Update EGL window size to physical pixels for sharp HiDPI rendering */
+    wl_egl_window_resize(native_window, physical_size.width, physical_size.height,
+                         0, 0);
   }
 
   /* Update opaque region for the new size BEFORE drawing.
-   * This ensures the compositor knows the new size before we present a frame. */
+   * Region is in surface-local logical coordinates. */
   if (wl_surface != nullptr && event_queue != nullptr) {
     auto compositor = event_queue->GetCompositor();
     if (compositor != nullptr) {
       const auto region = wl_compositor_create_region(compositor);
-      wl_region_add(region, 0, 0, native_size.width, native_size.height);
+      wl_region_add(region, 0, 0, new_size.width, new_size.height);
       wl_surface_set_opaque_region(wl_surface, region);
       wl_region_destroy(region);
       /* Don't commit yet - eglSwapBuffers() will commit automatically.
@@ -293,38 +320,33 @@ TopWindow::OnResize(PixelSize new_size) noexcept
     }
   }
 
-  /* The native configure callback has already updated the GL viewport size.
-     Orientation-only changes only need redraw/commit here. */
+  /* OpenGL viewport uses physical px; projection maps logical content. */
   if (screen != nullptr) {
-    Invalidate();
-    /* Force immediate redraw for visual feedback during resize.
-     * However, throttle flush/dispatch during rapid resize drags to avoid
-     * performance issues. Use longer throttle interval for e-paper displays
-     * which have much lower refresh rates (1-2fps full, ~10-15fps partial). */
-    if (screen->IsReady() && IsVisible()) {
-      Expose();
-      const auto now = std::chrono::steady_clock::now();
-      const auto time_since_last_flush =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-          now - last_resize_flush_time).count();
-      /* Use adaptive throttle based on display type:
-       * - E-paper: 100ms (~10fps max) to match slow refresh rate
-       * - Normal displays: 16ms (~60fps max) for smooth resizing */
-      const int throttle_ms = HasEPaper() ? 100 : 16;
-      if (time_since_last_flush >= throttle_ms) {
-        struct wl_display *wl_display = display.GetWaylandDisplay();
-        wl_display_flush(wl_display);
-        last_resize_flush_time = now;
+    const bool did_resize = screen->CheckResize(physical_size, new_size);
+    if (did_resize) {
+      Invalidate();
+      if (screen->IsReady() && IsVisible()) {
+        Expose();
+        const auto now = std::chrono::steady_clock::now();
+        const auto time_since_last_flush =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - last_resize_flush_time).count();
+        const int throttle_ms = HasEPaper() ? 100 : 16;
+        if (time_since_last_flush >= throttle_ms) {
+          struct wl_display *wl_display = display.GetWaylandDisplay();
+          wl_display_flush(wl_display);
+          wl_display_dispatch_pending(wl_display);
+          last_resize_flush_time = now;
+        }
+      } else {
+        if (wl_surface != nullptr)
+          wl_surface_commit(wl_surface);
       }
     } else {
-      /* If we can't draw now, commit the surface configuration so the
-       * compositor knows about the new size. We'll draw later. */
-      if (wl_surface != nullptr)
-        wl_surface_commit(wl_surface);
+      Invalidate();
     }
   }
 
-  /* Call base implementation */
   ContainerWindow::OnResize(new_size);
 
 #ifdef USE_MEMORY_CANVAS


### PR DESCRIPTION
## Summary

Rebased revival of the Wayland HiDPI work from closed #2116 onto current `master`.

- Query `wl_output` for physical size and compositor scale; compute real DPI instead of hardcoded 96
- Use `wl_surface_set_buffer_scale` and logical/physical coordinate separation for sharp rendering
- Add `GetContentScale()` / effective DPI in `Layout` to avoid double-scaling fonts and pen widths
- Fix OpenGL scissor/viewport handling so dialogs and lists render correctly on HiDPI (no clipped quarter-screen content)
- Detect touch screens via `wl_seat`; improve cursor edge detection for resize handles
- Add X11 `Xft.dpi` fallback for content scale when physical size is unavailable
- Refactor shared display metrics into `Math/DisplayMetrics.hpp`

Rebase notes: merged with master's existing `-touchscreen`/`-notouchscreen` handling via `CommandLine::ApplyTouchInputOverride()` and resolved `MenuBar` sizing to use `Layout::GetMaximumControlHeight()`.

## Test plan

- [ ] Build with `TARGET=WAYLAND` (CI / local)
- [ ] Run on Wayland compositor at 100% scale: UI sizing looks normal
- [ ] Run at 200% (or fractional) scale: text and controls remain readable, not blurry
- [ ] Open config dialog and waypoint list on HiDPI: full content visible (not clipped to lower-left quarter)
- [ ] Verify map scale / menu bar touch targets on touch-capable Wayland seat
- [ ] Compare X11 build with `Xft.dpi` set: layout uses logical coordinates correctly
- [ ] Test `-touchscreen` / `-notouchscreen` overrides still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved HiDPI and display-scaling support across Wayland and X11, helping the app size content more accurately on high-resolution screens.
  * Better touch-friendly sizing for controls, menus, and input rows.

* **Bug Fixes**
  * Fixed viewport, scissor, and texture coordinate handling so rendering matches the actual screen scale.
  * Improved Wayland cursor behavior near screen edges and during pointer movement.
  * Added more reliable display-size detection and DPI fallbacks when monitor metadata is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->