### PR TITLE
ui/event/Notify: Route GDI thread marshalling through EventQueue (#2663)

### DIFF
--- a/src/ui/event/Notify.cpp
+++ b/src/ui/event/Notify.cpp
@@ -11,7 +11,8 @@ Notify::Notify(CallbackFunction _callback) noexcept
   :callback(std::move(_callback))
 {
 #ifdef USE_WINUSER
-  Window::CreateMessageWindow();
+  if (event_queue == nullptr)
+    Window::CreateMessageWindow();
 #endif
 }
 
@@ -21,11 +22,11 @@ Notify::SendNotification() noexcept
   if (pending.exchange(true, std::memory_order_relaxed))
     return;
 
-#ifdef USE_WINUSER
-  SendUser(0);
-#else
   if (event_queue != nullptr)
     event_queue->InjectCall(Callback, this);
+#ifdef USE_WINUSER
+  else
+    SendUser(0);
 #endif
 }
 
@@ -35,10 +36,8 @@ Notify::ClearNotification() noexcept
   if (!pending.exchange(false, std::memory_order_relaxed))
     return;
 
-#ifndef USE_WINUSER
   if (event_queue != nullptr)
     event_queue->Purge(Callback, this);
-#endif
 }
 
 void
@@ -48,6 +47,13 @@ Notify::RunNotification() noexcept
     callback();
 }
 
+void
+Notify::Callback(void *ctx) noexcept
+{
+  Notify &notify = *(Notify *)ctx;
+  notify.RunNotification();
+}
+
 #ifdef USE_WINUSER
 
 bool
@@ -55,15 +61,6 @@ Notify::OnUser([[maybe_unused]] unsigned id) noexcept
 {
   RunNotification();
   return true;
-}
-
-#else
-
-void
-Notify::Callback(void *ctx) noexcept
-{
-  Notify &notify = *(Notify *)ctx;
-  notify.RunNotification();
 }
 
 #endif

--- a/src/ui/event/Notify.hpp
+++ b/src/ui/event/Notify.hpp
@@ -51,12 +51,10 @@ public:
 private:
   void RunNotification() noexcept;
 
-#ifndef USE_WINUSER
   /**
    * Called by the event loop when the "notify" message is received.
    */
   static void Callback(void *ctx) noexcept;
-#endif
 
 #ifdef USE_WINUSER
 private:

--- a/src/ui/event/windows/Event.hpp
+++ b/src/ui/event/windows/Event.hpp
@@ -11,7 +11,16 @@
 namespace UI {
 
 struct Event {
-  MSG msg;
+  using Callback = void (*)(void *ctx) noexcept;
+
+  MSG msg{};
+
+  Callback callback = nullptr;
+  void *callback_ctx = nullptr;
+
+  bool IsCallback() const noexcept {
+    return callback != nullptr;
+  }
 
   bool IsKeyDown() const {
     return msg.message == WM_KEYDOWN;

--- a/src/ui/event/windows/Loop.cpp
+++ b/src/ui/event/windows/Loop.cpp
@@ -17,6 +17,11 @@ EventLoop::Get(Event &event)
 void
 EventLoop::Dispatch(const Event &event)
 {
+  if (event.IsCallback()) {
+    event.callback(event.callback_ctx);
+    return;
+  }
+
   ::TranslateMessage(&event.msg);
   ::DispatchMessage(&event.msg);
 }
@@ -24,7 +29,7 @@ EventLoop::Dispatch(const Event &event)
 void
 DialogEventLoop::Dispatch(Event &event)
 {
-  if (::IsDialogMessage(dialog, &event.msg))
+  if (!event.IsCallback() && ::IsDialogMessage(dialog, &event.msg))
     return;
 
   EventLoop::Dispatch(event);

--- a/src/ui/event/windows/Queue.cpp
+++ b/src/ui/event/windows/Queue.cpp
@@ -13,6 +13,44 @@ namespace UI {
 EventQueue::EventQueue()
   :trigger(::CreateEvent(nullptr, true, false, nullptr)) {}
 
+void
+EventQueue::InjectCall(Event::Callback callback, void *ctx) noexcept
+{
+  {
+    const std::lock_guard lock{mutex};
+    injected_events.push({callback, ctx});
+  }
+
+  WakeUp();
+}
+
+bool
+EventQueue::PopInjected(Event &event) noexcept
+{
+  const std::lock_guard lock{mutex};
+  if (injected_events.empty())
+    return false;
+
+  const InjectedEvent &injected = injected_events.front();
+  event.callback = injected.callback;
+  event.callback_ctx = injected.ctx;
+  injected_events.pop();
+  return true;
+}
+
+void
+EventQueue::Purge(Event::Callback callback, void *ctx) noexcept
+{
+  const std::lock_guard lock{mutex};
+  size_t n = injected_events.size();
+  while (n-- > 0) {
+    const InjectedEvent &injected = injected_events.front();
+    if (injected.callback != callback || injected.ctx != ctx)
+      injected_events.push(injected);
+    injected_events.pop();
+  }
+}
+
 bool
 EventQueue::Wait(Event &event)
 {
@@ -22,6 +60,12 @@ EventQueue::Wait(Event &event)
 
   while (true) {
     ::ResetEvent(trigger);
+
+    event.callback = nullptr;
+    event.callback_ctx = nullptr;
+
+    if (PopInjected(event))
+      return true;
 
     /* invoke all due timers */
 

--- a/src/ui/event/windows/Queue.hpp
+++ b/src/ui/event/windows/Queue.hpp
@@ -3,17 +3,17 @@
 
 #pragma once
 
+#include "Event.hpp"
 #include "../shared/TimerQueue.hpp"
 #include "thread/Mutex.hxx"
 #include "time/ClockCache.hxx"
 
 #include <chrono>
+#include <queue>
 
 #include <handleapi.h>
 
 namespace UI {
-
-struct Event;
 
 class EventQueue {
   ClockCache<std::chrono::steady_clock> steady_clock_cache;
@@ -22,6 +22,13 @@ class EventQueue {
 
   Mutex mutex;
   TimerQueue timers;
+
+  struct InjectedEvent {
+    Event::Callback callback;
+    void *ctx;
+  };
+
+  std::queue<InjectedEvent> injected_events;
 
 public:
   EventQueue();
@@ -46,7 +53,13 @@ public:
 
   bool Wait(Event &event);
 
+  void InjectCall(Event::Callback callback, void *ctx) noexcept;
+
+  void Purge(Event::Callback callback, void *ctx) noexcept;
+
 private:
+  bool PopInjected(Event &event) noexcept;
+
   void WakeUp() {
     ::SetEvent(trigger);
   }


### PR DESCRIPTION
## Summary

- Fix PC/GDI crash when NOTAM refresh completes (#2663)
- Add `InjectCall()` / `Purge()` to the Windows (GDI) `EventQueue`
- Route `UI::Notify` through the event queue on GDI, like SDL/poll already do
- Keep the legacy `HWND_MESSAGE` path only as a fallback when no event queue exists

After a successful NOTAM fetch, the reporter's log stopped at `Successfully completed fetch` and never reached `Updating airspace database`. The failure was in marshalling fetch completion from the network thread to the UI thread on the deprecated PC/GDI build.

## Test plan

- [x] Build `TARGET=PC` on Windows
- [x] Enable NOTAM, load airspaces, open Config → Map Display → NOTAM → Refresh
- [x] Confirm refresh completes and map/list update without crash
- [x] Confirm log reaches `NOTAM: Updating airspace database with loaded NOTAMs`
- [x] Smoke-test `TARGET=WIN32OPENGL` (unaffected, but Notify path is shared when event queue is set)

Fixes #2663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved event processing for Windows, allowing queued actions to run promptly without unnecessary message-loop delays.
  * Enhanced notification delivery by prioritizing queued event handling when available.
  * Improved cleanup of pending notifications to prevent stale callbacks from running.
  * Added safer event initialization and callback handling for more reliable application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->