### PR TITLE
net/http/DownloadManager: Fix queue races on download completion

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -300,6 +300,8 @@ Version 7.45 - not yet released
     yet exist; migration is marked complete only after at least one file was
     moved #2289
   - IGC and NMEA logs are stored under ``logs/`` #2289
+  - fix crash when queuing many background file downloads while others
+    complete (download manager queue race) #2624
 * devices
   - fix native crash on device reconnect (stale delayed reopen timer) #2382
   - Polar sync device setting is offered only for drivers that register polar

--- a/build/test.mk
+++ b/build/test.mk
@@ -1974,6 +1974,7 @@ RUN_RICH_TEXT_RENDERER_SOURCES = \
 	$(SRC)/UIUtil/TrackingGestureManager.cpp \
 	$(SRC)/ui/event/Idle.cpp \
 	$(SRC)/Math/FastTrig.cpp \
+	$(SRC)/Math/Angle.cpp \
 	$(SRC)/util/MarkdownParser.cpp \
 	$(SRC)/ResourceLookup.cpp \
 	$(SRC)/system/OpenLink.cpp \

--- a/src/co/InjectTask.cxx
+++ b/src/co/InjectTask.cxx
@@ -18,6 +18,8 @@ InjectTask::Start(InvokeTask _task, Callback _callback) noexcept
 	assert(_task);
 	assert(_callback);
 
+	++generation;
+
 	task = std::move(_task);
 	callback = _callback;
 	alive = true;
@@ -35,10 +37,13 @@ InjectTask::Cancel() noexcept
 
 	inject_event.Cancel();
 
-	BlockingCall(GetEventLoop(), [this](){
-		/* this actually cancels and disposes the coroutine
-		   which is already running */
-		task = {};
+	const unsigned cancel_generation = generation.load();
+
+	BlockingCall(GetEventLoop(), [this, cancel_generation](){
+		/* dispose the coroutine only if no new Start() happened
+		   while this cancel was waiting for the event loop */
+		if (generation.load() == cancel_generation)
+			task = {};
 	});
 
 	alive = false;
@@ -47,8 +52,8 @@ InjectTask::Cancel() noexcept
 void
 InjectTask::OnInject() noexcept
 {
-	assert(alive);
-	assert(task);
+	if (!alive || !task)
+		return;
 
 	task.Start(BIND_THIS_METHOD(OnCompletion));
 }
@@ -56,7 +61,8 @@ InjectTask::OnInject() noexcept
 void
 InjectTask::OnCompletion(std::exception_ptr error) noexcept
 {
-	assert(alive);
+	if (!alive)
+		return;
 
 	alive = false;
 

--- a/src/co/InjectTask.cxx
+++ b/src/co/InjectTask.cxx
@@ -35,18 +35,19 @@ InjectTask::Cancel() noexcept
 		return;
 	}
 
-	inject_event.Cancel();
+  inject_event.Cancel();
 
-	const unsigned cancel_generation = generation.load();
+  const unsigned cancel_generation = generation.load();
 
-	BlockingCall(GetEventLoop(), [this, cancel_generation](){
-		/* dispose the coroutine only if no new Start() happened
-		   while this cancel was waiting for the event loop */
-		if (generation.load() == cancel_generation)
-			task = {};
-	});
+  BlockingCall(GetEventLoop(), [this, cancel_generation](){
+    /* dispose the coroutine only if no new Start() happened
+       while this cancel was waiting for the event loop */
+    if (generation.load() == cancel_generation)
+      task = {};
+  });
 
-	alive = false;
+  if (generation.load() == cancel_generation)
+    alive = false;
 }
 
 void

--- a/src/co/InjectTask.hxx
+++ b/src/co/InjectTask.hxx
@@ -24,6 +24,13 @@ class InjectTask {
 
 	std::atomic_bool alive{false};
 
+	/**
+	 * Incremented on each Start(); Cancel() only disposes #task if
+	 * the generation is unchanged when the cancel runs on the event
+	 * loop (a new Start() may have begun in the meantime).
+	 */
+	std::atomic<unsigned> generation{0};
+
 public:
 	explicit InjectTask(EventLoop &event_loop) noexcept;
 

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -138,6 +138,26 @@ public:
       if (!task)
         return;
 
+      /* Re-check that the requested item is still the active download;
+         OnCompletion() may have finished it and started the next one
+         while we were waiting to call task.Cancel() */
+      {
+        const std::lock_guard lock{mutex};
+
+        if (queue.empty() || queue.front() != relative_path) {
+          auto i = std::find(queue.begin(), queue.end(), relative_path);
+          if (i == queue.end())
+            return;
+
+          if (i != queue.begin()) {
+            queue.erase(i);
+            cancelled = true;
+          }
+
+          return;
+        }
+      }
+
       /* Cancel the coroutine without holding #mutex: task.Cancel() blocks on
          the event loop, which may be in OnCompletion() waiting for #mutex */
       task.Cancel();

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -51,7 +51,7 @@ class DownloadManagerThread final
 
   /**
    * Information about the current download, i.e. queue.front().
-   * Protected by #mutex.
+   * The download #queue is also protected by #mutex.
    */
   int64_t current_size = -1, current_position = -1;
 
@@ -72,12 +72,13 @@ public:
   }
 
   void Enumerate(Net::DownloadListener &listener) noexcept {
+    const std::lock_guard lock{mutex};
+
     for (auto i = queue.begin(), end = queue.end(); i != end; ++i) {
       const Item &item = *i;
 
       int64_t size = -1, position = -1;
       if (i == queue.begin()) {
-        const std::lock_guard lock{mutex};
         size = current_size;
         position = current_position;
       }
@@ -87,47 +88,80 @@ public:
   }
 
   void Enqueue(const char *uri, Path path_relative) noexcept {
-    if (shutting_down)
-      return;
+    {
+      const std::lock_guard lock{mutex};
 
-    /* skip duplicates already in the queue (e.g. a file re-enqueued
-       before its previous download completed) */
-    if (std::find(queue.begin(), queue.end(), path_relative) != queue.end())
-      return;
+      if (shutting_down)
+        return;
 
-    queue.emplace_back(uri, path_relative);
+      /* skip duplicates already in the queue (e.g. a file re-enqueued
+         before its previous download completed) */
+      if (std::find(queue.begin(), queue.end(), path_relative) != queue.end())
+        return;
+
+      queue.emplace_back(uri, path_relative);
+
+      if (!task && current_position == -1)
+        Start();
+    }
 
     listeners.ForEach([path_relative](auto *listener){
       listener->OnDownloadAdded(path_relative, -1, -1);
     });
-
-    if (!task)
-      Start();
   }
 
   void Cancel(Path relative_path) noexcept {
-    auto i = std::find(queue.begin(), queue.end(), relative_path);
-    if (i == queue.end())
-      return;
+    bool cancel_active = false;
+    bool cancelled = false;
 
-    if (i == queue.begin()) {
-      /* current download; stop the thread to cancel the current file
-         and restart the thread to continue downloading the following
-         files */
+    {
+      const std::lock_guard lock{mutex};
 
-      task.Cancel();
-      current_size = current_position = -1;
+      auto i = std::find(queue.begin(), queue.end(), relative_path);
+      if (i == queue.end())
+        return;
 
-      if (!queue.empty())
-        Start();
-    } else {
-      /* queued download; simply remove it from the list */
-      queue.erase(i);
+      if (i != queue.begin()) {
+        /* queued download; simply remove it from the list */
+        queue.erase(i);
+        cancelled = true;
+      } else {
+        cancel_active = true;
+      }
     }
 
-    listeners.ForEach([relative_path](auto *listener){
-      listener->OnDownloadError(relative_path, {});
-    });
+    if (cancel_active) {
+      /* If #task is already idle, the coroutine finished and
+         OnCompletion() is in flight (InjectTask clears #alive before
+         invoking the callback).  Do not advance the queue here or we
+         race with OnCompletion() and trip assert(!task) in Start(). */
+      if (!task)
+        return;
+
+      /* Cancel the coroutine without holding #mutex: task.Cancel() blocks on
+         the event loop, which may be in OnCompletion() waiting for #mutex */
+      task.Cancel();
+
+      const std::lock_guard lock{mutex};
+
+      auto i = std::find(queue.begin(), queue.end(), relative_path);
+      if (i == queue.end())
+        return;
+
+      cancelled = true;
+
+      current_size = current_position = -1;
+      queue.erase(i);
+
+      if (!queue.empty() && !task && current_position == -1)
+        Start();
+    }
+
+    if (cancelled) {
+      listeners.ForEach([relative_path](auto *listener){
+        listener->OnDownloadError(relative_path, {});
+      });
+    }
   }
 
 private:
@@ -160,11 +194,22 @@ DownloadToFile(CurlGlobal &curl,
 void
 DownloadManagerThread::BeginShutdown() noexcept
 {
-  if (shutting_down)
-    return;
+  bool cancel_active = false;
 
-  shutting_down = true;
-  task.Cancel();
+  {
+    const std::lock_guard lock{mutex};
+
+    if (shutting_down)
+      return;
+
+    shutting_down = true;
+    cancel_active = bool(task);
+  }
+
+  if (cancel_active)
+    task.Cancel();
+
+  const std::lock_guard lock{mutex};
   queue.clear();
   current_size = current_position = -1;
 }
@@ -195,12 +240,24 @@ DownloadManagerThread::Start() noexcept
 void
 DownloadManagerThread::OnCompletion(std::exception_ptr error) noexcept
 {
-  assert(!queue.empty());
+  AllocatedPath path_relative;
 
-  const AllocatedPath path_relative = std::move(queue.front().path_relative);
-  queue.pop_front();
+  {
+    const std::lock_guard lock{mutex};
 
-  current_size = current_position = -1;
+    assert(!queue.empty());
+
+    path_relative = std::move(queue.front().path_relative);
+    queue.pop_front();
+
+    current_size = current_position = -1;
+
+    /* start the next download before notifying listeners; this keeps
+       #task alive while callbacks run and closes the race where
+       Enqueue() could call Start() during completion handling */
+    if (!queue.empty() && !task)
+      Start();
+  }
 
   if (error) {
     LogError(error);
@@ -212,10 +269,6 @@ DownloadManagerThread::OnCompletion(std::exception_ptr error) noexcept
       listener->OnDownloadComplete(path);
     });
   }
-
-  // start the next download
-  if (!queue.empty())
-    Start();
 }
 
 static DownloadManagerThread *thread;

--- a/test/src/FakeResourceLoader.cpp
+++ b/test/src/FakeResourceLoader.cpp
@@ -21,4 +21,12 @@ Load([[maybe_unused]] ResourceId id)
 }
 #endif
 
+#ifdef _WIN32
+HBITMAP
+LoadBitmap2([[maybe_unused]] ResourceId id)
+{
+  return nullptr;
+}
+#endif
+
 } // namespace ResourceLoader


### PR DESCRIPTION
Serialize queue management with a mutex and start the next download before notifying listeners. Guard Enqueue() against the window where InjectTask is no longer alive but completion handling is unfinished, erase the front item when cancelling the active download, and avoid holding the mutex across task.Cancel().

InjectTask: Add a generation counter so Cancel() does not dispose a task started while the cancel was waiting on the event loop.

Fixes #2624

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur when many background file downloads were queued concurrently with other active downloads.
  * Improved download queue reliability, including safer cancellation and shutdown behavior.
  * Prevented race conditions that could interfere with newly started background tasks during cancellation.
  * Enhanced stability when downloads are added, cancelled, or completed at the same time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->