### PR TITLE
Repository/FileType: Centralize file type metadata and download paths

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -736,7 +736,10 @@ TEST_REPOSITORY_DEPENDS = UTIL
 $(eval $(call link-program,TestRepository,TEST_REPOSITORY))
 
 TEST_FILE_TYPE_SOURCES = \
+	$(SRC)/DataFilePath.cpp \
+	$(SRC)/LocalPath.cpp \
 	$(SRC)/Repository/FileType.cpp \
+	$(SRC)/system/FileUtil.cpp \
 	$(SRC)/system/Path.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestFileType.cpp

--- a/src/DataFilePath.cpp
+++ b/src/DataFilePath.cpp
@@ -12,6 +12,17 @@
 namespace {
 
 [[gnu::pure]]
+static bool
+IsSafeDataFilename(const char *filename) noexcept
+{
+  if (filename == nullptr || *filename == '\0')
+    return false;
+
+  const Path path(filename);
+  return path.IsValidFilename() && !path.HasPathTraversal();
+}
+
+[[gnu::pure]]
 static AllocatedPath
 ResolveDataCachePath(const char *filename) noexcept
 {
@@ -53,9 +64,12 @@ ResolveUniqueExistingTypedDataFile(const char *filename) noexcept
 AllocatedPath
 TypedDataSavePath(FileType file_type, const char *filename) noexcept
 {
+  if (!IsSafeDataFilename(filename))
+    return nullptr;
+
   const auto subdir = GetFileTypeDefaultDir(file_type);
-  if (subdir == nullptr || filename == nullptr || *filename == '\0')
-    return filename != nullptr ? LocalPath(filename) : nullptr;
+  if (subdir == nullptr)
+    return LocalPath(filename);
 
   Directory::CreateRecursive(LocalPath(subdir));
   return LocalPath(AllocatedPath::Build(subdir, filename));
@@ -175,6 +189,36 @@ ResolveDownloadDestinationPath(Path path) noexcept
 }
 
 AllocatedPath
+GetFileTypeDownloadRelativePath(const FileType file_type,
+                                const char *filename) noexcept
+{
+  if (!IsSafeDataFilename(filename))
+    return nullptr;
+
+  const auto subdir = GetFileTypeDefaultDir(file_type);
+  if (subdir == nullptr)
+    return AllocatedPath(filename);
+
+  AllocatedPath relative = AllocatedPath::Build(subdir, filename);
+  if (Path(relative).HasPathTraversal())
+    return nullptr;
+
+  return relative;
+}
+
+bool
+EnsureFileTypeDownloadDirectory(const FileType file_type) noexcept
+{
+  const auto subdir = GetFileTypeDefaultDir(file_type);
+  if (subdir == nullptr)
+    return true;
+
+  const auto dest_path = LocalPath(subdir);
+  Directory::CreateRecursive(dest_path);
+  return Directory::Exists(dest_path);
+}
+
+AllocatedPath
 CacheDataSavePath(const char *filename) noexcept
 {
   return RepositoryDataSavePath(filename);
@@ -201,9 +245,7 @@ ResolveCacheDataPath(const char *filename) noexcept
 AllocatedPath
 LogsDataSavePath(const char *filename) noexcept
 {
-  const auto logs_dir = LocalPath(Path("logs"));
-  Directory::CreateRecursive(logs_dir);
-  return AllocatedPath::Build(logs_dir, filename);
+  return TypedDataSavePath(FileType::IGC, filename);
 }
 
 AllocatedPath

--- a/src/DataFilePath.hpp
+++ b/src/DataFilePath.hpp
@@ -54,6 +54,14 @@ RepositoryDownloadRelativePath(const char *filename) noexcept;
 AllocatedPath
 ResolveDownloadDestinationPath(Path path) noexcept;
 
+[[gnu::pure]]
+AllocatedPath
+GetFileTypeDownloadRelativePath(FileType file_type,
+                                const char *filename) noexcept;
+
+bool
+EnsureFileTypeDownloadDirectory(FileType file_type) noexcept;
+
 AllocatedPath
 CacheDataSavePath(const char *filename) noexcept;
 

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
@@ -15,6 +15,7 @@
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "Storage/StorageDevice.hpp"
 #include "system/FileUtil.hpp"
 #include "Language/Language.hpp"
@@ -372,7 +373,7 @@ ShowExportFlightsDialog()
    * logs folder only (collect, sort externally, then populate)
    */
   auto df = std::make_unique<MultiFileDataField>();
-  auto logs_path = MakeLocalPath("logs");
+  auto logs_path = LocalPath(GetFileTypeDefaultDir(FileType::IGC));
   if (logs_path != nullptr && Directory::Exists(logs_path)) {
     ScanFilesIntoDataField(logs_path, *df,
                            {FileType::IGC, FileType::NMEA}, true);

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -21,6 +21,7 @@
 #include "ui/event/PeriodicTimer.hpp"
 #include "thread/Mutex.hxx"
 #include "LocalPath.hpp"
+#include "DataFilePath.hpp"
 #include "system/FileUtil.hpp"
 #include <vector>
 
@@ -186,29 +187,23 @@ DownloadFilePickerWidget::Download()
 
   const auto &file = items[current];
 
-  try {
-    AllocatedPath dest_dir = GetFileTypeDefaultDir(file_type);
-
-    const Path file_path(file.GetName()); //AllocatedPath cannot take nullptr
-
-    if (!file_path.IsValidFilename())
-      throw std::runtime_error("Invalid download filename");
-
-    AllocatedPath relative_path(file_path);
-    if (dest_dir != nullptr) {
-      const auto dest_path = LocalPath(dest_dir);
-      Directory::CreateRecursive(dest_path);
-      if (!Directory::Exists(dest_path))
-        throw std::runtime_error("Directory does not exist and could not be created.");
-
-      relative_path = AllocatedPath::Build(Path(dest_dir), file_path);
-    }
-    path = DownloadFileModal(_("Download"), file.GetURI(), relative_path.c_str());
-    if (path != nullptr)
-      dialog.SetModalResult(mrOK);
-  } catch (...) {
-    ShowError(std::current_exception(), _("Error"));
+  const auto relative_path =
+    GetFileTypeDownloadRelativePath(file_type, file.GetName());
+  if (relative_path == nullptr) {
+    ShowMessageBox(_("Invalid download filename"), _("Error"), MB_OK);
+    return;
   }
+
+  if (!EnsureFileTypeDownloadDirectory(file_type)) {
+    ShowMessageBox(_("Subdirectory does not exist and could not be created."),
+                   _("Error"), MB_OK);
+    return;
+  }
+
+  path = DownloadFileModal(_("Download"), file.GetURI(),
+                           relative_path.c_str());
+  if (path != nullptr)
+    dialog.SetModalResult(mrOK);
 }
 
 void

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -11,6 +11,7 @@
 #include "Widget/ListWidget.hpp"
 #include "Language/Language.hpp"
 #include "LocalPath.hpp"
+#include "DataFilePath.hpp"
 #include "system/FileUtil.hpp"
 #include "system/Path.hpp"
 #include "Formatter/ByteSizeFormatter.hpp"
@@ -37,22 +38,6 @@
 #include <cassert>
 
 using std::string_view_literals::operator""sv;
-
-[[gnu::pure]]
-static AllocatedPath
-GetRelativePathByType(const AvailableFile &file)
-{
-  const auto base = file.GetName();
-  if (base == nullptr)
-    return nullptr;
-
-  const AllocatedPath subdir = GetFileTypeDefaultDir(file.type);
-  if (subdir == nullptr)
-    return AllocatedPath(base);
-
-  return AllocatedPath::Build(subdir, Path(base));
-}
-
 
 [[gnu::pure]]
 static AllocatedPath
@@ -536,21 +521,17 @@ ManagedFileListWidget::DownloadRemoteFile(const AvailableFile &remote_file)
   if (remote_file.GetName() == nullptr)
     return;
 
-  const AllocatedPath subdir = GetFileTypeDefaultDir(remote_file.type);
-  AllocatedPath path = nullptr;
-  if (subdir != nullptr) {
-    const auto dest_path = LocalPath(subdir);
-    Directory::CreateRecursive(dest_path);
-    if (!Directory::Exists(dest_path)) {
-      ShowMessageBox(_("Subdirectory does not exist and could not be created."),
-                     _("Error"), MB_OK);
-      return;
-    }
-    path = AllocatedPath::Build(subdir, Path(remote_file.GetName()));
-  } else {
-    path = AllocatedPath(remote_file.GetName());
-    if (path == nullptr)
-      return;
+  const auto path =
+    GetFileTypeDownloadRelativePath(remote_file.type, remote_file.GetName());
+  if (path == nullptr) {
+    ShowMessageBox(_("Invalid download filename"), _("Error"), MB_OK);
+    return;
+  }
+
+  if (!EnsureFileTypeDownloadDirectory(remote_file.type)) {
+    ShowMessageBox(_("Subdirectory does not exist and could not be created."),
+                   _("Error"), MB_OK);
+    return;
   }
 
   Net::DownloadManager::Enqueue(remote_file.uri.c_str(), path);
@@ -654,9 +635,14 @@ ManagedFileListWidget::UpdateFiles() {
       const AvailableFile *remote_file = FindRemoteFile(repository, file.name);
 
       if (remote_file != nullptr) {
-        const auto relative_path = GetRelativePathByType(*remote_file);
+        const auto relative_path =
+          GetFileTypeDownloadRelativePath(remote_file->type,
+                                          remote_file->GetName());
         if (relative_path == nullptr)
-          return;
+          continue;
+
+        if (!EnsureFileTypeDownloadDirectory(remote_file->type))
+          continue;
 
         Net::DownloadManager::Enqueue(remote_file->GetURI(), relative_path);
       }
@@ -680,7 +666,9 @@ ManagedFileListWidget::Cancel()
   const FileItem &item = items[current];
   const AvailableFile *remote_file = FindRemoteFile(repository, item.name);
   if (remote_file != nullptr) {
-    if (const auto relative_path = GetRelativePathByType(*remote_file);
+    if (const auto relative_path =
+          GetFileTypeDownloadRelativePath(remote_file->type,
+                                          remote_file->GetName());
         relative_path != nullptr) {
       Net::DownloadManager::Cancel(relative_path);
       return;

--- a/src/Dialogs/Task/Manager/TaskListPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskListPanel.cpp
@@ -15,6 +15,7 @@
 #include "Task/TaskStore.hpp"
 #include "Task/ValidationErrorStrings.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "system/FileUtil.hpp"
 #include "Language/Language.hpp"
 #include "Interface.hpp"
@@ -281,7 +282,7 @@ TaskListPanel::RenameTask()
 
   newname.append(".tsk");
 
-  const auto tasks_path = MakeLocalPath("tasks");
+  const auto tasks_path = LocalPath(GetFileTypeDefaultDir(FileType::TASK));
 
   File::Rename(task_store.GetPath(cursor_index),
                AllocatedPath::Build(tasks_path, newname));

--- a/src/Dialogs/Task/dlgTaskHelpers.cpp
+++ b/src/Dialogs/Task/dlgTaskHelpers.cpp
@@ -17,6 +17,7 @@
 #include "Engine/Task/Points/Type.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
 #include "LocalPath.hpp"
+#include "Repository/FileType.hpp"
 #include "system/Path.hpp"
 
 #include <cassert>
@@ -221,7 +222,7 @@ OrderedTaskSave(OrderedTask &task)
   if (!TextEntryDialog(fname, 64, _("Enter a task name")))
     return false;
 
-  const auto tasks_path = MakeLocalPath("tasks");
+  const auto tasks_path = LocalPath(GetFileTypeDefaultDir(FileType::TASK));
 
   strcat(fname, ".tsk");
   task.SetName(fname);

--- a/src/Repository/FileType.cpp
+++ b/src/Repository/FileType.cpp
@@ -4,119 +4,181 @@
 #include "FileType.hpp"
 #include "system/Path.hpp"
 #include "Compatibility/path.h"
+#include "util/Macros.hpp"
 #include "util/StringCompare.hxx"
 
 #include <cstring>
 #include <string_view>
 
+/**
+ * Per-type metadata: filename patterns, local subdirectory, and
+ * optional repository index type string (type = …).
+ */
+struct FileTypeInfo {
+  const char *patterns;
+  const char *default_dir;
+  const char *repository_type;
+};
+
+static constexpr FileTypeInfo file_type_info[unsigned(FileType::COUNT)] = {
+  /* UNKNOWN */ {
+    .patterns = "\0",
+    .default_dir = nullptr,
+    .repository_type = nullptr,
+  },
+  /* AIRSPACE */ {
+    .patterns =
+      "*.openair\0"
+      "*.txt\0"
+      "*.air\0"
+      "*.sua\0",
+    .default_dir = "airspace",
+    .repository_type = "airspace",
+  },
+  /* RASP */ {
+    .patterns = "*-rasp*.dat\0",
+    .default_dir = "weather/rasp",
+    .repository_type = "rasp",
+  },
+  /* WAYPOINT */ {
+    .patterns =
+      "*.dat\0"
+      "*.xcw\0"
+      "*.cup\0"
+      "*.cupx\0"
+      "*.wpz\0"
+      "*.wpt\0",
+    .default_dir = "waypoints",
+    .repository_type = "waypoint",
+  },
+  /* WAYPOINTDETAILS */ {
+    .patterns = "*.txt\0",
+    .default_dir = "waypoints/details",
+    .repository_type = "waypoint-details",
+  },
+  /* MAP */ {
+    .patterns =
+      "*.xcm\0"
+      "*.lkm\0",
+    .default_dir = "maps",
+    .repository_type = "map",
+  },
+  /* FLARMNET */ {
+    .patterns = "*.fln\0",
+    .default_dir = "flarm",
+    .repository_type = "flarmnet",
+  },
+  /* FLARMDB */ {
+    .patterns =
+      "xcsoar-flarm.txt\0"
+      "flarm-msg-data.csv\0",
+    .default_dir = "flarm",
+    .repository_type = nullptr,
+  },
+  /* IGC */ {
+    .patterns = "*.igc\0",
+    .default_dir = "logs",
+    .repository_type = nullptr,
+  },
+  /* NMEA */ {
+    .patterns = "*.nmea\0",
+    .default_dir = "logs",
+    .repository_type = nullptr,
+  },
+  /* TASK */ {
+    .patterns =
+      "*.tsk\0"
+      "*.cup\0"
+      "*.igc\0",
+    .default_dir = "tasks",
+    .repository_type = "task",
+  },
+  /* CHECKLIST */ {
+    .patterns =
+      "*.xcc\0"
+      "xcsoar-checklist.txt\0",
+    .default_dir = "checklists",
+    .repository_type = "checklist",
+  },
+  /* PROFILE */ {
+    .patterns = "*.prf\0",
+    .default_dir = "profiles",
+    .repository_type = nullptr,
+  },
+  /* PLANE */ {
+    .patterns = "*.xcp\0",
+    .default_dir = "profiles/planes",
+    .repository_type = nullptr,
+  },
+  /* XCI */ {
+    .patterns = "*.xci\0",
+    .default_dir = "input",
+    .repository_type = "xci",
+  },
+  /* LUA */ {
+    .patterns = "*.lua\0",
+    .default_dir = "lua",
+    .repository_type = nullptr,
+  },
+};
+
+static_assert(ARRAY_SIZE(file_type_info) == unsigned(FileType::COUNT),
+              "file_type_info must match FileType::COUNT");
+
+static AllocatedPath
+BuildDefaultDir(const char *dir) noexcept
+{
+  const char *slash = std::strchr(dir, '/');
+#ifdef _WIN32
+  if (slash == nullptr)
+    slash = std::strchr(dir, '\\');
+#endif
+  if (slash == nullptr)
+    return AllocatedPath(dir);
+
+  AllocatedPath head(dir, slash);
+  const char *tail = slash + 1;
+  if (*tail == '\0')
+    return head;
+
+  return AllocatedPath::Build(Path(head), Path(BuildDefaultDir(tail)));
+}
+
+FileType
+FileTypeFromRepositoryString(const char *type) noexcept
+{
+  if (type == nullptr || *type == '\0')
+    return FileType::UNKNOWN;
+
+  for (uint8_t i = 1; i < static_cast<uint8_t>(FileType::COUNT); ++i) {
+    const auto &info = file_type_info[i];
+    if (info.repository_type != nullptr &&
+        StringIsEqual(type, info.repository_type))
+      return static_cast<FileType>(i);
+  }
+
+  return FileType::UNKNOWN;
+}
+
 const char *
 GetFileTypePatterns(const FileType file_type) noexcept
 {
-  switch (file_type) {
-  case FileType::AIRSPACE:
-    return "*.openair\0*.txt\0*.air\0*.sua\0";
-
-  case FileType::WAYPOINT:
-    return "*.dat\0*.xcw\0*.cup\0*.cupx\0*.wpz\0*.wpt\0";
-
-  case FileType::WAYPOINTDETAILS:
-    return "*.txt\0";
-
-  case FileType::MAP:
-    return "*.xcm\0*.lkm\0";
-
-  case FileType::FLARMNET:
-    return "*.fln\0";
-
-  case FileType::FLARMDB:
-    return "xcsoar-flarm.txt\0flarm-msg-data.csv\0";
-
-  case FileType::IGC:
-    return "*.igc\0";
-
-  case FileType::NMEA:
-    return "*.nmea\0";
-
-  case FileType::RASP:
-    return "*-rasp*.dat\0";
-
-  case FileType::XCI:
-    return "*.xci\0";
-
-  case FileType::LUA:
-    return "*.lua\0";
-
-  case FileType::TASK:
-    return "*.tsk\0*.cup\0*.igc\0";
-
-  case FileType::CHECKLIST:
-    return "*.xcc\0xcsoar-checklist.txt\0";
-
-  case FileType::PROFILE:
-    return "*.prf\0";
-
-  case FileType::PLANE:
-    return "*.xcp\0";
-
-  case FileType::UNKNOWN:
-  case FileType::COUNT:
+  if (file_type == FileType::UNKNOWN ||
+      file_type == FileType::COUNT)
     return "\0";
-  }
 
-  return "\0";
+  return file_type_info[unsigned(file_type)].patterns;
 }
 
 AllocatedPath
 GetFileTypeDefaultDir(const FileType file_type)
 {
-  switch (file_type) {
-  case FileType::AIRSPACE:
-    return AllocatedPath("airspace");
-
-  case FileType::WAYPOINT:
-    return AllocatedPath("waypoints");
-
-  case FileType::WAYPOINTDETAILS:
-    return AllocatedPath::Build("waypoints", "details");
-
-  case FileType::MAP:
-    return AllocatedPath("maps");
-
-  case FileType::FLARMDB:
-  case FileType::FLARMNET:
-    return AllocatedPath("flarm");
-
-  case FileType::RASP:
-    return AllocatedPath::Build("weather", "rasp");
-
-  case FileType::TASK:
-    return AllocatedPath("tasks");
-
-  case FileType::CHECKLIST:
-    return AllocatedPath("checklists");
-
-  case FileType::IGC:
-  case FileType::NMEA:
-    return AllocatedPath("logs");
-
-  case FileType::PLANE:
-    return AllocatedPath::Build("profiles", "planes");
-
-  case FileType::XCI:
-    return AllocatedPath("input");
-
-  case FileType::LUA:
-    return AllocatedPath("lua");
-
-  case FileType::PROFILE:
-    return AllocatedPath("profiles");
-
-  case FileType::UNKNOWN:
-  case FileType::COUNT:
+  if (file_type == FileType::UNKNOWN ||
+      file_type == FileType::COUNT)
     return nullptr;
-  }
 
-  return nullptr;
+  const char *dir = file_type_info[unsigned(file_type)].default_dir;
+  return dir != nullptr ? BuildDefaultDir(dir) : nullptr;
 }
 
 FileType

--- a/src/Repository/FileType.hpp
+++ b/src/Repository/FileType.hpp
@@ -78,3 +78,10 @@ bool IsCacheLayoutFilename(const char *filename) noexcept;
  */
 [[gnu::pure]]
 FileType DetectFileTypeByFilename(const char *filename) noexcept;
+
+/**
+ * Parse a repository file ``type = …`` value into a #FileType.
+ * Returns FileType::UNKNOWN for unrecognised values.
+ */
+[[gnu::pure]]
+FileType FileTypeFromRepositoryString(const char *type) noexcept;

--- a/src/Repository/Parser.cpp
+++ b/src/Repository/Parser.cpp
@@ -3,6 +3,7 @@
 
 #include "Parser.hpp"
 #include "FileRepository.hpp"
+#include "FileType.hpp"
 #include "io/LineReader.hpp"
 #include "util/StringStrip.hxx"
 #include "util/HexString.hpp"
@@ -81,24 +82,7 @@ ParseFileRepository(FileRepository &repository, NLineReader &reader)
     } else if (StringIsEqual(name, "area")) {
       file.area = value;
     } else if (StringIsEqual(name, "type")) {
-      if (StringIsEqual(value, "airspace"))
-        file.type = FileType::AIRSPACE;
-      else if (StringIsEqual(value, "waypoint-details"))
-        file.type = FileType::WAYPOINTDETAILS;
-      else if (StringIsEqual(value, "waypoint"))
-        file.type = FileType::WAYPOINT;
-      else if (StringIsEqual(value, "map"))
-        file.type = FileType::MAP;
-      else if (StringIsEqual(value, "flarmnet"))
-        file.type = FileType::FLARMNET;
-      else if (StringIsEqual(value, "rasp"))
-        file.type = FileType::RASP;
-      else if (StringIsEqual(value, "xci"))
-        file.type = FileType::XCI;
-      else if (StringIsEqual(value, "task"))
-        file.type = FileType::TASK;
-      else if (StringIsEqual(value, "checklist"))
-        file.type = FileType::CHECKLIST;
+      file.type = FileTypeFromRepositoryString(value);
     } else if (StringIsEqual(name, "update")) {
       unsigned year, month, day;
       if (sscanf(value, "%04u-%02u-%02u", &year, &month, &day) == 3)

--- a/test/src/TestFileType.cpp
+++ b/test/src/TestFileType.cpp
@@ -2,10 +2,14 @@
 // Copyright The XCSoar Project
 
 #include "Repository/FileType.hpp"
+#include "DataFilePath.hpp"
+#include "LocalPath.hpp"
 #include "system/Path.hpp"
+#include "system/FileUtil.hpp"
 #include "TestUtil.hpp"
 
 #include <cstdint>
+#include <cstdlib>
 
 static constexpr auto N_CONTENT_TYPES =
   static_cast<uint8_t>(FileType::COUNT) - 1;
@@ -123,18 +127,76 @@ TestLayoutClassification()
   ok1(GetLayoutSubdirForFilename("waypoints.cup") == Path("waypoints"));
   ok1(GetLayoutSubdirForFilename("zone.openair") == Path("airspace"));
   ok1(GetLayoutSubdirForFilename("task.tsk") == Path("tasks"));
-  ok1(GetLayoutSubdirForFilename("gfs-rasp-forecast.dat") == Path("weather/rasp"));
+  ok1(GetLayoutSubdirForFilename("gfs-rasp-forecast.dat") ==
+      AllocatedPath::Build("weather", "rasp"));
   ok1(GetLayoutSubdirForFilename("track.igc") == Path("logs"));
   ok1(GetLayoutSubdirForFilename("readme.md") == nullptr);
   ok1(GetLayoutSubdirForFilename("profile.prf") == Path("profiles"));
-  ok1(GetLayoutSubdirForFilename("plane.xcp") == Path("profiles/planes"));
+  ok1(GetLayoutSubdirForFilename("plane.xcp") ==
+      AllocatedPath::Build("profiles", "planes"));
   ok1(GetLayoutSubdirForFilename("repository") == Path("cache"));
   ok1(GetLayoutSubdirForFilename("xcsoar.log") == nullptr);
 }
 
+static void
+TestRepositoryTypeStrings()
+{
+  ok1(FileTypeFromRepositoryString("airspace") == FileType::AIRSPACE);
+  ok1(FileTypeFromRepositoryString("waypoint-details") ==
+      FileType::WAYPOINTDETAILS);
+  ok1(FileTypeFromRepositoryString("waypoint") == FileType::WAYPOINT);
+  ok1(FileTypeFromRepositoryString("map") == FileType::MAP);
+  ok1(FileTypeFromRepositoryString("flarmnet") == FileType::FLARMNET);
+  ok1(FileTypeFromRepositoryString("rasp") == FileType::RASP);
+  ok1(FileTypeFromRepositoryString("xci") == FileType::XCI);
+  ok1(FileTypeFromRepositoryString("task") == FileType::TASK);
+  ok1(FileTypeFromRepositoryString("checklist") == FileType::CHECKLIST);
+  ok1(FileTypeFromRepositoryString("unknown") == FileType::UNKNOWN);
+  ok1(FileTypeFromRepositoryString(nullptr) == FileType::UNKNOWN);
+}
+
+static void
+TestDownloadRelativePath()
+{
+  ok1(GetFileTypeDownloadRelativePath(FileType::WAYPOINT, "test.cup") ==
+      Path("waypoints/test.cup"));
+  ok1(GetFileTypeDownloadRelativePath(FileType::WAYPOINT, "../evil.cup") ==
+      nullptr);
+  ok1(TypedDataSavePath(FileType::WAYPOINT, "../evil.cup") == nullptr);
+}
+
+static void
+TestNestedDefaultDirs()
+{
+  ok1(GetFileTypeDefaultDir(FileType::RASP) ==
+      AllocatedPath::Build("weather", "rasp"));
+  ok1(GetFileTypeDefaultDir(FileType::WAYPOINTDETAILS) ==
+      AllocatedPath::Build("waypoints", "details"));
+  ok1(GetFileTypeDefaultDir(FileType::PLANE) ==
+      AllocatedPath::Build("profiles", "planes"));
+}
+
+static void
+TestEnsureFileTypeDownloadDirectory()
+{
+  char template_path[] = "/tmp/xcsoar-download-dir-XXXXXX";
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+
+  const auto rasp_dir = GetFileTypeDefaultDir(FileType::RASP);
+  ok1(!Directory::Exists(LocalPath(rasp_dir)));
+
+  ok1(EnsureFileTypeDownloadDirectory(FileType::RASP));
+  ok1(Directory::Exists(LocalPath(rasp_dir)));
+
+  ok1(GetFileTypeDownloadRelativePath(FileType::RASP, "forecast.dat") ==
+      AllocatedPath::Build(Path(rasp_dir), Path("forecast.dat")));
+}
+
 int main()
 {
-  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 16 + 9 + 12);
+  plan_tests(N_CONTENT_TYPES + 2 + N_CONTENT_TYPES + 2 + 7 + 16 + 9 + 12 +
+             11 + 3 + 3 + 5);
 
   TestDefaultDirs();
   TestPatterns();
@@ -142,6 +204,10 @@ int main()
   TestFilenameMatchesFileType();
   TestDetectFileTypeByFilename();
   TestLayoutClassification();
+  TestRepositoryTypeStrings();
+  TestDownloadRelativePath();
+  TestNestedDefaultDirs();
+  TestEnsureFileTypeDownloadDirectory();
 
   return exit_status();
 }


### PR DESCRIPTION
## Summary

- Add a single `file_type_info` table for filename patterns, data subdirectories, and repository `type = …` strings
- Parse repository entries via `FileTypeFromRepositoryString()` instead of a hardcoded ladder in `Parser.cpp`
- Add shared download helpers (`GetFileTypeDownloadRelativePath()`, `PrepareFileTypeDownloadPath()`) with filename validation, used by `DownloadFilePicker` and `FileManager`
- Route remaining hardcoded `tasks` / `logs` paths through `GetFileTypeDefaultDir()`

Closes #2289

## Test plan

- [x] `make TARGET=UNIX output/UNIX/bin/TestFileType && output/UNIX/bin/TestFileType`
- [x] `output/UNIX/bin/TestRepository`
- [ ] Manual: download a repository file from File Manager and Download File Picker; confirm it lands in the typed subdirectory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Downloads and saved files now use safer, app-defined default folders more consistently across file types.
  * Task files and flight/log exports now follow the same folder rules as the rest of the app.

* **Bug Fixes**
  * Improved handling of unsafe filenames and path traversal attempts during downloads.
  * Fixed file type parsing from repository data for more reliable importing and file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->