### PR TITLE
Device/Driver/GDL90: Fix SoftRF status and radar before GNSS

### DIFF
--- a/src/Device/Driver/GDL90/Driver.cpp
+++ b/src/Device/Driver/GDL90/Driver.cpp
@@ -667,6 +667,11 @@ GDL90Device::ParseTrafficReport(std::span<const uint8_t> payload,
 
     slot->Clear();
     slot->id = id;
+    /* Relatives are filled by FlarmComputer from ownship GPS; only clear
+       on first insert so later reports do not stomp computed values. */
+    slot->relative_north = 0;
+    slot->relative_east = 0;
+    slot->relative_altitude = 0;
     info.flarm.traffic.new_traffic.Update(info.clock);
   }
 
@@ -750,15 +755,12 @@ GDL90Device::ParseTrafficReport(std::span<const uint8_t> payload,
   } else
     slot->climb_rate_received = false;
 
-  /* not available / not conveyed by basic Traffic Report */
-  slot->relative_north = 0;
-  slot->relative_east = 0;
-  slot->relative_altitude = 0;
+  /* Not conveyed by the Traffic Report; leave relative_* and
+     climb_rate_avg30s_* for FlarmComputer. */
   slot->stealth = false;
   slot->no_track = false;
   slot->rssi_available = false;
   slot->turn_rate_received = false;
-  slot->climb_rate_avg30s_available = false;
 }
 
 bool

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -119,7 +119,10 @@ class DeviceListWidget final
         basic.total_energy_vario_available ||
         basic.noncomp_vario_available;
       traffic = basic.flarm.IsDetected();
-      gdl90 = traffic && config.UsesDriver() && config.driver_name == "GDL90";
+      /* GDL90 status follows protocol activity (heartbeat / any frame
+         sets alive), not traffic presence — SoftRF may have ownship
+         with an empty traffic list. */
+      gdl90 = alive && config.UsesDriver() && config.driver_name == "GDL90";
       foreflight_id = config.UsesDriver() && config.driver_name == "GDL90" &&
         basic.device.license.equals("ForeFlight");
       foreflight_ahrs = config.UsesDriver() && config.driver_name == "GDL90" &&
@@ -441,8 +444,10 @@ DeviceListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
       buffer.append(_("Vario"));
     }
 
-    if (flags.traffic)
-      buffer.append(flags.gdl90 ? "; GDL90" : "; FLARM");
+    if (flags.gdl90)
+      buffer.append("; GDL90");
+    else if (flags.traffic)
+      buffer.append("; FLARM");
 
     if (flags.foreflight_ahrs)
       buffer.append("; ForeFlight AHRS");

--- a/src/Gauge/FlarmTrafficWindow.cpp
+++ b/src/Gauge/FlarmTrafficWindow.cpp
@@ -328,6 +328,12 @@ FlarmTrafficWindow::PaintRadarTarget(Canvas &canvas,
                                      const FlarmTraffic &traffic,
                                      unsigned i) noexcept
 {
+  /* Absolute traffic (GDL90 / ADS-B) has no relatives until FlarmComputer
+     has ownship GPS.  Distance zero would plot on the aircraft — skip
+     until relatives are usable.  Classic FLARM already sends N/E. */
+  if (traffic.absolute_location && traffic.distance.IsZero())
+    return;
+
   // Save relative East/North
   DoublePoint2D p(traffic.relative_east, -traffic.relative_north);
 


### PR DESCRIPTION
## Summary
- Show `; GDL90` on the device list while the port is alive (any valid frame), not only when FLARM traffic is detected — SoftRF can have ownship with an empty traffic list.
- Skip absolute (GDL90/ADS-B) targets on the FLARM radar when relative distance is still zero, so traffic does not pile on the ownship before a GNSS fix. Classic FLARM relatives are unchanged.
- Stop re-zeroing `relative_*` (and clearing `climb_rate_avg30s_available`) on every GDL90 traffic update; clear relatives only on first insert and leave them for `FlarmComputer`.

No ownship-as-traffic ICAO filter (SoftRF does not emit that; see #2800 / etdey/gdl90#7).

Closes #2800

## Test plan
- [ ] SoftRF BLE/USB without GNSS: device list shows `; GDL90` when linked; radar does not place absolute targets on the aircraft
- [ ] SoftRF with GNSS fix: traffic appears on radar at correct relative positions
- [ ] Classic FLARM: radar still shows relative targets without XCSoar GNSS if the device provides N/E
- [ ] `simulate_stratux.py` / UDP GDL90: bandits still appear once ownship position is available
- [ ] `./output/UNIX/bin/TestGDL90Driver` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GDL90 devices now show as active when a valid heartbeat or data link is available, even before traffic is detected.
  * GDL90 and FLARM status indicators are displayed more accurately.
  * Traffic targets no longer appear incorrectly at the aircraft’s position while location data is unavailable.
  * Relative traffic position, altitude, and climb information are preserved correctly between updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->