### PR TITLE
io/Sqlite.cpp needs sqlite3

### DIFF
--- a/ide/provisioning/install-debian-packages.sh
+++ b/ide/provisioning/install-debian-packages.sh
@@ -32,7 +32,7 @@ install_base() {
     git quilt zip \
     m4 automake wget \
     pkg-config cmake ninja-build ccache \
-    ca-certificates
+    ca-certificates sqlite3
   echo
 }
 


### PR DESCRIPTION
It may not be obvious because most systems (used to build xcsoar) have sqlite anyway, but some systems don't.
Therefor sqlite3 should be in install-debian-packages.sh .
Perhaps also in install-android-tools.sh and/or install-darwin-packages.sh .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `sqlite3` to the set of packages installed during Debian setup, ensuring it is available in the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->