### PR TITLE
NOTAM: Fix warning-manager crash and refresh config rows on enable

### DIFF
--- a/src/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp
@@ -391,6 +391,11 @@ NOTAMConfigPanel::OnModified(DataField &df) noexcept
 #ifdef HAVE_HTTP
   if (IsDataField(ENABLE_NOTAM, df)) {
     UpdateVisibility();
+
+    const auto &enabled_field =
+      static_cast<const DataFieldBoolean &>(df);
+    if (enabled_field.GetValue())
+      UpdateFilterCounts();
   }
 #endif
 }

--- a/src/Engine/Airspace/AirspaceWarningManager.cpp
+++ b/src/Engine/Airspace/AirspaceWarningManager.cpp
@@ -154,9 +154,15 @@ AirspaceWarningManager::Update(const AircraftState& state,
 
   // update warning states
   if (airspaces.IsEmpty()) {
-    // no airspaces, no warnings possible
-    assert(warnings.empty());
-    return false;
+    // The airspace database can be rebuilt asynchronously (e.g. NOTAM
+    // disable/refresh), temporarily dropping all airspaces while stale warning
+    // entries from the previous set still exist.
+    if (warnings.empty())
+      return false;
+
+    ++serial;
+    warnings.clear();
+    return true;
   }
 
   // save old state


### PR DESCRIPTION
## Summary
- fix a crash in `AirspaceWarningManager` when the airspace set is temporarily empty during NOTAM disable/refresh by clearing stale warning entries instead of asserting
- update the NOTAM settings panel to refresh filter counters immediately when NOTAM support is toggled on, so dependent rows are populated right away
- keep both changes scoped to NOTAM transition behavior and panel state refresh

## Test plan
- [x] Toggle NOTAM support off after NOTAMs have been loaded; verify XCSoar no longer aborts in `AirspaceWarningManager::Update()`
- [x] Toggle NOTAM support on in the config panel; verify dependent rows become available and filter counters refresh immediately
- [ ] Build and run additional manual verification on target devices/platforms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settings now refresh NOTAM-related filter count readouts immediately when NOTAMs are enabled.
  * Airspace warnings are handled more safely during asynchronous airspace database rebuilds, clearing stale warnings instead of failing or asserting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->