### PR TITLE
Erase the gesture trail after it leaves the map window

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1328,11 +1328,12 @@ MainWindow::OnPaint(Canvas &canvas) noexcept
      window repaints (the safe area insets reserved by the
      #TopWindow, for example) would keep those pixels forever, and
      each buffer of the swap chain needs a clean frame of its own.
-     Therefore clear the whole window while a trail exists, and for a
-     few frames after it is gone. */
+     Therefore clear the whole window while a trail exists, and for
+     as many extra frames as the swap chain has buffers after it is
+     gone. */
   const bool gesture_trail = map != nullptr && map->HasGestureTrail();
   if (gesture_trail)
-    clear_gesture_frames = 3;
+    clear_gesture_frames = GetPresentationBufferCount();
 
   if (gesture_trail || clear_gesture_frames > 0) {
     canvas.DrawFilledRectangle(canvas.GetRect(), COLOR_BLACK);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1321,6 +1321,28 @@ MainWindow::OnClose() noexcept
 void
 MainWindow::OnPaint(Canvas &canvas) noexcept
 {
+#ifdef ENABLE_OPENGL
+  /* The gesture trail is painted by the #GlueMapWindow, but it
+     follows the pointer past the map borders, and OpenGL does not
+     clip a child window to its rectangle.  Areas which no child
+     window repaints (the safe area insets reserved by the
+     #TopWindow, for example) would keep those pixels forever, and
+     each buffer of the swap chain needs a clean frame of its own.
+     Therefore clear the whole window while a trail exists, and for a
+     few frames after it is gone. */
+  const bool gesture_trail = map != nullptr && map->HasGestureTrail();
+  if (gesture_trail)
+    clear_gesture_frames = 3;
+
+  if (gesture_trail || clear_gesture_frames > 0) {
+    canvas.DrawFilledRectangle(canvas.GetRect(), COLOR_BLACK);
+
+    if (!gesture_trail && --clear_gesture_frames > 0)
+      /* nothing else is going to request the remaining frames */
+      Invalidate();
+  }
+#endif
+
   if (HaveTopWidget() && map != nullptr) {
     /* draw a separator between top widget and map */
     PixelRect rc = map->GetPosition();

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -162,6 +162,16 @@ private:
    * because the map was replaced by a #Widget.
    */
   bool draw_suspended = false;
+#else
+  /**
+   * Number of frames which must still be repainted with a cleared
+   * background to erase a gesture trail which the #GlueMapWindow has
+   * painted outside its own rectangle.  Every buffer of the swap
+   * chain needs a frame of its own.
+   *
+   * @see OnPaint()
+   */
+  unsigned clear_gesture_frames = 0;
 #endif
 
   bool restore_page_pending = false;

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -166,10 +166,11 @@ private:
   /**
    * Number of frames which must still be repainted with a cleared
    * background to erase a gesture trail which the #GlueMapWindow has
-   * painted outside its own rectangle.  Every buffer of the swap
-   * chain needs a frame of its own.
+   * painted outside its own rectangle.  Sized from the swap-chain
+   * depth so every presentation buffer gets a clean frame.
    *
    * @see OnPaint()
+   * @see TopWindow::GetPresentationBufferCount()
    */
   unsigned clear_gesture_frames = 0;
 #endif

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -92,6 +92,20 @@ class GlueMapWindow : public MapWindow {
 #endif
   }
 
+public:
+  /**
+   * Is a gesture trail currently visible?  Under OpenGL, it may
+   * extend beyond this window, because the pointer is captured while
+   * the gesture is drawn.
+   *
+   * @see MainWindow::OnPaint()
+   */
+  [[gnu::pure]]
+  bool HasGestureTrail() const noexcept {
+    return gestures.HasPoints();
+  }
+
+private:
   /**
    * Should pan chrome (crosshair, pan info) be drawn?  Hidden during
    * an early multi-touch gesture that has not yet committed pan UI,

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -335,6 +335,11 @@ GlueMapWindow::OnMouseUp(PixelPoint p) noexcept
 
   case DRAG_GESTURE:
     const char* gesture = gestures.Finish();
+
+    /* repaint to erase the gesture trail; the map is not redrawn on
+       its own unless the gesture happens to trigger it */
+    PaintWindow::Invalidate();
+
     if (gesture && OnMouseGesture(gesture))
       return true;
 
@@ -663,8 +668,12 @@ GlueMapWindow::OnCancelMode() noexcept
     ResetMultiTouchSessionState();
 #endif
 
-    if (drag_mode == DRAG_GESTURE)
+    if (drag_mode == DRAG_GESTURE) {
       gestures.Finish();
+
+      /* repaint to erase the gesture trail */
+      PaintWindow::Invalidate();
+    }
 
     ReleaseCapture();
     drag_mode = DRAG_NONE;
@@ -693,6 +702,9 @@ GlueMapWindow::OnPaint(Canvas &canvas) noexcept
   if (IsPanChromeVisible())
     DrawCrossHairs(canvas);
 
+  /* the trail may leave this window (the pointer is captured); under
+     OpenGL it is painted over the InfoBoxes, and MainWindow::OnPaint()
+     takes care of erasing it afterwards */
   DrawGesture(canvas);
 }
 

--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -66,6 +66,17 @@ class TopCanvas
   const LinuxGraphicsTTY linux_graphics_tty;
 #endif
 
+#ifdef ENABLE_OPENGL
+  /**
+   * Swap-chain depth.  Extra full-window clears after an OpenGL
+   * gesture trail use this so every presentation buffer gets a
+   * clean frame.  Default 4 covers typical EGL/Android queues
+   * (triple-buffer plus a spare); Android overwrites it from the
+   * native window when the surface is acquired.
+   */
+  unsigned presentation_buffer_count = 4;
+#endif
+
 #ifdef USE_EGL
 
 #ifdef MESA_KMS
@@ -177,6 +188,14 @@ public:
    */
   [[gnu::pure]]
   PixelSize GetNativeSize() const noexcept;
+#endif
+
+#ifdef ENABLE_OPENGL
+  /**
+   * How many presentation buffers does the swap chain use?
+   */
+  [[gnu::pure]]
+  unsigned GetPresentationBufferCount() const noexcept;
 #endif
 
 #if defined(USE_MEMORY_CANVAS) || defined(ENABLE_OPENGL)

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -123,6 +123,18 @@ TopCanvas::AcquireSurface()
   if (native_window == nullptr)
     return false;
 
+  int min_undequeued = 0;
+  if (ANativeWindow_query(native_window,
+                          NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS,
+                          &min_undequeued) == 0 &&
+      min_undequeued > 0) {
+    /* BufferQueue: minUndequeued + 1 for the producer, +1 if
+       eglSwapBuffers is asynchronous. */
+    unsigned n = unsigned(min_undequeued) + 2;
+    if (n > presentation_buffer_count)
+      presentation_buffer_count = n;
+  }
+
   CreateSurface(native_window);
 
   return true;

--- a/src/ui/canvas/opengl/TopCanvas.cpp
+++ b/src/ui/canvas/opengl/TopCanvas.cpp
@@ -7,10 +7,42 @@
 #include "Init.hpp"
 #include "Math/Point2D.hpp"
 
+#ifdef USE_EGL
+#include "ui/display/Display.hpp"
+
+#include <algorithm>
+#endif
+
 PixelSize
 TopCanvas::GetSize() const noexcept
 {
   return {OpenGL::viewport_size.x, OpenGL::viewport_size.y};
+}
+
+unsigned
+TopCanvas::GetPresentationBufferCount() const noexcept
+{
+  unsigned count = presentation_buffer_count;
+
+#ifdef USE_EGL
+  if (surface != EGL_NO_SURFACE) {
+#ifdef EGL_BUFFER_AGE_KHR
+    const EGLint age_attr = EGL_BUFFER_AGE_KHR;
+#else
+    const EGLint age_attr = 0x313D;
+#endif
+    auto age = display.QuerySurface(surface, age_attr);
+    if (age && *age > 0)
+      count = std::max(count, unsigned(*age));
+  }
+#endif
+
+  if (count < 3)
+    count = 3;
+  else if (count > 8)
+    count = 8;
+
+  return count;
 }
 
 PixelSize

--- a/src/ui/window/TopWindow.hpp
+++ b/src/ui/window/TopWindow.hpp
@@ -298,6 +298,13 @@ public:
   uint32_t GetRenderStateToken() const noexcept {
     return render_state_token;
   }
+
+  /**
+   * Swap-chain depth.  Used to erase an OpenGL gesture trail from
+   * every presentation buffer.
+   */
+  [[gnu::pure]]
+  unsigned GetPresentationBufferCount() const noexcept;
 #endif
 
 #ifdef ANDROID

--- a/src/ui/window/custom/TopWindow.cpp
+++ b/src/ui/window/custom/TopWindow.cpp
@@ -53,6 +53,16 @@ TopWindow::~TopWindow() noexcept
   delete screen;
 }
 
+#ifdef ENABLE_OPENGL
+unsigned
+TopWindow::GetPresentationBufferCount() const noexcept
+{
+  return screen != nullptr
+    ? screen->GetPresentationBufferCount()
+    : 4;
+}
+#endif
+
 void
 TopWindow::Create([[maybe_unused]] const char *text, PixelSize size,
                   TopWindowStyle style)


### PR DESCRIPTION
The red gesture trail could be drawn beyond the map borders and stayed there after releasing the finger. The map window holds the pointer capture during a gesture, and under OpenGL a child window is not clipped to its rectangle, so the trail ends up outside the map. Nothing ever erased those pixels again.

Sibling windows repaint themselves every frame, so their area recovers on its own. Areas that no child window covers do not, and every buffer of the swap chain needs its own clean frame. The main window now clears its whole area while a trail exists and for a few frames afterwards, and the map window invalidates when a gesture finishes or is cancelled. Limited to OpenGL, since the other backends clip the trail anyway.

<img width="33%" alt="Bildschirmfoto 2026-08-21 um 21 48 23" src="https://github.com/user-attachments/assets/8f021d4c-f0f2-47c3-afdc-ade857180d83" />

No News.txt entry is needed for this PR in my opinion.

*(Ignore the missing InfoBoxes. This screenshot was taken in my testing branch for "invisible InfoBoxes".)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gesture trails that could remain visible after a gesture was completed or canceled.
  * Improved screen refreshing to reliably clear gesture trails across rendered frames.
  * Prevented stale visual artifacts from appearing during gesture interactions.
  * Improved rendering reliability across different display and buffering configurations, reducing leftover visual artifacts after gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->