### PR TITLE
Device/Parser: Parse $LK8EX1 on all ports

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -81,6 +81,9 @@ Version 7.45 - not yet released
   - always start in light mode; dark mode is not supported on e-paper
     displays #2568
 * devices
+  - support $LK8EX1 (LK8000 external instrument) on all device ports:
+    pressure, QNE altitude, vario, temperature, and battery voltage
+    or percentage #2772
   - $LXWP0 without airspeed publishes uncompensated vario (BlueFly LX
     mode) instead of labelling it total-energy; with IAS/TAS keep TE
   - Accept partial $LXWP0 vario samples (e.g. BlueFly LX mode with a

--- a/src/Device/Parser.cpp
+++ b/src/Device/Parser.cpp
@@ -2,6 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "Device/Parser.hpp"
+#include "Atmosphere/Pressure.hpp"
+#include "Atmosphere/Temperature.hpp"
 #include "Geo/Geoid.hpp"
 #include "NMEA/Info.hpp"
 #include "NMEA/Checksum.hpp"
@@ -43,6 +45,9 @@ NMEAParser::ParseLine(const char *string, NMEAInfo &info)
   const auto type = line.ReadView();
   if (type.size() < 6)
     return false;
+
+  if (type == "$LK8EX1"sv)
+    return LK8EX1(line, info);
 
   if (IsAlphaASCII(type[1]) && IsAlphaASCII(type[2])) {
     const auto type2 = type.substr(3);
@@ -728,6 +733,59 @@ NMEAParser::PTAS1(NMEAInputLine &line, NMEAInfo &info)
   double vtas;
   if (line.ReadChecked(vtas))
     info.ProvideTrueAirspeed(Units::ToSysUnit(vtas, Unit::KNOTS));
+
+  return true;
+}
+
+bool
+NMEAParser::LK8EX1(NMEAInputLine &line, NMEAInfo &info)
+{
+  /*
+   * $LK8EX1,pressure,altitude,vario,temperature,battery*CS
+   *
+   * pressure: Pa (hPa×100), or 999999 if missing
+   * altitude: m QNE (ignored if pressure present), or 99999 if missing
+   * vario: cm/s, or 9999 if missing
+   * temperature: °C, or 99 if missing
+   * battery: volts, or 1000+percent, or 999 if missing
+   *
+   * @see https://github.com/LK8000/LK8000/blob/master/Docs/LK8EX1.txt
+   */
+
+  bool have_pressure = false;
+
+  double pressure;
+  if (line.ReadChecked(pressure) && pressure != 999999) {
+    info.ProvideStaticPressure(AtmosphericPressure::Pascal(pressure));
+    have_pressure = true;
+  }
+
+  double altitude;
+  if (line.ReadChecked(altitude)) {
+    if (!have_pressure && altitude != 99999)
+      info.ProvidePressureAltitude(altitude);
+  }
+
+  double vario_cm;
+  if (line.ReadChecked(vario_cm) && vario_cm != 9999)
+    info.ProvideNoncompVario(vario_cm / 100);
+
+  double temperature;
+  if (line.ReadChecked(temperature) && temperature != 99) {
+    info.temperature = Temperature::FromCelsius(temperature);
+    info.temperature_available.Update(info.clock);
+  }
+
+  double battery;
+  if (line.ReadChecked(battery) && battery != 999) {
+    if (battery >= 1000 && battery <= 1100) {
+      info.battery_level = battery - 1000;
+      info.battery_level_available.Update(info.clock);
+    } else {
+      info.voltage = battery;
+      info.voltage_available.Update(info.clock);
+    }
+  }
 
   return true;
 }

--- a/src/Device/Parser.hpp
+++ b/src/Device/Parser.hpp
@@ -143,6 +143,16 @@ private:
   static bool PTAS1(NMEAInputLine &line, NMEAInfo &info);
 
   /**
+   * Parses an LK8EX1 sentence (LK8000 External Instrument Series 1).
+   *
+   * Handled in the central NMEA parser so any port/driver combination
+   * accepts the sentence (same approach as #PTAS1 / FLARM).
+   *
+   * @see https://github.com/LK8000/LK8000/blob/master/Docs/LK8EX1.txt
+   */
+  static bool LK8EX1(NMEAInputLine &line, NMEAInfo &info);
+
+  /**
    * Parses a MWV sentence (NMEA Wind information).
    *
    * @param line A NMEAInputLine instance that can be used for parsing

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -202,6 +202,78 @@ TestTasman()
 }
 
 static void
+TestLK8EX1()
+{
+  NMEAParser parser;
+
+  NMEAInfo nmea_info;
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};
+
+  /* pressure present: altitude field ignored; voltage battery */
+  ok1(parser.ParseLine("$LK8EX1,101325,99999,0,25.0,3.70*31", nmea_info));
+  ok1(nmea_info.static_pressure_available);
+  ok1(equals(nmea_info.static_pressure.GetPascal(), 101325));
+  ok1(!nmea_info.pressure_altitude_available);
+  ok1(nmea_info.noncomp_vario_available);
+  ok1(equals(nmea_info.noncomp_vario, 0));
+  ok1(nmea_info.temperature_available);
+  ok1(equals(nmea_info.temperature.ToCelsius(), 25));
+  ok1(nmea_info.voltage_available);
+  ok1(equals(nmea_info.voltage, 3.70));
+  ok1(!nmea_info.battery_level_available);
+
+  /* altitude-only + negative vario; missing temp/battery sentinels */
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};
+  ok1(parser.ParseLine("$LK8EX1,999999,1500,-50,99,999*2A", nmea_info));
+  ok1(!nmea_info.static_pressure_available);
+  ok1(nmea_info.pressure_altitude_available);
+  ok1(equals(nmea_info.pressure_altitude, 1500));
+  ok1(nmea_info.noncomp_vario_available);
+  ok1(equals(nmea_info.noncomp_vario, -0.5));
+  ok1(!nmea_info.temperature_available);
+  ok1(!nmea_info.voltage_available);
+  ok1(!nmea_info.battery_level_available);
+
+  /* all missing sentinels */
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};
+  ok1(parser.ParseLine("$LK8EX1,999999,99999,9999,99,999*3F", nmea_info));
+  ok1(!nmea_info.static_pressure_available);
+  ok1(!nmea_info.pressure_altitude_available);
+  ok1(!nmea_info.noncomp_vario_available);
+  ok1(!nmea_info.temperature_available);
+  ok1(!nmea_info.voltage_available);
+  ok1(!nmea_info.battery_level_available);
+
+  /* battery percentage encoding (14%) */
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};
+  ok1(parser.ParseLine("$LK8EX1,98725,99999,120,21.5,1014*18", nmea_info));
+  ok1(nmea_info.static_pressure_available);
+  ok1(equals(nmea_info.static_pressure.GetPascal(), 98725));
+  ok1(nmea_info.noncomp_vario_available);
+  ok1(equals(nmea_info.noncomp_vario, 1.2));
+  ok1(nmea_info.temperature_available);
+  ok1(equals(nmea_info.temperature.ToCelsius(), 21.5));
+  ok1(nmea_info.battery_level_available);
+  ok1(equals(nmea_info.battery_level, 14));
+  ok1(!nmea_info.voltage_available);
+
+  /* 0% battery via 1000+percent */
+  nmea_info.Reset();
+  nmea_info.clock = TimeStamp{FloatDuration{1}};
+  ok1(parser.ParseLine("$LK8EX1,101325,99999,0,25,1000*34", nmea_info));
+  ok1(nmea_info.battery_level_available);
+  ok1(equals(nmea_info.battery_level, 0));
+  ok1(!nmea_info.voltage_available);
+
+  /* bad checksum */
+  ok1(!parser.ParseLine("$LK8EX1,101325,99999,0,25.0,3.70*00", nmea_info));
+}
+
+static void
 TestFLARM()
 {
   NMEAParser parser;
@@ -3245,9 +3317,11 @@ int main()
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
              + 59 /* Condor3UDP */ + 24 /* FlarmTrafficBuilder */
-             + 24 /* TrafficExtensionsWire */);
+             + 24 /* TrafficExtensionsWire */
+             + 42 /* LK8EX1 */);
   TestGeneric();
   TestTasman();
+  TestLK8EX1();
   TestFLARM();
   TestAltairRU();
   TestBlueFly();


### PR DESCRIPTION
## Summary
- Parse `$LK8EX1` (LK8000 External Instrument Series 1) in the central `NMEAParser`, so it works on every port/driver (same approach as `$PFLA*` / `$PTAS1`).
- Maps pressure → static pressure, altitude (only if pressure missing) → pressure altitude, vario cm/s → non-compensated vario, temperature, battery volts or `1000+percent`.
- Unit tests cover pressure vs altitude-only, negative vario, missing sentinels, voltage vs percentage, and bad checksum.

Closes #2772  
Related: #2725 (Stodeus UltraBip/BlueBip — this covers the shared `$LK8EX1` half)

### References
- Spec: https://github.com/LK8000/LK8000/blob/master/Docs/LK8EX1.txt
- LK8000 parser: https://github.com/LK8000/LK8000/blob/master/Common/Source/Devices/devLKext1.cpp

## Test plan
- [x] `make TARGET=UNIX check` (includes new `TestLK8EX1`)
- [ ] Manual: UltraBip / BlueBip over BLE with Generic or XC-Tracer — pressure/temp/battery from `$LK8EX1`
- [ ] Manual: BlueFly output mode LK8EX1 — vario/baro via Generic or BlueFly driver fallthrough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for LK8000 external instrument data through `$LK8EX1` NMEA sentences on all device ports.
  * Now parses static pressure, pressure altitude, vario, temperature, and battery voltage or percentage from compatible instruments.

* **Bug Fixes**
  * Improved handling of missing/invalid sentinel values and checksum errors to avoid unreliable readings.

* **Tests**
  * Added unit coverage for `$LK8EX1`, including edge cases for partial data and battery percentage encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->