### PR TITLE
CommandLine: Resolve -profile= after -datapath=

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -498,6 +498,8 @@ Version 7.45 - not yet released
   - Configuration / Quick Guide: do not persist unchanged profile defaults
     (terrain, LanguageFile, ContestEnumLayout, HideQuickGuideDialogOnStartup);
     Expert writes UserLevel=1 or removes the key (#1793)
+  - fix ``-profile=`` basename so it resolves under ``-datapath=`` regardless of
+    command-line argument order #848
   - .cup tasks: More correctly parse SeeYou .cup task files with observation zones
     with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder.
     Previously these were incorrectly parsed into FAI Quadrants #2697

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -33,6 +33,9 @@ namespace CommandLine {
 #ifdef HAVE_CMDLINE_REPLAY
   const char *replay_path;
 #endif
+
+  /** Set by @c -profile=; applied in ApplyPendingProfile(). */
+  static AllocatedPath pending_profile;
 }
 
 /** Option list for Args::UsageError (stderr); leading newline continues Usage:. */
@@ -121,8 +124,11 @@ CommandLine::Parse(Args &args)
       if (StringIsEmpty(s))
         args.UsageError();
 
+      /* Defer Profile::SetFiles() until ApplyPendingProfile() so a
+         basename is joined to -datapath= even when -profile= appears
+         first on the command line (#848). */
       PathName convert(s);
-      Profile::SetFiles(convert);
+      pending_profile = AllocatedPath(Path(convert));
     } else if (StringIsEqual(s, "-datapath=", 10)) {
       s += 10;
       PathName convert(s);
@@ -204,4 +210,14 @@ CommandLine::Parse(Args &args)
   if (width < 240 || width > 4096 ||
       height < 240 || height > 4096)
     args.UsageError();
+}
+
+void
+CommandLine::ApplyPendingProfile() noexcept
+{
+  if (pending_profile == nullptr)
+    return;
+
+  Profile::SetFiles(pending_profile);
+  pending_profile = nullptr;
 }

--- a/src/CommandLine.hpp
+++ b/src/CommandLine.hpp
@@ -75,4 +75,11 @@ PrintHelp() noexcept;
  * @param CommandLine command line argument string
  */
   void Parse(Args &args);
+
+/**
+ * Apply a pending @c -profile= value after the data path is known
+ * (@c -datapath= and/or InitialiseDataPath()).  Basename profiles are
+ * resolved under the primary data path / @c profiles/.
+ */
+  void ApplyPendingProfile() noexcept;
 }

--- a/src/XCSoar.cpp
+++ b/src/XCSoar.cpp
@@ -122,6 +122,7 @@ try {
   }
 
   InitialiseDataPath();
+  CommandLine::ApplyPendingProfile();
 
   // Write startup note + version to logfile
   LogFormat("Starting %s", XCSoar_ProductToken);


### PR DESCRIPTION
## Summary
- Fixes `#848` (only open `topic-profile` + `low-hanging-fruit` issue): basename `-profile=` is deferred until after `-datapath=` / `InitialiseDataPath()`, so argument order no longer matters.
- Verified locally: `xcsoar -profile=foo.prf -datapath=/tmp/... -fly` loads `/tmp/.../profiles/foo.prf`.

## Test plan
- [ ] `xcsoar -profile=foo.prf -datapath=/custom -fly` loads `/custom/profiles/foo.prf` (order that used to fail)
- [ ] `xcsoar -datapath=/custom -profile=foo.prf -fly` still works
- [ ] Absolute `-profile=/path/to/file.prf` unchanged
- [ ] No `-profile=` → default profile under data path as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile selection so basename profiles consistently resolve from the configured data path, regardless of command-line option order.
  * Improved startup handling of profile settings before the application initializes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->