### PR TITLE
Asset: Make HasEPaper configurable via Display type setting

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -27,6 +27,9 @@ Version 7.45 - not yet released
     overflow by character budget, and use one measure for typical bullets
   - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
     button are reachable from the keyboard
+  - Expert Look → Screen Layout setting "Display type" (LCD / E-ink /
+    Color e-ink); e-ink modes disable kinetic and smooth scrolling.
+    Defaults to E-ink on Kobo and LCD elsewhere
   - Device list: show the Vario flag for non-compensated and netto vario
     sources as well as total-energy (e.g. BlueFly)
   - E-paper: snap VScrollPanel smooth scrolling instead of animating at

--- a/src/Asset.cpp
+++ b/src/Asset.cpp
@@ -9,6 +9,24 @@
 #include "ui/event/Queue.hpp"
 #endif
 
+#ifndef KOBO
+static DisplayType display_type = DisplayType::LCD;
+#else
+static DisplayType display_type = DisplayType::E_INK;
+#endif
+
+void
+SetDisplayType(DisplayType type) noexcept
+{
+  display_type = type;
+}
+
+bool
+HasEPaper() noexcept
+{
+  return IsEPaperDisplayType(display_type);
+}
+
 #if (defined(USE_CONSOLE) && !defined(KOBO)) || defined(USE_WAYLAND)
 
 bool

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "DisplayType.hpp"
+
 #ifdef ANDROID
 #include "Android/Product.hpp"
 #endif
@@ -10,8 +12,6 @@
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #endif
-
-#include "DisplayType.hpp"
 
 #if defined(__APPLE__) && TARGET_OS_IPHONE
 #include "Apple/KeyboardDetection.hpp"
@@ -247,8 +247,8 @@ IsDithered() noexcept
  * and show ghosting.  Animations shall be disabled when this function
  * returns true.
  *
- * Driven by #DisplaySettings::type via #SetDisplayType().  Defaults
- * to e-ink on Kobo and LCD elsewhere.
+ * Driven by #DisplaySettings::display_type via #SetDisplayType().
+ * Defaults to e-ink on Kobo and LCD elsewhere.
  */
 void
 SetDisplayType(DisplayType type) noexcept;

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -11,6 +11,8 @@
 #include <TargetConditionals.h>
 #endif
 
+#include "DisplayType.hpp"
+
 #if defined(__APPLE__) && TARGET_OS_IPHONE
 #include "Apple/KeyboardDetection.hpp"
 #endif
@@ -244,9 +246,13 @@ IsDithered() noexcept
  * Such screens need some special cases, because they are very slow
  * and show ghosting.  Animations shall be disabled when this function
  * returns true.
+ *
+ * Driven by #DisplaySettings::type via #SetDisplayType().  Defaults
+ * to e-ink on Kobo and LCD elsewhere.
  */
-static constexpr bool
-HasEPaper() noexcept
-{
-  return IsKobo();
-}
+void
+SetDisplayType(DisplayType type) noexcept;
+
+[[gnu::pure]]
+bool
+HasEPaper() noexcept;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -16,6 +16,7 @@
 #include "Asset.hpp"
 #include "Menu/ShowButton.hpp"
 #include "ActionInterface.hpp"
+#include "util/Macros.hpp"
 
 #ifdef ANDROID
 #include "Android/Main.hpp"
@@ -33,6 +34,7 @@ enum ControlIndex {
 #endif
   MapOrientation,
   DarkMode,
+  AppDisplayType,
   AppInfoBoxGeom,
   InfoBoxTitleScale,
   TabDialogStyle,
@@ -62,6 +64,22 @@ static constexpr StaticEnumChoice display_orientation_list[] = {
     N_("Reverse Landscape") },
   nullptr
 };
+
+static constexpr StaticEnumChoice display_type_list[] = {
+  { DisplayType::LCD, N_("LCD"),
+    N_("Conventional LCD or OLED. Full scrolling animations.") },
+  { DisplayType::E_INK, N_("E-ink"),
+    N_("Monochrome electronic paper. Disables kinetic and smooth "
+       "scrolling.") },
+  { DisplayType::COLOR_E_INK, N_("Color e-ink"),
+    N_("Colour electronic paper. Disables kinetic and smooth "
+       "scrolling like monochrome e-ink.") },
+  nullptr
+};
+
+static_assert(ARRAY_SIZE(display_type_list) ==
+              unsigned(DisplayType::COUNT) + 1,
+              "display_type_list must match DisplayType::COUNT");
 
 static constexpr StaticEnumChoice info_box_geometry_list[] = {
   { InfoBoxSettings::Geometry::SPLIT_8,
@@ -194,6 +212,13 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   AddDummy();
 #endif
 
+  AddEnum(_("Display type"),
+          _("Select the display technology. E-ink modes disable kinetic "
+            "and smooth scrolling for slow refresh screens."),
+          display_type_list,
+          (unsigned)ui_settings.display.type);
+  SetExpertRow(AppDisplayType);
+
   AddEnum(_("InfoBox geometry"),
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
@@ -278,6 +303,12 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
     changed = true;
   }
 #endif
+
+  if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
+                    ui_settings.display.type)) {
+    changed = true;
+    SetDisplayType(ui_settings.display.type);
+  }
 
   bool info_box_geometry_changed = false;
 

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -72,7 +72,7 @@ static constexpr StaticEnumChoice display_type_list[] = {
     N_("Monochrome electronic paper. Disables kinetic and smooth "
        "scrolling.") },
   { DisplayType::COLOR_E_INK, N_("Color e-ink"),
-    N_("Colour electronic paper. Disables kinetic and smooth "
+    N_("Color electronic paper. Disables kinetic and smooth "
        "scrolling like monochrome e-ink.") },
   nullptr
 };
@@ -216,7 +216,7 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
           _("Select the display technology. E-ink modes disable kinetic "
             "and smooth scrolling for slow refresh screens."),
           display_type_list,
-          (unsigned)ui_settings.display.type);
+          (unsigned)ui_settings.display.display_type);
   SetExpertRow(AppDisplayType);
 
   AddEnum(_("InfoBox geometry"),
@@ -305,9 +305,9 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 #endif
 
   if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
-                    ui_settings.display.type)) {
+                    ui_settings.display.display_type)) {
     changed = true;
-    SetDisplayType(ui_settings.display.type);
+    SetDisplayType(ui_settings.display.display_type);
   }
 
   bool info_box_geometry_changed = false;

--- a/src/DisplaySettings.cpp
+++ b/src/DisplaySettings.cpp
@@ -11,8 +11,8 @@ DisplaySettings::SetDefaults()
   invert_cursor_colors = false;
   full_screen = true;
 #ifdef KOBO
-  type = DisplayType::E_INK;
+  display_type = DisplayType::E_INK;
 #else
-  type = DisplayType::LCD;
+  display_type = DisplayType::LCD;
 #endif
 }

--- a/src/DisplaySettings.cpp
+++ b/src/DisplaySettings.cpp
@@ -10,4 +10,9 @@ DisplaySettings::SetDefaults()
   cursor_size = 1;
   invert_cursor_colors = false;
   full_screen = true;
+#ifdef KOBO
+  type = DisplayType::E_INK;
+#else
+  type = DisplayType::LCD;
+#endif
 }

--- a/src/DisplaySettings.hpp
+++ b/src/DisplaySettings.hpp
@@ -21,7 +21,7 @@ struct DisplaySettings {
    * Display technology for refresh-sensitive UI.  Defaults to e-ink
    * on Kobo and LCD on other platforms.
    */
-  DisplayType type;
+  DisplayType display_type;
 
   void SetDefaults();
 };

--- a/src/DisplaySettings.hpp
+++ b/src/DisplaySettings.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "DisplayOrientation.hpp"
+#include "DisplayType.hpp"
 
 #include <type_traits>
 
@@ -15,6 +16,12 @@ struct DisplaySettings {
   uint8_t cursor_size;
   bool invert_cursor_colors;
   bool full_screen;
+
+  /**
+   * Display technology for refresh-sensitive UI.  Defaults to e-ink
+   * on Kobo and LCD on other platforms.
+   */
+  DisplayType type;
 
   void SetDefaults();
 };

--- a/src/DisplayType.hpp
+++ b/src/DisplayType.hpp
@@ -11,13 +11,13 @@
  * separate and may follow later.
  */
 enum class DisplayType : uint8_t {
-  /** Conventional LCD / OLED — full animations. */
+  /** Conventional LCD or OLED; full animations. */
   LCD,
 
   /** Monochrome electronic paper (slow refresh). */
   E_INK,
 
-  /** Colour electronic paper (still slow refresh). */
+  /** Color electronic paper (still slow refresh). */
   COLOR_E_INK,
 
   COUNT

--- a/src/DisplayType.hpp
+++ b/src/DisplayType.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * User-selected display technology.  Affects refresh-sensitive UI
+ * (scrolling, animations).  Visual greyscale / dither for e-ink is
+ * separate and may follow later.
+ */
+enum class DisplayType : uint8_t {
+  /** Conventional LCD / OLED — full animations. */
+  LCD,
+
+  /** Monochrome electronic paper (slow refresh). */
+  E_INK,
+
+  /** Colour electronic paper (still slow refresh). */
+  COLOR_E_INK,
+
+  COUNT
+};
+
+[[gnu::const]]
+constexpr bool
+IsEPaperDisplayType(DisplayType type) noexcept
+{
+  return type == DisplayType::E_INK ||
+    type == DisplayType::COLOR_E_INK;
+}

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -11,6 +11,7 @@ constexpr std::string_view FullScreen = "FullScreen";
 constexpr std::string_view UIScale = "UIScale";
 constexpr std::string_view CustomDPI = "CustomDPI";
 constexpr std::string_view DarkMode = "DarkMode";
+constexpr std::string_view DisplayType = "DisplayType";
 constexpr std::string_view Password = "Password";
 constexpr std::string_view AirspaceWarning = "AirspaceWarn";
 constexpr std::string_view AirspaceWarningDialog = "AirspaceWarnDialog";

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -27,7 +27,7 @@ Profile::Load(const ProfileMap &map, DisplaySettings &settings)
   map.Get(ProfileKeys::CursorSize, settings.cursor_size);
   map.Get(ProfileKeys::CursorColorsInverted, settings.invert_cursor_colors);
   map.Get(ProfileKeys::FullScreen, settings.full_screen);
-  map.GetEnum(ProfileKeys::DisplayType, settings.type);
+  map.GetEnum(ProfileKeys::DisplayType, settings.display_type);
 }
 
 void

--- a/src/Profile/UIProfile.cpp
+++ b/src/Profile/UIProfile.cpp
@@ -27,6 +27,7 @@ Profile::Load(const ProfileMap &map, DisplaySettings &settings)
   map.Get(ProfileKeys::CursorSize, settings.cursor_size);
   map.Get(ProfileKeys::CursorColorsInverted, settings.invert_cursor_colors);
   map.Get(ProfileKeys::FullScreen, settings.full_screen);
+  map.GetEnum(ProfileKeys::DisplayType, settings.type);
 }
 
 void

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -419,6 +419,8 @@ Startup(UI::Display &display)
   Display::LoadOrientation(operation);
   main_window->CheckResize();
 
+  SetDisplayType(CommonInterface::GetUISettings().display.type);
+
   /* Log device capabilities and features after initialization */
   LogFormat("Device capabilities: HasIOIOLib()=%s",
             HasIOIOLib() ? "yes" : "no");

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -419,7 +419,7 @@ Startup(UI::Display &display)
   Display::LoadOrientation(operation);
   main_window->CheckResize();
 
-  SetDisplayType(CommonInterface::GetUISettings().display.type);
+  SetDisplayType(CommonInterface::GetUISettings().display.display_type);
 
   /* Log device capabilities and features after initialization */
   LogFormat("Device capabilities: HasIOIOLib()=%s",

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -4,6 +4,24 @@
 #include "Asset.hpp"
 #include "CommandLine.hpp"
 
+#ifndef KOBO
+static DisplayType display_type = DisplayType::LCD;
+#else
+static DisplayType display_type = DisplayType::E_INK;
+#endif
+
+void
+SetDisplayType(DisplayType type) noexcept
+{
+  display_type = type;
+}
+
+bool
+HasEPaper() noexcept
+{
+  return IsEPaperDisplayType(display_type);
+}
+
 #if (defined(USE_CONSOLE) && !defined(KOBO)) || defined(USE_WAYLAND)
 
 bool


### PR DESCRIPTION
## Summary
- Add expert **Look → Screen Layout → Display type** (`LCD` / `E-ink` / `Color e-ink`).
- `HasEPaper()` follows e-ink modes so kinetic / pixel-pan scrolling can be disabled on Android e-readers and colour Kobos without a special build.
- Defaults: **E-ink** on Kobo, **LCD** elsewhere; setting is available on all platforms (including Kobo).

First slice of runtime display traits for #2738 (scroll/animation only — not Look greyscale / OpenGL dither).

Related: discussion https://github.com/XCSoar/XCSoar/discussions/1433 (Clara Colour), branch https://github.com/anj1/XCSoar/tree/kobo-clara-colour.

## Test plan
- [ ] UNIX: set Display type to E-ink → list / VScrollPanel lose kinetic pan; set LCD → restore
- [ ] Kobo: default remains e-paper behaviour; changing to LCD enables kinetic pan
- [ ] Android: enable E-ink or Color e-ink → same scroll behaviour as Kobo for `HasEPaper()` call sites
- [ ] Confirm Look colours / `IsDithered()` unchanged when only this setting is toggled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an expert **Display type** setting (LCD, e-ink, color e-ink).
  * E-ink modes disable kinetic and smooth scrolling.
  * The selected display type is saved and applied immediately at startup/runtime.
  * Defaults are e-ink on Kobo devices and LCD on other platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->