### PR TITLE
Kobo Clara Colour Draft PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ ifeq ($(TARGET),ANDROID)
 OUTPUTS += $(ANDROID_BIN)/XCSoar-debug.apk
 endif
 
-ifeq ($(TARGET_IS_KOBO),y)
+ifeq ($(TARGET_IS_KOBO)$(TARGET_IS_KOBO_NICKEL),yn)
 OUTPUTS += $(KOBO_MENU_BIN) $(KOBO_POWER_OFF_BIN)
 endif
 

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -1,3 +1,5 @@
+ifeq ($(TARGET_IS_KOBO_NICKEL),n)
+
 $(eval $(call pkg-config-library,LIBCRYPTO,libcrypto))
 
 KOBO_MENU_SOURCES = \
@@ -50,7 +52,9 @@ ifeq ($(TARGET),UNIX)
 OPTIONAL_OUTPUTS += $(KOBO_MENU_BIN)
 endif
 
-ifeq ($(TARGET_IS_KOBO),y)
+endif
+
+ifeq ($(TARGET_IS_KOBO)$(TARGET_IS_KOBO_NICKEL),yn)
 
 KOBO_POWER_OFF_SOURCES = \
 	$(TEST_SRC_DIR)/Fonts.cpp \

--- a/build/kobo_nickel_libstdcxx_compat.hpp
+++ b/build/kobo_nickel_libstdcxx_compat.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef __cplusplus
+#include <bits/c++config.h>
+
+/*
+ * The GCC 10 libstdc++ headers come from Debian bullseye, while KOBO_NICKEL
+ * targets Nickel's older glibc sysroot.  Disable pthread header feature paths
+ * which assume libc declarations not present in Nickel.
+ */
+#undef _GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT
+#undef _GLIBCXX_USE_PTHREAD_MUTEX_CLOCKLOCK
+#undef _GLIBCXX_USE_PTHREAD_RWLOCK_CLOCKLOCK
+
+/*
+ * Preload <cmath> while libstdc++ can set up std:: math functions, then make
+ * subsequent <math.h> includes go directly to Nickel's C header.  This avoids
+ * libstdc++'s compatibility math.h wrapper re-exporting std::isinf/isnan over
+ * Nickel's older C declarations.
+ */
+#include <cmath>
+#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS
+#define _GLIBCXX_MATH_H 1
+#endif

--- a/build/link.mk
+++ b/build/link.mk
@@ -67,10 +67,17 @@ $$($(2)_OBJS): CPPFLAGS += $$($(2)_CPPFLAGS)
 $$($(2)_OBJS): CPPFLAGS_DEPENDS += $$($(2)_DEPENDS_FLAT)
 
 # Link the unstripped binary
+ifeq ($$($(2)_LINK_GROUP),y)
+$$($(2)_NOSTRIP): $$($(2)_OBJS) $$($(2)_LDADD) $$(TARGET_LDADD) | $$(TARGET_BIN_DIR)/dirstamp
+	@$$(NQ)echo "  LINK    $$@"
+	$$(file >$$@.rsp,$$(ld-flags) -o $$@ $$(sort $$($(2)_OBJS)) -Wl,--start-group $$($(2)_LDADD) $$(TARGET_LDADD) $$($(2)_LDLIBS) $$(ld-libs) -Wl,--end-group)
+	$$(Q)$$(LINK) @$$@.rsp
+else
 $$($(2)_NOSTRIP): $$($(2)_OBJS) $$($(2)_LDADD) $$(TARGET_LDADD) | $$(TARGET_BIN_DIR)/dirstamp
 	@$$(NQ)echo "  LINK    $$@"
 	$$(file >$$@.rsp,$$(ld-flags) -o $$@ $$^ $$($(2)_LDLIBS) $$(ld-libs))
 	$$(Q)$$(LINK) @$$@.rsp
+endif
 
 # Strip the binary (optional)
 ifeq ($$($(2)_STRIP),y)

--- a/build/main.mk
+++ b/build/main.mk
@@ -721,6 +721,11 @@ XCSOAR_SOURCES += \
 	$(SRC)/XCSoar.cpp
 endif
 
+ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+XCSOAR_SOURCES += \
+	$(SRC)/Compatibility/getrandom.c
+endif
+
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/DownloadFileModal.cpp \

--- a/build/options.mk
+++ b/build/options.mk
@@ -45,7 +45,9 @@ endif
 # compile without UI?
 HEADLESS ?= n
 
-ifeq ($(TARGET_IS_KOBO),y)
+ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+  DITHER ?= n
+else ifeq ($(TARGET_IS_KOBO),y)
   DITHER ?= y
 else
   DITHER ?= n

--- a/build/python/build/autotools.py
+++ b/build/python/build/autotools.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path, subprocess, sys
 from typing import Collection, Iterable, Optional, Sequence, Union
 from collections.abc import Mapping

--- a/build/python/build/cmake.py
+++ b/build/python/build/cmake.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import subprocess
@@ -72,10 +74,10 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 """)
-    elif toolchain.is_android:
-        # Android uses the NDK compiler sysroot for platform headers/libs,
-        # but third-party package discovery must still stay inside our
-        # target prefix to avoid picking up host libraries such as zlib.
+    elif toolchain.is_android or toolchain.is_nickel:
+        # Android and Nickel use the compiler's own platform sysroot, but
+        # third-party package discovery must stay inside our target prefix to
+        # avoid picking up host libraries such as zlib.
         f.write(f"""
 set(CMAKE_FIND_ROOT_PATH "{toolchain.install_prefix}")
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
@@ -108,7 +110,7 @@ def configure(toolchain: AnyToolchain, src: str, build: str, args: list[str]=[],
         # properly); but we must not do that on Android because the NDK
         # has a sysroot already
         no_isystem = False
-        if not toolchain.is_android and not toolchain.is_darwin:
+        if not toolchain.is_android and not toolchain.is_darwin and not toolchain.is_nickel:
             configure.append('-DCMAKE_SYSROOT=' + toolchain.install_prefix)
 
             # strip "-isystem" to avoid build failures with C++ headers

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -12,6 +12,26 @@ from build.lua import LuaProject
 from build.musl import MuslProject
 
 
+class CurlProject(CmakeProject):
+    def configure(self, toolchain):
+        src = self.unpack(toolchain)
+        build = self.make_build_path(toolchain)
+
+        configure_args = list(self.configure_args)
+        if toolchain.is_windows:
+            configure_args += self.windows_configure_args
+        if toolchain.is_android:
+            configure_args += self.android_configure_args
+        if toolchain.is_darwin:
+            configure_args += self.darwin_configure_args
+        if toolchain.is_nickel:
+            configure_args.append(
+                '-DOPENSSL_ROOT_DIR=' + toolchain.install_prefix)
+
+        configure_cmake(toolchain, src, build, configure_args, self.env)
+        return build
+
+
 class LibPngProject(CmakeProject):
     def configure(self, toolchain):
         src = self.unpack(toolchain)
@@ -235,7 +255,7 @@ cares = CmakeProject(
     patches=abspath("lib/c-ares/patches"),
 )
 
-curl = CmakeProject(
+curl = CurlProject(
     (
         "https://curl.se/download/curl-8.5.0.tar.xz",
         "https://github.com/curl/curl/releases/download/curl-8_5_0/curl-8.5.0.tar.xz",

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -351,6 +351,7 @@ libjpeg = CmakeProject(
     [
         "-DENABLE_STATIC=ON",
         "-DENABLE_SHARED=OFF",
+        "-DCMAKE_C_STANDARD_LIBRARIES=-lm",
     ],
     env={
         # unwind tables are needed for throwing C++ exceptions from C

--- a/build/python/build/linux.py
+++ b/build/python/build/linux.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Optional
 
 from .makeproject import MakeProject

--- a/build/python/build/lua.py
+++ b/build/python/build/lua.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os.path, subprocess, shutil
 from typing import Optional, Sequence, Union
 

--- a/build/python/build/makeproject.py
+++ b/build/python/build/makeproject.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess, multiprocessing
 from typing import Optional, Sequence, Union
 

--- a/build/python/build/meson.py
+++ b/build/python/build/meson.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 import platform

--- a/build/python/build/openssl.py
+++ b/build/python/build/openssl.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from typing import Optional, Sequence, Union
 
@@ -46,6 +48,7 @@ class OpenSSLProject(MakeProject):
 
             # Kobo
             'armv7a-kobo-linux-musleabihf': 'linux-generic32',
+            'arm-nickel-linux-gnueabihf': 'linux-generic32',
 
             # Windows
             'i686-w64-mingw32': 'mingw',
@@ -62,6 +65,7 @@ class OpenSSLProject(MakeProject):
             'no-module',
             'no-engine',
             'no-static-engine',
+            'no-dso',
             'no-async',
             'no-tests',
             'no-makedepend',

--- a/build/python/build/toolchain.py
+++ b/build/python/build/toolchain.py
@@ -23,6 +23,7 @@ class NativeToolchain:
         self.is_windows = False
         self.is_android = False
         self.is_darwin = sys.platform == 'darwin'
+        self.is_nickel = False
 
         self.cc = 'ccache gcc'
         self.cxx = 'ccache g++'
@@ -60,6 +61,7 @@ class Toolchain:
         self.is_windows = 'mingw32' in host_triplet
         self.is_android = '-android' in host_triplet
         self.is_darwin = '-darwin' in host_triplet
+        self.is_nickel = host_triplet == 'arm-nickel-linux-gnueabihf'
         
         self.is_target_ios = target_is_ios
 

--- a/build/python/build/zlib.py
+++ b/build/python/build/zlib.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import subprocess
 from typing import Optional, Sequence, Union
 

--- a/build/screen.mk
+++ b/build/screen.mk
@@ -217,6 +217,9 @@ SCREEN_SOURCES += \
 	$(CANVAS_SRC_DIR)/fb/TopCanvas.cpp \
 	$(WINDOW_SRC_DIR)/fb/Window.cpp \
 	$(WINDOW_SRC_DIR)/fb/SingleWindow.cpp
+ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+SCREEN_SOURCES += $(CANVAS_SRC_DIR)/fb/FBInkBackend.cpp
+endif
 FB_CPPFLAGS = -DUSE_FB
 else ifeq ($(HAVE_WIN32)$(ENABLE_SDL),yn)
 SCREEN_SOURCES += \

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -3,7 +3,7 @@ TARGETS = PC WIN64 \
 	UNIX UNIX32 UNIX64 OPT \
 	WAYLAND \
 	FUZZER \
-	PI PI2 CUBIE KOBO NEON \
+	PI PI2 CUBIE KOBO KOBO_NICKEL NEON \
 	ANDROID ANDROID7 ANDROID86 \
 	ANDROIDAARCH64 ANDROIDX64 \
 	ANDROIDFAT \
@@ -55,6 +55,7 @@ TARGET_IS_PI := n
 TARGET_IS_PI32 := n
 TARGET_IS_PI64 := n
 TARGET_IS_KOBO := n
+TARGET_IS_KOBO_NICKEL := n
 TARGET_IS_CUBIE := n
 HAVE_POSIX := n
 HAVE_WIN32 := y
@@ -237,6 +238,35 @@ ifeq ($(TARGET),KOBO)
   TARGET_IS_KOBO = y
 
   HOST_TRIPLET = armv7a-kobo-linux-musleabihf
+endif
+
+ifeq ($(TARGET),KOBO_NICKEL)
+  # Kobo devices launched from Nickel/NickelMenu, without replacing the boot
+  # flow with XCSoar's legacy KoboRoot.tgz package.
+  override TARGET = NEON
+  override TARGET_FLAVOR = KOBO_NICKEL
+  TARGET_IS_KOBO = y
+  TARGET_IS_KOBO_NICKEL = y
+
+  # Build against Nickel's ABI/sysroot with an external compiler new enough
+  # for XCSoar's C++20 coroutine usage.
+  HOST_TRIPLET = arm-nickel-linux-gnueabihf
+  NICKEL_CROSS_PREFIX ?= arm-linux-gnueabihf-
+  NICKEL_CROSS_SUFFIX ?= -10
+  TCPREFIX = $(NICKEL_CROSS_PREFIX)
+  TCSUFFIX = $(NICKEL_CROSS_SUFFIX)
+
+  # This toolchain's gold reports spurious alignment warnings for merged
+  # string sections.  BFD links the same input cleanly but has no ICF.
+  USE_LD ?= bfd
+  ICF ?= n
+
+  ifeq ($(strip $(NICKEL_SYSROOT)),)
+    $(error NICKEL_SYSROOT must name the Nickel target sysroot)
+  endif
+
+  # Audio support can be re-enabled once the base launch path is proven.
+  ENABLE_ALSA = n
 endif
 
 ifeq ($(TARGET),NEON)
@@ -533,7 +563,17 @@ ifeq ($(TARGET_IS_KOBO),y)
 
   TARGET_CXXFLAGS += -Wno-psabi
 
-  TCPREFIX = $(abspath $(THIRDPARTY_LIBS_DIR))/bin/$(HOST_TRIPLET)-
+  ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+    TARGET_ARCH += -no-pie
+    TARGET_CPPFLAGS += --sysroot=$(NICKEL_SYSROOT)
+    TARGET_CPPFLAGS += -DTARGET_IS_KOBO_NICKEL=1
+    # GCC 10 misdiagnoses nodiscard constructors used for base/member
+    # initialization as discarded temporaries.
+    TARGET_CXXFLAGS += -Wno-unused-result
+    TARGET_CXXFLAGS += -include $(abspath build/kobo_nickel_libstdcxx_compat.hpp)
+  else
+    TCPREFIX = $(abspath $(THIRDPARTY_LIBS_DIR))/bin/$(HOST_TRIPLET)-
+  endif
 endif
 
 ifeq ($(TARGET),ANDROID)
@@ -564,6 +604,14 @@ endif
 TARGET_LDFLAGS =
 TARGET_LDLIBS =
 TARGET_LDADD =
+
+ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+  TARGET_LDFLAGS += --sysroot=$(NICKEL_SYSROOT)
+  TARGET_LDFLAGS += -static-libstdc++ -static-libgcc
+  TARGET_LDFLAGS += -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/usr/local/Qt-5.2.1-arm/lib
+  TARGET_LDLIBS += -ldl
+  XCSOAR_LINK_GROUP = y
+endif
 
 ifeq ($(TARGET),PC)
   TARGET_LDFLAGS += -Wl,--major-subsystem-version=6
@@ -604,7 +652,7 @@ ifeq ($(HOST_IS_ARM)$(TARGET_IS_CUBIE),ny)
   TARGET_LDFLAGS += -L$(CUBIE)/usr/local/stow/sunxi-mali/lib
 endif
 
-ifeq ($(TARGET_IS_KOBO),y)
+ifeq ($(TARGET_IS_KOBO)$(TARGET_IS_KOBO_NICKEL),yn)
   TARGET_LDFLAGS += --static
 
   # Dirty workaround for a musl/libstdc++ problem: libstdc++ imports

--- a/build/targets.mk
+++ b/build/targets.mk
@@ -610,6 +610,7 @@ ifeq ($(TARGET_IS_KOBO_NICKEL),y)
   TARGET_LDFLAGS += -static-libstdc++ -static-libgcc
   TARGET_LDFLAGS += -Wl,-rpath,/usr/local/Kobo -Wl,-rpath,/usr/local/Qt-5.2.1-arm/lib
   TARGET_LDLIBS += -ldl
+  TARGET_LDLIBS += -lfbink
   XCSOAR_LINK_GROUP = y
 endif
 

--- a/build/test.mk
+++ b/build/test.mk
@@ -146,6 +146,7 @@ endif
 
 ifeq ($(HAVE_WIN32),n)
 TEST_NAMES += \
+	TestKoboModel \
 	TestDataLayoutMigration \
 	TestLocalPathResolve
 endif
@@ -363,6 +364,13 @@ TEST_DATE_TIME_SOURCES = \
 	$(TEST_SRC_DIR)/TestDateTime.cpp
 TEST_DATE_TIME_DEPENDS = MATH TIME
 $(eval $(call link-program,TestDateTime,TEST_DATE_TIME))
+
+TEST_KOBO_MODEL_SOURCES = \
+	$(SRC)/Kobo/Model.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestKoboModel.cpp
+TEST_KOBO_MODEL_CPPFLAGS = -DKOBO
+$(eval $(call link-program,TestKoboModel,TEST_KOBO_MODEL))
 
 TEST_ISO8601_SOURCES = \
 	$(SRC)/Formatter/TimeFormatter.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -80,6 +80,7 @@ TEST_NAMES = \
 	TestInputTransformMode \
 	TestOverwritingRingBuffer \
 	TestDateTime TestISO8601 TestRoughTime TestWrapClock \
+	TestCanvasExport \
 	TestPolylineDecoder \
 	TestTransponderCode \
 	TestMath \
@@ -366,11 +367,27 @@ TEST_DATE_TIME_DEPENDS = MATH TIME
 $(eval $(call link-program,TestDateTime,TEST_DATE_TIME))
 
 TEST_KOBO_MODEL_SOURCES = \
+	$(SRC)/Asset.cpp \
+	$(SRC)/DisplaySettings.cpp \
 	$(SRC)/Kobo/Model.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestKoboModel.cpp
 TEST_KOBO_MODEL_CPPFLAGS = -DKOBO
 $(eval $(call link-program,TestKoboModel,TEST_KOBO_MODEL))
+
+TEST_CANVAS_EXPORT_SOURCES = \
+	$(CANVAS_SRC_DIR)/memory/Dither.cpp \
+	$(TEST_SRC_DIR)/CanvasExportGreyscale.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestCanvasExport.cpp
+TEST_CANVAS_EXPORT_CPPFLAGS = -DDITHER -DGREYSCALE -DKOBO
+$(eval $(call link-program,TestCanvasExport,TEST_CANVAS_EXPORT))
+
+TEST_CANVAS_EXPORT_COLOR_SOURCES = \
+	$(TEST_SRC_DIR)/CanvasExportColor.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestCanvasExportColor.cpp
+$(eval $(call link-program,TestCanvasExportColor,TEST_CANVAS_EXPORT_COLOR))
 
 TEST_ISO8601_SOURCES = \
 	$(SRC)/Formatter/TimeFormatter.cpp \

--- a/build/thirdparty.mk
+++ b/build/thirdparty.mk
@@ -31,14 +31,17 @@ $(THIRDPARTY_LIBS_DIR)/stamp:
 	GEOTIFF=$(GEOTIFF) ./build/thirdparty.py $(THIRDPARTY_LIBS_DIR) $(HOST_TRIPLET) $(TARGET_IS_IOS) "$(TARGET_ARCH)" "$(TARGET_CPPFLAGS)" "$(filter-out $(THIRDPARTY_LDFLAGS_FILTER_OUT),$(TARGET_LDFLAGS))" "$(WRAPPED_CC)" "$(WRAPPED_CXX)" $(AR) "$(ARFLAGS)" $(RANLIB) $(STRIP) "$(WINDRES)" $(ENABLE_SDL)
 	touch $@
 
-ifeq ($(TARGET_IS_KOBO),n)
-TARGET_CPPFLAGS += -isystem $(THIRDPARTY_LIBS_ROOT)/include
-TARGET_LDFLAGS += -L$(THIRDPARTY_LIBS_ROOT)/lib
+ifeq ($(TARGET_IS_KOBO_NICKEL),y)
+  TARGET_CPPFLAGS += -isystem $(THIRDPARTY_LIBS_ROOT)/include
+  TARGET_LDFLAGS += -L$(THIRDPARTY_LIBS_ROOT)/lib
+else ifeq ($(TARGET_IS_KOBO),n)
+  TARGET_CPPFLAGS += -isystem $(THIRDPARTY_LIBS_ROOT)/include
+  TARGET_LDFLAGS += -L$(THIRDPARTY_LIBS_ROOT)/lib
 endif
 
 endif
 
-ifeq ($(TARGET_IS_KOBO),y)
+ifeq ($(TARGET_IS_KOBO)$(TARGET_IS_KOBO_NICKEL),yn)
   # we build a toolchain as part of the thirdparty-library build
   BUILD_TOOLCHAIN_TARGET = $(THIRDPARTY_LIBS_DIR)/stamp
 else

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -111,6 +111,19 @@ elif toolchain.is_android:
         libgeotiff,
         netcdf,
     ]
+elif host_triplet == 'arm-nickel-linux-gnueabihf':
+    thirdparty_libs = [
+        zlib,
+        libfmt,
+        libsodium,
+        freetype,
+        openssl,
+        libpng,
+        libjpeg,
+        cares,
+        curl,
+        lua,
+    ]
 elif '-kobo-linux-' in host_triplet:
     thirdparty_libs = [
         binutils,

--- a/build/warnings.mk
+++ b/build/warnings.mk
@@ -15,7 +15,9 @@ endif
 
 # disable some warnings, we're not ready for them yet
 CXX_WARNINGS += -Wno-missing-field-initializers
+ifneq ($(TARGET_IS_KOBO_NICKEL),y)
 CXX_WARNINGS += -Wcast-align
+endif
 
 # plain C warnings
 

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -394,8 +394,8 @@ Debugging for iOS and macOS
 
 Debugging under iOS and macOS is possible using the LLDB debugger.
 To make this convenient, Xcode or Visual Studio can be used.
-An example Xcode project is provided in `darwin/XCSoar.xcodeproj`. 
-It includes one target for iOS and macOS and will automatically build 
+An example Xcode project is provided in `darwin/XCSoar.xcodeproj`.
+It includes one target for iOS and macOS and will automatically build
 the XCSoar binary for the selected device target, using the build
 helper script `darwin/build.sh`.
 For iOS debugging with Visual Studio Code, the `iOS Debug`
@@ -494,6 +494,38 @@ packaging section in addition to the Kobo build dependencies (the
 Then compile using this command::
 
   make TARGET=KOBO output/KOBO/KoboRoot.tgz
+
+Compiling for Kobo Nickel/NickelMenu
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``KOBO_NICKEL`` target builds XCSoar for Kobo devices where XCSoar is
+launched from Nickel or NickelMenu instead of replacing the normal boot flow
+with ``KoboRoot.tgz``.  This target is intended for newer secure-boot Kobo
+devices such as the Kobo Clara Colour.
+
+This target requires a Nickel ABI sysroot with:
+
+- an ARM hard-float GCC 14 or newer cross compiler, because XCSoar requires
+  C++20 coroutine support;
+- Nickel's runtime libraries and headers;
+- FBInk's matching library and header installed in that sysroot;
+- a compiler prefix/suffix selecting that compiler.
+
+The validated toolchain image is
+``ghcr.io/anj1/nickeltc-gcc14:sha-6da75a292ebb40855cde651b910c36d975b154f7``.
+It exports ``NICKEL_SYSROOT`` and provides
+``arm-linux-gnueabihf-gcc-14``/``g++-14``.  Equivalent newer compilers may be
+selected with ``NICKEL_CROSS_PREFIX`` and ``NICKEL_CROSS_SUFFIX``.  To
+compile, run::
+  make TARGET=KOBO_NICKEL DEBUG=n WERROR=y
+
+The resulting binary is written to::
+
+  output/KOBO_NICKEL/bin/xcsoar
+
+Packaging and NickelMenu launcher scripts are maintained separately.  Nickel
+builds deliberately exclude the legacy ``KoboRoot.tgz``, ``KoboMenu`` and
+``PowerOff`` installation lifecycle.
 
 Building USB-OTG Kobo Kernel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -721,6 +721,11 @@ Defaults shown are from the build system (they can be overridden with
    - no
    - Framebuffer (software)
    - Cross-compile target (ARMv7 + NEON).
+ * - ``KOBO_NICKEL``
+   - Kobo e-readers launched from Nickel/NickelMenu
+   - no
+   - Framebuffer (software)
+   - Cross-compile target for Nickel's ABI/sysroot.
  * - ``NEON``
    - Generic ARMv7 + NEON
    - yes

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -719,7 +719,7 @@ Defaults shown are from the build system (they can be overridden with
  * - ``KOBO``
    - Kobo e-readers
    - no
-   - Framebuffer (software)
+   - FBInk framebuffer (software)
    - Cross-compile target (ARMv7 + NEON).
  * - ``KOBO_NICKEL``
    - Kobo e-readers launched from Nickel/NickelMenu

--- a/src/Asset.cpp
+++ b/src/Asset.cpp
@@ -22,6 +22,16 @@ SetDisplayType(DisplayType type) noexcept
 }
 
 bool
+HasColors() noexcept
+{
+#ifdef GREYSCALE
+  return false;
+#else
+  return display_type != DisplayType::E_INK;
+#endif
+}
+
+bool
 HasEPaper() noexcept
 {
   return IsEPaperDisplayType(display_type);

--- a/src/Asset.hpp
+++ b/src/Asset.hpp
@@ -218,15 +218,9 @@ HasCursorKeys() noexcept
 /**
  * Does this device have a display with colors?
  */
-static constexpr bool
-HasColors() noexcept
-{
-#if defined(GREYSCALE)
-  return false;
-#else
-  return !IsKobo();
-#endif
-}
+[[gnu::pure]]
+bool
+HasColors() noexcept;
 
 /**
  * Is dithering black&white used on the display?

--- a/src/Audio/Sound.cpp
+++ b/src/Audio/Sound.cpp
@@ -27,7 +27,7 @@
 #endif
 
 bool
-PlayResource(const char *resource_name)
+PlayResource([[maybe_unused]] const char *resource_name)
 {
 #ifdef ANDROID
 

--- a/src/Compatibility/getrandom.c
+++ b/src/Compatibility/getrandom.c
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+ssize_t getrandom(void *buffer, size_t count, unsigned int flags);
+
+ssize_t
+getrandom(void *buffer, size_t count, unsigned int flags)
+{
+  (void)flags;
+
+  int fd = open("/dev/urandom", O_RDONLY);
+  if (fd < 0)
+    return -1;
+
+  char *p = buffer;
+  size_t remaining = count;
+  while (remaining > 0) {
+    ssize_t n = read(fd, p, remaining);
+    if (n < 0) {
+      int saved_errno = errno;
+      close(fd);
+      errno = saved_errno;
+      return -1;
+    }
+
+    if (n == 0) {
+      close(fd);
+      errno = EIO;
+      return -1;
+    }
+
+    p += n;
+    remaining -= n;
+  }
+
+  close(fd);
+  return count;
+}

--- a/src/Device/Driver/XCTracer/Parser.cpp
+++ b/src/Device/Driver/XCTracer/Parser.cpp
@@ -129,7 +129,7 @@ XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
    * parse the date
    * parse and absorb all three values, even if one or more is empty, e.g. ",,13"
    */
-  unsigned year, month, day;
+  unsigned year{}, month{}, day{};
   valid_fields += ReadCheckedRange(line,year,1800,2500);
   valid_fields += ReadCheckedRange(line,month,1,12);
   valid_fields += ReadCheckedRange(line,day,1,31);
@@ -138,7 +138,7 @@ XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
    * parse the time
    * parse and check all four values, even if one or more is empty, e.g. ",,33,"
    */
-  unsigned hour, minute, second, centisecond;
+  unsigned hour{}, minute{}, second{}, centisecond{};
   valid_fields += ReadCheckedRange(line,hour,0,23);
   valid_fields += ReadCheckedRange(line,minute,0,59);
   valid_fields += ReadCheckedRange(line,second,0,59);
@@ -148,7 +148,7 @@ XCTracerDevice::XCTRC(NMEAInputLine &line, NMEAInfo &info)
    * parse the GPS fix
    * parse and check both  values, even if one or more is empty, e.g. ",3.1234,"
    */
-  double latitude, longitude;
+  double latitude{}, longitude{};
   valid_fields += ReadCheckedRange(line,latitude,-90.0,90.0);
   valid_fields += ReadCheckedRange(line,longitude,-180.0,180.0);
 

--- a/src/Dialogs/FileManager.cpp
+++ b/src/Dialogs/FileManager.cpp
@@ -454,7 +454,7 @@ ManagedFileListWidget::UpdateButtons()
 }
 
 void
-ManagedFileListWidget::OnActivateItem(unsigned index) noexcept
+ManagedFileListWidget::OnActivateItem([[maybe_unused]] unsigned index) noexcept
 {
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (items.empty()) {

--- a/src/Dialogs/dlgQuickMenu.cpp
+++ b/src/Dialogs/dlgQuickMenu.cpp
@@ -22,6 +22,9 @@
 #include "util/StaticString.hxx"
 
 #include <boost/container/static_vector.hpp>
+#ifdef TARGET_IS_KOBO_NICKEL
+#include <algorithm>
+#endif
 #include <cstdlib>
 #include <memory>
 
@@ -87,7 +90,16 @@ QuickMenuButtonRenderer::DrawButton(Canvas &canvas, const PixelRect &rc,
   canvas.Select(*look.button.font);
   canvas.SetBackgroundTransparent();
 
+#ifdef TARGET_IS_KOBO_NICKEL
+  const PixelSize text_size = canvas.CalcTextSize(caption);
+  const int x = rc.left +
+    std::max(0, int(rc.GetWidth()) - int(text_size.width)) / 2;
+  const int y = rc.top +
+    std::max(0, int(rc.GetHeight()) - int(text_size.height)) / 2;
+  canvas.DrawClippedText({x, y}, rc.right - x, caption);
+#else
   text_renderer.Draw(canvas, rc, caption);
+#endif
 }
 
 class QuickMenu final : public WindowWidget {

--- a/src/DisplaySettings.cpp
+++ b/src/DisplaySettings.cpp
@@ -3,6 +3,18 @@
 
 #include "DisplaySettings.hpp"
 
+#ifdef KOBO
+#include "Kobo/Model.hpp"
+
+DisplayType
+GetKoboDefaultDisplayType(KoboModel model) noexcept
+{
+  return model == KoboModel::CLARA_COLOUR
+    ? DisplayType::COLOR_E_INK
+    : DisplayType::E_INK;
+}
+#endif
+
 void
 DisplaySettings::SetDefaults()
 {
@@ -11,7 +23,7 @@ DisplaySettings::SetDefaults()
   invert_cursor_colors = false;
   full_screen = true;
 #ifdef KOBO
-  display_type = DisplayType::E_INK;
+  display_type = GetKoboDefaultDisplayType(DetectKoboModel());
 #else
   display_type = DisplayType::LCD;
 #endif

--- a/src/DisplaySettings.hpp
+++ b/src/DisplaySettings.hpp
@@ -8,6 +8,14 @@
 
 #include <type_traits>
 
+#ifdef KOBO
+enum class KoboModel;
+
+[[gnu::const]]
+DisplayType
+GetKoboDefaultDisplayType(KoboModel model) noexcept;
+#endif
+
 /**
  * Display settings.
  */

--- a/src/Hardware/Battery.cpp
+++ b/src/Hardware/Battery.cpp
@@ -65,6 +65,23 @@ GetInfo() noexcept
     }
     break;
 
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
+    if (File::ReadString(Path("/sys/class/power_supply/bd71827_bat/status"),
+                         line, sizeof(line))) {
+      if (StringIsEqual(line,"Not charging\n") ||
+          StringIsEqual(line,"Charging\n") ||
+          StringIsEqual(line,"Full\n"))
+        external.status = Power::ExternalInfo::Status::ON;
+      else if (StringIsEqual(line,"Discharging\n"))
+        external.status = Power::ExternalInfo::Status::OFF;
+    }
+
+    if (File::ReadString(Path("/sys/class/power_supply/bd71827_bat/capacity"),
+                         line, sizeof(line)))
+      battery.remaining_percent = atoi(line);
+    break;
+
   default:
     // code shamelessly copied from OS/SystemLoad.cpp
     if (!File::ReadString(Path("/sys/class/power_supply/mc13892_bat/uevent"),

--- a/src/Hardware/DisplayDPI.cpp
+++ b/src/Hardware/DisplayDPI.cpp
@@ -52,6 +52,8 @@ GetDPI()
   case KoboModel::GLO_HD:
   case KoboModel::CLARA_HD:
   case KoboModel::CLARA_2E:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
   case KoboModel::LIBRA2:
   case KoboModel::LIBRA_H2O:
     return 300;

--- a/src/Input/InputEventsSettings.cpp
+++ b/src/Input/InputEventsSettings.cpp
@@ -538,7 +538,7 @@ InputEvents::sub_TerrainTopography(int vswitch)
     settings_map.terrain.enable = ((val & 0x02) == 0x02);
 
     // Show current state after cycling
-    StaticString<128> buf;
+    StaticString<128> buf{};
     buf.AppendFormat(_("%s / %s"),
                      settings_map.topography_enabled ? _("On") : _("Off"),
                      settings_map.terrain.enable ? _("On") : _("Off"));

--- a/src/Kobo/Kernel.cpp
+++ b/src/Kobo/Kernel.cpp
@@ -51,6 +51,9 @@ Copy(int out_fd, int in_fd, const char *out_path, const char *in_path)
 bool
 KoboInstallKernel(const char *uimage_path)
 {
+  if (IsKoboMediaTek())
+    return false;
+
   const char *const out_path = "/dev/mmcblk0";
 
   const int in_fd = open(uimage_path, O_RDONLY|O_NOCTTY|O_CLOEXEC);
@@ -95,6 +98,7 @@ try {
   /* All Kobo except Clara HD, Clara 2E, Libra 2 and Libra H2O have a factory kernel without OTG mode so
      a custom kernel is installed for OTG. */
   if (kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
+      || IsKoboMediaTek(kobo_model)
       || kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::LIBRA_H2O)
         return false;
 
@@ -118,6 +122,9 @@ IsKoboOTGHostMode()
 {
 #ifdef KOBO
   KoboModel kobo_model = DetectKoboModel();
+  if (IsKoboMediaTek(kobo_model))
+    return false;
+
   if (kobo_model != KoboModel::CLARA_HD && kobo_model != KoboModel::CLARA_2E
       && kobo_model != KoboModel::LIBRA2 && kobo_model != KoboModel::LIBRA_H2O)
         return IsKoboCustomKernel();

--- a/src/Kobo/Model.cpp
+++ b/src/Kobo/Model.cpp
@@ -47,17 +47,23 @@ static constexpr struct {
   { "SN-RN437", KoboModel::GLO_HD },
   { "SN-N249", KoboModel::CLARA_HD },
   { "SN-N506", KoboModel::CLARA_2E },
+  { "SN-N365", KoboModel::CLARA_BW },
+  { "SN-P365", KoboModel::CLARA_BW },
+  { "SN-N367", KoboModel::CLARA_COLOUR },
   { "SN-N306", KoboModel::NIA },
   { "SN-N418", KoboModel::LIBRA2 },
   { "SN-N873", KoboModel::LIBRA_H2O },
 };
 
-static KoboModel
-DetectKoboModel(const char *p) noexcept
+KoboModel
+ParseKoboModel(std::span<const char> data) noexcept
 {
-  for (const auto &i : kobo_model_ids)
-    if (memcmp(p, i.id, strlen(i.id)) == 0)
-      return i.model;
+  for (const auto &i : kobo_model_ids) {
+    const size_t id_length = strlen(i.id);
+    for (size_t offset = 0; offset + id_length <= data.size(); ++offset)
+      if (memcmp(data.data() + offset, i.id, id_length) == 0)
+        return i.model;
+  }
 
   return KoboModel::UNKNOWN;
 }
@@ -66,22 +72,57 @@ KoboModel
 DetectKoboModel() noexcept
 {
   char buffer[16];
-  if (!ReadFromFile("/dev/mmcblk0", 0x200, buffer, sizeof(buffer)))
-    return KoboModel::UNKNOWN;
+  if (ReadFromFile("/dev/mmcblk0", 0x200, buffer, sizeof(buffer))) {
+    const KoboModel model = ParseKoboModel(buffer);
+    if (model != KoboModel::UNKNOWN)
+      return model;
+  }
 
-  return DetectKoboModel(buffer);
+  char hwcfg[512];
+  if (ReadFromFile("/dev/disk/by-partlabel/hwcfg", 0,
+                   hwcfg, sizeof(hwcfg)))
+    return ParseKoboModel(hwcfg);
+
+  return KoboModel::UNKNOWN;
+}
+
+bool
+IsKoboMediaTek() noexcept
+{
+  return IsKoboMediaTek(DetectKoboModel());
+}
+
+const char *
+GetKoboWifiInterface(KoboModel model) noexcept
+{
+  switch (model) {
+  case KoboModel::LIBRA2:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
+    return "wlan0";
+
+  case KoboModel::CLARA_2E:
+    return "mlan0";
+
+  default:
+    return "eth0";
+  }
 }
 
 const char *
 GetKoboWifiInterface() noexcept
 {
-  switch (DetectKoboModel())
-  {
-    case KoboModel::LIBRA2:
-      return "wlan0";
-    case KoboModel::CLARA_2E:
-      return "mlan0";
-    default:
-      return "eth0";
-  }
+  return GetKoboWifiInterface(DetectKoboModel());
+}
+
+const char *
+GetKoboOnboardPartition(KoboModel model) noexcept
+{
+  return IsKoboMediaTek(model) ? "/dev/mmcblk0p12" : "/dev/mmcblk0p3";
+}
+
+const char *
+GetKoboOnboardPartition() noexcept
+{
+  return GetKoboOnboardPartition(DetectKoboModel());
 }

--- a/src/Kobo/Model.hpp
+++ b/src/Kobo/Model.hpp
@@ -7,6 +7,8 @@
 #error This header is only for Kobo builds
 #endif
 
+#include <span>
+
 enum class KoboModel {
   UNKNOWN,
   MINI,
@@ -18,6 +20,8 @@ enum class KoboModel {
   GLO_HD,
   CLARA_HD,
   CLARA_2E,
+  CLARA_BW,
+  CLARA_COLOUR,
   NIA,
   LIBRA2,
   LIBRA_H2O,
@@ -27,6 +31,32 @@ enum class KoboModel {
 KoboModel
 DetectKoboModel() noexcept;
 
+[[gnu::pure]]
+KoboModel
+ParseKoboModel(std::span<const char> data) noexcept;
+
+constexpr bool
+IsKoboMediaTek(KoboModel model) noexcept
+{
+  return model == KoboModel::CLARA_BW ||
+    model == KoboModel::CLARA_COLOUR;
+}
+
+bool
+IsKoboMediaTek() noexcept;
+
+[[gnu::const]]
+const char *
+GetKoboWifiInterface(KoboModel model) noexcept;
+
 [[gnu::const]]
 const char *
 GetKoboWifiInterface() noexcept;
+
+[[gnu::const]]
+const char *
+GetKoboOnboardPartition(KoboModel model) noexcept;
+
+[[gnu::const]]
+const char *
+GetKoboOnboardPartition() noexcept;

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -22,6 +22,8 @@ static constexpr const char *kobo_config_dir = "/mnt/onboard/XCSoarData/kobo";
 static constexpr const char *kobo_wifi_auto_on_path =
   "/mnt/onboard/XCSoarData/kobo/wifi_auto_on";
 
+#ifndef TARGET_IS_KOBO_NICKEL
+
 static bool
 WaitForPath(const char *path, unsigned timeout_ms) noexcept
 {
@@ -68,11 +70,12 @@ SiblingPath(const char *name, char *buffer, size_t size)
 }
 
 #endif
+#endif
 
 bool
 KoboReboot()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   return Run("/sbin/reboot");
 #else
   return false;
@@ -82,7 +85,7 @@ KoboReboot()
 bool
 KoboPowerOff()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   char buffer[256];
   if (SiblingPath("PowerOff", buffer, sizeof(buffer)))
     execl(buffer, buffer, nullptr);
@@ -97,7 +100,7 @@ KoboPowerOff()
 bool
 KoboUmountData()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   return umount("/mnt/onboard") == 0 || errno == EINVAL;
 #else
   return true;
@@ -107,7 +110,7 @@ KoboUmountData()
 bool
 KoboMountData()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   Run("/bin/dosfsck", "-a", "-w", "/dev/mmcblk0p3");
   return mount("/dev/mmcblk0p3", "/mnt/onboard", "vfat",
                MS_NOATIME|MS_NODEV|MS_NOEXEC|MS_NOSUID,
@@ -120,7 +123,7 @@ KoboMountData()
 bool
 KoboExportUSBStorage()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   bool result = false;
 
   RmMod("g_ether");
@@ -178,7 +181,7 @@ KoboExportUSBStorage()
 void
 KoboUnexportUSBStorage()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   KoboModel kobo_model = DetectKoboModel();
   if(kobo_model == KoboModel::CLARA_HD || kobo_model == KoboModel::CLARA_2E
       || kobo_model == KoboModel::LIBRA2 || kobo_model == KoboModel::LIBRA_H2O)
@@ -243,7 +246,7 @@ SetKoboWifiAutoOn(bool enabled)
 void
 ApplyKoboWifiAutoOn()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   if (IsKoboWifiAutoOn()) {
     if (!IsKoboWifiOn())
       KoboWifiOn();
@@ -256,7 +259,7 @@ ApplyKoboWifiAutoOn()
 bool
 KoboWifiOn()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
 
   switch (DetectKoboModel())
   {
@@ -334,7 +337,7 @@ KoboWifiOn()
 bool
 KoboWifiOff()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   const char *interface =  GetKoboWifiInterface();
   Run("/usr/bin/killall", "wpa_supplicant", "udhcpc");
   if (DetectKoboModel() != KoboModel::CLARA_2E)
@@ -354,7 +357,7 @@ KoboWifiOff()
 void
 KoboExecNickel()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   /* our "rcS" will call the original Kobo "rcS" if start_nickel
      exists */
   mkdir("/mnt/onboard/XCSoarData", 0777);
@@ -370,7 +373,7 @@ KoboExecNickel()
 void
 KoboRunXCSoar([[maybe_unused]] const char *mode)
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   char buffer[256];
   const char *cmd = buffer;
 
@@ -384,7 +387,7 @@ KoboRunXCSoar([[maybe_unused]] const char *mode)
 void
 KoboRunTelnetd()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   /* telnetd requires /dev/pts - mount it (if it isn't already) */
   if (mkdir("/dev/pts", 0777) == 0)
     mount("none", "/dev/pts", "devpts", MS_RELATIME, NULL);
@@ -396,7 +399,7 @@ KoboRunTelnetd()
 void
 KoboRunFtpd()
 {
-#ifdef KOBO
+#if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   /* ftpd needs to be fired through tcpsvd (or inetd) */
   Start("/usr/bin/tcpsvd", "-E", "0.0.0.0", "21", "ftpd", "-w", "/mnt/onboard");
 #endif

--- a/src/Kobo/System.cpp
+++ b/src/Kobo/System.cpp
@@ -111,8 +111,9 @@ bool
 KoboMountData()
 {
 #if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
-  Run("/bin/dosfsck", "-a", "-w", "/dev/mmcblk0p3");
-  return mount("/dev/mmcblk0p3", "/mnt/onboard", "vfat",
+  const char *const partition = GetKoboOnboardPartition();
+  Run("/bin/dosfsck", "-a", "-w", partition);
+  return mount(partition, "/mnt/onboard", "vfat",
                MS_NOATIME|MS_NODEV|MS_NOEXEC|MS_NOSUID,
                "iocharset=utf8");
 #else
@@ -125,12 +126,19 @@ KoboExportUSBStorage()
 {
 #if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
   bool result = false;
+  StaticString<64> file_arg;
+  file_arg.Format("file=%s", GetKoboOnboardPartition());
 
   RmMod("g_ether");
   RmMod("g_file_storage");
 
   switch (DetectKoboModel())
   {
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
+    /* USB mass-storage export is not implemented for MediaTek Kobos. */
+    break;
+
   case KoboModel::UNKNOWN: // Let unknown try the old device
   case KoboModel::MINI:
   case KoboModel::TOUCH:
@@ -138,7 +146,7 @@ KoboExportUSBStorage()
   case KoboModel::GLO: // TODO: is this correct?
     InsMod("/drivers/ntx508/usb/gadget/arcotg_udc.ko");
     result = InsMod("/drivers/ntx508/usb/gadget/g_file_storage.ko",
-                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    file_arg, "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
 
@@ -147,7 +155,7 @@ KoboExportUSBStorage()
   case KoboModel::AURA2:
     InsMod("/drivers/mx6sl-ntx/usb/gadget/arcotg_udc.ko");
     result = InsMod("/drivers/mx6sl-ntx/usb/gadget/g_file_storage.ko",
-                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    file_arg, "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
 
@@ -159,7 +167,7 @@ KoboExportUSBStorage()
     InsMod("/drivers/mx6sll-ntx/usb/gadget/libcomposite.ko");
     InsMod("/drivers/mx6sll-ntx/usb/gadget/usb_f_mass_storage.ko");
     result = InsMod("/drivers/mx6sll-ntx/usb/gadget/g_file_storage.ko",
-                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    file_arg, "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
 
@@ -168,13 +176,13 @@ KoboExportUSBStorage()
     InsMod("/drivers/mx6ull-ntx/usb/gadget/libcomposite.ko");
     InsMod("/drivers/mx6ull-ntx/usb/gadget/usb_f_mass_storage.ko");
     result = InsMod("/drivers/mx6ull-ntx/usb/gadget/g_file_storage.ko",
-                    "file=/dev/mmcblk0p3", "stall=0", "removable=1",
+                    file_arg, "stall=0", "removable=1",
                     "product_id=Kobo");
     break;
   }
   return result;
 #else
-  return true;
+  return false;
 #endif
 }
 
@@ -304,17 +312,24 @@ KoboWifiOn()
     InsMod("/drivers/mx6sll-ntx/wifi/mlan.ko");
     InsMod("/drivers/mx6sll-ntx/wifi/moal.ko", "mod_para=nxp/wifi_mod_para_sd8987.conf");
     break;
+
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
+    /* The stock MediaTek kernel owns and loads the Wi-Fi modules. */
+    break;
   }
 
   Sleep(2000);
 
-  const char *interface = GetKoboWifiInterface();
-  const char *driver = (DetectKoboModel() == KoboModel::LIBRA2
-    || DetectKoboModel() == KoboModel::CLARA_2E) ? "nl80211" : "wext";
+  const KoboModel model = DetectKoboModel();
+  const char *interface = GetKoboWifiInterface(model);
+  const char *driver = (model == KoboModel::LIBRA2
+    || model == KoboModel::CLARA_2E || IsKoboMediaTek(model))
+    ? "nl80211" : "wext";
 
   Run("/sbin/ifconfig", interface, "up");
   Run("/sbin/iwconfig", interface, "power", "off");
-  if (DetectKoboModel() != KoboModel::CLARA_2E)
+  if (model != KoboModel::CLARA_2E && !IsKoboMediaTek(model))
     Run("/bin/wlarm_le", "-i", interface, "up");
   Run("/bin/wpa_supplicant", "-i", interface,
       "-c", "/etc/wpa_supplicant/wpa_supplicant.conf",
@@ -338,15 +353,18 @@ bool
 KoboWifiOff()
 {
 #if defined(KOBO) && !defined(TARGET_IS_KOBO_NICKEL)
-  const char *interface =  GetKoboWifiInterface();
+  const KoboModel model = DetectKoboModel();
+  const char *interface = GetKoboWifiInterface(model);
   Run("/usr/bin/killall", "wpa_supplicant", "udhcpc");
-  if (DetectKoboModel() != KoboModel::CLARA_2E)
+  if (model != KoboModel::CLARA_2E && !IsKoboMediaTek(model))
     Run("/bin/wlarm_le", "-i", interface, "down");
   Run("/sbin/ifconfig", interface, "down");
 
-  RmMod("dhd");
-  RmMod("8189fs");
-  RmMod("sdio_wifi_pwr");
+  if (!IsKoboMediaTek(model)) {
+    RmMod("dhd");
+    RmMod("8189fs");
+    RmMod("sdio_wifi_pwr");
+  }
 
   return true;
 #else
@@ -413,6 +431,8 @@ KoboCanChangeBacklightBrightness()
   case KoboModel::GLO_HD:
   case KoboModel::LIBRA2:
   case KoboModel::CLARA_2E:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
   case KoboModel::CLARA_HD:
     return true;
 
@@ -439,6 +459,8 @@ KoboGetBacklightBrightness()
 
   case KoboModel::LIBRA2:
   case KoboModel::CLARA_2E:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
   case KoboModel::CLARA_HD:
     if (File::ReadString(Path("/sys/class/backlight/mxc_msp430.0/brightness"), line, sizeof(line))) {
       result = atoi(line);
@@ -470,6 +492,8 @@ KoboSetBacklightBrightness([[maybe_unused]] int percent)
 
   case KoboModel::LIBRA2:
   case KoboModel::CLARA_2E:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
   case KoboModel::CLARA_HD:
     File::WriteExisting(Path("/sys/class/backlight/mxc_msp430.0/brightness"), std::to_string(percent).c_str());
     break;
@@ -512,6 +536,8 @@ KoboGetBacklightColourFile() noexcept
     break;
 
   case KoboModel::CLARA_HD:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
     files_to_check[1] = true;
     break;
 

--- a/src/Renderer/TextButtonRenderer.cpp
+++ b/src/Renderer/TextButtonRenderer.cpp
@@ -6,6 +6,28 @@
 #include "Screen/Layout.hpp"
 #include "Look/ButtonLook.hpp"
 
+#ifdef TARGET_IS_KOBO_NICKEL
+#include <algorithm>
+
+static void
+PrepareKoboNickelButtonCaption(Canvas &canvas, const PixelRect &rc,
+                               ButtonState state, PixelPoint position,
+                               PixelSize size) noexcept
+{
+  const bool inverted = state == ButtonState::FOCUSED ||
+    state == ButtonState::PRESSED;
+  const PixelRect text_rc{
+    position.x, position.y,
+    std::min(rc.right, position.x + int(size.width)),
+    std::min(rc.bottom, position.y + int(size.height)),
+  };
+
+  /* Temporary until FBInk glyph blending is root-caused on the devices. */
+  canvas.DrawFilledRectangle(text_rc, inverted ? COLOR_BLACK : COLOR_WHITE);
+  canvas.SetTextColor(inverted ? COLOR_WHITE : COLOR_BLACK);
+}
+#endif
+
 unsigned
 TextButtonRenderer::GetMinimumButtonWidth(const ButtonLook &look,
                                           std::string_view caption) noexcept
@@ -43,7 +65,18 @@ TextButtonRenderer::DrawCaption(Canvas &canvas, const PixelRect &rc,
 
   canvas.Select(*look.font);
 
+#ifdef TARGET_IS_KOBO_NICKEL
+  const PixelSize text_size = canvas.CalcTextSize(GetCaption());
+  const int x = rc.left +
+    std::max(0, int(rc.GetWidth()) - int(text_size.width)) / 2;
+  const int y = rc.top +
+    std::max(0, int(rc.GetHeight()) - int(text_size.height)) / 2;
+  const PixelPoint position{x, y};
+  PrepareKoboNickelButtonCaption(canvas, rc, state, position, text_size);
+  canvas.DrawClippedText(position, rc.right - x, GetCaption());
+#else
   text_renderer.Draw(canvas, rc, GetCaption());
+#endif
 }
 
 unsigned
@@ -63,4 +96,3 @@ TextButtonRenderer::DrawButton(Canvas &canvas, const PixelRect &rc,
     DrawCaption(canvas, frame_renderer.GetDrawingRect(rc, state),
                 state);
 }
-

--- a/src/SystemSettings.cpp
+++ b/src/SystemSettings.cpp
@@ -18,9 +18,14 @@ SystemSettings::SetDefaults()
 #ifdef _WIN32
     devices[0].path = "COM1:";
 #else
+#ifdef TARGET_IS_KOBO_NICKEL
+    devices[0].path = "/dev/ttyS0";
+    devices[0].baud_rate = 9600;
+#else
     devices[0].path = "/dev/tty0";
-#endif
     devices[0].baud_rate = 4800;
+#endif
+#endif
     devices[0].driver_name = "Generic";
   }
 }

--- a/src/net/wifi/WifiData.hpp
+++ b/src/net/wifi/WifiData.hpp
@@ -136,7 +136,7 @@ struct WifiNetworkEntry {
       }
 
       if (!entry.interface_name.empty()) {
-        StaticString<64> address;
+        StaticString<64> address{};
         if (TryFormatWifiInterfaceAddress(entry.interface_name.c_str(),
                                           address)) {
           text.Format("%s (%s)", _("Connected"), address.c_str());

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 
 #ifdef __APPLE__
 #include <TargetConditionals.h>
@@ -50,6 +51,9 @@ struct SDL_Texture;
 class Canvas;
 struct PixelSize;
 namespace UI { class Display; }
+#ifdef TARGET_IS_KOBO_NICKEL
+class FBInkBackend;
+#endif
 
 #if defined(USE_FB) && !defined(KOBO)
 /* defined if we need to initialise /dev/tty to graphics mode, see
@@ -112,12 +116,16 @@ class TopCanvas
 #endif /* USE_MEMORY_CANVAS */
 
 #ifdef USE_FB
+#ifdef TARGET_IS_KOBO_NICKEL
+  std::unique_ptr<FBInkBackend> fbink;
+#else
   int fd = -1;
 
   void *map = nullptr;
   unsigned map_pitch, map_bpp;
 
   uint32_t epd_update_marker;
+#endif
 #endif // USE_FB
 
 #ifdef KOBO

--- a/src/ui/canvas/fb/FBInkBackend.cpp
+++ b/src/ui/canvas/fb/FBInkBackend.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "FBInkBackend.hpp"
+
+#include <fbink.h>
+
+#include <stdexcept>
+
+struct FBInkBackend::Config : FBInkConfig {};
+
+static FBInkState
+GetState(const FBInkConfig &config) noexcept
+{
+  FBInkState state{};
+  fbink_get_state(&config, &state);
+  return state;
+}
+
+FBInkBackend::FBInkBackend()
+  :config(new Config{}), fd(fbink_open())
+{
+  if (fd < 0) {
+    delete config;
+    throw std::runtime_error("Failed to open the framebuffer with FBInk");
+  }
+
+  config->is_quiet = true;
+  if (fbink_init(fd, config) < 0) {
+    fbink_close(fd);
+    delete config;
+    throw std::runtime_error("Failed to initialise FBInk");
+  }
+}
+
+FBInkBackend::~FBInkBackend() noexcept
+{
+  fbink_close(fd);
+  delete config;
+}
+
+PixelSize
+FBInkBackend::GetSize() const noexcept
+{
+  const FBInkState state = GetState(*config);
+  return {state.screen_width, state.screen_height};
+}
+
+FBInkBackend::FrameBuffer
+FBInkBackend::Prepare()
+{
+  if (fbink_reinit(fd, config) < 0)
+    throw std::runtime_error("Failed to reinitialise FBInk");
+
+  const FBInkState state = GetState(*config);
+  if (state.screen_width == 0 || state.screen_height == 0 ||
+      state.scanline_stride == 0 ||
+      (state.bpp != 8 && state.bpp != 16 && state.bpp != 32))
+    throw std::runtime_error("FBInk reported an unsupported framebuffer");
+
+  std::size_t size = 0;
+  unsigned char *data = fbink_get_fb_pointer(fd, &size);
+  if (data == nullptr ||
+      size < std::size_t{state.scanline_stride} * state.screen_height)
+    throw std::runtime_error("FBInk did not provide a complete framebuffer");
+
+  return {data, size, state.scanline_stride, state.bpp / 8};
+}
+
+void
+FBInkBackend::Refresh(PixelSize size)
+{
+  if (fbink_refresh(fd, 0, 0, size.width, size.height, config) < 0)
+    throw std::runtime_error("FBInk screen refresh failed");
+}

--- a/src/ui/canvas/fb/FBInkBackend.hpp
+++ b/src/ui/canvas/fb/FBInkBackend.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/dim/Size.hpp"
+
+#include <cstddef>
+
+class FBInkBackend {
+public:
+  struct FrameBuffer {
+    unsigned char *data;
+    std::size_t size;
+    unsigned pitch;
+    unsigned bytes_per_pixel;
+  };
+
+private:
+  struct Config;
+  Config *config;
+  int fd;
+
+public:
+  FBInkBackend();
+  ~FBInkBackend() noexcept;
+
+  FBInkBackend(const FBInkBackend &) = delete;
+  FBInkBackend &operator=(const FBInkBackend &) = delete;
+
+  PixelSize GetSize() const noexcept;
+
+  FrameBuffer Prepare();
+  void Refresh(PixelSize size);
+};

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -5,6 +5,10 @@
 #include "ui/canvas/Canvas.hpp"
 #include "lib/fmt/SystemError.hxx"
 
+#ifdef TARGET_IS_KOBO_NICKEL
+#include "FBInkBackend.hpp"
+#endif
+
 #ifdef USE_FB
 #include "ui/canvas/memory/Export.hpp"
 #endif
@@ -13,7 +17,7 @@
 #include "Hardware/DisplayDPI.hpp"
 #endif
 
-#if defined(KOBO) && defined(USE_FB)
+#if defined(KOBO) && defined(USE_FB) && !defined(TARGET_IS_KOBO_NICKEL)
 #include "Kobo/Model.hpp"
 #include "mxcfb.h"
 #endif
@@ -21,15 +25,20 @@
 #include <algorithm>
 
 #ifdef USE_FB
+#ifndef TARGET_IS_KOBO_NICKEL
 #include <linux/fb.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#endif
 #include <cassert>
 #include <string.h>
+#ifndef TARGET_IS_KOBO_NICKEL
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#endif
 
+#ifndef TARGET_IS_KOBO_NICKEL
 static unsigned
 TranslateDimension(unsigned value) noexcept
 {
@@ -60,6 +69,7 @@ GetSize(const struct fb_var_screeninfo &vinfo) noexcept
 {
   return PixelSize(GetWidth(vinfo), GetHeight(vinfo));
 }
+#endif
 
 #endif
 
@@ -68,10 +78,12 @@ TopCanvas::~TopCanvas() noexcept
   buffer.Free();
 
 #ifdef USE_FB
+#ifndef TARGET_IS_KOBO_NICKEL
   if (fd >= 0) {
     close(fd);
     fd = -1;
   }
+#endif
 #endif
 }
 
@@ -80,6 +92,14 @@ TopCanvas::~TopCanvas() noexcept
 TopCanvas::TopCanvas(UI::Display &_display)
   :display(_display)
 {
+#ifdef TARGET_IS_KOBO_NICKEL
+  fbink = std::make_unique<FBInkBackend>();
+  const PixelSize new_size = fbink->GetSize();
+  if (new_size.width == 0 || new_size.height == 0)
+    throw std::runtime_error("FBInk reported an empty display");
+
+  buffer.Allocate(new_size);
+#else
   assert(fd < 0);
 
   const char *path = "/dev/fb0";
@@ -177,14 +197,19 @@ TopCanvas::TopCanvas(UI::Display &_display)
                            vinfo.width, vinfo.height);
 
   buffer.Allocate(new_size);
+#endif
 }
 
 inline PixelSize
 TopCanvas::GetNativeSize() const noexcept
 {
+#ifdef TARGET_IS_KOBO_NICKEL
+  return fbink->GetSize();
+#else
   struct fb_var_screeninfo vinfo;
   ioctl(fd, FBIOGET_VSCREENINFO, &vinfo);
   return ::GetSize(vinfo);
+#endif
 }
 
 bool
@@ -219,10 +244,12 @@ TopCanvas::CheckResize(const PixelSize new_native_size) noexcept
   /* changed: update the size and allocate a new buffer */
 
 #ifdef USE_FB
+#ifndef TARGET_IS_KOBO_NICKEL
   struct fb_fix_screeninfo finfo;
   ioctl(fd, FBIOGET_FSCREENINFO, &finfo);
 
   map_pitch = finfo.line_length;
+#endif
 #endif
 
   buffer.Free();
@@ -245,6 +272,30 @@ void
 TopCanvas::Flip()
 {
 #ifdef USE_FB
+
+#ifdef TARGET_IS_KOBO_NICKEL
+  const auto frame_buffer = fbink->Prepare();
+  if (frame_buffer.pitch < buffer.size.width * frame_buffer.bytes_per_pixel ||
+      frame_buffer.size < std::size_t{frame_buffer.pitch} * buffer.size.height)
+    throw std::runtime_error("FBInk framebuffer is smaller than the canvas");
+
+#ifdef GREYSCALE
+  CopyFromGreyscale(
+#ifdef DITHER
+                    dither,
+#endif
+#ifdef KOBO
+                    enable_dither,
+#endif
+                    frame_buffer.data, frame_buffer.pitch,
+                    frame_buffer.bytes_per_pixel, buffer);
+#else
+  CopyFromBGRA(frame_buffer.data, frame_buffer.pitch,
+               frame_buffer.bytes_per_pixel, buffer);
+#endif
+
+  fbink->Refresh(buffer.size);
+#else
 
 #ifdef GREYSCALE
   CopyFromGreyscale(
@@ -293,6 +344,7 @@ TopCanvas::Flip()
   ioctl(fd, MXCFB_SEND_UPDATE, &epd_update_data);
 #endif
 
+#endif /* TARGET_IS_KOBO_NICKEL */
 #endif /* USE_FB */
 }
 
@@ -301,7 +353,9 @@ TopCanvas::Flip()
 void
 TopCanvas::Wait() noexcept
 {
+#ifndef TARGET_IS_KOBO_NICKEL
   ioctl(fd, MXCFB_WAIT_FOR_UPDATE_COMPLETE, &epd_update_marker);
+#endif
 }
 
 #endif

--- a/src/ui/canvas/fb/TopCanvas.cpp
+++ b/src/ui/canvas/fb/TopCanvas.cpp
@@ -152,6 +152,8 @@ TopCanvas::TopCanvas(UI::Display &_display)
   case KoboModel::GLO:
   case KoboModel::AURA:
   case KoboModel::NIA:
+  case KoboModel::CLARA_BW:
+  case KoboModel::CLARA_COLOUR:
     frame_sync = false;
     break;
 

--- a/src/ui/canvas/kobo/Files.cpp
+++ b/src/ui/canvas/kobo/Files.cpp
@@ -5,6 +5,7 @@
 #include "ui/canvas/FontSearch.hpp"
 
 static constexpr const char *const font_search_paths[] = {
+  "/mnt/onboard/.adds/xcsoar/fonts",
   "/mnt/onboard/XCSoar/fonts",
   "/mnt/onboard/fonts",
   "/opt/xcsoar/share/fonts",

--- a/src/ui/canvas/memory/Canvas.cpp
+++ b/src/ui/canvas/memory/Canvas.cpp
@@ -19,6 +19,9 @@
 
 #include <algorithm>
 #include <cassert>
+#ifdef TARGET_IS_KOBO_NICKEL
+#include <memory>
+#endif
 #include <string.h>
 
 class SDLRasterCanvas : public RasterCanvas<ActivePixelTraits> {
@@ -206,14 +209,45 @@ Canvas::CalcTextSize(std::string_view text) const noexcept
   if (font == nullptr)
     return size;
 
+#ifdef TARGET_IS_KOBO_NICKEL
+  return font->TextSize(text2);
+#else
   /* see if the TextCache can handle this request */
   size = TextCache::LookupSize(*font, text2);
   if (size.height > 0)
     return size;
 
   return TextCache::GetSize(*font, text2);
+#endif
 }
 
+#ifdef TARGET_IS_KOBO_NICKEL
+struct RenderedTextBuffer {
+  std::unique_ptr<uint8_t[]> data;
+  PixelSize size;
+
+  explicit operator bool() const noexcept {
+    return data != nullptr;
+  }
+};
+
+static RenderedTextBuffer
+RenderTextUncached(const Font *font, std::string_view text) noexcept
+{
+  if (font == nullptr || text.empty())
+    return {};
+
+  assert(font->IsDefined());
+  const PixelSize size = font->TextSize(text);
+  const std::size_t buffer_size = font->BufferSize(size);
+  if (buffer_size == 0)
+    return {};
+
+  auto data = std::make_unique<uint8_t[]>(buffer_size);
+  font->Render(text, size, data.get());
+  return {std::move(data), size};
+}
+#else
 static TextCache::Result
 RenderText(const Font *font, std::string_view text) noexcept
 {
@@ -224,6 +258,7 @@ RenderText(const Font *font, std::string_view text) noexcept
 
   return TextCache::Get(*font, text);
 }
+#endif
 
 template<typename Operations>
 static void
@@ -260,12 +295,21 @@ Canvas::DrawText(PixelPoint p, std::string_view text) noexcept
 {
   assert(ValidateUTF8(text));
 
-  auto s = RenderText(font, text);
+#ifdef TARGET_IS_KOBO_NICKEL
+  const auto s = RenderTextUncached(font, text);
   if (!s)
     return;
+  const TextCache::Result result{s.data.get(), s.size.width, s.size};
+#else
+  const auto s = RenderText(font, text);
+  if (!s)
+    return;
+  const auto result = s;
+#endif
 
   SDLRasterCanvas canvas(buffer);
-  CopyTextRectangle(canvas, p.x, p.y, s.size.width, s.size.height, s,
+  CopyTextRectangle(canvas, p.x, p.y, result.size.width, result.size.height,
+                    result,
                     text_color, background_color,
                     background_mode == OPAQUE);
 }
@@ -275,14 +319,23 @@ Canvas::DrawTransparentText(PixelPoint p, std::string_view text) noexcept
 {
   assert(ValidateUTF8(text));
 
-  auto s = RenderText(font, text);
+#ifdef TARGET_IS_KOBO_NICKEL
+  const auto s = RenderTextUncached(font, text);
+  if (!s)
+    return;
+  const TextCache::Result result{s.data.get(), s.size.width, s.size};
+#else
+  const auto s = RenderText(font, text);
   if (s.data == nullptr)
     return;
+  const auto result = s;
+#endif
 
   SDLRasterCanvas canvas(buffer);
   ColoredAlphaPixelOperations<ActivePixelTraits, GreyscalePixelTraits>
     transparent(canvas.Import(text_color));
-  CopyTextRectangle(canvas, p.x, p.y, s.size.width, s.size.height, transparent, s);
+  CopyTextRectangle(canvas, p.x, p.y, result.size.width, result.size.height,
+                    transparent, result);
 }
 
 void
@@ -300,15 +353,23 @@ Canvas::DrawClippedText(PixelPoint p, unsigned width,
 {
   assert(ValidateUTF8(text));
 
-  auto s = RenderText(font, text);
+#ifdef TARGET_IS_KOBO_NICKEL
+  const auto s = RenderTextUncached(font, text);
+  if (!s)
+    return;
+  const TextCache::Result result{s.data.get(), s.size.width, s.size};
+#else
+  const auto s = RenderText(font, text);
   if (s.data == nullptr)
     return;
+  const auto result = s;
+#endif
 
-  if (width > s.size.width)
-    width = s.size.width;
+  if (width > result.size.width)
+    width = result.size.width;
 
   SDLRasterCanvas canvas(buffer);
-  CopyTextRectangle(canvas, p.x, p.y, width, s.size.height, s,
+  CopyTextRectangle(canvas, p.x, p.y, width, result.size.height, result,
                     text_color, background_color,
                     background_mode == OPAQUE);
 

--- a/src/ui/canvas/memory/Export.cpp
+++ b/src/ui/canvas/memory/Export.cpp
@@ -24,6 +24,26 @@ CopyGreyscale(uint8_t *dest_pixels, unsigned dest_pitch,
     std::copy_n(src_pixels, width, dest_pixels);
 }
 
+#ifdef DITHER
+static void
+ExpandDitheredGreyscale(void *dest_pixels, unsigned dest_pitch,
+                        unsigned dest_bpp, unsigned width, unsigned height)
+{
+  auto *row = static_cast<uint8_t *>(dest_pixels);
+  for (unsigned y = 0; y < height; ++y, row += dest_pitch) {
+    if (dest_bpp == 2) {
+      auto *expanded = reinterpret_cast<RGB565Color *>(row);
+      for (unsigned x = width; x > 0; --x)
+        expanded[x - 1] = GreyscaleToRGB565(Luminosity8{row[x - 1]});
+    } else if (dest_bpp == 4) {
+      auto *expanded = reinterpret_cast<uint32_t *>(row);
+      for (unsigned x = width; x > 0; --x)
+        expanded[x - 1] = GreyscaleToRGB8(Luminosity8{row[x - 1]});
+    }
+  }
+}
+#endif
+
 #endif /* KOBO */
 
 void
@@ -40,25 +60,38 @@ CopyFromGreyscale(
   const uint8_t *src_pixels = reinterpret_cast<const uint8_t *>(src.data);
 
 #ifdef KOBO
-  if (!enable_dither) {
+  assert(dest_bpp == 1 || dest_bpp == 2 || dest_bpp == 4);
+
+  if (dest_bpp == 1 && !enable_dither) {
     CopyGreyscale((uint8_t *)dest_pixels, dest_pitch,
                   src_pixels, src.pitch,
                   src.size.width, src.size.height);
     return;
   }
-#endif
 
 #ifdef DITHER
+  if (enable_dither) {
+    dither.DitherGreyscale(src_pixels, src.pitch,
+                           (uint8_t *)dest_pixels, dest_pitch,
+                           src.size.width, src.size.height);
+    if (dest_bpp != 1)
+      ExpandDitheredGreyscale(dest_pixels, dest_pitch, dest_bpp,
+                              src.size.width, src.size.height);
+    return;
+  }
+#endif
+#endif
+
+#if defined(DITHER) && !defined(KOBO)
 
   dither.DitherGreyscale(src_pixels, src.pitch,
                          (uint8_t *)dest_pixels,
                          dest_pitch,
                          src.size.width, src.size.height);
 
-#ifndef KOBO
   if (dest_bpp == 4) {
     const unsigned n_pixels = (dest_pitch / dest_bpp)
-      * src.height;
+      * src.size.height;
     int32_t *d = (int32_t *)dest_pixels + n_pixels;
     const int8_t *end = (int8_t *)dest_pixels;
     const int8_t *s = end + n_pixels;
@@ -66,39 +99,45 @@ CopyFromGreyscale(
     while (s != end)
       *--d = *--s;
   }
-#endif
-
-#else
+  return;
+#endif /* DITHER && !KOBO */
 
   const unsigned src_pitch = src.pitch;
+  auto *dest = static_cast<uint8_t *>(dest_pixels);
 
   if (dest_bpp == 2) {
     for (unsigned row = src.size.height; row > 0;
-         --row, src_pixels += src_pitch, dest_pixels += dest_pitch)
-      CopyGreyscaleToRGB565((RGB565Color *)dest_pixels,
+         --row, src_pixels += src_pitch, dest += dest_pitch)
+      CopyGreyscaleToRGB565((RGB565Color *)dest,
                             (const Luminosity8 *)src_pixels, src.size.width);
   } else {
     for (unsigned row = src.size.height; row > 0;
-         --row, src_pixels += src_pitch, dest_pixels += dest_pitch)
-      CopyGreyscaleToRGB8((uint32_t *)dest_pixels,
+         --row, src_pixels += src_pitch, dest += dest_pitch)
+      CopyGreyscaleToRGB8((uint32_t *)dest,
                            (const Luminosity8 *)src_pixels, src.size.width);
   }
-
-#endif
 }
 
 #else /* GREYSCALE */
 
 void
 CopyFromBGRA(void *_dest_pixels, unsigned _dest_pitch, unsigned dest_bpp,
-             ConstImageBuffer<BGRAPixelTraits> src)
+             ConstImageBuffer<BGRAPixelTraits> src) noexcept
 {
-  assert(dest_bpp == 4 || dest_bpp == 2);
+  assert(dest_bpp == 1 || dest_bpp == 2 || dest_bpp == 4);
 
   const uint32_t dest_pitch = _dest_pitch / dest_bpp;
   const uint32_t src_pitch = src.pitch / sizeof(*src.data);
 
-  if (dest_bpp == 2) {
+  if (dest_bpp == 1) {
+    auto *dest_pixels = static_cast<uint8_t *>(_dest_pixels);
+    const BGRA8Color *src_pixels = src.data;
+
+    for (unsigned row = src.size.height; row > 0;
+         --row, src_pixels += src_pitch, dest_pixels += dest_pitch)
+      for (unsigned x = 0; x < src.size.width; ++x)
+        dest_pixels[x] = Luminosity8{RGB8Color{src_pixels[x]}}.GetLuminosity();
+  } else if (dest_bpp == 2) {
     /* convert to RGB565 */
 
     RGB565Color *dest_pixels = reinterpret_cast<RGB565Color *>(_dest_pixels);

--- a/src/ui/canvas/memory/Export.hpp
+++ b/src/ui/canvas/memory/Export.hpp
@@ -79,6 +79,6 @@ CopyFromGreyscale(
 
 void
 CopyFromBGRA(void *_dest_pixels, unsigned _dest_pitch, unsigned dest_bpp,
-             ConstImageBuffer<BGRAPixelTraits> src);
+             ConstImageBuffer<BGRAPixelTraits> src) noexcept;
 
 #endif

--- a/src/ui/canvas/memory/Murphy.hpp
+++ b/src/ui/canvas/memory/Murphy.hpp
@@ -211,14 +211,14 @@ public:
     }
 
     /* outer loop, stepping perpendicular to line */
-    Point ml1, ml2, ml1b, ml2b;
+    Point ml1{0, 0}, ml2{0, 0}, ml1b{0, 0}, ml2b{0, 0};
     for (unsigned q = 0; dd <= tk; q++) {
 
       /* call to inner loop - right edge */
       const auto temp = Paraline(pt, d1);
       if (q == 0) {
-        ml1 = pt;
-        ml1b = temp;
+        ml1 = ml2 = pt;
+        ml1b = ml2b = temp;
       } else {
         ml2 = pt;
         ml2b = temp;

--- a/src/ui/event/poll/linux/Input.cpp
+++ b/src/ui/event/poll/linux/Input.cpp
@@ -15,6 +15,8 @@
 #include <sys/ioctl.h>
 #include <errno.h>
 
+#include <linux/input.h>
+
 template<typename T>
 static constexpr unsigned
 BitSize() noexcept
@@ -42,6 +44,9 @@ LinuxInputDevice::LinuxInputDevice(EventQueue &_queue,
                                    MergeMouse &_merge) noexcept
   :queue(_queue), merge(_merge),
    edit_position(0, 0), public_position(0, 0),
+#ifdef TARGET_IS_KOBO_NICKEL
+   grabbed(false),
+#endif
    event(queue.GetEventLoop(), BIND_THIS_METHOD(OnSocketReady))
 {
 }
@@ -97,6 +102,11 @@ LinuxInputDevice::Open(const char *path) noexcept
         max_y = abs.maximum;
       }
     }
+
+#ifdef TARGET_IS_KOBO_NICKEL
+    /* Nickel keeps running while XCSoar owns the display. */
+    grabbed = ioctl(event.GetFileDescriptor().Get(), EVIOCGRAB, 1) == 0;
+#endif
   }
 
   rel_x = rel_y = rel_wheel = 0;
@@ -111,8 +121,15 @@ LinuxInputDevice::Close() noexcept
   if (!IsOpen())
     return;
 
-  if (is_pointer)
+  if (is_pointer) {
+#ifdef TARGET_IS_KOBO_NICKEL
+    if (grabbed) {
+      ioctl(event.GetFileDescriptor().Get(), EVIOCGRAB, 0);
+      grabbed = false;
+    }
+#endif
     merge.RemovePointer();
+  }
 
   event.Close();
 }

--- a/src/ui/event/poll/linux/Input.hpp
+++ b/src/ui/event/poll/linux/Input.hpp
@@ -52,6 +52,10 @@ class LinuxInputDevice final {
 
   bool is_pointer;
 
+#ifdef TARGET_IS_KOBO_NICKEL
+  bool grabbed;
+#endif
+
   PipeEvent event;
 
 public:

--- a/src/util/VersionNumber.hxx
+++ b/src/util/VersionNumber.hxx
@@ -4,7 +4,15 @@
 #pragma once
 
 #include "StaticString.hxx"
-#include <stdlib.h>
+#include <cstdlib>
+
+#ifdef major
+#undef major
+#endif
+
+#ifdef minor
+#undef minor
+#endif
 
 /**
  * @brief Convert a string to a version number and compare it to other version number

--- a/test/src/CanvasExportColor.cpp
+++ b/test/src/CanvasExportColor.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+// Keep test-specific preprocessor flags out of the production Export object.
+#include "../../src/ui/canvas/memory/Export.cpp"

--- a/test/src/CanvasExportGreyscale.cpp
+++ b/test/src/CanvasExportGreyscale.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+// Keep test-specific preprocessor flags out of the production Export object.
+#include "../../src/ui/canvas/memory/Export.cpp"

--- a/test/src/FakeAsset.cpp
+++ b/test/src/FakeAsset.cpp
@@ -17,6 +17,16 @@ SetDisplayType(DisplayType type) noexcept
 }
 
 bool
+HasColors() noexcept
+{
+#ifdef GREYSCALE
+  return false;
+#else
+  return display_type != DisplayType::E_INK;
+#endif
+}
+
+bool
 HasEPaper() noexcept
 {
   return IsEPaperDisplayType(display_type);

--- a/test/src/TestCanvasExport.cpp
+++ b/test/src/TestCanvasExport.cpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ui/canvas/memory/Buffer.hpp"
+#include "ui/canvas/memory/Dither.hpp"
+#include "ui/canvas/memory/Export.hpp"
+#include "TestUtil.hpp"
+
+#include <array>
+#include <cstdint>
+
+static constexpr PixelSize SIZE{3, 2};
+
+int
+main()
+{
+  plan_tests(18);
+
+  std::array<Luminosity8, 6> pixels{
+    Luminosity8{0}, Luminosity8{255}, Luminosity8{0},
+    Luminosity8{255}, Luminosity8{0}, Luminosity8{255},
+  };
+  const ConstImageBuffer<GreyscalePixelTraits> source{
+    pixels.data(), SIZE.width, SIZE,
+  };
+  Dither dither;
+
+  std::array<uint8_t, 8> y8;
+  y8.fill(0x7f);
+  CopyFromGreyscale(dither, true, y8.data(), 4, 1, source);
+  ok1(y8[0] == 0);
+  ok1(y8[1] == 255);
+  ok1(y8[2] == 0);
+  ok1(y8[3] == 0x7f);
+  ok1(y8[4] == 255);
+  ok1(y8[5] == 0);
+  ok1(y8[6] == 255);
+  ok1(y8[7] == 0x7f);
+
+  std::array<uint16_t, 8> rgb565;
+  rgb565.fill(0x1234);
+  CopyFromGreyscale(dither, true, rgb565.data(), 8, 2, source);
+  ok1(rgb565[0] == 0);
+  ok1(rgb565[1] == 0xffff);
+  ok1(rgb565[2] == 0);
+  ok1(rgb565[3] == 0x1234);
+  ok1(rgb565[4] == 0xffff);
+
+  std::array<uint32_t, 8> rgb32;
+  rgb32.fill(0x12345678);
+  CopyFromGreyscale(dither, true, rgb32.data(), 16, 4, source);
+  ok1(rgb32[0] == 0);
+  ok1(rgb32[1] == 0xffffffff);
+  ok1(rgb32[2] == 0);
+  ok1(rgb32[3] == 0x12345678);
+  ok1(rgb32[4] == 0xffffffff);
+
+  return exit_status();
+}

--- a/test/src/TestCanvasExportColor.cpp
+++ b/test/src/TestCanvasExportColor.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ui/canvas/memory/Buffer.hpp"
+#include "ui/canvas/memory/Export.hpp"
+#include "TestUtil.hpp"
+
+#include <array>
+#include <cstdint>
+
+static constexpr PixelSize SIZE{3, 2};
+
+int
+main()
+{
+  plan_tests(15);
+
+  std::array<BGRA8Color, 6> pixels{
+    BGRA8Color{255, 0, 0}, BGRA8Color{0, 255, 0}, BGRA8Color{0, 0, 255},
+    BGRA8Color{0, 0, 0}, BGRA8Color{255, 255, 255}, BGRA8Color{127, 127, 127},
+  };
+  const ConstImageBuffer<BGRAPixelTraits> source{
+    pixels.data(), SIZE.width * sizeof(BGRA8Color), SIZE,
+  };
+
+  std::array<uint8_t, 8> y8;
+  y8.fill(0xee);
+  CopyFromBGRA(y8.data(), 4, 1, source);
+  ok1(y8[0] == Luminosity8{RGB8Color{pixels[0]}}.GetLuminosity());
+  ok1(y8[1] == Luminosity8{RGB8Color{pixels[1]}}.GetLuminosity());
+  ok1(y8[2] == Luminosity8{RGB8Color{pixels[2]}}.GetLuminosity());
+  ok1(y8[3] == 0xee);
+  ok1(y8[4] == Luminosity8{RGB8Color{pixels[3]}}.GetLuminosity());
+
+  std::array<RGB565Color, 8> rgb565;
+  rgb565.fill(RGB565Color{1, 2, 3});
+  CopyFromBGRA(rgb565.data(), 8, 2, source);
+  ok1(rgb565[0].GetNativeValue() == ToRGB565(pixels[0]).GetNativeValue());
+  ok1(rgb565[1].GetNativeValue() == ToRGB565(pixels[1]).GetNativeValue());
+  ok1(rgb565[2].GetNativeValue() == ToRGB565(pixels[2]).GetNativeValue());
+  ok1(rgb565[3].GetNativeValue() == RGB565Color(1, 2, 3).GetNativeValue());
+  ok1(rgb565[4].GetNativeValue() == ToRGB565(pixels[3]).GetNativeValue());
+
+  std::array<BGRA8Color, 8> bgra;
+  bgra.fill(BGRA8Color{1, 2, 3});
+  CopyFromBGRA(bgra.data(), 16, 4, source);
+  ok1(bgra[0] == pixels[0]);
+  ok1(bgra[1] == pixels[1]);
+  ok1(bgra[2] == pixels[2]);
+  ok1(bgra[3] == BGRA8Color(1, 2, 3));
+  ok1(bgra[4] == pixels[3]);
+
+  return exit_status();
+}

--- a/test/src/TestKoboModel.cpp
+++ b/test/src/TestKoboModel.cpp
@@ -2,6 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "Kobo/Model.hpp"
+#include "DisplaySettings.hpp"
+#include "Asset.hpp"
 #include "TestUtil.hpp"
 
 #include <span>
@@ -16,7 +18,7 @@ Parse(std::string_view value) noexcept
 int
 main()
 {
-  plan_tests(15);
+  plan_tests(24);
 
   ok1(Parse("SN-N365") == KoboModel::CLARA_BW);
   ok1(Parse("SN-P365") == KoboModel::CLARA_BW);
@@ -38,6 +40,21 @@ main()
       "/dev/mmcblk0p12");
   ok1(std::string_view{GetKoboOnboardPartition(KoboModel::CLARA_HD)} ==
       "/dev/mmcblk0p3");
+
+  ok1(GetKoboDefaultDisplayType(KoboModel::CLARA_BW) == DisplayType::E_INK);
+  ok1(GetKoboDefaultDisplayType(KoboModel::CLARA_COLOUR) ==
+      DisplayType::COLOR_E_INK);
+  ok1(GetKoboDefaultDisplayType(KoboModel::UNKNOWN) == DisplayType::E_INK);
+
+  SetDisplayType(DisplayType::E_INK);
+  ok1(!HasColors());
+  ok1(HasEPaper());
+  SetDisplayType(DisplayType::COLOR_E_INK);
+  ok1(HasColors());
+  ok1(HasEPaper());
+  SetDisplayType(DisplayType::LCD);
+  ok1(HasColors());
+  ok1(!HasEPaper());
 
   return exit_status();
 }

--- a/test/src/TestKoboModel.cpp
+++ b/test/src/TestKoboModel.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Kobo/Model.hpp"
+#include "TestUtil.hpp"
+
+#include <span>
+#include <string_view>
+
+static KoboModel
+Parse(std::string_view value) noexcept
+{
+  return ParseKoboModel(std::span{value.data(), value.size()});
+}
+
+int
+main()
+{
+  plan_tests(15);
+
+  ok1(Parse("SN-N365") == KoboModel::CLARA_BW);
+  ok1(Parse("SN-P365") == KoboModel::CLARA_BW);
+  ok1(Parse("SN-N367") == KoboModel::CLARA_COLOUR);
+  ok1(Parse("hwcfg-data-SN-N367-more-data") == KoboModel::CLARA_COLOUR);
+  ok1(Parse("SN-N999") == KoboModel::UNKNOWN);
+  ok1(Parse("SN-N36") == KoboModel::UNKNOWN);
+
+  ok1(IsKoboMediaTek(KoboModel::CLARA_BW));
+  ok1(IsKoboMediaTek(KoboModel::CLARA_COLOUR));
+  ok1(!IsKoboMediaTek(KoboModel::CLARA_2E));
+
+  ok1(std::string_view{GetKoboWifiInterface(KoboModel::CLARA_BW)} == "wlan0");
+  ok1(std::string_view{GetKoboWifiInterface(KoboModel::CLARA_COLOUR)} == "wlan0");
+  ok1(std::string_view{GetKoboWifiInterface(KoboModel::CLARA_2E)} == "mlan0");
+  ok1(std::string_view{GetKoboWifiInterface(KoboModel::GLO_HD)} == "eth0");
+
+  ok1(std::string_view{GetKoboOnboardPartition(KoboModel::CLARA_BW)} ==
+      "/dev/mmcblk0p12");
+  ok1(std::string_view{GetKoboOnboardPartition(KoboModel::CLARA_HD)} ==
+      "/dev/mmcblk0p3");
+
+  return exit_status();
+}


### PR DESCRIPTION
Adds Kobo Clara BW/Colour support when launched from Nickel, using the GCC 14 NickelTC toolchain.

See: https://github.com/XCSoar/XCSoar/discussions/2827

Includes:

- `KOBO_NICKEL` build target with static libstdc++/libgcc
- FBInk framebuffer integration
- Clara BW/Colour model detection and display defaults
- Color framebuffer support with grayscale fallback
- Nickel-specific input, display, and text compatibility fixes
- Focused model and canvas export tests

Validated by building with GCC 14 and `WERROR=y`, deploying on-device, and testing both color rendering and controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Kobo Nickel devices, including Clara BW and Clara Colour models.
  * Improved display rendering through FBInk framebuffer support, with model-specific display settings, DPI, dithering, and text handling.
  * Added Kobo model detection, battery status, Wi‑Fi, storage, USB, backlight, and colour-control support.
  * Added a prioritized font search path for Kobo installations.

* **Documentation**
  * Added build instructions and graphics-backend details for Kobo Nickel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->