### PR TITLE
Startup: Add a "Startup mode" setting to skip the Fly / Sim prompt

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -240,6 +240,11 @@ Version 7.45 - 2026-08-15
   - match the large-radar task direction arrow to the map
     best-cruise shape #2027
 * simulator
+  - add a “Startup mode” setting (Look → Language, Input) to always
+    start in fly or simulator mode instead of answering the Fly /
+    Simulator prompt on every start; the choice is stored per device
+    (state.ini), not in the profile, so it applies to all
+    profiles #2859
   - make simulator mode easier to find: startup tip to steer by
     dragging from the glider or via Altitude / Speed Ground
     InfoBoxes; Welcome Quick Guide paragraph; “Sim: Jump to” on map

--- a/build/main.mk
+++ b/build/main.mk
@@ -580,6 +580,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/ApplyExternalSettings.cpp \
 	$(SRC)/ApplyVegaSwitches.cpp \
 	$(SRC)/MainWindow.cpp \
+	$(SRC)/LocalAppState.cpp \
 	$(SRC)/Startup.cpp \
 	$(SRC)/Components.cpp \
 	$(SRC)/BackendComponents.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -149,7 +149,8 @@ endif
 ifeq ($(HAVE_WIN32),n)
 TEST_NAMES += \
 	TestDataLayoutMigration \
-	TestLocalPathResolve
+	TestLocalPathResolve \
+	TestLocalAppState
 endif
 
 ifeq ($(HAVE_WIN32),y)
@@ -886,6 +887,19 @@ TEST_DATA_LAYOUT_MIGRATION_SOURCES = \
 	$(TEST_SRC_DIR)/TestDataLayoutMigration.cpp
 TEST_DATA_LAYOUT_MIGRATION_DEPENDS = PROFILE IO OS UTIL
 $(eval $(call link-program,TestDataLayoutMigration,TEST_DATA_LAYOUT_MIGRATION))
+
+TEST_LOCAL_APP_STATE_SOURCES = \
+	$(SRC)/LocalPath.cpp \
+	$(SRC)/LocalAppState.cpp \
+	$(SRC)/system/FileUtil.cpp \
+	$(SRC)/system/Path.cpp \
+	$(SRC)/io/FileOutputStream.cxx \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestLocalAppState.cpp
+TEST_LOCAL_APP_STATE_DEPENDS = PROFILE IO OS UTIL
+$(eval $(call link-program,TestLocalAppState,TEST_LOCAL_APP_STATE))
 
 TEST_LOCAL_PATH_RESOLVE_SOURCES = \
 	$(SRC)/DataFileLayout.cpp \

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -1,8 +1,10 @@
 \chapter{Configuration}\label{cha:configuration}\label{conf:configuration}
 XCSoar is a highly configurable glide computer and can be customised
-to suit a wide variety of preferences and user requirements. The entire 
-configuration is saved in a so-called profile file, reflecting all 
-configuration settings. Whenever a configuration is judged being worthy, a 
+to suit a wide variety of preferences and user requirements. Most of the
+configuration is saved in a so-called profile file.  A few
+device-specific settings, such as the {\bf Startup mode}, are stored on
+the device itself (in the \texttt{state.ini} file) and apply to all
+profiles. Whenever a configuration is judged being worthy, a
 backup of the profile file is advisable (see Section~\ref{sec:profiles}. This
 chapter describes the configuration settings and options.
 
@@ -718,6 +720,17 @@ XCSoar.
   {\bf Default}: Uses the default input style for your platform.
 \item[Haptic feedback*]  (Android devices only) Let you switch on or off the `{\it brrt}' 
   when the device accepts your finger press as valid input on the touch-screen.
+\item[Startup mode]  Determines what XCSoar does with the fly/simulator
+  question on startup. \\
+  {\bf Ask}: The Fly / Simulator prompt appears on every start. \\
+  {\bf Fly}: XCSoar starts in fly mode straight away, which is what you
+  normally want in the cockpit. \\
+  {\bf Simulator}: XCSoar starts in simulator mode straight away. \\
+  The command line options \verb|-fly| and \verb|-simulator| override this
+  setting.  Unlike the other options on this page, this setting is stored
+  on the device, in the \texttt{state.ini} file in the data directory
+  (\texttt{XCSoarData}, or \texttt{.xcsoar} on Unix/Linux), not in the
+  profile; it therefore applies no matter which profile is loaded.
 \end{description}
 
 Press the \button{Fonts} button to adjust the fonts XCSoar uses.

--- a/doc/manual/en/installation.tex
+++ b/doc/manual/en/installation.tex
@@ -322,6 +322,15 @@ Two modes are available inside the XCSoar application:
   are attempted.
 \end{description}
 
+By default XCSoar asks which of the two modes to use every time it
+starts.  If you always want the same mode --- for example FLY, so the
+computer in the cockpit is ready without answering a question --- set
+{\bf Startup mode} to {\bf Fly} or {\bf Simulator} on the
+configuration page \emph{Look / Language, Input}, see
+Section~\ref{sec:interface}.  The command line options \verb|-fly| and
+\verb|-simulator| still override this setting.  The choice is stored on
+the device itself, not in the profile, so it applies to all profiles.
+
 \subsection*{XCSoar PC version}
 The program can be run by opening the explorer window, finding the directory
 that has the XCSoar.exe executable, and double clicking on that program file.

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -19,6 +19,8 @@
 #include "UIGlobals.hpp"
 #include "Hardware/Vibrator.hpp"
 #include "Repository/FileType.hpp"
+#include "Simulator.hpp"
+#include "LocalAppState.hpp"
 #include "Version.hpp"
 
 using namespace std::chrono;
@@ -32,6 +34,9 @@ enum ControlIndex {
   TextInput,
 #ifdef HAVE_VIBRATOR
   HapticFeedback,
+#endif
+#ifdef SIMULATOR_AVAILABLE
+  StartupMode,
 #endif
   ShowQuickGuideOnStartup,
   ShowReleaseNotesOnStartup,
@@ -161,6 +166,25 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
   SetExpertRow(HapticFeedback);
 #endif /* HAVE_VIBRATOR */
 
+#ifdef SIMULATOR_AVAILABLE
+  static constexpr StaticEnumChoice startup_mode_list[] = {
+    { LocalAppState::StartupMode::ASK, N_("Ask"),
+      N_("Show the Fly / Simulator prompt on every start.") },
+    { LocalAppState::StartupMode::FLY, N_("Fly"),
+      N_("Start in fly mode without asking.") },
+    { LocalAppState::StartupMode::SIMULATOR, N_("Simulator"),
+      N_("Start in simulator mode without asking.") },
+    nullptr
+  };
+
+  AddEnum(_("Startup mode"),
+          _("Determines whether XCSoar asks for fly or simulator mode on "
+            "startup, or always starts in one of them.  This setting is "
+            "stored on the device, not in the profile, so it applies to "
+            "all profiles."),
+          startup_mode_list, (unsigned)LocalAppState::GetStartupMode());
+#endif
+
   bool hide_quick_guide = false;
   Profile::Get(ProfileKeys::HideQuickGuideDialogOnStartup,
                hide_quick_guide);
@@ -268,6 +292,16 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
 
 #ifdef HAVE_VIBRATOR
   changed |= SaveValueEnum(HapticFeedback, ProfileKeys::HapticFeedback, settings.haptic_feedback);
+#endif
+
+#ifdef SIMULATOR_AVAILABLE
+  /* the startup mode is device state ("state.ini"), not a
+     profile setting, so that it applies to all profiles alike */
+  if (auto startup_mode = LocalAppState::GetStartupMode();
+      SaveValueEnum(StartupMode, startup_mode)) {
+    LocalAppState::SetStartupMode(startup_mode);
+    changed = true;
+  }
 #endif
 
   bool hide_quick_guide = false;

--- a/src/LocalAppState.cpp
+++ b/src/LocalAppState.cpp
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "LocalAppState.hpp"
+#include "LocalPath.hpp"
+#include "LogFile.hpp"
+#include "Profile/Map.hpp"
+#include "io/BufferedOutputStream.hxx"
+#include "io/FileLineReader.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/KeyValueFileReader.hpp"
+#include "io/KeyValueFileWriter.hpp"
+#include "system/FileUtil.hpp"
+#include "system/Path.hpp"
+
+#include <string_view>
+
+#define STATE_FILE "state.ini"
+
+namespace LocalAppState {
+
+namespace Keys {
+constexpr std::string_view StartupMode = "StartupMode";
+} // namespace Keys
+
+/** the in-memory copy of the state file */
+static ProfileMap state;
+
+[[gnu::pure]]
+static AllocatedPath
+GetPath() noexcept
+{
+  return LocalPath(STATE_FILE);
+}
+
+void
+Load() noexcept
+{
+  state.Clear();
+
+  const auto path = GetPath();
+  if (!File::Exists(path)) {
+    /* no state file yet; the first Save() call will create it */
+    state.SetModified(false);
+    return;
+  }
+
+  try {
+    FileLineReaderA reader(path);
+    KeyValueFileReader kv_reader(reader);
+    KeyValuePair pair;
+    while (kv_reader.Read(pair))
+      state.Set(pair.key, pair.value);
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to load " STATE_FILE);
+  }
+
+  state.SetModified(false);
+}
+
+void
+Save() noexcept
+{
+  if (!state.IsModified())
+    return;
+
+  const auto path = GetPath();
+
+  try {
+    if (const auto parent = path.GetParent(); parent != nullptr)
+      Directory::CreateRecursive(parent);
+
+    FileOutputStream file(path);
+    BufferedOutputStream buffered(file);
+    KeyValueFileWriter kv_writer(buffered);
+
+    for (const auto &i : state)
+      kv_writer.Write(i.first.c_str(), i.second.c_str());
+
+    buffered.Flush();
+    file.Commit();
+
+    state.SetModified(false);
+  } catch (...) {
+    LogError(std::current_exception(), "Failed to save " STATE_FILE);
+  }
+}
+
+StartupMode
+GetStartupMode() noexcept
+{
+  StartupMode mode = StartupMode::ASK;
+  state.GetEnum(Keys::StartupMode, mode);
+
+  switch (mode) {
+  case StartupMode::ASK:
+  case StartupMode::FLY:
+  case StartupMode::SIMULATOR:
+    return mode;
+  }
+
+  /* invalid value in the state file */
+  return StartupMode::ASK;
+}
+
+void
+SetStartupMode(StartupMode mode) noexcept
+{
+  state.SetEnum(Keys::StartupMode, mode);
+  Save();
+}
+
+} // namespace LocalAppState

--- a/src/LocalAppState.hpp
+++ b/src/LocalAppState.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * Manages the "state.ini" file in the XCSoarData directory.
+ *
+ * This file stores device-local state that is shared by all profiles:
+ * things that describe this XCSoar installation rather than a pilot's
+ * settings, e.g. whether to start in fly or simulator mode.  Unlike a
+ * profile, it is not meant to be copied to other devices, and changing
+ * it never touches any (possibly shareable) profile file.
+ */
+namespace LocalAppState {
+
+/**
+ * Which mode XCSoar starts in; ASK shows the fly/simulator prompt.
+ * Ignored when "-fly" or "-simulator" was passed on the command line.
+ */
+enum class StartupMode : uint_least8_t {
+  ASK,
+  FLY,
+  SIMULATOR,
+};
+
+/**
+ * Load the state file into memory.  A missing file is not an error;
+ * it leaves all values at their defaults.
+ */
+void
+Load() noexcept;
+
+/**
+ * Write the in-memory state back to the state file if it was
+ * modified.  Errors will be caught and logged.
+ */
+void
+Save() noexcept;
+
+[[gnu::pure]]
+StartupMode
+GetStartupMode() noexcept;
+
+/**
+ * Update the startup mode and persist it (calls Save()).
+ */
+void
+SetStartupMode(StartupMode mode) noexcept;
+
+} // namespace LocalAppState

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -81,6 +81,7 @@
 #include "Waypoint/WaypointGlue.hpp"
 #include "Storage/StorageManager.hpp"
 #include "DataLayoutMigration.hpp"
+#include "LocalAppState.hpp"
 
 #include "Airspace/AirspaceWarningManager.hpp"
 #include "Airspace/Airspaces.hpp"
@@ -378,21 +379,39 @@ Startup(UI::Display &display)
   CommonInterface::SetUISettings().SetDefaults();
   main_window->Initialise();
 
-#ifdef SIMULATOR_AVAILABLE
-  // prompt for simulator if not set by command line argument "-simulator" or "-fly"
-  if (!sim_set_in_cmd_line_flag) {
-    SimulatorPromptResult result = dlgSimulatorPromptShowModal();
-    switch (result) {
-    case SPR_QUIT:
-      startup_cancelled_by_user = true;
-      return false;
+  /* load the device state file ("state.ini") before any profile;
+     it is shared by all profiles */
+  LocalAppState::Load();
 
-    case SPR_FLY:
+#ifdef SIMULATOR_AVAILABLE
+  /* choose fly or simulator mode; the command line arguments
+     "-simulator" and "-fly" win over the state file setting, and the
+     prompt is shown only if neither has decided */
+  if (!sim_set_in_cmd_line_flag) {
+    switch (LocalAppState::GetStartupMode()) {
+    case LocalAppState::StartupMode::FLY:
       global_simulator_flag = false;
       break;
 
-    case SPR_SIMULATOR:
+    case LocalAppState::StartupMode::SIMULATOR:
       global_simulator_flag = true;
+      break;
+
+    case LocalAppState::StartupMode::ASK:
+      switch (dlgSimulatorPromptShowModal()) {
+      case SPR_QUIT:
+        startup_cancelled_by_user = true;
+        return false;
+
+      case SPR_FLY:
+        global_simulator_flag = false;
+        break;
+
+      case SPR_SIMULATOR:
+        global_simulator_flag = true;
+        break;
+      }
+
       break;
     }
   }

--- a/test/src/TestLocalAppState.cpp
+++ b/test/src/TestLocalAppState.cpp
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "LocalAppState.hpp"
+#include "FakeLogFile.hpp"
+#include "LocalPath.hpp"
+#include "io/FileLineReader.hpp"
+#include "io/FileOutputStream.hxx"
+#include "io/OutputStream.hxx"
+#include "system/FileUtil.hpp"
+#include "system/Path.hpp"
+#include "TestUtil.hpp"
+#include "util/SpanCast.hxx"
+#include "util/StringAPI.hxx"
+
+#include <string_view>
+
+#include <stdlib.h>
+
+static bool
+WriteTextFile(Path path, const char *content) noexcept
+try {
+  FileOutputStream out(path, FileOutputStream::Mode::CREATE);
+  out.Write(AsBytes(std::string_view(content)));
+  out.Commit();
+  return true;
+} catch (...) {
+  return false;
+}
+
+static bool
+FileContainsLine(Path path, const char *expected)
+{
+  FileLineReaderA reader(path);
+  char *line;
+  while ((line = reader.ReadLine()) != nullptr)
+    if (StringIsEqual(line, expected))
+      return true;
+
+  return false;
+}
+
+/** create a fresh data directory and return the state file path */
+static AllocatedPath
+SetUpDataPath(char *template_path)
+{
+  ok1(mkdtemp(template_path) != nullptr);
+  SetSingleDataPath(Path(template_path));
+  return LocalPath("state.ini");
+}
+
+static void
+TestDefaultsWithoutFile()
+{
+  char template_path[] = "/tmp/xcsoar-state-XXXXXX";
+  const auto state_path = SetUpDataPath(template_path);
+
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::ASK);
+
+  /* nothing was modified, so Save() must not create the file */
+  LocalAppState::Save();
+  ok1(!File::Exists(state_path));
+}
+
+static void
+TestRoundTrip()
+{
+  char template_path[] = "/tmp/xcsoar-state-XXXXXX";
+  const auto state_path = SetUpDataPath(template_path);
+
+  LocalAppState::Load();
+  LocalAppState::SetStartupMode(LocalAppState::StartupMode::FLY);
+  ok1(File::Exists(state_path));
+  ok1(FileContainsLine(state_path, "StartupMode=\"1\""));
+
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::FLY);
+
+  LocalAppState::SetStartupMode(LocalAppState::StartupMode::SIMULATOR);
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::SIMULATOR);
+
+  /* SetStartupMode() has already saved; deleting the file and calling
+     Save() again must not resurrect it */
+  ok1(File::Delete(state_path));
+  LocalAppState::Save();
+  ok1(!File::Exists(state_path));
+}
+
+static void
+TestPreservesUnknownKeys()
+{
+  char template_path[] = "/tmp/xcsoar-state-XXXXXX";
+  const auto state_path = SetUpDataPath(template_path);
+
+  ok1(WriteTextFile(state_path,
+                    "FutureKey=\"hello\"\n"
+                    "StartupMode=\"2\"\n"));
+
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::SIMULATOR);
+
+  /* rewriting the file must keep keys this XCSoar version does not
+     know about */
+  LocalAppState::SetStartupMode(LocalAppState::StartupMode::FLY);
+  ok1(FileContainsLine(state_path, "FutureKey=\"hello\""));
+  ok1(FileContainsLine(state_path, "StartupMode=\"1\""));
+}
+
+static void
+TestInvalidValues()
+{
+  char template_path[] = "/tmp/xcsoar-state-XXXXXX";
+  const auto state_path = SetUpDataPath(template_path);
+
+  ok1(WriteTextFile(state_path, "StartupMode=\"99\"\n"));
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::ASK);
+
+  ok1(WriteTextFile(state_path, "StartupMode=\"garbage\"\n"));
+  LocalAppState::Load();
+  ok1(LocalAppState::GetStartupMode() == LocalAppState::StartupMode::ASK);
+}
+
+int
+main()
+{
+  SetFakeLogFileQuiet(true);
+
+  plan_tests(20);
+  TestDefaultsWithoutFile();
+  TestRoundTrip();
+  TestPreservesUnknownKeys();
+  TestInvalidValues();
+  return exit_status();
+}


### PR DESCRIPTION
Closes #2662.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Startup mode** setting under **Look → Language, Input**.
  * Choose **Ask**, **Fly**, or **Simulator** as the default startup mode.
  * The preference is stored on the device and applies across profiles.
  * Command-line startup options continue to override this setting.

* **Documentation**
  * Updated the user manual with configuration details and startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->