### PR TITLE
Device/Driver/LX: Fix polar sync writes that zero S-series polars

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -43,6 +43,9 @@ Version 7.46 - not yet released
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log
     #2903
+  - fix LXNAV polar sync writes that could zero the vario polar when
+    crew or empty mass were sent before the device polar was known;
+    preserve max weight and glider name when sending a polar #2397
 * dialogs
   - let Shift type '_' on XCSoar's on-screen keyboard
   - fix keyboard wrap in the Checklist: Down from Close returns

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -196,6 +196,9 @@ Version 7.45 - not yet released
   - fix crash opening the log list when replay filenames contain
     non-ASCII characters (Unicode directory listing and file open)
 * devices
+  - LXNAV: fix polar sync writes that could zero the vario polar when
+    crew or empty mass were sent before the device polar was known;
+    preserve max weight and glider name when sending a polar #2397
   - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
     shows other gliders on the FLARM radar and map
   - Condor3UDP: stop deriving track from ground-velocity vx/vy (caused

--- a/build/test.mk
+++ b/build/test.mk
@@ -96,6 +96,7 @@ TEST_NAMES = \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
 	TestFileUtil TestRepository TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
+	TestLXNAVPolarConversion \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -815,6 +816,12 @@ TEST_GLIDE_POLAR_SOURCES = \
 	$(TEST_SRC_DIR)/TestGlidePolar.cpp
 TEST_GLIDE_POLAR_DEPENDS = GEO MATH IO UNITS
 $(eval $(call link-program,TestGlidePolar,TEST_GLIDE_POLAR))
+
+TEST_LXNAV_POLAR_CONVERSION_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestLXNAVPolarConversion.cpp
+TEST_LXNAV_POLAR_CONVERSION_DEPENDS = MATH UTIL GLIDE
+$(eval $(call link-program,TestLXNAVPolarConversion,TEST_LXNAV_POLAR_CONVERSION))
 
 TEST_FILE_UTIL_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -96,6 +96,7 @@ TEST_NAMES = \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
 	TestFileUtil TestRepository TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
+	TestLXNAVPolarConversion \
 	test_replay_task TestProjection TestFlatPoint TestFlatLine TestFlatGeoPoint \
 	TestMacCready TestOrderedTask TestAATPoint TestTaskSave \
 	TestTaskFileSeeYouParsing \
@@ -766,6 +767,12 @@ TEST_GLIDE_POLAR_SOURCES = \
 	$(TEST_SRC_DIR)/TestGlidePolar.cpp
 TEST_GLIDE_POLAR_DEPENDS = GEO MATH IO UNITS
 $(eval $(call link-program,TestGlidePolar,TEST_GLIDE_POLAR))
+
+TEST_LXNAV_POLAR_CONVERSION_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestLXNAVPolarConversion.cpp
+TEST_LXNAV_POLAR_CONVERSION_DEPENDS = MATH UTIL GLIDE
+$(eval $(call link-program,TestLXNAVPolarConversion,TEST_LXNAV_POLAR_CONVERSION))
 
 TEST_FILE_UTIL_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1165,7 +1165,7 @@ DEBUG_PROGRAM_NAMES += \
 	FlightPath \
 	ReadProfileString ReadProfileInt \
 	KeyCodeDumper \
-	ReadPort RunPortHandler LogPort \
+	ReadPort RunPortHandler LogPort RunLXNAVPolarEcho \
 	SplicePorts \
 	RunDeviceDriver RunDeclare RunFlightList RunDownloadFlight \
 	RunEnableNMEA \
@@ -1646,6 +1646,21 @@ LOG_PORT_SOURCES = \
 	$(TEST_SRC_DIR)/LogPort.cpp
 LOG_PORT_DEPENDS = PORT ASYNC LIBNET OPERATION IO OS THREAD TIME UTIL
 $(eval $(call link-program,LogPort,LOG_PORT))
+
+RUN_LXNAV_POLAR_ECHO_SOURCES = \
+	$(SRC)/Device/Port/ConfiguredPort.cpp \
+	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
+	$(SRC)/Device/Config.cpp \
+	$(SRC)/Device/Util/NMEAWriter.cpp \
+	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/DebugPort.cpp \
+	$(TEST_SRC_DIR)/RunLXNAVPolarEcho.cpp
+RUN_LXNAV_POLAR_ECHO_DEPENDS = PORT ASYNC LIBNET OPERATION IO OS THREAD TIME UTIL MATH GLIDE EVENT
+$(eval $(call link-program,RunLXNAVPolarEcho,RUN_LXNAV_POLAR_ECHO))
 
 SPLICE_PORTS_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -1116,7 +1116,7 @@ DEBUG_PROGRAM_NAMES += \
 	FlightPath \
 	ReadProfileString ReadProfileInt \
 	KeyCodeDumper \
-	ReadPort RunPortHandler LogPort \
+	ReadPort RunPortHandler LogPort RunLXNAVPolarEcho \
 	SplicePorts \
 	RunDeviceDriver RunDeclare RunFlightList RunDownloadFlight \
 	RunEnableNMEA \
@@ -1594,6 +1594,17 @@ LOG_PORT_SOURCES = \
 	$(TEST_SRC_DIR)/LogPort.cpp
 LOG_PORT_DEPENDS = PORT ASYNC LIBNET OPERATION IO OS THREAD TIME UTIL
 $(eval $(call link-program,LogPort,LOG_PORT))
+
+RUN_LXNAV_POLAR_ECHO_SOURCES = \
+	$(SRC)/Device/Util/NMEAWriter.cpp \
+	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/RunLXNAVPolarEcho.cpp
+RUN_LXNAV_POLAR_ECHO_DEPENDS = PORT ASYNC LIBNET OPERATION IO OS THREAD TIME UTIL MATH GLIDE EVENT
+$(eval $(call link-program,RunLXNAVPolarEcho,RUN_LXNAV_POLAR_ECHO))
 
 SPLICE_PORTS_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \

--- a/doc/test_debug_utilities.rst
+++ b/doc/test_debug_utilities.rst
@@ -816,6 +816,94 @@ This will:
 **Note**: Requires Debian/Ubuntu package ``socat``. The device port must be
 available (not in use by XCSoar) when monitoring directly.
 
+RunLXNAVPolarEcho
+~~~~~~~~~~~~~~~~~
+
+Hardware check for LXNAV ``PLXV0,POLAR`` coefficient conversion and
+safe full-POLAR rewrites (#2397).  Use with a V7, S80, S10, or compatible
+vario on a free serial/USB port (XCSoar must not hold the port).
+
+**Build**::
+
+   make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/bin/RunLXNAVPolarEcho
+   make -j$(nproc) TARGET=WIN64 USE_CCACHE=y output/WIN64/bin/RunLXNAVPolarEcho.exe
+
+**Usage**::
+
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200 --read-only
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200 --preserve-crew
+   ./output/WIN64/bin/RunLXNAVPolarEcho.exe COM3 115200
+
+**Modes**:
+
+- default: write a known Hornet sample polar, read it back, verify SI
+  round-trip of a,b,c
+- ``--read-only``: only ``PLXV0,POLAR,R``; print LX and SI coefficients
+  (non-destructive snapshot of the vario polar)
+- ``--preserve-crew``: after a successful read, rewrite a *full* POLAR
+  sentence with pilot weight 95 kg and check that a,b,c, max weight and
+  name are unchanged (guards against empty-field polar wipes)
+
+**Exit status**: ``0`` on success, non-zero on timeout or mismatch.
+
+LXNAV polar sync — manual XCSoar checklist (#2397)
+--------------------------------------------------
+
+Automated unit tests cover conversion and write shaping.  Confirm on a
+real S10/S80 (or V7) with XCSoar before merging polar-sync changes.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+- LXNAV driver selected; note baud rate and ``Sync from/to device``
+- Plane profile: reference mass, empty mass, pilot weight, and max
+  ballast match the vario (or use polar sync Receive to import them)
+- Enable NMEA logger on the device port if you need a recording
+
+A. Coefficient harness (no full UI)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Quit XCSoar so the serial port is free.
+2. Run ``RunLXNAVPolarEcho PORT BAUD`` then
+   ``RunLXNAVPolarEcho PORT BAUD --preserve-crew``.
+3. Expect ``Round-trip vs sent SI: OK`` and
+   ``Preserve coefficients after crew rewrite: OK``.
+
+B. Polar sync Receive (ballast kg)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Device dialog: **Polar sync = Receive from device**.
+2. Connect; wait for “Polar received from device” (or confirm masses
+   updated in Basic settings / plane).
+3. On the vario set MacCready and water ballast to a known full value
+   (e.g. 180 kg).
+4. XCSoar ballast litres / kg should match within a few kg (same
+   reference, empty, and pilot masses).
+5. Change MC on the vario; XCSoar MC should follow.
+
+C. Polar sync Send (must not corrupt vario)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Note the vario’s polar name, MC speed-to-fly at a fixed MC (e.g. 1.2),
+   and ballast display **before** connecting.
+2. Device dialog: **Polar sync = Send to device**; plane polar in XCSoar
+   must be the intended glider polar.
+3. Connect and wait for polar send.
+4. On the vario, MC speeds and polar must remain plausible (not
+   ±10 m/s nonsense, not 180 km/h at MC 1.2 with no water on a Ventus).
+5. Optional: ``RunLXNAVPolarEcho PORT BAUD --read-only`` afterwards and
+   confirm a,b,c are still non-tiny LX values (order ~1, not ~0.002).
+
+D. Crew / empty mass without wiping polar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Polar sync Off or Receive; connect so XCSoar has seen a POLAR reply.
+2. Change pilot weight in XCSoar Basic settings (sync to device on).
+3. Vario polar and STF must stay sane; pilot weight updates.
+4. Optional NMEA log: outgoing ``PLXV0,POLAR,W`` must include non-empty
+   a,b,c (not ``PLXV0,POLAR,W,,,,,,,,``).
+
 CAI302Tool
 ~~~~~~~~~~
 

--- a/doc/test_debug_utilities.rst
+++ b/doc/test_debug_utilities.rst
@@ -816,6 +816,92 @@ This will:
 **Note**: Requires Debian/Ubuntu package ``socat``. The device port must be
 available (not in use by XCSoar) when monitoring directly.
 
+RunLXNAVPolarEcho
+~~~~~~~~~~~~~~~~~
+
+Hardware check for LXNAV ``PLXV0,POLAR`` coefficient conversion and
+safe full-POLAR rewrites (#2397).  Use with a V7, S80, S10, or compatible
+vario on a free serial/USB port (XCSoar must not hold the port).
+
+**Build**::
+
+   make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/bin/RunLXNAVPolarEcho
+
+**Usage**::
+
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200 --read-only
+   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200 --preserve-crew
+
+**Modes**:
+
+- default: write a known Hornet sample polar, read it back, verify SI
+  round-trip of a,b,c
+- ``--read-only``: only ``PLXV0,POLAR,R``; print LX and SI coefficients
+  (non-destructive snapshot of the vario polar)
+- ``--preserve-crew``: after a successful read, rewrite a *full* POLAR
+  sentence with pilot weight 95 kg and check that a,b,c, max weight and
+  name are unchanged (guards against empty-field polar wipes)
+
+**Exit status**: ``0`` on success, non-zero on timeout or mismatch.
+
+LXNAV polar sync — manual XCSoar checklist (#2397)
+--------------------------------------------------
+
+Automated unit tests cover conversion and write shaping.  Confirm on a
+real S10/S80 (or V7) with XCSoar before merging polar-sync changes.
+
+Prerequisites
+^^^^^^^^^^^^^
+
+- LXNAV driver selected; note baud rate and ``Sync from/to device``
+- Plane profile: reference mass, empty mass, pilot weight, and max
+  ballast match the vario (or use polar sync Receive to import them)
+- Enable NMEA logger on the device port if you need a recording
+
+A. Coefficient harness (no full UI)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Quit XCSoar so the serial port is free.
+2. Run ``RunLXNAVPolarEcho PORT BAUD`` then
+   ``RunLXNAVPolarEcho PORT BAUD --preserve-crew``.
+3. Expect ``Round-trip vs sent SI: OK`` and
+   ``Preserve coefficients after crew rewrite: OK``.
+
+B. Polar sync Receive (ballast kg)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Device dialog: **Polar sync = Receive from device**.
+2. Connect; wait for “Polar received from device” (or confirm masses
+   updated in Basic settings / plane).
+3. On the vario set MacCready and water ballast to a known full value
+   (e.g. 180 kg).
+4. XCSoar ballast litres / kg should match within a few kg (same
+   reference, empty, and pilot masses).
+5. Change MC on the vario; XCSoar MC should follow.
+
+C. Polar sync Send (must not corrupt vario)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Note the vario’s polar name, MC speed-to-fly at a fixed MC (e.g. 1.2),
+   and ballast display **before** connecting.
+2. Device dialog: **Polar sync = Send to device**; plane polar in XCSoar
+   must be the intended glider polar.
+3. Connect and wait for polar send.
+4. On the vario, MC speeds and polar must remain plausible (not
+   ±10 m/s nonsense, not 180 km/h at MC 1.2 with no water on a Ventus).
+5. Optional: ``RunLXNAVPolarEcho PORT BAUD --read-only`` afterwards and
+   confirm a,b,c are still non-tiny LX values (order ~1, not ~0.002).
+
+D. Crew / empty mass without wiping polar
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Polar sync Off or Receive; connect so XCSoar has seen a POLAR reply.
+2. Change pilot weight in XCSoar Basic settings (sync to device on).
+3. Vario polar and STF must stay sane; pilot weight updates.
+4. Optional NMEA log: outgoing ``PLXV0,POLAR,W`` must include non-empty
+   a,b,c (not ``PLXV0,POLAR,W,,,,,,,,``).
+
 CAI302Tool
 ~~~~~~~~~~
 

--- a/src/ApplyExternalSettings.cpp
+++ b/src/ApplyExternalSettings.cpp
@@ -7,6 +7,9 @@
 #include "BackendComponents.hpp"
 #include "ActionInterface.hpp"
 #include "Device/MultipleDevices.hpp"
+#include "Device/Descriptor.hpp"
+#include "Device/Config.hpp"
+#include "Device/Features.hpp"
 #include "Engine/GlideSolvers/GlidePolar.hpp"
 #include "Engine/GlideSolvers/PolarCoefficients.hpp"
 #include "Engine/Task/TaskType.hpp"
@@ -226,6 +229,22 @@ TransponderProcess() noexcept
 }
 
 static bool
+AnyDeviceReceivingPolar() noexcept
+{
+  if (backend_components == nullptr ||
+      backend_components->devices == nullptr)
+    return false;
+
+  auto &devices = *backend_components->devices;
+  for (unsigned i = 0; i < NUMDEV; ++i)
+    if (devices[i].GetConfig().polar_sync ==
+        DeviceConfig::PolarSync::RECEIVE)
+      return true;
+
+  return false;
+}
+
+static bool
 PolarProcessTimer() noexcept
 {
   static Validity last_coefficients;
@@ -237,6 +256,11 @@ PolarProcessTimer() noexcept
   }
 
   last_coefficients = settings.polar_coefficients_available;
+
+  /* Metadata POLAR reads (SEND/OFF) still fill ExternalSettings for
+     the driver cache path; only RECEIVE may adopt into XCSoar (#2397). */
+  if (!AnyDeviceReceivingPolar())
+    return false;
 
   PolarCoefficients pc(settings.polar_a, settings.polar_b, settings.polar_c);
   if (!pc.IsValid())

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 
 struct MoreData;
 struct DerivedInfo;
@@ -506,6 +507,14 @@ public:
 
   void OnCalculatedUpdate(const MoreData &basic,
                           const DerivedInfo &calculated) override;
+
+  /**
+   * Cache a PLXV0 POLAR response in device_polar and publish
+   * coefficients/masses into ExternalSettings.  ApplyExternalSettings
+   * only adopts the polar when polar_sync is RECEIVE (#2397).
+   */
+  void StoreReceivedPolar(std::string_view value,
+                          NMEAInfo &info) noexcept;
 
 private:
   /**

--- a/src/Device/Driver/LX/Internal.hpp
+++ b/src/Device/Driver/LX/Internal.hpp
@@ -15,6 +15,8 @@
 #include "Engine/Task/TaskType.hpp"
 #include "time/PeriodClock.hpp"
 
+#include "LXNAVPolarConversion.hpp"
+
 #include <array>
 #include <atomic>
 #include <cstdint>
@@ -25,11 +27,9 @@ struct MoreData;
 struct DerivedInfo;
 
 /**
- * LXNAV polar coefficients use a normalised speed where
- * v==1 corresponds to 100 km/h.  This is the conversion factor
- * from that unit to m/s.
+ * LXNAV polar: v==1 corresponds to 100 km/h; same as LXNAVPolar::V_REF_MS.
  */
-static constexpr double LX_POLAR_V = 100.0 / 3.6;
+static constexpr double LX_POLAR_V = LXNAVPolar::V_REF_MS;
 
 class LXDevice: public AbstractDevice
 {

--- a/src/Device/Driver/LX/LXNAVPolarConversion.hpp
+++ b/src/Device/Driver/LX/LXNAVPolarConversion.hpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Engine/GlideSolvers/PolarCoefficients.hpp"
+
+#include <string_view>
+
+/**
+ * LXNAV PLXV0 POLAR coefficients use a normalised airspeed where v==1
+ * corresponds to 100 km/h.  XCSoar stores the glide parabola with true
+ * airspeed in m/s: w = a*V^2 + b*V + c.
+ */
+namespace LXNAVPolar {
+
+static constexpr double V_REF_MS = 100.0 / 3.6;
+
+/**
+ * Convert SI polar coefficients to values sent in PLXV0,POLAR NMEA fields.
+ */
+inline void
+ToNmeaPolar(const PolarCoefficients &pc,
+            double &a_lx, double &b_lx, double &c) noexcept
+{
+  const double v = V_REF_MS;
+  a_lx = pc.a * v * v;
+  b_lx = pc.b * v;
+  c = pc.c;
+}
+
+/**
+ * Convert PLXV0,POLAR NMEA coefficient fields to SI polar coefficients.
+ */
+[[gnu::const]]
+inline PolarCoefficients
+FromNmeaPolar(double a_lx, double b_lx, double c) noexcept
+{
+  const double v = V_REF_MS;
+  return PolarCoefficients(a_lx / (v * v), b_lx / v, c);
+}
+
+/**
+ * True if a recorded NMEA line is a PLXV0 POLAR write whose a,b,c
+ * fields are empty (partial write).  Empty coefficient fields zero
+ * the polar on LXNAV S-series varios (#2397).
+ *
+ * Accepts lines with or without leading '$' / trailing checksum.
+ */
+[[gnu::pure]]
+inline bool
+IsPartialPolarWrite(std::string_view line) noexcept
+{
+  using namespace std::string_view_literals;
+
+  if (line.starts_with('$'))
+    line.remove_prefix(1);
+
+  const auto star = line.find('*');
+  if (star != std::string_view::npos)
+    line = line.substr(0, star);
+
+  constexpr auto prefix = "PLXV0,POLAR,W,"sv;
+  if (!line.starts_with(prefix))
+    return false;
+
+  /* Body after "PLXV0,POLAR,W," — empty a,b,c are three leading
+     commas (partial crew/empty-weight writes use this form). */
+  const auto body = line.substr(prefix.size());
+  return body.starts_with(",,,"sv);
+}
+
+} // namespace LXNAVPolar

--- a/src/Device/Driver/LX/LXNAVVario.hpp
+++ b/src/Device/Driver/LX/LXNAVVario.hpp
@@ -146,7 +146,11 @@ namespace LXNAVVario {
   }
 
   /**
-   * Set only the pilot weight in POLAR command, leaving all other fields empty
+   * Set only the pilot weight in POLAR command, leaving all other fields empty.
+   *
+   * Do not use on LXNAV S-series: empty a,b,c fields zero the device
+   * polar (#2397). Prefer a full POLAR write via PutCrewMass().
+   *
    * @param pilot_weight crew mass (kg)
    */
   static inline void
@@ -163,7 +167,11 @@ namespace LXNAVVario {
   }
 
   /**
-   * Set only the empty weight in POLAR command, leaving all other fields empty
+   * Set only the empty weight in POLAR command, leaving all other fields empty.
+   *
+   * Do not use on LXNAV S-series: empty a,b,c fields zero the device
+   * polar (#2397). Prefer a full POLAR write via PutEmptyMass().
+   *
    * @param empty_weight empty mass (kg)
    */
   static inline void

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -247,17 +247,15 @@ LXDevice::OnCalculatedUpdate([[maybe_unused]] const MoreData &basic,
       mc_requested = true;
       ballast_requested = true;
       bugs_requested = true;
+      /* Always request POLAR once so device_polar caches metadata
+         for PutCrewMass/PutEmptyMass/PutPolar (#2397). */
+      polar_requested = true;
+      last_polar_request.Update();
     }
     RequestLXNAVVarioSetting("MC", env);
+    RequestLXNAVVarioSetting("POLAR", env);
 
     if (do_receive) {
-      {
-        const std::lock_guard lock{mutex};
-        polar_requested = true;
-        last_polar_request.Update();
-      }
-      RequestLXNAVVarioSetting("POLAR", env);
-
       {
         const std::lock_guard lock{mutex};
         if (!declaration_requested) {
@@ -313,9 +311,11 @@ LXDevice::PutPolar(const GlidePolar &polar,
   double max_weight = 0;
   std::string glider_name;
   double stall = 0;
+  bool have_device_polar = false;
   {
     const std::lock_guard lock{mutex};
     if (device_polar.valid) {
+      have_device_polar = true;
       if (fabs(device_polar.a - coeffs.a) < 0.0001 &&
           fabs(device_polar.b - coeffs.b) < 0.0001 &&
           fabs(device_polar.c - coeffs.c) < 0.0001 &&
@@ -329,6 +329,15 @@ LXDevice::PutPolar(const GlidePolar &polar,
       glider_name = device_polar.name;
       stall = device_polar.stall;
     }
+  }
+
+  /* Defer until we have device metadata (max weight, name, stall).
+     Empty fields zero those values on the vario (#2397). */
+  if (!have_device_polar) {
+    if (!EnableNMEA(env))
+      return false;
+    RequestLXNAVVarioSetting("POLAR", env);
+    return true;
   }
 
   if (polar_load <= 0) {

--- a/src/Device/Driver/LX/Mode.cpp
+++ b/src/Device/Driver/LX/Mode.cpp
@@ -301,11 +301,9 @@ LXDevice::PutPolar(const GlidePolar &polar,
   if (!coeffs.IsValid())
     return true;
 
-  /* Convert XCSoar m/s coefficients to LXNAV format
-     (v == 1 corresponds to 100 km/h) */
-  const double a_lx = coeffs.a * (LX_POLAR_V * LX_POLAR_V);
-  const double b_lx = coeffs.b * LX_POLAR_V;
-  const double c_lx = coeffs.c;
+  /* Convert XCSoar m/s coefficients to LXNAV format */
+  double a_lx, b_lx, c_lx;
+  LXNAVPolar::ToNmeaPolar(coeffs, a_lx, b_lx, c_lx);
 
   const double ref_mass = polar.GetReferenceMass();
   const double empty_mass = polar.GetEmptyMass();

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -304,10 +304,9 @@ ParsePLXV0Polar(std::string_view value, NMEAInfo &info) noexcept
       polar_line.ReadChecked(empty_weight) &&
       polar_line.ReadChecked(pilot_weight)) {
 
-    const double a = a_lx / (LX_POLAR_V * LX_POLAR_V);
-    const double b = b_lx / LX_POLAR_V;
+    const PolarCoefficients pc = LXNAVPolar::FromNmeaPolar(a_lx, b_lx, c);
 
-    info.settings.ProvidePolarCoefficients(a, b, c, info.clock);
+    info.settings.ProvidePolarCoefficients(pc.a, pc.b, pc.c, info.clock);
     info.settings.ProvidePolarLoad(polar_load, info.clock);
     info.settings.ProvidePolarReferenceMass(polar_weight, info.clock);
     info.settings.ProvidePolarMaximumMass(max_weight, info.clock);

--- a/src/Device/Driver/LX/Parser.cpp
+++ b/src/Device/Driver/LX/Parser.cpp
@@ -280,49 +280,11 @@ ParseDoubleValue(std::string_view sv) noexcept
 }
 
 /**
- * Parse the POLAR value from a PLXV0 sentence.
- *
- * Format: <a>,<b>,<c>,<polar_load>,<polar_weight>,
- *         <max_weight>,<empty_weight>,<pilot_weight>,<name>,<stall>
- *
- * Coefficients arrive in LX units (v=1 corresponds to 100 km/h)
- * and are converted to SI (m/s) before storing.
- */
-static void
-ParsePLXV0Polar(std::string_view value, NMEAInfo &info) noexcept
-{
-  const std::string value_str{value};
-  NMEAInputLine polar_line{value_str.c_str()};
-  double a_lx, b_lx, c, polar_load, polar_weight,
-    max_weight, empty_weight, pilot_weight;
-  if (polar_line.ReadChecked(a_lx) &&
-      polar_line.ReadChecked(b_lx) &&
-      polar_line.ReadChecked(c) &&
-      polar_line.ReadChecked(polar_load) &&
-      polar_line.ReadChecked(polar_weight) &&
-      polar_line.ReadChecked(max_weight) &&
-      polar_line.ReadChecked(empty_weight) &&
-      polar_line.ReadChecked(pilot_weight)) {
-
-    const PolarCoefficients pc = LXNAVPolar::FromNmeaPolar(a_lx, b_lx, c);
-
-    info.settings.ProvidePolarCoefficients(pc.a, pc.b, pc.c, info.clock);
-    info.settings.ProvidePolarLoad(polar_load, info.clock);
-    info.settings.ProvidePolarReferenceMass(polar_weight, info.clock);
-    info.settings.ProvidePolarMaximumMass(max_weight, info.clock);
-    info.settings.ProvidePolarPilotWeight(pilot_weight, info.clock);
-    info.settings.ProvidePolarEmptyWeight(empty_weight, info.clock);
-  } else {
-    LogFmt("LXNAV: Failed to parse POLAR values from: {}", value);
-  }
-}
-
-/**
  * Parse the $PLXV0 sentence (LXNAV sVarios (including V7)).
  */
 static bool
 PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings,
-      NMEAInfo &info)
+      NMEAInfo &info, LXDevice &device)
 {
   const auto name = line.ReadView();
   if (name.empty())
@@ -335,8 +297,10 @@ PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings,
   if (!type.starts_with('W'))
     return true;
 
-  const std::lock_guard<Mutex> lock{settings};
-  settings.Set(std::string{name}, value);
+  {
+    const std::lock_guard<Mutex> lock{settings};
+    settings.Set(std::string{name}, value);
+  }
 
   if (name == "ELEVATION"sv) {
     if (auto d = ParseDoubleValue(value))
@@ -345,10 +309,65 @@ PLXV0(NMEAInputLine &line, DeviceSettingsMap<std::string> &settings,
     if (auto d = ParseDoubleValue(value))
       info.settings.ProvideMacCready(*d, info.clock);
   } else if (name == "POLAR"sv || name == "POL"sv) {
-    ParsePLXV0Polar(value, info);
+    device.StoreReceivedPolar(value, info);
   }
 
   return true;
+}
+
+void
+LXDevice::StoreReceivedPolar(std::string_view value,
+                             NMEAInfo &info) noexcept
+{
+  /*
+   * Format: <a>,<b>,<c>,<polar_load>,<polar_weight>,
+   *         <max_weight>,<empty_weight>,<pilot_weight>,<name>,<stall>
+   *
+   * Coefficients arrive in LX units (v=1 corresponds to 100 km/h)
+   * and are converted to SI (m/s) before storing.
+   */
+  const std::string value_str{value};
+  NMEAInputLine polar_line{value_str.c_str()};
+  double a_lx, b_lx, c, polar_load, polar_weight,
+    max_weight, empty_weight, pilot_weight;
+  if (!polar_line.ReadChecked(a_lx) ||
+      !polar_line.ReadChecked(b_lx) ||
+      !polar_line.ReadChecked(c) ||
+      !polar_line.ReadChecked(polar_load) ||
+      !polar_line.ReadChecked(polar_weight) ||
+      !polar_line.ReadChecked(max_weight) ||
+      !polar_line.ReadChecked(empty_weight) ||
+      !polar_line.ReadChecked(pilot_weight)) {
+    LogFmt("LXNAV: Failed to parse POLAR values from: {}", value);
+    return;
+  }
+
+  const PolarCoefficients pc = LXNAVPolar::FromNmeaPolar(a_lx, b_lx, c);
+  const auto name = std::string{polar_line.ReadView()};
+  double stall = 0;
+  polar_line.ReadChecked(stall);
+
+  {
+    const std::lock_guard lock{mutex};
+    device_polar.a = pc.a;
+    device_polar.b = pc.b;
+    device_polar.c = pc.c;
+    device_polar.polar_load = polar_load;
+    device_polar.polar_weight = polar_weight;
+    device_polar.max_weight = max_weight;
+    device_polar.empty_weight = empty_weight;
+    device_polar.pilot_weight = pilot_weight;
+    device_polar.name = name;
+    device_polar.stall = stall;
+    device_polar.valid = true;
+  }
+
+  info.settings.ProvidePolarCoefficients(pc.a, pc.b, pc.c, info.clock);
+  info.settings.ProvidePolarLoad(polar_load, info.clock);
+  info.settings.ProvidePolarReferenceMass(polar_weight, info.clock);
+  info.settings.ProvidePolarMaximumMass(max_weight, info.clock);
+  info.settings.ProvidePolarPilotWeight(pilot_weight, info.clock);
+  info.settings.ProvidePolarEmptyWeight(empty_weight, info.clock);
 }
 
 static void
@@ -780,7 +799,7 @@ LXDevice::ParseNMEA(const char *String, NMEAInfo &info)
 
   if (type == "$PLXV0"sv) {
     is_colibri = false;
-    return PLXV0(line, lxnav_vario_settings, info);
+    return PLXV0(line, lxnav_vario_settings, info, *this);
   }
 
   if (type == "$PLXVC"sv) {

--- a/src/Device/Driver/LX/Settings.cpp
+++ b/src/Device/Driver/LX/Settings.cpp
@@ -252,8 +252,7 @@ LXDevice::PutCrewMass(double crew_mass, OperationEnvironment &env)
     return false;
 
   /* Send full POLAR command with only pilot_weight changed to
-     avoid zeroing other fields on the device.  Fall back to
-     partial command if we haven't read the device polar yet. */
+     avoid zeroing other fields on the device. */
   std::string cmd;
   {
     const std::lock_guard lock{mutex};
@@ -281,14 +280,9 @@ LXDevice::PutCrewMass(double crew_mass, OperationEnvironment &env)
     return true;
   }
 
-  /* Fall back to partial command */
-  LXNAVVario::SetPilotWeight(port, env, crew_mass);
-
-  {
-    const std::lock_guard lock{mutex};
-    last_sent_crew_mass = crew_mass;
-  }
-
+  /* Do not fall back to a partial POLAR write: empty a,b,c fields
+     zero the polar on LXNAV S-series varios (#2397).  Skip until
+     device_polar has been populated from a prior POLAR read/write. */
   return true;
 }
 
@@ -303,8 +297,7 @@ LXDevice::PutEmptyMass(double empty_mass, OperationEnvironment &env)
     return false;
 
   /* Send full POLAR command with only empty_weight changed to
-     avoid zeroing other fields on the device.  Fall back to
-     partial command if we haven't read the device polar yet. */
+     avoid zeroing other fields on the device. */
   std::string cmd;
   {
     const std::lock_guard lock{mutex};
@@ -332,14 +325,7 @@ LXDevice::PutEmptyMass(double empty_mass, OperationEnvironment &env)
     return true;
   }
 
-  /* Fall back to partial command */
-  LXNAVVario::SetEmptyWeight(port, env, empty_mass);
-
-  {
-    const std::lock_guard lock{mutex};
-    last_sent_empty_mass = empty_mass;
-  }
-
+  /* Same as PutCrewMass: never send empty-coefficient POLAR (#2397). */
   return true;
 }
 

--- a/src/event/Loop.hxx
+++ b/src/event/Loop.hxx
@@ -210,6 +210,19 @@ public:
 #endif // HAVE_THREADED_EVENT_LOOP
 
 	/**
+	 * Clear the quit flag so Run() can be invoked again.
+	 *
+	 * Must be called from the thread that runs the loop, after
+	 * Run() has returned.
+	 */
+	void ResetQuit() noexcept {
+		quit = false;
+#ifdef HAVE_THREADED_EVENT_LOOP
+		quit_injected = false;
+#endif
+	}
+
+	/**
 	 * Finish Run() after all pending events have been handled.
 	 */
 	void Finish() noexcept {

--- a/test/src/DumpPort.hpp
+++ b/test/src/DumpPort.hpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Device/Port/Port.hpp"
+#include "io/NullDataHandler.hpp"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+/**
+ * Port that records every Write() for driver unit tests.
+ * PortWriteNMEA() writes '$', body, then "*CS\\r\\n" in separate
+ * calls; this class reassembles complete lines.
+ */
+class DumpPort : public Port {
+  NullDataHandler null_handler;
+  std::string buffer;
+  std::vector<std::string> lines;
+
+public:
+  DumpPort() noexcept
+    :Port(nullptr, null_handler) {}
+
+  void Clear() noexcept {
+    buffer.clear();
+    lines.clear();
+  }
+
+  const std::vector<std::string> &GetLines() const noexcept {
+    return lines;
+  }
+
+  /**
+   * Return the first recorded line that contains @p needle, or
+   * nullptr if none.
+   */
+  [[gnu::pure]]
+  const char *FindContaining(std::string_view needle) const noexcept {
+    for (const auto &line : lines)
+      if (line.find(needle) != std::string::npos)
+        return line.c_str();
+    return nullptr;
+  }
+
+  /* virtual methods from class Port */
+  PortState GetState() const noexcept override {
+    return PortState::READY;
+  }
+
+  std::size_t Write(std::span<const std::byte> src) override {
+    buffer.append(reinterpret_cast<const char *>(src.data()), src.size());
+    for (;;) {
+      const auto pos = buffer.find('\n');
+      if (pos == std::string::npos)
+        break;
+      std::string line = buffer.substr(0, pos);
+      buffer.erase(0, pos + 1);
+      if (!line.empty() && line.back() == '\r')
+        line.pop_back();
+      if (!line.empty())
+        lines.push_back(std::move(line));
+    }
+    return src.size();
+  }
+
+  bool Drain() override {
+    return true;
+  }
+
+  void Flush() override {}
+
+  unsigned GetBaudrate() const noexcept override {
+    return 0;
+  }
+
+  void SetBaudrate(unsigned) override {}
+
+  bool StopRxThread() override {
+    return true;
+  }
+
+  bool StartRxThread() override {
+    return true;
+  }
+
+  std::size_t Read(std::span<std::byte>) override {
+    return 0;
+  }
+
+  void WaitRead(std::chrono::steady_clock::duration) override {}
+};

--- a/test/src/RunLXNAVPolarEcho.cpp
+++ b/test/src/RunLXNAVPolarEcho.cpp
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+//
+// Hardware check for LXNAV PLXV0 POLAR coefficient conversion (#2397).
+// Connect an LXNAV V7 / S80 / S10 (or similar) on a serial/USB port.
+//
+// Usage: RunLXNAVPolarEcho PORT BAUD [OPTION]...
+//
+// Default: write a known polar, read it back, verify SI round-trip.
+// --read-only: only request POLAR and print SI coefficients.
+// --preserve-crew: after a successful read, rewrite full POLAR with a
+//   changed pilot weight and verify a,b,c / max / name are preserved
+//   (regression for empty-field polar wipes).
+
+#include "Device/Driver/LX/LXNAVPolarConversion.hpp"
+#include "Device/Port/TTYPort.hpp"
+#include "Device/Util/NMEAWriter.hpp"
+#include "Engine/GlideSolvers/PolarCoefficients.hpp"
+#include "Operation/ConsoleOperationEnvironment.hpp"
+#include "ProductName.hpp"
+#include "Version.hpp"
+#include "event/CoarseTimerEvent.hxx"
+#include "event/Loop.hxx"
+#include "io/DataHandler.hpp"
+#include "system/Args.hpp"
+#include "system/StandardVersion.hpp"
+#include "util/BindMethod.hxx"
+#include "util/NumberParser.hpp"
+#include "util/PrintException.hxx"
+#include "util/StringCompare.hxx"
+
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <stdlib.h>
+
+static constexpr const char canonical_name[] = "RunLXNAVPolarEcho";
+
+struct PolarNmea {
+  double a_lx = 0, b_lx = 0, c_lx = 0;
+  double polar_load = 0, polar_weight = 0, max_weight = 0;
+  double empty_weight = 0, pilot_weight = 0, stall = 0;
+  char name[32]{};
+  bool have = false;
+};
+
+class PolarEchoHandler final : public DataHandler {
+  std::string buf;
+
+  EventLoop *event_loop = nullptr;
+
+public:
+  PolarNmea polar;
+
+  void SetEventLoop(EventLoop &_loop) noexcept {
+    event_loop = &_loop;
+  }
+
+  void ClearBuffer() noexcept {
+    buf.clear();
+    polar = {};
+  }
+
+  bool DataReceived(std::span<const std::byte> s) noexcept override {
+    buf.append(reinterpret_cast<const char *>(s.data()), s.size());
+
+    for (;;) {
+      const auto pos = buf.find('\n');
+      if (pos == std::string::npos)
+        break;
+
+      std::string line = buf.substr(0, pos);
+      buf.erase(0, pos + 1);
+      if (!line.empty() && line.back() == '\r')
+        line.pop_back();
+
+      const char *p = strstr(line.c_str(), ",POLAR,W,");
+      if (p != nullptr)
+        p += 9;
+      else {
+        p = strstr(line.c_str(), ",POL,W,");
+        if (p == nullptr)
+          continue;
+        p += 7;
+      }
+
+      PolarNmea parsed{};
+      int n = std::sscanf(
+        p,
+        "%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%31[^,],%lf",
+        &parsed.a_lx, &parsed.b_lx, &parsed.c_lx,
+        &parsed.polar_load, &parsed.polar_weight, &parsed.max_weight,
+        &parsed.empty_weight, &parsed.pilot_weight,
+        parsed.name, &parsed.stall);
+      if (n >= 3) {
+        parsed.have = true;
+        polar = parsed;
+        if (event_loop != nullptr)
+          event_loop->Break();
+        break;
+      }
+    }
+
+    return true;
+  }
+};
+
+struct Session final {
+  EventLoop &event_loop;
+  PolarEchoHandler &handler;
+  CoarseTimerEvent timeout;
+
+  Session(EventLoop &_event_loop, PolarEchoHandler &_handler) noexcept
+    :event_loop(_event_loop), handler(_handler),
+     timeout(_event_loop, BIND_THIS_METHOD(OnTimeout)) {}
+
+  void OnTimeout() noexcept {
+    event_loop.Break();
+  }
+
+  void ArmTimeout(std::chrono::seconds seconds) noexcept {
+    timeout.Schedule(seconds);
+  }
+};
+
+static void
+PrintHelp() noexcept
+{
+  std::printf(
+    "Usage: %s PORT BAUD [OPTION]...\n"
+    "\n"
+    "Talk to an LXNAV V7/S80/S10 (or compatible) and verify PLXV0 POLAR\n"
+    "coefficient conversion used by XCSoar (#2397).\n"
+    "\n"
+    "Options:\n"
+    "  --read-only       only request POLAR; print SI coefficients\n"
+    "  --preserve-crew   after read, rewrite full POLAR with pilot weight\n"
+    "                    95 kg and check a,b,c/max/name stay intact\n"
+    "  -h, --help        display this help and exit\n"
+    "  --version         output version information and exit\n"
+    "\n"
+    "Examples:\n"
+    "  %s /dev/ttyUSB0 115200\n"
+    "  %s /dev/ttyUSB0 115200 --read-only\n"
+    "  %s /dev/ttyUSB0 115200 --preserve-crew\n"
+    "\n"
+    "Report bugs to: %s\n"
+    "%s home page: %s\n",
+    canonical_name, canonical_name, canonical_name, canonical_name,
+    PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static bool
+RequestPolar(Port &port, OperationEnvironment &env,
+             EventLoop &event_loop, Session &session,
+             PolarEchoHandler &handler) noexcept
+{
+  handler.ClearBuffer();
+  PortWriteNMEA(port, "PLXV0,POLAR,R", env);
+  port.Drain();
+  session.ArmTimeout(std::chrono::seconds(3));
+  event_loop.Run();
+  session.timeout.Cancel();
+  return handler.polar.have;
+}
+
+static void
+PrintPolar(const PolarNmea &p) noexcept
+{
+  std::printf("Received LX a,b,c: %.9f %.9f %.9f\n",
+              p.a_lx, p.b_lx, p.c_lx);
+  std::printf("  load=%.2f ref=%.1f max=%.0f empty=%.1f pilot=%.1f "
+              "name='%s' stall=%.0f\n",
+              p.polar_load, p.polar_weight, p.max_weight,
+              p.empty_weight, p.pilot_weight, p.name, p.stall);
+
+  const PolarCoefficients si =
+    LXNAVPolar::FromNmeaPolar(p.a_lx, p.b_lx, p.c_lx);
+  std::printf("Converted SI a,b,c: %.9f %.9f %.9f\n", si.a, si.b, si.c);
+}
+
+int
+main(int argc, char **argv)
+try {
+  for (int i = 1; i < argc; ++i) {
+    if (StringIsEqual(argv[i], "--help") || StringIsEqual(argv[i], "-h")) {
+      PrintHelp();
+      return EXIT_SUCCESS;
+    }
+    if (StringIsEqual(argv[i], "--version")) {
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      return EXIT_SUCCESS;
+    }
+  }
+
+  Args args(argc, argv, "PORT BAUD [--read-only] [--preserve-crew]");
+  const char *path = args.ExpectNext();
+  const char *baud_s = args.ExpectNext();
+  char *endptr = nullptr;
+  const unsigned baud = ParseUnsigned(baud_s, &endptr);
+  if (endptr == baud_s || *endptr != '\0' || baud == 0) {
+    std::fprintf(stderr, "Invalid baud rate: %s\n", baud_s);
+    return EXIT_FAILURE;
+  }
+
+  bool read_only = false;
+  bool preserve_crew = false;
+  while (args.PeekNext() != nullptr) {
+    if (std::strcmp(args.PeekNext(), "--read-only") == 0) {
+      read_only = true;
+      args.Skip();
+    } else if (std::strcmp(args.PeekNext(), "--preserve-crew") == 0) {
+      preserve_crew = true;
+      args.Skip();
+    } else
+      break;
+  }
+  args.ExpectEnd();
+
+  EventLoop event_loop;
+  PolarEchoHandler handler;
+  handler.SetEventLoop(event_loop);
+  Session session(event_loop, handler);
+
+  TTYPort port(event_loop, nullptr, handler);
+  port.Open(path, baud);
+  ConsoleOperationEnvironment env;
+
+  if (!port.StartRxThread()) {
+    std::fprintf(stderr, "Failed to start the port thread\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Default SI polar (206 Hornet sample) and masses matching unit tests */
+  const PolarCoefficients expected_si(0.0022032, -0.08784, 1.47);
+  constexpr double ref_mass = 318.;
+  constexpr double empty_mass = 228.;
+  constexpr double crew_mass = 90.;
+  constexpr double wing_area = 9.8;
+  const double polar_load =
+    (wing_area > 0 && ref_mass > 0) ? ref_mass / wing_area : 0.;
+  constexpr double max_weight = 550.;
+  constexpr double stall = 25.;
+
+  if (!read_only) {
+    double a_lx, b_lx, c_lx;
+    LXNAVPolar::ToNmeaPolar(expected_si, a_lx, b_lx, c_lx);
+
+    char line[256];
+    const int n = std::snprintf(
+      line, sizeof(line),
+      "PLXV0,POLAR,W,%.6f,%.6f,%.6f,%.2f,%.1f,%.0f,%.1f,%.1f,%s,%.0f",
+      a_lx, b_lx, c_lx, polar_load, ref_mass, max_weight,
+      empty_mass, crew_mass, "ECHO", stall);
+    if (n <= 0 || unsigned(n) >= sizeof(line)) {
+      std::fprintf(stderr, "POLAR command buffer too small\n");
+      return EXIT_FAILURE;
+    }
+
+    std::printf("Writing test polar (name=ECHO)...\n");
+    PortWriteNMEA(port, line, env);
+    port.Drain();
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
+
+  if (!RequestPolar(port, env, event_loop, session, handler)) {
+    std::fprintf(stderr, "Timeout: no $PLXV0,...,POLAR,W,... line received.\n"
+                 "Check cabling, baud rate, and that XCSoar is not holding "
+                 "the port.\n");
+    return EXIT_FAILURE;
+  }
+
+  PrintPolar(handler.polar);
+
+  if (!read_only) {
+    const PolarCoefficients back =
+      LXNAVPolar::FromNmeaPolar(handler.polar.a_lx, handler.polar.b_lx,
+                                handler.polar.c_lx);
+    const bool ok_a = std::fabs(back.a - expected_si.a) < 1e-9;
+    const bool ok_b = std::fabs(back.b - expected_si.b) < 1e-9;
+    const bool ok_c = std::fabs(back.c - expected_si.c) < 1e-9;
+    std::printf("Round-trip vs sent SI: %s\n",
+                (ok_a && ok_b && ok_c) ? "OK" : "MISMATCH");
+    if (!ok_a || !ok_b || !ok_c) {
+      std::printf("Expected SI: %.9f %.9f %.9f\n",
+                  expected_si.a, expected_si.b, expected_si.c);
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (preserve_crew) {
+    const PolarNmea before = handler.polar;
+    if (!before.have) {
+      std::fprintf(stderr, "--preserve-crew needs a readable device polar\n");
+      return EXIT_FAILURE;
+    }
+
+    constexpr double new_crew = 95.;
+    char line[256];
+    const int n = std::snprintf(
+      line, sizeof(line),
+      "PLXV0,POLAR,W,%.6f,%.6f,%.6f,%.2f,%.1f,%.0f,%.1f,%.1f,%s,%.0f",
+      before.a_lx, before.b_lx, before.c_lx,
+      before.polar_load, before.polar_weight, before.max_weight,
+      before.empty_weight, new_crew, before.name, before.stall);
+    if (n <= 0 || unsigned(n) >= sizeof(line)) {
+      std::fprintf(stderr, "POLAR command buffer too small\n");
+      return EXIT_FAILURE;
+    }
+
+    std::printf("Rewriting full POLAR with pilot=%.1f (preserve a,b,c)...\n",
+                new_crew);
+    PortWriteNMEA(port, line, env);
+    port.Drain();
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    if (!RequestPolar(port, env, event_loop, session, handler)) {
+      std::fprintf(stderr, "Timeout after crew-weight rewrite\n");
+      return EXIT_FAILURE;
+    }
+
+    PrintPolar(handler.polar);
+
+    const bool ok =
+      std::fabs(handler.polar.a_lx - before.a_lx) < 1e-6 &&
+      std::fabs(handler.polar.b_lx - before.b_lx) < 1e-6 &&
+      std::fabs(handler.polar.c_lx - before.c_lx) < 1e-6 &&
+      std::fabs(handler.polar.max_weight - before.max_weight) < 0.5 &&
+      std::strcmp(handler.polar.name, before.name) == 0 &&
+      std::fabs(handler.polar.pilot_weight - new_crew) < 0.2;
+    std::printf("Preserve coefficients after crew rewrite: %s\n",
+                ok ? "OK" : "FAIL");
+    if (!ok)
+      return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+} catch (const std::exception &e) {
+  PrintException(e);
+  PrintHelp();
+  return EXIT_FAILURE;
+}

--- a/test/src/RunLXNAVPolarEcho.cpp
+++ b/test/src/RunLXNAVPolarEcho.cpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+//
+// Hardware check for LXNAV PLXV0 POLAR coefficient conversion (#2397).
+// Connect an LXNAV V7 / S80 / S10 (or similar) on a serial/USB port.
+//
+// Usage: RunLXNAVPolarEcho PORT BAUD [OPTION]...
+//
+// Default: write a known polar, read it back, verify SI round-trip.
+// --read-only: only request POLAR and print SI coefficients.
+// --preserve-crew: after a successful read, rewrite full POLAR with a
+//   changed pilot weight and verify a,b,c / max / name are preserved
+//   (regression for empty-field polar wipes).
+
+#include "DebugPort.hpp"
+#include "Device/Driver/LX/LXNAVPolarConversion.hpp"
+#include "Device/Port/Port.hpp"
+#include "Device/Util/NMEAWriter.hpp"
+#include "Engine/GlideSolvers/PolarCoefficients.hpp"
+#include "Operation/ConsoleOperationEnvironment.hpp"
+#include "ProductName.hpp"
+#include "Version.hpp"
+#include "event/CoarseTimerEvent.hxx"
+#include "event/Loop.hxx"
+#include "event/net/cares/Channel.hxx"
+#include "io/DataHandler.hpp"
+#include "system/Args.hpp"
+#include "system/StandardVersion.hpp"
+#include "util/BindMethod.hxx"
+#include "util/PrintException.hxx"
+#include "util/StringCompare.hxx"
+
+#include <cstdio>
+#include <cmath>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#include <stdlib.h>
+
+static constexpr const char canonical_name[] = "RunLXNAVPolarEcho";
+
+struct PolarNmea {
+  double a_lx = 0, b_lx = 0, c_lx = 0;
+  double polar_load = 0, polar_weight = 0, max_weight = 0;
+  double empty_weight = 0, pilot_weight = 0, stall = 0;
+  char name[32]{};
+  bool have = false;
+};
+
+class PolarEchoHandler final : public DataHandler {
+  std::string buf;
+
+  EventLoop *event_loop = nullptr;
+
+public:
+  PolarNmea polar;
+
+  void SetEventLoop(EventLoop &_loop) noexcept {
+    event_loop = &_loop;
+  }
+
+  void ClearBuffer() noexcept {
+    buf.clear();
+    polar = {};
+  }
+
+  bool DataReceived(std::span<const std::byte> s) noexcept override {
+    buf.append(reinterpret_cast<const char *>(s.data()), s.size());
+
+    for (;;) {
+      const auto pos = buf.find('\n');
+      if (pos == std::string::npos)
+        break;
+
+      std::string line = buf.substr(0, pos);
+      buf.erase(0, pos + 1);
+      if (!line.empty() && line.back() == '\r')
+        line.pop_back();
+
+      const char *p = strstr(line.c_str(), ",POLAR,W,");
+      if (p != nullptr)
+        p += 9;
+      else {
+        p = strstr(line.c_str(), ",POL,W,");
+        if (p == nullptr)
+          continue;
+        p += 7;
+      }
+
+      PolarNmea parsed{};
+      int n = std::sscanf(
+        p,
+        "%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%31[^,],%lf",
+        &parsed.a_lx, &parsed.b_lx, &parsed.c_lx,
+        &parsed.polar_load, &parsed.polar_weight, &parsed.max_weight,
+        &parsed.empty_weight, &parsed.pilot_weight,
+        parsed.name, &parsed.stall);
+      if (n >= 3) {
+        parsed.have = true;
+        polar = parsed;
+        if (event_loop != nullptr)
+          event_loop->InjectBreak();
+        break;
+      }
+    }
+
+    return true;
+  }
+};
+
+struct Session final {
+  EventLoop &event_loop;
+  PolarEchoHandler &handler;
+  CoarseTimerEvent timeout;
+
+  Session(EventLoop &_event_loop, PolarEchoHandler &_handler) noexcept
+    :event_loop(_event_loop), handler(_handler),
+     timeout(_event_loop, BIND_THIS_METHOD(OnTimeout)) {}
+
+  void OnTimeout() noexcept {
+    event_loop.Break();
+  }
+
+  void ArmTimeout(std::chrono::seconds seconds) noexcept {
+    timeout.Schedule(seconds);
+  }
+};
+
+static void
+PrintHelp() noexcept
+{
+  std::printf(
+    "Usage: %s PORT BAUD [OPTION]...\n"
+    "\n"
+    "Talk to an LXNAV V7/S80/S10 (or compatible) and verify PLXV0 POLAR\n"
+    "coefficient conversion used by XCSoar (#2397).\n"
+    "PORT is a serial device such as /dev/ttyUSB0 or COM3.\n"
+    "\n"
+    "Options:\n"
+    "  --read-only       only request POLAR; print SI coefficients\n"
+    "  --preserve-crew   after read, rewrite full POLAR with pilot weight\n"
+    "                    95 kg and check a,b,c/max/name stay intact\n"
+    "  -h, --help        display this help and exit\n"
+    "  --version         output version information and exit\n"
+    "\n"
+    "Examples:\n"
+    "  %s /dev/ttyUSB0 115200\n"
+    "  %s COM3 115200\n"
+    "  %s /dev/ttyUSB0 115200 --read-only\n"
+    "  %s /dev/ttyUSB0 115200 --preserve-crew\n"
+    "\n"
+    "Report bugs to: %s\n"
+    "%s home page: %s\n",
+    canonical_name, canonical_name, canonical_name, canonical_name,
+    canonical_name,
+    PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static bool
+RequestPolar(Port &port, OperationEnvironment &env,
+             EventLoop &event_loop, Session &session,
+             PolarEchoHandler &handler) noexcept
+{
+  handler.ClearBuffer();
+  PortWriteNMEA(port, "PLXV0,POLAR,R", env);
+  port.Drain();
+  session.ArmTimeout(std::chrono::seconds(3));
+  event_loop.Run();
+  session.timeout.Cancel();
+  event_loop.ResetQuit();
+  return handler.polar.have;
+}
+
+static void
+PrintPolar(const PolarNmea &p) noexcept
+{
+  std::printf("Received LX a,b,c: %.9f %.9f %.9f\n",
+              p.a_lx, p.b_lx, p.c_lx);
+  std::printf("  load=%.2f ref=%.1f max=%.0f empty=%.1f pilot=%.1f "
+              "name='%s' stall=%.0f\n",
+              p.polar_load, p.polar_weight, p.max_weight,
+              p.empty_weight, p.pilot_weight, p.name, p.stall);
+
+  const PolarCoefficients si =
+    LXNAVPolar::FromNmeaPolar(p.a_lx, p.b_lx, p.c_lx);
+  std::printf("Converted SI a,b,c: %.9f %.9f %.9f\n", si.a, si.b, si.c);
+}
+
+int
+main(int argc, char **argv)
+try {
+  for (int i = 1; i < argc; ++i) {
+    if (StringIsEqual(argv[i], "--help") || StringIsEqual(argv[i], "-h")) {
+      PrintHelp();
+      return EXIT_SUCCESS;
+    }
+    if (StringIsEqual(argv[i], "--version")) {
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      return EXIT_SUCCESS;
+    }
+  }
+
+  Args args(argc, argv, "PORT BAUD [--read-only] [--preserve-crew]");
+  DebugPort debug_port(args);
+
+  bool read_only = false;
+  bool preserve_crew = false;
+  while (args.PeekNext() != nullptr) {
+    if (std::strcmp(args.PeekNext(), "--read-only") == 0) {
+      read_only = true;
+      args.Skip();
+    } else if (std::strcmp(args.PeekNext(), "--preserve-crew") == 0) {
+      preserve_crew = true;
+      args.Skip();
+    } else
+      break;
+  }
+  args.ExpectEnd();
+
+  EventLoop event_loop;
+  Cares::Channel cares(event_loop);
+  PolarEchoHandler handler;
+  handler.SetEventLoop(event_loop);
+  Session session(event_loop, handler);
+
+  auto port = debug_port.Open(event_loop, cares, handler);
+  ConsoleOperationEnvironment env;
+
+  if (!port->StartRxThread()) {
+    std::fprintf(stderr, "Failed to start the port thread\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Default SI polar (206 Hornet sample) and masses matching unit tests */
+  const PolarCoefficients expected_si(0.0022032, -0.08784, 1.47);
+  constexpr double ref_mass = 318.;
+  constexpr double empty_mass = 228.;
+  constexpr double crew_mass = 90.;
+  constexpr double wing_area = 9.8;
+  const double polar_load =
+    (wing_area > 0 && ref_mass > 0) ? ref_mass / wing_area : 0.;
+  constexpr double max_weight = 550.;
+  constexpr double stall = 25.;
+
+  if (!read_only) {
+    double a_lx, b_lx, c_lx;
+    LXNAVPolar::ToNmeaPolar(expected_si, a_lx, b_lx, c_lx);
+
+    char line[256];
+    const int n = std::snprintf(
+      line, sizeof(line),
+      "PLXV0,POLAR,W,%.6f,%.6f,%.6f,%.2f,%.1f,%.0f,%.1f,%.1f,%s,%.0f",
+      a_lx, b_lx, c_lx, polar_load, ref_mass, max_weight,
+      empty_mass, crew_mass, "ECHO", stall);
+    if (n <= 0 || unsigned(n) >= sizeof(line)) {
+      std::fprintf(stderr, "POLAR command buffer too small\n");
+      return EXIT_FAILURE;
+    }
+
+    std::printf("Writing test polar (name=ECHO)...\n");
+    PortWriteNMEA(*port, line, env);
+    port->Drain();
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
+
+  if (!RequestPolar(*port, env, event_loop, session, handler)) {
+    std::fprintf(stderr, "Timeout: no $PLXV0,...,POLAR,W,... line received.\n"
+                 "Check cabling, baud rate, and that XCSoar is not holding "
+                 "the port.\n");
+    return EXIT_FAILURE;
+  }
+
+  PrintPolar(handler.polar);
+
+  if (!read_only) {
+    const PolarCoefficients back =
+      LXNAVPolar::FromNmeaPolar(handler.polar.a_lx, handler.polar.b_lx,
+                                handler.polar.c_lx);
+    const bool ok_a = std::fabs(back.a - expected_si.a) < 1e-9;
+    const bool ok_b = std::fabs(back.b - expected_si.b) < 1e-9;
+    const bool ok_c = std::fabs(back.c - expected_si.c) < 1e-9;
+    std::printf("Round-trip vs sent SI: %s\n",
+                (ok_a && ok_b && ok_c) ? "OK" : "MISMATCH");
+    if (!ok_a || !ok_b || !ok_c) {
+      std::printf("Expected SI: %.9f %.9f %.9f\n",
+                  expected_si.a, expected_si.b, expected_si.c);
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (preserve_crew) {
+    const PolarNmea before = handler.polar;
+    if (!before.have) {
+      std::fprintf(stderr, "--preserve-crew needs a readable device polar\n");
+      return EXIT_FAILURE;
+    }
+
+    constexpr double new_crew = 95.;
+    char line[256];
+    const int n = std::snprintf(
+      line, sizeof(line),
+      "PLXV0,POLAR,W,%.6f,%.6f,%.6f,%.2f,%.1f,%.0f,%.1f,%.1f,%s,%.0f",
+      before.a_lx, before.b_lx, before.c_lx,
+      before.polar_load, before.polar_weight, before.max_weight,
+      before.empty_weight, new_crew, before.name, before.stall);
+    if (n <= 0 || unsigned(n) >= sizeof(line)) {
+      std::fprintf(stderr, "POLAR command buffer too small\n");
+      return EXIT_FAILURE;
+    }
+
+    std::printf("Rewriting full POLAR with pilot=%.1f (preserve a,b,c)...\n",
+                new_crew);
+    PortWriteNMEA(*port, line, env);
+    port->Drain();
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+
+    if (!RequestPolar(*port, env, event_loop, session, handler)) {
+      std::fprintf(stderr, "Timeout after crew-weight rewrite\n");
+      return EXIT_FAILURE;
+    }
+
+    PrintPolar(handler.polar);
+
+    const bool ok =
+      std::fabs(handler.polar.a_lx - before.a_lx) < 1e-6 &&
+      std::fabs(handler.polar.b_lx - before.b_lx) < 1e-6 &&
+      std::fabs(handler.polar.c_lx - before.c_lx) < 1e-6 &&
+      std::fabs(handler.polar.max_weight - before.max_weight) < 0.5 &&
+      std::strcmp(handler.polar.name, before.name) == 0 &&
+      std::fabs(handler.polar.pilot_weight - new_crew) < 0.2;
+    std::printf("Preserve coefficients after crew rewrite: %s\n",
+                ok ? "OK" : "FAIL");
+    if (!ok)
+      return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+} catch (const std::exception &e) {
+  PrintException(e);
+  PrintHelp();
+  return EXIT_FAILURE;
+}

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -41,6 +41,9 @@
 #include "Device/Driver/Zander.hpp"
 #include "Device/Parser.hpp"
 #include "Device/Port/NullPort.hpp"
+#include "DumpPort.hpp"
+#include "Device/Driver/LX/LXNAVPolarConversion.hpp"
+#include "Engine/GlideSolvers/GlidePolar.hpp"
 #include "FLARM/Error.hpp"
 #include "FLARM/Progress.hpp"
 #include "FLARM/State.hpp"
@@ -72,6 +75,8 @@
 #include "util/StaticString.hxx"
 #include "util/ByteOrder.hxx"
 #include "util/PackedFloat.hxx"
+
+#include <fmt/format.h>
 
 #include <chrono>
 #include <cstring>
@@ -1965,6 +1970,91 @@ TestLXV7POLAR()
   delete device;
 }
 
+/**
+ * LXNAV polar write regressions for #2397.
+ *
+ * PutPolar must emit LX-scaled coefficients.  PutCrewMass must not
+ * fall back to a partial POLAR write with empty a,b,c (that zeroes
+ * the polar on S-series varios).
+ */
+static void
+TestLXV7PolarWrite()
+{
+  DumpPort dump;
+  Device *device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+
+  LXDevice &lx = *static_cast<LXDevice *>(device);
+  lx.ResetDeviceDetection();
+
+  NMEAInfo basic;
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{1}};
+
+  /* Identify as S-series so PutPolar/PutCrewMass are active */
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  ok1(lx.IsSVario());
+
+  dump.Clear();
+
+  GlidePolar polar{0};
+  const PolarCoefficients coeffs(0.0022032, -0.08784, 1.47);
+  polar.SetCoefficients(coeffs, false);
+  polar.SetReferenceMass(318, false);
+  polar.SetEmptyMass(228, false);
+  polar.SetCrewMass(90, false);
+  polar.SetWingArea(9.8);
+  polar.SetBugs(1);
+  polar.SetBallastLitres(0);
+  polar.Update();
+  ok1(polar.IsValid());
+
+  NullOperationEnvironment env;
+  ok1(device->PutPolar(polar, env));
+
+  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(polar_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
+
+  double a_lx, b_lx, c_lx;
+  LXNAVPolar::ToNmeaPolar(coeffs, a_lx, b_lx, c_lx);
+  const auto expected = fmt::format("PLXV0,POLAR,W,{:.6f},{:.6f},{:.6f},",
+                                    a_lx, b_lx, c_lx);
+  ok1(strstr(polar_line, expected.c_str()) != nullptr);
+
+  /* After PutPolar, crew-mass updates must keep full coefficients */
+  dump.Clear();
+  ok1(device->PutCrewMass(95, env));
+  const char *crew_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(crew_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(crew_line));
+  ok1(strstr(crew_line, expected.c_str()) != nullptr);
+
+  /* Fresh device: PutCrewMass without a cached polar must not emit
+     a partial POLAR write that would zero a,b,c on the vario. */
+  delete device;
+  dump.Clear();
+  device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+  LXDevice &lx2 = *static_cast<LXDevice *>(device);
+  lx2.ResetDeviceDetection();
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{2}};
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  dump.Clear();
+
+  ok1(device->PutCrewMass(95, env));
+
+  bool any_partial = false;
+  for (const auto &line : dump.GetLines())
+    if (LXNAVPolar::IsPartialPolarWrite(line))
+      any_partial = true;
+  ok1(!any_partial);
+
+  delete device;
+}
+
+
 static void
 TestLXRadioTransponder()
 {
@@ -3384,7 +3474,8 @@ int main()
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
              + 59 /* Condor3UDP */ + 29 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */
-             + 42 /* LK8EX1 */);
+             + 42 /* LK8EX1 */
+             + 16 /* LXV7PolarWrite */);
   TestGeneric();
   TestTasman();
   TestLK8EX1();
@@ -3407,6 +3498,7 @@ int main()
   TestLXEos();
   TestLXV7();
   TestLXV7POLAR();
+  TestLXV7PolarWrite();
   TestLXRadioTransponder();
   TestLXNavDeclare();
   TestILEC();

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -41,6 +41,9 @@
 #include "Device/Driver/Zander.hpp"
 #include "Device/Parser.hpp"
 #include "Device/Port/NullPort.hpp"
+#include "DumpPort.hpp"
+#include "Device/Driver/LX/LXNAVPolarConversion.hpp"
+#include "Engine/GlideSolvers/GlidePolar.hpp"
 #include "FLARM/Error.hpp"
 #include "FLARM/Progress.hpp"
 #include "FLARM/State.hpp"
@@ -72,6 +75,8 @@
 #include "util/StaticString.hxx"
 #include "util/ByteOrder.hxx"
 #include "util/PackedFloat.hxx"
+
+#include <fmt/format.h>
 
 #include <chrono>
 #include <cstring>
@@ -1952,6 +1957,91 @@ TestLXV7POLAR()
   delete device;
 }
 
+/**
+ * LXNAV polar write regressions for #2397.
+ *
+ * PutPolar must emit LX-scaled coefficients.  PutCrewMass must not
+ * fall back to a partial POLAR write with empty a,b,c (that zeroes
+ * the polar on S-series varios).
+ */
+static void
+TestLXV7PolarWrite()
+{
+  DumpPort dump;
+  Device *device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+
+  LXDevice &lx = *static_cast<LXDevice *>(device);
+  lx.ResetDeviceDetection();
+
+  NMEAInfo basic;
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{1}};
+
+  /* Identify as S-series so PutPolar/PutCrewMass are active */
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  ok1(lx.IsSVario());
+
+  dump.Clear();
+
+  GlidePolar polar{0};
+  const PolarCoefficients coeffs(0.0022032, -0.08784, 1.47);
+  polar.SetCoefficients(coeffs, false);
+  polar.SetReferenceMass(318, false);
+  polar.SetEmptyMass(228, false);
+  polar.SetCrewMass(90, false);
+  polar.SetWingArea(9.8);
+  polar.SetBugs(1);
+  polar.SetBallastLitres(0);
+  polar.Update();
+  ok1(polar.IsValid());
+
+  NullOperationEnvironment env;
+  ok1(device->PutPolar(polar, env));
+
+  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(polar_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
+
+  double a_lx, b_lx, c_lx;
+  LXNAVPolar::ToNmeaPolar(coeffs, a_lx, b_lx, c_lx);
+  const auto expected = fmt::format("PLXV0,POLAR,W,{:.6f},{:.6f},{:.6f},",
+                                    a_lx, b_lx, c_lx);
+  ok1(strstr(polar_line, expected.c_str()) != nullptr);
+
+  /* After PutPolar, crew-mass updates must keep full coefficients */
+  dump.Clear();
+  ok1(device->PutCrewMass(95, env));
+  const char *crew_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(crew_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(crew_line));
+  ok1(strstr(crew_line, expected.c_str()) != nullptr);
+
+  /* Fresh device: PutCrewMass without a cached polar must not emit
+     a partial POLAR write that would zero a,b,c on the vario. */
+  delete device;
+  dump.Clear();
+  device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+  LXDevice &lx2 = *static_cast<LXDevice *>(device);
+  lx2.ResetDeviceDetection();
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{2}};
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  dump.Clear();
+
+  ok1(device->PutCrewMass(95, env));
+
+  bool any_partial = false;
+  for (const auto &line : dump.GetLines())
+    if (LXNAVPolar::IsPartialPolarWrite(line))
+      any_partial = true;
+  ok1(!any_partial);
+
+  delete device;
+}
+
+
 static void
 TestLXRadioTransponder()
 {
@@ -3370,7 +3460,8 @@ int main()
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
              + 59 /* Condor3UDP */ + 29 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */
-             + 42 /* LK8EX1 */);
+             + 42 /* LK8EX1 */
+             + 16 /* LXV7PolarWrite */);
   TestGeneric();
   TestTasman();
   TestLK8EX1();
@@ -3393,6 +3484,7 @@ int main()
   TestLXEos();
   TestLXV7();
   TestLXV7POLAR();
+  TestLXV7PolarWrite();
   TestLXRadioTransponder();
   TestLXNavDeclare();
   TestILEC();

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1973,9 +1973,9 @@ TestLXV7POLAR()
 /**
  * LXNAV polar write regressions for #2397.
  *
- * PutPolar must emit LX-scaled coefficients.  PutCrewMass must not
- * fall back to a partial POLAR write with empty a,b,c (that zeroes
- * the polar on S-series varios).
+ * PutPolar must emit LX-scaled coefficients and preserve device
+ * metadata.  PutCrewMass must not fall back to a partial POLAR write
+ * with empty a,b,c (that zeroes the polar on S-series varios).
  */
 static void
 TestLXV7PolarWrite()
@@ -2010,17 +2010,31 @@ TestLXV7PolarWrite()
   ok1(polar.IsValid());
 
   NullOperationEnvironment env;
-  ok1(device->PutPolar(polar, env));
 
-  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
-  ok1(polar_line != nullptr);
-  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
+  /* Without cached metadata, PutPolar requests POLAR and does not
+     write a destructive full sentence with max_weight=0. */
+  ok1(device->PutPolar(polar, env));
+  ok1(dump.FindContaining("PLXV0,POLAR,W,") == nullptr);
+  ok1(dump.FindContaining("PLXV0,POLAR,R") != nullptr);
+
+  /* Seed device_polar from a device POLAR response */
+  dump.Clear();
+  ok1(device->ParseNMEA(
+        "$PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0*21",
+        basic));
 
   double a_lx, b_lx, c_lx;
   LXNAVPolar::ToNmeaPolar(coeffs, a_lx, b_lx, c_lx);
   const auto expected = fmt::format("PLXV0,POLAR,W,{:.6f},{:.6f},{:.6f},",
                                     a_lx, b_lx, c_lx);
+
+  ok1(device->PutPolar(polar, env));
+  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(polar_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
   ok1(strstr(polar_line, expected.c_str()) != nullptr);
+  ok1(strstr(polar_line, ",600,") != nullptr);
+  ok1(strstr(polar_line, ",LS 7,") != nullptr);
 
   /* After PutPolar, crew-mass updates must keep full coefficients */
   dump.Clear();
@@ -2030,8 +2044,8 @@ TestLXV7PolarWrite()
   ok1(!LXNAVPolar::IsPartialPolarWrite(crew_line));
   ok1(strstr(crew_line, expected.c_str()) != nullptr);
 
-  /* Fresh device: PutCrewMass without a cached polar must not emit
-     a partial POLAR write that would zero a,b,c on the vario. */
+  /* Receive-only path: cached POLAR enables full PutCrewMass without
+     a prior PutPolar from XCSoar. */
   delete device;
   dump.Clear();
   device = lx_driver.CreateOnPort(dummy_config, dump);
@@ -2040,6 +2054,31 @@ TestLXV7PolarWrite()
   lx2.ResetDeviceDetection();
   basic.Reset();
   basic.clock = TimeStamp{FloatDuration{2}};
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  ok1(device->ParseNMEA(
+        "$PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0*21",
+        basic));
+  dump.Clear();
+
+  ok1(device->PutCrewMass(95, env));
+  const char *recv_crew = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(recv_crew != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(recv_crew));
+  ok1(strstr(recv_crew, ",600,") != nullptr);
+  ok1(strstr(recv_crew, ",95.0,") != nullptr ||
+      strstr(recv_crew, ",95.00,") != nullptr ||
+      strstr(recv_crew, ",95,") != nullptr);
+
+  /* Fresh device: PutCrewMass without a cached polar must not emit
+     a partial POLAR write that would zero a,b,c on the vario. */
+  delete device;
+  dump.Clear();
+  device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+  LXDevice &lx3 = *static_cast<LXDevice *>(device);
+  lx3.ResetDeviceDetection();
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{3}};
   ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
   dump.Clear();
 
@@ -3475,7 +3514,7 @@ int main()
              + 59 /* Condor3UDP */ + 29 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */
              + 42 /* LK8EX1 */
-             + 16 /* LXV7PolarWrite */);
+             + 30 /* LXV7PolarWrite */);
   TestGeneric();
   TestTasman();
   TestLK8EX1();

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1960,9 +1960,9 @@ TestLXV7POLAR()
 /**
  * LXNAV polar write regressions for #2397.
  *
- * PutPolar must emit LX-scaled coefficients.  PutCrewMass must not
- * fall back to a partial POLAR write with empty a,b,c (that zeroes
- * the polar on S-series varios).
+ * PutPolar must emit LX-scaled coefficients and preserve device
+ * metadata.  PutCrewMass must not fall back to a partial POLAR write
+ * with empty a,b,c (that zeroes the polar on S-series varios).
  */
 static void
 TestLXV7PolarWrite()
@@ -1997,17 +1997,31 @@ TestLXV7PolarWrite()
   ok1(polar.IsValid());
 
   NullOperationEnvironment env;
-  ok1(device->PutPolar(polar, env));
 
-  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
-  ok1(polar_line != nullptr);
-  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
+  /* Without cached metadata, PutPolar requests POLAR and does not
+     write a destructive full sentence with max_weight=0. */
+  ok1(device->PutPolar(polar, env));
+  ok1(dump.FindContaining("PLXV0,POLAR,W,") == nullptr);
+  ok1(dump.FindContaining("PLXV0,POLAR,R") != nullptr);
+
+  /* Seed device_polar from a device POLAR response */
+  dump.Clear();
+  ok1(device->ParseNMEA(
+        "$PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0*21",
+        basic));
 
   double a_lx, b_lx, c_lx;
   LXNAVPolar::ToNmeaPolar(coeffs, a_lx, b_lx, c_lx);
   const auto expected = fmt::format("PLXV0,POLAR,W,{:.6f},{:.6f},{:.6f},",
                                     a_lx, b_lx, c_lx);
+
+  ok1(device->PutPolar(polar, env));
+  const char *polar_line = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(polar_line != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(polar_line));
   ok1(strstr(polar_line, expected.c_str()) != nullptr);
+  ok1(strstr(polar_line, ",600,") != nullptr);
+  ok1(strstr(polar_line, ",LS 7,") != nullptr);
 
   /* After PutPolar, crew-mass updates must keep full coefficients */
   dump.Clear();
@@ -2017,8 +2031,8 @@ TestLXV7PolarWrite()
   ok1(!LXNAVPolar::IsPartialPolarWrite(crew_line));
   ok1(strstr(crew_line, expected.c_str()) != nullptr);
 
-  /* Fresh device: PutCrewMass without a cached polar must not emit
-     a partial POLAR write that would zero a,b,c on the vario. */
+  /* Receive-only path: cached POLAR enables full PutCrewMass without
+     a prior PutPolar from XCSoar. */
   delete device;
   dump.Clear();
   device = lx_driver.CreateOnPort(dummy_config, dump);
@@ -2027,6 +2041,31 @@ TestLXV7PolarWrite()
   lx2.ResetDeviceDetection();
   basic.Reset();
   basic.clock = TimeStamp{FloatDuration{2}};
+  ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
+  ok1(device->ParseNMEA(
+        "$PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0*21",
+        basic));
+  dump.Clear();
+
+  ok1(device->PutCrewMass(95, env));
+  const char *recv_crew = dump.FindContaining("PLXV0,POLAR,W,");
+  ok1(recv_crew != nullptr);
+  ok1(!LXNAVPolar::IsPartialPolarWrite(recv_crew));
+  ok1(strstr(recv_crew, ",600,") != nullptr);
+  ok1(strstr(recv_crew, ",95.0,") != nullptr ||
+      strstr(recv_crew, ",95.00,") != nullptr ||
+      strstr(recv_crew, ",95,") != nullptr);
+
+  /* Fresh device: PutCrewMass without a cached polar must not emit
+     a partial POLAR write that would zero a,b,c on the vario. */
+  delete device;
+  dump.Clear();
+  device = lx_driver.CreateOnPort(dummy_config, dump);
+  ok1(device != nullptr);
+  LXDevice &lx3 = *static_cast<LXDevice *>(device);
+  lx3.ResetDeviceDetection();
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{3}};
   ok1(device->ParseNMEA("$LXWP1,S8x,12345,1.0,1.0,12345*1D", basic));
   dump.Clear();
 
@@ -3461,7 +3500,7 @@ int main()
              + 59 /* Condor3UDP */ + 29 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */
              + 42 /* LK8EX1 */
-             + 16 /* LXV7PolarWrite */);
+             + 30 /* LXV7PolarWrite */);
   TestGeneric();
   TestTasman();
   TestLK8EX1();

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -19,6 +19,7 @@ private:
   void Init();
   void TestBasic();
   void TestBallast();
+  void TestBallastOverload();
   void TestBugs();
   void TestMC();
   void TestDensityRatio();
@@ -113,6 +114,40 @@ GlidePolarTest::TestBallast()
 
   polar.SetBallastLitres(0);
   ok1(!polar.HasBallast());
+}
+
+void
+GlidePolarTest::TestBallastOverload()
+{
+  /* Matches ApplyExternalSettings BallastProcessTimer / LXNAV:
+       overload = (empty + crew + water) / reference_mass
+       water    = overload * reference_mass - crew - empty */
+  constexpr double ref = 318;
+  constexpr double empty = 228;
+  constexpr double crew = 90;
+  constexpr double water = 100;
+
+  polar.SetReferenceMass(ref, false);
+  polar.SetEmptyMass(empty, false);
+  polar.SetCrewMass(crew, false);
+  polar.SetMaxBallast(180);
+  polar.SetBallastLitres(water);
+
+  const double overload = polar.GetBallastOverload();
+  ok1(equals(overload, (empty + crew + water) / ref));
+
+  polar.SetBallastLitres(0);
+  polar.SetBallastOverload(overload);
+  ok1(equals(polar.GetBallastLitres(), water));
+
+  /* Decode path used by ApplyExternalSettings for LXWP2 ballast */
+  const double decoded_water =
+    overload * ref - crew - empty;
+  ok1(equals(decoded_water, water));
+
+  /* Restore baseline for subsequent tests */
+  Init();
+  polar.Update();
 }
 
 void
@@ -230,6 +265,7 @@ GlidePolarTest::Run()
   Init();
   TestBasic();
   TestBallast();
+  TestBallastOverload();
   TestBugs();
   TestMC();
   TestDensityRatio();
@@ -238,7 +274,7 @@ GlidePolarTest::Run()
 
 int main()
 {
-  plan_tests(69);
+  plan_tests(69 + 3);
 
   GlidePolarTest test;
   test.Run();

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -18,6 +18,7 @@ private:
   void Init();
   void TestBasic();
   void TestBallast();
+  void TestBallastOverload();
   void TestBugs();
   void TestMC();
   void TestDensityRatio();
@@ -114,6 +115,40 @@ GlidePolarTest::TestBallast()
 }
 
 void
+GlidePolarTest::TestBallastOverload()
+{
+  /* Matches ApplyExternalSettings BallastProcessTimer / LXNAV:
+       overload = (empty + crew + water) / reference_mass
+       water    = overload * reference_mass - crew - empty */
+  constexpr double ref = 318;
+  constexpr double empty = 228;
+  constexpr double crew = 90;
+  constexpr double water = 100;
+
+  polar.SetReferenceMass(ref, false);
+  polar.SetEmptyMass(empty, false);
+  polar.SetCrewMass(crew, false);
+  polar.SetMaxBallast(180);
+  polar.SetBallastLitres(water);
+
+  const double overload = polar.GetBallastOverload();
+  ok1(equals(overload, (empty + crew + water) / ref));
+
+  polar.SetBallastLitres(0);
+  polar.SetBallastOverload(overload);
+  ok1(equals(polar.GetBallastLitres(), water));
+
+  /* Decode path used by ApplyExternalSettings for LXWP2 ballast */
+  const double decoded_water =
+    overload * ref - crew - empty;
+  ok1(equals(decoded_water, water));
+
+  /* Restore baseline for subsequent tests */
+  Init();
+  polar.Update();
+}
+
+void
 GlidePolarTest::TestBugs()
 {
   polar.SetBugs(0.75);
@@ -191,6 +226,7 @@ GlidePolarTest::Run()
   Init();
   TestBasic();
   TestBallast();
+  TestBallastOverload();
   TestBugs();
   TestMC();
   TestDensityRatio();
@@ -198,7 +234,7 @@ GlidePolarTest::Run()
 
 int main()
 {
-  plan_tests(54);
+  plan_tests(54 + 3);
 
   GlidePolarTest test;
   test.Run();

--- a/test/src/TestLXNAVPolarConversion.cpp
+++ b/test/src/TestLXNAVPolarConversion.cpp
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+//
+// Round-trip and partial-write detection for LXNAV PLXV0 POLAR
+// coefficient scaling (#2397).
+
+#include "Device/Driver/LX/LXNAVPolarConversion.hpp"
+#include "Engine/GlideSolvers/PolarCoefficients.hpp"
+#include "TestUtil.hpp"
+
+#include <cmath>
+
+[[gnu::const]]
+static double
+SinkRateMs(const PolarCoefficients &pc, double v_ms) noexcept
+{
+  return v_ms * (v_ms * pc.a + pc.b) + pc.c;
+}
+
+static void
+TestRoundTrip(const PolarCoefficients &original)
+{
+  double a_lx, b_lx, c_lx;
+  LXNAVPolar::ToNmeaPolar(original, a_lx, b_lx, c_lx);
+  const PolarCoefficients back = LXNAVPolar::FromNmeaPolar(a_lx, b_lx, c_lx);
+
+  ok1(equals(original.a, back.a));
+  ok1(equals(original.b, back.b));
+  ok1(equals(original.c, back.c));
+
+  /* Same sink at an arbitrary airspeed in both representations */
+  constexpr double v_ms = 35.;
+  const double v_norm = v_ms / LXNAVPolar::V_REF_MS;
+  const double w_si = SinkRateMs(original, v_ms);
+  const double w_lx = a_lx * v_norm * v_norm + b_lx * v_norm + c_lx;
+  ok1(equals(w_si, w_lx));
+}
+
+static void
+TestPartialPolarDetection()
+{
+  /* Pilot-weight-only write used by SetPilotWeight() — empties a,b,c */
+  ok1(LXNAVPolar::IsPartialPolarWrite(
+        "PLXV0,POLAR,W,,,,,,,,90.00,,"));
+  ok1(LXNAVPolar::IsPartialPolarWrite(
+        "$PLXV0,POLAR,W,,,,,,,,90.00,,*1A"));
+
+  /* Empty-weight-only write */
+  ok1(LXNAVPolar::IsPartialPolarWrite(
+        "PLXV0,POLAR,W,,,,,,,265.00,,,"));
+
+  /* Full POLAR write must not be treated as partial */
+  ok1(!LXNAVPolar::IsPartialPolarWrite(
+        "PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0"));
+  ok1(!LXNAVPolar::IsPartialPolarWrite(
+        "$PLXV0,POLAR,W,1.780,-3.030,1.930,30.0,292,600,265,90,LS 7,0*21"));
+
+  /* Unrelated sentence */
+  ok1(!LXNAVPolar::IsPartialPolarWrite("PLXV0,MC,W,1.5"));
+}
+
+int
+main()
+{
+  plan_tests(8 + 6);
+
+  /* Polar 1: 206 Hornet sample (PolarStore) */
+  TestRoundTrip(PolarCoefficients(0.0022032, -0.08784, 1.47));
+
+  /* Polar 2: different magnitude */
+  TestRoundTrip(PolarCoefficients(0.0015, -0.065, 1.1));
+
+  TestPartialPolarDetection();
+
+  return exit_status();
+}


### PR DESCRIPTION
## Summary
- Stop LXNAV `PLXV0,POLAR` partial writes (empty a,b,c) that wipe the vario polar when crew/empty mass are sent before a polar is cached (#2397).
- Always cache received POLAR (including max weight / name / stall); request POLAR on connect; defer `PutPolar` until that metadata exists; only adopt device polars into XCSoar when polar sync is **Receive**.
- Add unit tests (`TestLXNAVPolarConversion`, `TestDriver` write capture, ballast overload) plus `RunLXNAVPolarEcho` hardware harness and a manual S10/S80 checklist in `doc/test_debug_utilities.rst`.

## Test plan
**CI / local (no hardware)**
- [x] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/bin/TestLXNAVPolarConversion output/UNIX/bin/TestGlidePolar output/UNIX/bin/TestDriver` — all pass
- [ ] Optional: full `make check`

**Real LXNAV device (required before merge)** — see `doc/test_debug_utilities.rst` (“RunLXNAVPolarEcho” and “LXNAV polar sync — manual XCSoar checklist”)

1. Free the serial port (quit XCSoar), then:
   ```bash
   make -j$(nproc) TARGET=UNIX USE_CCACHE=y output/UNIX/bin/RunLXNAVPolarEcho
   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200
   ./output/UNIX/bin/RunLXNAVPolarEcho /dev/ttyUSB0 115200 --preserve-crew
   ```
   Expect `Round-trip vs sent SI: OK` and `Preserve coefficients after crew rewrite: OK`.

2. **Polar sync = Receive**: after connect, set full ballast on the S10 (e.g. 180 kg); XCSoar kg should match within a few kg when ref/empty/pilot masses match; MC should sync.

3. **Polar sync = Send**: note STF at a fixed MC before connect; after send, vario polar/STF must stay plausible (not wiped / nonsense speeds). Optional `--read-only` snapshot afterwards.

4. Change pilot weight in XCSoar with sync-to-device on; vario polar must stay sane; NMEA must not show `PLXV0,POLAR,W,,,,,,,,`.

Fixes #2397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LXNAV polar synchronization and conversion accuracy.
  * Prevented polar data from being cleared when crew or empty weight is received before device polar data.
  * Preserved glider name and maximum weight during polar updates.
  * Applied received polar settings only when polar synchronization is enabled.

* **Documentation**
  * Added guidance and procedures for verifying LXNAV polar synchronization with the hardware utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->