### PR TITLE
Renderer/TrailRenderer: Reduce trail CPU load and improve merge-vario colouring

### DIFF
--- a/src/CalculationThread.cpp
+++ b/src/CalculationThread.cpp
@@ -112,6 +112,32 @@ CalculationThread::Tick() noexcept
 }
 
 void
+CalculationThread::ProcessReplayFix() noexcept
+{
+#ifdef HAVE_CPU_FREQUENCY
+  const ScopeLockCPU cpu;
+#endif
+
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+    glide_computer.ReadBlackboard(device_blackboard.Basic());
+  }
+
+  {
+    const std::lock_guard lock{mutex};
+    glide_computer.ReadComputerSettings(settings_computer);
+  }
+
+  glide_computer.Expire();
+  glide_computer.ProcessGPS(true);
+
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+    device_blackboard.ReadBlackboard(glide_computer.Calculated());
+  }
+}
+
+void
 CalculationThread::ForceTrigger() noexcept
 {
   {

--- a/src/CalculationThread.hpp
+++ b/src/CalculationThread.hpp
@@ -56,6 +56,12 @@ public:
 
   void ForceTrigger() noexcept;
 
+  /**
+   * Run one calculation cycle for bulk replay (no UI triggers).
+   * Call only while the worker thread is suspended.
+   */
+  void ProcessReplayFix() noexcept;
+
 protected:
   void Tick() noexcept override;
 };

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -5,15 +5,52 @@
 #include "Settings.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
+#include "Geo/GeoBounds.hpp"
 
-static constexpr unsigned full_trace_size = 1024;
+#include <cmath>
+
 static constexpr unsigned contest_trace_size = 256;
 static constexpr unsigned sprint_trace_size = 128;
 
 static constexpr auto full_trace_no_thin_time = std::chrono::minutes{2};
 
+/** Minimum |Δvario| to store another merge-vario sample (m/s). */
+static constexpr float MERGE_VARIO_DEDUPE_EPS = 0.05f;
+
+/** Near-zero band: always keep samples for Nullschieber colouring. */
+static constexpr float MERGE_VARIO_NULL_BAND = 0.05f;
+
+[[gnu::const]]
+static bool
+MergeVarioSampleWorthKeeping(float prev, float next) noexcept
+{
+  if (std::abs(next - prev) >= MERGE_VARIO_DEDUPE_EPS)
+    return true;
+
+  if ((prev > 0.f) != (next > 0.f))
+    return true;
+
+  const bool in_null = std::abs(next) < MERGE_VARIO_NULL_BAND;
+  const bool prev_in_null = std::abs(prev) < MERGE_VARIO_NULL_BAND;
+  if (in_null != prev_in_null)
+    return true;
+
+  return false;
+}
+
+static void
+PushMergeVarioDeduped(std::vector<TrailVarioSample> &dest,
+                      const TrailVarioSample &sample)
+{
+  if (!dest.empty() &&
+      !MergeVarioSampleWorthKeeping(dest.back().vario, sample.vario))
+    return;
+
+  dest.push_back(sample);
+}
+
 TraceComputer::TraceComputer()
- :full(full_trace_no_thin_time, Trace::null_time, full_trace_size),
+ :full(full_trace_no_thin_time, Trace::null_time, FULL_TRACE_MAX_POINTS),
   contest({}, Trace::null_time, contest_trace_size),
   sprint({}, std::chrono::minutes{120}, sprint_trace_size)
 {
@@ -26,6 +63,7 @@ TraceComputer::Reset()
     const std::lock_guard lock{mutex};
     full.clear();
     merge_vario_samples.clear();
+    merge_vario_archive.clear();
   }
 
   contest.clear();
@@ -40,14 +78,65 @@ TraceComputer::LockedCopyTo(TracePointVector &v) const
 }
 
 void
+TraceComputer::ArchiveMergeVarioForLegUnlocked(TracePoint::Time t0,
+                                               TracePoint::Time t1)
+{
+  if (!(t1 > t0))
+    return;
+
+  for (const auto &s : merge_vario_samples) {
+    if (s.time < t0 || s.time >= t1)
+      continue;
+
+    PushMergeVarioDeduped(merge_vario_archive, s);
+  }
+
+  const size_t max_archive_size = FULL_TRACE_MAX_POINTS;
+  if (merge_vario_archive.size() > max_archive_size) {
+    const size_t excess = merge_vario_archive.size() - max_archive_size;
+    merge_vario_archive.erase(merge_vario_archive.begin(),
+                              merge_vario_archive.begin() + excess);
+  }
+}
+
+void
 TraceComputer::CopyMergeVarioSamplesUnlocked(
-    std::vector<TrailVarioSample> &vario_samples) const
+    std::vector<TrailVarioSample> &vario_samples,
+    TracePoint::Time min_time) const
 {
   vario_samples.clear();
-  constexpr unsigned max_items = MERGE_VARIO_SAMPLES_CAPACITY - 1;
-  vario_samples.reserve(max_items);
-  for (const auto &s : merge_vario_samples)
-    vario_samples.push_back(s);
+
+  const auto min_count = merge_vario_archive.size() + MERGE_VARIO_SAMPLES_CAPACITY;
+  vario_samples.reserve(min_count);
+
+  for (const auto &s : merge_vario_archive) {
+    if (s.time >= min_time)
+      vario_samples.push_back(s);
+  }
+
+  const TracePoint::Time after_archive =
+    merge_vario_archive.empty()
+      ? min_time
+      : std::max(min_time, merge_vario_archive.back().time);
+
+  for (const auto &s : merge_vario_samples) {
+    if (s.time < after_archive)
+      continue;
+
+    bool duplicate = false;
+    /* Only need to compare vario values here; the loop is already limited
+       to archived samples with the same timestamp as the candidate. */
+    for (auto it = vario_samples.rbegin();
+         it != vario_samples.rend() && it->time == s.time; ++it) {
+      if (it->vario == s.vario) {
+        duplicate = true;
+        break;
+      }
+    }
+
+    if (!duplicate)
+      vario_samples.push_back(s);
+  }
 }
 
 void
@@ -78,7 +167,31 @@ TraceComputer::LockedCopySnapshot(TracePointVector &v,
 {
   const std::lock_guard lock{mutex};
   full.GetPoints(v, min_time, location, resolution);
-  CopyMergeVarioSamplesUnlocked(vario_samples);
+  CopyMergeVarioSamplesUnlocked(vario_samples, min_time);
+}
+
+void
+TraceComputer::LockedTrailQuery(const TrailQuery &query,
+                                TracePointVector &v,
+                                std::vector<TrailVarioSample> &vario_samples,
+                                Serial *append_serial,
+                                Serial *modify_serial) const
+{
+  const std::lock_guard lock{mutex};
+
+  if (query.bounds.IsValid())
+    full.GetPoints(v, query.min_time, query.bounds,
+                   query.project_location, query.min_distance_m);
+  else
+    full.GetPoints(v, query.min_time, query.project_location,
+                   query.min_distance_m);
+
+  CopyMergeVarioSamplesUnlocked(vario_samples, query.min_time);
+
+  if (append_serial != nullptr)
+    *append_serial = full.GetAppendSerial();
+  if (modify_serial != nullptr)
+    *modify_serial = full.GetModifySerial();
 }
 
 void
@@ -89,8 +202,14 @@ TraceComputer::PushMergeVarioSample(TracePoint::Time time, float vario) noexcept
      equal timestamps (several merge ticks per GPS second). */
   if (!merge_vario_samples.empty()) {
     const TracePoint::Time newest = merge_vario_samples.last().time;
-    if (time < newest)
+    if (time < newest) {
       merge_vario_samples.clear();
+      merge_vario_archive.clear();
+    } else {
+      const float last_vario = merge_vario_samples.last().vario;
+      if (!MergeVarioSampleWorthKeeping(last_vario, vario))
+        return;
+    }
   }
   merge_vario_samples.push({time, vario});
 }
@@ -110,7 +229,14 @@ TraceComputer::Update(const ComputerSettings &settings_computer,
 
   {
     const std::lock_guard lock{mutex};
+    const bool had_previous = !full.empty();
+    const TracePoint::Time leg_start =
+      had_previous ? full.back().GetTime() : TracePoint::Time{};
+
     full.push_back(point);
+
+    if (had_previous)
+      ArchiveMergeVarioForLegUnlocked(leg_start, point.GetTime());
   }
 
   // only contest requires trace_sprint

--- a/src/Computer/TraceComputer.hpp
+++ b/src/Computer/TraceComputer.hpp
@@ -5,6 +5,7 @@
 
 #include "thread/Mutex.hxx"
 #include "Engine/Trace/Trace.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "util/OverwritingRingBuffer.hpp"
 
 #include <vector>
@@ -22,9 +23,25 @@ struct TrailVarioSample {
 };
 
 /**
+ * Parameters for a filtered trace read (time, bounds, screen-space thinning).
+ */
+struct TrailQuery {
+  std::chrono::duration<unsigned> min_time{};
+  GeoBounds bounds{};
+  GeoPoint project_location{};
+  double min_distance_m{};
+};
+
+/**
  * Record a trace of the current flight.
  */
 class TraceComputer {
+  /**
+   * Full snail-trail capacity: ~14 h at \a Trace::push_back minimum spacing
+   * (2 s between stored fixes).
+   */
+  static constexpr unsigned FULL_TRACE_MAX_POINTS = 25200;
+
   /**
    * Capacity for #merge_vario_samples (must match ring template size).
    */
@@ -46,12 +63,23 @@ class TraceComputer {
   OverwritingRingBuffer<TrailVarioSample, MERGE_VARIO_SAMPLES_CAPACITY>
       merge_vario_samples;
 
+  /** Merge-vario samples for completed GPS legs (ring holds the open leg). */
+  std::vector<TrailVarioSample> merge_vario_archive;
+
   /**
-   * Append merge-time vario ring contents to \a vario_samples (mutex must
-   * already be held).
+   * Append merge-vario samples for the half-open interval [t0, t1) to
+   * #merge_vario_archive (mutex must already be held).
+   */
+  void ArchiveMergeVarioForLegUnlocked(TracePoint::Time t0,
+                                       TracePoint::Time t1);
+
+  /**
+   * Copy archived merge-vario samples plus the open-leg ring (mutex must
+   * already be held).  When \a min_time is non-zero, omit older samples.
    */
   void CopyMergeVarioSamplesUnlocked(
-      std::vector<TrailVarioSample> &vario_samples) const;
+      std::vector<TrailVarioSample> &vario_samples,
+      TracePoint::Time min_time = {}) const;
 
 public:
   TraceComputer();
@@ -115,6 +143,17 @@ public:
                           std::vector<TrailVarioSample> &vario_samples,
                           std::chrono::duration<unsigned> min_time,
                           const GeoPoint &location, double resolution) const;
+
+  /**
+   * Copy trace points and merge-vario samples matching \a query under one
+   * lock.  When \a append_serial and \a modify_serial are non-null, they
+   * are filled with the current trace serials.
+   */
+  void LockedTrailQuery(const TrailQuery &query,
+                        TracePointVector &v,
+                        std::vector<TrailVarioSample> &vario_samples,
+                        Serial *append_serial = nullptr,
+                        Serial *modify_serial = nullptr) const;
 
   /**
    * Called from #MergeThread after merged basic data is computed (must

--- a/src/Engine/Trace/Point.hpp
+++ b/src/Engine/Trace/Point.hpp
@@ -136,6 +136,10 @@ public:
   constexpr double GetVario() const noexcept {
     return vario;
   }
+
+  constexpr unsigned GetDriftFactor() const noexcept {
+    return drift_factor;
+  }
 };
 
 static_assert(is_trivial_ndebug<TracePoint>::value, "type is not trivial");

--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -3,10 +3,14 @@
 
 #include "Trace.hpp"
 #include "Vector.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/GeoClip.hpp"
 #include "util/GlobalSliceAllocator.hxx"
 
 #include <algorithm>
+#include <cstdint>
 #include <iterator>
+#include <vector>
 
 Trace::Trace(const Time _no_thin_time, const Time max_time,
              const unsigned max_size) noexcept
@@ -414,7 +418,7 @@ Trace::SyncPoints(TracePointerVector &v) const noexcept
 void
 Trace::GetPoints(TracePointVector &v, const Time min_time,
                  const GeoPoint &location,
-                 double min_distance) const noexcept
+                 double min_distance) const
 {
   /* skip the trace points that are before min_time */
   Trace::const_iterator i = begin(), end = this->end();
@@ -441,4 +445,58 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
     v.push_back(*i);
     i.NextSquareRange(sq_range, end);
   } while (i != end);
+}
+
+[[gnu::pure]]
+static bool
+SegmentIntersectsBounds(const GeoPoint &a, const GeoPoint &b,
+                        const GeoBounds &bounds) noexcept
+{
+  if (bounds.IsInside(a) || bounds.IsInside(b))
+    return true;
+
+  GeoClip clip(bounds);
+  GeoPoint a2 = a, b2 = b;
+  return clip.ClipLine(a2, b2);
+}
+
+void
+Trace::GetPoints(TracePointVector &v, const Time min_time,
+                 const GeoBounds &bounds,
+                 const GeoPoint &location,
+                 const double min_distance) const
+{
+  TracePointVector thinned;
+  GetPoints(thinned, min_time, location, min_distance);
+
+  if (thinned.empty()) {
+    v.clear();
+    return;
+  }
+
+  std::vector<uint8_t> keep(thinned.size(), 0);
+  for (size_t k = 0; k < thinned.size(); ++k) {
+    const GeoPoint gp = thinned[k].GetLocation();
+    if (bounds.IsInside(gp)) {
+      keep[k] = 1;
+      continue;
+    }
+
+    if (k > 0 &&
+        SegmentIntersectsBounds(thinned[k - 1].GetLocation(), gp, bounds))
+      keep[k] = 1;
+    else if (k + 1 < thinned.size() &&
+             SegmentIntersectsBounds(gp, thinned[k + 1].GetLocation(), bounds))
+      keep[k] = 1;
+  }
+
+  /* Keep only visible / bounds-crossing points.  Do not reinsert
+     off-screen gaps between separate viewport runs — that would let
+     trail size grow with flight duration despite the filter. */
+  v.clear();
+  v.reserve(thinned.size());
+  for (size_t k = 0; k < thinned.size(); ++k) {
+    if (keep[k])
+      v.push_back(thinned[k]);
+  }
 }

--- a/src/Engine/Trace/Trace.hpp
+++ b/src/Engine/Trace/Trace.hpp
@@ -20,6 +20,7 @@
 
 class TracePointVector;
 class TracePointerVector;
+class GeoBounds;
 
 /**
  * This class uses a smart thinning algorithm to limit the number of items
@@ -390,7 +391,16 @@ public:
    * resolution #min_distance.
    */
   void GetPoints(TracePointVector &v, Time min_time,
-                 const GeoPoint &location, double resolution) const noexcept;
+                 const GeoPoint &location, double resolution) const;
+
+  /**
+   * Like GetPoints() with time and distance thinning, but only returns
+   * points inside \a bounds or on legs that intersect \a bounds.
+   */
+  void GetPoints(TracePointVector &v, Time min_time,
+                 const GeoBounds &bounds,
+                 const GeoPoint &location,
+                 double min_distance) const;
 
   const TracePoint &front() const noexcept {
     assert(!empty());

--- a/src/Look/TrailLook.hpp
+++ b/src/Look/TrailLook.hpp
@@ -10,6 +10,7 @@ struct TrailSettings;
 
 struct TrailLook {
   static constexpr unsigned NUMSNAILCOLORS = 15;
+  static constexpr unsigned LOW_DPI_TRAIL_SCREEN_PX = 600;
 
   unsigned trail_widths[NUMSNAILCOLORS];
   Brush trail_brushes[NUMSNAILCOLORS];

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -43,6 +43,12 @@ MergeThread::Process() noexcept
 {
   assert(!IsDefined() || IsInside());
 
+  ProcessUnlocked();
+}
+
+void
+MergeThread::ProcessUnlocked() noexcept
+{
   device_blackboard.Merge();
 
   const MoreData &basic = device_blackboard.Basic();
@@ -61,6 +67,52 @@ MergeThread::Process() noexcept
 
   flarm_computer.Process(device_blackboard.SetBasic().flarm,
                          last_fix.flarm, basic);
+}
+
+void
+MergeThread::ProcessReplayFix() noexcept
+{
+  TracePoint::Time trail_push_time{};
+  float trail_push_vario = 0;
+  bool do_trail_vario_push = false;
+
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+
+    ProcessUnlocked();
+
+    const MoreData &basic = device_blackboard.Basic();
+    const DerivedInfo &calculated = device_blackboard.Calculated();
+
+    if (trail_vario_sink != nullptr &&
+        basic.time_available &&
+        basic.location_available &&
+        basic.NavAltitudeAvailable() &&
+        calculated.flight.flying) {
+      if (!computer.FilteredVarioActive()) {
+        if (basic.netto_vario_available) {
+          do_trail_vario_push = true;
+          trail_push_time = basic.time.Cast<TracePoint::Time>();
+          trail_push_vario = (float)basic.netto_vario;
+        }
+      } else if (basic.brutto_vario_available &&
+                 computer.FilteredVarioSampleUpdated()) {
+        do_trail_vario_push = true;
+        trail_push_time = basic.time.Cast<TracePoint::Time>();
+        trail_push_vario = (float)basic.FilteredNettoVario();
+      }
+    }
+
+    last_any = basic;
+
+    if ((basic.time_available &&
+         (!last_fix.time_available || basic.time != last_fix.time)) ||
+        basic.location_available != last_fix.location_available)
+      last_fix = basic;
+  }
+
+  if (do_trail_vario_push && trail_vario_sink != nullptr)
+    trail_vario_sink->PushMergeVarioSample(trail_push_time, trail_push_vario);
 }
 
 void
@@ -132,10 +184,8 @@ MergeThread::Tick() noexcept
     vario_output_updated = !computer.FilteredVarioActive() ||
       computer.FilteredVarioSampleUpdated();
 
-    /* update last_any in every iteration */
     last_any = basic;
 
-    /* update last_fix only when a new GPS fix was received */
     if ((basic.time_available &&
          (!last_fix.time_available || basic.time != last_fix.time)) ||
         basic.location_available != last_fix.location_available)

--- a/src/MergeThread.hpp
+++ b/src/MergeThread.hpp
@@ -58,6 +58,12 @@ public:
   }
 
   /**
+   * Process one replay fix through merge and trail-vario (no UI triggers).
+   * Call only while the worker thread is suspended.
+   */
+  void ProcessReplayFix() noexcept;
+
+  /**
    * Throws on error.
    */
   void Start(bool suspended=false) {
@@ -67,6 +73,12 @@ public:
 
 private:
   void Process() noexcept;
+
+  /**
+   * Merge and basic-computer update.  No thread assertion; caller must
+   * ensure the worker thread is not running concurrently.
+   */
+  void ProcessUnlocked() noexcept;
 
 protected:
   void Tick() noexcept override;

--- a/src/Renderer/ProgressBarRenderer.cpp
+++ b/src/Renderer/ProgressBarRenderer.cpp
@@ -24,7 +24,8 @@ void
 DrawSimpleProgressBar(Canvas &canvas, const PixelRect &r,
                       unsigned current_value,
                       unsigned min_value, unsigned max_value,
-                      const Color *background_color) noexcept
+                      const Color *background_color,
+                      const Color *progress_color) noexcept
 {
   const int position =
     CalcProgressBarPosition(current_value, min_value, max_value,
@@ -33,7 +34,12 @@ DrawSimpleProgressBar(Canvas &canvas, const PixelRect &r,
   auto a = r, b = r;
   a.right = b.left = a.left + position;
 
-  canvas.DrawFilledRectangle(a, IsDithered() ? COLOR_BLACK : COLOR_GREEN);
+  const Color fill_color = IsDithered()
+    ? COLOR_BLACK
+    : progress_color != nullptr
+      ? HasColors() ? *progress_color : COLOR_BLACK
+      : COLOR_GREEN;
+  canvas.DrawFilledRectangle(a, fill_color);
   canvas.DrawFilledRectangle(b,
                              background_color != nullptr
                              ? *background_color : COLOR_WHITE);

--- a/src/Renderer/ProgressBarRenderer.hpp
+++ b/src/Renderer/ProgressBarRenderer.hpp
@@ -11,7 +11,8 @@ void
 DrawSimpleProgressBar(Canvas &canvas, const PixelRect &r,
                       unsigned current_value,
                       unsigned min_value, unsigned max_value,
-                      const Color *background_color = nullptr) noexcept;
+                      const Color *background_color = nullptr,
+                      const Color *progress_color = nullptr) noexcept;
 
 void
 DrawRoundProgressBar(Canvas &canvas, const PixelRect &r,

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -2,7 +2,6 @@
 // Copyright The XCSoar Project
 
 #include "TrailRenderer.hpp"
-#include "Asset.hpp"
 #include "Look/TrailLook.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "NMEA/Info.hpp"
@@ -12,8 +11,6 @@
 #include "Projection/WindowProjection.hpp"
 #include "Geo/Math.hpp"
 #include "Engine/Contest/ContestTrace.hpp"
-#include "Math/Constants.hpp"
-#include "Math/Point2D.hpp"
 
 #include <algorithm>
 #include <new>
@@ -141,6 +138,49 @@ GetTrailThinDistance(const WindowProjection &projection,
   return projection.DistancePixelsToMeters(thin_px);
 }
 
+/**
+ * Bounded Catmull-Rom smoothing budget and recent trail tail.
+ * Stefan Schumann, PR #2664.
+ */
+static constexpr size_t MAX_SMOOTHED_TRAIL_POINTS = 180;
+
+[[gnu::const]]
+static unsigned
+GetBaseSmoothingSegments(double map_scale) noexcept
+{
+  return map_scale <= 3000 ? 4 : map_scale <= 6000 ? 3 : 2;
+}
+
+[[gnu::const]]
+static unsigned
+GetPreferredSmoothingSegments(double map_scale) noexcept
+{
+  return map_scale <= 3000 ? 8 : map_scale <= 6000 ? 6 : 4;
+}
+
+[[gnu::const]]
+static unsigned
+GetSmoothingSegments(double map_scale, size_t point_count) noexcept
+{
+  const unsigned base = GetBaseSmoothingSegments(map_scale);
+  if (point_count <= 1)
+    return base;
+
+  const unsigned budget = (MAX_SMOOTHED_TRAIL_POINTS - 1) * base;
+  const unsigned allowed = std::max(base,
+                                    budget / (unsigned)(point_count - 1));
+  return std::min(GetPreferredSmoothingSegments(map_scale), allowed);
+}
+
+[[gnu::const]]
+static size_t
+GetFirstSmoothedPointIndex(size_t point_count) noexcept
+{
+  return point_count > MAX_SMOOTHED_TRAIL_POINTS
+    ? point_count - MAX_SMOOTHED_TRAIL_POINTS
+    : 0;
+}
+
 [[gnu::pure]]
 static PixelPoint
 LerpPixelPoint(const PixelPoint &a, const PixelPoint &b,
@@ -149,16 +189,6 @@ LerpPixelPoint(const PixelPoint &a, const PixelPoint &b,
   return PixelPoint(
     int(std::lround(a.x + (b.x - a.x) * u)),
     int(std::lround(a.y + (b.y - a.y) * u)));
-}
-
-[[gnu::const]]
-static unsigned
-GetSplineBaseSegments(const PixelPoint &p1, const PixelPoint &p2) noexcept
-{
-  unsigned base = unsigned(std::clamp(ManhattanDistance(p1, p2) / 4, 4, 16));
-  if (IsEmbedded() && base > 4)
-    base = base * 3 / 4;
-  return std::max(base, 4u);
 }
 
 static void
@@ -312,68 +342,6 @@ CatmullRomInterpolate(const PixelPoint &p0, const PixelPoint &p1,
   );
 }
 
-/**
- * Turn angle at \a p1 between segments p0–p1 and p1–p2 (degrees).
- */
-[[gnu::pure]]
-static double
-CalculateAngle(const PixelPoint &p0, const PixelPoint &p1, const PixelPoint &p2) noexcept
-{
-  const IntPoint2D v1 = p1 - p0;
-  const IntPoint2D v2 = p2 - p1;
-
-  const double len1 = v1.Magnitude();
-  const double len2 = v2.Magnitude();
-
-  if (len1 < 1.0 || len2 < 1.0)
-    return 0.0;
-
-  const double dot = DotProduct(v1, v2) / (len1 * len2);
-  const double clamped = std::clamp(dot, -1.0, 1.0);
-  return std::acos(clamped) * 180.0 / M_PI;
-}
-
-/**
- * Generate interpolated points between two trace points using Catmull-Rom spline.
- * Adaptively adjusts the number of segments based on the turn angle for smoother curves.
- * @param p0 Control point before p1
- * @param p1 Start point
- * @param p2 End point
- * @param p3 Control point after p2
- * @param base_num_segments Base number of segments to generate
- * @param result Reused output buffer (including p1 and p2)
- */
-static void
-InterpolateSegment(const PixelPoint &p0, const PixelPoint &p1,
-                   const PixelPoint &p2, const PixelPoint &p3,
-                   unsigned base_num_segments, unsigned max_segments,
-                   std::vector<PixelPoint> &result) noexcept
-{
-  const double angle = CalculateAngle(p0, p1, p2);
-
-  unsigned num_segments = base_num_segments;
-  if (angle > 45.0) {
-    num_segments = base_num_segments * 2;
-  } else if (angle > 30.0) {
-    num_segments = static_cast<unsigned>(base_num_segments * 1.5);
-  } else if (angle > 15.0) {
-    num_segments = static_cast<unsigned>(base_num_segments * 1.2);
-  }
-
-  num_segments = std::min(num_segments, max_segments);
-
-  result.clear();
-  result.reserve(num_segments + 1);
-  result.push_back(p1);
-
-  for (unsigned i = 1; i < num_segments; ++i) {
-    const double t = static_cast<double>(i) / num_segments;
-    result.push_back(CatmullRomInterpolate(p0, p1, p2, p3, t));
-  }
-
-  result.push_back(p2);
-}
-
 void
 TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
                     const WindowProjection &projection,
@@ -414,6 +382,16 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     settings.type != TrailSettings::Type::VARIO_1_DOTS &&
     settings.type != TrailSettings::Type::VARIO_2_DOTS &&
     zoomed_in;
+
+  const size_t first_smoothed_point =
+    use_smoothing ? GetFirstSmoothedPointIndex(valid_points.size())
+                  : valid_points.size();
+  const size_t smoothed_point_count =
+    valid_points.size() - first_smoothed_point;
+  const unsigned num_segments =
+    use_smoothing
+      ? GetSmoothingSegments(map_scale, smoothed_point_count)
+      : 0u;
 
   valid_points.clear();
   valid_points.reserve(trace.size());
@@ -516,14 +494,11 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
       else
         vario_breakpoints.clear();
 
-      if (use_smoothing && i >= 1) {
-        const unsigned base_segments = GetSplineBaseSegments(p1, p2);
-        InterpolateSegment(p0, p1, p2, p3, base_segments, 16u,
-                           interpolated);
-        DrawSegmentWithVarioColour(canvas, prev_data, curr_data,
-                                   interpolated, settings.type,
-                                   value_min, value_max,
-                                   scaled_trail, use_merge_vario);
+      if (use_smoothing && i > first_smoothed_point) {
+        DrawSmoothTailSegmentInline(canvas, p0, p1, p2, p3, num_segments,
+                                    prev_data, curr_data, settings.type,
+                                    value_min, value_max, scaled_trail,
+                                    use_merge_vario);
       } else {
         BuildDirectSegmentPoints(p1, p2, vario_breakpoints,
                                  use_merge_vario, interpolated);
@@ -666,6 +641,50 @@ TrailRenderer::DrawSegmentWithVarioColour(
 
   if (run_active)
     flush_colour_run(segment_pts.size() - 1);
+}
+
+void
+TrailRenderer::DrawSmoothTailSegmentInline(
+    Canvas &canvas,
+    const PixelPoint &p0, const PixelPoint &p1,
+    const PixelPoint &p2, const PixelPoint &p3,
+    unsigned num_segments,
+    const TrailPointData &prev_data,
+    const TrailPointData &curr_data,
+    TrailSettings::Type type,
+    double value_min, double value_max,
+    bool scaled_trail,
+    bool use_merge_vario) noexcept
+{
+  const double piece_count = static_cast<double>(num_segments);
+  PixelPoint last_interpolated = p1;
+
+  for (unsigned j = 0; j < num_segments; ++j) {
+    const unsigned next_piece = j + 1;
+    const double t = static_cast<double>(next_piece) / piece_count;
+    const PixelPoint next_interpolated =
+      next_piece == num_segments
+        ? p2
+        : CatmullRomInterpolate(p0, p1, p2, p3, t);
+
+    double interp_value;
+    if (type == TrailSettings::Type::ALTITUDE) {
+      interp_value =
+        prev_data.value * (1.0 - t) + curr_data.value * t;
+    } else if (use_merge_vario && !vario_breakpoints.empty()) {
+      const double u = static_cast<double>(j + 0.5) / piece_count;
+      interp_value = LookupVarioAtU(u, vario_breakpoints);
+    } else {
+      interp_value =
+        prev_data.value * (1.0 - t) + curr_data.value * t;
+    }
+
+    const unsigned seg_color_index =
+      GetTrailColorIndex(type, interp_value, value_min, value_max);
+    SelectTrailPen(canvas, seg_color_index, scaled_trail);
+    canvas.DrawLinePiece(last_interpolated, next_interpolated);
+    last_interpolated = next_interpolated;
+  }
 }
 
 void

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -10,6 +10,7 @@
 #include "Computer/TraceComputer.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Geo/Math.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Engine/Contest/ContestTrace.hpp"
 
 #include <algorithm>
@@ -18,10 +19,10 @@
 #include <vector>
 #include <cmath>
 
-static constexpr double TRAIL_ZOOMED_IN_SCALE = 6000;
+static constexpr double TRAIL_ZOOMED_OUT_MAP_SCALE = 6000;
 static constexpr int TRAIL_THIN_PIXELS_MIN = 3;
 static constexpr int TRAIL_THIN_PIXELS_MAX = 24;
-
+static constexpr double TRAIL_BOUNDS_SCALE = 4.;
 namespace {
 
 /**
@@ -46,6 +47,19 @@ FindMergeSamplesBetween(TracePoint::Time t0, TracePoint::Time t1,
     ++search_from;
 
   return {begin, search_from};
+}
+
+[[gnu::pure]]
+static size_t
+FindMergeSampleIndexAtOrAfter(
+    TracePoint::Time time,
+    const std::vector<TrailVarioSample> &samples) noexcept
+{
+  return std::lower_bound(samples.begin(), samples.end(), time,
+                          [](const TrailVarioSample &sample,
+                             TracePoint::Time t) noexcept {
+                            return sample.time < t;
+                          }) - samples.begin();
 }
 
 void
@@ -126,16 +140,72 @@ LookupVarioAtU(double u,
   return a.second * (1. - t) + b.second * t;
 }
 
-/** ~1 canvas pixel per 500 m map scale, clamped to pre/post #2661 range. */
+[[gnu::const]]
+static bool
+IsVarioDotsOnlyMode(TrailSettings::Type type) noexcept
+{
+  return type == TrailSettings::Type::VARIO_1_DOTS ||
+    type == TrailSettings::Type::VARIO_2_DOTS;
+}
+
+[[gnu::pure]]
+static double
+InterpolatePieceValue(TrailSettings::Type type,
+                      double prev_value,
+                      double curr_value,
+                      unsigned piece_index,
+                      double piece_count,
+                      bool use_merge_vario,
+                      const std::vector<std::pair<double, double>> &bps) noexcept
+{
+  if (type == TrailSettings::Type::ALTITUDE) {
+    const double t = (piece_index + 1) / piece_count;
+    return prev_value * (1.0 - t) + curr_value * t;
+  }
+
+  if (use_merge_vario && !bps.empty()) {
+    const double u = (piece_index + 0.5) / piece_count;
+    return LookupVarioAtU(u, bps);
+  }
+
+  const double t = (piece_index + 1) / piece_count;
+  return prev_value * (1.0 - t) + curr_value * t;
+}
+
+struct CatmullRomWeights {
+  double c0, c1, c2, c3;
+};
+
+[[gnu::const]]
+static CatmullRomWeights
+ComputeCatmullRomWeights(double t) noexcept
+{
+  const double t2 = t * t;
+  const double t3 = t2 * t;
+  return {
+    -0.5 * t3 + t2 - 0.5 * t,
+    1.5 * t3 - 2.5 * t2 + 1.0,
+    -1.5 * t3 + 2.0 * t2 + 0.5 * t,
+    0.5 * t3 - 0.5 * t2,
+  };
+}
+
+/** Target screen-pixel spacing between kept trace fixes. */
+[[gnu::const]]
+static int
+GetTrailSpacingPixels(double map_scale) noexcept
+{
+  return std::clamp(int(map_scale / 500),
+                    TRAIL_THIN_PIXELS_MIN,
+                    TRAIL_THIN_PIXELS_MAX);
+}
+
 [[gnu::const]]
 static double
 GetTrailThinDistance(const WindowProjection &projection,
                      double map_scale) noexcept
 {
-  const int thin_px = std::clamp(int(map_scale / 500),
-                                 TRAIL_THIN_PIXELS_MIN,
-                                 TRAIL_THIN_PIXELS_MAX);
-  return projection.DistancePixelsToMeters(thin_px);
+  return projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
 }
 
 /**
@@ -146,30 +216,33 @@ static constexpr size_t MAX_SMOOTHED_TRAIL_POINTS = 180;
 
 [[gnu::const]]
 static unsigned
-GetBaseSmoothingSegments(double map_scale) noexcept
+GetBaseSmoothingSegments(const WindowProjection &projection) noexcept
 {
-  return map_scale <= 3000 ? 4 : map_scale <= 6000 ? 3 : 2;
+  const double map_scale = projection.GetMapScale();
+  return map_scale <= 3000 ? 4 : map_scale <= TRAIL_ZOOMED_OUT_MAP_SCALE ? 3 : 2;
 }
 
 [[gnu::const]]
 static unsigned
-GetPreferredSmoothingSegments(double map_scale) noexcept
+GetPreferredSmoothingSegments(const WindowProjection &projection) noexcept
 {
-  return map_scale <= 3000 ? 8 : map_scale <= 6000 ? 6 : 4;
+  const double map_scale = projection.GetMapScale();
+  return map_scale <= 3000 ? 8 : map_scale <= TRAIL_ZOOMED_OUT_MAP_SCALE ? 6 : 4;
 }
 
 [[gnu::const]]
 static unsigned
-GetSmoothingSegments(double map_scale, size_t point_count) noexcept
+GetSmoothingSegments(const WindowProjection &projection,
+                     size_t point_count) noexcept
 {
-  const unsigned base = GetBaseSmoothingSegments(map_scale);
+  const unsigned base = GetBaseSmoothingSegments(projection);
   if (point_count <= 1)
     return base;
 
   const unsigned budget = (MAX_SMOOTHED_TRAIL_POINTS - 1) * base;
   const unsigned allowed = std::max(base,
                                     budget / (unsigned)(point_count - 1));
-  return std::min(GetPreferredSmoothingSegments(map_scale), allowed);
+  return std::min(GetPreferredSmoothingSegments(projection), allowed);
 }
 
 [[gnu::const]]
@@ -209,7 +282,98 @@ BuildDirectSegmentPoints(const PixelPoint &p1, const PixelPoint &p2,
   result.push_back(p2);
 }
 
+/**
+ * Catmull-Rom spline interpolation between two points.
+ */
+[[gnu::pure]]
+static PixelPoint
+CatmullRomInterpolate(const PixelPoint &p0, const PixelPoint &p1,
+                      const PixelPoint &p2, const PixelPoint &p3,
+                      double t) noexcept
+{
+  const CatmullRomWeights c = ComputeCatmullRomWeights(t);
+
+  return PixelPoint(
+    static_cast<int>(c.c0 * p0.x + c.c1 * p1.x + c.c2 * p2.x + c.c3 * p3.x),
+    static_cast<int>(c.c0 * p0.y + c.c1 * p1.y + c.c2 * p2.y + c.c3 * p3.y)
+  );
+}
+
+[[gnu::pure]]
+static GeoPoint
+TrailGeoPoint(const TracePoint &tp, bool enable_traildrift,
+              const GeoPoint &traildrift,
+              const NMEAInfo &basic) noexcept
+{
+  if (!enable_traildrift)
+    return tp.GetLocation();
+
+  return tp.GetLocation().Parametric(traildrift,
+                                     tp.CalculateDrift(basic.time));
+}
+
+[[gnu::pure]]
+static GeoPoint
+CatmullRomGeo(const GeoPoint &p0, const GeoPoint &p1,
+              const GeoPoint &p2, const GeoPoint &p3,
+              double t) noexcept
+{
+  const CatmullRomWeights c = ComputeCatmullRomWeights(t);
+
+  return GeoPoint(
+    Angle::Native(c.c0 * p0.longitude.Native() + c.c1 * p1.longitude.Native() +
+                  c.c2 * p2.longitude.Native() + c.c3 * p3.longitude.Native()),
+    Angle::Native(c.c0 * p0.latitude.Native() + c.c1 * p1.latitude.Native() +
+                  c.c2 * p2.latitude.Native() + c.c3 * p3.latitude.Native()));
+}
+
+[[gnu::pure]]
+static GeoPoint
+DriftGeoPoint(const GeoPoint &geo, TracePoint::Time time,
+              uint16_t drift_factor,
+              bool enable_traildrift,
+              const GeoPoint &traildrift,
+              TimeStamp now) noexcept
+{
+  if (!enable_traildrift)
+    return geo;
+
+  const double dt =
+    (now.ToDuration() - std::chrono::duration_cast<FloatDuration>(time)).count();
+  return geo.Parametric(traildrift, dt * drift_factor / 256);
+}
+
 } // namespace
+
+void
+TrailRenderer::MergeAdjacentColourRuns(
+    std::vector<CachedColourRun> &runs) noexcept
+{
+  if (runs.size() < 2)
+    return;
+
+  size_t write = 0;
+  for (size_t read = 1; read < runs.size(); ++read) {
+    if (runs[read].color_index == runs[write].color_index) {
+      const auto &src = runs[read].points;
+      if (src.empty())
+        continue;
+
+      size_t start = 0;
+      if (!runs[write].points.empty() &&
+          runs[write].points.back().geo == src.front().geo)
+        start = 1;
+
+      runs[write].points.insert(runs[write].points.end(),
+                                src.begin() + start, src.end());
+    } else {
+      ++write;
+      if (write != read)
+        runs[write] = std::move(runs[read]);
+    }
+  }
+  runs.resize(write + 1);
+}
 
 bool
 TrailRenderer::LoadTrace(const TraceComputer &trace_computer) noexcept
@@ -229,56 +393,107 @@ TrailRenderer::LoadTrace(const TraceComputer &trace_computer) noexcept
 bool
 TrailRenderer::LoadTrace(const TraceComputer &trace_computer,
                          TimeStamp min_time,
-                         const WindowProjection &projection,
-                         double map_scale) noexcept
+                         const WindowProjection &projection) noexcept
 {
+  const TrailQuery query = MakeTrailQuery(min_time, projection);
+  return SyncTrace(trace_computer, query);
+}
+
+TrailQuery
+TrailRenderer::MakeTrailQuery(TimeStamp min_time,
+                              const WindowProjection &projection) noexcept
+{
+  const double map_scale = projection.GetMapScale();
+  TrailQuery query;
+  query.min_time = min_time.Cast<std::chrono::duration<unsigned>>();
+  query.bounds = projection.GetScreenBounds().Scale(TRAIL_BOUNDS_SCALE);
+  query.project_location = projection.GetGeoScreenCenter();
+  query.min_distance_m = GetTrailThinDistance(projection, map_scale);
+  return query;
+}
+
+bool
+TrailRenderer::TrailDrawFingerprint::operator==(
+    const TrailDrawFingerprint &other) const noexcept
+{
+  return scale_px_per_m == other.scale_px_per_m &&
+    color_min == other.color_min &&
+    color_max == other.color_max &&
+    query_bounds.GetNorthWest() == other.query_bounds.GetNorthWest() &&
+    query_bounds.GetSouthEast() == other.query_bounds.GetSouthEast();
+}
+
+void
+TrailRenderer::InvalidateSegmentCache() noexcept
+{
+  segment_cache.clear();
+  cached_trace_size = 0;
+}
+
+bool
+TrailRenderer::SyncTrace(const TraceComputer &trace_computer,
+                         const TrailQuery &query) noexcept
+{
+  Serial append{}, modify{};
   trace.clear();
   merge_vario_samples.clear();
   try {
-    trace_computer.LockedCopySnapshot(trace, merge_vario_samples,
-                                      min_time.Cast<std::chrono::duration<unsigned>>(),
-                                      projection.GetGeoScreenCenter(),
-                                      GetTrailThinDistance(projection,
-                                                           map_scale));
+    trace_computer.LockedTrailQuery(query, trace, merge_vario_samples,
+                                    &append, &modify);
   } catch (const std::bad_alloc &) {
     trace.clear();
     merge_vario_samples.clear();
+    InvalidateSegmentCache();
     return false;
   }
+
+  synced_append_serial = append;
+  synced_modify_serial = modify;
   return !trace.empty();
 }
 
-/**
- * This function returns the corresponding SnailTrail
- * color array index to the input
- * @param vario Input value between min_vario and max_vario
- * @return SnailTrail color array index
- */
-static constexpr unsigned
-GetSnailColorIndex(double vario, double min_vario, double max_vario) noexcept
+unsigned
+TrailRenderer::ColorScale::Index(double value) const noexcept
 {
-  auto cv = vario < 0 ? -vario / min_vario : vario / max_vario;
+  static constexpr unsigned max_index = TrailLook::NUMSNAILCOLORS - 1;
 
-  return std::clamp((int)((cv + 1) / 2 * TrailLook::NUMSNAILCOLORS),
-                    0, (int)(TrailLook::NUMSNAILCOLORS - 1));
+  if (is_altitude) {
+    const int idx = int((value - alt_min) * alt_inv_range);
+    if (idx <= 0)
+      return 0;
+    if (unsigned(idx) >= max_index)
+      return max_index;
+    return unsigned(idx);
+  }
+
+  const double cv = value < 0 ? value * neg_inv_min : value * inv_max;
+  const int idx =
+    int((cv + 1) * (TrailLook::NUMSNAILCOLORS * 0.5));
+  if (idx <= 0)
+    return 0;
+  if (unsigned(idx) >= max_index)
+    return max_index;
+  return unsigned(idx);
 }
 
-static constexpr unsigned
-GetAltitudeColorIndex(double alt, double min_alt, double max_alt) noexcept
+TrailRenderer::ColorScale
+TrailRenderer::ColorScale::FromMinMax(TrailSettings::Type type,
+                                      double value_min,
+                                      double value_max) noexcept
 {
-  auto relative_altitude = (alt - min_alt) / (max_alt - min_alt);
-  int _max = TrailLook::NUMSNAILCOLORS - 1;
-  return std::clamp((int)(relative_altitude * _max), 0, _max);
-}
-
-[[gnu::pure]]
-static unsigned
-GetTrailColorIndex(TrailSettings::Type type, double value,
-                   double value_min, double value_max) noexcept
-{
-  if (type == TrailSettings::Type::ALTITUDE)
-    return GetAltitudeColorIndex(value, value_min, value_max);
-  return GetSnailColorIndex(value, value_min, value_max);
+  ColorScale scale;
+  if (type == TrailSettings::Type::ALTITUDE) {
+    scale.is_altitude = true;
+    scale.alt_min = value_min;
+    const double range = value_max - value_min;
+    scale.alt_inv_range = range > 0
+      ? double(TrailLook::NUMSNAILCOLORS - 1) / range
+      : 0.;
+  } else {
+    scale.neg_inv_min = -1.0 / value_min;
+    scale.inv_max = 1.0 / value_max;
+  }
+  return scale;
 }
 
 [[gnu::pure]]
@@ -311,35 +526,382 @@ GetMinMax(TrailSettings::Type type, const TracePointVector &trace) noexcept
   return std::make_pair(value_min, value_max);
 }
 
-/**
- * Catmull-Rom spline interpolation between two points.
- * Interpolates between p1 and p2 using p0 and p3 as control points.
- * @param p0 Control point before p1
- * @param p1 Start point
- * @param p2 End point
- * @param p3 Control point after p2
- * @param t Interpolation parameter (0.0 = p1, 1.0 = p2)
- * @return Interpolated point
- */
-[[gnu::pure]]
-static PixelPoint
-CatmullRomInterpolate(const PixelPoint &p0, const PixelPoint &p1,
-                      const PixelPoint &p2, const PixelPoint &p3,
-                      double t) noexcept
+void
+TrailRenderer::DrawCachedSegments(Canvas &canvas,
+                                  const WindowProjection &projection,
+                                  const TrailSettings::Type type,
+                                  const bool scaled_trail,
+                                  const bool enable_traildrift,
+                                  const GeoPoint &traildrift,
+                                  const NMEAInfo &basic,
+                                  const std::vector<CachedTrailSegment> &segments) noexcept
 {
-  const double t2 = t * t;
-  const double t3 = t2 * t;
+  const bool suppress_sink_lines = IsVarioDotsOnlyMode(type);
+  static constexpr unsigned null_color_index =
+    TrailLook::NUMSNAILCOLORS / 2;
 
-  // Catmull-Rom spline coefficients
-  const double c0 = -0.5 * t3 + t2 - 0.5 * t;
-  const double c1 = 1.5 * t3 - 2.5 * t2 + 1.0;
-  const double c2 = -1.5 * t3 + 2.0 * t2 + 0.5 * t;
-  const double c3 = 0.5 * t3 - 0.5 * t2;
+  size_t max_batch_points = 0;
+  size_t current_batch_points = 0;
+  unsigned current_batch_color = TrailLook::NUMSNAILCOLORS;
+  for (const auto &seg : segments) {
+    for (const auto &run : seg.colour_runs) {
+      if (run.points.size() < 2)
+        continue;
 
-  return PixelPoint(
-    static_cast<int>(c0 * p0.x + c1 * p1.x + c2 * p2.x + c3 * p3.x),
-    static_cast<int>(c0 * p0.y + c1 * p1.y + c2 * p2.y + c3 * p3.y)
-  );
+      if (suppress_sink_lines && run.color_index < null_color_index)
+        continue;
+
+      if (run.color_index != current_batch_color) {
+        max_batch_points = std::max(max_batch_points, current_batch_points);
+        current_batch_points = 0;
+        current_batch_color = run.color_index;
+      }
+
+      current_batch_points += run.points.size();
+    }
+  }
+
+  max_batch_points = std::max(max_batch_points, current_batch_points);
+  if (max_batch_points > 0)
+    points.GrowDiscard(max_batch_points);
+
+  unsigned batch_color = TrailLook::NUMSNAILCOLORS;
+  unsigned batch_n = 0;
+
+  auto flush_batch = [&]() noexcept {
+    if (batch_n < 2)
+      return;
+
+    SelectTrailPen(canvas, batch_color, scaled_trail);
+    DrawPreparedPolyline(canvas, batch_n);
+    batch_n = 0;
+  };
+
+  for (const auto &seg : segments) {
+    for (const auto &run : seg.colour_runs) {
+      if (run.points.size() < 2)
+        continue;
+
+      if (suppress_sink_lines && run.color_index < null_color_index)
+        continue;
+
+      if (run.color_index != batch_color)
+        flush_batch();
+
+      batch_color = run.color_index;
+
+      size_t start = 0;
+      if (batch_n > 0 && !run.points.empty()) {
+        const auto &junction_pt = run.points.front();
+        const PixelPoint junction = projection.GeoToScreen(
+          DriftGeoPoint(junction_pt.geo, junction_pt.time,
+                        junction_pt.drift_factor,
+                        enable_traildrift, traildrift, basic.time));
+        if (junction.x == points[batch_n - 1].x &&
+            junction.y == points[batch_n - 1].y)
+          start = 1;
+      }
+
+      for (size_t i = start; i < run.points.size(); ++i) {
+        const auto &p = run.points[i];
+        const PixelPoint pt = projection.GeoToScreen(
+          DriftGeoPoint(p.geo, p.time, p.drift_factor,
+                        enable_traildrift, traildrift, basic.time));
+
+        points[batch_n++] = pt;
+      }
+    }
+  }
+
+  flush_batch();
+}
+
+void
+TrailRenderer::AppendColourRun(std::vector<CachedColourRun> &runs,
+                               const unsigned color_index,
+                               const CachedPathPoint &pt) noexcept
+{
+  if (!runs.empty() && runs.back().color_index == color_index) {
+    runs.back().points.push_back(pt);
+    return;
+  }
+
+  std::vector<CachedPathPoint> pts;
+  if (!runs.empty())
+    pts.push_back(runs.back().points.back());
+  pts.push_back(pt);
+  runs.push_back({color_index, std::move(pts)});
+}
+
+TrailRenderer::CachedPathPoint
+TrailRenderer::LerpCachedPathPoint(const GeoPoint &g0, const GeoPoint &g1,
+                                   const TracePoint::Time t0,
+                                   const TracePoint::Time t1,
+                                   const unsigned df0, const unsigned df1,
+                                   const double u) noexcept
+{
+  return {
+    g0.Interpolate(g1, u),
+    TracePoint::Time((unsigned)(t0.count() * (1. - u) + t1.count() * u)),
+    (uint16_t)(df0 * (1. - u) + df1 * u),
+  };
+}
+
+void
+TrailRenderer::BuildDirectColourRuns(
+    const TrailPointData &prev_data,
+    const TrailPointData &curr_data,
+    const GeoPoint &prev_geo,
+    const GeoPoint &curr_geo,
+    const unsigned prev_drift_factor,
+    const unsigned curr_drift_factor,
+    const std::vector<PixelPoint> &segment_pts,
+    TrailSettings::Type type,
+    const ColorScale &color_scale,
+    bool use_merge_vario,
+    std::vector<CachedColourRun> &runs) noexcept
+{
+  if (segment_pts.size() < 2)
+    return;
+
+  const double piece_count =
+    segment_pts.size() > 1
+      ? static_cast<double>(segment_pts.size() - 1)
+      : 1.0;
+
+  for (size_t j = 0; j + 1 < segment_pts.size(); ++j) {
+    const double u = static_cast<double>(j) / piece_count;
+    const double interp_value =
+      InterpolatePieceValue(type, prev_data.value, curr_data.value,
+                            unsigned(j), piece_count, use_merge_vario,
+                            vario_breakpoints);
+
+    AppendColourRun(runs, color_scale.Index(interp_value),
+                    LerpCachedPathPoint(prev_geo, curr_geo,
+                                        prev_data.time, curr_data.time,
+                                        prev_drift_factor, curr_drift_factor,
+                                        u));
+  }
+
+  AppendColourRun(runs, color_scale.Index(curr_data.value),
+                  {curr_geo, curr_data.time,
+                   (uint16_t)curr_drift_factor});
+}
+
+void
+TrailRenderer::BuildSmoothColourRuns(
+    const GeoPoint &g0, const GeoPoint &g1,
+    const GeoPoint &g2, const GeoPoint &g3,
+    const TracePoint::Time time1,
+    const TracePoint::Time time2,
+    const unsigned drift_factor1,
+    const unsigned drift_factor2,
+    const unsigned num_segments,
+    const TrailPointData &prev_data,
+    const TrailPointData &curr_data,
+    TrailSettings::Type type,
+    const ColorScale &color_scale,
+    bool use_merge_vario,
+    std::vector<CachedColourRun> &runs) noexcept
+{
+  const double piece_count = static_cast<double>(num_segments);
+
+  AppendColourRun(runs, color_scale.Index(prev_data.value),
+                  {g1, time1, (uint16_t)drift_factor1});
+
+  for (unsigned j = 0; j < num_segments; ++j) {
+    const unsigned next_piece = j + 1;
+    const double t = static_cast<double>(next_piece) / piece_count;
+    const GeoPoint next_geo =
+      next_piece == num_segments
+        ? g2
+        : CatmullRomGeo(g0, g1, g2, g3, t);
+
+    const double interp_value =
+      InterpolatePieceValue(type, prev_data.value, curr_data.value,
+                            j, piece_count, use_merge_vario,
+                            vario_breakpoints);
+
+    const CachedPathPoint meta =
+      LerpCachedPathPoint(g1, g2, time1, time2,
+                          drift_factor1, drift_factor2, t);
+
+    AppendColourRun(runs, color_scale.Index(interp_value),
+                    {next_geo, meta.time, meta.drift_factor});
+  }
+}
+
+void
+TrailRenderer::BuildCachedSegment(const WindowProjection &projection,
+                                  const size_t leg_index,
+                                  TrailSettings::Type type,
+                                  const ColorScale &color_scale,
+                                  const bool use_smoothing,
+                                  const unsigned num_segments,
+                                  const size_t first_smoothed_point,
+                                  size_t &merge_sample_index,
+                                  CachedTrailSegment &dest) noexcept
+{
+  assert(leg_index + 1 < trace.size());
+
+  const TracePoint &prev_tp = trace[leg_index];
+  const TracePoint &curr_tp = trace[leg_index + 1];
+  const GeoPoint gp0 = prev_tp.GetLocation();
+  const GeoPoint gp1 = curr_tp.GetLocation();
+  dest.colour_runs.clear();
+
+  const TrailPointData prev_data{
+    projection.GeoToScreen(gp0),
+    type == TrailSettings::Type::ALTITUDE
+      ? prev_tp.GetAltitude() : prev_tp.GetVario(),
+    prev_tp.GetTime()};
+  const TrailPointData curr_data{
+    projection.GeoToScreen(gp1),
+    type == TrailSettings::Type::ALTITUDE
+      ? curr_tp.GetAltitude() : curr_tp.GetVario(),
+    curr_tp.GetTime()};
+
+  const bool use_merge_vario =
+    type != TrailSettings::Type::ALTITUDE &&
+    !merge_vario_samples.empty();
+
+  if (use_merge_vario)
+    BuildVarioBreakpoints(prev_data.time, prev_data.value,
+                          curr_data.time, curr_data.value,
+                          merge_vario_samples, merge_sample_index,
+                          vario_breakpoints);
+  else
+    vario_breakpoints.clear();
+
+  const GeoPoint g0 = leg_index >= 1
+    ? trace[leg_index - 1].GetLocation()
+    : gp0;
+  const GeoPoint g1 = gp0;
+  const GeoPoint g2 = gp1;
+  const GeoPoint g3 = leg_index + 2 < trace.size()
+    ? trace[leg_index + 2].GetLocation()
+    : gp1;
+
+  if (use_smoothing && leg_index + 1 > first_smoothed_point) {
+    BuildSmoothColourRuns(g0, g1, g2, g3,
+                          prev_tp.GetTime(), curr_tp.GetTime(),
+                          prev_tp.GetDriftFactor(), curr_tp.GetDriftFactor(),
+                          num_segments, prev_data, curr_data, type, color_scale,
+                          use_merge_vario, dest.colour_runs);
+  } else {
+    const PixelPoint p1s = prev_data.point;
+    const PixelPoint p2s = curr_data.point;
+    BuildDirectSegmentPoints(p1s, p2s, vario_breakpoints,
+                             use_merge_vario, interpolated);
+    BuildDirectColourRuns(prev_data, curr_data, gp0, gp1,
+                          prev_tp.GetDriftFactor(), curr_tp.GetDriftFactor(),
+                          interpolated, type, color_scale, use_merge_vario,
+                          dest.colour_runs);
+  }
+
+  MergeAdjacentColourRuns(dest.colour_runs);
+}
+
+void
+TrailRenderer::UpdateSegmentCache(const WindowProjection &projection,
+                                  TrailSettings::Type type,
+                                  const ColorScale &color_scale,
+                                  const bool use_smoothing,
+                                  const unsigned num_segments,
+                                  const size_t first_smoothed_point,
+                                  const size_t from_leg,
+                                  const bool rebuild) noexcept
+{
+  if (rebuild) {
+    segment_cache.clear();
+    merge_sample_search_index = 0;
+  }
+
+  if (trace.size() < 2) {
+    cached_trace_size = trace.size();
+    return;
+  }
+
+  const size_t start_leg = rebuild ? 0 : from_leg;
+  if (rebuild)
+    segment_cache.reserve(trace.size() - 1);
+  else if (from_leg < segment_cache.size()) {
+    segment_cache.resize(from_leg);
+    merge_sample_search_index =
+      from_leg < trace.size()
+        ? FindMergeSampleIndexAtOrAfter(trace[from_leg].GetTime(),
+                                        merge_vario_samples)
+        : merge_vario_samples.size();
+  }
+
+  for (size_t leg = start_leg; leg + 1 < trace.size(); ++leg) {
+    segment_cache.emplace_back();
+    BuildCachedSegment(projection, leg, type, color_scale,
+                       use_smoothing, num_segments, first_smoothed_point,
+                       merge_sample_search_index, segment_cache.back());
+  }
+
+  cached_trace_size = trace.size();
+}
+
+void
+TrailRenderer::DrawOpenLeg(Canvas &canvas,
+                           const TrailSettings &settings,
+                           const ColorScale &color_scale,
+                           const bool scaled_trail,
+                           const bool use_smoothing,
+                           const unsigned num_segments,
+                           const size_t first_smoothed_point,
+                           const NMEAInfo &basic,
+                           const PixelPoint aircraft_pos) noexcept
+{
+  if (valid_points.size() < 1)
+    return;
+
+  const TrailPointData &last_data = valid_points.back();
+
+  const bool draw_lines =
+    !(last_data.value < 0 && IsVarioDotsOnlyMode(settings.type));
+
+  if (!draw_lines)
+    return;
+
+  const bool use_merge_vario =
+    settings.type != TrailSettings::Type::ALTITUDE &&
+    !merge_vario_samples.empty();
+
+  TrailPointData open_end{aircraft_pos, last_data.value,
+                          basic.time.Cast<TracePoint::Time>()};
+
+  if (use_merge_vario)
+    BuildVarioBreakpoints(last_data.time, last_data.value,
+                          basic.time.Cast<TracePoint::Time>(),
+                          last_data.value,
+                          merge_vario_samples, merge_sample_search_index,
+                          vario_breakpoints);
+  else
+    vario_breakpoints.clear();
+
+  if (use_smoothing && valid_points.size() > first_smoothed_point &&
+      valid_points.size() >= 2) {
+    const auto &prev_data = valid_points[valid_points.size() - 2];
+    const PixelPoint p0 = valid_points.size() >= 3
+      ? valid_points[valid_points.size() - 3].point
+      : prev_data.point;
+    DrawSmoothTailSegmentInline(canvas, p0, prev_data.point,
+                                last_data.point, aircraft_pos,
+                                num_segments, last_data, open_end,
+                                settings.type, color_scale, scaled_trail,
+                                use_merge_vario);
+  } else {
+    BuildDirectSegmentPoints(last_data.point, aircraft_pos,
+                             vario_breakpoints, use_merge_vario,
+                             interpolated);
+    DrawVarioColouredPolyline(canvas, interpolated, settings.type,
+                              last_data, open_end, color_scale,
+                              scaled_trail, use_merge_vario,
+                              unsigned(interpolated.size() - 1));
+  }
 }
 
 void
@@ -353,9 +915,8 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   if (settings.length == TrailSettings::Length::OFF)
     return;
 
-  const double map_scale = projection.GetMapScale();
-
-  if (!LoadTrace(trace_computer, min_time, projection, map_scale))
+  const TrailQuery query = MakeTrailQuery(min_time, projection);
+  if (!SyncTrace(trace_computer, query))
     return;
 
   if (!basic.location_available || !calculated.wind_available)
@@ -369,19 +930,32 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     traildrift = basic.location - tp1;
   }
 
-  auto minmax = GetMinMax(settings.type, trace);
-  auto value_min = minmax.first;
-  auto value_max = minmax.second;
+  const auto minmax = GetMinMax(settings.type, trace);
+  const ColorScale color_scale =
+    ColorScale::FromMinMax(settings.type, minmax.first, minmax.second);
 
-  const bool zoomed_in = map_scale <= TRAIL_ZOOMED_IN_SCALE;
+  const bool zoomed_in =
+    projection.GetMapScale() <= TRAIL_ZOOMED_OUT_MAP_SCALE;
   const bool scaled_trail = settings.scaling_enabled && zoomed_in;
-
-  const GeoBounds bounds = projection.GetScreenBounds().Scale(4);
 
   const bool use_smoothing =
     settings.type != TrailSettings::Type::VARIO_1_DOTS &&
     settings.type != TrailSettings::Type::VARIO_2_DOTS &&
     zoomed_in;
+
+  valid_points.clear();
+  valid_points.reserve(trace.size());
+
+  for (const auto &i : trace) {
+    const GeoPoint gp = TrailGeoPoint(i, enable_traildrift, traildrift, basic);
+    const PixelPoint pt = projection.GeoToScreen(gp);
+    const double value = (settings.type == TrailSettings::Type::ALTITUDE)
+      ? i.GetAltitude() : i.GetVario();
+    valid_points.push_back({pt, value, i.GetTime()});
+  }
+
+  if (valid_points.empty())
+    return;
 
   const size_t first_smoothed_point =
     use_smoothing ? GetFirstSmoothedPointIndex(valid_points.size())
@@ -390,136 +964,83 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     valid_points.size() - first_smoothed_point;
   const unsigned num_segments =
     use_smoothing
-      ? GetSmoothingSegments(map_scale, smoothed_point_count)
+      ? GetSmoothingSegments(projection, smoothed_point_count)
       : 0u;
 
-  valid_points.clear();
-  valid_points.reserve(trace.size());
+  const TrailDrawFingerprint new_fingerprint{
+    projection.GetScale(),
+    query.bounds,
+    minmax.first,
+    minmax.second,
+  };
 
-  for (const auto &i : trace) {
-    const GeoPoint gp = enable_traildrift
-      ? i.GetLocation().Parametric(traildrift, i.CalculateDrift(basic.time))
-      : i.GetLocation();
-    if (!bounds.IsInside(gp)) {
-      continue;
-    }
+  const bool modify_changed =
+    synced_modify_serial != cache_modify_serial;
+  const bool fingerprint_changed = !(fingerprint == new_fingerprint);
+  const bool settings_changed =
+    cached_settings_type != settings.type ||
+    cached_scaled_trail != scaled_trail;
 
-    auto pt = projection.GeoToScreen(gp);
-    const double value = (settings.type == TrailSettings::Type::ALTITUDE)
-      ? i.GetAltitude() : i.GetVario();
-    const TrailPointData pd{pt, value, i.GetTime()};
+  const size_t leg_count = trace.size() >= 2 ? trace.size() - 1 : 0;
 
-    if (!valid_points.empty() &&
-        ManhattanDistance(pt, valid_points.back().point) < 1) {
-      /* Same screen cell: keep latest vario/altitude for colour */
-      valid_points.back() = pd;
-      continue;
-    }
-
-    valid_points.push_back(pd);
+  if (modify_changed || fingerprint_changed || settings_changed)
+    UpdateSegmentCache(projection, settings.type, color_scale,
+                       use_smoothing, num_segments, first_smoothed_point,
+                       0, true);
+  else if (leg_count > segment_cache.size()) {
+    const size_t rebuild_from =
+      use_smoothing && leg_count > MAX_SMOOTHED_TRAIL_POINTS
+        ? leg_count - MAX_SMOOTHED_TRAIL_POINTS
+        : use_smoothing ? 0 : segment_cache.size();
+    UpdateSegmentCache(projection, settings.type, color_scale,
+                       use_smoothing, num_segments, first_smoothed_point,
+                       rebuild_from, false);
   }
+  else if (leg_count < segment_cache.size())
+    segment_cache.resize(leg_count);
 
-  if (valid_points.empty())
-    return;
+  cached_trace_size = trace.size();
 
-  size_t merge_sample_index = 0;
+  cache_append_serial = synced_append_serial;
+  cache_modify_serial = synced_modify_serial;
+  fingerprint = new_fingerprint;
+  cached_settings_type = settings.type;
+  cached_scaled_trail = scaled_trail;
 
-  // Draw the trail with spline interpolation
-  for (size_t i = 0; i < valid_points.size(); ++i) {
-    if (i == 0) {
-      // First point - just store it
-      continue;
-    }
-
-    const auto &prev_data = valid_points[i - 1];
+  for (size_t i = 1; i < valid_points.size(); ++i) {
     const auto &curr_data = valid_points[i];
+    const unsigned color_index = color_scale.Index(curr_data.value);
 
-    const unsigned color_index =
-      GetTrailColorIndex(settings.type, curr_data.value,
-                         value_min, value_max);
-
-    // Determine if we should draw dots (circles) for this segment
-    // Dots are drawn for negative vario in dots modes, or for positive vario in VARIO_DOTS_AND_LINES/VARIO_EINK
-    const bool draw_dots = 
+    const bool draw_dots =
       (curr_data.value < 0 &&
-       (settings.type == TrailSettings::Type::VARIO_1_DOTS ||
-        settings.type == TrailSettings::Type::VARIO_2_DOTS ||
+       (IsVarioDotsOnlyMode(settings.type) ||
         settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
         settings.type == TrailSettings::Type::VARIO_EINK)) ||
       (curr_data.value >= 0 &&
        (settings.type == TrailSettings::Type::VARIO_DOTS_AND_LINES ||
         settings.type == TrailSettings::Type::VARIO_EINK));
 
-    // Determine if we should draw lines for this segment
-    // Lines are NOT drawn only for negative vario in VARIO_1_DOTS/VARIO_2_DOTS modes
-    const bool draw_lines = 
-      !(curr_data.value < 0 &&
-        (settings.type == TrailSettings::Type::VARIO_1_DOTS ||
-         settings.type == TrailSettings::Type::VARIO_2_DOTS));
+    if (!draw_dots)
+      continue;
 
-    // Draw dots if needed
-    if (draw_dots) {
-      if (curr_data.value < 0) {
-        // Negative vario: draw filled circle with no pen
-        canvas.SelectNullPen();
-        canvas.Select(look.trail_brushes[color_index]);
-      } else {
-        // Positive vario in VARIO_DOTS_AND_LINES/VARIO_EINK: draw circle with pen
-        canvas.Select(look.trail_brushes[color_index]);
-        canvas.Select(look.trail_pens[color_index]);
-      }
-      canvas.DrawCircle({(curr_data.point.x + prev_data.point.x) / 2,
-                         (curr_data.point.y + prev_data.point.y) / 2},
-                        look.trail_widths[color_index]);
+    const auto &prev_data = valid_points[i - 1];
+    if (curr_data.value < 0) {
+      canvas.SelectNullPen();
+      canvas.Select(look.trail_brushes[color_index]);
+    } else {
+      canvas.Select(look.trail_brushes[color_index]);
+      canvas.Select(look.trail_pens[color_index]);
     }
-
-    // Draw lines if needed
-    if (draw_lines) {
-      // Determine control points for spline interpolation
-      // For beginning/end, duplicate points to create smooth curves
-      const auto &p0 = (i >= 2) ? valid_points[i - 2].point : prev_data.point;
-      const auto &p1 = prev_data.point;
-      const auto &p2 = curr_data.point;
-      const auto &p3 = (i + 1 < valid_points.size()) ? valid_points[i + 1].point : curr_data.point;
-
-      const bool use_merge_vario =
-        settings.type != TrailSettings::Type::ALTITUDE &&
-        !merge_vario_samples.empty();
-
-      if (use_merge_vario)
-        BuildVarioBreakpoints(prev_data.time, prev_data.value,
-                              curr_data.time, curr_data.value,
-                              merge_vario_samples, merge_sample_index,
-                              vario_breakpoints);
-      else
-        vario_breakpoints.clear();
-
-      if (use_smoothing && i > first_smoothed_point) {
-        DrawSmoothTailSegmentInline(canvas, p0, p1, p2, p3, num_segments,
-                                    prev_data, curr_data, settings.type,
-                                    value_min, value_max, scaled_trail,
-                                    use_merge_vario);
-      } else {
-        BuildDirectSegmentPoints(p1, p2, vario_breakpoints,
-                                 use_merge_vario, interpolated);
-        DrawSegmentWithVarioColour(canvas, prev_data, curr_data,
-                                   interpolated, settings.type,
-                                   value_min, value_max,
-                                   scaled_trail, use_merge_vario);
-      }
-    }
+    canvas.DrawCircle({(curr_data.point.x + prev_data.point.x) / 2,
+                       (curr_data.point.y + prev_data.point.y) / 2},
+                      look.trail_widths[color_index]);
   }
 
-  // Draw line to current aircraft position
-  if (!valid_points.empty()) {
-    const auto &last_data = valid_points.back();
-    const unsigned color_index =
-      GetTrailColorIndex(settings.type, last_data.value,
-                         value_min, value_max);
-
-    SelectTrailPen(canvas, color_index, scaled_trail);
-    canvas.DrawLine(last_data.point, pos);
-  }
+  DrawCachedSegments(canvas, projection, settings.type, scaled_trail,
+                     enable_traildrift, traildrift, basic, segment_cache);
+  DrawOpenLeg(canvas, settings, color_scale, scaled_trail,
+              use_smoothing, num_segments, first_smoothed_point,
+              basic, pos);
 }
 
 void
@@ -534,8 +1055,7 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
                     const WindowProjection &projection,
                     TimeStamp min_time) noexcept
 {
-  if (LoadTrace(trace_computer, min_time, projection,
-                projection.GetMapScale()))
+  if (LoadTrace(trace_computer, min_time, projection))
     Draw(canvas, projection);
 }
 
@@ -581,23 +1101,20 @@ TrailRenderer::DrawColourPolyline(Canvas &canvas, unsigned color_index,
 }
 
 void
-TrailRenderer::DrawSegmentWithVarioColour(
-    Canvas &canvas,
-    const TrailPointData &prev_data,
-    const TrailPointData &curr_data,
-    const std::vector<PixelPoint> &segment_pts,
-    TrailSettings::Type type,
-    double value_min, double value_max,
-    bool scaled_trail,
-    bool use_merge_vario) noexcept
+TrailRenderer::DrawVarioColouredPolyline(Canvas &canvas,
+                                         const std::vector<PixelPoint> &pts,
+                                         TrailSettings::Type type,
+                                         const TrailPointData &prev_data,
+                                         const TrailPointData &curr_data,
+                                         const ColorScale &color_scale,
+                                         const bool scaled_trail,
+                                         const bool use_merge_vario,
+                                         const unsigned num_pieces) noexcept
 {
-  if (segment_pts.size() < 2)
+  if (pts.size() < 2 || num_pieces == 0)
     return;
 
-  const double piece_count =
-    segment_pts.size() > 1
-      ? static_cast<double>(segment_pts.size() - 1)
-      : 1.0;
+  const double piece_count = static_cast<double>(num_pieces);
 
   size_t run_start = 0;
   unsigned run_color = 0;
@@ -607,26 +1124,15 @@ TrailRenderer::DrawSegmentWithVarioColour(
     if (!run_active || run_end <= run_start)
       return;
     DrawColourPolyline(canvas, run_color, scaled_trail,
-                       segment_pts, run_start, run_end);
+                       pts, run_start, run_end);
   };
 
-  for (size_t j = 0; j + 1 < segment_pts.size(); ++j) {
-    double interp_value;
-    if (type == TrailSettings::Type::ALTITUDE) {
-      const double t = static_cast<double>(j + 1) / piece_count;
-      interp_value =
-        prev_data.value * (1.0 - t) + curr_data.value * t;
-    } else if (use_merge_vario && !vario_breakpoints.empty()) {
-      const double u = static_cast<double>(j + 0.5) / piece_count;
-      interp_value = LookupVarioAtU(u, vario_breakpoints);
-    } else {
-      const double t = static_cast<double>(j + 1) / piece_count;
-      interp_value =
-        prev_data.value * (1.0 - t) + curr_data.value * t;
-    }
-
+  for (unsigned j = 0; j < num_pieces; ++j) {
     const unsigned seg_color_index =
-      GetTrailColorIndex(type, interp_value, value_min, value_max);
+      color_scale.Index(InterpolatePieceValue(type, prev_data.value,
+                                              curr_data.value, j,
+                                              piece_count, use_merge_vario,
+                                              vario_breakpoints));
 
     if (!run_active) {
       run_start = j;
@@ -640,7 +1146,7 @@ TrailRenderer::DrawSegmentWithVarioColour(
   }
 
   if (run_active)
-    flush_colour_run(segment_pts.size() - 1);
+    flush_colour_run(pts.size() - 1);
 }
 
 void
@@ -652,39 +1158,27 @@ TrailRenderer::DrawSmoothTailSegmentInline(
     const TrailPointData &prev_data,
     const TrailPointData &curr_data,
     TrailSettings::Type type,
-    double value_min, double value_max,
+    const ColorScale &color_scale,
     bool scaled_trail,
     bool use_merge_vario) noexcept
 {
   const double piece_count = static_cast<double>(num_segments);
-  PixelPoint last_interpolated = p1;
+
+  interpolated.clear();
+  interpolated.push_back(p1);
 
   for (unsigned j = 0; j < num_segments; ++j) {
     const unsigned next_piece = j + 1;
     const double t = static_cast<double>(next_piece) / piece_count;
-    const PixelPoint next_interpolated =
+    interpolated.push_back(
       next_piece == num_segments
         ? p2
-        : CatmullRomInterpolate(p0, p1, p2, p3, t);
-
-    double interp_value;
-    if (type == TrailSettings::Type::ALTITUDE) {
-      interp_value =
-        prev_data.value * (1.0 - t) + curr_data.value * t;
-    } else if (use_merge_vario && !vario_breakpoints.empty()) {
-      const double u = static_cast<double>(j + 0.5) / piece_count;
-      interp_value = LookupVarioAtU(u, vario_breakpoints);
-    } else {
-      interp_value =
-        prev_data.value * (1.0 - t) + curr_data.value * t;
-    }
-
-    const unsigned seg_color_index =
-      GetTrailColorIndex(type, interp_value, value_min, value_max);
-    SelectTrailPen(canvas, seg_color_index, scaled_trail);
-    canvas.DrawLinePiece(last_interpolated, next_interpolated);
-    last_interpolated = next_interpolated;
+        : CatmullRomInterpolate(p0, p1, p2, p3, t));
   }
+
+  DrawVarioColouredPolyline(canvas, interpolated, type,
+                            prev_data, curr_data, color_scale,
+                            scaled_trail, use_merge_vario, num_segments);
 }
 
 void

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -209,14 +209,6 @@ GetTrailSpacingPixels(double map_scale) noexcept
                     TRAIL_THIN_PIXELS_MAX);
 }
 
-[[gnu::const]]
-static double
-GetTrailThinDistance(const WindowProjection &projection,
-                     double map_scale) noexcept
-{
-  return projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
-}
-
 /** Max number of recent trace points that receive Catmull-Rom smoothing. */
 static constexpr size_t MAX_SMOOTHED_TRAIL_POINTS = 180;
 
@@ -459,7 +451,8 @@ TrailRenderer::MakeTrailQuery(TimeStamp min_time,
   query.min_time = min_time.Cast<std::chrono::duration<unsigned>>();
   query.bounds = projection.GetScreenBounds().Scale(TRAIL_BOUNDS_SCALE);
   query.project_location = projection.GetGeoScreenCenter();
-  query.min_distance_m = GetTrailThinDistance(projection, map_scale);
+  query.min_distance_m =
+    projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
   return query;
 }
 
@@ -470,6 +463,7 @@ TrailRenderer::TrailDrawFingerprint::operator==(
   return scale_px_per_m == other.scale_px_per_m &&
     color_min == other.color_min &&
     color_max == other.color_max &&
+    settings_type == other.settings_type &&
     query_bounds.GetNorthWest() == other.query_bounds.GetNorthWest() &&
     query_bounds.GetSouthEast() == other.query_bounds.GetSouthEast();
 }
@@ -478,7 +472,6 @@ void
 TrailRenderer::InvalidateSegmentCache() noexcept
 {
   segment_cache.clear();
-  cached_trace_size = 0;
 }
 
 bool
@@ -577,6 +570,39 @@ GetMinMax(TrailSettings::Type type, const TracePointVector &trace) noexcept
   return std::make_pair(value_min, value_max);
 }
 
+PixelPoint
+TrailRenderer::ProjectCachedPathPoint(
+    const CachedPathPoint &p,
+    const WindowProjection &projection,
+    const bool enable_traildrift,
+    const GeoPoint &traildrift,
+    const TimeStamp drift_now) noexcept
+{
+  return projection.GeoToScreen(
+    DriftGeoPoint(p.geo, p.time, p.drift_factor,
+                  enable_traildrift, traildrift, drift_now));
+}
+
+void
+TrailRenderer::ProjectCachedColourRun(
+    const CachedColourRun &run,
+    const size_t start_index,
+    const WindowProjection &projection,
+    const bool enable_traildrift,
+    const GeoPoint &traildrift,
+    const TimeStamp drift_now,
+    BulkPixelPoint *buffer,
+    unsigned &n,
+    const bool simplify_projected) noexcept
+{
+  for (size_t i = start_index; i < run.points.size(); ++i)
+    AppendFilteredTrailPoint(
+      buffer, n,
+      ProjectCachedPathPoint(run.points[i], projection,
+                             enable_traildrift, traildrift, drift_now),
+      simplify_projected);
+}
+
 void
 TrailRenderer::DrawCachedSegments(Canvas &canvas,
                                   const WindowProjection &projection,
@@ -604,12 +630,9 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
 
         auto *dst = Prepare(run.points.size());
         unsigned n = 0;
-        for (const auto &p : run.points) {
-          const PixelPoint pt = projection.GeoToScreen(
-            DriftGeoPoint(p.geo, p.time, p.drift_factor,
-                          enable_traildrift, traildrift, drift_now));
-          AppendFilteredTrailPoint(dst, n, pt, simplify_projected);
-        }
+        ProjectCachedColourRun(run, 0, projection, enable_traildrift,
+                               traildrift, drift_now, dst, n,
+                               simplify_projected);
 
         DrawRibbonPolyline(canvas, run.color_index, dst, n);
       }
@@ -670,25 +693,17 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
 
       size_t start = 0;
       if (batch_n > 0 && !run.points.empty()) {
-        const auto &junction_pt = run.points.front();
-        const PixelPoint junction = projection.GeoToScreen(
-          DriftGeoPoint(junction_pt.geo, junction_pt.time,
-                        junction_pt.drift_factor,
-                        enable_traildrift, traildrift, drift_now));
+        const PixelPoint junction =
+          ProjectCachedPathPoint(run.points.front(), projection,
+                                 enable_traildrift, traildrift, drift_now);
         if (junction.x == points[batch_n - 1].x &&
             junction.y == points[batch_n - 1].y)
           start = 1;
       }
 
-      for (size_t i = start; i < run.points.size(); ++i) {
-        const auto &p = run.points[i];
-        const PixelPoint pt = projection.GeoToScreen(
-          DriftGeoPoint(p.geo, p.time, p.drift_factor,
-                        enable_traildrift, traildrift, drift_now));
-
-        AppendFilteredTrailPoint(points.data(), batch_n, pt,
-                                 simplify_projected);
-      }
+      ProjectCachedColourRun(run, start, projection,
+                             enable_traildrift, traildrift, drift_now,
+                             points.data(), batch_n, simplify_projected);
     }
   }
 
@@ -829,24 +844,20 @@ TrailRenderer::BuildCachedSegment(const WindowProjection &projection,
   const GeoPoint gp1 = curr_tp.GetLocation();
   dest.colour_runs.clear();
 
-  const TrailPointData prev_data{
-    projection.GeoToScreen(gp0),
+  const double prev_value =
     type == TrailSettings::Type::ALTITUDE
-      ? prev_tp.GetAltitude() : prev_tp.GetVario(),
-    prev_tp.GetTime()};
-  const TrailPointData curr_data{
-    projection.GeoToScreen(gp1),
+      ? prev_tp.GetAltitude() : prev_tp.GetVario();
+  const double curr_value =
     type == TrailSettings::Type::ALTITUDE
-      ? curr_tp.GetAltitude() : curr_tp.GetVario(),
-    curr_tp.GetTime()};
+      ? curr_tp.GetAltitude() : curr_tp.GetVario();
 
   const bool use_merge_vario =
     type != TrailSettings::Type::ALTITUDE &&
     !merge_vario_samples.empty();
 
   if (use_merge_vario)
-    BuildVarioBreakpoints(prev_data.time, prev_data.value,
-                          curr_data.time, curr_data.value,
+    BuildVarioBreakpoints(prev_tp.GetTime(), prev_value,
+                          curr_tp.GetTime(), curr_value,
                           merge_vario_samples, merge_sample_index,
                           vario_breakpoints);
   else
@@ -862,14 +873,20 @@ TrailRenderer::BuildCachedSegment(const WindowProjection &projection,
     : gp1;
 
   if (use_smoothing && leg_index + 1 > first_smoothed_point) {
+    const TrailPointData prev_data{
+      PixelPoint{}, prev_value, prev_tp.GetTime()};
+    const TrailPointData curr_data{
+      PixelPoint{}, curr_value, curr_tp.GetTime()};
     BuildSmoothColourRuns(g0, g1, g2, g3,
                           prev_tp.GetTime(), curr_tp.GetTime(),
                           prev_tp.GetDriftFactor(), curr_tp.GetDriftFactor(),
                           num_segments, prev_data, curr_data, type, color_scale,
                           use_merge_vario, dest.colour_runs);
   } else {
-    const PixelPoint p1s = prev_data.point;
-    const PixelPoint p2s = curr_data.point;
+    const PixelPoint p1s = projection.GeoToScreen(gp0);
+    const PixelPoint p2s = projection.GeoToScreen(gp1);
+    const TrailPointData prev_data{p1s, prev_value, prev_tp.GetTime()};
+    const TrailPointData curr_data{p2s, curr_value, curr_tp.GetTime()};
     BuildDirectSegmentPoints(p1s, p2s, vario_breakpoints,
                              use_merge_vario, interpolated);
     BuildDirectColourRuns(prev_data, curr_data, gp0, gp1,
@@ -896,10 +913,8 @@ TrailRenderer::UpdateSegmentCache(const WindowProjection &projection,
     merge_sample_search_index = 0;
   }
 
-  if (trace.size() < 2) {
-    cached_trace_size = trace.size();
+  if (trace.size() < 2)
     return;
-  }
 
   const size_t start_leg = rebuild ? 0 : from_leg;
   if (rebuild)
@@ -919,8 +934,6 @@ TrailRenderer::UpdateSegmentCache(const WindowProjection &projection,
                        use_smoothing, num_segments, first_smoothed_point,
                        merge_sample_search_index, segment_cache.back());
   }
-
-  cached_trace_size = trace.size();
 }
 
 void
@@ -1054,12 +1067,12 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     query.bounds,
     minmax.first,
     minmax.second,
+    settings.type,
   };
 
   const bool fingerprint_changed = !(fingerprint == new_fingerprint);
-  const bool settings_changed = cached_settings_type != settings.type;
 
-  if (modify_changed || fingerprint_changed || settings_changed)
+  if (modify_changed || fingerprint_changed)
     UpdateSegmentCache(projection, settings.type, color_scale,
                        use_smoothing, num_segments, first_smoothed_point,
                        0, true);
@@ -1075,12 +1088,9 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   else if (leg_count < segment_cache.size())
     segment_cache.resize(leg_count);
 
-  cached_trace_size = trace.size();
-
   cache_append_serial = synced_append_serial;
   cache_modify_serial = synced_modify_serial;
   fingerprint = new_fingerprint;
-  cached_settings_type = settings.type;
 
   for (size_t i = 1; i < valid_points.size(); ++i) {
     const auto &curr_data = valid_points[i];

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -683,8 +683,10 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
       if (run.points.size() < 2)
         continue;
 
-      if (suppress_sink_lines && run.color_index < null_color_index)
+      if (suppress_sink_lines && run.color_index < null_color_index) {
+        flush_batch();
         continue;
+      }
 
       if (run.color_index != batch_color)
         flush_batch();
@@ -1241,7 +1243,7 @@ TrailRenderer::DrawRibbonPolyline(Canvas &canvas, unsigned color_index,
 
   if (join_radius > 1) {
     for (unsigned i = 1; i + 1 < n; ++i)
-      canvas.DrawCircle(pts[i], join_radius);
+      canvas.DrawCircle({pts[i].x, pts[i].y}, join_radius);
   }
 }
 

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -12,6 +12,7 @@
 #include "Geo/Math.hpp"
 #include "Geo/GeoBounds.hpp"
 #include "Engine/Contest/ContestTrace.hpp"
+#include "Screen/Layout.hpp"
 
 #include <algorithm>
 #include <new>
@@ -148,6 +149,14 @@ IsVarioDotsOnlyMode(TrailSettings::Type type) noexcept
     type == TrailSettings::Type::VARIO_2_DOTS;
 }
 
+[[gnu::const]]
+static bool
+IsVarioLineMode(TrailSettings::Type type) noexcept
+{
+  return type == TrailSettings::Type::VARIO_1 ||
+    type == TrailSettings::Type::VARIO_2;
+}
+
 [[gnu::pure]]
 static double
 InterpolatePieceValue(TrailSettings::Type type,
@@ -195,7 +204,7 @@ ComputeCatmullRomWeights(double t) noexcept
 static int
 GetTrailSpacingPixels(double map_scale) noexcept
 {
-  return std::clamp(int(map_scale / 500),
+  return std::clamp(static_cast<int>(map_scale / 500),
                     TRAIL_THIN_PIXELS_MIN,
                     TRAIL_THIN_PIXELS_MAX);
 }
@@ -208,42 +217,14 @@ GetTrailThinDistance(const WindowProjection &projection,
   return projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
 }
 
-/**
- * Bounded Catmull-Rom smoothing budget and recent trail tail.
- * Stefan Schumann, PR #2664.
- */
+/** Max number of recent trace points that receive Catmull-Rom smoothing. */
 static constexpr size_t MAX_SMOOTHED_TRAIL_POINTS = 180;
 
-[[gnu::const]]
-static unsigned
-GetBaseSmoothingSegments(const WindowProjection &projection) noexcept
-{
-  const double map_scale = projection.GetMapScale();
-  return map_scale <= 3000 ? 4 : map_scale <= TRAIL_ZOOMED_OUT_MAP_SCALE ? 3 : 2;
-}
-
-[[gnu::const]]
-static unsigned
-GetPreferredSmoothingSegments(const WindowProjection &projection) noexcept
-{
-  const double map_scale = projection.GetMapScale();
-  return map_scale <= 3000 ? 8 : map_scale <= TRAIL_ZOOMED_OUT_MAP_SCALE ? 6 : 4;
-}
-
-[[gnu::const]]
-static unsigned
-GetSmoothingSegments(const WindowProjection &projection,
-                     size_t point_count) noexcept
-{
-  const unsigned base = GetBaseSmoothingSegments(projection);
-  if (point_count <= 1)
-    return base;
-
-  const unsigned budget = (MAX_SMOOTHED_TRAIL_POINTS - 1) * base;
-  const unsigned allowed = std::max(base,
-                                    budget / (unsigned)(point_count - 1));
-  return std::min(GetPreferredSmoothingSegments(projection), allowed);
-}
+/**
+ * Fixed Catmull-Rom sub-divisions per GPS leg in the smoothed tail.
+ * Constant across zoom levels for visual consistency and bounded cost.
+ */
+static constexpr unsigned TRAIL_SMOOTH_SEGMENTS = 4;
 
 [[gnu::const]]
 static size_t
@@ -252,6 +233,76 @@ GetFirstSmoothedPointIndex(size_t point_count) noexcept
   return point_count > MAX_SMOOTHED_TRAIL_POINTS
     ? point_count - MAX_SMOOTHED_TRAIL_POINTS
     : 0;
+}
+
+[[gnu::pure]]
+static bool
+UseTrailSmoothing(TrailSettings::Type type, double map_scale) noexcept
+{
+  if (IsVarioDotsOnlyMode(type) || map_scale > TRAIL_ZOOMED_OUT_MAP_SCALE)
+    return false;
+
+  return true;
+}
+
+[[gnu::const]]
+static bool
+UseRibbonTrail(TrailSettings::Type type, bool scaled_trail) noexcept
+{
+  return scaled_trail && IsVarioLineMode(type);
+}
+
+[[gnu::const]]
+static PixelPoint
+RoundRibbonPoint(double x, double y) noexcept
+{
+  return {int(std::lround(x)), int(std::lround(y))};
+}
+
+[[gnu::pure]]
+static bool
+IsLowDpiTrail() noexcept
+{
+  return Layout::min_screen_pixels <= TrailLook::LOW_DPI_TRAIL_SCREEN_PX;
+}
+
+static void
+AppendFilteredTrailPoint(BulkPixelPoint *buffer, unsigned &n,
+                         PixelPoint pt, bool simplify) noexcept
+{
+  if (n > 0 && pt.x == buffer[n - 1].x && pt.y == buffer[n - 1].y)
+    return;
+
+  if (simplify && n >= 2) {
+    const auto &a = buffer[n - 2];
+    const auto &b = buffer[n - 1];
+
+    if (std::abs(pt.x - a.x) <= 1 && std::abs(pt.y - a.y) <= 1) {
+      buffer[n - 1] = pt;
+      return;
+    }
+
+    if ((a.x == b.x && b.x == pt.x) || (a.y == b.y && b.y == pt.y)) {
+      buffer[n - 1] = pt;
+      return;
+    }
+  }
+
+  buffer[n++] = pt;
+}
+
+[[gnu::pure]]
+static double
+GetRibbonWidth(const TrailLook &look, unsigned color_index) noexcept
+{
+  const unsigned min_width = look.trail_widths[0];
+  const unsigned width = look.trail_widths[color_index];
+
+  if (width <= min_width)
+    return min_width;
+
+  const double extra_factor = IsLowDpiTrail() ? 0.5 : 1.0;
+  return min_width + (width - min_width) * extra_factor;
 }
 
 [[gnu::pure]]
@@ -303,13 +354,13 @@ CatmullRomInterpolate(const PixelPoint &p0, const PixelPoint &p1,
 static GeoPoint
 TrailGeoPoint(const TracePoint &tp, bool enable_traildrift,
               const GeoPoint &traildrift,
-              const NMEAInfo &basic) noexcept
+              TimeStamp now) noexcept
 {
   if (!enable_traildrift)
     return tp.GetLocation();
 
   return tp.GetLocation().Parametric(traildrift,
-                                     tp.CalculateDrift(basic.time));
+                                     tp.CalculateDrift(now));
 }
 
 [[gnu::pure]]
@@ -533,12 +584,39 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
                                   const bool scaled_trail,
                                   const bool enable_traildrift,
                                   const GeoPoint &traildrift,
-                                  const NMEAInfo &basic,
+                                  const TimeStamp drift_now,
                                   const std::vector<CachedTrailSegment> &segments) noexcept
 {
   const bool suppress_sink_lines = IsVarioDotsOnlyMode(type);
+  const bool use_ribbon = UseRibbonTrail(type, scaled_trail);
+  const bool simplify_projected = IsLowDpiTrail() && use_ribbon;
   static constexpr unsigned null_color_index =
     TrailLook::NUMSNAILCOLORS / 2;
+
+  if (use_ribbon) {
+    for (const auto &seg : segments) {
+      for (const auto &run : seg.colour_runs) {
+        if (run.points.size() < 2)
+          continue;
+
+        if (suppress_sink_lines && run.color_index < null_color_index)
+          continue;
+
+        auto *dst = Prepare(run.points.size());
+        unsigned n = 0;
+        for (const auto &p : run.points) {
+          const PixelPoint pt = projection.GeoToScreen(
+            DriftGeoPoint(p.geo, p.time, p.drift_factor,
+                          enable_traildrift, traildrift, drift_now));
+          AppendFilteredTrailPoint(dst, n, pt, simplify_projected);
+        }
+
+        DrawRibbonPolyline(canvas, run.color_index, dst, n);
+      }
+    }
+
+    return;
+  }
 
   size_t max_batch_points = 0;
   size_t current_batch_points = 0;
@@ -596,7 +674,7 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
         const PixelPoint junction = projection.GeoToScreen(
           DriftGeoPoint(junction_pt.geo, junction_pt.time,
                         junction_pt.drift_factor,
-                        enable_traildrift, traildrift, basic.time));
+                        enable_traildrift, traildrift, drift_now));
         if (junction.x == points[batch_n - 1].x &&
             junction.y == points[batch_n - 1].y)
           start = 1;
@@ -606,9 +684,10 @@ TrailRenderer::DrawCachedSegments(Canvas &canvas,
         const auto &p = run.points[i];
         const PixelPoint pt = projection.GeoToScreen(
           DriftGeoPoint(p.geo, p.time, p.drift_factor,
-                        enable_traildrift, traildrift, basic.time));
+                        enable_traildrift, traildrift, drift_now));
 
-        points[batch_n++] = pt;
+        AppendFilteredTrailPoint(points.data(), batch_n, pt,
+                                 simplify_projected);
       }
     }
   }
@@ -934,20 +1013,28 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   const ColorScale color_scale =
     ColorScale::FromMinMax(settings.type, minmax.first, minmax.second);
 
-  const bool zoomed_in =
-    projection.GetMapScale() <= TRAIL_ZOOMED_OUT_MAP_SCALE;
+  const double map_scale = projection.GetMapScale();
+  const bool zoomed_in = map_scale <= TRAIL_ZOOMED_OUT_MAP_SCALE;
   const bool scaled_trail = settings.scaling_enabled && zoomed_in;
 
-  const bool use_smoothing =
-    settings.type != TrailSettings::Type::VARIO_1_DOTS &&
-    settings.type != TrailSettings::Type::VARIO_2_DOTS &&
-    zoomed_in;
+  const bool use_smoothing = UseTrailSmoothing(settings.type, map_scale);
+
+  const bool append_changed =
+    synced_append_serial != cache_append_serial;
+  const bool modify_changed =
+    synced_modify_serial != cache_modify_serial;
+  const size_t leg_count = trace.size() >= 2 ? trace.size() - 1 : 0;
+
+  if (!stable_drift_time.IsDefined() || append_changed || modify_changed ||
+      leg_count > segment_cache.size())
+    stable_drift_time = basic.time;
 
   valid_points.clear();
   valid_points.reserve(trace.size());
 
   for (const auto &i : trace) {
-    const GeoPoint gp = TrailGeoPoint(i, enable_traildrift, traildrift, basic);
+    const GeoPoint gp = TrailGeoPoint(i, enable_traildrift, traildrift,
+                                      stable_drift_time);
     const PixelPoint pt = projection.GeoToScreen(gp);
     const double value = (settings.type == TrailSettings::Type::ALTITUDE)
       ? i.GetAltitude() : i.GetVario();
@@ -960,12 +1047,7 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   const size_t first_smoothed_point =
     use_smoothing ? GetFirstSmoothedPointIndex(valid_points.size())
                   : valid_points.size();
-  const size_t smoothed_point_count =
-    valid_points.size() - first_smoothed_point;
-  const unsigned num_segments =
-    use_smoothing
-      ? GetSmoothingSegments(projection, smoothed_point_count)
-      : 0u;
+  const unsigned num_segments = use_smoothing ? TRAIL_SMOOTH_SEGMENTS : 0u;
 
   const TrailDrawFingerprint new_fingerprint{
     projection.GetScale(),
@@ -974,14 +1056,8 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     minmax.second,
   };
 
-  const bool modify_changed =
-    synced_modify_serial != cache_modify_serial;
   const bool fingerprint_changed = !(fingerprint == new_fingerprint);
-  const bool settings_changed =
-    cached_settings_type != settings.type ||
-    cached_scaled_trail != scaled_trail;
-
-  const size_t leg_count = trace.size() >= 2 ? trace.size() - 1 : 0;
+  const bool settings_changed = cached_settings_type != settings.type;
 
   if (modify_changed || fingerprint_changed || settings_changed)
     UpdateSegmentCache(projection, settings.type, color_scale,
@@ -1005,7 +1081,6 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   cache_modify_serial = synced_modify_serial;
   fingerprint = new_fingerprint;
   cached_settings_type = settings.type;
-  cached_scaled_trail = scaled_trail;
 
   for (size_t i = 1; i < valid_points.size(); ++i) {
     const auto &curr_data = valid_points[i];
@@ -1037,7 +1112,8 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   }
 
   DrawCachedSegments(canvas, projection, settings.type, scaled_trail,
-                     enable_traildrift, traildrift, basic, segment_cache);
+                     enable_traildrift, traildrift, stable_drift_time,
+                     segment_cache);
   DrawOpenLeg(canvas, settings, color_scale, scaled_trail,
               use_smoothing, num_segments, first_smoothed_point,
               basic, pos);
@@ -1077,16 +1153,11 @@ TrailRenderer::SelectTrailPen(Canvas &canvas, unsigned color_index,
 }
 
 void
-TrailRenderer::PrepareCopy(const PixelPoint *src, unsigned n) noexcept
-{
-  std::copy_n(src, n, Prepare(n));
-}
-
-void
 TrailRenderer::DrawColourPolyline(Canvas &canvas, unsigned color_index,
-                                   bool scaled_trail,
-                                   const std::vector<PixelPoint> &pts,
-                                   size_t first, size_t last) noexcept
+                                  TrailSettings::Type type,
+                                  bool scaled_trail,
+                                  const std::vector<PixelPoint> &pts,
+                                  size_t first, size_t last) noexcept
 {
   assert(first <= last);
   assert(last < pts.size());
@@ -1095,9 +1166,73 @@ TrailRenderer::DrawColourPolyline(Canvas &canvas, unsigned color_index,
   if (n < 2)
     return;
 
-  PrepareCopy(pts.data() + first, n);
+  const bool simplify_projected = IsLowDpiTrail() &&
+    (UseRibbonTrail(type, scaled_trail) || !scaled_trail);
+  auto *dst = Prepare(n);
+  unsigned filtered_n = 0;
+  for (size_t i = first; i <= last; ++i)
+    AppendFilteredTrailPoint(dst, filtered_n, pts[i], simplify_projected);
+
+  if (filtered_n < 2)
+    return;
+
+  if (UseRibbonTrail(type, scaled_trail)) {
+    DrawRibbonPolyline(canvas, color_index, dst, filtered_n);
+    return;
+  }
+
   SelectTrailPen(canvas, color_index, scaled_trail);
-  DrawPreparedPolyline(canvas, n);
+  DrawPreparedPolyline(canvas, filtered_n);
+}
+
+void
+TrailRenderer::DrawRibbonPolyline(Canvas &canvas, unsigned color_index,
+                                  const BulkPixelPoint *pts,
+                                  unsigned n) noexcept
+{
+  if (n < 2)
+    return;
+
+  const double half_width =
+    std::max(1., GetRibbonWidth(look, color_index) * 0.5);
+  const unsigned join_radius = unsigned(std::ceil(half_width));
+
+  canvas.SelectNullPen();
+  canvas.Select(look.trail_brushes[color_index]);
+
+  for (unsigned i = 0; i + 1 < n; ++i) {
+    const auto &a = pts[i];
+    const auto &b = pts[i + 1];
+    const double dx = double(b.x - a.x);
+    const double dy = double(b.y - a.y);
+    const double length = std::hypot(dx, dy);
+    if (length <= 0.)
+      continue;
+
+    const double ux = dx / length;
+    const double uy = dy / length;
+    const double nx = -uy * half_width;
+    const double ny = ux * half_width;
+    const double overlap = 0.5;
+    const double ax = double(a.x) - ux * overlap;
+    const double ay = double(a.y) - uy * overlap;
+    const double bx = double(b.x) + ux * overlap;
+    const double by = double(b.y) + uy * overlap;
+
+    BulkPixelPoint polygon[4] = {
+      RoundRibbonPoint(ax + nx, ay + ny),
+      RoundRibbonPoint(ax - nx, ay - ny),
+      RoundRibbonPoint(bx - nx, by - ny),
+      RoundRibbonPoint(bx + nx, by + ny),
+    };
+
+    canvas.DrawPolygon(polygon, 4);
+  }
+
+  if (join_radius > 1) {
+    for (unsigned i = 1; i + 1 < n; ++i)
+      canvas.DrawCircle(pts[i], join_radius);
+  }
 }
 
 void
@@ -1123,7 +1258,7 @@ TrailRenderer::DrawVarioColouredPolyline(Canvas &canvas,
   auto flush_colour_run = [&](size_t run_end) {
     if (!run_active || run_end <= run_start)
       return;
-    DrawColourPolyline(canvas, run_color, scaled_trail,
+    DrawColourPolyline(canvas, run_color, type, scaled_trail,
                        pts, run_start, run_end);
   };
 

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "TrailRenderer.hpp"
+#include "Asset.hpp"
 #include "Look/TrailLook.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "NMEA/Info.hpp"
@@ -20,53 +21,162 @@
 #include <vector>
 #include <cmath>
 
+static constexpr double TRAIL_ZOOMED_IN_SCALE = 6000;
+static constexpr int TRAIL_THIN_PIXELS_MIN = 3;
+static constexpr int TRAIL_THIN_PIXELS_MAX = 24;
+
 namespace {
 
-void
-BuildVarioKnots(TracePoint::Time t0, double v0,
-                TracePoint::Time t1, double v1,
-                const std::vector<TrailVarioSample> &samples,
-                std::vector<std::pair<TracePoint::Time, double>> &knots) noexcept
+/**
+ * Merge-vario samples in the half-open GPS interval [t0, t1).
+ * \a search_from advances monotonically across successive segments.
+ */
+struct MergeSampleRange {
+  size_t begin{};
+  size_t end{}; /* one past the last sample in range */
+};
+
+static MergeSampleRange
+FindMergeSamplesBetween(TracePoint::Time t0, TracePoint::Time t1,
+                        const std::vector<TrailVarioSample> &samples,
+                        size_t &search_from) noexcept
 {
-  knots.clear();
+  while (search_from < samples.size() && samples[search_from].time < t0)
+    ++search_from;
+
+  const size_t begin = search_from;
+  while (search_from < samples.size() && samples[search_from].time < t1)
+    ++search_from;
+
+  return {begin, search_from};
+}
+
+void
+BuildVarioBreakpoints(TracePoint::Time t0, double v0,
+                      TracePoint::Time t1, double v1,
+                      const std::vector<TrailVarioSample> &samples,
+                      size_t &merge_sample_index,
+                      std::vector<std::pair<double, double>> &bps) noexcept
+{
+  bps.clear();
   if (!(t1 > t0))
     return;
 
-  knots.reserve(samples.size() + 2);
-  knots.emplace_back(t0, v0);
-  for (const auto &s : samples) {
-    if (s.time > t0 && s.time < t1)
-      knots.emplace_back(s.time, (double)s.vario);
+  const MergeSampleRange range =
+    FindMergeSamplesBetween(t0, t1, samples, merge_sample_index);
+
+  const size_t n = range.end - range.begin;
+  bps.reserve(n + 2);
+  bps.emplace_back(0., v0);
+  if (n == 0) {
+    bps.emplace_back(1., v1);
+    return;
   }
-  knots.emplace_back(t1, v1);
-  /* merge_vario_samples are time-ordered; unstable sort would scramble ties */
+
+  const double dt = (double)(t1 - t0).count();
+
+  auto sample_u = [&](size_t i) noexcept -> double {
+    if (dt > 0.)
+      return (double)(samples[range.begin + i].time - t0).count() / dt;
+    return (double)(i + 1) / (double)(n + 1);
+  };
+
+  double u_prev = 0.;
+  for (size_t i = 0; i < n; ) {
+    const double u_i = sample_u(i);
+    size_t j = i + 1;
+    while (j < n && sample_u(j) == u_i)
+      ++j;
+
+    const double u_right = (j < n) ? sample_u(j) : 1.;
+    const size_t m = j - i;
+    const double u_left = u_prev;
+    for (size_t k = i; k < j; ++k) {
+      const double u = (m > 1)
+        ? u_left + (u_right - u_left) * (double)(k - i + 1) / (double)(m + 1)
+        : u_i;
+      bps.emplace_back(u, (double)samples[range.begin + k].vario);
+      u_prev = u;
+    }
+    i = j;
+  }
+
+  bps.emplace_back(1., v1);
 }
 
 [[gnu::pure]]
 double
-LookupVarioFromKnots(TracePoint::Time t_query,
-                       const std::vector<std::pair<TracePoint::Time, double>> &knots) noexcept
+LookupVarioAtU(double u,
+               const std::vector<std::pair<double, double>> &bps) noexcept
 {
-  if (knots.empty())
+  if (bps.empty())
     return 0;
-  if (t_query <= knots.front().first)
-    return knots.front().second;
-  if (t_query >= knots.back().first)
-    return knots.back().second;
-  for (size_t i = 0; i + 1 < knots.size(); ++i) {
-    const auto &a = knots[i];
-    const auto &b = knots[i + 1];
-    if (t_query <= b.first) {
-      const double da = (double)a.first.count();
-      const double db = (double)b.first.count();
-      const double dq = (double)t_query.count();
-      if (db <= da)
-        return b.second;
-      const double u = (dq - da) / (db - da);
-      return a.second * (1. - u) + b.second * u;
-    }
+  if (u <= bps.front().first)
+    return bps.front().second;
+  if (u >= bps.back().first)
+    return bps.back().second;
+
+  const auto it = std::upper_bound(bps.begin(), bps.end(), u,
+                                   [](double u, const auto &bp) {
+                                     return u < bp.first;
+                                   });
+  const auto &b = *it;
+  const auto &a = *std::prev(it);
+  const double du = b.first - a.first;
+  if (du <= 0.)
+    return b.second;
+  const double t = (u - a.first) / du;
+  return a.second * (1. - t) + b.second * t;
+}
+
+/** ~1 canvas pixel per 500 m map scale, clamped to pre/post #2661 range. */
+[[gnu::const]]
+static double
+GetTrailThinDistance(const WindowProjection &projection,
+                     double map_scale) noexcept
+{
+  const int thin_px = std::clamp(int(map_scale / 500),
+                                 TRAIL_THIN_PIXELS_MIN,
+                                 TRAIL_THIN_PIXELS_MAX);
+  return projection.DistancePixelsToMeters(thin_px);
+}
+
+[[gnu::pure]]
+static PixelPoint
+LerpPixelPoint(const PixelPoint &a, const PixelPoint &b,
+               double u) noexcept
+{
+  return PixelPoint(
+    int(std::lround(a.x + (b.x - a.x) * u)),
+    int(std::lround(a.y + (b.y - a.y) * u)));
+}
+
+[[gnu::const]]
+static unsigned
+GetSplineBaseSegments(const PixelPoint &p1, const PixelPoint &p2) noexcept
+{
+  unsigned base = unsigned(std::clamp(ManhattanDistance(p1, p2) / 4, 4, 16));
+  if (IsEmbedded() && base > 4)
+    base = base * 3 / 4;
+  return std::max(base, 4u);
+}
+
+static void
+BuildDirectSegmentPoints(const PixelPoint &p1, const PixelPoint &p2,
+                         const std::vector<std::pair<double, double>> &bps,
+                         bool use_merge_vario,
+                         std::vector<PixelPoint> &result) noexcept
+{
+  result.clear();
+  result.push_back(p1);
+
+  if (use_merge_vario && bps.size() > 2) {
+    const unsigned pieces = unsigned(bps.size() - 1);
+    for (unsigned j = 1; j < pieces; ++j)
+      result.push_back(LerpPixelPoint(p1, p2, double(j) / double(pieces)));
   }
-  return knots.back().second;
+
+  result.push_back(p2);
 }
 
 } // namespace
@@ -89,7 +199,8 @@ TrailRenderer::LoadTrace(const TraceComputer &trace_computer) noexcept
 bool
 TrailRenderer::LoadTrace(const TraceComputer &trace_computer,
                          TimeStamp min_time,
-                         const WindowProjection &projection) noexcept
+                         const WindowProjection &projection,
+                         double map_scale) noexcept
 {
   trace.clear();
   merge_vario_samples.clear();
@@ -97,7 +208,8 @@ TrailRenderer::LoadTrace(const TraceComputer &trace_computer,
     trace_computer.LockedCopySnapshot(trace, merge_vario_samples,
                                       min_time.Cast<std::chrono::duration<unsigned>>(),
                                       projection.GetGeoScreenCenter(),
-                                      projection.DistancePixelsToMeters(3));
+                                      GetTrailThinDistance(projection,
+                                                           map_scale));
   } catch (const std::bad_alloc &) {
     trace.clear();
     merge_vario_samples.clear();
@@ -127,6 +239,16 @@ GetAltitudeColorIndex(double alt, double min_alt, double max_alt) noexcept
   auto relative_altitude = (alt - min_alt) / (max_alt - min_alt);
   int _max = TrailLook::NUMSNAILCOLORS - 1;
   return std::clamp((int)(relative_altitude * _max), 0, _max);
+}
+
+[[gnu::pure]]
+static unsigned
+GetTrailColorIndex(TrailSettings::Type type, double value,
+                   double value_min, double value_max) noexcept
+{
+  if (type == TrailSettings::Type::ALTITUDE)
+    return GetAltitudeColorIndex(value, value_min, value_max);
+  return GetSnailColorIndex(value, value_min, value_max);
 }
 
 [[gnu::pure]]
@@ -219,18 +341,16 @@ CalculateAngle(const PixelPoint &p0, const PixelPoint &p1, const PixelPoint &p2)
  * @param p2 End point
  * @param p3 Control point after p2
  * @param base_num_segments Base number of segments to generate
- * @return Vector of interpolated points (including p1 and p2)
+ * @param result Reused output buffer (including p1 and p2)
  */
-static std::vector<PixelPoint>
+static void
 InterpolateSegment(const PixelPoint &p0, const PixelPoint &p1,
                    const PixelPoint &p2, const PixelPoint &p3,
-                   unsigned base_num_segments) noexcept
+                   unsigned base_num_segments, unsigned max_segments,
+                   std::vector<PixelPoint> &result) noexcept
 {
-  // Calculate turn angle to determine if we need more segments
   const double angle = CalculateAngle(p0, p1, p2);
-  
-  // Sharper turns need more segments for smooth appearance
-  // For angles > 30 degrees, increase segments significantly
+
   unsigned num_segments = base_num_segments;
   if (angle > 45.0) {
     num_segments = base_num_segments * 2;
@@ -239,26 +359,19 @@ InterpolateSegment(const PixelPoint &p0, const PixelPoint &p1,
   } else if (angle > 15.0) {
     num_segments = static_cast<unsigned>(base_num_segments * 1.2);
   }
-  
-  // Cap maximum segments for performance
-  num_segments = std::min(num_segments, 20u);
-  
-  std::vector<PixelPoint> result;
-  result.reserve(num_segments + 1);
 
-  // Always include the start point
+  num_segments = std::min(num_segments, max_segments);
+
+  result.clear();
+  result.reserve(num_segments + 1);
   result.push_back(p1);
 
-  // Generate intermediate points
   for (unsigned i = 1; i < num_segments; ++i) {
     const double t = static_cast<double>(i) / num_segments;
     result.push_back(CatmullRomInterpolate(p0, p1, p2, p3, t));
   }
 
-  // Always include the end point
   result.push_back(p2);
-
-  return result;
 }
 
 void
@@ -272,7 +385,9 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   if (settings.length == TrailSettings::Length::OFF)
     return;
 
-  if (!LoadTrace(trace_computer, min_time, projection))
+  const double map_scale = projection.GetMapScale();
+
+  if (!LoadTrace(trace_computer, min_time, projection, map_scale))
     return;
 
   if (!basic.location_available || !calculated.wind_available)
@@ -290,29 +405,17 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   auto value_min = minmax.first;
   auto value_max = minmax.second;
 
-  bool scaled_trail = settings.scaling_enabled &&
-                      projection.GetMapScale() <= 6000;
+  const bool zoomed_in = map_scale <= TRAIL_ZOOMED_IN_SCALE;
+  const bool scaled_trail = settings.scaling_enabled && zoomed_in;
 
   const GeoBounds bounds = projection.GetScreenBounds().Scale(4);
 
-  // Determine if we should use smoothing (only for line segments, not dots-only modes)
-  const bool use_smoothing = 
+  const bool use_smoothing =
     settings.type != TrailSettings::Type::VARIO_1_DOTS &&
-    settings.type != TrailSettings::Type::VARIO_2_DOTS;
+    settings.type != TrailSettings::Type::VARIO_2_DOTS &&
+    zoomed_in;
 
-  // Determine number of interpolation segments based on zoom level
-  // More segments when zoomed in for better quality, and always use enough for smooth curves
-  // Gliders fly in smooth arcs, so we need more segments for realistic appearance
-  const unsigned num_segments = projection.GetMapScale() <= 3000 ? 12 : 
-                                 projection.GetMapScale() <= 6000 ? 8 : 6;
-
-  // Collect valid points with their data
-  struct PointData {
-    PixelPoint point;
-    double value; // vario or altitude
-    TracePoint::Time time{};
-  };
-  std::vector<PointData> valid_points;
+  valid_points.clear();
   valid_points.reserve(trace.size());
 
   for (const auto &i : trace) {
@@ -326,12 +429,22 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     auto pt = projection.GeoToScreen(gp);
     const double value = (settings.type == TrailSettings::Type::ALTITUDE)
       ? i.GetAltitude() : i.GetVario();
+    const TrailPointData pd{pt, value, i.GetTime()};
 
-    valid_points.push_back({pt, value, i.GetTime()});
+    if (!valid_points.empty() &&
+        ManhattanDistance(pt, valid_points.back().point) < 1) {
+      /* Same screen cell: keep latest vario/altitude for colour */
+      valid_points.back() = pd;
+      continue;
+    }
+
+    valid_points.push_back(pd);
   }
 
   if (valid_points.empty())
     return;
+
+  size_t merge_sample_index = 0;
 
   // Draw the trail with spline interpolation
   for (size_t i = 0; i < valid_points.size(); ++i) {
@@ -343,15 +456,9 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
     const auto &prev_data = valid_points[i - 1];
     const auto &curr_data = valid_points[i];
 
-    // Determine color index for this segment
-    unsigned color_index;
-    if (settings.type == TrailSettings::Type::ALTITUDE) {
-      color_index = GetAltitudeColorIndex(curr_data.value,
-                                          value_min, value_max);
-    } else {
-      color_index = GetSnailColorIndex(curr_data.value,
-                                       value_min, value_max);
-    }
+    const unsigned color_index =
+      GetTrailColorIndex(settings.type, curr_data.value,
+                         value_min, value_max);
 
     // Determine if we should draw dots (circles) for this segment
     // Dots are drawn for negative vario in dots modes, or for positive vario in VARIO_DOTS_AND_LINES/VARIO_EINK
@@ -397,73 +504,33 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
       const auto &p2 = curr_data.point;
       const auto &p3 = (i + 1 < valid_points.size()) ? valid_points[i + 1].point : curr_data.point;
 
+      const bool use_merge_vario =
+        settings.type != TrailSettings::Type::ALTITUDE &&
+        !merge_vario_samples.empty();
+
+      if (use_merge_vario)
+        BuildVarioBreakpoints(prev_data.time, prev_data.value,
+                              curr_data.time, curr_data.value,
+                              merge_vario_samples, merge_sample_index,
+                              vario_breakpoints);
+      else
+        vario_breakpoints.clear();
+
       if (use_smoothing && i >= 1) {
-        // Use spline interpolation for smooth curves
-        auto interpolated = InterpolateSegment(p0, p1, p2, p3, num_segments);
-
-        std::vector<std::pair<TracePoint::Time, double>> vario_knots;
-        const bool use_merge_vario =
-          settings.type != TrailSettings::Type::ALTITUDE &&
-          !merge_vario_samples.empty();
-        if (use_merge_vario)
-          BuildVarioKnots(prev_data.time, prev_data.value,
-                          curr_data.time, curr_data.value,
-                          merge_vario_samples, vario_knots);
-
-        /* Colour parameter spans drawn line pieces (n−1), not vertex count n */
-        const double piece_count =
-          interpolated.size() > 1
-            ? static_cast<double>(interpolated.size() - 1)
-            : 1.0;
-
-        // Interpolate values for smooth color transitions
-        for (size_t j = 0; j + 1 < interpolated.size(); ++j) {
-          double interp_value;
-          if (settings.type == TrailSettings::Type::ALTITUDE) {
-            const double t =
-              static_cast<double>(j + 1) / piece_count;
-            interp_value =
-              prev_data.value * (1.0 - t) + curr_data.value * t;
-          } else if (use_merge_vario && !vario_knots.empty()) {
-            const double u =
-              static_cast<double>(j + 0.5) / piece_count;
-            const double tc =
-              (double)prev_data.time.count() +
-              ((double)curr_data.time.count() -
-               (double)prev_data.time.count()) *
-                u;
-            const TracePoint::Time t_query(
-              std::chrono::duration<unsigned>((unsigned)std::lround(tc)));
-            interp_value = LookupVarioFromKnots(t_query, vario_knots);
-          } else {
-            const double t =
-              static_cast<double>(j + 1) / piece_count;
-            interp_value =
-              prev_data.value * (1.0 - t) + curr_data.value * t;
-          }
-
-          unsigned seg_color_index;
-          if (settings.type == TrailSettings::Type::ALTITUDE) {
-            seg_color_index = GetAltitudeColorIndex(interp_value, value_min, value_max);
-          } else {
-            seg_color_index = GetSnailColorIndex(interp_value, value_min, value_max);
-          }
-
-          if (scaled_trail)
-            canvas.Select(look.scaled_trail_pens[seg_color_index]);
-          else
-            canvas.Select(look.trail_pens[seg_color_index]);
-
-          canvas.DrawLinePiece(interpolated[j], interpolated[j + 1]);
-        }
+        const unsigned base_segments = GetSplineBaseSegments(p1, p2);
+        InterpolateSegment(p0, p1, p2, p3, base_segments, 16u,
+                           interpolated);
+        DrawSegmentWithVarioColour(canvas, prev_data, curr_data,
+                                   interpolated, settings.type,
+                                   value_min, value_max,
+                                   scaled_trail, use_merge_vario);
       } else {
-        // Not enough points or smoothing disabled - draw direct line
-
-        if (scaled_trail)
-          canvas.Select(look.scaled_trail_pens[color_index]);
-        else
-          canvas.Select(look.trail_pens[color_index]);
-        canvas.DrawLinePiece(prev_data.point, curr_data.point);
+        BuildDirectSegmentPoints(p1, p2, vario_breakpoints,
+                                 use_merge_vario, interpolated);
+        DrawSegmentWithVarioColour(canvas, prev_data, curr_data,
+                                   interpolated, settings.type,
+                                   value_min, value_max,
+                                   scaled_trail, use_merge_vario);
       }
     }
   }
@@ -471,19 +538,11 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
   // Draw line to current aircraft position
   if (!valid_points.empty()) {
     const auto &last_data = valid_points.back();
-    unsigned color_index;
-    if (settings.type == TrailSettings::Type::ALTITUDE) {
-      color_index = GetAltitudeColorIndex(last_data.value,
-                                         value_min, value_max);
-    } else {
-      color_index = GetSnailColorIndex(last_data.value,
-                                      value_min, value_max);
-    }
+    const unsigned color_index =
+      GetTrailColorIndex(settings.type, last_data.value,
+                         value_min, value_max);
 
-    if (scaled_trail)
-      canvas.Select(look.scaled_trail_pens[color_index]);
-    else
-      canvas.Select(look.trail_pens[color_index]);
+    SelectTrailPen(canvas, color_index, scaled_trail);
     canvas.DrawLine(last_data.point, pos);
   }
 }
@@ -500,7 +559,8 @@ TrailRenderer::Draw(Canvas &canvas, const TraceComputer &trace_computer,
                     const WindowProjection &projection,
                     TimeStamp min_time) noexcept
 {
-  if (LoadTrace(trace_computer, min_time, projection))
+  if (LoadTrace(trace_computer, min_time, projection,
+                projection.GetMapScale()))
     Draw(canvas, projection);
 }
 
@@ -509,6 +569,103 @@ TrailRenderer::Prepare(unsigned n) noexcept
 {
   points.GrowDiscard(n);
   return points.data();
+}
+
+void
+TrailRenderer::SelectTrailPen(Canvas &canvas, unsigned color_index,
+                              bool scaled_trail) const noexcept
+{
+  if (scaled_trail)
+    canvas.Select(look.scaled_trail_pens[color_index]);
+  else
+    canvas.Select(look.trail_pens[color_index]);
+}
+
+void
+TrailRenderer::PrepareCopy(const PixelPoint *src, unsigned n) noexcept
+{
+  std::copy_n(src, n, Prepare(n));
+}
+
+void
+TrailRenderer::DrawColourPolyline(Canvas &canvas, unsigned color_index,
+                                   bool scaled_trail,
+                                   const std::vector<PixelPoint> &pts,
+                                   size_t first, size_t last) noexcept
+{
+  assert(first <= last);
+  assert(last < pts.size());
+
+  const unsigned n = unsigned(last - first + 1);
+  if (n < 2)
+    return;
+
+  PrepareCopy(pts.data() + first, n);
+  SelectTrailPen(canvas, color_index, scaled_trail);
+  DrawPreparedPolyline(canvas, n);
+}
+
+void
+TrailRenderer::DrawSegmentWithVarioColour(
+    Canvas &canvas,
+    const TrailPointData &prev_data,
+    const TrailPointData &curr_data,
+    const std::vector<PixelPoint> &segment_pts,
+    TrailSettings::Type type,
+    double value_min, double value_max,
+    bool scaled_trail,
+    bool use_merge_vario) noexcept
+{
+  if (segment_pts.size() < 2)
+    return;
+
+  const double piece_count =
+    segment_pts.size() > 1
+      ? static_cast<double>(segment_pts.size() - 1)
+      : 1.0;
+
+  size_t run_start = 0;
+  unsigned run_color = 0;
+  bool run_active = false;
+
+  auto flush_colour_run = [&](size_t run_end) {
+    if (!run_active || run_end <= run_start)
+      return;
+    DrawColourPolyline(canvas, run_color, scaled_trail,
+                       segment_pts, run_start, run_end);
+  };
+
+  for (size_t j = 0; j + 1 < segment_pts.size(); ++j) {
+    double interp_value;
+    if (type == TrailSettings::Type::ALTITUDE) {
+      const double t = static_cast<double>(j + 1) / piece_count;
+      interp_value =
+        prev_data.value * (1.0 - t) + curr_data.value * t;
+    } else if (use_merge_vario && !vario_breakpoints.empty()) {
+      const double u = static_cast<double>(j + 0.5) / piece_count;
+      interp_value = LookupVarioAtU(u, vario_breakpoints);
+    } else {
+      const double t = static_cast<double>(j + 1) / piece_count;
+      interp_value =
+        prev_data.value * (1.0 - t) + curr_data.value * t;
+    }
+
+    const unsigned seg_color_index =
+      GetTrailColorIndex(type, interp_value, value_min, value_max);
+
+    if (!run_active) {
+      run_start = j;
+      run_color = seg_color_index;
+      run_active = true;
+    } else if (seg_color_index != run_color) {
+      flush_colour_run(j);
+      run_start = j;
+      run_color = seg_color_index;
+    }
+  }
+
+  if (run_active)
+    flush_colour_run(segment_pts.size() - 1);
 }
 
 void

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -124,6 +124,18 @@ private:
                                   bool scaled_trail,
                                   bool use_merge_vario) noexcept;
 
+  /** Inline Catmull-Rom pieces for the bounded smoothed tail (#2664). */
+  void DrawSmoothTailSegmentInline(Canvas &canvas,
+                                   const PixelPoint &p0, const PixelPoint &p1,
+                                   const PixelPoint &p2, const PixelPoint &p3,
+                                   unsigned num_segments,
+                                   const TrailPointData &prev_data,
+                                   const TrailPointData &curr_data,
+                                   TrailSettings::Type type,
+                                   double value_min, double value_max,
+                                   bool scaled_trail,
+                                   bool use_merge_vario) noexcept;
+
   void DrawTraceVector(Canvas &canvas, const Projection &projection,
                        const TracePointVector &trace) noexcept;
 };

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -63,6 +63,7 @@ class TrailRenderer {
     GeoBounds query_bounds{};
     double color_min{};
     double color_max{};
+    TrailSettings::Type settings_type{};
 
     [[gnu::pure]]
     bool operator==(const TrailDrawFingerprint &other) const noexcept;
@@ -102,8 +103,6 @@ class TrailRenderer {
   Serial cache_append_serial;
   Serial cache_modify_serial;
   TrailDrawFingerprint fingerprint{};
-  TrailSettings::Type cached_settings_type{};
-  size_t cached_trace_size{};
   size_t merge_sample_search_index{};
   /** Keep completed-segment drift stable between GPS trace updates. */
   TimeStamp stable_drift_time{TimeStamp::Undefined()};
@@ -187,6 +186,23 @@ private:
                           const GeoPoint &traildrift,
                           TimeStamp drift_now,
                           const std::vector<CachedTrailSegment> &segments) noexcept;
+
+  [[gnu::pure]]
+  static PixelPoint ProjectCachedPathPoint(const CachedPathPoint &p,
+                                           const WindowProjection &projection,
+                                           bool enable_traildrift,
+                                           const GeoPoint &traildrift,
+                                           TimeStamp drift_now) noexcept;
+
+  static void ProjectCachedColourRun(const CachedColourRun &run,
+                                     size_t start_index,
+                                     const WindowProjection &projection,
+                                     bool enable_traildrift,
+                                     const GeoPoint &traildrift,
+                                     TimeStamp drift_now,
+                                     BulkPixelPoint *buffer,
+                                     unsigned &n,
+                                     bool simplify_projected) noexcept;
 
   void DrawVarioColouredPolyline(Canvas &canvas,
                                  const std::vector<PixelPoint> &pts,

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -7,9 +7,11 @@
 #include "Computer/TraceComputer.hpp"
 #include "Engine/Trace/Point.hpp"
 #include "Engine/Trace/Vector.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "MapSettings.hpp"
 #include "ui/dim/Point.hpp"
 #include "time/Stamp.hpp"
+#include "util/Serial.hpp"
 
 #include <vector>
 
@@ -37,6 +39,51 @@ class TrailRenderer {
     TracePoint::Time time{};
   };
 
+  /** Undrifted geo sample with metadata for per-frame drift projection. */
+  struct CachedPathPoint {
+    GeoPoint geo;
+    TracePoint::Time time{};
+    uint16_t drift_factor{};
+  };
+
+  /** Geo path with a single trail colour index (projected at draw time). */
+  struct CachedColourRun {
+    unsigned color_index{};
+    std::vector<CachedPathPoint> points;
+  };
+
+  /** Tessellated, coloured geometry for one completed GPS leg. */
+  struct CachedTrailSegment {
+    std::vector<CachedColourRun> colour_runs;
+  };
+
+  /** Projection state that affects tessellation or visible trail query. */
+  struct TrailDrawFingerprint {
+    double scale_px_per_m{};
+    GeoBounds query_bounds{};
+    double color_min{};
+    double color_max{};
+
+    [[gnu::pure]]
+    bool operator==(const TrailDrawFingerprint &other) const noexcept;
+  };
+
+  /** Precomputed reciprocals for vario/altitude → colour index. */
+  struct ColorScale {
+    double neg_inv_min{};
+    double inv_max{};
+    double alt_inv_range{};
+    double alt_min{};
+    bool is_altitude{};
+
+    [[gnu::pure]]
+    unsigned Index(double value) const noexcept;
+
+    static ColorScale FromMinMax(TrailSettings::Type type,
+                                 double value_min,
+                                 double value_max) noexcept;
+  };
+
   const TrailLook &look;
 
   TracePointVector trace;
@@ -48,6 +95,17 @@ class TrailRenderer {
   std::vector<PixelPoint> interpolated;
   /** Segment parameter u in [0,1] → vario for merge-vario colouring. */
   std::vector<std::pair<double, double>> vario_breakpoints;
+
+  std::vector<CachedTrailSegment> segment_cache;
+  Serial synced_append_serial;
+  Serial synced_modify_serial;
+  Serial cache_append_serial;
+  Serial cache_modify_serial;
+  TrailDrawFingerprint fingerprint{};
+  TrailSettings::Type cached_settings_type{};
+  bool cached_scaled_trail{};
+  size_t cached_trace_size{};
+  size_t merge_sample_search_index{};
 
 public:
   TrailRenderer(const TrailLook &_look) noexcept:look(_look) {}
@@ -62,8 +120,11 @@ public:
    */
   bool LoadTrace(const TraceComputer &trace_computer,
                  TimeStamp min_time,
-                 const WindowProjection &projection,
-                 double map_scale) noexcept;
+                 const WindowProjection &projection) noexcept;
+
+  [[gnu::pure]]
+  static TrailQuery MakeTrailQuery(TimeStamp min_time,
+                                   const WindowProjection &projection) noexcept;
 
   void ScanBounds(GeoBounds &bounds) const noexcept {
     trace.ScanBounds(bounds);
@@ -115,14 +176,62 @@ private:
                           const std::vector<PixelPoint> &pts,
                           size_t first, size_t last) noexcept;
 
-  void DrawSegmentWithVarioColour(Canvas &canvas,
-                                  const TrailPointData &prev_data,
-                                  const TrailPointData &curr_data,
-                                  const std::vector<PixelPoint> &segment_pts,
-                                  TrailSettings::Type type,
-                                  double value_min, double value_max,
-                                  bool scaled_trail,
-                                  bool use_merge_vario) noexcept;
+  void DrawCachedSegments(Canvas &canvas,
+                          const WindowProjection &projection,
+                          TrailSettings::Type type,
+                          bool scaled_trail,
+                          bool enable_traildrift,
+                          const GeoPoint &traildrift,
+                          const NMEAInfo &basic,
+                          const std::vector<CachedTrailSegment> &segments) noexcept;
+
+  void DrawVarioColouredPolyline(Canvas &canvas,
+                                 const std::vector<PixelPoint> &pts,
+                                 TrailSettings::Type type,
+                                 const TrailPointData &prev_data,
+                                 const TrailPointData &curr_data,
+                                 const ColorScale &color_scale,
+                                 bool scaled_trail,
+                                 bool use_merge_vario,
+                                 unsigned num_pieces) noexcept;
+
+  static void AppendColourRun(std::vector<CachedColourRun> &runs,
+                              unsigned color_index,
+                              const CachedPathPoint &pt) noexcept;
+
+  [[gnu::pure]]
+  static CachedPathPoint LerpCachedPathPoint(const GeoPoint &g0,
+                                             const GeoPoint &g1,
+                                             TracePoint::Time t0,
+                                             TracePoint::Time t1,
+                                             unsigned df0, unsigned df1,
+                                             double u) noexcept;
+
+  void BuildDirectColourRuns(const TrailPointData &prev_data,
+                             const TrailPointData &curr_data,
+                             const GeoPoint &prev_geo,
+                             const GeoPoint &curr_geo,
+                             unsigned prev_drift_factor,
+                             unsigned curr_drift_factor,
+                             const std::vector<PixelPoint> &segment_pts,
+                             TrailSettings::Type type,
+                             const ColorScale &color_scale,
+                             bool use_merge_vario,
+                             std::vector<CachedColourRun> &runs) noexcept;
+
+  void BuildSmoothColourRuns(const GeoPoint &g0, const GeoPoint &g1,
+                             const GeoPoint &g2, const GeoPoint &g3,
+                             TracePoint::Time time1,
+                             TracePoint::Time time2,
+                             unsigned drift_factor1,
+                             unsigned drift_factor2,
+                             unsigned num_segments,
+                             const TrailPointData &prev_data,
+                             const TrailPointData &curr_data,
+                             TrailSettings::Type type,
+                             const ColorScale &color_scale,
+                             bool use_merge_vario,
+                             std::vector<CachedColourRun> &runs) noexcept;
 
   /** Inline Catmull-Rom pieces for the bounded smoothed tail (#2664). */
   void DrawSmoothTailSegmentInline(Canvas &canvas,
@@ -132,9 +241,45 @@ private:
                                    const TrailPointData &prev_data,
                                    const TrailPointData &curr_data,
                                    TrailSettings::Type type,
-                                   double value_min, double value_max,
+                                   const ColorScale &color_scale,
                                    bool scaled_trail,
                                    bool use_merge_vario) noexcept;
+
+  bool SyncTrace(const TraceComputer &trace_computer,
+                 const TrailQuery &query) noexcept;
+
+  void InvalidateSegmentCache() noexcept;
+
+  void UpdateSegmentCache(const WindowProjection &projection,
+                          TrailSettings::Type type,
+                          const ColorScale &color_scale,
+                          bool use_smoothing,
+                          unsigned num_segments,
+                          size_t first_smoothed_point,
+                          size_t from_leg,
+                          bool rebuild) noexcept;
+
+  void MergeAdjacentColourRuns(std::vector<CachedColourRun> &runs) noexcept;
+
+  void BuildCachedSegment(const WindowProjection &projection,
+                          size_t leg_index,
+                          TrailSettings::Type type,
+                          const ColorScale &color_scale,
+                          bool use_smoothing,
+                          unsigned num_segments,
+                          size_t first_smoothed_point,
+                          size_t &merge_sample_index,
+                          CachedTrailSegment &dest) noexcept;
+
+  void DrawOpenLeg(Canvas &canvas,
+                   const TrailSettings &settings,
+                   const ColorScale &color_scale,
+                   bool scaled_trail,
+                   bool use_smoothing,
+                   unsigned num_segments,
+                   size_t first_smoothed_point,
+                   const NMEAInfo &basic,
+                   PixelPoint aircraft_pos) noexcept;
 
   void DrawTraceVector(Canvas &canvas, const Projection &projection,
                        const TracePointVector &trace) noexcept;

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -7,11 +7,12 @@
 #include "Computer/TraceComputer.hpp"
 #include "Engine/Trace/Point.hpp"
 #include "Engine/Trace/Vector.hpp"
+#include "MapSettings.hpp"
+#include "ui/dim/Point.hpp"
 #include "time/Stamp.hpp"
 
 #include <vector>
 
-struct PixelPoint;
 struct BulkPixelPoint;
 class Canvas;
 class TraceComputer;
@@ -30,11 +31,23 @@ struct TrailSettings;
  * includes filter for coarse-graining trail in LoadTrace
  */
 class TrailRenderer {
+  struct TrailPointData {
+    PixelPoint point;
+    double value{};
+    TracePoint::Time time{};
+  };
+
   const TrailLook &look;
 
   TracePointVector trace;
   std::vector<TrailVarioSample> merge_vario_samples;
   AllocatedArray<BulkPixelPoint> points;
+
+  /** Reused each Draw() to avoid per-frame heap allocations. */
+  std::vector<TrailPointData> valid_points;
+  std::vector<PixelPoint> interpolated;
+  /** Segment parameter u in [0,1] → vario for merge-vario colouring. */
+  std::vector<std::pair<double, double>> vario_breakpoints;
 
 public:
   TrailRenderer(const TrailLook &_look) noexcept:look(_look) {}
@@ -49,7 +62,8 @@ public:
    */
   bool LoadTrace(const TraceComputer &trace_computer,
                  TimeStamp min_time,
-                 const WindowProjection &projection) noexcept;
+                 const WindowProjection &projection,
+                 double map_scale) noexcept;
 
   void ScanBounds(GeoBounds &bounds) const noexcept {
     trace.ScanBounds(bounds);
@@ -91,6 +105,25 @@ public:
                     const ContestTraceVector &trace) noexcept;
 
 private:
+  void SelectTrailPen(Canvas &canvas, unsigned color_index,
+                      bool scaled_trail) const noexcept;
+
+  void PrepareCopy(const PixelPoint *src, unsigned n) noexcept;
+
+  void DrawColourPolyline(Canvas &canvas, unsigned color_index,
+                          bool scaled_trail,
+                          const std::vector<PixelPoint> &pts,
+                          size_t first, size_t last) noexcept;
+
+  void DrawSegmentWithVarioColour(Canvas &canvas,
+                                  const TrailPointData &prev_data,
+                                  const TrailPointData &curr_data,
+                                  const std::vector<PixelPoint> &segment_pts,
+                                  TrailSettings::Type type,
+                                  double value_min, double value_max,
+                                  bool scaled_trail,
+                                  bool use_merge_vario) noexcept;
+
   void DrawTraceVector(Canvas &canvas, const Projection &projection,
                        const TracePointVector &trace) noexcept;
 };

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -103,9 +103,10 @@ class TrailRenderer {
   Serial cache_modify_serial;
   TrailDrawFingerprint fingerprint{};
   TrailSettings::Type cached_settings_type{};
-  bool cached_scaled_trail{};
   size_t cached_trace_size{};
   size_t merge_sample_search_index{};
+  /** Keep completed-segment drift stable between GPS trace updates. */
+  TimeStamp stable_drift_time{TimeStamp::Undefined()};
 
 public:
   TrailRenderer(const TrailLook &_look) noexcept:look(_look) {}
@@ -169,12 +170,14 @@ private:
   void SelectTrailPen(Canvas &canvas, unsigned color_index,
                       bool scaled_trail) const noexcept;
 
-  void PrepareCopy(const PixelPoint *src, unsigned n) noexcept;
-
   void DrawColourPolyline(Canvas &canvas, unsigned color_index,
+                          TrailSettings::Type type,
                           bool scaled_trail,
                           const std::vector<PixelPoint> &pts,
                           size_t first, size_t last) noexcept;
+
+  void DrawRibbonPolyline(Canvas &canvas, unsigned color_index,
+                          const BulkPixelPoint *pts, unsigned n) noexcept;
 
   void DrawCachedSegments(Canvas &canvas,
                           const WindowProjection &projection,
@@ -182,7 +185,7 @@ private:
                           bool scaled_trail,
                           bool enable_traildrift,
                           const GeoPoint &traildrift,
-                          const NMEAInfo &basic,
+                          TimeStamp drift_now,
                           const std::vector<CachedTrailSegment> &segments) noexcept;
 
   void DrawVarioColouredPolyline(Canvas &canvas,

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -7,6 +7,8 @@
 #include "DemoReplayGlue.hpp"
 #include "io/FileLineReader.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
+#include "CalculationThread.hpp"
+#include "MergeThread.hpp"
 #include "Logger/Logger.hpp"
 #include "Interface.hpp"
 #include "Repository/FileType.hpp"
@@ -194,6 +196,45 @@ Replay::Update()
   }
 
   return true;
+}
+
+unsigned
+Replay::ProcessAllFixes(MergeThread &merge_thread,
+                        CalculationThread &calc_thread)
+{
+  if (replay == nullptr || path == nullptr || path.empty())
+    return 0;
+
+  timer.Cancel();
+  fast_forward = TimeStamp::Undefined();
+
+  NMEAInfo data;
+  data.Reset();
+  unsigned count = 0;
+
+  while (replay->Update(data)) {
+    assert(!data.gps.real);
+
+    if (data.time_available)
+      virtual_time = data.time;
+
+    {
+      const std::lock_guard lock{device_blackboard.mutex};
+      device_blackboard.SetReplayState() = data;
+    }
+
+    merge_thread.ProcessReplayFix();
+    calc_thread.ProcessReplayFix();
+    ++count;
+
+    if (data.time_available)
+      data.Expire();
+  }
+
+  if (count > 0)
+    next_data = data;
+
+  return count;
 }
 
 void

--- a/src/Replay/Replay.hpp
+++ b/src/Replay/Replay.hpp
@@ -14,6 +14,8 @@ class Logger;
 class ProtectedTaskManager;
 class AbstractReplay;
 class CatmullRomInterpolator;
+class MergeThread;
+class CalculationThread;
 class Error;
 
 class Replay final
@@ -117,6 +119,15 @@ public:
   TimeStamp GetVirtualTime() const noexcept {
     return virtual_time;
   }
+
+  /**
+   * Feed every fix from the current replay file through merge and
+   * calculation without virtual-time skipping.  For trail testing.
+   * Returns the number of fixes processed (0 if replay is inactive or
+   * demo mode).  \a merge_thread and \a calc_thread must be suspended.
+   */
+  unsigned ProcessAllFixes(MergeThread &merge_thread,
+                           CalculationThread &calc_thread);
 
 private:
   void OnTimer();

--- a/src/Widget/ProgressWidget.cpp
+++ b/src/Widget/ProgressWidget.cpp
@@ -7,10 +7,13 @@
 #include "ui/canvas/Canvas.hpp"
 #include "Renderer/ProgressBarRenderer.hpp"
 #include "Screen/Layout.hpp"
+#include "Look/Colors.hpp"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
 
 #include <string_view>
+
+static constexpr Color DARK_PROGRESS_GREEN = Color(0x00, 0x60, 0x00);
 
 class ProgressWidget::ProgressBar final : public PaintWindow {
   unsigned range = 0, position = 0;
@@ -42,7 +45,8 @@ protected:
   void OnPaint(Canvas &canvas) noexcept override {
     auto &look = UIGlobals::GetDialogLook();
     DrawSimpleProgressBar(canvas, canvas.GetRect(), position, 0, range,
-                          look.dark_mode ? &look.background_color : nullptr);
+                          look.dark_mode ? &look.background_color : nullptr,
+                          look.dark_mode ? &DARK_PROGRESS_GREEN : nullptr);
 
     if (!text.empty()) {
       auto &font = look.text_font;
@@ -53,9 +57,7 @@ protected:
 
       canvas.SetTextColor(look.text_color);
       canvas.SetBackgroundTransparent();
-
-      const std::string_view _text{text};
-      canvas.DrawText({padding, padding}, _text);
+      canvas.DrawText({padding, padding}, std::string_view{text});
     }
   }
 };

--- a/src/lua/Replay.cpp
+++ b/src/lua/Replay.cpp
@@ -9,6 +9,9 @@
 #include "Replay/Replay.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "CalculationThread.hpp"
+#include "MergeThread.hpp"
+#include "Protection.hpp"
 
 extern "C" {
 #include <lauxlib.h>
@@ -82,11 +85,48 @@ l_replay_stop([[maybe_unused]] lua_State *L)
   return 0;
 }
 
+static int
+l_replay_process_all([[maybe_unused]] lua_State *L)
+{
+  Replay *replay = backend_components->replay.get();
+  if (replay == nullptr || !replay->IsActive()) {
+    Lua::Push(L, lua_Integer{0});
+    return 1;
+  }
+
+  MergeThread *merge_thread = backend_components->merge_thread.get();
+  CalculationThread *calc_thread =
+    backend_components->calculation_thread.get();
+  if (merge_thread == nullptr || calc_thread == nullptr) {
+    Lua::Push(L, lua_Integer{0});
+    return 1;
+  }
+
+  merge_thread->Suspend();
+
+  unsigned count = 0;
+  {
+    const ScopeSuspendAllThreads suspend;
+    count = replay->ProcessAllFixes(*merge_thread, *calc_thread);
+  }
+
+  merge_thread->Resume();
+
+  if (count > 0) {
+    TriggerCalculatedUpdate();
+    TriggerMapUpdate();
+  }
+
+  Lua::Push(L, (lua_Integer)count);
+  return 1;
+}
+
 static constexpr struct luaL_Reg settings_funcs[] = {
   {"set_time_scale", l_replay_settimescale},
   {"fast_forward", l_replay_fastforward},
   {"start", l_replay_start},
   {"stop", l_replay_stop},
+  {"process_all", l_replay_process_all},
   {nullptr, nullptr}
 };
 


### PR DESCRIPTION
Fixes #2661

## Summary

- Reuse draw buffers each frame to avoid per-segment heap allocations during trail rendering
- Thin the GPS trace by map zoom (canvas pixels via `DistancePixelsToMeters`) and deduplicate vertices that map to the same screen pixel
- Disable Catmull-Rom splines above 6 km map scale; cap spline density from on-screen segment length (lower on embedded targets)
- Batch consecutive same-colour polyline pieces into single draw calls
- Replace per-segment binary search over merge-vario samples with a monotonic sliding window
- Fix merge sample collection to half-open `[t0, t1)` so high-rate vario ticks at the leg start GPS second are included
- Colour trail segments from merge-vario samples via segment parameter u (spreading equal timestamps), on both splined and direct paths

## Test plan

- [ ] Replay `short_2026-06-20_11-47.nmea` in simulator: circling at ~1.5 km zoom, trail ON — CPU stays reasonable vs OFF
- [ ] Replay `2026-06-20_11-47.nmea`: cruise at ~38 km zoom — coloured trail visible, no disappearance at wide zoom
- [ ] Verify vario trail shows colour changes within a single trace leg (merge-rate samples between GPS fixes)
- [ ] Confirm altitude trail and dots modes unchanged
- [ ] Build: `TARGET=UNIX WERROR=y`, `TARGET=WIN64 WERROR=y`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Lua API (`replay.process_all`) to process all pending replay fixes and refresh the map.
  * Added region-based trace point filtering to support rendering/thinning within selected geographic bounds.
* **Bug Fixes**
  * Improved trail coloring by interpolating vario/merged-vario using sampled breakpoints (including the open trail segment).
  * Updated trail thinning/smoothing to be map-scale aware and refined merged-vario handling with better deduplication and time-filtered loading.
* **Tests**
  * Added a callgrind datapath Lua driver to exercise rendering across multiple zoom scales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->