### PR TITLE
Map: Add pinch-to-zoom, two-finger pan, and twist rotation

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,7 +22,21 @@ Version 7.45 - not yet released
     ``label``), gesture ``data`` format, softkey ``location``,
     label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
   - document ``AirspaceLabels`` input event
+  - document map pinch-to-zoom on touchscreens that report both
+    finger positions #2790
 * ui
+  - Add pinch-to-zoom on the map for touchscreens that report both
+    finger positions (Android, iOS): two fingers scale about the
+    pinch centroid and can pan at the same time; a two-finger drag
+    or twist enters pan mode, a pinch that only zooms keeps
+    following the aircraft #2790
+  - Add two-finger twist to temporarily rotate the map; the angle is
+    held while panning and restored when pan mode is left #2790
+  - Animate keyboard and mouse-wheel map zoom on non-e-ink displays
+    so scale steps feel continuous after a pinch; free zoom continues
+    from an off-list (pinched) scale, and snaps to the usual scale
+    list again once the current scale is close to a list value
+  - Keep the north arrow clear of the on-screen menu and zoom buttons
   - Improve simulator discoverability: startup tip to steer by
     dragging from the glider or via Altitude / Speed Ground InfoBoxes
     (5 s); Welcome Quick Guide paragraph in simulator mode; add

--- a/android/src/EdgeTouchFilter.java
+++ b/android/src/EdgeTouchFilter.java
@@ -109,11 +109,13 @@ class EdgeTouchFilter implements View.OnApplyWindowInsetsListener {
    * Process a touch event.  Edge gestures are silently rejected;
    * all other events are forwarded to {@link EventBridge}.
    *
-   * @param event   the raw MotionEvent
-   * @param x       view-relative X coordinate (after offset correction)
-   * @param y       view-relative Y coordinate (after offset correction)
+   * @param event    the raw MotionEvent
+   * @param offsetX  window-to-view X offset (see NativeView)
+   * @param offsetY  window-to-view Y offset
    */
-  void onTouchEvent(MotionEvent event, float x, float y) {
+  void onTouchEvent(MotionEvent event, float offsetX, float offsetY) {
+    final float x = event.getX() - offsetX;
+    final float y = event.getY() - offsetY;
     final int finalX = (int)x;
     final int finalY = (int)y;
 
@@ -171,11 +173,13 @@ class EdgeTouchFilter implements View.OnApplyWindowInsetsListener {
       }
 
       EventBridge.onMouseMove(finalX, finalY);
+      if (event.getPointerCount() >= 2)
+        forwardTwoPointers(event, offsetX, offsetY, true);
       break;
 
     case MotionEvent.ACTION_POINTER_DOWN:
       if (!edgeTouchRejected)
-        EventBridge.onPointerDown();
+        forwardTwoPointers(event, offsetX, offsetY, false);
       break;
 
     case MotionEvent.ACTION_POINTER_UP:
@@ -190,6 +194,29 @@ class EdgeTouchFilter implements View.OnApplyWindowInsetsListener {
       edgeDownForwarded = false;
       break;
     }
+  }
+
+  /**
+   * Forward the first two active pointers to native code.
+   *
+   * @param move  true for {@link EventBridge#onPointerMove}, false for
+   *              {@link EventBridge#onPointerDown}
+   */
+  private static void forwardTwoPointers(MotionEvent event,
+                                         float offsetX, float offsetY,
+                                         boolean move) {
+    if (event.getPointerCount() < 2)
+      return;
+
+    final int x1 = (int)(event.getX(0) - offsetX);
+    final int y1 = (int)(event.getY(0) - offsetY);
+    final int x2 = (int)(event.getX(1) - offsetX);
+    final int y2 = (int)(event.getY(1) - offsetY);
+
+    if (move)
+      EventBridge.onPointerMove(x1, y1, x2, y2);
+    else
+      EventBridge.onPointerDown(x1, y1, x2, y2);
   }
 
   /**

--- a/android/src/EventBridge.java
+++ b/android/src/EventBridge.java
@@ -10,6 +10,18 @@ class EventBridge {
   public static native void onMouseUp(int x, int y);
   public static native void onMouseMove(int x, int y);
   public static native void onMouseCancel();
-  public static native void onPointerDown();
+
+  /**
+   * A second pointer was pressed.  Coordinates are view-relative
+   * pixels for the first two active pointers.
+   */
+  public static native void onPointerDown(int x1, int y1, int x2, int y2);
+
+  /**
+   * Two (or more) pointers are moving.  Coordinates are view-relative
+   * pixels for the first two active pointers.
+   */
+  public static native void onPointerMove(int x1, int y1, int x2, int y2);
+
   public static native void onPointerUp();
 }

--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -524,10 +524,7 @@ class NativeView extends SurfaceView
       offsetY += p.getY();
     }
 
-    float x = event.getX() - offsetX;
-    float y = event.getY() - offsetY;
-
-    edgeTouchFilter.onTouchEvent(event, x, y);
+    edgeTouchFilter.onTouchEvent(event, offsetX, offsetY);
     return true;
   }
 

--- a/build/mapwindow.mk
+++ b/build/mapwindow.mk
@@ -27,6 +27,7 @@ LIBMAPWINDOW_SOURCES = \
 	$(SRC)/MapWindow/GlueMapWindowEvents.cpp \
 	$(SRC)/MapWindow/GlueMapWindowOverlays.cpp \
 	$(SRC)/MapWindow/GlueMapWindowDisplayMode.cpp \
+	$(SRC)/MapWindow/UserMapScale.cpp \
 	$(SRC)/MapWindow/TargetMapWindow.cpp \
 	$(SRC)/MapWindow/TargetMapWindowEvents.cpp \
 	$(SRC)/MapWindow/TargetMapWindowDrag.cpp

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -737,7 +737,11 @@ shown below. \gesturespec{dr}
 {\includegraphics[angle=0,width=0.1\linewidth,keepaspectratio='true']{figures/gesture_right.pdf}}] R: Turn screen page retrograde (Normal, Full-screen...) 
 \item[\raisebox{-1em}
 {\includegraphics[angle=0,width=0.1\linewidth,keepaspectratio='true']{figures/gesture_urdl.pdf}}] URDL, denoting a P: \textbf{P}an-mode. Might also be invoked by 
-moving two fingers apart on the screen.
+moving two fingers on the screen.  On touchscreens that report both
+finger positions (Android, iOS), pinching zooms the map about the point
+between the fingers, and twisting rotates it temporarily.  A two-finger
+drag or twist enters pan mode, and the temporary rotation is held until
+pan mode is left; a pinch that only zooms keeps following the aircraft.
 \end{itemize}
 \vspace{2em}
 

--- a/src/Android/EventBridge.cpp
+++ b/src/Android/EventBridge.cpp
@@ -138,13 +138,36 @@ Java_org_xcsoar_EventBridge_onMouseCancel([[maybe_unused]] JNIEnv *env, [[maybe_
 
 gcc_visibility_default
 void
-Java_org_xcsoar_EventBridge_onPointerDown([[maybe_unused]] JNIEnv *env, [[maybe_unused]] jclass cls)
+Java_org_xcsoar_EventBridge_onPointerDown([[maybe_unused]] JNIEnv *env,
+                                          [[maybe_unused]] jclass cls,
+                                          jint x1, jint y1,
+                                          jint x2, jint y2)
 {
   if (event_queue == nullptr)
     /* XCSoar not yet initialised */
     return;
 
-  event_queue->Inject(Event::POINTER_DOWN);
+  event_queue->Inject(Event(Event::POINTER_DOWN,
+                            PixelPoint(x1, y1),
+                            PixelPoint(x2, y2)));
+  ResetUserIdle();
+}
+
+gcc_visibility_default
+void
+Java_org_xcsoar_EventBridge_onPointerMove([[maybe_unused]] JNIEnv *env,
+                                          [[maybe_unused]] jclass cls,
+                                          jint x1, jint y1,
+                                          jint x2, jint y2)
+{
+  if (event_queue == nullptr)
+    /* XCSoar not yet initialised */
+    return;
+
+  event_queue->Purge(Event::POINTER_MOVE);
+  event_queue->Inject(Event(Event::POINTER_MOVE,
+                            PixelPoint(x1, y1),
+                            PixelPoint(x2, y2)));
   ResetUserIdle();
 }
 

--- a/src/Input/InputEventsMap.cpp
+++ b/src/Input/InputEventsMap.cpp
@@ -10,19 +10,12 @@
 #include "Profile/Keys.hpp"
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
+#include "MapWindow/UserMapScale.hpp"
 #include "Units/Units.hpp"
-#include "UIState.hpp"
 #include "Pan.hpp"
 #include "PageActions.hpp"
 #include "Math/Constants.hpp"
 #include "Screen/Layout.hpp"
-
-#ifdef ENABLE_OPENGL
-#include "ui/canvas/opengl/Globals.hpp"
-#endif
-
-#include <algorithm> // for std::clamp()
-
 // eventAutoZoom - Turn on|off|toggle AutoZoom
 // misc:
 //	auto on - Turn on if not already
@@ -179,36 +172,14 @@ InputEvents::sub_AutoZoom(int vswitch)
 void
 InputEvents::sub_SetZoom(double value)
 {
-  MapSettings &settings_map = CommonInterface::SetMapSettings();
   GlueMapWindow *map_window = PageActions::ShowMap();
   if (map_window == NULL)
     return;
 
-  const DisplayMode displayMode = CommonInterface::GetUIState().display_mode;
-  if (settings_map.auto_zoom_enabled &&
-      !(displayMode == DisplayMode::CIRCLING && settings_map.circle_zoom_enabled) &&
-      !IsPanning()) {
-    settings_map.auto_zoom_enabled = false;  // disable autozoom if user manually changes zoom
-    Profile::Set(ProfileKeys::AutoZoom, false);
-    Message::AddMessage(_("Auto. zoom off"));
-  }
+  if (!IsPanning())
+    DisableAutoZoomForManualScale();
 
-  auto vmin = CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
-  auto scale_2min_distance = vmin * 12;
-  const double scale_100m = 10;
-  double scale_1600km = 1600*100;
-
-#ifdef ENABLE_OPENGL
-  if (OpenGL::max_map_scale > 0)
-    scale_1600km = std::min(scale_1600km,
-                            double(OpenGL::max_map_scale));
-#endif
-
-  auto minreasonable = displayMode == DisplayMode::CIRCLING
-    ? scale_100m
-    : std::max(scale_100m, scale_2min_distance);
-
-  value = std::clamp(value, minreasonable, scale_1600km);
+  value = ClampUserMapScale(value);
   map_window->SetMapScale(value);
   map_window->QuickRedraw();
 }

--- a/src/Input/InputEventsMap.cpp
+++ b/src/Input/InputEventsMap.cpp
@@ -16,6 +16,11 @@
 #include "PageActions.hpp"
 #include "Math/Constants.hpp"
 #include "Screen/Layout.hpp"
+#include "Asset.hpp"
+#include "Hardware/CPU.hpp"
+
+#include <cmath>
+
 // eventAutoZoom - Turn on|off|toggle AutoZoom
 // misc:
 //	auto on - Turn on if not already
@@ -180,8 +185,11 @@ InputEvents::sub_SetZoom(double value)
     DisableAutoZoomForManualScale();
 
   value = ClampUserMapScale(value);
-  map_window->SetMapScale(value);
-  map_window->QuickRedraw();
+  if (HasEPaper() || IsSlowCPU()) {
+    map_window->SetMapScale(value);
+    map_window->QuickRedraw();
+  } else
+    map_window->AnimateFreeMapScale(value);
 }
 
 void
@@ -221,7 +229,17 @@ InputEvents::sub_ScaleZoom(int vswitch)
 
   auto value = projection.GetMapScale();
 
-  if (projection.HaveScaleList()) {
+  /* Stay on the discrete scale list when the current scale already
+     sits on a list value (or on e-ink / slow CPUs).  After a pinch the
+     scale is usually off-list; then step with free factors so zoom
+     continues from that value instead of snapping first.
+     StepMapScale(..., 0) returns the nearest list value. */
+  const bool use_scale_list = projection.HaveScaleList() &&
+    (HasEPaper() || IsSlowCPU() ||
+     (value > 0 &&
+      std::fabs(value - projection.StepMapScale(value, 0)) / value < 0.02));
+
+  if (use_scale_list) {
     value = projection.StepMapScale(value, -vswitch);
   } else {
     if (vswitch == 1)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -103,6 +103,12 @@ MainWindow::GetShowMenuButtonRect(const PixelRect rc) noexcept
   return GetMapOverlayButtonRect(rc, rc.top + Layout::GetTextPadding());
 }
 
+/**
+ * The width of the overlay button column in the top right corner, or 0
+ * if there is none.  The zoom buttons alone are placed in the bottom
+ * left corner and do not occupy this column.
+ */
+
 [[gnu::pure]]
 PixelRect
 MainWindow::GetShowQuickMenuButtonRect(const PixelRect rc) noexcept
@@ -283,10 +289,47 @@ MainWindow::GetMapAreaRect() const noexcept
 }
 
 void
+MainWindow::BeginCoalesceMapLayout() noexcept
+{
+  if (coalesce_map_layout++ != 0)
+    return;
+
+  coalesce_map_redraw = map != nullptr;
+  if (coalesce_map_redraw)
+    map->BeginCoalesceFullRedraw();
+}
+
+void
+MainWindow::EndCoalesceMapLayout() noexcept
+{
+  assert(coalesce_map_layout > 0);
+
+  if (--coalesce_map_layout > 0)
+    return;
+
+  if (map_layout_pending) {
+    map_layout_pending = false;
+    LayoutMapArea();
+    UpdateMapOverlayButtonLayout();
+  }
+
+  if (coalesce_map_redraw) {
+    coalesce_map_redraw = false;
+    if (map != nullptr)
+      map->EndCoalesceFullRedraw();
+  }
+}
+
+void
 MainWindow::LayoutMapArea() noexcept
 {
   if (map == nullptr)
     return;
+
+  if (coalesce_map_layout > 0) {
+    map_layout_pending = true;
+    return;
+  }
 
   PixelRect main_rect = GetMainRect();
   const PixelRect top_rect = GetTopWidgetRect(main_rect, top_widget);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -108,6 +108,18 @@ MainWindow::GetShowMenuButtonRect(const PixelRect rc) noexcept
  * if there is none.  The zoom buttons alone are placed in the bottom
  * left corner and do not occupy this column.
  */
+[[gnu::pure]]
+static unsigned
+GetMapOverlayTopRightWidth(const PixelRect rc) noexcept
+{
+  const UISettings &settings = CommonInterface::GetUISettings();
+
+  if (!settings.show_menu_button && !settings.show_quickmenu_button)
+    return 0;
+
+  const PixelRect button_rc = GetMapOverlayButtonRect(rc, rc.top);
+  return unsigned(std::max(0, rc.right - button_rc.left));
+}
 
 [[gnu::pure]]
 PixelRect
@@ -383,6 +395,12 @@ MainWindow::UpdateMapOverlayButtonLayout() noexcept
   if (show_rotate_button != nullptr && overlay_buttons_active)
     show_rotate_button->Move(GetShowRotateButtonRect(map->GetPosition()));
 #endif
+
+  if (map != nullptr)
+    /* keep the north arrow clear of the overlay buttons */
+    map->SetTopRightMargin(overlay_buttons_active
+                           ? GetMapOverlayTopRightWidth(map->GetPosition())
+                           : 0);
 
   /* Newly created overlay buttons are added after the map; keep the map
      underneath them (same as ReinitialiseLayout()). */

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -139,6 +139,23 @@ private:
   PixelRect map_rect;
   bool FullScreen = false;
 
+  /**
+   * Nesting count for #BeginCoalesceMapLayout() /
+   * #EndCoalesceMapLayout().  While non-zero, #LayoutMapArea() only
+   * sets #map_layout_pending.
+   */
+  unsigned coalesce_map_layout = 0;
+
+  /** A #LayoutMapArea() was requested while coalescing was active. */
+  bool map_layout_pending = false;
+
+  /**
+   * True when #BeginCoalesceMapLayout() also started map full-redraw
+   * coalescing.  End must use this rather than re-testing #map, which
+   * may appear or disappear between the pair of calls.
+   */
+  bool coalesce_map_redraw = false;
+
 #ifndef ENABLE_OPENGL
   /**
    * This variable tracks whether the #DrawThread was suspended
@@ -347,6 +364,13 @@ public:
   }
 
   void SetFullScreen(bool _full_screen) noexcept;
+
+  /**
+   * Coalesce map area layout (and map #FullRedraw) while a page layout
+   * is applied in several steps (InfoBoxes, bottom widget, …).
+   */
+  void BeginCoalesceMapLayout() noexcept;
+  void EndCoalesceMapLayout() noexcept;
 
   void SendGPSUpdate(bool vario_bar_redraw=false) noexcept;
 

--- a/src/MapWindow/GlueMapWindow.cpp
+++ b/src/MapWindow/GlueMapWindow.cpp
@@ -13,6 +13,8 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 
+#include <cassert>
+
 GlueMapWindow::GlueMapWindow(const Look &look) noexcept
   :MapWindow(look.map, look.traffic),
    thermal_band_renderer(look.thermal_band, look.chart),
@@ -151,8 +153,28 @@ GlueMapWindow::InjectRedraw() noexcept
 }
 
 void
+GlueMapWindow::EndCoalesceFullRedraw() noexcept
+{
+  assert(coalesce_full_redraw > 0);
+
+  if (--coalesce_full_redraw > 0)
+    return;
+
+  if (!full_redraw_pending)
+    return;
+
+  full_redraw_pending = false;
+  FullRedraw();
+}
+
+void
 GlueMapWindow::FullRedraw() noexcept
 {
+  if (coalesce_full_redraw > 0) {
+    full_redraw_pending = true;
+    return;
+  }
+
   UpdateDisplayMode();
   UpdateScreenAngle();
   UpdateProjection();

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -53,10 +53,17 @@ class GlueMapWindow : public MapWindow {
 
 #ifdef HAVE_MULTI_TOUCH
     /**
-     * Dragging the map with two fingers; enters the "real" pan mode
-     * as soon as the user releases the finger press.
+     * Two-finger drag without scale/rotation yet, or single-finger
+     * continuation after a pinch; may enter the "real" pan mode when
+     * the gesture ends.
      */
     DRAG_MULTI_TOUCH_PAN,
+
+    /**
+     * Two-finger pan, pinch-zoom and twist when both finger positions
+     * are available.
+     */
+    DRAG_MULTI_TOUCH_PINCH,
 #endif
 
     DRAG_PAN,
@@ -68,6 +75,37 @@ class GlueMapWindow : public MapWindow {
   PixelPoint drag_start;
   TrackingGestureManager gestures;
   bool ignore_single_click = false;
+
+  /**
+   * A multi-touch gesture currently owns map projection updates
+   * (location, scale, angle).  This is distinct from pan UI
+   * (#FOLLOW_PAN, fullscreen layout, crosshair): the gesture may own
+   * the map long before pan UI is committed.
+   */
+  [[gnu::pure]]
+  bool GestureOwnsMap() const noexcept {
+#ifdef HAVE_MULTI_TOUCH
+    return drag_mode == DRAG_MULTI_TOUCH_PAN ||
+      drag_mode == DRAG_MULTI_TOUCH_PINCH;
+#else
+    return false;
+#endif
+  }
+
+  /**
+   * Should pan chrome (crosshair, pan info) be drawn?  Hidden during
+   * an early multi-touch gesture that has not yet committed pan UI,
+   * so the crosshair is not painted at the pre-fullscreen map centre.
+   */
+  [[gnu::pure]]
+  bool IsPanChromeVisible() const noexcept {
+#ifdef HAVE_MULTI_TOUCH
+    if (GestureOwnsMap())
+      return IsPanning() &&
+        (multi_touch_pan_ui || multi_touch_was_panning);
+#endif
+    return IsPanning();
+  }
 
 #ifdef ENABLE_OPENGL
   KineticManager kinetic_x{std::chrono::milliseconds{700}};
@@ -95,6 +133,53 @@ class GlueMapWindow : public MapWindow {
    * The projection which was active when dragging started.
    */
   Projection drag_projection;
+
+#ifdef ENABLE_OPENGL
+  /**
+   * Animate keyboard / mouse-wheel free-scale zoom.  Pinch stays
+   * instantaneous.
+   */
+  UI::Timer zoom_timer{[this]{ OnZoomTimer(); }};
+  double zoom_from_map_scale = 0;
+  double zoom_to_map_scale = 0;
+  std::chrono::steady_clock::time_point zoom_start_time{};
+#endif
+
+#ifdef HAVE_MULTI_TOUCH
+  double pinch_start_distance = 0;
+  double pinch_start_map_scale = 0;
+  GeoPoint pinch_anchor_geo = GeoPoint::Invalid();
+  PixelPoint pinch_start_centroid{};
+  PixelPoint pinch_last_a{}, pinch_last_b{};
+
+  /** True after finger separation crosses the scale dead zone. */
+  bool pinch_scaling = false;
+
+  /** Pan UI was already active at multi-touch down. */
+  bool multi_touch_was_panning = false;
+
+  /**
+   * Pan UI committed for this gesture (#CommitMultiTouchPanUI).
+   * Pure pinch-zoom leaves this false and returns to follow.
+   */
+  bool multi_touch_pan_ui = false;
+
+  /** Re-anchor single-finger pan after the second finger lifts. */
+  bool resume_pan_after_pinch = false;
+
+  Angle pinch_start_finger_angle = Angle::Zero();
+  Angle pinch_start_screen_angle = Angle::Zero();
+
+  /** True after finger twist crosses the rotate dead zone. */
+  bool pinch_rotating = false;
+
+  /**
+   * Hold #manual_rotation_angle instead of the configured orientation.
+   * Cleared by UpdateScreenAngle() when pan mode is left.
+   */
+  bool manual_rotation = false;
+  Angle manual_rotation_angle = Angle::Zero();
+#endif
 
   DisplayMode last_display_mode = DisplayMode::NONE;
 
@@ -137,6 +222,16 @@ class GlueMapWindow : public MapWindow {
 
   UI::Notify redraw_notify{[this]{ PartialRedraw(); }};
 
+  /**
+   * Nesting count for #BeginCoalesceFullRedraw() /
+   * #EndCoalesceFullRedraw().  While non-zero, #FullRedraw() only
+   * sets #full_redraw_pending.
+   */
+  unsigned coalesce_full_redraw = 0;
+
+  /** A #FullRedraw() was requested while coalescing was active. */
+  bool full_redraw_pending = false;
+
 public:
   GlueMapWindow(const Look &look) noexcept;
   virtual ~GlueMapWindow() noexcept;
@@ -157,6 +252,13 @@ public:
   void SetBottomMarginFactor(unsigned margin_factor) noexcept;
 
   /**
+   * Sets the width at the right edge of the map that is covered by the
+   * overlay buttons, so HUD elements in the top right corner can avoid
+   * them.
+   */
+  void SetTopRightMargin(unsigned margin) noexcept;
+
+  /**
    * Update the blackboard from DeviceBlackboard and
    * InterfaceBlackboard.
    */
@@ -171,6 +273,19 @@ public:
    * Resumt threads that are owned by this object.
    */
   void ResumeThreads() noexcept;
+
+  /**
+   * Coalesce #FullRedraw() calls until a matching
+   * #EndCoalesceFullRedraw().  Used while the main window applies a
+   * multi-step page layout so the map is not painted at intermediate
+   * sizes.  Distinct from #DeferRedraw(), which schedules an async
+   * invalidate.
+   */
+  void BeginCoalesceFullRedraw() noexcept {
+    ++coalesce_full_redraw;
+  }
+
+  void EndCoalesceFullRedraw() noexcept;
 
   /**
    * Trigger a full redraw of the map.
@@ -241,6 +356,8 @@ protected:
 
 #ifdef HAVE_MULTI_TOUCH
   bool OnMultiTouchDown() noexcept override;
+  bool OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept override;
+  bool OnMultiTouchUp() noexcept override;
 #endif
 
   bool OnKeyDown(unsigned key_code) noexcept override;
@@ -276,6 +393,12 @@ private:
   void SaveDisplayModeScales() noexcept;
 
   /**
+   * Persist the current projection scale as the circling or cruise
+   * scale, depending on the active display mode.
+   */
+  void PersistCurrentScale() noexcept;
+
+  /**
    * The attribute visible_projection has been edited.
    */
   void OnProjectionModified() noexcept {}
@@ -288,6 +411,39 @@ private:
 
   void UpdateScreenAngle() noexcept;
   void UpdateProjection() noexcept;
+
+#ifdef HAVE_MULTI_TOUCH
+  /**
+   * Discard a pending one-finger gesture trail without firing it.
+   */
+  void DiscardPendingFingerGesture() noexcept;
+
+  /**
+   * Begin multi-touch ownership of the map projection (not pan UI).
+   */
+  void BeginMultiTouchOwnership() noexcept;
+
+  /**
+   * Clear multi-touch session flags (ownership, pinch, rotation).
+   * Does not change #drag_mode or #follow_mode.
+   */
+  void ResetMultiTouchSessionState() noexcept;
+
+  /**
+   * Commit pan UI for the running gesture: fullscreen map and pan
+   * menu, with #FOLLOW_PAN only after the layout has been applied.
+   * No-op when already committed or pan UI was active at touch-down.
+   */
+  void CommitMultiTouchPanUI() noexcept;
+
+  /**
+   * Re-base pinch anchors after a layout change (pan UI commit) so the
+   * next motion does not jump in scale, rotation, or location.
+   */
+  void RebasePinchAfterLayoutChange(PixelPoint a, PixelPoint b,
+                                    double distance,
+                                    PixelPoint centroid) noexcept;
+#endif
 
 public:
   void SetLocation(const GeoPoint location) noexcept;
@@ -310,6 +466,13 @@ public:
 
   void UpdateDisplayMode() noexcept;
   void SetMapScale(double scale) noexcept;
+  void SetFreeMapScale(double scale) noexcept;
+
+  /**
+   * Smoothly animate to a free map scale (keyboard / mouse wheel).
+   * No-op path on builds without OpenGL: applies the scale immediately.
+   */
+  void AnimateFreeMapScale(double scale) noexcept;
 
 protected:
   DisplayMode GetDisplayMode() const noexcept {
@@ -325,6 +488,8 @@ private:
 
 #ifdef ENABLE_OPENGL
   void OnKineticTimer() noexcept;
+  void CancelZoomAnimation() noexcept;
+  void OnZoomTimer() noexcept;
   void NoteTerrainQuantisationUserActivity() noexcept;
   void OnTerrainQuantisationTimer() noexcept;
 #endif

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "GlueMapWindow.hpp"
+#include "UserMapScale.hpp"
 #include "Terrain/RasterTerrain.hpp"
 #include "Topography/Thread.hpp"
 #include "Terrain/Thread.hpp"
@@ -15,6 +16,7 @@
 #endif
 
 #include <algorithm> // for std::clamp()
+#include <cmath>
 
 void
 OffsetHistory::Reset() noexcept
@@ -113,17 +115,13 @@ GlueMapWindow::UpdateScreenBounds() noexcept
 }
 
 void
-GlueMapWindow::SetMapScale(double scale) noexcept
+GlueMapWindow::PersistCurrentScale() noexcept
 {
-  MapWindow::SetMapScale(scale);
-  OnProjectionModified();
-
   const bool circling =
     CommonInterface::GetUIState().display_mode == DisplayMode::CIRCLING;
   MapSettings &settings = CommonInterface::SetMapSettings();
 
   if (circling && settings.circle_zoom_enabled)
-    // save cruise scale
     settings.circling_scale = visible_projection.GetScale();
   else
     settings.cruise_scale = visible_projection.GetScale();
@@ -132,8 +130,128 @@ GlueMapWindow::SetMapScale(double scale) noexcept
 }
 
 void
+GlueMapWindow::SetMapScale(double scale) noexcept
+{
+#ifdef ENABLE_OPENGL
+  CancelZoomAnimation();
+#endif
+
+  MapWindow::SetMapScale(scale);
+  OnProjectionModified();
+  PersistCurrentScale();
+}
+
+void
+GlueMapWindow::SetFreeMapScale(double scale) noexcept
+{
+#ifdef ENABLE_OPENGL
+  CancelZoomAnimation();
+#endif
+
+  visible_projection.SetFreeMapScale(scale);
+  OnProjectionModified();
+  PersistCurrentScale();
+}
+
+void
+GlueMapWindow::AnimateFreeMapScale(double scale) noexcept
+{
+  scale = ClampUserMapScale(scale);
+
+#ifndef ENABLE_OPENGL
+  SetFreeMapScale(scale);
+  QuickRedraw();
+#else
+  if (!visible_projection.IsValid()) {
+    SetFreeMapScale(scale);
+    QuickRedraw();
+    return;
+  }
+
+  zoom_from_map_scale = visible_projection.GetMapScale();
+  zoom_to_map_scale = scale;
+
+  /* persist the target scale immediately */
+  {
+    const double saved_scale = visible_projection.GetScale();
+    visible_projection.SetFreeMapScale(scale);
+    PersistCurrentScale();
+    visible_projection.SetScale(saved_scale);
+  }
+
+  if (zoom_from_map_scale <= 0 || zoom_to_map_scale <= 0 ||
+      std::fabs(zoom_from_map_scale - scale) / zoom_from_map_scale < 0.001) {
+    SetFreeMapScale(scale);
+    QuickRedraw();
+    return;
+  }
+
+  zoom_start_time = std::chrono::steady_clock::now();
+  zoom_timer.Schedule(std::chrono::milliseconds(16));
+  OnZoomTimer();
+#endif
+}
+
+#ifdef ENABLE_OPENGL
+
+void
+GlueMapWindow::CancelZoomAnimation() noexcept
+{
+  if (!zoom_timer.IsPending())
+    return;
+
+  zoom_timer.Cancel();
+
+  /* the target scale was already persisted; snap the visible
+     projection so a mid-tween cancel does not leave an intermediate
+     scale fighting the saved setting */
+  if (zoom_to_map_scale > 0 && visible_projection.IsValid()) {
+    visible_projection.SetFreeMapScale(zoom_to_map_scale);
+    OnProjectionModified();
+  }
+}
+
+void
+GlueMapWindow::OnZoomTimer() noexcept
+{
+  constexpr auto duration = std::chrono::milliseconds(180);
+  const auto elapsed = std::chrono::steady_clock::now() - zoom_start_time;
+  const auto elapsed_ms =
+    std::chrono::duration_cast<std::chrono::milliseconds>(elapsed);
+  double t = double(elapsed_ms.count()) / double(duration.count());
+
+  if (t >= 1) {
+    visible_projection.SetFreeMapScale(zoom_to_map_scale);
+    OnProjectionModified();
+    QuickRedraw();
+    zoom_timer.Cancel();
+    return;
+  }
+
+  /* ease-out cubic; interpolate in log space so multiplicative zoom
+     feels constant */
+  t = 1 - (1 - t) * (1 - t) * (1 - t);
+  const double from_log = std::log(zoom_from_map_scale);
+  const double to_log = std::log(zoom_to_map_scale);
+  const double scale = std::exp(from_log + (to_log - from_log) * t);
+
+  visible_projection.SetFreeMapScale(scale);
+  OnProjectionModified();
+  QuickRedraw();
+  zoom_timer.Schedule(std::chrono::milliseconds(16));
+}
+
+#endif
+
+void
 GlueMapWindow::RestoreMapScale() noexcept
 {
+#ifdef ENABLE_OPENGL
+  /* stop a pending keyboard/wheel tween so OnZoomTimer cannot overwrite
+     the restored cruise/circling scale with a stale target */
+  CancelZoomAnimation();
+#endif
+
   const MapSettings &settings = CommonInterface::GetMapSettings();
   const bool circling =
     CommonInterface::GetUIState().display_mode == DisplayMode::CIRCLING;
@@ -207,11 +325,32 @@ GlueMapWindow::UpdateScreenAngle() noexcept
   // force north-up if the current page is a dedicated MAP_NORTH_UP page
   const PageLayout &layout = PageActions::GetConfiguredLayout();
   if (layout.main == PageLayout::Main::MAP_NORTH_UP) {
+#ifdef HAVE_MULTI_TOUCH
+    /* a north-up page rejects temporary twist; clear so the angle
+       cannot reappear when leaving this page */
+    manual_rotation = false;
+#endif
     visible_projection.SetScreenAngle(Angle::Zero());
     OnProjectionModified();
     compass_visible = false;
     return;
   }
+
+#ifdef HAVE_MULTI_TOUCH
+  /* a two-finger twist temporarily overrides the configured
+     orientation; the angle is held while panning and released (falling
+     back to the configured orientation) once pan mode is left */
+  if (manual_rotation) {
+    if (IsPanning() || GestureOwnsMap()) {
+      visible_projection.SetScreenAngle(manual_rotation_angle);
+      OnProjectionModified();
+      compass_visible = true;
+      return;
+    }
+
+    manual_rotation = false;
+  }
+#endif
 
   MapOrientation orientation =
     ui_state.display_mode == DisplayMode::CIRCLING
@@ -254,7 +393,7 @@ GlueMapWindow::UpdateMapScale() noexcept
   if (circling && settings.circle_zoom_enabled)
     return;
 
-  if (!IsNearSelf())
+  if (!IsNearSelf() || GestureOwnsMap())
     return;
 
   auto distance = calculated.auto_zoom_distance;
@@ -321,7 +460,14 @@ GlueMapWindow::UpdateProjection() noexcept
 
   const auto center = rc.GetCenter();
 
-  if (circling || !IsNearSelf())
+  /* Gesture ownership is not pan UI: while still FOLLOWING the
+     aircraft, freeze origin/GPS so two-finger down does not jump to
+     a pan-style centred projection below the pan-entry threshold. */
+  const bool freeze_for_gesture = GestureOwnsMap() && IsNearSelf();
+
+  if (freeze_for_gesture) {
+    /* keep the current screen origin */
+  } else if (circling || !IsNearSelf())
     visible_projection.SetScreenOrigin(center);
   else if (settings_map.cruise_orientation == MapOrientation::NORTH_UP ||
            settings_map.cruise_orientation == MapOrientation::WIND_UP) {
@@ -361,7 +507,7 @@ GlueMapWindow::UpdateProjection() noexcept
     visible_projection.SetScreenOrigin(center.x,
         ((rc.top - rc.bottom) * settings_map.glider_screen_position / 100) + rc.bottom);
 
-  if (!IsNearSelf()) {
+  if (freeze_for_gesture || !IsNearSelf()) {
     /* no-op - the Projection's location is updated manually */
   } else if (circling && calculated.thermal_locator.estimate_valid) {
     const auto d_t = calculated.thermal_locator.estimate_location.DistanceS(basic.location);

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -15,6 +15,7 @@
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "ActionInterface.hpp"
+#include "UserMapScale.hpp"
 #ifdef HAVE_EDL
 #include "UIState.hpp"
 #endif
@@ -29,6 +30,7 @@
 #endif
 
 #include <algorithm> // for std::clamp()
+#include <cmath> // for std::hypot()
 
 void
 GlueMapWindow::OnCreate()
@@ -47,6 +49,7 @@ GlueMapWindow::OnDestroy() noexcept
 
 #ifdef ENABLE_OPENGL
   kinetic_timer.Cancel();
+  CancelZoomAnimation();
   terrain_quantisation_timer.Cancel();
 #endif
 
@@ -83,6 +86,27 @@ GlueMapWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
 
 #ifdef HAVE_MULTI_TOUCH
   case DRAG_MULTI_TOUCH_PAN:
+    if (resume_pan_after_pinch) {
+      drag_projection = visible_projection;
+      drag_start = p;
+      drag_start_geopoint = drag_projection.ScreenToGeo(p);
+      resume_pan_after_pinch = false;
+      return true;
+    }
+
+    if (!multi_touch_pan_ui &&
+        (unsigned)ManhattanDistance(drag_start, p) > Layout::Scale(20u)) {
+      CommitMultiTouchPanUI();
+
+      /* entering pan mode may have resized the map; re-base the drag so
+         the map does not jump on the next motion event */
+      drag_projection = visible_projection;
+      drag_start = p;
+      drag_start_geopoint = drag_projection.ScreenToGeo(p);
+      return true;
+    }
+
+    [[fallthrough]];
 #endif
   case DRAG_PAN:
     SetLocation(drag_projection.GetGeoLocation()
@@ -95,6 +119,13 @@ GlueMapWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
     kinetic_y.MouseMove(p.y);
 #endif
     return true;
+
+#ifdef HAVE_MULTI_TOUCH
+  case DRAG_MULTI_TOUCH_PINCH:
+    /* primary-pointer mouse motion is ignored; scale/pan come from
+       OnMultiTouchMove() */
+    return true;
+#endif
 
   case DRAG_GESTURE:
     gestures.Update(p);
@@ -138,6 +169,7 @@ GlueMapWindow::OnMouseDown(PixelPoint p) noexcept
 #ifdef ENABLE_OPENGL
   was_kinetic_motion = kinetic_timer.IsActive();
   kinetic_timer.Cancel();
+  CancelZoomAnimation();
 #endif
 
   // Ignore single click event if double click detected
@@ -212,7 +244,12 @@ GlueMapWindow::OnMouseUp(PixelPoint p) noexcept
   // Ignore single click event if double click detected
   if (ignore_single_click) {
     ignore_single_click = false;
-    return true;
+
+    /* a multi-touch gesture must still be finished: it has already
+       switched to FOLLOW_PAN, and only the code below enters pan mode
+       properly, including its menu */
+    if (!GestureOwnsMap())
+      return true;
   }
 
   const auto click_time = mouse_down_clock.Elapsed();
@@ -228,8 +265,22 @@ GlueMapWindow::OnMouseUp(PixelPoint p) noexcept
 
 #ifdef HAVE_MULTI_TOUCH
   case DRAG_MULTI_TOUCH_PAN:
-    follow_mode = FOLLOW_SELF;
-    ::PanTo(visible_projection.GetGeoScreenCenter());
+  case DRAG_MULTI_TOUCH_PINCH:
+    PersistCurrentScale();
+
+    resume_pan_after_pinch = false;
+
+    if (multi_touch_was_panning || multi_touch_pan_ui)
+      /* pan UI was already active, or CommitMultiTouchPanUI() ran
+         during the gesture; stay in FOLLOW_PAN */
+      follow_mode = FOLLOW_PAN;
+    else {
+      /* a pure pinch-zoom only changed the scale; resume following the
+         aircraft */
+      follow_mode = FOLLOW_SELF;
+      QuickRedraw();
+    }
+
     return true;
 #endif
 
@@ -313,6 +364,7 @@ GlueMapWindow::OnMouseWheel([[maybe_unused]] PixelPoint p,
 
 #ifdef ENABLE_OPENGL
   kinetic_timer.Cancel();
+  CancelZoomAnimation();
 #endif
 
   if (drag_mode != DRAG_NONE)
@@ -336,16 +388,232 @@ GlueMapWindow::OnMultiTouchDown() noexcept
   if (!visible_projection.IsValid())
     return false;
 
-  if (drag_mode == DRAG_GESTURE)
-    gestures.Finish();
-  else if (follow_mode != FOLLOW_SELF)
-    return false;
+  if (drag_mode == DRAG_MULTI_TOUCH_PAN ||
+      drag_mode == DRAG_MULTI_TOUCH_PINCH)
+    /* another finger touched down during the gesture; the state below
+       was already captured, and re-capturing it now would read the
+       FOLLOW_PAN that this very gesture has set as "was already
+       panning", which skips entering pan mode on release */
+    return true;
 
-  /* start panning on MultiTouch event */
+  /* Start gesture ownership only.  Do not set FOLLOW_PAN or pan UI
+     yet: that is CommitMultiTouchPanUI()'s job after a drag/twist, so
+     chrome and fullscreen layout appear together at the final size. */
+  BeginMultiTouchOwnership();
 
   drag_mode = DRAG_MULTI_TOUCH_PAN;
   drag_projection = visible_projection;
-  follow_mode = FOLLOW_PAN;
+  arm_mapitem_list = false;
+  return true;
+}
+
+void
+GlueMapWindow::DiscardPendingFingerGesture() noexcept
+{
+  if (drag_mode != DRAG_GESTURE)
+    return;
+
+  /* discard without firing; repaint to erase the gesture trail */
+  gestures.Finish();
+  PaintWindow::Invalidate();
+}
+
+void
+GlueMapWindow::BeginMultiTouchOwnership() noexcept
+{
+  DiscardPendingFingerGesture();
+  multi_touch_was_panning = IsPanning();
+  multi_touch_pan_ui = false;
+  resume_pan_after_pinch = false;
+  pinch_scaling = false;
+  pinch_rotating = false;
+}
+
+void
+GlueMapWindow::ResetMultiTouchSessionState() noexcept
+{
+  resume_pan_after_pinch = false;
+  multi_touch_pan_ui = false;
+  multi_touch_was_panning = false;
+  pinch_scaling = false;
+  pinch_rotating = false;
+  manual_rotation = false;
+}
+
+void
+GlueMapWindow::CommitMultiTouchPanUI() noexcept
+{
+  if (multi_touch_pan_ui)
+    return;
+
+  multi_touch_pan_ui = true;
+
+  if (multi_touch_was_panning)
+    /* pan UI is already active */
+    return;
+
+  /* follow_mode is still FOLLOW_SELF, so ShowOnlyMap()'s DisablePan()
+     is a no-op; PanTo() expands the layout (coalesced) and only then
+     sets FOLLOW_PAN — chrome is drawn at the fullscreen centre. */
+  ::PanTo(visible_projection.GetGeoScreenCenter());
+}
+
+void
+GlueMapWindow::RebasePinchAfterLayoutChange(PixelPoint a, PixelPoint b,
+                                            double distance,
+                                            PixelPoint centroid) noexcept
+{
+  pinch_start_distance = distance;
+  pinch_start_map_scale = visible_projection.GetMapScale();
+  pinch_start_centroid = centroid;
+  pinch_anchor_geo = visible_projection.ScreenToGeo(centroid);
+  pinch_start_finger_angle =
+    Angle::Radians(std::atan2(double(b.y - a.y), double(b.x - a.x)));
+  pinch_start_screen_angle = visible_projection.GetScreenAngle();
+}
+
+bool
+GlueMapWindow::OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept
+{
+  if (!visible_projection.IsValid())
+    return false;
+
+  const double distance = std::hypot(double(a.x - b.x), double(a.y - b.y));
+  if (distance < 1)
+    return true;
+
+  const PixelPoint centroid{(a.x + b.x) / 2, (a.y + b.y) / 2};
+
+  if (drag_mode != DRAG_MULTI_TOUCH_PINCH) {
+    if (drag_mode != DRAG_MULTI_TOUCH_PAN)
+      /* OnMultiTouchDown() did not run; record the pan state here */
+      BeginMultiTouchOwnership();
+    else
+      DiscardPendingFingerGesture();
+
+    drag_mode = DRAG_MULTI_TOUCH_PINCH;
+    drag_projection = visible_projection;
+    arm_mapitem_list = false;
+    pinch_start_distance = distance;
+    pinch_start_map_scale = visible_projection.GetMapScale();
+    pinch_anchor_geo = visible_projection.ScreenToGeo(centroid);
+    pinch_start_centroid = centroid;
+    pinch_last_a = a;
+    pinch_last_b = b;
+    pinch_scaling = false;
+    pinch_rotating = false;
+    pinch_start_finger_angle =
+      Angle::Radians(std::atan2(double(b.y - a.y), double(b.x - a.x)));
+    pinch_start_screen_angle = visible_projection.GetScreenAngle();
+    SetCapture();
+    return true;
+  }
+
+  if (pinch_start_distance < 1 || !pinch_anchor_geo.IsValid())
+    return true;
+
+  if (a == pinch_last_a && b == pinch_last_b)
+    /* one motion event per finger arrives, but both positions are read
+       from the current device state; skip the duplicate */
+    return true;
+
+  pinch_last_a = a;
+  pinch_last_b = b;
+
+  if (!multi_touch_pan_ui &&
+      (unsigned)ManhattanDistance(pinch_start_centroid, centroid) >
+      Layout::Scale(20u)) {
+    CommitMultiTouchPanUI();
+    RebasePinchAfterLayoutChange(a, b, distance, centroid);
+    return true;
+  }
+
+  if (!pinch_scaling) {
+    /* Require a noticeable change in finger separation before the map
+       is rescaled.  Fingers always wobble while panning, and rescaling
+       invalidates the cached terrain and topography rendering, which
+       is far more expensive than panning. */
+    constexpr double dead_zone = 0.1;
+    const double ratio = distance / pinch_start_distance;
+
+    if (ratio > 1 + dead_zone || ratio < 1 - dead_zone) {
+      /* re-base so that scaling starts from the current scale without
+         a jump */
+      pinch_scaling = true;
+      pinch_start_distance = distance;
+      pinch_start_map_scale = visible_projection.GetMapScale();
+    }
+  }
+
+  if (pinch_scaling) {
+    if (!IsPanning())
+      DisableAutoZoomForManualScale();
+
+    const double new_scale = ClampUserMapScale(
+      pinch_start_map_scale * (pinch_start_distance / distance));
+
+    visible_projection.SetFreeMapScale(new_scale);
+    OnProjectionModified();
+  }
+
+  /* two-finger twist rotates the map around the pinch centroid */
+  const Angle finger_angle =
+    Angle::Radians(std::atan2(double(b.y - a.y), double(b.x - a.x)));
+
+  if (!pinch_rotating) {
+    /* ignore small twists so an ordinary pinch/pan does not rotate */
+    constexpr double rotate_dead_zone_deg = 8;
+    if ((finger_angle - pinch_start_finger_angle).AsDelta().Absolute() >
+        Angle::Degrees(rotate_dead_zone_deg)) {
+      /* re-base so rotation starts from the current angle without a
+         jump */
+      pinch_rotating = true;
+      pinch_start_finger_angle = finger_angle;
+      pinch_start_screen_angle = visible_projection.GetScreenAngle();
+    }
+  }
+
+  if (pinch_rotating) {
+    const Angle twist =
+      (finger_angle - pinch_start_finger_angle).AsDelta();
+
+    /* screen y grows downward, so a visually clockwise finger twist
+       increases the measured angle; subtract it so the map content
+       rotates with the fingers */
+    manual_rotation_angle = pinch_start_screen_angle - twist;
+    manual_rotation = true;
+
+    /* a rotation is a deliberate manipulation; enter pan mode so the
+       chosen angle is held */
+    if (!multi_touch_pan_ui) {
+      CommitMultiTouchPanUI();
+      RebasePinchAfterLayoutChange(a, b, distance, centroid);
+      pinch_start_finger_angle = finger_angle;
+      pinch_start_screen_angle = manual_rotation_angle;
+    }
+
+    visible_projection.SetScreenAngle(manual_rotation_angle);
+    OnProjectionModified();
+  }
+
+  SetLocation(visible_projection.GetGeoLocation() + pinch_anchor_geo
+              - visible_projection.ScreenToGeo(centroid));
+  QuickRedraw();
+  return true;
+}
+
+bool
+GlueMapWindow::OnMultiTouchUp() noexcept
+{
+  if (drag_mode != DRAG_MULTI_TOUCH_PINCH)
+    return false;
+
+  /* second finger lifted: keep current scale, fall back to single-
+     finger pan with the remaining pointer */
+  PersistCurrentScale();
+
+  drag_mode = DRAG_MULTI_TOUCH_PAN;
+  resume_pan_after_pinch = true;
   return true;
 }
 
@@ -364,6 +632,7 @@ GlueMapWindow::OnKeyDown(unsigned key_code) noexcept
 
 #ifdef ENABLE_OPENGL
   kinetic_timer.Cancel();
+  CancelZoomAnimation();
 #endif
 
   if (InputEvents::processKey(key_code)) {
@@ -380,8 +649,18 @@ GlueMapWindow::OnCancelMode() noexcept
 
   if (drag_mode != DRAG_NONE) {
 #ifdef HAVE_MULTI_TOUCH
-    if (drag_mode == DRAG_MULTI_TOUCH_PAN)
-      follow_mode = FOLLOW_SELF;
+    const bool was_multi_touch = GestureOwnsMap();
+    if (was_multi_touch) {
+      PersistCurrentScale();
+
+      /* multi_touch_pan_ui means pan mode has already been entered,
+         and its user interface is visible */
+      follow_mode = multi_touch_was_panning || multi_touch_pan_ui
+        ? FOLLOW_PAN
+        : FOLLOW_SELF;
+    }
+
+    ResetMultiTouchSessionState();
 #endif
 
     if (drag_mode == DRAG_GESTURE)
@@ -389,10 +668,18 @@ GlueMapWindow::OnCancelMode() noexcept
 
     ReleaseCapture();
     drag_mode = DRAG_NONE;
+
+#ifdef HAVE_MULTI_TOUCH
+    if (was_multi_touch)
+      /* drop a held twist angle and refresh after the session flags
+         were cleared */
+      QuickRedraw();
+#endif
   }
 
 #ifdef ENABLE_OPENGL
   kinetic_timer.Cancel();
+  CancelZoomAnimation();
 #endif
 
   map_item_timer.Cancel();
@@ -403,8 +690,7 @@ GlueMapWindow::OnPaint(Canvas &canvas) noexcept
 {
   MapWindow::OnPaint(canvas);
 
-  // Draw center screen cross hair in pan mode
-  if (IsPanning())
+  if (IsPanChromeVisible())
     DrawCrossHairs(canvas);
 
   DrawGesture(canvas);
@@ -422,7 +708,7 @@ GlueMapWindow::OnPaintBuffer(Canvas &canvas) noexcept
   MapWindow::OnPaintBuffer(canvas);
 
   DrawMapScale(canvas, GetClientRect(), render_projection);
-  if (IsPanning())
+  if (IsPanChromeVisible())
     DrawPanInfo(canvas);
 
 #ifdef ENABLE_OPENGL

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -294,6 +294,17 @@ GlueMapWindow::SetBottomMargin(unsigned margin) noexcept
 }
 
 void
+GlueMapWindow::SetTopRightMargin(unsigned margin) noexcept
+{
+  if (margin == top_right_margin)
+    /* no change, don't redraw */
+    return;
+
+  top_right_margin = margin;
+  QuickRedraw();
+}
+
+void
 GlueMapWindow::SetBottomMarginFactor(unsigned margin_factor) noexcept
 {
   if (follow_mode != FOLLOW_PAN || Layout::landscape) {

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -159,6 +159,13 @@ protected:
 
   bool compass_visible = true;
 
+  /**
+   * Width at the right edge of the map covered by the overlay buttons
+   * (menu, quick menu, zoom).  HUD items in the top right corner are
+   * moved left by this amount so the buttons do not hide them.
+   */
+  unsigned top_right_margin = 0;
+
 #ifndef ENABLE_OPENGL
   /**
    * Tracks whether the buffer canvas contains valid data.  We use

--- a/src/MapWindow/MapWindowSymbols.cpp
+++ b/src/MapWindow/MapWindowSymbols.cpp
@@ -9,6 +9,8 @@
 #include "Renderer/TurnBackMarkerRenderer.hpp"
 #include "Renderer/WindArrowRenderer.hpp"
 
+#include <algorithm> // for std::min()
+
 void
 MapWindow::DrawWind(Canvas &canvas, const PixelPoint &Start,
                     const PixelRect &rc) const noexcept
@@ -27,8 +29,13 @@ MapWindow::DrawCompass(Canvas &canvas, const PixelRect &rc) const noexcept
   if (!compass_visible)
     return;
 
+  PixelRect compass_rc = rc;
+  compass_rc.right -= std::min(int(top_right_margin),
+                               int(compass_rc.GetWidth()));
+
   CompassRenderer compass_renderer(look);
-  compass_renderer.Draw(canvas, render_projection.GetScreenAngle(), rc);
+  compass_renderer.Draw(canvas, render_projection.GetScreenAngle(),
+                        compass_rc);
 }
 
 void

--- a/src/MapWindow/UserMapScale.cpp
+++ b/src/MapWindow/UserMapScale.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "UserMapScale.hpp"
+#include "Interface.hpp"
+#include "UIState.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
+#include "Message.hpp"
+#include "Language/Language.hpp"
+
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
+#endif
+
+#include <algorithm>
+
+double
+ClampUserMapScale(double scale, DisplayMode mode, double vmin) noexcept
+{
+  const double scale_2min_distance = vmin * 12;
+  constexpr double scale_100m = 10;
+  double scale_1600km = 1600 * 100;
+
+#ifdef ENABLE_OPENGL
+  if (OpenGL::max_map_scale > 0)
+    scale_1600km = std::min(scale_1600km, double(OpenGL::max_map_scale));
+#endif
+
+  double minreasonable = mode == DisplayMode::CIRCLING
+    ? scale_100m
+    : std::max(scale_100m, scale_2min_distance);
+
+  /* a small GPU max_map_scale can push the upper bound below the
+     lower one; keep std::clamp() defined */
+  minreasonable = std::min(minreasonable, scale_1600km);
+
+  return std::clamp(scale, minreasonable, scale_1600km);
+}
+
+double
+ClampUserMapScale(double scale) noexcept
+{
+  const DisplayMode mode = CommonInterface::GetUIState().display_mode;
+  const auto vmin =
+    CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
+  return ClampUserMapScale(scale, mode, vmin);
+}
+
+bool
+DisableAutoZoomForManualScale() noexcept
+{
+  MapSettings &settings = CommonInterface::SetMapSettings();
+  const DisplayMode mode = CommonInterface::GetUIState().display_mode;
+
+  if (!settings.auto_zoom_enabled)
+    return false;
+
+  if (mode == DisplayMode::CIRCLING && settings.circle_zoom_enabled)
+    return false;
+
+  settings.auto_zoom_enabled = false;
+  Profile::Set(ProfileKeys::AutoZoom, false);
+  Message::AddMessage(_("Auto. zoom off"));
+  return true;
+}

--- a/src/MapWindow/UserMapScale.hpp
+++ b/src/MapWindow/UserMapScale.hpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "DisplayMode.hpp"
+
+/**
+ * Clamp a continuous user map scale (keyboard, mouse wheel, pinch,
+ * Lua) to the same min/max used by InputEvents::sub_SetZoom().
+ *
+ * @param vmin  polar minimum speed (m/s); used for the cruise
+ *              "2 minute" minimum scale
+ */
+[[nodiscard]] [[gnu::pure]]
+double
+ClampUserMapScale(double scale, DisplayMode mode, double vmin) noexcept;
+
+/**
+ * Clamp using the current display mode and polar from
+ * #CommonInterface.
+ */
+[[nodiscard]]
+double
+ClampUserMapScale(double scale) noexcept;
+
+/**
+ * Turn auto-zoom off after a manual scale change.  No-op when
+ * auto-zoom is already off, or while circling with circle-zoom.
+ *
+ * @return true if auto-zoom was disabled
+ */
+bool
+DisableAutoZoomForManualScale() noexcept;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -7,6 +7,7 @@
 #include "Interface.hpp"
 #include "ActionInterface.hpp"
 #include "MainWindow.hpp"
+#include "util/ScopeExit.hxx"
 #include "CrossSection/CrossSectionWidget.hpp"
 #include "Dialogs/Weather/WeatherDialog.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
@@ -550,6 +551,12 @@ PageActions::LoadLayout(const PageLayout &layout)
   PageLayout active = layout;
   active.Normalise();
 
+  /* InfoBoxes and the bottom widget each resize the map; coalesce so
+     the map jumps once to the final rectangle. */
+  auto &main_window = *CommonInterface::main_window;
+  main_window.BeginCoalesceMapLayout();
+  AtScopeExit(&main_window) { main_window.EndCoalesceMapLayout(); };
+
   DisablePan();
 
   LoadInfoBoxes(active.infobox_config);
@@ -562,8 +569,7 @@ PageActions::LoadLayout(const PageLayout &layout)
 
   ActionInterface::UpdateDisplayMode();
   ActionInterface::SendUIState(false);
-  if (CommonInterface::main_window != nullptr)
-    CommonInterface::main_window->ScheduleRefreshInfoBoxes();
+  main_window.ScheduleRefreshInfoBoxes();
 }
 
 void

--- a/src/Pan.cpp
+++ b/src/Pan.cpp
@@ -12,8 +12,46 @@
 #include "Input/InputEvents.hpp"
 #include "BackendComponents.hpp"
 #include "Components.hpp"
+#include "util/ScopeExit.hxx"
 
 #include <cassert>
+
+namespace {
+
+/**
+ * Suspend weather overlays if needed and show the fullscreen map.
+ * On failure, resumes weather if it was suspended.
+ *
+ * @param abort_if_already_panning  if true, treat an already-panning
+ *                                  map as failure (EnterPan)
+ */
+GlueMapWindow *
+PreparePanFullscreen(bool abort_if_already_panning) noexcept
+{
+  const bool suspending_weather =
+    PageActions::GetCurrentLayout().UsesWeatherOverlay();
+  if (suspending_weather)
+    PageActions::SuspendWeatherOverlaysForPan();
+
+  GlueMapWindow *map = PageActions::ShowOnlyMap();
+  if (map == nullptr ||
+      (abort_if_already_panning && map->IsPanning())) {
+    if (suspending_weather)
+      PageActions::ResumeWeatherOverlaysAfterPan();
+    return nullptr;
+  }
+
+  return map;
+}
+
+void
+FinishEnterPan() noexcept
+{
+  InputEvents::setMode(InputEvents::MODE_DEFAULT);
+  InputEvents::UpdatePan();
+}
+
+} // anonymous namespace
 
 bool
 IsPanning()
@@ -27,22 +65,12 @@ EnterPan()
 {
   assert(CommonInterface::main_window != nullptr);
 
-  const bool suspending_weather_page =
-    PageActions::GetCurrentLayout().UsesWeatherOverlay();
-  if (suspending_weather_page)
-    PageActions::SuspendWeatherOverlaysForPan();
-
-  GlueMapWindow *map = PageActions::ShowOnlyMap();
-  if (map == nullptr || map->IsPanning()) {
-    if (suspending_weather_page)
-      PageActions::ResumeWeatherOverlaysAfterPan();
+  GlueMapWindow *map = PreparePanFullscreen(true);
+  if (map == nullptr)
     return;
-  }
 
   map->SetPan(true);
-
-  InputEvents::setMode(InputEvents::MODE_DEFAULT);
-  InputEvents::UpdatePan();
+  FinishEnterPan();
 }
 
 bool
@@ -50,22 +78,12 @@ PanTo(const GeoPoint &location)
 {
   assert(CommonInterface::main_window != nullptr);
 
-  const bool suspending_weather_page =
-    PageActions::GetCurrentLayout().UsesWeatherOverlay();
-  if (suspending_weather_page)
-    PageActions::SuspendWeatherOverlaysForPan();
-
-  GlueMapWindow *map = PageActions::ShowOnlyMap();
-  if (map == nullptr) {
-    if (suspending_weather_page)
-      PageActions::ResumeWeatherOverlaysAfterPan();
+  GlueMapWindow *map = PreparePanFullscreen(false);
+  if (map == nullptr)
     return false;
-  }
 
   map->PanTo(location);
-
-  InputEvents::setMode(InputEvents::MODE_DEFAULT);
-  InputEvents::UpdatePan();
+  FinishEnterPan();
   return true;
 }
 
@@ -113,10 +131,18 @@ LeavePan()
     return;
   }
 
+  if (!map->IsPanning() && !PageActions::IsStuckPanFullScreenLayout())
+    return;
+
+  /* Coalesce leaving follow-pan with the page restore so the map is
+     not painted once at fullscreen with FOLLOW_SELF and again after
+     InfoBoxes return. */
+  auto &main_window = *CommonInterface::main_window;
+  main_window.BeginCoalesceMapLayout();
+  AtScopeExit(&main_window) { main_window.EndCoalesceMapLayout(); };
+
   if (map->IsPanning())
     map->SetPan(false);
-  else if (!PageActions::IsStuckPanFullScreenLayout())
-    return;
 
   InputEvents::UpdatePan();
   PageActions::Restore();

--- a/src/lua/Map.cpp
+++ b/src/lua/Map.cpp
@@ -9,23 +9,14 @@
 #include "UIGlobals.hpp"
 #include "PageActions.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
+#include "MapWindow/UserMapScale.hpp"
 #include "Pan.hpp"
-#include "Language/Language.hpp"
-#include "Message.hpp"
 #include "Interface.hpp"
-#include "Profile/Profile.hpp"
-#include "Profile/Keys.hpp"
 #include "Math/Constants.hpp"
-
-#ifdef ENABLE_OPENGL
-#include "ui/canvas/opengl/Globals.hpp"
-#endif
 
 extern "C" {
 #include <lauxlib.h>
 }
-
-#include <algorithm> // for std::clamp()
 
 static int
 l_map_index(lua_State *L)
@@ -166,33 +157,10 @@ l_map_zoom(lua_State *L)
       value *= 2;
   }
 
-  MapSettings &settings_map = CommonInterface::SetMapSettings();
+  if (!IsPanning())
+    DisableAutoZoomForManualScale();
 
-  const DisplayMode displayMode = CommonInterface::GetUIState().display_mode;
-  if (settings_map.auto_zoom_enabled &&
-      !(displayMode == DisplayMode::CIRCLING && settings_map.circle_zoom_enabled) &&
-      !IsPanning()) {
-    settings_map.auto_zoom_enabled = false;  // disable autozoom if user manually changes zoom
-    Profile::Set(ProfileKeys::AutoZoom, false);
-    Message::AddMessage(_("Auto. zoom off"));
-  }
-
-  auto vmin = CommonInterface::GetComputerSettings().polar.glide_polar_task.GetVMin();
-  auto scale_2min_distance = vmin * 12;
-  constexpr double scale_100m = 10;
-  double scale_1600km = 1600 * 100;
-
-#ifdef ENABLE_OPENGL
-  if (OpenGL::max_map_scale > 0)
-    scale_1600km = std::min(scale_1600km,
-                            double(OpenGL::max_map_scale));
-#endif
-
-  auto minreasonable = displayMode == DisplayMode::CIRCLING
-    ? scale_100m
-    : std::max(scale_100m, scale_2min_distance);
-
-  value = std::clamp(value, minreasonable, scale_1600km);
+  value = ClampUserMapScale(value);
   map_window->SetMapScale(value);
   map_window->QuickRedraw();
 

--- a/src/ui/event/shared/Event.hpp
+++ b/src/ui/event/shared/Event.hpp
@@ -39,6 +39,12 @@ struct Event {
     POINTER_UP,
 
     /**
+     * Two pointers are moving.  #point and #point2 hold the first two
+     * finger positions (view-relative pixels).
+     */
+    POINTER_MOVE,
+
+    /**
      * The NativeView was resized (e.g. by changing the screen
      * orientation).
      */
@@ -99,6 +105,13 @@ struct Event {
 
   PixelPoint point;
 
+#ifdef ANDROID
+  /**
+   * Second finger position for #POINTER_DOWN / #POINTER_MOVE.
+   */
+  PixelPoint point2;
+#endif
+
 #ifdef USE_X11
   unsigned ch;
 #else
@@ -115,6 +128,10 @@ struct Event {
     :type(CALLBACK), ptr(_ptr), callback(_callback) {}
   Event(Type _type, PixelPoint _point)
     :type(_type), point(_point) {}
+#ifdef ANDROID
+  Event(Type _type, PixelPoint _point, PixelPoint _point2) noexcept
+    :type(_type), point(_point), point2(_point2) {}
+#endif
 
   bool IsKeyDown() const {
     return type == KEY_DOWN;

--- a/src/ui/window/ContainerWindow.hpp
+++ b/src/ui/window/ContainerWindow.hpp
@@ -54,6 +54,7 @@ protected:
 
 #ifdef HAVE_MULTI_TOUCH
   bool OnMultiTouchDown() noexcept override;
+  bool OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept override;
   bool OnMultiTouchUp() noexcept override;
 #endif
 

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -257,6 +257,14 @@ public:
   bool touch_multi = false;
 
   /**
+   * Stable SDL finger ids for the active two-finger gesture.  Indices
+   * into SDL's finger array are not stable across up/down events.
+   */
+  bool touch_pair_valid = false;
+  std::int64_t touch_finger_a = 0;
+  std::int64_t touch_finger_b = 0;
+
+  /**
    * Is an emulated mouse button release waiting for the last finger to
    * be lifted?
    */

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -11,14 +11,17 @@
 
 #ifdef ENABLE_OPENGL
 #include "ui/opengl/Features.hpp"
-#include <cstdint>
 #endif
 
 #include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
 
+#if defined(ENABLE_OPENGL) || defined(ENABLE_SDL) || \
+  defined(DRAW_REDRAW_COUNTER)
+#include <cstdint>
+#endif
+
 #ifdef DRAW_REDRAW_COUNTER
 #include <chrono>
-#include <cstdint>
 #endif
 
 #ifdef ANDROID
@@ -241,6 +244,31 @@ public:
 #endif
 
   DoubleClick double_click;
+
+#if defined(ENABLE_SDL) && defined(HAVE_MULTI_TOUCH)
+  /**
+   * Number of fingers currently touching the screen.
+   */
+  unsigned touch_fingers = 0;
+
+  /**
+   * Were two or more fingers down during the current touch sequence?
+   */
+  bool touch_multi = false;
+
+  /**
+   * Is an emulated mouse button release waiting for the last finger to
+   * be lifted?
+   */
+  bool touch_mouse_up_pending = false;
+
+  PixelPoint touch_mouse_up_point{0, 0};
+
+  /**
+   * Deliver a postponed emulated mouse button release, if any.
+   */
+  bool FlushTouchMouseUp() noexcept;
+#endif
 
 #else /* USE_WINUSER */
 

--- a/src/ui/window/Window.cpp
+++ b/src/ui/window/Window.cpp
@@ -185,6 +185,13 @@ Window::OnMultiTouchDown() noexcept
 }
 
 bool
+Window::OnMultiTouchMove([[maybe_unused]] PixelPoint a,
+                         [[maybe_unused]] PixelPoint b) noexcept
+{
+  return false;
+}
+
+bool
 Window::OnMultiTouchUp() noexcept
 {
   return false;

--- a/src/ui/window/Window.hpp
+++ b/src/ui/window/Window.hpp
@@ -878,6 +878,13 @@ public:
   virtual bool OnMultiTouchDown() noexcept;
 
   /**
+   * Two pointers are moving.  Coordinates are relative to this
+   * window.  Used for pinch-to-zoom where both finger positions are
+   * available (e.g. SDL).
+   */
+  virtual bool OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept;
+
+  /**
    * A secondary pointer is being released.
    */
   virtual bool OnMultiTouchUp() noexcept;

--- a/src/ui/window/android/TopWindow.cpp
+++ b/src/ui/window/android/TopWindow.cpp
@@ -247,7 +247,12 @@ TopWindow::OnEvent(const Event &event)
     return OnMouseWheel(event.point, (int)event.param);
 
   case Event::POINTER_DOWN:
-    return OnMultiTouchDown();
+    if (!OnMultiTouchDown())
+      return false;
+    return OnMultiTouchMove(event.point, event.point2);
+
+  case Event::POINTER_MOVE:
+    return OnMultiTouchMove(event.point, event.point2);
 
   case Event::POINTER_UP:
     return OnMultiTouchUp();

--- a/src/ui/window/custom/ContainerWindow.cpp
+++ b/src/ui/window/custom/ContainerWindow.cpp
@@ -195,6 +195,17 @@ ContainerWindow::OnMultiTouchDown() noexcept
 }
 
 bool
+ContainerWindow::OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept
+{
+  if (!capture && capture_child != nullptr) {
+    const auto origin = capture_child->GetTopLeft();
+    return capture_child->OnMultiTouchMove(a - origin, b - origin);
+  }
+
+  return PaintWindow::OnMultiTouchMove(a, b);
+}
+
+bool
 ContainerWindow::OnMultiTouchUp() noexcept
 {
   if (!capture && capture_child != nullptr)

--- a/src/ui/window/sdl/TopWindow.cpp
+++ b/src/ui/window/sdl/TopWindow.cpp
@@ -9,6 +9,7 @@
 
 #include <SDL_video.h>
 #include <SDL_events.h>
+#include <SDL_version.h>
 
 #if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
 #include "ui/event/shared/TransformCoordinates.hpp"
@@ -29,6 +30,126 @@
 #endif
 
 namespace UI {
+
+#ifdef HAVE_MULTI_TOUCH
+
+/**
+ * Does this touch device report window coordinates?  SDL also emits
+ * finger events for touchpads, whose normalised coordinates describe a
+ * position on the pad, not on the screen; two-finger scrolling on a
+ * touchpad must not be mistaken for a pinch gesture.
+ */
+[[gnu::pure]]
+static bool
+IsTouchScreen([[maybe_unused]] SDL_TouchID touch_id) noexcept
+{
+#if SDL_VERSION_ATLEAST(2, 0, 10)
+  return SDL_GetTouchDeviceType(touch_id) == SDL_TOUCH_DEVICE_DIRECT;
+#else
+  return true;
+#endif
+}
+
+/**
+ * Count the fingers currently touching @p touch_id.  Depending on the
+ * SDL version, the finger that triggered a SDL_FINGERUP event may still
+ * be listed; pass its id in @p lifted to exclude it.
+ *
+ * Not [[gnu::pure]]: SDL touch state can change between identical calls.
+ */
+static unsigned
+CountFingers(SDL_TouchID touch_id, const SDL_FingerID *lifted) noexcept
+{
+  const int n = SDL_GetNumTouchFingers(touch_id);
+  if (n <= 0)
+    return 0;
+
+  unsigned count = unsigned(n);
+
+  if (lifted != nullptr)
+    for (int i = 0; i < n; ++i) {
+      const SDL_Finger *f = SDL_GetTouchFinger(touch_id, i);
+      if (f != nullptr && f->id == *lifted) {
+        --count;
+        break;
+      }
+    }
+
+  return count;
+}
+
+/**
+ * Count the fingers currently touching any direct (touch-screen)
+ * device.  The emulated mouse events do not carry a touch id, so the
+ * total across devices is used to decide when the last finger has been
+ * lifted.
+ */
+static unsigned
+CountAllFingers() noexcept
+{
+  unsigned count = 0;
+  const int devices = SDL_GetNumTouchDevices();
+  for (int i = 0; i < devices; ++i) {
+    const SDL_TouchID id = SDL_GetTouchDevice(i);
+    if (IsTouchScreen(id))
+      count += CountFingers(id, nullptr);
+  }
+
+  return count;
+}
+
+/**
+ * Capture the two active finger ids for a new two-finger gesture.
+ * Prefer stable #SDL_FingerID values over array indices; SDL may
+ * compact its finger list when another finger is added or removed.
+ */
+static bool
+CaptureTwoFingerIds(SDL_TouchID touch_id,
+                    SDL_FingerID &id_a, SDL_FingerID &id_b) noexcept
+{
+  if (SDL_GetNumTouchFingers(touch_id) < 2)
+    return false;
+
+  const SDL_Finger *f0 = SDL_GetTouchFinger(touch_id, 0);
+  const SDL_Finger *f1 = SDL_GetTouchFinger(touch_id, 1);
+  if (f0 == nullptr || f1 == nullptr)
+    return false;
+
+  id_a = f0->id;
+  id_b = f1->id;
+  return true;
+}
+
+/**
+ * Look up one finger by id into window-pixel coordinates (not yet
+ * HiDPI-scaled).
+ */
+static bool
+GetFingerPoint(SDL_Window *window, SDL_TouchID touch_id,
+               SDL_FingerID finger_id, PixelPoint &p) noexcept
+{
+  if (window == nullptr)
+    return false;
+
+  const int n = SDL_GetNumTouchFingers(touch_id);
+  for (int i = 0; i < n; ++i) {
+    const SDL_Finger *f = SDL_GetTouchFinger(touch_id, i);
+    if (f == nullptr || f->id != finger_id)
+      continue;
+
+    int w = 0, h = 0;
+    SDL_GetWindowSize(window, &w, &h);
+    if (w <= 0 || h <= 0)
+      return false;
+
+    p = {int(f->x * w), int(f->y * h)};
+    return true;
+  }
+
+  return false;
+}
+
+#endif
 
 static constexpr Uint32
 MakeSDLFlags([[maybe_unused]] bool full_screen, bool resizable) noexcept
@@ -94,9 +215,35 @@ TopWindow::CreateNative(const char *_text, PixelSize new_size,
 
 }
 
+#ifdef HAVE_MULTI_TOUCH
+
+bool
+TopWindow::FlushTouchMouseUp() noexcept
+{
+  if (!touch_mouse_up_pending)
+    return false;
+
+  touch_mouse_up_pending = false;
+  double_click.Moved(touch_mouse_up_point);
+  return OnMouseUp(touch_mouse_up_point);
+}
+
+#endif
+
 bool
 TopWindow::OnEvent(const SDL_Event &event)
 {
+  const auto event_to_window = [this](PixelPoint p) noexcept {
+    p = PointToReal(p);
+#if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
+    if (OpenGL::window_size.x > 0 && OpenGL::window_size.y > 0)
+      p = TransformCoordinates(p,
+                               PixelSize{OpenGL::window_size.x,
+                                         OpenGL::window_size.y});
+#endif
+    return p;
+  };
+
   switch (event.type) {
     Window *w;
 
@@ -141,38 +288,102 @@ TopWindow::OnEvent(const SDL_Event &event)
 
 #ifdef HAVE_MULTI_TOUCH
   case SDL_FINGERDOWN:
-    if (SDL_GetNumTouchFingers(event.tfinger.touchId) == 2)
-      return OnMultiTouchDown();
-    else
-      return false;
-
+  case SDL_FINGERMOTION:
   case SDL_FINGERUP:
-    if (SDL_GetNumTouchFingers(event.tfinger.touchId) == 1)
-      return OnMultiTouchUp();
-    else
-      return false;
+    {
+      if (!IsTouchScreen(event.tfinger.touchId))
+        return false;
+
+      /* trust SDL's live finger count instead of an incrementally
+         maintained counter, so a dropped event cannot leave the count
+         stuck; the finger that triggered SDL_FINGERUP may still be
+         listed and is excluded explicitly */
+      touch_fingers = event.type == SDL_FINGERUP
+        ? CountFingers(event.tfinger.touchId, &event.tfinger.fingerId)
+        : CountFingers(event.tfinger.touchId, nullptr);
+
+      if (touch_fingers >= 2)
+        touch_multi = true;
+      else if (event.type == SDL_FINGERDOWN && touch_fingers <= 1) {
+        /* first finger of a new sequence: forget any stale flag from a
+           previous gesture that did not tear down cleanly */
+        touch_multi = false;
+        touch_pair_valid = false;
+      }
+
+      if (event.type == SDL_FINGERUP) {
+        bool result = false;
+
+        if (touch_fingers == 1 && touch_pair_valid) {
+          result = OnMultiTouchUp();
+          touch_pair_valid = false;
+        }
+
+        if (touch_fingers == 0) {
+          touch_multi = false;
+          touch_pair_valid = false;
+          result |= FlushTouchMouseUp();
+        }
+
+        return result;
+      }
+
+      if (touch_fingers < 2) {
+        touch_pair_valid = false;
+        return false;
+      }
+
+      if (!touch_pair_valid) {
+        if (event.type != SDL_FINGERDOWN || touch_fingers != 2)
+          return false;
+
+        SDL_FingerID id_a, id_b;
+        if (!CaptureTwoFingerIds(event.tfinger.touchId, id_a, id_b) ||
+            !OnMultiTouchDown()) {
+          /* rejected start: do not treat the sequence as multi-touch */
+          touch_multi = false;
+          return false;
+        }
+
+        touch_finger_a = id_a;
+        touch_finger_b = id_b;
+        touch_pair_valid = true;
+      }
+
+      PixelPoint a, b;
+      if (!GetFingerPoint(window, event.tfinger.touchId,
+                          SDL_FingerID(touch_finger_a), a) ||
+          !GetFingerPoint(window, event.tfinger.touchId,
+                          SDL_FingerID(touch_finger_b), b))
+        return false;
+
+      return OnMultiTouchMove(event_to_window(a), event_to_window(b));
+    }
 #endif
 
   case SDL_MOUSEMOTION:
     // XXX keys
     {
-      auto p = PointToReal(PixelPoint(event.motion.x, event.motion.y));
-#if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-      if(OpenGL::window_size.x > 0 && OpenGL::window_size.y > 0)
-        p = TransformCoordinates(p, PixelSize{OpenGL::window_size.x,
-                                              OpenGL::window_size.y});
+#ifdef HAVE_MULTI_TOUCH
+      if (event.motion.which == SDL_TOUCH_MOUSEID && touch_fingers >= 2)
+        /* the pinch handler owns this gesture */
+        return true;
 #endif
-      return OnMouseMove(p, 0);
+
+      return OnMouseMove(event_to_window(PixelPoint(event.motion.x,
+                                                    event.motion.y)),
+                         0);
     }
 
   case SDL_MOUSEBUTTONDOWN:
     {
-      auto p = PointToReal(PixelPoint(event.button.x, event.button.y));
-#if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-      if(OpenGL::window_size.x > 0 && OpenGL::window_size.y > 0)
-        p = TransformCoordinates(p, PixelSize{OpenGL::window_size.x,
-                                              OpenGL::window_size.y});
+#ifdef HAVE_MULTI_TOUCH
+      /* safety net: never let a postponed release outlive its drag */
+      FlushTouchMouseUp();
 #endif
+
+      const auto p = event_to_window(PixelPoint(event.button.x,
+                                                event.button.y));
       return double_click.Check(p)
         ? OnMouseDouble(p)
         : OnMouseDown(p);
@@ -180,12 +391,25 @@ TopWindow::OnEvent(const SDL_Event &event)
 
   case SDL_MOUSEBUTTONUP:
     {
-      auto p = PointToReal(PixelPoint(event.button.x, event.button.y));
-#if defined(ENABLE_OPENGL) && defined(SOFTWARE_ROTATE_DISPLAY)
-      if(OpenGL::window_size.x > 0 && OpenGL::window_size.y > 0)
-        p = TransformCoordinates(p, PixelSize{OpenGL::window_size.x,
-                                              OpenGL::window_size.y});
+      const auto p = event_to_window(PixelPoint(event.button.x,
+                                                event.button.y));
+#ifdef HAVE_MULTI_TOUCH
+      if (event.button.which == SDL_TOUCH_MOUSEID) {
+        /* SDL emulates the mouse with the first finger only.  Base the
+           decision on the live finger total (the emulated event has no
+           touch id): while other fingers remain on a multi-touch
+           gesture, postpone the release so the drag does not end with
+           fingers still down; otherwise release capture now. */
+        if (touch_multi && CountAllFingers() > 0) {
+          touch_mouse_up_point = p;
+          touch_mouse_up_pending = true;
+          return true;
+        }
+
+        touch_multi = false;
+      }
 #endif
+
       double_click.Moved(p);
       return OnMouseUp(p);
     }


### PR DESCRIPTION
## Summary
- Add continuous map pinch-to-zoom (and simultaneous two-finger pan) on Android and SDL touchscreens (including iOS), scaling about the pinch centroid via `SetFreeMapScale` (#2790).
- Add two-finger twist rotation with an angular dead zone; the temporary angle is held while panning and restored when pan mode is left.
- Related UX: animate keyboard/mouse-wheel free-scale zoom on non-e-ink builds, keep the north arrow clear of overlay buttons, ignore touchpad finger events on SDL, and enter the pan fullscreen UI as soon as a two-finger drag or twist is recognized (not only on finger lift).

## Test plan
- [x] Android: two-finger pinch zooms about the centroid; pure pinch returns to aircraft follow; drag/twist enters pan with menu + crosshair while fingers are still down
- [x] Android/SDL: two-finger twist rotates the map; leave pan restores North/Track/Heading/Target/Wind-up
- [x] SDL UNIX with real touchscreen: same pinch/pan/rotate; laptop trackpad must not cancel gestures or stick capture
- [x] Single-finger gestures still draw and fire after multi-touch
- [x] Overlay menu/zoom buttons do not cover the north arrow when those buttons are enabled
- [x] Keyboard/mouse-wheel zoom on LCD feels continuous after a pinch; e-ink/slow-CPU keep stepped zoom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added two-finger pinch-to-zoom with simultaneous panning and temporary map rotation on supported touchscreens.
  - Zoom-only pinches can keep the map centered on the aircraft when applicable.
  - Improved multi-touch gesture handling across supported input devices.

- **UI Improvements**
  - Added animated keyboard and mouse-wheel zoom on compatible displays, with immediate scaling on e-paper and slower devices.
  - Repositioned the compass to avoid menu and quick-access controls.

- **Documentation**
  - Added guidance for pinch-to-zoom and two-finger rotation gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->