### PR TITLE
Dialogs/Plane/WeGlideTypePicker: Fix crash when offline

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -24,6 +24,9 @@ Version 7.45 - not yet released
   - document ``AirspaceLabels`` input event
   - document map pinch-to-zoom on touchscreens that report both
     finger positions #2790
+* WeGlide
+  - fix crash when opening the aircraft type picker without a network
+    connection
 * ui
   - Add pinch-to-zoom on the map for touchscreens that report both
     finger positions (Android, iOS): two fingers scale about the

--- a/src/Dialogs/Plane/WeGlideTypePicker.cpp
+++ b/src/Dialogs/Plane/WeGlideTypePicker.cpp
@@ -4,8 +4,8 @@
 #include "WeGlideTypePicker.hpp"
 
 #include "Dialogs/CoFunctionDialog.hpp"
+#include "Dialogs/Error.hpp"
 #include "Dialogs/ListPicker.hpp"
-#include "Dialogs/Message.hpp"
 #include "Language/Language.hpp"
 #include "Look/DialogLook.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
@@ -43,17 +43,24 @@ DownloadAircraftTypes([[maybe_unused]] const WeGlideSettings &settings)
   if (Net::curl == nullptr)
     return {};
 
-  PluggableOperationEnvironment env;
-  const auto value = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
-                                          UIGlobals::GetDialogLook(),
-                                          _("Download"),
-                                          WeGlide::DownloadAircraftList(
-                                            *Net::curl, settings, env),
-                                          &env);
-  if (!value)
-    return {};
+  try {
+    PluggableOperationEnvironment env;
+    const auto value = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
+                                            UIGlobals::GetDialogLook(),
+                                            _("Download"),
+                                            WeGlide::DownloadAircraftList(
+                                              *Net::curl, settings, env),
+                                            &env);
+    if (!value)
+      return {};
 
-  return *value;
+    return *value;
+  } catch (...) {
+    /* ShowCoDialog rethrows download/network failures; without this
+       catch the Plane Details dialog crashes (e.g. offline Android). */
+    ShowError(std::current_exception(), _("WeGlide Type"));
+    return {};
+  }
 #else
   return {};
 #endif
@@ -71,13 +78,12 @@ SelectWeGlideAircraftType(unsigned &aircraft_id,
                           const WeGlideSettings &settings)
 {
   auto list = WeGlide::LoadAircraftListCache();
-  if (list.empty())
-    list = DownloadAircraftTypes(settings);
-
   if (list.empty()) {
-    ShowMessageBox(_("Could not load WeGlide aircraft list."),
-                   _("WeGlide Type"), MB_OK | MB_ICONEXCLAMATION);
-    return false;
+    list = DownloadAircraftTypes(settings);
+    /* Cancel returns empty without a message; network errors are
+       already reported by DownloadAircraftTypes(). */
+    if (list.empty())
+      return false;
   }
 
   const unsigned old_aircraft_id = aircraft_id;
@@ -94,8 +100,10 @@ SelectWeGlideAircraftType(unsigned &aircraft_id,
 
   unsigned initial_index = find_index(aircraft_id);
 
-  WeGlideAircraftRenderer renderer(list);
   while (true) {
+    /* Recreate after each refresh so the renderer does not keep a
+       reference to a moved-from vector. */
+    WeGlideAircraftRenderer renderer(list);
     const int result = ListPicker(_("Select WeGlide Type"),
                                   list.size(), initial_index,
                                   renderer.CalculateLayout(
@@ -112,11 +120,8 @@ SelectWeGlideAircraftType(unsigned &aircraft_id,
 
     if (result == mrExtra) {
       auto refreshed = DownloadAircraftTypes(settings);
-      if (refreshed.empty()) {
-        ShowMessageBox(_("Could not load WeGlide aircraft list."),
-                       _("WeGlide Type"), MB_OK | MB_ICONEXCLAMATION);
+      if (refreshed.empty())
         continue;
-      }
 
       list = std::move(refreshed);
       initial_index = find_index(aircraft_id);


### PR DESCRIPTION
## Summary
- Catch download/network exceptions from `ShowCoFunctionDialog` when loading the WeGlide aircraft type list, so Plane Details no longer crashes offline (reproduced on Android 7.44 with no network and an empty cache).
- Show the error via `ShowError` instead of aborting; cancel remains silent.
- Recreate the list renderer after Refresh to avoid a dangling reference to a moved-from vector.

## Test plan
- [ ] Android (or UNIX): clear/remove `weglide-aircraft-v1.json` cache, disable network, open Plane Details → WeGlide Type — expect an error dialog, no crash
- [ ] With network: same path downloads and shows the picker
- [ ] With a populated cache offline: picker opens from cache; Refresh without network shows an error and keeps the existing list
- [ ] Cancel during download returns to Plane Details without a spurious “could not load” message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash that could occur when opening the aircraft type picker without an internet connection.
  - Download errors are now shown clearly, while cancelled downloads remain silent.
  - Improved aircraft list loading and refreshing when no list is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->