### PR TITLE
NOTAM/Settings: Fix hidden Q-code truncation in profile

### DIFF
--- a/src/NOTAM/Settings.hpp
+++ b/src/NOTAM/Settings.hpp
@@ -42,5 +42,5 @@ struct NOTAMSettings {
    *  obstacle admin)
    * See: faa.gov/air_traffic/publications/atpubs/notam_html/appendix_b.html
    */
-  StaticString<64> hidden_qcodes{"QA QK QN QOL QOA QOBTT"};
+  StaticString<256> hidden_qcodes{"QA QK QN QOL QOA QOBTT"};
 };

--- a/test/src/TestNOTAM.cpp
+++ b/test/src/TestNOTAM.cpp
@@ -67,7 +67,7 @@ MetadataValid(std::string_view json)
 int
 main()
 {
-  plan_tests(59);
+  plan_tests(62);
 
   const auto now = system_clock::now();
 
@@ -242,6 +242,16 @@ main()
   ok1(MetadataValid(R"({"xcsoar_timestamp":1712664000,"xcsoar_location_lat":50,"xcsoar_location_lon":8,"xcsoar_radius_km":25,"api_base_url":"https://notam.example/api"})"));
   ok1(!MetadataValid(R"({"xcsoar_timestamp":1712664000,"xcsoar_location_lat":50,"xcsoar_location_lon":8,"xcsoar_radius_km":25,"api_base_url":""})"));
   ok1(!MetadataValid(R"({"xcsoar_timestamp":1712664000})"));
+
+  {
+    NOTAMSettings settings;
+    settings.hidden_qcodes =
+      "QNMXX QOBCE QMXLT QAFXX QXXXX QRTTT QMXLC QOLAS QPOCH QFALT QWULW";
+    ok1(settings.hidden_qcodes == "QNMXX QOBCE QMXLT QAFXX QXXXX QRTTT "
+                                  "QMXLC QOLAS QPOCH QFALT QWULW");
+    ok1(NOTAMFilter::IsQCodeHidden("QWULW", settings.hidden_qcodes));
+    ok1(NOTAMFilter::IsQCodeHidden("QWULW", settings.hidden_qcodes.c_str()));
+  }
 
   {
     NOTAMSettings settings;


### PR DESCRIPTION
Fixes #2657

Increase `NOTAMSettings::hidden_qcodes` from `StaticString<64>` to
`StaticString<256>`. Lists longer than 63 characters were silently
truncated on profile save (e.g. the Q-code prefix list from the issue
report).

## Test plan

- [x] Unit test with the reported 65-character prefix list
- [x] CI green