### PR TITLE
Fix simulator replay and FLARM traffic crashes

### DIFF
--- a/src/Computer/GlideComputer.cpp
+++ b/src/Computer/GlideComputer.cpp
@@ -362,11 +362,20 @@ void
 GlideComputer::CalculateVarioScale()
 {
   DerivedInfo &calculated = SetCalculated();
-  const GlidePolar &glide_polar = GetComputerSettings().polar.glide_polar_task;
+  const FlightStatistics &stats = stats_computer.GetFlightStats();
   calculated.common_stats.vario_scale_positive =
-      std::max(stats_computer.GetFlightStats().GetVarioScalePositive(),
+      stats.GetVarioScalePositive();
+  calculated.common_stats.vario_scale_negative =
+      stats.GetVarioScaleNegative();
+
+  const GlidePolar &glide_polar = GetComputerSettings().polar.glide_polar_task;
+  if (!glide_polar.IsValid())
+    return;
+
+  calculated.common_stats.vario_scale_positive =
+      std::max(calculated.common_stats.vario_scale_positive,
                glide_polar.GetMC());
   calculated.common_stats.vario_scale_negative =
-      std::min(stats_computer.GetFlightStats().GetVarioScaleNegative(),
+      std::min(calculated.common_stats.vario_scale_negative,
                -glide_polar.GetSBestLD());
 }

--- a/src/FLARM/Computer.cpp
+++ b/src/FLARM/Computer.cpp
@@ -48,6 +48,7 @@ FlarmComputer::Process(FlarmData &flarm, const FlarmData &last_flarm,
     // Skip for no_track targets and random IDs: they must not be resolved
     // against databases (FTD-012 NoTrack / random ID semantics).
     if (!traffic.no_track &&
+        traffic.id.IsDefined() &&
         traffic.id_type != FlarmTraffic::IdType::RANDOM) {
       const char *fname = FlarmDetails::LookupCallsign(traffic.id);
       if (fname != nullptr &&

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -29,6 +29,11 @@ struct TrafficList {
   /** Flarm traffic information */
   TrivialArray<FlarmTraffic, MAX_COUNT> list;
 
+  constexpr void ClampListSize() noexcept {
+    if (list.size() > MAX_COUNT)
+      list.resize(MAX_COUNT);
+  }
+
   constexpr void Clear() noexcept {
     modified.Clear();
     new_traffic.Clear();
@@ -54,11 +59,14 @@ struct TrafficList {
       /* don't bother merging the two lists, we can simply memcpy()
          it */
       list = add.list;
+      ClampListSize();
       return;
     }
 
-    // Add unique traffic from 'add' list
-    for (auto &traffic : add.list) {
+    const unsigned add_count =
+      add.list.size() > MAX_COUNT ? MAX_COUNT : add.list.size();
+    for (unsigned i = 0; i < add_count; ++i) {
+      const FlarmTraffic &traffic = add.list[i];
       if (FindTraffic(traffic.id) == nullptr) {
         FlarmTraffic * new_traffic = AllocateTraffic();
         if (new_traffic == nullptr)
@@ -72,8 +80,7 @@ struct TrafficList {
     modified.Expire(clock, std::chrono::minutes(5));
     new_traffic.Expire(clock, std::chrono::minutes(1));
 
-    if (list.size() > MAX_COUNT)
-      list.resize(MAX_COUNT);
+    ClampListSize();
 
     for (unsigned i = 0; i < list.size(); ) {
       if (!list[i].Refresh(clock))
@@ -94,9 +101,11 @@ struct TrafficList {
    * @return the FLARM_TRAFFIC pointer, NULL if not found
    */
   constexpr FlarmTraffic *FindTraffic(FlarmId id) noexcept {
-    for (auto &traffic : list)
-      if (traffic.id == id)
-        return &traffic;
+    ClampListSize();
+
+    for (unsigned i = 0; i < list.size(); ++i)
+      if (list[i].id == id)
+        return &list[i];
 
     return NULL;
   }
@@ -108,9 +117,11 @@ struct TrafficList {
    * @return the FLARM_TRAFFIC pointer, NULL if not found
    */
   constexpr const FlarmTraffic *FindTraffic(FlarmId id) const noexcept {
-    for (const auto &traffic : list)
-      if (traffic.id == id)
-        return &traffic;
+    const unsigned n = list.size() > MAX_COUNT ? MAX_COUNT : list.size();
+
+    for (unsigned i = 0; i < n; ++i)
+      if (list[i].id == id)
+        return &list[i];
 
     return NULL;
   }
@@ -151,6 +162,8 @@ struct TrafficList {
    * @return the FLARM_TRAFFIC pointer, NULL if the array is full
    */
   constexpr FlarmTraffic *AllocateTraffic() noexcept {
+    ClampListSize();
+
     return list.full()
       ? NULL
       : &list.append();

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -49,6 +49,8 @@ struct TrafficList {
    * this one.
    */
   constexpr void Complement(const TrafficList &add) noexcept {
+    ClampListSize();
+
     if (add.modified.Modified(modified))
       modified = add.modified;
 

--- a/src/FLARM/List.hpp
+++ b/src/FLARM/List.hpp
@@ -72,9 +72,15 @@ struct TrafficList {
     modified.Expire(clock, std::chrono::minutes(5));
     new_traffic.Expire(clock, std::chrono::minutes(1));
 
-    for (unsigned i = list.size(); i-- > 0;)
+    if (list.size() > MAX_COUNT)
+      list.resize(MAX_COUNT);
+
+    for (unsigned i = 0; i < list.size(); ) {
       if (!list[i].Refresh(clock))
         list.quick_remove(i);
+      else
+        ++i;
+    }
   }
 
   constexpr unsigned GetActiveTrafficCount() const noexcept {

--- a/src/FLARM/NameDatabase.cpp
+++ b/src/FLARM/NameDatabase.cpp
@@ -6,7 +6,8 @@
 int
 FlarmNameDatabase::Find(FlarmId id) const noexcept
 {
-  assert(id.IsDefined());
+  if (!id.IsDefined())
+    return -1;
 
   for (unsigned i = 0, size = data.size(); i != size; ++i)
     if (data[i].id == id)

--- a/src/FLARM/TrafficDatabases.cpp
+++ b/src/FLARM/TrafficDatabases.cpp
@@ -9,6 +9,9 @@
 const char *
 TrafficDatabases::FindNameById(FlarmId id) const noexcept
 {
+  if (!id.IsDefined())
+    return nullptr;
+
   // try to find flarm from userFile (secondary names)
   const char *name = flarm_names.Get(id);
   if (name != nullptr)

--- a/src/GliderLink/List.hpp
+++ b/src/GliderLink/List.hpp
@@ -52,9 +52,15 @@ struct GliderLinkTrafficList {
   void Expire(TimeStamp clock) noexcept {
     new_traffic.Expire(clock, std::chrono::minutes(5));
 
-    for (unsigned i = list.size(); i-- > 0;)
+    if (list.size() > MAX_COUNT)
+      list.resize(MAX_COUNT);
+
+    for (unsigned i = 0; i < list.size(); ) {
       if (!list[i].Refresh(clock))
         list.quick_remove(i);
+      else
+        ++i;
+    }
   }
 
   /**

--- a/src/NOTAM/Client.cpp
+++ b/src/NOTAM/Client.cpp
@@ -13,6 +13,7 @@
 #include "lib/curl/Slist.hxx"
 #include "lib/curl/Setup.hxx"
 #include "lib/fmt/ToBuffer.hxx"
+#include <fmt/format.h>
 #include "Operation/ProgressListener.hpp"
 #include "net/http/Progress.hpp"
 #include "Formatter/TimeFormatter.hpp"

--- a/src/Terrain/HeightMatrix.cpp
+++ b/src/Terrain/HeightMatrix.cpp
@@ -32,6 +32,9 @@ void
 HeightMatrix::SetSize(UnsignedPoint2D _size,
                       unsigned quantisation_pixels) noexcept
 {
+  if (quantisation_pixels < 1)
+    quantisation_pixels = 1;
+
   const UnsignedPoint2D round_up{
     quantisation_pixels - 1,
     quantisation_pixels - 1,
@@ -46,6 +49,9 @@ void
 HeightMatrix::Fill(const RasterMap &map, const GeoBounds &bounds,
                    const UnsignedPoint2D _size, bool interpolate) noexcept
 {
+  if (_size.x == 0 || _size.y == 0)
+    return;
+
   SetSize(_size);
 
   const Angle delta_y = bounds.GetHeight() / _size.y;
@@ -64,7 +70,12 @@ void
 HeightMatrix::Fill(const RasterMap &map, const WindowProjection &projection,
                    unsigned quantisation_pixels, bool interpolate) noexcept
 {
+  if (quantisation_pixels < 1)
+    quantisation_pixels = 1;
+
   const auto screen_size = projection.GetScreenSize();
+  if (screen_size.width == 0 || screen_size.height == 0)
+    return;
 
   SetSize((UnsignedPoint2D)screen_size, quantisation_pixels);
 

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -27,6 +27,42 @@ static constexpr unsigned MAX_QUANTISATION_NEAR = 25;
 static constexpr unsigned MAX_QUANTISATION_LOW_ZOOM = 40;
 static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
 
+/** Keep slope neighbour sampling inside the height matrix. */
+static void
+ClampQuantisationEffectiveToMatrix(unsigned &quantisation_effective,
+                                     UnsignedPoint2D matrix_size) noexcept
+{
+  if (quantisation_effective == 0)
+    return;
+
+  if (matrix_size.x <= 1 || matrix_size.y <= 1) {
+    quantisation_effective = 0;
+    return;
+  }
+
+  const unsigned max_step =
+    std::min(matrix_size.x - 1, matrix_size.y - 1);
+  if (quantisation_effective > max_step)
+    quantisation_effective = max_step;
+}
+
+[[gnu::const]]
+static unsigned
+SafeMinusStep(unsigned pos, unsigned step) noexcept
+{
+  return std::min(step, pos);
+}
+
+[[gnu::const]]
+static unsigned
+SafePlusStep(unsigned pos, unsigned size, unsigned step) noexcept
+{
+  if (size <= 1 || pos >= size - 1)
+    return 0;
+
+  return std::min(step, size - 1 - pos);
+}
+
 /**
  * Interpolate between x and y with i/128, i.e. i/(1 << 7).
  *
@@ -144,6 +180,9 @@ RasterRenderer::ScanMap(const RasterMap &map,
   GeoPoint center = projection.ScreenToGeo(projection.GetScreenCenter());
 
   // Geographical edge length of one height matrix cell in meters
+  if (quantisation_pixels < 1)
+    quantisation_pixels = 1;
+
   pixel_size = quantisation_pixels / projection.GetScale();
 
   // set resolution
@@ -194,13 +233,24 @@ RasterRenderer::ScanMap(const RasterMap &map,
   bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
   bounds.IntersectWith(map.GetBounds());
 
-  height_matrix.Fill(map, bounds,
-                     (UnsignedPoint2D)projection.GetScreenSize() / quantisation_pixels,
-                     true);
+  const UnsignedPoint2D matrix_size =
+    (UnsignedPoint2D)projection.GetScreenSize() / quantisation_pixels;
+  if (matrix_size.x == 0 || matrix_size.y == 0) {
+    quantisation_effective = 0;
+    return;
+  }
+
+  height_matrix.Fill(map, bounds, matrix_size, true);
+
+  ClampQuantisationEffectiveToMatrix(quantisation_effective,
+                                     height_matrix.GetSize());
 
   last_quantisation_pixels = quantisation_pixels;
 #else
   height_matrix.Fill(map, projection, quantisation_pixels, true);
+
+  ClampQuantisationEffectiveToMatrix(quantisation_effective,
+                                     height_matrix.GetSize());
 #endif
 }
 
@@ -221,6 +271,8 @@ RasterRenderer::GenerateImage(bool do_shading,
     contour_column_base = new unsigned char[height_matrix.GetSize().x];
   }
 
+  ClampQuantisationEffectiveToMatrix(quantisation_effective,
+                                     height_matrix.GetSize());
   if (quantisation_effective == 0) {
     do_shading = false;
     do_contour = false;
@@ -312,32 +364,34 @@ RasterRenderer::GenerateSlopeImage(unsigned height_scale,
                                    const int sx, const int sy, const int sz,
                                    const unsigned contour_height_scale) noexcept
 {
-  assert(quantisation_effective > 0);
+  const UnsignedPoint2D matrix_size = height_matrix.GetSize();
+  ClampQuantisationEffectiveToMatrix(quantisation_effective, matrix_size);
+  if (quantisation_effective == 0)
+    return;
 
-  const auto border = PixelRect{PixelSize{height_matrix.GetSize()}}
-    .WithPadding(quantisation_effective);
-
+  const unsigned q_sq = quantisation_effective * quantisation_effective;
+  const unsigned max_height_slope_factor =
+    std::max(1u, 8192u / q_sq);
   const unsigned height_slope_factor =
-    std::clamp((unsigned)pixel_size, 1u,
-               /* this upper limit avoids integer overflows in the
-                  "mag" formula; it effectively limits "dd2" so
-                  calculating its square will not overflow */
-               8192u / (quantisation_effective * quantisation_effective));
-  
+    std::clamp(static_cast<unsigned>(pixel_size), 1u,
+               /* upper limit avoids integer overflows in the "mag"
+                  formula; it effectively limits "dd2" so calculating
+                  its square will not overflow */
+               max_height_slope_factor);
+
   const auto *src = height_matrix.GetData();
   const RawColor *oColorBuf = color_table + 64 * 256;
 
   RawColor *dest = image->GetTopRow();
 
-  for (unsigned y = 0; y < height_matrix.GetSize().y; ++y) {
-    const unsigned row_plus_index = y < (unsigned)border.bottom
-      ? quantisation_effective
-      : height_matrix.GetSize().y - 1 - y;
-    const unsigned row_plus_offset = height_matrix.GetSize().x * row_plus_index;
+  for (unsigned y = 0; y < matrix_size.y; ++y) {
+    const unsigned row_plus_index =
+      SafePlusStep(y, matrix_size.y, quantisation_effective);
+    const unsigned row_plus_offset = matrix_size.x * row_plus_index;
 
-    const unsigned row_minus_index = y >= quantisation_effective
-      ? quantisation_effective : y;
-    const unsigned row_minus_offset = height_matrix.GetSize().x * row_minus_index;
+    const unsigned row_minus_index =
+      SafeMinusStep(y, quantisation_effective);
+    const unsigned row_minus_offset = matrix_size.x * row_minus_index;
 
     const unsigned p31 = row_plus_index + row_minus_index;
 
@@ -347,7 +401,7 @@ RasterRenderer::GenerateSlopeImage(unsigned height_scale,
     unsigned contour_row_base = ContourInterval(*src, contour_height_scale);
     unsigned char *contour_this_column_base = contour_column_base;
 
-    for (unsigned x = 0; x < height_matrix.GetSize().x; ++x, ++src) {
+    for (unsigned x = 0; x < matrix_size.x; ++x, ++src) {
       const auto e = *src;
       if (!e.IsSpecial()) [[likely]] {
         unsigned h = std::max(0, (int)e.GetValue());
@@ -357,26 +411,10 @@ RasterRenderer::GenerateSlopeImage(unsigned height_scale,
 
         h = std::min(254u, h >> height_scale);
 
-        // no need to calculate slope if undefined height or sea level
-
-        // Y direction
-        assert(src - row_minus_offset >= height_matrix.GetData());
-        assert(src + row_plus_offset >= height_matrix.GetData());
-        assert(src - row_minus_offset < height_matrix.GetDataEnd());
-        assert(src + row_plus_offset < height_matrix.GetDataEnd());
-
-        // X direction
-
-        const unsigned column_plus_index = x < (unsigned)border.right
-          ? quantisation_effective
-          : height_matrix.GetSize().x - 1 - x;
-        const unsigned column_minus_index = x >= (unsigned)border.left
-          ? quantisation_effective : x;
-
-        assert(src - column_minus_index >= height_matrix.GetData());
-        assert(src + column_plus_index >= height_matrix.GetData());
-        assert(src - column_minus_index < height_matrix.GetDataEnd());
-        assert(src + column_plus_index < height_matrix.GetDataEnd());
+        const unsigned column_plus_index =
+          SafePlusStep(x, matrix_size.x, quantisation_effective);
+        const unsigned column_minus_index =
+          SafeMinusStep(x, quantisation_effective);
 
         const auto h_above = src[-(int)row_minus_offset];
         const auto h_below = src[row_plus_offset];

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -89,7 +89,7 @@ public:
    * regardless of user idle state.
    */
   void SetQuantisationPixels(unsigned q) noexcept {
-    quantisation_pixels = q;
+    quantisation_pixels = q < 1 ? 1u : q;
 #ifdef ENABLE_OPENGL
     fixed_quantisation = true;
 #endif

--- a/src/net/ToString.cxx
+++ b/src/net/ToString.cxx
@@ -6,7 +6,7 @@
 #include "SocketAddress.hxx"
 #include "IPv4Address.hxx"
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <cassert>

--- a/src/net/client/WeGlide/UploadIGCFile.cpp
+++ b/src/net/client/WeGlide/UploadIGCFile.cpp
@@ -18,10 +18,11 @@
 #include "Formatter/TimeFormatter.hpp"
 #include "json/ParserOutputStream.hxx"
 #include "Language/Language.hpp"
-#include "lib/fmt/tchar.hxx"
 #include "net/http/Init.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
 #include "util/StaticString.hxx"
+
+#include <fmt/format.h>
 
 #include <cinttypes>
 


### PR DESCRIPTION
## Summary

Fixes crashes and aborts seen when bulk-loading NMEA replay in simulator mode (trail testing for #2661). These changes are isolated from the trail renderer refactor.

- **Terrain/RasterRenderer:** Clamp quantisation and slope sampling so HiDPI/low-zoom paths cannot read past the height buffer.
- **FLARM:** Fix `TrafficList::Expire()` off-by-one / stale iteration (GliderLink list too); skip name DB lookup for undefined `FlarmId`; clamp oversized traffic lists and use index-based lookup during replay on reused `NMEAInfo`.
- **GlideComputer:** Guard `CalculateVarioScale()` when the task polar is not yet valid (abort during early replay before profile polar is ready).

## Test plan

- [ ] `-simulator -replay=<short NMEA>` through full flight without abort
- [ ] FLARM traffic in replay (PFLAA) with undefined/random IDs
- [ ] Terrain visible at extreme zoom on HiDPI display
- [ ] Normal fly mode: vario scale still updates when polar becomes valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terrain/slope/contour rendering stability by guarding against zero-sized map areas and forcing minimum quantisation values.
  * Prevented out-of-bounds height-matrix sampling by clamping effective quantisation to the current matrix size and using safe index stepping.
  * Hardened traffic handling: undefined IDs no longer trigger callsign/name resolution, and name lookup returns early when IDs are missing.
  * Made FLARM and GliderLink traffic lists safer by clamping list sizes and improving in-place expiration/removal logic.
  * Refined vario scaling: glide-polar overrides now apply only when configured settings are valid, using separate positive/negative rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->