### PR TITLE
Publish manuals and Windows installers for releases

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,5 +1,21 @@
 ---
 on:
+  workflow_call:
+    inputs:
+      release_version:
+        description: Release version used for download server publication
+        required: false
+        default: ''
+        type: string
+    secrets:
+      REPOSITORY_SSH_KEY:
+        required: false
+      REPOSITORY_HOST:
+        required: false
+      REPOSITORY_SSH_USER:
+        required: false
+      REPOSITORY_REMOTE_PATH:
+        required: false
   workflow_dispatch:
   push:
     paths:
@@ -36,7 +52,7 @@ jobs:
 
      - name: find githash
        run: |
-         echo "git_hash=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+         echo "git_hash=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
 
      - name: Install build dependencies
        run: |
@@ -50,6 +66,31 @@ jobs:
        with:
          name: ${{ env.TARGET_FINAL }}-${{ env.git_hash }}
          path: output/${{ env.DOC_OUTPUT }}/*.${{ env.TARGET_EXT }}
+
+     - name: Upload manuals to GitHub Release
+       if: ${{ inputs.release_version != '' }}
+       uses: ncipollo/release-action@v1
+       with:
+         allowUpdates: true
+         artifactErrorsFailBuild: true
+         artifacts: output/${{ env.DOC_OUTPUT }}/*.${{ env.TARGET_EXT }}
+         omitBodyDuringUpdate: true
+         omitNameDuringUpdate: true
+         omitPrereleaseDuringUpdate: true
+         replacesArtifacts: true
+         tag: ${{ github.ref_name }}
+
+     - name: Deploy manuals to Download server
+       if: ${{ inputs.release_version != '' && github.repository == 'XCSoar/XCSoar' }}
+       uses: easingthemes/ssh-deploy@main
+       env:
+         SSH_PRIVATE_KEY: ${{ secrets.REPOSITORY_SSH_KEY }}
+         ARGS: "-rltgoDzvO"
+         SOURCE: output/${{ env.DOC_OUTPUT }}/
+         REMOTE_HOST: ${{ secrets.REPOSITORY_HOST }}
+         REMOTE_USER: ${{ secrets.REPOSITORY_SSH_USER }}
+         TARGET: ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ inputs.release_version }}/
+         SCRIPT_BEFORE: mkdir -p ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ inputs.release_version }}
 
   readthedocs-sphinx:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -136,6 +136,17 @@ jobs:
           body: ${{ env.CHANGELOGENTRY }}
           prerelease: ${{ env.PRERELEASE }}
 
+  docs:
+    name: "Build and Publish Manuals"
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-docs.yml
+    with:
+      release_version: ${{ needs.release.outputs.version }}
+    secrets: inherit
+
   build:
     runs-on: ${{ matrix.os }}
     needs: release
@@ -826,6 +837,18 @@ jobs:
           REMOTE_USER: ${{ secrets.REPOSITORY_SSH_USER }}
           TARGET: ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ needs.release.outputs.version }}/${{ matrix.target }}/
           SCRIPT_BEFORE: mkdir -p ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ needs.release.outputs.version }}/${{ matrix.target }}/
+
+      - name: Deploy installer to Download server - release
+        if: ${{ github.repository == 'XCSoar/XCSoar' && startsWith(github.ref, 'refs/tags/v') && (matrix.target == 'WIN64OPENGL' || matrix.target == 'WIN32OPENGL') }}
+        uses: easingthemes/ssh-deploy@main
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.REPOSITORY_SSH_KEY }}
+          ARGS: "-rltgoDzvO"
+          SOURCE: output/${{ matrix.target }}/bin/${{ matrix.target_final }}-${{ needs.release.outputs.version }}-${{ matrix.target }}-Installer.exe
+          REMOTE_HOST: ${{ secrets.REPOSITORY_HOST }}
+          REMOTE_USER: ${{ secrets.REPOSITORY_SSH_USER }}
+          TARGET: ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ needs.release.outputs.version }}/${{ matrix.target }}/
+          SCRIPT_BEFORE: mkdir -p ${{ secrets.REPOSITORY_REMOTE_PATH }}/releases/${{ needs.release.outputs.version }}/${{ matrix.target }}
 
       - name: Show ccache stats
         run: ccache --show-stats || true


### PR DESCRIPTION
## Summary
- build the existing PDF manuals as part of tag-driven releases
- attach manuals to GitHub Releases and mirror them to the version directory on download.xcsoar.org
- mirror WIN64OPENGL and WIN32OPENGL installers beside their existing ZIP builds

## Test plan
- [x] Build all manuals locally with `make -j$(nproc) manual`
- [x] Parse both modified workflow files as YAML
- [x] Run `git diff --check`
- [ ] Verify publication paths with the v7.45.1 release tag