### PR TITLE
Device/Driver/Condor3UDP: Do not copy heading into track

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,9 @@ Version 7.46 - not yet released
 * glide computer
   - fix best-glide speed and speed-to-fly at altitude when MacCready
     is set, so density scaling no longer inflates MacCready #2881
+* devices
+  - fix the map ground track line following heading instead of ground
+    track with Condor 3 UDP in a crosswind #2900
 * dialogs
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row

--- a/src/Device/Driver/Condor3UDP.cpp
+++ b/src/Device/Driver/Condor3UDP.cpp
@@ -66,10 +66,9 @@ class Condor3UDPDevice final : public AbstractDevice {
     const double h = std::hypot(vx, vy);
     info.ground_speed = h;
     info.ground_speed_available.Update(info.clock);
-    /* Do not derive track from Condor vx/vy: Condor documents them as
-       ground velocity but they are not reliable earth-frame N/E (see
-       compass handler comment).  Using them after compass expires made
-       the FLARM traffic radar bearing jump by ~120°. */
+    /* Do not derive track from Condor vx/vy: documented as ground
+       velocity but not reliable earth-frame N/E.  Using them after
+       compass expired made FLARM traffic radar bearing jump ~120°. */
   }
 
   bool
@@ -106,10 +105,11 @@ class Condor3UDPDevice final : public AbstractDevice {
     if (StringIsEqualIgnoreCase(key, "compass"sv)) {
       info.attitude.heading = Angle::Degrees(value);
       info.attitude.heading_available.Update(info.clock);
-      /* Circling/thermal assistant use track turn rate; keep it aligned
-         with compass because Condor vx/vy are not reliable east/north. */
-      info.track = info.attitude.heading;
-      info.track_available.Update(info.clock);
+      /* Heading only.  Copying compass into track made the ground
+         track line follow heading in a crosswind (#2900).  Condor
+         vx/vy are not reliable earth-frame N/E either; leave track
+         unset so GPS RMC or ComputeTrack() from position can supply
+         ground track. */
       return true;
     }
 
@@ -190,8 +190,6 @@ class Condor3UDPDevice final : public AbstractDevice {
       if (!info.attitude.heading_available) {
         info.attitude.heading = Angle::Radians(value);
         info.attitude.heading_available.Update(info.clock);
-        info.track = info.attitude.heading;
-        info.track_available.Update(info.clock);
       }
       return true;
     }

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1666,19 +1666,19 @@ TestCondor3UDP()
   ok1(device->ParseNMEA("compass=270", info));
   ok1(info.attitude.heading_available);
   ok1(equals(info.attitude.heading.Degrees(), 270));
-  ok1(info.track_available);
-  ok1(equals(info.track.Degrees(), 270));
+  ok1(!info.track_available);
 
   next_step();
   ok1(device->ParseNMEA("compass=90", info));
-  ok1(info.track_available);
-  ok1(equals(info.track.Degrees(), 90));
+  ok1(info.attitude.heading_available);
+  ok1(equals(info.attitude.heading.Degrees(), 90));
+  ok1(!info.track_available);
   ++step;
   info.clock = TimeStamp{FloatDuration{step}};
   info.alive.Update(info.clock);
   ok1(device->ParseNMEA("vx=30", info));
   ok1(device->ParseNMEA("vy=40", info));
-  ok1(equals(info.track.Degrees(), 90));
+  ok1(!info.track_available);
   ok1(equals(info.ground_speed, 50));
 
   next_step();


### PR DESCRIPTION
## Summary
- Condor 3 UDP was copying compass heading (and yaw fallback) into `track`, so the map ground track line followed heading in a crosswind.
- Leave `track` unset. GPS `$GPRMC` or `ComputeTrack()` from position supplies ground track; `vx`/`vy` stay unused for track (they are not reliable earth-frame N/E).
- Fixes #2900.

## Test plan
- [ ] `TestDriver` Condor3UDP cases: compass sets heading, not track; `vx`/`vy` still only set ground speed
- [ ] Condor 3 with both Condor3 NMEA and Condor3UDP: ground track line On, strong crosswind — line follows ground track, not the aircraft heading/crab
- [ ] Thermal assistant / circling still work (heading and heading turn rate come from compass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Condor 3 UDP telemetry so map ground-track lines accurately follow the aircraft’s actual ground track instead of its compass heading.
  - Improved handling of compass, yaw, GPS, and position data for more reliable heading and track display.
  - Preserved accurate ground-speed calculations from velocity data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->