### PR TITLE
Widget: Fix WIN64 crash when scrolling bordered form panels

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -251,6 +251,7 @@ Version 7.45 - not yet released
     characters (e.g. Cyrillic account names) #2824
   - open ZIP maps, JPEG/TIFF images, Lua scripts, fonts, and cache files
     from folders with non-English characters on Windows
+  - fix crash when scrolling the Weather → RASP settings page #2828
 * devices
   - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
     shows other gliders on the FLARM radar and map

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -73,7 +73,12 @@ RowFormWidget::Row::GetMinimumHeight(const DialogLook &look,
     return Layout::GetMinimumControlHeight();
   }
 
-  return window->GetSize().height;
+  /* Use the window rectangle (outer size on GDI), not GetSize()
+     (client area).  Move() sizes the outer HWND; feeding client
+     height back into Move() shrinks bordered controls on every
+     layout pass (e.g. VScrollPanel smooth scroll) until height
+     reaches 0 and PaintCanvas asserts. */
+  return window->GetPosition().GetHeight();
 }
 
 unsigned
@@ -103,7 +108,7 @@ RowFormWidget::Row::GetMaximumHeight(const DialogLook &look,
     return 4096;
   }
 
-  return window->GetSize().height;
+  return window->GetPosition().GetHeight();
 }
 
 inline void
@@ -518,9 +523,15 @@ RowFormWidget::Show(const PixelRect &rc) noexcept
 void
 RowFormWidget::Move(const PixelRect &rc) noexcept
 {
+  /* Pure scroll origin changes only move the panel; skip row
+     re-layout so bordered GENERIC controls are not resized. */
+  const bool size_changed = !IsDefined() ||
+    GetWindow().GetSize() != rc.GetSize();
+
   WindowWidget::Move(rc);
 
-  UpdateLayout();
+  if (size_changed)
+    UpdateLayout();
 }
 
 bool

--- a/src/Widget/RowFormWidget.cpp
+++ b/src/Widget/RowFormWidget.cpp
@@ -523,15 +523,9 @@ RowFormWidget::Show(const PixelRect &rc) noexcept
 void
 RowFormWidget::Move(const PixelRect &rc) noexcept
 {
-  /* Pure scroll origin changes only move the panel; skip row
-     re-layout so bordered GENERIC controls are not resized. */
-  const bool size_changed = !IsDefined() ||
-    GetWindow().GetSize() != rc.GetSize();
-
   WindowWidget::Move(rc);
 
-  if (size_changed)
-    UpdateLayout();
+  UpdateLayout();
 }
 
 bool

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -282,10 +282,14 @@ VScrollWidget::KeyPress(unsigned key_code) noexcept
 void
 VScrollWidget::OnVScrollPanelChange() noexcept
 {
-  if (visible) {
-    UpdateVirtualHeight(GetWindow().GetClientRect());
-    widget->Move(GetWindow().GetVirtualRect());
-  }
+  if (!visible)
+    return;
+
+  /* Origin-only changes must not remeasure virtual height: form
+     widgets that report size from their HWND would feedback into
+     SetVirtualHeight and force a full child relayout on every
+     smooth-scroll tick (WIN64 crash with bordered controls). */
+  widget->Move(GetWindow().GetVirtualRect());
 }
 
 bool

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -145,12 +145,10 @@ VScrollWidget::Show(const PixelRect &rc) noexcept
   visible = true;
   widget->Show(GetWindow().GetVirtualRect());
 
-  if (reserve_scrollbar) {
-    /* Rich-text content may update its maximum size after the
-       initial Show (e.g. after text layout).  Re-measure. */
-    UpdateVirtualHeight(rc);
-    widget->Move(GetWindow().GetVirtualRect());
-  }
+  /* Remeasure after the child has laid out.  Forms may change
+     row sizes during Show(); rich text finishes text layout. */
+  UpdateVirtualHeight(rc);
+  widget->Move(GetWindow().GetVirtualRect());
 }
 
 bool
@@ -282,14 +280,10 @@ VScrollWidget::KeyPress(unsigned key_code) noexcept
 void
 VScrollWidget::OnVScrollPanelChange() noexcept
 {
-  if (!visible)
-    return;
-
-  /* Origin-only changes must not remeasure virtual height: form
-     widgets that report size from their HWND would feedback into
-     SetVirtualHeight and force a full child relayout on every
-     smooth-scroll tick (WIN64 crash with bordered controls). */
-  widget->Move(GetWindow().GetVirtualRect());
+  if (visible) {
+    UpdateVirtualHeight(GetWindow().GetClientRect());
+    widget->Move(GetWindow().GetVirtualRect());
+  }
 }
 
 bool


### PR DESCRIPTION
## Summary
- Fixes a WIN64 debug assert (`Canvas.hpp:54`, `new_size.height > 0`) when scrolling Configuration → Weather → RASP (#2828).
- On GDI, GENERIC `RowFormWidget` rows used client height (`GetSize()`) as input to `Move()`, which sizes the outer HWND; bordered controls (RASP colorbar) shrank on every smooth-scroll layout pass until height reached 0.
- Use outer window height via `GetPosition()`, skip row re-layout on position-only moves, and stop remeasuring virtual height on scroll origin changes.

## Test plan
- [x] WIN64 debug build: Configuration → Weather → RASP (Expert on, content tall enough for a scrollbar)
- [x] Click the scrollbar track below the thumb (page down) — must not assert/crash
- [x] Drag the thumb and use the mouse wheel on that page
- [x] Sanity-check another tall config page (e.g. Terrain with preview) and Quick Guide rich-text scroll
- [x] UNIX build still runs the same RASP page without layout regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a Windows UI crash when scrolling the Weather → RASP settings page.
  * Improved layout stability for bordered controls during window resizing and scrolling.
  * Prevented unnecessary layout updates when panels are moved without changing size.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->