### PR TITLE
Terrain/RasterRenderer: Clamp OpenGL terrain matrix to max texture size

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -207,6 +207,8 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
+  - fix black terrain after idle high-resolution sharpening on OpenGL
+    devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
   - dynamically adjust contour line density to zoom factor #2233
   - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -11,6 +11,11 @@
 #include "Renderer/GeoBitmapRenderer.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "ui/event/Idle.hpp"
+#include "LogFile.hpp"
+
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
+#endif
 
 #include <algorithm> // for std::clamp()
 #include <cassert>
@@ -281,13 +286,33 @@ RasterRenderer::ScanMap(const RasterMap &map,
   bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
   bounds.IntersectWith(map.GetBounds());
 
-  const UnsignedPoint2D matrix_size =
+  UnsignedPoint2D matrix_size =
     (UnsignedPoint2D)projection.GetScreenSize()
     * static_cast<unsigned>(BOUNDS_SCALE_FACTOR * 128.0f + 0.5f)
     / quantisation_pixels / 128;
   if (matrix_size.x == 0 || matrix_size.y == 0) {
     quantisation_effective = 0;
     return;
+  }
+
+  /* VC4 (and other GLES2 GPUs) reject textures larger than
+     GL_MAX_TEXTURE_SIZE (often 2048).  q=1 at 1080p with
+     BOUNDS_SCALE_FACTOR can request ~2880 wide → GL_INVALID_VALUE
+     on TexSubImage and a black map. */
+  const unsigned max_texture = OpenGL::max_texture_size > 0
+    ? OpenGL::max_texture_size
+    : OpenGL::DEFAULT_MAX_TEXTURE_SIZE;
+  if (matrix_size.x > max_texture || matrix_size.y > max_texture) {
+    const double scale = std::min(double(max_texture) / matrix_size.x,
+                                  double(max_texture) / matrix_size.y);
+    const unsigned clamped_x =
+      std::max(1u, unsigned(matrix_size.x * scale));
+    const unsigned clamped_y =
+      std::max(1u, unsigned(matrix_size.y * scale));
+    LogFmt("Terrain: clamp matrix {}x{} -> {}x{} (max texture {})",
+           matrix_size.x, matrix_size.y, clamped_x, clamped_y,
+           max_texture);
+    matrix_size = {clamped_x, clamped_y};
   }
 
   height_matrix.Fill(map, bounds, matrix_size, true);

--- a/src/ui/canvas/opengl/Globals.cpp
+++ b/src/ui/canvas/opengl/Globals.cpp
@@ -11,6 +11,8 @@ namespace OpenGL {
 
 bool texture_non_power_of_two;
 
+unsigned max_texture_size;
+
 bool mapbuffer;
 
 GLenum render_buffer_depth_stencil, render_buffer_stencil;

--- a/src/ui/canvas/opengl/Globals.hpp
+++ b/src/ui/canvas/opengl/Globals.hpp
@@ -32,6 +32,17 @@ namespace OpenGL {
 extern bool texture_non_power_of_two;
 
 /**
+ * Fallback when GL_MAX_TEXTURE_SIZE is missing or non-positive
+ * (common GLES2 floor, e.g. VC4).
+ */
+inline constexpr unsigned DEFAULT_MAX_TEXTURE_SIZE = 2048;
+
+/**
+ * GL_MAX_TEXTURE_SIZE from the driver (e.g. 2048 on VC4).
+ */
+extern unsigned max_texture_size;
+
+/**
  * Is glMapBuffer() available?  May be implemented by the extension
  * GL_OES_mapbuffer.
  */

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -142,6 +142,15 @@ OpenGL::SetupContext()
 
   texture_non_power_of_two = SupportsNonPowerOfTwoTextures();
 
+  {
+    GLint value = 0;
+    glGetIntegerv(GL_MAX_TEXTURE_SIZE, &value);
+    max_texture_size = value > 0
+      ? unsigned(value)
+      : DEFAULT_MAX_TEXTURE_SIZE;
+    LogFormat("GL max texture size: %u", max_texture_size);
+  }
+
 #ifdef ANDROID
   if (native_view != nullptr)
     native_view->SetTexturePowerOfTwo(Java::GetEnv(), texture_non_power_of_two);


### PR DESCRIPTION
## Summary
- Idle high-resolution terrain sharpening builds a height matrix about 1.5× the screen size. On 1080p OpenGL ES devices with `GL_MAX_TEXTURE_SIZE` of 2048 (notably Mesa VC4 / Raspberry Pi 3), that can request ~2880×1620, so `glTexSubImage2D` fails with `GL_INVALID_VALUE` and the map goes black.
- Query `GL_MAX_TEXTURE_SIZE` at GL init and clamp the OpenGL terrain matrix before allocating/uploading the bitmap.

## Test plan
- [x] On Raspberry Pi 3 (or other GLES2 with 2048 max texture): load high-res terrain, enter pan, wait for idle sharpen — terrain should stay visible (check log for `Terrain: clamp matrix …` and `GL max texture size: 2048`)
- [ ] Desktop OpenGL (large max texture): confirm no unwanted clamp / no regression in terrain sharpening
- [ ] Confirm UNIX build still compiles with `WERROR=y`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed black terrain artifacts after idle high-resolution sharpening on OpenGL devices with limited texture sizes.
  - Improved OpenGL terrain rendering by automatically clamping the processed height-matrix size to the GPU’s maximum supported texture dimension (with a 2048 fallback when unavailable).
  - Added logging to report the detected texture-size capability used for these adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->