### PR TITLE
Fix reading SeeYou .cup files with Angled ObservationZones

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -278,6 +278,9 @@ Version 7.45 - not yet released
   - add NOTAM settings and filters (IFR, effective time, max radius, hidden Q-codes)
   - add NOTAM details integration in airspace dialogs
 * data files
+  - .cup tasks: More correctly parse SeeYou .cup task files with observation zones 
+    with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder. 
+    Previously these were incorrectly parsed into FAI Quadrants #2697
   - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
     is read correctly
   - openair: map AY ASRA to aerial sporting/recreational airspace type #1827

--- a/src/Engine/Task/ObservationZones/SymmetricSectorZone.hpp
+++ b/src/Engine/Task/ObservationZones/SymmetricSectorZone.hpp
@@ -58,6 +58,25 @@ public:
   }
 
   /**
+   * An arbitrary angle circular sector centered at the bisector of incoming/outgoing legs
+   * Similar to an FAI quadrant but with configurable radius or other angles than 90 degrees
+   *
+   * @param radius1 The radius of the sector
+   * @param angle1 The angle of the sector, where 180 is a half-circle
+
+   */
+  static auto CreateSymmetricCircularSectorZone(const GeoPoint loc,
+                                  const double radius,
+                                  const Angle angle
+                                  ) noexcept {
+    std::unique_ptr<SymmetricSectorZone> oz(new SymmetricSectorZone(Shape::SYMMETRIC_QUADRANT, true, false, loc,
+                                                                    radius,
+                                                                    angle));
+    oz->UpdateSector();
+    return oz;
+  }
+
+  /**
    * Create a 180 degree sector centered at the inverse of the
    * outgoing leg.
    *
@@ -71,9 +90,9 @@ public:
     return oz;
   }
 
-  /** 
+  /**
    * Accessor for angle of sector (angle between start/end radials)
-   * 
+   *
    * @return Angle (deg) of sector
    */
   constexpr Angle GetSectorAngle() const noexcept {

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -125,9 +125,11 @@ DeserialiseOZ(const Waypoint &wp, const ConstDataNode &node, bool is_turnpoint)
     return SymmetricSectorZone::CreateFAISectorZone(wp.location, is_turnpoint);
   else if (StringIsEqual(type, "SymmetricQuadrant")) {
     double radius = 10000;
+    Angle angle = Angle::QuarterCircle();
     node.GetAttribute("radius", radius);
+    node.GetAttribute("angle", angle);
 
-    return std::make_unique<SymmetricSectorZone>(wp.location, radius);
+    return SymmetricSectorZone::CreateSymmetricCircularSectorZone(wp.location, radius, angle);
   } else if (StringIsEqual(type, "Keyhole"))
     return KeyholeZone::CreateDAeCKeyholeZone(wp.location);
   else if (StringIsEqual(type, "CustomKeyhole")) {
@@ -206,7 +208,7 @@ DeserialiseTaskpoint(AbstractTaskFactory &fact, const ConstDataNode &node,
     pt = oz != nullptr
       ? fact.CreateFinish(std::move(oz), std::move(wp))
       : fact.CreateFinish(std::move(wp));
-  } 
+  }
 
   if (!pt)
     return;
@@ -314,7 +316,7 @@ LoadTask(OrderedTask &task, const ConstDataNode &node,
     DeserialiseTaskpoint(fact, *i, waypoints);
   }
 
-  /* 
+  /*
     Normalize deserialized taskpoint types to match the task factory type.
     Some exporters (e.g., WeGlide) may serialize intermediate points with
     generic types (e.g., "turn") even when the task is declared as AAT.

--- a/src/Task/TaskFileSeeYou.cpp
+++ b/src/Task/TaskFileSeeYou.cpp
@@ -44,7 +44,7 @@ struct SeeYouTaskInformation {
 
 struct SeeYouTurnpointInformation {
   /** CUP file contained info for this OZ */
-  bool valid = false;
+  bool has_oz = false;
 
   enum Style {
     FIXED,
@@ -57,7 +57,13 @@ struct SeeYouTurnpointInformation {
   bool is_line = false;
   bool reduce = false;
 
+  bool radius1_set = false;
+  bool radius2_set = false;
   double radius1 = 500, radius2 = 200, max_altitude = 0;
+
+  bool angle1_set = false;
+  bool angle2_set = false;
+  bool angle12_set = false;
   Angle angle1{}, angle2{}, angle12{};
 };
 
@@ -175,27 +181,35 @@ ParseOptions(SeeYouTaskInformation &task_info, std::string_view src) noexcept
 static void
 ParseOZs(SeeYouTurnpointInformation &tp_info, std::string_view src) noexcept
 {
-  tp_info.valid = true;
+  tp_info.has_oz = true;
 
   for (std::string_view i : IterableSplitString(src, ',')) {
     if (SkipPrefix(i, "Style="sv))
       tp_info.style = ParseStyle(i);
     else if (SkipPrefix(i, "R1="sv)) {
       const double radius = ParseRadius(i);
-      if (radius > 0)
+      if (radius > 0) {
         tp_info.radius1 = radius;
-    } else if (SkipPrefix(i, "A1="sv))
+        tp_info.radius1_set = true;
+      }
+    } else if (SkipPrefix(i, "A1="sv)) {
+      tp_info.angle1_set = true;
       tp_info.angle1 = ParseAngle(i);
-    else if (SkipPrefix(i, "R2="sv)) {
+    } else if (SkipPrefix(i, "R2="sv)) {
       const double radius = ParseRadius(i);
-      if (radius > 0)
+      if (radius > 0) {
         tp_info.radius2 = radius;
+        tp_info.radius2_set = true;
+      }
     }
-    else if (SkipPrefix(i, "A2="sv))
+    else if (SkipPrefix(i, "A2="sv)) {
+      tp_info.angle2_set = true;
       tp_info.angle2 = ParseAngle(i);
-    else if (SkipPrefix(i, "A12="sv))
+    }
+    else if (SkipPrefix(i, "A12="sv)) {
+      tp_info.angle12_set = true;
       tp_info.angle12 = ParseAngle(i);
-    else if (SkipPrefix(i, "MaxAlt="sv))
+    } else if (SkipPrefix(i, "MaxAlt="sv))
       tp_info.max_altitude = ParseMaxAlt(i);
     else if (SkipPrefix(i, "Line="sv))
       tp_info.is_line = i.starts_with('1');
@@ -317,8 +331,9 @@ CreateOZ(const SeeYouTurnpointInformation &turnpoint_infos,
   const bool is_intermediate = (pos > 0) && (pos < (size - 1));
   const Waypoint *wp = &*wps[pos];
 
-  if (!turnpoint_infos.valid)
-    return nullptr;
+  // For turnpoints that don't have an explicit ObsZone line, default to an FAI Quadrant
+  if (!turnpoint_infos.has_oz)
+    return SymmetricSectorZone::CreateFAISectorZone(wp->location, is_intermediate);
 
   if (factType == TaskFactoryType::RACING &&
       is_intermediate && isKeyhole(turnpoint_infos)) {
@@ -350,13 +365,51 @@ CreateOZ(const SeeYouTurnpointInformation &turnpoint_infos,
 
   else if (factType == TaskFactoryType::RACING) {
 
-    // XCSoar does not support fixed sectors for RT
-    if (turnpoint_infos.style == SeeYouTurnpointInformation::FIXED)
+    // XCSoar does not support FIXED sectors for RT, fall back to a basic cylinder
+    if (turnpoint_infos.style == SeeYouTurnpointInformation::FIXED) {
       return std::make_unique<CylinderZone>(wp->location,
                                             turnpoint_infos.radius1);
-    else
+
+    // Handle SYMMETRICAL OZs for Racing tasks
+    } else if (turnpoint_infos.style == SeeYouTurnpointInformation::Style::SYMMETRICAL) {
+
+      /*
+      Compute "effective" radius and angle used for OZ type selection, depending on
+      whether the .cup file explicitly sets these explicitly or not.
+      */
+      const double eff_radius = turnpoint_infos.radius1_set ? turnpoint_infos.radius1 : 3000.0;
+      const Angle eff_angle  = turnpoint_infos.angle1_set ? turnpoint_infos.angle1 * 2: Angle::QuarterCircle();
+
+      /*
+      For FAI observation zones, SeeYou creates .cup files with a radius of 3000m
+      and an angle of 45 degrees. Detect these (with some margin of error, allowing for
+      any radius larger than 3000m as long as the angle is 45 degrees) and create
+      FAI quadrant OZs for them.
+      */
+      if (eff_radius >= 3000.0 &&
+          eff_angle.CompareRoughly(Angle::QuarterCircle(), Angle::Degrees(1))) {
+
+        return SymmetricSectorZone::CreateFAISectorZone(wp->location,
+                                                         is_intermediate);
+      } else {
+        /*
+        In case of a OZ definition with a non-FAI radius or other angle than a quadrant,
+        then specify a generic circular sector zone here instead of an FAI quadrant.
+        Even if the above heuristic for detecting FAI quadrants is not perfect, this remains
+        functionally correct and in line with what is specified in the .cup file.
+        */
+        return SymmetricSectorZone::CreateSymmetricCircularSectorZone(
+          wp->location, eff_radius, eff_angle);
+      }
+    } else {
+      /*
+      Default to FAI Quadrant OZ if we don't have a better option.
+      This will often not be what the task designer intended.
+      */
       return SymmetricSectorZone::CreateFAISectorZone(wp->location,
-                                                      is_intermediate);
+                                                         is_intermediate);
+
+    }
 
   } else if (is_intermediate) { //AAT intermediate point
     assert(wps[pos + 1]);

--- a/test/src/TestTaskFileSeeYouParsing.cpp
+++ b/test/src/TestTaskFileSeeYouParsing.cpp
@@ -143,12 +143,14 @@ TestAngleParsingWithDecimals()
     "\"Start2\",\"S2\",,4801.000N,01101.000E,500.0m,1,0,0.0m,\"\",\"Start 2\"\n"
     "\"Turn1\",\"T1\",,4810.000N,01110.000E,500.0m,1,0,0.0m,\"\",\"Turn 1\"\n"
     "\"Turn2\",\"T2\",,4815.000N,01115.000E,500.0m,1,0,0.0m,\"\",\"Turn 2\"\n"
+    "\"Turn3\",\"T3\",,4817.000N,01118.000E,500.0m,1,0,0.0m,\"\",\"Turn 3\"\n"
     "\"Finish1\",\"F1\",,4820.000N,01120.000E,500.0m,1,0,0.0m,\"\",\"Finish 1\"\n"
     "-----Related Tasks-----\n"
     "\"Test Task\",\"S1\",\"S1\",\"S2\",\"T1\",\"T2\",\"F1\",\"F1\"\n"
-    "ObsZone=0,Style=1,R1=1000m,A1=123.4\n"
+    "ObsZone=0,Style=1,R1=550m,A1=123.4\n"
     "ObsZone=1,Style=1,R1=1000m,A1=180\n"
-    "ObsZone=2,Style=1,R1=1000m,A12=45.67\n";
+    "ObsZone=2,Style=1,R1=4000m,A1=45\n"
+    "ObsZone=3,Style=1,R1=1000m,A12=45.67\n";
 
   constexpr Path task_path{"output/results/Test-Task-AngleParsing.cup"};
 
@@ -165,16 +167,57 @@ TestAngleParsingWithDecimals()
   ok1(task != nullptr);
 
   if (!task) {
-    skip(3, 0, "Failed to load task");
+    skip(12, 0, "Failed to load task");
     return;
   }
 
-  // Note: We can't directly test the parsed angle values without accessing
-  // internal zone structures, but we can verify the task loads successfully
-  // with decimal angles, which means ParseAngle is working correctly.
   ok1(task->IsValidIndex(0));
   ok1(task->IsValidIndex(1));
   ok1(task->IsValidIndex(2));
+  ok1(task->IsValidIndex(3));
+
+
+  /*
+  Check the contents of the parsed observation zones
+  This requires a bit of drilling into data structures, but is
+  worth it to get good test coverage.
+  */
+  const auto &tp0 = task->GetTaskPoint(0).GetObservationZone();
+  const auto &tp1 = task->GetTaskPoint(1).GetObservationZone();
+  const auto &tp2 = task->GetTaskPoint(2).GetObservationZone();
+  const auto &tp3 = task->GetTaskPoint(3).GetObservationZone();
+
+  ok1(tp0.GetShape() == ObservationZone::Shape::SYMMETRIC_QUADRANT);
+  if (const auto *s0 = dynamic_cast<const SymmetricSectorZone *>(&tp0)) {
+    // Allow for a 0.1 degree tolerance due to floating point precision
+    ok1(s0->GetRadius() == 550);
+    ok1(fabs(s0->GetSectorAngle().Degrees() - (123.4 * 2)) < 0.1);
+  } else {
+    ok(false, "Point 0 should be a SymmetricSectorZone");
+  }
+
+  ok1(tp1.GetShape() == ObservationZone::Shape::CYLINDER);
+  if (const auto *s1 = dynamic_cast<const CylinderZone *>(&tp1)) {
+    ok1(s1->GetRadius() == 1000);
+  } else {
+    ok(false, "Point 1 should be a CylinderZone");
+  }
+
+  ok1(tp2.GetShape() == ObservationZone::Shape::FAI_SECTOR);
+  if (const auto *s2 = dynamic_cast<const SymmetricSectorZone *>(&tp2)) {
+    ok1(fabs(s2->GetSectorAngle().Degrees() - (45.0 * 2)) < 0.1);
+    ok1(s2->GetRadius() >= 3000);
+  } else {
+    ok(false, "Point 2 should be a SymmetricSectorZone");
+  }
+
+  /*
+  TODO: This .cup OZ sets A12 angle, and thus should probably result in a different
+  OZ type than SYMMETRIC_QUADRANT. The A12 angle defines the sector centre line.
+  For now the purpose of this test is just to check that the angle parsing doesn't
+  crash for this field.
+  */
+  ok1(tp3.GetShape() == ObservationZone::Shape::SYMMETRIC_QUADRANT);
 }
 
 static void
@@ -246,7 +289,7 @@ int main()
 {
   Directory::Create(Path{"output/results"});
 
-  plan_tests(33);
+  plan_tests(43);
   task_behaviour.SetDefaults();
   TestAll();
   return exit_status();


### PR DESCRIPTION
Previously these kinds of tasks where you use a custom angle for the turnpoints where not correctly read by XCSoar. You can create such tasks in SeeYou and export to .cup, but when reading into XCSoar you got plain FAI quadrants instead of the intended circular sector.

---

This is my first contribution to XCSoar, thank you for an excellent piece of software!

There are probably other ways to structure this, happy to hear opinions.

I plan to also make a PR for a UI update to make this adjustable in-app, but wanted to hear thoughts or merge this initial PR first. There is already partial support for circular sectors in the UI, but the angle adjustment only appears if you load a task with a pre-existing angle set on a task point.

Here is an example task information from SeeYou which shows the intended task:
<img width="839" height="575" alt="image" src="https://github.com/user-attachments/assets/0c060b0c-1c0f-4413-b0f1-1ba530a25576" />

This is the .cup file (file format definition in https://github.com/naviter/seeyou_file_formats/blob/main/CUP_file_format.md ) : 
```
name,code,country,lat,lon,elev,style,rwdir,rwlen,rwwidth,freq,desc,userdata,pics
"Start D",STARTD,,6237.714N,00953.831E,812.0m,1,,,,,,,""
"TP1-D",TP1-D,,6234.110N,00946.407E,991.0m,1,,,,,,,""
"TP2-D",TP2-D,,6240.845N,00946.497E,1076.0m,1,,,,,,,""
"TP3-D",TP3-D,,6234.194N,00945.801E,921.0m,1,,,,,,,""
"Finish D",FINISHD,,6237.982N,00953.952E,739.0m,1,,,,,,,""
-----Related Tasks-----
"Task Delta","???","Start D","TP1-D","TP2-D","TP3-D","Finish D","???"
Options,Short=false,MultiStart=false
ObsZone=0,Style=2,R1=2000m,A1=45,Line=1,SpeedStyle=0
ObsZone=1,Style=1,R1=2000m,A1=90
ObsZone=2,Style=1,R1=2000m,A1=90
ObsZone=3,Style=1,R1=2000m,A1=90
ObsZone=4,Style=3,R1=1500m,A1=180,SpeedStyle=2
```

When loading this into current XCSoar, you get this incorrect task:
<img width="635" height="506" alt="image" src="https://github.com/user-attachments/assets/a8ab39ad-4110-458b-bbb5-e0d9e09cbabc" />



After my PR, you get the indended task:
<img width="637" height="507" alt="image" src="https://github.com/user-attachments/assets/5825fe67-48a6-4da8-a6c2-bf5774af0523" />
<img width="635" height="511" alt="image" src="https://github.com/user-attachments/assets/2472047d-e22d-4f47-9a7a-bf5b4f090a62" />


---

[...]

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ almost] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a factory for creating symmetric circular observation sectors with caller-defined radius and angle.
* **Bug Fixes**
  * Fixed `.cup` task loading so non-standard observation-zone angles are parsed correctly, preventing incorrect FAI quadrant behavior.
  * Improved symmetric racing-task observation-zone generation to honor explicitly provided radii/angles when available.
* **Tests**
  * Expanded `.cup` parsing tests to cover additional angle/radius fields and verify observation-zone shapes and parameters more thoroughly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->