### PR TITLE
TaskListPanel: by default show all tasks, including .cup files

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,8 @@ Version 7.45 - not yet released
   - Raise combined FLARM/online traffic list limit to 64 targets (cloud
     batch size); device FLARM traffic still typically stays within 25
 * ui
+  - Show all tasks by default in Task Browser instead of requiring to click
+    the "More" button first.
   - Outline selected targets on the FLARM traffic radar
   - Weather cursor bar: narrower stepper buttons on touchscreens and clip
     long centre labels instead of hiding them when they do not fit
@@ -159,7 +161,7 @@ Version 7.45 - not yet released
     dialog with its own icon #336
 * map
   - dynamically adjust contour line density to zoom factor #2233
-  - provide different contour density profile settings for mountains, 
+  - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type
   - turn back marker: new opt-in overlay (Safety Factors config panel) showing
     a green triangle along the current track indicating the furthest point from
@@ -285,8 +287,8 @@ Version 7.45 - not yet released
   - add NOTAM settings and filters (IFR, effective time, max radius, hidden Q-codes)
   - add NOTAM details integration in airspace dialogs
 * data files
-  - .cup tasks: More correctly parse SeeYou .cup task files with observation zones 
-    with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder. 
+  - .cup tasks: More correctly parse SeeYou .cup task files with observation zones
+    with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder.
     Previously these were incorrectly parsed into FAI Quadrants #2697
   - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
     is read correctly

--- a/src/Dialogs/Task/Manager/TaskListPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskListPanel.cpp
@@ -64,7 +64,7 @@ public:
                 TextWidget &_summary)
     :dialog(_dialog),
      active_task(_active_task), task_modified(_task_modified),
-     more(false),
+     more(true),
      summary(_summary)  {}
 
   void SetTwoWidgets(TwoWidgets &_two_widgets) {


### PR DESCRIPTION
Instead of requiring to click the "More" button first. Now shows the "Less" button by default.

Relates to Issue #2041   , fixing the low hanging fruit there. No other UI changes.

-----
## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Task Browser now shows all tasks by default, including `.cup` files.

* **Documentation**
  * Updated release notes with the Task Browser behavior and corrected formatting for mountain contour density settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->