### PR TITLE
Dialogs/Settings: Do not persist unchanged profile defaults

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -487,6 +487,9 @@ Version 7.45 - not yet released
   - add NOTAM settings and filters (IFR, effective time, max radius, hidden Q-codes)
   - add NOTAM details integration in airspace dialogs
 * data files
+  - Configuration / Quick Guide: do not persist unchanged profile defaults
+    (terrain, LanguageFile, ContestEnumLayout, HideQuickGuideDialogOnStartup);
+    Expert writes UserLevel=1 or removes the key (#1793)
   - .cup tasks: More correctly parse SeeYou .cup task files with observation zones
     with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder.
     Previously these were incorrectly parsed into FAI Quadrants #2697

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -248,10 +248,15 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
   if (wp != nullptr) {
     DataFieldEnum &df = *(DataFieldEnum *)wp->GetDataField();
 
+    /* Use AllocatedPath here: Path::empty() null-dereferences, while
+       AllocatedPath::empty() is safe. Missing / empty LanguageFile means
+       automatic — same as ReadLanguageFile(); do not persist "auto" just
+       because the key was absent (#1793). */
     const auto old_value_buffer = Profile::GetPath(ProfileKeys::LanguageFile);
-    Path old_value = old_value_buffer;
-    if (old_value == nullptr)
-      old_value = Path("");
+    const bool old_is_auto =
+      old_value_buffer == nullptr || old_value_buffer.empty() ||
+      old_value_buffer == Path("auto");
+    Path old_value = old_is_auto ? Path("auto") : Path(old_value_buffer);
 
     auto old_base = old_value.GetBase();
     if (old_base == nullptr)

--- a/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/ScoringConfigPanel.cpp
@@ -178,11 +178,16 @@ ScoringConfigPanel::Save(bool &_changed) noexcept
                        ProfileKeys::Show95PercentRuleHelpers,
                        map_settings.show_95_percent_rule_helpers);
 
-  /* Mark profile as using current Contest enum encoding (see ContestProfile). */
+  /* ContestEnumLayout=2 = current Contest encoding (see ContestProfile).
+     Only stamp when OLCRules is present — do not add the key to
+     untouched profiles.  Rewrite OLCRules so a migrated old NONE
+     (stored as 14) is not read as NET_COUPE after the stamp. */
   unsigned contest_enum_layout = 0;
-  if (!Profile::Get(ProfileKeys::ContestEnumLayout, contest_enum_layout) ||
-      contest_enum_layout < 2U) {
+  if (Profile::Exists(ProfileKeys::OLCRules) &&
+      (!Profile::Get(ProfileKeys::ContestEnumLayout, contest_enum_layout) ||
+       contest_enum_layout < 2U)) {
     Profile::Set(ProfileKeys::ContestEnumLayout, 2U);
+    Profile::SetEnum(ProfileKeys::OLCRules, contest_settings.contest);
     changed = true;
   }
 

--- a/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
@@ -84,7 +84,12 @@ class TerrainDisplayConfigPanel final
   bool have_terrain_preview;
 
 protected:
+  /** Current dialog values (may be previewed live). */
   TerrainRendererSettings terrain_settings;
+
+  /** Values when the panel was opened; used so Save() does not write
+      unchanged defaults into a profile that lacked those keys (#1793). */
+  TerrainRendererSettings initial_terrain_settings;
 
 public:
   TerrainDisplayConfigPanel()
@@ -342,6 +347,9 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
   terrain_settings = terrain;
   ShowTerrainControls();
   UpdateTerrainPreview();
+  /* Capture after UpdateTerrainPreview(): contrast/brightness go through
+     ByteToPercent ↔ PercentToByte, which is lossy for some values. */
+  initial_terrain_settings = terrain_settings;
 }
 
 bool
@@ -350,15 +358,22 @@ TerrainDisplayConfigPanel::Save(bool &_changed) noexcept
   MapSettings &settings_map = CommonInterface::SetMapSettings();
 
   bool changed = false;
-  changed = (settings_map.terrain != terrain_settings);
 
+  /* Always apply in-memory map settings (EnableTerrain may already
+     have updated settings_map live).  Persist only when values differ
+     from the panel-open snapshot so missing profile defaults stay
+     absent (#1793). */
   settings_map.terrain = terrain_settings;
-  Profile::Set(ProfileKeys::DrawTerrain, terrain_settings.enable);
-  Profile::Set(ProfileKeys::TerrainContrast, terrain_settings.contrast);
-  Profile::Set(ProfileKeys::TerrainBrightness, terrain_settings.brightness);
-  Profile::Set(ProfileKeys::TerrainRamp, terrain_settings.ramp);
-  Profile::SetEnum(ProfileKeys::SlopeShadingType, terrain_settings.slope_shading);
-  Profile::SetEnum(ProfileKeys::TerrainContours, terrain_settings.contours);
+  if (terrain_settings != initial_terrain_settings) {
+    Profile::Set(ProfileKeys::DrawTerrain, terrain_settings.enable);
+    Profile::Set(ProfileKeys::TerrainContrast, terrain_settings.contrast);
+    Profile::Set(ProfileKeys::TerrainBrightness, terrain_settings.brightness);
+    Profile::Set(ProfileKeys::TerrainRamp, terrain_settings.ramp);
+    Profile::SetEnum(ProfileKeys::SlopeShadingType,
+                     terrain_settings.slope_shading);
+    Profile::SetEnum(ProfileKeys::TerrainContours, terrain_settings.contours);
+    changed = true;
+  }
 
   changed |= SaveValue(EnableTopography, ProfileKeys::DrawTopography,
                        settings_map.topography_enabled);

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -307,7 +307,9 @@ static void
 OnUserLevel(bool expert) noexcept
 {
   CommonInterface::SetUISettings().dialog.expert = expert;
-  Profile::Set(ProfileKeys::UserLevel, expert);
+
+  /* Keep Profile I/O out of this checkbox callback (pager is mid-
+     relayout). Persist UserLevel when the dialog closes instead. */
 
   /* force layout update */
   pager->PagerWidget::Move(pager->GetPosition());
@@ -379,12 +381,31 @@ void dlgConfigurationShowModal()
     return true;
   });
 
-  dialog.ShowModal();
+  const int result = dialog.ShowModal();
 
   /* save page number for next time this dialog is opened */
   current_page = menu.GetCursor();
 
-  if (dialog.GetChanged()) {
+  /* Persist Expert only on OK. Missing UserLevel means beginner —
+     write "1" when enabling Expert; remove the key when returning to
+     beginner (do not leave UserLevel=0 cruft) (#1793). */
+  bool expert_changed = false;
+  if (result == mrOK) {
+    const bool expert = CommonInterface::GetUISettings().dialog.expert;
+    if (expert) {
+      bool profile_expert = false;
+      Profile::Get(ProfileKeys::UserLevel, profile_expert);
+      if (!profile_expert) {
+        Profile::Set(ProfileKeys::UserLevel, true);
+        expert_changed = true;
+      }
+    } else if (Profile::Exists(ProfileKeys::UserLevel)) {
+      Profile::Remove(ProfileKeys::UserLevel);
+      expert_changed = true;
+    }
+  }
+
+  if (dialog.GetChanged() || expert_changed) {
     Profile::Save();
     if (require_restart)
       ShowMessageBox(_("Changes to configuration saved. Restart XCSoar to apply changes."),

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -779,12 +779,17 @@ dlgQuickGuideShowModal(bool force_info)
   }
 #endif
 
-  // Save "don't show again" state (both checked and unchecked,
-  // so unticking from the Info menu re-enables the guide)
+  /* Only persist when the checkbox changed vs profile (missing key =
+     show guide). Still writes false when unticking from Info. */
   if (info_pages_needed) {
-    Profile::Set(ProfileKeys::HideQuickGuideDialogOnStartup,
-                 state.hide_guide_checked);
-    Profile::Save();
+    bool previously_hidden = false;
+    Profile::Get(ProfileKeys::HideQuickGuideDialogOnStartup,
+                 previously_hidden);
+    if (state.hide_guide_checked != previously_hidden) {
+      Profile::Set(ProfileKeys::HideQuickGuideDialogOnStartup,
+                   state.hide_guide_checked);
+      Profile::Save();
+    }
   }
 
   (void)result;

--- a/src/Profile/Map.hpp
+++ b/src/Profile/Map.hpp
@@ -52,8 +52,10 @@ public:
   }
 
   void Remove(std::string_view key) noexcept {
-    if (auto i = map.find(key); i != map.end())
+    if (auto i = map.find(key); i != map.end()) {
       map.erase(i);
+      SetModified();
+    }
   }
 
   [[gnu::pure]]

--- a/src/Profile/ProfileMap.cpp
+++ b/src/Profile/ProfileMap.cpp
@@ -120,6 +120,12 @@ Profile::Exists(std::string_view key) noexcept
 }
 
 void
+Profile::Remove(std::string_view key) noexcept
+{
+  map.Remove(key);
+}
+
+void
 Profile::Clear() noexcept
 {
   map.Clear();

--- a/src/Profile/ProfileMap.hpp
+++ b/src/Profile/ProfileMap.hpp
@@ -142,6 +142,9 @@ bool
 Exists(std::string_view key) noexcept;
 
 void
+Remove(std::string_view key) noexcept;
+
+void
 Clear() noexcept;
 
 } // namespace Profile


### PR DESCRIPTION
## Summary
- Fixes #1793: do not stamp unchanged profile defaults when opening/closing Configuration or Quick Guide.
- Terrain: snapshot at panel open (after preview percent↔byte sync); write only when values differ.
- Language: missing `LanguageFile` stays automatic (no `LanguageFile=auto`).
- Scoring: stamp `ContestEnumLayout` only when `OLCRules` is present.
- Quick Guide: write `HideQuickGuideDialogOnStartup` only when the checkbox changed.
- Expert: write `UserLevel=1` when enabled; remove the key for beginner (no `UserLevel=0`).
- `ProfileMap::Remove` marks the profile modified so removals are saved.

## Test plan
- [ ] Start with a `.prf` that lacks the keys from #1793
- [ ] Open Configuration → Terrain / Language / Scoring, close without changes — keys stay absent
- [ ] Change one terrain setting — only changed terrain keys are written
- [ ] Tick Expert on, close — `UserLevel=1`; tick off, close — key removed
- [ ] Quick Guide: leave “don’t show” unchecked — no `HideQuickGuideDialogOnStartup`; check it — key written
- [ ] Profile with `OLCRules` still gets `ContestEnumLayout=2` when needed; profile without `OLCRules` does not

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings persistence to avoid saving unchanged default preferences.
  * Fixed language, contest layout, terrain, Quick Guide, and Expert mode settings being saved unnecessarily or inconsistently.
  * Correctly removes disabled Expert mode settings from profiles.
  * Prevented legacy contest values from being misinterpreted during profile migration.
  * Profile changes are now detected accurately when settings are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->