### PR TITLE
ObservationZones/SymmetricSectorZone: Correct incorrect bounding box

### DIFF
--- a/src/Engine/Task/ObservationZones/SymmetricSectorZone.hpp
+++ b/src/Engine/Task/ObservationZones/SymmetricSectorZone.hpp
@@ -78,7 +78,7 @@ public:
                                   const double radius,
                                   const Angle angle
                                   ) noexcept {
-    std::unique_ptr<SymmetricSectorZone> oz(new SymmetricSectorZone(Shape::SYMMETRIC_SECTOR, true, false, loc,
+    std::unique_ptr<SymmetricSectorZone> oz(new SymmetricSectorZone(Shape::SYMMETRIC_SECTOR, true, true, loc,
                                                                     radius,
                                                                     angle));
     oz->UpdateSector();


### PR DESCRIPTION
For symmetric sector observation zones with angles over 180 degrees, the bounding box would be incorrectly computed, leading to the task advance/turnpoint trigger not firing. Setting a switch enables the arc to be included in the bounding box computation.

The below image shows the kind of OZ that previously would've missed detection. Bug was introduces as part of #2697 

<img width="632" height="493" alt="Screenshot 2026-07-20 at 22 39 09" src="https://github.com/user-attachments/assets/76080c48-1083-4dfc-a4fd-8972d94d5a89" />

----

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- x ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ x Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the setup for symmetric circular sector zones to use the intended configuration.
  * Improves the accuracy of sector behavior while preserving existing update behavior and outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->