### PR TITLE
Dialogs/Device/DeviceListDialog: Count noncomp and netto as Vario

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -17,6 +17,8 @@ Version 7.45 - not yet released
     to filter self and additional own aircraft from OGN when the device
     radio id is unavailable (e.g. LX passthrough) #2693
 * ui
+  - Device list: show the Vario flag for non-compensated and netto vario
+    sources as well as total-energy (e.g. BlueFly)
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude
     on the selected target (info panel already shows them) #2718

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -111,7 +111,9 @@ class DeviceListWidget final
       pitot = basic.pitot_pressure_available;
       airspeed = basic.airspeed_available ||
         basic.dyn_pressure_available;
-      vario = basic.total_energy_vario_available;
+      vario = basic.netto_vario_available ||
+        basic.total_energy_vario_available ||
+        basic.noncomp_vario_available;
       traffic = basic.flarm.IsDetected();
       temperature = basic.temperature_available;
       humidity = basic.humidity_available;


### PR DESCRIPTION
## Summary
- Device list Vario flag previously checked only total-energy vario, so BlueFly (noncomp) never showed `; Vario` even when healthy.
- Treat netto, total-energy, and noncomp the same way System Status already does.

## Test plan
- [ ] Connect a BlueFly (or other noncomp vario source) and confirm device list shows `Connected; Baro; Vario` (or similar) when PRS is flowing
- [ ] Confirm TE-vario devices still show `; Vario`
- [ ] Confirm devices with no vario still omit the flag

Related discussion: https://github.com/XCSoar/XCSoar/discussions/2605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The device list now displays the Vario capability for devices providing netto, non-compensated, or total-energy vario data.
* **Documentation**
  * Updated the release notes to reflect the expanded Vario device detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->