### PR TITLE
Fix white rectangles around logo on startup profile selector

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -17,6 +17,8 @@ Version 7.45 - not yet released
     to filter self and additional own aircraft from OGN when the device
     radio id is unavailable (e.g. LX passthrough) #2693
 * ui
+  - Fix white rectangles around the logo on the startup profile selector
+    #2742
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude
     on the selected target (info panel already shows them) #2718

--- a/src/Dialogs/SimulatorPromptWindow.cpp
+++ b/src/Dialogs/SimulatorPromptWindow.cpp
@@ -98,7 +98,7 @@ SimulatorPromptWindow::OnResize(PixelSize new_size) noexcept
 void
 SimulatorPromptWindow::OnPaint(Canvas &canvas) noexcept
 {
-#ifdef ENABLE_OPENGL
+#if defined(ENABLE_OPENGL) || (defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE))
   DrawVerticalGradient(canvas, GetClientRect(),
                        COLOR_XCSOAR, COLOR_XCSOAR_DARK,
                        COLOR_XCSOAR_DARK);
@@ -107,11 +107,7 @@ SimulatorPromptWindow::OnPaint(Canvas &canvas) noexcept
   canvas.Select(look.text_font);
   canvas.SetTextColor(COLOR_WHITE);
 #else
-  /* Without OpenGL there is no alpha blending — GDI uses BMP
-     resources and the software renderer uses pre-composited PNGs,
-     both with opaque white backgrounds.  A dark/gradient background
-     would show visible white rectangles around every bitmap.
-     Use a plain white background instead. */
+  /* GDI / greyscale: opaque BMP backgrounds still need a white pane. */
   canvas.ClearWhite();
   logo_view.draw(canvas, logo_rect);
 

--- a/src/Dialogs/StartupDialog.cpp
+++ b/src/Dialogs/StartupDialog.cpp
@@ -7,14 +7,17 @@
 #include "Form/DataField/File.hpp"
 #include "Form/Form.hpp"
 #include "Gauge/LogoView.hpp"
+#include "GlobalSettings.hpp"
 #include "Language/Language.hpp"
 #include "LocalPath.hpp"
 #include "LogFile.hpp"
+#include "Look/Colors.hpp"
 #include "Look/DialogLook.hpp"
 #include "Profile/Profile.hpp"
 #include "Repository/FileType.hpp"
 #include "ProfileListDialog.hpp"
 #include "ProfilePasswordDialog.hpp"
+#include "Renderer/GradientRenderer.hpp"
 #include "Screen/Layout.hpp"
 #include "UIGlobals.hpp"
 #include "Widget/RowFormWidget.hpp"
@@ -24,35 +27,49 @@
 #include "ui/canvas/Canvas.hpp"
 
 class LogoWindow final : public PaintWindow {
+#ifndef ENABLE_OPENGL
+  const DialogLook &look;
+#endif
   LogoView logo;
-  bool dark_mode;
 
 public:
-  explicit LogoWindow(bool _dark_mode = false,
-                     Color _background_color = COLOR_WHITE) noexcept
-    :dark_mode(_dark_mode), background_color(_background_color) {}
+#ifdef ENABLE_OPENGL
+  LogoWindow() noexcept = default;
+#else
+  explicit LogoWindow(const DialogLook &_look) noexcept
+    :look(_look) {}
+#endif
 
 protected:
   void OnPaint(Canvas &canvas) noexcept override {
-    canvas.Clear(background_color);
-    logo.draw(canvas, GetClientRect(), dark_mode);
+#ifdef ENABLE_OPENGL
+    /* Branded splash background (same as SimulatorPromptWindow).
+       Logo art is always light-on-dark on this blue gradient. */
+    DrawVerticalGradient(canvas, GetClientRect(),
+                         COLOR_XCSOAR, COLOR_XCSOAR_DARK,
+                         COLOR_XCSOAR_DARK);
+    logo.draw(canvas, GetClientRect(), true);
+#else
+    canvas.Clear(look.background_color);
+    logo.draw(canvas, GetClientRect(), look.dark_mode);
+#endif
   }
-
-private:
-  Color background_color;
 };
 
 class LogoQuitWidget final : public NullWidget {
-  const ButtonLook &look;
+  const DialogLook &look;
   WndForm &dialog;
 
   LogoWindow logo;
   Button quit;
 
 public:
-  LogoQuitWidget(const ButtonLook &_look, WndForm &_dialog,
-                 bool dark_mode, Color background_color) noexcept
-    :look(_look), dialog(_dialog), logo(dark_mode, background_color) {}
+  LogoQuitWidget(const DialogLook &_look, WndForm &_dialog) noexcept
+    :look(_look), dialog(_dialog)
+#ifndef ENABLE_OPENGL
+    , logo(_look)
+#endif
+  {}
 
 private:
   PixelRect GetButtonRect(PixelRect rc) noexcept {
@@ -81,7 +98,7 @@ public:
     button_style.Hide();
     button_style.TabStop();
 
-    quit.Create(parent, look, _("Quit"), rc,
+    quit.Create(parent, look.button, _("Quit"), rc,
                 button_style, dialog.MakeModalResultCallback(mrCancel));
     logo.Create(parent, rc, style);
   }
@@ -227,15 +244,15 @@ dlgStartupShowModal() noexcept
 
   dff->SetIndex(best_index);
 
-  /* show the dialog */
-  const DialogLook &look = UIGlobals::GetDialogLook();
+  /* Profile is not loaded yet; follow system AUTO like ProgressWindow. */
+  DialogLook look;
+  look.Initialise(GlobalSettings::dark_mode);
+
   TWidgetDialog<TwoWidgets> dialog(WidgetDialog::Full{},
                                    UIGlobals::GetMainWindow(),
-                                   UIGlobals::GetDialogLook(),
-                                   nullptr);
+                                   look, nullptr);
 
-  dialog.SetWidget(std::make_unique<LogoQuitWidget>(look.button, dialog,
-                                                    look.dark_mode, look.background_color),
+  dialog.SetWidget(std::make_unique<LogoQuitWidget>(look, dialog),
                    std::make_unique<StartupWidget>(look, dialog, dff));
 
   return dialog.ShowModal() == mrOK;

--- a/src/Dialogs/StartupDialog.cpp
+++ b/src/Dialogs/StartupDialog.cpp
@@ -26,14 +26,18 @@
 #include "system/FileUtil.hpp"
 #include "ui/canvas/Canvas.hpp"
 
+#if defined(ENABLE_OPENGL) || (defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE))
+#define HAVE_STARTUP_BRANDED_SPLASH
+#endif
+
 class LogoWindow final : public PaintWindow {
-#ifndef ENABLE_OPENGL
+#ifndef HAVE_STARTUP_BRANDED_SPLASH
   const DialogLook &look;
 #endif
   LogoView logo;
 
 public:
-#ifdef ENABLE_OPENGL
+#ifdef HAVE_STARTUP_BRANDED_SPLASH
   LogoWindow() noexcept = default;
 #else
   explicit LogoWindow(const DialogLook &_look) noexcept
@@ -42,7 +46,7 @@ public:
 
 protected:
   void OnPaint(Canvas &canvas) noexcept override {
-#ifdef ENABLE_OPENGL
+#ifdef HAVE_STARTUP_BRANDED_SPLASH
     /* Branded splash background (same as SimulatorPromptWindow).
        Logo art is always light-on-dark on this blue gradient. */
     DrawVerticalGradient(canvas, GetClientRect(),
@@ -66,7 +70,7 @@ class LogoQuitWidget final : public NullWidget {
 public:
   LogoQuitWidget(const DialogLook &_look, WndForm &_dialog) noexcept
     :look(_look), dialog(_dialog)
-#ifndef ENABLE_OPENGL
+#ifndef HAVE_STARTUP_BRANDED_SPLASH
     , logo(_look)
 #endif
   {}

--- a/src/Gauge/LogoView.cpp
+++ b/src/Gauge/LogoView.cpp
@@ -20,11 +20,12 @@ LogoView::LogoView() noexcept try
    title(IDB_TITLE), big_title(IDB_TITLE_HD), huge_title(IDB_TITLE_UHD)
 {
 #ifndef USE_WIN32_RESOURCES
-  /* Load RGBA logo variants for dark mode (transparent background) */
+  /* Transparent variants for OpenGL compositing on tinted dialog
+     backgrounds (light and dark). */
   logo_rgba.Load(IDB_LOGO_RGBA);
   big_logo_rgba.Load(IDB_LOGO_HD_RGBA);
   huge_logo_rgba.Load(IDB_LOGO_UHD_RGBA);
-  /* Load white title variants for dark mode */
+  title_rgba.Load(IDB_TITLE_HD_RGBA);
   white_title.Load(IDB_TITLE_HD_WHITE);
   huge_white_title.Load(IDB_TITLE_UHD_WHITE);
 #endif
@@ -78,6 +79,20 @@ EstimateLogoViewSize(LogoViewOrientation orientation,
   gcc_unreachable();
 }
 
+#ifdef ENABLE_OPENGL
+/**
+ * If @a selected points at @a match and @a variant is loaded, switch
+ * to the variant (used for transparent OpenGL assets).
+ */
+static void
+UseVariant(const Bitmap *&selected,
+           const Bitmap &match, const Bitmap &variant) noexcept
+{
+  if (selected == &match && variant.IsDefined())
+    selected = &variant;
+}
+#endif
+
 void
 LogoView::draw(Canvas &canvas, const PixelRect &rc,
                bool dark_mode) noexcept
@@ -97,14 +112,12 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   else
     orientation = LogoViewOrientation::PORTRAIT;
 
-  /* Select appropriate bitmap size based on display dimensions */
-  /* Pick the highest-resolution bitmap that IsDefined() (fall back from huge -> big -> logo) */
+  /* Pick the highest-resolution bitmap that IsDefined() */
   const Bitmap *bitmap_logo, *bitmap_title;
-  
+
   if ((orientation == LogoViewOrientation::LANDSCAPE && width >= 1024 && height >= 340) ||
       (orientation == LogoViewOrientation::PORTRAIT && width >= 660 && height >= 500) ||
       (orientation == LogoViewOrientation::SQUARE && width >= 420 && height >= 420)) {
-    /* Use huge (320px logo, 640px title) for very high resolution displays */
     if (huge_logo.IsDefined() && huge_title.IsDefined()) {
       bitmap_logo = &huge_logo;
       bitmap_title = &huge_title;
@@ -118,7 +131,6 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   } else if ((orientation == LogoViewOrientation::LANDSCAPE && width >= 510 && height >= 170) ||
              (orientation == LogoViewOrientation::PORTRAIT && width >= 330 && height >= 250) ||
              (orientation == LogoViewOrientation::SQUARE && width >= 210 && height >= 210)) {
-    /* Use big (160px logo, 320px title) for HD displays */
     if (big_logo.IsDefined() && big_title.IsDefined()) {
       bitmap_logo = &big_logo;
       bitmap_title = &big_title;
@@ -127,25 +139,30 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
       bitmap_title = &title;
     }
   } else {
-    /* Use standard (80px logo, 110px title) for low resolution displays */
     bitmap_logo = &logo;
     bitmap_title = &title;
   }
 
-  /* In dark mode, use RGBA logos (transparent background) if available */
+#ifdef ENABLE_OPENGL
+  /* Opaque BMP-derived assets leave white squares on tinted dialog
+     backgrounds; prefer transparent variants when available. */
+  UseVariant(bitmap_logo, huge_logo, huge_logo_rgba);
+  UseVariant(bitmap_logo, big_logo, big_logo_rgba);
+  UseVariant(bitmap_logo, logo, logo_rgba);
+
   if (dark_mode) {
-    if (bitmap_logo == &huge_logo && huge_logo_rgba.IsDefined())
-      bitmap_logo = &huge_logo_rgba;
-    else if (bitmap_logo == &big_logo && big_logo_rgba.IsDefined())
-      bitmap_logo = &big_logo_rgba;
-    else if (bitmap_logo == &logo && logo_rgba.IsDefined())
-      bitmap_logo = &logo_rgba;
+    UseVariant(bitmap_title, huge_title, huge_white_title);
+    /* Fall back UHD→HD white title without replacing base SD. */
+    UseVariant(bitmap_title, huge_title, white_title);
+    UseVariant(bitmap_title, big_title, white_title);
+  } else {
+    /* No UHD black RGBA title; fall back to HD. */
+    UseVariant(bitmap_title, huge_title, title_rgba);
+    UseVariant(bitmap_title, big_title, title_rgba);
   }
+#endif
 
-  // Determine logo size
   PixelSize logo_size = bitmap_logo->GetSize();
-
-  // Determine title image size
   PixelSize title_size = bitmap_title->GetSize();
 
   unsigned spacing = title_size.height / 2;
@@ -167,7 +184,6 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
 
   PixelPoint logo_position, title_position;
 
-  // Determine logo and title positions
   switch (orientation) {
   case LogoViewOrientation::LANDSCAPE:
     logo_position.x = Center(width, logo_size.width + spacing + title_size.width);
@@ -184,7 +200,6 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   case LogoViewOrientation::SQUARE:
     logo_position.x = Center(width, logo_size.width);
     logo_position.y = Center(height, logo_size.height);
-    // not needed - silence compiler "may be used uninitialized"
     title_position.x = 0;
     title_position.y = 0;
     break;
@@ -192,36 +207,19 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
     gcc_unreachable();
   }
 
-  // Draw 'XCSoar N.N' title
   if (orientation != LogoViewOrientation::SQUARE) {
-    const Bitmap *draw_title = bitmap_title;
 #ifdef ENABLE_OPENGL
-    /* On OpenGL, use white title variants for dark mode
-       (they have alpha and composite correctly).
-       On non-OpenGL, keep the standard (black) title since
-       the memory canvas composites alpha against white. */
-    if (dark_mode) {
-      if (bitmap_title == &huge_title &&
-          huge_white_title.IsDefined())
-        draw_title = &huge_white_title;
-      else if (white_title.IsDefined())
-        draw_title = &white_title;
-    }
-
     const ScopeAlphaBlend alpha_blend;
 #endif
-    canvas.Stretch(title_position, title_size, *draw_title);
+    canvas.Stretch(title_position, title_size, *bitmap_title);
   }
 
-  // Draw XCSoar swift logo
   {
 #ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
 #endif
     canvas.Stretch(logo_position, logo_size, *bitmap_logo);
   }
-
-  // Draw full XCSoar version number
 
 #ifndef USE_GDI
   if (!font.IsDefined())
@@ -240,30 +238,23 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   if (bold_font.IsDefined())
     canvas.Select(bold_font);
 #endif
-  
+
   const char *warning_text = "DEBUG BUILD - DO NOT FLY!";
   const auto text_size = canvas.CalcTextSize(warning_text);
-  
-  /* Half character padding (max) */
+
   const int padding = text_size.height / 2;
   const int banner_height = text_size.height + padding * 2;
   const int banner_width = text_size.width + padding * 2;
-  
-  /* Position banner below the logo/title with some spacing */
+
   int banner_y;
-  if (orientation == LogoViewOrientation::PORTRAIT) {
-    // Below title in portrait mode
+  if (orientation == LogoViewOrientation::PORTRAIT)
     banner_y = title_position.y + title_size.height + spacing / 2;
-  } else if (orientation == LogoViewOrientation::SQUARE) {
-    // Below logo in square mode
+  else if (orientation == LogoViewOrientation::SQUARE)
     banner_y = logo_position.y + logo_size.height + spacing / 2;
-  } else {
-    // Below whichever is lower in landscape mode
+  else
     banner_y = std::max(logo_position.y + logo_size.height,
-                       title_position.y + title_size.height) + spacing / 2;
-  }
-  
-  /* Only draw if banner fits within the visible area */
+                        title_position.y + title_size.height) + spacing / 2;
+
   if (banner_y + banner_height <= int(height)) {
     const PixelRect warning_rect{
       Center(width, banner_width),
@@ -271,17 +262,14 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
       Center(width, banner_width) + banner_width,
       banner_y + banner_height
     };
-    
+
     canvas.DrawFilledRectangle(warning_rect, COLOR_RED);
     canvas.SetTextColor(COLOR_WHITE);
     canvas.SetBackgroundTransparent();
-    
-    const PixelPoint text_pos{
-      warning_rect.left + padding,
-      warning_rect.top + padding
-    };
-    
-    canvas.DrawText(text_pos, warning_text);
+
+    canvas.DrawText({warning_rect.left + padding,
+                     warning_rect.top + padding},
+                    warning_text);
   }
 #endif
 }

--- a/src/Gauge/LogoView.cpp
+++ b/src/Gauge/LogoView.cpp
@@ -210,15 +210,22 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   if (orientation != LogoViewOrientation::SQUARE) {
 #ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
-#endif
     canvas.Stretch(title_position, title_size, *bitmap_title);
+#else
+    /* Opaque BMP titles have a white background; key it out so tinted
+       dialog panes do not show white rectangles. */
+    canvas.StretchTransparentWhite(title_position, title_size,
+                                   *bitmap_title);
+#endif
   }
 
   {
 #ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
-#endif
     canvas.Stretch(logo_position, logo_size, *bitmap_logo);
+#else
+    canvas.StretchTransparentWhite(logo_position, logo_size, *bitmap_logo);
+#endif
   }
 
 #ifndef USE_GDI

--- a/src/Gauge/LogoView.cpp
+++ b/src/Gauge/LogoView.cpp
@@ -15,12 +15,19 @@
 
 #include <algorithm>
 
+/* OpenGL composites RGBA textures with ScopeAlphaBlend.  Colour
+   memory canvases keep per-pixel alpha and use StretchWithSourceAlpha.
+   Greyscale and GDI fall back to white-keyed opaque bitmaps. */
+#if defined(ENABLE_OPENGL) || (defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE))
+#define HAVE_LOGO_SOURCE_ALPHA
+#endif
+
 LogoView::LogoView() noexcept try
   :logo(IDB_LOGO), big_logo(IDB_LOGO_HD), huge_logo(IDB_LOGO_UHD),
    title(IDB_TITLE), big_title(IDB_TITLE_HD), huge_title(IDB_TITLE_UHD)
 {
 #ifndef USE_WIN32_RESOURCES
-  /* Transparent variants for OpenGL compositing on tinted dialog
+  /* Transparent variants for compositing on tinted dialog
      backgrounds (light and dark). */
   logo_rgba.Load(IDB_LOGO_RGBA);
   big_logo_rgba.Load(IDB_LOGO_HD_RGBA);
@@ -79,10 +86,10 @@ EstimateLogoViewSize(LogoViewOrientation orientation,
   gcc_unreachable();
 }
 
-#ifdef ENABLE_OPENGL
+#ifdef HAVE_LOGO_SOURCE_ALPHA
 /**
  * If @a selected points at @a match and @a variant is loaded, switch
- * to the variant (used for transparent OpenGL assets).
+ * to the variant (transparent splash art).
  */
 static void
 UseVariant(const Bitmap *&selected,
@@ -92,6 +99,20 @@ UseVariant(const Bitmap *&selected,
     selected = &variant;
 }
 #endif
+
+static void
+DrawSplashBitmap(Canvas &canvas, PixelPoint position, PixelSize size,
+                 const Bitmap &bitmap) noexcept
+{
+#ifdef ENABLE_OPENGL
+  const ScopeAlphaBlend alpha_blend;
+  canvas.Stretch(position, size, bitmap);
+#elif defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE)
+  canvas.StretchWithSourceAlpha(position, size, bitmap);
+#else
+  canvas.StretchTransparentWhite(position, size, bitmap);
+#endif
+}
 
 void
 LogoView::draw(Canvas &canvas, const PixelRect &rc,
@@ -143,7 +164,7 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
     bitmap_title = &title;
   }
 
-#ifdef ENABLE_OPENGL
+#ifdef HAVE_LOGO_SOURCE_ALPHA
   /* Opaque BMP-derived assets leave white squares on tinted dialog
      backgrounds; prefer transparent variants when available. */
   UseVariant(bitmap_logo, huge_logo, huge_logo_rgba);
@@ -207,26 +228,10 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
     gcc_unreachable();
   }
 
-  if (orientation != LogoViewOrientation::SQUARE) {
-#ifdef ENABLE_OPENGL
-    const ScopeAlphaBlend alpha_blend;
-    canvas.Stretch(title_position, title_size, *bitmap_title);
-#else
-    /* Opaque BMP titles have a white background; key it out so tinted
-       dialog panes do not show white rectangles. */
-    canvas.StretchTransparentWhite(title_position, title_size,
-                                   *bitmap_title);
-#endif
-  }
+  if (orientation != LogoViewOrientation::SQUARE)
+    DrawSplashBitmap(canvas, title_position, title_size, *bitmap_title);
 
-  {
-#ifdef ENABLE_OPENGL
-    const ScopeAlphaBlend alpha_blend;
-    canvas.Stretch(logo_position, logo_size, *bitmap_logo);
-#else
-    canvas.StretchTransparentWhite(logo_position, logo_size, *bitmap_logo);
-#endif
-  }
+  DrawSplashBitmap(canvas, logo_position, logo_size, *bitmap_logo);
 
 #ifndef USE_GDI
   if (!font.IsDefined())

--- a/src/Gauge/LogoView.hpp
+++ b/src/Gauge/LogoView.hpp
@@ -12,7 +12,7 @@ class Canvas;
 class LogoView {
   Bitmap logo, big_logo, huge_logo, title, big_title, huge_title;
   Bitmap logo_rgba, big_logo_rgba, huge_logo_rgba;
-  Bitmap white_title, huge_white_title;
+  Bitmap title_rgba, white_title, huge_white_title;
 
 #ifndef USE_GDI
   Font font;
@@ -29,7 +29,7 @@ public:
    *
    * @param canvas the Canvas to draw on
    * @param rc the region within the Canvas to draw into
-   * @param dark_mode if true, use light-on-dark colors and white title
+   * @param dark_mode if true, use light text and white title art
    */
   void draw(Canvas &canvas, const PixelRect &rc,
             bool dark_mode = false) noexcept;

--- a/src/Renderer/BitmapButtonRenderer.cpp
+++ b/src/Renderer/BitmapButtonRenderer.cpp
@@ -19,16 +19,22 @@ void
 BitmapButtonRenderer::DrawButton(Canvas &canvas, [[maybe_unused]] const PixelRect &rc,
                                  ButtonState state) const noexcept
 {
-#ifdef ENABLE_OPENGL
   if (use_alpha) {
+#ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
     if (state == ButtonState::PRESSED)
       canvas.StretchNot(bitmap);
     else
       canvas.Stretch(bitmap);
     return;
-  }
+#elif defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE)
+    if (state == ButtonState::PRESSED)
+      canvas.StretchNot(bitmap);
+    else
+      canvas.StretchWithSourceAlpha({0, 0}, canvas.GetSize(), bitmap);
+    return;
 #endif
+  }
 
   if (state == ButtonState::PRESSED)
     canvas.StretchNot(bitmap);

--- a/src/ui/canvas/gdi/Canvas.cpp
+++ b/src/ui/canvas/gdi/Canvas.cpp
@@ -212,6 +212,23 @@ Canvas::CopyTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
 }
 
 void
+Canvas::StretchTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
+                                const Bitmap &src) noexcept
+{
+  assert(IsDefined());
+  assert(src.IsDefined());
+
+  HDC virtual_dc = GetCompatibleDC();
+  HBITMAP old = (HBITMAP)::SelectObject(virtual_dc, src.GetNative());
+  ::TransparentBlt(dc, dest_position.x, dest_position.y,
+                   dest_size.width, dest_size.height,
+                   virtual_dc, 0, 0,
+                   src.GetWidth(), src.GetHeight(),
+                   COLOR_WHITE);
+  ::SelectObject(virtual_dc, old);
+}
+
+void
 Canvas::StretchNot(const Bitmap &src)
 {
   assert(IsDefined());

--- a/src/ui/canvas/gdi/Canvas.hpp
+++ b/src/ui/canvas/gdi/Canvas.hpp
@@ -418,6 +418,12 @@ public:
                             const Canvas &src,
                             PixelPoint src_position) noexcept;
 
+  /**
+   * Stretch a bitmap, treating white source pixels as transparent.
+   */
+  void StretchTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
+                               const Bitmap &src) noexcept;
+
   void StretchNot(const Bitmap &src);
 
   void Stretch(PixelPoint dest_position, PixelSize dest_size,

--- a/src/ui/canvas/memory/Canvas.cpp
+++ b/src/ui/canvas/memory/Canvas.cpp
@@ -685,3 +685,49 @@ Canvas::AlphaBlendNotWhite(PixelPoint dest_position, PixelSize dest_size,
                      src.buffer, src_position, src_size,
                      alpha);
 }
+
+void
+Canvas::StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                               ConstImageBuffer src,
+                               PixelPoint src_position,
+                               PixelSize src_size) noexcept
+{
+  SDLRasterCanvas canvas(buffer);
+
+#ifdef GREYSCALE
+  /* Greyscale buffers store no alpha; fall back to opaque stretch. */
+  canvas.ScaleRectangle(dest_position, dest_size,
+                        src.At(src_position.x, src_position.y),
+                        src.pitch, src_size);
+#else
+  SourceAlphaPixelOperations<ActivePixelTraits> operations;
+
+  canvas.ScaleRectangle(dest_position, dest_size,
+                        src.At(src_position.x, src_position.y),
+                        src.pitch, src_size,
+                        operations);
+#endif
+}
+
+void
+Canvas::StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                               const Bitmap &src) noexcept
+{
+  assert(src.IsDefined());
+
+  ConstImageBuffer buffer = src.GetNative();
+  StretchWithSourceAlpha(dest_position, dest_size,
+                         buffer, {0, 0}, buffer.size);
+}
+
+void
+Canvas::StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                               const Bitmap &src,
+                               PixelPoint src_position,
+                               PixelSize src_size) noexcept
+{
+  assert(src.IsDefined());
+
+  StretchWithSourceAlpha(dest_position, dest_size,
+                         src.GetNative(), src_position, src_size);
+}

--- a/src/ui/canvas/memory/Canvas.cpp
+++ b/src/ui/canvas/memory/Canvas.cpp
@@ -413,6 +413,17 @@ Canvas::StretchTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
 }
 
 void
+Canvas::StretchTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
+                                const Bitmap &src) noexcept
+{
+  assert(src.IsDefined());
+
+  ConstImageBuffer buffer = src.GetNative();
+  StretchTransparentWhite(dest_position, dest_size,
+                          buffer, {0, 0}, buffer.size);
+}
+
+void
 Canvas::StretchNot(const Bitmap &_src)
 {
   assert(_src.IsDefined());

--- a/src/ui/canvas/memory/Canvas.cpp
+++ b/src/ui/canvas/memory/Canvas.cpp
@@ -608,19 +608,24 @@ Canvas::DrawRoundRectangle(PixelRect r, PixelSize ellipse_size) noexcept
 void
 Canvas::AlphaBlend(PixelPoint dest_position, PixelSize dest_size,
                    ConstImageBuffer src,
-                   PixelPoint src_position, [[maybe_unused]] PixelSize src_size,
+                   PixelPoint src_position, PixelSize src_size,
                    uint8_t alpha)
 {
-  // TODO: support scaling
-
   SDLRasterCanvas canvas(buffer);
 
   AlphaPixelOperations<ActivePixelTraits> operations(alpha);
 
-  canvas.CopyRectangle(dest_position.x, dest_position.y,
-                       dest_size.width, dest_size.height,
-                       src.At(src_position.x, src_position.y), src.pitch,
-                       operations);
+  if (dest_size == src_size)
+    /* 1:1 fast path without the scaling arithmetic */
+    canvas.CopyRectangle(dest_position.x, dest_position.y,
+                         dest_size.width, dest_size.height,
+                         src.At(src_position.x, src_position.y), src.pitch,
+                         operations);
+  else
+    canvas.ScaleRectangle(dest_position, dest_size,
+                          src.At(src_position.x, src_position.y),
+                          src.pitch, src_size,
+                          operations);
 }
 
 void
@@ -637,21 +642,26 @@ Canvas::AlphaBlend(PixelPoint dest_position, PixelSize dest_size,
 void
 Canvas::AlphaBlendNotWhite(PixelPoint dest_position, PixelSize dest_size,
                            ConstImageBuffer src,
-                           PixelPoint src_position, [[maybe_unused]] PixelSize src_size,
+                           PixelPoint src_position, PixelSize src_size,
                            uint8_t alpha)
 {
-  // TODO: support scaling
-
   SDLRasterCanvas canvas(buffer);
 
   NotWhiteCondition<ActivePixelTraits> c;
   NotWhiteAlphaPixelOperations<ActivePixelTraits> operations(c,
                                                              PortableAlphaPixelOperations<ActivePixelTraits>(alpha));
 
-  canvas.CopyRectangle(dest_position.x, dest_position.y,
-                       dest_size.width, dest_size.height,
-                       src.At(src_position.x, src_position.y), src.pitch,
-                       operations);
+  if (dest_size == src_size)
+    /* 1:1 fast path without the scaling arithmetic */
+    canvas.CopyRectangle(dest_position.x, dest_position.y,
+                         dest_size.width, dest_size.height,
+                         src.At(src_position.x, src_position.y), src.pitch,
+                         operations);
+  else
+    canvas.ScaleRectangle(dest_position, dest_size,
+                          src.At(src_position.x, src_position.y),
+                          src.pitch, src_size,
+                          operations);
 }
 
 void

--- a/src/ui/canvas/memory/Canvas.hpp
+++ b/src/ui/canvas/memory/Canvas.hpp
@@ -329,6 +329,9 @@ public:
                                ConstImageBuffer src, PixelPoint src_position,
                                PixelSize src_size) noexcept;
 
+  void StretchTransparentWhite(PixelPoint dest_position, PixelSize dest_size,
+                               const Bitmap &src) noexcept;
+
   void StretchNot(const Bitmap &src);
 
   void Stretch(PixelPoint dest_position, PixelSize dest_size,

--- a/src/ui/canvas/memory/Canvas.hpp
+++ b/src/ui/canvas/memory/Canvas.hpp
@@ -439,4 +439,20 @@ public:
                           const Canvas src,
                           PixelPoint src_position, PixelSize src_size,
                           uint8_t alpha);
+
+  /**
+   * Stretch with per-pixel alpha blending from the source buffer.
+   */
+  void StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                              ConstImageBuffer src,
+                              PixelPoint src_position,
+                              PixelSize src_size) noexcept;
+
+  void StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                              const Bitmap &src) noexcept;
+
+  void StretchWithSourceAlpha(PixelPoint dest_position, PixelSize dest_size,
+                              const Bitmap &src,
+                              PixelPoint src_position,
+                              PixelSize src_size) noexcept;
 };

--- a/src/ui/canvas/memory/PixelOperations.hpp
+++ b/src/ui/canvas/memory/PixelOperations.hpp
@@ -458,3 +458,45 @@ public:
       PixelTraits::WritePixel(p, (*this)(c));
   }
 };
+
+/**
+ * Blend a single channel using alpha.
+ */
+static constexpr uint8_t
+BlendChannel(uint8_t dest, uint8_t src, uint8_t alpha) noexcept
+{
+  return dest + ((int(src - dest) * alpha) >> 8);
+}
+
+/**
+ * Blend source and destination color using the alpha channel from
+ * the source pixel.
+ */
+template<AnyPixelTraits PT>
+struct PixelSourceAlpha {
+  using PixelTraits = PT;
+  using color_type = typename PixelTraits::color_type;
+  using channel_type = typename PixelTraits::channel_type;
+
+  using SourcePixelTraits = PT;
+
+  constexpr color_type operator()(color_type dest, color_type src) const {
+    const uint8_t alpha = src.Alpha();
+    if (alpha == 0)
+      return dest;
+    if (alpha == 0xff)
+      return src;
+
+    return color_type(BlendChannel(dest.Red(), src.Red(), alpha),
+                      BlendChannel(dest.Green(), src.Green(), alpha),
+                      BlendChannel(dest.Blue(), src.Blue(), alpha),
+                      alpha);
+  }
+};
+
+/**
+ * Per-pixel alpha blending operations using source pixel's alpha channel.
+ */
+template<AnyPixelTraits PixelTraits>
+using SourceAlphaPixelOperations =
+  BinaryPerPixelOperations<PixelSourceAlpha<PixelTraits>>;

--- a/src/ui/canvas/memory/UncompressedImage.hpp
+++ b/src/ui/canvas/memory/UncompressedImage.hpp
@@ -18,10 +18,12 @@ struct RGBPixelReader {
 };
 
 /**
- * Read RGBA pixels (4 bytes each), discarding the alpha channel.
- * The memory canvas has no alpha blending, so alpha is dropped
- * and transparent areas composite against an implicit white
- * background.
+ * Read RGBA pixels (4 bytes each).
+ *
+ * On colour memory canvases, alpha is preserved for
+ * Canvas::StretchWithSourceAlpha().  Greyscale buffers have no alpha
+ * channel, so transparent areas are composited against white and can
+ * later be keyed out with StretchTransparentWhite().
  */
 struct RGBAPixelReader {
   const uint8_t *p;
@@ -31,12 +33,14 @@ struct RGBAPixelReader {
     const uint8_t r = *p++, g = *p++, b = *p++;
     const uint8_t a = *p++;
 
-    /* Pre-multiply against white so that transparent areas
-       render as white instead of black. */
+#ifdef GREYSCALE
     const uint8_t rb = r + (255 - a) * (255 - r) / 255;
     const uint8_t gb = g + (255 - a) * (255 - g) / 255;
     const uint8_t bb = b + (255 - a) * (255 - b) / 255;
     return typename PixelTraits::color_type(rb, gb, bb);
+#else
+    return typename PixelTraits::color_type(r, g, b, a);
+#endif
   }
 };
 

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -24,6 +24,25 @@
 #include <string_view>
 
 /**
+ * Draw a resource bitmap with transparency when the canvas supports it.
+ */
+static void
+StretchResourceBitmap(Canvas &canvas, PixelPoint position, PixelSize size,
+                      const Bitmap &bitmap, PixelSize src_size) noexcept
+{
+#ifdef ENABLE_OPENGL
+  const ScopeAlphaBlend alpha_blend;
+  canvas.Stretch(position, size, bitmap, {0, 0}, src_size);
+#elif defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE)
+  canvas.StretchWithSourceAlpha(position, size, bitmap, {0, 0}, src_size);
+#elif defined(USE_MEMORY_CANVAS) || defined(USE_GDI)
+  canvas.StretchTransparentWhite(position, size, bitmap);
+#else
+  canvas.Stretch(position, size, bitmap, {0, 0}, src_size);
+#endif
+}
+
+/**
  * Safe proxy for "is this a touch device with larger controls".
  *
  * Cannot use HasTouchScreen() directly because on Wayland/libinput
@@ -205,10 +224,10 @@ RichTextWindow::LoadImage(const std::string &url) const noexcept
   if (StringStartsWith(url.c_str(), "resource:")) {
     const char *name = url.c_str() + 9;
 
-#ifdef ENABLE_OPENGL
-    /* On OpenGL, prefer the _RGBA variant (PNG with alpha channel)
-       over the base resource (BMP with white background) so that
-       images composite correctly on non-white backgrounds. */
+#if defined(ENABLE_OPENGL) || (defined(USE_MEMORY_CANVAS) && !defined(GREYSCALE))
+    /* Prefer the _RGBA variant (PNG with alpha channel) over the base
+       resource (BMP with white background) so images composite on
+       non-white backgrounds. */
     const std::string rgba_name = std::string(name) + "_RGBA";
     ResourceId rgba_id = LookupResourceByName(rgba_name.c_str());
     if (rgba_id.IsDefined())
@@ -847,12 +866,8 @@ RichTextWindow::RenderInlineImage(Canvas &canvas,
   int img_y = y + (cur_line_height -
                    static_cast<int>(target_h)) / 2;
 
-#ifdef ENABLE_OPENGL
-  const ScopeAlphaBlend alpha_blend;
-#endif
-  canvas.Stretch({x, img_y},
-                 {target_w, target_h},
-                 *bmp, {0, 0}, img_size);
+  StretchResourceBitmap(canvas, {x, img_y}, {target_w, target_h},
+                        *bmp, img_size);
   x += static_cast<int>(target_w) + Layout::Scale(2);
   return true;
 }
@@ -1062,12 +1077,9 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
           int img_y = y + (cur_line_height -
                            static_cast<int>(target_h)) / 2;
 
-#ifdef ENABLE_OPENGL
-          const ScopeAlphaBlend alpha_blend;
-#endif
-          sub_canvas.Stretch({img_x, img_y},
-                             {target_w, target_h},
-                             *bmp, {0, 0}, img_size);
+          StretchResourceBitmap(sub_canvas, {img_x, img_y},
+                                {target_w, target_h},
+                                *bmp, img_size);
           continue; // Skip normal text rendering for this line
         }
       }


### PR DESCRIPTION
## Summary
- Prefer transparent OpenGL logo/title bitmaps in `LogoView` so tinted dialog backgrounds no longer show white rectangles around the splash art.
- Theme the pre-profile startup dialog from `GlobalSettings::dark_mode` (same AUTO source as `ProgressWindow`).
- Paint the branded XCSoar gradient behind the startup logo pane (OpenGL), matching the fly/sim prompt splash.

Closes #2742

## Test plan
- [ ] OpenGL build: start with multiple profiles and confirm the profile selector logo has no white boxes on the blue gradient
- [ ] OpenGL light system theme (if available): profile/continue strip follows light `DialogLook`; logo pane still uses branded gradient with light-on-dark art
- [ ] Non-OpenGL / memory canvas: startup profile selector still shows logo without regressions
- [ ] Confirm Credits / Quick Guide / ProgressWindow logos still look correct in light and dark modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed white rectangles appearing around the logo in the startup profile selector.
* **New Features**
  * Improved logo and title rendering for dark mode and OpenGL displays, including better transparency handling and sizing behavior.
* **UI / Theming**
  * Updated the startup dialog’s logo/quit UI to consistently use theme colors (backgrounds, buttons) across display modes.
* **Documentation**
  * Added the startup logo white-rectangle fix to the Version 7.45 release notes under the UI section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->