### PR TITLE
Dialogs/Simulator: Explain and improve how to operate in sim mode

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -35,6 +35,7 @@ data=GPS_FIX_WAIT
 mode=default
 type=gce
 data=STARTUP_SIMULATOR
+event=StatusMessage Simulator Steer by dragging from the glider, or using InfoBoxes Altitude and Speed Ground
 
 mode=default
 type=gce

--- a/Data/Status/default.xcs
+++ b/Data/Status/default.xcs
@@ -114,6 +114,9 @@ sound=IDR_FAIL
 key=Screen Mode Full
 delay=1000
 
+key=Simulator Steer by dragging from the glider, or using InfoBoxes Altitude and Speed Ground
+delay=5000
+
 # Always leave dummy entry for now (work around issue in parser)
 key=Dummy
 delay=2500

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -23,6 +23,12 @@ Version 7.45 - not yet released
     label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
   - document ``AirspaceLabels`` input event
 * ui
+  - Improve simulator discoverability: startup tip to steer by
+    dragging from the glider or via Altitude / Speed Ground InfoBoxes
+    (5 s); Welcome Quick Guide paragraph in simulator mode; add
+    “Sim: Jump to” on map items and waypoint details; Speed Ground
+    simulator panel for bearing and ground-speed steps; label Set Home
+    as “Set as Startup Location” in simulator mode
   - Bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
     (same as AVG/ALT softkey and RL gesture); previous target remains
     on Down

--- a/build/infobox.mk
+++ b/build/infobox.mk
@@ -33,6 +33,7 @@ LIBINFOBOX_SOURCES = \
 	$(SRC)/InfoBoxes/Panel/AltitudeSetup.cpp \
 	$(SRC)/InfoBoxes/Panel/MacCreadyEdit.cpp \
 	$(SRC)/InfoBoxes/Panel/MacCreadySetup.cpp \
+	$(SRC)/InfoBoxes/Panel/SpeedSimulator.cpp \
 	$(SRC)/InfoBoxes/Panel/ATCReference.cpp \
 	$(SRC)/InfoBoxes/Panel/ATCSetup.cpp \
 	$(SRC)/InfoBoxes/Panel/RadioEdit.cpp

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -36,6 +36,8 @@
 #include "LogFile.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/canvas/Color.hpp"
+#include "Pan.hpp"
+#include "Simulator.hpp"
 #include <Message.hpp>
 
 #include <limits>
@@ -114,6 +116,7 @@ class MapItemListWidget final
   MapItemListRenderer renderer;
 
   Button *settings_button, *details_button, *cancel_button, *goto_button;
+  Button *sim_jump_button = nullptr;
   Button *ack_button, *enable_button;
 
   WndForm *dialog = nullptr;
@@ -121,6 +124,7 @@ class MapItemListWidget final
   ProtectedAirspaceWarningManager *airspace_warnings = nullptr;
 
   void OnDetailsClicked() noexcept;
+  void OnSimJumpClicked() noexcept;
 
 public:
   void CreateButtons(WidgetDialog &dialog,
@@ -169,6 +173,11 @@ protected:
     const MapItem *item = GetItem(GetCursorIndex());
     details_button->SetEnabled(item != nullptr && HasDetails(*item));
     goto_button->SetEnabled(item != nullptr && CanGotoItem(*item));
+    if (sim_jump_button != nullptr)
+      sim_jump_button->SetEnabled(item != nullptr &&
+                                  is_simulator() &&
+                                  (item->type == MapItem::Type::WAYPOINT ||
+                                   item->type == MapItem::Type::LOCATION));
     ack_button->SetEnabled(item != nullptr && CanAckItem(*item));
     enable_button->SetEnabled(item != nullptr && CanEnableItem(*item));
   }
@@ -270,6 +279,12 @@ MapItemListWidget::CreateButtons(WidgetDialog &dialog,
   goto_button = dialog.AddButton(_("Goto"), [this](){
     OnGotoClicked();
   });
+
+  if (is_simulator()) {
+    sim_jump_button = dialog.AddButton(_("Sim: Jump to"), [this](){
+      OnSimJumpClicked();
+    });
+  }
 
   ack_button = dialog.AddButton(_("Ack Day"), [this](){
     OnAckClicked();
@@ -460,6 +475,26 @@ MapItemListWidget::OnGotoClicked()
 
   backend_components->protected_task_manager->DoGoto(std::move(waypoint));
   cancel_button->Click();
+}
+
+void
+MapItemListWidget::OnSimJumpClicked() noexcept
+{
+  const MapItem *item = GetItem(GetCursorIndex());
+  if (item == nullptr ||
+      !is_simulator() ||
+      (item->type != MapItem::Type::WAYPOINT &&
+       item->type != MapItem::Type::LOCATION))
+    return;
+
+  GeoPoint location;
+  if (item->type == MapItem::Type::LOCATION)
+    location = static_cast<const LocationMapItem &>(*item).location;
+  else
+    location = static_cast<const WaypointMapItem &>(*item).waypoint->location;
+
+  if (SimJumpTo(location))
+    cancel_button->Click();
 }
 
 inline void

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.cpp
@@ -18,6 +18,7 @@
 #include "DataComponents.hpp"
 #include "Waypoint/WaypointGlue.hpp"
 #include "Pan.hpp"
+#include "Simulator.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Profile/Current.hpp"
@@ -214,10 +215,10 @@ WaypointCommandsWidget::UpdateButtons()
   SetRowEnabled(INSERT_IN_TASK, task_manager != nullptr);
   SetRowEnabled(APPEND_TO_TASK, task_manager != nullptr);
   SetRowEnabled(REMOVE_FROM_TASK, task_manager != nullptr && MapTaskManager::GetIndexInTask(*waypoint) >= 0);
-  
+
   SetRowEnabled(SET_ACTIVE_FREQUENCY, has_freq);
   SetRowEnabled(SET_STANDBY_FREQUENCY, has_freq);
-  
+
   SetRowEnabled(EDIT, allow_edit && waypoints != nullptr);
 }
 
@@ -237,7 +238,7 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
 {
 
   RowFormWidget::Prepare(parent, rc);
-  
+
   replace_button = AddButton(_("Replace in Task"), [this](){
     if (ReplaceInTask(*task_manager, waypoint))
       CommitParentSearchAndCloseForm();
@@ -252,13 +253,17 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
     if (AppendToTask(*task_manager, waypoint))
       CommitParentSearchAndCloseForm();
   });
-    
+
   remove_button = AddButton(_("Remove from Task"), [this](){
     if (RemoveFromTask(*task_manager, *waypoint))
       CommitParentSearchAndCloseForm();
   });
-  
-  home_button = AddButton(_("Set as New Home"), [this](){
+
+  const char *home_label = is_simulator()
+    ? _("Set as Startup Location")
+    : _("Set as New Home");
+
+  home_button = AddButton(home_label, [this](){
     SetHome(waypoints, *waypoint);
     CommitParentSearchAndCloseForm();
   });
@@ -273,7 +278,7 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
       *nesting.state_change_committed = true;
     form->SetModalResult(mrOK);
   });
-  
+
 
   set_active_button = AddButton(_("Set Active Frequency"), [this](){
     ActionInterface::SetActiveFrequency(waypoint->radio_frequency,
@@ -284,7 +289,7 @@ WaypointCommandsWidget::Prepare(ContainerWindow &parent,
     ActionInterface::SetStandbyFrequency(waypoint->radio_frequency,
                                          waypoint->name.c_str());
   });
-  
+
   edit_button = AddButton(_("Edit"), [this](){
     Waypoint wp_copy = *waypoint;
 

--- a/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
+++ b/src/Dialogs/Waypoint/WaypointCommandsWidget.hpp
@@ -41,7 +41,9 @@ class WaypointCommandsWidget final
 	EDIT,
   };
 
-  Button *replace_button, *insert_button, *append_button, *remove_button, *home_button, *pan_button, *set_active_button, *set_standby_button, *edit_button;
+  Button *replace_button, *insert_button, *append_button, *remove_button,
+         *home_button, *pan_button,
+         *set_active_button, *set_standby_button, *edit_button;
 
   /**
    * Mark a parent browse-search as committed and close this form (no-op if

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -4,6 +4,7 @@
 #include "WaypointDialogs.hpp"
 #include "WaypointInfoWidget.hpp"
 #include "WaypointCommandsWidget.hpp"
+#include "Simulator.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
@@ -122,6 +123,7 @@ class WaypointDetailsWidget final
   : public NullWidget {
   struct Layout {
     PixelRect goto_button;
+    PixelRect sim_jump_button;
     PixelRect magnify_button, shrink_button;
     PixelRect previous_button, next_button;
     PixelRect close_button;
@@ -135,6 +137,7 @@ class WaypointDetailsWidget final
 #endif
 
     explicit Layout(const PixelRect &rc,
+                    bool sim_jump_active,
 #ifdef HAVE_RUN_FILE
                     TextRowRenderer &row_renderer,
 #endif
@@ -149,8 +152,10 @@ class WaypointDetailsWidget final
   ProtectedTaskManager *const task_manager;
 
   const WaypointDetailsNesting nesting;
+  const bool sim_jump_active;
 
   Button goto_button;
+  Button sim_jump_button;
   Button magnify_button, shrink_button;
   Button previous_button, next_button;
   Button close_button;
@@ -185,6 +190,7 @@ public:
      waypoint(std::move(_waypoint)),
      task_manager(_task_manager),
      nesting(_nesting),
+     sim_jump_active(is_simulator()),
      commands_widget(new WaypointCommandsWidget(look, &dialog, waypoints, waypoint,
                                                 task_manager, allow_edit,
                                                 _nesting)) {}
@@ -217,6 +223,7 @@ public:
   void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
 
   void OnGotoClicked();
+  void OnSimJumpClicked();
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -224,12 +231,15 @@ public:
 
   void Show(const PixelRect &rc) noexcept override {
     const Layout layout(rc,
+                        sim_jump_active,
 #ifdef HAVE_RUN_FILE
                         file_list_handler.GetRowRenderer(),
 #endif
                         *waypoint);
 
     goto_button.MoveAndShow(layout.goto_button);
+    if (sim_jump_active)
+      sim_jump_button.MoveAndShow(layout.sim_jump_button);
 
     if (!images.empty()) {
       magnify_button.MoveAndShow(layout.magnify_button);
@@ -259,6 +269,8 @@ public:
 
   void Hide() noexcept override {
     goto_button.Hide();
+    if (sim_jump_active)
+      sim_jump_button.Hide();
 
     if (!images.empty()) {
       magnify_button.Hide();
@@ -281,12 +293,15 @@ public:
 
   void Move(const PixelRect &rc) noexcept override {
     const Layout layout(rc,
+                        sim_jump_active,
 #ifdef HAVE_RUN_FILE
                         file_list_handler.GetRowRenderer(),
 #endif
                         *waypoint);
 
     goto_button.Move(layout.goto_button);
+    if (sim_jump_active)
+      sim_jump_button.Move(layout.sim_jump_button);
 
     if (!images.empty()) {
       magnify_button.Move(layout.magnify_button);
@@ -318,6 +333,7 @@ public:
 
   bool HasFocus() const noexcept override {
     return (task_manager != nullptr && goto_button.HasFocus()) ||
+      (sim_jump_active && sim_jump_button.HasFocus()) ||
       (!images.empty() && (magnify_button.HasFocus() ||
                            shrink_button.HasFocus())) ||
        previous_button.HasFocus() || next_button.HasFocus() ||
@@ -355,6 +371,7 @@ WaypointDetailsDispatchImageInput(const char *misc) noexcept
 }
 
 WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
+                                      bool sim_jump_active,
 #ifdef HAVE_RUN_FILE
                                       TextRowRenderer &row_renderer,
 #endif
@@ -369,28 +386,51 @@ WaypointDetailsWidget::Layout::Layout(const PixelRect &rc,
     auto buttons = main.CutLeftSafe(::Layout::Scale(70));
 
     goto_button = buttons.CutTopSafe(button_height);
+    if (sim_jump_active)
+      sim_jump_button = buttons.CutTopSafe(button_height);
     std::tie(magnify_button, shrink_button) = buttons.CutTopSafe(button_height).VerticalSplit();
 
     close_button = buttons.CutBottomSafe(button_height);
 
     std::tie(previous_button, next_button) = buttons.CutBottomSafe(button_height).VerticalSplit();
   } else {
-    auto buttons = main.CutBottomSafe(button_height);
+    auto buttons = main.CutBottomSafe(sim_jump_active ? 2 * button_height
+                                                      : button_height);
 
     const unsigned one_third = (2 * buttons.left + buttons.right) / 3;
     const unsigned two_thirds = (buttons.left + 2 * buttons.right) / 3;
 
-    goto_button = buttons;
-    goto_button.right = one_third;
+    if (sim_jump_active) {
+      auto top_buttons = buttons.CutTopSafe(button_height);
+      auto bottom_buttons = buttons;
 
-    close_button = buttons;
-    close_button.left = two_thirds;
+      goto_button = top_buttons;
+      goto_button.right = one_third;
 
-    previous_button = buttons;
-    previous_button.left = one_third;
-    next_button = buttons;
-    next_button.right = two_thirds;
-    previous_button.right = next_button.left = (one_third + two_thirds) / 2;
+      sim_jump_button = bottom_buttons;
+      sim_jump_button.right = one_third;
+
+      previous_button = bottom_buttons;
+      previous_button.left = one_third;
+      next_button = bottom_buttons;
+      next_button.right = two_thirds;
+      previous_button.right = next_button.left = (one_third + two_thirds) / 2;
+
+      close_button = bottom_buttons;
+      close_button.left = two_thirds;
+    } else {
+      goto_button = buttons;
+      goto_button.right = one_third;
+
+      close_button = buttons;
+      close_button.left = two_thirds;
+
+      previous_button = buttons;
+      previous_button.left = one_third;
+      next_button = buttons;
+      next_button.right = two_thirds;
+      previous_button.right = next_button.left = (one_third + two_thirds) / 2;
+    }
 
     const unsigned padding = ::Layout::GetTextPadding();
     shrink_button.left = main.left + padding;
@@ -470,6 +510,7 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
   }
 
   const Layout layout(rc,
+                      sim_jump_active,
 #ifdef HAVE_RUN_FILE
                       file_list_handler.GetRowRenderer(),
 #endif
@@ -499,6 +540,11 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                          }
                        });
   }
+
+  if (sim_jump_active)
+    sim_jump_button.Create(parent, look.button, _("Sim: Jump to"),
+                           layout.sim_jump_button, button_style,
+                           [this](){ OnSimJumpClicked(); });
 
   if (!images.empty()) {
     magnify_button.Create(parent, layout.magnify_button, button_style,
@@ -834,6 +880,19 @@ WaypointDetailsWidget::OnGotoClicked()
   dialog.SetModalResult(mrOK);
 
   CommonInterface::main_window->FullRedraw();
+}
+
+void
+WaypointDetailsWidget::OnSimJumpClicked()
+{
+  if (!sim_jump_active)
+    return;
+
+  if (SimJumpTo(waypoint->location)) {
+    if (nesting.state_change_committed != nullptr)
+      *nesting.state_change_committed = true;
+    dialog.SetModalResult(mrOK);
+  }
 }
 
 /**

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -60,11 +60,12 @@ struct QuickGuideState {
 static const char *
 GetWelcomeText(bool dark_mode)
 {
-  static StaticString<1024> welcome;
+  static StaticString<1536> welcome;
   welcome.Format(
     "![XCSoar Logo](resource:IDB_LOGO_HD)\n\n"
     "![XCSoar](resource:%s)\n\n"
     "**Version %s**\n\n"
+    "%s"
     "%s\n\n"
     "%s\n\n"
     "- [https://xcsoar.org](https://xcsoar.org)\n"
@@ -73,6 +74,12 @@ GetWelcomeText(bool dark_mode)
     "- [%s](https://github.com/XCSoar/XCSoar/discussions)",
     dark_mode ? "IDB_TITLE_HD_WHITE" : "IDB_TITLE_HD",
     XCSoar_VersionString,
+    is_simulator()
+      ? _("**Simulator mode:** Drag from the glider to set direction "
+          "and speed. Jump with **Sim: Jump to** on a waypoint or map "
+          "point. Fine-tune height and speed with the **Altitude** and "
+          "**Speed Ground** InfoBoxes.\n\n")
+      : "",
     _("To get the most out of XCSoar and to learn about its many "
       "functions in detail, it is highly recommended to read the "
       "Quick Guide or the complete documentation."),
@@ -81,6 +88,7 @@ GetWelcomeText(bool dark_mode)
     _("XCSoar Manual & Quick Guide"),
     _("GitHub - Source Code & Contributions"),
     _("GitHub Discussions - Questions & Community"));
+
   return welcome.c_str();
 }
 
@@ -240,8 +248,8 @@ GetConfigurationHelpText()
     "Choose terrain colors, shading and contour lines\n\n"
     "- [ ] [Live tracking](xcsoar://config/tracking) *(optional)* - "
     "Share your position via SkyLines or LiveTrack24\n\n"
-    "The easiest way to explore XCSoar is to "
-    "[replay an existing IGC flight](xcsoar://dialog/replay)."),
+    "Explore XCSoar easily by restarting in Simulator mode, or by "
+    "[replaying an IGC flight](xcsoar://dialog/replay)."),
     has_map ? "x" : " ",
     has_polar ? "x" : " ",
     has_pilot ? "x" : " ",
@@ -250,6 +258,7 @@ GetConfigurationHelpText()
     tim_enabled ? "x" : " ",
     has_safety ? "x" : " ",
     has_terrain_display ? "x" : " ");
+
   return text.c_str();
 }
 
@@ -451,15 +460,15 @@ IsQuickGuideHidden() noexcept
 bool
 dlgQuickGuideShowModal(bool force_info)
 {
-  const bool is_simulator = global_simulator_flag;
+  const bool simulator = is_simulator();
   const bool warranty_needed =
-    !is_simulator && !IsWarrantyAcknowledged();
+    !simulator && !IsWarrantyAcknowledged();
   const bool news_needed = !IsNewsSeen();
   const bool cloud_needed =
-    !is_simulator && IsCloudConsentNeeded();
+    !simulator && IsCloudConsentNeeded();
 #ifdef ANDROID
   const bool permissions_needed =
-    !is_simulator && (!AreLocationPermissionsGranted() ||
+    !simulator && (!AreLocationPermissionsGranted() ||
                       !IsNotificationPermissionGranted());
 #else
   const bool permissions_needed = false;
@@ -606,7 +615,7 @@ dlgQuickGuideShowModal(bool force_info)
     advance_or_close();
   };
 
-  if (!is_simulator && !AreLocationPermissionsGranted()) {
+  if (!simulator && !AreLocationPermissionsGranted()) {
     state.location_page_index = pager->GetSize();
 
     auto page = QuickGuidePageWidget::CreateTwoButtonPage(
@@ -626,7 +635,7 @@ dlgQuickGuideShowModal(bool force_info)
     titles.push_back(_("Location Access"));
   }
 
-  if (!is_simulator && !IsNotificationPermissionGranted()) {
+  if (!simulator && !IsNotificationPermissionGranted()) {
     auto page = QuickGuidePageWidget::CreateTwoButtonPage(
       look, GetNotificationDisclosureText(),
       _("Continue"),

--- a/src/InfoBoxes/Content/Speed.cpp
+++ b/src/InfoBoxes/Content/Speed.cpp
@@ -2,6 +2,9 @@
 // Copyright The XCSoar Project
 
 #include "InfoBoxes/Content/Speed.hpp"
+#include "InfoBoxes/Panel/Panel.hpp"
+#include "InfoBoxes/Panel/SpeedSimulator.hpp"
+#include "Simulator.hpp"
 #include "BackendComponents.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "Components.hpp"
@@ -12,6 +15,20 @@
 #include "Language/Language.hpp"
 #include "Units/Units.hpp"
 #include <stdlib.h>
+
+static constexpr InfoBoxPanel speed_ground_panels[] = {
+  { N_("Simulator"), LoadSpeedSimulatorPanel },
+  { nullptr, nullptr }
+};
+
+const InfoBoxPanel *
+InfoBoxContentSpeedGround::GetDialogContent() noexcept
+{
+  if (!is_simulator())
+    return nullptr;
+
+  return speed_ground_panels;
+}
 
 void
 InfoBoxContentSpeedGround::Update(InfoBoxData &data) noexcept
@@ -38,7 +55,7 @@ InfoBoxContentSpeedGround::Update(InfoBoxData &data) noexcept
 bool
 InfoBoxContentSpeedGround::HandleKey(const InfoBoxKeyCodes keycode) noexcept
 {
-  if (!CommonInterface::Basic().gps.simulator)
+  if (!is_simulator())
     return false;
 
   if (!backend_components || !backend_components->device_blackboard)

--- a/src/InfoBoxes/Content/Speed.hpp
+++ b/src/InfoBoxes/Content/Speed.hpp
@@ -10,6 +10,7 @@ class InfoBoxContentSpeedGround : public InfoBoxContent
 public:
   void Update(InfoBoxData &data) noexcept override;
   bool HandleKey(const InfoBoxKeyCodes keycode) noexcept override;
+  const InfoBoxPanel *GetDialogContent() noexcept override;
 };
 
 void

--- a/src/InfoBoxes/Panel/SpeedSimulator.cpp
+++ b/src/InfoBoxes/Panel/SpeedSimulator.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Simulator.hpp"
+#include "SpeedSimulator.hpp"
+#include "Look/DialogLook.hpp"
+#include "ui/window/ContainerWindow.hpp"
+#include "Form/Button.hpp"
+#include "Math/Angle.hpp"
+#include "Formatter/AngleFormatter.hpp"
+#include "Formatter/UserUnits.hpp"
+#include "Blackboard/DeviceBlackboard.hpp"
+#include "Units/Units.hpp"
+#include "Interface.hpp"
+#include "UIGlobals.hpp"
+#include "Components.hpp"
+#include "BackendComponents.hpp"
+#include "Language/Language.hpp"
+#include "Screen/Layout.hpp"
+#include "Widget/WindowWidget.hpp"
+#include "util/StringFormat.hpp"
+#include "util/TruncateString.hpp"
+
+#include <array>
+#include <algorithm>
+#include <cmath>
+
+#ifdef SIMULATOR_AVAILABLE
+
+struct SpeedSimulatorAction {
+  enum class Type {
+    BEARING,
+    SPEED,
+  } type;
+
+  double step;
+};
+
+static constexpr int DIRECTION_STEP_DEG = 5;
+static constexpr double SPEED_STEP_KMH = 10;
+
+static void
+TriggerSpeedSimulatorAction(const SpeedSimulatorAction action) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  if (!is_simulator() || backend_components == nullptr ||
+      backend_components->device_blackboard == nullptr)
+    return;
+
+  auto &device_blackboard = *backend_components->device_blackboard;
+
+  switch (action.type) {
+  case SpeedSimulatorAction::Type::BEARING:
+    device_blackboard.SetTrack(basic.track + Angle::Degrees(action.step));
+    break;
+
+  case SpeedSimulatorAction::Type::SPEED:
+    device_blackboard.SetSpeed(std::max(basic.ground_speed + action.step, 0.0));
+    break;
+  }
+}
+
+static void
+FormatSpeedSimulatorCaption(const SpeedSimulatorAction action,
+                            char *buffer, size_t size) noexcept
+{
+  const char sign = action.step < 0 ? '-' : '+';
+  const double value = std::abs(action.step);
+  char formatted[128]{};
+
+  switch (action.type) {
+  case SpeedSimulatorAction::Type::BEARING: {
+    const auto degrees = (unsigned)std::lround(value);
+    StringFormat(formatted, sizeof(formatted), "%s %c%s",
+                 _("Brg"), sign, FormatBearing(degrees).c_str());
+    break;
+  }
+
+  case SpeedSimulatorAction::Type::SPEED: {
+    BasicStringBuffer<char, 32> step_buffer;
+    FormatUserSpeed(value, step_buffer.data(), true, false);
+    StringFormat(formatted, sizeof(formatted), "%s %c%s",
+                 _("Spd"), sign, step_buffer.c_str());
+    break;
+  }
+  }
+
+  CopyTruncateString(buffer, size, formatted);
+}
+
+static constexpr std::array<PixelRect, 4>
+LayoutSpeedButtons(const PixelRect &total_rc) noexcept
+{
+  const unsigned total_width = total_rc.GetWidth();
+  PixelRect rc = { 0, total_rc.top, total_rc.left, total_rc.bottom };
+
+  std::array<PixelRect, 4> buttons{};
+  for (unsigned i = 0; i < 4; ++i) {
+    rc.left = rc.right;
+    rc.right = total_rc.left + (i + 1) * total_width / 4;
+    buttons[i] = rc;
+  }
+
+  return buttons;
+}
+
+class SpeedSimulatorWindow final : public ContainerWindow {
+  const DialogLook &look;
+
+  Button direction_minus_button, direction_plus_button;
+  Button speed_minus_button, speed_plus_button;
+
+public:
+  explicit SpeedSimulatorWindow(const DialogLook &_look) noexcept
+    :look(_look) {}
+
+protected:
+  void OnCreate() override;
+  void OnResize(PixelSize new_size) noexcept override;
+
+private:
+  void MoveButtons(const PixelRect &rc) noexcept;
+};
+
+void
+SpeedSimulatorWindow::OnCreate()
+{
+  ContainerWindow::OnCreate();
+
+  WindowStyle style;
+  style.TabStop();
+  style.Hide();
+
+  const SpeedSimulatorAction direction_minus{
+    SpeedSimulatorAction::Type::BEARING, -DIRECTION_STEP_DEG
+  };
+  const SpeedSimulatorAction direction_plus{
+    SpeedSimulatorAction::Type::BEARING, DIRECTION_STEP_DEG
+  };
+  const SpeedSimulatorAction speed_minus{
+    SpeedSimulatorAction::Type::SPEED, -Units::ToSysSpeed(SPEED_STEP_KMH)
+  };
+  const SpeedSimulatorAction speed_plus{
+    SpeedSimulatorAction::Type::SPEED, Units::ToSysSpeed(SPEED_STEP_KMH)
+  };
+
+  char caption[32];
+
+  FormatSpeedSimulatorCaption(direction_minus, caption, sizeof(caption));
+  direction_minus_button.Create(*this, look.button, caption, GetClientRect(), style,
+                                [direction_minus](){
+                                  TriggerSpeedSimulatorAction(direction_minus);
+                                });
+
+  FormatSpeedSimulatorCaption(direction_plus, caption, sizeof(caption));
+  direction_plus_button.Create(*this, look.button, caption, GetClientRect(), style,
+                               [direction_plus](){
+                                 TriggerSpeedSimulatorAction(direction_plus);
+                               });
+
+  FormatSpeedSimulatorCaption(speed_minus, caption, sizeof(caption));
+  speed_minus_button.Create(*this, look.button, caption, GetClientRect(), style,
+                            [speed_minus](){
+                              TriggerSpeedSimulatorAction(speed_minus);
+                            });
+
+  FormatSpeedSimulatorCaption(speed_plus, caption, sizeof(caption));
+  speed_plus_button.Create(*this, look.button, caption, GetClientRect(), style,
+                           [speed_plus](){
+                             TriggerSpeedSimulatorAction(speed_plus);
+                           });
+}
+
+void
+SpeedSimulatorWindow::MoveButtons(const PixelRect &rc) noexcept
+{
+  const auto buttons = LayoutSpeedButtons(rc);
+
+  direction_minus_button.MoveAndShow(buttons[0]);
+  direction_plus_button.MoveAndShow(buttons[1]);
+  speed_minus_button.MoveAndShow(buttons[2]);
+  speed_plus_button.MoveAndShow(buttons[3]);
+}
+
+void
+SpeedSimulatorWindow::OnResize(PixelSize new_size) noexcept
+{
+  ContainerWindow::OnResize(new_size);
+  MoveButtons(GetClientRect());
+}
+
+class SpeedSimulatorWidget final : public WindowWidget {
+  const DialogLook &look;
+
+public:
+  explicit SpeedSimulatorWidget(const DialogLook &_look) noexcept
+    :look(_look) {}
+
+  [[gnu::pure]] PixelSize GetMinimumSize() const noexcept override;
+  [[gnu::pure]] PixelSize GetMaximumSize() const noexcept override;
+
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+};
+
+PixelSize
+SpeedSimulatorWidget::GetMinimumSize() const noexcept
+{
+  char caption[32];
+
+  const SpeedSimulatorAction direction_minus{
+    SpeedSimulatorAction::Type::BEARING, -DIRECTION_STEP_DEG
+  };
+  const SpeedSimulatorAction direction_plus{
+    SpeedSimulatorAction::Type::BEARING, DIRECTION_STEP_DEG
+  };
+  const SpeedSimulatorAction speed_minus{
+    SpeedSimulatorAction::Type::SPEED, -Units::ToSysSpeed(SPEED_STEP_KMH)
+  };
+  const SpeedSimulatorAction speed_plus{
+    SpeedSimulatorAction::Type::SPEED, Units::ToSysSpeed(SPEED_STEP_KMH)
+  };
+
+  FormatSpeedSimulatorCaption(direction_minus, caption, sizeof(caption));
+  const unsigned width1 = look.button.font->TextSize(caption).width;
+  FormatSpeedSimulatorCaption(direction_plus, caption, sizeof(caption));
+  const unsigned width2 = look.button.font->TextSize(caption).width;
+  FormatSpeedSimulatorCaption(speed_minus, caption, sizeof(caption));
+  const unsigned width3 = look.button.font->TextSize(caption).width;
+  FormatSpeedSimulatorCaption(speed_plus, caption, sizeof(caption));
+  const unsigned width4 = look.button.font->TextSize(caption).width;
+
+  const unsigned min_button_width = std::max({ width1, width2, width3, width4 }) +
+    2 * Layout::GetTextPadding();
+  const unsigned min_button_height =
+    std::max(Layout::GetMaximumControlHeight(),
+             look.button.font->GetHeight() + 2 * Layout::GetTextPadding());
+
+  return {
+    4 * min_button_width,
+    min_button_height,
+  };
+}
+
+PixelSize
+SpeedSimulatorWidget::GetMaximumSize() const noexcept
+{
+  return GetMinimumSize();
+}
+
+void
+SpeedSimulatorWidget::Prepare(ContainerWindow &parent,
+                              const PixelRect &rc) noexcept
+{
+  auto window = std::make_unique<SpeedSimulatorWindow>(look);
+  WindowStyle style;
+  style.ControlParent();
+  style.Hide();
+  window->Create(parent, rc, style);
+  SetWindow(std::move(window));
+}
+
+#endif
+
+std::unique_ptr<Widget>
+LoadSpeedSimulatorPanel([[maybe_unused]] unsigned id)
+{
+#ifdef SIMULATOR_AVAILABLE
+  return std::make_unique<SpeedSimulatorWidget>(UIGlobals::GetDialogLook());
+#else
+  return nullptr;
+#endif
+}

--- a/src/InfoBoxes/Panel/SpeedSimulator.hpp
+++ b/src/InfoBoxes/Panel/SpeedSimulator.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+LoadSpeedSimulatorPanel(unsigned id);

--- a/src/Pan.cpp
+++ b/src/Pan.cpp
@@ -2,11 +2,16 @@
 // Copyright The XCSoar Project
 
 #include "Pan.hpp"
+#include "Simulator.hpp"
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
+#include "Blackboard/DeviceBlackboard.hpp"
+#include "MainWindow.hpp"
 #include "Interface.hpp"
 #include "PageActions.hpp"
 #include "Input/InputEvents.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
 
 #include <cassert>
 
@@ -62,6 +67,28 @@ PanTo(const GeoPoint &location)
   InputEvents::setMode(InputEvents::MODE_DEFAULT);
   InputEvents::UpdatePan();
   return true;
+}
+
+bool
+SimJumpTo(const GeoPoint &location)
+{
+#ifdef SIMULATOR_AVAILABLE
+  assert(CommonInterface::main_window != nullptr);
+
+  if (!is_simulator() || backend_components == nullptr ||
+      backend_components->device_blackboard == nullptr)
+    return false;
+
+  backend_components->device_blackboard->SetSimulatorLocation(location);
+
+  if (CommonInterface::main_window != nullptr)
+    CommonInterface::main_window->FullRedraw();
+
+  return true;
+#else
+  (void)location;
+  return false;
+#endif
 }
 
 void

--- a/src/Pan.hpp
+++ b/src/Pan.hpp
@@ -15,6 +15,9 @@ EnterPan();
 bool
 PanTo(const GeoPoint &location);
 
+bool
+SimJumpTo(const GeoPoint &location);
+
 /**
  * Low-level version of LeavePan().  It disables panning in the map
  * and updates the input mode, but does not restore the page layout.


### PR DESCRIPTION
I've been using XCSoar for many years, but even so I never quite managed to become friendly with sim mode. This seems like an extremely useful way to practice using xcsoar, but I never quite understood how to jump or steer (I eventually figured out the drag-on-the-plane trick). This PR aims to make it a lot more obvious how to use sim mode, and also add some quality-of-life improvements with the ability to more easily jump anywhere.

Fly mode is largely unaffected (except for 1 help text), all the UI elements etc only appear in sim mode.

---
Commit message:

* Explain how to jump, set altitude and speed, in initial popup, welcome screen and getting started guide.
<img width="659" height="517" alt="image" src="https://github.com/user-attachments/assets/20dc74c7-0084-4d06-8596-d801003fa31b" />

* Add "Jump to" button in most places where a "goto" button exists, such as when viewing a waypoint or a clicking on a point in the map. Only appears while in Sim mode

<img width="633" height="506" alt="image" src="https://github.com/user-attachments/assets/c4e753a7-ff13-4a52-b8d5-9baa4b2154c7" />

<img width="642" height="509" alt="image" src="https://github.com/user-attachments/assets/ca784b72-d1da-4e69-bf34-8df9bb41cff9" />

* Added buttons for speed and bearing adjust to the Speed infobox, similar to how that already existed for Altitude. This only opens in sim mode. 
<img width="631" height="505" alt="image" src="https://github.com/user-attachments/assets/3a4e6a89-91ae-4542-a5bd-77978c3d0c70" />

<img width="664" height="511" alt="image" src="https://github.com/user-attachments/assets/f7d901ee-d230-4f49-ac92-c6b106872eb6" />

* Better labelling of "Set as home" in sim mode.

----

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Sim: Jump to” actions for selected waypoints and map locations when simulator mode is active.
  * Added a Speed Ground simulator panel with bearing and ground-speed adjustment controls.
  * Updated the waypoint home action label to “Set as Startup Location” in simulator mode.
  * Added startup and Quick Guide guidance for steering the simulator using InfoBoxes or glider dragging.
* **Improvements**
  * Refined simulator-specific Quick Guide permissions and disclosures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->