### PR TITLE
Terrain: Faster wide-scale panning (throttle + software overscan)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -196,6 +196,8 @@ Version 7.45 - not yet released
   - Reduce terrain tile reload frequency while panning by using a
     scale-relative movement threshold, and skip fine-tile loads when
     zoomed out to 100 km scale or wider (overview is enough)
+  - Software terrain: reuse an oversized render buffer while panning
+    (same idea as OpenGL overscan) to avoid regenerating every frame
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -193,6 +193,9 @@ Version 7.45 - not yet released
   - snail trail: Catmull-Rom smoothing between fixes; vario colouring samples
     high-rate netto from the merge thread between GPS points #2447
   - Add renderer to display distance rings around the current location #2522
+  - Reduce terrain tile reload frequency while panning by using a
+    scale-relative movement threshold, and skip fine-tile loads when
+    zoomed out to 100 km scale or wider (overview is enough)
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/build/test.mk
+++ b/build/test.mk
@@ -2137,6 +2137,8 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(SRC)/TransponderCode.cpp \
 	$(TEST_SRC_DIR)/Fonts.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
 	$(TEST_SRC_DIR)/FakeAsset.cpp \
 	$(TEST_SRC_DIR)/FakeDialogs.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \

--- a/src/MapWindow/MapWindow.cpp
+++ b/src/MapWindow/MapWindow.cpp
@@ -96,6 +96,11 @@ MapWindow::UpdateTerrain() noexcept
   if (terrain == nullptr)
     return false;
 
+  /* Fine tiles are not useful when zoomed out this far; the overview
+     already covers the screen (same threshold as TerrainThread). */
+  if (visible_projection.GetMapScale() >= 100000)
+    return false;
+
   GeoPoint location = visible_projection.GetGeoScreenCenter();
   auto radius = visible_projection.GetScreenWidthMeters() / 2;
 

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -25,7 +25,14 @@ static constexpr double PIXEL_SIZE_LOW_ZOOM_THRESHOLD = 20000.0;
 static constexpr double ZOOM_FACTOR_DIVISOR = 4250.0;
 static constexpr unsigned MAX_QUANTISATION_NEAR = 25;
 static constexpr unsigned MAX_QUANTISATION_LOW_ZOOM = 40;
+#ifdef ENABLE_OPENGL
 static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
+#else
+/* Software path regenerates the whole height matrix when the view
+   leaves the buffer; give pan more headroom than the OpenGL texture
+   overscan (1.5). */
+static constexpr double BOUNDS_SCALE_FACTOR = 2.0;
+#endif
 
 /** Keep slope neighbour sampling inside the height matrix. */
 static void
@@ -297,7 +304,21 @@ RasterRenderer::ScanMap(const RasterMap &map,
 
   last_quantisation_pixels = quantisation_pixels;
 #else
-  height_matrix.Fill(map, projection, quantisation_pixels, true);
+  /* Render into an oversized screen-aligned buffer so small pans can
+     blit a sub-rectangle instead of regenerating the height matrix. */
+  overscan_projection = projection;
+  const auto screen_size = projection.GetScreenSize();
+  const PixelSize buffer_size{
+    std::max(1u, unsigned(screen_size.width * BOUNDS_SCALE_FACTOR + 0.5)),
+    std::max(1u, unsigned(screen_size.height * BOUNDS_SCALE_FACTOR + 0.5)),
+  };
+  overscan_projection.SetScreenSize(buffer_size);
+  overscan_projection.SetScreenOrigin(PixelRect{buffer_size}.GetCenter());
+  overscan_projection.UpdateScreenBounds();
+  bounds = overscan_projection.GetScreenBounds();
+  bounds.IntersectWith(map.GetBounds());
+
+  height_matrix.Fill(map, overscan_projection, quantisation_pixels, true);
 
   ClampQuantisationEffectiveToMatrix(quantisation_effective,
                                      height_matrix.GetSize());
@@ -685,6 +706,9 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                      const WindowProjection &projection,
                      [[maybe_unused]] bool transparent_white) const noexcept
 {
+  if (image == nullptr)
+    return;
+
 #ifdef ENABLE_OPENGL
   if (bounds.IsValid() && bounds.Overlaps(projection.GetScreenBounds()))
     DrawGeoBitmap(*image,
@@ -692,7 +716,43 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                   bounds,
                   projection);
 #else
-  image->StretchTo(PixelSize{height_matrix.GetSize()},
+  assert(overscan_projection.IsValid());
+  assert(quantisation_pixels >= 1);
+
+  /* Map the visible screen into the overscan buffer (same scale and
+     angle ⇒ axis-aligned pixel translation). */
+  const PixelPoint src_tl =
+    overscan_projection.GeoToScreen(projection.ScreenToGeo({0, 0}));
+  const auto view = projection.GetScreenSize();
+
+  PixelPoint src_position{
+    src_tl.x / int(quantisation_pixels),
+    src_tl.y / int(quantisation_pixels),
+  };
+  PixelSize src_size{
+    (view.width + quantisation_pixels - 1) / quantisation_pixels,
+    (view.height + quantisation_pixels - 1) / quantisation_pixels,
+  };
+
+  const auto matrix_size = height_matrix.GetSize();
+  if (src_position.x < 0) {
+    src_size.width -= unsigned(-src_position.x);
+    src_position.x = 0;
+  }
+  if (src_position.y < 0) {
+    src_size.height -= unsigned(-src_position.y);
+    src_position.y = 0;
+  }
+  if (src_position.x >= int(matrix_size.x) ||
+      src_position.y >= int(matrix_size.y) ||
+      src_size.width == 0 || src_size.height == 0)
+    return;
+  if (src_position.x + int(src_size.width) > int(matrix_size.x))
+    src_size.width = matrix_size.x - unsigned(src_position.x);
+  if (src_position.y + int(src_size.height) > int(matrix_size.y))
+    src_size.height = matrix_size.y - unsigned(src_position.y);
+
+  image->StretchTo(src_position, src_size,
                    canvas, projection.GetScreenSize(),
                    transparent_white);
 #endif

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -4,9 +4,10 @@
 #pragma once
 
 #include "Terrain/HeightMatrix.hpp"
-
-#ifdef ENABLE_OPENGL
 #include "Geo/GeoBounds.hpp"
+
+#ifndef ENABLE_OPENGL
+#include "Projection/WindowProjection.hpp"
 #endif
 
 static constexpr unsigned NUM_COLOR_RAMP_LEVELS = 13;
@@ -46,13 +47,20 @@ class RasterRenderer {
    */
   unsigned quantisation_effective = 0;
 
-#ifdef ENABLE_OPENGL
   /**
    * The area that was rendered previously into the #HeightMatrix and
-   * the #RawBitmap.  This attribute is used to decide whether the
-   * texture has to be redrawn.
+   * the #RawBitmap.  Used to decide whether the image can be reused
+   * when panning (OpenGL texture or software overscan buffer).
    */
   GeoBounds bounds = GeoBounds::Invalid();
+
+#ifndef ENABLE_OPENGL
+  /**
+   * Projection of the overscan buffer filled by the last ScanMap().
+   * Draw() maps the visible screen into this projection to blit a
+   * sub-rectangle without regenerating terrain.
+   */
+  WindowProjection overscan_projection;
 #endif
 
   HeightMatrix height_matrix;
@@ -113,11 +121,15 @@ public:
     return quantisation_effective > 0;
   }
 
-#ifdef ENABLE_OPENGL
   void Invalidate() noexcept {
     bounds.SetInvalid();
   }
 
+  const GeoBounds &GetBounds() const noexcept {
+    return bounds;
+  }
+
+#ifdef ENABLE_OPENGL
   /**
    * Force a specific quantisation value.  Useful for preview
    * windows that should always render at full resolution
@@ -125,9 +137,7 @@ public:
    */
   void SetQuantisationPixels(unsigned q) noexcept {
     quantisation_pixels = q < 1 ? 1u : q;
-#ifdef ENABLE_OPENGL
     fixed_quantisation = true;
-#endif
   }
 
   /**
@@ -138,11 +148,14 @@ public:
    */
   bool UpdateQuantisation() noexcept;
 
-  const GeoBounds &GetBounds() const noexcept {
-    return bounds;
-  }
-
   const GLTexture &BindAndGetTexture() const noexcept;
+#else
+  /**
+   * Projection used to fill the overscan terrain buffer.
+   */
+  const WindowProjection &GetOverscanProjection() const noexcept {
+    return overscan_projection;
+  }
 #endif
 
   /**

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -306,7 +306,6 @@ TerrainRenderer::TerrainRenderer(const RasterTerrain &_terrain)
   settings.SetDefaults();
 }
 
-#ifdef ENABLE_OPENGL
 /**
  * Checks if the size difference of any dimension is more than a
  * factor of two.  This is used to check whether the terrain has to be
@@ -321,13 +320,11 @@ IsLargeSizeDifference(const GeoBounds &a, const GeoBounds &b)
   return a.GetWidth().Native() > 2 * b.GetWidth().Native() ||
     a.GetHeight().Native() > 2 * b.GetHeight().Native();
 }
-#endif
 
 bool
 TerrainRenderer::Generate(const WindowProjection &map_projection,
                           const Angle sunazimuth)
 {
-#ifdef ENABLE_OPENGL
   const GeoBounds &old_bounds = raster_renderer.GetBounds();
   GeoBounds new_bounds = map_projection.GetScreenBounds();
   assert(new_bounds.IsValid());
@@ -343,7 +340,17 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
       !IsLargeSizeDifference(old_bounds, new_bounds) &&
       terrain_serial == terrain.GetSerial() &&
       sunazimuth.CompareRoughly(last_sun_azimuth) &&
-      !raster_renderer.UpdateQuantisation()) {
+#ifdef ENABLE_OPENGL
+      !raster_renderer.UpdateQuantisation()
+#else
+      /* Software overscan is screen-aligned: reuse only when scale
+         and heading match the buffer that was filled. */
+      map_projection.GetScale() == last_projection_scale &&
+      map_projection.GetScreenAngle()
+        .CompareRoughly(raster_renderer.GetOverscanProjection()
+                          .GetScreenAngle())
+#endif
+      ) {
     /* The existing terrain image is suitable for reuse.
        But with contours: Re-use only without zoom change.
        Otherwise we can re-use as a fast preview, but
@@ -353,16 +360,6 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
         map_projection.GetScale() == last_projection_scale)
       return true;
   }
-
-#else
-  if (compare_projection.Compare(map_projection) &&
-      terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth))
-    /* no change since previous frame */
-    return true;
-
-  compare_projection = CompareProjection(map_projection);
-#endif
 
   terrain_serial = terrain.GetSerial();
 

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -6,10 +6,7 @@
 #include "RasterRenderer.hpp"
 #include "util/Serial.hpp"
 #include "Terrain/TerrainSettings.hpp"
-
-#ifndef ENABLE_OPENGL
-#include "Projection/CompareProjection.hpp"
-#endif
+#include "Math/Angle.hpp"
 
 class Canvas;
 class WindowProjection;
@@ -23,10 +20,6 @@ class TerrainRenderer {
 
 protected:
   struct TerrainRendererSettings settings;
-
-#ifndef ENABLE_OPENGL
-  CompareProjection compare_projection;
-#endif
 
   Angle last_sun_azimuth = Angle::Zero();
 
@@ -47,11 +40,7 @@ public:
    * Flush the cache.
    */
   void Flush() {
-#ifdef ENABLE_OPENGL
     raster_renderer.Invalidate();
-#else
-    compare_projection.Clear();
-#endif
   }
 
 public:

--- a/src/Terrain/Thread.cpp
+++ b/src/Terrain/Thread.cpp
@@ -6,6 +6,15 @@
 #include "Projection/WindowProjection.hpp"
 #include "thread/Util.hpp"
 
+#include <algorithm>
+
+/**
+ * Above this #WindowProjection::GetMapScale(), fine terrain tiles are
+ * not worth loading: the overview already covers the screen, and a
+ * half-screen radius would pull in thousands of kilometres of tiles.
+ */
+static constexpr double FINE_TILE_MAX_MAP_SCALE = 100000;
+
 TerrainThread::TerrainThread(RasterTerrain &_terrain,
                              std::function<void()> &&_callback)
   :StandbyThread("Terrain"), terrain(_terrain),
@@ -16,12 +25,22 @@ TerrainThread::Trigger(const WindowProjection &projection)
 {
   assert(projection.IsValid());
 
+  /* Rely on the overview cache when zoomed out; loading fine tiles
+     for a continental view is expensive and not useful for display. */
+  if (projection.GetMapScale() >= FINE_TILE_MAX_MAP_SCALE)
+    return;
+
   const std::lock_guard lock{mutex};
 
-  GeoPoint center = projection.GetGeoScreenCenter();
-  auto radius = projection.GetScreenWidthMeters() / 2;
+  const GeoPoint center = projection.GetGeoScreenCenter();
+  const auto screen_width = projection.GetScreenWidthMeters();
+  const auto radius = screen_width / 2;
+  /* Skip until the view has moved enough relative to map scale.  A
+     fixed 1 km threshold was too tight at cruise scales and woke the
+     thread on almost every pan event. */
+  const auto min_move = std::max(1000., screen_width * 0.25);
   if (last_center.IsValid() && last_radius >= radius &&
-      last_center.DistanceS(center) < 1000)
+      last_center.DistanceS(center) < min_move)
     return;
 
   next_center = center;

--- a/src/Terrain/Thread.hpp
+++ b/src/Terrain/Thread.hpp
@@ -32,6 +32,13 @@ public:
 
   void Trigger(const WindowProjection &projection);
 
+  /**
+   * Wait until the current (or pending) Tick() has finished.
+   */
+  void WaitDone() noexcept {
+    LockWaitDone();
+  }
+
 private:
   /* virtual methods from class StandbyThread*/
   void Tick() noexcept override;

--- a/src/ui/canvas/RawBitmap.hpp
+++ b/src/ui/canvas/RawBitmap.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "PortableColor.hpp"
+#include "ui/dim/Point.hpp"
 #include "ui/dim/Size.hpp"
 
 #ifdef USE_GDI
@@ -184,6 +185,18 @@ public:
 #endif
 
   void StretchTo(PixelSize src_size,
+                 Canvas &dest_canvas, PixelSize dest_size,
+                 bool transparent_white=false) const noexcept {
+    StretchTo({0, 0}, src_size, dest_canvas, dest_size,
+              transparent_white);
+  }
+
+  /**
+   * Stretch a source rectangle from this bitmap onto the destination
+   * canvas.  @p src_position is the top-left of the source rectangle
+   * within this bitmap.
+   */
+  void StretchTo(PixelPoint src_position, PixelSize src_size,
                  Canvas &dest_canvas, PixelSize dest_size,
                  bool transparent_white=false) const noexcept;
 };

--- a/src/ui/canvas/gdi/RawBitmap.cpp
+++ b/src/ui/canvas/gdi/RawBitmap.cpp
@@ -49,7 +49,7 @@ RawBitmap::~RawBitmap() noexcept
 }
 
 void
-RawBitmap::StretchTo(PixelSize src_size,
+RawBitmap::StretchTo(PixelPoint src_position, PixelSize src_size,
                      Canvas &dest_canvas, PixelSize dest_size,
                      bool transparent_white) const noexcept
 {
@@ -57,11 +57,13 @@ RawBitmap::StretchTo(PixelSize src_size,
   ::SelectObject(source_dc, bitmap);
   if (transparent_white)
     ::TransparentBlt(dest_canvas, 0, 0, dest_size.width, dest_size.height,
-                     source_dc, 0, 0, src_size.width, src_size.height,
+                     source_dc, src_position.x, src_position.y,
+                     src_size.width, src_size.height,
                      COLOR_WHITE);
   else
     ::StretchBlt(dest_canvas, 0, 0, dest_size.width, dest_size.height,
-                 source_dc, 0, 0, src_size.width, src_size.height,
+                 source_dc, src_position.x, src_position.y,
+                 src_size.width, src_size.height,
                  SRCCOPY);
   ::DeleteDC(source_dc);
 }

--- a/src/ui/canvas/memory/RawBitmap.cpp
+++ b/src/ui/canvas/memory/RawBitmap.cpp
@@ -13,7 +13,7 @@ RawBitmap::RawBitmap(PixelSize _size) noexcept
 }
 
 void
-RawBitmap::StretchTo(PixelSize src_size,
+RawBitmap::StretchTo(PixelPoint src_position, PixelSize src_size,
                      Canvas &dest_canvas, PixelSize dest_size,
                      bool transparent_white) const noexcept
 {
@@ -25,8 +25,8 @@ RawBitmap::StretchTo(PixelSize src_size,
 
   if (transparent_white)
     dest_canvas.StretchTransparentWhite({0, 0}, dest_size,
-                                        src, {0, 0}, src_size);
+                                        src, src_position, src_size);
   else
     dest_canvas.Stretch({0, 0}, dest_size,
-                        src, {0, 0}, src_size);
+                        src, src_position, src_size);
 }

--- a/src/ui/canvas/opengl/RawBitmap.cpp
+++ b/src/ui/canvas/opengl/RawBitmap.cpp
@@ -46,7 +46,7 @@ RawBitmap::BindAndGetTexture() const noexcept
 }
 
 void
-RawBitmap::StretchTo(PixelSize src_size,
+RawBitmap::StretchTo(PixelPoint src_position, PixelSize src_size,
                      [[maybe_unused]] Canvas &dest_canvas, PixelSize dest_size,
                      [[maybe_unused]] bool transparent_white) const noexcept
 {
@@ -54,5 +54,6 @@ RawBitmap::StretchTo(PixelSize src_size,
 
   OpenGL::texture_shader->Use();
 
-  texture.Draw(PixelRect{dest_size}, PixelRect{src_size});
+  texture.Draw(PixelRect{dest_size},
+               PixelRect{src_position, src_size});
 }

--- a/test/src/RunMapWindow.cpp
+++ b/test/src/RunMapWindow.cpp
@@ -7,6 +7,9 @@
 #define ENABLE_MAIN_WINDOW
 #define ENABLE_CLOSE_BUTTON
 #define ENABLE_LOOK
+#define ENABLE_CMDLINE
+#define USAGE "[OPTION]..."
+
 #include "Airspace/AirspaceGlue.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Engine/Airspace/Airspaces.hpp"
@@ -15,20 +18,34 @@
 #include "Main.hpp"
 #include "MapWindow/MapWindow.hpp"
 #include "Operation/ConsoleOperationEnvironment.hpp"
+#include "ProductName.hpp"
 #include "Profile/ComputerProfile.hpp"
 #include "Profile/Current.hpp"
 #include "Profile/Keys.hpp"
 #include "Profile/MapProfile.hpp"
+#include "Projection/Projection.hpp"
 #include "Repository/FileType.hpp"
 #include "Terrain/Loader.hpp"
 #include "Terrain/RasterTerrain.hpp"
+#include "Terrain/Thread.hpp"
 #include "Topography/TopographyGlue.hpp"
 #include "Topography/TopographyStore.hpp"
+#include "Version.hpp"
 #include "Waypoint/WaypointGlue.hpp"
 #include "io/BufferedReader.hxx"
 #include "io/ConfiguredFile.hpp"
 #include "io/FileReader.hxx"
+#include "system/Args.hpp"
+#include "system/StandardVersion.hpp"
 #include "thread/Debug.hpp"
+#include "ui/event/Notify.hpp"
+#include "util/Macros.hpp"
+#include "util/StringCompare.hxx"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
 
 void
 DeviceBlackboard::SetStartupLocation([[maybe_unused]] const GeoPoint &loc,
@@ -46,6 +63,14 @@ InDrawThread()
 
 #endif
 
+static constexpr const char canonical_name[] = "RunMapWindow";
+
+struct Options {
+  bool benchmark = false;
+};
+
+static Options options;
+
 static Waypoints way_points;
 
 static Airspaces airspace_database;
@@ -56,43 +81,263 @@ static RasterTerrain *terrain;
 class DrawThread {
 public:
 #ifndef ENABLE_OPENGL
+  /** Match production DrawThread: paint only (no sync UpdateTerrain). */
   static void Draw(MapWindow &map) {
-    map.Repaint();
-    map.UpdateAll();
     map.Repaint();
   }
 #else
-  static void UpdateAll(MapWindow &map) {
-    map.UpdateAll();
+  static void Draw(MapWindow &map) {
+    map.Invalidate();
   }
 #endif
 };
 
 class TestMapWindow final : public MapWindow {
+  bool dragging = false;
+  PixelPoint drag_start;
+  GeoPoint drag_start_geopoint;
+  Projection drag_projection;
+
+  std::unique_ptr<TerrainThread> terrain_thread;
+
+  /* Marshal TerrainThread completion onto the UI thread (like
+     GlueMapWindow::InjectRedraw). */
+  UI::Notify redraw_notify{[this]{ Redraw(); }};
+
 public:
 #ifndef ENABLE_OPENGL
-  bool initialised;
+  bool initialised = false;
 #endif
 
   TestMapWindow(const MapLook &map_look,
-             const TrafficLook &traffic_look)
+                const TrafficLook &traffic_look) noexcept
     :MapWindow(map_look, traffic_look)
-#ifndef ENABLE_OPENGL
-    , initialised(false)
-#endif
   {
+  }
+
+  ~TestMapWindow() noexcept override {
+    StopTerrainThread();
+  }
+
+  void SetTerrainThreaded(RasterTerrain *_terrain) noexcept {
+    StopTerrainThread();
+    MapWindow::SetTerrain(_terrain);
+    if (_terrain != nullptr)
+      terrain_thread = std::make_unique<TerrainThread>(
+        *_terrain,
+        [this](){ redraw_notify.SendNotification(); });
+  }
+
+  void Redraw() noexcept {
+#ifdef ENABLE_OPENGL
+    Invalidate();
+#else
+    if (initialised)
+      DrawThread::Draw(*this);
+#endif
+  }
+
+  /**
+   * Like GlueMapWindow::UpdateScreenBounds(): update bounds and wake
+   * the TerrainThread (no synchronous UpdateTiles).
+   */
+  void NotifyProjection() noexcept {
+    UpdateScreenBounds();
+    if (terrain_thread != nullptr && VisibleProjection().IsValid())
+      terrain_thread->Trigger(VisibleProjection());
+  }
+
+  void WaitTerrain() noexcept {
+    if (terrain_thread != nullptr)
+      terrain_thread->WaitDone();
+  }
+
+  void SetScaleRefresh(double scale) noexcept {
+    SetMapScale(scale);
+    NotifyProjection();
+    WaitTerrain();
+    Redraw();
+  }
+
+  void PanPixels(PixelPoint delta) noexcept {
+    const auto &proj = VisibleProjection();
+    const auto c = proj.GetScreenCenter();
+    SetLocation(proj.GetGeoLocation()
+                + proj.ScreenToGeo(c)
+                - proj.ScreenToGeo(c + delta));
+    NotifyProjection();
+    Redraw();
   }
 
   /* virtual methods from class Window */
   void OnResize(PixelSize new_size) noexcept override {
     MapWindow::OnResize(new_size);
+    if (terrain_thread != nullptr && VisibleProjection().IsValid())
+      terrain_thread->Trigger(VisibleProjection());
+    Redraw();
+  }
 
-#ifndef ENABLE_OPENGL
-    if (initialised)
-      DrawThread::Draw(*this);
-#endif
+  bool OnMouseDown(PixelPoint p) noexcept override {
+    if (!VisibleProjection().IsValid())
+      return false;
+
+    dragging = true;
+    drag_start = p;
+    drag_start_geopoint = VisibleProjection().ScreenToGeo(p);
+    drag_projection = VisibleProjection();
+    SetCapture();
+    return true;
+  }
+
+  bool OnMouseUp([[maybe_unused]] PixelPoint p) noexcept override {
+    if (!dragging)
+      return false;
+
+    dragging = false;
+    ReleaseCapture();
+
+    WaitTerrain();
+    Redraw();
+    return true;
+  }
+
+  bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override {
+    if (!dragging)
+      return MapWindow::OnMouseMove(p, keys);
+
+    SetLocation(drag_projection.GetGeoLocation()
+                + drag_start_geopoint
+                - drag_projection.ScreenToGeo(p));
+    NotifyProjection();
+    Redraw();
+    return true;
+  }
+
+  bool OnMouseWheel([[maybe_unused]] PixelPoint p, int delta) noexcept override {
+    if (dragging || !VisibleProjection().IsValid())
+      return true;
+
+    const double scale = VisibleProjection().GetMapScale();
+    if (delta > 0)
+      SetMapScale(scale / 1.5);
+    else if (delta < 0)
+      SetMapScale(scale * 1.5);
+
+    NotifyProjection();
+    WaitTerrain();
+    Redraw();
+    return true;
+  }
+
+private:
+  void StopTerrainThread() noexcept {
+    if (terrain_thread != nullptr) {
+      terrain_thread->LockStop();
+      terrain_thread.reset();
+    }
   }
 };
+
+static void
+PrintStandardHelp() noexcept
+{
+  std::printf(
+    "Usage: %s [OPTION]...\n"
+    "\n"
+    "Show a map window using the current profile (terrain, waypoints,\n"
+    "airspace). Drag to pan; mouse wheel to zoom.  Terrain tiles load via\n"
+    "TerrainThread (same path as GlueMapWindow).\n"
+    "\n"
+    "Options:\n"
+    "  --benchmark           run a fixed zoom/pan route, print timings, exit\n"
+    "  -WxH                  window size; must be first (e.g. -800x600)\n"
+    "  -h, --help            display this help and exit\n"
+    "  --version             output version information and exit\n"
+    "\n"
+    "Report bugs to: <%s>\n"
+    "%s home page: <%s>\n",
+    canonical_name, PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static void
+ParseCommandLine(Args &args)
+{
+  while (!args.IsEmpty()) {
+    const char *arg = args.PeekNext();
+    if (arg == nullptr || arg[0] != '-')
+      break;
+
+    if (StringIsEqual(arg, "-h") || StringIsEqual(arg, "--help")) {
+      PrintStandardHelp();
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--version")) {
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--benchmark")) {
+      args.GetNext();
+      options.benchmark = true;
+      continue;
+    }
+
+    break;
+  }
+}
+
+static long
+Ms(const std::chrono::steady_clock::duration d) noexcept
+{
+  return std::chrono::duration_cast<std::chrono::milliseconds>(d).count();
+}
+
+static void
+PanAtScale(TestMapWindow &map, double scale,
+           unsigned steps, PixelPoint step,
+           const char *label) noexcept
+{
+  using clock = std::chrono::steady_clock;
+
+  const auto t0 = clock::now();
+  map.SetScaleRefresh(scale);
+  const auto t1 = clock::now();
+
+  for (unsigned i = 0; i < steps; ++i) {
+    /* Oscillate so the view stays inside the terrain overscan buffer
+       (unidirectional pan exits a 1.5–2× buffer within a few steps). */
+    const int x = (i & 2) != 0 ? -step.x : step.x;
+    const int y = (i & 1) != 0 ? step.y : -step.y;
+    map.PanPixels({x, y});
+    map.WaitTerrain();
+  }
+  const auto t2 = clock::now();
+
+  std::printf("%s: first %ld ms, pan %ld ms, total %ld ms "
+              "(%u steps @ %.0f km)\n",
+              label, Ms(t1 - t0), Ms(t2 - t1), Ms(t2 - t0),
+              steps, scale / 1000.);
+}
+
+static void
+RunBenchmark(TestMapWindow &map) noexcept
+{
+  using clock = std::chrono::steady_clock;
+
+  const auto t0 = clock::now();
+
+  /* Wide scales first so TerrainThread skip/throttle is visible before
+     fine tiles are warmed by closer zooms. */
+  PanAtScale(map, 300000, 24, {80, 40}, "pan_300km");
+  PanAtScale(map, 150000, 24, {80, 40}, "pan_150km");
+  PanAtScale(map, 100000, 24, {80, 40}, "pan_100km");
+  PanAtScale(map, 50000, 24, {80, 40}, "pan_50km");
+  PanAtScale(map, 10000, 40, {40, 20}, "pan_10km");
+
+  std::printf("total: %ld ms\n", Ms(clock::now() - t0));
+  std::fflush(stdout);
+}
 
 static void
 LoadFiles(PlacesOfInterestSettings &poi_settings,
@@ -148,7 +393,9 @@ GenerateBlackboard(MapWindow &map, const ComputerSettings &settings_computer,
   derived_info.Reset();
   derived_info.terrain_valid = true;
 
-  if (terrain != nullptr)
+  /* Warm fine tiles only for interactive mode; benchmark starts cold
+     at 300 km so TerrainThread behaviour is measurable. */
+  if (!options.benchmark && terrain != nullptr)
     while (terrain->UpdateTiles(nmea_info.location, 50000)) {}
 
   map.ReadBlackboard(nmea_info, derived_info, settings_computer,
@@ -174,21 +421,30 @@ Main(TestMainWindow &main_window)
   map.SetWaypoints(&way_points);
   map.SetAirspaces(&airspace_database);
   map.SetTopography(topography);
-  map.SetTerrain(terrain);
+  map.SetTerrainThreaded(terrain);
   if (terrain != nullptr)
     map.SetLocation(terrain->GetTerrainCenter());
   map.Create(main_window, main_window.GetClientRect());
   main_window.SetFullWindow(map);
 
   GenerateBlackboard(map, settings_computer, settings_map);
-#ifdef ENABLE_OPENGL
-  DrawThread::UpdateAll(map);
-#else
-  DrawThread::Draw(map);
+#ifndef ENABLE_OPENGL
   map.initialised = true;
 #endif
 
-  main_window.RunEventLoop();
+  if (options.benchmark) {
+    /* Start cold at 300 km so fine-tile Trigger() is skipped until
+       the closer phases — matches production TerrainThread gating. */
+    map.SetMapScale(300000);
+    map.NotifyProjection();
+    DrawThread::Draw(map);
+    RunBenchmark(map);
+  } else {
+    map.NotifyProjection();
+    map.WaitTerrain();
+    DrawThread::Draw(map);
+    main_window.RunEventLoop();
+  }
 
   delete terrain;
   delete topography;


### PR DESCRIPTION
## Summary
- Throttle `TerrainThread` fine-tile loads with a scale-relative pan threshold, and skip fine tiles at ≥100 km map scale (overview is enough).
- On non-OpenGL builds, reuse a 2× overscan terrain buffer while panning (same idea as OpenGL) so frames blit instead of regenerating the height matrix.
- Extend `RunMapWindow --benchmark` to drive `TerrainThread` like `GlueMapWindow` for A/B timing.

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX OPENGL=n USE_CCACHE=y WERROR=y output/UNIX/bin/RunMapWindow`
- [ ] `output/UNIX/bin/RunMapWindow -800x600 --benchmark` — expect cheap pan loops after the first frame at 300 km
- [ ] Manual: pan at ~300 km and ~10 km on `OPENGL=n`; terrain should stay coherent without stutter from full regenerates on small pans
- [ ] Spot-check OpenGL build still pans/zooms normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved terrain rendering smoothness while panning by reducing unnecessary tile reloads and reusing rendered terrain buffers.
  * Reduced fine-tile loading at overview scales, improving responsiveness when zoomed far out.
  * Updated software rendering to display only the visible portion of oversized terrain buffers.

* **Bug Fixes**
  * Improved terrain updates across supported rendering modes, helping prevent unnecessary redraws during map movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->