### PR TITLE
ui/canvas: Preserve UTF-8 when wrapping formatted text

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -48,6 +48,8 @@ Version 7.45 - not yet released
     long centre labels instead of hiding them when they do not fit
   - Fix crash when opening the map item list on waypoints with long
     non-ASCII comments (UTF-8 truncation)
+  - Fix crash wrapping unspaced UTF-8 help text (e.g. Chinese language
+    picker) #2768
   - add optional map overlay QuickMenu button (Config → Look → Layout),
     enabled by default when a touch screen is detected #2610
   - input events: add ``VarioVolume`` to mute/unmute and adjust the

--- a/src/ui/canvas/custom/MoreCanvas.cpp
+++ b/src/ui/canvas/custom/MoreCanvas.cpp
@@ -55,7 +55,12 @@ Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
     ? UINT_MAX
     : (r.GetHeight() + skip - 1) / skip;
 
-  char *const duplicated = new char[text.size() + 1], *p = duplicated;
+  /*
+   * Word wrapping below inserts NUL separators between lines.  In the
+   * worst case, every UTF-8 character needs its own line, so reserve
+   * enough space for one separator per input byte.
+   */
+  char *const duplicated = new char[text.size() * 2 + 1], *p = duplicated;
   unsigned lines = 1;
   for (char ch : text) {
     if (ch == '\n') {
@@ -76,7 +81,7 @@ Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
   }
 
   *p = '\0';
-  const size_t len = p - duplicated;
+  size_t len = p - duplicated;
 
   // simple wordbreak algorithm. looks for single spaces only, no tabs,
   // no grouping of multiple spaces. If a line has no spaces and is too
@@ -147,16 +152,19 @@ Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
       
       // if we found a break point, insert a null terminator
       if (chars_that_fit > 0 && chars_that_fit < line_len_bytes) {
-        duplicated[line_start + chars_that_fit] = '\0';
-#ifndef UNICODE
-        // Ensure we don't split a UTF-8 sequence by cropping backward if needed
-        // CropIncompleteUTF8 finds the terminator and crops incomplete sequences
-        char *new_end = CropIncompleteUTF8(
-          reinterpret_cast<char *>(duplicated + line_start));
-        // Update chars_that_fit to the actual break position after cropping
-        chars_that_fit = new_end - reinterpret_cast<char *>(duplicated + line_start);
-#endif
-        prev_p = duplicated + line_start + chars_that_fit;
+        const size_t break_position = line_start + chars_that_fit;
+
+        /*
+         * Make room for the separator instead of overwriting the first
+         * byte of the next character.  Overwriting it made the following
+         * line begin with a UTF-8 continuation byte.
+         */
+        memmove(duplicated + break_position + 1,
+                duplicated + break_position,
+                len - break_position + 1);
+        duplicated[break_position] = '\0';
+        ++len;
+        prev_p = duplicated + break_position;
       }
     }
 

--- a/test/src/TestWrapText.cpp
+++ b/test/src/TestWrapText.cpp
@@ -4,6 +4,7 @@
 #include "ui/canvas/TextWrapper.hpp"
 #include "ui/canvas/AnyCanvas.hpp"
 #include "ui/canvas/Font.hpp"
+#include "ui/canvas/TextFormat.hpp"
 #include "util/UTF8.hpp"
 #include "Screen/Layout.hpp"
 #include "Fonts.hpp"
@@ -19,14 +20,19 @@ static void
 CheckLinesValidUTF8(const WrappedText &wrapped, std::string_view text,
                     const char *label) noexcept
 {
+  bool valid = true;
   for (const auto &line : wrapped.lines) {
     std::string_view seg = line.GetText(text);
-    if (!ok1(ValidateUTF8(seg)))
+    if (!ValidateUTF8(seg)) {
       diag("invalid UTF-8 in line from \"%s\" "
            "(start=%zu, length=%zu)",
            label,
            line.start, line.length);
+      valid = false;
+    }
   }
+
+  ok1(valid);
 }
 
 /**
@@ -45,17 +51,23 @@ CheckLinesCoverText(const WrappedText &wrapped, std::string_view text,
   /* the first line must start at a paragraph boundary (offset 0 or
      right after a newline) and the last line must end at or near the
      end of the text */
-  ok1(wrapped.lines.front().start == 0 ||
-      (wrapped.lines.front().start > 0 &&
-       text[wrapped.lines.front().start - 1] == '\n'));
+  const std::size_t first_start = wrapped.lines.front().start;
+  const bool valid_start =
+    first_start <= text.size() &&
+    (first_start == 0 || text[first_start - 1] == '\n');
 
   const auto &last = wrapped.lines.back();
-  const std::size_t last_end = last.start + last.length;
-  /* last_end may be less than text.size() if there are trailing
-     spaces or newlines, but must not exceed it */
-  if (!ok1(last_end <= text.size()))
-    diag("last line end %zu > text size %zu in \"%s\"",
-         last_end, text.size(), label);
+  const bool valid_end =
+    last.start <= text.size() &&
+    last.length <= text.size() - last.start;
+  /* The last line may end before text.size() if there are trailing
+     spaces or newlines, but its range must not exceed the text. */
+  if (!valid_end)
+    diag("last line range (start=%zu, length=%zu) exceeds text size %zu "
+         "in \"%s\"",
+         last.start, last.length, text.size(), label);
+
+  ok1(valid_start && valid_end);
 }
 
 static void
@@ -154,6 +166,33 @@ TestLongUTF8Line(const Font &font) noexcept
   CheckLinesValidUTF8(result, text, "long-utf8-80px");
 }
 
+/**
+ * Regression test for DrawFormattedText() splitting an unspaced UTF-8
+ * string.  The old implementation overwrote the leading byte of the
+ * character following each inserted line separator, so measuring the
+ * next line failed UTF-8 validation.
+ */
+static void
+TestDrawFormattedTextUTF8(const Font &font)
+{
+  AnyCanvas canvas;
+  canvas.Select(font);
+
+  /*
+   * CJK text triggered the original crash because it commonly has no ASCII
+   * spaces at which to wrap.  Use an unspaced UTF-8 character available in
+   * the test font so this test does not depend on an installed CJK font.
+   */
+  static constexpr std::string_view text = "ääääääää";
+  const unsigned character_width = canvas.CalcTextWidth("ä");
+  ok1(character_width > 0);
+
+  const unsigned height =
+    canvas.DrawFormattedText({0, 0, static_cast<int>(character_width), 10000},
+                             text, DT_CALCRECT);
+  ok1(height == 8 * font.GetLineSpacing());
+}
+
 int main()
 {
   /* Avoid creating a full UI Display (and OpenGL/EGL) for this unit
@@ -175,21 +214,14 @@ int main()
 
   InitialiseFonts();
 
-  /* count test points:
-     TestASCII: 1 + validUTF8(1) + cover(2) + 1 + 1 = 6
-     TestUTF8NoWrap: 5 * (1 + validUTF8(1) + cover(2)) = 20
-     TestUTF8ForceWrap: 5 * (1 + validUTF8(>=1)) >= 10
-     TestMultiParagraphUTF8: 1 + validUTF8(3) + cover(2) = 6
-     TestLongUTF8Line: 1 + validUTF8(>=1) + 1 + validUTF8(>=1) >= 4
-
-     Use no_plan since line counts depend on font metrics */
-  plan_no_plan();
+  plan_tests(39);
 
   TestASCII(normal_font);
   TestUTF8NoWrap(normal_font);
   TestUTF8ForceWrap(normal_font);
   TestMultiParagraphUTF8(normal_font);
   TestLongUTF8Line(normal_font);
+  TestDrawFormattedTextUTF8(normal_font);
 
   DeinitialiseFonts();
 


### PR DESCRIPTION
# ui/canvas: Preserve UTF-8 when wrapping formatted text

Fixes #2768.

## Summary

- insert line separators without overwriting the first byte of the next
  UTF-8 character
- reserve enough scratch-buffer space for inserted separators
- add a CJK regression case that wraps unspaced text at one glyph per line

## Root cause

`Canvas::DrawFormattedText()` wrapped text without ASCII spaces by finding a
UTF-8 character boundary and writing a NUL terminator at that byte offset.
The offset pointed to the leading byte of the next character, so the write
destroyed that byte. The following line then began with a UTF-8 continuation
byte and failed `ValidateUTF8()` in `Canvas::CalcTextSize()`.

This was reproducible on iOS by switching to Simplified Chinese and opening
the language picker. Its translated help text is an unspaced CJK paragraph
that needs wrapping on the narrow display.

## Testing

- `make -j8 TARGET=MACOS DEBUG=y output/MACOS/bin/TestWrapText`
- `output/MACOS/bin/TestWrapText`
- `make -j8 check TARGET=MACOS`
- manually changed languages repeatedly on iOS and reopened the language
  picker

`make check TARGET=MACOS` result:

```text
All tests successful.
Files=100, Tests=10136
Result: PASS
```

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase

- [x] PR is rebased on current `master`
- [x] Commit history contains one atomic commit

#### Commit Format & Messages

- [x] Commit follows the `<Component>: <Summary>` format
- [x] Commit uses present tense
- [x] Commit explains why the change is needed

#### Commit Structure

- [x] Commit builds successfully
- [x] One commit covers the logical fix and its regression test
- [x] No fixup, duplicate, or WIP commits

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved word-wrapping for unspaced UTF-8 text to prevent breaking multi-byte characters across lines.
  - Fixed `DrawFormattedText` wrapping/measurement so UTF-8 content reports the correct height for rectangle calculations (`DT_CALCRECT`).

- **Tests**
  - Added a regression test validating `DT_CALCRECT` height measurement when wrapping an unspaced multi-byte UTF-8 string.
  - Strengthened wrapped-output UTF-8 validation assertions to catch invalid segments while keeping existing diagnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->