### PR TITLE
Gauge: Fix FLARM traffic symbol sizing #2708

### DIFF
--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -13,7 +13,6 @@
 #include "util/Macros.hpp"
 #include "util/UTF8.hpp"
 #include "Look/FlarmTrafficLook.hpp"
-#include "Renderer/TextInBox.hpp"
 #include "Interface.hpp"
 
 #include <algorithm>
@@ -58,24 +57,6 @@ FlarmTrafficWindow::RadarArrowScale(bool small_radar,
 
   return std::max(int(icon_size) * 50 / int(arrow_span), 1);
 }
-
-static void
-DrawSideLabel(Canvas &canvas, const FlarmTrafficLook &look,
-              const char *text, PixelPoint p, bool selected,
-              Color text_color) noexcept
-{
-  canvas.SetBackgroundTransparent();
-
-  if (!selected) {
-    canvas.SetTextColor(text_color);
-    canvas.DrawText(p, text);
-    return;
-  }
-
-  const bool light_background = look.background_color != COLOR_BLACK;
-  RenderShadowedText(canvas, text, p, light_background);
-}
-
 
 FlarmTrafficWindow::FlarmTrafficWindow(const FlarmTrafficLook &_look,
                                        unsigned _h_padding,
@@ -304,7 +285,7 @@ FlarmTrafficWindow::PaintNoPositionTarget(Canvas &canvas,
                                         const PixelPoint &target_point,
                                         const PixelPoint &radar_center,
                                         double scale,
-                                        [[maybe_unused]] bool small,
+                                        bool small,
                                         const Pen *target_pen,
                                         const Color *text_color) const noexcept
 {
@@ -324,7 +305,7 @@ FlarmTrafficWindow::PaintNoPositionTarget(Canvas &canvas,
   // No position target - Paint a dot
   const unsigned radar_radius = radar_renderer.GetRadius();
   const int dot_radius = std::max(1,
-    int(ScaleRadarPermille(radar_radius, TARGET_RING_PERMILLE)));
+    int(ScaleRadarPermille(radar_radius, NOPOSTARGET_PERMILLE)));
   canvas.DrawCircle(target_point, dot_radius);
   // No position target - print exclamation mark in the middle over the dot
   if (!small) {
@@ -522,8 +503,7 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
       sc[i].y - int(ScaleRadarPermille(radar_radius, SIDE_LABEL_Y_PERMILLE)),
     };
 
-    DrawSideLabel(canvas, look, SuffixUTF8(traffic.name, 2).data(), ts,
-                  selected, *text_color);
+    canvas.DrawText(ts, SuffixUTF8(traffic.name, 2));
   }
 
   StaticString<10> side_text;
@@ -548,7 +528,7 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
   };
 
   if (!side_text.empty())
-    DrawSideLabel(canvas, look, side_text, tp, selected, *text_color);
+    canvas.DrawText(tp, side_text);
 }
 
 void

--- a/src/Gauge/FlarmTrafficWindow.hpp
+++ b/src/Gauge/FlarmTrafficWindow.hpp
@@ -115,12 +115,13 @@ protected:
 protected:
   static constexpr unsigned TARGET_RING_PERMILLE = 140;
   static constexpr unsigned TARGET_RING_OUTER_PERMILLE = 170;
+  static constexpr unsigned NOPOSTARGET_PERMILLE = 70;
   static constexpr unsigned ARROW_ICON_PERMILLE = 400;
   static constexpr unsigned ALT_LABEL_DIST_PERMILLE = 135;
   static constexpr unsigned ALT_LABEL_ALARM_DIST_PERMILLE = 200;
   static constexpr unsigned ALT_TRIANGLE_PERMILLE = 60;
   static constexpr unsigned SIDE_LABEL_X_PERMILLE = 100;
-  static constexpr unsigned SIDE_LABEL_Y_PERMILLE = 150;
+  static constexpr unsigned SIDE_LABEL_Y_PERMILLE = 175;
   static constexpr unsigned SIDE_LABEL_Y_CENTER_PERMILLE = 75;
   static constexpr unsigned PLANE_WING_X_PERMILLE = 85;
   static constexpr unsigned PLANE_WING_Y_PERMILLE = 17;
@@ -153,7 +154,7 @@ private:
                            const PixelPoint &target_point,
                            const PixelPoint &radar_center,
                            double scale,
-                           [[maybe_unused]] bool small,
+                           bool small,
                            const Pen *target_pen,
                            const Color *text_color) const noexcept;
 };

--- a/src/Renderer/TrafficRenderer.cpp
+++ b/src/Renderer/TrafficRenderer.cpp
@@ -25,7 +25,7 @@ static constexpr unsigned ARROW_SPAN = 14;
  * display DPI (and small-screen viewing distance) but not window size.
  * ~Scale(100) arrow size at the 240 px design baseline.
  */
-static constexpr unsigned MAP_TRAFFIC_ICON_VPT = 36;
+static constexpr unsigned MAP_TRAFFIC_ICON_VPT = 50;
 
 struct MapTrafficScale {
   int arrow_scale;


### PR DESCRIPTION
## Summary

Fixes FLARM traffic symbol sizing regressions reported in #2708 (7.45 vs 7.44):

- **Radar no-position dot:** use dedicated `NOPOSTARGET_PERMILLE` constants instead of the alarm ring size; smaller value for the corner gauge
- **Radar side labels:** drop the shadow halo on selected targets (bold arrow outline is sufficient); increase callsign vertical offset for clearer separation from altitude/vario text
- **Map traffic icons:** raise `MAP_TRAFFIC_ICON_VPT` from 36 to 50 for better readability on high-DPI displays

Closes #2708

/cc @fraktal-sb — you reported this; would you review on UNIX/Kobo/Android with your test data?

## Test plan

- [ ] Load Test12.txt replay data on UNIX
- [ ] Verify no-position targets show a small dot (not ring-sized) on full radar and corner gauge
- [ ] Select a radar target: labels readable without shadow halo, callsign separated from alt/vario
- [ ] Check map FLARM arrows are appropriately sized vs other map elements
- [ ] Spot-check on Kobo and Android if available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved FLARM traffic display scaling, making map traffic arrows and target circles more visible.
  * Adjusted radar overlay geometry for clearer target labels and positioning.
  * Improved sizing and spacing of traffic labels across map views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->