### PR TITLE
MainWindow: Fix overlay zoom button visibility and layout

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -44,6 +44,8 @@ Version 7.45 - not yet released
   - fix crash when opening the aircraft type picker without a network
     connection
 * ui
+  - Fix zoom buttons still appearing when "Show Zoom button" is off
+    while Menu or Quick Menu is on #2830
   - add help text for plane ``Max. Cruise Speed`` #1134
   - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
     toggles (also fixes north-up so it no longer changes auto-zoom)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -46,6 +46,10 @@ Version 7.45 - not yet released
 * ui
   - Fix zoom buttons still appearing when "Show Zoom button" is off
     while Menu or Quick Menu is on #2830
+  - Keep map overlay zoom with the menu/QuickMenu buttons top-right
+    (+ above -), including when zoom is the only overlay button
+  - Keep overlay buttons visible during bottom QuestionWidgets
+    (airspace / task prompts) #2830
   - add help text for plane ``Max. Cruise Speed`` #1134
   - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
     toggles (also fixes north-up so it no longer changes auto-zoom)

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -48,8 +48,8 @@ Version 7.45 - not yet released
     while Menu or Quick Menu is on #2830
   - Keep map overlay zoom with the menu/QuickMenu buttons top-right
     (+ above -), including when zoom is the only overlay button
-  - Keep overlay buttons visible during bottom QuestionWidgets
-    (airspace / task prompts) #2830
+  - Keep overlay buttons visible during airspace and task prompts
+    #2830
   - add help text for plane ``Max. Cruise Speed`` #1134
   - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
     toggles (also fixes north-up so it no longer changes auto-zoom)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -58,13 +58,6 @@
 static constexpr unsigned separator_height = 2;
 
 [[gnu::pure]]
-static bool
-ShowMapOverlayZoomButtons(const UISettings &settings) noexcept
-{
-  return settings.show_zoom_button;
-}
-
-[[gnu::pure]]
 static PixelRect
 GetMapOverlayButtonRect(const PixelRect rc, int top) noexcept
 {
@@ -105,8 +98,7 @@ MainWindow::GetShowMenuButtonRect(const PixelRect rc) noexcept
 
 /**
  * The width of the overlay button column in the top right corner, or 0
- * if there is none.  The zoom buttons alone are placed in the bottom
- * left corner and do not occupy this column.
+ * if there is none.
  */
 [[gnu::pure]]
 static unsigned
@@ -114,7 +106,8 @@ GetMapOverlayTopRightWidth(const PixelRect rc) noexcept
 {
   const UISettings &settings = CommonInterface::GetUISettings();
 
-  if (!settings.show_menu_button && !settings.show_quickmenu_button)
+  if (!settings.show_menu_button && !settings.show_quickmenu_button &&
+      !settings.show_zoom_button)
     return 0;
 
   const PixelRect button_rc = GetMapOverlayButtonRect(rc, rc.top);
@@ -142,46 +135,20 @@ MainWindow::GetShowZoomButtonRect(const PixelRect rc,
 {
   const UISettings &settings = CommonInterface::GetUISettings();
   const unsigned padding = Layout::GetTextPadding();
-  const unsigned size = Layout::GetMaximumControlHeight();
 
-  const bool stack_top_right =
-    (settings.show_menu_button || settings.show_quickmenu_button) &&
-    ShowMapOverlayZoomButtons(settings);
+  int top = rc.top + int(padding);
+  if (settings.show_quickmenu_button)
+    top = GetShowQuickMenuButtonRect(rc).bottom + int(padding);
+  else if (settings.show_menu_button)
+    top = GetShowMenuButtonRect(rc).bottom + int(padding);
 
-  if (stack_top_right) {
-    int top;
-    if (settings.show_quickmenu_button)
-      top = GetShowQuickMenuButtonRect(rc).bottom + int(padding);
-    else
-      top = GetShowMenuButtonRect(rc).bottom + int(padding);
-
-    if (sign == ShowZoomButton::Sign::ZOOM_IN) {
-      const PixelRect zoom_out =
-        GetShowZoomButtonRect(rc, ShowZoomButton::Sign::ZOOM_OUT);
-      top = zoom_out.bottom + int(padding);
-    }
-
-    return GetMapOverlayButtonRect(rc, top);
+  if (sign == ShowZoomButton::Sign::ZOOM_OUT) {
+    const PixelRect zoom_in =
+      GetShowZoomButtonRect(rc, ShowZoomButton::Sign::ZOOM_IN);
+    top = zoom_in.bottom + int(padding);
   }
 
-  const int scale_h =
-    int(GetLook().map.overlay.map_scale_left_icon.GetSize().height);
-  int bottom = rc.bottom - scale_h -
-    (sign == ShowZoomButton::Sign::ZOOM_IN ? int(size) : 0);
-  int top = bottom - int(size);
-  int left = rc.left + int(padding);
-  int right = left + int(size);
-
-  if (top < rc.top)
-    top = rc.top;
-  if (bottom > rc.bottom)
-    bottom = rc.bottom;
-  if (bottom <= top)
-    bottom = top + int(size);
-  if (right <= left)
-    right = left + int(size);
-
-  return PixelRect(left, top, right, bottom);
+  return GetMapOverlayButtonRect(rc, top);
 }
 
 #ifdef ANDROID
@@ -362,7 +329,7 @@ MainWindow::UpdateMapOverlayButtonLayout() noexcept
 {
   const bool overlay_buttons_active =
     widget == nullptr && map != nullptr &&
-    !CommonInterface::GetUIState().pages.special_page.IsDefined();
+    PageActions::AllowMapOverlayButtons();
 
   if (show_menu_button != nullptr) {
     show_menu_button->SetVisible(overlay_buttons_active);
@@ -439,7 +406,7 @@ MainWindow::ReinitialiseMapOverlayButtons() noexcept
     show_quickmenu_button = nullptr;
   }
 
-  if (ShowMapOverlayZoomButtons(settings)) {
+  if (settings.show_zoom_button) {
     if (show_zoom_out_button == nullptr) {
       show_zoom_out_button = new ShowZoomButton();
       show_zoom_out_button->Create(*this, look->dialog.button,

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -61,7 +61,7 @@ static constexpr unsigned separator_height = 2;
 static bool
 ShowMapOverlayZoomButtons(const UISettings &settings) noexcept
 {
-  return settings.show_zoom_button || settings.show_menu_button;
+  return settings.show_zoom_button;
 }
 
 [[gnu::pure]]

--- a/src/Menu/ShowButton.cpp
+++ b/src/Menu/ShowButton.cpp
@@ -6,8 +6,7 @@
 #include "Renderer/SymbolButtonRenderer.hpp"
 #include "Look/ButtonLook.hpp"
 #include "Input/InputEvents.hpp"
-#include "Interface.hpp"
-#include "UIState.hpp"
+#include "PageActions.hpp"
 
 #include <memory>
 
@@ -21,7 +20,8 @@
 #endif
 
 /**
- * Map overlay buttons (menu, QuickMenu, zoom) are hidden on special pages.
+ * Map overlay buttons (menu, QuickMenu, zoom) are hidden on special
+ * pages; see PageActions::AllowMapOverlayButtons().
  */
 class ShowMapOverlayButtonRenderer : public ButtonRenderer {
   std::unique_ptr<ButtonRenderer> inner;
@@ -36,7 +36,7 @@ public:
 
   void DrawButton(Canvas &canvas, const PixelRect &rc,
                   ButtonState state) const noexcept override {
-    if (CommonInterface::GetUIState().pages.special_page.IsDefined())
+    if (!PageActions::AllowMapOverlayButtons())
       return;
 
     inner->DrawButton(canvas, rc, state);

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -703,3 +703,17 @@ PageActions::SetCustomBottom(Widget *widget)
   state.special_page.bottom = PageLayout::Bottom::CUSTOM;
   CommonInterface::main_window->SetBottomWidget(widget);
 }
+
+bool
+PageActions::AllowMapOverlayButtons() noexcept
+{
+  const PageLayout &special_page =
+    CommonInterface::GetUIState().pages.special_page;
+  if (!special_page.IsDefined())
+    return true;
+
+  /* SetCustomBottom() marks special_page so RestoreBottom() can undo
+     it; the map remains active and overlay buttons should stay. */
+  return special_page.IsMapMain() &&
+    special_page.bottom == PageLayout::Bottom::CUSTOM;
+}

--- a/src/PageActions.hpp
+++ b/src/PageActions.hpp
@@ -130,4 +130,13 @@ namespace PageActions
    * MainWindow::SetBottomWidget().  Call RestoreBottom() to undo this.
    */
   void SetCustomBottom(Widget *widget);
+
+  /**
+   * Whether map overlay buttons (menu, QuickMenu, zoom) should be
+   * shown.  False for most special pages (e.g. pan fullscreen); true
+   * when #special_page is only a #SetCustomBottom() overlay such as a
+   * QuestionWidget on an otherwise normal map page.
+   */
+  [[gnu::pure]]
+  bool AllowMapOverlayButtons() noexcept;
 };


### PR DESCRIPTION
## Summary
- Honor the Screen Layout **Show Zoom button** setting: zoom overlays no longer appear just because Menu is on (#2830).
- Always stack zoom with menu/QuickMenu top-right (`+` above `-`), including when zoom is the only overlay button.
- Keep overlay buttons visible during bottom QuestionWidgets (airspace / task prompts); pan fullscreen and other special pages still hide them.

## Test plan
- [x] Config: Menu on, Quick Menu on, Zoom off → no `+`/`-` on the map
- [x] Config: Zoom on alone → `+` then `-` top-right
- [x] Config: Menu + Quick Menu + Zoom on → menu, quick menu, `+`, `-` top-right
- [x] Trigger an airspace or task-advance QuestionWidget → overlay buttons stay visible
- [x] Enter pan (fullscreen map) → overlay buttons hidden; leave pan → restored
- [x] Open FLARM radar / other full-page widget → overlay buttons hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zoom controls no longer appear when disabled while menus are open.
  * Map overlay zoom buttons remain aligned with the top-right menu controls.
  * Overlay buttons stay visible during bottom question prompts.
  * Improved button visibility across map and special-page layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->