### PR TITLE
Ragged text halo on high-DPI screens

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -70,6 +70,7 @@ Version 7.45 - not yet released
   - fix fluctuating hill-shading strength #2262
   - fix intermittent white-map hang on startup for non-OpenGL builds
     when drawing began before map bounds were ready #2734
+  - fix the ragged white halo behind map labels on high-DPI screens
 * weather
   - remember overlay layer/time (or level/altitude) per weather map
     page, with a map-bottom cursor bar, Weather Setup, and Forecast

--- a/src/Renderer/TextInBox.cpp
+++ b/src/Renderer/TextInBox.cpp
@@ -5,10 +5,13 @@
 #include "LabelBlock.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Pen.hpp"
+#include "Math/Angle.hpp"
 #include "Screen/Layout.hpp"
 #include "util/UTF8.hpp"
 
 #include <algorithm>
+
+#include <math.h>
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
@@ -56,19 +59,43 @@ TextInBoxMoveInView(PixelRect &rc, const PixelRect &map_rc) noexcept
   return offset;
 }
 
+/**
+ * Stamp the text along a circle of the given radius, one stamp per
+ * ~1.5px of circumference so consecutive stamps always overlap.  The
+ * four diagonal copies this used to be only close up while the offset
+ * is 1px; beyond that they leave gaps along every stroke, which is
+ * what high-DPI screens hit (offset 5 on a 3x iPhone).
+ */
+static void
+DrawTextHalo(Canvas &canvas, const char *text, const PixelPoint p,
+             const unsigned offset) noexcept
+{
+  /* 8 is the full neighbourhood of a 1px halo, 16 caps the cost */
+  const unsigned n = std::clamp(4 * offset, 8u, 16u);
+
+  for (unsigned i = 0; i < n; ++i) {
+    const auto [sin, cos] =
+      (Angle::FullCircle() * ((double)i / n)).SinCos();
+    canvas.DrawText({p.x + (int)lround(cos * offset),
+                     p.y + (int)lround(sin * offset)},
+                    text);
+  }
+}
+
 void
 RenderShadowedText(Canvas &canvas, const char *text,
                    PixelPoint p,
                    bool inverted) noexcept
 {
+  if (text == nullptr || text[0] == '\0')
+    return;
+
   canvas.SetBackgroundTransparent();
 
   canvas.SetTextColor(inverted ? COLOR_BLACK : COLOR_WHITE);
-  const int offset = canvas.GetFontHeight() / 12u;
-  canvas.DrawText({p.x + offset, p.y + offset}, text);
-  canvas.DrawText({p.x - offset, p.y + offset}, text);
-  canvas.DrawText({p.x + offset, p.y - offset}, text);
-  canvas.DrawText({p.x - offset, p.y - offset}, text);
+
+  /* at least 1px, or tiny fonts get no halo at all */
+  DrawTextHalo(canvas, text, p, std::max(1u, canvas.GetFontHeight() / 12u));
 
   canvas.SetTextColor(inverted ? COLOR_WHITE : COLOR_BLACK);
   canvas.DrawText(p, text);


### PR DESCRIPTION
`RenderShadowedText` fakes the halo behind map labels with four diagonal copies at plus/minus offset, where offset is the font height divided by 12. Those only close up at offset 1. iOS reports the screen scale times 160 as dpi, so a 3x iPhone gets offset 5 against stems of about 6px, and the halo breaks into displaced ghosts with gaps along every stroke.

Affects the map scale and PAN overlay, FLARM labels, outlined waypoint labels, the wind arrow label and the distance rings.

Fix: stamp the text along a circle of radius offset, one stamp per roughly 1.5px of circumference, 8 to 16 stamps. Patch attached.

Before:

<img width="540" height="265" alt="pan-before" src="https://github.com/user-attachments/assets/ace17682-524d-449e-bc76-db2b38df929e" />

After:

<img width="545" height="250" alt="pan-after" src="https://github.com/user-attachments/assets/7d3d8f03-faaa-458e-925f-0d449609584b" />

NEWS.txt entry is completely wrong due to the recent release. I am waiting for the new entries so I can rebase cleanly onto the version you want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ragged white halos appearing behind map labels on high-DPI screens.
  * Improved text halo rendering for smoother, more consistent label outlines.
  * Ensured labels retain a visible halo even when using very small shadow sizes.
  * Prevented unnecessary halo rendering for empty labels.

* **Documentation**
  * Added a release-note entry documenting the high-DPI map label halo fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->