### PR TITLE
Time: follow the operating system time zone automatically

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -84,6 +84,9 @@ Version 7.46 - not yet released
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
 * ui
+  - Support manual UTC offsets up to +14:00 in 15-minute increments
+  - Keep automatic UTC offsets synchronized with the operating-system
+    time zone, including daylight-saving and travel changes
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
   - fix blurry icons on high-DPI screens, most visible on the large
@@ -102,6 +105,7 @@ Version 7.46 - not yet released
     swipe had started on kept the mouse capture, so every later press
     was delivered to it instead of to the control that was pressed
 * documentation
+  - document 15-minute UTC offset selection
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development
   - build system: use Android SDK 36 and Build-Tools 36.0.0

--- a/build/libtime.mk
+++ b/build/libtime.mk
@@ -8,6 +8,7 @@ TIME_SOURCES = \
 	$(TIME_SRC_DIR)/DeltaTime.cpp \
 	$(TIME_SRC_DIR)/WrapClock.cpp \
 	$(TIME_SRC_DIR)/LocalTime.cpp \
+	$(TIME_SRC_DIR)/SystemTimeZone.cpp \
 	$(TIME_SRC_DIR)/BrokenTime.cpp \
 	$(TIME_SRC_DIR)/BrokenDate.cpp \
 	$(TIME_SRC_DIR)/BrokenDateTime.cpp

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -961,7 +961,10 @@ Es ist jedoch möglich, die angegebenen Werte nach Belieben zu mischen und so z.
 Einstellen der Uhr mit Referenz zur UTC-Zeit.
 
 \begin{description}
-\item[\textit{Zeitzonenverschiebung}]  {\bf -13 ..+13h}: In diesem Feld wird die Zeitzonenverscheibung zur UTC zeit eingebeben. Die Differenz kann im 30Minuten-Intervall eingegeben werden.
+\item[\textit{Automatische Zeitzonenverschiebung}] {\bf Ein /Aus}:\\
+{\bf Ein}: Die Zeitzonenverschiebung wird aus der im Betriebssystem eingestellten Zeitzone übernommen und laufend nachgeführt. Damit folgt sie automatisch der Sommer-/Winterzeitumstellung und einem Wechsel in eine andere Zeitzone.\\
+{\bf Aus}: Die Zeitzonenverschiebung wird im folgenden Feld von Hand eingegeben.
+\item[\textit{Zeitzonenverschiebung}]  {\bf -13 ..+13h}: In diesem Feld wird die Zeitzonenverscheibung zur UTC zeit eingebeben. Das Feld ist nur bearbeitbar, wenn die automatische Zeitzonenverschiebung ausgeschaltet ist. Die Differenz kann im 30Minuten-Intervall eingegeben werden.
 Zur Kontrolle wird im Feld darunter die entsprechende Lokalzeit angegeben -- um Mißverständnisse zu verhindern.
 
 Achtung! 

--- a/doc/manual/de/ch11_configuration.tex
+++ b/doc/manual/de/ch11_configuration.tex
@@ -964,7 +964,7 @@ Einstellen der Uhr mit Referenz zur UTC-Zeit.
 \item[\textit{Automatische Zeitzonenverschiebung}] {\bf Ein /Aus}:\\
 {\bf Ein}: Die Zeitzonenverschiebung wird aus der im Betriebssystem eingestellten Zeitzone übernommen und laufend nachgeführt. Damit folgt sie automatisch der Sommer-/Winterzeitumstellung und einem Wechsel in eine andere Zeitzone.\\
 {\bf Aus}: Die Zeitzonenverschiebung wird im folgenden Feld von Hand eingegeben.
-\item[\textit{Zeitzonenverschiebung}]  {\bf -13 ..+13h}: In diesem Feld wird die Zeitzonenverscheibung zur UTC zeit eingebeben. Das Feld ist nur bearbeitbar, wenn die automatische Zeitzonenverschiebung ausgeschaltet ist. Die Differenz kann im 30Minuten-Intervall eingegeben werden.
+\item[\textit{Zeitzonenverschiebung}]  {\bf -13 ..+14h}: In diesem Feld wird die Zeitzonenverscheibung zur UTC zeit eingebeben. Das Feld ist nur bearbeitbar, wenn die automatische Zeitzonenverschiebung ausgeschaltet ist. Die Differenz kann im 15-Minuten-Intervall eingegeben werden.
 Zur Kontrolle wird im Feld darunter die entsprechende Lokalzeit angegeben -- um Mißverständnisse zu verhindern.
 
 Achtung! 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -935,7 +935,12 @@ will be referenced as `Custom' set and will also be stored in your profile.
 Set the local time offset with respect to UTC.
 
 \begin{description}
-\item[UTC offset]  The field allows the UTC local time offset to be specified.
+\item[Automatic UTC offset]  If enabled, the UTC offset is taken from the time zone
+  configured in the operating system and is kept up to date, so it follows daylight
+  saving time changes and travelling to another time zone.  Disable this option to
+  enter the offset manually.
+\item[UTC offset]  The field allows the UTC local time offset to be specified.  It is
+  only editable while `Automatic UTC offset' is disabled.
 \item[Local time]  The local time is displayed below in order to make it easier to verify
   the correct offset has been entered.  Offsets to the half-hour may be set.
 \item[Use GPS time*] This option, if enabled sets the clock of the computer to 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -942,7 +942,7 @@ Set the local time offset with respect to UTC.
 \item[UTC offset]  The field allows the UTC local time offset to be specified.  It is
   only editable while `Automatic UTC offset' is disabled.
 \item[Local time]  The local time is displayed below in order to make it easier to verify
-  the correct offset has been entered.  Offsets to the half-hour may be set.
+  the correct offset has been entered.  Offsets to the quarter-hour may be set.
 \item[Use GPS time*] This option, if enabled sets the clock of the computer to 
   the GPS time once a fix is set. This is only necessary if your computer does 
   not have a real-time clock with battery backup or your computer 

--- a/doc/manual/pt_BR/ch11_configuration.tex
+++ b/doc/manual/pt_BR/ch11_configuration.tex
@@ -551,8 +551,11 @@ Há seleções separada para todos os itens.  Uma vez alterado alguma pré-confi
 Ajusta a hora local compensada relativa ao fuso horário.
 
 \begin{description}
-\item[Fuso horário]  o campo permite selecionar o fuso horário local.
-\item[Hora local]  a hora local é mostrada para que verifique mais facilmente se o fuso horário está correto.  Fusos horários de meia hora podem ser configurados.
+\item[Offset UTC automático]  se ativado, o offset UTC é obtido do fuso horário
+  configurado no sistema operacional e é mantido atualizado, seguindo mudanças
+  de horário de verão e viagens para outro fuso horário.  Desative esta opção
+  para inserir o offset UTC manualmente.
+\item[Hora local]  a hora local é mostrada para que verifique mais facilmente se o fuso horário está correto.  Fusos horários de quinze minutos podem ser configurados.
 \item[Usar hora GPS*] esta opção, se ativada, ajusta o relógio do computador à hora do GPS.  Isto é necessário somente se o seu computador não tiver um relógio com bateria de reserva ou seu computador frequentemente perde a energia da bateria.
 \end{description}
 

--- a/src/Computer/Settings.cpp
+++ b/src/Computer/Settings.cpp
@@ -3,7 +3,7 @@
 
 #include "Settings.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
-#include "time/Zone.hxx"
+#include "time/SystemTimeZone.hpp"
 
 void
 PolarSettings::SetDefaults()
@@ -57,7 +57,8 @@ ComputerSettings::SetDefaults()
 
   average_eff_time = ae30seconds;
   set_system_time_from_gps = false;
-  utc_offset = RoughTimeDelta::FromSeconds(GetTimeZoneOffset());
+  auto_utc_offset = true;
+  utc_offset = RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
   forecast_temperature = Temperature::FromCelsius(25);
   pressure = AtmosphericPressure::Standard();
   pressure_available.Clear();

--- a/src/Computer/Settings.hpp
+++ b/src/Computer/Settings.hpp
@@ -211,6 +211,13 @@ struct ComputerSettings {
   /** Update system time from GPS time */
   bool set_system_time_from_gps;
 
+  /**
+   * Keep #utc_offset synchronised with the time zone configured in the
+   * operating system?  This follows daylight saving time transitions
+   * and time zone changes while travelling.
+   */
+  bool auto_utc_offset;
+
   /** local time adjustment (in seconds) */
   RoughTimeDelta utc_offset;
 

--- a/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "TimeConfigPanel.hpp"
+#include "Form/DataField/Boolean.hpp"
 #include "Form/DataField/Listener.hpp"
 #include "Form/DataField/Time.hpp"
 #include "Formatter/LocalTimeFormatter.hpp"
@@ -10,10 +11,12 @@
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
+#include "time/SystemTimeZone.hpp"
 
 using namespace std::chrono;
 
 enum ControlIndex {
+  AutoUTCOffset,
   UTCOffset,
   LocalTime,
   SystemTimeFromGPS
@@ -27,6 +30,12 @@ public:
 
 public:
   void SetLocalTime(RoughTimeDelta utc_offset);
+
+  /**
+   * Enable/disable the manual UTC offset field and, while the
+   * automatic mode is enabled, show the offset we would use.
+   */
+  void UpdateAutoUTCOffset(bool automatic);
 
   /* methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -45,11 +54,26 @@ TimeConfigPanel::SetLocalTime(RoughTimeDelta utc_offset)
 }
 
 void
+TimeConfigPanel::UpdateAutoUTCOffset(bool automatic)
+{
+  SetRowEnabled(UTCOffset, !automatic);
+
+  if (automatic) {
+    const auto utc_offset =
+      RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
+    LoadValueDuration(UTCOffset, utc_offset.ToDuration());
+    SetLocalTime(utc_offset);
+  }
+}
+
+void
 TimeConfigPanel::OnModified(DataField &df) noexcept
 {
   if (IsDataField(UTCOffset, df)) {
     const auto &tdf = static_cast<const DataFieldTime &>(df);
     SetLocalTime(RoughTimeDelta::FromDuration(tdf.GetValue()));
+  } else if (IsDataField(AutoUTCOffset, df)) {
+    UpdateAutoUTCOffset(static_cast<const DataFieldBoolean &>(df).GetValue());
   }
 }
 
@@ -62,6 +86,14 @@ TimeConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
     CommonInterface::GetComputerSettings();
 
   const RoughTimeDelta utc_offset = settings_computer.utc_offset;
+
+  AddBoolean(_("Automatic UTC offset"),
+             _("Use the time zone configured in the operating system, and keep "
+               "following it across daylight saving time changes and when "
+               "travelling to another time zone. Disable this to enter the UTC "
+               "offset manually."),
+             settings_computer.auto_utc_offset, this);
+
   AddDuration(_("UTC offset"),
           _("The UTC offset field allows the UTC local time offset to be specified. The local "
             "time is displayed below in order to make it easier to verify the correct offset "
@@ -74,6 +106,8 @@ TimeConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
 
   Add(_("Local time"), 0, true);
   SetLocalTime(utc_offset);
+
+  UpdateAutoUTCOffset(settings_computer.auto_utc_offset);
 
   AddBoolean(_("Use GPS time"),
              _("If enabled sets the clock of the computer to the GPS time once a fix "
@@ -91,13 +125,31 @@ TimeConfigPanel::Save(bool &_changed) noexcept
 
   ComputerSettings &settings_computer = CommonInterface::SetComputerSettings();
 
-  const auto ival = GetValueTime(UTCOffset);
-  if (const auto new_utc_offset = RoughTimeDelta::FromDuration(ival);
-      new_utc_offset != settings_computer.utc_offset) {
-    settings_computer.utc_offset = new_utc_offset;
+  changed |= SaveValue(AutoUTCOffset, ProfileKeys::AutoUTCOffset,
+                       settings_computer.auto_utc_offset);
 
+  if (settings_computer.auto_utc_offset) {
+    /* in automatic mode, the UTC offset is owned by
+       UTCOffsetProcessTimer(); apply it right away instead of the
+       (disabled) form value, so the change is visible immediately */
+    if (const auto new_utc_offset =
+          RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
+        new_utc_offset != settings_computer.utc_offset) {
+      settings_computer.utc_offset = new_utc_offset;
+      changed = true;
+    }
+  } else {
+    const auto ival = GetValueTime(UTCOffset);
+
+    if (const auto new_utc_offset = RoughTimeDelta::FromDuration(ival);
+        new_utc_offset != settings_computer.utc_offset) {
+      settings_computer.utc_offset = new_utc_offset;
+      changed = true;
+    }
+
+    /* always store the manual offset, so switching back from automatic
+       mode restores what the user had configured */
     Profile::Set(ProfileKeys::UTCOffsetSigned, ival);
-    changed = true;
   }
 
   changed |= SaveValue(SystemTimeFromGPS, ProfileKeys::SetSystemTimeFromGPS,

--- a/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
@@ -20,10 +20,10 @@ using namespace std::chrono;
 static constexpr auto UTC_OFFSET_STEP = minutes{15};
 
 enum ControlIndex {
-  AutoUTCOffset,
-  UTCOffset,
-  LocalTime,
-  SystemTimeFromGPS
+  AUTO_UTC_OFFSET,
+  UTC_OFFSET,
+  LOCAL_TIME,
+  SYSTEM_TIME_FROM_GPS
 };
 
 class TimeConfigPanel final
@@ -56,31 +56,31 @@ private:
 void
 TimeConfigPanel::SetLocalTime(RoughTimeDelta utc_offset)
 {
-  SetText(LocalTime,
+  SetText(LOCAL_TIME,
           FormatLocalTimeHHMM(CommonInterface::Basic().time, utc_offset));
 }
 
 void
 TimeConfigPanel::UpdateAutoUTCOffset(bool automatic)
 {
-  SetRowEnabled(UTCOffset, !automatic);
+  SetRowEnabled(UTC_OFFSET, !automatic);
 
   const auto utc_offset = automatic
     ? RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset())
     : manual_utc_offset;
-  LoadValueDuration(UTCOffset, utc_offset.ToDuration());
+  LoadValueDuration(UTC_OFFSET, utc_offset.ToDuration());
   SetLocalTime(utc_offset);
 }
 
 void
 TimeConfigPanel::OnModified(DataField &df) noexcept
 {
-  if (IsDataField(UTCOffset, df)) {
+  if (IsDataField(UTC_OFFSET, df)) {
     const auto &tdf = static_cast<const DataFieldTime &>(df);
     manual_utc_offset = RoughTimeDelta::FromDuration(tdf.GetValue());
     manual_utc_offset_modified = true;
     SetLocalTime(manual_utc_offset);
-  } else if (IsDataField(AutoUTCOffset, df)) {
+  } else if (IsDataField(AUTO_UTC_OFFSET, df)) {
     UpdateAutoUTCOffset(static_cast<const DataFieldBoolean &>(df).GetValue());
   }
 }
@@ -125,7 +125,7 @@ TimeConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
                "real-time clock with battery backup or your computer frequently runs "
                "out of battery power or otherwise loses time."),
              settings_computer.set_system_time_from_gps);
-  SetExpertRow(SystemTimeFromGPS);
+  SetExpertRow(SYSTEM_TIME_FROM_GPS);
 }
 
 bool
@@ -135,7 +135,7 @@ TimeConfigPanel::Save(bool &_changed) noexcept
 
   ComputerSettings &settings_computer = CommonInterface::SetComputerSettings();
 
-  changed |= SaveValue(AutoUTCOffset, ProfileKeys::AutoUTCOffset,
+  changed |= SaveValue(AUTO_UTC_OFFSET, ProfileKeys::AutoUTCOffset,
                        settings_computer.auto_utc_offset);
 
   if (settings_computer.auto_utc_offset) {
@@ -149,7 +149,7 @@ TimeConfigPanel::Save(bool &_changed) noexcept
       changed = true;
     }
   } else {
-    const auto ival = GetValueTime(UTCOffset);
+    const auto ival = GetValueTime(UTC_OFFSET);
 
     if (const auto new_utc_offset = RoughTimeDelta::FromDuration(ival);
         new_utc_offset != settings_computer.utc_offset) {
@@ -166,7 +166,7 @@ TimeConfigPanel::Save(bool &_changed) noexcept
     changed = true;
   }
 
-  changed |= SaveValue(SystemTimeFromGPS, ProfileKeys::SetSystemTimeFromGPS,
+  changed |= SaveValue(SYSTEM_TIME_FROM_GPS, ProfileKeys::SetSystemTimeFromGPS,
                        settings_computer.set_system_time_from_gps);
 
   _changed |= changed;

--- a/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
@@ -17,6 +17,8 @@
 
 using namespace std::chrono;
 
+static constexpr auto UTC_OFFSET_STEP = minutes{15};
+
 enum ControlIndex {
   AutoUTCOffset,
   UTCOffset,
@@ -106,9 +108,9 @@ TimeConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
           _("The UTC offset field allows the UTC local time offset to be specified. The local "
             "time is displayed below in order to make it easier to verify the correct offset "
             "has been entered."),
-              hours{-13},
-              hours{13},
-              minutes{30},
+              Profile::MIN_UTC_OFFSET,
+              Profile::MAX_UTC_OFFSET,
+              UTC_OFFSET_STEP,
               utc_offset.ToDuration(),
               2, this);
 

--- a/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TimeConfigPanel.cpp
@@ -6,6 +6,8 @@
 #include "Form/DataField/Listener.hpp"
 #include "Form/DataField/Time.hpp"
 #include "Formatter/LocalTimeFormatter.hpp"
+#include "Profile/ComputerProfile.hpp"
+#include "Profile/Current.hpp"
 #include "Profile/Profile.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
@@ -24,6 +26,9 @@ enum ControlIndex {
 
 class TimeConfigPanel final
   : public RowFormWidget, DataFieldListener {
+  RoughTimeDelta manual_utc_offset;
+  bool manual_utc_offset_modified = false;
+
 public:
   TimeConfigPanel()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
@@ -58,12 +63,11 @@ TimeConfigPanel::UpdateAutoUTCOffset(bool automatic)
 {
   SetRowEnabled(UTCOffset, !automatic);
 
-  if (automatic) {
-    const auto utc_offset =
-      RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
-    LoadValueDuration(UTCOffset, utc_offset.ToDuration());
-    SetLocalTime(utc_offset);
-  }
+  const auto utc_offset = automatic
+    ? RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset())
+    : manual_utc_offset;
+  LoadValueDuration(UTCOffset, utc_offset.ToDuration());
+  SetLocalTime(utc_offset);
 }
 
 void
@@ -71,7 +75,9 @@ TimeConfigPanel::OnModified(DataField &df) noexcept
 {
   if (IsDataField(UTCOffset, df)) {
     const auto &tdf = static_cast<const DataFieldTime &>(df);
-    SetLocalTime(RoughTimeDelta::FromDuration(tdf.GetValue()));
+    manual_utc_offset = RoughTimeDelta::FromDuration(tdf.GetValue());
+    manual_utc_offset_modified = true;
+    SetLocalTime(manual_utc_offset);
   } else if (IsDataField(AutoUTCOffset, df)) {
     UpdateAutoUTCOffset(static_cast<const DataFieldBoolean &>(df).GetValue());
   }
@@ -86,6 +92,8 @@ TimeConfigPanel::Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept
     CommonInterface::GetComputerSettings();
 
   const RoughTimeDelta utc_offset = settings_computer.utc_offset;
+  manual_utc_offset = utc_offset;
+  Profile::LoadUTCOffset(Profile::map, manual_utc_offset);
 
   AddBoolean(_("Automatic UTC offset"),
              _("Use the time zone configured in the operating system, and keep "
@@ -146,10 +154,14 @@ TimeConfigPanel::Save(bool &_changed) noexcept
       settings_computer.utc_offset = new_utc_offset;
       changed = true;
     }
+  }
 
-    /* always store the manual offset, so switching back from automatic
-       mode restores what the user had configured */
-    Profile::Set(ProfileKeys::UTCOffsetSigned, ival);
+  if (!settings_computer.auto_utc_offset || manual_utc_offset_modified) {
+    /* Without this key, a saved offset implies legacy manual mode. */
+    Profile::Set(ProfileKeys::AutoUTCOffset, settings_computer.auto_utc_offset);
+    Profile::Set(ProfileKeys::UTCOffsetSigned, manual_utc_offset.AsSeconds());
+    manual_utc_offset_modified = false;
+    changed = true;
   }
 
   changed |= SaveValue(SystemTimeFromGPS, ProfileKeys::SetSystemTimeFromGPS,

--- a/src/ProcessTimer.cpp
+++ b/src/ProcessTimer.cpp
@@ -9,6 +9,8 @@
 #include "Device/MultipleDevices.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
 #include "time/PeriodClock.hpp"
+#include "time/RoughTime.hpp"
+#include "time/SystemTimeZone.hpp"
 #include "MainWindow.hpp"
 #include "PopupMessage.hpp"
 #include "Simulator.hpp"
@@ -164,9 +166,33 @@ ProcessAutoBugs() noexcept
   }
 }
 
+/**
+ * Follow the operating system's time zone, unless the user has
+ * configured the UTC offset manually.  This picks up daylight saving
+ * time transitions and time zone changes while travelling.
+ */
+static void
+UTCOffsetProcessTimer() noexcept
+{
+  if (!CommonInterface::GetComputerSettings().auto_utc_offset)
+    return;
+
+  /* querying the time zone is cheap, but there is no point in doing it
+     on every timer tick */
+  static PeriodClock clock;
+  if (!clock.CheckUpdate(std::chrono::seconds(30)))
+    return;
+
+  const auto utc_offset =
+    RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
+  if (utc_offset != CommonInterface::GetComputerSettings().utc_offset)
+    CommonInterface::SetComputerSettings().utc_offset = utc_offset;
+}
+
 static void
 SettingsProcessTimer() noexcept
 {
+  UTCOffsetProcessTimer();
   BallastDumpProcessTimer();
   ProcessAutoBugs();
 }

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -10,6 +10,7 @@
 #include "ContestProfile.hpp"
 #include "Map.hpp"
 #include "Computer/Settings.hpp"
+#include "time/SystemTimeZone.hpp"
 
 namespace Profile {
   static void Load(const ProfileMap &map, WindSettings &settings);
@@ -161,7 +162,17 @@ Profile::Load(const ProfileMap &map, ComputerSettings &settings)
 
   map.Get(ProfileKeys::SetSystemTimeFromGPS, settings.set_system_time_from_gps);
 
-  LoadUTCOffset(map, settings.utc_offset);
+  const bool has_utc_offset = LoadUTCOffset(map, settings.utc_offset);
+
+  if (!map.Get(ProfileKeys::AutoUTCOffset, settings.auto_utc_offset))
+    /* migration from a profile written by an older version: enable the
+       automatic mode only for users who never configured an explicit
+       UTC offset, so we don't override a deliberate setting */
+    settings.auto_utc_offset = !has_utc_offset;
+
+  if (settings.auto_utc_offset)
+    settings.utc_offset =
+      RoughTimeDelta::FromSeconds(GetCurrentTimeZoneOffset());
 
   Load(map, settings.task);
   Load(map, settings.contest);

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -122,8 +122,8 @@ Profile::Load(const ProfileMap &map, WaveSettings &settings)
   map.Get(ProfileKeys::WaveAssistant, settings.enabled);
 }
 
-static bool
-LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r)
+bool
+Profile::LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r)
 {
   /* NOTE: Until 6.2.4 utc_offset was stored as a positive int in the
      settings file (with negative offsets stored as "utc_offset + 24 *

--- a/src/Profile/ComputerProfile.cpp
+++ b/src/Profile/ComputerProfile.cpp
@@ -123,7 +123,7 @@ Profile::Load(const ProfileMap &map, WaveSettings &settings)
 }
 
 bool
-Profile::LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r)
+Profile::LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r) noexcept
 {
   /* NOTE: Until 6.2.4 utc_offset was stored as a positive int in the
      settings file (with negative offsets stored as "utc_offset + 24 *
@@ -138,7 +138,7 @@ Profile::LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r)
     /* no profile value present */
     return false;
 
-  if (value > 13 * 3600 || value < -13 * 3600)
+  if (value > MAX_UTC_OFFSET.count() || value < MIN_UTC_OFFSET.count())
     /* illegal value */
     return false;
 

--- a/src/Profile/ComputerProfile.hpp
+++ b/src/Profile/ComputerProfile.hpp
@@ -5,7 +5,9 @@
 
 class ProfileMap;
 struct ComputerSettings;
+class RoughTimeDelta;
 
 namespace Profile {
+  bool LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r);
   void Load(const ProfileMap &map, ComputerSettings &settings);
 };

--- a/src/Profile/ComputerProfile.hpp
+++ b/src/Profile/ComputerProfile.hpp
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#include <chrono>
+
 class ProfileMap;
 struct ComputerSettings;
 class RoughTimeDelta;
 
 namespace Profile {
-  bool LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r);
+  constexpr std::chrono::seconds MIN_UTC_OFFSET{-13 * 3600};
+  constexpr std::chrono::seconds MAX_UTC_OFFSET{14 * 3600};
+
+  bool LoadUTCOffset(const ProfileMap &map, RoughTimeDelta &value_r) noexcept;
   void Load(const ProfileMap &map, ComputerSettings &settings);
 };

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -144,6 +144,7 @@ constexpr std::string_view AppAveThermalNeedle = "AppAveThermalNeedle";
 constexpr std::string_view AutoAdvance = "AutoAdvance";
 constexpr std::string_view UTCOffset = "UTCOffset";
 constexpr std::string_view UTCOffsetSigned = "UTCOffsetSigned";
+constexpr std::string_view AutoUTCOffset = "AutoUTCOffset";
 constexpr std::string_view BlockSTF = "BlockSpeedToFly";
 constexpr std::string_view AutoZoom = "AutoZoom";
 constexpr std::string_view MenuTimeout = "MenuTimeout";

--- a/src/time/SystemTimeZone.cpp
+++ b/src/time/SystemTimeZone.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SystemTimeZone.hpp"
+
+#ifdef _WIN32
+#include <timezoneapi.h>
+#else
+#include <time.h>
+#endif
+
+int
+GetCurrentTimeZoneOffset() noexcept
+{
+#ifdef _WIN32
+  TIME_ZONE_INFORMATION tzi;
+  const DWORD result = GetTimeZoneInformation(&tzi);
+  if (result == TIME_ZONE_ID_INVALID)
+    return 0;
+
+  int offset = -tzi.Bias * 60;
+
+  if (result == TIME_ZONE_ID_DAYLIGHT)
+    offset -= tzi.DaylightBias * 60;
+  else
+    offset -= tzi.StandardBias * 60;
+
+  return offset;
+#else
+  /* localtime_r() is not required to consult the time zone
+     configuration again, and glibc indeed does not: without this
+     tzset(), a time zone which was reconfigured after our first call
+     (e.g. after travelling) would never be picked up.  Daylight saving
+     time transitions would still work, because those rules are part of
+     the time zone which was loaded already */
+  tzset();
+
+  const time_t t = time(nullptr);
+
+  struct tm tm;
+  if (localtime_r(&t, &tm) == nullptr)
+    return 0;
+
+  /* tm_gmtoff is a BSD extension which is available on all of our
+     POSIX targets (glibc, Bionic, macOS); it already includes the
+     daylight saving time correction */
+  return (int)tm.tm_gmtoff;
+#endif
+}

--- a/src/time/SystemTimeZone.hpp
+++ b/src/time/SystemTimeZone.hpp
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Determine the local time zone offset [seconds] which is currently in
+ * effect, i.e. including daylight saving time.
+ *
+ * Unlike GetTimeZoneOffset(), the return value is not constant: it
+ * changes at daylight saving time transitions and whenever the
+ * operating system's time zone is reconfigured (e.g. while
+ * travelling).  Therefore it must not be cached.
+ */
+int
+GetCurrentTimeZoneOffset() noexcept;


### PR DESCRIPTION
Closes #2848. This PR adds an "Automatic UTC offset" setting (`AutoUTCOffset`) which keeps `ComputerSettings::utc_offset` in sync with the system time zone, applied when the profile is loaded and re-checked every 30 seconds from `ProcessTimer()`. While it is enabled, the manual UTC offset field is disabled and shows the offset in effect.

The offset is now obtained from the new `GetCurrentTimeZoneOffset()`, which (unlike `GetTimeZoneOffset()`) includes the daylight saving time correction. The existing function could not be changed because `TimeGm()` relies on it returning the standard time offset to undo a `mktime()` with `tm_isdst == 0`. The `tzset()` call in the POSIX branch is required rather than defensive: `localtime_r()` alone does not re-read the time zone configuration, so without it a zone changed after the first call is never picked up.

Profiles written by older versions get the automatic mode only when they never stored an explicit UTC offset, so a deliberately configured offset (e.g. a competition publishing start times in another time zone) is not overridden on upgrade.

Is a 30 second polling interval reasonable? Measured against glibc the check costs ~830 ns, so it is free either way — happy to change the interval, or to drop the timer and only re-read the offset at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic UTC offset detection based on the operating system’s current time zone.
  * Automatically updates offsets for daylight-saving changes and travel-related time-zone changes.
  * Added a setting to enable or disable automatic offset handling.
  * Manual UTC offsets now support 15-minute increments, from −13:00 to +14:00.

* **Bug Fixes**
  * Manual offsets are preserved when switching between automatic and manual modes.
  * UTC offsets remain synchronized with current system time-zone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->