### PR TITLE
Quick Guide: expose startup settings in Config and on info pages

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -231,6 +231,10 @@ Version 7.45 - not yet released
   - Quick Guide, help & configuration checklists: list checkboxes use dialog
     look and min touch row height; keyboard focus frame on the checkbox; override
     touch autodetection with -touchscreen or -notouchscreen (non-Android) #2325
+  - Quick Guide: "Don't show this guide again" on every informational page;
+    skip Welcome on startup when the guide is hidden; Config → Look →
+    Language, Input controls startup visibility, release notes on next
+    startup, and safety disclaimer acceptance #2648
   - waypoint search: stays open until Esc or a successful GoTo / task / home / pan
     action (pan ends the search so the map is not hidden under the list); same for
     WaypointDetails select and WaypointDetailsPersistent (was: only after closing

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -19,6 +19,7 @@
 #include "UIGlobals.hpp"
 #include "Hardware/Vibrator.hpp"
 #include "Repository/FileType.hpp"
+#include "Version.hpp"
 
 using namespace std::chrono;
 
@@ -31,7 +32,12 @@ enum ControlIndex {
 #endif
   MenuTimeout,
   TextInput,
-  HapticFeedback
+#ifdef HAVE_VIBRATOR
+  HapticFeedback,
+#endif
+  ShowQuickGuideOnStartup,
+  ShowReleaseNotesOnStartup,
+  DisclaimerAccepted,
 };
 
 class InterfaceConfigPanel final : public RowFormWidget {
@@ -183,6 +189,41 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
                haptic_feedback_list, (unsigned)settings.haptic_feedback);
   SetExpertRow(HapticFeedback);
 #endif /* HAVE_VIBRATOR */
+
+  bool hide_quick_guide = false;
+  Profile::Get(ProfileKeys::HideQuickGuideDialogOnStartup,
+               hide_quick_guide);
+  AddBoolean(_("Show Quick Guide"),
+             _("If enabled, the Quick Guide is shown when XCSoar starts."),
+             !hide_quick_guide);
+
+  const char *last_seen_news =
+    Profile::Get(ProfileKeys::LastSeenNewsVersion);
+  const bool news_seen = last_seen_news != nullptr &&
+    StringIsEqual(last_seen_news, XCSoar_Version);
+  AddBoolean(_("Show release notes"),
+             _("If enabled, the What's New page is shown on the next "
+               "startup."),
+             !news_seen);
+
+  const char *disclaimer_acknowledged_version =
+    Profile::Get(ProfileKeys::DisclaimerAcknowledgedVersion);
+  const bool disclaimer_acknowledged =
+    disclaimer_acknowledged_version != nullptr &&
+    StringIsEqual(disclaimer_acknowledged_version, XCSoar_Version);
+
+  static constexpr StaticEnumChoice disclaimer_accepted_list[] = {
+    { 0, N_("No") },
+    { 1, N_("Yes") },
+    nullptr
+  };
+
+  AddEnum(_("Safety disclaimer accepted"),
+          _("Whether the safety disclaimer has been accepted for this "
+            "version."),
+          disclaimer_accepted_list,
+          disclaimer_acknowledged ? 1u : 0u);
+  SetExpertRow(DisclaimerAccepted);
 }
 
 bool
@@ -260,6 +301,42 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
 #ifdef HAVE_VIBRATOR
   changed |= SaveValueEnum(HapticFeedback, ProfileKeys::HapticFeedback, settings.haptic_feedback);
 #endif
+
+  bool hide_quick_guide = false;
+  Profile::Get(ProfileKeys::HideQuickGuideDialogOnStartup, hide_quick_guide);
+  if (SaveValue(ShowQuickGuideOnStartup,
+                ProfileKeys::HideQuickGuideDialogOnStartup,
+                hide_quick_guide, true))
+    changed = true;
+
+  const bool show_release_notes = GetValueBoolean(ShowReleaseNotesOnStartup);
+  const char *last_seen_news =
+    Profile::Get(ProfileKeys::LastSeenNewsVersion);
+  const bool news_seen = last_seen_news != nullptr &&
+    StringIsEqual(last_seen_news, XCSoar_Version);
+  if (show_release_notes != !news_seen) {
+    if (show_release_notes)
+      Profile::Set(ProfileKeys::LastSeenNewsVersion, "");
+    else
+      Profile::Set(ProfileKeys::LastSeenNewsVersion, XCSoar_Version);
+    changed = true;
+  }
+
+  const bool disclaimer_accepted =
+    GetValueEnum(DisclaimerAccepted) != 0;
+  const char *disclaimer_acknowledged_version =
+    Profile::Get(ProfileKeys::DisclaimerAcknowledgedVersion);
+  const bool disclaimer_acknowledged =
+    disclaimer_acknowledged_version != nullptr &&
+    StringIsEqual(disclaimer_acknowledged_version, XCSoar_Version);
+  if (disclaimer_accepted != disclaimer_acknowledged) {
+    if (disclaimer_accepted)
+      Profile::Set(ProfileKeys::DisclaimerAcknowledgedVersion,
+                   XCSoar_Version);
+    else
+      Profile::Set(ProfileKeys::DisclaimerAcknowledgedVersion, "");
+    changed = true;
+  }
 
   _changed |= changed;
   return true;

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "util/StringCompare.hxx"
 #include "util/StaticString.hxx"
+#include "util/Macros.hpp"
 #include "MapSettings.hpp"
 #include "Computer/Settings.hpp"
 
@@ -38,6 +39,9 @@
 // Page indices for the can-advance guard
 static constexpr unsigned INVALID_PAGE = ~0u;
 
+/** Index within #info_page_titles for the dynamic Getting Started page. */
+static constexpr std::size_t GETTING_STARTED_INFO_PAGE_INDEX = 1;
+
 /**
  * Track conditional page indices for post-dialog result handling.
  */
@@ -46,8 +50,9 @@ struct QuickGuideState {
   unsigned news_page_index = INVALID_PAGE;
   unsigned cloud_page_index = INVALID_PAGE;
   unsigned location_page_index = INVALID_PAGE;
+  unsigned first_info_page_index = INVALID_PAGE;
   bool warranty_accepted = false;
-  QuickGuidePageWidget *warranty_widget = nullptr;
+  bool hide_guide_checked = false;
 };
 
 /* ---- Welcome / Logo page text ---- */
@@ -461,6 +466,29 @@ dlgQuickGuideShowModal(bool force_info)
 #endif
   const bool info_pages_needed = force_info || !IsQuickGuideHidden();
 
+  static constexpr const char *info_page_titles[] = {
+    N_("Gesture Navigation"),
+    N_("Getting Started"),
+    N_("Preflight"),
+    N_("After Your Flight"),
+    N_("Done"),
+  };
+
+  static const char *(*const info_page_texts[])() = {
+    GetGestureHelpText,
+    GetConfigurationHelpText,
+    GetPreflightText,
+    GetPostflightText,
+    []() -> const char * {
+      return _("# That's it!\n\n"
+                "You can revisit the gesture help from the "
+                "**Info** menu at any time.");
+    },
+  };
+
+  static_assert(ARRAY_SIZE(info_page_titles) == ARRAY_SIZE(info_page_texts),
+                "Quick Guide info page tables must match");
+
   // If everything is already satisfied, skip the dialog entirely
   if (!warranty_needed && !news_needed &&
       !cloud_needed && !permissions_needed && !info_pages_needed)
@@ -473,6 +501,7 @@ dlgQuickGuideShowModal(bool force_info)
                       look, _("Welcome to XCSoar"));
 
   QuickGuideState state;
+  state.hide_guide_checked = IsQuickGuideHidden();
 
   auto pager = std::make_unique<ArrowPagerWidget>(
     look.button, [&dialog, &state, warranty_needed]() {
@@ -498,10 +527,12 @@ dlgQuickGuideShowModal(bool force_info)
     return std::make_unique<VScrollWidget>(std::move(w), look, true);
   };
 
-  /* ---- Logo / Welcome page (always shown) ---- */
-  pager->Add(make_scroll_page(
-    std::make_unique<RichTextWidget>(look, GetWelcomeText(look.dark_mode))));
-  titles.push_back(_("Welcome"));
+  /* ---- Logo / Welcome page (only with informational guide pages) ---- */
+  if (info_pages_needed) {
+    pager->Add(make_scroll_page(
+      std::make_unique<RichTextWidget>(look, GetWelcomeText(look.dark_mode))));
+    titles.push_back(_("Welcome"));
+  }
 
   /* ---- Warranty page (conditional) ---- */
   if (warranty_needed) {
@@ -518,8 +549,6 @@ dlgQuickGuideShowModal(bool force_info)
                                          ? _("Close")
                                          : _("Quit"));
       });
-    state.warranty_widget = page.get();
-
     pager->Add(std::move(page));
     titles.push_back(_("Safety Disclaimer"));
   }
@@ -615,52 +644,29 @@ dlgQuickGuideShowModal(bool force_info)
 #endif
 
   /* ---- Informational pages (conditional) ---- */
-  unsigned config_page_index = INVALID_PAGE;
-  RichTextWidget *config_widget_ptr = nullptr;
 
   if (info_pages_needed) {
-    // Gestures
-    pager->Add(make_scroll_page(
-      std::make_unique<RichTextWidget>(look, GetGestureHelpText())));
-    titles.push_back(_("Gesture Navigation"));
+    state.first_info_page_index = pager->GetSize();
 
-    // Configuration (checkboxes reflect current profile state)
-    auto config_widget =
-      std::make_unique<RichTextWidget>(look, GetConfigurationHelpText());
-    config_widget_ptr = config_widget.get();
-    config_widget->SetLinkReturnCallback([config_widget_ptr]() {
-      /* Refresh checkbox state after returning from a config dialog */
-      config_widget_ptr->SetText(GetConfigurationHelpText());
-    });
-    pager->Add(make_scroll_page(std::move(config_widget)));
-    config_page_index = pager->GetSize() - 1;
-    titles.push_back(_("Getting Started"));
-
-    // Preflight
-    pager->Add(make_scroll_page(
-      std::make_unique<RichTextWidget>(look, GetPreflightText())));
-    titles.push_back(_("Preflight"));
-
-    // Postflight
-    pager->Add(make_scroll_page(
-      std::make_unique<RichTextWidget>(look, GetPostflightText())));
-    titles.push_back(_("After Your Flight"));
-
-    // Don't show again - using a checkbox page
-    {
-      auto done_page = QuickGuidePageWidget::CreateCheckboxPage(
-        look,
-        _("# That's it!\n\n"
-          "You can revisit the gesture help from the "
-          "**Info** menu at any time.\n\n"
-          "Check the box below to skip this guide on "
-          "future startups."),
+    for (std::size_t i = 0; i < ARRAY_SIZE(info_page_titles); ++i) {
+      auto page = QuickGuidePageWidget::CreateCheckboxPage(
+        look, info_page_texts[i](),
         _("Don't show this guide again"),
-        IsQuickGuideHidden(),
-        [](bool) { /* state is read on dialog close */ });
-      pager->Add(std::move(done_page));
+        state.hide_guide_checked,
+        [&state](bool checked) {
+          state.hide_guide_checked = checked;
+        });
+
+      if (i == GETTING_STARTED_INFO_PAGE_INDEX) {
+        QuickGuidePageWidget *page_ptr = page.get();
+        page->SetLinkReturnCallback([page_ptr]() {
+          page_ptr->SetText(GetConfigurationHelpText());
+        });
+      }
+
+      pager->Add(std::move(page));
+      titles.push_back(gettext(info_page_titles[i]));
     }
-    titles.push_back(_("Done"));
   }
 
   // If no pages were added, skip
@@ -684,15 +690,22 @@ dlgQuickGuideShowModal(bool force_info)
   const unsigned total_pages = pager->GetSize();
 
   auto update_caption =
-    [&dialog, &titles, pager_ptr, total_pages,
-     config_page_index, config_widget_ptr]() {
+    [&dialog, &titles, pager_ptr, total_pages, &state]() {
     const unsigned current = pager_ptr->GetCurrentIndex();
 
-    /* Refresh the "Getting Started" checkboxes every time the
-       page becomes visible, so changes made via xcsoar:// links
-       are reflected immediately. */
-    if (current == config_page_index && config_widget_ptr != nullptr)
-      config_widget_ptr->SetText(GetConfigurationHelpText());
+    if (state.first_info_page_index != INVALID_PAGE &&
+        current >= state.first_info_page_index &&
+        current < state.first_info_page_index +
+        ARRAY_SIZE(info_page_titles)) {
+      auto &page_widget = pager_ptr->GetWidget(current);
+      if (auto *page = dynamic_cast<QuickGuidePageWidget *>(&page_widget)) {
+        page->SetCheckboxState(state.hide_guide_checked);
+
+        if (current == state.first_info_page_index +
+            GETTING_STARTED_INFO_PAGE_INDEX)
+          page->SetText(GetConfigurationHelpText());
+      }
+    }
 
     StaticString<128> caption;
     if (current < titles.size())
@@ -760,17 +773,9 @@ dlgQuickGuideShowModal(bool force_info)
   // Save "don't show again" state (both checked and unchecked,
   // so unticking from the Info menu re-enables the guide)
   if (info_pages_needed) {
-    // The last page is the don't-show-again page
-    const unsigned last_page_idx = total_pages - 1;
-    auto &last_widget = static_cast<ArrowPagerWidget &>(
-      dialog.GetWidget()).GetWidget(last_page_idx);
-    auto *guide_page =
-      dynamic_cast<QuickGuidePageWidget *>(&last_widget);
-    if (guide_page != nullptr) {
-      Profile::Set(ProfileKeys::HideQuickGuideDialogOnStartup,
-                   guide_page->GetCheckboxState());
-      Profile::Save();
-    }
+    Profile::Set(ProfileKeys::HideQuickGuideDialogOnStartup,
+                 state.hide_guide_checked);
+    Profile::Save();
   }
 
   (void)result;

--- a/src/Widget/QuickGuidePageWidget.cpp
+++ b/src/Widget/QuickGuidePageWidget.cpp
@@ -29,6 +29,12 @@ QuickGuidePageWidget::SetGestureCallback(std::function<void(bool)> cb) noexcept
       gesture_callback);
 }
 
+void
+QuickGuidePageWidget::SetLinkReturnCallback(std::function<void()> cb) noexcept
+{
+  link_return_callback = std::move(cb);
+}
+
 std::unique_ptr<QuickGuidePageWidget>
 QuickGuidePageWidget::CreateContentPage(
   const DialogLook &look,
@@ -108,8 +114,12 @@ void
 QuickGuidePageWidget::SetText(const char *text) noexcept
 {
   markdown_text = text ? text : "";
-  // If the scroll widget already has a RichTextWidget inside,
-  // we can't easily update it. The caller should recreate the page.
+  if (scroll_widget == nullptr)
+    return;
+
+  auto &rich_text = static_cast<RichTextWidget &>(
+    static_cast<VScrollWidget &>(*scroll_widget).GetWidget());
+  rich_text.SetText(markdown_text.c_str());
 }
 
 QuickGuidePageWidget::PageLayout
@@ -156,6 +166,8 @@ QuickGuidePageWidget::Initialise(ContainerWindow &parent,
   // Create the RichTextWidget wrapped in VScrollWidget
   auto rich_text = std::make_unique<RichTextWidget>(
     look, markdown_text.c_str(), parse_links);
+  if (link_return_callback)
+    rich_text->SetLinkReturnCallback(link_return_callback);
   auto scroll = std::make_unique<VScrollWidget>(
     std::move(rich_text), look, true);
 

--- a/src/Widget/QuickGuidePageWidget.hpp
+++ b/src/Widget/QuickGuidePageWidget.hpp
@@ -74,6 +74,12 @@ private:
    */
   std::function<void(bool)> gesture_callback;
 
+  /**
+   * Optional callback after an internal (xcsoar://) link dialog
+   * closes, forwarded to the internal RichTextWidget.
+   */
+  std::function<void()> link_return_callback;
+
 public:
   explicit QuickGuidePageWidget(const DialogLook &_look,
                                 const char *_markdown_text) noexcept;
@@ -95,6 +101,13 @@ public:
    * after #Initialise().
    */
   void SetGestureCallback(std::function<void(bool)> cb) noexcept;
+
+  /**
+   * Set a callback invoked after an internal (xcsoar://) link dialog
+   * closes.  Must be called before Initialise().
+   */
+  void SetLinkReturnCallback(std::function<void()> cb) noexcept;
+
   ~QuickGuidePageWidget() noexcept override;
 
   /**


### PR DESCRIPTION
Closes #2648

## Summary

- **Config → Look → Language, Input:** Add controls for showing the Quick Guide on startup, showing release notes on the next startup, and resetting safety disclaimer acceptance for the current version (expert row).
- **Quick Guide dialog:** Show "Don't show this guide again" on all informational pages (Gesture through Done) with shared state synced on page flips; persist checked and unchecked on close so the guide can be re-enabled from Info → Quick Guide.
- **Startup flow:** Skip the Welcome page when the guide is hidden on startup; disclaimer, release notes, cloud consent, and Android permission pages still show when needed.
- **QuickGuidePageWidget:** Support live markdown updates and `xcsoar://` link-return callbacks so the Getting Started checklist refreshes after config links.

## Commits

1. `QuickGuidePageWidget`: live `SetText()` and link-return callbacks
2. `InterfaceConfigPanel`: startup guide / release notes / disclaimer settings (+ `HAVE_VIBRATOR` enum guard)
3. `Dialogs/dlgQuickGuide`: hide-guide checkbox on info pages, conditional Welcome, checklist refresh
4. `NEWS.txt`: release notes

## Test plan

- [ ] Fresh profile: full startup Quick Guide flow (disclaimer → news → info pages)
- [ ] Check "Don't show this guide again" on an early info page; verify it stays checked on later pages and survives restart
- [ ] Uncheck from Info → Quick Guide; verify guide shows again on next startup
- [ ] With hide guide enabled: startup shows only mandatory pages (no Welcome, no info section)
- [ ] Config → toggle Show Quick Guide / Show release notes / Safety disclaimer accepted; verify on next startup
- [ ] Getting Started: follow an `xcsoar://config/…` link, return, verify checklist marks update
- [ ] Android: location disclosure still requires Continue/Not Now (swipe Next disabled)
- [ ] Build without `HAVE_VIBRATOR`: Config → Language, Input opens without crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interface options to control the Quick Guide, release notes, and safety disclaimer reminders, with settings persisted across sessions.
  * Enhanced the Quick Guide with dynamic informational pages, including a “Don’t show this guide again” option and updated “Getting Started” handling when returning from linked help.
  * Updated startup behavior so Welcome can be skipped when the guide is hidden.
* **Bug Fixes**
  * Improved Quick Guide text refresh so updates apply without recreating pages.
  * Hid haptic feedback options when vibration support isn’t available.
* **Documentation**
  * Updated Quick Guide release notes to describe the new optional reminder controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->