### PR TITLE
Device: Restore DumpPort wrapping for device Debug logging

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -31,6 +31,8 @@ Version 7.46 - not yet released
 * devices
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
+  - fix the Devices Debug button not writing port traffic to xcsoar.log
+    #2903
 * dialogs
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -215,15 +215,18 @@ try {
     parser.DisableGeoid();
 
   if (driver->CreateOnPort != nullptr) {
-    Device *new_device = driver->CreateOnPort(config, port->GetImplementationPort());
+    /* Pass DumpPort, not GetImplementationPort(): Devices Debug logs
+       driver Read/Write through this wrapper (#2903).  Drivers that
+       must downcast to a concrete port (Condor3Spectate) unwrap in
+       CreateOnPort. */
+    Device *new_device = driver->CreateOnPort(config, *port);
 
     const std::lock_guard lock{mutex};
     device = new_device;
 
     if (driver->HasPassThrough() && config.use_second_device &&
         second_driver->CreateOnPort != nullptr)
-      second_device = second_driver->CreateOnPort(config,
-                                                  port->GetImplementationPort());
+      second_device = second_driver->CreateOnPort(config, *port);
   } else
     port->StartRxThread();
 

--- a/src/Device/Driver/Condor3Spectate.cpp
+++ b/src/Device/Driver/Condor3Spectate.cpp
@@ -468,7 +468,8 @@ Condor3SpectateCreateOnPort([[maybe_unused]] const DeviceConfig &config,
                            Port &com_port)
 {
   auto *device = new Condor3SpectateDevice();
-  if (auto *spectate = dynamic_cast<SpectateFilePort *>(&com_port))
+  if (auto *spectate = dynamic_cast<SpectateFilePort *>(
+        &com_port.GetImplementationPort()))
     spectate->SetDevice(device);
   return device;
 }

--- a/src/Device/Port/DumpPort.hpp
+++ b/src/Device/Port/DumpPort.hpp
@@ -60,6 +60,11 @@ public:
     return *port;
   }
 
+  /**
+   * Unwrap this DumpPort (and any inner wrappers) so a driver can
+   * downcast to a concrete port type.  Do not pass this to
+   * CreateOnPort; that skips Debug I/O logging (#2903).
+   */
   Port &GetImplementationPort() noexcept override {
     return port->GetImplementationPort();
   }


### PR DESCRIPTION
## Summary
- Restores Devices → Debug hex dumps to `xcsoar.log` by passing `DumpPort` into `CreateOnPort` again (`Fixes #2903`).
- Condor 3 Spectate still unwraps with `GetImplementationPort()` so `SetDevice()` works after open/reconnect.

This is a v7.45 regression from `b0b173a1f0` (Condor 3 Spectate) and is labeled for **v7.45.1**.

## Test plan
- [ ] Devices → Debug on an LXNAV Nano (or similar logger), then Flight download: `xcsoar.log` contains `Write(`/`Read(`/hex dumps
- [ ] Condor 3 Spectate still injects multiplayer traffic after device open/reconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SkySight overlays that had no available layers.
  * Improved Devices Debug port traffic logging in `xcsoar.log`.
  * Improved device communication handling while preserving compatibility with existing drivers.

* **Documentation**
  * Added release-note entries describing these fixes in version 7.46.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->