### PR TITLE
Gauge/FlarmTrafficWindow: Fix FLARM radar callsign and side labels

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,9 @@ Version 7.45 - not yet released
   - Raise combined FLARM/online traffic list limit to 64 targets (cloud
     batch size); device FLARM traffic still typically stays within 25
 * ui
+  - FLARM radar: show callsigns on all registered targets again, use the
+    full callsign on target labels, and omit duplicate side vario/altitude
+    on the selected target (info panel already shows them) #2718
   - Show all tasks by default in Task Browser instead of requiring to click
     the "More" button first.
   - Rename to turnpoint observation zone type "Symmetric Quadrant" to

--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -11,7 +11,6 @@
 #include "Math/Screen.hpp"
 #include "Language/Language.hpp"
 #include "util/Macros.hpp"
-#include "util/UTF8.hpp"
 #include "Look/FlarmTrafficLook.hpp"
 #include "Interface.hpp"
 
@@ -494,16 +493,14 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
   const unsigned radar_radius = radar_renderer.GetRadius();
   const bool selected = static_cast<unsigned>(selection) == i;
 
-  // Draw callsign when selected, or in relative-altitude side-data mode
-  if (traffic.HasName() &&
-      (selected ||
-       side_display_type == SideInfoType::RELATIVE_ALTITUDE)) {
+  // Draw callsign for registered targets (FLARMnet / OGN / user names)
+  if (traffic.HasName()) {
     const PixelPoint ts{
       sc[i].x + int(ScaleRadarPermille(radar_radius, SIDE_LABEL_X_PERMILLE)),
       sc[i].y - int(ScaleRadarPermille(radar_radius, SIDE_LABEL_Y_PERMILLE)),
     };
 
-    canvas.DrawText(ts, SuffixUTF8(traffic.name, 2));
+    canvas.DrawText(ts, traffic.name);
   }
 
   StaticString<10> side_text;
@@ -527,7 +524,9 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
                                      SIDE_LABEL_Y_CENTER_PERMILLE)),
   };
 
-  if (!side_text.empty())
+  // Side vario/altitude is omitted on the selected target; the info panel
+  // already shows those values in the corners.
+  if (!side_text.empty() && !selected)
     canvas.DrawText(tp, side_text);
 }
 


### PR DESCRIPTION
## Summary
- Restore callsign labels on all registered FLARM radar targets (not only the selected one in default vario mode).
- Show the full callsign next to each target instead of a 2-character suffix (e.g. `fcm` instead of `cm`).
- Omit side vario/altitude on the selected target; the info panel corners already display those values, which avoided the appearance of another target's climb rate being repeated onto the selection.

Closes #2718

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y`
- [ ] Replay `test/data/FLARM_Traffic_Testcase_1.nmea` (attachment from #2718) with FLARMnet/OGN databases loaded
- [ ] Open FLARM radar: registered targets (`3FFD51`/`fcm`, `DDA71B`/`54`, `DDA73B`) show full callsigns; unregistered `3FF953` has no callsign
- [ ] Select each target and confirm corner info matches that target and no duplicate side vario appears on the selection
- [ ] Toggle Avg/Alt (relative altitude side data) and confirm labels remain correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registered FLARM target callsigns are now consistently displayed on the radar using their full names.

* **Bug Fixes**
  * Removed duplicate vario and altitude details beside the selected target, since this information is already shown in the target information panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->