### PR TITLE
android: Support Microchip/ISSC BLE UART serial

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -70,6 +70,8 @@ Version 7.45 - not yet released
   - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
     dongles, in addition to HM-10; the protocol is auto-detected at connection
     time #2260
+  - BLE serial ports also support Microchip/ISSC transparent UART
+    (e.g. BlueFly Vario over BLE); auto-detected like NUS/HM-10
   - The saved device port type string for that mode remains ble_hm10 so
     existing profiles load without migration
   - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices

--- a/android/src/BleSerialPort.java
+++ b/android/src/BleSerialPort.java
@@ -18,8 +18,8 @@ import android.util.Log;
 
 /**
  * An #AndroidPort implementation for BLE serial bridge devices.
- * Supports HM-10 and Nordic UART Service, with auto-detection based
- * on the service UUID.
+ * Supports HM-10, Nordic UART Service, and Microchip/ISSC transparent
+ * UART, with auto-detection based on the service UUID.
  */
 public class BleSerialPort
     extends BluetoothGattCallback
@@ -36,13 +36,14 @@ public class BleSerialPort
 
   private BluetoothGatt gatt;
 
-  /* For NUS, RX characteristic. For HM-10, RX and TX use the same one. */
+  /* For NUS/ISSC, RX characteristic. For HM-10, RX and TX use the same
+     one. */
   private BluetoothGattCharacteristic writeCharacteristic;
 
   private BluetoothGattCharacteristic notifyCharacteristic;
 
-  /* For NUS, stays null. For HM-10, used as a workaround to avoid a
-     race condition. */
+  /* For NUS/ISSC, stays null. For HM-10, used as a workaround to avoid
+     a race condition. */
   private BluetoothGattCharacteristic deviceNameCharacteristic;
 
   private volatile boolean shutdown = false;
@@ -102,6 +103,12 @@ public class BleSerialPort
         service.getCharacteristic(BluetoothUuids.NORDIC_UART_RX_CHARACTERISTIC);
       notifyCharacteristic =
         service.getCharacteristic(BluetoothUuids.NORDIC_UART_TX_CHARACTERISTIC);
+      /* deviceNameCharacteristic stays null */
+    } else if ((service = gatt.getService(BluetoothUuids.ISSC_UART_SERVICE)) != null) {
+      writeCharacteristic =
+        service.getCharacteristic(BluetoothUuids.ISSC_UART_RX_CHARACTERISTIC);
+      notifyCharacteristic =
+        service.getCharacteristic(BluetoothUuids.ISSC_UART_TX_CHARACTERISTIC);
       /* deviceNameCharacteristic stays null */
     } else {
       service = gatt.getService(BluetoothUuids.HM10_SERVICE);

--- a/android/src/BleSerialWriteBuffer.java
+++ b/android/src/BleSerialWriteBuffer.java
@@ -13,7 +13,7 @@ import android.util.Log;
 
 /**
  * This class helps with writing chunked data to a Bluetooth LE serial
- * bridge device (HM-10 or Nordic UART Service).
+ * bridge device (HM-10, Nordic UART Service, or Microchip/ISSC UART).
  */
 final class BleSerialWriteBuffer {
   private static final String TAG = "XCSoar";

--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -309,6 +309,8 @@ final class BluetoothHelper
         features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
       else if (BluetoothUuids.NORDIC_UART_SERVICE.equals(uuid))
         features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
+      else if (BluetoothUuids.ISSC_UART_SERVICE.equals(uuid))
+        features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
       else if (BluetoothUuids.HEART_RATE_SERVICE.equals(uuid))
         features |= DetectDeviceListener.FEATURE_HEART_RATE;
       else if (BluetoothUuids.FLYTEC_SENSBOX_SERVICE.equals(uuid))

--- a/android/src/BluetoothUuids.java
+++ b/android/src/BluetoothUuids.java
@@ -62,6 +62,26 @@ public final class BluetoothUuids {
   static final UUID NORDIC_UART_TX_CHARACTERISTIC =
     UUID.fromString("6E400003-B5A3-F393-E0A9-E50E24DCCA9E");
 
+  /**
+   * Microchip/ISSC transparent UART service (e.g. BlueFly Vario BLE).
+   */
+  static final UUID ISSC_UART_SERVICE =
+    UUID.fromString("49535343-FE7D-4AE5-8FA9-9FAFD205E455");
+
+  /**
+   * ISSC UART RX characteristic - XCSoar writes data to it
+   * (Write Without Response).
+   */
+  static final UUID ISSC_UART_RX_CHARACTERISTIC =
+    UUID.fromString("49535343-8841-43F4-A8D4-ECBE34729BB3");
+
+  /**
+   * ISSC UART TX characteristic - XCSoar receives data from here
+   * (Notify).
+   */
+  static final UUID ISSC_UART_TX_CHARACTERISTIC =
+    UUID.fromString("49535343-1E4D-4BD9-BA61-23C647249616");
+
   /* Flytec Sensbox */
   static final UUID FLYTEC_SENSBOX_SERVICE =
     UUID.fromString("aba27100-143b-4b81-a444-edcd0000f020");
@@ -85,6 +105,7 @@ public final class BluetoothUuids {
                           ENGINE_SENSORS_SERVICE,
                           HM10_SERVICE,
                           NORDIC_UART_SERVICE,
+                          ISSC_UART_SERVICE,
                           FLYTEC_SENSBOX_SERVICE
                         };
   }
@@ -98,6 +119,8 @@ public final class BluetoothUuids {
                         HM10_RX_TX_CHARACTERISTIC,
                         NORDIC_UART_RX_CHARACTERISTIC,
                         NORDIC_UART_TX_CHARACTERISTIC,
+                        ISSC_UART_RX_CHARACTERISTIC,
+                        ISSC_UART_TX_CHARACTERISTIC,
                         FLYTEC_SENSBOX_NAVIGATION_SENSOR_CHARACTERISTIC,
                         FLYTEC_SENSBOX_MOVEMENT_SENSOR_CHARACTERISTIC,
                         FLYTEC_SENSBOX_SECOND_GPS_CHARACTERISTIC,

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -85,10 +85,10 @@ struct DeviceConfig {
     BLE_SENSOR,
 
     /**
-     * Bluetooth Low Energy serial bridge to a paired device (HM-10 or
-     * Nordic UART Service).  Unlike #BLE_SENSOR, this provides a
-     * bidirectional data stream and XCSoar accesses it through the
-     * #Port interface.
+     * Bluetooth Low Energy serial bridge to a paired device (HM-10,
+     * Nordic UART Service, or Microchip/ISSC transparent UART).
+     * Unlike #BLE_SENSOR, this provides a bidirectional data stream
+     * and XCSoar accesses it through the #Port interface.
      *
      * @note The profile stores this mode under the legacy port type string
      * @c ble_hm10 (see Profile/DeviceConfig.cpp).


### PR DESCRIPTION
## Summary
- Add Microchip/ISSC transparent UART GATT UUIDs to Android BLE serial discovery and connection (same auto-detect pattern as Nordic NUS / HM-10).
- Lets BlueFly Vario (and other ISSC UART devices) appear as BLE serial ports; the existing BlueFly driver then talks ASCII over the `Port` as usual.
- Deliberately **no** shared connect-sequence changes (MTU/priority/settle) — keep HM-10/NUS behaviour unchanged (e.g. UltraBip / #2358).

## Out of scope
- `$LK8EX1` parsing for full UltraBip/BlueFly mode-1 telemetry → #2772 / #2725
- BLE MTU / connection-priority tuning (follow-up only if hardware needs it)

## Test plan
- [ ] Android LE scan: BlueFly advertises and is offered as a BLE serial port (not BLE sensor)
- [ ] Connect with BlueFly driver: telemetry (`PRS`/`BAT` or `$BFV`) flows
- [ ] Regression: HM-10 and Nordic NUS (e.g. UltraBip) BLE serial still connect