### PR TITLE
NEWS.txt: Restructure 7.45 notes with highlights

### DIFF
--- a/.cursor/rules/news.txt.mdc
+++ b/.cursor/rules/news.txt.mdc
@@ -22,10 +22,33 @@ unreleased version.
 - **Build, CI, contributor docs, scripting APIs** → `* development` (see below)
 - Pure refactors or CI tweaks with nothing worth noting: omit
 
+## Bug fixes vs the previous release
+
+`fix` / crash bullets in the current unreleased version must describe
+bugs that **already existed in the last released version**. Example: 7.45
+notes only list bugs that were present in 7.44.
+
+- Do **not** list regressions introduced and fixed during development of
+  the current version — users of the last release never saw them
+- If a **new feature** in this version had bugs during development, fold
+  the final behaviour into the feature bullet (or omit); do not add a
+  separate `fix` line
+
+```text
+# BAD in Version 7.45 (only happened on 7.45 development builds)
+- Fix crash when opening Weather Setup from the weather overlay picker
+
+# GOOD: bug already present in 7.44
+- fix crash when opening the aircraft type picker without a network
+  connection
+```
+
 ## Structure
 
 ```text
 Version X.Y - not yet released
+* highlights
+  - headline features for this release (moved here, not duplicated)
 * section
   - bullet describing the change
 * documentation
@@ -38,9 +61,31 @@ Version X.Y - not yet released
 - **Version line**: `Version X.Y - YYYY-MM-DD` or `- not yet released`
 - **Section headers**: `* android`, `* Windows`, `* ui`, … — lowercase after
   `*` unless a proper noun (Windows, macOS, iOS, Android, Linux, Kobo)
-- **Bullets**: start with a verb (`add`, `fix`, `deprecate`, `support`, …)
-- **Issue references**: append ` #1234` at end when related to a GitHub issue
-  (project practice since 2012)
+- **Bullets**: start with a verb (`add`, `fix`, `deprecate`, `support`,
+  `let`, `allow`, `remember`, `replace`, …). Do not lead with a noun
+  label or a bare adjective (`BlueFly Vario:`, `airspace warnings:`,
+  `configurable XCSoar Cloud…`, `Alternate 1/2 InfoBoxes can…`)
+- **Wrap** at 79 columns (same as source)
+- **Order within a section**: features first, then bug fixes. Do not
+  put an `add` after a `fix` / `accept` in the same section
+- **Issue references**: append ` #1234` at end when related to a GitHub
+  issue (project practice since 2012). **One issue, one bullet** — do
+  not list the same `#1234` under two sections; fold the device-specific
+  cause into the user-facing symptom
+
+```text
+# BAD (same fix twice)
+* glide computer
+  - fix wild T Avg climb rates … #2754
+* devices
+  - fix LXNAV thermal averages … #2754
+
+# GOOD
+* glide computer
+  - fix wild T Avg climb rates by preferring the instrument vario
+    when available (including LXNAV conflicting altitude sources)
+    #2754
+```
 
 ### Section naming (historical mess — pick one style per release)
 
@@ -48,6 +93,54 @@ The file mixes `* user interface` and `* ui`, `* android` and `* Android`,
 `* devices` and `* Devices`. For **new** entries in a release block, match the
 sections already used in that block; prefer lowercase generic names (`* ui`,
 `* devices`, `* android`) unless the release already uses another form.
+
+Each section header should appear **once** per version block. Do not start a
+second `* ui` (or `* map`, `* weather`, …) later in the same release.
+
+When `* ui` grows large, split into existing feature sections (`* map`,
+`* weather`, `* airspace`, `* input`, …) and add focused headings rather
+than stacking more `* ui` blocks. 7.45 uses `* highlights`, `* infoboxen`,
+`* waypoints`, `* task`, `* FLARM`, `* simulator`, `* Quick Guide`, and
+`* dialogs`.
+The in-app What's New view turns each `* section` into a heading.
+
+### `* highlights`
+
+Optional first section in a version block. Move a short list of
+**headline** user-facing features here so What's New opens with them.
+
+- **Move, do not copy.** Supporting detail, related polish, input-event
+  names, and bug fixes stay under `* map`, `* weather`, `* data files`,
+  `* input`, and so on
+- **One class of feature, one bullet.** SkySight, EDL, and XCTherm are
+  weather overlays — not three highlight items. Pinch-to-zoom and
+  two-finger rotate are one map-gesture bullet
+- **Keep highlight text short.** Drop ``DataManagement``-style event
+  names, long option lists, and upgrade-migration detail; leave those
+  in the original section
+- **If a section is emptied** by the move (e.g. a one-bullet
+  `* NOTAM`), delete the empty heading
+- Distinctive map/safety/audio items (turn-back marker, distance rings,
+  internal audio STF) may be promoted when they are first-launch
+  noticeable
+
+```text
+# BAD (three overlays + a leftover twist bullet + an event name)
+- add SkySight forecast overlays …
+- add EDL weather overlays …
+- add XCTherm as a map-page overlay …
+- add pinch-to-zoom … a two-finger drag or twist enters pan mode
+- add two-finger twist to temporarily rotate the map …
+- add a Data Management hub (menu, Quick Menu, and
+  ``DataManagement`` input event): …
+
+# GOOD
+- add SkySight, EDL, and XCTherm weather overlays … unified forecast
+  controls …
+- add pinch-to-zoom and two-finger map rotate …
+- add a Data Management hub (menu and Quick Menu): site files, …
+  (``DataManagement`` stays under * data files)
+```
 
 ## User-facing sections
 
@@ -68,9 +161,16 @@ leave; do not rewrite history.
 - Build target names: `WIN64OPENGL`, `WIN32OPENGL`, `PC`, `WIN64`, `TARGET=…`
 - Internal stack terms users do not see: GDI, NSIS, ANGLE, SDL, `USE_*`
 - Source paths, class names, “targets” in the build-system sense
+- Code identifiers when the UI uses another name: `pc_met` →
+  flugwetter.de; leave internals for `* development` or one
+  parenthetical if search needs them
 
-Driver names, file formats, and platform APIs are OK when that is what the user
-configures or sees.
+Driver names, file formats, and platform APIs are OK when that is what
+the user configures or sees.
+
+Translation catalog refresh: `update translations for N languages`
+under `* ui` (`N` = number of `po/*.po` files). Do not rewrite older
+version blocks.
 
 ### Examples
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,607 +1,337 @@
 Version 7.45 - not yet released
-* airspace
-  - Remove ineffective "Unknown" row from airspace warning, display, and
-    colour settings #1772
+* highlights
+  - add SkySight, EDL, and XCTherm weather overlays on map pages,
+    with unified forecast controls (layer/time per page, cursor bar,
+    Weather Setup), optional automatic updates, offline preload, and
+    EDL day precache #2690 #2705
+  - add optional contour lines on RASP weather overlays
+  - add NOTAM download, cache, map display, filters, and airspace
+    details #2018
+  - add pinch-to-zoom and two-finger map rotate on Android and iOS:
+    scale about the pinch centroid and pan at the same time; twist
+    rotates the map until pan mode is left; a pinch that only zooms
+    keeps following the aircraft #2790
+  - add an optional turn-back marker (Safety Factors) showing the
+    furthest point along track from which the active waypoint or Goto
+    is still reachable in cruise #1741
+  - add distance rings around the current location #2522
+  - add a Data Management hub (menu and Quick Menu): site files,
+    downloads, flight export, import, backups, and a file explorer
+    #2289
+  - add a WiFi dialog on Linux (Config → Setup → Network;
+    NetworkManager or ConnMan)
+  - scale the glide polar with air density so speed-to-fly and task
+    calculations increase cruise speed with altitude and keep best
+    L/D; netto vario and speed-to-fly arrows use the same scaling
+    #1569
+  - show OGN and SkyLines traffic with the same FLARM display as
+    device traffic, expire icons 5 minutes after the last update, and
+    raise the combined list limit to 64 targets
+  - add an internal audio vario speed-to-fly (STF) mode that can
+    follow cruise and circling automatically
 * map
-  - Fix repeated full terrain redraws when the view stays still near the
-    edge of the terrain map (OpenGL), which could make panning hitchy
+  - animate keyboard and mouse-wheel map zoom on non-e-ink displays so
+    scale steps feel continuous after a pinch; free zoom continues from
+    an off-list (pinched) scale, and snaps to the usual scale list again
+    once close to a list value
+  - add an optional map overlay QuickMenu button (Config → Look →
+    Layout), on by default when a touch screen is detected #2610
+  - keep overlay zoom with the menu/QuickMenu buttons top-right, keep
+    the north arrow clear of those buttons, and draw GPS status above
+    the map scale / title line
+  - swap map overlay sides: vario bar on the left, final glide bar on
+    the right #1210
+  - show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
+  - improve the map items dialog: scale the “Your Position” aircraft
+    icon to the row; Enter / Details opens Status: Flight
+  - adjust contour line density with zoom, with profile presets for
+    mountains, low lands, and similar landscapes #2233
+  - larger on-map typography (waypoint text, map-scale readout,
+    topography labels) and a Waypoint icon size setting (50–200%)
+  - hide obstacles at wider map scales than other non-landables, and
+    draw up to 1024 waypoints at once (was 256) #2327
+  - add terrain shading orientation “fixed (Top Left)”
+  - smooth the snail trail between GPS fixes and colour it from
+    high-rate netto between points #2447
+  - fix hitchy OpenGL panning from repeated full terrain redraws when
+    the view stays still near the edge of the terrain map
+  - fix map vario / final-glide value labels: rounded rectangle with
+    even padding and an unbroken outline #1438
+  - keep the aircraft and terrain together in follow mode on OpenGL
+    (the plane no longer slides ahead of the map until the next full
+    redraw)
+  - fix crash opening the map item list on waypoints with long
+    non-ASCII comments
+  - apply snail trail wind drift only when zoomed in, so a Full trail
+    in circling no longer looks shifted away from turnpoints at
+    overview scales #2835
+  - fix black terrain after idle high-resolution sharpening on OpenGL
+    devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3)
+  - fix fluctuating hill-shading strength #2262
+  - fix intermittent white-map hang on startup for non-OpenGL builds
+    when drawing began before map bounds were ready #2734
+* weather
+  - remember overlay layer/time (or level/altitude) per weather map
+    page, with a map-bottom cursor bar, Weather Setup, and Forecast
+    Controls; Apply / Add page / Pages setup commit those values;
+    weather controls work on non-OpenGL builds too
+    #2690 #2705 #2583
+  - enhance RASP rendering (transparency, colour scale, numerical
+    values) and add Auto update of the daily forecast while time
+    follows the clock
+  - add flugwetter.de RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT
+    RAD BLITZ, and Blitzkarte Europa; local radar uses Borkum instead
+    of Emden
+  - keep the RASP time cursor on all-day layers (e.g. PFD) and grey
+    out time controls until a multi-slot layer is selected #2705
+  - accept lowercase ICAO codes in the METAR/TAF station list
+* airspace
+  - add an airspace labels toggle (Display page 2, Quick Menu, and
+    the ``AirspaceLabels`` input event) #1243
+  - tint the bottom airspace warning banner red (inside) or yellow
+    (near), and show distance and time there
+  - show Inside/Near on airspaces in the map items dialog, grey
+    acknowledged airspaces in the map item and airspace lists, and an
+    Enable button to clear a day acknowledgement #2404
+  - replace Radio with Details on airspace warnings; Up/Down move the
+    list, Left/Right the action row
+  - remove the ineffective “Unknown” row from airspace warning,
+    display, and colour settings #1772
+* infoboxen
+  - add InfoBoxes: Altitude IGC, Home, Active Waypoint, Previous
+    Waypoint, and QNH #2320 #2521
+  - let Alternate 1/2 InfoBoxes follow the computed list (AUTO) or a
+    pilot-chosen field (MANUAL); the list holds up to 10 options, and
+    Alternate 2 no longer duplicates Alternate 1 when only one
+    automatic field exists #2347
+  - fix the InfoBox Sets editor so it follows the Screen Layout
+    selection immediately #2596
+  - size the InfoBox panel to the current tab so switching Altitude →
+    Simulator no longer jumps the map title
+  - refresh InfoBox titles after changing the interface language #2314
+  - fix Start reach and Start open: Start reach is time to the start
+    line; Start open is the gate countdown now; colours show
+    Waiting/Open/Closed and Too early/Can start/Too late #2502
+  - fix the InfoBox content list dropping the newest types once more
+    than 128 were defined
+* waypoints
+  - open waypoint details with Details / F1 (Enter still confirms the
+    selection)
+  - waypoint search matches anywhere in the long name and shortname
+    (e.g. ICAO in SeeYou .cup files), lists every CUP waypoint type,
+    and stays open until Esc or a successful GoTo / task / home / pan
+    #2483 #2485 #749
+  - waypoint details open above the search and alternates lists;
+    Close without a committed action returns to the list #620
+  - zoom and pan waypoint embedded images and flugwetter.de satellite
+    views about the focal point; new ``wptimg`` / ``WaypointImage``
+    keys #1127 #1246
+  - show landable reachability in map items, waypoint selection, and
+    the waypoint manager (icons were always drawn as unreachable)
+    #2836
+  - show each waypoint at most once in search results #1316
+  - hide the .xcm map archive Type filter when its waypoints are not
+    loaded #1376
+  - restore the “Recently Used” Type filter (it had been aliased to
+    “Map file”) #1994
+* task
+  - show all tasks by default in Task Browser
+  - rename observation zone type “Symmetric Quadrant” to “Symmetric
+    Sector” (these zones support any angle, not only 90°)
+  - show PEV offset at start on Status → Rules as a duration (e.g.
+    “45 sec”)
+  - fix Task Manager keyboard focus so Up/Down move the task list
+    after Manage → Browse
+  - fix task point dialog keys: Up/Down no longer skip OZ Radius;
+    Left/Right change the task point
+* FLARM
+  - outline the selected target on the traffic radar, rotate
+    track-up targets on cardinal bearings, and show callsigns on all
+    registered targets (full callsign on labels) #2718
+  - match the large-radar task direction arrow to the map
+    best-cruise shape #2027
+* simulator
+  - make simulator mode easier to find: startup tip to steer by
+    dragging from the glider or via Altitude / Speed Ground
+    InfoBoxes; Welcome Quick Guide paragraph; “Sim: Jump to” on map
+    items and waypoint details; Speed Ground panel for bearing and
+    ground-speed steps; label Set Home as “Set as Startup Location”
+  - allow Left/Right on the simulator prompt to choose Fly /
+    Simulator immediately
+* Quick Guide
+  - add Quick Guide and Replay to the Quick Menu (Replay disabled
+    when moving)
+  - generate What's New from NEWS.txt at build time, keep multi-line
+    bullets together, and speed up long What's New and Credits pages
+  - getting-started checkboxes follow live settings; “Don't show this
+    guide again” on every informational page #2324 #2648
+  - checklist links can set COM standby or active (``vhf:…#standby``
+    / ``vhf:…#active``)
+  - swipe horizontally to flip checklist, Credits, Quick Guide, and
+    configuration pages #2122 #2414
+  - fix Quick Guide Up/Down so the bottom-bar checkbox and Close are
+    reachable from the keyboard
+* dialogs
+  - improve the soft keyboard: default focus on OK so Enter
+    confirms; cursor keys move across the grid; F1 is backspace
+  - list and picker dialogs use a single keyboard focus: Left/Right
+    page the list, Enter confirms, Up/Down reach OK/Cancel
+  - allow lower-case letters in HighScore Style text entry #2387
+  - fix Configuration keyboard navigation so Up/Down move settings
+    rows again; map item and airspace lists keep readable focus text
+    on e-ink #2495
+  - fix crash wrapping unspaced UTF-8 help text (e.g. Chinese
+    language picker) #2768
+* ui
+  - add Expert Look → Screen Layout setting “Display type” (LCD /
+    E-ink / Color e-ink); e-ink modes disable kinetic and smooth
+    scrolling (default E-ink on Kobo, LCD elsewhere)
+  - snap e-paper scrolling instead of animating at display refresh
+    rate
+  - add help text for plane Max. Cruise Speed; put Reference Mass
+    above the polar V/W grid #1134
+  - encode bundled UI sounds at higher quality
+  - update translations for 33 languages
+  - fix profile selection / startup branding on light dialog
+    backgrounds #2742
+  - fix plane polar coefficient grid layout
+  - fix Status → Times flight time after minute rounding, including
+    across midnight #957
+  - fix thick solid lines on macOS so they render at the correct
+    pixel width #2545
 * data files
+  - add OpenAIP .cupx waypoint files to the file manager
+  - add a ``DataManagement`` input event for the Data Management hub
+    #2289
+  - store waypoints, airspaces, terrain, profiles, and logs in typed
+    subdirectories; on first start after upgrade, move legacy flat
+    files into those folders #2289
+  - map OpenAir AY ASRA to aerial sporting/recreational airspace
+    #1827
   - fix loading SeeYou .cupx waypoint files and embedded photos that
     use ZIP data descriptors (e.g. recent OpenAIP / SeeYou exports)
-  - fix LS-8 polar max.\ cruise speed: the default stored 190 (km/h) in
-    the m/s field; default and built-in LS-8 polars now use 52.78 m/s
-    #1134
+  - do not write unchanged settings back to the profile when opening
+    Configuration or Quick Guide #1793
+  - fix ``-profile=`` so it resolves under ``-datapath=`` regardless
+    of argument order #848
+  - parse SeeYou .cup task observation zones with uncommon angles
+    (previously forced to FAI Quadrants) #2697
+  - fix CUPX embedded POINTS.CUP on Windows
+  - fix crash when queuing many background file downloads #2624
 * tracking
-  - Do not resolve SkyLines or XCSoar Cloud hosts while the network link is
-    down, avoiding repeated DNS timeout errors in the log #1750
-  - Untangle XCSoar Cloud settings from SkyLines live tracking: cloud traffic
-    and roaming are independent of SkyLines options
-  - Rename map display setting to "Online traffic on map" (SkyLines and
-    XCSoar Cloud traffic)
-  - Expire online traffic map icons 5 minutes after the last update
-  - Show OGN and SkyLines traffic on the map, in the traffic list, and in
-    the what-is-here dialog using the same FLARM traffic display as device
-    traffic (fixes pan-mode disappearance of online targets)
-  - Configurable XCSoar Cloud server hostname and UDP port in cloud settings
-  - Raise combined FLARM/online traffic list limit to 64 targets (cloud
-    batch size); device FLARM traffic still typically stays within 25
-  - Drop OGN/cloud online traffic that matches the connected FLARM radio
-    id so own-ship no longer appears on the traffic display #2693
-  - Add expert cloud setting "Own FLARM IDs" (comma-separated hex list)
-    to filter self and additional own aircraft from OGN when the device
-    radio id is unavailable (e.g. LX passthrough) #2693
-* documentation
-  - document custom ``.xci`` loading: ``#CLEAR``, merge vs replace,
-    ``type`` values (``key`` / ``gce`` / ``gesture`` / ``ne`` /
-    ``label``), gesture ``data`` format, softkey ``location``,
-    label escapes, complete GCE list, and ``RemoteStick`` Quick Menu
-  - document ``AirspaceLabels`` input event
-  - document map pinch-to-zoom on touchscreens that report both
-    finger positions #2790
-  - correct ``.plr`` optional max.\ cruise speed unit to m/s and
-    distinguish WinPilot fields from the XCSoar extension #1134
-* development
-  - Log screen resolution, DPI, virtual DPI, approximate size, and
-    small-screen flag at startup #1548
+  - untangle XCSoar Cloud settings from SkyLines live tracking;
+    rename the map setting to “Online traffic on map”
+  - drop online traffic that matches the connected FLARM radio id
+    (own-ship); expert setting “Own FLARM IDs” for extra own aircraft
+    when the radio id is unavailable #2693
+  - allow configuring the XCSoar Cloud server hostname and UDP port
+  - do not resolve SkyLines or XCSoar Cloud hosts while the network
+    link is down #1750
 * WeGlide
-  - fix crash when opening the aircraft type picker without a network
+  - allow configuring WeGlide aircraft type when upload is disabled
+    #2323
+  - fix crash opening the aircraft type picker without a network
     connection
-* weather
-  - Offer weather controls (map-bottom cursor bar) on non-OpenGL builds
-    as well, so RASP pages can use them on memory-canvas and Kobo
-  - Keep the selected SkySight forecast time when changing layer
-    (picker or step); do not force Auto unless Auto was already selected
-* ui
-  - Fix zoom buttons still appearing when "Show Zoom button" is off
-    while Menu or Quick Menu is on #2830
-  - Keep map overlay zoom with the menu/QuickMenu buttons top-right
-    (+ above -), including when zoom is the only overlay button
-  - Keep overlay buttons visible during airspace and task prompts
-    #2830
-  - add help text for plane ``Max. Cruise Speed`` #1134
-  - Bind F5/F6 on the FLARM traffic radar to auto-zoom and north-up
-    toggles (also fixes north-up so it no longer changes auto-zoom)
-    #2535
-  - Fix InfoBox Sets editor using the previous InfoBox geometry until
-    Settings is closed; it now follows the Screen Layout selection
-    immediately #2596
-  - Add pinch-to-zoom on the map for touchscreens that report both
-    finger positions (Android, iOS): two fingers scale about the
-    pinch centroid and can pan at the same time; a two-finger drag
-    or twist enters pan mode, a pinch that only zooms keeps
-    following the aircraft #2790
-  - Add two-finger twist to temporarily rotate the map; the angle is
-    held while panning and restored when pan mode is left #2790
-  - Animate keyboard and mouse-wheel map zoom on non-e-ink displays
-    so scale steps feel continuous after a pinch; free zoom continues
-    from an off-list (pinched) scale, and snaps to the usual scale
-    list again once the current scale is close to a list value
-  - Keep the north arrow clear of the on-screen menu and zoom buttons
-  - Improve simulator discoverability: startup tip to steer by
-    dragging from the glider or via Altitude / Speed Ground InfoBoxes
-    (5 s); Welcome Quick Guide paragraph in simulator mode; add
-    “Sim: Jump to” on map items and waypoint details; Speed Ground
-    simulator panel for bearing and ground-speed steps; label Set Home
-    as “Set as Startup Location” in simulator mode
-  - Bind F1 on the FLARM traffic radar to toggle AVG/ALT side labels
-    (same as AVG/ALT softkey and RL gesture); previous target remains
-    on Down
-  - Draw map GPS status above the map scale / title line so it is not
-    covered by AUTO / Simulator / REPLAY text
-  - Improve soft keyboard text entry: default focus on OK so Enter
-    confirms (not the “1” key); cursor keys move across the grid (Up
-    from OK/Cancel/Clear enters the keyboard; arrows no longer jump in
-    tab order at row edges); F1 is backspace
-  - Allow lower-case letters in HighScore Style text entry #2387
-  - Fix profile selection / startup branding: use transparent RGBA logo
-    and title bitmaps on light (parchment) dialog backgrounds #2742
-  - Size the InfoBox panel to the current tab and lift map overlays by
-    that height only (Altitude → Simulator no longer jumps the map
-    title up by the taller Setup tab)
-  - Fix map vario / final-glide value labels: use a rounded rectangle
-    (not a pill) with even text padding and an unbroken outline for the
-    semitransparent background #1438
-  - Restore the thin, crisp outline on rounded map labels (landable
-    waypoints, vario, final glide); on Retina iPhones it had become
-    too thick, too dark and ragged at the corners #2840
-  - Swap map overlay sides: vario bar on the left, final glide bar on
-    the right #1210
-  - Add airspace labels toggle: Display page 2, Quick Menu, and
-    ``AirspaceLabels`` input event (on/off, saved to profile) #1243
-  - Add Quick Guide and Replay to the Quick Menu (Replay disabled when
-    moving)
-  - Show replay speed on the map scale overlay (e.g. REPLAY 2x) #2281
-  - Allow Left/Right on the simulator prompt to choose Fly / Simulator
-    immediately
-  - Improve the map items dialog: scale “Your Position” aircraft icon
-    to the row; Enter / Details opens Status: Flight; show airspace
-    Inside/Near status like the airspace warnings dialog
-  - Tint the bottom airspace warning banner red (inside) or yellow
-    (near), matching the warnings-list badges (colour displays only)
-  - Show distance and time in the bottom airspace warning banner, on a
-    second line only when the name and current distance/time do not fit
-    on one line
-  - Put WiFi Connect first and Close last (right / bottom)
-  - Put Download before Cancel in the download picker; Left/Right page
-    the list (no armed action-bar dual focus)
-  - Use single keyboard focus in the multi-file picker (no armed action
-    bar); Enter/Space toggles the highlighted file, Up/Down reach
-    OK/Cancel
-  - Use single keyboard focus in the value list picker (ComboPicker);
-    Left/Right page, Enter selects the highlighted value
-  - Draw a thin separator line above list-picker bottom help text
-  - Make Quick Menu Left/Right stay put when the next item is disabled,
-    but still wrap or flip page at a real row edge
-  - Use focus colour for action-bar buttons that have keyboard focus
-    (armed Left/Right selection still uses the selected colour while
-    the list keeps focus — same as Alternates)
-  - Open waypoint details with Details / F1 (Enter still confirms the
-    selection)
-  - Move Task Manager keyboard focus with Manage → Browse (and WeGlide
-    lists) so Up/Down can move the task list again
-  - Fix task point dialog keyboard navigation: Up/Down no longer skip
-    the OZ Radius field; Left/Right change the task point (same as
-    < / >); Type is an AddEnum-style field; in portrait the map and OZ
-    fields are full width and the form only uses height for active OZ
-    settings (landscape keeps the side form)
-  - Fill leftover pixels on the last dialog action-bar button in a row
-    (no empty right strip); landscape side bars stay normal height
-  - Put Reference Mass above the plane polar V/W grid; Up/Down moves
-    within each V/W column
-  - Fix Configuration keyboard navigation: Up/Down again move between
-    settings rows; Up from Close/arrows focuses the last row (Quick
-    Guide chrome path unchanged); opening the dialog focuses the menu,
-    not Close; Up/Down on the menu walk individual items (then
-    Close/arrows); Esc from a settings panel returns to the menu
-  - Speed up long rich-text layout (Quick Guide What's New): estimate
-    scroll height before wrapping, skip FreeType for runs that clearly
-    fit or overflow by character budget, and use one measure for
-    typical bullets
-  - Speed up scrolling long What's New and Credits pages
-  - Keep multi-line What's New bullets together with hanging indent
-  - Fix Quick Guide Up/Down focus so the bottom-bar checkbox and Close
-    button are reachable from the keyboard
-  - Add Expert Look → Screen Layout setting "Display type" (LCD /
-    E-ink / Color e-ink); e-ink modes disable kinetic and smooth
-    scrolling. Defaults to E-ink on Kobo and LCD elsewhere
-  - OpenGL: keep the follow-mode map projection in sync on every map
-    paint so the aircraft and terrain move together (avoids the plane
-    sliding ahead of the map until the next full redraw)
-  - Show the Vario flag on the device list for non-compensated and
-    netto vario
-    sources as well as total-energy (e.g. BlueFly)
-  - E-paper: snap VScrollPanel smooth scrolling instead of animating at
-    ~60 Hz, and debounce ComboPicker per-item help updates while
-    scrolling (InfoBox content list etc.)
-  - FLARM radar: show callsigns on all registered targets again, use the
-    full callsign on target labels, and omit duplicate side vario/altitude
-    on the selected target (info panel already shows them) #2718
-  - FLARM radar: rotate track-up targets on cardinal bearings (due
-    north/south or east/west)
-  - Add XCTherm to the pages config map overlay choices (alongside RASP
-    and EDL) #2705
-  - Add Weather Setup to the weather overlay menu (opens Info → Weather
-    on the active overlay tab); the layer/level/altitude list picker also
-    has a Setup button for the same path #2690
-  - Add Auto update to the RASP weather panel to enable/disable background
-    download of the forecast; it downloads at most once a day and only
-    while the forecast time follows the clock (Auto or Now); Update
-    remains available for a manual refresh
-  - Add Auto update to the EDL weather panel to enable/disable background
-    download of missing overlay tiles; Precache day is disabled while Auto
-    update is on #2690
-  - Add Layer/Time (Level/Altitude) on weather panels for the current map
-    page; Apply to page commits changes when dirty, Add page creates a
-    page with those values, and Pages setup opens Config → Look → Pages
-    #2705 #2690
-  - Store both overlay cursor axes on weather map pages: RASP Layer/Time,
-    EDL Level/Time, and XCTherm Altitude/Time; switching pages restores
-    Auto or manual selections independently #2690 #2705
-  - Show the current map page RASP layer and time on the RASP weather
-    panel; Apply commits them to that page #2690
-  - Allow Precache day on the EDL weather panel without an active EDL map
-    page; add Time and Level using the same pickers as the overlay
-    controls #2690
-  - Align the XCTherm weather panel Time / Altitude layout with RASP and
-    EDL; map Altitude is independent of the download Layer #2690 #2705
-  - Store RASP forecast time per map page (Auto, Now, or fixed slot);
-    selecting a page restores its Layer and Time #2690 #2705
-  - Fix crash when opening Weather Setup from the weather overlay
-    layer/level/altitude list picker #2690
-  - Keep the RASP time cursor when stepping onto all-day layers (single
-    archive time slot such as PFD); grey out the time controls until a
-    multi-slot layer is selected again #2705
-  - Show all tasks by default in Task Browser instead of requiring to click
-    the "More" button first.
-  - Rename to turnpoint observation zone type "Symmetric Quadrant" to
-    "Symmetric Sector", as these zones do not have to be 90 degrees but
-    support any angle.
-  - add SkySight forecast overlays with per-page layer/time selection,
-    selected-layer setup, optional automatic updates, offline preloading,
-    cache management, and throttle recovery #2690
-  - Outline selected targets on the FLARM traffic radar
-  - Fix crash when leaving the FLARM traffic radar with a horizontal
-    swipe (focus re-entry while destroying the page widget) #2824
-  - Weather cursor bar: narrower stepper buttons on touchscreens and clip
-    long centre labels instead of hiding them when they do not fit
-  - Fix crash when opening the map item list on waypoints with long
-    non-ASCII comments (UTF-8 truncation)
-  - Fix crash wrapping unspaced UTF-8 help text (e.g. Chinese language
-    picker) #2768
-  - add optional map overlay QuickMenu button (Config → Look → Layout),
-    enabled by default when a touch screen is detected #2610
-  - input events: add ``VarioVolume`` to mute/unmute and adjust the
-    internal audio vario volume
-  - audio vario: add manual/automatic Vario/STF sound switching and
-    ``VarioAudioMode`` input events
-  - show landable waypoint reachability in the "map elements at this
-    location" dialog, the waypoint selection dialog and the waypoint
-    manager; their icons were always drawn as unreachable even when the
-    map showed the same airfield as reachable #2836
 * glide computer
-  - fix wild T Avg climb rates by preferring the instrument vario when
-    available #2754
-  - Speed-to-fly and task calculations are now altitude-corrected: the glide
-    polar is scaled by the air density ratio (sqrt(rho0/rho)) each GPS cycle,
-    so optimal cruise speeds increase with altitude and best L/D is preserved
-    (#1569)
-  - Task manager glide and safety polars use the same density ratio from baro
-    or GPS altitude
-  - Netto vario (when derived from the polar) and vario speed-to-fly
-    push/pull arrows use true airspeed against the density-scaled polar sink
-    and speed-to-fly
-* android
-  - BLE serial ports now support Nordic UART Service (NUS) for e.g. Naviter
-    dongles, in addition to HM-10; the protocol is auto-detected at connection
-    time #2260
-  - BLE serial ports also support Microchip/ISSC transparent UART
-    (e.g. BlueFly Vario over BLE); auto-detected like NUS/HM-10
-  - The saved device port type string for that mode remains ble_hm10 so
-    existing profiles load without migration
-  - add support for SoftRF Concorde, Prime Mk4, and Retro Mk2 as supported USB devices
-  - Fix crash when the native thread restarts after surface teardown
-    (JNI helper classes were not cleared between runNative calls)
-* Kobo
-  - always start in light mode; dark mode is not supported on e-paper
-    displays #2568
-* Windows
-  - fix crash opening the log list when replay filenames contain
-    non-ASCII characters (Unicode directory listing and file open)
-  - fix startup crash when the Windows user profile contains non-English
-    characters (e.g. Cyrillic account names) #2824
-  - open ZIP maps, JPEG/TIFF images, Lua scripts, fonts, and cache files
-    from folders with non-English characters on Windows
-  - fix crash when scrolling the Weather → RASP settings page #2828
-* devices
-  - Condor 3: Spectate.json multiplayer traffic driver (Condor3Spectate)
-    shows other gliders on the FLARM radar and map
-  - Condor3UDP: stop deriving track from ground-velocity vx/vy (caused
-    spurious ~120° FLARM radar bearing jumps after compass expiry)
-  - support $LK8EX1 (LK8000 external instrument) on all device ports:
-    pressure, QNE altitude, vario, temperature, and battery voltage
-    or percentage #2772
-  - $LXWP0 without airspeed publishes uncompensated vario (BlueFly LX
-    mode) instead of labelling it total-energy; with IAS/TAS keep TE
-  - BlueFly Vario: publish battery voltage from BAT telemetry (mV)
-    in addition to the estimated percentage
-  - BlueFly Vario: parse TMP temperature telemetry (deci-degrees C)
-  - BlueFly Vario: parse $BFV/$BFX telemetry and offer BFV/BFX (and
-    None) output modes in the device manage dialog
-  - BlueFly Vario: download onboard IGC flight logs (Devices → Flight
-    download) via $BLF* / $BFF*
-  - BlueFly Vario: add output frequency, lift/sink thresholds, and
-    audio when connected to the device manage dialog
-  - Accept partial $LXWP0 vario samples (e.g. BlueFly LX mode with a
-    single rate) so Status Variometer is not stuck on Disconnected while
-    baro still works; keep the six-sample FIR for full LXNAV sentences #2763
-  - fix LXNAV thermal averages when the device reports conflicting
-    altitude sources #2754
-  - Android: multi-port USB serial adapters (e.g. dual FTDI) use 0-based port
-    suffixes (#0, #1) in both the port list and device list #2481
-  - FLARM $PGRMZ (when FLARM is detected) feeds igc_pressure_altitude for the
-    ISA logger datum; cleared when strong pressure replaces weak pressure or
-    ignores the sentence
-  - LXNAV: apply device vario filter time ($LXWP3 variofil) to gauge, map
-    vario bar, thermal rose, audio vario and snail-trail colouring
-  - Condor 3: new UDP telemetry driver (Condor3UDP) for Simkits generic UDP
-    output (default port 55278); complements TCP/NMEA Condor3 for MacCready,
-    ballast, attitude, radio, and related fields (#2340)
-  - Glide polar sync in the device dialog is only shown for drivers that
-    implement it (LXNAV)
-  - Increase the number of device slots from 6 to 8
-* ui
-  - fix crash when switching pages from FLARM radar or thermal assistant back
-    to a map page that has a bottom widget configured (#2583)
-  - airspace warnings: fix crash when the warning clears if the bottom page
-    was already restored
-  - pages config: map overlay and RASP layer rows stay visible on non-map
-    pages (disabled instead of hidden); weather controls and overlay
-    selection are decoupled (#2583)
-  - macOS: thick solid lines now render at their correct pixel width #2545
-  - Android: fix spurious outline lines on high-DPI OpenGL displays #1514
-  - plane details: WeGlide aircraft type can be configured even when WeGlide
-    upload is disabled #2323
-  - status dialog, Times: flight time matches takeoff and landing after
-    minute rounding (including across midnight); landing time clears on a
-    new takeoff in the same session #957
-  - status dialog, Rules: after a valid start, show PEV offset at start (time
-    from PEV window start to the crossing) when known, as a duration (e.g.
-    "45 sec", "2 min") not HH:MM so sub-minute offsets are not shown as 00:00
-  - infoboxen: Start reach uses remaining distance / ground speed when the
-    MacCready leg solution is not OK, so it matches Start open again in the
-    common MC-too-low / wind cases; Start open shows a signed gate countdown at
-    now instead of a blank value #2502; Start reach main value is time to the
-    start line (leg ETA), not gate countdown at arrival; Start open value colour
-    and comment reflect gate state at now (Waiting/Open/Closed, blue/green/red);
-    Start reach value colour and comment reflect gate state at leg ETA
-    (Too early/Can start/Too late, blue/green/red)
-  - infoboxen: new Altitude IGC InfoBox (logger pressure or ISA pressure only)
-  - BigTrafficWidget: task direction arrow matches map best-cruise shape,
-    drawn as outline between range rings #2027
-  - plane polar dialog: fix polar coefficient grid layout and auto-sized width
-  - waypoint search: name filter matches anywhere in the long name and the
-    shortname (typically the ICAO code in SeeYou .cup files), not only at
-    the start, so e.g. "FIELD" finds "AIRFIELD" and "INGEN" finds
-    "DITTINGEN" #2483
-  - waypoint search: each waypoint appears at most once in the result list,
-    even when the typed substring matches both its long name and its
-    shortname #1316
-  - waypoint search: Type filter no longer lists the .xcm map archive as a
-    selectable filter when its embedded waypoints are not loaded (e.g. when
-    a separate WPFileList already supplied the database), so the dropdown
-    no longer offers a filter that always yields zero matches #1376
-  - waypoint search: "Recently Used" Type filter entry shows the
-    recently-visited waypoints again; it had been silently aliased to the
-    unrelated "Map file" filter since the multi-file rework (#1994) due to
-    a positional dropdown/enum mismatch
-  - large FLARM radar: optional callsign and relative altitude (in hundreds,
-    as on the small gauge) beside targets when side data is in altitude mode;
-    passive targets use default colours when no altitude brush is set
-  - waypoint search: Type filter now lists every CUP waypoint type
-    (Mountain Top/Pass, Bridge, Tunnel, Tower, Power Plant, Obstacle,
-    Thermal Hotspot, Marker, VOR, NDB, Dam, Castle, Intersection,
-    Reporting Point, PG Take Off / Landing Zone) #2485
-  - infoboxen: new "Active Waypoint" InfoBox (next task waypoint, or Goto
-    waypoint when no task is loaded; shows name, arrival height above safety,
-    and distance; tap to pick a different task leg or set a new Goto)
-  - infoboxen: new "Previous Waypoint" InfoBox (task waypoint before the active
-    leg, or the start waypoint while on the first leg; shows name, arrival
-    height above safety, and distance; tap to display a different waypoint
-    without advancing the task or setting a Goto, or "Resume auto tracking" to
-    revert)
-  - new Data Management hub (menu, quick menu, and ``DataManagement`` input
-    event): site files, download manager, export flights, import data,
-    backup manager, and advanced file explorer in one place
-  - storage location picker lists removable and external volumes; the list
-    refreshes when media is plugged or unplugged (Linux udev, Windows
-    volumes, Android storage access framework)
-  - import data: pick files on external storage and copy recognized types
-    into the correct XCSoar data subdirectories (waypoints, airspaces,
-    terrain, and the rest); unknown files can stay in the data root #2289
-  - backup manager: create and restore ``.tar`` backups of the primary data
-    tree on a chosen volume; logs, existing archives, and ``cache/`` are
-    excluded; restore rejects paths outside the data tree
-  - advanced file explorer: browse any storage device, organize loose files
-    into typed subdirectories, transfer selections to another volume, and
-    rename or delete files #2289
-* desktop
-  - command-line: -h/--help and -version/--version print to stdout and exit;
-    unknown options print a short usage line on stderr
-  - flight export and data import use the shared storage picker and hotplug
-    refresh (extends external-storage export/import on Linux and Windows)
-    #1114
-* ui
-  - Waypoint details embedded image: new input mode ``wptimg`` and
-    ``WaypointImage`` events (magnify, shrink, reset, arrows) so keys
-    can be set in the ``.xci`` file without the map's ``default`` key
-    fallback
-  - Waypoint details embedded image and PC-Met satellite viewer: zoom and
-    pan with focal-point centering when magnifying; supports +/- buttons,
-    F2/F3, and arrow keys (#1127, #1246)
-* input
-  - F2 = zoom in, F3 = zoom out in pan, on the FLARM radar, and in waypoint
-    image ``wptimg`` (not on the main non-pan map, where F2/F3 stay Checklist
-    and FLARM as before). Traffic: ``next`` and ``previous`` events; FLARM: UP/DOWN
-    and F4 = next target (with UP/DOWN), F1 = AVG/ALT labels, F2/F3 = zoom.
-    The radar no longer hard-codes d-pad to zoom; bindings come from the
-    ``.xci`` file
-  - ``GotoLookup`` accepts an optional argument to pre-select the Type
-    filter on entry (``recent``/``last_used``, ``airport``, ``landable``,
-    ``turnpoint``, ``start``, ``finish``), so a gesture or key binding can
-    open the waypoint list focused on a category #336
-  - default Left-Up (LU) map gesture opens the Waypoint Selection dialog
-    pre-filtered to recently-used waypoints; listed in the Gesture Help
-    dialog with its own icon #336
-* map
-  - apply snail trail wind drift only when zoomed in (about 16 km across
-    the short map edge), so a Full trail in circling mode no longer
-    looks shifted away from turnpoints at overview scales #2835
-  - fix black terrain after idle high-resolution sharpening on OpenGL
-    devices with a 2048-pixel texture limit (e.g. Raspberry Pi 3 / VC4)
-  - on hosts with max CPU frequency ≤ 1.4 GHz (typical Kobo, Raspberry Pi
-    1–3 / 3B+, Cubieboard-class), keep the Full snail trail store at 1024
-    points (7.44 size) instead of the larger fast-host capacity #2661
-  - snail trail: reduce long-flight map CPU by clipping the trail to the
-    visible area before spacing-thinning (Full trail no longer walks the
-    whole history every redraw) #2661
-  - dynamically adjust contour line density to zoom factor #2233
-  - provide different contour density profile settings for mountains,
-    low lands, etc. to have sensible contours in a given landscape type
-  - turn back marker: new opt-in overlay (Safety Factors config panel) showing
-    a green triangle along the current track indicating the furthest point from
-    which the active task waypoint or Goto target can still be reached with the
-    current altitude and conditions; only shown during cruise when the target
-    is reachable; persisted via profile key TurnBackMarkerEnabled #1741
-  - larger on-map typography: default waypoint text, map-scale readout, and
-    topography labels
-  - map waypoint icons (bitmap and vector landables): new ``Waypoint icon
-    size`` on Configuration → Map display → Waypoints (50–200%, default 100%)
-  - obstacles hidden at wider map scales than other non-landables (5000 vs 10000)
-  - draw up to 1024 waypoints at once (was 256) #2327
-  - terrain: fix fluctuating hill-shading strength #2262
-  - snail trail: Catmull-Rom smoothing between fixes; vario colouring samples
-    high-rate netto from the merge thread between GPS points #2447
-  - Add renderer to display distance rings around the current location #2522
-  - Fix intermittent white-map hang on startup for non-OpenGL builds when
-    drawing began before map bounds were ready #2734
-* ui
-  - infoboxen: refresh titles after changing the interface language #2314
-  - infoboxen: add "Home" InfoBox (waypoint name, arrival height at home,
-    distance; tap to change home waypoint) #2320
-  - alternates: Alternate 1/2 InfoBoxes can follow the computed list (AUTO) or
-    a pilot-chosen field (MANUAL); tap the InfoBox to open the alternates list,
-    switch mode, and assign the selected row to that slot (runtime only; AUTO
-    clears the pin).  Titles show Altn 1/2 with AUTO or MAN.
-  - list dialogs: Up/Down move the list (when the list is focused) so
-    filter rows in the same dialog (e.g. waypoint file) still get those keys;
-    Left/Right move the action bar with cursor key selection; current
-    action uses list-focus colours in the light theme and the bright
-    focus colour in dark, like other dialog focus.  Select Airspace: Details
-    and Close are on the main dialog action bar (bottom/edge) so the same
-    keys can reach them after the list, like other list dialogs
-  - map item list and airspace list: respect list focus/selection text colours
-    (was unreadable focused row on e-ink: paint reset colour to black on a
-    black focused background) #2495
-  - alternates: list holds up to 10 options (was 6); if the task only has one
-    automatic alternate, Alternate 2 no longer shows the same as Alternate 1.
-    Displayed glide is re-solved with the current aircraft state; value colour
-    encodes not reachable, final glide, need climb, and MANUAL on/below glide.
-    Manual updated en/de/fr/pt_BR #2347
-  - clarify alternates mode help text in Safety Factors config panel (#555)
-  - status: show G-load availability in device list and variometer source in
-    system status
-  - terrain: add new terrain shading orientation "fixed (Top Left)"
-  - airspace list & map item list: grey text for airspaces with a day
-    acknowledgement; map item list adds an "Enable" button to clear it (like the
-    airspace warnings list) #2404
-  - airspace warnings: keep the cursor key action in sync with which actions
-    are enabled, and the armed action with keyboard focus (no double
-    highlight when e.g. Close is focused and another is cursor-selected);
-    replace Radio with Details; Up/Down move the list, Left/Right the action
-    row, Up from the action row returns to the list
-  - Form/DataField/Enum: remove the limit of 128 internal entries (It was
-    dropping the newest InfoBoxes, as we have 130 of them now)
-  - encode bundled UI OGG sound assets at Vorbis quality 5 (was 1)
-  - tabbed dialogs: show list-style focus on the tab strip when the device has
-    cursor keys and the strip has keyboard focus (or always on devices without
-    cursor keys, where the indicator is informational only)
-  - checklist rich text: Enter on a checkbox advances focus like Down #2405
-  - checklist/help markdown: vhf:…#standby / vhf:…#active links set COM standby or
-    active (optional station name in [text](url); label shows name and MHz);
-    confirmation after tap; documented in doc/checklist.rst; example on the
-    default getting-started checklist
-  - checklist, credits, Quick Guide, configuration: horizontal swipe to flip
-    pager pages (same behaviour as arrow keys); wiring lives in
-    ArrowPagerWidget::Prepare; red trail while drawing the swipe; fix crash when
-    swiping (pager change deferred until after mouse-up) #2122 #2414
-  - Quick Guide "What's New": release notes are Markdown generated at build time
-    from NEWS.txt (headings + merged list lines) instead of truncating the
-    gzipped file at runtime
-  - Quick Guide, getting started: "Safety factors" and "Terrain display" lines
-    use live settings vs factory defaults (not hardcoded unchecked) #2324
-  - Quick Guide, help & configuration checklists: list checkboxes use dialog
-    look and min touch row height; keyboard focus frame on the checkbox; override
-    touch autodetection with -touchscreen or -notouchscreen (non-Android) #2325
-  - Quick Guide: "Don't show this guide again" on every informational page;
-    skip Welcome on startup when the guide is hidden; Config → Look →
-    Language, Input controls startup visibility, release notes on next
-    startup, and safety disclaimer acceptance #2648
-  - waypoint search: stays open until Esc or a successful GoTo / task / home / pan
-    action (pan ends the search so the map is not hidden under the list); same for
-    WaypointDetails select and WaypointDetailsPersistent (was: only after closing
-    details) #749
-  - waypoint list & alternates: waypoint details open above the list; Close without
-    a committed action returns to the list, not the map #620
-  - Added QNH InfoBox displaying current QNH pressure setting in hectopascals #2521
-  - Linux: Config → Setup → Network for WiFi (NetworkManager or ConnMan
-    via D-Bus)
-* android
-  - use physical display metrics for startup DPI (getRealMetrics) #1784
-  - UI sounds via preloaded SoundPool (MediaPlayer fallback for early play or
-    external .wav); AudioAttributes before prepare; transient audio focus with
-    flush between SoundPool plays; volume scaled from media/notification streams;
-    log warnings/errors only on failure #2411
-  - native debug symbols for Google Play (symbols.zip), lib/<ABI>/ layout for
-    single-ABI and multi-ABI (AAB) builds; Makefile fix so parallel builds
-    reliably produce the symbol ZIP in CI
-  - configure built-in GPS & sensors in the last device slot by default (same on
-    iOS)
-  - storage enumeration and permission grants update the device list when
-    the user picks a folder or when SAF access changes
+  - fix wild T Avg climb rates by preferring the instrument vario
+    when available (including LXNAV conflicting altitude sources)
+    #2754
 * calculations
-  - BrokenDateTime: unified UTC conversion (rename FromUnixTimeUTC to
-    FromUnixTime); Windows TimeGm uses _mkgmtime
   - restore FFVV NetCoupe contest optimisation #2330
-  - angle bearing/delta normalization uses O(1) wrap (avoids stalls when angles
-    are extremely large; suspected Android freeze #1292)
-* weather
-  - Enhanced rendering of RASP weather data with layer transparency,
-    color scale key and numerical display of weather values, per-page-overlays,
-    bottom-panel controls and auto-advance.
-  - METAR/TAF station list: accept lowercase ICAO codes when adding a station;
-    codes are normalized to upper-case for download and profile storage
-  - add EDL weather support with per-page map overlays (None/RASP/EDL),
-    bottom-panel weather controls with auto-advance, day precaching,
-    and simplified RASP configuration (field/time on pages instead of the
-    weather dialog)
-  - add ``WeatherOverlay`` input event and ``mode=weather`` stick/button
-    bindings (via quick menu **Forecast Controls**) to step forecast time
-    and altitude/level on weather overlay map pages (#2583)
-  - pc_met www images: add RADAR Deutschland Nord/Mitte/Süd, Alpen, SAT RAD
-    BLITZ, and Blitzkarte Europa; local radar list uses Borkum instead of
-    the removed Emden site
-* NOTAM integration #2018
-  - add support for downloading, caching and displaying NOTAM airspaces
-  - add manual refresh and auto-refresh with location/time based updates
-  - add NOTAM settings and filters (IFR, effective time, max radius, hidden Q-codes)
-  - add NOTAM details integration in airspace dialogs
-* data files
-  - Configuration / Quick Guide: do not persist unchanged profile defaults
-    (terrain, LanguageFile, ContestEnumLayout, HideQuickGuideDialogOnStartup);
-    Expert writes UserLevel=1 or removes the key (#1793)
-  - fix ``-profile=`` basename so it resolves under ``-datapath=`` regardless of
-    command-line argument order #848
-  - .cup tasks: More correctly parse SeeYou .cup task files with observation zones
-    with uncommon angles, i.e. angles other than 90 degree quadrants or cylinder.
-    Previously these were incorrectly parsed into FAI Quadrants #2697
-  - windows: open files with O_BINARY so embedded ZIP (e.g. CUPX POINTS.CUP)
-    is read correctly
-  - openair: map AY ASRA to aerial sporting/recreational airspace type #1827
-  - XCSoar data layout: waypoints, airspaces, terrain, profiles, logs, and
-    other repository types use typed subdirectories under the data root;
-    built-in and downloaded files save and resolve through the FileType API
-    instead of hard-coded extensions #2289
-  - on first start after upgrade, move legacy flat files in the primary data
-    directory into the matching subdirectories when the destination does not
-    yet exist; migration is marked complete only after at least one file was
-    moved #2289
-  - IGC and NMEA logs are stored under ``logs/`` #2289
-  - fix crash when queuing many background file downloads while others
-    complete (download manager queue race) #2624
+  - fix LS-8 polar max. cruise speed: the default stored 190 (km/h)
+    in the m/s field; default and built-in LS-8 polars now use
+    52.78 m/s #1134
+  - fix stalls from extremely large angles (suspected Android freeze
+    #1292)
 * devices
-  - add GDL 90 input driver (standard ADS-B traffic and ownship over serial or
-    UDP; optional ForeFlight geometric altitude and AHRS; horizontal/vertical
-    traffic filters) #2356
-  - fix native crash on device reconnect (stale delayed reopen timer) #2382
-  - Polar sync device setting is offered only for drivers that register polar
-    support (currently LXNAV); PutPolar is skipped on other drivers even if an old
-    profile had Polar sync enabled #2457
+  - add a GDL 90 input driver (ADS-B traffic and ownship over serial
+    or UDP) #2356
+  - add a driver for the LX Navigation LX160 vario / final-glide
+    computer: GPS position out and LXWP vario/settings in on one
+    port
+  - add Condor 3 Spectate.json multiplayer traffic and a UDP
+    telemetry driver (Condor3UDP) #2340
+  - support $LK8EX1 (pressure, QNE altitude, vario, temperature,
+    battery) on all device ports #2772
+  - add BlueFly Vario battery voltage and temperature telemetry,
+    BFV/BFX output modes, onboard IGC download, and audio/threshold
+    settings in the device manage dialog
+  - increase device slots from 6 to 8
+  - show the Vario flag for non-compensated and netto vario as well
+    as total-energy
+  - show G-load and variometer source on the status device list
+  - number multi-port USB serial adapters from #0 in the port and
+    device lists #2481
+  - use FLARM $PGRMZ for the IGC logger pressure altitude when FLARM
+    is detected
+  - apply the LXNAV vario filter time to the gauge, map vario bar,
+    thermal rose, audio vario, and snail-trail colouring
+  - show polar sync in the device dialog only for drivers that
+    support it (LXNAV) #2457
+  - treat $LXWP0 without airspeed as uncompensated vario (BlueFly LX
+    mode), and accept partial vario samples so Status Variometer is
+    not stuck on Disconnected #2763
+  - fix native crash on device reconnect #2382
+* input
+  - bind F2/F3 to zoom in pan, on the FLARM radar, and in waypoint
+    images (not on the main map). FLARM: F1 AVG/ALT labels, F4 next
+    target, F5/F6 auto-zoom and north-up #2535
+  - ``GotoLookup`` accepts an optional Type filter (``recent``,
+    ``airport``, ``landable``, …); default Left-Up (LU) gesture opens
+    recently-used waypoints #336
+  - add ``VarioVolume`` and ``VarioAudioMode`` input events to mute
+    or adjust the internal audio vario and switch Vario/STF sound
+* android
+  - BLE serial ports auto-detect Nordic UART (e.g. Naviter dongles)
+    and Microchip/ISSC transparent UART (e.g. BlueFly) as well as
+    HM-10 #2260
+  - add USB support for SoftRF Concorde, Prime Mk4, and Retro Mk2
+  - use the physical display size for DPI so fonts and lines match
+    the screen #1784
+  - play UI sounds through the system sound pool with media volume
+    #2411
+  - put built-in GPS and sensors in the last device slot by default
+    (same on iOS)
+  - update the device list when storage folders or permissions change
+  - fix crash when the app restarts after the screen is torn down
+  - fix spurious outline lines on high-DPI displays #1514
 * iOS
   - fix audio vario playback through the device speaker
-  - disable Core Location distance filter for built-in GPS so fixes are not
+  - disable the Core Location distance filter so built-in GPS is not
     suppressed while stationary #2380
-* kobo
-  - memory canvas: fix painting when list rows or edit fields are partially
-    off-screen while scrolling (no black squares; safer clipping of subcanvas
-    and list blits) #2293
 * Windows
-  - add installer for the OpenGL Windows version (64-bit and 32-bit); zip
-    download remains available for a portable install
-  - deprecate the legacy single-file Windows executable; use the OpenGL
-    version instead — the legacy build will be removed in a future release
+  - add an installer for the OpenGL Windows version (64-bit and
+    32-bit); zip download remains available for a portable install
+  - deprecate the legacy single-file Windows executable; use the
+    OpenGL version instead — the legacy build will be removed in a
+    future release
+  - open ZIP maps, JPEG/TIFF images, Lua scripts, fonts, and cache
+    files from folders with non-English characters
+  - fix crash opening the log list when replay filenames contain
+    non-ASCII characters
+* Kobo
+  - always start in light mode; dark mode is not supported on
+    e-paper #2568
+  - fix painting when list rows or edit fields are partly off-screen
+    while scrolling (no black squares) #2293
+* desktop
+  - print -h/--help and -version/--version to stdout and exit
+  - flight export and data import use the shared storage picker
+    #1114
+* documentation
+  - document custom ``.xci`` loading (``#CLEAR``, merge vs replace,
+    event ``type`` values, gestures, softkeys, GCE list, RemoteStick
+    Quick Menu)
+  - document the ``AirspaceLabels`` input event and map
+    pinch-to-zoom #2790
+  - correct the ``.plr`` optional max. cruise speed unit to m/s #1134
 * development
-  - MapWindow: publish a coherent projection snapshot for the DrawThread on
-    non-OpenGL builds so rendering does not read a live UI projection #2735
+  - logging: record screen resolution, DPI, virtual DPI, approximate
+    size, and small-screen flag at startup #1548
+  - Android: ship native debug symbols for Google Play
+  - time: unify UTC conversion (BrokenDateTime / Windows TimeGm)
+  - MapWindow: publish a coherent projection snapshot for the
+    DrawThread on non-OpenGL builds #2735
 
 Version 7.44 - 2026-03-22
 * WaypointDetails


### PR DESCRIPTION
## Summary
- Restructure the unreleased 7.45 `NEWS.txt` block for What's New: a `* highlights` section, feature sections, user-facing wording, and only bugs that already existed in 7.44.
- Expand `.cursor/rules/news.txt.mdc` with highlights, one-issue-per-bullet, verb-led bullets, and naming conventions used for this rewrite.

## Test plan
- [ ] Read the 7.45 block in `NEWS.txt` (highlights first, then feature sections)
- [ ] Confirm What's New still builds from `NEWS.txt` (`tools/news_to_quickguide_md.py`)
- [ ] Spot-check that headline features are not duplicated below highlights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 7.45.
  * Documented new weather overlays, NOTAM integration, touch gestures, safety and distance displays, and improved data management.
  * Included updates to maps, airspace, waypoints, InfoBoxes, simulator features, Quick Guide content, device support, tracking, and platform functionality.
  * Refined release-note guidance for consistent structure, categorization, highlights, and UI terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->