### PR TITLE
Devices: Increase device slots from 6 to 8

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -28,6 +28,7 @@ Version 7.45 - not yet released
     ballast, attitude, radio, and related fields (#2340)
   - Glide polar sync in the device dialog is only shown for drivers that
     implement it (LXNAV)
+  - Increase the number of device slots from 6 to 8
 * ui
   - fix crash when switching pages from FLARM radar or thermal assistant back
     to a map page that has a bottom widget configured (#2583)

--- a/src/Device/Features.hpp
+++ b/src/Device/Features.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-static constexpr unsigned NUMDEV = 6;
+static constexpr unsigned NUMDEV = 8;
 static constexpr unsigned INTERNAL_DEVICE_SLOT = NUMDEV - 1;
 
 #if defined(ANDROID) || defined(__APPLE__)


### PR DESCRIPTION
- With the CCAS app being able to forward OGN traffic data to XCSoar and cheap SoftRF devices in Rx-only mode being able to afford a multi-protocol setup (FLARM + OGN), a device setup in XCSoar could end up looking like this:

1. FLARM
2. Vario
3. Secondary logger
4. Radio
5. SoftRF secondary OGN receiver
6. CCAS OGN middleware
7. Internal GPS

- Increasing the number of device slots to 8 would allow for this, as well as some flexibility for debugging devices without having to reconfigure device slots


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the number of available device slots from 6 to 8, allowing more devices to be used at once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->