### PR TITLE
Gauge/FlarmTrafficWindow: Fix leaked side vario labels

### DIFF
--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -503,7 +503,10 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
     canvas.DrawText(ts, traffic.name);
   }
 
-  StaticString<10> side_text;
+  // Value-initialize: an uninitialized StaticString keeps prior stack
+  // contents, so a target without side data would reuse the previous
+  // target's vario/altitude label (#2731).
+  StaticString<10> side_text{};
 
   if (side_display_type == SideInfoType::VARIO) {
     if (traffic.climb_rate_avg30s_available &&


### PR DESCRIPTION
## Summary
- Value-initialize the FLARM radar side-label `StaticString` so targets without vario/altitude side data do not reuse the previous target's label from leftover stack contents.
- Fixes identical side vario on ground/non-climbing targets after #2100 (post-v7.44).

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y`
- [ ] Replay `FLARM_Traffic_Testcase_1.nmea` from #2718 / #2731
- [ ] Open FLARM radar in vario side mode: ground target `54` must not show another aircraft's `+5.x` side vario
- [ ] Climbing gliders still show their own side vario; selected target still omits duplicate side label (#2718)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed radar traffic displays so targets without side information no longer show stale labels from previously displayed targets.
  * Improved display reliability when rendering target vario or altitude information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->