### PR TITLE
Engine/GlideSolvers/GlidePolar: Do not scale MacCready in UpdateBestLD

### DIFF
--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -224,8 +224,13 @@ GlidePolar::UpdateBestLD() noexcept
   assert(polar.IsValid());
   assert(mc >= 0);
 
-  const double vbld_ias = sqrt((polar.c + mc) / polar.a);
-  VbestLD = std::clamp(vbld_ias * density_ratio, Vmin, Vmax);
+  /* density-scaled polar: w'(v) = (a/DR) v^2 + b v + c DR; the
+     MacCready setting is a true vertical speed and must not be
+     scaled, so the optimum is sqrt((c DR + mc) DR / a) -- consistent
+     with GlidePolarSpeedToFly and GetBestGlideRatioSpeed() */
+  const double vbld = sqrt((polar.c * density_ratio + mc) *
+                           density_ratio / polar.a);
+  VbestLD = std::clamp(vbld, Vmin, Vmax);
   SbestLD = SinkRate(VbestLD);
   bestLD = VbestLD / SbestLD;
 #endif

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -5,6 +5,7 @@
 #include "GlideSolvers/GlidePolar.hpp"
 #include "Units/System.hpp"
 
+#include <cmath>
 #include <cstdio>
 
 class GlidePolarTest
@@ -21,6 +22,7 @@ private:
   void TestBugs();
   void TestMC();
   void TestDensityRatio();
+  void TestDensityRatioMC();
 };
 
 void
@@ -186,6 +188,43 @@ GlidePolarTest::TestDensityRatio()
 }
 
 void
+GlidePolarTest::TestDensityRatioMC()
+{
+  /* With MC > 0 the MacCready setting is a true vertical speed and
+     must not be scaled with the polar: VBestLD has to agree with the
+     analytic ground-polar solution and with the STF solver. */
+  const double dr = 1.1;
+
+  for (const double mc : {0.5, 1.0, 2.0}) {
+    polar.SetDensityRatio(1.0);
+    polar.SetMC(mc);
+    const double vbld_sl = polar.GetVBestLD();
+
+    polar.SetDensityRatio(dr);
+
+    // analytic optimum of w'(v) = (a/DR) v^2 + b v + c DR plus mc
+    const double expected =
+      sqrt((polar.polar.c * dr + mc) * dr / polar.polar.a);
+    ok1(equals(polar.GetVBestLD(), expected));
+
+    // consistent with GetBestGlideRatioSpeed() (no wind)
+    ok1(equals(polar.GetVBestLD(), polar.GetBestGlideRatioSpeed(0)));
+
+    // consistent with the STF solver (no netto, no wind)
+    ok1(equals(polar.GetVBestLD(), polar.SpeedToFly(0, 0), 1000));
+
+    // slower than naive scaling of the sea-level value
+    ok1(polar.GetVBestLD() < vbld_sl * dr);
+
+    // SinkRate at VBestLD is still SBestLD
+    ok1(equals(polar.SinkRate(polar.GetVBestLD()), polar.GetSBestLD()));
+  }
+
+  polar.SetDensityRatio(1.0);
+  polar.SetMC(0);
+}
+
+void
 GlidePolarTest::Run()
 {
   Init();
@@ -194,11 +233,12 @@ GlidePolarTest::Run()
   TestBugs();
   TestMC();
   TestDensityRatio();
+  TestDensityRatioMC();
 }
 
 int main()
 {
-  plan_tests(54);
+  plan_tests(69);
 
   GlidePolarTest test;
   test.Run();


### PR DESCRIPTION
## Summary
- `GlidePolar::UpdateBestLD()` computed `sqrt((c + mc) / a) * DR`, i.e. it scaled the MacCready setting together with the density-scaled polar. MC is a true vertical speed, and both the STF solver (`MSinkRate = SinkRate(V) + mc`) and `GetBestGlideRatioSpeed()` (`a' = a/DR, c' = c*DR`) treat it as such, so `VBestLD`/`SBestLD`/`bestLD` disagreed with the commanded speed-to-fly at altitude for MC > 0 (e.g. ~1400 m, MC 2 m/s: 181.4 km/h vs 178.0 km/h).
- Use the optimum of the density-scaled polar, `sqrt((c*DR + mc)*DR / a)`; unchanged for `mc == 0` or `DR == 1`.
- Add `TestDensityRatioMC` to `TestGlidePolar` asserting `VBestLD` equals the analytic solution, `GetBestGlideRatioSpeed(0)` and `SpeedToFly(0, 0)` for MC 0.5/1/2 m/s at DR 1.1, and that `SinkRate(VBestLD) == SBestLD`.

Follow-up to #2586 / #1569. Not related to the MC 0 discrepancy in #2877.

No NEWS.txt entry: there is no "not yet released" section after the 7.45 release yet; happy to add one under `* glide computer` once the 7.46 cycle is opened.

Closes #2881

## Test plan
- [ ] `make TARGET=UNIX output/UNIX/bin/TestGlidePolar && ./output/UNIX/bin/TestGlidePolar` (69 tests) — I could not build locally (no toolchain on this machine); the new assertions were cross-checked numerically against the Hornet test polar (analytic, `GetBestGlideRatioSpeed` and a bounded minimiser agree to <1e-8 relative), please let CI confirm
- [ ] `make TARGET=UNIX check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved best-glide speed calculations across varying air-density conditions.
  * MacCready settings now remain consistent while glide speeds are adjusted for density.
  * Glide speeds continue to stay within valid operating limits.

* **Tests**
  * Added coverage for density-related MacCready, best-glide, and speed-to-fly calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->