### PR TITLE
Device/Driver/LX: Map LXWP0 without airspeed to noncomp vario

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -79,6 +79,8 @@ Version 7.45 - not yet released
   - always start in light mode; dark mode is not supported on e-paper
     displays #2568
 * devices
+  - $LXWP0 without airspeed publishes uncompensated vario (BlueFly LX
+    mode) instead of labelling it total-energy; with IAS/TAS keep TE
   - Accept partial $LXWP0 vario samples (e.g. BlueFly LX mode with a
     single rate) so Status Variometer is not stuck on Disconnected while
     baro still works; keep the six-sample FIR for full LXNAV sentences #2763

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -139,8 +139,15 @@ LXWP0(NMEAInputLine &line, NMEAInfo &info, bool provide_altitude_vario)
     info.ProvideTrueAirspeed(Units::ToSysUnit(airspeed, Unit::KILOMETER_PER_HOUR));
 
   if (provide_altitude_vario) {
-    if (ReadFilteredLXWP0Vario(line, value))
-      info.ProvideTotalEnergyVario(value);
+    if (ReadFilteredLXWP0Vario(line, value)) {
+      /* Real LXNAV fills IAS/TAS and the vario slots are TE.  Partial
+         LX emitters (BlueFly LX mode) leave airspeed blank and put
+         uncompensated climb/sink in those slots — do not label as TE. */
+      if (tas_available)
+        info.ProvideTotalEnergyVario(value);
+      else
+        info.ProvideNoncompVario(value);
+    }
   } else
     line.Skip(6);
 

--- a/src/Device/Driver/LX/Parsers.hpp
+++ b/src/Device/Driver/LX/Parsers.hpp
@@ -19,14 +19,17 @@ namespace LX {
  * apply the 5th-order low-pass FIR used by LX EOS / full LXNAV
  * sentences.  When only some slots are filled (BlueFly LX mode,
  * Condor, older devices — often a single sample), use the first
- * valid sample so TE vario is still published (#2763).
+ * valid sample so vario is still published (#2763).
  */
 bool
 ReadFilteredLXWP0Vario(NMEAInputLine &line, double &vario);
 
 /**
  * @param provide_altitude_vario When false, skip pressure altitude and
- * TE vario (used once $PLXVF is active on LXNAV varios).
+ * vario (used once $PLXVF is active on LXNAV varios).
+ *
+ * Vario is published as TE when the sentence includes airspeed, else
+ * as uncompensated (BlueFly LX mode leaves IAS blank).
  */
 bool
 LXWP0(NMEAInputLine &line, NMEAInfo &info,

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1327,8 +1327,7 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
   ok1(equals(nmea_info.external_wind.bearing, reciprocal_wind ? 354 : 174));
 
   if (!condor) {
-    /* BlueFly LX mode / classic example: only the first of six vario
-       slots is filled.  Must still publish TE vario (#2763). */
+    /* Partial six-slot vario with airspeed: still TE (#2763). */
     nmea_info.Reset();
     nmea_info.clock = TimeStamp{FloatDuration{1}};
     ok1(device->ParseNMEA("$LXWP0,Y,222.3,1665.5,1.71,,,,,,239,174,10.1*47",
@@ -1339,6 +1338,18 @@ TestLX(const struct DeviceRegister &driver, bool condor=false, bool reciprocal_w
     ok1(nmea_info.total_energy_vario_available);
     ok1(equals(nmea_info.total_energy_vario, 1.71));
     ok1(nmea_info.external_wind_available);
+
+    /* BlueFly LX mode: no airspeed — uncompensated, not TE. */
+    nmea_info.Reset();
+    nmea_info.clock = TimeStamp{FloatDuration{1}};
+    ok1(device->ParseNMEA("$LXWP0,N,,119.9,0.16,,,,,,259,,*64",
+                          nmea_info));
+    ok1(nmea_info.pressure_altitude_available);
+    ok1(equals(nmea_info.pressure_altitude, 119.9));
+    ok1(!nmea_info.airspeed_available);
+    ok1(!nmea_info.total_energy_vario_available);
+    ok1(nmea_info.noncomp_vario_available);
+    ok1(equals(nmea_info.noncomp_vario, 0.16));
   }
 
 
@@ -3225,7 +3236,7 @@ int main()
   SetSingleDataPath(data_path);
   CreateDataPath();
 
-  plan_tests(1050 /* drivers */ + 29 /* PFLAU extended */
+  plan_tests(1057 /* drivers */ + 29 /* PFLAU extended */
              + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 109 /* LXNav protocol 1.05 */


### PR DESCRIPTION
## Summary
- When `$LXWP0` has no IAS/TAS, publish vario as uncompensated instead of total-energy (BlueFly LX mode)
- Real LXNAV sentences with airspeed still provide TE vario
- Status Variometer then shows "Uncompensated" for BlueFly LX instead of "Total energy"
- Unit test coverage for the no-airspeed case; NEWS entry

## Test plan
- [ ] `./output/UNIX/bin/TestDriver` (or `make check`)
- [ ] On Kobo + BlueFly in LXNAV mode: Status → System shows Uncompensated when monitor has vario data
- [ ] Real LXNAV (or LXWP0 with IAS filled): Status still shows Total energy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vario reporting for LX devices without airspeed data. These devices now provide uncompensated vario instead of incorrectly labeling it as total-energy vario.
  * Total-energy vario labeling remains available when airspeed data is present.

* **Documentation**
  * Clarified how partial vario data and missing airspeed are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->