### PR TITLE
Feat/alternates Select any waypoint as an Alternate target

### DIFF
--- a/doc/manual/de/ch04_xc_tasks.tex
+++ b/doc/manual/de/ch04_xc_tasks.tex
@@ -587,7 +587,12 @@ Varianten können entweder im Modus \textbf{AUTO} oder \textbf{MANUELL}
 verwendet werden. AUTO ist die Voreinstellung und zeigt die automatisch
 ermittelten besten Alternativen an. Im manuellen Modus kann für jeden Slot
 unabhängig eine erreichbare Alternative aus der Alternativenliste ausgewählt
-werden. Diese Auswahl gilt nur zur Laufzeit: sie wird beim Neustart von
+werden. Eine manuelle Alternative kann auch direkt von jedem Wegpunkt oder von
+einer Kartenposition, die für \bmenuw{Goto} verwendet werden kann, gesetzt
+werden: dazu im Dialog ``Kartenelemente an dieser Position'' oder im
+Wegpunktdetails-Dialog \bmenuw{Alternative 1} oder \bmenuw{Alternative 2}
+drücken. Der entsprechende Slot wird dabei automatisch auf MANUELL geschaltet.
+Diese Auswahl gilt nur zur Laufzeit: sie wird beim Neustart von
 \textsf{XCSoar} nicht gespeichert und bleibt aktiv, bis sie erneut geändert
 oder der Slot wieder auf AUTO zurückgestellt wird.
 

--- a/doc/manual/de/ch04_xc_tasks.tex
+++ b/doc/manual/de/ch04_xc_tasks.tex
@@ -588,7 +588,7 @@ verwendet werden. AUTO ist die Voreinstellung und zeigt die automatisch
 ermittelten besten Alternativen an. Im manuellen Modus kann für jeden Slot
 unabhängig eine erreichbare Alternative aus der Alternativenliste ausgewählt
 werden. Eine manuelle Alternative kann auch direkt von jedem Wegpunkt oder von
-einer Kartenposition, die für \bmenuw{Goto} verwendet werden kann, gesetzt
+einer Kartenposition, die für \bmenuw{Ziele auf} verwendet werden kann, gesetzt
 werden: dazu im Dialog ``Kartenelemente an dieser Position'' oder im
 Wegpunktdetails-Dialog \bmenuw{Alternative 1} oder \bmenuw{Alternative 2}
 drücken. Der entsprechende Slot wird dabei automatisch auf MANUELL geschaltet.

--- a/doc/manual/de/ch04_xc_tasks.tex
+++ b/doc/manual/de/ch04_xc_tasks.tex
@@ -596,7 +596,7 @@ landbare Wegpunkt gesetzt werden kann; bei nicht landbaren Wegpunkten wird sie
 nicht angeboten.
 Diese Auswahl gilt nur zur Laufzeit: sie wird beim Neustart von
 \textsf{XCSoar} nicht gespeichert und bleibt aktiv, bis sie erneut geändert
-wird oder \bmenuw{Alternate Mode: Auto} gedrückt wird, das fragt, welcher
+wird oder \bmenuw{Alternate AUTO} gedrückt wird, das fragt, welcher
 der beiden Slots wieder auf AUTO gestellt werden soll.
 
 Die Alternativenliste selbst gehört zu keiner der beiden InfoBoxen: die Ziele,

--- a/doc/manual/de/ch04_xc_tasks.tex
+++ b/doc/manual/de/ch04_xc_tasks.tex
@@ -587,14 +587,24 @@ Varianten können entweder im Modus \textbf{AUTO} oder \textbf{MANUELL}
 verwendet werden. AUTO ist die Voreinstellung und zeigt die automatisch
 ermittelten besten Alternativen an. Im manuellen Modus kann für jeden Slot
 unabhängig eine erreichbare Alternative aus der Alternativenliste ausgewählt
-werden. Eine manuelle Alternative kann auch direkt von jedem Wegpunkt oder von
-einer Kartenposition, die für \bmenuw{Ziele auf} verwendet werden kann, gesetzt
-werden: dazu im Dialog ``Kartenelemente an dieser Position'' oder im
-Wegpunktdetails-Dialog \bmenuw{Alternative 1} oder \bmenuw{Alternative 2}
-drücken. Der entsprechende Slot wird dabei automatisch auf MANUELL geschaltet.
+werden. Mit \bmenuw{Als Alternative wählen} wird ein landbarer Wegpunkt an
+eine der beiden InfoBoxen gebunden (MANUELL); \textsf{XCSoar} fragt dann,
+welche der beiden verwendet werden soll, und zeigt dabei das aktuelle Ziel
+jedes Slots an. Diese Schaltfläche steht auch im Dialog ``Kartenelemente an
+dieser Position'' und im Wegpunktdetails-Dialog zur Verfügung, so dass jeder
+landbare Wegpunkt gesetzt werden kann; bei nicht landbaren Wegpunkten wird sie
+nicht angeboten.
 Diese Auswahl gilt nur zur Laufzeit: sie wird beim Neustart von
 \textsf{XCSoar} nicht gespeichert und bleibt aktiv, bis sie erneut geändert
-oder der Slot wieder auf AUTO zurückgestellt wird.
+wird oder \bmenuw{Alternate Mode: Auto} gedrückt wird, das fragt, welcher
+der beiden Slots wieder auf AUTO gestellt werden soll.
+
+Die Alternativenliste selbst gehört zu keiner der beiden InfoBoxen: die Ziele,
+auf die Alternative 1 und Alternative 2 gerade zeigen, sind in der Liste mit
+``ALT1'' und ``ALT2'' markiert. Ein manuell gesetztes Ziel, das der
+Rechner nicht ermittelt hat, wird der Liste angehängt; sie kann daher bis zu
+zwölf Einträge enthalten: die zehn berechneten Optionen und die zwei vom
+Piloten gesetzten Ziele.
 
 Folgende Optionen sind dabei möglich:
 \begin{description}

--- a/doc/manual/de/ch10_infobox_reference.tex
+++ b/doc/manual/de/ch10_infobox_reference.tex
@@ -315,7 +315,10 @@ Alternative 1 / Alternative 2 und deren Gleitzahl-/Höhendifferenz-Varianten
 zeigen entweder die beste automatisch ermittelte Alternative (AUTO,
 Voreinstellung) oder eine im Flug manuell aus der Alternativenliste gewählte
 Alternative. Manuelle Alternativen gelten nur zur Laufzeit und bleiben aktiv,
-bis sie erneut geändert oder wieder auf AUTO gesetzt werden.
+bis sie erneut geändert oder wieder auf AUTO gesetzt werden. Sie können auch
+direkt mit \bmenuw{Alternative 1} oder \bmenuw{Alternative 2} im Dialog
+``Kartenelemente an dieser Position'' oder im Wegpunktdetails-Dialog gesetzt
+werden; dabei wird der entsprechende Slot automatisch auf MANUELL geschaltet.
 
 \ibi{Alternative 1}{Altn 1}{Zeigt Namen und Peilung zum besten Ausweichlandeplatz (Alternative) an.}
 

--- a/doc/manual/de/ch10_infobox_reference.tex
+++ b/doc/manual/de/ch10_infobox_reference.tex
@@ -316,9 +316,12 @@ zeigen entweder die beste automatisch ermittelte Alternative (AUTO,
 Voreinstellung) oder eine im Flug manuell aus der Alternativenliste gewählte
 Alternative. Manuelle Alternativen gelten nur zur Laufzeit und bleiben aktiv,
 bis sie erneut geändert oder wieder auf AUTO gesetzt werden. Sie können auch
-direkt mit \bmenuw{Alternative 1} oder \bmenuw{Alternative 2} im Dialog
-``Kartenelemente an dieser Position'' oder im Wegpunktdetails-Dialog gesetzt
-werden; dabei wird der entsprechende Slot automatisch auf MANUELL geschaltet.
+mit \bmenuw{Als Alternative wählen} im Dialog ``Kartenelemente an dieser
+Position'' oder im Wegpunktdetails-Dialog gesetzt werden; dabei wird gefragt,
+ob der Wegpunkt Alternative 1 oder Alternative 2 werden soll, und der Slot
+wird auf MANUELL geschaltet. Dafür kommen nur landbare Wegpunkte (Flugplätze
+und Außenlandefelder) in Frage. In der Alternativenliste sind die Ziele der
+beiden Slots mit ``ALT1'' und ``ALT2'' markiert.
 
 \ibi{Alternative 1}{Altn 1}{Zeigt Namen und Peilung zum besten Ausweichlandeplatz (Alternative) an.}
 

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -712,6 +712,11 @@ The Alternate 1 / Alternate 2 InfoBoxes and their variants can be used either
 in \textbf{AUTO} mode or in \textbf{MANUAL} mode. AUTO is the default and
 shows the best automatically selected alternates. In MANUAL mode, a reachable
 alternate can be selected from the alternates list for each slot independently.
+Manual alternates may also be assigned directly from any waypoint, or from a
+selected map location that can be used for Goto, by pressing \bmenuw{Alternate
+1} or \bmenuw{Alternate 2} in the ``Map elements at this location'' or
+Waypoint Details dialogue. This switches the corresponding slot to MANUAL
+automatically.
 This manual selection is runtime-only: it is not saved when XCSoar is
 restarted, and it remains active until the pilot changes it again or switches
 the slot back to AUTO.

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -710,11 +710,22 @@ As is with every waypoint list, additional information might be called by tappin
 
 The Alternate 1 / Alternate 2 InfoBoxes and their variants can be used either
 in \textbf{AUTO} mode or in \textbf{MANUAL} mode. AUTO is the default and
-shows the best automatically selected alternates. Tap \bmenuw{Select as Alternate}
-to pin a reachable field from the list onto that InfoBox (MANUAL). This
-manual selection is runtime-only: it is not saved when XCSoar is
-restarted, and it remains active until the pilot chooses another field or
-taps \bmenuw{Alternate Mode: Auto} to return the slot to AUTO.
+shows the best automatically selected alternates. Tap \bmenuw{Select as
+Alternate} to pin a landable field onto one of the two InfoBoxes (MANUAL);
+\xc{} then asks which of them shall be used, listing both with the field they
+currently refer to. Besides the alternates list, the same button is available
+in the ``Map elements at this location'' dialogue and on the waypoint details
+page, so that any landable waypoint may be pinned; it is not offered for
+waypoints that are not landable. This manual selection is runtime-only: it is
+not saved when \xc{} is restarted, and it remains active until the pilot
+chooses another field or taps \bmenuw{Alternate Mode: Auto}, which asks which
+of the two slots shall return to AUTO.
+
+The alternates list itself is not tied to one of the two InfoBoxes: the fields
+Alternate 1 and Alternate 2 currently refer to are marked ``ALT1'' and
+``ALT2'' in the list. A pinned field that the glide computer did not rank is
+appended to it, so the list may hold up to twelve entries: the ten computed
+options and the two fields pinned by the pilot.
 
 Although the items on the alternate list obey different rules they interact
 in the same way

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -718,7 +718,7 @@ in the ``Map elements at this location'' dialogue and on the waypoint details
 page, so that any landable waypoint may be pinned; it is not offered for
 waypoints that are not landable. This manual selection is runtime-only: it is
 not saved when \xc{} is restarted, and it remains active until the pilot
-chooses another field or taps \bmenuw{Alternate Mode: Auto}, which asks which
+chooses another field or taps \bmenuw{Alternate AUTO}, which asks which
 of the two slots shall return to AUTO.
 
 The alternates list itself is not tied to one of the two InfoBoxes: the fields

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -355,6 +355,9 @@ Alternate 1 / Alternate 2 and their GR / AltD variants may either display the
 best automatic alternate (AUTO, default) or a manually selected alternate
 chosen from the alternates list during flight. Manual selections are
 runtime-only and remain active until changed again or switched back to AUTO.
+They can also be set directly with \bmenuw{Alternate 1} or \bmenuw{Alternate
+2} from the ``Map elements at this location'' or Waypoint Details dialogue;
+using either button switches that slot to MANUAL automatically.
 The value is shown in red when the glide computer marks the alternate as not
 achievable at the current MacCready setting.  In AUTO mode, blue indicates
 final glide and grey that further climb is required.  In MANUAL mode, light

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -359,9 +359,12 @@ Alternate 1 / Alternate 2 and their GR / AltD variants may either display the
 best automatic alternate (AUTO, default) or a manually selected alternate
 chosen from the alternates list during flight. Manual selections are
 runtime-only and remain active until changed again or switched back to AUTO.
-They can also be set directly with \bmenuw{Alternate 1} or \bmenuw{Alternate
-2} from the ``Map elements at this location'' or Waypoint Details dialogue;
-using either button switches that slot to MANUAL automatically.
+They can also be set with \bmenuw{Select as Alternate} from the ``Map elements
+at this location'' or Waypoint Details dialogue, which asks whether the
+waypoint shall become Alternate 1 or Alternate 2 and switches that slot to
+MANUAL.  Only landable waypoints (airfields and outlanding fields) may be
+chosen this way.  In the alternates list, the fields the two slots refer to
+are marked ``ALT1'' and ``ALT2''.
 The value is shown in red when the glide computer marks the alternate as not
 achievable at the current MacCready setting.  Blue indicates final glide,
 as for Next waypoint.  In AUTO mode, the default colour means further climb

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -359,6 +359,9 @@ Alternate 1 / Alternate 2 and their GR / AltD variants may either display the
 best automatic alternate (AUTO, default) or a manually selected alternate
 chosen from the alternates list during flight. Manual selections are
 runtime-only and remain active until changed again or switched back to AUTO.
+They can also be set directly with \bmenuw{Alternate 1} or \bmenuw{Alternate
+2} from the ``Map elements at this location'' or Waypoint Details dialogue;
+using either button switches that slot to MANUAL automatically.
 The value is shown in red when the glide computer marks the alternate as not
 achievable at the current MacCready setting.  Blue indicates final glide,
 as for Next waypoint.  In AUTO mode, the default colour means further climb

--- a/doc/manual/fr/ch04_xc_tasks.tex
+++ b/doc/manual/fr/ch04_xc_tasks.tex
@@ -555,6 +555,12 @@ peuvent fonctionner en mode \textbf{AUTO} ou en mode \textbf{MANUEL}. AUTO est
 le mode par défaut et affiche les meilleurs dégagements choisis
 automatiquement. En mode MANUEL, il est possible de choisir séparément pour
 chaque emplacement un dégagement atteignable dans la liste des dégagements.
+Un dégagement manuel peut aussi être affecté directement depuis n'importe quel
+waypoint, ou depuis une position de carte utilisable pour \bmenuw{Aller à}, en
+appuyant sur \bmenuw{Dégagement 1} ou \bmenuw{Dégagement 2} dans le dialogue
+``Éléments de carte à cet endroit'' ou dans le dialogue de détails du waypoint.
+Le bouton utilisé bascule automatiquement l'emplacement correspondant en mode
+MANUEL.
 Cette sélection manuelle n'est valable que pendant l'exécution en cours : elle
 n'est pas sauvegardée au redémarrage de \xc{} et reste active jusqu'à
 ce qu'elle soit modifiée ou que l'emplacement soit remis sur AUTO.

--- a/doc/manual/fr/ch04_xc_tasks.tex
+++ b/doc/manual/fr/ch04_xc_tasks.tex
@@ -555,15 +555,23 @@ peuvent fonctionner en mode \textbf{AUTO} ou en mode \textbf{MANUEL}. AUTO est
 le mode par défaut et affiche les meilleurs dégagements choisis
 automatiquement. En mode MANUEL, il est possible de choisir séparément pour
 chaque emplacement un dégagement atteignable dans la liste des dégagements.
-Un dégagement manuel peut aussi être affecté directement depuis n'importe quel
-waypoint, ou depuis une position de carte utilisable pour \bmenuw{Aller à}, en
-appuyant sur \bmenuw{Dégagement 1} ou \bmenuw{Dégagement 2} dans le dialogue
-``Éléments de carte à cet endroit'' ou dans le dialogue de détails du waypoint.
-Le bouton utilisé bascule automatiquement l'emplacement correspondant en mode
-MANUEL.
+Appuyer sur \bmenuw{Choisir dégagement} pour affecter un waypoint posable à
+l'une des deux InfoBoxes (mode MANUEL) : \xc{} demande alors lequel des deux
+emplacements utiliser, en affichant le terrain auquel chacun se réfère
+actuellement. Ce bouton est aussi disponible dans le dialogue ``Éléments de
+carte à cet endroit'' et dans le dialogue de détails du waypoint, ce qui permet
+d'affecter n'importe quel waypoint posable ; il n'est pas proposé pour les
+waypoints non posables.
 Cette sélection manuelle n'est valable que pendant l'exécution en cours : elle
-n'est pas sauvegardée au redémarrage de \xc{} et reste active jusqu'à
-ce qu'elle soit modifiée ou que l'emplacement soit remis sur AUTO.
+n'est pas sauvegardée au redémarrage de \xc{} et reste active jusqu'à ce
+qu'elle soit modifiée ou que \bmenuw{Alternate Mode: Auto} soit utilisé, qui
+demande lequel des deux emplacements doit repasser en AUTO.
+
+La liste des dégagements n'est liée à aucune des deux InfoBoxes : les terrains
+auxquels Dégagement 1 et Dégagement 2 se réfèrent y sont marqués ``ALT1'' et
+``ALT2''. Un terrain choisi manuellement mais que le calculateur n'a pas retenu est
+ajouté à la liste, qui peut donc contenir jusqu'à douze entrées : les dix
+options calculées et les deux terrains choisis par le pilote.
 
 Bien que les éléments de la liste des dégagements suivent des règles différentes, ils ont le même comportement vis-à-vis du circuit en cours. Faire sa sélection dans la liste des dégagements annule le circuit en cours. Une fois que les conditions s'améliorent, la reprise du circuit en utilisant le bouton déjà mentionné.
 

--- a/doc/manual/fr/ch04_xc_tasks.tex
+++ b/doc/manual/fr/ch04_xc_tasks.tex
@@ -564,7 +564,7 @@ d'affecter n'importe quel waypoint posable ; il n'est pas proposé pour les
 waypoints non posables.
 Cette sélection manuelle n'est valable que pendant l'exécution en cours : elle
 n'est pas sauvegardée au redémarrage de \xc{} et reste active jusqu'à ce
-qu'elle soit modifiée ou que \bmenuw{Alternate Mode: Auto} soit utilisé, qui
+qu'elle soit modifiée ou que \bmenuw{Alternate AUTO} soit utilisé, qui
 demande lequel des deux emplacements doit repasser en AUTO.
 
 La liste des dégagements n'est liée à aucune des deux InfoBoxes : les terrains

--- a/doc/manual/pt_BR/ch04_xc_tasks.tex
+++ b/doc/manual/pt_BR/ch04_xc_tasks.tex
@@ -441,7 +441,12 @@ As InfoBoxes \textbf{Alternativo 1} / \textbf{Alternativo 2} e suas variantes
 podem funcionar em modo \textbf{AUTO} ou \textbf{MANUAL}. AUTO é o padrão e
 mostra os melhores alternativos escolhidos automaticamente. No modo MANUAL, um
 alternativo alcançável pode ser selecionado na lista de alternativos para cada
-slot de forma independente. Esta seleção manual vale apenas durante a execução
+slot de forma independente. Um alternativo manual também pode ser definido
+diretamente a partir de qualquer waypoint, ou de uma posição do mapa que possa
+ser usada para \bmenuw{Ir Para}, pressionando \bmenuw{Alternativo 1} ou
+\bmenuw{Alternativo 2} no diálogo ``Elementos do mapa neste local'' ou no
+diálogo de detalhes do waypoint. O botão usado muda automaticamente o slot
+correspondente para MANUAL. Esta seleção manual vale apenas durante a execução
 atual: ela não é salva ao reiniciar o \textsf{XCSoar} e permanece ativa até o
 piloto alterá-la novamente ou voltar o slot para AUTO.
 

--- a/doc/manual/pt_BR/ch04_xc_tasks.tex
+++ b/doc/manual/pt_BR/ch04_xc_tasks.tex
@@ -441,14 +441,22 @@ As InfoBoxes \textbf{Alternativo 1} / \textbf{Alternativo 2} e suas variantes
 podem funcionar em modo \textbf{AUTO} ou \textbf{MANUAL}. AUTO é o padrão e
 mostra os melhores alternativos escolhidos automaticamente. No modo MANUAL, um
 alternativo alcançável pode ser selecionado na lista de alternativos para cada
-slot de forma independente. Um alternativo manual também pode ser definido
-diretamente a partir de qualquer waypoint, ou de uma posição do mapa que possa
-ser usada para \bmenuw{Ir Para}, pressionando \bmenuw{Alternativo 1} ou
-\bmenuw{Alternativo 2} no diálogo ``Elementos do mapa neste local'' ou no
-diálogo de detalhes do waypoint. O botão usado muda automaticamente o slot
-correspondente para MANUAL. Esta seleção manual vale apenas durante a execução
+slot de forma independente. Pressione \bmenuw{Selecionar como Alternativo}
+para fixar um waypoint pousável em uma das duas InfoBoxes (MANUAL); o
+\textsf{XCSoar} pergunta então qual delas usar, mostrando o alvo atual de cada
+uma. Este botão também está disponível no diálogo ``Elementos do mapa neste
+local'' e no diálogo de detalhes do waypoint, de modo que qualquer waypoint
+pousável pode ser fixado; ele não é oferecido para waypoints não pousáveis.
+Esta seleção manual vale apenas durante a execução
 atual: ela não é salva ao reiniciar o \textsf{XCSoar} e permanece ativa até o
-piloto alterá-la novamente ou voltar o slot para AUTO.
+piloto alterá-la novamente ou pressionar \bmenuw{Alternate Mode: Auto}, que
+pergunta qual dos dois slots deve voltar para AUTO.
+
+A lista de alternativos não pertence a nenhuma das duas InfoBoxes: os alvos aos
+quais Alternativo 1 e Alternativo 2 se referem são marcados com ``ALT1'' e
+``ALT2''. Um alvo fixado manualmente que o computador de voo não classificou é
+acrescentado à lista, que pode portanto conter até doze entradas: as dez opções
+calculadas e os dois alvos fixados pelo piloto.
 
 Todavia, os itens na lista de alternativos obedecem regras diferentes e interagem da mesma forma com a prova atual.  Escolher um ponto na lista de alternativos aborta a prova; uma vez que as condições melhores, o resumo da prova pode ser realizado pelo botão já mencionado.
 

--- a/doc/manual/pt_BR/ch04_xc_tasks.tex
+++ b/doc/manual/pt_BR/ch04_xc_tasks.tex
@@ -449,7 +449,7 @@ local'' e no diálogo de detalhes do waypoint, de modo que qualquer waypoint
 pousável pode ser fixado; ele não é oferecido para waypoints não pousáveis.
 Esta seleção manual vale apenas durante a execução
 atual: ela não é salva ao reiniciar o \textsf{XCSoar} e permanece ativa até o
-piloto alterá-la novamente ou pressionar \bmenuw{Alternate Mode: Auto}, que
+piloto alterá-la novamente ou pressionar \bmenuw{Alternate AUTO}, que
 pergunta qual dos dois slots deve voltar para AUTO.
 
 A lista de alternativos não pertence a nenhuma das duas InfoBoxes: os alvos aos

--- a/doc/manual/pt_BR/ch10_infobox_reference.tex
+++ b/doc/manual/pt_BR/ch10_infobox_reference.tex
@@ -177,7 +177,10 @@ Alternativo 1 / Alternativo 2 e suas variantes de gradiente e diferença de
 altura podem mostrar o melhor alternativo automático (AUTO, padrão) ou um
 alternativo selecionado manualmente na lista de alternativos durante o vôo. As
 seleções manuais são apenas de tempo de execução e permanecem ativas até serem
-alteradas novamente ou até o slot voltar para AUTO.
+alteradas novamente ou até o slot voltar para AUTO. Elas também podem ser
+definidas diretamente com \bmenuw{Alternativo 1} ou \bmenuw{Alternativo 2} no
+diálogo ``Elementos do mapa neste local'' ou no diálogo de detalhes do
+waypoint; o slot correspondente é alterado automaticamente para MANUAL.
 
 \ibi{Alternate 1}{Altn 1}{Mostra o nome e direção do melhor ponto de pouso alternativo.}
 \ibi{Alternate 2}{Altn 2}{Mostra o nome e proa para o segundo melhor ponto de pouso alternativo.}

--- a/doc/manual/pt_BR/ch10_infobox_reference.tex
+++ b/doc/manual/pt_BR/ch10_infobox_reference.tex
@@ -178,9 +178,12 @@ altura podem mostrar o melhor alternativo automático (AUTO, padrão) ou um
 alternativo selecionado manualmente na lista de alternativos durante o vôo. As
 seleções manuais são apenas de tempo de execução e permanecem ativas até serem
 alteradas novamente ou até o slot voltar para AUTO. Elas também podem ser
-definidas diretamente com \bmenuw{Alternativo 1} ou \bmenuw{Alternativo 2} no
-diálogo ``Elementos do mapa neste local'' ou no diálogo de detalhes do
-waypoint; o slot correspondente é alterado automaticamente para MANUAL.
+definidas com \bmenuw{Selecionar como Alternativo} no diálogo ``Elementos do
+mapa neste local'' ou no diálogo de detalhes do waypoint, que pergunta se o
+waypoint deve se tornar Alternativo 1 ou Alternativo 2 e muda esse slot para
+MANUAL. Apenas waypoints pousáveis (aeródromos e locais de pouso) podem ser
+escolhidos assim. Na lista de alternativos, os alvos dos dois slots são
+marcados com ``ALT1'' e ``ALT2''.
 
 \ibi{Alternate 1}{Altn 1}{Mostra o nome e direção do melhor ponto de pouso alternativo.}
 \ibi{Alternate 2}{Altn 2}{Mostra o nome e proa para o segundo melhor ponto de pouso alternativo.}

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "Dialogs/MapItemListDialog.hpp"
 #include "Dialogs/WidgetDialog.hpp"
+#include "InfoBoxes/Content/Alternate.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Dialogs/Airspace/Airspace.hpp"
 #include "Dialogs/Task/TaskDialogs.hpp"
@@ -80,6 +81,7 @@ class MapItemListWidget final
   MapItemListRenderer renderer;
 
   Button *settings_button, *details_button, *cancel_button, *goto_button;
+  Button *alternate1_button, *alternate2_button;
   Button *ack_button, *enable_button;
 
   WndForm *dialog = nullptr;
@@ -133,13 +135,17 @@ public:
 protected:
   void UpdateButtons() {
     const MapItem *item = GetItem(GetCursorIndex());
+    const bool can_goto = item != nullptr && CanGotoItem(*item);
     details_button->SetEnabled(item != nullptr && HasDetails(*item));
-    goto_button->SetEnabled(item != nullptr && CanGotoItem(*item));
+    goto_button->SetEnabled(can_goto);
+    alternate1_button->SetEnabled(can_goto);
+    alternate2_button->SetEnabled(can_goto);
     ack_button->SetEnabled(item != nullptr && CanAckItem(*item));
     enable_button->SetEnabled(item != nullptr && CanEnableItem(*item));
   }
 
   void OnGotoClicked();
+  void OnAlternateClicked(AlternateInfoBoxSlot slot);
   void OnAckClicked();
   void OnEnableClicked();
 
@@ -237,6 +243,14 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
     OnGotoClicked();
   });
 
+  alternate1_button = dialog.AddButton(_("Alternate 1"), [this](){
+    OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
+  });
+
+  alternate2_button = dialog.AddButton(_("Alternate 2"), [this](){
+    OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
+  });
+
   ack_button = dialog.AddButton(_("Ack Day"), [this](){
     OnAckClicked();
   });
@@ -250,6 +264,50 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
   });
 
   cancel_button = dialog.AddButton(_("Close"), mrCancel);
+}
+
+static WaypointPtr
+MakeWaypointFromGotoMapItem(const MapItem &item) noexcept
+{
+  if (data_components == nullptr || data_components->waypoints == nullptr)
+    return nullptr;
+
+  assert(item.type == MapItem::Type::WAYPOINT ||
+         item.type == MapItem::Type::LOCATION);
+
+  if (item.type == MapItem::Type::WAYPOINT) {
+    auto &way_points = *data_components->waypoints;
+    {
+      ScopeSuspendAllThreads suspend;
+      way_points.EraseTempGoto();
+    }
+
+    return static_cast<const WaypointMapItem &>(item).waypoint;
+  }
+
+  const auto &loc_item = static_cast<const LocationMapItem &>(item);
+
+  const GeoPoint &location = loc_item.location;
+
+  double elevation = std::numeric_limits<double>::quiet_NaN();
+  if (loc_item.HasElevation()) {
+    elevation = loc_item.elevation;
+  } else if (data_components->terrain != nullptr) {
+    const auto h = data_components->terrain->GetTerrainHeight(location);
+    if (!h.IsSpecial())
+      elevation = h.GetValue();
+  }
+
+  auto &way_points = *data_components->waypoints;
+  const char *goto_name = "(goto)";
+  WaypointPtr waypoint;
+  {
+    ScopeSuspendAllThreads suspend;
+    way_points.AddTempPoint(location, elevation, goto_name);
+    waypoint = way_points.LookupName(goto_name);
+  }
+
+  return waypoint;
 }
 
 void
@@ -352,56 +410,30 @@ MapItemListWidget::OnGotoClicked()
   if (!backend_components->protected_task_manager)
     return;
 
-  if (data_components == nullptr || data_components->waypoints == nullptr)
+  const MapItem *item = GetItem(GetCursorIndex());
+  if (item == nullptr || !CanGotoItem(*item))
     return;
 
-  unsigned index = GetCursorIndex();
-  auto const &item = *list[index];
-
-  assert(item.type == MapItem::Type::WAYPOINT ||
-         item.type == MapItem::Type::LOCATION);
-
-  WaypointPtr waypoint;
-
-  if (item.type == MapItem::Type::LOCATION) {
-    const auto &loc_item = static_cast<const LocationMapItem &>(item);
-
-    // Use the stored location directly
-    const GeoPoint &location = loc_item.location;
-
-    // Get terrain elevation (prefer stored elevation, fall back to terrain lookup)
-    double elevation = std::numeric_limits<double>::quiet_NaN();
-    if (loc_item.HasElevation()) {
-      elevation = loc_item.elevation;
-    } else if (data_components->terrain != nullptr) {
-      const auto h = data_components->terrain->GetTerrainHeight(location);
-      if (!h.IsSpecial()) {
-        elevation = h.GetValue();
-      }
-    }
-
-    // Create temporary goto waypoint (elevation may be NaN if unavailable)
-    auto &way_points = *data_components->waypoints;
-    const char *goto_name = "(goto)";
-    {
-      ScopeSuspendAllThreads suspend;
-      way_points.AddTempPoint(location, elevation, goto_name);
-      waypoint = way_points.LookupName(goto_name);
-    }
-    if (!waypoint)
-      return;
-  } else {
-    waypoint = static_cast<const WaypointMapItem &>(item).waypoint;
-
-    // Remove old temporary goto waypoint when selecting a regular waypoint
-    auto &way_points = *data_components->waypoints;
-    {
-      ScopeSuspendAllThreads suspend;
-      way_points.EraseTempGoto();
-    }
-  }
+  auto waypoint = MakeWaypointFromGotoMapItem(*item);
+  if (waypoint == nullptr)
+    return;
 
   backend_components->protected_task_manager->DoGoto(std::move(waypoint));
+  cancel_button->Click();
+}
+
+inline void
+MapItemListWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+{
+  const MapItem *item = GetItem(GetCursorIndex());
+  if (item == nullptr || !CanGotoItem(*item))
+    return;
+
+  auto waypoint = MakeWaypointFromGotoMapItem(*item);
+  if (waypoint == nullptr)
+    return;
+
+  SelectManualAlternateWaypoint(slot, std::move(waypoint));
   cancel_button->Click();
 }
 

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -117,7 +117,7 @@ class MapItemListWidget final
   MapItemListRenderer renderer;
 
   Button *settings_button, *details_button, *cancel_button, *goto_button;
-  Button *alternate1_button, *alternate2_button;
+  Button *alternate_button;
   Button *sim_jump_button = nullptr;
   Button *ack_button, *enable_button;
 
@@ -173,11 +173,11 @@ public:
 protected:
   void UpdateButtons() {
     const MapItem *item = GetItem(GetCursorIndex());
-    const bool can_goto = item != nullptr && CanGotoItem(*item);
+    const bool can_select_alternate =
+      item != nullptr && CanSelectAlternateItem(*item);
     details_button->SetEnabled(item != nullptr && HasDetails(*item));
-    goto_button->SetEnabled(can_goto);
-    alternate1_button->SetEnabled(can_goto);
-    alternate2_button->SetEnabled(can_goto);
+    goto_button->SetEnabled(item != nullptr && CanGotoItem(*item));
+    alternate_button->SetEnabled(can_select_alternate);
     if (sim_jump_button != nullptr)
       sim_jump_button->SetEnabled(item != nullptr &&
                                   is_simulator() &&
@@ -188,7 +188,7 @@ protected:
   }
 
   void OnGotoClicked();
-  void OnAlternateClicked(AlternateInfoBoxSlot slot);
+  void OnAlternateClicked();
   void OnAckClicked();
   void OnEnableClicked();
 
@@ -219,6 +219,15 @@ public:
            backend_components->protected_task_manager &&
            (item.type == MapItem::Type::WAYPOINT ||
             item.type == MapItem::Type::LOCATION);
+  }
+
+  /**
+   * Only landable waypoints may be selected as an alternate; the
+   * temporary "goto" location of a LOCATION item is not one.
+   */
+  static bool CanSelectAlternateItem(const MapItem &item) noexcept {
+    return CanGotoItem(item) && item.type == MapItem::Type::WAYPOINT &&
+           static_cast<const WaypointMapItem &>(item).waypoint->IsLandable();
   }
 
   bool CanAckItem(unsigned index) const noexcept {
@@ -286,13 +295,8 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
     OnGotoClicked();
   });
 
-  alternate1_button = dialog.AddButton(_("Alternate 1"), [this](){
-    OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
-  });
-
-  alternate2_button = dialog.AddButton(_("Alternate 2"), [this](){
-    OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
-  });
+  alternate_button = dialog.AddButton(C_("Button", "Select as Alternate"),
+                                      [this](){ OnAlternateClicked(); });
 
   if (is_simulator()) {
     sim_jump_button = dialog.AddButton(C_("Button", "Sim: Jump to"), [this](){
@@ -515,17 +519,20 @@ MapItemListWidget::OnSimJumpClicked() noexcept
 }
 
 inline void
-MapItemListWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+MapItemListWidget::OnAlternateClicked()
 {
   const MapItem *item = GetItem(GetCursorIndex());
-  if (item == nullptr || !CanGotoItem(*item))
+  if (item == nullptr || !CanSelectAlternateItem(*item))
     return;
 
-  auto waypoint = MakeWaypointFromGotoMapItem(*item);
-  if (waypoint == nullptr)
+  const auto slot =
+    dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+  if (!slot.has_value())
     return;
 
-  SelectManualAlternateWaypoint(slot, std::move(waypoint));
+  SelectManualAlternateWaypoint(*slot,
+                                static_cast<const WaypointMapItem &>(*item)
+                                .waypoint);
   cancel_button->Click();
 }
 

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -4,6 +4,7 @@
 #include "Dialogs/MapItemListDialog.hpp"
 #include "Dialogs/Dialogs.h"
 #include "Dialogs/WidgetDialog.hpp"
+#include "InfoBoxes/Content/Alternate.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Dialogs/Airspace/Airspace.hpp"
 #include "Dialogs/Task/TaskDialogs.hpp"
@@ -116,6 +117,7 @@ class MapItemListWidget final
   MapItemListRenderer renderer;
 
   Button *settings_button, *details_button, *cancel_button, *goto_button;
+  Button *alternate1_button, *alternate2_button;
   Button *sim_jump_button = nullptr;
   Button *ack_button, *enable_button;
 
@@ -171,8 +173,11 @@ public:
 protected:
   void UpdateButtons() {
     const MapItem *item = GetItem(GetCursorIndex());
+    const bool can_goto = item != nullptr && CanGotoItem(*item);
     details_button->SetEnabled(item != nullptr && HasDetails(*item));
-    goto_button->SetEnabled(item != nullptr && CanGotoItem(*item));
+    goto_button->SetEnabled(can_goto);
+    alternate1_button->SetEnabled(can_goto);
+    alternate2_button->SetEnabled(can_goto);
     if (sim_jump_button != nullptr)
       sim_jump_button->SetEnabled(item != nullptr &&
                                   is_simulator() &&
@@ -183,6 +188,7 @@ protected:
   }
 
   void OnGotoClicked();
+  void OnAlternateClicked(AlternateInfoBoxSlot slot);
   void OnAckClicked();
   void OnEnableClicked();
 
@@ -280,6 +286,14 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
     OnGotoClicked();
   });
 
+  alternate1_button = dialog.AddButton(_("Alternate 1"), [this](){
+    OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
+  });
+
+  alternate2_button = dialog.AddButton(_("Alternate 2"), [this](){
+    OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
+  });
+
   if (is_simulator()) {
     sim_jump_button = dialog.AddButton(C_("Button", "Sim: Jump to"), [this](){
       OnSimJumpClicked();
@@ -299,6 +313,50 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
   });
 
   cancel_button = dialog.AddButton(_("Close"), mrCancel);
+}
+
+static WaypointPtr
+MakeWaypointFromGotoMapItem(const MapItem &item) noexcept
+{
+  if (data_components == nullptr || data_components->waypoints == nullptr)
+    return nullptr;
+
+  assert(item.type == MapItem::Type::WAYPOINT ||
+         item.type == MapItem::Type::LOCATION);
+
+  if (item.type == MapItem::Type::WAYPOINT) {
+    auto &way_points = *data_components->waypoints;
+    {
+      ScopeSuspendAllThreads suspend;
+      way_points.EraseTempGoto();
+    }
+
+    return static_cast<const WaypointMapItem &>(item).waypoint;
+  }
+
+  const auto &loc_item = static_cast<const LocationMapItem &>(item);
+
+  const GeoPoint &location = loc_item.location;
+
+  double elevation = std::numeric_limits<double>::quiet_NaN();
+  if (loc_item.HasElevation()) {
+    elevation = loc_item.elevation;
+  } else if (data_components->terrain != nullptr) {
+    const auto h = data_components->terrain->GetTerrainHeight(location);
+    if (!h.IsSpecial())
+      elevation = h.GetValue();
+  }
+
+  auto &way_points = *data_components->waypoints;
+  const char *goto_name = "(goto)";
+  WaypointPtr waypoint;
+  {
+    ScopeSuspendAllThreads suspend;
+    way_points.AddTempPoint(location, elevation, goto_name);
+    waypoint = way_points.LookupName(goto_name);
+  }
+
+  return waypoint;
 }
 
 void
@@ -424,54 +482,13 @@ MapItemListWidget::OnGotoClicked()
   if (!backend_components->protected_task_manager)
     return;
 
-  if (data_components == nullptr || data_components->waypoints == nullptr)
+  const MapItem *item = GetItem(GetCursorIndex());
+  if (item == nullptr || !CanGotoItem(*item))
     return;
 
-  unsigned index = GetCursorIndex();
-  auto const &item = *list[index];
-
-  assert(item.type == MapItem::Type::WAYPOINT ||
-         item.type == MapItem::Type::LOCATION);
-
-  WaypointPtr waypoint;
-
-  if (item.type == MapItem::Type::LOCATION) {
-    const auto &loc_item = static_cast<const LocationMapItem &>(item);
-
-    // Use the stored location directly
-    const GeoPoint &location = loc_item.location;
-
-    // Get terrain elevation (prefer stored elevation, fall back to terrain lookup)
-    double elevation = std::numeric_limits<double>::quiet_NaN();
-    if (loc_item.HasElevation()) {
-      elevation = loc_item.elevation;
-    } else if (data_components->terrain != nullptr) {
-      const auto h = data_components->terrain->GetTerrainHeight(location);
-      if (!h.IsSpecial()) {
-        elevation = h.GetValue();
-      }
-    }
-
-    // Create temporary goto waypoint (elevation may be NaN if unavailable)
-    auto &way_points = *data_components->waypoints;
-    const char *goto_name = "(goto)";
-    {
-      ScopeSuspendAllThreads suspend;
-      way_points.AddTempPoint(location, elevation, goto_name);
-      waypoint = way_points.LookupName(goto_name);
-    }
-    if (!waypoint)
-      return;
-  } else {
-    waypoint = static_cast<const WaypointMapItem &>(item).waypoint;
-
-    // Remove old temporary goto waypoint when selecting a regular waypoint
-    auto &way_points = *data_components->waypoints;
-    {
-      ScopeSuspendAllThreads suspend;
-      way_points.EraseTempGoto();
-    }
-  }
+  auto waypoint = MakeWaypointFromGotoMapItem(*item);
+  if (waypoint == nullptr)
+    return;
 
   backend_components->protected_task_manager->DoGoto(std::move(waypoint));
   cancel_button->Click();
@@ -495,6 +512,21 @@ MapItemListWidget::OnSimJumpClicked() noexcept
 
   if (SimJumpTo(location))
     cancel_button->Click();
+}
+
+inline void
+MapItemListWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+{
+  const MapItem *item = GetItem(GetCursorIndex());
+  if (item == nullptr || !CanGotoItem(*item))
+    return;
+
+  auto waypoint = MakeWaypointFromGotoMapItem(*item);
+  if (waypoint == nullptr)
+    return;
+
+  SelectManualAlternateWaypoint(slot, std::move(waypoint));
+  cancel_button->Click();
 }
 
 inline void

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -525,14 +525,13 @@ MapItemListWidget::OnAlternateClicked()
   if (item == nullptr || !CanSelectAlternateItem(*item))
     return;
 
-  const auto slot =
-    dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+  const auto &waypoint = static_cast<const WaypointMapItem &>(*item).waypoint;
+
+  const auto slot = dlgAlternateSlotShowModal(waypoint->name.c_str());
   if (!slot.has_value())
     return;
 
-  SelectManualAlternateWaypoint(*slot,
-                                static_cast<const WaypointMapItem &>(*item)
-                                .waypoint);
+  SelectManualAlternateWaypoint(*slot, waypoint);
   cancel_button->Click();
 }
 

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -218,8 +218,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
         return;
 
       const auto slot = GetConfiguredSlot();
-      SetManualAlternateWaypoint(slot, GetSelectedWaypointPtr());
-      SetAlternateInfoBoxMode(slot, AlternateInfoBoxMode::MANUAL);
+      SelectManualAlternateWaypoint(slot, GetSelectedWaypointPtr());
       cancel_button->Click();
     });
   }

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -3,6 +3,7 @@
 
 #include "TaskDialogs.hpp"
 #include "Dialogs/WidgetDialog.hpp"
+#include "Dialogs/ListPicker.hpp"
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
 #include "Form/Form.hpp"
 #include "InfoBoxes/Content/Alternate.hpp"
@@ -17,6 +18,8 @@
 #include "Look/MapLook.hpp"
 #include "Renderer/WaypointListRenderer.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
+#include "Renderer/TextRowListItemRenderer.hpp"
+#include "util/StaticString.hxx"
 #include "Language/Language.hpp"
 #include "ActionInterface.hpp"
 #include "Message.hpp"
@@ -26,16 +29,24 @@
 #include "Protection.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
 
+#include <algorithm>
+#include <array>
 #include <cassert>
 #include <optional>
 
+namespace {
 class AlternatesListWidget final
   : public ListWidget {
   const DialogLook &dialog_look;
   const bool select_mode;
-  const std::optional<AlternateInfoBoxSlot> slot;
 
   TwoTextRowsRenderer row_renderer;
+
+  /**
+   * The waypoints the alternate InfoBox slots currently refer to,
+   * indexed by slot; nullptr for a slot without a target.
+   */
+  std::array<WaypointPtr, alternate_info_box_slot_count> slot_waypoints;
 
   Button *details_button = nullptr;
   Button *cancel_button = nullptr;
@@ -55,18 +66,30 @@ public:
 public:
   explicit
   AlternatesListWidget(const DialogLook &_dialog_look,
-                       bool _select_mode = false,
-                       std::optional<AlternateInfoBoxSlot> _slot =
-                         std::nullopt) noexcept
-    :dialog_look(_dialog_look), select_mode(_select_mode), slot(_slot) {}
+                       bool _select_mode = false) noexcept
+    :dialog_look(_dialog_look), select_mode(_select_mode) {}
 
   unsigned GetCursorIndex() const {
     return GetList().GetCursorIndex();
   }
 
   bool Update() {
-    ProtectedTaskManager::Lease lease(*backend_components->protected_task_manager);
-    alternates = lease->GetAlternates();
+    {
+      ProtectedTaskManager::Lease lease(*backend_components->protected_task_manager);
+      alternates = lease->GetAlternates();
+    }
+
+    /* a manually pinned alternate is not necessarily among the
+       computed ones; append it so the pilot sees what the InfoBox
+       refers to */
+    for (const auto slot : all_alternate_info_box_slots) {
+      auto waypoint = GetAlternateSlotWaypoint(slot);
+      slot_waypoints[ToAlternateInfoBoxSlotIndex(slot)] = waypoint;
+
+      if (waypoint != nullptr && !Contains(*waypoint))
+        alternates.emplace_back(waypoint, SolveAlternateGlide(*waypoint));
+    }
+
     return !alternates.empty();
   }
 
@@ -77,16 +100,51 @@ private:
     return !alternates.empty() && GetCursorIndex() < alternates.size();
   }
 
-  /**
-   * Returns the configured alternate slot for the slot-aware dialog
-   * path.  This must only be used when slot-specific controls have
-   * been created.
-   */
   [[nodiscard]] [[gnu::pure]]
-  AlternateInfoBoxSlot
-  GetConfiguredSlot() const noexcept {
-    assert(slot.has_value());
-    return *slot;
+  bool
+  Contains(const Waypoint &waypoint) const noexcept {
+    return std::any_of(alternates.begin(), alternates.end(),
+                       [&waypoint](const AlternatePoint &alternate){
+                         return *alternate.waypoint == waypoint;
+                       });
+  }
+
+  [[nodiscard]] [[gnu::pure]]
+  static bool
+  HasManualAlternate() noexcept {
+    return std::any_of(all_alternate_info_box_slots.begin(),
+                       all_alternate_info_box_slots.end(),
+                       [](AlternateInfoBoxSlot slot){
+                         return GetAlternateInfoBoxMode(slot) ==
+                           AlternateInfoBoxMode::MANUAL;
+                       });
+  }
+
+  /**
+   * Formats the "ALT1"/"ALT2" markers of the alternate slots
+   * referring to the specified waypoint.
+   *
+   * @return false if no slot refers to it
+   */
+  [[nodiscard]]
+  bool
+  FormatSlotMarkers(const Waypoint &waypoint,
+                    StaticString<16> &buffer) const noexcept {
+    buffer.clear();
+
+    for (const auto slot : all_alternate_info_box_slots) {
+      const auto &slot_waypoint =
+        slot_waypoints[ToAlternateInfoBoxSlotIndex(slot)];
+      if (slot_waypoint == nullptr || !(*slot_waypoint == waypoint))
+        continue;
+
+      if (!buffer.empty())
+        buffer.push_back(' ');
+
+      buffer.AppendFormat("ALT%u", GetAlternateInfoBoxSlotDisplayNumber(slot));
+    }
+
+    return !buffer.empty();
   }
 
   [[nodiscard]] [[gnu::pure]]
@@ -116,7 +174,21 @@ public:
     const Waypoint &waypoint = *alternates[index].waypoint;
     const GlideResult& solution = alternates[index].solution;
 
-    WaypointListRenderer::Draw(canvas, rc, waypoint, solution.vector.distance,
+    PixelRect row_rc = rc;
+    StaticString<16> markers;
+    if (FormatSlotMarkers(waypoint, markers))
+      row_rc.right = row_renderer.DrawRightFirstRow(canvas, rc, markers.c_str());
+
+    if (!solution.IsDefined()) {
+      /* a manually pinned alternate while the glide computer has no
+         solution (yet); the glide figures would be undefined */
+      WaypointListRenderer::Draw(canvas, row_rc, waypoint, row_renderer,
+                                 UIGlobals::GetMapLook().waypoint,
+                                 CommonInterface::GetMapSettings().waypoint);
+      return;
+    }
+
+    WaypointListRenderer::Draw(canvas, row_rc, waypoint, solution.vector.distance,
                                solution.SelectAltitudeDifference(settings.task.glide),
                                row_renderer,
                                UIGlobals::GetMapLook().waypoint,
@@ -134,7 +206,20 @@ public:
   void OnActivateItem([[maybe_unused]] unsigned index) noexcept override;
 
 private:
-  void UpdateButtons() noexcept {
+  /**
+   * Rebuilds the list after the alternate slots have been modified.
+   */
+  void RefreshList() noexcept {
+    Update();
+
+    auto &list = GetList();
+    list.SetLength(alternates.size());
+    list.Invalidate();
+
+    UpdateButtons();
+  }
+
+  void UpdateButtons() const noexcept {
 
     // Check if window is initialized (widget is prepared)
     if (!IsDefined())
@@ -143,10 +228,8 @@ private:
     if (set_active_freq_button == nullptr || set_standby_freq_button == nullptr)
       return;
 
-    if (auto_button != nullptr) {
-      auto_button->SetEnabled(GetAlternateInfoBoxMode(GetConfiguredSlot()) ==
-                              AlternateInfoBoxMode::MANUAL);
-    }
+    if (auto_button != nullptr)
+      auto_button->SetEnabled(HasManualAlternate());
 
     if (!HasValidSelection()) {
       if (goto_button != nullptr)
@@ -172,6 +255,7 @@ private:
       manual_button->SetEnabled(true);
   }
 };
+}
 
 void
 AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
@@ -198,25 +282,28 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
     select_button = dialog.AddButton(_("Select"), mrOK);
   }
 
-  if (!select_mode && slot.has_value()) {
-    /* Alternate Mode: Auto returns a MANUAL slot to the computed
-       list. Pinning is Select as Alternate, which is always
-       available and sets MANUAL. */
-    auto_button = dialog.AddButton(C_("Button", "Alternate Mode: Auto"), [this](){
-      const auto slot = GetConfiguredSlot();
-      if (GetAlternateInfoBoxMode(slot) != AlternateInfoBoxMode::MANUAL)
+  if (!select_mode) {
+    auto_button = dialog.AddButton(C_("Button", "Alternate AUTO"), [this](){
+      const auto slot =
+        dlgAlternateSlotShowModal(C_("Button", "Alternate AUTO"));
+      if (!slot.has_value() ||
+          GetAlternateInfoBoxMode(*slot) != AlternateInfoBoxMode::MANUAL)
         return;
 
-      SetAlternateInfoBoxMode(slot, AlternateInfoBoxMode::AUTO);
-      UpdateButtons();
+      SetAlternateInfoBoxMode(*slot, AlternateInfoBoxMode::AUTO);
+      RefreshList();
     });
 
     manual_button = dialog.AddButton(C_("Button", "Select as Alternate"), [this](){
       if (!HasValidSelection())
         return;
 
-      const auto slot = GetConfiguredSlot();
-      SelectManualAlternateWaypoint(slot, GetSelectedWaypointPtr());
+      const auto slot =
+        dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+      if (!slot.has_value())
+        return;
+
+      SelectManualAlternateWaypoint(*slot, GetSelectedWaypointPtr());
       cancel_button->Click();
     });
   }
@@ -292,34 +379,71 @@ AlternatesListWidget::OnActivateItem([[maybe_unused]] unsigned index) noexcept
     details_button->Click();
 }
 
+namespace {
+
+/**
+ * Renders one row of the alternate slot picker, showing the slot
+ * name, its current target and its mode.
+ */
+class AlternateSlotListItemRenderer final : public TextRowListItemRenderer {
+  std::array<StaticString<128>, alternate_info_box_slot_count> rows;
+
+public:
+  AlternateSlotListItemRenderer() noexcept {
+    for (const auto slot : all_alternate_info_box_slots) {
+      const auto waypoint = GetAlternateSlotWaypoint(slot);
+      const auto alternate_mode_short_label =
+        GetAlternateModeShortLabel(GetAlternateInfoBoxMode(slot));
+
+      rows[ToAlternateInfoBoxSlotIndex(slot)]
+        .Format("%s - %s (%s)", GetAlternateSlotName(slot),
+                waypoint != nullptr ? waypoint->name.c_str() : _("None"),
+                alternate_mode_short_label);
+    }
+  }
+
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   const unsigned index) noexcept override {
+    assert(index < rows.size());
+
+    row_renderer.DrawTextRow(canvas, rc, rows[index].c_str());
+  }
+};
+
+} // namespace
+
+std::optional<AlternateInfoBoxSlot>
+dlgAlternateSlotShowModal(const char *caption) noexcept
+{
+  AlternateSlotListItemRenderer renderer;
+
+  const int i = ListPicker(caption, alternate_info_box_slot_count, 0,
+                           renderer.CalculateLayout(UIGlobals::GetDialogLook()),
+                           renderer);
+  if (i < 0)
+    return std::nullopt;
+
+  return all_alternate_info_box_slots[i];
+}
+
 void
-dlgAlternatesListShowModal(Waypoints *waypoints,
-                           std::optional<AlternateInfoBoxSlot> slot) noexcept
+dlgAlternatesListShowModal(Waypoints *waypoints) noexcept
 {
   if (!backend_components->protected_task_manager)
     return;
 
   const DialogLook &dialog_look = UIGlobals::GetDialogLook();
 
-  auto widget = std::make_unique<AlternatesListWidget>(dialog_look, false,
-                                                       slot);
-  const bool has_alternates = widget->Update();
-  if (!has_alternates && !slot.has_value()) {
+  auto widget = std::make_unique<AlternatesListWidget>(dialog_look);
+  if (!widget->Update()) {
     /* no alternates: don't show the dialog */
     Message::AddMessage(_("No alternates available"));
     return;
   }
 
-  const auto *title = _("Alternates");
-  if (slot.has_value()) {
-    title = C_("Menu", "Alternates 1");
-    if (*slot == AlternateInfoBoxSlot::SECOND)
-      title = C_("Menu", "Alternates 2");
-  }
-
   TWidgetDialog<AlternatesListWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(), dialog_look,
-           title);
+           _("Alternates"));
   widget->CreateButtons(dialog, waypoints);
   dialog.FinishPreliminary(std::move(widget));
   dialog.EnableCursorSelection();

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -216,8 +216,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
         return;
 
       const auto slot = GetConfiguredSlot();
-      SetManualAlternateWaypoint(slot, GetSelectedWaypointPtr());
-      SetAlternateInfoBoxMode(slot, AlternateInfoBoxMode::MANUAL);
+      SelectManualAlternateWaypoint(slot, GetSelectedWaypointPtr());
       cancel_button->Click();
     });
   }

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -3,11 +3,19 @@
 
 #include "TaskDialogs.hpp"
 #include "Dialogs/WidgetDialog.hpp"
-#include "Dialogs/ListPicker.hpp"
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
 #include "Form/Form.hpp"
 #include "InfoBoxes/Content/Alternate.hpp"
 #include "Widget/ListWidget.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Widget/ButtonWidget.hpp"
+#include "Form/Button.hpp"
+#include "Renderer/ButtonRenderer.hpp"
+#include "Renderer/TextRenderer.hpp"
+#include "Look/ButtonLook.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Font.hpp"
 #include "Look/DialogLook.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Engine/Task/TaskManager.hpp"
@@ -18,8 +26,8 @@
 #include "Look/MapLook.hpp"
 #include "Renderer/WaypointListRenderer.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
-#include "Renderer/TextRowListItemRenderer.hpp"
 #include "util/StaticString.hxx"
+#include "util/IterableSplitString.hxx"
 #include "Language/Language.hpp"
 #include "ActionInterface.hpp"
 #include "Message.hpp"
@@ -33,6 +41,8 @@
 #include <array>
 #include <cassert>
 #include <optional>
+#include <string>
+#include <utility>
 
 namespace {
 class AlternatesListWidget final
@@ -285,7 +295,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
   if (!select_mode) {
     auto_button = dialog.AddButton(C_("Button", "Alternate AUTO"), [this](){
       const auto slot =
-        dlgAlternateSlotShowModal(C_("Button", "Alternate AUTO"));
+        dlgAlternateSlotShowModal(_("AUTO mode"), true);
       if (!slot.has_value() ||
           GetAlternateInfoBoxMode(*slot) != AlternateInfoBoxMode::MANUAL)
         return;
@@ -299,7 +309,7 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
         return;
 
       const auto slot =
-        dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+        dlgAlternateSlotShowModal(GetSelectedWaypoint().name.c_str());
       if (!slot.has_value())
         return;
 
@@ -381,49 +391,197 @@ AlternatesListWidget::OnActivateItem([[maybe_unused]] unsigned index) noexcept
 
 namespace {
 
+[[gnu::pure]]
+Color
+GetButtonTextColor(const ButtonLook &look, ButtonState state) noexcept
+{
+  switch (state) {
+  case ButtonState::DISABLED:
+    return look.disabled.color;
+
+  case ButtonState::FOCUSED:
+  case ButtonState::PRESSED:
+    return look.focused.foreground_color;
+
+  case ButtonState::SELECTED:
+    return look.selected.foreground_color;
+
+  case ButtonState::ENABLED:
+    break;
+  }
+
+  return look.standard.foreground_color;
+}
+
 /**
- * Renders one row of the alternate slot picker, showing the slot
- * name, its current target and its mode.
+ * A #ButtonRenderer for a caption spanning several lines; the lines
+ * are separated by '\n'.
  */
-class AlternateSlotListItemRenderer final : public TextRowListItemRenderer {
-  std::array<StaticString<128>, alternate_info_box_slot_count> rows;
+class MultiLineTextButtonRenderer final : public ButtonRenderer {
+  ButtonFrameRenderer frame_renderer;
+
+  TextRenderer text_renderer;
+
+  const std::string caption;
 
 public:
-  AlternateSlotListItemRenderer() noexcept {
-    for (const auto slot : all_alternate_info_box_slots) {
-      const auto waypoint = GetAlternateSlotWaypoint(slot);
-      const auto alternate_mode_short_label =
-        GetAlternateModeShortLabel(GetAlternateInfoBoxMode(slot));
-
-      rows[ToAlternateInfoBoxSlotIndex(slot)]
-        .Format("%s - %s (%s)", GetAlternateSlotName(slot),
-                waypoint != nullptr ? waypoint->name.c_str() : _("None"),
-                alternate_mode_short_label);
-    }
+  MultiLineTextButtonRenderer(const ButtonLook &_look,
+                              std::string &&_caption) noexcept
+    :frame_renderer(_look), caption(std::move(_caption)) {
+    text_renderer.SetCenter();
+    text_renderer.SetVCenter();
+    text_renderer.SetControl();
   }
 
-  void OnPaintItem(Canvas &canvas, const PixelRect rc,
-                   const unsigned index) noexcept override {
-    assert(index < rows.size());
+  /* virtual methods from class ButtonRenderer */
+  unsigned GetMinimumButtonWidth() const noexcept override {
+    const Font &font = *frame_renderer.GetLook().font;
 
-    row_renderer.DrawTextRow(canvas, rc, rows[index].c_str());
+    unsigned width = 0;
+    for (const auto line : IterableSplitString(caption.c_str(), '\n'))
+      width = std::max(width, font.TextSize(line).width);
+
+    return 2 * (ButtonFrameRenderer::GetMargin() + Layout::GetTextPadding())
+      + width;
+  }
+
+  void DrawButton(Canvas &canvas, const PixelRect &rc,
+                  ButtonState state) const noexcept override {
+    frame_renderer.DrawButton(canvas, rc, state);
+
+    const ButtonLook &look = frame_renderer.GetLook();
+
+    canvas.SetBackgroundTransparent();
+    canvas.SetTextColor(GetButtonTextColor(look, state));
+    canvas.Select(*look.font);
+
+    text_renderer.Draw(canvas, frame_renderer.GetDrawingRect(rc, state),
+                       caption);
   }
 };
+
+/**
+ * One alternate slot button: twice as tall as a regular button,
+ * because its caption has two rows.
+ */
+class AlternateSlotButtonWidget final : public ButtonWidget {
+  const bool enabled;
+
+public:
+  AlternateSlotButtonWidget(std::unique_ptr<ButtonRenderer> _renderer,
+                            std::function<void()> _callback,
+                            bool _enabled) noexcept
+    :ButtonWidget(std::move(_renderer), std::move(_callback)),
+     enabled(_enabled) {}
+
+  /* virtual methods from class Widget */
+  PixelSize GetMinimumSize() const noexcept override {
+    auto size = ButtonWidget::GetMinimumSize();
+    size.height *= 2;
+    return size;
+  }
+
+  PixelSize GetMaximumSize() const noexcept override {
+    auto size = ButtonWidget::GetMaximumSize();
+    size.height *= 2;
+    return size;
+  }
+
+  void Initialise(ContainerWindow &parent,
+                  const PixelRect &rc) noexcept override {
+    ButtonWidget::Initialise(parent, rc);
+
+    if (!enabled)
+      GetWindow().SetEnabled(false);
+  }
+
+  bool SetFocus() noexcept override {
+    return enabled && ButtonWidget::SetFocus();
+  }
+};
+
+/**
+ * Asks the pilot which alternate InfoBox slot shall receive the
+ * action: one button per slot, showing what the slot currently
+ * refers to.
+ */
+class AlternateSlotWidget final : public RowFormWidget {
+  WndForm &dialog;
+
+  const char *const target_name;
+
+  /**
+   * Offer only the slots that are currently in MANUAL mode?
+   */
+  const bool manual_slots_only;
+
+  std::optional<AlternateInfoBoxSlot> &value;
+
+public:
+  AlternateSlotWidget(const DialogLook &look, WndForm &_dialog,
+                      const char *_target_name, bool _manual_slots_only,
+                      std::optional<AlternateInfoBoxSlot> &_value) noexcept
+    :RowFormWidget(look), dialog(_dialog), target_name(_target_name),
+     manual_slots_only(_manual_slots_only), value(_value) {}
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+};
+
+void
+AlternateSlotWidget::Prepare(ContainerWindow &parent,
+                             const PixelRect &rc) noexcept
+{
+  RowFormWidget::Prepare(parent, rc);
+
+  StaticString<256> text;
+  text.Format("%s\n%s", _("Select alternate slot for"), target_name);
+  AddMultiLine(text);
+
+  for (const auto slot : all_alternate_info_box_slots) {
+    const auto mode = GetAlternateInfoBoxMode(slot);
+    const auto waypoint = GetAlternateSlotWaypoint(slot);
+
+    text.Format("%s\n%s: %s / %s", GetAlternateSlotName(slot), _("Current"),
+                GetAlternateModeShortLabel(mode),
+                waypoint != nullptr ? waypoint->name.c_str() : _("None"));
+
+    const bool enabled =
+      !manual_slots_only || mode == AlternateInfoBoxMode::MANUAL;
+
+    Add(std::make_unique<AlternateSlotButtonWidget>(
+          std::make_unique<MultiLineTextButtonRenderer>(GetLook().button,
+                                                        std::string{text.c_str()}),
+          [this, slot](){
+            value = slot;
+            dialog.SetModalResult(mrOK);
+          },
+          enabled));
+  }
+}
 
 } // namespace
 
 std::optional<AlternateInfoBoxSlot>
-dlgAlternateSlotShowModal(const char *caption) noexcept
+dlgAlternateSlotShowModal(const char *target_name,
+                          bool manual_slots_only) noexcept
 {
-  AlternateSlotListItemRenderer renderer;
+  const DialogLook &look = UIGlobals::GetDialogLook();
 
-  const int i = ListPicker(caption, alternate_info_box_slot_count, 0,
-                           renderer.CalculateLayout(UIGlobals::GetDialogLook()),
-                           renderer);
-  if (i < 0)
+  std::optional<AlternateInfoBoxSlot> value;
+
+  WidgetDialog dialog(WidgetDialog::Auto{}, UIGlobals::GetMainWindow(), look,
+                      _("Alternate slot"));
+  dialog.FinishPreliminary(std::make_unique<AlternateSlotWidget>(look, dialog,
+                                                                target_name,
+                                                                manual_slots_only,
+                                                                value));
+  dialog.AddButton(_("Cancel"), mrCancel);
+
+  if (dialog.ShowModal() != mrOK)
     return std::nullopt;
 
-  return all_alternate_info_box_slots[i];
+  return value;
 }
 
 void

--- a/src/Dialogs/Task/TaskDialogs.hpp
+++ b/src/Dialogs/Task/TaskDialogs.hpp
@@ -54,16 +54,23 @@ void
 dlgTargetShowModal(int TargetPoint = -1);
 
 /**
- * Shows the current alternates list.
- *
- * @param slot if set, the dialog exposes the manual/auto controls for
- * the specified alternate InfoBox slot; otherwise it behaves as a
- * generic alternates list dialog
+ * Shows the current alternates list.  The dialog is not tied to an
+ * alternate InfoBox slot: it exposes the manual/auto controls for
+ * both of them, and marks the waypoints the slots currently refer to.
  */
 void
-dlgAlternatesListShowModal(Waypoints *waypoints,
-                           std::optional<AlternateInfoBoxSlot> slot =
-                             std::nullopt) noexcept;
+dlgAlternatesListShowModal(Waypoints *waypoints) noexcept;
+
+/**
+ * Asks the pilot which alternate InfoBox slot an action shall be
+ * applied to.  The dialog lists both slots with their current target
+ * and mode.
+ *
+ * @param caption the dialog caption, describing the action
+ * @return the selected slot, or std::nullopt if the pilot cancelled
+ */
+std::optional<AlternateInfoBoxSlot>
+dlgAlternateSlotShowModal(const char *caption) noexcept;
 
 /**
  * Shows the current alternates list and returns the selected waypoint.

--- a/src/Dialogs/Task/TaskDialogs.hpp
+++ b/src/Dialogs/Task/TaskDialogs.hpp
@@ -63,14 +63,18 @@ dlgAlternatesListShowModal(Waypoints *waypoints) noexcept;
 
 /**
  * Asks the pilot which alternate InfoBox slot an action shall be
- * applied to.  The dialog lists both slots with their current target
- * and mode.
+ * applied to.  The dialog shows one button per slot, with the
+ * waypoint and the mode the slot currently refers to.
  *
- * @param caption the dialog caption, describing the action
+ * @param target_name what the slots are offered for, e.g. the name of
+ * the waypoint that shall become the alternate
+ * @param manual_slots_only offer only the slots that are currently in
+ * MANUAL mode
  * @return the selected slot, or std::nullopt if the pilot cancelled
  */
 std::optional<AlternateInfoBoxSlot>
-dlgAlternateSlotShowModal(const char *caption) noexcept;
+dlgAlternateSlotShowModal(const char *target_name,
+                          bool manual_slots_only=false) noexcept;
 
 /**
  * Shows the current alternates list and returns the selected waypoint.

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -4,6 +4,7 @@
 #include "WaypointDialogs.hpp"
 #include "WaypointInfoWidget.hpp"
 #include "WaypointCommandsWidget.hpp"
+#include "InfoBoxes/Content/Alternate.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
@@ -122,6 +123,7 @@ class WaypointDetailsWidget final
   : public NullWidget {
   struct Layout {
     PixelRect goto_button;
+    PixelRect alternate1_button, alternate2_button;
     PixelRect magnify_button, shrink_button;
     PixelRect previous_button, next_button;
     PixelRect close_button;
@@ -151,6 +153,7 @@ class WaypointDetailsWidget final
   const WaypointDetailsNesting nesting;
 
   Button goto_button;
+  Button alternate1_button, alternate2_button;
   Button magnify_button, shrink_button;
   Button previous_button, next_button;
   Button close_button;
@@ -217,6 +220,7 @@ public:
   void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
 
   void OnGotoClicked();
+  void OnAlternateClicked(AlternateInfoBoxSlot slot);
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -230,6 +234,8 @@ public:
                         *waypoint);
 
     goto_button.MoveAndShow(layout.goto_button);
+    alternate1_button.MoveAndShow(layout.alternate1_button);
+    alternate2_button.MoveAndShow(layout.alternate2_button);
 
     if (!images.empty()) {
       magnify_button.MoveAndShow(layout.magnify_button);
@@ -259,6 +265,8 @@ public:
 
   void Hide() noexcept override {
     goto_button.Hide();
+    alternate1_button.Hide();
+    alternate2_button.Hide();
 
     if (!images.empty()) {
       magnify_button.Hide();
@@ -287,6 +295,8 @@ public:
                         *waypoint);
 
     goto_button.Move(layout.goto_button);
+    alternate1_button.Move(layout.alternate1_button);
+    alternate2_button.Move(layout.alternate2_button);
 
     if (!images.empty()) {
       magnify_button.Move(layout.magnify_button);
@@ -317,7 +327,10 @@ public:
   }
 
   bool HasFocus() const noexcept override {
-    return (task_manager != nullptr && goto_button.HasFocus()) ||
+    return (task_manager != nullptr &&
+            (goto_button.HasFocus() ||
+             alternate1_button.HasFocus() ||
+             alternate2_button.HasFocus())) ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
        previous_button.HasFocus() || next_button.HasFocus() ||
@@ -366,31 +379,41 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
   main = rc;
 
   if (width > height) {
-    auto buttons = main.CutLeftSafe(::Layout::Scale(70));
+    auto buttons = main.CutLeftSafe(::Layout::Scale(96));
 
     goto_button = buttons.CutTopSafe(button_height);
+    alternate1_button = buttons.CutTopSafe(button_height);
+    alternate2_button = buttons.CutTopSafe(button_height);
     std::tie(magnify_button, shrink_button) = buttons.CutTopSafe(button_height).VerticalSplit();
 
     close_button = buttons.CutBottomSafe(button_height);
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe(button_height);
+    auto buttons = main.CutBottomSafe(3 * button_height);
 
-    const unsigned one_third = (2 * buttons.left + buttons.right) / 3;
-    const unsigned two_thirds = (buttons.left + 2 * buttons.right) / 3;
+    auto alternate_column = buttons;
+    alternate_column.right = alternate_column.left + buttons.GetWidth() / 3;
 
-    goto_button = buttons;
-    goto_button.right = one_third;
+    goto_button = alternate_column.CutTopSafe(button_height);
+    alternate1_button = alternate_column.CutTopSafe(button_height);
+    alternate2_button = alternate_column.CutTopSafe(button_height);
 
-    close_button = buttons;
-    close_button.left = two_thirds;
+    auto navigation = buttons.CutBottomSafe(button_height);
+    navigation.left = alternate_column.right;
 
-    previous_button = buttons;
-    previous_button.left = one_third;
-    next_button = buttons;
-    next_button.right = two_thirds;
-    previous_button.right = next_button.left = (one_third + two_thirds) / 2;
+    const unsigned first_third =
+      (2 * navigation.left + navigation.right) / 3;
+    const unsigned second_third =
+      (navigation.left + 2 * navigation.right) / 3;
+
+    previous_button = navigation;
+    previous_button.right = first_third;
+    next_button = navigation;
+    next_button.left = first_third;
+    next_button.right = second_third;
+    close_button = navigation;
+    close_button.left = second_third;
 
     const unsigned padding = ::Layout::GetTextPadding();
     shrink_button.left = main.left + padding;
@@ -499,6 +522,20 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                          }
                        });
   }
+
+  alternate1_button.Create(parent, look.button, _("Alternate 1"),
+                           layout.alternate1_button, button_style,
+                           [this](){
+                             OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
+                           });
+  alternate2_button.Create(parent, look.button, _("Alternate 2"),
+                           layout.alternate2_button, button_style,
+                           [this](){
+                             OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
+                           });
+  const bool can_select_alternate = task_manager != nullptr;
+  alternate1_button.SetEnabled(can_select_alternate);
+  alternate2_button.SetEnabled(can_select_alternate);
 
   if (!images.empty()) {
     magnify_button.Create(parent, layout.magnify_button, button_style,
@@ -829,6 +866,20 @@ WaypointDetailsWidget::OnGotoClicked()
   }
 
   task_manager->DoGoto(waypoint);
+  if (nesting.state_change_committed != nullptr)
+    *nesting.state_change_committed = true;
+  dialog.SetModalResult(mrOK);
+
+  CommonInterface::main_window->FullRedraw();
+}
+
+void
+WaypointDetailsWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+{
+  if (task_manager == nullptr)
+    return;
+
+  SelectManualAlternateWaypoint(slot, waypoint);
   if (nesting.state_change_committed != nullptr)
     *nesting.state_change_committed = true;
   dialog.SetModalResult(mrOK);

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -327,10 +327,9 @@ public:
   }
 
   bool HasFocus() const noexcept override {
-    return (task_manager != nullptr &&
-            (goto_button.HasFocus() ||
-             alternate1_button.HasFocus() ||
-             alternate2_button.HasFocus())) ||
+    return goto_button.HasFocus() ||
+           alternate1_button.HasFocus() ||
+           alternate2_button.HasFocus() ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
        previous_button.HasFocus() || next_button.HasFocus() ||
@@ -390,30 +389,17 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe(3 * button_height);
+    auto buttons = main.CutBottomSafe(2 * button_height);
 
-    auto alternate_column = buttons;
-    alternate_column.right = alternate_column.left + buttons.GetWidth() / 3;
+    auto top_row = buttons.CutTopSafe(button_height);
+    goto_button = top_row.CutLeftSafe(top_row.GetWidth() / 3);
+    alternate1_button = top_row.CutLeftSafe(top_row.GetWidth() / 2);
+    alternate2_button = top_row;
 
-    goto_button = alternate_column.CutTopSafe(button_height);
-    alternate1_button = alternate_column.CutTopSafe(button_height);
-    alternate2_button = alternate_column.CutTopSafe(button_height);
-
-    auto navigation = buttons.CutBottomSafe(button_height);
-    navigation.left = alternate_column.right;
-
-    const unsigned first_third =
-      (2 * navigation.left + navigation.right) / 3;
-    const unsigned second_third =
-      (navigation.left + 2 * navigation.right) / 3;
-
-    previous_button = navigation;
-    previous_button.right = first_third;
-    next_button = navigation;
-    next_button.left = first_third;
-    next_button.right = second_third;
-    close_button = navigation;
-    close_button.left = second_third;
+    auto bottom_row = buttons;
+    previous_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 3);
+    next_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 2);
+    close_button = bottom_row;
 
     const unsigned padding = ::Layout::GetTextPadding();
     shrink_button.left = main.left + padding;

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -5,6 +5,7 @@
 #include "WaypointInfoWidget.hpp"
 #include "WaypointCommandsWidget.hpp"
 #include "Simulator.hpp"
+#include "InfoBoxes/Content/Alternate.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
@@ -123,6 +124,7 @@ class WaypointDetailsWidget final
   : public NullWidget {
   struct Layout {
     PixelRect goto_button;
+    PixelRect alternate1_button, alternate2_button;
     PixelRect sim_jump_button;
     PixelRect magnify_button, shrink_button;
     PixelRect previous_button, next_button;
@@ -155,6 +157,7 @@ class WaypointDetailsWidget final
   const bool sim_jump_active;
 
   Button goto_button;
+  Button alternate1_button, alternate2_button;
   Button sim_jump_button;
   Button magnify_button, shrink_button;
   Button previous_button, next_button;
@@ -223,6 +226,7 @@ public:
   void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
 
   void OnGotoClicked();
+  void OnAlternateClicked(AlternateInfoBoxSlot slot);
   void OnSimJumpClicked();
 
   /* virtual methods from class Widget */
@@ -238,6 +242,8 @@ public:
                         *waypoint);
 
     goto_button.MoveAndShow(layout.goto_button);
+    alternate1_button.MoveAndShow(layout.alternate1_button);
+    alternate2_button.MoveAndShow(layout.alternate2_button);
     if (sim_jump_active)
       sim_jump_button.MoveAndShow(layout.sim_jump_button);
 
@@ -269,6 +275,8 @@ public:
 
   void Hide() noexcept override {
     goto_button.Hide();
+    alternate1_button.Hide();
+    alternate2_button.Hide();
     if (sim_jump_active)
       sim_jump_button.Hide();
 
@@ -300,6 +308,8 @@ public:
                         *waypoint);
 
     goto_button.Move(layout.goto_button);
+    alternate1_button.Move(layout.alternate1_button);
+    alternate2_button.Move(layout.alternate2_button);
     if (sim_jump_active)
       sim_jump_button.Move(layout.sim_jump_button);
 
@@ -332,7 +342,10 @@ public:
   }
 
   bool HasFocus() const noexcept override {
-    return (task_manager != nullptr && goto_button.HasFocus()) ||
+    return (task_manager != nullptr &&
+            (goto_button.HasFocus() ||
+             alternate1_button.HasFocus() ||
+             alternate2_button.HasFocus())) ||
       (sim_jump_active && sim_jump_button.HasFocus()) ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
@@ -383,9 +396,11 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
   main = rc;
 
   if (width > height) {
-    auto buttons = main.CutLeftSafe(::Layout::Scale(70));
+    auto buttons = main.CutLeftSafe(::Layout::Scale(96));
 
     goto_button = buttons.CutTopSafe(button_height);
+    alternate1_button = buttons.CutTopSafe(button_height);
+    alternate2_button = buttons.CutTopSafe(button_height);
     if (sim_jump_active)
       sim_jump_button = buttons.CutTopSafe(button_height);
     std::tie(magnify_button, shrink_button) = buttons.CutTopSafe(button_height).VerticalSplit();
@@ -394,43 +409,32 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe(sim_jump_active ? 2 * button_height
-                                                      : button_height);
+    auto buttons = main.CutBottomSafe((sim_jump_active ? 4 : 3) * button_height);
 
-    const unsigned one_third = (2 * buttons.left + buttons.right) / 3;
-    const unsigned two_thirds = (buttons.left + 2 * buttons.right) / 3;
+    auto alternate_column = buttons;
+    alternate_column.right = alternate_column.left + buttons.GetWidth() / 3;
 
-    if (sim_jump_active) {
-      auto top_buttons = buttons.CutTopSafe(button_height);
-      auto bottom_buttons = buttons;
+    goto_button = alternate_column.CutTopSafe(button_height);
+    alternate1_button = alternate_column.CutTopSafe(button_height);
+    alternate2_button = alternate_column.CutTopSafe(button_height);
+    if (sim_jump_active)
+      sim_jump_button = alternate_column.CutTopSafe(button_height);
 
-      goto_button = top_buttons;
-      goto_button.right = one_third;
+    auto navigation = buttons.CutBottomSafe(button_height);
+    navigation.left = alternate_column.right;
 
-      sim_jump_button = bottom_buttons;
-      sim_jump_button.right = one_third;
+    const unsigned first_third =
+      (2 * navigation.left + navigation.right) / 3;
+    const unsigned second_third =
+      (navigation.left + 2 * navigation.right) / 3;
 
-      previous_button = bottom_buttons;
-      previous_button.left = one_third;
-      next_button = bottom_buttons;
-      next_button.right = two_thirds;
-      previous_button.right = next_button.left = (one_third + two_thirds) / 2;
-
-      close_button = bottom_buttons;
-      close_button.left = two_thirds;
-    } else {
-      goto_button = buttons;
-      goto_button.right = one_third;
-
-      close_button = buttons;
-      close_button.left = two_thirds;
-
-      previous_button = buttons;
-      previous_button.left = one_third;
-      next_button = buttons;
-      next_button.right = two_thirds;
-      previous_button.right = next_button.left = (one_third + two_thirds) / 2;
-    }
+    previous_button = navigation;
+    previous_button.right = first_third;
+    next_button = navigation;
+    next_button.left = first_third;
+    next_button.right = second_third;
+    close_button = navigation;
+    close_button.left = second_third;
 
     const unsigned padding = ::Layout::GetTextPadding();
     shrink_button.left = main.left + padding;
@@ -540,6 +544,20 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                          }
                        });
   }
+
+  alternate1_button.Create(parent, look.button, _("Alternate 1"),
+                           layout.alternate1_button, button_style,
+                           [this](){
+                             OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
+                           });
+  alternate2_button.Create(parent, look.button, _("Alternate 2"),
+                           layout.alternate2_button, button_style,
+                           [this](){
+                             OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
+                           });
+  const bool can_select_alternate = task_manager != nullptr;
+  alternate1_button.SetEnabled(can_select_alternate);
+  alternate2_button.SetEnabled(can_select_alternate);
 
   if (sim_jump_active)
     sim_jump_button.Create(parent, look.button, C_("Button", "Sim: Jump to"),
@@ -875,6 +893,20 @@ WaypointDetailsWidget::OnGotoClicked()
   }
 
   task_manager->DoGoto(waypoint);
+  if (nesting.state_change_committed != nullptr)
+    *nesting.state_change_committed = true;
+  dialog.SetModalResult(mrOK);
+
+  CommonInterface::main_window->FullRedraw();
+}
+
+void
+WaypointDetailsWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+{
+  if (task_manager == nullptr)
+    return;
+
+  SelectManualAlternateWaypoint(slot, waypoint);
   if (nesting.state_change_committed != nullptr)
     *nesting.state_change_committed = true;
   dialog.SetModalResult(mrOK);

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -6,6 +6,7 @@
 #include "WaypointCommandsWidget.hpp"
 #include "Simulator.hpp"
 #include "InfoBoxes/Content/Alternate.hpp"
+#include "Dialogs/Task/TaskDialogs.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
@@ -124,7 +125,7 @@ class WaypointDetailsWidget final
   : public NullWidget {
   struct Layout {
     PixelRect goto_button;
-    PixelRect alternate1_button, alternate2_button;
+    PixelRect alternate_button;
     PixelRect sim_jump_button;
     PixelRect magnify_button, shrink_button;
     PixelRect previous_button, next_button;
@@ -139,7 +140,7 @@ class WaypointDetailsWidget final
 #endif
 
     explicit Layout(const PixelRect &rc,
-                    bool sim_jump_active,
+                    bool sim_jump_active, bool alternate_active,
 #ifdef HAVE_RUN_FILE
                     TextRowRenderer &row_renderer,
 #endif
@@ -156,8 +157,14 @@ class WaypointDetailsWidget final
   const WaypointDetailsNesting nesting;
   const bool sim_jump_active;
 
+  /**
+   * Only a landable waypoint may be pinned as an alternate, and only
+   * when navigation actions are allowed at all.
+   */
+  const bool alternate_active;
+
   Button goto_button;
-  Button alternate1_button, alternate2_button;
+  Button alternate_button;
   Button sim_jump_button;
   Button magnify_button, shrink_button;
   Button previous_button, next_button;
@@ -194,6 +201,7 @@ public:
      task_manager(_task_manager),
      nesting(_nesting),
      sim_jump_active(is_simulator()),
+     alternate_active(task_manager != nullptr && waypoint->IsLandable()),
      commands_widget(new WaypointCommandsWidget(look, &dialog, waypoints, waypoint,
                                                 task_manager, allow_edit,
                                                 _nesting)) {}
@@ -226,7 +234,7 @@ public:
   void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
 
   void OnGotoClicked();
-  void OnAlternateClicked(AlternateInfoBoxSlot slot);
+  void OnAlternateClicked();
   void OnSimJumpClicked();
 
   /* virtual methods from class Widget */
@@ -235,15 +243,15 @@ public:
 
   void Show(const PixelRect &rc) noexcept override {
     const Layout layout(rc,
-                        sim_jump_active,
+                        sim_jump_active, alternate_active,
 #ifdef HAVE_RUN_FILE
                         file_list_handler.GetRowRenderer(),
 #endif
                         *waypoint);
 
     goto_button.MoveAndShow(layout.goto_button);
-    alternate1_button.MoveAndShow(layout.alternate1_button);
-    alternate2_button.MoveAndShow(layout.alternate2_button);
+    if (alternate_active)
+      alternate_button.MoveAndShow(layout.alternate_button);
     if (sim_jump_active)
       sim_jump_button.MoveAndShow(layout.sim_jump_button);
 
@@ -275,8 +283,8 @@ public:
 
   void Hide() noexcept override {
     goto_button.Hide();
-    alternate1_button.Hide();
-    alternate2_button.Hide();
+    if (alternate_active)
+      alternate_button.Hide();
     if (sim_jump_active)
       sim_jump_button.Hide();
 
@@ -301,15 +309,15 @@ public:
 
   void Move(const PixelRect &rc) noexcept override {
     const Layout layout(rc,
-                        sim_jump_active,
+                        sim_jump_active, alternate_active,
 #ifdef HAVE_RUN_FILE
                         file_list_handler.GetRowRenderer(),
 #endif
                         *waypoint);
 
     goto_button.Move(layout.goto_button);
-    alternate1_button.Move(layout.alternate1_button);
-    alternate2_button.Move(layout.alternate2_button);
+    if (alternate_active)
+      alternate_button.Move(layout.alternate_button);
     if (sim_jump_active)
       sim_jump_button.Move(layout.sim_jump_button);
 
@@ -343,8 +351,7 @@ public:
 
   bool HasFocus() const noexcept override {
     return goto_button.HasFocus() ||
-           alternate1_button.HasFocus() ||
-           alternate2_button.HasFocus() ||
+           (alternate_active && alternate_button.HasFocus()) ||
       (sim_jump_active && sim_jump_button.HasFocus()) ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
@@ -384,6 +391,7 @@ WaypointDetailsDispatchImageInput(const char *misc) noexcept
 
 WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
                                       bool sim_jump_active,
+                                      bool alternate_active,
 #ifdef HAVE_RUN_FILE
                                       TextRowRenderer &row_renderer,
 #endif
@@ -398,8 +406,8 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
     auto buttons = main.CutLeftSafe(::Layout::Scale(96));
 
     goto_button = buttons.CutTopSafe(button_height);
-    alternate1_button = buttons.CutTopSafe(button_height);
-    alternate2_button = buttons.CutTopSafe(button_height);
+    if (alternate_active)
+      alternate_button = buttons.CutTopSafe(button_height);
     if (sim_jump_active)
       sim_jump_button = buttons.CutTopSafe(button_height);
     std::tie(magnify_button, shrink_button) = buttons.CutTopSafe(button_height).VerticalSplit();
@@ -408,12 +416,17 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe((sim_jump_active ? 3 : 2) * button_height);
+    /* GoTo shares the bottom row unless the alternate button needs a
+       row of its own */
+    const unsigned button_rows = 1 + (alternate_active ? 1 : 0) +
+      (sim_jump_active ? 1 : 0);
+    auto buttons = main.CutBottomSafe(button_rows * button_height);
 
-    auto top_row = buttons.CutTopSafe(button_height);
-    goto_button = top_row.CutLeftSafe(top_row.GetWidth() / 3);
-    alternate1_button = top_row.CutLeftSafe(top_row.GetWidth() / 2);
-    alternate2_button = top_row;
+    if (alternate_active) {
+      auto top_row = buttons.CutTopSafe(button_height);
+      goto_button = top_row.CutLeftSafe(top_row.GetWidth() / 2);
+      alternate_button = top_row;
+    }
 
     if (sim_jump_active) {
       auto sim_row = buttons.CutTopSafe(button_height);
@@ -422,8 +435,15 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
     }
 
     auto bottom_row = buttons;
-    previous_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 3);
-    next_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 2);
+    if (alternate_active) {
+      previous_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 3);
+      next_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 2);
+    } else {
+      goto_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 3);
+      std::tie(previous_button, next_button) =
+        bottom_row.CutLeftSafe(bottom_row.GetWidth() / 2).VerticalSplit();
+    }
+
     close_button = bottom_row;
 
     const unsigned padding = ::Layout::GetTextPadding();
@@ -504,7 +524,7 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
   }
 
   const Layout layout(rc,
-                      sim_jump_active,
+                      sim_jump_active, alternate_active,
 #ifdef HAVE_RUN_FILE
                       file_list_handler.GetRowRenderer(),
 #endif
@@ -535,19 +555,11 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                        });
   }
 
-  alternate1_button.Create(parent, look.button, _("Alternate 1"),
-                           layout.alternate1_button, button_style,
-                           [this](){
-                             OnAlternateClicked(AlternateInfoBoxSlot::FIRST);
-                           });
-  alternate2_button.Create(parent, look.button, _("Alternate 2"),
-                           layout.alternate2_button, button_style,
-                           [this](){
-                             OnAlternateClicked(AlternateInfoBoxSlot::SECOND);
-                           });
-  const bool can_select_alternate = task_manager != nullptr;
-  alternate1_button.SetEnabled(can_select_alternate);
-  alternate2_button.SetEnabled(can_select_alternate);
+  if (alternate_active)
+    alternate_button.Create(parent, look.button,
+                            C_("Button", "Select as Alternate"),
+                            layout.alternate_button, button_style,
+                            [this](){ OnAlternateClicked(); });
 
   if (sim_jump_active)
     sim_jump_button.Create(parent, look.button, C_("Button", "Sim: Jump to"),
@@ -891,12 +903,17 @@ WaypointDetailsWidget::OnGotoClicked()
 }
 
 void
-WaypointDetailsWidget::OnAlternateClicked(AlternateInfoBoxSlot slot)
+WaypointDetailsWidget::OnAlternateClicked()
 {
-  if (task_manager == nullptr)
+  if (!alternate_active)
     return;
 
-  SelectManualAlternateWaypoint(slot, waypoint);
+  const auto slot =
+    dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+  if (!slot.has_value())
+    return;
+
+  SelectManualAlternateWaypoint(*slot, waypoint);
   if (nesting.state_change_committed != nullptr)
     *nesting.state_change_committed = true;
   dialog.SetModalResult(mrOK);

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -342,10 +342,9 @@ public:
   }
 
   bool HasFocus() const noexcept override {
-    return (task_manager != nullptr &&
-            (goto_button.HasFocus() ||
-             alternate1_button.HasFocus() ||
-             alternate2_button.HasFocus())) ||
+    return goto_button.HasFocus() ||
+           alternate1_button.HasFocus() ||
+           alternate2_button.HasFocus() ||
       (sim_jump_active && sim_jump_button.HasFocus()) ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
@@ -409,32 +408,23 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe((sim_jump_active ? 4 : 3) * button_height);
+    auto buttons = main.CutBottomSafe((sim_jump_active ? 3 : 2) * button_height);
 
-    auto alternate_column = buttons;
-    alternate_column.right = alternate_column.left + buttons.GetWidth() / 3;
+    auto top_row = buttons.CutTopSafe(button_height);
+    goto_button = top_row.CutLeftSafe(top_row.GetWidth() / 3);
+    alternate1_button = top_row.CutLeftSafe(top_row.GetWidth() / 2);
+    alternate2_button = top_row;
 
-    goto_button = alternate_column.CutTopSafe(button_height);
-    alternate1_button = alternate_column.CutTopSafe(button_height);
-    alternate2_button = alternate_column.CutTopSafe(button_height);
-    if (sim_jump_active)
-      sim_jump_button = alternate_column.CutTopSafe(button_height);
+    if (sim_jump_active) {
+      auto sim_row = buttons.CutTopSafe(button_height);
+      sim_jump_button = sim_row;
+      sim_jump_button.right = sim_row.left + sim_row.GetWidth() / 3;
+    }
 
-    auto navigation = buttons.CutBottomSafe(button_height);
-    navigation.left = alternate_column.right;
-
-    const unsigned first_third =
-      (2 * navigation.left + navigation.right) / 3;
-    const unsigned second_third =
-      (navigation.left + 2 * navigation.right) / 3;
-
-    previous_button = navigation;
-    previous_button.right = first_third;
-    next_button = navigation;
-    next_button.left = first_third;
-    next_button.right = second_third;
-    close_button = navigation;
-    close_button.left = second_third;
+    auto bottom_row = buttons;
+    previous_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 3);
+    next_button = bottom_row.CutLeftSafe(bottom_row.GetWidth() / 2);
+    close_button = bottom_row;
 
     const unsigned padding = ::Layout::GetTextPadding();
     shrink_button.left = main.left + padding;

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -908,8 +908,7 @@ WaypointDetailsWidget::OnAlternateClicked()
   if (!alternate_active)
     return;
 
-  const auto slot =
-    dlgAlternateSlotShowModal(C_("Button", "Select as Alternate"));
+  const auto slot = dlgAlternateSlotShowModal(waypoint->name.c_str());
   if (!slot.has_value())
     return;
 

--- a/src/Form/ButtonPanel.cpp
+++ b/src/Form/ButtonPanel.cpp
@@ -47,6 +47,8 @@ Button *
 ButtonPanel::Add(std::unique_ptr<ButtonRenderer> &&renderer,
                  Button::Callback callback) noexcept
 {
+  assert(!buttons.full());
+
   auto *button = new Button(parent, dummy_rc, style,
                             std::move(renderer), std::move(callback));
   button->SetCursorKeyGroup(this);

--- a/src/Form/ButtonPanel.hpp
+++ b/src/Form/ButtonPanel.hpp
@@ -9,16 +9,18 @@
 #include <cassert>
 
 class ButtonPanel {
+  static constexpr unsigned MAX_BUTTONS = 12u;
+
   ContainerWindow &parent;
   const ButtonLook &look;
   WindowStyle style;
 
-  StaticArray<Button *, 8u> buttons;
+  StaticArray<Button *, MAX_BUTTONS> buttons;
 
   /**
    * Map key codes to the button that "owns" it.  Used by KeyPress().
    */
-  unsigned keys[8u];
+  unsigned keys[MAX_BUTTONS];
 
   /**
    * The button currently selected with KEY_LEFT / KEY_RIGHT on

--- a/src/InfoBoxes/Content/Alternate.cpp
+++ b/src/InfoBoxes/Content/Alternate.cpp
@@ -215,6 +215,20 @@ SetManualAlternateWaypoint(AlternateInfoBoxSlot slot,
 }
 
 void
+SelectManualAlternateWaypoint(AlternateInfoBoxSlot slot,
+                              WaypointPtr waypoint) noexcept
+{
+  {
+    const std::scoped_lock lock(alternate_state_mutex);
+    auto &state = alternate_slot_states[ToAlternateInfoBoxSlotIndex(slot)];
+    state.waypoint = std::move(waypoint);
+    state.mode = AlternateInfoBoxMode::MANUAL;
+  }
+
+  MarkAlternateInfoBoxesDirty();
+}
+
+void
 ClearManualAlternateWaypoint(AlternateInfoBoxSlot slot) noexcept
 {
   SetManualAlternateWaypoint(slot, nullptr);

--- a/src/InfoBoxes/Content/Alternate.cpp
+++ b/src/InfoBoxes/Content/Alternate.cpp
@@ -224,6 +224,20 @@ SetManualAlternateWaypoint(AlternateInfoBoxSlot slot,
 }
 
 void
+SelectManualAlternateWaypoint(AlternateInfoBoxSlot slot,
+                              WaypointPtr waypoint) noexcept
+{
+  {
+    const std::scoped_lock lock(alternate_state_mutex);
+    auto &state = alternate_slot_states[ToAlternateInfoBoxSlotIndex(slot)];
+    state.waypoint = std::move(waypoint);
+    state.mode = AlternateInfoBoxMode::MANUAL;
+  }
+
+  MarkAlternateInfoBoxesDirty();
+}
+
+void
 ClearManualAlternateWaypoint(AlternateInfoBoxSlot slot) noexcept
 {
   SetManualAlternateWaypoint(slot, nullptr);

--- a/src/InfoBoxes/Content/Alternate.cpp
+++ b/src/InfoBoxes/Content/Alternate.cpp
@@ -51,15 +51,6 @@ std::mutex alternate_state_mutex;
  */
 std::array<AlternateSlotState, alternate_info_box_slot_count> alternate_slot_states;
 
-[[gnu::pure]]
-const char *
-GetAlternateModeShortLabel(AlternateInfoBoxMode mode) noexcept
-{
-  return mode == AlternateInfoBoxMode::MANUAL
-    ? C_("Abbreviation", "MAN")
-    : C_("Abbreviation", "AUTO");
-}
-
 /**
  * Value colour for Alternate InfoBoxes.
  *
@@ -104,9 +95,57 @@ GetManualAlternateWaypointUnlocked(AlternateInfoBoxSlot slot) noexcept
   return alternate_slot_states[ToAlternateInfoBoxSlotIndex(slot)].waypoint;
 }
 
-[[gnu::pure]]
+ResolvedAlternateInfo
+ResolveAlternateInfo(const AlternateInfoBoxSlot slot) noexcept
+{
+  ResolvedAlternateInfo resolved;
+  resolved.mode = GetAlternateInfoBoxMode(slot);
+  resolved.waypoint = GetAlternateSlotWaypoint(slot);
+
+  /* Re-solve with the current aircraft state every time the InfoBox
+     updates.  The list on the task stores solutions from the last glide
+     computer pass, which may skip runs when only altitude (e.g. baro)
+     changes without a new location fix timestamp. */
+  if (resolved.waypoint != nullptr)
+    resolved.solution = SolveAlternateGlide(*resolved.waypoint);
+
+  return resolved;
+}
+
+void
+SetAlternateTitle(InfoBoxData &data, const AlternateInfoBoxSlot slot,
+                  const char *suffix) noexcept
+{
+  const char *mode_label =
+    GetAlternateModeShortLabel(GetAlternateInfoBoxMode(slot));
+  const unsigned display_number = GetAlternateInfoBoxSlotDisplayNumber(slot);
+
+  if (suffix == nullptr)
+    data.FmtTitle(_("Altn {} {}"), display_number, mode_label);
+  else
+    data.FmtTitle(_("Altn {} {} {}"), display_number, suffix, mode_label);
+}
+
+} // namespace
+
+const char *
+GetAlternateSlotName(AlternateInfoBoxSlot slot) noexcept
+{
+  return slot == AlternateInfoBoxSlot::FIRST
+    ? _("Alternate 1")
+    : _("Alternate 2");
+}
+
+const char *
+GetAlternateModeShortLabel(AlternateInfoBoxMode mode) noexcept
+{
+  return mode == AlternateInfoBoxMode::MANUAL
+    ? C_("Abbreviation", "MAN")
+    : C_("Abbreviation", "AUTO");
+}
+
 GlideResult
-SolveManualAlternate(const Waypoint &waypoint) noexcept
+SolveAlternateGlide(const Waypoint &waypoint) noexcept
 {
   const auto &basic = CommonInterface::Basic();
   const auto &calculated = CommonInterface::Calculated();
@@ -128,58 +167,26 @@ SolveManualAlternate(const Waypoint &waypoint) noexcept
     settings.task.glide, calculated.glide_polar_safety);
 }
 
-ResolvedAlternateInfo
-ResolveAlternateInfo(AlternateInfoBoxSlot slot) noexcept
+WaypointPtr
+GetAlternateSlotWaypoint(const AlternateInfoBoxSlot slot) noexcept
 {
-  ResolvedAlternateInfo resolved;
-  resolved.mode = GetAlternateInfoBoxMode(slot);
+  if (GetAlternateInfoBoxMode(slot) == AlternateInfoBoxMode::MANUAL)
+    return GetManualAlternateWaypoint(slot);
 
   if (!backend_components || !backend_components->protected_task_manager)
-    return resolved;
-
-  if (resolved.mode == AlternateInfoBoxMode::MANUAL) {
-    resolved.waypoint = GetManualAlternateWaypoint(slot);
-    if (resolved.waypoint != nullptr)
-      resolved.solution = SolveManualAlternate(*resolved.waypoint);
-
-    return resolved;
-  }
+    return nullptr;
 
   ProtectedTaskManager::Lease lease{*backend_components->protected_task_manager};
   const AlternateList &alternates = lease->GetAlternates();
-  if (alternates.empty())
-    return resolved;
 
+  /* do not make Alternate 2 mirror Alternate 1 whenever only one
+     computed alternate is available */
   const unsigned index = ToAlternateInfoBoxSlotIndex(slot);
-
-  // Do not makes Alternate 2 mirror Alternate 1 whenever only one computed alternate is available
   if (index >= alternates.size())
-    return resolved;
+    return nullptr;
 
-  resolved.waypoint = alternates[index].waypoint;
-  /* Re-solve with the current aircraft state every time the InfoBox
-     updates.  The list on the task stores solutions from the last glide
-     computer pass, which may skip runs when only altitude (e.g. baro)
-     changes without a new location fix timestamp. */
-  resolved.solution = SolveManualAlternate(*resolved.waypoint);
-  return resolved;
+  return alternates[index].waypoint;
 }
-
-void
-SetAlternateTitle(InfoBoxData &data, AlternateInfoBoxSlot slot,
-                  const char *suffix) noexcept
-{
-  const char *mode_label =
-    GetAlternateModeShortLabel(GetAlternateInfoBoxMode(slot));
-  const unsigned display_number = GetAlternateInfoBoxSlotDisplayNumber(slot);
-
-  if (suffix == nullptr)
-    data.FmtTitle(_("Altn {} {}"), display_number, mode_label);
-  else
-    data.FmtTitle(_("Altn {} {} {}"), display_number, suffix, mode_label);
-}
-
-} // namespace
 
 AlternateInfoBoxMode
 GetAlternateInfoBoxMode(AlternateInfoBoxSlot slot) noexcept
@@ -250,7 +257,7 @@ InfoBoxContentAlternateBase::HandleClick() noexcept
       !data_components || !data_components->waypoints)
     return false;
 
-  dlgAlternatesListShowModal(data_components->waypoints.get(), slot);
+  dlgAlternatesListShowModal(data_components->waypoints.get());
   return true;
 }
 

--- a/src/InfoBoxes/Content/Alternate.hpp
+++ b/src/InfoBoxes/Content/Alternate.hpp
@@ -76,6 +76,14 @@ SetManualAlternateWaypoint(AlternateInfoBoxSlot slot,
                            WaypointPtr waypoint) noexcept;
 
 /**
+ * Stores the manually selected waypoint for the specified alternate
+ * slot and switches the slot to MANUAL mode.
+ */
+void
+SelectManualAlternateWaypoint(AlternateInfoBoxSlot slot,
+                              WaypointPtr waypoint) noexcept;
+
+/**
  * Clears the manually selected waypoint for the specified alternate
  * slot.
  */

--- a/src/InfoBoxes/Content/Alternate.hpp
+++ b/src/InfoBoxes/Content/Alternate.hpp
@@ -77,6 +77,14 @@ SetManualAlternateWaypoint(AlternateInfoBoxSlot slot,
                            WaypointPtr waypoint) noexcept;
 
 /**
+ * Stores the manually selected waypoint for the specified alternate
+ * slot and switches the slot to MANUAL mode.
+ */
+void
+SelectManualAlternateWaypoint(AlternateInfoBoxSlot slot,
+                              WaypointPtr waypoint) noexcept;
+
+/**
  * Clears the manually selected waypoint for the specified alternate
  * slot.
  */

--- a/src/InfoBoxes/Content/Alternate.hpp
+++ b/src/InfoBoxes/Content/Alternate.hpp
@@ -6,8 +6,12 @@
 #include "InfoBoxes/Content/Base.hpp"
 #include "Engine/Waypoint/Ptr.hpp"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
+
+struct Waypoint;
+struct GlideResult;
 
 enum class AlternateInfoBoxMode : uint8_t {
   AUTO,
@@ -44,6 +48,29 @@ static constexpr std::size_t alternate_info_box_slot_count = 2;
 static_assert(ToAlternateInfoBoxSlotIndex(AlternateInfoBoxSlot::FIRST) == 0);
 static_assert(ToAlternateInfoBoxSlotIndex(AlternateInfoBoxSlot::SECOND) == 1);
 static_assert(alternate_info_box_slot_count == 2);
+
+/** All alternate InfoBox slots, in display order. */
+inline constexpr std::array<AlternateInfoBoxSlot, alternate_info_box_slot_count>
+all_alternate_info_box_slots{
+  AlternateInfoBoxSlot::FIRST,
+  AlternateInfoBoxSlot::SECOND,
+};
+
+/**
+ * Returns the translated name of the specified alternate slot, e.g.
+ * "Alternate 1".
+ */
+[[gnu::pure]]
+const char *
+GetAlternateSlotName(AlternateInfoBoxSlot slot) noexcept;
+
+/**
+ * Returns the abbreviated label of the specified mode, as shown in
+ * the InfoBox titles ("AUTO" or "MAN").
+ */
+[[gnu::pure]]
+const char *
+GetAlternateModeShortLabel(AlternateInfoBoxMode mode) noexcept;
 
 /**
  * Returns the current source mode for the specified alternate InfoBox
@@ -83,6 +110,24 @@ SetManualAlternateWaypoint(AlternateInfoBoxSlot slot,
 void
 SelectManualAlternateWaypoint(AlternateInfoBoxSlot slot,
                               WaypointPtr waypoint) noexcept;
+
+/**
+ * Returns the waypoint the specified alternate slot currently refers
+ * to: the manually selected one in MANUAL mode, the computed
+ * alternate in AUTO mode, or nullptr if the slot has no target.
+ */
+[[gnu::pure]]
+WaypointPtr
+GetAlternateSlotWaypoint(AlternateInfoBoxSlot slot) noexcept;
+
+/**
+ * Solves the glide to the specified alternate for the current
+ * aircraft state.  The result is undefined if no solution is
+ * available.
+ */
+[[gnu::pure]]
+GlideResult
+SolveAlternateGlide(const Waypoint &waypoint) noexcept;
 
 /**
  * Clears the manually selected waypoint for the specified alternate

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -630,10 +630,8 @@ InputEvents::eventSetup(const char *misc)
     dlgPlanesShowModal();
   else if (StringIsEqual(misc, "Profile"))
     ProfileListDialog();
-  else if (StringIsEqual(misc, "Alternates")) {
-    dlgAlternatesListShowModal(data_components->waypoints.get(),
-                               AlternateInfoBoxSlot::FIRST);
-  }
+  else if (StringIsEqual(misc, "Alternates"))
+    dlgAlternatesListShowModal(data_components->waypoints.get());
 
   trigger_redraw();
 }


### PR DESCRIPTION
I'm adding the possibility to select any waypoint as an Alternate target. 

The goal is to be able to **select far in advance** an alternate when the pilot knows that he will cross some hostile terrain (eg: mountains valleys with no good landings), while keeping his tasks active.
Another possibility offered by this system is to set Alternate 1 in front of your route, in direction of the next turnpoint ; and the Alternate 2 to be the current, good landing option. Then with the right set of InfoBoxes the pilot knows quickly at any time if he can continue ahead or he should turn back.

Selection of an alternate can be done by:
- The MapItemListDialog menu with two new buttons Alternate 1 / Alternate 2
- The waypoint details dialog, with again two new buttons Alternate 1 / Alternate 2
- Those buttons (in the MapItemListDialog) will be activated or greyed out based on the same conditions applying to the "GoTo" button
- When selecting a waypoint as an alternate, the related set of Infoboxes will go in Alternate MANUAL mode
- The existing "quick" list of Alternates has not been touched to keep a quick view to the nearest alternates

**MapItemListDialog** with two buttons:
<img width="639" height="509" alt="image" src="https://github.com/user-attachments/assets/9b061204-ad50-44a4-8bbf-80b6a7b4a476" />


Waypoint details:
<img width="639" height="509" alt="image" src="https://github.com/user-attachments/assets/63e30742-c7a0-4004-9225-48e77e5fa47c" />

Portrait layout:
<img width="381" height="618" alt="image" src="https://github.com/user-attachments/assets/57bbbff3-94d9-4629-81b2-6be762544af3" />


New possibility offered by this on the map view:
<img width="639" height="509" alt="image" src="https://github.com/user-attachments/assets/4bb67bf5-1ac8-4787-8fed-1469d3a5f501" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select landable waypoints as **Alternate 1** or **Alternate 2** from waypoint details, map locations, or the alternates list.
  * Choosing an alternate switches its slot to **MANUAL**; return individual slots to **AUTO** at any time.
  * Non-landable waypoints cannot be selected. Alternates are marked **ALT1** and **ALT2**, with support for up to twelve entries.

* **Documentation**
  * Updated EN, DE, FR, and pt-BR manuals with the new workflow and selection rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->