### PR TITLE
Fix T Avg Infobox with LXNAV PLXVF/LXWP0 altitude mismatch

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -59,6 +59,8 @@ Version 7.45 - not yet released
   - always start in light mode; dark mode is not supported on e-paper
     displays #2568
 * devices
+  - fix LXNAV thermal averages when the device reports conflicting
+    altitude sources #2754
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
     suffixes (#0, #1) in both the port list and device list #2481
   - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -37,6 +37,8 @@ Version 7.45 - not yet released
   - audio vario: add manual/automatic Vario/STF sound switching and
     ``VarioAudioMode`` input events
 * glide computer
+  - fix wild T Avg climb rates by preferring the instrument vario when
+    available #2754
   - Speed-to-fly and task calculations are now altitude-corrected: the glide
     polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
     so optimal cruise speeds increase with altitude and best L/D is preserved

--- a/src/Computer/CirclingComputer.cpp
+++ b/src/Computer/CirclingComputer.cpp
@@ -231,6 +231,12 @@ CirclingComputer::PercentCircling(const MoreData &basic,
   if (!flight.flying)
     return;
 
+  /* Integrate brutto vario only when available so T Avg matches the
+     cockpit vario and is not corrupted by pressure-altitude
+     differentiation spikes (#2754). */
+  const bool vario_available = basic.brutto_vario_available;
+  const double vario = vario_available ? basic.brutto_vario : 0;
+
   // if (Circling)
   if (circling_info.circling && circling_info.turning) {
     // Add time step to the circling time
@@ -238,19 +244,18 @@ CirclingComputer::PercentCircling(const MoreData &basic,
     circling_info.time_circling += dt;
 
     // Add the Vario signal to the total climb height
-    circling_info.total_height_gain += basic.gps_vario * ToFloatSeconds(dt);
+    if (vario_available)
+      circling_info.total_height_gain += vario * ToFloatSeconds(dt);
 
-    if (basic.gps_vario>= 0) {
+    if (vario_available && vario >= 0)
       circling_info.time_climb_circling += dt;
-    }
   } else {
     // Add time step to the cruise time
     // timeCruising += (Basic->Time-LastTime);
     circling_info.time_cruise += dt;
 
-    if (basic.gps_vario>= 0) {
+    if (vario_available && vario >= 0)
       circling_info.time_climb_noncircling += dt;
-    }
   }
 
   const auto time_total = (circling_info.time_cruise + circling_info.time_circling);

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -220,8 +220,9 @@ private:
   bool vario_just_detected = false;
 
   /**
-   * Was $PLXVF received?  When set, $LXWP0 vario samples are ignored so
-   * the slower sentence cannot overwrite high-rate total-energy vario.
+   * Was $PLXVF received?  When set, $LXWP0 pressure altitude and vario
+   * samples are ignored so the slower sentence cannot overwrite
+   * high-rate PLXVF data (and cannot inject ALTOFF-adjusted altitude).
    */
   bool plxvf_received = false;
 

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -46,8 +46,8 @@ namespace LXNAVVario {
    * - PLXVF at 10 Hz (total-energy vario, IAS, pressure altitude; spec
    *   recommends 20, 10, 5, 2, 1)
    * - PLXVS every 5 seconds
-   * - LXWP0 every second (TAS, altitude, wind; six TE samples ignored
-   *   when PLXVF is active)
+   * - LXWP0 every second (TAS, wind; altitude and six TE samples
+   *   ignored when PLXVF is active — LXWP0 altitude may include ALTOFF)
    * - LXWP1 every 60 seconds
    * - LXWP2 every 5 seconds (contains MC, ballast, bugs - more frequent for better sync)
    * - LXWP3 every 5 seconds (variofil; changes rarely on the vario)

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -76,8 +76,17 @@ ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario)
   return vario_ok;
 }
 
+/**
+ * @param provide_altitude_vario When false ($PLXVF already received, or
+ * this is an LXNAV vario), skip pressure altitude and TE vario from
+ * $LXWP0.  On LXNAV S8x/S10x, $LXWP0 altitude includes ALTOFF (QNH /
+ * calibration) while $PLXVF PressAlt is raw pressure altitude above
+ * 1013.25 hPa; alternating both into ProvidePressureAltitude() spikes
+ * gps_vario and corrupts T Avg (#2754).  Airspeed and wind are still
+ * taken from $LXWP0.
+ */
 bool
-LXWP0(NMEAInputLine &line, NMEAInfo &info, bool provide_vario)
+LXWP0(NMEAInputLine &line, NMEAInfo &info, bool provide_altitude_vario)
 {
   /*
   $LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1
@@ -98,20 +107,24 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info, bool provide_vario)
   if (tas_available && (airspeed < -50 || airspeed > 250))
     /* implausible */
     return false;
+
   double value;
-  if (line.ReadChecked(value))
-    /* a dump on a LX7007 has confirmed that the LX sends uncorrected
-       altitude above 1013.25hPa here */
-    info.ProvidePressureAltitude(value);
+  if (line.ReadChecked(value)) {
+    if (provide_altitude_vario)
+      /* Without $PLXVF, treat as pressure altitude above 1013.25 hPa
+         (confirmed on LX7007).  With $PLXVF, the value may include
+         ALTOFF — ignore it and keep $PLXVF PressAlt. */
+      info.ProvidePressureAltitude(value);
+  }
 
   if (tas_available)
     /*
-     * Call ProvideTrueAirspeed() after ProvidePressureAltitude() to use
-     * the provided altitude (if available)
+     * Prefer providing TAS after any pressure altitude update so
+     * density correction can use it when available.
      */
     info.ProvideTrueAirspeed(Units::ToSysUnit(airspeed, Unit::KILOMETER_PER_HOUR));
 
-  if (provide_vario) {
+  if (provide_altitude_vario) {
     if (ReadFilteredLXWP0Vario(line, value))
       info.ProvideTotalEnergyVario(value);
   } else

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -21,9 +21,13 @@ namespace LX {
 bool
 ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario);
 
+/**
+ * @param provide_altitude_vario When false, skip pressure altitude and
+ * TE vario (used once $PLXVF is active on LXNAV varios).
+ */
 bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info,
-      bool provide_vario=true);
+      bool provide_altitude_vario=true);
 
 void
 LXWP1(NMEAInputLine &line, DeviceInfo &device);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1706,6 +1706,7 @@ TestLXV7()
   NMEAInfo basic;
   basic.Reset();
   basic.clock = TimeStamp{FloatDuration{1}};
+  basic.alive.Update(basic.clock);
 
   LXDevice &lx_device = *(LXDevice *)device;
   lx_device.ResetDeviceDetection();
@@ -1720,6 +1721,19 @@ TestLXV7()
   ok1(basic.acceleration.available);
   ok1(equals(basic.acceleration.g_load, 1.331));
 
+  /* After $PLXVF, $LXWP0 must not overwrite pressure altitude or TE vario
+     (ALTOFF-adjusted LXWP0 altitude vs raw PLXVF PressAlt, #2754). */
+  basic.clock = TimeStamp{FloatDuration{2}};
+  ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,1.71,1.71,1.71,1.71,1.71,239,174,10.1*5E",
+                        basic));
+  ok1(basic.pressure_altitude_available);
+  ok1(equals(basic.pressure_altitude, 244.3));
+  ok1(basic.total_energy_vario_available);
+  ok1(equals(basic.total_energy_vario, -0.25));
+  ok1(basic.airspeed_available);
+  ok1(basic.external_wind_available);
+
+  basic.clock = TimeStamp{FloatDuration{3}};
   ok1(device->ParseNMEA("$PLXVS,23.1,0,12.3,*71", basic));
   ok1(basic.temperature_available);
   ok1(equals(basic.temperature.ToKelvin(), 296.25));
@@ -3196,7 +3210,7 @@ int main()
   SetSingleDataPath(data_path);
   CreateDataPath();
 
-  plan_tests(1036 /* drivers */ + 29 /* PFLAU extended */
+  plan_tests(1043 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 109 /* LXNav protocol 1.05 */


### PR DESCRIPTION
## Summary
- On LXNAV S8x/S10x, `$LXWP0` altitude includes ALTOFF while `$PLXVF` PressAlt is raw pressure altitude; ignore LXWP0 pressure altitude (like vario) when PLXVF is active so they no longer fight in `ProvidePressureAltitude()`.
- Thermal day average (`T Avg`) now integrates `brutto_vario` only when available, instead of unguarded `gps_vario` from pressure-altitude differentiation.
- Fixes wild T Avg values (e.g. tens of m/s) on OpenVario/SteFly with LX S100 + FLARM while current thermal average stayed correct. Fixes #2754.

## Test plan
- [x] `TestDriver` passes, including new regression: after `$PLXVF`, `$LXWP0` must not change pressure altitude / TE vario
- [x] UNIX target builds with `WERROR=y`
- [x] Replay or fly with LXNAV device sending both `$PLXVF` and `$LXWP0`; confirm T Avg stays in a realistic range and tracks TC Avg / instrument vario
- [ ] Confirm LXWP0-only devices (no PLXVF) still get pressure altitude from LXWP0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thermal-average climb rate accuracy when instrument vario data is available.
  * Prevented conflicting flight-computer data from corrupting altitude and vario readings.
  * Improved circling statistics by using instrument vario data when available.

* **Tests**
  * Added coverage confirming that lower-priority data does not overwrite established altitude or vario values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->