### PR TITLE
Device/Driver/LX: Accept partial LXWP0 vario samples

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -61,6 +61,9 @@ Version 7.45 - not yet released
   - always start in light mode; dark mode is not supported on e-paper
     displays #2568
 * devices
+  - Accept partial $LXWP0 vario samples (e.g. BlueFly LX mode with a
+    single rate) so Status Variometer is not stuck on Disconnected while
+    baro still works; keep the six-sample FIR for full LXNAV sentences #2763
   - fix LXNAV thermal averages when the device reports conflicting
     altitude sources #2754
   - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -62,18 +62,32 @@ ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario)
   static constexpr double fir_coefficients[] = {
     -0.0421, 0.1628, 0.3793, 0.3793, 0.1628, -0.0421,
   };
+  static constexpr unsigned N = ARRAY_SIZE(fir_coefficients);
 
-  vario = 0;
-  bool vario_ok = true;
-  double value = 0;
-  for (double fir_b : fir_coefficients) {
-    if (!line.ReadChecked(value))
-      vario_ok = false;
-    else
-      vario += value * fir_b;
+  double samples[N];
+  unsigned n_valid = 0;
+
+  /* Always consume six fields so heading/wind stay aligned. */
+  for (unsigned i = 0; i < N; ++i) {
+    double value;
+    if (line.ReadChecked(value))
+      samples[n_valid++] = value;
   }
 
-  return vario_ok;
+  if (n_valid == 0)
+    return false;
+
+  if (n_valid == N) {
+    vario = 0;
+    for (unsigned i = 0; i < N; ++i)
+      vario += samples[i] * fir_coefficients[i];
+    return true;
+  }
+
+  /* Partial sentence (e.g. BlueFly LX output): restore 7.44 behaviour
+     and take the first successfully parsed sample. */
+  vario = samples[0];
+  return true;
 }
 
 /**

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -15,8 +15,11 @@ struct DeviceInfo;
 namespace LX {
 
 /**
- * Read six LXWP0 vario samples and apply the 5th-order low-pass FIR
- * filter used by LX EOS.
+ * Read up to six LXWP0 vario samples.  When all six are present,
+ * apply the 5th-order low-pass FIR used by LX EOS / full LXNAV
+ * sentences.  When only some slots are filled (BlueFly LX mode,
+ * Condor, older devices — often a single sample), use the first
+ * valid sample so TE vario is still published (#2763).
  */
 bool
 ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario);

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1326,6 +1326,21 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
   ok1(equals(nmea_info.external_wind.norm, 10.1 / 3.6));
   ok1(equals(nmea_info.external_wind.bearing, reciprocal_wind ? 354 : 174));
 
+  if (!condor) {
+    /* BlueFly LX mode / classic example: only the first of six vario
+       slots is filled.  Must still publish TE vario (#2763). */
+    nmea_info.Reset();
+    nmea_info.clock = TimeStamp{FloatDuration{1}};
+    ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1*47",
+                          nmea_info));
+    ok1(nmea_info.pressure_altitude_available);
+    ok1(equals(nmea_info.pressure_altitude, 1665.5));
+    ok1(nmea_info.airspeed_available);
+    ok1(nmea_info.total_energy_vario_available);
+    ok1(equals(nmea_info.total_energy_vario, 1.71));
+    ok1(nmea_info.external_wind_available);
+  }
+
 
   nmea_info.Reset();
   nmea_info.clock = TimeStamp{FloatDuration{1}};
@@ -3210,7 +3225,7 @@ int main()
   SetSingleDataPath(data_path);
   CreateDataPath();
 
-  plan_tests(1043 /* drivers */ + 29 /* PFLAU extended */
+  plan_tests(1050 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 109 /* LXNav protocol 1.05 */


### PR DESCRIPTION
## Summary
- `$LXWP0` TE vario parsing required all six FIR samples; devices that only fill the first slot (BlueFly LX mode, classic sentence shape) never published total-energy vario while baro from the same sentence still worked → Status Variometer stuck on **Disconnected**.
- Keep the six-sample FIR when all slots parse; otherwise use the first valid sample (7.44 behaviour).

Fixes #2763

## Test plan
- [ ] `output/UNIX/bin/TestDriver` (includes new single-sample `$LXWP0` case for LXNAV)
- [ ] BlueFly in LX @ 5 Hz + driver LXNAV: Status → Variometer shows **Total energy**, Alt Baro still OK
- [ ] Real LXNAV with six samples / `$PLXVF` path unchanged (#2754)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LXWP0 vario handling when only partial sampling data is available.
  * Prevented the Status Variometer from incorrectly showing “Disconnected” while barometric data remains available.
  * Preserved full six-sample filtering when complete LXNAV sentences are received.
* **Tests**
  * Added coverage for BlueFly LX data with a single vario sample, including altitude, airspeed, TE vario, and wind reporting.
* **Documentation**
  * Updated vario parsing documentation to reflect partial-sample behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->