### PR TITLE
ui: Faster rich-text scrolling and What's New list wrap

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -152,13 +152,8 @@ Version 7.45 - not yet released
     scroll height before wrapping, skip FreeType for runs that clearly
     fit or overflow by character budget, and use one measure for
     typical bullets
-  - Speed up scrolling long rich-text pages (What's New, Credits):
-    size the text window to the viewport instead of the full content
-    height so each scroll frame does not move or clear a tall window;
-    cache a painted strip and pan it when scrolling
-
-  - Treat Markdown list items as one paragraph (indented continuations
-    stay in the same bullet with hanging indent), including What's New
+  - Speed up scrolling long What's New and Credits pages
+  - Keep multi-line What's New bullets together with hanging indent
   - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
     button are reachable from the keyboard
   - Add Expert Look → Screen Layout setting "Display type" (LCD /

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -152,6 +152,11 @@ Version 7.45 - not yet released
     scroll height before wrapping, skip FreeType for runs that clearly
     fit or overflow by character budget, and use one measure for
     typical bullets
+  - Speed up scrolling long rich-text pages (What's New, Credits):
+    size the text window to the viewport instead of the full content
+    height so each scroll frame does not move or clear a tall window;
+    cache a painted strip and pan it when scrolling
+
   - Treat Markdown list items as one paragraph (indented continuations
     stay in the same bullet with hanging indent), including What's New
   - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -152,6 +152,8 @@ Version 7.45 - not yet released
     scroll height before wrapping, skip FreeType for runs that clearly
     fit or overflow by character budget, and use one measure for
     typical bullets
+  - Treat Markdown list items as one paragraph (indented continuations
+    stay in the same bullet with hanging indent), including What's New
   - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
     button are reachable from the keyboard
   - Add Expert Look → Screen Layout setting "Display type" (LCD /

--- a/build/test.mk
+++ b/build/test.mk
@@ -4,10 +4,10 @@ MORE_SCREEN_SOURCES = \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(SRC)/Look/FontDescription.cpp \
 	$(SRC)/Screen/Layout.cpp \
-	$(SRC)/Hardware/DisplayDPI.cpp
+	$(SRC)/Hardware/DisplayDPI.cpp \
+	$(SRC)/Hardware/CPU.cpp
 ifeq ($(TARGET_IS_KOBO),y)
 MORE_SCREEN_SOURCES += \
-	$(SRC)/Hardware/CPU.cpp \
 	$(SRC)/Hardware/RotateDisplay.cpp
 endif
 

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -563,9 +563,10 @@ dlgQuickGuideShowModal(bool force_info)
   }
 
   /* ---- What's New page (conditional, shown on version change) ---- */
-  /* Body is Markdown generated at build time from the first block of NEWS.txt
-     (see tools/news_to_quickguide_md.py and QuickGuideNEWS.hpp).  The Credits
-     dialog still loads the full gzipped NEWS history as plain text. */
+  /* Body is Markdown generated at build time from the first block of
+     NEWS.txt (tools/news_to_quickguide_md.py → QuickGuideNEWS.hpp).
+     Each NEWS bullet is one list-item paragraph.  Credits still loads
+     the full gzipped NEWS as plain text. */
   if (news_needed && quick_guide_news_markdown[0] != '\0') {
     state.news_page_index = pager->GetSize();
 

--- a/src/Form/VScrollPanel.cpp
+++ b/src/Form/VScrollPanel.cpp
@@ -6,6 +6,7 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/event/KeyCode.hpp"
 #include "Asset.hpp"
+#include "Hardware/CPU.hpp"
 #include "Screen/Layout.hpp"
 #include "Math/Point2D.hpp"
 #include "util/StringAPI.hxx"
@@ -61,12 +62,13 @@ VScrollPanel::GetScrollStep() const noexcept
 
 /**
  * Can the user scroll with pixel precision?  Fast displays get
- * kinetic/smooth scrolling; e-paper snaps to avoid refresh storms.
+ * kinetic/smooth scrolling; e-paper and slow CPUs snap (same gate as
+ * map pan animations in InputEventsMap).
  */
 static bool
 UsePixelPan() noexcept
 {
-  return !HasEPaper();
+  return !HasEPaper() && !IsSlowCPU();
 }
 
 void

--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -135,8 +135,20 @@ public:
   void SetVirtualHeight(unsigned _virtual_height) noexcept;
 
   /**
+   * Current scroll offset in pixels (0 = top).
+   */
+  [[gnu::pure]]
+  unsigned GetOrigin() const noexcept {
+    return origin;
+  }
+
+  /**
    * Returns the position of the virtual rectangle within this window.
    * If the user has scrolled down, then its #top field is negative.
+   *
+   * Prefer #GetPhysicalRect for rich-text children that paint a
+   * viewport strip using #GetOrigin (avoids moving a full-height
+   * window on every scroll tick).
    */
   [[gnu::pure]]
   PixelRect GetVirtualRect() const noexcept {
@@ -159,6 +171,14 @@ public:
         scroll_bar.GetLeft(size),
         size.height,
       }};
+  }
+
+  /**
+   * #GetPhysicalRect for the panel's current size.
+   */
+  [[gnu::pure]]
+  PixelRect GetPhysicalRect() const noexcept {
+    return GetPhysicalRect(GetSize());
   }
 
 private:

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -270,6 +270,34 @@ ArrowPagerWidget::MoveChromeFocusUp() noexcept
 }
 
 bool
+ArrowPagerWidget::FocusChromeStart() noexcept
+{
+  if (previous_button.IsEnabled())
+    previous_button.SetFocus();
+  else if (next_button.IsEnabled())
+    next_button.SetFocus();
+  else
+    close_button.SetFocus();
+  return true;
+}
+
+bool
+ArrowPagerWidget::PageHandsOffToChrome(bool key_up) const noexcept
+{
+  const Widget &page = GetCurrentWidget();
+  if (auto *qg = dynamic_cast<const QuickGuidePageWidget *>(&page))
+    /* Down: only from the bottom bar (content goes there first).
+       Up: from content at the top (bottom bar handles Up itself). */
+    return key_up || qg->IsBottomBarFocused();
+
+  /* Credits / Checklist: reserved-scrollbar rich text. */
+  if (auto *vs = dynamic_cast<const VScrollWidget *>(&page))
+    return vs->ReservesScrollbar();
+
+  return false;
+}
+
+bool
 ArrowPagerWidget::MoveChromeFocusDown() noexcept
 {
   if (close_button.HasFocus())
@@ -288,22 +316,7 @@ ArrowPagerWidget::MoveChromeFocusDown() noexcept
     return true;
   }
 
-  /* Quick Guide bottom bar → chrome.  Other pages return false so
-     WndForm can walk TabStops (z-order FocusNext would bounce back). */
-  auto *qg = dynamic_cast<QuickGuidePageWidget *>(&GetCurrentWidget());
-  if (qg == nullptr || !qg->IsBottomBarFocused())
-    return false;
-
-  if (previous_button.IsEnabled()) {
-    previous_button.SetFocus();
-    return true;
-  }
-  if (next_button.IsEnabled()) {
-    next_button.SetFocus();
-    return true;
-  }
-  close_button.SetFocus();
-  return true;
+  return PageHandsOffToChrome(false) && FocusChromeStart();
 }
 
 bool
@@ -317,7 +330,15 @@ ArrowPagerWidget::KeyPress(unsigned key_code) noexcept
 
   switch (key_code) {
   case KEY_UP:
-    return MoveChromeFocusUp();
+    if (MoveChromeFocusUp())
+      return true;
+    /* Content at top declined Up; rich-text OnKeyCheck would
+       otherwise swallow further Ups. */
+    if (PageHandsOffToChrome(true)) {
+      close_button.SetFocus();
+      return true;
+    }
+    return false;
 
   case KEY_DOWN:
     return MoveChromeFocusDown();

--- a/src/Widget/ArrowPagerWidget.hpp
+++ b/src/Widget/ArrowPagerWidget.hpp
@@ -150,4 +150,14 @@ private:
   /** Up/Down among prev / next / Close (and into the page). */
   bool MoveChromeFocusUp() noexcept;
   bool MoveChromeFocusDown() noexcept;
+
+  /** Focus prev, else next, else Close. */
+  bool FocusChromeStart() noexcept;
+
+  /**
+   * Whether declined page Up/Down should move to chrome (rich-text
+   * scroll pages), not Configuration form panels.
+   */
+  [[gnu::pure]]
+  bool PageHandsOffToChrome(bool key_up) const noexcept;
 };

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -143,12 +143,22 @@ VScrollWidget::Show(const PixelRect &rc) noexcept
   UpdateVirtualHeight(rc);
 
   visible = true;
-  widget->Show(GetWindow().GetVirtualRect());
 
-  /* Remeasure after the child has laid out.  Forms may change
-     row sizes during Show(); rich text finishes text layout. */
-  UpdateVirtualHeight(rc);
-  widget->Move(GetWindow().GetVirtualRect());
+  if (reserve_scrollbar) {
+    /* Viewport-sized child: paint uses VScrollPanel::GetOrigin().
+       Avoids Move()/Invalidate of a full virtual-height window on
+       every smooth-scroll tick. */
+    widget->Show(GetWindow().GetPhysicalRect());
+    UpdateVirtualHeight(rc);
+    widget->Move(GetWindow().GetPhysicalRect());
+  } else {
+    widget->Show(GetWindow().GetVirtualRect());
+
+    /* Remeasure after the child has laid out.  Forms may change
+       row sizes during Show(). */
+    UpdateVirtualHeight(rc);
+    widget->Move(GetWindow().GetVirtualRect());
+  }
 }
 
 bool
@@ -180,7 +190,9 @@ VScrollWidget::Move(const PixelRect &rc) noexcept
      and child widget changes size) */
   if (visible) {
     UpdateVirtualHeight(rc);
-    widget->Move(GetWindow().GetVirtualRect());
+    widget->Move(reserve_scrollbar
+                 ? GetWindow().GetPhysicalRect()
+                 : GetWindow().GetVirtualRect());
   }
 }
 
@@ -280,10 +292,19 @@ VScrollWidget::KeyPress(unsigned key_code) noexcept
 void
 VScrollWidget::OnVScrollPanelChange() noexcept
 {
-  if (visible) {
-    UpdateVirtualHeight(GetWindow().GetClientRect());
-    widget->Move(GetWindow().GetVirtualRect());
+  if (!visible)
+    return;
+
+  if (reserve_scrollbar) {
+    /* Origin-only updates already Invalidate() the panel.  Do not
+       Move() the child (Window::Move always invalidates, and the
+       child stays at the physical viewport).  Resize still goes
+       through VScrollWidget::Move. */
+    return;
   }
+
+  UpdateVirtualHeight(GetWindow().GetClientRect());
+  widget->Move(GetWindow().GetVirtualRect());
 }
 
 bool

--- a/src/Widget/VScrollWidget.hpp
+++ b/src/Widget/VScrollWidget.hpp
@@ -16,9 +16,11 @@ struct DialogLook;
  *
  * When @a reserve_scrollbar is true the child widget's width is
  * reduced by the scrollbar width so content never hides behind the
- * scrollbar.  This mode also enables enhanced keyboard handling
- * (Up/Down scroll only when scrollable) and the gesture callback
- * for horizontal swipes.
+ * scrollbar, and the child is sized to the physical viewport (not
+ * the full virtual content height) so scrolling does not Move() a
+ * tall window each frame.  This mode also enables enhanced keyboard
+ * handling (Up/Down scroll only when scrollable) and the gesture
+ * callback for horizontal swipes.
  *
  * When @a reserve_scrollbar is false (the default) the child widget
  * receives the full rectangle and scrolling only activates when the

--- a/src/Widget/VScrollWidget.hpp
+++ b/src/Widget/VScrollWidget.hpp
@@ -72,6 +72,11 @@ public:
     return *widget;
   }
 
+  [[gnu::pure]]
+  bool ReservesScrollbar() const noexcept {
+    return reserve_scrollbar;
+  }
+
   /**
    * Set a callback for horizontal swipe gestures.
    * Only effective when reserve_scrollbar is true.

--- a/src/ui/canvas/BufferCanvas.cpp
+++ b/src/ui/canvas/BufferCanvas.cpp
@@ -5,11 +5,19 @@
 
 #include <algorithm>
 
+#ifdef USE_MEMORY_CANVAS
+/* Memory BufferCanvas is a VirtualCanvas subclass; Grow lives on the
+   base (historically BufferCanvas was a typedef of VirtualCanvas). */
+void
+VirtualCanvas::Grow(PixelSize new_size) noexcept
+#else
 void
 BufferCanvas::Grow(PixelSize new_size) noexcept
+#endif
 {
   const unsigned old_width = GetWidth();
   const unsigned old_height = GetHeight();
 
-  Resize({std::max(old_width, new_size.width), std::max(old_height, new_size.height)});
+  Resize({std::max(old_width, new_size.width),
+          std::max(old_height, new_size.height)});
 }

--- a/src/ui/canvas/BufferCanvas.hpp
+++ b/src/ui/canvas/BufferCanvas.hpp
@@ -6,8 +6,7 @@
 #ifdef ENABLE_OPENGL
 #include "opengl/BufferCanvas.hpp"
 #elif defined(USE_MEMORY_CANVAS)
-#include "VirtualCanvas.hpp"
-using BufferCanvas = VirtualCanvas;
+#include "memory/BufferCanvas.hpp"
 #else /* GDI */
 #include "gdi/BufferCanvas.hpp"
 #endif

--- a/src/ui/canvas/gdi/BufferCanvas.hpp
+++ b/src/ui/canvas/gdi/BufferCanvas.hpp
@@ -34,4 +34,22 @@ public:
    * Similar to Resize(), but never shrinks the buffer.
    */
   void Grow(PixelSize new_size) noexcept;
+
+  /** No-op on GDI (buffer is always drawable). */
+  void Begin() noexcept {}
+
+  void Begin([[maybe_unused]] Canvas &other) noexcept {}
+
+  /** No-op on GDI. */
+  void End() noexcept {}
+
+  void CopyTo(Canvas &other) noexcept {
+    other.Copy(*this);
+  }
+
+  void CopyTo(Canvas &dest, PixelRect dest_rc,
+              PixelRect src_rc) noexcept {
+    dest.Copy(dest_rc.GetTopLeft(), dest_rc.GetSize(),
+              *this, src_rc.GetTopLeft());
+  }
 };

--- a/src/ui/canvas/memory/BufferCanvas.hpp
+++ b/src/ui/canvas/memory/BufferCanvas.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/canvas/VirtualCanvas.hpp"
+
+/**
+ * Off-screen canvas for the memory backend (#VirtualCanvas with
+ * Begin/End/CopyTo helpers matching OpenGL/GDI).
+ *
+ * #Grow is inherited from #VirtualCanvas (defined in
+ * ui/canvas/BufferCanvas.cpp for this backend).
+ */
+class BufferCanvas : public VirtualCanvas {
+public:
+  using VirtualCanvas::VirtualCanvas;
+
+  /** No-op on memory canvas (buffer is always drawable). */
+  void Begin() noexcept {}
+
+  void Begin([[maybe_unused]] Canvas &other) noexcept {}
+
+  /** No-op on memory canvas. */
+  void End() noexcept {}
+
+  void CopyTo(Canvas &other) noexcept {
+    other.Copy(*this);
+  }
+
+  void CopyTo(Canvas &dest, PixelRect dest_rc,
+              PixelRect src_rc) noexcept {
+    dest.Copy(dest_rc.GetTopLeft(), dest_rc.GetSize(),
+              *this, src_rc.GetTopLeft());
+  }
+};

--- a/src/ui/canvas/opengl/BufferCanvas.cpp
+++ b/src/ui/canvas/opengl/BufferCanvas.cpp
@@ -30,7 +30,8 @@ BufferCanvas::Create(PixelSize new_size) noexcept
     stencil_buffer = new GLRenderBuffer();
     stencil_buffer->Bind();
     PixelSize size = texture->GetAllocatedSize();
-    stencil_buffer->Storage(OpenGL::render_buffer_stencil, size.width, size.height);
+    stencil_buffer->Storage(OpenGL::render_buffer_stencil,
+                            size.width, size.height);
     stencil_buffer->Unbind();
   }
 
@@ -74,7 +75,8 @@ BufferCanvas::Resize(PixelSize new_size) noexcept
 
     stencil_buffer->Bind();
     PixelSize size = texture->GetAllocatedSize();
-    stencil_buffer->Storage(OpenGL::render_buffer_stencil, size.width, size.height);
+    stencil_buffer->Storage(OpenGL::render_buffer_stencil,
+                            size.width, size.height);
     stencil_buffer->Unbind();
   }
 
@@ -82,12 +84,11 @@ BufferCanvas::Resize(PixelSize new_size) noexcept
 }
 
 void
-BufferCanvas::Begin(Canvas &other) noexcept
+BufferCanvas::Activate() noexcept
 {
   assert(IsDefined());
   assert(!active);
-
-  Resize(other.GetSize());
+  assert(frame_buffer != nullptr);
 
   /* activate the frame buffer */
   frame_buffer->Bind();
@@ -112,6 +113,13 @@ BufferCanvas::Begin(Canvas &other) noexcept
   old_translate = OpenGL::translate;
   old_size = OpenGL::viewport_size;
 
+  /* Parent paint may have enabled a screen-space scissor (e.g.
+     VScrollPanel).  That box is wrong for this FBO's viewport and
+     would clip strip fills to a band that shifts with layout. */
+  old_scissor_enabled = glIsEnabled(GL_SCISSOR_TEST);
+  if (old_scissor_enabled)
+    glDisable(GL_SCISSOR_TEST);
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
   old_orientation = OpenGL::display_orientation;
   OpenGL::display_orientation = DisplayOrientation::DEFAULT;
@@ -129,12 +137,10 @@ BufferCanvas::Begin(Canvas &other) noexcept
 }
 
 void
-BufferCanvas::Commit(Canvas &other) noexcept
+BufferCanvas::Deactivate() noexcept
 {
   assert(IsDefined());
   assert(active);
-  assert(GetWidth() == other.GetWidth());
-  assert(GetHeight() == other.GetHeight());
   assert(frame_buffer != nullptr);
 
   assert(OpenGL::translate.x == 0);
@@ -157,12 +163,12 @@ BufferCanvas::Commit(Canvas &other) noexcept
 
   OpenGL::UpdateShaderTranslate();
 
+  if (old_scissor_enabled)
+    glEnable(GL_SCISSOR_TEST);
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
   OpenGL::display_orientation = old_orientation;
 #endif
-
-  /* copy frame buffer to screen */
-  CopyTo(other);
 
 #ifndef NDEBUG
   active = false;
@@ -170,13 +176,67 @@ BufferCanvas::Commit(Canvas &other) noexcept
 }
 
 void
+BufferCanvas::Begin() noexcept
+{
+  Activate();
+}
+
+void
+BufferCanvas::Begin(Canvas &other) noexcept
+{
+  assert(IsDefined());
+
+  Resize(other.GetSize());
+  Activate();
+}
+
+void
+BufferCanvas::End() noexcept
+{
+  Deactivate();
+}
+
+void
+BufferCanvas::Commit(Canvas &other) noexcept
+{
+  assert(IsDefined());
+  assert(active);
+  assert(GetWidth() == other.GetWidth());
+  assert(GetHeight() == other.GetHeight());
+
+  End();
+  CopyTo(other);
+}
+
+void
 BufferCanvas::CopyTo(Canvas &other) noexcept
+{
+  CopyTo(other, other.GetRect(), GetRect());
+}
+
+void
+BufferCanvas::CopyTo([[maybe_unused]] Canvas &dest, PixelRect dest_rc,
+                     PixelRect src_rc) noexcept
 {
   assert(IsDefined());
   assert(frame_buffer != nullptr);
+  assert(!active);
+
+  /* FBO-backed buffers use a flipped texture.  Full-buffer CopyTo is
+     fine (the whole image is inverted as a unit), but a partial source
+     rectangle would otherwise show the strip upside-down and invert
+     scroll direction.  Remap canvas-space Y into the flipped texel
+     space that #GLTexture::Draw expects. */
+  if (texture->IsFlipped()) {
+    const int buffer_h = static_cast<int>(GetHeight());
+    const int src_h = static_cast<int>(src_rc.GetHeight());
+    const int new_top = buffer_h - src_rc.bottom;
+    src_rc.top = new_top;
+    src_rc.bottom = new_top + src_h;
+  }
 
   OpenGL::texture_shader->Use();
 
   texture->Bind();
-  texture->Draw(other.GetRect(), GetRect());
+  texture->Draw(dest_rc, src_rc);
 }

--- a/src/ui/canvas/opengl/BufferCanvas.hpp
+++ b/src/ui/canvas/opengl/BufferCanvas.hpp
@@ -39,6 +39,13 @@ class BufferCanvas : public Canvas {
   PixelPoint old_translate;
   UnsignedPoint2D old_size;
 
+  /**
+   * Screen-space scissor must not clip FBO draws (e.g. #VScrollPanel
+   * leaves GL_SCISSOR_TEST enabled while child OnPaint fills a tall
+   * buffer).
+   */
+  GLboolean old_scissor_enabled = GL_FALSE;
+
 #ifdef SOFTWARE_ROTATE_DISPLAY
   DisplayOrientation old_orientation;
 #endif
@@ -78,11 +85,23 @@ public:
   void Grow(PixelSize new_size) noexcept;
 
   /**
-   * Begin painting to the buffer and to the specified #Canvas.
+   * Begin painting into this buffer's current size (no resize).
+   * Pair with #End.  Does not copy to any on-screen canvas.
+   */
+  void Begin() noexcept;
+
+  /**
+   * Begin painting to the buffer, resizing it to match @a other.
    *
    * @param other an on-screen #Canvas
    */
   void Begin(Canvas &other) noexcept;
+
+  /**
+   * Finish painting started with #Begin; restores GL state.
+   * Does not blit to the screen.
+   */
+  void End() noexcept;
 
   /**
    * Commit the data that was painted into this #BufferCanvas into
@@ -97,4 +116,14 @@ public:
   void Commit(Canvas &other) noexcept;
 
   void CopyTo(Canvas &other) noexcept;
+
+  /**
+   * Copy a source rectangle from this buffer onto @a dest.
+   */
+  void CopyTo(Canvas &dest, PixelRect dest_rc,
+              PixelRect src_rc) noexcept;
+
+private:
+  void Activate() noexcept;
+  void Deactivate() noexcept;
 };

--- a/src/ui/control/List.cpp
+++ b/src/ui/control/List.cpp
@@ -8,6 +8,7 @@
 #include "ui/event/KeyCode.hpp"
 #include "ui/dim/Rect.hpp"
 #include "Asset.hpp"
+#include "Hardware/CPU.hpp"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scissor.hpp"
@@ -20,15 +21,15 @@
 #include <algorithm>
 
 /**
- * Can the user scroll with pixel precision?  This is used on fast
- * displays to give more instant feedback, which feels more slick.  On
- * slow e-paper screens, this is not a good idea.
+ * Can the user scroll with pixel precision?  Fast displays get
+ * kinetic/smooth scrolling; e-paper and slow CPUs snap (same gate as
+ * map pan animations in InputEventsMap).
  */
-[[gnu::const]]
+[[gnu::pure]]
 static bool
 UsePixelPan() noexcept
 {
-  return !HasEPaper();
+  return !HasEPaper() && !IsSlowCPU();
 }
 
 ListControl::ListControl(const DialogLook &_look) noexcept

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -5,7 +5,6 @@
 #include "ui/canvas/TextWrapper.hpp"
 #include "ui/canvas/Font.hpp"
 #include "ui/canvas/Canvas.hpp"
-#include "ui/canvas/SubCanvas.hpp"
 #include "ui/canvas/AnyCanvas.hpp"
 #include "ui/window/ContainerWindow.hpp"
 #include "ui/event/KeyCode.hpp"
@@ -306,7 +305,10 @@ RichTextWindow::EnsureLineLayout() const noexcept
   if (size.width <= unsigned(padding * 2))
     return;
 
-  const unsigned text_width = size.width - padding * 2;
+  const unsigned column_width = size.width - padding * 2;
+  const unsigned text_width = CalcWrapTextWidth(column_width);
+  if (text_width == 0)
+    return;
 
   if (!line_y_offsets.empty() && line_layout_width == text_width)
     return;
@@ -358,8 +360,8 @@ RichTextWindow::EnsureLineLayout() const noexcept
         PixelSize img_size = bmp->GetSize();
         if (img_size.width == 0)
           img_size.width = 1;
-        /* Scale to fit within text_width, maintaining aspect ratio */
-        unsigned target_w = std::min(text_width, img_size.width);
+        /* Scale to fit within the full column (not wrap slack). */
+        unsigned target_w = std::min(column_width, img_size.width);
         unsigned target_h = img_size.height * target_w / img_size.width;
         /* Add small vertical padding around the image */
         line_heights[i] = static_cast<int>(target_h) + padding;
@@ -425,6 +427,8 @@ RichTextWindow::InvalidateLayout() noexcept
   line_y_offsets.clear();
   line_heights.clear();
   line_layout_width = 0;
+  checkbox_placeholders_expanded = false;
+  InvalidateContentCache();
 }
 
 std::size_t
@@ -473,6 +477,16 @@ void
 RichTextWindow::GetVisibleArea(int &visible_top, int &visible_bottom,
                                int &viewport_height) const noexcept
 {
+  /* Prefer VScrollPanel origin: rich-text children are sized to the
+     physical viewport and do not Move() on every scroll tick. */
+  if (const auto *panel =
+        dynamic_cast<const VScrollPanel *>(GetParent())) {
+    viewport_height = static_cast<int>(panel->GetSize().height);
+    visible_top = static_cast<int>(panel->GetOrigin());
+    visible_bottom = visible_top + viewport_height;
+    return;
+  }
+
   const PixelPoint top_left = GetPosition().GetTopLeft();
 
   viewport_height = 2000;
@@ -488,6 +502,49 @@ RichTextWindow::GetVisibleArea(int &visible_top, int &visible_bottom,
   }
 }
 
+unsigned
+RichTextWindow::CalcWrapTextWidth(unsigned column_width) const noexcept
+{
+  if (font == nullptr || column_width == 0)
+    return 0;
+
+  unsigned text_width = column_width;
+  bool has_list = false;
+  for (const auto &span : parsed.styles) {
+    if (span.style == TextStyle::ListItem ||
+        span.style == TextStyle::Checkbox ||
+        span.style == TextStyle::CheckboxChecked) {
+      has_list = true;
+      break;
+    }
+  }
+
+  AnyCanvas measure;
+  measure.Select(*font);
+
+  /* Link paint adds a space before/after each segment. */
+  if (!parsed.links.empty()) {
+    const unsigned space_w =
+      std::max(1u, measure.CalcTextSize(" ").width);
+    if (text_width > space_w * 2)
+      text_width -= space_w * 2;
+  }
+
+  /* List first lines paint with a left indent; continuations hang
+     under the body.  WrapText uses one width for the whole doc, so
+     reserve the hang so wrapped lines do not run past the edge. */
+  if (has_list) {
+    const unsigned hang = static_cast<unsigned>(
+      measure.CalcTextSize("  ").width +
+      measure.CalcTextSize("- ").width +
+      measure.CalcTextSize(" ").width);
+    if (text_width > hang)
+      text_width -= hang;
+  }
+
+  return text_width;
+}
+
 void
 RichTextWindow::EnsureWrappedText() const noexcept
 {
@@ -499,13 +556,33 @@ RichTextWindow::EnsureWrappedText() const noexcept
   if (size.width <= unsigned(padding * 2))
     return;
 
-  const unsigned text_width = size.width - padding * 2;
+  /* const API: expand placeholders before wrap (mutates parse). */
+  const_cast<RichTextWindow *>(this)->ExpandCheckboxPlaceholders();
+
+  const unsigned column_width = size.width - padding * 2;
+  const unsigned text_width = CalcWrapTextWidth(column_width);
+  if (text_width == 0)
+    return;
 
   if (wrapped_text && wrapped_text_width == text_width)
     return;
 
+  /* Wrap with the body font.  Never use H1/H2 for the whole document
+     — one title heading would force every bullet to wrap early.
+     Bold is only slightly wider; use it when present so bold runs
+     are less likely to overflow. */
+  bool has_bold = false;
+  for (const auto &span : parsed.styles) {
+    if (span.style == TextStyle::Bold ||
+        span.style == TextStyle::Heading3) {
+      has_bold = true;
+      break;
+    }
+  }
+  const Font &wrap_font = has_bold ? GetBoldFont() : *font;
+
   AnyCanvas canvas;
-  canvas.Select(*font);
+  canvas.Select(wrap_font);
   wrapped_text = std::make_unique<WrappedText>(
     WrapText(canvas, text_width, parsed.text));
   wrapped_text_width = text_width;
@@ -598,6 +675,73 @@ CheckboxPrefixWidth(const Font &font) noexcept
   return box_size + Layout::Scale(4);
 }
 
+void
+RichTextWindow::ExpandCheckboxPlaceholders() noexcept
+{
+  if (checkbox_placeholders_expanded || font == nullptr)
+    return;
+
+  const int need_px = CheckboxPrefixWidth(*font);
+  AnyCanvas canvas;
+  canvas.Select(*font);
+  const int space_px =
+    std::max(1, static_cast<int>(canvas.CalcTextSize(" ").width));
+  const int n_spaces =
+    std::max(2, (need_px + space_px - 1) / space_px);
+
+  /* Widen/shrink from the end so earlier offsets stay stable. */
+  for (std::size_t si = parsed.styles.size(); si-- > 0;) {
+    auto &span = parsed.styles[si];
+    if (span.style != TextStyle::Checkbox &&
+        span.style != TextStyle::CheckboxChecked)
+      continue;
+    if (span.end <= span.start)
+      continue;
+
+    const int cur = static_cast<int>(span.end - span.start);
+    const int delta = n_spaces - cur;
+    if (delta == 0)
+      continue;
+
+    if (delta > 0)
+      parsed.text.insert(span.start + cur, delta, ' ');
+    else
+      parsed.text.erase(span.start + n_spaces,
+                        static_cast<std::size_t>(-delta));
+
+    /* Other spans/links: shift from the edit point.  This span's
+       end is updated explicitly so it is not double-shifted. */
+    const std::size_t edit_pos = delta > 0
+      ? span.start + cur
+      : span.start + n_spaces;
+    span.end = span.start + n_spaces;
+    for (auto &other : parsed.styles) {
+      if (&other == &span)
+        continue;
+      if (other.start >= edit_pos) {
+        other.start += delta;
+        other.end += delta;
+      } else if (other.end > edit_pos)
+        other.end += delta;
+    }
+    for (auto &link : parsed.links) {
+      if (link.start >= edit_pos) {
+        link.start += delta;
+        link.end += delta;
+      } else if (link.end > edit_pos)
+        link.end += delta;
+    }
+    for (auto &img : parsed.images) {
+      if (img.position >= edit_pos)
+        img.position += delta;
+    }
+  }
+
+  checkbox_placeholders_expanded = true;
+  if (checkbox_toggled.size() != parsed.styles.size())
+    checkbox_toggled.assign(parsed.styles.size(), 0);
+}
+
 /**
  * Horizontal distance from content #padding to where body text begins on the
  * first line of a list paragraph (same as x after drawing the list prefix).
@@ -639,7 +783,11 @@ RichTextWindow::EnsureSegmentedLines() const noexcept
   if (size.width <= unsigned(padding * 2))
     return;
 
-  const unsigned text_width = size.width - padding * 2;
+  /* Key off wrap width (not raw column) so hang/link slack stays in sync. */
+  const unsigned text_width =
+    CalcWrapTextWidth(size.width - padding * 2);
+  if (text_width == 0)
+    return;
 
   if (segmented_lines && segmented_lines_width == text_width)
     return;
@@ -777,7 +925,8 @@ RichTextWindow::GetContentHeight() const noexcept
   if (size.width <= unsigned(padding * 2))
     return 0;
 
-  const unsigned text_width = size.width - padding * 2;
+  const unsigned column_width = size.width - padding * 2;
+  const unsigned text_width = CalcWrapTextWidth(column_width);
 
   if (cached_content_height > 0 && cached_height_width == text_width)
     return cached_content_height;
@@ -829,11 +978,12 @@ RichTextWindow::SyncParentScrollHeight() noexcept
     return;
 
   /* Move() may trigger OnResize() → InvalidateLayout(), which clears
-     cached_content_height; keep the value we synced. */
+     cached_content_height; keep the value we synced.  Stay at the
+     physical viewport; scrolling uses panel origin, not child y. */
   const unsigned height = cached_content_height;
   const unsigned vh = std::max(panel->GetSize().height, height);
   panel->SetVirtualHeight(vh);
-  Move(panel->GetVirtualRect());
+  Move(panel->GetPhysicalRect());
   panel->Invalidate();
   synced_scroll_height = height;
 }
@@ -871,6 +1021,9 @@ RichTextWindow::OnResize(PixelSize new_size) noexcept
      vertical resizes or resolution changes that don't alter width). */
   if (new_size.width != old_size.width)
     InvalidateLayout();
+  else if (new_size.height != old_size.height)
+    /* Strip height tracks the viewport. */
+    InvalidateContentCache();
 
   if (!parsed.text.empty())
     Invalidate();
@@ -932,16 +1085,15 @@ RichTextWindow::RenderLinkSegment(Canvas &canvas,
                                   const TextSegment &seg,
                                   const char *text_data,
                                   int &x, int text_y,
-                                  int visible_top,
-                                  int text_line_height) noexcept
+                                  int text_line_height,
+                                  int content_y_origin) noexcept
 {
   std::string_view seg_text(text_data + seg.start, seg.length);
-  const bool is_focused = IsLinkFocused(seg.link_index);
 
   if (dark_mode)
-    canvas.SetTextColor(is_focused ? COLOR_WHITE : COLOR_XCSOAR_LIGHT);
+    canvas.SetTextColor(COLOR_XCSOAR_LIGHT);
   else
-    canvas.SetTextColor(is_focused ? COLOR_XCSOAR_LIGHT : COLOR_XCSOAR);
+    canvas.SetTextColor(COLOR_XCSOAR);
 
   const int link_spacing = canvas.CalcTextSize(" ").width;
   x += link_spacing;
@@ -950,26 +1102,13 @@ RichTextWindow::RenderLinkSegment(Canvas &canvas,
   const int seg_width = static_cast<int>(text_size.width);
   canvas.DrawText({x, text_y}, seg_text);
 
-  /* Expand the touch target vertically on touch screens
-     so links are easier to tap */
   const int touch_expand = IsTouchLayout() ? Layout::Scale(4) : 0;
-  PixelRect link_rect{x, text_y + visible_top - touch_expand,
+  PixelRect link_rect{x, text_y - touch_expand,
                       x + seg_width,
-                      text_y + visible_top + text_line_height
-                        + touch_expand};
-  RegisterLinkRect(seg.link_index, link_rect);
-
-  if (is_focused && HasFocus()) {
-    const int focus_pad = Layout::ScalePenWidth(2);
-    PixelRect focus_rc{x - focus_pad, text_y - focus_pad,
-                       x + seg_width + focus_pad,
-                       text_y + text_line_height + focus_pad};
-    canvas.Select(Pen(Layout::ScalePenWidth(1),
-                      dark_mode ? COLOR_LIGHT_GRAY
-                                : COLOR_DARK_GRAY));
-    canvas.SelectHollowBrush();
-    canvas.DrawRectangle(focus_rc);
-  }
+                      text_y + text_line_height + touch_expand};
+  link_rect.Offset(0, content_y_origin);
+  content_hits.push_back({link_rect, seg.link_index, false,
+                          seg.start, seg.length});
 
   x += seg_width;
   x += link_spacing;
@@ -978,8 +1117,9 @@ RichTextWindow::RenderLinkSegment(Canvas &canvas,
 void
 RichTextWindow::RenderCheckboxSegment(Canvas &canvas,
                                       const TextSegment &seg,
-                                      int &x, int y_line, int visible_top,
-                                      int row_height) noexcept
+                                      int &x, int y_line,
+                                      int row_height,
+                                      int content_y_origin) noexcept
 {
   const std::size_t style_idx = FindCheckboxStyleIndex(seg.start);
   const int box_size = CheckboxBoxSize(*font);
@@ -989,31 +1129,20 @@ RichTextWindow::RenderCheckboxSegment(Canvas &canvas,
   bool checked = (style_idx != SIZE_MAX)
     ? IsCheckboxChecked(style_idx)
     : seg.IsCheckboxChecked();
-  const bool key_focused = (style_idx != SIZE_MAX) &&
-                          IsCheckboxFocused(style_idx);
-  if (dialog_look != nullptr) {
-    /* Outer focus square (same idea as #RenderLinkSegment); DrawCheckBox
-       only changes inner border, not a visible selection frame. */
-    if (key_focused && HasFocus()) {
-      const unsigned focus_w = Layout::ScalePenWidth(2);
-      PixelRect focus_rc = box_rc;
-      focus_rc.Grow((int)focus_w);
-      canvas.Select(Pen(focus_w, COLOR_XCSOAR_LIGHT));
-      canvas.SelectHollowBrush();
-      canvas.DrawRectangle(focus_rc);
-    }
-    DrawCheckBox(canvas, *dialog_look, box_rc, checked, key_focused, false, true);
-  } else
-    DrawSimpleCheckbox(canvas, box_rc, checked, key_focused, dark_mode);
+  if (dialog_look != nullptr)
+    DrawCheckBox(canvas, *dialog_look, box_rc, checked, false,
+                 false, true);
+  else
+    DrawSimpleCheckbox(canvas, box_rc, checked, false, dark_mode);
 
   if (style_idx != SIZE_MAX) {
-    /* Expand hit area on touch screens for easier tapping */
     const int cb_expand = IsTouchLayout() ? Layout::Scale(6) : 0;
     PixelRect click_rc{x - cb_expand,
-                       box_y + visible_top - cb_expand,
+                       box_y - cb_expand,
                        x + box_size + cb_expand,
-                       box_y + box_size + visible_top + cb_expand};
-    checkbox_rects.push_back({click_rc, style_idx});
+                       box_y + box_size + cb_expand};
+    click_rc.Offset(0, content_y_origin);
+    content_hits.push_back({click_rc, style_idx, true});
   }
 
   const int box_gap = Layout::Scale(4);
@@ -1046,73 +1175,56 @@ RichTextWindow::RenderPlainSegment(Canvas &canvas,
 }
 
 void
-RichTextWindow::OnPaint(Canvas &canvas) noexcept
+RichTextWindow::PaintContent(Canvas &canvas, int y_origin,
+                             int clip_top, int clip_bottom) noexcept
 {
-  canvas.Clear(background_color);
-
-  if (parsed.text.empty() || font == nullptr)
+  if (parsed.text.empty() || font == nullptr ||
+      !segmented_lines || segmented_lines->empty() ||
+      line_y_offsets.empty())
     return;
 
   const int padding = GetContentPadding();
   const int text_line_height = font->GetLineSpacing();
-
-  EnsureSegmentedLines();
-  EnsureLineLayout();
-  /* Sync before GetVisibleArea(): Move() changes GetPosition(). */
-  SyncParentScrollHeight();
-
-  int visible_top, visible_bottom, viewport_height;
-  GetVisibleArea(visible_top, visible_bottom, viewport_height);
-
-  if (!segmented_lines || segmented_lines->empty() ||
-      line_y_offsets.empty())
-    return;
-
-  const std::size_t n_lines = segmented_lines->size();
-
-  /* Find first visible line using line layout Y offsets */
-  std::size_t first_line = 0;
-  for (std::size_t i = 0; i < n_lines; ++i) {
-    if (padding + line_y_offsets[i] + line_heights[i] > visible_top) {
-      first_line = i;
-      break;
-    }
-  }
-
-  /* Find last visible line */
-  std::size_t last_line = n_lines;
-  for (std::size_t i = first_line; i < n_lines; ++i) {
-    if (padding + line_y_offsets[i] > visible_bottom) {
-      last_line = i;
-      break;
-    }
-  }
-
   const auto widget_size = GetSize();
   if (widget_size.width <= unsigned(padding * 2))
     return;
   const unsigned text_width = widget_size.width - padding * 2;
 
-  const auto rc = canvas.GetRect();
-  const PixelSize sub_size{rc.GetWidth(),
-                           static_cast<unsigned>(viewport_height)};
-  SubCanvas sub_canvas(canvas, PixelPoint{0, visible_top}, sub_size);
-  sub_canvas.SetBackgroundTransparent();
+  const std::size_t n_lines = segmented_lines->size();
 
-  ClearLinkRects();
-  checkbox_rects.clear();
+  /* Binary search: first line whose bottom is past clip_top. */
+  std::size_t first_line = 0;
+  {
+    std::size_t lo = 0, hi = n_lines;
+    while (lo < hi) {
+      const std::size_t mid = lo + (hi - lo) / 2;
+      if (padding + line_y_offsets[mid] + line_heights[mid]
+          <= clip_top)
+        lo = mid + 1;
+      else
+        hi = mid;
+    }
+    first_line = lo;
+  }
+
+  std::size_t last_line = n_lines;
+  for (std::size_t i = first_line; i < n_lines; ++i) {
+    if (padding + line_y_offsets[i] >= clip_bottom) {
+      last_line = i;
+      break;
+    }
+  }
+
+  canvas.SetBackgroundTransparent();
 
   const char *text_data = parsed.text.c_str();
-
-  // Indentation for list items and checkboxes (roughly 2 spaces)
   const int list_indent = font->TextSize("  ").width;
 
   for (std::size_t i = first_line; i < last_line; ++i) {
     const SegmentedLine &line = (*segmented_lines)[i];
-    const int y = padding + line_y_offsets[i] - visible_top;
+    const int y = padding + line_y_offsets[i] - y_origin;
     const int cur_line_height = line_heights[i];
 
-    /* Check if this line contains a block image */
     if (!line.segments.empty()) {
       const auto &first_seg = line.segments.front();
       const MarkdownImage *img =
@@ -1137,17 +1249,14 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
 #ifdef ENABLE_OPENGL
           const ScopeAlphaBlend alpha_blend;
 #endif
-          sub_canvas.Stretch({img_x, img_y},
-                             {target_w, target_h},
-                             *bmp, {0, 0}, img_size);
-          continue; // Skip normal text rendering for this line
+          canvas.Stretch({img_x, img_y},
+                         {target_w, target_h},
+                         *bmp, {0, 0}, img_size);
+          continue;
         }
       }
     }
 
-    /* Determine the effective text height for this line.
-       Heading lines use a larger font, so we need to account for
-       that when vertically centering. */
     int effective_text_height = text_line_height;
     if (!line.segments.empty()) {
       const TextSegment &first = line.segments.front();
@@ -1156,14 +1265,12 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
           GetHeadingFont(first.style).GetLineSpacing();
     }
 
-    /* Normal text rendering -- vertically center text when the
-       line is taller than normal (e.g. due to inline images) */
     const int text_y =
       y + (cur_line_height - effective_text_height) / 2;
     int x = padding;
     if (line.is_list_continuation) {
-      /* Align with body text after bullet / "1. " on the first line */
-      x += line.list_hang_offset > 0 ? line.list_hang_offset : list_indent;
+      x += line.list_hang_offset > 0 ? line.list_hang_offset
+                                     : list_indent;
     } else if (!line.segments.empty()) {
       const TextSegment &first_seg = line.segments.front();
       if (first_seg.IsCheckbox() || first_seg.IsListItem())
@@ -1171,31 +1278,256 @@ RichTextWindow::OnPaint(Canvas &canvas) noexcept
     }
 
     for (const TextSegment &seg : line.segments) {
-      if (RenderInlineImage(sub_canvas, seg, x, y,
+      if (RenderInlineImage(canvas, seg, x, y,
                             cur_line_height, text_line_height))
         continue;
 
-      const Font *seg_font = font;
-      if (seg.IsHeading())
-        seg_font = &GetHeadingFont(seg.style);
-      else if (seg.IsBold() && bold_font)
-        seg_font = bold_font;
-
-      sub_canvas.Select(*seg_font);
+      const Font &seg_font = GetStyleFont(seg.style);
+      canvas.Select(seg_font);
 
       if (seg.IsLink())
-        RenderLinkSegment(sub_canvas, seg, text_data,
-                          x, text_y, visible_top,
-                          text_line_height);
+        /* Hit/focus height must match the painted font, not the
+           body line spacing (bold/heading links are taller/wider). */
+        RenderLinkSegment(canvas, seg, text_data,
+                          x, text_y, seg_font.GetLineSpacing(),
+                          y_origin);
       else if (seg.IsCheckbox())
-        RenderCheckboxSegment(sub_canvas, seg,
-                              x, y, visible_top,
-                              cur_line_height);
+        RenderCheckboxSegment(canvas, seg,
+                              x, y, cur_line_height,
+                              y_origin);
       else
-        RenderPlainSegment(sub_canvas, seg, text_data,
+        RenderPlainSegment(canvas, seg, text_data,
                            x, text_y);
     }
   }
+}
+
+void
+RichTextWindow::EnsureContentCache(int origin,
+                                   int viewport_h) noexcept
+{
+  if (viewport_h <= 0)
+    return;
+
+  const auto widget_size = GetSize();
+  if (widget_size.width == 0)
+    return;
+
+  const int content_h = static_cast<int>(
+    std::max(cached_content_height, widget_size.height));
+
+  /* Three viewports of strip so prefetch has runway; capped for
+     GL/memory. */
+  static constexpr int MAX_CACHE_HEIGHT = 4096;
+  int buf_h = std::max(viewport_h * 3, viewport_h + Layout::Scale(64));
+  buf_h = std::min(buf_h, MAX_CACHE_HEIGHT);
+  buf_h = std::min(buf_h, content_h);
+  buf_h = std::max(buf_h, viewport_h);
+
+  const PixelSize buf_size{widget_size.width,
+                           static_cast<unsigned>(buf_h)};
+
+  if (!content_cache.IsDefined() ||
+      content_cache.GetSize() != buf_size) {
+    content_cache.Create(buf_size);
+    content_cache_dirty = true;
+  }
+
+  const int max_top = std::max(0, content_h - buf_h);
+  const int margin = std::max(1, viewport_h / 4);
+  const int cache_bottom = content_cache_top + buf_h;
+
+  const bool outside =
+    origin < content_cache_top ||
+    origin + viewport_h > cache_bottom;
+  /* Prefetch before the hard edge when more content exists that way. */
+  const bool near_top =
+    content_cache_top > 0 &&
+    origin < content_cache_top + margin;
+  const bool near_bottom =
+    cache_bottom < content_h &&
+    origin + viewport_h > cache_bottom - margin;
+
+  if (!content_cache_dirty && !outside && !near_top && !near_bottom)
+    return;
+
+  /* Centre the strip on the visible origin when possible. */
+  int new_top = origin - (buf_h - viewport_h) / 2;
+  if (new_top < 0)
+    new_top = 0;
+  else if (new_top > max_top)
+    new_top = max_top;
+
+  if (!content_cache_dirty && new_top == content_cache_top)
+    return;
+
+  content_cache_top = new_top;
+  content_hits.clear();
+
+  content_cache.Begin();
+  content_cache.Clear(background_color);
+  PaintContent(content_cache, content_cache_top,
+               content_cache_top, content_cache_top + buf_h);
+  content_cache.End();
+  content_cache_dirty = false;
+}
+
+void
+RichTextWindow::PublishWindowHits(int origin,
+                                  int viewport_h) noexcept
+{
+  ClearLinkRects();
+  checkbox_rects.clear();
+
+  const int visible_bottom = origin + viewport_h;
+  for (const auto &hit : content_hits) {
+    if (hit.content_rect.bottom <= origin ||
+        hit.content_rect.top >= visible_bottom)
+      continue;
+
+    PixelRect window_rc = hit.content_rect;
+    window_rc.Offset(0, -origin);
+    if (hit.is_checkbox)
+      checkbox_rects.push_back({window_rc, hit.index});
+    else
+      RegisterLinkRect(hit.index, window_rc);
+  }
+}
+
+void
+RichTextWindow::DrawFocusOverlay(Canvas &canvas,
+                                 int origin) noexcept
+{
+  if (!HasFocus())
+    return;
+
+  canvas.SetBackgroundTransparent();
+
+  for (const auto &hit : content_hits) {
+    const bool focused = hit.is_checkbox
+      ? IsCheckboxFocused(hit.index)
+      : IsLinkFocused(hit.index);
+    if (!focused)
+      continue;
+
+    PixelRect window_rc = hit.content_rect;
+    window_rc.Offset(0, -origin);
+
+    if (hit.is_checkbox) {
+      const int box_size = CheckboxBoxSize(*font);
+      /* Shrink touch-expanded hit back toward the box for drawing. */
+      const int cb_expand = IsTouchLayout() ? Layout::Scale(6) : 0;
+      PixelRect box_rc = window_rc;
+      if (cb_expand > 0)
+        box_rc.Grow(-cb_expand);
+      /* Prefer exact box size if the hit was expanded. */
+      if (box_rc.GetWidth() != unsigned(box_size) ||
+          box_rc.GetHeight() != unsigned(box_size)) {
+        box_rc.left = window_rc.left + cb_expand;
+        box_rc.top = window_rc.top + cb_expand;
+        box_rc.right = box_rc.left + box_size;
+        box_rc.bottom = box_rc.top + box_size;
+      }
+
+      const bool checked = IsCheckboxChecked(hit.index);
+      if (dialog_look != nullptr) {
+        const unsigned focus_w = Layout::ScalePenWidth(2);
+        PixelRect focus_rc = box_rc;
+        focus_rc.Grow((int)focus_w);
+        canvas.Select(Pen(focus_w, COLOR_XCSOAR_LIGHT));
+        canvas.SelectHollowBrush();
+        canvas.DrawRectangle(focus_rc);
+        DrawCheckBox(canvas, *dialog_look, box_rc, checked, true,
+                     false, true);
+      } else
+        DrawSimpleCheckbox(canvas, box_rc, checked, true, dark_mode);
+    } else {
+      /* Repaint this link segment only (wrapped links have one hit
+         per visual line), using the same font as PaintContent. */
+      if (font == nullptr || hit.text_length == 0 ||
+          hit.text_start + hit.text_length > parsed.text.size())
+        continue;
+
+      std::string_view seg_text(parsed.text.c_str() + hit.text_start,
+                                hit.text_length);
+      const TextStyle style =
+        GetStyleAt(parsed.styles, hit.text_start);
+      const Font &seg_font = GetStyleFont(style);
+      canvas.Select(seg_font);
+      if (dark_mode)
+        canvas.SetTextColor(COLOR_WHITE);
+      else
+        canvas.SetTextColor(COLOR_XCSOAR_LIGHT);
+
+      const int touch_expand = IsTouchLayout() ? Layout::Scale(4) : 0;
+      const int text_y = window_rc.top + touch_expand;
+      canvas.DrawText({window_rc.left, text_y}, seg_text);
+
+      /* Size the ring to the formatted glyph box, not the
+         touch-expanded hit (which may use a taller line spacing). */
+      const PixelSize text_size = canvas.CalcTextSize(seg_text);
+      const int seg_width = static_cast<int>(text_size.width);
+      const int seg_height = seg_font.GetLineSpacing();
+      PixelRect focus_rc{window_rc.left, text_y,
+                         window_rc.left + seg_width,
+                         text_y + seg_height};
+      focus_rc.Grow(Layout::ScalePenWidth(2));
+      canvas.Select(Pen(Layout::ScalePenWidth(1),
+                        dark_mode ? COLOR_LIGHT_GRAY
+                                  : COLOR_DARK_GRAY));
+      canvas.SelectHollowBrush();
+      canvas.DrawRectangle(focus_rc);
+    }
+  }
+}
+
+void
+RichTextWindow::OnPaint(Canvas &canvas) noexcept
+{
+  if (parsed.text.empty() || font == nullptr) {
+    canvas.Clear(background_color);
+    return;
+  }
+
+  EnsureSegmentedLines();
+  EnsureLineLayout();
+  SyncParentScrollHeight();
+
+  int visible_top, visible_bottom, viewport_height;
+  GetVisibleArea(visible_top, visible_bottom, viewport_height);
+  (void)visible_bottom;
+
+  if (!segmented_lines || segmented_lines->empty() ||
+      line_y_offsets.empty()) {
+    canvas.Clear(background_color);
+    return;
+  }
+
+  EnsureContentCache(visible_top, viewport_height);
+
+  if (!content_cache.IsDefined()) {
+    canvas.Clear(background_color);
+    return;
+  }
+
+  /* Pan: blit the visible strip from the content cache. */
+  const int src_y = visible_top - content_cache_top;
+  const PixelSize view_size = GetSize();
+  const unsigned copy_h = std::min(view_size.height,
+    content_cache.GetHeight() > unsigned(src_y)
+      ? content_cache.GetHeight() - unsigned(src_y)
+      : 0u);
+  canvas.Clear(background_color);
+  if (copy_h == 0)
+    return;
+
+  const PixelSize copy_size{view_size.width, copy_h};
+  content_cache.CopyTo(canvas,
+                       PixelRect{PixelPoint{0, 0}, copy_size},
+                       PixelRect{PixelPoint{0, src_y}, copy_size});
+
+  PublishWindowHits(visible_top, viewport_height);
+  DrawFocusOverlay(canvas, visible_top);
 }
 
 bool
@@ -1261,6 +1593,7 @@ RichTextWindow::ToggleCheckbox(std::size_t style_index) noexcept
     return;
 
   checkbox_toggled[style_index] = !checkbox_toggled[style_index];
+  InvalidateContentCache();
   Invalidate();
 }
 
@@ -1370,12 +1703,19 @@ RichTextWindow::ScrollToFocusItem(const FocusItem &item) noexcept
   /* #VScrollPanel::ScrollTo expects parent-client coordinates. */
   ContainerWindow *parent = GetParent();
   if (parent != nullptr) {
-    const PixelRect window_rect = GetPosition();
     const int parent_height = parent->GetSize().height;
     const int margin = Layout::Scale(20);
 
-    const int item_top = item.y_pos + window_rect.top;
-    const int item_bottom = item.y_pos + item.height + window_rect.top;
+    /* Content Y → parent/viewport Y via scroll origin (child stays at
+       y=0 when hosted in a viewport-sized VScrollPanel). */
+    int origin = 0;
+    if (const auto *panel = dynamic_cast<const VScrollPanel *>(parent))
+      origin = static_cast<int>(panel->GetOrigin());
+    else
+      origin = -GetPosition().top;
+
+    const int item_top = item.y_pos - origin;
+    const int item_bottom = item.y_pos + item.height - origin;
 
     if (item_top < margin || item_bottom > parent_height - margin) {
       PixelRect scroll_rc{0, 0, 1, 1};
@@ -1429,8 +1769,11 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
 
   switch (key_code) {
   case KEY_DOWN:
-    if (!current_pos.has_value()) {
-      /* Pick the first item currently in view. */
+    /* After PageDown (etc.) focus may sit on an off-screen item.
+       Re-anchor to the first visible focusable before advancing. */
+    if (!current_pos.has_value() ||
+        !FocusItemVisible(items[current_pos.value()],
+                          visible_top, visible_bottom)) {
       for (const auto &it : items) {
         if (FocusItemVisible(it, visible_top, visible_bottom)) {
           ScrollToFocusItem(it);
@@ -1440,12 +1783,14 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
       return false;
     }
     if (current_pos.value() + 1 < items.size()) {
+      const auto &cur = items[current_pos.value()];
       const auto &next = items[current_pos.value() + 1];
-      /* Stay within roughly one viewport; otherwise let the
-         scroller move — keep the current item so focus is not
-         lost while scrolling between sparse links. */
-      if (next.y_pos - items[current_pos.value()].y_pos <=
-          visible_bottom - visible_top) {
+      /* Move when the next item is on screen, or still within
+         about one viewport.  If it is farther, return false so
+         the parent scroller moves; once it enters the viewport
+         the FocusItemVisible branch selects it. */
+      if (FocusItemVisible(next, visible_top, visible_bottom) ||
+          next.y_pos - cur.y_pos <= visible_bottom - visible_top) {
         ScrollToFocusItem(next);
         return true;
       }
@@ -1453,7 +1798,9 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
     return false;
 
   case KEY_UP:
-    if (!current_pos.has_value()) {
+    if (!current_pos.has_value() ||
+        !FocusItemVisible(items[current_pos.value()],
+                          visible_top, visible_bottom)) {
       for (auto it = items.rbegin(); it != items.rend(); ++it) {
         if (FocusItemVisible(*it, visible_top, visible_bottom)) {
           ScrollToFocusItem(*it);
@@ -1463,9 +1810,10 @@ RichTextWindow::OnKeyDown(unsigned key_code) noexcept
       return false;
     }
     if (current_pos.value() > 0) {
+      const auto &cur = items[current_pos.value()];
       const auto &prev = items[current_pos.value() - 1];
-      if (items[current_pos.value()].y_pos - prev.y_pos <=
-          visible_bottom - visible_top) {
+      if (FocusItemVisible(prev, visible_top, visible_bottom) ||
+          cur.y_pos - prev.y_pos <= visible_bottom - visible_top) {
         ScrollToFocusItem(prev);
         return true;
       }

--- a/src/ui/control/RichTextWindow.cpp
+++ b/src/ui/control/RichTextWindow.cpp
@@ -80,6 +80,17 @@ CheckboxBoxSize(const Font &font) noexcept
 }
 
 /**
+ * Width of checkbox + gap after it (must match #RenderCheckboxSegment).
+ */
+[[gnu::pure]]
+static int
+CheckboxPrefixWidth(const Font &font) noexcept
+{
+  const int box_size = CheckboxBoxSize(font);
+  return box_size + Layout::Scale(4);
+}
+
+/**
  * Content margin for the rich text area (top, left, right, bottom).
  * Larger than GetTextPadding() for comfortable reading.
  * Touch layouts get extra padding for easier interaction.
@@ -510,12 +521,14 @@ RichTextWindow::CalcWrapTextWidth(unsigned column_width) const noexcept
 
   unsigned text_width = column_width;
   bool has_list = false;
+  bool has_checkbox = false;
   for (const auto &span : parsed.styles) {
-    if (span.style == TextStyle::ListItem ||
-        span.style == TextStyle::Checkbox ||
-        span.style == TextStyle::CheckboxChecked) {
+    if (span.style == TextStyle::ListItem)
       has_list = true;
-      break;
+    else if (span.style == TextStyle::Checkbox ||
+             span.style == TextStyle::CheckboxChecked) {
+      has_list = true;
+      has_checkbox = true;
     }
   }
 
@@ -532,12 +545,18 @@ RichTextWindow::CalcWrapTextWidth(unsigned column_width) const noexcept
 
   /* List first lines paint with a left indent; continuations hang
      under the body.  WrapText uses one width for the whole doc, so
-     reserve the hang so wrapped lines do not run past the edge. */
+     reserve the hang so wrapped lines do not run past the edge.
+     Checkboxes are often wider than "- "; use the larger of the two. */
   if (has_list) {
-    const unsigned hang = static_cast<unsigned>(
-      measure.CalcTextSize("  ").width +
+    const unsigned list_indent = measure.CalcTextSize("  ").width;
+    unsigned hang = list_indent +
       measure.CalcTextSize("- ").width +
-      measure.CalcTextSize(" ").width);
+      measure.CalcTextSize(" ").width;
+    if (has_checkbox) {
+      const unsigned cb_hang = list_indent +
+        static_cast<unsigned>(CheckboxPrefixWidth(*font));
+      hang = std::max(hang, cb_hang);
+    }
     if (text_width > hang)
       text_width -= hang;
   }
@@ -662,17 +681,6 @@ MeasureNumberedListPrefixWidth(const Font &font, const std::string &text,
     return 0;
   const std::size_t n = i + 2 - line_start;
   return font.TextSize(std::string_view(text.c_str() + line_start, n)).width;
-}
-
-/**
- * Width of checkbox + gap after it (must match #RenderCheckboxSegment).
- */
-[[gnu::pure]]
-static int
-CheckboxPrefixWidth(const Font &font) noexcept
-{
-  const int box_size = CheckboxBoxSize(font);
-  return box_size + Layout::Scale(4);
 }
 
 void
@@ -818,10 +826,18 @@ RichTextWindow::EnsureSegmentedLines() const noexcept
     return TextStartsWithNumberedList(text, line_start, line_length);
   };
 
-  /* Plain-text "- " bullet (e.g. Credits NEWS without Markdown). */
-  auto PlainLineStartsWithBullet =
-    [&text](std::size_t start, std::size_t length) noexcept {
-      return length >= 2 && text[start] == '-' && text[start + 1] == ' ';
+  /* Plain-text "- " bullet (e.g. Credits NEWS without Markdown).
+     NEWS uses an indented "  - " prefix; skip leading spaces/tabs.
+     Returns byte length of leading whitespace + "- ", or 0. */
+  auto PlainBulletPrefixLength =
+    [&text](std::size_t start, std::size_t length) noexcept -> std::size_t {
+      const std::size_t end = start + length;
+      std::size_t i = start;
+      while (i < end && (text[i] == ' ' || text[i] == '\t'))
+        ++i;
+      if (i + 1 >= end || text[i] != '-' || text[i + 1] != ' ')
+        return 0;
+      return i + 2 - start;
     };
 
   // If no links and no styles, each line is a single normal segment
@@ -835,15 +851,18 @@ RichTextWindow::EnsureSegmentedLines() const noexcept
         seg_line.segments.push_back({line.start, line.length, SIZE_MAX, TextStyle::Normal});
 
       if (is_new_para) {
+        const std::size_t plain_bullet_n =
+          PlainBulletPrefixLength(line.start, line.length);
         in_list_paragraph =
           IsListParagraphStart(seg_line, line.start, line.length) ||
-          PlainLineStartsWithBullet(line.start, line.length);
+          plain_bullet_n > 0;
         if (in_list_paragraph && font != nullptr) {
           if (TextStartsWithNumberedList(text, line.start, line.length))
             current_list_hang = MeasureNumberedListPrefixWidth(
               *font, text, line.start, line.length);
-          else if (PlainLineStartsWithBullet(line.start, line.length))
-            current_list_hang = font->TextSize("- ").width;
+          else if (plain_bullet_n > 0)
+            current_list_hang = font->TextSize(std::string_view(
+              text.c_str() + line.start, plain_bullet_n)).width;
           else
             current_list_hang = list_indent;
         } else
@@ -1190,7 +1209,9 @@ RichTextWindow::PaintContent(Canvas &canvas, int y_origin,
     return;
   const unsigned text_width = widget_size.width - padding * 2;
 
-  const std::size_t n_lines = segmented_lines->size();
+  const std::size_t n_lines = std::min({segmented_lines->size(),
+                                        line_y_offsets.size(),
+                                        line_heights.size()});
 
   /* Binary search: first line whose bottom is past clip_top. */
   std::size_t first_line = 0;

--- a/src/ui/control/RichTextWindow.hpp
+++ b/src/ui/control/RichTextWindow.hpp
@@ -6,6 +6,7 @@
 #include "LinkableWindow.hpp"
 #include "util/MarkdownParser.hpp"
 #include "ui/canvas/Bitmap.hpp"
+#include "ui/canvas/BufferCanvas.hpp"
 #include "ui/canvas/Color.hpp"
 
 #include <map>
@@ -108,12 +109,26 @@ class RichTextWindow : public LinkableWindow {
   /** Checkbox toggle states (non-zero = toggled from original) */
   mutable std::vector<uint8_t> checkbox_toggled;
 
-  /** Checkbox hit rectangles for click detection */
+  /** Checkbox hit rectangles for click detection (window space). */
   struct CheckboxRect {
     PixelRect rect;
     std::size_t style_index;  ///< Index into parsed.styles
   };
   mutable std::vector<CheckboxRect> checkbox_rects;
+
+  /**
+   * Link/checkbox hit rectangles in content coordinates, filled with
+   * the painted strip.  Published to window space on each paint.
+   */
+  struct ContentHit {
+    PixelRect content_rect;
+    std::size_t index; ///< link index or checkbox style index
+    bool is_checkbox;
+    /** Link segment bytes in #parsed.text (ignored for checkboxes). */
+    std::size_t text_start = 0;
+    std::size_t text_length = 0;
+  };
+  std::vector<ContentHit> content_hits;
 
   /** Currently focused checkbox style_index (into parsed.styles), or nullopt */
   mutable std::optional<std::size_t> focused_checkbox_style;
@@ -129,7 +144,30 @@ class RichTextWindow : public LinkableWindow {
   mutable std::vector<int> line_heights;
   mutable unsigned line_layout_width = 0;
 
+  /**
+   * Sliding offscreen strip of painted content.  Scroll pans by
+   * blitting; the strip is refilled only when the origin leaves it
+   * or #content_cache_dirty is set.
+   */
+  BufferCanvas content_cache;
+
+  /** Content-space Y of buffer row 0. */
+  int content_cache_top = 0;
+
+  bool content_cache_dirty = true;
+
+  /**
+   * True after checkbox "  " placeholders were widened to match
+   * #CheckboxBoxSize for the current font (wrap/paint alignment).
+   */
+  bool checkbox_placeholders_expanded = false;
+
 private:
+  /**
+   * Widen Markdown checkbox placeholders so WrapText measures the
+   * same width as the painted checkbox + gap.
+   */
+  void ExpandCheckboxPlaceholders() noexcept;
   /**
    * Load or retrieve a cached bitmap for the given image URL.
    * Supports "resource:IDB_NAME" for compiled-in resources.
@@ -170,6 +208,13 @@ private:
    */
   void EnsureLineLayout() const noexcept;
   /**
+   * Column width available for wrapping (content width minus slack for
+   * link spacing and list hanging indent).
+   */
+  [[gnu::pure]]
+  unsigned CalcWrapTextWidth(unsigned column_width) const noexcept;
+
+  /**
    * Ensure wrapped_text is populated for current width.
    */
   void EnsureWrappedText() const noexcept;
@@ -196,22 +241,51 @@ private:
    */
   void SyncParentScrollHeight() noexcept;
 
+  /**
+   * Paint lines whose content Y overlaps [clip_top, clip_bottom) into
+   * @a canvas.  Canvas Y = content Y - @a y_origin.
+   * Also records #content_hits in content space (canvas rect + y_origin).
+   */
+  void PaintContent(Canvas &canvas, int y_origin,
+                    int clip_top, int clip_bottom) noexcept;
+
+  /**
+   * Ensure #content_cache covers the viewport with prefetch margin.
+   */
+  void EnsureContentCache(int origin, int viewport_h) noexcept;
+
+  /** Mark the painted strip invalid (text, layout, checkbox, theme). */
+  void InvalidateContentCache() noexcept {
+    content_cache_dirty = true;
+    content_hits.clear();
+  }
+
+  /**
+   * Publish #content_hits into window-space link/checkbox rects for
+   * the visible band.
+   */
+  void PublishWindowHits(int origin, int viewport_h) noexcept;
+
+  /** Draw keyboard focus chrome for the focused link/checkbox. */
+  void DrawFocusOverlay(Canvas &canvas, int origin) noexcept;
+
   /** Render an inline image for a segment, if present.
    * @return true if an image was rendered (caller should skip text) */
   bool RenderInlineImage(Canvas &canvas, const TextSegment &seg,
                          int &x, int y, int cur_line_height,
                          int text_line_height) const noexcept;
 
-  /** Render an underlined link segment with hit-rect registration. */
+  /** Render an underlined link segment; record content-space hit. */
   void RenderLinkSegment(Canvas &canvas, const TextSegment &seg,
                          const char *text_data, int &x, int text_y,
-                         int visible_top,
-                         int text_line_height) noexcept;
+                         int text_line_height,
+                         int content_y_origin) noexcept;
 
-  /** Render a checkbox segment with hit-rect registration. */
+  /** Render a checkbox segment; record content-space hit. */
   void RenderCheckboxSegment(Canvas &canvas, const TextSegment &seg,
-                             int &x, int y_line, int visible_top,
-                             int row_height) noexcept;
+                             int &x, int y_line,
+                             int row_height,
+                             int content_y_origin) noexcept;
 
   /** Render a plain text segment (heading, bold, list item, normal). */
   void RenderPlainSegment(Canvas &canvas, const TextSegment &seg,
@@ -244,6 +318,9 @@ public:
     bold_font = _bold_font ? _bold_font : &_font;
     heading1_font = _heading1_font ? _heading1_font : bold_font;
     heading2_font = _heading2_font ? _heading2_font : bold_font;
+    /* Placeholder expansion depends on font metrics. */
+    checkbox_placeholders_expanded = false;
+    InvalidateLayout();
   }
 
   /**
@@ -255,10 +332,12 @@ public:
                    Color _background_color = COLOR_WHITE) noexcept {
     dark_mode = _dark_mode;
     background_color = _background_color;
+    InvalidateContentCache();
   }
 
   void SetDialogLook(const DialogLook &look) noexcept {
     dialog_look = &look;
+    InvalidateContentCache();
   }
 
   [[gnu::pure]]
@@ -285,6 +364,21 @@ public:
       return heading2_font ? *heading2_font : GetBoldFont();
     default:
       return GetBoldFont();
+    }
+  }
+
+  /** Font used when painting a span with the given Markdown style. */
+  [[gnu::pure]]
+  const Font &GetStyleFont(TextStyle style) const noexcept {
+    switch (style) {
+    case TextStyle::Heading1:
+    case TextStyle::Heading2:
+    case TextStyle::Heading3:
+      return GetHeadingFont(style);
+    case TextStyle::Bold:
+      return GetBoldFont();
+    default:
+      return GetFont();
     }
   }
 

--- a/src/util/MarkdownParser.cpp
+++ b/src/util/MarkdownParser.cpp
@@ -175,6 +175,62 @@ SkipListMarker(const char *str) noexcept
   return str;
 }
 
+/**
+ * Indented line continuing the previous list item (CommonMark-style soft
+ * break inside one list paragraph).  Requires at least two spaces of
+ * indent; not a new list marker or heading.
+ */
+[[gnu::pure]]
+static bool
+IsListItemContinuation(const char *line_start) noexcept
+{
+  const char *str = line_start;
+  unsigned indent = 0;
+  while (*str == ' ' || *str == '\t') {
+    ++indent;
+    ++str;
+  }
+  if (indent < 2 || *str == '\0' || *str == '\n')
+    return false;
+  if (GetHeadingLevel(str) > 0)
+    return false;
+  return !IsListItem(line_start);
+}
+
+/**
+ * Join a list item's first line and indented continuations into one
+ * paragraph body (spaces, no newlines).  @p str_inout advances past
+ * the last consumed source line (still pointing at its trailing
+ * newline or NUL).
+ */
+static std::string
+CollectListItemBody(const char *content, const char *&str_inout)
+{
+  std::string body;
+  const char *line_end = FindLineEnd(content);
+  body.append(content, line_end);
+  str_inout = line_end;
+
+  while (*str_inout == '\n' && str_inout[1] != '\0') {
+    const char *next = str_inout + 1;
+    if (*next == '\n')
+      break;
+    if (!IsListItemContinuation(next))
+      break;
+
+    const char *q = next;
+    while (*q == ' ' || *q == '\t')
+      ++q;
+    line_end = FindLineEnd(q);
+    if (!body.empty() && body.back() != ' ')
+      body += ' ';
+    body.append(q, line_end);
+    str_inout = line_end;
+  }
+
+  return body;
+}
+
 [[gnu::const]]
 static constexpr bool
 IsLeadLabelChar(char c) noexcept
@@ -330,7 +386,6 @@ ParseMarkdown(const char *input)
       // Check for list item
       if (IsListItem(str)) {
         const char *content = SkipListMarker(str);
-        const char *line_end = FindLineEnd(str);
 
         // Check for checkbox: [ ] or [x]
         int checkbox_state = GetCheckboxState(content);
@@ -352,11 +407,10 @@ ParseMarkdown(const char *input)
           result.styles.push_back({marker_start, marker_start + 2, TextStyle::ListItem});
         }
 
-        // Find line end from content start
-        line_end = FindLineEnd(content);
-
-        // Now process the content for inline formatting (bold, links)
-        const char *p = content;
+        /* One list item = one paragraph: fold indented continuations. */
+        const std::string item_body = CollectListItemBody(content, str);
+        const char *p = item_body.c_str();
+        const char *line_end = p + item_body.size();
 
         MaybeAppendBoldListLeadLabel(result.text, result.styles, p, line_end);
 
@@ -399,10 +453,9 @@ ParseMarkdown(const char *input)
                 image.url.assign(img_url_begin, img_url_end);
                 image.is_block = false; // inline in list item
 
-                if (!image.alt_text.empty())
-                  result.text.append(image.alt_text);
-                else
-                  result.text += ' ';
+                /* Single-character placeholder so wrap cannot split
+                   alt text across lines; alt stays in #alt_text. */
+                result.text += ' ';
 
                 result.images.push_back(std::move(image));
                 p = img_url_end + 1;
@@ -486,7 +539,8 @@ ParseMarkdown(const char *input)
           result.text += *p++;
         }
 
-        str = line_end;
+        /* #CollectListItemBody left #str at the end of the last source
+           line; emit a single paragraph break after the item. */
         if (*str == '\n') {
           result.text += '\n';
           ++str;
@@ -556,11 +610,9 @@ ParseMarkdown(const char *input)
           image.url.assign(img_url_begin, img_url_end);
           image.is_block = is_block;
 
-          // Add placeholder text (alt text or single space)
-          if (!image.alt_text.empty())
-            result.text.append(image.alt_text);
-          else
-            result.text += ' ';
+          /* Single-character placeholder so wrap cannot split alt
+             text across lines; alt stays in #alt_text. */
+          result.text += ' ';
 
           result.images.push_back(std::move(image));
 

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -3,6 +3,7 @@
 
 #include "Asset.hpp"
 #include "CommandLine.hpp"
+#include "Hardware/CPU.hpp"
 
 #ifndef KOBO
 static DisplayType display_type = DisplayType::LCD;
@@ -48,3 +49,15 @@ HasKeyboard() noexcept
 }
 
 #endif
+
+/**
+ * Default for harness / tools that link Form/List without
+ * Hardware/CPU.cpp.  The strong definition in CPU.cpp overrides this
+ * in the main binary.
+ */
+[[gnu::weak]]
+bool
+IsSlowCPU() noexcept
+{
+  return false;
+}

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -3,7 +3,6 @@
 
 #include "Asset.hpp"
 #include "CommandLine.hpp"
-#include "Hardware/CPU.hpp"
 
 #ifndef KOBO
 static DisplayType display_type = DisplayType::LCD;
@@ -49,15 +48,3 @@ HasKeyboard() noexcept
 }
 
 #endif
-
-/**
- * Default for harness / tools that link Form/List without
- * Hardware/CPU.cpp.  The strong definition in CPU.cpp overrides this
- * in the main binary.
- */
-[[gnu::weak]]
-bool
-IsSlowCPU() noexcept
-{
-  return false;
-}

--- a/tools/news_to_quickguide_md.py
+++ b/tools/news_to_quickguide_md.py
@@ -4,10 +4,10 @@
 #
 # Reads NEWS.txt and writes a C++ header defining the Quick Guide "What's New"
 # body as Markdown: first "# Version …" line is Heading 1, each "* section"
-# line is Heading 2, with a blank line before and after each section title,
-# "  - " bullets merge indented continuation lines into one list item so the
-# in-app renderer wraps with correct hanging indent. A blank line is also
-# inserted after the H1.  ``#1234`` issue references become GitHub links.
+# line is Heading 2, with a blank line before and after each section title.
+# Each NEWS bullet (``  - `` plus indented continuations) becomes one Markdown
+# list item / paragraph so the in-app renderer keeps hanging indent.  ``#1234``
+# issue references become GitHub links.
 
 from __future__ import annotations
 
@@ -17,8 +17,9 @@ import sys
 
 # GitHub issue links for NEWS “#1234” references (same tracker as the repo).
 GITHUB_ISSUE_BASE = "https://github.com/XCSoar/XCSoar/issues"
-# Do not match “#digits” already used as link text in […](…); avoid “##…” headings.
-_ISSUE_REF = re.compile(r"(?<!\[)#(\d+)\b")
+# At least two digits, not ``#0`` / ``#1`` FLARM-style suffixes.  Skip
+# ``#digits`` already used as link text in […](…); avoid “##…” headings.
+_ISSUE_REF = re.compile(r"(?<!\[)#([1-9]\d+)\b")
 
 
 def extract_first_version_block(text: str) -> str:
@@ -80,7 +81,8 @@ def convert_news_block_to_markdown(block: str) -> str:
             i += 1
             continue
 
-        # Bullet with optional indented continuations (4 spaces).
+        # Bullet with optional indented continuations (4 spaces) → one
+        # Markdown list item (one paragraph in the rich-text renderer).
         if line.startswith("  - "):
             parts: list[str] = [line[4:].strip()]
             i += 1

--- a/tools/news_to_quickguide_md.py
+++ b/tools/news_to_quickguide_md.py
@@ -18,8 +18,9 @@ import sys
 # GitHub issue links for NEWS “#1234” references (same tracker as the repo).
 GITHUB_ISSUE_BASE = "https://github.com/XCSoar/XCSoar/issues"
 # At least two digits, not ``#0`` / ``#1`` FLARM-style suffixes.  Skip
-# ``#digits`` already used as link text in […](…); avoid “##…” headings.
-_ISSUE_REF = re.compile(r"(?<!\[)#([1-9]\d+)\b")
+# ``#digits`` already used as link text in […](…), headings (``##…``),
+# and bare ``#1234(`` fragments.
+_ISSUE_REF = re.compile(r"(?<![#\[])#([1-9]\d+)\b(?!\()")
 
 
 def extract_first_version_block(text: str) -> str:


### PR DESCRIPTION
## Summary
- Speed up What's New / Credits scrolling by keeping the rich-text child viewport-sized, painting a sliding strip cache, and blitting on pan (OpenGL, GDI, and memory canvas).
- Treat Markdown list items as one paragraph (indented continuations) so hanging indent wraps correctly; keep image alt out of the wrap stream.
- Fix wrap/focus alignment (checkbox width, link/heading fonts, keyboard focus after Page Up/Down) and disable kinetic/smooth pixel-pan on slow CPUs as well as e-paper.

## Test plan
- [ ] Open Quick Guide → What's New: scroll with mouse/touch (kinetic on desktop); CPU stays modest; no black bars / upside-down strips on OpenGL
- [ ] Build/run `TARGET=UNIX OPENGL=n` and confirm What's New still scrolls and paints correctly
- [ ] Keyboard: Page Down then Up/Down through links — newly visible links get focus; focus ring matches bold/heading link text
- [ ] Long bullets wrap near the scrollbar with hanging indent under the body (not under the `-`)
- [ ] Lists with checkboxes: wrap aligns with painted box; Enter toggles and advances
- [ ] On a slow-CPU or e-paper profile: fling/kinetic snap (no inertia animation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster scrolling and smoother navigation on long What's New and Credits pages.
  * Multi-line What's New bullets remain together with clearer indentation.
  * Improved rich-text rendering for lists, checkboxes, links, images, and viewport updates.
  * More reliable keyboard focus movement between page content and navigation controls.
  * Enhanced support for buffered and partial canvas updates.

* **Bug Fixes**
  * Improved scrolling on slower devices and e-paper displays.
  * Corrected content sizing and positioning when scrollbars are reserved.
  * Improved Markdown list continuation and image placeholder handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->