### PR TITLE
Map: tappable compass, stable pan mode (#2839)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -424,6 +424,9 @@ Version 7.45 - not yet released
   - tap the on-map compass to reset a rotated map to north-up in pan
     mode, or to cycle the active display mode's map orientation; the
     compass is now always shown (previously hidden with north-up) #2839
+  - pan mode: the map rotation freezes at pan entry instead of following
+    the configured orientation (no more map spinning when panning while
+    circling with track-up); leaving pan restores the orientation
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -423,7 +423,8 @@ Version 7.45 - not yet released
     drawing began before map bounds were ready #2734
   - tap the on-map compass to reset a rotated map to north-up in pan
     mode, or to cycle the active display mode's map orientation; the
-    compass is now always shown (previously hidden with north-up) #2839
+    compass is now shown with north-up as well (it stays hidden only on
+    a dedicated "Map (north-up)" page) #2839
   - pan mode: the map rotation freezes at pan entry instead of following
     the configured orientation (no more map spinning when panning while
     circling with track-up); leaving pan restores the orientation

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -427,6 +427,8 @@ Version 7.45 - not yet released
   - pan mode: the map rotation freezes at pan entry instead of following
     the configured orientation (no more map spinning when panning while
     circling with track-up); leaving pan restores the orientation
+  - pan mode: with circling zoom enabled, the automatic zoom switch on
+    circling/cruise transitions is deferred until pan mode is left
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -421,6 +421,9 @@ Version 7.45 - not yet released
   - Add renderer to display distance rings around the current location #2522
   - Fix intermittent white-map hang on startup for non-OpenGL builds when
     drawing began before map bounds were ready #2734
+  - tap the on-map compass to reset a rotated map to north-up in pan
+    mode, or to cycle the active display mode's map orientation; the
+    compass is now always shown (previously hidden with north-up) #2839
 * ui
   - infoboxen: refresh titles after changing the interface language #2314
   - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -748,7 +748,9 @@ while outside pan mode it cycles through the available map
 orientations, briefly showing the newly selected mode.  The tap only
 changes the orientation setting of the currently active flight mode:
 while circling it cycles the circling orientation, otherwise the
-cruise orientation.
+cruise orientation.  On a dedicated \emph{Map (north-up)} page the
+orientation is fixed; the compass is not shown there and tapping it is
+therefore unavailable.
 \end{itemize}
 \vspace{2em}
 

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -742,6 +742,13 @@ finger positions (Android, iOS), pinching zooms the map about the point
 between the fingers, and twisting rotates it temporarily.  A two-finger
 drag or twist enters pan mode, and the temporary rotation is held until
 pan mode is left; a pinch that only zooms keeps following the aircraft.
+The north arrow (compass) in the top right corner of the map is a
+button: tapping it in pan mode resets a rotated map back to north-up,
+while outside pan mode it cycles through the available map
+orientations, briefly showing the newly selected mode.  The tap only
+changes the orientation setting of the currently active flight mode:
+while circling it cycles the circling orientation, otherwise the
+cruise orientation.
 \end{itemize}
 \vspace{2em}
 

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -184,6 +184,12 @@ class GlueMapWindow : public MapWindow {
 
   DisplayMode last_display_mode = DisplayMode::NONE;
 
+  /**
+   * A circling/cruise zoom switch (#SwitchZoomClimb) is due, but was
+   * deferred because pan mode was active.
+   */
+  bool switch_zoom_climb_pending = false;
+
   OffsetHistory offset_history;
 
   /*

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -172,14 +172,15 @@ class GlueMapWindow : public MapWindow {
 
   /** True after finger twist crosses the rotate dead zone. */
   bool pinch_rotating = false;
+#endif
 
   /**
-   * Hold #manual_rotation_angle instead of the configured orientation.
-   * Cleared by UpdateScreenAngle() when pan mode is left.
+   * Hold #manual_rotation_angle instead of the configured orientation
+   * while panning: set by a two-finger twist and by a compass tap in
+   * pan mode.  Cleared by UpdateScreenAngle() when pan mode is left.
    */
   bool manual_rotation = false;
   Angle manual_rotation_angle = Angle::Zero();
-#endif
 
   DisplayMode last_display_mode = DisplayMode::NONE;
 
@@ -391,6 +392,25 @@ private:
   void SwitchZoomClimb() noexcept;
 
   void SaveDisplayModeScales() noexcept;
+
+  /**
+   * Handle a tap at the given position if it hits the on-map compass
+   * (using a hit box somewhat larger than the drawn arrow so it can
+   * be tapped with a finger): while panning, reset a rotated map
+   * back to north-up; otherwise cycle through the map orientations
+   * (#CycleMapOrientation).
+   *
+   * @return true if the position hit the compass and the tap was
+   * handled
+   */
+  bool HandleCompassTap(PixelPoint p) noexcept;
+
+  /**
+   * Switch the orientation setting of the current display mode
+   * (cruise or circling) to the next available one and show a brief
+   * popup message with the new value.
+   */
+  void CycleMapOrientation() noexcept;
 
   /**
    * Persist the current projection scale as the circling or cruise

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -174,14 +174,6 @@ class GlueMapWindow : public MapWindow {
   bool pinch_rotating = false;
 #endif
 
-  /**
-   * Hold #manual_rotation_angle instead of the configured orientation
-   * while panning: set by a two-finger twist and by a compass tap in
-   * pan mode.  Cleared by UpdateScreenAngle() when pan mode is left.
-   */
-  bool manual_rotation = false;
-  Angle manual_rotation_angle = Angle::Zero();
-
   DisplayMode last_display_mode = DisplayMode::NONE;
 
   /**

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -314,7 +314,15 @@ GlueMapWindow::UpdateDisplayMode() noexcept
   last_display_mode = new_mode;
 
   if (is_circling != was_circling)
+    switch_zoom_climb_pending = true;
+
+  /* while panning, the user is inspecting the map; don't let a
+     circling/cruise transition of the (still flying) aircraft yank
+     the scale away - apply the switch once pan mode is left */
+  if (switch_zoom_climb_pending && !IsPanning() && !GestureOwnsMap()) {
+    switch_zoom_climb_pending = false;
     SwitchZoomClimb();
+  }
 }
 
 void

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -338,35 +338,19 @@ GlueMapWindow::UpdateScreenAngle() noexcept
   // force north-up if the current page is a dedicated MAP_NORTH_UP page
   const PageLayout &layout = PageActions::GetConfiguredLayout();
   if (layout.main == PageLayout::Main::MAP_NORTH_UP) {
-    /* a north-up page rejects a held manual rotation; clear so the
-       angle cannot reappear when leaving this page */
-    manual_rotation = false;
     visible_projection.SetScreenAngle(Angle::Zero());
     OnProjectionModified();
     compass_visible = false;
     return;
   }
 
-  /* a two-finger twist or a compass tap in pan mode temporarily
-     overrides the configured orientation; the angle is held while
-     panning and released (falling back to the configured orientation)
-     once pan mode is left */
-  if (manual_rotation) {
-    if (IsPanning() || GestureOwnsMap()) {
-      visible_projection.SetScreenAngle(manual_rotation_angle);
-      OnProjectionModified();
-      compass_visible = true;
-      return;
-    }
-
-    manual_rotation = false;
-  }
-
   /* while panning (or while a two-finger gesture owns the map), the
-     screen angle stays frozen at the angle from pan entry; without
-     this, the configured orientation would keep rotating the panned
-     map with every fix (e.g. track-up while circling).  Leaving pan
-     mode falls back to the configured orientation. */
+     screen angle is user-controlled: it stays frozen at the angle from
+     pan entry, and a two-finger twist or a compass tap sets it
+     directly.  Without this, the configured orientation would keep
+     rotating the panned map with every fix (e.g. track-up while
+     circling).  Leaving pan mode falls back to the configured
+     orientation. */
   if (IsPanning() || GestureOwnsMap()) {
     compass_visible = true;
     return;
@@ -465,12 +449,11 @@ GlueMapWindow::HandleCompassTap(const PixelPoint p) noexcept
     return false;
 
   if (IsPanning()) {
-    /* while panning, tapping the compass resets a rotated map back
-       to north-up; the angle is held by the manual-rotation
-       mechanism (like a two-finger twist) and released when pan mode
-       is left */
-    manual_rotation = true;
-    manual_rotation_angle = Angle::Zero();
+    /* while panning, tapping the compass resets a rotated map back to
+       north-up; UpdateScreenAngle() leaves the angle alone while
+       panning, so it is held until pan mode is left */
+    visible_projection.SetScreenAngle(Angle::Zero());
+    OnProjectionModified();
     QuickRedraw();
   } else
     CycleMapOrientation();

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -7,9 +7,14 @@
 #include "Topography/Thread.hpp"
 #include "Terrain/Thread.hpp"
 #include "Interface.hpp"
+#include "ActionInterface.hpp"
+#include "Language/Language.hpp"
+#include "Message.hpp"
 #include "Profile/Profile.hpp"
+#include "Renderer/CompassRenderer.hpp"
 #include "Screen/Layout.hpp"
 #include "PageActions.hpp"
+#include "util/StaticString.hxx"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Globals.hpp"
@@ -325,21 +330,19 @@ GlueMapWindow::UpdateScreenAngle() noexcept
   // force north-up if the current page is a dedicated MAP_NORTH_UP page
   const PageLayout &layout = PageActions::GetConfiguredLayout();
   if (layout.main == PageLayout::Main::MAP_NORTH_UP) {
-#ifdef HAVE_MULTI_TOUCH
-    /* a north-up page rejects temporary twist; clear so the angle
-       cannot reappear when leaving this page */
+    /* a north-up page rejects a held manual rotation; clear so the
+       angle cannot reappear when leaving this page */
     manual_rotation = false;
-#endif
     visible_projection.SetScreenAngle(Angle::Zero());
     OnProjectionModified();
     compass_visible = false;
     return;
   }
 
-#ifdef HAVE_MULTI_TOUCH
-  /* a two-finger twist temporarily overrides the configured
-     orientation; the angle is held while panning and released (falling
-     back to the configured orientation) once pan mode is left */
+  /* a two-finger twist or a compass tap in pan mode temporarily
+     overrides the configured orientation; the angle is held while
+     panning and released (falling back to the configured orientation)
+     once pan mode is left */
   if (manual_rotation) {
     if (IsPanning() || GestureOwnsMap()) {
       visible_projection.SetScreenAngle(manual_rotation_angle);
@@ -350,7 +353,6 @@ GlueMapWindow::UpdateScreenAngle() noexcept
 
     manual_rotation = false;
   }
-#endif
 
   MapOrientation orientation =
     ui_state.display_mode == DisplayMode::CIRCLING
@@ -377,7 +379,106 @@ GlueMapWindow::UpdateScreenAngle() noexcept
 
   OnProjectionModified();
 
-  compass_visible = orientation != MapOrientation::NORTH_UP;
+  /* the compass is always drawn: it doubles as a button (tap to
+     cycle through the map orientations), so it must stay tappable
+     with north-up, too */
+  compass_visible = true;
+}
+
+/**
+ * The order in which a compass tap cycles through the map
+ * orientations.
+ */
+static constexpr MapOrientation
+NextMapOrientation(MapOrientation orientation) noexcept
+{
+  switch (orientation) {
+  case MapOrientation::TRACK_UP:
+    return MapOrientation::NORTH_UP;
+  case MapOrientation::NORTH_UP:
+    return MapOrientation::TARGET_UP;
+  case MapOrientation::TARGET_UP:
+    return MapOrientation::HEADING_UP;
+  case MapOrientation::HEADING_UP:
+    return MapOrientation::WIND_UP;
+  case MapOrientation::WIND_UP:
+    return MapOrientation::TRACK_UP;
+  }
+
+  return MapOrientation::NORTH_UP;
+}
+
+[[gnu::const]]
+static const char *
+MapOrientationCaption(MapOrientation orientation) noexcept
+{
+  /* the same strings as in MapDisplayConfigPanel, so the existing
+     translations are reused */
+  switch (orientation) {
+  case MapOrientation::TRACK_UP:
+    return N_("Track up");
+  case MapOrientation::NORTH_UP:
+    return N_("North up");
+  case MapOrientation::TARGET_UP:
+    return N_("Target up");
+  case MapOrientation::HEADING_UP:
+    return N_("Heading up");
+  case MapOrientation::WIND_UP:
+    return N_("Wind up");
+  }
+
+  return "";
+}
+
+bool
+GlueMapWindow::HandleCompassTap(const PixelPoint p) noexcept
+{
+  if (!compass_visible)
+    return false;
+
+  PixelRect rc = GetClientRect();
+  rc.right -= std::min(int(top_right_margin), int(rc.GetWidth()));
+
+  const auto pos = CompassRenderer::GetPosition(rc);
+  const int radius = Layout::Scale(19);
+  const PixelRect hit_box{pos.x - radius, pos.y - radius,
+                          pos.x + radius + 1, pos.y + radius + 1};
+  if (!hit_box.Contains(p))
+    return false;
+
+  if (IsPanning()) {
+    /* while panning, tapping the compass resets a rotated map back
+       to north-up; the angle is held by the manual-rotation
+       mechanism (like a two-finger twist) and released when pan mode
+       is left */
+    manual_rotation = true;
+    manual_rotation_angle = Angle::Zero();
+    QuickRedraw();
+  } else
+    CycleMapOrientation();
+
+  return true;
+}
+
+inline void
+GlueMapWindow::CycleMapOrientation() noexcept
+{
+  MapSettings &settings = CommonInterface::SetMapSettings();
+  const bool circling =
+    CommonInterface::GetUIState().display_mode == DisplayMode::CIRCLING;
+
+  MapOrientation &orientation = circling
+    ? settings.circling_orientation
+    : settings.cruise_orientation;
+  orientation = NextMapOrientation(orientation);
+
+  StaticString<64> msg;
+  msg.Format("%s: %s",
+             circling ? _("Circling orientation") : _("Cruise orientation"),
+             gettext(MapOrientationCaption(orientation)));
+  Message::AddMessage(msg);
+
+  ActionInterface::SendMapSettings(true);
 }
 
 void

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -354,6 +354,16 @@ GlueMapWindow::UpdateScreenAngle() noexcept
     manual_rotation = false;
   }
 
+  /* while panning (or while a two-finger gesture owns the map), the
+     screen angle stays frozen at the angle from pan entry; without
+     this, the configured orientation would keep rotating the panned
+     map with every fix (e.g. track-up while circling).  Leaving pan
+     mode falls back to the configured orientation. */
+  if (IsPanning() || GestureOwnsMap()) {
+    compass_visible = true;
+    return;
+  }
+
   MapOrientation orientation =
     ui_state.display_mode == DisplayMode::CIRCLING
     ? settings.circling_orientation

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -59,11 +59,18 @@ GlueMapWindow::OnDestroy() noexcept
 }
 
 bool
-GlueMapWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
+GlueMapWindow::OnMouseDouble(PixelPoint p) noexcept
 {
   map_item_timer.Cancel();
 
   mouse_down_clock.Update();
+
+  if (HandleCompassTap(p)) {
+    /* rapid repeated taps on the compass are cycling through the map
+       orientations, not requesting the menu */
+    ignore_single_click = true;
+    return true;
+  }
 
   InputEvents::ShowMenu();
   ignore_single_click = true;
@@ -349,6 +356,12 @@ GlueMapWindow::OnMouseUp(PixelPoint p) noexcept
   }
 
   if (arm_mapitem_list) {
+    /* the compass doubles as a button: tapping it resets a rotated
+       map back to north-up while panning and cycles through the map
+       orientations otherwise */
+    if (HandleCompassTap(drag_start))
+      return true;
+
     map_item_timer.Schedule(std::chrono::milliseconds(200));
     return true;
   }

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -450,7 +450,6 @@ GlueMapWindow::ResetMultiTouchSessionState() noexcept
   multi_touch_was_panning = false;
   pinch_scaling = false;
   pinch_rotating = false;
-  manual_rotation = false;
 }
 
 void
@@ -593,19 +592,19 @@ GlueMapWindow::OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept
     /* screen y grows downward, so a visually clockwise finger twist
        increases the measured angle; subtract it so the map content
        rotates with the fingers */
-    manual_rotation_angle = pinch_start_screen_angle - twist;
-    manual_rotation = true;
+    const Angle new_angle = pinch_start_screen_angle - twist;
 
     /* a rotation is a deliberate manipulation; enter pan mode so the
-       chosen angle is held */
+       chosen angle is held (UpdateScreenAngle() leaves the angle alone
+       while panning) */
     if (!multi_touch_pan_ui) {
       CommitMultiTouchPanUI();
       RebasePinchAfterLayoutChange(a, b, distance, centroid);
       pinch_start_finger_angle = finger_angle;
-      pinch_start_screen_angle = manual_rotation_angle;
+      pinch_start_screen_angle = new_angle;
     }
 
-    visible_projection.SetScreenAngle(manual_rotation_angle);
+    visible_projection.SetScreenAngle(new_angle);
     OnProjectionModified();
   }
 
@@ -684,8 +683,9 @@ GlueMapWindow::OnCancelMode() noexcept
 
 #ifdef HAVE_MULTI_TOUCH
     if (was_multi_touch)
-      /* drop a held twist angle and refresh after the session flags
-         were cleared */
+      /* refresh after the session flags were cleared; a twist angle
+         from a cancelled gesture that did not enter pan mode is
+         dropped by UpdateScreenAngle() */
       QuickRedraw();
 #endif
   }

--- a/src/Renderer/CompassRenderer.cpp
+++ b/src/Renderer/CompassRenderer.cpp
@@ -13,13 +13,17 @@
 #include "ui/canvas/opengl/Scope.hpp"
 #endif
 
+PixelPoint
+CompassRenderer::GetPosition(const PixelRect rc) noexcept
+{
+  return {rc.right - Layout::Scale(19), Layout::Scale(19) + rc.top};
+}
+
 void
 CompassRenderer::Draw(Canvas &canvas, const Angle screen_angle,
                       const PixelRect rc) noexcept
 {
-  PixelPoint pos(rc.right - Layout::Scale(19),
-                 Layout::Scale(19) + rc.top);
-  Draw(canvas, screen_angle, pos);
+  Draw(canvas, screen_angle, GetPosition(rc));
 }
 
 void

--- a/src/Renderer/CompassRenderer.hpp
+++ b/src/Renderer/CompassRenderer.hpp
@@ -15,6 +15,14 @@ class CompassRenderer {
 public:
   CompassRenderer(const MapLook &_look) noexcept:look(_look) {}
 
+  /**
+   * The position at which Draw(Canvas &, Angle, PixelRect) draws the
+   * compass within the given map rectangle; also used for tap
+   * hit-testing.
+   */
+  [[gnu::pure]]
+  static PixelPoint GetPosition(PixelRect rc) noexcept;
+
   void Draw(Canvas &canvas, Angle screen_angle, PixelPoint pos) noexcept;
   void Draw(Canvas &canvas, Angle screen_angle, PixelRect rc) noexcept;
 };


### PR DESCRIPTION
Closes #2839.

**The on-map compass becomes a button**. Tapping the north arrow in pan mode resets a rotated map back to north-up, giving a one-tap recovery after a two-finger twist. Outside pan mode, a tap cycles through the map orientations (Track up, North up, Target up, Heading up, Wind up) and briefly shows the newly selected mode, changing only the setting of the currently active display mode: circling while circling, cruise otherwise. Since a button must be visible to be usable, the compass is now always drawn; on a dedicated "Map (north up)" page it stays hidden and inactive. Hit-testing shares its position with the renderer via a new `CompassRenderer::GetPosition()`.

**Two pan-mode annoyances are fixed along the way.** The configured orientation used to keep rotating a panned map with every fix, most noticeably when panning while circling with track-up; the screen angle is now frozen on pan entry and treated as user-controlled, with twist and compass tap setting it directly and the configured orientation returning once pan mode is left. With circling zoom enabled, every circling/cruise transition also yanked the scale away mid-inspection; that switch is now deferred until pan mode is left. Freezing the angle made the `manual_rotation` hold flag redundant, so a final no-functional-change commit removes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The map compass is always visible and interactive, except on dedicated north-up pages.
  * Tap the compass to reset a rotated map to north-up or cycle through the active flight mode’s orientation.
  * Orientation changes are briefly displayed and synchronized with map settings.
* **Bug Fixes**
  * Map rotation remains stable while panning or using gestures.
  * Zoom-mode transitions are deferred until panning ends.
* **Documentation**
  * Added guidance for using the compass and changing map orientation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->