### PR TITLE
darwin: Allow TESTING=y in darwin/.env

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -368,6 +368,8 @@ Version 7.45 - 2026-08-15
   - time: unify UTC conversion (BrokenDateTime / Windows TimeGm)
   - MapWindow: publish a coherent projection snapshot for the
     DrawThread on non-OpenGL builds #2735
+  - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
+    produce the testing flavour
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -33,6 +33,8 @@ Version 7.46 - not yet released
     #2862
 * development
   - documentation: document the release and post-release version workflow
+  - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
+    produce the testing flavour
 
 Version 7.45 - 2026-08-15
 * highlights
@@ -368,8 +370,6 @@ Version 7.45 - 2026-08-15
   - time: unify UTC conversion (BrokenDateTime / Windows TimeGm)
   - MapWindow: publish a coherent projection snapshot for the
     DrawThread on non-OpenGL builds #2735
-  - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
-    produce the testing flavour
 
 Version 7.44 - 2026-03-22
 * WaypointDetails

--- a/darwin/.env.example
+++ b/darwin/.env.example
@@ -1,5 +1,11 @@
-# Apple App Store Signing Configuration
+# Apple App Store Signing and Build Configuration
 # Copy this file to .env and fill in your actual values
+
+# Build Configuration
+# Build the "Testing" flavour: red icon/logo and, on iOS, the separate bundle
+# identifier "XCSoar-testing" so it can be installed next to the stable app.
+# Read by darwin/build.sh (Xcode builds) and darwin/install.sh.
+# TESTING=y
 
 # App Store Connect - App's numeric ID (NOT your personal Apple ID email)
 APPLE_ID_NUMERIC=1234567890

--- a/darwin/build.sh
+++ b/darwin/build.sh
@@ -16,6 +16,28 @@ fi
 readonly TARGET_PLATFORM_NAME="$1"
 readonly CONFIGURATION="$2"
 
+# Load environment variables from .env file if it exists from darwin/.env
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/.env" ]; then
+    echo "build.sh: Loading configuration from darwin/.env"
+    set -a
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+# Normalise the TESTING flag; make expects a lower case "y"
+case "$(printf '%s' "${TESTING:-n}" | tr '[:upper:]' '[:lower:]')" in
+    y|yes|true|1)
+        TESTING="y"
+        echo "build.sh: Building the testing flavour (TESTING=y)"
+        ;;
+    *)
+        TESTING="n"
+        ;;
+esac
+export TESTING
+
 # Set debug flag based on configuration
 DEBUG="n"
 if [ "${CONFIGURATION}" = "Debug" ]; then
@@ -75,7 +97,9 @@ NUM_CPUS=$(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu 2>/dev/nul
 echo "Building with $NUM_CPUS parallel jobs..."
 
 # Execute make with error checking
-if ! gmake -j"${NUM_CPUS}" USE_CCACHE=y V=2 OPTIMIZE="-O0" DEBUG="$DEBUG" TARGET="$TARGET" $IPA_TARGET; then
+# TESTING must be passed on the command line: build/options.mk assigns a
+# default with "=", which would override the value from the environment.
+if ! gmake -j"${NUM_CPUS}" USE_CCACHE=y V=2 OPTIMIZE="-O0" DEBUG="$DEBUG" TESTING="$TESTING" TARGET="$TARGET" $IPA_TARGET; then
     echo "Error: Build failed" >&2
     exit 1
 fi

--- a/darwin/install.sh
+++ b/darwin/install.sh
@@ -8,10 +8,16 @@ if [[ -f "$SCRIPT_DIR/.env" ]]; then
   source "$SCRIPT_DIR/.env"
 fi
 
+# Testing builds use their own bundle identifier (see build/ios.mk)
+case "$(printf '%s' "${TESTING:-n}" | tr '[:upper:]' '[:lower:]')" in
+  y|yes|true|1) DEFAULT_BUNDLE_ID="XCSoar-testing" ;;
+  *) DEFAULT_BUNDLE_ID="XCSoar" ;;
+esac
+
 # Configuration
 IPA_SIGNED_PATH="${IOS_SIGNED_IPA_PATH:-$(pwd)/output/IOS64/xcsoar-signed.ipa}"
 DEVICE_NAME="${IOS_DEVICE_NAME:-}"
-BUNDLE_ID="${IOS_BUNDLE_ID:-"XCSoar"}"
+BUNDLE_ID="${IOS_BUNDLE_ID:-$DEFAULT_BUNDLE_ID}"
 
 # Validate required environment variables
 if [[ -z "$DEVICE_NAME" ]]; then

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -395,9 +395,14 @@ Debugging for iOS and macOS
 Debugging under iOS and macOS is possible using the LLDB debugger.
 To make this convenient, Xcode or Visual Studio can be used.
 An example Xcode project is provided in `darwin/XCSoar.xcodeproj`. 
-It includes one target for iOS and macOS and will automatically build 
+It includes one target for iOS and macOS and will automatically build
 the XCSoar binary for the selected device target, using the build
 helper script `darwin/build.sh`.
+That script reads optional settings from `darwin/.env` (see
+`darwin/.env.example`); for example ``TESTING=y`` builds the testing
+flavour with the red icon, which on iOS uses the separate bundle
+identifier ``XCSoar-testing`` and can therefore be installed next to the
+stable app.
 For iOS debugging with Visual Studio Code, the `iOS Debug`
 extension (https://github.com/nisargjhaveri/vscode-ios-debug) can be used.
 Note that this also requires an Xcode installation.


### PR DESCRIPTION
`darwin/build.sh` does not read `darwin/.env`, so Xcode builds cannot select the testing flavour without editing the script. `build.sh` should load `darwin/.env` and pass `TESTING` on the `gmake` command line. `darwin/install.sh` should then default the bundle ID to `XCSoar-testing`, matching the identifier `build/ios.mk` uses for testing builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional testing build flavor for macOS and iOS.
  * Testing builds use a separate bundle identifier and a red visual indicator.
  * Added environment-file configuration for selecting the testing flavor and related build settings.

* **Documentation**
  * Updated macOS and iOS build, installation, signing, and configuration guidance.
  * Documented testing flavor behavior, bundle identifiers, and affected build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->