### PR TITLE
.github/workflows/build-native.yml: Run CI on v*.x patch branches

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -38,6 +38,9 @@ on:
     branches:
       - master
       - apple-testing
+      # Current minor patch line (v7.45.x, v7.46.x, ...). Publish jobs stay
+      # gated to master and v* tags below.
+      - 'v*.x'
     tags:
       - 'v*'
 
@@ -67,6 +70,7 @@ on:
       - 'VERSION.txt'
     branches:
       - master
+      - 'v*.x'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Native CI currently runs for `push`/`pull_request` only on `master` (plus `apple-testing` pushes and `v*` tags). PRs and pushes to the current minor line (`v7.45.x`) therefore get no checks.
- Add `'v*.x'` so patch-line PRs (including #2889) run native builds. Play / VirusTotal / release upload jobs stay gated to `master` and version tags.
- Merge this first. GitHub uses the workflow on the **base** branch, so #2889 will not get native checks until this is on `v7.45.x`. This PR itself will not get those checks either (chicken and egg); it is a four-line trigger change.

## Test plan
- [ ] Merge this into `v7.45.x`
- [ ] Confirm a follow-up push to #2889 starts `build-native` checks
- [ ] Confirm no Play / VirusTotal / GitHub-release publish jobs run for this branch