### PR TITLE
MapWindow: GeoTIFF raster overlays and multi-overlay support

### DIFF
--- a/build/libtiff.mk
+++ b/build/libtiff.mk
@@ -1,6 +1,10 @@
-# Experimental feature - only enabled on Linux for now
-ifeq ($(TARGET_IS_DARWIN),y)
+# GeoTIFF-backed raster overlays are available on all non-Kobo targets.
+ifeq ($(TARGET_IS_KOBO),y)
 GEOTIFF = n
+else ifeq ($(TARGET_IS_DARWIN),y)
+GEOTIFF ?= y
+else ifeq ($(TARGET),PC)
+GEOTIFF ?= y
 else ifeq ($(TARGET)$(TARGET_IS_KOBO),UNIXn)
 GEOTIFF ?= y
 else ifeq ($(TARGET),ANDROID)
@@ -19,10 +23,31 @@ LIBTIFF_CPPFLAGS += -DUSE_LIBTIFF
 
 ifeq ($(GEOTIFF),y)
 LIBTIFF_CPPFLAGS += -DUSE_GEOTIFF
+LIBGEOTIFF_USE_PKG_CONFIG := y
+LIBGEOTIFF_LDLIBS = -lgeotiff
+
 ifneq ($(USE_THIRDPARTY_LIBS),y)
-LIBTIFF_CPPFLAGS += -isystem /usr/include/geotiff
+ifeq ($(HOST_IS_LINUX)$(TARGET_IS_LINUX),yy)
+ifeq ($(HOST_TRIPLET),)
+# Native Linux distributions may ship libgeotiff without libgeotiff.pc.
+LIBGEOTIFF_USE_PKG_CONFIG := n
 endif
-LIBTIFF_LDLIBS += -lgeotiff
+endif
+endif
+
+ifeq ($(LIBGEOTIFF_USE_PKG_CONFIG),y)
+$(eval $(call pkg-config-library,LIBGEOTIFF,libgeotiff))
+LIBTIFF_CPPFLAGS += $(LIBGEOTIFF_CPPFLAGS)
+else
+ifneq ($(shell $(PKG_CONFIG) --exists proj >/dev/null 2>&1 && echo y),)
+# Some system libgeotiff builds don't ship libgeotiff.pc, but still
+# depend on PROJ at link time (e.g. libgeotiff 1.7.x on Yocto).
+$(eval $(call pkg-config-library,LIBGEOTIFF_PROJ,proj))
+LIBTIFF_LDLIBS += $(LIBGEOTIFF_PROJ_LDLIBS)
+endif
+endif
+
+LIBTIFF_LDLIBS += $(LIBGEOTIFF_LDLIBS)
 endif
 
 ifeq ($(GEOTIFF)$(USE_THIRDPARTY_LIBS),yy)

--- a/build/screen.mk
+++ b/build/screen.mk
@@ -244,6 +244,13 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/gdi/BufferCanvas.cpp \
 	$(CANVAS_SRC_DIR)/gdi/PaintCanvas.cpp \
 
+ifeq ($(OPENGL),y)
+SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/GeoBitmap.cpp
+ifeq ($(TIFF),y)
+SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/LibTiff.cpp
+endif
+endif
+
 GDI_CPPFLAGS = -DUSE_GDI
 WINUSER_CPPFLAGS = -DUSE_WINUSER
 GDI_LDLIBS = -luser32 -lgdi32 -lmsimg32 -lgdiplus

--- a/src/Geo/GeoTIFFHeaders.hpp
+++ b/src/Geo/GeoTIFFHeaders.hpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#if defined(__has_include)
+
+#if __has_include(<geotiff.h>)
+#include <geo_normalize.h>
+#include <geotiff.h>
+#include <geotiffio.h>
+#include <geovalues.h>
+#include <xtiffio.h>
+#elif __has_include(<geotiff/geotiff.h>)
+#include <geotiff/geo_normalize.h>
+#include <geotiff/geotiff.h>
+#include <geotiff/geotiffio.h>
+#include <geotiff/geovalues.h>
+#include <geotiff/xtiffio.h>
+#else
+#error "libgeotiff headers not found"
+#endif
+
+#else
+
+#include <geo_normalize.h>
+#include <geotiff.h>
+#include <geotiffio.h>
+#include <geovalues.h>
+#include <xtiffio.h>
+
+#endif

--- a/src/MapWindow/GlueMapWindowItems.cpp
+++ b/src/MapWindow/GlueMapWindowItems.cpp
@@ -20,6 +20,7 @@
 #endif
 #include "Interface.hpp"
 #include "Overlay.hpp"
+#include "OverlayLimits.hpp"
 
 bool
 GlueMapWindow::ShowMapItems(const GeoPoint &location,
@@ -87,8 +88,16 @@ GlueMapWindow::ShowMapItems(const GeoPoint &location,
   builder.AddTraffic(basic.flarm.traffic);
 
 #ifdef ENABLE_OPENGL
+#ifdef HAVE_HTTP
+  if (!list.full())
+    for (unsigned i = 0; i < MapWindowOverlay::MAX_MAP_OVERLAYS && !list.full(); ++i)
+      if (const auto *map_overlay = GetOverlay(i);
+          map_overlay != nullptr && map_overlay->IsInside(location))
+        list.push_back(new OverlayMapItem(*map_overlay, location));
+#else
   if (!list.full() && overlay && overlay->IsInside(location))
     list.push_back(new OverlayMapItem(*overlay, location));
+#endif
 #endif
 
   if (!list.full()) {

--- a/src/MapWindow/MapWindow.cpp
+++ b/src/MapWindow/MapWindow.cpp
@@ -50,8 +50,22 @@ MapWindow::PublishFrameProjection() noexcept
 void
 MapWindow::SetOverlay(std::unique_ptr<MapOverlay> &&_overlay) noexcept
 {
+#if defined(HAVE_HTTP)
+  SetOverlay(0, std::move(_overlay));
+#else
   overlay = std::move(_overlay);
+#endif
 }
+
+#if defined(HAVE_HTTP)
+void
+MapWindow::SetOverlay(unsigned index, std::unique_ptr<MapOverlay> &&_overlay) noexcept
+{
+  assert(index < MapWindowOverlay::MAX_MAP_OVERLAYS);
+  if (index < MapWindowOverlay::MAX_MAP_OVERLAYS)
+    overlay[index] = std::move(_overlay);
+}
+#endif
 
 #endif
 

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -17,6 +17,7 @@
 #include "Renderer/WaypointRenderer.hpp"
 #include "Renderer/TrailRenderer.hpp"
 #include "Renderer/TurnBackMarkerRenderer.hpp"
+#include "OverlayLimits.hpp"
 #include "Weather/Features.hpp"
 #include "Tracking/SkyLines/Features.hpp"
 
@@ -127,7 +128,11 @@ protected:
   std::unique_ptr<RaspRenderer> rasp_renderer;
 
 #ifdef ENABLE_OPENGL
+#if defined(HAVE_HTTP)
+  std::unique_ptr<MapOverlay> overlay[MapWindowOverlay::MAX_MAP_OVERLAYS];
+#else
   std::unique_ptr<MapOverlay> overlay;
+#endif
 #endif
 
   const TrafficLook &traffic_look;
@@ -231,8 +236,22 @@ public:
 #ifdef ENABLE_OPENGL
   void SetOverlay(std::unique_ptr<MapOverlay> &&_overlay) noexcept;
 
+#if defined(HAVE_HTTP)
+  void SetOverlay(unsigned index, std::unique_ptr<MapOverlay> &&_overlay) noexcept;
+
+  const MapOverlay *GetOverlay(unsigned index) const noexcept {
+    return index < MapWindowOverlay::MAX_MAP_OVERLAYS
+      ? overlay[index].get()
+      : nullptr;
+  }
+#endif
+
   const MapOverlay *GetOverlay() const noexcept {
+#if defined(HAVE_HTTP)
+    return GetOverlay(0);
+#else
     return overlay.get();
+#endif
   }
 #endif
 

--- a/src/MapWindow/OverlayBitmap.cpp
+++ b/src/MapWindow/OverlayBitmap.cpp
@@ -29,11 +29,7 @@ using ClippedPolygon = boost::geometry::model::polygon<DoublePoint2D>;
 using ClippedMultiPolygon =
   boost::geometry::model::multi_polygon<ClippedPolygon>;
 
-#ifdef USE_GEOTIFF
 MapOverlayBitmap::MapOverlayBitmap(Path path)
-#else
-[[noreturn]] MapOverlayBitmap::MapOverlayBitmap(Path path)
-#endif
   :label((path.GetBase() != nullptr ? path.GetBase() : path).c_str())
 {
   bounds = bitmap.LoadGeoFile(path);

--- a/src/MapWindow/OverlayBitmap.hpp
+++ b/src/MapWindow/OverlayBitmap.hpp
@@ -40,15 +40,11 @@ class MapOverlayBitmap final : public MapOverlay {
 
 public:
   /**
-   * Load a GeoTIFF file.
+  * Load a georeferenced image file.
    *
    * Throws on error.
    */
-#ifdef USE_GEOTIFF
   MapOverlayBitmap(Path path);
-#else
-  [[noreturn]] MapOverlayBitmap(Path path);
-#endif
 
   /**
    * Move an existing #Bitmap with a geo reference.

--- a/src/MapWindow/OverlayLimits.hpp
+++ b/src/MapWindow/OverlayLimits.hpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstddef>
+
+namespace MapWindowOverlay {
+
+inline constexpr std::size_t MAX_MAP_OVERLAYS = 9;
+
+} // namespace MapWindowOverlay

--- a/src/ui/canvas/Bitmap.hpp
+++ b/src/ui/canvas/Bitmap.hpp
@@ -180,14 +180,10 @@ public:
   bool LoadFile(Path path);
 
   /**
-   * Load a georeferenced image (e.g. GeoTIFF) and return its bounds.
+   * Load a georeferenced image and return its bounds.
    * Throws a std::runtime_error on error.
    */
-#ifdef USE_GEOTIFF
   GeoQuadrilateral LoadGeoFile(Path path);
-#else
-  [[noreturn]] GeoQuadrilateral LoadGeoFile(Path path);
-#endif
 
   void Reset() noexcept;
 

--- a/src/ui/canvas/Bitmap.hpp
+++ b/src/ui/canvas/Bitmap.hpp
@@ -161,8 +161,11 @@ public:
   }
 #endif
 
-#ifndef USE_GDI
+#if !defined(USE_GDI) || defined(ENABLE_OPENGL)
   bool Load(UncompressedImage &&uncompressed, Type type=Type::STANDARD);
+#endif
+
+#if !defined(USE_GDI) && !defined(ANDROID)
 #ifndef ANDROID
   bool Load(std::span<const std::byte> buffer, Type type=Type::STANDARD);
 #endif

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -2,10 +2,18 @@
 // Copyright The XCSoar Project
 
 #include "ui/canvas/Bitmap.hpp"
+#include "GeoBitmap.hpp"
 #include "UncompressedImage.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/Quadrilateral.hpp"
+#include "Projection/MapWindowProjection.hpp"
 #include "system/Path.hpp"
 #include "system/FileUtil.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <string_view>
 
 #ifdef USE_GEOTIFF
 #include "LibTiff.hpp"
@@ -13,13 +21,120 @@
 
 #include <stdexcept>
 
-#ifdef USE_GEOTIFF
-/* Smallest useful GeoTIFF is far larger; skip obvious truncation before LibTiff. */
-static constexpr unsigned kMinTiffGeoFileSize = 100;
+using namespace GeoBitmap;
+
+static int
+LonToTileX(double lon, int zoom) noexcept
+{
+  return (int)std::floor((lon + 180.0) / 360.0 * (1 << zoom));
+}
+
+static int
+LatToTileY(double lat, int zoom) noexcept
+{
+  const double latitude_radians = lat * M_PI / 180.0;
+  return (int)std::floor((1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) /
+                         2.0 * (1 << zoom));
+}
+
+static double
+TileXToLon(int x, int zoom) noexcept
+{
+  return x / (double)(1 << zoom) * 360.0 - 180.0;
+}
+
+static double
+TileYToLat(int y, int zoom) noexcept
+{
+  const double n = M_PI - 2.0 * M_PI * y / (double)(1 << zoom);
+  return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
+}
+
+TileData
+GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
+{
+  return {
+    zoom,
+    (uint16_t)LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
+    (uint16_t)LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
+  };
+}
+
+TileData
+GeoBitmap::GetTile(const MapWindowProjection &projection,
+                   uint16_t zoom_min, uint16_t zoom_max) noexcept
+{
+  constexpr double earth_circumference = 42e6;
+
+  const double diagonal = projection.GetScreenDistanceMeters();
+  const double ratio = earth_circumference / diagonal;
+  const auto zoom = (uint16_t)std::clamp((int)std::floor(std::log2(ratio)) + 1,
+                                         (int)zoom_min, (int)zoom_max);
+  return GetTile(projection.GetScreenBounds(), zoom);
+}
+
+GeoQuadrilateral
+GeoBitmap::GetGeoQuadrilateral(const TileData &tile) noexcept
+{
+  GeoQuadrilateral bounds;
+
+  bounds.top_left.longitude = Angle::Degrees(TileXToLon(tile.x, tile.zoom));
+  bounds.top_left.latitude = Angle::Degrees(TileYToLat(tile.y, tile.zoom));
+  bounds.bottom_left.longitude = bounds.top_left.longitude;
+  bounds.bottom_left.latitude = Angle::Degrees(TileYToLat(tile.y + 1, tile.zoom));
+
+  bounds.top_right.longitude = Angle::Degrees(TileXToLon(tile.x + 1, tile.zoom));
+  bounds.top_right.latitude = bounds.top_left.latitude;
+  bounds.bottom_right.longitude = bounds.top_right.longitude;
+  bounds.bottom_right.latitude = bounds.bottom_left.latitude;
+
+  return bounds;
+}
+
+GeoBounds
+GeoBitmap::GetBounds(const TileData &tile) noexcept
+{
+  return GetGeoQuadrilateral(tile).GetBounds();
+}
+
+static GeoQuadrilateral
+ParseTileBounds(std::string_view name)
+{
+  if (name.starts_with("satellite-"))
+    name.remove_prefix(std::char_traits<char>::length("satellite-"));
+  else if (name.starts_with("rain-"))
+    name.remove_prefix(std::char_traits<char>::length("rain-"));
+
+  auto next = [](std::string_view &remaining) {
+    const auto split = remaining.find('-');
+    const auto value = remaining.substr(0, split);
+    if (split == std::string_view::npos)
+      remaining = {};
+    else
+      remaining.remove_prefix(split + 1);
+    return value;
+  };
+
+  std::string_view remaining = name;
+  const auto zoom_string = next(remaining);
+  const auto x_string = next(remaining);
+  const auto y_string = next(remaining);
+  if (zoom_string.empty() || x_string.empty() || y_string.empty())
+    throw std::runtime_error("Unsupported geo image file");
+
+  const auto zoom = (uint16_t)std::strtoul(std::string(zoom_string).c_str(), nullptr, 10);
+  const auto x = (uint16_t)std::strtoul(std::string(x_string).c_str(), nullptr, 10);
+  const auto y = (uint16_t)std::strtoul(std::string(y_string).c_str(), nullptr, 10);
+  return GeoBitmap::GetGeoQuadrilateral({zoom, x, y});
+}
 
 GeoQuadrilateral
 Bitmap::LoadGeoFile(Path path)
 {
+#ifdef USE_GEOTIFF
+  /* Smallest useful GeoTIFF is far larger; skip obvious truncation before LibTiff. */
+  static constexpr unsigned kMinTiffGeoFileSize = 100;
+
   if (path.EndsWithIgnoreCase(".tif") ||
       path.EndsWithIgnoreCase(".tiff")) {
     if (File::GetSize(path) < kMinTiffGeoFileSize)
@@ -33,13 +148,23 @@ Bitmap::LoadGeoFile(Path path)
 
     return result.second;
   }
+#endif
+
+  if (path.EndsWithIgnoreCase(".jpg") ||
+      path.EndsWithIgnoreCase(".jpeg") ||
+      path.EndsWithIgnoreCase(".jfif") ||
+      path.EndsWithIgnoreCase(".png")) {
+    if (!LoadFile(path))
+      throw std::runtime_error("Failed to use geo image file");
+
+    assert(IsDefined());
+
+    const auto base = path.GetBase();
+    if (base == nullptr)
+      throw std::runtime_error("Unsupported geo image file");
+
+    return ParseTileBounds(base.c_str());
+  }
 
   throw std::runtime_error("Unsupported geo image file");
 }
-#else
-[[noreturn]] GeoQuadrilateral
-Bitmap::LoadGeoFile([[maybe_unused]] Path)
-{
-  throw std::runtime_error("Unsupported geo image file");
-}
-#endif

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -11,8 +11,8 @@
 #include "system/FileUtil.hpp"
 
 #include <algorithm>
+#include <charconv>
 #include <cmath>
-#include <cstdlib>
 #include <string_view>
 
 #ifdef USE_GEOTIFF
@@ -23,30 +23,33 @@
 
 using namespace GeoBitmap;
 
-static int
-LonToTileX(double lon, int zoom) noexcept
+static uint32_t
+LonToTileX(double lon, unsigned zoom) noexcept
 {
-  return (int)std::floor((lon + 180.0) / 360.0 * (1 << zoom));
+  return uint32_t(std::floor((lon + 180.0) / 360.0 *
+                             (uint32_t{1} << zoom)));
 }
 
-static int
-LatToTileY(double lat, int zoom) noexcept
+static uint32_t
+LatToTileY(double lat, unsigned zoom) noexcept
 {
   const double latitude_radians = lat * M_PI / 180.0;
-  return (int)std::floor((1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) /
-                         2.0 * (1 << zoom));
+  return uint32_t(std::floor(
+    (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
+    (uint32_t{1} << zoom)));
 }
 
 static double
-TileXToLon(int x, int zoom) noexcept
+TileXToLon(uint32_t x, unsigned zoom) noexcept
 {
-  return x / (double)(1 << zoom) * 360.0 - 180.0;
+  return x / double(uint32_t{1} << zoom) * 360.0 - 180.0;
 }
 
 static double
-TileYToLat(int y, int zoom) noexcept
+TileYToLat(uint32_t y, unsigned zoom) noexcept
 {
-  const double n = M_PI - 2.0 * M_PI * y / (double)(1 << zoom);
+  const double n = M_PI - 2.0 * M_PI * y /
+    double(uint32_t{1} << zoom);
   return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
 }
 
@@ -55,8 +58,8 @@ GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
 {
   return {
     zoom,
-    (uint16_t)LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
-    (uint16_t)LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
+    LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
+    LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
   };
 }
 
@@ -122,9 +125,26 @@ ParseTileBounds(std::string_view name)
   if (zoom_string.empty() || x_string.empty() || y_string.empty())
     throw std::runtime_error("Unsupported geo image file");
 
-  const auto zoom = (uint16_t)std::strtoul(std::string(zoom_string).c_str(), nullptr, 10);
-  const auto x = (uint16_t)std::strtoul(std::string(x_string).c_str(), nullptr, 10);
-  const auto y = (uint16_t)std::strtoul(std::string(y_string).c_str(), nullptr, 10);
+  auto parse = [](std::string_view value) {
+    uint32_t result = 0;
+    const auto [end, error] = std::from_chars(value.begin(), value.end(), result);
+    if (error != std::errc{} || end != value.end())
+      throw std::runtime_error("Unsupported geo image file");
+
+    return result;
+  };
+
+  const auto zoom_value = parse(zoom_string);
+  const auto x = parse(x_string);
+  const auto y = parse(y_string);
+  if (zoom_value == 0 || zoom_value > MAX_TILE_ZOOM)
+    throw std::runtime_error("Unsupported geo image file");
+
+  const auto tile_count = uint32_t{1} << zoom_value;
+  if (x >= tile_count || y >= tile_count)
+    throw std::runtime_error("Unsupported geo image file");
+
+  const auto zoom = uint16_t(zoom_value);
   return GeoBitmap::GetGeoQuadrilateral({zoom, x, y});
 }
 

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -151,6 +151,9 @@ ParseTileBounds(std::string_view name)
 GeoQuadrilateral
 Bitmap::LoadGeoFile(Path path)
 {
+  if (!File::Exists(path))
+    throw std::runtime_error("Geo image file not found");
+
 #ifdef USE_GEOTIFF
   /* Smallest useful GeoTIFF is far larger; skip obvious truncation before LibTiff. */
   static constexpr unsigned kMinTiffGeoFileSize = 100;

--- a/src/ui/canvas/custom/GeoBitmap.hpp
+++ b/src/ui/canvas/custom/GeoBitmap.hpp
@@ -11,10 +11,12 @@ class MapWindowProjection;
 
 namespace GeoBitmap {
 
+inline constexpr unsigned MAX_TILE_ZOOM = 20;
+
 struct TileData {
   uint16_t zoom = 0;
-  uint16_t x = 0;
-  uint16_t y = 0;
+  uint32_t x = 0;
+  uint32_t y = 0;
 
   constexpr bool IsValid() const noexcept {
     return zoom > 0;
@@ -26,7 +28,8 @@ GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept;
 
 TileData
 GetTile(const MapWindowProjection &projection,
-        uint16_t zoom_min = 1, uint16_t zoom_max = 20) noexcept;
+        uint16_t zoom_min = 1,
+        uint16_t zoom_max = MAX_TILE_ZOOM) noexcept;
 
 GeoBounds
 GetBounds(const TileData &data) noexcept;

--- a/src/ui/canvas/custom/GeoBitmap.hpp
+++ b/src/ui/canvas/custom/GeoBitmap.hpp
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+class GeoBounds;
+struct GeoQuadrilateral;
+class MapWindowProjection;
+
+namespace GeoBitmap {
+
+struct TileData {
+  uint16_t zoom = 0;
+  uint16_t x = 0;
+  uint16_t y = 0;
+
+  constexpr bool IsValid() const noexcept {
+    return zoom > 0;
+  }
+};
+
+TileData
+GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept;
+
+TileData
+GetTile(const MapWindowProjection &projection,
+        uint16_t zoom_min = 1, uint16_t zoom_max = 20) noexcept;
+
+GeoBounds
+GetBounds(const TileData &data) noexcept;
+
+GeoQuadrilateral
+GetGeoQuadrilateral(const TileData &data) noexcept;
+
+} // namespace GeoBitmap

--- a/src/ui/canvas/custom/LibTiff.cpp
+++ b/src/ui/canvas/custom/LibTiff.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <stdexcept>
 
 #include <tiffio.h>
@@ -65,6 +66,11 @@ BilinearUpscale(UncompressedImage &&src, unsigned scale)
 
   const unsigned src_width = src.GetWidth();
   const unsigned src_height = src.GetHeight();
+  if (src_width == 0 || src_height == 0 ||
+      src_width > std::numeric_limits<unsigned>::max() / scale ||
+      src_height > std::numeric_limits<unsigned>::max() / scale)
+    return std::move(src);
+
   const unsigned dst_width = src_width * scale;
   const unsigned dst_height = src_height * scale;
 
@@ -90,7 +96,16 @@ BilinearUpscale(UncompressedImage &&src, unsigned scale)
   const auto src_pitch = src.GetPitch();
   const auto *src_data = (const uint8_t *)src.GetData();
 
+  constexpr std::size_t MAX_SCALED_BYTES = 256u * 1024u * 1024u;
+  if (std::size_t(dst_width) >
+      std::numeric_limits<std::size_t>::max() / bytes_per_pixel)
+    return std::move(src);
+
   const std::size_t dst_pitch = std::size_t(dst_width) * bytes_per_pixel;
+  if (dst_height > std::numeric_limits<std::size_t>::max() / dst_pitch ||
+      dst_pitch * dst_height > MAX_SCALED_BYTES)
+    return std::move(src);
+
   auto dst_data = std::make_unique<uint8_t[]>(dst_pitch * dst_height);
 
   for (unsigned dst_y = 0; dst_y < dst_height; ++dst_y) {
@@ -122,8 +137,7 @@ BilinearUpscale(UncompressedImage &&src, unsigned scale)
           float(p10[channel]) * fx * (1.0f - fy) +
           float(p01[channel]) * (1.0f - fx) * fy +
           float(p11[channel]) * fx * fy;
-        const auto out_channel = (channel & 1u) ? channel : (channel + 2u) % 4u;
-        dst[out_channel] = (uint8_t)(value + 0.5f);
+        dst[channel] = (uint8_t)(value + 0.5f);
       }
     }
   }

--- a/src/ui/canvas/custom/LibTiff.cpp
+++ b/src/ui/canvas/custom/LibTiff.cpp
@@ -6,17 +6,15 @@
 #include "system/Path.hpp"
 #include "util/ScopeExit.hxx"
 
+#include <algorithm>
+#include <cmath>
 #include <stdexcept>
 
 #include <tiffio.h>
 
 #ifdef USE_GEOTIFF
 #include "Geo/Quadrilateral.hpp"
-
-#include <geotiff.h>
-#include <geo_normalize.h>
-#include <geovalues.h>
-#include <xtiffio.h>
+#include "Geo/GeoTIFFHeaders.hpp"
 #endif
 
 static TIFF *
@@ -58,6 +56,83 @@ public:
   }
 };
 
+#if defined(_WIN32)
+static UncompressedImage
+BilinearUpscale(UncompressedImage &&src, unsigned scale)
+{
+  if (scale <= 1)
+    return std::move(src);
+
+  const unsigned src_width = src.GetWidth();
+  const unsigned src_height = src.GetHeight();
+  const unsigned dst_width = src_width * scale;
+  const unsigned dst_height = src_height * scale;
+
+  const auto format = src.GetFormat();
+  unsigned bytes_per_pixel;
+  switch (format) {
+  case UncompressedImage::Format::RGBA:
+    bytes_per_pixel = 4;
+    break;
+
+  case UncompressedImage::Format::RGB:
+    bytes_per_pixel = 3;
+    break;
+
+  case UncompressedImage::Format::GRAY:
+    bytes_per_pixel = 1;
+    break;
+
+  default:
+    return std::move(src);
+  }
+
+  const auto src_pitch = src.GetPitch();
+  const auto *src_data = (const uint8_t *)src.GetData();
+
+  const std::size_t dst_pitch = std::size_t(dst_width) * bytes_per_pixel;
+  auto dst_data = std::make_unique<uint8_t[]>(dst_pitch * dst_height);
+
+  for (unsigned dst_y = 0; dst_y < dst_height; ++dst_y) {
+    const float src_y = (float(dst_y) + 0.5f) / float(scale) - 0.5f;
+    const int src_y_index = (int)std::floor(src_y);
+    const float fy = src_y - float(src_y_index);
+
+    const unsigned src_y0 = (unsigned)std::max(src_y_index, 0);
+    const unsigned src_y1 = std::min((unsigned)(src_y_index + 1), src_height - 1);
+
+    for (unsigned dst_x = 0; dst_x < dst_width; ++dst_x) {
+      const float src_x = (float(dst_x) + 0.5f) / float(scale) - 0.5f;
+      const int src_x_index = (int)std::floor(src_x);
+      const float fx = src_x - float(src_x_index);
+
+      const unsigned src_x0 = (unsigned)std::max(src_x_index, 0);
+      const unsigned src_x1 = std::min((unsigned)(src_x_index + 1), src_width - 1);
+
+      const uint8_t *p00 = src_data + src_y0 * src_pitch + src_x0 * bytes_per_pixel;
+      const uint8_t *p10 = src_data + src_y0 * src_pitch + src_x1 * bytes_per_pixel;
+      const uint8_t *p01 = src_data + src_y1 * src_pitch + src_x0 * bytes_per_pixel;
+      const uint8_t *p11 = src_data + src_y1 * src_pitch + src_x1 * bytes_per_pixel;
+
+      uint8_t *dst = dst_data.get() + dst_y * dst_pitch + dst_x * bytes_per_pixel;
+
+      for (unsigned channel = 0; channel < bytes_per_pixel; ++channel) {
+        const float value =
+          float(p00[channel]) * (1.0f - fx) * (1.0f - fy) +
+          float(p10[channel]) * fx * (1.0f - fy) +
+          float(p01[channel]) * (1.0f - fx) * fy +
+          float(p11[channel]) * fx * fy;
+        const auto out_channel = (channel & 1u) ? channel : (channel + 2u) % 4u;
+        dst[out_channel] = (uint8_t)(value + 0.5f);
+      }
+    }
+  }
+
+  return UncompressedImage(format, dst_pitch, dst_width, dst_height,
+                           std::move(dst_data), src.IsFlipped());
+}
+#endif
+
 static UncompressedImage
 LoadTiff(TIFFRGBAImage &img)
 {
@@ -70,8 +145,15 @@ LoadTiff(TIFFRGBAImage &img)
   if (!TIFFRGBAImageGet(&img, data32, img.width, img.height))
     throw std::runtime_error("Failed to copy TIFF data");
 
+#if defined(_WIN32)
+  auto uncompressed = UncompressedImage(UncompressedImage::Format::RGBA,
+                                        img.width * 4, img.width, img.height,
+                                        std::move(data), true);
+  return BilinearUpscale(std::move(uncompressed), 4);
+#else
   return UncompressedImage(UncompressedImage::Format::RGBA, img.width * 4,
                            img.width, img.height, std::move(data), true);
+#endif
 }
 
 static UncompressedImage


### PR DESCRIPTION
## Summary
- Add GeoTIFF/georeferenced tile image support on desktop canvas targets (LibTiff + GeoBitmap).
- Enable raster overlay loading with early rejection of missing files, tile-coordinate validation, and bounded/smooth Windows image scaling.
- Allow MapWindow to keep multiple raster overlays.

## Test plan
- [ ] Build `TARGET=UNIX` and confirm overlay GeoTIFF loads on the map
- [ ] Build `TARGET=WIN64` / `PC` and exercise Windows LibTiff scaling path
- [ ] Verify missing overlay files are rejected without crashing
- [ ] Confirm existing RASP/weather overlays still work alongside GeoTIFF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading georeferenced GeoTIFF, JPEG/JFIF, and PNG tile images.
  - Map windows can now display and select multiple overlays, with up to nine overlays supported.
  - Added automatic tile positioning and geographic boundary calculations for map images.
  - OpenGL builds on Windows now support additional bitmap and TIFF functionality.

- **Bug Fixes**
  - Improved GeoTIFF detection and compatibility across supported platforms.
  - Added safer handling for missing files, invalid tiles, oversized images, and image-processing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->