### PR TITLE
MapWindow: Fix uninitialized projection and publish DrawThread snapshot

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -193,6 +193,8 @@ Version 7.45 - not yet released
   - snail trail: Catmull-Rom smoothing between fixes; vario colouring samples
     high-rate netto from the merge thread between GPS points #2447
   - Add renderer to display distance rings around the current location #2522
+  - Fix intermittent white-map hang on startup for non-OpenGL builds when
+    drawing began before map bounds were ready #2734
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
@@ -337,6 +339,9 @@ Version 7.45 - not yet released
     download remains available for a portable install
   - deprecate the legacy single-file Windows executable; use the OpenGL
     version instead — the legacy build will be removed in a future release
+* development
+  - MapWindow: publish a coherent projection snapshot for the DrawThread on
+    non-OpenGL builds so rendering does not read a live UI projection #2735
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -97,7 +97,7 @@ GlueMapWindow::PanTo(const GeoPoint &location) noexcept
 void
 GlueMapWindow::UpdateScreenBounds() noexcept
 {
-  visible_projection.UpdateScreenBounds();
+  MapWindow::UpdateScreenBounds();
 
   if (topography_thread != nullptr &&
       visible_projection.IsValid() &&

--- a/src/MapWindow/MapWindow.cpp
+++ b/src/MapWindow/MapWindow.cpp
@@ -34,6 +34,17 @@ MapWindow::~MapWindow() noexcept
   delete topography_renderer;
 }
 
+#ifndef ENABLE_OPENGL
+
+void
+MapWindow::PublishFrameProjection() noexcept
+{
+  const std::lock_guard lock{frame_projection_mutex};
+  published_projection = visible_projection;
+}
+
+#endif
+
 #ifdef ENABLE_OPENGL
 
 void

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -89,6 +89,19 @@ protected:
    * the DrawThread has finished drawing the new projection.
    */
   MapWindowProjection buffer_projection;
+
+  /**
+   * Protects #published_projection.  Held only for a short copy into
+   * or out of that field; never across Render().
+   */
+  mutable Mutex frame_projection_mutex;
+
+  /**
+   * Coherent projection snapshot published by the UI thread after
+   * UpdateScreenBounds().  The DrawThread copies this into
+   * #render_projection at the start of each frame.
+   */
+  MapWindowProjection published_projection;
 #endif
 
   /**
@@ -267,9 +280,21 @@ public:
 
   void UpdateScreenBounds() noexcept {
     visible_projection.UpdateScreenBounds();
+#ifndef ENABLE_OPENGL
+    PublishFrameProjection();
+#endif
   }
 
 protected:
+#ifndef ENABLE_OPENGL
+  /**
+   * Publish a coherent copy of #visible_projection for the DrawThread.
+   * Call only after UpdateScreenBounds() (or equivalent) so bounds match
+   * location/scale/angle/origin.
+   */
+  void PublishFrameProjection() noexcept;
+#endif
+
   void DrawBestCruiseTrack(Canvas &canvas, PixelPoint aircraft_pos) const noexcept;
   void DrawTrackBearing(Canvas &canvas,
                         PixelPoint aircraft_pos, bool circling) const noexcept;

--- a/src/MapWindow/MapWindowEvents.cpp
+++ b/src/MapWindow/MapWindowEvents.cpp
@@ -23,7 +23,7 @@ MapWindow::OnResize(PixelSize new_size) noexcept
 #endif
 
   visible_projection.SetScreenSize(new_size);
-  visible_projection.UpdateScreenBounds();
+  UpdateScreenBounds();
 }
 
 void
@@ -41,7 +41,7 @@ MapWindow::OnCreate()
   visible_projection.SetScreenSize(size);
   visible_projection.SetMapScale(5000);
   visible_projection.SetScreenOrigin(PixelRect{size}.GetCenter());
-  visible_projection.UpdateScreenBounds();
+  UpdateScreenBounds();
 
 #ifndef ENABLE_OPENGL
   buffer_projection = visible_projection;

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -188,7 +188,14 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc) noexcept
   // reset label over-write preventer
   label_block.reset();
 
+#ifndef ENABLE_OPENGL
+  {
+    const std::lock_guard lock{frame_projection_mutex};
+    render_projection = published_projection;
+  }
+#else
   render_projection = visible_projection;
+#endif
 
   if (!render_projection.IsValid() ||
       !render_projection.GetScreenBounds().IsValid()) {

--- a/src/MapWindow/MapWindowRender.cpp
+++ b/src/MapWindow/MapWindowRender.cpp
@@ -190,7 +190,8 @@ MapWindow::Render(Canvas &canvas, const PixelRect &rc) noexcept
 
   render_projection = visible_projection;
 
-  if (!render_projection.IsValid()) {
+  if (!render_projection.IsValid() ||
+      !render_projection.GetScreenBounds().IsValid()) {
     canvas.ClearWhite();
     return;
   }

--- a/src/Projection/WindowProjection.hpp
+++ b/src/Projection/WindowProjection.hpp
@@ -28,7 +28,7 @@ class WindowProjection:
    * This is a cached member that has to be updated manually by
    * calling UpdateScreenBounds()
    */
-  GeoBounds screen_bounds;
+  GeoBounds screen_bounds = GeoBounds::Invalid();
 
 public:
   /**


### PR DESCRIPTION
## Summary
- Initialize `WindowProjection::screen_bounds` to invalid and skip map render when bounds are not ready, fixing the intermittent non-OpenGL startup hang/white map (#2734).
- On `OPENGL=n`, publish a coherent `visible_projection` snapshot after `UpdateScreenBounds()` / create / resize; the DrawThread copies it under a short lock at the start of `Render()` instead of reading the live UI projection (#2735, minimal scope).
- OpenGL path unchanged (no DrawThread).

## Out of scope
Follow-mode / compass / bottom-margin / buffer-generation snapshotting and RASP renderer handoff remain for a follow-up (#2735).

## Test plan
- [ ] `make TARGET=UNIX OPENGL=n USE_CCACHE=y WERROR=y`
- [ ] `make TARGET=UNIX USE_CCACHE=y WERROR=y`
- [ ] Start with a configured home location on `OPENGL=n`; confirm no hang and map appears after first full redraw
- [ ] Resize, pan, and zoom while redrawing; confirm map stays coherent
- [ ] Smoke-test default OpenGL UNIX build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an intermittent startup hang that could display a blank map in non-OpenGL builds.
  - Improved map rendering stability during startup, resizing, and window creation.
  - Prevented invalid screen-bound data from being used before map bounds are initialized.
  - Improved rendering consistency by using a synchronized projection snapshot in non-OpenGL builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->