### PR TITLE
Dialogs/Settings/Panels/SafetyFactorsConfigPanel: Clarify alternates mode help

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -170,6 +170,7 @@ Version 7.45 - not yet released
     Displayed glide is re-solved with the current aircraft state; value colour
     encodes not reachable, final glide, need climb, and MANUAL on/below glide.
     Manual updated en/de/fr/pt_BR #2347
+  - clarify alternates mode help text in Safety Factors config panel (#555)
   - status: show G-load availability in device list and variometer source in
     system status
   - terrain: add new terrain shading orientation "fixed (Top Left)"

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -59,16 +59,20 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
 
   static constexpr StaticEnumChoice abort_task_mode_list[] = {
     { AbortTaskMode::SIMPLE, N_("Simple"),
-      N_("The alternates will only be sorted by waypoint type (airport/outlanding field) and arrival height.") },
+      N_("Reachable airfields are listed first (nearest at top), then "
+         "outlanding sites (nearest at top).") },
     { AbortTaskMode::TASK, N_("Task"),
-      N_("The sorting will also take the current task direction into account.") },
+      N_("Reachable airfields are listed first (smallest detour to the "
+         "active turnpoint at top), then outlanding sites.") },
     { AbortTaskMode::HOME, N_("Home"),
-      N_("The sorting will try to find landing options in the current direction to the configured home waypoint.") },
+      N_("Reachable airfields are listed first (smallest detour toward "
+         "home at top), then outlanding sites.") },
     nullptr
   };
 
   AddEnum(_("Alternates mode"),
-          _("Determines sorting of alternates in the alternates dialog and in abort mode."),
+          _("Determines sorting of alternates in the alternates dialog "
+            "and in abort mode."),
           abort_task_mode_list, (unsigned)task_behaviour.abort_task_mode);
 
   AddFloat(_("Polar degradation"), /* xgettext:no-c-format */


### PR DESCRIPTION
## Summary

- Update Simple, Task, and Home help text for **Alternates mode** in the Safety Factors config panel
- Descriptions now match alternates list behaviour after #1856: reachable airfields first, then outlanding sites, with mode-specific ordering explained in plain language
- Regenerate translation catalogs for the new strings

Closes #555

## Test plan

- [ ] Open **Configuration → Glide Computer → Safety Factors**
- [ ] Select **Alternates mode** and read help for Simple, Task, and Home
- [ ] Confirm wording matches alternates dialog ordering during flight