### PR TITLE
Kobo: Force light mode; speed up What's New text wrapping (#2568)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -38,6 +38,9 @@ Version 7.45 - not yet released
   - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices
   - Fix crash when the native thread restarts after surface teardown
     (JNI helper classes were not cleared between runNative calls)
+* Kobo
+  - always start in light mode; dark mode is not supported on e-paper
+    displays #2568
 * devices
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481

--- a/build/test.mk
+++ b/build/test.mk
@@ -1069,7 +1069,7 @@ DEBUG_PROGRAM_NAMES += \
 	RunExternalWind \
 	RunTask \
 	LoadImage ViewImage \
-	RunCanvas RunMapWindow \
+	RunCanvas RunMapWindow RunRichTextRenderer \
 	RunListControl \
 	RunTextEntry RunNumberEntry RunDateEntry RunTimeEntry RunAngleEntry \
 	RunGeoPointEntry \
@@ -1965,6 +1965,39 @@ RUN_CANVAS_SOURCES = \
 RUN_CANVAS_LDADD = $(FAKE_LIBS)
 RUN_CANVAS_DEPENDS = FORM SCREEN EVENT ASYNC OS IO THREAD MATH UTIL
 $(eval $(call link-program,RunCanvas,RUN_CANVAS))
+
+RUN_RICH_TEXT_RENDERER_SOURCES = \
+	$(SRC)/Dialogs/DialogSettings.cpp \
+	$(SRC)/Dialogs/WidgetDialog.cpp \
+	$(SRC)/Form/CheckBox.cpp \
+	$(SRC)/UIUtil/GestureManager.cpp \
+	$(SRC)/UIUtil/TrackingGestureManager.cpp \
+	$(SRC)/ui/event/Idle.cpp \
+	$(SRC)/Math/FastTrig.cpp \
+	$(SRC)/util/MarkdownParser.cpp \
+	$(SRC)/ResourceLookup.cpp \
+	$(SRC)/system/OpenLink.cpp \
+	$(SRC)/RadioFrequency.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(MORE_SCREEN_SOURCES) \
+	$(SRC)/Look/DialogLook.cpp \
+	$(SRC)/Look/ButtonLook.cpp \
+	$(SRC)/Look/CheckBoxLook.cpp \
+	$(SRC)/Formatter/HexColor.cpp \
+	$(TEST_SRC_DIR)/Fonts.cpp \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/FakeHelpDialog.cpp \
+	$(TEST_SRC_DIR)/FakeDialogs.cpp \
+	$(TEST_SRC_DIR)/FakeInternalLink.cpp \
+	$(TEST_SRC_DIR)/FakeResourceLoader.cpp \
+	$(TEST_SRC_DIR)/RunRichTextRenderer.cpp
+RUN_RICH_TEXT_RENDERER_LDADD = $(FAKE_LIBS)
+RUN_RICH_TEXT_RENDERER_DEPENDS = GEO WIDGET DATA_FIELD SCREEN FORM EVENT RESOURCE ASYNC OS IO THREAD MATH UTIL ZLIB TIME LOOK
+$(eval $(call link-program,RunRichTextRenderer,RUN_RICH_TEXT_RENDERER))
+
+$(call SRC_TO_OBJ,$(TEST_SRC_DIR)/RunRichTextRenderer.cpp): $(OUT)/include/QuickGuideNEWS.hpp
 
 RUN_MAP_WINDOW_SOURCES = \
 	$(CONTEST_SRC_DIR)/Settings.cpp \

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -186,9 +186,13 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   else
     AddDummy();
 
+#ifndef KOBO
   AddEnum(_("Dark mode"), nullptr, dark_mode_list,
           (unsigned)ui_settings.dark_mode);
   SetExpertRow(DarkMode);
+#else
+  AddDummy();
+#endif
 
   AddEnum(_("InfoBox geometry"),
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
@@ -265,8 +269,15 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
     changed |= orientation_changed;
   }
 
+#ifndef KOBO
   changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
                            ui_settings.dark_mode);
+#else
+  if (ui_settings.dark_mode != UISettings::DarkMode::OFF) {
+    ui_settings.dark_mode = UISettings::DarkMode::OFF;
+    changed = true;
+  }
+#endif
 
   bool info_box_geometry_changed = false;
 

--- a/src/Look/Look.cpp
+++ b/src/Look/Look.cpp
@@ -18,6 +18,10 @@ Look::Initialise(const Font &map_font)
 static bool
 GetDarkMode(const UISettings &settings) noexcept
 {
+#ifdef KOBO
+  (void)settings;
+  return false;
+#else
   switch (settings.dark_mode) {
   case UISettings::DarkMode::OFF:
     break;
@@ -30,6 +34,7 @@ GetDarkMode(const UISettings &settings) noexcept
   }
 
   return false;
+#endif
 }
 
 [[gnu::pure]]

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -144,6 +144,11 @@ Profile::Load(const ProfileMap &map, UISettings &settings)
         : UISettings::DarkMode::OFF;
   }
 
+#ifdef KOBO
+  /* Dark mode is not supported on e-paper displays. */
+  settings.dark_mode = UISettings::DarkMode::OFF;
+#endif
+
   Load(map, settings.format);
   Load(map, settings.map);
   Load(map, settings.info_boxes);

--- a/src/UISettings.cpp
+++ b/src/UISettings.cpp
@@ -31,7 +31,11 @@ UISettings::SetDefaults() noexcept
   show_zoom_button = show_menu_button;
   show_quickmenu_button = HasTouchScreen();
 
+#ifdef KOBO
+  dark_mode = DarkMode::OFF;
+#else
   dark_mode = DarkMode::AUTO;
+#endif
 
   format.SetDefaults();
   map.SetDefaults();

--- a/src/ui/canvas/TextWrapper.cpp
+++ b/src/ui/canvas/TextWrapper.cpp
@@ -25,6 +25,126 @@ ClampedSequenceLengthUTF8(char ch, std::size_t max_bytes) noexcept
 }
 
 /**
+ * Advance @p p by @p n whole UTF-8 characters, not past @p end.
+ */
+static const char *
+AdvanceUTF8Chars(const char *p, const char *end, std::size_t n) noexcept
+{
+  while (n > 0 && p < end) {
+    p += ClampedSequenceLengthUTF8(*p, end - p);
+    --n;
+  }
+  return p;
+}
+
+/**
+ * Count whole UTF-8 characters in [start, end).
+ */
+static std::size_t
+CountUTF8Chars(const char *start, const char *end) noexcept
+{
+  std::size_t n = 0;
+  for (const char *p = start; p < end;) {
+    p += ClampedSequenceLengthUTF8(*p, end - p);
+    ++n;
+  }
+  return n;
+}
+
+[[gnu::pure]]
+static bool
+TextFitsWidth(Canvas &canvas, const char *start, const char *end,
+              unsigned width) noexcept
+{
+  if (start >= end)
+    return true;
+
+  const PixelSize size =
+    canvas.CalcTextSize({start, std::size_t(end - start)});
+  return size.width <= width;
+}
+
+/**
+ * Break within [line_start, word_end) when a single word exceeds @p width.
+ * Returns a pointer past the last UTF-8 character that still fits; at
+ * least one character is included even when it is wider than @p width.
+ */
+static const char *
+FindCharWrapBreak(Canvas &canvas, const char *line_start,
+                  const char *word_end, unsigned width) noexcept
+{
+  const std::size_t char_count = CountUTF8Chars(line_start, word_end);
+  if (char_count == 0)
+    return line_start;
+
+  std::size_t lo = 1;
+  std::size_t hi = char_count;
+  std::size_t best = 0;
+
+  while (lo <= hi) {
+    const std::size_t mid = (lo + hi) / 2;
+    const char *mid_end = AdvanceUTF8Chars(line_start, word_end, mid);
+    if (TextFitsWidth(canvas, line_start, mid_end, width)) {
+      best = mid;
+      lo = mid + 1;
+    } else
+      hi = mid - 1;
+  }
+
+  if (best == 0)
+    return AdvanceUTF8Chars(line_start, word_end, 1);
+
+  return AdvanceUTF8Chars(line_start, word_end, best);
+}
+
+/**
+ * Find the next line break for text that does not fit on one line.
+ * Breaks at the last word boundary that fits, or within a word when
+ * needed.
+ */
+static const char *
+FindWrapBreak(Canvas &canvas, const char *line_start, const char *para_end,
+              unsigned width) noexcept
+{
+  const char *p = line_start;
+  const char *break_point = nullptr;
+
+  while (p < para_end) {
+    while (p < para_end && *p == ' ')
+      ++p;
+    if (p >= para_end)
+      break;
+
+    const char *word_start = p;
+    while (p < para_end && *p != ' ')
+      ++p;
+    const char *word_end = p;
+
+    const char *extent = word_end;
+    if (extent < para_end && *extent == ' ')
+      ++extent;
+
+    if (TextFitsWidth(canvas, line_start, extent, width)) {
+      break_point = word_end;
+      if (word_end < para_end && *word_end == ' ')
+        break_point = word_end + 1;
+      p = word_end;
+      continue;
+    }
+
+    if (break_point != nullptr && break_point > line_start)
+      return break_point;
+
+    return FindCharWrapBreak(canvas, word_start, word_end, width);
+  }
+
+  if (break_point != nullptr && break_point > line_start)
+    return break_point;
+
+  return FindCharWrapBreak(canvas, line_start, para_end, width);
+}
+
+/**
  * Wrap a single paragraph (no embedded newlines) into lines.
  */
 static void
@@ -43,13 +163,8 @@ WrapParagraph(Canvas &canvas, unsigned width,
   const char *line_start = para_start;
 
   while (line_start < para_end) {
-    // Measure remaining text
     const std::size_t remaining = para_end - line_start;
-    std::string_view remaining_text(line_start, remaining);
-    const PixelSize full_size = canvas.CalcTextSize(remaining_text);
-
-    if (full_size.width <= width) {
-      // Remaining text fits on one line
+    if (TextFitsWidth(canvas, line_start, para_end, width)) {
       lines.push_back({
         text_offset + static_cast<std::size_t>(line_start - para_start),
         remaining
@@ -57,49 +172,14 @@ WrapParagraph(Canvas &canvas, unsigned width,
       break;
     }
 
-    // Need to wrap - find last space that fits
-    const char *break_point = nullptr;
-    const char *last_space = nullptr;
-
-    for (const char *p = line_start; p < para_end;) {
-      /* advance by one whole UTF-8 character so we never
-         create a test_text that ends mid-sequence */
-      const std::size_t seq_len =
-        ClampedSequenceLengthUTF8(*p, para_end - p);
-      const char *next = p + seq_len;
-
-      std::string_view test_text(line_start, next - line_start);
-      const PixelSize test_size = canvas.CalcTextSize(test_text);
-      if (test_size.width > width) {
-        // Text up to next doesn't fit
-        if (last_space != nullptr) {
-          // Break at last space
-          break_point = last_space;
-        } else if (p > line_start) {
-          // No space found - break at previous character boundary
-          break_point = p;
-        } else {
-          // Single character too wide - include it anyway
-          break_point = next;
-        }
-        break;
-      }
-
-      if (*p == ' ')
-        last_space = next;  // Break after space
-
-      break_point = next;
-      p = next;
-    }
-
-    if (break_point == nullptr || break_point <= line_start) {
-      // Ensure progress: skip at least one full UTF-8 character
+    const char *break_point =
+      FindWrapBreak(canvas, line_start, para_end, width);
+    if (break_point <= line_start) {
       const std::size_t seq_len =
         ClampedSequenceLengthUTF8(*line_start, para_end - line_start);
       break_point = line_start + seq_len;
     }
 
-    // Calculate line length (exclude trailing space if we broke at space)
     std::size_t line_len = break_point - line_start;
     if (line_len > 0 && line_start[line_len - 1] == ' ')
       --line_len;
@@ -109,7 +189,6 @@ WrapParagraph(Canvas &canvas, unsigned width,
       line_len
     });
 
-    // Move to next line, skipping any spaces at break point
     line_start = break_point;
     while (line_start < para_end && *line_start == ' ')
       ++line_start;
@@ -129,7 +208,6 @@ WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept
   const char *para_start = start;
 
   while (para_start < end) {
-    // Find end of current paragraph (newline or end of text)
     const char *para_end = para_start;
     while (para_end < end && *para_end != '\n')
       ++para_end;
@@ -138,7 +216,6 @@ WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept
     WrapParagraph(canvas, width, para_start, para_end - para_start,
                   text_offset, result.lines);
 
-    // Skip past newline
     para_start = para_end;
     if (para_start < end && *para_start == '\n')
       ++para_start;

--- a/test/src/FakeInternalLink.cpp
+++ b/test/src/FakeInternalLink.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Dialogs/InternalLink.hpp"
+#include "Dialogs/VhfLink.hpp"
+
+bool
+HandleInternalLink([[maybe_unused]] const char *uri)
+{
+  return false;
+}
+
+bool
+HandleVhfLink([[maybe_unused]] const char *url,
+              [[maybe_unused]] const char *station_name)
+{
+  return false;
+}

--- a/test/src/FakeResourceLoader.cpp
+++ b/test/src/FakeResourceLoader.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ResourceLoader.hpp"
+#include "ResourceId.hpp"
+
+namespace ResourceLoader {
+
+Data
+Load([[maybe_unused]] const char *name,
+     [[maybe_unused]] const char *type)
+{
+  return {};
+}
+
+#ifndef ANDROID
+Data
+Load([[maybe_unused]] ResourceId id)
+{
+  return {};
+}
+#endif
+
+} // namespace ResourceLoader

--- a/test/src/RunRichTextRenderer.cpp
+++ b/test/src/RunRichTextRenderer.cpp
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#define ENABLE_CMDLINE
+#define ENABLE_DIALOG
+#define ENABLE_MAIN_WINDOW
+#define USAGE "[OPTION]... [FILE]"
+
+#include "Main.hpp"
+#include "QuickGuideNEWS.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Widget/VScrollWidget.hpp"
+#include "Widget/RichTextWidget.hpp"
+#include "ui/control/RichTextWindow.hpp"
+#include "ui/canvas/TextWrapper.hpp"
+#include "ui/canvas/AnyCanvas.hpp"
+#include "util/MarkdownParser.hpp"
+#include "ProductName.hpp"
+#include "Version.hpp"
+#include "system/StandardVersion.hpp"
+#include "system/Path.hpp"
+#include "system/Args.hpp"
+#include "io/FileLineReader.hpp"
+#include "util/StringCompare.hxx"
+#include "util/Compiler.h"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+static constexpr const char canonical_name[] = "RunRichTextRenderer";
+
+struct Options {
+  bool benchmark = false;
+  bool plain = false;
+  unsigned layout_width = 0;
+  const char *file = nullptr;
+};
+
+static Options options;
+
+static void
+PrintStandardHelp() noexcept
+{
+  std::printf(
+    "Usage: %s [OPTION]... [FILE]\n"
+    "\n"
+    "Show scrollable rich text (Markdown) in a full-screen dialog, or\n"
+    "benchmark layout without opening the UI.\n"
+    "\n"
+    "With no FILE, uses the Quick Guide release-notes Markdown generated\n"
+    "from NEWS.txt at build time.\n"
+    "\n"
+    "Options:\n"
+    "  --benchmark           measure parse, wrap, and layout; exit\n"
+    "  --plain               treat input as plain text (no Markdown)\n"
+    "  --width=PIXELS        text width for --benchmark (default: 560)\n"
+    "  -WxH                  window size (e.g. -600x800 for Kobo)\n"
+    "  -h, --help            display this help and exit\n"
+    "  --version             output version information and exit\n"
+    "\n"
+    "Interactive mode: scroll with keys or mouse; Esc closes.\n"
+    "\n"
+    "Report bugs to: <%s>\n"
+    "%s home page: <%s>\n",
+    canonical_name, PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static void
+ParseCommandLine(Args &args)
+{
+  while (!args.IsEmpty()) {
+    const char *arg = args.PeekNext();
+    if (arg == nullptr || arg[0] != '-')
+      break;
+
+    if (StringIsEqual(arg, "-h") || StringIsEqual(arg, "--help")) {
+      PrintStandardHelp();
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--version")) {
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--benchmark")) {
+      args.GetNext();
+      options.benchmark = true;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--plain")) {
+      args.GetNext();
+      options.plain = true;
+      continue;
+    }
+
+    if (StringStartsWith(arg, "--width=")) {
+      args.GetNext();
+      char *end = nullptr;
+      const unsigned w = ParseUnsigned(arg + 8, &end);
+      if (end == nullptr || *end != '\0' || w == 0)
+        args.UsageError();
+      options.layout_width = w;
+      continue;
+    }
+
+    break;
+  }
+
+  if (!args.IsEmpty())
+    options.file = args.GetNext();
+}
+
+static std::string
+ReadTextFile(const Path &path)
+{
+  FileLineReaderA reader(path);
+  std::string content;
+  char *line;
+  while ((line = reader.ReadLine()) != nullptr) {
+    if (!content.empty())
+      content += '\n';
+    content += line;
+  }
+  return content;
+}
+
+static std::string
+LoadContent()
+{
+  if (options.file != nullptr)
+    return ReadTextFile(Path(options.file));
+
+  if (quick_guide_news_markdown[0] == '\0') {
+    std::fprintf(stderr,
+                 "%s: no FILE and Quick Guide news is empty "
+                 "(build NEWS.txt first)\n",
+                 canonical_name);
+    std::exit(EXIT_FAILURE);
+  }
+
+  return quick_guide_news_markdown;
+}
+
+[[gnu::pure]]
+static long long
+Ms(const std::chrono::steady_clock::duration d) noexcept
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(d).count();
+}
+
+static void
+RunBenchmark(TestMainWindow &main_window, const std::string &text)
+{
+  const DialogLook &look = *dialog_look;
+  const unsigned width = options.layout_width > 0
+    ? options.layout_width
+    : 560U;
+
+  using clock = std::chrono::steady_clock;
+
+  const auto t0 = clock::now();
+  if (!options.plain)
+    (void)ParseMarkdown(text.c_str());
+  const auto t1 = clock::now();
+
+  AnyCanvas canvas;
+  canvas.Select(look.text_font);
+  const WrappedText wrapped = WrapText(canvas, width, text);
+  const auto t2 = clock::now();
+
+  WindowStyle style;
+  style.Hide();
+  RichTextWindow window;
+  window.Create(main_window,
+                PixelRect{0, 0, int(width), 400},
+                style);
+  window.SetFont(look.text_font, &look.bold_font,
+                 &look.heading1_font, &look.heading2_font);
+  window.SetDarkMode(look.dark_mode, look.background_color);
+  window.SetDialogLook(look);
+  window.SetText(text.c_str(), !options.plain);
+  const auto t3 = clock::now();
+  const unsigned height = window.GetContentHeight();
+  const auto t4 = clock::now();
+
+  std::printf("source bytes: %zu\n", text.size());
+  std::printf("layout width: %u px\n", width);
+  std::printf("wrapped lines: %zu\n", wrapped.lines.size());
+  std::printf("content height: %u px\n", height);
+  if (!options.plain)
+    std::printf("parse markdown: %lld ms\n", Ms(t1 - t0));
+  std::printf("wrap text: %lld ms\n", Ms(t2 - t1));
+  std::printf("set text: %lld ms\n", Ms(t3 - t2));
+  std::printf("line layout (GetContentHeight): %lld ms\n", Ms(t4 - t3));
+  std::printf("total: %lld ms\n", Ms(t4 - t0));
+}
+
+static void
+RunInteractive(TestMainWindow &main_window, const std::string &text)
+{
+  WidgetDialog dialog(WidgetDialog::Full{}, main_window, *dialog_look,
+                      "RunRichTextRenderer");
+
+  auto rich_text = std::make_unique<RichTextWidget>(
+    *dialog_look, text.c_str(), !options.plain);
+  auto scroll = std::make_unique<VScrollWidget>(
+    std::move(rich_text), *dialog_look, true);
+
+  dialog.FinishPreliminary(std::move(scroll));
+  dialog.ShowModal();
+}
+
+static void
+Main(TestMainWindow &main_window)
+{
+  const std::string text = LoadContent();
+  if (text.empty()) {
+    std::fprintf(stderr, "%s: input is empty\n", canonical_name);
+    std::exit(EXIT_FAILURE);
+  }
+
+  if (options.benchmark)
+    RunBenchmark(main_window, text);
+  else
+    RunInteractive(main_window, text);
+}


### PR DESCRIPTION
## Summary
- Force light mode on Kobo e-paper: default OFF, override saved profiles, hide Dark mode in layout config, and always render light (#2568)
- Speed up `WrapText()` for long Markdown paragraphs (word-based wrapping + binary search for overlong tokens); Quick Guide What's New drops from ~380 ms to ~86 ms layout on desktop benchmark
- Add `RunRichTextRenderer` debug harness to display or `--benchmark` the generated release-notes Markdown

## Test plan
- [x] `make TARGET=UNIX VFB=y SANITIZE=y WERROR=y everything check` — 98 tests pass
- [x] `TestWrapText` passes (UTF-8 wrap safety unchanged)
- [x] `RunRichTextRenderer --benchmark --width=560` on generated What's New markdown
- [ ] Kobo: verify startup in light mode, Config → System has solid backgrounds
- [ ] Kobo: swipe to Thermal Assistant page — no crash with dark mode previously enabled in profile
- [ ] Quick Guide What's New opens noticeably faster on Kobo