### PR TITLE
ci, darwin: upload iOS dSYMs to App Store Connect

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -566,7 +566,7 @@ jobs:
           elif [ ${{ matrix.target }} = "MACOS" ]; then
             gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=y OPTIMIZE="-O0" dmg pkg
           elif [ ${{ matrix.target }} = "IOS64" ]; then
-            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=y OPTIMIZE="-O0" ipa
+            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=y OPTIMIZE="-O0" ipa ios-dsym
           elif [ ${{ matrix.target }} = "UNIX" ]; then
             mkdir -p output/UNIX/DPKG
             rsync -apt . output/UNIX/DPKG --exclude=output/UNIX/DPKG
@@ -632,7 +632,7 @@ jobs:
             echo "Building production release version with TESTING=n"
             
             # Build the IPA without TESTING (production release)
-            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=n ipa
+            gmake -j$(nproc) TARGET=${{ matrix.target }} DEBUG=${{ env.DEBUG }} USE_CCACHE=y V=2 TESTING=n ipa ios-dsym
           elif [ ${{ matrix.target }} = "UNIX" ]; then
             mkdir -p output/UNIX/DPKG
             rsync -apt . output/UNIX/DPKG --exclude=output/UNIX/DPKG
@@ -668,6 +668,10 @@ jobs:
 
           echo "iOS IPA signed successfully"
 
+      - name: Create iOS archive for App Store Connect
+        if: ${{ matrix.target == 'IOS64' && steps.sign_ios.outcome == 'success' }}
+        run: bash darwin/create-ios-archive.sh
+
       - name: Sign macOS package
         id: sign_macos
         if: ${{ matrix.target == 'MACOS' && env.MACOS_SIGNING_CONFIGURED == 'true' && steps.tests.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
@@ -690,8 +694,13 @@ jobs:
         if: ${{ matrix.target == 'IOS64' && steps.tests.outcome == 'success' && steps.sign_ios.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
         uses: actions/upload-artifact@v7
         with:
-          name: ios-testflight-ipa
-          path: output/IOS64/xcsoar-signed.ipa
+          name: ios-testflight-build
+          path: |
+            output/IOS64/xcsoar-signed.ipa
+            output/IOS64/XCSoar.xcarchive
+            output/IOS64/XCSoar.app.dSYM
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Upload artifact for TestFlight (macOS)
         if: ${{ matrix.target == 'MACOS' && steps.tests.outcome == 'success' && steps.sign_macos.outcome == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
@@ -924,12 +933,17 @@ jobs:
     needs: [build]
     if: ${{ (github.repository == 'XCSoar/XCSoar' || github.repository == 'yorickreum/XCSoar') && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/apple-testing' || startsWith(github.ref, 'refs/tags/v')) }}
     steps:
-      - name: Download iOS IPA
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ (github.event.inputs != null && github.event.inputs.ref) || github.ref }}
+
+      - name: Download iOS build
         id: ios_ipa
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          name: ios-testflight-ipa
+          name: ios-testflight-build
 
       - name: Download macOS PKG
         id: macos_pkg
@@ -938,49 +952,38 @@ jobs:
         with:
           name: macos-testflight-pkg
 
+      - name: Prepare iOS archive export signing
+        if: steps.ios_ipa.outcome == 'success'
+        env:
+          APPLE_CERTIFICATES_BASE64: ${{ secrets.APPLE_CERTIFICATES_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATES_BASE64" ] || [ -z "$APPLE_CERTIFICATE_PASSWORD" ]; then
+            echo "iOS archive export requires the distribution certificate"
+            exit 1
+          fi
+
+          printf '%s' "$APPLE_CERTIFICATES_BASE64" | base64 --decode > ios-cert.p12
+          security create-keychain -p actions ios-export.keychain
+          security default-keychain -s ios-export.keychain
+          security unlock-keychain -p actions ios-export.keychain
+          security set-keychain-settings -t 3600 -u ios-export.keychain
+          security import ios-cert.p12 -k ios-export.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/security -T /usr/bin/xcodebuild
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions ios-export.keychain
+          rm ios-cert.p12
+
       - name: Upload iOS to App Store Connect / TestFlight
         if: steps.ios_ipa.outcome == 'success'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
           ASC_PROVIDER: ${{ secrets.ASC_PROVIDER }}
-        run: |
-          IPA_PATH=""
-          for candidate in \
-            "ios-testflight-ipa/output/IOS64/xcsoar-signed.ipa" \
-            "ios-testflight-ipa/xcsoar-signed.ipa" \
-            "xcsoar-signed.ipa"; do
-            if [ -f "$candidate" ]; then
-              IPA_PATH="$candidate"
-              break
-            fi
-          done
-          if [ -z "$IPA_PATH" ]; then
-            echo "Signed IPA not found after download"
-            exit 1
-          fi
-          echo "Using IPA at: $IPA_PATH"
-
-          if [ -z "$APPLE_ID" ] || [ -z "$APP_SPECIFIC_PASSWORD" ]; then
-            echo "TestFlight credentials not configured"
-            exit 1
-          fi
-
-          echo "Uploading iOS build to App Store Connect / TestFlight..."
-          if [ -n "$ASC_PROVIDER" ]; then
-            xcrun altool --upload-app \
-              -f "$IPA_PATH" \
-              -t ios \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD" \
-              --asc-provider "$ASC_PROVIDER"
-          else
-            xcrun altool --upload-app \
-              -f "$IPA_PATH" \
-              -t ios \
-              -u "$APPLE_ID" \
-              -p "$APP_SPECIFIC_PASSWORD"
-          fi
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: bash darwin/upload-ios-testflight.sh
 
       - name: Upload macOS to App Store Connect / TestFlight
         if: steps.macos_pkg.outcome == 'success'
@@ -1025,6 +1028,10 @@ jobs:
               -u "$APPLE_ID" \
               -p "$APP_SPECIFIC_PASSWORD"
           fi
+
+      - name: Cleanup iOS export keychain
+        if: always()
+        run: security delete-keychain ios-export.keychain || true
 
       - name: No TestFlight artifacts from build
         if: ${{ steps.ios_ipa.outcome != 'success' && steps.macos_pkg.outcome != 'success' }}

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -6,6 +6,9 @@ IPA_TMPDIR = $(TARGET_OUTPUT_DIR)/ipa
 
 IPA_NAME = xcsoar.ipa
 IOS_APP_DIR_NAME = XCSoar.app
+IOS_DSYM_NAME = $(IOS_APP_DIR_NAME).dSYM
+IOS_DSYM = $(TARGET_OUTPUT_DIR)/$(IOS_DSYM_NAME)
+IOS_DSYM_INPUT = $(TARGET_OUTPUT_DIR)/dsym-input/XCSoar
 
 ifeq ($(wildcard VERSION.txt),)
 $(error VERSION.txt is missing)
@@ -110,5 +113,26 @@ $(TARGET_OUTPUT_DIR)/$(IPA_NAME): $(TARGET_BIN_DIR)/xcsoar $(TARGET_OUTPUT_DIR)/
 	$(Q)cd $(IPA_TMPDIR) && $(ZIP) -qr ../$(IPA_NAME) ./*
 
 ipa: $(TARGET_OUTPUT_DIR)/$(IPA_NAME)
+
+# Generate the dSYM from an identically named copy of the executable that is
+# shipped in the IPA, and verify that both retain the same build UUID.
+$(IOS_DSYM_INPUT): $(TARGET_BIN_DIR)/xcsoar
+	@$(NQ)echo "  CP      $@"
+	$(Q)$(MKDIR) -p $(@D)
+	$(Q)cp $< $@
+
+$(IOS_DSYM): $(IOS_DSYM_INPUT)
+	@$(NQ)echo "  DSYM    $@"
+	$(Q)rm -rf $@
+	$(Q)xcrun dsymutil $(IOS_DSYM_INPUT) -o $@
+	$(Q)binary_uuid="$$(xcrun dwarfdump --uuid $(TARGET_BIN_DIR)/xcsoar | awk '{ print $$2 }' | LC_ALL=C sort | tr '\n' ' ')"; \
+	  dsym_uuid="$$(xcrun dwarfdump --uuid $@ | awk '{ print $$2 }' | LC_ALL=C sort | tr '\n' ' ')"; \
+	  test -n "$$binary_uuid" && test "$$binary_uuid" = "$$dsym_uuid" || { \
+	    echo "dSYM UUID mismatch: binary=$$binary_uuid dSYM=$$dsym_uuid" >&2; \
+	    exit 1; \
+	  }
+
+.PHONY: ios-dsym
+ios-dsym: $(IOS_DSYM)
 
 endif

--- a/darwin/create-ios-archive.sh
+++ b/darwin/create-ios-archive.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IPA_PATH="${IOS_SIGNED_IPA_PATH:-$PROJECT_ROOT/output/IOS64/xcsoar-signed.ipa}"
+DSYM_PATH="${IOS_DSYM_PATH:-$PROJECT_ROOT/output/IOS64/XCSoar.app.dSYM}"
+ARCHIVE_PATH="${IOS_ARCHIVE_PATH:-$PROJECT_ROOT/output/IOS64/XCSoar.xcarchive}"
+
+if [[ ! -f "$IPA_PATH" ]]; then
+  echo "Signed IPA not found: $IPA_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -d "$DSYM_PATH" ]]; then
+  echo "dSYM not found: $DSYM_PATH" >&2
+  exit 1
+fi
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+unzip -q "$IPA_PATH" -d "$TEMP_DIR"
+APP_PATH="$(find "$TEMP_DIR/Payload" -mindepth 1 -maxdepth 1 -type d -name '*.app' -print -quit)"
+if [[ -z "$APP_PATH" ]]; then
+  echo "No app bundle found in $IPA_PATH" >&2
+  exit 1
+fi
+
+APP_NAME="$(basename "$APP_PATH")"
+APP_EXECUTABLE="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_PATH/Info.plist")"
+APP_BINARY="$APP_PATH/$APP_EXECUTABLE"
+if [[ ! -f "$APP_BINARY" ]]; then
+  echo "App executable not found: $APP_BINARY" >&2
+  exit 1
+fi
+
+binary_uuid="$(xcrun dwarfdump --uuid "$APP_BINARY" | awk '{ print $2 }' | LC_ALL=C sort | tr '\n' ' ')"
+dsym_uuid="$(xcrun dwarfdump --uuid "$DSYM_PATH" | awk '{ print $2 }' | LC_ALL=C sort | tr '\n' ' ')"
+if [[ -z "$binary_uuid" || "$binary_uuid" != "$dsym_uuid" ]]; then
+  echo "dSYM UUID mismatch: binary=$binary_uuid dSYM=$dsym_uuid" >&2
+  exit 1
+fi
+
+bundle_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$APP_PATH/Info.plist")"
+bundle_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$APP_PATH/Info.plist")"
+short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP_PATH/Info.plist")"
+signing_identity="$(codesign -dvv "$APP_PATH" 2>&1 | sed -n 's/^Authority=//p' | head -n 1)"
+team_identifier="$(codesign -dvv "$APP_PATH" 2>&1 | sed -n 's/^TeamIdentifier=//p' | head -n 1)"
+
+rm -rf "$ARCHIVE_PATH"
+mkdir -p "$ARCHIVE_PATH/Products/Applications" "$ARCHIVE_PATH/dSYMs"
+cp -a "$APP_PATH" "$ARCHIVE_PATH/Products/Applications/$APP_NAME"
+cp -a "$DSYM_PATH" "$ARCHIVE_PATH/dSYMs/"
+
+cat > "$ARCHIVE_PATH/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>ApplicationProperties</key>
+  <dict>
+    <key>ApplicationPath</key>
+    <string>Applications/$APP_NAME</string>
+    <key>CFBundleIdentifier</key>
+    <string>$bundle_identifier</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$short_version</string>
+    <key>CFBundleVersion</key>
+    <string>$bundle_version</string>
+    <key>SigningIdentity</key>
+    <string>$signing_identity</string>
+    <key>Team</key>
+    <string>$team_identifier</string>
+  </dict>
+  <key>ArchiveVersion</key>
+  <integer>2</integer>
+  <key>CreationDate</key>
+  <date>$(date -u +%Y-%m-%dT%H:%M:%SZ)</date>
+  <key>Name</key>
+  <string>XCSoar</string>
+  <key>SchemeName</key>
+  <string>XCSoar</string>
+</dict>
+</plist>
+EOF
+
+echo "Created iOS archive: $ARCHIVE_PATH"

--- a/darwin/upload-ios-testflight.sh
+++ b/darwin/upload-ios-testflight.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$script_dir/.env" ]]; then
+  # shellcheck disable=SC1091
+  source "$script_dir/.env"
+fi
+
+find_archive() {
+  for candidate in \
+    "ios-testflight-build/output/IOS64/XCSoar.xcarchive" \
+    "ios-testflight-build/XCSoar.xcarchive" \
+    "XCSoar.xcarchive"; do
+    if [[ -d "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+find_ipa() {
+  for candidate in \
+    "ios-testflight-build/output/IOS64/xcsoar-signed.ipa" \
+    "ios-testflight-build/xcsoar-signed.ipa" \
+    "xcsoar-signed.ipa"; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if [[ -n "${ASC_API_KEY_BASE64:-}" && -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" ]]; then
+  archive_path="$(find_archive)" || {
+    echo "iOS archive not found after download" >&2
+    exit 1
+  }
+
+  temporary_directory="$(mktemp -d "${RUNNER_TEMP:-/tmp}/xcsoar-ios-upload.XXXXXX")"
+  trap 'rm -rf "$temporary_directory"' EXIT
+  api_key_path="$temporary_directory/AuthKey_${ASC_API_KEY_ID}.p8"
+  export_options="$temporary_directory/ExportOptions.plist"
+  profile_plist="$temporary_directory/embedded-profile.plist"
+
+  printf '%s' "$ASC_API_KEY_BASE64" | base64 --decode > "$api_key_path"
+  chmod 600 "$api_key_path"
+
+  profile_path="$(find "$archive_path/Products/Applications" -name embedded.mobileprovision -type f -print -quit)"
+  if [[ -z "$profile_path" ]]; then
+    echo "Embedded provisioning profile not found in iOS archive" >&2
+    exit 1
+  fi
+  security cms -D -i "$profile_path" > "$profile_plist"
+  profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$profile_plist")"
+  profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$profile_plist")"
+  app_path="$(find "$archive_path/Products/Applications" -maxdepth 1 -name '*.app' -type d -print -quit)"
+  bundle_identifier="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app_path/Info.plist")"
+  mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+  cp "$profile_path" "$HOME/Library/MobileDevice/Provisioning Profiles/$profile_uuid.mobileprovision"
+  cat > "$export_options" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>destination</key>
+  <string>upload</string>
+  <key>method</key>
+  <string>app-store-connect</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>$bundle_identifier</key>
+    <string>$profile_name</string>
+  </dict>
+  <key>signingCertificate</key>
+  <string>Apple Distribution</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>uploadSymbols</key>
+  <true/>
+</dict>
+</plist>
+EOF
+
+  xcodebuild -exportArchive \
+    -archivePath "$archive_path" \
+    -exportOptionsPlist "$export_options" \
+    -exportPath "$temporary_directory/export" \
+    -authenticationKeyPath "$api_key_path" \
+    -authenticationKeyID "$ASC_API_KEY_ID" \
+    -authenticationKeyIssuerID "$ASC_API_ISSUER_ID"
+  exit 0
+fi
+
+echo "::warning::App Store Connect API key is not configured; uploading the IPA without dSYM delivery"
+ipa_path="$(find_ipa)" || {
+  echo "Signed IPA not found after download" >&2
+  exit 1
+}
+
+if [[ -z "${APPLE_ID:-}" || -z "${APP_SPECIFIC_PASSWORD:-}" ]]; then
+  echo "TestFlight credentials not configured" >&2
+  exit 1
+fi
+
+echo "Uploading iOS build to App Store Connect / TestFlight..."
+if [[ -n "${ASC_PROVIDER:-}" ]]; then
+  xcrun altool --upload-app \
+    -f "$ipa_path" \
+    -t ios \
+    -u "$APPLE_ID" \
+    -p "$APP_SPECIFIC_PASSWORD" \
+    --asc-provider "$ASC_PROVIDER"
+else
+  xcrun altool --upload-app \
+    -f "$ipa_path" \
+    -t ios \
+    -u "$APPLE_ID" \
+    -p "$APP_SPECIFIC_PASSWORD"
+fi


### PR DESCRIPTION
## Summary

TestFlight and App Store builds currently upload a stripped iOS executable without its matching dSYM. Native crash reports therefore cannot be reliably symbolicated into XCSoar C++ function names and source locations.

Generate a matching `XCSoar.app.dSYM` during the iOS build, verify its UUID against the executable shipped in the IPA, and retain it as a CI artifact.

Build an `.xcarchive` containing the signed app and dSYM. Upload it using `xcodebuild -exportArchive` with `uploadSymbols=YES`, so App Store Connect receives symbols for TestFlight and release builds. The legacy IPA upload remains available when API-key credentials are unavailable.

## Validation

- Generated a local dSYM and verified it matches the signed IPA UUID.
- Created a local `XCSoar.xcarchive` and verified its app/dSYM UUIDs match.
- Ran shell syntax checks for the archive and TestFlight upload scripts.
- Parsed `build-native.yml` and ran `git diff --check`.
- Ran the `apple-testing` workflow through successful archive/TestFlight
  upload.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>`
- [x] Use present tense in commit messages
- [x] Commit messages explain why the change was made
- [x] Commit message body provides context

#### Commit Structure
- [x] Each commit is atomic
- [x] One commit per logical change
- [x] Self-contained commit
- [x] No fixup commits
- [x] No duplicate commits
- [x] No WIP or testing commits

---

- [x] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS builds now include debug symbols alongside the IPA.
  * TestFlight deliveries include the IPA, archive, and debug symbols as a single artifact.
  * Added authenticated archive uploads, with IPA upload fallback when needed.

* **Bug Fixes**
  * Improved validation to ensure debug symbols match the app.
  * Enhanced cleanup and error handling during archive creation and TestFlight delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->