### PR TITLE
Startup: Log screen metrics at startup

### DIFF
--- a/src/Screen/Layout.cpp
+++ b/src/Screen/Layout.cpp
@@ -12,6 +12,7 @@
 namespace Layout {
 
 bool landscape = false;
+bool small_screen = false;
 unsigned min_screen_pixels = 512;
 unsigned scale = 1;
 unsigned scale_1024 = 1024;
@@ -80,8 +81,9 @@ Initialise(const UI::Display &display, PixelSize new_size,
     return;
 
   const auto dpi = Display::GetDPI(display, custom_dpi);
-  const bool is_small_screen = IsSmallScreen(GetDisplaySize(display, new_size),
-                                             dpi);
+  const bool is_small_screen =
+    IsSmallScreen(GetDisplaySize(display, new_size), dpi);
+  small_screen = is_small_screen;
 
   const auto SmallScreenAdjust = [is_small_screen](unsigned value) constexpr noexcept {
     if (is_small_screen)

--- a/src/Screen/Layout.hpp
+++ b/src/Screen/Layout.hpp
@@ -13,6 +13,12 @@ namespace Layout
 extern bool landscape;
 
 /**
+ * True when the short edge is smaller than about 5 inches (used to
+ * shrink fonts for closer viewing distance).
+ */
+extern bool small_screen;
+
+/**
  * Screen size in pixels, the smaller of width and height.
  */
 extern unsigned min_screen_pixels;

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -71,6 +71,7 @@
 #include "net/client/tim/Glue.hpp"
 #include "Hardware/DisplayDPI.hpp"
 #include "Hardware/DisplayGlue.hpp"
+#include "Screen/Layout.hpp"
 #include "util/Compiler.h"
 #include "NMEA/Aircraft.hpp"
 #include "Waypoint/Waypoints.hpp"
@@ -331,9 +332,6 @@ Startup(UI::Display &display)
   if (!main_window->IsDefined())
     return false;
 
-  LogFmt("Display dpi={},{}",
-         Display::GetDPI(display).x, Display::GetDPI(display).y);
-
 #ifdef ENABLE_OPENGL
   LogFmt("OpenGL: "
 #ifdef HAVE_DYNAMIC_MULTI_DRAW_ARRAYS
@@ -421,6 +419,17 @@ Startup(UI::Display &display)
   main_window->CheckResize();
 
   SetDisplayType(CommonInterface::GetUISettings().display.display_type);
+
+  {
+    const PixelSize size = main_window->GetSize();
+    const auto dpi = Display::GetDPI(display);
+    LogFmt("Display: {}x{} dpi={},{} vdpi={} size={:.2f}x{:.2f}in "
+           "small_screen={}",
+           size.width, size.height, dpi.x, dpi.y, Layout::vdpi,
+           dpi.x > 0 ? double(size.width) / dpi.x : 0.,
+           dpi.y > 0 ? double(size.height) / dpi.y : 0.,
+           Layout::small_screen);
+  }
 
   /* Log device capabilities and features after initialization */
   LogFormat("Device capabilities: HasIOIOLib()=%s",


### PR DESCRIPTION
## Summary
- Replace the DPI-only startup log with resolution, DPI, virtual DPI, approximate size (inches from DPI), and the layout `small_screen` flag.
- Log after orientation/`CheckResize` so the size matches the final window; leave touch-screen and other capability flags in the existing device-capabilities block.

## Test plan
- [ ] Start XCSoar and confirm `xcsoar.log` contains a line like `Display: WxH dpi=… vdpi=… size=…in small_screen=…`
- [ ] Confirm existing `Device capabilities: HasTouchScreen()=…` (and related) lines still appear
- [ ] On a small / high-DPI device (or forced DPI), check `small_screen` and size look plausible

Closes #1548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved small-screen detection and font scaling for compact displays.
  * Startup display information now includes screen dimensions, DPI, physical size, and small-screen status.
* **Improvements**
  * Consolidated display diagnostics into a single, more informative startup log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->