### PR TITLE
Replay: seek to a flight minute or flight phase, and make +10' a real skip

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -82,12 +82,18 @@ Version 7.46 - not yet released
 * ui
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
+* replay
+  - add seek to a chosen flight minute or to the next circling or cruise
+    phase, showing progress and allowing cancellation
+  - skip 10 minutes instead of fast-forwarding (+10' button) #933
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can
     produce the testing flavour
+  - lua: add replay seek functions seek_to_flight_minutes,
+    seek_to_next_circling and seek_to_next_cruise
 
 Version 7.45 - 2026-08-15
 * highlights

--- a/src/CalculationThread.cpp
+++ b/src/CalculationThread.cpp
@@ -140,6 +140,12 @@ CalculationThread::ProcessReplayFix() noexcept
 }
 
 void
+CalculationThread::ResetFlight() noexcept
+{
+  glide_computer.ResetFlight(true);
+}
+
+void
 CalculationThread::ForceTrigger() noexcept
 {
   {

--- a/src/CalculationThread.hpp
+++ b/src/CalculationThread.hpp
@@ -69,6 +69,12 @@ public:
    */
   void ProcessReplayFix() noexcept;
 
+  /**
+   * Reset the flight state of the GlideComputer before a replay
+   * restart.  Call only while the worker thread is suspended.
+   */
+  void ResetFlight() noexcept;
+
 protected:
   void Tick() noexcept override;
 

--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -35,7 +35,7 @@ public:
   void CreateButtons(WidgetDialog &dialog) noexcept {
     dialog.AddButton(_("Start"), [this](){ OnStartClicked(); });
     dialog.AddButton(_("Stop"), [this](){ OnStopClicked(); });
-    dialog.AddButton("+10'", [this](){ OnFastForwardClicked(); });
+    dialog.AddButton("+10'", [this](){ OnSkipClicked(); });
     dialog.AddButton(_("Seek"), [this](){ OnSeekClicked(); });
     dialog.AddButton(_("Circling"), [this](){ OnSeekNextCirclingClicked(); });
     dialog.AddButton(_("Cruise"), [this](){ OnSeekNextCruiseClicked(); });
@@ -44,7 +44,7 @@ public:
 private:
   void OnStopClicked() noexcept;
   void OnStartClicked() noexcept;
-  void OnFastForwardClicked() noexcept;
+  void OnSkipClicked() noexcept;
   void OnSeekClicked() noexcept;
   void OnSeekNextCirclingClicked() noexcept;
   void OnSeekNextCruiseClicked() noexcept;
@@ -101,9 +101,27 @@ ReplayControlWidget::OnStartClicked() noexcept
 }
 
 inline void
-ReplayControlWidget::OnFastForwardClicked() noexcept
+ReplayControlWidget::OnSkipClicked() noexcept
 {
-  replay.FastForward(std::chrono::minutes{10});
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return;
+
+  if (!replay.IsActive()) {
+    ShowMessageBox(_("Replay is not active."), _("Replay"), MB_OK);
+    return;
+  }
+
+  DialogJobRunner runner{UIGlobals::GetMainWindow(),
+                         UIGlobals::GetDialogLook(),
+                         _("Replay"), true};
+
+  /* reaching the end of the recording is fine here, so the result is
+     ignored */
+  replay.SeekForward(std::chrono::minutes{10},
+                     *backend_components->merge_thread,
+                     *backend_components->calculation_thread, runner);
 }
 
 inline void

--- a/src/Dialogs/ReplayDialog.cpp
+++ b/src/Dialogs/ReplayDialog.cpp
@@ -3,11 +3,15 @@
 
 #include "ReplayDialog.hpp"
 #include "Dialogs/Error.hpp"
+#include "Dialogs/JobDialog.hpp"
+#include "Dialogs/Message.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
+#include "BackendComponents.hpp"
 #include "Components.hpp"
 #include "Replay/Replay.hpp"
+#include "NMEA/CirclingInfo.hpp"
 #include "Form/DataField/Base.hpp"
 #include "Language/Language.hpp"
 #include "Repository/FileType.hpp"
@@ -19,6 +23,7 @@ class ReplayControlWidget final
   enum Controls {
     FILE,
     RATE,
+    FLIGHT_MINUTES,
   };
 
   Replay &replay;
@@ -31,12 +36,18 @@ public:
     dialog.AddButton(_("Start"), [this](){ OnStartClicked(); });
     dialog.AddButton(_("Stop"), [this](){ OnStopClicked(); });
     dialog.AddButton("+10'", [this](){ OnFastForwardClicked(); });
+    dialog.AddButton(_("Seek"), [this](){ OnSeekClicked(); });
+    dialog.AddButton(_("Circling"), [this](){ OnSeekNextCirclingClicked(); });
+    dialog.AddButton(_("Cruise"), [this](){ OnSeekNextCruiseClicked(); });
   }
 
 private:
   void OnStopClicked() noexcept;
   void OnStartClicked() noexcept;
   void OnFastForwardClicked() noexcept;
+  void OnSeekClicked() noexcept;
+  void OnSeekNextCirclingClicked() noexcept;
+  void OnSeekNextCruiseClicked() noexcept;
 
 public:
   /* virtual methods from class Widget */
@@ -63,6 +74,12 @@ ReplayControlWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
   GetDataField(RATE).SetOnModified([this]{
     replay.SetTimeScale(GetValueFloat(RATE));
   });
+
+  AddInteger(_("Flight min"),
+             _("Position in the flight to jump to, in minutes since the "
+               "recording started."),
+             "%u", "%u",
+             0, Replay::MAX_SEEK_MINUTES, 1, 0);
 }
 
 inline void
@@ -87,6 +104,80 @@ inline void
 ReplayControlWidget::OnFastForwardClicked() noexcept
 {
   replay.FastForward(std::chrono::minutes{10});
+}
+
+inline void
+ReplayControlWidget::OnSeekClicked() noexcept
+{
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return;
+
+  if (!replay.IsActive()) {
+    ShowMessageBox(_("Replay is not active."), _("Replay"), MB_OK);
+    return;
+  }
+
+  const unsigned minutes =
+    static_cast<unsigned>(GetValueInteger(FLIGHT_MINUTES));
+
+  DialogJobRunner runner{UIGlobals::GetMainWindow(),
+                         UIGlobals::GetDialogLook(),
+                         _("Replay"), true};
+
+  if (!replay.SeekToFlightElapsedMinutes(
+        minutes, *backend_components->merge_thread,
+        *backend_components->calculation_thread, runner))
+    ShowMessageBox(_("Could not seek replay."), _("Replay"), MB_OK);
+}
+
+inline void
+ReplayControlWidget::OnSeekNextCirclingClicked() noexcept
+{
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return;
+
+  if (!replay.IsActive()) {
+    ShowMessageBox(_("Replay is not active."), _("Replay"), MB_OK);
+    return;
+  }
+
+  DialogJobRunner runner{UIGlobals::GetMainWindow(),
+                         UIGlobals::GetDialogLook(),
+                         _("Replay"), true};
+
+  if (!replay.SeekToNextFlightMode(
+        CirclingMode::CLIMB, *backend_components->merge_thread,
+        *backend_components->calculation_thread, runner))
+    ShowMessageBox(_("No further circling phase found."), _("Replay"),
+                   MB_OK);
+}
+
+inline void
+ReplayControlWidget::OnSeekNextCruiseClicked() noexcept
+{
+  if (backend_components == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return;
+
+  if (!replay.IsActive()) {
+    ShowMessageBox(_("Replay is not active."), _("Replay"), MB_OK);
+    return;
+  }
+
+  DialogJobRunner runner{UIGlobals::GetMainWindow(),
+                         UIGlobals::GetDialogLook(),
+                         _("Replay"), true};
+
+  if (!replay.SeekToNextFlightMode(
+        CirclingMode::CRUISE, *backend_components->merge_thread,
+        *backend_components->calculation_thread, runner))
+    ShowMessageBox(_("No further cruise phase found."), _("Replay"),
+                   MB_OK);
 }
 
 void

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -62,70 +62,6 @@ ApplyReplayFix(DeviceBlackboard &device_blackboard,
 }
 
 /**
- * Result of a cheap parse-only pass over the recording, without merge
- * or calculation.  Used to scale the seek progress bar.
- */
-struct RecordingScan {
-  /**
-   * The number of lines that will produce replay fixes (IGC B
-   * records); 0 if unknown for this file type.
-   */
-  unsigned fix_lines = 0;
-
-  /**
-   * The time of day of the first fix, or undefined if unknown.
-   */
-  TimeStamp start_time = TimeStamp::Undefined();
-
-  /**
-   * The time of day of the last fix, or undefined if unknown.
-   */
-  TimeStamp end_time = TimeStamp::Undefined();
-};
-
-RecordingScan
-ScanRecording(Path path) noexcept
-try {
-  RecordingScan result;
-
-  if (path == nullptr || path.empty() ||
-      !FilenameMatchesFileType(path.GetBase().c_str(), FileType::IGC))
-    return result;
-
-  FileLineReaderA reader{path};
-  while (const char *line = reader.ReadLine()) {
-    if (*line != 'B')
-      continue;
-
-    ++result.fix_lines;
-
-    /* B records start with the time of day as HHMMSS; the comparison
-       stops at the terminating null byte of short lines */
-    const char *t = line + 1;
-    bool valid = true;
-    for (unsigned i = 0; valid && i < 6; ++i)
-      valid = t[i] >= '0' && t[i] <= '9';
-
-    if (valid) {
-      const unsigned hh = (t[0] - '0') * 10 + (t[1] - '0');
-      const unsigned mm = (t[2] - '0') * 10 + (t[3] - '0');
-      const unsigned ss = (t[4] - '0') * 10 + (t[5] - '0');
-      if (hh < 24 && mm < 60 && ss < 60) {
-        const TimeStamp time_stamp{
-          std::chrono::seconds{hh * 3600 + mm * 60 + ss}};
-        if (!result.start_time.IsDefined())
-          result.start_time = time_stamp;
-        result.end_time = time_stamp;
-      }
-    }
-  }
-
-  return result;
-} catch (...) {
-  return {};
-}
-
-/**
  * Show the scanned flight time in the progress dialog, in seconds,
  * as "1234 / 12000 s" when the total is known and "1234 s"
  * otherwise.
@@ -275,6 +211,10 @@ Replay::Start(Path _path)
      creating a new one */
   Stop();
 
+  if (path != _path)
+    /* another file: the cached scan no longer describes it */
+    recording_scan_valid = false;
+
   path = _path;
 
   if (path == nullptr || path.empty()) {
@@ -299,6 +239,55 @@ Replay::Start(Path _path)
   fixes_read = 0;
 
   timer.Schedule(std::chrono::milliseconds(100));
+}
+
+const Replay::RecordingScan &
+Replay::GetRecordingScan() noexcept
+{
+  if (recording_scan_valid)
+    return recording_scan;
+
+  recording_scan = {};
+  recording_scan_valid = true;
+
+  if (path == nullptr || path.empty() ||
+      !FilenameMatchesFileType(path.GetBase().c_str(), FileType::IGC))
+    return recording_scan;
+
+  try {
+    FileLineReaderA reader{path};
+    while (const char *line = reader.ReadLine()) {
+      if (*line != 'B')
+        continue;
+
+      ++recording_scan.fix_lines;
+
+      /* B records start with the time of day as HHMMSS; the
+         comparison stops at the terminating null byte of short
+         lines */
+      const char *t = line + 1;
+      bool valid = true;
+      for (unsigned i = 0; valid && i < 6; ++i)
+        valid = t[i] >= '0' && t[i] <= '9';
+
+      if (valid) {
+        const unsigned hh = (t[0] - '0') * 10 + (t[1] - '0');
+        const unsigned mm = (t[2] - '0') * 10 + (t[3] - '0');
+        const unsigned ss = (t[4] - '0') * 10 + (t[5] - '0');
+        if (hh < 24 && mm < 60 && ss < 60) {
+          const TimeStamp time_stamp{
+            std::chrono::seconds{hh * 3600 + mm * 60 + ss}};
+          if (!recording_scan.start_time.IsDefined())
+            recording_scan.start_time = time_stamp;
+          recording_scan.end_time = time_stamp;
+        }
+      }
+    }
+  } catch (...) {
+    recording_scan = {};
+  }
+
+  return recording_scan;
 }
 
 bool
@@ -329,7 +318,7 @@ Replay::SeekToFlightElapsedMinutes(unsigned minutes,
   if (!IsActive() || path == nullptr || path.empty())
     return false;
 
-  const RecordingScan scan = ScanRecording(path);
+  const RecordingScan &scan = GetRecordingScan();
 
   if (scan.start_time.IsDefined() && virtual_time.IsDefined()) {
     const TimeStamp forward_target =
@@ -633,7 +622,7 @@ Replay::SeekForward(FloatDuration delta,
 
   /* clamp the progress scale at the recording end, so the bar still
      reaches 100% when skipping past the end of the flight */
-  const RecordingScan scan = ScanRecording(path);
+  const RecordingScan &scan = GetRecordingScan();
   TimeStamp progress_end = target_ts;
   if (scan.end_time.IsDefined() && scan.end_time > virtual_time &&
       scan.end_time < target_ts)
@@ -658,7 +647,7 @@ Replay::SeekToNextFlightMode(CirclingMode mode,
   /* the number of fixes until the requested phase cannot be known in
      advance, so the bar shows how far through the remaining recording
      the scan has come */
-  const unsigned total_fixes = ScanRecording(path).fix_lines;
+  const unsigned total_fixes = GetRecordingScan().fix_lines;
   const unsigned remaining_fixes =
     total_fixes > fixes_read ? total_fixes - fixes_read : 0;
 

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -618,6 +618,32 @@ Replay::ForwardScanToTime(TimeStamp target_ts, TimeStamp progress_end,
 }
 
 bool
+Replay::SeekForward(FloatDuration delta,
+                    MergeThread &merge_thread,
+                    CalculationThread &calculation_thread,
+                    JobRunner &runner) noexcept
+{
+  /* an empty path means demo mode, which has no recording to seek
+     in */
+  if (!IsActive() || path == nullptr || path.empty() ||
+      !virtual_time.IsDefined() || delta.count() <= 0)
+    return false;
+
+  const TimeStamp target_ts = virtual_time + delta;
+
+  /* clamp the progress scale at the recording end, so the bar still
+     reaches 100% when skipping past the end of the flight */
+  const RecordingScan scan = ScanRecording(path);
+  TimeStamp progress_end = target_ts;
+  if (scan.end_time.IsDefined() && scan.end_time > virtual_time &&
+      scan.end_time < target_ts)
+    progress_end = scan.end_time;
+
+  return ForwardScanToTime(target_ts, progress_end,
+                           merge_thread, calculation_thread, runner);
+}
+
+bool
 Replay::SeekToNextFlightMode(CirclingMode mode,
                               MergeThread &merge_thread,
                               CalculationThread &calculation_thread,

--- a/src/Replay/Replay.cpp
+++ b/src/Replay/Replay.cpp
@@ -13,11 +13,238 @@
 #include "Interface.hpp"
 #include "Repository/FileType.hpp"
 #include "CatmullRomInterpolator.hpp"
+#include "Geo/GeoVector.hpp"
+#include "Protection.hpp"
+#include "Job/Job.hpp"
+#include "Job/Runner.hpp"
+#include "Operation/Operation.hpp"
 #include "time/Cast.hxx"
+#include "util/ScopeExit.hxx"
+
+#include <fmt/format.h>
 
 #include <algorithm> // for std::clamp()
 #include <cassert>
+#include <functional>
 #include <stdexcept>
+
+namespace {
+
+/**
+ * How long a seek may scan synchronously on the UI thread before it
+ * escalates to a progress dialog via the #JobRunner.  Short scans
+ * finish inline, so no dialog flashes up just to disappear again.
+ */
+constexpr std::chrono::steady_clock::duration SYNC_SEEK_BUDGET =
+  std::chrono::milliseconds(500);
+
+/**
+ * Minimum interval between seek progress updates.  Posting on every
+ * fix would flood the event queue faster than the UI thread drains
+ * it, so updates are rate-limited at the source.
+ */
+constexpr std::chrono::steady_clock::duration PROGRESS_UPDATE_INTERVAL =
+  std::chrono::milliseconds(100);
+
+void
+ApplyReplayFix(DeviceBlackboard &device_blackboard,
+               MergeThread &merge_thread,
+               CalculationThread &calculation_thread,
+               const NMEAInfo &fix) noexcept
+{
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+    device_blackboard.SetReplayState() = fix;
+  }
+
+  merge_thread.ProcessReplayFix();
+  calculation_thread.ProcessReplayFix();
+}
+
+/**
+ * Result of a cheap parse-only pass over the recording, without merge
+ * or calculation.  Used to scale the seek progress bar.
+ */
+struct RecordingScan {
+  /**
+   * The number of lines that will produce replay fixes (IGC B
+   * records); 0 if unknown for this file type.
+   */
+  unsigned fix_lines = 0;
+
+  /**
+   * The time of day of the first fix, or undefined if unknown.
+   */
+  TimeStamp start_time = TimeStamp::Undefined();
+
+  /**
+   * The time of day of the last fix, or undefined if unknown.
+   */
+  TimeStamp end_time = TimeStamp::Undefined();
+};
+
+RecordingScan
+ScanRecording(Path path) noexcept
+try {
+  RecordingScan result;
+
+  if (path == nullptr || path.empty() ||
+      !FilenameMatchesFileType(path.GetBase().c_str(), FileType::IGC))
+    return result;
+
+  FileLineReaderA reader{path};
+  while (const char *line = reader.ReadLine()) {
+    if (*line != 'B')
+      continue;
+
+    ++result.fix_lines;
+
+    /* B records start with the time of day as HHMMSS; the comparison
+       stops at the terminating null byte of short lines */
+    const char *t = line + 1;
+    bool valid = true;
+    for (unsigned i = 0; valid && i < 6; ++i)
+      valid = t[i] >= '0' && t[i] <= '9';
+
+    if (valid) {
+      const unsigned hh = (t[0] - '0') * 10 + (t[1] - '0');
+      const unsigned mm = (t[2] - '0') * 10 + (t[3] - '0');
+      const unsigned ss = (t[4] - '0') * 10 + (t[5] - '0');
+      if (hh < 24 && mm < 60 && ss < 60) {
+        const TimeStamp time_stamp{
+          std::chrono::seconds{hh * 3600 + mm * 60 + ss}};
+        if (!result.start_time.IsDefined())
+          result.start_time = time_stamp;
+        result.end_time = time_stamp;
+      }
+    }
+  }
+
+  return result;
+} catch (...) {
+  return {};
+}
+
+/**
+ * Show the scanned flight time in the progress dialog, in seconds,
+ * as "1234 / 12000 s" when the total is known and "1234 s"
+ * otherwise.
+ */
+void
+SetProgressText(OperationEnvironment &env,
+                double elapsed_s, double total_s) noexcept
+{
+  char buffer[32];
+  const auto result = total_s > 0
+    ? fmt::format_to_n(buffer, sizeof(buffer) - 1, "{} / {} s",
+                       unsigned(std::clamp(elapsed_s, 0., total_s)),
+                       unsigned(total_s))
+    : fmt::format_to_n(buffer, sizeof(buffer) - 1, "{} s",
+                       unsigned(std::max(elapsed_s, 0.)));
+  *result.out = '\0';
+
+  env.SetText(buffer);
+}
+
+/**
+ * Run a seek scan through the #JobRunner.  The scan itself cannot
+ * throw, but the runner may fail to show its progress dialog, and
+ * #JobThread rethrows in the calling thread; the seek then keeps the
+ * position it has reached, so seeks can be noexcept.
+ */
+void
+RunSeekJob(JobRunner &runner, Job &job) noexcept
+try {
+  runner.Run(job);
+} catch (...) {
+}
+
+/**
+ * Adapter running a seek scan through a #JobRunner, so the potentially
+ * expensive loop can be offloaded into a worker thread with progress
+ * reporting and cancellation.
+ */
+class ReplaySeekJob final : public Job {
+  std::function<void(OperationEnvironment &)> function;
+
+public:
+  template<typename F>
+  explicit ReplaySeekJob(F &&_function) noexcept
+    :function(std::forward<F>(_function)) {}
+
+  void Run(OperationEnvironment &env) override {
+    function(env);
+  }
+};
+
+/**
+ * Does the given turn mode belong to the given definite flight phase
+ * (#CirclingMode::CLIMB or #CirclingMode::CRUISE)?  The transitional
+ * POSSIBLE_* states count as part of the phase they may be leaving,
+ * because they often revert without an actual phase change.
+ */
+constexpr bool
+IsInPhase(CirclingMode phase, CirclingMode mode) noexcept
+{
+  return phase == CirclingMode::CLIMB
+    ? mode == CirclingMode::CLIMB || mode == CirclingMode::POSSIBLE_CRUISE
+    : mode == CirclingMode::CRUISE || mode == CirclingMode::POSSIBLE_CLIMB;
+}
+
+/**
+ * Suspend the merge and calculation worker threads for the lifetime
+ * of this object so replay fixes can be processed synchronously.
+ */
+struct ScopedWorkerSuspend final {
+  MergeThread &merge_thread;
+  CalculationThread &calculation_thread;
+
+  ScopedWorkerSuspend(MergeThread &m, CalculationThread &c) noexcept
+    :merge_thread(m), calculation_thread(c)
+  {
+    calculation_thread.Suspend();
+    merge_thread.Suspend();
+  }
+
+  ~ScopedWorkerSuspend() noexcept
+  {
+    merge_thread.Resume();
+    calculation_thread.Resume();
+  }
+
+  ScopedWorkerSuspend(const ScopedWorkerSuspend &) = delete;
+  ScopedWorkerSuspend &operator=(const ScopedWorkerSuspend &) = delete;
+};
+
+/**
+ * Build a replay fix from the Catmull-Rom interpolator at the given
+ * time stamp, copying all other fields from the last replay fix.
+ */
+NMEAInfo
+MakeInterpolatedFix(const CatmullRomInterpolator &cli, TimeStamp time,
+                    const NMEAInfo &last) noexcept
+{
+  const CatmullRomInterpolator::Record r = cli.Interpolate(time);
+  const GeoVector v = cli.GetVector(time);
+
+  NMEAInfo data = last;
+  data.clock = time;
+  data.alive.Update(data.clock);
+  data.ProvideTime(time);
+  data.location = r.location;
+  data.location_available.Update(data.clock);
+  data.ground_speed = v.distance;
+  data.ground_speed_available.Update(data.clock);
+  data.track = v.bearing;
+  data.track_available.Update(data.clock);
+  data.gps_altitude = r.gps_altitude;
+  data.gps_altitude_available.Update(data.clock);
+  data.ProvidePressureAltitude(r.baro_altitude);
+  data.ProvideBaroAltitudeTrue(r.baro_altitude);
+  return data;
+}
+
+} // namespace
 
 void
 Replay::Stop()
@@ -69,8 +296,372 @@ Replay::Start(Path _path)
   virtual_time = TimeStamp::Undefined();
   fast_forward = TimeStamp::Undefined();
   next_data.Reset();
+  fixes_read = 0;
 
   timer.Schedule(std::chrono::milliseconds(100));
+}
+
+bool
+Replay::ReadNextFix(NMEAInfo &data) noexcept
+try {
+  if (!replay->Update(data))
+    return false;
+
+  ++fixes_read;
+  return true;
+} catch (...) {
+  /* a broken or unreadable file ends the recording, just like
+     reaching its end */
+  return false;
+}
+
+bool
+Replay::SeekToFlightElapsedMinutes(unsigned minutes,
+                                    MergeThread &merge_thread,
+                                    CalculationThread &calculation_thread,
+                                    JobRunner &runner) noexcept
+{
+  if (minutes > MAX_SEEK_MINUTES)
+    return false;
+
+  /* an empty path means demo mode, which has no recording to seek
+     in */
+  if (!IsActive() || path == nullptr || path.empty())
+    return false;
+
+  const RecordingScan scan = ScanRecording(path);
+
+  if (scan.start_time.IsDefined() && virtual_time.IsDefined()) {
+    const TimeStamp forward_target =
+      scan.start_time + FloatDuration{(double)minutes * 60.};
+
+    if (forward_target > virtual_time) {
+      /* the target lies ahead of the current position: scan forward
+         instead of restarting and replaying from the beginning */
+      TimeStamp progress_end = forward_target;
+      if (scan.end_time.IsDefined() && scan.end_time > virtual_time &&
+          scan.end_time < forward_target)
+        progress_end = scan.end_time;
+
+      return ForwardScanToTime(forward_target, progress_end,
+                               merge_thread, calculation_thread, runner);
+    }
+  }
+
+  timer.Cancel();
+
+  const AllocatedPath saved_path{GetFilename()};
+
+  try {
+    Stop();
+    Start(saved_path);
+  } catch (...) {
+    return false;
+  }
+
+  timer.Cancel();
+
+  /* declared before the suspension guard so the timer is re-armed
+     after the worker threads have been resumed */
+  AtScopeExit(this) {
+    if (IsActive())
+      timer.Schedule(std::chrono::milliseconds(100));
+  };
+
+  const ScopedWorkerSuspend suspend{merge_thread, calculation_thread};
+
+  /* the derived state (trail, statistics) of the previous playback
+     would otherwise be mixed with the fixes applied again from the
+     start of the recording */
+  calculation_thread.ResetFlight();
+
+  next_data.Reset();
+
+  while (!next_data.time_available) {
+    if (!ReadNextFix(next_data))
+      return false;
+  }
+
+  const TimeStamp anchor = next_data.time;
+  const TimeStamp target_ts =
+    anchor + FloatDuration{(double)minutes * 60.};
+
+  /* clamp the progress scale at the recording end, so the bar still
+     reaches 100% when the requested minute lies beyond the flight */
+  TimeStamp progress_end = target_ts;
+  if (scan.end_time.IsDefined() && scan.end_time > anchor &&
+      scan.end_time < target_ts)
+    progress_end = scan.end_time;
+
+  const double progress_range =
+    std::max(1., (progress_end - anchor).count());
+
+  TimeStamp last_time = anchor;
+  bool complete = false;
+
+  /* returns false when the time budget ran out and the scan must
+     continue in a job behind the progress dialog */
+  const auto run_scan = [&](OperationEnvironment &env, bool bounded){
+    PeriodClock budget;
+    budget.Update();
+
+    PeriodClock progress_clock;
+
+    while (true) {
+      if (env.IsCancelled())
+        return true;
+
+      if (bounded && budget.Check(SYNC_SEEK_BUDGET))
+        return false;
+
+      if (!next_data.time_available) {
+        /* a fix without a time stamp, e.g. an NMEA sentence carrying
+           none: skip it and keep scanning */
+        if (!ReadNextFix(next_data))
+          return true;
+
+        continue;
+      }
+
+      if (next_data.time > target_ts)
+        break;
+
+      if (next_data.time < last_time)
+        /* time warp, e.g. midnight wraparound during NMEA replay:
+           stop here instead of replaying the whole remaining file */
+        return true;
+
+      ApplyReplayFix(device_blackboard, merge_thread, calculation_thread,
+                     next_data);
+      last_time = next_data.time;
+
+      if (progress_clock.CheckUpdate(PROGRESS_UPDATE_INTERVAL)) {
+        env.SetProgressRange(unsigned(progress_range));
+        env.SetProgressPosition(
+          unsigned(std::clamp((last_time - anchor).count(), 0.,
+                              progress_range)));
+        SetProgressText(env, (last_time - anchor).count(), progress_range);
+      }
+
+      if (cli != nullptr)
+        cli->Update(next_data.time, next_data.location,
+                    next_data.gps_altitude, next_data.pressure_altitude);
+
+      if (!ReadNextFix(next_data))
+        return true;
+    }
+
+    complete = true;
+    return true;
+  };
+
+  NullOperationEnvironment sync_env;
+  if (!run_scan(sync_env, true)) {
+    ReplaySeekJob job{[&](OperationEnvironment &env){
+      run_scan(env, false);
+    }};
+
+    RunSeekJob(runner, job);
+  }
+
+  /* when the seek stopped early (end of recording, time warp or
+     cancelled), stay at the last applied fix instead of jumping past
+     the applied data */
+  virtual_time = complete ? target_ts : last_time;
+
+  if (complete && cli != nullptr) {
+    while (cli->NeedData(virtual_time)) {
+      if (!ReadNextFix(next_data))
+        break;
+
+      if (next_data.time_available)
+        cli->Update(next_data.time, next_data.location,
+                    next_data.gps_altitude, next_data.pressure_altitude);
+    }
+
+    if (cli->Ready())
+      ApplyReplayFix(device_blackboard, merge_thread, calculation_thread,
+                     MakeInterpolatedFix(*cli, virtual_time, next_data));
+  }
+
+  fast_forward = TimeStamp::Undefined();
+  clock.Update();
+
+  {
+    const std::lock_guard lock{device_blackboard.mutex};
+    CommonInterface::ReadBlackboardBasic(device_blackboard.Basic());
+  }
+
+  TriggerCalculatedUpdate();
+  TriggerVarioUpdate();
+
+  return true;
+}
+
+bool
+Replay::ForwardScan(MergeThread &merge_thread,
+                    CalculationThread &calculation_thread,
+                    JobRunner &runner,
+                    std::function<bool(OperationEnvironment &)> matched) noexcept
+{
+  timer.Cancel();
+
+  /* declared before the suspension guard so the timer is re-armed
+     after the worker threads have been resumed */
+  AtScopeExit(this) {
+    if (IsActive())
+      timer.Schedule(std::chrono::milliseconds(100));
+  };
+
+  const ScopedWorkerSuspend suspend{merge_thread, calculation_thread};
+
+  bool found = false;
+  TimeStamp last_time = virtual_time;
+
+  /* returns false when the time budget ran out and the scan must
+     continue in a job behind the progress dialog */
+  const auto run_scan = [&](OperationEnvironment &env, bool bounded){
+    PeriodClock budget;
+    budget.Update();
+
+    while (!env.IsCancelled()) {
+      if (bounded && budget.Check(SYNC_SEEK_BUDGET))
+        return false;
+
+      if (!ReadNextFix(next_data))
+        break;
+
+      if (!next_data.time_available)
+        continue;
+
+      if (next_data.time < last_time)
+        /* time warp, e.g. midnight wraparound during NMEA replay */
+        break;
+
+      ApplyReplayFix(device_blackboard, merge_thread, calculation_thread,
+                     next_data);
+      last_time = next_data.time;
+
+      if (cli != nullptr)
+        cli->Update(next_data.time, next_data.location,
+                    next_data.gps_altitude, next_data.pressure_altitude);
+
+      if (matched(env)) {
+        found = true;
+        break;
+      }
+    }
+
+    return true;
+  };
+
+  /* scan synchronously first: short seeks finish without flashing a
+     progress dialog, only long ones escalate to the runner */
+  NullOperationEnvironment sync_env;
+  if (!run_scan(sync_env, true)) {
+    ReplaySeekJob job{[&](OperationEnvironment &env){
+      run_scan(env, false);
+    }};
+
+    RunSeekJob(runner, job);
+  }
+
+  /* even when no match was found (end of recording, time warp or
+     cancelled), keep the position that was reached, so playback
+     resumes consistently with the fixes already applied */
+  if (last_time > virtual_time) {
+    virtual_time = last_time;
+    fast_forward = TimeStamp::Undefined();
+    clock.Update();
+
+    {
+      const std::lock_guard lock{device_blackboard.mutex};
+      CommonInterface::ReadBlackboardBasic(device_blackboard.Basic());
+    }
+
+    TriggerCalculatedUpdate();
+    TriggerVarioUpdate();
+  }
+
+  return found;
+}
+
+bool
+Replay::ForwardScanToTime(TimeStamp target_ts, TimeStamp progress_end,
+                          MergeThread &merge_thread,
+                          CalculationThread &calculation_thread,
+                          JobRunner &runner) noexcept
+{
+  const TimeStamp start = virtual_time;
+  const double progress_range =
+    std::max(1., (progress_end - start).count());
+
+  /* reaching the end of the recording before the target is not an
+     error, so the scan result is ignored */
+  ForwardScan(merge_thread, calculation_thread, runner,
+              [this, start, target_ts, progress_range,
+               progress_clock = PeriodClock{}]
+              (OperationEnvironment &env) mutable {
+    if (progress_clock.CheckUpdate(PROGRESS_UPDATE_INTERVAL)) {
+      env.SetProgressRange(unsigned(progress_range));
+
+      const auto elapsed = next_data.time - start;
+      env.SetProgressPosition(
+        unsigned(std::clamp(elapsed.count(), 0., progress_range)));
+      SetProgressText(env, elapsed.count(), progress_range);
+    }
+
+    return next_data.time >= target_ts;
+  });
+
+  return true;
+}
+
+bool
+Replay::SeekToNextFlightMode(CirclingMode mode,
+                              MergeThread &merge_thread,
+                              CalculationThread &calculation_thread,
+                              JobRunner &runner) noexcept
+{
+  /* an empty path means demo mode, which has no recording to seek
+     in */
+  if (!IsActive() || path == nullptr || path.empty() ||
+      !virtual_time.IsDefined())
+    return false;
+
+  /* the number of fixes until the requested phase cannot be known in
+     advance, so the bar shows how far through the remaining recording
+     the scan has come */
+  const unsigned total_fixes = ScanRecording(path).fix_lines;
+  const unsigned remaining_fixes =
+    total_fixes > fixes_read ? total_fixes - fixes_read : 0;
+
+  bool passed_current_phase =
+    !IsInPhase(mode, device_blackboard.Calculated().turn_mode);
+  const TimeStamp scan_start = virtual_time;
+
+  return ForwardScan(merge_thread, calculation_thread, runner,
+                     [this, mode, passed_current_phase,
+                      remaining_fixes, scan_start, applied = 0u,
+                      progress_clock = PeriodClock{}]
+                     (OperationEnvironment &env) mutable {
+    ++applied;
+
+    if (progress_clock.CheckUpdate(PROGRESS_UPDATE_INTERVAL)) {
+      if (remaining_fixes > 0) {
+        env.SetProgressRange(remaining_fixes);
+        env.SetProgressPosition(std::min(applied, remaining_fixes));
+      }
+
+      SetProgressText(env, (next_data.time - scan_start).count(), 0);
+    }
+
+    const auto current = device_blackboard.Calculated().turn_mode;
+    if (!passed_current_phase && !IsInPhase(mode, current))
+      passed_current_phase = true;
+
+    return passed_current_phase && current == mode;
+  });
 }
 
 bool
@@ -121,7 +712,7 @@ Replay::Update()
     }
 
     while (true) {
-      if (!replay->Update(next_data)) {
+      if (!ReadNextFix(next_data)) {
         Stop();
         return false;
       }
@@ -150,7 +741,7 @@ Replay::Update()
     }
   } else {
     while (cli->NeedData(virtual_time)) {
-      if (!replay->Update(next_data)) {
+      if (!ReadNextFix(next_data)) {
         Stop();
         return false;
       }
@@ -170,23 +761,7 @@ Replay::Update()
       clock.Update();
     }
 
-    const CatmullRomInterpolator::Record r = cli->Interpolate(virtual_time);
-    const GeoVector v = cli->GetVector(virtual_time);
-
-    NMEAInfo data = next_data;
-    data.clock = virtual_time;
-    data.alive.Update(data.clock);
-    data.ProvideTime(virtual_time);
-    data.location = r.location;
-    data.location_available.Update(data.clock);
-    data.ground_speed = v.distance;
-    data.ground_speed_available.Update(data.clock);
-    data.track = v.bearing;
-    data.track_available.Update(data.clock);
-    data.gps_altitude = r.gps_altitude;
-    data.gps_altitude_available.Update(data.clock);
-    data.ProvidePressureAltitude(r.baro_altitude);
-    data.ProvideBaroAltitudeTrue(r.baro_altitude);
+    const NMEAInfo data = MakeInterpolatedFix(*cli, virtual_time, next_data);
 
     {
       const std::lock_guard lock{device_blackboard.mutex};
@@ -212,7 +787,7 @@ Replay::ProcessAllFixes(MergeThread &merge_thread,
   data.Reset();
   unsigned count = 0;
 
-  while (replay->Update(data)) {
+  while (ReadNextFix(data)) {
     assert(!data.gps.real);
 
     if (data.time_available)

--- a/src/Replay/Replay.hpp
+++ b/src/Replay/Replay.hpp
@@ -173,6 +173,19 @@ public:
                             CalculationThread &calculation_thread,
                             JobRunner &runner) noexcept;
 
+  /**
+   * Skip the replay forward by the given duration from the current
+   * position, applying every fix on the way.  Unlike FastForward(),
+   * this jumps immediately instead of playing back faster.  The scan
+   * is run through the given #JobRunner, which may report progress
+   * and allow cancelling; reaching the end of the recording is not
+   * an error.
+   */
+  bool SeekForward(FloatDuration delta,
+                   MergeThread &merge_thread,
+                   CalculationThread &calculation_thread,
+                   JobRunner &runner) noexcept;
+
 private:
   /**
    * Read the next fix from the #AbstractReplay, keeping #fixes_read

--- a/src/Replay/Replay.hpp
+++ b/src/Replay/Replay.hpp
@@ -73,6 +73,35 @@ class Replay final
 
   CatmullRomInterpolator *cli = nullptr;
 
+  /**
+   * Cheap parse-only summary of a recording, used to scale the seek
+   * progress bar and to find the time of the first fix.
+   */
+  struct RecordingScan {
+    /**
+     * The number of lines that will produce replay fixes (IGC B
+     * records); 0 if unknown for this file type.
+     */
+    unsigned fix_lines = 0;
+
+    /**
+     * The time of day of the first fix, or undefined if unknown.
+     */
+    TimeStamp start_time = TimeStamp::Undefined();
+
+    /**
+     * The time of day of the last fix, or undefined if unknown.
+     */
+    TimeStamp end_time = TimeStamp::Undefined();
+  };
+
+  /**
+   * The scan of #path, filled by the first seek and reused by the
+   * following ones; invalidated when Start() loads another file.
+   */
+  RecordingScan recording_scan;
+  bool recording_scan_valid = false;
+
 public:
   Replay(DeviceBlackboard &_device_blackboard,
          Logger *_logger, ProtectedTaskManager &_task_manager)
@@ -187,6 +216,12 @@ public:
                    JobRunner &runner) noexcept;
 
 private:
+  /**
+   * Return the scan of the current recording, reading the file once
+   * and caching the result.
+   */
+  const RecordingScan &GetRecordingScan() noexcept;
+
   /**
    * Read the next fix from the #AbstractReplay, keeping #fixes_read
    * up to date.  An I/O or parser error ends the recording just like

--- a/src/Replay/Replay.hpp
+++ b/src/Replay/Replay.hpp
@@ -9,6 +9,10 @@
 #include "time/Stamp.hpp"
 #include "system/Path.hpp"
 
+#include "NMEA/CirclingInfo.hpp"
+
+#include <functional>
+
 class DeviceBlackboard;
 class Logger;
 class ProtectedTaskManager;
@@ -16,6 +20,8 @@ class AbstractReplay;
 class CatmullRomInterpolator;
 class MergeThread;
 class CalculationThread;
+class JobRunner;
+class OperationEnvironment;
 class Error;
 
 class Replay final
@@ -58,6 +64,12 @@ class Replay final
    * is held back until #virtual_time has passed #next_data.time.
    */
   NMEAInfo next_data;
+
+  /**
+   * The number of fixes read from the #AbstractReplay since Start().
+   * Used to scale the seek progress bar.
+   */
+  unsigned fixes_read;
 
   CatmullRomInterpolator *cli = nullptr;
 
@@ -129,6 +141,72 @@ public:
   unsigned ProcessAllFixes(MergeThread &merge_thread,
                            CalculationThread &calc_thread);
 
+  /**
+   * The largest flight minute SeekToFlightElapsedMinutes() accepts,
+   * and the upper bound the dialog offers.
+   */
+  static constexpr unsigned MAX_SEEK_MINUTES = 24 * 60;
+
+  /**
+   * Seek to the given number of minutes after the first fix of the
+   * current recording, merging every fix into the blackboard.  A
+   * target ahead of the current position is reached by scanning
+   * forward, keeping the flight state accumulated so far; only a
+   * target behind it restarts the recording and replays it from the
+   * beginning.  The scan is run through the given #JobRunner, which
+   * may report progress and allow cancelling; a cancelled seek keeps
+   * the position that was reached.
+   */
+  bool SeekToFlightElapsedMinutes(unsigned minutes,
+                                  MergeThread &merge_thread,
+                                  CalculationThread &calculation_thread,
+                                  JobRunner &runner) noexcept;
+
+  /**
+   * Replay forward from the current position until the flight mode
+   * changes to the requested state (circling or cruise).  The scan is
+   * run through the given #JobRunner, which may allow cancelling; a
+   * cancelled seek keeps the position that was reached.
+   */
+  bool SeekToNextFlightMode(CirclingMode mode,
+                            MergeThread &merge_thread,
+                            CalculationThread &calculation_thread,
+                            JobRunner &runner) noexcept;
+
 private:
+  /**
+   * Read the next fix from the #AbstractReplay, keeping #fixes_read
+   * up to date.  An I/O or parser error ends the recording just like
+   * reaching its end, so seeks can be noexcept.
+   */
+  bool ReadNextFix(NMEAInfo &data) noexcept;
+
+  /**
+   * Apply fixes forward from the current position through merge and
+   * calculation until the given predicate matches the state after a
+   * fix, the recording ends, time warps or the scan is cancelled.
+   * The worker threads are suspended while scanning, and the reached
+   * position becomes the new playback position.  Call only while the
+   * replay is active with a defined #virtual_time and not in demo
+   * mode.
+   *
+   * @return true if the predicate matched
+   */
+  bool ForwardScan(MergeThread &merge_thread,
+                   CalculationThread &calculation_thread,
+                   JobRunner &runner,
+                   std::function<bool(OperationEnvironment &)> matched) noexcept;
+
+  /**
+   * Scan forward from the current position until the given time of
+   * day, showing progress scaled to \a progress_end (usually the
+   * target, clamped at the recording end).  Reaching the end of the
+   * recording before the target is not an error.
+   */
+  bool ForwardScanToTime(TimeStamp target_ts, TimeStamp progress_end,
+                         MergeThread &merge_thread,
+                         CalculationThread &calculation_thread,
+                         JobRunner &runner) noexcept;
+
   void OnTimer();
 };

--- a/src/lua/Replay.cpp
+++ b/src/lua/Replay.cpp
@@ -7,15 +7,36 @@
 #include "Util.hxx"
 #include "system/Path.hpp"
 #include "Replay/Replay.hpp"
+#include "NMEA/CirclingInfo.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
 #include "CalculationThread.hpp"
 #include "MergeThread.hpp"
+#include "Job/Job.hpp"
+#include "Job/Runner.hpp"
+#include "Operation/Operation.hpp"
 #include "Protection.hpp"
 
 extern "C" {
 #include <lauxlib.h>
 }
+
+namespace {
+
+/**
+ * Runs a replay seek synchronously, without a progress dialog;
+ * scripts have no UI to report progress to.
+ */
+class InlineJobRunner final : public JobRunner {
+public:
+  bool Run(Job &job) override {
+    NullOperationEnvironment env;
+    job.Run(env);
+    return true;
+  }
+};
+
+} // namespace
 
 static int
 l_replay_index(lua_State *L)
@@ -57,6 +78,64 @@ l_replay_fastforward(lua_State *L)
 
   FloatDuration delta_s{luaL_checknumber(L, 1)};
   return !backend_components->replay->FastForward(delta_s);
+}
+
+static int
+l_replay_seek_to_flight_minutes(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "Invalid parameters");
+
+  if (backend_components == nullptr ||
+      backend_components->replay == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return luaL_error(L, "Replay seek unavailable");
+
+  const auto minutes = static_cast<unsigned>(luaL_checkinteger(L, 1));
+  InlineJobRunner runner;
+  const bool ok =
+    backend_components->replay->SeekToFlightElapsedMinutes(
+      minutes, *backend_components->merge_thread,
+      *backend_components->calculation_thread, runner);
+  Lua::Push(L, ok);
+  return 1;
+}
+
+static int
+l_replay_seek_to_next_circling(lua_State *L)
+{
+  if (backend_components == nullptr ||
+      backend_components->replay == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return luaL_error(L, "Replay seek unavailable");
+
+  InlineJobRunner runner;
+  const bool ok =
+    backend_components->replay->SeekToNextFlightMode(
+      CirclingMode::CLIMB, *backend_components->merge_thread,
+      *backend_components->calculation_thread, runner);
+  Lua::Push(L, ok);
+  return 1;
+}
+
+static int
+l_replay_seek_to_next_cruise(lua_State *L)
+{
+  if (backend_components == nullptr ||
+      backend_components->replay == nullptr ||
+      backend_components->merge_thread == nullptr ||
+      backend_components->calculation_thread == nullptr)
+    return luaL_error(L, "Replay seek unavailable");
+
+  InlineJobRunner runner;
+  const bool ok =
+    backend_components->replay->SeekToNextFlightMode(
+      CirclingMode::CRUISE, *backend_components->merge_thread,
+      *backend_components->calculation_thread, runner);
+  Lua::Push(L, ok);
+  return 1;
 }
 
 static int
@@ -124,6 +203,9 @@ l_replay_process_all([[maybe_unused]] lua_State *L)
 static constexpr struct luaL_Reg settings_funcs[] = {
   {"set_time_scale", l_replay_settimescale},
   {"fast_forward", l_replay_fastforward},
+  {"seek_to_flight_minutes", l_replay_seek_to_flight_minutes},
+  {"seek_to_next_circling", l_replay_seek_to_next_circling},
+  {"seek_to_next_cruise", l_replay_seek_to_next_cruise},
   {"start", l_replay_start},
   {"stop", l_replay_stop},
   {"process_all", l_replay_process_all},

--- a/src/ui/event/sdl/Queue.cpp
+++ b/src/ui/event/sdl/Queue.cpp
@@ -44,7 +44,14 @@ EventQueue::Generate(Event &event) noexcept
 bool
 EventQueue::Pop(Event &event) noexcept
 {
-  return !quit && (Generate(event) || ::SDL_PollEvent(&event.event));
+  if (quit)
+    return false;
+
+  /* update the cached clock so due timers are dispatched even while
+     events keep arriving and Wait() never runs into its timeout */
+  FlushClockCaches();
+
+  return Generate(event) || ::SDL_PollEvent(&event.event);
 }
 
 bool
@@ -58,6 +65,8 @@ EventQueue::Wait(Event &event) noexcept
     return false;
 
   while (true) {
+    FlushClockCaches();
+
     if (Generate(event))
       return true;
 
@@ -71,8 +80,6 @@ EventQueue::Wait(Event &event) noexcept
       : SDL_WaitEvent(&event.event);
     if (result != 0)
       return result > 0;
-
-    FlushClockCaches();
   }
 }
 


### PR DESCRIPTION
Closes #933.

Adds seek to a chosen flight minute and seek to the next circling or cruise phase, and turns the +10' button into a real ten minute skip instead of fast forward mode, as asked for in #933. The flight minute seek picks up the idea from the mockup in #2472. Each seek applies every fix through merge and calculation, so trail, statistics and phases stay consistent, and it only restarts the recording when the target lies behind the current position.

Every seek scans inline for up to 500 ms, so short ones show no dialog. Only when that budget runs out does the rest move to a worker thread and the progress dialog appears, with a bar and a cancel button.

<img width="33%" alt="Bildschirmfoto 2026-08-21 um 14 32 37" src="https://github.com/user-attachments/assets/fd8d6626-c74f-4430-ba03-c159205ccb68" />
<img width="33%" alt="Bildschirmfoto 2026-08-21 um 14 33 05" src="https://github.com/user-attachments/assets/937146ab-2eb0-48f6-bee4-3a9a8c5c1671" />


Two questions for reviewers: 19a637f fixes the cached clock in the SDL event queue, where timers never became due while events kept arriving, which is why the progress bar stayed empty on macOS and iOS. It is an independent fix in shared code, so can it go in without putting the rest of XCSoar at risk? And 4f88e3b still contains a fair amount of LLM written code: is this an acceptable way to implement the seek logic in `src/Replay/Replay.cpp`, especially suspending and resuming the worker threads around the scan? I am not yet confident about thread handling in C++, so a close look there would be welcome.

I have not yet got around to testing this on top of #2819.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added replay seeking by elapsed flight time.
  * Added controls to jump forward 10 minutes or move to the next circling or cruise phase.
  * Added progress reporting and cancellation for longer seek operations.
  * Added Lua support for replay seeking.
* **Bug Fixes**
  * Improved replay restart handling by resetting flight state.
  * Improved replay accuracy when seeking through recorded flights.
  * Improved event timing and responsiveness during event processing.
  * Improved handling of replay speed and interpolated positions during seeking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->