### PR TITLE
NEWS.txt: Restore notes dropped by rebase merges

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -32,6 +32,9 @@ Version 7.45 - not yet released
   - document ``AirspaceLabels`` input event
   - document map pinch-to-zoom on touchscreens that report both
     finger positions #2790
+* development
+  - Log screen resolution, DPI, virtual DPI, approximate size, and
+    small-screen flag at startup #1548
 * WeGlide
   - fix crash when opening the aircraft type picker without a network
     connection
@@ -69,6 +72,7 @@ Version 7.45 - not yet released
     confirms (not the “1” key); cursor keys move across the grid (Up
     from OK/Cancel/Clear enters the keyboard; arrows no longer jump in
     tab order at row edges); F1 is backspace
+  - Allow lower-case letters in HighScore Style text entry #2387
   - Fix profile selection / startup branding: use transparent RGBA logo
     and title bitmaps on light (parchment) dialog backgrounds #2742
   - Size the InfoBox panel to the current tab and lift map overlays by


### PR DESCRIPTION
## Summary
- Restore NEWS entries for #2811 (`* development` screen metrics #1548) and #2812 (HighScore lower-case #2387) that were dropped when those PRs were rebase-merged onto master.
- Soft-keyboard NEWS from #2804 was already present.

## Test plan
- [x] NEWS-only; no rebuild required