### PR TITLE
Task: Scan task QR codes with the camera (portable zxing-cpp decoder)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ include $(topdir)/build/libjpeg.mk
 include $(topdir)/build/libsqlite.mk
 include $(topdir)/build/libtiff.mk
 include $(topdir)/build/netcdf.mk
+include $(topdir)/build/zxing.mk
 include $(topdir)/build/coregraphics.mk
 include $(topdir)/build/appkit.mk
 include $(topdir)/build/uikit.mk

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,7 @@
 Version 7.46 - not yet released
+* android
+  - add "Scan QR Code" to the task manager to import an XCTrack task
+    with the camera, instead of opening the code in another app #1270
 * development
   - documentation: document the release and post-release version workflow
 

--- a/THIRD_PARTY_NOTICES.txt
+++ b/THIRD_PARTY_NOTICES.txt
@@ -1,5 +1,217 @@
 # Third-Party Notices
 
+## zxing-cpp
+
+XCSoar uses **zxing-cpp** to decode the QR codes read by the task QR
+scanner.  It is built with the QR reader only; the encoders and the
+other barcode formats are disabled.
+
+**License:** [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
+Copyright (c) zxing-cpp contributors.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
 ## ANGLE (Almost Native Graphics Layer Engine)
 
 XCSoar on macOS uses **ANGLE** (OpenGL ES over Metal) for rendering.

--- a/android/AndroidManifest.xml.template
+++ b/android/AndroidManifest.xml.template
@@ -59,7 +59,17 @@
 
     <service android:name="org.xcsoar.MyService" android:foregroundServiceType="location"/>
 
-    <!-- this Activity receives scanned QR codes -->
+    <!-- this Activity scans task QR codes with the built-in camera.
+         hardwareAccelerated is spelled out because the TextureView
+         showing the camera preview draws nothing without it, and never
+         hands out the SurfaceTexture the scanner waits for. -->
+    <activity android:name="org.xcsoar.QRScannerActivity"
+              android:exported="false"
+              android:hardwareAccelerated="true"
+              android:screenOrientation="portrait"
+              android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"/>
+
+    <!-- this Activity receives QR codes scanned by another app -->
     <activity android:name="org.xcsoar.ReceiveTaskActivity"
               android:exported="true">
       <intent-filter>
@@ -104,6 +114,9 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
 
+  <!-- used only to scan task QR codes, on demand -->
+  <uses-permission android:name="android.permission.CAMERA"/>
+
   <!-- required since Android 13 / targetSdkVersion 33+ for posting notifications -->
   <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
@@ -132,6 +145,8 @@
   <uses-feature android:name="android.hardware.location.network" android:required="false"/>
   <uses-feature android:name="android.hardware.location.gps" android:required="false"/>
   <uses-feature android:name="android.hardware.usb.accessory" android:required="false"/>
+  <uses-feature android:name="android.hardware.camera" android:required="false"/>
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
 
   <!-- enable USB host mode -->
   <uses-feature android:name="android.hardware.usb.host" android:required="false" />

--- a/android/src/NativeView.java
+++ b/android/src/NativeView.java
@@ -343,6 +343,26 @@ class NativeView extends SurfaceView
 
   static native String onReceiveXCTrackTask(String data);
 
+  /**
+   * Hand the raw text of a scanned QR code to native code, which
+   * inspects the URI scheme prefix itself.
+   *
+   * @return null on success, or a human-readable error message
+   */
+  static native String onReceiveTaskQRCode(String text);
+
+  /**
+   * Open the camera to scan a task QR code.  Called from native code
+   * when the pilot picks "Scan QR Code".  The scanner Activity
+   * reports its own result, so there is nothing to return here.
+   */
+  void scanQRCode() {
+    final Context ctx = getContext();
+    if (ctx instanceof XCSoar) {
+      ((XCSoar) ctx).scanQRCode();
+    }
+  }
+
   protected native void runNative(Context context,
                                   PermissionManager permissionManager,
                                   int width, int height,

--- a/android/src/QRScannerActivity.java
+++ b/android/src/QRScannerActivity.java
@@ -1,0 +1,637 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+package org.xcsoar;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Color;
+import android.graphics.ImageFormat;
+import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraDevice;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+import android.util.Size;
+import android.view.Gravity;
+import android.view.Surface;
+import android.view.TextureView;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+/**
+ * Scans a task QR code with the device camera and hands the decoded
+ * text to native code.
+ *
+ * This is the in-app counterpart to {@link ReceiveTaskActivity}: that
+ * one receives an "xctsk:" link decoded by some other app, this one
+ * decodes the code itself so the pilot never leaves XCSoar.  Both end
+ * up in the same native task-receive path.
+ *
+ * The caller (XCSoar.scanQRCode()) has already acquired the camera
+ * permission.
+ */
+public class QRScannerActivity extends Activity {
+  private static final String TAG = "XCSoar";
+
+  /**
+   * Preferred analysis resolution.  Big enough to resolve a dense
+   * XCTrack task code, small enough to decode at frame rate.
+   */
+  private static final int TARGET_WIDTH = 1280;
+  private static final int TARGET_HEIGHT = 720;
+
+  private TextureView textureView;
+  private TextView statusView;
+
+  private HandlerThread cameraThread;
+  private Handler cameraHandler;
+
+  private CameraManager cameraManager;
+  private String cameraId;
+  private Size previewSize;
+
+  /* written by the camera thread in onOpened()/onConfigured() and read
+     by the UI thread in onPause(), hence volatile */
+  private volatile CameraDevice camera;
+  private volatile CameraCaptureSession captureSession;
+  private volatile ImageReader imageReader;
+  private volatile Surface previewSurface;
+
+  /**
+   * Set while the activity is paused.  The camera opens
+   * asynchronously, so it can arrive after onPause() has already
+   * looked for something to close; this tells the callback to hand it
+   * straight back instead of leaving the camera held.
+   */
+  private volatile boolean paused = true;
+
+  /**
+   * Set once a code has been decoded, so that the frames still in
+   * flight cannot deliver a second result.
+   */
+  private final AtomicBoolean delivered = new AtomicBoolean();
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+
+    setContentView(buildContentView());
+
+    cameraManager = (CameraManager)getSystemService(CAMERA_SERVICE);
+
+    /* One thread for the whole Activity, rather than one per resume:
+       the camera framework keeps posting callbacks while close() runs,
+       and a thread torn down in onPause() would still be receiving
+       them ("sending message to a Handler on a dead thread"). */
+    cameraThread = new HandlerThread("QRScanner");
+    cameraThread.start();
+    cameraHandler = new Handler(cameraThread.getLooper());
+  }
+
+  @Override protected void onDestroy() {
+    final HandlerThread thread = cameraThread;
+    final Handler handler = cameraHandler;
+    cameraThread = null;
+    cameraHandler = null;
+
+    if (handler != null)
+      /* Quit from the camera thread itself, so the teardown onPause()
+         posted there has finished first.  Calling quitSafely() straight
+         from here races it, and the camera framework then finds the
+         looper gone while it is still delivering close callbacks. */
+      handler.post(thread::quitSafely);
+
+    super.onDestroy();
+  }
+
+  private View buildContentView() {
+    final FrameLayout root = new FrameLayout(this);
+    root.setBackgroundColor(Color.BLACK);
+
+    textureView = new TextureView(this);
+    root.addView(textureView,
+                 new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                              ViewGroup.LayoutParams.MATCH_PARENT));
+
+    /* hint above the button, so a gloved thumb aiming for Cancel
+       cannot cover the only feedback the pilot gets */
+    final LinearLayout bottom = new LinearLayout(this);
+    bottom.setOrientation(LinearLayout.VERTICAL);
+
+    statusView = new TextView(this);
+    statusView.setText("Point the camera at a task QR code");
+    statusView.setTextColor(Color.WHITE);
+    statusView.setBackgroundColor(Color.argb(160, 0, 0, 0));
+    statusView.setPadding(24, 16, 24, 16);
+    statusView.setGravity(Gravity.CENTER);
+    bottom.addView(statusView,
+                   new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                                 ViewGroup.LayoutParams.WRAP_CONTENT));
+
+    final Button cancelButton = new Button(this);
+    cancelButton.setText("Cancel");
+    cancelButton.setAllCaps(false);
+    cancelButton.setOnClickListener(v -> cancel());
+
+    /* tall enough to hit without looking, like the dialog buttons in
+       the rest of the app */
+    final LinearLayout.LayoutParams buttonParams =
+      new LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                    (int)(56 * getResources()
+                                          .getDisplayMetrics().density));
+    bottom.addView(cancelButton, buttonParams);
+
+    final FrameLayout.LayoutParams bottomParams =
+      new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                                   ViewGroup.LayoutParams.WRAP_CONTENT);
+    bottomParams.gravity = Gravity.BOTTOM;
+    root.addView(bottom, bottomParams);
+
+    return root;
+  }
+
+  /**
+   * Give up on scanning and go back to XCSoar.
+   *
+   * Simply finishing is not enough: the main Activity is
+   * "singleInstance", so it sits in a task of its own and Android
+   * would drop the pilot on the home screen instead of back into the
+   * map.  ReceiveTaskActivity does the same thing on its way out.
+   */
+  private void cancel() {
+    startActivity(new Intent(this, XCSoar.class));
+    finish();
+  }
+
+  @Override public void onBackPressed() {
+    cancel();
+  }
+
+  @Override protected void onResume() {
+    super.onResume();
+
+    paused = false;
+
+    if (textureView.isAvailable())
+      openCamera();
+    else
+      textureView.setSurfaceTextureListener(surfaceTextureListener);
+  }
+
+  @Override protected void onPause() {
+    paused = true;
+
+    /* Hand the resources over as locals and clear the fields right
+       away, so a teardown still in progress cannot close a camera, or
+       release a surface, that a quick resume has meanwhile made. */
+    final CameraCaptureSession session = captureSession;
+    final CameraDevice device = camera;
+    final ImageReader reader = imageReader;
+    final Surface surface = previewSurface;
+    captureSession = null;
+    camera = null;
+    imageReader = null;
+    previewSurface = null;
+
+    if (cameraHandler != null)
+      /* Close on the camera thread, which is where onImageAvailable()
+         runs: that lets a decode in flight finish instead of having the
+         ImageReader closed from under it.  The thread outlives this,
+         and is stopped in onDestroy(). */
+      cameraHandler.post(() -> closeCamera(session, device, reader, surface));
+    else
+      closeCamera(session, device, reader, surface);
+
+    super.onPause();
+  }
+
+  private final TextureView.SurfaceTextureListener surfaceTextureListener =
+    new TextureView.SurfaceTextureListener() {
+      @Override
+      public void onSurfaceTextureAvailable(SurfaceTexture surface,
+                                            int width, int height) {
+        openCamera();
+      }
+
+      @Override
+      public void onSurfaceTextureSizeChanged(SurfaceTexture surface,
+                                              int width, int height) {
+        configureTransform();
+      }
+
+      @Override
+      public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+        return true;
+      }
+
+      @Override
+      public void onSurfaceTextureUpdated(SurfaceTexture surface) {
+      }
+    };
+
+  /**
+   * Pick the rear camera, or any camera if the device has no rear one.
+   */
+  private String selectCamera() throws CameraAccessException {
+    String fallback = null;
+
+    for (String id : cameraManager.getCameraIdList()) {
+      final Integer facing = cameraManager.getCameraCharacteristics(id)
+        .get(CameraCharacteristics.LENS_FACING);
+
+      if (facing != null && facing == CameraCharacteristics.LENS_FACING_BACK)
+        return id;
+
+      if (fallback == null)
+        fallback = id;
+    }
+
+    return fallback;
+  }
+
+  /**
+   * Choose the largest supported YUV size that does not exceed
+   * {@link #TARGET_WIDTH} x {@link #TARGET_HEIGHT}, falling back to
+   * the smallest size the camera offers if none of them fit.
+   */
+  private static long area(Size size) {
+    return (long)size.getWidth() * size.getHeight();
+  }
+
+  private static Size selectPreviewSize(Size[] choices) {
+    /* the largest size that still fits the analysis budget: more
+       pixels resolve a denser code */
+    Size best = null;
+    for (Size size : choices)
+      if (size.getWidth() <= TARGET_WIDTH && size.getHeight() <= TARGET_HEIGHT &&
+          (best == null || area(size) > area(best)))
+        best = size;
+
+    if (best != null)
+      return best;
+
+    /* nothing fits, so take the smallest on offer rather than
+       binarising full resolution frames for every preview frame */
+    for (Size size : choices)
+      if (best == null || area(size) < area(best))
+        best = size;
+
+    return best;
+  }
+
+  private void openCamera() {
+    try {
+      cameraId = selectCamera();
+      if (cameraId == null) {
+        fail("No camera found");
+        return;
+      }
+
+      final StreamConfigurationMap map = cameraManager
+        .getCameraCharacteristics(cameraId)
+        .get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+      if (map == null) {
+        fail("Camera not usable");
+        return;
+      }
+
+      final Size[] sizes = map.getOutputSizes(ImageFormat.YUV_420_888);
+      if (sizes == null || sizes.length == 0) {
+        fail("Camera not usable");
+        return;
+      }
+
+      previewSize = selectPreviewSize(sizes);
+
+      imageReader = ImageReader.newInstance(previewSize.getWidth(),
+                                            previewSize.getHeight(),
+                                            ImageFormat.YUV_420_888, 2);
+      imageReader.setOnImageAvailableListener(imageAvailableListener,
+                                              cameraHandler);
+
+      configureTransform();
+
+      cameraManager.openCamera(cameraId, cameraStateCallback, cameraHandler);
+    } catch (CameraAccessException e) {
+      Log.e(TAG, "Failed to access camera", e);
+      fail("Cannot access the camera");
+    } catch (SecurityException e) {
+      Log.e(TAG, "No camera permission", e);
+      fail("No camera permission");
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to open camera", e);
+      fail("Cannot open the camera");
+    }
+  }
+
+  /**
+   * Release the camera resources.  Takes them as parameters rather
+   * than reading the fields, because it runs on the camera thread
+   * after onPause() has already handed ownership over.
+   */
+  private static void closeCamera(CameraCaptureSession session,
+                                  CameraDevice device,
+                                  ImageReader reader,
+                                  Surface surface) {
+    if (session != null) {
+      try {
+        /* stop first, so the camera is not still filling the reader we
+           are about to close */
+        session.stopRepeating();
+      } catch (Exception e) {
+        /* ignore - we are tearing down anyway */
+      }
+
+      try {
+        session.close();
+      } catch (Exception e) {
+        /* ignore */
+      }
+    }
+
+    if (device != null)
+      device.close();
+
+    if (reader != null) {
+      /* drop the listener first so no further frame can arrive while
+         the reader is going away */
+      try {
+        reader.setOnImageAvailableListener(null, null);
+      } catch (Exception e) {
+        /* ignore */
+      }
+      reader.close();
+    }
+
+    if (surface != null)
+      surface.release();
+  }
+
+  private final CameraDevice.StateCallback cameraStateCallback =
+    new CameraDevice.StateCallback() {
+      @Override public void onOpened(CameraDevice cameraDevice) {
+        if (paused) {
+          /* onPause() has already been and gone; it cannot have seen
+             this device, so give it back here */
+          cameraDevice.close();
+          return;
+        }
+
+        camera = cameraDevice;
+        startPreview();
+      }
+
+      @Override public void onDisconnected(CameraDevice cameraDevice) {
+        cameraDevice.close();
+        camera = null;
+      }
+
+      @Override public void onError(CameraDevice cameraDevice, int error) {
+        Log.e(TAG, "Camera error " + error);
+        cameraDevice.close();
+        camera = null;
+        fail("Camera error");
+      }
+    };
+
+  private void startPreview() {
+    try {
+      final SurfaceTexture texture = textureView.getSurfaceTexture();
+      /* read the reader once: onPause() clears the field from the UI
+         thread while this runs on the camera thread */
+      final ImageReader reader = imageReader;
+      if (texture == null || camera == null || reader == null || paused)
+        return;
+
+      texture.setDefaultBufferSize(previewSize.getWidth(),
+                                    previewSize.getHeight());
+
+      final Surface surface = new Surface(texture);
+      if (paused) {
+        /* onPause() has already taken ownership of everything it could
+           see, so nothing would ever release this one */
+        surface.release();
+        return;
+      }
+
+      /* kept in a field so it can be released in closeCamera(): a
+         Surface holds a native reference that finalization would
+         otherwise be left to clean up.  The ImageReader's surface is
+         owned by the reader and must not be released here. */
+      previewSurface = surface;
+      final Surface analysisSurface = reader.getSurface();
+
+      final CaptureRequest.Builder builder =
+        camera.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+      builder.addTarget(surface);
+      builder.addTarget(analysisSurface);
+      builder.set(CaptureRequest.CONTROL_AF_MODE,
+                  CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE);
+
+      camera.createCaptureSession(Arrays.asList(surface,
+                                                 analysisSurface),
+        new CameraCaptureSession.StateCallback() {
+          @Override
+          public void onConfigured(CameraCaptureSession session) {
+            if (paused || camera == null) {
+              /* paused while the session was being configured */
+              try {
+                session.close();
+              } catch (Exception e) {
+                /* ignore */
+              }
+              return;
+            }
+
+            captureSession = session;
+
+            try {
+              session.setRepeatingRequest(builder.build(), null,
+                                          cameraHandler);
+            } catch (Exception e) {
+              Log.e(TAG, "Failed to start preview", e);
+              fail("Cannot start the camera preview");
+            }
+          }
+
+          @Override
+          public void onConfigureFailed(CameraCaptureSession session) {
+            Log.e(TAG, "Failed to configure capture session");
+            fail("Cannot start the camera preview");
+          }
+        }, cameraHandler);
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to create capture session", e);
+      fail("Cannot start the camera preview");
+    }
+  }
+
+  /**
+   * Scale the preview to fill the view without distorting it, taking
+   * the display rotation into account.
+   */
+  private void configureTransform() {
+    if (previewSize == null || textureView == null)
+      return;
+
+    final int viewWidth = textureView.getWidth();
+    final int viewHeight = textureView.getHeight();
+    if (viewWidth == 0 || viewHeight == 0)
+      return;
+
+    final int rotation = getWindowManager().getDefaultDisplay().getRotation();
+
+    /* the camera delivers landscape buffers; swap them when the
+       display is portrait */
+    final boolean swapped = rotation == Surface.ROTATION_0 ||
+      rotation == Surface.ROTATION_180;
+    final float bufferWidth = swapped
+      ? previewSize.getHeight() : previewSize.getWidth();
+    final float bufferHeight = swapped
+      ? previewSize.getWidth() : previewSize.getHeight();
+
+    final float scale = Math.max(viewWidth / bufferWidth,
+                                  viewHeight / bufferHeight);
+
+    final Matrix matrix = new Matrix();
+    matrix.setScale(bufferWidth * scale / viewWidth,
+                    bufferHeight * scale / viewHeight,
+                    viewWidth / 2f, viewHeight / 2f);
+
+    if (rotation == Surface.ROTATION_90)
+      matrix.postRotate(270, viewWidth / 2f, viewHeight / 2f);
+    else if (rotation == Surface.ROTATION_270)
+      matrix.postRotate(90, viewWidth / 2f, viewHeight / 2f);
+    else if (rotation == Surface.ROTATION_180)
+      matrix.postRotate(180, viewWidth / 2f, viewHeight / 2f);
+
+    textureView.setTransform(matrix);
+  }
+
+  private final ImageReader.OnImageAvailableListener imageAvailableListener =
+    new ImageReader.OnImageAvailableListener() {
+      @Override public void onImageAvailable(ImageReader imageReader) {
+        /* acquireLatestImage() drops the frames that piled up while
+           the previous decode was running */
+        final Image image = imageReader.acquireLatestImage();
+        if (image == null)
+          return;
+
+        try {
+          if (!delivered.get())
+            decode(image);
+        } finally {
+          image.close();
+        }
+      }
+    };
+
+  /**
+   * Try to decode one camera frame, and deliver the result if it
+   * contains a QR code.
+   */
+  private void decode(Image image) {
+    final String text = decodeQRCode(image);
+    if (text == null)
+      return;
+
+    if (!delivered.compareAndSet(false, true))
+      /* another frame won the race */
+      return;
+
+    runOnUiThread(() -> deliver(text));
+  }
+
+  /**
+   * @return the decoded QR text, or null if this frame holds no
+   * readable QR code
+   */
+  private String decodeQRCode(Image image) {
+    final Image.Plane[] planes = image.getPlanes();
+    if (planes == null || planes.length == 0)
+      return null;
+
+    final Image.Plane plane = planes[0];
+    final ByteBuffer buffer = plane.getBuffer();
+
+    if (!buffer.isDirect())
+      /* decodeQRCode() reads the buffer through
+         GetDirectBufferAddress(); Camera2 always hands out direct
+         buffers, so this is a guard rather than a real case */
+      return null;
+
+    return decodeQRCode(buffer, image.getWidth(), image.getHeight(),
+                        plane.getRowStride(), plane.getPixelStride());
+  }
+
+  /**
+   * Decode a QR code from the Y plane of a camera frame, using
+   * zxing-cpp through src/Task/QRDecoder.cpp.
+   *
+   * The buffer must be direct: native code reads the camera's memory
+   * in place rather than copying the plane, and the strides are passed
+   * through so a padded plane needs no repacking.
+   *
+   * @return the decoded text, or null if the frame holds no readable
+   * QR code
+   */
+  private static native String decodeQRCode(ByteBuffer plane,
+                                            int width, int height,
+                                            int rowStride, int pixelStride);
+
+  /**
+   * Hand the decoded text to native code and return to the map.
+   */
+  private void deliver(String text) {
+    if (!Loader.loaded) {
+      fail("Error");
+      return;
+    }
+
+    Log.d(TAG, "Scanned QR code");
+
+    final String msg = NativeView.onReceiveTaskQRCode(text);
+    if (msg != null) {
+      /* not a task, or a broken one - stay open so the pilot can
+         simply aim at another code */
+      delivered.set(false);
+      statusView.setText(msg);
+      return;
+    }
+
+    /* the task was accepted; the main activity shows it in the task
+       manager */
+    startActivity(new Intent(this, XCSoar.class));
+    finish();
+  }
+
+  private void fail(String message) {
+    Log.e(TAG, "QR scanner failed: " + message);
+    runOnUiThread(() -> {
+      Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+      cancel();
+    });
+  }
+}

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -24,6 +24,7 @@ import android.view.WindowMetrics;
 import android.graphics.Insets;
 import android.graphics.Rect;
 import android.widget.TextView;
+import android.widget.Toast;
 import android.os.Build;
 import android.os.Environment;
 import android.os.PowerManager;
@@ -453,6 +454,18 @@ public class XCSoar extends Activity implements PermissionManager {
   @Override
   public synchronized void onRequestPermissionsResult(int requestCode, String[] permissions,
                                                       int[] grantResults) {
+    if (requestCode == REQUEST_CODE_CAMERA) {
+      if (grantResults.length > 0 &&
+          grantResults[0] == PackageManager.PERMISSION_GRANTED)
+        startQRScanner();
+      else
+        /* say so rather than returning to the map with no explanation
+           for why nothing happened */
+        Toast.makeText(this, "No camera permission",
+                       Toast.LENGTH_LONG).show();
+      return;
+    }
+
     if (permissionHelper != null) {
       permissionHelper.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
@@ -539,6 +552,43 @@ public class XCSoar extends Activity implements PermissionManager {
       launch.run();
     } else {
       runOnUiThread(launch);
+    }
+  }
+
+  // ---- Task QR code scanner ----
+
+  /**
+   * Called from native code to open the camera and scan a task QR
+   * code.  Acquires the camera permission first if necessary.
+   *
+   * Like launchSAFTreePicker(), this never blocks: the scanner
+   * Activity delivers the decoded task to native code itself.
+   */
+  private static final int REQUEST_CODE_CAMERA = 0x7101;
+
+  public void scanQRCode() {
+    runOnUiThread(() -> {
+      /* request the camera directly instead of going through
+         PermissionHelper: that shortcuts every request to "granted"
+         in simulator mode without actually asking, which would leave
+         the scanner staring at a camera it may not open */
+      if (Build.VERSION.SDK_INT >= 23 &&
+          checkSelfPermission(Manifest.permission.CAMERA)
+          != PackageManager.PERMISSION_GRANTED) {
+        requestPermissions(new String[]{Manifest.permission.CAMERA},
+                           REQUEST_CODE_CAMERA);
+        return;
+      }
+
+      startQRScanner();
+    });
+  }
+
+  private void startQRScanner() {
+    try {
+      startActivity(new Intent(this, QRScannerActivity.class));
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to start QR scanner", e);
     }
   }
 

--- a/build/android.mk
+++ b/build/android.mk
@@ -90,6 +90,7 @@ NATIVE_CLASSES := \
 	FileProvider \
 	TextEntryDialog \
 	NativeView \
+	QRScannerActivity \
 	EventBridge \
 	NativeSensorListener \
 	NativeInputListener \
@@ -444,6 +445,7 @@ $(call SRC_TO_OBJ,$(SRC)/Android/NativeInputListener.cpp): $(NATIVE_HEADERS)
 $(call SRC_TO_OBJ,$(SRC)/Android/DownloadManager.cpp): $(NATIVE_HEADERS)
 $(call SRC_TO_OBJ,$(SRC)/Android/TextEntryDialog.cpp): $(NATIVE_HEADERS)
 $(call SRC_TO_OBJ,$(SRC)/Android/FileProvider.cpp): $(NATIVE_HEADERS)
+$(call SRC_TO_OBJ,$(SRC)/Android/QRScanner.cpp): $(NATIVE_HEADERS)
 
 ANDROID_LIB_BUILD = $(patsubst %,$(ANDROID_ABI_DIR)/lib%.so,$(ANDROID_LIB_NAMES))
 $(ANDROID_LIB_BUILD): $(ANDROID_ABI_DIR)/lib%.so: $(ABI_BIN_DIR)/lib%.so | $(ANDROID_ABI_DIR)/dirstamp

--- a/build/main.mk
+++ b/build/main.mk
@@ -706,6 +706,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Android/TextEntryDialog.cpp \
 	$(SRC)/Android/FileProvider.cpp \
 	$(SRC)/Android/ReceiveTask.cpp \
+	$(SRC)/Android/QRScanner.cpp \
+	$(SRC)/Task/QRDecoder.cpp \
 	$(SRC)/Android/SAFHelper.cpp \
 	$(SRC)/Storage/android/SAFReader.cpp \
 	$(SRC)/Storage/android/SAFOutputStream.cpp \
@@ -834,6 +836,11 @@ endif
 
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_LDLIBS += $(NETCDF_LDLIBS)
+endif
+
+ifeq ($(ZXING),y)
+$(call SRC_TO_OBJ,$(SRC)/Task/QRDecoder.cpp): CPPFLAGS += $(ZXING_CPPFLAGS)
+XCSOAR_LDLIBS += $(ZXING_LDLIBS)
 endif
 
 XCSOAR_STRIP = y

--- a/build/main.mk
+++ b/build/main.mk
@@ -610,6 +610,8 @@ XCSOAR_SOURCES := \
 	\
 	$(SRC)/Hardware/PowerGlobal.cpp \
 	$(SRC)/Hardware/Battery.cpp \
+	\
+	$(SRC)/Task/ReceiveTask.cpp \
 
 ifneq ($(TARGET),ANDROID)
 ifeq ($(TARGET_IS_LINUX),y)
@@ -705,7 +707,6 @@ XCSOAR_SOURCES += \
 	$(SRC)/Android/UsbSerialHelper.cpp \
 	$(SRC)/Android/TextEntryDialog.cpp \
 	$(SRC)/Android/FileProvider.cpp \
-	$(SRC)/Android/ReceiveTask.cpp \
 	$(SRC)/Android/QRScanner.cpp \
 	$(SRC)/Task/QRDecoder.cpp \
 	$(SRC)/Android/SAFHelper.cpp \

--- a/build/python/build/libs.py
+++ b/build/python/build/libs.py
@@ -174,6 +174,37 @@ libfmt = CmakeProject(
     base="fmt-11.2.0",
 )
 
+zxing_cpp = CmakeProject(
+    "https://github.com/zxing-cpp/zxing-cpp/archive/v3.1.1.tar.gz",
+    "7286b1e6ade66fe82b7c8208b4595deeb55d6486b410834fdc65702f46650542",
+    "lib/libZXing.a",
+    [
+        "-DBUILD_SHARED_LIBS=OFF",
+        # we only decode, and only QR codes
+        "-DZXING_READERS=ON",
+        "-DZXING_WRITERS=OFF",
+        "-DZXING_ENABLE_1D=OFF",
+        "-DZXING_ENABLE_AZTEC=OFF",
+        "-DZXING_ENABLE_DATAMATRIX=OFF",
+        "-DZXING_ENABLE_MAXICODE=OFF",
+        "-DZXING_ENABLE_PDF417=OFF",
+        "-DZXING_ENABLE_QRCODE=ON",
+        "-DZXING_C_API=OFF",
+        "-DZXING_EXAMPLES=OFF",
+        "-DZXING_UNIT_TESTS=OFF",
+        "-DZXING_BLACKBOX_TESTS=OFF",
+        # never fetch anything from the network during the build
+        "-DZXING_DEPENDENCIES=LOCAL",
+        # Android's libc++ falls back to __bsd_locale_fallbacks.h below
+        # API 24, and precompiling that header with NDK r26d fails with
+        # a va_list mismatch.  GTIN.cpp compiles fine without the PCH.
+        "-DZXING_DISABLE_PCH=ON",
+    ],
+    name="zxing-cpp",
+    version="3.1.1",
+    base="zxing-cpp-3.1.1",
+)
+
 libsodium = AutotoolsProject(
     (
         "https://download.libsodium.org/libsodium/releases/libsodium-1.0.20.tar.gz",

--- a/build/thirdparty.py
+++ b/build/thirdparty.py
@@ -110,6 +110,7 @@ elif toolchain.is_android:
         libtiff,
         libgeotiff,
         netcdf,
+        zxing_cpp,
     ]
 elif '-kobo-linux-' in host_triplet:
     thirdparty_libs = [

--- a/build/zxing.mk
+++ b/build/zxing.mk
@@ -1,0 +1,13 @@
+# zxing-cpp decodes the QR codes scanned by the task QR scanner.  Only
+# the Android port has a camera to feed it so far; the decoder itself is
+# portable, so this is deliberately not guarded by anything but
+# availability.
+ZXING ?= $(TARGET_IS_ANDROID)
+
+ifeq ($(ZXING),y)
+
+$(eval $(call pkg-config-library,ZXING,zxing))
+
+ZXING_CPPFLAGS += -DHAVE_ZXING
+
+endif

--- a/po/bg.po
+++ b/po/bg.po
@@ -5174,6 +5174,9 @@ msgstr "Декларирай"
 msgid "Browse"
 msgstr "Преглед"
 
+msgid "Scan QR Code"
+msgstr "Сканиране на QR код"
+
 msgid "Download Declaration"
 msgstr "Изтегли декларация"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -5182,6 +5182,9 @@ msgstr "Declara"
 msgid "Browse"
 msgstr "Explora"
 
+msgid "Scan QR Code"
+msgstr "Escaneja el codi QR"
+
 msgid "Download Declaration"
 msgstr "Descarrega la declaració"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -5133,6 +5133,9 @@ msgstr "Deklaruj"
 msgid "Browse"
 msgstr "Procházej"
 
+msgid "Scan QR Code"
+msgstr "Skenovat QR kód"
+
 msgid "Download Declaration"
 msgstr "Stáhnout deklaraci"
 

--- a/po/da.po
+++ b/po/da.po
@@ -5141,6 +5141,9 @@ msgstr "Deklarér"
 msgid "Browse"
 msgstr "Bliv venlig at søge"
 
+msgid "Scan QR Code"
+msgstr "Scan QR-kode"
+
 msgid "Download Declaration"
 msgstr "Download deklaration"
 

--- a/po/de.po
+++ b/po/de.po
@@ -5178,6 +5178,9 @@ msgstr "Anmelden"
 msgid "Browse"
 msgstr "Durchsuchen"
 
+msgid "Scan QR Code"
+msgstr "QR-Code scannen"
+
 msgid "Download Declaration"
 msgstr "Deklaration herunterladen"
 

--- a/po/el.po
+++ b/po/el.po
@@ -5206,6 +5206,9 @@ msgstr "Δήλωση"
 msgid "Browse"
 msgstr "Αναζήτηση"
 
+msgid "Scan QR Code"
+msgstr "Σάρωση κωδικού QR"
+
 msgid "Download Declaration"
 msgstr "Λήψη δήλωσης"
 

--- a/po/es.po
+++ b/po/es.po
@@ -5208,6 +5208,9 @@ msgstr "Declarar"
 msgid "Browse"
 msgstr "Buscar"
 
+msgid "Scan QR Code"
+msgstr "Escanear código QR"
+
 msgid "Download Declaration"
 msgstr "Descargar declaración"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -5127,6 +5127,9 @@ msgstr "Ilmoita"
 msgid "Browse"
 msgstr "Selaa"
 
+msgid "Scan QR Code"
+msgstr "Skannaa QR-koodi"
+
 msgid "Download Declaration"
 msgstr "Lataa ilmoitus"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -5195,6 +5195,9 @@ msgstr "Déclarer"
 msgid "Browse"
 msgstr "Circuits enregistrés"
 
+msgid "Scan QR Code"
+msgstr "Scanner le code QR"
+
 msgid "Download Declaration"
 msgstr "Télécharger la déclaration"
 

--- a/po/he.po
+++ b/po/he.po
@@ -5170,6 +5170,9 @@ msgstr "הצהר"
 msgid "Browse"
 msgstr "עיין"
 
+msgid "Scan QR Code"
+msgstr "סרוק קוד QR"
+
 msgid "Download Declaration"
 msgstr "הורד הצהרה"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -5132,6 +5132,9 @@ msgstr "Prijavi"
 msgid "Browse"
 msgstr "Pretraživanje"
 
+msgid "Scan QR Code"
+msgstr "Skeniraj QR kod"
+
 msgid "Download Declaration"
 msgstr "Šaljem deklaraciju zadatka"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -5140,6 +5140,9 @@ msgstr "Deklarál"
 msgid "Browse"
 msgstr "Tallóz"
 
+msgid "Scan QR Code"
+msgstr "QR-kód beolvasása"
+
 msgid "Download Declaration"
 msgstr "Deklaráció letöltése"
 

--- a/po/it.po
+++ b/po/it.po
@@ -5193,6 +5193,9 @@ msgstr "Dichiara"
 msgid "Browse"
 msgstr "Sfoglia"
 
+msgid "Scan QR Code"
+msgstr "Scansiona codice QR"
+
 msgid "Download Declaration"
 msgstr "Scarica dichiarazione"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -5173,6 +5173,9 @@ msgstr "宣言"
 msgid "Browse"
 msgstr "表示"
 
+msgid "Scan QR Code"
+msgstr "QRコードをスキャン"
+
 msgid "Download Declaration"
 msgstr "宣言をダウンロード"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -5063,6 +5063,9 @@ msgstr "타스크 선언"
 msgid "Browse"
 msgstr "타스크 찾아보기"
 
+msgid "Scan QR Code"
+msgstr "QR 코드 스캔"
+
 msgid "Download Declaration"
 msgstr "선언서 다운로드"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -5154,6 +5154,9 @@ msgstr "Apibrėžti"
 msgid "Browse"
 msgstr "Paieška"
 
+msgid "Scan QR Code"
+msgstr "Skenuoti QR kodą"
+
 msgid "Download Declaration"
 msgstr "Atsisiųsti deklaraciją"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -5120,6 +5120,9 @@ msgstr "Deklarer"
 msgid "Browse"
 msgstr "Bla gjennom"
 
+msgid "Scan QR Code"
+msgstr "Skann QR-kode"
+
 msgid "Download Declaration"
 msgstr "Last ned deklarasjon"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -5179,6 +5179,9 @@ msgstr "Declareer"
 msgid "Browse"
 msgstr "Bladeren"
 
+msgid "Scan QR Code"
+msgstr "QR-code scannen"
+
 msgid "Download Declaration"
 msgstr "Download declaratie"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -5158,6 +5158,9 @@ msgstr "Zadeklaruj"
 msgid "Browse"
 msgstr "Wybierz..."
 
+msgid "Scan QR Code"
+msgstr "Skanuj kod QR"
+
 msgid "Download Declaration"
 msgstr "Pobierz deklarację"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -5155,6 +5155,9 @@ msgstr "Declarar"
 msgid "Browse"
 msgstr "Procurar"
 
+msgid "Scan QR Code"
+msgstr "Ler código QR"
+
 msgid "Download Declaration"
 msgstr "Descarregar declaração"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -5154,6 +5154,9 @@ msgstr "Declarar"
 msgid "Browse"
 msgstr "Procurar"
 
+msgid "Scan QR Code"
+msgstr "Escanear código QR"
+
 msgid "Download Declaration"
 msgstr "Baixar declaração"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -5177,6 +5177,9 @@ msgstr "Declara"
 msgid "Browse"
 msgstr "Navigare"
 
+msgid "Scan QR Code"
+msgstr "Scanează codul QR"
+
 msgid "Download Declaration"
 msgstr "Descarcă declarația"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -5165,6 +5165,9 @@ msgstr "Заявить"
 msgid "Browse"
 msgstr "Просмотр"
 
+msgid "Scan QR Code"
+msgstr "Сканировать QR-код"
+
 msgid "Download Declaration"
 msgstr "Скачать декларацию"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -5133,6 +5133,9 @@ msgstr "Deklarovať"
 msgid "Browse"
 msgstr "Prehľadávať"
 
+msgid "Scan QR Code"
+msgstr "Skenovať QR kód"
+
 msgid "Download Declaration"
 msgstr "Stiahnuť deklaráciu"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -5137,6 +5137,9 @@ msgstr "Obvesti"
 msgid "Browse"
 msgstr "Pretražuj"
 
+msgid "Scan QR Code"
+msgstr "Skeniraj kodo QR"
+
 msgid "Download Declaration"
 msgstr "Prenesi deklaracijo"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -5129,6 +5129,9 @@ msgstr "Objaviti"
 msgid "Browse"
 msgstr "Pretraživanje"
 
+msgid "Scan QR Code"
+msgstr "Skeniraj QR kod"
+
 msgid "Download Declaration"
 msgstr "Slanje deklaracije"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -5090,6 +5090,9 @@ msgstr "Deklarera"
 msgid "Browse"
 msgstr "Bläddra"
 
+msgid "Scan QR Code"
+msgstr "Skanna QR-kod"
+
 msgid "Download Declaration"
 msgstr "Ladda ner deklaration"
 

--- a/po/te.po
+++ b/po/te.po
@@ -5014,6 +5014,9 @@ msgstr "పేవెన్న"
 msgid "Browse"
 msgstr "అర్చ్‌బుక్"
 
+msgid "Scan QR Code"
+msgstr "QR కోడ్ స్కాన్ చేయండి"
+
 msgid "Download Declaration"
 msgstr "ప్రకటనను డౌన్‌లోడ్ చేయండి"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -5133,6 +5133,9 @@ msgstr "Tanımla"
 msgid "Browse"
 msgstr "Gez"
 
+msgid "Scan QR Code"
+msgstr "QR kodu tara"
+
 msgid "Download Declaration"
 msgstr "Deklarasyonu indir"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -5164,6 +5164,9 @@ msgstr "Заявити"
 msgid "Browse"
 msgstr "Огляд"
 
+msgid "Scan QR Code"
+msgstr "Сканувати QR-код"
+
 msgid "Download Declaration"
 msgstr "Завантажити декларацію"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -5115,6 +5115,9 @@ msgstr "Khai báo"
 msgid "Browse"
 msgstr "duyệt"
 
+msgid "Scan QR Code"
+msgstr "Quét mã QR"
+
 msgid "Download Declaration"
 msgstr "Tải xuống tờ khai"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4975,6 +4975,9 @@ msgstr "申报"
 msgid "Browse"
 msgstr "浏览"
 
+msgid "Scan QR Code"
+msgstr "扫描二维码"
+
 msgid "Download Declaration"
 msgstr "下载申报"
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -4971,6 +4971,9 @@ msgstr "申報"
 msgid "Browse"
 msgstr "流覽"
 
+msgid "Scan QR Code"
+msgstr "掃描 QR 碼"
+
 msgid "Download Declaration"
 msgstr "下載申報"
 

--- a/src/Android/Main.cpp
+++ b/src/Android/Main.cpp
@@ -206,6 +206,18 @@ try {
 }
 
 gcc_visibility_default
+JNIEXPORT jstring JNICALL
+Java_org_xcsoar_NativeView_onReceiveTaskQRCode(JNIEnv *env,
+                                               [[maybe_unused]] jclass cls,
+                                               jstring text)
+try {
+  ReceiveTaskQRCode(Java::String::GetUTFChars(env, text).c_str());
+  return nullptr;
+} catch (...) {
+  return env->NewStringUTF(GetFullMessage(std::current_exception()).c_str());
+}
+
+gcc_visibility_default
 jboolean
 Java_org_xcsoar_NativeView_isSimulatorNative([[maybe_unused]] JNIEnv *env,
                                              [[maybe_unused]] jclass cls)

--- a/src/Android/Main.cpp
+++ b/src/Android/Main.cpp
@@ -2,7 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Main.hpp"
-#include "ReceiveTask.hpp"
+#include "Task/ReceiveTask.hpp"
 #include "Environment.hpp"
 #include "Components.hpp"
 #include "Context.hpp"

--- a/src/Android/NativeView.cpp
+++ b/src/Android/NativeView.cpp
@@ -28,6 +28,7 @@ jmethodID NativeView::isAutoRotateEnabled_method;
 jmethodID NativeView::getPhysicalOrientation_method;
 jmethodID NativeView::startMyService_method;
 jmethodID NativeView::launchSAFTreePicker_method;
+jmethodID NativeView::scanQRCode_method;
 
 Java::TrivialClass NativeView::clsBitmap;
 jmethodID NativeView::createBitmap_method;
@@ -90,6 +91,8 @@ NativeView::Initialise(JNIEnv *env)
   launchSAFTreePicker_method =
     env->GetMethodID(cls, "launchSAFTreePicker",
                      "(Ljava/lang/String;)V");
+
+  scanQRCode_method = env->GetMethodID(cls, "scanQRCode", "()V");
 
   clsBitmap.Find(env, "android/graphics/Bitmap");
   createBitmap_method = env->GetStaticMethodID(

--- a/src/Android/NativeView.hpp
+++ b/src/Android/NativeView.hpp
@@ -42,6 +42,7 @@ class NativeView {
   static jmethodID getPhysicalOrientation_method;
   static jmethodID startMyService_method;
   static jmethodID launchSAFTreePicker_method;
+  static jmethodID scanQRCode_method;
 
   static Java::TrivialClass clsBitmap;
   static jmethodID createBitmap_method;
@@ -204,4 +205,12 @@ public:
    * Launch the SAF document-tree picker for a given volume UUID.
    */
   void LaunchSAFTreePicker(JNIEnv *env, const char *volume_uuid) const noexcept;
+
+  /**
+   * Open the camera to scan a task QR code.  The scanner Activity
+   * delivers its result on its own, via ReceiveTaskQRCode().
+   */
+  void ScanQRCode(JNIEnv *env) const noexcept {
+    env->CallVoidMethod(obj, scanQRCode_method);
+  }
 };

--- a/src/Android/QRScanner.cpp
+++ b/src/Android/QRScanner.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Task/QRScanner.hpp"
+#include "Task/QRDecoder.hpp"
+#include "Main.hpp"
+#include "NativeView.hpp"
+#include "java/Global.hxx"
+#include "util/Compiler.h"
+#include "org_xcsoar_QRScannerActivity.h"
+
+#include <cstddef>
+#include <cstdint>
+
+bool
+HaveQRScanner() noexcept
+{
+  return native_view != nullptr;
+}
+
+void
+ScanTaskQRCode() noexcept
+{
+  if (native_view != nullptr)
+    native_view->ScanQRCode(Java::GetEnv());
+}
+
+/**
+ * Decode one camera frame.  The plane is a direct ByteBuffer owned by
+ * the Camera2 Image, so this borrows the camera's memory instead of
+ * copying a megabyte per frame, and zxing-cpp is handed the strides
+ * rather than a repacked buffer.
+ */
+gcc_visibility_default
+JNIEXPORT jstring JNICALL
+Java_org_xcsoar_QRScannerActivity_decodeQRCode(JNIEnv *env,
+                                               [[maybe_unused]] jclass cls,
+                                               jobject plane,
+                                               jint width, jint height,
+                                               jint row_stride,
+                                               jint pixel_stride)
+{
+  if (plane == nullptr || width <= 0 || height <= 0 ||
+      row_stride <= 0 || pixel_stride <= 0)
+    return nullptr;
+
+  const auto *data = (const uint8_t *)
+    env->GetDirectBufferAddress(plane);
+  if (data == nullptr)
+    /* not a direct buffer; the caller checks for this, so getting here
+       means the camera handed us something unexpected */
+    return nullptr;
+
+  const jlong capacity = env->GetDirectBufferCapacity(plane);
+  if (capacity <= 0)
+    return nullptr;
+
+  /* DecodeQRCode() takes the capacity and lets zxing-cpp reject a
+     buffer too small for the geometry */
+  const auto text = DecodeQRCode(data, (std::size_t)capacity,
+                                 width, height,
+                                 row_stride, pixel_stride);
+  if (text.empty())
+    return nullptr;
+
+  return env->NewStringUTF(text.c_str());
+}

--- a/src/Android/ReceiveTask.cpp
+++ b/src/Android/ReceiveTask.cpp
@@ -8,8 +8,11 @@
 #include "thread/Mutex.hxx"
 #include "ui/event/Globals.hpp"
 #include "ui/event/Queue.hpp"
+#include "util/StringCompare.hxx"
 
 #include <boost/json.hpp>
+
+#include <stdexcept>
 
 static Mutex received_task_mutex;
 static std::unique_ptr<OrderedTask> received_task;
@@ -47,4 +50,18 @@ ReceiveXCTrackTask(std::string_view data)
      MainWindow::OnTaskReceived() opens the task manager */
   if (UI::event_queue != nullptr)
     UI::event_queue->Inject(UI::Event::TASK_RECEIVED);
+}
+
+void
+ReceiveTaskQRCode(std::string_view text)
+{
+  using std::string_view_literals::operator""sv;
+
+  /* XCTrack writes the scheme in upper case ("XCTSK:"), whereas an
+     Android intent URI arrives lower-cased - accept either */
+  static constexpr auto xctrack_prefix = "XCTSK:"sv;
+  if (!StringStartsWithIgnoreCase(text, xctrack_prefix))
+    throw std::invalid_argument{"Not a task QR code"};
+
+  ReceiveXCTrackTask(text.substr(xctrack_prefix.size()));
 }

--- a/src/Android/ReceiveTask.hpp
+++ b/src/Android/ReceiveTask.hpp
@@ -17,3 +17,16 @@ GetReceivedTask() noexcept;
 
 void
 ReceiveXCTrackTask(std::string_view data);
+
+/**
+ * Handle the raw text of a scanned task QR code, i.e. a payload
+ * prefixed with its URI scheme such as "XCTSK:{...}".
+ *
+ * Unlike ReceiveXCTrackTask(), this inspects the prefix, so it can
+ * grow support for further task QR flavours without the callers
+ * having to know about any of them.
+ *
+ * Throws on an unknown prefix or a malformed payload.
+ */
+void
+ReceiveTaskQRCode(std::string_view text);

--- a/src/Dialogs/Task/Manager/Internal.hpp
+++ b/src/Dialogs/Task/Manager/Internal.hpp
@@ -78,6 +78,12 @@ public:
   void SwitchToPropertiesPanel();
 
   /**
+   * Replace the task being edited with one that arrived from outside,
+   * e.g. a scanned QR code, and show it.
+   */
+  void ReceiveTask(std::unique_ptr<OrderedTask> task) noexcept;
+
+  /**
    * Validates task and prompts if change or error
    * Commits task if no error
    * @return True if task manager should close

--- a/src/Dialogs/Task/Manager/TaskActionsPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskActionsPanel.cpp
@@ -15,6 +15,7 @@
 #include "Interface.hpp"
 #include "Device/Declaration.hpp"
 #include "Task/ValidationErrorStrings.hpp"
+#include "Task/QRScanner.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
 #include "Engine/Waypoint/Waypoints.hpp"
@@ -132,6 +133,21 @@ TaskActionsPanel::OnDownloadClicked() noexcept
 }
 #endif
 
+#ifdef ANDROID
+/**
+ * Open the camera, leaving this dialog open behind it.  The scan runs
+ * in a separate Activity and reports back asynchronously, so closing
+ * here would throw away the pilot's task if they then cancelled the
+ * scan.  A task that does arrive is handed to this still-open dialog
+ * by MainWindow::OnTaskReceived() via TaskManagerReceiveTask().
+ */
+inline void
+TaskActionsPanel::OnScanQRCodeClicked() noexcept
+{
+  ScanTaskQRCode();
+}
+#endif
+
 void
 TaskActionsPanel::ReClick() noexcept
 {
@@ -150,6 +166,11 @@ TaskActionsPanel::Prepare([[maybe_unused]] ContainerWindow &_parent,
   AddButton(_("Declare"), [this](){ OnDeclareClicked(); });
   AddButton(_("Browse"), [this](){ OnBrowseClicked(); });
   AddButton(_("Save"), [this](){ SaveTask(); });
+
+#ifdef ANDROID
+  AddButton(_("Scan QR Code"), [this](){ OnScanQRCodeClicked(); });
+  SetRowEnabled(SCAN_QR_CODE, HaveQRScanner());
+#endif
 
 #ifdef HAVE_HTTP
   AddSpacer();

--- a/src/Dialogs/Task/Manager/TaskActionsPanel.hpp
+++ b/src/Dialogs/Task/Manager/TaskActionsPanel.hpp
@@ -15,6 +15,9 @@ class TaskActionsPanel : public RowFormWidget {
     DECLARE,
     BROWSE,
     SAVE,
+#ifdef ANDROID
+    SCAN_QR_CODE,
+#endif
 #ifdef HAVE_HTTP
     WEGLIDE_SPACER,
     WEGLIDE_STATUS,
@@ -44,6 +47,9 @@ private:
   void OnNewTaskClicked();
   void OnDeclareClicked();
   void OnDownloadClicked() noexcept;
+#ifdef ANDROID
+  void OnScanQRCodeClicked() noexcept;
+#endif
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;

--- a/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
+++ b/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
@@ -33,14 +33,52 @@
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
 
+/**
+ * The task manager currently on screen, or nullptr.  A received task
+ * is handed to this one instead of opening a second task manager on
+ * top of it; see TaskManagerReceiveTask().
+ */
+static TaskManagerDialog *visible_dialog;
+
 inline
 TaskManagerDialog::TaskManagerDialog(WndForm &_dialog,
                                      std::unique_ptr<OrderedTask> &&_task) noexcept
     :TabWidget(Orientation::AUTO),
      dialog(_dialog),
-     task(std::move(_task)) {}
+     task(std::move(_task))
+{
+  visible_dialog = this;
+}
 
-TaskManagerDialog::~TaskManagerDialog() noexcept = default;
+TaskManagerDialog::~TaskManagerDialog() noexcept
+{
+  visible_dialog = nullptr;
+}
+
+void
+TaskManagerDialog::ReceiveTask(std::unique_ptr<OrderedTask> _task) noexcept
+{
+  task = std::move(_task);
+  modified = true;
+
+  ResetTaskView();
+  UpdateCaption();
+  SwitchToEditTab();
+}
+
+bool
+HasVisibleTaskManager() noexcept
+{
+  return visible_dialog != nullptr;
+}
+
+void
+TaskManagerReceiveTask(std::unique_ptr<OrderedTask> task) noexcept
+{
+  assert(visible_dialog != nullptr);
+
+  visible_dialog->ReceiveTask(std::move(task));
+}
 
 bool
 TaskManagerDialog::KeyPress(unsigned key_code) noexcept

--- a/src/Dialogs/Task/TaskDialogs.hpp
+++ b/src/Dialogs/Task/TaskDialogs.hpp
@@ -23,6 +23,24 @@ void
 dlgTaskManagerShowModal();
 
 /**
+ * Is a task manager currently on screen?
+ */
+[[gnu::pure]]
+bool
+HasVisibleTaskManager() noexcept;
+
+/**
+ * Show a task that arrived from outside (e.g. a scanned QR code) in
+ * the task manager that is already on screen.  This keeps a scan
+ * started from inside the task manager from stacking a second one on
+ * top of it.
+ *
+ * May only be called when HasVisibleTaskManager() returns true.
+ */
+void
+TaskManagerReceiveTask(std::unique_ptr<OrderedTask> task) noexcept;
+
+/**
  * Show a dialog that lets the user edit a task point (and lets him
  * navigate to other task points).
  *

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -44,14 +44,15 @@
 #include "Storage/win/WinHotplugForward.hpp"
 #endif
 
-#ifdef ANDROID
-#include "Android/ReceiveTask.hpp"
-#include "Android/Main.hpp"
-#include "Android/NativeView.hpp"
+#include "Task/ReceiveTask.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Dialogs/Task/TaskDialogs.hpp"
 #include "ui/event/Globals.hpp"
 #include "ui/event/Queue.hpp"
+
+#ifdef ANDROID
+#include "Android/Main.hpp"
+#include "Android/NativeView.hpp"
 #include "java/Global.hxx"
 #endif
 
@@ -878,6 +879,8 @@ MainWindow::OnLook() noexcept
   ReinitialiseLook();
 }
 
+#endif // ANDROID
+
 void
 MainWindow::OnTaskReceived() noexcept
 {
@@ -906,7 +909,23 @@ MainWindow::OnTaskReceived() noexcept
   dlgTaskManagerShowModal(std::move(task));
 }
 
-#endif // ANDROID
+/**
+ * Trampoline for PostReceivedTask(): the event loop calls this on the
+ * UI thread, where opening a dialog is safe.
+ */
+static void
+ShowReceivedTask(void *ctx) noexcept
+{
+  ((MainWindow *)ctx)->OnTaskReceived();
+}
+
+void
+PostReceivedTask() noexcept
+{
+  if (UI::event_queue != nullptr && CommonInterface::main_window != nullptr)
+    UI::event_queue->InjectCall(ShowReceivedTask,
+                                CommonInterface::main_window);
+}
 
 void
 MainWindow::Destroy() noexcept
@@ -1170,14 +1189,12 @@ MainWindow::RunTimer() noexcept
 {
   LateInitialise();
 
-#ifdef ANDROID
   /* if we still havn't processed the task that was received from a QR
-     code, re-post the TASK_RECEIVED event to invoke OnTaskReceived()
-     again; we must not open the task manager dialog here because it
-     would block the timer while the dialog is open */
+     code, ask the event loop for OnTaskReceived() again; we must not
+     open the task manager dialog here because it would block the timer
+     while the dialog is open */
   if (IsRunning() && !HasDialog() && HasReceivedTask())
-    UI::event_queue->Inject(UI::Event::TASK_RECEIVED);
-#endif
+    PostReceivedTask();
 
   ProcessTimer();
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -885,8 +885,18 @@ MainWindow::OnTaskReceived() noexcept
     /* postpone until XCSoar is running */
     return;
 
+  if (HasVisibleTaskManager()) {
+    /* the task manager may be the dialog that started the scan in the
+       first place; give the task straight to it rather than stacking a
+       second one on top */
+    if (auto task = GetReceivedTask())
+      TaskManagerReceiveTask(std::move(task));
+    return;
+  }
+
   if (HasDialog())
-    /* don't intercept an existing modal dialog */
+    /* don't intercept an existing modal dialog; the task stays
+       pending and RunTimer() offers it again later */
     return;
 
   auto task = GetReceivedTask();

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -388,6 +388,17 @@ public:
   }
 #endif
 
+  /**
+   * Show a task that arrived from outside XCSoar (a scanned QR code,
+   * or an "xctsk:" link handed over by another app).
+   *
+   * Called from the event loop via PostReceivedTask(), never directly
+   * from the thread the task arrived on.  Does nothing while XCSoar is
+   * still starting up or while another modal dialog is open; RunTimer()
+   * offers the task again in that case.
+   */
+  void OnTaskReceived() noexcept;
+
   void SetTerrain(RasterTerrain *terrain) noexcept;
   void SetTopography(TopographyStore *topography) noexcept;
 
@@ -554,6 +565,5 @@ protected:
 
 #ifdef ANDROID
   void OnLook() noexcept override;
-  void OnTaskReceived() noexcept override;
 #endif
 };

--- a/src/Task/QRDecoder.cpp
+++ b/src/Task/QRDecoder.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "QRDecoder.hpp"
+
+#include <ZXing/ImageView.h>
+#include <ZXing/ReadBarcode.h>
+
+#include <limits>
+
+std::string
+DecodeQRCode(const uint8_t *luminance, std::size_t size,
+             unsigned width, unsigned height,
+             unsigned row_stride, unsigned pixel_stride) noexcept
+try {
+  if (luminance == nullptr || size == 0 || width == 0 || height == 0 ||
+      row_stride == 0 || pixel_stride == 0 ||
+      size > size_t(std::numeric_limits<int>::max()))
+    /* ImageView would throw, and the catch below cannot tell a bad
+       caller from a frame with no QR code in it */
+    return {};
+
+  /* The strides are passed through, so a padded camera plane needs no
+     repacking before it gets here.  This is the bounds-checking
+     constructor: it rejects a buffer too small for the geometry, so we
+     do not have to reproduce that arithmetic at every call site. */
+  const ZXing::ImageView image{luminance, static_cast<int>(size),
+                               static_cast<int>(width),
+                               static_cast<int>(height),
+                               ZXing::ImageFormat::Lum,
+                               static_cast<int>(row_stride),
+                               static_cast<int>(pixel_stride)};
+
+  /* tryHarder and tryRotate are off: this runs on every preview frame,
+     and the pilot can simply hold the camera still for another one.
+     The library is compiled with QR support only, but the format is
+     restricted here too so that a build with more formats enabled
+     cannot start returning barcodes we have no use for. */
+  const auto options = ZXing::ReaderOptions{}
+    .setFormats(ZXing::BarcodeFormat::QRCode)
+    .setTryHarder(false)
+    .setTryRotate(false)
+    .setTryInvert(false)
+    .setMaxNumberOfSymbols(1);
+
+  const auto barcode = ZXing::ReadBarcode(image, options);
+  if (!barcode.isValid())
+    return {};
+
+  return barcode.text();
+} catch (...) {
+  /* not expected, but a decoder failure must never take down the
+     camera thread */
+  return {};
+}

--- a/src/Task/QRDecoder.hpp
+++ b/src/Task/QRDecoder.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+/**
+ * Decode a QR code from a greyscale image.
+ *
+ * This is deliberately free of any platform types so that every port
+ * can feed it whatever its camera produces: Android hands over the Y
+ * plane of a Camera2 frame, and an iOS or desktop caller could pass
+ * any 8 bit luminance buffer.
+ *
+ * @param luminance one byte per pixel
+ * @param size the buffer's size in bytes, so the decoder can reject a
+ * buffer too small for the geometry rather than reading past its end
+ * @param row_stride bytes between the starts of two rows; camera
+ * planes often pad these, so it is not necessarily equal to width
+ * @param pixel_stride bytes between two horizontally adjacent pixels,
+ * which semi-planar formats may set to more than one
+ *
+ * @return the decoded text, or an empty string if the image contains
+ * no readable QR code
+ */
+[[gnu::pure]]
+std::string
+DecodeQRCode(const uint8_t *luminance, std::size_t size,
+             unsigned width, unsigned height,
+             unsigned row_stride, unsigned pixel_stride) noexcept;

--- a/src/Task/QRScanner.hpp
+++ b/src/Task/QRScanner.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Scanning a task QR code with the built-in camera.  Only the mobile
+ * ports can do this, so the rest of the code asks HaveQRScanner()
+ * before offering it and gets a compile-time "no" everywhere else.
+ */
+
+#ifdef ANDROID
+
+/**
+ * Is a camera-based QR scanner available right now?  False when the
+ * UI is not up yet, so a menu binding cannot fire into nothing.
+ */
+[[gnu::pure]]
+bool
+HaveQRScanner() noexcept;
+
+/**
+ * Open the camera and scan one task QR code.
+ *
+ * This returns immediately: the scanner runs outside the XCSoar
+ * window and hands its result to ReceiveTaskQRCode(), which posts
+ * UI::Event::TASK_RECEIVED.  Nothing happens if the user cancels or
+ * denies the camera permission.
+ */
+void
+ScanTaskQRCode() noexcept;
+
+#else
+
+constexpr bool
+HaveQRScanner() noexcept
+{
+  return false;
+}
+
+inline void
+ScanTaskQRCode() noexcept
+{
+}
+
+#endif

--- a/src/Task/ReceiveTask.cpp
+++ b/src/Task/ReceiveTask.cpp
@@ -6,8 +6,6 @@
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/TaskBehaviour.hpp"
 #include "thread/Mutex.hxx"
-#include "ui/event/Globals.hpp"
-#include "ui/event/Queue.hpp"
 #include "util/StringCompare.hxx"
 
 #include <boost/json.hpp>
@@ -46,10 +44,9 @@ ReceiveXCTrackTask(std::string_view data)
     received_task = std::move(task);
   }
 
-  /* if XCSoar is already running, post a TASK_RECEIVED event so
-     MainWindow::OnTaskReceived() opens the task manager */
-  if (UI::event_queue != nullptr)
-    UI::event_queue->Inject(UI::Event::TASK_RECEIVED);
+  /* if XCSoar is already running, ask the UI thread to open the task
+     manager; otherwise the task stays pending until it does */
+  PostReceivedTask();
 }
 
 void

--- a/src/Task/ReceiveTask.hpp
+++ b/src/Task/ReceiveTask.hpp
@@ -15,6 +15,19 @@ HasReceivedTask() noexcept;
 std::unique_ptr<OrderedTask>
 GetReceivedTask() noexcept;
 
+/**
+ * Ask the UI thread to show the task that has just been stored, by
+ * calling MainWindow::OnTaskReceived() from the event loop.
+ *
+ * This is implemented by the UI layer (MainWindow.cpp) rather than
+ * here, because only that knows how to reach the main window.  It may
+ * be called from any thread, and does nothing at all while the event
+ * loop does not exist yet: the task stays pending and
+ * MainWindow::RunTimer() offers it again once XCSoar is up.
+ */
+void
+PostReceivedTask() noexcept;
+
 void
 ReceiveXCTrackTask(std::string_view data);
 

--- a/src/ui/event/shared/Event.hpp
+++ b/src/ui/event/shared/Event.hpp
@@ -71,11 +71,6 @@ struct Event {
      * can be created again.
      */
     RESUME,
-
-    /**
-     * A task has been received and the task manager should be opened.
-     */
-    TASK_RECEIVED,
 #endif
 
 #ifdef USE_X11

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -563,8 +563,6 @@ protected:
    */
   void OnSurface() noexcept;
 
-  virtual void OnTaskReceived() noexcept {}
-
   /**
    * @see Event::PAUSE
    */

--- a/src/ui/window/android/TopWindow.cpp
+++ b/src/ui/window/android/TopWindow.cpp
@@ -289,10 +289,6 @@ TopWindow::OnEvent(const Event &event)
     OnSurface();
     return true;
 
-  case Event::TASK_RECEIVED:
-    OnTaskReceived();
-    return true;
-
   case Event::PAUSE:
     OnPause();
     return true;


### PR DESCRIPTION
Adds a **Scan QR Code** button to the task manager, so an XCTrack task can be
imported with the built-in camera instead of being routed through the phone's
camera app and an app chooser.

https://github.com/user-attachments/assets/0f4000da-e3a9-4c70-8908-1484788a1f40

Requested in #1270.

## Where the code lives

The decoder is portable C++, not Android code. `src/Task/QRDecoder.cpp` takes
nothing but an 8-bit luminance buffer and its row/pixel strides — no platform
types, no JNI — and is built on **zxing-cpp**, added as a `CmakeProject`
alongside the other third-party libraries. So the iOS and desktop ports can
reuse it as soon as they have a camera to point at it, with no second decoder
and no duplicated task parsing.

Only the capture layer is platform-specific, and only that part is in Java:
`QRScannerActivity` drives Camera2, and hands each frame's Y plane straight
across JNI. Because `ZXing::ImageView` accepts strides directly, the plane is
never repacked, and since Camera2 gives out a direct `ByteBuffer`, native code
reads the camera's memory in place rather than copying a frame at a time.

Nothing about the *decode* path is new: it already existed for the `xctsk:` URI
scheme (7.38). `ReceiveTaskQRCode()` strips the scheme prefix and reuses
`ReceiveXCTrackTask()`, so a scanned code and a scanned-elsewhere link end up
in exactly the same place. The prefix match is case-insensitive because XCTrack
writes `XCTSK:` while an intent URI arrives lower-cased.

The button lives on the task manager's *Manage* page, next to Save. A scan
started there leaves the dialog open, and the scanned task is handed to that
dialog via `TaskManagerReceiveTask()` rather than stacking a second task
manager on top — so cancelling a scan leaves the pilot's task untouched.

## zxing-cpp

Built with the reader only and only for QR: the encoders and the other five
symbologies are switched off, leaving 42 objects and none for 1D, Aztec,
DataMatrix, MaxiCode or PDF417, and no bundled zint.
`ZXING_DEPENDENCIES=LOCAL` keeps the build off the network. Apache-2.0, noted
in `THIRD_PARTY_NOTICES.txt`.

One build caveat worth knowing: zxing-cpp does not compile for Android with the
NDK we pin (r26d) out of the box. Below API 24 libc++ falls back to
`__bsd_locale_fallbacks.h`, and *precompiling* that header fails with a
`va_list` mismatch on aarch64. The affected translation unit is fine without
the PCH, so the recipe passes `-DZXING_DISABLE_PCH=ON`, with the reason
recorded there.

## Notes for review

- `android:hardwareAccelerated="true"` is spelled out on the activity. A
  `TextureView` in a software-rendered window draws nothing and never hands out
  its `SurfaceTexture`, which left the preview black and the camera unopened.
  Nothing else in the app depended on it, since the main activity drives its
  own GLES `SurfaceView`.
- The camera thread lives as long as the activity and is quit *from* that
  thread, so the teardown posted by `onPause()` has run first; otherwise the
  camera framework finds the looper gone while still delivering close
  callbacks.
- `onPause()` takes the session, device, reader and preview surface as locals
  and clears the fields before posting the teardown, and `onOpened()` /
  `startPreview()` re-check the paused flag, so a camera or surface arriving
  late is handed straight back instead of leaking.
- The camera permission is requested directly rather than through
  `PermissionHelper`, which reports every permission as granted in simulator
  mode without asking for it.
- Cancelling returns through `XCSoar` rather than just finishing, because the
  main activity is `singleInstance` and a bare `finish()` drops the pilot on
  the home screen.

## Testing

On a Pixel 7a (Android 17, arm64) and in the emulator:

- Scanning a real XCTrack task QR code imports it into the task manager, with
  turnpoints, cylinder radii and task distance as expected.
- The existing `xctsk:` intent path still opens a populated task manager.
- Cancel, hardware Back and camera errors all return to the map, with the task
  manager left as it was.
- `DecodeQRCode()` exercised off-device against the same zxing-cpp release,
  decoding the payload through a packed plane and through `rowStride +1`,
  `rowStride +64`, `pixelStride 2` and `pixelStride 2 + rowStride +32` — which
  also demonstrates it building and running outside Android. Its input guards
  are covered too: null pointer, zero size/width/height/stride, and a buffer
  too small for the geometry all return empty rather than throwing.
- Builds clean for `ANDROIDAARCH64`; the non-Android build is unaffected
  (`HaveQRScanner()` is a `constexpr false` stub off Android).
- All 33 catalogues pass `msgfmt --check`, and the button renders translated on
  a German device.

The translations are a separate commit so native speakers can correct them
without disturbing the feature.

## Known limitations

- Only Android has the capture side so far. iOS needs `AVFoundation` capture
  plus lifting `ReceiveTask.cpp` and `MainWindow::OnTaskReceived()` out of
  `#ifdef ANDROID`; the decoder it would call is already in place.
- The preview transform derives its orientation from the display rotation, so
  it may be stretched on a device whose natural orientation is landscape. The
  scanner is locked to portrait for now. Decoding is unaffected.
