### PR TITLE
Dialogs/ExportFlightsPanel: Shut down IGC cache before Asio

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -12,6 +12,7 @@ Version 7.46 - not yet released
     survive being swiped away in the app switcher
   - fix other apps' audio staying ducked after XCSoar plays a sound,
     and the audio vario cutting out when leaving settings #2609
+  - fix crash on exit after opening the flight export dialog
   - remove the thin white frame around full-screen dialogs (such as
     the Fly/Simulator screen), which no longer stop one pixel short of
     the display edge

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.cpp
@@ -40,6 +40,12 @@ static constexpr char EXPORT_FLIGHTS_SUBFOLDER[] = "xcsoar_flights";
 
 static IgcMetaCache igc_cache;
 
+void
+ShutdownExportFlightsPanel() noexcept
+{
+  igc_cache.Shutdown();
+}
+
 // Export job that runs in background thread
 struct ExportJob final : public Job {
   std::vector<Path> selected_files;

--- a/src/Dialogs/DataManagement/ExportFlightsPanel.hpp
+++ b/src/Dialogs/DataManagement/ExportFlightsPanel.hpp
@@ -7,3 +7,6 @@
  * Declaration for the Export Flights dialog (moved into DataManagement).
  */
 void ShowExportFlightsDialog();
+
+/** Releases the export-flight metadata cache before the Asio event loop. */
+void ShutdownExportFlightsPanel() noexcept;

--- a/src/IGC/IgcMetaCache.cpp
+++ b/src/IGC/IgcMetaCache.cpp
@@ -46,7 +46,7 @@ ParseBRecordTime(const char *line, BrokenTime &time,
 
 IgcMetaCache::~IgcMetaCache() noexcept
 {
-  CancelBackgroundFill();
+  Shutdown();
 }
 
 IgcMetaCache::CacheEntry
@@ -179,6 +179,13 @@ IgcMetaCache::CancelBackgroundFill() noexcept
 
   current_notify.store(nullptr);
   inject_task->Cancel();
+}
+
+void
+IgcMetaCache::Shutdown() noexcept
+{
+  CancelBackgroundFill();
+  inject_task.reset();
 }
 
 void

--- a/src/IGC/IgcMetaCache.hpp
+++ b/src/IGC/IgcMetaCache.hpp
@@ -64,6 +64,13 @@ public:
   void CancelBackgroundFill() noexcept;
 
   /**
+   * Releases resources which reference the Asio event loop.  This must be
+   * called before that event loop is destroyed when the cache has static
+   * storage duration.
+   */
+  void Shutdown() noexcept;
+
+  /**
    * Non-blocking. Returns immediately; completion is signalled via
    * `OnFillComplete()` and the `UI::Notify` passed to
    * `StartBackgroundFill()`.

--- a/src/XCSoar.cpp
+++ b/src/XCSoar.cpp
@@ -23,6 +23,7 @@
 #include "Audio/GlobalPCMMixer.hpp"
 #include "Audio/GlobalPCMResourcePlayer.hpp"
 #include "Audio/GlobalVolumeController.hpp"
+#include "Dialogs/DataManagement/ExportFlightsPanel.hpp"
 #include "system/Args.hpp"
 #include "io/async/GlobalAsioThread.hpp"
 #include "io/async/AsioThread.hpp"
@@ -79,6 +80,9 @@ Main()
   int ret = EXIT_FAILURE;
   if (Startup(screen_init.GetDisplay()))
     ret = CommonInterface::main_window->RunEventLoop();
+
+  /* The export-flight cache owns an InjectTask on the Asio event loop. */
+  ShutdownExportFlightsPanel();
 
   Shutdown();
 


### PR DESCRIPTION
An iOS crash report showed this static cache being destroyed after the Asio event loop.  Release the cache while the loop is still alive.

That prevents its InjectTask from removing an injected event through a destroyed event loop during process exit.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash that could occur when exiting the app after opening the flight export dialog.
  - Improved shutdown handling for background export-flight processing.
  - Ensured export-related resources are released safely before application shutdown.

- **Documentation**
  - Added an iOS release-note entry describing the Version 7.46 exit crash fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->