### PR TITLE
Computer/TraceComputer: Cap Full trail store on slow CPUs (#2661)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -209,6 +209,9 @@ Version 7.45 - not yet released
 * map
   - fix black terrain after idle high-resolution sharpening on OpenGL
     devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
+  - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi
+    1–3 / 3B+, Cubieboard-class), keep the Full snail trail store at 1024
+    points (7.44 size) instead of the larger fast-host capacity #2661
   - dynamically adjust contour line density to zoom factor #2233
   - provide different contour density profile settings for mountains,
     low lands, etc. to have sensible contours in a given landscape type

--- a/build/test.mk
+++ b/build/test.mk
@@ -127,6 +127,7 @@ TEST_NAMES = \
 	TestThermalBand \
 	TestPackedFloat \
 	TestVersionNumber \
+	TestSlowCPU \
 	TestWeglideScoring \
 	TestNetCoupeScoring \
 	TestDMStScoring
@@ -2866,6 +2867,11 @@ TEST_VERSION_NUMBER_SOURCES = \
 	$(TEST_SRC_DIR)/TestVersionNumber.cpp
 TEST_VERSION_NUMBER_DEPENDS = MATH UTIL
 $(eval $(call link-program,TestVersionNumber,TEST_VERSION_NUMBER))
+
+TEST_SLOW_CPU_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestSlowCPU.cpp
+$(eval $(call link-program,TestSlowCPU,TEST_SLOW_CPU))
 
 TEST_HTTPS_VERIFY_SOURCES = \
 	$(SRC)/net/SocketError.cxx \

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -21,6 +21,18 @@ static constexpr float MERGE_VARIO_DEDUPE_EPS = 0.05f;
 /** Near-zero band: always keep samples for Nullschieber colouring. */
 static constexpr float MERGE_VARIO_NULL_BAND = 0.05f;
 
+/**
+ * Default for harness / tools that link TraceComputer without
+ * Hardware/CPU.cpp. The strong definition in CPU.cpp overrides this
+ * in the main binary.
+ */
+[[gnu::weak]]
+bool
+IsSlowCPU() noexcept
+{
+  return false;
+}
+
 [[gnu::const]]
 static bool
 MergeVarioSampleWorthKeeping(float prev, float next) noexcept

--- a/src/Computer/TraceComputer.cpp
+++ b/src/Computer/TraceComputer.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "TraceComputer.hpp"
+#include "Hardware/CPU.hpp"
 #include "Settings.hpp"
 #include "NMEA/MoreData.hpp"
 #include "NMEA/Derived.hpp"
@@ -49,8 +50,16 @@ PushMergeVarioDeduped(std::vector<TrailVarioSample> &dest,
   dest.push_back(sample);
 }
 
+static unsigned
+FullTraceMaxPoints() noexcept
+{
+  return IsSlowCPU()
+    ? TraceComputer::FULL_TRACE_MAX_POINTS_SLOW
+    : TraceComputer::FULL_TRACE_MAX_POINTS;
+}
+
 TraceComputer::TraceComputer()
- :full(full_trace_no_thin_time, Trace::null_time, FULL_TRACE_MAX_POINTS),
+ :full(full_trace_no_thin_time, Trace::null_time, FullTraceMaxPoints()),
   contest({}, Trace::null_time, contest_trace_size),
   sprint({}, std::chrono::minutes{120}, sprint_trace_size)
 {
@@ -91,7 +100,7 @@ TraceComputer::ArchiveMergeVarioForLegUnlocked(TracePoint::Time t0,
     PushMergeVarioDeduped(merge_vario_archive, s);
   }
 
-  const size_t max_archive_size = FULL_TRACE_MAX_POINTS;
+  const size_t max_archive_size = full.GetMaxSize();
   if (merge_vario_archive.size() > max_archive_size) {
     const size_t excess = merge_vario_archive.size() - max_archive_size;
     merge_vario_archive.erase(merge_vario_archive.begin(),

--- a/src/Computer/TraceComputer.hpp
+++ b/src/Computer/TraceComputer.hpp
@@ -36,12 +36,19 @@ struct TrailQuery {
  * Record a trace of the current flight.
  */
 class TraceComputer {
+public:
   /**
-   * Full snail-trail capacity: ~14 h at \a Trace::push_back minimum spacing
-   * (2 s between stored fixes).
+   * Full snail-trail capacity on fast hosts: ~14 h at
+   * \a Trace::push_back minimum spacing (2 s between stored fixes).
    */
   static constexpr unsigned FULL_TRACE_MAX_POINTS = 25200;
 
+  /**
+   * Full snail-trail capacity on slow hosts (≤ 1.4 GHz): v7.44 size.
+   */
+  static constexpr unsigned FULL_TRACE_MAX_POINTS_SLOW = 1024;
+
+private:
   /**
    * Capacity for #merge_vario_samples (must match ring template size).
    */

--- a/src/Hardware/CPU.cpp
+++ b/src/Hardware/CPU.cpp
@@ -44,8 +44,9 @@ ReadMaxCPUFrequencyKHz() noexcept
 {
 #ifdef __linux__
   char buffer[64];
-  if (!File::ReadString(Path("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"),
-                        buffer, sizeof(buffer)))
+  if (!File::ReadString(
+        Path("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"),
+        buffer, sizeof(buffer)))
     return 0;
 
   StripRight(buffer);

--- a/src/Hardware/CPU.cpp
+++ b/src/Hardware/CPU.cpp
@@ -2,12 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "CPU.hpp"
-
-#ifdef HAVE_CPU_FREQUENCY
-
 #include "system/FileUtil.hpp"
+#include "util/NumberParser.hpp"
+#include "util/StringStrip.hxx"
 
 #include <atomic>
+
+#ifdef HAVE_CPU_FREQUENCY
 
 static bool
 SetCPUFrequencyGovernor(const char *governor) noexcept
@@ -37,3 +38,38 @@ UnlockCPU() noexcept
 }
 
 #endif /* HAVE_CPU_FREQUENCY */
+
+static unsigned
+ReadMaxCPUFrequencyKHz() noexcept
+{
+#ifdef __linux__
+  char buffer[64];
+  if (!File::ReadString(Path("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"),
+                        buffer, sizeof(buffer)))
+    return 0;
+
+  StripRight(buffer);
+
+  char *endptr;
+  const unsigned value = ParseUnsigned(buffer, &endptr, 10);
+  if (endptr == buffer || *endptr != '\0' || value == 0)
+    return 0;
+
+  return value;
+#else
+  return 0;
+#endif
+}
+
+unsigned
+GetMaxCPUFrequencyKHz() noexcept
+{
+  static const unsigned cached = ReadMaxCPUFrequencyKHz();
+  return cached;
+}
+
+bool
+IsSlowCPU() noexcept
+{
+  return IsSlowCPUFrequency(GetMaxCPUFrequencyKHz());
+}

--- a/src/Hardware/CPU.hpp
+++ b/src/Hardware/CPU.hpp
@@ -54,7 +54,6 @@ IsSlowCPUFrequency(unsigned max_freq_khz) noexcept
  * Maximum CPU frequency in kHz from the OS, or 0 if unknown.
  * Cached after the first successful read on Linux.
  */
-[[gnu::pure]]
 unsigned
 GetMaxCPUFrequencyKHz() noexcept;
 
@@ -62,6 +61,5 @@ GetMaxCPUFrequencyKHz() noexcept;
  * True when the host max CPU frequency is known and ≤ 1.4 GHz
  * (typical Kobo, Raspberry Pi 1–3 / 3B+, Cubieboard-class boards).
  */
-[[gnu::pure]]
 bool
 IsSlowCPU() noexcept;

--- a/src/Hardware/CPU.hpp
+++ b/src/Hardware/CPU.hpp
@@ -33,3 +33,35 @@ struct ScopeLockCPU {
 #else
 #endif
 };
+
+/**
+ * Max CPU frequency threshold for #IsSlowCPUFrequency / #IsSlowCPU
+ * (1.4 GHz in kHz).
+ */
+static constexpr unsigned SLOW_CPU_MAX_FREQ_KHZ = 1400000;
+
+/**
+ * True if \a max_freq_khz is known and at most #SLOW_CPU_MAX_FREQ_KHZ.
+ */
+[[gnu::const]]
+constexpr bool
+IsSlowCPUFrequency(unsigned max_freq_khz) noexcept
+{
+  return max_freq_khz != 0 && max_freq_khz <= SLOW_CPU_MAX_FREQ_KHZ;
+}
+
+/**
+ * Maximum CPU frequency in kHz from the OS, or 0 if unknown.
+ * Cached after the first successful read on Linux.
+ */
+[[gnu::pure]]
+unsigned
+GetMaxCPUFrequencyKHz() noexcept;
+
+/**
+ * True when the host max CPU frequency is known and ≤ 1.4 GHz
+ * (typical Kobo, Raspberry Pi 1–3 / 3B+, Cubieboard-class boards).
+ */
+[[gnu::pure]]
+bool
+IsSlowCPU() noexcept;

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -13,6 +13,7 @@
 #include "Profile/Current.hpp"
 #include "Profile/Settings.hpp"
 #include "Asset.hpp"
+#include "Hardware/CPU.hpp"
 #include "Simulator.hpp"
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "Terrain/RasterTerrain.hpp"
@@ -444,6 +445,13 @@ Startup(UI::Display &display)
             HasEPaper() ? "yes" : "no");
   LogFormat("Device capabilities: IsDithered()=%s",
             IsDithered() ? "yes" : "no");
+  if (const unsigned max_cpu_khz = GetMaxCPUFrequencyKHz();
+      max_cpu_khz != 0)
+    LogFormat("Device capabilities: max_cpu_freq=%u kHz", max_cpu_khz);
+  else
+    LogFormat("Device capabilities: max_cpu_freq=unknown");
+  LogFormat("Device capabilities: IsSlowCPU()=%s",
+            IsSlowCPU() ? "yes" : "no");
 
   main_window->InitialiseConfigured();
 

--- a/test/src/TestSlowCPU.cpp
+++ b/test/src/TestSlowCPU.cpp
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Hardware/CPU.hpp"
+#include "TestUtil.hpp"
+
+int main()
+{
+  plan_tests(5);
+
+  ok1(!IsSlowCPUFrequency(0));
+  ok1(IsSlowCPUFrequency(1000000));
+  ok1(IsSlowCPUFrequency(SLOW_CPU_MAX_FREQ_KHZ));
+  ok1(!IsSlowCPUFrequency(SLOW_CPU_MAX_FREQ_KHZ + 1));
+  ok1(!IsSlowCPUFrequency(1500000));
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- Detect slow hosts via Linux `cpuinfo_max_freq` (`IsSlowCPU()` when ≤ 1.4 GHz), including Kobo / Pi / Cubie-class boards when cpufreq is present.
- On slow hosts, keep Full snail-trail capacity at **1024** points (7.44 behaviour) instead of **25200**; fast hosts unchanged.
- Log max CPU frequency and `IsSlowCPU()` at startup; add `TestSlowCPU` for the threshold helper.

Verified on a Raspberry Pi 3 (`max_cpu_freq=1200000 kHz`, `IsSlowCPU()=yes`).

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y` and `output/UNIX/bin/TestSlowCPU`
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/bin/test_replay_olc` (links `Hardware/CPU`)
- [ ] On a ≤1.4 GHz Linux board: confirm startup log shows `IsSlowCPU()=yes` and Full trail stays usable
- [ ] On a desktop / Pi 4+: `IsSlowCPU()=no` and Full trail retains the large store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Snail-trail storage now adapts to device performance, using a smaller capacity on slower hosts to help maintain responsiveness.
  - Startup diagnostics now report the detected maximum CPU frequency and whether the device is classified as slow.

- **Bug Fixes**
  - Archived snail-trail data now follows the active capacity limit, ensuring consistent storage behavior across hardware.

- **Tests**
  - Added coverage for CPU-speed classification, including threshold and boundary values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->