### PR TITLE
Fix GDI bad_function_call and BufferCanvas::Create(PixelSize)

### DIFF
--- a/src/ui/canvas/gdi/BufferCanvas.cpp
+++ b/src/ui/canvas/gdi/BufferCanvas.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "ui/canvas/BufferCanvas.hpp"
+#include "ui/canvas/gdi/RootDC.hpp"
 
 #include <cassert>
 
@@ -15,6 +16,23 @@ BufferCanvas::BufferCanvas(const Canvas &canvas, PixelSize new_size) noexcept
 BufferCanvas::~BufferCanvas() noexcept
 {
   Destroy();
+}
+
+void
+BufferCanvas::Create(PixelSize new_size) noexcept
+{
+  /* CreateCompatibleBitmap() needs a colour-compatible DC; a bare
+     CreateCompatibleDC(nullptr) would yield a monochrome bitmap. */
+  RootDC root_dc;
+  HDC hdc = root_dc;
+  assert(hdc != nullptr);
+  if (hdc == nullptr) {
+    Destroy();
+    return;
+  }
+
+  Canvas screen(hdc, new_size);
+  Create(screen, new_size);
 }
 
 void

--- a/src/ui/canvas/gdi/BufferCanvas.hpp
+++ b/src/ui/canvas/gdi/BufferCanvas.hpp
@@ -18,6 +18,12 @@ public:
   BufferCanvas(const Canvas &canvas, PixelSize new_size) noexcept;
   ~BufferCanvas() noexcept;
 
+  /**
+   * Create an off-screen buffer with the screen pixel format.
+   * Matches OpenGL / memory-canvas BufferCanvas::Create(PixelSize).
+   */
+  void Create(PixelSize new_size) noexcept;
+
   void Create(const Canvas &canvas, PixelSize new_size) noexcept;
   void Create(const Canvas &canvas) noexcept;
   void Destroy() noexcept;

--- a/src/ui/event/CoInjectFunction.hpp
+++ b/src/ui/event/CoInjectFunction.hpp
@@ -27,10 +27,12 @@ class CoInjectFunction final {
   std::function<void(std::exception_ptr)> on_error;
 
   Notify notify{[this]{
-    if (error)
-      on_error(std::move(error));
-    else
+    if (error) {
+      if (on_error)
+        on_error(std::move(error));
+    } else if (on_success) {
       on_success(std::move(value).Get());
+    }
   }};
 
 public:

--- a/src/ui/event/DelayedNotify.hpp
+++ b/src/ui/event/DelayedNotify.hpp
@@ -13,13 +13,15 @@ namespace UI {
  * with a certain delay, to limit the rate of redundant notifications.
  */
 class DelayedNotify final {
+  using Callback = std::function<void()>;
+
+  /* delay/callback must outlive timer/notify: destruction is reverse
+     declaration order, and a pending Notify/Timer may still run. */
+  const std::chrono::steady_clock::duration delay;
+  const Callback callback;
+
   Timer timer{[this]{ callback(); }};
   Notify notify{[this]{ timer.SchedulePreserve(delay); }};
-
-  const std::chrono::steady_clock::duration delay;
-
-  using Callback = std::function<void()>;
-  const Callback callback;
 
 public:
   explicit DelayedNotify(std::chrono::steady_clock::duration _delay,

--- a/src/ui/event/Notify.cpp
+++ b/src/ui/event/Notify.cpp
@@ -33,17 +33,22 @@ Notify::SendNotification() noexcept
 void
 Notify::ClearNotification() noexcept
 {
-  if (!pending.exchange(false, std::memory_order_relaxed))
-    return;
-
+  /* Always purge first.  Gating on pending races with SendNotification
+     (pending cleared before InjectCall), which left dangling InjectCall
+     entries on the GDI EventQueue after #2663. */
   if (event_queue != nullptr)
     event_queue->Purge(Callback, this);
+
+  pending.store(false, std::memory_order_relaxed);
 }
 
 void
 Notify::RunNotification() noexcept
 {
-  if (pending.exchange(false, std::memory_order_relaxed))
+  if (!pending.exchange(false, std::memory_order_relaxed))
+    return;
+
+  if (callback)
     callback();
 }
 


### PR DESCRIPTION
## Summary
- Fix `std::bad_function_call` abort on GDI/Windows (Wine-reproduced during replay): `DelayedNotify` destroyed `callback` before `Timer`/`Notify`, so a pending delivery could invoke an empty `std::function`. Also always `Purge` on `ClearNotification` (GDI `InjectCall` race after #2663) and guard empty `CoInjectFunction` handlers.
- Add GDI `BufferCanvas::Create(PixelSize)` via `RootDC` so `RunTrailRendererStress` builds for PC/WIN64 (API parity with OpenGL/memory canvas).

## Test plan
- [ ] `make -j$(nproc) TARGET=WIN64 USE_CCACHE=y` (and/or `TARGET=PC`) — includes `RunTrailRendererStress`
- [ ] Wine/Windows: start XCSoar, run IGC/NMEA replay with trail scaled on — no `bad_function_call` / exit code 3
- [ ] Confirm map redraw and progress notifications still work (terrain load, downloads)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating off-screen drawing buffers using the system’s screen pixel format.

- **Bug Fixes**
  - Prevented missing completion handlers from being invoked unexpectedly.
  - Improved delayed notification cleanup to avoid callbacks running after they are cleared.
  - Fixed notification queue handling to prevent stale or duplicate notifications during rapid updates.

- **Reliability**
  - Improved stability for drawing, asynchronous events, and notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->