### PR TITLE
Speed up rich-text layout and fix Quick Guide keyboard focus

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -25,6 +25,8 @@ Version 7.45 - not yet released
   - Speed up long rich-text layout (Quick Guide What's New): estimate scroll
     height before wrapping, skip FreeType for runs that clearly fit or
     overflow by character budget, and use one measure for typical bullets
+  - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
+    button are reachable from the keyboard
   - Device list: show the Vario flag for non-compensated and netto vario
     sources as well as total-energy (e.g. BlueFly)
   - FLARM radar: show callsigns on all registered targets again, use the

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,9 @@ Version 7.45 - not yet released
     ``label``), gesture ``data`` format, softkey ``location``,
     label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
 * ui
+  - Speed up long rich-text layout (Quick Guide What's New): estimate scroll
+    height before wrapping, skip FreeType for runs that clearly fit or
+    overflow by character budget, and use one measure for typical bullets
   - Device list: show the Vario flag for non-compensated and netto vario
     sources as well as total-energy (e.g. BlueFly)
   - FLARM radar: show callsigns on all registered targets again, use the

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -220,7 +220,71 @@ ArrowPagerWidget::KeyPress(unsigned key_code) noexcept
   if (extra != nullptr && extra->KeyPress(key_code))
     return true;
 
+  auto focus_page_bottom = [this]() noexcept {
+    Widget &page = GetCurrentWidget();
+    if (auto *qg = dynamic_cast<QuickGuidePageWidget *>(&page)) {
+      if (qg->FocusBottomBar(true))
+        return true;
+    }
+    return page.SetFocus();
+  };
+
   switch (key_code) {
+  case KEY_UP:
+    /* Chrome focus chain (portrait: prev | next | Close):
+       Close → next → prev → page bottom bar / content. */
+    if (close_button.HasFocus()) {
+      if (next_button.IsEnabled()) {
+        next_button.SetFocus();
+        return true;
+      }
+      if (previous_button.IsEnabled()) {
+        previous_button.SetFocus();
+        return true;
+      }
+      return focus_page_bottom();
+    }
+    if (next_button.HasFocus()) {
+      if (previous_button.IsEnabled()) {
+        previous_button.SetFocus();
+        return true;
+      }
+      return focus_page_bottom();
+    }
+    if (previous_button.HasFocus())
+      return focus_page_bottom();
+    return false;
+
+  case KEY_DOWN:
+    /* Page content / bottom bar finished with Down, or chrome
+       arrows — move toward Close.  Do not use dialog FocusNext:
+       window z-order would send focus back into the scroller. */
+    if (close_button.HasFocus())
+      return true; /* end of chain */
+
+    if (previous_button.HasFocus()) {
+      if (next_button.IsEnabled())
+        next_button.SetFocus();
+      else
+        close_button.SetFocus();
+      return true;
+    }
+    if (next_button.HasFocus()) {
+      close_button.SetFocus();
+      return true;
+    }
+
+    if (previous_button.IsEnabled()) {
+      previous_button.SetFocus();
+      return true;
+    }
+    if (next_button.IsEnabled()) {
+      next_button.SetFocus();
+      return true;
+    }
+    close_button.SetFocus();
+    return true;
+
   case KEY_LEFT:
     if (Previous(true))
       SetFocus();

--- a/src/Widget/QuickGuidePageWidget.cpp
+++ b/src/Widget/QuickGuidePageWidget.cpp
@@ -331,59 +331,86 @@ QuickGuidePageWidget::HasFocus() const noexcept
 }
 
 bool
-QuickGuidePageWidget::KeyPress(unsigned key_code) noexcept
+QuickGuidePageWidget::FocusBottomBar(bool from_end) noexcept
 {
-  // Let the scroll content handle the key first
-  if (scroll_widget->KeyPress(key_code))
+  switch (bar_type) {
+  case BottomBarType::NONE:
+    return false;
+
+  case BottomBarType::CHECKBOX:
+    if (checkbox == nullptr)
+      return false;
+    checkbox->SetFocus();
     return true;
 
-  // Handle DOWN to move focus from content to bottom bar
-  if (key_code == KEY_DOWN && bar_type != BottomBarType::NONE) {
-    switch (bar_type) {
-    case BottomBarType::NONE:
-      break;
-    case BottomBarType::CHECKBOX:
-      if (checkbox) {
-        checkbox->SetFocus();
-        return true;
-      }
-      break;
-    case BottomBarType::ONE_BUTTON:
-      if (button1) {
-        button1->SetFocus();
-        return true;
-      }
-      break;
-    case BottomBarType::TWO_BUTTONS:
-      if (button1) {
-        button1->SetFocus();
-        return true;
-      }
-      break;
-    }
-  }
+  case BottomBarType::ONE_BUTTON:
+    if (button1 == nullptr)
+      return false;
+    button1->SetFocus();
+    return true;
 
-  // Handle UP to move focus from bottom bar back to content
-  if (key_code == KEY_UP) {
-    bool bottom_has_focus =
-      (checkbox && checkbox->HasFocus()) ||
-      (button1 && button1->HasFocus()) ||
-      (button2 && button2->HasFocus());
-    if (bottom_has_focus) {
-      scroll_widget->SetFocus();
-      return true;
-    }
-  }
-
-  // Handle LEFT/RIGHT between buttons in two-button mode
-  if (bar_type == BottomBarType::TWO_BUTTONS) {
-    if (key_code == KEY_RIGHT && button1 &&
-        button1->HasFocus() && button2) {
+  case BottomBarType::TWO_BUTTONS:
+    if (from_end && button2 != nullptr) {
       button2->SetFocus();
       return true;
     }
-    if (key_code == KEY_LEFT && button2 &&
-        button2->HasFocus() && button1) {
+    if (button1 != nullptr) {
+      button1->SetFocus();
+      return true;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+bool
+QuickGuidePageWidget::KeyPress(unsigned key_code) noexcept
+{
+  if (scroll_widget->HasFocus()) {
+    if (scroll_widget->KeyPress(key_code))
+      return true;
+    /* Content done with Down → bottom bar (don't show again, …). */
+    if (key_code == KEY_DOWN)
+      return FocusBottomBar(false);
+    return false;
+  }
+
+  const bool on_checkbox = checkbox && checkbox->HasFocus();
+  const bool on_button1 = button1 && button1->HasFocus();
+  const bool on_button2 = button2 && button2->HasFocus();
+
+  if (key_code == KEY_DOWN) {
+    if (on_button1 && button2 != nullptr) {
+      button2->SetFocus();
+      return true;
+    }
+    /* Checkbox / last button: let the dialog move to Close. */
+    if (on_checkbox || on_button1 || on_button2)
+      return false;
+  }
+
+  if (key_code == KEY_UP) {
+    if (on_button2 && button1 != nullptr) {
+      button1->SetFocus();
+      return true;
+    }
+    if (on_checkbox || on_button1 || on_button2) {
+      /* Return focus to the content and select the last visible
+         link/checkbox — SetFocus alone left the scroller focused
+         with nothing highlighted. */
+      scroll_widget->SetFocus();
+      scroll_widget->KeyPress(KEY_UP);
+      return true;
+    }
+  }
+
+  if (bar_type == BottomBarType::TWO_BUTTONS) {
+    if (key_code == KEY_RIGHT && on_button1 && button2) {
+      button2->SetFocus();
+      return true;
+    }
+    if (key_code == KEY_LEFT && on_button2 && button1) {
       button1->SetFocus();
       return true;
     }

--- a/src/Widget/QuickGuidePageWidget.hpp
+++ b/src/Widget/QuickGuidePageWidget.hpp
@@ -108,6 +108,13 @@ public:
    */
   void SetLinkReturnCallback(std::function<void()> cb) noexcept;
 
+  /**
+   * Move keyboard focus onto the bottom bar.
+   * @param from_end  If true, prefer the control nearest Close
+   *                  (right button); otherwise the first control.
+   */
+  bool FocusBottomBar(bool from_end=false) noexcept;
+
   ~QuickGuidePageWidget() noexcept override;
 
   /**

--- a/src/Widget/RichTextWidget.cpp
+++ b/src/Widget/RichTextWidget.cpp
@@ -6,6 +6,9 @@
 #include "Look/DialogLook.hpp"
 #include "Screen/Layout.hpp"
 #include "UIGlobals.hpp"
+#include "ui/canvas/TextWrapper.hpp"
+
+#include <algorithm>
 
 PixelSize
 RichTextWidget::GetMinimumSize() const noexcept
@@ -16,7 +19,6 @@ RichTextWidget::GetMinimumSize() const noexcept
 PixelSize
 RichTextWidget::GetMaximumSize() const noexcept
 {
-  // If window is prepared, use actual content height
   if (IsDefined()) {
     const auto &w = static_cast<const RichTextWindow &>(GetWindow());
     unsigned content_height = w.GetContentHeight();
@@ -25,26 +27,16 @@ RichTextWidget::GetMaximumSize() const noexcept
                        static_cast<int>(content_height)};
   }
 
-  // Estimate height from text length before window is prepared
   if (!text.empty()) {
     const Font &font = GetLook().text_font;
     const unsigned line_height = font.GetLineSpacing();
-
-    // Count newlines for initial estimate
-    unsigned line_count = 1;
-    for (const char c : text) {
-      if (c == '\n')
-        ++line_count;
-    }
-
-    // Add extra for word wrapping (rough estimate: 50% more lines)
-    line_count = line_count * 3 / 2;
-
+    const unsigned estimate_width = Layout::FastScale(600);
+    const unsigned line_count =
+      std::max(1u, EstimateWrappedLineCount(font, estimate_width, text));
     const unsigned padding = Layout::GetTextPadding() * 2;
-    const int estimated_height =
-      static_cast<int>(line_count * line_height + padding * 2);
-
-    return PixelSize{Layout::FastScale(600), estimated_height};
+    return PixelSize{
+      Layout::FastScale(600),
+      static_cast<int>(line_count * line_height + padding * 2)};
   }
 
   return PixelSize{Layout::FastScale(600), Layout::FastScale(200)};

--- a/src/Widget/RichTextWidget.cpp
+++ b/src/Widget/RichTextWidget.cpp
@@ -33,7 +33,7 @@ RichTextWidget::GetMaximumSize() const noexcept
     const unsigned estimate_width = Layout::FastScale(600);
     const unsigned line_count =
       std::max(1u, EstimateWrappedLineCount(font, estimate_width, text));
-    const unsigned padding = Layout::GetTextPadding() * 2;
+    const unsigned padding = Layout::GetTextPadding();
     return PixelSize{
       Layout::FastScale(600),
       static_cast<int>(line_count * line_height + padding * 2)};

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -95,8 +95,10 @@ VScrollWidget::Initialise(ContainerWindow &parent,
   style.ControlParent();
   style.Hide();
 
-  if (reserve_scrollbar)
-    style.TabStop();
+  /* Do not TabStop the panel itself.  With TabStop, dialog
+     FocusNext/Previous land on the panel and Up/Down scroll it
+     (including past the real content).  Child tab-stops such as
+     RichTextWindow are found via ControlParent instead. */
 
   VScrollPanelListener &listener = *this;
   SetWindow(std::make_unique<VScrollPanel>(parent, look, rc, style,

--- a/src/ui/canvas/TextWrapper.cpp
+++ b/src/ui/canvas/TextWrapper.cpp
@@ -24,9 +24,6 @@ ClampedSequenceLengthUTF8(char ch, std::size_t max_bytes) noexcept
   return std::min(n, max_bytes);
 }
 
-/**
- * Advance @p p by @p n whole UTF-8 characters, not past @p end.
- */
 static const char *
 AdvanceUTF8Chars(const char *p, const char *end, std::size_t n) noexcept
 {
@@ -37,9 +34,6 @@ AdvanceUTF8Chars(const char *p, const char *end, std::size_t n) noexcept
   return p;
 }
 
-/**
- * Count whole UTF-8 characters in [start, end).
- */
 static std::size_t
 CountUTF8Chars(const char *start, const char *end) noexcept
 {
@@ -51,31 +45,61 @@ CountUTF8Chars(const char *start, const char *end) noexcept
   return n;
 }
 
+/**
+ * Glyph-width character budgets (one calibration per WrapText).
+ * Short runs skip FreeType; very long runs skip a doomed full measure.
+ */
+struct WrapBudget {
+  std::size_t safe_fit_chars;
+  std::size_t must_wrap_chars;
+};
+
+[[gnu::pure]]
+static WrapBudget
+CalibrateWrapBudget(Canvas &canvas, unsigned width) noexcept
+{
+  const unsigned max_cw =
+    std::max(1u, canvas.CalcTextSize("W").width);
+  const unsigned min_cw =
+    std::max(1u, canvas.CalcTextSize("i").width);
+
+  std::size_t safe = width / max_cw;
+  std::size_t must = width / min_cw + 1;
+  if (must <= safe)
+    must = safe + 1;
+
+  return {safe, must};
+}
+
 [[gnu::pure]]
 static bool
 TextFitsWidth(Canvas &canvas, const char *start, const char *end,
-              unsigned width) noexcept
+              unsigned width, const WrapBudget &budget) noexcept
 {
   if (start >= end)
     return true;
 
-  const PixelSize size =
-    canvas.CalcTextSize({start, std::size_t(end - start)});
-  return size.width <= width;
+  const std::size_t chars = CountUTF8Chars(start, end);
+  if (chars <= budget.safe_fit_chars)
+    return true;
+  if (chars >= budget.must_wrap_chars)
+    return false;
+
+  return canvas.CalcTextSize({start, std::size_t(end - start)}).width
+    <= width;
 }
 
-/**
- * Break within [line_start, word_end) when a single word exceeds @p width.
- * Returns a pointer past the last UTF-8 character that still fits; at
- * least one character is included even when it is wider than @p width.
- */
 static const char *
 FindCharWrapBreak(Canvas &canvas, const char *line_start,
-                  const char *word_end, unsigned width) noexcept
+                  const char *word_end, unsigned width,
+                  const WrapBudget &budget) noexcept
 {
   const std::size_t char_count = CountUTF8Chars(line_start, word_end);
   if (char_count == 0)
     return line_start;
+
+  if (char_count <= budget.safe_fit_chars)
+    return word_end;
 
   std::size_t lo = 1;
   std::size_t hi = char_count;
@@ -84,7 +108,7 @@ FindCharWrapBreak(Canvas &canvas, const char *line_start,
   while (lo <= hi) {
     const std::size_t mid = (lo + hi) / 2;
     const char *mid_end = AdvanceUTF8Chars(line_start, word_end, mid);
-    if (TextFitsWidth(canvas, line_start, mid_end, width)) {
+    if (TextFitsWidth(canvas, line_start, mid_end, width, budget)) {
       best = mid;
       lo = mid + 1;
     } else
@@ -97,14 +121,9 @@ FindCharWrapBreak(Canvas &canvas, const char *line_start,
   return AdvanceUTF8Chars(line_start, word_end, best);
 }
 
-/**
- * Find the next line break for text that does not fit on one line.
- * Breaks at the last word boundary that fits, or within a word when
- * needed.
- */
 static const char *
 FindWrapBreak(Canvas &canvas, const char *line_start, const char *para_end,
-              unsigned width) noexcept
+              unsigned width, const WrapBudget &budget) noexcept
 {
   const char *p = line_start;
   const char *break_point = nullptr;
@@ -124,7 +143,7 @@ FindWrapBreak(Canvas &canvas, const char *line_start, const char *para_end,
     if (extent < para_end && *extent == ' ')
       ++extent;
 
-    if (TextFitsWidth(canvas, line_start, extent, width)) {
+    if (TextFitsWidth(canvas, line_start, extent, width, budget)) {
       break_point = word_end;
       if (word_end < para_end && *word_end == ' ')
         break_point = word_end + 1;
@@ -135,45 +154,51 @@ FindWrapBreak(Canvas &canvas, const char *line_start, const char *para_end,
     if (break_point != nullptr && break_point > line_start)
       return break_point;
 
-    return FindCharWrapBreak(canvas, word_start, word_end, width);
+    return FindCharWrapBreak(canvas, word_start, word_end, width, budget);
   }
 
   if (break_point != nullptr && break_point > line_start)
     return break_point;
 
-  return FindCharWrapBreak(canvas, line_start, para_end, width);
+  return FindCharWrapBreak(canvas, line_start, para_end, width, budget);
 }
 
 /**
- * Wrap a single paragraph (no embedded newlines) into lines.
+ * Wrap one paragraph.  Fast path: character budget or one full-line
+ * FreeType measure (typical list bullets stay on one line).
  */
 static void
-WrapParagraph(Canvas &canvas, unsigned width,
+WrapParagraph(Canvas &canvas, unsigned width, const WrapBudget &budget,
               const char *para_start, std::size_t para_len,
               std::size_t text_offset,
               std::vector<WrappedTextLine> &lines) noexcept
 {
   if (para_len == 0) {
-    // Empty paragraph (blank line)
     lines.push_back({text_offset, 0});
     return;
   }
 
   const char *para_end = para_start + para_len;
-  const char *line_start = para_start;
+  if (TextFitsWidth(canvas, para_start, para_end, width, budget)) {
+    lines.push_back({text_offset, para_len});
+    return;
+  }
 
+  const char *line_start = para_start;
   while (line_start < para_end) {
-    const std::size_t remaining = para_end - line_start;
-    if (TextFitsWidth(canvas, line_start, para_end, width)) {
+    if (TextFitsWidth(canvas, line_start, para_end, width, budget)) {
+      std::size_t line_len = para_end - line_start;
+      if (line_len > 0 && line_start[line_len - 1] == ' ')
+        --line_len;
       lines.push_back({
         text_offset + static_cast<std::size_t>(line_start - para_start),
-        remaining
+        line_len
       });
       break;
     }
 
     const char *break_point =
-      FindWrapBreak(canvas, line_start, para_end, width);
+      FindWrapBreak(canvas, line_start, para_end, width, budget);
     if (break_point <= line_start) {
       const std::size_t seq_len =
         ClampedSequenceLengthUTF8(*line_start, para_end - line_start);
@@ -195,14 +220,10 @@ WrapParagraph(Canvas &canvas, unsigned width,
   }
 }
 
-WrappedText
-WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept
+template<typename F>
+static void
+ForEachParagraph(std::string_view text, F &&fn) noexcept
 {
-  WrappedText result;
-
-  if (text.empty() || width == 0)
-    return result;
-
   const char *start = text.data();
   const char *end = start + text.size();
   const char *para_start = start;
@@ -212,14 +233,28 @@ WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept
     while (para_end < end && *para_end != '\n')
       ++para_end;
 
-    const std::size_t text_offset = para_start - start;
-    WrapParagraph(canvas, width, para_start, para_end - para_start,
-                  text_offset, result.lines);
+    fn(para_start, para_end - para_start,
+       static_cast<std::size_t>(para_start - start));
 
     para_start = para_end;
     if (para_start < end && *para_start == '\n')
       ++para_start;
   }
+}
+
+WrappedText
+WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept
+{
+  WrappedText result;
+
+  if (text.empty() || width == 0)
+    return result;
+
+  const WrapBudget budget = CalibrateWrapBudget(canvas, width);
+  ForEachParagraph(text, [&](const char *para, std::size_t len,
+                             std::size_t offset) {
+    WrapParagraph(canvas, width, budget, para, len, offset, result.lines);
+  });
 
   return result;
 }
@@ -230,4 +265,38 @@ WrapText(const Font &font, unsigned width, std::string_view text) noexcept
   AnyCanvas canvas;
   canvas.Select(font);
   return WrapText(canvas, width, text);
+}
+
+unsigned
+EstimateWrappedLineCount(const Font &font, unsigned width,
+                         std::string_view text) noexcept
+{
+  if (text.empty() || width == 0)
+    return 0;
+
+  AnyCanvas canvas;
+  canvas.Select(font);
+
+  static constexpr char sample[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const unsigned sample_chars = sizeof(sample) - 1;
+  const unsigned avg_cw = std::max(
+    1u,
+    (std::max(1u, canvas.CalcTextSize(sample).width) + sample_chars - 1) /
+      sample_chars);
+  const std::size_t chars_per_line =
+    std::max<std::size_t>(1, width / avg_cw);
+
+  unsigned lines = 0;
+  ForEachParagraph(text, [&](const char *para, std::size_t len,
+                             [[maybe_unused]] std::size_t offset) {
+    const std::size_t chars = CountUTF8Chars(para, para + len);
+    if (chars == 0)
+      ++lines;
+    else
+      lines += static_cast<unsigned>((chars + chars_per_line - 1) /
+                                     chars_per_line);
+  });
+
+  return lines + (lines + 9) / 10;
 }

--- a/src/ui/canvas/TextWrapper.cpp
+++ b/src/ui/canvas/TextWrapper.cpp
@@ -80,7 +80,10 @@ TextFitsWidth(Canvas &canvas, const char *start, const char *end,
     return true;
 
   const std::size_t chars = CountUTF8Chars(start, end);
-  if (chars <= budget.safe_fit_chars)
+  /* safe_fit is calibrated with 'W' (Latin).  Only trust it when every
+     character is a single byte — wider scripts (CJK, …) must measure. */
+  if (chars <= budget.safe_fit_chars &&
+      std::size_t(end - start) == chars)
     return true;
   if (chars >= budget.must_wrap_chars)
     return false;
@@ -98,7 +101,8 @@ FindCharWrapBreak(Canvas &canvas, const char *line_start,
   if (char_count == 0)
     return line_start;
 
-  if (char_count <= budget.safe_fit_chars)
+  if (char_count <= budget.safe_fit_chars &&
+      std::size_t(word_end - line_start) == char_count)
     return word_end;
 
   std::size_t lo = 1;

--- a/src/ui/canvas/TextWrapper.hpp
+++ b/src/ui/canvas/TextWrapper.hpp
@@ -50,6 +50,9 @@ struct WrappedText {
  * Breaks at word boundaries (spaces) when possible, otherwise
  * breaks at character boundaries for very long words.
  *
+ * Short runs skip FreeType via a glyph-width character budget; a single
+ * full-line measure keeps typical list bullets on one line.
+ *
  * @param canvas Canvas with font selected for text measurement
  * @param width Maximum width in pixels for each line
  * @param text The text to wrap
@@ -66,3 +69,12 @@ WrapText(Canvas &canvas, unsigned width, std::string_view text) noexcept;
 [[gnu::pure]]
 WrappedText
 WrapText(const Font &font, unsigned width, std::string_view text) noexcept;
+
+/**
+ * Cheap line-count estimate for scroll sizing (no wrapping).
+ * Average Latin glyph width plus ~10% slack.
+ */
+[[gnu::pure]]
+unsigned
+EstimateWrappedLineCount(const Font &font, unsigned width,
+                         std::string_view text) noexcept;

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -13,6 +13,7 @@
 #include "Look/Colors.hpp"
 #include "ResourceLookup.hpp"
 #include "Form/CheckBox.hpp"
+#include "Form/VScrollPanel.hpp"
 #include "system/OpenLink.hpp"
 #include "util/StringCompare.hxx"
 #include "util/UriSchemes.hpp"
@@ -394,6 +395,14 @@ RichTextWindow::EnsureLineLayout() const noexcept
   }
 
   line_layout_width = text_width;
+
+  if (!line_y_offsets.empty()) {
+    const std::size_t n = line_y_offsets.size();
+    cached_content_height =
+      static_cast<unsigned>(line_y_offsets[n - 1] + line_heights[n - 1])
+      + padding * 2;
+    cached_height_width = text_width;
+  }
 }
 
 void
@@ -408,6 +417,7 @@ RichTextWindow::InvalidateLayout() noexcept
 {
   cached_content_height = 0;
   cached_height_width = 0;
+  synced_scroll_height = 0;
   wrapped_text.reset();
   wrapped_text_width = 0;
   segmented_lines.reset();
@@ -772,21 +782,75 @@ RichTextWindow::GetContentHeight() const noexcept
   if (cached_content_height > 0 && cached_height_width == text_width)
     return cached_content_height;
 
-  EnsureLineLayout();
+  /* Exact once already wrapped for this width (e.g. after paint). */
+  if (wrapped_text && wrapped_text_width == text_width) {
+    EnsureLineLayout();
+    return line_y_offsets.empty() ? 0 : cached_content_height;
+  }
 
-  if (line_y_offsets.empty())
+  /* Cheap estimate so Show()/VScroll does not wrap yet.  Use the
+     tallest font that may appear so heading pages are not clipped. */
+  const int touch_line_pad = IsTouchLayout() ? Layout::Scale(2) : 0;
+  unsigned line_height =
+    static_cast<unsigned>(font->GetLineSpacing() + touch_line_pad);
+  for (const auto &span : parsed.styles) {
+    if (span.style != TextStyle::Heading1 &&
+        span.style != TextStyle::Heading2 &&
+        span.style != TextStyle::Heading3)
+      continue;
+    const unsigned h =
+      static_cast<unsigned>(GetHeadingFont(span.style).GetLineSpacing() +
+                            touch_line_pad);
+    if (h > line_height)
+      line_height = h;
+  }
+
+  const unsigned line_count =
+    std::max(1u, EstimateWrappedLineCount(*font, text_width, parsed.text));
+
+  cached_content_height = line_count * line_height + padding * 2;
+  cached_height_width = text_width;
+  return cached_content_height;
+}
+
+/**
+ * After exact layout, resize the parent #VScrollPanel virtual height
+ * so the scrollbar matches content (Show() only saw the estimate).
+ */
+void
+RichTextWindow::SyncParentScrollHeight() noexcept
+{
+  if (cached_content_height == 0 ||
+      synced_scroll_height == cached_content_height)
+    return;
+
+  auto *panel = dynamic_cast<VScrollPanel *>(GetParent());
+  if (panel == nullptr)
+    return;
+
+  const unsigned vh =
+    std::max(panel->GetSize().height, cached_content_height);
+  panel->SetVirtualHeight(vh);
+  Move(panel->GetVirtualRect());
+  panel->Invalidate();
+  synced_scroll_height = cached_content_height;
+}
+
+unsigned
+RichTextWindow::CalculateExactContentHeight() const noexcept
+{
+  if (font == nullptr || parsed.text.empty())
     return 0;
 
-  /* Total height = Y offset of last line + its height + padding*2 */
-  const std::size_t n = line_y_offsets.size();
-  const unsigned content_height =
-    static_cast<unsigned>(line_y_offsets[n - 1] + line_heights[n - 1])
-    + padding * 2;
+  const int padding = GetContentPadding();
+  const auto size = GetSize();
+  if (size.width <= unsigned(padding * 2))
+    return 0;
 
-  cached_content_height = content_height;
-  cached_height_width = text_width;
-
-  return content_height;
+  cached_content_height = 0;
+  EnsureLineLayout();
+  /* const API used by the harness; sync from OnPaint in the UI. */
+  return cached_content_height;
 }
 
 void
@@ -809,8 +873,6 @@ void
 RichTextWindow::OnSetFocus() noexcept
 {
   PaintWindow::OnSetFocus();
-  focus_exhausted_down = false;
-  focus_exhausted_up = false;
   Invalidate();
 }
 
@@ -819,6 +881,7 @@ RichTextWindow::OnKillFocus() noexcept
 {
   PaintWindow::OnKillFocus();
   ClearLinkFocus();
+  focused_checkbox_style.reset();
   Invalidate();
 }
 
@@ -986,11 +1049,13 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
   const int padding = GetContentPadding();
   const int text_line_height = font->GetLineSpacing();
 
-  int visible_top, visible_bottom, viewport_height;
-  GetVisibleArea(visible_top, visible_bottom, viewport_height);
-
   EnsureSegmentedLines();
   EnsureLineLayout();
+  /* Sync before GetVisibleArea(): Move() changes GetPosition(). */
+  SyncParentScrollHeight();
+
+  int visible_top, visible_bottom, viewport_height;
+  GetVisibleArea(visible_top, visible_bottom, viewport_height);
 
   if (!segmented_lines || segmented_lines->empty() ||
       line_y_offsets.empty())
@@ -1143,14 +1208,6 @@ RichTextWindow::OnLinkActivated(std::size_t index) noexcept
 bool
 RichTextWindow::OnKeyCheck(unsigned key_code) const noexcept
 {
-  /* If focus navigation has been exhausted in this direction,
-     tell the dialog we don't want the key so it can cycle focus
-     to the next tab stop (e.g. pager buttons). */
-  if (key_code == KEY_DOWN && focus_exhausted_down)
-    return false;
-  if (key_code == KEY_UP && focus_exhausted_up)
-    return false;
-
   switch (key_code) {
   case KEY_UP:
   case KEY_DOWN:
@@ -1303,28 +1360,24 @@ RichTextWindow::ScrollToFocusItem(const FocusItem &item) noexcept
     focused_checkbox_style.reset();
   }
 
-  /* Scroll to the item using content coordinates */
+  /* #VScrollPanel::ScrollTo expects parent-client coordinates. */
   ContainerWindow *parent = GetParent();
   if (parent != nullptr) {
     const PixelRect window_rect = GetPosition();
     const int parent_height = parent->GetSize().height;
-    const int scroll_margin = Layout::Scale(20);
+    const int margin = Layout::Scale(20);
 
-    /* Convert content-space Y to parent coordinates */
     const int item_top = item.y_pos + window_rect.top;
     const int item_bottom = item.y_pos + item.height + window_rect.top;
 
-    if (item_top < scroll_margin ||
-        item_bottom > parent_height - scroll_margin) {
-      PixelRect scroll_rc;
-      scroll_rc.left = 0;
-      scroll_rc.right = 1;
-      if (item_top < scroll_margin) {
-        scroll_rc.top = item.y_pos - scroll_margin;
+    if (item_top < margin || item_bottom > parent_height - margin) {
+      PixelRect scroll_rc{0, 0, 1, 1};
+      if (item_top < margin) {
+        scroll_rc.top = item_top - margin;
         scroll_rc.bottom = scroll_rc.top + 1;
       } else {
-        scroll_rc.top = item.y_pos + item.height + scroll_margin;
-        scroll_rc.bottom = scroll_rc.top + 1;
+        scroll_rc.bottom = item_bottom + margin;
+        scroll_rc.top = scroll_rc.bottom - 1;
       }
       parent->ScrollTo(scroll_rc);
     }
@@ -1333,39 +1386,13 @@ RichTextWindow::ScrollToFocusItem(const FocusItem &item) noexcept
   Invalidate();
 }
 
-bool
-RichTextWindow::AdvanceFocusToNextFrom(
-  const std::vector<FocusItem> &items,
-  std::optional<std::size_t> current_pos,
-  int max_jump) noexcept
+[[gnu::pure]]
+static bool
+FocusItemVisible(const FocusItem &item,
+                 int visible_top, int visible_bottom) noexcept
 {
-  if (!current_pos.has_value())
-    return false;
-
-  if (current_pos.value() + 1 < items.size()) {
-    const auto &cur = items[current_pos.value()];
-    const auto &next = items[current_pos.value() + 1];
-    if (next.y_pos - cur.y_pos > max_jump) {
-      /* Next item is too far away — clear focus and let
-         the scroll widget handle line-by-line scrolling. */
-      focused_checkbox_style.reset();
-      focused_link.reset();
-      focus_exhausted_down = true;
-      Invalidate();
-      return false;
-    }
-    focus_exhausted_up = false;
-    ScrollToFocusItem(next);
-    return true;
-  }
-
-  focused_checkbox_style.reset();
-  focused_link.reset();
-  focus_exhausted_down = true;
-  Invalidate();
-  if (ContainerWindow *parent = GetParent())
-    return parent->InjectKeyPress(KEY_DOWN);
-  return LinkableWindow::OnKeyDown(KEY_DOWN);
+  return item.y_pos + item.height > visible_top &&
+         item.y_pos < visible_bottom;
 }
 
 bool
@@ -1373,124 +1400,82 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
 {
   EnsureSegmentedLines();
   EnsureLineLayout();
+  SyncParentScrollHeight();
 
   if (!segmented_lines || segmented_lines->empty() ||
       line_y_offsets.empty())
     return LinkableWindow::OnKeyDown(key_code);
 
   const int padding = GetContentPadding();
-  const int text_line_height =
-    font != nullptr ? font->GetLineSpacing() : 16;
-
   const auto items = BuildFocusItems(*this, *segmented_lines,
                                      line_y_offsets, line_heights,
                                      padding);
   if (items.empty())
     return LinkableWindow::OnKeyDown(key_code);
 
+  int visible_top, visible_bottom, viewport_height;
+  GetVisibleArea(visible_top, visible_bottom, viewport_height);
+  (void)viewport_height;
+
   const auto current_pos =
-    FindCurrentFocusIndex(items, focused_checkbox_style,
-                          focused_link);
-
-  /* Maximum distance (in pixels) between two focus items before we
-     let the scroll widget handle line-by-line scrolling instead of
-     jumping directly.  This prevents jarring full-document jumps
-     when links are far apart (e.g. one at the top, several at the
-     bottom of a long text). */
-  const int viewport_height = GetClientRect().GetHeight();
-  const int max_jump = viewport_height;
-
-  /* Current visible range in content-space coordinates.  When
-     the window is scrolled inside a VScrollPanel, GetPosition().top
-     becomes negative by the scroll offset. */
-  const PixelRect win_pos = GetPosition();
-  const int visible_top = -win_pos.top;
-  const int visible_bottom = visible_top + viewport_height;
+    FindCurrentFocusIndex(items, focused_checkbox_style, focused_link);
 
   switch (key_code) {
   case KEY_DOWN:
     if (!current_pos.has_value()) {
-      /* No focus set.  When focus_exhausted_down is active (we
-         cleared focus because the next link was too far away),
-         only pick up items in the lower portion of the viewport
-         to avoid jumping back to items we've already scrolled
-         past.  Otherwise accept any visible item. */
-      const int search_start = focus_exhausted_down
-        ? visible_top + viewport_height / 3
-        : visible_top - text_line_height;
-
-      const FocusItem *best = nullptr;
+      /* Pick the first item currently in view. */
       for (const auto &it : items) {
-        if (it.y_pos >= search_start) {
-          best = &it;
-          break;
+        if (FocusItemVisible(it, visible_top, visible_bottom)) {
+          ScrollToFocusItem(it);
+          return true;
         }
       }
-      if (best != nullptr && best->y_pos <= visible_bottom) {
-        focus_exhausted_down = false;
-        focus_exhausted_up = false;
-        ScrollToFocusItem(*best);
-        return true;
-      }
-      /* No suitable item — let scroll widget handle it */
       return false;
     }
-    return AdvanceFocusToNextFrom(items, current_pos, max_jump);
+    if (current_pos.value() + 1 < items.size()) {
+      const auto &next = items[current_pos.value() + 1];
+      /* Stay within roughly one viewport; otherwise let the
+         scroller move — keep the current item so focus is not
+         lost while scrolling between sparse links. */
+      if (next.y_pos - items[current_pos.value()].y_pos <=
+          visible_bottom - visible_top) {
+        ScrollToFocusItem(next);
+        return true;
+      }
+    }
+    return false;
 
   case KEY_UP:
     if (!current_pos.has_value()) {
-      /* No focus set.  When focus_exhausted_up is active,
-         only pick up items in the upper portion of the viewport
-         to avoid jumping forward to items we've scrolled past.
-         Otherwise accept any visible item. */
-      const int search_end = focus_exhausted_up
-        ? visible_bottom - viewport_height / 3
-        : visible_bottom;
-
-      const FocusItem *best = nullptr;
       for (auto it = items.rbegin(); it != items.rend(); ++it) {
-        if (it->y_pos <= search_end) {
-          best = &*it;
-          break;
+        if (FocusItemVisible(*it, visible_top, visible_bottom)) {
+          ScrollToFocusItem(*it);
+          return true;
         }
       }
-      if (best != nullptr && best->y_pos >= visible_top - text_line_height) {
-        focus_exhausted_up = false;
-        focus_exhausted_down = false;
-        ScrollToFocusItem(*best);
+      return false;
+    }
+    if (current_pos.value() > 0) {
+      const auto &prev = items[current_pos.value() - 1];
+      if (items[current_pos.value()].y_pos - prev.y_pos <=
+          visible_bottom - visible_top) {
+        ScrollToFocusItem(prev);
         return true;
       }
-      /* No suitable item — let scroll widget handle it */
-      return false;
-    } else if (current_pos.value() > 0) {
-      const auto &cur = items[current_pos.value()];
-      const auto &prev = items[current_pos.value() - 1];
-      if (cur.y_pos - prev.y_pos > max_jump) {
-        /* Previous item is too far away — clear focus and let
-           the scroll widget handle line-by-line scrolling. */
-        focused_checkbox_style.reset();
-        focused_link.reset();
-        focus_exhausted_up = true;
-        Invalidate();
-        return false;
-      }
-      focus_exhausted_down = false;
-      ScrollToFocusItem(prev);
-      return true;
-    } else {
-      focused_checkbox_style.reset();
-      focused_link.reset();
-      focus_exhausted_up = true;
-      Invalidate();
-      if (ContainerWindow *parent = GetParent())
-        return parent->InjectKeyPress(key_code);
     }
-    break;
+    return false;
 
   case KEY_RETURN:
     if (focused_checkbox_style.has_value()) {
       ToggleCheckbox(focused_checkbox_style.value());
-      AdvanceFocusToNextFrom(items, current_pos, max_jump);
+      /* Advance like Down when possible. */
+      if (current_pos.has_value() &&
+          current_pos.value() + 1 < items.size()) {
+        const auto &next = items[current_pos.value() + 1];
+        if (next.y_pos - items[current_pos.value()].y_pos <=
+            visible_bottom - visible_top)
+          ScrollToFocusItem(next);
+      }
       return true;
     }
     if (focused_link.has_value()) {

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -828,12 +828,14 @@ RichTextWindow::SyncParentScrollHeight() noexcept
   if (panel == nullptr)
     return;
 
-  const unsigned vh =
-    std::max(panel->GetSize().height, cached_content_height);
+  /* Move() may trigger OnResize() → InvalidateLayout(), which clears
+     cached_content_height; keep the value we synced. */
+  const unsigned height = cached_content_height;
+  const unsigned vh = std::max(panel->GetSize().height, height);
   panel->SetVirtualHeight(vh);
   Move(panel->GetVirtualRect());
   panel->Invalidate();
-  synced_scroll_height = cached_content_height;
+  synced_scroll_height = height;
 }
 
 unsigned
@@ -848,6 +850,11 @@ RichTextWindow::CalculateExactContentHeight() const noexcept
     return 0;
 
   cached_content_height = 0;
+  /* EnsureLineLayout() returns early when the layout is still valid
+     for this width, which would leave the height at 0. */
+  line_y_offsets.clear();
+  line_heights.clear();
+  line_layout_width = 0;
   EnsureLineLayout();
   /* const API used by the harness; sync from OnPaint in the UI. */
   return cached_content_height;

--- a/src/ui/control/RichTextWindow.hpp
+++ b/src/ui/control/RichTextWindow.hpp
@@ -90,6 +90,9 @@ class RichTextWindow : public LinkableWindow {
   /** Width used for cached height calculation */
   mutable unsigned cached_height_width = 0;
 
+  /** Last content height pushed to a parent #VScrollPanel (0 = none). */
+  mutable unsigned synced_scroll_height = 0;
+
   /** Wrapped lines from TextWrapper (opaque pointer to avoid header include) */
   mutable std::unique_ptr<WrappedText> wrapped_text;
 
@@ -114,15 +117,6 @@ class RichTextWindow : public LinkableWindow {
 
   /** Currently focused checkbox style_index (into parsed.styles), or nullopt */
   mutable std::optional<std::size_t> focused_checkbox_style;
-
-  /**
-   * Set when focus navigation reached the end (down) or start (up)
-   * of all focusable items.  While set, the next DOWN/UP returns
-   * false so the dialog can cycle focus to the next tab stop
-   * (e.g. pager buttons).  Cleared when the window receives focus.
-   */
-  mutable bool focus_exhausted_down = false;
-  mutable bool focus_exhausted_up = false;
 
   /** Cache of loaded bitmaps keyed by URL */
   mutable std::map<std::string, Bitmap> image_cache;
@@ -196,6 +190,12 @@ private:
    */
   void InvalidateLayout() noexcept;
 
+  /**
+   * Push exact #cached_content_height to a parent #VScrollPanel after
+   * layout (Show() may have sized the panel from the estimate).
+   */
+  void SyncParentScrollHeight() noexcept;
+
   /** Render an inline image for a segment, if present.
    * @return true if an image was rendered (caller should skip text) */
   bool RenderInlineImage(Canvas &canvas, const TextSegment &seg,
@@ -220,14 +220,6 @@ private:
 
   /** Set focus to a FocusItem and scroll to make it visible. */
   void ScrollToFocusItem(const FocusItem &item) noexcept;
-
-  /**
-   * Move focus to the next link or checkbox (same rules as KEY_DOWN when
-   * focus is already set), including max_jump and end-of-list handling.
-   */
-  bool AdvanceFocusToNextFrom(const std::vector<FocusItem> &items,
-                              std::optional<std::size_t> current_pos,
-                              int max_jump) noexcept;
 
 public:
   RichTextWindow() noexcept;
@@ -308,12 +300,14 @@ public:
   void SetText(const char *text, bool parse_markdown = true);
 
   /**
-   * Get the total content height in pixels.
-   * This accounts for text wrapping at the current width.
-   * Used by VScrollWidget to set virtual height.
+   * Content height for scroll sizing.  May be a cheap estimate before
+   * the first wrap; exact after layout / #CalculateExactContentHeight.
    */
   [[gnu::pure]]
   unsigned GetContentHeight() const noexcept;
+
+  /** Force wrap + line layout; return exact content height. */
+  unsigned CalculateExactContentHeight() const noexcept;
 
   /**
    * Get the parsed links.

--- a/test/src/RunRichTextRenderer.cpp
+++ b/test/src/RunRichTextRenderer.cpp
@@ -184,19 +184,23 @@ RunBenchmark(TestMainWindow &main_window, const std::string &text)
   window.SetDialogLook(look);
   window.SetText(text.c_str(), !options.plain);
   const auto t3 = clock::now();
-  const unsigned height = window.GetContentHeight();
+  const unsigned height_estimate = window.GetContentHeight();
   const auto t4 = clock::now();
+  const unsigned height = window.CalculateExactContentHeight();
+  const auto t5 = clock::now();
 
   std::printf("source bytes: %zu\n", text.size());
   std::printf("layout width: %u px\n", width);
   std::printf("wrapped lines: %zu\n", wrapped.lines.size());
+  std::printf("estimated height: %u px\n", height_estimate);
   std::printf("content height: %u px\n", height);
   if (!options.plain)
     std::printf("parse markdown: %lld ms\n", Ms(t1 - t0));
   std::printf("wrap text: %lld ms\n", Ms(t2 - t1));
   std::printf("set text: %lld ms\n", Ms(t3 - t2));
-  std::printf("line layout (GetContentHeight): %lld ms\n", Ms(t4 - t3));
-  std::printf("total: %lld ms\n", Ms(t4 - t0));
+  std::printf("estimate height: %lld ms\n", Ms(t4 - t3));
+  std::printf("exact line layout: %lld ms\n", Ms(t5 - t4));
+  std::printf("total: %lld ms\n", Ms(t5 - t0));
 }
 
 static void


### PR DESCRIPTION
## Summary
- Speed up long Markdown pages (Quick Guide / What’s New) by estimating scroll height before wrapping, skipping FreeType for runs that clearly fit or overflow via a character budget, and syncing `VScrollPanel` to the exact height after layout.
- Fix Up/Down link focus scrolling to use viewport coordinates so selected links stay visible.
- Fix Quick Guide keyboard navigation so the bottom-bar checkbox and Close are reachable (explicit pager chrome focus chain; stop TabStop on `VScrollPanel` so focus does not land on the panel and scroll off-screen).

## Test plan
- [ ] Open Quick Guide from **Info → Quick Guide**; walk Down through content → “Don’t show this guide again” → prev/next → **Close**; Up returns through the same chain
- [ ] On What’s New (if shown): Down/Up between links keeps the focused link in view; Down past last link reaches the release-notes checkbox then Close
- [ ] Long What’s New / Credits News page opens without a long freeze on e-ink/Kobo; scrollbar matches content after first paint
- [ ] `output/UNIX/bin/TestWrapText` and `RunRichTextRenderer --benchmark` still look sane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Quick Guide keyboard navigation, including access to bottom-bar controls and the Close button.
  * Improved rich-text layout estimation for faster loading of long “What’s New” content.
  * Enhanced scrolling and focus movement within rich-text pages.

* **Bug Fixes**
  * Fixed focus navigation reaching all Quick Guide controls reliably.
  * Improved scroll sizing and reduced unnecessary delays during rich-text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->