### PR TITLE
Computer/Wind/CirclingWind: Restore wind without TAS or gyro

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -53,6 +53,9 @@ Version 7.46 - not yet released
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862
+* infoboxen
+  - show Airspeed TAS and IAS in blue when the value is estimated
+    from ground speed and wind instead of an instrument
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -38,6 +38,9 @@ Version 7.46 - not yet released
 * glide computer
   - fix best-glide speed and speed-to-fly at altitude when MacCready
     is set, so density scaling no longer inflates MacCready #2881
+  - fix circling wind staying blank on paragliders and other aircraft
+    without airspeed or a gyroscope, including fast IGC replay; polar
+    min-sink can lower GPS-only wind quality #2905
 * devices
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -41,6 +41,8 @@ Version 7.46 - not yet released
   - fix circling wind staying blank on paragliders and other aircraft
     without airspeed or a gyroscope, including fast IGC replay; polar
     min-sink can lower GPS-only wind quality #2905
+  - skip estimated TAS from ground speed and wind when GPS track is
+    missing
 * devices
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900

--- a/build/test.mk
+++ b/build/test.mk
@@ -90,7 +90,8 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
-	TestLogger TestGRecord TestClimbAvCalc TestFilteredVarioComputer \
+	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
+	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
 	TestWaypointReader TestThermalBase \
 	TestFlarmNet TestFlarmMessaging \
@@ -645,6 +646,15 @@ TEST_CLIMB_AV_CALC_SOURCES = \
 	$(TEST_SRC_DIR)/TestClimbAvCalc.cpp
 TEST_CLIMB_AV_CALC_DEPENDS = MATH
 $(eval $(call link-program,TestClimbAvCalc,TEST_CLIMB_AV_CALC))
+
+TEST_CIRCLING_WIND_SOURCES = \
+	$(SRC)/Computer/Wind/CirclingWind.cpp \
+	$(SRC)/Atmosphere/AirDensity.cpp \
+	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestCirclingWind.cpp
+TEST_CIRCLING_WIND_DEPENDS = LIBNMEA GEO MATH UTIL TIME FMT UNITS
+$(eval $(call link-program,TestCirclingWind,TEST_CIRCLING_WIND))
 
 TEST_FILTERED_VARIO_COMPUTER_SOURCES = \
 	$(SRC)/Atmosphere/AirDensity.cpp \

--- a/src/CalculationThread.cpp
+++ b/src/CalculationThread.cpp
@@ -5,6 +5,7 @@
 #include "Computer/GlideComputer.hpp"
 #include "Protection.hpp"
 #include "Blackboard/DeviceBlackboard.hpp"
+#include "Asset.hpp"
 #include "Hardware/CPU.hpp"
 
 /**
@@ -69,6 +70,7 @@ CalculationThread::Tick() noexcept
 
     // Copy data from DeviceBlackboard to GlideComputerBlackboard
     glide_computer.ReadBlackboard(device_blackboard.Basic());
+    replay_active = glide_computer.Basic().gps.replay;
   }
 
   bool force;
@@ -146,4 +148,15 @@ CalculationThread::ForceTrigger() noexcept
   }
 
   WorkerThread::Trigger();
+}
+
+CalculationThread::Duration
+CalculationThread::GetPeriodMin() const noexcept
+{
+  /* Fast LCD hosts: skip the 450 ms cap so 10x IGC replay still
+     feeds circling wind at ~1 Hz.  Idle stays 100 ms.  E-paper and
+     slow CPUs keep the limit; 1x replay already matches it. */
+  if (replay_active && !HasEPaper() && !IsSlowCPU())
+    return Duration{};
+  return WorkerThread::GetPeriodMin();
 }

--- a/src/CalculationThread.hpp
+++ b/src/CalculationThread.hpp
@@ -29,6 +29,13 @@ class CalculationThread final : public WorkerThread {
    */
   bool force;
 
+  /**
+   * Set from the last Tick() GPS.  On fast LCD hosts, replay skips the
+   * 450 ms period so 10x IGC still feeds circling wind.  E-paper and
+   * slow CPUs keep the limit.  Idle stays 100 ms.
+   */
+  bool replay_active = false;
+
   ComputerSettings settings_computer;
 
   double screen_distance_meters;
@@ -64,4 +71,6 @@ public:
 
 protected:
   void Tick() noexcept override;
+
+  Duration GetPeriodMin() const noexcept override;
 };

--- a/src/Computer/BasicComputer.cpp
+++ b/src/Computer/BasicComputer.cpp
@@ -181,8 +181,9 @@ ComputeAirspeed(NMEAInfo &basic, const DerivedInfo &calculated) noexcept
   }
 
   if (!basic.ground_speed_available || !calculated.wind_available ||
-      !calculated.flight.flying) {
-    /* impossible to calculate */
+      !calculated.flight.flying ||
+      (basic.ground_speed > 0 && !basic.track_available)) {
+    /* GS+wind TAS needs a track whenever ground speed is used */
     basic.airspeed_available.Clear();
     return;
   }

--- a/src/Computer/Wind/CirclingWind.cpp
+++ b/src/Computer/Wind/CirclingWind.cpp
@@ -10,6 +10,7 @@
 #include "Math/Util.hpp"
 #include "NMEA/CirclingInfo.hpp"
 #include "NMEA/MoreData.hpp"
+#include "time/FloatDuration.hxx"
 
 #include <algorithm>
 #include <cmath>
@@ -38,6 +39,11 @@ IMU, if available. IMU data is more reliable especially at higher wind speeds.
 The algorithm uses True Airspeed to compensate for changing airspeed during the
 circle. The algorithm also runs without the availability of True Airspeed, but
 then without this compensation.
+
+GPS track rate is not constant in wind when wind is a large fraction of
+airspeed (typical for paragliders). Without TAS or a gyroscope, the
+angular-rate roundness gate is therefore skipped. Quality comes from the
+cosine fit of ground speed, nudged by polar min-sink.
 
 Some of the errors made here will be averaged-out by the WindStore, which keeps
 a number of wind measurements and calculates a weighted average based on
@@ -77,7 +83,8 @@ void CirclingWind::ShowResources(const MoreData &info) noexcept {
 }
 
 CirclingWind::Result CirclingWind::NewSample(const MoreData &info,
-                                             const CirclingInfo &circling) noexcept {
+                                             const CirclingInfo &circling,
+                                             double vmin) noexcept {
   if (!circling.circling) {
     Reset();
     return Result(0);
@@ -193,12 +200,20 @@ CirclingWind::Result CirclingWind::NewSample(const MoreData &info,
       }
 
       // this should be small (< 0.3) for a good enough circle
+      const auto avg_deg = angular_rate_avg.Degrees();
       const double circle_quality_metric =
-          std::abs(max_angular_rate_deviation / angular_rate_avg.Degrees());
+          avg_deg == 0
+              ? INITIAL_MIN_FIT_METRIC
+              : std::abs(max_angular_rate_deviation / avg_deg);
 
-      if (circle_quality_metric < 1.0) {
+      /* GPS track rate varies with wind when W/V is large.  Without TAS
+         or a gyro that is not a reason to discard the circle (#2905). */
+      const bool relax_roundness =
+          !usable_airspeed && !usable_gyroscope;
+
+      if (relax_roundness || circle_quality_metric < 1.0) {
         result = CalcWind(circle_quality_metric, n_samples, current_circle,
-                          angular_rate_source);
+                          angular_rate_source, relax_roundness, vmin);
 
         /* we have a good circle, wait for 1/4 circle before calculating the
            next */
@@ -215,23 +230,34 @@ CirclingWind::Result CirclingWind::NewSample(const MoreData &info,
 CirclingWind::Result CirclingWind::CalcWind(double quality_metric,
                                             size_t n_samples,
                                             Angle circle,
-                                            char angular_rate_source) noexcept {
+                                            char angular_rate_source,
+                                            bool relax_roundness,
+                                            double vmin) noexcept {
   assert(n_samples > 1);
   assert(!samples.empty());
 
-  // reject if average time step greater than 2.0 seconds
+  /* Reject circles whose GPS samples are too sparse for a cosine fit.
+     4 s covers 3 s IGC logger steps; 2 s was too tight for that and
+     for IGC replay faster than 1× (virtual time jumps by the replay
+     rate each wall-clock tick). */
   const auto measure_time = (samples[0].time - samples[n_samples - 1].time);
   const auto avg_step_width = measure_time / (n_samples - 1);
   if (avg_step_width <= std::chrono::seconds{0})
     return Result(0);
-  if (avg_step_width > std::chrono::seconds{2})
+  if (avg_step_width > std::chrono::seconds{4})
     return Result(0);
 
-  // reject if step width isn't sufficiently uniform
-  for (size_t i = 1; i < n_samples; i++)
-    if (std::chrono::abs(samples[i - 1].time - samples[i].time -
-                         avg_step_width) > (avg_step_width * 0.05))
-      return Result(0);
+  /* 5 % was tighter than wall-clock jitter on IGC replay and phone
+     GPS.  Without TAS or a gyro, time spacing is not a roundness
+     proxy — skip it.  Otherwise allow half a step or 0.5 s. */
+  if (!relax_roundness) {
+    const auto max_dev = std::max(avg_step_width * 0.5,
+                                  FloatDuration{0.5});
+    for (size_t i = 1; i < n_samples; i++)
+      if (std::chrono::abs(samples[i - 1].time - samples[i].time -
+                           avg_step_width) > max_dev)
+        return Result(0);
+  }
 
   /* the fraction of the last step to be removed from the sum over the full
      circle */
@@ -323,8 +349,15 @@ CirclingWind::Result CirclingWind::CalcWind(double quality_metric,
   }
 
   SpeedVector wind(wind_bearing.AsBearing(), wind_speed);
-  const auto quality = EstimateQuality(quality_metric, min_fit_metric,
-                                       wind_speed, angular_rate_source);
+  auto quality = EstimateQuality(quality_metric, min_fit_metric,
+                                 wind_speed, angular_rate_source,
+                                 relax_roundness);
+
+  /* No TAS: GPS roundness is skipped.  If mean GS is far from polar
+     min-sink, drop quality by one (never to zero). */
+  if (relax_roundness && vmin > 0 && quality > 0 &&
+      (speed_offset < vmin / 2 || speed_offset > 2 * vmin))
+    quality = std::max(1u, quality - 1);
 
   return Result(quality, wind);
 }
@@ -332,10 +365,23 @@ CirclingWind::Result CirclingWind::CalcWind(double quality_metric,
 unsigned int CirclingWind::EstimateQuality(double circle_quality,
                                            double fit_cosine_quality,
                                            double wind_speed,
-                                           char angular_rate_source) noexcept {
+                                           char angular_rate_source,
+                                           bool relax_roundness) noexcept {
   /* The return value matches the quality number of WindStore::SlotMeasurement
    * This estimation is heuristic, not scientific.
    */
+  if (relax_roundness) {
+    /* GPS track rate is not a circle-quality proxy when W/V is large.
+     * Score the cosine fit only, and keep quality at least 1 so a
+     * plausible wind is not discarded (replay GPS is noisy). */
+    int quality = 3;
+    if (fit_cosine_quality > 8)
+      quality = 2;
+    if (fit_cosine_quality > 20)
+      quality = 1;
+    return (unsigned)quality;
+  }
+
   /* Perfect circles are skewed, if GPS-track is the criteria, with higher
    * winds, hence allow some margin for this. wind_speed in m/s
    */

--- a/src/Computer/Wind/CirclingWind.hpp
+++ b/src/Computer/Wind/CirclingWind.hpp
@@ -71,10 +71,11 @@ public:
   void Reset() noexcept;
 
   /**
-   * Called if a new sample is available in the samplelist.
+   * @param vmin polar min-sink TAS [m/s], or 0 if unknown.
    */
   [[nodiscard]]
-  Result NewSample(const MoreData &info, const CirclingInfo &circling) noexcept;
+  Result NewSample(const MoreData &info, const CirclingInfo &circling,
+                   double vmin = 0) noexcept;
 
 private:
   // remembers the status when circling started
@@ -85,11 +86,13 @@ private:
   unsigned int EstimateQuality(double circle_quality,
                                double fit_cosine_quality,
                                double wind_speed,
-                               char angular_rate_source) noexcept;
+                               char angular_rate_source,
+                               bool relax_roundness) noexcept;
 
   [[nodiscard]]
   Result CalcWind(double quality_metric, size_t n_samples,
-                  Angle circle, char angular_rate_source) noexcept;
+                  Angle circle, char angular_rate_source,
+                  bool relax_roundness, double vmin) noexcept;
 
   [[gnu::pure]]
   double FitCosine(size_t n_samples, double amplitude,

--- a/src/Computer/Wind/Computer.cpp
+++ b/src/Computer/Wind/Computer.cpp
@@ -40,7 +40,9 @@ WindComputer::Compute(const WindSettings &settings,
     return;
 
   if (settings.CirclingWindEnabled()) {
-    CirclingWind::Result result = circling_wind.NewSample(basic, calculated);
+    const double vmin = glide_polar.IsValid() ? glide_polar.GetVMin() : 0;
+    CirclingWind::Result result =
+      circling_wind.NewSample(basic, calculated, vmin);
     if (result.IsValid())
       wind_store.SlotMeasurement(basic, result.wind, result.quality);
   }

--- a/src/InfoBoxes/Content/Speed.cpp
+++ b/src/InfoBoxes/Content/Speed.cpp
@@ -98,6 +98,7 @@ UpdateInfoBoxSpeedIndicated(InfoBoxData &data) noexcept
   }
 
   data.SetValueFromSpeed(basic.indicated_airspeed, false);
+  data.SetValueColor(basic.airspeed_real ? 0 : 2);
 }
 
 void
@@ -110,6 +111,7 @@ UpdateInfoBoxSpeed(InfoBoxData &data) noexcept
   }
 
   data.SetValueFromSpeed(basic.true_airspeed, false);
+  data.SetValueColor(basic.airspeed_real ? 0 : 2);
 }
 
 void

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -250,9 +250,21 @@ Replay::OnTimer()
     schedule = std::chrono::milliseconds(100);
   else if (!virtual_time.IsDefined() || !next_data.time_available)
     schedule = std::chrono::milliseconds(500);
-  else if (cli != nullptr)
-    schedule = std::chrono::seconds(1);
-  else {
+  else if (cli != nullptr) {
+    /* Interpolated IGC emits one GPS sample per timer tick, with
+       virtual time advancing by elapsed × rate.  A fixed 1 s wall
+       timer therefore produces 10 s flight steps at 10×, which is too
+       sparse for circling wind.  Keep flight-time steps near 1 Hz. */
+    const double scale = std::max(time_scale, 0.1);
+    constexpr std::chrono::steady_clock::duration lower =
+      std::chrono::milliseconds(50);
+    constexpr std::chrono::steady_clock::duration upper =
+      std::chrono::seconds(1);
+    const auto period =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+        FloatDuration{1} / scale);
+    schedule = std::clamp(period, lower, upper);
+  } else {
     constexpr std::chrono::steady_clock::duration lower = std::chrono::milliseconds(100);
     constexpr std::chrono::steady_clock::duration upper = std::chrono::seconds(3);
     const FloatDuration delta_s((next_data.time - virtual_time) / time_scale);

--- a/src/thread/WorkerThread.cpp
+++ b/src/thread/WorkerThread.cpp
@@ -49,17 +49,16 @@ WorkerThread::Run() noexcept
       const ScopeUnlock unlock(mutex);
 
       /* do the actual work */
-      if (period_min.count() > 0)
-        clock.Update();
-
+      clock.Update();
       Tick();
     }
 
     auto idle = idle_min;
-    if (period_min.count() > 0) {
+    const auto pmin = GetPeriodMin();
+    if (pmin.count() > 0) {
       const auto elapsed = clock.Elapsed();
-      if (elapsed + idle < period_min)
-        idle = period_min - elapsed;
+      if (elapsed + idle < pmin)
+        idle = pmin - elapsed;
     }
 
     if (idle.count() > 0 && _WaitForStopped(lock, idle))

--- a/src/thread/WorkerThread.hpp
+++ b/src/thread/WorkerThread.hpp
@@ -9,8 +9,10 @@
  * A thread which performs regular work in background.
  */
 class WorkerThread : public SuspensibleThread {
+protected:
   using Duration = std::chrono::steady_clock::duration;
 
+private:
   Cond trigger_cond;
   bool trigger_flag = false;
 
@@ -75,6 +77,16 @@ public:
   }
 
 protected:
+  /**
+   * Rate-limit for the next idle after Tick().  Subclasses may drop
+   * this (e.g. IGC replay on fast hosts) so GPS-driven computers keep
+   * ~1 Hz samples.
+   */
+  [[gnu::pure]]
+  virtual Duration GetPeriodMin() const noexcept {
+    return period_min;
+  }
+
   virtual void Run() noexcept;
 
   /**

--- a/test/src/RunWindComputer.cpp
+++ b/test/src/RunWindComputer.cpp
@@ -24,6 +24,7 @@ int main(int argc, char **argv)
   GlidePolar glide_polar(0);
 
   CirclingSettings circling_settings;
+  circling_settings.SetDefaults();
 
   WindSettings wind_settings;
   wind_settings.SetDefaults();
@@ -39,17 +40,23 @@ int main(int argc, char **argv)
 
   while (replay->Next()) {
     const MoreData &basic = replay->Basic();
-    const DerivedInfo &calculated = replay->Calculated();
+    DerivedInfo &calculated = replay->SetCalculated();
 
-    circling_computer.TurnRate(replay->SetCalculated(),
+    /* DebugReplay's default polar is a glider.  Paraglider IGC ground
+       speeds are often below that takeoff threshold, so flying (and
+       circling wind) never start.  This tool is for wind analysis:
+       treat logged fixes as airborne. */
+    calculated.flight.flying = true;
+
+    circling_computer.TurnRate(calculated,
                                basic, calculated.flight);
-    circling_computer.Turning(replay->SetCalculated(),
+    circling_computer.Turning(calculated,
                               basic,
                               calculated.flight,
                               circling_settings);
 
     wind_computer.Compute(wind_settings, glide_polar, basic,
-                          replay->SetCalculated());
+                          calculated);
 
     if (calculated.estimated_wind_available.Modified(last)) {
       char time_buffer[32];

--- a/test/src/TestCirclingWind.cpp
+++ b/test/src/TestCirclingWind.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Computer/Wind/CirclingWind.hpp"
+#include "FakeLogFile.hpp"
+#include "NMEA/CirclingInfo.hpp"
+#include "NMEA/MoreData.hpp"
+#include "TestUtil.hpp"
+
+#include <cmath>
+
+/**
+ * Feed CirclingWind a constant-rate heading circle in a uniform wind.
+ *
+ * Ground track and ground speed are the GPS observables (air vector
+ * plus wind).  No gyroscope.  Optional true airspeed, as a typical
+ * vario would provide; paragliders usually have none.
+ */
+struct CircleConfig {
+  double tas;
+  SpeedVector wind;
+  double period_s;
+  double dt_s = 1;
+  /** Alternate samples by ± this many seconds (replay / GPS jitter). */
+  double dt_jitter_s = 0;
+  unsigned circles = 3;
+  bool report_tas = false;
+  /** Polar min-sink TAS [m/s]; 0 = do not weight quality. */
+  double vmin = 0;
+};
+
+static CirclingWind::Result
+FeedCircle(const CircleConfig &cfg) noexcept
+{
+  CirclingWind circling_wind;
+  circling_wind.Reset();
+
+  CirclingInfo circling;
+  circling.Clear();
+  circling.circling = true;
+
+  CirclingWind::Result last(0);
+
+  const Angle wind_to = cfg.wind.bearing.Reciprocal();
+  const double wind_east = cfg.wind.norm * wind_to.sin();
+  const double wind_north = cfg.wind.norm * wind_to.cos();
+
+  const unsigned n =
+    unsigned(std::ceil(cfg.period_s * cfg.circles / cfg.dt_s)) + 2;
+
+  double t = 0;
+  for (unsigned i = 0; i < n; ++i) {
+    const Angle heading =
+      Angle::Degrees(360 * t / cfg.period_s);
+    const double air_east = cfg.tas * heading.sin();
+    const double air_north = cfg.tas * heading.cos();
+    const SpeedVector gs(air_east + wind_east, air_north + wind_north);
+
+    MoreData info;
+    info.Reset();
+    info.clock = TimeStamp{FloatDuration{t + 1}};
+    info.time = info.clock;
+    info.time_available.Update(info.clock);
+    info.track = gs.bearing;
+    info.track_available.Update(info.clock);
+    info.ground_speed = gs.norm;
+    info.ground_speed_available.Update(info.clock);
+    if (cfg.report_tas) {
+      info.true_airspeed = cfg.tas;
+      info.airspeed_available.Update(info.clock);
+      info.airspeed_real = true;
+    }
+
+    const auto result = circling_wind.NewSample(info, circling, cfg.vmin);
+    if (result.IsValid())
+      last = result;
+
+    const double jitter =
+      (i % 2) ? cfg.dt_jitter_s : -cfg.dt_jitter_s;
+    t += cfg.dt_s + jitter;
+  }
+
+  return last;
+}
+
+static void
+TestNotCircling() noexcept
+{
+  CirclingWind circling_wind;
+  circling_wind.Reset();
+
+  CirclingInfo circling;
+  circling.Clear();
+
+  MoreData info;
+  info.Reset();
+  info.clock = TimeStamp{FloatDuration{1}};
+  info.time = info.clock;
+  info.track = Angle::Zero();
+  info.track_available.Update(info.clock);
+  info.ground_speed = 10;
+  info.ground_speed_available.Update(info.clock);
+
+  const auto result = circling_wind.NewSample(info, circling);
+  ok1(!result.IsValid());
+}
+
+static void
+TestStillAir() noexcept
+{
+  /* Constant GPS track rate, no wind: a 20 s glider circle. */
+  const auto result = FeedCircle({
+    .tas = 25,
+    .wind = SpeedVector::Zero(),
+    .period_s = 20,
+  });
+  ok1(result.IsValid());
+  ok1(result.wind.norm < 1.5);
+}
+
+static bool
+WindMatches(const CirclingWind::Result &result, const SpeedVector &want,
+            double speed_tol, Angle bearing_tol) noexcept
+{
+  if (!result.IsValid())
+    return false;
+  if (std::fabs(result.wind.norm - want.norm) > speed_tol)
+    return false;
+  return result.wind.bearing.AsBearing().CompareRoughly(want.bearing,
+                                                        bearing_tol);
+}
+
+static void
+TestGliderGpsWind() noexcept
+{
+  /* Typical glider: 25 m/s TAS, 5 m/s from west, GPS only. */
+  const SpeedVector wind(Angle::Degrees(270), 5);
+  const auto result = FeedCircle({
+    .tas = 25,
+    .wind = wind,
+    .period_s = 20,
+  });
+  ok1(result.IsValid());
+  ok1(WindMatches(result, wind, 1.5, Angle::Degrees(30)));
+}
+
+static void
+TestGliderTasWind() noexcept
+{
+  const SpeedVector wind(Angle::Degrees(270), 5);
+  const auto result = FeedCircle({
+    .tas = 25,
+    .wind = wind,
+    .period_s = 20,
+    .report_tas = true,
+  });
+  ok1(result.IsValid());
+  ok1(WindMatches(result, wind, 1.5, Angle::Degrees(30)));
+}
+
+static void
+TestParagliderGpsWind() noexcept
+{
+  /* Paraglider without TAS or gyro, 1 Hz GPS: 9 m/s TAS, 5 m/s from
+     east, 25 s circles.  GPS track rate is not constant in wind when
+     W/V is large — this is issue #2905. */
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  const auto result = FeedCircle({
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+  });
+  ok1(result.IsValid());
+  ok1(WindMatches(result, wind, 2, Angle::Degrees(40)));
+}
+
+static void
+TestParagliderReplayJitter() noexcept
+{
+  /* IGC replay timestamps come from the wall clock; 150 ms jitter
+     exceeds the old 5 % (50 ms at 1 Hz) gate. */
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  const auto result = FeedCircle({
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+    .dt_jitter_s = 0.15,
+  });
+  ok1(result.IsValid());
+  ok1(WindMatches(result, wind, 2, Angle::Degrees(40)));
+}
+
+static void
+TestParagliderThreeSecondFixes() noexcept
+{
+  /* Slow IGC logger / replay faster than 1×: ~3 s steps. */
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  const auto result = FeedCircle({
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+    .dt_s = 3,
+  });
+  ok1(result.IsValid());
+  ok1(WindMatches(result, wind, 2.5, Angle::Degrees(45)));
+}
+
+static void
+TestParagliderPolarSpeedQuality() noexcept
+{
+  /* Matching polar min-sink keeps quality; a glider polar on a PG
+     lowers it by one but still yields a wind. */
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  CircleConfig cfg{
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+  };
+
+  cfg.vmin = 9;
+  const auto matched = FeedCircle(cfg);
+  cfg.vmin = 25;
+  const auto mismatched = FeedCircle(cfg);
+
+  ok1(matched.IsValid());
+  ok1(mismatched.IsValid());
+  ok1(WindMatches(matched, wind, 2, Angle::Degrees(40)));
+  ok1(matched.quality > mismatched.quality);
+}
+
+int
+main()
+{
+  plan_tests(1 + 2 + 2 + 2 + 2 + 2 + 2 + 4);
+
+  SetFakeLogFileQuiet(true);
+
+  TestNotCircling();
+  TestStillAir();
+  TestGliderGpsWind();
+  TestGliderTasWind();
+  TestParagliderGpsWind();
+  TestParagliderReplayJitter();
+  TestParagliderThreeSecondFixes();
+  TestParagliderPolarSpeedQuality();
+
+  return exit_status();
+}

--- a/test/src/TestCirclingWind.cpp
+++ b/test/src/TestCirclingWind.cpp
@@ -124,10 +124,20 @@ WindMatches(const CirclingWind::Result &result, const SpeedVector &want,
 {
   if (!result.IsValid())
     return false;
-  if (std::fabs(result.wind.norm - want.norm) > speed_tol)
+
+  const double speed_err = std::fabs(result.wind.norm - want.norm);
+  const double bearing_err =
+    std::fabs((result.wind.bearing.AsBearing() - want.bearing)
+                .AsDelta()
+                .Degrees());
+  if (speed_err > speed_tol || bearing_err > bearing_tol.Degrees()) {
+    diag("got %.2f m/s %.1f deg, want %.2f m/s %.1f deg "
+         "(speed_err %.2f, bearing_err %.1f)",
+         result.wind.norm, result.wind.bearing.AsBearing().Degrees(),
+         want.norm, want.bearing.Degrees(), speed_err, bearing_err);
     return false;
-  return result.wind.bearing.AsBearing().CompareRoughly(want.bearing,
-                                                        bearing_tol);
+  }
+  return true;
 }
 
 static void


### PR DESCRIPTION
## Summary
- Restore circling wind for paragliders and other GPS-only aircraft: without TAS or a gyroscope, skip the GPS-track roundness gate and score the cosine fit instead (`Fixes #2905`).
- Keep interpolated IGC replay near 1 Hz of flight time at high replay rates, and skip the calculation thread’s 450 ms period on fast LCD hosts so 10× replay still sees usable GPS samples. E-paper and slow CPUs keep the existing rate limit.

This is a v7.44 regression from `ea6f9a12c9` (circling-wind rewrite). 7.43 estimated wind from min/max ground speed and did not require a round GPS track rate.

## Test plan
- [x] Replay the #2905 IGC (`HFGTYGLIDERTYPE:Para EN C`) with a paraglider polar and Auto wind Circling or Both: wind InfoBox and map arrow fill after a thermal
- [x] Same replay at 1× and 10× on a desktop/fast LCD
- [ ] Glider with TAS: circling wind still updates as before
- [ ] `output/UNIX/bin/TestCirclingWind` passes (GPS-only PG, jitter, 3 s steps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS keyboard, font, settings persistence, audio, and exit-crash issues.
  * Fixed device debug logging and keyboard Shift handling.
  * Improved circling-wind calculations, including sparse or irregular GPS updates and polar minimum-sink data.
  * Suppressed estimated airspeed without GPS track data.
  * Estimated indicated and true airspeed values are now shown in blue.
  * Improved fast IGC replay timing and responsiveness.
* **Tests**
  * Added comprehensive circling-wind estimation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->