### PR TITLE
MapWindow: Limit trail drift to near zoom scales

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -403,6 +403,9 @@ Version 7.45 - not yet released
     pre-filtered to recently-used waypoints; listed in the Gesture Help
     dialog with its own icon #336
 * map
+  - apply snail trail wind drift only when zoomed in (about 16 km across
+    the short map edge), so a Full trail in circling mode no longer
+    looks shifted away from turnpoints at overview scales #2835
   - fix black terrain after idle high-resolution sharpening on OpenGL
     devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
   - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi

--- a/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SymbolsConfigPanel.cpp
@@ -149,9 +149,9 @@ SymbolsConfigPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
   SetExpertRow(TRAIL_LENGTH);
 
   AddBoolean(_("Trail drift"),
-             _("Determines whether the snail trail is drifted with the wind when displayed in "
-               "circling mode. Switched Off, "
-               "the snail trail stays uncompensated for wind drift."),
+             _("Determines whether the snail trail is drifted with the wind "
+               "when displayed in circling mode at near map scales. Switched "
+               "Off, the snail trail stays uncompensated for wind drift."),
              settings_map.trail.wind_drift_enabled);
   SetExpertRow(TRAIL_DRIFT);
 

--- a/src/Dialogs/Settings/WindSettingsPanel.cpp
+++ b/src/Dialogs/Settings/WindSettingsPanel.cpp
@@ -52,8 +52,8 @@ WindSettingsPanel::Prepare(ContainerWindow &parent,
   if (edit_trail_drift)
     AddBoolean(_("Trail drift"),
                _("Determines whether the snail trail is drifted with the wind "
-                 "when displayed in circling mode. Switched Off, "
-                 "the snail trail stays uncompensated for wind drift."),
+                 "when displayed in circling mode at near map scales. Switched "
+                 "Off, the snail trail stays uncompensated for wind drift."),
                map_settings.trail.wind_drift_enabled);
   else
     AddDummy();

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -465,8 +465,17 @@ GlueMapWindow::RenderTrail(Canvas &canvas,
     break;
   }
 
-  DrawTrail(canvas, aircraft_pos, min_time,
-            GetMapSettings().trail.wind_drift_enabled && InCirclingMode());
+  /* Trail drift is for thermal centering at near zoom.  At overview
+     scales a Full trail shifted by hours of wind looks like a wrong
+     ground track (#2835, #709).  GetMapScale 2000 ≈ 16 km short edge. */
+  static constexpr double TRAIL_DRIFT_MAX_MAP_SCALE = 2000;
+
+  const bool enable_traildrift =
+    GetMapSettings().trail.wind_drift_enabled &&
+    InCirclingMode() &&
+    render_projection.GetMapScale() <= TRAIL_DRIFT_MAX_MAP_SCALE;
+
+  DrawTrail(canvas, aircraft_pos, min_time, enable_traildrift);
 }
 
 void


### PR DESCRIPTION
## Summary
- Enable snail trail wind drift only when circling **and** zoomed in (`GetMapScale` ≤ 2000, ~16 km short map edge), so a Full trail no longer looks shifted away from turnpoints at overview / pan scales.
- Update Trail drift help text to mention near map scales.
- Fixes #2835 (same class of confusion as #709).

## Test plan
- [ ] Enable Trail drift; enter circling with a long/Full trail at typical circle zoom — trail still drifts with wind for thermal centering
- [ ] While still circling, zoom/pan out past ~16 km short-edge scale — trail snaps back to the real ground track
- [ ] In cruise (any zoom), trail remains undrifted
- [ ] Confirm help text under Map Display → Elements and Wind settings mentions near map scales

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wind-drift compensation for snail trails now appears only while circling and when zoomed in sufficiently, preventing displaced trails at overview map scales.
  * Updated the “Trail drift” setting descriptions to clarify when wind compensation applies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->