### PR TITLE
ui/window/gdi: Fix CreateMessageWindow assertion on startup

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -333,10 +333,6 @@ Version 7.45 - not yet released
     off-screen while scrolling (no black squares; safer clipping of subcanvas
     and list blits) #2293
 * Windows
-  - fix legacy Windows executable failing to start with an assertion
-    dialog on some systems #2720
-  - fix legacy Windows executable crash on quit when Lua timers or
-    background notifications were still pending #2720
   - add installer for the OpenGL Windows version (64-bit and 32-bit); zip
     download remains available for a portable install
   - deprecate the legacy single-file Windows executable; use the OpenGL

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -335,6 +335,8 @@ Version 7.45 - not yet released
 * Windows
   - fix legacy Windows executable failing to start with an assertion
     dialog on some systems #2720
+  - fix legacy Windows executable crash on quit when Lua timers or
+    background notifications were still pending #2720
   - add installer for the OpenGL Windows version (64-bit and 32-bit); zip
     download remains available for a portable install
   - deprecate the legacy single-file Windows executable; use the OpenGL

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -333,6 +333,8 @@ Version 7.45 - not yet released
     off-screen while scrolling (no black squares; safer clipping of subcanvas
     and list blits) #2293
 * Windows
+  - fix legacy Windows executable failing to start with an assertion
+    dialog on some systems #2720
   - add installer for the OpenGL Windows version (64-bit and 32-bit); zip
     download remains available for a portable install
   - deprecate the legacy single-file Windows executable; use the OpenGL

--- a/src/lua/Timer.cpp
+++ b/src/lua/Timer.cpp
@@ -32,6 +32,10 @@ public:
   explicit LuaTimer(lua_State *L, int callback_idx)
     :callback(L, Lua::StackIndex(callback_idx)), timer(L) {}
 
+  ~LuaTimer() noexcept {
+    Cancel();
+  }
+
   lua_State *GetLuaState() {
     return callback.GetState();
   }
@@ -45,17 +49,23 @@ public:
     timer_event.Schedule(d);
   }
 
-  void Cancel() {
-    const Lua::ScopeCheckStack check_stack(GetLuaState());
-
+  void Cancel() noexcept {
+    lua_State *const L = GetLuaState();
     timer_event.Cancel();
+    if (L == nullptr)
+      return;
+
+    const Lua::ScopeCheckStack check_stack(L);
     timer.Set(nullptr);
-    Lua::RemovePersistent(GetLuaState(), this);
+    Lua::RemovePersistent(L, this);
   }
 
 protected:
   void OnTimer() noexcept {
     const auto L = GetLuaState();
+    if (L == nullptr)
+      return;
+
     const Lua::ScopeCheckStack check_stack(L);
 
     callback.Push();
@@ -63,6 +73,9 @@ protected:
     if (lua_pcall(L, 1, 0, 0))
       Lua::ThrowError(L, Lua::PopError(L));
 
+    /* May destroy this object (and the PeriodicTimer) when the last
+       persistent handle is gone -- PeriodicTimer::Invoke tolerates
+       that via invoke_alive. */
     Lua::CheckPersistent(L);
   }
 

--- a/src/ui/event/Notify.hpp
+++ b/src/ui/event/Notify.hpp
@@ -31,11 +31,9 @@ public:
 
   Notify(const Notify &) = delete;
 
-#ifndef USE_WINUSER
   ~Notify() noexcept {
     ClearNotification();
   }
-#endif
 
   /**
    * Send a notification to this object.  This method can be called

--- a/src/ui/event/PeriodicTimer.hpp
+++ b/src/ui/event/PeriodicTimer.hpp
@@ -75,9 +75,13 @@ public:
     bool alive = true;
     invoke_alive = &alive;
     callback();
+    /* Callback may have destroyed this object (e.g. LuaTimer). */
+    if (!alive)
+      return;
+
     invoke_alive = nullptr;
 
-    if (alive && IsActive() && !timer.IsPending())
+    if (IsActive() && !timer.IsPending())
       timer.Schedule(interval);
   }
 };

--- a/src/ui/event/PeriodicTimer.hpp
+++ b/src/ui/event/PeriodicTimer.hpp
@@ -21,6 +21,13 @@ class PeriodicTimer final {
 
   std::chrono::steady_clock::duration interval{-1};
 
+  /**
+   * Cleared by the destructor while Invoke() is running, so a
+   * callback that destroys this object does not touch freed memory
+   * on return (LuaTimer / CheckPersistent).
+   */
+  bool *invoke_alive = nullptr;
+
   using Callback = std::function<void()>;
   const Callback callback;
 
@@ -30,6 +37,12 @@ public:
    */
   explicit PeriodicTimer(Callback &&_callback) noexcept
     :callback(std::move(_callback)) {}
+
+  ~PeriodicTimer() noexcept {
+    if (invoke_alive != nullptr)
+      *invoke_alive = false;
+    Cancel();
+  }
 
   /**
    * Is the timer active, i.e. is it waiting for the current period to
@@ -59,9 +72,12 @@ public:
 
 public:
   void Invoke() noexcept {
+    bool alive = true;
+    invoke_alive = &alive;
     callback();
+    invoke_alive = nullptr;
 
-    if (IsActive() && !timer.IsPending())
+    if (alive && IsActive() && !timer.IsPending())
       timer.Schedule(interval);
   }
 };

--- a/src/ui/window/SingleWindow.hpp
+++ b/src/ui/window/SingleWindow.hpp
@@ -19,16 +19,14 @@ struct Event;
  * the process quits.
  */
 class SingleWindow : public TopWindow {
-#ifdef USE_WINUSER
-  static constexpr const char *class_name = "XCSoarMain";
-#endif
-
   std::forward_list<WndForm *> dialogs;
 
 public:
   using TopWindow::TopWindow;
 
 #ifdef USE_WINUSER
+  static constexpr const char *class_name = "XCSoarMain";
+
   /**
    * Register the WIN32 window class.
    */

--- a/src/ui/window/gdi/Window.cpp
+++ b/src/ui/window/gdi/Window.cpp
@@ -19,7 +19,7 @@
 #include <errhandlingapi.h>
 
 /** Dedicated class for HWND_MESSAGE windows (UI::Notify fallback). */
-static constexpr char message_window_class[] = "XCSoarMessage";
+static constexpr char MESSAGE_WINDOW_CLASS[] = "XCSoarMessage";
 
 static bool
 RegisterMessageWindowClass() noexcept
@@ -27,7 +27,7 @@ RegisterMessageWindowClass() noexcept
   WNDCLASS wc{};
   wc.lpfnWndProc = Window::WndProc;
   wc.hInstance = ::GetModuleHandle(nullptr);
-  wc.lpszClassName = message_window_class;
+  wc.lpszClassName = MESSAGE_WINDOW_CLASS;
   if (::RegisterClass(&wc) != 0)
     return true;
 
@@ -69,7 +69,7 @@ Window::CreateMessageWindow() noexcept
   static const bool registered = RegisterMessageWindowClass();
   assert(registered);
 
-  hWnd = ::CreateWindowEx(0, message_window_class, nullptr, 0,
+  hWnd = ::CreateWindowEx(0, MESSAGE_WINDOW_CLASS, nullptr, 0,
                           0, 0, 0, 0,
                           HWND_MESSAGE,
                           nullptr, nullptr, this);

--- a/src/ui/window/gdi/Window.cpp
+++ b/src/ui/window/gdi/Window.cpp
@@ -3,6 +3,7 @@
 
 #include "../Window.hpp"
 #include "../ContainerWindow.hpp"
+#include "../SingleWindow.hpp"
 #include "../MinimumSize.hpp"
 #include "ui/canvas/Font.hpp"
 #include "Screen/Debug.hpp"
@@ -19,9 +20,6 @@
 
 /** Dedicated class for HWND_MESSAGE windows (UI::Notify fallback). */
 static constexpr char message_window_class[] = "XCSoarMessage";
-
-/** Main window class registered by UI::SingleWindow::RegisterClass(). */
-static constexpr char main_window_class[] = "XCSoarMain";
 
 static bool
 RegisterMessageWindowClass() noexcept
@@ -64,10 +62,10 @@ Window::Create(ContainerWindow *parent, const char *cls, const char *text,
 void
 Window::CreateMessageWindow() noexcept
 {
-  /* Lazily register a class without CS_PARENTDC.  Reusing
-     "PaintWindow" for HWND_MESSAGE windows interacts badly with
-     WM_GETMINMAXINFO minimum-size enforcement and fails
-     CreateWindowEx on some Windows hosts (issue #2720). */
+  /* Lazily register a dedicated class for HWND_MESSAGE windows.
+     Reusing "PaintWindow" shares WndProc's WM_GETMINMAXINFO path,
+     which used to treat parent-less message windows as top-level
+     and could make CreateWindowEx fail (issue #2720). */
   static const bool registered = RegisterMessageWindowClass();
   assert(registered);
 
@@ -349,15 +347,15 @@ Window::WndProc(HWND _hWnd, UINT message,
     /* WM_GETMINMAXINFO is called before WM_CREATE, and we have not
        set a Window pointer yet.  Let DefWindowProc fill defaults,
        then clamp the main window only (issue #2110).  Do not apply
-       this to message-only / PaintWindow children — GetParent() is
-       also null for HWND_MESSAGE windows, and forcing a minimum
-       size makes CreateMessageWindow() fail (issue #2720). */
+       this to message-only windows: GetParent() is also null for
+       HWND_MESSAGE, and forcing a minimum size can make
+       CreateMessageWindow() fail (issue #2720). */
     const LRESULT result =
       ::DefWindowProc(_hWnd, message, wParam, lParam);
 
     char class_name[64];
     if (::GetClassNameA(_hWnd, class_name, sizeof(class_name)) > 0 &&
-        std::strcmp(class_name, main_window_class) == 0) {
+        std::strcmp(class_name, UI::SingleWindow::class_name) == 0) {
       MINMAXINFO *mmi = reinterpret_cast<MINMAXINFO *>(lParam);
       /* Allow either landscape (320x240) or portrait (240x320). */
       mmi->ptMinTrackSize.x = LONG(UI::MIN_HEIGHT);

--- a/src/ui/window/gdi/Window.cpp
+++ b/src/ui/window/gdi/Window.cpp
@@ -10,7 +10,32 @@
 #include "Asset.hpp"
 
 #include <cassert>
+#include <cstring>
 #include <windowsx.h>
+#include <winerror.h>
+
+#include <libloaderapi.h>
+#include <errhandlingapi.h>
+
+/** Dedicated class for HWND_MESSAGE windows (UI::Notify fallback). */
+static constexpr char message_window_class[] = "XCSoarMessage";
+
+/** Main window class registered by UI::SingleWindow::RegisterClass(). */
+static constexpr char main_window_class[] = "XCSoarMain";
+
+static bool
+RegisterMessageWindowClass() noexcept
+{
+  WNDCLASS wc{};
+  wc.lpfnWndProc = Window::WndProc;
+  wc.hInstance = ::GetModuleHandle(nullptr);
+  wc.lpszClassName = message_window_class;
+  if (::RegisterClass(&wc) != 0)
+    return true;
+
+  /* Already registered by another CreateMessageWindow() call. */
+  return ::GetLastError() == ERROR_CLASS_ALREADY_EXISTS;
+}
 
 void
 Window::Create(ContainerWindow *parent, const char *cls, const char *text,
@@ -39,7 +64,15 @@ Window::Create(ContainerWindow *parent, const char *cls, const char *text,
 void
 Window::CreateMessageWindow() noexcept
 {
-  hWnd = ::CreateWindowEx(0, "PaintWindow", nullptr, 0, 0, 0, 0, 0,
+  /* Lazily register a class without CS_PARENTDC.  Reusing
+     "PaintWindow" for HWND_MESSAGE windows interacts badly with
+     WM_GETMINMAXINFO minimum-size enforcement and fails
+     CreateWindowEx on some Windows hosts (issue #2720). */
+  static const bool registered = RegisterMessageWindowClass();
+  assert(registered);
+
+  hWnd = ::CreateWindowEx(0, message_window_class, nullptr, 0,
+                          0, 0, 0, 0,
                           HWND_MESSAGE,
                           nullptr, nullptr, this);
   assert(hWnd != nullptr);
@@ -313,17 +346,25 @@ Window::WndProc(HWND _hWnd, UINT message,
                 WPARAM wParam, LPARAM lParam) noexcept
 {
   if (message == WM_GETMINMAXINFO) {
-    /* WM_GETMINMAXINFO is called before WM_CREATE, and we havn't set
-       a Window pointer yet - but we can still enforce minimum size.
-       This prevents crashes from invalid rectangles (issue #2110) */
-    MINMAXINFO *mmi = reinterpret_cast<MINMAXINFO *>(lParam);
+    /* WM_GETMINMAXINFO is called before WM_CREATE, and we have not
+       set a Window pointer yet.  Let DefWindowProc fill defaults,
+       then clamp the main window only (issue #2110).  Do not apply
+       this to message-only / PaintWindow children — GetParent() is
+       also null for HWND_MESSAGE windows, and forcing a minimum
+       size makes CreateMessageWindow() fail (issue #2720). */
+    const LRESULT result =
+      ::DefWindowProc(_hWnd, message, wParam, lParam);
 
-    /* Only enforce minimum for top-level windows (no parent) */
-    if (::GetParent(_hWnd) == nullptr) {
-      mmi->ptMinTrackSize.x = UI::MIN_HEIGHT;
-      mmi->ptMinTrackSize.y = UI::MIN_HEIGHT;
+    char class_name[64];
+    if (::GetClassNameA(_hWnd, class_name, sizeof(class_name)) > 0 &&
+        std::strcmp(class_name, main_window_class) == 0) {
+      MINMAXINFO *mmi = reinterpret_cast<MINMAXINFO *>(lParam);
+      /* Allow either landscape (320x240) or portrait (240x320). */
+      mmi->ptMinTrackSize.x = LONG(UI::MIN_HEIGHT);
+      mmi->ptMinTrackSize.y = LONG(UI::MIN_HEIGHT);
     }
-    return 0;
+
+    return result;
   }
 
   Window *window;


### PR DESCRIPTION
## Summary
- Fix legacy Windows (GDI) startup assertion (`hWnd != nullptr` in `CreateMessageWindow`) reported in #2720.
- Message-only windows no longer reuse the `PaintWindow` class; they use a dedicated `XCSoarMessage` class.
- `WM_GETMINMAXINFO` min-size enforcement applies only to `XCSoarMain` and runs after `DefWindowProc`, so HWND_MESSAGE creation is not broken.

## Test plan
- [ ] Build `TARGET=WIN64` (GDI) debug and confirm `Window.o` / full exe link
- [ ] Start the legacy Windows executable on a machine that previously showed the assertion — no assert dialog
- [ ] Confirm the main window still cannot be resized below ~240px in either dimension
- [ ] Build/run `TARGET=WIN64OPENGL` briefly to ensure no impact on OpenGL path

Fixes #2720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a legacy Windows executable startup failure that could trigger an assertion on some systems.
  * Fixed a crash on exit when Lua timers or background notifications were still pending.
  * Improved stability around timer and notification shutdown to prevent safe-cancellation and callback timing issues.
  * Prevented Windows message-only/background windows from being affected by minimum sizing rules intended for main windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->