### PR TITLE
Dialogs/Settings: Fix InfoBox Sets ignoring pending geometry (#2596)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -39,6 +39,9 @@ Version 7.45 - not yet released
   - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
     toggles (also fixes north-up so it no longer changes auto-zoom)
     #2535
+  - Fix InfoBox Sets editor using the previous InfoBox geometry until
+    Settings is closed; it now follows the Screen Layout selection
+    immediately #2596
   - Add pinch-to-zoom on the map for touchscreens that report both
     finger positions (Android, iOS): two fingers scale about the
     pinch centroid and can pan at the same time; a two-finger drag

--- a/src/Dialogs/Settings/Panels/InfoBoxesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InfoBoxesConfigPanel.cpp
@@ -2,14 +2,13 @@
 // Copyright The XCSoar Project
 
 #include "InfoBoxesConfigPanel.hpp"
+#include "LayoutConfigPanel.hpp"
 #include "../dlgConfigInfoboxes.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Current.hpp"
 #include "Profile/InfoBoxConfig.hpp"
 #include "Form/Button.hpp"
 #include "Interface.hpp"
-#include "InfoBoxes/InfoBoxManager.hpp"
-#include "InfoBoxes/InfoBoxLayout.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
@@ -40,7 +39,7 @@ InfoBoxesConfigPanel::OnAction(int id) noexcept
     dlgConfigInfoboxesShowModal(UIGlobals::GetMainWindow(),
                                 UIGlobals::GetDialogLook(),
                                 UIGlobals::GetLook().info_box,
-                                InfoBoxManager::layout.geometry, data,
+                                GetConfiguredInfoBoxGeometry(), data,
                                 i >= InfoBoxSettings::PREASSIGNED_PANELS);
   if (changed) {
     Profile::Save(Profile::map, data, i);

--- a/src/Dialogs/Settings/Panels/InfoBoxesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InfoBoxesConfigPanel.cpp
@@ -2,7 +2,6 @@
 // Copyright The XCSoar Project
 
 #include "InfoBoxesConfigPanel.hpp"
-#include "LayoutConfigPanel.hpp"
 #include "../dlgConfigInfoboxes.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Current.hpp"
@@ -39,7 +38,7 @@ InfoBoxesConfigPanel::OnAction(int id) noexcept
     dlgConfigInfoboxesShowModal(UIGlobals::GetMainWindow(),
                                 UIGlobals::GetDialogLook(),
                                 UIGlobals::GetLook().info_box,
-                                GetConfiguredInfoBoxGeometry(), data,
+                                settings.geometry, data,
                                 i >= InfoBoxSettings::PREASSIGNED_PANELS);
   if (changed) {
     Profile::Save(Profile::map, data, i);

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -292,7 +292,8 @@ LayoutConfigPanel::Unprepare() noexcept
 bool
 LayoutConfigPanel::Leave() noexcept
 {
-  /* Make the selection visible to sibling panels before Settings closes. */
+  /* Switching to another settings page (still inside Configuration):
+     copy geometry so InfoBox Sets can read settings.geometry. */
   SaveValueEnum(AppInfoBoxGeom,
                 CommonInterface::SetUISettings().info_boxes.geometry);
   return true;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -292,10 +292,9 @@ LayoutConfigPanel::Unprepare() noexcept
 bool
 LayoutConfigPanel::Leave() noexcept
 {
-  /* Publish the selection so sibling panels (InfoBox Sets) see it
-     before Settings is closed. */
-  CommonInterface::SetUISettings().info_boxes.geometry =
-    static_cast<InfoBoxSettings::Geometry>(GetValueEnum(AppInfoBoxGeom));
+  /* Make the selection visible to sibling panels before Settings closes. */
+  SaveValueEnum(AppInfoBoxGeom,
+                CommonInterface::SetUISettings().info_boxes.geometry);
   return true;
 }
 
@@ -340,15 +339,12 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   bool info_box_geometry_changed = false;
 
-  const auto geometry =
-    static_cast<InfoBoxSettings::Geometry>(GetValueEnum(AppInfoBoxGeom));
-  ui_settings.info_boxes.geometry = geometry;
-  if (geometry != original_geometry) {
-    Profile::Set(ProfileKeys::InfoBoxGeometry,
-                 static_cast<unsigned>(geometry));
-    info_box_geometry_changed = true;
-  }
-
+  /* Leave() may already have synced the DataField into ui_settings;
+     re-base so SaveValueEnum still writes the profile when needed. */
+  ui_settings.info_boxes.geometry = original_geometry;
+  info_box_geometry_changed |=
+    SaveValueEnum(AppInfoBoxGeom, ProfileKeys::InfoBoxGeometry,
+                  ui_settings.info_boxes.geometry);
   info_box_geometry_changed |=
     SaveValueInteger(InfoBoxTitleScale, ProfileKeys::InfoBoxTitleScale,
                   ui_settings.info_boxes.scale_title_font);

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -176,24 +176,28 @@ static constexpr StaticEnumChoice infobox_theme_list[] = {
 };
 
 class LayoutConfigPanel final : public RowFormWidget {
+  /** Geometry when this panel was opened; restored if Settings is cancelled. */
+  InfoBoxSettings::Geometry original_geometry{};
+  bool saved = false;
+
 public:
   LayoutConfigPanel()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
 
-public:
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   void Unprepare() noexcept override;
+  bool Leave() noexcept override;
   bool Save(bool &changed) noexcept override;
 };
-
-/** Active Screen Layout panel, if any (for pending geometry). */
-static LayoutConfigPanel *layout_config_panel;
 
 void
 LayoutConfigPanel::Prepare(ContainerWindow &parent,
                            const PixelRect &rc) noexcept
 {
   const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  original_geometry = ui_settings.info_boxes.geometry;
+  saved = false;
 
   RowFormWidget::Prepare(parent, rc);
 
@@ -274,27 +278,25 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
              ui_settings.display.invert_cursor_colors);
 #endif
-
-  layout_config_panel = this;
 }
 
 void
 LayoutConfigPanel::Unprepare() noexcept
 {
-  if (layout_config_panel == this)
-    layout_config_panel = nullptr;
+  if (!saved)
+    CommonInterface::SetUISettings().info_boxes.geometry = original_geometry;
 
   RowFormWidget::Unprepare();
 }
 
-InfoBoxSettings::Geometry
-GetConfiguredInfoBoxGeometry() noexcept
+bool
+LayoutConfigPanel::Leave() noexcept
 {
-  if (layout_config_panel != nullptr)
-    return static_cast<InfoBoxSettings::Geometry>(
-      layout_config_panel->GetValueEnum(AppInfoBoxGeom));
-
-  return CommonInterface::GetUISettings().info_boxes.geometry;
+  /* Publish the selection so sibling panels (InfoBox Sets) see it
+     before Settings is closed. */
+  CommonInterface::SetUISettings().info_boxes.geometry =
+    static_cast<InfoBoxSettings::Geometry>(GetValueEnum(AppInfoBoxGeom));
+  return true;
 }
 
 bool
@@ -303,6 +305,7 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   bool changed = false;
 
   UISettings &ui_settings = CommonInterface::SetUISettings();
+  saved = true;
 
 #ifdef ANDROID
   changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
@@ -337,9 +340,15 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   bool info_box_geometry_changed = false;
 
-  info_box_geometry_changed |=
-    SaveValueEnum(AppInfoBoxGeom, ProfileKeys::InfoBoxGeometry,
-                  ui_settings.info_boxes.geometry);
+  const auto geometry =
+    static_cast<InfoBoxSettings::Geometry>(GetValueEnum(AppInfoBoxGeom));
+  ui_settings.info_boxes.geometry = geometry;
+  if (geometry != original_geometry) {
+    Profile::Set(ProfileKeys::InfoBoxGeometry,
+                 static_cast<unsigned>(geometry));
+    info_box_geometry_changed = true;
+  }
+
   info_box_geometry_changed |=
     SaveValueInteger(InfoBoxTitleScale, ProfileKeys::InfoBoxTitleScale,
                   ui_settings.info_boxes.scale_title_font);

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -182,8 +182,12 @@ public:
 
 public:
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Unprepare() noexcept override;
   bool Save(bool &changed) noexcept override;
 };
+
+/** Active Screen Layout panel, if any (for pending geometry). */
+static LayoutConfigPanel *layout_config_panel;
 
 void
 LayoutConfigPanel::Prepare(ContainerWindow &parent,
@@ -270,6 +274,27 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
              ui_settings.display.invert_cursor_colors);
 #endif
+
+  layout_config_panel = this;
+}
+
+void
+LayoutConfigPanel::Unprepare() noexcept
+{
+  if (layout_config_panel == this)
+    layout_config_panel = nullptr;
+
+  RowFormWidget::Unprepare();
+}
+
+InfoBoxSettings::Geometry
+GetConfiguredInfoBoxGeometry() noexcept
+{
+  if (layout_config_panel != nullptr)
+    return static_cast<InfoBoxSettings::Geometry>(
+      layout_config_panel->GetValueEnum(AppInfoBoxGeom));
+
+  return CommonInterface::GetUISettings().info_boxes.geometry;
 }
 
 bool

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.hpp
@@ -3,9 +3,18 @@
 
 #pragma once
 
+#include "InfoBoxes/InfoBoxSettings.hpp"
+
 #include <memory>
 
 class Widget;
 
 std::unique_ptr<Widget>
 CreateLayoutConfigPanel();
+
+/**
+ * Geometry selected in Screen Layout, including unsaved changes while
+ * that panel is still open.  Falls back to the committed UI setting.
+ */
+[[nodiscard]] InfoBoxSettings::Geometry
+GetConfiguredInfoBoxGeometry() noexcept;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.hpp
@@ -3,18 +3,9 @@
 
 #pragma once
 
-#include "InfoBoxes/InfoBoxSettings.hpp"
-
 #include <memory>
 
 class Widget;
 
 std::unique_ptr<Widget>
 CreateLayoutConfigPanel();
-
-/**
- * Geometry selected in Screen Layout, including unsaved changes while
- * that panel is still open.  Falls back to the committed UI setting.
- */
-[[nodiscard]] InfoBoxSettings::Geometry
-GetConfiguredInfoBoxGeometry() noexcept;


### PR DESCRIPTION
## Summary
- InfoBox Sets was using `InfoBoxManager::layout.geometry`, which only updates when Settings closes and applies Screen Layout.
- Read the pending Screen Layout geometry (or the committed UI setting) so Circling / Cruise / etc. show the layout just selected under Look → Screen Layout.
- Fixes #2596

Replaces #2809 (closed when the head branch was deleted during merge conflict recovery).

## Test plan
- [ ] Open Config → System → Look → Screen Layout
- [ ] Change InfoBox geometry (e.g. 4 Top or Left → 12 Top or Left)
- [ ] Without closing Settings, open InfoBox Sets: layout matches the new geometry