### PR TITLE
Fix Windows startup crash with non-ASCII profile paths (#2824)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -239,6 +239,8 @@ Version 7.45 - not yet released
 * Windows
   - fix crash opening the log list when replay filenames contain
     non-ASCII characters (Unicode directory listing and file open)
+  - fix startup crash when the Windows user profile contains non-English
+    characters (e.g. Cyrillic account names) #2824
 * devices
   - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
     shows other gliders on the FLARM radar and map

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -241,6 +241,8 @@ Version 7.45 - not yet released
     non-ASCII characters (Unicode directory listing and file open)
   - fix startup crash when the Windows user profile contains non-English
     characters (e.g. Cyrillic account names) #2824
+  - open ZIP maps, JPEG/TIFF images, Lua scripts, fonts, and cache files
+    from folders with non-English characters on Windows
 * devices
   - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
     shows other gliders on the FLARM radar and map

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -198,6 +198,8 @@ Version 7.45 - not yet released
     "Symmetric Sector", as these zones do not have to be 90 degrees but
     support any angle.
   - Outline selected targets on the FLARM traffic radar
+  - Fix crash when leaving the FLARM traffic radar with a horizontal
+    swipe (focus re-entry while destroying the page widget) #2824
   - Weather cursor bar: narrower stepper buttons on touchscreens and clip
     long centre labels instead of hiding them when they do not fit
   - Fix crash when opening the map item list on waypoints with long

--- a/src/Device/Driver/Volkslogger/Logger.cpp
+++ b/src/Device/Driver/Volkslogger/Logger.cpp
@@ -5,6 +5,7 @@
 #include "Protocol.hpp"
 #include "Device/RecordedFlight.hpp"
 #include "Device/Port/Port.hpp"
+#include "system/OpenPathFile.hpp"
 #include "system/Path.hpp"
 #include "Operation/Operation.hpp"
 #include "vlconv.h"
@@ -90,7 +91,7 @@ DownloadFlightInner(Port &port, unsigned bulkrate,
   if (length == 0)
     return false;
 
-  FILE *outfile = fopen(path.c_str(), "wt");
+  FILE *outfile = OpenPathFile(path, "wt");
   if (outfile == nullptr)
     return false;
 

--- a/src/Device/Port/SerialPort.cpp
+++ b/src/Device/Port/SerialPort.cpp
@@ -7,11 +7,14 @@
 #include "system/Error.hxx"
 #include "system/Sleep.h"
 #include "system/OverlappedEvent.hpp"
+#include "system/UTF8Win32.hpp"
 
 #include <fileapi.h>
+#include "system/Win32UTF8PathGuard.hpp"
 
 #include <algorithm>
 #include <cassert>
+#include <stdexcept>
 #include <stdio.h>
 
 SerialPort::SerialPort(PortListener *_listener, DataHandler &_handler)
@@ -38,16 +41,19 @@ SerialPort::Open(const char *path, unsigned _baud_rate)
 {
   assert(!Thread::IsInside());
 
+  if (path == nullptr || *path == '\0')
+    throw std::runtime_error("Invalid serial port path");
+
   DCB PortDCB;
 
-  // Open the serial port.
-  hPort = CreateFile(path,
-                     GENERIC_READ | GENERIC_WRITE, // Access (read-write) mode
-                     0,            // Share mode
-                     nullptr, // Pointer to the security attribute
-                     OPEN_EXISTING,// How to open the serial port
-                     FILE_FLAG_OVERLAPPED, // Overlapped I/O
-                     nullptr); // Handle to port with attribute to copy
+  // Open the serial port (wide API; path is UTF-8, usually "COMn").
+  hPort = CreateFileW(UTF8ToWide(path).c_str(),
+                      GENERIC_READ | GENERIC_WRITE, // Access (read-write) mode
+                      0,            // Share mode
+                      nullptr, // Pointer to the security attribute
+                      OPEN_EXISTING,// How to open the serial port
+                      FILE_FLAG_OVERLAPPED, // Overlapped I/O
+                      nullptr); // Handle to port with attribute to copy
 
   // If it fails to open the port, return false.
   if (hPort == INVALID_HANDLE_VALUE)

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -23,12 +23,13 @@
 #endif
 
 #ifdef _WIN32
-#include "system/PathName.hpp"
+#include "system/UTF8Win32.hpp"
 #endif
 
 #include <algorithm>
 #include <list>
 #include <string>
+#include <string_view>
 #include <stdio.h>
 
 #include <cassert>
@@ -183,19 +184,38 @@ ContractLocalPath(Path src) noexcept
 #ifdef _WIN32
 
 /**
+ * Replace the final path component of a UTF-8 path string.
+ */
+static void
+ReplaceBaseNameUTF8(std::string &path, const char *new_base) noexcept
+{
+  const auto slash = path.find_last_of("/\\");
+  if (slash == std::string::npos)
+    path = new_base;
+  else
+    path.replace(slash + 1, std::string::npos, new_base);
+}
+
+/**
  * Find a product data folder in the same location as the executable.
  */
 [[gnu::pure]]
 static AllocatedPath
 FindDataPathAtModule(HMODULE hModule) noexcept
 {
-  char buffer[MAX_PATH];
-  if (GetModuleFileName(hModule, buffer, MAX_PATH) <= 0)
+  wchar_t buffer[MAX_PATH];
+  const DWORD n = GetModuleFileNameW(hModule, buffer, MAX_PATH);
+  /* n == MAX_PATH means truncated (and may lack a terminator). */
+  if (n == 0 || n >= MAX_PATH)
     return nullptr;
 
-  ReplaceBaseName(buffer, PRODUCT_DATA_DIR);
-  return Directory::Exists(Path(buffer))
-    ? AllocatedPath(buffer)
+  std::string path = WideToUTF8(std::wstring_view(buffer, n));
+  if (path.empty())
+    return nullptr;
+
+  ReplaceBaseNameUTF8(path, PRODUCT_DATA_DIR);
+  return Directory::Exists(Path(path.c_str()))
+    ? AllocatedPath(path.c_str())
     : nullptr;
 }
 
@@ -278,10 +298,14 @@ FindDataPaths() noexcept
 
   /* Windows: use "My Documents\<ProductDataDir>" */
   {
-    char buffer[MAX_PATH];
-    if (SHGetSpecialFolderPath(nullptr, buffer, CSIDL_PERSONAL,
-                               result.empty()))
-      result.emplace_back(AllocatedPath::Build(buffer, PRODUCT_DATA_DIR));
+    wchar_t buffer[MAX_PATH];
+    if (SHGetSpecialFolderPathW(nullptr, buffer, CSIDL_PERSONAL,
+                                result.empty())) {
+      const std::string personal = WideToUTF8(buffer);
+      if (!personal.empty())
+        result.emplace_back(AllocatedPath::Build(personal.c_str(),
+                                                 PRODUCT_DATA_DIR));
+    }
   }
 #endif // _WIN32
 

--- a/src/LocalPath.cpp
+++ b/src/LocalPath.cpp
@@ -37,6 +37,7 @@
 #ifdef _WIN32
 #include <shlobj.h>
 #include <windef.h> // for MAX_PATH
+#include "system/Win32UTF8PathGuard.hpp"
 #endif
 
 #ifdef ANDROID

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1504,13 +1504,18 @@ MainWindow::KillWidget() noexcept
   if (widget == nullptr)
     return;
 
-  widget->Leave();
-  widget->Hide();
-  widget->Unprepare();
-  delete widget;
+  /* Clear the pointer before destroying.  On Windows, DestroyWindow on
+     a focused child (e.g. FLARM radar) can re-enter OnSetFocus(); if
+     #widget still pointed here, WindowWidget::SetFocus() would assert
+     after the native window was already destroyed (#2824). */
+  Widget *const old = widget;
   widget = nullptr;
-
   InputEvents::SetFlavour(nullptr);
+
+  old->Leave();
+  old->Hide();
+  old->Unprepare();
+  delete old;
 }
 
 void
@@ -1519,10 +1524,12 @@ MainWindow::KillTopWidget() noexcept
   if (top_widget == nullptr)
     return;
 
-  top_widget->Hide();
-  top_widget->Unprepare();
-  delete top_widget;
+  Widget *const old = top_widget;
   top_widget = nullptr;
+
+  old->Hide();
+  old->Unprepare();
+  delete old;
 }
 
 void
@@ -1556,14 +1563,16 @@ MainWindow::KillBottomWidget() noexcept
   if (bottom_widget == nullptr)
     return;
 
+  Widget *const old = bottom_widget;
+  bottom_widget = nullptr;
+
   if (widget == nullptr)
     /* the bottom widget is only visible below the map, but not below
        a custom main widget; see HaveBottomWidget() */
-    bottom_widget->Hide();
+    old->Hide();
 
-  bottom_widget->Unprepare();
-  delete bottom_widget;
-  bottom_widget = nullptr;
+  old->Unprepare();
+  delete old;
 }
 
 void

--- a/src/VALI-XCS.cpp
+++ b/src/VALI-XCS.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "system/ConvertPathName.hpp"
+#include "system/FileUtil.hpp"
 #include "Logger/GRecord.hpp"
 #include "Version.hpp"
 #include "util/PrintException.hxx"
@@ -27,14 +28,8 @@ static const char szNoFile[] = "Validation check failed.  File not found";
 static STATUS_t
 ValidateXCS(Path path, GRecord &oGRecord)
 {
-  STATUS_t eStatus = eValidationFileNotFound;
-
-  FILE *inFile = nullptr;
-  inFile = fopen(path.c_str(), "r");
-  if (inFile == nullptr)
-    return eStatus;
-
-  fclose(inFile);
+  if (!File::Exists(path))
+    return eValidationFileNotFound;
 
   oGRecord.Initialize();
   oGRecord.VerifyGRecordInFile(path);

--- a/src/io/FileCache.cpp
+++ b/src/io/FileCache.cpp
@@ -8,6 +8,7 @@
 #include "util/SpanCast.hxx"
 
 #ifdef _WIN32
+#include "system/UTF8Win32.hpp"
 #include "time/FileTime.hxx"
 #endif
 
@@ -60,7 +61,8 @@ GetRegularFileInfo(Path path, FileInfo &info)
   return true;
 #else
   WIN32_FILE_ATTRIBUTE_DATA data;
-  if (!GetFileAttributesEx(path.c_str(), GetFileExInfoStandard, &data) ||
+  if (!GetFileAttributesExW(UTF8ToWide(path.c_str()).c_str(),
+                            GetFileExInfoStandard, &data) ||
       (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0)
     return false;
 

--- a/src/io/ZipArchive.cpp
+++ b/src/io/ZipArchive.cpp
@@ -4,15 +4,35 @@
 #include "ZipArchive.hpp"
 #include "lib/fmt/RuntimeError.hxx"
 #include "lib/fmt/PathFormatter.hpp"
-#include "system/ConvertPathName.hpp"
+#include "system/Path.hpp"
 
 #include <zzip/zzip.h>
 
+#ifdef _WIN32
+#include "UniqueFileDescriptor.hxx"
+#endif
+
 ZipArchive::ZipArchive(Path path)
-  :dir(zzip_dir_open(NarrowPathName(path), nullptr))
 {
+#ifdef _WIN32
+  /* zzip_dir_open() uses CRT open() (ANSI); open via _wopen and hand
+     the fd to zzip so UTF-8 Paths work. Steal only after success so a
+     failed zzip_dir_fdopen (e.g. OOM before it adopts the fd) cannot
+     leak the descriptor. */
+  UniqueFileDescriptor fd;
+  if (!fd.OpenReadOnly(path.c_str()))
+    throw FmtRuntimeError("Failed to open ZIP archive {}", path);
+
+  dir = zzip_dir_fdopen(fd.Get(), nullptr);
   if (dir == nullptr)
     throw FmtRuntimeError("Failed to open ZIP archive {}", path);
+
+  (void)fd.Steal();
+#else
+  dir = zzip_dir_open(path.c_str(), nullptr);
+  if (dir == nullptr)
+    throw FmtRuntimeError("Failed to open ZIP archive {}", path);
+#endif
 }
 
 ZipArchive::~ZipArchive() noexcept

--- a/src/lua/RunFile.cxx
+++ b/src/lua/RunFile.cxx
@@ -3,16 +3,77 @@
 
 #include "RunFile.hxx"
 #include "Error.hxx"
-#include "system/ConvertPathName.hpp"
+#include "system/OpenPathFile.hpp"
 #include "system/Path.hpp"
+#include "util/ScopeExit.hxx"
+
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
 
 extern "C" {
 #include <lauxlib.h>
 }
 
+/**
+ * Skip an optional UTF-8 BOM and a leading shebang line, matching
+ * luaL_loadfile() preprocessing.
+ */
+static std::string_view
+SkipLuaFileHeader(std::string_view data) noexcept
+{
+	static constexpr char utf8_bom[] = {
+		'\xef', '\xbb', '\xbf'
+	};
+	if (data.size() >= 3 &&
+	    data[0] == utf8_bom[0] &&
+	    data[1] == utf8_bom[1] &&
+	    data[2] == utf8_bom[2])
+		data.remove_prefix(3);
+
+	if (!data.empty() && data.front() == '#') {
+		const auto nl = data.find('\n');
+		if (nl == std::string_view::npos)
+			data = {};
+		else
+			data.remove_prefix(nl + 1);
+	}
+
+	return data;
+}
+
 void
 Lua::RunFile(lua_State *L, Path path)
 {
-	if (luaL_loadfile(L, NarrowPathName(path)) || lua_pcall(L, 0, 0, 0))
+	FILE *file = OpenPathFile(path, "rb");
+	if (file == nullptr)
+		throw std::runtime_error("Failed to open Lua file");
+
+	AtScopeExit(file) { fclose(file); };
+
+	if (fseek(file, 0, SEEK_END) != 0)
+		throw std::runtime_error("Failed to seek Lua file");
+
+	const long size = ftell(file);
+	if (size < 0)
+		throw std::runtime_error("Failed to size Lua file");
+
+	if (fseek(file, 0, SEEK_SET) != 0)
+		throw std::runtime_error("Failed to rewind Lua file");
+
+	std::vector<char> buffer(static_cast<std::size_t>(size));
+	if (size > 0 &&
+	    fread(buffer.data(), 1, buffer.size(), file) != buffer.size())
+		throw std::runtime_error("Failed to read Lua file");
+
+	const std::string_view chunk =
+		SkipLuaFileHeader(std::string_view(buffer.data(),
+						   buffer.size()));
+
+	const std::string chunk_name = "@" + std::string(path.c_str());
+	if (luaL_loadbuffer(L, chunk.data(), chunk.size(),
+			    chunk_name.c_str()) ||
+	    lua_pcall(L, 0, 0, 0))
 		throw PopError(L);
 }

--- a/src/lua/RunFile.cxx
+++ b/src/lua/RunFile.cxx
@@ -33,11 +33,13 @@ SkipLuaFileHeader(std::string_view data) noexcept
 		data.remove_prefix(3);
 
 	if (!data.empty() && data.front() == '#') {
+		/* luaL_loadfile() skips the shebang and then inserts a
+		   newline so Lua line numbers still match the file. */
 		const auto nl = data.find('\n');
 		if (nl == std::string_view::npos)
 			data = {};
 		else
-			data.remove_prefix(nl + 1);
+			data.remove_prefix(nl);
 	}
 
 	return data;

--- a/src/system/FileUtil.cpp
+++ b/src/system/FileUtil.cpp
@@ -40,7 +40,7 @@ Directory::Create(Path path) noexcept
 #ifdef HAVE_POSIX
   mkdir(path.c_str(), 0777);
 #else /* !HAVE_POSIX */
-  CreateDirectory(path.c_str(), nullptr);
+  CreateDirectoryW(UTF8ToWide(path.c_str()).c_str(), nullptr);
 #endif /* !HAVE_POSIX */
 }
 
@@ -67,7 +67,7 @@ Directory::Exists(Path path) noexcept
 
   return S_ISDIR(st.st_mode);
 #else
-  DWORD attributes = GetFileAttributes(path.c_str());
+  DWORD attributes = GetFileAttributesW(UTF8ToWide(path.c_str()).c_str());
   return attributes != INVALID_FILE_ATTRIBUTES &&
     (attributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
 #endif
@@ -89,7 +89,7 @@ Directory::IsWritable(Path path) noexcept
   if (!Directory::Exists(path))
     return false;
 
-  // Try to create a uniquely-named file using CreateFileA and remove it
+  // Try to create a uniquely-named file using CreateFileW and remove it
   // immediately. This avoids CRT path formatting and keeps overhead low.
   std::string base = path.c_str();
   if (base.empty())
@@ -103,8 +103,6 @@ Directory::IsWritable(Path path) noexcept
   constexpr size_t hex_len = 8;
   constexpr std::string_view suffix = "_wt";
   constexpr std::string_view ext = ".tmp";
-  if (base.size() + suffix.size() + hex_len + ext.size() >= MAX_PATH)
-    return false;
 
   const unsigned seed = GetTickCount() ^ GetCurrentProcessId();
   for (unsigned attempt = 0; attempt < 8; ++attempt) {
@@ -116,13 +114,19 @@ Directory::IsWritable(Path path) noexcept
     tmpname.append(hexbuf);
     tmpname.append(ext);
 
-    HANDLE h = CreateFile(tmpname.c_str(),
-                          GENERIC_WRITE,
-                          FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                          nullptr,
-                          CREATE_NEW,
-                          FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE,
-                          nullptr);
+    const std::wstring wtmp = UTF8ToWide(tmpname);
+    if (wtmp.empty() || wtmp.size() >= MAX_PATH)
+      return false;
+
+    HANDLE h = CreateFileW(wtmp.c_str(),
+                           GENERIC_WRITE,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE |
+                             FILE_SHARE_DELETE,
+                           nullptr,
+                           CREATE_NEW,
+                           FILE_ATTRIBUTE_TEMPORARY |
+                             FILE_FLAG_DELETE_ON_CLOSE,
+                           nullptr);
     if (h != INVALID_HANDLE_VALUE) {
       CloseHandle(h);
       return true;
@@ -369,28 +373,29 @@ Directory::Remove(Path path) noexcept
   closedir(dir);
   return ok && rmdir(path.c_str()) == 0;
 #else
-  AllocatedPath search = AllocatedPath::Build(path, Path("*"));
-
-  WIN32_FIND_DATA fd;
-  HANDLE hFind = FindFirstFile(search.c_str(), &fd);
-  if (hFind == INVALID_HANDLE_VALUE)
-    return RemoveDirectoryA(path.c_str());
+  std::string dir = path.c_str();
+  AppendDirSeparator(dir);
 
   bool ok = true;
-  do {
-    if (IsDots(fd.cFileName))
-      continue;
+  const bool enumerated =
+    ForEachFindFile(dir + "*", [&](const WIN32_FIND_DATAW &fd) {
+      const std::string name = WideToUTF8(fd.cFileName);
+      if (IsDots(name.c_str()))
+        return;
 
-    AllocatedPath child = AllocatedPath::Build(path, Path(fd.cFileName));
+      AllocatedPath child = AllocatedPath::Build(path, Path(name.c_str()));
 
-    if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-      ok &= Remove(child);
-    else
-      ok &= (DeleteFile(child.c_str()) != 0);
-  } while (FindNextFile(hFind, &fd));
+      if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+        ok &= Remove(child);
+      else
+        ok &= File::Delete(child);
+    });
 
-  FindClose(hFind);
-  return ok && RemoveDirectoryA(path.c_str());
+  if (!enumerated)
+    return RemoveDirectoryW(UTF8ToWide(path.c_str()).c_str()) != 0;
+
+  return ok &&
+    RemoveDirectoryW(UTF8ToWide(path.c_str()).c_str()) != 0;
 #endif
 }
 

--- a/src/system/FileUtil.hpp
+++ b/src/system/FileUtil.hpp
@@ -17,9 +17,7 @@
 #include <fileapi.h>
 #include <windef.h> // for HWND (needed by winbase.h)
 #include <winbase.h>
-#ifdef CopyFile
-#undef CopyFile
-#endif
+#include "Win32UTF8PathGuard.hpp"
 #endif
 
 namespace File {

--- a/src/system/OpenPathFile.hpp
+++ b/src/system/OpenPathFile.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Path.hpp"
+
+#include <stdio.h>
+
+#ifdef _WIN32
+#include "UTF8Win32.hpp"
+#endif
+
+/**
+ * fopen() with a UTF-8 #Path.  On Windows this uses _wfopen() so
+ * non-ASCII paths work; elsewhere it is a plain fopen().
+ *
+ * Prefer this (or CreateFileW + UTF8ToWide) over CRT fopen()/_open()
+ * whenever the path may contain non-ASCII characters.
+ */
+[[nodiscard]]
+inline FILE *
+OpenPathFile(Path path, const char *mode) noexcept
+{
+  if (mode == nullptr || *mode == '\0')
+    return nullptr;
+
+#ifdef _WIN32
+  const std::wstring wpath = UTF8ToWide(path.c_str());
+  const std::wstring wmode = UTF8ToWide(mode);
+  if (wpath.empty() || wmode.empty())
+    return nullptr;
+
+  return _wfopen(wpath.c_str(), wmode.c_str());
+#else
+  return fopen(path.c_str(), mode);
+#endif
+}

--- a/src/system/UTF8Win32.cpp
+++ b/src/system/UTF8Win32.cpp
@@ -5,6 +5,8 @@
 
 #ifdef _WIN32
 
+#include "util/UTF8.hpp"
+
 #include <cassert>
 #include <stringapiset.h>
 
@@ -13,6 +15,13 @@ UTF8ToWide(std::string_view s) noexcept
 {
   if (s.empty())
     return {};
+
+  /* Catch ACP/ANSI bytes mistaken for UTF-8 before the Win32 call
+     (#2824). MB_ERR_INVALID_CHARS would also fail; assert early. */
+  if (!ValidateUTF8(s)) {
+    assert(false);
+    return {};
+  }
 
   const int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                                          s.data(), (int)s.size(),

--- a/src/system/UTF8Win32.hpp
+++ b/src/system/UTF8Win32.hpp
@@ -8,10 +8,30 @@
 #include <string>
 #include <string_view>
 
+/**
+ * Convert between UTF-8 #Path strings and UTF-16 for Win32 *W APIs.
+ *
+ * Never pass ANSI/ACP bytes (from CreateFileA, GetModuleFileNameA,
+ * fopen, …) into UTF8ToWide — that asserts and fails (#2824). Obtain
+ * paths with *W APIs + WideToUTF8, or open files with OpenPathFile() /
+ * CreateFileW(UTF8ToWide(...)).
+ */
+
 /** UTF-8 → UTF-16 for Win32 *W APIs. Empty on failure. */
 [[nodiscard]] [[gnu::pure]]
 std::wstring
 UTF8ToWide(std::string_view s) noexcept;
+
+/** Like UTF8ToWide(string_view); empty if @p s is null or empty. */
+[[nodiscard]] [[gnu::pure]]
+inline std::wstring
+UTF8ToWide(const char *s) noexcept
+{
+  if (s == nullptr || *s == '\0')
+    return {};
+
+  return UTF8ToWide(std::string_view(s));
+}
 
 /** UTF-16 → UTF-8 from Win32 *W APIs. Empty on failure. */
 [[nodiscard]] [[gnu::pure]]

--- a/src/system/Win32UTF8PathGuard.hpp
+++ b/src/system/Win32UTF8PathGuard.hpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Include this *after* Windows headers (`windows.h`, `fileapi.h`,
+ * `shlobj.h`, …).
+ *
+ * XCSoar #Path is UTF-8. Without `UNICODE`, Win32 macros such as
+ * `CreateFile` expand to `CreateFileA` (active code page). That is
+ * incompatible with UTF-8 paths and caused #2824.
+ *
+ * Undefining the A/W selector macros forces call sites to use the
+ * explicit `*W` APIs with `UTF8ToWide()`, or `OpenPathFile()`.
+ */
+
+#ifdef _WIN32
+
+#ifdef CreateFile
+#undef CreateFile
+#endif
+#ifdef DeleteFile
+#undef DeleteFile
+#endif
+#ifdef MoveFile
+#undef MoveFile
+#endif
+#ifdef MoveFileEx
+#undef MoveFileEx
+#endif
+#ifdef CopyFile
+#undef CopyFile
+#endif
+#ifdef GetFileAttributes
+#undef GetFileAttributes
+#endif
+#ifdef GetFileAttributesEx
+#undef GetFileAttributesEx
+#endif
+#ifdef FindFirstFile
+#undef FindFirstFile
+#endif
+#ifdef FindNextFile
+#undef FindNextFile
+#endif
+#ifdef CreateDirectory
+#undef CreateDirectory
+#endif
+#ifdef RemoveDirectory
+#undef RemoveDirectory
+#endif
+#ifdef GetModuleFileName
+#undef GetModuleFileName
+#endif
+#ifdef SHGetSpecialFolderPath
+#undef SHGetSpecialFolderPath
+#endif
+#ifdef GetTempPath
+#undef GetTempPath
+#endif
+#ifdef GetTempFileName
+#undef GetTempFileName
+#endif
+
+#endif /* _WIN32 */

--- a/src/ui/canvas/custom/LibJPEG.cpp
+++ b/src/ui/canvas/custom/LibJPEG.cpp
@@ -3,6 +3,7 @@
 
 #include "LibJPEG.hpp"
 #include "UncompressedImage.hpp"
+#include "system/OpenPathFile.hpp"
 #include "system/Path.hpp"
 #include "util/ScopeExit.hxx"
 
@@ -10,7 +11,6 @@
 #include <stdexcept>
 
 #include <cassert>
-#include <stdio.h>
 #include <cstddef>
 
 extern "C" {
@@ -69,7 +69,7 @@ DecodeJPEG(struct jpeg_decompress_struct &cinfo)
 UncompressedImage
 LoadJPEGFile(Path path)
 {
-  FILE *file = fopen(path.c_str(), "rb");
+  FILE *file = OpenPathFile(path, "rb");
   if (file == nullptr)
     return UncompressedImage();
 

--- a/src/ui/canvas/custom/LibTiff.cpp
+++ b/src/ui/canvas/custom/LibTiff.cpp
@@ -10,6 +10,10 @@
 
 #include <tiffio.h>
 
+#ifdef _WIN32
+#include "system/UTF8Win32.hpp"
+#endif
+
 #ifdef USE_GEOTIFF
 #include "Geo/Quadrilateral.hpp"
 
@@ -26,7 +30,11 @@ TiffOpen(Path path, const char *mode)
   XTIFFInitialize();
 #endif
 
+#ifdef _WIN32
+  return TIFFOpenW(UTF8ToWide(path.c_str()).c_str(), mode);
+#else
   return TIFFOpen(path.c_str(), mode);
+#endif
 }
 
 class TiffLoader {

--- a/src/ui/canvas/freetype/Init.cpp
+++ b/src/ui/canvas/freetype/Init.cpp
@@ -15,6 +15,14 @@
 
 #include <stdexcept>
 
+#ifdef _WIN32
+#include "system/OpenPathFile.hpp"
+#include "system/Path.hpp"
+#include "util/ScopeExit.hxx"
+
+#include <vector>
+#endif
+
 namespace FreeType {
 
 #ifdef KOBO
@@ -37,14 +45,72 @@ Deinitialise()
   FT_Done_FreeType(ft_library);
 }
 
+#ifdef _WIN32
+
+/**
+ * Free the heap buffer attached to a memory face (see FreeType::Load).
+ */
+static void
+FreeFaceFileBuffer(void *object)
+{
+  auto *face = (FT_Face)object;
+  delete (std::vector<unsigned char> *)face->generic.data;
+  face->generic.data = nullptr;
+}
+
+#endif
+
 FT_Face
 Load(const char *path)
 {
+  if (path == nullptr || *path == '\0')
+    throw std::runtime_error("Invalid font path");
+
   FT_Face face;
+
+#ifdef _WIN32
+  /* FT_New_Face() uses CRT open() (ANSI); load via _wfopen into a
+     memory face so UTF-8 font paths work. */
+  FILE *file = OpenPathFile(Path(path), "rb");
+  if (file == nullptr)
+    throw FmtRuntimeError("Failed to open font {}", path);
+
+  AtScopeExit(file) { fclose(file); };
+
+  if (fseek(file, 0, SEEK_END) != 0)
+    throw FmtRuntimeError("Failed to seek font {}", path);
+
+  const long size = ftell(file);
+  if (size <= 0)
+    throw FmtRuntimeError("Failed to size font {}", path);
+
+  if (fseek(file, 0, SEEK_SET) != 0)
+    throw FmtRuntimeError("Failed to rewind font {}", path);
+
+  auto *buffer = new std::vector<unsigned char>((std::size_t)size);
+  if (fread(buffer->data(), 1, buffer->size(), file) != buffer->size()) {
+    delete buffer;
+    throw FmtRuntimeError("Failed to read font {}", path);
+  }
+
+  FT_Error error = FT_New_Memory_Face(ft_library,
+                                      buffer->data(),
+                                      (FT_Long)buffer->size(),
+                                      0, &face);
+  if (error) {
+    delete buffer;
+    throw FmtRuntimeError("Failed to load font {}: {}",
+                          path, FT_Error_String(error));
+  }
+
+  face->generic.data = buffer;
+  face->generic.finalizer = FreeFaceFileBuffer;
+#else
   FT_Error error = FT_New_Face(ft_library, path, 0, &face);
   if (error)
     throw FmtRuntimeError("Failed to load font {}: {}",
                           path, FT_Error_String(error));
+#endif
 
   return face;
 }

--- a/src/ui/canvas/windows/Files.cpp
+++ b/src/ui/canvas/windows/Files.cpp
@@ -3,11 +3,24 @@
 
 #include "ui/canvas/custom/Files.hpp"
 #include "ui/canvas/FontSearch.hpp"
-#include "system/PathName.hpp"
+#include "system/UTF8Win32.hpp"
 
 #include <shlobj.h>
 #include <windef.h> // for MAX_PATH
 #include <string>
+
+/**
+ * Replace the final path component of a UTF-8 path string.
+ */
+static void
+ReplaceBaseNameUTF8(std::string &path, const char *new_base) noexcept
+{
+  const auto slash = path.find_last_of("/\\");
+  if (slash == std::string::npos)
+    path = new_base;
+  else
+    path.replace(slash + 1, std::string::npos, new_base);
+}
 
 /**
  * Get the Windows fonts directory using the Shell API.
@@ -20,14 +33,15 @@ GetWindowsFontsPath() noexcept
   static std::string fonts_path;
 
   if (fonts_path.empty()) {
-    char buffer[MAX_PATH];
-    if (SHGetSpecialFolderPathA(nullptr, buffer,
+    wchar_t buffer[MAX_PATH];
+    if (SHGetSpecialFolderPathW(nullptr, buffer,
                                 CSIDL_FONTS, FALSE)) {
-      fonts_path = buffer;
-    } else {
+      fonts_path = WideToUTF8(buffer);
+    }
+
+    if (fonts_path.empty())
       // Fallback to typical location if API fails
       fonts_path = "C:\\Windows\\Fonts";
-    }
   }
 
   return fonts_path.c_str();
@@ -43,11 +57,12 @@ GetExeFontsPath() noexcept
   static std::string exe_fonts_path;
 
   if (exe_fonts_path.empty()) {
-    char buffer[MAX_PATH];
-    DWORD len = GetModuleFileName(nullptr, buffer, MAX_PATH);
+    wchar_t buffer[MAX_PATH];
+    DWORD len = GetModuleFileNameW(nullptr, buffer, MAX_PATH);
     if (len > 0 && len < MAX_PATH) {
-      ReplaceBaseName(buffer, "fonts");
-      exe_fonts_path = buffer;
+      exe_fonts_path = WideToUTF8(buffer);
+      if (!exe_fonts_path.empty())
+        ReplaceBaseNameUTF8(exe_fonts_path, "fonts");
     }
   }
 

--- a/src/ui/canvas/windows/Files.cpp
+++ b/src/ui/canvas/windows/Files.cpp
@@ -7,6 +7,8 @@
 
 #include <shlobj.h>
 #include <windef.h> // for MAX_PATH
+#include "system/Win32UTF8PathGuard.hpp"
+
 #include <string>
 
 /**

--- a/test/src/TestUTF8Win.cpp
+++ b/test/src/TestUTF8Win.cpp
@@ -3,9 +3,11 @@
 
 #include "system/UTF8Win32.hpp"
 #include "system/FileUtil.hpp"
+#include "system/OpenPathFile.hpp"
 #include "system/Path.hpp"
 #include "io/FileOutputStream.hxx"
 #include "io/FileReader.hxx"
+#include "util/Macros.hpp"
 #include "util/SpanCast.hxx"
 #include "util/UTF8.hpp"
 #include "util/StringAPI.hxx"
@@ -19,6 +21,42 @@
 extern "C" {
 #include "tap.h"
 }
+
+/**
+ * UTF-8 path samples exercised on Windows CI (Wine). Covers scripts
+ * that use different legacy ANSI code pages (CP1251, GBK, CP932, …).
+ */
+struct ScriptSample {
+  const char *utf8;
+  std::size_t wide_chars;
+};
+
+static constexpr ScriptSample SCRIPT_SAMPLES[] = {
+  /* Russian Линар (#2824 reporter path) */
+  { "\xd0\x9b\xd0\xb8\xd0\xbd\xd0\xb0\xd1\x80", 5 },
+  /* Ukrainian Київ */
+  { "\xd0\x9a\xd0\xb8\xd1\x97\xd0\xb2", 4 },
+  /* Greek Αθήνα */
+  { "\xce\x91\xce\xb8\xce\xae\xce\xbd\xce\xb1", 5 },
+  /* Hebrew עברית */
+  { "\xd7\xa2\xd7\x91\xd7\xa8\xd7\x99\xd7\xaa", 5 },
+  /* Arabic العربية */
+  { "\xd8\xa7\xd9\x84\xd8\xb9\xd8\xb1\xd8\xa8\xd9\x8a\xd8\xa9", 7 },
+  /* Telugu తెలుగు */
+  { "\xe0\xb0\xa4\xe0\xb1\x86\xe0\xb0\xb2\xe0\xb1\x81\xe0\xb0\x97\xe0\xb1\x81", 6 },
+  /* Vietnamese Việt */
+  { "Vi\xe1\xbb\x87t", 4 },
+  /* Chinese 北京 */
+  { "\xe5\x8c\x97\xe4\xba\xac", 2 },
+  /* Japanese 東京 */
+  { "\xe6\x9d\xb1\xe4\xba\xac", 2 },
+  /* Korean 한국 */
+  { "\xed\x95\x9c\xea\xb5\xad", 2 },
+  /* Western European café */
+  { "caf\xc3\xa9", 4 },
+  /* Supplementary-plane emoji (UTF-16 surrogate pair) */
+  { "\xf0\x9f\x98\x80", 2 },
+};
 
 class FindUtf8Igc final : public File::Visitor {
 public:
@@ -113,37 +151,86 @@ TestUtf8FileRoundTrip() noexcept
 }
 
 /**
- * Directory Create/Exists/IsWritable/Remove with a Cyrillic UTF-8 name
- * (same class of path as issue #2824).
+ * UTF8ToWide / WideToUTF8 for each script sample.
+ * 3 assertions per sample.
  */
 static void
-TestUtf8Directory() noexcept
+TestScriptConversions() noexcept
 {
+  for (const auto &sample : SCRIPT_SAMPLES) {
+    const std::string_view utf8{sample.utf8};
+    ok1(ValidateUTF8(utf8));
+    ok1(UTF8ToWide(utf8).size() == sample.wide_chars);
+    ok1(WideToUTF8(UTF8ToWide(utf8)) == sample.utf8);
+  }
+}
+
+/**
+ * Directory Create/Exists/IsWritable/Remove for each script.
+ * Also writes a small file via OpenPathFile under that directory.
+ * 8 assertions per sample.
+ */
+static void
+TestScriptDirectories() noexcept
+{
+  constexpr unsigned PER_SAMPLE = 8;
+  constexpr unsigned TOTAL = PER_SAMPLE * ARRAY_SIZE(SCRIPT_SAMPLES);
+
   const AllocatedPath dir = MakeTempDir();
   if (dir == nullptr) {
-    skip(5, 0, "temp directory failed");
+    skip(TOTAL, 0, "temp directory failed");
     return;
   }
 
-  /* Линар */
-  static constexpr const char *const utf8_subdir =
-    "\xd0\x9b\xd0\xb8\xd0\xbd\xd0\xb0\xd1\x80";
-  const AllocatedPath sub = AllocatedPath::Build(dir, Path(utf8_subdir));
+  static constexpr std::string_view PAYLOAD = "utf8\n";
 
-  Directory::Create(sub);
-  ok1(Directory::Exists(sub));
-  ok1(ValidateUTF8(sub.c_str()));
-  ok1(Directory::IsWritable(sub));
-  ok1(Directory::Remove(sub));
-  ok1(!Directory::Exists(sub));
+  for (const auto &sample : SCRIPT_SAMPLES) {
+    const AllocatedPath sub =
+      AllocatedPath::Build(dir, Path(sample.utf8));
+
+    Directory::Create(sub);
+    ok1(Directory::Exists(sub));
+    ok1(ValidateUTF8(sub.c_str()));
+    ok1(Directory::IsWritable(sub));
+
+    const AllocatedPath file =
+      AllocatedPath::Build(sub, Path("t.txt"));
+    FILE *out = OpenPathFile(file, "wb");
+    ok1(out != nullptr);
+    if (out != nullptr) {
+      const auto n = fwrite(PAYLOAD.data(), 1, PAYLOAD.size(), out);
+      fclose(out);
+      ok1(n == PAYLOAD.size());
+    } else {
+      ok1(false);
+    }
+
+    ok1(File::Exists(file));
+    File::Delete(file);
+
+    ok1(Directory::Remove(sub));
+    ok1(!Directory::Exists(sub));
+  }
 
   Directory::Remove(dir);
+}
+
+/**
+ * Bytes that are valid CP1251 for "Ли" must not be accepted as UTF-8.
+ * (Do not call UTF8ToWide here — debug builds assert on invalid input.)
+ */
+static void
+TestRejectAcpBytes() noexcept
+{
+  static constexpr char cp1251_li[] = { '\xcb', '\xe8', '\0' };
+  ok1(!ValidateUTF8(cp1251_li));
 }
 
 int
 main()
 {
-  plan_tests(23);
+  constexpr unsigned N_SCRIPTS = ARRAY_SIZE(SCRIPT_SAMPLES);
+  plan_tests(12 + 6 + 3 * N_SCRIPTS + 8 * N_SCRIPTS + 1);
 
   /* Returned size() must equal character count (no null in size) */
   ok1(UTF8ToWide(std::string_view("")).size() == 0);
@@ -169,7 +256,9 @@ main()
   ok1(WideToUTF8((const wchar_t *)nullptr).empty());
 
   TestUtf8FileRoundTrip();
-  TestUtf8Directory();
+  TestScriptConversions();
+  TestScriptDirectories();
+  TestRejectAcpBytes();
 
   return exit_status();
 }

--- a/test/src/TestUTF8Win.cpp
+++ b/test/src/TestUTF8Win.cpp
@@ -43,8 +43,7 @@ public:
 };
 
 /**
- * Create an empty temp directory with an ASCII path (so teardown via
- * Directory::Remove remains reliable).
+ * Create an empty temp directory (UTF-8 Path from GetTempPathW).
  */
 static AllocatedPath
 MakeTempDir() noexcept
@@ -113,10 +112,38 @@ TestUtf8FileRoundTrip() noexcept
   Directory::Remove(dir);
 }
 
+/**
+ * Directory Create/Exists/IsWritable/Remove with a Cyrillic UTF-8 name
+ * (same class of path as issue #2824).
+ */
+static void
+TestUtf8Directory() noexcept
+{
+  const AllocatedPath dir = MakeTempDir();
+  if (dir == nullptr) {
+    skip(5, 0, "temp directory failed");
+    return;
+  }
+
+  /* Линар */
+  static constexpr const char *const utf8_subdir =
+    "\xd0\x9b\xd0\xb8\xd0\xbd\xd0\xb0\xd1\x80";
+  const AllocatedPath sub = AllocatedPath::Build(dir, Path(utf8_subdir));
+
+  Directory::Create(sub);
+  ok1(Directory::Exists(sub));
+  ok1(ValidateUTF8(sub.c_str()));
+  ok1(Directory::IsWritable(sub));
+  ok1(Directory::Remove(sub));
+  ok1(!Directory::Exists(sub));
+
+  Directory::Remove(dir);
+}
+
 int
 main()
 {
-  plan_tests(18);
+  plan_tests(23);
 
   /* Returned size() must equal character count (no null in size) */
   ok1(UTF8ToWide(std::string_view("")).size() == 0);
@@ -142,6 +169,7 @@ main()
   ok1(WideToUTF8((const wchar_t *)nullptr).empty());
 
   TestUtf8FileRoundTrip();
+  TestUtf8Directory();
 
   return exit_status();
 }


### PR DESCRIPTION
## Summary
- Fix WIN64/WIN64OPENGL startup assert in `UTF8ToWide` when the user profile path contains non-ASCII characters (e.g. Cyrillic account names) by obtaining paths via Win32 `*W` APIs and finishing Directory file ops on the wide path (#2824).
- Switch remaining Windows I/O (ZIP, JPEG/TIFF, Lua, FreeType fonts, FileCache, Volkslogger, VALI, serial ports) to UTF-8-safe opens (`OpenPathFile` / `CreateFileW` / memory faces).
- Add `Win32UTF8PathGuard` so ANSI path macros cannot silently resolve to `*A` APIs, and expand `TestUTF8Win` script coverage (RU/UK/EL/HE/AR/TE/VI/CJK/KO/Latin/emoji) for WIN64 CI under Wine.

## Test plan
- [x] `make TARGET=WIN64 USE_CCACHE=y WERROR=y` and `TARGET=WIN64OPENGL`
- [x] `wine output/WIN64/bin/TestUTF8Win.exe` (151 tests)
- [x] Reporter retest of testing WIN64 / WIN64OPENGL builds from a non-ASCII profile path (issue #2824)
- [x] CI `WIN64` / `WIN64OPENGL` `check` on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows crash when exiting FLARM radar after horizontal swiping.
  * Fixed startup crashes when user profile paths contain non-ASCII characters.
  * Improved support for opening ZIP maps, JPEG/TIFF images, Lua scripts, fonts, and cached files from Unicode paths.
  * Improved handling of Unicode serial-port, flight-download, and filesystem paths.
  * Improved reliability when accessing files and folders with international characters.
* **Tests**
  * Added coverage for international filenames, supplementary Unicode characters, file operations, and invalid path encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->