### PR TITLE
Device/Port, build/test.mk: Fix master CI link failures

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -191,6 +191,7 @@ TEST_GDL90_DRIVER_SOURCES = \
 	$(SRC)/util/CRC16CCITT.cpp \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(SRC)/Computer/ClimbAverageCalculator.cpp \
+	$(TEST_SRC_DIR)/FakeFlarmGlue.cpp \
 	$(TEST_SRC_DIR)/FakeGeoidNonZero.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/tap.c \
@@ -1556,6 +1557,7 @@ $(eval $(call link-program,EnumeratePorts,ENUMERATE_PORTS))
 
 READ_PORT_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -1567,6 +1569,7 @@ $(eval $(call link-program,ReadPort,READ_PORT))
 
 RUN_PORT_HANDLER_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -1578,6 +1581,7 @@ $(eval $(call link-program,RunPortHandler,RUN_PORT_HANDLER))
 
 LOG_PORT_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -1590,6 +1594,7 @@ $(eval $(call link-program,LogPort,LOG_PORT))
 
 SPLICE_PORTS_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -2788,6 +2793,7 @@ $(eval $(call link-program,TestNotify,TEST_NOTIFY))
 
 FEED_NMEA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -2799,6 +2805,7 @@ $(eval $(call link-program,FeedNMEA,FEED_NMEA))
 
 FEED_VEGA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -2810,6 +2817,7 @@ $(eval $(call link-program,FeedVega,FEED_VEGA))
 
 EMULATE_DEVICE_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Util/LineSplitter.cpp \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Device/Util/NMEAReader.cpp \
@@ -2831,6 +2839,7 @@ $(eval $(call link-program,EmulateDevice,EMULATE_DEVICE))
 
 FEED_FLYNET_DATA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -4,7 +4,7 @@
 #include "ConfiguredPort.hpp"
 #include "UDPPort.hpp"
 #include "TCPPort.hpp"
-#include "SpectateFilePort.hpp"
+#include "OpenSpectateFilePort.hpp"
 #include "K6BtPort.hpp"
 #include "Device/Config.hpp"
 #include "LogFile.hpp"
@@ -181,9 +181,9 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
       ? DeviceConfig::DEFAULT_SPECTATE_PATH
       : config.path.c_str();
 
-    return std::make_unique<SpectateFilePort>(Path(spectate_path),
-                                              config.port_name,
-                                              listener, handler);
+    return OpenSpectateFilePort(Path(spectate_path),
+                                config.port_name,
+                                listener, handler);
   }
 
   case DeviceConfig::PortType::PTY: {

--- a/src/Device/Port/OpenSpectateFilePort.hpp
+++ b/src/Device/Port/OpenSpectateFilePort.hpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+
+#include <memory>
+
+class Port;
+class PortListener;
+class DataHandler;
+
+/**
+ * Open a Condor Spectate.json polling port.
+ *
+ * The real implementation lives with SpectateFilePort; tests that link
+ * ConfiguredPort without DRIVER may provide a stub instead.
+ */
+std::unique_ptr<Port>
+OpenSpectateFilePort(Path path, const char *own_cn,
+                     PortListener *listener,
+                     DataHandler &handler);

--- a/src/Device/Port/SpectateFilePort.cpp
+++ b/src/Device/Port/SpectateFilePort.cpp
@@ -2,18 +2,34 @@
 // Copyright The XCSoar Project
 
 #include "SpectateFilePort.hpp"
+#include "OpenSpectateFilePort.hpp"
 #include "Device/Driver/Condor3Spectate.hpp"
 #include "io/DataHandler.hpp"
 
+#include <memory>
 #include <stdexcept>
+
+std::unique_ptr<Port>
+OpenSpectateFilePort(Path path, const char *own_cn,
+                     PortListener *listener,
+                     DataHandler &handler)
+{
+  return std::make_unique<SpectateFilePort>(path, own_cn, listener, handler);
+}
 
 SpectateFilePort::SpectateFilePort(Path _path, const char *_own_cn,
                                    PortListener *listener,
                                    DataHandler &handler) noexcept
-  :Port(listener, handler), path(_path)
+  :Port(listener, handler), SuspensibleThread("SpectateFilePort"),
+   path(_path)
 {
   if (_own_cn != nullptr)
     own_cn = _own_cn;
+}
+
+SpectateFilePort::~SpectateFilePort() noexcept
+{
+  StopRxThread();
 }
 
 PortState
@@ -53,17 +69,19 @@ SpectateFilePort::SetBaudrate(unsigned)
 bool
 SpectateFilePort::StopRxThread()
 {
-  running = false;
-  timer.Cancel();
+  if (Thread::IsDefined()) {
+    BeginStop();
+    Thread::Join();
+  }
+
   return true;
 }
 
 bool
 SpectateFilePort::StartRxThread()
 {
-  running = true;
-  Poll();
-  timer.Schedule(std::chrono::seconds(1));
+  StopRxThread();
+  SuspensibleThread::Start();
   return true;
 }
 
@@ -102,11 +120,10 @@ SpectateFilePort::Poll() noexcept
 }
 
 void
-SpectateFilePort::OnTimer() noexcept
+SpectateFilePort::Run() noexcept
 {
-  if (!running)
-    return;
-
   Poll();
-  timer.Schedule(std::chrono::seconds(1));
+
+  while (!WaitForStopped(std::chrono::seconds(1)))
+    Poll();
 }

--- a/src/Device/Port/SpectateFilePort.hpp
+++ b/src/Device/Port/SpectateFilePort.hpp
@@ -5,7 +5,7 @@
 
 #include "Port.hpp"
 #include "system/Path.hpp"
-#include "ui/event/Timer.hpp"
+#include "thread/SuspensibleThread.hpp"
 #include "util/StaticString.hxx"
 
 class Condor3SpectateDevice;
@@ -14,20 +14,17 @@ class Condor3SpectateDevice;
  * Poll a Condor Spectate.json file and inject FLARM NMEA into the
  * device pipeline.
  */
-class SpectateFilePort final : public Port {
+class SpectateFilePort final : public Port, SuspensibleThread {
   const Path path;
   StaticString<128> own_cn;
   Condor3SpectateDevice *device = nullptr;
 
-  UI::Timer timer{[this]{ OnTimer(); }};
-  bool running = false;
-
-  void OnTimer() noexcept;
   void Poll() noexcept;
 
 public:
   SpectateFilePort(Path _path, const char *_own_cn,
                    PortListener *listener, DataHandler &handler) noexcept;
+  ~SpectateFilePort() noexcept override;
 
   void SetDevice(Condor3SpectateDevice *_device) noexcept {
     device = _device;
@@ -46,4 +43,8 @@ public:
 
   [[noreturn]]
   void WaitRead(std::chrono::steady_clock::duration timeout) override;
+
+protected:
+  /* virtual methods from class Thread */
+  void Run() noexcept override;
 };

--- a/test/src/FakeFlarmGlue.cpp
+++ b/test/src/FakeFlarmGlue.cpp
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "FLARM/Glue.hpp"
+
+/**
+ * Darwin's static linker resolves weak undefined symbols from archives,
+ * so Details.cpp's weak SaveFlarmMessagingPeriodic would pull Glue.o into
+ * unit tests. Provide a strong no-op stub for tests that need FlarmDetails
+ * without the full FLARM glue stack.
+ */
+void
+SaveFlarmMessagingPeriodic() noexcept
+{
+}

--- a/test/src/FakeSpectateFilePort.cpp
+++ b/test/src/FakeSpectateFilePort.cpp
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Device/Port/OpenSpectateFilePort.hpp"
+#include "Device/Port/NullPort.hpp"
+
+std::unique_ptr<Port>
+OpenSpectateFilePort(Path, const char *,
+                     PortListener *, DataHandler &handler)
+{
+  return std::make_unique<NullPort>(handler);
+}


### PR DESCRIPTION
## Summary
- Replace `SpectateFilePort`'s `UI::Timer` with portable `SuspensibleThread` so `driver.a` consumers (`RunTrace`, contest harnesses) and Windows port tools link again after Condor3 Spectate.
- Open Spectate ports via `OpenSpectateFilePort`, with a `FakeSpectateFilePort` stub for ConfiguredPort tests that do not link `DRIVER`.
- Add `FakeFlarmGlue` for `TestGDL90Driver` so Darwin does not pull `FLARM/Glue.o` through Details.cpp's weak `SaveFlarmMessagingPeriodic` reference.

Master native builds were failing these jobs (continue-on-error on push made the workflow look green): UNIX, PC, WIN*, MACOS, IOS64.

## Test plan
- [x] `make TARGET=UNIX` link `ReadPort`, `RunPortHandler`, `LogPort`, `RunTrace`, `RunContestAnalysis`, `RunDeclare`, `TestGDL90Driver`
- [x] `./output/UNIX/bin/TestGDL90Driver` passes
- [x] `make TARGET=PC` link `ReadPort.exe`, `RunPortHandler.exe`, `LogPort.exe`
- [ ] CI green on UNIX / PC / WIN* / MACOS / IOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Condor `Spectate.json` polling for more reliable startup, shutdown, and periodic updates.
  * Added a dedicated interface for opening Spectate file connections.
* **Tests**
  * Expanded test support for GDL90 drivers, port utilities, feed tools, and emulation programs.
  * Improved test compatibility on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->