### PR TITLE
Tracking: Filter OGN ownship by FLARM id

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -11,6 +11,8 @@ Version 7.45 - not yet released
   - Configurable XCSoar Cloud server hostname and UDP port in cloud settings
   - Raise combined FLARM/online traffic list limit to 64 targets (cloud
     batch size); device FLARM traffic still typically stays within 25
+  - Drop OGN/cloud online traffic that matches the connected FLARM radio
+    id so own-ship no longer appears on the traffic display #2693
 * ui
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -13,6 +13,9 @@ Version 7.45 - not yet released
     batch size); device FLARM traffic still typically stays within 25
   - Drop OGN/cloud online traffic that matches the connected FLARM radio
     id so own-ship no longer appears on the traffic display #2693
+  - Add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
+    to filter self and additional own aircraft from OGN when the device
+    radio id is unavailable (e.g. LX passthrough) #2693
 * ui
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -98,7 +98,7 @@ protected:
   bool TextMode(OperationEnvironment &env);
   bool BinaryMode(OperationEnvironment &env);
 
-  bool ParsePFLAC(NMEAInputLine &line);
+  bool ParsePFLAC(NMEAInputLine &line, NMEAInfo &info);
 
 public:
   /* virtual methods from class Device */

--- a/src/Device/Driver/FLARM/Mode.cpp
+++ b/src/Device/Driver/FLARM/Mode.cpp
@@ -16,9 +16,10 @@ FlarmDevice::EnableNMEA(OperationEnvironment &env)
     was_binary = false;
     mode = Mode::NMEA;
 
-    /* request self-test results and version information from FLARM */
+    /* request self-test results, version and radio id from FLARM */
     Send("PFLAE,R", env);
     Send("PFLAV,R", env);
+    Send("PFLAC,R,RADIOID", env);
     return true;
 
   case Mode::NMEA:

--- a/src/Device/Driver/FLARM/Parser.cpp
+++ b/src/Device/Driver/FLARM/Parser.cpp
@@ -2,15 +2,18 @@
 // Copyright The XCSoar Project
 
 #include "Device.hpp"
-#include "NMEA/InputLine.hpp"
+#include "FLARM/Id.hpp"
 #include "NMEA/Checksum.hpp"
+#include "NMEA/Info.hpp"
+#include "NMEA/InputLine.hpp"
 
-#include <string.h>
+#include <cstring>
+#include <string>
 
 using std::string_view_literals::operator""sv;
 
 bool
-FlarmDevice::ParsePFLAC(NMEAInputLine &line)
+FlarmDevice::ParsePFLAC(NMEAInputLine &line, NMEAInfo &info)
 {
   [[maybe_unused]] const auto responsetype = line.ReadView();
 
@@ -20,16 +23,48 @@ FlarmDevice::ParsePFLAC(NMEAInputLine &line)
     // ignore error responses...
     return true;
 
+  if (name == "RADIOID"sv) {
+    /* Format: <IDType>,<ID> */
+    const auto id_type = line.ReadView();
+    const auto id_hex = line.ReadView();
+    {
+      std::string value;
+      value.reserve(id_type.size() + 1 + id_hex.size());
+      value.append(id_type);
+      value.push_back(',');
+      value.append(id_hex);
+
+      const std::lock_guard<Mutex> lock(settings);
+      settings.Set(std::string{name}, std::move(value));
+    }
+
+    FlarmId id = FlarmId::Undefined();
+    if (!id_hex.empty() && id_hex.size() < 16) {
+      char hex[16];
+      memcpy(hex, id_hex.data(), id_hex.size());
+      hex[id_hex.size()] = '\0';
+      id = FlarmId::Parse(hex, nullptr);
+    }
+
+    /* Always update radio_id so a missing/invalid RADIOID does not
+       leave a stale self-id in the blackboard. */
+    info.flarm.hardware.radio_id = id;
+    if (id.IsDefined())
+      info.flarm.hardware.available.Update(info.clock);
+
+    return true;
+  }
+
   const auto value = line.Rest();
 
   const std::lock_guard<Mutex> lock(settings);
-  settings.Set(std::string{name}, value);
+  settings.Set(std::string{name}, std::string{value});
 
   return true;
 }
 
 bool
-FlarmDevice::ParseNMEA(const char *_line, [[maybe_unused]] NMEAInfo &info)
+FlarmDevice::ParseNMEA(const char *_line, NMEAInfo &info)
 {
   if (!VerifyNMEAChecksum(_line))
     return false;
@@ -38,7 +73,7 @@ FlarmDevice::ParseNMEA(const char *_line, [[maybe_unused]] NMEAInfo &info)
 
   const auto type = line.ReadView();
   if (type == "$PFLAC"sv)
-    return ParsePFLAC(line);
+    return ParsePFLAC(line, info);
   else
     return false;
 }

--- a/src/Dialogs/Settings/Panels/CloudConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/CloudConfigPanel.cpp
@@ -16,8 +16,13 @@
 #include "Form/DataField/Boolean.hpp"
 #include "Form/DataField/Listener.hpp"
 #include "net/State.hpp"
+#include "util/StringStrip.hxx"
+
+#include <fmt/format.h>
 
 #include <stdio.h>
+#include <string>
+#include <string_view>
 
 enum ControlIndex {
   ENABLED,
@@ -28,10 +33,14 @@ enum ControlIndex {
   SHOW_THERMALS,
   HOST,
   PORT,
+  OWN_FLARM_ID,
 };
 
 class CloudConfigPanel final
   : public RowFormWidget, DataFieldListener {
+  /** Help text for Own FLARM IDs (holds fmt result for SetHelpText). */
+  std::string own_flarm_help;
+
 public:
   CloudConfigPanel()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
@@ -57,6 +66,7 @@ CloudConfigPanel::SetEnabled(bool enabled)
   SetRowEnabled(SHOW_THERMALS, enabled);
   SetRowEnabled(HOST, enabled);
   SetRowEnabled(PORT, enabled);
+  SetRowEnabled(OWN_FLARM_ID, enabled);
 }
 
 void
@@ -112,6 +122,23 @@ CloudConfigPanel::Prepare(ContainerWindow &parent,
              1, 65535, 1, int(settings.port));
   SetExpertRow(PORT);
 
+  char own_flarm_text[CloudSettings::OWN_FLARM_IDS_TEXT_SIZE] = "";
+  CloudSettings::FormatOwnFlarmIds(settings.own_flarm_ids,
+                                   own_flarm_text, sizeof(own_flarm_text));
+  own_flarm_help = fmt::format(
+    fmt::runtime(
+      _("Comma-separated hex FLARM / ICAO addresses (up to {}) "
+        "used to hide your own aircraft from OGN traffic. Use "
+        "this when the FLARM radio id is not available (for "
+        "example behind an LX passthrough), or to hide "
+        "additional own aircraft. Leave empty to use the "
+        "device id when known.")),
+    CloudSettings::MAX_OWN_FLARM_IDS);
+  AddText(_("Own FLARM IDs"),
+          own_flarm_help.c_str(),
+          own_flarm_text);
+  SetExpertRow(OWN_FLARM_ID);
+
   SetEnabled(settings.enabled == TriState::TRUE);
 }
 
@@ -162,6 +189,29 @@ CloudConfigPanel::Save(bool &_changed) noexcept
     if (settings.port == 0 || settings.port > 65535u)
       settings.port = CloudSettings::DEFAULT_PORT;
     changed = true;
+  }
+
+  StaticString<CloudSettings::OWN_FLARM_IDS_TEXT_SIZE> own_flarm_text;
+  if (SaveValue(OWN_FLARM_ID, own_flarm_text)) {
+    const auto ids =
+      CloudSettings::ParseOwnFlarmIds(own_flarm_text.c_str());
+    const bool input_blank = Strip(std::string_view{own_flarm_text.c_str()})
+      .empty();
+
+    /* Non-empty garbage must not wipe a previously valid list. */
+    if (input_blank || !ids.empty()) {
+      bool same = settings.own_flarm_ids.size() == ids.size();
+      for (unsigned i = 0; same && i < ids.size(); ++i)
+        same = settings.own_flarm_ids[i] == ids[i];
+
+      if (!same) {
+        settings.own_flarm_ids = ids;
+        char tmp[CloudSettings::OWN_FLARM_IDS_TEXT_SIZE];
+        CloudSettings::FormatOwnFlarmIds(ids, tmp, sizeof(tmp));
+        Profile::Set(ProfileKeys::CloudOwnFlarmId, tmp);
+        changed = true;
+      }
+    }
   }
 
   _changed |= changed;

--- a/src/FLARM/Hardware.hpp
+++ b/src/FLARM/Hardware.hpp
@@ -29,6 +29,7 @@ struct FlarmHardware {
 
   constexpr void Clear() noexcept {
     available.Clear();
+    radio_id.Clear();
   }
 
   constexpr void Complement(const FlarmHardware &add) noexcept {

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -273,6 +273,7 @@ constexpr std::string_view CloudRoaming = "CloudRoaming";
 constexpr std::string_view CloudHost = "CloudHost";
 constexpr std::string_view CloudPort = "CloudPort";
 constexpr std::string_view CloudKey = "CloudKey";
+constexpr std::string_view CloudOwnFlarmId = "CloudOwnFlarmId";
 
 constexpr std::string_view OnlineTrafficMapMode = "OnlineTrafficMapMode";
 

--- a/src/Profile/TrackingProfile.cpp
+++ b/src/Profile/TrackingProfile.cpp
@@ -34,6 +34,9 @@ static void Load(const ProfileMap &map, CloudSettings &settings) {
   const char *key = map.Get(ProfileKeys::CloudKey);
   if (key != nullptr)
     ParseIntegerTo(key, settings.key, 16);
+
+  settings.own_flarm_ids =
+    CloudSettings::ParseOwnFlarmIds(map.Get(ProfileKeys::CloudOwnFlarmId));
 }
 
 static void Load(const ProfileMap &map,

--- a/src/Tracking/CloudSettings.hpp
+++ b/src/Tracking/CloudSettings.hpp
@@ -5,15 +5,34 @@
 
 #include "Tracking/SkyLines/Features.hpp"
 #include "util/TriState.hpp"
+#include "util/StaticArray.hxx"
 #include "util/StaticString.hxx"
+#include "util/IterableSplitString.hxx"
+#include "util/StringStrip.hxx"
+#include "FLARM/Id.hpp"
 
 #ifdef HAVE_SKYLINES_TRACKING
 
 #include <cstdint>
+#include <cstring>
+#include <cstddef>
 
 struct CloudSettings {
   static constexpr const char *DEFAULT_HOST = "cloud.xcsoar.org";
   static constexpr unsigned DEFAULT_PORT = 5597;
+
+  /** Maximum manual own-ship FLARM ids (comma-separated profile value). */
+  static constexpr unsigned MAX_OWN_FLARM_IDS = 8;
+
+  /**
+   * Buffer for formatted list: 8 hex digits per id, commas, NUL.
+   * FlarmId::Format() can emit up to 8 hex digits for a uint32_t.
+   */
+  static constexpr std::size_t OWN_FLARM_IDS_TEXT_SIZE =
+    MAX_OWN_FLARM_IDS * 8 +
+    (MAX_OWN_FLARM_IDS > 0 ? MAX_OWN_FLARM_IDS - 1 : 0) + 1;
+
+  using OwnFlarmIdList = StaticArray<FlarmId, MAX_OWN_FLARM_IDS>;
 
   /**
    * Is submitting data to the (experimental) XCSoar Cloud enabled?
@@ -42,6 +61,14 @@ struct CloudSettings {
   /** UDP port of the XCSoar Cloud server. */
   unsigned port = DEFAULT_PORT;
 
+  /**
+   * Manual own-ship FLARM ids used to filter self from OGN/cloud
+   * traffic when the device radio id is not available (e.g. FLARM
+   * behind an LX passthrough), or to hide additional own aircraft.
+   * Comma-separated hex ids in the profile.
+   */
+  OwnFlarmIdList own_flarm_ids;
+
   void SetDefaults() {
     enabled = TriState::UNKNOWN;
     show_traffic = true;
@@ -50,6 +77,7 @@ struct CloudSettings {
     key = 0;
     host = DEFAULT_HOST;
     port = DEFAULT_PORT;
+    own_flarm_ids.clear();
   }
 
   [[gnu::pure]]
@@ -63,6 +91,71 @@ struct CloudSettings {
       return port;
 
     return DEFAULT_PORT;
+  }
+
+  /**
+   * Parse a comma-separated list of hex FLARM / ICAO ids.  Invalid
+   * tokens and duplicates are skipped.  Accepts a single id (legacy
+   * profile values).
+   */
+  [[gnu::pure]]
+  static OwnFlarmIdList ParseOwnFlarmIds(const char *text) noexcept {
+    OwnFlarmIdList ids;
+    if (text == nullptr || *text == '\0')
+      return ids;
+
+    for (const auto token : IterableSplitString(text, ',')) {
+      if (ids.full())
+        break;
+
+      const auto trimmed = Strip(token);
+      if (trimmed.empty())
+        continue;
+
+      char buf[16];
+      if (trimmed.size() >= sizeof(buf))
+        continue;
+
+      memcpy(buf, trimmed.data(), trimmed.size());
+      buf[trimmed.size()] = '\0';
+
+      char *endptr;
+      const FlarmId id = FlarmId::Parse(buf, &endptr);
+      if (!id.IsDefined() || endptr == buf || *endptr != '\0')
+        continue;
+
+      if (!ids.contains(id))
+        ids.append(id);
+    }
+
+    return ids;
+  }
+
+  /** Format @ids as comma-separated hex (empty string when none). */
+  static void FormatOwnFlarmIds(const OwnFlarmIdList &ids,
+                                char *buffer, std::size_t size) noexcept {
+    if (buffer == nullptr || size == 0)
+      return;
+
+    buffer[0] = '\0';
+    if (ids.empty() || size < 2)
+      return;
+
+    std::size_t used = 0;
+    for (unsigned i = 0; i < ids.size(); ++i) {
+      char hex[16];
+      ids[i].Format(hex);
+      const std::size_t hex_len = strlen(hex);
+      const std::size_t need = (i > 0 ? 1 : 0) + hex_len;
+      if (used + need + 1 > size)
+        break;
+
+      if (i > 0)
+        buffer[used++] = ',';
+      memcpy(buffer + used, hex, hex_len);
+      used += hex_len;
+      buffer[used] = '\0';
+    }
   }
 };
 

--- a/src/Tracking/SkyLines/FlarmTrafficBuilder.cpp
+++ b/src/Tracking/SkyLines/FlarmTrafficBuilder.cpp
@@ -32,10 +32,17 @@ SkyLinesTracking::FlarmTrafficBuilder::SourceForOnline(
 }
 
 bool
-SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(FlarmId own_radio_id,
-                                                    FlarmId traffic_id) noexcept
+SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
+  std::span<const FlarmId> own_ids, FlarmId traffic_id) noexcept
 {
-  return own_radio_id.IsDefined() && traffic_id == own_radio_id;
+  if (!traffic_id.IsDefined())
+    return false;
+
+  for (const FlarmId id : own_ids)
+    if (id.IsDefined() && id == traffic_id)
+      return true;
+
+  return false;
 }
 
 bool

--- a/src/Tracking/SkyLines/FlarmTrafficBuilder.cpp
+++ b/src/Tracking/SkyLines/FlarmTrafficBuilder.cpp
@@ -32,6 +32,13 @@ SkyLinesTracking::FlarmTrafficBuilder::SourceForOnline(
 }
 
 bool
+SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(FlarmId own_radio_id,
+                                                    FlarmId traffic_id) noexcept
+{
+  return own_radio_id.IsDefined() && traffic_id == own_radio_id;
+}
+
+bool
 SkyLinesTracking::FlarmTrafficBuilder::FillRelative(FlarmTraffic &traffic,
                                                     const NMEAInfo &basic) noexcept
 {

--- a/src/Tracking/SkyLines/FlarmTrafficBuilder.hpp
+++ b/src/Tracking/SkyLines/FlarmTrafficBuilder.hpp
@@ -9,6 +9,8 @@
 #include "Geo/GeoPoint.hpp"
 #include "NMEA/Info.hpp"
 
+#include <span>
+
 namespace SkyLinesTracking {
 
 /**
@@ -25,11 +27,12 @@ public:
   SourceForOnline(uint32_t pilot_id, TrafficSource source) noexcept;
 
   /**
-   * True when online traffic #traffic_id matches the own-ship FLARM
-   * radio id (drop self from OGN / cloud feeds).
+   * True when online traffic #traffic_id matches any own-ship FLARM
+   * id (device radio id and/or configured list — drop self from OGN /
+   * cloud feeds).
    */
-  [[gnu::const]]
-  static bool IsOwnShipId(FlarmId own_radio_id,
+  [[gnu::pure]]
+  static bool IsOwnShipId(std::span<const FlarmId> own_ids,
                           FlarmId traffic_id) noexcept;
 
   /**

--- a/src/Tracking/SkyLines/FlarmTrafficBuilder.hpp
+++ b/src/Tracking/SkyLines/FlarmTrafficBuilder.hpp
@@ -25,6 +25,14 @@ public:
   SourceForOnline(uint32_t pilot_id, TrafficSource source) noexcept;
 
   /**
+   * True when online traffic #traffic_id matches the own-ship FLARM
+   * radio id (drop self from OGN / cloud feeds).
+   */
+  [[gnu::const]]
+  static bool IsOwnShipId(FlarmId own_radio_id,
+                          FlarmId traffic_id) noexcept;
+
+  /**
    * Populate relative_north/east/altitude from own-ship GPS.
    *
    * @return false if relative position cannot be computed

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -90,6 +90,7 @@ TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
   {
     const std::lock_guard lock{online_mutex};
     own_altitude = OwnAltitudeMeters(basic);
+    own_flarm_id = basic.flarm.hardware.radio_id;
   }
 
   try {
@@ -110,6 +111,7 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
   const std::lock_guard lock{online_mutex};
 
   own_altitude = OwnAltitudeMeters(basic);
+  own_flarm_id = flarm.hardware.radio_id;
 
   online_traffic.ClampListSize();
 
@@ -121,7 +123,9 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
     if (last_i == online_last_received.end() ||
         now - last_i->second > ONLINE_BUFFER_STALE ||
         !WithinOnlineAltitudeBand(own_altitude, int(t.altitude),
-                                  t.altitude_available)) {
+                                  t.altitude_available) ||
+        SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_flarm_id,
+                                                           t.id)) {
       online_last_received.erase(t.id);
       online_pilot_ids.erase(t.id);
       online_traffic.list.quick_remove(i);
@@ -130,6 +134,10 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
   }
 
   for (const auto &online : online_traffic.list) {
+    if (SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_flarm_id,
+                                                           online.id))
+      continue;
+
     FlarmTraffic *existing = flarm.traffic.FindTraffic(online.id);
     if (existing != nullptr &&
         !FlarmTraffic::IsInjectedSource(existing->source) &&
@@ -184,9 +192,11 @@ TrackingGlue::OnTraffic(uint32_t pilot_id,
   }
 
   int own_alt;
+  FlarmId own_id;
   {
     const std::lock_guard lock{online_mutex};
     own_alt = own_altitude;
+    own_id = own_flarm_id;
   }
 
   if (!WithinOnlineAltitudeBand(own_alt, altitude, altitude_valid))
@@ -203,6 +213,9 @@ TrackingGlue::OnTraffic(uint32_t pilot_id,
     track_deg, track_valid, flarm_id, aircraft_type, server_name);
 
   if (!built.location_available)
+    return;
+
+  if (SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_id, built.id))
     return;
 
   bool user_known;

--- a/src/Tracking/TrackingGlue.cpp
+++ b/src/Tracking/TrackingGlue.cpp
@@ -45,6 +45,21 @@ WithinOnlineAltitudeBand(int own_alt, int target_alt,
 
 static constexpr auto ONLINE_BUFFER_STALE = minutes(5);
 
+/**
+ * Configured own FLARM ids plus the device radio id when known.
+ */
+static StaticArray<FlarmId, CloudSettings::MAX_OWN_FLARM_IDS + 1>
+MakeEffectiveOwnFlarmIds(const CloudSettings::OwnFlarmIdList &configured,
+                         FlarmId radio_id) noexcept
+{
+  StaticArray<FlarmId, CloudSettings::MAX_OWN_FLARM_IDS + 1> ids;
+  for (const FlarmId id : configured)
+    ids.append(id);
+  if (radio_id.IsDefined() && !ids.contains(radio_id))
+    ids.append(radio_id);
+  return ids;
+}
+
 TrackingGlue::TrackingGlue(EventLoop &event_loop,
                            CurlGlobal &curl) noexcept
   :skylines(event_loop, this),
@@ -59,11 +74,17 @@ TrackingGlue::SetSettings(const TrackingSettings &_settings)
   cloud_enabled = _settings.cloud.enabled;
   cloud_show_traffic = _settings.cloud.show_traffic;
 
-  if (cloud_enabled != TriState::TRUE || !cloud_show_traffic) {
+  {
     const std::lock_guard lock{online_mutex};
-    online_traffic.Clear();
-    online_pilot_ids.clear();
-    online_last_received.clear();
+    configured_own_flarm_ids = _settings.cloud.own_flarm_ids;
+    own_flarm_ids = MakeEffectiveOwnFlarmIds(configured_own_flarm_ids,
+                                             device_radio_id);
+
+    if (cloud_enabled != TriState::TRUE || !cloud_show_traffic) {
+      online_traffic.Clear();
+      online_pilot_ids.clear();
+      online_last_received.clear();
+    }
   }
 
   skylines.SetSettings(_settings.skylines, _settings.cloud);
@@ -90,7 +111,9 @@ TrackingGlue::OnTimer(const MoreData &basic, const DerivedInfo &calculated)
   {
     const std::lock_guard lock{online_mutex};
     own_altitude = OwnAltitudeMeters(basic);
-    own_flarm_id = basic.flarm.hardware.radio_id;
+    device_radio_id = basic.flarm.hardware.radio_id;
+    own_flarm_ids = MakeEffectiveOwnFlarmIds(configured_own_flarm_ids,
+                                             device_radio_id);
   }
 
   try {
@@ -111,7 +134,9 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
   const std::lock_guard lock{online_mutex};
 
   own_altitude = OwnAltitudeMeters(basic);
-  own_flarm_id = flarm.hardware.radio_id;
+  device_radio_id = flarm.hardware.radio_id;
+  own_flarm_ids = MakeEffectiveOwnFlarmIds(configured_own_flarm_ids,
+                                           device_radio_id);
 
   online_traffic.ClampListSize();
 
@@ -124,7 +149,7 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
         now - last_i->second > ONLINE_BUFFER_STALE ||
         !WithinOnlineAltitudeBand(own_altitude, int(t.altitude),
                                   t.altitude_available) ||
-        SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_flarm_id,
+        SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_flarm_ids,
                                                            t.id)) {
       online_last_received.erase(t.id);
       online_pilot_ids.erase(t.id);
@@ -134,10 +159,6 @@ TrackingGlue::MergeOnlineTraffic(FlarmData &flarm,
   }
 
   for (const auto &online : online_traffic.list) {
-    if (SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_flarm_id,
-                                                           online.id))
-      continue;
-
     FlarmTraffic *existing = flarm.traffic.FindTraffic(online.id);
     if (existing != nullptr &&
         !FlarmTraffic::IsInjectedSource(existing->source) &&
@@ -192,11 +213,11 @@ TrackingGlue::OnTraffic(uint32_t pilot_id,
   }
 
   int own_alt;
-  FlarmId own_id;
+  StaticArray<FlarmId, CloudSettings::MAX_OWN_FLARM_IDS + 1> own_ids;
   {
     const std::lock_guard lock{online_mutex};
     own_alt = own_altitude;
-    own_id = own_flarm_id;
+    own_ids = own_flarm_ids;
   }
 
   if (!WithinOnlineAltitudeBand(own_alt, altitude, altitude_valid))
@@ -215,7 +236,7 @@ TrackingGlue::OnTraffic(uint32_t pilot_id,
   if (!built.location_available)
     return;
 
-  if (SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_id, built.id))
+  if (SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_ids, built.id))
     return;
 
   bool user_known;

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -8,6 +8,7 @@
 #ifdef HAVE_TRACKING
 
 #include "Tracking/SkyLines/Handler.hpp"
+#include "Tracking/CloudSettings.hpp"
 #include "FLARM/Id.hpp"
 #include "FLARM/List.hpp"
 #include "FLARM/Data.hpp"
@@ -15,6 +16,7 @@
 #include "Tracking/SkyLines/Data.hpp"
 #include "Tracking/LiveTrack24/Glue.hpp"
 #include "util/StaticString.hxx"
+#include "util/StaticArray.hxx"
 #include "util/TriState.hpp"
 #include "thread/Mutex.hxx"
 
@@ -54,8 +56,18 @@ class TrackingGlue final
   /** Own-ship altitude [m MSL] for online-traffic filtering; -1 if unknown. */
   int own_altitude = -1;
 
-  /** Own-ship FLARM radio id when known (filters OGN self). */
-  FlarmId own_flarm_id = FlarmId::Undefined();
+  /**
+   * Effective own-ship FLARM ids for filtering online self traffic:
+   * configured #CloudSettings::own_flarm_ids plus #device_radio_id when
+   * known (room for one extra id beyond the configured maximum).
+   */
+  StaticArray<FlarmId, CloudSettings::MAX_OWN_FLARM_IDS + 1> own_flarm_ids;
+
+  /** Manual own FLARM ids from cloud settings. */
+  CloudSettings::OwnFlarmIdList configured_own_flarm_ids;
+
+  /** Last observed #FlarmHardware::radio_id (device self id). */
+  FlarmId device_radio_id = FlarmId::Undefined();
 
 public:
   TrackingGlue(EventLoop &event_loop, CurlGlobal &curl) noexcept;

--- a/src/Tracking/TrackingGlue.hpp
+++ b/src/Tracking/TrackingGlue.hpp
@@ -54,6 +54,9 @@ class TrackingGlue final
   /** Own-ship altitude [m MSL] for online-traffic filtering; -1 if unknown. */
   int own_altitude = -1;
 
+  /** Own-ship FLARM radio id when known (filters OGN self). */
+  FlarmId own_flarm_id = FlarmId::Undefined();
+
 public:
   TrackingGlue(EventLoop &event_loop, CurlGlobal &curl) noexcept;
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -51,6 +51,7 @@
 #include "Tracking/SkyLines/TrafficExtensions.hpp"
 #include "Tracking/SkyLines/Protocol.hpp"
 #include "Tracking/SkyLines/Handler.hpp"
+#include "Tracking/CloudSettings.hpp"
 #include "Device/RecordedFlight.hpp"
 #include "Device/device.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
@@ -73,7 +74,9 @@
 #include "util/PackedFloat.hxx"
 
 #include <chrono>
+#include <cstring>
 #include <memory>
+#include <span>
 
 #ifdef _WIN32
 #include <process.h>
@@ -3089,12 +3092,41 @@ TestFlarmTrafficBuilder()
   ok1(merged.track_received);
 
   const FlarmId radio = FlarmId::FromValue(0xABCDEFu);
+  const FlarmId other = FlarmId::FromValue(0x123456u);
+  const FlarmId own_ids[] = { radio };
+  ok1(SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_ids, radio));
+  ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(own_ids, other));
+  ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
+         std::span<const FlarmId>{}, radio));
+
+  const FlarmId multi[] = {
+    FlarmId::FromValue(0x111111u),
+    FlarmId::FromValue(0x222222u),
+  };
   ok1(SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
-        radio, FlarmId::FromValue(0xABCDEFu)));
+        multi, FlarmId::FromValue(0x222222u)));
   ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
-         radio, FlarmId::FromValue(0x123456u)));
-  ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
-         FlarmId::Undefined(), radio));
+         multi, FlarmId::FromValue(0x333333u)));
+
+  const auto parsed =
+    CloudSettings::ParseOwnFlarmIds("ABCDEF, 111111,ABCDEF,zz,222222");
+  ok1(parsed.size() == 3);
+  ok1(parsed[0] == FlarmId::FromValue(0xABCDEFu));
+  ok1(parsed[1] == FlarmId::FromValue(0x111111u));
+  ok1(parsed[2] == FlarmId::FromValue(0x222222u));
+
+  char formatted[CloudSettings::OWN_FLARM_IDS_TEXT_SIZE];
+  CloudSettings::FormatOwnFlarmIds(parsed, formatted, sizeof(formatted));
+  ok1(StringIsEqual(formatted, "ABCDEF,111111,222222"));
+
+  /* Worst-case 8×8-hex ids must fit the format buffer. */
+  CloudSettings::OwnFlarmIdList full;
+  for (unsigned i = 0; i < CloudSettings::MAX_OWN_FLARM_IDS; ++i)
+    full.append(FlarmId::FromValue(0xF0000000u + i));
+  CloudSettings::FormatOwnFlarmIds(full, formatted, sizeof(formatted));
+  ok1(strlen(formatted) + 1 <= CloudSettings::OWN_FLARM_IDS_TEXT_SIZE);
+  ok1(CloudSettings::ParseOwnFlarmIds(formatted).size() ==
+      CloudSettings::MAX_OWN_FLARM_IDS);
 }
 
 static void
@@ -3172,7 +3204,7 @@ int main()
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
-             + 59 /* Condor3UDP */ + 15 /* FlarmTrafficBuilder */
+             + 59 /* Condor3UDP */ + 24 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */);
   TestGeneric();
   TestTasman();

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -3087,6 +3087,14 @@ TestFlarmTrafficBuilder()
   partial.track_received = false;
   merged.UpdateOnline(partial);
   ok1(merged.track_received);
+
+  const FlarmId radio = FlarmId::FromValue(0xABCDEFu);
+  ok1(SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
+        radio, FlarmId::FromValue(0xABCDEFu)));
+  ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
+         radio, FlarmId::FromValue(0x123456u)));
+  ok1(!SkyLinesTracking::FlarmTrafficBuilder::IsOwnShipId(
+         FlarmId::Undefined(), radio));
 }
 
 static void
@@ -3164,7 +3172,7 @@ int main()
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
-             + 59 /* Condor3UDP */ + 12 /* FlarmTrafficBuilder */
+             + 59 /* Condor3UDP */ + 15 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */);
   TestGeneric();
   TestTasman();


### PR DESCRIPTION
## Summary

- Request `RADIOID` from a connected FLARM and drop matching OGN/cloud traffic so own-ship no longer appears on the traffic display.
- Add expert cloud setting **Own FLARM IDs** (comma-separated hex list, up to 8) for LX passthrough / missing device radio id, and for hiding additional own aircraft. Device radio id is always included when known.

Closes #2693

## Test plan

- [ ] With a direct FLARM device: enable XCSoar Cloud traffic and confirm own aircraft no longer shows as online traffic after RADIOID is received.
- [ ] With LX passthrough (no RADIOID): set expert Own FLARM IDs to your hex id(s) and confirm those targets are filtered.
- [ ] Enter multiple ids (`DEADBE,ABCDEF`), invalid tokens, and blanks; confirm parse/dedupe and that garbage alone does not wipe a valid saved list.
- [ ] `./output/UNIX/bin/TestDriver` (ownship / ParseOwnFlarmIds cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of the connected FLARM radio ID.
  * Added an expert “Own FLARM IDs” cloud setting for manually specifying aircraft identifiers.
* **Bug Fixes**
  * Own-ship entries are now dropped from the OGN/cloud traffic display when identifiers match.
  * Self-traffic filtering also applies when the device radio ID is unavailable.
  * Clearing FLARM hardware data now fully resets stored identifier information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->