### PR TITLE
DistanceRingsRenderer: Select rings from map scale

### DIFF
--- a/src/Renderer/DistanceRingsRenderer.cpp
+++ b/src/Renderer/DistanceRingsRenderer.cpp
@@ -117,7 +117,9 @@ DrawDistanceRings(Canvas &canvas,
   if (!projection.IsValid() || !aircraft_pos.IsValid())
     return;
 
-  const auto rings = SelectRingSet(projection.GetScreenDistanceMeters());
+  /* 8 * GetMapScale() is the short-edge span; GetScreenDistanceMeters()
+     follows the long edge and changes with InfoBox layout aspect. */
+  const auto rings = SelectRingSet(8 * projection.GetMapScale());
   const PixelPoint aircraft_px = projection.GeoToScreen(aircraft_pos);
   const PixelRect screen_rect = projection.GetScreenRect();
 


### PR DESCRIPTION
## Summary
- Distance ring presets were selected from `GetScreenDistanceMeters()` (longer map edge), so pages with different InfoBox layouts (different map aspect ratios) could show different rings at the same map scale.
- Select presets with `8 * GetMapScale()` (short-edge span), matching the stored page scale.
- Fixes #2741

## Test plan
- [ ] Create two pages: map-only, and one with many InfoBoxes (~12)
- [ ] Set the same map scale on both (e.g. 30 km)
- [ ] Enable distance rings
- [ ] Swipe between pages and confirm the same ring radii appear
- [ ] Zoom through several scale steps and confirm rings still update sensibly