### PR TITLE
iOS: Save settings when the app enters the background

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,8 @@ Version 7.46 - not yet released
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit
 * iOS
+  - save the settings when the app moves to the background, so they
+    survive being swiped away in the app switcher
   - remove the thin white frame around full-screen dialogs (such as
     the Fly/Simulator screen), which no longer stop one pixel short of
     the display edge

--- a/build/main.mk
+++ b/build/main.mk
@@ -652,6 +652,7 @@ endif
 ifeq ($(TARGET_IS_DARWIN),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Apple/Services.cpp \
+	$(SRC)/Apple/BackgroundSave.cpp \
 	$(SRC)/Apple/SoundUtil.cpp \
 	$(SRC)/Apple/PathProvider.cpp \
 	$(SRC)/Apple/InternalSensors.cpp \

--- a/src/Apple/BackgroundSave.cpp
+++ b/src/Apple/BackgroundSave.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BackgroundSave.hpp"
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+
+#include "Startup.hpp"
+#include "LogFile.hpp"
+
+#include <SDL_events.h>
+
+/**
+ * Unlike events which are dispatched by our event loop, an SDL event
+ * watch runs synchronously inside the UIApplicationDelegate method
+ * which posted the event.  For the background transition, that is the
+ * only moment when iOS still lets us write to disk; once the delegate
+ * method has returned, the process gets suspended and may never be
+ * resumed.
+ */
+static int SDLCALL
+OnApplicationEvent([[maybe_unused]] void *ctx, SDL_Event *event) noexcept
+{
+  switch (event->type) {
+  case SDL_APP_DIDENTERBACKGROUND:
+  case SDL_APP_TERMINATING:
+    LogString("Entering background, saving user state");
+    SaveUserState();
+    break;
+  }
+
+  /* keep the event, it is none of our business */
+  return 1;
+}
+
+void
+InitializeAppleBackgroundSave() noexcept
+{
+  SDL_AddEventWatch(OnApplicationEvent, nullptr);
+}
+
+void
+DeinitializeAppleBackgroundSave() noexcept
+{
+  SDL_DelEventWatch(OnApplicationEvent, nullptr);
+}
+
+#else /* !TARGET_OS_IPHONE */
+
+void
+InitializeAppleBackgroundSave() noexcept
+{
+}
+
+void
+DeinitializeAppleBackgroundSave() noexcept
+{
+}
+
+#endif /* !TARGET_OS_IPHONE */

--- a/src/Apple/BackgroundSave.hpp
+++ b/src/Apple/BackgroundSave.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Start writing the user's settings to disk whenever iOS moves the app
+ * to the background.  A backgrounded app gets suspended, and a
+ * suspended app may be killed - by the user swiping it up in the app
+ * switcher, or by the system reclaiming memory - without ever running
+ * again, i.e. without another chance to persist anything.
+ *
+ * This is a no-op on macOS, which does not suspend applications.
+ */
+void
+InitializeAppleBackgroundSave() noexcept;
+
+void
+DeinitializeAppleBackgroundSave() noexcept;

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -130,6 +130,7 @@
 
 #ifdef __APPLE__
 #include "Apple/Services.hpp"
+#include "Apple/BackgroundSave.hpp"
 #endif
 
 #ifdef HAVE_EDL
@@ -400,6 +401,13 @@ Startup(UI::Display &display)
 
   if (!LoadProfile())
     return false;
+
+#ifdef __APPLE__
+  /* now that there is a profile to save, arm the "save on suspend"
+     hook; doing this any earlier could persist the still empty
+     profile map */
+  InitializeAppleBackgroundSave();
+#endif
 
   operation.SetText(_("Initialising"));
 
@@ -778,6 +786,14 @@ DestroyNetComponents() noexcept
 #endif
 
 void
+SaveUserState() noexcept
+{
+  SaveFlarmColors();
+  SaveFlarmMessaging();
+  Profile::Save();
+}
+
+void
 Shutdown()
 {
   VerboseOperationEnvironment operation;
@@ -787,6 +803,12 @@ Shutdown()
 
   // Turn off all displays first to prevent UI operations from blocking
   global_running = false;
+
+#ifdef __APPLE__
+  /* stop saving on suspend before we start tearing down the state
+     which SaveUserState() would touch */
+  DeinitializeAppleBackgroundSave();
+#endif
 
 #ifdef HAVE_HTTP
   if (main_window != nullptr)
@@ -832,12 +854,9 @@ Shutdown()
   }
 #endif
 
-  SaveFlarmColors();
-  SaveFlarmMessaging();
-
   // Save settings to profile
   operation.SetText(_("Shutdown, saving profile..."));
-  Profile::Save();
+  SaveUserState();
 
   operation.SetText(_("Shutdown, please wait..."));
 

--- a/src/Startup.hpp
+++ b/src/Startup.hpp
@@ -8,5 +8,14 @@ namespace UI { class Display; }
 bool
 Startup(UI::Display &display);
 
+/**
+ * Write all user state which is only kept in memory (the profile
+ * settings and the FLARM databases) to disk.  Apart from the regular
+ * shutdown, this is called whenever the operating system may kill the
+ * process without notifying us again, e.g. when iOS suspends the app.
+ */
+void
+SaveUserState() noexcept;
+
 void
 Shutdown();


### PR DESCRIPTION
Until now the profile was only written to disk during the regular shutdown. iOS never runs that code when the user swipes the app away in the app switcher: the app is suspended first, and the suspended process is killed without any further callback. Everything changed since the last explicit `Profile::Save()` was therefore lost (changing InfoBoxes onscreen with long press).

Register an SDL event watch which reacts to `SDL_APP_DIDENTERBACKGROUND` and `SDL_APP_TERMINATING`. Unlike our event loop, an event watch runs synchronously inside the `UIApplicationDelegate` method which posted the event, which is the last moment iOS lets us write to disk.

The saving itself moves into the new `SaveUserState()`, shared with `Shutdown()`, so the FLARM databases are persisted along with the profile. The watch is armed only after the profile has been loaded, so an early suspend cannot overwrite the profile with an empty map.

@yorickreum, could you please verify that this change is fine, particularly the `SDL_AddEventWatch` section?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iOS now automatically saves user settings when the app moves to the background or may be terminated.
  * User preferences and related state are preserved across app-switcher dismissal and unexpected app termination.

* **Bug Fixes**
  * Prevented recent settings changes from being lost when leaving the app on iOS.

* **Documentation**
  * Updated iOS release notes to describe automatic background saving in version 7.46.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->