### PR TITLE
Dialogs/KnobTextEntry: Allow lower-case letters

### DIFF
--- a/src/Dialogs/KnobTextEntry.cpp
+++ b/src/Dialogs/KnobTextEntry.cpp
@@ -9,7 +9,6 @@
 #include "ui/event/KeyCode.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
-#include "util/CharUtil.hxx"
 #include "util/Macros.hpp"
 #include "util/StringStrip.hxx"
 #include "util/TruncateString.hpp"
@@ -29,7 +28,7 @@ enum Buttons {
 static constexpr size_t MAX_TEXTENTRY = 40;
 
 static constexpr char EntryLetters[] =
-  " ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890.-";
+  " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890.-";
 
 static constexpr unsigned MAXENTRYLETTERS = ARRAY_SIZE(EntryLetters) - 1;
 
@@ -139,7 +138,7 @@ private:
     }
 
     lettercursor = GetCurrentSequenceLength() == 1
-      ? FindEntryLetter(ToUpperASCII(buffer[cursor]))
+      ? FindEntryLetter(buffer[cursor])
       : 0;
 
     if (IsDefined())


### PR DESCRIPTION
## Summary
- HighScore Style (`KnobTextEntry`) could only enter `A–Z` and uppercased characters when moving the cursor.
- Add `a–z` to the alphabet and stop forcing `ToUpperASCII`, so literal fields (e.g. WiFi passphrases) can keep lower-case letters.
- Waypoint search still normalizes case separately; this change is for stored text, not find-as-you-type matching.

## Test plan
- [ ] Setup → Config → Interface → set text input to HighScore Style
- [ ] Open a text field (e.g. WiFi passphrase / profile password) and enter both upper- and lower-case letters with A+/A−
- [ ] Move the cursor across mixed-case text; case is preserved
- [ ] Waypoint name filter still finds matches regardless of case entered

Closes #2387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HighScore Style text entry now accepts lowercase letters.
  * Cursor selection preserves the entered letter’s capitalization for more accurate editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->