### PR TITLE
Weather: Integrate XCTherm and harden weather overlays

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1063,7 +1063,7 @@ type=key
 data=7
 event=Weather
 event=Mode default
-label=Weather
+label=Weather Setup
 location=6
 
 mode=Info1
@@ -1218,7 +1218,7 @@ mode=Menu
 type=key
 data=5
 event=Mode weather
-label=Weather
+label=Forecast Controls
 location=5
 
 mode=Menu
@@ -1490,7 +1490,7 @@ type=key
 data=0
 event=Weather
 event=Mode default
-label=Weather
+label=Weather Setup
 location=25
 
 mode=RemoteStick

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -290,9 +290,8 @@ location=8
 
 # ------------
 # mode=weather (weather overlay cursor bar)
-# Stick: UP/DOWN altitude, LEFT/RIGHT time, RETURN time auto/manual,
-#        APP6 altitude auto/manual, ESCAPE exit
-# Buttons: 1=Exit, 6=Alt auto, 7=Time+, 8=Time-, 9=Alt+, 10=Alt-
+# Stick: UP/DOWN altitude, LEFT/RIGHT time, RETURN time picker, ESCAPE exit
+# Buttons: 1=Exit, 7=Time+, 8=Time-, 9=Alt+, 10=Alt-
 # ------------
 
 mode=weather
@@ -318,14 +317,7 @@ event=WeatherOverlay time +
 mode=weather
 type=key
 data=RETURN
-event=WeatherOverlay time auto show
-event=WeatherOverlay time auto toggle
-
-mode=weather
-type=key
-data=APP6
-event=WeatherOverlay altitude auto show
-event=WeatherOverlay altitude auto toggle
+event=WeatherOverlay time picker
 
 mode=weather
 type=key
@@ -338,14 +330,6 @@ data=0
 event=Mode default
 label=Exit\n(ESC)
 location=1
-
-mode=weather
-type=key
-data=0
-event=WeatherOverlay altitude auto show
-event=WeatherOverlay altitude auto toggle
-label=Alt\nauto
-location=6
 
 mode=weather
 type=key

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1218,7 +1218,7 @@ mode=Menu
 type=key
 data=5
 event=Mode weather
-label=Forecast Controls
+label=Weather
 location=5
 
 mode=Menu

--- a/build/libclient.mk
+++ b/build/libclient.mk
@@ -3,7 +3,10 @@ ifeq ($(HAVE_HTTP),y)
 # network services.
 
 LIBCLIENT_SOURCES = \
+	$(SRC)/net/client/auth/JwtBearerSession.cpp \
+	$(SRC)/net/client/SyncHttp.cpp \
 	$(SRC)/net/client/tim/Client.cpp \
+	$(SRC)/net/client/xctherm/Http.cpp \
 	$(SRC)/net/client/WeGlide/AircraftCache.cpp \
 	$(SRC)/net/client/WeGlide/AircraftList.cpp \
 	$(SRC)/net/client/WeGlide/Error.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -136,6 +136,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Settings/Panels/TimeConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WeatherConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/XCThermConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WeGlideConfigPanel.cpp \
 	\
 	$(SRC)/Dialogs/Task/Widgets/ObservationZoneEditWidget.cpp \
@@ -702,6 +703,17 @@ XCSOAR_SOURCES += \
 	$(SRC)/Weather/NOAADownloader.cpp \
 	$(SRC)/Weather/NOAAStore.cpp \
 	$(SRC)/Weather/NOAAUpdater.cpp \
+	$(SRC)/Weather/xctherm/XCThermAPI.cpp \
+	$(SRC)/Weather/xctherm/XCThermDownload.cpp \
+	$(SRC)/Weather/xctherm/XCThermDownloadGlue.cpp \
+	$(SRC)/Weather/xctherm/XCThermGeoJSON.cpp \
+	$(SRC)/Weather/xctherm/XCThermGeoQuery.cpp \
+	$(SRC)/Weather/xctherm/XCThermGeoJSONOverlay.cpp \
+	$(SRC)/Weather/xctherm/XCThermMapOverlay.cpp \
+	$(SRC)/Weather/xctherm/XCThermCatalog.cpp \
+	$(SRC)/Weather/xctherm/XCThermForecastTime.cpp \
+	$(SRC)/Weather/xctherm/XCThermControlsModel.cpp \
+	$(SRC)/Weather/xctherm/XCThermAutoSwitch.cpp \
 
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Settings/Panels/TrackingConfigPanel.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -182,6 +182,8 @@ endif
 
 ifeq ($(HAVE_HTTP),y)
 DIALOG_SOURCES += \
+	$(SRC)/Dialogs/Weather/XCThermDialog.cpp \
+	$(SRC)/Dialogs/Weather/WeatherCredentialGateWidget.cpp \
 	$(SRC)/Dialogs/Weather/PCMetDialog.cpp \
 	$(SRC)/Dialogs/Weather/NOAAList.cpp \
 	$(SRC)/Dialogs/Weather/NOAADetails.cpp

--- a/build/main.mk
+++ b/build/main.mk
@@ -124,6 +124,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Settings/Panels/MapDisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/NetworkConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/PagesConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/RaspConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/RouteConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/SiteConfigPanel.cpp \
@@ -136,7 +137,8 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Settings/Panels/TimeConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WeatherConfigPanel.cpp \
-	$(SRC)/Dialogs/Settings/Panels/XCThermConfigPanel.cpp \
+	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/PCMetConfigPanel.cpp) \
+	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/XCThermConfigPanel.cpp) \
 	$(SRC)/Dialogs/Settings/Panels/WeGlideConfigPanel.cpp \
 	\
 	$(SRC)/Dialogs/Task/Widgets/ObservationZoneEditWidget.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -168,6 +168,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/DateEntry.cpp \
 	$(SRC)/Dialogs/GeoPointEntry.cpp \
 	$(SRC)/Dialogs/Weather/WeatherDialog.cpp \
+	$(SRC)/Dialogs/Weather/OverlayPageActions.cpp \
 	$(SRC)/Dialogs/Weather/RASPDialog.cpp \
 	$(SRC)/Dialogs/dlgCredits.cpp \
 	$(SRC)/Dialogs/dlgQuickGuide.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -93,7 +93,7 @@ TEST_NAMES = \
 	TestLogger TestGRecord TestClimbAvCalc TestFilteredVarioComputer \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
-	TestColorRamp TestGeoPoint TestDiffFilter \
+	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
 	TestFileUtil TestRepository TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
@@ -856,6 +856,13 @@ TEST_COLOR_RAMP_SOURCES = \
 	$(TEST_SRC_DIR)/TestColorRamp.cpp
 TEST_COLOR_RAMP_CPPFLAGS = $(SCREEN_CPPFLAGS)
 $(eval $(call link-program,TestColorRamp,TEST_COLOR_RAMP))
+
+TEST_XCTHERM_BAND_QUERY_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(SRC)/Weather/xctherm/XCThermGeoQuery.cpp \
+	$(TEST_SRC_DIR)/TestXCThermBandQuery.cpp
+TEST_XCTHERM_BAND_QUERY_DEPENDS = GEO MATH
+$(eval $(call link-program,TestXCThermBandQuery,TEST_XCTHERM_BAND_QUERY))
 
 TEST_SUN_EPHEMERIS_SOURCES = \
 	$(SRC)/Math/SunEphemeris.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -225,6 +225,7 @@ TEST_NAMES += TestWeatherOverlayPagePlacement
 
 TEST_WEATHER_OVERLAY_PAGE_PLACEMENT_SOURCES = \
 	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestWeatherOverlayPagePlacement.cpp
 TEST_WEATHER_OVERLAY_PAGE_PLACEMENT_DEPENDS = TIME UTIL

--- a/build/test.mk
+++ b/build/test.mk
@@ -221,6 +221,15 @@ TEST_WEATHER_UI_STATE_SOURCES = \
 TEST_WEATHER_UI_STATE_DEPENDS = TIME UTIL
 $(eval $(call link-program,TestWeatherUIState,TEST_WEATHER_UI_STATE))
 
+TEST_NAMES += TestWeatherOverlayPagePlacement
+
+TEST_WEATHER_OVERLAY_PAGE_PLACEMENT_SOURCES = \
+	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestWeatherOverlayPagePlacement.cpp
+TEST_WEATHER_OVERLAY_PAGE_PLACEMENT_DEPENDS = TIME UTIL
+$(eval $(call link-program,TestWeatherOverlayPagePlacement,TEST_WEATHER_OVERLAY_PAGE_PLACEMENT))
+
 ifeq ($(HAVE_HTTP),y)
 TEST_NAMES += TestEDL
 

--- a/doc/weather_overlays.rst
+++ b/doc/weather_overlays.rst
@@ -121,3 +121,24 @@ Common pitfalls
 - performing UI operations from non-UI threads
 - adding provider logic without tests for enter/leave/suspend/resume
 
+Page placement UX
+-----------------
+
+Weather dialogs provide two placement actions:
+
+- ``Add to page`` updates the currently configured page and replaces any
+  existing weather overlay on that page.
+- ``Add new page`` clones the currently configured page, forces map main,
+  applies the selected overlay, and appends the clone as a new configured
+  page.
+
+Both actions:
+
+- set ``bottom = WEATHER_CONTROLS`` so the shared weather cursor bar is active
+- persist page layout changes to the profile immediately
+- clear provider cursor initialization so first-enter behavior
+  is reapplied consistently
+
+When the page limit (``PageSettings::MAX_PAGES``) is reached, ``Add new page``
+must fail without mutating existing pages, and the UI must show a clear
+message.

--- a/src/Dialogs/Settings/Panels/PCMetConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PCMetConfigPanel.cpp
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "PCMetConfigPanel.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Weather/Settings.hpp"
+#include "Weather/Features.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Interface.hpp"
+#include "UIGlobals.hpp"
+#include "Language/Language.hpp"
+
+enum ControlIndex {
+#ifdef HAVE_PCMET
+  PCMET_USER,
+  PCMET_PASSWORD,
+#endif
+};
+
+class PCMetConfigPanel final : public RowFormWidget {
+public:
+  PCMetConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+public:
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+void
+PCMetConfigPanel::Prepare(ContainerWindow &parent,
+                          const PixelRect &rc) noexcept
+{
+#ifdef HAVE_PCMET
+  const auto &settings = CommonInterface::GetComputerSettings().weather;
+#endif
+
+  RowFormWidget::Prepare(parent, rc);
+
+#ifdef HAVE_PCMET
+  AddText(_("pc_met Username"), "",
+          settings.pcmet.www_credentials.username);
+  AddPassword(_("pc_met Password"), "",
+              settings.pcmet.www_credentials.password);
+#endif
+}
+
+bool
+PCMetConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+#ifdef HAVE_PCMET
+  auto &settings = CommonInterface::SetComputerSettings().weather;
+
+  changed |= SaveValue(PCMET_USER, ProfileKeys::PCMetUsername,
+                       settings.pcmet.www_credentials.username);
+
+  changed |= SaveValue(PCMET_PASSWORD, ProfileKeys::PCMetPassword,
+                       settings.pcmet.www_credentials.password);
+#endif
+
+  _changed |= changed;
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreatePCMetConfigPanel()
+{
+  return std::make_unique<PCMetConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/PCMetConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/PCMetConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreatePCMetConfigPanel();

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -279,7 +279,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
     { PageLayout::Bottom::NOTHING, N_("Nothing") },
     { PageLayout::Bottom::CROSS_SECTION, N_("Cross section") },
 #if defined(HAVE_EDL) || defined(ENABLE_OPENGL)
-    { PageLayout::Bottom::EDL_CONTROLS, N_("Weather controls") },
+    { PageLayout::Bottom::WEATHER_CONTROLS, N_("Weather controls") },
 #endif
     nullptr
   };
@@ -364,7 +364,7 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     value.bottom = (PageLayout::Bottom)dfe.GetValue();
 
-    if (value.bottom == PageLayout::Bottom::EDL_CONTROLS &&
+    if (value.bottom == PageLayout::Bottom::WEATHER_CONTROLS &&
         value.IsMapMain() &&
         !value.UsesWeatherOverlay()) {
 #ifdef HAVE_EDL

--- a/src/Dialogs/Settings/Panels/RaspConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/RaspConfigPanel.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RaspConfigPanel.hpp"
+#include "Dialogs/Weather/RASPDialog.hpp"
+#include "Widget/Widget.hpp"
+
+std::unique_ptr<Widget>
+CreateRaspConfigPanel() noexcept
+{
+  return CreateRaspWidget();
+}

--- a/src/Dialogs/Settings/Panels/RaspConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/RaspConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateRaspConfigPanel() noexcept;

--- a/src/Dialogs/Settings/Panels/WeatherConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WeatherConfigPanel.cpp
@@ -5,24 +5,13 @@
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Weather/Settings.hpp"
-#include "Weather/Features.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "net/http/Features.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
-#include "util/NumberParser.hpp"
 
 enum ControlIndex {
-#ifdef HAVE_PCMET
-  PCMET_USER,
-  PCMET_PASSWORD,
-#if 0
-  PCMET_FTP_USER,
-  PCMET_FTP_PASSWORD,
-#endif
-#endif
-
 #ifdef HAVE_HTTP
   ENABLE_TIM,
 #endif
@@ -44,29 +33,14 @@ void
 WeatherConfigPanel::Prepare(ContainerWindow &parent,
                             const PixelRect &rc) noexcept
 {
-#if defined(HAVE_PCMET) || defined(HAVE_HTTP)
+#ifdef HAVE_HTTP
   const auto &settings = CommonInterface::GetComputerSettings().weather;
 #endif
 
   RowFormWidget::Prepare(parent, rc);
 
-#ifdef HAVE_PCMET
-  AddText("pc_met Username", "",
-          settings.pcmet.www_credentials.username);
-  AddPassword("pc_met Password", "",
-              settings.pcmet.www_credentials.password);
-
-#if 0
-  // code disabled because DWD has terminated our access */
-  AddText("pc_met FTP Username", "",
-          settings.pcmet.ftp_credentials.username);
-  AddPassword("pc_met FTP Password", "",
-              settings.pcmet.ftp_credentials.password);
-#endif
-#endif
-
 #ifdef HAVE_HTTP
-  AddBoolean("Thermal Information Map",
+  AddBoolean(_("Thermal Information Map"),
              _("Show thermal locations downloaded from Thermal Information Map (thermalmap.info)."),
              settings.enable_tim);
 #endif
@@ -77,25 +51,8 @@ WeatherConfigPanel::Save(bool &_changed) noexcept
 {
   bool changed = false;
 
-#if defined(HAVE_PCMET) || defined(HAVE_HTTP)
+#ifdef HAVE_HTTP
   auto &settings = CommonInterface::SetComputerSettings().weather;
-#endif
-
-#ifdef HAVE_PCMET
-  changed |= SaveValue(PCMET_USER, ProfileKeys::PCMetUsername,
-                       settings.pcmet.www_credentials.username);
-
-  changed |= SaveValue(PCMET_PASSWORD, ProfileKeys::PCMetPassword,
-                       settings.pcmet.www_credentials.password);
-
-#if 0
-  // code disabled because DWD has terminated our access */
-  changed |= SaveValue(PCMET_FTP_USER, ProfileKeys::PCMetFtpUsername,
-                       settings.pcmet.ftp_credentials.username);
-
-  changed |= SaveValue(PCMET_FTP_PASSWORD, ProfileKeys::PCMetFtpPassword,
-                       settings.pcmet.ftp_credentials.password);
-#endif
 #endif
 
 #ifdef HAVE_HTTP

--- a/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermConfigPanel.hpp"
+
+#ifdef HAVE_HTTP
+
+#include "Form/DataField/Enum.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Weather/Settings.hpp"
+#include "Weather/xctherm/XCThermAPI.hpp"
+#include "Weather/xctherm/XCThermCatalog.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+
+enum ControlIndex {
+  XCTHERM_EMAIL,
+  XCTHERM_PASSWORD,
+  XCTHERM_REGION,
+  XCTHERM_AUTO_SWITCH,
+};
+
+static constexpr StaticEnumChoice xctherm_region_list[] = {
+  { unsigned(XCTherm::Region::CH), N_("CH (Alps)"),
+    N_("Covers the entire Alpine arc from Vienna to Perpignan, "
+       "forecasting wave throughout the whole Alps region. "
+       "ICON-CH model.") },
+  { unsigned(XCTherm::Region::UK), N_("UK"),
+    N_("United Kingdom. ICON-UK model.") },
+  nullptr
+};
+
+class XCThermConfigPanel final : public RowFormWidget {
+public:
+  XCThermConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+void
+XCThermConfigPanel::Prepare(ContainerWindow &parent,
+                           const PixelRect &rc) noexcept
+{
+  const auto &settings = CommonInterface::GetComputerSettings().weather;
+
+  RowFormWidget::Prepare(parent, rc);
+
+  AddText(_("XCTherm email"),
+          _("Email address for your XCTherm account."),
+          settings.xctherm.credentials.email);
+
+  AddPassword(_("XCTherm password"),
+              _("Password for your XCTherm account."),
+              settings.xctherm.credentials.password);
+
+  AddEnum(_("XCTherm region"),
+          _("Forecast region. Changes which model XCTherm fetches data "
+            "from. Restart or re-download after changing."),
+          xctherm_region_list,
+          settings.xctherm.model);
+
+  AddBoolean(_("XCTherm Auto Layer/Time"),
+             _("Automatically switch altitude layer based on GPS altitude "
+               "and forecast time based on UTC clock."),
+             settings.xctherm.auto_switch);
+}
+
+bool
+XCThermConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+  auto &settings = CommonInterface::SetComputerSettings().weather;
+
+  changed |= SaveValue(XCTHERM_AUTO_SWITCH,
+                       ProfileKeys::XCThermAutoSwitch,
+                       settings.xctherm.auto_switch);
+
+  changed |= SaveValue(XCTHERM_EMAIL, ProfileKeys::XCThermEmail,
+                       settings.xctherm.credentials.email);
+
+  changed |= SaveValue(XCTHERM_PASSWORD, ProfileKeys::XCThermPassword,
+                       settings.xctherm.credentials.password);
+
+  changed |= SaveValueEnum(XCTHERM_REGION, ProfileKeys::XCThermModel,
+                           settings.xctherm.model);
+
+  XCThermAPI::Instance().ApplySessionSettings(settings.xctherm);
+
+  _changed |= changed;
+
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateXCThermConfigPanel()
+{
+  return std::make_unique<XCThermConfigPanel>();
+}
+
+#endif /* HAVE_HTTP */

--- a/src/Dialogs/Settings/Panels/XCThermConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/XCThermConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateXCThermConfigPanel();

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -64,6 +64,9 @@
 #if defined(HAVE_PCMET) || defined(HAVE_HTTP)
 #include "Panels/WeatherConfigPanel.hpp"
 #endif
+#ifdef HAVE_HTTP
+#include "Panels/XCThermConfigPanel.hpp"
+#endif
 
 #include "Panels/WeGlideConfigPanel.hpp"
 #include "Panels/NetworkConfigPanel.hpp"
@@ -137,6 +140,9 @@ static constexpr TabMenuPage setup_pages[] = {
 #endif
 #if defined(HAVE_PCMET) || defined(HAVE_HTTP)
   { N_("Weather"), CreateWeatherConfigPanel },
+#endif
+#ifdef HAVE_HTTP
+  { N_("XCTherm"), CreateXCThermConfigPanel },
 #endif
   { "WeGlide", CreateWeGlideConfigPanel },
 #ifdef HAVE_VOLUME_CONTROLLER

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -137,10 +137,10 @@ static constexpr TabMenuPage weather_pages[] = {
 #endif
   { "RASP", CreateRaspConfigPanel },
 #ifdef HAVE_PCMET
-  { N_("Flugwetter (pc_met)"), CreatePCMetConfigPanel },
+  { "Flugwetter (pc_met)", CreatePCMetConfigPanel },
 #endif
 #ifdef HAVE_HTTP
-  { N_("XCTherm"), CreateXCThermConfigPanel },
+  { "XCTherm", CreateXCThermConfigPanel },
 #endif
   { nullptr, nullptr }
 };

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -61,8 +61,12 @@
 #include "Panels/CloudConfigPanel.hpp"
 #endif
 
-#if defined(HAVE_PCMET) || defined(HAVE_HTTP)
+#ifdef HAVE_HTTP
 #include "Panels/WeatherConfigPanel.hpp"
+#endif
+#include "Panels/RaspConfigPanel.hpp"
+#ifdef HAVE_PCMET
+#include "Panels/PCMetConfigPanel.hpp"
 #endif
 #ifdef HAVE_HTTP
 #include "Panels/XCThermConfigPanel.hpp"
@@ -127,6 +131,20 @@ static constexpr TabMenuPage look_pages[] = {
   { nullptr, nullptr }
 };
 
+static constexpr TabMenuPage weather_pages[] = {
+#ifdef HAVE_HTTP
+  { N_("Thermal Information Map"), CreateWeatherConfigPanel },
+#endif
+  { "RASP", CreateRaspConfigPanel },
+#ifdef HAVE_PCMET
+  { N_("Flugwetter (pc_met)"), CreatePCMetConfigPanel },
+#endif
+#ifdef HAVE_HTTP
+  { N_("XCTherm"), CreateXCThermConfigPanel },
+#endif
+  { nullptr, nullptr }
+};
+
 static constexpr TabMenuPage setup_pages[] = {
   { N_("Logger"), CreateLoggerConfigPanel },
   { N_("Units"), CreateUnitsConfigPanel },
@@ -137,12 +155,6 @@ static constexpr TabMenuPage setup_pages[] = {
 #ifdef HAVE_TRACKING
   { N_("Tracking"), CreateTrackingConfigPanel },
   { "XCSoar Cloud", CreateCloudConfigPanel },
-#endif
-#if defined(HAVE_PCMET) || defined(HAVE_HTTP)
-  { N_("Weather"), CreateWeatherConfigPanel },
-#endif
-#ifdef HAVE_HTTP
-  { N_("XCTherm"), CreateXCThermConfigPanel },
 #endif
   { "WeGlide", CreateWeGlideConfigPanel },
 #ifdef HAVE_VOLUME_CONTROLLER
@@ -159,6 +171,7 @@ static constexpr TabMenuGroup main_menu_captions[] = {
   { N_("Gauges"), gauge_pages },
   { N_("Task Defaults"), task_pages },
   { N_("Look"), look_pages },
+  { N_("Weather"), weather_pages },
   { N_("Setup"), setup_pages },
 };
 

--- a/src/Dialogs/Weather/EdlSettingsWidget.cpp
+++ b/src/Dialogs/Weather/EdlSettingsWidget.cpp
@@ -4,6 +4,7 @@
 #include "EdlSettingsWidget.hpp"
 
 #include "Dialogs/Message.hpp"
+#include "OverlayPageActions.hpp"
 #include "Components.hpp"
 #include "NetComponents.hpp"
 #include "Form/Button.hpp"
@@ -63,6 +64,8 @@ class EdlSettingsWidget final
   unsigned cached_day_row = unsigned(-1);
   Button *precache_day_button = nullptr;
   Button *clean_other_days_button = nullptr;
+  Button *add_to_current_button = nullptr;
+  Button *add_to_new_page_button = nullptr;
 #ifdef HAVE_EDL
   EDL::DownloadGlue *edl_listener_glue = nullptr;
 #endif
@@ -89,6 +92,8 @@ private:
   void RefreshControls();
   void PrecacheDay();
   void CleanOtherDays();
+  void AddToCurrentPage();
+  void AddToNewPage();
 
 #ifdef HAVE_EDL
   void OnDownloadFinished(const EDL::DownloadNotification &notification) noexcept override;
@@ -162,6 +167,10 @@ EdlSettingsWidget::Prepare(ContainerWindow &parent,
 
   clean_other_days_button = AddButton(_("Clean other days"),
                                       [this]{ CleanOtherDays(); });
+  add_to_current_button = AddButton(_("Add to page"),
+                                    [this]{ AddToCurrentPage(); });
+  add_to_new_page_button = AddButton(_("Add new page"),
+                                     [this]{ AddToNewPage(); });
 }
 
 void
@@ -195,6 +204,8 @@ EdlSettingsWidget::Unprepare() noexcept
   cached_day_row = unsigned(-1);
   precache_day_button = nullptr;
   clean_other_days_button = nullptr;
+  add_to_current_button = nullptr;
+  add_to_new_page_button = nullptr;
   cached_days.clear();
   RowFormWidget::Unprepare();
 }
@@ -247,6 +258,20 @@ EdlSettingsWidget::CleanOtherDays()
   StaticString<64> result;
   result.Format(_("Deleted %u cached files."), deleted);
   ShowMessageBox(result, _("Weather"), MB_OK);
+}
+
+void
+EdlSettingsWidget::AddToCurrentPage()
+{
+  WeatherDialogOverlayActions::AddOverlayToCurrentPage(
+    PageLayout::Overlay::EDL);
+}
+
+void
+EdlSettingsWidget::AddToNewPage()
+{
+  WeatherDialogOverlayActions::AddOverlayToNewPage(
+    PageLayout::Overlay::EDL);
 }
 
 std::unique_ptr<Widget>

--- a/src/Dialogs/Weather/OverlayPageActions.cpp
+++ b/src/Dialogs/Weather/OverlayPageActions.cpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "OverlayPageActions.hpp"
+
+#include "Dialogs/Message.hpp"
+#include "Language/Language.hpp"
+#include "PageActions.hpp"
+
+namespace WeatherDialogOverlayActions {
+
+bool
+AddOverlayToCurrentPage(PageLayout::Overlay overlay, int rasp_field) noexcept
+{
+  const auto result =
+    PageActions::AddWeatherOverlayToCurrentPage(overlay, rasp_field);
+  if (result == PageActions::ConfigureWeatherOverlayResult::PAGE_LIMIT_REACHED)
+    ShowMessageBox(_("Cannot add another weather page (page limit reached)."),
+                   _("Weather"), MB_OK);
+
+  return result == PageActions::ConfigureWeatherOverlayResult::APPLIED_CURRENT ||
+         result == PageActions::ConfigureWeatherOverlayResult::ADDED_PAGE;
+}
+
+bool
+AddOverlayToNewPage(PageLayout::Overlay overlay, int rasp_field) noexcept
+{
+  const auto result =
+    PageActions::AddWeatherOverlayToNewPage(overlay, rasp_field);
+  if (result == PageActions::ConfigureWeatherOverlayResult::PAGE_LIMIT_REACHED)
+    ShowMessageBox(_("Cannot add another weather page (page limit reached)."),
+                   _("Weather"), MB_OK);
+
+  return result == PageActions::ConfigureWeatherOverlayResult::ADDED_PAGE ||
+         result == PageActions::ConfigureWeatherOverlayResult::APPLIED_CURRENT;
+}
+
+} // namespace WeatherDialogOverlayActions

--- a/src/Dialogs/Weather/OverlayPageActions.hpp
+++ b/src/Dialogs/Weather/OverlayPageActions.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "PageSettings.hpp"
+
+namespace WeatherDialogOverlayActions {
+
+bool
+AddOverlayToCurrentPage(PageLayout::Overlay overlay,
+                        int rasp_field=-1) noexcept;
+
+bool
+AddOverlayToNewPage(PageLayout::Overlay overlay,
+                    int rasp_field=-1) noexcept;
+
+} // namespace WeatherDialogOverlayActions

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -3,6 +3,8 @@
 
 #include "PCMetDialog.hpp"
 #include "Dialogs/Message.hpp"
+#include "WeatherCredentialGateWidget.hpp"
+#include "Dialogs/Settings/Panels/WeatherConfigPanel.hpp"
 #include "Language/Language.hpp"
 #include "Weather/Features.hpp"
 
@@ -302,19 +304,26 @@ protected:
 };
 
 std::unique_ptr<Widget>
-CreatePCMetWidget()
+CreatePCMetMainWidget()
 {
-  const auto &settings = CommonInterface::GetComputerSettings().weather.pcmet;
-  if (!settings.www_credentials.IsDefined())
-    return std::make_unique<LargeTextWidget>(UIGlobals::GetDialogLook(),
-                                             "No account was configured.");
-
   auto area_widget = std::make_unique<ImageAreaListWidget>();
   auto type_widget = std::make_unique<ImageTypeListWidget>(*area_widget);
 
   return std::make_unique<TwoWidgets>(std::move(type_widget),
                                       std::move(area_widget),
                                       false);
+}
+
+std::unique_ptr<Widget>
+CreatePCMetWidget()
+{
+  return CreateWeatherCredentialGateWidget(
+    []() {
+      return CommonInterface::GetComputerSettings()
+        .weather.pcmet.www_credentials.IsDefined();
+    },
+    CreateWeatherConfigPanel,
+    CreatePCMetMainWidget);
 }
 
 #endif  // HAVE_PCMET

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -3,8 +3,6 @@
 
 #include "PCMetDialog.hpp"
 #include "Dialogs/Message.hpp"
-#include "WeatherCredentialGateWidget.hpp"
-#include "Dialogs/Settings/Panels/WeatherConfigPanel.hpp"
 #include "Language/Language.hpp"
 #include "Weather/Features.hpp"
 
@@ -312,18 +310,6 @@ CreatePCMetMainWidget()
   return std::make_unique<TwoWidgets>(std::move(type_widget),
                                       std::move(area_widget),
                                       false);
-}
-
-std::unique_ptr<Widget>
-CreatePCMetWidget()
-{
-  return CreateWeatherCredentialGateWidget(
-    []() {
-      return CommonInterface::GetComputerSettings()
-        .weather.pcmet.www_credentials.IsDefined();
-    },
-    CreateWeatherConfigPanel,
-    CreatePCMetMainWidget);
 }
 
 #endif  // HAVE_PCMET

--- a/src/Dialogs/Weather/PCMetDialog.hpp
+++ b/src/Dialogs/Weather/PCMetDialog.hpp
@@ -8,7 +8,4 @@
 class Widget;
 
 std::unique_ptr<Widget>
-CreatePCMetWidget();
-
-std::unique_ptr<Widget>
 CreatePCMetMainWidget();

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -4,10 +4,13 @@
 #include "RASPDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Weather/Rasp/Configured.hpp"
+#include "Weather/Rasp/FieldControls.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
+#include "OverlayPageActions.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Form/Button.hpp"
+#include "Form/DataField/Enum.hpp"
 #include "Form/Edit.hpp"
 #include "Repository/FileType.hpp"
 #include "DataGlobals.hpp"
@@ -27,9 +30,11 @@ class RASPSettingsPanel final
   enum Controls {
     FILE,
     MODIFIED,
+    LAYER,
   };
 
   std::shared_ptr<RaspStore> rasp;
+  int selected_field = -1;
 
 #ifdef HAVE_DOWNLOAD_MANAGER
   Button *update_button = nullptr;
@@ -37,7 +42,11 @@ class RASPSettingsPanel final
 
   void ReloadRasp();
   void UpdateModifiedDisplay();
+  void UpdateLayerControl();
+  int GetPlacementFieldIndex() const noexcept;
   void UpdateClicked();
+  void AddToCurrentClicked();
+  void AddToNewPageClicked();
 
 public:
   explicit RASPSettingsPanel(std::shared_ptr<RaspStore> &&_rasp) noexcept
@@ -56,6 +65,7 @@ RASPSettingsPanel::ReloadRasp()
   RaspFileChanged = true;
   Profile::Save();
   UpdateModifiedDisplay();
+  UpdateLayerControl();
 }
 
 void
@@ -79,11 +89,59 @@ RASPSettingsPanel::UpdateModifiedDisplay()
 }
 
 void
+RASPSettingsPanel::UpdateLayerControl()
+{
+  auto &control = GetControl(LAYER);
+  auto &df = (DataFieldEnum &)*control.GetDataField();
+  df.ClearChoices();
+
+  if (rasp == nullptr || rasp->GetItemCount() == 0) {
+    df.AddChoice(-1, _("No RASP file loaded"));
+    df.SetValue(-1);
+    selected_field = -1;
+    control.SetEnabled(false);
+    control.RefreshDisplay();
+    return;
+  }
+
+  Rasp::FillFieldChoices(df, rasp.get());
+
+  if (selected_field < 0 || unsigned(selected_field) >= rasp->GetItemCount())
+    selected_field = 0;
+
+  df.SetValue(selected_field);
+  control.SetEnabled(true);
+  control.RefreshDisplay();
+}
+
+void
 RASPSettingsPanel::UpdateClicked()
 {
 #ifdef HAVE_DOWNLOAD_MANAGER
   RequestConfiguredRaspUpdate();
 #endif
+}
+
+int
+RASPSettingsPanel::GetPlacementFieldIndex() const noexcept
+{
+  return selected_field >= 0
+    ? selected_field
+    : Rasp::GetActiveFieldIndex();
+}
+
+void
+RASPSettingsPanel::AddToCurrentClicked()
+{
+  WeatherDialogOverlayActions::AddOverlayToCurrentPage(
+    PageLayout::Overlay::RASP, GetPlacementFieldIndex());
+}
+
+void
+RASPSettingsPanel::AddToNewPageClicked()
+{
+  WeatherDialogOverlayActions::AddOverlayToNewPage(
+    PageLayout::Overlay::RASP, GetPlacementFieldIndex());
 }
 
 void
@@ -105,11 +163,21 @@ RASPSettingsPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
               _("Local date and time of the selected RASP file."));
   UpdateModifiedDisplay();
 
+  auto *layer = AddEnum(_("Layer"),
+                        _("RASP layer used when adding the overlay to pages."));
+  layer->GetDataField()->SetOnModified([this, layer]{
+    selected_field = ((DataFieldEnum &)*layer->GetDataField()).GetValue();
+  });
+  UpdateLayerControl();
+
 #ifdef HAVE_DOWNLOAD_MANAGER
   update_button = AddButton(_("Update"), [this]{ UpdateClicked(); });
   if (!Net::DownloadManager::IsAvailable())
     update_button->SetEnabled(false);
 #endif
+
+  AddButton(_("Add to page"), [this]{ AddToCurrentClicked(); });
+  AddButton(_("Add new page"), [this]{ AddToNewPageClicked(); });
 }
 
 bool

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -96,15 +96,18 @@ RASPSettingsPanel::UpdateLayerControl()
   df.ClearChoices();
 
   if (rasp == nullptr || rasp->GetItemCount() == 0) {
-    df.AddChoice(-1, _("No RASP file loaded"));
+    df.AddChoice(-1, "none", _("None"), nullptr);
+    df.AddChoice(-2, _("No RASP file loaded"));
     df.SetValue(-1);
     selected_field = -1;
-    control.SetEnabled(false);
+    control.SetEnabled(true);
     control.RefreshDisplay();
     return;
   }
 
-  Rasp::FillFieldChoices(df, rasp.get());
+  Rasp::FieldChoicesOptions options;
+  options.include_none = true;
+  Rasp::FillFieldChoices(df, rasp.get(), options);
 
   if (selected_field < 0 || unsigned(selected_field) >= rasp->GetItemCount())
     selected_field = 0;
@@ -133,6 +136,12 @@ RASPSettingsPanel::GetPlacementFieldIndex() const noexcept
 void
 RASPSettingsPanel::AddToCurrentClicked()
 {
+  if (GetPlacementFieldIndex() < 0) {
+    WeatherDialogOverlayActions::AddOverlayToCurrentPage(
+      PageLayout::Overlay::NONE);
+    return;
+  }
+
   WeatherDialogOverlayActions::AddOverlayToCurrentPage(
     PageLayout::Overlay::RASP, GetPlacementFieldIndex());
 }
@@ -140,6 +149,12 @@ RASPSettingsPanel::AddToCurrentClicked()
 void
 RASPSettingsPanel::AddToNewPageClicked()
 {
+  if (GetPlacementFieldIndex() < 0) {
+    WeatherDialogOverlayActions::AddOverlayToNewPage(
+      PageLayout::Overlay::NONE);
+    return;
+  }
+
   WeatherDialogOverlayActions::AddOverlayToNewPage(
     PageLayout::Overlay::RASP, GetPlacementFieldIndex());
 }

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -97,10 +97,9 @@ RASPSettingsPanel::UpdateLayerControl()
 
   if (rasp == nullptr || rasp->GetItemCount() == 0) {
     df.AddChoice(-1, "none", _("None"), nullptr);
-    df.AddChoice(-2, _("No RASP file loaded"));
     df.SetValue(-1);
     selected_field = -1;
-    control.SetEnabled(true);
+    control.SetEnabled(false);
     control.RefreshDisplay();
     return;
   }
@@ -128,9 +127,7 @@ RASPSettingsPanel::UpdateClicked()
 int
 RASPSettingsPanel::GetPlacementFieldIndex() const noexcept
 {
-  return selected_field >= 0
-    ? selected_field
-    : Rasp::GetActiveFieldIndex();
+  return selected_field;
 }
 
 void

--- a/src/Dialogs/Weather/WeatherCredentialGateWidget.cpp
+++ b/src/Dialogs/Weather/WeatherCredentialGateWidget.cpp
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "WeatherCredentialGateWidget.hpp"
+
+#include "Dialogs/Message.hpp"
+#include "Form/Button.hpp"
+#include "Form/ButtonPanel.hpp"
+#include "Language/Language.hpp"
+#include "Look/DialogLook.hpp"
+#include "Profile/Profile.hpp"
+#include "UIGlobals.hpp"
+#include "Widget/ButtonPanelWidget.hpp"
+#include "Widget/VScrollWidget.hpp"
+
+#include <algorithm>
+
+class WeatherCredentialGateWidget final : public Widget {
+  std::function<bool()> credentials_ok;
+  std::function<std::unique_ptr<Widget>()> create_main;
+
+  std::unique_ptr<Widget> setup;
+  std::unique_ptr<Widget> main;
+
+  enum class Phase {
+    Setup,
+    Main,
+  } phase;
+
+  bool initialised = false;
+  bool prepared = false;
+  bool visible = false;
+  bool continue_added = false;
+
+  ContainerWindow *parent = nullptr;
+  PixelRect position;
+
+  Widget &Active() noexcept {
+    return phase == Phase::Setup ? *setup : *main;
+  }
+
+  const Widget &Active() const noexcept {
+    return phase == Phase::Setup ? *setup : *main;
+  }
+
+  void EnsureContinueButton() noexcept;
+  void ContinueClicked() noexcept;
+  void SwitchToMain() noexcept;
+
+  [[gnu::pure]]
+  PixelSize MaxSize(PixelSize a, PixelSize b) const noexcept {
+    return {std::max(a.width, b.width), std::max(a.height, b.height)};
+  }
+
+public:
+  WeatherCredentialGateWidget(std::function<bool()> _credentials_ok,
+                              std::unique_ptr<Widget> (*create_config_panel)(),
+                              std::function<std::unique_ptr<Widget>()> _create_main)
+    :credentials_ok(std::move(_credentials_ok)),
+     create_main(std::move(_create_main)),
+     phase(credentials_ok() ? Phase::Main : Phase::Setup)
+  {
+    const DialogLook &look = UIGlobals::GetDialogLook();
+    auto config_panel = create_config_panel();
+    auto scroll = std::make_unique<VScrollWidget>(std::move(config_panel),
+                                                  look);
+    setup = std::make_unique<ButtonPanelWidget>(
+      std::move(scroll), ButtonPanelWidget::Alignment::BOTTOM);
+    main = create_main();
+  }
+
+  PixelSize GetMinimumSize() const noexcept override {
+    return MaxSize(setup->GetMinimumSize(), main->GetMinimumSize());
+  }
+
+  PixelSize GetMaximumSize() const noexcept override {
+    return MaxSize(setup->GetMaximumSize(), main->GetMaximumSize());
+  }
+
+  void Initialise(ContainerWindow &_parent,
+                  const PixelRect &rc) noexcept override {
+    assert(!initialised);
+
+    initialised = true;
+    parent = &_parent;
+    position = rc;
+
+    setup->Initialise(_parent, rc);
+    main->Initialise(_parent, rc);
+  }
+
+  void Prepare(ContainerWindow &_parent,
+               const PixelRect &rc) noexcept override {
+    assert(initialised);
+    assert(!prepared);
+
+    prepared = true;
+    visible = false;
+    parent = &_parent;
+    position = rc;
+
+    phase = credentials_ok() ? Phase::Main : Phase::Setup;
+
+    if (phase == Phase::Setup) {
+      setup->Prepare(_parent, rc);
+      EnsureContinueButton();
+    } else
+      main->Prepare(_parent, rc);
+  }
+
+  void Unprepare() noexcept override {
+    assert(prepared);
+
+    if (phase == Phase::Setup)
+      setup->Unprepare();
+    else
+      main->Unprepare();
+
+    prepared = false;
+    visible = false;
+  }
+
+  bool Save(bool &changed) noexcept override {
+    assert(prepared);
+    return Active().Save(changed);
+  }
+
+  bool Click() noexcept override {
+    assert(prepared);
+    return Active().Click();
+  }
+
+  void ReClick() noexcept override {
+    assert(prepared);
+    Active().ReClick();
+  }
+
+  void Show(const PixelRect &rc) noexcept override {
+    assert(prepared);
+    assert(!visible);
+
+    visible = true;
+    position = rc;
+    Active().Show(rc);
+  }
+
+  bool Leave() noexcept override {
+    assert(prepared);
+    assert(visible);
+    return Active().Leave();
+  }
+
+  void Hide() noexcept override {
+    assert(prepared);
+    assert(visible);
+
+    Active().Hide();
+    visible = false;
+  }
+
+  void Move(const PixelRect &rc) noexcept override {
+    assert(prepared);
+    assert(visible);
+
+    position = rc;
+    Active().Move(rc);
+  }
+
+  bool SetFocus() noexcept override {
+    assert(prepared);
+    return Active().SetFocus();
+  }
+
+  bool HasFocus() const noexcept override {
+    assert(prepared);
+    return Active().HasFocus();
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    assert(prepared);
+    return Active().KeyPress(key_code);
+  }
+};
+
+void
+WeatherCredentialGateWidget::EnsureContinueButton() noexcept
+{
+  if (continue_added)
+    return;
+
+  auto &buttons_widget = static_cast<ButtonPanelWidget &>(*setup);
+  ButtonPanel &buttons = buttons_widget.GetButtonPanel();
+  buttons.Add(_("Continue"), [this]() { ContinueClicked(); });
+  continue_added = true;
+}
+
+void
+WeatherCredentialGateWidget::ContinueClicked() noexcept
+{
+  bool changed = false;
+  if (!setup->Save(changed))
+    return;
+
+  if (!credentials_ok()) {
+    ShowMessageBox(_("Enter your account details."),
+                   _("Error"), MB_OK);
+    return;
+  }
+
+  if (changed)
+    Profile::Save();
+
+  SwitchToMain();
+}
+
+void
+WeatherCredentialGateWidget::SwitchToMain() noexcept
+{
+  assert(prepared);
+  assert(parent != nullptr);
+
+  if (phase == Phase::Main)
+    return;
+
+  if (visible)
+    setup->Hide();
+  setup->Unprepare();
+
+  phase = Phase::Main;
+  main->Prepare(*parent, position);
+
+  if (visible)
+    main->Show(position);
+}
+
+std::unique_ptr<Widget>
+CreateWeatherCredentialGateWidget(
+  std::function<bool()> credentials_ok,
+  std::unique_ptr<Widget> (*create_config_panel)(),
+  std::function<std::unique_ptr<Widget>()> create_main) noexcept
+{
+  return std::make_unique<WeatherCredentialGateWidget>(
+    std::move(credentials_ok), create_config_panel, std::move(create_main));
+}

--- a/src/Dialogs/Weather/WeatherCredentialGateWidget.hpp
+++ b/src/Dialogs/Weather/WeatherCredentialGateWidget.hpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Widget/Widget.hpp"
+
+#include <functional>
+#include <memory>
+
+/**
+ * Two-phase weather tab: inline credential config, then main UI.
+ */
+std::unique_ptr<Widget>
+CreateWeatherCredentialGateWidget(
+  std::function<bool()> credentials_ok,
+  std::unique_ptr<Widget> (*create_config_panel)(),
+  std::function<std::unique_ptr<Widget>()> create_main) noexcept;

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -59,12 +59,24 @@ CreatePCMetTabWidget() noexcept
 #endif
 
 #ifndef HAVE_EDL
+class EDLUnavailableWidget final : public TextWidget {
+  const char *text;
+
+public:
+  explicit EDLUnavailableWidget(const char *_text) noexcept
+    :text(_text) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override {
+    TextWidget::Prepare(parent, rc);
+    SetText(text);
+  }
+};
+
 static std::unique_ptr<Widget>
 CreateEDLUnavailableWidget() noexcept
 {
-  auto widget = std::make_unique<TextWidget>();
-  widget->SetText(_("EDL weather is not available because this build has no OpenGL renderer."));
-  return widget;
+  return std::make_unique<EDLUnavailableWidget>(
+    _("EDL weather is not available because this build has no OpenGL renderer."));
 }
 #endif
 

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -5,6 +5,7 @@
 #include "NOAAList.hpp"
 #include "RASPDialog.hpp"
 #include "PCMetDialog.hpp"
+#include "Dialogs/Settings/Panels/PCMetConfigPanel.hpp"
 #ifdef HAVE_HTTP
 #include "XCThermDialog.hpp"
 #include "WeatherCredentialGateWidget.hpp"
@@ -53,7 +54,7 @@ CreatePCMetTabWidget() noexcept
       return CommonInterface::GetComputerSettings()
         .weather.pcmet.www_credentials.IsDefined();
     },
-    CreateWeatherConfigPanel,
+    CreatePCMetConfigPanel,
     CreatePCMetMainWidget);
 }
 #endif

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -5,6 +5,12 @@
 #include "NOAAList.hpp"
 #include "RASPDialog.hpp"
 #include "PCMetDialog.hpp"
+#ifdef HAVE_HTTP
+#include "XCThermDialog.hpp"
+#include "WeatherCredentialGateWidget.hpp"
+#include "Dialogs/Settings/Panels/XCThermConfigPanel.hpp"
+#endif
+#include "Dialogs/Settings/Panels/WeatherConfigPanel.hpp"
 #include "Weather/Features.hpp"
 #if 0
 #include "MapOverlayWidget.hpp"
@@ -19,9 +25,38 @@
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
 #include "Language/Language.hpp"
+#include "Interface.hpp"
 #include "util/StaticString.hxx"
 
 static int weather_page = 0;
+
+#ifdef HAVE_HTTP
+static std::unique_ptr<Widget>
+CreateXCThermTabWidget() noexcept
+{
+  return CreateWeatherCredentialGateWidget(
+    []() {
+      return CommonInterface::GetComputerSettings()
+        .weather.xctherm.credentials.IsDefined();
+    },
+    CreateXCThermConfigPanel,
+    CreateXCThermMainWidget);
+}
+#endif
+
+#ifdef HAVE_PCMET
+static std::unique_ptr<Widget>
+CreatePCMetTabWidget() noexcept
+{
+  return CreateWeatherCredentialGateWidget(
+    []() {
+      return CommonInterface::GetComputerSettings()
+        .weather.pcmet.www_credentials.IsDefined();
+    },
+    CreateWeatherConfigPanel,
+    CreatePCMetMainWidget);
+}
+#endif
 
 #ifndef HAVE_EDL
 static std::unique_ptr<Widget>
@@ -73,6 +108,13 @@ ShowWeatherDialog(const char *page)
   widget.AddTab(CreateNOAAListWidget(), _("METAR and TAF"));
 #endif
 
+#ifdef HAVE_HTTP
+  if (page != nullptr && StringIsEqual(page, "xctherm"))
+    start_page = widget.GetSize();
+
+  widget.AddTab(CreateXCThermTabWidget(), "XCTherm");
+#endif
+
   if (page != nullptr && StringIsEqual(page, "rasp"))
     start_page = widget.GetSize();
 
@@ -91,7 +133,7 @@ ShowWeatherDialog(const char *page)
   if (page != nullptr && StringIsEqual(page, "pc_met"))
     start_page = widget.GetSize();
 
-  widget.AddTab(CreatePCMetWidget(), "Flugwetter");
+  widget.AddTab(CreatePCMetTabWidget(), "Flugwetter");
 #endif
 
 #if 0

--- a/src/Dialogs/Weather/XCThermDialog.cpp
+++ b/src/Dialogs/Weather/XCThermDialog.cpp
@@ -364,7 +364,7 @@ XCThermWidget::UpdateList()
   /* Update span button label */
   {
     StaticString<16> span_caption;
-    span_caption.Format("Span: %uh", settings.download_span_hours);
+    span_caption.Format(_("Span: %uh"), settings.download_span_hours);
     span_button->SetCaption(span_caption);
   }
 
@@ -695,8 +695,8 @@ XCThermWidget::FinishDownload()
   std::time_t now = std::time(nullptr);
   std::tm *lt = std::localtime(&now);
   char tbuf[16];
-  std::strftime(tbuf, sizeof(tbuf), "%H:%M:%S", lt);
-  row_info.download_time = tbuf;
+  if (lt != nullptr && std::strftime(tbuf, sizeof(tbuf), "%H:%M:%S", lt) > 0)
+    row_info.download_time = tbuf;
 
   /* Stale-run sweep — but only AFTER the new forecast is successfully
      in the cache and the overlay was swapped above. Older-run entries

--- a/src/Dialogs/Weather/XCThermDialog.cpp
+++ b/src/Dialogs/Weather/XCThermDialog.cpp
@@ -1,0 +1,869 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermDialog.hpp"
+#include "Dialogs/Error.hpp"
+#include "Dialogs/Message.hpp"
+#include "Message.hpp"
+#include "Dialogs/ListPicker.hpp"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "PageActions.hpp"
+#include "Weather/Features.hpp"
+
+#ifdef HAVE_HTTP
+
+#include "UIGlobals.hpp"
+#include "Look/DialogLook.hpp"
+#include "Form/Button.hpp"
+#include "Form/ButtonPanel.hpp"
+#include "Widget/ListWidget.hpp"
+#include "Widget/ButtonPanelWidget.hpp"
+#include "WeatherCredentialGateWidget.hpp"
+#include "Dialogs/Settings/Panels/XCThermConfigPanel.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
+#include "Interface.hpp"
+#include "UIState.hpp"
+#include "Language/Language.hpp"
+#include "Renderer/TextRowRenderer.hpp"
+#include "Renderer/TwoTextRowsRenderer.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+#include "util/StaticString.hxx"
+#include "Weather/xctherm/XCThermAPI.hpp"
+#include "Weather/xctherm/XCThermCatalog.hpp"
+#include "Weather/xctherm/XCThermDownloadGlue.hpp"
+#include "Weather/xctherm/XCThermDownloadJob.hpp"
+#include "Weather/xctherm/XCThermForecastTime.hpp"
+#include "Weather/xctherm/XCThermMapOverlay.hpp"
+#include "LogFile.hpp"
+#include "lib/fmt/ToBuffer.hxx"
+#include "net/http/Init.hpp"
+
+#include <chrono>
+#include <ctime>
+#include <memory>
+
+namespace {
+
+/**
+ * Download metadata for a layer — shown in the second row.
+ * For a span download, sizes/speed are totals across all hourly slices,
+ * span_hours is the number of slices successfully fetched, and
+ * pending_index/pending_total animate progress during the loop.
+ */
+struct LayerDownloadInfo {
+  enum Status { NONE, PENDING, DONE, FAILED, CANCELED };
+  Status status = NONE;
+  double wire_mb = 0.0;           // total bytes over the network
+  double speed_mbs = 0.0;         // average download speed
+  unsigned span_hours = 0;        // hours of forecast cached (incl. reuse)
+  unsigned future_hours = 0;      // cached hours still in the future from now
+  unsigned new_downloads = 0;     // slices newly fetched this run
+  unsigned pending_index = 0;     // current slice being fetched (1-based)
+  unsigned pending_total = 0;     // total slices in this span
+  uint64_t pending_bytes_now = 0; // bytes received on current slice
+  uint64_t pending_bytes_total = 0; // expected total of current slice
+  unsigned retry_attempt = 0;     // 0 = not retrying; >0 = nth retry
+  unsigned retry_seconds_left = 0;// seconds until next retry attempt
+  std::string download_time;      // "HH:MM:SS" local time
+  std::string issued_utc;         // "YYYY-MM-DD HH UTC" of the model run
+};
+
+/** Per-layer download info (indexed by layer position in the list) */
+static LayerDownloadInfo download_info_ch[
+  XCTherm::GetRegion(XCTherm::Region::CH).layer_count];
+static LayerDownloadInfo download_info_uk[
+  XCTherm::GetRegion(XCTherm::Region::UK).layer_count];
+
+static LayerDownloadInfo *
+GetDownloadInfo(unsigned model) noexcept
+{
+  if (XCTherm::ToRegion(model) == XCTherm::Region::UK)
+    return download_info_uk;
+  return download_info_ch;
+}
+
+/* ---- List item renderer ---- */
+
+class XCThermRowRenderer {
+  TwoTextRowsRenderer row_renderer;
+
+public:
+  unsigned CalculateLayout(const DialogLook &look) {
+    return row_renderer.CalculateLayout(*look.list.font_bold,
+                                       look.small_font);
+  }
+
+  void Draw(Canvas &canvas, const PixelRect rc, unsigned index,
+            unsigned model, unsigned active_parameter,
+            unsigned active_wave_height,
+            unsigned active_vertical_agl,
+            unsigned span_hours_setting);
+};
+
+void
+XCThermRowRenderer::Draw(Canvas &canvas, const PixelRect rc,
+                          unsigned index, unsigned model,
+                          unsigned active_parameter,
+                          unsigned active_wave_height,
+                          unsigned active_vertical_agl,
+                          unsigned span_hours_setting)
+{
+  const auto &region = XCTherm::GetRegion(model);
+  if (index >= region.layer_count)
+    return;
+
+  const auto &layer = region.layers[index];
+  const bool active = XCTherm::IsActiveLayer(layer, active_parameter,
+                                             active_wave_height,
+                                             active_vertical_agl);
+
+  StaticString<80> first_row;
+  if (active)
+    first_row.Format("%s  %s", gettext(layer.dialog_label), _("[ACTIVE]"));
+  else
+    first_row = gettext(layer.dialog_label);
+
+  /* Second row: download status */
+  StaticString<200> second_row;
+  const auto *info = GetDownloadInfo(model);
+  switch (info[index].status) {
+  case LayerDownloadInfo::PENDING: {
+    const auto &p = info[index];
+    /* pending_index is the 1-based slot number being fetched (1 = the
+       previous-hour slice we always prepend, 2..pending_total = future
+       hours). "Slot N/M" rather than "+Nh of M" because the offset for
+       N=1 is actually -1h. */
+    if (p.retry_seconds_left > 0) {
+      /* Network seems down — show countdown to next attempt. */
+      second_row.Format(_("Slot %u: reconnect in %us (try #%u)"),
+                        p.pending_index,
+                        p.retry_seconds_left,
+                        p.retry_attempt + 1);
+    } else if (p.pending_bytes_total > 0) {
+      const double now_mb = (double)p.pending_bytes_now / (1024.0 * 1024.0);
+      const double tot_mb = (double)p.pending_bytes_total / (1024.0 * 1024.0);
+      second_row.Format(_("Slot %u/%u: %.2f / %.2f MB"),
+                        p.pending_index,
+                        p.pending_total,
+                        now_mb, tot_mb);
+    } else if (p.pending_bytes_now > 0) {
+      const double now_mb = (double)p.pending_bytes_now / (1024.0 * 1024.0);
+      second_row.Format(_("Slot %u/%u: %.2f MB"),
+                        p.pending_index,
+                        p.pending_total,
+                        now_mb);
+    } else if (p.pending_total > 0) {
+      second_row.Format(_("Slot %u/%u: connecting..."),
+                        p.pending_index,
+                        p.pending_total);
+    } else {
+      second_row = _("Connecting...");
+    }
+    break;
+  }
+  case LayerDownloadInfo::DONE: {
+    /* "X/Yh" where X = cached future-hours still ahead of now and
+       Y = the user's currently configured download span. Letting the
+       user see at-a-glance how much of a fresh fetch they'd actually
+       need: e.g. "4 / 12 h" means the layer covers 4 of the next 12
+       requested hours; the rest would be new downloads. */
+    const unsigned future = info[index].future_hours;
+    if (info[index].new_downloads == 0)
+      second_row.Format(_("%u/%uh | Issued %s | %s"),
+                        future, span_hours_setting,
+                        info[index].issued_utc.c_str(),
+                        info[index].download_time.c_str());
+    else
+      second_row.Format(_("%u/%uh (%u new) | Issued %s | %.2f MB wire %.1f MB/s | %s"),
+                        future, span_hours_setting,
+                        info[index].new_downloads,
+                        info[index].issued_utc.c_str(),
+                        info[index].wire_mb,
+                        info[index].speed_mbs,
+                        info[index].download_time.c_str());
+    break;
+  }
+  case LayerDownloadInfo::FAILED:
+    second_row = _("Download failed");
+    break;
+  case LayerDownloadInfo::CANCELED:
+    second_row = _("Cancelled");
+    break;
+  default:
+    if (active)
+      second_row = _("Not downloaded");
+    else
+      second_row = "";
+    break;
+  }
+
+  row_renderer.DrawFirstRow(canvas, rc, first_row);
+  row_renderer.DrawSecondRow(canvas, rc, second_row);
+}
+
+/* ---- String choice renderer for model picker ---- */
+
+class StringChoiceRenderer final : public ListItemRenderer {
+  TextRowRenderer row_renderer;
+  const char *const *choices;
+
+public:
+  explicit StringChoiceRenderer(const char *const *_choices) noexcept
+    : choices(_choices) {}
+
+  unsigned CalculateLayout(const DialogLook &look) {
+    return row_renderer.CalculateLayout(*look.list.font);
+  }
+
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned i) noexcept override {
+    /* Choices are stored with N_() markers and translated at paint
+       time so callers can pass plain string literals into the array
+       and still get localized display. */
+    row_renderer.DrawTextRow(canvas, rc, gettext(choices[i]));
+  }
+};
+
+/* ---- Main widget ---- */
+
+class XCThermWidget final : public ListWidget {
+  ButtonPanelWidget *buttons_widget = nullptr;
+  Button *span_button = nullptr;
+  Button *activate_button = nullptr;
+  Button *download_button = nullptr;   // labeled "Update" or "Stop"
+  Button *delete_button = nullptr;
+
+  XCThermRowRenderer row_renderer;
+
+  std::shared_ptr<XCThermDownloadJob> active_job;
+
+  /* Polls active_job every 200 ms for live progress (UI thread). */
+  UI::PeriodicTimer poll_timer{[this]{ PollDownload(); }};
+
+public:
+  void SetButtonPanel(ButtonPanelWidget &_buttons) {
+    buttons_widget = &_buttons;
+  }
+
+  void CreateButtons(ButtonPanel &buttons);
+
+  ~XCThermWidget() noexcept override {
+    if (auto *glue = GetXCThermDownloadGlue())
+      glue->Abandon();
+  }
+
+private:
+  void UpdateList();
+  void SaveSettings();
+
+  void ActivateClicked();
+  void DownloadClicked();
+  void DeleteClicked();
+  void SpanClicked();
+
+  /* New download flow */
+  void StartDownload();
+  void PollDownload();
+  void FinishDownload();
+  void CancelDownload();
+
+  /**
+   * Walk every row for the current model and populate its
+   * LayerDownloadInfo from the XCThermAPI in-RAM cache (which on
+   * startup includes anything the persistent disk cache rehydrated).
+   * Lets the user open the dialog and immediately see that prior-
+   * session forecasts are still available, with their freshness and
+   * the run they came from, without having to redownload.
+   *
+   * Never stomps on session state (PENDING / FAILED / CANCELED entries
+   * are left alone), so this is safe to call from Prepare().
+   */
+  void RehydrateRowsFromCache() noexcept;
+
+public:
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+
+protected:
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned idx) noexcept override;
+
+  void OnCursorMoved(unsigned index) noexcept override;
+
+  bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept override {
+    return true;
+  }
+
+  void OnActivateItem([[maybe_unused]] unsigned index) noexcept override {
+    ActivateClicked();
+  }
+};
+
+void
+XCThermWidget::CreateButtons(ButtonPanel &buttons)
+{
+  /* Button order matches user-flow:
+       1. Span  — pick how much to fetch
+       2. Activate — mark which row is "active"
+       3. Update — fetch / refresh data (acts as Stop while running)
+       4. Delete — clear cached data for the cursor row
+     Region (CH/UK) lives in Config → Weather → XCTherm. */
+  span_button = buttons.Add(_("Span"), [this]() { SpanClicked(); });
+  activate_button = buttons.Add(_("Activate"),
+                                [this]() { ActivateClicked(); });
+  download_button = buttons.Add(_("Update"),
+                                [this]() { DownloadClicked(); });
+  delete_button = buttons.Add(_("Delete"),
+                              [this]() { DeleteClicked(); });
+}
+
+void
+XCThermWidget::SaveSettings()
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  Profile::Set(ProfileKeys::XCThermModel, (int)settings.model);
+  Profile::Set(ProfileKeys::XCThermParameter, (int)settings.parameter);
+  Profile::Set(ProfileKeys::XCThermWaveHeight, (int)settings.wave_height);
+  Profile::Set(ProfileKeys::XCThermVerticalWindAGL,
+               (int)settings.vertical_wind_agl);
+  /* download_span_hours is session-only — not persisted. */
+}
+
+void
+XCThermWidget::UpdateList()
+{
+  ListControl &list = GetList();
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+
+  const auto &region = XCTherm::GetRegion(settings.model);
+
+  list.SetLength(region.layer_count);
+
+  /* Important: do NOT call SetCursorIndex here. UpdateList runs after
+     every action (download progress tick, Activate, Span change). If
+     we re-positioned the cursor to the active row each time, a user
+     who downloaded a non-active layer would see the cursor jump back
+     to the active row on completion — losing track of what they just
+     fetched. Initial cursor positioning happens once in Prepare(). */
+
+  list.Invalidate();
+
+  /* Update span button label */
+  {
+    StaticString<16> span_caption;
+    span_caption.Format("Span: %uh", settings.download_span_hours);
+    span_button->SetCaption(span_caption);
+  }
+
+  /* Flip Update button to Stop while a job is running; freeze the
+     other settings buttons so the job's target/span can't change
+     underneath the worker. */
+  const bool job_running = (bool)active_job;
+  download_button->SetCaption(job_running ? _("Stop") : _("Update"));
+  if (span_button)   span_button->SetEnabled(!job_running);
+  if (delete_button) delete_button->SetEnabled(!job_running);
+
+  /* Update activate/update button state based on cursor */
+  OnCursorMoved(list.GetCursorIndex());
+}
+
+void
+XCThermWidget::OnCursorMoved(unsigned index) noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+
+  const auto &region = XCTherm::GetRegion(settings.model);
+
+  const bool cursor_is_active = index < region.layer_count &&
+    XCTherm::IsActiveLayer(region.layers[index], settings.parameter,
+                           settings.wave_height, settings.vertical_wind_agl);
+
+  if (cursor_is_active) {
+    activate_button->SetCaption(_("Active"));
+    activate_button->SetEnabled(false);
+  } else {
+    activate_button->SetCaption(_("Activate"));
+    activate_button->SetEnabled(true);
+  }
+
+  /* While a download is running, freeze Activate so we don't change
+     the active layer concept mid-flight. */
+  if (active_job)
+    activate_button->SetEnabled(false);
+}
+
+void
+XCThermWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
+                            unsigned idx) noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  row_renderer.Draw(canvas, rc, idx,
+                    settings.model, settings.parameter,
+                    settings.wave_height, settings.vertical_wind_agl,
+                    settings.download_span_hours);
+}
+
+void
+XCThermWidget::ActivateClicked()
+{
+  auto &settings = CommonInterface::SetComputerSettings().weather.xctherm;
+
+  const int index = GetList().GetCursorIndex();
+  const auto &region = XCTherm::GetRegion(settings.model);
+
+  if (index < 0 || unsigned(index) >= region.layer_count)
+    return;
+
+  const auto &layer = region.layers[index];
+
+  if (layer.is_agl) {
+    settings.parameter = 1;
+    settings.vertical_wind_agl = layer.altitude_m;
+  } else {
+    settings.parameter = 0;
+    settings.wave_height = layer.altitude_m;
+  }
+
+  SaveSettings();
+
+  /* New activation must not reuse the previous cursor-bar session. */
+  CommonInterface::SetUIState().weather.xctherm.cursor_initialized = false;
+
+  XCTherm::RestoreActiveLayerOverlay();
+  PageActions::Update();
+
+  UpdateList();
+}
+
+/* ---- Delete cached data for the cursor-selected layer ---- */
+
+void
+XCThermWidget::DeleteClicked()
+{
+  /* Don't allow Delete while a download is running — would race with
+     the worker writing fresh entries into the cache. */
+  if (active_job)
+    return;
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+
+  const auto &region = XCTherm::GetRegion(settings.model);
+
+  const int cursor_index = GetList().GetCursorIndex();
+  if (cursor_index < 0 || unsigned(cursor_index) >= region.layer_count) {
+    ShowMessageBox(_("No layer selected."), "XCTherm", MB_OK);
+    return;
+  }
+  const auto &target = region.layers[cursor_index];
+
+  XCThermAPI::Instance().ClearLayer(target.api_parameter);
+
+  /* Reset the per-row status so the dialog stops showing the old
+     "Cached Nh | Issued …" line. */
+  auto *info = GetDownloadInfo(settings.model);
+  info[cursor_index] = LayerDownloadInfo{};
+
+  /* If the deleted layer was currently displayed on the map, clear the
+     overlay and refresh page state. */
+  if (XCTherm::IsActiveLayer(target, settings.parameter,
+                             settings.wave_height,
+                             settings.vertical_wind_agl))
+    XCTherm::ClearMapOverlay();
+
+  UpdateList();
+  PageActions::Update();
+}
+
+/* ---- Download span (asynchronous worker thread) ---- */
+
+void
+XCThermWidget::DownloadClicked()
+{
+  /* The download button doubles as Stop. */
+  if (active_job) {
+    CancelDownload();
+    return;
+  }
+  StartDownload();
+}
+
+void
+XCThermWidget::CancelDownload()
+{
+  if (!active_job)
+    return;
+
+  if (auto *glue = GetXCThermDownloadGlue())
+    glue->RequestCancel();
+  else if (active_job)
+    active_job->cancel.store(true);
+}
+
+void
+XCThermWidget::StartDownload()
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return;
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+
+  const unsigned span_hours = settings.download_span_hours;
+  if (span_hours == 0)
+    return;
+
+  /* Download targets the cursor-selected row, not the active layer. */
+  const auto &region = XCTherm::GetRegion(settings.model);
+
+  const int cursor_index = GetList().GetCursorIndex();
+  if (cursor_index < 0 || unsigned(cursor_index) >= region.layer_count) {
+    ShowMessageBox(_("No layer selected."), "XCTherm", MB_OK);
+    return;
+  }
+  XCThermAPI::Instance().PrepareSession(settings);
+
+  active_job = XCTherm::StartSpanDownload(
+    settings, unsigned(cursor_index),
+    [this](std::shared_ptr<XCThermDownloadJob> finished) {
+      active_job = std::move(finished);
+      FinishDownload();
+    });
+  if (active_job == nullptr) {
+    if (GetXCThermDownloadGlue() == nullptr || Net::curl == nullptr)
+      ShowMessageBox(_("Network is not available."), "XCTherm", MB_OK);
+    return;
+  }
+
+  auto *info = GetDownloadInfo(settings.model);
+  auto &row_info = info[cursor_index];
+  row_info.status = LayerDownloadInfo::PENDING;
+  row_info.pending_total = span_hours + 1;
+  row_info.pending_index = 0;
+  row_info.pending_bytes_now = 0;
+  row_info.pending_bytes_total = 0;
+  row_info.retry_attempt = 0;
+  row_info.retry_seconds_left = 0;
+
+  UpdateList();
+  poll_timer.Schedule(std::chrono::milliseconds(200));
+}
+
+void
+XCThermWidget::PollDownload()
+{
+  if (!active_job)
+    return;
+
+  auto &job = *active_job;
+
+  /* Mirror live atomics into the row state so the renderer can pick
+     them up on the next paint. */
+  auto *info = GetDownloadInfo(job.model);
+  auto &row_info = info[job.target_index];
+  row_info.pending_index = job.current_offset.load();
+  row_info.pending_total = job.span_hours + 1;
+  row_info.pending_bytes_now = job.bytes_now.load();
+  row_info.pending_bytes_total = job.bytes_total.load();
+  row_info.retry_attempt = job.retry_attempt.load();
+  row_info.retry_seconds_left = job.retry_seconds_left.load();
+
+  GetList().Invalidate();
+}
+
+void
+XCThermWidget::FinishDownload()
+{
+  if (!active_job)
+    return;
+
+  poll_timer.Cancel();
+
+  auto job = std::move(active_job);
+  active_job.reset();
+
+  auto *info = GetDownloadInfo(job->model);
+  auto &row_info = info[job->target_index];
+
+  const unsigned span = job->span_hours;
+  const unsigned ok    = job->succeeded_or_cached.load();
+  const unsigned nu    = job->newly_downloaded.load();
+  const bool canceled  = job->cancel.load();
+  const bool any_miss  = job->any_slot_missing.load();
+
+  /* Decide the post-run row state. */
+  if (ok == 0) {
+    row_info.status = canceled
+      ? LayerDownloadInfo::CANCELED
+      : LayerDownloadInfo::FAILED;
+    row_info.pending_index = 0;
+    row_info.pending_total = 0;
+    row_info.pending_bytes_now = 0;
+    row_info.pending_bytes_total = 0;
+    row_info.retry_attempt = 0;
+    row_info.retry_seconds_left = 0;
+    UpdateList();
+    if (canceled) {
+      /* nothing — Cancelled state in the row says it all */
+    } else if (job->index_no_parameters.load()) {
+      ShowMessageBox(_("Forecast index has no XCTherm parameters."),
+                     "XCTherm", MB_OK);
+    } else if (job->error_eptr) {
+      /* Surface the actual cause (auth, forbidden, server error, …)
+         instead of a generic message. ShowError unpacks the chain of
+         what() strings from the exception_ptr. */
+      ShowError(job->error_eptr, "XCTherm");
+    } else {
+      ShowMessageBox(_("Forecast download failed.\nKeeping previous data."),
+                     "XCTherm", MB_OK);
+    }
+    return;
+  }
+
+  XCTherm::ApplyJobPreviewToMap(job);
+
+  const double span_secs = std::chrono::duration<double>(
+    std::chrono::steady_clock::now() - job->started_at).count();
+  const double wire_mb = (double)job->total_wire_bytes.load() / (1024.0 * 1024.0);
+  const double speed_mbs = span_secs > 0 ? wire_mb / span_secs : 0.0;
+
+  row_info.status = LayerDownloadInfo::DONE;
+  row_info.wire_mb = wire_mb;
+  row_info.speed_mbs = speed_mbs;
+  row_info.span_hours = ok;
+  row_info.new_downloads = nu;
+  /* Recompute the count of future-valid slices so the "X/Yh" cell
+     reflects this fresh download immediately. */
+  row_info.future_hours = XCThermAPI::Instance()
+    .GetCachedLayerSummary(job->param).future_hours;
+  row_info.pending_index = 0;
+  row_info.pending_total = 0;
+  row_info.pending_bytes_now = 0;
+  row_info.pending_bytes_total = 0;
+  row_info.retry_attempt = 0;
+  row_info.retry_seconds_left = 0;
+
+  if (job->latest_run_date.size() == 8 && job->latest_run_hour.size() == 2) {
+    const std::string &d = job->latest_run_date;
+    row_info.issued_utc = std::string(FmtBuffer<32>("{}-{}-{} {} UTC",
+                                                    d.substr(0, 4),
+                                                    d.substr(4, 2),
+                                                    d.substr(6, 2),
+                                                    job->latest_run_hour).c_str());
+  } else {
+    row_info.issued_utc = "?";
+  }
+
+  std::time_t now = std::time(nullptr);
+  std::tm *lt = std::localtime(&now);
+  char tbuf[16];
+  std::strftime(tbuf, sizeof(tbuf), "%H:%M:%S", lt);
+  row_info.download_time = tbuf;
+
+  /* Stale-run sweep — but only AFTER the new forecast is successfully
+     in the cache and the overlay was swapped above. Older-run entries
+     for hours we didn't re-fetch this round get dropped here so the
+     cache for this layer is consistent (one run per layer). Past
+     hours stay in the cache (user can browse back); we just align
+     them with the latest run. */
+  if (nu > 0) {
+    const unsigned current_utc = XCTherm::GetUtcTimeParts().hour;
+
+    const unsigned dropped =
+      XCThermAPI::Instance().PruneStaleRuns(job->param, current_utc);
+    if (dropped > 0)
+      LogFmt("xctherm: stale-run sweep dropped {} entries for {}",
+             dropped, job->param);
+  }
+
+  UpdateList();
+
+  /* Trigger a page reload so PageActions::LoadBottom re-evaluates
+     XCThermAPI::HasAnyCache() and the cursor bar appears on the
+     current XCTherm page (instead of waiting for the next manual
+     page switch). Cheap on success — does nothing if the current page
+     isn't configured for XCTherm. */
+  if (nu > 0)
+    PageActions::Update();
+
+  if (job->error_eptr && !canceled) {
+    /* Partial success: some slots got through, then a persistent
+       error stopped us. Surface the cause via ShowError so the user
+       knows what to fix. */
+    ShowError(job->error_eptr, "XCTherm");
+  } else if (any_miss && !canceled) {
+    StaticString<128> msg;
+    msg.Format(_("Got %u of %u hourly slices (%u newly downloaded).\n"
+                 "Some slots were unavailable."),
+               ok, span, nu);
+    ShowMessageBox(msg, "XCTherm", MB_OK);
+  }
+}
+
+void
+XCThermWidget::SpanClicked()
+{
+  /* These strings are localized via gettext() at render time inside
+     StringChoiceRenderer; mark them with N_() so they're picked up
+     into the translation catalog. */
+  static constexpr const char *choices[] = {
+    N_("1 hour"), N_("3 hours"), N_("6 hours"),
+    N_("12 hours"), N_("18 hours"),
+  };
+  static constexpr unsigned spans[] = { 1, 3, 6, 12, 18 };
+  static_assert(std::size(choices) == std::size(spans));
+
+  auto &settings = CommonInterface::SetComputerSettings().weather.xctherm;
+
+  /* Pre-select the current value */
+  int initial = 0;
+  for (unsigned i = 0; i < std::size(spans); ++i) {
+    if (spans[i] == settings.download_span_hours) {
+      initial = (int)i;
+      break;
+    }
+  }
+
+  StringChoiceRenderer item_renderer(choices);
+  int index = ListPicker(_("Download span"),
+                         std::size(choices), initial,
+                         item_renderer.CalculateLayout(UIGlobals::GetDialogLook()),
+                         item_renderer,
+                         false, nullptr, nullptr, nullptr);
+  if (index < 0)
+    return;
+
+  settings.download_span_hours = spans[index];
+  SaveSettings();
+  UpdateList();
+}
+
+void
+XCThermWidget::RehydrateRowsFromCache() noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = XCTherm::GetRegion(settings.model);
+  auto *info = GetDownloadInfo(settings.model);
+  auto &api = XCThermAPI::Instance();
+
+  /* Make sure the disk index is built before we read it — otherwise a
+     fresh session that opens this dialog without having downloaded
+     anything yet would show "Not downloaded" for slices that are in
+     fact sitting in the on-disk cache. Idempotent. */
+  api.EnableDiskCache();
+
+  for (unsigned i = 0; i < region.layer_count; ++i) {
+    /* Don't overwrite session state — a row that's mid-download
+       (PENDING) or failed/canceled should keep its visible status. */
+    if (info[i].status != LayerDownloadInfo::NONE)
+      continue;
+
+    const auto summary =
+      api.GetCachedLayerSummary(region.layers[i].api_parameter);
+    if (summary.hours.empty())
+      continue;
+
+    LayerDownloadInfo &row = info[i];
+    row.status = LayerDownloadInfo::DONE;
+    row.span_hours = (unsigned)summary.hours.size();
+    row.future_hours = summary.future_hours;
+    row.new_downloads = 0;
+    row.wire_mb = 0.0;
+    row.speed_mbs = 0.0;
+    row.pending_index = 0;
+    row.pending_total = 0;
+    row.pending_bytes_now = 0;
+    row.pending_bytes_total = 0;
+    row.retry_attempt = 0;
+    row.retry_seconds_left = 0;
+
+    if (summary.latest_run_date.size() == 8 &&
+        summary.latest_run_hour.size() == 2) {
+      const std::string &d = summary.latest_run_date;
+      row.issued_utc = std::string(FmtBuffer<32>("{}-{}-{} {} UTC",
+                                                 d.substr(0, 4),
+                                                 d.substr(4, 2),
+                                                 d.substr(6, 2),
+                                                 summary.latest_run_hour).c_str());
+    } else {
+      row.issued_utc = "?";
+    }
+
+    if (summary.latest_downloaded_at > 0) {
+      const std::time_t t = (std::time_t)summary.latest_downloaded_at;
+      std::tm *lt = std::localtime(&t);
+      char tbuf[16];
+      if (lt && std::strftime(tbuf, sizeof(tbuf), "%H:%M:%S", lt) > 0)
+        row.download_time = tbuf;
+    }
+  }
+}
+
+void
+XCThermWidget::Prepare(ContainerWindow &parent,
+                        const PixelRect &rc) noexcept
+{
+  CreateButtons(buttons_widget->GetButtonPanel());
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  CreateList(parent, look, rc, row_renderer.CalculateLayout(look));
+
+  /* Pull any forecasts that the persistent disk cache restored at app
+     startup into the per-row LayerDownloadInfo, so the user sees them
+     as cached (with freshness + run info) the first time they open the
+     dialog this session — not as "Not downloaded". */
+  RehydrateRowsFromCache();
+
+  UpdateList();
+
+  /* Seed the cursor to the currently active layer — but only here,
+     once, on initial display. UpdateList() deliberately does NOT touch
+     the cursor on subsequent calls so a user who downloads layer X
+     while layer Y is active stays parked on X after the download. */
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = XCTherm::GetRegion(settings.model);
+  for (unsigned i = 0; i < region.layer_count; ++i) {
+    if (XCTherm::IsActiveLayer(region.layers[i], settings.parameter,
+                               settings.wave_height,
+                               settings.vertical_wind_agl)) {
+      GetList().SetCursorIndex(i);
+      break;
+    }
+  }
+}
+
+} // namespace
+
+std::unique_ptr<Widget>
+CreateXCThermMainWidget() noexcept
+{
+  auto widget = std::make_unique<XCThermWidget>();
+  auto buttons = std::make_unique<ButtonPanelWidget>(
+    std::move(widget),
+    ButtonPanelWidget::Alignment::BOTTOM);
+  auto *widget_ptr = static_cast<XCThermWidget *>(&buttons->GetWidget());
+  widget_ptr->SetButtonPanel(*buttons);
+  return buttons;
+}
+
+std::unique_ptr<Widget>
+CreateXCThermWidget() noexcept
+{
+  return CreateWeatherCredentialGateWidget(
+    []() {
+      return CommonInterface::GetComputerSettings()
+        .weather.xctherm.credentials.IsDefined();
+    },
+    CreateXCThermConfigPanel,
+    CreateXCThermMainWidget);
+}
+
+#endif

--- a/src/Dialogs/Weather/XCThermDialog.cpp
+++ b/src/Dialogs/Weather/XCThermDialog.cpp
@@ -8,7 +8,9 @@
 #include "Dialogs/ListPicker.hpp"
 #include "Components.hpp"
 #include "NetComponents.hpp"
+#include "OverlayPageActions.hpp"
 #include "PageActions.hpp"
+#include "PageSettings.hpp"
 #include "Weather/Features.hpp"
 
 #ifdef HAVE_HTTP
@@ -19,8 +21,6 @@
 #include "Form/ButtonPanel.hpp"
 #include "Widget/ListWidget.hpp"
 #include "Widget/ButtonPanelWidget.hpp"
-#include "WeatherCredentialGateWidget.hpp"
-#include "Dialogs/Settings/Panels/XCThermConfigPanel.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Keys.hpp"
 #include "Interface.hpp"
@@ -232,6 +232,8 @@ class XCThermWidget final : public ListWidget {
   ButtonPanelWidget *buttons_widget = nullptr;
   Button *span_button = nullptr;
   Button *activate_button = nullptr;
+  Button *add_to_current_button = nullptr;
+  Button *add_to_new_page_button = nullptr;
   Button *download_button = nullptr;   // labeled "Update" or "Stop"
   Button *delete_button = nullptr;
 
@@ -257,8 +259,11 @@ public:
 private:
   void UpdateList();
   void SaveSettings();
+  bool SetActiveLayerFromCursor();
 
   void ActivateClicked();
+  void AddToCurrentClicked();
+  void AddToNewPageClicked();
   void DownloadClicked();
   void DeleteClicked();
   void SpanClicked();
@@ -313,6 +318,10 @@ XCThermWidget::CreateButtons(ButtonPanel &buttons)
   span_button = buttons.Add(_("Span"), [this]() { SpanClicked(); });
   activate_button = buttons.Add(_("Activate"),
                                 [this]() { ActivateClicked(); });
+  add_to_current_button = buttons.Add(_("Add to page"),
+                                      [this]() { AddToCurrentClicked(); });
+  add_to_new_page_button = buttons.Add(_("Add new page"),
+                                       [this]() { AddToNewPageClicked(); });
   download_button = buttons.Add(_("Update"),
                                 [this]() { DownloadClicked(); });
   delete_button = buttons.Add(_("Delete"),
@@ -412,16 +421,19 @@ XCThermWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
 void
 XCThermWidget::ActivateClicked()
 {
-  auto &settings = CommonInterface::SetComputerSettings().weather.xctherm;
+  AddToCurrentClicked();
+}
 
+bool
+XCThermWidget::SetActiveLayerFromCursor()
+{
+  auto &settings = CommonInterface::SetComputerSettings().weather.xctherm;
   const int index = GetList().GetCursorIndex();
   const auto &region = XCTherm::GetRegion(settings.model);
-
   if (index < 0 || unsigned(index) >= region.layer_count)
-    return;
+    return false;
 
   const auto &layer = region.layers[index];
-
   if (layer.is_agl) {
     settings.parameter = 1;
     settings.vertical_wind_agl = layer.altitude_m;
@@ -430,13 +442,32 @@ XCThermWidget::ActivateClicked()
     settings.wave_height = layer.altitude_m;
   }
 
+  return true;
+}
+
+void
+XCThermWidget::AddToCurrentClicked()
+{
+  if (!SetActiveLayerFromCursor())
+    return;
+
   SaveSettings();
-
-  /* New activation must not reuse the previous cursor-bar session. */
   CommonInterface::SetUIState().weather.xctherm.cursor_initialized = false;
+  WeatherDialogOverlayActions::AddOverlayToCurrentPage(
+    PageLayout::Overlay::XCTHERM);
+  UpdateList();
+}
 
-  XCTherm::RestoreActiveLayerOverlay();
-  PageActions::Update();
+void
+XCThermWidget::AddToNewPageClicked()
+{
+  if (!SetActiveLayerFromCursor())
+    return;
+
+  SaveSettings();
+  CommonInterface::SetUIState().weather.xctherm.cursor_initialized = false;
+  WeatherDialogOverlayActions::AddOverlayToNewPage(
+    PageLayout::Overlay::XCTHERM);
 
   UpdateList();
 }
@@ -852,18 +883,6 @@ CreateXCThermMainWidget() noexcept
   auto *widget_ptr = static_cast<XCThermWidget *>(&buttons->GetWidget());
   widget_ptr->SetButtonPanel(*buttons);
   return buttons;
-}
-
-std::unique_ptr<Widget>
-CreateXCThermWidget() noexcept
-{
-  return CreateWeatherCredentialGateWidget(
-    []() {
-      return CommonInterface::GetComputerSettings()
-        .weather.xctherm.credentials.IsDefined();
-    },
-    CreateXCThermConfigPanel,
-    CreateXCThermMainWidget);
 }
 
 #endif

--- a/src/Dialogs/Weather/XCThermDialog.hpp
+++ b/src/Dialogs/Weather/XCThermDialog.hpp
@@ -8,7 +8,7 @@
 class Widget;
 
 std::unique_ptr<Widget>
-CreatePCMetWidget();
+CreateXCThermWidget() noexcept;
 
 std::unique_ptr<Widget>
-CreatePCMetMainWidget();
+CreateXCThermMainWidget() noexcept;

--- a/src/Dialogs/Weather/XCThermDialog.hpp
+++ b/src/Dialogs/Weather/XCThermDialog.hpp
@@ -8,7 +8,4 @@
 class Widget;
 
 std::unique_ptr<Widget>
-CreateXCThermWidget() noexcept;
-
-std::unique_ptr<Widget>
 CreateXCThermMainWidget() noexcept;

--- a/src/Form/TabMenuDisplay.cpp
+++ b/src/Form/TabMenuDisplay.cpp
@@ -89,8 +89,10 @@ TabMenuDisplay::UpdateLayout() noexcept
 {
   const auto window_size = GetSize();
   const unsigned border_width = GetTabLineHeight();
+  const unsigned n_main_menu_items = std::max(GetNumMainMenuItems(), 1u);
   const unsigned menu_button_height =
-    std::min(Layout::GetMaximumControlHeight(), window_size.height / 7u);
+    std::min(Layout::GetMaximumControlHeight(),
+             window_size.height / n_main_menu_items);
   const unsigned menu_button_width = (window_size.width - 2 * border_width) / 2;
 
   const unsigned offset = Layout::Scale(2);

--- a/src/Form/TabMenuDisplay.hpp
+++ b/src/Form/TabMenuDisplay.hpp
@@ -14,7 +14,7 @@ class PagerWidget;
 class TabMenuDisplay final : public PaintWindow
 {
   /* excludes "Main Menu" which is a "super menu" */
-  static constexpr unsigned MAX_MAIN_MENU_ITEMS = 7;
+  static constexpr unsigned MAX_MAIN_MENU_ITEMS = 9;
 
   /**
    * The offset from a page number in the #TabMenuDisplay to a page
@@ -116,7 +116,7 @@ class TabMenuDisplay final : public PaintWindow
   PagerWidget &pager;
   const DialogLook &look;
 
-  StaticArray<SubMenuButton, 32> buttons;
+  StaticArray<SubMenuButton, 48> buttons;
 
   /* holds info and buttons for the main menu.  not on child menus */
   StaticArray<MainMenuButton, MAX_MAIN_MENU_ITEMS> main_menu_buttons;

--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -57,4 +57,20 @@ static constexpr Color COLOR_ADMONITION_TIP =
  */
 static constexpr Color COLOR_LIGHT_GREEN = Color(0x00, 0xc0, 0x00);
 
+/**
+ * XCTherm overlay palette.
+ */
+static constexpr Color COLOR_XCTHERM_BLUE = Color(0x00, 0x00, 0xc8);
+static constexpr Color COLOR_XCTHERM_BRIGHT_CYAN = Color(0x00, 0xd0, 0xff);
+static constexpr Color COLOR_XCTHERM_SKY_BLUE = Color(0x60, 0xe0, 0xff);
+static constexpr Color COLOR_XCTHERM_LIGHT_BLUE = Color(0xa0, 0xe8, 0xff);
+static constexpr Color COLOR_XCTHERM_PALE_BLUE = Color(0xc8, 0xf0, 0xff);
+static constexpr Color COLOR_XCTHERM_CREAM = Color(0xf0, 0xf0, 0xc0);
+static constexpr Color COLOR_XCTHERM_YELLOW = Color(0xff, 0xff, 0x00);
+static constexpr Color COLOR_XCTHERM_GOLD = Color(0xff, 0xd0, 0x00);
+static constexpr Color COLOR_XCTHERM_ORANGE = Color(0xff, 0xa0, 0x00);
+static constexpr Color COLOR_XCTHERM_RED_ORANGE = Color(0xff, 0x40, 0x00);
+static constexpr Color COLOR_XCTHERM_RED = Color(0xff, 0x00, 0x00);
+static constexpr Color COLOR_XCTHERM_PURPLE = Color(0xa0, 0x20, 0xf0);
+
 static constexpr uint8_t ALPHA_OVERLAY = 0xA0;

--- a/src/MapWindow/GlueMapWindowItems.cpp
+++ b/src/MapWindow/GlueMapWindowItems.cpp
@@ -88,7 +88,7 @@ GlueMapWindow::ShowMapItems(const GeoPoint &location,
 
 #ifdef ENABLE_OPENGL
   if (!list.full() && overlay && overlay->IsInside(location))
-    list.push_back(new OverlayMapItem(*overlay));
+    list.push_back(new OverlayMapItem(*overlay, location));
 #endif
 
   if (!list.full()) {

--- a/src/MapWindow/Items/OverlayMapItem.cpp
+++ b/src/MapWindow/Items/OverlayMapItem.cpp
@@ -4,6 +4,11 @@
 #include "OverlayMapItem.hpp"
 #include "MapWindow/Overlay.hpp"
 
-OverlayMapItem::OverlayMapItem(const MapOverlay &_overlay)
+OverlayMapItem::OverlayMapItem(const MapOverlay &_overlay, GeoPoint location)
   :MapItem(Type::OVERLAY),
-   label(_overlay.GetLabel()) {}
+   label(_overlay.GetLabel())
+{
+  char buffer[256];
+  if (_overlay.FormatPointInfo(location, buffer, sizeof(buffer)))
+    info = buffer;
+}

--- a/src/MapWindow/Items/OverlayMapItem.hpp
+++ b/src/MapWindow/Items/OverlayMapItem.hpp
@@ -13,6 +13,7 @@ class MapOverlay;
 struct OverlayMapItem : public MapItem
 {
   const StaticString<64> label;
+  StaticString<256> info;
 
-  explicit OverlayMapItem(const MapOverlay &_overlay);
+  OverlayMapItem(const MapOverlay &_overlay, GeoPoint location);
 };

--- a/src/MapWindow/Overlay.hpp
+++ b/src/MapWindow/Overlay.hpp
@@ -5,6 +5,8 @@
 
 #include "util/Compiler.h"
 
+#include <cstddef>
+
 class Canvas;
 class WindowProjection;
 struct GeoPoint;
@@ -29,6 +31,18 @@ public:
    */
   [[gnu::pure]]
   virtual bool IsInside(GeoPoint p) const noexcept = 0;
+
+  /**
+   * Format overlay-specific information for a tapped map point.
+   *
+   * Returns true and fills @p buffer on success. The default
+   * implementation provides no extra info.
+   */
+  virtual bool FormatPointInfo([[maybe_unused]] const GeoPoint &p,
+                               [[maybe_unused]] char *buffer,
+                               [[maybe_unused]] std::size_t size) const noexcept {
+    return false;
+  }
 
   /**
    * Draw the overlay to the given #Canvas.

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -125,9 +125,6 @@ AirspaceWarningMonitor::HideWidget() noexcept
     return;
 
   PageActions::RestoreBottom();
-
-  if (widget != nullptr && CommonInterface::main_window != nullptr)
-    CommonInterface::main_window->SetBottomWidget(nullptr);
 }
 
 void

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -16,6 +16,9 @@
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Weather/Rasp/DownloadGlue.hpp"
 #endif
+#ifdef HAVE_HTTP
+#include "Weather/xctherm/XCThermDownloadGlue.hpp"
+#endif
 
 NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
                              const TrackingSettings &tracking_settings,
@@ -34,6 +37,7 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
 # ifdef HAVE_EDL
   ,edl(new EDL::DownloadGlue(curl))
 # endif
+  ,xctherm_download(new XCThermDownloadGlue(curl))
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   ,rasp_download(new RaspDownloadGlue())
@@ -79,6 +83,9 @@ NetComponents::BeginShutdown() noexcept
   if (edl != nullptr)
     edl->BeginShutdown();
 # endif
+
+  if (xctherm_download != nullptr)
+    xctherm_download->BeginShutdown();
 
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (rasp_download != nullptr)

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -19,6 +19,7 @@ class NOTAMGlue;
 #ifdef HAVE_EDL
 namespace EDL { class DownloadGlue; }
 #endif
+class XCThermDownloadGlue;
 #ifdef HAVE_DOWNLOAD_MANAGER
 class RaspDownloadGlue;
 #endif
@@ -41,6 +42,7 @@ struct NetComponents {
 # ifdef HAVE_EDL
   const std::unique_ptr<EDL::DownloadGlue> edl;
 # endif
+  const std::unique_ptr<XCThermDownloadGlue> xctherm_download;
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   const std::unique_ptr<RaspDownloadGlue> rasp_download;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -25,6 +25,9 @@
 #include "Weather/EDL/Glue.hpp"
 #include "Weather/EDL/StateController.hpp"
 #endif
+#ifdef HAVE_HTTP
+#include "Weather/xctherm/XCThermMapOverlay.hpp"
+#endif
 
 #if defined(ENABLE_SDL) && defined(main)
 /* on some platforms, SDL wraps the main() function and clutters our
@@ -123,6 +126,9 @@ PageActions::LeaveXcthermOverlay() noexcept
     return;
 
   xctherm.LeavePage();
+#ifdef HAVE_HTTP
+  XCTherm::ClearMapOverlay();
+#endif
 }
 
 void
@@ -182,7 +188,14 @@ PageActions::ApplyEdlOverlay() noexcept
 void
 PageActions::ApplyXcthermOverlay() noexcept
 {
-  CommonInterface::SetUIState().weather.xctherm.EnterPage();
+  auto &xctherm = CommonInterface::SetUIState().weather.xctherm;
+  const bool first_enter = xctherm.EnterPage();
+#ifdef HAVE_HTTP
+  if (!xctherm.cursor_initialized)
+    XCTherm::ActivatePageOverlay();
+  else if (first_enter)
+    XCTherm::ApplyCursorOverlayFromSession();
+#endif
 }
 
 void

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -17,7 +17,10 @@
 #include "Components.hpp"
 #include "Weather/MapOverlay/ControlsFactory.hpp"
 #include "Weather/MapOverlay/ControlsWidget.hpp"
+#include "Weather/MapOverlay/PagePlacement.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
+#include "Profile/Current.hpp"
+#include "Profile/PageProfile.hpp"
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Weather/Rasp/DownloadGlue.hpp"
 #endif
@@ -69,6 +72,10 @@ namespace PageActions {
   static void ApplyXcthermOverlay() noexcept;
 
   static void ApplyPageOverlay(const PageLayout &layout) noexcept;
+
+  static void ResetOverlayCursorSession(PageLayout::Overlay overlay) noexcept;
+  static ConfigureWeatherOverlayResult ConfigureWeatherOverlayPage(
+    PageLayout::Overlay overlay, bool add_new_page, int rasp_field);
 };
 
 const PageLayout &
@@ -468,7 +475,7 @@ LoadBottom(const PageLayout &layout)
     CommonInterface::main_window->SetBottomWidget(new CrossSectionWidget(*data_components));
     break;
 
-  case PageLayout::Bottom::EDL_CONTROLS:
+  case PageLayout::Bottom::WEATHER_CONTROLS:
     if (auto model = WeatherMapOverlay::CreateControlsModel(layout.overlay)) {
       CommonInterface::main_window->SetBottomWidget(
         new WeatherMapOverlay::ControlsWidget(std::move(model)));
@@ -645,7 +652,7 @@ PageActions::ShowWeatherPage()
   if (!layout.IsMapMain())
     layout.main = PageLayout::Main::MAP;
   layout.overlay = PageLayout::Overlay::EDL;
-  layout.bottom = PageLayout::Bottom::EDL_CONTROLS;
+  layout.bottom = PageLayout::Bottom::WEATHER_CONTROLS;
   OpenLayout(layout);
 #else
   ShowWeatherDialog("edl");
@@ -662,4 +669,86 @@ PageActions::SetCustomBottom(Widget *widget)
   state.special_page = GetCurrentLayout();
   state.special_page.bottom = PageLayout::Bottom::CUSTOM;
   CommonInterface::main_window->SetBottomWidget(widget);
+}
+
+void
+PageActions::ResetOverlayCursorSession(PageLayout::Overlay overlay) noexcept
+{
+  auto &weather = CommonInterface::SetUIState().weather;
+
+  switch (overlay) {
+  case PageLayout::Overlay::NONE:
+  case PageLayout::Overlay::MAX:
+    break;
+
+  case PageLayout::Overlay::RASP:
+    weather.rasp.cursor_initialized = false;
+    break;
+
+  case PageLayout::Overlay::EDL:
+    weather.edl.session.cursor_initialized = false;
+    break;
+
+  case PageLayout::Overlay::XCTHERM:
+    weather.xctherm.cursor_initialized = false;
+    break;
+  }
+}
+
+PageActions::ConfigureWeatherOverlayResult
+PageActions::ConfigureWeatherOverlayPage(PageLayout::Overlay overlay,
+                                         bool add_new_page,
+                                         int rasp_field)
+{
+  auto &settings = CommonInterface::SetUISettings().pages;
+  auto &pages = CommonInterface::SetUIState().pages;
+  if (settings.n_pages == 0)
+    return ConfigureWeatherOverlayResult::NO_CONFIGURED_PAGE;
+
+  if (pages.current_index >= settings.n_pages)
+    pages.current_index = 0;
+
+  unsigned target_page_index = pages.current_index;
+  ConfigureWeatherOverlayResult result =
+    ConfigureWeatherOverlayResult::APPLIED_CURRENT;
+  const bool current_is_map_main =
+    settings.pages[pages.current_index].IsMapMain();
+
+  /* Preserve non-map pages: "add to page" should not rewrite a task/list page
+     into a map page; create a new weather page instead. */
+  if (add_new_page || !current_is_map_main) {
+    const auto add_result = WeatherMapOverlay::AddWeatherOverlayPage(
+      settings, pages.current_index, overlay, target_page_index, rasp_field);
+    if (add_result == WeatherMapOverlay::AddPageResult::PAGE_LIMIT_REACHED)
+      return ConfigureWeatherOverlayResult::PAGE_LIMIT_REACHED;
+    if (add_result != WeatherMapOverlay::AddPageResult::SUCCESS)
+      return ConfigureWeatherOverlayResult::NO_CONFIGURED_PAGE;
+
+    result = ConfigureWeatherOverlayResult::ADDED_PAGE;
+  } else if (!WeatherMapOverlay::ApplyWeatherOverlayToPage(
+               settings, pages.current_index, overlay, rasp_field))
+    return ConfigureWeatherOverlayResult::NO_CONFIGURED_PAGE;
+
+  pages.current_index = target_page_index;
+  pages.special_page.SetUndefined();
+  ResetOverlayCursorSession(overlay);
+
+  Profile::Save(Profile::map, settings);
+  Update();
+
+  return result;
+}
+
+PageActions::ConfigureWeatherOverlayResult
+PageActions::AddWeatherOverlayToCurrentPage(PageLayout::Overlay overlay,
+                                            int rasp_field)
+{
+  return ConfigureWeatherOverlayPage(overlay, false, rasp_field);
+}
+
+PageActions::ConfigureWeatherOverlayResult
+PageActions::AddWeatherOverlayToNewPage(PageLayout::Overlay overlay,
+                                        int rasp_field)
+{
+  return ConfigureWeatherOverlayPage(overlay, true, rasp_field);
 }

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -3,12 +3,20 @@
 
 #pragma once
 
-struct PageLayout;
+#include "PageSettings.hpp"
+
 class GlueMapWindow;
 class Widget;
 
 namespace PageActions
 {
+  enum class ConfigureWeatherOverlayResult {
+    APPLIED_CURRENT,
+    ADDED_PAGE,
+    NO_CONFIGURED_PAGE,
+    PAGE_LIMIT_REACHED,
+  };
+
   /**
    * Returns the configured #PageLayout that was most recently
    * visible.
@@ -113,6 +121,24 @@ namespace PageActions
    * Show the dedicated weather map page.
    */
   void ShowWeatherPage();
+
+  /**
+   * Apply a weather overlay to the currently configured page.
+   *
+   * This mutates configured page settings (not transient special pages),
+   * persists profile changes, and refreshes the active layout.
+   */
+  ConfigureWeatherOverlayResult
+  AddWeatherOverlayToCurrentPage(PageLayout::Overlay overlay,
+                                 int rasp_field=-1);
+
+  /**
+   * Clone the current configured page, apply a weather overlay to the clone,
+   * append it as a new configured page, and activate it.
+   */
+  ConfigureWeatherOverlayResult
+  AddWeatherOverlayToNewPage(PageLayout::Overlay overlay,
+                             int rasp_field=-1);
 
   /**
    * Preserve active weather overlays across a temporary pan full-screen.

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -16,7 +16,7 @@ PageLayout::Normalise() noexcept
     main = Main::MAP;
     overlay = Overlay::EDL;
     if (bottom == Bottom::NOTHING)
-      bottom = Bottom::EDL_CONTROLS;
+      bottom = Bottom::WEATHER_CONTROLS;
   }
 
   if (unsigned(overlay) >= unsigned(Overlay::MAX))
@@ -25,11 +25,11 @@ PageLayout::Normalise() noexcept
   if (IsMapMain()) {
     if (overlay != Overlay::EDL && overlay != Overlay::RASP &&
         overlay != Overlay::XCTHERM &&
-        bottom == Bottom::EDL_CONTROLS)
+        bottom == Bottom::WEATHER_CONTROLS)
       bottom = Bottom::NOTHING;
   } else {
     overlay = Overlay::NONE;
-    if (bottom == Bottom::EDL_CONTROLS)
+    if (bottom == Bottom::WEATHER_CONTROLS)
       bottom = Bottom::NOTHING;
   }
 
@@ -144,7 +144,7 @@ PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,
       builder.Append(", XS");
       break;
 
-    case Bottom::EDL_CONTROLS:
+    case Bottom::WEATHER_CONTROLS:
       break;
 
     case Bottom::MAX:

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -35,8 +35,8 @@ PageLayout::Normalise() noexcept
 
   if (overlay != Overlay::RASP)
     rasp_field = -1;
-  else if (rasp_field < 0)
-    rasp_field = 0;
+  else if (rasp_field < -1)
+    rasp_field = -1;
 }
 
 static void

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -73,7 +73,7 @@ struct PageLayout
      */
     CROSS_SECTION,
 
-    EDL_CONTROLS,
+    WEATHER_CONTROLS,
 
     /**
      * A custom #Widget is being displayed.  This is not a

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -319,6 +319,13 @@ constexpr std::string_view WaveAssistant = "WaveAssistant";
 constexpr std::string_view MasterAudioVolume = "MasterAudioVolume";
 
 constexpr std::string_view RaspFile = "RaspFile";
+constexpr std::string_view XCThermAutoSwitch = "XCThermAutoSwitch";
+constexpr std::string_view XCThermEmail = "XCThermEmail";
+constexpr std::string_view XCThermPassword = "XCThermPassword";
+constexpr std::string_view XCThermModel = "XCThermModel";
+constexpr std::string_view XCThermParameter = "XCThermParameter";
+constexpr std::string_view XCThermWaveHeight = "XCThermWaveHeight";
+constexpr std::string_view XCThermVerticalWindAGL = "XCThermVerticalWindAGL";
 
 constexpr std::string_view StratuxHorizontalRange = "StratuxHorizontalRange";
 constexpr std::string_view StratuxVerticalRange = "StratuxVerticalRange";

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -72,7 +72,7 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
   map.Get(profileKey, pl.rasp_field);
 
   if (pl.overlay == PageLayout::Overlay::NONE &&
-      pl.bottom == PageLayout::Bottom::EDL_CONTROLS)
+      pl.bottom == PageLayout::Bottom::WEATHER_CONTROLS)
     pl.overlay = PageLayout::Overlay::EDL;
 
   pl.Normalise();

--- a/src/Profile/WeatherProfile.cpp
+++ b/src/Profile/WeatherProfile.cpp
@@ -5,6 +5,7 @@
 #include "Map.hpp"
 #include "Keys.hpp"
 #include "Weather/Settings.hpp"
+#include "util/StaticString.hxx"
 
 #ifdef HAVE_PCMET
 
@@ -32,5 +33,28 @@ Profile::Load(const ProfileMap &map, WeatherSettings &settings)
 
 #ifdef HAVE_HTTP
   map.Get(ProfileKeys::EnableThermalInformationMap, settings.enable_tim);
+  map.Get(ProfileKeys::XCThermAutoSwitch, settings.xctherm.auto_switch);
 #endif
+
+  {
+    StaticString<64> xctherm_email;
+    map.Get(ProfileKeys::XCThermEmail, xctherm_email);
+    if (!xctherm_email.empty())
+      settings.xctherm.credentials.email = xctherm_email;
+  }
+
+  {
+    StaticString<64> xctherm_password;
+    map.Get(ProfileKeys::XCThermPassword, xctherm_password);
+    if (!xctherm_password.empty())
+      settings.xctherm.credentials.password = xctherm_password;
+  }
+
+  map.Get(ProfileKeys::XCThermModel, settings.xctherm.model);
+  map.Get(ProfileKeys::XCThermParameter, settings.xctherm.parameter);
+  map.Get(ProfileKeys::XCThermWaveHeight, settings.xctherm.wave_height);
+  map.Get(ProfileKeys::XCThermVerticalWindAGL,
+          settings.xctherm.vertical_wind_agl);
+  /* download_span_hours is intentionally NOT persisted — it resets
+     to the default (1 h) at every startup. */
 }

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -427,6 +427,8 @@ Draw(Canvas &canvas, PixelRect rc,
      const TwoTextRowsRenderer &row_renderer)
 {
   row_renderer.DrawFirstRow(canvas, rc, item.label.c_str());
+  if (!item.info.empty())
+    row_renderer.DrawSecondRow(canvas, rc, item.info.c_str());
 }
 
 static void

--- a/src/Weather/MapOverlay/ControlsFactory.cpp
+++ b/src/Weather/MapOverlay/ControlsFactory.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "ControlsFactory.hpp"
+#include "Weather/Features.hpp"
 
 #ifdef HAVE_EDL
 #include "EdlControlsModel.hpp"

--- a/src/Weather/MapOverlay/ControlsModel.hpp
+++ b/src/Weather/MapOverlay/ControlsModel.hpp
@@ -20,6 +20,12 @@ enum class SecondaryLabelAction : uint8_t {
   OPEN_PICKER,
 };
 
+enum class PrimaryLabelAction : uint8_t {
+  NONE,
+  RESUME_AUTO,
+  OPEN_PICKER,
+};
+
 /**
  * How #ControlsWidget should refresh after a model-driven change.
  */
@@ -88,6 +94,13 @@ public:
   }
 
   virtual void ApplySecondaryAutoAdvance() noexcept {}
+
+  [[nodiscard]]
+  virtual PrimaryLabelAction GetPrimaryLabelAction() const noexcept {
+    return PrimaryLabelAction::RESUME_AUTO;
+  }
+
+  virtual void OpenPrimaryPicker() noexcept {}
 
   [[nodiscard]]
   virtual SecondaryLabelAction GetSecondaryLabelAction() const noexcept {

--- a/src/Weather/MapOverlay/ControlsWidget.cpp
+++ b/src/Weather/MapOverlay/ControlsWidget.cpp
@@ -113,10 +113,19 @@ ControlsWidget::OnStepSecondary(int delta) noexcept
 void
 ControlsWidget::OnPrimaryLabelClick() noexcept
 {
-  if (model->GetPrimaryAutoAdvance())
-    return;
+  switch (model->GetPrimaryLabelAction()) {
+  case PrimaryLabelAction::OPEN_PICKER:
+    model->OpenPrimaryPicker();
+    break;
 
-  model->ResumePrimaryAuto();
+  case PrimaryLabelAction::RESUME_AUTO:
+    if (!model->GetPrimaryAutoAdvance())
+      model->ResumePrimaryAuto();
+    break;
+
+  case PrimaryLabelAction::NONE:
+    break;
+  }
 }
 
 void
@@ -145,6 +154,10 @@ ControlsWidget::HandleWeatherOverlayInput(const char *misc) noexcept
     return;
 
   switch (ParseOverlayInputAction(misc)) {
+  case OverlayInputAction::TIME_PICKER:
+    OnPrimaryLabelClick();
+    break;
+
   case OverlayInputAction::TIME_PLUS:
     OnStepPrimary(+1);
     break;

--- a/src/Weather/MapOverlay/EdlControlsModel.cpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.cpp
@@ -5,7 +5,9 @@
 
 #include "ActionInterface.hpp"
 #include "Components.hpp"
+#include "Dialogs/ComboPicker.hpp"
 #include "Dialogs/Message.hpp"
+#include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "NetComponents.hpp"
@@ -17,8 +19,14 @@
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
 
 #include <chrono>
+#include <limits>
 
 namespace WeatherMapOverlay {
+
+static constexpr unsigned TIME_PICKER_AUTO =
+  std::numeric_limits<unsigned>::max() - 1;
+static constexpr unsigned TIME_PICKER_NOW =
+  std::numeric_limits<unsigned>::max();
 
 EdlControlsModel::~EdlControlsModel() noexcept
 {
@@ -227,6 +235,61 @@ EdlControlsModel::ApplyPrimaryAutoAdvance() noexcept
   const auto &basic = CommonInterface::Basic();
   if (basic.date_time_utc.IsPlausible())
     EDL::OnTimeUpdate(basic.date_time_utc);
+}
+
+PrimaryLabelAction
+EdlControlsModel::GetPrimaryLabelAction() const noexcept
+{
+  return PrimaryLabelAction::OPEN_PICKER;
+}
+
+void
+EdlControlsModel::OpenPrimaryPicker() noexcept
+{
+  RebuildForecastTimes();
+
+  DataFieldEnum picker;
+  picker.ClearChoices();
+  picker.addEnumText(_("Auto"), TIME_PICKER_AUTO);
+  picker.addEnumText(_("Now"), TIME_PICKER_NOW);
+
+  for (unsigned i = 0; i < forecast_choices; ++i) {
+    const auto local = forecast_times[i].ToLocal();
+    StaticString<16> label;
+    label.Format("%02u:00", unsigned(local.hour));
+    picker.addEnumText(label.c_str(), i);
+  }
+
+  if (GetPrimaryAutoAdvance())
+    picker.SetValue(TIME_PICKER_AUTO);
+  else
+    picker.SetValue(FindForecastIndex());
+
+  if (!ComboPicker(_("EDL Time"), picker, nullptr))
+    return;
+
+  const unsigned selected = picker.GetValue();
+  if (selected == TIME_PICKER_AUTO) {
+    ResumePrimaryAuto();
+    return;
+  }
+
+  if (selected == TIME_PICKER_NOW) {
+    const BrokenDateTime tracked = EDL::GetTrackedForecastTime(BrokenDateTime::NowUTC());
+    for (unsigned i = 0; i < forecast_choices; ++i) {
+      if (forecast_times[i] == tracked) {
+        SetPrimaryAutoAdvance(false);
+        SelectForecast(i);
+        Notify(ControlsUpdate::OVERLAY);
+        return;
+      }
+    }
+    return;
+  } else if (selected < forecast_choices) {
+    SetPrimaryAutoAdvance(false);
+    SelectForecast(selected);
+    Notify(ControlsUpdate::OVERLAY);
+  }
 }
 
 bool

--- a/src/Weather/MapOverlay/EdlControlsModel.hpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.hpp
@@ -45,6 +45,9 @@ public:
   bool GetPrimaryAutoAdvance() const noexcept override;
   void SetPrimaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplyPrimaryAutoAdvance() noexcept override;
+  [[nodiscard]]
+  PrimaryLabelAction GetPrimaryLabelAction() const noexcept override;
+  void OpenPrimaryPicker() noexcept override;
 
   [[nodiscard]]
   bool SupportsSecondaryAutoAdvance() const noexcept override;

--- a/src/Weather/MapOverlay/InputEventMisc.hpp
+++ b/src/Weather/MapOverlay/InputEventMisc.hpp
@@ -9,6 +9,7 @@ namespace WeatherMapOverlay {
 
 enum class OverlayInputAction {
   NONE,
+  TIME_PICKER,
   TIME_PLUS,
   TIME_MINUS,
   ALTITUDE_PLUS,
@@ -42,6 +43,8 @@ ParseOverlayInputAction(const char *misc) noexcept
     return OverlayInputAction::TIME_PLUS;
   if (StringIsEqual(misc, "time -"))
     return OverlayInputAction::TIME_MINUS;
+  if (StringIsEqual(misc, "time picker"))
+    return OverlayInputAction::TIME_PICKER;
 
   if (StringIsEqual(misc, "altitude +") || StringIsEqual(misc, "level +"))
     return OverlayInputAction::ALTITUDE_PLUS;

--- a/src/Weather/MapOverlay/PagePlacement.hpp
+++ b/src/Weather/MapOverlay/PagePlacement.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "PageSettings.hpp"
+
+namespace WeatherMapOverlay {
+
+enum class AddPageResult {
+  SUCCESS,
+  INVALID_SOURCE_PAGE,
+  PAGE_LIMIT_REACHED,
+};
+
+static inline void
+ApplyWeatherOverlayToLayout(PageLayout &layout,
+                            PageLayout::Overlay overlay,
+                            int rasp_field=-1) noexcept
+{
+  if (!layout.IsDefined())
+    layout = PageLayout::Default();
+
+  if (!layout.IsMapMain())
+    layout.main = PageLayout::Main::MAP;
+
+  layout.overlay = overlay;
+  layout.bottom = PageLayout::Bottom::WEATHER_CONTROLS;
+  layout.rasp_field = overlay == PageLayout::Overlay::RASP
+    ? rasp_field
+    : -1;
+  layout.Normalise();
+}
+
+static inline bool
+ApplyWeatherOverlayToPage(PageSettings &settings,
+                          unsigned page_index,
+                          PageLayout::Overlay overlay,
+                          int rasp_field=-1) noexcept
+{
+  if (page_index >= settings.n_pages)
+    return false;
+
+  ApplyWeatherOverlayToLayout(settings.pages[page_index], overlay, rasp_field);
+  return true;
+}
+
+static inline AddPageResult
+AddWeatherOverlayPage(PageSettings &settings,
+                      unsigned source_page_index,
+                      PageLayout::Overlay overlay,
+                      unsigned &new_page_index,
+                      int rasp_field=-1) noexcept
+{
+  if (source_page_index >= settings.n_pages)
+    return AddPageResult::INVALID_SOURCE_PAGE;
+
+  if (settings.n_pages >= PageSettings::MAX_PAGES)
+    return AddPageResult::PAGE_LIMIT_REACHED;
+
+  const unsigned append_index = settings.n_pages;
+  settings.pages[append_index] = settings.pages[source_page_index];
+  ApplyWeatherOverlayToLayout(settings.pages[append_index],
+                              overlay, rasp_field);
+  ++settings.n_pages;
+  new_page_index = append_index;
+  return AddPageResult::SUCCESS;
+}
+
+} // namespace WeatherMapOverlay

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -123,13 +123,11 @@ RaspControlsModel::OpenSecondaryPicker() noexcept
 
   const int selected = field.GetValue();
   if (selected < 0) {
-    PageActions::AddWeatherOverlayToCurrentPage(PageLayout::Overlay::NONE);
-    Notify(ControlsUpdate::OVERLAY);
+    Rasp::ClearSelectedField();
     return;
   }
 
   Rasp::SelectField(unsigned(selected));
-  Notify(ControlsUpdate::OVERLAY);
 }
 
 void

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -9,6 +9,7 @@
 #include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "PageActions.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
 
@@ -110,7 +111,9 @@ RaspControlsModel::OpenSecondaryPicker() noexcept
     return;
 
   DataFieldEnum field;
-  Rasp::FillFieldChoices(field, rasp.get());
+  Rasp::FieldChoicesOptions options;
+  options.include_none = true;
+  Rasp::FillFieldChoices(field, rasp.get(), options);
 
   const int current = Rasp::GetEffectiveFieldIndex();
   field.SetValue(current >= 0 ? current : 0);
@@ -119,8 +122,11 @@ RaspControlsModel::OpenSecondaryPicker() noexcept
     return;
 
   const int selected = field.GetValue();
-  if (selected < 0)
+  if (selected < 0) {
+    PageActions::AddWeatherOverlayToCurrentPage(PageLayout::Overlay::NONE);
+    Notify(ControlsUpdate::OVERLAY);
     return;
+  }
 
   Rasp::SelectField(unsigned(selected));
   Notify(ControlsUpdate::OVERLAY);

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -12,12 +12,21 @@
 #include "PageActions.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
+#include "UIState.hpp"
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Weather/Rasp/DownloadGlue.hpp"
 #endif
 
+#include <cstdio>
+#include <limits>
+
 namespace WeatherMapOverlay {
+
+static constexpr unsigned TIME_PICKER_AUTO =
+  std::numeric_limits<unsigned>::max() - 1;
+static constexpr unsigned TIME_PICKER_NOW =
+  std::numeric_limits<unsigned>::max();
 
 void
 RaspControlsModel::OnShow() noexcept
@@ -80,11 +89,61 @@ RaspControlsModel::ApplyPrimaryAutoAdvance() noexcept
   Rasp::ApplyAutoAdvanceTime();
 }
 
+PrimaryLabelAction
+RaspControlsModel::GetPrimaryLabelAction() const noexcept
+{
+  return PrimaryLabelAction::OPEN_PICKER;
+}
+
 [[nodiscard]]
 SecondaryLabelAction
 RaspControlsModel::GetSecondaryLabelAction() const noexcept
 {
   return SecondaryLabelAction::OPEN_PICKER;
+}
+
+void
+RaspControlsModel::OpenPrimaryPicker() noexcept
+{
+  const auto rasp = DataGlobals::GetRasp();
+  const int field_index = Rasp::GetEffectiveFieldIndex();
+  if (rasp == nullptr || field_index < 0 ||
+      unsigned(field_index) >= rasp->GetItemCount())
+    return;
+
+  DataFieldEnum time;
+  time.ClearChoices();
+  time.addEnumText(_("Auto"), TIME_PICKER_AUTO);
+  time.addEnumText(_("Now"), TIME_PICKER_NOW);
+
+  for (unsigned i = 0; i < RaspStore::MAX_WEATHER_TIMES; ++i) {
+    const BrokenTime t = RaspStore::IndexToTime(i);
+    char label[24];
+    std::snprintf(label, sizeof(label), "%02u:%02u %s",
+                  unsigned(t.hour), unsigned(t.minute),
+                  rasp->IsTimeAvailable(unsigned(field_index), i)
+                  ? "[x]" : "[ ]");
+    time.addEnumText(label, t.GetMinuteOfDay());
+  }
+
+  const auto &weather = CommonInterface::GetUIState().weather;
+  if (weather.time_auto_advance)
+    time.SetValue(TIME_PICKER_AUTO);
+  else if (!weather.time.IsPlausible())
+    time.SetValue(TIME_PICKER_NOW);
+  else
+    time.SetValue(weather.time.GetMinuteOfDay());
+
+  if (!ComboPicker(_("RASP Time"), time, nullptr))
+    return;
+
+  const unsigned selected = time.GetValue();
+  if (selected == TIME_PICKER_AUTO)
+    Rasp::ResumeAutoAdvance();
+  else if (selected == TIME_PICKER_NOW)
+    Rasp::SetCursorNow();
+  else
+    Rasp::SetCursorTime(selected);
 }
 
 void

--- a/src/Weather/MapOverlay/RaspControlsModel.hpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.hpp
@@ -34,8 +34,12 @@ public:
   void ApplyPrimaryAutoAdvance() noexcept override;
 
   [[nodiscard]]
+  PrimaryLabelAction GetPrimaryLabelAction() const noexcept override;
+
+  [[nodiscard]]
   SecondaryLabelAction GetSecondaryLabelAction() const noexcept override;
 
+  void OpenPrimaryPicker() noexcept override;
   void ResumePrimaryAuto() noexcept override;
   void OpenSecondaryPicker() noexcept override;
 

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -64,7 +64,7 @@ XcthermControlsModel::FormatPrimaryLabel(StaticString<64> &text) const noexcept
     return;
   }
 #endif
-  text = _("XCTherm");
+  text = "XCTherm";
 }
 
 void

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -60,7 +60,7 @@ XcthermControlsModel::FormatPrimaryLabel(StaticString<64> &text) const noexcept
 {
 #ifdef HAVE_HTTP
   if (model != nullptr) {
-    const_cast<XCTherm::XCThermControlsModel *>(model)->FormatTimeLabel(text);
+    model->FormatTimeLabel(text);
     return;
   }
 #endif

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -4,6 +4,8 @@
 #include "XcthermControlsModel.hpp"
 
 #include "ActionInterface.hpp"
+#include "Dialogs/ComboPicker.hpp"
+#include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
@@ -12,7 +14,16 @@
 #include "Weather/xctherm/XCThermControlsModel.hpp"
 #endif
 
+#include <algorithm>
+#include <cstdio>
+#include <limits>
+
 namespace WeatherMapOverlay {
+
+static constexpr unsigned TIME_PICKER_AUTO =
+  std::numeric_limits<unsigned>::max() - 1;
+static constexpr unsigned TIME_PICKER_NOW =
+  std::numeric_limits<unsigned>::max();
 
 XcthermControlsModel::XcthermControlsModel() noexcept
 {
@@ -147,6 +158,73 @@ XcthermControlsModel::SetPrimaryAutoAdvance(bool auto_advance) noexcept
 void
 XcthermControlsModel::ApplyPrimaryAutoAdvance() noexcept
 {
+}
+
+PrimaryLabelAction
+XcthermControlsModel::GetPrimaryLabelAction() const noexcept
+{
+  return PrimaryLabelAction::OPEN_PICKER;
+}
+
+void
+XcthermControlsModel::OpenPrimaryPicker() noexcept
+{
+#ifdef HAVE_HTTP
+  if (model == nullptr)
+    return;
+
+  DataFieldEnum picker;
+  picker.ClearChoices();
+  picker.addEnumText(_("Auto"), TIME_PICKER_AUTO);
+
+  const auto &state = model->GetState();
+  const auto &cached_hours = state.cached_hours;
+  const auto &basic = CommonInterface::Basic();
+  const bool time_plausible = basic.date_time_utc.IsPlausible();
+  if (time_plausible)
+    picker.addEnumText(_("Now"), TIME_PICKER_NOW);
+
+  for (unsigned hour = 0; hour < 24; ++hour) {
+    char label[20];
+    const bool has_data =
+      std::find(cached_hours.begin(), cached_hours.end(), hour) !=
+      cached_hours.end();
+    std::snprintf(label, sizeof(label), "%02u:00 %s", hour,
+                  has_data ? "[x]" : "[ ]");
+    picker.addEnumText(label, hour);
+  }
+
+  if (model->IsTimeAutoActive()) {
+    picker.SetValue(TIME_PICKER_AUTO);
+  } else {
+    if (!time_plausible)
+      picker.SetValue(model->GetCurrentForecastHour());
+    else {
+      const unsigned now_hour = unsigned(basic.date_time_utc.hour);
+      picker.SetValue(model->GetCurrentForecastHour() == now_hour
+                      ? TIME_PICKER_NOW
+                      : model->GetCurrentForecastHour());
+    }
+  }
+
+  if (!ComboPicker(_("XCTherm Time"), picker, nullptr))
+    return;
+
+  const unsigned selected = picker.GetValue();
+  if (selected == TIME_PICKER_AUTO) {
+    model->ResumeTimeAuto();
+  } else if (selected == TIME_PICKER_NOW && time_plausible) {
+    model->SetTimeAutoAdvance(false);
+    model->SetCurrentTimeIndex(unsigned(basic.date_time_utc.hour));
+  } else {
+    model->SetTimeAutoAdvance(false);
+    model->SetCurrentTimeIndex(selected);
+  }
+
+  model->ApplyCurrentSelectionToMap();
+  model->SaveCursorSession();
+  Notify(ControlsUpdate::OVERLAY);
+#endif
 }
 
 bool

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -4,59 +4,144 @@
 #include "XcthermControlsModel.hpp"
 
 #include "ActionInterface.hpp"
+#include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
 
+#ifdef HAVE_HTTP
+#include "Weather/xctherm/XCThermControlsModel.hpp"
+#endif
+
 namespace WeatherMapOverlay {
+
+XcthermControlsModel::XcthermControlsModel() noexcept
+{
+#ifdef HAVE_HTTP
+  model = new XCTherm::XCThermControlsModel();
+#endif
+}
+
+XcthermControlsModel::~XcthermControlsModel() noexcept
+{
+#ifdef HAVE_HTTP
+  delete model;
+#endif
+}
+
+void
+XcthermControlsModel::OnShow() noexcept
+{
+#ifdef HAVE_HTTP
+  if (model == nullptr)
+    return;
+
+  if (!prepared) {
+    model->Prepare([this]() noexcept {
+      Notify(ControlsUpdate::LABELS);
+    });
+    prepared = true;
+  }
+
+  model->OnShow();
+#endif
+}
+
+void
+XcthermControlsModel::OnHide() noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->OnHide();
+#endif
+}
 
 void
 XcthermControlsModel::FormatPrimaryLabel(StaticString<64> &text) const noexcept
 {
-  text = "XCTherm";
+#ifdef HAVE_HTTP
+  if (model != nullptr) {
+    const_cast<XCTherm::XCThermControlsModel *>(model)->FormatTimeLabel(text);
+    return;
+  }
+#endif
+  text = _("XCTherm");
 }
 
 void
 XcthermControlsModel::FormatSecondaryLabel(StaticString<64> &text) const noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr) {
+    StaticString<80> layer_text;
+    model->FormatLayerLabel(layer_text);
+    text = layer_text;
+    return;
+  }
+#endif
   text = NoForecastHint();
 }
 
 bool
 XcthermControlsModel::HasPrimaryData() const noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->HasCacheAtCurrentHour(model->GetCurrentLayer());
+#endif
   return false;
 }
 
 bool
 XcthermControlsModel::HasSecondaryData() const noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->HasCacheAtCurrentHour(model->GetCurrentLayer());
+#endif
   return false;
 }
 
 bool
 XcthermControlsModel::StepPrimary(int delta) noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->StepTime(delta);
+#endif
   (void)delta;
-  return false;
+  return true;
 }
 
 bool
 XcthermControlsModel::StepSecondary(int delta) noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->StepLayer(delta);
+#endif
   (void)delta;
-  return false;
+  return true;
 }
 
 bool
 XcthermControlsModel::GetPrimaryAutoAdvance() const noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->IsTimeAutoActive();
+#endif
   return true;
 }
 
 void
 XcthermControlsModel::SetPrimaryAutoAdvance(bool auto_advance) noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->SetTimeAutoAdvance(auto_advance);
+#else
   (void)auto_advance;
+#endif
 }
 
 void
@@ -64,9 +149,72 @@ XcthermControlsModel::ApplyPrimaryAutoAdvance() noexcept
 {
 }
 
+bool
+XcthermControlsModel::SupportsSecondaryAutoAdvance() const noexcept
+{
+  return true;
+}
+
+bool
+XcthermControlsModel::GetSecondaryAutoAdvance() const noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    return model->IsAltitudeAutoActive();
+#endif
+  return true;
+}
+
+void
+XcthermControlsModel::SetSecondaryAutoAdvance(bool auto_advance) noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->SetAltitudeAutoAdvance(auto_advance, CommonInterface::Basic());
+#else
+  (void)auto_advance;
+#endif
+}
+
+void
+XcthermControlsModel::ResumePrimaryAuto() noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->ResumeTimeAuto();
+#endif
+  Notify(ControlsUpdate::OVERLAY);
+}
+
+void
+XcthermControlsModel::ResumeSecondaryAuto() noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->ResumeLayerAuto(CommonInterface::Basic());
+#endif
+  Notify(ControlsUpdate::OVERLAY);
+}
+
+void
+XcthermControlsModel::OnGPSUpdate(const MoreData &basic) noexcept
+{
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->OnGPSUpdate(basic);
+#else
+  (void)basic;
+#endif
+  Notify(ControlsUpdate::LABELS);
+}
+
 void
 XcthermControlsModel::RefreshOverlay() noexcept
 {
+#ifdef HAVE_HTTP
+  if (model != nullptr)
+    model->ApplyCurrentSelectionToMap();
+#endif
   ActionInterface::SendUIState(true);
 }
 

--- a/src/Weather/MapOverlay/XcthermControlsModel.hpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.hpp
@@ -43,6 +43,9 @@ public:
   bool GetPrimaryAutoAdvance() const noexcept override;
   void SetPrimaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplyPrimaryAutoAdvance() noexcept override;
+  [[nodiscard]]
+  PrimaryLabelAction GetPrimaryLabelAction() const noexcept override;
+  void OpenPrimaryPicker() noexcept override;
 
   [[nodiscard]]
   bool SupportsSecondaryAutoAdvance() const noexcept override;

--- a/src/Weather/MapOverlay/XcthermControlsModel.hpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.hpp
@@ -13,9 +13,7 @@ class XCThermControlsModel;
 
 namespace WeatherMapOverlay {
 
-/**
- * Placeholder cursor-bar model for XCTherm until the backend is wired.
- */
+/** Weather cursor-bar model backed by XCTherm controls state. */
 class XcthermControlsModel final : public ControlsModel {
 #ifdef HAVE_HTTP
   bool prepared = false;

--- a/src/Weather/MapOverlay/XcthermControlsModel.hpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.hpp
@@ -5,13 +5,29 @@
 
 #include "ControlsModel.hpp"
 
+#ifdef HAVE_HTTP
+namespace XCTherm {
+class XCThermControlsModel;
+}
+#endif
+
 namespace WeatherMapOverlay {
 
 /**
  * Placeholder cursor-bar model for XCTherm until the backend is wired.
  */
 class XcthermControlsModel final : public ControlsModel {
+#ifdef HAVE_HTTP
+  bool prepared = false;
+  XCTherm::XCThermControlsModel *model = nullptr;
+#endif
 public:
+  XcthermControlsModel() noexcept;
+  ~XcthermControlsModel() noexcept override;
+
+  void OnShow() noexcept override;
+  void OnHide() noexcept override;
+
   void FormatPrimaryLabel(StaticString<64> &text) const noexcept override;
   void FormatSecondaryLabel(StaticString<64> &text) const noexcept override;
 
@@ -29,6 +45,17 @@ public:
   bool GetPrimaryAutoAdvance() const noexcept override;
   void SetPrimaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplyPrimaryAutoAdvance() noexcept override;
+
+  [[nodiscard]]
+  bool SupportsSecondaryAutoAdvance() const noexcept override;
+  [[nodiscard]]
+  bool GetSecondaryAutoAdvance() const noexcept override;
+  void SetSecondaryAutoAdvance(bool auto_advance) noexcept override;
+
+  void ResumePrimaryAuto() noexcept override;
+  void ResumeSecondaryAuto() noexcept override;
+
+  void OnGPSUpdate(const MoreData &basic) noexcept override;
 
   void RefreshOverlay() noexcept override;
 };

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -175,6 +175,12 @@ SetCursorTime(unsigned minute_of_day) noexcept
   ActionInterface::SendUIState(true);
 }
 
+void
+SetCursorNow() noexcept
+{
+  SetCursorTime(NOW_CHOICE_MINUTE_OF_DAY);
+}
+
 bool
 GetTimeAutoAdvance() noexcept
 {

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -118,6 +118,9 @@ GetFieldIndex(const PageLayout &layout) noexcept
   if (layout.overlay != PageLayout::Overlay::RASP)
     return -1;
 
+  if (layout.rasp_field < 0)
+    return -1;
+
   const auto rasp = DataGlobals::GetRasp();
   if (rasp == nullptr || rasp->GetItemCount() == 0)
     return -1;
@@ -277,6 +280,30 @@ SelectField(unsigned field_index) noexcept
       weather.time = RaspStore::IndexToTime(nearest);
     }
   }
+
+  ActionInterface::UpdateDisplayMode();
+  ActionInterface::SendUIState(true);
+  return true;
+}
+
+bool
+ClearSelectedField() noexcept
+{
+  PageSettings &settings = CommonInterface::SetUISettings().pages;
+  const PagesState &pages = CommonInterface::GetUIState().pages;
+  const unsigned page_index = pages.current_index;
+
+  PageLayout &page = settings.pages[page_index];
+  if (page.overlay != PageLayout::Overlay::RASP)
+    return false;
+
+  page.rasp_field = -1;
+  page.Normalise();
+  Profile::Save(Profile::map, page, page_index);
+
+  auto &weather = CommonInterface::SetUIState().weather;
+  weather.map = -1;
+  weather.rasp.cursor_initialized = true;
 
   ActionInterface::UpdateDisplayMode();
   ActionInterface::SendUIState(true);

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -28,6 +28,10 @@
 namespace Rasp {
 
 static BrokenTime GetAutoAdvanceLocalTime() noexcept;
+static BrokenTime GetEffectiveLocalTime(bool auto_advance) noexcept;
+static bool FieldHasAnyTime(const RaspStore &rasp,
+                            unsigned field_index) noexcept;
+static constexpr unsigned NOW_CHOICE_MINUTE_OF_DAY = 24U * 60U;
 
 [[gnu::pure]]
 static const char *
@@ -64,7 +68,7 @@ void
 InitTimeChoices(DataFieldEnum &field) noexcept
 {
   field.ClearChoices();
-  field.addEnumText(_("Now"));
+  field.addEnumText(_("Now"), NOW_CHOICE_MINUTE_OF_DAY);
 }
 
 void
@@ -95,15 +99,17 @@ FillTimeChoices(DataFieldEnum &field, const RaspStore *rasp,
 BrokenTime
 TimeFromMinuteOfDay(unsigned minute_of_day) noexcept
 {
-  return minute_of_day > 0
-    ? BrokenTime::FromMinuteOfDay(minute_of_day)
-    : BrokenTime::Invalid();
+  if (minute_of_day == NOW_CHOICE_MINUTE_OF_DAY || minute_of_day >= 24U * 60U)
+    return BrokenTime::Invalid();
+
+  return BrokenTime::FromMinuteOfDay(minute_of_day);
 }
 
 unsigned
 MinuteOfDayFromTime(BrokenTime time) noexcept
 {
-  return time.IsPlausible() ? time.GetMinuteOfDay() : 0U;
+  return time.IsPlausible() ? time.GetMinuteOfDay()
+                            : NOW_CHOICE_MINUTE_OF_DAY;
 }
 
 int
@@ -204,7 +210,8 @@ StepCursorTime(int delta) noexcept
 
   const auto &weather = CommonInterface::GetUIState().weather;
   unsigned minute_of_day = 0;
-  if (!StepTime(weather.time_auto_advance, delta, minute_of_day))
+  if (!StepTime(weather.time_auto_advance, field_index, delta,
+                minute_of_day))
     return false;
 
   SetCursorTime(minute_of_day);
@@ -238,6 +245,9 @@ SelectField(unsigned field_index) noexcept
   if (rasp == nullptr || field_index >= rasp->GetItemCount())
     return false;
 
+  if (!FieldHasAnyTime(*rasp, field_index))
+    return false;
+
   PageSettings &settings = CommonInterface::SetUISettings().pages;
   const PagesState &pages = CommonInterface::GetUIState().pages;
   const unsigned page_index = pages.current_index;
@@ -254,6 +264,20 @@ SelectField(unsigned field_index) noexcept
   weather.map = int(field_index);
   weather.rasp.cursor_initialized = true;
 
+  if (!weather.time_auto_advance &&
+      !rasp->HasSelectedTimeData(field_index, false,
+                                 weather.time, GetAutoAdvanceLocalTime())) {
+    const BrokenTime effective =
+      GetEffectiveLocalTime(false);
+    const unsigned desired = effective.IsPlausible()
+      ? RaspStore::TimeToIndex(effective)
+      : 0;
+    const unsigned nearest = rasp->GetNearestTime(field_index, desired);
+    if (nearest < RaspStore::MAX_WEATHER_TIMES) {
+      weather.time = RaspStore::IndexToTime(nearest);
+    }
+  }
+
   ActionInterface::UpdateDisplayMode();
   ActionInterface::SendUIState(true);
   return true;
@@ -266,15 +290,38 @@ StepField(int delta) noexcept
   if (count == 0 || delta == 0)
     return false;
 
+  const auto rasp = DataGlobals::GetRasp();
+  if (rasp == nullptr)
+    return false;
+
   int index = GetEffectiveFieldIndex();
   if (index < 0)
     index = 0;
 
-  int next = (int(index) + delta) % int(count);
-  if (next < 0)
-    next += int(count);
+  int current = index;
+  int remaining = delta;
+  while (remaining != 0) {
+    const int direction = remaining > 0 ? 1 : -1;
+    bool found = false;
+    for (unsigned i = 0; i < count; ++i) {
+      current += direction;
+      current %= int(count);
+      if (current < 0)
+        current += int(count);
 
-  return SelectField(unsigned(next));
+      if (FieldHasAnyTime(*rasp, unsigned(current))) {
+        found = true;
+        break;
+      }
+    }
+
+    if (!found)
+      return false;
+
+    remaining -= direction;
+  }
+
+  return SelectField(unsigned(current));
 }
 
 bool
@@ -344,11 +391,59 @@ GetEffectiveLocalTime(bool auto_advance) noexcept
   return weather.time;
 }
 
+[[gnu::pure]]
+static bool
+FieldHasAnyTime(const RaspStore &rasp, unsigned field_index) noexcept
+{
+  for (unsigned i = 0; i < RaspStore::MAX_WEATHER_TIMES; ++i)
+    if (rasp.IsTimeAvailable(field_index, i))
+      return true;
+
+  return false;
+}
+
+[[gnu::pure]]
+static unsigned
+StepToAvailableTimeIndex(const RaspStore &rasp, unsigned field_index,
+                         unsigned from, int delta) noexcept
+{
+  if (!FieldHasAnyTime(rasp, field_index))
+    return RaspStore::MAX_WEATHER_TIMES;
+
+  int current = int(from);
+  int remaining = delta;
+  while (remaining != 0) {
+    const int direction = remaining > 0 ? 1 : -1;
+    bool found = false;
+    for (int next = current + direction;
+         next >= 0 && next < int(RaspStore::MAX_WEATHER_TIMES);
+         next += direction) {
+      if (!rasp.IsTimeAvailable(field_index, unsigned(next)))
+        continue;
+
+      current = next;
+      found = true;
+      break;
+    }
+
+    if (!found)
+      return RaspStore::MAX_WEATHER_TIMES;
+
+    remaining -= direction;
+  }
+
+  return unsigned(current);
+}
+
 bool
-StepTime(bool time_auto_advance, int delta,
+StepTime(bool time_auto_advance, int field_index, int delta,
          unsigned &minute_of_day) noexcept
 {
-  if (delta == 0)
+  if (field_index < 0 || delta == 0)
+    return false;
+
+  const auto rasp = DataGlobals::GetRasp();
+  if (rasp == nullptr || unsigned(field_index) >= rasp->GetItemCount())
     return false;
 
   unsigned quarter = 0;
@@ -356,9 +451,12 @@ StepTime(bool time_auto_advance, int delta,
   if (effective.IsPlausible())
     quarter = RaspStore::TimeToIndex(effective);
 
-  int next = int(quarter) + delta;
-  next = (next % 96 + 96) % 96;
-  minute_of_day = unsigned(next) * 15;
+  const unsigned next = StepToAvailableTimeIndex(*rasp, unsigned(field_index),
+                                                 quarter, delta);
+  if (next >= RaspStore::MAX_WEATHER_TIMES)
+    return false;
+
+  minute_of_day = RaspStore::IndexToTime(next).GetMinuteOfDay();
   return true;
 }
 

--- a/src/Weather/Rasp/FieldControls.hpp
+++ b/src/Weather/Rasp/FieldControls.hpp
@@ -134,6 +134,14 @@ bool
 SelectField(unsigned field_index) noexcept;
 
 /**
+ * Clear the selected RASP field while keeping the RASP overlay active.
+ *
+ * @return false when the current page is not a RASP overlay page
+ */
+bool
+ClearSelectedField() noexcept;
+
+/**
  * Step the active RASP field by @p delta (wraps at list ends).
  *
  * @return false when stepping is not possible

--- a/src/Weather/Rasp/FieldControls.hpp
+++ b/src/Weather/Rasp/FieldControls.hpp
@@ -67,12 +67,12 @@ unsigned
 MinuteOfDayFromTime(BrokenTime time) noexcept;
 
 /**
- * Step through local quarter hours (0:00–23:45), even when no raster exists.
+ * Step through forecast times available for @p field_index.
  *
- * @return false when @p delta is zero
+ * @return false when stepping is not possible
  */
 bool
-StepTime(bool time_auto_advance, int delta,
+StepTime(bool time_auto_advance, int field_index, int delta,
          unsigned &minute_of_day) noexcept;
 
 /**
@@ -104,7 +104,8 @@ void
 ResumeAutoAdvance() noexcept;
 
 /**
- * Step the cursor-bar time by @p delta quarters and apply the selection.
+ * Step the cursor-bar time by @p delta available forecast slots and
+ * apply the selection.
  *
  * @return false when stepping is not possible
  */

--- a/src/Weather/Rasp/FieldControls.hpp
+++ b/src/Weather/Rasp/FieldControls.hpp
@@ -87,6 +87,12 @@ SyncCursorFromPageLayout() noexcept;
 void
 SetCursorTime(unsigned minute_of_day) noexcept;
 
+/**
+ * Select the "Now" cursor mode while staying in manual mode.
+ */
+void
+SetCursorNow() noexcept;
+
 [[nodiscard]] [[gnu::pure]]
 bool
 GetTimeAutoAdvance() noexcept;

--- a/src/Weather/Rasp/RaspCache.cpp
+++ b/src/Weather/Rasp/RaspCache.cpp
@@ -89,6 +89,9 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
     return;
 
   const unsigned requested_time = effective_time;
+  if (requested_time == failed_time)
+    /* avoid retrying malformed/unsupported tiles every redraw */
+    return;
 
   effective_time = store.GetNearestTime(parameter, effective_time);
   if (effective_time == RaspStore::MAX_WEATHER_TIMES)
@@ -110,6 +113,7 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
                         true, operation);
   } catch (...) {
     LogError(std::current_exception(), "Failed to load RASP file");
+    failed_time = requested_time;
     return;
   }
 
@@ -117,4 +121,5 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
 
   map = std::move(new_map);
   last_time = requested_time;
+  failed_time = unsigned(-1);
 }

--- a/src/Weather/Rasp/RaspCache.cpp
+++ b/src/Weather/Rasp/RaspCache.cpp
@@ -84,17 +84,18 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
     assert(effective_time < RaspStore::MAX_WEATHER_TIMES);
   }
 
-  if (effective_time == last_time)
+  const unsigned requested_time = effective_time;
+  const unsigned resolved_time =
+    store.GetNearestTime(parameter, requested_time);
+  if (resolved_time == RaspStore::MAX_WEATHER_TIMES)
+    return;
+
+  if (resolved_time == last_time)
     // no change, quick exit.
     return;
 
-  const unsigned requested_time = effective_time;
-  if (requested_time == failed_time)
+  if (resolved_time == failed_time)
     /* avoid retrying malformed/unsupported tiles every redraw */
-    return;
-
-  effective_time = store.GetNearestTime(parameter, effective_time);
-  if (effective_time == RaspStore::MAX_WEATHER_TIMES)
     return;
 
   auto archive = store.OpenArchive();
@@ -103,7 +104,7 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
 
   char new_name[MAX_PATH];
   if (!store.WeatherFilename(new_name, Path(store.GetItemInfo(parameter).name),
-                             effective_time))
+                             resolved_time))
     return;
 
   auto new_map = std::make_unique<RasterMap>();
@@ -113,13 +114,13 @@ RaspCache::Reload(BrokenTime time_local, OperationEnvironment &operation)
                         true, operation);
   } catch (...) {
     LogError(std::current_exception(), "Failed to load RASP file");
-    failed_time = requested_time;
+    failed_time = resolved_time;
     return;
   }
 
   new_map->UpdateProjection();
 
   map = std::move(new_map);
-  last_time = requested_time;
+  last_time = resolved_time;
   failed_time = unsigned(-1);
 }

--- a/src/Weather/Rasp/RaspCache.hpp
+++ b/src/Weather/Rasp/RaspCache.hpp
@@ -22,6 +22,7 @@ class RaspCache {
 
   unsigned time = 0;
   unsigned last_time = 0;
+  unsigned failed_time = unsigned(-1);
 
   std::unique_ptr<RasterMap> map;
 

--- a/src/Weather/Settings.hpp
+++ b/src/Weather/Settings.hpp
@@ -5,12 +5,72 @@
 
 #include "Weather/Features.hpp"
 #include "net/http/Features.hpp"
+#include "util/StaticString.hxx"
+
+#include <cstdint>
 
 #ifdef HAVE_PCMET
 
 #include "PCMet/Settings.hpp"
 
 #endif
+
+struct WeatherCredentialsSettings {
+  StaticString<64> email;
+  StaticString<64> password;
+
+  bool IsDefined() const noexcept {
+    return !email.empty() && !password.empty();
+  }
+
+  void SetDefaults() noexcept {
+    /* Never embed real credentials in source — they would ship in the
+       binary and end up reused across users. Users supply their own
+       credentials via Config → Weather → XCTherm. */
+    email.clear();
+    password.clear();
+  }
+};
+
+struct XCThermSettings {
+#ifdef HAVE_HTTP
+  /**
+   * Automatically switch altitude layer and forecast time
+   * based on current GPS altitude and UTC time.
+   */
+  bool auto_switch;
+#endif
+
+  WeatherCredentialsSettings credentials;
+  unsigned model;
+  unsigned parameter;
+  unsigned wave_height;
+  unsigned vertical_wind_agl;
+
+  /**
+   * How many hours of hourly forecasts the Download button fetches,
+   * starting from the next full hour. E.g. 12 → download +1h, +2h, ..., +12h.
+   *
+   * Session-only: always resets to the default on startup. The user can
+   * change it via the "Span" button during a session, but the value is
+   * never persisted to the profile — by design, so each session starts
+   * with the cheap quick-look default.
+   */
+  unsigned download_span_hours;
+
+  void SetDefaults() noexcept {
+#ifdef HAVE_HTTP
+    auto_switch = true;
+#endif
+
+    credentials.SetDefaults();
+    model = 0;
+    parameter = 0;
+    wave_height = 3000;
+    vertical_wind_agl = 100;
+    download_span_hours = 1;
+  }
+};
 
 struct WeatherSettings {
 #ifdef HAVE_PCMET
@@ -24,6 +84,8 @@ struct WeatherSettings {
   bool enable_tim;
 #endif
 
+  XCThermSettings xctherm;
+
   void SetDefaults() noexcept {
 #ifdef HAVE_PCMET
     pcmet.SetDefaults();
@@ -32,5 +94,7 @@ struct WeatherSettings {
 #ifdef HAVE_HTTP
     enable_tim = false;
 #endif
+
+    xctherm.SetDefaults();
   }
 };

--- a/src/Weather/WeatherUIState.hpp
+++ b/src/Weather/WeatherUIState.hpp
@@ -149,6 +149,19 @@ struct WeatherUIState {
   EDLWeatherUIState edl;
 
   OverlaySession xctherm;
+  struct XCThermCursorState {
+    unsigned layer = 0;
+    unsigned forecast_utc_hour = 12;
+    bool altitude_manual_override = false;
+    bool time_manual_override = false;
+
+    void Clear() noexcept {
+      layer = 0;
+      forecast_utc_hour = 12;
+      altitude_manual_override = false;
+      time_manual_override = false;
+    }
+  } xctherm_cursor;
 
   void Clear() noexcept {
     map = -1;
@@ -157,6 +170,7 @@ struct WeatherUIState {
     rasp.Clear();
     edl.Clear();
     xctherm.Clear();
+    xctherm_cursor.Clear();
   }
 
   /**

--- a/src/Weather/xctherm/XCThermAPI.cpp
+++ b/src/Weather/xctherm/XCThermAPI.cpp
@@ -1,0 +1,1090 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermAPI.hpp"
+#include "XCThermForecastTime.hpp"
+#include "Weather/Settings.hpp"
+#include "Weather/xctherm/XCThermCatalog.hpp"
+#include "Weather/xctherm/XCThermMapOverlay.hpp"
+#include "LocalPath.hpp"
+#include "LogFile.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/FileReader.hxx"
+#include "lib/fmt/ToBuffer.hxx"
+#include "co/InvokeTask.hxx"
+#include "lib/curl/Global.hxx"
+#include "util/ReturnValue.hxx"
+#include "net/client/xctherm/Http.hpp"
+#include "net/http/Init.hpp"
+#include "system/FileUtil.hpp"
+#include "system/Path.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <set>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <boost/json.hpp>
+
+/* ------------------------------------------------------------------ */
+/* Singleton                                                           */
+/* ------------------------------------------------------------------ */
+
+XCThermAPI &
+XCThermAPI::Instance() {
+  static XCThermAPI instance;
+  return instance;
+}
+
+XCThermAPI::XCThermAPI() = default;
+XCThermAPI::~XCThermAPI() = default;
+
+void
+XCThermAPI::SetCredentials(const std::string &email,
+                           const std::string &password) noexcept
+{
+  auth.SetCredentials(email, password);
+}
+
+void
+XCThermAPI::SetModel(const std::string &m) noexcept
+{
+  if (model == m)
+    return;
+
+  model = m;
+  available_parameters.clear();
+  index_loaded.store(false, std::memory_order_release);
+
+  {
+    const std::lock_guard lock{cache_mutex};
+    disk_index.clear();
+    geojson_cache.clear();
+    lru_order.clear();
+  }
+
+  XCTherm::ClearParsedLayerCache();
+
+  if (disk_cache_dir != nullptr)
+    ReloadDiskIndex();
+}
+
+void
+XCThermAPI::SetRegion(const unsigned region_model_id) noexcept
+{
+  SetModel(XCTherm::GetRegion(region_model_id).api_slug);
+}
+
+void
+XCThermAPI::ApplySessionSettings(const XCThermSettings &settings) noexcept
+{
+  SetCredentials(settings.credentials.email.c_str(),
+                 settings.credentials.password.c_str());
+  SetRegion(settings.model);
+}
+
+void
+XCThermAPI::PrepareSession(const XCThermSettings &settings) noexcept
+{
+  EnableDiskCache();
+  ApplySessionSettings(settings);
+}
+
+/* ------------------------------------------------------------------ */
+/* Index.json                                                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Map a (curl result, HTTP code) pair to an XCThermAPIError with a
+ * user-readable message. Caller decides whether to retry or surface.
+ */
+static XCThermAPIError
+MakeApiError(bool transfer_failed, long http_code, const std::string &context)
+{
+  if (transfer_failed) {
+    std::string msg = "Network error (";
+    msg += context;
+    msg += ")";
+    return XCThermAPIError(XCThermAPIError::Kind::NETWORK, 0,
+                           std::move(msg));
+  }
+
+  XCThermAPIError::Kind kind;
+  std::string msg;
+  switch (http_code) {
+  case 401:
+    kind = XCThermAPIError::Kind::AUTH_FAILED;
+    msg = "Authentication expired or invalid. "
+          "Check XCTherm credentials in Config → Weather → XCTherm.";
+    break;
+  case 403:
+    kind = XCThermAPIError::Kind::FORBIDDEN;
+    msg = "Access denied by XCTherm server. "
+          "Your account may not have access to this region.";
+    break;
+  case 404:
+    kind = XCThermAPIError::Kind::NOT_FOUND;
+    msg = "Forecast slot not available on server (" + context + ").";
+    break;
+  default:
+    if (http_code >= 500 && http_code < 600) {
+      kind = XCThermAPIError::Kind::SERVER_ERROR;
+      msg = "XCTherm server error (HTTP " + std::to_string(http_code) +
+            "). Will retry.";
+    } else {
+      kind = XCThermAPIError::Kind::OTHER_HTTP;
+      msg = "Unexpected HTTP " + std::to_string(http_code) +
+            " from XCTherm server.";
+    }
+    break;
+  }
+  msg += " [" + context + "]";
+  return XCThermAPIError(kind, http_code, std::move(msg));
+}
+
+Co::Task<bool>
+XCThermAPI::CoFetchIndex(CurlGlobal &curl)
+{
+  LogFmt("xctherm: fetching index for model='{}'", model);
+
+  const auto url = FmtBuffer<256>(
+    "{}/{}/index.json", XCTherm::Http::kForecastBaseUrl, model);
+
+  Curl::CoResponse response;
+  try {
+    response = co_await XCTherm::Http::CoGet(curl, url.c_str());
+  } catch (...) {
+    LogFmt("xctherm: index fetch failed (network)");
+    throw MakeApiError(true, 0, "index.json");
+  }
+
+  if (response.status != 200) {
+    LogFmt("xctherm: index fetch failed http={}", response.status);
+    throw MakeApiError(response.status == 0, (long)response.status,
+                       "index.json");
+  }
+
+  co_return ParseIndex(response.body);
+}
+
+Co::Task<bool>
+XCThermAPI::CoEnsureIndexLoaded(CurlGlobal &curl)
+{
+  if (IsIndexLoaded())
+    co_return true;
+
+  co_return co_await CoFetchIndex(curl);
+}
+
+bool
+XCThermAPI::FetchIndex()
+{
+  if (Net::curl == nullptr)
+    throw MakeApiError(true, 0, "index.json");
+
+  ReturnValue<bool> parsed;
+  const auto invoke = [&parsed](Co::Task<bool> task) -> Co::InvokeTask {
+    parsed.Set(co_await task);
+  };
+  XCTherm::Http::RunSync(*Net::curl, invoke(CoFetchIndex(*Net::curl)));
+  return std::move(parsed).Get();
+}
+
+namespace {
+
+/** Largest step span we iterate when reading index.json metadata. */
+constexpr unsigned kMaxIndexStepSpan = 168;
+
+} // namespace
+
+/* ------------------------------------------------------------------ */
+/* index.json parsing via boost::json                                  */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Extract a YYYYMMDD date and HH hour from an ISO-8601 "run" timestamp
+ * like "2026-05-18T12:00:00+00:00". Conservative: returns false if the
+ * shape doesn't match the expected length and structure.
+ */
+static bool
+ParseRunTimestamp(std::string_view iso,
+                  std::string &out_date,
+                  std::string &out_hour) noexcept
+{
+  if (iso.size() < 13 || iso[4] != '-' || iso[7] != '-' ||
+      iso[10] != 'T')
+    return false;
+  out_date.clear();
+  out_date.append(iso.substr(0, 4));
+  out_date.append(iso.substr(5, 2));
+  out_date.append(iso.substr(8, 2));
+  out_hour = iso.substr(11, 2);
+  return true;
+}
+
+/**
+ * Convenience: try to get a uint from a json value, defaulting if the
+ * value is missing or of the wrong kind. Useful because the API may
+ * send `"step": null` for partially-filled runs.
+ */
+static unsigned
+TryGetUInt(const boost::json::object &obj, std::string_view key,
+           unsigned default_val) noexcept
+{
+  auto it = obj.find(key);
+  if (it == obj.end())
+    return default_val;
+  try {
+    return (unsigned)it->value().to_number<int64_t>();
+  } catch (...) {
+    return default_val;
+  }
+}
+
+bool
+XCThermAPI::ParseIndex(const std::string &json) noexcept
+{
+  available_parameters.clear();
+  index_loaded.store(false, std::memory_order_release);
+
+  boost::json::value root;
+  try {
+    root = boost::json::parse(json);
+  } catch (const std::exception &e) {
+    LogFmt("xctherm: index.json is not valid JSON: {}", e.what());
+    return false;
+  }
+
+  if (!root.is_object()) {
+    LogFmt("xctherm: index.json root is not an object");
+    return false;
+  }
+
+  const auto &root_obj = root.as_object();
+  auto it_params = root_obj.find("parameters");
+  if (it_params == root_obj.end() || !it_params->value().is_object()) {
+    LogFmt("xctherm: no 'parameters' object in index.json");
+    return false;
+  }
+
+  for (const auto &param_kv : it_params->value().as_object()) {
+    std::string_view param_name{param_kv.key()};
+    /* We only consume "vertical_wind_*" — other params (CAPE, IR, …)
+       exist in some forecasts and are silently ignored. */
+    if (!param_name.starts_with("vertical_wind_"))
+      continue;
+    if (!param_kv.value().is_object())
+      continue;
+
+    const auto &param_obj = param_kv.value().as_object();
+    auto it_slots = param_obj.find("slots");
+    if (it_slots == param_obj.end() || !it_slots->value().is_array())
+      continue;
+
+    ParameterInfo info;
+    info.name = std::string{param_name};
+
+    for (const auto &slot_val : it_slots->value().as_array()) {
+      if (!slot_val.is_object())
+        continue;
+      const auto &slot_obj = slot_val.as_object();
+
+      auto it_run = slot_obj.find("run");
+      if (it_run == slot_obj.end() || !it_run->value().is_string())
+        continue;
+
+      ForecastSlot slot;
+      if (!ParseRunTimestamp(it_run->value().as_string().c_str(),
+                             slot.run_date, slot.run_hour))
+        continue;
+
+      auto it_steps = slot_obj.find("steps");
+      if (it_steps != slot_obj.end() && it_steps->value().is_object()) {
+        const auto &steps_obj = it_steps->value().as_object();
+        slot.step_min  = TryGetUInt(steps_obj, "min", 0);
+        slot.step_max  = TryGetUInt(steps_obj, "max", 0);
+        slot.step_step = TryGetUInt(steps_obj, "step", 1);
+        if (slot.step_step == 0)
+          slot.step_step = 1;
+        if (slot.step_max > slot.step_min + kMaxIndexStepSpan)
+          slot.step_max = slot.step_min + kMaxIndexStepSpan;
+      }
+
+      info.slots.push_back(std::move(slot));
+    }
+
+    if (!info.slots.empty())
+      available_parameters.push_back(std::move(info));
+  }
+
+  index_loaded.store(!available_parameters.empty(),
+                     std::memory_order_release);
+  LogFmt("xctherm: index parsed, {} vertical_wind parameters",
+         available_parameters.size());
+  return index_loaded.load(std::memory_order_acquire);
+}
+
+/* ------------------------------------------------------------------ */
+/* Available forecast hours                                            */
+/* ------------------------------------------------------------------ */
+
+std::vector<unsigned>
+XCThermAPI::GetAvailableForecastHours(const std::string &parameter) const noexcept
+{
+  std::set<unsigned> hours;
+
+  for (const auto &p : available_parameters) {
+    if (p.name != parameter)
+      continue;
+
+    for (const auto &slot : p.slots) {
+      unsigned run_h = (unsigned)std::atoi(slot.run_hour.c_str());
+      const unsigned capped_max = std::min(slot.step_max,
+                                           slot.step_min + kMaxIndexStepSpan);
+      if (capped_max < slot.step_min)
+        continue;
+
+      unsigned iterations = 0;
+      for (unsigned s = slot.step_min;
+           s <= capped_max && iterations < kMaxIndexStepSpan;
+           s += slot.step_step, ++iterations) {
+        unsigned forecast_h = (run_h + s) % 24;
+        hours.insert(forecast_h);
+      }
+    }
+  }
+
+  return {hours.begin(), hours.end()};
+}
+
+/* ------------------------------------------------------------------ */
+/* Find best slot for an offset from current time                      */
+/* ------------------------------------------------------------------ */
+
+bool
+XCThermAPI::FindSlotForOffset(const std::string &parameter,
+                              unsigned current_utc_hour,
+                              unsigned offset_hours,
+                              std::string &out_date,
+                              std::string &out_run_hour,
+                              unsigned &out_step) const noexcept
+{
+  /*
+   * We want: forecast for (current_utc + offset) hours from now.
+   * For a run starting at run_h, the required step is:
+   *   step = (current_utc - run_h) + offset
+   * If run_h > current_utc (run from yesterday still valid), add 24:
+   *   step = (current_utc + 24 - run_h) + offset
+   *
+   * We prefer the slot with the highest step (= most future) from
+   * the latest available run.
+   */
+  for (const auto &p : available_parameters) {
+    if (p.name != parameter)
+      continue;
+
+    /* Try slots in reverse (latest run first) */
+    for (int i = (int)p.slots.size() - 1; i >= 0; --i) {
+      const auto &slot = p.slots[i];
+      unsigned run_h = (unsigned)std::atoi(slot.run_hour.c_str());
+
+      /* How many hours ago did this run start? */
+      int hours_since_run = (int)current_utc_hour - (int)run_h;
+      if (hours_since_run < 0)
+        hours_since_run += 24;
+
+      /* The step we need */
+      unsigned needed_step = (unsigned)(hours_since_run + (int)offset_hours);
+
+      /* Check if this step is in range */
+      if (needed_step >= slot.step_min && needed_step <= slot.step_max &&
+          ((needed_step - slot.step_min) % slot.step_step == 0)) {
+        out_date = slot.run_date;
+        out_run_hour = slot.run_hour;
+        out_step = needed_step;
+        return true;
+      }
+    }
+  }
+
+  LogFmt("xctherm: FindSlotForOffset: no slot for {} +{}h from {}UTC",
+         parameter, offset_hours, current_utc_hour);
+  return false;
+}
+
+/* ------------------------------------------------------------------ */
+/* GeoJSON download                                                    */
+/* ------------------------------------------------------------------ */
+
+std::string
+XCThermAPI::FormatStep(unsigned step) noexcept
+{
+  return std::string(FmtBuffer<8>("{:03}", step).c_str());
+}
+
+Co::Task<bool>
+XCThermAPI::CoDownloadGeoJSON(CurlGlobal &curl,
+                              const std::string &parameter,
+                              const std::string &date,
+                              const std::string &run_hour,
+                              const unsigned step,
+                              std::string &out_geojson,
+                              int64_t *const out_wire_bytes,
+                              ProgressListener *const progress,
+                              const std::function<bool()> &should_continue)
+{
+  out_geojson.clear();
+
+  if (!auth.EnsureValidToken()) {
+    LogFmt("xctherm: cannot download — auth failed");
+    throw XCThermAPIError(XCThermAPIError::Kind::AUTH_FAILED, 0,
+                          "XCTherm authentication failed. Check "
+                          "credentials in Config → Weather → XCTherm.");
+  }
+
+  const std::string step_str = FormatStep(step);
+  const auto url = FmtBuffer<512>(
+    "{}/{}/{}/{}/{}/{}.geojson",
+    XCTherm::Http::kForecastBaseUrl,
+    model, date, run_hour, step_str, parameter);
+  const std::string context = parameter + " " + date + "/" + run_hour +
+                              "Z step " + step_str;
+
+  LogFmt("xctherm: downloading {}", url.c_str());
+
+  Curl::CoResponse response;
+  try {
+    response = co_await XCTherm::Http::CoBearerGet(
+      curl, url.c_str(), auth, progress, should_continue, true);
+  } catch (const XCTherm::Http::TransferCancelled &) {
+    co_return false;
+  } catch (...) {
+    if (!should_continue())
+      co_return false;
+
+    LogFmt("xctherm: download failed (network) {}", context);
+    throw MakeApiError(true, 0, context);
+  }
+
+  if (!should_continue())
+    co_return false;
+
+  if (response.status != 200) {
+    LogFmt("xctherm: download failed http={}", response.status);
+    throw MakeApiError(response.status == 0, (long)response.status, context);
+  }
+
+  if (out_wire_bytes != nullptr)
+    *out_wire_bytes = (int64_t)response.body.size();
+
+  out_geojson = std::move(response.body);
+
+  LogFmt("xctherm: {:.1f} KB decompressed",
+         out_geojson.size() / 1024.0);
+
+  /* Build the cache entry once; commit it atomically only after the
+     curl handle reported success above. ControlsWidget reads from
+     geojson_cache by UTC hour on the UI thread, so we must lock — but
+     only across the short map insert, never across the curl call. */
+  CachedSlice slice;
+  slice.geojson = out_geojson;
+  slice.run_date = date;
+  slice.run_hour = run_hour;
+  slice.step = step;
+  slice.downloaded_at = (int64_t)std::chrono::duration_cast<std::chrono::seconds>(
+    std::chrono::system_clock::now().time_since_epoch()).count();
+
+  const unsigned run_h = (unsigned)std::atoi(run_hour.c_str());
+  const unsigned forecast_utc = (run_h + step) % 24;
+
+  /* Persist to disk before committing to RAM — that way a crash mid-
+     write doesn't leave the RAM cache pointing at a slice that has no
+     on-disk backing. Disk write is best-effort: failure logs, doesn't
+     throw, doesn't prevent the RAM cache update below. */
+  WriteSliceToDisk(parameter, forecast_utc, slice);
+
+  {
+    const std::lock_guard lock{cache_mutex};
+    /* Record in the authoritative disk index... */
+    disk_index[parameter][forecast_utc] =
+      SliceMeta{slice.run_date, slice.run_hour, slice.step,
+                slice.downloaded_at};
+    /* ...and keep the just-downloaded body hot in the LRU cache. */
+    InsertResident(parameter, forecast_utc, std::move(slice));
+  }
+
+  co_return !out_geojson.empty();
+}
+
+/* ------------------------------------------------------------------ */
+/* Cache accessors                                                     */
+/* ------------------------------------------------------------------ */
+
+/* All cache accessors lock briefly to coordinate with the download
+   worker thread that may be writing entries concurrently. */
+
+bool
+XCThermAPI::IsLayerCached(const std::string &parameter,
+                           unsigned utc_hour) const noexcept
+{
+  const std::lock_guard lock{cache_mutex};
+  auto it = disk_index.find(parameter);
+  if (it == disk_index.end())
+    return false;
+  return it->second.find(utc_hour) != it->second.end();
+}
+
+bool
+XCThermAPI::IsCachedAtRun(const std::string &parameter,
+                          unsigned utc_hour,
+                          const std::string &run_date,
+                          const std::string &run_hour) const noexcept
+{
+  const std::lock_guard lock{cache_mutex};
+  auto it = disk_index.find(parameter);
+  if (it == disk_index.end())
+    return false;
+  auto it2 = it->second.find(utc_hour);
+  if (it2 == it->second.end())
+    return false;
+  return it2->second.run_date == run_date
+    && it2->second.run_hour == run_hour;
+}
+
+std::string
+XCThermAPI::GetCachedGeoJSON(const std::string &parameter,
+                             unsigned utc_hour) noexcept
+{
+  const std::lock_guard lock{cache_mutex};
+
+  /* Fast path: body already resident. */
+  auto it = geojson_cache.find(parameter);
+  if (it != geojson_cache.end()) {
+    auto it2 = it->second.find(utc_hour);
+    if (it2 != it->second.end()) {
+      TouchResident(parameter, utc_hour);
+      return it2->second.geojson;
+    }
+  }
+
+  /* Not resident — is it on disk (in the index)? */
+  auto di = disk_index.find(parameter);
+  if (di == disk_index.end() || di->second.find(utc_hour) == di->second.end())
+    return {};
+
+  /* Fault the body in from disk and keep it (LRU-bounded). The read
+     happens under the lock; bodies are a few MB and reads are fast, and
+     this is never called from the map draw thread. */
+  CachedSlice slice;
+  if (!ReadSliceFile(parameter, utc_hour, slice))
+    return {};
+
+  std::string body = slice.geojson;  // copy out before move into cache
+  InsertResident(parameter, utc_hour, std::move(slice));
+  return body;
+}
+
+std::optional<XCThermAPI::SliceMeta>
+XCThermAPI::GetSliceMeta(const std::string &parameter,
+                         unsigned utc_hour) const noexcept
+{
+  const std::lock_guard lock{cache_mutex};
+  auto it = disk_index.find(parameter);
+  if (it == disk_index.end())
+    return std::nullopt;
+  auto it2 = it->second.find(utc_hour);
+  if (it2 == it->second.end())
+    return std::nullopt;
+  return it2->second;
+}
+
+std::vector<unsigned>
+XCThermAPI::GetCachedHours(const std::string &parameter) const noexcept
+{
+  std::vector<unsigned> result;
+  const std::lock_guard lock{cache_mutex};
+  auto it = disk_index.find(parameter);
+  if (it == disk_index.end())
+    return result;
+  for (const auto &kv : it->second)
+    result.push_back(kv.first);
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+XCThermAPI::LayerCacheSummary
+XCThermAPI::GetCachedLayerSummary(const std::string &parameter) const noexcept
+{
+  LayerCacheSummary out;
+  const std::lock_guard lock{cache_mutex};
+  auto it = disk_index.find(parameter);
+  if (it == disk_index.end())
+    return out;
+
+  const auto now = std::chrono::system_clock::now();
+
+  for (const auto &kv : it->second) {
+    out.hours.push_back(kv.first);
+    const auto &s = kv.second;
+    if (s.downloaded_at != 0) {
+      if (s.downloaded_at > out.latest_downloaded_at) {
+        out.latest_downloaded_at = s.downloaded_at;
+        /* Track the run identity of the most recently written slice
+           — assuming all slices in one download share a run, this
+           gives the dialog a coherent "Issued <run>" tag. */
+        out.latest_run_date = s.run_date;
+        out.latest_run_hour = s.run_hour;
+      }
+    }
+
+    /* Count slices that are still valid in the future. valid_time =
+       run_date (YYYYMMDD) + run_hour (HH) + step hours. Anything that
+       fails to parse is silently skipped — we'd rather under-report
+       than crash on malformed metadata. */
+    std::chrono::sys_seconds valid_tp{};
+    if (XCTherm::MakeForecastDateTime(s.run_date, s.run_hour, s.step, valid_tp) &&
+        valid_tp > now)
+      ++out.future_hours;
+  }
+  std::sort(out.hours.begin(), out.hours.end());
+  return out;
+}
+
+bool
+XCThermAPI::HasAnyCache() const noexcept
+{
+  const std::lock_guard lock{cache_mutex};
+  for (const auto &kv : disk_index)
+    if (!kv.second.empty())
+      return true;
+  return false;
+}
+
+void
+XCThermAPI::ClearLayer(const std::string &parameter) noexcept
+{
+  std::vector<unsigned> dropped_hours;
+  {
+    const std::lock_guard lock{cache_mutex};
+    auto it = disk_index.find(parameter);
+    if (it != disk_index.end()) {
+      dropped_hours.reserve(it->second.size());
+      for (const auto &kv : it->second)
+        dropped_hours.push_back(kv.first);
+    }
+    disk_index.erase(parameter);
+    geojson_cache.erase(parameter);
+    for (unsigned utc : dropped_hours)
+      DropResident(parameter, utc);
+  }
+
+  /* Disk cleanup outside the cache mutex — file I/O isn't a hot path
+     and FileUtil functions are noexcept but can still take a moment. */
+  for (unsigned utc : dropped_hours)
+    DeleteSliceFromDisk(parameter, utc);
+
+  XCTherm::ClearParsedLayerCache(&parameter);
+}
+
+unsigned
+XCThermAPI::PruneStaleRuns(const std::string &parameter,
+                           unsigned current_utc_hour) noexcept
+{
+  /* Sweep policy: for every cached UTC hour of @p parameter, ask
+     FindSlotForOffset which run is currently the freshest for that
+     hour and drop the cache entry if it doesn't match.
+
+     We compute the offset to the *next* occurrence of each hour from
+     @c current_utc_hour. For past hours that means an offset in
+     1..23 (wrapping into tomorrow); that's fine for matching the
+     latest model run because runs don't depend on whether the
+     forecast time has already passed.
+
+     The lock is held briefly per lookup; FindSlotForOffset reads
+     available_parameters which is only written by FetchIndex on the
+     UI thread, so no second mutex needed. */
+  std::vector<unsigned> hours_to_drop;
+
+  {
+    const std::lock_guard lock{cache_mutex};
+    auto it = disk_index.find(parameter);
+    if (it == disk_index.end())
+      return 0;
+
+    for (const auto &kv : it->second) {
+      const unsigned utc = kv.first;
+      const auto &meta = kv.second;
+
+      const unsigned offset = (utc + 24 - current_utc_hour) % 24;
+      std::string latest_date, latest_run;
+      unsigned latest_step;
+      if (!FindSlotForOffset(parameter, current_utc_hour, offset,
+                             latest_date, latest_run, latest_step))
+        /* Index doesn't cover this hour any more — keep the cached
+           slice, the user explicitly downloaded it. */
+        continue;
+
+      if (meta.run_date != latest_date ||
+          meta.run_hour != latest_run)
+        hours_to_drop.push_back(utc);
+    }
+
+    for (unsigned utc : hours_to_drop) {
+      it->second.erase(utc);
+      DropResident(parameter, utc);
+    }
+  }
+
+  for (unsigned utc : hours_to_drop)
+    DeleteSliceFromDisk(parameter, utc);
+
+  return (unsigned)hours_to_drop.size();
+}
+
+/* ------------------------------------------------------------------ */
+/* Disk cache                                                          */
+/* ------------------------------------------------------------------ */
+
+/* On-disk file header: one-line metadata, then the original GeoJSON
+   bytes. v=1 lets future versions invalidate older format silently. */
+/* Current on-disk format marker. v2 added `downloaded_at=<unix_sec>`.
+   v1 files are still loaded for backwards compatibility, with the
+   timestamp falling back to the file mtime — see Loader::Visit. */
+static constexpr const char *kDiskHeaderV1 = "#XCTHERMv1";
+static constexpr const char *kDiskHeaderV2 = "#XCTHERMv2";
+static constexpr const char *kDiskHeader = kDiskHeaderV2;
+
+/* Files older than this on app startup are treated as stale and not
+   loaded back into RAM (and deleted to keep the directory tidy). */
+static constexpr std::chrono::hours kDiskTTL{24};
+
+static AllocatedPath
+BuildDiskCacheDirectory()
+{
+  const auto weather_path = LocalPath("weather");
+  Directory::Create(weather_path);
+  auto xctherm_path = AllocatedPath::Build(weather_path, Path("xctherm"));
+  Directory::Create(xctherm_path);
+  return xctherm_path;
+}
+
+AllocatedPath
+XCThermAPI::ModelDiskCacheDirectory() const noexcept
+{
+  if (disk_cache_dir == nullptr)
+    return nullptr;
+
+  try {
+    auto model_dir = AllocatedPath::Build(disk_cache_dir, Path(model.c_str()));
+    Directory::Create(model_dir);
+    return model_dir;
+  } catch (...) {
+    return nullptr;
+  }
+}
+
+void
+XCThermAPI::ReloadDiskIndex() noexcept
+{
+  const auto model_dir = ModelDiskCacheDirectory();
+  if (model_dir == nullptr)
+    return;
+
+  {
+    const std::lock_guard lock{cache_mutex};
+    disk_index.clear();
+  }
+
+  struct Indexer final : public File::Visitor {
+    XCThermAPI &api;
+    const std::chrono::system_clock::time_point cutoff;
+    unsigned indexed = 0;
+    unsigned dropped = 0;
+    Indexer(XCThermAPI &_api,
+            std::chrono::system_clock::time_point _cutoff) noexcept
+      : api(_api), cutoff(_cutoff) {}
+
+    void Visit(Path path, Path filename) override {
+      /* Filename pattern: <param>_<utc>.xctcache */
+      const auto mtime_tp = File::GetLastModification(path);
+      if (mtime_tp < cutoff) {
+        File::Delete(path);
+        ++dropped;
+        return;
+      }
+
+      /* Parse filename to recover (parameter, utc). */
+      const std::string_view name{filename.c_str()};
+      const auto dot = name.rfind('.');
+      const auto under = name.rfind('_', dot);
+      if (dot == std::string_view::npos ||
+          under == std::string_view::npos ||
+          under >= dot)
+        return;
+      const std::string parameter{name.substr(0, under)};
+      unsigned utc;
+      try {
+        utc = (unsigned)std::stoul(std::string{name.substr(under + 1,
+                                                           dot - under - 1)});
+      } catch (...) {
+        return;
+      }
+      if (utc >= 24)
+        return;
+
+      /* Read just the first chunk — enough to hold the one-line header
+         (~80 bytes). We never pull the multi-MB body at startup. */
+      std::string head;
+      try {
+        FileReader r{path};
+        char buf[512];
+        const auto n = r.Read(std::as_writable_bytes(std::span{buf}));
+        head.assign(buf, n);
+      } catch (...) {
+        return;
+      }
+
+      const auto eol = head.find('\n');
+      if (eol == std::string::npos)
+        return;
+      const bool is_v2 = head.compare(0, 10, kDiskHeaderV2) == 0;
+      const bool is_v1 = head.compare(0, 10, kDiskHeaderV1) == 0;
+      if (!is_v2 && !is_v1)
+        return;
+
+      /* v1: "#XCTHERMv1 run_date=YYYYMMDD run_hour=HH step=N"
+         v2: same + " downloaded_at=<unix_sec>" */
+      SliceMeta meta;
+      auto extract = [&](const char *key) -> std::string_view {
+        const std::string_view header(head.data(), eol);
+        const std::string needle = std::string{key} + "=";
+        const auto pos = header.find(needle);
+        if (pos == std::string_view::npos)
+          return {};
+        const auto v_start = pos + needle.size();
+        const auto v_end = header.find(' ', v_start);
+        return header.substr(v_start,
+          v_end == std::string_view::npos ? std::string_view::npos : v_end - v_start);
+      };
+      meta.run_date = std::string{extract("run_date")};
+      meta.run_hour = std::string{extract("run_hour")};
+      try {
+        meta.step = (unsigned)std::stoul(std::string{extract("step")});
+      } catch (...) {
+        return;
+      }
+      if (meta.run_date.size() != 8 || meta.run_hour.size() != 2)
+        return;
+
+      /* v2: read explicit timestamp. v1: fall back to file mtime so old
+         caches still display a sensible "downloaded at" in the dialog. */
+      const auto dl_at = extract("downloaded_at");
+      if (!dl_at.empty()) {
+        try {
+          meta.downloaded_at = (int64_t)std::stoll(std::string{dl_at});
+        } catch (...) {
+          meta.downloaded_at = 0;
+        }
+      }
+      if (meta.downloaded_at == 0) {
+        meta.downloaded_at =
+          (int64_t)std::chrono::duration_cast<std::chrono::seconds>(
+            mtime_tp.time_since_epoch()).count();
+      }
+
+      {
+        const std::lock_guard lock{api.cache_mutex};
+        api.disk_index[parameter][utc] = std::move(meta);
+      }
+      ++indexed;
+    }
+  };
+
+  const auto now = std::chrono::system_clock::now();
+  Indexer indexer(*this, now - kDiskTTL);
+  Directory::VisitSpecificFiles(model_dir, "*.xctcache", indexer);
+  LogFmt("xctherm: disk cache indexed {} slices for {} (dropped {} stale)",
+         indexer.indexed, model.c_str(), indexer.dropped);
+}
+
+void
+XCThermAPI::EnableDiskCache() noexcept
+{
+  if (disk_cache_dir != nullptr)
+    return;  /* idempotent */
+
+  try {
+    disk_cache_dir = BuildDiskCacheDirectory();
+  } catch (...) {
+    LogFmt("xctherm: could not create disk cache dir");
+    disk_cache_dir = nullptr;
+    return;
+  }
+  LogFmt("xctherm: disk cache dir = {}", disk_cache_dir.c_str());
+
+  ReloadDiskIndex();
+}
+
+AllocatedPath
+XCThermAPI::SliceFilePath(const std::string &parameter,
+                          unsigned forecast_utc) const noexcept
+{
+  const auto model_dir = ModelDiskCacheDirectory();
+  if (model_dir == nullptr)
+    return nullptr;
+  const auto name = FmtBuffer<128>("{}_{:02}.xctcache",
+                                   parameter, forecast_utc);
+  return AllocatedPath::Build(model_dir, name.c_str());
+}
+
+void
+XCThermAPI::WriteSliceToDisk(const std::string &parameter,
+                             unsigned forecast_utc,
+                             const CachedSlice &slice) const noexcept
+{
+  const auto path = SliceFilePath(parameter, forecast_utc);
+  if (path == nullptr)
+    return;
+
+  try {
+    FileOutputStream out{path};
+    const auto header = FmtBuffer<128>(
+      "{} run_date={} run_hour={} step={} downloaded_at={}\n",
+      kDiskHeader,
+      slice.run_date, slice.run_hour, slice.step, slice.downloaded_at);
+    out.Write(std::as_bytes(std::span(header.c_str(), std::strlen(header.c_str()))));
+    out.Write(std::as_bytes(std::span(slice.geojson.data(),
+                                      slice.geojson.size())));
+    out.Commit();
+  } catch (const std::exception &e) {
+    LogFmt("xctherm: failed to persist {} @{:02}h: {}",
+           parameter, forecast_utc, e.what());
+  } catch (...) {
+    /* never let disk failures escape — cache will simply be RAM-only
+       this session. */
+  }
+}
+
+void
+XCThermAPI::DeleteSliceFromDisk(const std::string &parameter,
+                                unsigned forecast_utc) const noexcept
+{
+  const auto path = SliceFilePath(parameter, forecast_utc);
+  if (path == nullptr)
+    return;
+  File::Delete(path);
+}
+
+bool
+XCThermAPI::ReadSliceFile(const std::string &parameter, unsigned utc_hour,
+                          CachedSlice &out) const noexcept
+{
+  const auto path = SliceFilePath(parameter, utc_hour);
+  if (path == nullptr)
+    return false;
+
+  std::string contents;
+  try {
+    FileReader r{path};
+    char buf[64 * 1024];
+    while (true) {
+      const auto n = r.Read(std::as_writable_bytes(std::span{buf}));
+      if (n == 0)
+        break;
+      contents.append(buf, n);
+    }
+  } catch (...) {
+    return false;
+  }
+
+  const auto eol = contents.find('\n');
+  if (eol == std::string::npos)
+    return false;
+  const bool is_v2 = contents.compare(0, 10, kDiskHeaderV2) == 0;
+  const bool is_v1 = contents.compare(0, 10, kDiskHeaderV1) == 0;
+  if (!is_v2 && !is_v1)
+    return false;
+
+  auto extract = [&](const char *key) -> std::string_view {
+    const std::string_view header(contents.data(), eol);
+    const std::string needle = std::string{key} + "=";
+    const auto pos = header.find(needle);
+    if (pos == std::string_view::npos)
+      return {};
+    const auto v_start = pos + needle.size();
+    const auto v_end = header.find(' ', v_start);
+    return header.substr(v_start,
+      v_end == std::string_view::npos ? std::string_view::npos : v_end - v_start);
+  };
+  out.run_date = std::string{extract("run_date")};
+  out.run_hour = std::string{extract("run_hour")};
+  try {
+    out.step = (unsigned)std::stoul(std::string{extract("step")});
+  } catch (...) {
+    return false;
+  }
+  const auto dl_at = extract("downloaded_at");
+  if (!dl_at.empty()) {
+    try {
+      out.downloaded_at = (int64_t)std::stoll(std::string{dl_at});
+    } catch (...) {
+      out.downloaded_at = 0;
+    }
+  }
+  out.geojson = contents.substr(eol + 1);
+  return true;
+}
+
+void
+XCThermAPI::TouchResident(const std::string &parameter,
+                          unsigned utc_hour) noexcept
+{
+  const auto key = std::make_pair(parameter, utc_hour);
+  auto it = std::find(lru_order.begin(), lru_order.end(), key);
+  if (it != lru_order.end())
+    lru_order.erase(it);
+  lru_order.push_front(key);
+}
+
+void
+XCThermAPI::DropResident(const std::string &parameter,
+                         unsigned utc_hour) noexcept
+{
+  const auto key = std::make_pair(parameter, utc_hour);
+  auto it = std::find(lru_order.begin(), lru_order.end(), key);
+  if (it != lru_order.end())
+    lru_order.erase(it);
+
+  auto pit = geojson_cache.find(parameter);
+  if (pit != geojson_cache.end()) {
+    pit->second.erase(utc_hour);
+    if (pit->second.empty())
+      geojson_cache.erase(pit);
+  }
+}
+
+void
+XCThermAPI::InsertResident(const std::string &parameter, unsigned utc_hour,
+                           CachedSlice &&slice) noexcept
+{
+  geojson_cache[parameter][utc_hour] = std::move(slice);
+  TouchResident(parameter, utc_hour);
+
+  /* Evict least-recently-used bodies beyond the budget. The disk index
+     and the on-disk files are untouched — only the RAM body goes. */
+  while (lru_order.size() > kMaxResidentSlices) {
+    const auto victim = lru_order.back();
+    lru_order.pop_back();
+    auto pit = geojson_cache.find(victim.first);
+    if (pit != geojson_cache.end()) {
+      pit->second.erase(victim.second);
+      if (pit->second.empty())
+        geojson_cache.erase(pit);
+    }
+  }
+}

--- a/src/Weather/xctherm/XCThermAPI.cpp
+++ b/src/Weather/xctherm/XCThermAPI.cpp
@@ -95,6 +95,12 @@ XCThermAPI::PrepareSession(const XCThermSettings &settings) noexcept
   ApplySessionSettings(settings);
 }
 
+bool
+XCThermAPI::EnsureAuthenticated() noexcept
+{
+  return auth.EnsureValidToken();
+}
+
 /* ------------------------------------------------------------------ */
 /* Index.json                                                          */
 /* ------------------------------------------------------------------ */
@@ -440,13 +446,6 @@ XCThermAPI::CoDownloadGeoJSON(CurlGlobal &curl,
 {
   out_geojson.clear();
 
-  if (!auth.EnsureValidToken()) {
-    LogFmt("xctherm: cannot download — auth failed");
-    throw XCThermAPIError(XCThermAPIError::Kind::AUTH_FAILED, 0,
-                          "XCTherm authentication failed. Check "
-                          "credentials in Config → Weather → XCTherm.");
-  }
-
   const std::string step_str = FormatStep(step);
   const auto url = FmtBuffer<512>(
     "{}/{}/{}/{}/{}/{}.geojson",
@@ -460,7 +459,7 @@ XCThermAPI::CoDownloadGeoJSON(CurlGlobal &curl,
   Curl::CoResponse response;
   try {
     response = co_await XCTherm::Http::CoBearerGet(
-      curl, url.c_str(), auth, progress, should_continue, true);
+      curl, url.c_str(), auth, progress, should_continue, false);
   } catch (const XCTherm::Http::TransferCancelled &) {
     co_return false;
   } catch (...) {
@@ -810,104 +809,116 @@ XCThermAPI::ReloadDiskIndex() noexcept
       : api(_api), cutoff(_cutoff) {}
 
     void Visit(Path path, Path filename) override {
-      /* Filename pattern: <param>_<utc>.xctcache */
-      const auto mtime_tp = File::GetLastModification(path);
-      if (mtime_tp < cutoff) {
-        File::Delete(path);
-        ++dropped;
-        return;
-      }
-
-      /* Parse filename to recover (parameter, utc). */
-      const std::string_view name{filename.c_str()};
-      const auto dot = name.rfind('.');
-      const auto under = name.rfind('_', dot);
-      if (dot == std::string_view::npos ||
-          under == std::string_view::npos ||
-          under >= dot)
-        return;
-      const std::string parameter{name.substr(0, under)};
-      unsigned utc;
       try {
-        utc = (unsigned)std::stoul(std::string{name.substr(under + 1,
-                                                           dot - under - 1)});
-      } catch (...) {
-        return;
-      }
-      if (utc >= 24)
-        return;
-
-      /* Read just the first chunk — enough to hold the one-line header
-         (~80 bytes). We never pull the multi-MB body at startup. */
-      std::string head;
-      try {
-        FileReader r{path};
-        char buf[512];
-        const auto n = r.Read(std::as_writable_bytes(std::span{buf}));
-        head.assign(buf, n);
-      } catch (...) {
-        return;
-      }
-
-      const auto eol = head.find('\n');
-      if (eol == std::string::npos)
-        return;
-      const bool is_v2 = head.compare(0, 10, kDiskHeaderV2) == 0;
-      const bool is_v1 = head.compare(0, 10, kDiskHeaderV1) == 0;
-      if (!is_v2 && !is_v1)
-        return;
-
-      /* v1: "#XCTHERMv1 run_date=YYYYMMDD run_hour=HH step=N"
-         v2: same + " downloaded_at=<unix_sec>" */
-      SliceMeta meta;
-      auto extract = [&](const char *key) -> std::string_view {
-        const std::string_view header(head.data(), eol);
-        const std::string needle = std::string{key} + "=";
-        const auto pos = header.find(needle);
-        if (pos == std::string_view::npos)
-          return {};
-        const auto v_start = pos + needle.size();
-        const auto v_end = header.find(' ', v_start);
-        return header.substr(v_start,
-          v_end == std::string_view::npos ? std::string_view::npos : v_end - v_start);
-      };
-      meta.run_date = std::string{extract("run_date")};
-      meta.run_hour = std::string{extract("run_hour")};
-      try {
-        meta.step = (unsigned)std::stoul(std::string{extract("step")});
-      } catch (...) {
-        return;
-      }
-      if (meta.run_date.size() != 8 || meta.run_hour.size() != 2)
-        return;
-
-      /* v2: read explicit timestamp. v1: fall back to file mtime so old
-         caches still display a sensible "downloaded at" in the dialog. */
-      const auto dl_at = extract("downloaded_at");
-      if (!dl_at.empty()) {
-        try {
-          meta.downloaded_at = (int64_t)std::stoll(std::string{dl_at});
-        } catch (...) {
-          meta.downloaded_at = 0;
+        /* Filename pattern: <param>_<utc>.xctcache */
+        const auto mtime_tp = File::GetLastModification(path);
+        if (mtime_tp < cutoff) {
+          File::Delete(path);
+          ++dropped;
+          return;
         }
-      }
-      if (meta.downloaded_at == 0) {
-        meta.downloaded_at =
-          (int64_t)std::chrono::duration_cast<std::chrono::seconds>(
-            mtime_tp.time_since_epoch()).count();
-      }
 
-      {
-        const std::lock_guard lock{api.cache_mutex};
-        api.disk_index[parameter][utc] = std::move(meta);
+        /* Parse filename to recover (parameter, utc). */
+        const std::string_view name{filename.c_str()};
+        const auto dot = name.rfind('.');
+        const auto under = name.rfind('_', dot);
+        if (dot == std::string_view::npos ||
+            under == std::string_view::npos ||
+            under >= dot)
+          return;
+
+        const std::string parameter{name.substr(0, under)};
+        unsigned utc;
+        try {
+          utc = (unsigned)std::stoul(std::string{name.substr(under + 1,
+                                                             dot - under - 1)});
+        } catch (...) {
+          return;
+        }
+        if (utc >= 24)
+          return;
+
+        /* Read just the first chunk — enough to hold the one-line header
+           (~80 bytes). We never pull the multi-MB body at startup. */
+        std::string head;
+        {
+          FileReader r{path};
+          char buf[512];
+          const auto n = r.Read(std::as_writable_bytes(std::span{buf}));
+          head.assign(buf, n);
+        }
+
+        const auto eol = head.find('\n');
+        if (eol == std::string::npos)
+          return;
+        const bool is_v2 = head.compare(0, 10, kDiskHeaderV2) == 0;
+        const bool is_v1 = head.compare(0, 10, kDiskHeaderV1) == 0;
+        if (!is_v2 && !is_v1)
+          return;
+
+        /* v1: "#XCTHERMv1 run_date=YYYYMMDD run_hour=HH step=N"
+           v2: same + " downloaded_at=<unix_sec>" */
+        SliceMeta meta;
+        auto extract = [&](const char *key) -> std::string_view {
+          const std::string_view header(head.data(), eol);
+          const std::string needle = std::string{key} + "=";
+          const auto pos = header.find(needle);
+          if (pos == std::string_view::npos)
+            return {};
+          const auto v_start = pos + needle.size();
+          const auto v_end = header.find(' ', v_start);
+          return header.substr(v_start,
+            v_end == std::string_view::npos ? std::string_view::npos : v_end - v_start);
+        };
+
+        meta.run_date = std::string{extract("run_date")};
+        meta.run_hour = std::string{extract("run_hour")};
+        try {
+          meta.step = (unsigned)std::stoul(std::string{extract("step")});
+        } catch (...) {
+          return;
+        }
+        if (meta.run_date.size() != 8 || meta.run_hour.size() != 2)
+          return;
+
+        /* v2: read explicit timestamp. v1: fall back to file mtime so old
+           caches still display a sensible "downloaded at" in the dialog. */
+        const auto dl_at = extract("downloaded_at");
+        if (!dl_at.empty()) {
+          try {
+            meta.downloaded_at = (int64_t)std::stoll(std::string{dl_at});
+          } catch (...) {
+            meta.downloaded_at = 0;
+          }
+        }
+        if (meta.downloaded_at == 0) {
+          meta.downloaded_at =
+            (int64_t)std::chrono::duration_cast<std::chrono::seconds>(
+              mtime_tp.time_since_epoch()).count();
+        }
+
+        {
+          const std::lock_guard lock{api.cache_mutex};
+          api.disk_index[parameter][utc] = std::move(meta);
+        }
+        ++indexed;
+      } catch (...) {
+        /* ReloadDiskIndex() is noexcept; ignore malformed entries and OOM
+           from a single file so indexing can continue. */
+        return;
       }
-      ++indexed;
     }
   };
 
   const auto now = std::chrono::system_clock::now();
   Indexer indexer(*this, now - kDiskTTL);
-  Directory::VisitSpecificFiles(model_dir, "*.xctcache", indexer);
+  try {
+    Directory::VisitSpecificFiles(model_dir, "*.xctcache", indexer);
+  } catch (...) {
+    LogError(std::current_exception(),
+             "xctherm: disk cache scan failed");
+  }
+
   LogFmt("xctherm: disk cache indexed {} slices for {} (dropped {} stale)",
          indexer.indexed, model.c_str(), indexer.dropped);
 }

--- a/src/Weather/xctherm/XCThermAPI.hpp
+++ b/src/Weather/xctherm/XCThermAPI.hpp
@@ -39,7 +39,7 @@ class XCThermAPIError : public std::runtime_error {
 public:
   enum class Kind {
     NETWORK,        ///< curl-level transport failure (timeout, DNS, etc.)
-    AUTH_FAILED,    ///< 401 after re-auth attempt
+    AUTH_FAILED,    ///< 401 unauthorized / auth invalid
     FORBIDDEN,      ///< 403
     NOT_FOUND,      ///< 404 — a single slot might genuinely be absent
     SERVER_ERROR,   ///< 5xx
@@ -115,6 +115,14 @@ public:
   void PrepareSession(const XCThermSettings &settings) noexcept;
 
   /**
+   * Ensure a valid JWT using synchronous auth/refresh.
+   *
+   * Call only from non-network-loop threads (e.g. UI thread) before
+   * launching async download work.
+   */
+  bool EnsureAuthenticated() noexcept;
+
+  /**
    * Fetch and parse index.json for the current model.
    * Populates available_parameters.
    *
@@ -173,8 +181,9 @@ public:
   /**
    * Download a single GeoJSON layer on @p curl's event loop (async).
    *
-   * Ensures a valid JWT via #auth before the request; sends Bearer auth;
-   * on HTTP 401 re-authenticates once and retries.
+   * Sends Bearer auth with the current JWT and performs one request.
+   * The async path intentionally avoids synchronous re-authentication to
+   * keep the network event loop non-blocking.
    *
    * @return @c true on success; @c false if @p should_continue returned false.
    * @throws XCThermAPIError on network / HTTP failure.

--- a/src/Weather/xctherm/XCThermAPI.hpp
+++ b/src/Weather/xctherm/XCThermAPI.hpp
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/Task.hxx"
+#include "net/client/xctherm/Auth.hpp"
+#include "Operation/Operation.hpp"
+
+#include "system/Path.hpp"
+
+class CurlGlobal;
+
+#include <atomic>
+#include <cstdint>
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+class ProgressListener;
+struct XCThermSettings;
+
+/**
+ * Errors thrown by XCThermAPI on network / HTTP failures. Callers can
+ * inspect @c kind to decide whether to retry (transient: NETWORK,
+ * SERVER_ERROR, NOT_FOUND for a single slot) or surface to the user
+ * (persistent: AUTH_FAILED, FORBIDDEN, OTHER_HTTP).
+ *
+ * what() returns a short human-readable explanation already suitable
+ * for ShowError.
+ */
+class XCThermAPIError : public std::runtime_error {
+public:
+  enum class Kind {
+    NETWORK,        ///< curl-level transport failure (timeout, DNS, etc.)
+    AUTH_FAILED,    ///< 401 after re-auth attempt
+    FORBIDDEN,      ///< 403
+    NOT_FOUND,      ///< 404 — a single slot might genuinely be absent
+    SERVER_ERROR,   ///< 5xx
+    OTHER_HTTP,     ///< unexpected HTTP code
+  };
+
+  XCThermAPIError(Kind kind, long http_code, std::string message) noexcept
+    : std::runtime_error(std::move(message)),
+      kind(kind), http_code(http_code) {}
+
+  Kind kind;
+  long http_code;
+};
+
+/**
+ * XCTherm GeoJSON API client.
+ *
+ * Fetches index.json to discover available parameters and forecast times,
+ * then downloads individual GeoJSON layers on demand.
+ *
+ * URL schema:
+ *   Index:    https://tiles.xctherm.com/forecast/{model}/index.json
+ *   GeoJSON:  https://tiles.xctherm.com/forecast/{model}/{YYYYMMDD}/{HH}/{STEP}/{parameter}.geojson
+ */
+class XCThermAPI {
+public:
+  /**
+   * A single forecast slot from index.json.
+   * Forecast time = run_datetime + step hours.
+   */
+  struct ForecastSlot {
+    std::string run_date;   // "20260506"
+    std::string run_hour;   // "03"
+    unsigned step_min = 0;
+    unsigned step_max = 0;
+    unsigned step_step = 1;
+  };
+
+  /**
+   * Info about one available parameter (e.g. "vertical_wind_3000amsl").
+   */
+  struct ParameterInfo {
+    std::string name;
+    std::vector<ForecastSlot> slots;
+  };
+
+  static XCThermAPI &Instance();
+
+  XCThermAPI();
+  ~XCThermAPI();
+
+  XCThermAPI(const XCThermAPI &) = delete;
+  XCThermAPI &operator=(const XCThermAPI &) = delete;
+
+  void SetCredentials(const std::string &email,
+                      const std::string &password) noexcept;
+
+  /**
+   * Tiles URL model slug (e.g. @c "icon-ch"), not @c settings.xctherm.model.
+   */
+  void SetModel(const std::string &api_slug) noexcept;
+
+  /**
+   * Map profile region id (@c XCTherm::Region / settings.xctherm.model)
+   * to the tiles API slug and invalidate the index when it changes.
+   */
+  void SetRegion(unsigned region_model_id) noexcept;
+
+  /** Sync credentials and region from computer settings. */
+  void ApplySessionSettings(const XCThermSettings &settings) noexcept;
+
+  /** Enable disk cache and apply @p settings (idempotent). */
+  void PrepareSession(const XCThermSettings &settings) noexcept;
+
+  /**
+   * Fetch and parse index.json for the current model.
+   * Populates available_parameters.
+   *
+   * @throws XCThermAPIError on network / HTTP failure.
+   * @return true on success, false only if parsing yielded no
+   *   recognisable forecast parameters (server response not in the
+   *   expected shape — treated as a "no XCTherm data" non-error).
+   */
+  bool FetchIndex();
+
+  /**
+   * Fetch index.json on @p curl's event loop when not already loaded.
+   *
+   * @throws XCThermAPIError on network / HTTP failure.
+   * @return false if the response contained no forecast parameters.
+   */
+  Co::Task<bool> CoEnsureIndexLoaded(CurlGlobal &curl);
+
+  /**
+   * Get available vertical_wind parameters from the last FetchIndex().
+   */
+  const std::vector<ParameterInfo> &GetAvailableParameters() const noexcept {
+    return available_parameters;
+  }
+
+  /**
+   * Get available forecast UTC hours for a given parameter.
+   * Returns sorted unique hours.
+   */
+  std::vector<unsigned> GetAvailableForecastHours(
+    const std::string &parameter) const noexcept;
+
+  /**
+   * Find the best slot for a forecast N hours into the future.
+   *
+   * Unlike FindSlotForHour, this handles the offset correctly across
+   * midnight by picking the slot whose (run_h + step) equals
+   * (current_utc + offset_hours), preferring the highest step (=most
+   * future forecast) from the latest available run.
+   *
+   * @param parameter e.g. "vertical_wind_3000amsl"
+   * @param current_utc_hour current UTC hour (0-23)
+   * @param offset_hours forecast offset (1, 6, 12, 18)
+   * @param out_date filled with YYYYMMDD
+   * @param out_run_hour filled with HH
+   * @param out_step filled with step number
+   * @return true if a valid slot was found
+   */
+  bool FindSlotForOffset(const std::string &parameter,
+                         unsigned current_utc_hour,
+                         unsigned offset_hours,
+                         std::string &out_date,
+                         std::string &out_run_hour,
+                         unsigned &out_step) const noexcept;
+
+  /**
+   * Download a single GeoJSON layer on @p curl's event loop (async).
+   *
+   * Ensures a valid JWT via #auth before the request; sends Bearer auth;
+   * on HTTP 401 re-authenticates once and retries.
+   *
+   * @return @c true on success; @c false if @p should_continue returned false.
+   * @throws XCThermAPIError on network / HTTP failure.
+   */
+  Co::Task<bool> CoDownloadGeoJSON(CurlGlobal &curl,
+                                   const std::string &parameter,
+                                   const std::string &date,
+                                   const std::string &run_hour,
+                                   unsigned step,
+                                   std::string &out_geojson,
+                                   int64_t *out_wire_bytes = nullptr,
+                                   ProgressListener *progress = nullptr,
+                                   const std::function<bool()> &should_continue = []() {
+                                     return true;
+                                   });
+
+  bool IsIndexLoaded() const noexcept {
+    return index_loaded.load(std::memory_order_acquire);
+  }
+
+  /* ---- Download cache ---- */
+
+  /**
+   * One cached forecast slice.
+   *
+   * @c run_date / @c run_hour identify the model run that issued the
+   * forecast (e.g. "20260518" / "12"). We track this so we can decide
+   * whether a cached entry is still fresh when the API offers a newer
+   * run for the same UTC hour.
+   *
+   * @c step is the forecast offset from the run (in hours). Together
+   * with run_date/run_hour it pinpoints the absolute UTC moment the
+   * forecast is valid for — needed because spans longer than 12 h
+   * cross midnight and would otherwise be ambiguous when looked up by
+   * UTC hour alone.
+   */
+  struct CachedSlice {
+    std::string geojson;
+    std::string run_date;
+    std::string run_hour;
+    unsigned step = 0;
+
+    /**
+     * Wall-clock moment this slice was first written to the cache
+     * (seconds since the Unix epoch). Persisted in the on-disk header
+     * so it survives across app restarts and is shown by the dialog
+     * to indicate forecast freshness. Zero for slices loaded from an
+     * older (#XCTHERMv1) file with no embedded timestamp — callers
+     * should fall back to the file mtime in that case.
+     */
+    int64_t downloaded_at = 0;
+  };
+
+  /**
+   * Lightweight metadata about a cached slice — everything except the
+   * (potentially multi-MB) GeoJSON body. The disk index holds one of
+   * these per cached slice so we can answer "what's available, from
+   * which run, downloaded when" without loading any bodies into RAM.
+   */
+  struct SliceMeta {
+    std::string run_date;
+    std::string run_hour;
+    unsigned step = 0;
+    int64_t downloaded_at = 0;
+  };
+
+  /**
+   * Check if a layer has already been downloaded for the given UTC hour.
+   */
+  bool IsLayerCached(const std::string &parameter,
+                     unsigned utc_hour) const noexcept;
+
+  /**
+   * Check if the cached entry for (parameter, utc_hour) was produced by
+   * the given run. Used to decide whether a Download click for an
+   * already-cached hour should be skipped (cache matches latest run) or
+   * re-issued (a newer run is now available).
+   */
+  bool IsCachedAtRun(const std::string &parameter,
+                     unsigned utc_hour,
+                     const std::string &run_date,
+                     const std::string &run_hour) const noexcept;
+
+  /**
+   * Get cached GeoJSON for a layer/hour combination, returned by value.
+   * If the slice exists on disk but isn't resident in RAM, it is
+   * faulted in (read from disk) and kept in a small LRU body cache.
+   * Returns an empty string if the slice isn't cached at all.
+   *
+   * Not const: it mutates the in-RAM LRU body cache. Call from the UI
+   * or download-worker thread, never from the map draw thread.
+   */
+  std::string GetCachedGeoJSON(const std::string &parameter,
+                               unsigned utc_hour) noexcept;
+
+  /**
+   * Get the model run / freshness metadata for a cached slice, read
+   * from the disk index (no body load). std::nullopt if not cached.
+   */
+  std::optional<SliceMeta> GetSliceMeta(const std::string &parameter,
+                                        unsigned utc_hour) const noexcept;
+
+  /**
+   * Get all UTC hours that are cached for a given parameter.
+   * Returns sorted list.
+   */
+  std::vector<unsigned> GetCachedHours(const std::string &parameter) const noexcept;
+
+  /**
+   * Summary of what's cached for a single forecast parameter — used by
+   * the XCTherm dialog on open to rehydrate per-row state from the
+   * persistent disk cache, without having to lock and look up every
+   * slice individually.
+   *
+   * All fields are empty / zero when nothing is cached for the
+   * parameter.
+   */
+  struct LayerCacheSummary {
+    std::vector<unsigned> hours;          ///< sorted cached UTC hours
+    int64_t latest_downloaded_at = 0;     ///< newest write time (unix s)
+    std::string latest_run_date;          ///< run_date of the newest slice
+    std::string latest_run_hour;          ///< run_hour of the newest slice
+
+    /**
+     * How many of the cached slices are still valid in the future,
+     * computed at query time against wall-clock. A slice's "valid
+     * time" is run_date + run_hour + step. Used by the dialog to
+     * show "4 / 12 h" — meaning 4 cached future-hours remain of the
+     * 12 h span the user has configured.
+     */
+    unsigned future_hours = 0;
+  };
+
+  LayerCacheSummary GetCachedLayerSummary(
+      const std::string &parameter) const noexcept;
+
+  /**
+   * Quick "is there any cached forecast at all?" check, used by the
+   * controls widget to collapse itself to a sliver when no XCTherm
+   * data has been downloaded — so non-XCTherm users don't see an
+   * empty cursor bar.
+   */
+  bool HasAnyCache() const noexcept;
+
+  /**
+   * Initialise the persistent disk cache directory and load any
+   * existing files from previous sessions. Files older than the TTL
+   * (24 h) are discarded on load.
+   *
+   * Idempotent — safe to call repeatedly; only the first call does
+   * work. Call once at app startup from a UI-thread context.
+   */
+  void EnableDiskCache() noexcept;
+
+  /**
+   * Clear every cached entry for a single parameter (e.g. one altitude
+   * layer). Used by the dialog's Delete button.
+   */
+  void ClearLayer(const std::string &parameter) noexcept;
+
+  /**
+   * Stale-run prune: drop cached slices for @p parameter whose
+   * (run_date, run_hour) is older than the latest run the index
+   * currently advertises for that UTC hour.
+   *
+   * Only the cached entries are touched; nothing is re-downloaded.
+   * Slices for past hours are kept (the dialog lets the user browse
+   * back), but their run version is harmonised with the rest.
+   *
+   * Returns the number of entries removed.
+   */
+  unsigned PruneStaleRuns(const std::string &parameter,
+                          unsigned current_utc_hour) noexcept;
+
+private:
+  XCTherm::Auth auth{XCTherm::kAuthConfig};
+
+  /** Tiles path segment; kept in sync via #SetRegion / #ApplySessionSettings. */
+  std::string model = "icon-ch";
+  std::vector<ParameterInfo> available_parameters;
+  std::atomic<bool> index_loaded{false};
+
+  /**
+   * Disk index: parameter -> (utc_hour -> SliceMeta). The authoritative
+   * record of what is cached on disk, populated by EnableDiskCache()
+   * scanning file headers (cheap) and kept in sync by the write paths.
+   * Metadata queries (hours, run, freshness) answer from here without
+   * touching any GeoJSON body — that's what keeps startup RAM low.
+   */
+  std::map<std::string, std::map<unsigned, SliceMeta>> disk_index;
+
+  /**
+   * In-RAM body cache: parameter -> (utc_hour -> CachedSlice with the
+   * GeoJSON body). A *bounded* LRU subset of what's in disk_index —
+   * only slices recently accessed via GetCachedGeoJSON are resident.
+   * Capped at kMaxResidentSlices so we never hold the whole 24 h × N
+   * layer cache (hundreds of MB) in memory at once.
+   */
+  std::map<std::string, std::map<unsigned, CachedSlice>> geojson_cache;
+
+  /** MRU-ordered keys for geojson_cache; front = most recently used. */
+  std::list<std::pair<std::string, unsigned>> lru_order;
+
+  /** Max number of GeoJSON bodies kept resident in geojson_cache. */
+  static constexpr std::size_t kMaxResidentSlices = 12;
+
+  /** Guards disk_index, geojson_cache and lru_order. */
+  mutable std::mutex cache_mutex;
+
+  /**
+   * Absolute path to the persistent cache directory (e.g.
+   * …/XCSoarData/weather/xctherm). Empty when disk caching is not
+   * (yet) enabled.
+   */
+  AllocatedPath disk_cache_dir = nullptr;
+
+  void ReloadDiskIndex() noexcept;
+
+  AllocatedPath ModelDiskCacheDirectory() const noexcept;
+
+  /* ---- Disk cache helpers ---- */
+
+  /**
+   * Compute the path of the on-disk cache file for one slice.
+   * Returns nullptr if disk_cache_dir is not set.
+   */
+  AllocatedPath SliceFilePath(const std::string &parameter,
+                              unsigned forecast_utc) const noexcept;
+
+  /** Write the slice to disk. No-op if disk cache disabled. */
+  void WriteSliceToDisk(const std::string &parameter,
+                        unsigned forecast_utc,
+                        const CachedSlice &slice) const noexcept;
+
+  /** Delete the on-disk file for one slice. No-op if disk cache disabled. */
+  void DeleteSliceFromDisk(const std::string &parameter,
+                           unsigned forecast_utc) const noexcept;
+
+  /**
+   * Read and parse one on-disk slice file (header + GeoJSON body).
+   * @return true on success, with @p out fully populated.
+   */
+  bool ReadSliceFile(const std::string &parameter, unsigned utc_hour,
+                     CachedSlice &out) const noexcept;
+
+  /**
+   * Insert a freshly-obtained body into the LRU body cache, recording
+   * it as most-recently-used and evicting the least-recently-used
+   * entries beyond kMaxResidentSlices. Caller must hold cache_mutex.
+   */
+  void InsertResident(const std::string &parameter, unsigned utc_hour,
+                      CachedSlice &&slice) noexcept;
+
+  /** Mark (parameter, utc_hour) most-recently-used. Caller holds lock. */
+  void TouchResident(const std::string &parameter,
+                     unsigned utc_hour) noexcept;
+
+  /** Drop a key from the LRU body cache. Caller holds lock. */
+  void DropResident(const std::string &parameter,
+                    unsigned utc_hour) noexcept;
+
+  Co::Task<bool> CoFetchIndex(CurlGlobal &curl);
+
+  /**
+   * Parse the index.json response and populate available_parameters.
+   */
+  bool ParseIndex(const std::string &json) noexcept;
+
+  /**
+   * Format step as 3-digit string (e.g. 9 → "009").
+   */
+  static std::string FormatStep(unsigned step) noexcept;
+};

--- a/src/Weather/xctherm/XCThermAutoSwitch.cpp
+++ b/src/Weather/xctherm/XCThermAutoSwitch.cpp
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermAutoSwitch.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+void
+XCThermAutoSwitch::SetLoadedLayers(std::vector<LayerInfo> layers) noexcept
+{
+  /* Sort AMSL layers by altitude ascending */
+  std::sort(layers.begin(), layers.end(),
+            [](const LayerInfo &a, const LayerInfo &b) {
+              /* AGL layers go after AMSL layers */
+              if (a.is_agl != b.is_agl)
+                return !a.is_agl;
+              return a.altitude_m < b.altitude_m;
+            });
+
+  loaded_layers = std::move(layers);
+  RecalculateThresholds();
+
+  /* Refreshing the layer list (e.g. when index.json arrives) must not
+     discard a pilot's manual ◀/▶ choice or in-flight altitude override. */
+  threshold_pending = false;
+}
+
+void
+XCThermAutoSwitch::SetLoadedTimes(std::vector<unsigned> times) noexcept
+{
+  std::sort(times.begin(), times.end());
+  loaded_times_utc = std::move(times);
+}
+
+void
+XCThermAutoSwitch::SetCurrentLayerPos(int pos) noexcept
+{
+  current_layer_pos = pos;
+  threshold_pending = false;
+}
+
+void
+XCThermAutoSwitch::SyncCurrentLayerIndex(unsigned layer_index) noexcept
+{
+  for (size_t i = 0; i < loaded_layers.size(); ++i) {
+    if (loaded_layers[i].index == layer_index) {
+      SetCurrentLayerPos(int(i));
+      return;
+    }
+  }
+}
+
+void
+XCThermAutoSwitch::SetCurrentTimePos(int pos) noexcept
+{
+  current_time_pos = pos;
+}
+
+void
+XCThermAutoSwitch::OnManualLayerStep() noexcept
+{
+  altitude_manual_override = true;
+  /* Snapshot the altitude band the aircraft is currently in. Auto
+     resumes only once the aircraft has physically flown into a
+     different band — so picking 4000 m at ground level no longer
+     gets undone the moment the override grace window expires.
+     If we don't yet have an altitude reading, the snapshot is
+     deferred to the first UpdateAltitude() after this. */
+  manual_step_band = last_known_band;
+  threshold_pending = false;
+}
+
+void
+XCThermAutoSwitch::OnManualTimeStep() noexcept
+{
+  time_manual_override = true;
+}
+
+void
+XCThermAutoSwitch::ResumeAltitudeAuto(double altitude) noexcept
+{
+  altitude_manual_override = false;
+  manual_step_band = -1;
+  threshold_pending = false;
+  pending_target_pos = -1;
+
+  if (!enabled || altitude < 0)
+    return;
+
+  const int target_pos = FindLayerForAltitude(altitude);
+  if (target_pos < 0)
+    return;
+
+  current_layer_pos = target_pos;
+  if (on_layer_switch)
+    on_layer_switch(loaded_layers[target_pos].index);
+}
+
+void
+XCThermAutoSwitch::ResumeTimeAuto() noexcept
+{
+  time_manual_override = false;
+}
+
+void
+XCThermAutoSwitch::RecalculateThresholds() noexcept
+{
+  thresholds.clear();
+
+  /* Only compute thresholds for non-AGL layers */
+  std::vector<unsigned> amsl_alts;
+  for (const auto &l : loaded_layers) {
+    if (!l.is_agl)
+      amsl_alts.push_back(l.altitude_m);
+  }
+
+  if (amsl_alts.size() < 2)
+    return;
+
+  /* Midpoints between consecutive AMSL layers */
+  for (size_t i = 0; i + 1 < amsl_alts.size(); ++i) {
+    thresholds.push_back((amsl_alts[i] + amsl_alts[i + 1]) / 2.0);
+  }
+}
+
+int
+XCThermAutoSwitch::FindLayerForAltitude(double altitude) const noexcept
+{
+  if (loaded_layers.empty())
+    return -1;
+
+  /* Count AMSL layers. AGL layers are explicitly out of scope for
+     auto-switch — they're picked manually only. If the user has
+     downloaded only AGL forecasts (no AMSL), we return -1 so auto
+     does nothing and the manual choice stays put. */
+  int n_amsl = 0;
+  for (const auto &l : loaded_layers) {
+    if (!l.is_agl)
+      ++n_amsl;
+  }
+
+  if (n_amsl == 0)
+    return -1;
+
+  /* Find which AMSL band the altitude falls into using thresholds.
+     loaded_layers is sorted AMSL-first, so positions 0..n_amsl-1 are
+     guaranteed to be AMSL — never AGL. */
+  int amsl_pos = 0;
+  for (size_t i = 0; i < thresholds.size(); ++i) {
+    if (altitude >= thresholds[i])
+      amsl_pos = (int)(i + 1);
+  }
+
+  /* Clamp */
+  if (amsl_pos >= n_amsl)
+    amsl_pos = n_amsl - 1;
+
+  return amsl_pos;
+}
+
+void
+XCThermAutoSwitch::UpdateAltitude(double altitude, TimeStamp now) noexcept
+{
+  if (loaded_layers.empty())
+    return;
+
+  int target_pos = FindLayerForAltitude(altitude);
+  if (target_pos < 0)
+    return;
+
+  /* Track the band the aircraft is currently flying in. OnManualLayerStep
+     reads this to snapshot the band at the moment of the manual press. */
+  last_known_band = target_pos;
+
+  /* Manual override: the pilot picked a layer. Auto resumes only once
+     the aircraft physically flies into a band other than the one it was
+     in when the pilot pressed. This means you can sit at 500 m and
+     park the forecast on 4000 m for as long as you want — auto won't
+     fight you. It re-engages naturally when you climb (or descend)
+     into a new altitude band. */
+  if (altitude_manual_override) {
+    if (manual_step_band < 0) {
+      /* No altitude was available when the manual step happened. Bind
+         the snapshot to the first altitude we see now. */
+      manual_step_band = target_pos;
+      return;
+    }
+    if (target_pos == manual_step_band) {
+      /* Aircraft is still in the same physical band as when the pilot
+         chose a layer → keep the manual choice. */
+      return;
+    }
+    /* Aircraft has flown into a new band → release the override and
+       fall through to normal auto-switch (which will apply the 20 s
+       hysteresis before actually moving the cursor). */
+    altitude_manual_override = false;
+  }
+
+  if (target_pos == current_layer_pos) {
+    /* No change needed, cancel any pending switch */
+    threshold_pending = false;
+    return;
+  }
+
+  /* Hysteresis: start or check pending timer */
+  if (!threshold_pending || pending_target_pos != target_pos) {
+    /* New threshold crossing detected — start timer */
+    threshold_pending = true;
+    pending_target_pos = target_pos;
+    threshold_crossed_at = now;
+    return;
+  }
+
+  /* Check if 20 seconds have elapsed */
+  if (now.IsDefined() && threshold_crossed_at.IsDefined()) {
+    const auto elapsed = now - threshold_crossed_at;
+    if (elapsed.count() < HYSTERESIS_SECONDS)
+      return; /* Not yet — keep waiting */
+  }
+
+  /* Timer expired — switch! */
+  threshold_pending = false;
+  current_layer_pos = target_pos;
+
+  if (current_layer_pos >= 0 &&
+      current_layer_pos < (int)loaded_layers.size() &&
+      on_layer_switch)
+    on_layer_switch(loaded_layers[current_layer_pos].index);
+}
+
+void
+XCThermAutoSwitch::UpdateTime(unsigned utc_hour, unsigned utc_minute) noexcept
+{
+  /* Switch at :45 — use the NEXT hour's forecast */
+  unsigned target_hour = utc_hour;
+  if (utc_minute >= 45)
+    target_hour = (utc_hour + 1) % 24;
+
+  /* If manual override, check if a new hour boundary was crossed */
+  if (time_manual_override) {
+    if ((int)target_hour != last_switch_hour) {
+      /* New hour boundary — resume auto */
+      time_manual_override = false;
+    } else {
+      return;
+    }
+  }
+
+  /* Already switched for this hour? */
+  if ((int)target_hour == last_switch_hour)
+    return;
+
+  last_switch_hour = (int)target_hour;
+
+  auto it = std::find(loaded_times_utc.begin(), loaded_times_utc.end(),
+                      target_hour);
+  if (it != loaded_times_utc.end())
+    current_time_pos =
+      (int)std::distance(loaded_times_utc.begin(), it);
+
+  if (on_time_switch)
+    on_time_switch(target_hour);
+}
+
+void
+XCThermAutoSwitch::Update(double gps_alt, double baro_alt,
+                          unsigned utc_hour, unsigned utc_minute,
+                          TimeStamp now) noexcept
+{
+  if (!enabled)
+    return;
+
+  /* Pick best available altitude */
+  double alt = -1;
+  if (gps_alt >= 0)
+    alt = gps_alt;
+  else if (baro_alt >= 0)
+    alt = baro_alt;
+
+  if (alt >= 0)
+    UpdateAltitude(alt, now);
+
+  UpdateTime(utc_hour, utc_minute);
+}

--- a/src/Weather/xctherm/XCThermAutoSwitch.hpp
+++ b/src/Weather/xctherm/XCThermAutoSwitch.hpp
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "time/Stamp.hpp"
+
+#include <vector>
+#include <functional>
+
+/**
+ * Manages automatic switching of XCTherm forecast layers (altitude)
+ * and time steps based on current flight data.
+ *
+ * Altitude: switches layer when GPS/baro altitude crosses the midpoint
+ * between two loaded layers, with a 20-second hysteresis.
+ *
+ * Time: switches forecast time at :45 of each hour.
+ *
+ * Manual override: stepping manually pauses auto for that axis.
+ * Auto resumes when the next threshold is crossed, or immediately
+ * when the user taps the centre label in the cursor bar.
+ */
+class XCThermAutoSwitch {
+public:
+  struct LayerInfo {
+    unsigned index;        // index into the LAYERS array
+    unsigned altitude_m;   // altitude in meters
+    bool is_agl;
+  };
+
+  using SwitchCallback = std::function<void(unsigned layer_index)>;
+  using TimeSwitchCallback = std::function<void(unsigned utc_hour)>;
+
+private:
+  bool enabled = true;
+
+  /* --- Altitude auto-switch --- */
+  std::vector<LayerInfo> loaded_layers;
+  std::vector<double> thresholds; // midpoints between loaded layers (AMSL only)
+  int current_layer_pos = -1;     // position in loaded_layers
+
+  // Hysteresis state
+  bool threshold_pending = false;
+  int pending_target_pos = -1;
+  TimeStamp threshold_crossed_at = TimeStamp::Undefined();
+  static constexpr double HYSTERESIS_SECONDS = 20.0;
+
+  bool altitude_manual_override = false;
+
+  /**
+   * Most recent altitude→layer band reported by UpdateAltitude().
+   * Tracked continuously so OnManualLayerStep() can snapshot it.
+   * -1 until the first altitude tick has arrived.
+   */
+  int last_known_band = -1;
+
+  /**
+   * The physical altitude band the aircraft was in when the pilot
+   * last pressed ◀/▶ on the altitude row. Auto-switch only resumes
+   * once the aircraft has flown into a *different* band — i.e. the
+   * pilot's manual choice sticks until the altitude actually changes
+   * to somewhere the auto logic would naturally re-evaluate.
+   *
+   * -1 means the snapshot is still pending (no altitude reading
+   * arrived between class construction / reset and the manual step);
+   * the next UpdateAltitude() tick binds it.
+   */
+  int manual_step_band = -1;
+
+  /* --- Time auto-switch --- */
+  std::vector<unsigned> loaded_times_utc; // available UTC hours (0-23)
+  int current_time_pos = -1;
+
+  bool time_manual_override = false;
+  int last_switch_hour = -1; // track which hour we last auto-switched for
+
+  /* --- Callbacks --- */
+  SwitchCallback on_layer_switch;
+  TimeSwitchCallback on_time_switch;
+
+public:
+  void SetEnabled(bool e) noexcept { enabled = e; }
+  bool IsEnabled() const noexcept { return enabled; }
+
+  /**
+   * Set the available (loaded) altitude layers, sorted by altitude.
+   * Recalculates midpoint thresholds.
+   */
+  void SetLoadedLayers(std::vector<LayerInfo> layers) noexcept;
+
+  /**
+   * Set the available forecast UTC hours.
+   */
+  void SetLoadedTimes(std::vector<unsigned> times) noexcept;
+
+  /**
+   * Set current positions (called after manual selection or initial load).
+   */
+  void SetCurrentLayerPos(int pos) noexcept;
+
+  /**
+   * Match @c current_layer_pos to a region layer index from
+   * #SetLoadedLayers().
+   */
+  void SyncCurrentLayerIndex(unsigned layer_index) noexcept;
+
+  void SetCurrentTimePos(int pos) noexcept;
+
+  /**
+   * Called when user manually steps the layer.
+   * Pauses auto-altitude until next threshold crossing.
+   */
+  void OnManualLayerStep() noexcept;
+
+  /**
+   * Called when user manually steps the time.
+   * Pauses auto-time until next threshold crossing.
+   */
+  void OnManualTimeStep() noexcept;
+
+  /**
+   * Clear altitude manual override and snap to the layer for @p altitude.
+   */
+  void ResumeAltitudeAuto(double altitude) noexcept;
+
+  /** Clear time manual override (caller applies the auto time index). */
+  void ResumeTimeAuto() noexcept;
+
+  void SetLayerSwitchCallback(SwitchCallback cb) noexcept {
+    on_layer_switch = std::move(cb);
+  }
+
+  void SetTimeSwitchCallback(TimeSwitchCallback cb) noexcept {
+    on_time_switch = std::move(cb);
+  }
+
+  void SetAltitudeManualOverride(bool override) noexcept {
+    altitude_manual_override = override;
+  }
+
+  void SetTimeManualOverride(bool override) noexcept {
+    time_manual_override = override;
+  }
+
+  bool IsAltitudeManualOverride() const noexcept {
+    return altitude_manual_override;
+  }
+
+  bool IsTimeManualOverride() const noexcept {
+    return time_manual_override;
+  }
+
+  /**
+   * Called periodically (~1 Hz) with current flight data.
+   * @param gps_alt GPS altitude in meters (negative if unavailable)
+   * @param baro_alt barometric altitude in meters (negative if unavailable)
+   * @param utc_hour current UTC hour (0-23)
+   * @param utc_minute current UTC minute (0-59)
+   * @param now monotonic timestamp for hysteresis timing
+   */
+  void Update(double gps_alt, double baro_alt,
+              unsigned utc_hour, unsigned utc_minute,
+              TimeStamp now) noexcept;
+
+  bool IsAltitudeAutoActive() const noexcept { return enabled && !altitude_manual_override; }
+  bool IsTimeAutoActive() const noexcept { return enabled && !time_manual_override; }
+
+private:
+  void RecalculateThresholds() noexcept;
+  void UpdateAltitude(double altitude, TimeStamp now) noexcept;
+  void UpdateTime(unsigned utc_hour, unsigned utc_minute) noexcept;
+
+  /**
+   * Find which layer position the given altitude maps to.
+   * Returns -1 if no layers loaded.
+   */
+  int FindLayerForAltitude(double altitude) const noexcept;
+};

--- a/src/Weather/xctherm/XCThermCatalog.cpp
+++ b/src/Weather/xctherm/XCThermCatalog.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermCatalog.hpp"
+#include "XCThermAPI.hpp"
+#include "Weather/Settings.hpp"
+
+#include <iterator>
+
+namespace XCTherm {
+
+int
+FindActiveLayerIndex(const XCThermSettings &settings) noexcept
+{
+  const auto &region = GetRegion(settings.model);
+  for (unsigned i = 0; i < region.layer_count; ++i) {
+    if (IsActiveLayer(region.layers[i], settings.parameter,
+                      settings.wave_height, settings.vertical_wind_agl))
+      return int(i);
+  }
+  return -1;
+}
+
+int
+FindFirstCachedLayerIndex(const XCThermSettings &settings) noexcept
+{
+  auto &api = XCThermAPI::Instance();
+  const auto &region = GetRegion(settings.model);
+  for (unsigned i = 0; i < region.layer_count; ++i) {
+    if (!api.GetCachedHours(region.layers[i].api_parameter).empty())
+      return int(i);
+  }
+  return -1;
+}
+
+int
+ResolveDisplayLayerIndex(const XCThermSettings &settings) noexcept
+{
+  const int active = FindActiveLayerIndex(settings);
+  if (active >= 0) {
+    const auto &region = GetRegion(settings.model);
+    if (!XCThermAPI::Instance()
+          .GetCachedHours(region.layers[unsigned(active)].api_parameter)
+          .empty())
+      return active;
+  }
+
+  return FindFirstCachedLayerIndex(settings);
+}
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermCatalog.hpp
+++ b/src/Weather/xctherm/XCThermCatalog.hpp
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Language/Language.hpp"
+
+#include <cstddef>
+#include <iterator>
+
+struct XCThermSettings;
+
+namespace XCTherm {
+
+/**
+ * Forecast region — stored in profile as @c settings.xctherm.model
+ * (unsigned). Must match @c StaticEnumChoice order in
+ * XCThermConfigPanel.
+ */
+enum class Region : unsigned {
+  CH = 0,
+  UK = 1,
+  COUNT,
+};
+
+struct Layer {
+  /** API path segment, e.g. @c "5000amsl". */
+  const char *file_suffix;
+
+  /** Full index.json parameter name, e.g. @c "vertical_wind_5000amsl". */
+  const char *api_parameter;
+
+  /** Dialog list row (English; list widget caption). */
+  const char *dialog_label;
+
+  /** Cursor bar center label, e.g. @c "5000m AMSL". */
+  const char *short_label;
+
+  unsigned altitude_m;
+  bool is_agl;
+};
+
+struct RegionDef {
+  /** Tiles URL model slug, e.g. @c "icon-ch". */
+  const char *api_slug;
+  const Layer *layers;
+  unsigned layer_count;
+};
+
+namespace detail {
+
+constexpr Layer CH_LAYERS[] = {
+  { "1500amsl", "vertical_wind_1500amsl",
+    N_("Vertical wind 1500 m AMSL"), N_("1500m AMSL"), 1500, false },
+  { "2000amsl", "vertical_wind_2000amsl",
+    N_("Vertical wind 2000 m AMSL"), N_("2000m AMSL"), 2000, false },
+  { "3000amsl", "vertical_wind_3000amsl",
+    N_("Vertical wind 3000 m AMSL"), N_("3000m AMSL"), 3000, false },
+  { "4000amsl", "vertical_wind_4000amsl",
+    N_("Vertical wind 4000 m AMSL"), N_("4000m AMSL"), 4000, false },
+  { "5000amsl", "vertical_wind_5000amsl",
+    N_("Vertical wind 5000 m AMSL"), N_("5000m AMSL"), 5000, false },
+  { "6000amsl", "vertical_wind_6000amsl",
+    N_("Vertical wind 6000 m AMSL"), N_("6000m AMSL"), 6000, false },
+  { "7000amsl", "vertical_wind_7000amsl",
+    N_("Vertical wind 7000 m AMSL"), N_("7000m AMSL"), 7000, false },
+  { "8000amsl", "vertical_wind_8000amsl",
+    N_("Vertical wind 8000 m AMSL"), N_("8000m AMSL"), 8000, false },
+  { "100agl", "vertical_wind_100agl",
+    N_("Vertical wind 100 m AGL"), N_("100m AGL"), 100, true },
+  { "400agl", "vertical_wind_400agl",
+    N_("Vertical wind 400 m AGL"), N_("400m AGL"), 400, true },
+};
+
+constexpr Layer UK_LAYERS[] = {
+  { "1000amsl", "vertical_wind_1000amsl",
+    N_("Vertical wind 1000 m AMSL"), N_("1000m AMSL"), 1000, false },
+  { "1500amsl", "vertical_wind_1500amsl",
+    N_("Vertical wind 1500 m AMSL"), N_("1500m AMSL"), 1500, false },
+  { "2000amsl", "vertical_wind_2000amsl",
+    N_("Vertical wind 2000 m AMSL"), N_("2000m AMSL"), 2000, false },
+  { "2500amsl", "vertical_wind_2500amsl",
+    N_("Vertical wind 2500 m AMSL"), N_("2500m AMSL"), 2500, false },
+  { "3000amsl", "vertical_wind_3000amsl",
+    N_("Vertical wind 3000 m AMSL"), N_("3000m AMSL"), 3000, false },
+  { "4200amsl", "vertical_wind_4200amsl",
+    N_("Vertical wind 4200 m AMSL"), N_("4200m AMSL"), 4200, false },
+  { "100agl", "vertical_wind_100agl",
+    N_("Vertical wind 100 m AGL"), N_("100m AGL"), 100, true },
+  { "200agl", "vertical_wind_200agl",
+    N_("Vertical wind 200 m AGL"), N_("200m AGL"), 200, true },
+  { "400agl", "vertical_wind_400agl",
+    N_("Vertical wind 400 m AGL"), N_("400m AGL"), 400, true },
+  { "800agl", "vertical_wind_800agl",
+    N_("Vertical wind 800 m AGL"), N_("800m AGL"), 800, true },
+};
+
+constexpr RegionDef REGIONS[] = {
+  { "icon-ch", CH_LAYERS, unsigned(std::size(CH_LAYERS)) },
+  { "icon-uk", UK_LAYERS, unsigned(std::size(UK_LAYERS)) },
+};
+
+static_assert(std::size(REGIONS) == unsigned(Region::COUNT),
+              "REGIONS must match Region::COUNT");
+
+} // namespace detail
+
+constexpr unsigned MaxLayerCount() noexcept {
+  unsigned n = 0;
+  for (const auto &region : detail::REGIONS)
+    if (region.layer_count > n)
+      n = region.layer_count;
+  return n;
+}
+
+[[gnu::pure]]
+constexpr Region ToRegion(unsigned model_id) noexcept {
+  if (model_id >= unsigned(Region::COUNT))
+    return Region::CH;
+  return Region(model_id);
+}
+
+[[gnu::pure]]
+constexpr const RegionDef &GetRegion(Region region) noexcept {
+  return detail::REGIONS[unsigned(region)];
+}
+
+[[gnu::pure]]
+constexpr const RegionDef &GetRegion(unsigned model_id) noexcept {
+  return GetRegion(ToRegion(model_id));
+}
+
+/**
+ * Index of @p altitude_m in the region's layer table, or -1 if absent.
+ */
+[[gnu::pure]]
+constexpr int FindLayerIndex(Region region, unsigned altitude_m,
+                             bool is_agl) noexcept {
+  const auto &def = GetRegion(region);
+  for (unsigned i = 0; i < def.layer_count; ++i) {
+    const auto &layer = def.layers[i];
+    if (layer.is_agl == is_agl && layer.altitude_m == altitude_m)
+      return int(i);
+  }
+  return -1;
+}
+
+[[gnu::pure]]
+constexpr bool IsActiveLayer(const Layer &layer,
+                             unsigned active_parameter,
+                             unsigned active_wave_height,
+                             unsigned active_vertical_agl) noexcept {
+  if (layer.is_agl)
+    return active_parameter == 1 &&
+           layer.altitude_m == active_vertical_agl;
+  return active_parameter == 0 && layer.altitude_m == active_wave_height;
+}
+
+/**
+ * Index of the layer matching dialog Activate settings, or -1.
+ */
+[[gnu::pure]]
+int FindActiveLayerIndex(const XCThermSettings &settings) noexcept;
+
+/**
+ * First region layer with any cached forecast slices, or -1.
+ */
+[[gnu::pure]]
+int FindFirstCachedLayerIndex(const XCThermSettings &settings) noexcept;
+
+/**
+ * Layer to display: activated layer when cached, otherwise first
+ * cached layer.
+ */
+[[gnu::pure]]
+int ResolveDisplayLayerIndex(const XCThermSettings &settings) noexcept;
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermControlsModel.cpp
+++ b/src/Weather/xctherm/XCThermControlsModel.cpp
@@ -1,0 +1,589 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermControlsModel.hpp"
+#include "XCThermAPI.hpp"
+#include "XCThermDownloadJob.hpp"
+#include "XCThermForecastTime.hpp"
+#include "XCThermMapOverlay.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "Weather/MapOverlay/CursorBarLabels.hpp"
+#include "Weather/Settings.hpp"
+#include "UIState.hpp"
+#include "NMEA/Info.hpp"
+
+#include <algorithm>
+
+namespace XCTherm {
+
+const RegionDef &
+XCThermControlsModel::Region() const noexcept
+{
+  return GetRegion(Settings().model);
+}
+
+const Layer &
+XCThermControlsModel::LayerAt(unsigned index) const noexcept
+{
+  return Region().layers[index];
+}
+
+const XCThermSettings &
+XCThermControlsModel::Settings() const noexcept
+{
+  return CommonInterface::GetComputerSettings().weather.xctherm;
+}
+
+double
+XCThermControlsModel::BestAltitude(const MoreData &basic) noexcept
+{
+  if (basic.gps_altitude_available)
+    return basic.gps_altitude;
+  if (basic.baro_altitude_available)
+    return basic.baro_altitude;
+  return -1.0;
+}
+
+void
+XCThermControlsModel::ApplyAutoSwitchLayer(unsigned layer_index) noexcept
+{
+  if (!LayerUsableForAutoSwitch(layer_index))
+    return;
+
+  state.current_layer = layer_index;
+  RefreshCurrentLayerHours(false);
+  ApplyCurrentSelectionToMap();
+
+  auto_switch.SyncCurrentLayerIndex(state.current_layer);
+  SaveCursorSession();
+  NotifyStateChanged();
+}
+
+void
+XCThermControlsModel::ConfigureAutoSwitch() noexcept
+{
+  if (!auto_switch_configured) {
+    auto_switch.SetLayerSwitchCallback([this](unsigned layer_index) {
+      ApplyAutoSwitchLayer(layer_index);
+    });
+    auto_switch.SetTimeSwitchCallback([this](unsigned utc_hour) {
+      if (!auto_switch.IsTimeAutoActive())
+        return;
+
+      state.current_time_index = utc_hour % 24;
+      ApplySelectionAndPersist();
+      NotifyStateChanged();
+    });
+    auto_switch_configured = true;
+  }
+
+  auto_switch.SetLoadedLayers(BuildAutoSwitchLayers());
+  auto_switch.SyncCurrentLayerIndex(state.current_layer);
+  auto_switch.SetLoadedTimes(state.available_hours);
+  if (!state.available_hours.empty())
+    auto_switch.SetCurrentTimePos(0);
+
+  auto_switch.SetEnabled(Settings().auto_switch);
+}
+
+void
+XCThermControlsModel::ApplyLayerToMap(unsigned layer_index,
+                                      unsigned utc_hour) noexcept
+{
+  ApplyCachedLayerOverlay(layer_index, utc_hour);
+}
+
+unsigned
+XCThermControlsModel::GetCurrentForecastHour() const noexcept
+{
+  return state.current_time_index % 24;
+}
+
+void
+XCThermControlsModel::NotifyStateChanged() noexcept
+{
+  if (on_state_changed)
+    on_state_changed();
+}
+
+void
+XCThermControlsModel::Prepare(std::function<void()> state_changed) noexcept
+{
+  on_state_changed = std::move(state_changed);
+
+  BootstrapSession();
+  RequestBackgroundIndex([this]{
+    OnIndexLoaded();
+    NotifyStateChanged();
+  });
+  MaybeFetchActiveLayer([this](std::shared_ptr<XCThermDownloadJob> job) {
+    OnDownloadFinished(job);
+    NotifyStateChanged();
+  });
+}
+
+void
+XCThermControlsModel::OnShow() noexcept
+{
+  RefreshCachedHours();
+
+  const auto &layer = LayerAt(state.current_layer);
+  if (MapShowsForecast(layer.api_parameter, GetCurrentForecastHour()))
+    return;
+
+  ApplyCurrentSelectionToMap();
+}
+
+void
+XCThermControlsModel::OnHide() noexcept
+{
+  if (!IsDedicatedPageSuspendedForPan())
+    ClearMapOverlay();
+}
+
+void
+XCThermControlsModel::OnGPSUpdate(const MoreData &basic) noexcept
+{
+  auto_switch.SetEnabled(Settings().auto_switch);
+  SyncActiveLayerFromSettings();
+
+  if (!auto_switch.IsEnabled())
+    return;
+
+  double gps_alt = basic.gps_altitude_available ? basic.gps_altitude : -1.0;
+  double baro_alt = basic.baro_altitude_available ? basic.baro_altitude : -1.0;
+
+  unsigned utc_hour = XCTHERM_DEFAULT_UTC_HOUR;
+  unsigned utc_minute = 0;
+  if (basic.date_time_utc.IsPlausible()) {
+    utc_hour = basic.date_time_utc.hour;
+    utc_minute = basic.date_time_utc.minute;
+  }
+
+  auto_switch.Update(gps_alt, baro_alt, utc_hour, utc_minute, basic.time);
+  SaveCursorSession();
+}
+
+void
+XCThermControlsModel::LoadCursorSession() noexcept
+{
+  const auto &weather = CommonInterface::GetUIState().weather;
+  const auto &session = weather.xctherm;
+  const auto &cursor = weather.xctherm_cursor;
+  if (!session.cursor_initialized)
+    return;
+
+  state.current_layer = cursor.layer;
+  state.current_time_index = cursor.forecast_utc_hour;
+  state.last_synced_active_layer = FindActiveLayerIndex(Settings());
+  auto_switch.SetAltitudeManualOverride(cursor.altitude_manual_override);
+  auto_switch.SetTimeManualOverride(cursor.time_manual_override);
+}
+
+void
+XCThermControlsModel::SaveCursorSession() noexcept
+{
+  auto &weather = CommonInterface::SetUIState().weather;
+  auto &session = weather.xctherm;
+  auto &cursor = weather.xctherm_cursor;
+  session.cursor_initialized = true;
+  cursor.layer = state.current_layer;
+  cursor.forecast_utc_hour = GetCurrentForecastHour();
+  cursor.altitude_manual_override = auto_switch.IsAltitudeManualOverride();
+  cursor.time_manual_override = auto_switch.IsTimeManualOverride();
+}
+
+void
+XCThermControlsModel::BootstrapSession() noexcept
+{
+  auto &api = XCThermAPI::Instance();
+  const auto &settings = Settings();
+
+  api.PrepareSession(settings);
+
+  ApplyIndexAvailability();
+
+  LoadCursorSession();
+
+  if (!CommonInterface::GetUIState().weather.xctherm.cursor_initialized) {
+    const int def = FindLayerIndex(ToRegion(settings.model), 5000, false);
+    if (def >= 0)
+      state.current_layer = unsigned(def);
+
+    SyncActiveLayerFromSettings();
+    RefreshCachedHours();
+    SelectBestTimeIndex();
+    SaveCursorSession();
+  } else {
+    RefreshCachedHours();
+  }
+
+  ConfigureAutoSwitch();
+}
+
+void
+XCThermControlsModel::ApplyIndexAvailability() noexcept
+{
+  auto &api = XCThermAPI::Instance();
+  state.index_loaded = api.IsIndexLoaded();
+  if (state.index_loaded) {
+    const auto &params = api.GetAvailableParameters();
+    for (unsigned i = 0; i < Region().layer_count; ++i) {
+      state.layer_available[i] = false;
+      for (const auto &p : params) {
+        if (p.name == LayerAt(i).api_parameter) {
+          state.layer_available[i] = true;
+          break;
+        }
+      }
+    }
+    if (state.layer_available[state.current_layer])
+      state.available_hours =
+        api.GetAvailableForecastHours(
+          LayerAt(state.current_layer).api_parameter);
+  } else {
+    for (unsigned i = 0; i < Region().layer_count; ++i)
+      state.layer_available[i] = false;
+  }
+}
+
+void
+XCThermControlsModel::SyncActiveLayerFromSettings() noexcept
+{
+  auto &api = XCThermAPI::Instance();
+  const int active_layer = FindActiveLayerIndex(Settings());
+
+  if (active_layer == state.last_synced_active_layer) {
+    MaybeFetchActiveLayer(nullptr);
+    return;
+  }
+
+  state.last_synced_active_layer = active_layer;
+  ResetAutoFetchAttempt();
+
+  if (active_layer >= 0) {
+    const unsigned active = unsigned(active_layer);
+    const std::string &active_param = LayerAt(active).api_parameter;
+
+    if (!api.GetCachedHours(active_param).empty()) {
+      state.current_layer = active;
+    } else if (state.current_layer == active) {
+      const int fallback = FindFirstCachedLayerIndex(Settings());
+      if (fallback >= 0)
+        state.current_layer = unsigned(fallback);
+    }
+
+    MaybeFetchActiveLayer(nullptr);
+    return;
+  }
+
+  const int fallback = FindFirstCachedLayerIndex(Settings());
+  if (fallback >= 0)
+    state.current_layer = unsigned(fallback);
+}
+
+void
+XCThermControlsModel::RefreshCachedHours() noexcept
+{
+  state.cached_hours =
+    XCThermAPI::Instance().GetCachedHours(
+      LayerAt(state.current_layer).api_parameter);
+}
+
+void
+XCThermControlsModel::RefreshCurrentLayerHours(
+  bool include_available_hours) noexcept
+{
+  RefreshCachedHours();
+  if (include_available_hours)
+    RefreshAvailableHours();
+}
+
+void
+XCThermControlsModel::RefreshAvailableHours() noexcept
+{
+  if (!state.index_loaded)
+    return;
+
+  state.available_hours =
+    XCThermAPI::Instance().GetAvailableForecastHours(
+      LayerAt(state.current_layer).api_parameter);
+}
+
+void
+XCThermControlsModel::SelectBestTimeIndex() noexcept
+{
+  const auto utc = GetUtcTimeParts();
+  state.current_time_index = PickAutoTargetUtcHour(utc.hour, utc.minute);
+}
+
+void
+XCThermControlsModel::ApplyCurrentSelectionToMap() noexcept
+{
+  if (!HasCacheAtCurrentHour(state.current_layer)) {
+    ClearMapOverlay();
+    return;
+  }
+
+  ApplyLayerToMap(state.current_layer, GetCurrentForecastHour());
+}
+
+bool
+XCThermControlsModel::StepLayer(int delta) noexcept
+{
+  auto_switch.OnManualLayerStep();
+
+  const unsigned layer_count = Region().layer_count;
+  if (layer_count == 0)
+    return false;
+
+  int pos = int(state.current_layer) + delta;
+  if (pos < 0)
+    pos = int(layer_count) - 1;
+  else if (pos >= int(layer_count))
+    pos = 0;
+  state.current_layer = unsigned(pos);
+
+  RefreshCurrentLayerHours(true);
+  SelectBestTimeIndex();
+  ApplyCurrentSelectionToMap();
+  auto_switch.SyncCurrentLayerIndex(state.current_layer);
+  SaveCursorSession();
+  return true;
+}
+
+bool
+XCThermControlsModel::StepTime(int delta) noexcept
+{
+  auto_switch.OnManualTimeStep();
+
+  int hour = int(GetCurrentForecastHour()) + delta;
+  hour = (hour % 24 + 24) % 24;
+  state.current_time_index = unsigned(hour);
+
+  ApplySelectionAndPersist();
+  return true;
+}
+
+void
+XCThermControlsModel::ResumeLayerAuto(const MoreData &basic) noexcept
+{
+  if (!auto_switch.IsEnabled() || auto_switch.IsAltitudeAutoActive())
+    return;
+
+  auto_switch.ResumeAltitudeAuto(BestAltitude(basic));
+  SaveCursorSession();
+}
+
+void
+XCThermControlsModel::ResumeTimeAuto() noexcept
+{
+  if (!auto_switch.IsEnabled() || auto_switch.IsTimeAutoActive())
+    return;
+
+  auto_switch.ResumeTimeAuto();
+
+  const auto utc = GetUtcTimeParts();
+  state.current_time_index = PickAutoTargetUtcHour(utc.hour, utc.minute);
+  ApplySelectionAndPersist();
+}
+
+void
+XCThermControlsModel::SetAltitudeAutoAdvance(bool auto_advance,
+                                             const MoreData &basic) noexcept
+{
+  if (auto_advance)
+    ResumeLayerAuto(basic);
+  else {
+    auto_switch.SetAltitudeManualOverride(true);
+    SaveCursorSession();
+    NotifyStateChanged();
+  }
+}
+
+void
+XCThermControlsModel::SetTimeAutoAdvance(bool auto_advance) noexcept
+{
+  if (auto_advance)
+    ResumeTimeAuto();
+  else {
+    auto_switch.SetTimeManualOverride(true);
+    SaveCursorSession();
+    NotifyStateChanged();
+  }
+}
+
+void
+XCThermControlsModel::OnIndexLoaded() noexcept
+{
+  ApplyIndexAvailability();
+  if (!state.index_loaded)
+    return;
+
+  if (!CommonInterface::GetUIState().weather.xctherm.cursor_initialized)
+    SyncActiveLayerFromSettings();
+  RefreshCachedHours();
+  if (!CommonInterface::GetUIState().weather.xctherm.cursor_initialized)
+    SelectBestTimeIndex();
+
+  const auto &layer = LayerAt(state.current_layer);
+  if (!MapShowsForecast(layer.api_parameter, GetCurrentForecastHour()))
+    ApplyCurrentSelectionToMap();
+
+  MaybeFetchActiveLayer(nullptr);
+  ConfigureAutoSwitch();
+  SaveCursorSession();
+}
+
+void
+XCThermControlsModel::RequestBackgroundIndex(
+  std::function<void()> on_ready) const
+{
+  if (state.index_loaded) {
+    if (on_ready)
+      on_ready();
+    return;
+  }
+
+  RequestBackgroundIndexFetch(std::move(on_ready));
+}
+
+void
+XCThermControlsModel::MaybeFetchActiveLayer(
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished) const
+{
+  if (!state.index_loaded)
+    return;
+
+  MaybeFetchActiveLayerSpan(std::move(on_finished));
+}
+
+bool
+XCThermControlsModel::RequestLayerDownload(
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished) noexcept
+{
+  const auto &settings = Settings();
+  if (!settings.credentials.IsDefined() ||
+      settings.download_span_hours == 0)
+    return false;
+
+  ResetAutoFetchAttempt();
+  XCThermAPI::Instance().PrepareSession(settings);
+
+  const auto shared = StartSpanDownload(
+    settings, state.current_layer,
+    [this, finished = std::move(on_finished)](
+      std::shared_ptr<XCThermDownloadJob> done) mutable {
+      ApplyJobPreviewToMap(done);
+      OnDownloadFinished(done);
+      if (finished)
+        finished(std::move(done));
+    });
+
+  return shared != nullptr;
+}
+
+void
+XCThermControlsModel::OnDownloadFinished(
+  const std::shared_ptr<XCThermDownloadJob> &job) noexcept
+{
+  RefreshCurrentLayerHours(false);
+
+  if (job == nullptr || job->cancel.load())
+    return;
+
+  if (!job->error_eptr && job->succeeded_or_cached.load() > 0) {
+    if (!CommonInterface::GetUIState().weather.xctherm.cursor_initialized)
+      SelectBestTimeIndex();
+    ApplySelectionAndPersist();
+  }
+}
+
+void
+XCThermControlsModel::ApplySelectionAndPersist() noexcept
+{
+  ApplyCurrentSelectionToMap();
+  SaveCursorSession();
+}
+
+void
+XCThermControlsModel::FormatLayerLabel(StaticString<80> &text) const noexcept
+{
+  const unsigned layer = state.current_layer;
+  const bool has_cache = HasCacheAtCurrentHour(layer);
+
+  StaticString<80> base;
+  if (auto_switch.IsAltitudeAutoActive())
+    base.Format("%s %s", _("AUTO:"), gettext(LayerAt(layer).short_label));
+  else
+    base.Format("%s", gettext(LayerAt(layer).short_label));
+
+  if (has_cache)
+    text = base;
+  else
+    WeatherMapOverlay::AppendNoDataTag(text, base.c_str());
+}
+
+void
+XCThermControlsModel::FormatTimeLabel(StaticString<64> &text) noexcept
+{
+  RefreshCurrentLayerHours(true);
+
+  StaticString<64> base;
+  XCTherm::FormatTimeLabel(base,
+                           LayerAt(state.current_layer).api_parameter,
+                           GetCurrentForecastHour(),
+                           auto_switch.IsTimeAutoActive());
+
+  if (HasCacheAtCurrentHour(state.current_layer))
+    text = base;
+  else
+    WeatherMapOverlay::AppendNoDataTag(text, base.c_str());
+}
+
+bool
+XCThermControlsModel::IsAltitudeAutoActive() const noexcept
+{
+  return auto_switch.IsAltitudeAutoActive();
+}
+
+bool
+XCThermControlsModel::IsTimeAutoActive() const noexcept
+{
+  return auto_switch.IsTimeAutoActive();
+}
+
+bool
+XCThermControlsModel::LayerHasCache(unsigned layer_index) const noexcept
+{
+  return !XCThermAPI::Instance()
+    .GetCachedHours(LayerAt(layer_index).api_parameter).empty();
+}
+
+bool
+XCThermControlsModel::LayerUsableForAutoSwitch(
+  unsigned layer_index) const noexcept
+{
+  return state.layer_available[layer_index] || LayerHasCache(layer_index);
+}
+
+std::vector<XCThermAutoSwitch::LayerInfo>
+XCThermControlsModel::BuildAutoSwitchLayers() const noexcept
+{
+  std::vector<XCThermAutoSwitch::LayerInfo> layers;
+  for (unsigned i = 0; i < Region().layer_count; ++i) {
+    if (LayerUsableForAutoSwitch(i))
+      layers.push_back({i, LayerAt(i).altitude_m, LayerAt(i).is_agl});
+  }
+  return layers;
+}
+
+bool
+XCThermControlsModel::HasCacheAtCurrentHour(unsigned layer_index) const noexcept
+{
+  return XCThermAPI::Instance().IsLayerCached(
+    LayerAt(layer_index).api_parameter, GetCurrentForecastHour());
+}
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermControlsModel.cpp
+++ b/src/Weather/xctherm/XCThermControlsModel.cpp
@@ -17,6 +17,25 @@
 
 namespace XCTherm {
 
+XCThermControlsModel::~XCThermControlsModel() noexcept
+{
+  const std::lock_guard lock{callback_gate->mutex};
+  callback_gate->alive = false;
+}
+
+void
+XCThermControlsModel::ClampCurrentLayer() noexcept
+{
+  const unsigned layer_count = Region().layer_count;
+  if (layer_count == 0) {
+    state.current_layer = 0;
+    return;
+  }
+
+  if (state.current_layer >= layer_count)
+    state.current_layer = layer_count - 1;
+}
+
 const RegionDef &
 XCThermControlsModel::Region() const noexcept
 {
@@ -111,13 +130,26 @@ void
 XCThermControlsModel::Prepare(std::function<void()> state_changed) noexcept
 {
   on_state_changed = std::move(state_changed);
+  const auto gate = callback_gate;
 
   BootstrapSession();
-  RequestBackgroundIndex([this]{
+  RequestBackgroundIndex([this, gate]{
+    {
+      const std::lock_guard lock{gate->mutex};
+      if (!gate->alive)
+        return;
+    }
+
     OnIndexLoaded();
     NotifyStateChanged();
   });
-  MaybeFetchActiveLayer([this](std::shared_ptr<XCThermDownloadJob> job) {
+  MaybeFetchActiveLayer([this, gate](std::shared_ptr<XCThermDownloadJob> job) {
+    {
+      const std::lock_guard lock{gate->mutex};
+      if (!gate->alive)
+        return;
+    }
+
     OnDownloadFinished(job);
     NotifyStateChanged();
   });
@@ -126,6 +158,7 @@ XCThermControlsModel::Prepare(std::function<void()> state_changed) noexcept
 void
 XCThermControlsModel::OnShow() noexcept
 {
+  ClampCurrentLayer();
   RefreshCachedHours();
 
   const auto &layer = LayerAt(state.current_layer);
@@ -174,7 +207,12 @@ XCThermControlsModel::LoadCursorSession() noexcept
   if (!session.cursor_initialized)
     return;
 
-  state.current_layer = cursor.layer;
+  const unsigned layer_count = Region().layer_count;
+  if (layer_count > 0)
+    state.current_layer = std::min(cursor.layer, layer_count - 1);
+  else
+    state.current_layer = 0;
+
   state.current_time_index = cursor.forecast_utc_hour;
   state.last_synced_active_layer = FindActiveLayerIndex(Settings());
   auto_switch.SetAltitudeManualOverride(cursor.altitude_manual_override);
@@ -205,6 +243,7 @@ XCThermControlsModel::BootstrapSession() noexcept
   ApplyIndexAvailability();
 
   LoadCursorSession();
+  ClampCurrentLayer();
 
   if (!CommonInterface::GetUIState().weather.xctherm.cursor_initialized) {
     const int def = FindLayerIndex(ToRegion(settings.model), 5000, false);
@@ -227,6 +266,8 @@ XCThermControlsModel::ApplyIndexAvailability() noexcept
 {
   auto &api = XCThermAPI::Instance();
   state.index_loaded = api.IsIndexLoaded();
+  ClampCurrentLayer();
+
   if (state.index_loaded) {
     const auto &params = api.GetAvailableParameters();
     for (unsigned i = 0; i < Region().layer_count; ++i) {
@@ -238,7 +279,8 @@ XCThermControlsModel::ApplyIndexAvailability() noexcept
         }
       }
     }
-    if (state.layer_available[state.current_layer])
+    if (state.current_layer < Region().layer_count &&
+        state.layer_available[state.current_layer])
       state.available_hours =
         api.GetAvailableForecastHours(
           LayerAt(state.current_layer).api_parameter);
@@ -286,6 +328,7 @@ XCThermControlsModel::SyncActiveLayerFromSettings() noexcept
 void
 XCThermControlsModel::RefreshCachedHours() noexcept
 {
+  ClampCurrentLayer();
   state.cached_hours =
     XCThermAPI::Instance().GetCachedHours(
       LayerAt(state.current_layer).api_parameter);
@@ -303,6 +346,7 @@ XCThermControlsModel::RefreshCurrentLayerHours(
 void
 XCThermControlsModel::RefreshAvailableHours() noexcept
 {
+  ClampCurrentLayer();
   if (!state.index_loaded)
     return;
 
@@ -470,11 +514,18 @@ XCThermControlsModel::RequestLayerDownload(
 
   ResetAutoFetchAttempt();
   XCThermAPI::Instance().PrepareSession(settings);
+  const auto gate = callback_gate;
 
   const auto shared = StartSpanDownload(
     settings, state.current_layer,
-    [this, finished = std::move(on_finished)](
+    [this, gate, finished = std::move(on_finished)](
       std::shared_ptr<XCThermDownloadJob> done) mutable {
+      {
+        const std::lock_guard lock{gate->mutex};
+        if (!gate->alive)
+          return;
+      }
+
       ApplyJobPreviewToMap(done);
       OnDownloadFinished(done);
       if (finished)
@@ -557,6 +608,9 @@ XCThermControlsModel::IsTimeAutoActive() const noexcept
 bool
 XCThermControlsModel::LayerHasCache(unsigned layer_index) const noexcept
 {
+  if (layer_index >= Region().layer_count)
+    return false;
+
   return !XCThermAPI::Instance()
     .GetCachedHours(LayerAt(layer_index).api_parameter).empty();
 }
@@ -565,6 +619,9 @@ bool
 XCThermControlsModel::LayerUsableForAutoSwitch(
   unsigned layer_index) const noexcept
 {
+  if (layer_index >= Region().layer_count)
+    return false;
+
   return state.layer_available[layer_index] || LayerHasCache(layer_index);
 }
 
@@ -582,6 +639,9 @@ XCThermControlsModel::BuildAutoSwitchLayers() const noexcept
 bool
 XCThermControlsModel::HasCacheAtCurrentHour(unsigned layer_index) const noexcept
 {
+  if (layer_index >= Region().layer_count)
+    return false;
+
   return XCThermAPI::Instance().IsLayerCached(
     LayerAt(layer_index).api_parameter, GetCurrentForecastHour());
 }

--- a/src/Weather/xctherm/XCThermControlsModel.hpp
+++ b/src/Weather/xctherm/XCThermControlsModel.hpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Weather/xctherm/XCThermAutoSwitch.hpp"
+#include "Weather/xctherm/XCThermCatalog.hpp"
+#include "util/StaticString.hxx"
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+struct MoreData;
+struct XCThermDownloadJob;
+struct XCThermSettings;
+
+namespace XCTherm {
+
+/**
+ * Cursor-bar state: layer/time selection, index availability, cache hours,
+ * and auto-switch orchestration.  UI-agnostic; used by #XCThermControlsWidget.
+ */
+struct XCThermControlsState {
+  unsigned current_layer = 0;
+  /** Selected forecast UTC hour (0–23) for cursor bar and map. */
+  unsigned current_time_index = 0;
+  bool layer_available[MaxLayerCount()] = {};
+  std::vector<unsigned> cached_hours;
+  std::vector<unsigned> available_hours;
+  bool index_loaded = false;
+  int last_synced_active_layer = -1;
+};
+
+class XCThermControlsModel {
+  XCThermControlsState state;
+  XCThermAutoSwitch auto_switch;
+  bool auto_switch_configured = false;
+  std::function<void()> on_state_changed;
+
+  void NotifyStateChanged() noexcept;
+
+  [[gnu::pure]]
+  const RegionDef &Region() const noexcept;
+
+  [[gnu::pure]]
+  const Layer &LayerAt(unsigned index) const noexcept;
+
+  [[gnu::pure]]
+  const XCThermSettings &Settings() const noexcept;
+
+  [[gnu::pure]]
+  static double BestAltitude(const MoreData &basic) noexcept;
+
+  void ConfigureAutoSwitch() noexcept;
+  void ApplyAutoSwitchLayer(unsigned layer_index) noexcept;
+  void RefreshCurrentLayerHours(bool include_available_hours) noexcept;
+  void ApplySelectionAndPersist() noexcept;
+
+public:
+  const XCThermControlsState &GetState() const noexcept {
+    return state;
+  }
+
+  unsigned GetCurrentLayer() const noexcept {
+    return state.current_layer;
+  }
+
+  unsigned GetCurrentTimeIndex() const noexcept {
+    return state.current_time_index;
+  }
+
+  void SetCurrentLayer(unsigned layer) noexcept {
+    state.current_layer = layer;
+  }
+
+  void SetCurrentTimeIndex(unsigned index) noexcept {
+    state.current_time_index = index;
+  }
+
+  bool IsLayerAvailable(unsigned index) const noexcept {
+    return index < Region().layer_count && state.layer_available[index];
+  }
+
+  bool IsIndexLoaded() const noexcept { return state.index_loaded; }
+
+  const std::vector<unsigned> &GetCachedHours() const noexcept {
+    return state.cached_hours;
+  }
+
+  const std::vector<unsigned> &GetAvailableHours() const noexcept {
+    return state.available_hours;
+  }
+
+  unsigned GetCurrentForecastHour() const noexcept;
+
+  /** Widget lifetime: bootstrap session and background fetches. */
+  void Prepare(std::function<void()> on_state_changed = nullptr) noexcept;
+
+  void OnShow() noexcept;
+  void OnHide() noexcept;
+
+  /** Periodic blackboard tick (auto-switch, settings sync). */
+  void OnGPSUpdate(const MoreData &basic) noexcept;
+
+  void BootstrapSession() noexcept;
+
+  void ApplyIndexAvailability() noexcept;
+
+  void SyncActiveLayerFromSettings() noexcept;
+
+  void RefreshCachedHours() noexcept;
+
+  void RefreshAvailableHours() noexcept;
+
+  void LoadCursorSession() noexcept;
+  void SaveCursorSession() noexcept;
+
+  void SelectBestTimeIndex() noexcept;
+
+  void ApplyCurrentSelectionToMap() noexcept;
+
+  void ApplyLayerToMap(unsigned layer_index, unsigned utc_hour) noexcept;
+
+  /**
+   * Step through all altitude bands for the region.
+   * @return false when the region defines no bands.
+   */
+  bool StepLayer(int delta) noexcept;
+
+  /** Step through index forecast hours, or 24 UTC hours when unknown. */
+  bool StepTime(int delta) noexcept;
+
+  void ResumeLayerAuto(const MoreData &basic) noexcept;
+  void ResumeTimeAuto() noexcept;
+
+  void SetAltitudeAutoAdvance(bool auto_advance,
+                              const MoreData &basic) noexcept;
+  void SetTimeAutoAdvance(bool auto_advance) noexcept;
+
+  void OnIndexLoaded() noexcept;
+
+  void RequestBackgroundIndex(std::function<void()> on_ready) const;
+
+  void MaybeFetchActiveLayer(
+    std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished) const;
+
+  /**
+   * Queue a span download for the cursor-bar layer.
+   *
+   * @return true if a download was started
+   */
+  bool RequestLayerDownload(
+    std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished
+    = nullptr) noexcept;
+
+  void OnDownloadFinished(const std::shared_ptr<XCThermDownloadJob> &job) noexcept;
+
+  void FormatLayerLabel(StaticString<80> &text) const noexcept;
+  void FormatTimeLabel(StaticString<64> &text) noexcept;
+
+  [[gnu::pure]]
+  bool IsAltitudeAutoActive() const noexcept;
+
+  [[gnu::pure]]
+  bool IsTimeAutoActive() const noexcept;
+
+  [[gnu::pure]]
+  bool LayerHasCache(unsigned layer_index) const noexcept;
+
+  [[gnu::pure]]
+  bool LayerUsableForAutoSwitch(unsigned layer_index) const noexcept;
+
+  [[gnu::pure]]
+  std::vector<XCThermAutoSwitch::LayerInfo> BuildAutoSwitchLayers() const noexcept;
+
+  [[gnu::pure]]
+  bool HasCacheAtCurrentHour(unsigned layer_index) const noexcept;
+};
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermControlsModel.hpp
+++ b/src/Weather/xctherm/XCThermControlsModel.hpp
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 struct MoreData;
@@ -33,12 +34,20 @@ struct XCThermControlsState {
 };
 
 class XCThermControlsModel {
+  struct CallbackGate {
+    std::mutex mutex;
+    bool alive = true;
+  };
+
   XCThermControlsState state;
   XCThermAutoSwitch auto_switch;
   bool auto_switch_configured = false;
   std::function<void()> on_state_changed;
+  std::shared_ptr<CallbackGate> callback_gate =
+    std::make_shared<CallbackGate>();
 
   void NotifyStateChanged() noexcept;
+  void ClampCurrentLayer() noexcept;
 
   [[gnu::pure]]
   const RegionDef &Region() const noexcept;
@@ -58,6 +67,8 @@ class XCThermControlsModel {
   void ApplySelectionAndPersist() noexcept;
 
 public:
+  ~XCThermControlsModel() noexcept;
+
   const XCThermControlsState &GetState() const noexcept {
     return state;
   }

--- a/src/Weather/xctherm/XCThermDownload.cpp
+++ b/src/Weather/xctherm/XCThermDownload.cpp
@@ -229,7 +229,8 @@ RunXCThermDownload(CurlGlobal &curl,
           MaybeSetFirstForecast(job, geojson, forecast_utc);
           slot_ok = true;
           break;
-        }
+        } else
+          transient_failure = true;
       } catch (const XCThermAPIError &e) {
         switch (e.kind) {
         case XCThermAPIError::Kind::NETWORK:

--- a/src/Weather/xctherm/XCThermDownload.cpp
+++ b/src/Weather/xctherm/XCThermDownload.cpp
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermDownloadJob.hpp"
+#include "XCThermAPI.hpp"
+#include "XCThermCatalog.hpp"
+#include "XCThermGeoJSON.hpp"
+#include "Weather/BackgroundDownloadProgress.hpp"
+#include "Weather/Settings.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "Operation/ProgressListener.hpp"
+#include "co/Sleep.hxx"
+#include "co/Task.hxx"
+#include "lib/curl/Global.hxx"
+#include "util/StaticString.hxx"
+
+#include <cstdlib>
+
+namespace {
+
+void
+FinishJob(const std::shared_ptr<XCThermDownloadJob> &job,
+          std::exception_ptr error={}) noexcept
+{
+  if (error)
+    job->error_eptr = std::move(error);
+
+  job->finished_at = std::chrono::steady_clock::now();
+  job->done.store(true);
+}
+
+void
+MaybeSetFirstForecast(const std::shared_ptr<XCThermDownloadJob> &job,
+                      const std::string &geojson,
+                      unsigned forecast_utc) noexcept
+{
+  std::lock_guard lock{job->result_mutex};
+  if (!job->first_forecast.IsEmpty())
+    return;
+
+  auto forecast = XCThermGeoJSON::Parse(geojson, true);
+  if (forecast.IsEmpty())
+    return;
+
+  forecast.layer_name = job->target_label;
+  job->first_forecast = std::move(forecast);
+  job->first_forecast_utc = forecast_utc;
+  job->has_first_forecast_utc = true;
+}
+
+void
+UpdateDownloadProgressText(const XCThermDownloadJob &job) noexcept
+{
+  const unsigned total = job.span_hours + 1;
+  const unsigned slot = job.current_offset.load();
+
+  StaticString<128> text;
+  if (slot > 0 && total > 0)
+    text.Format(_("Downloading XCTherm %s (%u/%u)..."),
+                gettext(job.target_label.c_str()), slot, total);
+  else
+    text.Format(_("Downloading XCTherm %s..."),
+                gettext(job.target_label.c_str()));
+
+  BackgroundDownloadProgress::Get().SetText(text.c_str());
+}
+
+void
+UpdateDownloadProgressPosition(const XCThermDownloadJob &job,
+                             unsigned bytes_now,
+                             unsigned bytes_total) noexcept
+{
+  const unsigned total_slots = job.span_hours + 1;
+  if (total_slots == 0)
+    return;
+
+  const unsigned slot = job.current_offset.load();
+  if (slot == 0)
+    return;
+
+  const unsigned slot_index = slot - 1;
+  unsigned percent = (slot_index * 100) / total_slots;
+  if (bytes_total > 0)
+    percent += (bytes_now * 100 / bytes_total) / total_slots;
+
+  if (percent > 100)
+    percent = 100;
+
+  BackgroundDownloadProgress::Get().SetProgressRange(100);
+  BackgroundDownloadProgress::Get().SetProgressPosition(percent);
+}
+
+class JobProgressListener final : public ProgressListener {
+  const std::shared_ptr<XCThermDownloadJob> job;
+
+public:
+  explicit JobProgressListener(const std::shared_ptr<XCThermDownloadJob> &j) noexcept
+    :job(j) {}
+
+  void SetProgressRange(unsigned range) noexcept override {
+    job->bytes_total.store(range);
+    UpdateDownloadProgressPosition(*job, job->bytes_now.load(), range);
+  }
+
+  void SetProgressPosition(unsigned position) noexcept override {
+    job->bytes_now.store(position);
+    UpdateDownloadProgressPosition(*job, position, job->bytes_total.load());
+  }
+};
+
+} // namespace
+
+std::shared_ptr<XCThermDownloadJob>
+MakeXCThermSpanJob(const XCThermSettings &settings, unsigned layer_index,
+                   unsigned current_utc) noexcept
+{
+  const auto &region = XCTherm::GetRegion(settings.model);
+  if (layer_index >= region.layer_count || settings.download_span_hours == 0)
+    return nullptr;
+
+  const auto &target = region.layers[layer_index];
+  auto job = std::make_shared<XCThermDownloadJob>();
+  job->model = settings.model;
+  job->target_index = int(layer_index);
+  job->target_label = target.dialog_label;
+  job->param = target.api_parameter;
+  job->span_hours = settings.download_span_hours;
+  job->current_utc = current_utc;
+  job->started_at = std::chrono::steady_clock::now();
+  return job;
+}
+
+Co::Task<void>
+RunXCThermDownload(CurlGlobal &curl,
+                   const std::shared_ptr<XCThermDownloadJob> &job)
+{
+  auto &api = XCThermAPI::Instance();
+  JobProgressListener progress_listener{job};
+
+  if (!api.IsIndexLoaded()) {
+    try {
+      if (!co_await api.CoEnsureIndexLoaded(curl)) {
+        job->index_no_parameters.store(true);
+        FinishJob(job);
+        co_return;
+      }
+    } catch (...) {
+      FinishJob(job, std::current_exception());
+      co_return;
+    }
+  }
+
+  const unsigned total_slots = job->span_hours + 1;
+  for (unsigned slot_i = 0; slot_i < total_slots; ++slot_i) {
+    if (job->cancel.load())
+      break;
+
+    const bool is_past = (slot_i == 0);
+    const unsigned slot_base = is_past
+      ? (job->current_utc + 23) % 24
+      : job->current_utc;
+    const unsigned slot_offset = is_past ? 0u : slot_i;
+
+    job->current_offset.store(slot_i + 1);
+    job->bytes_now.store(0);
+    job->bytes_total.store(0);
+    UpdateDownloadProgressText(*job);
+    UpdateDownloadProgressPosition(*job, 0, 0);
+
+    std::string slot_date, slot_run_hour;
+    unsigned slot_step = 0;
+    if (!api.FindSlotForOffset(job->param, slot_base, slot_offset,
+                               slot_date, slot_run_hour, slot_step)) {
+      job->any_slot_missing.store(true);
+      continue;
+    }
+
+    const unsigned run_h = (unsigned)std::atoi(slot_run_hour.c_str());
+    const unsigned forecast_utc = (run_h + slot_step) % 24;
+
+    {
+      std::lock_guard lock{job->result_mutex};
+      if (slot_date > job->latest_run_date ||
+          (slot_date == job->latest_run_date &&
+           slot_run_hour > job->latest_run_hour)) {
+        job->latest_run_date = slot_date;
+        job->latest_run_hour = slot_run_hour;
+      }
+    }
+
+    if (api.IsCachedAtRun(job->param, forecast_utc,
+                          slot_date, slot_run_hour)) {
+      job->succeeded_or_cached.fetch_add(1);
+      const std::string &cached = api.GetCachedGeoJSON(job->param, forecast_utc);
+      if (!cached.empty())
+        MaybeSetFirstForecast(job, cached, forecast_utc);
+      continue;
+    }
+
+    bool slot_ok = false;
+    bool slot_abandon = false;
+    for (unsigned attempt = 0; !job->cancel.load(); ++attempt) {
+      job->retry_attempt.store(attempt);
+      job->retry_seconds_left.store(0);
+      job->bytes_now.store(0);
+      job->bytes_total.store(0);
+
+      std::string geojson;
+      int64_t wire_bytes = 0;
+
+      const auto should_continue = [&job]() noexcept {
+        return !job->cancel.load();
+      };
+
+      bool transient_failure = false;
+      try {
+        const bool ok = co_await api.CoDownloadGeoJSON(
+          curl, job->param, slot_date, slot_run_hour, slot_step,
+          geojson, &wire_bytes, &progress_listener, should_continue);
+
+        if (job->cancel.load())
+          break;
+
+        if (ok) {
+          job->total_wire_bytes.fetch_add((uint64_t)wire_bytes);
+          job->succeeded_or_cached.fetch_add(1);
+          job->newly_downloaded.fetch_add(1);
+          MaybeSetFirstForecast(job, geojson, forecast_utc);
+          slot_ok = true;
+          break;
+        }
+      } catch (const XCThermAPIError &e) {
+        switch (e.kind) {
+        case XCThermAPIError::Kind::NETWORK:
+        case XCThermAPIError::Kind::SERVER_ERROR:
+          transient_failure = true;
+          break;
+        case XCThermAPIError::Kind::NOT_FOUND:
+          LogFmt("xctherm: slot#{}: {}", slot_i, e.what());
+          slot_abandon = true;
+          break;
+        case XCThermAPIError::Kind::AUTH_FAILED:
+        case XCThermAPIError::Kind::FORBIDDEN:
+        case XCThermAPIError::Kind::OTHER_HTTP:
+          LogFmt("xctherm: aborting job — {}", e.what());
+          FinishJob(job, std::current_exception());
+          co_return;
+        }
+      } catch (...) {
+        FinishJob(job, std::current_exception());
+        co_return;
+      }
+
+      if (slot_abandon)
+        break;
+
+      if (transient_failure) {
+        constexpr unsigned MAX_TRANSIENT_RETRIES = 5;
+        if (attempt + 1 >= MAX_TRANSIENT_RETRIES) {
+          LogFmt("xctherm: slot#{} giving up after {} attempts",
+                 slot_i, attempt + 1);
+          break;
+        }
+
+        constexpr unsigned RETRY_SECONDS = 5;
+        LogFmt("xctherm: slot#{} attempt {} transient failure — retry in {}s",
+               slot_i, attempt + 1, RETRY_SECONDS);
+        for (unsigned s = RETRY_SECONDS; s > 0 && !job->cancel.load(); --s) {
+          job->retry_seconds_left.store(s);
+          co_await Co::Sleep(curl.GetEventLoop(), std::chrono::seconds(1));
+        }
+        job->retry_seconds_left.store(0);
+      }
+    }
+
+    if (!slot_ok && !job->cancel.load())
+      job->any_slot_missing.store(true);
+  }
+
+  FinishJob(job);
+}

--- a/src/Weather/xctherm/XCThermDownloadGlue.cpp
+++ b/src/Weather/xctherm/XCThermDownloadGlue.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermDownloadGlue.hpp"
+#include "XCThermAPI.hpp"
+#include "XCThermDownloadJob.hpp"
+#include "Weather/BackgroundDownloadProgress.hpp"
+#include "Components.hpp"
+#include "Language/Language.hpp"
+#include "NetComponents.hpp"
+#include "LogFile.hpp"
+#include "lib/curl/Global.hxx"
+#include "util/Macros.hpp"
+#include "util/StaticString.hxx"
+
+#include <utility>
+
+XCThermDownloadGlue *
+GetXCThermDownloadGlue() noexcept
+{
+  if (net_components == nullptr)
+    return nullptr;
+  return net_components->xctherm_download.get();
+}
+
+XCThermDownloadGlue::XCThermDownloadGlue(CurlGlobal &_curl) noexcept
+  :curl(_curl),
+   task(curl.GetEventLoop())
+{
+}
+
+void
+XCThermDownloadGlue::BeginShutdown() noexcept
+{
+  if (job != nullptr)
+    job->cancel.store(true);
+
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  job.reset();
+  on_finished = nullptr;
+  on_index_fetched = nullptr;
+  index_fetch = false;
+  completion_error = {};
+  BackgroundDownloadProgress::Get().ForceHide();
+}
+
+void
+XCThermDownloadGlue::Start(
+  std::shared_ptr<XCThermDownloadJob> new_job,
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> &&finished)
+{
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  index_fetch = false;
+  on_index_fetched = nullptr;
+  job = std::move(new_job);
+  on_finished = std::move(finished);
+  completion_error = {};
+
+  StaticString<128> text;
+  text.Format(_("Downloading XCTherm %s..."),
+              gettext(job->target_label.c_str()));
+  BackgroundDownloadProgress::Get().Begin(text.c_str());
+  BackgroundDownloadProgress::Get().SetProgressRange(100);
+
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+void
+XCThermDownloadGlue::StartIndexFetch(std::function<void()> &&finished)
+{
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  if (XCThermAPI::Instance().IsIndexLoaded()) {
+    if (finished)
+      finished();
+    return;
+  }
+
+  index_fetch = true;
+  on_index_fetched = std::move(finished);
+  job.reset();
+  on_finished = nullptr;
+  completion_error = {};
+
+  task.Start(RunIndexFetch(), BIND_THIS_METHOD(OnCompletion));
+}
+
+void
+XCThermDownloadGlue::RequestCancel() noexcept
+{
+  if (job != nullptr)
+    job->cancel.store(true);
+}
+
+void
+XCThermDownloadGlue::Abandon() noexcept
+{
+  RequestCancel();
+  on_finished = nullptr;
+}
+
+Co::InvokeTask
+XCThermDownloadGlue::RunDownload()
+{
+  if (job != nullptr)
+    co_await RunXCThermDownload(curl, job);
+  co_return;
+}
+
+Co::InvokeTask
+XCThermDownloadGlue::RunIndexFetch()
+{
+  try {
+    co_await XCThermAPI::Instance().CoEnsureIndexLoaded(curl);
+  } catch (const std::exception &e) {
+    LogFmt("xctherm: background index fetch failed: {}", e.what());
+  } catch (...) {
+    LogFmt("xctherm: background index fetch failed (unknown)");
+  }
+  co_return;
+}
+
+void
+XCThermDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  if (completion_error)
+    LogError(completion_error, "XCTherm download coroutine failed");
+
+  complete_notify.SendNotification();
+}
+
+void
+XCThermDownloadGlue::OnCompleteNotify() noexcept
+{
+  if (task.IsShuttingDown())
+    return;
+
+  if (completion_error && job != nullptr && !job->error_eptr)
+    job->error_eptr = completion_error;
+
+  if (index_fetch) {
+    index_fetch = false;
+    auto callback = std::move(on_index_fetched);
+    on_index_fetched = nullptr;
+    completion_error = {};
+
+    if (callback)
+      callback();
+    return;
+  }
+
+  if (!task.IsRunning())
+    BackgroundDownloadProgress::Get().End();
+
+  auto finished_job = std::move(job);
+  auto callback = std::move(on_finished);
+  on_finished = nullptr;
+  completion_error = {};
+
+  if (finished_job != nullptr && callback)
+    callback(std::move(finished_job));
+}

--- a/src/Weather/xctherm/XCThermDownloadGlue.cpp
+++ b/src/Weather/xctherm/XCThermDownloadGlue.cpp
@@ -53,6 +53,11 @@ XCThermDownloadGlue::Start(
   if (task.IsShuttingDown() || task.IsRunning())
     return;
 
+  if (new_job == nullptr) {
+    LogFmt("xctherm: Start() called with null job");
+    return;
+  }
+
   index_fetch = false;
   on_index_fetched = nullptr;
   job = std::move(new_job);
@@ -101,6 +106,7 @@ XCThermDownloadGlue::Abandon() noexcept
 {
   RequestCancel();
   on_finished = nullptr;
+  on_index_fetched = nullptr;
 }
 
 Co::InvokeTask

--- a/src/Weather/xctherm/XCThermDownloadGlue.hpp
+++ b/src/Weather/xctherm/XCThermDownloadGlue.hpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Weather/xctherm/XCThermDownloadJob.hpp"
+#include "co/InvokeTask.hxx"
+#include "net/AsyncTask.hpp"
+#include "ui/event/Notify.hpp"
+
+#include <exception>
+#include <functional>
+#include <memory>
+
+class CurlGlobal;
+
+/**
+ * Runs #RunXCThermDownload on the network #EventLoop and notifies the
+ * UI thread when complete (EDL DownloadGlue pattern).
+ */
+class XCThermDownloadGlue final {
+  CurlGlobal &curl;
+  Net::AsyncTask task;
+  UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
+
+  std::shared_ptr<XCThermDownloadJob> job;
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished;
+  std::function<void()> on_index_fetched;
+  bool index_fetch = false;
+  std::exception_ptr completion_error;
+
+  Co::InvokeTask RunDownload();
+  Co::InvokeTask RunIndexFetch();
+  void OnCompletion(std::exception_ptr error) noexcept;
+  void OnCompleteNotify() noexcept;
+
+public:
+  explicit XCThermDownloadGlue(CurlGlobal &_curl) noexcept;
+
+  ~XCThermDownloadGlue() noexcept { BeginShutdown(); }
+
+  XCThermDownloadGlue(const XCThermDownloadGlue &) = delete;
+  XCThermDownloadGlue &operator=(const XCThermDownloadGlue &) = delete;
+
+  [[nodiscard]]
+  bool IsRunning() const noexcept { return task.IsRunning(); }
+
+  void BeginShutdown() noexcept;
+
+  void Start(std::shared_ptr<XCThermDownloadJob> new_job,
+             std::function<void(std::shared_ptr<XCThermDownloadJob>)> &&finished);
+
+  /**
+   * Fetch index.json on the network thread when not already loaded.
+   * @p finished runs on the UI thread (no-op if a job is already running).
+   */
+  void StartIndexFetch(std::function<void()> &&finished);
+
+  void RequestCancel() noexcept;
+
+  /**
+   * Cancel an in-flight job and drop the UI completion handler (e.g.
+   * dialog closed). Does not stop the shared #Net::AsyncTask — use
+   * #BeginShutdown() from #NetComponents on app exit.
+   */
+  void Abandon() noexcept;
+};
+
+/**
+ * Shared #XCThermDownloadGlue from #net_components (UI thread only).
+ */
+[[gnu::pure]]
+XCThermDownloadGlue *
+GetXCThermDownloadGlue() noexcept;
+

--- a/src/Weather/xctherm/XCThermDownloadJob.hpp
+++ b/src/Weather/xctherm/XCThermDownloadJob.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Weather/xctherm/XCThermGeoJSON.hpp"
+#include "Weather/xctherm/XCThermForecastTime.hpp"
+#include "co/Task.hxx"
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <string>
+
+/**
+ * Cross-thread state for a multi-hour XCTherm span download.
+ */
+struct XCThermDownloadJob {
+  unsigned model = 0;
+  int target_index = -1;
+  std::string target_label;
+  std::string param;
+  unsigned span_hours = 0;
+  unsigned current_utc = XCTherm::XCTHERM_DEFAULT_UTC_HOUR;
+
+  std::atomic<bool> cancel{false};
+  std::atomic<bool> done{false};
+  std::atomic<unsigned> current_offset{0};
+  std::atomic<uint64_t> bytes_now{0};
+  std::atomic<uint64_t> bytes_total{0};
+  std::atomic<uint64_t> total_wire_bytes{0};
+  std::atomic<unsigned> succeeded_or_cached{0};
+  std::atomic<unsigned> newly_downloaded{0};
+  std::atomic<unsigned> retry_attempt{0};
+  std::atomic<unsigned> retry_seconds_left{0};
+  std::atomic<bool> any_slot_missing{false};
+  std::atomic<bool> index_no_parameters{false};
+
+  std::mutex result_mutex;
+  XCThermGeoJSON::ForecastLayer first_forecast;
+  unsigned first_forecast_utc = 0;
+  bool has_first_forecast_utc = false;
+  std::string latest_run_date;
+  std::string latest_run_hour;
+  std::chrono::steady_clock::time_point started_at;
+  std::chrono::steady_clock::time_point finished_at;
+
+  std::exception_ptr error_eptr;
+};
+
+class CurlGlobal;
+struct XCThermSettings;
+
+/**
+ * Build a span download job for @p layer_index (region from @p settings).
+ */
+std::shared_ptr<XCThermDownloadJob>
+MakeXCThermSpanJob(const XCThermSettings &settings, unsigned layer_index,
+                   unsigned current_utc) noexcept;
+
+/**
+ * Multi-hour download loop on @p curl's event loop. Updates @p job
+ * atomics and sets @c done when finished.
+ */
+Co::Task<void>
+RunXCThermDownload(CurlGlobal &curl,
+                    const std::shared_ptr<XCThermDownloadJob> &job);

--- a/src/Weather/xctherm/XCThermForecastTime.cpp
+++ b/src/Weather/xctherm/XCThermForecastTime.cpp
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermForecastTime.hpp"
+#include "XCThermAPI.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "Weather/MapOverlay/CursorBarLabels.hpp"
+
+#include <chrono>
+#include <optional>
+
+namespace XCTherm {
+
+UtcTimeParts
+GetUtcTimeParts() noexcept
+{
+  UtcTimeParts utc;
+  const auto &basic = CommonInterface::Basic();
+  if (basic.date_time_utc.IsPlausible()) {
+    utc.hour = basic.date_time_utc.hour;
+    utc.minute = basic.date_time_utc.minute;
+  }
+  return utc;
+}
+
+unsigned
+PickAutoTargetUtcHour(unsigned utc_h, unsigned utc_min) noexcept
+{
+  return (utc_min >= 45) ? (utc_h + 1) % 24 : utc_h;
+}
+
+int
+PickAutoTimeIndex(const std::vector<unsigned> &cached_hours,
+                  unsigned utc_h, unsigned utc_min) noexcept
+{
+  if (cached_hours.empty())
+    return -1;
+
+  const unsigned target = PickAutoTargetUtcHour(utc_h, utc_min);
+
+  int best_future = -1;
+  unsigned best_future_dist = 25;
+  int best_past = -1;
+  unsigned best_past_dist = 25;
+
+  for (size_t i = 0; i < cached_hours.size(); ++i) {
+    const unsigned fwd = (cached_hours[i] + 24 - target) % 24;
+    if (fwd <= 12) {
+      if (fwd < best_future_dist) {
+        best_future_dist = fwd;
+        best_future = int(i);
+      }
+    } else {
+      const unsigned back = 24 - fwd;
+      if (back < best_past_dist) {
+        best_past_dist = back;
+        best_past = int(i);
+      }
+    }
+  }
+
+  return best_future >= 0 ? best_future : best_past;
+}
+
+unsigned
+ForecastHourAt(const std::vector<unsigned> &cached_hours,
+             unsigned time_index,
+             const std::vector<unsigned> &available_hours,
+             unsigned fallback) noexcept
+{
+  if (!available_hours.empty()) {
+    if (time_index < available_hours.size())
+      return available_hours[time_index];
+    return available_hours[0];
+  }
+
+  if (time_index < cached_hours.size())
+    return cached_hours[time_index];
+  if (!cached_hours.empty())
+    return cached_hours[0];
+
+  return time_index < 24 ? time_index : fallback;
+}
+
+bool
+MakeForecastDateTime(std::string_view run_date,
+                     std::string_view run_hour,
+                     unsigned step,
+                     std::chrono::sys_seconds &out) noexcept
+{
+  if (run_date.size() != 8 || run_hour.size() != 2)
+    return false;
+
+  try {
+    const int year = std::stoi(std::string{run_date.substr(0, 4)});
+    const unsigned month = (unsigned)std::stoul(
+      std::string{run_date.substr(4, 2)});
+    const unsigned day = (unsigned)std::stoul(
+      std::string{run_date.substr(6, 2)});
+    const unsigned hour = (unsigned)std::stoul(std::string{run_hour});
+
+    const std::chrono::year_month_day ymd{
+      std::chrono::year{year},
+      std::chrono::month{month},
+      std::chrono::day{day},
+    };
+    if (!ymd.ok())
+      return false;
+
+    out = std::chrono::sys_days{ymd}
+      + std::chrono::hours{hour}
+      + std::chrono::hours{step};
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+void
+FormatTimeLabel(StaticString<64> &dest, const char *api_parameter,
+                unsigned forecast_utc_hour, bool time_auto_active) noexcept
+{
+  int offset_min = 0;
+  bool has_real_offset = false;
+  std::optional<XCThermAPI::SliceMeta> slice;
+  if (api_parameter != nullptr && api_parameter[0] != '\0')
+    slice = XCThermAPI::Instance().GetSliceMeta(api_parameter,
+                                                forecast_utc_hour);
+
+  std::chrono::sys_seconds forecast_dt{};
+  if (slice.has_value() &&
+      MakeForecastDateTime(slice->run_date, slice->run_hour,
+                           slice->step, forecast_dt)) {
+    const auto delta = forecast_dt - std::chrono::system_clock::now();
+    offset_min = (int)std::chrono::duration_cast<std::chrono::minutes>(delta)
+      .count();
+    has_real_offset = true;
+  } else if (CommonInterface::Basic().date_time_utc.IsPlausible()) {
+    const auto &basic = CommonInterface::Basic();
+    const int cur_min = int(basic.date_time_utc.hour) * 60
+                      + int(basic.date_time_utc.minute);
+    const int fc_min = int(forecast_utc_hour) * 60;
+    offset_min = fc_min - cur_min;
+    if (offset_min < 0)
+      offset_min += 1440;
+    has_real_offset = true;
+  }
+
+  char offset_buf[16] = {};
+  if (has_real_offset)
+    WeatherMapOverlay::FormatSignedMinuteOffset(offset_buf, sizeof(offset_buf),
+                                         offset_min);
+
+  WeatherMapOverlay::FormatAutoUtcHourLabel(dest, time_auto_active,
+                                     forecast_utc_hour, offset_buf);
+}
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermForecastTime.hpp
+++ b/src/Weather/xctherm/XCThermForecastTime.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "util/StaticString.hxx"
+
+#include <chrono>
+#include <string_view>
+#include <vector>
+
+namespace XCTherm {
+
+constexpr unsigned XCTHERM_DEFAULT_UTC_HOUR = 12;
+
+struct UtcTimeParts {
+  unsigned hour = XCTHERM_DEFAULT_UTC_HOUR;
+  unsigned minute = 0;
+};
+
+/**
+ * Current UTC hour/minute from the live blackboard, or 12:00 if unknown.
+ */
+[[gnu::pure]]
+UtcTimeParts GetUtcTimeParts() noexcept;
+
+/**
+ * Forecast UTC hour selected by auto-time mode (:45 switches to next hour).
+ */
+[[gnu::const]]
+unsigned PickAutoTargetUtcHour(unsigned utc_h, unsigned utc_min) noexcept;
+
+/**
+ * Pick the cached-hour vector index closest to #PickAutoTargetUtcHour().
+ *
+ * @return index into @p cached_hours, or -1 if empty.
+ */
+[[gnu::pure]]
+int PickAutoTimeIndex(const std::vector<unsigned> &cached_hours,
+                      unsigned utc_h, unsigned utc_min) noexcept;
+
+/**
+ * Forecast UTC hour for cursor-bar @p time_index.
+ *
+ * Prefers @p available_hours (index catalog), then @p cached_hours, then
+ * wraps @p time_index across a 24 h UTC day.
+ */
+[[gnu::pure]]
+unsigned ForecastHourAt(const std::vector<unsigned> &cached_hours,
+                        unsigned time_index,
+                        const std::vector<unsigned> &available_hours,
+                        unsigned fallback = XCTHERM_DEFAULT_UTC_HOUR) noexcept;
+
+/**
+ * Convert run metadata (YYYYMMDD + HH + step) to an absolute UTC time.
+ * @return false if any field is malformed.
+ */
+bool MakeForecastDateTime(std::string_view run_date,
+                          std::string_view run_hour,
+                          unsigned step,
+                          std::chrono::sys_seconds &out) noexcept;
+
+/**
+ * Cursor-bar time label, e.g. @c "12:00 UTC (+1:30)" or @c "AUTO: …".
+ */
+void FormatTimeLabel(StaticString<64> &dest, const char *api_parameter,
+                     unsigned forecast_utc_hour,
+                     bool time_auto_active) noexcept;
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermGeoJSON.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSON.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermGeoJSON.hpp"
+
+#include <boost/json.hpp>
+
+#include <cstdlib>
+#include <string_view>
+
+namespace XCThermGeoJSON {
+
+/**
+ * Parse one [lon, lat] coordinate pair into a GeoPoint.
+ * @return false if @p arr doesn't hold two numeric elements.
+ */
+static bool
+ParseCoord(const boost::json::array &arr, GeoPoint &out) noexcept
+{
+  if (arr.size() < 2)
+    return false;
+  try {
+    const double lon = arr.at(0).to_number<double>();
+    const double lat = arr.at(1).to_number<double>();
+    out = GeoPoint(Angle::Degrees(lon), Angle::Degrees(lat));
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+/**
+ * Parse a ring [[lon,lat], [lon,lat], …] into a Ring.
+ */
+static void
+ParseRing(const boost::json::array &arr, Ring &ring)
+{
+  ring.reserve(arr.size());
+  for (const auto &pt_val : arr) {
+    if (!pt_val.is_array())
+      continue;
+    GeoPoint pt;
+    if (ParseCoord(pt_val.as_array(), pt))
+      ring.push_back(pt);
+  }
+}
+
+/**
+ * Parse one polygon — array of rings; ring 0 = exterior, rest = holes.
+ */
+static void
+ParsePolygon(const boost::json::array &arr, std::vector<Ring> &polygon)
+{
+  polygon.reserve(arr.size());
+  for (const auto &ring_val : arr) {
+    if (!ring_val.is_array())
+      continue;
+    Ring ring;
+    ParseRing(ring_val.as_array(), ring);
+    if (!ring.empty())
+      polygon.push_back(std::move(ring));
+  }
+}
+
+/**
+ * Parse the "coordinates" of a MultiPolygon geometry into @p polygons.
+ */
+static void
+ParseMultiPolygonCoords(const boost::json::array &arr,
+                        std::vector<std::vector<Ring>> &polygons)
+{
+  polygons.reserve(arr.size());
+  for (const auto &poly_val : arr) {
+    if (!poly_val.is_array())
+      continue;
+    std::vector<Ring> polygon;
+    ParsePolygon(poly_val.as_array(), polygon);
+    if (!polygon.empty())
+      polygons.push_back(std::move(polygon));
+  }
+}
+
+/**
+ * Parse one Feature (one line of the GeoJSON stream).
+ *
+ * Expected shape:
+ *   { "type": "Feature",
+ *     "properties": { "min": <num>, "max": <num> },
+ *     "geometry": { "type": "MultiPolygon",
+ *                   "coordinates": [[[[lon,lat],...]]]} }
+ *
+ * Errors swallow into @return false — server occasionally serves
+ * Features without geometry on the edges of a tile and we just skip
+ * those.
+ */
+static bool
+ParseFeature(std::string_view line, WindBand &band) noexcept
+{
+  try {
+    boost::json::value root = boost::json::parse(line);
+    if (!root.is_object())
+      return false;
+    const auto &feature = root.as_object();
+
+    /* properties.min / properties.max — band bounds in m/s */
+    auto it_props = feature.find("properties");
+    if (it_props == feature.end() || !it_props->value().is_object())
+      return false;
+    const auto &props = it_props->value().as_object();
+
+    auto it_min = props.find("min");
+    auto it_max = props.find("max");
+    if (it_min == props.end() || it_max == props.end())
+      return false;
+    band.min_ms = it_min->value().to_number<double>();
+    band.max_ms = it_max->value().to_number<double>();
+
+    /* geometry.coordinates */
+    auto it_geom = feature.find("geometry");
+    if (it_geom == feature.end() || !it_geom->value().is_object())
+      return false;
+    const auto &geom = it_geom->value().as_object();
+
+    auto it_coords = geom.find("coordinates");
+    if (it_coords == geom.end() || !it_coords->value().is_array())
+      return false;
+
+    ParseMultiPolygonCoords(it_coords->value().as_array(), band.polygons);
+    return true;
+  } catch (const std::exception &) {
+    /* Malformed line — skip silently (server sometimes ends a tile
+       with a partially-buffered Feature). */
+    return false;
+  }
+}
+
+ForecastLayer
+Parse(std::string_view content, bool skip_neutral) noexcept
+{
+  ForecastLayer layer;
+
+  /* The server streams one Feature per line (NDJSON style). Iterate
+     over lines, parse each as JSON, append to the layer's bands. */
+  std::size_t pos = 0;
+  while (pos < content.size()) {
+    const std::size_t eol = content.find('\n', pos);
+    const std::size_t end = (eol == std::string_view::npos)
+      ? content.size() : eol;
+
+    if (end > pos) {
+      const std::string_view line = content.substr(pos, end - pos);
+
+      WindBand band;
+      if (ParseFeature(line, band)) {
+        const bool is_neutral =
+          band.min_ms >= -0.2 && band.max_ms <= 0.2;
+        if ((!skip_neutral || !is_neutral) && !band.polygons.empty()) {
+          /* Grow the layer's geographic extent over this band's
+             exterior rings, so callers can cheaply test coverage. */
+          for (const auto &polygon : band.polygons)
+            if (!polygon.empty())
+              for (const auto &pt : polygon[0])
+                layer.bounds.Extend(pt);
+
+          /* push_back can throw bad_alloc; the function is noexcept
+             on the .hpp, so we keep allocations modest by reserving
+             nothing extra and trust that std::terminate on OOM is
+             acceptable here (consistent with the rest of the file). */
+          layer.bands.push_back(std::move(band));
+        }
+      }
+    }
+
+    if (eol == std::string_view::npos)
+      break;
+    pos = eol + 1;
+  }
+
+  return layer;
+}
+
+/* FindBandAtPoint() + its PointInRing() helper live in
+   XCThermGeoQuery.cpp so they link without boost::json and stay
+   unit-testable. */
+
+} // namespace XCThermGeoJSON

--- a/src/Weather/xctherm/XCThermGeoJSON.hpp
+++ b/src/Weather/xctherm/XCThermGeoJSON.hpp
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/GeoPoint.hpp"
+#include "Geo/GeoBounds.hpp"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace XCThermGeoJSON {
+
+/**
+ * A single polygon ring (closed ring of GeoPoints).
+ */
+using Ring = std::vector<GeoPoint>;
+
+/**
+ * One wind-speed band (e.g. +0.2 → +0.5 m/s) containing
+ * many polygons.
+ */
+struct WindBand {
+  double min_ms;  // minimum vertical wind m/s
+  double max_ms;  // maximum vertical wind m/s
+
+  /**
+   * Each polygon is a vector of rings.
+   * Ring 0 = exterior, rings 1..n = holes (rare in weather data).
+   */
+  std::vector<std::vector<Ring>> polygons;
+
+  /** Total number of coordinate points across all polygons. */
+  [[gnu::pure]]
+  unsigned TotalCoords() const noexcept {
+    unsigned n = 0;
+    for (const auto &poly : polygons)
+      for (const auto &ring : poly)
+        n += ring.size();
+    return n;
+  }
+};
+
+/**
+ * A complete forecast layer parsed from one GeoJSON file.
+ */
+struct ForecastLayer {
+  /** All wind bands in this layer */
+  std::vector<WindBand> bands;
+
+  /** Metadata (optional, populated if available) */
+  std::string layer_name;   // e.g. "vertical_wind_5000amsl"
+  std::string model;        // e.g. "ICON-CH"
+  std::string valid_time;   // ISO timestamp if known
+
+  /**
+   * Geographic extent of all polygon coordinates, filled in by Parse().
+   * Invalid when the layer is empty. Used to answer "is this location
+   * even covered by the forecast?" without scanning every polygon.
+   */
+  GeoBounds bounds = GeoBounds::Invalid();
+
+  /** Is there any data? */
+  bool IsEmpty() const noexcept { return bands.empty(); }
+
+  /** Total number of polygons across all bands */
+  [[gnu::pure]]
+  unsigned TotalPolygons() const noexcept {
+    unsigned n = 0;
+    for (const auto &b : bands)
+      n += b.polygons.size();
+    return n;
+  }
+
+  /** Total number of coordinates across all bands */
+  [[gnu::pure]]
+  unsigned TotalCoords() const noexcept {
+    unsigned n = 0;
+    for (const auto &b : bands)
+      n += b.TotalCoords();
+    return n;
+  }
+};
+
+/**
+ * Parse a newline-delimited GeoJSON string (one Feature per line).
+ *
+ * Each Feature must have:
+ *   properties: { "min": <float>, "max": <float> }
+ *   geometry: { "type": "MultiPolygon", "coordinates": [...] }
+ *
+ * @param content The full file content
+ * @param skip_neutral If true, skip the band where
+ *   min >= -0.2 && max <= 0.2 (saves ~48% of data)
+ * @return Parsed forecast layer
+ */
+ForecastLayer
+Parse(std::string_view content, bool skip_neutral = true) noexcept;
+
+/**
+ * Find the vertical-wind band whose polygons contain @p p and write its
+ * [min,max] m/s range to the out-parameters. When the point falls inside
+ * several bands, the most extreme (largest |midpoint|) wins — the
+ * innermost contour, i.e. the true local value.
+ *
+ * Pure geometry over @p layer; no UI / projection dependencies, so it is
+ * unit-testable in isolation. Returns false (out-params untouched) if no
+ * band contains the point.
+ */
+bool
+FindBandAtPoint(const ForecastLayer &layer, GeoPoint p,
+                double &out_min_ms, double &out_max_ms) noexcept;
+
+} // namespace XCThermGeoJSON

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermGeoJSONOverlay.hpp"
+#include "lib/fmt/ToBuffer.hxx"
+
+#include <cstring>
+#include <string>
+#include "XCThermAPI.hpp"
+
+#include "Look/Colors.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Scope.hpp"
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <ctime>
+#include <vector>
+
+void
+XCThermGeoJSONOverlay::SetForecast(
+    XCThermGeoJSON::ForecastLayer &&_forecast,
+    const char *_label,
+    const char *_parameter,
+    unsigned _forecast_utc) noexcept
+{
+  const std::lock_guard lock{mutex};
+  forecast = std::move(_forecast);
+  label = _label != nullptr ? _label : "XCTherm";
+  parameter = _parameter != nullptr ? _parameter : "";
+  forecast_utc = _forecast_utc;
+}
+
+bool
+XCThermGeoJSONOverlay::HasData() const noexcept
+{
+  const std::lock_guard lock{mutex};
+  return !forecast.IsEmpty();
+}
+
+bool
+XCThermGeoJSONOverlay::MatchesForecast(const char *parameter,
+                                        unsigned utc_hour) const noexcept
+{
+  if (parameter == nullptr || parameter[0] == '\0')
+    return false;
+
+  const std::lock_guard lock{mutex};
+  return !forecast.IsEmpty() && forecast_utc == utc_hour &&
+    this->parameter == parameter;
+}
+
+XCThermGeoJSON::ForecastLayer
+XCThermGeoJSONOverlay::TakeForecast(std::string &out_label,
+                                    std::string &out_parameter,
+                                    unsigned &out_forecast_utc) noexcept
+{
+  const std::lock_guard lock{mutex};
+  out_label = std::move(label);
+  out_parameter = std::move(parameter);
+  out_forecast_utc = forecast_utc;
+  forecast_utc = 0;
+  return std::move(forecast);
+}
+
+bool
+XCThermGeoJSONOverlay::GetClimbAt(GeoPoint p, double &out_min_ms,
+                                  double &out_max_ms) const noexcept
+{
+  const std::lock_guard lock{mutex};
+  /* Pure geometry lives in XCThermGeoJSON::FindBandAtPoint so it can be
+     unit-tested without dragging in the overlay's UI dependencies. */
+  return XCThermGeoJSON::FindBandAtPoint(forecast, p, out_min_ms, out_max_ms);
+}
+
+bool
+XCThermGeoJSONOverlay::FormatPointInfo(GeoPoint p, char *buffer,
+                                       std::size_t size) const noexcept
+{
+  if (buffer == nullptr || size == 0)
+    return false;
+
+  /* Snapshot the metadata we need under the lock, then format without
+     holding it (snprintf + API call must not nest the mutex). */
+  std::string label_copy, parameter_copy;
+  unsigned hour;
+  {
+    const std::lock_guard lock{mutex};
+    if (forecast.IsEmpty())
+      return false;
+    label_copy = label;
+    parameter_copy = parameter;
+    hour = forecast_utc;
+  }
+
+  /* Climb value at the tapped location.
+     The source data is contoured into bands server-side, so the finest
+     value available is the band the point falls in; we report its
+     midpoint as the representative number. The neutral band
+     (−0.2…+0.2 m/s) is dropped at parse time, so a point inside no band
+     is neutral → 0.0. Open-ended edge bands carry a ±1000 sentinel
+     bound; for those the finite edge is the only meaningful figure. */
+  double min_ms = 0, max_ms = 0;
+  std::string climb;
+  if (GetClimbAt(p, min_ms, max_ms)) {
+    double value;
+    if (min_ms <= -100.0)
+      value = max_ms;
+    else if (max_ms >= 100.0)
+      value = min_ms;
+    else
+      value = (min_ms + max_ms) / 2;
+    climb = std::string(FmtBuffer<32>("{:+.1f} m/s", value).c_str());
+  } else {
+    climb = "0.0 m/s";
+  }
+
+  std::string meta;
+  if (!parameter_copy.empty()) {
+    const auto summary =
+      XCThermAPI::Instance().GetCachedLayerSummary(parameter_copy);
+    if (summary.latest_run_date.size() == 8 &&
+        summary.latest_run_hour.size() == 2) {
+      const std::string &d = summary.latest_run_date;
+      meta += std::string(FmtBuffer<32>(" | run {}-{}-{} {}Z",
+                                        d.substr(0, 4), d.substr(4, 2),
+                                        d.substr(6, 2),
+                                        summary.latest_run_hour).c_str());
+    }
+    if (summary.latest_downloaded_at > 0) {
+      const std::time_t t = (std::time_t)summary.latest_downloaded_at;
+      std::tm *lt = std::localtime(&t);
+      char tbuf[8];
+      if (lt != nullptr && std::strftime(tbuf, sizeof(tbuf), "%H:%M", lt) > 0)
+        meta += std::string(FmtBuffer<16>(" | dl {}", tbuf).c_str());
+    }
+  }
+
+  const auto line = FmtBuffer<256>("{} @ {} ({:02}Z){}",
+                                   climb, label_copy, hour, meta);
+  std::strncpy(buffer, line.c_str(), size - 1);
+  buffer[size - 1] = '\0';
+  return true;
+}
+
+const char *
+XCThermGeoJSONOverlay::GetLabel() const noexcept
+{
+  return "XCTherm";
+}
+
+bool
+XCThermGeoJSONOverlay::IsInside(GeoPoint p) const noexcept
+{
+  const std::lock_guard lock{mutex};
+  /* Only claim the location if the forecast actually covers it — so a
+     tap far outside the model domain doesn't surface a bogus XCTherm
+     map item reading "0.0 m/s". */
+  return !forecast.IsEmpty() && forecast.bounds.IsValid() &&
+         forecast.bounds.IsInside(p);
+}
+
+Color
+XCThermGeoJSONOverlay::WindToColor(double min_ms, double max_ms) noexcept
+{
+  /*
+   * Official XCTherm color scale (from legend):
+   *
+   *  < -3.0 m/s   dark navy     (extreme sink)
+   *   -3.0 m/s    blue          #0000C8
+   *   -2.0 m/s    bright cyan   #00D0FF
+   *   -1.0 m/s    sky blue      #60E0FF
+   *   -0.5 m/s    light blue    #A0E8FF
+   *   -0.2 m/s    pale blue     #C8F0FF (neutral sink edge)
+   *   +0.2 m/s    cream/beige   #F0F0C0 (neutral lift edge)
+   *   +0.5 m/s    yellow        #FFFF00
+   *   +1.0 m/s    gold/amber    #FFD000
+   *   +2.0 m/s    orange        #FFA000
+   *   +3.0 m/s    red-orange    #FF4000
+   *   +4.0 m/s    red           #FF0000
+   *   > +4.0 m/s  purple        #A020F0 (extreme lift)
+   */
+
+  const double mid = (min_ms + max_ms) / 2.0;
+
+  if (mid <= -3.0)  return COLOR_XCTHERM_BLUE;         // blue
+  if (mid <= -2.0)  return COLOR_XCTHERM_BRIGHT_CYAN;  // bright cyan
+  if (mid <= -1.0)  return COLOR_XCTHERM_SKY_BLUE;     // sky blue
+  if (mid <= -0.5)  return COLOR_XCTHERM_LIGHT_BLUE;   // light blue
+  if (mid <= -0.2)  return COLOR_XCTHERM_PALE_BLUE;    // pale blue
+  if (mid <= +0.2)  return COLOR_XCTHERM_CREAM;        // cream/beige
+  if (mid <= +0.5)  return COLOR_XCTHERM_YELLOW;       // yellow
+  if (mid <= +1.0)  return COLOR_XCTHERM_GOLD;         // gold/amber
+  if (mid <= +2.0)  return COLOR_XCTHERM_ORANGE;       // orange
+  if (mid <= +3.0)  return COLOR_XCTHERM_RED_ORANGE;   // red-orange
+  if (mid <= +4.0)  return COLOR_XCTHERM_RED;          // red
+  return COLOR_XCTHERM_PURPLE;                         // purple
+}
+
+void
+XCThermGeoJSONOverlay::Draw(Canvas &canvas,
+                             const WindowProjection &projection) noexcept
+{
+  const std::lock_guard lock{mutex};
+
+  if (forecast.IsEmpty())
+    return;
+
+#ifdef ENABLE_OPENGL
+  /* Enable alpha blending for the entire overlay draw */
+  const ScopeAlphaBlend alpha_blend;
+#endif
+
+  /* Temporary buffer for screen-space polygon points.
+     We reuse this across polygons to avoid reallocation. */
+  std::vector<BulkPixelPoint> screen_points;
+  screen_points.reserve(256);
+
+  const auto screen_rect = projection.GetScreenRect();
+
+  for (const auto &band : forecast.bands) {
+    /* Set color for this wind band.
+     * Alpha ramps down with intensity so the underlying map stays
+     * readable through the stronger lift/sink colors (which would
+     * otherwise saturate). |mid| = 0  → 140, |mid| = 4 → 68. */
+    const Color color = WindToColor(band.min_ms, band.max_ms);
+    const double abs_mid = std::abs((band.min_ms + band.max_ms) / 2.0);
+    int alpha = (int)std::lround(140.0 - 18.0 * abs_mid);
+    if (alpha < 60) alpha = 60;
+    if (alpha > 150) alpha = 150;
+    const Color fill_color = ColorWithAlpha(color, (uint8_t)alpha);
+
+    Brush brush(fill_color);
+    canvas.Select(brush);
+    canvas.SelectNullPen();
+
+    for (const auto &polygon : band.polygons) {
+      /* We only draw the exterior ring (ring 0).
+         Holes are rare in weather contour data. */
+      if (polygon.empty())
+        continue;
+
+      const auto &ring = polygon[0];
+      if (ring.size() < 3)
+        continue;
+
+      /* Quick bounding-box visibility check */
+      GeoPoint bb_min = ring[0], bb_max = ring[0];
+      for (const auto &pt : ring) {
+        if (pt.longitude < bb_min.longitude) bb_min.longitude = pt.longitude;
+        if (pt.latitude < bb_min.latitude) bb_min.latitude = pt.latitude;
+        if (pt.longitude > bb_max.longitude) bb_max.longitude = pt.longitude;
+        if (pt.latitude > bb_max.latitude) bb_max.latitude = pt.latitude;
+      }
+
+      /* Check if bounding box intersects the screen */
+      auto tl = projection.GeoToScreen(GeoPoint(bb_min.longitude, bb_max.latitude));
+      auto br = projection.GeoToScreen(GeoPoint(bb_max.longitude, bb_min.latitude));
+
+      if (br.x < screen_rect.left || tl.x > screen_rect.right ||
+          br.y < screen_rect.top || tl.y > screen_rect.bottom)
+        continue;
+
+      /* Project all points to screen coordinates */
+      screen_points.clear();
+      for (const auto &pt : ring) {
+        auto sp = projection.GeoToScreen(pt);
+        screen_points.push_back(BulkPixelPoint{sp.x, sp.y});
+      }
+
+      canvas.DrawPolygon(screen_points.data(),
+                         (unsigned)screen_points.size());
+    }
+  }
+}

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -22,6 +22,19 @@
 #include <ctime>
 #include <vector>
 
+static bool
+FormatLocalHourMinute(std::time_t t, char *buffer, std::size_t size) noexcept
+{
+  std::tm tm_buf{};
+#ifdef _WIN32
+  return localtime_s(&tm_buf, &t) == 0 &&
+    std::strftime(buffer, size, "%H:%M", &tm_buf) > 0;
+#else
+  return localtime_r(&t, &tm_buf) != nullptr &&
+    std::strftime(buffer, size, "%H:%M", &tm_buf) > 0;
+#endif
+}
+
 void
 XCThermGeoJSONOverlay::SetForecast(
     XCThermGeoJSON::ForecastLayer &&_forecast,
@@ -79,7 +92,7 @@ XCThermGeoJSONOverlay::GetClimbAt(GeoPoint p, double &out_min_ms,
 }
 
 bool
-XCThermGeoJSONOverlay::FormatPointInfo(GeoPoint p, char *buffer,
+XCThermGeoJSONOverlay::FormatPointInfo(const GeoPoint &p, char *buffer,
                                        std::size_t size) const noexcept
 {
   if (buffer == nullptr || size == 0)
@@ -134,9 +147,8 @@ XCThermGeoJSONOverlay::FormatPointInfo(GeoPoint p, char *buffer,
     }
     if (summary.latest_downloaded_at > 0) {
       const std::time_t t = (std::time_t)summary.latest_downloaded_at;
-      std::tm *lt = std::localtime(&t);
       char tbuf[8];
-      if (lt != nullptr && std::strftime(tbuf, sizeof(tbuf), "%H:%M", lt) > 0)
+      if (FormatLocalHourMinute(t, tbuf, sizeof(tbuf)))
         meta += std::string(FmtBuffer<16>(" | dl {}", tbuf).c_str());
     }
   }

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.hpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.hpp
@@ -90,8 +90,8 @@ public:
   /* virtual methods from class MapOverlay */
   const char *GetLabel() const noexcept override;
   bool IsInside(GeoPoint p) const noexcept override;
-  bool FormatPointInfo(GeoPoint p, char *buffer,
-                       std::size_t size) const noexcept;
+  bool FormatPointInfo(const GeoPoint &p, char *buffer,
+                       std::size_t size) const noexcept override;
   void Draw(Canvas &canvas,
             const WindowProjection &projection) noexcept override;
 

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.hpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.hpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "MapWindow/Overlay.hpp"
+#include "XCThermGeoJSON.hpp"
+#include "ui/canvas/Color.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+
+/**
+ * A MapOverlay that renders XCTherm vertical wind forecast
+ * polygons parsed from GeoJSON data.
+ *
+ * Thread safety: The forecast data can be updated from a
+ * background thread while the draw thread reads it. A mutex
+ * protects the shared state.
+ */
+class XCThermGeoJSONOverlay final : public MapOverlay {
+  mutable std::mutex mutex;
+
+  /** The parsed forecast data (protected by mutex) */
+  XCThermGeoJSON::ForecastLayer forecast;
+
+  /** Human-readable label (the altitude layer, e.g. "5000m AMSL") */
+  std::string label;
+
+  /**
+   * The API parameter this overlay was built from (e.g.
+   * "vertical_wind_5000amsl") and the forecast UTC hour it represents.
+   * Used by FormatPointInfo to look up the download time / run from
+   * the XCThermAPI cache. Empty / 0 when not set.
+   */
+  std::string parameter;
+  unsigned forecast_utc = 0;
+
+public:
+  XCThermGeoJSONOverlay() noexcept = default;
+
+  /**
+   * Replace the forecast data.
+   * Can be called from any thread.
+   *
+   * @param _label    altitude layer label shown to the user
+   * @param _parameter API parameter name (for cache metadata lookup)
+   * @param _forecast_utc the forecast's valid UTC hour
+   */
+  void SetForecast(XCThermGeoJSON::ForecastLayer &&_forecast,
+                   const char *_label,
+                   const char *_parameter = nullptr,
+                   unsigned _forecast_utc = 0) noexcept;
+
+  /** Is any data loaded? */
+  bool HasData() const noexcept;
+
+  /**
+   * Return true when this overlay already shows @p parameter at @p utc_hour.
+   */
+  bool MatchesForecast(const char *parameter,
+                       unsigned utc_hour) const noexcept;
+
+  /**
+   * Move the parsed forecast out of this overlay (e.g. when the map
+   * overlay is cleared but the parsed data should be kept in RAM).
+   */
+  XCThermGeoJSON::ForecastLayer TakeForecast(std::string &out_label,
+                                             std::string &out_parameter,
+                                             unsigned &out_forecast_utc) noexcept;
+
+  /**
+   * Find the vertical-wind band whose polygons contain @p p and
+   * return its [min,max] m/s range. When the point falls inside
+   * several nested bands, the most extreme (largest |mid|) wins —
+   * that's the innermost contour and the true local value.
+   *
+   * @return true if a band contains the point.
+   *
+   * NOT [[gnu::pure]] — it writes results through the reference
+   * out-parameters, which a pure function may not do (the optimizer
+   * would assume the writes never happen and use the caller's
+   * uninitialised/initial values instead).
+   */
+  bool GetClimbAt(GeoPoint p, double &out_min_ms,
+                  double &out_max_ms) const noexcept;
+
+  /* virtual methods from class MapOverlay */
+  const char *GetLabel() const noexcept override;
+  bool IsInside(GeoPoint p) const noexcept override;
+  bool FormatPointInfo(GeoPoint p, char *buffer,
+                       std::size_t size) const noexcept;
+  void Draw(Canvas &canvas,
+            const WindowProjection &projection) noexcept override;
+
+private:
+  /**
+   * Map a vertical wind speed (m/s) to an RGBA color.
+   * Uses the standard XCTherm color scale:
+   *   strong sink = blue, weak sink = light blue,
+   *   weak lift = light red/orange, strong lift = red
+   */
+  static Color WindToColor(double min_ms, double max_ms) noexcept;
+};

--- a/src/Weather/xctherm/XCThermGeoQuery.cpp
+++ b/src/Weather/xctherm/XCThermGeoQuery.cpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+/*
+ * Pure geometry query over a parsed XCTherm forecast layer, split out
+ * from XCThermGeoJSON.cpp so it links without boost::json / LogFile and
+ * can be unit-tested in isolation (see test/src/TestXCThermBandQuery).
+ */
+
+#include "XCThermGeoJSON.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+namespace XCThermGeoJSON {
+
+/**
+ * Ray-casting point-in-polygon test on a single ring, in geographic
+ * coordinates (longitude = x, latitude = y). Good enough at forecast
+ * scale; we don't correct for meridian convergence.
+ */
+[[gnu::pure]]
+static bool
+PointInRing(const Ring &ring, double x, double y) noexcept
+{
+  bool inside = false;
+  const std::size_t n = ring.size();
+  if (n < 3)
+    return false;
+  for (std::size_t i = 0, j = n - 1; i < n; j = i++) {
+    const double xi = ring[i].longitude.Degrees();
+    const double yi = ring[i].latitude.Degrees();
+    const double xj = ring[j].longitude.Degrees();
+    const double yj = ring[j].latitude.Degrees();
+    if (((yi > y) != (yj > y)) &&
+        (x < (xj - xi) * (y - yi) / (yj - yi) + xi))
+      inside = !inside;
+  }
+  return inside;
+}
+
+[[gnu::pure]]
+static bool
+PointInPolygon(const std::vector<Ring> &polygon, double x, double y) noexcept
+{
+  if (polygon.empty() || polygon[0].size() < 3)
+    return false;
+
+  if (!PointInRing(polygon[0], x, y))
+    return false;
+
+  for (std::size_t i = 1; i < polygon.size(); ++i) {
+    if (polygon[i].size() >= 3 && PointInRing(polygon[i], x, y))
+      return false;
+  }
+
+  return true;
+}
+
+bool
+FindBandAtPoint(const ForecastLayer &layer, GeoPoint p,
+                double &out_min_ms, double &out_max_ms) noexcept
+{
+  if (layer.IsEmpty())
+    return false;
+
+  const double x = p.longitude.Degrees();
+  const double y = p.latitude.Degrees();
+
+  bool found = false;
+  double best_abs_mid = -1.0;
+
+  for (const auto &band : layer.bands) {
+    const double mid = (band.min_ms + band.max_ms) / 2.0;
+    const double abs_mid = std::abs(mid);
+    /* Skip bands that can't beat the current best — cheap early-out
+       before the expensive polygon scan. */
+    if (found && abs_mid <= best_abs_mid)
+      continue;
+
+    for (const auto &polygon : band.polygons) {
+      if (PointInPolygon(polygon, x, y)) {
+        out_min_ms = band.min_ms;
+        out_max_ms = band.max_ms;
+        best_abs_mid = abs_mid;
+        found = true;
+        break;  /* this band matched; move to next band */
+      }
+    }
+  }
+
+  return found;
+}
+
+} // namespace XCThermGeoJSON

--- a/src/Weather/xctherm/XCThermMapOverlay.cpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.cpp
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermMapOverlay.hpp"
+#include "XCThermAPI.hpp"
+#include "XCThermCatalog.hpp"
+#include "XCThermForecastTime.hpp"
+#include "XCThermDownloadGlue.hpp"
+#include "XCThermDownloadJob.hpp"
+#include "XCThermGeoJSONOverlay.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "LogFile.hpp"
+#include "MapWindow/GlueMapWindow.hpp"
+#include "UIGlobals.hpp"
+#include "Weather/Settings.hpp"
+#include "net/http/Init.hpp"
+
+#include <mutex>
+
+namespace XCTherm {
+
+namespace {
+
+std::string auto_fetch_attempted_param;
+
+#ifdef ENABLE_OPENGL
+
+/** Parsed forecast kept after ClearMapOverlay() for fast page return. */
+struct ParsedLayerCache {
+  std::string parameter;
+  std::string label;
+  unsigned utc_hour = 0;
+  XCThermGeoJSON::ForecastLayer forecast;
+
+  bool Matches(const char *parameter, unsigned utc_hour) const noexcept
+  {
+    return !forecast.IsEmpty() && parameter != nullptr &&
+           this->parameter == parameter && this->utc_hour == utc_hour;
+  }
+
+  void Store(XCThermGeoJSON::ForecastLayer &&layer, std::string label,
+             std::string parameter, unsigned utc_hour) noexcept
+  {
+    forecast = std::move(layer);
+    this->label = std::move(label);
+    this->parameter = std::move(parameter);
+    this->utc_hour = utc_hour;
+  }
+
+  void Clear() noexcept
+  {
+    parameter.clear();
+    label.clear();
+    utc_hour = 0;
+    forecast = {};
+  }
+
+  bool TakeIfMatches(const char *parameter, unsigned utc_hour,
+                     XCThermGeoJSON::ForecastLayer &out_forecast) noexcept
+  {
+    if (!Matches(parameter, utc_hour))
+      return false;
+
+    out_forecast = std::move(forecast);
+    Clear();
+    return true;
+  }
+};
+
+static ParsedLayerCache parsed_layer_cache;
+
+#endif /* ENABLE_OPENGL */
+
+static bool
+MapShowsXCThermForecast(const char *parameter, unsigned utc_hour) noexcept
+{
+#ifdef ENABLE_OPENGL
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return false;
+
+  const auto *overlay =
+    dynamic_cast<const XCThermGeoJSONOverlay *>(map->GetOverlay());
+  if (overlay == nullptr)
+    return false;
+
+  return overlay->MatchesForecast(parameter, utc_hour);
+#else
+  (void)parameter;
+  (void)utc_hour;
+  return false;
+#endif
+}
+
+} // namespace
+
+bool
+MapShowsForecast(const char *parameter, unsigned utc_hour) noexcept
+{
+  return MapShowsXCThermForecast(parameter, utc_hour);
+}
+
+bool
+HasActiveMapOverlay() noexcept
+{
+#ifdef ENABLE_OPENGL
+  const auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return false;
+
+  return dynamic_cast<const XCThermGeoJSONOverlay *>(map->GetOverlay()) !=
+    nullptr;
+#else
+  return false;
+#endif
+}
+
+void
+ApplyForecastToMap(const std::string &geojson, const char *label,
+                   const char *parameter, const unsigned forecast_utc) noexcept
+{
+  if (parameter != nullptr &&
+      MapShowsXCThermForecast(parameter, forecast_utc))
+    return;
+
+#ifdef ENABLE_OPENGL
+  if (parameter != nullptr) {
+    XCThermGeoJSON::ForecastLayer cached_forecast;
+    if (parsed_layer_cache.TakeIfMatches(parameter, forecast_utc,
+                                         cached_forecast)) {
+      ApplyForecastLayerToMap(std::move(cached_forecast), label,
+                              parameter, forecast_utc);
+      return;
+    }
+  }
+#endif
+
+  auto forecast = XCThermGeoJSON::Parse(geojson, true);
+  if (forecast.IsEmpty()) {
+    LogFmt("xctherm: parse failed for {}", label);
+    return;
+  }
+
+  forecast.layer_name = label;
+  ApplyForecastLayerToMap(std::move(forecast), label, parameter, forecast_utc);
+}
+
+void
+ApplyForecastLayerToMap(XCThermGeoJSON::ForecastLayer &&forecast,
+                        const char *label, const char *parameter,
+                        const unsigned forecast_utc) noexcept
+{
+  if (forecast.IsEmpty())
+    return;
+
+  if (parameter != nullptr &&
+      MapShowsXCThermForecast(parameter, forecast_utc))
+    return;
+
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return;
+
+#ifdef ENABLE_OPENGL
+  auto overlay = std::make_unique<XCThermGeoJSONOverlay>();
+  overlay->SetForecast(std::move(forecast), label, parameter, forecast_utc);
+  map->SetOverlay(std::move(overlay));
+#else
+  (void)label;
+  (void)parameter;
+  (void)forecast_utc;
+#endif
+}
+
+void
+ClearMapOverlay() noexcept
+{
+#ifdef ENABLE_OPENGL
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return;
+
+  const auto *overlay =
+    dynamic_cast<const XCThermGeoJSONOverlay *>(map->GetOverlay());
+  if (overlay == nullptr)
+    return;
+
+  std::string label, parameter;
+  unsigned utc_hour = 0;
+  auto forecast = const_cast<XCThermGeoJSONOverlay *>(overlay)
+    ->TakeForecast(label, parameter, utc_hour);
+  if (!forecast.IsEmpty())
+    parsed_layer_cache.Store(std::move(forecast), std::move(label),
+                               std::move(parameter), utc_hour);
+
+  map->SetOverlay(nullptr);
+#endif
+}
+
+void
+ClearParsedLayerCache(const std::string *parameter) noexcept
+{
+#ifdef ENABLE_OPENGL
+  if (parameter == nullptr || parsed_layer_cache.parameter == *parameter)
+    parsed_layer_cache.Clear();
+#else
+  (void)parameter;
+#endif
+}
+
+void
+ApplyCursorOverlayFromSession() noexcept
+{
+  const auto &weather = CommonInterface::GetUIState().weather;
+  const auto &session = weather.xctherm;
+  const auto &cursor = weather.xctherm_cursor;
+  if (!session.cursor_initialized) {
+    RestoreActiveLayerOverlay();
+    return;
+  }
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = GetRegion(settings.model);
+  if (cursor.layer >= region.layer_count)
+    return;
+
+  const auto &layer = region.layers[cursor.layer];
+  if (!XCThermAPI::Instance().IsLayerCached(layer.api_parameter,
+                                             cursor.forecast_utc_hour)) {
+    ClearMapOverlay();
+    return;
+  }
+
+  ApplyCachedLayerOverlay(cursor.layer, cursor.forecast_utc_hour);
+}
+
+bool
+EnterDedicatedPage() noexcept
+{
+  return CommonInterface::SetUIState().weather.xctherm.EnterPage();
+}
+
+void
+LeaveDedicatedPage() noexcept
+{
+  CommonInterface::SetUIState().weather.xctherm.LeavePage();
+}
+
+void
+SuspendDedicatedPageForPan() noexcept
+{
+  CommonInterface::SetUIState().weather.xctherm.SuspendForPan();
+}
+
+void
+ResumeDedicatedPageAfterPan() noexcept
+{
+  CommonInterface::SetUIState().weather.xctherm.ResumeAfterPan();
+}
+
+bool
+IsDedicatedPageSuspendedForPan() noexcept
+{
+  return CommonInterface::GetUIState().weather.xctherm.IsSuspendedForPan();
+}
+
+StaticString<64>
+GetPanOverlayLabel() noexcept
+{
+  StaticString<64> label;
+#ifdef ENABLE_OPENGL
+  const auto *map = UIGlobals::GetMap();
+  if (map != nullptr) {
+    const auto *xctherm =
+      dynamic_cast<const XCThermGeoJSONOverlay *>(map->GetOverlay());
+    if (xctherm != nullptr) {
+      const char *layer = xctherm->GetLabel();
+      if (layer != nullptr && *layer != '\0') {
+        label.Format(_("XCTherm %s"), layer);
+        return label;
+      }
+    }
+  }
+#endif
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const int li = FindActiveLayerIndex(settings);
+  if (li >= 0) {
+    label.Format(_("XCTherm %s"),
+                 gettext(GetRegion(settings.model)
+                           .layers[unsigned(li)].short_label));
+  } else
+    label = _("XCTherm");
+
+  return label;
+}
+
+bool
+ApplyCachedLayerOverlay(unsigned layer_index, unsigned utc_hour) noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = GetRegion(settings.model);
+  if (layer_index >= region.layer_count)
+    return false;
+
+  auto &api = XCThermAPI::Instance();
+  const auto &layer = region.layers[layer_index];
+  if (MapShowsXCThermForecast(layer.api_parameter, utc_hour))
+    return true;
+
+#ifdef ENABLE_OPENGL
+  XCThermGeoJSON::ForecastLayer cached_forecast;
+  if (parsed_layer_cache.TakeIfMatches(layer.api_parameter, utc_hour,
+                                       cached_forecast)) {
+    ApplyForecastLayerToMap(std::move(cached_forecast),
+                            gettext(layer.short_label),
+                            layer.api_parameter, utc_hour);
+    return true;
+  }
+#endif
+
+  const std::string &cached =
+    api.GetCachedGeoJSON(layer.api_parameter, utc_hour);
+  if (cached.empty()) {
+    LogFmt("xctherm: cache miss {}@{}h", layer.api_parameter, utc_hour);
+    return false;
+  }
+
+  ApplyForecastToMap(cached, gettext(layer.short_label),
+                       layer.api_parameter, utc_hour);
+  return true;
+}
+
+bool
+ApplyCachedLayerOverlayAuto(unsigned layer_index) noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = GetRegion(settings.model);
+  if (layer_index >= region.layer_count)
+    return false;
+
+  const auto &layer = region.layers[layer_index];
+  const auto hours =
+    XCThermAPI::Instance().GetCachedHours(layer.api_parameter);
+  if (hours.empty())
+    return false;
+
+  const auto utc = GetUtcTimeParts();
+  const int idx = PickAutoTimeIndex(hours, utc.hour, utc.minute);
+  const unsigned hour = idx >= 0 ? hours[unsigned(idx)] : hours[0];
+  return ApplyCachedLayerOverlay(layer_index, hour);
+}
+
+void
+RestoreActiveLayerOverlay() noexcept
+{
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const int layer_index = ResolveDisplayLayerIndex(settings);
+  if (layer_index < 0)
+    return;
+
+  if (!ApplyCachedLayerOverlayAuto(unsigned(layer_index)))
+    ClearMapOverlay();
+}
+
+void
+ApplyJobPreviewToMap(const std::shared_ptr<XCThermDownloadJob> &job) noexcept
+{
+  if (job == nullptr || job->cancel.load() ||
+      job->error_eptr || job->succeeded_or_cached.load() == 0)
+    return;
+
+  std::lock_guard lock{job->result_mutex};
+  if (!job->first_forecast.IsEmpty()) {
+    const unsigned shown_utc = job->has_first_forecast_utc
+      ? job->first_forecast_utc
+      : (job->current_utc + 23) % 24;
+    ApplyForecastLayerToMap(std::move(job->first_forecast),
+                            gettext(job->target_label.c_str()),
+                            job->param.c_str(), shown_utc);
+  } else {
+    RestoreActiveLayerOverlay();
+  }
+}
+
+std::shared_ptr<XCThermDownloadJob>
+StartSpanDownload(
+  const XCThermSettings &settings, unsigned layer_index,
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished)
+{
+  if (settings.download_span_hours == 0 || !settings.credentials.IsDefined())
+    return nullptr;
+
+  auto *glue = GetXCThermDownloadGlue();
+  if (glue == nullptr || Net::curl == nullptr || glue->IsRunning())
+    return nullptr;
+
+  auto job = MakeXCThermSpanJob(settings, layer_index, GetUtcTimeParts().hour);
+  if (job == nullptr)
+    return nullptr;
+
+  auto shared = job;
+  glue->Start(std::move(job), std::move(on_finished));
+  return shared;
+}
+
+void
+RequestBackgroundIndexFetch(std::function<void()> on_ready)
+{
+  auto *glue = GetXCThermDownloadGlue();
+  if (glue == nullptr)
+    return;
+
+  if (XCThermAPI::Instance().IsIndexLoaded()) {
+    if (on_ready)
+      on_ready();
+    return;
+  }
+
+  glue->StartIndexFetch(std::move(on_ready));
+}
+
+void
+MaybeFetchActiveLayerSpan(
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished)
+{
+  if (!XCThermAPI::Instance().IsIndexLoaded())
+    return;
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const int active = FindActiveLayerIndex(settings);
+  if (active < 0)
+    return;
+
+  const auto &region = GetRegion(settings.model);
+  const std::string &param = region.layers[unsigned(active)].api_parameter;
+  if (!XCThermAPI::Instance().GetCachedHours(param).empty())
+    return;
+
+  if (auto_fetch_attempted_param == param)
+    return;
+
+  auto_fetch_attempted_param = param;
+  LogFmt("xctherm: auto-fetching active layer {}", param);
+
+  if (!StartSpanDownload(settings, unsigned(active),
+                         [finished = std::move(on_finished)](
+                           std::shared_ptr<XCThermDownloadJob> done) mutable {
+                           ApplyJobPreviewToMap(done);
+                           if (finished)
+                             finished(std::move(done));
+                         }))
+    auto_fetch_attempted_param.clear();
+}
+
+void
+ResetAutoFetchAttempt() noexcept
+{
+  auto_fetch_attempted_param.clear();
+}
+
+void
+ActivatePageOverlay() noexcept
+{
+  auto &weather = CommonInterface::SetUIState().weather;
+  auto &session = weather.xctherm;
+  auto &cursor = weather.xctherm_cursor;
+  if (cursor.altitude_manual_override || cursor.time_manual_override)
+    session.cursor_initialized = true;
+
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+
+  XCThermAPI::Instance().PrepareSession(settings);
+  ApplyCursorOverlayFromSession();
+
+  RequestBackgroundIndexFetch([]{
+    MaybeFetchActiveLayerSpan(nullptr);
+  });
+}
+
+} // namespace XCTherm

--- a/src/Weather/xctherm/XCThermMapOverlay.cpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.cpp
@@ -293,7 +293,7 @@ GetPanOverlayLabel() noexcept
                  gettext(GetRegion(settings.model)
                            .layers[unsigned(li)].short_label));
   } else
-    label = _("XCTherm");
+    label = "XCTherm";
 
   return label;
 }

--- a/src/Weather/xctherm/XCThermMapOverlay.cpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.cpp
@@ -378,6 +378,8 @@ ApplyJobPreviewToMap(const std::shared_ptr<XCThermDownloadJob> &job) noexcept
 
   std::lock_guard lock{job->result_mutex};
   if (!job->first_forecast.IsEmpty()) {
+    /* The span starts at the previous UTC hour; when the job has not
+       reported the first slot's UTC yet, fall back to current_utc-1. */
     const unsigned shown_utc = job->has_first_forecast_utc
       ? job->first_forecast_utc
       : (job->current_utc + 23) % 24;
@@ -396,6 +398,11 @@ StartSpanDownload(
 {
   if (settings.download_span_hours == 0 || !settings.credentials.IsDefined())
     return nullptr;
+
+  if (!XCThermAPI::Instance().EnsureAuthenticated()) {
+    LogFmt("xctherm: cannot start download — auth failed");
+    return nullptr;
+  }
 
   auto *glue = GetXCThermDownloadGlue();
   if (glue == nullptr || Net::curl == nullptr || glue->IsRunning())

--- a/src/Weather/xctherm/XCThermMapOverlay.hpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.hpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Weather/xctherm/XCThermGeoJSON.hpp"
+#include "util/StaticString.hxx"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+struct XCThermDownloadJob;
+struct XCThermSettings;
+
+namespace XCTherm {
+
+/**
+ * Parse @p geojson and install it as the main map XCTherm overlay.
+ *
+ * @param label user-visible layer name (e.g. @c "5000m AMSL")
+ * @param parameter API parameter for map-item metadata (optional)
+ * @param forecast_utc valid UTC hour for cache lookup (optional)
+ */
+void ApplyForecastToMap(const std::string &geojson, const char *label,
+                        const char *parameter = nullptr,
+                        unsigned forecast_utc = 0) noexcept;
+
+/**
+ * Install an already-parsed forecast as the main map overlay.
+ */
+void ApplyForecastLayerToMap(XCThermGeoJSON::ForecastLayer &&forecast,
+                             const char *label,
+                             const char *parameter = nullptr,
+                             unsigned forecast_utc = 0) noexcept;
+
+void ClearMapOverlay() noexcept;
+
+/**
+ * Drop parsed forecast data kept in RAM after the map overlay was
+ * cleared. When @p parameter is non-null, only entries for that
+ * parameter are removed.
+ */
+void ClearParsedLayerCache(const std::string *parameter = nullptr) noexcept;
+
+/** True when the main map overlay already shows @p parameter at @p utc_hour. */
+bool MapShowsForecast(const char *parameter, unsigned utc_hour) noexcept;
+
+/** True when the main map shows an XCTherm forecast overlay. */
+bool HasActiveMapOverlay() noexcept;
+
+/** Apply overlay for cursor-bar layer/time from UI session state. */
+void ApplyCursorOverlayFromSession() noexcept;
+
+/**
+ * Dedicated XCTherm page lifecycle (mirrors EDL pan suspension).
+ */
+bool EnterDedicatedPage() noexcept;
+void LeaveDedicatedPage() noexcept;
+void SuspendDedicatedPageForPan() noexcept;
+void ResumeDedicatedPageAfterPan() noexcept;
+bool IsDedicatedPageSuspendedForPan() noexcept;
+
+/**
+ * Compact label for the active forecast overlay (map-scale PAN string).
+ */
+StaticString<64> GetPanOverlayLabel() noexcept;
+
+/**
+ * Apply a cached slice to the map.
+ * @return false when nothing is cached for @p layer_index at @p utc_hour.
+ */
+bool ApplyCachedLayerOverlay(unsigned layer_index,
+                             unsigned utc_hour) noexcept;
+
+/**
+ * Apply the best cached hour for @p layer_index (auto-time :45 rule).
+ */
+bool ApplyCachedLayerOverlayAuto(unsigned layer_index) noexcept;
+
+/**
+ * Apply the activated (or first cached) layer from cache to the map.
+ */
+void RestoreActiveLayerOverlay() noexcept;
+
+/**
+ * Install the first parseable slice from a finished download job.
+ */
+void ApplyJobPreviewToMap(const std::shared_ptr<XCThermDownloadJob> &job) noexcept;
+
+/**
+ * Start a span download on the network glue.
+ * @return nullptr when prerequisites are missing or glue is busy.
+ */
+std::shared_ptr<XCThermDownloadJob>
+StartSpanDownload(
+  const XCThermSettings &settings, unsigned layer_index,
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished);
+
+/**
+ * Fetch index.json on the network thread when needed.
+ */
+void RequestBackgroundIndexFetch(std::function<void()> on_ready = nullptr);
+
+/**
+ * Start a span download for the activated layer when it has no cache.
+ */
+void MaybeFetchActiveLayerSpan(
+  std::function<void(std::shared_ptr<XCThermDownloadJob>)> on_finished =
+    nullptr);
+
+/**
+ * Restore overlay from cache and ensure index / active-layer data.
+ */
+void ActivatePageOverlay() noexcept;
+
+/** Allow a new auto-fetch after the activated layer changed. */
+void ResetAutoFetchAttempt() noexcept;
+
+} // namespace XCTherm

--- a/src/Widget/PagerWidget.hpp
+++ b/src/Widget/PagerWidget.hpp
@@ -37,7 +37,7 @@ class PagerWidget : public Widget {
   PixelRect position;
 
   unsigned current;
-  boost::container::static_vector<Child, 32u> children;
+  boost::container::static_vector<Child, 48u> children;
 
   PageFlippedCallback page_flipped_callback;
 

--- a/src/co/Sleep.hxx
+++ b/src/co/Sleep.hxx
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Compat.hxx"
+#include "event/CoarseTimerEvent.hxx"
+#include "event/Chrono.hxx"
+#include "util/BindMethod.hxx"
+
+#include <coroutine>
+
+class EventLoop;
+
+namespace Co {
+
+/**
+ * Suspend the current coroutine until @p delay has elapsed on
+ * @p loop.  Must run on the thread that owns @p loop.
+ */
+class SleepAwaitable final {
+  const Event::Duration delay;
+  std::coroutine_handle<> continuation{nullptr};
+  CoarseTimerEvent timer;
+
+  void OnExpired() noexcept {
+    timer.Cancel();
+    if (continuation)
+      continuation.resume();
+  }
+
+public:
+  SleepAwaitable(EventLoop &loop, Event::Duration delay) noexcept
+    :delay(delay),
+     timer(loop, BIND_THIS_METHOD(OnExpired)) {}
+
+  ~SleepAwaitable() noexcept {
+    timer.Cancel();
+  }
+
+  bool await_ready() const noexcept {
+    return delay <= Event::Duration::zero();
+  }
+
+  void await_suspend(std::coroutine_handle<> h) noexcept {
+    continuation = h;
+    timer.Schedule(delay);
+  }
+
+  void await_resume() noexcept {}
+};
+
+inline SleepAwaitable
+Sleep(EventLoop &loop, Event::Duration delay) noexcept
+{
+  return SleepAwaitable{loop, delay};
+}
+
+} // namespace Co

--- a/src/net/client/SyncHttp.cpp
+++ b/src/net/client/SyncHttp.cpp
@@ -81,7 +81,7 @@ HeaderCallback(char *buffer, size_t size, size_t nitems,
 
 bool
 Perform(CurlEasy &easy, StringOutputStream &body, SyncHttpResponse &response,
-        HeaderCapture *headers, SyncHttpProgressFn progress) noexcept
+        HeaderCapture *headers, SyncHttpProgressFn progress)
 {
   response = {};
 

--- a/src/net/client/SyncHttp.cpp
+++ b/src/net/client/SyncHttp.cpp
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SyncHttp.hpp"
+
+#include "Operation/ProgressListener.hpp"
+#include "io/StringOutputStream.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
+
+#include <climits>
+#include <curl/curl.h>
+#include <span>
+
+namespace Net::Client {
+
+namespace {
+
+size_t
+WriteToStream(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept
+{
+  auto *os = static_cast<StringOutputStream *>(userdata);
+  const size_t total = size * nmemb;
+  try {
+    os->Write(std::span{
+      reinterpret_cast<const std::byte *>(ptr), total});
+    return total;
+  } catch (...) {
+    return 0;
+  }
+}
+
+struct ProgressCtx {
+  const SyncHttpProgressFn *progress = nullptr;
+};
+
+int
+XferInfoCallback(void *userp,
+                 curl_off_t dltotal, curl_off_t dlnow,
+                 [[maybe_unused]] curl_off_t ultotal,
+                 [[maybe_unused]] curl_off_t ulnow) noexcept
+{
+  auto *ctx = static_cast<ProgressCtx *>(userp);
+  if (ctx == nullptr || ctx->progress == nullptr || !*ctx->progress)
+    return 0;
+
+  return (*ctx->progress)((uint64_t)dlnow, (uint64_t)dltotal) ? 0 : 1;
+}
+
+struct HeaderCapture {
+  const char *cookie_name = nullptr;
+  std::string set_cookie_value;
+};
+
+size_t
+HeaderCallback(char *buffer, size_t size, size_t nitems,
+               void *userdata) noexcept
+{
+  auto *capture = static_cast<HeaderCapture *>(userdata);
+  const size_t total = size * nitems;
+  if (capture == nullptr || capture->cookie_name == nullptr)
+    return total;
+
+  try {
+    std::string line(buffer, total);
+    if (line.size() <= 12)
+      return total;
+
+    if (line.substr(0, 11) != "Set-Cookie:" &&
+        line.substr(0, 11) != "set-cookie:")
+      return total;
+
+    if (line.find(capture->cookie_name) == std::string::npos)
+      return total;
+
+    capture->set_cookie_value = line.substr(12);
+  } catch (...) {
+  }
+  return total;
+}
+
+bool
+Perform(CurlEasy &easy, StringOutputStream &body, SyncHttpResponse &response,
+        HeaderCapture *headers, SyncHttpProgressFn progress) noexcept
+{
+  response = {};
+
+  easy.SetWriteFunction(WriteToStream, &body);
+  if (headers != nullptr)
+    easy.SetHeaderFunction(HeaderCallback, headers);
+
+  ProgressCtx progress_ctx;
+  if (progress) {
+    progress_ctx.progress = &progress;
+    easy.SetXferInfoFunction(XferInfoCallback, &progress_ctx);
+  } else {
+    easy.SetNoProgress();
+  }
+
+  try {
+    easy.Perform();
+  } catch (...) {
+    return false;
+  }
+
+  easy.GetInfo(CURLINFO_RESPONSE_CODE, &response.http_code);
+  curl_off_t size_download = 0;
+  curl_off_t speed_download = 0;
+  easy.GetInfo(CURLINFO_SIZE_DOWNLOAD_T, &size_download);
+  easy.GetInfo(CURLINFO_SPEED_DOWNLOAD_T, &speed_download);
+  response.size_download = (int64_t)size_download;
+  response.speed_download = (int64_t)speed_download;
+  response.body = body.GetValue();
+
+  if (headers != nullptr)
+    response.captured_set_cookie =
+      std::move(headers->set_cookie_value);
+
+  return true;
+}
+
+} // anonymous namespace
+
+bool
+SyncHttpGet(const char *url, curl_slist *headers, bool accept_gzip,
+            SyncHttpResponse &response, const char *capture_set_cookie_name,
+            SyncHttpProgressFn progress) noexcept
+{
+  try {
+    CurlEasy easy{url};
+    Curl::Setup(easy);
+    easy.SetRequestHeaders(headers);
+    easy.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+    easy.SetTimeout(60);
+
+    if (accept_gzip)
+      easy.SetOption(CURLOPT_ACCEPT_ENCODING, "gzip");
+
+    HeaderCapture header_capture;
+    HeaderCapture *capture = nullptr;
+    if (capture_set_cookie_name != nullptr) {
+      header_capture.cookie_name = capture_set_cookie_name;
+      capture = &header_capture;
+    }
+
+    StringOutputStream body;
+    if (!Perform(easy, body, response, capture, std::move(progress)))
+      return false;
+
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool
+SyncHttpPost(const char *url, curl_slist *headers, std::string_view body,
+             SyncHttpResponse &response, const char *capture_set_cookie_name,
+             const char *cookie) noexcept
+{
+  try {
+    CurlEasy easy{url};
+    Curl::Setup(easy);
+    easy.SetRequestHeaders(headers);
+    easy.SetPost();
+    easy.SetRequestBody(body);
+    easy.SetTimeout(30);
+
+    if (cookie != nullptr)
+      easy.SetOption(CURLOPT_COOKIE, cookie);
+
+    HeaderCapture header_capture;
+    HeaderCapture *capture = nullptr;
+    if (capture_set_cookie_name != nullptr) {
+      header_capture.cookie_name = capture_set_cookie_name;
+      capture = &header_capture;
+    }
+
+    StringOutputStream response_body;
+    return Perform(easy, response_body, response, capture, nullptr);
+  } catch (...) {
+    return false;
+  }
+}
+
+SyncHttpProgressFn
+MakeSyncHttpProgress(ProgressListener *listener,
+                     const std::function<bool()> &should_continue) noexcept
+{
+  return [listener, should_continue](uint64_t bytes_now,
+                                    uint64_t bytes_total) -> bool {
+    if (!should_continue())
+      return false;
+
+    if (listener == nullptr)
+      return true;
+
+    if (bytes_total == 0)
+      bytes_now = 0;
+
+    if (bytes_total == 0 || bytes_total > UINT_MAX)
+      return true;
+
+    listener->SetProgressRange((unsigned)bytes_total);
+    listener->SetProgressPosition((unsigned)bytes_now);
+    return true;
+  };
+}
+
+} // namespace Net::Client

--- a/src/net/client/SyncHttp.hpp
+++ b/src/net/client/SyncHttp.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <string_view>
+
+struct curl_slist;
+
+class ProgressListener;
+
+namespace Net::Client {
+
+struct SyncHttpResponse {
+  std::string body;
+  long http_code = 0;
+  int64_t size_download = 0;
+  int64_t speed_download = 0;
+
+  /** Value part of a captured Set-Cookie line (without header prefix). */
+  std::string captured_set_cookie;
+};
+
+using SyncHttpProgressFn = std::function<bool(uint64_t bytes_now,
+                                              uint64_t bytes_total)>;
+
+/**
+ * Synchronous HTTP GET/POST via CurlEasy (blocking; not for the asio thread).
+ */
+bool
+SyncHttpGet(const char *url, curl_slist *headers, bool accept_gzip,
+            SyncHttpResponse &response,
+            const char *capture_set_cookie_name = nullptr,
+            SyncHttpProgressFn progress = nullptr) noexcept;
+
+bool
+SyncHttpPost(const char *url, curl_slist *headers, std::string_view body,
+             SyncHttpResponse &response,
+             const char *capture_set_cookie_name = nullptr,
+             const char *cookie = nullptr) noexcept;
+
+/**
+ * Bridge #ProgressListener to #SyncHttpProgressFn. @p should_continue
+ * is polled on each progress tick; returning false aborts the transfer.
+ */
+[[nodiscard]]
+SyncHttpProgressFn
+MakeSyncHttpProgress(ProgressListener *listener,
+                     const std::function<bool()> &should_continue) noexcept;
+
+} // namespace Net::Client

--- a/src/net/client/auth/JwtBearerSession.cpp
+++ b/src/net/client/auth/JwtBearerSession.cpp
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "JwtBearerSession.hpp"
+#include "net/client/SyncHttp.hpp"
+#include "LogFile.hpp"
+#include "io/StringOutputStream.hxx"
+#include "json/Serialize.hxx"
+#include "lib/curl/Slist.hxx"
+
+#include <cstring>
+#include <ctime>
+#include <exception>
+
+#include <boost/json.hpp>
+
+namespace Net::Client::Auth {
+
+void
+JwtBearerSession::SetCredentials(const std::string &id,
+                                 const std::string &secret) noexcept
+{
+  if (login_id != id || login_secret != secret) {
+    login_id = id;
+    login_secret = secret;
+    access_token.clear();
+    refresh_token.clear();
+    access_token_expiry = 0;
+  }
+}
+
+bool
+JwtBearerSession::HasValidToken() const noexcept
+{
+  return !access_token.empty() &&
+         access_token_expiry > static_cast<uint32_t>(std::time(nullptr));
+}
+
+std::string
+JwtBearerSession::GetAuthHeader() const noexcept
+{
+  return std::string{"Authorization: Bearer "} + access_token;
+}
+
+bool
+JwtBearerSession::EnsureValidToken() noexcept
+{
+  if (HasValidToken())
+    return true;
+
+  if (!refresh_token.empty()) {
+    if (RefreshAccessToken())
+      return true;
+    LogFmt("{}: refresh failed, falling back to full auth", config.log_tag);
+  }
+
+  return Authenticate();
+}
+
+bool
+JwtBearerSession::ForceReauthenticate() noexcept
+{
+  access_token.clear();
+  access_token_expiry = 0;
+  return Authenticate();
+}
+
+bool
+JwtBearerSession::Authenticate() noexcept
+{
+  try {
+    if (login_id.empty() || login_secret.empty()) {
+      LogFmt("{}: auth skipped — no credentials", config.log_tag);
+      return false;
+    }
+
+    LogFmt("{}: authenticating (user len={})", config.log_tag, login_id.size());
+
+    const boost::json::object body{
+      {config.login_id_json_field, login_id},
+      {config.login_secret_json_field, login_secret},
+    };
+    StringOutputStream post_stream;
+    Json::Serialize(post_stream, body);
+    const std::string post_data = post_stream.GetValue();
+
+    CurlSlist headers;
+    headers.Append("Content-Type: application/json");
+
+    SyncHttpResponse response;
+    if (!SyncHttpPost(config.login_url, headers.Get(), post_data, response,
+                      config.refresh_cookie_name) ||
+        response.http_code != 200) {
+      LogFmt("{}: auth failed http={}", config.log_tag, response.http_code);
+      return false;
+    }
+
+    if (!ParseAccessTokenFromResponse(config, response.body, access_token)) {
+      LogFmt("{}: no {} in auth response",
+             config.log_tag, config.access_token_json_field);
+      return false;
+    }
+
+    access_token_expiry = static_cast<uint32_t>(std::time(nullptr)) +
+      config.token_lifetime_seconds;
+
+    if (!response.captured_set_cookie.empty()) {
+      ParseRefreshTokenFromCookie(config, response.captured_set_cookie,
+                                refresh_token);
+      if (!refresh_token.empty())
+        LogFmt("{}: got {} (len={})", config.log_tag,
+               config.refresh_cookie_name, refresh_token.size());
+    }
+
+    LogFmt("{}: auth success, token_len={}", config.log_tag,
+           access_token.size());
+    return true;
+  } catch (const std::exception &e) {
+    LogFmt("{}: auth exception: {}", config.log_tag, e.what());
+    return false;
+  } catch (...) {
+    LogFmt("{}: auth unknown exception", config.log_tag);
+    return false;
+  }
+}
+
+bool
+JwtBearerSession::RefreshAccessToken() noexcept
+{
+  try {
+    if (refresh_token.empty())
+      return false;
+
+    LogFmt("{}: refreshing access token", config.log_tag);
+
+    std::string cookie = config.refresh_cookie_name;
+    cookie += '=';
+    cookie += refresh_token;
+
+    CurlSlist headers;
+    headers.Append("Content-Type: application/json");
+
+    SyncHttpResponse response;
+    if (!SyncHttpPost(config.refresh_url, headers.Get(), "", response,
+                      config.refresh_cookie_name, cookie.c_str()) ||
+        response.http_code != 200) {
+      LogFmt("{}: refresh failed http={}", config.log_tag, response.http_code);
+      refresh_token.clear();
+      return false;
+    }
+
+    if (!ParseAccessTokenFromResponse(config, response.body, access_token)) {
+      LogFmt("{}: no {} in refresh response",
+             config.log_tag, config.access_token_json_field);
+      return false;
+    }
+
+    access_token_expiry = static_cast<uint32_t>(std::time(nullptr)) +
+      config.token_lifetime_seconds;
+
+    if (!response.captured_set_cookie.empty()) {
+      std::string new_refresh;
+      if (ParseRefreshTokenFromCookie(config, response.captured_set_cookie,
+                                      new_refresh))
+        refresh_token = std::move(new_refresh);
+    }
+
+    LogFmt("{}: refresh success, token_len={}",
+           config.log_tag, access_token.size());
+    return true;
+  } catch (const std::exception &e) {
+    LogFmt("{}: refresh exception: {}", config.log_tag, e.what());
+    return false;
+  } catch (...) {
+    LogFmt("{}: refresh unknown exception", config.log_tag);
+    return false;
+  }
+}
+
+bool
+JwtBearerSession::ParseAccessTokenFromResponse(
+  const JwtBearerSessionConfig &config,
+  const std::string &response,
+  std::string &out_token) noexcept
+{
+  try {
+    const boost::json::value jv = boost::json::parse(response);
+    if (!jv.is_object())
+      return false;
+
+    const auto *token = jv.as_object().if_contains(config.access_token_json_field);
+    if (token == nullptr || !token->is_string())
+      return false;
+
+    out_token = std::string{token->as_string()};
+    return !out_token.empty();
+  } catch (const std::exception &) {
+    return false;
+  }
+}
+
+bool
+JwtBearerSession::ParseRefreshTokenFromCookie(
+  const JwtBearerSessionConfig &config,
+  const std::string &cookie_header,
+  std::string &out_token) noexcept
+{
+  std::string needle = config.refresh_cookie_name;
+  needle += '=';
+
+  size_t pos = cookie_header.find(needle);
+  if (pos == std::string::npos)
+    return false;
+
+  pos += needle.size();
+  size_t end = cookie_header.find(';', pos);
+  if (end == std::string::npos)
+    end = cookie_header.size();
+
+  while (end > pos && (cookie_header[end - 1] == ' ' ||
+                       cookie_header[end - 1] == '\r' ||
+                       cookie_header[end - 1] == '\n'))
+    --end;
+
+  out_token = cookie_header.substr(pos, end - pos);
+  return !out_token.empty();
+}
+
+} // namespace Net::Client::Auth

--- a/src/net/client/auth/JwtBearerSession.hpp
+++ b/src/net/client/auth/JwtBearerSession.hpp
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace Net::Client::Auth {
+
+/**
+ * Configuration for email/password login with JWT access token and
+ * optional refresh token delivered as an HTTP cookie.
+ */
+struct JwtBearerSessionConfig {
+  /** Prefix for LogFmt messages (e.g. "xctherm"). */
+  const char *log_tag;
+
+  const char *login_url;
+  const char *refresh_url;
+
+  /** JSON field name for the access token in login/refresh responses. */
+  const char *access_token_json_field;
+
+  /** JSON object keys for the login POST body. */
+  const char *login_id_json_field;
+  const char *login_secret_json_field;
+
+  /** Cookie name for the refresh token (without trailing '='). */
+  const char *refresh_cookie_name;
+
+  /** Conservative lifetime before EnsureValidToken() re-authenticates. */
+  uint32_t token_lifetime_seconds;
+};
+
+/**
+ * JWT bearer session: login, refresh via cookie, Bearer header for API calls.
+ */
+class JwtBearerSession {
+public:
+  explicit JwtBearerSession(const JwtBearerSessionConfig &config) noexcept
+    :config(config) {}
+
+  void SetCredentials(const std::string &id,
+                      const std::string &secret) noexcept;
+
+  bool EnsureValidToken() noexcept;
+  bool ForceReauthenticate() noexcept;
+
+  bool HasValidToken() const noexcept;
+
+  /** Returns "Authorization: Bearer <token>". */
+  std::string GetAuthHeader() const noexcept;
+
+private:
+  const JwtBearerSessionConfig &config;
+
+  std::string login_id;
+  std::string login_secret;
+
+  std::string access_token;
+  std::string refresh_token;
+  uint32_t access_token_expiry = 0;
+
+  bool Authenticate() noexcept;
+  bool RefreshAccessToken() noexcept;
+
+  static bool ParseAccessTokenFromResponse(const JwtBearerSessionConfig &config,
+                                           const std::string &response,
+                                           std::string &out_token) noexcept;
+
+  static bool ParseRefreshTokenFromCookie(const JwtBearerSessionConfig &config,
+                                          const std::string &cookie_header,
+                                          std::string &out_token) noexcept;
+};
+
+} // namespace Net::Client::Auth

--- a/src/net/client/xctherm/Auth.hpp
+++ b/src/net/client/xctherm/Auth.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "net/client/auth/JwtBearerSession.hpp"
+
+namespace XCTherm {
+
+inline constexpr Net::Client::Auth::JwtBearerSessionConfig kAuthConfig{
+  .log_tag = "xctherm",
+  .login_url = "https://xctherm.com/api/accounts/authenticate",
+  .refresh_url = "https://xctherm.com/api/accounts/refresh-token",
+  .access_token_json_field = "jwtToken",
+  .login_id_json_field = "email",
+  .login_secret_json_field = "password",
+  .refresh_cookie_name = "refreshToken",
+  .token_lifetime_seconds = 14 * 60,
+};
+
+using Auth = Net::Client::Auth::JwtBearerSession;
+
+} // namespace XCTherm

--- a/src/net/client/xctherm/Http.cpp
+++ b/src/net/client/xctherm/Http.cpp
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Http.hpp"
+#include "net/client/auth/JwtBearerSession.hpp"
+#include "net/http/Progress.hpp"
+#include "io/OutputStream.hxx"
+#include "io/StringOutputStream.hxx"
+#include "lib/curl/CoStreamRequest.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
+#include "lib/curl/Slist.hxx"
+#include "co/InjectTask.hxx"
+#include "co/Task.hxx"
+#include "lib/curl/Global.hxx"
+#include "util/BindMethod.hxx"
+
+#include <condition_variable>
+#include <exception>
+#include <mutex>
+
+namespace XCTherm::Http {
+
+namespace {
+
+class CancelCheckOutputStream final : public OutputStream {
+  OutputStream &destination;
+  const std::function<bool()> &should_continue;
+
+public:
+  CancelCheckOutputStream(OutputStream &_destination,
+                          const std::function<bool()> &_should_continue) noexcept
+    :destination(_destination),
+     should_continue(_should_continue) {}
+
+  void Write(std::span<const std::byte> data) override {
+    if (!should_continue())
+      throw TransferCancelled{};
+    destination.Write(data);
+  }
+};
+
+Co::Task<Curl::CoResponse>
+CoGetWithHeaders(CurlGlobal &curl, const char *url, curl_slist *headers,
+                 ProgressListener *progress,
+                 const std::function<bool()> &should_continue)
+{
+  CurlEasy easy{url};
+  Curl::Setup(easy);
+  easy.SetRequestHeaders(headers);
+  easy.SetOption(CURLOPT_ACCEPT_ENCODING, "gzip");
+  easy.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+  easy.SetTimeout(60);
+
+  StringOutputStream body;
+  CancelCheckOutputStream checked{body, should_continue};
+
+  std::optional<Net::ProgressAdapter> progress_adapter;
+  if (progress != nullptr)
+    progress_adapter.emplace(easy, *progress);
+
+  Curl::CoResponse response;
+  try {
+    response = co_await Curl::CoStreamRequest(curl, std::move(easy), checked);
+  } catch (const TransferCancelled &) {
+    throw;
+  }
+
+  /* CoStreamRequest writes to @p body, not CoResponse::body. */
+  response.body = std::move(body).GetValue();
+  co_return response;
+}
+
+} // anonymous namespace
+
+Co::Task<Curl::CoResponse>
+CoGet(CurlGlobal &curl, const char *url, ProgressListener *progress,
+      const std::function<bool()> &should_continue)
+{
+  co_return co_await CoGetWithHeaders(curl, url, nullptr, progress,
+                                      should_continue);
+}
+
+Co::Task<Curl::CoResponse>
+CoBearerGet(CurlGlobal &curl, const char *url,
+            Net::Client::Auth::JwtBearerSession &session,
+            ProgressListener *progress,
+            const std::function<bool()> &should_continue,
+            const bool retry_on_401)
+{
+  auto do_get = [&]() -> Co::Task<Curl::CoResponse> {
+    CurlSlist headers;
+    headers.Append(session.GetAuthHeader().c_str());
+    co_return co_await CoGetWithHeaders(curl, url, headers.Get(), progress,
+                                        should_continue);
+  };
+
+  auto response = co_await do_get();
+
+  if (response.status == 401 && retry_on_401 &&
+      session.ForceReauthenticate())
+    response = co_await do_get();
+
+  co_return response;
+}
+
+namespace {
+
+struct RunSyncCompletion {
+  std::mutex mutex;
+  std::condition_variable cv;
+  std::exception_ptr error;
+  bool done = false;
+
+  void OnDone(std::exception_ptr e) noexcept {
+    const std::lock_guard lock{mutex};
+    error = std::move(e);
+    done = true;
+    cv.notify_one();
+  }
+};
+
+} // namespace
+
+void
+RunSync(CurlGlobal &curl, Co::InvokeTask task)
+{
+  RunSyncCompletion completion;
+
+  Co::InjectTask inject{curl.GetEventLoop()};
+  inject.Start(std::move(task),
+                BIND_METHOD(completion, &RunSyncCompletion::OnDone));
+
+  std::unique_lock lock{completion.mutex};
+  completion.cv.wait(lock, [&]() { return completion.done; });
+
+  if (completion.error)
+    std::rethrow_exception(std::move(completion.error));
+}
+
+} // namespace XCTherm::Http

--- a/src/net/client/xctherm/Http.cpp
+++ b/src/net/client/xctherm/Http.cpp
@@ -59,12 +59,8 @@ CoGetWithHeaders(CurlGlobal &curl, const char *url, curl_slist *headers,
   if (progress != nullptr)
     progress_adapter.emplace(easy, *progress);
 
-  Curl::CoResponse response;
-  try {
-    response = co_await Curl::CoStreamRequest(curl, std::move(easy), checked);
-  } catch (const TransferCancelled &) {
-    throw;
-  }
+  Curl::CoResponse response =
+    co_await Curl::CoStreamRequest(curl, std::move(easy), checked);
 
   /* CoStreamRequest writes to @p body, not CoResponse::body. */
   response.body = std::move(body).GetValue();
@@ -125,6 +121,8 @@ struct RunSyncCompletion {
 void
 RunSync(CurlGlobal &curl, Co::InvokeTask task)
 {
+  /* Blocking helper: caller must not be the curl/asio event-loop thread,
+     otherwise completion cannot be delivered and this wait deadlocks. */
   RunSyncCompletion completion;
 
   Co::InjectTask inject{curl.GetEventLoop()};

--- a/src/net/client/xctherm/Http.hpp
+++ b/src/net/client/xctherm/Http.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/InvokeTask.hxx"
+#include "co/Task.hxx"
+#include "lib/curl/CoRequest.hxx"
+
+#include <functional>
+
+class CurlGlobal;
+class ProgressListener;
+
+namespace Net::Client::Auth {
+class JwtBearerSession;
+}
+
+namespace XCTherm::Http {
+
+/** Base URL for XCTherm forecast tiles and index. */
+inline constexpr const char *kForecastBaseUrl =
+  "https://tiles.xctherm.com/forecast";
+
+/** Thrown from the write path when @p should_continue returns false. */
+struct TransferCancelled {};
+
+/**
+ * GET with gzip, redirects, optional progress and cancel checks.
+ */
+Co::Task<Curl::CoResponse>
+CoGet(CurlGlobal &curl, const char *url,
+      ProgressListener *progress = nullptr,
+      const std::function<bool()> &should_continue = []() { return true; });
+
+/**
+ * GET with @c Authorization: Bearer from @p session. On HTTP 401, calls
+ * ForceReauthenticate() once and retries when @p retry_on_401 is true.
+ */
+Co::Task<Curl::CoResponse>
+CoBearerGet(CurlGlobal &curl, const char *url,
+            Net::Client::Auth::JwtBearerSession &session,
+            ProgressListener *progress,
+            const std::function<bool()> &should_continue,
+            bool retry_on_401 = true);
+
+/**
+ * Run a coroutine to completion on @p curl's event loop (blocks caller).
+ * For short UI-thread fetches only (e.g. index.json).
+ */
+void
+RunSync(CurlGlobal &curl, Co::InvokeTask task);
+
+} // namespace XCTherm::Http

--- a/test/src/TestWeatherOverlayPagePlacement.cpp
+++ b/test/src/TestWeatherOverlayPagePlacement.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/MapOverlay/PagePlacement.hpp"
+#include "TestUtil.hpp"
+
+using namespace WeatherMapOverlay;
+
+static void
+TestApplyToCurrentPage()
+{
+  PageSettings settings;
+  settings.SetDefaults();
+
+  ok1(ApplyWeatherOverlayToPage(settings, 0, PageLayout::Overlay::RASP, 3));
+
+  const auto &page = settings.pages[0];
+  ok1(page.overlay == PageLayout::Overlay::RASP);
+  ok1(page.bottom == PageLayout::Bottom::WEATHER_CONTROLS);
+  ok1(page.main == PageLayout::Main::MAP);
+  ok1(page.rasp_field == 3);
+}
+
+static void
+TestAddNewOverlayPageFromNonMapSource()
+{
+  PageSettings settings;
+  settings.SetDefaults();
+  settings.pages[0].main = PageLayout::Main::FLARM_RADAR;
+  settings.pages[0].overlay = PageLayout::Overlay::NONE;
+  settings.pages[0].bottom = PageLayout::Bottom::NOTHING;
+  settings.pages[0].Normalise();
+
+  unsigned new_page_index = 0;
+  const auto result = AddWeatherOverlayPage(settings, 0,
+                                            PageLayout::Overlay::XCTHERM,
+                                            new_page_index);
+  ok1(result == AddPageResult::SUCCESS);
+  ok1(new_page_index == 2);
+  ok1(settings.n_pages == 3);
+
+  const auto &page = settings.pages[new_page_index];
+  ok1(page.main == PageLayout::Main::MAP);
+  ok1(page.overlay == PageLayout::Overlay::XCTHERM);
+  ok1(page.bottom == PageLayout::Bottom::WEATHER_CONTROLS);
+}
+
+static void
+TestReplaceCurrentOverlay()
+{
+  PageSettings settings;
+  settings.SetDefaults();
+  settings.pages[0].overlay = PageLayout::Overlay::EDL;
+  settings.pages[0].bottom = PageLayout::Bottom::WEATHER_CONTROLS;
+  settings.pages[0].Normalise();
+
+  ok1(ApplyWeatherOverlayToPage(settings, 0, PageLayout::Overlay::RASP, 1));
+  ok1(settings.pages[0].overlay == PageLayout::Overlay::RASP);
+  ok1(settings.pages[0].rasp_field == 1);
+  ok1(settings.pages[0].bottom == PageLayout::Bottom::WEATHER_CONTROLS);
+}
+
+static void
+TestPageLimitGuard()
+{
+  PageSettings settings;
+  settings.SetDefaults();
+  settings.n_pages = PageSettings::MAX_PAGES;
+  for (unsigned i = 0; i < settings.n_pages; ++i)
+    settings.pages[i] = PageLayout::Default();
+
+  unsigned new_page_index = 0;
+  const auto result = AddWeatherOverlayPage(settings, 0,
+                                            PageLayout::Overlay::EDL,
+                                            new_page_index);
+  ok1(result == AddPageResult::PAGE_LIMIT_REACHED);
+}
+
+static void
+TestInvalidSourcePage()
+{
+  PageSettings settings;
+  settings.SetDefaults();
+
+  unsigned new_page_index = 0;
+  const auto result = AddWeatherOverlayPage(settings, settings.n_pages,
+                                            PageLayout::Overlay::EDL,
+                                            new_page_index);
+  ok1(result == AddPageResult::INVALID_SOURCE_PAGE);
+}
+
+int
+main()
+{
+  plan_tests(17);
+
+  TestApplyToCurrentPage();
+  TestAddNewOverlayPageFromNonMapSource();
+  TestReplaceCurrentOverlay();
+  TestPageLimitGuard();
+  TestInvalidSourcePage();
+
+  return exit_status();
+}

--- a/test/src/TestWeatherUIState.cpp
+++ b/test/src/TestWeatherUIState.cpp
@@ -57,13 +57,43 @@ TestWeatherUiStateRaspReset()
   ok1(!weather.time.IsPlausible());
 }
 
+static void
+TestWeatherUiStateXcthermCursor()
+{
+  WeatherUIState weather;
+  weather.Clear();
+
+  ok1(!weather.xctherm.cursor_initialized);
+  ok1(weather.xctherm_cursor.layer == 0);
+  ok1(weather.xctherm_cursor.forecast_utc_hour == 12);
+  ok1(!weather.xctherm_cursor.altitude_manual_override);
+  ok1(!weather.xctherm_cursor.time_manual_override);
+
+  weather.xctherm.EnterPage();
+  weather.xctherm.SuspendForPan();
+  weather.xctherm.cursor_initialized = true;
+  weather.xctherm_cursor.layer = 7;
+  weather.xctherm_cursor.forecast_utc_hour = 19;
+  weather.xctherm_cursor.altitude_manual_override = true;
+  weather.xctherm_cursor.time_manual_override = true;
+
+  weather.Clear();
+  ok1(!weather.xctherm.HasPageOwnership());
+  ok1(!weather.xctherm.cursor_initialized);
+  ok1(weather.xctherm_cursor.layer == 0);
+  ok1(weather.xctherm_cursor.forecast_utc_hour == 12);
+  ok1(!weather.xctherm_cursor.altitude_manual_override);
+  ok1(!weather.xctherm_cursor.time_manual_override);
+}
+
 int
 main()
 {
-  plan_tests(21);
+  plan_tests(32);
 
   TestOverlaySession();
   TestWeatherUiStateRaspReset();
+  TestWeatherUiStateXcthermCursor();
 
   return exit_status();
 }

--- a/test/src/TestXCThermBandQuery.cpp
+++ b/test/src/TestXCThermBandQuery.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/xctherm/XCThermGeoJSON.hpp"
+#include "TestUtil.hpp"
+
+using namespace XCThermGeoJSON;
+
+/* Build a square exterior-ring band [min,max] m/s covering the lon/lat
+   box [west,east] x [south,north]. */
+static WindBand
+MakeSquareBand(double min_ms, double max_ms,
+               double west, double south, double east, double north)
+{
+  Ring ring;
+  ring.push_back(GeoPoint(Angle::Degrees(west), Angle::Degrees(south)));
+  ring.push_back(GeoPoint(Angle::Degrees(east), Angle::Degrees(south)));
+  ring.push_back(GeoPoint(Angle::Degrees(east), Angle::Degrees(north)));
+  ring.push_back(GeoPoint(Angle::Degrees(west), Angle::Degrees(north)));
+  ring.push_back(GeoPoint(Angle::Degrees(west), Angle::Degrees(south)));
+
+  WindBand band;
+  band.min_ms = min_ms;
+  band.max_ms = max_ms;
+  band.polygons.push_back({std::move(ring)});  // one polygon, one ring
+  return band;
+}
+
+static GeoPoint
+P(double lon, double lat)
+{
+  return GeoPoint(Angle::Degrees(lon), Angle::Degrees(lat));
+}
+
+int main()
+{
+  plan_tests(14 + 4);
+
+  ForecastLayer layer;
+  /* Two disjoint bands side by side:
+       A: +0.5..+1.0 over lon[0,1] lat[0,1]
+       B: +2.0..+3.0 over lon[2,3] lat[0,1]                       */
+  layer.bands.push_back(MakeSquareBand(0.5, 1.0, 0, 0, 1, 1));
+  layer.bands.push_back(MakeSquareBand(2.0, 3.0, 2, 0, 3, 1));
+
+  double lo = -99, hi = -99;
+
+  /* --- Point inside band A --- */
+  /* This is the exact contract the [[gnu::pure]] bug broke: the
+     out-params MUST be written when the function returns true. */
+  ok1(FindBandAtPoint(layer, P(0.5, 0.5), lo, hi));
+  ok1(equals(lo, 0.5));
+  ok1(equals(hi, 1.0));
+
+  /* --- Point inside band B --- */
+  lo = hi = -99;
+  ok1(FindBandAtPoint(layer, P(2.5, 0.5), lo, hi));
+  ok1(equals(lo, 2.0));
+  ok1(equals(hi, 3.0));
+
+  /* --- Point in the gap between A and B: no match, out-params kept --- */
+  lo = hi = -99;
+  ok1(!FindBandAtPoint(layer, P(1.5, 0.5), lo, hi));
+  ok1(equals(lo, -99));
+  ok1(equals(hi, -99));
+
+  /* --- Point well outside everything --- */
+  ok1(!FindBandAtPoint(layer, P(50, 50), lo, hi));
+
+  /* --- Empty layer never matches --- */
+  ForecastLayer empty;
+  ok1(!FindBandAtPoint(empty, P(0.5, 0.5), lo, hi));
+
+  /* --- Nested bands: the most extreme (largest |midpoint|) wins --- */
+  ForecastLayer nested;
+  /* Big weak band over lon[0,4], strong band nested inside lon[1,2]. */
+  nested.bands.push_back(MakeSquareBand(0.2, 0.5, 0, 0, 4, 4));
+  nested.bands.push_back(MakeSquareBand(3.0, 4.0, 1, 1, 2, 2));
+  lo = hi = -99;
+  /* (1.5,1.5) is inside BOTH → expect the strong band. */
+  ok1(FindBandAtPoint(nested, P(1.5, 1.5), lo, hi));
+  ok1(equals(lo, 3.0));
+  ok1(equals(hi, 4.0));
+
+  /* --- Polygon with a hole: interior ring excludes the center --- */
+  ForecastLayer holed;
+  {
+    WindBand band = MakeSquareBand(1.0, 2.0, 0, 0, 4, 4);
+    Ring hole;
+    hole.push_back(GeoPoint(Angle::Degrees(1.5), Angle::Degrees(1.5)));
+    hole.push_back(GeoPoint(Angle::Degrees(2.5), Angle::Degrees(1.5)));
+    hole.push_back(GeoPoint(Angle::Degrees(2.5), Angle::Degrees(2.5)));
+    hole.push_back(GeoPoint(Angle::Degrees(1.5), Angle::Degrees(2.5)));
+    hole.push_back(GeoPoint(Angle::Degrees(1.5), Angle::Degrees(1.5)));
+    band.polygons[0].push_back(std::move(hole));
+    holed.bands.push_back(std::move(band));
+  }
+  lo = hi = -99;
+  ok1(!FindBandAtPoint(holed, P(2.0, 2.0), lo, hi));
+  ok1(FindBandAtPoint(holed, P(0.5, 0.5), lo, hi));
+  ok1(equals(lo, 1.0));
+  ok1(equals(hi, 2.0));
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- integrate XCTherm into the shared weather overlay model (settings, API/client, download glue, map overlay rendering, controls model, and weather dialog wiring)
- add reusable weather overlay page placement actions across RASP/EDL/XCTherm, including add-to-current/add-new-page UX, cursor controls activation, and documentation/tests
- harden RASP behavior by avoiding repeated reload attempts for broken tiles, adding a selectable `None` layer path, and making time/field cursor stepping follow available datasets (including 00:00-safe time selection)

## Test plan
- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- [x] Build after each weather/RASP behavior change to verify no regressions
- [x] Validate weather dialog flows for RASP/EDL/XCTherm/Flugwetter (credential gating and placement actions)
- [x] Validate RASP cursor behavior manually: stepping time and field with sparse availability, AUTO/manual transitions, and selecting `None`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XC Therm weather support: credential-gated weather tab and cursor controls, plus downloadable XCTherm map overlay.
  * Added weather overlay page actions (“add to current page” / “add new page”).
  * Added “time picker” interaction for overlay time selection.
* **Bug Fixes**
  * Fixed weather-controls placement/bottom-area mapping and related labels/keybindings.
  * Improved weather overlay page placement behavior, including clear feedback when the page limit is reached.
  * Updated RASP cursor/time stepping to respect per-field available forecast slots.
* **Documentation**
  * Documented weather overlay page placement UX and max-page failure behavior.
* **Tests**
  * Added tests for weather overlay page placement and XCTherm band queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #2583
