### PR TITLE
Menu/MenuBar: Fix side-column button geometry

### DIFF
--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -8,68 +8,37 @@
 #include <algorithm>
 #include <cassert>
 
-/** Side-column slots (location 5+) must fit at least this many buttons. */
-static constexpr unsigned side_column_slots = 8;
-
-[[gnu::pure]]
-static unsigned
-GetSideColumnRowHeight(unsigned screen_height) noexcept
-{
-  return std::max(1u, screen_height / side_column_slots);
-}
-
 [[gnu::pure]]
 static PixelRect
 GetButtonPosition(unsigned i, PixelRect rc)
 {
-  unsigned hwidth = rc.GetWidth(), hheight = rc.GetHeight();
+  const unsigned screen_width = rc.GetWidth();
+  const unsigned screen_height = rc.GetHeight();
+  const bool portrait = screen_height > screen_width;
 
-  if (hheight > hwidth) {
-    // portrait
+  unsigned width = std::max(1u, screen_width / (portrait ? 4u : 5u));
+  unsigned height = std::max(1u,
+    screen_height / (portrait ? menubar_height_scale_factor : 5u));
 
-    hheight = std::max(1u, hheight / menubar_height_scale_factor);
-
-    if (i == 0) {
-      rc.left = rc.right;
-      rc.top = rc.bottom;
-    } else if (i < 5) {
-      hwidth = std::max(1u, hwidth / 4);
-
-      rc.left += hwidth * (i - 1);
-      rc.top = rc.bottom - hheight;
-    } else {
-      hwidth = std::max(1u, hwidth / 3);
-      hheight = GetSideColumnRowHeight(rc.GetHeight());
-
-      rc.left = rc.right - hwidth;
-      rc.top += (i - 5) * hheight;
-    }
-
-    rc.right = rc.left + hwidth;
-    rc.bottom = rc.top + hheight;
+  if (i == 0) {
+    rc.left = rc.right;
+    rc.top = rc.bottom;
+  } else if (i < 5) {
+    if (portrait) {
+      rc.left += width * (i - 1);
+      rc.top = rc.bottom - height;
+    } else
+      rc.top += height * (i - 1);
   } else {
-    // landscape
+    if (portrait)
+      width = std::max(1u, screen_width / 3);
 
-    hwidth = std::max(1u, hwidth / 5);
-    hheight = std::max(1u, hheight / 5);
-
-    if (i == 0) {
-      rc.left = rc.right;
-      rc.top = rc.bottom;
-    } else if (i < 5) {
-      rc.top += hheight * (i - 1);
-    } else {
-      hwidth = std::max(1u, hwidth * 5 / 3);
-      hheight = GetSideColumnRowHeight(rc.GetHeight());
-
-      rc.left = rc.right - hwidth;
-      rc.top += (i - 5) * hheight;
-    }
-
-    rc.right = rc.left + hwidth;
-    rc.bottom = rc.top + hheight;
+    rc.left = rc.right - width;
+    rc.top += (i - 5) * height;
   }
 
+  rc.right = rc.left + width;
+  rc.bottom = rc.top + height;
   return rc;
 }
 


### PR DESCRIPTION
## Summary
- Restore menubar side-column cell size after the weather-menu layout change made portrait side buttons too short (`height/8`) and landscape right-column buttons too wide (`width/3`).
- Portrait side buttons match the bottom bar again (`menubar_height_scale_factor`); landscape left and right columns both use `width/5` × `height/5`.
- Simplify `GetButtonPosition` with shared size and placement logic.

## Test plan
- [ ] Portrait: open Nav/Config menu — right-column buttons same height as bottom bar
- [ ] Landscape: open Nav/Config (and weather mode) — right-column buttons same width and height as left column
- [ ] Resize between portrait and landscape and confirm buttons relocate cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified menu button layout calculations across portrait and landscape orientations.
  * Improved consistency in button sizing and positioning, including side-column buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->