### PR TITLE
Fix iOS internal sensor reconnect status

### DIFF
--- a/src/Apple/InternalSensors.cpp
+++ b/src/Apple/InternalSensors.cpp
@@ -8,6 +8,7 @@
 #include "Geo/GeoPoint.hpp"
 #include "time/FloatDuration.hxx"
 #include "time/SystemClock.hxx"
+#include "LogFile.hpp"
 
 #include <TargetConditionals.h>
 
@@ -108,6 +109,9 @@
 - (void)locationManager:(CLLocationManager *)manager
     didFailWithError:(NSError *)error
 {
+  LogFmt("CoreLocation failed: domain={} code={} description={}",
+         [[error domain] UTF8String], [error code],
+         [[error localizedDescription] UTF8String]);
   self->listener->OnConnected(0);
 }
 

--- a/src/Apple/InternalSensors.cpp
+++ b/src/Apple/InternalSensors.cpp
@@ -6,6 +6,7 @@
 #include "Apple/InternalSensors.hpp"
 #include "Device/SensorListener.hpp"
 #include "Geo/GeoPoint.hpp"
+#include "Language/Language.hpp"
 #include "time/FloatDuration.hxx"
 #include "time/SystemClock.hxx"
 #include "LogFile.hpp"
@@ -113,6 +114,9 @@
          [[error domain] UTF8String], [error code],
          [[error localizedDescription] UTF8String]);
   self->listener->OnConnected(0);
+
+  if ([error code] == kCLErrorDenied)
+    self->listener->OnSensorError(_("Location access denied"));
 }
 
 #if TARGET_OS_IPHONE

--- a/src/Device/AndroidSensors.cpp
+++ b/src/Device/AndroidSensors.cpp
@@ -374,10 +374,4 @@ DeviceDescriptor::OnSensorStateChanged() noexcept
   PortStateChanged();
 }
 
-void
-DeviceDescriptor::OnSensorError(const char *msg) noexcept
-{
-  PortError(msg);
-}
-
 #endif

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -112,7 +112,7 @@ DeviceDescriptor::GetState() const noexcept
   if (has_failed)
     return PortState::FAILED;
 
-  if (open_job != nullptr)
+  if (open_job != nullptr || waiting_to_call_open)
     return PortState::LIMBO;
 
   if (port != nullptr)
@@ -124,6 +124,12 @@ DeviceDescriptor::GetState() const noexcept
 
   if (internal_sensors != nullptr)
     return internal_sensors->GetState(Java::GetEnv());
+#elif defined(__APPLE__)
+  /* Like Android internal sensors, this does not use a Port.  The
+     Apple wrapper has no state API; successful construction means it
+     is ready. */
+  if (internal_sensors != nullptr)
+    return PortState::READY;
 #endif
 
   return PortState::FAILED;

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -679,8 +679,9 @@ private:
   void OnTemperature(Temperature temperature) noexcept override;
   void OnBatteryPercent(double battery_percent) noexcept override;
   void OnSensorStateChanged() noexcept override;
-  void OnSensorError(const char *msg) noexcept override;
 #endif // ANDROID
+
+  void OnSensorError(const char *msg) noexcept override;
 
   void OnBarometricPressureSensor(float pressure,
                                   float sensor_noise_variance) noexcept override;

--- a/src/Device/SensorListener.hpp
+++ b/src/Device/SensorListener.hpp
@@ -74,8 +74,10 @@ public:
   virtual void OnBatteryPercent(double battery_percent) noexcept = 0;
 
   virtual void OnSensorStateChanged() noexcept = 0;
-  virtual void OnSensorError(const char *msg) noexcept = 0;
 #endif // ANDROID
+
+  virtual void OnSensorError(const char *msg) noexcept = 0;
+
   virtual void OnBarometricPressureSensor(float pressure,
                       float sensor_noise_variance) noexcept = 0;
 };

--- a/src/Device/SmartDeviceSensors.cpp
+++ b/src/Device/SmartDeviceSensors.cpp
@@ -38,6 +38,15 @@ DeviceDescriptor::OnConnected(int connected) noexcept
 }
 
 void
+DeviceDescriptor::OnSensorError(const char *msg) noexcept
+{
+  if (msg == nullptr || *msg == '\0')
+    return;
+
+  PortError(msg);
+}
+
+void
 DeviceDescriptor::OnLocationSensor(std::chrono::system_clock::time_point time,
                                    int n_satellites,
                                    GeoPoint location,


### PR DESCRIPTION
Fixes https://github.com/XCSoar/XCSoar/issues/2626.

## Summary

The iOS built-in GPS continued to provide valid fixes, but the Devices page
could briefly show `Error` while reconnecting.  Apple internal sensors do not
use a `Port`, and `DeviceDescriptor::GetState()` only recognized the
equivalent Android sensor object.  The Apple sensor therefore fell through to
`PortState::FAILED` after opening.  The intentional delayed-reopen interval
also fell through to the same state.

This change:

- reports the delayed-reopen interval as `PortState::LIMBO`;
- reports a successfully constructed Apple internal sensor as ready;
- logs the CoreLocation error domain, code, and description;
- reports denied location access through the existing device-error path; and
- keeps transient CoreLocation failures in the no-data state.

The sensor-error callback is moved from the Android-only implementation to
the shared smart-device sensor implementation so Apple can reuse the same
error-reporting path.

## Testing

- `make -j8 TARGET=IOS64 ipa`;
- `./darwin/sign.sh && ./darwin/install.sh`;
- signed, installed, and launched the resulting IPA on a physical iOS device;
- confirmed that the built-in sensor supplies valid GPS fixes;
- confirmed that barometric data appears when Motion & Fitness access is
  granted; and
- confirmed that denied location access produces `kCLErrorDomain` code `1`.

The final branch was rebuilt after rebasing onto current `master`.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase

- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages

- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure

- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified sensor error reporting across supported platforms.
  * Apple now surfaces a localized “location access denied” sensor error when permission is denied.
  * Apple internal sensors are now reported as ready when applicable.

* **Bug Fixes**
  * Device state now remains in a pending/LIMBO status during delayed reopen scheduling.
  * Improved handling of sensor connection failures, including better error reporting to the listener.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->