### PR TITLE
Fix the map scale arrows

### DIFF
--- a/Data/icons/contour_spacing_icon.svg
+++ b/Data/icons/contour_spacing_icon.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.1"
-   viewBox="0 0 12.5 22"
+   viewBox="0 0 25 22"
    id="svg3"
    sodipodi:docname="contour_spacing_icon.svg"
    inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
-   width="12.5"
+   width="25"
    height="22"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -112,6 +112,9 @@
        id="guide10"
        inkscape:locked="false" />
   </sodipodi:namedview>
+  <g
+     transform="matrix(2.004224,0,0,1.995702,-0.012184,-0.083862)"
+     id="content">
   <rect
      style="fill:#ffffff;fill-rule:evenodd;stroke:none;stroke-width:0.506457;stroke-linecap:butt;stroke-linejoin:round;stroke-dasharray:none"
      id="rect13"
@@ -139,4 +142,5 @@
      d="M 6.1822682,3.773297 V 7.356086"
      id="path10-4-1"
      sodipodi:nodetypes="cc" />
+  </g>
 </svg>

--- a/Data/icons/scalearrow_left.svg
+++ b/Data/icons/scalearrow_left.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.1"
-   viewBox="0 0 16 22"
+   viewBox="0 0 14 22"
    id="svg3"
    sodipodi:docname="scalearrow_left.svg"
-   width="16"
+   width="14"
    height="22"
    inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -33,21 +33,17 @@
      inkscape:window-maximized="1"
      inkscape:current-layer="svg3" />
   <g
-     transform="rotate(180,12.510349,6.993)"
-     id="g3">
-    <g
-       transform="matrix(0.34374,0,0,0.34374,8.9989,3)"
-       fill-rule="evenodd"
-       id="g2">
-      <path
-         d="M 20.228,15.98 C 20.2237,14.8699 19.80076,13.7612 18.9592,12.9136 L 7.4012,1.2786 C 6.6077,0.48093 5.5602,0.0434 4.4835,0.0072 V -6.01e-5 L 0.0037,2e-4 l 8.68e-6,31.96 4.47980002,-0.0012 v -0.0058 c 1.0767,-0.03619 2.1242,-0.47373 2.9177,-1.2714 L 18.959209,19.0468 c 0.84157,-0.84756 1.2659,-1.9563 1.2688,-3.0664"
-         fill="#ffffff"
-         style="-inkscape-stroke:none"
-         id="path1" />
-      <path
-         d="M 5.358,3.3367 3.3151,5.394 13.8581,16 3.3151,26.606 5.358,28.6633 17.938,16.0003 Z"
-         style="-inkscape-stroke:none"
-         id="path2" />
-    </g>
+     transform="matrix(-0.694213,0,0,0.689612,14.022568,-0.02)"
+     fill-rule="evenodd"
+     id="g2">
+    <path
+       d="M 20.228,15.98 C 20.2237,14.8699 19.80076,13.7612 18.9592,12.9136 L 7.4012,1.2786 C 6.6077,0.48093 5.5602,0.0434 4.4835,0.0072 V -6.01e-5 L 0.0037,2e-4 l 8.68e-6,31.96 4.47980002,-0.0012 v -0.0058 c 1.0767,-0.03619 2.1242,-0.47373 2.9177,-1.2714 L 18.959209,19.0468 c 0.84157,-0.84756 1.2659,-1.9563 1.2688,-3.0664"
+       fill="#ffffff"
+       style="-inkscape-stroke:none"
+       id="path1" />
+    <path
+       d="M 5.358,3.3367 3.3151,5.394 13.8581,16 3.3151,26.606 5.358,28.6633 17.938,16.0003 Z"
+       style="-inkscape-stroke:none"
+       id="path2" />
   </g>
 </svg>

--- a/Data/icons/scalearrow_right.svg
+++ b/Data/icons/scalearrow_right.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.1"
-   viewBox="0 0 16 22"
+   viewBox="0 0 14 22"
    id="svg3"
    sodipodi:docname="scalearrow_right.svg"
-   width="16"
+   width="14"
    height="22"
    inkscape:version="1.4.3 (0d15f75, 2025-12-25)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -32,21 +32,17 @@
      inkscape:window-maximized="1"
      inkscape:current-layer="svg3" />
   <g
-     transform="translate(-9,-3)"
-     id="g3">
-    <g
-       transform="matrix(0.34374,0,0,0.34374,8.9989,3)"
-       fill-rule="evenodd"
-       id="g2">
-      <path
-         d="M 20.228,15.98 C 20.2237,14.8699 19.80076,13.7612 18.9592,12.9136 L 7.4012,1.2786 C 6.6077,0.48093 5.5602,0.0434 4.4835,0.0072 V -6.01e-5 L 0.0037,2e-4 l 8.68e-6,31.96 4.47980002,-0.0012 v -0.0058 c 1.0767,-0.03619 2.1242,-0.47373 2.9177,-1.2714 L 18.959209,19.0468 c 0.84157,-0.84756 1.2659,-1.9563 1.2688,-3.0664"
-         fill="#ffffff"
-         style="-inkscape-stroke:none"
-         id="path1" />
-      <path
-         d="M 5.358,3.3367 3.3151,5.394 13.8581,16 3.3151,26.606 5.358,28.6633 17.938,16.0003 Z"
-         style="-inkscape-stroke:none"
-         id="path2" />
-    </g>
+     transform="matrix(0.694213,0,0,0.689612,-0.022568,-0.02)"
+     fill-rule="evenodd"
+     id="g2">
+    <path
+       d="M 20.228,15.98 C 20.2237,14.8699 19.80076,13.7612 18.9592,12.9136 L 7.4012,1.2786 C 6.6077,0.48093 5.5602,0.0434 4.4835,0.0072 V -6.01e-5 L 0.0037,2e-4 l 8.68e-6,31.96 4.47980002,-0.0012 v -0.0058 c 1.0767,-0.03619 2.1242,-0.47373 2.9177,-1.2714 L 18.959209,19.0468 c 0.84157,-0.84756 1.2659,-1.9563 1.2688,-3.0664"
+       fill="#ffffff"
+       style="-inkscape-stroke:none"
+       id="path1" />
+    <path
+       d="M 5.358,3.3367 3.3151,5.394 13.8581,16 3.3151,26.606 5.358,28.6633 17.938,16.0003 Z"
+       style="-inkscape-stroke:none"
+       id="path2" />
   </g>
 </svg>

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -16,6 +16,8 @@ Version 7.46 - not yet released
 * map
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
+  - fix the map scale arrows: draw them at the height of the scale box
+    instead of overlapping it
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/src/Renderer/MapScaleRenderer.cpp
+++ b/src/Renderer/MapScaleRenderer.cpp
@@ -36,36 +36,49 @@ RenderMapScale(Canvas &canvas,
   const int height = font.GetCapitalHeight()
       + Layout::GetTextPadding();
 
-  int x = rc.left;
-  look.map_scale_left_icon.Draw(canvas, PixelPoint(x, rc.bottom - height - 1));
+  const int top = rc.bottom - height - 1;
 
-  x += look.map_scale_left_icon.GetSize().width;
-  canvas.DrawFilledRectangle({{x, rc.bottom - height - 1},
-                              PixelSize{2 * text_padding_x + (int)text_size.width, height}}, COLOR_WHITE);
+  /* The icons are scaled to the height of the white boxes so that the
+     whole scale bar is one band, independent of DPI and font metrics.
+     They are flush with the edge of their bitmap where they meet a
+     box; overlap that seam by one pixel, because magnifying a texture
+     can leave its outermost pixel column slightly translucent. */
+  constexpr int overlap = 1;
+
+  /* MaskedIcon::Draw() inverts greyscale icons when the canvas' text
+     colour suggests a dark background.  These icons always sit on a
+     white box, so pin the text colour before drawing them. */
+  canvas.SetTextColor(COLOR_BLACK);
+
+  int x = rc.left;
+  look.map_scale_left_icon.Draw(canvas, PixelPoint(x, top), height);
+
+  x += look.map_scale_left_icon.GetScaledSize(height).width;
+  canvas.DrawFilledRectangle({{x - overlap, top},
+                              PixelSize{overlap + 2 * text_padding_x + (int)text_size.width, height}}, COLOR_WHITE);
 
   canvas.SetBackgroundTransparent();
-  canvas.SetTextColor(COLOR_BLACK);
   x += text_padding_x;
   canvas.DrawText({x, rc.bottom - (int)(font.GetAscentHeight() + Layout::Scale(1u)) - 1},
                   buffer);
 
   x += text_padding_x + text_size.width;
-  look.map_scale_right_icon.Draw(canvas, PixelPoint(x, rc.bottom - height - 1));
+  look.map_scale_right_icon.Draw(canvas, PixelPoint(x - overlap, top), height);
 
   if (contour_spacing_m > 0) {
-    x += look.map_scale_right_icon.GetSize().width;
+    x += look.map_scale_right_icon.GetScaledSize(height).width;
     x += text_padding_x * 2;
 
     const auto contour_buf = FormatUserAltitude((double)contour_spacing_m);
     PixelSize contour_size = canvas.CalcTextSize(contour_buf.c_str());
-    const int icon_width = look.contour_spacing_icon.GetSize().width;
+    const int icon_width = look.contour_spacing_icon.GetScaledSize(height).width;
 
     canvas.DrawFilledRectangle(
-      {{x, rc.bottom - height - 1},
+      {{x, top},
        PixelSize{icon_width + 2 * text_padding_x + (int)contour_size.width, height}},
       COLOR_WHITE);
 
-    look.contour_spacing_icon.Draw(canvas, PixelPoint(x, rc.bottom - height - 1));
+    look.contour_spacing_icon.Draw(canvas, PixelPoint(x, top), height);
 
     canvas.SetBackgroundTransparent();
     canvas.SetTextColor(COLOR_BLACK);

--- a/src/ui/canvas/Icon.hpp
+++ b/src/ui/canvas/Icon.hpp
@@ -65,9 +65,6 @@ public:
    * Draw the icon centred on @p p, uniformly scaled so its height
    * matches @p target_height.  If target_height is 0 the icon is
    * drawn at native size.
-   *
-   * On memory-canvas targets (Kobo) this falls back to the unscaled
-   * Draw() because no stretch+blend primitives exist.
    */
   void Draw(Canvas &canvas, PixelPoint p,
             unsigned target_height) const noexcept;

--- a/src/ui/canvas/Icon.hpp
+++ b/src/ui/canvas/Icon.hpp
@@ -34,6 +34,19 @@ public:
     return size;
   }
 
+  /**
+   * The size Draw(Canvas&, PixelPoint, unsigned) will paint for the
+   * given target height.
+   */
+  [[gnu::pure]]
+  PixelSize GetScaledSize(unsigned target_height) const noexcept {
+    if (target_height == 0 || target_height == size.height ||
+        size.height == 0)
+      return size;
+
+    return {size.width * target_height / size.height, target_height};
+  }
+
   bool IsDefined() const noexcept {
     return bitmap.IsDefined();
   }


### PR DESCRIPTION
The map scale arrows were drawn on a canvas twice as tall as the drawing inside it, so they came out taller than the white box beside them and stuck out above and below it on every display. The three overlay SVGs now have their canvas cropped to the drawing, and the icons are scaled to the height of the box, which makes the scale bar a single band regardless of display density or font metrics. Cropping also removes the wide empty margin the old canvases carried on their outer side, so the scale bar no longer sits indented from the screen edge but flush at the left, aligned with the title line above it.

Zoomed in there is still some dirt along the edges of the icons that I have not managed to get rid of. Disabling texture interpolation does not remove it, so it is not caused by the scaling; my best guess is the antialiasing of the diagonal and rounded edges.

I'm not sure if this was iOS only.

| Before | After |
|-|-|
| <img width="603" height="207" alt="Bildschirmfoto 2026-08-18 um 00 31 11" src="https://github.com/user-attachments/assets/a2541e10-8132-4703-bc1a-7a8aa0ce57de" /> | <img width="603" height="214" alt="Bildschirmfoto 2026-08-18 um 00 43 38" src="https://github.com/user-attachments/assets/8ac78607-a6eb-4a83-b6b7-ee0d01e24032" /> |

Please ignore the different InfoBox borders and missing page labels. This screenshots were taken on different builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed map scale arrows overlapping the scale box.
  - Improved icon sizing and alignment so arrows match the scale bar height.
  - Adjusted backgrounds and seams for cleaner rendering.
- **Improvements**
  - Preserved icon proportions when scaling to different heights.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->