### PR TITLE
Tracking/SkyLines: Skip DNS Open when link is down

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,5 +1,7 @@
 Version 7.45 - not yet released
 * tracking
+  - Do not resolve SkyLines or XCSoar Cloud hosts while the network link is
+    down, avoiding repeated DNS timeout errors in the log #1750
   - Untangle XCSoar Cloud settings from SkyLines live tracking: cloud traffic
     and roaming are independent of SkyLines options
   - Rename map display setting to "Online traffic on map" (SkyLines and

--- a/src/Tracking/SkyLines/Glue.cpp
+++ b/src/Tracking/SkyLines/Glue.cpp
@@ -222,9 +222,13 @@ SkyLinesTracking::Glue::SetSettings(const Settings &skylines_settings,
     if (endpoint_changed && cloud_client.IsDefined())
       cloud_client.Close();
 
-    if (!cloud_client.IsDefined()) {
-      cloud_host = host;
-      cloud_port = port;
+    cloud_host = host;
+    cloud_port = port;
+
+    /* Do not start DNS while offline (LiveTrack24 / TIM do the same).
+       ProcessTimer re-applies settings often; Open() without this gate
+       retries resolve on every failure and floods xcsoar.log (#1750). */
+    if (!cloud_client.IsDefined() && IsNetConnected(cloud_roaming)) {
       cloud_client.Open(*global_cares_channel, host, port);
       if (GetEnvBool("XCS_CLOUD_DEBUG"))
         LogFmt("Cloud: opening {}:{} (simulator override enabled)",
@@ -247,12 +251,11 @@ SkyLinesTracking::Glue::SetSettings(const Settings &skylines_settings,
 
   interval = seconds(skylines_settings.interval);
 
-  if (!client.IsDefined()) {
-    client.Open(*global_cares_channel, "tracking.skylines.aero");
-  }
-
   traffic_enabled = skylines_settings.traffic_enabled;
   near_traffic_enabled = skylines_settings.near_traffic_enabled;
 
   skylines_roaming = skylines_settings.roaming;
+
+  if (!client.IsDefined() && IsNetConnected(skylines_roaming))
+    client.Open(*global_cares_channel, "tracking.skylines.aero");
 }


### PR DESCRIPTION
## Summary
- Gate SkyLines and XCSoar Cloud `Open()` on `IsNetConnected()` so DNS is not started while offline (same idea as LiveTrack24 / TIM).
- Fixes log spam of `SkyLines error: ares_gethostbyname() failed: Timeout...` every ~12s when `ProcessTimer` re-applies settings after a failed resolve (#1750).

## Test plan
- [ ] Enable SkyLines (or XCSoar Cloud), go offline, run for several minutes: no repeating DNS timeout lines in `xcsoar.log`
- [ ] Come back online: client opens and tracking / traffic resume
- [ ] With SkyLines disabled: no client open attempts
- [ ] Roaming disabled + cellular roaming: Open stays skipped (existing roaming preference)

Closes #1750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated DNS timeout errors when the network connection is unavailable.
  * SkyLines and XCSoar Cloud connections now wait until network access is allowed before resolving hosts or connecting.
  * Cloud endpoint changes continue to close existing connections and apply updated settings correctly.
* **Documentation**
  * Added a version 7.45 release-note entry describing the improved offline behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->