### PR TITLE
Dialogs/PagesConfigPanel: explain unavailable SkySight overlays

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -15,6 +15,8 @@ Version 7.46 - not yet released
   - fix SkySight re-downloading forecast metadata when stepping
     layers on the weather cursor, which could hit the API rate
     limit #2867
+  - fix choosing SkySight as a page overlay with no layers available
+    silently switching back to None
 * map
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "PagesConfigPanel.hpp"
+#include "Dialogs/Message.hpp"
 #include "Look/DialogLook.hpp"
 #include "Renderer/TextRowRenderer.hpp"
 #include "Form/Button.hpp"
@@ -524,15 +525,46 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
     }
   } else if (&df == &GetDataField(OVERLAY)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
-    value.overlay = (PageLayout::Overlay)dfe.GetValue();
-    if (value.overlay == PageLayout::Overlay::SKYSIGHT &&
-        value.skysight_overlay.empty()) {
+    const auto overlay = (PageLayout::Overlay)dfe.GetValue();
+    if (overlay == PageLayout::Overlay::SKYSIGHT) {
 #ifdef HAVE_HTTP
-      if (auto skysight = DataGlobals::GetSkySight(); skysight != nullptr)
-        if (const auto *layer = skysight->GetSelectedLayer(0); layer != nullptr)
-          value.skysight_overlay = layer->id;
+      const auto skysight = DataGlobals::GetSkySight();
+      const SkySight::Layer *layer = nullptr;
+      if (skysight != nullptr) {
+        if (!value.skysight_overlay.empty() &&
+            skysight->IsSelectedLayer(value.skysight_overlay.c_str()))
+          layer = skysight->GetSelectedLayer(value.skysight_overlay.c_str());
+
+        for (std::size_t i = 0; layer == nullptr &&
+             i < skysight->NumSelectedLayers(); ++i)
+          layer = skysight->GetSelectedLayer(i);
+      }
+
+      if (layer != nullptr) {
+        value.skysight_overlay = layer->id;
+      } else if (value.skysight_overlay.empty()) {
+        const char *message;
+        if (skysight == nullptr)
+          message = _("SkySight is unavailable.");
+        else if (skysight->IsThrottled())
+          message = _("SkySight API rate-limited. Retrying shortly.");
+        else if (!skysight->HasForecastLayers())
+          message = _("Loading SkySight catalog...");
+        else
+          message = _("No SkySight layers selected");
+
+        ShowMessageBox(message, "SkySight", MB_OK | MB_ICONINFORMATION);
+        ApplyValueToForm();
+        return;
+      }
+
+      if (layer == nullptr)
+        value.skysight_overlay.clear();
+#else
+      value.skysight_overlay.clear();
 #endif
     }
+    value.overlay = overlay;
   } else if (&df == &GetDataField(OVERLAY_DETAIL)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     if (value.overlay == PageLayout::Overlay::RASP)


### PR DESCRIPTION
Related: #2860 (credential/HTTP error feedback; this PR does not implement 401/402/403 messages).

# Dialogs/Settings: Explain unavailable SkySight page overlays

## Summary

- validate that a usable SkySight layer exists before changing a page's map
  overlay
- show an actionable message when SkySight is unavailable, credentials are
  missing, the catalog is still loading, or no layers have been added
- preserve the page's existing overlay when SkySight cannot be selected

## Reproduction

1. Start XCSoar without any SkySight layers in the global selected-layer list.
2. Open **Config > Look > Pages**.
3. Edit a map page and choose **SkySight** as its map overlay.

The page editor previously accepted the list selection temporarily and then
immediately displayed **None** with **N/A** as its layer. No explanation was
shown.

## Root cause

Every SkySight page needs a non-empty layer ID. When SkySight was chosen, the
page editor tried to copy the first item from the global SkySight
selected-layer list. If that list was empty or had not yet been restored from
the asynchronously loaded catalog, the ID remained empty.

The editor then normalized the draft page layout. Normalization treats a
SkySight overlay without a layer ID as invalid and changes it back to
**None**, producing a silent failure before networking or map rendering is
reached.

## Testing

- manually verified in the macOS simulator that selecting SkySight without an
  available layer shows an actionable message and preserves the existing page
  overlay
- `gmake -j4 output/OSX64/opt/src/Dialogs/Settings/Panels/PagesConfigPanel.o`
- `gmake -j4 output/OSX64/bin/TestWeatherOverlayPagePlacement`
- `output/OSX64/bin/TestWeatherOverlayPagePlacement` — all 66 tests passed
- `git diff --check`

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase

- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages

- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure

- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SkySight overlay selection handling by preserving valid selections, selecting the first available layer when needed, and clearing invalid selections.
  * Added clearer status-specific messages when overlay layers are unavailable.
  * Prevented updates when no layer can be assigned and restored the previous settings form.
* **Style**
  * Renamed the XC Therm overlay option from “XCTherm” to “XC Therm” for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->