### PR TITLE
add SoftRF Concorde, Prime Mk4 and Retro Mk2 into 'white list' of USB devices

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -29,6 +29,7 @@ Version 7.45 - not yet released
     time #2260
   - The saved device port type string for that mode remains ble_hm10 so
     existing profiles load without migration
+  - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices
 * devices
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481

--- a/android/res/xml/usb_device_filter.xml
+++ b/android/res/xml/usb_device_filter.xml
@@ -22,6 +22,8 @@
   <usb-device vendor-id="12346" product-id="33184"/> <!-- SoftRF Midi -->
   <usb-device vendor-id="12346" product-id="33290"/> <!-- SoftRF Ink -->
   <usb-device vendor-id="10374" product-id="87"/> <!-- SoftRF Card -->
+  <usb-device vendor-id="12346" product-id="33603"/> <!-- SoftRF Concorde -->
+  <usb-device vendor-id="12346" product-id="33638"/> <!-- SoftRF Prime Mk4 -->
 
   <usb-device vendor-id="1027" product-id="24577"/> <!-- FT232AM, FT232BM, FT232R FT245R -->
   <usb-device vendor-id="1027" product-id="24592"/> <!-- FT2232D, FT2232H -->
@@ -29,7 +31,9 @@
   <usb-device vendor-id="1027" product-id="24596"/> <!-- FT232H -->
 
   <usb-device vendor-id="4292" product-id="60000"/> <!-- CP210x -->
+  <usb-device vendor-id="6790" product-id="21971"/> <!-- CH343 -->
   <usb-device vendor-id="6790" product-id="21972"/> <!-- CH9102 -->
+  <usb-device vendor-id="6790" product-id="29987"/> <!-- CH340, SoftRF Retro Mk2 -->
 
   <usb-device vendor-id="1659" product-id="8963"/> <!-- PL2303 -->
 

--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -59,6 +59,8 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x303a, 0x81a0), // SoftRF Midi
     createDevice(0x303a, 0x820a), // SoftRF Ink
     createDevice(0x2886, 0x0057), // SoftRF Card
+    createDevice(0x303a, 0x8343), // SoftRF Concorde
+    createDevice(0x303a, 0x8366), // SoftRF Prime Mk4
 
     createDevice(0x0403, 0x6001), // FT232AM, FT232BM, FT232R FT245R,
     createDevice(0x0403, 0x6010), // FT2232D, FT2232H
@@ -66,7 +68,9 @@ public final class UsbSerialHelper extends BroadcastReceiver {
     createDevice(0x0403, 0x6014), // FT232H
 
     createDevice(0x10C4, 0xEA60), // CP210x
+    createDevice(0x1A86, 0x55D3), // CH343
     createDevice(0x1A86, 0x55D4), // CH9102
+    createDevice(0x1A86, 0x7523), // CH340, SoftRF Retro Mk2
 
     createDevice(0x067B, 0x2303), // PL2303
     createDevice(0x1546, 0x01A7)  // U-BLOX 7 USB GPS


### PR DESCRIPTION
Brief summary of the changes
----------------------------

add USB VID/PID pairs for SoftRF Concorde, Prime Mk4 and Retro Mk2 Editions into (Android) 'white list' of USB devices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional USB device models, including SoftRF Concorde, SoftRF Prime Mk4, and SoftRF Retro Mk2.
  * These devices are now recognized and eligible for connections via the existing USB workflow.
* **Documentation**
  * Updated the release notes to reflect the newly supported USB devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->