### PR TITLE
Form/DataField/File: Sort IGC and NMEA lists in descending order

### DIFF
--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -11,6 +11,7 @@
 #include "Form/DataField/Base.hpp"
 #include "Language/Language.hpp"
 #include "Repository/FileType.hpp"
+#include "Form/DataField/File.hpp"
 
 class ReplayControlWidget final
   : public RowFormWidget
@@ -53,6 +54,7 @@ ReplayControlWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
           {FileType::NMEA, FileType::IGC},
           true);
   LoadValue(FILE, replay.GetFilename());
+  GetFileDataField(FILE).Sort(FileDataField::SortOrder::DESCENDING, true);
 
   AddFloat(_("Rate"),
            _("Time acceleration of replay. Set to 0 for pause, 1 for normal real-time replay."),

--- a/src/Form/DataField/File.cpp
+++ b/src/Form/DataField/File.cpp
@@ -77,7 +77,7 @@ FileDataField::FileDataField(DataFieldListener *listener) noexcept
    // Set selection to zero
    current_index(0),
    loaded(false), postponed_sort(SortOrder::NO_ORDER),
-   postponed_value(nullptr)
+   postponed_preserve_first(false), postponed_value(nullptr)
 {
   file_types.append() = FileType::UNKNOWN;
 }
@@ -182,7 +182,8 @@ FileDataField::ScanDirectoryTop(const char *filter) noexcept
     VisitDataFiles(filter, fv);
   }
 
-  Sort();
+  if (postponed_sort == SortOrder::NO_ORDER)
+    Sort();
 }
 
 void
@@ -393,31 +394,46 @@ FileDataField::Dec() noexcept
 }
 
 void
-FileDataField::Sort(SortOrder order) noexcept
+FileDataField::Sort(SortOrder order, bool preserve_first) noexcept
 {
   if (order == SortOrder::NO_ORDER)
     return;
 
   if (!loaded) {
     postponed_sort = order;
+    postponed_preserve_first = preserve_first;
     return;
   }
 
-  if (order == SortOrder::ASCENDING) {
-    // Sort the filelist in ascending order
-    std::sort(files.begin(), files.end(), [](const Item &a,
-                                             const Item &b) {
-                return StringCollate(a.filename.c_str(), b.filename.c_str()) < 0;
-              });
-  } else {
-    // Sort the filelist in descending order
-    std::sort(files.begin(), files.end(), [](const Item &a,
+  if (files.size() > 1) {
+    if (preserve_first) {
+      // Keep first entry in place for flight replay demo; sort remainder by the requested order
+      if (order == SortOrder::DESCENDING) {
+        std::sort(std::next(files.begin()), files.end(), [](const Item &a, const Item &b) {
+                  return StringCollate(a.filename.c_str(), b.filename.c_str()) > 0;
+        });
+      } else {
+        // Sort the filelist in ascending order
+        std::sort(std::next(files.begin()), files.end(), [](const Item &a, const Item &b) {
+                  return StringCollate(a.filename.c_str(), b.filename.c_str()) < 0;
+        });
+      }
+    } else if (order == SortOrder::DESCENDING) {
+      std::sort(files.begin(), files.end(), [](const Item &a,
                                              const Item &b) {
                 return StringCollate(a.filename.c_str(), b.filename.c_str()) > 0;
               });
+    } else {
+      // Sort the filelist in ascending order
+      std::sort(files.begin(), files.end(), [](const Item &a,
+                                             const Item &b) {
+                return StringCollate(a.filename.c_str(), b.filename.c_str()) < 0;
+              });
+    }
   }
 
   postponed_sort = SortOrder::NO_ORDER;
+  postponed_preserve_first = false;
 }
 
 ComboList
@@ -511,7 +527,7 @@ FileDataField::EnsureLoaded() noexcept
     ScanDirectoryTop(*i);
 
   if (postponed_sort != SortOrder::NO_ORDER)
-    Sort(postponed_sort);
+    Sort(postponed_sort, postponed_preserve_first);
 
   if (postponed_value != nullptr)
     SetValue(postponed_value);

--- a/src/Form/DataField/File.hpp
+++ b/src/Form/DataField/File.hpp
@@ -80,6 +80,12 @@ private:
   SortOrder postponed_sort;
 
   /**
+   * Stores whether the first entry should be skipped during sorting if
+   * Sort() has been called before the file list was loaded.
+   */
+  bool postponed_preserve_first = false;
+
+  /**
    * Used to store the value while !loaded.
    */
   AllocatedPath postponed_value;
@@ -167,7 +173,8 @@ public:
   void ModifyIndex(unsigned new_value) noexcept;
 
   /** Sorts the filelist by filenames */
-  void Sort(SortOrder order = SortOrder::ASCENDING) noexcept;
+  void Sort(SortOrder order = SortOrder::ASCENDING,
+            bool preserve_first = false) noexcept;
   void ScanDirectoryTop(const char *filter) noexcept;
 
   /**

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -801,6 +801,7 @@ InputEvents::eventUploadIGCFile([[maybe_unused]] const char *misc) {
   FileDataField df;
   df.ScanMultiplePatterns(GetFileTypePatterns(FileType::IGC));
   df.SetFileType(FileType::IGC);
+  df.Sort(FileDataField::SortOrder::DESCENDING, false);
   if (FilePicker("IGC-FilePicker", df)) {
     auto path = df.GetValue();
     if (!path.empty())

--- a/src/Widget/FileRowFormWidget.cpp
+++ b/src/Widget/FileRowFormWidget.cpp
@@ -10,9 +10,23 @@
 Path
 RowFormWidget::GetValueFile(unsigned i) const noexcept
 {
+  return GetFileDataField(i).GetValue();
+}
+
+FileDataField &
+RowFormWidget::GetFileDataField(unsigned i) noexcept
+{
+  auto &df = (FileDataField &)GetDataField(i);
+  assert(df.GetType() == DataField::Type::FILE);
+  return df;
+}
+
+const FileDataField &
+RowFormWidget::GetFileDataField(unsigned i) const noexcept
+{
   const auto &df = (const FileDataField &)GetDataField(i);
   assert(df.GetType() == DataField::Type::FILE);
-  return df.GetValue();
+  return df;
 }
 
 void

--- a/src/Widget/RowFormWidget.hpp
+++ b/src/Widget/RowFormWidget.hpp
@@ -26,6 +26,7 @@
 struct DialogLook;
 struct StaticEnumChoice;
 class Angle;
+class FileDataField;
 class RoughTimeDelta;
 class Path;
 class Button;
@@ -650,6 +651,12 @@ public:
 
   [[gnu::pure]]
   Path GetValueFile(unsigned i) const noexcept;
+
+  [[gnu::pure]]
+  FileDataField &GetFileDataField(unsigned i) noexcept;
+
+  [[gnu::pure]]
+  const FileDataField &GetFileDataField(unsigned i) const noexcept;
 
   [[gnu::pure]]
   const char *GetValueString(unsigned i) const noexcept {


### PR DESCRIPTION
Supersedes #2578 (same change, rebased on master with review fixes).

Follow-up to closed #2528.

Log file pickers (replay, WeGlide IGC upload) should list newest filenames first. Other file lists stay in ascending order.

Sorting uses **filename collation**, not file modification time.