### PR TITLE
Form/VScrollPanel, Dialogs/ListPicker: Ease e-paper scrolling

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -29,6 +29,9 @@ Version 7.45 - not yet released
     button are reachable from the keyboard
   - Device list: show the Vario flag for non-compensated and netto vario
     sources as well as total-energy (e.g. BlueFly)
+  - E-paper: snap VScrollPanel smooth scrolling instead of animating at
+    ~60 Hz, and debounce ComboPicker per-item help updates while
+    scrolling (InfoBox content list etc.)
   - FLARM radar: show callsigns on all registered targets again, use the
     full callsign on target labels, and omit duplicate side vario/altitude
     on the selected target (info panel already shows them) #2718

--- a/src/Dialogs/ListPicker.cpp
+++ b/src/Dialogs/ListPicker.cpp
@@ -14,6 +14,7 @@
 #include "WidgetDialog.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "ui/event/Timer.hpp"
+#include "Asset.hpp"
 
 #include <cassert>
 
@@ -51,6 +52,17 @@ ListPickerWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   }
 
   item_renderer.OnPaintItem(canvas, rc, idx);
+}
+
+void
+ListPickerWidget::OnCursorMoved([[maybe_unused]] unsigned index) noexcept
+{
+  /* Per-item help triggers UpdateLayout(); on e-paper that is too
+     expensive to run on every cursor step while scrolling. */
+  if (HasEPaper())
+    postpone_update_help.Schedule(std::chrono::milliseconds(350));
+  else
+    UpdateHelp(index);
 }
 
 int

--- a/src/Dialogs/ListPicker.hpp
+++ b/src/Dialogs/ListPicker.hpp
@@ -109,7 +109,7 @@ public:
   void OnPaintItem(Canvas &canvas, const PixelRect rc,
                    unsigned idx) noexcept override;
 
-  void OnCursorMoved(unsigned index) noexcept override { UpdateHelp(index); }
+  void OnCursorMoved(unsigned index) noexcept override;
 
   bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept override
   {

--- a/src/Form/VScrollPanel.cpp
+++ b/src/Form/VScrollPanel.cpp
@@ -59,6 +59,16 @@ VScrollPanel::GetScrollStep() const noexcept
   return step > 0 ? step : 1;
 }
 
+/**
+ * Can the user scroll with pixel precision?  Fast displays get
+ * kinetic/smooth scrolling; e-paper snaps to avoid refresh storms.
+ */
+static bool
+UsePixelPan() noexcept
+{
+  return !HasEPaper();
+}
+
 void
 VScrollPanel::ScrollBy(int delta) noexcept
 {
@@ -95,7 +105,17 @@ VScrollPanel::SmoothScrollTo(int target) noexcept
   const int max_origin = std::max(0, static_cast<int>(virtual_height) -
                                      static_cast<int>(physical_height));
 
-  smooth_scroll_target = std::clamp(target, 0, max_origin);
+  target = std::clamp(target, 0, max_origin);
+
+  /* E-paper cannot keep up with ~60 Hz scroll animation; snap. */
+  if (!UsePixelPan()) {
+    smooth_scroll_timer.Cancel();
+    smooth_scroll_target = -1;
+    SetOriginClamped(target);
+    return;
+  }
+
+  smooth_scroll_target = target;
 
   // Start animation at ~60fps
   smooth_scroll_timer.Schedule(std::chrono::milliseconds(16));
@@ -122,11 +142,6 @@ VScrollPanel::OnSmoothScrollTimer() noexcept
     const int step = diff / 3;
     SetOriginClamped(static_cast<int>(origin) + (step != 0 ? step : (diff > 0 ? 1 : -1)));
   }
-}
-
-static bool UsePixelPan() noexcept
-{
-  return !HasEPaper();
 }
 
 void


### PR DESCRIPTION
## Summary
- Snap `VScrollPanel` smooth scrolling on e-paper instead of animating at ~60 Hz (kinetic drag was already gated by `HasEPaper()`, but `SmoothScrollTo` was not).
- Debounce ComboPicker per-item help `UpdateLayout` while the cursor moves on e-paper — large lists with item help (e.g. InfoBox content) were especially painful on Kobo.

Reported in https://github.com/XCSoar/XCSoar/discussions/2605 (InfoBox configuration scrolling freezing for a minute or more on Kobo Nia).

## Test plan
- [ ] Kobo (or `HasEPaper()` build): scroll a long settings form / VScrollPanel — should jump without multi-second freeze
- [ ] Kobo: open InfoBox set → Content combo (item help enabled) and scroll the list — UI should stay responsive; help text updates after a short pause
- [ ] Non–e-paper UNIX/Android: smooth/kinetic scroll and immediate item help still behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved E-paper scrolling by switching from continuous ~60Hz animation to smoother, clamped scroll behavior.
  - Reduced per-item help refreshes on E-paper pickers by delaying and debouncing help updates while the cursor moves during scrolling.
  - Kept immediate per-item help updates on non–E-paper displays.
- **Documentation**
  - Updated the Version 7.45 release notes to reflect the E-paper scrolling and picker help behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->