### PR TITLE
Linux brighness and KMS rotation to fbcon

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -611,6 +611,7 @@ XCSOAR_SOURCES := \
 	\
 	$(SRC)/Hardware/PowerGlobal.cpp \
 	$(SRC)/Hardware/Battery.cpp \
+	$(SRC)/Hardware/DisplayBrightness.cpp \
 
 ifneq ($(TARGET),ANDROID)
 ifeq ($(TARGET_IS_LINUX),y)

--- a/build/main.mk
+++ b/build/main.mk
@@ -116,6 +116,7 @@ DIALOG_SOURCES = \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp) \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/NOTAM/NOTAMMessageListener.cpp) \
 	$(SRC)/Dialogs/Settings/Panels/GaugesConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/DisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/VarioConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WindConfigPanel.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -115,6 +115,7 @@ DIALOG_SOURCES = \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/NOTAMConfigPanel.cpp) \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/NOTAM/NOTAMMessageListener.cpp) \
 	$(SRC)/Dialogs/Settings/Panels/GaugesConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/DisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/VarioConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/GlideComputerConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WindConfigPanel.cpp \

--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DisplayConfigPanel.hpp"
+#include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Hardware/RotateDisplay.hpp"
+#include "Interface.hpp"
+#include "MainWindow.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "UIGlobals.hpp"
+#include "UtilsSettings.hpp"
+#include "Asset.hpp"
+#include "ActionInterface.hpp"
+#include "util/Macros.hpp"
+
+#ifdef ANDROID
+#include "Android/Main.hpp"
+#include "Android/NativeView.hpp"
+#endif
+
+#ifdef USE_POLL_EVENT
+#include "ui/event/Globals.hpp"
+#include "ui/event/Queue.hpp"
+#endif
+
+enum ControlIndex {
+#ifdef ANDROID
+  FullScreen,
+#endif
+  Orientation,
+  DarkMode,
+  AppDisplayType,
+#ifdef DRAW_MOUSE_CURSOR
+  CursorSize,
+  CursorInverted,
+#endif
+};
+
+static constexpr StaticEnumChoice display_orientation_list[] = {
+  { DisplayOrientation::DEFAULT,
+    N_("Default") },
+  { DisplayOrientation::PORTRAIT,
+    N_("Portrait") },
+  { DisplayOrientation::LANDSCAPE,
+    N_("Landscape") },
+  { DisplayOrientation::REVERSE_PORTRAIT,
+    N_("Reverse Portrait") },
+  { DisplayOrientation::REVERSE_LANDSCAPE,
+    N_("Reverse Landscape") },
+  nullptr
+};
+
+static constexpr StaticEnumChoice dark_mode_list[] = {
+  { UISettings::DarkMode::AUTO, N_("Auto"),
+    N_("Use the system-wide setting") },
+  { UISettings::DarkMode::OFF, N_("Off"),
+    N_("Black text on white background") },
+  { UISettings::DarkMode::ON, N_("On"),
+    N_("White text on black background") },
+  nullptr
+};
+
+static constexpr StaticEnumChoice display_type_list[] = {
+  { ::DisplayType::LCD, N_("LCD"),
+    N_("Conventional LCD or OLED. Full scrolling animations.") },
+  { ::DisplayType::E_INK, N_("E-ink"),
+    N_("Monochrome electronic paper. Disables kinetic and smooth "
+       "scrolling.") },
+  { ::DisplayType::COLOR_E_INK, N_("Color e-ink"),
+    N_("Color electronic paper. Disables kinetic and smooth "
+       "scrolling like monochrome e-ink.") },
+  nullptr
+};
+
+static_assert(ARRAY_SIZE(display_type_list) ==
+              unsigned(::DisplayType::COUNT) + 1,
+              "display_type_list must match DisplayType::COUNT");
+
+class DisplayConfigPanel final : public RowFormWidget {
+public:
+  DisplayConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+public:
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+void
+DisplayConfigPanel::Prepare(ContainerWindow &parent,
+                            const PixelRect &rc) noexcept
+{
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  RowFormWidget::Prepare(parent, rc);
+
+#ifdef ANDROID
+  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
+             ui_settings.display.full_screen);
+#endif
+
+  if (Display::RotateSupported())
+    AddEnum(_("Display orientation"),
+            _("Rotate the display on devices that support it."),
+            display_orientation_list,
+            (unsigned)ui_settings.display.orientation);
+  else
+    AddDummy();
+
+#ifndef KOBO
+  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
+          (unsigned)ui_settings.dark_mode);
+  SetExpertRow(DarkMode);
+#else
+  AddDummy();
+#endif
+
+  AddEnum(_("Display type"),
+          _("Select the display technology. E-ink modes disable kinetic "
+            "and smooth scrolling for slow refresh screens."),
+          display_type_list,
+          (unsigned)ui_settings.display.display_type);
+  SetExpertRow(AppDisplayType);
+
+#ifdef DRAW_MOUSE_CURSOR
+  AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x",
+             1, 10, 1, (unsigned)ui_settings.display.cursor_size);
+  AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
+             ui_settings.display.invert_cursor_colors);
+#endif
+}
+
+bool
+DisplayConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+  UISettings &ui_settings = CommonInterface::SetUISettings();
+
+#ifdef ANDROID
+  changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
+                       ui_settings.display.full_screen);
+  native_view->SetFullScreen(Java::GetEnv(), ui_settings.display.full_screen);
+#endif
+
+  bool orientation_changed = false;
+
+  if (Display::RotateSupported()) {
+    orientation_changed =
+      SaveValueEnum(Orientation, ProfileKeys::MapOrientation,
+                    ui_settings.display.orientation);
+    changed |= orientation_changed;
+  }
+
+#ifndef KOBO
+  changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
+                           ui_settings.dark_mode);
+#else
+  if (ui_settings.dark_mode != UISettings::DarkMode::OFF) {
+    ui_settings.dark_mode = UISettings::DarkMode::OFF;
+    changed = true;
+  }
+#endif
+
+  if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
+                    ui_settings.display.display_type)) {
+    changed = true;
+    SetDisplayType(ui_settings.display.display_type);
+  }
+
+#ifdef DRAW_MOUSE_CURSOR
+  changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
+                              ui_settings.display.cursor_size);
+  CommonInterface::main_window->SetCursorSize(ui_settings.display.cursor_size);
+
+  changed |= SaveValue(CursorInverted, ProfileKeys::CursorColorsInverted,
+                       ui_settings.display.invert_cursor_colors);
+  CommonInterface::main_window->SetCursorColorsInverted(
+    ui_settings.display.invert_cursor_colors);
+#endif
+
+  if (orientation_changed) {
+    assert(Display::RotateSupported());
+
+    if (!Display::Rotate(ui_settings.display.orientation))
+      LogString("Display rotation failed");
+
+#ifdef USE_POLL_EVENT
+    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
+#endif
+
+    CommonInterface::main_window->CheckResize();
+  }
+
+  _changed |= changed;
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateDisplayConfigPanel()
+{
+  return std::make_unique<DisplayConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
@@ -6,6 +6,7 @@
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Form/DataField/Enum.hpp"
+#include "Hardware/DisplayBrightness.hpp"
 #include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
@@ -25,12 +26,21 @@
 #include "ui/event/Queue.hpp"
 #endif
 
+#include <memory>
+
+#if defined(KOBO) || (defined(__linux__) && !defined(ANDROID))
+#define HAVE_DISPLAY_BRIGHTNESS_CONTROL
+#endif
+
 enum ControlIndex {
 #ifdef ANDROID
   FullScreen,
 #endif
   Orientation,
   DarkMode,
+#if defined(HAVE_DISPLAY_BRIGHTNESS_CONTROL)
+  ScreenBrightness,
+#endif
 #ifdef DRAW_MOUSE_CURSOR
   CursorSize,
   CursorInverted,
@@ -62,9 +72,12 @@ static constexpr StaticEnumChoice dark_mode_list[] = {
 };
 
 class DisplayConfigPanel final : public RowFormWidget {
+  std::unique_ptr<DisplayBrightness> brightness;
+
 public:
   DisplayConfigPanel()
-    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+    :RowFormWidget(UIGlobals::GetDialogLook()),
+     brightness(DisplayBrightness::Detect()) {}
 
 public:
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -94,6 +107,21 @@ DisplayConfigPanel::Prepare(ContainerWindow &parent,
 
   AddEnum(_("Dark mode"), nullptr, dark_mode_list,
           (unsigned)ui_settings.dark_mode);
+
+#ifdef HAVE_DISPLAY_BRIGHTNESS_CONTROL
+  if (brightness != nullptr) {
+    AddInteger(_("Screen brightness"),
+               brightness->IsWritable()
+               ? _("Adjust the screen brightness.")
+               : _("Screen brightness is read-only because writing requires additional permissions."),
+               "%d %%", "%d", 0, 100, 5,
+               brightness->GetBrightnessPercent());
+
+    if (!brightness->IsWritable())
+      SetReadOnly(ScreenBrightness);
+  } else
+    AddDummy();
+#endif
 
 #ifdef DRAW_MOUSE_CURSOR
   AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x",
@@ -128,6 +156,15 @@ DisplayConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
                            ui_settings.dark_mode);
 
+  if (brightness != nullptr && brightness->IsWritable()) {
+#ifdef HAVE_DISPLAY_BRIGHTNESS_CONTROL
+    const unsigned old_percent = brightness->GetBrightnessPercent();
+    const unsigned new_percent = GetValueInteger(ScreenBrightness);
+    if (new_percent != old_percent)
+      brightness->SetBrightnessPercent(new_percent);
+#endif
+  }
+
 #ifdef DRAW_MOUSE_CURSOR
   changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
                               ui_settings.display.cursor_size);
@@ -161,3 +198,5 @@ CreateDisplayConfigPanel()
 {
   return std::make_unique<DisplayConfigPanel>();
 }
+
+#undef HAVE_DISPLAY_BRIGHTNESS_CONTROL

--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DisplayConfigPanel.hpp"
+#include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Hardware/RotateDisplay.hpp"
+#include "Interface.hpp"
+#include "MainWindow.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "UIGlobals.hpp"
+#include "UtilsSettings.hpp"
+
+#ifdef ANDROID
+#include "Android/Main.hpp"
+#include "Android/NativeView.hpp"
+#endif
+
+#ifdef USE_POLL_EVENT
+#include "ui/event/Globals.hpp"
+#include "ui/event/Queue.hpp"
+#endif
+
+enum ControlIndex {
+#ifdef ANDROID
+  FullScreen,
+#endif
+  Orientation,
+  DarkMode,
+#ifdef DRAW_MOUSE_CURSOR
+  CursorSize,
+  CursorInverted,
+#endif
+};
+
+static constexpr StaticEnumChoice display_orientation_list[] = {
+  { DisplayOrientation::DEFAULT,
+    N_("Default") },
+  { DisplayOrientation::PORTRAIT,
+    N_("Portrait") },
+  { DisplayOrientation::LANDSCAPE,
+    N_("Landscape") },
+  { DisplayOrientation::REVERSE_PORTRAIT,
+    N_("Reverse Portrait") },
+  { DisplayOrientation::REVERSE_LANDSCAPE,
+    N_("Reverse Landscape") },
+  nullptr
+};
+
+static constexpr StaticEnumChoice dark_mode_list[] = {
+  { UISettings::DarkMode::AUTO, N_("Auto"),
+    N_("Use the system-wide setting") },
+  { UISettings::DarkMode::OFF, N_("Off"),
+    N_("Black text on white background") },
+  { UISettings::DarkMode::ON, N_("On"),
+    N_("White text on black background") },
+  nullptr
+};
+
+class DisplayConfigPanel final : public RowFormWidget {
+public:
+  DisplayConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+public:
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+void
+DisplayConfigPanel::Prepare(ContainerWindow &parent,
+                            const PixelRect &rc) noexcept
+{
+  const UISettings &ui_settings = CommonInterface::GetUISettings();
+
+  RowFormWidget::Prepare(parent, rc);
+
+#ifdef ANDROID
+  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
+             ui_settings.display.full_screen);
+#endif
+
+  if (Display::RotateSupported())
+    AddEnum(_("Display orientation"),
+            _("Rotate the display on devices that support it."),
+            display_orientation_list,
+            (unsigned)ui_settings.display.orientation);
+  else
+    AddDummy();
+
+  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
+          (unsigned)ui_settings.dark_mode);
+
+#ifdef DRAW_MOUSE_CURSOR
+  AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x",
+             1, 10, 1, (unsigned)ui_settings.display.cursor_size);
+  AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
+             ui_settings.display.invert_cursor_colors);
+#endif
+}
+
+bool
+DisplayConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+
+  UISettings &ui_settings = CommonInterface::SetUISettings();
+
+#ifdef ANDROID
+  changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
+                       ui_settings.display.full_screen);
+  native_view->SetFullScreen(Java::GetEnv(), ui_settings.display.full_screen);
+#endif
+
+  bool orientation_changed = false;
+
+  if (Display::RotateSupported()) {
+    orientation_changed =
+      SaveValueEnum(Orientation, ProfileKeys::MapOrientation,
+                    ui_settings.display.orientation);
+    changed |= orientation_changed;
+  }
+
+  changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
+                           ui_settings.dark_mode);
+
+#ifdef DRAW_MOUSE_CURSOR
+  changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
+                              ui_settings.display.cursor_size);
+  CommonInterface::main_window->SetCursorSize(ui_settings.display.cursor_size);
+
+  changed |= SaveValue(CursorInverted, ProfileKeys::CursorColorsInverted,
+                       ui_settings.display.invert_cursor_colors);
+  CommonInterface::main_window->SetCursorColorsInverted(
+    ui_settings.display.invert_cursor_colors);
+#endif
+
+  if (orientation_changed) {
+    assert(Display::RotateSupported());
+
+    if (!Display::Rotate(ui_settings.display.orientation))
+      LogString("Display rotation failed");
+
+#ifdef USE_POLL_EVENT
+    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
+#endif
+
+    CommonInterface::main_window->CheckResize();
+  }
+
+  _changed |= changed;
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateDisplayConfigPanel()
+{
+  return std::make_unique<DisplayConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateDisplayConfigPanel();

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -2,39 +2,18 @@
 // Copyright The XCSoar Project
 
 #include "LayoutConfigPanel.hpp"
-#include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Form/DataField/Enum.hpp"
-#include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
-#include "LogFile.hpp"
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
 #include "Asset.hpp"
 #include "Menu/ShowButton.hpp"
-#include "ActionInterface.hpp"
-#include "util/Macros.hpp"
-
-#ifdef ANDROID
-#include "Android/Main.hpp"
-#include "Android/NativeView.hpp"
-#endif
-
-#ifdef USE_POLL_EVENT
-#include "ui/event/Globals.hpp"
-#include "ui/event/Queue.hpp"
-#endif
 
 enum ControlIndex {
-#ifdef ANDROID
-  FullScreen,
-#endif
-  MapOrientation,
-  DarkMode,
-  AppDisplayType,
   AppInfoBoxGeom,
   InfoBoxTitleScale,
   TabDialogStyle,
@@ -45,41 +24,7 @@ enum ControlIndex {
   ShowMenuButton,
   ShowZoomButton,
   ShowQuickMenuButton,
-#ifdef DRAW_MOUSE_CURSOR
-  CursorSize,
-  CursorInverted,
-#endif
 };
-
-static constexpr StaticEnumChoice display_orientation_list[] = {
-  { DisplayOrientation::DEFAULT,
-    N_("Default") },
-  { DisplayOrientation::PORTRAIT,
-    N_("Portrait") },
-  { DisplayOrientation::LANDSCAPE,
-    N_("Landscape") },
-  { DisplayOrientation::REVERSE_PORTRAIT,
-    N_("Reverse Portrait") },
-  { DisplayOrientation::REVERSE_LANDSCAPE,
-    N_("Reverse Landscape") },
-  nullptr
-};
-
-static constexpr StaticEnumChoice display_type_list[] = {
-  { DisplayType::LCD, N_("LCD"),
-    N_("Conventional LCD or OLED. Full scrolling animations.") },
-  { DisplayType::E_INK, N_("E-ink"),
-    N_("Monochrome electronic paper. Disables kinetic and smooth "
-       "scrolling.") },
-  { DisplayType::COLOR_E_INK, N_("Color e-ink"),
-    N_("Color electronic paper. Disables kinetic and smooth "
-       "scrolling like monochrome e-ink.") },
-  nullptr
-};
-
-static_assert(ARRAY_SIZE(display_type_list) ==
-              unsigned(DisplayType::COUNT) + 1,
-              "display_type_list must match DisplayType::COUNT");
 
 static constexpr StaticEnumChoice info_box_geometry_list[] = {
   { InfoBoxSettings::Geometry::SPLIT_8,
@@ -155,16 +100,6 @@ static constexpr StaticEnumChoice infobox_border_list[] = {
   nullptr
 };
 
-static constexpr StaticEnumChoice dark_mode_list[] = {
-  { UISettings::DarkMode::AUTO, N_("Auto"),
-    N_("Use the system-wide setting") },
-  { UISettings::DarkMode::OFF, N_("Off"),
-    N_("Black text on white background") },
-  { UISettings::DarkMode::ON, N_("On"),
-    N_("White text on black background") },
-  nullptr
-};
-
 static constexpr StaticEnumChoice infobox_theme_list[] = {
   { InfoBoxSettings::Theme::FOLLOW_GLOBAL, N_("Follow global"),
     N_("Use the same light/dark mode as the overall UI.") },
@@ -200,32 +135,6 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   saved = false;
 
   RowFormWidget::Prepare(parent, rc);
-
-#ifdef ANDROID
-  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
-             ui_settings.display.full_screen);
-#endif
-
-  if (Display::RotateSupported())
-    AddEnum(_("Display orientation"), _("Rotate the display on devices that support it."),
-            display_orientation_list, (unsigned)ui_settings.display.orientation);
-  else
-    AddDummy();
-
-#ifndef KOBO
-  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
-          (unsigned)ui_settings.dark_mode);
-  SetExpertRow(DarkMode);
-#else
-  AddDummy();
-#endif
-
-  AddEnum(_("Display type"),
-          _("Select the display technology. E-ink modes disable kinetic "
-            "and smooth scrolling for slow refresh screens."),
-          display_type_list,
-          (unsigned)ui_settings.display.display_type);
-  SetExpertRow(AppDisplayType);
 
   AddEnum(_("InfoBox geometry"),
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
@@ -271,13 +180,6 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
              _("Show the QuickMenu button"),
              ui_settings.show_quickmenu_button);
   SetExpertRow(ShowQuickMenuButton);
-
-#ifdef DRAW_MOUSE_CURSOR
-  AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x", 1, 10, 1,
-             (unsigned)ui_settings.display.cursor_size);
-  AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
-             ui_settings.display.invert_cursor_colors);
-#endif
 }
 
 void
@@ -306,38 +208,6 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   UISettings &ui_settings = CommonInterface::SetUISettings();
   saved = true;
-
-#ifdef ANDROID
-  changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
-                       ui_settings.display.full_screen);
-  native_view->SetFullScreen(Java::GetEnv(), ui_settings.display.full_screen);
-#endif
-
-  bool orientation_changed = false;
-
-  if (Display::RotateSupported()) {
-    orientation_changed =
-      SaveValueEnum(MapOrientation, ProfileKeys::MapOrientation,
-                    ui_settings.display.orientation);
-    changed |= orientation_changed;
-  }
-
-#ifndef KOBO
-  changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
-                           ui_settings.dark_mode);
-#else
-  if (ui_settings.dark_mode != UISettings::DarkMode::OFF) {
-    ui_settings.dark_mode = UISettings::DarkMode::OFF;
-    changed = true;
-  }
-#endif
-
-  if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
-                    ui_settings.display.display_type)) {
-    changed = true;
-    SetDisplayType(ui_settings.display.display_type);
-  }
-
   bool info_box_geometry_changed = false;
 
   /* Leave() may already have synced the DataField into ui_settings;
@@ -381,27 +251,7 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   DialogSettings &dialog_settings = CommonInterface::SetUISettings().dialog;
   changed |= SaveValueEnum(TabDialogStyle, ProfileKeys::AppDialogTabStyle, dialog_settings.tab_style);
 
-#ifdef DRAW_MOUSE_CURSOR
-  changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
-                              ui_settings.display.cursor_size);
-  CommonInterface::main_window->SetCursorSize(ui_settings.display.cursor_size);
-
-  changed |= SaveValue(CursorInverted, ProfileKeys::CursorColorsInverted, ui_settings.display.invert_cursor_colors);
-  CommonInterface::main_window->SetCursorColorsInverted(ui_settings.display.invert_cursor_colors);
-#endif
-
-  if (orientation_changed) {
-    assert(Display::RotateSupported());
-
-    if (!Display::Rotate(ui_settings.display.orientation))
-      LogString("Display rotation failed");
-
-#ifdef USE_POLL_EVENT
-    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
-#endif
-
-    CommonInterface::main_window->CheckResize();
-  } else if (info_box_geometry_changed)
+  if (info_box_geometry_changed)
     CommonInterface::main_window->ReinitialiseLayout();
 
   _changed |= changed;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -2,38 +2,19 @@
 // Copyright The XCSoar Project
 
 #include "LayoutConfigPanel.hpp"
-#include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
 #include "Profile/Keys.hpp"
 #include "Profile/Profile.hpp"
 #include "Form/DataField/Enum.hpp"
-#include "Hardware/RotateDisplay.hpp"
 #include "Interface.hpp"
 #include "MainWindow.hpp"
-#include "LogFile.hpp"
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
 #include "Asset.hpp"
 #include "Menu/ShowButton.hpp"
-#include "ActionInterface.hpp"
 #include "util/Macros.hpp"
 
-#ifdef ANDROID
-#include "Android/Main.hpp"
-#include "Android/NativeView.hpp"
-#endif
-
-#ifdef USE_POLL_EVENT
-#include "ui/event/Globals.hpp"
-#include "ui/event/Queue.hpp"
-#endif
-
 enum ControlIndex {
-#ifdef ANDROID
-  FullScreen,
-#endif
-  MapOrientation,
-  DarkMode,
   AppDisplayType,
   AppInfoBoxGeom,
   InfoBoxTitleScale,
@@ -45,24 +26,6 @@ enum ControlIndex {
   ShowMenuButton,
   ShowZoomButton,
   ShowQuickMenuButton,
-#ifdef DRAW_MOUSE_CURSOR
-  CursorSize,
-  CursorInverted,
-#endif
-};
-
-static constexpr StaticEnumChoice display_orientation_list[] = {
-  { DisplayOrientation::DEFAULT,
-    N_("Default") },
-  { DisplayOrientation::PORTRAIT,
-    N_("Portrait") },
-  { DisplayOrientation::LANDSCAPE,
-    N_("Landscape") },
-  { DisplayOrientation::REVERSE_PORTRAIT,
-    N_("Reverse Portrait") },
-  { DisplayOrientation::REVERSE_LANDSCAPE,
-    N_("Reverse Landscape") },
-  nullptr
 };
 
 static constexpr StaticEnumChoice display_type_list[] = {
@@ -155,16 +118,6 @@ static constexpr StaticEnumChoice infobox_border_list[] = {
   nullptr
 };
 
-static constexpr StaticEnumChoice dark_mode_list[] = {
-  { UISettings::DarkMode::AUTO, NC_("Setting", "Auto"),
-    N_("Use the system-wide setting") },
-  { UISettings::DarkMode::OFF, N_("Off"),
-    N_("Black text on white background") },
-  { UISettings::DarkMode::ON, N_("On"),
-    N_("White text on black background") },
-  nullptr
-};
-
 static constexpr StaticEnumChoice infobox_theme_list[] = {
   { InfoBoxSettings::Theme::FOLLOW_GLOBAL, N_("Follow global"),
     N_("Use the same light/dark mode as the overall UI.") },
@@ -200,25 +153,6 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
   saved = false;
 
   RowFormWidget::Prepare(parent, rc);
-
-#ifdef ANDROID
-  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
-             ui_settings.display.full_screen);
-#endif
-
-  if (Display::RotateSupported())
-    AddEnum(_("Display orientation"), _("Rotate the display on devices that support it."),
-            display_orientation_list, (unsigned)ui_settings.display.orientation);
-  else
-    AddDummy();
-
-#ifndef KOBO
-  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
-          (unsigned)ui_settings.dark_mode);
-  SetExpertRow(DarkMode);
-#else
-  AddDummy();
-#endif
 
   AddEnum(C_("Setting", "Display type"),
           _("Select the display technology. E-ink modes disable kinetic "
@@ -272,12 +206,6 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
              ui_settings.show_quickmenu_button);
   SetExpertRow(ShowQuickMenuButton);
 
-#ifdef DRAW_MOUSE_CURSOR
-  AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x", 1, 10, 1,
-             (unsigned)ui_settings.display.cursor_size);
-  AddBoolean(_("Invert cursor color"), _("Enable black cursor"),
-             ui_settings.display.invert_cursor_colors);
-#endif
 }
 
 void
@@ -306,31 +234,6 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   UISettings &ui_settings = CommonInterface::SetUISettings();
   saved = true;
-
-#ifdef ANDROID
-  changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
-                       ui_settings.display.full_screen);
-  native_view->SetFullScreen(Java::GetEnv(), ui_settings.display.full_screen);
-#endif
-
-  bool orientation_changed = false;
-
-  if (Display::RotateSupported()) {
-    orientation_changed =
-      SaveValueEnum(MapOrientation, ProfileKeys::MapOrientation,
-                    ui_settings.display.orientation);
-    changed |= orientation_changed;
-  }
-
-#ifndef KOBO
-  changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
-                           ui_settings.dark_mode);
-#else
-  if (ui_settings.dark_mode != UISettings::DarkMode::OFF) {
-    ui_settings.dark_mode = UISettings::DarkMode::OFF;
-    changed = true;
-  }
-#endif
 
   if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
                     ui_settings.display.display_type)) {
@@ -381,27 +284,7 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   DialogSettings &dialog_settings = CommonInterface::SetUISettings().dialog;
   changed |= SaveValueEnum(TabDialogStyle, ProfileKeys::AppDialogTabStyle, dialog_settings.tab_style);
 
-#ifdef DRAW_MOUSE_CURSOR
-  changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
-                              ui_settings.display.cursor_size);
-  CommonInterface::main_window->SetCursorSize(ui_settings.display.cursor_size);
-
-  changed |= SaveValue(CursorInverted, ProfileKeys::CursorColorsInverted, ui_settings.display.invert_cursor_colors);
-  CommonInterface::main_window->SetCursorColorsInverted(ui_settings.display.invert_cursor_colors);
-#endif
-
-  if (orientation_changed) {
-    assert(Display::RotateSupported());
-
-    if (!Display::Rotate(ui_settings.display.orientation))
-      LogString("Display rotation failed");
-
-#ifdef USE_POLL_EVENT
-    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
-#endif
-
-    CommonInterface::main_window->CheckResize();
-  } else if (info_box_geometry_changed)
+  if (info_box_geometry_changed)
     CommonInterface::main_window->ReinitialiseLayout();
 
   _changed |= changed;

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -32,6 +32,7 @@
 #include "Panels/SafetyFactorsConfigPanel.hpp"
 #include "Panels/RouteConfigPanel.hpp"
 #include "Panels/InterfaceConfigPanel.hpp"
+#include "Panels/DisplayConfigPanel.hpp"
 #include "Panels/LayoutConfigPanel.hpp"
 #include "Panels/GaugesConfigPanel.hpp"
 #include "Panels/VarioConfigPanel.hpp"
@@ -133,7 +134,8 @@ static constexpr TabMenuPage task_pages[] = {
 
 static constexpr TabMenuPage look_pages[] = {
   { N_("Language, Input"), CreateInterfaceConfigPanel },
-  { N_("Screen Layout"), CreateLayoutConfigPanel },
+  { N_("Display"), CreateDisplayConfigPanel },
+  { N_("Layout"), CreateLayoutConfigPanel },
   { N_("Pages"), CreatePagesConfigPanel },
   { N_("InfoBox Sets"), CreateInfoBoxesConfigPanel },
   { nullptr, nullptr }

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -32,6 +32,7 @@
 #include "Panels/SafetyFactorsConfigPanel.hpp"
 #include "Panels/RouteConfigPanel.hpp"
 #include "Panels/InterfaceConfigPanel.hpp"
+#include "Panels/DisplayConfigPanel.hpp"
 #include "Panels/LayoutConfigPanel.hpp"
 #include "Panels/GaugesConfigPanel.hpp"
 #include "Panels/VarioConfigPanel.hpp"
@@ -126,7 +127,8 @@ static constexpr TabMenuPage task_pages[] = {
 
 static constexpr TabMenuPage look_pages[] = {
   { N_("Language, Input"), CreateInterfaceConfigPanel },
-  { N_("Screen Layout"), CreateLayoutConfigPanel },
+  { N_("Display"), CreateDisplayConfigPanel },
+  { N_("Layout"), CreateLayoutConfigPanel },
   { N_("Pages"), CreatePagesConfigPanel },
   { N_("InfoBox Sets"), CreateInfoBoxesConfigPanel },
   { nullptr, nullptr }

--- a/src/Hardware/DisplayBrightness.cpp
+++ b/src/Hardware/DisplayBrightness.cpp
@@ -3,6 +3,10 @@
 
 #include "DisplayBrightness.hpp"
 
+#ifdef KOBO
+#include "Kobo/System.hpp"
+#endif
+
 #include "system/FileUtil.hpp"
 #include "util/NumberParser.hxx"
 
@@ -17,7 +21,7 @@
 #include <fmt/format.h>
 #endif
 
-#if defined(__linux__) && !defined(ANDROID)
+#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
 static std::optional<unsigned>
 ReadUnsigned(Path path) noexcept
 {
@@ -38,11 +42,13 @@ ReadUnsigned(Path path) noexcept
 }
 #endif
 
-#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
-DisplayBrightness::DisplayBrightness(AllocatedPath &&_brightness_path,
+#if defined(KOBO) || (defined(__linux__) && !defined(ANDROID))
+DisplayBrightness::DisplayBrightness(Type _type,
+                                     AllocatedPath &&_brightness_path,
                                      unsigned _max_brightness,
                                      bool _writable) noexcept
-  :brightness_path(std::move(_brightness_path)),
+  :type(_type),
+   brightness_path(std::move(_brightness_path)),
    max_brightness(_max_brightness),
    writable(_writable) {}
 #endif
@@ -50,7 +56,13 @@ DisplayBrightness::DisplayBrightness(AllocatedPath &&_brightness_path,
 std::unique_ptr<DisplayBrightness>
 DisplayBrightness::Detect() noexcept
 {
-#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+#ifdef KOBO
+  if (!KoboCanChangeBacklightBrightness())
+    return nullptr;
+
+  return std::unique_ptr<DisplayBrightness>(
+    new DisplayBrightness(Type::Kobo, nullptr, 100, true));
+#elif defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
   struct Visitor final : Directory::DirEntryVisitor {
     unsigned best_max_brightness = 0;
     bool best_writable = false;
@@ -80,8 +92,8 @@ DisplayBrightness::Detect() noexcept
       best_max_brightness = *max_brightness;
       best_writable = writable;
       result = std::unique_ptr<DisplayBrightness>(
-        new DisplayBrightness(std::move(brightness_path), *max_brightness,
-                              writable));
+        new DisplayBrightness(Type::Linux, std::move(brightness_path),
+                              *max_brightness, writable));
     }
   } visitor;
 
@@ -96,9 +108,18 @@ DisplayBrightness::Detect() noexcept
 unsigned
 DisplayBrightness::GetBrightnessPercent() const noexcept
 {
-#if defined(__linux__) && !defined(ANDROID)
+#ifdef KOBO
+  if (type != Type::Kobo)
+    return 0;
+
+  return std::clamp(KoboGetBacklightBrightness(), 0, 100);
+#elif defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+  if (type != Type::Linux)
+    return 0;
+
   if (brightness_path == nullptr || max_brightness == 0)
     return 0;
+
   const auto brightness = ReadUnsigned(brightness_path);
   if (!brightness)
     return 0;
@@ -112,7 +133,15 @@ DisplayBrightness::GetBrightnessPercent() const noexcept
 void
 DisplayBrightness::SetBrightnessPercent(unsigned percent) const noexcept
 {
-#ifdef HAVE_POSIX
+#ifdef KOBO
+  if (type != Type::Kobo)
+    return;
+
+  KoboSetBacklightBrightness((int)std::clamp(percent, 0u, 100u));
+#elif defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+  if (type != Type::Linux)
+    return;
+
   if (!writable || max_brightness == 0 || brightness_path == nullptr)
     return;
 

--- a/src/Hardware/DisplayBrightness.cpp
+++ b/src/Hardware/DisplayBrightness.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DisplayBrightness.hpp"
+
+#include "system/FileUtil.hpp"
+#include "util/NumberParser.hxx"
+
+#include <algorithm> // for std::clamp()
+#include <cctype>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#ifdef HAVE_POSIX
+#include <unistd.h>
+#include <fmt/format.h>
+#endif
+
+#if defined(__linux__) && !defined(ANDROID)
+static std::optional<unsigned>
+ReadUnsigned(Path path) noexcept
+{
+  char buffer[32];
+  if (!File::ReadString(path, buffer, sizeof(buffer)))
+    return std::nullopt;
+
+  std::string_view value(buffer);
+  while (!value.empty() && std::isspace((unsigned char)value.front()))
+    value.remove_prefix(1);
+  while (!value.empty() && std::isspace((unsigned char)value.back()))
+    value.remove_suffix(1);
+
+  if (value.empty())
+    return std::nullopt;
+
+  return ParseInteger<unsigned>(value);
+}
+#endif
+
+#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+DisplayBrightness::DisplayBrightness(AllocatedPath &&_brightness_path,
+                                     unsigned _max_brightness,
+                                     bool _writable) noexcept
+  :brightness_path(std::move(_brightness_path)),
+   max_brightness(_max_brightness),
+   writable(_writable) {}
+#endif
+
+std::unique_ptr<DisplayBrightness>
+DisplayBrightness::Detect() noexcept
+{
+#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+  struct Visitor final : Directory::DirEntryVisitor {
+    unsigned best_max_brightness = 0;
+    bool best_writable = false;
+    std::unique_ptr<DisplayBrightness> result;
+
+    void Visit(Path full, [[maybe_unused]] Path filename,
+               bool is_dir) noexcept override {
+      if (!is_dir)
+        return;
+
+      const auto max_path = AllocatedPath::Build(full, "max_brightness");
+      auto brightness_path = AllocatedPath::Build(full, "brightness");
+
+      const auto max_brightness = ReadUnsigned(max_path);
+      const auto brightness = ReadUnsigned(brightness_path);
+      if (!max_brightness || !brightness || *max_brightness <= 1 ||
+          *brightness > *max_brightness)
+        return;
+
+      const bool writable = access(brightness_path.c_str(), W_OK) == 0;
+      if (result != nullptr &&
+          (writable < best_writable ||
+           (writable == best_writable &&
+            *max_brightness <= best_max_brightness)))
+        return;
+
+      best_max_brightness = *max_brightness;
+      best_writable = writable;
+      result = std::unique_ptr<DisplayBrightness>(
+        new DisplayBrightness(std::move(brightness_path), *max_brightness,
+                              writable));
+    }
+  } visitor;
+
+  Directory::VisitDirectoriesAndFiles(Path("/sys/class/backlight"), visitor,
+                                      false);
+  return std::move(visitor.result);
+#else
+  return nullptr;
+#endif
+}
+
+unsigned
+DisplayBrightness::GetBrightnessPercent() const noexcept
+{
+#if defined(__linux__) && !defined(ANDROID)
+  if (brightness_path == nullptr || max_brightness == 0)
+    return 0;
+  const auto brightness = ReadUnsigned(brightness_path);
+  if (!brightness)
+    return 0;
+
+  return std::min((*brightness * 100u) / max_brightness, 100u);
+#else
+  return 0u;
+#endif
+}
+
+void
+DisplayBrightness::SetBrightnessPercent(unsigned percent) const noexcept
+{
+#ifdef HAVE_POSIX
+  if (!writable || max_brightness == 0 || brightness_path == nullptr)
+    return;
+
+  if (!ReadUnsigned(brightness_path))
+    return;
+
+  const unsigned clamped = std::clamp(percent, 0u, 100u);
+  const auto raw = clamped * max_brightness / 100u;
+  File::WriteExisting(brightness_path, fmt::format_int(raw).c_str());
+#else
+  (void)percent;
+#endif
+}

--- a/src/Hardware/DisplayBrightness.hpp
+++ b/src/Hardware/DisplayBrightness.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+
+#include <memory>
+
+class DisplayBrightness final {
+#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+  AllocatedPath brightness_path;
+  unsigned max_brightness;
+  bool writable;
+
+  DisplayBrightness(AllocatedPath &&_brightness_path,
+                    unsigned _max_brightness,
+                    bool _writable) noexcept;
+#endif
+
+public:
+  [[nodiscard]] static std::unique_ptr<DisplayBrightness>
+  Detect() noexcept;
+
+  [[nodiscard]] bool IsWritable() const noexcept {
+#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+    return writable;
+#else
+    return false;
+#endif
+  }
+
+  [[nodiscard]] unsigned GetBrightnessPercent() const noexcept;
+
+  void SetBrightnessPercent(unsigned percent) const noexcept;
+};

--- a/src/Hardware/DisplayBrightness.hpp
+++ b/src/Hardware/DisplayBrightness.hpp
@@ -8,12 +8,19 @@
 #include <memory>
 
 class DisplayBrightness final {
-#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+#if defined(KOBO) || (defined(__linux__) && !defined(ANDROID))
+  enum class Type {
+    Kobo,
+    Linux,
+  };
+
+  Type type;
   AllocatedPath brightness_path;
   unsigned max_brightness;
   bool writable;
 
-  DisplayBrightness(AllocatedPath &&_brightness_path,
+  DisplayBrightness(Type _type,
+                    AllocatedPath &&_brightness_path,
                     unsigned _max_brightness,
                     bool _writable) noexcept;
 #endif
@@ -23,7 +30,7 @@ public:
   Detect() noexcept;
 
   [[nodiscard]] bool IsWritable() const noexcept {
-#if defined(__linux__) && !defined(ANDROID) && !defined(KOBO)
+#if defined(KOBO) || (defined(__linux__) && !defined(ANDROID))
     return writable;
 #else
     return false;

--- a/src/Hardware/RotateDisplay.cpp
+++ b/src/Hardware/RotateDisplay.cpp
@@ -3,6 +3,7 @@
 
 #include "RotateDisplay.hpp"
 #include "DisplayOrientation.hpp"
+#include "util/Compiler.h"
 
 #ifdef ANDROID
 #include "Android/Main.hpp"
@@ -14,6 +15,12 @@
 #include "Kobo/Model.hpp"
 #endif
 
+#ifdef MESA_KMS
+#include "LogFile.hpp"
+#include "system/FileUtil.hpp"
+#include "system/Path.hpp"
+#endif
+
 #ifdef ENABLE_OPENGL
 #include "ui/opengl/Features.hpp"
 #ifdef SOFTWARE_ROTATE_DISPLAY
@@ -21,6 +28,31 @@
 #include "ui/window/SingleWindow.hpp"
 #include "ui/canvas/opengl/Globals.hpp"
 #endif
+#endif
+
+#ifdef MESA_KMS
+[[gnu::const]]
+static const char *
+ToFbconRotate(DisplayOrientation orientation) noexcept
+{
+  switch (orientation) {
+  case DisplayOrientation::DEFAULT:
+  case DisplayOrientation::LANDSCAPE:
+    return "0";
+
+  case DisplayOrientation::REVERSE_PORTRAIT:
+    return "1";
+
+  case DisplayOrientation::REVERSE_LANDSCAPE:
+    return "2";
+
+  case DisplayOrientation::PORTRAIT:
+    return "3";
+  }
+
+  assert(false);
+  gcc_unreachable();
+}
 #endif
 
 void
@@ -146,6 +178,12 @@ Display::Rotate(DisplayOrientation orientation)
 #elif defined(SOFTWARE_ROTATE_DISPLAY)
   if (!RotateSupported())
     return false;
+
+#ifdef MESA_KMS
+  if (!File::WriteExisting(Path("/sys/class/graphics/fbcon/rotate"),
+                           ToFbconRotate(orientation)))
+    LogString("Failed to publish display rotation to fbcon");
+#endif
 
   UIGlobals::GetMainWindow().SetDisplayOrientation(orientation);
   return true;


### PR DESCRIPTION
- split display and layout setting panels
- add Linux and Kobo in-app brightness settings
- publish KMS rotation to fbcon
Note: persistence shall be handled by the linux backend. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Display settings page.
  - Configure fullscreen mode, orientation, dark mode, display technology, brightness, and cursor visibility.
  - Added brightness controls on supported devices.
  - Added display rotation support for compatible Linux systems.
  - Display options automatically reflect available device capabilities.

- **Changes**
  - Simplified the Layout settings page to focus on layout-related options.
  - Renamed “Screen Layout” to “Layout” for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->