### PR TITLE
Fix redundant rasp update and infinite user repository downloads

### DIFF
--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -36,6 +36,7 @@ static constexpr std::string_view USER_REPOSITORY_FILE_PREFIX{
     "user_repository_"};
 
 static bool repository_downloaded = false;
+static bool user_repository_downloaded = false;
 
 std::vector<RepositoryLink>
 GetUserRepositories()
@@ -134,12 +135,15 @@ EnqueueRepositoryDownload(bool force, bool main_repo, bool user_repo)
 
   // Enqueue additional user-defined repository URIs, if set
   if (user_repo) {
-    for (const auto &repo : GetUserRepositories())
-      {
-        const auto path =
-          RepositoryDownloadRelativePath(repo.filename.c_str());
-        Net::DownloadManager::Enqueue(repo.uri.c_str(), Path(path.c_str()));
-      }
+    if (!user_repository_downloaded || force) {
+      user_repository_downloaded = true;
+      for (const auto &repo : GetUserRepositories())
+        {
+          const auto path =
+            RepositoryDownloadRelativePath(repo.filename.c_str());
+          Net::DownloadManager::Enqueue(repo.uri.c_str(), Path(path.c_str()));
+        }
+    }
   }
 }
 
@@ -284,6 +288,7 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
         ShowError(std::current_exception(), _("Updating repository"));
       }
     }
+    user_repository_downloaded = true;
   }
 }
 

--- a/src/Repository/Glue.cpp
+++ b/src/Repository/Glue.cpp
@@ -277,6 +277,7 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
   }
 
   if (user_repo) {
+    bool user_repo_download_success = true;
     for (const auto &repo : GetUserRepositories()) {
       try {
         const auto path =
@@ -285,10 +286,12 @@ DownloadRepositoriesModal(bool main_repo, bool user_repo)
                               repo.uri.c_str(), path.c_str()) == nullptr)
           return; /* cancelled */
       } catch (...) {
+        user_repo_download_success = false;
         ShowError(std::current_exception(), _("Updating repository"));
       }
     }
-    user_repository_downloaded = true;
+    if (user_repo_download_success)
+      user_repository_downloaded = true;
   }
 }
 

--- a/src/Weather/Rasp/DownloadGlue.cpp
+++ b/src/Weather/Rasp/DownloadGlue.cpp
@@ -269,10 +269,6 @@ RaspDownloadGlue::OnDownloadNotify() noexcept
   }
 
   PollDownloadProgress();
-
-  FileRepository repository;
-  LoadAllRepositories(repository);
-  EnqueueConfiguredRaspUpdate(repository);
 }
 
 void

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -90,6 +90,11 @@ public:
     if (shutting_down)
       return;
 
+    /* skip duplicates already in the queue (e.g. a file re-enqueued
+       before its previous download completed) */
+    if (std::find(queue.begin(), queue.end(), path_relative) != queue.end())
+      return;
+
     queue.emplace_back(uri, path_relative);
 
     listeners.ForEach([path_relative](auto *listener){


### PR DESCRIPTION
The recent changes on weather data handling surfaced an existing bug that causes infinite repetitive downloading of user repository files.
This fixes the issue, using patterns already used in the code in other places.

Also removes redundant rasp file update downloading.

**Note that this is independent of the issues in** #2624 - those are more fundamental and not fixed with this, although the probability of actually triggering #2624 assertion is reduced by this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented user-defined repository downloads from being repeatedly enqueued by adding a “download already processed” guard with improved success/failure handling.
  * Avoided duplicate queued items for relative paths and reduced repeated progress notifications.
  * Improved post-download update behavior by triggering update refresh when repository downloads indicate pending completion, helping keep outdated content current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->