### PR TITLE
Dialogs/TouchTextEntry: Focus OK so Enter confirms

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -65,10 +65,10 @@ Version 7.45 - not yet released
     on Down
   - Draw map GPS status above the map scale / title line so it is not
     covered by AUTO / Simulator / REPLAY text
-  - Improve soft keyboard text entry: default focus on a key; cursor
-    keys move across the grid (Up from OK/Cancel/Clear enters the
-    keyboard; arrows no longer jump in tab order at row edges); F1 is
-    backspace
+  - Improve soft keyboard text entry: default focus on OK so Enter
+    confirms (not the “1” key); cursor keys move across the grid (Up
+    from OK/Cancel/Clear enters the keyboard; arrows no longer jump in
+    tab order at row edges); F1 is backspace
   - Fix profile selection / startup branding: use transparent RGBA logo
     and title bitmaps on light (parchment) dialog backgrounds #2742
   - Size the InfoBox panel to the current tab and lift map overlays by

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -269,24 +269,10 @@ TouchTextEntry(char *text, size_t width,
   WindowStyle button_style;
   button_style.TabStop();
 
-  /* Create the soft keyboard before OK/Cancel/Clear so
-     FocusFirstControl (dialog default focus) lands on a key and the
-     cursor keys can navigate immediately. */
-  KeyboardWidget keyboard(look.button, FormCharacter, !accb,
-                          default_shift_state);
-
-  keyboard.Initialise(client_area, L.keyboard);
-  keyboard.Prepare(client_area, L.keyboard);
-  keyboard.Show(L.keyboard);
-
-  kb = &keyboard;
-
-  Button backspace_button(client_area, look.button, "<-",
-                          L.backspace,
-                          button_style, [](){ OnBackspace(); });
-
-  textentry_backspace = &backspace_button;
-
+  /* Create OK first so FocusFirstControl lands there: Enter confirms
+     instead of typing the focused soft key (often @em 1).  Do not use
+     HasKeyboard() for this — joystick remotes often appear as HID
+     keyboards.  Up from OK still enters the grid (Space). */
   Button ok_button(client_area, look.button, _("OK"),
                    L.ok,
                    button_style, form.MakeModalResultCallback(mrOK));
@@ -302,6 +288,21 @@ TouchTextEntry(char *text, size_t width,
                       button_style,
                       [](){ ClearText(); });
   textentry_clear = &clear_button;
+
+  KeyboardWidget keyboard(look.button, FormCharacter, !accb,
+                          default_shift_state);
+
+  keyboard.Initialise(client_area, L.keyboard);
+  keyboard.Prepare(client_area, L.keyboard);
+  keyboard.Show(L.keyboard);
+
+  kb = &keyboard;
+
+  Button backspace_button(client_area, look.button, "<-",
+                          L.backspace,
+                          button_style, [](){ OnBackspace(); });
+
+  textentry_backspace = &backspace_button;
 
   form.SetClientLayoutFunction([&]() {
     const PixelRect rc = client_area.GetClientRect();

--- a/src/Widget/KeyboardWidget.hpp
+++ b/src/Widget/KeyboardWidget.hpp
@@ -70,8 +70,7 @@ public:
 
   /**
    * Focus the first enabled on-screen key (number row first).  Used as
-   * a fallback when Space is unavailable, and for the dialog default
-   * focus when the keyboard is created before the action buttons.
+   * a fallback when Space is unavailable.
    */
   bool FocusFirstEnabledInGrid() noexcept;
 


### PR DESCRIPTION
## Summary
- Soft keyboard text entry had default focus on the first key (`1`), so Enter inserted that character instead of confirming.
- Restore OK-first control creation so `FocusFirstControl` lands on OK; Up still enters the key grid at Space.
- Avoid `HasKeyboard()` for this: joystick remotes often appear as HID keyboards, and Enter must still activate a focused soft key.

## Test plan
- [ ] Open soft keyboard text entry on a desktop build with a physical keyboard: Enter confirms (OK), does not insert `1`
- [ ] Press Up from OK: focus moves to Space; arrows move across the grid; Enter on a soft key inserts that character
- [ ] Escape / Cancel still dismisses without saving
- [ ] F1 / Back still deletes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Soft keyboard dialogs now initially focus the **OK** button, allowing Enter to confirm input instead of selecting the “1” key.
  * Preserved grid-based cursor navigation, including smooth movement from OK, Cancel, and Clear buttons.
  * Maintained F1 as the backspace shortcut and prevented unwanted focus jumps at row edges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->