### PR TITLE
Widget/VScroll: Keep empty panels valid

### DIFF
--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -41,16 +41,17 @@ VScrollWidget::CalcVirtualHeight(const PixelRect &rc) const noexcept
   if (reserve_scrollbar) {
     /* Rich-text / prose content: the widget has a fixed content
        height and cannot shrink, so scroll the full extent. */
-    return max_height > height ? max_height : height;
+    return std::max({1u, max_height, height});
   }
 
   /* Flexible form widgets: only scroll when the widget truly
      cannot compress to fit the viewport (min_height > height). */
-  if (max_height <= height)
-    return max_height;
+  const unsigned virtual_height = max_height <= height
+    ? max_height
+    : std::max(widget->GetMinimumSize().height, height);
 
-  const unsigned min_height = widget->GetMinimumSize().height;
-  return std::max(min_height, height);
+  /* Window::Move() requires a non-empty rectangle. */
+  return std::max(1u, virtual_height);
 }
 
 inline void


### PR DESCRIPTION
# Widget/VScroll: Keep empty panels valid

## Summary

Keep `VScrollWidget` virtual rectangles at least one pixel high. This
prevents empty scrollable configuration panels from passing invalid geometry
to `Window::Move()`.

## Reproduction

1. Open **Config → System → Gauges → Vario** with Expert mode disabled.
2. Enable the **Expert** checkbox; the Vario settings appear.
3. Disable the **Expert** checkbox again.

All rows on the Vario page are expert-only, so disabling Expert makes the
panel report a content height of zero. `VScrollWidget` then passed a rectangle
with `top == bottom` to `Window::Move()`, causing this assertion and terminating
the app with `SIGABRT`:

```text
Assertion failed: (rc.top < rc.bottom), function Move, file Window.hpp, line 303.
```

## Testing

- Reproduced the crash on iOS before the change.
- Verified on iOS that the exact Expert checkbox sequence above no longer
  crashes after the change.
- Compiled `output/IOS64/dbg/src/Widget/VScrollWidget.o` successfully.
- `git diff --check` passes.
- The broader UNIX `check` target could not run with the local Clang toolchain
  because it rejects the existing `-fconserve-space` option.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior to ensure scrollable content always maintains a valid virtual height.
  * Preserved flexible widget sizing while preventing content from collapsing below the minimum usable height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->