### PR TITLE
Renderer/Waypoint: Show reachability in waypoint lists

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -218,6 +218,10 @@ Version 7.45 - not yet released
     internal audio vario volume
   - audio vario: add manual/automatic Vario/STF sound switching and
     ``VarioAudioMode`` input events
+  - show landable waypoint reachability in the "map elements at this
+    location" dialog, the waypoint selection dialog and the waypoint
+    manager; their icons were always drawn as unreachable even when the
+    map showed the same airfield as reachable #2836
 * glide computer
   - fix wild T Avg climb rates by preferring the instrument vario when
     available #2754

--- a/build/main.mk
+++ b/build/main.mk
@@ -109,6 +109,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Waypoint/Manager.cpp \
 	$(SRC)/Dialogs/Waypoint/dlgWaypointEdit.cpp \
 	$(SRC)/Dialogs/Waypoint/WaypointList.cpp \
+	$(SRC)/Dialogs/Waypoint/GetWaypointReachability.cpp \
 	$(SRC)/Dialogs/Waypoint/NearestWaypoint.cpp \
 	\
 	$(SRC)/Dialogs/Settings/Panels/AirspaceConfigPanel.cpp \

--- a/src/Dialogs/Waypoint/GetWaypointReachability.cpp
+++ b/src/Dialogs/Waypoint/GetWaypointReachability.cpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "GetWaypointReachability.hpp"
+#include "Engine/Waypoint/Waypoint.hpp"
+#include "Computer/GlideComputer.hpp"
+#include "BackendComponents.hpp"
+#include "Components.hpp"
+#include "Interface.hpp"
+
+WaypointReachability
+GetWaypointReachability(const Waypoint &waypoint) noexcept
+{
+  if (!waypoint.IsLandable() && !waypoint.flags.watched)
+    return WaypointReachability::INVALID;
+
+  const auto *glide_computer = backend_components != nullptr
+    ? backend_components->glide_computer.get()
+    : nullptr;
+  const auto &settings = CommonInterface::GetComputerSettings();
+
+  return CalculateWaypointReach(waypoint,
+                                glide_computer != nullptr
+                                ? &glide_computer->GetProtectedRoutePlanner()
+                                : nullptr,
+                                CommonInterface::Basic(),
+                                CommonInterface::Calculated(),
+                                settings.polar, settings.task).reachability;
+}

--- a/src/Dialogs/Waypoint/GetWaypointReachability.hpp
+++ b/src/Dialogs/Waypoint/GetWaypointReachability.hpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Renderer/WaypointReachability.hpp"
+
+struct Waypoint;
+
+/**
+ * Reachability for drawing a waypoint icon in a dialog, using the
+ * same calculation as the map (current aircraft state and route
+ * planner when available).
+ */
+[[nodiscard]]
+WaypointReachability
+GetWaypointReachability(const Waypoint &waypoint) noexcept;

--- a/src/Dialogs/Waypoint/Manager.cpp
+++ b/src/Dialogs/Waypoint/Manager.cpp
@@ -18,6 +18,7 @@
 #include "Waypoint/WaypointFilter.hpp"
 #include "Waypoint/WaypointGlue.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
+#include "GetWaypointReachability.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 
@@ -160,7 +161,8 @@ WaypointManagerWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
   WaypointListRenderer::Draw(canvas, rc, *info.waypoint,
                              row_renderer,
                              UIGlobals::GetMapLook().waypoint,
-                             CommonInterface::GetMapSettings().waypoint);
+                             CommonInterface::GetMapSettings().waypoint,
+                             GetWaypointReachability(*info.waypoint));
 }
 
 void

--- a/src/Dialogs/Waypoint/WaypointList.cpp
+++ b/src/Dialogs/Waypoint/WaypointList.cpp
@@ -39,6 +39,7 @@
 #include "Language/Language.hpp"
 #include "Components.hpp"
 #include "DataComponents.hpp"
+#include "GetWaypointReachability.hpp"
 
 #include <algorithm>
 #include <list>
@@ -636,7 +637,8 @@ WaypointListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
                              info.GetVector(location),
                              row_renderer,
                              UIGlobals::GetMapLook().waypoint,
-                             CommonInterface::GetMapSettings().waypoint);
+                             CommonInterface::GetMapSettings().waypoint,
+                             GetWaypointReachability(*info.waypoint));
 }
 
 void

--- a/src/MapWindow/GlueMapWindowItems.cpp
+++ b/src/MapWindow/GlueMapWindowItems.cpp
@@ -77,7 +77,8 @@ GlueMapWindow::ShowMapItems(const GeoPoint &location,
   }
 
   if (waypoints)
-    builder.AddWaypoints(*waypoints);
+    builder.AddWaypoints(*waypoints, route_planner, basic, calculated,
+                         computer_settings);
 
 #ifdef HAVE_NOAA
   if (noaa_store)

--- a/src/MapWindow/Items/Builder.cpp
+++ b/src/MapWindow/Items/Builder.cpp
@@ -9,6 +9,8 @@
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/Points/OrderedTaskPoint.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
+#include "Renderer/WaypointReachability.hpp"
+#include "Computer/Settings.hpp"
 #include "NMEA/Aircraft.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Task/ProtectedRoutePlanner.hpp"
@@ -71,11 +73,25 @@ MapItemListBuilder::AddSelfIfNear(const GeoPoint &self, Angle bearing)
 }
 
 void
-MapItemListBuilder::AddWaypoints(const Waypoints &waypoints)
+MapItemListBuilder::AddWaypoints(const Waypoints &waypoints,
+                                 const ProtectedRoutePlanner *route_planner,
+                                 const MoreData &basic,
+                                 const DerivedInfo &calculated,
+                                 const ComputerSettings &settings)
 {
-  waypoints.VisitWithinRange(location, range, [&list=list](const auto &w){
-    if (!list.full())
-      list.append(new WaypointMapItem(w));
+  waypoints.VisitWithinRange(location, range, [&](const auto &w){
+    if (list.full())
+      return;
+
+    /* calculate the reachability the same way the map does, so the
+       icon in the dialog matches the one on the map */
+    auto reachable = WaypointReachability::INVALID;
+    if (w->IsLandable() || w->flags.watched)
+      reachable = CalculateWaypointReach(*w, route_planner, basic, calculated,
+                                         settings.polar,
+                                         settings.task).reachability;
+
+    list.append(new WaypointMapItem(w, reachable));
   });
 }
 

--- a/src/MapWindow/Items/Builder.hpp
+++ b/src/MapWindow/Items/Builder.hpp
@@ -22,6 +22,7 @@ struct ThermalLocatorInfo;
 struct NMEAInfo;
 class RasterTerrain;
 class ProtectedRoutePlanner;
+struct ComputerSettings;
 class NOAAStore;
 namespace TIM { struct Thermal; }
 
@@ -39,7 +40,10 @@ public:
   void AddArrivalAltitudes(const ProtectedRoutePlanner &route_planner,
                      const RasterTerrain *terrain, double safety_height);
   void AddSelfIfNear(const GeoPoint &self, Angle bearing);
-  void AddWaypoints(const Waypoints &waypoints);
+  void AddWaypoints(const Waypoints &waypoints,
+                    const ProtectedRoutePlanner *route_planner,
+                    const MoreData &basic, const DerivedInfo &calculated,
+                    const ComputerSettings &settings);
   void AddVisibleAirspace(const Airspaces &airspaces,
                           const ProtectedAirspaceWarningManager *warning_manager,
                           const AirspaceComputerSettings &computer_settings,

--- a/src/MapWindow/Items/MapItem.hpp
+++ b/src/MapWindow/Items/MapItem.hpp
@@ -13,6 +13,7 @@
 #include "Engine/Waypoint/Ptr.hpp"
 #include "Engine/Airspace/Ptr.hpp"
 #include "Engine/Route/ReachResult.hpp"
+#include "Renderer/WaypointReachability.hpp"
 #include "Tracking/SkyLines/Features.hpp"
 #include "util/StaticString.hxx"
 
@@ -166,8 +167,15 @@ struct WaypointMapItem: public MapItem
 {
   WaypointPtr waypoint;
 
-  WaypointMapItem(const WaypointPtr &_waypoint)
-    :MapItem(Type::WAYPOINT), waypoint(_waypoint) {}
+  /**
+   * The reachability of this waypoint, calculated the same way as on
+   * the map, so the icon in the dialog matches the one on the map.
+   */
+  WaypointReachability reachable;
+
+  WaypointMapItem(const WaypointPtr &_waypoint,
+                  WaypointReachability _reachable=WaypointReachability::INVALID)
+    :MapItem(Type::WAYPOINT), waypoint(_waypoint), reachable(_reachable) {}
 };
 
 #ifdef HAVE_NOAA

--- a/src/Renderer/MapItemListRenderer.cpp
+++ b/src/Renderer/MapItemListRenderer.cpp
@@ -241,7 +241,8 @@ Draw(Canvas &canvas, const PixelRect rc,
      const WaypointRendererSettings &renderer_settings)
 {
   WaypointListRenderer::Draw(canvas, rc, *item.waypoint,
-                             row_renderer, look, renderer_settings);
+                             row_renderer, look, renderer_settings,
+                             item.reachable);
 }
 
 #ifdef HAVE_NOAA

--- a/src/Renderer/WaypointListRenderer.cpp
+++ b/src/Renderer/WaypointListRenderer.cpp
@@ -41,7 +41,8 @@ Draw(Canvas &canvas, PixelRect rc,
      const Waypoint &waypoint, const GeoVector *vector,
      const TwoTextRowsRenderer &row_renderer,
      const WaypointLook &look,
-     const WaypointRendererSettings &settings)
+     const WaypointRendererSettings &settings,
+     WaypointReachability reachable)
 {
   const unsigned padding = Layout::GetTextPadding();
   const unsigned line_height = rc.GetHeight();
@@ -53,7 +54,7 @@ Draw(Canvas &canvas, PixelRect rc,
   const PixelPoint pt(rc.left + line_height / 2, rc.top + line_height / 2);
   WaypointIconRenderer wir(settings, look, canvas);
   wir.SetIconSize(icon_size);
-  wir.Draw(waypoint, pt);
+  wir.Draw(waypoint, pt, reachable);
 
   rc.left += line_height + padding;
 
@@ -91,9 +92,11 @@ WaypointListRenderer::Draw(Canvas &canvas, const PixelRect rc,
                            const Waypoint &waypoint,
                            const TwoTextRowsRenderer &row_renderer,
                            const WaypointLook &look,
-                           const WaypointRendererSettings &renderer_settings)
+                           const WaypointRendererSettings &renderer_settings,
+                           WaypointReachability reachable)
 {
-  ::Draw(canvas, rc, waypoint, nullptr, row_renderer, look, renderer_settings);
+  ::Draw(canvas, rc, waypoint, nullptr, row_renderer, look, renderer_settings,
+         reachable);
 }
 
 void
@@ -101,9 +104,11 @@ WaypointListRenderer::Draw(Canvas &canvas, const PixelRect rc,
                            const Waypoint &waypoint, const GeoVector &vector,
                            const TwoTextRowsRenderer &row_renderer,
                            const WaypointLook &look,
-                           const WaypointRendererSettings &settings)
+                           const WaypointRendererSettings &settings,
+                           WaypointReachability reachable)
 {
-  ::Draw(canvas, rc, waypoint, &vector, row_renderer, look, settings);
+  ::Draw(canvas, rc, waypoint, &vector, row_renderer, look, settings,
+         reachable);
 }
 
 void

--- a/src/Renderer/WaypointListRenderer.hpp
+++ b/src/Renderer/WaypointListRenderer.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "WaypointReachability.hpp"
+
 class Canvas;
 class TwoTextRowsRenderer;
 struct PixelRect;
@@ -16,13 +18,15 @@ namespace WaypointListRenderer
   void Draw(Canvas &canvas, const PixelRect rc, const Waypoint &waypoint,
             const TwoTextRowsRenderer &row_renderer,
             const WaypointLook &look,
-            const WaypointRendererSettings &renderer_settings);
+            const WaypointRendererSettings &renderer_settings,
+            WaypointReachability reachable=WaypointReachability::INVALID);
 
   void Draw(Canvas &canvas, const PixelRect rc, const Waypoint &waypoint,
             const GeoVector &vector,
             const TwoTextRowsRenderer &row_renderer,
             const WaypointLook &look,
-            const WaypointRendererSettings &settings);
+            const WaypointRendererSettings &settings,
+            WaypointReachability reachable=WaypointReachability::INVALID);
 
   void Draw(Canvas &canvas, const PixelRect rc, const Waypoint &waypoint,
             double distance, double arrival_altitude,

--- a/src/Renderer/WaypointReachability.hpp
+++ b/src/Renderer/WaypointReachability.hpp
@@ -3,7 +3,18 @@
 
 #pragma once
 
+#include "Engine/Route/ReachResult.hpp"
+
 #include <cstdint>
+
+struct Waypoint;
+struct MoreData;
+struct DerivedInfo;
+struct PolarSettings;
+struct TaskBehaviour;
+struct SpeedVector;
+class MacCready;
+class ProtectedRoutePlanner;
 
 enum class WaypointReachability : uint8_t {
   INVALID,
@@ -27,3 +38,55 @@ IsReachable(WaypointReachability r) noexcept
 
   return false;
 }
+
+/**
+ * The reachability of a waypoint, as used for drawing its icon.
+ */
+struct WaypointReach {
+  ReachResult result{
+    .direct = 0,
+    .terrain = 0,
+    .terrain_valid = ReachResult::Validity::INVALID,
+  };
+
+  WaypointReachability reachability = WaypointReachability::INVALID;
+
+  constexpr bool IsReachable() const noexcept {
+    return ::IsReachable(reachability);
+  }
+};
+
+/**
+ * Calculate the reachability of the given waypoint using the route
+ * planner, i.e. taking terrain into account.
+ */
+WaypointReach
+CalculateWaypointReachRoute(const Waypoint &waypoint,
+                            const ProtectedRoutePlanner &route_planner,
+                            const TaskBehaviour &task_behaviour) noexcept;
+
+/**
+ * Calculate the reachability of the given waypoint with a straight
+ * glide, ignoring terrain.
+ */
+WaypointReach
+CalculateWaypointReachDirect(const Waypoint &waypoint, const MoreData &basic,
+                             const SpeedVector &wind,
+                             const MacCready &mac_cready,
+                             const TaskBehaviour &task_behaviour) noexcept;
+
+/**
+ * Calculate the reachability of the given waypoint the same way the
+ * map does: via the route planner as long as terrain reach data is
+ * available, and with a straight glide otherwise.
+ *
+ * This is for code which draws a waypoint icon outside of the map
+ * (e.g. dialogs), and which therefore has no pre-calculated reach at
+ * hand.
+ */
+WaypointReach
+CalculateWaypointReach(const Waypoint &waypoint,
+                       const ProtectedRoutePlanner *route_planner,
+                       const MoreData &basic, const DerivedInfo &calculated,
+                       const PolarSettings &polar_settings,
+                       const TaskBehaviour &task_behaviour) noexcept;

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -34,6 +34,95 @@
 #include <cassert>
 #include <stdio.h>
 
+WaypointReach
+CalculateWaypointReachRoute(const Waypoint &waypoint,
+                            const ProtectedRoutePlanner &route_planner,
+                            const TaskBehaviour &task_behaviour) noexcept
+{
+  WaypointReach reach;
+
+  if (!waypoint.has_elevation)
+    return reach;
+
+  const double elevation = waypoint.elevation +
+    task_behaviour.safety_height_arrival;
+  const AGeoPoint p_dest(waypoint.location, elevation);
+
+  const auto result = route_planner.FindPositiveArrival(p_dest);
+  if (!result)
+    return reach;
+
+  reach.result = *result;
+  reach.result.Subtract(elevation);
+
+  if (!reach.result.IsReachableDirect())
+    reach.reachability = WaypointReachability::UNREACHABLE;
+  else if (task_behaviour.route_planner.IsReachEnabled() &&
+           !reach.result.IsReachableTerrain())
+    reach.reachability = WaypointReachability::STRAIGHT;
+  else
+    reach.reachability = WaypointReachability::TERRAIN;
+
+  return reach;
+}
+
+WaypointReach
+CalculateWaypointReachDirect(const Waypoint &waypoint, const MoreData &basic,
+                             const SpeedVector &wind,
+                             const MacCready &mac_cready,
+                             const TaskBehaviour &task_behaviour) noexcept
+{
+  assert(basic.location_available);
+  assert(basic.NavAltitudeAvailable());
+
+  WaypointReach reach;
+
+  if (!waypoint.has_elevation)
+    return reach;
+
+  const auto elevation = waypoint.elevation +
+    task_behaviour.safety_height_arrival;
+  const GlideState state(GeoVector(basic.location, waypoint.location),
+                         elevation, basic.nav_altitude, wind);
+
+  const GlideResult result = mac_cready.SolveStraight(state);
+  if (!result.IsOk())
+    return reach;
+
+  reach.result.direct = result.pure_glide_altitude_difference;
+  reach.reachability = result.pure_glide_altitude_difference > 0
+    ? WaypointReachability::TERRAIN
+    : WaypointReachability::UNREACHABLE;
+
+  return reach;
+}
+
+WaypointReach
+CalculateWaypointReach(const Waypoint &waypoint,
+                       const ProtectedRoutePlanner *route_planner,
+                       const MoreData &basic, const DerivedInfo &calculated,
+                       const PolarSettings &polar_settings,
+                       const TaskBehaviour &task_behaviour) noexcept
+{
+  if (route_planner != nullptr && !route_planner->IsTerrainReachEmpty())
+    return CalculateWaypointReachRoute(waypoint, *route_planner,
+                                       task_behaviour);
+
+  if (!basic.location_available || !basic.NavAltitudeAvailable())
+    return {};
+
+  const GlidePolar &glide_polar =
+    task_behaviour.route_planner.reach_polar_mode == RoutePlannerConfig::Polar::TASK
+    ? polar_settings.glide_polar_task
+    : calculated.glide_polar_safety;
+
+  return CalculateWaypointReachDirect(waypoint, basic,
+                                      calculated.GetWindOrZero(),
+                                      MacCready(task_behaviour.glide,
+                                                glide_polar),
+                                      task_behaviour);
+}
+
 /**
  * Metadata for a Waypoint that is about to be drawn.
  */
@@ -61,63 +150,23 @@ struct VisibleWaypoint {
     return ::IsReachable(reachable);
   }
 
+  void Set(const WaypointReach &_reach) noexcept {
+    reach = _reach.result;
+    reachable = _reach.reachability;
+  }
+
   void CalculateReachabilityDirect(const MoreData &basic,
                                    const SpeedVector &wind,
                                    const MacCready &mac_cready,
                                    const TaskBehaviour &task_behaviour) noexcept {
-    assert(basic.location_available);
-    assert(basic.NavAltitudeAvailable());
-
-    if (!waypoint->has_elevation)
-      return;
-
-    const auto elevation = waypoint->elevation +
-      task_behaviour.safety_height_arrival;
-    const GlideState state(GeoVector(basic.location, waypoint->location),
-                           elevation, basic.nav_altitude, wind);
-
-    const GlideResult result = mac_cready.SolveStraight(state);
-    if (!result.IsOk())
-      return;
-
-    reach.direct = result.pure_glide_altitude_difference;
-    if (result.pure_glide_altitude_difference > 0)
-      reachable = WaypointReachability::TERRAIN;
-    else
-      reachable = WaypointReachability::UNREACHABLE;
-  }
-
-  bool CalculateRouteArrival(const ProtectedRoutePlanner &route_planner,
-                             const TaskBehaviour &task_behaviour) noexcept {
-    if (!waypoint->has_elevation)
-      return false;
-
-    const double elevation = waypoint->elevation +
-      task_behaviour.safety_height_arrival;
-    const AGeoPoint p_dest (waypoint->location, elevation);
-
-    auto _reach = route_planner.FindPositiveArrival(p_dest);
-    if (!_reach)
-      return false;
-
-    reach = *_reach;
-    reach.Subtract(elevation);
-    return true;
+    Set(CalculateWaypointReachDirect(*waypoint, basic, wind, mac_cready,
+                                     task_behaviour));
   }
 
   void CalculateReachability(const ProtectedRoutePlanner &route_planner,
                              const TaskBehaviour &task_behaviour) noexcept
   {
-    if (!CalculateRouteArrival(route_planner, task_behaviour))
-      return;
-
-    if (!reach.IsReachableDirect())
-      reachable = WaypointReachability::UNREACHABLE;
-    else if (task_behaviour.route_planner.IsReachEnabled() &&
-             !reach.IsReachableTerrain())
-      reachable = WaypointReachability::STRAIGHT;
-    else
-      reachable = WaypointReachability::TERRAIN;
+    Set(CalculateWaypointReachRoute(*waypoint, route_planner, task_behaviour));
   }
 
   void DrawSymbol(WaypointIconRenderer &wir) const noexcept {


### PR DESCRIPTION
Closes #2836.

The alternates list still derives its icon from `arrival_altitude > 0` and therefore never shows the marginal/orange state that the map has. Is that intentional, or would you like me to switch it to the same functions?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added waypoint reachability indicators to map elements, waypoint selection, and waypoint manager views.
  * Icons now reflect whether landable or watched waypoints are reachable based on current flight conditions and route settings.

* **Bug Fixes**
  * Corrected waypoint icons that were previously displayed as unreachable regardless of actual accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->