### PR TITLE
Weather/MapOverlay: Improve in-flight weather overlay controls

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -290,19 +290,21 @@ location=8
 
 # ------------
 # mode=weather (weather overlay cursor bar)
-# Stick: UP/DOWN altitude, LEFT/RIGHT time, RETURN time picker, ESCAPE exit
-# Buttons: 1=Exit, 7=Time+, 8=Time-, 9=Alt+, 10=Alt-
+# Stick: UP/DOWN field, LEFT/RIGHT time, RETURN time picker, ESCAPE exit
+# Zoom: F2/+ = list, F3/- = auto
+# Buttons: 1=Time-, 2=List (F2/+), 3=Auto (F3/-), 4=Time+,
+#          5=Field+, 6=Field-, 7=Time Picker
 # ------------
 
 mode=weather
 type=key
 data=UP
-event=WeatherOverlay altitude +
+event=WeatherOverlay field +
 
 mode=weather
 type=key
 data=DOWN
-event=WeatherOverlay altitude -
+event=WeatherOverlay field -
 
 mode=weather
 type=key
@@ -321,43 +323,67 @@ event=WeatherOverlay time picker
 
 mode=weather
 type=key
+data=F2
+event=WeatherOverlay field picker
+
+mode=weather
+type=key
+data=F3
+event=WeatherOverlay field auto toggle
+
+mode=weather
+type=key
 data=ESCAPE
 event=Mode default
 
 mode=weather
 type=key
 data=0
-event=Mode default
-label=Exit\n(ESC)
+event=WeatherOverlay time -
+label=Time-\n(LEFT)
 location=1
+
+mode=weather
+type=key
+data=0
+event=WeatherOverlay field picker
+label=$(WeatherSecondaryPickerLabel)
+location=2
+
+mode=weather
+type=key
+data=0
+event=WeatherOverlay field auto toggle
+label=$(WeatherSecondaryAutoLabel)
+location=3
 
 mode=weather
 type=key
 data=0
 event=WeatherOverlay time +
 label=Time+\n(RIGHT)
+location=4
+
+mode=weather
+type=key
+data=0
+event=WeatherOverlay field +
+label=$(WeatherSecondaryPlusLabel)
+location=5
+
+mode=weather
+type=key
+data=0
+event=WeatherOverlay field -
+label=$(WeatherSecondaryMinusLabel)
+location=6
+
+mode=weather
+type=key
+data=0
+event=WeatherOverlay time picker
+label=Time\nPicker\n(RETURN)
 location=7
-
-mode=weather
-type=key
-data=0
-event=WeatherOverlay time -
-label=Time-\n(LEFT)
-location=8
-
-mode=weather
-type=key
-data=0
-event=WeatherOverlay altitude +
-label=Alt+\n(UP)
-location=9
-
-mode=weather
-type=key
-data=0
-event=WeatherOverlay altitude -
-label=Alt-\n(DOWN)
-location=10
 
 ###### main entry buttons
 
@@ -1197,13 +1223,6 @@ data=APP4
 event=Mode Info1
 label=Info
 location=4
-
-mode=Menu
-type=key
-data=5
-event=Mode weather
-label=Weather
-location=5
 
 mode=Menu
 type=key

--- a/build/main.mk
+++ b/build/main.mk
@@ -345,6 +345,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Input/InputParser.cpp \
 	$(SRC)/Input/TaskEventObserver.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(SRC)/PageOverlayTitle.cpp \
 	$(SRC)/PageState.cpp \
 	$(SRC)/PageActions.cpp \
 	$(SRC)/StatusMessage.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -405,6 +405,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Weather/MapOverlay/InputEvents.cpp \
 	$(SRC)/Weather/MapOverlay/ControlsFactory.cpp \
 	$(SRC)/Weather/MapOverlay/ControlsWidget.cpp \
+	$(SRC)/Weather/MapOverlay/TimePicker.cpp \
 	$(SRC)/Weather/MapOverlay/RaspControlsModel.cpp \
 	$(SRC)/Weather/MapOverlay/XcthermControlsModel.cpp \
 	$(SRC)/Weather/BackgroundDownloadProgress.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -225,6 +225,7 @@ TEST_NAMES += TestWeatherOverlayPagePlacement
 
 TEST_WEATHER_OVERLAY_PAGE_PLACEMENT_SOURCES = \
 	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/PageOverlayTitleStub.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestWeatherOverlayPagePlacement.cpp
@@ -2029,6 +2030,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Audio/VarioSettings.cpp \
 	$(SRC)/DisplaySettings.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/PageOverlayTitleStub.cpp \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Dialogs/DialogSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
@@ -2462,6 +2464,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(SRC)/UISettings.cpp \
 	$(SRC)/DisplaySettings.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/PageOverlayTitleStub.cpp \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \
@@ -2533,6 +2536,7 @@ RUN_AIRSPACE_WARNING_DIALOG_SOURCES = \
 	$(SRC)/UISettings.cpp \
 	$(SRC)/DisplaySettings.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(TEST_SRC_DIR)/PageOverlayTitleStub.cpp \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/Gauge/VarioSettings.cpp \
 	$(SRC)/Gauge/TrafficSettings.cpp \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -483,23 +483,26 @@ Event list
      XCTherm). Only has an effect on map pages that show weather overlay
      controls. Arguments use a common ``<axis> …`` prefix:
 
-     **Time:** ``time +``, ``time -`` (step forecast time)
+     **Time:** ``time +``, ``time -`` (step forecast time), ``time picker``
+     (open the time picker with Auto, Now, and manual selection)
 
      **Time auto/manual:** ``time auto toggle``, ``time auto on``,
      ``time auto off``, ``time auto show``
 
-     **Altitude / level:** ``altitude +``, ``altitude -`` (step altitude
-     band or pressure level). For EDL overlays, ``level +``/``level -``
-     and ``level auto …`` are accepted as aliases for the altitude
-     commands.
+     **Secondary axis:** ``field +``, ``field -`` (step layer, pressure
+     level, or altitude band). ``altitude +/-`` and EDL ``level +/-`` are
+     accepted as aliases.
 
-     **Altitude auto/manual:** ``altitude auto toggle``,
-     ``altitude auto on``, ``altitude auto off``,
-     ``altitude auto show``
+     **Secondary list:** ``field picker``, ``layer picker``, or
+     ``level picker`` (open the ComboPicker list for the active overlay).
 
-     RASP overlays support time commands only. EDL overlays support
-     both time and level. XCTherm overlays map altitude to the layer
-     (altitude band) row and time to the forecast hour row.
+     **Secondary auto/manual:** ``field auto toggle`` (and ``altitude auto
+     …``, ``level auto …`` aliases). On RASP, secondary auto falls back
+     to time auto when no secondary axis exists.
+
+     RASP overlays support time and layer selection. EDL overlays support
+     time and pressure level. XCTherm overlays map the secondary axis to
+     altitude bands and time to forecast hours.
  * - ``Zoom Z``
    - Controls map zoom. Possible arguments: ``auto toggle``,
      ``auto on``, ``auto off``, ``auto show``, ``in``, ``out``,
@@ -530,12 +533,12 @@ Built-in modes
   the ``Mode mc`` event (default key ``3``). Stick UP/DOWN adjust MC;
   RETURN toggles auto/manual MC; ESCAPE returns to ``default``.
 - ``weather`` -- weather overlay cursor bar mode. Enter from the quick
-  menu (**Forecast Controls**) or the on-screen menu (**Menu → Weather**),
-  or via the ``Mode weather`` event. Stick UP/DOWN step altitude/level,
-  LEFT/RIGHT step time, RETURN toggles time auto/manual, APP6 toggles
-  altitude auto/manual, ESCAPE returns to ``default``. Only affects map
-  pages with a weather overlay (EDL or RASP) and weather controls in the
-  bottom widget (**Config > System > Pages > Bottom widget**).
+  menu (**Forecast Controls** on RemoteStick) or via the ``Mode weather``
+  event. Stick UP/DOWN step the secondary axis (layer, level, or
+  altitude), LEFT/RIGHT step time, RETURN opens the time picker, ESCAPE
+  returns to ``default``. On map pages with weather overlay controls,
+  F2 and the on-screen **+** button open the secondary list; F3 and
+  **−** toggle auto (secondary axis on EDL/XCTherm, time auto on RASP).
   See :ref:`weather-overlay-mode` below.
 - ``wptimg`` -- the waypoint details dialog is on an **image** page;
   key bindings in this map control zoom and pan of the image (the
@@ -550,12 +553,12 @@ hierarchies.
 Weather overlay mode (``mode=weather``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a map page displays EDL or RASP overlay controls in the bottom
-cursor bar, open the quick menu (F1 or the ULDR gesture) and choose
-**Forecast Controls**, or use **Menu → Weather**, to enter
-``mode=weather`` so stick and button bindings can adjust forecast time
-and altitude without leaving the map. Leaving the page (or pressing
-ESCAPE / the Exit label) returns to ``default``.
+When a map page displays EDL, RASP, or XCTherm overlay controls in the
+bottom cursor bar, open the quick menu (F1 or the ULDR gesture) and choose
+**Forecast Controls** (RemoteStick), or bind ``Mode weather`` elsewhere,
+to enter ``mode=weather`` so stick and button bindings can adjust forecast
+time and the secondary axis without leaving the map. Pressing ESCAPE
+returns to ``default``.
 
 The built-in stick bindings in :file:`Data/Input/default.xci` are:
 
@@ -567,24 +570,57 @@ The built-in stick bindings in :file:`Data/Input/default.xci` are:
    - Event
    - Action
  * - UP / DOWN
-   - ``WeatherOverlay altitude +/-``
-   - Step pressure level (EDL)
+   - ``WeatherOverlay field +/-``
+   - Step layer (RASP), pressure level (EDL), or altitude band (XCTherm)
  * - LEFT / RIGHT
    - ``WeatherOverlay time -/+``
    - Step forecast time
  * - RETURN
-   - ``WeatherOverlay time auto show/toggle``
-   - Toggle time auto/manual
- * - APP6
-   - ``WeatherOverlay altitude auto show/toggle``
-   - Toggle altitude/level auto/manual
+   - ``WeatherOverlay time picker``
+   - Open time picker (Auto, Now, manual)
+ * - F2 / on-screen **+**
+   - ``WeatherOverlay field picker``
+   - Open secondary-axis list (layer, level, or altitude)
+ * - F3 / on-screen **−**
+   - ``WeatherOverlay field auto toggle``
+   - Toggle secondary auto (EDL/XCTherm) or time auto (RASP)
  * - ESCAPE
    - ``Mode default``
    - Exit weather input mode
 
-On-screen labels (locations 1, 6--10) mirror these actions. On RASP
-pages, UP/DOWN step the forecast layer; EDL pages use them for pressure
-level. RASP ignores altitude auto/manual commands.
+On-screen menubar buttons (locations 1--7) mirror these actions:
+
+.. list-table::
+ :widths: 15 35 50
+ :header-rows: 1
+
+ * - Location
+   - Action
+   - Label (overlay-specific)
+ * - 1
+   - Time step back
+   - ``Time- (LEFT)``
+ * - 2
+   - Secondary list
+   - Layer / Level / Altitude list (``F2/+``)
+ * - 3
+   - Auto toggle
+   - Time auto (RASP) or secondary auto (EDL/XCTherm) (``F3/-``)
+ * - 4
+   - Time step forward
+   - ``Time+ (RIGHT)``
+ * - 5
+   - Secondary step up
+   - ``Field+ / Level+ / Altitude+ (UP)``
+ * - 6
+   - Secondary step down
+   - ``Field- / Level- / Altitude- (DOWN)``
+ * - 7
+   - Time picker
+   - ``Time Picker (RETURN)``
+
+Tapping the secondary cursor-bar label also opens the list picker. The
+map title shows the active overlay layer when applicable.
 
 The same ``WeatherOverlay`` arguments can be bound in any mode (for
 example from ``mode=default``) if you prefer not to use ``mode=weather``.

--- a/src/ActionInterface.cpp
+++ b/src/ActionInterface.cpp
@@ -22,9 +22,6 @@
 #include "PageSettings.hpp"
 #include "Weather/Features.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
-#ifdef HAVE_EDL
-#include "Weather/EDL/StateController.hpp"
-#endif
 
 using namespace CommonInterface;
 
@@ -32,6 +29,10 @@ namespace ActionInterface {
 static void
 SendGetComputerSettings() noexcept;
 }
+
+static void
+UpdateMapScalePageInfo(UIState &state,
+                       const UISettings &settings) noexcept;
 
 void
 XCSoarInterface::ReceiveGPS() noexcept
@@ -261,6 +262,8 @@ ActionInterface::SendMapSettings(const bool trigger_draw) noexcept
 void
 ActionInterface::SendUIState(const bool trigger_draw) noexcept
 {
+  UpdateMapScalePageInfo(SetUIState(), GetUISettings());
+
   main_window->SetUIState(GetUIState());
 
   if (trigger_draw)
@@ -313,27 +316,9 @@ UpdateMapScalePageInfo(UIState &state,
 
   state.map_scale_page_title.clear();
 
-  const bool pan_fullscreen =
-    pages.special_page.IsDefined() &&
-    pages.special_page == PageLayout::FullScreen();
-
-#ifdef HAVE_EDL
-  if (pan_fullscreen &&
-      state.weather.edl.session.IsSuspendedForPan() &&
-      configured.UsesEdlOverlay()) {
-    state.map_scale_page_title = EDL::GetOverlayLabel();
-    return;
-  }
-#endif
-  if (pan_fullscreen &&
-      configured.overlay == PageLayout::Overlay::RASP) {
-    state.map_scale_page_title = Rasp::GetPanOverlayLabel(configured);
-    return;
-  }
-
-  if (layout.IsMapMain() &&
-      layout.overlay != PageLayout::Overlay::NONE) {
-    const char *title = layout.MakeTitle(settings.info_boxes,
+  if (overlay_layout.IsMapMain() &&
+      overlay_layout.overlay != PageLayout::Overlay::NONE) {
+    const char *title = overlay_layout.MakeTitle(settings.info_boxes,
                                          std::span{state.map_scale_page_title.data(),
                                                    state.map_scale_page_title.capacity()},
                                          DataGlobals::GetRasp().get(),
@@ -362,6 +347,8 @@ ActionInterface::UpdateDisplayMode() noexcept
 void
 ActionInterface::SendUIState() noexcept
 {
+  UpdateMapScalePageInfo(SetUIState(), GetUISettings());
+
   /* force-update all InfoBoxes just in case the display mode has
      changed */
   InfoBoxManager::SetDirty();

--- a/src/Dialogs/ComboPicker.cpp
+++ b/src/Dialogs/ComboPicker.cpp
@@ -37,7 +37,8 @@ ComboPicker(const char *caption,
             const ComboList &combo_list,
             const char *help_text,
             bool enable_item_help,
-            const char *extra_caption)
+            const char *extra_caption,
+            const char *extra_caption2)
 {
   ComboListPopup = &combo_list;
 
@@ -49,7 +50,8 @@ ComboPicker(const char *caption,
                     support, false,
                     help_text,
                     enable_item_help ? OnItemHelp : nullptr,
-                    extra_caption);
+                    extra_caption,
+                    extra_caption2);
 }
 
 bool

--- a/src/Dialogs/ComboPicker.hpp
+++ b/src/Dialogs/ComboPicker.hpp
@@ -11,7 +11,8 @@ ComboPicker(const char *caption,
             const ComboList &combo_list,
             const char *help_text = nullptr,
             bool enable_item_help = false,
-            const char *extra_caption=nullptr);
+            const char *extra_caption = nullptr,
+            const char *extra_caption2 = nullptr);
 
 /**
  * @return true if the user has selected a new value (though it may be

--- a/src/Dialogs/ListPicker.cpp
+++ b/src/Dialogs/ListPicker.cpp
@@ -60,7 +60,8 @@ ListPicker(const char *caption,
            ListItemRenderer &item_renderer, bool update,
            const char *help_text,
            ItemHelpCallback_t _itemhelp_callback,
-           const char *extra_caption)
+           const char *extra_caption,
+           const char *extra_caption2)
 {
   assert(num_items <= 0x7fffffff);
   assert((num_items == 0 && initial_value == 0) || initial_value < num_items);
@@ -98,6 +99,8 @@ ListPicker(const char *caption,
 
   if (extra_caption != nullptr)
     dialog.AddButton(extra_caption, mrExtra);
+  if (extra_caption2 != nullptr)
+    dialog.AddButton(extra_caption2, mrExtra2);
 
   /* only show a Help button when item help is active (the general
      help text complements the per-item help); for pickers without
@@ -122,7 +125,7 @@ ListPicker(const char *caption,
   int result = dialog.ShowModal();
   if (result == mrOK)
     result = (int)list_widget->GetList().GetCursorIndex();
-  else if (result != mrExtra)
+  else if (result != mrExtra && result != mrExtra2)
     result = -1;
 
   return result;

--- a/src/Dialogs/ListPicker.hpp
+++ b/src/Dialogs/ListPicker.hpp
@@ -138,8 +138,10 @@ public:
  * @param itemhelp_callback Callback to return string for current item help
  * @param extra_caption caption of another button that closes the
  * dialog (nullptr disables it)
+ * @param extra_caption2 caption of a second extra button that closes the
+ * dialog (nullptr disables it)
  * @return the list index, -1 if the user cancelled the dialog, mrExtra if
- * the user clicked the "extra" button
+ * the user clicked the first extra button, mrExtra2 for the second
  */
 int
 ListPicker(const char *caption,
@@ -148,4 +150,5 @@ ListPicker(const char *caption,
            ListItemRenderer &item_renderer, bool update = false,
            const char *help_text = nullptr,
            ItemHelpCallback_t itemhelp_callback = nullptr,
-           const char *extra_caption=nullptr);
+           const char *extra_caption = nullptr,
+           const char *extra_caption2 = nullptr);

--- a/src/Form/Form.hpp
+++ b/src/Form/Form.hpp
@@ -17,6 +17,8 @@ enum ModalResult {
   mrCancel = 3,
   /** Extra dialog button (e.g. ListPicker download action). */
   mrExtra = -2,
+  /** Second extra dialog button (e.g. ListPicker "Now" action). */
+  mrExtra2 = -3,
 };
 
 /**

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -138,6 +138,15 @@ InfoBoxManager::InfoBoxDrawIfDirty() noexcept
   }
 }
 
+InfoBoxWindow *
+InfoBoxManager::GetWindow(unsigned id) noexcept
+{
+  if (!infoboxes_ready || id >= layout.count)
+    return nullptr;
+
+  return infoboxes[id];
+}
+
 void
 InfoBoxManager::SetDirty() noexcept
 {

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -5,6 +5,7 @@
 
 struct InfoBoxLook;
 class ContainerWindow;
+class InfoBoxWindow;
 
 namespace InfoBoxLayout { struct Layout; }
 
@@ -18,6 +19,13 @@ ProcessTimer() noexcept;
 
 [[nodiscard]] bool
 IsReady() noexcept;
+
+/**
+ * Returns the InfoBox window for the given slot, or nullptr if the
+ * manager was reinitialised and the window no longer exists.
+ */
+[[nodiscard]] InfoBoxWindow *
+GetWindow(unsigned id) noexcept;
 
 void
 SetDirty() noexcept;

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -262,9 +262,14 @@ InfoBoxWindow::ShowDialog()
 
   dlgInfoBoxAccessShowModeless(id, GetDialogContent());
 
+  /* Layout may be reinitialised while the modal dialog runs (e.g. window
+     resize), which destroys and recreates InfoBox windows. */
+  if (InfoBoxManager::GetWindow(id) != this)
+    return;
+
   force_draw_selector = false;
   Invalidate();
-  
+
   FocusParent();
 }
 

--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -556,6 +556,7 @@ InputEvents::eventLockScreen([[maybe_unused]] const char *mode)
 // Adjusts the active map weather overlay cursor bar.
 // time +/-, time auto on/off/toggle/show
 // altitude +/-, altitude auto on/off/toggle/show
+// field/layer/level picker (secondary axis list)
 // level +/- and level auto … (EDL pressure level alias for altitude)
 void
 InputEvents::eventWeatherOverlay(const char *misc)

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -277,6 +277,21 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
     }
   }
 
+  if (name == "WeatherSecondaryPickerLabel") {
+    switch (GetUIState().page_overlay) {
+    case PageLayout::Overlay::EDL:
+      return _("Level\nList\n(APP4)");
+
+    case PageLayout::Overlay::XCTHERM:
+      return _("Altitude\nList\n(APP4)");
+
+    case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::NONE:
+    case PageLayout::Overlay::MAX:
+      return _("Layer\nList\n(APP4)");
+    }
+  }
+
   if (name =="CheckFLARM") {
     invalid |= !Basic().flarm.status.available;
     return nullptr;

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -260,6 +260,23 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
   if (value != nullptr)
     return value;
 
+  if (name == "WeatherSecondaryPlusLabel" ||
+      name == "WeatherSecondaryMinusLabel") {
+    const bool plus = name == "WeatherSecondaryPlusLabel";
+    switch (GetUIState().page_overlay) {
+    case PageLayout::Overlay::EDL:
+      return plus ? _("Level+\n(UP)") : _("Level-\n(DOWN)");
+
+    case PageLayout::Overlay::XCTHERM:
+      return plus ? _("Altitude+\n(UP)") : _("Altitude-\n(DOWN)");
+
+    case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::NONE:
+    case PageLayout::Overlay::MAX:
+      return plus ? _("Field+\n(UP)") : _("Field-\n(DOWN)");
+    }
+  }
+
   if (name =="CheckFLARM") {
     invalid |= !Basic().flarm.status.available;
     return nullptr;

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -280,15 +280,30 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
   if (name == "WeatherSecondaryPickerLabel") {
     switch (GetUIState().page_overlay) {
     case PageLayout::Overlay::EDL:
-      return _("Level\nList\n(APP4)");
+      return _("Level\nList\n(F2/+)");
 
     case PageLayout::Overlay::XCTHERM:
-      return _("Altitude\nList\n(APP4)");
+      return _("Altitude\nList\n(F2/+)");
 
     case PageLayout::Overlay::RASP:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
-      return _("Layer\nList\n(APP4)");
+      return _("Layer\nList\n(F2/+)");
+    }
+  }
+
+  if (name == "WeatherSecondaryAutoLabel") {
+    switch (GetUIState().page_overlay) {
+    case PageLayout::Overlay::EDL:
+      return _("Level\nAuto\n(F3/-)");
+
+    case PageLayout::Overlay::XCTHERM:
+      return _("Altitude\nAuto\n(F3/-)");
+
+    case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::NONE:
+    case PageLayout::Overlay::MAX:
+      return _("Time\nAuto\n(F3/-)");
     }
   }
 

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -8,6 +8,16 @@
 #include <algorithm>
 #include <cassert>
 
+/** Side-column slots (location 5+) must fit at least this many buttons. */
+static constexpr unsigned side_column_slots = 8;
+
+[[gnu::pure]]
+static unsigned
+GetSideColumnRowHeight(unsigned screen_height) noexcept
+{
+  return std::max(1u, screen_height / side_column_slots);
+}
+
 [[gnu::pure]]
 static PixelRect
 GetButtonPosition(unsigned i, PixelRect rc)
@@ -29,6 +39,7 @@ GetButtonPosition(unsigned i, PixelRect rc)
       rc.top = rc.bottom - hheight;
     } else {
       hwidth = std::max(1u, hwidth / 3);
+      hheight = GetSideColumnRowHeight(rc.GetHeight());
 
       rc.left = rc.right - hwidth;
       rc.top += (i - 5) * hheight;
@@ -48,8 +59,11 @@ GetButtonPosition(unsigned i, PixelRect rc)
     } else if (i < 5) {
       rc.top += hheight * (i - 1);
     } else {
-      rc.left += hwidth * (i - 5);
-      rc.top = rc.bottom - hheight;
+      hwidth = std::max(1u, hwidth * 5 / 3);
+      hheight = GetSideColumnRowHeight(rc.GetHeight());
+
+      rc.left = rc.right - hwidth;
+      rc.top += (i - 5) * hheight;
     }
 
     rc.right = rc.left + hwidth;

--- a/src/Menu/ShowButton.cpp
+++ b/src/Menu/ShowButton.cpp
@@ -7,6 +7,8 @@
 #include "Look/ButtonLook.hpp"
 #include "Input/InputEvents.hpp"
 #include "Interface.hpp"
+#include "PageActions.hpp"
+#include "PageSettings.hpp"
 #include "UIState.hpp"
 
 #include <memory>
@@ -79,6 +81,13 @@ ShowZoomButton::Create(ContainerWindow &parent, const ButtonLook &look,
 bool
 ShowZoomButton::OnClicked() noexcept
 {
+  if (PageActions::GetCurrentLayout().UsesWeatherOverlay()) {
+    InputEvents::eventWeatherOverlay(sign == Sign::ZOOM_IN
+                                     ? "field picker"
+                                     : "field auto toggle");
+    return true;
+  }
+
   InputEvents::eventZoom(sign == Sign::ZOOM_IN ? "in" : "out");
   return true;
 }

--- a/src/PageOverlayTitle.cpp
+++ b/src/PageOverlayTitle.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "PageOverlayTitle.hpp"
+
+#include "Language/Language.hpp"
+#include "Weather/Features.hpp"
+#include "Weather/Rasp/RaspStore.hpp"
+#include "util/StaticString.hxx"
+#include "util/StringBuilder.hxx"
+#include "util/Compiler.h"
+
+#ifdef HAVE_EDL
+#include "Formatter/UserUnits.hpp"
+#include "Weather/EDL/StateController.hpp"
+#endif
+#ifdef HAVE_HTTP
+#include "Weather/xctherm/XCThermMapOverlay.hpp"
+#endif
+
+void
+AppendOverlayTitle(BasicStringBuilder<char> &builder,
+                   const PageLayout &layout,
+                   const RaspStore *rasp)
+{
+  switch (layout.overlay) {
+  case PageLayout::Overlay::NONE:
+    break;
+
+  case PageLayout::Overlay::RASP:
+    builder.Append(", RASP");
+    if (rasp != nullptr &&
+        layout.rasp_field >= 0 &&
+        unsigned(layout.rasp_field) < rasp->GetItemCount()) {
+      const auto &item = rasp->GetItemInfo(layout.rasp_field);
+      const char *label = item.label != nullptr
+        ? gettext(item.label)
+        : item.name;
+      if (label != nullptr && *label != '\0') {
+        builder.Append(' ');
+        builder.Append(label);
+      }
+    }
+    break;
+
+  case PageLayout::Overlay::EDL:
+    builder.Append(", EDL");
+#ifdef HAVE_EDL
+    {
+      EDL::EnsureInitialised();
+      char alt[32];
+      FormatUserAltitude(EDL::GetAltitude(), alt);
+      if (alt[0] != '\0') {
+        builder.Append(' ');
+        builder.Append(alt);
+      }
+    }
+#endif
+    break;
+
+  case PageLayout::Overlay::XCTHERM:
+    builder.Append(", XCTherm");
+#ifdef HAVE_HTTP
+    {
+      StaticString<64> label;
+      XCTherm::FormatLayerTitleLabel(label);
+      if (!label.empty()) {
+        builder.Append(' ');
+        builder.Append(label.c_str());
+      }
+    }
+#endif
+    break;
+
+  case PageLayout::Overlay::MAX:
+    gcc_unreachable();
+  }
+}

--- a/src/PageOverlayTitle.hpp
+++ b/src/PageOverlayTitle.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "PageSettings.hpp"
+
+class RaspStore;
+
+template<typename T>
+class BasicStringBuilder;
+
+void
+AppendOverlayTitle(BasicStringBuilder<char> &builder,
+                   const PageLayout &layout,
+                   const RaspStore *rasp);

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -2,80 +2,12 @@
 // Copyright The XCSoar Project
 
 #include "PageSettings.hpp"
+#include "PageOverlayTitle.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Language/Language.hpp"
-#include "Weather/Rasp/RaspStore.hpp"
 #include "util/StringBuilder.hxx"
 
 #include <algorithm>
-
-void
-PageLayout::Normalise() noexcept
-{
-  if (main == Main::EDL_MAP) {
-    main = Main::MAP;
-    overlay = Overlay::EDL;
-    if (bottom == Bottom::NOTHING)
-      bottom = Bottom::WEATHER_CONTROLS;
-  }
-
-  if (unsigned(overlay) >= unsigned(Overlay::MAX))
-    overlay = Overlay::NONE;
-
-  if (IsMapMain()) {
-    if (overlay != Overlay::EDL && overlay != Overlay::RASP &&
-        overlay != Overlay::XCTHERM &&
-        bottom == Bottom::WEATHER_CONTROLS)
-      bottom = Bottom::NOTHING;
-  } else {
-    overlay = Overlay::NONE;
-    if (bottom == Bottom::WEATHER_CONTROLS)
-      bottom = Bottom::NOTHING;
-  }
-
-  if (overlay != Overlay::RASP)
-    rasp_field = -1;
-  else if (rasp_field < -1)
-    rasp_field = -1;
-}
-
-static void
-AppendOverlayTitle(BasicStringBuilder<char> &builder,
-                   const PageLayout &layout,
-                   const RaspStore *rasp)
-{
-  switch (layout.overlay) {
-  case PageLayout::Overlay::NONE:
-    break;
-
-  case PageLayout::Overlay::RASP:
-    builder.Append(", RASP");
-    if (rasp != nullptr &&
-        layout.rasp_field >= 0 &&
-        unsigned(layout.rasp_field) < rasp->GetItemCount()) {
-      const auto &item = rasp->GetItemInfo(layout.rasp_field);
-      const char *label = item.label != nullptr
-        ? gettext(item.label)
-        : item.name;
-      if (label != nullptr && *label != '\0') {
-        builder.Append(' ');
-        builder.Append(label);
-      }
-    }
-    break;
-
-  case PageLayout::Overlay::EDL:
-    builder.Append(", EDL");
-    break;
-
-  case PageLayout::Overlay::XCTHERM:
-    builder.Append(", XCTherm");
-    break;
-
-  case PageLayout::Overlay::MAX:
-    gcc_unreachable();
-  }
-}
 
 const char *
 PageLayout::MakeTitle(const InfoBoxSettings &info_box_settings,

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -200,7 +200,34 @@ struct PageLayout
   /**
    * Convert legacy page layouts to the current representation.
    */
-  void Normalise() noexcept;
+  constexpr void Normalise() noexcept
+  {
+    if (main == Main::EDL_MAP) {
+      main = Main::MAP;
+      overlay = Overlay::EDL;
+      if (bottom == Bottom::NOTHING)
+        bottom = Bottom::WEATHER_CONTROLS;
+    }
+
+    if (unsigned(overlay) >= unsigned(Overlay::MAX))
+      overlay = Overlay::NONE;
+
+    if (IsMapMain()) {
+      if (overlay != Overlay::EDL && overlay != Overlay::RASP &&
+          overlay != Overlay::XCTHERM &&
+          bottom == Bottom::WEATHER_CONTROLS)
+        bottom = Bottom::NOTHING;
+    } else {
+      overlay = Overlay::NONE;
+      if (bottom == Bottom::WEATHER_CONTROLS)
+        bottom = Bottom::NOTHING;
+    }
+
+    if (overlay != Overlay::RASP)
+      rasp_field = -1;
+    else if (rasp_field < -1)
+      rasp_field = -1;
+  }
 
   [[nodiscard]]
   const char *MakeTitle(const InfoBoxSettings &info_box_settings,

--- a/src/Weather/MapOverlay/ControlsModel.hpp
+++ b/src/Weather/MapOverlay/ControlsModel.hpp
@@ -7,6 +7,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <utility>
 
 struct MoreData;
 
@@ -118,7 +119,31 @@ public:
     (void)basic;
   }
 
+  /** Shared entry point for menu/input and picker auto-on actions. */
+  virtual void EnablePrimaryAutoFromInput() noexcept {
+    EnablePrimaryAutoAndRefresh();
+  }
+
 protected:
+  void NotifyOverlay() noexcept {
+    Notify(ControlsUpdate::OVERLAY);
+  }
+
+  void EnablePrimaryAutoAndRefresh() noexcept {
+    SetPrimaryAutoAdvance(true);
+    ApplyPrimaryAutoAdvance();
+    NotifyOverlay();
+  }
+
+  template<typename F>
+  void
+  ApplyManualPrimarySelection(F &&select_manual)
+  {
+    SetPrimaryAutoAdvance(false);
+    std::forward<F>(select_manual)();
+    NotifyOverlay();
+  }
+
   void Notify(ControlsUpdate update) noexcept {
     if (notify)
       notify(update);

--- a/src/Weather/MapOverlay/ControlsWidget.cpp
+++ b/src/Weather/MapOverlay/ControlsWidget.cpp
@@ -135,15 +135,10 @@ ControlsWidget::OnPrimaryLabelClick() noexcept
 void
 ControlsWidget::OnSecondaryLabelClick() noexcept
 {
-  if (model->SupportsSecondaryAutoAdvance()) {
-    if (!model->GetSecondaryAutoAdvance())
-      model->ResumeSecondaryAuto();
-    return;
-  }
-
   switch (model->GetSecondaryLabelAction()) {
   case SecondaryLabelAction::OPEN_PICKER:
     model->OpenSecondaryPicker();
+    RefreshOverlay();
     break;
 
   case SecondaryLabelAction::NONE:
@@ -176,6 +171,11 @@ ControlsWidget::HandleWeatherOverlayInput(const char *misc) noexcept
 
   case OverlayInputAction::ALTITUDE_MINUS:
     OnStepSecondary(-1);
+    break;
+
+  case OverlayInputAction::FIELD_PICKER:
+    model->OpenSecondaryPicker();
+    RefreshOverlay();
     break;
 
   case OverlayInputAction::TIME_AUTO_TOGGLE:

--- a/src/Weather/MapOverlay/ControlsWidget.cpp
+++ b/src/Weather/MapOverlay/ControlsWidget.cpp
@@ -201,8 +201,15 @@ ControlsWidget::HandleWeatherOverlayInput(const char *misc) noexcept
     break;
 
   case OverlayInputAction::ALTITUDE_AUTO_TOGGLE:
-    if (!model->SupportsSecondaryAutoAdvance())
+    if (!model->SupportsSecondaryAutoAdvance()) {
+      if (model->GetPrimaryAutoAdvance()) {
+        model->SetPrimaryAutoAdvance(false);
+        UpdateLabels();
+      } else {
+        model->EnablePrimaryAutoFromInput();
+      }
       break;
+    }
     model->SetSecondaryAutoAdvance(!model->GetSecondaryAutoAdvance());
     if (model->GetSecondaryAutoAdvance())
       model->ApplySecondaryAutoAdvance();

--- a/src/Weather/MapOverlay/ControlsWidget.cpp
+++ b/src/Weather/MapOverlay/ControlsWidget.cpp
@@ -116,6 +116,7 @@ ControlsWidget::OnPrimaryLabelClick() noexcept
   switch (model->GetPrimaryLabelAction()) {
   case PrimaryLabelAction::OPEN_PICKER:
     model->OpenPrimaryPicker();
+    UpdateLabels();
     break;
 
   case PrimaryLabelAction::RESUME_AUTO:
@@ -175,16 +176,16 @@ ControlsWidget::HandleWeatherOverlayInput(const char *misc) noexcept
     break;
 
   case OverlayInputAction::TIME_AUTO_TOGGLE:
-    model->SetPrimaryAutoAdvance(!model->GetPrimaryAutoAdvance());
-    if (model->GetPrimaryAutoAdvance())
-      model->ApplyPrimaryAutoAdvance();
-    RefreshOverlay();
+    if (model->GetPrimaryAutoAdvance()) {
+      model->SetPrimaryAutoAdvance(false);
+      UpdateLabels();
+    } else {
+      model->EnablePrimaryAutoFromInput();
+    }
     break;
 
   case OverlayInputAction::TIME_AUTO_ON:
-    model->SetPrimaryAutoAdvance(true);
-    model->ApplyPrimaryAutoAdvance();
-    RefreshOverlay();
+    model->EnablePrimaryAutoFromInput();
     break;
 
   case OverlayInputAction::TIME_AUTO_OFF:

--- a/src/Weather/MapOverlay/ControlsWidget.cpp
+++ b/src/Weather/MapOverlay/ControlsWidget.cpp
@@ -3,6 +3,7 @@
 
 #include "ControlsWidget.hpp"
 
+#include "ActionInterface.hpp"
 #include "CursorBarLabels.hpp"
 #include "InputEventMisc.hpp"
 #include "Interface.hpp"
@@ -73,6 +74,7 @@ ControlsWidget::RefreshOverlay() noexcept
 {
   UpdateLabels();
   model->RefreshOverlay();
+  ActionInterface::SendUIState(true);
 }
 
 void
@@ -84,6 +86,7 @@ ControlsWidget::ApplyUpdate(ControlsUpdate update) noexcept
 
   case ControlsUpdate::LABELS:
     UpdateLabels();
+    ActionInterface::SendUIState(false);
     break;
 
   case ControlsUpdate::OVERLAY:

--- a/src/Weather/MapOverlay/EdlControlsModel.cpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.cpp
@@ -5,13 +5,14 @@
 
 #include "ActionInterface.hpp"
 #include "Components.hpp"
-#include "Dialogs/ComboPicker.hpp"
 #include "Dialogs/Message.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "NetComponents.hpp"
+#include "PrimaryTimePicker.hpp"
 #include "UIState.hpp"
+#include "util/StaticString.hxx"
 #include "Weather/EDL/Glue.hpp"
 #include "Weather/EDL/Levels.hpp"
 #include "Weather/EDL/StateController.hpp"
@@ -19,14 +20,8 @@
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
 
 #include <chrono>
-#include <limits>
 
 namespace WeatherMapOverlay {
-
-static constexpr unsigned TIME_PICKER_AUTO =
-  std::numeric_limits<unsigned>::max() - 1;
-static constexpr unsigned TIME_PICKER_NOW =
-  std::numeric_limits<unsigned>::max();
 
 EdlControlsModel::~EdlControlsModel() noexcept
 {
@@ -68,9 +63,18 @@ EdlControlsModel::SelectForecast(unsigned index) noexcept
   if (index >= forecast_times.size())
     return;
 
+  SelectForecastTime(forecast_times[index]);
+}
+
+void
+EdlControlsModel::SelectForecastTime(const BrokenDateTime &time) noexcept
+{
+  if (!time.IsPlausible())
+    return;
+
   EDL::EnsureInitialised();
   auto &edl = CommonInterface::SetUIState().weather.edl;
-  edl.forecast_datetime = forecast_times[index];
+  edl.forecast_datetime = time;
   edl.forecast_auto_advance = false;
   edl.session.cursor_initialized = true;
 }
@@ -100,7 +104,23 @@ EdlControlsModel::FindForecastIndex() const noexcept
     if (forecast_times[i] == selected)
       return i;
 
+  if (const auto tracked = FindTrackedForecastIndex())
+    return *tracked;
+
   return 0;
+}
+
+std::optional<unsigned>
+EdlControlsModel::FindTrackedForecastIndex() const noexcept
+{
+  const BrokenDateTime tracked =
+    EDL::GetTrackedForecastTime(BrokenDateTime::NowUTC());
+
+  for (unsigned i = 0; i < forecast_choices; ++i)
+    if (forecast_times[i] == tracked)
+      return i;
+
+  return std::nullopt;
 }
 
 bool
@@ -149,9 +169,7 @@ EdlControlsModel::ResumePrimaryAuto() noexcept
   if (GetPrimaryAutoAdvance())
     return;
 
-  SetPrimaryAutoAdvance(true);
-  ApplyPrimaryAutoAdvance();
-  Notify(ControlsUpdate::OVERLAY);
+  EnablePrimaryAutoFromInput();
 }
 
 void
@@ -248,48 +266,44 @@ EdlControlsModel::OpenPrimaryPicker() noexcept
 {
   RebuildForecastTimes();
 
-  DataFieldEnum picker;
-  picker.ClearChoices();
-  picker.addEnumText(_("Auto"), TIME_PICKER_AUTO);
-  picker.addEnumText(_("Now"), TIME_PICKER_NOW);
+  StaticString<64> caption;
+  caption.Format("%s %s (UTC)", "EDL", _("Time"));
 
-  for (unsigned i = 0; i < forecast_choices; ++i) {
-    const auto local = forecast_times[i].ToLocal();
-    StaticString<16> label;
-    label.Format("%02u:00", unsigned(local.hour));
-    picker.addEnumText(label.c_str(), i);
-  }
+  OpenPrimaryTimePicker(*this, caption.c_str(),
+    [this](DataFieldEnum &field) noexcept {
+      field.ClearChoices();
 
-  if (GetPrimaryAutoAdvance())
-    picker.SetValue(TIME_PICKER_AUTO);
-  else
-    picker.SetValue(FindForecastIndex());
-
-  if (!ComboPicker(_("EDL Time"), picker, nullptr))
-    return;
-
-  const unsigned selected = picker.GetValue();
-  if (selected == TIME_PICKER_AUTO) {
-    ResumePrimaryAuto();
-    return;
-  }
-
-  if (selected == TIME_PICKER_NOW) {
-    const BrokenDateTime tracked = EDL::GetTrackedForecastTime(BrokenDateTime::NowUTC());
-    for (unsigned i = 0; i < forecast_choices; ++i) {
-      if (forecast_times[i] == tracked) {
-        SetPrimaryAutoAdvance(false);
-        SelectForecast(i);
-        Notify(ControlsUpdate::OVERLAY);
+      for (unsigned i = 0; i < forecast_choices; ++i) {
+        StaticString<16> label;
+        label.Format("%02u:00", unsigned(forecast_times[i].hour));
+        field.addEnumText(label.c_str(), i);
+      }
+    },
+    [this]() noexcept {
+      return FindForecastIndex();
+    },
+    [](ControlsModel &model) noexcept {
+      model.EnablePrimaryAutoFromInput();
+    },
+    [this](ControlsModel &) noexcept {
+      if (const auto tracked = FindTrackedForecastIndex()) {
+        ApplyManualPrimarySelection([this, tracked]() noexcept {
+          SelectForecast(*tracked);
+        });
         return;
       }
-    }
-    return;
-  } else if (selected < forecast_choices) {
-    SetPrimaryAutoAdvance(false);
-    SelectForecast(selected);
-    Notify(ControlsUpdate::OVERLAY);
-  }
+
+      const BrokenDateTime tracked =
+        EDL::GetTrackedForecastTime(BrokenDateTime::NowUTC());
+      ApplyManualPrimarySelection([this, tracked]() noexcept {
+        SelectForecastTime(tracked);
+      });
+    },
+    [this](ControlsModel &, unsigned index) noexcept {
+      ApplyManualPrimarySelection([this, index]() noexcept {
+        SelectForecast(index);
+      });
+    });
 }
 
 bool

--- a/src/Weather/MapOverlay/EdlControlsModel.cpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.cpp
@@ -5,6 +5,7 @@
 
 #include "ActionInterface.hpp"
 #include "Components.hpp"
+#include "Dialogs/ComboPicker.hpp"
 #include "Dialogs/Message.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
@@ -304,6 +305,46 @@ EdlControlsModel::OpenPrimaryPicker() noexcept
         SelectForecast(index);
       });
     });
+}
+
+SecondaryLabelAction
+EdlControlsModel::GetSecondaryLabelAction() const noexcept
+{
+  return SecondaryLabelAction::OPEN_PICKER;
+}
+
+void
+EdlControlsModel::OpenSecondaryPicker() noexcept
+{
+  EDL::EnsureInitialised();
+
+  DataFieldEnum field;
+  const unsigned active = EDL::GetIsobar();
+  unsigned current_index = 0;
+
+  for (unsigned i = 0; i < EDL::NUM_ISOBARS; ++i) {
+    const unsigned isobar = EDL::ISOBARS[i];
+    const int altitude = EDL::GetAltitudeForIsobar(isobar);
+
+    StaticString<32> label;
+    label.Format(_("%u hPa (%d m)"), isobar / 100, altitude);
+    field.addEnumText(label.c_str(), int(i));
+
+    if (isobar == active)
+      current_index = i;
+  }
+
+  field.SetValue(int(current_index));
+
+  if (!ComboPicker(_("EDL Level"), field, nullptr))
+    return;
+
+  const int selected = field.GetValue();
+  if (selected < 0 || unsigned(selected) >= EDL::NUM_ISOBARS)
+    return;
+
+  SelectLevel(EDL::ISOBARS[unsigned(selected)]);
+  Notify(ControlsUpdate::OVERLAY);
 }
 
 bool

--- a/src/Weather/MapOverlay/EdlControlsModel.hpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.hpp
@@ -57,8 +57,13 @@ public:
   void SetSecondaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplySecondaryAutoAdvance() noexcept override;
 
+  [[nodiscard]]
+  SecondaryLabelAction GetSecondaryLabelAction() const noexcept override;
+
   void ResumePrimaryAuto() noexcept override;
   void ResumeSecondaryAuto() noexcept override;
+
+  void OpenSecondaryPicker() noexcept override;
 
   void RefreshOverlay() noexcept override;
   void OnGPSUpdate(const MoreData &basic) noexcept override;

--- a/src/Weather/MapOverlay/EdlControlsModel.hpp
+++ b/src/Weather/MapOverlay/EdlControlsModel.hpp
@@ -10,6 +10,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 
 namespace WeatherMapOverlay {
 
@@ -67,11 +68,15 @@ public:
 private:
   void RebuildForecastTimes() noexcept;
   void SelectForecast(unsigned index) noexcept;
+  void SelectForecastTime(const BrokenDateTime &time) noexcept;
   void SelectLevel(unsigned isobar) noexcept;
   void UnregisterEdlDownloadListener() noexcept;
 
   [[nodiscard]] [[gnu::pure]]
   unsigned FindForecastIndex() const noexcept;
+
+  [[nodiscard]]
+  std::optional<unsigned> FindTrackedForecastIndex() const noexcept;
 
   [[nodiscard]]
   bool HasOverlayData() const noexcept;

--- a/src/Weather/MapOverlay/InputEventMisc.hpp
+++ b/src/Weather/MapOverlay/InputEventMisc.hpp
@@ -14,6 +14,7 @@ enum class OverlayInputAction {
   TIME_MINUS,
   ALTITUDE_PLUS,
   ALTITUDE_MINUS,
+  FIELD_PICKER,
   TIME_AUTO_TOGGLE,
   TIME_AUTO_ON,
   TIME_AUTO_OFF,
@@ -30,6 +31,8 @@ enum class OverlayInputAction {
  * Step commands use a common ``<axis> +/-`` form: ``time +``,
  * ``time -``, ``altitude +``, ``altitude -``. ``field +/-`` and EDL
  * ``level +/-`` are accepted as aliases for ``altitude +/-``.
+ * ``field picker``, ``layer picker``, and ``level picker`` open the
+ * secondary-axis list (RASP layer, EDL level, XCTherm layer).
  * Auto/manual commands use
  * ``<axis> auto …`` (``toggle``, ``on``, ``off``, ``show``).
  */
@@ -55,6 +58,11 @@ ParseOverlayInputAction(const char *misc) noexcept
       StringIsEqual(misc, "field -") ||
       StringIsEqual(misc, "level -"))
     return OverlayInputAction::ALTITUDE_MINUS;
+
+  if (StringIsEqual(misc, "field picker") ||
+      StringIsEqual(misc, "layer picker") ||
+      StringIsEqual(misc, "level picker"))
+    return OverlayInputAction::FIELD_PICKER;
 
   if (StringIsEqual(misc, "time auto toggle"))
     return OverlayInputAction::TIME_AUTO_TOGGLE;

--- a/src/Weather/MapOverlay/InputEventMisc.hpp
+++ b/src/Weather/MapOverlay/InputEventMisc.hpp
@@ -28,8 +28,9 @@ enum class OverlayInputAction {
  * Parse a ``WeatherOverlay`` misc argument.
  *
  * Step commands use a common ``<axis> +/-`` form: ``time +``,
- * ``time -``, ``altitude +``, ``altitude -``. EDL accepts ``level``
- * as an alias for ``altitude``. Auto/manual commands use
+ * ``time -``, ``altitude +``, ``altitude -``. ``field +/-`` and EDL
+ * ``level +/-`` are accepted as aliases for ``altitude +/-``.
+ * Auto/manual commands use
  * ``<axis> auto …`` (``toggle``, ``on``, ``off``, ``show``).
  */
 [[gnu::pure]]
@@ -46,9 +47,13 @@ ParseOverlayInputAction(const char *misc) noexcept
   if (StringIsEqual(misc, "time picker"))
     return OverlayInputAction::TIME_PICKER;
 
-  if (StringIsEqual(misc, "altitude +") || StringIsEqual(misc, "level +"))
+  if (StringIsEqual(misc, "altitude +") ||
+      StringIsEqual(misc, "field +") ||
+      StringIsEqual(misc, "level +"))
     return OverlayInputAction::ALTITUDE_PLUS;
-  if (StringIsEqual(misc, "altitude -") || StringIsEqual(misc, "level -"))
+  if (StringIsEqual(misc, "altitude -") ||
+      StringIsEqual(misc, "field -") ||
+      StringIsEqual(misc, "level -"))
     return OverlayInputAction::ALTITUDE_MINUS;
 
   if (StringIsEqual(misc, "time auto toggle"))
@@ -61,15 +66,19 @@ ParseOverlayInputAction(const char *misc) noexcept
     return OverlayInputAction::TIME_AUTO_SHOW;
 
   if (StringIsEqual(misc, "altitude auto toggle") ||
+      StringIsEqual(misc, "field auto toggle") ||
       StringIsEqual(misc, "level auto toggle"))
     return OverlayInputAction::ALTITUDE_AUTO_TOGGLE;
   if (StringIsEqual(misc, "altitude auto on") ||
+      StringIsEqual(misc, "field auto on") ||
       StringIsEqual(misc, "level auto on"))
     return OverlayInputAction::ALTITUDE_AUTO_ON;
   if (StringIsEqual(misc, "altitude auto off") ||
+      StringIsEqual(misc, "field auto off") ||
       StringIsEqual(misc, "level auto off"))
     return OverlayInputAction::ALTITUDE_AUTO_OFF;
   if (StringIsEqual(misc, "altitude auto show") ||
+      StringIsEqual(misc, "field auto show") ||
       StringIsEqual(misc, "level auto show"))
     return OverlayInputAction::ALTITUDE_AUTO_SHOW;
 

--- a/src/Weather/MapOverlay/PrimaryTimePicker.hpp
+++ b/src/Weather/MapOverlay/PrimaryTimePicker.hpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ControlsModel.hpp"
+#include "TimePicker.hpp"
+
+#include "Form/DataField/Enum.hpp"
+
+#include "util/Compiler.h"
+
+#include <utility>
+
+namespace WeatherMapOverlay {
+
+/**
+ * Shared primary time picker workflow with overlay-specific callbacks.
+ */
+template<typename BuildChoicesFn, typename CurrentValueFn,
+         typename ApplyAutoFn, typename ApplyNowFn, typename ApplyManualFn>
+void
+OpenPrimaryTimePicker(ControlsModel &model, const char *caption,
+                      BuildChoicesFn &&build_choices,
+                      CurrentValueFn &&current_value,
+                      ApplyAutoFn &&apply_auto,
+                      ApplyNowFn &&apply_now,
+                      ApplyManualFn &&apply_manual,
+                      bool enable_now = true) noexcept
+{
+  DataFieldEnum field;
+  build_choices(field);
+  field.SetValue(current_value());
+
+  const ComboList combo_list = field.CreateComboList(nullptr);
+  const TimePickerResult result =
+    RunTimePicker(caption, combo_list, enable_now);
+
+  switch (result.selection) {
+  case TimePickerSelection::CANCEL:
+    return;
+
+  case TimePickerSelection::AUTO:
+    apply_auto(model);
+    return;
+
+  case TimePickerSelection::NOW:
+    apply_now(model);
+    return;
+
+  case TimePickerSelection::MANUAL:
+    apply_manual(model, combo_list[result.manual_index].int_value);
+    return;
+
+  case TimePickerSelection::COUNT:
+    break;
+  }
+
+  gcc_unreachable();
+}
+
+} // namespace WeatherMapOverlay

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -10,23 +10,17 @@
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "PageActions.hpp"
+#include "PrimaryTimePicker.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
 #include "UIState.hpp"
+#include "util/StaticString.hxx"
 
 #ifdef HAVE_DOWNLOAD_MANAGER
 #include "Weather/Rasp/DownloadGlue.hpp"
 #endif
 
-#include <cstdio>
-#include <limits>
-
 namespace WeatherMapOverlay {
-
-static constexpr unsigned TIME_PICKER_AUTO =
-  std::numeric_limits<unsigned>::max() - 1;
-static constexpr unsigned TIME_PICKER_NOW =
-  std::numeric_limits<unsigned>::max();
 
 void
 RaspControlsModel::OnShow() noexcept
@@ -87,6 +81,18 @@ void
 RaspControlsModel::ApplyPrimaryAutoAdvance() noexcept
 {
   Rasp::ApplyAutoAdvanceTime();
+  last_quarter = unsigned(-1);
+}
+
+void
+RaspControlsModel::EnablePrimaryAutoFromInput() noexcept
+{
+  EnablePrimaryAutoAndRefresh();
+
+#ifdef HAVE_DOWNLOAD_MANAGER
+  if (!Rasp::HasSelectedTimeData(true))
+    RequestConfiguredRaspUpdateIfOutOfDate();
+#endif
 }
 
 PrimaryLabelAction
@@ -111,39 +117,32 @@ RaspControlsModel::OpenPrimaryPicker() noexcept
       unsigned(field_index) >= rasp->GetItemCount())
     return;
 
-  DataFieldEnum time;
-  time.ClearChoices();
-  time.addEnumText(_("Auto"), TIME_PICKER_AUTO);
-  time.addEnumText(_("Now"), TIME_PICKER_NOW);
+  OpenPrimaryTimePicker(*this, _("RASP Time"),
+    [&](DataFieldEnum &field) noexcept {
+      field.ClearChoices();
 
-  for (unsigned i = 0; i < RaspStore::MAX_WEATHER_TIMES; ++i) {
-    const BrokenTime t = RaspStore::IndexToTime(i);
-    char label[24];
-    std::snprintf(label, sizeof(label), "%02u:%02u %s",
-                  unsigned(t.hour), unsigned(t.minute),
-                  rasp->IsTimeAvailable(unsigned(field_index), i)
-                  ? "[x]" : "[ ]");
-    time.addEnumText(label, t.GetMinuteOfDay());
-  }
-
-  const auto &weather = CommonInterface::GetUIState().weather;
-  if (weather.time_auto_advance)
-    time.SetValue(TIME_PICKER_AUTO);
-  else if (!weather.time.IsPlausible())
-    time.SetValue(TIME_PICKER_NOW);
-  else
-    time.SetValue(weather.time.GetMinuteOfDay());
-
-  if (!ComboPicker(_("RASP Time"), time, nullptr))
-    return;
-
-  const unsigned selected = time.GetValue();
-  if (selected == TIME_PICKER_AUTO)
-    Rasp::ResumeAutoAdvance();
-  else if (selected == TIME_PICKER_NOW)
-    Rasp::SetCursorNow();
-  else
-    Rasp::SetCursorTime(selected);
+      for (unsigned i = 0; i < RaspStore::MAX_WEATHER_TIMES; ++i) {
+        const BrokenTime t = RaspStore::IndexToTime(i);
+        StaticString<24> label;
+        label.Format("%02u:%02u %s",
+                     unsigned(t.hour), unsigned(t.minute),
+                     rasp->IsTimeAvailable(unsigned(field_index), i)
+                     ? "[x]" : "[ ]");
+        field.addEnumText(label.c_str(), t.GetMinuteOfDay());
+      }
+    },
+    []() noexcept {
+      return Rasp::GetCursorBarMinuteOfDay();
+    },
+    [](ControlsModel &model) noexcept {
+      model.EnablePrimaryAutoFromInput();
+    },
+    [](ControlsModel &) noexcept {
+      Rasp::SetCursorNow();
+    },
+    [](ControlsModel &, unsigned minute_of_day) noexcept {
+      Rasp::SetCursorTime(minute_of_day);
+    });
 }
 
 void
@@ -152,14 +151,7 @@ RaspControlsModel::ResumePrimaryAuto() noexcept
   if (GetPrimaryAutoAdvance())
     return;
 
-  Rasp::ResumeAutoAdvance();
-  last_quarter = unsigned(-1);
-  Notify(ControlsUpdate::OVERLAY);
-
-#ifdef HAVE_DOWNLOAD_MANAGER
-  if (!Rasp::HasSelectedTimeData(true))
-    RequestConfiguredRaspUpdateIfOutOfDate();
-#endif
+  EnablePrimaryAutoFromInput();
 }
 
 void

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -179,6 +179,7 @@ RaspControlsModel::OpenSecondaryPicker() noexcept
   }
 
   Rasp::SelectField(unsigned(selected));
+  Notify(ControlsUpdate::OVERLAY);
 }
 
 void

--- a/src/Weather/MapOverlay/RaspControlsModel.cpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.cpp
@@ -184,7 +184,6 @@ RaspControlsModel::OpenSecondaryPicker() noexcept
 void
 RaspControlsModel::RefreshOverlay() noexcept
 {
-  ActionInterface::SendUIState(true);
 }
 
 void

--- a/src/Weather/MapOverlay/RaspControlsModel.hpp
+++ b/src/Weather/MapOverlay/RaspControlsModel.hpp
@@ -32,6 +32,7 @@ public:
   bool GetPrimaryAutoAdvance() const noexcept override;
   void SetPrimaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplyPrimaryAutoAdvance() noexcept override;
+  void EnablePrimaryAutoFromInput() noexcept override;
 
   [[nodiscard]]
   PrimaryLabelAction GetPrimaryLabelAction() const noexcept override;

--- a/src/Weather/MapOverlay/TimePicker.cpp
+++ b/src/Weather/MapOverlay/TimePicker.cpp
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "TimePicker.hpp"
+
+#include "Dialogs/ComboPicker.hpp"
+#include "Form/Form.hpp"
+#include "Language/Language.hpp"
+
+namespace WeatherMapOverlay {
+
+TimePickerResult
+RunTimePicker(const char *caption,
+              const ComboList &choices,
+              const bool enable_now) noexcept
+{
+  const int selected_index =
+    ComboPicker(caption, choices, nullptr, false, _("Auto"),
+                enable_now ? _("Now") : nullptr);
+
+  TimePickerResult result;
+  if (selected_index == mrExtra) {
+    result.selection = TimePickerSelection::AUTO;
+    return result;
+  }
+
+  if (selected_index == mrExtra2) {
+    result.selection = TimePickerSelection::NOW;
+    return result;
+  }
+
+  if (selected_index < 0)
+    return result;
+
+  result.selection = TimePickerSelection::MANUAL;
+  result.manual_index = unsigned(selected_index);
+  return result;
+}
+
+} // namespace WeatherMapOverlay

--- a/src/Weather/MapOverlay/TimePicker.hpp
+++ b/src/Weather/MapOverlay/TimePicker.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Form/DataField/ComboList.hpp"
+
+#include <cstdint>
+
+namespace WeatherMapOverlay {
+
+enum class TimePickerSelection : uint8_t {
+  CANCEL,
+  AUTO,
+  NOW,
+  MANUAL,
+  COUNT,
+};
+
+struct TimePickerResult {
+  TimePickerSelection selection = TimePickerSelection::CANCEL;
+  unsigned manual_index = 0;
+};
+
+/**
+ * Weather forecast time picker with dedicated Auto / Now buttons.
+ */
+[[nodiscard]]
+TimePickerResult
+RunTimePicker(const char *caption,
+              const ComboList &choices,
+              bool enable_now = true) noexcept;
+
+} // namespace WeatherMapOverlay

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -3,7 +3,6 @@
 
 #include "XcthermControlsModel.hpp"
 
-#include "ActionInterface.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "PrimaryTimePicker.hpp"
@@ -303,7 +302,6 @@ XcthermControlsModel::RefreshOverlay() noexcept
     backend.ApplyCurrentSelectionToMap();
   });
 #endif
-  ActionInterface::SendUIState(true);
 }
 
 } // namespace WeatherMapOverlay

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -3,12 +3,14 @@
 
 #include "XcthermControlsModel.hpp"
 
+#include "Dialogs/ComboPicker.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "PrimaryTimePicker.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "util/StaticString.hxx"
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
+#include "Weather/xctherm/XCThermCatalog.hpp"
 
 #include <algorithm>
 
@@ -257,6 +259,56 @@ XcthermControlsModel::SetSecondaryAutoAdvance(bool auto_advance) noexcept
   });
 #else
   (void)auto_advance;
+#endif
+}
+
+SecondaryLabelAction
+XcthermControlsModel::GetSecondaryLabelAction() const noexcept
+{
+  return SecondaryLabelAction::OPEN_PICKER;
+}
+
+void
+XcthermControlsModel::OpenSecondaryPicker() noexcept
+{
+#ifdef HAVE_HTTP
+  const auto &settings =
+    CommonInterface::GetComputerSettings().weather.xctherm;
+  const auto &region = XCTherm::GetRegion(settings.model);
+  if (region.layer_count == 0)
+    return;
+
+  DataFieldEnum field;
+  unsigned current_layer = 0;
+
+  WithBackend([&](const XCTherm::XCThermControlsModel &backend) noexcept {
+    current_layer = backend.GetCurrentLayer();
+  });
+
+  for (unsigned i = 0; i < region.layer_count; ++i) {
+    field.addEnumText(gettext(region.layers[i].short_label), int(i));
+  }
+
+  field.SetValue(int(current_layer));
+
+  if (!ComboPicker(_("XCTherm Altitude"), field, nullptr))
+    return;
+
+  const int selected = field.GetValue();
+  if (selected < 0 || unsigned(selected) >= region.layer_count)
+    return;
+
+  const auto &basic = CommonInterface::Basic();
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.SetAltitudeAutoAdvance(false, basic);
+    backend.SetCurrentLayer(unsigned(selected));
+    backend.ApplyCurrentSelectionToMap();
+    backend.SaveCursorSession();
+  });
+
+  Notify(ControlsUpdate::OVERLAY);
+#else
+  (void)0;
 #endif
 }
 

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -4,56 +4,31 @@
 #include "XcthermControlsModel.hpp"
 
 #include "ActionInterface.hpp"
-#include "Dialogs/ComboPicker.hpp"
-#include "Form/DataField/Enum.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "PrimaryTimePicker.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "util/StaticString.hxx"
 #include "Weather/MapOverlay/CursorBarLabels.hpp"
 
-#ifdef HAVE_HTTP
-#include "Weather/xctherm/XCThermControlsModel.hpp"
-#endif
-
 #include <algorithm>
-#include <cstdio>
-#include <limits>
 
 namespace WeatherMapOverlay {
-
-static constexpr unsigned TIME_PICKER_AUTO =
-  std::numeric_limits<unsigned>::max() - 1;
-static constexpr unsigned TIME_PICKER_NOW =
-  std::numeric_limits<unsigned>::max();
-
-XcthermControlsModel::XcthermControlsModel() noexcept
-{
-#ifdef HAVE_HTTP
-  model = new XCTherm::XCThermControlsModel();
-#endif
-}
-
-XcthermControlsModel::~XcthermControlsModel() noexcept
-{
-#ifdef HAVE_HTTP
-  delete model;
-#endif
-}
 
 void
 XcthermControlsModel::OnShow() noexcept
 {
 #ifdef HAVE_HTTP
-  if (model == nullptr)
-    return;
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    if (!prepared) {
+      backend.Prepare([this]() noexcept {
+        Notify(ControlsUpdate::LABELS);
+      });
+      prepared = true;
+    }
 
-  if (!prepared) {
-    model->Prepare([this]() noexcept {
-      Notify(ControlsUpdate::LABELS);
-    });
-    prepared = true;
-  }
-
-  model->OnShow();
+    backend.OnShow();
+  });
 #endif
 }
 
@@ -61,8 +36,9 @@ void
 XcthermControlsModel::OnHide() noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->OnHide();
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.OnHide();
+  });
 #endif
 }
 
@@ -70,86 +46,103 @@ void
 XcthermControlsModel::FormatPrimaryLabel(StaticString<64> &text) const noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr) {
-    model->FormatTimeLabel(text);
-    return;
-  }
-#endif
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.FormatTimeLabel(text);
+  });
+  if (text.empty())
+    text = "XCTherm";
+#else
   text = "XCTherm";
+#endif
 }
 
 void
 XcthermControlsModel::FormatSecondaryLabel(StaticString<64> &text) const noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr) {
+  WithBackend([&](const XCTherm::XCThermControlsModel &backend) noexcept {
     StaticString<80> layer_text;
-    model->FormatLayerLabel(layer_text);
+    backend.FormatLayerLabel(layer_text);
     text = layer_text;
-    return;
-  }
-#endif
+  });
+  if (text.empty())
+    text = NoForecastHint();
+#else
   text = NoForecastHint();
+#endif
 }
 
 bool
 XcthermControlsModel::HasPrimaryData() const noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->HasCacheAtCurrentHour(model->GetCurrentLayer());
-#endif
+  bool has_data = false;
+  WithBackend([&](const XCTherm::XCThermControlsModel &backend) noexcept {
+    has_data = backend.HasCacheAtCurrentHour(backend.GetCurrentLayer());
+  });
+  return has_data;
+#else
   return false;
+#endif
 }
 
 bool
 XcthermControlsModel::HasSecondaryData() const noexcept
 {
-#ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->HasCacheAtCurrentHour(model->GetCurrentLayer());
-#endif
-  return false;
+  return HasPrimaryData();
 }
 
 bool
 XcthermControlsModel::StepPrimary(int delta) noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->StepTime(delta);
-#endif
+  bool stepped = true;
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    stepped = backend.StepTime(delta);
+  });
+  return stepped;
+#else
   (void)delta;
   return true;
+#endif
 }
 
 bool
 XcthermControlsModel::StepSecondary(int delta) noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->StepLayer(delta);
-#endif
+  bool stepped = true;
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    stepped = backend.StepLayer(delta);
+  });
+  return stepped;
+#else
   (void)delta;
   return true;
+#endif
 }
 
 bool
 XcthermControlsModel::GetPrimaryAutoAdvance() const noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->IsTimeAutoActive();
-#endif
+  bool active = true;
+  WithBackend([&](const XCTherm::XCThermControlsModel &backend) noexcept {
+    active = backend.IsTimeAutoActive();
+  });
+  return active;
+#else
   return true;
+#endif
 }
 
 void
 XcthermControlsModel::SetPrimaryAutoAdvance(bool auto_advance) noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->SetTimeAutoAdvance(auto_advance);
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.SetTimeAutoAdvance(auto_advance);
+  });
 #else
   (void)auto_advance;
 #endif
@@ -158,6 +151,19 @@ XcthermControlsModel::SetPrimaryAutoAdvance(bool auto_advance) noexcept
 void
 XcthermControlsModel::ApplyPrimaryAutoAdvance() noexcept
 {
+}
+
+void
+XcthermControlsModel::EnablePrimaryAutoFromInput() noexcept
+{
+#ifdef HAVE_HTTP
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.ResumeTimeAuto();
+    backend.ApplyCurrentSelectionToMap();
+    backend.SaveCursorSession();
+  });
+#endif
+  Notify(ControlsUpdate::OVERLAY);
 }
 
 PrimaryLabelAction
@@ -170,60 +176,55 @@ void
 XcthermControlsModel::OpenPrimaryPicker() noexcept
 {
 #ifdef HAVE_HTTP
-  if (model == nullptr)
-    return;
+  const bool time_plausible =
+    CommonInterface::Basic().date_time_utc.IsPlausible();
 
-  DataFieldEnum picker;
-  picker.ClearChoices();
-  picker.addEnumText(_("Auto"), TIME_PICKER_AUTO);
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    const auto persist = [this, &backend]() noexcept {
+      backend.ApplyCurrentSelectionToMap();
+      backend.SaveCursorSession();
+      NotifyOverlay();
+    };
 
-  const auto &state = model->GetState();
-  const auto &cached_hours = state.cached_hours;
-  const auto &basic = CommonInterface::Basic();
-  const bool time_plausible = basic.date_time_utc.IsPlausible();
-  if (time_plausible)
-    picker.addEnumText(_("Now"), TIME_PICKER_NOW);
+    StaticString<64> caption;
+    caption.Format("%s %s (UTC)", "XCTherm", _("Time"));
 
-  for (unsigned hour = 0; hour < 24; ++hour) {
-    char label[20];
-    const bool has_data =
-      std::find(cached_hours.begin(), cached_hours.end(), hour) !=
-      cached_hours.end();
-    std::snprintf(label, sizeof(label), "%02u:00 %s", hour,
-                  has_data ? "[x]" : "[ ]");
-    picker.addEnumText(label, hour);
-  }
+    OpenPrimaryTimePicker(*this, caption.c_str(),
+      [&backend](DataFieldEnum &field) noexcept {
+        field.ClearChoices();
 
-  if (model->IsTimeAutoActive()) {
-    picker.SetValue(TIME_PICKER_AUTO);
-  } else {
-    if (!time_plausible)
-      picker.SetValue(model->GetCurrentForecastHour());
-    else {
-      const unsigned now_hour = unsigned(basic.date_time_utc.hour);
-      picker.SetValue(model->GetCurrentForecastHour() == now_hour
-                      ? TIME_PICKER_NOW
-                      : model->GetCurrentForecastHour());
-    }
-  }
+        const auto &cached_hours = backend.GetCachedHours();
+        for (unsigned hour = 0; hour < 24; ++hour) {
+          StaticString<20> label;
+          const bool has_data =
+            std::find(cached_hours.begin(), cached_hours.end(), hour) !=
+            cached_hours.end();
+          label.Format("%02u:00 %s", hour, has_data ? "[x]" : "[ ]");
+          field.addEnumText(label.c_str(), hour);
+        }
+      },
+      [&backend]() noexcept {
+        return backend.GetCurrentForecastHour();
+      },
+      [](ControlsModel &model) noexcept {
+        model.EnablePrimaryAutoFromInput();
+      },
+      [&backend, &persist](ControlsModel &) noexcept {
+        const auto &basic = CommonInterface::Basic();
+        if (!basic.date_time_utc.IsPlausible())
+          return;
 
-  if (!ComboPicker(_("XCTherm Time"), picker, nullptr))
-    return;
-
-  const unsigned selected = picker.GetValue();
-  if (selected == TIME_PICKER_AUTO) {
-    model->ResumeTimeAuto();
-  } else if (selected == TIME_PICKER_NOW && time_plausible) {
-    model->SetTimeAutoAdvance(false);
-    model->SetCurrentTimeIndex(unsigned(basic.date_time_utc.hour));
-  } else {
-    model->SetTimeAutoAdvance(false);
-    model->SetCurrentTimeIndex(selected);
-  }
-
-  model->ApplyCurrentSelectionToMap();
-  model->SaveCursorSession();
-  Notify(ControlsUpdate::OVERLAY);
+        backend.SetTimeAutoAdvance(false);
+        backend.SetCurrentTimeIndex(unsigned(basic.date_time_utc.hour));
+        persist();
+      },
+      [&backend, &persist](ControlsModel &, unsigned hour) noexcept {
+        backend.SetTimeAutoAdvance(false);
+        backend.SetCurrentTimeIndex(hour);
+        persist();
+      },
+      time_plausible);
+  });
 #endif
 }
 
@@ -237,18 +238,24 @@ bool
 XcthermControlsModel::GetSecondaryAutoAdvance() const noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    return model->IsAltitudeAutoActive();
-#endif
+  bool active = true;
+  WithBackend([&](const XCTherm::XCThermControlsModel &backend) noexcept {
+    active = backend.IsAltitudeAutoActive();
+  });
+  return active;
+#else
   return true;
+#endif
 }
 
 void
 XcthermControlsModel::SetSecondaryAutoAdvance(bool auto_advance) noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->SetAltitudeAutoAdvance(auto_advance, CommonInterface::Basic());
+  const auto &basic = CommonInterface::Basic();
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.SetAltitudeAutoAdvance(auto_advance, basic);
+  });
 #else
   (void)auto_advance;
 #endif
@@ -257,19 +264,20 @@ XcthermControlsModel::SetSecondaryAutoAdvance(bool auto_advance) noexcept
 void
 XcthermControlsModel::ResumePrimaryAuto() noexcept
 {
-#ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->ResumeTimeAuto();
-#endif
-  Notify(ControlsUpdate::OVERLAY);
+  if (GetPrimaryAutoAdvance())
+    return;
+
+  EnablePrimaryAutoFromInput();
 }
 
 void
 XcthermControlsModel::ResumeSecondaryAuto() noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->ResumeLayerAuto(CommonInterface::Basic());
+  const auto &basic = CommonInterface::Basic();
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.ResumeLayerAuto(basic);
+  });
 #endif
   Notify(ControlsUpdate::OVERLAY);
 }
@@ -278,8 +286,9 @@ void
 XcthermControlsModel::OnGPSUpdate(const MoreData &basic) noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->OnGPSUpdate(basic);
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.OnGPSUpdate(basic);
+  });
 #else
   (void)basic;
 #endif
@@ -290,8 +299,9 @@ void
 XcthermControlsModel::RefreshOverlay() noexcept
 {
 #ifdef HAVE_HTTP
-  if (model != nullptr)
-    model->ApplyCurrentSelectionToMap();
+  WithBackend([&](XCTherm::XCThermControlsModel &backend) noexcept {
+    backend.ApplyCurrentSelectionToMap();
+  });
 #endif
   ActionInterface::SendUIState(true);
 }

--- a/src/Weather/MapOverlay/XcthermControlsModel.hpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.hpp
@@ -61,6 +61,10 @@ public:
   void OpenPrimaryPicker() noexcept override;
 
   [[nodiscard]]
+  SecondaryLabelAction GetSecondaryLabelAction() const noexcept override;
+  void OpenSecondaryPicker() noexcept override;
+
+  [[nodiscard]]
   bool SupportsSecondaryAutoAdvance() const noexcept override;
   [[nodiscard]]
   bool GetSecondaryAutoAdvance() const noexcept override;

--- a/src/Weather/MapOverlay/XcthermControlsModel.hpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.hpp
@@ -6,9 +6,7 @@
 #include "ControlsModel.hpp"
 
 #ifdef HAVE_HTTP
-namespace XCTherm {
-class XCThermControlsModel;
-}
+#include "Weather/xctherm/XCThermControlsModel.hpp"
 #endif
 
 namespace WeatherMapOverlay {
@@ -16,13 +14,26 @@ namespace WeatherMapOverlay {
 /** Weather cursor-bar model backed by XCTherm controls state. */
 class XcthermControlsModel final : public ControlsModel {
 #ifdef HAVE_HTTP
+  mutable XCTherm::XCThermControlsModel backend;
   bool prepared = false;
-  XCTherm::XCThermControlsModel *model = nullptr;
-#endif
-public:
-  XcthermControlsModel() noexcept;
-  ~XcthermControlsModel() noexcept override;
 
+  template<typename F>
+  void WithBackend(F &&f) noexcept
+  {
+    std::forward<F>(f)(backend);
+  }
+
+  template<typename F>
+  void WithBackend(F &&f) const noexcept
+  {
+    std::forward<F>(f)(backend);
+  }
+#else
+  template<typename F>
+  void WithBackend(F &&) noexcept {}
+#endif
+
+public:
   void OnShow() noexcept override;
   void OnHide() noexcept override;
 
@@ -43,6 +54,8 @@ public:
   bool GetPrimaryAutoAdvance() const noexcept override;
   void SetPrimaryAutoAdvance(bool auto_advance) noexcept override;
   void ApplyPrimaryAutoAdvance() noexcept override;
+  void EnablePrimaryAutoFromInput() noexcept override;
+
   [[nodiscard]]
   PrimaryLabelAction GetPrimaryLabelAction() const noexcept override;
   void OpenPrimaryPicker() noexcept override;

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -545,6 +545,17 @@ MaybeRequestConfiguredRaspUpdateOnAutoNoData() noexcept
 #endif
 }
 
+unsigned
+GetCursorBarMinuteOfDay() noexcept
+{
+  const BrokenTime effective =
+    GetEffectiveLocalTime(GetTimeAutoAdvance());
+  if (!effective.IsPlausible())
+    return 0;
+
+  return effective.GetMinuteOfDay();
+}
+
 void
 FormatTimeCursorLabel(StaticString<64> &text, bool auto_advance) noexcept
 {

--- a/src/Weather/Rasp/FieldControls.cpp
+++ b/src/Weather/Rasp/FieldControls.cpp
@@ -363,35 +363,6 @@ HasSelectedField() noexcept
   return GetFieldCount() > 0 && GetEffectiveFieldIndex() >= 0;
 }
 
-StaticString<64>
-GetPanOverlayLabel(const PageLayout &configured) noexcept
-{
-  StaticString<64> label;
-
-  if (configured.overlay != PageLayout::Overlay::RASP)
-    return label;
-
-  const auto rasp = DataGlobals::GetRasp();
-  if (rasp == nullptr || rasp->GetItemCount() == 0)
-    return label;
-
-  const int field_index = GetFieldIndex(configured);
-  if (field_index < 0)
-    return label;
-
-  const char *field_label =
-    GetFieldLabel(rasp->GetItemInfo(unsigned(field_index)));
-
-  const auto &weather = CommonInterface::GetUIState().weather;
-  if (weather.time_auto_advance || !weather.time.IsPlausible())
-    label.Format(_("RASP %s"), field_label);
-  else
-    label.Format(_("RASP %s %02u:%02u"), field_label,
-                 weather.time.hour, weather.time.minute);
-
-  return label;
-}
-
 static BrokenTime
 GetLocalTimeNow() noexcept
 {

--- a/src/Weather/Rasp/FieldControls.hpp
+++ b/src/Weather/Rasp/FieldControls.hpp
@@ -163,12 +163,6 @@ bool
 HasSelectedField() noexcept;
 
 /**
- * Compact label for the active RASP field (map-scale PAN string).
- */
-StaticString<64>
-GetPanOverlayLabel(const PageLayout &configured) noexcept;
-
-/**
  * Cursor-bar time label, e.g. @c "14:30 (+0:15)" or @c "AUTO: …".
  *
  * When @p auto_advance is true, the display follows GPS local time ("Now").

--- a/src/Weather/Rasp/FieldControls.hpp
+++ b/src/Weather/Rasp/FieldControls.hpp
@@ -177,6 +177,13 @@ void
 FormatTimeCursorLabel(StaticString<64> &text, bool auto_advance) noexcept;
 
 /**
+ * Minute-of-day for the effective cursor-bar time (manual or AUTO).
+ */
+[[gnu::pure]]
+unsigned
+GetCursorBarMinuteOfDay() noexcept;
+
+/**
  * Return true when the active RASP field has raster data for the
  * effective cursor-bar time ("Now"/AUTO or manual selection).
  *

--- a/src/Weather/xctherm/XCThermMapOverlay.cpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.cpp
@@ -266,36 +266,33 @@ IsDedicatedPageSuspendedForPan() noexcept
   return CommonInterface::GetUIState().weather.xctherm.IsSuspendedForPan();
 }
 
-StaticString<64>
-GetPanOverlayLabel() noexcept
+void
+FormatLayerTitleLabel(StaticString<64> &text) noexcept
 {
-  StaticString<64> label;
-#ifdef ENABLE_OPENGL
-  const auto *map = UIGlobals::GetMap();
-  if (map != nullptr) {
-    const auto *xctherm =
-      dynamic_cast<const XCThermGeoJSONOverlay *>(map->GetOverlay());
-    if (xctherm != nullptr) {
-      const char *layer = xctherm->GetLabel();
-      if (layer != nullptr && *layer != '\0') {
-        label.Format(_("XCTherm %s"), layer);
-        return label;
-      }
-    }
-  }
-#endif
+  text.clear();
 
+  const auto &weather = CommonInterface::GetUIState().weather;
   const auto &settings =
     CommonInterface::GetComputerSettings().weather.xctherm;
-  const int li = FindActiveLayerIndex(settings);
-  if (li >= 0) {
-    label.Format(_("XCTherm %s"),
-                 gettext(GetRegion(settings.model)
-                           .layers[unsigned(li)].short_label));
-  } else
-    label = "XCTherm";
+  const auto &region = GetRegion(settings.model);
 
-  return label;
+  unsigned layer_index = 0;
+  if (weather.xctherm.cursor_initialized) {
+    if (weather.xctherm_cursor.layer >= region.layer_count)
+      return;
+
+    layer_index = weather.xctherm_cursor.layer;
+  } else {
+    const int li = FindActiveLayerIndex(settings);
+    if (li < 0)
+      return;
+
+    layer_index = unsigned(li);
+  }
+
+  const char *label = gettext(region.layers[layer_index].short_label);
+  if (label != nullptr && *label != '\0')
+    text = label;
 }
 
 bool

--- a/src/Weather/xctherm/XCThermMapOverlay.hpp
+++ b/src/Weather/xctherm/XCThermMapOverlay.hpp
@@ -62,9 +62,9 @@ void ResumeDedicatedPageAfterPan() noexcept;
 bool IsDedicatedPageSuspendedForPan() noexcept;
 
 /**
- * Compact label for the active forecast overlay (map-scale PAN string).
+ * Short layer label for map page titles (e.g. @c "1500m AMSL"), or empty.
  */
-StaticString<64> GetPanOverlayLabel() noexcept;
+void FormatLayerTitleLabel(StaticString<64> &text) noexcept;
 
 /**
  * Apply a cached slice to the map.

--- a/test/src/PageOverlayTitleStub.cpp
+++ b/test/src/PageOverlayTitleStub.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "PageOverlayTitle.hpp"
+
+#include "Language/Language.hpp"
+#include "Weather/Rasp/RaspStore.hpp"
+#include "util/StringBuilder.hxx"
+
+#include "util/Compiler.h"
+
+void
+AppendOverlayTitle(BasicStringBuilder<char> &builder,
+                   const PageLayout &layout,
+                   const RaspStore *rasp)
+{
+  switch (layout.overlay) {
+  case PageLayout::Overlay::NONE:
+    break;
+
+  case PageLayout::Overlay::RASP:
+    builder.Append(", RASP");
+    if (rasp != nullptr &&
+        layout.rasp_field >= 0 &&
+        unsigned(layout.rasp_field) < rasp->GetItemCount()) {
+      const auto &item = rasp->GetItemInfo(layout.rasp_field);
+      const char *label = item.label != nullptr
+        ? gettext(item.label)
+        : item.name;
+      if (label != nullptr && *label != '\0') {
+        builder.Append(' ');
+        builder.Append(label);
+      }
+    }
+    break;
+
+  case PageLayout::Overlay::EDL:
+    builder.Append(", EDL");
+    break;
+
+  case PageLayout::Overlay::XCTHERM:
+    builder.Append(", XCTherm");
+    break;
+
+  case PageLayout::Overlay::MAX:
+    gcc_unreachable();
+  }
+}


### PR DESCRIPTION
## Summary

Improve in-flight control of RASP, EDL, and XCTherm map overlays without leaving the map page.

- **Unified time picker** — shared `TimePicker` with Auto, Now, and manual selection for all three overlays; RETURN opens it in weather mode
- **Secondary-axis picker** — ComboPicker lists for RASP layers, EDL levels, and XCTherm altitude bands; tap the cursor-bar label or use F2 / on-screen **+**
- **List and auto at zoom positions** — on weather pages, map **+** / **−** and menubar slots 2–3 open the list and toggle auto (secondary axis on EDL/XCTherm; time auto on RASP)
- **Overlay-specific labels** — menubar captions adapt (Layer/Level/Altitude, Field+/−, auto hints)
- **`mode=weather` layout** — time−, list, auto, time+ on slots 1–4; field step on 5–6; time picker on 7; consolidated in a single `default.xci` commit
- **Map title** — shows the active weather layer name when applicable
- **InfoBox fix** — prevent crash when reopening dialogs after window recreation

## Input (`mode=weather`)

| Input | Action |
|-------|--------|
| UP / DOWN | Step secondary axis (layer / level / altitude) |
| LEFT / RIGHT | Step forecast time |
| RETURN | Open time picker |
| F2 / **+** | Open secondary list |
| F3 / **−** | Toggle auto |
| ESCAPE | Exit weather mode |

Enter via RemoteStick **Forecast Controls** or `Mode weather`. See `doc/input_events.rst` for full details.

## Test plan

- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y`
- [x] `make everything check` (98 tests)
- [x] RASP / EDL / XCTherm overlay pages: verify menubar slots 1–7 in portrait and landscape
- [x] RETURN opens time picker with Auto / Now / manual paths
- [x] F2, **+**, and secondary label tap open the correct list per overlay
- [x] F3 and **−** toggle the expected auto mode (time auto on RASP)
- [x] Map title reflects active layer after picker or stick changes
- [x] InfoBox survives dialog close/reopen cycle

Refs #2690