### PR TITLE
iOS: Remove white 1px frame around full-screen dialogs

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -2,6 +2,10 @@ Version 7.46 - not yet released
 * android
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit
+* iOS
+  - remove the thin white frame around full-screen dialogs (such as
+    the Fly/Simulator screen), which no longer stop one pixel short of
+    the display edge
 * input
   - fix USB HID remotes (e.g. SteFly) that stop sending keys on
     OpenVario after the stick re-enumerates #2820
@@ -319,9 +323,6 @@ Version 7.45 - 2026-08-15
   - fix crash when the app restarts after the screen is torn down
   - fix spurious outline lines on high-DPI displays #1514
 * iOS
-  - remove the thin white frame around full-screen dialogs (such as
-    the Fly/Simulator screen), which no longer stop one pixel short of
-    the display edge
   - fix audio vario playback through the device speaker
   - disable the Core Location distance filter so built-in GPS is not
     suppressed while stationary #2380

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -319,6 +319,9 @@ Version 7.45 - 2026-08-15
   - fix crash when the app restarts after the screen is torn down
   - fix spurious outline lines on high-DPI displays #1514
 * iOS
+  - remove the thin white frame around full-screen dialogs (such as
+    the Fly/Simulator screen), which no longer stop one pixel short of
+    the display edge
   - fix audio vario playback through the device speaker
   - disable the Core Location distance filter so built-in GPS is not
     suppressed while stationary #2380

--- a/src/UtilsSystem.cpp
+++ b/src/UtilsSystem.cpp
@@ -27,6 +27,7 @@
 
 #if defined(__APPLE__) && TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#include <cmath>
 #endif
 
 #if !defined(ANDROID) && !defined(__APPLE__)
@@ -57,25 +58,33 @@ SystemWindowSize() noexcept
 #ifdef ANDROID
   return native_view->GetSize();
 #elif defined(__APPLE__) && TARGET_OS_IPHONE
+  /* Round the point size to the nearest pixel instead of truncating
+     it: nativeScale is not always a whole number, because some devices
+     render at a higher resolution and scale the result down, and the
+     zoomed display mode changes the ratio as well.  Truncating then
+     yields a window one pixel smaller than the OpenGL drawable, which
+     leaves an unpainted strip at the screen edge. */
+
   UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
-  
+
   // Check if window is null to prevent crashes
   if (!window) {
     // Fallback to main screen dimensions if no window is available
     CGRect screenBounds = [UIScreen mainScreen].bounds;
     CGFloat scale = [UIScreen mainScreen].nativeScale;
-    return PixelSize{(int)(screenBounds.size.width * scale), (int)(screenBounds.size.height * scale)};
+    return PixelSize{(int)std::lround(screenBounds.size.width * scale),
+                     (int)std::lround(screenBounds.size.height * scale)};
   }
-  
-  
+
+
   CGRect bounds = window.bounds;
   CGFloat scale = window.screen.nativeScale;
 
   CGFloat width = bounds.size.width;
   CGFloat height = bounds.size.height;
 
-  int pixelWidth = (int)(width * scale);
-  int pixelHeight = (int)(height * scale);
+  int pixelWidth = (int)std::lround(width * scale);
+  int pixelHeight = (int)std::lround(height * scale);
 
   return PixelSize{ pixelWidth, pixelHeight };
 #elif defined(__APPLE__) && !TARGET_OS_IPHONE

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -72,6 +72,7 @@ struct zxdg_toplevel_decoration_v1;
 
 #if defined(__APPLE__) && TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#include <cmath>
 #endif
 
 namespace UI {
@@ -412,20 +413,21 @@ public:
       return rc;
     }
 
-    // Get screen scale factor. We need to use nativeScale instead of scale
-    // to correctly account for downsampling on mini and Plus devices.
-    CGFloat scale = [UIScreen mainScreen].nativeScale;
+    /* Get the scale factor of the screen this window is on.  We need
+       nativeScale instead of scale to correctly account for
+       downsampling on mini and Plus devices; it is also the scale the
+       window size was derived from. */
+    const CGFloat scale = window.screen.nativeScale;
 
-    UIEdgeInsets insets = window.safeAreaInsets;
-    insets.top *= scale;
-    insets.left *= scale;
-    insets.bottom *= scale;
-    insets.right *= scale;
+    /* The safe area is expressed in points.  Round the scaled insets
+       instead of truncating them, which would bias them towards being
+       too small. */
+    const UIEdgeInsets insets = window.safeAreaInsets;
 
-    rc.left += static_cast<int>(insets.left);
-    rc.top += static_cast<int>(insets.top);
-    rc.right -= static_cast<int>(insets.right);
-    rc.bottom -= static_cast<int>(insets.bottom);
+    rc.left += (int)std::lround(insets.left * scale);
+    rc.top += (int)std::lround(insets.top * scale);
+    rc.right -= (int)std::lround(insets.right * scale);
+    rc.bottom -= (int)std::lround(insets.bottom * scale);
 
     return rc;
   }

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -397,35 +397,37 @@ public:
   [[gnu::pure]]
   const PixelRect GetClientRect() const noexcept override {
     assert(IsDefined());
-    
-    // Get screen bounds
-    CGRect screenBounds = [UIScreen mainScreen].bounds;
-    // Get screen scale factor. We need to use nativeScale instead of scale
-    // to correctly account for downsampling on mini and Plus devices.
-    CGFloat scale = [UIScreen mainScreen].nativeScale;
-    int width = (int)(screenBounds.size.width * scale);
-    int height = (int)(screenBounds.size.height * scale);
-    
+
+    /* Start from this window's real size (which was derived from the
+       OpenGL drawable) instead of computing the screen size from
+       UIScreen again: two independent conversions from points to
+       pixels can be rounded differently, and a client rect which is
+       one pixel smaller than the framebuffer makes full-screen dialogs
+       look non-maximised. */
+    PixelRect rc = ContainerWindow::GetClientRect();
+
     UIWindow *window = UIApplication.sharedApplication.windows.firstObject;
     if (window == nullptr) {
       // Fallback to full screen if window is not available
-      return PixelRect(0, 0, width, height);
+      return rc;
     }
-    
+
+    // Get screen scale factor. We need to use nativeScale instead of scale
+    // to correctly account for downsampling on mini and Plus devices.
+    CGFloat scale = [UIScreen mainScreen].nativeScale;
+
     UIEdgeInsets insets = window.safeAreaInsets;
     insets.top *= scale;
     insets.left *= scale;
     insets.bottom *= scale;
     insets.right *= scale;
 
-    PixelRect result(
-        static_cast<int>(insets.left),
-        static_cast<int>(insets.top),
-        static_cast<int>(width - insets.right),
-        static_cast<int>(height - insets.bottom)
-    );
+    rc.left += static_cast<int>(insets.left);
+    rc.top += static_cast<int>(insets.top);
+    rc.right -= static_cast<int>(insets.right);
+    rc.bottom -= static_cast<int>(insets.bottom);
 
-    return result;
+    return rc;
   }
 #endif
 

--- a/src/ui/window/custom/Window.cpp
+++ b/src/ui/window/custom/Window.cpp
@@ -47,9 +47,19 @@ Window::IsMaximised() const noexcept
 {
   assert(IsDefined());
 
-  return parent != nullptr &&
-    GetSize().width >= parent->GetSize().width &&
-    GetSize().height >= parent->GetSize().height;
+  if (parent == nullptr)
+    return false;
+
+  /* compare with the parent's client rect, not with its raw size: a
+     #TopWindow may reserve space at the edges (e.g. the iOS safe
+     area), and a window which fills that client area is "maximised",
+     even though it is smaller than the parent window itself.  For all
+     other windows, GetClientRect() is PixelRect{GetSize()}, so this is
+     equivalent to comparing the sizes. */
+  const PixelSize parent_size = parent->GetClientRect().GetSize();
+
+  return GetSize().width >= parent_size.width &&
+    GetSize().height >= parent_size.height;
 }
 
 void


### PR DESCRIPTION
On iOS, full-screen dialogs like the Fly/Simulator prompt showed a thin bright frame at the display edges. The usable area of the main window was recomputed from the screen dimensions and truncated, which can end up one pixel off from the actual framebuffer size, so a dialog sized from it was no longer recognised as filling its parent and got a raised border drawn around it. The usable area now comes from the window's real framebuffer size, the window size rounds instead of truncating, and the check whether a window fills its parent uses the parent's usable area rather than its raw size, which changes nothing on any other platform.

Two questions: is `std::lround()` right for the window size, or `std::ceil()`? And should the safe-area insets in `GetClientRect()`, still truncated with `static_cast<int>()`, use the same?

| Before | After |
|-|-|
| <img width="603" height="1311" alt="Bildschirmfoto 2026-08-17 um 10 27 46" src="https://github.com/user-attachments/assets/b88b0f94-e104-40dc-8bb3-916c99987334" /> | <img width="603" height="1311" alt="Bildschirmfoto 2026-08-17 um 10 40 29" src="https://github.com/user-attachments/assets/914df4f1-533e-4e50-b7dc-7a67328cf860" /> |

(it's better visible on a real device)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Fixed Android crashes.
- Full-screen iOS dialogs now extend cleanly to display edges without thin white frames.
- Improved iOS window sizing, pixel alignment, safe-area handling, and maximized-window detection.
- Corrected USB HID device re-enumeration.
- Fixed SkySight metadata downloads.
- Improved high-DPI map-label rendering.
- Corrected ADS-B speed handling.
- Fixed Checklist keyboard navigation.

## Documentation
- Updated release workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->