### PR TITLE
Data/Input/default.xci: Bind F5/F6 on FLARM traffic radar

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -93,7 +93,7 @@ data=RETURN
 event=Traffic details
 
 # Traffic radar: F1 = AVG/ALT side labels; F2/F3 = zoom;
-# UP/DOWN and F4 = next/prev target
+# F5 = auto zoom; F6 = north-up; UP/DOWN and F4 = next/prev target
 mode=default.Traffic Display1.Traffic Display2.Traffic
 type=key
 data=UP
@@ -123,6 +123,16 @@ mode=default.Traffic Display1.Traffic Display2.Traffic
 type=key
 data=F4
 event=Traffic next
+
+mode=default.Traffic Display1.Traffic Display2.Traffic
+type=key
+data=F5
+event=Traffic zoom auto toggle
+
+mode=default.Traffic Display1.Traffic Display2.Traffic
+type=key
+data=F6
+event=Traffic northup toggle
 
 ###### pan mode
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -33,6 +33,9 @@ Version 7.45 - not yet released
   - fix crash when opening the aircraft type picker without a network
     connection
 * ui
+  - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
+    toggles (also fixes north-up so it no longer changes auto-zoom)
+    #2535
   - Add pinch-to-zoom on the map for touchscreens that report both
     finger positions (Android, iOS): two fingers scale about the
     pinch centroid and can pan at the same time; a two-finger drag

--- a/src/Gauge/BigTrafficWidget.cpp
+++ b/src/Gauge/BigTrafficWidget.cpp
@@ -797,7 +797,7 @@ TrafficWidget::GetNorthUp() const noexcept
 void
 TrafficWidget::SetNorthUp(bool value) noexcept
 {
-  windows->view.SetAutoZoom(value);
+  windows->view.SetNorthUp(value);
 }
 
 void


### PR DESCRIPTION
## Summary
- Bind **F5** (auto-zoom) and **F6** (north-up) on the FLARM traffic radar for `default.Traffic` / Display1 / Display2.
- Fix `TrafficWidget::SetNorthUp` so it does not call `SetAutoZoom`.

Does **not** close #2535: panel vs blip AVG/ALT labelling and softkey toolbar buttons remain.

## Test plan
- [ ] Open FLARM traffic radar with default input: F5 toggles auto-zoom, F6 toggles north-up / track-up
- [ ] F1–F4 still work (AVG/ALT, zoom, next target)
- [ ] Main map F5/F6 still open Alternates / GotoLookup when not in traffic mode
- [ ] Display1 softkeys 8 / 0 still work alongside F5/F6

Refs #2535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added F5 and F6 controls for FLARM traffic radar:
    - F5 toggles automatic zoom.
    - F6 toggles north-up orientation.

- **Bug Fixes**
  - Corrected the north-up control so changing it no longer unintentionally changes automatic zoom settings.

- **Documentation**
  - Updated traffic mode documentation to include the new keyboard controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->