### PR TITLE
Apple/InternalSensors: Filter iOS pressure sensor noise

### DIFF
--- a/src/Apple/InternalSensors.cpp
+++ b/src/Apple/InternalSensors.cpp
@@ -338,6 +338,13 @@ void InternalSensors::Deinit()
  */
 void InternalSensors::StartAltimeterUpdates()
 {
+  /* Core Motion does not publish the pressure sensor's noise
+     characteristics.  Use the same conservative fallback variance as
+     Android's unidentified pressure sensors.  Passing zero here makes the
+     Kalman filter treat every pressure sample as exact, which turns normal
+     sensor noise into large vario excursions. */
+  static constexpr float PRESSURE_SENSOR_NOISE_VARIANCE = 0.05f;
+
   // Initialize altimeter for pressure readings
   altimeter = [[CMAltimeter alloc] init];
   NSOperationQueue *queue = [[NSOperationQueue alloc] init];
@@ -353,7 +360,7 @@ void InternalSensors::StartAltimeterUpdates()
     // Convert pressure readings (from kPa to hPa/mbar) and notify listener
     listener.OnBarometricPressureSensor(
       static_cast<float>(altitudeData.pressure.floatValue * 10.0f),
-      0.0f
+      PRESSURE_SENSOR_NOISE_VARIANCE
     );
   }];
 }


### PR DESCRIPTION
The iOS pressure path declared Core Motion samples as noise-free.  This made the Kalman filter treat normal barometer fluctuations as exact measurements, producing erratic vario indications as large as -10 to +10 m/s.

Use the same conservative fallback pressure variance as unidentified Android sensors.

Tested by running up and down the stairs here with my phone in the hand, got sensible readings now.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved barometric pressure readings by accounting for sensor noise, resulting in more reliable altimeter updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->