### PR TITLE
Support for Polish Start, cleanup of Task types

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -662,10 +662,19 @@ location=1
 
 mode=Nav1
 type=key
-data=6
+data=2
 event=Calculator
 event=Mode default
 label=Task Manager
+location=4
+
+mode=Nav1
+type=key
+data=6
+event=StatusMessage Pilot event announced
+event=Logger note PEV
+event=PilotEvent
+label=Pilot Event Announce
 location=5
 
 mode=Nav1
@@ -730,16 +739,6 @@ location=6
 mode=Nav2
 type=key
 data=8
-event=Mode default
-event=StatusMessage Pilot event announced
-event=Logger note PEV
-event=PilotEvent
-label=Pilot Event Announce
-location=7
-
-mode=Nav2
-type=key
-data=9
 event=Setup Target
 event=Mode default
 label=Target$(CheckTask)$(CheckTaskResumed)

--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -674,8 +674,8 @@ data=6
 event=StatusMessage Pilot event announced
 event=Logger note PEV
 event=PilotEvent
-label=Pilot Event Announce
-location=5
+label=$(PilotEventAnnounce)
+location=7
 
 mode=Nav1
 type=key
@@ -689,7 +689,7 @@ type=key
 data=8
 event=AdjustWaypoint nextarm
 label=$(WaypointNextArm)
-location=7
+location=5
 
 mode=Nav1
 type=key

--- a/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
@@ -106,14 +106,14 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
   SetExpertRow(spacer_3);
 
   AddDuration(_("PEV start wait time"),
-              _("Wait time in minutes after Pilot Event and before start gate opens. "
+              _("Wait time in minutes after Pilot Event (PEV) and before start gate opens. "
                 "0 means start opens immediately."),
               {}, minutes{30}, minutes{1},
               task_behaviour.ordered_defaults.start_constraints.pev_start_wait_time);
   SetExpertRow(PEVStartWaitTime);
 
   AddDuration(_("PEV start window"),
-              _("Number of minutes start remains open after Pilot Event and PEV wait time."
+              _("Number of minutes start remains open after Pilot Event (PEV) and PEV wait time."
                 "0 means start will never close after it opens."),
               {}, minutes{30}, minutes{1},
               task_behaviour.ordered_defaults.start_constraints.pev_start_window);

--- a/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
@@ -4,6 +4,8 @@
 #include "TaskRulesConfigPanel.hpp"
 #include "Profile/Keys.hpp"
 #include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Float.hpp"
+#include "Form/DataField/Listener.hpp"
 #include "Interface.hpp"
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
@@ -26,7 +28,7 @@ enum ControlIndex {
   PEVStartWindow,
 };
 
-class TaskRulesConfigPanel final : public RowFormWidget {
+class TaskRulesConfigPanel final : public RowFormWidget, DataFieldListener {
 public:
   TaskRulesConfigPanel()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
@@ -34,6 +36,19 @@ public:
 public:
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   bool Save(bool &changed) noexcept override;
+
+private:
+  void OnModified(DataField &df) noexcept override {
+    if (IsDataField(FinishHeightRef, df))
+      UpdateFinishHeightRange();
+  }
+
+  void UpdateFinishHeightRange() noexcept {
+    auto &height = (DataFieldFloat &)GetDataField(FinishMinHeight);
+    const auto &reference = (const DataFieldEnum &)GetDataField(FinishHeightRef);
+    const bool start = reference.GetValue() == (unsigned)AltitudeReference::START;
+    height.SetMin(start ? -10000 : 0);
+  }
 };
 
 void
@@ -77,6 +92,8 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
       N_("Reference is the height above the task point."), },
     { AltitudeReference::MSL, N_("MSL"),
       N_("Reference is altitude above mean sea level."), },
+    { AltitudeReference::START, N_("Start"),
+      N_("Reference is the altitude at which the task was started."), },
     nullptr
   };
 
@@ -90,7 +107,9 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
   SetExpertRow(spacer_2);
 
   AddFloat(_("Finish min. height"),
-           _("Minimum height based on finish height reference (AGL or MSL) while finishing the task. "
+           _("Minimum height based on the finish height reference while finishing the task. "
+               "With Start reference, this is the maximum permitted height loss from start "
+               "to finish; negative values allow the finish to be below the start height. "
                "Set to 0 for no limit."),
            "%.0f %s", "%.0f", 0, 10000, 50, false, UnitGroup::ALTITUDE,
            task_behaviour.ordered_defaults.finish_constraints.min_height);
@@ -99,8 +118,11 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
   AddEnum(_("Finish height ref."),
           _("Reference used for finish min height rule."),
           altitude_reference_list,
-          (unsigned)task_behaviour.ordered_defaults.finish_constraints.min_height_ref);
+          (unsigned)task_behaviour.ordered_defaults.finish_constraints.min_height_ref,
+          this);
   SetExpertRow(FinishHeightRef);
+
+  UpdateFinishHeightRange();
 
   AddSpacer();
   SetExpertRow(spacer_3);

--- a/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
+++ b/src/Dialogs/Task/Manager/TaskManagerDialog.cpp
@@ -32,6 +32,7 @@
 #include "Language/Language.hpp"
 #include "BackendComponents.hpp"
 #include "DataComponents.hpp"
+#include "Input/InputEvents.hpp"
 
 inline
 TaskManagerDialog::TaskManagerDialog(WndForm &_dialog,
@@ -194,6 +195,7 @@ TaskManagerDialog::Commit()
     }
 
     backend_components->protected_task_manager->TaskCommit(*task);
+    InputEvents::UpdateMenu();
 
     try {
       backend_components->protected_task_manager->TaskSaveDefault();

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -4,6 +4,7 @@
 #include "TaskPropertiesPanel.hpp"
 #include "Internal.hpp"
 #include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Float.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
 #include "Task/TypeStrings.hpp"
@@ -220,12 +221,29 @@ TaskPropertiesPanel::OnTaskTypeChange(DataFieldEnum &df)
 void
 TaskPropertiesPanel::OnModified(DataField &df) noexcept
 {
+  bool refresh = true;
   if (IsDataField(TASK_TYPE, df))
     OnTaskTypeChange((DataFieldEnum &)df);
   else if (IsDataField(START_MODE, df))
     ReadValues();
+  else if (IsDataField(FINISH_HEIGHT_REF, df)) {
+    UpdateFinishHeightRange();
+    refresh = false;
+  }
 
-  RefreshView();
+  if (refresh)
+    RefreshView();
+}
+
+void
+TaskPropertiesPanel::UpdateFinishHeightRange() noexcept
+{
+  auto &height = (DataFieldFloat &)GetDataField(FINISH_MIN_HEIGHT);
+  const auto &reference = (const DataFieldEnum &)GetDataField(FINISH_HEIGHT_REF);
+  const bool start = reference.GetValue() == (unsigned)AltitudeReference::START;
+  height.SetMin(start ? -10000 : 0);
+  if (!start && height.GetValue() < 0)
+    height.SetValue(0);
 }
 
 void
@@ -282,6 +300,8 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
       N_("Reference is the height above the task point."), },
     { AltitudeReference::MSL, N_("MSL"),
       N_("Reference is altitude above mean sea level."), },
+    { AltitudeReference::START, N_("Start"),
+      N_("Reference is the altitude at which the task was started."), },
     nullptr
   };
 
@@ -290,13 +310,18 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
           altitude_reference_list);
 
   AddFloat(_("Finish min. height"),
-           _("Minimum height based on finish height reference (AGL or MSL) while finishing the task. Set to 0 for no limit."),
+           _("Minimum height of finish compared to reference. With MSL or AGL reference, "
+             "the finish must be above this height. With Start reference, positive values "
+             "require the finish to be above the actual start height, while negative values "
+             "allow the finish to be below it."),
            "%.0f %s", "%.0f",
            0, 10000, 25, false, 0);
 
   AddEnum(_("Finish height ref."),
           _("Reference used for finish min height rule."),
-          altitude_reference_list);
+          altitude_reference_list, 0, this);
+
+  UpdateFinishHeightRange();
 
   AddDuration(_("PEV start wait time"),
               _("Wait time in minutes after Pilot Event (PEV) and before start gate opens. "

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -224,8 +224,14 @@ TaskPropertiesPanel::OnModified(DataField &df) noexcept
   bool refresh = true;
   if (IsDataField(TASK_TYPE, df))
     OnTaskTypeChange((DataFieldEnum &)df);
-  else if (IsDataField(START_MODE, df))
-    ReadValues();
+  else if (IsDataField(START_MODE, df)) {
+    auto p = ordered_task->GetOrderedTaskSettings();
+    SetStartMode(p, (StartMode)((DataFieldEnum &)df).GetValue());
+    ordered_task->SetOrderedTaskSettings(p);
+    *task_changed = true;
+    refresh = false;
+    RefreshView();
+  }
   else if (IsDataField(FINISH_HEIGHT_REF, df)) {
     UpdateFinishHeightRange();
     refresh = false;

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -4,7 +4,6 @@
 #include "TaskPropertiesPanel.hpp"
 #include "Internal.hpp"
 #include "Form/DataField/Enum.hpp"
-#include "Form/DataField/Boolean.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
 #include "Task/TypeStrings.hpp"
@@ -16,6 +15,7 @@ using namespace std::chrono;
 
 enum Controls {
   TASK_TYPE,
+  START_MODE,
   MIN_TIME,
   START_REQUIRES_ARM,
   START_SCORE_EXIT,
@@ -28,8 +28,51 @@ enum Controls {
   FINISH_HEIGHT_REF,
   PEV_START_WAIT_TIME,
   PEV_START_WINDOW,
-  FAI_FINISH_HEIGHT,
 };
+
+static constexpr StaticEnumChoice start_mode_list[] = {
+  { StartMode::NORMAL, N_("Normal Start"),
+    N_("Use normal start rules.") },
+  { StartMode::FAI_START_FINISH, N_("FAI start+finish"),
+    N_("Use FAI start and finish rules.") },
+  { StartMode::PEV, N_("Pilot Event (PEV) Start"),
+    N_("Enable Pilot Event (PEV) start timing.") },
+  { StartMode::POLISH, N_("Polish Start"),
+    N_("Use Pilot Event to start from the current location inside the start sector.") },
+  nullptr
+};
+
+static StartMode
+GetStartMode(const OrderedTaskSettings &p) noexcept
+{
+  return p.start_constraints.start_mode;
+}
+
+static void
+SetStartMode(OrderedTaskSettings &p, StartMode mode) noexcept
+{
+  switch (mode) {
+  case StartMode::NORMAL:
+    p.finish_constraints.fai_finish = false;
+    p.start_constraints.fai_finish = false;
+    p.start_constraints.pev_start_enabled = false;
+    break;
+
+  case StartMode::FAI_START_FINISH:
+    p.finish_constraints.fai_finish = true;
+    p.start_constraints.fai_finish = true;
+    p.start_constraints.pev_start_enabled = false;
+    break;
+
+  case StartMode::PEV:
+  case StartMode::POLISH:
+    p.finish_constraints.fai_finish = false;
+    p.start_constraints.fai_finish = false;
+    p.start_constraints.pev_start_enabled = true;
+    break;
+  }
+  p.start_constraints.start_mode = mode;
+}
 
 TaskPropertiesPanel::TaskPropertiesPanel(TaskManagerDialog &_dialog,
                                          std::unique_ptr<OrderedTask> &_active_task,
@@ -47,10 +90,13 @@ TaskPropertiesPanel::RefreshView()
 
   const bool aat_types = ftype == TaskFactoryType::AAT ||
     ftype == TaskFactoryType::MAT;
-  bool fai_start_finish = p.finish_constraints.fai_finish;
+  const StartMode start_mode = GetStartMode(p);
+  const bool fai_start_finish = start_mode == StartMode::FAI_START_FINISH;
 
   SetRowVisible(MIN_TIME, aat_types);
   LoadValueDuration(MIN_TIME, p.aat_min_time);
+
+  LoadValueEnum(START_MODE, start_mode);
 
   LoadValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
   LoadValue(START_SCORE_EXIT, p.start_constraints.score_exit);
@@ -76,15 +122,12 @@ TaskPropertiesPanel::RefreshView()
   SetRowVisible(FINISH_HEIGHT_REF, !fai_start_finish);
   LoadValueEnum(FINISH_HEIGHT_REF, p.finish_constraints.min_height_ref);
 
-  SetRowVisible(FAI_FINISH_HEIGHT, IsFai(ftype));
-  LoadValue(FAI_FINISH_HEIGHT, fai_start_finish);
-
   LoadValueEnum(TASK_TYPE, ftype);
 
-  SetRowVisible(PEV_START_WAIT_TIME, !fai_start_finish);
+  SetRowVisible(PEV_START_WAIT_TIME, !fai_start_finish && start_mode == StartMode::PEV);
   LoadValueDuration(PEV_START_WAIT_TIME,
                     p.start_constraints.pev_start_wait_time);
-  SetRowVisible(PEV_START_WINDOW, !fai_start_finish);
+  SetRowVisible(PEV_START_WINDOW, !fai_start_finish && start_mode == StartMode::PEV);
   LoadValueDuration(PEV_START_WINDOW,
                     p.start_constraints.pev_start_window);
 
@@ -145,30 +188,21 @@ TaskPropertiesPanel::ReadValues()
   changed |= SaveValueEnum(FINISH_HEIGHT_REF,
                            p.finish_constraints.min_height_ref);
 
+  StartMode start_mode = GetStartMode(p);
+  changed |= SaveValueEnum(START_MODE, start_mode);
+  if (changed)
+    SetStartMode(p, start_mode);
+
   changed |= SaveValue(PEV_START_WAIT_TIME,
                        p.start_constraints.pev_start_wait_time);
   changed |= SaveValue(PEV_START_WINDOW,
                        p.start_constraints.pev_start_window);
 
-  if (changed)
+  if (changed) {
     ordered_task->SetOrderedTaskSettings(p);
+  }
 
   *task_changed |= changed;
-}
-
-void
-TaskPropertiesPanel::OnFAIFinishHeightChange(DataFieldBoolean &df)
-{
-  OrderedTaskSettings p = ordered_task->GetOrderedTaskSettings();
-  bool newvalue = df.GetValue();
-  if (newvalue != p.finish_constraints.fai_finish) {
-    p.finish_constraints.fai_finish = p.start_constraints.fai_finish
-      = newvalue;
-    ordered_task->SetOrderedTaskSettings(p);
-
-    *task_changed = true;
-    RefreshView();
-  }
 }
 
 void
@@ -180,17 +214,18 @@ TaskPropertiesPanel::OnTaskTypeChange(DataFieldEnum &df)
     ReadValues();
     ordered_task->SetFactory(newtype);
     *task_changed =true;
-    RefreshView();
   }
 }
 
 void
 TaskPropertiesPanel::OnModified(DataField &df) noexcept
 {
-  if (IsDataField(FAI_FINISH_HEIGHT, df))
-    OnFAIFinishHeightChange((DataFieldBoolean &)df);
-  else if (IsDataField(TASK_TYPE, df))
+  if (IsDataField(TASK_TYPE, df))
     OnTaskTypeChange((DataFieldEnum &)df);
+  else if (IsDataField(START_MODE, df))
+    ReadValues();
+
+  RefreshView();
 }
 
 void
@@ -209,6 +244,12 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
       dfe->SetValue(factory_types[i]);
   }
   Add(_("Task type"), _("Sets the behaviour for the current task."), dfe);
+
+  AddEnum(_("Start mode"),
+          _("Choose how the start is configured."),
+          start_mode_list,
+          (unsigned)GetStartMode(ordered_task->GetOrderedTaskSettings()),
+          this);
 
   AddDuration(_("AAT min. time"), _("Minimum AAT task time in minutes."),
               {}, hours{10}, minutes{1}, minutes{3});
@@ -258,17 +299,13 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
           altitude_reference_list);
 
   AddDuration(_("PEV start wait time"),
-              _("Wait time in minutes after Pilot Event and before start gate opens. "
+              _("Wait time in minutes after Pilot Event (PEV) and before start gate opens. "
                 "0 means start opens immediately."),
-              {}, minutes{30}, minutes{1}, {});
+              {}, minutes{10}, minutes{1}, {});
   AddDuration(_("PEV start window"),
-              _("Number of minutes the start remains open after Pilot Event and PEV wait time. "
+              _("Number of minutes the start remains open after Pilot Event (PEV) and PEV wait time. "
                 "0 means start will never close after it opens."),
-              {}, minutes{30}, minutes{1}, {});
-
-  AddBoolean(_("FAI start / finish rules"),
-             _("If enabled, has no max start height or max start speed and requires the minimum height above ground for finish to be greater than 1000m below the start height."),
-             false, this);
+              minutes{0}, minutes{10}, minutes{1}, {});
 }
 
 void

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -6,6 +6,7 @@
 #include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Float.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/FinishConstraints.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
 #include "Task/TypeStrings.hpp"
 #include "Units/Units.hpp"
@@ -105,30 +106,34 @@ TaskPropertiesPanel::RefreshView()
   LoadValue(START_OPEN_TIME, p.start_constraints.open_time_span.GetRoughStart());
   LoadValue(START_CLOSE_TIME, p.start_constraints.open_time_span.GetRoughEnd());
 
-  SetRowVisible(START_MAX_SPEED, !fai_start_finish);
+  SetRowEnabled(START_MAX_SPEED, !fai_start_finish);
   LoadValue(START_MAX_SPEED, p.start_constraints.max_speed,
             UnitGroup::HORIZONTAL_SPEED);
 
-  SetRowVisible(START_MAX_HEIGHT, !fai_start_finish);
+  SetRowEnabled(START_MAX_HEIGHT, !fai_start_finish);
   LoadValue(START_MAX_HEIGHT, double(p.start_constraints.max_height),
             UnitGroup::ALTITUDE);
 
-  SetRowVisible(START_HEIGHT_REF, !fai_start_finish);
+  SetRowEnabled(START_HEIGHT_REF, !fai_start_finish);
   LoadValueEnum(START_HEIGHT_REF, p.start_constraints.max_height_ref);
 
-  SetRowVisible(FINISH_MIN_HEIGHT, !fai_start_finish);
-  LoadValue(FINISH_MIN_HEIGHT, double(p.finish_constraints.min_height),
+  SetRowEnabled(FINISH_MIN_HEIGHT, !fai_start_finish);
+  LoadValue(FINISH_MIN_HEIGHT,
+            double(fai_start_finish ? FAI_FINISH_HEIGHT_LOSS :
+                   p.finish_constraints.min_height),
             UnitGroup::ALTITUDE);
 
-  SetRowVisible(FINISH_HEIGHT_REF, !fai_start_finish);
+  SetRowEnabled(FINISH_HEIGHT_REF, !fai_start_finish);
   LoadValueEnum(FINISH_HEIGHT_REF, p.finish_constraints.min_height_ref);
 
   LoadValueEnum(TASK_TYPE, ftype);
 
-  SetRowVisible(PEV_START_WAIT_TIME, !fai_start_finish && start_mode == StartMode::PEV);
+  SetRowEnabled(PEV_START_WAIT_TIME,
+                !fai_start_finish && start_mode == StartMode::PEV);
   LoadValueDuration(PEV_START_WAIT_TIME,
                     p.start_constraints.pev_start_wait_time);
-  SetRowVisible(PEV_START_WINDOW, !fai_start_finish && start_mode == StartMode::PEV);
+  SetRowEnabled(PEV_START_WINDOW,
+                !fai_start_finish && start_mode == StartMode::PEV);
   LoadValueDuration(PEV_START_WINDOW,
                     p.start_constraints.pev_start_window);
 
@@ -179,11 +184,13 @@ TaskPropertiesPanel::ReadValues()
   changed |= SaveValueEnum(START_HEIGHT_REF,
                            p.start_constraints.max_height_ref);
 
-  unsigned min_height =
-    iround(Units::ToSysAltitude(GetValueFloat(FINISH_MIN_HEIGHT)));
-  if (min_height != p.finish_constraints.min_height) {
-    p.finish_constraints.min_height = min_height;
-    changed = true;
+  if (!p.finish_constraints.fai_finish) {
+    unsigned min_height =
+      iround(Units::ToSysAltitude(GetValueFloat(FINISH_MIN_HEIGHT)));
+    if (min_height != p.finish_constraints.min_height) {
+      p.finish_constraints.min_height = min_height;
+      changed = true;
+    }
   }
 
   changed |= SaveValueEnum(FINISH_HEIGHT_REF,

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -71,6 +71,7 @@ SetStartMode(OrderedTaskSettings &p, StartMode mode) noexcept
     p.finish_constraints.fai_finish = false;
     p.start_constraints.fai_finish = false;
     p.start_constraints.pev_start_enabled = true;
+    p.start_constraints.require_arm = false;
     break;
   }
   p.start_constraints.start_mode = mode;
@@ -94,13 +95,17 @@ TaskPropertiesPanel::RefreshView()
     ftype == TaskFactoryType::MAT;
   const StartMode start_mode = GetStartMode(p);
   const bool fai_start_finish = start_mode == StartMode::FAI_START_FINISH;
+  const bool arm_start_allowed = start_mode == StartMode::NORMAL ||
+    start_mode == StartMode::FAI_START_FINISH;
 
   SetRowVisible(MIN_TIME, aat_types);
   LoadValueDuration(MIN_TIME, p.aat_min_time);
 
   LoadValueEnum(START_MODE, start_mode);
 
-  LoadValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
+  SetRowEnabled(START_REQUIRES_ARM, arm_start_allowed);
+  LoadValue(START_REQUIRES_ARM,
+            arm_start_allowed && p.start_constraints.require_arm);
   LoadValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 
   LoadValue(START_OPEN_TIME, p.start_constraints.open_time_span.GetRoughStart());
@@ -154,8 +159,15 @@ TaskPropertiesPanel::ReadValues()
 
   changed |= SaveValue(MIN_TIME, p.aat_min_time);
 
-  if (SaveValue(START_REQUIRES_ARM, p.start_constraints.require_arm))
+  const bool arm_start_allowed = p.start_constraints.start_mode == StartMode::NORMAL ||
+    p.start_constraints.start_mode == StartMode::FAI_START_FINISH;
+  if (arm_start_allowed) {
+    if (SaveValue(START_REQUIRES_ARM, p.start_constraints.require_arm))
+      changed = true;
+  } else if (p.start_constraints.require_arm) {
+    p.start_constraints.require_arm = false;
     changed = true;
+  }
 
   changed |= SaveValue(START_SCORE_EXIT, p.start_constraints.score_exit);
 

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -5,6 +5,7 @@
 #include "Internal.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Float.hpp"
+#include "Form/DataField/Boolean.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
 #include "Engine/Task/Ordered/FinishConstraints.hpp"
 #include "Engine/Task/Factory/AbstractTaskFactory.hpp"
@@ -301,7 +302,9 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
              _("Configure whether the start must be armed manually or automatically."),
              false);
 
-  AddBoolean(_("Score start exit"), nullptr, false);
+  Add(_("Start zone behavior"), nullptr,
+      new DataFieldBoolean(false, _("Start on exit"),
+                           _("Start on entry")));
 
   const RoughTimeDelta time_zone =
     CommonInterface::GetComputerSettings().utc_offset;

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.hpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.hpp
@@ -9,7 +9,6 @@
 
 class TaskManagerDialog;
 class OrderedTask;
-class DataFieldBoolean;
 class DataFieldEnum;
 
 class TaskPropertiesPanel final
@@ -29,7 +28,6 @@ public:
                       std::unique_ptr<OrderedTask> &_active_task,
                       bool *_task_modified) noexcept;
 
-  void OnFAIFinishHeightChange(DataFieldBoolean &df);
   void OnTaskTypeChange(DataFieldEnum &df);
 
   /* virtual methods from Widget */

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.hpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.hpp
@@ -49,4 +49,5 @@ protected:
 private:
   /* virtual methods from DataFieldListener */
   void OnModified(DataField &df) noexcept override;
+  void UpdateFinishHeightRange() noexcept;
 };

--- a/src/Engine/Task/Ordered/FinishConstraints.cpp
+++ b/src/Engine/Task/Ordered/FinishConstraints.cpp
@@ -14,10 +14,15 @@ FinishConstraints::SetDefaults()
 
 bool
 FinishConstraints::CheckHeight(const AircraftState &state,
-                               const double finish_elevation) const
+                               const double finish_elevation,
+                               const std::optional<double> start_altitude) const
 {
   if (min_height == 0)
     return true;
+
+  if (min_height_ref == AltitudeReference::START)
+    return start_altitude.has_value() &&
+      state.altitude >= *start_altitude - min_height;
 
   if (min_height_ref == AltitudeReference::MSL)
     return state.altitude >= min_height;

--- a/src/Engine/Task/Ordered/FinishConstraints.hpp
+++ b/src/Engine/Task/Ordered/FinishConstraints.hpp
@@ -9,6 +9,9 @@
 
 struct AircraftState;
 
+/** Maximum height loss allowed by the FAI finish rule (m). */
+static constexpr unsigned FAI_FINISH_HEIGHT_LOSS = 1000;
+
 struct FinishConstraints {
   /** Minimum height AGL (m) allowed to finish */
   unsigned min_height;

--- a/src/Engine/Task/Ordered/FinishConstraints.hpp
+++ b/src/Engine/Task/Ordered/FinishConstraints.hpp
@@ -5,6 +5,8 @@
 
 #include "Geo/AltitudeReference.hpp"
 
+#include <optional>
+
 struct AircraftState;
 
 struct FinishConstraints {
@@ -36,5 +38,6 @@ struct FinishConstraints {
    */
   [[gnu::pure]]
   bool CheckHeight(const AircraftState &state,
-                   double finish_elevation) const;
+                   double finish_elevation,
+                   std::optional<double> start_altitude = {}) const;
 };

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -545,6 +545,9 @@ OrderedTask::CheckTransitions(const AircraftState &state,
                                                 : nullptr);
 
     if (taskpoint_finish != nullptr)
+      taskpoint_finish->SetStartAltitude(start_state.altitude);
+
+    if (taskpoint_finish != nullptr)
       taskpoint_finish->SetFaiFinishHeight(start_state.altitude - 1000);
   }
 

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -136,6 +136,15 @@ OrderedTask::UpdateStatsGeometry() noexcept
 }
 
 void
+OrderedTask::SetPilotEventWindowSnapshot(const TimeSpan &span) noexcept
+{
+  pilot_event_window_snapshot = span;
+
+  if (taskpoint_start != nullptr)
+    taskpoint_start->SetPilotEventWindowSnapshot(span);
+}
+
+void
 OrderedTask::UpdateGeometry() noexcept
 {
   UpdateStatsGeometry();
@@ -532,8 +541,8 @@ OrderedTask::CheckTransitions(const AircraftState &state,
     assert(start_state.HasTime());
     stats.start.SetStarted(
         start_state,
-        pilot_pev_window_snapshot.IsDefined() ? &pilot_pev_window_snapshot
-                                             : nullptr);
+        pilot_event_window_snapshot.IsDefined() ? &pilot_event_window_snapshot
+                                                : nullptr);
 
     if (taskpoint_finish != nullptr)
       taskpoint_finish->SetFaiFinishHeight(start_state.altitude - 1000);
@@ -1150,6 +1159,30 @@ OrderedTask::TaskStarted(bool soft) const noexcept
   }
 
   return false;
+}
+
+bool
+OrderedTask::StartPolish(const AircraftState &state) noexcept
+{
+  if (task_points.size() < 2 || taskpoint_start == nullptr ||
+      !taskpoint_start->IsPolishStart())
+    return false;
+
+  if (TaskStarted() || !taskpoint_start->StartPolish(state))
+    return false;
+
+  stats.start.SetStarted(state);
+
+  SetActiveTaskPoint(1);
+  taskpoint_start->ScanActive(*task_points[active_task_point]);
+
+  if (task_events != nullptr) {
+    task_events->TaskStart();
+    task_events->ActiveAdvanced(*task_points[active_task_point],
+                                (int)active_task_point);
+  }
+
+  return true;
 }
 
 /**

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -548,7 +548,8 @@ OrderedTask::CheckTransitions(const AircraftState &state,
       taskpoint_finish->SetStartAltitude(start_state.altitude);
 
     if (taskpoint_finish != nullptr)
-      taskpoint_finish->SetFaiFinishHeight(start_state.altitude - 1000);
+      taskpoint_finish->SetFaiFinishHeight(
+        start_state.altitude - FAI_FINISH_HEIGHT_LOSS);
   }
 
   if (task_events != nullptr) {

--- a/src/Engine/Task/Ordered/OrderedTask.hpp
+++ b/src/Engine/Task/Ordered/OrderedTask.hpp
@@ -76,8 +76,8 @@ private:
 
   StaticString<64> name;
 
-  /** Snapshot from #TaskManager for PEV offset at start recording. */
-  TimeSpan pilot_pev_window_snapshot{TimeSpan::Invalid()};
+  /** Snapshot from #TaskManager for pilot-event offset at start recording. */
+  TimeSpan pilot_event_window_snapshot{TimeSpan::Invalid()};
 
 public:
   /**
@@ -94,12 +94,17 @@ public:
   ~OrderedTask() noexcept;
 
   /**
-   * Copy the current PEV window from #CommonStats before each
+   * Copy the current pilot-event window from #CommonStats before each
    * #Update(); used when recording start offset at crossing.
    */
-  void SetPilotPevWindowSnapshot(const TimeSpan &span) noexcept {
-    pilot_pev_window_snapshot = span;
-  }
+  void SetPilotEventWindowSnapshot(const TimeSpan &span) noexcept;
+
+  /**
+   * Start a Polish task from the current aircraft location.
+   *
+   * @return True if the task was started successfully.
+   */
+  bool StartPolish(const AircraftState &state) noexcept;
 
   /**
    * Accessor for factory system for constructing tasks

--- a/src/Engine/Task/Ordered/Points/FinishPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/FinishPoint.cpp
@@ -29,6 +29,7 @@ FinishPoint::Reset() noexcept
 {
   OrderedTaskPoint::Reset();
   fai_finish_height = 0;
+  start_altitude.reset();
 }
 
 bool
@@ -44,6 +45,11 @@ FinishPoint::GetElevation() const noexcept
 
   if (constraints.fai_finish) {
     return std::max(nominal_elevation, fai_finish_height);
+  } else if (constraints.min_height != 0 &&
+             constraints.min_height_ref == AltitudeReference::START &&
+             start_altitude.has_value()) {
+    return std::max(nominal_elevation,
+                    *start_altitude - constraints.min_height);
   } else {
     return std::max(nominal_elevation,
                     constraints.min_height +
@@ -86,7 +92,7 @@ FinishPoint::IsInSector(const AircraftState &state) const noexcept
 bool
 FinishPoint::InInHeightLimit(const AircraftState &state) const
 {
-  if (!constraints.CheckHeight(state, GetBaseElevation()))
+  if (!constraints.CheckHeight(state, GetBaseElevation(), start_altitude))
     return false;
 
   if (constraints.fai_finish)

--- a/src/Engine/Task/Ordered/Points/FinishPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/FinishPoint.hpp
@@ -6,6 +6,8 @@
 #include "OrderedTaskPoint.hpp"
 #include "Task/Ordered/FinishConstraints.hpp"
 
+#include <optional>
+
 struct FinishConstraints;
 
 /**
@@ -27,6 +29,7 @@ class FinishPoint final : public OrderedTaskPoint
   FinishConstraints constraints;
 
   double fai_finish_height = 0;
+  std::optional<double> start_altitude;
 
 public:
   /**
@@ -51,6 +54,11 @@ public:
    * @param height FAI finish height (m)
    */
   void SetFaiFinishHeight(double height);
+
+  /** Set the altitude at which the task was started. */
+  void SetStartAltitude(double altitude) noexcept {
+    start_altitude = altitude;
+  }
 
   /* virtual methods from class TaskPoint */
   double GetElevation() const noexcept override;

--- a/src/Engine/Task/Ordered/Points/OrderedTaskPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/OrderedTaskPoint.hpp
@@ -8,6 +8,7 @@
 #include "Task/Points/ScoredTaskPoint.hpp"
 #include "Task/ObservationZones/ObservationZoneClient.hpp"
 #include "Geo/Flat/FlatBoundingBox.hpp"
+#include "time/RoughTime.hpp"
 
 #include <memory>
 
@@ -105,6 +106,7 @@ public:
 
   virtual void SetTaskBehaviour([[maybe_unused]] const TaskBehaviour &tb) noexcept {}
   virtual void SetOrderedTaskSettings([[maybe_unused]] const OrderedTaskSettings &otb) noexcept {}
+  virtual void SetPilotEventWindowSnapshot([[maybe_unused]] const TimeSpan &span) noexcept {}
 
   /**
    * Set previous/next task points.

--- a/src/Engine/Task/Ordered/Points/StartPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.cpp
@@ -41,11 +41,124 @@ StartPoint::SetOrderedTaskSettings(const OrderedTaskSettings &settings) noexcept
 }
 
 void
+StartPoint::SetPilotEventWindowSnapshot(const TimeSpan &span) noexcept
+{
+  pilot_event_window_snapshot = span;
+}
+
+void
+StartPoint::Reset() noexcept
+{
+  ScoredTaskPoint::Reset();
+  pilot_event_window_snapshot = TimeSpan::Invalid();
+  polish_start_state.Reset();
+}
+
+bool
+StartPoint::StartPolish(const AircraftState &state) noexcept
+{
+  if (!IsPolishStart() || polish_start_state.HasTime() ||
+      !state.HasTime() || !state.location.IsValid() || !state.flying)
+    return false;
+
+  if (!IsInSector(state) ||
+      !constraints.CheckSpeed(state.ground_speed, &margins))
+    return false;
+
+  polish_start_state = state;
+  return true;
+}
+
+void
 StartPoint::SetNeighbours(OrderedTaskPoint *_prev, OrderedTaskPoint *_next) noexcept
 {
   assert(_prev==NULL);
   // should not ever have an inbound leg
   OrderedTaskPoint::SetNeighbours(_prev, _next);
+}
+
+bool
+StartPoint::HasEntered() const noexcept
+{
+  return polish_start_state.HasTime() || ScoredTaskPoint::HasEntered();
+}
+
+const AircraftState &
+StartPoint::GetEnteredState() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state
+    : ScoredTaskPoint::GetEnteredState();
+}
+
+bool
+StartPoint::HasExited() const noexcept
+{
+  return polish_start_state.HasTime() || ScoredTaskPoint::HasExited();
+}
+
+const AircraftState &
+StartPoint::GetExitedState() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state
+    : ScoredTaskPoint::GetExitedState();
+}
+
+const AircraftState &
+StartPoint::GetScoredState() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state
+    : ScoredTaskPoint::GetScoredState();
+}
+
+const GeoPoint &
+StartPoint::GetLocationRemaining() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : ScoredTaskPoint::GetLocationRemaining();
+}
+
+const GeoPoint &
+StartPoint::GetLocationScored() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : ScoredTaskPoint::GetLocationScored();
+}
+
+const GeoPoint &
+StartPoint::GetLocationTravelled() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : ScoredTaskPoint::GetLocationTravelled();
+}
+
+const GeoPoint &
+StartPoint::GetLocationMaxTotal() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : SampledTaskPoint::GetLocationMaxTotal();
+}
+
+const GeoPoint &
+StartPoint::GetLocationMax() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : SampledTaskPoint::GetLocationMax();
+}
+
+const GeoPoint &
+StartPoint::GetLocationMin() const noexcept
+{
+  return polish_start_state.HasTime()
+    ? polish_start_state.location
+    : SampledTaskPoint::GetLocationMin();
 }
 
 
@@ -92,11 +205,22 @@ bool
 StartPoint::CheckExitTransition(const AircraftState &ref_now,
                                 const AircraftState &ref_last) const noexcept
 {
-  if (!constraints.open_time_span.HasBegun(FineTime{ref_last.time}))
+  if (constraints.start_mode == StartMode::POLISH)
+    return false;
+
+  const TimeSpan *start_window = &constraints.open_time_span;
+  if (constraints.start_mode == StartMode::PEV) {
+    if (!pilot_event_window_snapshot.IsDefined())
+      return false;
+
+    start_window = &pilot_event_window_snapshot;
+  }
+
+  if (!start_window->HasBegun(FineTime{ref_last.time}))
     /* the start gate is not yet open when we left the OZ */
     return false;
 
-  if (constraints.open_time_span.HasEnded(FineTime{ref_now.time}))
+  if (start_window->HasEnded(FineTime{ref_now.time}))
     /* the start gate was already closed when we left the OZ */
     return false;
 

--- a/src/Engine/Task/Ordered/Points/StartPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.cpp
@@ -62,7 +62,8 @@ StartPoint::StartPolish(const AircraftState &state) noexcept
     return false;
 
   if (!IsInSector(state) ||
-      !constraints.CheckSpeed(state.ground_speed, &margins))
+      !constraints.CheckSpeed(state.ground_speed, &margins) ||
+      !constraints.open_time_span.IsInside(FineTime{state.time}))
     return false;
 
   polish_start_state = state;

--- a/src/Engine/Task/Ordered/Points/StartPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "OrderedTaskPoint.hpp"
+#include "Navigation/Aircraft.hpp"
 #include "Task/TaskBehaviour.hpp"
 #include "Task/Ordered/StartConstraints.hpp"
 
@@ -21,6 +22,8 @@ class StartPoint final : public OrderedTaskPoint {
   double safety_height;
 
   TaskStartMargins margins;
+  TimeSpan pilot_event_window_snapshot = TimeSpan::Invalid();
+  AircraftState polish_start_state;
 
   /**
    * A copy of OrderedTaskSettings::start_constraints, managed by
@@ -49,9 +52,15 @@ public:
     return constraints.require_arm;
   }
 
+  bool IsPolishStart() const noexcept {
+    return constraints.start_mode == StartMode::POLISH;
+  }
+
   bool GetScoreExit() const noexcept {
     return constraints.score_exit;
   }
+
+  bool StartPolish(const AircraftState &state) noexcept;
 
   /**
    * Search for the min point on the boundary from
@@ -69,12 +78,26 @@ public:
   double GetElevation() const noexcept override;
 
   /* virtual methods from class ScoredTaskPoint */
+  void Reset() noexcept override;
+  bool HasEntered() const noexcept override;
+  const AircraftState &GetEnteredState() const noexcept override;
+  bool HasExited() const noexcept override;
+  const AircraftState &GetExitedState() const noexcept override;
+  const AircraftState &GetScoredState() const noexcept override;
+  const GeoPoint &GetLocationScored() const noexcept override;
+  const GeoPoint &GetLocationTravelled() const noexcept override;
+
   bool CheckExitTransition(const AircraftState &ref_now,
                            const AircraftState &ref_last) const noexcept override;
 
   /* virtual methods from class OrderedTaskPoint */
+  const GeoPoint &GetLocationRemaining() const noexcept override;
+  const GeoPoint &GetLocationMaxTotal() const noexcept override;
+  const GeoPoint &GetLocationMax() const noexcept override;
+  const GeoPoint &GetLocationMin() const noexcept override;
   void SetTaskBehaviour(const TaskBehaviour &tb) noexcept override;
   void SetOrderedTaskSettings(const OrderedTaskSettings &s) noexcept override;
+  void SetPilotEventWindowSnapshot(const TimeSpan &span) noexcept override;
   void SetNeighbours(OrderedTaskPoint *prev,
                      OrderedTaskPoint *next) noexcept override;
   bool IsInSector(const AircraftState &ref) const noexcept override;

--- a/src/Engine/Task/Ordered/StartConstraints.cpp
+++ b/src/Engine/Task/Ordered/StartConstraints.cpp
@@ -15,6 +15,8 @@ StartConstraints::SetDefaults()
   require_arm = false;
   score_exit = true;
   fai_finish = false;
+  start_mode = StartMode::NORMAL;
+  pev_start_enabled = false;
   pev_start_wait_time = {};
   pev_start_window = {};
 }

--- a/src/Engine/Task/Ordered/StartConstraints.hpp
+++ b/src/Engine/Task/Ordered/StartConstraints.hpp
@@ -9,6 +9,13 @@
 struct AircraftState;
 struct TaskStartMargins;
 
+enum class StartMode : unsigned {
+  NORMAL,
+  FAI_START_FINISH,
+  PEV,
+  POLISH,
+};
+
 struct StartConstraints {
   /**
    * The time span during which a hard start gate is open.
@@ -43,6 +50,16 @@ struct StartConstraints {
    * the constraints defined in this class will be ignored.
    */
   bool fai_finish;
+
+  /**
+   * Selected start mode.
+   */
+  StartMode start_mode;
+
+  /**
+   * Pilot Event (PEV) start is enabled.
+   */
+  bool pev_start_enabled;
 
   /**
    * Wait duration after Pilot Event (PEV) and start gate open time.

--- a/src/Engine/Task/Points/SampledTaskPoint.hpp
+++ b/src/Engine/Task/Points/SampledTaskPoint.hpp
@@ -68,7 +68,7 @@ public:
    * @return Location of max distance node
    */
   [[gnu::pure]]
-  const GeoPoint &GetLocationMaxTotal() const noexcept {
+  virtual const GeoPoint &GetLocationMaxTotal() const noexcept {
     assert(search_max_total.IsValid());
 
     return search_max_total.GetLocation();
@@ -81,7 +81,7 @@ public:
    * @return Location of max distance node
    */
   [[gnu::pure]]
-  const GeoPoint &GetLocationMax() const noexcept {
+  virtual const GeoPoint &GetLocationMax() const noexcept {
     assert(search_max.IsValid());
 
     return search_max.GetLocation();
@@ -93,7 +93,7 @@ public:
    *
    * @return Location of minimum distance node
    */
-  const GeoPoint &GetLocationMin() const noexcept {
+  virtual const GeoPoint &GetLocationMin() const noexcept {
     assert(search_min.IsValid());
 
     return search_min.GetLocation();

--- a/src/Engine/Task/Points/ScoredTaskPoint.hpp
+++ b/src/Engine/Task/Points/ScoredTaskPoint.hpp
@@ -50,7 +50,7 @@ public:
    *
    * @return True if observation zone has been entered
    */
-  bool HasEntered() const noexcept {
+  virtual bool HasEntered() const noexcept {
     return entered_state.HasTime();
   }
 
@@ -59,7 +59,7 @@ public:
    *
    * @return State at entry, or null if never entered
    */
-  const AircraftState &GetEnteredState() const noexcept {
+  virtual const AircraftState &GetEnteredState() const noexcept {
     return entered_state;
   }
 
@@ -70,15 +70,15 @@ public:
    *
    * @return True if aircraft has exited the OZ
    */
-  bool HasExited() const noexcept {
+  virtual bool HasExited() const noexcept {
     return exited_state.HasTime();
   }
 
-  const AircraftState &GetExitedState() const noexcept {
+  virtual const AircraftState &GetExitedState() const noexcept {
     return exited_state;
   }
 
-  const AircraftState &GetScoredState() const noexcept {
+  virtual const AircraftState &GetScoredState() const noexcept {
     return HasExited() && ScoreLastExit()
       ? exited_state
       : entered_state;
@@ -111,14 +111,14 @@ public:
 
   /** Retrieve location to be used for the scored task. */
   [[gnu::pure]]
-  const GeoPoint &GetLocationScored() const noexcept;
+  virtual const GeoPoint &GetLocationScored() const noexcept;
 
   /**
    * Retrieve location to be used for the task already travelled.
    * This is always the scored best location for prior-active task points.
    */
   [[gnu::pure]]
-  const GeoPoint &GetLocationTravelled() const noexcept {
+  virtual const GeoPoint &GetLocationTravelled() const noexcept {
     return GetLocationMin();
   }
 

--- a/src/Engine/Task/Stats/CommonStats.cpp
+++ b/src/Engine/Task/Stats/CommonStats.cpp
@@ -4,7 +4,7 @@ void
 CommonStats::ResetTask() noexcept
 {
   start_open_time_span = TimeSpan::Invalid();
-  pev_start_time_span = TimeSpan::Invalid();
+  pilot_event_start_time_span = TimeSpan::Invalid();
   landable_reachable = false;
   TimeUnderStartMaxHeight = TimeStamp::Undefined();
   aat_time_remaining = {};

--- a/src/Engine/Task/Stats/CommonStats.hpp
+++ b/src/Engine/Task/Stats/CommonStats.hpp
@@ -27,13 +27,13 @@ public:
   TimeSpan start_open_time_span;
 
   /**
-   * The start window resulting from the last Pilot Event declared, based on
+   * The start window resulting from the last Pilot Event (PEV) declared, based on
    * the task settings #StartConstraints::pev_start_wait_time and
    * #StartConstraints::pev_start_window.
-   * If defined, it defines a soft start window, which is informative
-   * to the pilot only and will not be enforced in any way.
+   * If defined, it is used by the task engine for start timing when the
+   * selected start mode enables PEV timing, and it is also exposed to the UI.
    */
-  TimeSpan pev_start_time_span;
+  TimeSpan pilot_event_start_time_span;
 
   /** Whether the task found landable reachable waypoints (aliases abort) */
   bool landable_reachable;

--- a/src/Engine/Task/Stats/StartStats.hpp
+++ b/src/Engine/Task/Stats/StartStats.hpp
@@ -33,12 +33,12 @@ struct StartStats {
   double ground_speed;
 
   /**
-   * True when #pev_offset_seconds records start time minus PEV window
-   * start (#CommonStats::pev_start_time_span) at the crossing.
+   * True when #pev_offset_seconds records start time minus pilot-event
+   * window start (#CommonStats::pilot_event_start_time_span) at the crossing.
    */
   bool pev_offset_available;
 
-  /** Seconds from PEV window start to actual start; only if
+  /** Seconds from pilot-event window start to actual start; only if
    * #pev_offset_available. */
   int pev_offset_seconds;
 
@@ -56,7 +56,7 @@ struct StartStats {
    * Enable the #HasStarted() flag and copy data from the
    * #AircraftState.
    *
-   * @param pev_span optional PEV window snapshot; if defined with a
+   * @param pev_span optional pilot-event window snapshot; if defined with a
    * valid start, #pev_offset_seconds records start time minus that
    * start.
    */

--- a/src/Engine/Task/TaskManager.cpp
+++ b/src/Engine/Task/TaskManager.cpp
@@ -263,7 +263,7 @@ TaskManager::Update(const AircraftState &state,
     Reset();
 
   if (ordered_task->TaskSize() > 1) {
-    ordered_task->SetPilotPevWindowSnapshot(common_stats.pev_start_time_span);
+    ordered_task->SetPilotEventWindowSnapshot(common_stats.pilot_event_start_time_span);
     // always update ordered task
     retval |= ordered_task->Update(state, state_last, glide_polar);
   }
@@ -560,7 +560,17 @@ TaskManager::ResetTask() noexcept
 }
 
 void
-TaskManager::SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept
+TaskManager::SetPilotEventStartTimeSpan(const TimeSpan &open_time_span) noexcept
 {
-  common_stats.pev_start_time_span = open_time_span;
+  common_stats.pilot_event_start_time_span = open_time_span;
+}
+
+bool
+TaskManager::StartPolish(const AircraftState &state) noexcept
+{
+  if (!ordered_task->StartPolish(state))
+    return false;
+
+  SetMode(TaskType::ORDERED);
+  return true;
 }

--- a/src/Engine/Task/TaskManager.hpp
+++ b/src/Engine/Task/TaskManager.hpp
@@ -24,6 +24,7 @@ class AlternateTask;
 class AlternateList;
 class TaskWaypoint;
 class AbortIntersectionTest;
+struct AircraftState;
 struct RangeAndRadial;
 
 /**
@@ -424,10 +425,11 @@ public:
   void ResetTask() noexcept;
 
   /**
-   * Sets the PEV start time span.
-   * To be called when PEV has been pressed.
+   * Sets the Pilot Event (PEV) start time span.
+   * To be called when Pilot Event (PEV) has been pressed.
    */
-  void SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept;
+  void SetPilotEventStartTimeSpan(const TimeSpan &open_time_span) noexcept;
+  bool StartPolish(const AircraftState &state) noexcept;
 
   /**
    * Update speed-to-fly and risk MC from the current polar.

--- a/src/Formatter/AirspaceUserUnitsFormatter.cpp
+++ b/src/Formatter/AirspaceUserUnitsFormatter.cpp
@@ -42,6 +42,11 @@ AirspaceFormatter::FormatAltitudeShort(char *buffer,
       StringFormatUnsafe(buffer, "%d",
                          iround(Units::ToUserAltitude(altitude.altitude)));
     break;
+
+  case AltitudeReference::START:
+    /* Not applicable to airspace altitudes. */
+    strcpy(buffer, "START");
+    break;
   }
 }
 

--- a/src/Geo/AltitudeReference.hpp
+++ b/src/Geo/AltitudeReference.hpp
@@ -30,4 +30,9 @@ enum class AltitudeReference : uint8_t {
    * This is used for flight levels (FL).
    */
   STD,
+
+  /**
+   * Altitude is measured relative to the task start altitude.
+   */
+  START,
 };

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -926,7 +926,7 @@ static constexpr MetaData meta_data[] = {
     N_("Start open"),
     N_("Signed countdown until the start gate opens or closes (now). "
        "Value colour and secondary line reflect gate state at the current "
-       "time: Waiting (blue), Open (green), Closed (red). PEV window overrides "
+       "time: Waiting (blue), Open (green), Closed (red). Pilot Event (PEV) window overrides "
        "task gate when set."),
     IBFHelper<InfoBoxContentStartOpen>::Create,
   },

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -1003,11 +1003,13 @@ UpdateStartOpenInfobox(InfoBoxData &data, const TimeStamp &projected_start_time_
   const CommonStats &common_stats = CommonInterface::Calculated().common_stats;
 
   const TimeSpan &task_open_span = common_stats.start_open_time_span;
-  const TimeSpan &pev_open_span = common_stats.pev_start_time_span;
+  const TimeSpan &pilot_event_open_span =
+    common_stats.pilot_event_start_time_span;
 
-  // give priority to PEV window
-  const bool have_pev_start = pev_open_span.IsDefined();
-  const TimeSpan &eff_start_window = have_pev_start ? pev_open_span : task_open_span;
+  // give priority to the Pilot Event (PEV) window
+  const bool have_pilot_event_start = pilot_event_open_span.IsDefined();
+  const TimeSpan &eff_start_window =
+    have_pilot_event_start ? pilot_event_open_span : task_open_span;
 
   /* reset color that may have been set by a previous call */
   data.SetValueColor(0);

--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -147,6 +147,12 @@ InputEvents::UpdatePan() noexcept
 }
 
 void
+InputEvents::UpdateMenu() noexcept
+{
+  drawButtons(getModeID(), true);
+}
+
+void
 InputEvents::SetFlavour(const char *_flavour) noexcept
 {
   if (flavour == NULL && _flavour == NULL)

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -54,6 +54,12 @@ void
 UpdatePan() noexcept;
 
 /**
+ * Update dynamic items in the current menu.
+ */
+void
+UpdateMenu() noexcept;
+
+/**
  * Set the "flavour" of the current mode.  It is an optional string
  * that gets appended to the current mode name, separated with a
  * dot, to build a new "overlay" mode.  This may be used to replace

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -71,6 +71,8 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Simulator.hpp"
 #include "Formatter/TimeFormatter.hpp"
+#include "Engine/Navigation/Aircraft.hpp"
+#include "NMEA/Aircraft.hpp"
 #include "Operation/MessageOperationEnvironment.hpp"
 #include "Device/MultipleDevices.hpp"
 #include "Form/DataField/File.hpp"
@@ -200,28 +202,39 @@ InputEvents::eventMarkLocation(const char *misc)
 void
 InputEvents::eventPilotEvent([[maybe_unused]] const char *misc)
 try {
-  // Configure start window
+  const auto &basic = CommonInterface::Basic();
+  const auto &calculated = CommonInterface::Calculated();
+  const AircraftState aircraft = ToAircraftState(basic, calculated);
+
   const OrderedTaskSettings &ots =
     backend_components->protected_task_manager->GetOrderedTaskSettings();
   const StartConstraints &constraints = ots.start_constraints;
 
-  const auto now = CommonInterface::Basic().time;
+  if (!constraints.pev_start_enabled)
+    return;
 
-  // Note: pev_start_wait_time == 0 means window starts right away
-  TimeStamp new_start_ts( now.ToDuration() + constraints.pev_start_wait_time );
-  FineTime new_start(new_start_ts);
+  if (constraints.start_mode == StartMode::POLISH) {
+    backend_components->protected_task_manager->StartPolish(aircraft);
+  } else {
+    // Configure start window
+    const auto now = basic.time;
 
-  FineTime new_end = (constraints.pev_start_window.count() > 0) ?
-                     FineTime(new_start_ts + constraints.pev_start_window) :
-                     FineTime::Invalid();
+    // Note: pev_start_wait_time == 0 means window starts right away
+    TimeStamp new_start_ts( now.ToDuration() + constraints.pev_start_wait_time );
+    FineTime new_start(new_start_ts);
 
-  const TimeSpan ts = TimeSpan(new_start, new_end);
+    FineTime new_end = (constraints.pev_start_window.count() > 0) ?
+                       FineTime(new_start_ts + constraints.pev_start_window) :
+                       FineTime::Invalid();
 
-  backend_components->protected_task_manager->SetPevStartTimeSpan(ts);
+    const TimeSpan ts = TimeSpan(new_start, new_end);
+
+    backend_components->protected_task_manager->SetPilotEventStartTimeSpan(ts);
+  }
 
   // Log pilot event
   if (backend_components->igc_logger)
-    backend_components->igc_logger->LogPilotEvent(CommonInterface::Basic());
+    backend_components->igc_logger->LogPilotEvent(basic);
 
   // Let devices know the pilot event was pressed
   if (backend_components->devices) {

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -18,6 +18,9 @@
 #include "Task/ProtectedTaskManager.hpp"
 #include "Engine/Task/TaskManager.hpp"
 #include "Engine/Task/Ordered/OrderedTask.hpp"
+#include "Engine/Task/Ordered/Points/StartPoint.hpp"
+#include "Engine/Navigation/Aircraft.hpp"
+#include "NMEA/Aircraft.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
 #include "Device/MultipleDevices.hpp"
 #include "PageActions.hpp"
@@ -150,6 +153,37 @@ ExpandTaskMacros(std::string_view name,
         return _("Disarm turn");
       }
     }
+  }
+
+  if (name == "PilotEventAnnounce") {
+    if (task == nullptr || common_stats.task_type != TaskType::ORDERED ||
+        !task_stats.task_valid)
+      return nullptr;
+
+    const auto &ordered_task = task_manager->GetOrderedTask();
+    if (ordered_task.TaskSize() == 0)
+      return nullptr;
+
+    const auto &start = (const StartPoint &)ordered_task.GetTaskPoint(0);
+    const auto &constraints =
+      ordered_task.GetOrderedTaskSettings().start_constraints;
+    if (!constraints.pev_start_enabled || ordered_task.TaskStarted())
+      return nullptr;
+
+    const AircraftState aircraft =
+      ToAircraftState(CommonInterface::Basic(), CommonInterface::Calculated());
+    bool can_announce;
+    if (constraints.start_mode == StartMode::POLISH) {
+      can_announce = start.IsInSector(aircraft) &&
+        constraints.open_time_span.IsInside(FineTime{aircraft.time});
+    } else {
+      const TimeStamp start_time(aircraft.time.ToDuration() +
+                                 constraints.pev_start_wait_time);
+      can_announce = constraints.open_time_span.IsInside(FineTime{start_time});
+    }
+
+    invalid |= !can_announce;
+    return _("Pilot Event Announce");
   }
 
   if (name == "AdvanceArmed") {

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -252,6 +252,8 @@ Deserialise(OrderedTaskSettings &data, const ConstDataNode &node)
                     data.start_constraints.require_arm);
   node.GetAttribute("start_score_exit",
                     data.start_constraints.score_exit);
+  node.GetAttribute("pev_start_enabled",
+                    data.start_constraints.pev_start_enabled);
   node.GetAttribute("start_max_speed", data.start_constraints.max_speed);
   node.GetAttribute("start_max_height", data.start_constraints.max_height);
   GetHeightRef(node, "start_max_height_ref",
@@ -270,6 +272,15 @@ Deserialise(OrderedTaskSettings &data, const ConstDataNode &node)
                     data.start_constraints.pev_start_wait_time);
   node.GetAttribute("pev_start_window",
                     data.start_constraints.pev_start_window);
+  unsigned start_mode = (unsigned)StartMode::NORMAL;
+  if (node.GetAttribute("start_mode", start_mode))
+    data.start_constraints.start_mode = (StartMode)start_mode;
+  else if (data.finish_constraints.fai_finish)
+    data.start_constraints.start_mode = StartMode::FAI_START_FINISH;
+  else if (data.start_constraints.pev_start_enabled)
+    data.start_constraints.start_mode = StartMode::PEV;
+  else
+    data.start_constraints.start_mode = StartMode::NORMAL;
 
 }
 

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -238,6 +238,8 @@ GetHeightRef(const ConstDataNode &node, const char *nodename,
   }
   if (StringIsEqual(type, "MSL")) {
     value = AltitudeReference::MSL;
+  } else if (StringIsEqual(type, "START")) {
+    value = AltitudeReference::START;
   } else {
     value = AltitudeReference::AGL;
   }

--- a/src/Task/ProtectedTaskManager.cpp
+++ b/src/Task/ProtectedTaskManager.cpp
@@ -37,10 +37,17 @@ ProtectedTaskManager::SetDensityRatio(const double dr) noexcept
 }
 
 void
-ProtectedTaskManager::SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept
+ProtectedTaskManager::SetPilotEventStartTimeSpan(const TimeSpan &open_time_span) noexcept
 {
   ExclusiveLease lease(*this);
-  lease->SetPevStartTimeSpan(open_time_span);
+  lease->SetPilotEventStartTimeSpan(open_time_span);
+}
+
+bool
+ProtectedTaskManager::StartPolish(const AircraftState &state) noexcept
+{
+  ExclusiveLease lease(*this);
+  return lease->StartPolish(state);
 }
 
 const OrderedTaskSettings

--- a/src/Task/ProtectedTaskManager.hpp
+++ b/src/Task/ProtectedTaskManager.hpp
@@ -13,6 +13,7 @@
 struct AGeoPoint;
 struct TaskBehaviour;
 struct OrderedTaskSettings;
+struct AircraftState;
 class Path;
 class GlidePolar;
 class ProtectedRoutePlanner;
@@ -53,7 +54,8 @@ public:
   [[gnu::pure]]
   const OrderedTaskSettings GetOrderedTaskSettings() const noexcept;
 
-  void SetPevStartTimeSpan(const TimeSpan &open_time_span) noexcept;
+  void SetPilotEventStartTimeSpan(const TimeSpan &open_time_span) noexcept;
+  bool StartPolish(const AircraftState &state) noexcept;
 
   [[gnu::pure]]
   WaypointPtr GetActiveWaypoint() const noexcept;

--- a/src/Task/Serialiser.cpp
+++ b/src/Task/Serialiser.cpp
@@ -249,6 +249,10 @@ Serialise(WritableDataNode &node, const OrderedTaskSettings &data)
                     data.start_constraints.require_arm);
   node.SetAttribute("start_score_exit",
                     data.start_constraints.score_exit);
+  node.SetAttribute("start_mode",
+                    (unsigned)data.start_constraints.start_mode);
+  node.SetAttribute("pev_start_enabled",
+                    data.start_constraints.pev_start_enabled);
   node.SetAttribute("start_max_speed", data.start_constraints.max_speed);
   node.SetAttribute("start_max_height", data.start_constraints.max_height);
   node.SetAttribute("start_max_height_ref",

--- a/src/Task/Serialiser.cpp
+++ b/src/Task/Serialiser.cpp
@@ -203,7 +203,8 @@ GetHeightRef(AltitudeReference height_ref)
     return ("AGL");
   case AltitudeReference::MSL:
     return ("MSL");
-
+  case AltitudeReference::START:
+    return ("START");
   case AltitudeReference::STD:
     /* not applicable here */
     break;


### PR DESCRIPTION
Fixes #2389.

DRAFT.

Initial preview of work to enable clearer separation of start types, including support for Polish start.

* Splits out the "start" type selection into a separate dropdown in the task options. Selecting the task start type disables or enables various options surrounding the tasks. E.g. selecting FAI start/finish means only FAI waypoints are supported, Polish or PEV start shows PEV button but not Arm task button and so on.

* Adds support for Polish start: A start method where the start location can be anywhere within an observation zone, and the task is scored from that location.


I'm currently not entirely happy with the UX surrounding Polish start, it needs clearer markings on where the task was started from, update of navigation lines drawn and so on.

I also need to add substantial amount of help text.

<img width="544" height="495" alt="image" src="https://github.com/user-attachments/assets/48a54735-0575-4950-91e0-44ffdd77a911" />


<img width="539" height="661" alt="image" src="https://github.com/user-attachments/assets/ab337d64-693e-4004-907f-1594a6780579" />

This is currently not ready for merging.

---

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified task start-mode selector for Normal, FAI, Pilot Event (PEV), and Polish starts.
  * Added Polish task-start support based on current flight conditions.
  * PEV start settings are now saved and restored with task configuration.
  * Updated navigation shortcuts for Calculator/Task Manager and Pilot Event actions.

* **Improvements**
  * PEV timing descriptions and Start Open information now use clearer terminology.
  * PEV controls appear only when the PEV start mode is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->