### PR TITLE
Map: GPU hillshade, faster topography, and KMS -WIDTHxHEIGHT

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -46,8 +46,8 @@ Version 7.46 - not yet released
   - fix the map scale arrows: draw them at the height of the scale box
     instead of overlapping it
   - fix topography labels flickering on and off while panning,
-    centre them on the feature, and enlarge place names when zoomed
-    in
+    centre area names on the feature, sit place names under point
+    icons, and enlarge place names when zoomed in
   - fix the live snail trail losing circling detail and jumping as the
     map follows the aircraft, including at 10x replay #2948
   - keep the pan-mode map scale while panning, and restore the saved

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -84,10 +84,14 @@ Version 7.46 - not yet released
     large enough for a gloved tap
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
+* Linux
+  - fix -WIDTHxHEIGHT so Raspberry Pi and other KMS displays actually
+    switch to that resolution when the display lists it (e.g. -800x600)
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
     produce the testing flavour
+
 
 Version 7.45 - 2026-08-15
 * highlights

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -34,8 +34,11 @@ Version 7.46 - not yet released
     rebuilding the slope image; contour lines stay unshaded (also on
     older OpenGL ES 2 devices); faster devices use full terrain
     resolution immediately instead of waiting until the map is idle
-  - skip tiny topography fills, simplify large areas, clip long roads
-    to the map view, and keep recently seen shapes while panning
+  - skip tiny topography fills, simplify large areas without tearing
+    them, clip long roads to the map view, and keep recently seen
+    shapes while panning
+  - fix crash drawing dense topography fills at close zoom
+  - fix topography fills stretching across the map at some zoom levels
   - fix map fills and outlines (airspace, XC Therm, reach, FAI
     areas, weather overlays) vanishing when only partly on the map
   - fix the ragged white halo behind map labels on high-DPI screens

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -30,6 +30,10 @@ Version 7.46 - not yet released
   - fix choosing SkySight as a page overlay with no layers available
     silently switching back to None
 * map
+  - add terrain shading that follows sun and wind lighting without
+    rebuilding the slope image; contour lines stay unshaded (also on
+    older OpenGL ES 2 devices); faster devices use full terrain
+    resolution immediately instead of waiting until the map is idle
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,6 +42,9 @@ Version 7.46 - not yet released
     #2879
   - fix the map scale arrows: draw them at the height of the scale box
     instead of overlapping it
+  - fix topography labels flickering on and off while panning,
+    centre them on the feature, and enlarge place names when zoomed
+    in
   - fix the live snail trail losing circling detail and jumping as the
     map follows the aircraft, including at 10x replay #2948
   - keep the pan-mode map scale while panning, and restore the saved
@@ -90,11 +93,11 @@ Version 7.46 - not yet released
 * ui
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
-* documentation
-  - describe the T Next Leg InfoBox and how to use it at a turn
 * Linux
   - fix -WIDTHxHEIGHT so Raspberry Pi and other KMS displays actually
     switch to that resolution when the display lists it (e.g. -800x600)
+* documentation
+  - describe the T Next Leg InfoBox and how to use it at a turn
 * development
   - add RunTerrainRenderer to show TerrainRenderer hillshade with a
     rotating sun; --cpu-shade compares CPU GenerateSlopeImage vs the

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -49,6 +49,8 @@ Version 7.46 - not yet released
   - fix topography labels flickering on and off while panning,
     centre area names on the feature, sit place names under point
     icons, and enlarge place names when zoomed in
+  - fix airspace altitude labels overlapping each other and
+    topography names
   - fix the live snail trail losing circling detail and jumping as the
     map follows the aircraft, including at 10x replay #2948
   - keep the pan-mode map scale while panning, and restore the saved

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -34,12 +34,24 @@ Version 7.46 - not yet released
     rebuilding the slope image; contour lines stay unshaded (also on
     older OpenGL ES 2 devices); faster devices use full terrain
     resolution immediately instead of waiting until the map is idle
+  - add an experimental GPU DEM path (expert Map Display → Terrain →
+    GPU DEM spike): draws the DEM overview and loaded fine tiles on
+    the GPU instead of CPU sampling, so panning keeps coarse terrain
+    until detail arrives; close zoom interpolates decoded heights
+    and bilinear slopes so hillshade is not too dark or blocky in
+    shadow; on a Pixel-class phone,
+    full rebuilds drop from roughly 40–70 ms to about 2–6 ms
   - skip tiny topography fills, simplify large areas without tearing
     them, clip long roads to the map view, and keep recently seen
     shapes while panning
+  - load on-screen topography first when panning to a new area, then
+    fill the surrounding cache, so roads appear sooner
   - fix crash drawing dense topography fills at close zoom, including
     devices that cannot map large OpenGL vertex buffers, and PowerVR
-    GPUs whose driver crashes in MapBuffer or MultiDrawElements
+    GPUs whose driver crashes in MapBuffer or MultiDrawElements;
+    those GPUs draw fills and roads in 64k-vertex batches and keep
+    the last terrain image while panning instead of rebuilding it
+    every frame
   - fix topography fills stretching across the map at some zoom levels
   - fix map fills and outlines (airspace, XC Therm, reach, FAI
     areas, weather overlays) vanishing when only partly on the map

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -36,6 +36,8 @@ Version 7.46 - not yet released
     resolution immediately instead of waiting until the map is idle
   - skip tiny topography fills, simplify large areas, clip long roads
     to the map view, and keep recently seen shapes while panning
+  - fix map fills and outlines (airspace, XC Therm, reach, FAI
+    areas, weather overlays) vanishing when only partly on the map
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -38,7 +38,8 @@ Version 7.46 - not yet released
     them, clip long roads to the map view, and keep recently seen
     shapes while panning
   - fix crash drawing dense topography fills at close zoom, including
-    devices that cannot map large OpenGL vertex buffers
+    devices that cannot map large OpenGL vertex buffers, and PowerVR
+    GPUs whose driver crashes in MapBuffer or MultiDrawElements
   - fix topography fills stretching across the map at some zoom levels
   - fix map fills and outlines (airspace, XC Therm, reach, FAI
     areas, weather overlays) vanishing when only partly on the map

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -37,7 +37,8 @@ Version 7.46 - not yet released
   - skip tiny topography fills, simplify large areas without tearing
     them, clip long roads to the map view, and keep recently seen
     shapes while panning
-  - fix crash drawing dense topography fills at close zoom
+  - fix crash drawing dense topography fills at close zoom, including
+    devices that cannot map large OpenGL vertex buffers
   - fix topography fills stretching across the map at some zoom levels
   - fix map fills and outlines (airspace, XC Therm, reach, FAI
     areas, weather overlays) vanishing when only partly on the map

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -34,6 +34,8 @@ Version 7.46 - not yet released
     rebuilding the slope image; contour lines stay unshaded (also on
     older OpenGL ES 2 devices); faster devices use full terrain
     resolution immediately instead of waiting until the map is idle
+  - skip tiny topography fills, simplify large areas, clip long roads
+    to the map view, and keep recently seen shapes while panning
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -94,6 +94,11 @@ Version 7.46 - not yet released
   - fix -WIDTHxHEIGHT so Raspberry Pi and other KMS displays actually
     switch to that resolution when the display lists it (e.g. -800x600)
 * development
+  - add RunTerrainRenderer to show TerrainRenderer hillshade with a
+    rotating sun; --cpu-shade compares CPU GenerateSlopeImage vs the
+    OpenGL shader, --seconds=N exits for profiling
+  - add RunMapRendererStress to time terrain and topography map paint
+    from an .xcm; --no-cache forces a full rasterize each draw
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
     produce the testing flavour

--- a/build/test.mk
+++ b/build/test.mk
@@ -1173,6 +1173,8 @@ ifeq ($(TARGET_IS_ANDROID),n)
 # These programs are broken on Android because they require Java code
 DEBUG_PROGRAM_NAMES += \
 	RunTrailRendererStress \
+	RunMapRendererStress \
+	RunTerrainRenderer \
 	RunTrace \
 	RunContestAnalysis \
 	RunWaveComputer \
@@ -2019,6 +2021,45 @@ RUN_TRAIL_RENDERER_STRESS_DEPENDS = \
 	$(DEBUG_REPLAY_DEPENDS) SCREEN EVENT ASYNC OS IO THREAD GEO MATH UTIL TIME
 $(eval $(call link-program,RunTrailRendererStress,RUN_TRAIL_RENDERER_STRESS))
 
+RUN_MAP_RENDERER_STRESS_SOURCES = \
+	$(SRC)/Projection/Projection.cpp \
+	$(SRC)/Projection/WindowProjection.cpp \
+	$(SRC)/Projection/CompareProjection.cpp \
+	$(SRC)/Look/TopographyLook.cpp \
+	$(SRC)/Renderer/LabelBlock.cpp \
+	$(SRC)/Renderer/GeoBitmapRenderer.cpp \
+	$(SRC)/Renderer/TransparentRendererCache.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(MORE_SCREEN_SOURCES) \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/FakeProfile.cpp \
+	$(SRC)/Hardware/CPU.cpp \
+	$(TEST_SRC_DIR)/RunMapRendererStress.cpp
+RUN_MAP_RENDERER_STRESS_DEPENDS = \
+	TERRAIN TOPO SCREEN EVENT RESOURCE OPERATION \
+	ASYNC OS IO THREAD GEO MATH UTIL TIME ZZIP JASPER
+$(eval $(call link-program,RunMapRendererStress,RUN_MAP_RENDERER_STRESS))
+
+RUN_TERRAIN_RENDERER_SOURCES = \
+	$(SRC)/Projection/Projection.cpp \
+	$(SRC)/Projection/WindowProjection.cpp \
+	$(SRC)/Projection/CompareProjection.cpp \
+	$(SRC)/Renderer/GeoBitmapRenderer.cpp \
+	$(SRC)/Look/ButtonLook.cpp \
+	$(SRC)/Version.cpp \
+	$(SRC)/system/StandardVersion.cpp \
+	$(MORE_SCREEN_SOURCES) \
+	$(TEST_SRC_DIR)/FakeAsset.cpp \
+	$(TEST_SRC_DIR)/FakeProfile.cpp \
+	$(TEST_SRC_DIR)/Fonts.cpp \
+	$(SRC)/Hardware/CPU.cpp \
+	$(TEST_SRC_DIR)/RunTerrainRenderer.cpp
+RUN_TERRAIN_RENDERER_DEPENDS = \
+	TERRAIN FORM SCREEN EVENT RESOURCE OPERATION \
+	ASYNC OS IO THREAD GEO MATH UTIL TIME ZZIP JASPER
+$(eval $(call link-program,RunTerrainRenderer,RUN_TERRAIN_RENDERER))
+
 RUN_TRACE_SOURCES = \
 	$(DEBUG_REPLAY_SOURCES) \
 	$(SRC)/IGC/IGCParser.cpp \
@@ -2285,6 +2326,7 @@ RUN_MAP_WINDOW_SOURCES = \
 	$(TEST_SRC_DIR)/FakeDialogs.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(SRC)/Hardware/CPU.cpp \
 	$(TEST_SRC_DIR)/RunMapWindow.cpp
 
 ifeq ($(HAVE_HTTP),y)
@@ -2707,6 +2749,7 @@ RUN_ANALYSIS_SOURCES = \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/Fonts.cpp \
+	$(SRC)/Hardware/CPU.cpp \
 	$(TEST_SRC_DIR)/RunAnalysis.cpp
 RUN_ANALYSIS_DEPENDS = \
 	TERRAIN \

--- a/doc/test_debug_utilities.rst
+++ b/doc/test_debug_utilities.rst
@@ -321,6 +321,66 @@ Tests task calculation with flight data.
 - Replays flight data through the task
 - Reports task start, finish, and statistics
 
+RunMapRendererStress
+~~~~~~~~~~~~~~~~~~~~
+
+Benchmarks map rendering (terrain DEM plus vector topography) from an
+``.xcm`` map container.  This is the map-paint counterpart to
+``RunTrailRendererStress``.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunMapRendererStress ~/.xcsoar/maps/ALPS_Test.xcm
+   ./output/UNIX/bin/RunMapRendererStress --radius=3000 --lat=46.5 --lon=11.3 map.xcm
+   ./output/UNIX/bin/RunMapRendererStress --no-cache --draws=40 --width=1600 --height=960 map.xcm
+
+**What it does**:
+
+- Loads ``topology.tpl`` and shapefiles from the map ZIP
+- Optionally loads ``terrain.jp2``
+- For each map half-width (``--radius``), times shape loading
+  (``ScanVisibility``), terrain tiles, the first paint, and warm redraws
+- Prints a TSV table on stdout (``scan_ms``, ``first_ms``, ``frame_ms``,
+  plus terrain / topography / label breakdowns)
+- ``--no-cache`` flushes the software topography/terrain bitmap caches
+  before each timed draw so ``frame_ms`` / ``topo_ms`` measure rasterize
+  cost instead of a blit.  OpenGL already redraws vectors every frame.
+
+Default radii are 750 m, 3 km, 19 km, 50 km and 150 km (circling through
+overview).  Samples run small-to-large so the shape cache expands; pass a
+single ``--radius`` for an isolated measurement.
+
+RunTerrainRenderer
+~~~~~~~~~~~~~~~~~~
+
+Opens a window that loads DEM terrain from an ``.xcm`` and redraws
+``TerrainRenderer`` with a rotating sun azimuth.  OpenGL builds use
+the GPU hillshade shader by default; ``--cpu-shade`` forces the CPU
+``GenerateSlopeImage`` path for A/B tests.
+
+**Usage**:
+
+.. code-block:: bash
+
+   ./output/UNIX/bin/RunTerrainRenderer ~/.xcsoar/maps/ALPS_Test.xcm
+   ./output/UNIX/bin/RunTerrainRenderer -800x600 --radius=19000 \
+     --lat=46.12 --lon=10.58 map.xcm
+   ./output/UNIX/bin/RunTerrainRenderer -800x600 --cpu-shade \
+     --seconds=15 --radius=25000 map.xcm
+
+**What it does**:
+
+- Loads ``terrain.jp2`` from the map ZIP
+- Rotates the sun every timer tick (default 3° / 50 ms)
+- GPU path uploads the height matrix once; CPU path rebuilds slope
+  shading every tick
+- Overlay shows ``GPU`` or ``CPU``, sun azimuth, and ``Generate()``
+  time
+- ``--seconds=N`` closes the window (for ``perf``)
+- ``-WxH`` sets the window size (same as other ``Run*`` window tools)
+
 RunWindComputer
 ~~~~~~~~~~~~~~~
 

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -25,6 +25,7 @@
 namespace CommandLine {
   unsigned width = IsKobo() ? 600 : 640;
   unsigned height = IsKobo() ? 800 : 480;
+  bool size_specified = false;
 
 #ifdef HAVE_CMDLINE_FULLSCREEN
   bool full_screen = false;
@@ -154,15 +155,19 @@ CommandLine::Parse(Args &args)
       height = ParseUnsigned(s + 1, &p);
       if (*p != '\0')
         args.UsageError();
+      size_specified = true;
     } else if (StringIsEqual(s, "-portrait")) {
       width = 480;
       height = 640;
+      size_specified = true;
     } else if (StringIsEqual(s, "-square")) {
       width = 480;
       height = 480;
+      size_specified = true;
     } else if (StringIsEqual(s, "-small")) {
       width = 320;
       height = 240;
+      size_specified = true;
     } else if (StringIsEqual(s, "-touchscreen")) {
       touch_input = TouchInput::Force;
     } else if (StringIsEqual(s, "-notouchscreen")) {

--- a/src/CommandLine.hpp
+++ b/src/CommandLine.hpp
@@ -41,6 +41,13 @@ namespace CommandLine {
 
   extern unsigned width, height;
 
+  /**
+   * True if the user passed @c -WIDTHxHEIGHT, @c -portrait,
+   * @c -square or @c -small.  Used by DRM/KMS to pick a connector
+   * mode instead of the preferred native resolution.
+   */
+  extern bool size_specified;
+
 #ifdef KOBO
   static constexpr bool full_screen = false;
 #elif defined(ENABLE_SDL) || defined(USE_X11)

--- a/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
@@ -36,6 +36,9 @@ enum ControlIndex {
   TerrainContrast,
   TerrainBrightness,
   TerrainContours,
+#ifdef ENABLE_OPENGL
+  TerrainGpuDemSpike,
+#endif
   TerrainSpacer,
   TerrainPreview,
 };
@@ -121,6 +124,9 @@ TerrainDisplayConfigPanel::ShowTerrainControls()
   SetRowVisible(TerrainContrast, show);
   SetRowVisible(TerrainBrightness, show);
   SetRowVisible(TerrainContours, show);
+#ifdef ENABLE_OPENGL
+  SetRowVisible(TerrainGpuDemSpike, show);
+#endif
   if (have_terrain_preview) {
     SetRowVisible(TerrainSpacer, show);
     SetRowVisible(TerrainPreview, show);
@@ -150,6 +156,9 @@ TerrainDisplayConfigPanel::UpdateTerrainPreview()
   terrain_settings.ramp = GetValueEnum(TerrainColors);
   terrain_settings.contours = (Contours)
     GetValueEnum(TerrainContours);
+#ifdef ENABLE_OPENGL
+  terrain_settings.gpu_dem_spike = GetValueBoolean(TerrainGpuDemSpike);
+#endif
 
   // Invalidate terrain preview
   if (have_terrain_preview)
@@ -327,6 +336,15 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
   GetDataField(TerrainContours).SetListener(this);
   SetExpertRow(TerrainContours);
 
+#ifdef ENABLE_OPENGL
+  AddBoolean(_("GPU DEM spike"),
+             _("Experimental: sample fine DEM tiles on the GPU "
+               "(no ScanMap)."),
+             terrain.gpu_dem_spike);
+  GetDataField(TerrainGpuDemSpike).SetListener(this);
+  SetExpertRow(TerrainGpuDemSpike);
+#endif
+
   have_terrain_preview = data_components->terrain != nullptr;
   if (have_terrain_preview) {
     AddSpacer();
@@ -372,6 +390,10 @@ TerrainDisplayConfigPanel::Save(bool &_changed) noexcept
     Profile::SetEnum(ProfileKeys::SlopeShadingType,
                      terrain_settings.slope_shading);
     Profile::SetEnum(ProfileKeys::TerrainContours, terrain_settings.contours);
+#ifdef ENABLE_OPENGL
+    Profile::Set(ProfileKeys::TerrainGpuDemSpike,
+                 terrain_settings.gpu_dem_spike);
+#endif
     changed = true;
   }
 

--- a/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
@@ -31,14 +31,14 @@
 enum ControlIndex {
   EnableTerrain,
   EnableTopography,
+#ifdef ENABLE_OPENGL
+  TerrainGpuDemSpike,
+#endif
   TerrainColors,
   TerrainSlopeShading,
   TerrainContrast,
   TerrainBrightness,
   TerrainContours,
-#ifdef ENABLE_OPENGL
-  TerrainGpuDemSpike,
-#endif
   TerrainSpacer,
   TerrainPreview,
 };
@@ -252,6 +252,15 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
              settings_map.topography_enabled);
   GetDataField(EnableTopography).SetListener(this);
 
+#ifdef ENABLE_OPENGL
+  AddBoolean(_("GPU DEM spike"),
+             _("Experimental: sample fine DEM tiles on the GPU "
+               "(no ScanMap)."),
+             terrain.gpu_dem_spike);
+  GetDataField(TerrainGpuDemSpike).SetListener(this);
+  SetExpertRow(TerrainGpuDemSpike);
+#endif
+
   static constexpr StaticEnumChoice terrain_ramp_list[] = {
     { 0, N_("Low lands"), },
     { 1, N_("Mountainous"), },
@@ -335,15 +344,6 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
           contours_list, (unsigned)terrain.contours);
   GetDataField(TerrainContours).SetListener(this);
   SetExpertRow(TerrainContours);
-
-#ifdef ENABLE_OPENGL
-  AddBoolean(_("GPU DEM spike"),
-             _("Experimental: sample fine DEM tiles on the GPU "
-               "(no ScanMap)."),
-             terrain.gpu_dem_spike);
-  GetDataField(TerrainGpuDemSpike).SetListener(this);
-  SetExpertRow(TerrainGpuDemSpike);
-#endif
 
   have_terrain_preview = data_components->terrain != nullptr;
   if (have_terrain_preview) {

--- a/src/Dialogs/Weather/RASPDialog.cpp
+++ b/src/Dialogs/Weather/RASPDialog.cpp
@@ -114,6 +114,11 @@ RaspColorbarWindow::OnPaint(Canvas &canvas) noexcept
     0, (int)INT16_MAX);
 
   RasterRenderer renderer;
+#ifdef ENABLE_OPENGL
+  /* Colorbar uses GetImage(); the shader path never allocates that
+     bitmap. */
+  renderer.SetUseCpuHillshade(true);
+#endif
   if (use_alpha)
     renderer.PrepareColorTableAlpha(
       &ramp, style->do_water,

--- a/src/Geo/GeoClip.cpp
+++ b/src/Geo/GeoClip.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Geo/GeoClip.hpp"
+#include "util/AllocatedArray.hxx"
 
 #include <cassert>
 
@@ -388,17 +389,23 @@ GeoClip::ClipPolygon(GeoPoint *dest,
   if (src_length < 3)
     return 0;
 
-  GeoPoint *imported = dest + src_length * 2;
+  /* Do not overlay dest with the longitude-clip output: that pass
+     inserts vertices, so dest+src_length overlaps dest+2*src_length
+     and corrupts polygons that straddle the clip box. */
+  AllocatedArray<GeoPoint> imported;
+  imported.GrowDiscard(src_length);
   for (unsigned i = 0; i < src_length; ++i)
     imported[i] = ImportPoint(src[i]);
 
-  GeoPoint *first_stage = dest + src_length;
+  AllocatedArray<GeoPoint> stage;
+  stage.GrowDiscard(src_length * 3);
   unsigned n = ClipPolygonLongitude(Angle::Zero(), width,
-                                    first_stage, imported, src_length);
+                                    stage.data(), imported.data(),
+                                    src_length);
   if (n < 3)
     return 0;
 
-  n = ClipPolygonLatitude(GetSouth(), GetNorth(), dest, first_stage, n);
+  n = ClipPolygonLatitude(GetSouth(), GetNorth(), dest, stage.data(), n);
   if (n < 3)
     return 0;
 

--- a/src/Geo/GeoClip.hpp
+++ b/src/Geo/GeoClip.hpp
@@ -19,6 +19,9 @@ public:
   GeoClip(const GeoBounds &other)
     :GeoBounds(other), width(GetWidth()) {}
 
+  using GeoBounds::Overlaps;
+  using GeoBounds::IsValid;
+
 protected:
   /**
    * Imports a longitude value.  To avoid wraparound bugs, all
@@ -72,7 +75,11 @@ public:
    * The implementation is a specialization of the Sutherland-Hodgman
    * algorithm, with only horizontal and vertical bound lines.
    *
-   * @param dest a GeoPoint array with enough space for three times
+   * Scratch space is allocated internally so dest is write-only and
+   * may alias src.  Each clip pass can insert vertices, so dest must
+   * hold four times src_length.
+   *
+   * @param dest a GeoPoint array with enough space for four times
    * src_length
    * @return the number of vertices written to dest; if less than 3,
    * then the polygon can not be drawn

--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -81,7 +81,9 @@ MapLook::Initialise(const MapSettings &settings,
   no_gps_icon.LoadResource(IDB_GPSSTATUS2_ALL, false);
 
   topography.Initialise();
-  airspace.Initialise(settings.airspace, topography.important_label_font);
+  airspace.Initialise(settings.airspace,
+                      topography.GetLabelFont(true,
+                                              TopographyLook::LabelSize::SMALL));
 
   overlay.Initialise(font, bold_font);
 }

--- a/src/Look/TopographyLook.cpp
+++ b/src/Look/TopographyLook.cpp
@@ -4,10 +4,19 @@
 #include "TopographyLook.hpp"
 #include "FontDescription.hpp"
 #include "Screen/Layout.hpp"
+#include "util/Macros.hpp"
 
 void
 TopographyLook::Initialise()
 {
-  regular_label_font.Load(FontDescription(Layout::FontScale(10), false, false));
-  important_label_font.Load(FontDescription(Layout::FontScale(10), true, false));
+  static constexpr unsigned points[] = { 10, 12, 14 };
+  static_assert(ARRAY_SIZE(points) == unsigned(LabelSize::COUNT),
+                "Label font sizes must match LabelSize::COUNT");
+
+  for (unsigned i = 0; i < unsigned(LabelSize::COUNT); ++i) {
+    regular_label_font[i].Load(FontDescription(Layout::FontScale(points[i]),
+                                               false, false));
+    important_label_font[i].Load(FontDescription(Layout::FontScale(points[i]),
+                                                 true, false));
+  }
 }

--- a/src/Look/TopographyLook.hpp
+++ b/src/Look/TopographyLook.hpp
@@ -5,11 +5,30 @@
 
 #include "ui/canvas/Font.hpp"
 
+#include <array>
+#include <cassert>
+
 struct TopographyLook {
-  Font regular_label_font;
+  enum class LabelSize : unsigned {
+    SMALL,
+    MEDIUM,
+    LARGE,
+    COUNT
+  };
+
+  std::array<Font, unsigned(LabelSize::COUNT)> regular_label_font;
 
   /** for big/medium cities */
-  Font important_label_font;
+  std::array<Font, unsigned(LabelSize::COUNT)> important_label_font;
 
   void Initialise();
+
+  [[gnu::pure]]
+  const Font &GetLabelFont(bool important, LabelSize size) const noexcept {
+    assert(size < LabelSize::COUNT);
+    const auto &fonts = important
+      ? important_label_font
+      : regular_label_font;
+    return fonts[unsigned(size)];
+  }
 };

--- a/src/MapWindow/GlueMapWindow.cpp
+++ b/src/MapWindow/GlueMapWindow.cpp
@@ -9,6 +9,9 @@
 #include "time/PeriodClock.hpp"
 #include "ui/event/Idle.hpp"
 #include "Hardware/CPU.hpp"
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
+#endif
 #include "Topography/Thread.hpp"
 #include "Terrain/Thread.hpp"
 #include "Components.hpp"
@@ -239,7 +242,7 @@ static constexpr auto TERRAIN_QUANTISATION_IDLE_STEP =
 void
 GlueMapWindow::NoteTerrainQuantisationUserActivity() noexcept
 {
-  if (!IsSlowCPU())
+  if (!IsSlowCPU() && !OpenGL::idle_terrain_quantisation)
     return;
 
   terrain_quantisation_idle_done = false;
@@ -249,7 +252,7 @@ GlueMapWindow::NoteTerrainQuantisationUserActivity() noexcept
 void
 GlueMapWindow::PollTerrainQuantisationIdle() noexcept
 {
-  if (!IsSlowCPU())
+  if (!IsSlowCPU() && !OpenGL::idle_terrain_quantisation)
     return;
 
   if (!IsUserIdle(750)) {

--- a/src/MapWindow/GlueMapWindow.cpp
+++ b/src/MapWindow/GlueMapWindow.cpp
@@ -8,6 +8,7 @@
 #include "Interface.hpp"
 #include "time/PeriodClock.hpp"
 #include "ui/event/Idle.hpp"
+#include "Hardware/CPU.hpp"
 #include "Topography/Thread.hpp"
 #include "Terrain/Thread.hpp"
 #include "Components.hpp"
@@ -238,6 +239,9 @@ static constexpr auto TERRAIN_QUANTISATION_IDLE_STEP =
 void
 GlueMapWindow::NoteTerrainQuantisationUserActivity() noexcept
 {
+  if (!IsSlowCPU())
+    return;
+
   terrain_quantisation_idle_done = false;
   terrain_quantisation_timer.Schedule(TERRAIN_QUANTISATION_IDLE_STEP);
 }
@@ -245,6 +249,9 @@ GlueMapWindow::NoteTerrainQuantisationUserActivity() noexcept
 void
 GlueMapWindow::PollTerrainQuantisationIdle() noexcept
 {
+  if (!IsSlowCPU())
+    return;
+
   if (!IsUserIdle(750)) {
     terrain_quantisation_idle_done = false;
     return;

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -128,7 +128,7 @@ private:
 
   /**
    * Re-render terrain at higher OpenGL quantisation after the user
-   * stops interacting (see RasterRenderer::GetQuantisation()).
+   * stops interacting on slow CPUs (see GetQuantisation()).
    */
   UI::Timer terrain_quantisation_timer{
     [this]{ OnTerrainQuantisationTimer(); }};

--- a/src/MapWindow/MapCanvas.cpp
+++ b/src/MapWindow/MapCanvas.cpp
@@ -7,6 +7,12 @@
 #include "Screen/Layout.hpp"
 #include "Math/Screen.hpp"
 #include "Geo/SearchPointVector.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/GeoPoint.hpp"
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Triangulate.hpp"
+#include "ui/opengl/System.hpp"
+#endif
 
 void
 MapCanvas::DrawLine(GeoPoint a, GeoPoint b) noexcept
@@ -46,26 +52,92 @@ MapCanvas::Project(const Projection &projection,
     *screen++ = projection.GeoToScreen(i.GetLocation());
 }
 
+#ifdef ENABLE_OPENGL
+/**
+ * Ear-clip a geographic ring in a local equirectangular frame.
+ * Drops a closing duplicate.  @p n is updated to the vertex count
+ * used.  Indices refer to src[0..n).
+ *
+ * @return triangle index count, or 0 on failure
+ */
+static unsigned
+TriangulateGeoRing(const GeoPoint *src, unsigned &n,
+                   AllocatedArray<uint16_t> &indices) noexcept
+{
+  if (n >= 2 && src[0] == src[n - 1])
+    n--;
+  if (n < 3)
+    return 0;
+
+  AllocatedArray<FloatPoint2D> flat;
+  flat.GrowDiscard(n);
+  const GeoPoint origin = src[0];
+  const double cos_lat = origin.latitude.cos();
+  for (unsigned i = 0; i < n; ++i) {
+    const double x =
+      (src[i].longitude - origin.longitude).Native() * cos_lat;
+    const double y = (src[i].latitude - origin.latitude).Native();
+    flat[i] = FloatPoint2D(float(x), float(y));
+  }
+
+  indices.GrowDiscard(3 * (n - 2));
+  return PolygonToTriangles(flat.data(), n,
+                            reinterpret_cast<GLushort *>(indices.data()),
+                            0.f);
+}
+#endif
+
 bool
 MapCanvas::PreparePolygon(const SearchPointVector &points) noexcept
 {
-  unsigned num_points = points.size();
+  const unsigned n = points.size();
+  if (n < 3)
+    return false;
+
+  geo_points.GrowDiscard(n * 4);
+  for (unsigned i = 0; i < n; ++i)
+    geo_points[i] = points[i].GetLocation();
+  return PrepareCopied(n);
+}
+
+bool
+MapCanvas::PreparePolygon(const GeoPoint *src, unsigned num_points) noexcept
+{
   if (num_points < 3)
     return false;
 
-  /* copy all SearchPointVector elements to geo_points */
-  geo_points.GrowDiscard(num_points * 3);
+  geo_points.GrowDiscard(num_points * 4);
   for (unsigned i = 0; i < num_points; ++i)
-    geo_points[i] = points[i].GetLocation();
+    geo_points[i] = src[i];
+  return PrepareCopied(num_points);
+}
 
-  /* clip them */
+bool
+MapCanvas::PrepareCopied(unsigned num_points) noexcept
+{
+  GeoBounds bb(geo_points[0]);
+  for (unsigned i = 1; i < num_points; ++i)
+    bb.Extend(geo_points[i]);
+  if (bb.IsValid() && !clip.Overlaps(bb))
+    return false;
+
+#ifdef ENABLE_OPENGL
+  num_triangle_indices = 0;
+  unsigned n = num_points;
+  num_triangle_indices = TriangulateGeoRing(geo_points.data(), n,
+                                            triangle_indices);
+  if (num_triangle_indices >= 3) {
+    num_raster_points = n;
+    return true;
+  }
+  num_triangle_indices = 0;
+#endif
+
   num_raster_points = clip.ClipPolygon(geo_points.data(),
                                        geo_points.data(), num_points);
   if (num_raster_points < 3)
-    /* it's completely outside the screen */
     return false;
 
-  /* project all GeoPoints to screen coordinates */
   raster_points.GrowDiscard(num_raster_points);
   for (unsigned i = 0; i < num_raster_points; ++i)
     raster_points[i] = projection.GeoToScreen(geo_points[i]);
@@ -76,6 +148,85 @@ MapCanvas::PreparePolygon(const SearchPointVector &points) noexcept
 void
 MapCanvas::DrawPrepared() noexcept
 {
-  /* draw it all */
+#ifdef ENABLE_OPENGL
+  if (num_triangle_indices >= 3) {
+    screen_points.GrowDiscard(num_raster_points);
+    for (unsigned i = 0; i < num_raster_points; ++i) {
+      const auto sp = projection.GeoToScreen(geo_points[i]);
+      screen_points[i] = FloatPoint2D(float(sp.x), float(sp.y));
+    }
+    canvas.DrawFilledTriangles(screen_points.data(),
+                               reinterpret_cast<const GLushort *>(
+                                 triangle_indices.data()),
+                               num_triangle_indices);
+    return;
+  }
+#endif
+
   canvas.DrawPolygon(raster_points.data(), num_raster_points);
+}
+
+static void
+FlushOutlineStrip(Canvas &canvas, const BulkPixelPoint *strip,
+                  unsigned &length) noexcept
+{
+  if (length >= 2)
+    canvas.DrawPolyline(strip, length);
+  length = 0;
+}
+
+template<typename GetPoint>
+static void
+DrawPolygonOutlineN(Canvas &canvas, const Projection &projection,
+                    const GeoClip &clip, unsigned n,
+                    GetPoint get) noexcept
+{
+  if (n < 2)
+    return;
+
+  if (get(0) == get(n - 1))
+    n--;
+  if (n < 2)
+    return;
+
+  AllocatedArray<BulkPixelPoint> strip;
+  strip.GrowDiscard(n + 1);
+  unsigned strip_len = 0;
+
+  for (unsigned i = 0; i < n; ++i) {
+    GeoPoint a = get(i);
+    GeoPoint b = get((i + 1) % n);
+    if (!clip.ClipLine(a, b)) {
+      FlushOutlineStrip(canvas, strip.data(), strip_len);
+      continue;
+    }
+
+    const BulkPixelPoint sa(projection.GeoToScreen(a));
+    const BulkPixelPoint sb(projection.GeoToScreen(b));
+    if (strip_len > 0 && strip[strip_len - 1] != sa)
+      FlushOutlineStrip(canvas, strip.data(), strip_len);
+
+    if (strip_len == 0)
+      strip[strip_len++] = sa;
+    strip[strip_len++] = sb;
+  }
+
+  FlushOutlineStrip(canvas, strip.data(), strip_len);
+}
+
+void
+MapCanvas::DrawPolygonOutline(const SearchPointVector &points) noexcept
+{
+  DrawPolygonOutlineN(canvas, projection, clip, points.size(),
+                      [&](unsigned i) {
+                        return points[i].GetLocation();
+                      });
+}
+
+void
+MapCanvas::DrawPolygonOutline(const GeoPoint *src,
+                              unsigned num_points) noexcept
+{
+  DrawPolygonOutlineN(canvas, projection, clip, num_points,
+                      [&](unsigned i) { return src[i]; });
 }

--- a/src/MapWindow/MapCanvas.hpp
+++ b/src/MapWindow/MapCanvas.hpp
@@ -5,7 +5,10 @@
 
 #include "ui/dim/BulkPoint.hpp"
 #include "Geo/GeoClip.hpp"
+#include "Math/Point2D.hpp"
 #include "util/AllocatedArray.hxx"
+
+#include <cstdint>
 
 class Canvas;
 class Projection;
@@ -34,6 +37,16 @@ public:
   AllocatedArray<BulkPixelPoint> raster_points;
   unsigned num_raster_points;
 
+#ifdef ENABLE_OPENGL
+  /**
+   * Geographic-space ear-clip indices so pan does not rebuild the
+   * fill from ClipPolygon vertices sliding along the view box.
+   */
+  AllocatedArray<FloatPoint2D> screen_points;
+  AllocatedArray<uint16_t> triangle_indices;
+  unsigned num_triangle_indices = 0;
+#endif
+
 public:
   MapCanvas(Canvas &_canvas, const Projection &_projection,
             const GeoClip &_clip) noexcept
@@ -60,14 +73,41 @@ public:
   }
 
   void DrawPolygon(const SearchPointVector &points) noexcept {
+    FillPolygon(points);
+  }
+
+  void DrawPolygon(const GeoPoint *src, unsigned n) noexcept {
+    if (PreparePolygon(src, n))
+      DrawPrepared();
+    DrawPolygonOutline(src, n);
+  }
+
+  void FillPolygon(const SearchPointVector &points) noexcept {
     if (PreparePolygon(points))
       DrawPrepared();
   }
+
+  void FillPolygon(const GeoPoint *src, unsigned n) noexcept {
+    if (PreparePolygon(src, n))
+      DrawPrepared();
+  }
+
+  /**
+   * Draw the border of a polygon.  Each edge is clipped as a line so
+   * the view-box edges that ClipPolygon inserts for fills are not
+   * drawn as a fake outline.
+   */
+  void DrawPolygonOutline(const SearchPointVector &points) noexcept;
+  void DrawPolygonOutline(const GeoPoint *src, unsigned n) noexcept;
 
   /**
    * @return false if it's completely outside the screen (don't call
    * DrawPrepared())
    */
   bool PreparePolygon(const SearchPointVector &points) noexcept;
+  bool PreparePolygon(const GeoPoint *src, unsigned n) noexcept;
   void DrawPrepared() noexcept;
+
+private:
+  bool PrepareCopied(unsigned n) noexcept;
 };

--- a/src/MapWindow/MapWindow.cpp
+++ b/src/MapWindow/MapWindow.cpp
@@ -6,6 +6,7 @@
 #include "Look/MapLook.hpp"
 #include "Topography/CachedTopographyRenderer.hpp"
 #include "Topography/TopographyStore.hpp"
+#include "Screen/Layout.hpp"
 #include "Terrain/RasterTerrain.hpp"
 #include "Weather/Rasp/RaspRenderer.hpp"
 #include "Computer/GlideComputer.hpp"
@@ -110,7 +111,8 @@ unsigned
 MapWindow::UpdateTopography(unsigned max_update) noexcept
 {
   if (topography != nullptr && GetMapSettings().topography_enabled)
-    return topography->ScanVisibility(visible_projection, max_update);
+    return topography->ScanVisibility(visible_projection, max_update,
+                                      Layout::Scale(1u));
   else
     return 0;
 }

--- a/src/MapWindow/MapWindowGlideRange.cpp
+++ b/src/MapWindow/MapWindowGlideRange.cpp
@@ -2,178 +2,21 @@
 // Copyright The XCSoar Project
 
 #include "MapWindow.hpp"
+#include "MapCanvas.hpp"
 #include "Look/MapLook.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/GeoClip.hpp"
+#include "Geo/GeoPoint.hpp"
 #include "Task/ProtectedRoutePlanner.hpp"
 #include "Route/FlatTriangleFanVisitor.hpp"
+#include "util/StaticArray.hxx"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
-#include "ui/canvas/opengl/VertexPointer.hpp"
-#include "ui/canvas/opengl/Triangulate.hpp"
 #endif
 
 #include <stdio.h>
-#include "util/StaticArray.hxx"
-
-typedef std::vector<BulkPixelPoint> BulkPixelPointVector;
-
-struct ProjectedFan {
-  /**
-   * The number of points of the associated ReachFan.  The first
-   * ProjectedFan starts of ProjectedFans::points[0], followed by the
-   * second one at ProjectedFans::points[reach_fan0.size], etc.
-   */
-  unsigned size;
-
-  ProjectedFan() noexcept = default;
-
-  constexpr ProjectedFan(unsigned n) noexcept:size(n) {}
-
-#ifdef ENABLE_OPENGL
-  void DrawFill(const BulkPixelPoint *points, unsigned start) const noexcept {
-    /* triangulate the polygon */
-    AllocatedArray<GLushort> triangle_buffer;
-
-    unsigned idx_count = PolygonToTriangles(points + start, size,
-                                            triangle_buffer);
-    if (idx_count == 0)
-      return;
-
-    /* add offset to all vertex indices */
-    for (unsigned i = 0; i < idx_count; ++i)
-      triangle_buffer[i] += start;
-
-    glDrawElements(GL_TRIANGLES, idx_count, GL_UNSIGNED_SHORT,
-                   triangle_buffer.data());
-  }
-
-  void DrawOutline(const BulkPixelPoint *all_points, unsigned start,
-                   unsigned pen_width) const noexcept {
-    const BulkPixelPoint *fan_points = all_points + start;
-
-    if (UseOpenGLLineLoopOutline(pen_width)) {
-      glDrawArrays(GL_LINE_LOOP, start, size);
-    } else {
-      static AllocatedArray<BulkPixelPoint> outline_buffer;
-      const unsigned strip_len =
-        LineToTriangles(fan_points, size, outline_buffer,
-                        pen_width, true);
-      if (strip_len > 0) {
-        const ScopeVertexPointer vp{outline_buffer.data()};
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
-      }
-    }
-  }
-#else
-  void DrawFill(Canvas &canvas, const BulkPixelPoint *points) const noexcept {
-    canvas.DrawPolygon(&points[0], size);
-  }
-
-  void DrawOutline(Canvas &canvas, const BulkPixelPoint *points) const noexcept {
-    canvas.DrawPolygon(&points[0], size);
-  }
-#endif
-};
-
-struct ProjectedFans {
-  typedef StaticArray<ProjectedFan, FlatTriangleFanTree::MAX_FANS> ProjectedFanVector;
-
-  ProjectedFanVector fans;
-
-  /**
-   * All points of all ProjectedFan objects.  The first one starts of
-   * points[0], followed by the second one at points[fans[0].size],
-   * etc.
-   */
-  BulkPixelPointVector points;
-
-#ifndef NDEBUG
-  unsigned remaining = 0;
-#endif
-
-  ProjectedFans() noexcept {
-    /* try to guess the total number of vertices */
-    points.reserve(FlatTriangleFanTree::MAX_FANS * ROUTEPOLAR_POINTS / 10);
-  }
-
-  bool empty() const noexcept {
-    return fans.empty();
-  }
-
-  bool full() const noexcept {
-    return fans.full();
-  }
-
-  ProjectedFanVector::size_type size() const noexcept {
-    return fans.size();
-  }
-
-  ProjectedFan &Append(unsigned n) noexcept {
-#ifndef NDEBUG
-    assert(remaining == 0);
-    remaining = n;
-#endif
-
-    points.reserve(points.size() + n);
-
-    fans.push_back(ProjectedFan(n));
-    return fans.back();
-  }
-
-  void Append(const PixelPoint &pt) noexcept {
-#ifndef NDEBUG
-    assert(remaining > 0);
-    --remaining;
-#endif
-
-    points.push_back(pt);
-  }
-
-  void DrawFill([[maybe_unused]] Canvas &canvas) const noexcept {
-    assert(remaining == 0);
-
-#ifdef ENABLE_OPENGL
-    unsigned start = 0;
-    const auto *points = &this->points[0];
-    for (auto i = fans.begin(), end = fans.end(); i != end; ++i) {
-      i->DrawFill(points, start);
-      start += i->size;
-    }
-#else
-    const auto *points = &this->points[0];
-    for (auto i = fans.begin(), end = fans.end(); i != end; ++i) {
-      i->DrawFill(canvas, points);
-      points += i->size;
-    }
-#endif
-  }
-
-#ifdef ENABLE_OPENGL
-  void DrawOutline(unsigned pen_width) const noexcept {
-    assert(remaining == 0);
-
-    const auto *points = &this->points[0];
-    unsigned start = 0;
-    for (auto i = fans.begin(), end = fans.end(); i != end; ++i) {
-      i->DrawOutline(points, start, pen_width);
-      start += i->size;
-    }
-  }
-#else
-  void DrawOutline(Canvas &canvas) const noexcept {
-    assert(remaining == 0);
-
-    const auto *points = &this->points[0];
-    for (auto i = fans.begin(), end = fans.end(); i != end; ++i) {
-      i->DrawOutline(canvas, points);
-      points += i->size;
-    }
-  }
-#endif
-};
-
-typedef StaticArray<ProjectedFan, FlatTriangleFanTree::MAX_FANS> ProjectedFanVector;
+#include <vector>
 
 class TriangleCompound final : public FlatTriangleFanVisitor {
   /**
@@ -186,10 +29,14 @@ class TriangleCompound final : public FlatTriangleFanVisitor {
   /** GeoClip instance used for TriangleFan clipping */
   const GeoClip clip;
 
-public:
-  /** STL-Container of rasterized polygons */
-  ProjectedFans fans;
+  StaticArray<unsigned, FlatTriangleFanTree::MAX_FANS> sizes;
 
+  /**
+   * Concatenated geographic rings; ring i has sizes[i] vertices.
+   */
+  std::vector<GeoPoint> geo;
+
+public:
   TriangleCompound(const FlatProjection &_flat_projection,
                    const MapWindowProjection &_proj) noexcept
     :flat_projection(_flat_projection), proj(_proj),
@@ -197,30 +44,59 @@ public:
   {
   }
 
+  bool empty() const noexcept {
+    return sizes.empty();
+  }
+
+  auto size() const noexcept {
+    return sizes.size();
+  }
+
+  void DrawFill(Canvas &canvas) const noexcept {
+    MapCanvas map_canvas(canvas, proj, clip);
+    unsigned start = 0;
+    for (unsigned n : sizes) {
+      map_canvas.FillPolygon(&geo[start], n);
+      start += n;
+    }
+  }
+
+  void DrawOutline(Canvas &canvas) const noexcept {
+    MapCanvas map_canvas(canvas, proj, clip);
+    unsigned start = 0;
+    for (unsigned n : sizes) {
+      map_canvas.DrawPolygonOutline(&geo[start], n);
+      start += n;
+    }
+  }
+
   /* virtual methods from class FlatTriangleFanVisitor */
 
-  void VisitFan([[maybe_unused]] FlatGeoPoint origin, std::span<const FlatGeoPoint> fan) noexcept override {
+  void VisitFan([[maybe_unused]] FlatGeoPoint origin,
+                std::span<const FlatGeoPoint> fan) noexcept override {
 
-    if (fan.size() < 3 || fans.full())
+    if (fan.size() < 3 || sizes.full())
       return;
 
     GeoPoint g[ROUTEPOLAR_POINTS + 2];
     for (size_t i = 0; i < fan.size(); ++i)
       g[i] = flat_projection.Unproject(fan[i]);
 
-    // Perform clipping on the GeoPointVector
-    GeoPoint clipped[(ROUTEPOLAR_POINTS + 2) * 3];
-    unsigned size = clip.ClipPolygon(clipped, g, fan.size());
-    // With less than three points we can't draw a polygon
-    if (size < 3)
+    unsigned n = (unsigned)fan.size();
+    if (g[0] == g[n - 1])
+      n--;
+    if (n < 3)
       return;
 
-    // Work directly on the PixelPoints in the fans vector
-    fans.Append(size);
+    GeoBounds bb(g[0]);
+    for (unsigned i = 1; i < n; ++i)
+      bb.Extend(g[i]);
+    if (bb.IsValid() && !clip.Overlaps(bb))
+      return;
 
-    // Convert GeoPoints to PixelPoints
-    for (unsigned i = 0; i < size; ++i)
-      fans.Append(proj.GeoToScreen(clipped[i]));
+    sizes.push_back(n);
+    for (unsigned i = 0; i < n; ++i)
+      geo.push_back(g[i]);
   }
 };
 
@@ -268,7 +144,7 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
                                visitor, working);
 
   // Exit early if not fans found
-  if (visitor.fans.empty())
+  if (visitor.empty())
     return;
 
   const Pen& reach_pen = working? look.reach_working_pen : look.reach_terrain_pen;
@@ -285,8 +161,6 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
 
 #ifdef ENABLE_OPENGL
 
-    const ScopeVertexPointer vp(&visitor.fans.points[0]);
-
     const GLEnable<GL_STENCIL_TEST> stencil_test;
     glClear(GL_STENCIL_BUFFER_BIT);
 
@@ -295,8 +169,9 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
     glStencilFunc(GL_ALWAYS, 1, 1);
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-    COLOR_WHITE.Bind();
-    visitor.fans.DrawFill(canvas);
+    canvas.SelectWhiteBrush();
+    canvas.SelectNullPen();
+    visitor.DrawFill(canvas);
 
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
     glStencilFunc(GL_NOTEQUAL, 1, 1);
@@ -325,7 +200,7 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
     buffer.SetBackgroundColor(Color(0xf0, 0xf0, 0xf0));
 
     // Draw the TerrainLine polygons
-    visitor.fans.DrawOutline(buffer);
+    visitor.DrawOutline(buffer);
 
     // Select a white brush (will later be transparent)
     buffer.SelectNullPen();
@@ -333,7 +208,7 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
 
     // Draw the TerrainLine polygons to remove the
     // brush pattern from the polygon areas
-    visitor.fans.DrawFill(buffer);
+    visitor.DrawFill(buffer);
 
     // Copy everything non-white to the buffer
     canvas.CopyTransparentWhite({0, 0}, render_projection.GetScreenSize(),
@@ -347,12 +222,12 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
 
   }
 
-  if (visitor.fans.size() == 1) {
+  if (visitor.size() == 1) {
     /* only one fan: we can draw a simple polygon */
 
 #ifdef ENABLE_OPENGL
-    const ScopeVertexPointer vp(&visitor.fans.points[0]);
-    reach_pen.Bind();
+    canvas.Select(reach_pen);
+    visitor.DrawOutline(canvas);
 #else
     // Select the TerrainLine pen
     canvas.SelectHollowBrush();
@@ -365,22 +240,14 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
 
     // Draw the TerrainLine polygon
 
-#ifdef ENABLE_OPENGL
-    visitor.fans.DrawOutline(reach_pen.GetWidth());
-#else
-    visitor.fans.DrawOutline(canvas);
-#endif
-
-#ifdef ENABLE_OPENGL
-    reach_pen.Unbind();
+#ifndef ENABLE_OPENGL
+    visitor.DrawOutline(canvas);
 #endif
   } else {
     /* more than one fan (turning reach enabled): we have to use a
        stencil to draw the outline, because the fans may overlap */
 
 #ifdef ENABLE_OPENGL
-  const ScopeVertexPointer vp(&visitor.fans.points[0]);
-
   glEnable(GL_STENCIL_TEST);
   glClear(GL_STENCIL_BUFFER_BIT);
 
@@ -389,16 +256,16 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
   glStencilFunc(GL_ALWAYS, 1, 1);
   glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-  COLOR_WHITE.Bind();
-  visitor.fans.DrawFill(canvas);
+  canvas.SelectWhiteBrush();
+  canvas.SelectNullPen();
+  visitor.DrawFill(canvas);
 
   glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
   glStencilFunc(GL_NOTEQUAL, 1, 1);
   glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
 
-  reach_pen_thick.Bind();
-  visitor.fans.DrawOutline(reach_pen_thick.GetWidth());
-  reach_pen_thick.Unbind();
+  canvas.Select(reach_pen_thick);
+  visitor.DrawOutline(canvas);
 
   glDisable(GL_STENCIL_TEST);
 
@@ -417,7 +284,7 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
   buffer.SetBackgroundColor(Color(0xf0, 0xf0, 0xf0));
 
   // Draw the TerrainLine polygons
-  visitor.fans.DrawOutline(buffer);
+  visitor.DrawOutline(buffer);
 
   // Select a white brush (will later be transparent)
   buffer.SelectNullPen();
@@ -427,7 +294,7 @@ MapWindow::RenderTerrainAbove(Canvas &canvas, bool working) noexcept
   // the lines connecting all the polygons
   //
   // This removes half of the TerrainLine line width !!
-  visitor.fans.DrawFill(buffer);
+  visitor.DrawFill(buffer);
 
   // Copy everything non-white to the buffer
   canvas.CopyTransparentWhite({0, 0}, render_projection.GetScreenSize(),

--- a/src/MapWindow/OverlayBitmap.cpp
+++ b/src/MapWindow/OverlayBitmap.cpp
@@ -9,26 +9,17 @@
 #include "ui/canvas/opengl/VertexPointer.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Math/Point2D.hpp"
-#include "Math/Quadrilateral.hpp"
 #include "Math/Boost/Point.hpp"
 #include "system/Path.hpp"
 #include "util/StaticArray.hxx"
 
 #include <algorithm>
 #include <boost/geometry/geometries/register/ring.hpp>
-#include <boost/geometry/geometries/polygon.hpp>
-#include <boost/geometry/geometries/multi_polygon.hpp>
-#include <boost/geometry/algorithms/intersection.hpp>
 #include <boost/geometry/algorithms/covered_by.hpp>
 #include <boost/geometry/strategies/strategies.hpp>
 
 using ArrayQuadrilateral = StaticArray<DoublePoint2D, 5>;
 BOOST_GEOMETRY_REGISTER_RING(ArrayQuadrilateral);
-
-using ClippedPolygon = boost::geometry::model::polygon<DoublePoint2D>;
-
-using ClippedMultiPolygon =
-  boost::geometry::model::multi_polygon<ClippedPolygon>;
 
 MapOverlayBitmap::MapOverlayBitmap(Path path)
   :label((path.GetBase() != nullptr ? path.GetBase() : path).c_str())
@@ -38,32 +29,12 @@ MapOverlayBitmap::MapOverlayBitmap(Path path)
 }
 
 /**
- * Convert a GeoPoint to a "fake" flat DoublePoint2D.  This conversion
- * is flawed in many ways, but good enough for clipping polygons.
+ * Convert a GeoPoint to a "fake" flat DoublePoint2D.
  */
 static constexpr DoublePoint2D
 GeoTo2D(GeoPoint p) noexcept
 {
   return {p.longitude.Native(), p.latitude.Native()};
-}
-
-/**
- * Inverse of GeoTo2D().
- */
-static constexpr GeoPoint
-GeoFrom2D(DoublePoint2D p) noexcept
-{
-  return {Angle::Native(p.x), Angle::Native(p.y)};
-}
-
-/**
- * Convert a #GeoBounds instance to a boost::geometry box.
- */
-[[gnu::const]]
-static boost::geometry::model::box<DoublePoint2D>
-ToBox(const GeoBounds b) noexcept
-{
-  return {GeoTo2D(b.GetSouthWest()), GeoTo2D(b.GetNorthEast())};
 }
 
 /**
@@ -77,37 +48,6 @@ ToArrayQuadrilateral(const GeoQuadrilateral q) noexcept
       GeoTo2D(q.bottom_right), GeoTo2D(q.bottom_left),
       /* close the ring: */
       GeoTo2D(q.top_left) };
-}
-
-/**
- * Clip the quadrilateral inside the screen bounds.
- */
-[[gnu::pure]]
-static ClippedMultiPolygon
-Clip(const GeoQuadrilateral &_geo, const GeoBounds &_bounds) noexcept
-{
-  const auto geo = ToArrayQuadrilateral(_geo);
-  const auto bounds = ToBox(_bounds);
-
-  ClippedMultiPolygon clipped;
-
-  try {
-    boost::geometry::intersection(geo, bounds, clipped);
-  } catch (const boost::geometry::exception &) {
-    /* this can (theoretically) occur with self-intersecting
-       geometries; in that case, return an empty polygon */
-  }
-
-  return clipped;
-}
-
-[[gnu::pure]]
-static DoublePoint2D
-MapInQuadrilateral(const GeoQuadrilateral &q, const GeoPoint p) noexcept
-{
-  return MapInQuadrilateral(GeoTo2D(q.top_left), GeoTo2D(q.top_right),
-                            GeoTo2D(q.bottom_right), GeoTo2D(q.bottom_left),
-                            GeoTo2D(p));
 }
 
 [[gnu::pure]]
@@ -155,8 +95,10 @@ MapOverlayBitmap::Draw([[maybe_unused]] Canvas &canvas,
   const double x_factor = double(texture.GetWidth()) / allocated.width;
   const double y_factor = double(texture.GetHeight()) / allocated.height;
 
-  Point2D<GLfloat> coord[16];
-  BulkPixelPoint vertices[16];
+  Point2D<GLfloat> coord[4];
+  /* Float positions so OpenGL can clip corners that sit far off the
+     screen.  GLshort wraps at ±32767 and the tile vanishes. */
+  FloatPoint2D vertices[4];
 
   const ScopeVertexPointer vp(vertices);
 
@@ -200,10 +142,11 @@ MapOverlayBitmap::Draw([[maybe_unused]] Canvas &canvas,
         };
 
         for (unsigned i = 0; i < 4; ++i) {
-          coord[i].x = uv[i][0] * x_factor;
-          coord[i].y = (bitmap.IsFlipped() ? 1 - uv[i][1] : uv[i][1]) * y_factor;
-
-          vertices[i] = projection.GeoToScreen(geo[i]);
+          coord[i].x = GLfloat(uv[i][0] * x_factor);
+          coord[i].y = GLfloat((bitmap.IsFlipped() ? 1 - uv[i][1]
+                                                   : uv[i][1]) * y_factor);
+          const auto sp = projection.GeoToScreen(geo[i]);
+          vertices[i] = FloatPoint2D(float(sp.x), float(sp.y));
         }
 
         glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
@@ -214,31 +157,31 @@ MapOverlayBitmap::Draw([[maybe_unused]] Canvas &canvas,
     return;
   }
 
-  auto clipped = Clip(bounds, screen_bounds);
-  if (clipped.empty()) {
-    glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
-    return;
+  /* Draw the full quad and let OpenGL clip.  Clipping to the screen
+     AABB then rebuilding a TRIANGLE_FAN made partly visible tiles
+     flicker (MapInQuadrilateral UVs jumped to -1 on the clip edge). */
+  const GeoPoint geo[4] = {
+    bounds.top_left,
+    bounds.top_right,
+    bounds.bottom_right,
+    bounds.bottom_left,
+  };
+  const double uv[4][2] = {
+    {0, 0},
+    {1, 0},
+    {1, 1},
+    {0, 1},
+  };
+
+  for (unsigned i = 0; i < 4; ++i) {
+    coord[i].x = GLfloat(uv[i][0] * x_factor);
+    coord[i].y = GLfloat((bitmap.IsFlipped() ? 1 - uv[i][1]
+                                             : uv[i][1]) * y_factor);
+    const auto sp = projection.GeoToScreen(geo[i]);
+    vertices[i] = FloatPoint2D(float(sp.x), float(sp.y));
   }
 
-  for (const auto &polygon : clipped) {
-    const auto &ring = polygon.outer();
-
-    size_t n = ring.size();
-    if (ring.front() == ring.back())
-      --n;
-
-    for (size_t i = 0; i < n; ++i) {
-      const auto v = GeoFrom2D(ring[i]);
-
-      auto p = MapInQuadrilateral(bounds, v);
-      coord[i].x = p.x * x_factor;
-      coord[i].y = (bitmap.IsFlipped() ? 1 - p.y : p.y) * y_factor;
-
-      vertices[i] = projection.GeoToScreen(v);
-    }
-
-    glDrawArrays(GL_TRIANGLE_FAN, 0, n);
-  }
+  glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 
   glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
 }

--- a/src/MapWindow/StencilMapCanvas.cpp
+++ b/src/MapWindow/StencilMapCanvas.cpp
@@ -4,6 +4,7 @@
 #ifndef ENABLE_OPENGL
 
 #include "StencilMapCanvas.hpp"
+#include "MapCanvas.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "Renderer/AirspaceRendererSettings.hpp"
@@ -36,29 +37,12 @@ StencilMapCanvas::StencilMapCanvas(const StencilMapCanvas &other)
 void
 StencilMapCanvas::DrawSearchPointVector(const SearchPointVector &points)
 {
-  size_t size = points.size();
-  if (size < 3)
-    return;
-
-  /* copy all SearchPointVector elements to geo_points */
-  GeoPoint *geo_points = geo_points_buffer.get(size * 3);
-  for (unsigned i = 0; i < size; ++i)
-    geo_points[i] = points[i].GetLocation();
-
-  /* clip them */
-  size = clip.ClipPolygon(geo_points, geo_points, size);
-  if (size < 3)
-    /* it's completely outside the screen */
-    return;
-
-  /* draw it all */
-  BulkPixelPoint *screen = pixel_points_buffer.get(size);
-  for (unsigned i = 0; i < size; ++i)
-    screen[i] = proj.GeoToScreen(geo_points[i]);
-
-  buffer.DrawPolygon(&screen[0], size);
-  if (use_stencil)
-    stencil.DrawPolygon(&screen[0], size);
+  MapCanvas map_canvas(buffer, proj, clip);
+  map_canvas.FillPolygon(points);
+  if (use_stencil) {
+    MapCanvas stencil_canvas(stencil, proj, clip);
+    stencil_canvas.FillPolygon(points);
+  }
 }
 
 void

--- a/src/MapWindow/StencilMapCanvas.hpp
+++ b/src/MapWindow/StencilMapCanvas.hpp
@@ -6,12 +6,9 @@
 #ifndef ENABLE_OPENGL
 
 #include "Geo/GeoClip.hpp"
-#include "util/ReusableArray.hpp"
 
 struct PixelPoint;
-struct BulkPixelPoint;
 class Canvas;
-class Projection;
 class WindowProjection;
 struct AirspaceRendererSettings;
 class SearchPointVector;
@@ -22,13 +19,6 @@ class SearchPointVector;
 class StencilMapCanvas
 {
   const GeoClip clip;
-
-  /**
-   * A variable-length buffer for clipped GeoPoints.
-   */
-  ReusableArray<GeoPoint> geo_points_buffer;
-
-  ReusableArray<BulkPixelPoint> pixel_points_buffer;
 
 public:
   Canvas &buffer;

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -42,6 +42,7 @@ constexpr std::string_view DrawTerrain = "DrawTerrain";
 constexpr std::string_view SlopeShading = "SlopeShading";
 constexpr std::string_view SlopeShadingType = "SlopeShadingType";
 constexpr std::string_view TerrainContours = "TerrainContours";
+constexpr std::string_view TerrainGpuDemSpike = "TerrainGpuDemSpike";
 constexpr std::string_view DrawTopography = "DrawTopology";
 constexpr std::string_view FinalGlideTerrain = "FinalGlideTerrain";
 constexpr std::string_view AutoWind = "AutoWind";

--- a/src/Profile/TerrainConfig.cpp
+++ b/src/Profile/TerrainConfig.cpp
@@ -6,6 +6,10 @@
 #include "Map.hpp"
 #include "Terrain/TerrainSettings.hpp"
 
+#ifdef ENABLE_OPENGL
+#include <cstdlib>
+#endif
+
 void
 Profile::LoadTerrainRendererSettings(const ProfileMap &map,
                                      TerrainRendererSettings &settings)
@@ -34,4 +38,11 @@ Profile::LoadTerrainRendererSettings(const ProfileMap &map,
   if (map.Get(ProfileKeys::TerrainContours, contours) &&
       contours < (uint8_t)Contours::COUNT)
     settings.contours = (Contours)contours;
+
+  map.Get(ProfileKeys::TerrainGpuDemSpike, settings.gpu_dem_spike);
+#ifdef ENABLE_OPENGL
+  /* UNIX A/B without touching the profile editor. */
+  if (const char *env = getenv("XCSOAR_GPU_DEM"); env != nullptr)
+    settings.gpu_dem_spike = env[0] != '\0' && env[0] != '0';
+#endif
 }

--- a/src/Renderer/AirspaceLabelList.cpp
+++ b/src/Renderer/AirspaceLabelList.cpp
@@ -18,12 +18,11 @@ public:
     bool en1 = config.IsClassEnabled(label1.cls);
     bool en2 = config.IsClassEnabled(label2.cls);
 
-    if(en1 == en2)
-      return AirspaceAltitude::SortHighest(label2.base, label1.base);
-    else if(en1)
-      return false;
-    else
-      return true;
+    /* LabelBlock keeps the first box that claims a slot, so enabled
+       classes and higher bases must come first. */
+    if (en1 != en2)
+      return en1;
+    return AirspaceAltitude::SortHighest(label1.base, label2.base);
   }
 };
 

--- a/src/Renderer/AirspaceLabelRenderer.cpp
+++ b/src/Renderer/AirspaceLabelRenderer.cpp
@@ -14,6 +14,7 @@
 #include "Formatter/AirspaceFormatter.hpp"
 #include "Language/Language.hpp"
 #include "Renderer/TextInBox.hpp"
+#include "Renderer/LabelBlock.hpp"
 #include "Geo/GeoBounds.hpp"
 #include "NMEA/Aircraft.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -256,7 +257,7 @@ AirspaceLabelRenderer::DrawInternal(Canvas &canvas,
 
   if (draw_altitude_labels) {
     for (const auto &label : labels)
-      DrawLabel(canvas, projection, label);
+      DrawLabel(canvas, projection, label, label_block);
   }
 
   if (draw_notam_labels) {
@@ -330,7 +331,8 @@ AirspaceLabelRenderer::DrawInternal(Canvas &canvas,
 inline void
 AirspaceLabelRenderer::DrawLabel(Canvas &canvas,
                                  const WindowProjection &projection,
-                                 const AirspaceLabelList::Label &label) noexcept
+                                 const AirspaceLabelList::Label &label,
+                                 LabelBlock *label_block) noexcept
 {
   char topText[NAME_SIZE + 1];
   AirspaceFormatter::FormatAltitudeShort(topText, label.top, false);
@@ -345,13 +347,20 @@ AirspaceLabelRenderer::DrawLabel(Canvas &canvas,
     std::max(topSize.width, baseSize.width) + 2 * padding;
   const unsigned labelHeight = topSize.height + baseSize.height;
 
-  // box
-  const auto pos = projection.GeoToScreen(label.pos);
+  /* Stay on GetCenter(); do not slide the box onto the visible clip
+     of a large airspace.  Skip if that centre is off the map. */
+  const auto pos = projection.GeoToScreenIfVisible(label.pos);
+  if (!pos)
+    return;
+
   PixelRect rect;
-  rect.left = pos.x - labelWidth / 2;
-  rect.top = pos.y;
+  rect.left = pos->x - int(labelWidth / 2);
+  rect.top = pos->y;
   rect.right = rect.left + labelWidth;
   rect.bottom = rect.top + labelHeight;
+  if (label_block != nullptr && !label_block->check(rect))
+    return;
+
   canvas.DrawRectangle(rect);
 
 #ifdef USE_GDI

--- a/src/Renderer/AirspaceLabelRenderer.hpp
+++ b/src/Renderer/AirspaceLabelRenderer.hpp
@@ -63,7 +63,8 @@ private:
                     LabelBlock *label_block) noexcept;
 
   void DrawLabel(Canvas &canvas, const WindowProjection &projection,
-                 const AirspaceLabelList::Label &label) noexcept;
+                 const AirspaceLabelList::Label &label,
+                 LabelBlock *label_block) noexcept;
 
 public:
   /**

--- a/src/Renderer/AirspaceRendererGL.cpp
+++ b/src/Renderer/AirspaceRendererGL.cpp
@@ -82,8 +82,7 @@ private:
 
   void VisitPolygon(const AirspacePolygon &airspace) {
 	AirspaceClass as_type_or_class = settings.classes[airspace.GetTypeOrClass()].display ? airspace.GetTypeOrClass() : airspace.GetClass();
-    if (!PreparePolygon(airspace.GetPoints()))
-      return;
+    const bool prepared = PreparePolygon(airspace.GetPoints());
 
     const AirspaceClassRendererSettings &class_settings =
       settings.classes[as_type_or_class];
@@ -93,7 +92,7 @@ private:
       class_settings.fill_mode ==
       AirspaceClassRendererSettings::FillMode::ALL;
 
-    if (!warning_manager.IsAcked(airspace) &&
+    if (prepared && !warning_manager.IsAcked(airspace) &&
         class_settings.fill_mode !=
         AirspaceClassRendererSettings::FillMode::NONE) {
       const GLEnable<GL_STENCIL_TEST> stencil;
@@ -101,7 +100,7 @@ private:
       if (!fill_airspace) {
         // set stencil for filling (bit 0)
         SetFillStencil();
-        DrawPrepared();
+        DrawPolygonOutline(airspace.GetPoints());
         glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
       }
 
@@ -115,14 +114,14 @@ private:
       if (!fill_airspace) {
         // clear fill stencil (bit 0)
         ClearFillStencil();
-        DrawPrepared();
+        DrawPolygonOutline(airspace.GetPoints());
         glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
       }
     }
 
-    // draw outline
+    /* ClipPolygon inserts view-box edges; draw the original ring. */
     if (SetupOutline(airspace))
-      DrawPrepared();
+      DrawPolygonOutline(airspace.GetPoints());
   }
 
 public:
@@ -232,18 +231,15 @@ private:
   }
 
   void VisitPolygon(const AirspacePolygon &airspace) {
-    if (!PreparePolygon(airspace.GetPoints()))
-      return;
-
-    if (!warning_manager.IsAcked(airspace) && SetupInterior(airspace)) {
+    if (PreparePolygon(airspace.GetPoints()) &&
+        !warning_manager.IsAcked(airspace) && SetupInterior(airspace)) {
       // fill interior without overpainting any previous outlines
       GLEnable<GL_BLEND> blend;
       DrawPrepared();
     }
 
-    // draw outline
     if (SetupOutline(airspace))
-      DrawPrepared();
+      DrawPolygonOutline(airspace.GetPoints());
   }
 
 public:

--- a/src/Renderer/AirspaceRendererOther.cpp
+++ b/src/Renderer/AirspaceRendererOther.cpp
@@ -169,7 +169,7 @@ private:
   }
 
   void VisitPolygon(const AirspacePolygon &airspace) {
-    DrawPolygon(airspace.GetPoints());
+    DrawPolygonOutline(airspace.GetPoints());
   }
 
 public:

--- a/src/Renderer/FAITriangleAreaRenderer.cpp
+++ b/src/Renderer/FAITriangleAreaRenderer.cpp
@@ -5,6 +5,7 @@
 #include "Engine/Task/Shapes/FAITriangleArea.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "Geo/GeoClip.hpp"
+#include "MapWindow/MapCanvas.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "ui/canvas/Canvas.hpp"
 
@@ -17,14 +18,7 @@ RenderFAISector(Canvas &canvas, const WindowProjection &projection,
   GeoPoint *geo_end = GenerateFAITriangleArea(geo_points, pt1, pt2,
                                               reverse, settings);
 
-  GeoPoint clipped[FAI_TRIANGLE_SECTOR_MAX * 3],
-    *clipped_end = clipped +
-    GeoClip(projection.GetScreenBounds().Scale(1.1))
-    .ClipPolygon(clipped, geo_points, geo_end - geo_points);
-
-  BulkPixelPoint points[FAI_TRIANGLE_SECTOR_MAX], *p = points;
-  for (GeoPoint *geo_i = clipped; geo_i != clipped_end;)
-    *p++ = projection.GeoToScreen(*geo_i++);
-
-  canvas.DrawPolygon(points, p - points);
+  MapCanvas map_canvas(canvas, projection,
+                       GeoClip(projection.GetScreenBounds().Scale(1.1)));
+  map_canvas.DrawPolygon(geo_points, geo_end - geo_points);
 }

--- a/src/Renderer/LabelBlock.cpp
+++ b/src/Renderer/LabelBlock.cpp
@@ -23,20 +23,29 @@ LabelBlock::reset() noexcept
 bool
 LabelBlock::check(const PixelRect rc) noexcept
 {
-  unsigned top = rc.top >> BUCKET_SHIFT;
-  unsigned bottom = rc.bottom >> BUCKET_SHIFT;
+  /* Negative Y used to shift into a huge unsigned bucket and clamp
+     to the last row, so labels along the top of the map collided
+     with those along the bottom. */
+  const unsigned y0 = rc.top < 0 ? 0 : unsigned(rc.top);
+  const unsigned y1 = rc.bottom < 0 ? 0 : unsigned(rc.bottom);
+
+  unsigned top = y0 >> BUCKET_SHIFT;
+  unsigned bottom = y1 >> BUCKET_SHIFT;
 
   if (top >= BUCKET_COUNT)
     top = BUCKET_COUNT - 1;
 
-  if (bottom < BUCKET_COUNT && !buckets[bottom].Check(rc))
+  if (bottom >= BUCKET_COUNT)
+    bottom = BUCKET_COUNT - 1;
+
+  if (!buckets[bottom].Check(rc))
     return false;
 
-  if (top < bottom && !buckets[top].Check(rc))
+  if (top != bottom && !buckets[top].Check(rc))
     return false;
 
   buckets[top].Add(rc);
-  if (bottom < BUCKET_COUNT && top != bottom)
+  if (top != bottom)
     buckets[bottom].Add(rc);
 
   return true;

--- a/src/Terrain/RasterMap.hpp
+++ b/src/Terrain/RasterMap.hpp
@@ -72,6 +72,14 @@ public:
     return projection;
   }
 
+  const RasterBuffer &GetOverview() const noexcept {
+    return raster_tile_cache.GetOverview();
+  }
+
+  const RasterTileCache &GetTileCache() const noexcept {
+    return raster_tile_cache;
+  }
+
   /**
    * The geographical distance in meters of the given amount
    * of pixels multiplied by 256.

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -3,6 +3,7 @@
 
 #include "Terrain/RasterRenderer.hpp"
 #include "Terrain/RasterMap.hpp"
+#include "Math/Angle.hpp"
 #include "Math/Constants.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/canvas/Ramp.hpp"
@@ -11,17 +12,25 @@
 #include "Renderer/GeoBitmapRenderer.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "ui/event/Idle.hpp"
+#include "Hardware/CPU.hpp"
 #include "LogFile.hpp"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Globals.hpp"
-#endif
-
-#ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/ConstantAlpha.hpp"
+#include "ui/canvas/opengl/Scope.hpp"
+#include "ui/canvas/opengl/Texture.hpp"
+#include "ui/canvas/opengl/Shaders.hpp"
+#include "ui/canvas/opengl/Program.hpp"
+#include "ui/canvas/opengl/Attribute.hpp"
+#include "ui/canvas/opengl/VertexPointer.hpp"
+#include "ui/dim/BulkPoint.hpp"
 #endif
 
 #include <algorithm> // for std::clamp()
+#ifdef ENABLE_OPENGL
+#include <bit>
+#endif
 #include <cassert>
 #include <cstdint>
 
@@ -197,6 +206,11 @@ RasterRenderer::~RasterRenderer() noexcept
 static unsigned
 GetQuantisation() noexcept
 {
+  if (!IsSlowCPU())
+    /* fast hosts: full resolution immediately (GPU hillshade and
+       ScanMap are cheap enough without the idle ladder) */
+    return 1;
+
   if (IsUserIdle(1500))
     /* full terrain resolution when the user stops interacting */
     return 1;
@@ -349,20 +363,6 @@ RasterRenderer::GenerateImage(bool do_shading,
                               const Angle sunazimuth,
                               unsigned contour_spacing) noexcept
 {
-  if (image == nullptr ||
-      height_matrix.GetSize().x > image->GetSize().width ||
-      height_matrix.GetSize().y > image->GetSize().height) {
-    delete image;
-    image = new RawBitmap(PixelSize{height_matrix.GetSize()});
-
-    delete[] contour_column_base;
-    contour_column_base = new unsigned char[height_matrix.GetSize().x];
-
-    delete[] contour_pending;
-    contour_pending =
-      new ColumnContourPending[height_matrix.GetSize().x];
-  }
-
   // At extreme zoom out, terrain features are too small to be meaningful;
   // disable both slope shading and contours.
   ClampQuantisationEffectiveToMatrix(quantisation_effective,
@@ -387,6 +387,44 @@ RasterRenderer::GenerateImage(bool do_shading,
                Layout::ScalePenWidth(1u * 768u)
                / (quantisation_pixels * 1024u))
     : 1;
+
+#ifdef ENABLE_OPENGL
+  height_scale_for_draw = height_scale;
+  shading_for_draw = do_shading;
+  {
+    const unsigned q = std::max(1u, quantisation_effective);
+    const unsigned q_sq = q * q;
+    const unsigned max_hsf = std::max(1u, 8192u / q_sq);
+    height_slope_factor_for_draw =
+      std::clamp(static_cast<unsigned>(pixel_size), 1u, max_hsf);
+  }
+
+  if (!use_cpu_hillshade && OpenGL::hillshade_shader != nullptr &&
+      !has_alpha &&
+      height_matrix.GetSize().x > 0 && height_matrix.GetSize().y > 0) {
+    SetContourSpacing(contour_spacing);
+    UploadHeightTexture();
+    UploadRampTexture();
+    shader_hillshade = true;
+    return;
+  }
+
+  shader_hillshade = false;
+#endif
+
+  if (image == nullptr ||
+      height_matrix.GetSize().x > image->GetSize().width ||
+      height_matrix.GetSize().y > image->GetSize().height) {
+    delete image;
+    image = new RawBitmap(PixelSize{height_matrix.GetSize()});
+
+    delete[] contour_column_base;
+    contour_column_base = new unsigned char[height_matrix.GetSize().x];
+
+    delete[] contour_pending;
+    contour_pending =
+      new ColumnContourPending[height_matrix.GetSize().x];
+  }
 
   ContourStart(contour_height_scale);
 
@@ -679,6 +717,10 @@ RasterRenderer::PrepareColorTable(const ColorRamp *color_ramp, bool do_water,
   if (color_table == nullptr)
     color_table = new RawColor[256 * 128];
 
+#ifdef ENABLE_OPENGL
+  ramp_texture_dirty = true;
+#endif
+
   for (int i = 0; i < 256; i++) {
     for (int mag = -64; mag < 64; mag++) {
       RawColor color;
@@ -748,6 +790,10 @@ RasterRenderer::PrepareColorTableAlpha(const ColorRamp *color_ramp,
   if (color_table == nullptr)
     color_table = new RawColor[256 * 128];
 
+#ifdef ENABLE_OPENGL
+  ramp_texture_dirty = true;
+#endif
+
   for (int i = 0; i < 256; i++) {
     for (int mag = -64; mag < 64; mag++) {
       RawColor color;
@@ -787,6 +833,196 @@ RasterRenderer::ContourStart(const unsigned contour_height_scale) noexcept
               ColumnContourPending{});
 }
 
+#ifdef ENABLE_OPENGL
+
+static void
+FillRampRgba(uint8_t *dest, const RawColor *table) noexcept
+{
+  for (unsigned i = 0; i < 256 * 128; ++i) {
+#ifdef GREYSCALE
+    const uint8_t y = table[i].value.GetLuminosity();
+    *dest++ = y;
+    *dest++ = y;
+    *dest++ = y;
+    *dest++ = 255;
+#elif defined(USE_RGB565)
+    const uint16_t v = table[i].value.GetNativeValue();
+    *dest++ = uint8_t((v >> 8) & 0xf8);
+    *dest++ = uint8_t((v >> 3) & 0xfc);
+    *dest++ = uint8_t((v << 3) & 0xf8);
+    *dest++ = 255;
+#else
+    *dest++ = table[i].value.Red();
+    *dest++ = table[i].value.Green();
+    *dest++ = table[i].value.Blue();
+    *dest++ = table[i].alpha;
+#endif
+  }
+}
+
+void
+RasterRenderer::SetSunFromAzimuth(Angle sunazimuth, int brightness,
+                                  int contrast) noexcept
+{
+  const Angle fudgeelevation = Angle::Degrees(10) +
+    Angle::Degrees(80.0 / 255.0) * brightness;
+
+  sun_sx = (int)(255 * fudgeelevation.fastcosine() *
+                 -sunazimuth.fastsine());
+  sun_sy = (int)(255 * fudgeelevation.fastcosine() *
+                 -sunazimuth.fastcosine());
+  sun_sz = (int)(255 * fudgeelevation.fastsine());
+  contrast_for_draw = contrast;
+}
+
+void
+RasterRenderer::SetContourSpacing(unsigned contour_spacing) noexcept
+{
+  if (contour_spacing == 0) {
+    contour_div_for_draw = 0;
+    return;
+  }
+
+  unsigned s = 0;
+  while ((1u << s) < contour_spacing)
+    ++s;
+
+  contour_div_for_draw = s >= 16 ? 0 : (1u << s);
+}
+
+void
+RasterRenderer::UploadHeightTexture() noexcept
+{
+  const auto sz = height_matrix.GetSize();
+  const PixelSize ps{int(sz.x), int(sz.y)};
+  const void *data = height_matrix.GetData();
+
+  /* decode_height() reads L then A as little-endian int16. */
+  static_assert(std::endian::native == std::endian::little);
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+  if (height_texture == nullptr || height_texture->GetSize() != ps) {
+    height_texture = std::make_unique<GLTexture>(GL_LUMINANCE_ALPHA, ps,
+                                                 GL_LUMINANCE_ALPHA,
+                                                 GL_UNSIGNED_BYTE, data);
+  } else {
+    height_texture->Bind();
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, ps.width, ps.height,
+                    GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
+  }
+
+  height_texture->Bind();
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+}
+
+void
+RasterRenderer::UploadRampTexture() noexcept
+{
+  assert(color_table != nullptr);
+
+  if (ramp_texture != nullptr && !ramp_texture_dirty)
+    return;
+
+  constexpr unsigned n = 256 * 128 * 4;
+  if (ramp_rgba == nullptr)
+    ramp_rgba = std::make_unique<uint8_t[]>(n);
+
+  FillRampRgba(ramp_rgba.get(), color_table);
+
+  constexpr PixelSize ramp_size{256, 128};
+
+  glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+  if (ramp_texture == nullptr) {
+    ramp_texture = std::make_unique<GLTexture>(GL_RGBA, ramp_size,
+                                               GL_RGBA, GL_UNSIGNED_BYTE,
+                                               ramp_rgba.get());
+  } else {
+    ramp_texture->Bind();
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
+                    ramp_size.width, ramp_size.height,
+                    GL_RGBA, GL_UNSIGNED_BYTE, ramp_rgba.get());
+  }
+
+  ramp_texture->Bind();
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  ramp_texture_dirty = false;
+}
+
+void
+RasterRenderer::DrawHillshade(const WindowProjection &projection,
+                              float alpha) const noexcept
+{
+  assert(bounds.IsValid());
+  assert(height_texture != nullptr);
+  assert(ramp_texture != nullptr);
+
+  const BulkPixelPoint vertices[] = {
+    projection.GeoToScreen(bounds.GetNorthWest()),
+    projection.GeoToScreen(bounds.GetNorthEast()),
+    projection.GeoToScreen(bounds.GetSouthWest()),
+    projection.GeoToScreen(bounds.GetSouthEast()),
+  };
+
+  const ScopeVertexPointer vp(vertices);
+
+  glActiveTexture(GL_TEXTURE0);
+  height_texture->Bind();
+  glActiveTexture(GL_TEXTURE1);
+  ramp_texture->Bind();
+  glActiveTexture(GL_TEXTURE0);
+
+  OpenGL::hillshade_shader->Use();
+
+  const PixelSize allocated = height_texture->GetAllocatedSize();
+  const auto matrix_size = height_matrix.GetSize();
+  const GLfloat x1 = GLfloat(matrix_size.x) / allocated.width;
+  const GLfloat y1 = GLfloat(matrix_size.y) / allocated.height;
+  const GLfloat coord[] = {
+    0, 0,
+    x1, 0,
+    0, y1,
+    x1, y1,
+  };
+
+  glEnableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+  glVertexAttribPointer(OpenGL::Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
+                        0, coord);
+
+  const unsigned q = std::max(1u, quantisation_effective);
+  glUniform2f(OpenGL::hillshade_texel_step,
+              GLfloat(q) / allocated.width,
+              GLfloat(q) / allocated.height);
+  glUniform3f(OpenGL::hillshade_sun,
+              GLfloat(sun_sx), GLfloat(sun_sy), GLfloat(sun_sz));
+  glUniform1f(OpenGL::hillshade_contrast, GLfloat(contrast_for_draw));
+  glUniform1f(OpenGL::hillshade_height_slope_factor,
+              GLfloat(height_slope_factor_for_draw));
+  glUniform1f(OpenGL::hillshade_height_div,
+              GLfloat(1u << height_scale_for_draw));
+  glUniform1f(OpenGL::hillshade_q, GLfloat(q));
+  glUniform1f(OpenGL::hillshade_do_shading, shading_for_draw ? 1.f : 0.f);
+  glUniform2f(OpenGL::hillshade_height_texel,
+              1.f / GLfloat(allocated.width),
+              1.f / GLfloat(allocated.height));
+  glUniform1f(OpenGL::hillshade_contour_div,
+              GLfloat(contour_div_for_draw));
+
+  if (alpha < 1.0f) {
+    const GLBlend blend(alpha);
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  } else {
+    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+  }
+
+  glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+}
+
+#endif
+
 void
 RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                      const WindowProjection &projection,
@@ -794,14 +1030,23 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                      [[maybe_unused]] float alpha) const noexcept
 {
 #ifdef ENABLE_OPENGL
-  if (bounds.IsValid() && bounds.Overlaps(projection.GetScreenBounds())) {
-    const ScopeTextureConstantAlpha blend(has_alpha, alpha);
+  if (!bounds.IsValid() || !bounds.Overlaps(projection.GetScreenBounds()))
+    return;
 
-    DrawGeoBitmap(*image,
-                  PixelSize{height_matrix.GetSize()},
-                  bounds,
-                  projection);
+  if (shader_hillshade && height_texture && ramp_texture) {
+    DrawHillshade(projection, alpha);
+    return;
   }
+
+  if (image == nullptr)
+    return;
+
+  const ScopeTextureConstantAlpha blend(has_alpha, alpha);
+
+  DrawGeoBitmap(*image,
+                PixelSize{height_matrix.GetSize()},
+                bounds,
+                projection);
 #else
   image->StretchTo(PixelSize{height_matrix.GetSize()},
                    canvas, projection.GetScreenSize(),

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -1019,6 +1019,11 @@ RasterRenderer::DrawHillshade(const WindowProjection &projection,
   }
 
   glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glActiveTexture(GL_TEXTURE0);
+  OpenGL::solid_shader->Use();
 }
 
 #endif

--- a/src/Terrain/RasterRenderer.cpp
+++ b/src/Terrain/RasterRenderer.cpp
@@ -3,6 +3,10 @@
 
 #include "Terrain/RasterRenderer.hpp"
 #include "Terrain/RasterMap.hpp"
+#include "Terrain/RasterTileCache.hpp"
+#include "Terrain/RasterTile.hpp"
+#include "Terrain/RasterTraits.hpp"
+#include "Terrain/Height.hpp"
 #include "Math/Angle.hpp"
 #include "Math/Constants.hpp"
 #include "Screen/Layout.hpp"
@@ -14,6 +18,8 @@
 #include "ui/event/Idle.hpp"
 #include "Hardware/CPU.hpp"
 #include "LogFile.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/PeriodClock.hpp"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Globals.hpp"
@@ -25,6 +31,7 @@
 #include "ui/canvas/opengl/Attribute.hpp"
 #include "ui/canvas/opengl/VertexPointer.hpp"
 #include "ui/dim/BulkPoint.hpp"
+#include "ui/dim/Point.hpp"
 #endif
 
 #include <algorithm> // for std::clamp()
@@ -32,6 +39,8 @@
 #include <bit>
 #endif
 #include <cassert>
+#include <chrono>
+#include <cmath>
 #include <cstdint>
 
 /**
@@ -44,6 +53,134 @@ static constexpr double ZOOM_FACTOR_DIVISOR = 4250.0;
 static constexpr unsigned MAX_QUANTISATION_NEAR = 25;
 static constexpr unsigned MAX_QUANTISATION_LOW_ZOOM = 40;
 static constexpr double BOUNDS_SCALE_FACTOR = 1.5;
+
+static void
+ApplySlopeQuantisation(unsigned &quantisation_effective,
+                       double pixel_size,
+                       double map_cell_meters) noexcept
+{
+  if (pixel_size < PIXEL_SIZE_NORMAL_THRESHOLD) {
+    /* How many matrix cells one DEM sample spans.  Round down to
+       reduce slope artefacts from RasterBuffer interpolation. */
+    auto q = map_cell_meters / pixel_size;
+    quantisation_effective = std::max(1, (int)q);
+    const unsigned cap = Layout::FastScale(MAX_QUANTISATION_NEAR);
+    if (quantisation_effective > cap)
+      quantisation_effective = cap;
+  } else if (pixel_size < PIXEL_SIZE_LOW_ZOOM_THRESHOLD) {
+    auto q = map_cell_meters / pixel_size;
+    const double zoom_factor = 1.0 +
+      (pixel_size - PIXEL_SIZE_NORMAL_THRESHOLD) / ZOOM_FACTOR_DIVISOR;
+    quantisation_effective = std::max(1, (int)(q * zoom_factor));
+    const unsigned cap = Layout::FastScale(MAX_QUANTISATION_LOW_ZOOM);
+    if (quantisation_effective > cap)
+      quantisation_effective = cap;
+  } else {
+    /* Extremely far: terrain features are too small to shade. */
+    quantisation_effective = 0;
+  }
+}
+
+#ifdef ENABLE_OPENGL
+static double
+TerrainBoundsScale() noexcept
+{
+  /* Weak GPUs freeze ScanMap while dragging; a wider overscan keeps
+     the last height image covering the view so the white map
+     background does not show through. */
+  return OpenGL::idle_terrain_quantisation ? 2.5 : BOUNDS_SCALE_FACTOR;
+}
+
+static constexpr auto GPU_DEM_STATS_PERIOD = std::chrono::seconds(2);
+
+struct GpuDemStats {
+  PeriodClock log_clock;
+  unsigned frames = 0;
+  unsigned reuse = 0, prep = 0, scan = 0;
+  uint64_t prep_us = 0, prep_max_us = 0;
+  uint64_t scan_us = 0, scan_max_us = 0;
+  uint64_t draw_us = 0, draw_max_us = 0;
+  uint64_t gpu_sync_us = 0;
+  unsigned quads_ov = 0, quads_tile = 0;
+  unsigned uploads = 0;
+  uint64_t upload_bytes = 0;
+  unsigned last_q = 0, last_qe = 0, last_active = 0;
+  unsigned last_nx = 0, last_ny = 0;
+  unsigned last_sw = 0, last_sh = 0;
+  unsigned last_drawn = 0;
+  bool last_idle = false;
+  bool have_gpu_sync = false;
+
+  void Reset() noexcept {
+    frames = reuse = prep = scan = 0;
+    prep_us = prep_max_us = 0;
+    scan_us = scan_max_us = 0;
+    draw_us = draw_max_us = 0;
+    gpu_sync_us = 0;
+    quads_ov = quads_tile = 0;
+    uploads = 0;
+    upload_bytes = 0;
+    have_gpu_sync = false;
+  }
+
+  void AddUs(uint64_t us, uint64_t &sum, uint64_t &mx) noexcept {
+    sum += us;
+    if (us > mx)
+      mx = us;
+  }
+
+  void Flush() noexcept {
+    if (frames == 0)
+      return;
+
+    const auto elapsed = log_clock.Elapsed();
+    const double sec =
+      elapsed.count() > 0
+      ? std::chrono::duration<double>(elapsed).count()
+      : 2.0;
+    const double fps = frames / sec;
+    const unsigned prep_n = prep > 0 ? prep : 1;
+    const double prep_avg_ms = (prep_us / 1000.0) / prep_n;
+    const double draw_avg_ms = (draw_us / 1000.0) / frames;
+    const double tiles_pf = quads_tile / double(frames);
+
+    LogFmt("OpenGL: GPU DEM {:.1f}s frames={} ({:.0f}/s) idle={}",
+           sec, frames, fps, last_idle ? 1 : 0);
+    LogFmt("OpenGL: GPU DEM path reuse={} prep={} scan={}",
+           reuse, prep, scan);
+    LogFmt("OpenGL: GPU DEM cpu prep avg/max {:.2f}/{:.2f} ms  "
+           "scan avg/max {:.2f}/{:.2f} ms  "
+           "draw avg/max {:.2f}/{:.2f} ms",
+           prep_avg_ms, prep_max_us / 1000.0,
+           scan > 0 ? (scan_us / 1000.0) / scan : 0.0,
+           scan_max_us / 1000.0,
+           draw_avg_ms, draw_max_us / 1000.0);
+    LogFmt("OpenGL: GPU DEM quads ov={} tiles={} (avg {:.1f}/frame) "
+           "uploads={} ({:.1f} KiB)",
+           quads_ov, quads_tile, tiles_pf,
+           uploads, upload_bytes / 1024.0);
+    LogFmt("OpenGL: GPU DEM q={} qe={} active={} grid={}x{} "
+           "view={}x{} drawn={} gpu_sync={:.1f}ms",
+           last_q, last_qe, last_active, last_nx, last_ny,
+           last_sw, last_sh, last_drawn,
+           have_gpu_sync ? gpu_sync_us / 1000.0 : -1.0);
+
+    Reset();
+    log_clock.Update();
+  }
+};
+
+static GpuDemStats gpu_dem_stats;
+
+static uint64_t
+SteadyUsSince(std::chrono::steady_clock::time_point t0) noexcept
+{
+  return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - t0)
+                    .count());
+}
+
+#endif
 
 /** Keep slope neighbour sampling inside the height matrix. */
 static void
@@ -206,7 +343,7 @@ RasterRenderer::~RasterRenderer() noexcept
 static unsigned
 GetQuantisation() noexcept
 {
-  if (!IsSlowCPU())
+  if (!IsSlowCPU() && !OpenGL::idle_terrain_quantisation)
     /* fast hosts: full resolution immediately (GPU hillshade and
        ScanMap are cheap enough without the idle ladder) */
     return 1;
@@ -256,57 +393,17 @@ RasterRenderer::ScanMap(const RasterMap &map,
 
   pixel_size = quantisation_pixels / projection.GetScale();
 
-  // set resolution
-
-  if (pixel_size < PIXEL_SIZE_NORMAL_THRESHOLD) {
-    // Data point size of the (terrain) map in meters multiplied by 256
-    auto map_pixel_size = map.PixelDistance(center, 1);
-
-    // How many screen pixels does one data point stretch?
-    auto q = map_pixel_size / pixel_size;
-
-    /* round down to reduce slope shading artefacts (caused by
-       RasterBuffer interpolation) */
-    quantisation_effective = std::max(1, (int)q);
-
-    /* when zoomed in very near, use a large fixed area for slope
-       calculation to ensure terrain shading still works */
-    const unsigned max_quantisation_near = Layout::FastScale(MAX_QUANTISATION_NEAR);
-    if (quantisation_effective > max_quantisation_near)
-      quantisation_effective = max_quantisation_near;
-
-  } else if (pixel_size < PIXEL_SIZE_LOW_ZOOM_THRESHOLD) {
-    auto map_pixel_size = map.PixelDistance(center, 1);
-    auto q = map_pixel_size / pixel_size;
-
-    /* At low zoom levels (3000-20000m pixel size), use adaptive coarse
-       quantisation instead of completely disabling shading. Scale
-       quantisation based on pixel_size: at 3000m use calculated q
-       (transition from normal mode), at 20000m use ~4x coarser
-       quantisation for better performance */
-    const double zoom_factor = 1.0 + (pixel_size - PIXEL_SIZE_NORMAL_THRESHOLD) / ZOOM_FACTOR_DIVISOR;
-    quantisation_effective = std::max(1, (int)(q * zoom_factor));
-
-    /* Cap at reasonable maximum to avoid artifacts and maintain
-       performance. Higher cap than normal mode since we're at low zoom */
-    const unsigned max_quantisation_low_zoom = Layout::FastScale(MAX_QUANTISATION_LOW_ZOOM);
-    if (quantisation_effective > max_quantisation_low_zoom)
-      quantisation_effective = max_quantisation_low_zoom;
-
-  } else {
-    /* disable slope shading when zoomed out extremely far (pixel_size >= 20000m)
-       as terrain features become too small to be meaningful and performance
-       would suffer with reasonable quantisation */
-    quantisation_effective = 0;
-  }
+  ApplySlopeQuantisation(quantisation_effective, pixel_size,
+                         map.PixelDistance(center, 1));
 
 #ifdef ENABLE_OPENGL
-  bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
+  const double bounds_scale = TerrainBoundsScale();
+  bounds = projection.GetScreenBounds().Scale(bounds_scale);
   bounds.IntersectWith(map.GetBounds());
 
   UnsignedPoint2D matrix_size =
     (UnsignedPoint2D)projection.GetScreenSize()
-    * static_cast<unsigned>(BOUNDS_SCALE_FACTOR * 128.0f + 0.5f)
+    * static_cast<unsigned>(bounds_scale * 128.0f + 0.5f)
     / quantisation_pixels / 128;
   if (matrix_size.x == 0 || matrix_size.y == 0) {
     quantisation_effective = 0;
@@ -402,6 +499,7 @@ RasterRenderer::GenerateImage(bool do_shading,
   if (!use_cpu_hillshade && OpenGL::hillshade_shader != nullptr &&
       !has_alpha &&
       height_matrix.GetSize().x > 0 && height_matrix.GetSize().y > 0) {
+    gpu_dem_tiles = false;
     SetContourSpacing(contour_spacing);
     UploadHeightTexture();
     UploadRampTexture();
@@ -410,6 +508,7 @@ RasterRenderer::GenerateImage(bool do_shading,
   }
 
   shader_hillshade = false;
+  gpu_dem_tiles = false;
 #endif
 
   if (image == nullptr ||
@@ -891,30 +990,184 @@ RasterRenderer::SetContourSpacing(unsigned contour_spacing) noexcept
 }
 
 void
-RasterRenderer::UploadHeightTexture() noexcept
+RasterRenderer::UploadHeightLATexture(const void *data, PixelSize ps,
+                                      std::unique_ptr<GLTexture> &dest) noexcept
 {
-  const auto sz = height_matrix.GetSize();
-  const PixelSize ps{int(sz.x), int(sz.y)};
-  const void *data = height_matrix.GetData();
-
-  /* decode_height() reads L then A as little-endian int16. */
   static_assert(std::endian::native == std::endian::little);
 
   glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
 
-  if (height_texture == nullptr || height_texture->GetSize() != ps) {
-    height_texture = std::make_unique<GLTexture>(GL_LUMINANCE_ALPHA, ps,
-                                                 GL_LUMINANCE_ALPHA,
-                                                 GL_UNSIGNED_BYTE, data);
+  if (dest == nullptr || dest->GetSize() != ps) {
+    dest = std::make_unique<GLTexture>(GL_LUMINANCE_ALPHA, ps,
+                                       GL_LUMINANCE_ALPHA,
+                                       GL_UNSIGNED_BYTE, data);
   } else {
-    height_texture->Bind();
+    dest->Bind();
     glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, ps.width, ps.height,
                     GL_LUMINANCE_ALPHA, GL_UNSIGNED_BYTE, data);
   }
 
-  height_texture->Bind();
+  dest->Bind();
+  /* Packed int16 in L/A: decode, then filter in the shader. */
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+}
+
+void
+RasterRenderer::UploadHeightTexture() noexcept
+{
+  const auto sz = height_matrix.GetSize();
+  UploadHeightLATexture(height_matrix.GetData(),
+                        PixelSize{int(sz.x), int(sz.y)},
+                        height_texture);
+}
+
+void
+RasterRenderer::SyncGpuDemTileTextures(const RasterMap &map) noexcept
+{
+  const auto &cache = map.GetTileCache();
+  const unsigned nx = cache.GetTileCountX();
+  const unsigned ny = cache.GetTileCountY();
+  const unsigned n = nx * ny;
+  dem_tile_grid = {nx, ny};
+
+  tile_tex_active = 0;
+  tile_tex_dropped = false;
+
+  if (tile_textures.size() != n) {
+    tile_textures.clear();
+    tile_textures.resize(n);
+    tile_starts.assign(n, {});
+    tile_ends.assign(n, {});
+    /* Grid rebuild drops cached tile textures. */
+    tile_tex_dropped = true;
+  }
+
+  const RasterBuffer &overview = map.GetOverview();
+  if (overview.IsDefined()) {
+    const auto osz = overview.GetSize();
+    const PixelSize ps{int(osz.x), int(osz.y)};
+      if (overview_texture == nullptr || overview_texture->GetSize() != ps) {
+        UploadHeightLATexture(overview.GetData(), ps, overview_texture);
+        gpu_dem_stats.uploads++;
+        gpu_dem_stats.upload_bytes +=
+          unsigned(ps.width) * unsigned(ps.height) * 2u;
+      }
+  }
+
+  for (unsigned y = 0; y < ny; ++y) {
+    for (unsigned x = 0; x < nx; ++x) {
+      const unsigned i = y * nx + x;
+      const RasterTile &tile = cache.GetTile(x, y);
+      if (!tile.IsLoaded() || !tile.buffer.IsDefined()) {
+        if (tile_textures[i]) {
+          tile_textures[i].reset();
+          tile_tex_dropped = true;
+        }
+        continue;
+      }
+
+      ++tile_tex_active;
+      tile_starts[i] = tile.start;
+      tile_ends[i] = tile.end;
+      const auto tsz = tile.buffer.GetSize();
+      const PixelSize ps{int(tsz.x), int(tsz.y)};
+      auto &tex = tile_textures[i];
+      if (tex == nullptr || tex->GetSize() != ps) {
+        UploadHeightLATexture(tile.buffer.GetData(), ps, tex);
+        gpu_dem_stats.uploads++;
+        gpu_dem_stats.upload_bytes +=
+          unsigned(ps.width) * unsigned(ps.height) * 2u;
+      }
+    }
+  }
+}
+
+bool
+RasterRenderer::PrepareGpuDemTiles(const RasterMap &map,
+                                   const WindowProjection &projection,
+                                   bool do_shading,
+                                   unsigned height_scale,
+                                   unsigned contour_spacing,
+                                   bool allow_incremental) noexcept
+{
+  const auto t0 = std::chrono::steady_clock::now();
+  gpu_dem_tiles = false;
+
+  if (use_cpu_hillshade ||
+      OpenGL::hillshade_shader == nullptr ||
+      has_alpha)
+    return false;
+
+  SyncGpuDemTileTextures(map);
+  if (tile_tex_active == 0 && overview_texture == nullptr)
+    return false;
+
+  dem_map_bounds = map.GetBounds();
+  dem_projection = map.GetProjection();
+
+  /* Same overscan + resolution policy as ScanMap(). */
+  const GeoPoint center = projection.ScreenToGeo(projection.GetScreenCenter());
+  if (quantisation_pixels < 1)
+    quantisation_pixels = 1;
+  pixel_size = quantisation_pixels / projection.GetScale();
+  gpu_dem_cell_meters = std::max(1.0, map.PixelDistance(center, 1));
+  ApplySlopeQuantisation(quantisation_effective, pixel_size,
+                         gpu_dem_cell_meters);
+
+  last_quantisation_pixels = quantisation_pixels;
+
+  /* DrawGpuDemTiles uses the overview for coverage; keep an overscan
+     bounds only so Generate() can skip this call while panning. */
+  if (!allow_incremental || !bounds.IsValid() || tile_tex_dropped) {
+    bounds = projection.GetScreenBounds().Scale(BOUNDS_SCALE_FACTOR);
+    bounds.IntersectWith(dem_map_bounds);
+    if (!bounds.IsValid())
+      return false;
+  }
+
+  UnsignedPoint2D matrix_size =
+    (UnsignedPoint2D)projection.GetScreenSize() / quantisation_pixels;
+  if (matrix_size.x < 2)
+    matrix_size.x = 2;
+  if (matrix_size.y < 2)
+    matrix_size.y = 2;
+  ClampQuantisationEffectiveToMatrix(quantisation_effective, matrix_size);
+
+  height_scale_for_draw = height_scale;
+  shading_for_draw = do_shading && quantisation_effective > 0;
+  SetContourSpacing(contour_spacing);
+  UploadRampTexture();
+
+  gpu_dem_tiles = true;
+  shader_hillshade = true;
+
+  gpu_dem_stats.prep++;
+  gpu_dem_stats.AddUs(SteadyUsSince(t0),
+                      gpu_dem_stats.prep_us, gpu_dem_stats.prep_max_us);
+
+  static bool logged_gpu_dem = false;
+  if (!logged_gpu_dem) {
+    logged_gpu_dem = true;
+    LogFormat("OpenGL: GPU DEM tiles (overview + %u fine)",
+              tile_tex_active);
+  }
+
+  return true;
+}
+
+void
+RasterRenderer::GpuDemNoteReuse() noexcept
+{
+  gpu_dem_stats.reuse++;
+}
+
+void
+RasterRenderer::GpuDemNoteScanMap(unsigned cpu_us) noexcept
+{
+  gpu_dem_stats.scan++;
+  gpu_dem_stats.AddUs(cpu_us, gpu_dem_stats.scan_us,
+                      gpu_dem_stats.scan_max_us);
 }
 
 void
@@ -952,35 +1205,48 @@ RasterRenderer::UploadRampTexture() noexcept
   ramp_texture_dirty = false;
 }
 
-void
-RasterRenderer::DrawHillshade(const WindowProjection &projection,
-                              float alpha) const noexcept
+double
+RasterRenderer::GpuDemHeightSlopeFactor() const noexcept
 {
-  assert(bounds.IsValid());
-  assert(height_texture != nullptr);
+  /* Meters per DEM sample: n0/n2 is then the true slope. */
+  return gpu_dem_cell_meters;
+}
+
+void
+RasterRenderer::DrawHillshadeQuad(const WindowProjection &projection,
+                                  const GLTexture &height_tex,
+                                  const GeoPoint &nw, const GeoPoint &ne,
+                                  const GeoPoint &sw, const GeoPoint &se,
+                                  double height_slope_factor,
+                                  float alpha) const noexcept
+{
   assert(ramp_texture != nullptr);
 
   const BulkPixelPoint vertices[] = {
-    projection.GeoToScreen(bounds.GetNorthWest()),
-    projection.GeoToScreen(bounds.GetNorthEast()),
-    projection.GeoToScreen(bounds.GetSouthWest()),
-    projection.GeoToScreen(bounds.GetSouthEast()),
+    projection.GeoToScreen(nw),
+    projection.GeoToScreen(ne),
+    projection.GeoToScreen(sw),
+    projection.GeoToScreen(se),
   };
 
   const ScopeVertexPointer vp(vertices);
 
   glActiveTexture(GL_TEXTURE0);
-  height_texture->Bind();
+  const_cast<GLTexture &>(height_tex).Bind();
+  /* GLTexture::Configure() defaults to LINEAR; packed int16 heights
+     must stay NEAREST or decode-and-filter in the shader is skipped. */
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glActiveTexture(GL_TEXTURE1);
   ramp_texture->Bind();
   glActiveTexture(GL_TEXTURE0);
 
   OpenGL::hillshade_shader->Use();
 
-  const PixelSize allocated = height_texture->GetAllocatedSize();
-  const auto matrix_size = height_matrix.GetSize();
-  const GLfloat x1 = GLfloat(matrix_size.x) / allocated.width;
-  const GLfloat y1 = GLfloat(matrix_size.y) / allocated.height;
+  const PixelSize allocated = height_tex.GetAllocatedSize();
+  const PixelSize size = height_tex.GetSize();
+  const GLfloat x1 = GLfloat(size.width) / allocated.width;
+  const GLfloat y1 = GLfloat(size.height) / allocated.height;
   const GLfloat coord[] = {
     0, 0,
     x1, 0,
@@ -992,24 +1258,39 @@ RasterRenderer::DrawHillshade(const WindowProjection &projection,
   glVertexAttribPointer(OpenGL::Attribute::TEXCOORD, 2, GL_FLOAT, GL_FALSE,
                         0, coord);
 
-  const unsigned q = std::max(1u, quantisation_effective);
-  glUniform2f(OpenGL::hillshade_texel_step,
-              GLfloat(q) / allocated.width,
-              GLfloat(q) / allocated.height);
   glUniform3f(OpenGL::hillshade_sun,
               GLfloat(sun_sx), GLfloat(sun_sy), GLfloat(sun_sz));
-  glUniform1f(OpenGL::hillshade_contrast, GLfloat(contrast_for_draw));
+  /* GPU DEM samples real 90 m posts, not interpolated screen pixels.
+     The CPU contrast curve is too shallow for Jura-scale slopes at
+     default brightness; scale it so relief stays visible. */
+  const float contrast = gpu_dem_tiles
+    ? float(contrast_for_draw) * 2.5f
+    : float(contrast_for_draw);
+  glUniform1f(OpenGL::hillshade_contrast, contrast);
   glUniform1f(OpenGL::hillshade_height_slope_factor,
-              GLfloat(height_slope_factor_for_draw));
+              GLfloat(height_slope_factor));
   glUniform1f(OpenGL::hillshade_height_div,
               GLfloat(1u << height_scale_for_draw));
-  glUniform1f(OpenGL::hillshade_q, GLfloat(q));
   glUniform1f(OpenGL::hillshade_do_shading, shading_for_draw ? 1.f : 0.f);
   glUniform2f(OpenGL::hillshade_height_texel,
               1.f / GLfloat(allocated.width),
               1.f / GLfloat(allocated.height));
   glUniform1f(OpenGL::hillshade_contour_div,
               GLfloat(contour_div_for_draw));
+  {
+    const float span_x =
+      std::hypot(float(vertices[1].x - vertices[0].x),
+                 float(vertices[1].y - vertices[0].y));
+    const float span_y =
+      std::hypot(float(vertices[2].x - vertices[0].x),
+                 float(vertices[2].y - vertices[0].y));
+    /* Screen pixels per DEM texel (shader isoline width). */
+    const unsigned tw = std::max(1u, size.width);
+    const unsigned th = std::max(1u, size.height);
+    const GLfloat csx = span_x / float(tw);
+    const GLfloat csy = span_y / float(th);
+    glUniform2f(OpenGL::hillshade_contour_step, csx, csy);
+  }
 
   if (alpha < 1.0f) {
     const GLBlend blend(alpha);
@@ -1019,11 +1300,118 @@ RasterRenderer::DrawHillshade(const WindowProjection &projection,
   }
 
   glDisableVertexAttribArray(OpenGL::Attribute::TEXCOORD);
+}
+
+void
+RasterRenderer::DrawHillshade(const WindowProjection &projection,
+                              float alpha) const noexcept
+{
+  assert(bounds.IsValid());
+  assert(height_texture != nullptr);
+  assert(ramp_texture != nullptr);
+
+  DrawHillshadeQuad(projection, *height_texture,
+                    bounds.GetNorthWest(), bounds.GetNorthEast(),
+                    bounds.GetSouthWest(), bounds.GetSouthEast(),
+                    height_slope_factor_for_draw, alpha);
 
   glActiveTexture(GL_TEXTURE1);
   glBindTexture(GL_TEXTURE_2D, 0);
   glActiveTexture(GL_TEXTURE0);
   OpenGL::solid_shader->Use();
+}
+
+void
+RasterRenderer::DrawGpuDemTiles(const WindowProjection &projection,
+                                float alpha) const noexcept
+{
+  assert(ramp_texture != nullptr);
+  assert(dem_map_bounds.IsValid());
+
+  const auto t0 = std::chrono::steady_clock::now();
+  const GeoBounds screen = projection.GetScreenBounds();
+  const double hsf = GpuDemHeightSlopeFactor();
+  unsigned tiles_drawn = 0;
+  unsigned ov_drawn = 0;
+
+  if (overview_texture) {
+    const double overview_hsf =
+      std::max(1.0, hsf * double(1u << RasterTraits::OVERVIEW_BITS));
+    DrawHillshadeQuad(projection, *overview_texture,
+                      dem_map_bounds.GetNorthWest(),
+                      dem_map_bounds.GetNorthEast(),
+                      dem_map_bounds.GetSouthWest(),
+                      dem_map_bounds.GetSouthEast(),
+                      overview_hsf, alpha);
+    ov_drawn = 1;
+  }
+
+  const unsigned nx = dem_tile_grid.x;
+  const unsigned ny = dem_tile_grid.y;
+  if (nx > 0 && ny > 0 &&
+      tile_textures.size() == nx * ny &&
+      tile_starts.size() == nx * ny) {
+    for (unsigned i = 0; i < nx * ny; ++i) {
+      if (!tile_textures[i])
+        continue;
+
+      const RasterLocation start = tile_starts[i];
+      const RasterLocation end = tile_ends[i];
+      if (end.x <= start.x || end.y <= start.y)
+        continue;
+
+      const GeoPoint nw = dem_projection.UnprojectCoarse(start);
+      const GeoPoint ne = dem_projection.UnprojectCoarse(
+        SignedRasterLocation(int(end.x), int(start.y)));
+      const GeoPoint sw = dem_projection.UnprojectCoarse(
+        SignedRasterLocation(int(start.x), int(end.y)));
+      const GeoPoint se = dem_projection.UnprojectCoarse(end);
+
+      const GeoBounds tb(nw, se);
+      if (!tb.IsValid() || !tb.Overlaps(screen))
+        continue;
+
+      DrawHillshadeQuad(projection, *tile_textures[i],
+                        nw, ne, sw, se,
+                        hsf, alpha);
+      ++tiles_drawn;
+    }
+  }
+
+  glActiveTexture(GL_TEXTURE1);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  glActiveTexture(GL_TEXTURE0);
+  OpenGL::solid_shader->Use();
+
+  const uint64_t cpu_us = SteadyUsSince(t0);
+  gpu_dem_stats.frames++;
+  gpu_dem_stats.AddUs(cpu_us, gpu_dem_stats.draw_us,
+                      gpu_dem_stats.draw_max_us);
+  gpu_dem_stats.quads_ov += ov_drawn;
+  gpu_dem_stats.quads_tile += tiles_drawn;
+  gpu_dem_stats.last_q = quantisation_pixels;
+  gpu_dem_stats.last_qe = quantisation_effective;
+  gpu_dem_stats.last_active = tile_tex_active;
+  gpu_dem_stats.last_nx = nx;
+  gpu_dem_stats.last_ny = ny;
+  gpu_dem_stats.last_drawn = tiles_drawn;
+  const auto view = projection.GetScreenSize();
+  gpu_dem_stats.last_sw = view.width;
+  gpu_dem_stats.last_sh = view.height;
+  gpu_dem_stats.last_idle = IsUserIdle(750);
+
+  if (!gpu_dem_stats.log_clock.IsDefined())
+    gpu_dem_stats.log_clock.Update();
+  else if (gpu_dem_stats.log_clock.Check(GPU_DEM_STATS_PERIOD)) {
+    const auto g0 = std::chrono::steady_clock::now();
+    glFinish();
+    gpu_dem_stats.gpu_sync_us = SteadyUsSince(g0);
+    gpu_dem_stats.have_gpu_sync = true;
+    const GLenum err = glGetError();
+    if (err != GL_NO_ERROR)
+      LogFmt("OpenGL: GPU DEM glGetError=0x{:x}", unsigned(err));
+    gpu_dem_stats.Flush();
+  }
 }
 
 #endif
@@ -1035,6 +1423,13 @@ RasterRenderer::Draw([[maybe_unused]] Canvas &canvas,
                      [[maybe_unused]] float alpha) const noexcept
 {
 #ifdef ENABLE_OPENGL
+  if (gpu_dem_tiles && ramp_texture && dem_map_bounds.IsValid()) {
+    /* Overview first, then loaded fine tiles (covers holes). */
+    if (dem_map_bounds.Overlaps(projection.GetScreenBounds()))
+      DrawGpuDemTiles(projection, alpha);
+    return;
+  }
+
   if (!bounds.IsValid() || !bounds.Overlaps(projection.GetScreenBounds()))
     return;
 

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -9,6 +9,9 @@
 #include "Geo/GeoBounds.hpp"
 #endif
 
+#include <cstdint>
+#include <memory>
+
 static constexpr unsigned NUM_COLOR_RAMP_LEVELS = 13;
 
 class Angle;
@@ -42,8 +45,9 @@ class RasterRenderer {
 
   /**
    * Lower bound for the idle-based quantisation heuristic in
-   * UpdateQuantisation().  Terrain leaves this at 1 (allowing full
-   * resolution when idle); RASP raises it to suppress the step to 1.
+   * UpdateQuantisation() (slow CPUs only; fast hosts stay at 1).
+   * Terrain leaves this at 1 (allowing full resolution when idle);
+   * RASP raises it to suppress the step to 1.
    */
   unsigned min_quantisation_pixels = 1;
 #endif
@@ -61,6 +65,19 @@ class RasterRenderer {
    * texture has to be redrawn.
    */
   GeoBounds bounds = GeoBounds::Invalid();
+
+  std::unique_ptr<GLTexture> height_texture;
+  std::unique_ptr<GLTexture> ramp_texture;
+  std::unique_ptr<uint8_t[]> ramp_rgba;
+  bool use_cpu_hillshade = false;
+  bool shader_hillshade = false;
+  bool ramp_texture_dirty = true;
+  int sun_sx = 0, sun_sy = 0, sun_sz = 255;
+  int contrast_for_draw = 65;
+  unsigned height_scale_for_draw = 4;
+  double height_slope_factor_for_draw = 1;
+  bool shading_for_draw = true;
+  unsigned contour_div_for_draw = 0;
 #endif
 
   HeightMatrix height_matrix;
@@ -153,6 +170,14 @@ public:
   }
 
   /**
+   * True when SetQuantisationPixels() locked the value (previews).
+   */
+  [[gnu::pure]]
+  bool IsQuantisationFixed() const noexcept {
+    return fixed_quantisation;
+  }
+
+  /**
    * Calculate a new #quantisation_pixels value.
    *
    * @return true if the new #quantisation_pixels value is smaller
@@ -165,6 +190,28 @@ public:
   }
 
   const GLTexture &BindAndGetTexture() const noexcept;
+
+  /**
+   * Use the CPU GenerateSlopeImage() path even on OpenGL (A/B tests).
+   */
+  void SetUseCpuHillshade(bool cpu) noexcept {
+    use_cpu_hillshade = cpu;
+    shader_hillshade = false;
+  }
+
+  [[gnu::pure]]
+  bool IsShaderHillshade() const noexcept {
+    return shader_hillshade;
+  }
+
+  void SetSunFromAzimuth(Angle sunazimuth, int brightness,
+                         int contrast) noexcept;
+
+  /**
+   * Contour interval as a height divisor (power of two), or 0 to
+   * disable.  Applied in the hillshade shader without a CPU rebuild.
+   */
+  void SetContourSpacing(unsigned contour_spacing) noexcept;
 #endif
 
   /**
@@ -245,4 +292,11 @@ protected:
 
 private:
   void ContourStart(unsigned contour_height_scale) noexcept;
+
+#ifdef ENABLE_OPENGL
+  void UploadHeightTexture() noexcept;
+  void UploadRampTexture() noexcept;
+  void DrawHillshade(const WindowProjection &projection,
+                     float alpha) const noexcept;
+#endif
 };

--- a/src/Terrain/RasterRenderer.hpp
+++ b/src/Terrain/RasterRenderer.hpp
@@ -7,6 +7,10 @@
 
 #ifdef ENABLE_OPENGL
 #include "Geo/GeoBounds.hpp"
+#include "Terrain/RasterProjection.hpp"
+#include "Terrain/RasterLocation.hpp"
+#include "ui/dim/Size.hpp"
+#include <vector>
 #endif
 
 #include <cstdint>
@@ -76,8 +80,22 @@ class RasterRenderer {
   int contrast_for_draw = 65;
   unsigned height_scale_for_draw = 4;
   double height_slope_factor_for_draw = 1;
+  /** Meters between adjacent fine DEM samples (GPU DEM lighting). */
+  double gpu_dem_cell_meters = 1;
   bool shading_for_draw = true;
   unsigned contour_div_for_draw = 0;
+
+  /** Overview plus loaded fine-tile height textures. */
+  bool gpu_dem_tiles = false;
+  std::unique_ptr<GLTexture> overview_texture;
+  std::vector<std::unique_ptr<GLTexture>> tile_textures;
+  unsigned tile_tex_active = 0;
+  bool tile_tex_dropped = false;
+  GeoBounds dem_map_bounds = GeoBounds::Invalid();
+  RasterProjection dem_projection{};
+  UnsignedPoint2D dem_tile_grid{0, 0};
+  std::vector<RasterLocation> tile_starts;
+  std::vector<RasterLocation> tile_ends;
 #endif
 
   HeightMatrix height_matrix;
@@ -147,6 +165,7 @@ public:
 #ifdef ENABLE_OPENGL
   void Invalidate() noexcept {
     bounds.SetInvalid();
+    gpu_dem_tiles = false;
   }
 
   /**
@@ -212,6 +231,30 @@ public:
    * disable.  Applied in the hillshade shader without a CPU rebuild.
    */
   void SetContourSpacing(unsigned contour_spacing) noexcept;
+
+  [[gnu::pure]]
+  bool IsGpuDemTiles() const noexcept {
+    return gpu_dem_tiles;
+  }
+
+  /**
+   * Upload overview + loaded fine tiles; compose into height FBO.
+   * @param allow_incremental if true and coverage FBO is still valid,
+   *   blit only newly uploaded tiles (no clear).
+   * @return false → use ScanMap fallback.
+   */
+  bool PrepareGpuDemTiles(const RasterMap &map,
+                          const WindowProjection &projection,
+                          bool do_shading,
+                          unsigned height_scale,
+                          unsigned contour_spacing,
+                          bool allow_incremental=false) noexcept;
+
+  /** Generate() reused the last GPU DEM coverage (no Prepare). */
+  void GpuDemNoteReuse() noexcept;
+
+  /** ScanMap fallback after GPU DEM Prepare failed. */
+  void GpuDemNoteScanMap(unsigned cpu_us) noexcept;
 #endif
 
   /**
@@ -296,7 +339,20 @@ private:
 #ifdef ENABLE_OPENGL
   void UploadHeightTexture() noexcept;
   void UploadRampTexture() noexcept;
+  void UploadHeightLATexture(const void *data, PixelSize ps,
+                             std::unique_ptr<GLTexture> &dest) noexcept;
+  void SyncGpuDemTileTextures(const RasterMap &map) noexcept;
+  [[gnu::pure]]
+  double GpuDemHeightSlopeFactor() const noexcept;
+  void DrawHillshadeQuad(const WindowProjection &projection,
+                         const GLTexture &height_tex,
+                         const GeoPoint &nw, const GeoPoint &ne,
+                         const GeoPoint &sw, const GeoPoint &se,
+                         double height_slope_factor,
+                         float alpha) const noexcept;
   void DrawHillshade(const WindowProjection &projection,
                      float alpha) const noexcept;
+  void DrawGpuDemTiles(const WindowProjection &projection,
+                       float alpha) const noexcept;
 #endif
 };

--- a/src/Terrain/RasterTileCache.hpp
+++ b/src/Terrain/RasterTileCache.hpp
@@ -270,6 +270,29 @@ public:
   }
 
   /**
+   * Coarse full-map height buffer (1/16 of fine DEM resolution).
+   */
+  const RasterBuffer &GetOverview() const noexcept {
+    return overview;
+  }
+
+  Point2D<uint_least16_t> GetTileSize() const noexcept {
+    return tile_size;
+  }
+
+  unsigned GetTileCountX() const noexcept {
+    return tiles.GetWidth();
+  }
+
+  unsigned GetTileCountY() const noexcept {
+    return tiles.GetHeight();
+  }
+
+  const RasterTile &GetTile(unsigned x, unsigned y) const noexcept {
+    return tiles.Get(x, y);
+  }
+
+  /**
    * Is the given point inside the map?
    */
   bool IsInside(RasterLocation p) const noexcept {

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -9,10 +9,14 @@
 #include "util/Macros.hpp"
 
 #ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Globals.hpp"
 #include "ui/event/Idle.hpp"
 #endif
 
 #include <cassert>
+#ifdef ENABLE_OPENGL
+#include <chrono>
+#endif
 
 static constexpr ColorRampEntry terrain_colors[][NUM_COLOR_RAMP_LEVELS] = {
   {
@@ -394,43 +398,84 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
         raster_renderer.GetQuantisationPixels() > 2 ||
 #endif
         map_projection.GetScale() == last_projection_scale) {
+#ifdef ENABLE_OPENGL
+      if (settings.gpu_dem_spike)
+        raster_renderer.GpuDemNoteReuse();
+#endif
       return true;
     }
   }
+
+  /* With GPU DEM tiles, serial bumps mean new fine tiles — fall
+     through to PrepareGpuDemTiles even if the camera is unchanged. */
 
 #ifdef ENABLE_OPENGL
   const GeoBounds &old_bounds = raster_renderer.GetBounds();
   GeoBounds new_bounds = map_projection.GetScreenBounds();
   assert(new_bounds.IsValid());
 
+  const bool spike = settings.gpu_dem_spike;
+  const bool serial_ok = terrain_serial == terrain.GetSerial();
+
   {
     RasterTerrain::Lease map(terrain);
     if (!new_bounds.IntersectWith(map->GetBounds()))
-      /* map is outside of visible screen area */
       return false;
   }
 
+  const bool do_water = true;
+  const int interp_levels = 2;
+  const bool is_terrain = true;
+  const bool do_shading = is_terrain &&
+                          settings.slope_shading != SlopeShading::OFF;
+
+  const ColorRamp *const color_ramp = &terrain_ramps[settings.ramp];
+  if (color_ramp != last_color_ramp) {
+    raster_renderer.PrepareColorTable(color_ramp, do_water,
+                                      height_scale, interp_levels);
+    last_color_ramp = color_ramp;
+  }
+
+  const bool coverage_ok = old_bounds.IsValid() &&
+    old_bounds.IsInside(new_bounds) &&
+    !IsLargeSizeDifference(old_bounds, new_bounds);
+
+  /* Same overscan reuse as the CPU path: pan/rotate within the
+     composed height FBO without a full re-blit. */
   if (!quantisation_improved &&
-      old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
-      !IsLargeSizeDifference(old_bounds, new_bounds) &&
-      terrain_serial == terrain.GetSerial() &&
-      sun_ok) {
-    /* The existing terrain image is suitable for reuse.
-       CPU contours need a rebuild when zoom changes the interval;
-       the shader updates contour_div as a uniform. */
+      coverage_ok &&
+      serial_ok &&
+      sun_ok &&
+      (!spike || raster_renderer.IsGpuDemTiles())) {
     if (settings.contours == Contours::OFF ||
         raster_renderer.IsShaderHillshade() ||
         raster_renderer.GetQuantisationPixels() > 2 ||
         map_projection.GetScale() == last_projection_scale) {
       compare_projection = CompareProjection(map_projection);
+      if (spike)
+        raster_renderer.GpuDemNoteReuse();
       return true;
     }
   }
 
-  /* CPU slope shading is too expensive to run while the user is
-     dragging.  GPU hillshade only resamples the DEM; overscan reuse
-     already covers small pans, and GPS follow is idle so coverage
-     updates immediately. */
+  /* Approach 2: fine DEM tiles on GPU — no ScanMap. */
+  if (spike) {
+    const bool allow_incremental =
+      coverage_ok && !quantisation_improved &&
+      raster_renderer.IsGpuDemTiles();
+    RasterTerrain::Lease map(terrain);
+    if (raster_renderer.PrepareGpuDemTiles(map, map_projection,
+                                           do_shading, height_scale,
+                                           last_contour_spacing,
+                                           allow_incremental)) {
+      terrain_serial = terrain.GetSerial();
+      compare_projection = CompareProjection(map_projection);
+      last_sun_azimuth = sunazimuth;
+      last_projection_scale = map_projection.GetScale();
+      return true;
+    }
+  }
+
   if (!raster_renderer.IsShaderHillshade() &&
       !raster_renderer.IsQuantisationFixed() &&
       old_bounds.IsValid() &&
@@ -438,8 +483,47 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
       !IsUserIdle(750))
     return true;
 
-#endif
+  /* Weak GPUs (PowerVR GE8300): ScanMap of a detailed DEM is the
+     hitch.  The GPU DEM path above already skips ScanMap; this
+     freeze is only the CPU fallback while dragging. */
+  if (!spike &&
+      OpenGL::idle_terrain_quantisation &&
+      !quantisation_improved &&
+      !raster_renderer.IsQuantisationFixed() &&
+      old_bounds.IsValid() &&
+      old_bounds.Overlaps(new_bounds) &&
+      serial_ok &&
+      !IsUserIdle(750)) {
+    compare_projection = CompareProjection(map_projection);
+    return true;
+  }
 
+  terrain_serial = terrain.GetSerial();
+  compare_projection = CompareProjection(map_projection);
+  last_sun_azimuth = sunazimuth;
+
+  const auto scan_t0 = std::chrono::steady_clock::now();
+  {
+    RasterTerrain::Lease map(terrain);
+    raster_renderer.ScanMap(map, map_projection);
+  }
+
+  raster_renderer.GenerateImage(do_shading, height_scale,
+                                settings.contrast, settings.brightness,
+                                sunazimuth,
+                                last_contour_spacing);
+
+  if (spike) {
+    const unsigned us = unsigned(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - scan_t0)
+        .count());
+    raster_renderer.GpuDemNoteScanMap(us);
+  }
+
+  last_projection_scale = map_projection.GetScale();
+  return true;
+#else
   terrain_serial = terrain.GetSerial();
   compare_projection = CompareProjection(map_projection);
 
@@ -471,4 +555,5 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
   last_projection_scale = map_projection.GetScale();
 
   return true;
+#endif
 }

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -8,6 +8,10 @@
 #include "Projection/WindowProjection.hpp"
 #include "util/Macros.hpp"
 
+#ifdef ENABLE_OPENGL
+#include "ui/event/Idle.hpp"
+#endif
+
 #include <cassert>
 
 static constexpr ColorRampEntry terrain_colors[][NUM_COLOR_RAMP_LEVELS] = {
@@ -353,8 +357,26 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
 #ifdef ENABLE_OPENGL
   /* Call once — the helper mutates quantisation_pixels. */
   const bool quantisation_improved = raster_renderer.UpdateQuantisation();
+  raster_renderer.SetSunFromAzimuth(sunazimuth, settings.brightness,
+                                    settings.contrast);
+  const bool sun_ok = raster_renderer.IsShaderHillshade() ||
+    sunazimuth.CompareRoughly(last_sun_azimuth);
 #else
   constexpr bool quantisation_improved = false;
+  const bool sun_ok = sunazimuth.CompareRoughly(last_sun_azimuth);
+#endif
+
+  const unsigned height_scale = 4;
+  const double screen_pixel_size =
+    1.0 / map_projection.GetScale();
+  const double dpi_factor =
+    Layout::ScalePenWidth(1024u) / 1024.0;
+  const double contour_pixel_size = screen_pixel_size * dpi_factor *
+    std::max(1u, raster_renderer.GetQuantisationPixels() / 2u);
+  last_contour_spacing = ContourSpacing(settings.contours, height_scale,
+                                        contour_pixel_size);
+#ifdef ENABLE_OPENGL
+  raster_renderer.SetContourSpacing(last_contour_spacing);
 #endif
 
   /* Exact same view: reuse without consulting overscan bounds.
@@ -365,9 +387,10 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
   if (!quantisation_improved &&
       compare_projection.CompareExact(map_projection) &&
       terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth)) {
+      sun_ok) {
     if (settings.contours == Contours::OFF ||
 #ifdef ENABLE_OPENGL
+        raster_renderer.IsShaderHillshade() ||
         raster_renderer.GetQuantisationPixels() > 2 ||
 #endif
         map_projection.GetScale() == last_projection_scale) {
@@ -391,18 +414,29 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
       old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
       !IsLargeSizeDifference(old_bounds, new_bounds) &&
       terrain_serial == terrain.GetSerial() &&
-      sunazimuth.CompareRoughly(last_sun_azimuth)) {
+      sun_ok) {
     /* The existing terrain image is suitable for reuse.
-       But with contours: Re-use only without zoom change.
-       Otherwise we can re-use as a fast preview, but
-       re-render the higher quality views (q=2 and q=1) */
+       CPU contours need a rebuild when zoom changes the interval;
+       the shader updates contour_div as a uniform. */
     if (settings.contours == Contours::OFF ||
+        raster_renderer.IsShaderHillshade() ||
         raster_renderer.GetQuantisationPixels() > 2 ||
         map_projection.GetScale() == last_projection_scale) {
       compare_projection = CompareProjection(map_projection);
       return true;
     }
   }
+
+  /* CPU slope shading is too expensive to run while the user is
+     dragging.  GPU hillshade only resamples the DEM; overscan reuse
+     already covers small pans, and GPS follow is idle so coverage
+     updates immediately. */
+  if (!raster_renderer.IsShaderHillshade() &&
+      !raster_renderer.IsQuantisationFixed() &&
+      old_bounds.IsValid() &&
+      old_bounds.IsInside(new_bounds) &&
+      !IsUserIdle(750))
+    return true;
 
 #endif
 
@@ -412,21 +446,10 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
   last_sun_azimuth = sunazimuth;
 
   const bool do_water = true;
-  const unsigned height_scale = 4;
   const int interp_levels = 2;
   const bool is_terrain = true;
   const bool do_shading = is_terrain &&
                           settings.slope_shading != SlopeShading::OFF;
-  const double screen_pixel_size =
-    1.0 / map_projection.GetScale();
-  const double dpi_factor =
-    Layout::ScalePenWidth(1024u) / 1024.0;
-  const double contour_pixel_size = screen_pixel_size * dpi_factor *
-    std::max(1u, raster_renderer.GetQuantisationPixels() / 2u);
-  last_contour_spacing = is_terrain
-    ? ContourSpacing(settings.contours, height_scale,
-                     contour_pixel_size)
-    : 0u;
 
   const ColorRamp *const color_ramp = &terrain_ramps[settings.ramp];
   if (color_ramp != last_color_ramp) {

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -80,6 +80,15 @@ public:
   void SetQuantisationPixels(unsigned q) noexcept {
     raster_renderer.SetQuantisationPixels(q);
   }
+
+  void SetUseCpuHillshade(bool cpu) noexcept {
+    raster_renderer.SetUseCpuHillshade(cpu);
+  }
+
+  [[gnu::pure]]
+  bool IsShaderHillshade() const noexcept {
+    return raster_renderer.IsShaderHillshade();
+  }
 #endif
 
   /**

--- a/src/Terrain/TerrainSettings.cpp
+++ b/src/Terrain/TerrainSettings.cpp
@@ -14,6 +14,7 @@ TerrainRendererSettings::SetDefaults()
   brightness = 192;
   ramp = 0;
   contours = Contours::OFF;
+  gpu_dem_spike = false;
 }
 
 /**

--- a/src/Terrain/TerrainSettings.hpp
+++ b/src/Terrain/TerrainSettings.hpp
@@ -67,6 +67,12 @@ struct TerrainRendererSettings {
   Contours contours;
 
   /**
+   * Experimental: draw loaded fine DEM tiles as GPU height textures
+   * (no ScanMap).  Falls back to ScanMap when unavailable.
+   */
+  bool gpu_dem_spike;
+
+  /**
    * Set all attributes to the default values.
    */
   void SetDefaults();
@@ -77,7 +83,8 @@ struct TerrainRendererSettings {
       contrast == other.contrast &&
       brightness == other.brightness &&
       ramp == other.ramp &&
-      contours == other.contours;
+      contours == other.contours &&
+      gpu_dem_spike == other.gpu_dem_spike;
   }
 
   bool operator!=(const TerrainRendererSettings &other) const {

--- a/src/Topography/ShapeRenderer.hpp
+++ b/src/Topography/ShapeRenderer.hpp
@@ -14,6 +14,19 @@
 #include <cassert>
 
 /**
+ * Minimum screen-space spacing (pixels) between polyline vertices.
+ * Used by #AddPointIfDistant on the software renderer.
+ */
+constexpr int SHAPE_MIN_POINT_SPACING_PX = 8;
+
+/**
+ * Drop a whole fill only if its bbox is smaller than this on screen.
+ * Must not be used for polylines: at 120 km, even 1 px is ~150 m and
+ * skipping short OSM road sticks leaves a broken network.
+ */
+constexpr int SHAPE_MIN_BBOX_PX = 1;
+
+/**
  * A helper class optimized for doing bulk draws on OpenGL.
  */
 class ShapeRenderer : private NonCopyable {
@@ -53,7 +66,9 @@ public:
    void AddPointIfDistant(PixelPoint pt) {
     assert(num_points < points.size());
 
-    if (num_points == 0 || ManhattanDistance((PixelPoint)points[num_points - 1], pt) >= 8)
+    if (num_points == 0 ||
+        ManhattanDistance((PixelPoint)points[num_points - 1], pt) >=
+          SHAPE_MIN_POINT_SPACING_PX)
       AddPoint(pt);
   }
 

--- a/src/Topography/Thread.cpp
+++ b/src/Topography/Thread.cpp
@@ -3,6 +3,7 @@
 
 #include "Thread.hpp"
 #include "TopographyStore.hpp"
+#include "Screen/Layout.hpp"
 
 TopographyThread::TopographyThread(TopographyStore &_store,
                                    std::function<void()> &&_callback)
@@ -53,7 +54,7 @@ TopographyThread::Tick() noexcept
     const WindowProjection projection = next_projection;
 
     const ScopeUnlock unlock(mutex);
-    again = store.ScanVisibility(projection, 1) > 0;
+    again = store.ScanVisibility(projection, 1, Layout::Scale(1u)) > 0;
   }
 
   /* notify the client that we have updated the topography cache */

--- a/src/Topography/Thread.cpp
+++ b/src/Topography/Thread.cpp
@@ -3,6 +3,7 @@
 
 #include "Thread.hpp"
 #include "TopographyStore.hpp"
+#include "TopographyFile.hpp"
 #include "Screen/Layout.hpp"
 
 TopographyThread::TopographyThread(TopographyStore &_store,
@@ -33,7 +34,7 @@ TopographyThread::Trigger(const WindowProjection &_projection)
       return;
   }
 
-  last_bounds = new_bounds.Scale(1.1);
+  last_bounds = new_bounds.Scale(TopographyFile::CACHE_BOUNDS_SCALE);
   scale_threshold = store.GetNextScaleThreshold(_projection.GetMapScale());
 
   {

--- a/src/Topography/Thread.cpp
+++ b/src/Topography/Thread.cpp
@@ -54,13 +54,18 @@ TopographyThread::Tick() noexcept
   while (next_projection.IsValid() && again && !IsStopped()) {
     const WindowProjection projection = next_projection;
 
-    const ScopeUnlock unlock(mutex);
-    again = store.ScanVisibility(projection, 1, Layout::Scale(1u)) > 0;
-  }
+    unsigned n_updated;
+    {
+      const ScopeUnlock unlock(mutex);
+      n_updated = store.ScanVisibility(projection, 1, Layout::Scale(1u));
+    }
+    again = n_updated > 0;
 
-  /* notify the client that we have updated the topography cache */
-  if (callback) {
-    const ScopeUnlock unlock(mutex);
-    callback();
+    /* Redraw after each layer so the screen pass is visible before
+       the 2× overscan finishes. */
+    if (callback) {
+      const ScopeUnlock unlock(mutex);
+      callback();
+    }
   }
 }

--- a/src/Topography/TopographyFile.cpp
+++ b/src/Topography/TopographyFile.cpp
@@ -7,6 +7,11 @@
 #include "Projection/WindowProjection.hpp"
 #include "util/ScopeExit.hxx"
 
+#ifdef ENABLE_OPENGL
+#include "Topography/ShapeRenderer.hpp"
+#include "Geo/FAISphere.hpp"
+#endif
+
 #include <zzip/lib.h>
 
 #include <algorithm>
@@ -63,14 +68,80 @@ TopographyFile::~TopographyFile() noexcept
 void
 TopographyFile::ClearCache() noexcept
 {
-  for (auto &i : shapes)
-    i.shape.reset();
-
+  const std::lock_guard lock{mutex};
+  cache_list.clear();
   list.clear();
+  cache_bounds.SetInvalid();
+
+  for (auto &i : shapes) {
+    i.in_list = false;
+    i.clip_bounds.SetInvalid();
+    i.shape.reset();
+  }
+
+  cached_shapes = 0;
+  ++serial;
+}
+
+void
+TopographyFile::UnlinkVisible(ShapeEnvelope &e,
+                              ShapeList::iterator &prev) noexcept
+{
+  assert(e.in_list);
+  assert(&*std::next(prev) == &e);
+
+  const std::lock_guard lock{mutex};
+  list.erase_after(prev);
+  e.in_list = false;
+  ++serial;
+}
+
+void
+TopographyFile::DropCached(ShapeEnvelope &e) noexcept
+{
+  assert(!e.in_list);
+  assert(e.shape != nullptr);
+
+  if (e.cache_hook.is_linked())
+    cache_list.erase(cache_list.iterator_to(e));
+
+  e.shape.reset();
+  e.clip_bounds.SetInvalid();
+  --cached_shapes;
+}
+
+void
+TopographyFile::TouchCache(ShapeEnvelope &e) noexcept
+{
+  if (e.cache_hook.is_linked())
+    cache_list.erase(cache_list.iterator_to(e));
+  cache_list.push_front(e);
+}
+
+void
+TopographyFile::EvictOverflow() noexcept
+{
+  if (cached_shapes <= MAX_CACHED_SHAPES)
+    return;
+
+  auto it = cache_list.end();
+  while (cached_shapes > CACHE_KEEP_SHAPES &&
+         it != cache_list.begin()) {
+    --it;
+    ShapeEnvelope &e = *it;
+    if (e.in_list)
+      continue;
+
+    it = cache_list.erase(it);
+    e.shape.reset();
+    e.clip_bounds.SetInvalid();
+    --cached_shapes;
+  }
 }
 
 static std::unique_ptr<XShape>
-LoadShape(ShapeFile &file, GeoPoint &center, std::size_t i, int label_field)
+LoadShape(ShapeFile &file, GeoPoint &center, std::size_t i, int label_field,
+          const GeoBounds *clip, bool *clipped)
 {
   shapeObj shape;
   msInitShape(&shape);
@@ -81,11 +152,12 @@ LoadShape(ShapeFile &file, GeoPoint &center, std::size_t i, int label_field)
     ? file.ReadLabel(i, label_field)
     : nullptr;
 
-  return std::make_unique<XShape>(shape, center, label);
+  return std::make_unique<XShape>(shape, center, label, clip, clipped);
 }
 
 bool
-TopographyFile::Update(const WindowProjection &map_projection)
+TopographyFile::Update(const WindowProjection &map_projection,
+                       [[maybe_unused]] unsigned layout_scale)
 {
   if (map_projection.GetMapScale() > scale_threshold)
     /* not visible, don't update cache now */
@@ -117,41 +189,74 @@ TopographyFile::Update(const WindowProjection &map_projection)
   const auto status = file.GetStatus();
   assert(status != nullptr);
 
-  // Iterate through the shapefile entries
   auto prev = list.before_begin();
   auto it = shapes.begin();
   for (std::size_t i = 0; i < file.size(); ++i, ++it) {
-    if (!msGetBit(status, i)) {
-      // If the shape is outside the bounds
-      // delete the shape from the cache
-      if (it->shape != nullptr) {
-        assert(&*std::next(prev) == &*it);
+    const bool visible = msGetBit(status, i);
 
-        /* remove from linked list (protected) */
-        {
-          const std::lock_guard lock{mutex};
-          list.erase_after(prev);
-          ++serial;
+    if (visible && it->shape != nullptr &&
+        it->clip_bounds.IsValid() &&
+        !it->clip_bounds.IsInside(cache_bounds)) {
+      /* clipped to an old viewport; reload so the new area is
+         complete */
+      if (it->in_list)
+        UnlinkVisible(*it, prev);
+      DropCached(*it);
+    }
+
+    if (!visible) {
+      if (it->in_list)
+        UnlinkVisible(*it, prev);
+      continue;
+    }
+
+    if (it->shape == nullptr) {
+      assert(!it->in_list);
+
+      EvictOverflow();
+
+      bool clipped = false;
+      it->shape = LoadShape(file, center, i, label_field,
+                            &cache_bounds, &clipped);
+      it->clip_bounds = clipped ? cache_bounds : GeoBounds::Invalid();
+      ++cached_shapes;
+      TouchCache(*it);
+
+#ifdef ENABLE_OPENGL
+      /* Triangulate on the topography thread so Paint never
+         ear-clips a newly panned-in fill.  Skip sub-pixel fills
+         (same 1 px bbox rule as Paint). */
+      if (it->shape->get_type() == MS_SHAPE_POLYGON) {
+        const Angle min_span =
+          map_projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
+        const GeoBounds &b = it->shape->get_bounds();
+        if (b.GetWidth() >= min_span || b.GetHeight() >= min_span) {
+          const unsigned level =
+            GetThinningLevel(map_projection.GetMapScale());
+          if (layout_scale == 0)
+            layout_scale = 1;
+          const ShapeScalar min_distance =
+            ShapeScalar(GetMinimumPointDistance(level))
+            / (layout_scale * FAISphere::REARTH);
+          [[maybe_unused]] const auto indices =
+            it->shape->GetIndices(int(level), min_distance);
         }
+      }
+#endif
 
-        /* now it's unreachable, and we can delete the XShape without
-           holding a lock */
-        it->shape.reset();
+      {
+        const std::lock_guard lock{mutex};
+        prev = list.insert_after(prev, *it);
+        it->in_list = true;
+        ++serial;
       }
     } else {
-      // is inside the bounds
-      if (it->shape == nullptr) {
-        assert(&*std::next(prev) != &*it);
-
-        // shape isn't cached yet -> cache the shape
-        it->shape = LoadShape(file, center, i, label_field);
-
-        /* insert into linked list (protected) */
-        {
-          const std::lock_guard lock{mutex};
-          prev = list.insert_after(prev, *it);
-          ++serial;
-        }
+      TouchCache(*it);
+      if (!it->in_list) {
+        const std::lock_guard lock{mutex};
+        prev = list.insert_after(prev, *it);
+        it->in_list = true;
+        ++serial;
       } else {
         ++prev;
         assert(&*prev == &*it);
@@ -161,22 +266,40 @@ TopographyFile::Update(const WindowProjection &map_projection)
 
   assert(std::next(prev) == list.end());
 
+  EvictOverflow();
+
   return true;
 }
 
 void
 TopographyFile::LoadAll()
 {
-  // Iterate through the shapefile entries
+  /* After Update(), an envelope can be cached but not in #list
+     (off-screen LRU), or cached with a viewport clip.  Walk
+     in_list, not shape, and reload clipped geometry unclipped. */
   auto prev = list.before_begin();
   auto it = shapes.begin();
   for (std::size_t i = 0; i < file.size(); ++i, ++it) {
+    if (it->shape != nullptr && it->clip_bounds.IsValid()) {
+      if (it->in_list)
+        UnlinkVisible(*it, prev);
+      DropCached(*it);
+    }
+
     if (it->shape == nullptr) {
-      assert(&*std::next(prev) != &*it);
-      // shape isn't cached yet -> cache the shape
-      it->shape = LoadShape(file, center, i, label_field);
-      // update list pointer
+      assert(!it->in_list);
+      it->shape = LoadShape(file, center, i, label_field,
+                            nullptr, nullptr);
+      ++cached_shapes;
+      TouchCache(*it);
+      const std::lock_guard lock{mutex};
       prev = list.insert_after(prev, *it);
+      it->in_list = true;
+    } else if (!it->in_list) {
+      TouchCache(*it);
+      const std::lock_guard lock{mutex};
+      prev = list.insert_after(prev, *it);
+      it->in_list = true;
     } else {
       ++prev;
       assert(&*prev == &*it);

--- a/src/Topography/TopographyFile.cpp
+++ b/src/Topography/TopographyFile.cpp
@@ -169,7 +169,7 @@ TopographyFile::Update(const WindowProjection &map_projection,
     /* the cache is still fresh */
     return false;
 
-  cache_bounds = screenRect.Scale(2);
+  cache_bounds = screenRect.Scale(CACHE_BOUNDS_SCALE);
 
   // Test which shapes are inside the given bounds and save the
   // status to file.status

--- a/src/Topography/TopographyFile.cpp
+++ b/src/Topography/TopographyFile.cpp
@@ -6,6 +6,8 @@
 #include "Convert.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "util/ScopeExit.hxx"
+#include "util/TruncateString.hpp"
+#include "util/StringCompare.hxx"
 
 #ifdef ENABLE_OPENGL
 #include "Topography/ShapeRenderer.hpp"
@@ -16,6 +18,22 @@
 
 #include <algorithm>
 #include <stdexcept>
+
+static void
+CopyShapeBaseName(char *dest, std::size_t dest_size,
+                  const char *path) noexcept
+{
+  const char *base = path;
+  for (const char *p = path; *p != '\0'; ++p)
+    if (*p == '/' || *p == '\\')
+      base = p + 1;
+
+  CopyTruncateString(dest, dest_size, base);
+
+  const std::size_t n = StringLength(dest);
+  if (n >= 4 && StringIsEqualIgnoreCase(dest + n - 4, ".shp"))
+    dest[n - 4] = '\0';
+}
 
 TopographyFile::TopographyFile(zzip_dir *_dir, const char *filename,
                                double _threshold,
@@ -35,6 +53,8 @@ TopographyFile::TopographyFile(zzip_dir *_dir, const char *filename,
    label_threshold(_label_threshold),
    important_label_threshold(_important_label_threshold)
 {
+  CopyShapeBaseName(name, sizeof(name), filename);
+
   const std::size_t n_shapes = file.size();
   constexpr std::size_t MAX_SHAPES = 16 * 1024 * 1024;
   if (n_shapes == 0)

--- a/src/Topography/TopographyFile.cpp
+++ b/src/Topography/TopographyFile.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <vector>
 
 static void
 CopyShapeBaseName(char *dest, std::size_t dest_size,
@@ -92,6 +93,7 @@ TopographyFile::ClearCache() noexcept
   cache_list.clear();
   list.clear();
   cache_bounds.SetInvalid();
+  cache_overscan = false;
 
   for (auto &i : shapes) {
     i.in_list = false;
@@ -110,10 +112,8 @@ TopographyFile::UnlinkVisible(ShapeEnvelope &e,
   assert(e.in_list);
   assert(&*std::next(prev) == &e);
 
-  const std::lock_guard lock{mutex};
   list.erase_after(prev);
   e.in_list = false;
-  ++serial;
 }
 
 void
@@ -175,6 +175,37 @@ LoadShape(ShapeFile &file, GeoPoint &center, std::size_t i, int label_field,
   return std::make_unique<XShape>(shape, center, label, clip, clipped);
 }
 
+#ifdef ENABLE_OPENGL
+/**
+ * Ear-clip polygons on the topography thread so Paint never
+ * triangulates a newly panned-in fill.
+ */
+static void
+PrepareOpenGLShape(const XShape &shape, const TopographyFile &file,
+                   const WindowProjection &map_projection,
+                   unsigned layout_scale) noexcept
+{
+  if (shape.get_type() != MS_SHAPE_POLYGON)
+    return;
+
+  const Angle min_span =
+    map_projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
+  const GeoBounds &b = shape.get_bounds();
+  if (b.GetWidth() < min_span && b.GetHeight() < min_span)
+    return;
+
+  const unsigned level =
+    file.GetThinningLevel(map_projection.GetMapScale());
+  if (layout_scale == 0)
+    layout_scale = 1;
+  const ShapeScalar min_distance =
+    ShapeScalar(file.GetMinimumPointDistance(level))
+    / (layout_scale * FAISphere::REARTH);
+  [[maybe_unused]] const auto indices =
+    shape.GetIndices(int(level), min_distance);
+}
+#endif
+
 bool
 TopographyFile::Update(const WindowProjection &map_projection,
                        [[maybe_unused]] unsigned layout_scale)
@@ -185,11 +216,17 @@ TopographyFile::Update(const WindowProjection &map_projection,
 
   const GeoBounds screenRect =
     map_projection.GetScreenBounds();
-  if (cache_bounds.IsValid() && cache_bounds.IsInside(screenRect))
-    /* the cache is still fresh */
+  if (cache_bounds.IsValid() && cache_bounds.IsInside(screenRect) &&
+      cache_overscan)
+    /* 2× cache still covers the screen */
     return false;
 
-  cache_bounds = screenRect.Scale(CACHE_BOUNDS_SCALE);
+  /* First pass: screen only, so on-map roads appear before the
+     surround is read from the zip.  Second pass: 2× overscan. */
+  const bool fill_overscan =
+    cache_bounds.IsValid() && cache_bounds.IsInside(screenRect);
+  cache_bounds = screenRect.Scale(fill_overscan ? CACHE_BOUNDS_SCALE : 1);
+  cache_overscan = fill_overscan;
 
   // Test which shapes are inside the given bounds and save the
   // status to file.status
@@ -209,7 +246,13 @@ TopographyFile::Update(const WindowProjection &map_projection,
   const auto status = file.GetStatus();
   assert(status != nullptr);
 
-  auto prev = list.before_begin();
+  struct PendingReload {
+    ShapeEnvelope *envelope;
+    std::unique_ptr<XShape> shape;
+    GeoBounds clip_bounds;
+  };
+  std::vector<PendingReload> reloads;
+
   auto it = shapes.begin();
   for (std::size_t i = 0; i < file.size(); ++i, ++it) {
     const bool visible = msGetBit(status, i);
@@ -218,73 +261,91 @@ TopographyFile::Update(const WindowProjection &map_projection,
         it->clip_bounds.IsValid() &&
         !it->clip_bounds.IsInside(cache_bounds)) {
       /* clipped to an old viewport; reload so the new area is
-         complete */
-      if (it->in_list)
-        UnlinkVisible(*it, prev);
-      DropCached(*it);
-    }
+         complete.  Keep in-list geometry until the mutex commit
+         so Paint cannot see a dangling XShape. */
+      bool clipped = false;
+      auto neu = LoadShape(file, center, i, label_field,
+                           &cache_bounds, &clipped);
+#ifdef ENABLE_OPENGL
+      PrepareOpenGLShape(*neu, *this, map_projection, layout_scale);
+#endif
+      if (it->in_list) {
+        reloads.push_back({
+          &*it, std::move(neu),
+          clipped ? cache_bounds : GeoBounds::Invalid(),
+        });
+        continue;
+      }
 
-    if (!visible) {
-      if (it->in_list)
-        UnlinkVisible(*it, prev);
+      DropCached(*it);
+      it->shape = std::move(neu);
+      it->clip_bounds = clipped ? cache_bounds : GeoBounds::Invalid();
+      ++cached_shapes;
+      TouchCache(*it);
       continue;
     }
+
+    if (!visible)
+      continue;
 
     if (it->shape == nullptr) {
       assert(!it->in_list);
 
-      EvictOverflow();
-
       bool clipped = false;
-      it->shape = LoadShape(file, center, i, label_field,
-                            &cache_bounds, &clipped);
+      auto neu = LoadShape(file, center, i, label_field,
+                           &cache_bounds, &clipped);
+#ifdef ENABLE_OPENGL
+      PrepareOpenGLShape(*neu, *this, map_projection, layout_scale);
+#endif
+      it->shape = std::move(neu);
       it->clip_bounds = clipped ? cache_bounds : GeoBounds::Invalid();
       ++cached_shapes;
       TouchCache(*it);
-
-#ifdef ENABLE_OPENGL
-      /* Triangulate on the topography thread so Paint never
-         ear-clips a newly panned-in fill.  Skip sub-pixel fills
-         (same 1 px bbox rule as Paint). */
-      if (it->shape->get_type() == MS_SHAPE_POLYGON) {
-        const Angle min_span =
-          map_projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
-        const GeoBounds &b = it->shape->get_bounds();
-        if (b.GetWidth() >= min_span || b.GetHeight() >= min_span) {
-          const unsigned level =
-            GetThinningLevel(map_projection.GetMapScale());
-          if (layout_scale == 0)
-            layout_scale = 1;
-          const ShapeScalar min_distance =
-            ShapeScalar(GetMinimumPointDistance(level))
-            / (layout_scale * FAISphere::REARTH);
-          [[maybe_unused]] const auto indices =
-            it->shape->GetIndices(int(level), min_distance);
-        }
-      }
-#endif
-
-      {
-        const std::lock_guard lock{mutex};
-        prev = list.insert_after(prev, *it);
-        it->in_list = true;
-        ++serial;
-      }
     } else {
       TouchCache(*it);
+    }
+  }
+
+  {
+    const std::lock_guard lock{mutex};
+
+    for (auto &r : reloads) {
+      if (r.envelope->cache_hook.is_linked())
+        cache_list.erase(cache_list.iterator_to(*r.envelope));
+      r.envelope->shape = std::move(r.shape);
+      r.envelope->clip_bounds = r.clip_bounds;
+      TouchCache(*r.envelope);
+    }
+
+    auto prev = list.before_begin();
+    it = shapes.begin();
+    for (std::size_t i = 0; i < file.size(); ++i, ++it) {
+      const bool visible = msGetBit(status, i);
+
+      if (!visible) {
+        if (it->in_list)
+          UnlinkVisible(*it, prev);
+        continue;
+      }
+
       if (!it->in_list) {
-        const std::lock_guard lock{mutex};
+        /* LRU may have dropped this envelope during an earlier
+           load in this pass; skip rather than linking a null
+           shape. */
+        if (it->shape == nullptr)
+          continue;
+
         prev = list.insert_after(prev, *it);
         it->in_list = true;
-        ++serial;
       } else {
         ++prev;
         assert(&*prev == &*it);
       }
     }
-  }
 
-  assert(std::next(prev) == list.end());
+    assert(std::next(prev) == list.end());
+    ++serial;
+  }
 
   EvictOverflow();
 
@@ -301,8 +362,11 @@ TopographyFile::LoadAll()
   auto it = shapes.begin();
   for (std::size_t i = 0; i < file.size(); ++i, ++it) {
     if (it->shape != nullptr && it->clip_bounds.IsValid()) {
-      if (it->in_list)
-        UnlinkVisible(*it, prev);
+      {
+        const std::lock_guard lock{mutex};
+        if (it->in_list)
+          UnlinkVisible(*it, prev);
+      }
       DropCached(*it);
     }
 
@@ -328,6 +392,7 @@ TopographyFile::LoadAll()
 
   assert(std::next(prev) == list.end());
 
+  const std::lock_guard lock{mutex};
   ++serial;
 }
 

--- a/src/Topography/TopographyFile.hpp
+++ b/src/Topography/TopographyFile.hpp
@@ -205,6 +205,10 @@ public:
     return map_scale <= label_threshold;
   }
 
+  double GetLabelThreshold() const noexcept {
+    return label_threshold;
+  }
+
   /**
    * Returns the map scale threshold that will be reached next by
    * zooming in.  This is used to decide when to rescan shapes that

--- a/src/Topography/TopographyFile.hpp
+++ b/src/Topography/TopographyFile.hpp
@@ -116,6 +116,12 @@ class TopographyFile {
    */
   GeoBounds cache_bounds = GeoBounds::Invalid();
 
+  /**
+   * True after the 2× overscan pass.  A cache miss first loads the
+   * screen rectangle so on-map shapes appear before the surround.
+   */
+  bool cache_overscan = false;
+
 public:
   /**
    * Viewport overscan for #cache_bounds, the topography thread
@@ -327,6 +333,9 @@ protected:
   void ClearCache() noexcept;
 
 private:
+  /**
+   * Remove @e from #list.  Caller must hold #mutex.
+   */
   void UnlinkVisible(ShapeEnvelope &e,
                      ShapeList::iterator &prev) noexcept;
   void DropCached(ShapeEnvelope &e) noexcept;

--- a/src/Topography/TopographyFile.hpp
+++ b/src/Topography/TopographyFile.hpp
@@ -113,6 +113,13 @@ class TopographyFile {
 
 public:
   /**
+   * Viewport overscan for #cache_bounds, the topography thread
+   * trigger, and the paint-time visible list.  Pan inside this factor
+   * does not reload shapefile data or rebuild #visible_shapes.
+   */
+  static constexpr double CACHE_BOUNDS_SCALE = 2;
+
+  /**
    * Protects #serial, #shapes, #first.
    * The caller is responsible for locking it.
    */

--- a/src/Topography/TopographyFile.hpp
+++ b/src/Topography/TopographyFile.hpp
@@ -7,6 +7,7 @@
 #include "Geo/GeoBounds.hpp"
 #include "util/AllocatedArray.hxx"
 #include "util/IntrusiveForwardList.hxx"
+#include "util/IntrusiveList.hxx"
 #include "util/Serial.hpp"
 #include "ui/canvas/PortableColor.hpp"
 #include "ResourceId.hpp"
@@ -26,7 +27,30 @@ struct zzip_dir;
 class TopographyFile {
   struct ShapeEnvelope final : IntrusiveForwardListHook {
     std::unique_ptr<const XShape> shape;
+
+    IntrusiveListHook<IntrusiveHookMode::TRACK> cache_hook;
+
+    /**
+     * Viewport used when #shape was clipped.  Invalid means the
+     * full shapefile feature is in RAM.
+     */
+    GeoBounds clip_bounds = GeoBounds::Invalid();
+
+    /**
+     * True while this envelope is in #list (visible cache).
+     */
+    bool in_list = false;
   };
+
+  /**
+   * Cap on loaded #XShape objects (on- and off-screen).  Prevents
+   * unbounded RAM when panning a dense map; triangulation stays
+   * cached until LRU eviction.
+   */
+  static constexpr unsigned MAX_CACHED_SHAPES = 8192;
+
+  /** After a miss, evict down to this so one pan does not thrash. */
+  static constexpr unsigned CACHE_KEEP_SHAPES = MAX_CACHED_SHAPES * 3 / 4;
 
   /**
    * This gets incremented by Update().
@@ -46,6 +70,13 @@ class TopographyFile {
 
   using ShapeList = IntrusiveForwardList<ShapeEnvelope>;
   ShapeList list;
+
+  using CacheList = IntrusiveList<
+    ShapeEnvelope,
+    IntrusiveListMemberHookTraits<&ShapeEnvelope::cache_hook>>;
+  CacheList cache_list;
+
+  unsigned cached_shapes = 0;
 
   const int label_field;
 
@@ -247,17 +278,29 @@ public:
   /**
    * Throws on error.
    *
+   * @param layout_scale UI pixel scale (Layout::Scale(1)); used for
+   * OpenGL ear-clip tolerance so it matches Paint()
    * @return true if new data from the topography file has been loaded
    */
-  bool Update(const WindowProjection &map_projection);
+  bool Update(const WindowProjection &map_projection,
+              unsigned layout_scale=1);
 
   /**
    * Throws on error.
    *
-   * Load all shapes into memory.  For debugging purposes.
+   * Load all shapes into memory.  For debugging purposes.  Reloads
+   * viewport-clipped cache entries unclipped, and inserts envelopes
+   * that Update() left in the off-screen LRU.
    */
   void LoadAll();
 
 protected:
   void ClearCache() noexcept;
+
+private:
+  void UnlinkVisible(ShapeEnvelope &e,
+                     ShapeList::iterator &prev) noexcept;
+  void DropCached(ShapeEnvelope &e) noexcept;
+  void TouchCache(ShapeEnvelope &e) noexcept;
+  void EvictOverflow() noexcept;
 };

--- a/src/Topography/TopographyFile.hpp
+++ b/src/Topography/TopographyFile.hpp
@@ -78,6 +78,11 @@ class TopographyFile {
 
   unsigned cached_shapes = 0;
 
+  /**
+   * Shapefile basename without directory or ".shp", for logging.
+   */
+  char name[40]{};
+
   const int label_field;
 
   const ResourceId icon, big_icon, ultra_icon;
@@ -191,6 +196,19 @@ public:
 
   const Serial &GetSerial() const noexcept {
     return serial;
+  }
+
+  const char *GetName() const noexcept {
+    return name;
+  }
+
+  std::size_t GetFileShapeCount() const noexcept {
+    return shapes.size();
+  }
+
+  unsigned GetCachedShapeCount() const noexcept {
+    const std::lock_guard lock{mutex};
+    return cached_shapes;
   }
 
   const GeoPoint &GetCenter() const noexcept {

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -11,6 +11,7 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Features.hpp"
 #include "Screen/Layout.hpp"
+#include "LogFile.hpp"
 #include "shapelib/mapserver.h"
 #include "util/AllocatedArray.hxx"
 #include "Geo/GeoClip.hpp"
@@ -124,15 +125,13 @@ TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) 
 
 #ifdef ENABLE_OPENGL
 
-inline void
+inline bool
 TopographyFileRenderer::UpdateArrayBuffer() noexcept
 {
   if (array_buffer == nullptr)
     array_buffer = std::make_unique<GLArrayBuffer>();
   else if (file.GetSerial() == array_buffer_serial)
-    return;
-
-  array_buffer_serial = file.GetSerial();
+    return true;
 
   unsigned n = 0;
   for (auto &shape : file) {
@@ -142,9 +141,17 @@ TopographyFileRenderer::UpdateArrayBuffer() noexcept
     n = std::accumulate(lines.begin(), lines.end(), n);
   }
 
+  if (n == 0)
+    return false;
+
   ShapePoint *p = (ShapePoint *)
     array_buffer->BeginWrite(n * sizeof(*p));
-  assert (p != nullptr);
+  if (p == nullptr) {
+    LogFmt("Topography: {} failed to allocate {} vertices",
+           file.GetName(), n);
+    GLArrayBuffer::Unbind();
+    return false;
+  }
 
   for (const auto &shape : file) {
     const auto lines = shape.GetLines();
@@ -156,6 +163,8 @@ TopographyFileRenderer::UpdateArrayBuffer() noexcept
   }
 
   array_buffer->CommitWrite(n * sizeof(*p), p - n);
+  array_buffer_serial = file.GetSerial();
+  return true;
 }
 
 #endif
@@ -189,7 +198,8 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 #ifdef ENABLE_OPENGL
   OpenGL::solid_shader->Use();
 
-  UpdateArrayBuffer();
+  if (!UpdateArrayBuffer())
+    return;
   array_buffer->Bind();
   const ShapePoint *const buffer = nullptr;
 

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -385,6 +385,38 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 #endif
 }
 
+/**
+ * Map scale (metres) at which labels use the largest font (circuit).
+ */
+static constexpr double LABEL_LARGE_SCALE = 2000;
+
+/**
+ * Fraction of the layer's label range at which labels step up to the
+ * medium font (well inside the range, not just as they appear).
+ */
+static constexpr double LABEL_MEDIUM_RANGE_FRACTION = 0.25;
+
+[[gnu::pure]]
+static TopographyLook::LabelSize
+LabelSizeForScale(double map_scale, double label_threshold,
+                  MS_SHAPE_TYPE type) noexcept
+{
+  /* Lines (roads, rivers) stay SMALL.  Each font size is a separate
+     TextCache key; 256 GPU textures.  Upsizing every street name at
+     circuit scale misses the cache and uploads glyphs on Mali-400. */
+  if (type != MS_SHAPE_POINT)
+    return TopographyLook::LabelSize::SMALL;
+
+  if (map_scale <= LABEL_LARGE_SCALE)
+    return TopographyLook::LabelSize::LARGE;
+
+  if (label_threshold > 0 &&
+      map_scale <= label_threshold * LABEL_MEDIUM_RANGE_FRACTION)
+    return TopographyLook::LabelSize::MEDIUM;
+
+  return TopographyLook::LabelSize::SMALL;
+}
+
 void
 TopographyFileRenderer::PaintLabels(Canvas &canvas,
                                     const WindowProjection &projection,
@@ -401,73 +433,50 @@ TopographyFileRenderer::PaintLabels(Canvas &canvas,
   if (visible_labels.empty())
     return;
 
-  canvas.Select(file.IsLabelImportant(map_scale)
-                ? look.important_label_font
-                : look.regular_label_font);
-  canvas.SetTextColor(file.IsLabelImportant(map_scale) ?
-                COLOR_BLACK : COLOR_VERY_DARK_GRAY);
+  const bool important = file.IsLabelImportant(map_scale);
+  const auto size = LabelSizeForScale(map_scale,
+                                      file.GetLabelThreshold(),
+                                      visible_labels.front()->get_type());
+  canvas.Select(look.GetLabelFont(important, size));
+  canvas.SetTextColor(important ? COLOR_BLACK : COLOR_VERY_DARK_GRAY);
   canvas.SetBackgroundTransparent();
-
-  // get drawing info
-
-  int iskip = file.GetSkipSteps(map_scale);
 
   std::set<std::string> drawn_labels;
 
   const Angle min_span =
     projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
 
-  // Iterate over all shapes in the file
   for (const XShape *shape_p : visible_labels) {
     const XShape &shape = *shape_p;
 
     if (ShapeTooSmallToDraw(shape, min_span))
       continue;
 
-    // Skip shapes without a label
     const char *label = shape.GetLabel();
     assert(label != nullptr);
+    if (label[0] == '\0')
+      continue;
 
-    const auto lines = shape.GetLines();
-    const auto *points = shape.GetPoints();
+    /* Geographic centre, not the leftmost vertex: on compact shapes
+       that vertex flips while panning/rotating, so the text jumps
+       and loses the LabelBlock contest. */
+    const GeoPoint center = shape.get_bounds().GetCenter();
+    if (!center.IsValid())
+      continue;
 
-    for (const unsigned n : lines) {
-      int minx = canvas.GetWidth();
-      int miny = canvas.GetHeight();
+    const auto pt = projection.GeoToScreenIfVisible(center);
+    if (!pt)
+      continue;
 
-      const auto *end = points + n;
-      for (; points < end; points += iskip) {
-#ifdef ENABLE_OPENGL
-        auto pt = projection.GeoToScreen(file.ToGeoPoint(*points));
-#else
-        auto pt = projection.GeoToScreen(*points);
-#endif
+    if (drawn_labels.contains(label))
+      continue;
 
-        if (pt.x <= minx) {
-          minx = pt.x;
-          miny = pt.y;
-        }
-      }
+    const PixelRect brect = PixelRect::Centered(*pt,
+                                                canvas.CalcTextSize(label));
+    if (!label_block.check(brect))
+      continue;
 
-      points = end;
-
-      minx += 2;
-      miny += 2;
-
-      PixelSize tsize = canvas.CalcTextSize(label);
-      PixelRect brect;
-      brect.left = minx;
-      brect.right = brect.left + tsize.width;
-      brect.top = miny;
-      brect.bottom = brect.top + tsize.height;
-
-      if (!label_block.check(brect))
-        continue;
-
-      if (!drawn_labels.insert(label).second)
-        continue;
-
-      canvas.DrawText({minx, miny}, label);
-    }
+    drawn_labels.emplace(label);
+    canvas.DrawText(brect.GetTopLeft(), label);
   }
 }

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -4,6 +4,7 @@
 #include "Topography/TopographyFileRenderer.hpp"
 #include "Topography/TopographyFile.hpp"
 #include "Topography/XShape.hpp"
+#include "Topography/ShapeRenderer.hpp"
 #include "Look/TopographyLook.hpp"
 #include "Renderer/LabelBlock.hpp"
 #include "Projection/WindowProjection.hpp"
@@ -47,26 +48,56 @@ TopographyFileRenderer::TopographyFileRenderer(const TopographyFile &_file,
 
 TopographyFileRenderer::~TopographyFileRenderer() noexcept = default;
 
+/**
+ * True if a feature's geographic box is smaller than
+ * #SHAPE_MIN_BBOX_PX on screen.  Cheap (angle spans only).
+ */
+[[gnu::pure]]
+static bool
+ShapeTooSmall(const GeoBounds &bounds, Angle min_span) noexcept
+{
+  return bounds.GetWidth() < min_span && bounds.GetHeight() < min_span;
+}
+
+[[gnu::pure]]
+static bool
+ShapeTooSmallToDraw(const XShape &shape, Angle min_span) noexcept
+{
+  /* Lines: never skip.  At 120 km, 1 px is ~150 m; OSM road sticks
+     shorter than that would leave a gapped network.  Polygons: skip
+     sub-pixel fills that would still cost ear-clip. */
+  return shape.get_type() == MS_SHAPE_POLYGON &&
+    ShapeTooSmall(shape.get_bounds(), min_span);
+}
+
 void
 TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) noexcept
 {
+  const double scale = projection.GetScale();
   if (file.GetSerial() == visible_serial &&
+      scale <= visible_scale &&
       visible_bounds.IsInside(projection.GetScreenBounds()) &&
       projection.GetScreenBounds().Scale(2).IsInside(visible_bounds))
     /* cache is clean */
     return;
 
   visible_serial = file.GetSerial();
+  visible_scale = scale;
   visible_bounds = projection.GetScreenBounds().Scale(1.2);
   visible_shapes.clear();
   visible_points.clear();
   visible_labels.clear();
 
+  const Angle min_span =
+    projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
+
   for (const XShape &shape : file) {
     if (!visible_bounds.Overlaps(shape.get_bounds()))
       continue;
 
-    if (shape.get_type() != MS_SHAPE_NULL) {
+    const bool too_small = ShapeTooSmallToDraw(shape, min_span);
+
+    if (shape.get_type() != MS_SHAPE_NULL && !too_small) {
       if (shape.get_type() == MS_SHAPE_POINT) {
         if (icon.IsDefined()) {
           const auto *points = shape.GetPoints();
@@ -85,7 +116,7 @@ TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) 
         visible_shapes.push_back(&shape);
     }
 
-    if (shape.GetLabel() != nullptr)
+    if (shape.GetLabel() != nullptr && !too_small)
       visible_labels.push_back(&shape);
   }
 }
@@ -197,8 +228,14 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 #endif
 #endif
 
+  const Angle min_span =
+    projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
+
   for (const XShape *shape_p : visible_shapes) {
     const XShape &shape = *shape_p;
+
+    if (ShapeTooSmallToDraw(shape, min_span))
+      continue;
 
     const auto lines = shape.GetLines();
 #ifdef ENABLE_OPENGL
@@ -253,6 +290,10 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 #ifdef ENABLE_OPENGL
       {
         const auto triangles = shape.GetIndices(level, min_distance);
+        if (triangles.indices == nullptr || triangles.count == nullptr ||
+            *triangles.count == 0)
+          break;
+
         const unsigned n = *triangles.count;
 
 #ifdef GL_EXT_multi_draw_arrays
@@ -372,9 +413,15 @@ TopographyFileRenderer::PaintLabels(Canvas &canvas,
 
   std::set<std::string> drawn_labels;
 
+  const Angle min_span =
+    projection.PixelsToAngle(SHAPE_MIN_BBOX_PX);
+
   // Iterate over all shapes in the file
   for (const XShape *shape_p : visible_labels) {
     const XShape &shape = *shape_p;
+
+    if (ShapeTooSmallToDraw(shape, min_span))
+      continue;
 
     // Skip shapes without a label
     const char *label = shape.GetLabel();

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -299,7 +299,15 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 
 #ifdef GL_EXT_multi_draw_arrays
         const unsigned offset = shape.GetOffset();
-        if (GLExt::HaveMultiDrawElements() && offset + n < 0x10000) {
+        unsigned n_verts = 0;
+        for (const unsigned nv : shape.GetLines())
+          n_verts += nv;
+        /* GLushort indices; offset+n (strip length) is not the
+           highest vertex.  Wrapping picks vertices from other
+           shapes and stretches fills across the map. */
+        if (GLExt::HaveMultiDrawElements() &&
+            offset < 0x10000 &&
+            n_verts <= 0x10000 - offset) {
           /* postpone, draw many polygons with a single
              glMultiDrawElements() call */
           polygon_counts.push_back(n);

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -74,16 +74,17 @@ void
 TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) noexcept
 {
   const double scale = projection.GetScale();
+  const GeoBounds screen = projection.GetScreenBounds();
   if (file.GetSerial() == visible_serial &&
       scale <= visible_scale &&
-      visible_bounds.IsInside(projection.GetScreenBounds()) &&
-      projection.GetScreenBounds().Scale(2).IsInside(visible_bounds))
-    /* cache is clean */
+      visible_bounds.IsValid() &&
+      visible_bounds.IsInside(screen))
+    /* still inside the last 2× viewport; pan only reprojects */
     return;
 
   visible_serial = file.GetSerial();
   visible_scale = scale;
-  visible_bounds = projection.GetScreenBounds().Scale(1.2);
+  visible_bounds = screen.Scale(TopographyFile::CACHE_BOUNDS_SCALE);
   visible_shapes.clear();
   visible_points.clear();
   visible_labels.clear();
@@ -324,7 +325,7 @@ TopographyFileRenderer::Paint(Canvas &canvas,
              clip them, to avoid integer overflows (as PixelPoint may
              store only 16 bit integers on some platforms) */
 
-          geo_points.GrowDiscard(msize * 3);
+          geo_points.GrowDiscard(msize * 4);
           for (unsigned i = 0; i < msize; ++i)
             geo_points[i] = src[i * iskip];
 

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -22,9 +22,11 @@
 #include "ui/canvas/opengl/Buffer.hpp"
 #include "ui/canvas/opengl/Dynamic.hpp"
 #include "ui/canvas/opengl/Geo.hpp"
-
 #include "ui/canvas/opengl/Program.hpp"
 #include "ui/canvas/opengl/Shaders.hpp"
+#include "ui/opengl/System.hpp"
+#include "ui/event/Idle.hpp"
+#include "time/PeriodClock.hpp"
 
 #include <glm/gtc/type_ptr.hpp>
 #endif
@@ -33,6 +35,158 @@
 #include <algorithm>
 #include <numeric>
 #include <set>
+#include <vector>
+#ifdef ENABLE_OPENGL
+#include <chrono>
+#include <cstdint>
+#include <span>
+#endif
+
+#ifdef ENABLE_OPENGL
+
+static constexpr auto TOPO_STATS_PERIOD = std::chrono::seconds(2);
+
+struct TopographyGpuStatsState {
+  PeriodClock log_clock;
+  unsigned frames = 0;
+  unsigned layers = 0;
+  unsigned vis_rebuilds = 0, vbo_rebuilds = 0;
+  unsigned line_draws = 0, fill_draws = 0, points = 0;
+  uint64_t paint_us = 0, paint_max_us = 0;
+  uint64_t label_us = 0, label_max_us = 0;
+  uint64_t gpu_sync_us = 0;
+  unsigned last_sw = 0, last_sh = 0;
+  unsigned last_lines = 0, last_fills = 0;
+  double last_scale = 0;
+  bool last_idle = false;
+  bool have_gpu_sync = false;
+
+  void Reset() noexcept {
+    frames = layers = 0;
+    vis_rebuilds = vbo_rebuilds = 0;
+    line_draws = fill_draws = points = 0;
+    paint_us = paint_max_us = 0;
+    label_us = label_max_us = 0;
+    gpu_sync_us = 0;
+    have_gpu_sync = false;
+  }
+
+  void AddUs(uint64_t us, uint64_t &sum, uint64_t &mx) noexcept {
+    sum += us;
+    if (us > mx)
+      mx = us;
+  }
+
+  void Flush() noexcept {
+    if (frames == 0)
+      return;
+
+    const auto elapsed = log_clock.Elapsed();
+    const double sec =
+      elapsed.count() > 0
+      ? std::chrono::duration<double>(elapsed).count()
+      : 2.0;
+    const double fps = frames / sec;
+    const double paint_avg = (paint_us / 1000.0) / frames;
+    const double label_avg =
+      (label_us / 1000.0) / std::max(1u, frames);
+
+    LogFmt("OpenGL: Topo {:.1f}s frames={} ({:.0f}/s) idle={} "
+           "scale={:.0f}m view={}x{}",
+           sec, frames, fps, last_idle ? 1 : 0,
+           last_scale, last_sw, last_sh);
+    LogFmt("OpenGL: Topo cpu paint avg/max {:.2f}/{:.2f} ms  "
+           "labels avg/max {:.2f}/{:.2f} ms  gpu_sync={:.1f}ms",
+           paint_avg, paint_max_us / 1000.0,
+           label_avg, label_max_us / 1000.0,
+           have_gpu_sync ? gpu_sync_us / 1000.0 : -1.0);
+    LogFmt("OpenGL: Topo layers/frame={:.1f} line_draws={} "
+           "(avg {:.0f}) fill_draws={} (avg {:.1f}) points={}  "
+           "vis_rebuild={} vbo_rebuild={}",
+           layers / double(frames),
+           line_draws, line_draws / double(frames),
+           fill_draws, fill_draws / double(frames),
+           points, vis_rebuilds, vbo_rebuilds);
+    LogFmt("OpenGL: Topo last frame lines={} fills={}",
+           last_lines, last_fills);
+
+    Reset();
+    log_clock.Update();
+  }
+};
+
+static TopographyGpuStatsState topo_stats;
+static uint64_t topo_frame_paint_us;
+static unsigned topo_frame_lines, topo_frame_fills;
+
+static uint64_t
+TopoSteadyUsSince(std::chrono::steady_clock::time_point t0) noexcept
+{
+  return uint64_t(std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - t0)
+                    .count());
+}
+
+void
+TopographyGpuStatsBeginDraw() noexcept
+{
+  topo_frame_paint_us = 0;
+  topo_frame_lines = 0;
+  topo_frame_fills = 0;
+}
+
+static void
+TopoAddLayer(unsigned cpu_us, unsigned line_draws, unsigned fill_draws,
+             unsigned point_n, bool vis_rebuild, bool vbo_rebuild) noexcept
+{
+  topo_stats.layers++;
+  topo_frame_paint_us += cpu_us;
+  topo_stats.line_draws += line_draws;
+  topo_stats.fill_draws += fill_draws;
+  topo_frame_lines += line_draws;
+  topo_frame_fills += fill_draws;
+  topo_stats.points += point_n;
+  if (vis_rebuild)
+    topo_stats.vis_rebuilds++;
+  if (vbo_rebuild)
+    topo_stats.vbo_rebuilds++;
+}
+
+void
+TopographyGpuStatsEndDraw(const WindowProjection &projection) noexcept
+{
+  topo_stats.frames++;
+  topo_stats.AddUs(topo_frame_paint_us, topo_stats.paint_us,
+                   topo_stats.paint_max_us);
+  topo_stats.last_lines = topo_frame_lines;
+  topo_stats.last_fills = topo_frame_fills;
+  topo_stats.last_scale = projection.GetMapScale();
+  const auto view = projection.GetScreenSize();
+  topo_stats.last_sw = view.width;
+  topo_stats.last_sh = view.height;
+  topo_stats.last_idle = IsUserIdle(750);
+
+  if (!topo_stats.log_clock.IsDefined())
+    topo_stats.log_clock.Update();
+  else if (topo_stats.log_clock.Check(TOPO_STATS_PERIOD)) {
+    const auto g0 = std::chrono::steady_clock::now();
+    glFinish();
+    topo_stats.gpu_sync_us = TopoSteadyUsSince(g0);
+    topo_stats.have_gpu_sync = true;
+    const GLenum err = glGetError();
+    if (err != GL_NO_ERROR)
+      LogFmt("OpenGL: Topo glGetError=0x{:x}", unsigned(err));
+    topo_stats.Flush();
+  }
+}
+
+void
+TopographyGpuStatsAddLabels(unsigned cpu_us) noexcept
+{
+  topo_stats.AddUs(cpu_us, topo_stats.label_us, topo_stats.label_max_us);
+}
+
+#endif
 
 TopographyFileRenderer::TopographyFileRenderer(const TopographyFile &_file,
                                                const TopographyLook &_look) noexcept
@@ -71,7 +225,249 @@ ShapeTooSmallToDraw(const XShape &shape, Angle min_span) noexcept
     ShapeTooSmall(shape.get_bounds(), min_span);
 }
 
-void
+#ifdef ENABLE_OPENGL
+
+/** GLES2 indices are 16-bit; batch shapes that share a 64k vertex window. */
+static constexpr unsigned GLUSHORT_WINDOW = 0x10000;
+
+[[gnu::pure]]
+static unsigned
+CountLineVertices(std::span<const uint16_t> lines) noexcept
+{
+  unsigned n = 0;
+  for (const unsigned nv : lines)
+    n += nv;
+  return n;
+}
+
+[[gnu::pure]]
+static constexpr bool
+FitsGLushortWindow(unsigned offset, unsigned n_verts) noexcept
+{
+  const unsigned local = offset % GLUSHORT_WINDOW;
+  return n_verts <= GLUSHORT_WINDOW - local;
+}
+
+static constexpr unsigned
+GLushortWindowBase(unsigned offset) noexcept
+{
+  return offset - offset % GLUSHORT_WINDOW;
+}
+
+static void
+AppendOffsetStrip(std::vector<GLsizei> &counts,
+                  std::vector<GLushort> &indices,
+                  unsigned base, unsigned n) noexcept
+{
+  if (n < 2)
+    return;
+
+  counts.push_back(GLsizei(n));
+  const size_t size = indices.size();
+  indices.resize(size + n);
+  for (unsigned i = 0; i < n; ++i)
+    indices[size + i] = GLushort(base + i);
+}
+
+static void
+AppendIndexedStrip(std::vector<GLsizei> &counts,
+                   std::vector<GLushort> &indices,
+                   unsigned offset,
+                   const GLushort *src, unsigned n) noexcept
+{
+  if (n < 2)
+    return;
+
+  counts.push_back(GLsizei(n));
+  const size_t size = indices.size();
+  indices.resize(size + n, GLushort(offset));
+  for (unsigned i = 0; i < n; ++i)
+    indices[size + i] += src[i];
+}
+
+/**
+ * Expand a triangle strip to independent triangles, skipping
+ * degenerates used as strip restarts.  One glDrawElements then
+ * covers many polygons when MultiDrawElements is unavailable.
+ */
+static void
+AppendStripAsTriangles(std::vector<uint16_t> &triangles,
+                       const GLushort *strip, unsigned n) noexcept
+{
+  if (n < 3)
+    return;
+
+  for (unsigned i = 0; i + 2 < n; ++i) {
+    const GLushort a = strip[i];
+    const GLushort b = strip[i + 1];
+    const GLushort c = strip[i + 2];
+    if (a == b || b == c || a == c)
+      continue;
+
+    if (i & 1) {
+      triangles.push_back(b);
+      triangles.push_back(a);
+      triangles.push_back(c);
+    } else {
+      triangles.push_back(a);
+      triangles.push_back(b);
+      triangles.push_back(c);
+    }
+  }
+}
+
+/**
+ * Expand a line strip to independent segments.  Used when the
+ * driver cannot MultiDraw (PowerVR GE8300 SIGSEGV in
+ * glMultiDrawElementsEXT).  Core glDrawElements(GL_LINES) is the
+ * same path as the fill triangle list that already runs there.
+ */
+static void
+AppendStripAsLines(std::vector<uint16_t> &segments,
+                   const GLushort *strip, unsigned n) noexcept
+{
+  if (n < 2)
+    return;
+
+  for (unsigned i = 0; i + 1 < n; ++i) {
+    const GLushort a = strip[i];
+    const GLushort b = strip[i + 1];
+    if (a == b)
+      continue;
+
+    segments.push_back(a);
+    segments.push_back(b);
+  }
+}
+
+static void
+ExpandLines(std::vector<uint16_t> &segments,
+            const std::vector<GLsizei> &counts,
+            const std::vector<GLushort> &indices) noexcept
+{
+  unsigned i = 0;
+  for (auto count : counts) {
+    AppendStripAsLines(segments, indices.data() + i, count);
+    i += count;
+  }
+}
+
+static void
+ExpandFills(std::vector<uint16_t> &triangles,
+            const std::vector<GLsizei> &counts,
+            const std::vector<GLushort> &indices) noexcept
+{
+  unsigned i = 0;
+  for (auto count : counts) {
+    AppendStripAsTriangles(triangles, indices.data() + i, count);
+    i += count;
+  }
+}
+
+static void
+DrawCachedWindow(ScopeVertexPointer &vp, const ShapePoint *buffer,
+                 const TopographyFileRenderer::CachedWindow &w,
+                 unsigned &line_draws, unsigned &fill_draws) noexcept
+{
+  vp.Update(GL_FLOAT, buffer + w.window_base);
+
+#ifdef GL_EXT_multi_draw_arrays
+  if (!w.line_counts.empty() && GLExt::HaveMultiDrawElements()) {
+    std::vector<const GLushort *> pointers;
+    unsigned i = 0;
+    for (auto count : w.line_counts) {
+      pointers.push_back(w.lines.data() + i);
+      i += unsigned(count);
+    }
+    GLExt::MultiDrawElements(GL_LINE_STRIP, w.line_counts.data(),
+                             GL_UNSIGNED_SHORT,
+                             (const GLvoid **)pointers.data(),
+                             w.line_counts.size());
+    ++line_draws;
+  } else
+#endif
+  if (!w.lines.empty()) {
+    glDrawElements(GL_LINES, GLsizei(w.lines.size()),
+                   GL_UNSIGNED_SHORT, w.lines.data());
+    ++line_draws;
+  }
+
+#ifdef GL_EXT_multi_draw_arrays
+  if (!w.fill_counts.empty() && GLExt::HaveMultiDrawElements()) {
+    std::vector<const GLushort *> pointers;
+    unsigned i = 0;
+    for (auto count : w.fill_counts) {
+      pointers.push_back(w.fills.data() + i);
+      i += unsigned(count);
+    }
+    GLExt::MultiDrawElements(GL_TRIANGLE_STRIP, w.fill_counts.data(),
+                             GL_UNSIGNED_SHORT,
+                             (const GLvoid **)pointers.data(),
+                             w.fill_counts.size());
+    ++fill_draws;
+  } else
+#endif
+  if (!w.fills.empty()) {
+    glDrawElements(GL_TRIANGLES, GLsizei(w.fills.size()),
+                   GL_UNSIGNED_SHORT, w.fills.data());
+    ++fill_draws;
+  }
+}
+
+struct TopoShapeBatch {
+  std::vector<GLsizei> line_counts;
+  std::vector<GLushort> line_indices;
+  std::vector<GLsizei> polygon_counts;
+  std::vector<GLushort> polygon_indices;
+  unsigned window_base = 0;
+  bool active = false;
+
+  void FlushTo(std::vector<TopographyFileRenderer::CachedWindow> &out) noexcept {
+    if (!active)
+      return;
+
+    TopographyFileRenderer::CachedWindow w;
+    w.window_base = window_base;
+
+#ifdef GL_EXT_multi_draw_arrays
+    if (GLExt::HaveMultiDrawElements()) {
+      w.line_counts.assign(line_counts.begin(), line_counts.end());
+      w.lines.assign(line_indices.begin(), line_indices.end());
+      w.fill_counts.assign(polygon_counts.begin(), polygon_counts.end());
+      w.fills.assign(polygon_indices.begin(), polygon_indices.end());
+    } else
+#endif
+    {
+      w.lines.reserve(line_indices.size() * 2);
+      w.fills.reserve(polygon_indices.size() * 3);
+      ExpandLines(w.lines, line_counts, line_indices);
+      ExpandFills(w.fills, polygon_counts, polygon_indices);
+    }
+
+    if (!w.lines.empty() || !w.fills.empty() ||
+        !w.line_counts.empty() || !w.fill_counts.empty())
+      out.push_back(std::move(w));
+
+    line_counts.clear();
+    line_indices.clear();
+    polygon_counts.clear();
+    polygon_indices.clear();
+    active = false;
+  }
+
+  void EnsureWindow(unsigned window,
+                    std::vector<TopographyFileRenderer::CachedWindow> &out) noexcept {
+    if (active && window != window_base)
+      FlushTo(out);
+
+    window_base = window;
+    active = true;
+  }
+};
+
+#endif
+
+bool
 TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) noexcept
 {
   const double scale = projection.GetScale();
@@ -81,7 +477,7 @@ TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) 
       visible_bounds.IsValid() &&
       visible_bounds.IsInside(screen))
     /* still inside the last 2× viewport; pan only reprojects */
-    return;
+    return false;
 
   visible_serial = file.GetSerial();
   visible_scale = scale;
@@ -121,6 +517,8 @@ TopographyFileRenderer::UpdateVisibleShapes(const WindowProjection &projection) 
     if (shape.GetLabel() != nullptr && !too_small)
       visible_labels.push_back(&shape);
   }
+
+  return true;
 }
 
 #ifdef ENABLE_OPENGL
@@ -189,17 +587,32 @@ TopographyFileRenderer::Paint(Canvas &canvas,
   if (!file.IsVisible(map_scale))
     return;
 
-  UpdateVisibleShapes(projection);
+#ifdef ENABLE_OPENGL
+  const auto t0 = std::chrono::steady_clock::now();
+  unsigned line_draws = 0, fill_draws = 0;
+#endif
+  const bool vis_rebuild = UpdateVisibleShapes(projection);
   PaintPoints(canvas, projection);
 
-  if (visible_shapes.empty())
+  if (visible_shapes.empty()) {
+#ifdef ENABLE_OPENGL
+    draw_cache_valid = false;
+    TopoAddLayer(TopoSteadyUsSince(t0), 0, 0,
+                 unsigned(visible_points.size()), vis_rebuild, false);
+#endif
     return;
+  }
 
 #ifdef ENABLE_OPENGL
   OpenGL::solid_shader->Use();
 
-  if (!UpdateArrayBuffer())
+  const bool vbo_rebuild =
+    array_buffer == nullptr || file.GetSerial() != array_buffer_serial;
+  if (!UpdateArrayBuffer()) {
+    TopoAddLayer(TopoSteadyUsSince(t0), 0, 0,
+                 unsigned(visible_points.size()), vis_rebuild, vbo_rebuild);
     return;
+  }
   array_buffer->Bind();
   const ShapePoint *const buffer = nullptr;
 
@@ -233,10 +646,17 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 #ifdef ENABLE_OPENGL
   ScopeVertexPointer vp;
 
-#ifdef GL_EXT_multi_draw_arrays
-  std::vector<GLsizei> polygon_counts;
-  std::vector<GLushort> polygon_indices;
-#endif
+  const bool cache_ok = draw_cache_valid &&
+    !vis_rebuild && !vbo_rebuild &&
+    draw_cache_thinning == level;
+
+  if (cache_ok) {
+    for (const auto &w : draw_windows)
+      DrawCachedWindow(vp, buffer, w, line_draws, fill_draws);
+  } else {
+    draw_windows.clear();
+    TopoShapeBatch batch;
+    bool index_cache_complete = true;
 #endif
 
   const Angle min_span =
@@ -263,23 +683,77 @@ TopographyFileRenderer::Paint(Canvas &canvas,
     case MS_SHAPE_LINE:
       {
 #ifdef ENABLE_OPENGL
+        const unsigned offset = shape.GetOffset();
+        const unsigned n_verts = CountLineVertices(lines);
+        XShape::Indices indices{};
+        const bool have_thin =
+          level != 0 &&
+          (indices = shape.GetIndices(level, min_distance)).indices != nullptr;
+
+        if (FitsGLushortWindow(offset, n_verts)) {
+          /* postpone: one draw per 64k-vertex window */
+          const unsigned window = GLushortWindowBase(offset);
+          batch.EnsureWindow(window, draw_windows);
+          const unsigned local_base = offset - window;
+          if (!have_thin) {
+            unsigned local = 0;
+            for (unsigned n : lines) {
+              AppendOffsetStrip(batch.line_counts, batch.line_indices,
+                                local_base + local, n);
+              local += n;
+            }
+          } else {
+            for (unsigned n : std::span<const GLushort>{
+                   indices.count, lines.size()}) {
+              AppendIndexedStrip(batch.line_counts, batch.line_indices,
+                                 local_base, indices.indices, n);
+              indices.indices += n;
+            }
+          }
+          break;
+        }
+
+        if (n_verts <= GLUSHORT_WINDOW) {
+          /* Shape spans a 64k VBO window; address it from its own
+             base so indices stay 16-bit. */
+          batch.EnsureWindow(offset, draw_windows);
+          if (!have_thin) {
+            unsigned local = 0;
+            for (unsigned n : lines) {
+              AppendOffsetStrip(batch.line_counts, batch.line_indices,
+                                local, n);
+              local += n;
+            }
+          } else {
+            for (unsigned n : std::span<const GLushort>{
+                   indices.count, lines.size()}) {
+              AppendIndexedStrip(batch.line_counts, batch.line_indices,
+                                 0, indices.indices, n);
+              indices.indices += n;
+            }
+          }
+          break;
+        }
+
         vp.Update(GL_FLOAT, points);
 
-        XShape::Indices indices;
-        if (level == 0 ||
-            (indices = shape.GetIndices(level, min_distance)).indices == nullptr) {
-          unsigned offset = 0;
+        if (!have_thin) {
+          unsigned local = 0;
           for (unsigned n : lines) {
-            glDrawArrays(GL_LINE_STRIP, offset, n);
-            offset += n;
+            glDrawArrays(GL_LINE_STRIP, local, n);
+            ++line_draws;
+            local += n;
           }
         } else {
-          for (unsigned n : std::span<const GLushort>{indices.count, lines.size()}) {
+          for (unsigned n : std::span<const GLushort>{
+                 indices.count, lines.size()}) {
             glDrawElements(GL_LINE_STRIP, n, GL_UNSIGNED_SHORT,
                            indices.indices);
+            ++line_draws;
             indices.indices += n;
           }
         }
+        index_cache_complete = false;
 #else // !ENABLE_OPENGL
         for (unsigned msize : lines) {
         shape_renderer.Begin(msize);
@@ -307,31 +781,38 @@ TopographyFileRenderer::Paint(Canvas &canvas,
 
         const unsigned n = *triangles.count;
 
-#ifdef GL_EXT_multi_draw_arrays
         const unsigned offset = shape.GetOffset();
-        unsigned n_verts = 0;
-        for (const unsigned nv : shape.GetLines())
-          n_verts += nv;
-        /* GLushort indices; offset+n (strip length) is not the
-           highest vertex.  Wrapping picks vertices from other
-           shapes and stretches fills across the map. */
-        if (GLExt::HaveMultiDrawElements() &&
-            offset < 0x10000 &&
-            n_verts <= 0x10000 - offset) {
-          /* postpone, draw many polygons with a single
-             glMultiDrawElements() call */
-          polygon_counts.push_back(n);
-          const size_t size = polygon_indices.size();
-          polygon_indices.resize(size + n, offset);
+        const unsigned n_verts = CountLineVertices(lines);
+        /* GLushort indices relative to the 64k window that
+           contains this shape.  A strip that crosses a window
+           is drawn unbatched so indices cannot wrap. */
+        if (FitsGLushortWindow(offset, n_verts)) {
+          const unsigned window = GLushortWindowBase(offset);
+          batch.EnsureWindow(window, draw_windows);
+          const unsigned local_base = offset - window;
+          batch.polygon_counts.push_back(n);
+          const size_t size = batch.polygon_indices.size();
+          batch.polygon_indices.resize(size + n, local_base);
           for (unsigned i = 0; i < n; ++i)
-            polygon_indices[size + i] += triangles.indices[i];
+            batch.polygon_indices[size + i] += triangles.indices[i];
           break;
         }
-#endif
+
+        if (n_verts <= GLUSHORT_WINDOW) {
+          batch.EnsureWindow(offset, draw_windows);
+          batch.polygon_counts.push_back(n);
+          const size_t size = batch.polygon_indices.size();
+          batch.polygon_indices.resize(size + n);
+          for (unsigned i = 0; i < n; ++i)
+            batch.polygon_indices[size + i] = triangles.indices[i];
+          break;
+        }
 
         vp.Update(GL_FLOAT, points);
         glDrawElements(GL_TRIANGLE_STRIP, n, GL_UNSIGNED_SHORT,
                        triangles.indices);
+        ++fill_draws;
+        index_cache_complete = false;
       }
 #else // !ENABLE_OPENGL
       {
@@ -370,25 +851,12 @@ TopographyFileRenderer::Paint(Canvas &canvas,
   }
 #ifdef ENABLE_OPENGL
 
-#ifdef GL_EXT_multi_draw_arrays
-  if (!polygon_indices.empty()) {
-    assert(GLExt::HaveMultiDrawElements());
-
-    std::vector<const GLushort *> polygon_pointers;
-    unsigned i = 0;
-    for (auto count : polygon_counts) {
-      polygon_pointers.push_back(polygon_indices.data() + i);
-      i += count;
-    }
-
-    vp.Update(GL_FLOAT, buffer);
-
-    GLExt::MultiDrawElements(GL_TRIANGLE_STRIP, polygon_counts.data(),
-                             GL_UNSIGNED_SHORT,
-                             (const GLvoid **)polygon_pointers.data(),
-                             polygon_counts.size());
+    batch.FlushTo(draw_windows);
+    for (const auto &w : draw_windows)
+      DrawCachedWindow(vp, buffer, w, line_draws, fill_draws);
+    draw_cache_valid = index_cache_complete;
+    draw_cache_thinning = level;
   }
-#endif
 
   glUniformMatrix4fv(OpenGL::solid_modelview, 1, GL_FALSE,
                      glm::value_ptr(glm::mat4(1)));
@@ -398,6 +866,9 @@ TopographyFileRenderer::Paint(Canvas &canvas,
   pen.Unbind();
 
   array_buffer->Unbind();
+
+  TopoAddLayer(TopoSteadyUsSince(t0), line_draws, fill_draws,
+               unsigned(visible_points.size()), vis_rebuild, vbo_rebuild);
 #else
   shape_renderer.Commit();
 #endif

--- a/src/Topography/TopographyFileRenderer.cpp
+++ b/src/Topography/TopographyFileRenderer.cpp
@@ -479,8 +479,20 @@ TopographyFileRenderer::PaintLabels(Canvas &canvas,
     if (drawn_labels.contains(label))
       continue;
 
-    const PixelRect brect = PixelRect::Centered(*pt,
-                                                canvas.CalcTextSize(label));
+    const PixelSize tsize = canvas.CalcTextSize(label);
+    PixelRect brect;
+    if (shape.get_type() == MS_SHAPE_POINT && icon.IsDefined()) {
+      /* Sit the name under the icon so it does not cover the symbol.
+         Fills and roads stay centred on the hook. */
+      const int pad = Layout::GetTextPadding();
+      const PixelPoint origin{
+        pt->x - int(tsize.width) / 2,
+        pt->y + int(icon.GetSize().height + 1) / 2 + pad,
+      };
+      brect = PixelRect{origin, tsize};
+    } else {
+      brect = PixelRect::Centered(*pt, tsize);
+    }
     if (!label_block.check(brect))
       continue;
 

--- a/src/Topography/TopographyFileRenderer.hpp
+++ b/src/Topography/TopographyFileRenderer.hpp
@@ -50,6 +50,13 @@ class TopographyFileRenderer final
   Serial visible_serial;
   GeoBounds visible_bounds;
 
+  /**
+   * #Projection::GetScale() (px/m) used to build #visible_shapes.
+   * Recache when the map is zoomed in (larger scale) so previously
+   * skipped sub-pixel lines can appear.
+   */
+  double visible_scale = 0;
+
   std::vector<const XShape *> visible_shapes, visible_labels;
 
   std::vector<GeoPoint> visible_points;

--- a/src/Topography/TopographyFileRenderer.hpp
+++ b/src/Topography/TopographyFileRenderer.hpp
@@ -112,7 +112,7 @@ private:
   void UpdateVisibleShapes(const WindowProjection &projection) noexcept;
 
 #ifdef ENABLE_OPENGL
-  void UpdateArrayBuffer() noexcept;
+  bool UpdateArrayBuffer() noexcept;
 #endif
 
   void PaintPoints(Canvas &canvas, const WindowProjection &projection) noexcept;

--- a/src/Topography/TopographyFileRenderer.hpp
+++ b/src/Topography/TopographyFileRenderer.hpp
@@ -48,12 +48,12 @@ class TopographyFileRenderer final
   MaskedIcon icon;
 
   Serial visible_serial;
-  GeoBounds visible_bounds;
+  GeoBounds visible_bounds = GeoBounds::Invalid();
 
   /**
    * #Projection::GetScale() (px/m) used to build #visible_shapes.
    * Recache when the map is zoomed in (larger scale) so previously
-   * skipped sub-pixel lines can appear.
+   * skipped sub-pixel fills can appear.
    */
   double visible_scale = 0;
 

--- a/src/Topography/TopographyFileRenderer.hpp
+++ b/src/Topography/TopographyFileRenderer.hpp
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 class TopographyFile;
 class Canvas;
@@ -64,6 +65,21 @@ class TopographyFileRenderer final
 #ifdef ENABLE_OPENGL
   std::unique_ptr<GLArrayBuffer> array_buffer;
   Serial array_buffer_serial;
+
+  /**
+   * Expanded (or MultiDraw) index lists for the current VBO and
+   * visible set.  Reused while panning inside the 2× cache.
+   */
+public:
+  struct CachedWindow {
+    unsigned window_base = 0;
+    std::vector<uint16_t> lines, fills;
+    std::vector<int> line_counts, fill_counts;
+  };
+private:
+  std::vector<CachedWindow> draw_windows;
+  unsigned draw_cache_thinning = ~0u;
+  bool draw_cache_valid = false;
 #endif
 
 public:
@@ -109,7 +125,8 @@ public:
                    LabelBlock &label_block) noexcept;
 
 private:
-  void UpdateVisibleShapes(const WindowProjection &projection) noexcept;
+  /** @return true if the visible-shape cache was rebuilt */
+  bool UpdateVisibleShapes(const WindowProjection &projection) noexcept;
 
 #ifdef ENABLE_OPENGL
   bool UpdateArrayBuffer() noexcept;

--- a/src/Topography/TopographyFileRenderer.hpp
+++ b/src/Topography/TopographyFileRenderer.hpp
@@ -74,6 +74,22 @@ public:
 
   ~TopographyFileRenderer() noexcept;
 
+  const TopographyFile &GetFile() const noexcept {
+    return file;
+  }
+
+  std::size_t GetVisibleShapeCount() const noexcept {
+    return visible_shapes.size();
+  }
+
+  std::size_t GetVisiblePointCount() const noexcept {
+    return visible_points.size();
+  }
+
+  std::size_t GetVisibleLabelCount() const noexcept {
+    return visible_labels.size();
+  }
+
   /**
    * Paints the polygons, lines and points/icons in the TopographyFile
    * @param canvas The canvas to paint on

--- a/src/Topography/TopographyRenderer.cpp
+++ b/src/Topography/TopographyRenderer.cpp
@@ -10,6 +10,9 @@
 
 #include <algorithm>
 #include <cmath>
+#ifdef ENABLE_OPENGL
+#include <chrono>
+#endif
 
 TopographyRenderer::TopographyRenderer(const TopographyStore &_store,
                                        const TopographyLook &look) noexcept
@@ -26,8 +29,14 @@ void
 TopographyRenderer::Draw(Canvas &canvas,
                          const WindowProjection &projection) noexcept
 {
+#ifdef ENABLE_OPENGL
+  TopographyGpuStatsBeginDraw();
+#endif
   for (auto &i : files)
     i.Paint(canvas, projection);
+#ifdef ENABLE_OPENGL
+  TopographyGpuStatsEndDraw(projection);
+#endif
 
   const double map_scale = projection.GetMapScale();
   if (last_logged_map_scale > 0 &&
@@ -71,6 +80,16 @@ TopographyRenderer::DrawLabels(Canvas &canvas,
                                const WindowProjection &projection,
                                LabelBlock &label_block) noexcept
 {
+#ifdef ENABLE_OPENGL
+  const auto t0 = std::chrono::steady_clock::now();
+#endif
   for (auto &i : files)
     i.PaintLabels(canvas, projection, label_block);
+#ifdef ENABLE_OPENGL
+  const unsigned us = unsigned(
+    std::chrono::duration_cast<std::chrono::microseconds>(
+      std::chrono::steady_clock::now() - t0)
+      .count());
+  TopographyGpuStatsAddLabels(us);
+#endif
 }

--- a/src/Topography/TopographyRenderer.cpp
+++ b/src/Topography/TopographyRenderer.cpp
@@ -5,6 +5,11 @@
 #include "Topography/TopographyFileRenderer.hpp"
 #include "TopographyStore.hpp"
 #include "TopographyFile.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "LogFile.hpp"
+
+#include <algorithm>
+#include <cmath>
 
 TopographyRenderer::TopographyRenderer(const TopographyStore &_store,
                                        const TopographyLook &look) noexcept
@@ -23,6 +28,42 @@ TopographyRenderer::Draw(Canvas &canvas,
 {
   for (auto &i : files)
     i.Paint(canvas, projection);
+
+  const double map_scale = projection.GetMapScale();
+  if (last_logged_map_scale > 0 &&
+      std::fabs(map_scale - last_logged_map_scale) /
+        std::max(map_scale, last_logged_map_scale) < 0.05)
+    return;
+
+  last_logged_map_scale = map_scale;
+
+  unsigned n_layers = 0;
+  std::size_t n_fills = 0, n_points = 0, n_labels = 0, n_cached = 0;
+  for (const auto &i : files) {
+    const auto &file = i.GetFile();
+    const bool on = file.IsVisible(map_scale);
+    const std::size_t fills = on ? i.GetVisibleShapeCount() : 0;
+    const std::size_t points = on ? i.GetVisiblePointCount() : 0;
+    const std::size_t labels = on ? i.GetVisibleLabelCount() : 0;
+    const unsigned cached = file.GetCachedShapeCount();
+    if (!on && cached == 0)
+      continue;
+
+    ++n_layers;
+    n_fills += fills;
+    n_points += points;
+    n_labels += labels;
+    n_cached += cached;
+
+    LogFmt("Topography: scale={:.0f} m  {}  fills={}  points={}  "
+           "labels={}  cached={}/{}",
+           map_scale, file.GetName(), fills, points, labels,
+           cached, file.GetFileShapeCount());
+  }
+
+  LogFmt("Topography: scale={:.0f} m  layers={}  fills={}  points={}  "
+         "labels={}  cached={}",
+         map_scale, n_layers, n_fills, n_points, n_labels, n_cached);
 }
 
 void

--- a/src/Topography/TopographyRenderer.hpp
+++ b/src/Topography/TopographyRenderer.hpp
@@ -22,6 +22,12 @@ class TopographyRenderer : private NonCopyable {
 
   std::forward_list<TopographyFileRenderer> files;
 
+  /**
+   * Last #WindowProjection::GetMapScale() that was written to the
+   * log, so pinch/pan does not flood xcsoar.log.
+   */
+  double last_logged_map_scale = -1;
+
 public:
   TopographyRenderer(const TopographyStore &store,
                      const TopographyLook &look) noexcept;

--- a/src/Topography/TopographyRenderer.hpp
+++ b/src/Topography/TopographyRenderer.hpp
@@ -50,3 +50,9 @@ public:
   void DrawLabels(Canvas &canvas, const WindowProjection &projection,
                   LabelBlock &label_block) noexcept;
 };
+
+#ifdef ENABLE_OPENGL
+void TopographyGpuStatsBeginDraw() noexcept;
+void TopographyGpuStatsEndDraw(const WindowProjection &projection) noexcept;
+void TopographyGpuStatsAddLabels(unsigned cpu_us) noexcept;
+#endif

--- a/src/Topography/TopographyStore.cpp
+++ b/src/Topography/TopographyStore.cpp
@@ -34,7 +34,8 @@ TopographyStore::GetNextScaleThreshold(double map_scale) const noexcept
 
 unsigned
 TopographyStore::ScanVisibility(const WindowProjection &m_projection,
-                                unsigned max_update) noexcept
+                                unsigned max_update,
+                                unsigned layout_scale) noexcept
 {
   // check if any needs to have cache updates because wasnt
   // visible previously when bounds moved
@@ -44,7 +45,7 @@ TopographyStore::ScanVisibility(const WindowProjection &m_projection,
   unsigned num_updated = 0;
   for (auto &file : files) {
     try {
-      if (file.Update(m_projection)) {
+      if (file.Update(m_projection, layout_scale)) {
         ++num_updated;
         if (num_updated >= max_update)
           break;

--- a/src/Topography/TopographyStore.hpp
+++ b/src/Topography/TopographyStore.hpp
@@ -53,10 +53,13 @@ public:
   /**
    * @param max_update the maximum number of files updated in this
    * call
+   * @param layout_scale UI pixel scale (Layout::Scale(1)); forwarded
+   * to TopographyFile::Update() for OpenGL triangulation
    * @return the number of files which were updated
    */
   unsigned ScanVisibility(const WindowProjection &m_projection,
-                          unsigned max_update=1024) noexcept;
+                          unsigned max_update=1024,
+                          unsigned layout_scale=1) noexcept;
 
   /**
    * Load all shapes of all files into memory.  For debugging

--- a/src/Topography/XShape.cpp
+++ b/src/Topography/XShape.cpp
@@ -4,6 +4,7 @@
 #include "Topography/XShape.hpp"
 #include "Convert.hpp"
 #include "util/Compiler.h"
+#include "util/StaticArray.hxx"
 #include "util/StringAPI.hxx"
 #include "util/UTF8.hpp"
 #include "util/StringStrip.hxx"
@@ -14,8 +15,12 @@
 #include "ui/canvas/opengl/Triangulate.hpp"
 #endif
 
+#include "Geo/GeoClip.hpp"
+
 #include <algorithm>
+#include <cassert>
 #include <stdexcept>
+#include <vector>
 
 static BasicAllocatedString<char>
 ImportLabel(const char *src) noexcept
@@ -68,6 +73,74 @@ ToGeoPoint(const pointObj &src) noexcept
 }
 
 [[gnu::pure]]
+static bool
+ShapeFullyInsideClip(const shapeObj &shape, const GeoBounds &clip) noexcept
+{
+  return clip.IsInside(ImportRect(shape.bounds));
+}
+
+static constexpr uint16_t MAX_LINE_POINTS = 16384;
+
+static_assert(XShape::MAX_LINES <= 255,
+              "num_lines is stored in a uint8_t");
+
+/**
+ * Clip one shapefile line into #out_pts / #out_counts.  A long way
+ * that leaves and re-enters the viewport becomes several short
+ * polylines.
+ */
+static void
+ClipShapeLine(const lineObj &line, const GeoClip &clip,
+              std::vector<GeoPoint> &out_pts,
+              std::array<uint16_t, XShape::MAX_LINES> &out_counts,
+              uint8_t &n_out, uint8_t max_lines) noexcept
+{
+  if (line.numpoints < 2 || n_out >= max_lines)
+    return;
+
+  uint16_t count = 0;
+  for (int j = 1; j < line.numpoints; ++j) {
+    GeoPoint a = ToGeoPoint(line.point[j - 1]);
+    GeoPoint b = ToGeoPoint(line.point[j]);
+    const GeoPoint b_orig = b;
+    if (!clip.ClipLine(a, b))
+      continue;
+
+    if (count == 0) {
+      if (n_out >= max_lines)
+        return;
+      out_pts.push_back(a);
+      out_pts.push_back(b);
+      count = 2;
+    } else if (count >= MAX_LINE_POINTS) {
+      out_counts[n_out++] = count;
+      count = 0;
+      if (n_out >= max_lines)
+        return;
+      out_pts.push_back(a);
+      out_pts.push_back(b);
+      count = 2;
+    } else {
+      out_pts.push_back(b);
+      ++count;
+    }
+
+    if (b.longitude != b_orig.longitude ||
+        b.latitude != b_orig.latitude) {
+      out_counts[n_out++] = count;
+      count = 0;
+    }
+  }
+
+  if (count >= 2) {
+    if (n_out < max_lines)
+      out_counts[n_out++] = count;
+    else
+      out_pts.resize(out_pts.size() - count);
+  }
+}
+
+[[gnu::pure]]
 static auto
 ImportShapePoint(const pointObj &src, [[maybe_unused]] const GeoPoint &file_center) noexcept
 {
@@ -88,10 +161,30 @@ ImportShapePoint(const pointObj &src, [[maybe_unused]] const GeoPoint &file_cent
 #endif
 }
 
+[[gnu::pure]]
+static auto
+ImportGeoPoint(const GeoPoint &vertex,
+               [[maybe_unused]] const GeoPoint &file_center) noexcept
+{
+#ifdef ENABLE_OPENGL
+  const GeoPoint relative = vertex - file_center;
+  return ShapePoint{
+    ShapeScalar(relative.longitude.Native()),
+    ShapeScalar(relative.latitude.Native()),
+  };
+#else
+  return vertex;
+#endif
+}
+
 XShape::XShape(const shapeObj &shape, const GeoPoint &file_center,
-               const char *_label)
+               const char *_label, const GeoBounds *clip,
+               bool *clipped)
   :label(ImportLabel(_label))
 {
+  if (clipped != nullptr)
+    *clipped = false;
+
   bounds = ImportRect(shape.bounds);
   if (!bounds.Check())
     throw std::runtime_error{"Malformed shape bounds"};
@@ -106,6 +199,54 @@ XShape::XShape(const shapeObj &shape, const GeoPoint &file_center,
     return;
   }
 
+  const bool do_clip = clip != nullptr &&
+    shape.type == MS_SHAPE_LINE &&
+    !ShapeFullyInsideClip(shape, *clip);
+
+  if (do_clip) {
+    if (clipped != nullptr)
+      *clipped = true;
+
+    std::vector<GeoPoint> clipped_pts;
+    std::array<uint16_t, XShape::MAX_LINES> clipped_counts{};
+    uint8_t n_clipped = 0;
+    const GeoClip geo_clip{*clip};
+
+    const std::size_t input_lines = std::min((std::size_t)shape.numlines,
+                                             lines.size());
+    for (std::size_t l = 0; l < input_lines; ++l)
+      ClipShapeLine(shape.line[l], geo_clip,
+                    clipped_pts, clipped_counts, n_clipped,
+                    uint8_t(lines.size()));
+
+    num_lines = n_clipped;
+    if (num_lines == 0)
+      return;
+
+    GeoBounds new_bounds = GeoBounds::Invalid();
+    for (const GeoPoint &gp : clipped_pts) {
+      if (!new_bounds.IsValid())
+        new_bounds = GeoBounds(gp);
+      else
+        new_bounds.Extend(gp);
+    }
+    if (new_bounds.Check())
+      bounds = new_bounds;
+
+    std::size_t n = 0;
+    for (uint8_t l = 0; l < num_lines; ++l) {
+      lines[l] = clipped_counts[l];
+      n += lines[l];
+    }
+    assert(n == clipped_pts.size());
+
+    points = std::make_unique<Point[]>(n);
+    auto *p = points.get();
+    for (const GeoPoint &gp : clipped_pts)
+      *p++ = ImportGeoPoint(gp, file_center);
+    return;
+  }
+
   const std::size_t input_lines = std::min((std::size_t)shape.numlines,
                                            lines.size());
   std::size_t num_points = 0;
@@ -114,7 +255,8 @@ XShape::XShape(const shapeObj &shape, const GeoPoint &file_center,
       /* malformed shape */
       continue;
 
-    lines[num_lines] = std::min(shape.line[l].numpoints, 16384);
+    lines[num_lines] = std::min(shape.line[l].numpoints,
+                                int(MAX_LINE_POINTS));
     num_points += lines[num_lines];
     ++num_lines;
   }
@@ -133,6 +275,46 @@ XShape::XShape(const shapeObj &shape, const GeoPoint &file_center,
 XShape::~XShape() noexcept = default;
 
 #ifdef ENABLE_OPENGL
+
+/**
+ * Ear-clip a ring.  Rings larger than TARGET are subsampled in O(n)
+ * first at every thinning level; PolygonToTriangles() itself is O(n²)
+ * and a large landcover ring would freeze the topography loader.
+ */
+static unsigned
+PolygonToTrianglesThinned(const ShapePoint *src, unsigned n,
+                          GLushort *triangles,
+                          ShapeScalar min_distance) noexcept
+{
+  constexpr unsigned TARGET = 128;
+  /* orig[] stores source vertex indices in GLushort. */
+  assert(n > 0 && n - 1 <= 0xffff);
+
+  if (n <= TARGET)
+    return PolygonToTriangles(src, n, triangles, min_distance);
+
+  StaticArray<ShapePoint, TARGET + 1> thin_pts;
+  StaticArray<GLushort, TARGET + 1> orig;
+
+  const unsigned stride = (n + TARGET - 1) / TARGET;
+  for (unsigned i = 0; i < n; i += stride) {
+    orig.append(i);
+    thin_pts.append(src[i]);
+  }
+  if (orig.back() != GLushort(n - 1)) {
+    orig.append(n - 1);
+    thin_pts.append(src[n - 1]);
+  }
+
+  /* PolygonToTriangles writes at most 3*(m-2) indices for m vertices;
+     m <= TARGET+1. */
+  GLushort tmp[3 * (TARGET + 1)];
+  const unsigned count =
+    PolygonToTriangles(thin_pts.data(), thin_pts.size(), tmp, 0);
+  for (unsigned j = 0; j < count; ++j)
+    triangles[j] = orig[tmp[j]];
+  return count;
+}
 
 inline bool
 XShape::BuildIndices(unsigned thinning_level, ShapeScalar min_distance) noexcept
@@ -185,8 +367,9 @@ XShape::BuildIndices(unsigned thinning_level, ShapeScalar min_distance) noexcept
     *idx_count = 0;
     const ShapePoint *pt = points.get();
     for (std::size_t i=0; i < num_lines; i++) {
-      std::size_t count = PolygonToTriangles(pt, lines[i], idx + *idx_count,
-                                             min_distance);
+      std::size_t count = PolygonToTrianglesThinned(pt, lines[i],
+                                                    idx + *idx_count,
+                                                    min_distance);
       if (i > 0) {
         const GLushort offset = pt - points.get();
         const std::size_t max_idx_count = *idx_count + count;

--- a/src/Topography/XShape.cpp
+++ b/src/Topography/XShape.cpp
@@ -4,7 +4,6 @@
 #include "Topography/XShape.hpp"
 #include "Convert.hpp"
 #include "util/Compiler.h"
-#include "util/StaticArray.hxx"
 #include "util/StringAPI.hxx"
 #include "util/UTF8.hpp"
 #include "util/StringStrip.hxx"
@@ -13,6 +12,7 @@
 #ifdef ENABLE_OPENGL
 #include "Projection/Projection.hpp"
 #include "ui/canvas/opengl/Triangulate.hpp"
+#include "Math/Line2D.hpp"
 #endif
 
 #include "Geo/GeoClip.hpp"
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cassert>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 static BasicAllocatedString<char>
@@ -277,9 +278,69 @@ XShape::~XShape() noexcept = default;
 #ifdef ENABLE_OPENGL
 
 /**
- * Ear-clip a ring.  Rings larger than TARGET are subsampled in O(n)
- * first at every thinning level; PolygonToTriangles() itself is O(n²)
- * and a large landcover ring would freeze the topography loader.
+ * Squared distance from #p to the segment #a–#b.
+ */
+[[gnu::pure]]
+static ShapeScalar
+PointSegmentDistance2(ShapePoint p, ShapePoint a, ShapePoint b) noexcept
+{
+  const Line2D<ShapePoint> line(a, b);
+  if (line.GetSquaredDistance() == 0)
+    return (p - a).MagnitudeSquared();
+
+  double t = line.ProjectedRatio(p);
+  if (t < 0)
+    t = 0;
+  else if (t > 1)
+    t = 1;
+  return (p - line.Interpolate(t)).MagnitudeSquared();
+}
+
+/**
+ * Douglas–Peucker keep-flags for src[0..n).  First and last are kept.
+ */
+static void
+SimplifyRingRDP(const ShapePoint *src, unsigned n, ShapeScalar eps2,
+                std::vector<char> &keep) noexcept
+{
+  keep.assign(n, 0);
+  if (n < 2)
+    return;
+
+  keep.front() = 1;
+  keep.back() = 1;
+
+  std::vector<std::pair<unsigned, unsigned>> stack;
+  stack.emplace_back(0, n - 1);
+
+  while (!stack.empty()) {
+    const auto [first, last] = stack.back();
+    stack.pop_back();
+
+    unsigned best = 0;
+    ShapeScalar best_d2 = eps2;
+    for (unsigned i = first + 1; i < last; ++i) {
+      const ShapeScalar d2 =
+        PointSegmentDistance2(src[i], src[first], src[last]);
+      if (d2 > best_d2) {
+        best_d2 = d2;
+        best = i;
+      }
+    }
+
+    if (best != 0) {
+      keep[best] = 1;
+      stack.emplace_back(first, best);
+      stack.emplace_back(best, last);
+    }
+  }
+}
+
+/**
+ * Ear-clip a ring.  Rings larger than TARGET are simplified with
+ * Douglas–Peucker first: PolygonToTriangles() is O(n²), and a
+ * uniform stride used to drop bays so landcover triangles stretched
+ * across the map.
  */
 static unsigned
 PolygonToTrianglesThinned(const ShapePoint *src, unsigned n,
@@ -287,30 +348,59 @@ PolygonToTrianglesThinned(const ShapePoint *src, unsigned n,
                           ShapeScalar min_distance) noexcept
 {
   constexpr unsigned TARGET = 128;
-  /* orig[] stores source vertex indices in GLushort. */
   assert(n > 0 && n - 1 <= 0xffff);
+
+  if (n >= 2 && src[0] == src[n - 1])
+    n--;
 
   if (n <= TARGET)
     return PolygonToTriangles(src, n, triangles, min_distance);
 
-  StaticArray<ShapePoint, TARGET + 1> thin_pts;
-  StaticArray<GLushort, TARGET + 1> orig;
-
-  const unsigned stride = (n + TARGET - 1) / TARGET;
-  for (unsigned i = 0; i < n; i += stride) {
-    orig.append(i);
-    thin_pts.append(src[i]);
-  }
-  if (orig.back() != GLushort(n - 1)) {
-    orig.append(n - 1);
-    thin_pts.append(src[n - 1]);
+  ShapeScalar min_x = src[0].x, max_x = src[0].x;
+  ShapeScalar min_y = src[0].y, max_y = src[0].y;
+  for (unsigned i = 1; i < n; ++i) {
+    min_x = std::min(min_x, src[i].x);
+    max_x = std::max(max_x, src[i].x);
+    min_y = std::min(min_y, src[i].y);
+    max_y = std::max(max_y, src[i].y);
   }
 
-  /* PolygonToTriangles writes at most 3*(m-2) indices for m vertices;
-     m <= TARGET+1. */
-  GLushort tmp[3 * (TARGET + 1)];
+  const ShapeScalar span = std::max(max_x - min_x, max_y - min_y);
+  if (span <= 0)
+    return PolygonToTriangles(src, n, triangles, min_distance);
+
+  ShapeScalar eps = span / ShapeScalar(TARGET);
+  ShapeScalar eps2 = eps * eps;
+
+  std::vector<char> keep;
+  unsigned n_keep = n;
+  for (unsigned pass = 0; pass < 8; ++pass) {
+    SimplifyRingRDP(src, n, eps2, keep);
+    n_keep = 0;
+    for (char k : keep)
+      n_keep += k != 0;
+    if (n_keep <= TARGET)
+      break;
+    eps2 *= 4;
+  }
+
+  if (n_keep < 3)
+    return 0;
+
+  std::vector<ShapePoint> thin_pts;
+  std::vector<GLushort> orig;
+  thin_pts.reserve(n_keep);
+  orig.reserve(n_keep);
+  for (unsigned i = 0; i < n; ++i) {
+    if (keep[i] == 0)
+      continue;
+    orig.push_back(GLushort(i));
+    thin_pts.push_back(src[i]);
+  }
+
+  std::vector<GLushort> tmp(3 * (thin_pts.size() - 2));
   const unsigned count =
-    PolygonToTriangles(thin_pts.data(), thin_pts.size(), tmp, 0);
+    PolygonToTriangles(thin_pts.data(), thin_pts.size(), tmp.data(), 0);
   for (unsigned j = 0; j < count; ++j)
     triangles[j] = orig[tmp[j]];
   return count;
@@ -360,7 +450,14 @@ XShape::BuildIndices(unsigned thinning_level, ShapeScalar min_distance) noexcept
     // TODO: free memory saved by thinning (use malloc/realloc or some class?)
     return true;
   } else if (type == MS_SHAPE_POLYGON) {
-    index_count[thinning_level] = std::make_unique<GLushort[]>(1 + 3 * (num_points - 2) + 2 * (num_lines - 1));
+    /* Strip conversion may restart once per triangle; keep room for
+       2 extra indices per restart. */
+    const unsigned max_triangles =
+      num_points >= 2 * num_lines ? num_points - 2 * num_lines : 0;
+    const unsigned max_strip =
+      max_triangles == 0 ? 0 : 5 * max_triangles - 2;
+    index_count[thinning_level] =
+      std::make_unique<GLushort[]>(1 + max_strip);
     idx_count = index_count[thinning_level].get();
     indices[thinning_level] = idx = idx_count + 1;
 

--- a/src/Topography/XShape.hpp
+++ b/src/Topography/XShape.hpp
@@ -20,7 +20,10 @@
 struct GeoPoint;
 
 class XShape {
-  static constexpr std::size_t MAX_LINES = 32;
+public:
+  static constexpr std::size_t MAX_LINES = 64;
+
+private:
 #ifdef ENABLE_OPENGL
   static constexpr std::size_t THINNING_LEVELS = 4;
 #endif
@@ -78,9 +81,15 @@ class XShape {
 public:
   /**
    * Throws on error.
+   *
+   * @param clip if non-null and this is a polyline, keep only the
+   * parts that intersect #clip (long OSM ways otherwise occupy RAM
+   * for the whole map)
+   * @param clipped set to true when geometry was reduced to #clip
    */
   XShape(const shapeObj &shape, const GeoPoint &file_center,
-         const char *label);
+         const char *label, const GeoBounds *clip=nullptr,
+         bool *clipped=nullptr);
 
   ~XShape() noexcept;
 

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -10,6 +10,8 @@
 
 #include "Look/Colors.hpp"
 #include "Projection/WindowProjection.hpp"
+#include "Geo/GeoClip.hpp"
+#include "MapWindow/MapCanvas.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Color.hpp"
 #ifdef ENABLE_OPENGL
@@ -228,12 +230,8 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
   const ScopeAlphaBlend alpha_blend;
 #endif
 
-  /* Temporary buffer for screen-space polygon points.
-     We reuse this across polygons to avoid reallocation. */
-  std::vector<BulkPixelPoint> screen_points;
-  screen_points.reserve(256);
-
-  const auto screen_rect = projection.GetScreenRect();
+  const GeoClip clip(projection.GetScreenBounds().Scale(1.1));
+  MapCanvas map_canvas(canvas, projection, clip);
 
   for (const auto &band : forecast.bands) {
     /* Set color for this wind band.
@@ -261,32 +259,7 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
       if (ring.size() < 3)
         continue;
 
-      /* Quick bounding-box visibility check */
-      GeoPoint bb_min = ring[0], bb_max = ring[0];
-      for (const auto &pt : ring) {
-        if (pt.longitude < bb_min.longitude) bb_min.longitude = pt.longitude;
-        if (pt.latitude < bb_min.latitude) bb_min.latitude = pt.latitude;
-        if (pt.longitude > bb_max.longitude) bb_max.longitude = pt.longitude;
-        if (pt.latitude > bb_max.latitude) bb_max.latitude = pt.latitude;
-      }
-
-      /* Check if bounding box intersects the screen */
-      auto tl = projection.GeoToScreen(GeoPoint(bb_min.longitude, bb_max.latitude));
-      auto br = projection.GeoToScreen(GeoPoint(bb_max.longitude, bb_min.latitude));
-
-      if (br.x < screen_rect.left || tl.x > screen_rect.right ||
-          br.y < screen_rect.top || tl.y > screen_rect.bottom)
-        continue;
-
-      /* Project all points to screen coordinates */
-      screen_points.clear();
-      for (const auto &pt : ring) {
-        auto sp = projection.GeoToScreen(pt);
-        screen_points.push_back(BulkPixelPoint{sp.x, sp.y});
-      }
-
-      canvas.DrawPolygon(screen_points.data(),
-                         (unsigned)screen_points.size());
+      map_canvas.FillPolygon(ring.data(), (unsigned)ring.size());
     }
   }
 }

--- a/src/XCSoar.cpp
+++ b/src/XCSoar.cpp
@@ -54,7 +54,12 @@
 static int
 Main()
 {
+#ifdef MESA_KMS
+  ScreenGlobalInit screen_init({CommandLine::width, CommandLine::height},
+                               CommandLine::size_specified);
+#else
   ScreenGlobalInit screen_init;
+#endif
 
 #ifdef _WIN32
   /* try to make the UI most responsive */

--- a/src/ui/canvas/opengl/Buffer.hpp
+++ b/src/ui/canvas/opengl/Buffer.hpp
@@ -25,6 +25,12 @@ class GLBuffer {
   GLvoid *p;
 #endif
 
+  /**
+   * True when #BeginWrite mapped the GL buffer.  False when it fell
+   * back to malloc (or the write was empty).
+   */
+  bool mapped = false;
+
 public:
   GLBuffer() noexcept {
     glGenBuffers(1, &id);
@@ -90,13 +96,21 @@ public:
 
   GLvoid *BeginWrite(size_t size) noexcept {
     Bind();
+    mapped = false;
 
-    void *result;
-    if (OpenGL::mapbuffer) {
-      Data(GLsizeiptr(size), nullptr);
-      result = MapWrite();
-    } else {
-      result = malloc(size);
+    void *result = nullptr;
+    if (size > 0) {
+      if (OpenGL::mapbuffer) {
+        Data(GLsizeiptr(size), nullptr);
+        result = MapWrite();
+        if (result != nullptr)
+          mapped = true;
+      }
+
+      /* Mali-400 advertises GL_OES_mapbuffer but returns null for
+         large VBOs (dense landcover).  Fall back to a client copy. */
+      if (result == nullptr)
+        result = malloc(size);
     }
 
 #ifndef NDEBUG
@@ -112,9 +126,9 @@ public:
     p = nullptr;
 #endif
 
-    if (OpenGL::mapbuffer) {
+    if (mapped) {
       Unmap();
-    } else {
+    } else if (data != nullptr) {
       Data(GLsizeiptr(size), data);
       free(data);
     }

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -186,10 +186,13 @@ Canvas::DrawPolyline(const BulkPixelPoint *points, unsigned num_points) noexcept
 
   pen.Bind();
 
-  // On macOS, glLineWidth() is capped at 1px, so use triangles for pens > 1px
-  if (IsMacOSX() && pen.GetStyle() == Pen::SOLID && pen.GetWidth() > 1u) {
+  /* GLES and macOS cannot draw wide GL_LINE_STRIP; use a triangle
+     strip so airspace borders keep their width. */
+  const unsigned width = pen.GetWidth();
+  if (pen.GetStyle() == Pen::SOLID && width > 1 &&
+      !UseOpenGLLineLoopOutline(width)) {
     unsigned strip_len = LineToTriangles(points, num_points, vertex_buffer,
-                                         pen.GetWidth(), false, false);
+                                         width, false, false);
     if (strip_len > 0) {
       const ScopeVertexPointer vp{vertex_buffer.data()};
       glDrawArrays(GL_TRIANGLE_STRIP, 0, strip_len);
@@ -229,6 +232,20 @@ Canvas::DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept
                           vertex_buffer);
     pen.Unbind();
   }
+}
+
+void
+Canvas::DrawFilledTriangles(const FloatPoint2D *points,
+                            const GLushort *indices,
+                            unsigned idx_count) noexcept
+{
+  if (brush.IsHollow() || idx_count < 3)
+    return;
+
+  OpenGL::solid_shader->Use();
+  brush.Bind();
+  const ScopeVertexPointer vp(points);
+  glDrawElements(GL_TRIANGLES, idx_count, GL_UNSIGNED_SHORT, indices);
 }
 
 void

--- a/src/ui/canvas/opengl/Canvas.hpp
+++ b/src/ui/canvas/opengl/Canvas.hpp
@@ -229,6 +229,14 @@ public:
   void DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept;
 
   /**
+   * Fill triangles whose vertices are in canvas pixel coordinates.
+   * Used for map polygons triangulated in geographic space.
+   */
+  void DrawFilledTriangles(const FloatPoint2D *points,
+                           const GLushort *indices,
+                           unsigned idx_count) noexcept;
+
+  /**
    * Draw a triangle fan (GL_TRIANGLE_FAN).  The first point is the
    * origin of the fan.
    */

--- a/src/ui/canvas/opengl/Globals.cpp
+++ b/src/ui/canvas/opengl/Globals.cpp
@@ -29,6 +29,8 @@ glm::mat4 projection_matrix;
 
 unsigned max_map_scale;
 
+bool idle_terrain_quantisation;
+
 #ifndef NDEBUG
 #ifdef _WIN32
 DWORD thread;

--- a/src/ui/canvas/opengl/Globals.hpp
+++ b/src/ui/canvas/opengl/Globals.hpp
@@ -86,4 +86,11 @@ extern glm::mat4 projection_matrix;
  */
 extern unsigned max_map_scale;
 
+/**
+ * True when full-resolution terrain should wait until the user is
+ * idle (weak GPU: ScanMap + hillshade at q=1 during a pan is too
+ * expensive even if the CPU is above the slow-CPU threshold).
+ */
+extern bool idle_terrain_quantisation;
+
 } // namespace OpenGL

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -121,6 +121,9 @@ OpenGL::SetupContext()
   if (auto s = (const char *)glGetString(GL_VERSION))
     LogFormat("GL version: %s", s);
 
+  bool disable_mapbuffer = false;
+  bool disable_multi_draw = false;
+
   if (auto s = (const char *)glGetString(GL_RENDERER)) {
     LogFormat("GL renderer: %s", s);
 
@@ -134,6 +137,12 @@ OpenGL::SetupContext()
          Limit the maximum map scale to avoid triggering the bug.
          See https://github.com/XCSoar/XCSoar/issues/1235 */
       max_map_scale = 300000;
+      /* glMapBufferOES after glBufferData(..., nullptr) and
+         glMultiDrawElementsEXT SIGSEGV in libGLESv2_mtk (memcpy
+         from null).  Upload VBOs from client memory and draw
+         fills one polygon at a time. */
+      disable_mapbuffer = true;
+      disable_multi_draw = true;
     }
   }
 
@@ -169,6 +178,9 @@ OpenGL::SetupContext()
   }
 #endif
 
+  if (disable_mapbuffer)
+    mapbuffer = false;
+
 #ifdef HAVE_DYNAMIC_MULTI_DRAW_ARRAYS
   if (IsExtensionSupported("GL_EXT_multi_draw_arrays")) {
     GLExt::multi_draw_arrays = (PFNGLMULTIDRAWARRAYSEXTPROC)
@@ -179,7 +191,17 @@ OpenGL::SetupContext()
     GLExt::multi_draw_arrays = nullptr;
     GLExt::multi_draw_elements = nullptr;
   }
+
+  if (disable_multi_draw) {
+    GLExt::multi_draw_arrays = nullptr;
+    GLExt::multi_draw_elements = nullptr;
+  }
 #endif
+
+  if (disable_mapbuffer || disable_multi_draw)
+    LogFormat("OpenGL: MapBuffer=%s MultiDrawElements=%s (GE8300)",
+              mapbuffer ? "on" : "off",
+              disable_multi_draw ? "off" : "on");
 
 #ifdef GL_EXT_discard_framebuffer
   if (IsExtensionSupported("GL_EXT_discard_framebuffer")) {

--- a/src/ui/canvas/opengl/Init.cpp
+++ b/src/ui/canvas/opengl/Init.cpp
@@ -123,6 +123,7 @@ OpenGL::SetupContext()
 
   bool disable_mapbuffer = false;
   bool disable_multi_draw = false;
+  idle_terrain_quantisation = false;
 
   if (auto s = (const char *)glGetString(GL_RENDERER)) {
     LogFormat("GL renderer: %s", s);
@@ -139,10 +140,12 @@ OpenGL::SetupContext()
       max_map_scale = 300000;
       /* glMapBufferOES after glBufferData(..., nullptr) and
          glMultiDrawElementsEXT SIGSEGV in libGLESv2_mtk (memcpy
-         from null).  Upload VBOs from client memory and draw
-         fills one polygon at a time. */
+         from null).  Upload VBOs from client memory; join fills
+         into one triangle list and roads into one GL_LINES list.
+         Do not ScanMap the DEM on every pan frame. */
       disable_mapbuffer = true;
       disable_multi_draw = true;
+      idle_terrain_quantisation = true;
     }
   }
 

--- a/src/ui/canvas/opengl/Shaders.cpp
+++ b/src/ui/canvas/opengl/Shaders.cpp
@@ -47,10 +47,10 @@ GLint filled_circle_projection, filled_circle_translate,
 GLProgram *hillshade_shader;
 GLint hillshade_projection, hillshade_translate,
   hillshade_height_tex, hillshade_ramp_tex,
-  hillshade_texel_step, hillshade_sun, hillshade_contrast,
+  hillshade_sun, hillshade_contrast,
   hillshade_height_slope_factor, hillshade_height_div,
-  hillshade_q, hillshade_do_shading, hillshade_contour_div,
-  hillshade_height_texel;
+  hillshade_do_shading, hillshade_contour_div,
+  hillshade_height_texel, hillshade_contour_step;
 
 } // namespace OpenGL
 
@@ -260,15 +260,14 @@ static constexpr char hillshade_fragment_shader[] =
     precision mediump float;
     uniform sampler2D height_tex;
     uniform sampler2D ramp_tex;
-    uniform vec2 texel_step;
     uniform vec3 sun;
     uniform float contrast;
     uniform float height_slope_factor;
     uniform float height_div;
-    uniform float q;
     uniform float do_shading;
     uniform float contour_div;
     uniform vec2 height_texel;
+    uniform vec2 contour_step;
     varying vec2 texcoordvar;
 
     vec2 unpack_la(vec4 t) {
@@ -276,9 +275,12 @@ static constexpr char hillshade_fragment_shader[] =
                   floor(t.a * 255.0 + 0.5));
     }
 
+    vec2 la(vec2 uv) {
+      return unpack_la(texture2D(height_tex, uv));
+    }
+
     /* TerrainHeight::IsSpecial(): value <= -30000.
-       -32768 → hi=128; -30000 → hi=138 lo=208.  Do not reconstruct
-       those heights (they do not fit in mediump). */
+       -32768 → hi=128; -30000 → hi=138 lo=208. */
     bool is_special(vec2 b) {
       return b.y >= 128.0 &&
              (b.y < 138.0 || (b.y == 138.0 && b.x <= 208.0));
@@ -296,69 +298,87 @@ static constexpr char hillshade_fragment_shader[] =
                                       (sindex + 64.5) / 128.0));
     }
 
-    float contour_interval(float h) {
-      if (h <= 0.0)
-        return 0.0;
-      return min(254.0, floor(h / contour_div));
+    float shade_index(float n0, float n1) {
+      n0 = clamp(n0, -512.0, 512.0);
+      n1 = clamp(n1, -512.0, 512.0);
+      float n2 = height_slope_factor;
+      float mag = sqrt(n0 * n0 + n1 * n1 + n2 * n2);
+      float num = n2 * sun.z + n0 * sun.x + n1 * sun.y;
+      float sval = mag > 0.0 ? num / mag : 0.0;
+      return clamp((sval - sun.z) * contrast / 128.0, -63.0, 63.0);
     }
 
     void main() {
-      vec2 b = unpack_la(texture2D(height_tex, texcoordvar));
+      vec2 b = la(texcoordvar);
       if (is_special(b)) {
         gl_FragColor = ramp_lookup(255.0, 0.0);
         return;
       }
 
-      float h = height(b);
+      /* Decode, then bilinear.  Hardware LINEAR on packed L/A is
+         wrong (mixes the two bytes). */
+      vec2 ts = height_texel;
+      vec2 f = fract(texcoordvar / ts - 0.5);
+      vec2 o = (floor(texcoordvar / ts - 0.5) + 0.5) * ts;
+      vec2 b00 = la(o);
+      vec2 b10 = la(o + vec2(ts.x, 0.0));
+      vec2 b01 = la(o + vec2(0.0, ts.y));
+      vec2 b11 = la(o + ts);
+      float h00 = height(b00);
+      float h10 = height(b10);
+      float h01 = height(b01);
+      float h11 = height(b11);
+      bool corners_ok = !is_special(b00) && !is_special(b10) &&
+                        !is_special(b01) && !is_special(b11);
+
+      float h = corners_ok
+        ? mix(mix(h00, h10, f.x), mix(h01, h11, f.x), f.y)
+        : height(b);
       float h_idx = min(254.0, max(0.0, floor(h / height_div)));
       float sindex = 0.0;
 
       if (do_shading > 0.5) {
-        vec2 b_above = unpack_la(texture2D(height_tex,
-            texcoordvar - vec2(0.0, texel_step.y)));
-        vec2 b_below = unpack_la(texture2D(height_tex,
-            texcoordvar + vec2(0.0, texel_step.y)));
-        vec2 b_left = unpack_la(texture2D(height_tex,
-            texcoordvar - vec2(texel_step.x, 0.0)));
-        vec2 b_right = unpack_la(texture2D(height_tex,
-            texcoordvar + vec2(texel_step.x, 0.0)));
-
-        if (!is_special(b_above) && !is_special(b_below) &&
-            !is_special(b_left) && !is_special(b_right)) {
-          /* Same n as GenerateSlopeImage, divided by p20*p31 so
-             mediump cannot overflow (dd0 = p22*p31).  sval/sindex
-             use trunc-toward-zero, matching the CPU ints. */
-          float p32 = clamp(height(b_above) - height(b_below),
-                            -512.0, 512.0);
-          float p22 = clamp(height(b_right) - height(b_left),
-                            -512.0, 512.0);
-          float p20 = max(2.0 * q, 1.0);
-          float p31 = max(2.0 * q, 1.0);
-          float n0 = p22 / p20;
-          float n1 = p32 / p31;
-          float n2 = height_slope_factor;
-          float mag = sqrt(n0 * n0 + n1 * n1 + n2 * n2);
-          float num = n2 * sun.z + n0 * sun.x + n1 * sun.y;
-          float sval = mag > 0.0 ? float(int(num / mag)) : 0.0;
-          sindex = float(int((sval - sun.z) * contrast / 128.0));
-          sindex = clamp(sindex, -63.0, 63.0);
+        if (corners_ok) {
+          /* Mix this cell's slope with the next so shade is continuous
+             at DEM edges (visible mainly in shadow). */
+          vec2 b20 = la(o + vec2(2.0 * ts.x, 0.0));
+          vec2 b21 = la(o + vec2(2.0 * ts.x, ts.y));
+          vec2 b02 = la(o + vec2(0.0, 2.0 * ts.y));
+          vec2 b12 = la(o + vec2(ts.x, 2.0 * ts.y));
+          float n0 = mix(h10 - h00, h11 - h01, f.y);
+          float n1 = mix(h00 - h01, h10 - h11, f.x);
+          if (!is_special(b20) && !is_special(b21) &&
+              !is_special(b02) && !is_special(b12)) {
+            float n0r = mix(height(b20) - h10, height(b21) - h11, f.y);
+            float n1b = mix(h01 - height(b02), h11 - height(b12), f.x);
+            n0 = mix(n0, n0r, f.x);
+            n1 = mix(n1, n1b, f.y);
+          }
+          sindex = shade_index(n0, n1);
         }
       }
 
-      if (contour_div > 0.5) {
-        vec2 b_up = unpack_la(texture2D(height_tex,
-            texcoordvar - vec2(0.0, height_texel.y)));
-        vec2 b_lf = unpack_la(texture2D(height_tex,
-            texcoordvar - vec2(height_texel.x, 0.0)));
-        float h_up = is_special(b_up) ? 0.0 : height(b_up);
-        float h_lf = is_special(b_lf) ? 0.0 : height(b_lf);
-        float ci = contour_interval(h);
-        if (ci != contour_interval(h_up) ||
-            ci != contour_interval(h_lf))
-          sindex = -64.0;
+      float s0 = floor(sindex);
+      vec4 terrain = mix(ramp_lookup(h_idx, s0),
+                         ramp_lookup(h_idx, min(s0 + 1.0, 63.0)),
+                         sindex - s0);
+
+      float cover = 0.0;
+      if (contour_div > 0.5 && corners_ok && h > 0.0) {
+        /* contour_step is screen pixels per DEM texel (mediump-safe).
+           Distance to the bilinear isoline, ~2 px wide with a fade so
+           diagonals stay a stroke instead of a 4-connected staircase. */
+        float gx = mix(h10 - h00, h11 - h01, f.y);
+        float gy = mix(h01 - h00, h11 - h10, f.x);
+        vec2 ppt = max(contour_step, vec2(0.5));
+        float g_px = length(vec2(gx, gy) / ppt);
+        float frac = fract(h / contour_div);
+        float dh = min(frac, 1.0 - frac) * contour_div;
+        float dist = dh / max(g_px, 1.0e-3);
+        cover = 1.0 - smoothstep(0.5, 2.0, dist);
       }
 
-      gl_FragColor = ramp_lookup(h_idx, sindex);
+      gl_FragColor = mix(terrain, ramp_lookup(h_idx, -64.0), cover);
     }
 )glsl";
 
@@ -517,16 +537,15 @@ OpenGL::InitShaders()
     hillshade_translate = hillshade_shader->GetUniformLocation("translate");
     hillshade_height_tex = hillshade_shader->GetUniformLocation("height_tex");
     hillshade_ramp_tex = hillshade_shader->GetUniformLocation("ramp_tex");
-    hillshade_texel_step = hillshade_shader->GetUniformLocation("texel_step");
     hillshade_sun = hillshade_shader->GetUniformLocation("sun");
     hillshade_contrast = hillshade_shader->GetUniformLocation("contrast");
     hillshade_height_slope_factor =
       hillshade_shader->GetUniformLocation("height_slope_factor");
     hillshade_height_div = hillshade_shader->GetUniformLocation("height_div");
-    hillshade_q = hillshade_shader->GetUniformLocation("q");
     hillshade_do_shading = hillshade_shader->GetUniformLocation("do_shading");
     hillshade_contour_div = hillshade_shader->GetUniformLocation("contour_div");
     hillshade_height_texel = hillshade_shader->GetUniformLocation("height_texel");
+    hillshade_contour_step = hillshade_shader->GetUniformLocation("contour_step");
 
     hillshade_shader->Use();
     glUniform1i(hillshade_height_tex, 0);

--- a/src/ui/canvas/opengl/Shaders.cpp
+++ b/src/ui/canvas/opengl/Shaders.cpp
@@ -6,7 +6,9 @@
 #include "Attribute.hpp"
 #include "Globals.hpp"
 #include "ui/dim/Point.hpp"
+#include "LogFile.hpp"
 #include "lib/fmt/RuntimeError.hxx"
+#include "util/Exception.hxx"
 
 #include <glm/gtc/type_ptr.hpp>
 
@@ -41,6 +43,14 @@ GLProgram *filled_circle_shader;
 GLint filled_circle_projection, filled_circle_translate,
   filled_circle_center, filled_circle_radius1, filled_circle_radius2,
   filled_circle_color1, filled_circle_color2;
+
+GLProgram *hillshade_shader;
+GLint hillshade_projection, hillshade_translate,
+  hillshade_height_tex, hillshade_ramp_tex,
+  hillshade_texel_step, hillshade_sun, hillshade_contrast,
+  hillshade_height_slope_factor, hillshade_height_div,
+  hillshade_q, hillshade_do_shading, hillshade_contour_div,
+  hillshade_height_texel;
 
 } // namespace OpenGL
 
@@ -240,6 +250,118 @@ static constexpr char filled_circle_fragment_shader[] =
     }
 )glsl";
 
+static const char *const hillshade_vertex_shader = texture_vertex_shader;
+
+static constexpr char hillshade_fragment_shader[] =
+  GLSL_VERSION
+  R"glsl(
+    /* Always mediump: Mali-400 has no fragment highp, and forming
+       int16 as 0..65535 is not representable (mediump is ±16384). */
+    precision mediump float;
+    uniform sampler2D height_tex;
+    uniform sampler2D ramp_tex;
+    uniform vec2 texel_step;
+    uniform vec3 sun;
+    uniform float contrast;
+    uniform float height_slope_factor;
+    uniform float height_div;
+    uniform float q;
+    uniform float do_shading;
+    uniform float contour_div;
+    uniform vec2 height_texel;
+    varying vec2 texcoordvar;
+
+    vec2 unpack_la(vec4 t) {
+      return vec2(floor(t.r * 255.0 + 0.5),
+                  floor(t.a * 255.0 + 0.5));
+    }
+
+    /* TerrainHeight::IsSpecial(): value <= -30000.
+       -32768 → hi=128; -30000 → hi=138 lo=208.  Do not reconstruct
+       those heights (they do not fit in mediump). */
+    bool is_special(vec2 b) {
+      return b.y >= 128.0 &&
+             (b.y < 138.0 || (b.y == 138.0 && b.x <= 208.0));
+    }
+
+    float height(vec2 b) {
+      float h = (b.y >= 128.0)
+        ? ((b.y - 256.0) * 256.0 + b.x)
+        : (b.y * 256.0 + b.x);
+      return clamp(h, -16383.0, 16383.0);
+    }
+
+    vec4 ramp_lookup(float h_idx, float sindex) {
+      return texture2D(ramp_tex, vec2((h_idx + 0.5) / 256.0,
+                                      (sindex + 64.5) / 128.0));
+    }
+
+    float contour_interval(float h) {
+      if (h <= 0.0)
+        return 0.0;
+      return min(254.0, floor(h / contour_div));
+    }
+
+    void main() {
+      vec2 b = unpack_la(texture2D(height_tex, texcoordvar));
+      if (is_special(b)) {
+        gl_FragColor = ramp_lookup(255.0, 0.0);
+        return;
+      }
+
+      float h = height(b);
+      float h_idx = min(254.0, max(0.0, floor(h / height_div)));
+      float sindex = 0.0;
+
+      if (do_shading > 0.5) {
+        vec2 b_above = unpack_la(texture2D(height_tex,
+            texcoordvar - vec2(0.0, texel_step.y)));
+        vec2 b_below = unpack_la(texture2D(height_tex,
+            texcoordvar + vec2(0.0, texel_step.y)));
+        vec2 b_left = unpack_la(texture2D(height_tex,
+            texcoordvar - vec2(texel_step.x, 0.0)));
+        vec2 b_right = unpack_la(texture2D(height_tex,
+            texcoordvar + vec2(texel_step.x, 0.0)));
+
+        if (!is_special(b_above) && !is_special(b_below) &&
+            !is_special(b_left) && !is_special(b_right)) {
+          /* Same n as GenerateSlopeImage, divided by p20*p31 so
+             mediump cannot overflow (dd0 = p22*p31).  sval/sindex
+             use trunc-toward-zero, matching the CPU ints. */
+          float p32 = clamp(height(b_above) - height(b_below),
+                            -512.0, 512.0);
+          float p22 = clamp(height(b_right) - height(b_left),
+                            -512.0, 512.0);
+          float p20 = max(2.0 * q, 1.0);
+          float p31 = max(2.0 * q, 1.0);
+          float n0 = p22 / p20;
+          float n1 = p32 / p31;
+          float n2 = height_slope_factor;
+          float mag = sqrt(n0 * n0 + n1 * n1 + n2 * n2);
+          float num = n2 * sun.z + n0 * sun.x + n1 * sun.y;
+          float sval = mag > 0.0 ? float(int(num / mag)) : 0.0;
+          sindex = float(int((sval - sun.z) * contrast / 128.0));
+          sindex = clamp(sindex, -63.0, 63.0);
+        }
+      }
+
+      if (contour_div > 0.5) {
+        vec2 b_up = unpack_la(texture2D(height_tex,
+            texcoordvar - vec2(0.0, height_texel.y)));
+        vec2 b_lf = unpack_la(texture2D(height_tex,
+            texcoordvar - vec2(height_texel.x, 0.0)));
+        float h_up = is_special(b_up) ? 0.0 : height(b_up);
+        float h_lf = is_special(b_lf) ? 0.0 : height(b_lf);
+        float ci = contour_interval(h);
+        if (ci != contour_interval(h_up) ||
+            ci != contour_interval(h_lf))
+          sindex = -64.0;
+      }
+
+      gl_FragColor = ramp_lookup(h_idx, sindex);
+    }
+)glsl";
+
 static void
 CompileAttachShader(GLProgram &program, GLenum type, const char *code)
 {
@@ -383,11 +505,45 @@ OpenGL::InitShaders()
   filled_circle_radius2 = filled_circle_shader->GetUniformLocation("radius2");
   filled_circle_color1 = filled_circle_shader->GetUniformLocation("color1");
   filled_circle_color2 = filled_circle_shader->GetUniformLocation("color2");
+
+  try {
+    hillshade_shader = CompileProgram(hillshade_vertex_shader,
+                                      hillshade_fragment_shader);
+    hillshade_shader->BindAttribLocation(Attribute::POSITION, "position");
+    hillshade_shader->BindAttribLocation(Attribute::TEXCOORD, "texcoord");
+    LinkProgram(*hillshade_shader);
+
+    hillshade_projection = hillshade_shader->GetUniformLocation("projection");
+    hillshade_translate = hillshade_shader->GetUniformLocation("translate");
+    hillshade_height_tex = hillshade_shader->GetUniformLocation("height_tex");
+    hillshade_ramp_tex = hillshade_shader->GetUniformLocation("ramp_tex");
+    hillshade_texel_step = hillshade_shader->GetUniformLocation("texel_step");
+    hillshade_sun = hillshade_shader->GetUniformLocation("sun");
+    hillshade_contrast = hillshade_shader->GetUniformLocation("contrast");
+    hillshade_height_slope_factor =
+      hillshade_shader->GetUniformLocation("height_slope_factor");
+    hillshade_height_div = hillshade_shader->GetUniformLocation("height_div");
+    hillshade_q = hillshade_shader->GetUniformLocation("q");
+    hillshade_do_shading = hillshade_shader->GetUniformLocation("do_shading");
+    hillshade_contour_div = hillshade_shader->GetUniformLocation("contour_div");
+    hillshade_height_texel = hillshade_shader->GetUniformLocation("height_texel");
+
+    hillshade_shader->Use();
+    glUniform1i(hillshade_height_tex, 0);
+    glUniform1i(hillshade_ramp_tex, 1);
+  } catch (...) {
+    delete hillshade_shader;
+    hillshade_shader = nullptr;
+    LogFmt("OpenGL: hillshade shader failed ({}); using CPU",
+           GetFullMessage(std::current_exception()));
+  }
 }
 
 void
 OpenGL::DeinitShaders() noexcept
 {
+  delete hillshade_shader;
+  hillshade_shader = nullptr;
   delete filled_circle_shader;
   filled_circle_shader = nullptr;
   delete circle_outline_shader;
@@ -441,6 +597,12 @@ OpenGL::UpdateShaderProjectionMatrix() noexcept
   filled_circle_shader->Use();
   glUniformMatrix4fv(filled_circle_projection, 1, GL_FALSE,
                      glm::value_ptr(projection_matrix));
+
+  if (hillshade_shader != nullptr) {
+    hillshade_shader->Use();
+    glUniformMatrix4fv(hillshade_projection, 1, GL_FALSE,
+                       glm::value_ptr(projection_matrix));
+  }
 }
 
 void
@@ -471,4 +633,9 @@ OpenGL::UpdateShaderTranslate() noexcept
 
   filled_circle_shader->Use();
   glUniform2f(filled_circle_translate, t.x, t.y);
+
+  if (hillshade_shader != nullptr) {
+    hillshade_shader->Use();
+    glUniform2f(hillshade_translate, t.x, t.y);
+  }
 }

--- a/src/ui/canvas/opengl/Shaders.hpp
+++ b/src/ui/canvas/opengl/Shaders.hpp
@@ -65,6 +65,18 @@ extern GLint filled_circle_projection, filled_circle_translate,
   filled_circle_color1, filled_circle_color2;
 
 /**
+ * DEM hillshade: height texture + colour ramp, sun as a uniform.
+ * Null if the shader failed to compile (CPU GenerateSlopeImage).
+ */
+extern GLProgram *hillshade_shader;
+extern GLint hillshade_projection, hillshade_translate,
+  hillshade_height_tex, hillshade_ramp_tex,
+  hillshade_texel_step, hillshade_sun, hillshade_contrast,
+  hillshade_height_slope_factor, hillshade_height_div,
+  hillshade_q, hillshade_do_shading, hillshade_contour_div,
+  hillshade_height_texel;
+
+/**
  * Throws on error.
  */
 void InitShaders();

--- a/src/ui/canvas/opengl/Shaders.hpp
+++ b/src/ui/canvas/opengl/Shaders.hpp
@@ -71,10 +71,10 @@ extern GLint filled_circle_projection, filled_circle_translate,
 extern GLProgram *hillshade_shader;
 extern GLint hillshade_projection, hillshade_translate,
   hillshade_height_tex, hillshade_ramp_tex,
-  hillshade_texel_step, hillshade_sun, hillshade_contrast,
+  hillshade_sun, hillshade_contrast,
   hillshade_height_slope_factor, hillshade_height_div,
-  hillshade_q, hillshade_do_shading, hillshade_contour_div,
-  hillshade_height_texel;
+  hillshade_do_shading, hillshade_contour_div,
+  hillshade_height_texel, hillshade_contour_step;
 
 /**
  * Throws on error.

--- a/src/ui/canvas/opengl/Triangulate.cpp
+++ b/src/ui/canvas/opengl/Triangulate.cpp
@@ -300,7 +300,8 @@ FindSharedEdge(const unsigned idx1, const unsigned idx2,
 
 unsigned
 TriangleToStrip(GLushort *triangles, unsigned index_count,
-                unsigned vertex_count, unsigned polygon_count) noexcept
+                unsigned vertex_count,
+                [[maybe_unused]] unsigned polygon_count) noexcept
 {
   if (index_count < 3)
     /* bail out, because we didn't get even one triangle; we need to
@@ -315,7 +316,14 @@ TriangleToStrip(GLushort *triangles, unsigned index_count,
 
   AddValueCounts(vcount, vertex_count, t, t_end);
 
-  const unsigned triangle_buffer_size = index_count + 2 * (polygon_count - 1);
+  /* Restarts insert two duplicate indices.  A landcover ring can
+     triangulate into many disconnected fans, so size for the worst
+     case (a restart before every remaining triangle), not
+     polygon_count. */
+  const unsigned triangle_count = index_count / 3;
+  const unsigned triangle_buffer_size = triangle_count == 0
+    ? 0
+    : index_count + 2 * (triangle_count - 1);
   const auto triangle_strip = new GLushort[triangle_buffer_size];
   auto strip = triangle_strip;
 
@@ -353,12 +361,6 @@ TriangleToStrip(GLushort *triangles, unsigned index_count,
     t += 3;
     triangles_left--;
 
-    /* TODO: I'm almost sure this is true, but I can't prove it. Maybe there
-     *       are polygons, where the degenerated triangle strip is longer
-     *       than all triangle indices.
-     *       Use a higher polygon_count and bigger triangle buffer if you
-     *       hit this one.
-     */
     assert(strip + 4 <= triangle_strip + triangle_buffer_size);
 
     // search for a shared edge

--- a/src/ui/canvas/opengl/Triangulate.hpp
+++ b/src/ui/canvas/opengl/Triangulate.hpp
@@ -38,7 +38,8 @@ PolygonToTriangles(const FloatPoint2D *points, unsigned num_points,
  * be discarded pretty early in the rendering pipeline. This saves a lot of
  * OpenGL API calls.
  * The triangle buffer must hold at least:
- *   3*(triangle_count-2) + 2*(polygon_count-1) indices.
+ *   index_count + 2*(triangle_count-1) indices
+ * (worst case: every triangle starts a new strip).
  *
  * @param triangles triangle indicies, which will be overwriten with the strip
  * @param index_count number of triangle indices. (triangle_count*3)

--- a/src/ui/display/Display.hpp
+++ b/src/ui/display/Display.hpp
@@ -82,8 +82,10 @@ class Display
   bool dirty = true;
 
 public:
-  Display()
-    :EGL::GbmDisplay(GetDriFD()),
+  Display(PixelSize preferred_mode = {},
+          bool use_preferred_mode = false)
+    :EGL::DrmDisplay(preferred_mode, use_preferred_mode),
+     EGL::GbmDisplay(GetDriFD()),
      EGL::Display(GetGbmDevice()) {}
 
   void SetDirty() noexcept {

--- a/src/ui/display/egl/DrmDisplay.cpp
+++ b/src/ui/display/egl/DrmDisplay.cpp
@@ -3,6 +3,7 @@
 
 #include "DrmDisplay.hpp"
 #include "Hardware/DisplayDPI.hpp"
+#include "LogFile.hpp"
 #include "lib/fmt/SystemError.hxx"
 
 #include <span>
@@ -74,7 +75,48 @@ ChooseConnector(FileDescriptor dri_fd, const drmModeRes &resources)
   return ChooseConnector(dri_fd, connectors);
 }
 
-DrmDisplay::DrmDisplay()
+/**
+ * Pick a connector mode.  When the user passed @c -WIDTHxHEIGHT,
+ * prefer an exact match (closest to 60 Hz).  Otherwise keep the
+ * first/preferred mode so KMS stays at native resolution.
+ */
+static drmModeModeInfo
+ChooseMode(const drmModeConnector &connector,
+           PixelSize preferred, bool use_preferred) noexcept
+{
+  const drmModeModeInfo *best = &connector.modes[0];
+  if (!use_preferred || preferred.width == 0 || preferred.height == 0)
+    return *best;
+
+  const drmModeModeInfo *exact = nullptr;
+  for (int i = 0; i < connector.count_modes; ++i) {
+    const auto &m = connector.modes[i];
+    if (m.hdisplay != preferred.width || m.vdisplay != preferred.height)
+      continue;
+
+    if (exact == nullptr) {
+      exact = &m;
+      continue;
+    }
+
+    const int err = m.vrefresh > 60 ? int(m.vrefresh) - 60
+                                    : 60 - int(m.vrefresh);
+    const int best_err = exact->vrefresh > 60 ? int(exact->vrefresh) - 60
+                                              : 60 - int(exact->vrefresh);
+    if (err < best_err)
+      exact = &m;
+  }
+
+  if (exact != nullptr)
+    return *exact;
+
+  LogFmt("DRM: no {}x{} mode, using {}x{}@{}",
+         preferred.width, preferred.height,
+         best->hdisplay, best->vdisplay, best->vrefresh);
+  return *best;
+}
+
+DrmDisplay::DrmDisplay(PixelSize preferred_mode, bool use_preferred_mode)
   :dri_fd(OpenDriDevice())
 {
   drmModeRes *resources = drmModeGetResources(dri_fd.Get());
@@ -87,14 +129,21 @@ DrmDisplay::DrmDisplay()
   if (auto *encoder = drmModeGetEncoder(dri_fd.Get(), connector->encoder_id)) {
     crtc_id = encoder->crtc_id;
     drmModeFreeEncoder(encoder);
-  } else
+  } else {
+    drmModeFreeConnector(connector);
+    drmModeFreeResources(resources);
     throw std::runtime_error("No usable DRM encoder found");
+  }
 
-  mode = connector->modes[0];
+  mode = ChooseMode(*connector, preferred_mode, use_preferred_mode);
+
+  LogFmt("DRM mode: {}x{}@{}",
+         mode.hdisplay, mode.vdisplay, mode.vrefresh);
 
   size_mm = {connector->mmWidth, connector->mmHeight};
 
   drmModeFreeConnector(connector);
+  drmModeFreeResources(resources);
 }
 
 DrmDisplay::~DrmDisplay() noexcept = default;

--- a/src/ui/display/egl/DrmDisplay.hpp
+++ b/src/ui/display/egl/DrmDisplay.hpp
@@ -24,8 +24,12 @@ class DrmDisplay {
 public:
   /**
    * Throws on error.
+   *
+   * @param preferred_mode if @p use_preferred_mode is true, select a
+   * matching connector mode (e.g. from @c -800x600)
    */
-  DrmDisplay();
+  explicit DrmDisplay(PixelSize preferred_mode = {},
+                      bool use_preferred_mode = false);
 
   ~DrmDisplay() noexcept;
 

--- a/src/ui/window/Init.cpp
+++ b/src/ui/window/Init.cpp
@@ -25,9 +25,15 @@
 #include <libloaderapi.h>
 #endif
 
+#ifdef MESA_KMS
+ScreenGlobalInit::ScreenGlobalInit(PixelSize preferred_mode,
+                                   bool use_preferred_mode)
+  :display(preferred_mode, use_preferred_mode)
+#else
 ScreenGlobalInit::ScreenGlobalInit()
 #ifdef ANDROID
   :display(EGL_DEFAULT_DISPLAY)
+#endif
 #endif
 {
 #ifdef USE_FREETYPE

--- a/src/ui/window/Init.hpp
+++ b/src/ui/window/Init.hpp
@@ -16,7 +16,16 @@ class ScreenGlobalInit {
 #endif
 
 public:
+#ifdef MESA_KMS
+  /**
+   * @param preferred_mode used only when @p use_preferred_mode is
+   * true (command-line @c -WIDTHxHEIGHT)
+   */
+  explicit ScreenGlobalInit(PixelSize preferred_mode = {},
+                            bool use_preferred_mode = false);
+#else
   ScreenGlobalInit();
+#endif
   ~ScreenGlobalInit();
 
   auto &GetDisplay() noexcept {

--- a/test/src/RunMapRendererStress.cpp
+++ b/test/src/RunMapRendererStress.cpp
@@ -1,0 +1,619 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Look/TopographyLook.hpp"
+#include "Operation/Operation.hpp"
+#include "ProductName.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "Renderer/LabelBlock.hpp"
+#include "Screen/Layout.hpp"
+#include "Terrain/RasterTerrain.hpp"
+#include "Terrain/TerrainRenderer.hpp"
+#include "Terrain/TerrainSettings.hpp"
+#include "Topography/CachedTopographyRenderer.hpp"
+#include "Topography/TopographyFile.hpp"
+#include "Topography/TopographyStore.hpp"
+#include "Version.hpp"
+#include "io/ZipArchive.hpp"
+#include "io/ZipLineReader.hpp"
+#include "system/Args.hpp"
+#include "system/Path.hpp"
+#include "system/StandardVersion.hpp"
+#include "ui/canvas/BufferCanvas.hpp"
+#include "ui/window/Init.hpp"
+#include "util/NumberParser.hpp"
+#include "util/PrintException.hxx"
+#include "util/StringCompare.hxx"
+
+#ifdef ENABLE_OPENGL
+#include "ui/opengl/System.hpp"
+#endif
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+static constexpr const char canonical_name[] = "RunMapRendererStress";
+
+static constexpr double kDefaultRadiiM[] = {
+  750.,
+  3000.,
+  19000.,
+  50000.,
+  150000.,
+};
+
+struct Options {
+  unsigned draws_per_sample = 5;
+  unsigned width = 800;
+  unsigned height = 480;
+  unsigned dpi = 130;
+  bool draw_terrain = true;
+  bool draw_topo = true;
+  bool draw_labels = true;
+  bool no_cache = false;
+  bool progress = true;
+  bool layers = false;
+  bool have_lat = false;
+  bool have_lon = false;
+  double latitude_deg = 0;
+  double longitude_deg = 0;
+  std::vector<double> radii_m;
+};
+
+static Options options;
+
+static void
+PrintStandardHelp() noexcept
+{
+  std::printf(
+    "Usage: %s [OPTION]... FILE.xcm\n"
+    "\n"
+    "Load a map container and benchmark MapWindow-style terrain plus\n"
+    "topography draw cost.  Shape loading (ScanVisibility) is timed\n"
+    "separately from warm redraws so pan/zoom I/O is not mixed with\n"
+    "steady-state paint.\n"
+    "\n"
+    "Options:\n"
+    "  --draws=N             warm redraws per radius (default: 5)\n"
+    "  --width=PIXELS        canvas width (default: 800)\n"
+    "  --height=PIXELS       canvas height (default: 480)\n"
+    "  --dpi=N               Layout DPI (default: 130)\n"
+    "  --lat=DEG             map centre latitude (default: terrain centre)\n"
+    "  --lon=DEG             map centre longitude (default: terrain centre)\n"
+    "  --radius=M            half-width in metres (repeatable; default:\n"
+    "                        750, 3000, 19000, 50000, 150000)\n"
+    "  --no-terrain          skip DEM load and terrain paint\n"
+    "  --no-topo             skip topography load and paint\n"
+    "  --no-labels           skip topography label paint\n"
+    "  --no-cache            flush renderer caches before each timed\n"
+    "                        draw (software rasterize, not blit)\n"
+    "  --layers              print per-layer shape counts on stderr\n"
+    "  --no-progress         do not print progress on stderr\n"
+    "  -h, --help            display this help and exit\n"
+    "  --version             output version information and exit\n"
+    "\n"
+    "Example:\n"
+    "  %s ~/.xcsoar/maps/ALPS_Test.xcm\n"
+    "  %s --radius=3000 --radius=19000 --lat=46.5 --lon=11.3 map.xcm\n"
+    "\n"
+    "Report bugs to: <%s>\n"
+    "%s home page: <%s>\n",
+    canonical_name, canonical_name, canonical_name,
+    PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static bool
+ParseUnsignedOption(const char *arg, const char *prefix,
+                    unsigned &value) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const unsigned parsed = ParseUnsigned(p, &end);
+  if (end == nullptr || *end != '\0' || parsed == 0)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static bool
+ParseDoubleOption(const char *arg, const char *prefix,
+                  double &value, bool positive) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const double parsed = ParseDouble(p, &end);
+  if (end == nullptr || *end != '\0')
+    return false;
+  if (positive && parsed <= 0.)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static void
+ParseCommandLine(Args &args) noexcept
+{
+  while (!args.IsEmpty()) {
+    const char *arg = args.PeekNext();
+
+    if (StringIsEqual(arg, "-h") || StringIsEqual(arg, "--help")) {
+      args.Skip();
+      PrintStandardHelp();
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--version")) {
+      args.Skip();
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--no-terrain")) {
+      args.Skip();
+      options.draw_terrain = false;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-topo")) {
+      args.Skip();
+      options.draw_topo = false;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-labels")) {
+      args.Skip();
+      options.draw_labels = false;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-cache")) {
+      args.Skip();
+      options.no_cache = true;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--layers")) {
+      args.Skip();
+      options.layers = true;
+      continue;
+    }
+
+    if (StringIsEqual(arg, "--no-progress")) {
+      args.Skip();
+      options.progress = false;
+      continue;
+    }
+
+    if (ParseUnsignedOption(arg, "--draws=", options.draws_per_sample) ||
+        ParseUnsignedOption(arg, "--width=", options.width) ||
+        ParseUnsignedOption(arg, "--height=", options.height) ||
+        ParseUnsignedOption(arg, "--dpi=", options.dpi)) {
+      args.Skip();
+      continue;
+    }
+
+    double radius = 0;
+    if (ParseDoubleOption(arg, "--radius=", radius, true)) {
+      args.Skip();
+      options.radii_m.push_back(radius);
+      continue;
+    }
+
+    double coord = 0;
+    if (ParseDoubleOption(arg, "--lat=", coord, false)) {
+      args.Skip();
+      options.latitude_deg = coord;
+      options.have_lat = true;
+      continue;
+    }
+
+    if (ParseDoubleOption(arg, "--lon=", coord, false)) {
+      args.Skip();
+      options.longitude_deg = coord;
+      options.have_lon = true;
+      continue;
+    }
+
+    if (StringStartsWith(arg, "--")) {
+      std::fprintf(stderr, "%s: unrecognised or invalid option: %s\n",
+                   canonical_name, arg);
+      std::exit(EXIT_FAILURE);
+    }
+
+    break;
+  }
+}
+
+static void
+FlushGL() noexcept
+{
+#ifdef ENABLE_OPENGL
+  glFinish();
+#endif
+}
+
+static WindowProjection
+MakeProjection(const GeoPoint &location, double radius_m,
+               PixelSize screen_size) noexcept
+{
+  WindowProjection projection;
+  projection.SetScreenSize(screen_size);
+  projection.SetScaleFromRadius(radius_m);
+  projection.SetGeoLocation(location);
+  projection.SetScreenOrigin(screen_size.width / 2,
+                             screen_size.height / 2);
+  projection.UpdateScreenBounds();
+  return projection;
+}
+
+struct VisibilityStats {
+  unsigned files = 0;
+  unsigned shapes = 0;
+};
+
+static VisibilityStats
+CountVisible(const TopographyStore &store, double map_scale) noexcept
+{
+  VisibilityStats stats;
+  for (const auto &file : store) {
+    if (!file.IsVisible(map_scale))
+      continue;
+
+    ++stats.files;
+    const std::lock_guard lock{file.mutex};
+    for ([[maybe_unused]] const auto &shape : file)
+      ++stats.shapes;
+  }
+
+  return stats;
+}
+
+static unsigned
+CountStoreFiles(const TopographyStore &store) noexcept
+{
+  unsigned n = 0;
+  for ([[maybe_unused]] const auto &file : store)
+    ++n;
+  return n;
+}
+
+static void
+PrintLayers(const TopographyStore &store, double map_scale) noexcept
+{
+  unsigned i = 0;
+  for (const auto &file : store) {
+    unsigned shapes = 0;
+    {
+      const std::lock_guard lock{file.mutex};
+      for ([[maybe_unused]] const auto &shape : file)
+        ++shapes;
+    }
+
+    std::fprintf(stderr,
+                 "  layer %u: visible=%d labels=%d shapes=%u\n",
+                 i,
+                 file.IsVisible(map_scale) ? 1 : 0,
+                 file.IsLabelVisible(map_scale) ? 1 : 0,
+                 shapes);
+    ++i;
+  }
+}
+
+static double
+ElapsedMs(std::chrono::steady_clock::time_point t0,
+          std::chrono::steady_clock::time_point t1) noexcept
+{
+  return std::chrono::duration<double, std::milli>(t1 - t0).count();
+}
+
+static void
+MaybeFlushCaches(CachedTopographyRenderer *topo,
+                 TerrainRenderer *terrain_renderer) noexcept
+{
+  if (!options.no_cache)
+    return;
+
+  if (topo != nullptr)
+    topo->Flush();
+  if (terrain_renderer != nullptr)
+    terrain_renderer->Flush();
+}
+
+static void
+DrawTerrain(Canvas &canvas, TerrainRenderer *terrain_renderer,
+            const TerrainRendererSettings *terrain_settings,
+            const WindowProjection &projection,
+            Angle sun_azimuth) noexcept
+{
+  if (terrain_renderer == nullptr || terrain_settings == nullptr)
+    return;
+
+  MaybeFlushCaches(nullptr, terrain_renderer);
+  terrain_renderer->SetSettings(*terrain_settings);
+  if (terrain_renderer->Generate(projection, sun_azimuth))
+    terrain_renderer->Draw(canvas, projection);
+}
+
+static void
+DrawTopography(Canvas &canvas, CachedTopographyRenderer *topo,
+               const WindowProjection &projection) noexcept
+{
+  if (topo == nullptr)
+    return;
+
+  MaybeFlushCaches(topo, nullptr);
+  topo->Draw(canvas, projection);
+}
+
+static void
+DrawLabels(Canvas &canvas, CachedTopographyRenderer *topo,
+           const WindowProjection &projection) noexcept
+{
+  if (topo == nullptr)
+    return;
+
+  LabelBlock label_block;
+  topo->DrawLabels(canvas, projection, label_block);
+}
+
+static void
+DrawFrame(Canvas &canvas, TerrainRenderer *terrain_renderer,
+          const TerrainRendererSettings *terrain_settings,
+          CachedTopographyRenderer *topo, bool draw_labels,
+          const WindowProjection &projection,
+          Angle sun_azimuth) noexcept
+{
+  canvas.ClearWhite();
+  DrawTerrain(canvas, terrain_renderer, terrain_settings,
+              projection, sun_azimuth);
+  DrawTopography(canvas, topo, projection);
+  if (draw_labels)
+    DrawLabels(canvas, topo, projection);
+}
+
+template<typename Fn>
+static double
+TimeDrawsMs(unsigned draws, Fn &&fn) noexcept
+{
+  if (draws == 0)
+    return 0.;
+
+  FlushGL();
+  const auto t0 = std::chrono::steady_clock::now();
+  for (unsigned i = 0; i < draws; ++i)
+    fn();
+  FlushGL();
+  return ElapsedMs(t0, std::chrono::steady_clock::now());
+}
+
+static unsigned
+ScanAll(TopographyStore &store,
+        const WindowProjection &projection) noexcept
+{
+  unsigned total = 0;
+  unsigned n;
+  while ((n = store.ScanVisibility(projection, 1024,
+                                   Layout::Scale(1u))) > 0)
+    total += n;
+  return total;
+}
+
+static void
+PrintSampleHeader() noexcept
+{
+  std::puts("radius_m\tmap_scale\tfiles\tshapes\t"
+            "scan_ms\ttiles_ms\tfirst_ms\tframe_ms\t"
+            "terrain_ms\ttopo_ms\tlabels_ms");
+}
+
+int
+main(int argc, char **argv)
+try {
+  Args args(argc, argv, "FILE.xcm");
+  ParseCommandLine(args);
+
+  const auto map_path = args.ExpectNextPath();
+  args.ExpectEnd();
+
+  if (options.have_lat != options.have_lon) {
+    std::fprintf(stderr, "%s: --lat and --lon must be used together\n",
+                 canonical_name);
+    return EXIT_FAILURE;
+  }
+
+  if (!options.draw_topo && !options.draw_terrain) {
+    std::fprintf(stderr, "%s: nothing to benchmark\n", canonical_name);
+    return EXIT_FAILURE;
+  }
+
+  if (options.radii_m.empty()) {
+    for (double radius : kDefaultRadiiM)
+      options.radii_m.push_back(radius);
+  }
+
+  const PixelSize screen_size{int(options.width), int(options.height)};
+
+  ScreenGlobalInit screen_init;
+  Layout::Initialise(screen_init.GetDisplay(), screen_size,
+                     100, options.dpi);
+
+  BufferCanvas canvas;
+  canvas.Create(screen_size);
+  canvas.Begin();
+  canvas.ClearWhite();
+
+  using clock = std::chrono::steady_clock;
+
+  ZipArchive archive(map_path);
+  TopographyStore topography;
+  unsigned topo_files = 0;
+
+  if (options.draw_topo) {
+    if (options.progress)
+      std::fprintf(stderr, "loading topography from %s...\n",
+                   map_path.c_str());
+
+    const auto t0 = clock::now();
+    ZipLineReaderA reader(archive.get(), "topology.tpl");
+    topography.Load(reader, nullptr, archive.get());
+    topo_files = CountStoreFiles(topography);
+    if (options.progress)
+      std::fprintf(stderr, "loaded %u topography layers in %.1f ms\n",
+                   topo_files, ElapsedMs(t0, clock::now()));
+  }
+
+  TopographyLook topo_look;
+  topo_look.Initialise();
+  std::unique_ptr<CachedTopographyRenderer> topo_renderer;
+  if (options.draw_topo)
+    topo_renderer =
+      std::make_unique<CachedTopographyRenderer>(topography, topo_look);
+
+  std::unique_ptr<RasterTerrain> terrain;
+  std::unique_ptr<TerrainRenderer> terrain_renderer;
+  TerrainRendererSettings terrain_settings;
+  terrain_settings.SetDefaults();
+  terrain_settings.slope_shading = SlopeShading::FIXED;
+
+  if (options.draw_terrain) {
+    if (options.progress)
+      std::fprintf(stderr, "loading terrain from %s...\n",
+                   map_path.c_str());
+
+    QuietOperationEnvironment operation;
+    const auto t0 = clock::now();
+    try {
+      terrain = RasterTerrain::OpenTerrain(nullptr, map_path, operation);
+      terrain_renderer = std::make_unique<TerrainRenderer>(*terrain);
+#ifdef ENABLE_OPENGL
+      terrain_renderer->SetQuantisationPixels(1);
+#endif
+      if (options.progress)
+        std::fprintf(stderr, "loaded terrain overview in %.1f ms\n",
+                     ElapsedMs(t0, clock::now()));
+    } catch (...) {
+      PrintException(std::current_exception());
+      std::fprintf(stderr, "%s: continuing without terrain\n",
+                   canonical_name);
+      terrain.reset();
+      terrain_renderer.reset();
+    }
+  }
+
+  GeoPoint location = GeoPoint::Invalid();
+  if (options.have_lat)
+    location = GeoPoint(Angle::Degrees(options.longitude_deg),
+                        Angle::Degrees(options.latitude_deg));
+  else if (terrain)
+    location = terrain->GetTerrainCenter();
+  else {
+    for (const auto &file : topography) {
+      location = file.GetCenter();
+      break;
+    }
+  }
+
+  if (!location.IsValid()) {
+    std::fprintf(stderr, "%s: no map centre (pass --lat/--lon)\n",
+                 canonical_name);
+    return EXIT_FAILURE;
+  }
+
+  if (options.progress)
+    std::fprintf(stderr,
+                 "centre lat=%.5f lon=%.5f canvas=%ux%u dpi=%u%s\n",
+                 location.latitude.Degrees(),
+                 location.longitude.Degrees(),
+                 options.width, options.height, options.dpi,
+                 options.no_cache ? " no-cache" : "");
+
+  const Angle sun_azimuth = Angle::Degrees(-45);
+  CachedTopographyRenderer *topo = topo_renderer.get();
+  TerrainRenderer *tr = terrain_renderer.get();
+  const TerrainRendererSettings *ts =
+    terrain_renderer ? &terrain_settings : nullptr;
+
+  PrintSampleHeader();
+
+  for (double radius_m : options.radii_m) {
+    const auto projection =
+      MakeProjection(location, radius_m, screen_size);
+    const double map_scale = projection.GetMapScale();
+
+    if (options.progress)
+      std::fprintf(stderr,
+                   "scanning radius=%.0f m (map_scale=%.0f)...\n",
+                   radius_m, map_scale);
+
+    double scan_ms = 0;
+    if (options.draw_topo) {
+      const auto t0 = clock::now();
+      ScanAll(topography, projection);
+      scan_ms = ElapsedMs(t0, clock::now());
+    }
+
+    double tiles_ms = 0;
+    if (terrain) {
+      const auto t0 = clock::now();
+      const auto tile_radius =
+        projection.GetScreenWidthMeters() / 2;
+      while (terrain->UpdateTiles(location, tile_radius)) {}
+      tiles_ms = ElapsedMs(t0, clock::now());
+    }
+
+    const auto visible = CountVisible(topography, map_scale);
+    if (options.layers)
+      PrintLayers(topography, map_scale);
+
+    FlushGL();
+    const auto t_first0 = clock::now();
+    DrawFrame(canvas, tr, ts, topo, options.draw_labels,
+              projection, sun_azimuth);
+    FlushGL();
+    const double first_ms = ElapsedMs(t_first0, clock::now());
+
+    const unsigned draws = options.draws_per_sample;
+    const double frame_ms = TimeDrawsMs(draws, [&]() {
+      DrawFrame(canvas, tr, ts, topo, options.draw_labels,
+                projection, sun_azimuth);
+    }) / draws;
+
+    const double terrain_ms = TimeDrawsMs(draws, [&]() {
+      canvas.ClearWhite();
+      DrawTerrain(canvas, tr, ts, projection, sun_azimuth);
+    }) / draws;
+
+    const double topo_ms = TimeDrawsMs(draws, [&]() {
+      DrawTopography(canvas, topo, projection);
+    }) / draws;
+
+    const double labels_ms = options.draw_labels
+      ? TimeDrawsMs(draws, [&]() {
+          DrawLabels(canvas, topo, projection);
+        }) / draws
+      : 0.;
+
+    std::printf("%.0f\t%.0f\t%u\t%u\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f\n",
+                radius_m, map_scale, visible.files, visible.shapes,
+                scan_ms, tiles_ms, first_ms, frame_ms,
+                terrain_ms, topo_ms, labels_ms);
+  }
+
+  canvas.End();
+  return EXIT_SUCCESS;
+} catch (...) {
+  PrintException(std::current_exception());
+  return EXIT_FAILURE;
+}

--- a/test/src/RunTerrainRenderer.cpp
+++ b/test/src/RunTerrainRenderer.cpp
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#define ENABLE_MAIN_WINDOW
+#define ENABLE_CLOSE_BUTTON
+#define ENABLE_CMDLINE
+#define USAGE "[-WxH] [OPTION]... FILE.xcm"
+
+#include "Fonts.hpp"
+#include "Main.hpp"
+#include "Math/Angle.hpp"
+#include "Operation/Operation.hpp"
+#include "ProductName.hpp"
+#include "Projection/WindowProjection.hpp"
+#include "Terrain/RasterTerrain.hpp"
+#include "Terrain/TerrainRenderer.hpp"
+#include "Terrain/TerrainSettings.hpp"
+#include "Version.hpp"
+#include "system/Args.hpp"
+#include "system/Path.hpp"
+#include "system/StandardVersion.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+#include "ui/event/Timer.hpp"
+#include "ui/window/PaintWindow.hpp"
+#include "util/NumberParser.hpp"
+#include "util/StringCompare.hxx"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+#include <fmt/format.h>
+
+static constexpr const char canonical_name[] = "RunTerrainRenderer";
+
+static AllocatedPath map_path;
+static double radius_m = 25000;
+static bool have_lat = false;
+static bool have_lon = false;
+static double latitude_deg = 0;
+static double longitude_deg = 0;
+static double step_deg = 3;
+static unsigned period_ms = 50;
+static unsigned seconds = 0;
+static bool cpu_shade [[maybe_unused]] = false;
+
+static void
+PrintHelp() noexcept
+{
+  std::printf(
+    "Usage: %s [-WxH] [OPTION]... FILE.xcm\n"
+    "\n"
+    "Load terrain from a map container and redraw TerrainRenderer\n"
+    "with a rotating sun azimuth (OpenGL GPU hillshade by default).\n"
+    "\n"
+    "Options:\n"
+    "  --radius=M     half-width in metres (default: 25000)\n"
+    "  --lat=DEG      map centre latitude (default: terrain centre)\n"
+    "  --lon=DEG      map centre longitude (default: terrain centre)\n"
+    "  --step=DEG     sun azimuth step per tick (default: 3)\n"
+    "  --period=MS    timer period (default: 50)\n"
+    "  --seconds=N    close after N seconds (for profiling)\n"
+    "  --cpu-shade    force CPU GenerateSlopeImage() (A/B vs GPU)\n"
+    "  -h, --help     display this help and exit\n"
+    "  --version      output version information and exit\n"
+    "\n"
+    "Report bugs to: <%s>\n"
+    "%s home page: <%s>\n",
+    canonical_name,
+    PRODUCT_BUGS_URL, PRODUCT_NAME, PRODUCT_WEB_SITE_URL);
+}
+
+static bool
+ParseUnsignedOption(const char *arg, const char *prefix,
+                    unsigned &value) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const unsigned parsed = ParseUnsigned(p, &end);
+  if (end == nullptr || *end != '\0' || parsed == 0)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static bool
+ParseDoubleOption(const char *arg, const char *prefix,
+                  double &value, bool positive) noexcept
+{
+  if (!StringStartsWith(arg, prefix))
+    return false;
+
+  const char *p = arg + std::strlen(prefix);
+  char *end = nullptr;
+  const double parsed = ParseDouble(p, &end);
+  if (end == nullptr || *end != '\0')
+    return false;
+  if (positive && parsed <= 0.)
+    return false;
+
+  value = parsed;
+  return true;
+}
+
+static void
+ParseCommandLine(Args &args)
+{
+  while (!args.IsEmpty()) {
+    const char *arg = args.PeekNext();
+
+    if (StringIsEqual(arg, "-h") || StringIsEqual(arg, "--help")) {
+      args.Skip();
+      PrintHelp();
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--version")) {
+      args.Skip();
+      PrintStandardVersion(canonical_name, XCSoar_Version);
+      std::exit(EXIT_SUCCESS);
+    }
+
+    if (StringIsEqual(arg, "--cpu-shade")) {
+      args.Skip();
+#ifdef ENABLE_OPENGL
+      cpu_shade = true;
+#else
+      std::fprintf(stderr, "%s: --cpu-shade requires OpenGL\n",
+                   canonical_name);
+      std::exit(EXIT_FAILURE);
+#endif
+      continue;
+    }
+
+    if (ParseDoubleOption(arg, "--radius=", radius_m, true) ||
+        ParseDoubleOption(arg, "--step=", step_deg, true) ||
+        ParseUnsignedOption(arg, "--period=", period_ms) ||
+        ParseUnsignedOption(arg, "--seconds=", seconds)) {
+      args.Skip();
+      continue;
+    }
+
+    double coord = 0;
+    if (ParseDoubleOption(arg, "--lat=", coord, false)) {
+      args.Skip();
+      latitude_deg = coord;
+      have_lat = true;
+      continue;
+    }
+
+    if (ParseDoubleOption(arg, "--lon=", coord, false)) {
+      args.Skip();
+      longitude_deg = coord;
+      have_lon = true;
+      continue;
+    }
+
+    if (StringStartsWith(arg, "-")) {
+      std::fprintf(stderr, "%s: unrecognised or invalid option: %s\n",
+                   canonical_name, arg);
+      std::exit(EXIT_FAILURE);
+    }
+
+    break;
+  }
+
+  map_path = args.ExpectNextPath();
+}
+
+class TerrainWindow : public PaintWindow {
+  RasterTerrain &terrain;
+  TerrainRenderer renderer;
+  TerrainRendererSettings settings;
+  WindowProjection projection;
+  GeoPoint location;
+  double radius_m;
+  Angle sun = Angle::Degrees(-45);
+  double last_generate_ms = 0;
+
+public:
+  TerrainWindow(RasterTerrain &_terrain, GeoPoint _location,
+                double _radius_m) noexcept
+    :terrain(_terrain), renderer(_terrain),
+     location(_location), radius_m(_radius_m)
+  {
+    settings.SetDefaults();
+    settings.enable = true;
+    settings.slope_shading = SlopeShading::SUN;
+    settings.contours = Contours::OFF;
+    renderer.SetSettings(settings);
+#ifdef ENABLE_OPENGL
+    renderer.SetQuantisationPixels(1);
+    renderer.SetUseCpuHillshade(cpu_shade);
+#endif
+  }
+
+  void SetSun(Angle _sun) noexcept {
+    sun = _sun;
+#ifdef ENABLE_OPENGL
+    if (cpu_shade)
+#endif
+      renderer.Flush();
+    Invalidate();
+  }
+
+  Angle GetSun() const noexcept {
+    return sun;
+  }
+
+  void LoadTiles() noexcept {
+    RebuildProjection();
+    const double tile_radius = projection.GetScreenWidthMeters() / 2;
+    while (terrain.UpdateTiles(location, tile_radius)) {}
+  }
+
+protected:
+  void RebuildProjection() noexcept {
+    const PixelSize size = GetSize();
+    if (size.width < 1 || size.height < 1)
+      return;
+
+    projection.SetScreenSize(size);
+    projection.SetScaleFromRadius(radius_m);
+    projection.SetGeoLocation(location);
+    projection.SetScreenOrigin(size.width / 2, size.height / 2);
+    projection.UpdateScreenBounds();
+  }
+
+  void OnResize(PixelSize new_size) noexcept override {
+    PaintWindow::OnResize(new_size);
+    LoadTiles();
+  }
+
+  void OnPaint(Canvas &canvas) noexcept override {
+    canvas.ClearWhite();
+
+    if (!projection.IsValid())
+      RebuildProjection();
+
+    renderer.SetSettings(settings);
+
+    const auto t0 = std::chrono::steady_clock::now();
+    const bool ok = renderer.Generate(projection, sun);
+    last_generate_ms =
+      std::chrono::duration<double, std::milli>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    if (ok)
+      renderer.Draw(canvas, projection);
+
+    canvas.Select(normal_font);
+    canvas.SetTextColor(COLOR_BLACK);
+#ifdef ENABLE_OPENGL
+    const char *mode = renderer.IsShaderHillshade() ? "GPU" : "CPU";
+#else
+    const char *mode = "CPU";
+#endif
+    canvas.DrawText({8, 8},
+                    fmt::format("{}  sun {:.0f}°  generate {:.1f} ms",
+                                mode, sun.Degrees(), last_generate_ms));
+  }
+};
+
+static void
+Main(TestMainWindow &main_window)
+{
+  if (have_lat != have_lon) {
+    std::fprintf(stderr, "%s: --lat and --lon must be used together\n",
+                 canonical_name);
+    std::exit(EXIT_FAILURE);
+  }
+
+  QuietOperationEnvironment operation;
+  std::fprintf(stderr, "loading terrain from %s...\n", map_path.c_str());
+  auto terrain = RasterTerrain::OpenTerrain(nullptr, map_path, operation);
+  if (terrain == nullptr) {
+    std::fprintf(stderr, "%s: no terrain in %s\n",
+                 canonical_name, map_path.c_str());
+    std::exit(EXIT_FAILURE);
+  }
+
+  GeoPoint location = have_lat
+    ? GeoPoint(Angle::Degrees(longitude_deg),
+               Angle::Degrees(latitude_deg))
+    : terrain->GetTerrainCenter();
+
+  std::fprintf(stderr,
+               "centre lat=%.5f lon=%.5f radius=%.0f m step=%.1f°\n",
+               location.latitude.Degrees(), location.longitude.Degrees(),
+               radius_m, step_deg);
+
+  WindowStyle with_border;
+  with_border.Border();
+
+  TerrainWindow view(*terrain, location, radius_m);
+  view.Create(main_window, main_window.GetClientRect(), with_border);
+  main_window.SetFullWindow(view);
+  view.LoadTiles();
+
+  UI::PeriodicTimer timer([&view]() {
+    view.SetSun(view.GetSun() + Angle::Degrees(step_deg));
+  });
+  timer.Schedule(std::chrono::milliseconds(period_ms));
+
+  UI::Timer quit_timer{[&main_window]() {
+    main_window.Close();
+  }};
+  if (seconds > 0)
+    quit_timer.Schedule(std::chrono::seconds(seconds));
+
+  main_window.RunEventLoop();
+}

--- a/test/src/TestGeoClip.cpp
+++ b/test/src/TestGeoClip.cpp
@@ -203,11 +203,18 @@ test_clip_polygon()
     make_geo_point(-5, -50),
   };
   test_clip_polygon(clip, src8, 3, result7, 4);
+
+  /* in-place dest==src, one vertex clipped (MapCanvas / airspace) */
+  GeoPoint inplace[12];
+  for (unsigned i = 0; i < 3; ++i)
+    inplace[i] = src3[i];
+  unsigned inplace_n = clip.ClipPolygon(inplace, inplace, 3);
+  ok1(equals(result3, 4, inplace, inplace_n));
 }
 
 int main()
 {
-  plan_tests(24);
+  plan_tests(25);
 
   test_clip_line();
   test_clip_polygon();


### PR DESCRIPTION
Fixes #3132.

Also addresses (does not close):

- #3127 — parent (GPU hillshade, topography loader-thread triangulation, `MapCanvas` geo fill)
- #3131 — reach fill uses `MapCanvas::FillPolygon` (ear-clip in geographic space, not screen `PolygonToTriangles`). Remaining: draw from the fan origin with `DrawTriangleFan`.
- #3129 — XCTherm rings use `FillPolygon` instead of `GeoToScreen` + `DrawPolygon`. Remaining: topography-style VBO + GPU project.

Airspace padding blink stays **#2479** / PR **#2961**. This PR shares the clipped-fill flicker class but is not the even-odd stencil fix.

## Summary
- Honour `-WIDTHxHEIGHT` on KMS/DRM so Raspberry Pi and other GBM targets actually switch away from the connector’s first mode (often 1080p).
- Shade terrain slope and contours in a GLES2 fragment shader so sun/wind lighting can change without a CPU `GenerateSlopeImage` rebuild (CPU path kept for GDI, e-ink, RASP, `--cpu-shade`).
- Keep dense topography usable: skip sub-pixel fills, subsample huge rings before ear-clip, triangulate on the loader thread, cap an LRU of loaded shapes, and clip long roads to the viewport.

## Test plan
- [ ] `make -j$(nproc) TARGET=UNIX USE_CCACHE=y WERROR=y` (xcsoar + the two new tools)
- [ ] Linux KMS/Pi: `./xcsoar -800x600` logs `DRM mode: 800x600@…` when that mode exists; omit the flag and confirm native/preferred mode
- [ ] OpenGL: pan/zoom a map with terrain + topography; rotate sun/wind and confirm shading updates without a hitch
- [ ] Hide/show topography; pan away and back over the same ground
- [ ] Optional: `RunTerrainRenderer map.xcm` vs `--cpu-shade`; `RunMapRendererStress map.xcm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPU-accelerated terrain hillshading with contours, adjustable sun settings, and color ramps.
  * Added map and terrain renderer stress-test utilities with timing, profiling, cache, and rendering options.
  * Added configurable display resolution selection for Linux KMS.

* **Performance Improvements**
  * Improved map and terrain caching, clipping, polygon handling, and rendering efficiency while zooming and panning.

* **Bug Fixes**
  * Fixed Linux KMS resolution selection and weather colorbar rendering.

* **Documentation**
  * Documented the new rendering utilities and release workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
