### PR TITLE
MapWindow: Sync follow projection on OpenGL PartialRedraw paints

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -118,6 +118,9 @@ Version 7.45 - not yet released
   - Add Expert Look → Screen Layout setting "Display type" (LCD /
     E-ink / Color e-ink); e-ink modes disable kinetic and smooth
     scrolling. Defaults to E-ink on Kobo and LCD elsewhere
+  - OpenGL: keep the follow-mode map projection in sync on every map
+    paint so the aircraft and terrain move together (avoids the plane
+    sliding ahead of the map until the next full redraw)
   - Show the Vario flag on the device list for non-compensated and
     netto vario
     sources as well as total-energy (e.g. BlueFly)

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -701,8 +701,26 @@ GlueMapWindow::OnPaintBuffer(Canvas &canvas) noexcept
 {
 #ifdef ENABLE_OPENGL
   ExchangeBlackboard();
-
   EnterDrawThread();
+
+  /* PartialRedraw (vario/GPS/topography) invalidates without running
+     FullRedraw.  Without a projection update here, Render() draws the
+     new aircraft against a stale map origin — the plane slides, then
+     the next FullRedraw recenters and the terrain jerks. */
+  if (IsNearSelf()) {
+    UpdateDisplayMode();
+    UpdateScreenAngle();
+    UpdateProjection();
+    /* Pin origin to the DeviceBlackboard sample we just exchanged so
+       aircraft and terrain share one geo origin in this frame. */
+    if (Basic().location_available)
+      SetLocationLazy(Basic().location);
+    UpdateMapScale();
+    /* Refresh cached screen_bounds only — not GlueMapWindow's
+       UpdateScreenBounds(), which would re-trigger terrain/topo
+       threads.  Stale bounds break airspace GeoClip (MapCanvas). */
+    MapWindow::UpdateScreenBounds();
+  }
 #endif
 
   MapWindow::OnPaintBuffer(canvas);


### PR DESCRIPTION
## Summary
- On OpenGL, `PartialRedraw` (vario/GPS/topography/terrain tile notifies) only invalidates; paint then exchanged a fresh aircraft position onto a stale follow projection, so the plane moved and the map jerked on the next `FullRedraw`.
- While following, update display mode / screen angle / projection / scale on each map paint, pin the origin to the exchanged DeviceBlackboard location, and refresh cached `screen_bounds` via `MapWindow::UpdateScreenBounds()` so airspace `GeoClip` stays valid.
- Intentionally does **not** call `GlueMapWindow::UpdateScreenBounds()` (avoids waking terrain/topo threads on every PartialRedraw).

## Test plan
- [ ] OpenGL follow mode with GPS/sim moving: aircraft and terrain/topo move together on PartialRedraw (no plane-then-map slip).
- [ ] Airspaces: fills/outlines stay correctly clipped while the map follows (no edge clipping glitches after the projection sync).
- [ ] Pan mode unchanged; entering/leaving pan still works.
- [ ] Confirm terrain/topo tile loads still update via InjectRedraw without a loader thrash storm.
- [ ] Optional: Android e-ink / LCD follow flight or simulator replay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenGL map rendering in follow mode.
  * Aircraft and terrain now remain synchronized during map updates.
  * Prevented the aircraft from appearing to move ahead of the map between full redraws.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->