### PR TITLE
flatpak: Add Wayland build artifacts

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -136,6 +136,46 @@ jobs:
           body: ${{ env.CHANGELOGENTRY }}
           prerelease: ${{ env.PRERELEASE }}
 
+  flatpak:
+    name: Flatpak (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          submodules: true
+
+      - name: Generate Flatpak manifest
+        run: make flatpak-manifest
+
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@401fe28a8384095fc1531b9d320b292f0ee45adb # v6
+        with:
+          manifest-path: output/UNIX/flatpak/org.xcsoar.XCSoar.yml
+          bundle: XCSoar-${{ matrix.arch }}.flatpak
+          arch: ${{ matrix.arch }}
+          cache-key: flatpak-${{ matrix.arch }}-${{ hashFiles('flatpak/**', 'build/**', 'lib/boost/patches/**', 'Makefile') }}
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: XCSoar-${{ github.sha }}-FLATPAK-${{ matrix.arch }}
+          path: XCSoar-${{ matrix.arch }}.flatpak
+          if-no-files-found: error
+
   build:
     runs-on: ${{ matrix.os }}
     needs: release

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -136,6 +136,45 @@ jobs:
           body: ${{ env.CHANGELOGENTRY }}
           prerelease: ${{ env.PRERELEASE }}
 
+  flatpak:
+    name: Flatpak (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:freedesktop-25.08
+      options: --privileged
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - name: Generate Flatpak manifest
+        run: make FLATPAK_SOURCE_TYPE=dir flatpak-manifest
+
+      - name: Build Flatpak bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          manifest-path: output/UNIX/flatpak/org.xcsoar.XCSoar.yml
+          bundle: XCSoar-${{ matrix.arch }}.flatpak
+          arch: ${{ matrix.arch }}
+          cache-key: flatpak-${{ matrix.arch }}-${{ hashFiles('flatpak/**', 'build/**', 'lib/boost/patches/**', 'Makefile') }}
+
+      - name: Upload Flatpak artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: XCSoar-${{ github.sha }}-FLATPAK-${{ matrix.arch }}
+          path: XCSoar-${{ matrix.arch }}.flatpak
+          if-no-files-found: error
+
   build:
     runs-on: ${{ matrix.os }}
     needs: release

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@ build/local-config.mk
 
 .idea
 .ccache
+.flatpak-builder
 messages.mo
 po/*.mo

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ endif
 ifeq ($(FUZZER),n)
 include $(topdir)/build/dist.mk
 include $(topdir)/build/install.mk
+include $(topdir)/build/flatpak.mk
 endif
 
 ######## compiler flags

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ endif
 ifeq ($(FUZZER),n)
 include $(topdir)/build/dist.mk
 include $(topdir)/build/install.mk
+include $(topdir)/build/flatpak.mk
 endif
 
 ######## compiler flags

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -38,6 +38,8 @@ Version 7.45 - not yet released
   - correct ``.plr`` optional max.\ cruise speed unit to m/s and
     distinguish WinPilot fields from the XCSoar extension #1134
 * development
+  - build system: add a Wayland Flatpak packaging target and CI artifacts
+    for x86_64 and aarch64
   - Log screen resolution, DPI, virtual DPI, approximate size, and
     small-screen flag at startup #1548
 * WeGlide

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,8 @@
+Version X.Y - not yet released
+* development
+  - build system: add a Wayland Flatpak packaging target and CI artifacts
+    for x86_64 and aarch64
+
 Version 7.45 - 2026-08-15
 * highlights
   - add SkySight, EDL, and XCTherm weather overlays on map pages,

--- a/build/flatpak.mk
+++ b/build/flatpak.mk
@@ -1,0 +1,76 @@
+# Flatpak is a package format for the existing native Linux build, not a
+# separate XCSoar target. Keep the default ID stable: it is the Flatpak
+# update identity. Downstream forks may override it on the make command line.
+FLATPAK_APP_ID ?= org.xcsoar.XCSoar
+FLATPAK_REMOTE ?= flathub
+FLATPAK_RUNTIME_REPO ?= https://dl.flathub.org/repo/flathub.flatpakrepo
+FLATPAK_BUILDER ?= flatpak-builder
+FLATPAK ?= flatpak
+# Apple Container and other nested-container environments cannot mount
+# rofiles-fuse.  Disabling it is slower but portable.  force-clean also makes
+# a retry safe after flatpak-builder was interrupted before its first export.
+# Override this (e.g. FLATPAK_BUILDER_OPTIONS=) to retain the local build dir.
+FLATPAK_BUILDER_OPTIONS ?= --disable-rofiles-fuse --force-clean
+
+FLATPAK_OUTPUT_DIR ?= $(OUT)/UNIX/flatpak
+FLATPAK_BUILD_DIR = $(FLATPAK_OUTPUT_DIR)/build
+FLATPAK_REPO_DIR = $(FLATPAK_OUTPUT_DIR)/repo
+FLATPAK_MANIFEST = $(FLATPAK_OUTPUT_DIR)/$(FLATPAK_APP_ID).yml
+FLATPAK_BUNDLE = $(FLATPAK_OUTPUT_DIR)/$(FLATPAK_APP_ID).flatpak
+FLATPAK_SOURCE_TYPE ?= git
+
+ifeq ($(FLATPAK_SOURCE_TYPE),git)
+FLATPAK_SOURCE_COMMIT = $(shell git -C $(topdir) rev-parse HEAD)
+endif
+
+FLATPAK_TEMPLATES = \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.yml.in \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.desktop.in \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.metainfo.xml.in
+
+$(FLATPAK_MANIFEST): $(FLATPAK_TEMPLATES) | $(FLATPAK_OUTPUT_DIR)/dirstamp
+	@$(NQ)echo "  FLATPAK  manifest $(FLATPAK_APP_ID)"
+	$(Q)sed -e 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		-e 's/@FLATPAK_SOURCE_TYPE@/$(FLATPAK_SOURCE_TYPE)/g' \
+		-e 's/@FLATPAK_SOURCE_COMMIT@/commit: $(FLATPAK_SOURCE_COMMIT)/g' \
+		-e '/^[[:space:]]*commit: *$$/d' \
+		-e 's|@FLATPAK_SOURCE_ROOT@|../../..|g' \
+		$(topdir)/flatpak/org.xcsoar.XCSoar.yml.in > $@
+
+.PHONY: flatpak flatpak-manifest flatpak-clean flatpak-install \
+	flatpak-install-metadata
+
+flatpak-manifest: $(FLATPAK_MANIFEST)
+
+flatpak: $(FLATPAK_MANIFEST)
+	@$(NQ)echo "  FLATPAK  $(FLATPAK_BUNDLE)"
+	$(Q)$(FLATPAK_BUILDER) $(FLATPAK_BUILDER_OPTIONS) \
+		--install-deps-from=$(FLATPAK_REMOTE) \
+		--repo=$(FLATPAK_REPO_DIR) \
+		$(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	$(Q)$(FLATPAK) build-bundle $(FLATPAK_REPO_DIR) $(FLATPAK_BUNDLE) \
+		$(FLATPAK_APP_ID) --runtime-repo=$(FLATPAK_RUNTIME_REPO)
+
+# This target is run by flatpak-builder inside the Flatpak SDK.  Keep all
+# XCSoar source preparation and installation in the existing Make system;
+# the manifest only describes the sandbox and calls this target.
+flatpak-install:
+	$(Q)$(MAKE) $(BOOST_UNTAR_STAMP)
+	$(Q)$(MAKE) install-bin install-mo
+	$(Q)$(MAKE) flatpak-install-metadata
+
+flatpak-install-metadata:
+	install -Dm644 flatpak/org.xcsoar.XCSoar.desktop.in \
+		$(prefix)/share/applications/$(FLATPAK_APP_ID).desktop
+	sed -i 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		$(prefix)/share/applications/$(FLATPAK_APP_ID).desktop
+	install -Dm644 flatpak/org.xcsoar.XCSoar.metainfo.xml.in \
+		$(prefix)/share/metainfo/$(FLATPAK_APP_ID).metainfo.xml
+	sed -i 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		$(prefix)/share/metainfo/$(FLATPAK_APP_ID).metainfo.xml
+	install -Dm644 Data/graphics/logo.svg \
+		$(prefix)/share/icons/hicolor/scalable/apps/$(FLATPAK_APP_ID).svg
+
+flatpak-clean:
+	@$(NQ)echo "cleaning Flatpak output"
+	$(Q)rm -rf $(FLATPAK_OUTPUT_DIR)

--- a/build/flatpak.mk
+++ b/build/flatpak.mk
@@ -1,0 +1,83 @@
+# Flatpak is a package format for the existing native Linux build, not a
+# separate XCSoar target. Keep the default ID stable: it is the Flatpak
+# update identity. Downstream forks may override it on the make command line.
+FLATPAK_APP_ID ?= org.xcsoar.XCSoar
+FLATPAK_REMOTE ?= flathub
+FLATPAK_RUNTIME_REPO ?= https://dl.flathub.org/repo/flathub.flatpakrepo
+FLATPAK_BUILDER ?= flatpak-builder
+FLATPAK ?= flatpak
+# Apple Container and other nested-container environments cannot mount
+# rofiles-fuse.  Disabling it is slower but portable.  Use the invoking
+# user's Flatpak installation by default.  force-clean resets the app
+# directory for repeat builds while preserving the state directory cache.
+FLATPAK_BUILDER_OPTIONS ?= --disable-rofiles-fuse --force-clean --user
+
+FLATPAK_OUTPUT_DIR ?= $(OUT)/UNIX/flatpak
+FLATPAK_OUTPUT_DIR := $(abspath $(FLATPAK_OUTPUT_DIR))
+FLATPAK_WORK_DIR ?= $(FLATPAK_OUTPUT_DIR)/work
+FLATPAK_BUILD_DIR = $(FLATPAK_WORK_DIR)/build
+FLATPAK_STATE_DIR = $(FLATPAK_WORK_DIR)/state
+FLATPAK_REPO_DIR = $(FLATPAK_OUTPUT_DIR)/repo
+FLATPAK_MANIFEST = $(FLATPAK_OUTPUT_DIR)/$(FLATPAK_APP_ID).yml
+FLATPAK_BUNDLE = $(FLATPAK_OUTPUT_DIR)/$(FLATPAK_APP_ID).flatpak
+FLATPAK_SOURCE_ROOT ?= $(abspath $(topdir))
+FLATPAK_SOURCE_ROOT_SED = $(subst |,\|,$(subst &,\&,$(subst \,\\,$(FLATPAK_SOURCE_ROOT))))
+FLATPAK_HIDDEN_SOURCE_FILES = $(shell find "$(FLATPAK_SOURCE_ROOT)" -mindepth 1 -maxdepth 1 -name '.*' -exec basename {} \; | LC_ALL=C sort | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/"/' -e 's/$$/"/' | paste -sd, - | sed 's/^/, /')
+FLATPAK_HIDDEN_SOURCE_FILES_SED = $(subst |,\|,$(subst &,\&,$(subst \,\\,$(FLATPAK_HIDDEN_SOURCE_FILES))))
+
+FLATPAK_TEMPLATES = \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.yml.in \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.desktop.in \
+	$(topdir)/flatpak/org.xcsoar.XCSoar.metainfo.xml.in
+
+$(FLATPAK_MANIFEST): FORCE $(FLATPAK_TEMPLATES) | $(FLATPAK_OUTPUT_DIR)/dirstamp
+	@$(NQ)echo "  FLATPAK  manifest $(FLATPAK_APP_ID)"
+	$(Q)sed -e 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		-e 's|@FLATPAK_SOURCE_ROOT@|$(FLATPAK_SOURCE_ROOT_SED)|g' \
+		-e 's|@FLATPAK_HIDDEN_SOURCE_FILES@|$(FLATPAK_HIDDEN_SOURCE_FILES_SED)|g' \
+		$(topdir)/flatpak/org.xcsoar.XCSoar.yml.in > $@
+
+.PHONY: flatpak flatpak-manifest flatpak-clean flatpak-install \
+	flatpak-install-metadata FORCE
+
+FORCE:
+
+flatpak-manifest: $(FLATPAK_MANIFEST)
+
+flatpak: $(FLATPAK_MANIFEST)
+	@$(NQ)echo "  FLATPAK  $(FLATPAK_BUNDLE)"
+	# Keep the app build and state directories on the local user filesystem,
+	# where Flatpak can remove files and retain its incremental-build cache.
+	$(Q)mkdir -p $(FLATPAK_WORK_DIR)
+	$(Q)cd $(FLATPAK_OUTPUT_DIR) && $(FLATPAK_BUILDER) $(FLATPAK_BUILDER_OPTIONS) \
+		--install-deps-from=$(FLATPAK_REMOTE) \
+		--repo=$(FLATPAK_REPO_DIR) \
+		--state-dir=$(FLATPAK_STATE_DIR) \
+		$(FLATPAK_BUILD_DIR) $(FLATPAK_MANIFEST)
+	$(Q)$(FLATPAK) build-bundle $(FLATPAK_REPO_DIR) $(FLATPAK_BUNDLE) \
+		$(FLATPAK_APP_ID) --runtime-repo=$(FLATPAK_RUNTIME_REPO)
+
+# This target is run by flatpak-builder inside the Flatpak SDK.  Keep all
+# XCSoar source preparation and installation in the existing Make system;
+# the manifest only describes the sandbox and calls this target.
+flatpak-install: $(BOOST_UNTAR_STAMP) \
+	$(TARGET_OUTPUT_DIR)/include/MakeResource.hpp \
+	$(TARGET_OUTPUT_DIR)/include/ResourceLookup_entries.cpp
+	$(Q)$(MAKE) install-bin install-mo
+	$(Q)$(MAKE) flatpak-install-metadata
+
+flatpak-install-metadata:
+	install -Dm644 flatpak/org.xcsoar.XCSoar.desktop.in \
+		$(prefix)/share/applications/$(FLATPAK_APP_ID).desktop
+	sed -i 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		$(prefix)/share/applications/$(FLATPAK_APP_ID).desktop
+	install -Dm644 flatpak/org.xcsoar.XCSoar.metainfo.xml.in \
+		$(prefix)/share/metainfo/$(FLATPAK_APP_ID).metainfo.xml
+	sed -i 's/@FLATPAK_APP_ID@/$(FLATPAK_APP_ID)/g' \
+		$(prefix)/share/metainfo/$(FLATPAK_APP_ID).metainfo.xml
+	install -Dm644 Data/graphics/logo.svg \
+		$(prefix)/share/icons/hicolor/scalable/apps/$(FLATPAK_APP_ID).svg
+
+flatpak-clean:
+	@$(NQ)echo "cleaning Flatpak output"
+	$(Q)rm -rf $(FLATPAK_OUTPUT_DIR)

--- a/build/install.mk
+++ b/build/install.mk
@@ -1,4 +1,4 @@
-ifeq ($(TARGET),UNIX)
+ifneq ($(filter $(TARGET),UNIX WAYLAND),)
 
 DESTDIR =
 prefix = $(DESTDIR)/usr

--- a/build/libboost.mk
+++ b/build/libboost.mk
@@ -6,7 +6,7 @@ BOOST_TARBALL_NAME = $(notdir $(BOOST_URL))
 BOOST_TARBALL = $(DOWNLOAD_DIR)/$(BOOST_TARBALL_NAME)
 BOOST_BASE_NAME = $(patsubst %.tar.bz2,%,$(BOOST_TARBALL_NAME))
 BOOST_SRC = $(OUT)/src/$(BOOST_BASE_NAME)
-BOOST_PATCHES_DIR = $(topdir)/lib/boost/patches
+BOOST_PATCHES_DIR = $(abspath $(topdir)/lib/boost/patches)
 BOOST_PATCHES = $(addprefix $(BOOST_PATCHES_DIR)/,$(shell cat $(BOOST_PATCHES_DIR)/series))
 
 $(BOOST_TARBALL): | $(DOWNLOAD_DIR)/dirstamp
@@ -18,7 +18,9 @@ $(BOOST_UNTAR_STAMP): $(BOOST_TARBALL) $(BOOST_PATCHES_DIR)/series $(BOOST_PATCH
 	@$(NQ)echo "  UNTAR   $(BOOST_TARBALL_NAME)"
 	$(Q)rm -rf $(BOOST_SRC)
 	$(Q)tar xjfC $< $(OUT)/src $(BOOST_BASE_NAME)/boost
-	$(Q)cd $(BOOST_SRC) && QUILT_PATCHES=$(abspath $(BOOST_PATCHES_DIR)) quilt push -a -q
+	$(Q)cd $(BOOST_SRC) && while IFS= read -r patch_file; do \
+		patch -p1 < "$(BOOST_PATCHES_DIR)/$$patch_file" || exit $$?; \
+	done < "$(BOOST_PATCHES_DIR)/series"
 	@touch $@
 
 .PHONY: boost

--- a/build/libboost.mk
+++ b/build/libboost.mk
@@ -6,7 +6,7 @@ BOOST_TARBALL_NAME = $(notdir $(BOOST_URL))
 BOOST_TARBALL = $(DOWNLOAD_DIR)/$(BOOST_TARBALL_NAME)
 BOOST_BASE_NAME = $(patsubst %.tar.bz2,%,$(BOOST_TARBALL_NAME))
 BOOST_SRC = $(OUT)/src/$(BOOST_BASE_NAME)
-BOOST_PATCHES_DIR = $(topdir)/lib/boost/patches
+BOOST_PATCHES_DIR = $(abspath $(topdir)/lib/boost/patches)
 BOOST_PATCHES = $(addprefix $(BOOST_PATCHES_DIR)/,$(shell cat $(BOOST_PATCHES_DIR)/series))
 
 $(BOOST_TARBALL): | $(DOWNLOAD_DIR)/dirstamp
@@ -18,7 +18,9 @@ $(BOOST_UNTAR_STAMP): $(BOOST_TARBALL) $(BOOST_PATCHES_DIR)/series $(BOOST_PATCH
 	@$(NQ)echo "  UNTAR   $(BOOST_TARBALL_NAME)"
 	$(Q)rm -rf $(BOOST_SRC)
 	$(Q)tar xjfC $< $(OUT)/src $(BOOST_BASE_NAME)/boost
-	$(Q)cd $(BOOST_SRC) && QUILT_PATCHES=$(abspath $(BOOST_PATCHES_DIR)) quilt push -a -q
+	$(Q)cd $(BOOST_SRC) && while IFS= read -r patch_file; do \
+		patch -p1 < "$(BOOST_PATCHES_DIR)/$$patch_file"; \
+	done < "$(BOOST_PATCHES_DIR)/series"
 	@touch $@
 
 .PHONY: boost

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -1,0 +1,61 @@
+# XCSoar Flatpak
+
+The Flatpak packages the existing native Linux Wayland build
+(`TARGET=WAYLAND`); it is not a separate XCSoar compiler target. It is
+intended for glibc- and musl-based distributions, including postmarketOS and
+Alpine, provided Flatpak is available.
+
+The bundle has not yet been run on a Linux phone or other target device. The
+build integration has been exercised, but runtime validation needs suitable
+hardware.
+
+`FLATPAK_APP_ID` defaults to `org.xcsoar.XCSoar`. It is the persistent
+installation and update identity, so official releases must keep that value.
+Downstream forks can use their own identity, for example:
+
+```sh
+make flatpak FLATPAK_APP_ID=org.example.XCSoar
+```
+
+For a local development build from a Git checkout, install Flatpak and
+`flatpak-builder`, add the Flathub remote, then run this from the repository
+root:
+
+```sh
+flatpak remote-add --if-not-exists flathub \
+  https://dl.flathub.org/repo/flathub.flatpakrepo
+make flatpak
+```
+
+`make flatpak` obtains the required Flatpak SDK from `FLATPAK_REMOTE`
+(`flathub` by default), then creates a portable test bundle in
+`output/UNIX/flatpak`:
+
+```sh
+make flatpak
+```
+
+If the remote has a different name, use e.g.
+`make flatpak FLATPAK_REMOTE=my-remote`.
+
+## Apple Container
+
+Flatpak uses Bubblewrap to create a nested mount namespace during the build.
+Apple Container does not grant that capability by default. Start the Linux
+container with `CAP_SYS_ADMIN` (not `ALL`) before running `make flatpak`:
+
+```sh
+container run --name xcsoar-flatpak --interactive --tty --cap-add SYS_ADMIN \
+  --volume "$PWD:/workspace" --workdir /workspace debian:trixie bash
+```
+
+Install the required tools in that container, add Flathub, and run the normal
+commands above. Omitting `--rm` lets the container retain the downloaded
+Flatpak SDK between builds. The Make target already disables `rofiles-fuse`,
+which is also unavailable in nested Apple containers.
+
+Use `make flatpak-clean` to discard its cached build directory and bundle.
+
+The CI workflow builds native `x86_64` and `aarch64` bundles and uploads each
+as a GitHub Actions artifact.  A published Flatpak repository or Flathub
+submission can be added later without changing the application build.

--- a/flatpak/org.xcsoar.XCSoar.desktop.in
+++ b/flatpak/org.xcsoar.XCSoar.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=XCSoar
+Comment=Flight navigation and tactical glide computer
+Exec=xcsoar
+Icon=@FLATPAK_APP_ID@
+Terminal=false
+Categories=Navigation;Utility;Science;
+Keywords=gliding;soaring;flight;navigation;aviation;

--- a/flatpak/org.xcsoar.XCSoar.metainfo.xml.in
+++ b/flatpak/org.xcsoar.XCSoar.metainfo.xml.in
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>@FLATPAK_APP_ID@</id>
+  <name>XCSoar</name>
+  <summary>Flight navigation and tactical glide computer</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-or-later</project_license>
+  <developer>
+    <name>XCSoar</name>
+  </developer>
+  <url type="homepage">https://xcsoar.org/</url>
+  <url type="bugtracker">https://github.com/XCSoar/XCSoar/issues</url>
+  <description>
+    <p>XCSoar is a tactical glide computer for gliders, paragliders and hang
+    gliders. It provides flight navigation, airspace awareness, task
+    management and flight analysis.</p>
+  </description>
+  <launchable type="desktop-id">@FLATPAK_APP_ID@.desktop</launchable>
+  <provides>
+    <binary>xcsoar</binary>
+  </provides>
+</component>

--- a/flatpak/org.xcsoar.XCSoar.yml.in
+++ b/flatpak/org.xcsoar.XCSoar.yml.in
@@ -1,0 +1,117 @@
+id: @FLATPAK_APP_ID@
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: xcsoar
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --device=dri
+  - --share=network
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - '*.a'
+  - '*.la'
+  - /bin/magick
+  - /bin/sox
+  - /bin/soxi
+  - /lib/libMagickCore-*.so*
+  - /lib/libMagickWand-*.so*
+  - /share/ImageMagick-*
+
+modules:
+  - name: imagemagick
+    buildsystem: autotools
+    config-opts:
+      - --disable-docs
+      - --disable-static
+      - --without-magick-plus-plus
+      - --without-perl
+    sources:
+      - type: archive
+        url: https://download.imagemagick.org/archive/releases/ImageMagick-7.1.2-27.tar.xz
+        sha256: 005b177dd25f46c2458b543164f296d66ce97e6a7be1084529d25df527984813
+
+  - name: sox
+    buildsystem: simple
+    build-commands:
+      - "sed -i '/#include <assert.h>/a #include <math.h>' src/sox_sample_test.h"
+      - ./configure --prefix=/app --disable-shared
+      - make
+      - make install
+    sources:
+      - type: archive
+        url: https://downloads.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2.tar.gz
+        sha256: b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c
+
+  - name: c-ares
+    buildsystem: cmake
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DCARES_STATIC=ON
+      - -DCARES_SHARED=OFF
+      - -DCARES_STATIC_PIC=ON
+      - -DCARES_BUILD_TOOLS=OFF
+      - -DCARES_THREADS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/c-ares/c-ares/releases/download/cares-1_24_0/c-ares-1.24.0.tar.gz
+        sha256: c517de6d5ac9cd55a9b72c1541c3e25b84588421817b5f092850ac09a8df5103
+
+  - name: libsodium
+    buildsystem: autotools
+    config-opts:
+      - --disable-shared
+      - --enable-static
+    sources:
+      - type: archive
+        url: https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz
+        sha256: ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19
+
+  # XCSoar's third-party builds pin Lua 5.4.6.  Lua itself does not ship a
+  # pkg-config file, so install the static library and expose the package name
+  # which build/liblua.mk uses.
+  - name: lua
+    buildsystem: simple
+    build-commands:
+      - make -C src MYCFLAGS="$CFLAGS -fPIC" MYLDFLAGS="$LDFLAGS" liblua.a
+      - install -Dm644 src/liblua.a /app/lib/liblua.a
+      - install -Dm644 src/lauxlib.h src/luaconf.h src/lua.h src/lualib.h -t /app/include
+      - >-
+        printf '%s\n' 'prefix=/app' 'exec_prefix=${prefix}' 'libdir=${exec_prefix}/lib'
+        'includedir=${prefix}/include' '' 'Name: Lua' 'Description: Lua language'
+        'Version: 5.4.6' 'Libs: -L${libdir} -llua -lm' 'Cflags: -I${includedir}'
+        > /app/lib/pkgconfig/lua5.4.pc
+    sources:
+      - type: archive
+        url: http://www.lua.org/ftp/lua-5.4.6.tar.gz
+        sha256: 7d5ea1b9cb6aa0b59ca3dde1c6adcb57ef83a1ba8e5432c0ecd06bf439b3ad88
+
+  - name: xcsoar
+    buildsystem: simple
+    build-commands:
+      # Do not reuse target configuration generated outside the SDK.  In
+      # particular, it may describe host-only pkg-config dependencies.
+      - rm -rf output/WAYLAND
+      - >-
+        make -j"$FLATPAK_BUILDER_N_JOBS" TARGET=WAYLAND DEBUG=n GEOTIFF=n ICF=n
+        EXTRA_CPPFLAGS="-isystem /app/include"
+        FLATPAK_APP_ID=@FLATPAK_APP_ID@ flatpak-install prefix=/app
+    sources:
+      # Build the checked-out source tree, as CI does.  Do not copy generated
+      # output or builder state into the sandbox.
+      - type: dir
+        path: @FLATPAK_SOURCE_ROOT@
+        skip: [darwin/XCSoarExecutable, darwin/XCSoar.xcodeproj/XCSoar.app,
+          output@FLATPAK_HIDDEN_SOURCE_FILES@]
+      - type: file
+        url: https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2
+        sha256: 49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305
+        dest: output/download
+        dest-filename: boost_1_90_0.tar.bz2

--- a/flatpak/org.xcsoar.XCSoar.yml.in
+++ b/flatpak/org.xcsoar.XCSoar.yml.in
@@ -1,0 +1,92 @@
+id: @FLATPAK_APP_ID@
+runtime: org.freedesktop.Platform
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+command: xcsoar
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --device=dri
+  - --share=network
+  - --device=all
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - '*.a'
+  - '*.la'
+  - /bin/magick
+  - /bin/sox
+  - /bin/soxi
+  - /lib/libMagickCore-*.so*
+  - /lib/libMagickWand-*.so*
+  - /share/ImageMagick-*
+
+modules:
+  - name: imagemagick
+    buildsystem: autotools
+    config-opts:
+      - --disable-docs
+      - --disable-static
+      - --without-magick-plus-plus
+      - --without-perl
+    sources:
+      - type: archive
+        url: https://download.imagemagick.org/archive/releases/ImageMagick-7.1.2-27.tar.xz
+        sha256: 005b177dd25f46c2458b543164f296d66ce97e6a7be1084529d25df527984813
+
+  - name: sox
+    buildsystem: autotools
+    config-opts:
+      - --disable-shared
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/sox/files/sox/14.4.2/sox-14.4.2.tar.gz/download
+        sha256: b45f598643ffbd8e363ff24d61166ccec4836fea6d3888881b8df53e3bb55f6c
+        dest-filename: sox-14.4.2.tar.gz
+      - type: patch
+        path: ../../../flatpak/sox-include-math.patch
+
+  - name: c-ares
+    buildsystem: cmake
+    config-opts:
+      - -DCMAKE_INSTALL_LIBDIR=lib
+      - -DCARES_STATIC=ON
+      - -DCARES_SHARED=OFF
+      - -DCARES_STATIC_PIC=ON
+      - -DCARES_BUILD_TOOLS=OFF
+      - -DCARES_THREADS=OFF
+    sources:
+      - type: archive
+        url: https://github.com/c-ares/c-ares/releases/download/cares-1_24_0/c-ares-1.24.0.tar.gz
+        sha256: c517de6d5ac9cd55a9b72c1541c3e25b84588421817b5f092850ac09a8df5103
+
+  - name: libsodium
+    buildsystem: autotools
+    config-opts:
+      - --disable-shared
+      - --enable-static
+    sources:
+      - type: archive
+        url: https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz
+        sha256: ebb65ef6ca439333c2bb41a0c1990587288da07f6c7fd07cb3a18cc18d30ce19
+
+  - name: xcsoar
+    buildsystem: simple
+    build-commands:
+      - >-
+        make -j"$FLATPAK_BUILDER_N_JOBS" TARGET=WAYLAND DEBUG=n
+        FLATPAK_APP_ID=@FLATPAK_APP_ID@ flatpak-install prefix=/app
+    sources:
+      - type: @FLATPAK_SOURCE_TYPE@
+        path: @FLATPAK_SOURCE_ROOT@
+        @FLATPAK_SOURCE_COMMIT@
+      - type: file
+        url: https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2
+        sha256: 49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305
+        dest: output/download
+        dest-filename: boost_1_90_0.tar.bz2

--- a/flatpak/sox-include-math.patch
+++ b/flatpak/sox-include-math.patch
@@ -1,0 +1,8 @@
+--- a/src/sox_sample_test.h
++++ b/src/sox_sample_test.h
+@@ -18,5 +18,6 @@
+ #endif
+ #include <assert.h>
++#include <math.h>
+ #include "sox.h"
+ #define TEST_UINT(bits) \


### PR DESCRIPTION
# Flatpak: Add Wayland build artifacts

## Summary

- Add a `make flatpak` packaging target for the existing Wayland build.
- Build x86_64 and aarch64 Flatpak bundles in GitHub Actions and upload them
  as artifacts.
- Keep the application ID configurable for downstream users while preserving
  `org.xcsoar.XCSoar` as the default.

## Motivation

This was requested by a friend from a flying club who uses a Linux phone. A
Flatpak bundle offers a distribution-neutral route for postmarketOS, Alpine,
and similar systems, without adding a separate XCSoar compiler target.

## Validation and limitations

- Generated and parsed the Flatpak manifest locally.
- Checked the commands emitted by `make -n flatpak`.
- Exercised the Flatpak dependency and build-initialisation path in Apple
  Container; its default nested-container permissions prevent Bubblewrap from
  mounting `/proc`.

Only the build integration has been tested. Running XCSoar from the Flatpak is
currently untested because suitable Linux phone or Wayland target hardware is
not available.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase

- [x] Branch is based on local `master`.
- [x] Commit history contains one feature commit.

#### Commit Format & Messages

- [x] Commit follows the `<Component>: <Summary>` format.
- [x] Commit uses present tense and explains the reason for the change.

#### Commit Structure

- [x] The feature is self-contained and has no fixup commits.
- [x] Local manifest, Makefile, YAML, and XML validation checks pass.
- [ ] Full bundle creation and runtime validation await a suitable Linux
  device or CI result.

---

- [ ] I'm ready to merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Flatpak packaging for Linux, including desktop integration, application metadata, and support for x86_64 and aarch64 builds.
  * Added Make targets for creating, installing, and cleaning Flatpak bundles.
* **Documentation**
  * Added instructions for building and testing the Flatpak package locally.
  * Documented Flatpak CI artifacts and Wayland packaging support.
* **Build Improvements**
  * Improved Boost patch application during builds.
  * Extended installation support to Wayland targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->