### PR TITLE
Weather: Show the overlay name as XC Therm

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -10,6 +10,8 @@ Version 7.46 - not yet released
   - fix USB HID remotes (e.g. SteFly) that stop sending keys on
     OpenVario after the stick re-enumerates #2820
 * weather
+  - show the overlay name as XC Therm (with a space) in setup, weather
+    dialogs, map titles, and download messages
   - fix SkySight re-downloading forecast metadata when stepping
     layers on the weather cursor, which could hit the API rate
     limit #2867

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -527,7 +527,7 @@ Event list
  * - ``Weather``
    - Opens the weather dialog.
  * - ``WeatherOverlay``
-   - Adjusts the active map weather overlay cursor bar (EDL, RASP, XCTherm,
+   - Adjusts the active map weather overlay cursor bar (EDL, RASP, XC Therm,
      or SkySight). Only has an effect on map pages that show weather overlay
      controls. Arguments use a common ``<axis> …`` prefix:
 
@@ -545,14 +545,14 @@ Event list
      ``level picker`` (open the ComboPicker list for the active overlay).
 
      **Setup:** ``setup`` opens the Info → Weather dialog on the tab that
-     matches the active overlay (RASP, EDL, or XCTherm).
+     matches the active overlay (RASP, EDL, or XC Therm).
 
      **Secondary auto/manual:** ``field auto toggle`` (and ``altitude auto
      …``, ``level auto …`` aliases). On RASP, secondary auto falls back
      to time auto when no secondary axis exists.
 
      RASP overlays support time and layer selection. EDL overlays support
-     time and pressure level. XCTherm overlays map the secondary axis to
+     time and pressure level. XC Therm overlays map the secondary axis to
      altitude bands and time to forecast hours. SkySight uses the secondary
      axis for selected layers and the time axis for available forecast steps.
  * - ``Zoom Z``
@@ -594,7 +594,7 @@ Built-in modes
   event. Stick UP/DOWN step the secondary axis (layer, level, or
   altitude), LEFT/RIGHT step time, RETURN opens the time picker, ESCAPE
   returns to ``default``. In ``mode=weather``, F2 opens the secondary
-  list and F3 toggles auto (secondary axis on EDL/XCTherm, time auto on
+  list and F3 toggles auto (secondary axis on EDL/XC Therm, time auto on
   RASP). The map overlay **+** / **−** buttons always zoom the map.
   See :ref:`weather-overlay-mode` below.
 - ``wptimg`` -- the waypoint details dialog is on an **image** page;
@@ -610,7 +610,7 @@ hierarchies.
 Weather overlay mode (``mode=weather``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When a map page displays EDL, RASP, XCTherm, or SkySight overlay controls in the
+When a map page displays EDL, RASP, XC Therm, or SkySight overlay controls in the
 bottom cursor bar, open the quick menu (F1 or the ULDR gesture) and choose
 **Forecast Controls** (RemoteStick), or bind ``Mode weather`` elsewhere,
 to enter ``mode=weather`` so stick and button bindings can adjust forecast
@@ -628,7 +628,7 @@ The built-in stick bindings in :file:`Data/Input/default.xci` are:
    - Action
  * - UP / DOWN
    - ``WeatherOverlay field +/-``
-   - Step layer (RASP), pressure level (EDL), or altitude band (XCTherm)
+   - Step layer (RASP), pressure level (EDL), or altitude band (XC Therm)
  * - LEFT / RIGHT
    - ``WeatherOverlay time -/+``
    - Step forecast time
@@ -640,7 +640,7 @@ The built-in stick bindings in :file:`Data/Input/default.xci` are:
    - Open secondary-axis list (layer, level, or altitude)
  * - F3
    - ``WeatherOverlay field auto toggle``
-   - Toggle secondary auto (EDL/XCTherm) or time auto (RASP)
+   - Toggle secondary auto (EDL/XC Therm) or time auto (RASP)
  * - ESCAPE
    - ``Mode default``
    - Exit weather input mode
@@ -664,7 +664,7 @@ mirror the stick actions:
    - Layer / Level / Altitude list (``F2``)
  * - 3
    - Auto toggle
-   - Time auto (RASP) or secondary auto (EDL/XCTherm) (``F3``)
+   - Time auto (RASP) or secondary auto (EDL/XC Therm) (``F3``)
  * - 4
    - Time step forward
    - ``Time+ (RIGHT)``

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -795,11 +795,11 @@ When editing a page, the following options are available for map pages:
   or \emph{Map (north-up)}.
 \item[InfoBoxes]  Which InfoBox set is shown alongside the main area.
 \item[Bottom area]  Optional panel below the main area.  Select
-  \emph{Weather controls} to show in-flight RASP, EDL, or XCTherm forecast
+  \emph{Weather controls} to show in-flight RASP, EDL, or XC Therm forecast
   controls when the page uses a weather overlay.
 \item[Map overlay]  Optional weather overlay drawn on map pages: \emph{None},
-  \emph{RASP}, \emph{EDL}, or \emph{XCTherm}.  RASP requires a loaded RASP
-  file; EDL and XCTherm require network-capable builds with the respective
+  \emph{RASP}, \emph{EDL}, or \emph{XC Therm}.  RASP requires a loaded RASP
+  file; EDL and XC Therm require network-capable builds with the respective
   weather provider configured.
 \item[Layer / Level]  When \emph{Map overlay} is \emph{RASP}, selects
   which RASP field is displayed on this page.  When the overlay is

--- a/po/bg.po
+++ b/po/bg.po
@@ -10038,30 +10038,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Обединено кралство. Модел ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Имейл XCTherm"
+msgid "XC Therm email"
+msgstr "Имейл XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Имейл адрес за вашия акаунт XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Имейл адрес за вашия акаунт XC Therm."
 
-msgid "XCTherm password"
-msgstr "Парола XCTherm"
+msgid "XC Therm password"
+msgstr "Парола XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Парола за вашия акаунт XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Парола за вашия акаунт XC Therm."
 
-msgid "XCTherm region"
-msgstr "Регион XCTherm"
+msgid "XC Therm region"
+msgstr "Регион XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Регион на прогнозата. Променя модела, от който XCTherm изтегля данни. След "
+"Регион на прогнозата. Променя модела, от който XC Therm изтегля данни. След "
 "промяна рестартирайте или изтеглете отново."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Авто слой/време XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Авто слой/време XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10350,8 +10350,8 @@ msgstr "Няма избран слой."
 msgid "Network is not available."
 msgstr "Мрежа недоступна."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Индексът на прогнозата не съдържа параметри на XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Индексът на прогнозата не съдържа параметри на XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10474,12 +10474,12 @@ msgid "HTTP support"
 msgstr "Поддержка HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Зареждане XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Зареждане XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Зареждане XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Зареждане XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -10026,30 +10026,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Regne Unit. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Email XCTherm"
+msgid "XC Therm email"
+msgstr "Email XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Adreça de correu del compte XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Adreça de correu del compte XC Therm."
 
-msgid "XCTherm password"
-msgstr "Contrasenya XCTherm"
+msgid "XC Therm password"
+msgstr "Contrasenya XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Contrasenya del tuo account XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Contrasenya del tuo account XC Therm."
 
-msgid "XCTherm region"
-msgstr "Regione XCTherm"
+msgid "XC Therm region"
+msgstr "Regione XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regió de previsió. Canvia el model del qual XCTherm obté dades. Reinicieu o "
+"Regió de previsió. Canvia el model del qual XC Therm obté dades. Reinicieu o "
 "torneu a baixar després del canvi."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Capa/Ora auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Capa/Ora auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10339,8 +10339,8 @@ msgstr "Capo capa seleccionato."
 msgid "Network is not available."
 msgstr "Xarxa non disponibile."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "L'indice di previsione non ha parametri XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "L'indice di previsione non ha parametri XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10462,12 +10462,12 @@ msgid "HTTP support"
 msgstr "Supporto HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Baixada XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Baixada XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Baixada XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Baixada XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -9911,30 +9911,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Spojené království. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mailová adresa účtu XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "E-mailová adresa účtu XC Therm."
 
-msgid "XCTherm password"
-msgstr "Heslo XCTherm"
+msgid "XC Therm password"
+msgstr "Heslo XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Heslo účtu XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Heslo účtu XC Therm."
 
-msgid "XCTherm region"
-msgstr "Region XCTherm"
+msgid "XC Therm region"
+msgstr "Region XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Region předpovědi. Mění model, ze kterého XCTherm stahuje data. Po změně "
+"Region předpovědi. Mění model, ze kterého XC Therm stahuje data. Po změně "
 "restartujte nebo stáhněte znovu."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto vrstva/čas"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto vrstva/čas"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10223,8 +10223,8 @@ msgstr "Není vybrána žádná vrstva."
 msgid "Network is not available."
 msgstr "Síť není dostupná."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Index předpovědi nemá parametry XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Index předpovědi nemá parametry XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10346,12 +10346,12 @@ msgid "HTTP support"
 msgstr "Podpora HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Stahování XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Stahování XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Stahování XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Stahování XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "Povolit živé sledování přes server SkyLines (tracking.skylines.aero)."

--- a/po/da.po
+++ b/po/da.po
@@ -9977,30 +9977,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
-msgid "XCTherm email"
-msgstr "XCTherm-e-post"
+msgid "XC Therm email"
+msgstr "XC Therm-e-post"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-postadresse for ditt XCTherm-konto."
+msgid "Email address for your XC Therm account."
+msgstr "E-postadresse for ditt XC Therm-konto."
 
-msgid "XCTherm password"
-msgstr "XCTherm-løsenord"
+msgid "XC Therm password"
+msgstr "XC Therm-løsenord"
 
-msgid "Password for your XCTherm account."
-msgstr "Løsenord for dit XCTherm-konto."
+msgid "Password for your XC Therm account."
+msgstr "Løsenord for dit XC Therm-konto."
 
-msgid "XCTherm region"
-msgstr "XCTherm-region"
+msgid "XC Therm region"
+msgstr "XC Therm-region"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Prognoseregion. Ændrer hvilken model XCTherm henter data fra. Genstart eller"
+"Prognoseregion. Ændrer hvilken model XC Therm henter data fra. Genstart eller"
 " hent igen efter ændring."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto lager/tid"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto lager/tid"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10285,8 +10285,8 @@ msgstr "Inget lager valt."
 msgid "Network is not available."
 msgstr "Netværket er ikke tilgængeligt."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Vejrudsigtindexet har ingen XCTherm-parametrar."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Vejrudsigtindexet har ingen XC Therm-parametrar."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10407,12 +10407,12 @@ msgid "HTTP support"
 msgstr "HTTP-understøttelse"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Downloader XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Downloader XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Downloader XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Downloader XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "Aktivér live tracking via SkyLines-servern (tracking.skylines.aero)."

--- a/po/da.po
+++ b/po/da.po
@@ -9978,19 +9978,19 @@ msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
 msgid "XC Therm email"
-msgstr "XC Therm-e-post"
+msgstr "XC Therm e-post"
 
 msgid "Email address for your XC Therm account."
-msgstr "E-postadresse for ditt XC Therm-konto."
+msgstr "E-postadresse til din konto hos XC Therm."
 
 msgid "XC Therm password"
-msgstr "XC Therm-løsenord"
+msgstr "XC Therm løsenord"
 
 msgid "Password for your XC Therm account."
-msgstr "Løsenord for dit XC Therm-konto."
+msgstr "Løsenord til din konto hos XC Therm."
 
 msgid "XC Therm region"
-msgstr "XC Therm-region"
+msgstr "XC Therm region"
 
 msgid ""
 "Forecast region. Changes which model XC Therm fetches data from. Restart or "
@@ -10286,7 +10286,7 @@ msgid "Network is not available."
 msgstr "Netværket er ikke tilgængeligt."
 
 msgid "Forecast index has no XC Therm parameters."
-msgstr "Vejrudsigtindexet har ingen XC Therm-parametrar."
+msgstr "Vejrudsigtindexet har ingen parametre for XC Therm."
 
 msgid ""
 "Forecast download failed.\n"

--- a/po/de.po
+++ b/po/de.po
@@ -10042,30 +10042,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Vereinigtes Königreich. ICON-UK-Modell."
 
-msgid "XCTherm email"
-msgstr "XCTherm-E-Mail"
+msgid "XC Therm email"
+msgstr "XC Therm-E-Mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-Mail-Adresse Ihres XCTherm-Kontos."
+msgid "Email address for your XC Therm account."
+msgstr "E-Mail-Adresse Ihres XC Therm-Kontos."
 
-msgid "XCTherm password"
-msgstr "XCTherm-Passwort"
+msgid "XC Therm password"
+msgstr "XC Therm-Passwort"
 
-msgid "Password for your XCTherm account."
-msgstr "Passwort Ihres XCTherm-Kontos."
+msgid "Password for your XC Therm account."
+msgstr "Passwort Ihres XC Therm-Kontos."
 
-msgid "XCTherm region"
-msgstr "XCTherm-Region"
+msgid "XC Therm region"
+msgstr "XC Therm-Region"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Vorhersageregion. Bestimmt, aus welchem Modell XCTherm Daten holt. Nach "
+"Vorhersageregion. Bestimmt, aus welchem Modell XC Therm Daten holt. Nach "
 "Änderung neu starten oder erneut herunterladen."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm Auto Schicht/Zeit"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm Auto Schicht/Zeit"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10355,8 +10355,8 @@ msgstr "Keine Schicht gewählt."
 msgid "Network is not available."
 msgstr "Netzwerk ist nicht verfügbar."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Vorhersageindex hat keine XCTherm-Parameter."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Vorhersageindex hat keine XC Therm-Parameter."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10478,12 +10478,12 @@ msgid "HTTP support"
 msgstr "HTTP-Unterstützung"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Lade XCTherm %s (%u/%u) herunter..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Lade XC Therm %s (%u/%u) herunter..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Lade XCTherm %s herunter..."
+msgid "Downloading XC Therm %s..."
+msgstr "Lade XC Therm %s herunter..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -10043,19 +10043,19 @@ msgid "United Kingdom. ICON-UK model."
 msgstr "Vereinigtes Königreich. ICON-UK-Modell."
 
 msgid "XC Therm email"
-msgstr "XC Therm-E-Mail"
+msgstr "XC Therm E-Mail"
 
 msgid "Email address for your XC Therm account."
-msgstr "E-Mail-Adresse Ihres XC Therm-Kontos."
+msgstr "E-Mail-Adresse Ihres Kontos bei XC Therm."
 
 msgid "XC Therm password"
-msgstr "XC Therm-Passwort"
+msgstr "XC Therm Passwort"
 
 msgid "Password for your XC Therm account."
-msgstr "Passwort Ihres XC Therm-Kontos."
+msgstr "Passwort Ihres Kontos bei XC Therm."
 
 msgid "XC Therm region"
-msgstr "XC Therm-Region"
+msgstr "XC Therm Region"
 
 msgid ""
 "Forecast region. Changes which model XC Therm fetches data from. Restart or "
@@ -10356,7 +10356,7 @@ msgid "Network is not available."
 msgstr "Netzwerk ist nicht verfügbar."
 
 msgid "Forecast index has no XC Therm parameters."
-msgstr "Vorhersageindex hat keine XC Therm-Parameter."
+msgstr "Vorhersageindex hat keine Parameter von XC Therm."
 
 msgid ""
 "Forecast download failed.\n"

--- a/po/el.po
+++ b/po/el.po
@@ -10054,30 +10054,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ηνωμένο Βασίλειο. Μοντέλο ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Email XCTherm"
+msgid "XC Therm email"
+msgstr "Email XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Διεύθυνση email για τον λογαριασμό XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Διεύθυνση email για τον λογαριασμό XC Therm."
 
-msgid "XCTherm password"
-msgstr "Κωδικός XCTherm"
+msgid "XC Therm password"
+msgstr "Κωδικός XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Κωδικός πρόσβασης για τον λογαριασμό XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Κωδικός πρόσβασης για τον λογαριασμό XC Therm."
 
-msgid "XCTherm region"
-msgstr "Περιοχή XCTherm"
+msgid "XC Therm region"
+msgstr "Περιοχή XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Περιοχή πρόγνωσης. Αλλάζει από ποιο μοντέλο λαμβάνει δεδομένα το XCTherm. "
+"Περιοχή πρόγνωσης. Αλλάζει από ποιο μοντέλο λαμβάνει δεδομένα το XC Therm. "
 "Επανεκκινήστε ή κατεβάστε ξανά μετά την αλλαγή."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Αυτόμ. στρώμα/ώρα XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Αυτόμ. στρώμα/ώρα XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10368,8 +10368,8 @@ msgstr "Δεν έχει επιλεγεί στρώμα."
 msgid "Network is not available."
 msgstr "Το δίκτυο δεν είναι διαθέσιμο."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Ο δείκτης πρόγνωσης δεν έχει παραμέτρους XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Ο δείκτης πρόγνωσης δεν έχει παραμέτρους XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10491,12 +10491,12 @@ msgid "HTTP support"
 msgstr "Υποστήριξη HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Λήψη XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Λήψη XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Λήψη XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Λήψη XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -10078,30 +10078,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Reino Unido. Modelo ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Correo XCTherm"
+msgid "XC Therm email"
+msgstr "Correo XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Dirección de correo de su cuenta XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Dirección de correo de su cuenta XC Therm."
 
-msgid "XCTherm password"
-msgstr "Contraseña XCTherm"
+msgid "XC Therm password"
+msgstr "Contraseña XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Contraseña de su cuenta XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Contraseña de su cuenta XC Therm."
 
-msgid "XCTherm region"
-msgstr "Región XCTherm"
+msgid "XC Therm region"
+msgstr "Región XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Región de previsión. Cambia de qué modelo XCTherm obtiene los datos. "
+"Región de previsión. Cambia de qué modelo XC Therm obtiene los datos. "
 "Reinicie o vuelva a descargar tras el cambio."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Capa/hora auto. XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Capa/hora auto. XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10392,8 +10392,8 @@ msgstr "Ninguna capa seleccionada."
 msgid "Network is not available."
 msgstr "La red no está disponible."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "El índice de previsión no tiene parámetros XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "El índice de previsión no tiene parámetros XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10516,12 +10516,12 @@ msgid "HTTP support"
 msgstr "Soporte HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Descargando XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Descargando XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Descargando XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Descargando XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -9928,30 +9928,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Yhdistynyt kuningaskunta. ICON-UK-malli."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm salasana"
+msgid "XC Therm password"
+msgstr "XC Therm salasana"
 
-msgid "Password for your XCTherm account."
-msgstr "XCTherm-tilisi salasana."
+msgid "Password for your XC Therm account."
+msgstr "XC Therm-tilisi salasana."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Ennustealue. Vaihtaa mallin, josta XCTherm hakee tiedot. Käynnistä uudelleen"
+"Ennustealue. Vaihtaa mallin, josta XC Therm hakee tiedot. Käynnistä uudelleen"
 " tai lataa uudelleen muutoksen jälkeen."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto kerros/aika"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto kerros/aika"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10241,8 +10241,8 @@ msgstr "Nije odabran kerros."
 msgid "Network is not available."
 msgstr "Verkko nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks ennuste nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks ennuste nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10364,12 +10364,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Lataus XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Lataus XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Lataus XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Lataus XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -9938,7 +9938,7 @@ msgid "XC Therm password"
 msgstr "XC Therm salasana"
 
 msgid "Password for your XC Therm account."
-msgstr "XC Therm-tilisi salasana."
+msgstr "XC Therm -tilisi salasana."
 
 msgid "XC Therm region"
 msgstr "XC Therm regija"

--- a/po/fr.po
+++ b/po/fr.po
@@ -10071,30 +10071,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Royaume-Uni. Modèle ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Adresse e-mail de votre compte XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Adresse e-mail de votre compte XC Therm."
 
-msgid "XCTherm password"
-msgstr "Mot de passe XCTherm"
+msgid "XC Therm password"
+msgstr "Mot de passe XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Mot de passe de votre compte XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Mot de passe de votre compte XC Therm."
 
-msgid "XCTherm region"
-msgstr "Région XCTherm"
+msgid "XC Therm region"
+msgstr "Région XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Région de prévision. Change le modèle depuis lequel XCTherm récupère les "
+"Région de prévision. Change le modèle depuis lequel XC Therm récupère les "
 "données. Redémarrez ou retéléchargez après modification."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Couche/heure auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Couche/heure auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10385,8 +10385,8 @@ msgstr "Aucune couche sélectionnée."
 msgid "Network is not available."
 msgstr "Le réseau n'est pas disponible."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "L'index de prévision n'a pas de paramètres XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "L'index de prévision n'a pas de paramètres XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10510,12 +10510,12 @@ msgid "HTTP support"
 msgstr "Support HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Téléchargement XCTherm %s (%u/%u)…"
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Téléchargement XC Therm %s (%u/%u)…"
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Téléchargement XCTherm %s…"
+msgid "Downloading XC Therm %s..."
+msgstr "Téléchargement XC Therm %s…"
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -9873,30 +9873,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "הממלכה המאוחדת. מודל ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm סיסמה"
+msgid "XC Therm password"
+msgstr "XC Therm סיסמה"
 
-msgid "Password for your XCTherm account."
-msgstr "סיסמה XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "סיסמה XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"אזור תחזית. משנה מאיזה מודל XCTherm שואב נתונים. הפעילו מחדש או הורידו מחדש "
+"אזור תחזית. משנה מאיזה מודל XC Therm שואב נתונים. הפעילו מחדש או הורידו מחדש "
 "לאחר השינוי."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm שכבה/זמן אוטומטי"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm שכבה/זמן אוטומטי"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10183,8 +10183,8 @@ msgstr "Nije odabran שכבה."
 msgid "Network is not available."
 msgstr "רשת nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks תחזית nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks תחזית nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10302,12 +10302,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "הורדה XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "הורדה XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "הורדה XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "הורדה XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "אפשר מעקב חי דרך שרת SkyLines (tracking.skylines.aero)."

--- a/po/hr.po
+++ b/po/hr.po
@@ -9943,30 +9943,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm lozinka"
+msgid "XC Therm password"
+msgstr "XC Therm lozinka"
 
-msgid "Password for your XCTherm account."
-msgstr "Lozinka XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Lozinka XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regija prognoze. Mijenja model s kojeg XCTherm dohvaća podatke. Nakon "
+"Regija prognoze. Mijenja model s kojeg XC Therm dohvaća podatke. Nakon "
 "promjene ponovno pokrenite ili ponovno preuzmite."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto sloj/vrijeme"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto sloj/vrijeme"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10256,8 +10256,8 @@ msgstr "Nije odabran sloj."
 msgid "Network is not available."
 msgstr "Mreža nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks prognoze nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks prognoze nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10379,12 +10379,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Preuzimanje XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Preuzimanje XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Preuzimanje XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Preuzimanje XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/hu.po
+++ b/po/hu.po
@@ -9974,30 +9974,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Egyesült Királyság. ICON-UK modell."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm jelszó"
+msgid "XC Therm password"
+msgstr "XC Therm jelszó"
 
-msgid "Password for your XCTherm account."
-msgstr "Jelszó XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Jelszó XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
 "Előrejelzési régió. Megváltoztatja, melyik modellből kér le adatokat az "
-"XCTherm. Változtatás után indítsa újra vagy töltse le újra."
+"XC Therm. Változtatás után indítsa újra vagy töltse le újra."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto réteg/idő"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto réteg/idő"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10287,8 +10287,8 @@ msgstr "Nije odabran réteg."
 msgid "Network is not available."
 msgstr "Hálózat nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks előrejelzés nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks előrejelzés nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10410,12 +10410,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Letöltés XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Letöltés XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Letöltés XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Letöltés XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -10084,30 +10084,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Regno Unito. Modello ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Email XCTherm"
+msgid "XC Therm email"
+msgstr "Email XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Indirizzo email del tuo account XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Indirizzo email del tuo account XC Therm."
 
-msgid "XCTherm password"
-msgstr "Password XCTherm"
+msgid "XC Therm password"
+msgstr "Password XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Password del tuo account XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Password del tuo account XC Therm."
 
-msgid "XCTherm region"
-msgstr "Regione XCTherm"
+msgid "XC Therm region"
+msgstr "Regione XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regione di previsione. Cambia il modello da cui XCTherm scarica i dati. "
+"Regione di previsione. Cambia il modello da cui XC Therm scarica i dati. "
 "Riavvia o riscarica dopo la modifica."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Strato/Ora auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Strato/Ora auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10397,8 +10397,8 @@ msgstr "Nessuno strato selezionato."
 msgid "Network is not available."
 msgstr "Rete non disponibile."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "L'indice di previsione non ha parametri XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "L'indice di previsione non ha parametri XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10520,12 +10520,12 @@ msgid "HTTP support"
 msgstr "Supporto HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Download XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Download XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Download XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Download XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -9986,28 +9986,28 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "英国。ICON-UK モデル。"
 
-msgid "XCTherm email"
-msgstr "XCTherm メール"
+msgid "XC Therm email"
+msgstr "XC Therm メール"
 
-msgid "Email address for your XCTherm account."
-msgstr "XCTherm アカウントのメールアドレス。"
+msgid "Email address for your XC Therm account."
+msgstr "XC Therm アカウントのメールアドレス。"
 
-msgid "XCTherm password"
-msgstr "XCTherm パスワード"
+msgid "XC Therm password"
+msgstr "XC Therm パスワード"
 
-msgid "Password for your XCTherm account."
-msgstr "XCTherm アカウントのパスワード。"
+msgid "Password for your XC Therm account."
+msgstr "XC Therm アカウントのパスワード。"
 
-msgid "XCTherm region"
-msgstr "XCTherm 地域"
+msgid "XC Therm region"
+msgstr "XC Therm 地域"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
-msgstr "予報地域。XCTherm がデータを取得するモデルを変更します。変更後は再起動または再ダウンロード。"
+msgstr "予報地域。XC Therm がデータを取得するモデルを変更します。変更後は再起動または再ダウンロード。"
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm 自動レイヤ/時刻"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm 自動レイヤ/時刻"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10286,8 +10286,8 @@ msgstr "レイヤが選択されていません。"
 msgid "Network is not available."
 msgstr "ネットワークを利用できません。"
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "予報インデックスに XCTherm パラメータがありません。"
+msgid "Forecast index has no XC Therm parameters."
+msgstr "予報インデックスに XC Therm パラメータがありません。"
 
 msgid ""
 "Forecast download failed.\n"
@@ -10398,12 +10398,12 @@ msgid "HTTP support"
 msgstr "HTTP サポート"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "XCTherm %s をダウンロード中 (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "XC Therm %s をダウンロード中 (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "XCTherm %s をダウンロード中..."
+msgid "Downloading XC Therm %s..."
+msgstr "XC Therm %s をダウンロード中..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "SkyLines サーバ（tracking.skylines.aero）経由のライブトラッキングを有効にします。"

--- a/po/ko.po
+++ b/po/ko.po
@@ -9760,28 +9760,28 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm 암호"
+msgid "XC Therm password"
+msgstr "XC Therm 암호"
 
-msgid "Password for your XCTherm account."
-msgstr "암호 XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "암호 XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
-msgstr "예보 지역. XCTherm이 데이터를 가져오는 모델을 바꿉니다. 변경 후 다시 시작하거나 다시 내려받으세요."
+msgstr "예보 지역. XC Therm이 데이터를 가져오는 모델을 바꿉니다. 변경 후 다시 시작하거나 다시 내려받으세요."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto 레이어/시간"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto 레이어/시간"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10062,8 +10062,8 @@ msgstr "Nije odabran 레이어."
 msgid "Network is not available."
 msgstr "네트워크 nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks 예보 nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks 예보 nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10174,12 +10174,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "다운로드 XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "다운로드 XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "다운로드 XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "다운로드 XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "SkyLines 서버(tracking.skylines.aero)를 통한 실시간 추적을 사용합니다."

--- a/po/lt.po
+++ b/po/lt.po
@@ -9968,30 +9968,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Jungtinė Karalystė. ICON-UK modelis."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm slaptažodis"
+msgid "XC Therm password"
+msgstr "XC Therm slaptažodis"
 
-msgid "Password for your XCTherm account."
-msgstr "Jūsų XCTherm paskyros slaptažodis."
+msgid "Password for your XC Therm account."
+msgstr "Jūsų XC Therm paskyros slaptažodis."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Prognozės regionas. Keičia modelį, iš kurio XCTherm gauna duomenis. Už "
+"Prognozės regionas. Keičia modelį, iš kurio XC Therm gauna duomenis. Už "
 "pakeitus paleiskite iš naujo arba atsisiųskite iš naujo."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto sluoksnis/laikas"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto sluoksnis/laikas"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10282,8 +10282,8 @@ msgstr "Nije odabran sluoksnis."
 msgid "Network is not available."
 msgstr "Tinklas nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks prognozė nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks prognozė nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10405,12 +10405,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Atsisiuntimas XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Atsisiuntimas XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Atsisiuntimas XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Atsisiuntimas XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "Įjungti gyvąjį sekimą per SkyLines serverį (tracking.skylines.aero)."

--- a/po/nb.po
+++ b/po/nb.po
@@ -9890,30 +9890,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
-msgid "XCTherm email"
-msgstr "XCTherm-e-post"
+msgid "XC Therm email"
+msgstr "XC Therm-e-post"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-postadress for ditt XCTherm-konto."
+msgid "Email address for your XC Therm account."
+msgstr "E-postadress for ditt XC Therm-konto."
 
-msgid "XCTherm password"
-msgstr "XCTherm-passord"
+msgid "XC Therm password"
+msgstr "XC Therm-passord"
 
-msgid "Password for your XCTherm account."
-msgstr "Passord for XCTherm-kontoen din."
+msgid "Password for your XC Therm account."
+msgstr "Passord for XC Therm-kontoen din."
 
-msgid "XCTherm region"
-msgstr "XCTherm-region"
+msgid "XC Therm region"
+msgstr "XC Therm-region"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Varselregion. Endrer hvilken modell XCTherm henter data fra. Start på nytt "
+"Varselregion. Endrer hvilken modell XC Therm henter data fra. Start på nytt "
 "eller last ned igjen etter endring."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto lager/tid"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto lager/tid"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10201,8 +10201,8 @@ msgstr "Inget lager valt."
 msgid "Network is not available."
 msgstr "Nettverket er ikke tilgjengeligt."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Varselindexet har ingen XCTherm-parametrar."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Varselindexet har ingen XC Therm-parametrar."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10324,12 +10324,12 @@ msgid "HTTP support"
 msgstr "HTTP-støtte"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Laster ned XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Laster ned XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Laster ned XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Laster ned XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "Aktiver live tracking via SkyLines-servern (tracking.skylines.aero)."

--- a/po/nb.po
+++ b/po/nb.po
@@ -9891,19 +9891,19 @@ msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
 msgid "XC Therm email"
-msgstr "XC Therm-e-post"
+msgstr "XC Therm e-post"
 
 msgid "Email address for your XC Therm account."
-msgstr "E-postadress for ditt XC Therm-konto."
+msgstr "E-postadresse for kontoen din hos XC Therm."
 
 msgid "XC Therm password"
-msgstr "XC Therm-passord"
+msgstr "XC Therm passord"
 
 msgid "Password for your XC Therm account."
-msgstr "Passord for XC Therm-kontoen din."
+msgstr "Passord for kontoen din hos XC Therm."
 
 msgid "XC Therm region"
-msgstr "XC Therm-region"
+msgstr "XC Therm region"
 
 msgid ""
 "Forecast region. Changes which model XC Therm fetches data from. Restart or "
@@ -10202,7 +10202,7 @@ msgid "Network is not available."
 msgstr "Nettverket er ikke tilgjengeligt."
 
 msgid "Forecast index has no XC Therm parameters."
-msgstr "Varselindexet har ingen XC Therm-parametrar."
+msgstr "Varselindexet har ingen parametere for XC Therm."
 
 msgid ""
 "Forecast download failed.\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -10032,30 +10032,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Verenigd Koninkrijk. ICON-UK-model."
 
-msgid "XCTherm email"
-msgstr "XCTherm-e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm-e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mailadres van je XCTherm-account."
+msgid "Email address for your XC Therm account."
+msgstr "E-mailadres van je XC Therm-account."
 
-msgid "XCTherm password"
-msgstr "XCTherm-wachtwoord"
+msgid "XC Therm password"
+msgstr "XC Therm-wachtwoord"
 
-msgid "Password for your XCTherm account."
-msgstr "Wachtwoord van je XCTherm-account."
+msgid "Password for your XC Therm account."
+msgstr "Wachtwoord van je XC Therm-account."
 
-msgid "XCTherm region"
-msgstr "XCTherm-regio"
+msgid "XC Therm region"
+msgstr "XC Therm-regio"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Prognoseregio. Bepaalt welk model XCTherm gebruikt. Herstart of download "
+"Prognoseregio. Bepaalt welk model XC Therm gebruikt. Herstart of download "
 "opnieuw na wijziging."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm Auto Laag/Tijd"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm Auto Laag/Tijd"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10345,8 +10345,8 @@ msgstr "Geen laag geselecteerd."
 msgid "Network is not available."
 msgstr "Netwerk is niet beschikbaar."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Prognose-index heeft geen XCTherm-parameters."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Prognose-index heeft geen XC Therm-parameters."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10468,12 +10468,12 @@ msgid "HTTP support"
 msgstr "HTTP-ondersteuning"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "XCTherm %s downloaden (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "XC Therm %s downloaden (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "XCTherm %s downloaden..."
+msgid "Downloading XC Therm %s..."
+msgstr "XC Therm %s downloaden..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -10033,19 +10033,19 @@ msgid "United Kingdom. ICON-UK model."
 msgstr "Verenigd Koninkrijk. ICON-UK-model."
 
 msgid "XC Therm email"
-msgstr "XC Therm-e-mail"
+msgstr "XC Therm e-mail"
 
 msgid "Email address for your XC Therm account."
-msgstr "E-mailadres van je XC Therm-account."
+msgstr "E-mailadres van je account bij XC Therm."
 
 msgid "XC Therm password"
-msgstr "XC Therm-wachtwoord"
+msgstr "XC Therm wachtwoord"
 
 msgid "Password for your XC Therm account."
-msgstr "Wachtwoord van je XC Therm-account."
+msgstr "Wachtwoord van je account bij XC Therm."
 
 msgid "XC Therm region"
-msgstr "XC Therm-regio"
+msgstr "XC Therm regio"
 
 msgid ""
 "Forecast region. Changes which model XC Therm fetches data from. Restart or "
@@ -10346,7 +10346,7 @@ msgid "Network is not available."
 msgstr "Netwerk is niet beschikbaar."
 
 msgid "Forecast index has no XC Therm parameters."
-msgstr "Prognose-index heeft geen XC Therm-parameters."
+msgstr "Prognose-index heeft geen parameters van XC Therm."
 
 msgid ""
 "Forecast download failed.\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -10032,30 +10032,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Zjednoczone Królestwo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Adres e-mail konta XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Adres e-mail konta XC Therm."
 
-msgid "XCTherm password"
-msgstr "Hasło XCTherm"
+msgid "XC Therm password"
+msgstr "Hasło XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Hasło konta XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Hasło konta XC Therm."
 
-msgid "XCTherm region"
-msgstr "Region XCTherm"
+msgid "XC Therm region"
+msgstr "Region XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Region prognozy. Zmienia model, z którego XCTherm pobiera dane. Po zmianie "
+"Region prognozy. Zmienia model, z którego XC Therm pobiera dane. Po zmianie "
 "uruchom ponownie lub pobierz na nowo."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Auto warstwa/czas XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Auto warstwa/czas XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10345,8 +10345,8 @@ msgstr "Nie wybrano warstwy."
 msgid "Network is not available."
 msgstr "Sieć jest niedostępna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks prognozy nie ma parametrów XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks prognozy nie ma parametrów XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10468,12 +10468,12 @@ msgid "HTTP support"
 msgstr "Obsługa HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Pobieranie XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Pobieranie XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Pobieranie XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Pobieranie XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -9992,30 +9992,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Reino Unido. Modelo ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Endereço de e-mail da sua conta XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Endereço de e-mail da sua conta XC Therm."
 
-msgid "XCTherm password"
-msgstr "Palavra-passe XCTherm"
+msgid "XC Therm password"
+msgstr "Palavra-passe XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Palavra-passe da sua conta XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Palavra-passe da sua conta XC Therm."
 
-msgid "XCTherm region"
-msgstr "Região XCTherm"
+msgid "XC Therm region"
+msgstr "Região XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Região de previsão. Altera o modelo de onde o XCTherm obtém dados. Reinicie "
+"Região de previsão. Altera o modelo de onde o XC Therm obtém dados. Reinicie "
 "ou volte a transferir após alterar."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Camada/Hora auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Camada/Hora auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10306,8 +10306,8 @@ msgstr "Nenhuma camada selecionada."
 msgid "Network is not available."
 msgstr "A rede não está disponível."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "O índice de previsão não tem parâmetros XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "O índice de previsão não tem parâmetros XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10429,12 +10429,12 @@ msgid "HTTP support"
 msgstr "Suporte HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "A transferir XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "A transferir XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "A transferir XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "A transferir XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9989,30 +9989,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Reino Unido. Modelo ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Endereço de e-mail da sua conta XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Endereço de e-mail da sua conta XC Therm."
 
-msgid "XCTherm password"
-msgstr "Senha XCTherm"
+msgid "XC Therm password"
+msgstr "Senha XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Senha da sua conta XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Senha da sua conta XC Therm."
 
-msgid "XCTherm region"
-msgstr "Região XCTherm"
+msgid "XC Therm region"
+msgstr "Região XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Região de previsão. Altera o modelo de onde o XCTherm obtém dados. Reinicie "
+"Região de previsão. Altera o modelo de onde o XC Therm obtém dados. Reinicie "
 "ou volte baixando após alterar."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Camada/Hora auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Camada/Hora auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10303,8 +10303,8 @@ msgstr "Nenhuma camada selecionada."
 msgid "Network is not available."
 msgstr "A rede não está disponível."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "O índice de previsão não tem parâmetros XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "O índice de previsão não tem parâmetros XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10426,12 +10426,12 @@ msgid "HTTP support"
 msgstr "Suporte HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Baixando XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Baixando XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Baixando XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Baixando XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/ro.po
+++ b/po/ro.po
@@ -9981,30 +9981,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Regatul Unit. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Email XCTherm"
+msgid "XC Therm email"
+msgstr "Email XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Adresa de e-mail a contului XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Adresa de e-mail a contului XC Therm."
 
-msgid "XCTherm password"
-msgstr "Parolă XCTherm"
+msgid "XC Therm password"
+msgstr "Parolă XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Parolă del tuo account XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Parolă del tuo account XC Therm."
 
-msgid "XCTherm region"
-msgstr "Regione XCTherm"
+msgid "XC Therm region"
+msgstr "Regione XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regiune de prognoză. Schimbă modelul din care XCTherm preia date. Reporniți "
+"Regiune de prognoză. Schimbă modelul din care XC Therm preia date. Reporniți "
 "sau re-descărcați după modificare."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Strat/Ora auto XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Strat/Ora auto XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10294,8 +10294,8 @@ msgstr "Niciuno strat selecteazăto."
 msgid "Network is not available."
 msgstr "Rețea non disponibile."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "L'indice di previsione non ha parametri XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "L'indice di previsione non ha parametri XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10417,12 +10417,12 @@ msgid "HTTP support"
 msgstr "Supporto HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Download XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Download XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Download XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Download XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -10020,30 +10020,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Соединённое Королевство. Модель ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Эл. почта XCTherm"
+msgid "XC Therm email"
+msgstr "Эл. почта XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Адрес эл. почты вашей учётной записи XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Адрес эл. почты вашей учётной записи XC Therm."
 
-msgid "XCTherm password"
-msgstr "Пароль XCTherm"
+msgid "XC Therm password"
+msgstr "Пароль XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Пароль вашей учётной записи XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Пароль вашей учётной записи XC Therm."
 
-msgid "XCTherm region"
-msgstr "Регион XCTherm"
+msgid "XC Therm region"
+msgstr "Регион XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Регион прогноза. Меняет модель, из которой XCTherm загружает данные. После "
+"Регион прогноза. Меняет модель, из которой XC Therm загружает данные. После "
 "изменения перезапустите или загрузите заново."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Авто слой/время XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Авто слой/время XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10333,8 +10333,8 @@ msgstr "Слой не выбран."
 msgid "Network is not available."
 msgstr "Сеть недоступна."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Индекс прогноза не содержит параметров XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Индекс прогноза не содержит параметров XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10456,12 +10456,12 @@ msgid "HTTP support"
 msgstr "Поддержка HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Загрузка XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Загрузка XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Загрузка XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Загрузка XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/sk.po
+++ b/po/sk.po
@@ -9950,30 +9950,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Spolené království. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "E-mail XCTherm"
+msgid "XC Therm email"
+msgstr "E-mail XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mailová adresa účtu XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "E-mailová adresa účtu XC Therm."
 
-msgid "XCTherm password"
-msgstr "Heslo XCTherm"
+msgid "XC Therm password"
+msgstr "Heslo XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Heslo účtu XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Heslo účtu XC Therm."
 
-msgid "XCTherm region"
-msgstr "Region XCTherm"
+msgid "XC Therm region"
+msgstr "Region XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Region predpovědi. Mění model, ze ktorého XCTherm stahuje dáta. Po změně "
+"Region predpovědi. Mění model, ze ktorého XC Therm stahuje dáta. Po změně "
 "restartujte alebo stáhněte znova."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto vrstva/čas"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto vrstva/čas"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10262,8 +10262,8 @@ msgstr "Nie je vybrána žádná vrstva."
 msgid "Network is not available."
 msgstr "Sieť nie je dostupná."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Index predpovědi nemá parametery XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Index predpovědi nemá parametery XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10385,12 +10385,12 @@ msgid "HTTP support"
 msgstr "Podpora HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Sťahovanie XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Sťahovanie XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Sťahovanie XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Sťahovanie XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -9925,30 +9925,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm geslo"
+msgid "XC Therm password"
+msgstr "XC Therm geslo"
 
-msgid "Password for your XCTherm account."
-msgstr "Geslo XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Geslo XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regija napovedi. Mijenja model s kojeg XCTherm dohvaća podatke. Nakon "
+"Regija napovedi. Mijenja model s kojeg XC Therm dohvaća podatke. Nakon "
 "promjene ponovno pokrenite ili ponovno prenesite."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto plast/čas"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto plast/čas"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10237,8 +10237,8 @@ msgstr "Nije odabran plast."
 msgid "Network is not available."
 msgstr "Omrežje nije na voljo."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks napovedi nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks napovedi nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10360,12 +10360,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Prenos XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Prenos XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Prenos XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Prenos XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -9934,30 +9934,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm lozinka"
+msgid "XC Therm password"
+msgstr "XC Therm lozinka"
 
-msgid "Password for your XCTherm account."
-msgstr "Lozinka XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Lozinka XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Regija prognoze. Mijenja model s kojeg XCTherm dohvaća podatke. Nakon "
+"Regija prognoze. Mijenja model s kojeg XC Therm dohvaća podatke. Nakon "
 "promjene ponovno pokrenite ili ponovno preuzmite."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto sloj/vreme"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto sloj/vreme"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10247,8 +10247,8 @@ msgstr "Nije odabran sloj."
 msgid "Network is not available."
 msgstr "Mreža nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks prognoze nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks prognoze nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10370,12 +10370,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Preuzimanje XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Preuzimanje XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Preuzimanje XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Preuzimanje XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -9895,30 +9895,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
-msgid "XCTherm email"
-msgstr "XCTherm-e-post"
+msgid "XC Therm email"
+msgstr "XC Therm-e-post"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-postadress för ditt XCTherm-konto."
+msgid "Email address for your XC Therm account."
+msgstr "E-postadress för ditt XC Therm-konto."
 
-msgid "XCTherm password"
-msgstr "XCTherm-lösenord"
+msgid "XC Therm password"
+msgstr "XC Therm-lösenord"
 
-msgid "Password for your XCTherm account."
-msgstr "Lösenord för ditt XCTherm-konto."
+msgid "Password for your XC Therm account."
+msgstr "Lösenord för ditt XC Therm-konto."
 
-msgid "XCTherm region"
-msgstr "XCTherm-region"
+msgid "XC Therm region"
+msgstr "XC Therm-region"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Prognosregion. Ändrar vilken modell XCTherm hämtar data från. Starta om "
+"Prognosregion. Ändrar vilken modell XC Therm hämtar data från. Starta om "
 "eller ladda ner igen efter ändring."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto lager/tid"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto lager/tid"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10207,8 +10207,8 @@ msgstr "Inget lager valt."
 msgid "Network is not available."
 msgstr "Nätverket är inte tillgängligt."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Prognosindexet har inga XCTherm-parametrar."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Prognosindexet har inga XC Therm-parametrar."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10330,12 +10330,12 @@ msgid "HTTP support"
 msgstr "HTTP-stöd"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Laddar ner XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Laddar ner XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Laddar ner XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Laddar ner XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "Aktivera live tracking via SkyLines-servern (tracking.skylines.aero)."

--- a/po/sv.po
+++ b/po/sv.po
@@ -9896,19 +9896,19 @@ msgid "United Kingdom. ICON-UK model."
 msgstr "Storbritannien. ICON-UK-modell."
 
 msgid "XC Therm email"
-msgstr "XC Therm-e-post"
+msgstr "XC Therm e-post"
 
 msgid "Email address for your XC Therm account."
-msgstr "E-postadress för ditt XC Therm-konto."
+msgstr "E-postadress för ditt konto hos XC Therm."
 
 msgid "XC Therm password"
-msgstr "XC Therm-lösenord"
+msgstr "XC Therm lösenord"
 
 msgid "Password for your XC Therm account."
-msgstr "Lösenord för ditt XC Therm-konto."
+msgstr "Lösenord för ditt konto hos XC Therm."
 
 msgid "XC Therm region"
-msgstr "XC Therm-region"
+msgstr "XC Therm region"
 
 msgid ""
 "Forecast region. Changes which model XC Therm fetches data from. Restart or "
@@ -10208,7 +10208,7 @@ msgid "Network is not available."
 msgstr "Nätverket är inte tillgängligt."
 
 msgid "Forecast index has no XC Therm parameters."
-msgstr "Prognosindexet har inga XC Therm-parametrar."
+msgstr "Prognosindexet har inga parametrar för XC Therm."
 
 msgid ""
 "Forecast download failed.\n"

--- a/po/te.po
+++ b/po/te.po
@@ -9762,30 +9762,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm పాస్‌వర్డ్"
+msgid "XC Therm password"
+msgstr "XC Therm పాస్‌వర్డ్"
 
-msgid "Password for your XCTherm account."
-msgstr "పాస్‌వర్డ్ XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "పాస్‌వర్డ్ XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"సూచన ప్రాంతం. ఏ మోడల్ XCTherm నుండి డేటాను పొందాలో మారుస్తుంది. మార్చిన "
+"సూచన ప్రాంతం. ఏ మోడల్ XC Therm నుండి డేటాను పొందాలో మారుస్తుంది. మార్చిన "
 "తర్వాత పునఃప్రారంభించండి లేదా మళ్లీ డౌన్‌లోడ్ చేయండి."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto లేయర్/సమయం"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto లేయర్/సమయం"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10075,8 +10075,8 @@ msgstr "Nije odabran లేయర్."
 msgid "Network is not available."
 msgstr "నెట్‌వర్క్ nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks అంచనా nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks అంచనా nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10198,12 +10198,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "డౌన్‌లోడ్ XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "డౌన్‌లోడ్ XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "డౌన్‌లోడ్ XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "డౌన్‌లోడ్ XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -9946,30 +9946,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Birleşik Krallık. ICON-UK modeli."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm parola"
+msgid "XC Therm password"
+msgstr "XC Therm parola"
 
-msgid "Password for your XCTherm account."
-msgstr "Parola XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Parola XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Tahmin bölgesi. XCTherm'nin hangi modelden veri alacağını değiştirir. "
+"Tahmin bölgesi. XC Therm'nin hangi modelden veri alacağını değiştirir. "
 "Değiştirdikten sonra yeniden başlatın veya yeniden indirin."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto katman/zaman"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto katman/zaman"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10259,8 +10259,8 @@ msgstr "Nije odabran katman."
 msgid "Network is not available."
 msgstr "Ağ nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks tahmin nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks tahmin nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10382,12 +10382,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "İndirme XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "İndirme XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "İndirme XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "İndirme XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -10019,30 +10019,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Сполучене Королівство. Модель ICON-UK."
 
-msgid "XCTherm email"
-msgstr "Ел. пошта XCTherm"
+msgid "XC Therm email"
+msgstr "Ел. пошта XC Therm"
 
-msgid "Email address for your XCTherm account."
-msgstr "Адреса ел. пошти вашого облікового запису XCTherm."
+msgid "Email address for your XC Therm account."
+msgstr "Адреса ел. пошти вашого облікового запису XC Therm."
 
-msgid "XCTherm password"
-msgstr "Пароль XCTherm"
+msgid "XC Therm password"
+msgstr "Пароль XC Therm"
 
-msgid "Password for your XCTherm account."
-msgstr "Пароль вашого облікового запису XCTherm."
+msgid "Password for your XC Therm account."
+msgstr "Пароль вашого облікового запису XC Therm."
 
-msgid "XCTherm region"
-msgstr "Регион XCTherm"
+msgid "XC Therm region"
+msgstr "Регион XC Therm"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Регіон прогнозу. Змінює модель, з якої XCTherm завантажує дані. Після зміни "
+"Регіон прогнозу. Змінює модель, з якої XC Therm завантажує дані. Після зміни "
 "перезапустіть або завантажте знову."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "Авто шар/час XCTherm"
+msgid "XC Therm Auto Layer/Time"
+msgstr "Авто шар/час XC Therm"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10332,8 +10332,8 @@ msgstr "Шар не вибрано."
 msgid "Network is not available."
 msgstr "Мережа недоступна."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Індекс прогнозу не містить параметрів XCTherm."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Індекс прогнозу не містить параметрів XC Therm."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10455,12 +10455,12 @@ msgid "HTTP support"
 msgstr "Поддержка HTTP"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Завантаження XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Завантаження XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Завантаження XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Завантаження XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -9902,30 +9902,30 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "Vương quốc Anh. Mô hình ICON-UK."
 
-msgid "XCTherm email"
-msgstr "XCTherm e-mail"
+msgid "XC Therm email"
+msgstr "XC Therm e-mail"
 
-msgid "Email address for your XCTherm account."
-msgstr "E-mail adresa XCTherm računa."
+msgid "Email address for your XC Therm account."
+msgstr "E-mail adresa XC Therm računa."
 
-msgid "XCTherm password"
-msgstr "XCTherm mật khẩu"
+msgid "XC Therm password"
+msgstr "XC Therm mật khẩu"
 
-msgid "Password for your XCTherm account."
-msgstr "Mật khẩu XCTherm računa."
+msgid "Password for your XC Therm account."
+msgstr "Mật khẩu XC Therm računa."
 
-msgid "XCTherm region"
-msgstr "XCTherm regija"
+msgid "XC Therm region"
+msgstr "XC Therm regija"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
 msgstr ""
-"Khu vực dự báo. Thay đổi mô hình mà XCTherm dùng để tải dữ liệu. Sau khi "
+"Khu vực dự báo. Thay đổi mô hình mà XC Therm dùng để tải dữ liệu. Sau khi "
 "thay đổi, hãy khởi động lại hoặc tải xuống lại."
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm auto lớp/thời gian"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm auto lớp/thời gian"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -10215,8 +10215,8 @@ msgstr "Nije odabran lớp."
 msgid "Network is not available."
 msgstr "Mạng nije dostupna."
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "Indeks dự báo nema XCTherm parametre."
+msgid "Forecast index has no XC Therm parameters."
+msgstr "Indeks dự báo nema XC Therm parametre."
 
 msgid ""
 "Forecast download failed.\n"
@@ -10338,12 +10338,12 @@ msgid "HTTP support"
 msgstr "HTTP podrška"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "Đang tải XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "Đang tải XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "Đang tải XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "Đang tải XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr ""

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xcsoar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-12 23:20+0200\n"
+"POT-Creation-Date: 2026-08-20 22:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6183,25 +6183,25 @@ msgstr ""
 msgid "United Kingdom. ICON-UK model."
 msgstr ""
 
-msgid "XCTherm email"
+msgid "XC Therm email"
 msgstr ""
 
-msgid "Email address for your XCTherm account."
+msgid "Email address for your XC Therm account."
 msgstr ""
 
-msgid "XCTherm password"
+msgid "XC Therm password"
 msgstr ""
 
-msgid "Password for your XCTherm account."
+msgid "Password for your XC Therm account."
 msgstr ""
 
-msgid "XCTherm region"
+msgid "XC Therm region"
 msgstr ""
 
-msgid "Forecast region. Changes which model XCTherm fetches data from. Restart or re-download after changing."
+msgid "Forecast region. Changes which model XC Therm fetches data from. Restart or re-download after changing."
 msgstr ""
 
-msgid "XCTherm Auto Layer/Time"
+msgid "XC Therm Auto Layer/Time"
 msgstr ""
 
 msgid "Automatically switch altitude layer based on GPS altitude and forecast time based on UTC clock."
@@ -7008,7 +7008,7 @@ msgstr ""
 msgid "Network is not available."
 msgstr ""
 
-msgid "Forecast index has no XCTherm parameters."
+msgid "Forecast index has no XC Therm parameters."
 msgstr ""
 
 msgid ""
@@ -7357,11 +7357,11 @@ msgid "No TAF available!"
 msgstr ""
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
 msgstr ""
 
 #, c-format
-msgid "Downloading XCTherm %s..."
+msgid "Downloading XC Therm %s..."
 msgstr ""
 
 #, no-c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9596,28 +9596,28 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "英国。ICON-UK 模式。"
 
-msgid "XCTherm email"
-msgstr "XCTherm 邮箱"
+msgid "XC Therm email"
+msgstr "XC Therm 邮箱"
 
-msgid "Email address for your XCTherm account."
-msgstr "XCTherm 账户的电子邮箱地址。"
+msgid "Email address for your XC Therm account."
+msgstr "XC Therm 账户的电子邮箱地址。"
 
-msgid "XCTherm password"
-msgstr "XCTherm 密码"
+msgid "XC Therm password"
+msgstr "XC Therm 密码"
 
-msgid "Password for your XCTherm account."
-msgstr "XCTherm 账户的密码。"
+msgid "Password for your XC Therm account."
+msgstr "XC Therm 账户的密码。"
 
-msgid "XCTherm region"
-msgstr "XCTherm 区域"
+msgid "XC Therm region"
+msgstr "XC Therm 区域"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
-msgstr "预报区域。更改 XCTherm 获取数据所用的模式。更改后请重启或重新下载。"
+msgstr "预报区域。更改 XC Therm 获取数据所用的模式。更改后请重启或重新下载。"
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm 自动图层/时间"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm 自动图层/时间"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -9896,8 +9896,8 @@ msgstr "未选择图层。"
 msgid "Network is not available."
 msgstr "网络不可用。"
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "预报索引没有 XCTherm 参数。"
+msgid "Forecast index has no XC Therm parameters."
+msgstr "预报索引没有 XC Therm 参数。"
 
 msgid ""
 "Forecast download failed.\n"
@@ -10006,12 +10006,12 @@ msgid "HTTP support"
 msgstr "HTTP 支持"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "正在下载 XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "正在下载 XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "正在下载 XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "正在下载 XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "通过 SkyLines 服务器（tracking.skylines.aero）启用实时跟踪。"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -9604,28 +9604,28 @@ msgstr "UK"
 msgid "United Kingdom. ICON-UK model."
 msgstr "英國。ICON-UK 模式。"
 
-msgid "XCTherm email"
-msgstr "XCTherm 信箱"
+msgid "XC Therm email"
+msgstr "XC Therm 信箱"
 
-msgid "Email address for your XCTherm account."
-msgstr "XCTherm 帳戶的電子郵件地址。"
+msgid "Email address for your XC Therm account."
+msgstr "XC Therm 帳戶的電子郵件地址。"
 
-msgid "XCTherm password"
-msgstr "XCTherm 密碼"
+msgid "XC Therm password"
+msgstr "XC Therm 密碼"
 
-msgid "Password for your XCTherm account."
-msgstr "XCTherm 帳戶的密碼。"
+msgid "Password for your XC Therm account."
+msgstr "XC Therm 帳戶的密碼。"
 
-msgid "XCTherm region"
-msgstr "XCTherm 區域"
+msgid "XC Therm region"
+msgstr "XC Therm 區域"
 
 msgid ""
-"Forecast region. Changes which model XCTherm fetches data from. Restart or "
+"Forecast region. Changes which model XC Therm fetches data from. Restart or "
 "re-download after changing."
-msgstr "預報區域。更改 XCTherm 取得資料所用的模式。更改後請重新啟動或重新下載。"
+msgstr "預報區域。更改 XC Therm 取得資料所用的模式。更改後請重新啟動或重新下載。"
 
-msgid "XCTherm Auto Layer/Time"
-msgstr "XCTherm 自動圖層/時間"
+msgid "XC Therm Auto Layer/Time"
+msgstr "XC Therm 自動圖層/時間"
 
 msgid ""
 "Automatically switch altitude layer based on GPS altitude and forecast time "
@@ -9904,8 +9904,8 @@ msgstr "未選擇圖層。"
 msgid "Network is not available."
 msgstr "網路不可用。"
 
-msgid "Forecast index has no XCTherm parameters."
-msgstr "預報索引沒有 XCTherm 參數。"
+msgid "Forecast index has no XC Therm parameters."
+msgstr "預報索引沒有 XC Therm 參數。"
 
 msgid ""
 "Forecast download failed.\n"
@@ -10014,12 +10014,12 @@ msgid "HTTP support"
 msgstr "HTTP 支援"
 
 #, c-format
-msgid "Downloading XCTherm %s (%u/%u)..."
-msgstr "正在下載 XCTherm %s (%u/%u)..."
+msgid "Downloading XC Therm %s (%u/%u)..."
+msgstr "正在下載 XC Therm %s (%u/%u)..."
 
 #, c-format
-msgid "Downloading XCTherm %s..."
-msgstr "正在下載 XCTherm %s..."
+msgid "Downloading XC Therm %s..."
+msgstr "正在下載 XC Therm %s..."
 
 msgid "Enable live tracking via the SkyLines server (tracking.skylines.aero)."
 msgstr "透過 SkyLines 伺服器（tracking.skylines.aero）啟用即時追蹤。"

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -436,7 +436,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
     { PageLayout::Overlay::EDL, NC_("Abbreviation", "EDL") },
 #endif
 #ifdef HAVE_HTTP
-    { PageLayout::Overlay::XCTHERM, "XCTherm" },
+    { PageLayout::Overlay::XCTHERM, "XC Therm" },
     { PageLayout::Overlay::SKYSIGHT, "SkySight" },
 #endif
     nullptr

--- a/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
@@ -50,21 +50,21 @@ XCThermConfigPanel::Prepare(ContainerWindow &parent,
 
   RowFormWidget::Prepare(parent, rc);
 
-  AddText(_("XCTherm email"),
-          _("Email address for your XCTherm account."),
+  AddText(_("XC Therm email"),
+          _("Email address for your XC Therm account."),
           settings.xctherm.credentials.email);
 
-  AddPassword(_("XCTherm password"),
-              _("Password for your XCTherm account."),
+  AddPassword(_("XC Therm password"),
+              _("Password for your XC Therm account."),
               settings.xctherm.credentials.password);
 
-  AddEnum(_("XCTherm region"),
-          _("Forecast region. Changes which model XCTherm fetches data "
+  AddEnum(_("XC Therm region"),
+          _("Forecast region. Changes which model XC Therm fetches data "
             "from. Restart or re-download after changing."),
           xctherm_region_list,
           settings.xctherm.model);
 
-  AddBoolean(_("XCTherm Auto Layer/Time"),
+  AddBoolean(_("XC Therm Auto Layer/Time"),
              _("Automatically switch altitude layer based on GPS altitude "
                "and forecast time based on UTC clock."),
              settings.xctherm.auto_switch);

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -147,7 +147,7 @@ static constexpr TabMenuPage weather_pages[] = {
   { "Flugwetter (pc_met)", CreatePCMetConfigPanel },
 #endif
 #ifdef HAVE_HTTP
-  { "XCTherm", CreateXCThermConfigPanel },
+  { "XC Therm", CreateXCThermConfigPanel },
 #endif
   { nullptr, nullptr }
 };

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -152,7 +152,7 @@ ShowWeatherDialog(const char *page)
   if (page != nullptr && StringIsEqual(page, "xctherm"))
     start_page = widget.GetSize();
 
-  widget.AddTab(CreateXCThermTabWidget(), "XCTherm");
+  widget.AddTab(CreateXCThermTabWidget(), "XC Therm");
 #endif
 
   if (page != nullptr && StringIsEqual(page, "rasp"))

--- a/src/Dialogs/Weather/XCThermDialog.cpp
+++ b/src/Dialogs/Weather/XCThermDialog.cpp
@@ -453,7 +453,7 @@ XCThermWidget::StartDownload() noexcept
 
   const auto &region = XCTherm::GetRegion(settings.model);
   if (selected_layer >= region.layer_count) {
-    ShowMessageBox(_("No layer selected."), "XCTherm", MB_OK);
+    ShowMessageBox(_("No layer selected."), "XC Therm", MB_OK);
     return;
   }
 
@@ -467,7 +467,7 @@ XCThermWidget::StartDownload() noexcept
     });
   if (active_job == nullptr) {
     if (GetXCThermDownloadGlue() == nullptr || Net::curl == nullptr)
-      ShowMessageBox(_("Network is not available."), "XCTherm", MB_OK);
+      ShowMessageBox(_("Network is not available."), "XC Therm", MB_OK);
     return;
   }
 
@@ -539,13 +539,13 @@ XCThermWidget::FinishDownload() noexcept
     UpdateStatusControl();
     if (!canceled) {
       if (job->index_no_parameters.load()) {
-        ShowMessageBox(_("Forecast index has no XCTherm parameters."),
-                       "XCTherm", MB_OK);
+        ShowMessageBox(_("Forecast index has no XC Therm parameters."),
+                       "XC Therm", MB_OK);
       } else if (job->error_eptr) {
-        ShowError(job->error_eptr, "XCTherm");
+        ShowError(job->error_eptr, "XC Therm");
       } else {
         ShowMessageBox(_("Forecast download failed.\nKeeping previous data."),
-                       "XCTherm", MB_OK);
+                       "XC Therm", MB_OK);
       }
     }
     return;
@@ -608,13 +608,13 @@ XCThermWidget::FinishDownload() noexcept
     PageActions::Update();
 
   if (job->error_eptr && !canceled) {
-    ShowError(job->error_eptr, "XCTherm");
+    ShowError(job->error_eptr, "XC Therm");
   } else if (any_miss && !canceled) {
     StaticString<128> msg;
     msg.Format(_("Got %u of %u hourly slices (%u newly downloaded).\n"
                  "Some slots were unavailable."),
                ok, span, nu);
-    ShowMessageBox(msg, "XCTherm", MB_OK);
+    ShowMessageBox(msg, "XC Therm", MB_OK);
   }
 }
 
@@ -629,7 +629,7 @@ XCThermWidget::DeleteClicked() noexcept
   const auto &region = XCTherm::GetRegion(settings.model);
 
   if (selected_layer >= region.layer_count) {
-    ShowMessageBox(_("No layer selected."), "XCTherm", MB_OK);
+    ShowMessageBox(_("No layer selected."), "XC Therm", MB_OK);
     return;
   }
 
@@ -756,7 +756,7 @@ XCThermWidget::Prepare(ContainerWindow &parent,
   time_help.Format(_("Forecast time for the current map page %s overlay. "
                      "Opens the same picker as the weather controls "
                      "(Auto, Now, or a UTC hour)."),
-                   "XCTherm");
+                   "XC Therm");
   auto *time = AddEnum(C_("Weather control", "Time"), time_help.c_str());
   time->SetEditCallback(EditTimeCallback);
 

--- a/src/PageOverlayTitle.cpp
+++ b/src/PageOverlayTitle.cpp
@@ -68,7 +68,7 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     break;
 
   case PageLayout::Overlay::XCTHERM:
-    builder.Append(", XCTherm");
+    builder.Append(", XC Therm");
 #ifdef HAVE_HTTP
     {
       builder.Append(' ');

--- a/src/Weather/MapOverlay/XcthermControlsModel.cpp
+++ b/src/Weather/MapOverlay/XcthermControlsModel.cpp
@@ -45,9 +45,9 @@ XcthermControlsModel::FormatPrimaryLabel(StaticString<64> &text) const noexcept
     backend.FormatTimeLabel(text);
   });
   if (text.empty())
-    text = "XCTherm";
+    text = "XC Therm";
 #else
-  text = "XCTherm";
+  text = "XC Therm";
 #endif
 }
 

--- a/src/Weather/xctherm/FieldControls.cpp
+++ b/src/Weather/xctherm/FieldControls.cpp
@@ -196,7 +196,7 @@ EditTimeOnLayout(PageLayout &page) noexcept
 
   const ComboList combo_list = field.CreateComboList(nullptr);
   StaticString<64> caption;
-  caption.Format("%s %s (UTC)", "XCTherm", C_("Weather control", "Time"));
+  caption.Format("%s %s (UTC)", "XC Therm", C_("Weather control", "Time"));
   const auto result =
     WeatherMapOverlay::RunTimePicker(caption.c_str(), combo_list);
 
@@ -268,7 +268,7 @@ EditLayerOnLayout(PageLayout &page, bool offer_setup) noexcept
   bool setup = false;
   const char *setup_caption = offer_setup ? C_("Button", "Setup") : nullptr;
   StaticString<64> caption;
-  caption.Format("%s %s", "XCTherm", C_("Weather control", "Altitude"));
+  caption.Format("%s %s", "XC Therm", C_("Weather control", "Altitude"));
   if (!ComboPicker(caption.c_str(), field, nullptr,
                    setup_caption, &setup))
     return setup ? LayerPickerResult::OPEN_SETUP

--- a/src/Weather/xctherm/XCThermDownload.cpp
+++ b/src/Weather/xctherm/XCThermDownload.cpp
@@ -57,10 +57,10 @@ UpdateDownloadProgressText(const XCThermDownloadJob &job) noexcept
 
   StaticString<128> text;
   if (slot > 0 && total > 0)
-    text.Format(_("Downloading XCTherm %s (%u/%u)..."),
+    text.Format(_("Downloading XC Therm %s (%u/%u)..."),
                 gettext(job.target_label.c_str()), slot, total);
   else
-    text.Format(_("Downloading XCTherm %s..."),
+    text.Format(_("Downloading XC Therm %s..."),
                 gettext(job.target_label.c_str()));
 
   BackgroundDownloadProgress::Get().SetText(text.c_str());

--- a/src/Weather/xctherm/XCThermDownloadGlue.cpp
+++ b/src/Weather/xctherm/XCThermDownloadGlue.cpp
@@ -65,7 +65,7 @@ XCThermDownloadGlue::Start(
   completion_error = {};
 
   StaticString<128> text;
-  text.Format(_("Downloading XCTherm %s..."),
+  text.Format(_("Downloading XC Therm %s..."),
               gettext(job->target_label.c_str()));
   BackgroundDownloadProgress::Get().Begin(text.c_str());
   BackgroundDownloadProgress::Get().SetProgressRange(100);

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -44,7 +44,7 @@ XCThermGeoJSONOverlay::SetForecast(
 {
   const std::lock_guard lock{mutex};
   forecast = std::move(_forecast);
-  label = _label != nullptr ? _label : "XCTherm";
+  label = _label != nullptr ? _label : "XC Therm";
   parameter = _parameter != nullptr ? _parameter : "";
   forecast_utc = _forecast_utc;
 }
@@ -163,7 +163,7 @@ XCThermGeoJSONOverlay::FormatPointInfo(const GeoPoint &p, char *buffer,
 const char *
 XCThermGeoJSONOverlay::GetLabel() const noexcept
 {
-  return "XCTherm";
+  return "XC Therm";
 }
 
 bool

--- a/test/src/PageOverlayTitleStub.cpp
+++ b/test/src/PageOverlayTitleStub.cpp
@@ -39,7 +39,7 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     break;
 
   case PageLayout::Overlay::XCTHERM:
-    builder.Append(", XCTherm");
+    builder.Append(", XC Therm");
     break;
 
   case PageLayout::Overlay::SKYSIGHT:


### PR DESCRIPTION
## Summary
- Rename user-facing **XCTherm** strings to **XC Therm** (setup, weather dialogs, map titles, download messages, configuration manual).
- Leave code identifiers, profile keys, and file names as `XCTherm`.
- Update translation catalogs so existing translations keep the new product name.

## Test plan
- [ ] Config → Setup → Weather: tab and fields say **XC Therm**
- [ ] Info → Weather: XC Therm tab, dialog captions, and download status use **XC Therm**
- [ ] Map page overlay title and weather cursor labels show **XC Therm**
- [ ] A translated UI (e.g. German) still shows the product name with a space