### PR TITLE
Engine/Trace: Bounds-first trail viewport query (long-flight CPU)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -179,6 +179,9 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
+  - snail trail: reduce long-flight map CPU by clipping the trail to the
+    visible area before spacing-thinning (Full trail no longer walks the
+    whole history every redraw) #2661
   - dynamically adjust contour line density to zoom factor #2233
   - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type

--- a/build/test.mk
+++ b/build/test.mk
@@ -109,6 +109,7 @@ TEST_NAMES = \
 	TestOGNAprsParser \
 	TestMETARParser \
 	TestIGCParser \
+	TestTraceBounds \
 	TestStrings TestUnescapeCString TestUTF8 TestWrapText \
 	TestInputConfig \
 	TestCRC16 TestCRC8 \
@@ -1021,6 +1022,14 @@ TEST_TRACE_SOURCES = \
 	$(TEST_SRC_DIR)/TestTrace.cpp
 TEST_TRACE_DEPENDS = IO OS GEO MATH UTIL
 $(eval $(call link-program,TestTrace,TEST_TRACE))
+
+TEST_TRACE_BOUNDS_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(SRC)/Engine/Trace/Point.cpp \
+	$(SRC)/Engine/Trace/Trace.cpp \
+	$(TEST_SRC_DIR)/TestTraceBounds.cpp
+TEST_TRACE_BOUNDS_DEPENDS = GEO MATH UTIL
+$(eval $(call link-program,TestTraceBounds,TEST_TRACE_BOUNDS))
 
 FLIGHT_TABLE_SOURCES = \
 	$(SRC)/IGC/IGCParser.cpp \

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -5,6 +5,7 @@
 #include "Settings.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
+#include "Engine/Trace/Vector.hpp"
 #include "Geo/GeoBounds.hpp"
 
 #include <cmath>
@@ -186,7 +187,15 @@ TraceComputer::LockedTrailQuery(const TrailQuery &query,
     full.GetPoints(v, query.min_time, query.project_location,
                    query.min_distance_m);
 
-  CopyMergeVarioSamplesUnlocked(vario_samples, query.min_time);
+  /* Only copy merge-vario for the kept trail span (plus open-leg ring
+     samples after the last GPS fix).  Avoids walking the full-flight
+     archive when the viewport only needs a local subset. */
+  if (v.empty())
+    vario_samples.clear();
+  else {
+    const auto vario_min = std::max(query.min_time, v.front().GetTime());
+    CopyMergeVarioSamplesUnlocked(vario_samples, vario_min);
+  }
 
   if (append_serial != nullptr)
     *append_serial = full.GetAppendSerial();

--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -4,7 +4,8 @@
 #include "Trace.hpp"
 #include "Vector.hpp"
 #include "Geo/GeoBounds.hpp"
-#include "Geo/GeoClip.hpp"
+#include "Geo/Flat/FlatBoundingBox.hpp"
+#include "Geo/Flat/FlatRay.hpp"
 #include "util/GlobalSliceAllocator.hxx"
 
 #include <algorithm>
@@ -447,17 +448,21 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
   } while (i != end);
 }
 
+/**
+ * True if the flat segment [a,b] hits \a box (endpoint inside or edge cross).
+ */
 [[gnu::pure]]
 static bool
-SegmentIntersectsBounds(const GeoPoint &a, const GeoPoint &b,
-                        const GeoBounds &bounds) noexcept
+FlatSegmentHitsBox(const FlatGeoPoint &a, const FlatGeoPoint &b,
+                   const FlatBoundingBox &box) noexcept
 {
-  if (bounds.IsInside(a) || bounds.IsInside(b))
+  if (box.IsInside(a) || box.IsInside(b))
     return true;
 
-  GeoClip clip(bounds);
-  GeoPoint a2 = a, b2 = b;
-  return clip.ClipLine(a2, b2);
+  if (a == b)
+    return false;
+
+  return box.Intersects(FlatRay(a, b));
 }
 
 void
@@ -466,37 +471,74 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
                  const GeoPoint &location,
                  const double min_distance) const
 {
-  TracePointVector thinned;
-  GetPoints(thinned, min_time, location, min_distance);
+  v.clear();
 
-  if (thinned.empty()) {
-    v.clear();
+  if (!bounds.IsValid() || empty() || !task_projection.IsValid())
     return;
-  }
 
-  std::vector<uint8_t> keep(thinned.size(), 0);
-  for (size_t k = 0; k < thinned.size(); ++k) {
-    const GeoPoint gp = thinned[k].GetLocation();
-    if (bounds.IsInside(gp)) {
-      keep[k] = 1;
-      continue;
+  /* Skip points before min_time. */
+  Trace::const_iterator i = begin(), end = this->end();
+  while (i != end && i->GetTime() < min_time)
+    ++i;
+
+  if (i == end)
+    return;
+
+  /* Bounds first (flat AABB), then spacing-thin.  Avoids thinning the
+     entire flight history before clipping — that dominated cost at
+     circling zoom where min_distance is only a few metres. */
+  const FlatBoundingBox flat_box = task_projection.Project(bounds);
+
+  TracePointVector candidates;
+  candidates.reserve(std::min(size_t(size()), size_t(4096)));
+
+  const TracePoint *prev = nullptr;
+  FlatGeoPoint prev_flat{};
+
+  for (; i != end; ++i) {
+    const TracePoint &point = *i;
+    const FlatGeoPoint flat = point.GetFlatLocation();
+    bool keep = flat_box.IsInside(flat);
+
+    if (!keep && prev != nullptr &&
+        FlatSegmentHitsBox(prev_flat, flat, flat_box))
+      keep = true;
+
+    if (keep) {
+      /* If this point is kept because a leg crosses into the box,
+         also keep the outside predecessor so the crossing leg is drawn. */
+      if (prev != nullptr &&
+          (candidates.empty() ||
+           candidates.back().GetTime() != prev->GetTime())) {
+        if (!flat_box.IsInside(prev_flat) &&
+            FlatSegmentHitsBox(prev_flat, flat, flat_box))
+          candidates.push_back(*prev);
+      }
+
+      if (candidates.empty() ||
+          candidates.back().GetTime() != point.GetTime())
+        candidates.push_back(point);
     }
 
-    if (k > 0 &&
-        SegmentIntersectsBounds(thinned[k - 1].GetLocation(), gp, bounds))
-      keep[k] = 1;
-    else if (k + 1 < thinned.size() &&
-             SegmentIntersectsBounds(gp, thinned[k + 1].GetLocation(), bounds))
-      keep[k] = 1;
+    prev = &point;
+    prev_flat = flat;
   }
 
-  /* Keep only visible / bounds-crossing points.  Do not reinsert
-     off-screen gaps between separate viewport runs — that would let
-     trail size grow with flight duration despite the filter. */
-  v.clear();
-  v.reserve(thinned.size());
-  for (size_t k = 0; k < thinned.size(); ++k) {
-    if (keep[k])
-      v.push_back(thinned[k]);
+  if (candidates.empty())
+    return;
+
+  /* Spacing-thin the chronological candidates (same metric as the
+     non-bounds GetPoints).  Do not reinsert off-screen gaps. */
+  const unsigned range = ProjectRange(location, min_distance);
+  const unsigned sq_range = range * range;
+
+  v.reserve(candidates.size());
+  v.push_back(candidates.front());
+  size_t last = 0;
+  for (size_t k = 1; k < candidates.size(); ++k) {
+    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >= sq_range) {
+      v.push_back(candidates[k]);
+      last = k;
+    }
   }
 }

--- a/src/Engine/Trace/Trace.hpp
+++ b/src/Engine/Trace/Trace.hpp
@@ -394,8 +394,10 @@ public:
                  const GeoPoint &location, double resolution) const;
 
   /**
-   * Like GetPoints() with time and distance thinning, but only returns
-   * points inside \a bounds or on legs that intersect \a bounds.
+   * Fill the vector with trace points not before #min_time that lie
+   * inside \a bounds or on legs that intersect \a bounds, then apply
+   * minimum resolution #min_distance.  Bounds are applied before
+   * spacing thinning so cost tracks the viewport, not flight length.
    */
   void GetPoints(TracePointVector &v, Time min_time,
                  const GeoBounds &bounds,

--- a/test/src/TestTraceBounds.cpp
+++ b/test/src/TestTraceBounds.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Engine/Trace/Trace.hpp"
+#include "Engine/Trace/Vector.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "TestUtil.hpp"
+
+#include <chrono>
+
+using namespace std::chrono;
+
+/**
+ * Build a long eastbound track, then query a tight box around the end.
+ * Bounds-first GetPoints must return far fewer points than the full
+ * spacing-thinned path, while still including a leg that crosses the box.
+ */
+static void
+TestBoundsFirstQuery() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 8192);
+
+  constexpr unsigned n_points = 2000;
+  constexpr double step_deg = 0.001; /* ~111 m east per step */
+
+  for (unsigned i = 0; i < n_points; ++i) {
+    const GeoPoint loc(Angle::Degrees(8 + i * step_deg),
+                       Angle::Degrees(48));
+    const TracePoint point(loc, seconds{i * 2}, 1000, 0, 0);
+    trace.push_back(point);
+  }
+
+  ok1(trace.size() > 1000);
+
+  TracePointVector all_thinned;
+  const GeoPoint end_loc = trace.back().GetLocation();
+  /* Fine spacing: almost every stored point survives thinning. */
+  trace.GetPoints(all_thinned, {}, end_loc, 1.);
+  ok1(all_thinned.size() > 1000);
+
+  /* Tight box around the end (~0.01° ≈ 1 km). */
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(8 + (n_points - 20) * step_deg),
+             Angle::Degrees(48.005)),
+    GeoPoint(Angle::Degrees(8 + (n_points - 1) * step_deg + 0.002),
+             Angle::Degrees(47.995)));
+  ok1(box.IsValid());
+  ok1(box.IsInside(end_loc));
+
+  TracePointVector bounded;
+  trace.GetPoints(bounded, {}, box, end_loc, 1.);
+  ok1(!bounded.empty());
+  ok1(bounded.size() < all_thinned.size() / 10);
+  ok1(bounded.size() < 80);
+
+  /* Last point of the flight must be present. */
+  ok1(bounded.back().GetTime() == trace.back().GetTime());
+
+  /* A point well before the box must not appear. */
+  bool early_found = false;
+  const auto early_time = seconds{100};
+  for (const auto &p : bounded) {
+    if (p.GetTime() == early_time) {
+      early_found = true;
+      break;
+    }
+  }
+  ok1(!early_found);
+}
+
+/**
+ * A single long leg that crosses the viewport must keep both endpoints
+ * (outside → outside with segment through the box).
+ */
+static void
+TestCrossingLegKept() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 64);
+
+  const GeoPoint west(Angle::Degrees(8.0), Angle::Degrees(48));
+  const GeoPoint east(Angle::Degrees(8.2), Angle::Degrees(48));
+  trace.push_back(TracePoint(west, seconds{0}, 1000, 0, 0));
+  /* push_back enforces 2 s min delta */
+  trace.push_back(TracePoint(east, seconds{10}, 1000, 0, 0));
+
+  ok1(trace.size() == 2);
+
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(8.05), Angle::Degrees(48.05)),
+    GeoPoint(Angle::Degrees(8.15), Angle::Degrees(47.95)));
+  ok1(box.IsValid());
+  ok1(!box.IsInside(west));
+  ok1(!box.IsInside(east));
+
+  TracePointVector bounded;
+  const GeoPoint mid(Angle::Degrees(8.1), Angle::Degrees(48));
+  trace.GetPoints(bounded, {}, box, mid, 1.);
+
+  ok1(bounded.size() == 2);
+  ok1(bounded.front().GetTime() == seconds{0});
+  ok1(bounded.back().GetTime() == seconds{10});
+}
+
+int
+main()
+{
+  plan_tests(9 + 7);
+  TestBoundsFirstQuery();
+  TestCrossingLegKept();
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- Change `Trace::GetPoints(..., bounds, ...)` to **bounds/leg-filter first** (flat AABB), then spacing-thin, so Full-trail map paints no longer thin+`GeoClip` the whole flight history every frame at circling zoom (#2661).
- Limit `LockedTrailQuery` merge-vario copies to the kept point time span.
- Add `TestTraceBounds` and a NEWS note.

## Motivation
At circling zoom, spacing is only a few metres, so thin-then-filter barely reduces a Full (~25k) store and still pays expensive Angle/`GeoClip` work over nearly the whole history. Prep cost grew with flight length even when the on-screen trail looked steady.

## Measurement (Bruno Capelle IGC, desktop, `--trail-type=vario1 --circle-radius=750`)
| | before `circle_ms` | after |
|---|---:|---:|
| end-only (30 draws) | 89.8 | 51.8 |
| timeline @ 6 h (10 draws) | 51.7 | 18.7 |

Circling cost vs store size is ~10× flatter after the change.

## Test plan
- [x] `make TARGET=UNIX WERROR=y output/UNIX/bin/TestTraceBounds` — 16/16 ok
- [ ] Smoke: long IGC replay, Trail Full / Vario #1, circling zoom — map stays responsive; trail still draws crossing legs into view
- [ ] Confirm Trail Short (10 min) / Long (1 h) still look correct vs Full