### PR TITLE
Cherry-pick v7.45.1 bugfixes onto 7.46

### DIFF
--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -462,6 +462,9 @@ jobs:
             VERSION_NAME="${VERSION_NAME}.${PATCH}"
           fi
 
+          echo "ANDROID_VERSION_CODE=${VERSION_CODE}" >> $GITHUB_ENV
+          echo "ANDROID_VERSION_NAME=${VERSION_NAME}" >> $GITHUB_ENV
+
           sed -i \
             -e "s/android:versionCode=\"[0-9][0-9]*\"/android:versionCode=\"${VERSION_CODE}\"/" \
             -e "s/android:versionName=\"[^\"]*\"/android:versionName=\"${VERSION_NAME}\"/" \

--- a/.github/workflows/build-native.yml
+++ b/.github/workflows/build-native.yml
@@ -38,6 +38,9 @@ on:
     branches:
       - master
       - apple-testing
+      # Current minor patch line (v7.45.x, v7.46.x, ...). Publish jobs stay
+      # gated to master and v* tags below.
+      - 'v*.x'
     tags:
       - 'v*'
 
@@ -67,6 +70,7 @@ on:
       - 'VERSION.txt'
     branches:
       - master
+      - 'v*.x'
 
 permissions:
   contents: read

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,23 @@
 Version 7.46 - not yet released
+* android
+  - fix crash when exiting the app #2873
+  - fix crash when restarting the app immediately after exit
+* input
+  - fix USB HID remotes (e.g. SteFly) that stop sending keys on
+    OpenVario after the stick re-enumerates #2820
+* weather
+  - fix SkySight re-downloading forecast metadata when stepping
+    layers on the weather cursor, which could hit the API rate
+    limit #2867
+* map
+  - fix the ragged white halo behind map labels on high-DPI screens
+    #2879
+* FLARM
+  - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
+* dialogs
+  - fix keyboard wrap in the Checklist: Down from Close returns
+    to the list and highlights an item so Enter acts on that row
+    #2862
 * development
   - documentation: document the release and post-release version workflow
 

--- a/android/src/XCSoar.java
+++ b/android/src/XCSoar.java
@@ -47,6 +47,13 @@ public class XCSoar extends Activity implements PermissionManager {
 
   private static NativeView nativeView;
 
+  /**
+   * The activity that currently owns the process.  A quick relaunch
+   * can construct a new instance before the exiting one is destroyed;
+   * onDestroy() must not System.exit() in that case.
+   */
+  private static XCSoar currentActivity;
+
   private Handler mainHandler;
   private PermissionHelper permissionHelper;
 
@@ -73,6 +80,8 @@ public class XCSoar extends Activity implements PermissionManager {
     Log.d(TAG, "DEVICE=" + Build.DEVICE);
     Log.d(TAG, "BOARD=" + Build.BOARD);
     Log.d(TAG, "FINGERPRINT=" + Build.FINGERPRINT);
+
+    currentActivity = this;
 
     if (!Loader.loaded) {
       TextView tv = new TextView(this);
@@ -354,6 +363,15 @@ public class XCSoar extends Activity implements PermissionManager {
       super.onDestroy();
       return;
     }
+
+    /* A newer activity is already running in this process (quick
+       relaunch).  Leave JNI and the VM alone. */
+    if (currentActivity != this) {
+      super.onDestroy();
+      return;
+    }
+
+    currentActivity = null;
 
     /* Mark the app as shutting down so that MyService will not restart
        itself after System.exit() kills the process.  The flag must be

--- a/build/android.mk
+++ b/build/android.mk
@@ -80,10 +80,12 @@ $(MANIFEST_PACKAGE_STAMP): FORCE | $(ANDROID_OUTPUT_DIR)/dirstamp
 		echo "$(MANIFEST_PACKAGE)" > $@.tmp && mv $@.tmp $@; \
 	fi
 
-$(MANIFEST_PROCESSED): $(MANIFEST_TEMPLATE) $(MANIFEST_PACKAGE_STAMP) | $(ANDROID_OUTPUT_DIR)/dirstamp
+$(MANIFEST_PROCESSED): $(MANIFEST_TEMPLATE) $(MANIFEST_PACKAGE_STAMP) $(topdir)/VERSION.txt | $(ANDROID_OUTPUT_DIR)/dirstamp
 	@$(NQ)echo "  PROCESS $@"
 	$(Q)sed -e 's/@PACKAGE_NAME@/$(MANIFEST_PACKAGE)/g' \
 		-e 's|@APP_LABEL@|$(MANIFEST_APP_LABEL)|g' \
+		-e 's/android:versionCode="[0-9][0-9]*"/android:versionCode="$(ANDROID_VERSION_CODE)"/' \
+		-e 's/android:versionName="[^"]*"/android:versionName="$(ANDROID_VERSION_NAME)"/' \
 		$< > $@
 
 NATIVE_CLASSES := \

--- a/build/android_bundle.mk
+++ b/build/android_bundle.mk
@@ -84,10 +84,12 @@ $(MANIFEST_PACKAGE_STAMP): FORCE | $(NO_ARCH_OUTPUT_DIR)/dirstamp
 		echo "$(MANIFEST_PACKAGE)" > $@.tmp && mv $@.tmp $@; \
 	fi
 
-$(MANIFEST_PROCESSED): $(MANIFEST_TEMPLATE) $(MANIFEST_PACKAGE_STAMP) | $(NO_ARCH_OUTPUT_DIR)/dirstamp
+$(MANIFEST_PROCESSED): $(MANIFEST_TEMPLATE) $(MANIFEST_PACKAGE_STAMP) $(topdir)/VERSION.txt | $(NO_ARCH_OUTPUT_DIR)/dirstamp
 	@$(NQ)echo "  PROCESS $@"
 	$(Q)sed -e 's/@PACKAGE_NAME@/$(MANIFEST_PACKAGE)/g' \
 		-e 's|@APP_LABEL@|$(MANIFEST_APP_LABEL)|g' \
+		-e 's/android:versionCode="[0-9][0-9]*"/android:versionCode="$(ANDROID_VERSION_CODE)"/' \
+		-e 's/android:versionName="[^"]*"/android:versionName="$(ANDROID_VERSION_NAME)"/' \
 		$< > $@
 
 

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -12,7 +12,13 @@ $(error VERSION.txt is missing)
 endif
 
 IOS_PATCH_VERSION ?= 0
-IOS_APP_VERSION ?= $(shell cat VERSION.txt).$(IOS_PATCH_VERSION)
+# Patch releases put X.Y.Z in VERSION.txt.  Two-part VERSION.txt still
+# appends IOS_PATCH_VERSION so CFBundleShortVersionString is X.Y.Z.
+ifeq ($(words $(subst ., ,$(VERSION))),2)
+IOS_APP_VERSION ?= $(VERSION).$(IOS_PATCH_VERSION)
+else
+IOS_APP_VERSION ?= $(VERSION_SHORT)
+endif
 IOS_APP_BUILD_NUMBER ?= 1
 
 ifeq ($(TESTING),y)

--- a/build/osx.mk
+++ b/build/osx.mk
@@ -18,7 +18,12 @@ endif
 
 # App Store version (must be X.Y.Z format)
 MACOS_PATCH_VERSION ?= 0
-MACOS_APP_VERSION ?= $(shell cat VERSION.txt).$(MACOS_PATCH_VERSION)
+# Same rule as ios.mk: full semver in VERSION.txt, or X.Y + patch.
+ifeq ($(words $(subst ., ,$(VERSION))),2)
+MACOS_APP_VERSION ?= $(VERSION).$(MACOS_PATCH_VERSION)
+else
+MACOS_APP_VERSION ?= $(VERSION_SHORT)
+endif
 MACOS_APP_BUILD_NUMBER ?= 1
 
 # App name and package names are always the same

--- a/build/test.mk
+++ b/build/test.mk
@@ -79,7 +79,7 @@ TEST_NAMES = \
 	test_task \
 	TestInputTransformMode \
 	TestOverwritingRingBuffer \
-	TestDateTime TestISO8601 TestRoughTime TestWrapClock \
+	TestDateTime TestISO8601 TestRoughTime TestRoughSpeed TestWrapClock \
 	TestPolylineDecoder \
 	TestTransponderCode \
 	TestMath \
@@ -390,6 +390,12 @@ TEST_ROUGH_TIME_SOURCES = \
 	$(TEST_SRC_DIR)/TestRoughTime.cpp
 TEST_ROUGH_TIME_DEPENDS = MATH TIME
 $(eval $(call link-program,TestRoughTime,TEST_ROUGH_TIME))
+
+TEST_ROUGH_SPEED_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestRoughSpeed.cpp
+TEST_ROUGH_SPEED_DEPENDS = MATH
+$(eval $(call link-program,TestRoughSpeed,TEST_ROUGH_SPEED))
 
 TEST_WRAP_CLOCK_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/version.mk
+++ b/build/version.mk
@@ -1,6 +1,25 @@
 VERSION = $(strip $(shell cat $(topdir)/VERSION.txt))
 FULL_VERSION = $(VERSION)
 
+# VERSION.txt is major.minor or major.minor.patch (policy.rst / release.rst).
+VERSION_WORDS := $(subst ., ,$(VERSION))
+VERSION_MAJOR := $(word 1,$(VERSION_WORDS))
+VERSION_MINOR := $(word 2,$(VERSION_WORDS))
+VERSION_PATCH := $(or $(word 3,$(VERSION_WORDS)),0)
+
+# Always three components for stores that require X.Y.Z (iOS / macOS).
+VERSION_SHORT = $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
+
+# Android versionName omits a trailing .0; versionCode uses
+# major*10^7 + minor*10^5 + patch*10^4 + build (build 0 for tags).
+ifeq ($(VERSION_PATCH),0)
+ANDROID_VERSION_NAME ?= $(VERSION_MAJOR).$(VERSION_MINOR)
+else
+ANDROID_VERSION_NAME ?= $(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_PATCH)
+endif
+ANDROID_VERSION_BUILD ?= 0
+ANDROID_VERSION_CODE ?= $(shell echo $$(($(VERSION_MAJOR)*10000000+$(VERSION_MINOR)*100000+$(VERSION_PATCH)*10000+$(ANDROID_VERSION_BUILD))))
+
 # Product name (default: XCSoar, can be overridden via PRODUCT_NAME variable)
 PRODUCT_NAME ?= XCSoar
 

--- a/src/Renderer/TextInBox.cpp
+++ b/src/Renderer/TextInBox.cpp
@@ -5,10 +5,13 @@
 #include "LabelBlock.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Pen.hpp"
+#include "Math/Angle.hpp"
 #include "Screen/Layout.hpp"
 #include "util/UTF8.hpp"
 
 #include <algorithm>
+
+#include <math.h>
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
@@ -56,19 +59,43 @@ TextInBoxMoveInView(PixelRect &rc, const PixelRect &map_rc) noexcept
   return offset;
 }
 
+/**
+ * Stamp the text along a circle of the given radius, one stamp per
+ * ~1.5px of circumference so consecutive stamps always overlap.  The
+ * four diagonal copies this used to be only close up while the offset
+ * is 1px; beyond that they leave gaps along every stroke, which is
+ * what high-DPI screens hit (offset 5 on a 3x iPhone).
+ */
+static void
+DrawTextHalo(Canvas &canvas, const char *text, const PixelPoint p,
+             const unsigned offset) noexcept
+{
+  /* 8 is the full neighbourhood of a 1px halo, 16 caps the cost */
+  const unsigned n = std::clamp(4 * offset, 8u, 16u);
+
+  for (unsigned i = 0; i < n; ++i) {
+    const auto [sin, cos] =
+      (Angle::FullCircle() * ((double)i / n)).SinCos();
+    canvas.DrawText({p.x + (int)lround(cos * offset),
+                     p.y + (int)lround(sin * offset)},
+                    text);
+  }
+}
+
 void
 RenderShadowedText(Canvas &canvas, const char *text,
                    PixelPoint p,
                    bool inverted) noexcept
 {
+  if (text == nullptr || text[0] == '\0')
+    return;
+
   canvas.SetBackgroundTransparent();
 
   canvas.SetTextColor(inverted ? COLOR_BLACK : COLOR_WHITE);
-  const int offset = canvas.GetFontHeight() / 12u;
-  canvas.DrawText({p.x + offset, p.y + offset}, text);
-  canvas.DrawText({p.x - offset, p.y + offset}, text);
-  canvas.DrawText({p.x + offset, p.y - offset}, text);
-  canvas.DrawText({p.x - offset, p.y - offset}, text);
+
+  /* at least 1px, or tiny fonts get no halo at all */
+  DrawTextHalo(canvas, text, p, std::max(1u, canvas.GetFontHeight() / 12u));
 
   canvas.SetTextColor(inverted ? COLOR_WHITE : COLOR_BLACK);
   canvas.DrawText(p, text);

--- a/src/Rough/RoughSpeed.hpp
+++ b/src/Rough/RoughSpeed.hpp
@@ -8,19 +8,28 @@
 #include <cstdint>
 
 /**
- * Store an rough speed value, when the exact value is not needed.
+ * Store a rough speed value, when the exact value is not needed.
  *
- * The accuracy is about 2mm/s. The range is 0 - 127 m/s.
+ * The accuracy is about 16 mm/s. The range is 0 - 1023 m/s.
  */
 class RoughSpeed {
   uint16_t value;
 
+  static constexpr double SCALE = 64;
+  static constexpr double MAX_MPS = 1023;
+
   static constexpr uint16_t Import(double x) {
-    return (uint16_t)(x * 512);
+    if (!(x > 0))
+      return 0;
+
+    if (x > MAX_MPS)
+      x = MAX_MPS;
+
+    return uint16_t(x * SCALE);
   }
 
   static constexpr double Export(uint16_t x) {
-    return double(x) / 512;
+    return double(x) / SCALE;
   }
 
 public:

--- a/src/Storage/android/AndroidStorageHotplugMonitor.cpp
+++ b/src/Storage/android/AndroidStorageHotplugMonitor.cpp
@@ -72,6 +72,11 @@ AndroidStorageHotplugMonitor::Start() noexcept
     return;
   }
 
+  if (receiver_ctor == nullptr ||
+      receiver_start_method == nullptr ||
+      receiver_stop_method == nullptr)
+    return;
+
   try {
     Java::LocalObject obj{env,
         env->NewObject(receiver_cls, receiver_ctor, context->Get())};
@@ -108,9 +113,11 @@ AndroidStorageHotplugMonitor::Stop() noexcept
   if (env == nullptr)
     return;
 
-  env->CallVoidMethod(receiver_.Get(), receiver_stop_method);
-  if (env->ExceptionCheck())
-    env->ExceptionClear();
+  if (receiver_stop_method != nullptr) {
+    env->CallVoidMethod(receiver_.Get(), receiver_stop_method);
+    if (env->ExceptionCheck())
+      env->ExceptionClear();
+  }
 
   receiver_.Clear(env);
 }

--- a/src/Storage/android/AndroidStorageHotplugMonitor.hpp
+++ b/src/Storage/android/AndroidStorageHotplugMonitor.hpp
@@ -25,10 +25,10 @@ class AndroidStorageHotplugMonitor : public StorageHotplugMonitor {
 
   /**
    * Java-side StorageHotplugReceiver instance.
-   * Uses TrivialRef because it may or may not be set, and needs
-   * explicit Set/Clear lifecycle management.
+   * Value-initialised: TrivialRef does not zero its stored
+   * reference, so an uninitialised member looks "defined".
    */
-  Java::TrivialRef<jobject> receiver_;
+  Java::TrivialRef<jobject> receiver_{};
 
 public:
   explicit AndroidStorageHotplugMonitor(StorageHotplugHandler &handler) noexcept;

--- a/src/Weather/SkySight/SkySightAPI.cpp
+++ b/src/Weather/SkySight/SkySightAPI.cpp
@@ -901,7 +901,22 @@ SkySightAPI::PreloadDefaultDatafile(std::string_view layer_id) noexcept
 
   bool success = false;
   const auto *selected = layer->FindDatafile(layer->forecast_time);
+  if ((selected == nullptr || selected->link.empty()) &&
+      layer->UsesAutomaticForecastTime()) {
+    const auto forecast_time =
+      SkySight::ChooseAutomaticForecastTime(*layer);
+    if (forecast_time > 0)
+      selected = layer->FindDatafile(forecast_time);
+  }
+
   if (selected == nullptr || selected->link.empty()) {
+    /* Catalog links from a recent /api/data are enough to display or
+       queue the default step.  Do not start another metadata fetch. */
+    if (SkySight::HasForecastCatalogLinks(*layer)) {
+      owner.OnDataUpdated();
+      return false;
+    }
+
     layer->RequestForecastMetadata(
       SkySight::ForecastMetadataIntent::ActiveDefault);
     success = true;

--- a/src/Weather/SkySight/SkySightClient.cpp
+++ b/src/Weather/SkySight/SkySightClient.cpp
@@ -802,6 +802,14 @@ SkySightClient::SetLayerActive(std::string_view id, bool request_update)
   manual_update_requested = request_update;
   if (!active_layer->SupportsLiveTiles()) {
     if (api->IsSelectedLayer(id)) {
+      /* Restore AUTO's catalog default when the page has not picked a
+         step yet, so the cache lookup can match a just-fetched layer. */
+      if (active_layer->UsesAutomaticForecastTime() &&
+          active_layer->forecast_time <= 0 &&
+          !active_layer->forecast_datafiles.empty())
+        active_layer->forecast_time =
+          SkySight::ChooseAutomaticForecastTime(*active_layer);
+
       const bool has_exact_forecast_image =
         HasExactForecastImage(GetRegion(), *active_layer);
       const bool manual_update_started = request_update &&
@@ -811,7 +819,7 @@ SkySightClient::SetLayerActive(std::string_view id, bool request_update)
       if (!manual_update_started && !has_exact_forecast_image &&
           (IsAutoUpdateEnabled() || request_update))
         (void)api->PreloadDefaultDatafile(id);
-      else if (!manual_update_started)
+      else if (!manual_update_started && !has_exact_forecast_image)
         api->RequestForecastMetadata(id);
     }
   }
@@ -844,7 +852,10 @@ SkySightClient::ApplyPageOverlay(const PageLayout &page) noexcept
       ? SkySight::ForecastTimeMode::AutoDefault
       : SkySight::ForecastTimeMode::Fixed;
     if (automatic)
-      layer->forecast_time = 0;
+      /* Keep a usable catalog time so SetLayerActive can reuse a
+         cached image instead of treating AUTO as a cache miss. */
+      layer->forecast_time =
+        SkySight::ChooseAutomaticForecastTime(*layer);
     else {
       const time_t fixed = time_t(page.skysight_time);
       if (int64_t(fixed) == page.skysight_time)

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -235,7 +235,35 @@ ArrowPagerWidget::FocusPageBottom() noexcept
       return true;
   }
 
-  return page.SetFocus();
+  if (!page.SetFocus())
+    return false;
+
+  /* Reserved-scrollbar rich text: highlight the last visible item.
+     SetFocus alone leaves the scroller focused with nothing
+     selected (same as #QuickGuidePageWidget wrapping Up from the
+     bottom bar).  Call the inner widget so the scroller does not
+     treat this as a page-scroll. */
+  if (auto *vs = dynamic_cast<VScrollWidget *>(&page))
+    if (vs->ReservesScrollbar())
+      vs->GetWidget().KeyPress(KEY_UP);
+
+  return true;
+}
+
+bool
+ArrowPagerWidget::FocusPageStart() noexcept
+{
+  Widget &page = GetCurrentWidget();
+  if (!page.SetFocus())
+    return false;
+
+  /* Highlight the first visible link/checkbox.  A page with no
+     items just keeps window focus. */
+  Widget *inner = &page;
+  if (auto *vs = dynamic_cast<VScrollWidget *>(&page))
+    inner = &vs->GetWidget();
+  inner->KeyPress(KEY_DOWN);
+  return true;
 }
 
 bool
@@ -300,8 +328,13 @@ ArrowPagerWidget::PageHandsOffToChrome(bool key_up) const noexcept
 bool
 ArrowPagerWidget::MoveChromeFocusDown() noexcept
 {
-  if (close_button.HasFocus())
-    return true; /* end of chrome chain */
+  if (close_button.HasFocus()) {
+    /* Wrap back into reserved-scrollbar rich text (Checklist,
+       Credits).  Other pages stay on Close. */
+    if (PageHandsOffToChrome(false))
+      return FocusPageStart();
+    return true;
+  }
 
   if (previous_button.HasFocus()) {
     if (next_button.IsEnabled())
@@ -322,7 +355,16 @@ ArrowPagerWidget::MoveChromeFocusDown() noexcept
 bool
 ArrowPagerWidget::KeyPress(unsigned key_code) noexcept
 {
-  if (PagerWidget::KeyPress(key_code))
+  const bool chrome_focused =
+    previous_button.HasFocus() ||
+    next_button.HasFocus() ||
+    close_button.HasFocus();
+
+  /* When chrome has focus, do not forward to the page.  Unfocused
+     rich text would treat Down as "no current item -> first link"
+     without taking focus, so Close stayed highlighted and Enter
+     activated that first item. */
+  if (!chrome_focused && PagerWidget::KeyPress(key_code))
     return true;
 
   if (extra != nullptr && extra->KeyPress(key_code))

--- a/src/Widget/ArrowPagerWidget.hpp
+++ b/src/Widget/ArrowPagerWidget.hpp
@@ -147,6 +147,12 @@ private:
   /** Up from chrome: last form row, Quick Guide bottom bar, or page. */
   bool FocusPageBottom() noexcept;
 
+  /**
+   * Down from Close: first page control, or first visible rich-text
+   * link/checkbox.
+   */
+  bool FocusPageStart() noexcept;
+
   /** Up/Down among prev / next / Close (and into the page). */
   bool MoveChromeFocusUp() noexcept;
   bool MoveChromeFocusDown() noexcept;

--- a/src/Widget/RichTextWidget.cpp
+++ b/src/Widget/RichTextWidget.cpp
@@ -97,8 +97,11 @@ RichTextWidget::SetFocus() noexcept
 bool
 RichTextWidget::KeyPress(unsigned key_code) noexcept
 {
-  // Forward key events to the window
-  if (IsDefined())
-    return GetWindow().InjectKeyPress(key_code);
-  return false;
+  /* Only when the window has focus.  Otherwise Up/Down/Enter would
+     move the link cursor or activate a link while Close (or another
+     control) is focused; same rule as #ListWidget. */
+  if (!IsDefined() || !HasFocus())
+    return false;
+
+  return GetWindow().InjectKeyPress(key_code);
 }

--- a/src/net/http/DownloadManager.cpp
+++ b/src/net/http/DownloadManager.cpp
@@ -312,9 +312,12 @@ Net::DownloadManager::BeginDeinitialise() noexcept
 void
 Net::DownloadManager::Deinitialise() noexcept
 {
-  assert(thread != nullptr);
-
+  /* Null after delete so a same-process re-entry of runNative
+     (quick restart before System.exit finishes) can Initialise()
+     again.  Leaving a dangling pointer trips assert(thread ==
+     nullptr) on the next startup. */
   delete thread;
+  thread = nullptr;
 }
 
 bool

--- a/src/ui/event/poll/libinput/LibInputHandler.cpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.cpp
@@ -185,8 +185,13 @@ int
 LibInputHandler::OpenDevice(const char *path, int flags) noexcept
 {
   int fd = open(path, flags);
-  if (fd < 0)
-    return -errno;
+  if (fd < 0) {
+    const int e = errno;
+    LogFormat("libinput: failed to open %s: %s",
+              path != nullptr ? path : "?", strerror(e));
+    need_rescan = true;
+    return -e;
+  }
 
   return fd;
 }
@@ -361,18 +366,49 @@ LibInputHandler::HandleEvent(struct libinput_event *li_event) noexcept
 }
 
 inline void
-LibInputHandler::HandlePendingEvents() noexcept
+LibInputHandler::DrainEvents() noexcept
 {
-  if (li == nullptr)
-    return;
-
-  libinput_dispatch(li);
   for (libinput_event *li_event = libinput_get_event(li);
        nullptr != li_event;
        li_event = libinput_get_event(li)) {
     HandleEvent(li_event);
     libinput_event_destroy(li_event);
   }
+}
+
+inline void
+LibInputHandler::RescanDevices() noexcept
+{
+  /* libinput ignores devices that fail to open until
+     libinput_resume().  Resume is a no-op while the udev monitor is
+     already running, so bounce suspend/resume to re-enumerate
+     without destroying the context.  Do not call this from
+     OpenDevice(); that runs inside libinput_resume(). */
+  need_rescan = false;
+  LogFormat("libinput: re-scanning input devices");
+  libinput_suspend(li);
+  if (libinput_resume(li) != 0)
+    LogFormat("libinput: resume after re-scan failed");
+
+  libinput_dispatch(li);
+  DrainEvents();
+
+  /* Ignore remove/open-failure flags from the bounce itself so we
+     do not loop.  A later udev event can set need_rescan again. */
+  need_rescan = false;
+}
+
+inline void
+LibInputHandler::HandlePendingEvents() noexcept
+{
+  if (li == nullptr)
+    return;
+
+  libinput_dispatch(li);
+  DrainEvents();
+
+  if (need_rescan)
+    RescanDevices();
 }
 
 void

--- a/src/ui/event/poll/libinput/LibInputHandler.hpp
+++ b/src/ui/event/poll/libinput/LibInputHandler.hpp
@@ -45,6 +45,13 @@ class LibInputHandler final {
    */
   unsigned n_pointers = 0, n_touch_screens = 0, n_keyboards = 0;
 
+  /**
+   * Set when open_restricted fails.  Cleared after a suspend/resume
+   * re-scan so a failed hotplug is not ignored for the rest of the
+   * session.
+   */
+  bool need_rescan = false;
+
 public:
   explicit LibInputHandler(EventQueue &_queue) noexcept;
 
@@ -119,6 +126,8 @@ private:
   void CloseDevice(int fd) noexcept;
 
   void HandleEvent(struct libinput_event *li_event) noexcept;
+  void DrainEvents() noexcept;
+  void RescanDevices() noexcept;
   void HandlePendingEvents() noexcept;
 
   void OnSocketReady(unsigned events) noexcept;

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -414,6 +414,19 @@ TestFLARM()
     skip(15, 0, "traffic == NULL");
   }
 
+  /* ADS-B airliner GS via PFLAA; used to wrap RoughSpeed above 127 m/s. */
+  ok1(parser.ParseLine("$PFLAA,0,100,-150,10,1,4CAAAA,90,,223,0,8*1B",
+                       nmea_info));
+
+  id = FlarmId::Parse("4CAAAA", NULL);
+  traffic = nmea_info.flarm.traffic.FindTraffic(id);
+  if (ok1(traffic != NULL)) {
+    ok1(traffic->speed_received);
+    ok1(equals(traffic->speed, 223));
+  } else {
+    skip(2, 0, "traffic == NULL");
+  }
+
   // PFLAA with IDType=0 (random ID)
   ok1(parser.ParseLine("$PFLAA,0,300,400,20,0,ABC123,90,,20,,8*30",
                        nmea_info));
@@ -3361,7 +3374,8 @@ int main()
   CreateDataPath();
 
   plan_tests(1091 /* drivers */ + 29 /* PFLAU extended */
-             + 37 /* PFLAA v7+ */ + 12 /* PFLAE */ + 10 /* PFLAJ */
+             + 37 /* PFLAA v7+ */ + 4 /* PFLAA high speed */
+             + 12 /* PFLAE */ + 10 /* PFLAJ */
              + 16 /* PFLAQ */
              + 109 /* LXNav protocol 1.05 */
              + 8 /* SubSecond */ + 4 /* MWVStatus */

--- a/test/src/TestGDL90Driver.cpp
+++ b/test/src/TestGDL90Driver.cpp
@@ -570,6 +570,47 @@ TestTrafficDriver() noexcept
   ok1(t != nullptr && between(t->altitude,
                               Units::ToSysUnit(4990, Unit::FEET),
                               Units::ToSysUnit(5010, Unit::FEET)));
+  ok1(t != nullptr && t->speed_received);
+  ok1(t != nullptr && between(t->speed,
+                              Units::ToSysUnit(122.5, Unit::KNOTS),
+                              Units::ToSysUnit(123.5, Unit::KNOTS)));
+}
+
+static void
+TestTrafficHighSpeed() noexcept
+{
+  /* Same layout as TestTrafficDriver; 434 kt ≈ 223 m/s (A320 cruise).
+     The old RoughSpeed 1/512 scale wrapped above 127 m/s. */
+  static constexpr uint8_t payload[] = {
+    0x00,
+    0x4C, 0xAA, 0xAA,
+    0x1F, 0xEF, 0x15,
+    0xA8, 0x89, 0x78,
+    0x0F, 0x09,
+    0xA9,
+    0x1B, 0x20, 0x00, // 434 kt, vertical 0
+    0x20,
+    0x01,
+    0x41, 0x33, 0x32, 0x30, 0x20, 0x20, 0x20, 0x20, // callsign
+    0x00,
+  };
+
+  const auto frame = BuildFrame(0x14, payload, sizeof(payload));
+
+  GDL90Device dev;
+  NMEAInfo info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+
+  Feed(dev, info, frame);
+
+  const FlarmId expected = FlarmId::Parse("4CAAAA", nullptr);
+  const FlarmTraffic *t = info.flarm.traffic.FindTraffic(expected);
+  ok1(t != nullptr);
+  ok1(t != nullptr && t->speed_received);
+  ok1(t != nullptr && between(t->speed,
+                              Units::ToSysUnit(433.5, Unit::KNOTS),
+                              Units::ToSysUnit(434.5, Unit::KNOTS)));
 }
 
 static void
@@ -881,7 +922,7 @@ TestOversizeFrameDropped() noexcept
 
 int main()
 {
-  plan_tests(89);
+  plan_tests(94);
 
   TestBadCrcIgnored();
   TestHeartbeatTimeOfDay();
@@ -894,6 +935,7 @@ int main()
   TestOwnshipGeometricAltitudeDatum();
   TestForeFlightAhrs();
   TestTrafficDriver();
+  TestTrafficHighSpeed();
   TestTrafficAddressTypeSource();
   TestRelativeAltitudeFromPressureAltitude();
   TestHorizontalRangeFilter();

--- a/test/src/TestRoughSpeed.cpp
+++ b/test/src/TestRoughSpeed.cpp
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Rough/RoughSpeed.hpp"
+#include "TestUtil.hpp"
+
+#include <limits>
+
+int main()
+{
+  plan_tests(13);
+
+  ok1(double(RoughSpeed(0)) == 0);
+  ok1(double(RoughSpeed(-10)) == 0);
+  ok1(double(RoughSpeed(std::numeric_limits<double>::quiet_NaN())) == 0);
+
+  /* Typical FLARM PFLAA values and the IsPassive() 4 m/s threshold. */
+  ok1(equals(double(RoughSpeed(4)), 4));
+  ok1(equals(double(RoughSpeed(24)), 24));
+  ok1(equals(double(RoughSpeed(32)), 32));
+  ok1(equals(double(RoughSpeed(127)), 127));
+
+  /* 128 m/s overflowed the old 1/512 scale (uint16 max / 512 ≈ 128). */
+  ok1(equals(double(RoughSpeed(128)), 128));
+  ok1(between(double(RoughSpeed(223.3)), 223.2, 223.4));
+
+  ok1(equals(double(RoughSpeed(1023)), 1023));
+  ok1(equals(double(RoughSpeed(2000)), 1023));
+
+  ok1(RoughSpeed(3) < 4);
+  ok1(!(RoughSpeed(4) < 4));
+
+  return exit_status();
+}

--- a/tools/changelog.sh
+++ b/tools/changelog.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-TAG="${1}"
-VERSION=$(echo "$TAG" | cut -f2 -d v)
-STARTLINENUMBER=$(grep -n -E "^Version $VERSION " NEWS.txt | cut -f1 -d:)
+RAW="${1:-}"
+# Accept v7.45.1, 7.45.1, or refs/tags/v7.45.1
+VERSION="${RAW##*/}"
+VERSION="${VERSION#v}"
+STARTLINENUMBER=$(grep -n -E "^Version ${VERSION} " NEWS.txt | cut -f1 -d:)
 if [ -z "${STARTLINENUMBER}" ]; then
   echo "ERROR: Version $1 not found in NEWS.txt"
   exit 1

--- a/windows/xcsoar.nsi
+++ b/windows/xcsoar.nsi
@@ -7,7 +7,7 @@
 !define PRODUCT_NAME "XCSoar"
 !endif
 
-; Version should be coming via override from command line with -DPRODUCT_VERSION=x.y
+; Version should be coming via override from command line with -DPRODUCT_VERSION=x.y.z
 !ifndef PRODUCT_VERSION
 !define PRODUCT_VERSION "dev"
 !endif


### PR DESCRIPTION
## Summary
- Cherry-pick #2890 first: run native CI on `v*.x` patch branches so a future `v7.46.x` gets checks. `build-native.yml` then matches `v7.45.x`.
- Cherry-pick the v7.45.1 bugfixes from #2889 onto `master` (already 7.46). Skip the VERSION / debian / Android bump to 7.45.1.
- Android JNI abort on exit and crash when restarting immediately (`System.exit` killing the new activity, dangling DownloadManager thread) — #2873
- Reuse SkySight cached forecast metadata when stepping weather-cursor layers, avoiding `/api/data` 429s — #2867
- Wrap Checklist keyboard focus from Close back into the list — #2862
- Recover libinput HID remotes after a failed USB reopen on OpenVario — #2820
- Close ragged map-label halos on high-DPI screens — #2879
- Fix ADS-B / GDL90 traffic ground speed wrapping above 457 km/h — #2887
- Include `build: Derive store versions from two- or three-part VERSION.txt` so future patch lines (7.46.1) keep store metadata in sync; iOS/macOS conflict resolved against master's 7.46 two-part `VERSION.txt`.
- Recreate the NEWS.txt notes under **Version 7.46 - not yet released** (same bullets as 7.45.1).

Closes #2873
Closes #2867
Closes #2862
Closes #2820
Closes #2879
Closes #2887

## Test plan
- [ ] Confirm VERSION.txt stays `7.46` (no 7.45.1 bump)
- [ ] Confirm NEWS.txt bullets sit under Version 7.46, not a 7.45.1 heading
- [ ] Confirm `build-native.yml` includes `'v*.x'` and matches `v7.45.x`
- [ ] Android: exit without JNI abort; immediate relaunch stays alive
- [ ] SkySight: step layers on the weather cursor; no HTTP 429 / one TIFF per selected layer
- [ ] Checklist: Down from Close highlights a list row; Enter acts on that row
- [ ] OpenVario: unplug/replug SteFly (or similar HID); keys return without restarting XCSoar
- [ ] High-DPI: Goto/task labels and PAN overlay halo look continuous
- [ ] RoughSpeed / GDL90: `TestRoughSpeed`, `TestDriver` PFLAA 223 m/s, `TestGDL90Driver` 434 kt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Android crashes during rapid exit and restart.
  - Improved USB HID remote key handling after device re-enumeration.
  - Prevented forecast metadata rate-limit issues and improved automatic forecast selection.
  - Improved high-DPI map label halos.
  - Corrected high-speed ADS-B traffic speed handling.
  - Fixed Checklist and rich-text keyboard navigation.
  - Improved recovery when input devices are temporarily unavailable.

- **Release Improvements**
  - Improved version handling across Android, iOS, macOS, and Windows builds.
  - Added support for more version tag formats in changelog generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->