### PR TITLE
ui/window/TopWindow: Add optional redraw counter overlay

### DIFF
--- a/build/options.mk
+++ b/build/options.mk
@@ -36,6 +36,12 @@ ifeq ($(STOP_WATCH),y)
   TARGET_CPPFLAGS += -DSTOP_WATCH
 endif
 
+# show TopWindow present count + Hz overlay (e-ink debug)?
+DRAW_REDRAW_COUNTER ?= n
+ifeq ($(DRAW_REDRAW_COUNTER),y)
+  TARGET_CPPFLAGS += -DDRAW_REDRAW_COUNTER
+endif
+
 # compile without UI?
 HEADLESS ?= n
 

--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -100,6 +100,33 @@ etc.). Usage and examples: **Debugging XCSoar** in :doc:`architecture`::
 ``Run*`` utilities are small standalone binaries and are often easier to
 debug under :program:`gdb` or :program:`valgrind` than the full application.
 
+Redraw counter overlay (e-ink)
+------------------------------
+
+To see how often the display actually presents a frame (important on
+slow e-ink screens), build with ``DRAW_REDRAW_COUNTER=y``::
+
+  make -j$(nproc) TARGET=UNIX USE_CCACHE=y DRAW_REDRAW_COUNTER=y
+
+The flag is defined in :file:`build/options.mk` (default ``n``). When
+enabled, each ``TopWindow::Expose()`` / framebuffer flip draws a
+high-contrast overlay in the top-left corner::
+
+  R:<total>  <hz>/s
+
+``R`` is the lifetime present count; the rate is frames over the last
+one-second window (it stays ``0.0/s`` until the first full second).
+The overlay is paint-only (it does not capture mouse or touch).
+
+On Kobo, or any build where ``HasEPaper()`` is true, use the overlay
+while scrolling lists and panels. Paths already gated by ``HasEPaper()``
+(for example list pixel pan and kinetic scrolling) should keep the rate
+low; spikes mean something is still forcing full-screen presents.
+The same make flag works for ``TARGET=KOBO`` and ``OPENGL=n`` builds.
+
+Clean or rebuild affected objects when toggling the flag; mixed objects
+with and without ``-DDRAW_REDRAW_COUNTER`` are not reliable.
+
 iOS and macOS
 -------------
 

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -16,6 +16,11 @@
 
 #include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
 
+#ifdef DRAW_REDRAW_COUNTER
+#include <chrono>
+#include <cstdint>
+#endif
+
 #ifdef ANDROID
 #include "thread/Mutex.hxx"
 #include "thread/Cond.hxx"
@@ -167,6 +172,13 @@ public:
   uint8_t cursor_size = 1;
   bool invert_cursor_colors = false;
   std::chrono::steady_clock::time_point cursor_visible_until;
+#endif
+
+#ifdef DRAW_REDRAW_COUNTER
+  uint64_t redraw_count = 0;
+  unsigned hz_window_frames = 0;
+  double redraw_hz = 0;
+  std::chrono::steady_clock::time_point hz_window_start{};
 #endif
 
 #ifndef USE_WINUSER
@@ -466,6 +478,11 @@ public:
 #ifdef DRAW_MOUSE_CURSOR
 private:
   void DrawMouseCursor(Canvas &canvas) noexcept;
+#endif
+
+#ifdef DRAW_REDRAW_COUNTER
+private:
+  void DrawRedrawCounter(Canvas &canvas) noexcept;
 #endif
 
 protected:

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -30,8 +30,16 @@
 #include "ui/canvas/opengl/Dynamic.hpp" // for GLExt::discard_framebuffer
 #endif
 
-#ifdef DRAW_MOUSE_CURSOR
+#if defined(DRAW_MOUSE_CURSOR) || defined(DRAW_REDRAW_COUNTER)
 #include "Screen/Layout.hpp"
+#endif
+
+#ifdef DRAW_REDRAW_COUNTER
+#include "Look/FontDescription.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/Font.hpp"
+#include <fmt/format.h>
+#include <chrono>
 #endif
 
 namespace UI {
@@ -169,6 +177,59 @@ TopWindow::DrawMouseCursor(Canvas &canvas) noexcept
 
 #endif
 
+#ifdef DRAW_REDRAW_COUNTER
+
+inline void
+TopWindow::DrawRedrawCounter(Canvas &canvas) noexcept
+{
+  using namespace std::chrono;
+
+  ++redraw_count;
+  ++hz_window_frames;
+
+  const auto now = steady_clock::now();
+  if (hz_window_start.time_since_epoch().count() == 0)
+    hz_window_start = now;
+
+  const auto elapsed = now - hz_window_start;
+  if (elapsed >= seconds{1}) {
+    const double seconds_elapsed =
+      duration<double>(elapsed).count();
+    if (seconds_elapsed > 0)
+      redraw_hz = hz_window_frames / seconds_elapsed;
+    hz_window_start = now;
+    hz_window_frames = 0;
+  }
+
+  static Font font;
+  if (!font.IsDefined()) {
+    try {
+      font.Load(FontDescription(Layout::FontScale(12)));
+    } catch (...) {
+      return;
+    }
+  }
+
+  const auto text = fmt::format("R:{}  {:.1f}/s",
+                                redraw_count, redraw_hz);
+  const PixelSize text_size = font.TextSize(text);
+  const int pad = Layout::Scale(2);
+  const PixelRect box{
+    pad,
+    pad,
+    pad + int(text_size.width) + pad * 2,
+    pad + int(text_size.height) + pad * 2,
+  };
+
+  canvas.DrawFilledRectangle(box, COLOR_WHITE);
+  canvas.Select(font);
+  canvas.SetTextColor(COLOR_BLACK);
+  canvas.SetBackgroundColor(COLOR_WHITE);
+  canvas.DrawText({box.left + pad, box.top + pad}, text);
+}
+
+#endif
+
 void
 TopWindow::Expose() noexcept
 {
@@ -187,6 +248,10 @@ TopWindow::Expose() noexcept
 #ifdef DRAW_MOUSE_CURSOR
     if (std::chrono::steady_clock::now() < cursor_visible_until)
       DrawMouseCursor(canvas);
+#endif
+
+#ifdef DRAW_REDRAW_COUNTER
+    DrawRedrawCounter(canvas);
 #endif
 
     screen->Unlock();


### PR DESCRIPTION
## Summary
- Add compile-time `DRAW_REDRAW_COUNTER=y` (like `STOP_WATCH`) that draws `R:<count>  <hz>/s` after each `TopWindow::Expose()` / Flip
- Helps spot unwanted full-screen presents when testing e-ink / `HasEPaper()` behaviour
- Documented in `doc/debugging.rst`; off by default; paint-only (no input capture)

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y DRAW_REDRAW_COUNTER=y`
- [ ] Run XCSoar and confirm top-left overlay appears and Hz updates after ~1s
- [ ] Scroll a list / panel; confirm clicks under the overlay still work
- [ ] Default build without the flag has no overlay and no behaviour change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional redraw counter overlay for e-ink builds.
  * The overlay displays total screen redraws and the current redraw rate (frames per second) in a high-contrast box.
  * The feature can be enabled through the `DRAW_REDRAW_COUNTER=y` build option.

* **Documentation**
  * Added debugging guidance covering the overlay, supported builds, and rebuild requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->