### PR TITLE
Various fixes: UTF-8, Android restart, File Manager, CursorBar

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -13,6 +13,8 @@ Version 7.45 - not yet released
     batch size); device FLARM traffic still typically stays within 25
 * ui
   - Outline selected targets on the FLARM traffic radar
+  - Weather cursor bar: narrower stepper buttons on touchscreens and clip
+    long centre labels instead of hiding them when they do not fit
 * glide computer
   - Speed-to-fly and task calculations are now altitude-corrected: the glide
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,8 @@ Version 7.45 - not yet released
   - Outline selected targets on the FLARM traffic radar
   - Weather cursor bar: narrower stepper buttons on touchscreens and clip
     long centre labels instead of hiding them when they do not fit
+  - Fix crash when opening the map item list on waypoints with long
+    non-ASCII comments (UTF-8 truncation)
 * glide computer
   - Speed-to-fly and task calculations are now altitude-corrected: the glide
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -34,6 +34,8 @@ Version 7.45 - not yet released
   - The saved device port type string for that mode remains ble_hm10 so
     existing profiles load without migration
   - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices
+  - Fix crash when the native thread restarts after surface teardown
+    (JNI helper classes were not cleared between runNative calls)
 * devices
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481

--- a/build/test.mk
+++ b/build/test.mk
@@ -2802,7 +2802,7 @@ $(eval $(call link-program,TestDMStScoring,TEST_DMST_SCORING))
 TEST_VERSION_NUMBER_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestVersionNumber.cpp
-TEST_VERSION_NUMBER_DEPENDS = MATH UTILS
+TEST_VERSION_NUMBER_DEPENDS = MATH UTIL
 $(eval $(call link-program,TestVersionNumber,TEST_VERSION_NUMBER))
 
 TEST_HTTPS_VERIFY_SOURCES = \

--- a/src/Android/Main.cpp
+++ b/src/Android/Main.cpp
@@ -234,6 +234,16 @@ try {
   const bool have_usb_serial = UsbSerialHelper::Initialise(env);
   const bool have_ioio = IOIOHelper::Initialise(env);
 
+  /* These class globals must be cleared before runNative can be
+     entered again in the same process (e.g. surface recreate before
+     System.exit).  Helper instances below are destroyed first because
+     AtScopeExit runs in reverse registration order. */
+  AtScopeExit(env) {
+    IOIOHelper::Deinitialise(env);
+    UsbSerialHelper::Deinitialise(env);
+    BluetoothHelper::Deinitialise(env);
+  };
+
   context = new Context(env, _context);
   AtScopeExit() {
     delete context;

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -626,8 +626,13 @@ ManagedFileListWidget::Add()
       list.push_back(remote_file);
   }
 
-  if (list.empty())
+  if (list.empty()) {
+    /* Empty File Manager with no index yet: retry repository download
+       (same as DownloadFilePicker's empty-list activate). */
+    if (repository.begin() == repository.end())
+      EnqueueRepositoryDownload(true);
     return;
+  }
 
   AddFileListItemRenderer item_renderer(list, look);
   int i = ListPicker(_("Select a file"),

--- a/src/Widget/CursorBarWidget.cpp
+++ b/src/Widget/CursorBarWidget.cpp
@@ -67,9 +67,18 @@ protected:
     canvas.Select(look.text_font);
 
     const auto text_size = canvas.CalcTextSize(text);
-    const int x = (rc.GetWidth() - (int)text_size.width) / 2;
-    const int y = (rc.GetHeight() - (int)text_size.height) / 2;
-    canvas.DrawText({x, y}, text);
+    const int avail_w = int(rc.GetWidth());
+    const int avail_h = int(rc.GetHeight());
+    const int y = std::max(0, (avail_h - int(text_size.height)) / 2);
+
+    if (int(text_size.width) <= avail_w) {
+      const int x = (avail_w - int(text_size.width)) / 2;
+      canvas.DrawText({x, y}, text);
+    } else {
+      /* Keep long labels visible: DrawText with a negative/huge x from
+         unsigned underflow is clipped away entirely on OpenGL. */
+      canvas.DrawClippedText({0, y}, unsigned(avail_w), text);
+    }
   }
 };
 
@@ -82,8 +91,12 @@ class CursorBarWidget::BarWindow final : public SolidContainerWindow {
   StaticArray<Button, MAX_ROWS> next_buttons;
   StaticArray<std::unique_ptr<CursorBarLabel>, MAX_ROWS> labels;
 
-  static int CalcButtonWidth(int row_h) noexcept {
-    return row_h * 2;
+  /**
+   * Prev/next width is based on the compact control height, not the
+   * tall touch row height, so phone bars keep enough room for labels.
+   */
+  static int CalcButtonWidth() noexcept {
+    return int(Layout::GetMinimumControlHeight()) * 2;
   }
 
   static void
@@ -98,8 +111,10 @@ class CursorBarWidget::BarWindow final : public SolidContainerWindow {
     row_h = std::max(1, (total_h - int(separators) * SEPARATOR_H)
                      / int(rows));
 
-    const int max_btn_w = std::max(1, w / 3);
-    btn_w = std::max(1, std::min(CalcButtonWidth(row_h), max_btn_w));
+    /* Cap at 1/5 of the bar so both buttons leave most of the width
+       for the centre label on narrow phones. */
+    const int max_btn_w = std::max(1, w / 5);
+    btn_w = std::max(1, std::min(CalcButtonWidth(), max_btn_w));
   }
 
   [[gnu::pure]]

--- a/src/util/StaticString.hxx
+++ b/src/util/StaticString.hxx
@@ -218,6 +218,10 @@ public:
 	/**
 	 * Use snprintf() to set the value of this string.  The value
 	 * is truncated if it is too long for the buffer.
+	 *
+	 * When truncated, any incomplete trailing UTF-8 sequence is
+	 * removed so the result remains valid UTF-8 (same as
+	 * CopyString()).
 	 */
 	template<typename... Args>
 	std::basic_string_view<T> Format(const_pointer fmt, Args&&... args) noexcept {
@@ -227,9 +231,12 @@ public:
 			return {};
 
 		size_type length = (size_type)s_length;
-		if (length >= capacity())
-			/* truncated */
-			length = capacity() - 1;
+		if (length >= capacity()) {
+			/* truncated — snprintf may have split a multi-byte
+			   UTF-8 sequence at the buffer end */
+			CropIncompleteUTF8(data());
+			length = StringLength(data());
+		}
 
 		return {data(), length};
 	}
@@ -237,11 +244,18 @@ public:
 	/**
 	 * Use snprintf() to append to this string.  The value is
 	 * truncated if it would become too long for the buffer.
+	 *
+	 * When truncated, any incomplete trailing UTF-8 sequence is
+	 * removed so the result remains valid UTF-8 (same as
+	 * CopyString()).
 	 */
 	template<typename... Args>
 	void AppendFormat(const_pointer fmt, Args&&... args) noexcept {
 		size_t l = length();
-		StringFormat(data() + l, capacity() - l, fmt, args...);
+		const size_t avail = capacity() - l;
+		int s_length = StringFormat(data() + l, avail, fmt, args...);
+		if (s_length >= 0 && (size_t)s_length >= avail)
+			CropIncompleteUTF8(data());
 	}
 
 	/**

--- a/test/src/TestUTF8.cpp
+++ b/test/src/TestUTF8.cpp
@@ -3,6 +3,7 @@
 
 #include "util/UTF8.hpp"
 #include "util/StringUtil.hpp"
+#include "util/StaticString.hxx"
 #include "util/Macros.hpp"
 #include "TestUtil.hpp"
 
@@ -183,6 +184,42 @@ TestCopyString()
   }
 }
 
+/**
+ * Test that StaticString::Format / AppendFormat never leave an
+ * incomplete UTF-8 sequence after snprintf truncation.  This is the
+ * map-item list crash path (WaypointListRenderer packs long CUP
+ * comments into StaticString<256>).
+ */
+static void
+TestStaticStringFormat()
+{
+  /* ü = \xc3\xbc — capacity 5 fits "foo" + leading \xc3 only */
+  {
+    StaticString<5> s;
+    s.Format("foo%s", "\xc3\xbc");
+    ok1(strcmp(s.c_str(), "foo") == 0);
+    ok1(ValidateUTF8(s.c_str()));
+  }
+
+  /* AppendFormat: "xx" + "fooü" into capacity 7 → append avail 5
+     truncates after \xc3, then crop */
+  {
+    StaticString<7> s;
+    s.Format("%s", "xx");
+    s.AppendFormat("%s", "foo\xc3\xbc");
+    ok1(strcmp(s.c_str(), "xxfoo") == 0);
+    ok1(ValidateUTF8(s.c_str()));
+  }
+
+  /* 3-byte 目 truncated mid-sequence */
+  {
+    StaticString<6> s;
+    s.Format("foo%s", "\xe7\x9b\xae");
+    ok1(strcmp(s.c_str(), "foo") == 0);
+    ok1(ValidateUTF8(s.c_str()));
+  }
+}
+
 static void
 TestSuffixUTF8()
 {
@@ -223,7 +260,8 @@ int main()
              ARRAY_SIZE(truncate_string_tests) +
              2 * ARRAY_SIZE(copy_string_tests) +
              2 * 7 + 3 +
-             10 + 27);
+             10 + 27 +
+             6);
 
   for (auto i : valid) {
     ok1(ValidateUTF8(i));
@@ -258,6 +296,7 @@ int main()
 
   TestTruncateString();
   TestCopyString();
+  TestStaticStringFormat();
   TestSuffixUTF8();
 
   /* test NextUTF8() */


### PR DESCRIPTION
## Summary
- Make `StaticString::Format` / `AppendFormat` UTF-8-safe after `snprintf` truncation (fixes map-item list abort on long non-ASCII CUP comments).
- Clear Bluetooth/USB/IOIO JNI helpers when `runNative` exits so Android surface recreate does not assert on already-set class refs.
- File Manager empty-list “Press here to download” retries repository index download when none is loaded yet.
- CursorBarWidget: fix touch prev/next button width and clipped centre labels.

## Test plan
- [ ] Tap a map waypoint with a long UTF-8 CUP comment (e.g. French OpenAIP) and confirm the map item list opens without aborting
- [ ] On Android, force a quick surface recreate / restart path and confirm XCSoar starts without `TrivialRef::Set` abort
- [x] Delete/hide the repository index, open File Manager, press the empty-list download hint, and confirm the index downloads
- [x] On a touchscreen, open a weather (or other) cursor bar and confirm prev/next buttons are narrower and centre labels remain visible when long

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an Android crash when restarting the native thread after surface teardown.
  - Prevented crashes when opening map item lists with long, non-ASCII waypoint comments.
  - Improved the weather cursor bar on touchscreens (narrower stepper buttons and safer rendering for long labels).
  - Ensured truncated formatted/merged text never breaks UTF-8 sequences.
  - Improved remote file list loading when repository contents aren’t available yet.
- **Tests**
  - Added UTF-8 coverage for static string formatting and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->