### PR TITLE
Menu: Add map overlay QuickMenu button

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -291,8 +291,8 @@ location=8
 # ------------
 # mode=weather (weather overlay cursor bar)
 # Stick: UP/DOWN field, LEFT/RIGHT time, RETURN time picker, ESCAPE exit
-# Zoom: F2/+ = list, F3/- = auto
-# Buttons: 1=Time-, 2=List (F2/+), 3=Auto (F3/-), 4=Time+,
+# Keys: F2 = list, F3 = auto (map overlay +/- always zoom)
+# Buttons: 1=Time-, 2=List (F2), 3=Auto (F3), 4=Time+,
 #          5=Field+, 6=Field-, 7=Time Picker
 # ------------
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -17,6 +17,8 @@ Version 7.45 - not yet released
     long centre labels instead of hiding them when they do not fit
   - Fix crash when opening the map item list on waypoints with long
     non-ASCII comments (UTF-8 truncation)
+  - add optional map overlay QuickMenu button (Config → Look → Layout),
+    enabled by default when a touch screen is detected #2610
 * glide computer
   - Speed-to-fly and task calculations are now altitude-corrected: the glide
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -536,9 +536,9 @@ Built-in modes
   menu (**Forecast Controls** on RemoteStick) or via the ``Mode weather``
   event. Stick UP/DOWN step the secondary axis (layer, level, or
   altitude), LEFT/RIGHT step time, RETURN opens the time picker, ESCAPE
-  returns to ``default``. On map pages with weather overlay controls,
-  F2 and the on-screen **+** button open the secondary list; F3 and
-  **−** toggle auto (secondary axis on EDL/XCTherm, time auto on RASP).
+  returns to ``default``. In ``mode=weather``, F2 opens the secondary
+  list and F3 toggles auto (secondary axis on EDL/XCTherm, time auto on
+  RASP). The map overlay **+** / **−** buttons always zoom the map.
   See :ref:`weather-overlay-mode` below.
 - ``wptimg`` -- the waypoint details dialog is on an **image** page;
   key bindings in this map control zoom and pan of the image (the
@@ -578,17 +578,19 @@ The built-in stick bindings in :file:`Data/Input/default.xci` are:
  * - RETURN
    - ``WeatherOverlay time picker``
    - Open time picker (Auto, Now, manual)
- * - F2 / on-screen **+**
+ * - F2
    - ``WeatherOverlay field picker``
    - Open secondary-axis list (layer, level, or altitude)
- * - F3 / on-screen **−**
+ * - F3
    - ``WeatherOverlay field auto toggle``
    - Toggle secondary auto (EDL/XCTherm) or time auto (RASP)
  * - ESCAPE
    - ``Mode default``
    - Exit weather input mode
 
-On-screen menubar buttons (locations 1--7) mirror these actions:
+The map overlay **+** / **−** buttons always zoom the map (they are not
+remapped in weather mode). On-screen menubar buttons (locations 1--7)
+mirror the stick actions:
 
 .. list-table::
  :widths: 15 35 50
@@ -602,10 +604,10 @@ On-screen menubar buttons (locations 1--7) mirror these actions:
    - ``Time- (LEFT)``
  * - 2
    - Secondary list
-   - Layer / Level / Altitude list (``F2/+``)
+   - Layer / Level / Altitude list (``F2``)
  * - 3
    - Auto toggle
-   - Time auto (RASP) or secondary auto (EDL/XCTherm) (``F3/-``)
+   - Time auto (RASP) or secondary auto (EDL/XCTherm) (``F3``)
  * - 4
    - Time step forward
    - ``Time+ (RIGHT)``

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -13,7 +13,6 @@
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
-#include "UtilsSettings.hpp"
 #include "Asset.hpp"
 #include "Menu/ShowButton.hpp"
 #include "ActionInterface.hpp"
@@ -43,6 +42,7 @@ enum ControlIndex {
   AppInfoBoxBorder,
   ShowMenuButton,
   ShowZoomButton,
+  ShowQuickMenuButton,
 #ifdef DRAW_MOUSE_CURSOR
   CursorSize,
   CursorInverted,
@@ -230,6 +230,10 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   AddBoolean(_("Show Zoom button"), _("Show the Zoom button"),
              ui_settings.show_zoom_button);
   SetExpertRow(ShowZoomButton);
+  AddBoolean(_("Show QuickMenu button"),
+             _("Show the QuickMenu button"),
+             ui_settings.show_quickmenu_button);
+  SetExpertRow(ShowQuickMenuButton);
 
 #ifdef DRAW_MOUSE_CURSOR
   AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x", 1, 10, 1,
@@ -288,11 +292,18 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValueEnum(AppInfoBoxBorder, ProfileKeys::AppInfoBoxBorder,
                            ui_settings.info_boxes.border_style);
 
-  if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,ui_settings.show_menu_button))
-    require_restart = changed = true;
+  bool overlay_buttons_changed = false;
+  if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,
+                ui_settings.show_menu_button))
+    overlay_buttons_changed = changed = true;
   if (SaveValue(ShowZoomButton, ProfileKeys::ShowZoomButton,
-		ui_settings.show_zoom_button))
-    require_restart = changed = true;
+                ui_settings.show_zoom_button))
+    overlay_buttons_changed = changed = true;
+  if (SaveValue(ShowQuickMenuButton, ProfileKeys::ShowQuickMenuButton,
+                ui_settings.show_quickmenu_button))
+    overlay_buttons_changed = changed = true;
+  if (overlay_buttons_changed)
+    CommonInterface::main_window->ReinitialiseMapOverlayButtons();
 
   DialogSettings &dialog_settings = CommonInterface::SetUISettings().dialog;
   changed |= SaveValueEnum(TabDialogStyle, ProfileKeys::AppDialogTabStyle, dialog_settings.tab_style);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -105,6 +105,20 @@ MainWindow::GetShowMenuButtonRect(const PixelRect rc) noexcept
 
 [[gnu::pure]]
 PixelRect
+MainWindow::GetShowQuickMenuButtonRect(const PixelRect rc) noexcept
+{
+  const UISettings &settings = CommonInterface::GetUISettings();
+  const unsigned padding = Layout::GetTextPadding();
+
+  int top = rc.top + int(padding);
+  if (settings.show_menu_button)
+    top = GetShowMenuButtonRect(rc).bottom + int(padding);
+
+  return GetMapOverlayButtonRect(rc, top);
+}
+
+[[gnu::pure]]
+PixelRect
 MainWindow::GetShowZoomButtonRect(const PixelRect rc,
                                   ShowZoomButton::Sign sign) noexcept
 {
@@ -112,8 +126,17 @@ MainWindow::GetShowZoomButtonRect(const PixelRect rc,
   const unsigned padding = Layout::GetTextPadding();
   const unsigned size = Layout::GetMaximumControlHeight();
 
-  if (settings.show_menu_button && ShowMapOverlayZoomButtons(settings)) {
-    int top = GetShowMenuButtonRect(rc).bottom + int(padding);
+  const bool stack_top_right =
+    (settings.show_menu_button || settings.show_quickmenu_button) &&
+    ShowMapOverlayZoomButtons(settings);
+
+  if (stack_top_right) {
+    int top;
+    if (settings.show_quickmenu_button)
+      top = GetShowQuickMenuButtonRect(rc).bottom + int(padding);
+    else
+      top = GetShowMenuButtonRect(rc).bottom + int(padding);
+
     if (sign == ShowZoomButton::Sign::ZOOM_IN) {
       const PixelRect zoom_out =
         GetShowZoomButtonRect(rc, ShowZoomButton::Sign::ZOOM_OUT);
@@ -295,6 +318,12 @@ MainWindow::UpdateMapOverlayButtonLayout() noexcept
     if (overlay_buttons_active)
       show_menu_button->Move(GetShowMenuButtonRect(rc));
   }
+  if (show_quickmenu_button != nullptr) {
+    show_quickmenu_button->SetVisible(overlay_buttons_active);
+    show_quickmenu_button->SetEnabled(overlay_buttons_active);
+    if (overlay_buttons_active)
+      show_quickmenu_button->Move(GetShowQuickMenuButtonRect(rc));
+  }
   if (show_zoom_out_button != nullptr) {
     show_zoom_out_button->SetVisible(overlay_buttons_active);
     show_zoom_out_button->SetEnabled(overlay_buttons_active);
@@ -314,6 +343,62 @@ MainWindow::UpdateMapOverlayButtonLayout() noexcept
   if (show_rotate_button != nullptr)
     show_rotate_button->Move(GetShowRotateButtonRect(rc));
 #endif
+}
+
+void
+MainWindow::ReinitialiseMapOverlayButtons() noexcept
+{
+  if (look == nullptr)
+    return;
+
+  const UISettings &settings = CommonInterface::GetUISettings();
+  const PixelRect map_area_rect = GetMapAreaRect();
+
+  if (settings.show_menu_button) {
+    if (show_menu_button == nullptr) {
+      show_menu_button = new ShowMenuButton();
+      show_menu_button->Create(*this, look->dialog.button,
+                               GetShowMenuButtonRect(map_area_rect));
+    }
+  } else if (show_menu_button != nullptr) {
+    delete show_menu_button;
+    show_menu_button = nullptr;
+  }
+
+  if (settings.show_quickmenu_button) {
+    if (show_quickmenu_button == nullptr) {
+      show_quickmenu_button = new ShowQuickMenuButton();
+      show_quickmenu_button->Create(*this, look->dialog.button,
+                                    GetShowQuickMenuButtonRect(map_area_rect));
+    }
+  } else if (show_quickmenu_button != nullptr) {
+    delete show_quickmenu_button;
+    show_quickmenu_button = nullptr;
+  }
+
+  if (ShowMapOverlayZoomButtons(settings)) {
+    if (show_zoom_out_button == nullptr) {
+      show_zoom_out_button = new ShowZoomButton();
+      show_zoom_out_button->Create(*this, look->dialog.button,
+                                   GetShowZoomButtonRect(map_area_rect,
+                                                         ShowZoomButton::Sign::ZOOM_OUT),
+                                   ShowZoomButton::Sign::ZOOM_OUT);
+    }
+    if (show_zoom_in_button == nullptr) {
+      show_zoom_in_button = new ShowZoomButton();
+      show_zoom_in_button->Create(*this, look->dialog.button,
+                                  GetShowZoomButtonRect(map_area_rect,
+                                                        ShowZoomButton::Sign::ZOOM_IN),
+                                  ShowZoomButton::Sign::ZOOM_IN);
+    }
+  } else {
+    delete show_zoom_out_button;
+    show_zoom_out_button = nullptr;
+    delete show_zoom_in_button;
+    show_zoom_in_button = nullptr;
+  }
+
+  UpdateMapOverlayButtonLayout();
 }
 
 MainWindow::MainWindow(UI::Display &display) noexcept
@@ -381,32 +466,15 @@ MainWindow::InitialiseConfigured()
   ReinitialiseLayoutTA(rc, ib_layout);
   ReinitialiseLayout_flarm(rc, ib_layout);
 
-  const UISettings &settings = CommonInterface::GetUISettings();
-  const PixelRect map_area_rect = GetMapAreaRect();
-
-  if (settings.show_menu_button) {
-    show_menu_button = new ShowMenuButton();
-    show_menu_button->Create(*this, look->dialog.button,
-                             GetShowMenuButtonRect(map_area_rect));
-  }
-  if (ShowMapOverlayZoomButtons(settings)) {
-    show_zoom_out_button = new ShowZoomButton();
-    show_zoom_out_button->Create(*this, look->dialog.button,
-                                 GetShowZoomButtonRect(map_area_rect,
-                                                       ShowZoomButton::Sign::ZOOM_OUT),
-                                 ShowZoomButton::Sign::ZOOM_OUT);
-    show_zoom_in_button = new ShowZoomButton();
-    show_zoom_in_button->Create(*this, look->dialog.button,
-                                GetShowZoomButtonRect(map_area_rect,
-                                                      ShowZoomButton::Sign::ZOOM_IN),
-                                ShowZoomButton::Sign::ZOOM_IN);
-  }
+  ReinitialiseMapOverlayButtons();
 
 #ifdef ANDROID
   /* create a rotate button (initially hidden) when orientation is
      DEFAULT (not forced) and the system auto-rotate setting is
      enabled; the button appears temporarily when the Java
      OrientationEventListener detects a physical orientation change */
+  const UISettings &settings = CommonInterface::GetUISettings();
+  const PixelRect map_area_rect = GetMapAreaRect();
   if (settings.display.orientation == DisplayOrientation::DEFAULT &&
       native_view != nullptr &&
       native_view->IsAutoRotateEnabled(Java::GetEnv())) {
@@ -482,6 +550,8 @@ MainWindow::Deinitialise() noexcept
 
   delete show_menu_button;
   show_menu_button = nullptr;
+  delete show_quickmenu_button;
+  show_quickmenu_button = nullptr;
   delete show_zoom_out_button;
   show_zoom_out_button = nullptr;
   delete show_zoom_in_button;

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -47,6 +47,7 @@ class MainWindow : public UI::SingleWindow {
   MenuBar *menu_bar = nullptr;
 
   ShowMenuButton *show_menu_button = nullptr;
+  ShowQuickMenuButton *show_quickmenu_button = nullptr;
   ShowZoomButton *show_zoom_out_button = nullptr;
   ShowZoomButton *show_zoom_in_button = nullptr;
 
@@ -285,6 +286,12 @@ private:
 
 public:
   /**
+   * Create or destroy map overlay buttons to match the current
+   * UISettings, then update their positions.
+   */
+  void ReinitialiseMapOverlayButtons() noexcept;
+
+  /**
    * Called by XCSoarInterface::Startup() after startup has been
    * completed.
    */
@@ -510,6 +517,7 @@ protected:
   bool OnKeyDown(unsigned key_code) noexcept override;
   void OnPaint(Canvas &canvas) noexcept override;
   PixelRect GetShowMenuButtonRect(const PixelRect rc) noexcept;
+  PixelRect GetShowQuickMenuButtonRect(const PixelRect rc) noexcept;
   PixelRect GetShowZoomButtonRect(const PixelRect rc,
                                   ShowZoomButton::Sign sign) noexcept;
 

--- a/src/Menu/ShowButton.cpp
+++ b/src/Menu/ShowButton.cpp
@@ -7,8 +7,6 @@
 #include "Look/ButtonLook.hpp"
 #include "Input/InputEvents.hpp"
 #include "Interface.hpp"
-#include "PageActions.hpp"
-#include "PageSettings.hpp"
 #include "UIState.hpp"
 
 #include <memory>
@@ -23,7 +21,7 @@
 #endif
 
 /**
- * Map overlay buttons (menu, zoom) are hidden on special pages.
+ * Map overlay buttons (menu, QuickMenu, zoom) are hidden on special pages.
  */
 class ShowMapOverlayButtonRenderer : public ButtonRenderer {
   std::unique_ptr<ButtonRenderer> inner;
@@ -68,6 +66,21 @@ ShowMenuButton::OnClicked() noexcept
 }
 
 void
+ShowQuickMenuButton::Create(ContainerWindow &parent, const ButtonLook &look,
+                            const PixelRect &rc,
+                            WindowStyle style) noexcept
+{
+  Button::Create(parent, rc, style, MakeMapOverlaySymbolButton(look, "q"));
+}
+
+bool
+ShowQuickMenuButton::OnClicked() noexcept
+{
+  InputEvents::eventQuickMenu(nullptr);
+  return true;
+}
+
+void
 ShowZoomButton::Create(ContainerWindow &parent, const ButtonLook &look,
                        const PixelRect &rc, Sign _sign,
                        WindowStyle style) noexcept
@@ -81,13 +94,6 @@ ShowZoomButton::Create(ContainerWindow &parent, const ButtonLook &look,
 bool
 ShowZoomButton::OnClicked() noexcept
 {
-  if (PageActions::GetCurrentLayout().UsesWeatherOverlay()) {
-    InputEvents::eventWeatherOverlay(sign == Sign::ZOOM_IN
-                                     ? "field picker"
-                                     : "field auto toggle");
-    return true;
-  }
-
   InputEvents::eventZoom(sign == Sign::ZOOM_IN ? "in" : "out");
   return true;
 }

--- a/src/Menu/ShowButton.hpp
+++ b/src/Menu/ShowButton.hpp
@@ -23,6 +23,18 @@ protected:
   bool OnClicked() noexcept override;
 };
 
+/* map overlay QuickMenu button (bolt icon) */
+class ShowQuickMenuButton : public Button {
+public:
+  void Create(ContainerWindow &parent, const ButtonLook &look,
+              const PixelRect &rc,
+              WindowStyle style=WindowStyle()) noexcept;
+
+protected:
+  /* virtual methods from class ButtonWindow */
+  bool OnClicked() noexcept override;
+};
+
 /* map overlay zoom button (+ or -) */
 class ShowZoomButton : public Button {
 public:

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -132,6 +132,7 @@ constexpr std::string_view TeamcodeRefWaypoint = "TeamcodeRefWaypoint";
 constexpr std::string_view AppInfoBoxBorder = "AppInfoBoxBorder";
 constexpr std::string_view ShowMenuButton = "ShowMenuButton";
 constexpr std::string_view ShowZoomButton = "ShowZoomButton";
+constexpr std::string_view ShowQuickMenuButton = "ShowQuickMenuButton";
 constexpr std::string_view CursorSize = "CursorSize";
 constexpr std::string_view CursorColorsInverted = "CursorColorsInverted";
 constexpr std::string_view NoPositionTargetDistanceRing = "NoPositionTargetDistanceRing";

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -133,6 +133,7 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
 
   map.Get(ProfileKeys::ShowMenuButton, settings.show_menu_button);
   map.Get(ProfileKeys::ShowZoomButton, settings.show_zoom_button);
+  map.Get(ProfileKeys::ShowQuickMenuButton, settings.show_quickmenu_button);
 
   if (!map.GetEnum(ProfileKeys::DarkMode, settings.dark_mode)) {
     /* migrate the old AppInverseInfoBox setting */

--- a/src/Renderer/SymbolButtonRenderer.cpp
+++ b/src/Renderer/SymbolButtonRenderer.cpp
@@ -17,7 +17,7 @@ SymbolButtonRenderer::IsSymbolCaption(const char *caption) noexcept
     return false;
 
   return ch == '+' || ch == '-' || ch == '<' || ch == '>' ||
-    ch == '^' || ch == 'v' || ch == 'h';
+    ch == '^' || ch == 'v' || ch == 'h' || ch == 'q';
 }
 
 [[gnu::pure]]
@@ -89,6 +89,10 @@ SymbolButtonRenderer::DrawSymbol(Canvas &canvas, PixelRect rc,
   // Draw hamburger menu icon (map overlay menu button)
   else if (ch == 'h')
     SymbolRenderer::DrawHamburger(canvas, rc);
+
+  // Draw bolt icon (map overlay QuickMenu button)
+  else if (ch == 'q')
+    SymbolRenderer::DrawBolt(canvas, rc);
 }
 
 void

--- a/src/Renderer/SymbolRenderer.cpp
+++ b/src/Renderer/SymbolRenderer.cpp
@@ -113,3 +113,27 @@ SymbolRenderer::DrawHamburger(Canvas &canvas, PixelRect rc) noexcept
   DrawBarAt(canvas, center, margin);
   DrawBarAt(canvas, {center.x, center.y + step}, margin);
 }
+
+void
+SymbolRenderer::DrawBolt(Canvas &canvas, PixelRect rc) noexcept
+{
+  const unsigned min_dim = MinDimension(rc);
+  if (min_dim == 0)
+    return;
+
+  /* Material-style lightning bolt (filled zigzag), sized like the
+     hamburger icon so it reads clearly on map overlay buttons. */
+  const int s = int(std::max(1u, min_dim * 3 / 8));
+  const auto c = rc.GetCenter();
+
+  const BulkPixelPoint bolt[] = {
+    {c.x + s * 2 / 10, c.y - s},
+    {c.x - s * 5 / 10, c.y + s / 10},
+    {c.x - s / 10, c.y + s / 10},
+    {c.x - s * 2 / 10, c.y + s},
+    {c.x + s * 5 / 10, c.y - s / 10},
+    {c.x + s / 10, c.y - s / 10},
+  };
+
+  canvas.DrawPolygon(bolt, 6);
+}

--- a/src/Renderer/SymbolRenderer.hpp
+++ b/src/Renderer/SymbolRenderer.hpp
@@ -20,4 +20,5 @@ namespace SymbolRenderer
   void DrawSign(Canvas &canvas, PixelRect rc, bool plus,
                 unsigned max_draw_size=0) noexcept;
   void DrawHamburger(Canvas &canvas, PixelRect rc) noexcept;
+  void DrawBolt(Canvas &canvas, PixelRect rc) noexcept;
 }

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "UISettings.hpp"
+#include "Asset.hpp"
 
 void
 UISettings::SetDefaults() noexcept
@@ -28,6 +29,7 @@ UISettings::SetDefaults() noexcept
   show_menu_button = false;
 #endif
   show_zoom_button = show_menu_button;
+  show_quickmenu_button = HasTouchScreen();
 
   dark_mode = DarkMode::AUTO;
 

--- a/src/UISettings.hpp
+++ b/src/UISettings.hpp
@@ -52,6 +52,7 @@ struct UISettings {
   /** Show Menubutton */
   bool show_menu_button;
   bool show_zoom_button;
+  bool show_quickmenu_button;
 
   enum class PopupMessagePosition : uint8_t {
     CENTER,


### PR DESCRIPTION
## Summary
- Add an on-screen QuickMenu map overlay button (bolt icon) in the top-right stack beside menu/zoom, with a Config → Look → Layout toggle; default on when a touch screen is detected.
- Apply menu / QuickMenu / zoom overlay button setting changes without restarting XCSoar.
- Keep map overlay +/- as zoom on weather pages (list/auto stay on F2/F3 and the weather menubar).

Closes #2610

## Test plan
- [ ] Enable/disable **Show QuickMenu button** in Config → Look → Layout and confirm the button appears/disappears without restart
- [ ] Tap the bolt overlay button and confirm QuickMenu opens (`dlgQuickMenuShowModal`)
- [ ] Confirm the button is hidden on special pages (same as menu/zoom overlays)
- [ ] On a weather overlay page, confirm overlay +/- still zoom; F2/F3 and weather menubar still open list / toggle auto
- [ ] Spot-check on OpenGL, memory canvas (or Kobo), and a touch-default layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional map overlay **QuickMenu** button under **Config → Look → Layout**.
  - Enabled by default when a touchscreen is detected.
  - Added a lightning-bolt icon for the QuickMenu button.

- **Improvements**
  - Map overlay **+ / −** buttons always control **map zoom**.
  - Weather overlay controls now use **F2** for the secondary list and **F3** for the corresponding auto mode, with **+ / −** reserved for zoom.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->