### PR TITLE
build: Add Raspberry Pi cross-compile sysroot and host provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 #   ENABLE_MESA_KMS If set to "y", the program uses KMS to switch to graphics mode.
 #               Use this option when the program runs on a text-mode system
 #               without graphics and window system like X11 or Wayland.
-#               Default for Rasperry PI 4, optional for Cubieboard.
+#               Default for Raspberry Pi 4, optional for Cubieboard.
 #
 #   OPENGL      "y" means render with OpenGL.
 #

--- a/build/pkgconfig.mk
+++ b/build/pkgconfig.mk
@@ -17,7 +17,8 @@ ifeq ($(HOST_IS_WIN32)$(HAVE_WIN32)$(HAVE_CE),nyn)
 endif
 
 ifeq ($(HOST_IS_PI)$(TARGET_IS_PI),ny)
-  PKG_CONFIG := PKG_CONFIG_LIBDIR=$(PI)/usr/lib/arm-linux-gnueabihf/pkgconfig $(PKG_CONFIG) --define-variable=prefix=$(PI)/usr
+  PI_PKG_CONFIG_LIBDIR := $(PI)/usr/lib/arm-linux-gnueabihf/pkgconfig:$(PI)/usr/share/pkgconfig
+  PKG_CONFIG := PKG_CONFIG_LIBDIR=$(PI_PKG_CONFIG_LIBDIR) $(PKG_CONFIG) --define-variable=prefix=$(PI)/usr
 endif
 
 ifeq ($(HOST_IS_ARM)$(TARGET_IS_CUBIE),ny)

--- a/build/setup-pi-sysroot.sh
+++ b/build/setup-pi-sysroot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright The XCSoar Project
+exec "$(dirname "$0")/../ide/provisioning/setup-pi-sysroot.sh" "$@"

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -393,6 +393,8 @@ Developing
 Debugging XCSoar
 ~~~~~~~~~~~~~~~~
 
+See also :doc:`debugging` for replay, simulator, and utility workflows.
+
 The XCSoar source repository contains a module for the GNU debugger
 (``gdb``). It contains pretty-printers for various XCSoar types,
 including ``Angle``, ``GeoPoint`` and others. These are helpful when you

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -55,7 +55,7 @@ To update third-party libraries used by XCSoar (such as `Boost
 
   git submodule update --init --recursive
 
-For more information, please read to the :program:`git` documentation.
+For more information, please read the :program:`git` documentation.
 
 Requirements
 ------------
@@ -81,13 +81,38 @@ The following is needed for all targets:
 
 -  `SoX <http://sox.sourceforge.net/>`__
 
-The following command installs these on Debian::
+On Debian and Ubuntu, install these with the ``BASE`` section of
+:file:`ide/provisioning/install-debian-packages.sh` (GCC/g++ is installed
+with ``LINUX``)::
 
-  sudo apt-get install make \
-      librsvg2-bin xsltproc \
-      imagemagick gettext sox \
-      git quilt zip \
-      m4 automake
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE
+
+Package lists for all targets live in that script; pass one or more
+section names instead of running it with no arguments. Available
+sections:
+
+=========== ===========================================================
+``BASE``    tools common to all targets (make, gettext, git, ccache, …)
+``LINUX``   native Linux/UNIX build libraries and compiler
+``LIBINPUT_GBM`` libinput, GBM, DRM, GLES (Pi and similar embedded Linux)
+``WAYLAND`` Wayland protocols
+``DEBIAN``  building ``.deb`` packages
+``LLVM``    compiling with Clang
+``ARM``     ARM cross toolchain (Kobo bootstrap, generic ARM)
+``PI_HOST`` Pi cross-compile host tools (debootstrap, qemu, …)
+``WIN``     MinGW Windows cross compiler and NSIS
+``KOBO``    Kobo image packaging tools
+``ANDROID`` JDK and Android host tools (not SDK/NDK)
+``MANUAL``  TeXLive for ``make manual``
+=========== ===========================================================
+
+See also :doc:`devsetup` for a Linux development environment overview.
+
+On Debian and Ubuntu, the usual order is: **native build** on the host
+(recommended), then **Docker** if you avoid installing dependencies
+locally, then **Vagrant** for an optional preconfigured VM. See
+:ref:`docker-build` and “Using a build VM with Vagrant” below.
 
 Target-specific Build Instructions
 ----------------------------------
@@ -123,27 +148,10 @@ similar operating systems:
    DejaVu (``fonts-dejavu``), Roboto (``fonts-roboto``), Droid
    (``fonts-droid``), Freefont (``fonts-freefont-ttf``)
 
-The following command installs these on Debian::
+Install host packages on Debian/Ubuntu::
 
-  sudo apt-get install make g++  zlib1g-dev \
-      libfmt-dev \
-      libdbus-1-dev \
-      libsodium-dev \
-      libfreetype-dev \
-      libpng-dev libjpeg-dev \
-      libtiff5-dev libgeotiff-dev \
-      libc-ares-dev \
-      libcurl4-openssl-dev \
-      libssl-dev \
-      libc-ares-dev \
-      liblua5.4-dev \
-      libxml-parser-perl \
-      libasound2-dev \
-      librsvg2-bin xsltproc \
-      imagemagick gettext \
-      mesa-common-dev libgl1-mesa-dev libegl1-mesa-dev \
-      libinput-dev \
-      fonts-dejavu
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX LIBINPUT_GBM
 
 To compile, run::
 
@@ -158,6 +166,32 @@ You may specify one of the following targets with ``TARGET=x``:
 ``OPT``    alias for UNIX with optimisation and no debugging
 ========== =================================================
 
+Experimental Wayland build
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Install the ``WAYLAND`` provisioning section in addition to ``LINUX``::
+
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX WAYLAND
+
+Compile::
+
+  make TARGET=WAYLAND
+
+Software rendering without OpenGL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For headless builds (CI, no GPU), use the virtual framebuffer::
+
+  make TARGET=UNIX VFB=y
+
+For software rendering with SDL (same as Docker ``UNIX-SDL``), disable
+OpenGL and enable SDL2::
+
+  make TARGET=UNIX OPENGL=n ENABLE_SDL=y USE_SDL2=y
+
+``VFB`` and SDL are mutually exclusive with the default OpenGL/EGL path.
+
 Compiling for Android
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -171,12 +205,12 @@ For Android, you need:
 
 - Java JDK
 
-On Debian::
+On Debian, install host packages and the SDK/NDK via the provisioning
+scripts::
 
-  sudo apt-get install
-      default-jdk-headless \
-      vorbis-tools \
-      adb
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX ANDROID
+  ./install-android-tools.sh
 
 The required Android SDK components are:
 
@@ -184,10 +218,16 @@ The required Android SDK components are:
 
 - SDK Platform 35
 
-These can be installed from the Android Studio SDK Manager, or using the
-SDK command line tools:
+These can be installed from the Android Studio SDK Manager. On Debian/Ubuntu,
+:file:`ide/provisioning/install-android-tools.sh` (run after the ``ANDROID``
+provisioning section) downloads the command-line tools and installs the
+required packages automatically.
 
-tools/bin/sdkmanager  "build-tools;35.0.0"  "platforms;android-35"
+To install the same components manually::
+
+  ~/opt/android-sdk-linux/cmdline-tools/bin/sdkmanager \
+      --sdk_root=~/opt/android-sdk-linux \
+      "build-tools;35.0.0" "platforms;android-35"
 
 The ``Makefile`` assumes that the Android SDK is installed in
 ``~/opt/android-sdk-linux`` and the NDK is installed in
@@ -229,9 +269,10 @@ Compiling for Windows
 To cross-compile to (desktop) Windows, you need
 `Mingw-w64 <http://mingw-w64.org>`__.
 
-On Debian, install the cross compiler (and NSIS if you need the installer)::
+On Debian, install the cross compiler and NSIS (for the installer)::
 
-  sudo apt-get install g++-mingw-w64 nsis
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX WIN
 
 A minimal 64-bit OpenGL build::
 
@@ -346,6 +387,7 @@ To compile for macOS / x86_64, run::
   make TARGET=OSX64 dmg
 
 Debugging for iOS and macOS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Debugging under iOS and macOS is possible using the LLDB debugger.
 To make this convenient, Xcode or Visual Studio can be used.
@@ -357,46 +399,78 @@ For iOS debugging with Visual Studio Code, the `iOS Debug`
 extension (https://github.com/nisargjhaveri/vscode-ios-debug) can be used.
 Note that this also requires an Xcode installation.
 
-Compiling on the Raspberry Pi 4
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Compiling on the Raspberry Pi (4 / 5)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Install additional dependencies::
+On current Raspberry Pi boards, compile **natively on the device**. Pi 4 and
+Pi 5 are fast enough for practical development builds; cross-compiling from a
+desktop host is no longer the usual workflow.
 
-  sudo apt-get install libdrm-dev libgbm-dev \
-      libgles2-mesa-dev \
-      libinput-dev
+On the Pi, install the same embedded-Linux graphics packages as a desktop
+``UNIX`` build, plus ``LIBINPUT_GBM`` (DRM/GBM/GLES)::
 
-Compile::
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX LIBINPUT_GBM
 
-  make
+Compile (``TARGET=UNIX`` is selected automatically on Raspberry Pi)::
 
-Compiling for the Raspberry Pi 1-3
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  make -j$(nproc) USE_CCACHE=y
 
-You need an ARM toolchain. For example, you can use the Debian package
-``g++-arm-linux-gnueabihf``::
+Cross-compiling for legacy Raspberry Pi 1–3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  make TARGET=PI
+``TARGET=PI`` and ``TARGET=PI2`` remain for cross-compiling **on a desktop
+host** for old ARMv6/ARMv7 boards (Pi 1–3). This path needs an armhf sysroot.
+The same steps work on a native Debian/Ubuntu host or inside the
+:ref:`docker-build` container (privileged, for ``setup-pi-sysroot.sh``).
+``setup-pi-sysroot.sh`` installs ``PI_HOST`` tools on the host by default::
 
-To optimize for the Raspberry Pi 2 (which has an ARMv7 with NEON instead
-of an ARMv6)::
+  cd ide/provisioning
+  sudo ./setup-pi-sysroot.sh
 
-  make TARGET=PI2
+Cross-compile (Pi 1 / ARMv6; binaries in ``output/PI/bin/``)::
 
-These targets are only used for cross-compiling on a (desktop) computer.
-If you compile on the Raspberry Pi, the default target will auto-detect
-the Pi.
+  make TARGET=PI PI=/opt/pi/root
+
+For Raspberry Pi 2/3 (ARMv7 with NEON; ``output/PI2/bin/``)::
+
+  make TARGET=PI2 PI=/opt/pi/root
+
+Although ``TARGET=PI`` and ``TARGET=PI2`` compile as ``UNIX`` internally,
+binaries are written to ``output/PI/`` and ``output/PI2/`` respectively
+(the flavour name is preserved for the output directory).
 
 Compiling for the Cubieboard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To compile, run::
+``TARGET=CUBIE`` cross-compiles XCSoar for ARMv7 + NEON (Cubieboard-class
+boards) on a desktop host. You need an armhf sysroot and the cross
+toolchain; install the ``ARM`` provisioning section::
 
-  make TARGET=CUBIE
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE ARM
 
-This target is only used for cross-compiling on a (desktop) computer. If
-you compile on the Cubieboard, the default target will auto-detect the
-Cubieboard.
+Cross-compile (binaries in ``output/CUBIE/bin/``)::
+
+  make TARGET=CUBIE CUBIE=/opt/cubie/root
+
+The default sysroot path is ``/opt/cubie/root``. Unlike the Raspberry Pi
+path, XCSoar does not ship an automated sysroot script for Cubie; the
+sysroot must provide ARMhf development libraries and the Mali/EGL headers
+under ``usr/local/stow/sunxi-mali/`` (see ``build/targets.mk``).
+
+If you compile on the Cubieboard itself, the default ``UNIX`` target
+auto-detects the board.
+
+OpenVario flight computer images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For **OpenVario** hardware (Cubieboard-based flight computers, CH-070
+and other displays), building the full OS image is handled outside this
+tree. Follow the current instructions in the
+`meta-openvario <https://github.com/Openvario/meta-openvario>`__
+repository (``MACHINE`` selection, Docker build container, ``bitbake``,
+and so on). See also `OpenVario <https://openvario.org>`__.
 
 Compiling for Kobo E-book Readers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -407,14 +481,12 @@ To compile XCSoar, run::
 
   make TARGET=KOBO
 
-To build the kobo install file ``KoboRoot.tgz``, you need the following
-Debian packages::
+To build the kobo install file ``KoboRoot.tgz``, install the Kobo
+packaging section in addition to the Kobo build dependencies (the
+``KOBO`` target bootstraps its own ARM toolchain during the build)::
 
-  sudo apt-get install \
-      fakeroot \
-      python3-setuptools \
-      ttf-bitstream-vera \
-      fonts-roboto-unhinted
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE BASE LINUX ARM KOBO
 
 Then compile using this command::
 
@@ -594,20 +666,21 @@ Defaults shown are from the build system (they can be overridden with
    - OpenGL ES
    - Simulator SDK (min iOS 11.0).
  * - ``PI``
-   - Raspberry Pi 1-3
+   - Raspberry Pi 1
    - no
    - OpenGL (EGL/KMS)
-   - ARMv6 cross-compile target.
+   - ARMv6 cross-compile target (Pi 1).
  * - ``PI2``
-   - Raspberry Pi 2
+   - Raspberry Pi 2/3
    - no
    - OpenGL (EGL/KMS)
-   - ARMv7 + NEON cross-compile target.
+   - ARMv7 + NEON cross-compile target (Pi 2 and 3).
  * - ``CUBIE``
    - Cubieboard
    - no
    - OpenGL (EGL/KMS)
-   - Cross-compile target (ARMv7 + NEON).
+   - Cross-compile target (ARMv7 + NEON); OpenVario images: `meta-openvario
+     <https://github.com/Openvario/meta-openvario>`__.
  * - ``KOBO``
    - Kobo e-readers
    - no
@@ -621,12 +694,13 @@ Defaults shown are from the build system (they can be overridden with
 
 For a full list of build variables and their defaults, see the
 parameter list at the top of ``Makefile`` and the files in
-``build/*.mk``.
+``build/*.mk``. For ``Run*`` test/debug programs, see
+:doc:`test_debug_utilities`.
 
 Editing the Manuals
 ~~~~~~~~~~~~~~~~~~~
 
-The XCSoar documententation (except for the developer manual) is
+The XCSoar documentation (except for the developer manual) is
 written using the TeX markup language. You can edit the source files
 with any text editor, although a specific TeX editor (e.g. LateXila)
 makes it easier.
@@ -639,16 +713,10 @@ output/manual directory.
 To generate the PDF manuals, you need the TexLive package, plus some
 European languages.
 
-The following command installs these on Debian::
+Install the ``MANUAL`` section on Debian/Ubuntu::
 
-  sudo apt-get install texlive \
-      texlive-latex-extra \
-      texlive-luatex \
-      texlive-lang-french \
-      texlive-lang-polish \
-      texlive-lang-german \
-      texlive-lang-portuguese \
-      liblocale-po-perl
+  cd ide/provisioning
+  sudo ./install-debian-packages.sh UPDATE MANUAL
 
 The documentation is distributed as PDF files. Generating the PDFs from
 the TeX files is done by typing::
@@ -662,11 +730,19 @@ successful.
 Options
 -------
 
+.. _parallel-build:
+
 Parallel Build
 ~~~~~~~~~~~~~~
 
 Most contemporary computers have multiple CPU cores. To take advantage
-of these, use the ``make -j`` option::
+of these, use the ``make -j`` option. On Linux, ``-j$(nproc)`` matches
+the number of available CPU cores::
+
+  make -j$(nproc)
+
+A fixed job count works too (slightly above core count is a common rule
+of thumb)::
 
   make -j12
 
@@ -701,14 +777,144 @@ Compiling with ccache
 ~~~~~~~~~~~~~~~~~~~~~
 
 To speed up the compilation of XCSoar we can use ``ccache`` to cache the
-object files for us. All we have to do is install ccache and add
-``USE_CCACHE=y`` to the make command line::
+object files for us. ``ccache`` is installed by the ``BASE`` provisioning
+section; add ``USE_CCACHE=y`` to the make command line::
 
-  sudo apt-get install ccache
   make TARGET=UNIX USE_CCACHE=y
+
+.. _development-workflow:
+
+Development workflow
+~~~~~~~~~~~~~~~~~~~~
+
+Day-to-day development on ``UNIX`` typically uses debug builds
+(``DEBUG=y``, the default) with warnings as errors: ``WERROR`` defaults
+to ``DEBUG``, so a normal ``make`` already fails on compiler warnings.
+Use parallel builds (``-j$(nproc)``) and ``USE_CCACHE=y`` for faster
+turnaround; see :ref:`parallel-build` below for details.
+
+Incremental build::
+
+  make -j$(nproc) USE_CCACHE=y
+
+Full build with unit tests (matches what many contributors run locally
+before submitting changes)::
+
+  make -j$(nproc) USE_CCACHE=y everything check
+
+Test and debug utilities
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Standalone tools (``RunTask``, ``RunAnalysis``, ``FeedNMEA``, …) for
+component testing without the full app are described in
+:doc:`test_debug_utilities`. Build them with::
+
+  make -j$(nproc) debug
+
+or as part of ``everything`` (below). To build one program::
+
+  make -j$(nproc) output/UNIX/bin/RunTask
+
+The ``everything`` target adds optional outputs, those ``debug`` utilities,
+unit-test binaries, and test harness programs; ``check`` runs the tests (build
+them first with ``everything`` or ``build-check``).
+
+``debug`` lists all ``Run*`` tools in :file:`build/test.mk`; ``build-harness``
+builds the ``test_*`` harness programs (also included in ``everything``).
+Utilities are built for the host platform (``UNIX``, Windows OpenGL, macOS),
+not for embedded targets such as Android or Kobo.
+
+CI uses a headless software renderer and optional sanitizers (clean the
+output tree when switching ``SANITIZE=``)::
+
+  make -j$(nproc) TARGET=UNIX VFB=y USE_CCACHE=y everything check
+  make -j$(nproc) TARGET=UNIX VFB=y SANITIZE=y DEBUG_GLIBCXX=y everything check
+
+To force warnings-as-errors on an optimised build (``DEBUG=n`` disables
+``WERROR`` by default), pass ``WERROR=y`` explicitly.
+
+.. _docker-build:
+
+Using Docker
+------------
+
+Use Docker when you prefer not to install XCSoar build dependencies on
+the host. Native builds (provisioning scripts + ``make`` on Debian/Ubuntu)
+are simpler and recommended when that is acceptable.
+
+The Docker image in :file:`ide/docker/` provides a Debian-based build
+environment with the same provisioning scripts as a native host. Bind-mount
+the XCSoar source tree; build products appear in ``output/`` on the host.
+
+Pull the published image (or build locally — see :file:`ide/docker/README.md`)::
+
+  docker pull ghcr.io/xcsoar/xcsoar/xcsoar-build:latest
+
+Interactive shell (compile with ``make`` or ``xcsoar-compile``)::
+
+  docker run \
+      --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+      -it ghcr.io/xcsoar/xcsoar/xcsoar-build:latest /bin/bash
+
+One-shot build via the wrapper script (``ANDROID``, ``DOCS``, ``KOBO``,
+``UNIX``, ``UNIX-SDL``, ``WAYLAND``, ``WIN64OPENGL``, ``WIN32OPENGL``;
+legacy GDI: ``PC``, ``WIN64``)::
+
+  docker run \
+      --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+      ghcr.io/xcsoar/xcsoar/xcsoar-build:latest \
+      xcsoar-compile UNIX USE_CCACHE=y
+
+Windows OpenGL cross-compile example::
+
+  docker run \
+      --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+      ghcr.io/xcsoar/xcsoar/xcsoar-build:latest \
+      xcsoar-compile WIN64OPENGL USE_CCACHE=y everything
+
+Add ``USE_CCACHE=y`` as needed; ccache data is stored in ``./.ccache/`` on
+the host. For GUI testing with software rendering and X11 forwarding, see
+:file:`ide/docker/README.md`.
+
+**Raspberry Pi:** Pi 4 and 5 should be built **natively on the device**
+(see above). The container runs on x86_64 and does not replace that
+workflow.
+
+For **legacy Pi 1–3 cross-compiles**, start a **privileged** container
+(debootstrap and ``qemu-user-static`` need it), create the sysroot, then
+build::
+
+  docker run --privileged \
+      --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+      -it ghcr.io/xcsoar/xcsoar/xcsoar-build:latest /bin/bash
+
+  sudo ./ide/provisioning/setup-pi-sysroot.sh
+  make -j$(nproc) TARGET=PI2 PI=/opt/pi/root USE_CCACHE=y
+
+**Android and iOS:** The image ships with the Android SDK and NDK. On
+**Linux x86_64**, ``xcsoar-compile ANDROID`` is the usual Docker workflow
+(see :file:`ide/docker/README.md`). Clone with ``--recurse-submodules``
+(see *Getting the source* above) before mounting the tree into the
+container.
+
+**iOS** is not built inside Docker. Use a **Mac** with Xcode and the
+native steps in *Compiling for iOS* above
+(``ide/provisioning/install-darwin-packages.sh BASE IOS``, then
+``make TARGET=IOS64 ipa``).
+
+On **macOS** hosts, Docker-based Android builds have been reported to
+hang during third-party downloads or fail under ``linux/amd64`` emulation
+on Apple Silicon (`#892 <https://github.com/XCSoar/XCSoar/issues/892>`__).
+Prefer a **native** Android build on the Mac (Android Studio SDK/NDK,
+``make TARGET=ANDROID`` — see *Compiling for Android* above) or run the
+Docker image on a Linux x86_64 machine.
 
 Using a build VM with Vagrant
 -----------------------------
+
+Vagrant is an optional third choice: a VirtualBox VM with dependencies
+for several targets. Prefer a native host install or Docker unless you
+specifically want this workflow.
 
 An easy way to install a virtual machine with all build dependencies
 required for various targets (e.g. Linux, Windows, Android and Kobo), is
@@ -731,8 +937,8 @@ The XCSoar source directory on the host is automatically mounted as a
 shared folder at ``/xcsoar-host-src`` in the VM. For performance
 reasons, it is not recommended to compile directly in this folder. A git
 clone of this directory is automatically created in the home directory
-(`` /xcsoar-src``), which should be used instead. In this git clone, the
-XSoar source directory on the host is preconfigured as a git remote
+(``~/xcsoar-src``), which should be used instead. In this git clone, the
+XCSoar source directory on the host is preconfigured as a git remote
 named “host”, and the XCSoar master directory is preconfigured as a
 remote named “master”.
 

--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -1,27 +1,108 @@
 ===============
-Debugging Tipps
+Debugging Tips
 ===============
 
-Replaying NMEA Logs
--------------------
+Overview
+--------
 
-To replay NMEA logs in XCSoar, follow these steps:
+XCSoar offers several ways to debug and explore behaviour without flying:
 
-1. **Configure the Device Driver in XCSoar**:
-   - Open XCSoar in the device configuration add a new device.
-   - Set the device to a TCP client with IP `127.0.0.1` and port `4353`.
+- **In-app replay and simulator** — built into the main binary (desktop)
+- **NMEA/IGC utilities** — ``FeedNMEA``, ``EmulateDevice``, ``Run*`` tools
+- **Scripting** — Lua ``init.lua`` and :doc:`lua` replay bindings
+- **Native debugger** — :program:`gdb` with XCSoar pretty-printers
 
-2. **Replaying NMEA Logs**:
-   - Build the FeenNMEA program by running:
+Build utilities with ``make debug`` or ``make everything``; see
+:ref:`development-workflow` in :doc:`build`. Full utility reference:
+:doc:`test_debug_utilities`.
 
-.. code-block:: bash
+Built-in replay and simulator
+-----------------------------
 
-    make ./output/UNIX/bin/FeedNMEA
+On **Linux and macOS desktop** builds, start XCSoar directly in replay or
+simulator mode from the command line::
 
+  ./output/UNIX/bin/xcsoar -replay=flight.igc
+  ./output/UNIX/bin/xcsoar -simulator
+  ./output/UNIX/bin/xcsoar -fly -profile=test/data/issue-2661/trail-on.prf
 
-     This will compile the `FeedNMEA` program that you will use to send NMEA data.
+``-replay=PATH`` loads an IGC (or other supported log) at startup.
+``-simulator`` skips the fly/sim prompt and opens simulator mode (manual
+position/speed control — useful for UI testing). ``-profile=FNAME`` loads
+a settings profile; ``-datapath=PATH`` selects an alternate data directory
+(for example a minimal tree under :file:`test/data/`).
 
-   - Replay the NMEA log using the following command:
-.. code-block:: bash
+See ``./output/UNIX/bin/xcsoar --help`` for all desktop options.
 
-        cat ./test/data/driver/FLARM/pflaf01.nmea | ./output/UNIX/bin/FeedNMEA tcp 4353
+Replaying NMEA into a running XCSoar
+------------------------------------
+
+To feed recorded NMEA into XCSoar over the network (e.g. with Condor or
+another simulator sending to a TCP client):
+
+1. In XCSoar device configuration, add a **TCP client** device with IP
+   ``127.0.0.1`` and port ``4353``.
+
+2. Build and run ``FeedNMEA`` (see :doc:`test_debug_utilities`)::
+
+     make -j$(nproc) output/UNIX/bin/FeedNMEA
+     cat test/data/driver/FLARM/pflaf01.nmea | ./output/UNIX/bin/FeedNMEA tcp 4353
+
+``FeedNMEA`` can also write to a serial port or act as a TCP/UDP server;
+see :doc:`test_debug_utilities` for other port modes.
+
+Device and port debugging
+-------------------------
+
+- ``EnumeratePorts`` — list serial/TTY devices on the host
+- ``EmulateDevice`` — respond to XCSoar as a FLARM, Vega, or ATR833 device
+- ``RunDeviceDriver`` — pipe NMEA through a driver parser on stdin
+- **socat** — monitor bidirectional serial traffic (Debian package ``socat``)
+
+Details and examples: :doc:`test_debug_utilities` (device utilities and
+socat section).
+
+Component testing with Run* utilities
+-------------------------------------
+
+Standalone programs exercise one subsystem at a time (task engine, wind
+computer, analysis dialog, renderers, …) using ``DebugReplay`` on IGC/NMEA
+files. Examples::
+
+  ./output/UNIX/bin/RunTask task.xct test/data/01lz1hq1.igc
+  ./output/UNIX/bin/RunAnalysis FLARM test/data/01lz1hq1.igc
+  ./output/UNIX/bin/RunDeviceDriver FLARM < test/data/driver/FLARM/pflaf01.nmea
+
+See :doc:`test_debug_utilities` for the full list and patterns.
+
+Lua scripting and automated replay
+----------------------------------
+
+Place ``init.lua`` in the XCSoar data directory (``lua/init.lua`` under
+``-datapath``) to run scripts at startup. The replay API can bulk-process a
+log without stepping through the UI manually — useful for profiling map
+draw or backend paths::
+
+  xcsoar.replay.start("test/data/issue-2661/short_2026-06-20_11-47.nmea")
+  xcsoar.replay.process_all()
+
+Experiment with scripts using ``RunLua`` (see :doc:`lua`). Replay
+bindings: :ref:`lua.replay`.
+
+GNU debugger (gdb)
+------------------
+
+XCSoar ships gdb pretty-printers for common types (``GeoPoint``, angles,
+etc.). Usage and examples: **Debugging XCSoar** in :doc:`architecture`::
+
+  gdb -ex "source tools/gdb.py" output/UNIX/bin/xcsoar
+
+``Run*`` utilities are small standalone binaries and are often easier to
+debug under :program:`gdb` or :program:`valgrind` than the full application.
+
+iOS and macOS
+-------------
+
+Use LLDB via Xcode or the VS Code iOS Debug extension; see **Debugging for
+iOS and macOS** in :doc:`build`. Run ``make check-ios-sim`` for automated
+simulator tests.

--- a/doc/devsetup.rst
+++ b/doc/devsetup.rst
@@ -10,8 +10,6 @@ In the following instructions, ``sudo`` is used to execute commands with
 root privileges. This is not enabled by default in Debian (but on some
 Debian based distributions, like Ubuntu).
 
-To install a virtual machine with the required, you can use ``Vagrant``.
-
 Download source code
 ====================
 
@@ -25,63 +23,83 @@ following way in your project directory::
 
  git clone --recurse-submodules https://github.com/XCSoar/XCSoar
 
-Use provisioning scripts
-========================
+Setting up the build environment
+================================
 
-If you are not using Vagrant, but an existing standard installation of a
-Debian-based Linux distribution, you can run the scripts from
-``ide/provisioning`` subfolder of the XCSoar source to install the build
-dependencies for various XCSoar target platforms.
+On Debian or Ubuntu, use one of the following — in order of preference:
 
-::
+1. **Native build** on the host (recommended): install dependencies with
+   the provisioning scripts, then run ``make``.
+2. **Docker** on x86_64: use the pre-built image when you prefer not to
+   install libraries on the host (see :ref:`docker-build` in :doc:`build`).
+3. **Vagrant** VM: optional legacy path if you want an isolated VM with
+   many targets preconfigured (see “Using a build VM with Vagrant” in
+   :doc:`build`).
+
+Native build
+------------
+
+Run the scripts from ``ide/provisioning`` to install build dependencies.
+See :doc:`build` for per-target section names and compile commands.
+For ``Run*`` test and debug utilities after building, see
+:doc:`test_debug_utilities`::
 
    cd ide/provisioning
    sudo ./install-debian-packages.sh
    ./install-android-tools.sh
 
-Optional: Eclipse IDE
-=====================
+Docker
+------
 
-One of the most widespread IDEs is eclipse. It is not limited to
-Android, and can be used for all targets. It is not required for XCSoar, but
-its installation is described here as an example. Eclipse is quite
-heavyweight, and many developers prefer other IDEs for XCSoar development.
+On an x86_64 Linux host, bind-mount the source tree and compile inside
+the container (details in :doc:`build`)::
 
-To install, download the eclipse installer (Sometimes called
-“*Ooomph!*” for some reason) from here:
-``https://www.eclipse.org/downloads/``
+   docker run \
+       --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+       -it ghcr.io/xcsoar/xcsoar/xcsoar-build:latest /bin/bash
 
-Important: Install the CDT version of eclipse for C development, not the
-Android/Java package, even if you plan developing for Android. In
-addition, it is very convenient to install the git support (egit).
+   xcsoar-compile UNIX USE_CCACHE=y
 
-The current stable version is *eclipse mars* (4.5) and works with
-OpenJDK 7 or 8, the new *eclipse neon* 4.6, currently RC2, is also quite
-stable, and requires OpenJDK 8. Both can be installed with the
-installer.
+Vagrant
+-------
 
-You can also install the ADT (Android development tools) package for
-better integration with Android.
+See :doc:`build` for VM setup with VirtualBox and the Vagrantfile in
+``ide/vagrant``.
 
-Next, create a new project, by generating a make project from existing
-sources files. Choose your xcsoar source directory which contains the
-makefile.
+Raspberry Pi
+============
 
-Important: After you have added the sources, eclipse will start
-indexing all files. If you have already started ``make`` before this
-time, then a lot of files have been downloaded for the various
-libraries which are exctracted/built within the XCSoar directory (most
-notably the boost libraries). Indexing all these takes a very long
-time, and a lot of heap space, so you should probably stop the indexer
-right away. In addition you should probably exclude these directories
-from the indexer for the future.
+On a **Raspberry Pi 4 or 5**, install dependencies and build **natively on
+the device** (``TARGET=UNIX`` is auto-detected)::
 
-For this, in the C/C++ scope, right-click on the “output” directory in
-the file tree on the left side, select “Properties”, then
-“Resource/Resource Filters” and add a filter. In the “add filter”
-dialog, choose “exclude all”, “files and folders”, “all children
-(recursive)” and set the Filter details to “Name matches \*”. This will
-exclude the output tree from the indexer, leading to a minimal index.
+   cd ide/provisioning
+   sudo ./install-debian-packages.sh UPDATE BASE LINUX LIBINPUT_GBM
+   make -j$(nproc) USE_CCACHE=y
+
+Cross-compiling for legacy Raspberry Pi 1–3
+------------------------------------------
+
+``TARGET=PI`` and ``TARGET=PI2`` are for cross-compiling on a desktop host
+for old ARMv6/ARMv7 boards. Create an armhf sysroot (``setup-pi-sysroot.sh``
+installs ``PI_HOST`` host tools by default)::
+
+   cd ide/provisioning
+   sudo ./setup-pi-sysroot.sh
+
+Cross-compile (Pi 1 / ARMv6)::
+
+   make TARGET=PI PI=/opt/pi/root
+
+For Raspberry Pi 2/3 (ARMv7 with NEON)::
+
+   make TARGET=PI2 PI=/opt/pi/root
+
+Binaries are written to ``output/PI/`` and ``output/PI2/`` (not
+``output/UNIX/``). See :doc:`build` for details.
+
+The same sysroot steps work inside a privileged Docker container; see
+:doc:`build` (“Using Docker” and “Cross-compiling for legacy Raspberry Pi
+1–3”).
 
 Optional: modern LaTeX editor for editing the Manual
 ====================================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -21,6 +21,8 @@ XCSoar
 
 Build system reference: :ref:`build-system-reference`
 
+Developer docs: :doc:`build` (:ref:`development-workflow`), :doc:`test_debug_utilities`
+
 
 Indices and tables
 ==================

--- a/doc/test_debug_utilities.rst
+++ b/doc/test_debug_utilities.rst
@@ -1,6 +1,11 @@
 Test and Debug Utilities
 =========================
 
+.. _test-debug-utilities:
+
+For a shorter overview of debugging workflows (replay, simulator, gdb,
+device tools), see :doc:`debugging`.
+
 The XCSoar test suite includes a collection of standalone utility programs
 for debugging, testing, and interactive exploration of XCSoar components
 without running the full application. Many of these utilities are prefixed
@@ -47,16 +52,21 @@ find your output directory, check what was created in the ``output/`` folder
 after building.
 
 Building Run* Utilities
-------------------------
+-----------------------
 
-All Run* utilities are automatically built when you compile XCSoar. They are
-defined in ``build/test.mk`` and compiled as part of the debug programs target.
+These utilities are **not** built by plain ``make``; use the ``debug`` target
+(see :ref:`development-workflow` in :doc:`build`). They are defined in
+:file:`build/test.mk` and compiled as the ``debug`` make target.
 
 To build all Run* utilities:
 
 .. code-block:: bash
 
-   make DEBUG
+   make -j$(nproc) debug
+
+Or build everything (main binary, utilities, unit tests, harness)::
+
+   make -j$(nproc) everything
 
 To build a specific utility:
 

--- a/ide/docker/README.md
+++ b/ide/docker/README.md
@@ -1,22 +1,39 @@
 # XCSoar Docker Image
 
-This Docker Image when built, will compile XCSoar for several targets in a clean room environment.
+This Docker image compiles XCSoar for several targets in a clean-room
+environment. See ``doc/build.rst`` (“Using Docker”) for full instructions,
+including legacy Raspberry Pi cross-compile in a privileged container.
 
-## Currently Supported Targets
+## Currently Supported Targets (`xcsoar-compile`)
 
-Targets:
-  - UNIX (linux & co)
-  - UNIX-SDL (Software Rendering for X11 forward)
-  - ANDROID
-  - PC
-  - KOBO
-  - DOCS
+| Target | Description |
+|--------|-------------|
+| ``UNIX`` | Native Linux/Unix build (OpenGL, default desktop target) |
+| ``UNIX-SDL`` | Software rendering via SDL (useful with X11 forwarding) |
+| ``WAYLAND`` | Experimental Wayland display server build |
+| ``WIN64OPENGL`` | Windows x64, OpenGL ES via ANGLE (**recommended**) |
+| ``WIN32OPENGL`` | Windows 32-bit, OpenGL ES via ANGLE (**recommended**) |
+| ``ANDROID`` | Android fat package (all ABIs) |
+| ``KOBO`` | Kobo e-reader build plus ``KoboRoot.tgz`` |
+| ``DOCS`` | Build the PDF manuals (``make manual``) |
+| ``UNIX-DEBIAN`` | Build a ``.deb`` package (``dpkg-buildpackage``) |
+| ``PC`` | Windows 32-bit GDI (**deprecated**; use ``WIN32OPENGL``) |
+| ``WIN64`` | Windows x64 GDI (**deprecated**; use ``WIN64OPENGL``) |
+
+Pass additional ``make`` options after the target name (e.g. ``USE_CCACHE=y
+everything``).
+
+**Platform notes:** The image targets **Linux x86_64** hosts. **iOS** builds
+are not supported in Docker — use a Mac with Xcode (see ``doc/build.rst``,
+*Compiling for iOS*). On **macOS**, Android via Docker can hang or fail under
+emulation; prefer a native Android build or a Linux Docker host (see
+``doc/build.rst``, *Using Docker*).
 
 ## Instructions
 
 The container itself is readonly. The build results will appear in `./output/`.
 
-To run the container interactivly:
+To run the container interactively:
 ```bash
 docker run \
     --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
@@ -28,6 +45,14 @@ To run the ANDROID build:
 docker run \
     --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
     -it ghcr.io/xcsoar/xcsoar/xcsoar-build:latest xcsoar-compile ANDROID
+```
+
+To cross-compile Windows (OpenGL, recommended):
+```bash
+docker run \
+    --mount type=bind,source="$(pwd)",target=/opt/xcsoar \
+    ghcr.io/xcsoar/xcsoar/xcsoar-build:latest \
+    xcsoar-compile WIN64OPENGL USE_CCACHE=y everything
 ```
 
 To build the container:

--- a/ide/docker/bin/xcsoar-compile
+++ b/ide/docker/bin/xcsoar-compile
@@ -4,9 +4,14 @@ CPUS=$(lscpu -p | tail -n1 | cut -f1 -d,)
 (( CPUS++ ))
 cd /opt/xcsoar || exit 1
 
-ARGS=($@)
-TARGET=${ARGS[0]}
-unset "ARGS[0]"
+if [[ $# -lt 1 ]]; then
+  echo "No target specified. Valid targets: ANDROID DOCS KOBO WAYLAND UNIX UNIX-SDL UNIX-DEBIAN WIN64OPENGL WIN32OPENGL PC WIN64"
+  exit 1
+fi
+
+TARGET=$1
+shift
+ARGS=("$@")
 
 case "${TARGET}" in
       ANDROID)
@@ -20,7 +25,7 @@ case "${TARGET}" in
         make TARGET="${TARGET}" -j"${CPUS}" "${ARGS[@]}"
         make TARGET="${TARGET}" -j"${CPUS}" output/KOBO/KoboRoot.tgz
       ;;
-      "WAYLAND" | "UNIX" | "PC" | "WIN64")
+      "WAYLAND" | "UNIX" | "WIN64OPENGL" | "WIN32OPENGL" | "PC" | "WIN64")
         make TARGET="${TARGET}" -j"${CPUS}" "${ARGS[@]}"
       ;;
       "UNIX-SDL")
@@ -31,7 +36,7 @@ case "${TARGET}" in
         ls ../
       ;;
       *)
-        echo "No target specified. Valid targets: ANDROID DOCS KOBO WAYLAND UNIX UNIX-SDL PC WIN64"
+        echo "No target specified. Valid targets: ANDROID DOCS KOBO WAYLAND UNIX UNIX-SDL UNIX-DEBIAN WIN64OPENGL WIN32OPENGL PC WIN64"
         exit 1
       ;;
 esac

--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -55,6 +55,7 @@ install_linux() {
   apt-get install "${APTOPTS[@]}" make g++ \
     binutils-gold \
     zlib1g-dev \
+    libbz2-dev \
     libfmt-dev \
     libdbus-1-dev \
     libsodium-dev \
@@ -105,7 +106,8 @@ install_llvm() {
 
 install_libinput_gbm() {
   echo Installing dependencies for compiling targets which need libinput or GBM...
-  apt-get install "${APTOPTS[@]}" libinput-dev libgbm-dev
+  apt-get install "${APTOPTS[@]}" libinput-dev libgbm-dev libdrm-dev \
+    libgles2-mesa-dev
   echo
 }
 
@@ -114,6 +116,13 @@ install_arm() {
   apt-get install "${APTOPTS[@]}" g++-arm-linux-gnueabihf \
     libmpc-dev \
     meson
+  echo
+}
+
+install_pi_host() {
+  echo Installing host tools for Raspberry Pi cross-compilation and sysroot...
+  apt-get install "${APTOPTS[@]}" debootstrap qemu-user-static binfmt-support \
+    g++-arm-linux-gnueabihf libmpc-dev ca-certificates pkg-config
   echo
 }
 
@@ -180,6 +189,9 @@ for section in "${sections_to_install[@]}"; do
       ;;
     ARM)
       install_arm
+      ;;
+    PI_HOST)
+      install_pi_host
       ;;
     WIN)
       install_win

--- a/ide/provisioning/setup-pi-sysroot.sh
+++ b/ide/provisioning/setup-pi-sysroot.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+# Copyright The XCSoar Project
+#
+# Create an armhf Debian sysroot for cross-compiling XCSoar (TARGET=PI / PI2).
+# Legacy use only: Pi 1–3 cross-build from a desktop host. Pi 4/5 should
+# compile natively (see doc/build.rst).
+#
+# Usage (requires root, e.g. sudo):
+#   sudo ./ide/provisioning/setup-pi-sysroot.sh
+#   sudo PI_ROOT=$HOME/pi-sysroot ./ide/provisioning/setup-pi-sysroot.sh
+#
+# Then on the host:
+#   make TARGET=PI2 PI=/opt/pi/root USE_CCACHE=y DEBUG=y
+#
+# Host packages: ide/provisioning/install-debian-packages.sh PI_HOST
+#
+# Sysroot dev packages align with LINUX + LIBINPUT_GBM in
+# install-debian-packages.sh, plus Pi graphics (DRM/GBM/GLES).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PI_SYSROOT_PACKAGES=(
+  build-essential
+  pkg-config
+  ca-certificates
+  zlib1g-dev
+  libbz2-dev
+  libfmt-dev
+  libdbus-1-dev
+  libsodium-dev
+  libfreetype-dev
+  libpng-dev
+  libjpeg-dev
+  libtiff5-dev
+  libgeotiff-dev
+  libc-ares-dev
+  libcurl4-openssl-dev
+  libssl-dev
+  liblua5.4-dev
+  libasound2-dev
+  libdrm-dev
+  libgbm-dev
+  libgles2-mesa-dev
+  libinput-dev
+  libudev-dev
+  libegl1-mesa-dev
+  mesa-common-dev
+)
+
+PI_ROOT="${PI_ROOT:-/opt/pi/root}"
+DEBIAN_SUITE="${DEBIAN_SUITE:-trixie}"
+DEBIAN_MIRROR="${DEBIAN_MIRROR:-http://deb.debian.org/debian}"
+INSTALL_HOST_DEPS="${INSTALL_HOST_DEPS:-1}"
+FORCE=0
+PACKAGES_ONLY=0
+
+usage() {
+  sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+  cat <<EOF
+
+Options:
+  --force              Remove an existing sysroot and recreate it
+  --packages-only      Install dev packages into an existing sysroot (no debootstrap)
+  --no-host-deps       Do not apt-get install tools on the host
+  -h, --help           Show this help
+
+Environment:
+  PI_ROOT              Sysroot path (default: /opt/pi/root)
+  DEBIAN_SUITE         Debian release (default: trixie)
+  DEBIAN_MIRROR        Debian mirror URL
+  INSTALL_HOST_DEPS    1 = install host packages (default), 0 = skip
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --force)
+    FORCE=1
+    shift
+    ;;
+  --no-host-deps)
+    INSTALL_HOST_DEPS=0
+    shift
+    ;;
+  --packages-only)
+    PACKAGES_ONLY=1
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Run as root (e.g. sudo $0)" >&2
+  exit 1
+fi
+
+if ! command -v debootstrap >/dev/null; then
+  echo "debootstrap not found. Run:" >&2
+  echo "  sudo ${SCRIPT_DIR}/install-debian-packages.sh UPDATE PI_HOST" >&2
+  exit 1
+fi
+
+is_unsafe_removal_path() {
+  case "${PI_ROOT}" in
+  / | /usr | /opt | /home | /var | /etc | /bin | /sbin | /lib | /lib64 | /root)
+    return 0
+    ;;
+  esac
+  [[ "${PI_ROOT}" != /* ]]
+}
+
+is_xcsoar_pi_sysroot() {
+  [[ -f "${PI_ROOT}/.xcsoar-pi-sysroot" ]] || \
+    [[ -f "${PI_ROOT}/debootstrap/debootstrap" ]] || \
+    { [[ -d "${PI_ROOT}/usr/lib/arm-linux-gnueabihf" ]] && \
+      [[ -f "${PI_ROOT}/etc/debian_version" ]]; }
+}
+
+if [[ -d "${PI_ROOT}/usr" ]]; then
+  if [[ "${FORCE}" -eq 1 ]]; then
+    if is_unsafe_removal_path; then
+      echo "Refusing to remove unsafe path: ${PI_ROOT}" >&2
+      exit 1
+    fi
+    if ! is_xcsoar_pi_sysroot; then
+      echo "Refusing --force: ${PI_ROOT} does not look like a Pi sysroot." >&2
+      echo "Use a dedicated directory (default: /opt/pi/root)." >&2
+      exit 1
+    fi
+    echo "Removing existing sysroot at ${PI_ROOT}"
+    rm -rf "${PI_ROOT}"
+  elif [[ "${PACKAGES_ONLY}" -eq 1 ]]; then
+    echo "Installing packages into existing sysroot at ${PI_ROOT}"
+  else
+    echo "Sysroot already exists: ${PI_ROOT}" >&2
+    echo "Use --force to recreate, --packages-only to install dev packages," >&2
+    echo "or set PI_ROOT to another path." >&2
+    exit 1
+  fi
+fi
+
+install_sysroot_packages() {
+  echo "Installing sysroot development packages..."
+  DEBIAN_FRONTEND=noninteractive \
+    chroot "${PI_ROOT}" apt-get update
+  DEBIAN_FRONTEND=noninteractive \
+    chroot "${PI_ROOT}" apt-get install -y --no-install-recommends \
+    "${PI_SYSROOT_PACKAGES[@]}"
+}
+
+verify_sysroot() {
+  PKG_CONFIG_LIBDIR="${PI_ROOT}/usr/lib/arm-linux-gnueabihf/pkgconfig:${PI_ROOT}/usr/share/pkgconfig"
+  echo "Verifying pkg-config entries in sysroot..."
+  missing=0
+  for pc in egl gbm libdrm libinput libudev bzip2 freetype2; do
+    if ! PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR}" \
+      pkg-config --define-variable=prefix="${PI_ROOT}/usr" \
+      --exists "${pc}"; then
+      echo "pkg-config missing: ${pc}" >&2
+      missing=1
+    fi
+  done
+
+  if [[ "${missing}" -ne 0 ]]; then
+    echo "Sysroot verification failed." >&2
+    exit 1
+  fi
+}
+
+if [[ "${INSTALL_HOST_DEPS}" == 1 ]]; then
+  "${SCRIPT_DIR}/install-debian-packages.sh" UPDATE PI_HOST
+fi
+
+if ! command -v qemu-arm-static >/dev/null; then
+  echo "qemu-arm-static not found (needed for chroot apt)." >&2
+  exit 1
+fi
+
+if [[ "${PACKAGES_ONLY}" -eq 1 ]]; then
+  if [[ ! -d "${PI_ROOT}/usr" ]]; then
+    echo "Sysroot does not exist: ${PI_ROOT}" >&2
+    echo "Create it first or drop --packages-only." >&2
+    exit 1
+  fi
+  install_sysroot_packages
+  echo "Cleaning apt caches in sysroot..."
+  chroot "${PI_ROOT}" apt-get clean
+  verify_sysroot
+  touch "${PI_ROOT}/.xcsoar-pi-sysroot"
+  exit 0
+fi
+
+mkdir -p "${PI_ROOT}"
+
+echo "Bootstrapping ${DEBIAN_SUITE} armhf into ${PI_ROOT}..."
+debootstrap --arch=armhf --foreign "${DEBIAN_SUITE}" "${PI_ROOT}" "${DEBIAN_MIRROR}"
+
+QEMU_BIN="$(command -v qemu-arm-static)"
+install -D -m 0755 "${QEMU_BIN}" "${PI_ROOT}/usr/bin/qemu-arm-static"
+
+echo "Running debootstrap second stage..."
+DEBIAN_FRONTEND=noninteractive \
+  chroot "${PI_ROOT}" /debootstrap/debootstrap --second-stage
+
+install_sysroot_packages
+
+echo "Cleaning apt caches in sysroot..."
+chroot "${PI_ROOT}" apt-get clean
+
+verify_sysroot
+
+touch "${PI_ROOT}/.xcsoar-pi-sysroot"
+
+cat <<EOF
+
+Pi sysroot ready: ${PI_ROOT}
+
+Cross-compile XCSoar for Raspberry Pi 2/3:
+
+  make -j\$(nproc) TARGET=PI2 PI=${PI_ROOT} USE_CCACHE=y DEBUG=y
+
+For Pi 1 (ARMv6) use TARGET=PI instead of PI2.
+EOF


### PR DESCRIPTION
## Summary

- Add `ide/provisioning/setup-pi-sysroot.sh` to create an armhf Debian sysroot on a desktop host (debootstrap + `qemu-user-static`, chroot package install, pkg-config verification)
- Add `build/setup-pi-sysroot.sh` wrapper and `PI_HOST` section in `install-debian-packages.sh` (debootstrap, qemu, `g++-arm-linux-gnueabihf`, …)
- Extend `LIBINPUT_GBM` with `libdrm-dev` and `libgles2-mesa-dev`; add `libbz2-dev` to Linux host deps
- Fix Pi cross `pkg-config` to search both `usr/lib/arm-linux-gnueabihf/pkgconfig` and `usr/share/pkgconfig`
- Update `doc/build.rst` and `doc/devsetup.rst` to document provisioning sections and Pi 1–3 cross-compile workflow

## Test plan

- [ ] `sudo ide/provisioning/install-debian-packages.sh UPDATE PI_HOST` on Debian/Ubuntu
- [ ] `sudo ide/provisioning/setup-pi-sysroot.sh` creates sysroot at `/opt/pi/root`
- [ ] `make -j$(nproc) TARGET=PI2 PI=/opt/pi/root USE_CCACHE=y DEBUG=y` completes on amd64 host
- [ ] `pkg-config --exists egl gbm libdrm` succeeds with `PKG_CONFIG_LIBDIR` set to sysroot paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided setup flow for Raspberry Pi cross-compilation, including sysroot creation and verification.
  * Introduced a simpler wrapper command to launch the Pi sysroot setup process.
  * Updated documentation to use provisioning scripts with clearer setup steps for Linux, Android, Windows, Pi, Kobo, and manual builds.

* **Bug Fixes**
  * Improved build environment detection for Pi-related targets by using a combined package-config search path.
  * Added missing system packages needed for Linux, graphics, and Pi host setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->