### PR TITLE
Add STF to audio vario and expose events

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -24,6 +24,10 @@ Version 7.45 - not yet released
     non-ASCII comments (UTF-8 truncation)
   - add optional map overlay QuickMenu button (Config → Look → Layout),
     enabled by default when a touch screen is detected #2610
+  - input events: add ``VarioVolume`` to mute/unmute and adjust the
+    internal audio vario volume
+  - audio vario: add manual/automatic Vario/STF sound switching and
+    ``VarioAudioMode`` input events
 * glide computer
   - Speed-to-fly and task calculations are now altitude-corrected: the glide
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,

--- a/build/libaudio.mk
+++ b/build/libaudio.mk
@@ -20,6 +20,7 @@ AUDIO_SRC_DIR = $(SRC)/Audio
 
 AUDIO_SOURCES = \
 	$(AUDIO_SRC_DIR)/ToneSynthesiser.cpp \
+	$(AUDIO_SRC_DIR)/VarioAudioValue.cpp \
 	$(AUDIO_SRC_DIR)/VarioSynthesiser.cpp \
 	$(AUDIO_SRC_DIR)/PCMPlayer.cpp
 

--- a/build/libcomputer.mk
+++ b/build/libcomputer.mk
@@ -42,6 +42,7 @@ LIBCOMPUTER_SOURCES = \
 	$(SRC)/Computer/GlideComputerInterface.cpp \
 	$(SRC)/Computer/Events.cpp \
 	$(SRC)/Computer/BasicComputer.cpp \
+	$(SRC)/Computer/STF.cpp \
 	$(SRC)/Computer/FilteredVarioComputer.cpp \
 	$(SRC)/Computer/GroundSpeedComputer.cpp \
 	$(SRC)/Computer/AutoQNH.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -91,6 +91,7 @@ TEST_NAMES = \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
 	TestLogger TestGRecord TestClimbAvCalc TestFilteredVarioComputer \
+	TestVarioSynthesiser \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
@@ -896,6 +897,14 @@ TEST_VALIDITY_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestValidity.cpp
 $(eval $(call link-program,TestValidity,TEST_VALIDITY))
+
+TEST_VARIO_SYNTHESISER_SOURCES = \
+	$(SRC)/Audio/ToneSynthesiser.cpp \
+	$(SRC)/Audio/VarioSynthesiser.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestVarioSynthesiser.cpp
+TEST_VARIO_SYNTHESISER_DEPENDS = MATH THREAD
+$(eval $(call link-program,TestVarioSynthesiser,TEST_VARIO_SYNTHESISER))
 
 TEST_ALLOCATED_GRID_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -91,7 +91,7 @@ TEST_NAMES = \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
 	TestLogger TestGRecord TestClimbAvCalc TestFilteredVarioComputer \
-	TestVarioSynthesiser \
+	TestVarioSynthesiser TestAudioVario \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
@@ -905,6 +905,19 @@ TEST_VARIO_SYNTHESISER_SOURCES = \
 	$(TEST_SRC_DIR)/TestVarioSynthesiser.cpp
 TEST_VARIO_SYNTHESISER_DEPENDS = MATH THREAD
 $(eval $(call link-program,TestVarioSynthesiser,TEST_VARIO_SYNTHESISER))
+
+TEST_AUDIO_VARIO_SOURCES = \
+	$(SRC)/Audio/ToneSynthesiser.cpp \
+	$(SRC)/Audio/VarioAudioValue.cpp \
+	$(SRC)/Audio/VarioSynthesiser.cpp \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(SRC)/Computer/STF.cpp \
+	$(SRC)/Engine/GlideSolvers/GlidePolar.cpp \
+	$(SRC)/NMEA/Aircraft.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestAudioVario.cpp
+TEST_AUDIO_VARIO_DEPENDS = GEO MATH THREAD UTIL
+$(eval $(call link-program,TestAudioVario,TEST_AUDIO_VARIO))
 
 TEST_ALLOCATED_GRID_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -457,6 +457,22 @@ Event list
  * - ``UserDisplayModeForce M``
    - Forces a display mode. Possible arguments: ``unforce``,
      ``forceclimb``, ``forcecruise``, ``forcefinal``.
+ * - ``VarioAudioMode``
+   - Controls whether the internal audio vario uses Vario or STF
+     tones. Possible arguments: ``auto`` (switch automatically
+     between Vario in circling and STF in cruise), ``manual`` (keep
+     the current runtime manual mode; after a restart, manual mode
+     starts in Vario), ``vario`` (manual Vario), ``stf``
+     (manual speed-to-fly), ``toggle`` (toggle manual Vario/STF),
+     ``show`` (display the current mode). STF audio needs valid
+     airspeed and total-energy vario input; in the built-in simulator,
+     manual STF stays silent and auto cruise falls back to vario unless
+     such input is provided.
+ * - ``VarioVolume``
+   - Adjusts the internal audio vario volume. Possible arguments:
+     ``mute`` (toggle mute and restore the previous level when hit
+     again), ``up`` / ``+`` (increase and unmute), ``down`` / ``-``
+     (decrease and unmute), ``show`` (display current value).
  * - ``WaypointDetails W``
    - Displays airfield/waypoint details.
 

--- a/src/Audio/ToneSynthesiser.cpp
+++ b/src/Audio/ToneSynthesiser.cpp
@@ -16,9 +16,11 @@ void
 ToneSynthesiser::Synthesise(int16_t *buffer, size_t n)
 {
   assert(angle < ISINETABLE.size());
+  const auto current_volume = volume.load();
 
   for (int16_t *end = buffer + n; buffer != end; ++buffer) {
-    *buffer = ISINETABLE[angle] * (32767 / 1024) * (int)volume / 100;
+    *buffer = ISINETABLE[angle] * (32767 / 1024) *
+      (int)current_volume / 100;
     angle = (angle + increment) & (ISINETABLE.size() - 1);
   }
 }

--- a/src/Audio/ToneSynthesiser.hpp
+++ b/src/Audio/ToneSynthesiser.hpp
@@ -5,11 +5,14 @@
 
 #include "PCMSynthesiser.hpp"
 
+#include <atomic>
+
 /**
  * This class generates tones with a sine wave.
  */
 class ToneSynthesiser : public PCMSynthesiser {
-  unsigned volume = 100, angle = 0, increment = 0;
+  std::atomic<unsigned> volume{100};
+  unsigned angle = 0, increment = 0;
 
 public:
   explicit ToneSynthesiser(unsigned _sample_rate) : sample_rate(_sample_rate) {

--- a/src/Audio/VarioAudioValue.cpp
+++ b/src/Audio/VarioAudioValue.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "VarioAudioValue.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace AudioVarioGlue {
+
+static constexpr double STF_FULL_SCALE = 16.0;
+static constexpr double VARIO_FULL_SCALE = 5.0;
+static constexpr double STF_SPEED_DEAD_BAND = 2.0;
+
+[[gnu::const]]
+static double
+STFSpeedErrorToPseudoVario(double speed_error) noexcept
+{
+  /* Reuse the existing tone model: sink-like tones command speeding up,
+     climb-like tones command slowing down. */
+  return std::clamp(-speed_error * (VARIO_FULL_SCALE / STF_FULL_SCALE),
+                    -VARIO_FULL_SCALE, VARIO_FULL_SCALE);
+}
+
+std::optional<double>
+ComputeAudioValue(const VarioAudioInput &input,
+                  const VarioSoundSwitchingMode switching_mode,
+                  const VarioSoundManualMode manual_mode) noexcept
+{
+  const bool use_stf = switching_mode == VarioSoundSwitchingMode::AUTO
+    ? !input.circling
+    : manual_mode == VarioSoundManualMode::STF;
+
+  if (!use_stf)
+    return input.vario;
+
+  if (input.stf_speed_error) {
+    if (std::abs(*input.stf_speed_error) <= STF_SPEED_DEAD_BAND)
+      return std::nullopt;
+
+    return STFSpeedErrorToPseudoVario(*input.stf_speed_error);
+  }
+
+  /* Automatic switching keeps the vario useful until STF inputs become
+     available.  Explicit manual STF instead stays silent. */
+  return switching_mode == VarioSoundSwitchingMode::AUTO
+    ? input.vario
+    : std::nullopt;
+}
+
+} // namespace AudioVarioGlue

--- a/src/Audio/VarioAudioValue.cpp
+++ b/src/Audio/VarioAudioValue.cpp
@@ -8,7 +8,6 @@
 
 namespace AudioVarioGlue {
 
-static constexpr double STF_FULL_SCALE = 16.0;
 static constexpr double VARIO_FULL_SCALE = 5.0;
 static constexpr double STF_SPEED_DEAD_BAND = 2.0;
 
@@ -16,9 +15,12 @@ static constexpr double STF_SPEED_DEAD_BAND = 2.0;
 static double
 STFSpeedErrorToPseudoVario(double speed_error) noexcept
 {
-  /* Reuse the existing tone model: sink-like tones command speeding up,
-     climb-like tones command slowing down. */
-  return std::clamp(-speed_error * (VARIO_FULL_SCALE / STF_FULL_SCALE),
+  /* Square-root scaling compresses large speed errors while preserving
+     useful cue separation just outside the quiet band.  Sink-like tones
+     command speeding up; climb-like tones command slowing down. */
+  const double cue = -std::copysign(std::sqrt(std::abs(speed_error)),
+                                    speed_error);
+  return std::clamp(cue,
                     -VARIO_FULL_SCALE, VARIO_FULL_SCALE);
 }
 

--- a/src/Audio/VarioAudioValue.hpp
+++ b/src/Audio/VarioAudioValue.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "VarioSettings.hpp"
+
+#include <optional>
+
+namespace AudioVarioGlue {
+
+struct VarioAudioInput {
+  /** Current total-energy vario value [m/s]. */
+  std::optional<double> vario;
+
+  /** Whether the aircraft is currently circling. */
+  bool circling = false;
+
+  /** Target true airspeed minus current true airspeed [m/s]. */
+  std::optional<double> stf_speed_error;
+};
+
+/**
+ * Convert the current Vario/STF inputs to the value consumed by the vario
+ * synthesiser.  An empty result requests silence.
+ */
+[[gnu::pure]]
+std::optional<double>
+ComputeAudioValue(const VarioAudioInput &input,
+                  VarioSoundSwitchingMode switching_mode,
+                  VarioSoundManualMode manual_mode) noexcept;
+
+} // namespace AudioVarioGlue

--- a/src/Audio/VarioGlue.cpp
+++ b/src/Audio/VarioGlue.cpp
@@ -11,7 +11,6 @@
 #include "SLES/Init.hpp"
 #endif
 
-#include <algorithm>
 #include <atomic>
 #include <cassert>
 
@@ -29,19 +28,6 @@ static std::atomic<VarioSoundSwitchingMode> switching_mode{
 static std::atomic<VarioSoundManualMode> manual_mode{
   VarioSoundManualMode::VARIO
 };
-
-static constexpr double stf_full_scale = 16.0;
-static constexpr double vario_full_scale = 5.0;
-
-[[gnu::const]]
-static double
-STFSpeedErrorToPseudoVario(double speed_error) noexcept
-{
-  /* Reuse the existing tone model: sink-like tones command speeding up,
-     climb-like tones command slowing down. */
-  return std::clamp(-speed_error * (vario_full_scale / stf_full_scale),
-                    -vario_full_scale, vario_full_scale);
-}
 
 bool
 AudioVarioGlue::HaveAudioVario()
@@ -115,26 +101,10 @@ AudioVarioGlue::SetValue(const VarioAudioInput &input)
   assert(player != nullptr);
   assert(synthesiser != nullptr);
 
-  const auto configured_switching_mode =
-    switching_mode.load();
-  const bool use_stf = configured_switching_mode == VarioSoundSwitchingMode::AUTO
-    ? !input.circling
-    : manual_mode.load() == VarioSoundManualMode::STF;
-
-  if (use_stf) {
-    if (input.stf_speed_error)
-      synthesiser->SetVario(STFSpeedErrorToPseudoVario(*input.stf_speed_error));
-    else if (configured_switching_mode == VarioSoundSwitchingMode::AUTO &&
-             input.vario)
-      synthesiser->SetVario(*input.vario);
-    else
-      synthesiser->SetSilence();
-
-    return;
-  }
-
-  if (input.vario)
-    synthesiser->SetVario(*input.vario);
+  const auto value = ComputeAudioValue(input, switching_mode.load(),
+                                       manual_mode.load());
+  if (value)
+    synthesiser->SetVario(*value);
   else
     synthesiser->SetSilence();
 }

--- a/src/Audio/VarioGlue.cpp
+++ b/src/Audio/VarioGlue.cpp
@@ -11,6 +11,8 @@
 #include "SLES/Init.hpp"
 #endif
 
+#include <algorithm>
+#include <atomic>
 #include <cassert>
 
 static constexpr unsigned sample_rate = 44100;
@@ -21,6 +23,25 @@ static bool have_sles;
 
 static PCMPlayer *player;
 static VarioSynthesiser *synthesiser;
+static std::atomic<VarioSoundSwitchingMode> switching_mode{
+  VarioSoundSwitchingMode::MANUAL
+};
+static std::atomic<VarioSoundManualMode> manual_mode{
+  VarioSoundManualMode::VARIO
+};
+
+static constexpr double stf_full_scale = 16.0;
+static constexpr double vario_full_scale = 5.0;
+
+[[gnu::const]]
+static double
+STFSpeedErrorToPseudoVario(double speed_error) noexcept
+{
+  /* Reuse the existing tone model: sink-like tones command speeding up,
+     climb-like tones command slowing down. */
+  return std::clamp(-speed_error * (vario_full_scale / stf_full_scale),
+                    -vario_full_scale, vario_full_scale);
+}
 
 bool
 AudioVarioGlue::HaveAudioVario()
@@ -68,6 +89,9 @@ AudioVarioGlue::Configure(const VarioSoundSettings &settings)
   assert(player != nullptr);
   assert(synthesiser != nullptr);
 
+  manual_mode = settings.manual_mode;
+  switching_mode = settings.switching_mode;
+
   if (settings.enabled) {
     synthesiser->SetVolume(settings.volume);
     synthesiser->SetDeadBand(settings.dead_band_enabled);
@@ -81,7 +105,7 @@ AudioVarioGlue::Configure(const VarioSoundSettings &settings)
 }
 
 void
-AudioVarioGlue::SetValue(double vario)
+AudioVarioGlue::SetValue(const VarioAudioInput &input)
 {
 #ifdef ANDROID
   if (!have_sles)
@@ -91,19 +115,26 @@ AudioVarioGlue::SetValue(double vario)
   assert(player != nullptr);
   assert(synthesiser != nullptr);
 
-  synthesiser->SetVario(vario);
-}
+  const auto configured_switching_mode =
+    switching_mode.load();
+  const bool use_stf = configured_switching_mode == VarioSoundSwitchingMode::AUTO
+    ? !input.circling
+    : manual_mode.load() == VarioSoundManualMode::STF;
 
-void
-AudioVarioGlue::NoValue()
-{
-#ifdef ANDROID
-  if (!have_sles)
+  if (use_stf) {
+    if (input.stf_speed_error)
+      synthesiser->SetVario(STFSpeedErrorToPseudoVario(*input.stf_speed_error));
+    else if (configured_switching_mode == VarioSoundSwitchingMode::AUTO &&
+             input.vario)
+      synthesiser->SetVario(*input.vario);
+    else
+      synthesiser->SetSilence();
+
     return;
-#endif
+  }
 
-  assert(player != nullptr);
-  assert(synthesiser != nullptr);
-
-  synthesiser->SetSilence();
+  if (input.vario)
+    synthesiser->SetVario(*input.vario);
+  else
+    synthesiser->SetSilence();
 }

--- a/src/Audio/VarioGlue.hpp
+++ b/src/Audio/VarioGlue.hpp
@@ -5,9 +5,23 @@
 
 #include "Features.hpp"
 
+#include <optional>
+
 struct VarioSoundSettings;
 
 namespace AudioVarioGlue {
+
+struct VarioAudioInput {
+  /** Current total-energy vario value [m/s]. */
+  std::optional<double> vario;
+
+  /** Whether the aircraft is currently circling. */
+  bool circling = false;
+
+  /** Target true airspeed minus current true airspeed [m/s]. */
+  std::optional<double> stf_speed_error;
+};
+
 #ifdef HAVE_PCM_PLAYER
 
   /**
@@ -27,18 +41,9 @@ namespace AudioVarioGlue {
   void Configure(const VarioSoundSettings &settings);
 
   /**
-   * Update the vario value.
-   *
-   * @param vario the current vario value [m/s]
+   * Update the values used by the audio vario.
    */
-  void SetValue(double vario);
-
-  /**
-   * Declare that no vario value is known (e.g. when connection to all
-   * devices is lost).  Vario sound will be shut off until vario
-   * reception is back.
-   */
-  void NoValue();
+  void SetValue(const VarioAudioInput &input);
 
   /**
    * Is the audio vario platform available on this platform?
@@ -50,8 +55,7 @@ namespace AudioVarioGlue {
   static inline void Initialise() {}
   static inline void Deinitialise() {}
   static inline void Configure([[maybe_unused]] const VarioSoundSettings &settings) {}
-  static inline void SetValue([[maybe_unused]] double vario) {}
-  static inline void NoValue() {}
+  static inline void SetValue([[maybe_unused]] const VarioAudioInput &input) {}
   static inline bool HaveAudioVario() { return false; }
 #endif
 };

--- a/src/Audio/VarioGlue.hpp
+++ b/src/Audio/VarioGlue.hpp
@@ -4,23 +4,11 @@
 #pragma once
 
 #include "Features.hpp"
-
-#include <optional>
+#include "VarioAudioValue.hpp"
 
 struct VarioSoundSettings;
 
 namespace AudioVarioGlue {
-
-struct VarioAudioInput {
-  /** Current total-energy vario value [m/s]. */
-  std::optional<double> vario;
-
-  /** Whether the aircraft is currently circling. */
-  bool circling = false;
-
-  /** Target true airspeed minus current true airspeed [m/s]. */
-  std::optional<double> stf_speed_error;
-};
 
 #ifdef HAVE_PCM_PLAYER
 

--- a/src/Audio/VarioSettings.cpp
+++ b/src/Audio/VarioSettings.cpp
@@ -8,6 +8,8 @@ VarioSoundSettings::SetDefaults()
 {
   enabled = false;
   volume = 80;
+  switching_mode = VarioSoundSwitchingMode::MANUAL;
+  manual_mode = VarioSoundManualMode::VARIO;
   dead_band_enabled = false;
 
   min_frequency = 200;

--- a/src/Audio/VarioSettings.hpp
+++ b/src/Audio/VarioSettings.hpp
@@ -6,9 +6,21 @@
 #include <cstdint>
 #include <type_traits>
 
+enum class VarioSoundSwitchingMode : uint8_t {
+  MANUAL,
+  AUTO,
+};
+
+enum class VarioSoundManualMode : uint8_t {
+  VARIO,
+  STF,
+};
+
 struct VarioSoundSettings {
   bool enabled;
   uint8_t volume;
+  VarioSoundSwitchingMode switching_mode;
+  VarioSoundManualMode manual_mode;
   bool dead_band_enabled;
 
   unsigned min_frequency;

--- a/src/Audio/VarioSynthesiser.hpp
+++ b/src/Audio/VarioSynthesiser.hpp
@@ -94,6 +94,7 @@ public:
    * Enable/disable the dead band silence
    */
   void SetDeadBand(bool enabled) {
+    const std::lock_guard lock{mutex};
     dead_band_enabled = enabled;
   }
 
@@ -101,6 +102,7 @@ public:
    * Set the base frequencies for minimum, zero and maximum lift
    */
   void SetFrequencies(unsigned min, unsigned zero, unsigned max) {
+    const std::lock_guard lock{mutex};
     min_frequency = min;
     zero_frequency = zero;
     max_frequency = max;
@@ -110,6 +112,7 @@ public:
    * Set the time periods for minimum and maximum lift
    */
   void SetPeriods(unsigned min, unsigned max) {
+    const std::lock_guard lock{mutex};
     min_period_ms = min;
     max_period_ms = max;
   }
@@ -118,6 +121,7 @@ public:
    * Set the vario range of the "dead band" during which no sound is emitted
    */
   void SetDeadBandRange(double min, double max) {
+    const std::lock_guard lock{mutex};
     min_dead = (int)(min * 100);
     max_dead = (int)(max * 100);
   }

--- a/src/Computer/STF.cpp
+++ b/src/Computer/STF.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "STF.hpp"
+
+#include "Atmosphere/AirDensity.hpp"
+#include "Computer/Settings.hpp"
+#include "NMEA/Aircraft.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
+#include "Navigation/Aircraft.hpp"
+
+std::optional<double>
+ComputeSTFSpeedError(const MoreData &basic,
+                     const DerivedInfo &calculated,
+                     const ComputerSettings &settings) noexcept
+{
+  if (!calculated.flight.flying ||
+      !basic.airspeed_available ||
+      !basic.total_energy_vario_available)
+    return std::nullopt;
+
+  GlidePolar polar = settings.polar.glide_polar_task;
+  if (!polar.IsValid())
+    return std::nullopt;
+
+  if (const auto altitude = basic.GetAnyAltitude())
+    polar.SetDensityRatio(AirDensityRatio(*altitude));
+
+  const bool block_stf = settings.features.block_stf_enabled;
+  if (!block_stf)
+    polar.SetMC(polar.GetRiskMC(
+      calculated.common_stats.height_fraction_working,
+      settings.task.risk_gamma));
+
+  AircraftState state = ToAircraftState(basic, calculated);
+  const double g_load = basic.acceleration.available
+    ? basic.acceleration.g_load
+    : 1.;
+
+  /* Derive netto from this same TE/airspeed sample.  Do not use a possibly
+     device-supplied or GPS-cycle-aged netto value. */
+  state.netto_vario = basic.total_energy_vario +
+    polar.SinkRate(basic.true_airspeed, g_load);
+
+  const double target = polar.SpeedToFly(
+    state, calculated.task_stats.current_leg.solution_remaining, block_stf);
+  return target - basic.true_airspeed;
+}

--- a/src/Computer/STF.cpp
+++ b/src/Computer/STF.cpp
@@ -11,6 +11,18 @@
 #include "Navigation/Aircraft.hpp"
 
 std::optional<double>
+GetSTFSpeed(const MoreData &basic, const DerivedInfo &calculated) noexcept
+{
+  if (basic.V_stf_available)
+    return basic.V_stf;
+
+  if (calculated.V_stf_available)
+    return calculated.V_stf;
+
+  return std::nullopt;
+}
+
+std::optional<double>
 ComputeSTFSpeedError(const MoreData &basic,
                      const DerivedInfo &calculated,
                      const ComputerSettings &settings) noexcept

--- a/src/Computer/STF.hpp
+++ b/src/Computer/STF.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <optional>
+
+struct MoreData;
+struct DerivedInfo;
+struct ComputerSettings;
+
+/**
+ * Compute target TAS minus current TAS from the latest merged sensor sample.
+ *
+ * Unlike DerivedInfo::V_stf, this cheap calculation is intended to run at
+ * sensor/merge rate so STF audio follows total-energy and airspeed changes
+ * without waiting for the next GPS calculation cycle.
+ */
+[[gnu::pure]]
+std::optional<double>
+ComputeSTFSpeedError(const MoreData &basic,
+                     const DerivedInfo &calculated,
+                     const ComputerSettings &settings) noexcept;

--- a/src/Computer/STF.hpp
+++ b/src/Computer/STF.hpp
@@ -10,6 +10,14 @@ struct DerivedInfo;
 struct ComputerSettings;
 
 /**
+ * Get the most recent speed-to-fly target.  Prefer the value calculated from
+ * the latest merged sensor sample, but fall back to the GPS-cycle result.
+ */
+[[gnu::pure]]
+std::optional<double>
+GetSTFSpeed(const MoreData &basic, const DerivedInfo &calculated) noexcept;
+
+/**
  * Compute target TAS minus current TAS from the latest merged sensor sample.
  *
  * Unlike DerivedInfo::V_stf, this cheap calculation is intended to run at

--- a/src/Computer/TaskComputer.cpp
+++ b/src/Computer/TaskComputer.cpp
@@ -103,10 +103,15 @@ TaskComputer::ProcessMoreTask(const MoreData &basic,
                      settings_computer.task.route_planner,
                      glide_polar, safety_polar);
 
-  if (settings_computer.features.block_stf_enabled)
-    calculated.V_stf = calculated.common_stats.V_block;
-  else
-    calculated.V_stf = calculated.common_stats.V_dolphin;
+  if (glide_polar.IsValid()) {
+    calculated.V_stf = settings_computer.features.block_stf_enabled
+      ? calculated.common_stats.V_block
+      : calculated.common_stats.V_dolphin;
+    calculated.V_stf_available = calculated.V_stf > 0;
+  } else {
+    calculated.V_stf = 0;
+    calculated.V_stf_available = false;
+  }
 
   if (calculated.task_stats.current_leg.vector_remaining.IsValid()) {
     const GeoVector &v = calculated.task_stats.current_leg.vector_remaining;

--- a/src/Dialogs/Settings/Panels/AudioVarioConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/AudioVarioConfigPanel.cpp
@@ -6,16 +6,19 @@
 #include "Language/Language.hpp"
 #include "Interface.hpp"
 #include "Widget/RowFormWidget.hpp"
+#include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Float.hpp"
 #include "UIGlobals.hpp"
 #include "Audio/Features.hpp"
 #include "Audio/VarioGlue.hpp"
+#include "Audio/VarioSettings.hpp"
 #include "Units/Units.hpp"
 #include "Formatter/UserUnits.hpp"
 
 enum ControlIndex {
-  Enabled,
-  Volume,
+  ENABLED,
+  VOLUME,
+  SWITCHING_MODE,
   DEAD_BAND_ENABLED,
   SPACER,
   MIN_FREQUENCY,
@@ -24,6 +27,12 @@ enum ControlIndex {
   SPACER2,
   DEAD_BAND_MIN,
   DEAD_BAND_MAX,
+};
+
+static constexpr StaticEnumChoice switching_modes[] = {
+  { VarioSoundSwitchingMode::MANUAL, N_("Manual") },
+  { VarioSoundSwitchingMode::AUTO, N_("Auto") },
+  nullptr
 };
 
 
@@ -55,6 +64,10 @@ AudioVarioConfigPanel::Prepare(ContainerWindow &parent,
   AddInteger(_("Volume"),
              _("The audio vario sound volume."), "%u %%", "%u",
              0, 100, 1, settings.volume);
+
+  AddEnum(_("Mode switching"),
+      _("Choose whether the audio vario stays in manual mode or switches automatically between Vario in circling and STF in cruise. Manual mode starts in Vario after each restart and can be changed by external input events. In the built-in simulator, STF audio needs valid airspeed and total-energy vario input; without those, manual STF is silent and auto cruise falls back to vario."),
+          switching_modes, (unsigned)settings.switching_mode);
 
   AddBoolean(_("Enable Deadband"),
              _("Mute the audio output in when the current lift is in a "
@@ -113,11 +126,14 @@ AudioVarioConfigPanel::Save(bool &changed) noexcept
 
   auto &settings = CommonInterface::SetUISettings().sound.vario;
 
-  changed |= SaveValue(Enabled, ProfileKeys::SoundAudioVario,
+  changed |= SaveValue(ENABLED, ProfileKeys::SoundAudioVario,
                        settings.enabled);
 
-  changed |= SaveValueInteger(Volume, ProfileKeys::SoundVolume,
+  changed |= SaveValueInteger(VOLUME, ProfileKeys::SoundVolume,
                               settings.volume);
+
+  changed |= SaveValueEnum(SWITCHING_MODE, ProfileKeys::VarioSoundSwitchingMode,
+                           settings.switching_mode);
 
   changed |= SaveValue(DEAD_BAND_ENABLED, ProfileKeys::VarioDeadBandEnabled,
                        settings.dead_band_enabled);

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -564,7 +564,7 @@ GaugeVario::RenderValue(Canvas &canvas, const LabelValueGeometry &g,
 inline void
 GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
 {
-  if (!Basic().airspeed_available ||
+  if (!Calculated().V_stf_available || !Basic().airspeed_available ||
       !Basic().total_energy_vario_available)
     return;
 

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Gauge/GaugeVario.hpp"
+#include "Computer/STF.hpp"
 #include "Look/VarioLook.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Screen/Layout.hpp"
@@ -564,7 +565,8 @@ GaugeVario::RenderValue(Canvas &canvas, const LabelValueGeometry &g,
 inline void
 GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
 {
-  if (!Calculated().V_stf_available || !Basic().airspeed_available ||
+  const auto stf = GetSTFSpeed(Basic(), Calculated());
+  if (!stf || !Basic().airspeed_available ||
       !Basic().total_energy_vario_available)
     return;
 
@@ -588,7 +590,7 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
   if ((Calculated().flight.flying)
       && (!Basic().gps.simulator || !Calculated().circling)) {
     /* V_stf is TAS (density-compensated); compare to actual TAS */
-    v_diff = Calculated().V_stf - Basic().true_airspeed;
+    v_diff = *stf - Basic().true_airspeed;
     v_diff = std::clamp(v_diff, -DELTA_V_LIMIT, DELTA_V_LIMIT); // limit it
     v_diff = iround(v_diff/DELTA_V_STEP) * DELTA_V_STEP;
   } else

--- a/src/InfoBoxes/Content/Speed.cpp
+++ b/src/InfoBoxes/Content/Speed.cpp
@@ -5,6 +5,7 @@
 #include "BackendComponents.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Components.hpp"
+#include "Computer/STF.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "InfoBoxes/Data.hpp"
 #include "Interface.hpp"
@@ -105,13 +106,14 @@ void
 UpdateInfoBoxSpeedDolphin(InfoBoxData &data) noexcept
 {
   // Set Value
-  const DerivedInfo &calculated = CommonInterface::Calculated();
-  if (!calculated.V_stf_available) {
+  const auto stf = GetSTFSpeed(CommonInterface::Basic(),
+                               CommonInterface::Calculated());
+  if (!stf) {
     data.SetInvalid();
     return;
   }
 
-  data.SetValueFromSpeed(calculated.V_stf, false);
+  data.SetValueFromSpeed(*stf, false);
 
   // Set Comment
   if (CommonInterface::GetComputerSettings().features.block_stf_enabled)

--- a/src/InfoBoxes/Content/Speed.cpp
+++ b/src/InfoBoxes/Content/Speed.cpp
@@ -106,6 +106,11 @@ UpdateInfoBoxSpeedDolphin(InfoBoxData &data) noexcept
 {
   // Set Value
   const DerivedInfo &calculated = CommonInterface::Calculated();
+  if (!calculated.V_stf_available) {
+    data.SetInvalid();
+    return;
+  }
+
   data.SetValueFromSpeed(calculated.V_stf, false);
 
   // Set Comment

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -141,6 +141,8 @@ void sub_SetZoom(double value);
 void eventAbortTask(const char *misc);
 void eventAdjustForecastTemperature(const char *misc);
 void eventAdjustVarioFilter(const char *misc);
+void eventVarioAudioMode(const char *misc);
+void eventVarioVolume(const char *misc);
 void eventAdjustWaypoint(const char *misc);
 void eventAnalysis(const char *misc);
 void eventArmAdvance(const char *misc);

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -24,6 +24,19 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 
+static uint8_t last_unmuted_vario_volume = 80;
+
+static const char *
+GetVarioAudioModeLabel(const VarioSoundSettings &settings) noexcept
+{
+  if (settings.switching_mode == VarioSoundSwitchingMode::AUTO)
+    return _("Auto (circling/cruise)");
+
+  return settings.manual_mode == VarioSoundManualMode::STF
+    ? _("Manual STF")
+    : _("Manual Vario");
+}
+
 void
 InputEvents::eventSounds(const char *misc)
 {
@@ -148,6 +161,81 @@ InputEvents::eventAudioDeadband(const char *misc)
   Profile::Set(ProfileKeys::SoundDeadband, settings.sound_deadband);
 
   // TODO feature: send to vario if available
+}
+
+void
+InputEvents::eventVarioVolume(const char *misc)
+{
+  auto &settings = CommonInterface::SetUISettings().sound.vario;
+
+  if (StringIsEqual(misc, "mute")) {
+    if (settings.volume == 0)
+      settings.volume = last_unmuted_vario_volume;
+    else {
+      last_unmuted_vario_volume = settings.volume;
+      settings.volume = 0;
+    }
+  } else if (StringIsEqual(misc, "up") || StringIsEqual(misc, "+")) {
+    if (settings.volume == 0)
+      settings.volume = last_unmuted_vario_volume;
+
+    if (settings.volume < 95)
+      settings.volume += 5;
+    else
+      settings.volume = 100;
+  } else if (StringIsEqual(misc, "down") || StringIsEqual(misc, "-")) {
+    if (settings.volume == 0)
+      settings.volume = last_unmuted_vario_volume;
+
+    if (settings.volume > 5)
+      settings.volume -= 5;
+    else
+      settings.volume = 0;
+  } else if (StringIsEqual(misc, "show")) {
+    char Temp[64];
+    StringFormatUnsafe(Temp, "%d", (int)settings.volume);
+    Message::AddMessage(_("Volume"), Temp);
+    return;
+  } else
+    return;
+
+  if (settings.volume > 0)
+    last_unmuted_vario_volume = settings.volume;
+
+  AudioVarioGlue::Configure(settings);
+  Profile::Set(ProfileKeys::SoundVolume, settings.volume);
+}
+
+void
+InputEvents::eventVarioAudioMode(const char *misc)
+{
+  auto &settings = CommonInterface::SetUISettings().sound.vario;
+
+  if (StringIsEqual(misc, "auto"))
+    settings.switching_mode = VarioSoundSwitchingMode::AUTO;
+  else if (StringIsEqual(misc, "manual"))
+    settings.switching_mode = VarioSoundSwitchingMode::MANUAL;
+  else if (StringIsEqual(misc, "vario")) {
+    settings.switching_mode = VarioSoundSwitchingMode::MANUAL;
+    settings.manual_mode = VarioSoundManualMode::VARIO;
+  } else if (StringIsEqual(misc, "stf")) {
+    settings.switching_mode = VarioSoundSwitchingMode::MANUAL;
+    settings.manual_mode = VarioSoundManualMode::STF;
+  } else if (StringIsEqual(misc, "toggle")) {
+    settings.switching_mode = VarioSoundSwitchingMode::MANUAL;
+    settings.manual_mode = settings.manual_mode == VarioSoundManualMode::VARIO
+      ? VarioSoundManualMode::STF
+      : VarioSoundManualMode::VARIO;
+  } else if (StringIsEqual(misc, "show")) {
+    Message::AddMessage(_("Audio vario mode"), GetVarioAudioModeLabel(settings));
+    return;
+  } else {
+    return;
+  }
+
+  AudioVarioGlue::Configure(settings);
+  Profile::Set(ProfileKeys::VarioSoundSwitchingMode,
+               (unsigned)settings.switching_mode);
 }
 
 // Bugs

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -69,8 +69,7 @@ MergeThread::Tick() noexcept
   bool gps_updated, calculated_updated;
 
 #ifdef HAVE_PCM_PLAYER
-  bool vario_available;
-  double vario;
+  AudioVarioGlue::VarioAudioInput vario_audio_input;
 #endif
 
   TracePoint::Time trail_push_time{};
@@ -120,12 +119,19 @@ MergeThread::Tick() noexcept
 
 #ifdef HAVE_PCM_PLAYER
     if (!computer.FilteredVarioActive()) {
-      vario_available = basic.brutto_vario_available;
-      vario = vario_available ? basic.brutto_vario : 0;
+      if (basic.brutto_vario_available)
+        vario_audio_input.vario = basic.brutto_vario;
     } else {
-      vario_available = basic.filtered_brutto_vario_available;
-      vario = vario_available ? basic.FilteredBruttoVario() : 0;
+      if (basic.filtered_brutto_vario_available)
+        vario_audio_input.vario = basic.FilteredBruttoVario();
     }
+
+    if (calculated.V_stf_available && basic.airspeed_available &&
+        basic.total_energy_vario_available && calculated.flight.flying)
+      vario_audio_input.stf_speed_error =
+        calculated.V_stf - basic.true_airspeed;
+
+    vario_audio_input.circling = calculated.circling;
 #endif
 
     /* Throttle map vario-bar redraws to ~1 Hz when the LX filter is active. */
@@ -146,10 +152,7 @@ MergeThread::Tick() noexcept
     trail_vario_sink->PushMergeVarioSample(trail_push_time, trail_push_vario);
 
 #ifdef HAVE_PCM_PLAYER
-  if (vario_available)
-    AudioVarioGlue::SetValue(vario);
-  else
-    AudioVarioGlue::NoValue();
+  AudioVarioGlue::SetValue(vario_audio_input);
 #endif
 
   if (gps_updated)

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -88,6 +88,15 @@ MergeThread::Tick() noexcept
     const ComputerSettings &settings_computer =
       device_blackboard.GetComputerSettings();
 
+    const auto stf_speed_error =
+      ComputeSTFSpeedError(basic, calculated, settings_computer);
+    auto &more_data = device_blackboard.SetMoreData();
+    if (stf_speed_error) {
+      more_data.V_stf = basic.true_airspeed + *stf_speed_error;
+      more_data.V_stf_available.Update(basic.clock);
+    } else
+      more_data.V_stf_available.Clear();
+
     if (trail_vario_sink != nullptr &&
         basic.time_available &&
         basic.location_available &&
@@ -129,8 +138,7 @@ MergeThread::Tick() noexcept
         vario_audio_input.vario = basic.FilteredBruttoVario();
     }
 
-    vario_audio_input.stf_speed_error =
-      ComputeSTFSpeedError(basic, calculated, settings_computer);
+    vario_audio_input.stf_speed_error = stf_speed_error;
 
     vario_audio_input.circling = calculated.circling;
 #endif

--- a/src/MergeThread.cpp
+++ b/src/MergeThread.cpp
@@ -4,6 +4,7 @@
 #include "MergeThread.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Computer/TraceComputer.hpp"
+#include "Computer/STF.hpp"
 #include "Protection.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
@@ -84,6 +85,8 @@ MergeThread::Tick() noexcept
 
     const MoreData &basic = device_blackboard.Basic();
     const DerivedInfo &calculated = device_blackboard.Calculated();
+    const ComputerSettings &settings_computer =
+      device_blackboard.GetComputerSettings();
 
     if (trail_vario_sink != nullptr &&
         basic.time_available &&
@@ -126,10 +129,8 @@ MergeThread::Tick() noexcept
         vario_audio_input.vario = basic.FilteredBruttoVario();
     }
 
-    if (calculated.V_stf_available && basic.airspeed_available &&
-        basic.total_energy_vario_available && calculated.flight.flying)
-      vario_audio_input.stf_speed_error =
-        calculated.V_stf - basic.true_airspeed;
+    vario_audio_input.stf_speed_error =
+      ComputeSTFSpeedError(basic, calculated, settings_computer);
 
     vario_audio_input.circling = calculated.circling;
 #endif

--- a/src/NMEA/Derived.cpp
+++ b/src/NMEA/Derived.cpp
@@ -37,6 +37,9 @@ DerivedInfo::Reset()
 {
   date_time_local = BrokenDateTime::Invalid();
 
+  V_stf = 0;
+  V_stf_available = false;
+
   VarioInfo::Clear();
   ClimbInfo::Clear();
   CirclingInfo::Clear();

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -133,6 +133,9 @@ struct DerivedInfo:
   /** Speed to fly block/dolphin (m/s) */
   double V_stf;
 
+  /** Whether #V_stf was calculated from a valid glide polar. */
+  bool V_stf_available;
+
   /** Auto QNH calculation result. */
   AtmosphericPressure pressure;
   Validity pressure_available;

--- a/src/NMEA/MoreData.cpp
+++ b/src/NMEA/MoreData.cpp
@@ -24,5 +24,8 @@ MoreData::Reset() noexcept
   filtered_netto_vario = 0;
   filtered_netto_vario_available.Clear();
 
+  V_stf = 0;
+  V_stf_available.Clear();
+
   NMEAInfo::Reset();
 }

--- a/src/NMEA/MoreData.hpp
+++ b/src/NMEA/MoreData.hpp
@@ -46,6 +46,12 @@ struct MoreData : public NMEAInfo {
 
   Validity filtered_netto_vario_available;
 
+  /** Speed to fly calculated from the latest merged sensor sample (m/s TAS). */
+  double V_stf;
+
+  /** Whether #V_stf is available from the latest merged sensor sample. */
+  Validity V_stf_available;
+
   void Reset() noexcept;
 
   constexpr bool NavAltitudeAvailable() const noexcept {

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -309,6 +309,7 @@ constexpr std::string_view VarioZeroFrequency = "VarioZeroFrequency";
 constexpr std::string_view VarioMaxFrequency = "VarioMaxFrequency";
 constexpr std::string_view VarioMinPeriod = "VarioMinPeriod";
 constexpr std::string_view VarioMaxPeriod = "VarioMaxPeriod";
+constexpr std::string_view VarioSoundSwitchingMode = "VarioSoundSwitchingMode";
 constexpr std::string_view VarioDeadBandEnabled = "VarioDeadBandEnabled";
 constexpr std::string_view VarioDeadBandMin = "VarioDeadBandMin";
 constexpr std::string_view VarioDeadBandMax = "VarioDeadBandMax";

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -74,6 +74,7 @@ Profile::Load(const ProfileMap &map, VarioSoundSettings &settings)
 {
   map.Get(ProfileKeys::SoundAudioVario, settings.enabled);
   map.Get(ProfileKeys::SoundVolume, settings.volume);
+  map.GetEnum(ProfileKeys::VarioSoundSwitchingMode, settings.switching_mode);
   map.Get(ProfileKeys::VarioDeadBandEnabled, settings.dead_band_enabled);
 
   map.Get(ProfileKeys::VarioMinFrequency, settings.min_frequency);

--- a/src/UIReceiveBlackboard.cpp
+++ b/src/UIReceiveBlackboard.cpp
@@ -60,13 +60,20 @@ UIReceiveSensorData(OperationEnvironment &env)
 
   bool modified = ApplyExternalSettings(env);
 
-  /*
-   * Update the infoboxes if no location is available
-   *
-   * (if the location is available the CalculationThread will send the
-   * Command::CALCULATED_UPDATE message which will update them)
-   */
-  if (modified || !CommonInterface::Basic().location_available) {
+  /* Most InfoBoxes are refreshed by calculated updates.  Merge-rate STF
+     (MoreData::V_stf) also dirties boxes when availability or value changes.
+     Compare as bool so Validity timestamps alone do not thrash redraws. */
+  static bool last_stf_available = false;
+  static double last_stf = 0;
+  const auto &basic = CommonInterface::Basic();
+  const bool stf_available = (bool)basic.V_stf_available;
+  const bool stf_changed = stf_available != last_stf_available ||
+    (stf_available && basic.V_stf != last_stf);
+  last_stf_available = stf_available;
+  if (stf_available)
+    last_stf = basic.V_stf;
+
+  if (modified || !basic.location_available || stf_changed) {
     InfoBoxManager::SetDirty();
     InfoBoxManager::ProcessTimer();
   }

--- a/test/src/TestAudioVario.cpp
+++ b/test/src/TestAudioVario.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Audio/VarioAudioValue.hpp"
+#include "Audio/VarioSynthesiser.hpp"
+#include "Computer/STF.hpp"
+#include "Computer/Settings.hpp"
+#include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
+#include "TestUtil.hpp"
+
+#include <algorithm>
+#include <array>
+
+using namespace AudioVarioGlue;
+
+static bool
+HasSound(const std::optional<double> value) noexcept
+{
+  VarioSynthesiser synthesiser(44100);
+  if (value)
+    synthesiser.SetVario(*value);
+  else
+    synthesiser.SetSilence();
+
+  std::array<int16_t, 2048> buffer{};
+  synthesiser.Synthesise(buffer.data(), buffer.size());
+  return std::any_of(buffer.begin(), buffer.end(),
+                     [](const int16_t sample) { return sample != 0; });
+}
+
+static void
+TestModesAndDeadBand() noexcept
+{
+  VarioAudioInput input;
+  input.vario = 1.5;
+
+  auto value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                                 VarioSoundManualMode::VARIO);
+  ok1(value && equals(*value, 1.5));
+
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(!value);
+
+  input.circling = true;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::AUTO,
+                            VarioSoundManualMode::STF);
+  ok1(value && equals(*value, 1.5));
+
+  input.circling = false;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::AUTO,
+                            VarioSoundManualMode::VARIO);
+  ok1(value && equals(*value, 1.5));
+
+  input.stf_speed_error = 2.;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(!value);
+  ok1(!HasSound(value));
+
+  input.stf_speed_error = -2.;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(!value);
+
+  input.stf_speed_error = 2.01;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(value && *value < 0);
+  ok1(HasSound(value));
+
+  input.stf_speed_error = -2.01;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(value && *value > 0);
+}
+
+static void
+TestMergedSensorSTF() noexcept
+{
+  ComputerSettings settings;
+  settings.features.block_stf_enabled = false;
+  settings.task.risk_gamma = 0.;
+  settings.polar.glide_polar_task = GlidePolar(1.);
+
+  MoreData basic{};
+  basic.clock = TimeStamp{FloatDuration{1}};
+
+  DerivedInfo calculated{};
+
+  ok1(!ComputeSTFSpeedError(basic, calculated, settings));
+
+  calculated.flight.flying = true;
+  basic.ProvideBothAirspeeds(35., 35.);
+  basic.ProvideTotalEnergyVario(-3.);
+
+  /* This deliberately stale value must not affect the merge-rate result. */
+  basic.netto_vario = 100.;
+  calculated.V_stf = 35.;
+  calculated.V_stf_available = true;
+
+  const auto sink_error = ComputeSTFSpeedError(basic, calculated, settings);
+  ok1(sink_error && *sink_error > 4.);
+
+  VarioAudioInput input;
+  input.stf_speed_error = sink_error;
+  auto value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                                 VarioSoundManualMode::STF);
+  ok1(value && *value < 0);
+  ok1(HasSound(value));
+
+  /* A new TE sample must reverse the command without a GPS calculation. */
+  basic.ProvideTotalEnergyVario(3.);
+  const auto lift_error = ComputeSTFSpeedError(basic, calculated, settings);
+  ok1(lift_error && *lift_error < -4.);
+
+  input.stf_speed_error = lift_error;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(value && *value > 0);
+  ok1(HasSound(value));
+
+  calculated.flight.flying = false;
+  ok1(!ComputeSTFSpeedError(basic, calculated, settings));
+}
+
+int
+main()
+{
+  plan_tests(18);
+
+  TestModesAndDeadBand();
+  TestMergedSensorSTF();
+
+  return exit_status();
+}

--- a/test/src/TestAudioVario.cpp
+++ b/test/src/TestAudioVario.cpp
@@ -70,6 +70,11 @@ TestModesAndDeadBand() noexcept
   ok1(value && *value < 0);
   ok1(HasSound(value));
 
+  input.stf_speed_error = 9.;
+  value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
+                            VarioSoundManualMode::STF);
+  ok1(value && equals(*value, -3.));
+
   input.stf_speed_error = -2.01;
   value = ComputeAudioValue(input, VarioSoundSwitchingMode::MANUAL,
                             VarioSoundManualMode::STF);
@@ -128,7 +133,7 @@ TestMergedSensorSTF() noexcept
 int
 main()
 {
-  plan_tests(18);
+  plan_tests(19);
 
   TestModesAndDeadBand();
   TestMergedSensorSTF();

--- a/test/src/TestVarioSynthesiser.cpp
+++ b/test/src/TestVarioSynthesiser.cpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Audio/VarioSynthesiser.hpp"
+#include "TestUtil.hpp"
+
+#include <algorithm>
+#include <array>
+
+static bool
+IsSilent(double vario, bool dead_band_enabled,
+         double min_dead=-0.3, double max_dead=0.1)
+{
+  VarioSynthesiser synthesiser(44100);
+  synthesiser.SetDeadBand(dead_band_enabled);
+  synthesiser.SetDeadBandRange(min_dead, max_dead);
+  synthesiser.SetVario(vario);
+
+  std::array<int16_t, 512> buffer{};
+  synthesiser.Synthesise(buffer.data(), buffer.size());
+  return std::all_of(buffer.begin(), buffer.end(),
+                     [](int16_t sample) { return sample == 0; });
+}
+
+int
+main()
+{
+  plan_tests(5);
+
+  ok1(!IsSilent(0, false));
+  ok1(IsSilent(0, true));
+  ok1(IsSilent(-0.3, true));
+  ok1(IsSilent(0.1, true));
+  ok1(!IsSilent(0.2, true));
+
+  return exit_status();
+}


### PR DESCRIPTION
- expose vario volume + mute to events
- guard STF by checking for valid polar
- add STF to audio vario and expose settings
- expose STF switch to events

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added input commands for audio vario volume (mute/unmute, up/down, show) and vario/STF mode switching (auto/manual, vario/stf, toggle, show).
  * Added an audio vario “Mode switching” setting with profile persistence.
* **Bug Fixes**
  * Speed-to-fly and STF-based rendering/displays now properly handle STF availability/missing glide polar.
  * Audio vario output now correctly mutes/suppresses when STF conditions aren’t met.
* **Documentation**
  * Updated the input event list with the new commands.
* **Tests**
  * Added new audio vario and vario synthesiser test coverage and test harness wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->