### PR TITLE
Renderer/Trail: Cheap full-history trail scan with DPI point budget (#2661)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -207,11 +207,17 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
+<<<<<<< HEAD
   - fix black terrain after idle high-resolution sharpening on OpenGL
     devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
   - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi
     1–3 / 3B+, Cubieboard-class), keep the Full snail trail store at 1024
     points (7.44 size) instead of the larger fast-host capacity #2661
+=======
+  - snail trail: reduce long-flight map CPU by clipping the trail to the
+    visible area before spacing-thinning (Full trail no longer walks the
+    whole history every redraw) #2661
+>>>>>>> 6b8cb6a70e (NEWS.txt: Note snail trail bounds-first query)
   - dynamically adjust contour line density to zoom factor #2233
   - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -207,17 +207,14 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
-<<<<<<< HEAD
   - fix black terrain after idle high-resolution sharpening on OpenGL
     devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
   - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi
     1–3 / 3B+, Cubieboard-class), keep the Full snail trail store at 1024
     points (7.44 size) instead of the larger fast-host capacity #2661
-=======
   - snail trail: reduce long-flight map CPU by clipping the trail to the
     visible area before spacing-thinning (Full trail no longer walks the
     whole history every redraw) #2661
->>>>>>> 6b8cb6a70e (NEWS.txt: Note snail trail bounds-first query)
   - dynamically adjust contour line density to zoom factor #2233
   - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type

--- a/build/test.mk
+++ b/build/test.mk
@@ -109,6 +109,7 @@ TEST_NAMES = \
 	TestOGNAprsParser \
 	TestMETARParser \
 	TestIGCParser \
+	TestTraceBounds \
 	TestStrings TestUnescapeCString TestUTF8 TestWrapText \
 	TestInputConfig \
 	TestCRC16 TestCRC8 \
@@ -1022,6 +1023,14 @@ TEST_TRACE_SOURCES = \
 	$(TEST_SRC_DIR)/TestTrace.cpp
 TEST_TRACE_DEPENDS = IO OS GEO MATH UTIL
 $(eval $(call link-program,TestTrace,TEST_TRACE))
+
+TEST_TRACE_BOUNDS_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(SRC)/Engine/Trace/Point.cpp \
+	$(SRC)/Engine/Trace/Trace.cpp \
+	$(TEST_SRC_DIR)/TestTraceBounds.cpp
+TEST_TRACE_BOUNDS_DEPENDS = GEO MATH UTIL
+$(eval $(call link-program,TestTraceBounds,TEST_TRACE_BOUNDS))
 
 FLIGHT_TABLE_SOURCES = \
 	$(SRC)/IGC/IGCParser.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1084,6 +1084,7 @@ DEBUG_PROGRAM_NAMES = \
 ifeq ($(TARGET_IS_ANDROID),n)
 # These programs are broken on Android because they require Java code
 DEBUG_PROGRAM_NAMES += \
+	RunTrailRendererStress \
 	RunTrace \
 	RunContestAnalysis \
 	RunWaveComputer \
@@ -1886,6 +1887,28 @@ RUN_TASK_SOURCES = \
 	$(TEST_SRC_DIR)/RunTask.cpp
 RUN_TASK_DEPENDS = $(DEBUG_REPLAY_DEPENDS) TASKFILE WAYPOINTFILE GLIDE GEO MATH UTIL IO TIME
 $(eval $(call link-program,RunTask,RUN_TASK))
+
+
+RUN_TRAIL_RENDERER_STRESS_SOURCES = \
+	$(SRC)/Computer/TraceComputer.cpp \
+	$(SRC)/Engine/Trace/Point.cpp \
+	$(SRC)/Engine/Trace/Trace.cpp \
+	$(SRC)/Engine/Trace/Vector.cpp \
+	$(SRC)/Projection/Projection.cpp \
+	$(SRC)/Projection/WindowProjection.cpp \
+	$(SRC)/Math/Screen.cpp \
+	$(SRC)/Look/TrailLook.cpp \
+	$(SRC)/Renderer/TrailRenderer.cpp \
+	$(SRC)/TransponderCode.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(MORE_SCREEN_SOURCES) \
+	$(DEBUG_REPLAY_SOURCES) \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/RunTrailRendererStress.cpp
+RUN_TRAIL_RENDERER_STRESS_DEPENDS = \
+	$(DEBUG_REPLAY_DEPENDS) SCREEN EVENT ASYNC OS IO THREAD GEO MATH UTIL TIME
+$(eval $(call link-program,RunTrailRendererStress,RUN_TRAIL_RENDERER_STRESS))
 
 RUN_TRACE_SOURCES = \
 	$(DEBUG_REPLAY_SOURCES) \

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -203,7 +203,8 @@ TraceComputer::LockedTrailQuery(const TrailQuery &query,
 
   if (query.bounds.IsValid())
     full.GetPoints(v, query.min_time, query.bounds,
-                   query.project_location, query.min_distance_m);
+                   query.project_location, query.min_distance_m,
+                   query.point_stride, query.max_points);
   else
     full.GetPoints(v, query.min_time, query.project_location,
                    query.min_distance_m);
@@ -222,6 +223,74 @@ TraceComputer::LockedTrailQuery(const TrailQuery &query,
     *append_serial = full.GetAppendSerial();
   if (modify_serial != nullptr)
     *modify_serial = full.GetModifySerial();
+}
+
+void
+TraceComputer::LockedGetSerials(Serial &append_serial,
+                                Serial &modify_serial) const noexcept
+{
+  const std::lock_guard lock{mutex};
+  append_serial = full.GetAppendSerial();
+  modify_serial = full.GetModifySerial();
+}
+
+void
+TraceComputer::LockedCopyHistory(std::chrono::duration<unsigned> min_time,
+                                 TracePointVector &history,
+                                 std::vector<TrailVarioSample> &vario_samples,
+                                 Serial *append_serial,
+                                 Serial *modify_serial) const
+{
+  const std::lock_guard lock{mutex};
+  full.GetPointsFrom(min_time, history);
+  CopyMergeVarioSamplesUnlocked(vario_samples, min_time);
+  if (append_serial != nullptr)
+    *append_serial = full.GetAppendSerial();
+  if (modify_serial != nullptr)
+    *modify_serial = full.GetModifySerial();
+}
+
+void
+TraceComputer::LockedAppendHistoryAfter(
+    TracePoint::Time after,
+    TracePointVector &history,
+    std::vector<TrailVarioSample> &vario_samples,
+    Serial *append_serial,
+    Serial *modify_serial) const
+{
+  const std::lock_guard lock{mutex};
+  full.AppendPointsAfter(after, history);
+
+  /* Append open-leg / archive samples newer than the previous history
+     tip.  Dedup against the last kept sample. */
+  const TracePoint::Time vario_after =
+    vario_samples.empty() ? after : vario_samples.back().time;
+
+  for (const auto &s : merge_vario_archive) {
+    if (s.time <= vario_after)
+      continue;
+    PushMergeVarioDeduped(vario_samples, s);
+  }
+
+  for (const auto &s : merge_vario_samples) {
+    if (s.time <= vario_after)
+      continue;
+    PushMergeVarioDeduped(vario_samples, s);
+  }
+
+  if (append_serial != nullptr)
+    *append_serial = full.GetAppendSerial();
+  if (modify_serial != nullptr)
+    *modify_serial = full.GetModifySerial();
+}
+
+TrailSpatialFilter
+TraceComputer::LockedMakeSpatialFilter(const TrailQuery &query) const noexcept
+{
+  const std::lock_guard lock{mutex};
+  return full.MakeSpatialFilter(query.bounds, query.project_location,
+                                query.min_distance_m, query.point_stride,
+                                query.max_points);
 }
 
 void

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -6,6 +6,7 @@
 #include "Settings.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
+#include "Engine/Trace/Vector.hpp"
 #include "Geo/GeoBounds.hpp"
 
 #include <cmath>
@@ -207,7 +208,15 @@ TraceComputer::LockedTrailQuery(const TrailQuery &query,
     full.GetPoints(v, query.min_time, query.project_location,
                    query.min_distance_m);
 
-  CopyMergeVarioSamplesUnlocked(vario_samples, query.min_time);
+  /* Only copy merge-vario for the kept trail span (plus open-leg ring
+     samples after the last GPS fix).  Avoids walking the full-flight
+     archive when the viewport only needs a local subset. */
+  if (v.empty())
+    vario_samples.clear();
+  else {
+    const auto vario_min = std::max(query.min_time, v.front().GetTime());
+    CopyMergeVarioSamplesUnlocked(vario_samples, vario_min);
+  }
 
   if (append_serial != nullptr)
     *append_serial = full.GetAppendSerial();

--- a/src/Computer/TraceComputer.hpp
+++ b/src/Computer/TraceComputer.hpp
@@ -30,6 +30,10 @@ struct TrailQuery {
   GeoBounds bounds{};
   GeoPoint project_location{};
   double min_distance_m{};
+  /** Minimum stride before budget (usually 1). */
+  unsigned point_stride = 1;
+  /** Cap kept points; 0 = unlimited. */
+  unsigned max_points = 0;
 };
 
 /**
@@ -161,6 +165,34 @@ public:
                         std::vector<TrailVarioSample> &vario_samples,
                         Serial *append_serial = nullptr,
                         Serial *modify_serial = nullptr) const;
+
+  /** Read append/modify serials under the trace mutex. */
+  void LockedGetSerials(Serial &append_serial,
+                        Serial &modify_serial) const noexcept;
+
+  /**
+   * Copy the time-windowed history (no bounds filter) and matching
+   * merge-vario samples for UI-side spatial re-filtering.
+   */
+  void LockedCopyHistory(std::chrono::duration<unsigned> min_time,
+                         TracePointVector &history,
+                         std::vector<TrailVarioSample> &vario_samples,
+                         Serial *append_serial = nullptr,
+                         Serial *modify_serial = nullptr) const;
+
+  /**
+   * Append store points with time greater than \a after onto \a history
+   * and extend \a vario_samples for the new span.
+   */
+  void LockedAppendHistoryAfter(TracePoint::Time after,
+                                TracePointVector &history,
+                                std::vector<TrailVarioSample> &vario_samples,
+                                Serial *append_serial = nullptr,
+                                Serial *modify_serial = nullptr) const;
+
+  /** Project query bounds/spacing into a flat spatial filter. */
+  [[nodiscard]]
+  TrailSpatialFilter LockedMakeSpatialFilter(const TrailQuery &query) const noexcept;
 
   /**
    * Called from #MergeThread after merged basic data is computed (must

--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -4,7 +4,8 @@
 #include "Trace.hpp"
 #include "Vector.hpp"
 #include "Geo/GeoBounds.hpp"
-#include "Geo/GeoClip.hpp"
+#include "Geo/Flat/FlatBoundingBox.hpp"
+#include "Geo/Flat/FlatRay.hpp"
 #include "util/GlobalSliceAllocator.hxx"
 
 #include <algorithm>
@@ -447,17 +448,21 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
   } while (i != end);
 }
 
+/**
+ * True if the flat segment [a,b] hits \a box (endpoint inside or edge cross).
+ */
 [[gnu::pure]]
 static bool
-SegmentIntersectsBounds(const GeoPoint &a, const GeoPoint &b,
-                        const GeoBounds &bounds) noexcept
+FlatSegmentHitsBox(const FlatGeoPoint &a, const FlatGeoPoint &b,
+                   const FlatBoundingBox &box) noexcept
 {
-  if (bounds.IsInside(a) || bounds.IsInside(b))
+  if (box.IsInside(a) || box.IsInside(b))
     return true;
 
-  GeoClip clip(bounds);
-  GeoPoint a2 = a, b2 = b;
-  return clip.ClipLine(a2, b2);
+  if (a == b)
+    return false;
+
+  return box.Intersects(FlatRay(a, b));
 }
 
 void
@@ -466,37 +471,74 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
                  const GeoPoint &location,
                  const double min_distance) const
 {
-  TracePointVector thinned;
-  GetPoints(thinned, min_time, location, min_distance);
+  v.clear();
 
-  if (thinned.empty()) {
-    v.clear();
+  if (!bounds.IsValid() || empty() || !task_projection.IsValid())
     return;
-  }
 
-  std::vector<uint8_t> keep(thinned.size(), 0);
-  for (size_t k = 0; k < thinned.size(); ++k) {
-    const GeoPoint gp = thinned[k].GetLocation();
-    if (bounds.IsInside(gp)) {
-      keep[k] = 1;
-      continue;
+  /* Skip points before min_time. */
+  Trace::const_iterator i = begin(), end = this->end();
+  while (i != end && i->GetTime() < min_time)
+    ++i;
+
+  if (i == end)
+    return;
+
+  /* Bounds first (flat AABB), then spacing-thin.  Avoids thinning the
+     entire flight history before clipping — that dominated cost at
+     circling zoom where min_distance is only a few metres. */
+  const FlatBoundingBox flat_box = task_projection.Project(bounds);
+
+  TracePointVector candidates;
+  candidates.reserve(std::min(size_t(size()), size_t(4096)));
+
+  const TracePoint *prev = nullptr;
+  FlatGeoPoint prev_flat{};
+
+  for (; i != end; ++i) {
+    const TracePoint &point = *i;
+    const FlatGeoPoint flat = point.GetFlatLocation();
+    bool keep = flat_box.IsInside(flat);
+
+    if (!keep && prev != nullptr &&
+        FlatSegmentHitsBox(prev_flat, flat, flat_box))
+      keep = true;
+
+    if (keep) {
+      /* If this point is kept because a leg crosses into the box,
+         also keep the outside predecessor so the crossing leg is drawn. */
+      if (prev != nullptr &&
+          (candidates.empty() ||
+           candidates.back().GetTime() != prev->GetTime())) {
+        if (!flat_box.IsInside(prev_flat) &&
+            FlatSegmentHitsBox(prev_flat, flat, flat_box))
+          candidates.push_back(*prev);
+      }
+
+      if (candidates.empty() ||
+          candidates.back().GetTime() != point.GetTime())
+        candidates.push_back(point);
     }
 
-    if (k > 0 &&
-        SegmentIntersectsBounds(thinned[k - 1].GetLocation(), gp, bounds))
-      keep[k] = 1;
-    else if (k + 1 < thinned.size() &&
-             SegmentIntersectsBounds(gp, thinned[k + 1].GetLocation(), bounds))
-      keep[k] = 1;
+    prev = &point;
+    prev_flat = flat;
   }
 
-  /* Keep only visible / bounds-crossing points.  Do not reinsert
-     off-screen gaps between separate viewport runs — that would let
-     trail size grow with flight duration despite the filter. */
-  v.clear();
-  v.reserve(thinned.size());
-  for (size_t k = 0; k < thinned.size(); ++k) {
-    if (keep[k])
-      v.push_back(thinned[k]);
+  if (candidates.empty())
+    return;
+
+  /* Spacing-thin the chronological candidates (same metric as the
+     non-bounds GetPoints).  Do not reinsert off-screen gaps. */
+  const unsigned range = ProjectRange(location, min_distance);
+  const unsigned sq_range = range * range;
+
+  v.reserve(candidates.size());
+  v.push_back(candidates.front());
+  size_t last = 0;
+  for (size_t k = 1; k < candidates.size(); ++k) {
+    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >= sq_range) {
+      v.push_back(candidates[k]);
+      last = k;
+    }
   }
 }

--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -465,53 +465,74 @@ FlatSegmentHitsBox(const FlatGeoPoint &a, const FlatGeoPoint &b,
   return box.Intersects(FlatRay(a, b));
 }
 
-void
-Trace::GetPoints(TracePointVector &v, const Time min_time,
-                 const GeoBounds &bounds,
-                 const GeoPoint &location,
-                 const double min_distance) const
+/**
+ * After distance thinning, keep first/last and every \a stride-th point.
+ */
+static void
+ApplyPointStride(TracePointVector &points, unsigned stride) noexcept
 {
-  v.clear();
-
-  if (!bounds.IsValid() || empty() || !task_projection.IsValid())
+  if (stride <= 1 || points.size() <= 2)
     return;
 
-  /* Skip points before min_time. */
-  Trace::const_iterator i = begin(), end = this->end();
-  while (i != end && i->GetTime() < min_time)
-    ++i;
+  TracePointVector kept;
+  kept.reserve(points.size() / stride + 2);
+  kept.push_back(points.front());
+  for (size_t i = stride; i + 1 < points.size(); i += stride)
+    kept.push_back(points[i]);
+  if (kept.back().GetTime() != points.back().GetTime())
+    kept.push_back(points.back());
+  points.swap(kept);
+}
 
-  if (i == end)
+/**
+ * Raise stride until #points fits in \a max_points (first/last preserved).
+ * Speed-agnostic: PG dense circles and glider cruise share one budget.
+ */
+static unsigned
+StrideForBudget(unsigned point_count, unsigned max_points,
+                unsigned min_stride) noexcept
+{
+  unsigned stride = std::max(1u, min_stride);
+  if (max_points < 2 || point_count <= max_points)
+    return stride;
+
+  /* kept ≈ 1 + ceil((n - 1) / stride), and we always re-add the tip. */
+  const unsigned numer = point_count - 1;
+  const unsigned denom = max_points - 1;
+  const unsigned need = (numer + denom - 1) / denom;
+  return std::max(stride, need);
+}
+
+void
+FilterTraceByBounds(const TracePointVector &in,
+                    TracePointVector &out,
+                    const TrailSpatialFilter &filter) noexcept
+{
+  out.clear();
+
+  if (!filter.valid || in.empty())
     return;
-
-  /* Bounds first (flat AABB), then spacing-thin.  Avoids thinning the
-     entire flight history before clipping — that dominated cost at
-     circling zoom where min_distance is only a few metres. */
-  const FlatBoundingBox flat_box = task_projection.Project(bounds);
 
   TracePointVector candidates;
-  candidates.reserve(std::min(size_t(size()), size_t(4096)));
+  candidates.reserve(std::min(in.size(), size_t(4096)));
 
   const TracePoint *prev = nullptr;
   FlatGeoPoint prev_flat{};
 
-  for (; i != end; ++i) {
-    const TracePoint &point = *i;
+  for (const auto &point : in) {
     const FlatGeoPoint flat = point.GetFlatLocation();
-    bool keep = flat_box.IsInside(flat);
+    bool keep = filter.box.IsInside(flat);
 
     if (!keep && prev != nullptr &&
-        FlatSegmentHitsBox(prev_flat, flat, flat_box))
+        FlatSegmentHitsBox(prev_flat, flat, filter.box))
       keep = true;
 
     if (keep) {
-      /* If this point is kept because a leg crosses into the box,
-         also keep the outside predecessor so the crossing leg is drawn. */
       if (prev != nullptr &&
           (candidates.empty() ||
            candidates.back().GetTime() != prev->GetTime())) {
-        if (!flat_box.IsInside(prev_flat) &&
-            FlatSegmentHitsBox(prev_flat, flat, flat_box))
+        if (!filter.box.IsInside(prev_flat) &&
+            FlatSegmentHitsBox(prev_flat, flat, filter.box))
           candidates.push_back(*prev);
       }
 
@@ -527,18 +548,145 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
   if (candidates.empty())
     return;
 
-  /* Spacing-thin the chronological candidates (same metric as the
-     non-bounds GetPoints).  Do not reinsert off-screen gaps. */
+  out.reserve(candidates.size());
+  out.push_back(candidates.front());
+  size_t last = 0;
+  for (size_t k = 1; k < candidates.size(); ++k) {
+    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >=
+        filter.sq_range) {
+      out.push_back(candidates[k]);
+      last = k;
+    }
+  }
+
+  const unsigned stride =
+    StrideForBudget(unsigned(out.size()), filter.max_points,
+                    filter.point_stride);
+  ApplyPointStride(out, stride);
+}
+
+TrailSpatialFilter
+Trace::MakeSpatialFilter(const GeoBounds &bounds,
+                         const GeoPoint &location,
+                         double min_distance,
+                         unsigned point_stride,
+                         unsigned max_points) const noexcept
+{
+  TrailSpatialFilter filter;
+  if (!bounds.IsValid() || empty() || !task_projection.IsValid())
+    return filter;
+
+  filter.box = task_projection.Project(bounds);
   const unsigned range = ProjectRange(location, min_distance);
-  const unsigned sq_range = range * range;
+  filter.sq_range = range * range;
+  filter.point_stride = std::max(1u, point_stride);
+  filter.max_points = max_points;
+  filter.valid = true;
+  return filter;
+}
+
+void
+Trace::GetPointsFrom(Time min_time, TracePointVector &v) const noexcept
+{
+  v.clear();
+
+  Trace::const_iterator i = begin(), end = this->end();
+  while (i != end && i->GetTime() < min_time)
+    ++i;
+
+  if (i == end)
+    return;
+
+  v.reserve(size());
+  for (; i != end; ++i)
+    v.push_back(*i);
+}
+
+void
+Trace::AppendPointsAfter(Time after, TracePointVector &v) const noexcept
+{
+  Trace::const_iterator i = begin(), end = this->end();
+  while (i != end && i->GetTime() <= after)
+    ++i;
+
+  for (; i != end; ++i)
+    v.push_back(*i);
+}
+
+void
+Trace::GetPoints(TracePointVector &v, const Time min_time,
+                 const GeoBounds &bounds,
+                 const GeoPoint &location,
+                 const double min_distance,
+                 const unsigned point_stride,
+                 const unsigned max_points) const
+{
+  v.clear();
+
+  const TrailSpatialFilter filter =
+    MakeSpatialFilter(bounds, location, min_distance, point_stride,
+                      max_points);
+  if (!filter.valid)
+    return;
+
+  /* Skip points before min_time. */
+  Trace::const_iterator i = begin(), end = this->end();
+  while (i != end && i->GetTime() < min_time)
+    ++i;
+
+  if (i == end)
+    return;
+
+  /* Bounds first (flat AABB), then spacing-thin — one chronological pass. */
+  TracePointVector candidates;
+  candidates.reserve(std::min(size_t(size()), size_t(4096)));
+
+  const TracePoint *prev = nullptr;
+  FlatGeoPoint prev_flat{};
+
+  for (; i != end; ++i) {
+    const TracePoint &point = *i;
+    const FlatGeoPoint flat = point.GetFlatLocation();
+    bool keep = filter.box.IsInside(flat);
+
+    if (!keep && prev != nullptr &&
+        FlatSegmentHitsBox(prev_flat, flat, filter.box))
+      keep = true;
+
+    if (keep) {
+      if (prev != nullptr &&
+          (candidates.empty() ||
+           candidates.back().GetTime() != prev->GetTime())) {
+        if (!filter.box.IsInside(prev_flat) &&
+            FlatSegmentHitsBox(prev_flat, flat, filter.box))
+          candidates.push_back(*prev);
+      }
+
+      if (candidates.empty() ||
+          candidates.back().GetTime() != point.GetTime())
+        candidates.push_back(point);
+    }
+
+    prev = &point;
+    prev_flat = flat;
+  }
+
+  if (candidates.empty())
+    return;
 
   v.reserve(candidates.size());
   v.push_back(candidates.front());
   size_t last = 0;
   for (size_t k = 1; k < candidates.size(); ++k) {
-    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >= sq_range) {
+    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >=
+        filter.sq_range) {
       v.push_back(candidates[k]);
       last = k;
     }
   }
+
+  const unsigned stride =
+    StrideForBudget(unsigned(v.size()), filter.max_points,
+                    filter.point_stride);
+  ApplyPointStride(v, stride);
 }

--- a/src/Engine/Trace/Trace.hpp
+++ b/src/Engine/Trace/Trace.hpp
@@ -394,8 +394,10 @@ public:
                  const GeoPoint &location, double resolution) const;
 
   /**
-   * Like GetPoints() with time and distance thinning, but only returns
-   * points inside \a bounds or on legs that intersect \a bounds.
+   * Fill the vector with trace points not before #min_time that lie
+   * inside \a bounds or on legs that intersect \a bounds, then apply
+   * minimum resolution #min_distance.  Bounds are applied before
+   * spacing thinning so cost tracks the viewport, not flight length.
    */
   void GetPoints(TracePointVector &v, Time min_time,
                  const GeoBounds &bounds,

--- a/src/Engine/Trace/Trace.hpp
+++ b/src/Engine/Trace/Trace.hpp
@@ -8,6 +8,7 @@
 #include "util/Sanitizer.hxx"
 #include "util/SliceAllocator.hxx"
 #include "util/Serial.hpp"
+#include "Geo/Flat/FlatBoundingBox.hpp"
 #include "Geo/Flat/TaskProjection.hpp"
 #include "time/Stamp.hpp"
 
@@ -21,6 +22,32 @@
 class TracePointVector;
 class TracePointerVector;
 class GeoBounds;
+
+/**
+ * Flat AABB + spacing used to filter a chronological #TracePointVector
+ * to the visible set (points inside or on crossing legs).
+ */
+struct TrailSpatialFilter {
+  FlatBoundingBox box{};
+  unsigned sq_range = 0;
+  /** Minimum stride (1 = no forced skip). */
+  unsigned point_stride = 1;
+  /**
+   * Soft cap on returned points.  If distance thinning still exceeds
+   * this, stride is raised so draw cost stays bounded (PG and glider).
+   */
+  unsigned max_points = 0;
+  bool valid = false;
+};
+
+/**
+ * Bounds-first then spacing-thin, matching Trace::GetPoints(..., bounds, ...).
+ * Used by TrailRenderer on a local time-window history without re-walking
+ * the store under lock.
+ */
+void FilterTraceByBounds(const TracePointVector &in,
+                         TracePointVector &out,
+                         const TrailSpatialFilter &filter) noexcept;
 
 /**
  * This class uses a smart thinning algorithm to limit the number of items
@@ -402,7 +429,31 @@ public:
   void GetPoints(TracePointVector &v, Time min_time,
                  const GeoBounds &bounds,
                  const GeoPoint &location,
-                 double min_distance) const;
+                 double min_distance,
+                 unsigned point_stride = 1,
+                 unsigned max_points = 0) const;
+
+  /**
+   * Copy every chronological point with time >= \a min_time (no spacing
+   * thin).  Used as a UI-side history buffer for cheap local re-filters.
+   */
+  void GetPointsFrom(Time min_time, TracePointVector &v) const noexcept;
+
+  /**
+   * Append chronological points with time > \a after onto \a v.
+   */
+  void AppendPointsAfter(Time after, TracePointVector &v) const noexcept;
+
+  /**
+   * Build a flat spatial filter for \a bounds / spacing (requires a valid
+   * task projection).
+   */
+  [[nodiscard]] [[gnu::pure]]
+  TrailSpatialFilter MakeSpatialFilter(const GeoBounds &bounds,
+                                       const GeoPoint &location,
+                                       double min_distance,
+                                       unsigned point_stride = 1,
+                                       unsigned max_points = 0) const noexcept;
 
   const TracePoint &front() const noexcept {
     assert(!empty());

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -21,9 +21,23 @@
 #include <cmath>
 
 static constexpr double TRAIL_ZOOMED_OUT_MAP_SCALE = 6000;
-static constexpr int TRAIL_THIN_PIXELS_MIN = 3;
-static constexpr int TRAIL_THIN_PIXELS_MAX = 24;
 static constexpr double TRAIL_BOUNDS_SCALE = 4.;
+
+/**
+ * On-screen trail sample spacing in points (1/72").  Converted to pixels
+ * via Layout::PtScale (DPI / UI scale) then to metres via the projection,
+ * so thinning tracks physical size across phones, OV boxes, and Kobo.
+ */
+static constexpr unsigned TRAIL_SPACING_PT_MIN = 2;
+static constexpr unsigned TRAIL_SPACING_PT_MAX = 18;
+
+/**
+ * Grow spacing with zoom-out: GetMapScale / this → pixel target before
+ * PtScale clamps.  Smaller → more thinning when zoomed out.  Still only
+ * feeds the px→m pipeline (not a device-specific stride ladder).
+ */
+static constexpr double TRAIL_SPACING_MAP_SCALE_DIV = 250.;
+
 namespace {
 
 /**
@@ -199,14 +213,24 @@ ComputeCatmullRomWeights(double t) noexcept
   };
 }
 
-/** Target screen-pixel spacing between kept trace fixes. */
-[[gnu::const]]
+/**
+ * Target on-screen spacing between kept fixes, in pixels.
+ * Floor/ceiling use Layout::PtScale so the same physical size on glass
+ * applies across DPI/resolution; zoom only moves within that range.
+ * Metres come from WindowProjection::DistancePixelsToMeters in
+ * MakeTrailQuery — not from magic GetMapScale stride bands.
+ */
+[[gnu::pure]]
 static int
 GetTrailSpacingPixels(double map_scale) noexcept
 {
-  return std::clamp(static_cast<int>(map_scale / 500),
-                    TRAIL_THIN_PIXELS_MIN,
-                    TRAIL_THIN_PIXELS_MAX);
+  const int min_px =
+    std::max(1, int(Layout::PtScale(TRAIL_SPACING_PT_MIN)));
+  const int max_px =
+    std::max(min_px, int(Layout::PtScale(TRAIL_SPACING_PT_MAX)));
+  const int from_zoom =
+    int(map_scale / TRAIL_SPACING_MAP_SCALE_DIV);
+  return std::clamp(from_zoom, min_px, max_px);
 }
 
 /** Max number of recent trace points that receive Catmull-Rom smoothing. */
@@ -421,6 +445,8 @@ TrailRenderer::MergeAdjacentColourRuns(
 bool
 TrailRenderer::LoadTrace(const TraceComputer &trace_computer) noexcept
 {
+  InvalidateHistory();
+  InvalidateSegmentCache();
   trace.clear();
   merge_vario_samples.clear();
   try {
@@ -442,6 +468,20 @@ TrailRenderer::LoadTrace(const TraceComputer &trace_computer,
   return SyncTrace(trace_computer, query);
 }
 
+/**
+ * Soft cap on drawable trail samples.  Scaled with short-edge resolution
+ * and point size so denser panels may keep a bit more; clamped so weak
+ * ARM targets stay bounded regardless of airspeed / zoom.
+ */
+[[gnu::pure]]
+static unsigned
+GetTrailPointBudget() noexcept
+{
+  const unsigned pt = std::max(1u, Layout::PtScale(2));
+  const unsigned by_screen = Layout::min_screen_pixels / pt;
+  return std::clamp(by_screen, 96u, 384u);
+}
+
 TrailQuery
 TrailRenderer::MakeTrailQuery(TimeStamp min_time,
                               const WindowProjection &projection) noexcept
@@ -453,6 +493,8 @@ TrailRenderer::MakeTrailQuery(TimeStamp min_time,
   query.project_location = projection.GetGeoScreenCenter();
   query.min_distance_m =
     projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
+  query.point_stride = 1;
+  query.max_points = GetTrailPointBudget();
   return query;
 }
 
@@ -469,9 +511,48 @@ TrailRenderer::TrailDrawFingerprint::operator==(
 }
 
 void
+TrailRenderer::InvalidateHistory() noexcept
+{
+  history.clear();
+  history_vario.clear();
+  history_valid = false;
+  history_min_time = {};
+  last_query = {};
+}
+
+void
 TrailRenderer::InvalidateSegmentCache() noexcept
 {
   segment_cache.clear();
+}
+
+bool
+TrailRenderer::TrailQueryViewEqual(const TrailQuery &a,
+                                   const TrailQuery &b) noexcept
+{
+  return a.min_distance_m == b.min_distance_m &&
+    a.point_stride == b.point_stride &&
+    a.max_points == b.max_points &&
+    a.project_location == b.project_location &&
+    a.bounds.GetNorthWest() == b.bounds.GetNorthWest() &&
+    a.bounds.GetSouthEast() == b.bounds.GetSouthEast();
+}
+
+void
+TrailRenderer::RefilterTraceFromHistory(const TrailSpatialFilter &filter) noexcept
+{
+  FilterTraceByBounds(history, trace, filter);
+
+  merge_vario_samples.clear();
+  if (trace.empty())
+    return;
+
+  const auto vario_min = trace.front().GetTime();
+  merge_vario_samples.reserve(history_vario.size());
+  for (const auto &s : history_vario) {
+    if (s.time >= vario_min)
+      merge_vario_samples.push_back(s);
+  }
 }
 
 bool
@@ -479,18 +560,62 @@ TrailRenderer::SyncTrace(const TraceComputer &trace_computer,
                          const TrailQuery &query) noexcept
 {
   Serial append{}, modify{};
-  trace.clear();
-  merge_vario_samples.clear();
   try {
-    trace_computer.LockedTrailQuery(query, trace, merge_vario_samples,
-                                    &append, &modify);
+    trace_computer.LockedGetSerials(append, modify);
   } catch (const std::bad_alloc &) {
+    InvalidateHistory();
+    InvalidateSegmentCache();
     trace.clear();
     merge_vario_samples.clear();
-    InvalidateSegmentCache();
     return false;
   }
 
+  const bool have_history = history_valid;
+  const bool modify_ok =
+    have_history && modify == history_modify_serial;
+  const bool min_time_ok =
+    have_history && history_min_time == query.min_time;
+  const bool append_ok =
+    have_history && append == history_append_serial;
+  const bool view_ok =
+    have_history && TrailQueryViewEqual(last_query, query);
+
+  if (modify_ok && min_time_ok && append_ok && view_ok) {
+    synced_append_serial = append;
+    synced_modify_serial = modify;
+    return !trace.empty();
+  }
+
+  try {
+    if (!modify_ok || !min_time_ok) {
+      trace_computer.LockedCopyHistory(query.min_time, history,
+                                       history_vario, &append, &modify);
+      history_append_serial = append;
+      history_modify_serial = modify;
+      history_min_time = query.min_time;
+      history_valid = true;
+    } else if (!append_ok) {
+      const TracePoint::Time after =
+        history.empty() ? TracePoint::Time{} : history.back().GetTime();
+      trace_computer.LockedAppendHistoryAfter(after, history, history_vario,
+                                              &append, &modify);
+      history_append_serial = append;
+      history_modify_serial = modify;
+    }
+
+    const TrailSpatialFilter filter =
+      trace_computer.LockedMakeSpatialFilter(query);
+    RefilterTraceFromHistory(filter);
+  } catch (const std::bad_alloc &) {
+    InvalidateHistory();
+    InvalidateSegmentCache();
+    trace.clear();
+    merge_vario_samples.clear();
+    return false;
+  }
+
+  last_query = query;
+  last_query.min_time = query.min_time;
   synced_append_serial = append;
   synced_modify_serial = modify;
   return !trace.empty();

--- a/src/Renderer/TrailRenderer.hpp
+++ b/src/Renderer/TrailRenderer.hpp
@@ -91,6 +91,18 @@ class TrailRenderer {
   std::vector<TrailVarioSample> merge_vario_samples;
   AllocatedArray<BulkPixelPoint> points;
 
+  /**
+   * Time-windowed store copy (no viewport filter).  Spatial filter runs
+   * locally into #trace so pan/zoom need not re-walk the store under lock.
+   */
+  TracePointVector history;
+  std::vector<TrailVarioSample> history_vario;
+  bool history_valid = false;
+  std::chrono::duration<unsigned> history_min_time{};
+  Serial history_append_serial{};
+  Serial history_modify_serial{};
+  TrailQuery last_query{};
+
   /** Reused each Draw() to avoid per-frame heap allocations. */
   std::vector<TrailPointData> valid_points;
   std::vector<PixelPoint> interpolated;
@@ -267,7 +279,14 @@ private:
   bool SyncTrace(const TraceComputer &trace_computer,
                  const TrailQuery &query) noexcept;
 
+  void InvalidateHistory() noexcept;
   void InvalidateSegmentCache() noexcept;
+
+  void RefilterTraceFromHistory(const TrailSpatialFilter &filter) noexcept;
+
+  [[gnu::pure]]
+  static bool TrailQueryViewEqual(const TrailQuery &a,
+                                  const TrailQuery &b) noexcept;
 
   void UpdateSegmentCache(const WindowProjection &projection,
                           TrailSettings::Type type,

--- a/test/src/RunTrailRendererStress.cpp
+++ b/test/src/RunTrailRendererStress.cpp
@@ -1,0 +1,672 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DebugReplay.hpp"
+#include "DebugReplayIGC.hpp"
+#include "DebugReplayNMEA.hpp"
+#include "Computer/Settings.hpp"
+#include "Computer/TraceComputer.hpp"
+#include "Look/TrailLook.hpp"
+#include "MapSettings.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "Renderer/TrailRenderer.hpp"
+#include "ProductName.hpp"
+#include "Screen/Layout.hpp"
+#include "Version.hpp"
+#include "system/Args.hpp"
+#include "system/Path.hpp"
+#include "system/StandardVersion.hpp"
+#include "ui/canvas/BufferCanvas.hpp"
+#include "ui/window/Init.hpp"
+#include "util/NumberParser.hpp"
+#include "util/PrintException.hxx"
+#include "util/StringCompare.hxx"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+static constexpr const char canonical_name[] = "RunTrailRendererStress";
+
+struct Options {
+  unsigned sample_minutes = 10;
+  unsigned draws_per_sample = 5;
+  /** Circling half-width: ~1.5 km map (issue #2661 / typical climb zoom). */
+  double circle_radius_m = 750;
+  /** Cruise half-width: ~38 km map (typical task cruise). */
+  double cruise_radius_m = 19000;
+  /** Default ≈ OpenVario / 5" landscape at ~130 DPI logical size. */
+  unsigned width = 800;
+  unsigned height = 480;
+  unsigned dpi = 130;
+  TrailSettings::Type trail_type = TrailSettings::Type::VARIO_1;
+  TrailSettings::Length trail_length = TrailSettings::Length::FULL;
+  bool trail_scaling = true;
+  bool sample_end_only = true;
+  bool progress = true;
+};
+
+static Options options;
+
+struct ReplayInput {
+  Path file;
+  std::string driver;
+};
+
+struct Checkpoint {
+  unsigned flight_minutes;
+  unsigned fix_index;
+};
+
+static void
+PrintStandardHelp() noexcept
+{
+  std::printf(
+    "Usage: %s [OPTION]... <driver> <file>\n"
+    "   or: %s [OPTION]... <file>\n"
+    "\n"
+    "Replay a flight recording, accumulate a snail trail, and benchmark\n"
+    "TrailRenderer draw cost (#2661).  Draw benchmarks are deferred until\n"
+    "after replay so a long flight does not redraw an ever-growing trail\n"
+    "inside the replay loop.\n"
+    "\n"
+    "Options:\n"
+    "  --sample-minutes=N    sample every N flight minutes (default: 10)\n"
+    "  --draws=N             map redraws per sample (default: 5)\n"
+    "  --circle-radius=M     circling half-width in metres (default: 750,\n"
+    "                        ~1.5 km map width)\n"
+    "  --cruise-radius=M     cruise half-width in metres (default: 19000,\n"
+    "                        ~38 km map width)\n"
+    "  --width=PIXELS        canvas width (default: 800)\n"
+    "  --height=PIXELS       canvas height (default: 480)\n"
+    "  --dpi=N               Layout DPI for spacing scale (default: 130)\n"
+    "  --trail-type=TYPE     vario1, vario1_dots, vario2, altitude\n"
+    "  --trail-length=LEN    off, short, long, full (default: full)\n"
+    "  --no-trail-scaling    disable scaled vario trail pens\n"
+    "  --timeline            benchmark at each sample point (default: end only)\n"
+    "  --end-only            benchmark only after full replay (default)\n"
+    "  --no-progress         do not print replay progress on stderr\n"
+    "  -h, --help            display this help and exit\n"
+    "  --version             output version information and exit\n"
+    "\n"
+    "Example:\n"
+    "  %s test/data/issue-2661/short_2026-06-20_11-47.nmea OpenVario\n"
+    "  %s --timeline --sample-minutes=5 flight.igc\n"
+    "\n"
+    "Report bugs to: <%s>\n"
+    "%s home page: <%s>\n",
+    canonical_name, canonical_name, canonical_name, canonical_name,
+    PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+[[gnu::pure]]
+static std::optional<TrailSettings::Type>
+ParseTrailType(const char *value) noexcept
+{
+  if (StringIsEqualIgnoreCase(value, "vario1"))
+    return TrailSettings::Type::VARIO_1;
+  if (StringIsEqualIgnoreCase(value, "vario1_dots"))
+    return TrailSettings::Type::VARIO_1_DOTS;
+  if (StringIsEqualIgnoreCase(value, "vario2"))
+    return TrailSettings::Type::VARIO_2;
+  if (StringIsEqualIgnoreCase(value, "altitude"))
+    return TrailSettings::Type::ALTITUDE;
+  return std::nullopt;
+}
+
+[[gnu::pure]]
+static std::optional<TrailSettings::Length>
+ParseTrailLength(const char *value) noexcept
+{
+  if (StringIsEqualIgnoreCase(value, "off"))
+    return TrailSettings::Length::OFF;
+  if (StringIsEqualIgnoreCase(value, "short"))
+    return TrailSettings::Length::SHORT;
+  if (StringIsEqualIgnoreCase(value, "long"))
+    return TrailSettings::Length::LONG;
+  if (StringIsEqualIgnoreCase(value, "full"))
+    return TrailSettings::Length::FULL;
+  return std::nullopt;
+}
+
+static bool
+ParseUnsignedOption(const char *arg, const char *prefix,
+                    unsigned &value) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const unsigned parsed = ParseUnsigned(p, &end);
+  if (end == nullptr || *end != '\0' || parsed == 0)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static bool
+ParseDoubleOption(const char *arg, const char *prefix,
+                  double &value) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const double parsed = ParseDouble(p, &end);
+  if (end == nullptr || *end != '\0' || parsed <= 0.)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static void
+ParseCommandLine(Args &args) noexcept
+{
+  while (!args.IsEmpty()) {
+    const char *arg = args.PeekNext();
+
+    if (StringIsEqual(arg, "-h") || StringIsEqual(arg, "--help")) {
+      args.Skip();
+      PrintStandardHelp();
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--version")) {
+      args.Skip();
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--timeline")) {
+      args.Skip();
+      options.sample_end_only = false;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--end-only")) {
+      args.Skip();
+      options.sample_end_only = true;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-progress")) {
+      args.Skip();
+      options.progress = false;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-trail-scaling")) {
+      args.Skip();
+      options.trail_scaling = false;
+      continue;
+    }
+
+    if (ParseUnsignedOption(arg, "--sample-minutes=", options.sample_minutes) ||
+        ParseUnsignedOption(arg, "--draws=", options.draws_per_sample) ||
+        ParseUnsignedOption(arg, "--width=", options.width) ||
+        ParseUnsignedOption(arg, "--height=", options.height) ||
+        ParseUnsignedOption(arg, "--dpi=", options.dpi)) {
+      args.Skip();
+      continue;
+    }
+
+    if (ParseDoubleOption(arg, "--circle-radius=", options.circle_radius_m) ||
+        ParseDoubleOption(arg, "--cruise-radius=", options.cruise_radius_m)) {
+      args.Skip();
+      continue;
+    }
+
+    if (StringStartsWith(arg, "--trail-type=")) {
+      args.Skip();
+      const auto type = ParseTrailType(arg + 13);
+      if (!type) {
+        std::fprintf(stderr, "Unknown trail type '%s'\n", arg + 13);
+        std::exit(EXIT_FAILURE);
+      }
+      options.trail_type = *type;
+      continue;
+    }
+
+    if (StringStartsWith(arg, "--trail-length=")) {
+      args.Skip();
+      const auto length = ParseTrailLength(arg + 15);
+      if (!length) {
+        std::fprintf(stderr, "Unknown trail length '%s'\n", arg + 15);
+        std::exit(EXIT_FAILURE);
+      }
+      options.trail_length = *length;
+      continue;
+    }
+
+    break;
+  }
+}
+
+static ReplayInput
+ParseReplayInput(Args &args)
+{
+  ReplayInput input;
+
+  if (!args.IsEmpty() && StringEndsWithIgnoreCase(args.PeekNext(), ".igc"))
+    input.file = args.ExpectNextPath();
+  else {
+    input.driver = args.ExpectNextT();
+    input.file = args.ExpectNextPath();
+    if (StringEndsWithIgnoreCase(input.file.c_str(), ".igc"))
+      input.driver.clear();
+  }
+
+  return input;
+}
+
+static DebugReplay *
+OpenReplay(const ReplayInput &input)
+{
+  if (input.driver.empty())
+    return DebugReplayIGC::Create(input.file);
+
+  return DebugReplayNMEA::Create(input.file, input.driver);
+}
+
+static void
+PushMergeVarioSample(TraceComputer &trace_computer,
+                     const MoreData &basic,
+                     const DerivedInfo &calculated) noexcept
+{
+  if (!basic.time_available || !basic.location_available ||
+      !basic.NavAltitudeAvailable() || !calculated.flight.flying)
+    return;
+
+  float vario = 0;
+  if (basic.netto_vario_available)
+    vario = (float)basic.netto_vario;
+  else if (basic.total_energy_vario_available)
+    vario = (float)basic.total_energy_vario;
+  else if (basic.brutto_vario_available)
+    vario = (float)basic.brutto_vario;
+  else
+    return;
+
+  trace_computer.PushMergeVarioSample(basic.time.Cast<TracePoint::Time>(), vario);
+}
+
+static void
+ProcessFix(TraceComputer &trace_computer,
+           const ComputerSettings &settings_computer,
+           const MoreData &basic,
+           const DerivedInfo &calculated) noexcept
+{
+  PushMergeVarioSample(trace_computer, basic, calculated);
+  trace_computer.Update(settings_computer, basic, calculated);
+}
+
+static WindowProjection
+MakeProjection(const GeoPoint &location, double radius_m,
+               PixelSize screen_size) noexcept
+{
+  WindowProjection projection;
+  projection.SetScreenSize(screen_size);
+  projection.SetScaleFromRadius(radius_m);
+  projection.SetGeoLocation(location);
+  projection.SetScreenOrigin(screen_size.width / 2, screen_size.height / 2);
+  projection.UpdateScreenBounds();
+  return projection;
+}
+
+static double
+BenchmarkDrawMs(Canvas &canvas, TrailRenderer &renderer,
+                TraceComputer &trace_computer,
+                const WindowProjection &projection,
+                const MoreData &basic, const DerivedInfo &calculated,
+                const TrailSettings &trail_settings,
+                unsigned draws) noexcept
+{
+  if (draws == 0)
+    return 0.;
+
+  const PixelPoint aircraft_pos = projection.GeoToScreen(basic.location);
+
+  using clock = std::chrono::steady_clock;
+  const auto t0 = clock::now();
+  for (unsigned i = 0; i < draws; ++i)
+    renderer.Draw(canvas, trace_computer, projection, {},
+                  false, aircraft_pos, basic, calculated, trail_settings);
+  const auto t1 = clock::now();
+
+  return std::chrono::duration<double, std::milli>(t1 - t0).count();
+}
+
+static void
+PrintSampleHeader() noexcept
+{
+  std::puts("minute\tstore_pts\tmerge_samples\t"
+            "circle_kept\tcruise_kept\t"
+            "circle_budget\tcruise_budget\t"
+            "circle_ms\tcruise_ms\t"
+            "circle_map_scale\tcruise_map_scale");
+}
+
+static void
+PrintSample(unsigned flight_minutes, unsigned store_pts,
+            unsigned merge_samples,
+            unsigned circle_kept, unsigned cruise_kept,
+            unsigned circle_budget, unsigned cruise_budget,
+            double circle_ms, double cruise_ms,
+            double circle_map_scale, double cruise_map_scale) noexcept
+{
+  std::printf("%u\t%u\t%u\t%u\t%u\t%u\t%u\t%.2f\t%.2f\t%.0f\t%.0f\n",
+              flight_minutes, store_pts, merge_samples,
+              circle_kept, cruise_kept,
+              circle_budget, cruise_budget,
+              circle_ms, cruise_ms,
+              circle_map_scale, cruise_map_scale);
+}
+
+static unsigned
+CountKeptPoints(const TraceComputer &trace_computer,
+                const TrailQuery &query) noexcept
+{
+  TracePointVector kept;
+  std::vector<TrailVarioSample> merge_vario;
+  trace_computer.LockedTrailQuery(query, kept, merge_vario);
+  return unsigned(kept.size());
+}
+
+static void
+ReportReplayProgress(unsigned fix_count, unsigned flight_minutes,
+                     unsigned trace_points) noexcept
+{
+  std::fprintf(stderr,
+               "replaying: fix %u, minute %u, trail %u points\n",
+               fix_count, flight_minutes, trace_points);
+}
+
+static unsigned
+CountTracePoints(const TraceComputer &trace_computer) noexcept
+{
+  TracePointVector points;
+  std::vector<TrailVarioSample> merge_vario;
+  trace_computer.LockedCopySnapshot(points, merge_vario);
+  return unsigned(points.size());
+}
+
+static void
+SampleAndPrint(Canvas &canvas, TrailRenderer &renderer,
+               TraceComputer &trace_computer,
+               const MoreData &basic, const DerivedInfo &calculated,
+               const TrailSettings &trail_settings,
+               PixelSize screen_size, unsigned flight_minutes) noexcept
+{
+  TracePointVector points;
+  std::vector<TrailVarioSample> merge_samples;
+  trace_computer.LockedCopySnapshot(points, merge_samples);
+
+  const auto circle_projection =
+    MakeProjection(basic.location, options.circle_radius_m, screen_size);
+  const auto cruise_projection =
+    MakeProjection(basic.location, options.cruise_radius_m, screen_size);
+
+  const TrailQuery circle_query =
+    TrailRenderer::MakeTrailQuery({}, circle_projection);
+  const TrailQuery cruise_query =
+    TrailRenderer::MakeTrailQuery({}, cruise_projection);
+  const unsigned circle_kept = CountKeptPoints(trace_computer, circle_query);
+  const unsigned cruise_kept = CountKeptPoints(trace_computer, cruise_query);
+
+  if (options.progress)
+    std::fprintf(stderr,
+                 "benchmarking minute %u (store %u, circle kept %u/%u, "
+                 "cruise kept %u/%u)...\n",
+                 flight_minutes, unsigned(points.size()),
+                 circle_kept, circle_query.max_points,
+                 cruise_kept, cruise_query.max_points);
+
+  const double circle_ms =
+    BenchmarkDrawMs(canvas, renderer, trace_computer, circle_projection,
+                    basic, calculated, trail_settings,
+                    options.draws_per_sample);
+  const double cruise_ms =
+    BenchmarkDrawMs(canvas, renderer, trace_computer, cruise_projection,
+                    basic, calculated, trail_settings,
+                    options.draws_per_sample);
+
+  PrintSample(flight_minutes, unsigned(points.size()),
+              unsigned(merge_samples.size()),
+              circle_kept, cruise_kept,
+              circle_query.max_points, cruise_query.max_points,
+              circle_ms, cruise_ms,
+              circle_projection.GetMapScale(),
+              cruise_projection.GetMapScale());
+}
+
+static bool
+ReplayToCheckpoint(const ReplayInput &input,
+                   TraceComputer &trace_computer,
+                   const ComputerSettings &settings_computer,
+                   unsigned target_fixes,
+                   MoreData &basic_out,
+                   DerivedInfo &calculated_out) noexcept
+{
+  std::unique_ptr<DebugReplay> replay(OpenReplay(input));
+  if (replay == nullptr)
+    return false;
+
+  trace_computer.Reset();
+
+  unsigned fix_count = 0;
+  while (replay->Next()) {
+    ++fix_count;
+    ProcessFix(trace_computer, settings_computer,
+               replay->Basic(), replay->Calculated());
+
+    if (fix_count >= target_fixes) {
+      basic_out = replay->Basic();
+      calculated_out = replay->Calculated();
+      return true;
+    }
+  }
+
+  if (fix_count == 0)
+    return false;
+
+  basic_out = replay->Basic();
+  calculated_out = replay->Calculated();
+  return fix_count >= target_fixes;
+}
+
+static std::vector<Checkpoint>
+CollectCheckpoints(const ReplayInput &input,
+                   const ComputerSettings &settings_computer) noexcept
+{
+  std::vector<Checkpoint> checkpoints;
+
+  std::unique_ptr<DebugReplay> replay(OpenReplay(input));
+  if (replay == nullptr)
+    return checkpoints;
+
+  TraceComputer trace_computer;
+  std::optional<TimeStamp> flight_start;
+  unsigned last_sampled_minute = 0;
+  unsigned fix_count = 0;
+  unsigned last_progress_minute = 0;
+
+  while (replay->Next()) {
+    ++fix_count;
+    ProcessFix(trace_computer, settings_computer,
+               replay->Basic(), replay->Calculated());
+
+    const MoreData &basic = replay->Basic();
+    if (!basic.time_available)
+      continue;
+
+    if (!flight_start)
+      flight_start = basic.time;
+
+    const auto elapsed = basic.time - *flight_start;
+    const unsigned flight_minutes =
+      unsigned(std::chrono::duration_cast<std::chrono::minutes>(elapsed).count());
+
+    if (options.progress &&
+        flight_minutes >= last_progress_minute + 5) {
+      ReportReplayProgress(fix_count, flight_minutes,
+                           CountTracePoints(trace_computer));
+      last_progress_minute = flight_minutes;
+    }
+
+    if (flight_minutes < last_sampled_minute + options.sample_minutes)
+      continue;
+
+    last_sampled_minute = flight_minutes;
+    checkpoints.push_back({flight_minutes, fix_count});
+  }
+
+  if (fix_count == 0)
+    return checkpoints;
+
+  const MoreData &basic = replay->Basic();
+  unsigned flight_minutes = 0;
+  if (basic.time_available && flight_start)
+    flight_minutes = unsigned(std::chrono::duration_cast<std::chrono::minutes>(
+      basic.time - *flight_start).count());
+
+  if (checkpoints.empty() ||
+      checkpoints.back().fix_index != fix_count)
+    checkpoints.push_back({flight_minutes, fix_count});
+
+  if (options.progress)
+    ReportReplayProgress(fix_count, flight_minutes,
+                         CountTracePoints(trace_computer));
+
+  return checkpoints;
+}
+
+int
+main(int argc, char **argv)
+try {
+  Args args(argc, argv, "DRIVER FILE");
+  ParseCommandLine(args);
+
+  const ReplayInput input = ParseReplayInput(args);
+  args.ExpectEnd();
+
+  const PixelSize screen_size{int(options.width), int(options.height)};
+
+  ScreenGlobalInit screen_init;
+  Layout::Initialise(screen_init.GetDisplay(), screen_size,
+                     100, options.dpi);
+
+  BufferCanvas canvas;
+  canvas.Create(screen_size);
+  canvas.ClearWhite();
+
+  TrailSettings trail_settings{};
+  trail_settings.wind_drift_enabled = false;
+  trail_settings.scaling_enabled = options.trail_scaling;
+  trail_settings.type = options.trail_type;
+  trail_settings.length = options.trail_length;
+
+  TrailLook trail_look;
+  trail_look.Initialise(trail_settings);
+
+  TrailRenderer renderer(trail_look);
+
+  ComputerSettings settings_computer{};
+  settings_computer.contest.enable = false;
+
+  PrintSampleHeader();
+
+  if (options.sample_end_only) {
+    std::unique_ptr<DebugReplay> replay(OpenReplay(input));
+    if (replay == nullptr)
+      return EXIT_FAILURE;
+
+    TraceComputer trace_computer;
+    std::optional<TimeStamp> flight_start;
+    unsigned fix_count = 0;
+    unsigned last_progress_minute = 0;
+
+    while (replay->Next()) {
+      ++fix_count;
+      ProcessFix(trace_computer, settings_computer,
+                 replay->Basic(), replay->Calculated());
+
+      const MoreData &basic = replay->Basic();
+      if (!basic.time_available)
+        continue;
+
+      if (!flight_start)
+        flight_start = basic.time;
+
+      const unsigned flight_minutes =
+        unsigned(std::chrono::duration_cast<std::chrono::minutes>(
+          basic.time - *flight_start).count());
+
+      if (options.progress &&
+          flight_minutes >= last_progress_minute + 5) {
+        ReportReplayProgress(fix_count, flight_minutes,
+                             CountTracePoints(trace_computer));
+        last_progress_minute = flight_minutes;
+      }
+    }
+
+    if (fix_count == 0) {
+      std::fprintf(stderr, "%s: replay produced no fixes\n", canonical_name);
+      return EXIT_FAILURE;
+    }
+
+    const MoreData &basic = replay->Basic();
+    const DerivedInfo &calculated = replay->Calculated();
+    unsigned flight_minutes = 0;
+    if (basic.time_available && flight_start)
+      flight_minutes = unsigned(std::chrono::duration_cast<std::chrono::minutes>(
+        basic.time - *flight_start).count());
+
+    if (options.progress)
+      ReportReplayProgress(fix_count, flight_minutes,
+                           CountTracePoints(trace_computer));
+
+    SampleAndPrint(canvas, renderer, trace_computer,
+                   basic, calculated, trail_settings,
+                   screen_size, flight_minutes);
+    return EXIT_SUCCESS;
+  }
+
+  const std::vector<Checkpoint> checkpoints =
+    CollectCheckpoints(input, settings_computer);
+
+  if (checkpoints.empty()) {
+    std::fprintf(stderr, "%s: replay produced no fixes\n", canonical_name);
+    return EXIT_FAILURE;
+  }
+
+  TraceComputer trace_computer;
+  MoreData basic;
+  DerivedInfo calculated;
+
+  for (const Checkpoint &checkpoint : checkpoints) {
+    if (!ReplayToCheckpoint(input, trace_computer, settings_computer,
+                            checkpoint.fix_index, basic, calculated)) {
+      std::fprintf(stderr, "%s: replay stopped before fix %u\n",
+                   canonical_name, checkpoint.fix_index);
+      return EXIT_FAILURE;
+    }
+
+    SampleAndPrint(canvas, renderer, trace_computer,
+                   basic, calculated, trail_settings,
+                   screen_size, checkpoint.flight_minutes);
+  }
+
+  return EXIT_SUCCESS;
+} catch (const std::runtime_error &e) {
+  PrintException(e);
+  return EXIT_FAILURE;
+}

--- a/test/src/TestTraceBounds.cpp
+++ b/test/src/TestTraceBounds.cpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Engine/Trace/Trace.hpp"
+#include "Engine/Trace/Vector.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "TestUtil.hpp"
+
+#include <chrono>
+
+using namespace std::chrono;
+
+/**
+ * Build a long eastbound track, then query a tight box around the end.
+ * Bounds-first GetPoints must return far fewer points than the full
+ * spacing-thinned path, while still including a leg that crosses the box.
+ */
+static void
+TestBoundsFirstQuery() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 8192);
+
+  constexpr unsigned n_points = 2000;
+  constexpr double step_deg = 0.001; /* ~111 m east per step */
+
+  for (unsigned i = 0; i < n_points; ++i) {
+    const GeoPoint loc(Angle::Degrees(8 + i * step_deg),
+                       Angle::Degrees(48));
+    const TracePoint point(loc, seconds{i * 2}, 1000, 0, 0);
+    trace.push_back(point);
+  }
+
+  ok1(trace.size() > 1000);
+
+  TracePointVector all_thinned;
+  const GeoPoint end_loc = trace.back().GetLocation();
+  /* Fine spacing: almost every stored point survives thinning. */
+  trace.GetPoints(all_thinned, {}, end_loc, 1.);
+  ok1(all_thinned.size() > 1000);
+
+  /* Tight box around the end (~0.01° ≈ 1 km). */
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(8 + (n_points - 20) * step_deg),
+             Angle::Degrees(48.005)),
+    GeoPoint(Angle::Degrees(8 + (n_points - 1) * step_deg + 0.002),
+             Angle::Degrees(47.995)));
+  ok1(box.IsValid());
+  ok1(box.IsInside(end_loc));
+
+  TracePointVector bounded;
+  trace.GetPoints(bounded, {}, box, end_loc, 1.);
+  ok1(!bounded.empty());
+  ok1(bounded.size() < all_thinned.size() / 10);
+  ok1(bounded.size() < 80);
+
+  /* Last point of the flight must be present. */
+  ok1(bounded.back().GetTime() == trace.back().GetTime());
+
+  /* A point well before the box must not appear. */
+  bool early_found = false;
+  const auto early_time = seconds{100};
+  for (const auto &p : bounded) {
+    if (p.GetTime() == early_time) {
+      early_found = true;
+      break;
+    }
+  }
+  ok1(!early_found);
+}
+
+/**
+ * A single long leg that crosses the viewport must keep both endpoints
+ * (outside → outside with segment through the box).
+ */
+static void
+TestCrossingLegKept() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 64);
+
+  const GeoPoint west(Angle::Degrees(8.0), Angle::Degrees(48));
+  const GeoPoint east(Angle::Degrees(8.2), Angle::Degrees(48));
+  trace.push_back(TracePoint(west, seconds{0}, 1000, 0, 0));
+  /* push_back enforces 2 s min delta */
+  trace.push_back(TracePoint(east, seconds{10}, 1000, 0, 0));
+
+  ok1(trace.size() == 2);
+
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(8.05), Angle::Degrees(48.05)),
+    GeoPoint(Angle::Degrees(8.15), Angle::Degrees(47.95)));
+  ok1(box.IsValid());
+  ok1(!box.IsInside(west));
+  ok1(!box.IsInside(east));
+
+  TracePointVector bounded;
+  const GeoPoint mid(Angle::Degrees(8.1), Angle::Degrees(48));
+  trace.GetPoints(bounded, {}, box, mid, 1.);
+
+  ok1(bounded.size() == 2);
+  ok1(bounded.front().GetTime() == seconds{0});
+  ok1(bounded.back().GetTime() == seconds{10});
+}
+
+int
+main()
+{
+  plan_tests(9 + 7);
+  TestBoundsFirstQuery();
+  TestCrossingLegKept();
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- Extends the bounds-first trail query (#2758) with a **time-window history** on `TrailRenderer`: skip store re-copy when serials/view are unchanged, append-only on `append_serial`, and re-filter spatially on pan/zoom.
- Thin by **DPI-aware on-screen spacing** (`Layout::PtScale` → metres via projection), then raise stride if the visible set still exceeds a **screen-scaled point budget** so Full trail stays usable for paragliders and gliders on weak ARM (Cubieboard / OpenVario class).
- Adds `RunTrailRendererStress` for Draw()-timing under Full trail (OpenVario-like defaults) and updates NEWS for #2661.

This branch includes the three bounds-first commits from #2758 plus the cheap-scan follow-ups; #2758 can be closed in favour of this PR once reviewed, or this can be rebased after #2758 lands.

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y` (and/or `PI2`) builds cleanly
- [ ] Unit: `TestTraceBounds` still passes
- [ ] `RunTrailRendererStress` with a long IGC: mid-zoom Full trail Draw() cost stays bounded; climb zoom keeps dense vario colour (stride 1 under budget)
- [ ] Manual map: Full snail trail, pan/zoom during long flight — no missing segments; trail updates as points append
- [ ] Optional: Cubieboard / Pi 2-class device — process CPU with Full trail + smoothing vs master / #2758 alone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved map trail rendering by filtering to the visible area before thinning points.
  * Reduced redraw work during panning, zooming, and trail updates.
  * Added DPI- and zoom-aware spacing and point limits for smoother display.

* **Bug Fixes**
  * Preserved trail segments that cross the visible map boundary.
  * Improved trail history updates and rendering stability during memory pressure.

* **Tests**
  * Added coverage for visible-area filtering and boundary-crossing segments.
  * Added a trail-rendering stress benchmark.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->