### PR TITLE
Terrain/TerrainRenderer: Reuse OpenGL terrain when the view is unchanged

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,9 @@ Version 7.45 - not yet released
 * airspace
   - Remove ineffective "Unknown" row from airspace warning, display, and
     colour settings #1772
+* map
+  - Fix repeated full terrain redraws when the view stays still near the
+    edge of the terrain map (OpenGL), which could make panning hitchy
 * data files
   - fix loading SeeYou .cupx waypoint files and embedded photos that
     use ZIP data descriptors (e.g. recent OpenAIP / SeeYou exports)

--- a/src/Projection/CompareProjection.cpp
+++ b/src/Projection/CompareProjection.cpp
@@ -40,6 +40,16 @@ CompareProjection::Compare(const CompareProjection &other) const noexcept
 }
 
 bool
+CompareProjection::CompareExact(const CompareProjection &other) const noexcept
+{
+  return IsDefined() &&
+    corners.top_left == other.corners.top_left &&
+    corners.top_right == other.corners.top_right &&
+    corners.bottom_left == other.corners.bottom_left &&
+    corners.bottom_right == other.corners.bottom_right;
+}
+
+bool
 CompareProjection::CompareAndUpdate(const CompareProjection &other) noexcept
 {
   if (Compare(other))

--- a/src/Projection/CompareProjection.hpp
+++ b/src/Projection/CompareProjection.hpp
@@ -54,6 +54,16 @@ public:
     return Compare(CompareProjection(projection));
   }
 
+  /**
+   * Are the screen-corner geopoints identical to the saved ones?
+   * Unlike Compare(), this rejects any movement — including sub-pixel.
+   */
+  bool CompareExact(const CompareProjection &other) const noexcept;
+
+  bool CompareExact(const WindowProjection &projection) const noexcept {
+    return CompareExact(CompareProjection(projection));
+  }
+
   bool CompareAndUpdate(const CompareProjection &other) noexcept;
 
   /**

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -359,9 +359,11 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
 
   /* Exact same view: reuse without consulting overscan bounds.
      Near the map edge, overscan is clipped so old_bounds.IsInside()
-     can fail even when the projection is unchanged. */
+     can fail even when the projection is unchanged.  Use
+     CompareExact (not tolerant Compare) so a tiny pan cannot skip
+     the IsInside coverage check. */
   if (!quantisation_improved &&
-      compare_projection.Compare(map_projection) &&
+      compare_projection.CompareExact(map_projection) &&
       terrain_serial == terrain.GetSerial() &&
       sunazimuth.CompareRoughly(last_sun_azimuth)) {
     if (settings.contours == Contours::OFF ||

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -351,6 +351,29 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
                           const Angle sunazimuth)
 {
 #ifdef ENABLE_OPENGL
+  /* Call once — the helper mutates quantisation_pixels. */
+  const bool quantisation_improved = raster_renderer.UpdateQuantisation();
+#else
+  constexpr bool quantisation_improved = false;
+#endif
+
+  /* Exact same view: reuse without consulting overscan bounds.
+     Near the map edge, overscan is clipped so old_bounds.IsInside()
+     can fail even when the projection is unchanged. */
+  if (!quantisation_improved &&
+      compare_projection.Compare(map_projection) &&
+      terrain_serial == terrain.GetSerial() &&
+      sunazimuth.CompareRoughly(last_sun_azimuth)) {
+    if (settings.contours == Contours::OFF ||
+#ifdef ENABLE_OPENGL
+        raster_renderer.GetQuantisationPixels() > 2 ||
+#endif
+        map_projection.GetScale() == last_projection_scale) {
+      return true;
+    }
+  }
+
+#ifdef ENABLE_OPENGL
   const GeoBounds &old_bounds = raster_renderer.GetBounds();
   GeoBounds new_bounds = map_projection.GetScreenBounds();
   assert(new_bounds.IsValid());
@@ -362,32 +385,27 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
       return false;
   }
 
-  if (old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
+  if (!quantisation_improved &&
+      old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
       !IsLargeSizeDifference(old_bounds, new_bounds) &&
       terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth) &&
-      !raster_renderer.UpdateQuantisation()) {
+      sunazimuth.CompareRoughly(last_sun_azimuth)) {
     /* The existing terrain image is suitable for reuse.
        But with contours: Re-use only without zoom change.
        Otherwise we can re-use as a fast preview, but
        re-render the higher quality views (q=2 and q=1) */
     if (settings.contours == Contours::OFF ||
         raster_renderer.GetQuantisationPixels() > 2 ||
-        map_projection.GetScale() == last_projection_scale)
+        map_projection.GetScale() == last_projection_scale) {
+      compare_projection = CompareProjection(map_projection);
       return true;
+    }
   }
 
-#else
-  if (compare_projection.Compare(map_projection) &&
-      terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth))
-    /* no change since previous frame */
-    return true;
-
-  compare_projection = CompareProjection(map_projection);
 #endif
 
   terrain_serial = terrain.GetSerial();
+  compare_projection = CompareProjection(map_projection);
 
   last_sun_azimuth = sunazimuth;
 

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -6,10 +6,7 @@
 #include "RasterRenderer.hpp"
 #include "util/Serial.hpp"
 #include "Terrain/TerrainSettings.hpp"
-
-#ifndef ENABLE_OPENGL
 #include "Projection/CompareProjection.hpp"
-#endif
 
 class Canvas;
 class WindowProjection;
@@ -24,9 +21,7 @@ class TerrainRenderer {
 protected:
   struct TerrainRendererSettings settings;
 
-#ifndef ENABLE_OPENGL
   CompareProjection compare_projection;
-#endif
 
   Angle last_sun_azimuth = Angle::Zero();
 
@@ -49,9 +44,8 @@ public:
   void Flush() {
 #ifdef ENABLE_OPENGL
     raster_renderer.Invalidate();
-#else
-    compare_projection.Clear();
 #endif
+    compare_projection.Clear();
   }
 
 public:


### PR DESCRIPTION
## Summary
- Near the edge of a terrain map, OpenGL overscan bounds are clipped so `old_bounds.IsInside(new_bounds)` can fail even when the projection did not change.
- That forced a full `ScanMap` + texture upload on every paint (~20+ ms in a hotspot near the eastern edge of FRA HighRes).
- Reuse `CompareProjection` for exact-view reuse on OpenGL (same idea as the non-GL path), keep overscan reuse for small pans, and call `UpdateQuantisation()` once per `Generate()`.

## Test plan
- [ ] Pan/hold the map near the edge of a terrain file that does not cover the whole screen (e.g. FRA HighRes eastern edge); terrain should stay smooth when the view is still
- [ ] Pan within the overscan buffer away from the map edge; still no unnecessary full regenerations
- [ ] Zoom in/out and confirm terrain still regenerates as expected
- [ ] Confirm idle quantisation still upgrades to full resolution after interaction stops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed repeated terrain redraws near the edge of the map when using OpenGL.
  - Reduced hitching while panning with a stationary view.
  - Improved terrain rendering reuse when projection, scale, contour, lighting, and terrain data remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->