### PR TITLE
Renderer/TextInBox: Restore hairline outline for rounded map labels

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -93,6 +93,9 @@ Version 7.45 - not yet released
   - Fix map vario / final-glide value labels: use a rounded rectangle
     (not a pill) with even text padding and an unbroken outline for the
     semitransparent background #1438
+  - Restore the thin, crisp outline on rounded map labels (landable
+    waypoints, vario, final glide); on Retina iPhones it had become
+    too thick, too dark and ragged at the corners #2840
   - Swap map overlay sides: vario bar on the left, final glide bar on
     the right #1210
   - Add airspace labels toggle: Display page 2, Quick Menu, and

--- a/src/Renderer/TextInBox.cpp
+++ b/src/Renderer/TextInBox.cpp
@@ -12,6 +12,7 @@
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
+#include "ui/canvas/opengl/Triangulate.hpp"
 #endif
 
 static PixelPoint
@@ -114,11 +115,21 @@ TextInBox(Canvas &canvas, const char *text, PixelPoint p,
 
   if (mode.shape == LabelShape::ROUNDED_BLACK ||
       mode.shape == LabelShape::ROUNDED_WHITE) {
-    /* A hairline pen breaks up along the rounded corners: OpenGL draws
-       the outline as a triangle strip whose half width (0.5px) rounds
-       to zero on most of the arc segments, leaving a dotted edge.
-       Scale the width so every segment has area. */
-    const Pen outline_pen{std::max(1u, Layout::ScaleFinePenWidth(1)),
+    /* A hairline pen breaks up along the rounded corners where the
+       outline is emitted as a triangle strip: its half width (0.5px)
+       rounds to zero on most of the arc segments, leaving a dotted
+       edge.  Widen the pen only there.  Where GL_LINE_LOOP draws the
+       outline (and on the non-OpenGL canvases), a DPI-scaled pen would
+       merely make the box fat and - because LineToTriangles() rounds
+       the segment offsets to whole pixels - ragged around the corners;
+       on a 3x iPhone it turns the 1px hairline into 3px. */
+    unsigned outline_width = 1;
+#ifdef ENABLE_OPENGL
+    if (!UseOpenGLLineLoopOutline(outline_width))
+      outline_width = std::max(2u, Layout::ScaleFinePenWidth(1));
+#endif
+
+    const Pen outline_pen{outline_width,
                           mode.shape == LabelShape::ROUNDED_BLACK
                           ? COLOR_BLACK : COLOR_WHITE};
     canvas.Select(outline_pen);


### PR DESCRIPTION
Closes #2840. Can anyone confirm that this did not break the workaround on Android?

<img width="328" height="225" alt="Bildschirmfoto 2026-08-10 um 15 20 07" src="https://github.com/user-attachments/assets/137de66e-c73e-4639-bdba-e0ecaaa42a5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map label outlines for landable waypoints, vario, and final-glide labels.
  * Reduced overly thick and ragged outlines on Retina iPhones.
  * Refined rounded label borders to avoid dotted corners while preserving display quality across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->