### PR TITLE
Keyboard and remote UX: focus, menus, and soft keyboard

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -91,7 +91,8 @@ type=key
 data=RETURN
 event=Traffic details
 
-# Traffic radar: F2/F3 zoom in/out, UP/DOWN and F1/F4 = next/prev target
+# Traffic radar: F1 = AVG/ALT side labels; F2/F3 = zoom;
+# UP/DOWN and F4 = next/prev target
 mode=default.Traffic Display1.Traffic Display2.Traffic
 type=key
 data=UP
@@ -105,7 +106,7 @@ event=Traffic previous
 mode=default.Traffic Display1.Traffic Display2.Traffic
 type=key
 data=F1
-event=Traffic previous
+event=Traffic label toggle
 
 mode=default.Traffic Display1.Traffic Display2.Traffic
 type=key
@@ -829,6 +830,14 @@ event=AirSpace toggle
 label=Airspace\n$(AirspaceToggleActionName)
 location=9
 
+mode=Display2
+type=key
+data=5
+event=AirspaceLabels show
+event=AirspaceLabels toggle
+label=Airspace Labels\n$(AirspaceLabelsToggleActionName)$(CheckAirspace)
+location=4
+
 # -------------
 # mode=Config1
 # -------------
@@ -1391,20 +1400,28 @@ event=TerrainTopography topography toggle
 label=Topo.\n$(TopographyToggleActionName)
 location=10
 
+mode=RemoteStick
+type=key
+data=0
+event=AirspaceLabels show
+event=AirspaceLabels toggle
+label=Airspace Labels\n$(AirspaceLabelsToggleActionName)$(CheckAirspace)
+location=11
+
 # Priority 2: Task management (inner ring)
 mode=RemoteStick
 type=key
 data=0
 event=AdjustWaypoint previousarm
 label=$(WaypointPreviousArm)
-location=11
+location=12
 
 mode=RemoteStick
 type=key
 data=0
 event=AdjustWaypoint nextarm
 label=$(WaypointNextArm)
-location=12
+location=13
 
 mode=RemoteStick
 type=key
@@ -1412,7 +1429,7 @@ data=0
 event=Calculator
 event=Mode default
 label=Task
-location=13
+location=14
 
 mode=RemoteStick
 type=key
@@ -1420,7 +1437,7 @@ data=0
 event=Mode default
 event=AbortTask toggle
 label=Task\n$(TaskAbortToggleActionName)$(CheckWaypointFile)
-location=14
+location=15
 
 mode=RemoteStick
 type=key
@@ -1430,7 +1447,7 @@ event=StatusMessage Pilot event announced
 event=Logger note PEV
 event=PilotEvent
 label=Pilot Event Announce
-location=15
+location=16
 
 # Priority 1: Most important in-flight buttons (CENTER AREA)
 mode=RemoteStick
@@ -1439,7 +1456,7 @@ data=0
 event=Checklist
 event=Mode default
 label=Checklist
-location=16
+location=17
 
 mode=RemoteStick
 type=key
@@ -1447,28 +1464,28 @@ data=0
 event=Setup Target
 event=Mode default
 label=Target Show$(CheckTask)$(CheckTaskResumed)
-location=17
+location=18
 
 mode=RemoteStick
 type=key
 data=0
 event=Mode mc
 label=MacCready
-location=18
+location=19
 
 mode=RemoteStick
 type=key
 data=0
 event=AirSpace toggle
 label=Airspace\n$(AirspaceToggleActionName)
-location=19
+location=20
 
 mode=RemoteStick
 type=key
 data=0
 event=Pan on
 label=Pan Mode
-location=20
+location=21
 
 mode=RemoteStick
 type=key
@@ -1476,7 +1493,7 @@ data=0
 event=WaypointDetails select
 event=Mode default
 label=Waypoint List$(CheckWaypointFile)
-location=21
+location=22
 
 mode=RemoteStick
 type=key
@@ -1484,7 +1501,7 @@ data=0
 event=Setup Alternates
 event=Mode default
 label=Alternates$(CheckWaypointFile)
-location=22
+location=23
 
 mode=RemoteStick
 type=key
@@ -1492,7 +1509,7 @@ data=0
 event=AirspaceWarnings
 event=Mode default
 label=Airspace Warnings
-location=23
+location=24
 
 mode=RemoteStick
 type=key
@@ -1500,7 +1517,7 @@ data=0
 event=NearestAirspaceDetails
 event=Mode default
 label=Nearest Airspace$(CheckAirspace)
-location=24
+location=25
 
 # Priority 2: Task management continued (inner ring)
 mode=RemoteStick
@@ -1509,7 +1526,7 @@ data=0
 event=Weather
 event=Mode default
 label=Weather Setup
-location=25
+location=26
 
 mode=RemoteStick
 type=key
@@ -1517,14 +1534,14 @@ data=0
 event=GotoLookup
 event=Mode default
 label=GoTo$(CheckWaypointFile)
-location=26
+location=27
 
 mode=RemoteStick
 type=key
 data=0
 event=FlarmTraffic
 label=FLARM Radar$(CheckFLARM)
-location=27
+location=28
 
 mode=RemoteStick
 type=key
@@ -1534,7 +1551,7 @@ event=StatusMessage Dropped marker
 event=Logger note Mark
 event=MarkLocation
 label=Marker Drop
-location=28
+location=29
 
 mode=RemoteStick
 type=key
@@ -1542,7 +1559,7 @@ data=0
 event=Zoom auto show
 event=Zoom auto toggle
 label=Zoom\n$(ZoomAutoToggleActionName)
-location=29
+location=30
 
 # Analysis and info screens (outer ring)
 mode=RemoteStick
@@ -1551,7 +1568,7 @@ data=0
 event=Analysis
 event=Mode default
 label=Analysis
-location=30
+location=31
 
 mode=RemoteStick
 type=key
@@ -1559,7 +1576,15 @@ data=0
 event=Status all
 event=Mode default
 label=Status
-location=31
+location=32
+
+mode=RemoteStick
+type=key
+data=0
+event=QuickGuide
+event=Mode default
+label=Quick Guide
+location=33
 
 mode=RemoteStick
 type=key
@@ -1567,7 +1592,7 @@ data=0
 event=ThermalAssistant
 event=Mode default
 label=Thermal Assistant$(CheckCircling)
-location=32
+location=34
 
 mode=RemoteStick
 type=key
@@ -1575,7 +1600,7 @@ data=0
 event=AirSpace list
 event=Mode default
 label=Airspaces
-location=33
+location=35
 
 # Low priority: System functions (far from center)
 mode=RemoteStick
@@ -1584,14 +1609,22 @@ data=0
 event=Logger show
 event=Logger toggle ask
 label=Logger\n$(LoggerActive)$(CheckLogger)
-location=34
+location=36
 
 mode=RemoteStick
 type=key
 data=0
 event=Logger nmea
 label=NMEA Logger$(CheckLogger)
-location=35
+location=37
+
+mode=RemoteStick
+type=key
+data=0
+event=Setup Replay
+event=Mode default
+label=Replay$(CheckReplay)
+location=38
 
 mode=RemoteStick
 type=key
@@ -1599,7 +1632,7 @@ data=0
 event=Device list
 event=Mode default
 label=Devices
-location=36
+location=39
 
 mode=RemoteStick
 type=key
@@ -1607,14 +1640,14 @@ data=0
 event=DataManagement
 event=Mode default
 label=Data Management
-location=37
+location=40
 
 mode=RemoteStick
 type=key
 data=0
 event=RepeatStatusMessage
 label=Message Repeat
-location=38
+location=41
 
 mode=RemoteStick
 type=key
@@ -1622,7 +1655,7 @@ data=0
 event=DistanceRings show
 event=DistanceRings toggle
 label=Dist. Rings\n$(DistanceRingsToggleActionName)
-location=39
+location=42
 
 mode=RemoteStick
 type=key
@@ -1630,21 +1663,21 @@ data=0
 event=UploadIGCFile
 event=Mode default
 label=WeGlide Upload$(CheckWeGlide)
-location=40
+location=43
 
 mode=RemoteStick
 type=key
 data=0
 event=Exit
 label=Quit XCSoar
-location=41
+location=44
 
 mode=RemoteStick
 type=key
 data=0
 event=Mode weather
 label=Forecast\nControls
-location=42
+location=45
 
 # -------------
 # Define gesture to open Quickmenu without keyboard or remote

--- a/Data/resources.txt
+++ b/Data/resources.txt
@@ -163,7 +163,9 @@ bitmap_graphic IDB_TITLE "title_red_110"
 bitmap_graphic IDB_TITLE_HD "title_red_320"
 bitmap_graphic IDB_TITLE_UHD "title_red_640"
 #ifndef USE_WIN32_RESOURCES
+bitmap_graphic IDB_TITLE_RGBA "title_red_110_rgba"
 bitmap_graphic IDB_TITLE_HD_RGBA "title_red_320_rgba"
+bitmap_graphic IDB_TITLE_UHD_RGBA "title_red_640_rgba"
 bitmap_graphic IDB_TITLE_HD_WHITE "title_red_white_320_rgba"
 bitmap_graphic IDB_TITLE_UHD_WHITE "title_red_white_640_rgba"
 #endif
@@ -172,7 +174,9 @@ bitmap_graphic IDB_TITLE "title_110"
 bitmap_graphic IDB_TITLE_HD "title_320"
 bitmap_graphic IDB_TITLE_UHD "title_640"
 #ifndef USE_WIN32_RESOURCES
+bitmap_graphic IDB_TITLE_RGBA "title_110_rgba"
 bitmap_graphic IDB_TITLE_HD_RGBA "title_320_rgba"
+bitmap_graphic IDB_TITLE_UHD_RGBA "title_640_rgba"
 bitmap_graphic IDB_TITLE_HD_WHITE "title_white_320_rgba"
 bitmap_graphic IDB_TITLE_UHD_WHITE "title_white_640_rgba"
 #endif

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -21,16 +21,80 @@ Version 7.45 - not yet released
     ``type`` values (``key`` / ``gce`` / ``gesture`` / ``ne`` /
     ``label``), gesture ``data`` format, softkey ``location``,
     label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
+  - document ``AirspaceLabels`` input event
 * ui
-  - Speed up long rich-text layout (Quick Guide What's New): estimate scroll
-    height before wrapping, skip FreeType for runs that clearly fit or
-    overflow by character budget, and use one measure for typical bullets
+  - Bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
+    (same as AVG/ALT softkey and RL gesture); previous target remains
+    on Down
+  - Draw map GPS status above the map scale / title line so it is not
+    covered by AUTO / Simulator / REPLAY text
+  - Improve soft keyboard text entry: default focus on a key; cursor
+    keys move across the grid (Up from OK/Cancel/Clear enters the
+    keyboard; arrows no longer jump in tab order at row edges); F1 is
+    backspace
+  - Fix profile selection / startup branding: use transparent RGBA logo
+    and title bitmaps on light (parchment) dialog backgrounds #2742
+  - Size the InfoBox panel to the current tab and lift map overlays by
+    that height only (Altitude → Simulator no longer jumps the map
+    title up by the taller Setup tab)
+  - Fix map vario / final-glide value labels: use a rounded rectangle
+    (not a pill) with even text padding and an unbroken outline for the
+    semitransparent background #1438
+  - Swap map overlay sides: vario bar on the left, final glide bar on
+    the right #1210
+  - Add airspace labels toggle: Display page 2, Quick Menu, and
+    ``AirspaceLabels`` input event (on/off, saved to profile) #1243
+  - Add Quick Guide and Replay to the Quick Menu (Replay disabled when
+    moving)
+  - Show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
+  - Allow Left/Right on the simulator prompt to choose Fly / Simulator
+    immediately
+  - Improve the map items dialog: scale “Your Position” aircraft icon
+    to the row; Enter / Details opens Status: Flight; show airspace
+    Inside/Near status like the airspace warnings dialog
+  - Put WiFi Connect first and Close last (right / bottom)
+  - Put Download before Cancel in the download picker; Left/Right page
+    the list (no armed action-bar dual focus)
+  - Use single keyboard focus in the multi-file picker (no armed action
+    bar); Enter/Space toggles the highlighted file, Up/Down reach
+    OK/Cancel
+  - Use single keyboard focus in the value list picker (ComboPicker);
+    Left/Right page, Enter selects the highlighted value
+  - Draw a thin separator line above list-picker bottom help text
+  - Make Quick Menu Left/Right stay put when the next item is disabled,
+    but still wrap or flip page at a real row edge
+  - Use focus colour for action-bar buttons that have keyboard focus
+    (armed Left/Right selection still uses the selected colour while
+    the list keeps focus — same as Alternates)
+  - Open waypoint details with Details / F1 (Enter still confirms the
+    selection)
+  - Move Task Manager keyboard focus with Manage → Browse (and WeGlide
+    lists) so Up/Down can move the task list again
+  - Fix task point dialog keyboard navigation: Up/Down no longer skip
+    the OZ Radius field; Left/Right change the task point (same as
+    < / >); Type is an AddEnum-style field; in portrait the map and OZ
+    fields are full width and the form only uses height for active OZ
+    settings (landscape keeps the side form)
+  - Fill leftover pixels on the last dialog action-bar button in a row
+    (no empty right strip); landscape side bars stay normal height
+  - Put Reference Mass above the plane polar V/W grid; Up/Down moves
+    within each V/W column
+  - Fix Configuration keyboard navigation: Up/Down again move between
+    settings rows; Up from Close/arrows focuses the last row (Quick
+    Guide chrome path unchanged); opening the dialog focuses the menu,
+    not Close; Up/Down on the menu walk individual items (then
+    Close/arrows); Esc from a settings panel returns to the menu
+  - Speed up long rich-text layout (Quick Guide What's New): estimate
+    scroll height before wrapping, skip FreeType for runs that clearly
+    fit or overflow by character budget, and use one measure for
+    typical bullets
   - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
     button are reachable from the keyboard
-  - Expert Look → Screen Layout setting "Display type" (LCD / E-ink /
-    Color e-ink); e-ink modes disable kinetic and smooth scrolling.
-    Defaults to E-ink on Kobo and LCD elsewhere
-  - Device list: show the Vario flag for non-compensated and netto vario
+  - Add Expert Look → Screen Layout setting "Display type" (LCD /
+    E-ink / Color e-ink); e-ink modes disable kinetic and smooth
+    scrolling. Defaults to E-ink on Kobo and LCD elsewhere
+  - Show the Vario flag on the device list for non-compensated and
+    netto vario
     sources as well as total-energy (e.g. BlueFly)
   - E-paper: snap VScrollPanel smooth scrolling instead of animating at
     ~60 Hz, and debounce ComboPicker per-item help updates while
@@ -235,8 +299,9 @@ Version 7.45 - not yet released
   - F2 = zoom in, F3 = zoom out in pan, on the FLARM radar, and in waypoint
     image ``wptimg`` (not on the main non-pan map, where F2/F3 stay Checklist
     and FLARM as before). Traffic: ``next`` and ``previous`` events; FLARM: UP/DOWN
-    and F1/F4 = next/prev target, F2/F3 = zoom. The radar no longer hard-codes
-    d-pad to zoom; bindings come from the ``.xci`` file
+    and F4 = next target (with UP/DOWN), F1 = AVG/ALT labels, F2/F3 = zoom.
+    The radar no longer hard-codes d-pad to zoom; bindings come from the
+    ``.xci`` file
   - ``GotoLookup`` accepts an optional argument to pre-select the Type
     filter on entry (``recent``/``last_used``, ``airport``, ``landable``,
     ``turnpoint``, ``start``, ``finish``), so a gesture or key binding can

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -54,6 +54,9 @@ Version 7.45 - not yet released
     Inside/Near status like the airspace warnings dialog
   - Tint the bottom airspace warning banner red (inside) or yellow
     (near), matching the warnings-list badges (colour displays only)
+  - Show distance and time in the bottom airspace warning banner, on a
+    second line only when the name and current distance/time do not fit
+    on one line
   - Put WiFi Connect first and Close last (right / bottom)
   - Put Download before Cancel in the download picker; Left/Right page
     the list (no armed action-bar dual focus)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -52,6 +52,8 @@ Version 7.45 - not yet released
   - Improve the map items dialog: scale “Your Position” aircraft icon
     to the row; Enter / Details opens Status: Flight; show airspace
     Inside/Near status like the airspace warnings dialog
+  - Tint the bottom airspace warning banner red (inside) or yellow
+    (near), matching the warnings-list badges (colour displays only)
   - Put WiFi Connect first and Close last (right / bottom)
   - Put Download before Cancel in the download picker; Left/Right page
     the list (no armed action-bar dual focus)

--- a/build/android.mk
+++ b/build/android.mk
@@ -307,7 +307,7 @@ $(PNG8a): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirst
 	$(Q)cp $< $@
 
 ####### title PNGs with alpha (normal + white)
-PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_320_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
+PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_110_RGBA) $(PNG_TITLE_320_RGBA) $(PNG_TITLE_640_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
 $(PNG8): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -292,7 +292,7 @@ $(PNG8a): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirst
 	$(Q)cp $< $@
 
 ####### title PNGs with alpha (normal + white)
-PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_320_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
+PNG8 := $(patsubst $(DATA)/graphics2/%.png,$(DRAWABLE_DIR)/%.png,$(PNG_TITLE_110_RGBA) $(PNG_TITLE_320_RGBA) $(PNG_TITLE_640_RGBA) $(PNG_TITLE_WHITE_320_RGBA) $(PNG_TITLE_WHITE_640_RGBA))
 $(PNG8): $(DRAWABLE_DIR)/%.png: $(DATA)/graphics2/%.png | $(DRAWABLE_DIR)/dirstamp
 	$(Q)cp $< $@
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -371,6 +371,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Renderer/AirspaceLabelRenderer.cpp \
 	$(SRC)/Renderer/AirspaceListRenderer.cpp \
 	$(SRC)/Renderer/AirspacePreviewRenderer.cpp \
+	$(SRC)/Renderer/AirspaceWarningStatusRenderer.cpp \
 	$(SRC)/Renderer/BestCruiseArrowRenderer.cpp \
 	$(SRC)/Renderer/CompassRenderer.cpp \
 	$(SRC)/Renderer/FinalGlideBarRenderer.cpp \

--- a/build/resource.mk
+++ b/build/resource.mk
@@ -113,7 +113,9 @@ PNG_TITLE_320 = $(patsubst Data/graphics/%.svg,$(DATA)/graphics/%_320.png,$(SVG_
 BMP_TITLE_320 = $(PNG_TITLE_320:.png=.bmp)
 PNG_TITLE_640 = $(patsubst Data/graphics/%.svg,$(DATA)/graphics/%_640.png,$(SVG_TITLE))
 BMP_TITLE_640 = $(PNG_TITLE_640:.png=.bmp)
+PNG_TITLE_110_RGBA = $(patsubst Data/graphics/%.svg,$(DATA)/graphics2/%_110_rgba.png,$(SVG_TITLE))
 PNG_TITLE_320_RGBA = $(patsubst Data/graphics/%.svg,$(DATA)/graphics2/%_320_rgba.png,$(SVG_TITLE))
+PNG_TITLE_640_RGBA = $(patsubst Data/graphics/%.svg,$(DATA)/graphics2/%_640_rgba.png,$(SVG_TITLE))
 
 SVG_TITLE_WHITE = Data/graphics/title_white.svg Data/graphics/title_red_white.svg
 PNG_TITLE_WHITE_320_RGBA = $(patsubst Data/graphics/%.svg,$(DATA)/graphics2/%_320_rgba.png,$(SVG_TITLE_WHITE))
@@ -123,7 +125,9 @@ PNG_TITLE_WHITE_640_RGBA = $(patsubst Data/graphics/%.svg,$(DATA)/graphics2/%_64
 $(eval $(call rsvg-convert,$(PNG_TITLE_110),$(DATA)/graphics/%_110.png,Data/graphics/%.svg,--width=110))
 $(eval $(call rsvg-convert,$(PNG_TITLE_320),$(DATA)/graphics/%_320.png,Data/graphics/%.svg,--width=320))
 $(eval $(call rsvg-convert,$(PNG_TITLE_640),$(DATA)/graphics/%_640.png,Data/graphics/%.svg,--width=640))
+$(eval $(call rsvg-convert,$(PNG_TITLE_110_RGBA),$(DATA)/graphics2/%_110_rgba.png,Data/graphics/%.svg,--width=110))
 $(eval $(call rsvg-convert,$(PNG_TITLE_320_RGBA),$(DATA)/graphics2/%_320_rgba.png,Data/graphics/%.svg,--width=320))
+$(eval $(call rsvg-convert,$(PNG_TITLE_640_RGBA),$(DATA)/graphics2/%_640_rgba.png,Data/graphics/%.svg,--width=640))
 $(eval $(call rsvg-convert,$(PNG_TITLE_WHITE_320_RGBA),$(DATA)/graphics2/%_320_rgba.png,Data/graphics/%.svg,--width=320))
 $(eval $(call rsvg-convert,$(PNG_TITLE_WHITE_640_RGBA),$(DATA)/graphics2/%_640_rgba.png,Data/graphics/%.svg,--width=640))
 
@@ -327,7 +331,7 @@ RESOURCE_FILES += $(BMP_DIALOG_TITLE) $(BMP_PROGRESS_BORDER)
 RESOURCE_FILES += $(BMP_TITLE_640) $(BMP_TITLE_320) $(BMP_TITLE_110)
 ifneq ($(USE_WIN32_RESOURCES),y)
 RESOURCE_FILES += $(PNG_SPLASH_320_RGBA) $(PNG_SPLASH_160_RGBA) $(PNG_SPLASH_80_RGBA)
-RESOURCE_FILES += $(PNG_TITLE_320_RGBA)
+RESOURCE_FILES += $(PNG_TITLE_110_RGBA) $(PNG_TITLE_320_RGBA) $(PNG_TITLE_640_RGBA)
 RESOURCE_FILES += $(PNG_TITLE_WHITE_320_RGBA)
 RESOURCE_FILES += $(PNG_TITLE_WHITE_640_RGBA)
 endif

--- a/build/test.mk
+++ b/build/test.mk
@@ -2623,6 +2623,7 @@ RUN_AIRSPACE_WARNING_DIALOG_SOURCES = \
 	$(SRC)/Look/CheckBoxLook.cpp \
 	$(SRC)/Renderer/TwoTextRowsRenderer.cpp \
 	$(SRC)/Renderer/AirspacePreviewRenderer.cpp \
+	$(SRC)/Renderer/AirspaceWarningStatusRenderer.cpp \
 	$(SRC)/Renderer/AirspaceRendererSettings.cpp \
 	$(SRC)/Projection/Projection.cpp \
 	$(SRC)/Projection/WindowProjection.cpp \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -55,7 +55,8 @@ Default key bindings
 The built-in ``type=key`` mapping in :file:`Data/Input/default.xci`
 currently uses this grouped layout for ``F1`` -- ``F12``:
 
-- **F1**: quick menu.
+- **F1**: quick menu.  On the FLARM traffic radar, ``F1`` is
+  ``Traffic label toggle`` (AVG/ALT side labels) instead.
 - **F2 / F3** (on the main map, ``mode=default`` only): ``Checklist`` and
   ``FlarmTraffic``.  **F2 / F3** are zoom in / out in ``pan`` mode, on
   the FLARM traffic radar, and in waypoint image ``wptimg``; they do not
@@ -236,6 +237,11 @@ Event list
    - Controls the airspace display filter mode. Possible arguments:
      ``all`` (show all), ``clip`` (clip to altitude), ``auto``
      (automatic), ``below`` (show all below), ``off`` (hide all).
+ * - ``AirspaceLabels``
+   - Toggles airspace altitude labels on the map (same setting as
+     Configuration → Airspace → Labels). Possible arguments:
+     ``toggle``, ``on`` / ``all``, ``off`` / ``none``, ``show``
+     (display current state).
  * - ``AirspaceWarnings``
    - Opens the airspace warnings dialog.
  * - ``Analysis``

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -7,6 +7,7 @@
 #include "Form/Button.hpp"
 #include "Look/DialogLook.hpp"
 #include "Look/MapLook.hpp"
+#include "Renderer/AirspaceWarningStatusRenderer.hpp"
 #include "Formatter/UserUnits.hpp"
 #include "Renderer/TwoTextRowsRenderer.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -124,10 +125,6 @@ public:
 static WndForm *dialog = NULL;
 static AirspaceWarningListWidget *list;
 
-static constexpr Color inside_color(254,50,50);
-static constexpr Color near_color(254,254,50);
-static constexpr Color inside_ack_color(254,100,100);
-static constexpr Color near_ack_color(254,254,100);
 static bool auto_close = true;
 
 
@@ -395,9 +392,7 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
     layout_rc.left += line_height + padding;
   }
 
-  // word "inside" is used as the etalon, because it is longer than "near" and
-  // currently (9.4.2011) there is no other possibility for the status text.
-  const int status_width = canvas.CalcTextWidth("inside");
+  const int status_width = AirspaceWarningStatusWidth(canvas);
   // "1888" is used in order to have enough space for 4-digit heights with "AGL"
   const int altitude_width = canvas.CalcTextWidth("1888 m AGL");
 
@@ -453,43 +448,14 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
   }
 
   /* draw the warning state indicator */
-
-  Color state_color;
-  const char *state_text;
-
-  if (warning.IsInside()) {
-    state_color = warning.IsActive() ? inside_color : inside_ack_color;
-    state_text = "inside";
-  } else if (warning.IsWarning()) {
-    state_color = warning.IsActive() ? near_color : near_ack_color;
-    state_text = "near";
-  } else {
-    state_color = COLOR_WHITE;
-    state_text = NULL;
+  AirspaceWarningStatusBadge status;
+  if (warning.IsWarning()) {
+    status.active = warning.IsActive();
+    status.kind = warning.IsInside()
+      ? AirspaceWarningStatusBadge::Kind::Inside
+      : AirspaceWarningStatusBadge::Kind::Near;
   }
-
-  const PixelSize state_text_size =
-    canvas.CalcTextSize(state_text != NULL ? state_text : "W");
-
-  if (state_color != COLOR_WHITE) {
-    /* colored background */
-    PixelRect rc = status_rc;
-    rc.top += padding;
-    rc.right -= padding;
-    rc.bottom -= padding;
-
-    canvas.DrawFilledRectangle(rc, state_color);
-
-    /* on this background we just painted, we must use black color for
-       the state text; our caller might have selected a different
-       color, override it here */
-    canvas.SetTextColor(COLOR_BLACK);
-  }
-
-  if (state_text != NULL) {
-    // -- status text will be centered inside its table cell:
-    canvas.DrawText(status_rc.CenteredTopLeft(state_text_size), state_text);
-  }
+  DrawAirspaceWarningStatus(canvas, status_rc, status);
 }
 
 inline void

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -392,14 +392,15 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
     layout_rc.left += line_height + padding;
   }
 
-  const int status_width = AirspaceWarningStatusWidth(canvas);
+  const Font &list_font = *UIGlobals::GetDialogLook().list.font;
+  const int status_width = AirspaceWarningStatusWidth(canvas, list_font);
   // "1888" is used in order to have enough space for 4-digit heights with "AGL"
   const int altitude_width = canvas.CalcTextWidth("1888 m AGL");
 
   // Dynamic columns scaling - "name" column is flexible, altitude and state
   // columns are fixed-width.
   auto [text_altitude_rc, status_rc] =
-    layout_rc.VerticalSplit(layout_rc.right - (2 * padding + status_width));
+    layout_rc.VerticalSplit(layout_rc.right - status_width);
   auto text_rc =
     text_altitude_rc.VerticalSplit(text_altitude_rc.right - (padding + altitude_width)).first;
   text_rc.right -= padding;
@@ -455,7 +456,7 @@ AirspaceWarningListWidget::OnPaintItem(Canvas &canvas,
       ? AirspaceWarningStatusBadge::Kind::Inside
       : AirspaceWarningStatusBadge::Kind::Near;
   }
-  DrawAirspaceWarningStatus(canvas, status_rc, status);
+  DrawAirspaceWarningStatus(canvas, list_font, status_rc, status);
 }
 
 inline void

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -322,10 +322,11 @@ DownloadFilePicker(FileType file_type)
   TWidgetDialog<DownloadFilePickerWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
            UIGlobals::GetDialogLook(), _("Download"));
-  dialog.AddButton(_("Cancel"), mrCancel);
   dialog.SetWidget(dialog, file_type);
   dialog.GetWidget().CreateButtons();
-  dialog.EnableCursorSelection();
+  dialog.AddButton(_("Cancel"), mrCancel);
+  /* No EnableCursorSelection: Left/Right page the list (ListControl).
+     Up/Down walk list ↔ Download/Cancel; Enter downloads the cursor row. */
   dialog.ShowModal();
 
   return dialog.GetWidget().GetPath();

--- a/src/Dialogs/ListPicker.cpp
+++ b/src/Dialogs/ListPicker.cpp
@@ -94,7 +94,7 @@ ListPicker(const char *caption,
 
   if (_itemhelp_callback != nullptr) {
     widget = std::make_unique<TwoWidgets>(std::move(widget),
-                                          std::make_unique<TextWidget>());
+                                          std::make_unique<TextWidget>(true));
     auto &two_widgets = (TwoWidgets &)*widget;
     list_widget->EnableItemHelp(_itemhelp_callback,
                                 (TextWidget &)two_widgets.GetSecond(),
@@ -124,8 +124,8 @@ ListPicker(const char *caption,
 
   dialog.AddButton(_("Cancel"), mrCancel);
 
-  dialog.EnableCursorSelection();
-
+  /* No EnableCursorSelection: Left/Right page the list; Enter activates
+     the cursor row (Select).  Up/Down walk list ↔ buttons. */
   UI::PeriodicTimer update_timer([list_widget](){
     list_widget->GetList().Invalidate();
   });

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -355,9 +355,8 @@ MapItemListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   bool show_status = false;
   if (warning_status.HasStatus()) {
     /* Reserve a status column only when the main text still has room. */
-    const int status_width = AirspaceWarningStatusWidth(canvas);
-    const unsigned padding = Layout::GetTextPadding();
-    const int needed = 2 * (int)padding + status_width;
+    const int needed =
+      AirspaceWarningStatusWidth(canvas, *dialog_look.list.font);
     const int min_main = Layout::Scale(80);
     if ((int)rc.GetWidth() > needed + min_main) {
       const auto split = rc.VerticalSplit(rc.right - needed);
@@ -371,7 +370,8 @@ MapItemListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                 &CommonInterface::Basic().flarm.traffic);
 
   if (show_status)
-    DrawAirspaceWarningStatus(canvas, status_rc, warning_status);
+    DrawAirspaceWarningStatus(canvas, *dialog_look.list.font,
+                              status_rc, warning_status);
 
   if ((settings.item_list.add_arrival_altitude &&
        item->type == MapItem::Type::ARRIVAL_ALTITUDE) ||

--- a/src/Dialogs/MapItemListDialog.cpp
+++ b/src/Dialogs/MapItemListDialog.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Dialogs/MapItemListDialog.hpp"
+#include "Dialogs/Dialogs.h"
 #include "Dialogs/WidgetDialog.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Dialogs/Airspace/Airspace.hpp"
@@ -20,7 +21,9 @@
 #include "Weather/Features.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
+#include "Airspace/AirspaceWarningManager.hpp"
 #include "Look/DialogLook.hpp"
+#include "Renderer/AirspaceWarningStatusRenderer.hpp"
 #include "Interface.hpp"
 #include "UIGlobals.hpp"
 #include "Components.hpp"
@@ -31,6 +34,8 @@
 #include "Terrain/RasterTerrain.hpp"
 #include "Protection.hpp"
 #include "LogFile.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Color.hpp"
 #include <Message.hpp>
 
 #include <limits>
@@ -40,20 +45,49 @@
 #include "Dialogs/Weather/NOAADetails.hpp"
 #endif
 
+/* Matches tab order in dlgStatusShowModal(). */
+static constexpr int STATUS_PAGE_FLIGHT = 0;
+
 static bool
 ShowMapItemDialog(const MapItem &item,
                   Waypoints *waypoints,
                   ProtectedAirspaceWarningManager *airspace_warnings);
 
 static bool
+QueryWarningStatusNoThrow(ProtectedAirspaceWarningManager &warnings,
+                          const AbstractAirspace &airspace,
+                          AirspaceWarningStatusBadge &status) noexcept
+{
+  try {
+    const ProtectedAirspaceWarningManager::Lease lease(warnings);
+    const AirspaceWarning *warning = lease->GetWarningPtr(airspace);
+    if (warning == nullptr || !warning->IsWarning())
+      return true;
+
+    status.active = warning->IsActive();
+    status.kind = warning->IsInside()
+      ? AirspaceWarningStatusBadge::Kind::Inside
+      : AirspaceWarningStatusBadge::Kind::Near;
+    return true;
+  } catch (const std::exception &e) {
+    LogFmt("Failed to query airspace warning status: {}", e.what());
+  } catch (...) {
+    LogError(std::current_exception(),
+             "Failed to query airspace warning status");
+  }
+
+  return false;
+}
+
+static bool
 HasDetails(const MapItem &item)
 {
   switch (item.type) {
   case MapItem::Type::ARRIVAL_ALTITUDE:
-  case MapItem::Type::SELF:
   case MapItem::Type::THERMAL:
     return false;
 
+  case MapItem::Type::SELF:
   case MapItem::Type::LOCATION:
   case MapItem::Type::AIRSPACE:
   case MapItem::Type::WAYPOINT:
@@ -301,20 +335,43 @@ MapItemListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   }
 
   bool ack_day = false;
+  AirspaceWarningStatusBadge warning_status;
   if (item->type == MapItem::Type::AIRSPACE &&
       backend_components != nullptr) {
     if (auto *warnings = backend_components->GetAirspaceWarnings();
         warnings != nullptr) {
       const auto &as_item = static_cast<const AirspaceMapItem &>(*item);
       QueryAckDayNoThrow(*warnings, *as_item.airspace, ack_day);
+      QueryWarningStatusNoThrow(*warnings, *as_item.airspace,
+                               warning_status);
     }
   }
 
   if (ack_day)
     canvas.SetTextColor(COLOR_GRAY);
 
-  renderer.Draw(canvas, rc, *item,
+  PixelRect draw_rc = rc;
+  PixelRect status_rc{};
+  bool show_status = false;
+  if (warning_status.HasStatus()) {
+    /* Reserve a status column only when the main text still has room. */
+    const int status_width = AirspaceWarningStatusWidth(canvas);
+    const unsigned padding = Layout::GetTextPadding();
+    const int needed = 2 * (int)padding + status_width;
+    const int min_main = Layout::Scale(80);
+    if ((int)rc.GetWidth() > needed + min_main) {
+      const auto split = rc.VerticalSplit(rc.right - needed);
+      draw_rc = split.first;
+      status_rc = split.second;
+      show_status = true;
+    }
+  }
+
+  renderer.Draw(canvas, draw_rc, *item,
                 &CommonInterface::Basic().flarm.traffic);
+
+  if (show_status)
+    DrawAirspaceWarningStatus(canvas, status_rc, warning_status);
 
   if ((settings.item_list.add_arrival_altitude &&
        item->type == MapItem::Type::ARRIVAL_ALTITUDE) ||
@@ -493,9 +550,12 @@ ShowMapItemDialog(const MapItem &item,
 {
   switch (item.type) {
   case MapItem::Type::ARRIVAL_ALTITUDE:
-  case MapItem::Type::SELF:
   case MapItem::Type::THERMAL:
     return false;
+
+  case MapItem::Type::SELF:
+    dlgStatusShowModal(STATUS_PAGE_FLIGHT);
+    return true;
 
   case MapItem::Type::AIRSPACE:
     return dlgAirspaceDetailsForBrowseParent(

--- a/src/Dialogs/MultiFilePicker.cpp
+++ b/src/Dialogs/MultiFilePicker.cpp
@@ -90,7 +90,9 @@ MultiFilePicker(const char *caption, MultiFileDataField &df,
   UpdateButtons();
   file_widget->SetSelectionChangedCallback(UpdateButtons);
 
-  dialog.EnableCursorSelection();
+  /* No EnableCursorSelection: an armed action-bar button plus the list
+     cursor reads as dual focus.  Up/Down walk list ↔ buttons; Enter/Space
+     on the list toggles (MultiSelectListWidget::KeyPress). */
   dialog.FinishPreliminary(std::move(widget));
 
   int result = dialog.ShowModal();

--- a/src/Dialogs/Plane/PlaneListDialog.cpp
+++ b/src/Dialogs/Plane/PlaneListDialog.cpp
@@ -64,7 +64,7 @@ class PlaneListWidget final
     }
   };
 
-  WndForm *form;
+  WidgetDialog *form;
   Button *edit_button, *copy_button, *delete_button, *load_button;
 
   std::vector<ListItem> list;
@@ -123,6 +123,9 @@ PlaneListWidget::UpdateList() noexcept
   edit_button->SetEnabled(!empty);
   copy_button->SetEnabled(!empty);
   delete_button->SetEnabled(!empty);
+
+  if (form != nullptr)
+    form->ResyncButtonPanelSelection();
 }
 
 void
@@ -362,6 +365,8 @@ dlgPlanesShowModal() noexcept
   dialog.SetWidget();
   dialog.GetWidget().CreateButtons(dialog);
   dialog.AddButton(_("Close"), mrOK);
+  /* Like Alternates: list cursor picks the plane; Left/Right arm an
+     action (New/Edit/…); Enter runs it. */
   dialog.EnableCursorSelection();
 
   dialog.ShowModal();

--- a/src/Dialogs/Plane/PlanePolarDialog.cpp
+++ b/src/Dialogs/Plane/PlanePolarDialog.cpp
@@ -24,8 +24,8 @@ class PlanePolarWidget final
   enum Controls {
     NAME,
     INVALID,
-    SHAPE,
     REFERENCE_MASS,
+    SHAPE,
   };
 
   Plane plane;
@@ -107,13 +107,13 @@ PlanePolarWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   Add(std::make_unique<TextWidget>());
   SetRowVisible(INVALID, false);
 
-  DataFieldListener *listener = this;
-  Add(std::make_unique<PolarShapeEditWidget>(plane.polar_shape, listener));
-
   AddFloat(_("Reference Mass"), _("Reference mass of the polar."),
            "%.0f %s", "%.0f",
            0, 1000, 5, false,
            UnitGroup::MASS, plane.polar_shape.reference_mass);
+
+  DataFieldListener *listener = this;
+  Add(std::make_unique<PolarShapeEditWidget>(plane.polar_shape, listener));
 }
 
 void

--- a/src/Dialogs/Plane/PolarShapeEditWidget.cpp
+++ b/src/Dialogs/Plane/PolarShapeEditWidget.cpp
@@ -156,7 +156,6 @@ PolarShapeEditWidget::CreateControls(ContainerWindow &panel,
   const unsigned columns_width = width > label_width ? width - label_width : 1U;
   const unsigned edit_width =
     std::max(1U, columns_width / unsigned(ARRAY_SIZE(points)));
-  const unsigned edit_remainder = columns_width - edit_width * ARRAY_SIZE(points);
 
   const char *v_text = C_("Glider polar coefficient", "Polar V");
   const char *w_text = C_("Glider polar coefficient", "Polar W");
@@ -168,36 +167,10 @@ PolarShapeEditWidget::CreateControls(ContainerWindow &panel,
   v_label = std::make_unique<WndFrame>(panel, look, label_rc);
   v_label->SetText(v_text);
 
-  PixelRect field_rc;
-  field_rc.left = label_width;
-  field_rc.top = 0;
-  field_rc.right = field_rc.left + edit_width;
-  field_rc.bottom = row_height;
-  for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
-    if (i + 1 == ARRAY_SIZE(points))
-      field_rc.right = width;
-
-    points[i].v = std::make_unique<WndProperty>(panel, look, "",
-                                                field_rc, 0, style);
-    DataFieldFloat *df = new DataFieldFloat("%.0f", "%.0f %s",
-                                            0, 300, 0, 1, false,
-                                            listener);
-    points[i].v->SetDataField(df);
-
-    field_rc.left = field_rc.right;
-    field_rc.right = field_rc.left + edit_width +
-      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
-  }
-
   label_rc.top += row_height;
   label_rc.bottom += row_height;
   w_label = std::make_unique<WndFrame>(panel, look, label_rc);
   w_label->SetText(w_text);
-
-  field_rc.left = label_width;
-  field_rc.top = row_height;
-  field_rc.right = field_rc.left + edit_width;
-  field_rc.bottom = height;
 
   double step = 0.01, min = -10;
   switch (Units::current.vertical_speed_unit) {
@@ -215,21 +188,29 @@ PolarShapeEditWidget::CreateControls(ContainerWindow &panel,
     break;
   }
 
+  /* Create controls column-by-column (V then W) so Up/Down focus
+     walk matches the visual grid instead of sweeping each row. */
+  unsigned col_left = label_width;
   for (unsigned i = 0; i < ARRAY_SIZE(points); ++i) {
-    if (i + 1 == ARRAY_SIZE(points))
-      field_rc.right = width;
+    const unsigned col_right = (i + 1 == ARRAY_SIZE(points))
+      ? width
+      : col_left + edit_width;
 
+    PixelRect v_rc(col_left, 0, col_right, row_height);
+    points[i].v = std::make_unique<WndProperty>(panel, look, "",
+                                                v_rc, 0, style);
+    points[i].v->SetDataField(new DataFieldFloat("%.0f", "%.0f %s",
+                                                 0, 300, 0, 1, false,
+                                                 listener));
+
+    PixelRect w_rc(col_left, row_height, col_right, height);
     points[i].w = std::make_unique<WndProperty>(panel, look, "",
-                                                field_rc, 0, style);
-    DataFieldFloat *df = new DataFieldFloat("%.2f", "%.2f %s",
-                                            min, 0, 0, step, false,
-                                            listener);
+                                                w_rc, 0, style);
+    points[i].w->SetDataField(new DataFieldFloat("%.2f", "%.2f %s",
+                                                 min, 0, 0, step, false,
+                                                 listener));
 
-    points[i].w->SetDataField(df);
-
-    field_rc.left = field_rc.right;
-    field_rc.right = field_rc.left + edit_width +
-      (i + 1 == ARRAY_SIZE(points) ? edit_remainder : 0u);
+    col_left = col_right;
   }
 
   for (unsigned i = 0; i < ARRAY_SIZE(points); ++i)

--- a/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SiteConfigPanel.cpp
@@ -57,7 +57,7 @@ SiteConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unuse
   AddMultipleFiles(_("Waypoints"),
                    _("Primary waypoints files.  Supported file types are "
                      "Cambridge/WinPilot files (.dat), "
-                     "Zander files (.wpz) or SeeYou files (.cup)."),
+                     "Zander files (.wpz) or SeeYou files (.cup, .cupx)."),
                    ProfileKeys::WaypointFileList,
                    GetFileTypePatterns(FileType::WAYPOINT),
                    FileType::WAYPOINT);

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -8,6 +8,7 @@
 #include "Dialogs/WidgetDialog.hpp"
 #include "Look/DialogLook.hpp"
 #include "UIGlobals.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "Form/TabMenuDisplay.hpp"
 #include "Form/TabMenuData.hpp"
 #include "Form/CheckBox.hpp"
@@ -367,6 +368,16 @@ void dlgConfigurationShowModal()
   });
 
   dialog.FinishPreliminary(pager);
+
+  /* Esc on a settings panel returns to the menu (same as Close);
+     on the menu itself, leave Esc to cancel the dialog. */
+  dialog.SetKeyDownFunction([&dialog](unsigned key_code) {
+    if (key_code != KEY_ESCAPE || pager->GetCurrentIndex() == 0)
+      return false;
+
+    OnCloseClicked(dialog);
+    return true;
+  });
 
   dialog.ShowModal();
 

--- a/src/Dialogs/SimulatorPromptWindow.hpp
+++ b/src/Dialogs/SimulatorPromptWindow.hpp
@@ -46,6 +46,14 @@ public:
     :look(_look), callback(std::move(_callback)),
      have_quit_button(_quit) {}
 
+  void SelectFly() noexcept {
+    callback(Result::FLY);
+  }
+
+  void SelectSimulator() noexcept {
+    callback(Result::SIMULATOR);
+  }
+
 protected:
   /* virtual methods from class Window */
   void OnCreate() override;

--- a/src/Dialogs/Task/Manager/TaskListPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskListPanel.cpp
@@ -80,6 +80,7 @@ public:
     buttons.Add(_("Rename"), [this](){ RenameTask(); });
     buttons.Add(_("Delete"), [this](){ DeleteTask(); });
     more_button = buttons.Add(_("More"), [this](){ OnMoreClicked(); });
+    buttons.EnableCursorSelection();
   }
 
   void RefreshView();

--- a/src/Dialogs/Task/Manager/WeGlideTasksPanel.cpp
+++ b/src/Dialogs/Task/Manager/WeGlideTasksPanel.cpp
@@ -84,6 +84,7 @@ public:
   void CreateButtons(ButtonPanel &buttons) noexcept {
     load_button = buttons.Add(_("Load"), [this](){ LoadTask(); });
     buttons.Add(_("Refresh"), [this](){ ReloadList(); });
+    buttons.EnableCursorSelection();
   }
 
   void UpdateButtons() noexcept {

--- a/src/Dialogs/Task/TaskPointDialog.cpp
+++ b/src/Dialogs/Task/TaskPointDialog.cpp
@@ -10,6 +10,9 @@
 #include "Form/Frame.hpp"
 #include "Form/Button.hpp"
 #include "Form/CheckBox.hpp"
+#include "Form/Edit.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Listener.hpp"
 #include "Widget/ManagedWidget.hpp"
 #include "Widget/PanelWidget.hpp"
 #include "Screen/Layout.hpp"
@@ -17,8 +20,10 @@
 #include "Components.hpp"
 #include "Units/Units.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
 #include "Engine/Task/Ordered/Points/ASTPoint.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
+#include "Task/Factory/TaskPointFactoryType.hpp"
 #include "Task/ObservationZones/LineSectorZone.hpp"
 #include "Task/ObservationZones/CylinderZone.hpp"
 #include "Task/ObservationZones/KeyholeZone.hpp"
@@ -30,6 +35,7 @@
 #include "Look/DialogLook.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "Widgets/CylinderZoneEditWidget.hpp"
 #include "Widgets/SectorZoneEditWidget.hpp"
 #include "Widgets/LineSectorZoneEditWidget.hpp"
@@ -40,8 +46,17 @@
 #include "ui/canvas/opengl/Scissor.hpp"
 #endif
 
+namespace {
+
+/* Window::Move asserts a non-empty rect; ApplyLayout replaces this
+   once the OZ form's minimum height is known. */
+constexpr PixelSize OZ_PREPARE_PLACEHOLDER{1, 1};
+
+} // namespace
+
 class TaskPointWidget final
   : public NullWidget,
+    DataFieldListener,
     ObservationZoneEditWidget::Listener {
 
   struct Layout {
@@ -50,27 +65,34 @@ class TaskPointWidget final
     PixelRect waypoint_details, waypoint_remove, waypoint_relocate;
 
     PixelRect tp_panel;
-    PixelRect type_label, change_type;
+    PixelRect type_field;
     PixelRect map, properties;
     PixelRect optional_starts, score_exit;
 
-    explicit Layout(PixelRect rc, const DialogLook &look);
+    /**
+     * @param properties_height portrait-only: height of the active OZ
+     *        form (0 when none); landscape ignores this and uses a
+     *        fixed side column
+     */
+    Layout(PixelRect rc, const DialogLook &look,
+           unsigned properties_height) noexcept;
   };
 
   OrderedTask &ordered_task;
   bool task_modified;
   unsigned active_index;
+  bool loading_type = false;
 
   WidgetDialog &dialog;
   const DialogLook &look;
+  PixelRect position{};
 
   PanelControl waypoint_panel;
   WndFrame waypoint_name;
   Button waypoint_details, waypoint_remove, waypoint_relocate;
 
   PanelControl tp_panel;
-  WndFrame type_label;
-  Button change_type;
+  WndProperty type_field;
   WndOwnerDrawFrame map;
   ManagedWidget properties_widget{nullptr};
 
@@ -85,9 +107,9 @@ public:
     :ordered_task(_task), task_modified(false), active_index(_index),
      dialog(_dialog), look(dialog.GetLook()),
      waypoint_name(look),
-     type_label(look) {}
+     type_field(look) {}
 
-  bool IsModified() const {
+  bool IsModified() const noexcept {
     return task_modified;
   }
 
@@ -102,21 +124,48 @@ public:
   }
 
 private:
-  void MoveChildren(const Layout &layout) {
+  [[nodiscard]]
+  unsigned GetPropertiesFormHeight() noexcept {
+    if (!properties_widget.IsPrepared())
+      return 0;
+
+    return properties_widget.Get()->GetMinimumSize().height;
+  }
+
+  Layout MakeLayout(const PixelRect &rc) noexcept {
+    return Layout(rc, look, GetPropertiesFormHeight());
+  }
+
+  void MoveChildren(const Layout &layout) noexcept {
     waypoint_name.Move(layout.waypoint_name);
     waypoint_details.Move(layout.waypoint_details);
     waypoint_remove.Move(layout.waypoint_remove);
     waypoint_relocate.Move(layout.waypoint_relocate);
 
-    type_label.Move(layout.type_label);
-    change_type.Move(layout.change_type);
+    type_field.Move(layout.type_field);
     map.Move(layout.map);
-    properties_widget.Move(layout.properties);
+    if (layout.properties.GetHeight() > 0) {
+      properties_widget.Move(layout.properties);
+      if (!properties_widget.IsVisible())
+        properties_widget.Show();
+    } else if (properties_widget.IsVisible())
+      properties_widget.Hide();
     optional_starts.Move(layout.optional_starts);
     score_exit.Move(layout.score_exit);
   }
 
-  void RefreshView();
+  void ApplyLayout(const PixelRect &rc) noexcept {
+    position = rc;
+    const Layout layout = MakeLayout(rc);
+    waypoint_panel.Move(layout.waypoint_panel);
+    tp_panel.Move(layout.tp_panel);
+    MoveChildren(layout);
+  }
+
+  void RecreateOzForm() noexcept;
+  void RefreshControls() noexcept;
+  void RefreshView() noexcept;
+  void LoadTypeField() noexcept;
   bool ReadValues();
 
   void PaintMap(Canvas &canvas, const PixelRect &rc);
@@ -124,7 +173,6 @@ private:
   void OnDetailsClicked();
   void OnRemoveClicked();
   void OnRelocateClicked();
-  void OnTypeClicked();
   void OnPreviousClicked();
   void OnNextClicked();
   void OnOptionalStartsClicked();
@@ -141,7 +189,8 @@ public:
   }
 
   void Show(const PixelRect &rc) noexcept override {
-    const Layout layout(rc, look);
+    position = rc;
+    const Layout layout = MakeLayout(rc);
     waypoint_panel.MoveAndShow(layout.waypoint_panel);
     tp_panel.MoveAndShow(layout.tp_panel);
     MoveChildren(layout);
@@ -153,22 +202,30 @@ public:
   }
 
   void Move(const PixelRect &rc) noexcept override {
-    const Layout layout(rc, look);
-    waypoint_panel.Move(layout.waypoint_panel);
-    tp_panel.Move(layout.tp_panel);
-    MoveChildren(layout);
+    ApplyLayout(rc);
   }
 
+  /* Like #TargetWidget: Left/Right flip the active task point (< / >). */
+  bool KeyPress(unsigned key_code) noexcept override;
+
 private:
+  /* virtual methods from DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
+
   /* virtual methods from class ObservationZoneEditWidget::Listener */
   void OnModified(ObservationZoneEditWidget &widget) noexcept override;
 };
 
-TaskPointWidget::Layout::Layout(PixelRect rc, const DialogLook &look)
+TaskPointWidget::Layout::Layout(PixelRect rc, const DialogLook &look,
+                                unsigned properties_height) noexcept
 {
   const unsigned padding = ::Layout::GetTextPadding();
   const unsigned font_height = look.text_font.GetHeight();
   const unsigned button_height = ::Layout::GetMaximumControlHeight();
+  /* Decide before cutting the waypoint header / Type / action
+     buttons: those shrink the map area until it is often wider than
+     tall even on a portrait dialog, which wrongly kept the side form. */
+  const bool landscape = rc.GetWidth() > rc.GetHeight();
 
   waypoint_panel = rc.CutTopSafe(font_height + button_height + 5 * padding)
     .WithPadding(padding);
@@ -190,22 +247,34 @@ TaskPointWidget::Layout::Layout(PixelRect rc, const DialogLook &look)
 
   auto tp_rc = PixelRect{tp_panel.GetSize()}.WithPadding(padding);
 
-  auto type_rc = tp_rc.CutTopSafe(button_height);
-  type_label = change_type = type_rc;
-  type_label.right = change_type.left = type_rc.right
-    - look.button.font->TextSize(_("Change Type")).width - 3 * padding;
+  type_field = tp_rc.CutTopSafe(button_height);
 
   PixelRect buttons_rc = tp_rc.CutBottomSafe(button_height);
   optional_starts = score_exit = buttons_rc;
 
   map = tp_rc;
-  properties = map.CutRightSafe(::Layout::Scale(90));
+  if (properties_height > 0) {
+    if (landscape) {
+      /* landscape: OZ form beside the map */
+      const unsigned landscape_oz_width = ::Layout::Scale(120);
+      properties = map.CutRightSafe(landscape_oz_width);
+    } else {
+      /* portrait: only as tall as the active OZ fields */
+      properties = map.CutBottomSafe(std::min(properties_height,
+                                              tp_rc.GetHeight() / 2));
+    }
+  } else {
+    /* No OZ form (e.g. fixed FAI sector): map keeps the full area.
+       Leave properties empty; MoveChildren hides the widget. */
+    properties.SetEmpty();
+  }
 }
 
 void
 TaskPointWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 {
-  const Layout layout(rc, look);
+  position = rc;
+  const Layout layout = MakeLayout(rc);
 
   WindowStyle panel_style;
   panel_style.Hide();
@@ -229,16 +298,18 @@ TaskPointWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 
   tp_panel.Create(parent, look, layout.tp_panel, panel_style);
 
-  type_label.Create(tp_panel, layout.type_label);
-  change_type.Create(tp_panel, look.button, _("Change Type"),
-                     layout.change_type,
-                     button_style, [this](){ OnTypeClicked(); });
+  /* Same control shape as RowFormWidget::AddEnum in config panels. */
+  type_field.Create(tp_panel, layout.type_field, _("Type"),
+                    0, button_style);
+  type_field.SetCaptionWidth(type_field.GetRecommendedCaptionWidth());
+  type_field.SetDataField(new DataFieldEnum(this));
   map.Create(tp_panel, layout.map, WindowStyle(),
              [this](Canvas &canvas, const PixelRect &rc){
                PaintMap(canvas, rc);
              });
 
-  properties_widget.Initialise(tp_panel, layout.properties);
+  properties_widget.Initialise(tp_panel,
+                               PixelRect{OZ_PREPARE_PLACEHOLDER});
   optional_starts.Create(tp_panel, look.button, _("Enable Alternate Starts"),
                          layout.optional_starts, button_style,
                          [this](){ OnOptionalStartsClicked(); });
@@ -285,10 +356,8 @@ CreateObservationZoneEditWidget(ObservationZonePoint &oz, bool is_fai_general)
 }
 
 void
-TaskPointWidget::RefreshView()
+TaskPointWidget::RecreateOzForm() noexcept
 {
-  map.Invalidate();
-
   OrderedTaskPoint &tp = ordered_task.GetPoint(active_index);
 
   properties_widget.Clear();
@@ -296,16 +365,34 @@ TaskPointWidget::RefreshView()
   ObservationZonePoint &oz = tp.GetObservationZone();
   const bool is_fai_general =
     ordered_task.GetFactoryType() == TaskFactoryType::FAI_GENERAL;
-  auto new_properties_widget = CreateObservationZoneEditWidget(oz, is_fai_general);
-  if (new_properties_widget != nullptr) {
-    new_properties_widget->SetListener(this);
-    properties_widget.Set(std::move(new_properties_widget));
+  auto new_oz = CreateObservationZoneEditWidget(oz, is_fai_general);
+  if (new_oz != nullptr) {
+    new_oz->SetListener(this);
+    properties_widget.Set(std::move(new_oz));
   } else
     properties_widget.Set(std::make_unique<PanelWidget>());
 
+  /* Prepare at a placeholder size so GetMinimumSize() works for
+     portrait layout; ApplyLayout assigns the real rect (or hides). */
+  properties_widget.Move(PixelRect{OZ_PREPARE_PLACEHOLDER});
   properties_widget.Show();
 
-  type_label.SetText(OrderedTaskPointName(ordered_task.GetFactory().GetType(tp)));
+  /* OZ editors are created after Alternates / Score exit, so keep
+     those actions last in TabStop order (Up/Down reach Radius). */
+  optional_starts.BringToBottom();
+  score_exit.BringToBottom();
+
+  ApplyLayout(position);
+}
+
+void
+TaskPointWidget::RefreshControls() noexcept
+{
+  map.Invalidate();
+
+  const OrderedTaskPoint &tp = ordered_task.GetPoint(active_index);
+
+  LoadTypeField();
 
   previous_button->SetEnabled(active_index > 0);
   next_button->SetEnabled(active_index < (ordered_task.TaskSize() - 1));
@@ -356,12 +443,17 @@ TaskPointWidget::RefreshView()
 
   dialog.SetCaption(type_buffer);
 
-  {
-    StaticString<100> buffer;
-    buffer.Format("%s %s", name_prefix_buffer.c_str(),
-                  tp.GetWaypoint().name.c_str());
-    waypoint_name.SetText(buffer);
-  }
+  StaticString<100> buffer;
+  buffer.Format("%s %s", name_prefix_buffer.c_str(),
+                tp.GetWaypoint().name.c_str());
+  waypoint_name.SetText(buffer);
+}
+
+void
+TaskPointWidget::RefreshView() noexcept
+{
+  RecreateOzForm();
+  RefreshControls();
 }
 
 bool
@@ -447,15 +539,55 @@ TaskPointWidget::OnRelocateClicked()
   RefreshView();
 }
 
-inline void
-TaskPointWidget::OnTypeClicked()
+void
+TaskPointWidget::LoadTypeField() noexcept
 {
-  if (dlgTaskPointType(ordered_task, active_index)) {
-    ordered_task.ClearName();
-    ordered_task.UpdateGeometry();
-    task_modified = true;
-    RefreshView();
+  loading_type = true;
+
+  DataFieldEnum &df = *(DataFieldEnum *)type_field.GetDataField();
+  df.ClearChoices();
+  df.EnableItemHelp(true);
+
+  AbstractTaskFactory &factory = ordered_task.GetFactory();
+  const LegalPointSet valid = factory.GetValidTypes(active_index);
+  for (unsigned i = 0; i < LegalPointSet::N; ++i) {
+    const auto type = TaskPointFactoryType(i);
+    if (!valid.Contains(type))
+      continue;
+
+    df.addEnumText(OrderedTaskPointName(type), (unsigned)type,
+                   OrderedTaskPointDescription(type));
   }
+
+  df.SetValue(factory.GetType(ordered_task.GetPoint(active_index)));
+  type_field.RefreshDisplay();
+
+  loading_type = false;
+}
+
+void
+TaskPointWidget::OnModified(DataField &df) noexcept
+{
+  if (loading_type || &df != type_field.GetDataField())
+    return;
+
+  AbstractTaskFactory &factory = ordered_task.GetFactory();
+  const auto &old_point = ordered_task.GetPoint(active_index);
+  const auto type =
+    TaskPointFactoryType(((DataFieldEnum &)df).GetValue());
+  if (type == factory.GetType(old_point))
+    return;
+
+  auto point = factory.CreateMutatedPoint(old_point, type);
+  if (point == nullptr || !factory.Replace(*point, active_index, true)) {
+    LoadTypeField();
+    return;
+  }
+
+  ordered_task.ClearName();
+  ordered_task.UpdateGeometry();
+  task_modified = true;
+  RefreshView();
 }
 
 inline void
@@ -498,6 +630,26 @@ TaskPointWidget::OnModified([[maybe_unused]] ObservationZoneEditWidget &widget) 
 {
   ReadValues();
   map.Invalidate();
+}
+
+bool
+TaskPointWidget::KeyPress(unsigned key_code) noexcept
+{
+  switch (key_code) {
+  case KEY_LEFT:
+    if (active_index == 0)
+      return false;
+    OnPreviousClicked();
+    return true;
+
+  case KEY_RIGHT:
+    if (active_index >= ordered_task.TaskSize() - 1)
+      return false;
+    OnNextClicked();
+    return true;
+  }
+
+  return false;
 }
 
 bool

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -198,7 +198,7 @@ FormKeyDown(unsigned key_code)
     }
   }
 
-  if (key_code == KEY_BACK) {
+  if (key_code == KEY_BACK || key_code == KEY_F1) {
     DoBackspace();
     return true;
   }
@@ -269,6 +269,24 @@ TouchTextEntry(char *text, size_t width,
   WindowStyle button_style;
   button_style.TabStop();
 
+  /* Create the soft keyboard before OK/Cancel/Clear so
+     FocusFirstControl (dialog default focus) lands on a key and the
+     cursor keys can navigate immediately. */
+  KeyboardWidget keyboard(look.button, FormCharacter, !accb,
+                          default_shift_state);
+
+  keyboard.Initialise(client_area, L.keyboard);
+  keyboard.Prepare(client_area, L.keyboard);
+  keyboard.Show(L.keyboard);
+
+  kb = &keyboard;
+
+  Button backspace_button(client_area, look.button, "<-",
+                          L.backspace,
+                          button_style, [](){ OnBackspace(); });
+
+  textentry_backspace = &backspace_button;
+
   Button ok_button(client_area, look.button, _("OK"),
                    L.ok,
                    button_style, form.MakeModalResultCallback(mrOK));
@@ -284,21 +302,6 @@ TouchTextEntry(char *text, size_t width,
                       button_style,
                       [](){ ClearText(); });
   textentry_clear = &clear_button;
-
-  KeyboardWidget keyboard(look.button, FormCharacter, !accb,
-                          default_shift_state);
-
-  keyboard.Initialise(client_area, L.keyboard);
-  keyboard.Prepare(client_area, L.keyboard);
-  keyboard.Show(L.keyboard);
-
-  kb = &keyboard;
-
-  Button backspace_button(client_area, look.button, "<-",
-                          L.backspace,
-                          button_style, [](){ OnBackspace(); });
-
-  textentry_backspace = &backspace_button;
 
   form.SetClientLayoutFunction([&]() {
     const PixelRect rc = client_area.GetClientRect();

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -154,10 +154,10 @@ class WaypointFilterWidget;
 class WaypointListWidget
   : public ListWidget, public DataFieldListener,
     NullBlackboardListener {
-  Waypoints &way_points;
   TwoTextRowsRenderer row_renderer;
 
 protected:
+  Waypoints &way_points;
   WndForm &dialog;
   WaypointList items;
 
@@ -195,6 +195,13 @@ public:
   void UpdateList();
 
   virtual void OnWaypointListEnter();
+
+  /**
+   * Open waypoint details for the cursor row (Details button / F1).
+   * Unlike #OnWaypointListEnter in the select dialog, this does not
+   * confirm the selection.
+   */
+  virtual void ShowDetails() noexcept;
 
   WaypointPtr GetCursorObject() const {
     unsigned i = GetList().GetCursorIndex();
@@ -261,6 +268,7 @@ public:
      allow_navigation(_allow_navigation), allow_edit(_allow_edit) {}
 
   void OnWaypointListEnter() override;
+  void ShowDetails() noexcept override;
 };
 
 class WaypointFilterWidget : public RowFormWidget {
@@ -286,6 +294,7 @@ public:
 class WaypointListButtons : public RowFormWidget {
   WndForm &dialog;
   WaypointListWidget *list;
+  Button *details_button = nullptr;
 
 public:
   WaypointListButtons(const DialogLook &look, WndForm &_dialog)
@@ -297,11 +306,20 @@ public:
 
   /* virtual methods from class Widget */
   void Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_unused]] const PixelRect &rc) noexcept override {
-    AddButton(_("Details"), [this](){
-      list->OnWaypointListEnter();
+    details_button = AddButton(_("Details"), [this](){
+      list->ShowDetails();
     });
 
     AddButton(_("Close"), dialog.MakeModalResultCallback(mrCancel));
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    if (key_code == KEY_F1 && details_button != nullptr) {
+      details_button->Click();
+      return true;
+    }
+
+    return false;
   }
 };
 
@@ -647,6 +665,20 @@ WaypointListWidget::OnWaypointListEnter()
 }
 
 void
+WaypointListWidget::ShowDetails() noexcept
+{
+  auto waypoint = GetCursorObject();
+  if (waypoint == nullptr)
+    return;
+
+  /* Same browse semantics as Alternates: details may Goto/edit; if that
+     commits a state change, dismiss this picker like a successful select. */
+  if (dlgWaypointDetailsShowModalForBrowseParent(
+        &way_points, std::move(waypoint), true, true))
+    dialog.SetModalResult(mrOK);
+}
+
+void
 WaypointListPersistentWidget::OnWaypointListEnter()
 {
   if (items.empty()) {
@@ -654,10 +686,18 @@ WaypointListPersistentWidget::OnWaypointListEnter()
     return;
   }
 
+  ShowDetails();
+}
+
+void
+WaypointListPersistentWidget::ShowDetails() noexcept
+{
+  auto waypoint = GetCursorObject();
+  if (waypoint == nullptr)
+    return;
+
   if (dlgWaypointDetailsShowModalForBrowseParent(
-        data_components->waypoints.get(),
-        WaypointPtr(items[GetList().GetCursorIndex()].waypoint), allow_navigation,
-        allow_edit))
+        &way_points, std::move(waypoint), allow_navigation, allow_edit))
     dialog.SetModalResult(mrOK);
 }
 

--- a/src/Dialogs/WifiDialog.cpp
+++ b/src/Dialogs/WifiDialog.cpp
@@ -220,17 +220,17 @@ public:
      backend_(std::move(_backend)) {}
 
   void CreateButtons(WidgetDialog &dialog) {
-    scan_button = dialog.AddButton(_("Scan"), [this](){
-      Scan(true, true);
-      scan_timer.Schedule(kWifiAutoScanInterval);
-    });
-
     connect_button = dialog.AddButton(_("Connect"), [this](){
       try {
         Connect();
       } catch (...) {
         ShowWifiError(std::current_exception(), _("Error"));
       }
+    });
+
+    scan_button = dialog.AddButton(_("Scan"), [this](){
+      Scan(true, true);
+      scan_timer.Schedule(kWifiAutoScanInterval);
     });
 
     forget_button = dialog.AddButton(_("Forget"), [this](){
@@ -240,7 +240,6 @@ public:
         ShowWifiError(std::current_exception(), _("Error"));
       }
     });
-
   }
 
   void UpdateButtons();
@@ -510,9 +509,9 @@ ShowWifiDialog(UniqueWifiBackend backend)
   TWidgetDialog<WifiListWidget>
     dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
            look, _("WiFi"));
-  dialog.AddButton(_("Close"), mrOK);
   dialog.SetWidget(std::move(backend));
   dialog.GetWidget().CreateButtons(dialog);
+  dialog.AddButton(_("Close"), mrOK);
   dialog.EnableCursorSelection();
   dialog.ShowModal();
 }

--- a/src/Dialogs/dlgInfoBoxAccess.cpp
+++ b/src/Dialogs/dlgInfoBoxAccess.cpp
@@ -19,6 +19,7 @@
 #include "Language/Language.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <stdio.h>
 
@@ -103,23 +104,38 @@ dlgInfoBoxAccessShowModeless(const int id, const InfoBoxPanel *panels)
   tab_widget.AddTab(std::make_unique<ActionWidget>(dialog.MakeModalResultCallback(mrOK)),
                     _("Close"));
 
-  const PixelRect client_rc = dialog.GetClientAreaWindow().GetClientRect();
-  const PixelSize max_size = tab_widget.GetMaximumSize();
-  if (max_size.height < client_rc.GetHeight()) {
-    form_rc.top += client_rc.GetHeight() - max_size.height;
-    dialog.Move(form_rc);
-  }
+  /* Dock to the bottom of the map area and lift map overlays by the
+     visible dialog height.  Size to the *current* tab so a short page
+     (Altitude → Simulator) does not reserve space for a taller sibling
+     (Setup); re-dock when the user flips tabs. */
+  const auto dock_dialog = [&dialog, &tab_widget]() noexcept {
+    PixelRect rc = InfoBoxManager::layout.remaining;
+    const PixelSize content = tab_widget.GetCurrentMaximumSize();
+    const PixelSize dialog_size = dialog.ClientAreaToDialogSize(content);
+    if (dialog_size.height < rc.GetHeight())
+      rc.top = rc.bottom - (int)dialog_size.height;
+    dialog.Move(rc);
+
+    GlueMapWindow *map = UIGlobals::GetMap();
+    if (map == nullptr)
+      return;
+
+    const PixelRect map_rc = map->GetPosition();
+    const PixelRect dlg_rc = dialog.GetPosition();
+    if (dlg_rc.top < map_rc.bottom && dlg_rc.bottom > map_rc.top) {
+      const unsigned margin =
+        (unsigned)(map_rc.bottom - std::max(dlg_rc.top, map_rc.top));
+      map->SetBottomMargin(margin);
+    } else
+      map->SetBottomMargin(0);
+  };
+
+  tab_widget.SetPageFlippedCallback(dock_dialog);
+  dock_dialog();
 
   dialog.SetModeless();
 
-  /* When InfoBox panel opens, adjust bottom margin to make room */
   GlueMapWindow *map = UIGlobals::GetMap();
-  if (map != nullptr) {
-    unsigned dialog_height = form_rc.GetHeight();
-
-    if (dialog_height > 0)
-      map->SetBottomMargin(dialog_height);
-  }
 
   int result = dialog.ShowModal();
 

--- a/src/Dialogs/dlgSimulatorPrompt.cpp
+++ b/src/Dialogs/dlgSimulatorPrompt.cpp
@@ -7,6 +7,7 @@
 #include "Widget/WindowWidget.hpp"
 #include "UIGlobals.hpp"
 #include "Simulator.hpp"
+#include "ui/event/KeyCode.hpp"
 
 #ifdef SIMULATOR_AVAILABLE
 
@@ -30,6 +31,23 @@ public:
                                                      true);
     w->Create(parent, rc, style);
     SetWindow(std::move(w));
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    /* Bitmap buttons have no visible focus; activate immediately. */
+    auto &prompt = (SimulatorPromptWindow &)GetWindow();
+    switch (key_code) {
+    case KEY_LEFT:
+      prompt.SelectFly();
+      return true;
+
+    case KEY_RIGHT:
+      prompt.SelectSimulator();
+      return true;
+
+    default:
+      return false;
+    }
   }
 };
 

--- a/src/Form/Button.cpp
+++ b/src/Form/Button.cpp
@@ -262,13 +262,14 @@ Button::GetState() const noexcept
     return ButtonState::DISABLED;
   else if (down)
     return ButtonState::PRESSED;
-  /* #ButtonPanel cursor selection uses `look.selected` (bright); that
-     must come before #HasFocus (`look.focused`) so the current action
-     is not downgraded when the list still holds focus. */
-  else if (HasCursorKeys() && selected)
-    return ButtonState::SELECTED;
+  /* Real keyboard focus uses `look.focused`.  Armed cursor-selection
+     (list still focused, Left/Right chose an action) uses
+     `look.selected` so the list cursor and action stay visible
+     together — same model as Alternates. */
   else if (HasCursorKeys() && HasFocus())
     return ButtonState::FOCUSED;
+  else if (HasCursorKeys() && selected)
+    return ButtonState::SELECTED;
   else
     return ButtonState::ENABLED;
 }

--- a/src/Form/ButtonPanel.cpp
+++ b/src/Form/ButtonPanel.cpp
@@ -109,16 +109,23 @@ ButtonPanel::VerticalRange(PixelRect rc, unsigned start, unsigned end) noexcept
   const unsigned width = RangeMaxWidth(start, end);
   const unsigned total_height = rc.GetHeight();
   const unsigned max_height = n * Layout::GetMaximumControlHeight();
-  const unsigned row_height =
-    std::max(1u, std::min(total_height, max_height) / n);
+  /* Cap the stack so landscape left bars stay control-sized; only the
+     few leftover pixels from used_height / n go to the last button. */
+  const unsigned used_height = std::min(total_height, max_height);
 
-  auto button_rc = rc.CutLeftSafe(width).TopAligned(row_height);
+  auto column_rc = rc.CutLeftSafe(width);
 
+  /* Proportional tops/bottoms keep every rect non-inverted even when
+     used_height < n (integer division would otherwise overrun). */
   for (unsigned i = start; i < end; ++i) {
-    buttons[i]->Move(button_rc);
+    const unsigned idx = i - start;
+    PixelRect button_rc = column_rc;
+    button_rc.top = column_rc.top + (int)(used_height * idx / n);
+    button_rc.bottom = column_rc.top + (int)(used_height * (idx + 1) / n);
+    if (button_rc.bottom <= button_rc.top)
+      button_rc.bottom = button_rc.top + 1;
 
-    button_rc.top = button_rc.bottom;
-    button_rc.bottom += row_height;
+    buttons[i]->Move(button_rc);
   }
 
   return rc;
@@ -139,15 +146,19 @@ ButtonPanel::HorizontalRange(PixelRect rc,
       ? max_row_height
       : std::max(Layout::GetMinimumControlHeight(),
                  total_height / 2));
-  const unsigned width = std::max(1u, total_width / n);
+  auto row_rc = rc.CutBottomSafe(row_height);
 
-  auto button_rc = rc.CutBottomSafe(row_height).LeftAligned(width);
-
+  /* Proportional left/right absorbs the total_width % n remainder into
+     later buttons (no empty strip) and avoids inverted rects. */
   for (unsigned i = start; i < end; ++i) {
-    buttons[i]->Move(button_rc);
+    const unsigned idx = i - start;
+    PixelRect button_rc = row_rc;
+    button_rc.left = row_rc.left + (int)(total_width * idx / n);
+    button_rc.right = row_rc.left + (int)(total_width * (idx + 1) / n);
+    if (button_rc.right <= button_rc.left)
+      button_rc.right = button_rc.left + 1;
 
-    button_rc.left = button_rc.right;
-    button_rc.right += width;
+    buttons[i]->Move(button_rc);
   }
 
   return rc;

--- a/src/Form/ButtonPanel.hpp
+++ b/src/Form/ButtonPanel.hpp
@@ -57,8 +57,7 @@ public:
 
   /**
    * Called from #Button::OnSetFocus: move #selected_index to the
-   * focused #Button so only one of #ButtonState::SELECTED / FOCUSED
-   * is visible when cursor key mode is on.
+   * focused #Button so cursor-selection stays aligned with focus.
    */
   void OnButtonGainedFocus(Button &b) noexcept;
 

--- a/src/Form/Frame.cpp
+++ b/src/Form/Frame.cpp
@@ -6,6 +6,8 @@
 #include "Screen/Layout.hpp"
 #include "Look/DialogLook.hpp"
 
+#include <algorithm>
+
 WndFrame::WndFrame(const DialogLook &_look) noexcept
   :look(_look),
    text_color(look.text_color)
@@ -61,6 +63,14 @@ WndFrame::OnPaint(Canvas &canvas) noexcept
 {
   if (HaveClipping())
     canvas.Clear(look.background_brush);
+
+  if (top_separator) {
+    /* Filled strip instead of DrawLine at y=0: OpenGL often clips a
+       1px stroke on the window edge. */
+    const int thickness = (int)std::max(1u, Layout::ScaleFinePenWidth(1));
+    canvas.DrawFilledRectangle({0, 0, (int)canvas.GetWidth(), thickness},
+                               look.dark_mode ? COLOR_GRAY : COLOR_BLACK);
+  }
 
   canvas.SetTextColor(text_color);
   canvas.SetBackgroundTransparent();

--- a/src/Form/Frame.cpp
+++ b/src/Form/Frame.cpp
@@ -61,7 +61,9 @@ WndFrame::GetTextHeight() const noexcept
 void
 WndFrame::OnPaint(Canvas &canvas) noexcept
 {
-  if (HaveClipping())
+  if (background_color)
+    canvas.Clear(*background_color);
+  else if (HaveClipping())
     canvas.Clear(look.background_brush);
 
   if (top_separator) {

--- a/src/Form/Frame.hpp
+++ b/src/Form/Frame.hpp
@@ -20,6 +20,8 @@ class WndFrame : public PaintWindow {
 
   std::string text;
 
+  bool top_separator = false;
+
 public:
   explicit WndFrame(const DialogLook &look) noexcept;
 
@@ -42,6 +44,10 @@ public:
 
   void SetTextColor(const Color &color) noexcept {
     text_color = color;
+  }
+
+  void SetTopSeparator(bool value = true) noexcept {
+    top_separator = value;
   }
 
   [[gnu::pure]]

--- a/src/Form/Frame.hpp
+++ b/src/Form/Frame.hpp
@@ -7,6 +7,7 @@
 #include "ui/canvas/Color.hpp"
 #include "Renderer/TextRenderer.hpp"
 
+#include <optional>
 #include <string>
 
 struct DialogLook;
@@ -15,6 +16,8 @@ class WndFrame : public PaintWindow {
   const DialogLook &look;
 
   Color text_color;
+
+  std::optional<Color> background_color;
 
   TextRenderer text_renderer;
 
@@ -44,6 +47,14 @@ public:
 
   void SetTextColor(const Color &color) noexcept {
     text_color = color;
+  }
+
+  /**
+   * Fill the frame with this colour instead of the look's background,
+   * e.g. to mark a message as a warning.
+   */
+  void SetBackgroundColor(const Color &color) noexcept {
+    background_color = color;
   }
 
   void SetTopSeparator(bool value = true) noexcept {

--- a/src/Form/GridView.cpp
+++ b/src/Form/GridView.cpp
@@ -588,47 +588,64 @@ GridView::GetNextItemIndex(unsigned currIndex, Direction direction) const
   return nextPos;
 }
 
+bool
+GridView::IsAtRowEdge(signed focus_pos, Direction direction) const noexcept
+{
+  const PageBounds bounds = GetPageBoundsForIndex(focus_pos);
+  const PagePosition pos = GetPagePosition(focus_pos);
+  const unsigned row_end = std::min(bounds.pageStart
+                                      + (pos.rowNum + 1) * num_columns,
+                                    bounds.pageEnd);
+
+  if (direction == Direction::LEFT)
+    return pos.colNum == 0;
+
+  /* Last column, or last cell of a short final row. */
+  return pos.colNum + 1 >= num_columns ||
+    focus_pos + 1 >= (signed)row_end;
+}
+
 void
 GridView::MoveFocus(Direction direction)
 {
-  signed focusPos = GetIndexOfItemInFocus();
+  signed focus_pos = GetIndexOfItemInFocus();
 
-  if (focusPos == -1) {
+  if (focus_pos == -1) {
     ShowNextPage(direction);
     return;
   }
 
-  unsigned pageSize = GetPageSize();
-  bool singlePage = (items.size() <= pageSize);
-
-  signed newFocusPos = -1;
+  signed new_focus_pos = -1;
 
   if (direction == Direction::LEFT || direction == Direction::RIGHT) {
-    newFocusPos = FindNextInRow(focusPos, direction, singlePage);
-    
-    if (newFocusPos == -1) {
-      if (singlePage) {
+    /* Prefer an enabled neighbour in-row without wrapping. */
+    new_focus_pos = FindNextInRow(focus_pos, direction, false);
+    if (new_focus_pos == -1) {
+      if (!IsAtRowEdge(focus_pos, direction))
+        return; /* disabled mid-row: stay put */
+
+      const bool single_page = items.size() <= GetPageSize();
+      if (single_page) {
+        new_focus_pos = FindNextInRow(focus_pos, direction, true);
+        if (new_focus_pos == -1)
+          return;
+      } else {
+        ShowNextPage(direction);
         return;
       }
-      ShowNextPage(direction);
-      return;
     }
   } else {
-    newFocusPos = FindNextInColumn(focusPos, direction, true);
-    
-    if (newFocusPos == -1) {
+    new_focus_pos = FindNextInColumn(focus_pos, direction, true);
+    if (new_focus_pos == -1)
       return;
-    }
   }
 
-  if (newFocusPos == focusPos) {
+  if (new_focus_pos == focus_pos || new_focus_pos < 0 ||
+      !IsItemValid(new_focus_pos))
     return;
-  }
 
-  if (newFocusPos >= 0 && IsItemValid(newFocusPos)) {
-    items[newFocusPos]->SetFocus();
-    RefreshLayout();
-  }
+  items[new_focus_pos]->SetFocus();
+  RefreshLayout();
 }
 
 void

--- a/src/Form/GridView.hpp
+++ b/src/Form/GridView.hpp
@@ -104,6 +104,10 @@ private:
   
   signed FindNextInRow(signed currIndex, Direction direction, bool cycle) const noexcept;
   signed FindNextInColumn(signed currIndex, Direction direction, bool cycle) const noexcept;
+
+  /** True at the first/last cell of the focused item's row. */
+  [[gnu::pure]]
+  bool IsAtRowEdge(signed focus_pos, Direction direction) const noexcept;
   
   struct PageBounds {
     unsigned pageStart;

--- a/src/Form/TabMenuDisplay.cpp
+++ b/src/Form/TabMenuDisplay.cpp
@@ -225,16 +225,24 @@ TabMenuDisplay::OnResize(PixelSize new_size) noexcept
 bool
 TabMenuDisplay::OnKeyCheck(unsigned key_code) const noexcept
 {
- switch (key_code) {
+  switch (key_code) {
+  case KEY_RETURN:
+  case KEY_LEFT:
+  case KEY_RIGHT:
+    return true;
 
- case KEY_RETURN:
- case KEY_LEFT:
- case KEY_RIGHT:
-   return true;
+  case KEY_DOWN:
+    /* Only claim Down while another menu item follows; at the last
+       item, let the dialog move focus to Close / arrows. */
+    return cursor + 1 < GetNumPages();
 
- default:
-   return false;
- }
+  case KEY_UP:
+    /* Same for Up at the first item. */
+    return cursor > 0;
+
+  default:
+    return false;
+  }
 }
 
 bool
@@ -246,10 +254,12 @@ TabMenuDisplay::OnKeyDown(unsigned key_code) noexcept
     return true;
 
   case KEY_RIGHT:
+  case KEY_DOWN:
     HighlightNext();
     return true;
 
   case KEY_LEFT:
+  case KEY_UP:
     HighlightPrevious();
     return true;
 

--- a/src/Gauge/LogoView.cpp
+++ b/src/Gauge/LogoView.cpp
@@ -20,11 +20,14 @@ LogoView::LogoView() noexcept try
    title(IDB_TITLE), big_title(IDB_TITLE_HD), huge_title(IDB_TITLE_UHD)
 {
 #ifndef USE_WIN32_RESOURCES
-  /* Load RGBA logo variants for dark mode (transparent background) */
+  /* Load RGBA logo variants (transparent background) */
   logo_rgba.Load(IDB_LOGO_RGBA);
   big_logo_rgba.Load(IDB_LOGO_HD_RGBA);
   huge_logo_rgba.Load(IDB_LOGO_UHD_RGBA);
-  /* Load white title variants for dark mode */
+  /* Transparent title for light backgrounds; white for dark mode */
+  title_rgba.Load(IDB_TITLE_RGBA);
+  big_title_rgba.Load(IDB_TITLE_HD_RGBA);
+  huge_title_rgba.Load(IDB_TITLE_UHD_RGBA);
   white_title.Load(IDB_TITLE_HD_WHITE);
   huge_white_title.Load(IDB_TITLE_UHD_WHITE);
 #endif
@@ -132,15 +135,15 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
     bitmap_title = &title;
   }
 
-  /* In dark mode, use RGBA logos (transparent background) if available */
-  if (dark_mode) {
-    if (bitmap_logo == &huge_logo && huge_logo_rgba.IsDefined())
-      bitmap_logo = &huge_logo_rgba;
-    else if (bitmap_logo == &big_logo && big_logo_rgba.IsDefined())
-      bitmap_logo = &big_logo_rgba;
-    else if (bitmap_logo == &logo && logo_rgba.IsDefined())
-      bitmap_logo = &logo_rgba;
-  }
+  /* Prefer RGBA logos (transparent background).  Opaque BMP/PNG
+     variants have a white fill that shows as a rectangle on the
+     parchment dialog background and on dark themes. */
+  if (bitmap_logo == &huge_logo && huge_logo_rgba.IsDefined())
+    bitmap_logo = &huge_logo_rgba;
+  else if (bitmap_logo == &big_logo && big_logo_rgba.IsDefined())
+    bitmap_logo = &big_logo_rgba;
+  else if (bitmap_logo == &logo && logo_rgba.IsDefined())
+    bitmap_logo = &logo_rgba;
 
   // Determine logo size
   PixelSize logo_size = bitmap_logo->GetSize();
@@ -195,19 +198,26 @@ LogoView::draw(Canvas &canvas, const PixelRect &rc,
   // Draw 'XCSoar N.N' title
   if (orientation != LogoViewOrientation::SQUARE) {
     const Bitmap *draw_title = bitmap_title;
-#ifdef ENABLE_OPENGL
-    /* On OpenGL, use white title variants for dark mode
-       (they have alpha and composite correctly).
-       On non-OpenGL, keep the standard (black) title since
-       the memory canvas composites alpha against white. */
+#ifndef USE_WIN32_RESOURCES
+    /* Opaque title BMPs have a white fill.  Prefer matching-size RGBA
+       variants so the title composites over parchment / dark dialog
+       backgrounds (OpenGL and memory canvas). */
     if (dark_mode) {
       if (bitmap_title == &huge_title &&
           huge_white_title.IsDefined())
         draw_title = &huge_white_title;
       else if (white_title.IsDefined())
         draw_title = &white_title;
-    }
-
+    } else if (bitmap_title == &huge_title &&
+               huge_title_rgba.IsDefined())
+      draw_title = &huge_title_rgba;
+    else if (bitmap_title == &big_title &&
+             big_title_rgba.IsDefined())
+      draw_title = &big_title_rgba;
+    else if (bitmap_title == &title && title_rgba.IsDefined())
+      draw_title = &title_rgba;
+#endif
+#ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
 #endif
     canvas.Stretch(title_position, title_size, *draw_title);

--- a/src/Gauge/LogoView.hpp
+++ b/src/Gauge/LogoView.hpp
@@ -12,6 +12,7 @@ class Canvas;
 class LogoView {
   Bitmap logo, big_logo, huge_logo, title, big_title, huge_title;
   Bitmap logo_rgba, big_logo_rgba, huge_logo_rgba;
+  Bitmap title_rgba, big_title_rgba, huge_title_rgba;
   Bitmap white_title, huge_white_title;
 
 #ifndef USE_GDI

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -182,6 +182,7 @@ void eventSendNMEAPort2(const char *misc);
 void eventSetup(const char *misc);
 void eventSnailTrail(const char *misc);
 void eventAirSpace(const char *misc); // VENTA3
+void eventAirspaceLabels(const char *misc);
 void eventSounds(const char *misc);
 void eventStatus(const char *misc);
 void eventStatusMessage(const char *misc);

--- a/src/Input/InputEventsAirspace.cpp
+++ b/src/Input/InputEventsAirspace.cpp
@@ -17,6 +17,9 @@
 #include "Dialogs/Airspace/Airspace.hpp"
 #include "Dialogs/Airspace/AirspaceWarningDialog.hpp"
 #include "NMEA/Aircraft.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
+#include "util/StringCompare.hxx"
 
 /*
  * This even currently toggles DrawAirSpace() and does nothing else.
@@ -58,6 +61,41 @@ InputEvents::eventAirSpace(const char *misc)
     return;
   }
 
+  ActionInterface::SendMapSettings(true);
+}
+
+void
+InputEvents::eventAirspaceLabels(const char *misc)
+{
+  AirspaceRendererSettings &settings =
+    CommonInterface::SetMapSettings().airspace;
+
+  const bool currently_on =
+    settings.label_selection == AirspaceRendererSettings::LabelSelection::ALL;
+
+  if (StringIsEqual(misc, "toggle")) {
+    settings.label_selection = currently_on
+      ? AirspaceRendererSettings::LabelSelection::NONE
+      : AirspaceRendererSettings::LabelSelection::ALL;
+    Message::AddMessage(currently_on
+                        ? _("Airspace labels hidden")
+                        : _("Airspace labels shown"));
+  } else if (StringIsEqual(misc, "off") || StringIsEqual(misc, "none")) {
+    settings.label_selection = AirspaceRendererSettings::LabelSelection::NONE;
+    Message::AddMessage(_("Airspace labels hidden"));
+  } else if (StringIsEqual(misc, "on") || StringIsEqual(misc, "all")) {
+    settings.label_selection = AirspaceRendererSettings::LabelSelection::ALL;
+    Message::AddMessage(_("Airspace labels shown"));
+  } else if (StringIsEqual(misc, "show")) {
+    Message::AddMessage(currently_on
+                        ? _("Airspace labels on")
+                        : _("Airspace labels off"));
+    return;
+  } else
+    return;
+
+  Profile::Set(ProfileKeys::AirspaceLabelSelection,
+               (int)settings.label_selection);
   ActionInterface::SendMapSettings(true);
 }
 

--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -58,6 +58,18 @@ static constexpr Color COLOR_ADMONITION_TIP =
 static constexpr Color COLOR_LIGHT_GREEN = Color(0x00, 0xc0, 0x00);
 
 /**
+ * Airspace warning list / map-item status badge colours.
+ */
+static constexpr Color COLOR_AIRSPACE_WARNING_INSIDE =
+  Color(254, 50, 50);
+static constexpr Color COLOR_AIRSPACE_WARNING_NEAR =
+  Color(254, 254, 50);
+static constexpr Color COLOR_AIRSPACE_WARNING_INSIDE_ACK =
+  Color(254, 100, 100);
+static constexpr Color COLOR_AIRSPACE_WARNING_NEAR_ACK =
+  Color(254, 254, 100);
+
+/**
  * XCTherm overlay palette.
  */
 static constexpr Color COLOR_XCTHERM_BLUE = Color(0x00, 0x00, 0xc8);

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -21,6 +21,9 @@
 #include "Look/GestureLook.hpp"
 #include "Input/InputEvents.hpp"
 #include "Renderer/MapScaleRenderer.hpp"
+#include "Components.hpp"
+#include "BackendComponents.hpp"
+#include "Replay/Replay.hpp"
 
 #include <algorithm> // for std::clamp()
 
@@ -157,18 +160,32 @@ GlueMapWindow::DrawGPSStatus(Canvas &canvas, const PixelRect &rc,
     // early exit
     return;
 
+  const Font &font = *look.overlay.overlay_font;
+  canvas.Select(font);
+
+  /* DrawMapScale paints the scale bar and the map-title line
+     (AUTO / Simulator / REPLAY / …) after this overlay.  Reserve that
+     band (and bottom_margin) so the GPS label sits above the title. */
+  const int scale_band = (int)font.GetCapitalHeight()
+    + (int)Layout::GetTextPadding();
+  const int title_band = (int)font.GetHeight()
+    + (int)Layout::GetTextPadding();
+  const int clear_bottom = rc.bottom - (int)bottom_margin
+    - scale_band - title_band - Layout::Scale(2);
+
+  const int row_height = std::max((int)icon->GetSize().height,
+                                  (int)font.GetHeight());
   PixelPoint p(rc.left + Layout::FastScale(2),
-               rc.bottom - Layout::FastScale(35));
+               clear_bottom - row_height);
   icon->Draw(canvas, p);
 
   p.x += icon->GetSize().width + Layout::FastScale(4);
-  p.y = rc.bottom - Layout::FastScale(34);
+  p.y = clear_bottom - (int)font.GetAscentHeight()
+    - ((row_height - (int)font.GetHeight()) / 2);
 
   TextInBoxMode mode;
   mode.shape = LabelShape::ROUNDED_BLACK;
 
-  const Font &font = *look.overlay.overlay_font;
-  canvas.Select(font);
   TextInBox(canvas, txt, p, mode, rc, nullptr);
 }
 
@@ -341,9 +358,14 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     buffer += " ";
   }
 
-  if (Basic().gps.replay)
-    buffer += "REPLAY ";
-  else if (Basic().gps.simulator) {
+  if (Basic().gps.replay) {
+    if (backend_components != nullptr &&
+        backend_components->replay != nullptr)
+      buffer.AppendFormat(_("REPLAY %.0fx "),
+                          backend_components->replay->GetTimeScale());
+    else
+      buffer += _("REPLAY ");
+  } else if (Basic().gps.simulator) {
     buffer += _("Simulator");
     buffer += " ";
   }

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -395,6 +395,10 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
     return GetMapSettings().terrain.enable ? _("Hide") : _("Show");
   } else if (name == "AirspaceToggleActionName") {
     return GetMapSettings().airspace.enable ? _("Hide") : _("Show");
+  } else if (name == "AirspaceLabelsToggleActionName") {
+    return GetMapSettings().airspace.label_selection
+      == AirspaceRendererSettings::LabelSelection::ALL
+      ? _("Hide") : _("Show");
   } else if (name == "DistanceRingsToggleActionName") {
     return GetMapSettings().distance_rings_enabled ? _("Hide") : _("Show");
   } else if (name == "MapLabelsToggleActionName") {

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -7,6 +7,7 @@
 #include "Audio/Sound.hpp"
 #include "Dialogs/Airspace/AirspaceWarningDialog.hpp"
 #include "ui/event/Idle.hpp"
+#include "Look/Colors.hpp"
 #include "PageActions.hpp"
 #include "Widget/QuestionWidget.hpp"
 #include "Language/Language.hpp"
@@ -46,6 +47,24 @@ class AirspaceWarningWidget final
                                         2).c_str());
 
     return buffer;
+  }
+
+  /**
+   * Mark the message with the same colours the airspace warning list
+   * uses for its Inside / Near badge.
+   */
+  void UpdateMessageColors() noexcept {
+    if (!HasColors())
+      /* greyscale and e-paper displays: the plain message keeps more
+         contrast than a dithered fill */
+      return;
+
+    /* Black on both fills: 5.7:1 on Inside red and 19.4:1 on Near
+       yellow, whereas white would only reach 3.7:1 on the red. */
+    SetMessageColors(state == AirspaceWarning::WARNING_INSIDE
+                     ? COLOR_AIRSPACE_WARNING_INSIDE
+                     : COLOR_AIRSPACE_WARNING_NEAR,
+                     COLOR_BLACK);
   }
 
 public:
@@ -91,6 +110,8 @@ public:
     AddButton(_("More"), [this](){
       dlgAirspaceWarningsShowModal(manager);
     });
+
+    UpdateMessageColors();
   }
 
   ~AirspaceWarningWidget() noexcept {
@@ -106,6 +127,7 @@ public:
 
     state = _state;
     SetMessage(MakeMessage(*airspace, state, solution));
+    UpdateMessageColors();
     return true;
   }
 };

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -8,6 +8,11 @@
 #include "Dialogs/Airspace/AirspaceWarningDialog.hpp"
 #include "ui/event/Idle.hpp"
 #include "Look/Colors.hpp"
+#include "Look/DialogLook.hpp"
+#include "UIGlobals.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/AnyCanvas.hpp"
+#include "ui/canvas/Font.hpp"
 #include "PageActions.hpp"
 #include "Widget/QuestionWidget.hpp"
 #include "Language/Language.hpp"
@@ -16,6 +21,7 @@
 #include "Engine/Airspace/AbstractAirspace.hpp"
 #include "Airspace/ProtectedAirspaceWarningManager.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "Formatter/UserUnits.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "LogFile.hpp"
@@ -33,20 +39,95 @@ class AirspaceWarningWidget final
   const ConstAirspacePtr airspace;
   AirspaceWarning::State state;
 
+  /** state and airspace name, e.g. "Near: CTA MARSEILLE 7" */
+  StaticString<192> name_text;
+
+  /** distance and time until the intercept; empty while inside */
+  StaticString<64> details_text;
+
+  /** the message as shown, composed by Compose() */
   StaticString<256> buffer;
 
-  [[gnu::pure]]
-  const char *MakeMessage(const AbstractAirspace &airspace,
-                           AirspaceWarning::State state,
-                           const AirspaceInterceptSolution &solution) noexcept {
-    if (state == AirspaceWarning::WARNING_INSIDE)
-      buffer.Format("%s: %s", _("Inside airspace"), airspace.GetName());
-    else
-      buffer.Format("%s: %s (%s)", _("Near airspace"), airspace.GetName(),
-                    FormatTimespanSmart(solution.elapsed_time,
-                                        2).c_str());
+  /** width available for the message text, known from Prepare() */
+  unsigned message_width = 0;
 
-    return buffer;
+  /**
+   * True when the name plus the current distance/time do not fit on
+   * one line.  Locked after DecideLayout() so later updates (which
+   * only shrink those values) cannot change the banner height.
+   */
+  bool two_lines = false;
+
+  /**
+   * Format the two message parts.  The labels match the Inside / Near
+   * badges of the airspace warning list.
+   */
+  void MakeMessage(const AbstractAirspace &airspace,
+                   AirspaceWarning::State state,
+                   const AirspaceInterceptSolution &solution) noexcept {
+    if (state == AirspaceWarning::WARNING_INSIDE) {
+      name_text.Format("%s: %s", _("Inside"), airspace.GetName());
+      details_text.clear();
+      return;
+    }
+
+    name_text.Format("%s: %s", _("Near"), airspace.GetName());
+
+    if (solution.distance > 0)
+      details_text.Format("%s  ",
+                          FormatUserDistanceSmart(solution.distance).c_str());
+    else if (solution.IsValid()) {
+      /* the airspace is right above or below us, so the intercept has
+         no horizontal distance: show the vertical one instead */
+      char relative_altitude[32];
+      FormatRelativeUserAltitude(solution.altitude
+                                 - CommonInterface::Basic().nav_altitude,
+                                 relative_altitude);
+      details_text.Format("%s  ", relative_altitude);
+    } else
+      details_text.clear();
+
+    details_text.AppendFormat("%s",
+                              FormatTimespanSmart(solution.elapsed_time,
+                                                  2).c_str());
+  }
+
+  /**
+   * The bottom area spans the full width, and WndFrame insets the text
+   * by the padding on both sides.
+   */
+  void SetMessageWidth(const PixelRect &rc) noexcept {
+    message_width = rc.GetWidth() - 2 * Layout::GetTextPadding();
+  }
+
+  /**
+   * Decide one vs two lines from the airspace name and the current
+   * distance/time.  Those values shrink as the intercept approaches,
+   * so measuring them once (and locking the result) is enough; a
+   * synthetic "long" timespan was the wrong shape - FormatTimespanSmart
+   * with two tokens is wider for "59 min 59 sec" than for "4 days 3 h".
+   */
+  void DecideLayout() noexcept {
+    if (details_text.empty() || message_width == 0) {
+      two_lines = false;
+      return;
+    }
+
+    AnyCanvas canvas;
+    canvas.Select(UIGlobals::GetDialogLook().text_font);
+
+    StaticString<256> one_line;
+    one_line.Format("%s  %s", name_text.c_str(), details_text.c_str());
+    two_lines = canvas.CalcTextWidth(one_line) > message_width;
+  }
+
+  void Compose() noexcept {
+    if (details_text.empty())
+      buffer = name_text;
+    else if (two_lines)
+      buffer.Format("%s\n%s", name_text.c_str(), details_text.c_str());
+    else
+      buffer.Format("%s  %s", name_text.c_str(), details_text.c_str());
   }
 
   /**
@@ -73,9 +154,13 @@ public:
                         ConstAirspacePtr _airspace,
                         AirspaceWarning::State _state,
                         const AirspaceInterceptSolution &solution) noexcept
-    :QuestionWidget(MakeMessage(*_airspace, _state, solution)),
+    /* the message depends on the width and is only known in
+       Prepare() */
+    :QuestionWidget(""),
      monitor(_monitor), manager(_manager),
      airspace(std::move(_airspace)), state(_state) {
+    MakeMessage(*airspace, state, solution);
+
     AddButton(_("ACK"), [this](){
       try {
         if (state == AirspaceWarning::WARNING_INSIDE)
@@ -119,14 +204,53 @@ public:
     monitor.widget = nullptr;
   }
 
+  /* virtual methods from class Widget */
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override {
+    SetMessageWidth(rc);
+    DecideLayout();
+    Compose();
+
+    QuestionWidget::Prepare(parent, rc);
+    SetMessage(buffer);
+  }
+
+  void Move(const PixelRect &rc) noexcept override {
+    SetMessageWidth(rc);
+    DecideLayout();
+    Compose();
+
+    QuestionWidget::Move(rc);
+    SetMessage(buffer);
+  }
+
+  PixelSize GetMinimumSize() const noexcept override {
+    /* QuestionWidget already reserves one text line plus the button
+       row */
+    PixelSize size = QuestionWidget::GetMinimumSize();
+    if (two_lines)
+      size.height += UIGlobals::GetDialogLook().text_font.GetHeight();
+    return size;
+  }
+
   bool Update(const AbstractAirspace &_airspace,
               AirspaceWarning::State _state,
               const AirspaceInterceptSolution &solution) noexcept {
     if (&_airspace != airspace.get())
       return false;
 
+    const bool had_details = !details_text.empty();
+
     state = _state;
-    SetMessage(MakeMessage(*airspace, state, solution));
+    MakeMessage(*airspace, state, solution);
+
+    /* Inside has no details line; Near may need two.  Recreate when
+       that changes so MainWindow picks up the new height. */
+    if (had_details != !details_text.empty())
+      return false;
+
+    Compose();
+    SetMessage(buffer);
     UpdateMessageColors();
     return true;
   }

--- a/src/Renderer/AircraftRenderer.cpp
+++ b/src/Renderer/AircraftRenderer.cpp
@@ -8,8 +8,14 @@
 #include "MapSettings.hpp"
 #include "Asset.hpp"
 #include "Math/Angle.hpp"
+#include "Math/Screen.hpp"
 #include "Screen/Layout.hpp"
 #include "util/Macros.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <span>
 
 static void
 DrawMirroredPolygon(std::span<const BulkPixelPoint> src,
@@ -80,65 +86,87 @@ DrawDetailedAircraft(Canvas &canvas, bool inverse,
 }
 
 
+static constexpr BulkPixelPoint AircraftLarge[] = {
+  {1, -7},
+  {1, -1},
+  {17, -1},
+  {17, 1},
+  {1, 1},
+  {1, 10},
+  {5, 10},
+  {5, 12},
+  {-5, 12},
+  {-5, 10},
+  {-1, 10},
+  {-1, 1},
+  {-17, 1},
+  {-17, -1},
+  {-1, -1},
+  {-1, -7},
+};
+
+static constexpr BulkPixelPoint AircraftSmall[] = {
+  {1, -5},
+  {1, 0},
+  {14, 0},
+  {14, 1},
+  {1, 1},
+  {1, 8},
+  {4, 8},
+  {4, 9},
+  {-3, 9},
+  {-3, 8},
+  {0, 8},
+  {0, 1},
+  {-13, 1},
+  {-13, 0},
+  {0, 0},
+  {0, -5},
+};
+
+void
+AircraftRenderer::DrawSimple(Canvas &canvas, const AircraftLook &look,
+                             Angle angle, PixelPoint aircraft_pos,
+                             int scale, bool large) noexcept
+{
+  const auto src = large
+    ? std::span<const BulkPixelPoint>{AircraftLarge}
+    : std::span<const BulkPixelPoint>{AircraftSmall};
+
+  std::array<BulkPixelPoint, ARRAY_SIZE(AircraftLarge)> aircraft;
+  assert(src.size() <= aircraft.size());
+  std::copy_n(src.begin(), src.size(), aircraft.begin());
+
+  PolygonRotateShift({aircraft.data(), src.size()},
+                     aircraft_pos, angle, scale);
+
+  canvas.SelectHollowBrush();
+  canvas.Select(look.aircraft_simple2_pen);
+  canvas.DrawPolygon(aircraft.data(), src.size());
+  canvas.SelectBlackBrush();
+  canvas.Select(look.aircraft_simple1_pen);
+  canvas.DrawPolygon(aircraft.data(), src.size());
+}
+
 static void
 DrawSimpleAircraft(Canvas &canvas, const AircraftLook &look,
                    const Angle angle,
-                   const PixelPoint aircraft_pos, bool large)
+                   const PixelPoint aircraft_pos, bool large) noexcept
 {
-  static constexpr BulkPixelPoint AircraftLarge[] = {
-    {1, -7},
-    {1, -1},
-    {17, -1},
-    {17, 1},
-    {1, 1},
-    {1, 10},
-    {5, 10},
-    {5, 12},
-    {-5, 12},
-    {-5, 10},
-    {-1, 10},
-    {-1, 1},
-    {-17, 1},
-    {-17, -1},
-    {-1, -1},
-    {-1, -7},
-  };
+  const auto *aircraft = large ? AircraftLarge : AircraftSmall;
+  const std::size_t aircraft_points = large
+    ? ARRAY_SIZE(AircraftLarge)
+    : ARRAY_SIZE(AircraftSmall);
 
-  static constexpr BulkPixelPoint AircraftSmall[] = {
-    {1, -5},
-    {1, 0},
-    {14, 0},
-    {14, 1},
-    {1, 1},
-    {1, 8},
-    {4, 8},
-    {4, 9},
-    {-3, 9},
-    {-3, 8},
-    {0, 8},
-    {0, 1},
-    {-13, 1},
-    {-13, 0},
-    {0, 0},
-    {0, -5},
-   };
-
-  static constexpr unsigned AIRCRAFT_POINTS_LARGE = ARRAY_SIZE(AircraftLarge);
-  static constexpr unsigned AIRCRAFT_POINTS_SMALL = ARRAY_SIZE(AircraftSmall);
-
-  const auto *Aircraft = large ? AircraftLarge : AircraftSmall;
-  const std::size_t AircraftPoints = large ?
-                                  AIRCRAFT_POINTS_LARGE : AIRCRAFT_POINTS_SMALL;
-
-  const RotatedPolygonRenderer renderer({Aircraft, AircraftPoints},
+  const RotatedPolygonRenderer renderer({aircraft, aircraft_points},
                                         aircraft_pos, angle);
 
   canvas.SelectHollowBrush();
   canvas.Select(look.aircraft_simple2_pen);
-  renderer.Draw(canvas, 0, AircraftPoints);
+  renderer.Draw(canvas, 0, aircraft_points);
   canvas.SelectBlackBrush();
   canvas.Select(look.aircraft_simple1_pen);
-  renderer.Draw(canvas, 0, AircraftPoints);
+  renderer.Draw(canvas, 0, aircraft_points);
 }
 
 static void

--- a/src/Renderer/AircraftRenderer.hpp
+++ b/src/Renderer/AircraftRenderer.hpp
@@ -14,4 +14,13 @@ namespace AircraftRenderer
   void Draw(Canvas &canvas, const MapSettings &settings_map,
             const AircraftLook &look,
             Angle angle, PixelPoint aircraft_pos);
+
+  /**
+   * Draw the simple aircraft outline.  #scale is a
+   * PolygonRotateShift() scale (coordinates in +/-50 map to #scale
+   * pixels); use this for list icons sized to a row.
+   */
+  void DrawSimple(Canvas &canvas, const AircraftLook &look,
+                  Angle angle, PixelPoint aircraft_pos,
+                  int scale, bool large = false) noexcept;
 }

--- a/src/Renderer/AirspaceWarningStatusRenderer.cpp
+++ b/src/Renderer/AirspaceWarningStatusRenderer.cpp
@@ -9,15 +9,26 @@
 
 #include <algorithm>
 
-int
-AirspaceWarningStatusWidth(Canvas &canvas) noexcept
+[[gnu::pure]]
+static int
+CaptionWidth(Canvas &canvas) noexcept
 {
   return std::max(canvas.CalcTextWidth(_("Inside")),
                   canvas.CalcTextWidth(_("Near")));
 }
 
+int
+AirspaceWarningStatusWidth(Canvas &canvas, const Font &font) noexcept
+{
+  canvas.Select(font);
+
+  /* caption + padding on both sides + gap to the row edge */
+  return CaptionWidth(canvas) + 3 * (int)Layout::GetTextPadding();
+}
+
 void
-DrawAirspaceWarningStatus(Canvas &canvas, PixelRect status_rc,
+DrawAirspaceWarningStatus(Canvas &canvas, const Font &font,
+                          PixelRect status_rc,
                           AirspaceWarningStatusBadge status) noexcept
 {
   Color state_color;
@@ -42,25 +53,19 @@ DrawAirspaceWarningStatus(Canvas &canvas, PixelRect status_rc,
     return;
   }
 
-  if (state_text == nullptr)
-    return;
+  canvas.Select(font);
 
   const unsigned padding = Layout::GetTextPadding();
   const PixelSize state_text_size = canvas.CalcTextSize(state_text);
 
-  /* Size the badge from the caption instead of the reserved column:
-     the column is measured with the widest caption and would leave no
-     room around a caption that is exactly as wide. */
+  /* Fill the reserved column (pad top/bottom/right).  Both captions
+     share this rectangle so Inside and Near stay the same width. */
   PixelRect badge_rc = status_rc;
   badge_rc.top += padding;
   badge_rc.bottom -= padding;
   badge_rc.right -= padding;
-  badge_rc.left = std::max(status_rc.left,
-                           badge_rc.right
-                           - (int)(state_text_size.width + 2 * padding));
 
   canvas.DrawFilledRectangle(badge_rc, state_color);
-
   canvas.SetTextColor(COLOR_BLACK);
   canvas.DrawText(badge_rc.CenteredTopLeft(state_text_size), state_text);
 }

--- a/src/Renderer/AirspaceWarningStatusRenderer.cpp
+++ b/src/Renderer/AirspaceWarningStatusRenderer.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "AirspaceWarningStatusRenderer.hpp"
+#include "Look/Colors.hpp"
+#include "Language/Language.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Canvas.hpp"
+
+#include <algorithm>
+
+int
+AirspaceWarningStatusWidth(Canvas &canvas) noexcept
+{
+  return std::max(canvas.CalcTextWidth(_("Inside")),
+                  canvas.CalcTextWidth(_("Near")));
+}
+
+void
+DrawAirspaceWarningStatus(Canvas &canvas, PixelRect status_rc,
+                          AirspaceWarningStatusBadge status) noexcept
+{
+  Color state_color;
+  const char *state_text = nullptr;
+
+  switch (status.kind) {
+  case AirspaceWarningStatusBadge::Kind::Inside:
+    state_color = status.active
+      ? COLOR_AIRSPACE_WARNING_INSIDE
+      : COLOR_AIRSPACE_WARNING_INSIDE_ACK;
+    state_text = _("Inside");
+    break;
+
+  case AirspaceWarningStatusBadge::Kind::Near:
+    state_color = status.active
+      ? COLOR_AIRSPACE_WARNING_NEAR
+      : COLOR_AIRSPACE_WARNING_NEAR_ACK;
+    state_text = _("Near");
+    break;
+
+  case AirspaceWarningStatusBadge::Kind::None:
+    return;
+  }
+
+  if (state_text == nullptr)
+    return;
+
+  const unsigned padding = Layout::GetTextPadding();
+  const PixelSize state_text_size = canvas.CalcTextSize(state_text);
+
+  /* Size the badge from the caption instead of the reserved column:
+     the column is measured with the widest caption and would leave no
+     room around a caption that is exactly as wide. */
+  PixelRect badge_rc = status_rc;
+  badge_rc.top += padding;
+  badge_rc.bottom -= padding;
+  badge_rc.right -= padding;
+  badge_rc.left = std::max(status_rc.left,
+                           badge_rc.right
+                           - (int)(state_text_size.width + 2 * padding));
+
+  canvas.DrawFilledRectangle(badge_rc, state_color);
+
+  canvas.SetTextColor(COLOR_BLACK);
+  canvas.DrawText(badge_rc.CenteredTopLeft(state_text_size), state_text);
+}

--- a/src/Renderer/AirspaceWarningStatusRenderer.hpp
+++ b/src/Renderer/AirspaceWarningStatusRenderer.hpp
@@ -7,6 +7,7 @@
 
 struct PixelRect;
 class Canvas;
+class Font;
 
 /**
  * Inside / Near badge used by the airspace warnings list and the
@@ -27,10 +28,15 @@ struct AirspaceWarningStatusBadge {
   }
 };
 
+/**
+ * Width to reserve at the right of a row for
+ * DrawAirspaceWarningStatus().  Uses @p font for the caption measure.
+ */
 [[nodiscard]]
 int
-AirspaceWarningStatusWidth(Canvas &canvas) noexcept;
+AirspaceWarningStatusWidth(Canvas &canvas, const Font &font) noexcept;
 
 void
-DrawAirspaceWarningStatus(Canvas &canvas, PixelRect status_rc,
+DrawAirspaceWarningStatus(Canvas &canvas, const Font &font,
+                          PixelRect status_rc,
                           AirspaceWarningStatusBadge status) noexcept;

--- a/src/Renderer/AirspaceWarningStatusRenderer.hpp
+++ b/src/Renderer/AirspaceWarningStatusRenderer.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+struct PixelRect;
+class Canvas;
+
+/**
+ * Inside / Near badge used by the airspace warnings list and the
+ * map-items dialog.
+ */
+struct AirspaceWarningStatusBadge {
+  enum class Kind : uint8_t {
+    None,
+    Inside,
+    Near,
+  } kind = Kind::None;
+
+  bool active = true;
+
+  [[nodiscard]]
+  bool HasStatus() const noexcept {
+    return kind != Kind::None;
+  }
+};
+
+[[nodiscard]]
+int
+AirspaceWarningStatusWidth(Canvas &canvas) noexcept;
+
+void
+DrawAirspaceWarningStatus(Canvas &canvas, PixelRect status_rc,
+                          AirspaceWarningStatusBadge status) noexcept;

--- a/src/Renderer/FinalGlideBarRenderer.cpp
+++ b/src/Renderer/FinalGlideBarRenderer.cpp
@@ -123,7 +123,7 @@ FinalGlideBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   for (unsigned i = 0; i < 6; i++) {
     GlideBar[i].y += y0 + dy_glidebar;
-    GlideBar[i].x = Layout::Scale(GlideBar[i].x) + rc.left;
+    GlideBar[i].x = rc.right - Layout::Scale(GlideBar[i].x);
   }
 
   GlideBar[0].y -= Offset;
@@ -132,7 +132,7 @@ FinalGlideBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   for (unsigned i = 0; i < 4; i++) {
     GlideBar0[i].y += y0 + dy_glidebar0;
-    GlideBar0[i].x = Layout::Scale(GlideBar0[i].x) + rc.left;
+    GlideBar0[i].x = rc.right - Layout::Scale(GlideBar0[i].x);
   }
 
   GlideBar0[0].y -= Offset0;
@@ -148,14 +148,14 @@ FinalGlideBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
   for (unsigned i = 0; i < 6; i++) {
     clipping_arrow[i].y = Layout::Scale(clipping_arrow[i].y) + y0 - Offset
       + clipping_arrow_offset + dy_glidebar;
-    clipping_arrow[i].x = Layout::Scale(clipping_arrow[i].x) + rc.left;
+    clipping_arrow[i].x = rc.right - Layout::Scale(clipping_arrow[i].x);
   }
 
   // prepare clipping arrow mc0
   for (unsigned i = 0; i < 4; i++) {
     clipping_arrow0[i].y = Layout::Scale(clipping_arrow0[i].y) + y0 - Offset0
       + clipping_arrow0_offset + dy_glidebar0;
-    clipping_arrow0[i].x = Layout::Scale(clipping_arrow0[i].x) + rc.left;
+    clipping_arrow0[i].x = rc.right - Layout::Scale(clipping_arrow0[i].x);
   }
 
   // draw actual glide bar
@@ -211,10 +211,14 @@ FinalGlideBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   if (cross_sign != 0) {
     canvas.Select(task_look.bearing_pen);
-    canvas.DrawLine({Layout::Scale(9 - 5), y0 + cross_sign * Layout::Scale(9 - 5)},
-                    {Layout::Scale(9 + 5), y0 + cross_sign * Layout::Scale(9 + 5)});
-    canvas.DrawLine({Layout::Scale(9 - 5), y0 + cross_sign * Layout::Scale(9 + 5)},
-                    {Layout::Scale(9 + 5), y0 + cross_sign * Layout::Scale(9 - 5)});
+    canvas.DrawLine({rc.right - Layout::Scale(9 + 5),
+                     y0 + cross_sign * Layout::Scale(9 - 5)},
+                    {rc.right - Layout::Scale(9 - 5),
+                     y0 + cross_sign * Layout::Scale(9 + 5)});
+    canvas.DrawLine({rc.right - Layout::Scale(9 + 5),
+                     y0 + cross_sign * Layout::Scale(9 + 5)},
+                    {rc.right - Layout::Scale(9 - 5),
+                     y0 + cross_sign * Layout::Scale(9 - 5)});
   }
 
   canvas.SetTextColor(COLOR_BLACK);
@@ -226,8 +230,8 @@ FinalGlideBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   if (text_size.width < Layout::Scale(18u)) {
     style.align = TextInBoxMode::Alignment::RIGHT;
-    TextInBox(canvas, Value, {Layout::Scale(18), y0}, style, rc);
+    TextInBox(canvas, Value, {rc.right, y0}, style, rc);
   } else
-    TextInBox(canvas, Value, {0, y0}, style, rc);
+    TextInBox(canvas, Value, {rc.right - Layout::Scale(18), y0}, style, rc);
 
 }

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -9,7 +9,6 @@
 #include "MapWindow/Items/RaspMapItem.hpp"
 #include "Look/DialogLook.hpp"
 #include "Look/MapLook.hpp"
-#include "Renderer/AircraftRenderer.hpp"
 #include "Renderer/AirspaceListRenderer.hpp"
 #include "Renderer/WaypointListRenderer.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
@@ -20,6 +19,7 @@
 #include "Formatter/AngleFormatter.hpp"
 #include "Dialogs/Task/dlgTaskHelpers.hpp"
 #include "Renderer/OZPreviewRenderer.hpp"
+#include "Renderer/AircraftRenderer.hpp"
 #include "Language/Language.hpp"
 #include "util/StringCompare.hxx"
 #include "util/Macros.hpp"
@@ -195,16 +195,24 @@ static void
 Draw(Canvas &canvas, PixelRect rc,
      const SelfMapItem &item,
      const TwoTextRowsRenderer &row_renderer,
-     const AircraftLook &look,
-     const MapSettings &settings)
+     const AircraftLook &look)
 {
   const unsigned line_height = rc.GetHeight();
   const unsigned text_padding = Layout::GetTextPadding();
+  if (line_height > 2 * text_padding) {
+    const unsigned icon_size = line_height - 2 * text_padding;
 
-  const PixelPoint pt(rc.left + line_height / 2, rc.top + line_height / 2);
-  AircraftRenderer::Draw(canvas, settings, look, item.bearing, pt);
+    const PixelPoint pt(rc.left + icon_size / 2, rc.top + line_height / 2);
 
-  rc.left += line_height + text_padding;
+    /* Wingspan of AircraftSmall is ~28 in +/-50 PolygonRotateShift units. */
+    constexpr unsigned aircraft_span = 28;
+    const int aircraft_scale =
+      std::max(int(icon_size) * 50 / int(aircraft_span), 1);
+    AircraftRenderer::DrawSimple(canvas, look, item.bearing, pt,
+                                 aircraft_scale);
+
+    rc.left += icon_size + text_padding;
+  }
 
   row_renderer.DrawFirstRow(canvas, rc, _("Your Position"));
   row_renderer.DrawSecondRow(canvas, rc, FormatGeoPoint(item.location));
@@ -454,7 +462,7 @@ MapItemListRenderer::Draw(Canvas &canvas, const PixelRect rc,
     break;
   case MapItem::Type::SELF:
     ::Draw(canvas, rc, (const SelfMapItem &)item,
-           row_renderer, look.aircraft, settings);
+           row_renderer, look.aircraft);
     break;
   case MapItem::Type::AIRSPACE:
     ::Draw(canvas, rc, (const AirspaceMapItem &)item,

--- a/src/Renderer/TextInBox.cpp
+++ b/src/Renderer/TextInBox.cpp
@@ -4,8 +4,11 @@
 #include "TextInBox.hpp"
 #include "LabelBlock.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Pen.hpp"
 #include "Screen/Layout.hpp"
 #include "util/UTF8.hpp"
+
+#include <algorithm>
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
@@ -97,8 +100,8 @@ TextInBox(Canvas &canvas, const char *text, PixelPoint p,
   PixelRect rc;
   rc.left = p.x - padding - 1;
   rc.right = p.x + tsize.width + padding;
-  rc.top = p.y;
-  rc.bottom = p.y + tsize.height + 1;
+  rc.top = p.y - (int)padding;
+  rc.bottom = p.y + tsize.height + padding;
 
   if (mode.move_in_view) {
     auto offset = TextInBoxMoveInView(rc, map_rc);
@@ -111,10 +114,14 @@ TextInBox(Canvas &canvas, const char *text, PixelPoint p,
 
   if (mode.shape == LabelShape::ROUNDED_BLACK ||
       mode.shape == LabelShape::ROUNDED_WHITE) {
-    if (mode.shape == LabelShape::ROUNDED_BLACK)
-      canvas.SelectBlackPen();
-    else
-      canvas.SelectWhitePen();
+    /* A hairline pen breaks up along the rounded corners: OpenGL draws
+       the outline as a triangle strip whose half width (0.5px) rounds
+       to zero on most of the arc segments, leaving a dotted edge.
+       Scale the width so every segment has area. */
+    const Pen outline_pen{std::max(1u, Layout::ScaleFinePenWidth(1)),
+                          mode.shape == LabelShape::ROUNDED_BLACK
+                          ? COLOR_BLACK : COLOR_WHITE};
+    canvas.Select(outline_pen);
 
     {
 #ifdef ENABLE_OPENGL
@@ -124,7 +131,13 @@ TextInBox(Canvas &canvas, const char *text, PixelPoint p,
       canvas.SelectWhiteBrush();
 #endif
 
-      canvas.DrawRoundRectangle(rc, PixelSize{Layout::VptScale(8)});
+      /* DrawRoundRectangle takes an ellipse diameter (radius =
+         diameter/2). Cap it so short labels stay rounded rectangles
+         instead of pills. */
+      const unsigned ellipse =
+        std::min(Layout::VptScale(8),
+                 std::max(2u, (unsigned)rc.GetHeight() / 2));
+      canvas.DrawRoundRectangle(rc, PixelSize{ellipse});
     }
 
     canvas.SetBackgroundTransparent();

--- a/src/Renderer/TwoTextRowsRenderer.cpp
+++ b/src/Renderer/TwoTextRowsRenderer.cpp
@@ -4,6 +4,7 @@
 #include "TwoTextRowsRenderer.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Screen/Layout.hpp"
+#include "ui/dim/Rect.hpp"
 
 #include <algorithm>
 
@@ -32,9 +33,21 @@ TwoTextRowsRenderer::CalculateLayout(const Font &_first_font,
 }
 
 void
+TwoTextRowsRenderer::PrepareRow(const PixelRect &rc) const noexcept
+{
+  if (rc.top == edge_row_top)
+    return;
+
+  edge_row_top = rc.top;
+  first_row_right_edge = second_row_right_edge = 0;
+}
+
+void
 TwoTextRowsRenderer::DrawFirstRow(Canvas &canvas, const PixelRect &rc,
                                   const char *text) const noexcept
 {
+  PrepareRow(rc);
+
   canvas.Select(*first_font);
   first_row_right_edge = rc.left + x + (int)canvas.CalcTextWidth(text);
   canvas.DrawClippedText({rc.left + x, rc.top + first_y}, rc, text);
@@ -44,6 +57,8 @@ void
 TwoTextRowsRenderer::DrawSecondRow(Canvas &canvas, const PixelRect &rc,
                                    const char *text) const noexcept
 {
+  PrepareRow(rc);
+
   canvas.Select(*second_font);
   second_row_right_edge = rc.left + x + (int)canvas.CalcTextWidth(text);
   canvas.DrawClippedText({rc.left + x, rc.top + second_y}, rc, text);
@@ -53,6 +68,8 @@ int
 TwoTextRowsRenderer::DrawRightFirstRow(Canvas &canvas, const PixelRect &rc,
                                        const char *text) const noexcept
 {
+  PrepareRow(rc);
+
   canvas.Select(*second_font);
   int text_width = canvas.CalcTextWidth(text);
   int text_x = rc.right - x - text_width;
@@ -73,6 +90,8 @@ int
 TwoTextRowsRenderer::DrawRightSecondRow(Canvas &canvas, const PixelRect &rc,
                                         const char *text) const noexcept
 {
+  PrepareRow(rc);
+
   canvas.Select(*second_font);
   int text_width = canvas.CalcTextWidth(text);
   int text_x = rc.right - x - text_width;

--- a/src/Renderer/TwoTextRowsRenderer.hpp
+++ b/src/Renderer/TwoTextRowsRenderer.hpp
@@ -21,6 +21,15 @@ class TwoTextRowsRenderer {
   /** Right edge of the last DrawSecondRow() text, or 0 if not yet drawn. */
   mutable int second_row_right_edge = 0;
 
+  /**
+   * Top of the row the edges above were measured in.  Cleared when a
+   * draw method is called for a different row so right-before-left
+   * callers are not affected by the previous item.
+   */
+  mutable int edge_row_top = 0x7fffffff;
+
+  void PrepareRow(const PixelRect &rc) const noexcept;
+
 public:
   /**
    * @return the row height (including top and bottom padding)
@@ -58,7 +67,7 @@ public:
    * Draws a right-aligned column in the first row (but with the
    * second font which is usually smaller) and returns the new "right"
    * coordinate.  Skips drawing if it would overlap text previously
-   * drawn by DrawFirstRow().
+   * drawn by DrawFirstRow() in the same row.
    */
   int DrawRightFirstRow(Canvas &canvas, const PixelRect &rc,
                         const char *text) const noexcept;
@@ -66,7 +75,7 @@ public:
   /**
    * Draws a right-aligned column in the second row and returns the
    * new "right" coordinate.  Skips drawing if it would overlap text
-   * previously drawn by DrawSecondRow().
+   * previously drawn by DrawSecondRow() in the same row.
    */
   int DrawRightSecondRow(Canvas &canvas, const PixelRect &rc,
                          const char *text) const noexcept;

--- a/src/Renderer/VarioBarRenderer.cpp
+++ b/src/Renderer/VarioBarRenderer.cpp
@@ -129,7 +129,7 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   for (unsigned i = 0; i < 6; i++) {
     VarioBar[i].y += y0 + dy_variobar;
-    VarioBar[i].x = rc.right - Layout::Scale(VarioBar[i].x);
+    VarioBar[i].x = Layout::Scale(VarioBar[i].x) + rc.left;
   }
 
   VarioBar[0].y -= Offset;
@@ -138,7 +138,7 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   for (unsigned i = 0; i < 4; i++) {
     VarioBarAvg[i].y += y0 + dy_variobar_av;
-    VarioBarAvg[i].x = rc.right-Layout::Scale(VarioBarAvg[i].x);
+    VarioBarAvg[i].x = Layout::Scale(VarioBarAvg[i].x) + rc.left;
   }
 
   VarioBarAvg[0].y -= OffsetAvg;
@@ -148,21 +148,21 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
   for (unsigned i = 0; i < 6; i++) {
     mc_arrow[i].y = Layout::Scale(mc_arrow[i].y) + y0
       - OffsetMC + dy_variobar_mc;
-    mc_arrow[i].x = rc.right - Layout::Scale(mc_arrow[i].x);
+    mc_arrow[i].x = Layout::Scale(mc_arrow[i].x) + rc.left;
   }
 
   // prepare clipping arrow
   for (unsigned i = 0; i < 6; i++) {
     clipping_arrow[i].y = Layout::Scale(clipping_arrow[i].y) + y0 - Offset
       + clipping_arrow_offset + dy_variobar;
-    clipping_arrow[i].x = rc.right - Layout::Scale(clipping_arrow[i].x);
+    clipping_arrow[i].x = Layout::Scale(clipping_arrow[i].x) + rc.left;
   }
 
   // prepare clipping avg
   for (unsigned i = 0; i < 4; i++) {
     clipping_arrow_av[i].y = Layout::Scale(clipping_arrow_av[i].y) + y0 - OffsetAvg
       + clipping_arrow_av_offset + dy_variobar_av;
-    clipping_arrow_av[i].x = rc.right-Layout::Scale(clipping_arrow_av[i].x);
+    clipping_arrow_av[i].x = Layout::Scale(clipping_arrow_av[i].x) + rc.left;
   }
 
   // draw actual vario bar
@@ -210,7 +210,7 @@ VarioBarRenderer::Draw(Canvas &canvas, const PixelRect &rc,
 
   if (text_size.width < Layout::Scale(18u)) {
     style.align = TextInBoxMode::Alignment::RIGHT;
-    TextInBox(canvas, Value, {rc.right, y0}, style, rc);
+    TextInBox(canvas, Value, {rc.left + Layout::Scale(18), y0}, style, rc);
   } else
-    TextInBox(canvas, Value, {rc.right - Layout::Scale(18), y0}, style, rc);
+    TextInBox(canvas, Value, {rc.left, y0}, style, rc);
 }

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -5,8 +5,10 @@
 #include "ArrowPagerGesture.hpp"
 #include "QuickGuidePageWidget.hpp"
 #include "VScrollWidget.hpp"
+#include "WindowWidget.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/event/KeyCode.hpp"
+#include "ui/window/ContainerWindow.hpp"
 #include "Language/Language.hpp"
 #include "Form/Form.hpp"
 #include "Renderer/SymbolButtonRenderer.hpp"
@@ -212,6 +214,99 @@ ArrowPagerWidget::HasFocus() const noexcept
 }
 
 bool
+ArrowPagerWidget::FocusPageBottom() noexcept
+{
+  Widget &page = GetCurrentWidget();
+  if (auto *qg = dynamic_cast<QuickGuidePageWidget *>(&page)) {
+    if (qg->FocusBottomBar(true))
+      return true;
+    return page.SetFocus();
+  }
+
+  /* Prefer the last TabStop so Up from chrome reverses Down leaving
+     a RowForm (SetFocus alone would hit the first control). */
+  Widget *inner = &page;
+  if (auto *vs = dynamic_cast<VScrollWidget *>(&page))
+    inner = &vs->GetWidget();
+
+  if (auto *ww = dynamic_cast<WindowWidget *>(inner)) {
+    auto *cw = dynamic_cast<ContainerWindow *>(&ww->GetWindow());
+    if (cw != nullptr && cw->FocusLastControl())
+      return true;
+  }
+
+  return page.SetFocus();
+}
+
+bool
+ArrowPagerWidget::MoveChromeFocusUp() noexcept
+{
+  /* Portrait chrome order: prev | next | Close.  Up walks toward the
+     page: Close → next → prev → page bottom. */
+  if (close_button.HasFocus()) {
+    if (next_button.IsEnabled()) {
+      next_button.SetFocus();
+      return true;
+    }
+    if (previous_button.IsEnabled()) {
+      previous_button.SetFocus();
+      return true;
+    }
+    return FocusPageBottom();
+  }
+
+  if (next_button.HasFocus()) {
+    if (previous_button.IsEnabled()) {
+      previous_button.SetFocus();
+      return true;
+    }
+    return FocusPageBottom();
+  }
+
+  if (previous_button.HasFocus())
+    return FocusPageBottom();
+
+  return false;
+}
+
+bool
+ArrowPagerWidget::MoveChromeFocusDown() noexcept
+{
+  if (close_button.HasFocus())
+    return true; /* end of chrome chain */
+
+  if (previous_button.HasFocus()) {
+    if (next_button.IsEnabled())
+      next_button.SetFocus();
+    else
+      close_button.SetFocus();
+    return true;
+  }
+
+  if (next_button.HasFocus()) {
+    close_button.SetFocus();
+    return true;
+  }
+
+  /* Quick Guide bottom bar → chrome.  Other pages return false so
+     WndForm can walk TabStops (z-order FocusNext would bounce back). */
+  auto *qg = dynamic_cast<QuickGuidePageWidget *>(&GetCurrentWidget());
+  if (qg == nullptr || !qg->IsBottomBarFocused())
+    return false;
+
+  if (previous_button.IsEnabled()) {
+    previous_button.SetFocus();
+    return true;
+  }
+  if (next_button.IsEnabled()) {
+    next_button.SetFocus();
+    return true;
+  }
+  close_button.SetFocus();
+  return true;
+}
+
+bool
 ArrowPagerWidget::KeyPress(unsigned key_code) noexcept
 {
   if (PagerWidget::KeyPress(key_code))
@@ -220,70 +315,12 @@ ArrowPagerWidget::KeyPress(unsigned key_code) noexcept
   if (extra != nullptr && extra->KeyPress(key_code))
     return true;
 
-  auto focus_page_bottom = [this]() noexcept {
-    Widget &page = GetCurrentWidget();
-    if (auto *qg = dynamic_cast<QuickGuidePageWidget *>(&page)) {
-      if (qg->FocusBottomBar(true))
-        return true;
-    }
-    return page.SetFocus();
-  };
-
   switch (key_code) {
   case KEY_UP:
-    /* Chrome focus chain (portrait: prev | next | Close):
-       Close → next → prev → page bottom bar / content. */
-    if (close_button.HasFocus()) {
-      if (next_button.IsEnabled()) {
-        next_button.SetFocus();
-        return true;
-      }
-      if (previous_button.IsEnabled()) {
-        previous_button.SetFocus();
-        return true;
-      }
-      return focus_page_bottom();
-    }
-    if (next_button.HasFocus()) {
-      if (previous_button.IsEnabled()) {
-        previous_button.SetFocus();
-        return true;
-      }
-      return focus_page_bottom();
-    }
-    if (previous_button.HasFocus())
-      return focus_page_bottom();
-    return false;
+    return MoveChromeFocusUp();
 
   case KEY_DOWN:
-    /* Page content / bottom bar finished with Down, or chrome
-       arrows — move toward Close.  Do not use dialog FocusNext:
-       window z-order would send focus back into the scroller. */
-    if (close_button.HasFocus())
-      return true; /* end of chain */
-
-    if (previous_button.HasFocus()) {
-      if (next_button.IsEnabled())
-        next_button.SetFocus();
-      else
-        close_button.SetFocus();
-      return true;
-    }
-    if (next_button.HasFocus()) {
-      close_button.SetFocus();
-      return true;
-    }
-
-    if (previous_button.IsEnabled()) {
-      previous_button.SetFocus();
-      return true;
-    }
-    if (next_button.IsEnabled()) {
-      next_button.SetFocus();
-      return true;
-    }
-    close_button.SetFocus();
-    return true;
+    return MoveChromeFocusDown();
 
   case KEY_LEFT:
     if (Previous(true))

--- a/src/Widget/ArrowPagerWidget.hpp
+++ b/src/Widget/ArrowPagerWidget.hpp
@@ -143,4 +143,11 @@ private:
    * (#VScrollWidget, #QuickGuidePageWidget).  Called from #Prepare().
    */
   void WireHorizontalSwipeToPages() noexcept;
+
+  /** Up from chrome: last form row, Quick Guide bottom bar, or page. */
+  bool FocusPageBottom() noexcept;
+
+  /** Up/Down among prev / next / Close (and into the page). */
+  bool MoveChromeFocusUp() noexcept;
+  bool MoveChromeFocusDown() noexcept;
 };

--- a/src/Widget/KeyboardWidget.cpp
+++ b/src/Widget/KeyboardWidget.cpp
@@ -309,8 +309,7 @@ KeyboardWidget::GetCenterByIndex(int idx, PixelPoint &out) const noexcept
   const Button *b = GetByIndex(idx);
   if (b == nullptr || !b->IsDefined() || !b->IsVisible())
     return false;
-  const PixelRect r = b->GetPosition();
-  out = {(r.left + r.right) / 2, (r.top + r.bottom) / 2};
+  out = b->GetPosition().GetCenter();
   return true;
 }
 
@@ -572,6 +571,20 @@ KeyboardWidget::MoveFocusInGridByArrowKey(unsigned key_code, Window *w,
   return false;
 }
 
+KeyboardWidget::FocusArea
+KeyboardWidget::ClassifyFocusArea(Window *w, int grid_index,
+                                  Button *backspace,
+                                  Button *action_row_first) const noexcept
+{
+  if (grid_index >= 0)
+    return FocusArea::Grid;
+  if (backspace != nullptr && w == static_cast<Window *>(backspace))
+    return FocusArea::Backspace;
+  if (action_row_first != nullptr)
+    return FocusArea::ActionRow;
+  return FocusArea::Other;
+}
+
 bool
 KeyboardWidget::KeyPressImpl(unsigned key_code, Button *backspace,
                              Button *action_row_first) noexcept
@@ -582,24 +595,43 @@ KeyboardWidget::KeyPressImpl(unsigned key_code, Button *backspace,
   if (w == nullptr)
     return false;
 
-  if (action_row_first != nullptr &&
-      w == static_cast<Window *>(action_row_first) && key_code == KEY_UP) {
-    /* @em OK is outside the grid: first @em up is @em Space, then
-       @c FindIndexVerticalFrom (Z → A → Q → 0…9) and
-       @c RouteNumberRowAndBackspace to on-screen @em backspace. */
-    return FocusSpaceKey();
+  const int from = FindIndexOf(w);
+  const FocusArea area =
+    ClassifyFocusArea(w, from, backspace, action_row_first);
+
+  switch (area) {
+  case FocusArea::ActionRow:
+    /* Up from OK / Cancel / Clear enters at Space (or first key). */
+    if (key_code != KEY_UP)
+      return false;
+    if (FocusSpaceKey())
+      return true;
+    return FocusFirstEnabledInGrid();
+
+  case FocusArea::Backspace:
+    if (key_code == KEY_UP && action_row_first != nullptr) {
+      action_row_first->SetFocus();
+      return true;
+    }
+    return RouteNumberRowAndBackspace(key_code, backspace, w);
+
+  case FocusArea::Grid:
+    if (RouteSpaceToActionRow(key_code, action_row_first, w))
+      return true;
+    if (RouteNumberRowAndBackspace(key_code, backspace, w))
+      return true;
+    if (MoveFocusInGridByArrowKey(key_code, w, backspace, action_row_first))
+      return true;
+    /* Stay put at a geometric edge — do not use letter-creation tab
+       order (FocusNextControl). */
+    {
+      int dix = 0, diy = 0;
+      return ArrowToDirection(key_code, dix, diy);
+    }
+
+  case FocusArea::Other:
+    return false;
   }
 
-  if (RouteSpaceToActionRow(key_code, action_row_first, w))
-    return true;
-  if (backspace != nullptr && action_row_first != nullptr &&
-      w == static_cast<Window *>(backspace) && key_code == KEY_UP) {
-    /* @em backspace is not in the key grid, so
-       @c MoveFocusInGridByArrowKey is never used; send @em up to @em OK. */
-    action_row_first->SetFocus();
-    return true;
-  }
-  if (RouteNumberRowAndBackspace(key_code, backspace, w))
-    return true;
-  return MoveFocusInGridByArrowKey(key_code, w, backspace, action_row_first);
+  return false;
 }

--- a/src/Widget/KeyboardWidget.hpp
+++ b/src/Widget/KeyboardWidget.hpp
@@ -8,6 +8,8 @@
 #include "Form/CharacterButton.hpp"
 #include "Form/Button.hpp"
 
+#include <cstdint>
+
 struct ButtonLook;
 class ContainerWindow;
 class Window;
@@ -66,6 +68,13 @@ public:
    */
   bool FocusSpaceKey() noexcept;
 
+  /**
+   * Focus the first enabled on-screen key (number row first).  Used as
+   * a fallback when Space is unavailable, and for the dialog default
+   * focus when the keyboard is created before the action buttons.
+   */
+  bool FocusFirstEnabledInGrid() noexcept;
+
 private:
   void PrepareSize(const PixelRect &rc) noexcept;
   void OnResize(const PixelRect &rc);
@@ -103,11 +112,10 @@ public:
   /**
    * @param backspace optional backspace @c Button above the key grid.
    * @param action_row_first the first of the main row (usually @em OK);
-   *  @c KEY_UP from @em OK focuses @em Space, then further @c KEY_UP
-   *  follows the key grid to on-screen @em backspace; @c KEY_DOWN from
-   *  the @em Space key focuses it; with no on-screen key below the
-   *  focus, @c KEY_DOWN moves here too; @c KEY_UP from on-screen
-   *  @em backspace also focuses it.
+   *  @c KEY_UP from the action row (@em OK / Cancel / Clear) focuses
+   *  @em Space (or the first enabled key); further @c KEY_UP follows
+   *  the grid to on-screen @em backspace; @c KEY_DOWN from @em Space
+   *  focuses the action row; @c KEY_UP from @em backspace focuses it.
    */
   bool KeyPress(unsigned key_code, Button *backspace,
                 Button *action_row_first = nullptr) noexcept {
@@ -115,8 +123,20 @@ public:
   }
 
 private:
+  enum class FocusArea : uint8_t {
+    Grid,
+    Backspace,
+    ActionRow,
+    Other,
+  };
+
   bool KeyPressImpl(unsigned key_code, Button *backspace,
                     Button *action_row_first) noexcept;
+
+  [[gnu::pure]]
+  FocusArea ClassifyFocusArea(Window *w, int grid_index,
+                              Button *backspace,
+                              Button *action_row_first) const noexcept;
 
   bool RouteSpaceToActionRow(unsigned key_code, Button *action_row,
                             Window *w) noexcept;
@@ -154,5 +174,4 @@ private:
   int FindIndexHorizontalFrom(int from_idx, int dix) const noexcept;
 
   bool FocusFirstEnabledInNumberRow(int prefer_index) noexcept;
-  bool FocusFirstEnabledInGrid() noexcept;
 };

--- a/src/Widget/MultiSelectListWidget.cpp
+++ b/src/Widget/MultiSelectListWidget.cpp
@@ -6,10 +6,33 @@
 #include "Look/DialogLook.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/dim/Rect.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "Screen/Layout.hpp"
 #include "util/Macros.hpp"
 #include "Asset.hpp"
 #include "Form/CheckBox.hpp"
+
+bool
+MultiSelectListWidget::KeyPress(unsigned key_code) noexcept
+{
+  if (ListWidget::KeyPress(key_code))
+    return true;
+
+  if (!IsDefined() || !GetList().HasFocus())
+    return false;
+
+  switch (key_code) {
+  case KEY_RETURN:
+  case KEY_SPACE:
+    /* Activate (toggle) via ListControl; always consume so the dialog
+       action bar does not treat Return as OK while browsing files. */
+    GetList().OnKeyFromWidgetParent(KEY_RETURN);
+    return true;
+
+  default:
+    return false;
+  }
+}
 
 void
 MultiSelectListWidget::DrawCheckboxText(Canvas &canvas, const PixelRect &rc,

--- a/src/Widget/MultiSelectListWidget.hpp
+++ b/src/Widget/MultiSelectListWidget.hpp
@@ -93,6 +93,13 @@ public:
     GetList().SetActivateOnFirstClick(true);
   }
 
+  /**
+   * When the list has focus, Return/Space toggle the cursor row before
+   * #ButtonPanel::KeyPress can fire the armed action (OK / Select all)
+   * under #WidgetDialog::EnableCursorSelection.
+   */
+  bool KeyPress(unsigned key_code) noexcept override;
+
 private:
   /** Select or deselect all items. */
   void SetAllSelected(bool value) noexcept {

--- a/src/Widget/PagerWidget.cpp
+++ b/src/Widget/PagerWidget.cpp
@@ -101,6 +101,10 @@ PagerWidget::SetCurrent(unsigned i, bool click) noexcept
   if (click && !new_child.widget->Click())
     return false;
 
+  /* If the hidden page kept keyboard focus, Up/Down and list keys
+     would stop working (e.g. Task Manager Manage → Browse). */
+  const bool steal_focus = visible && old_child.widget->HasFocus();
+
   if (visible)
     old_child.widget->Hide();
 
@@ -111,8 +115,11 @@ PagerWidget::SetCurrent(unsigned i, bool click) noexcept
     new_child.widget->Prepare(*parent, position);
   }
 
-  if (visible)
+  if (visible) {
     new_child.widget->Show(position);
+    if (steal_focus)
+      new_child.widget->SetFocus();
+  }
 
   OnPageFlipped();
   return true;

--- a/src/Widget/QuestionWidget.cpp
+++ b/src/Widget/QuestionWidget.cpp
@@ -19,6 +19,24 @@ QuestionWidget::SetMessage(const char *_message) noexcept
   tw.SetText(_message);
 }
 
+inline void
+QuestionWidget::ApplyMessageColors() noexcept
+{
+  auto &bpw = (ButtonPanelWidget &)GetWidget();
+  auto &tw = (TextWidget &)bpw.GetWidget();
+  tw.SetBackgroundColor(message_colors->background);
+  tw.SetColor(message_colors->text);
+}
+
+void
+QuestionWidget::SetMessageColors(Color background, Color text) noexcept
+{
+  message_colors.emplace(MessageColors{background, text});
+
+  if (prepared)
+    ApplyMessageColors();
+}
+
 void
 QuestionWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 {
@@ -32,6 +50,11 @@ QuestionWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 
   for (auto button : buttons)
     panel.Add(button.caption, button.callback);
+
+  prepared = true;
+
+  if (message_colors)
+    ApplyMessageColors();
 }
 
 

--- a/src/Widget/QuestionWidget.hpp
+++ b/src/Widget/QuestionWidget.hpp
@@ -4,9 +4,11 @@
 #pragma once
 
 #include "SolidWidget.hpp"
+#include "ui/canvas/Color.hpp"
 #include "util/StaticArray.hxx"
 
 #include <functional>
+#include <optional>
 
 /**
  * A #Widget that displays a message and a number of buttons.  It is
@@ -19,14 +21,30 @@ class QuestionWidget : public SolidWidget {
     std::function<void()> callback;
   };
 
+  struct MessageColors {
+    Color background, text;
+  };
+
   const char *const message;
 
   StaticArray<Button, 8> buttons;
+
+  std::optional<MessageColors> message_colors;
+
+  bool prepared = false;
+
+  void ApplyMessageColors() noexcept;
 
 public:
   explicit QuestionWidget(const char *_message) noexcept;
 
   void SetMessage(const char *_message) noexcept;
+
+  /**
+   * Paint the message area in these colours, e.g. to show the
+   * severity of a warning.  May be called before #Prepare.
+   */
+  void SetMessageColors(Color background, Color text) noexcept;
 
   void AddButton(const char *caption,
                  std::function<void()> callback) noexcept {

--- a/src/Widget/QuickGuidePageWidget.cpp
+++ b/src/Widget/QuickGuidePageWidget.cpp
@@ -365,6 +365,18 @@ QuickGuidePageWidget::FocusBottomBar(bool from_end) noexcept
 }
 
 bool
+QuickGuidePageWidget::IsBottomBarFocused() const noexcept
+{
+  if (checkbox != nullptr && checkbox->HasFocus())
+    return true;
+  if (button1 != nullptr && button1->HasFocus())
+    return true;
+  if (button2 != nullptr && button2->HasFocus())
+    return true;
+  return false;
+}
+
+bool
 QuickGuidePageWidget::KeyPress(unsigned key_code) noexcept
 {
   if (scroll_widget->HasFocus()) {

--- a/src/Widget/QuickGuidePageWidget.hpp
+++ b/src/Widget/QuickGuidePageWidget.hpp
@@ -115,6 +115,15 @@ public:
    */
   bool FocusBottomBar(bool from_end=false) noexcept;
 
+  /**
+   * True when the checkbox or a bottom-bar button has focus (not the
+   * scrollable content).  ArrowPager uses this so Down from the bar
+   * enters the prev/next/Close chrome without stealing Down from
+   * ordinary form pages (e.g. Configuration panels).
+   */
+  [[gnu::pure]]
+  bool IsBottomBarFocused() const noexcept;
+
   ~QuickGuidePageWidget() noexcept override;
 
   /**

--- a/src/Widget/StaticHelpTextWidget.hpp
+++ b/src/Widget/StaticHelpTextWidget.hpp
@@ -27,7 +27,7 @@ public:
   StaticHelpTextWidget(std::unique_ptr<Widget> main_widget,
                        const char *_help_text) noexcept
     :TwoWidgets(std::move(main_widget),
-                std::make_unique<TextWidget>()),
+                std::make_unique<TextWidget>(true)),
      help_text(_help_text) {}
 
   void Show(const PixelRect &rc) noexcept override {

--- a/src/Widget/TabWidget.cpp
+++ b/src/Widget/TabWidget.cpp
@@ -149,6 +149,20 @@ TabWidget::GetMaximumSize() const noexcept
   return size;
 }
 
+PixelSize
+TabWidget::GetCurrentMaximumSize() const noexcept
+{
+  auto size = GetCurrentWidget().GetMaximumSize();
+  if (tab_display != nullptr) {
+    if (tab_display->IsVertical())
+      size.width += tab_display->GetRecommendedColumnWidth();
+    else
+      size.height += tab_display->GetRecommendedRowHeight();
+  }
+
+  return size;
+}
+
 void
 TabWidget::Initialise(ContainerWindow &parent, const PixelRect &rc) noexcept
 {

--- a/src/Widget/TabWidget.hpp
+++ b/src/Widget/TabWidget.hpp
@@ -118,6 +118,15 @@ public:
   [[gnu::pure]]
   const char *GetButtonCaption(unsigned i) const noexcept;
 
+  /**
+   * Preferred size for the current page plus the tab strip.  Unlike
+   * GetMaximumSize(), this does not grow to the tallest page, so a
+   * short tab (e.g. Altitude Simulator) does not reserve space for a
+   * taller sibling (Setup).
+   */
+  [[gnu::pure]]
+  PixelSize GetCurrentMaximumSize() const noexcept;
+
 public:
   /* virtual methods from class Widget */
   PixelSize GetMinimumSize() const noexcept override;

--- a/src/Widget/TextWidget.cpp
+++ b/src/Widget/TextWidget.cpp
@@ -22,6 +22,14 @@ TextWidget::SetColor(Color _color) noexcept
   w.SetTextColor(_color);
 }
 
+void
+TextWidget::SetBackgroundColor(Color _color) noexcept
+{
+  WndFrame &w = (WndFrame &)GetWindow();
+  w.SetBackgroundColor(_color);
+  w.Invalidate();
+}
+
 PixelSize
 TextWidget::GetMinimumSize() const noexcept
 {

--- a/src/Widget/TextWidget.cpp
+++ b/src/Widget/TextWidget.cpp
@@ -52,8 +52,11 @@ TextWidget::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
   WindowStyle style;
   style.Hide();
 
-  SetWindow(std::make_unique<WndFrame>(parent, UIGlobals::GetDialogLook(),
-                                       rc, style));
+  auto frame = std::make_unique<WndFrame>(parent, UIGlobals::GetDialogLook(),
+                                          rc, style);
+  if (top_separator)
+    frame->SetTopSeparator();
+  SetWindow(std::move(frame));
 }
 
 

--- a/src/Widget/TextWidget.hpp
+++ b/src/Widget/TextWidget.hpp
@@ -9,9 +9,17 @@ class Color;
 
 /**
  * A #Widget implementation that displays multi-line text.
+ *
+ * @param top_separator draw a thin line along the top edge (e.g. to
+ *        separate list-dialog help text from the list above)
  */
 class TextWidget : public WindowWidget {
+  const bool top_separator;
+
 public:
+  explicit TextWidget(bool _top_separator = false) noexcept
+    :top_separator(_top_separator) {}
+
   void SetText(const char *text) noexcept;
   void SetColor(Color _color) noexcept;
 

--- a/src/Widget/TextWidget.hpp
+++ b/src/Widget/TextWidget.hpp
@@ -22,6 +22,7 @@ public:
 
   void SetText(const char *text) noexcept;
   void SetColor(Color _color) noexcept;
+  void SetBackgroundColor(Color _color) noexcept;
 
   /* virtual methods from class Widget */
   PixelSize GetMinimumSize() const noexcept override;

--- a/src/Widget/TwoWidgets.cpp
+++ b/src/Widget/TwoWidgets.cpp
@@ -9,7 +9,23 @@
 void
 TwoWidgets::UpdateLayout() noexcept
 {
-  const auto layout = CalculateLayout(rc);
+  ApplyLayout();
+}
+
+void
+TwoWidgets::ApplyLayout() noexcept
+{
+  auto layout = CalculateLayout(rc);
+  first->Move(layout.first);
+  second->Move(layout.second);
+
+  if (!vertical)
+    return;
+
+  /* Bottom pane spans the full width.  The first CalculateLayout()
+     still saw the previous window width inside GetMaximumSize() (e.g.
+     TextWidget help), so recompute after Move assigned the new width. */
+  layout = CalculateLayout(rc);
   first->Move(layout.first);
   second->Move(layout.second);
 }
@@ -152,9 +168,17 @@ void
 TwoWidgets::Show(const PixelRect &rc) noexcept
 {
   this->rc = rc;
-  const auto layout = CalculateLayout(rc);
+  auto layout = CalculateLayout(rc);
   first->Show(layout.first);
   second->Show(layout.second);
+
+  if (vertical) {
+    /* Same as ApplyLayout()'s second pass: after Show the bottom pane
+       has the final width for wrapped text measurement. */
+    layout = CalculateLayout(rc);
+    first->Move(layout.first);
+    second->Move(layout.second);
+  }
 }
 
 bool
@@ -174,9 +198,7 @@ void
 TwoWidgets::Move(const PixelRect &rc) noexcept
 {
   this->rc = rc;
-  const auto layout = CalculateLayout(rc);
-  first->Move(layout.first);
-  second->Move(layout.second);
+  ApplyLayout();
 }
 
 bool

--- a/src/Widget/TwoWidgets.hpp
+++ b/src/Widget/TwoWidgets.hpp
@@ -60,6 +60,13 @@ protected:
   [[gnu::pure]]
   std::pair<PixelRect,PixelRect> CalculateLayout(const PixelRect &rc) const noexcept;
 
+  /**
+   * Apply #rc to both children.  In vertical mode, run a second pass
+   * after the bottom pane has its final width so widgets whose height
+   * depends on width (wrapped help text) measure correctly.
+   */
+  void ApplyLayout() noexcept;
+
 public:
   /* virtual methods from Widget */
   PixelSize GetMinimumSize() const noexcept override;

--- a/src/Widget/WindowWidget.cpp
+++ b/src/Widget/WindowWidget.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "WindowWidget.hpp"
+#include "ui/window/ContainerWindow.hpp"
 #include "ui/window/Window.hpp"
 
 WindowWidget::WindowWidget() noexcept = default;
@@ -73,6 +74,26 @@ WindowWidget::Move(const PixelRect &rc) noexcept
      Move() may be called before or during Show() (e.g. SolidWidget
      nested UI during Show()). */
   window->Move(rc);
+}
+
+bool
+WindowWidget::SetFocus() noexcept
+{
+  assert(window != nullptr);
+  assert(window->IsDefined());
+
+  /* Prefer a child TabStop (e.g. form rows).  Fall back to the window
+     itself when it is a TabStop (e.g. Configuration TabMenuDisplay).
+     Returning false lets ArrowPager put focus on Close instead. */
+  if (auto *container = dynamic_cast<ContainerWindow *>(window.get()))
+    if (container->FocusFirstControl())
+      return true;
+
+  if (!window->IsTabStop())
+    return false;
+
+  window->SetFocus();
+  return true;
 }
 
 bool

--- a/src/Widget/WindowWidget.hpp
+++ b/src/Widget/WindowWidget.hpp
@@ -59,5 +59,6 @@ public:
   void Show(const PixelRect &rc) noexcept override;
   void Hide() noexcept override;
   void Move(const PixelRect &rc) noexcept override;
+  bool SetFocus() noexcept override;
   bool HasFocus() const noexcept override;
 };

--- a/src/ui/window/ContainerWindow.hpp
+++ b/src/ui/window/ContainerWindow.hpp
@@ -140,6 +140,14 @@ public:
   bool FocusFirstControl() noexcept;
 
   /**
+   * Sets the keyboard focus on the last descendant window which has
+   * the WindowStyle::tab_stop() attribute.
+   *
+   * @return true if the focus has been moved
+   */
+  bool FocusLastControl() noexcept;
+
+  /**
    * Sets the keyboard focus on the next descendant window which has
    * the WindowStyle::tab_stop() attribute.
    *

--- a/src/ui/window/custom/ContainerWindow.cpp
+++ b/src/ui/window/custom/ContainerWindow.cpp
@@ -71,6 +71,17 @@ ContainerWindow::FocusFirstControl() noexcept
 }
 
 bool
+ContainerWindow::FocusLastControl() noexcept
+{
+  Window *control = children.FindLastControl();
+  if (control == nullptr)
+    return false;
+
+  control->SetFocus();
+  return true;
+}
+
+bool
 ContainerWindow::FocusNextControl() noexcept
 {
   Window *focused = GetFocusedWindow();

--- a/src/ui/window/gdi/ContainerWindow.cpp
+++ b/src/ui/window/gdi/ContainerWindow.cpp
@@ -37,6 +37,22 @@ ContainerWindow::FocusFirstControl() noexcept
 }
 
 bool
+ContainerWindow::FocusLastControl() noexcept
+{
+  /* Previous from the first TabStop wraps to the last TabStop. */
+  HWND hFirst = ::GetNextDlgTabItem(hWnd, nullptr, false);
+  if (hFirst == nullptr)
+    return false;
+
+  HWND hLast = ::GetNextDlgTabItem(hWnd, hFirst, true);
+  if (hLast == nullptr)
+    return false;
+
+  ::SetFocus(hLast);
+  return true;
+}
+
+bool
 ContainerWindow::FocusNextControl() noexcept
 {
   HWND hControl = ::GetNextDlgTabItem(hWnd, ::GetFocus(), false);


### PR DESCRIPTION
## Summary

Keyboard / remote UX and related map polish, organized bottom-up:

### Focus infrastructure
- `FocusLastControl` and pager / ArrowPager focus handoff
- Button focus colour, ButtonPanel proportional layout, GridView over disabled Quick Menu items, list help separators

### Dialogs and pickers
- Single keyboard focus for List / Download / Multi-file pickers
- Plane polar editor, Waypoint Details/F1, Task Point navigation + portrait layout
- Configuration menu keyboard navigation
- WiFi button order; simulator prompt Left/Right

### Map items and overlays
- Your Position icon (shared `AircraftRenderer::DrawSimple`), Status Flight, Inside/Near badges (`AirspaceWarningStatusRenderer`)
- Replay speed on map scale; GPS status above title

### Input and UI
- `AirspaceLabels` toggle (Display + Quick Menu); Quick Guide / Replay in Quick Menu; FLARM F1 → AVG/ALT
- Vario bar left / final-glide right; TextInBox padding; InfoBox panel sized to current tab
- RGBA logo/title tiers on parchment; soft-keyboard cursor grid + F1 backspace

Closes #1210
Closes #1243
Closes #1438
Closes #2281
Closes #2742

Related (partial): #2535 (FLARM F1 label toggle only)

## Test plan
- [ ] Configuration: Up/Down rows; Left/Right pages; Esc returns to menu; focus starts on menu
- [ ] Quick Menu: Left/Right over disabled items; Quick Guide + Replay entries
- [ ] Soft keyboard: arrows on grid; Enter types; F1 backspace; Up from OK/Cancel/Clear into keys
- [ ] Task Point (portrait): map + OZ stack; Type + Left/Right change point; Left/Right unused at ends
- [ ] Waypoint list: Details / F1 open details; download/multi pickers: Download before Cancel; single focus
- [ ] Simulator prompt: Left = Fly, Right = Simulator
- [ ] Profile selection (light + HiDPI): no white rectangles on logo/title (#2742)
- [ ] InfoBox Altitude → Simulator: map title does not jump by Setup tab height
- [ ] Map items: Your Position icon; Enter → Status Flight; Inside/Near when room
- [ ] Replay speed on scale (#2281); Airspace Labels toggle (#1243)
- [ ] Map overlays: vario left, final glide right (#1210); even label padding (#1438)
- [ ] FLARM radar: F1 toggles AVG/ALT; Down still previous target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added airspace-label controls and improved FLARM radar navigation, zoom, and label switching.
  * Expanded the RemoteStick Quick Menu with Quick Guide and Replay actions.
  * Added `.cupx` waypoint-file support, waypoint details access, and clearer airspace warning badges.
* **Bug Fixes**
  * Improved keyboard navigation across dialogs, lists, task editing, simulator selection, and soft-keyboard input.
  * Refined panel sizing, focus handling, map overlays, GPS/replay labels, startup branding, polar editing, and flight-data rendering.
  * Improved configuration-menu Escape behavior and dynamic dialog sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->