### PR TITLE
Faster builds with OpenGL: Use GLM_FORCE_PURE to avoid including unused headers

### DIFF
--- a/build/libglm.mk
+++ b/build/libglm.mk
@@ -1,1 +1,1 @@
-GLM_CPPFLAGS = -isystem lib/glm
+GLM_CPPFLAGS = -isystem lib/glm -DGLM_FORCE_PURE


### PR DESCRIPTION
Almost all of the GLM include (used in OpenGL variants) is not actually used in any of the targets.
Using GLM_FORCE_PURE reduces the included subset of GLM and avoids processing of millions of lines of code for functionally identical code on OpenGL variants.
Without the flag, compilation of the full project takes more than 20% longer than with the flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and consistency when using the GLM graphics library by enforcing its pure implementation mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->