### PR TITLE
Fix scrolling lists inside settings panels

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -94,6 +94,10 @@ Version 7.46 - not yet released
     makes the short scroll bars in settings panels usable at all
   - on touch screens, swiping a list scrolls it without dragging the
     selection to the row the finger came down on
+  - fix dragging inside a settings panel, e.g. scrolling the list in
+    Setup / Look / Pages: the panel claimed every drag that started
+    on one of its controls, so the list and its scroll bar never
+    moved
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -98,6 +98,9 @@ Version 7.46 - not yet released
     Setup / Look / Pages: the panel claimed every drag that started
     on one of its controls, so the list and its scroll bar never
     moved
+  - fix a settings panel going dead after a swipe: the control the
+    swipe had started on kept the mouse capture, so every later press
+    was delivered to it instead of to the control that was pressed
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -89,6 +89,11 @@ Version 7.46 - not yet released
   - fix blurry icons on high-DPI screens, most visible on the large
     waypoint list icons, by rendering the icon set at a higher
     resolution
+  - pressing the scroll bar of a list beside the slider now moves the
+    slider to that spot instead of stepping a row or a page, which
+    makes the short scroll bars in settings panels usable at all
+  - on touch screens, swiping a list scrolls it without dragging the
+    selection to the row the finger came down on
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development

--- a/src/Form/VScrollPanel.cpp
+++ b/src/Form/VScrollPanel.cpp
@@ -252,12 +252,11 @@ VScrollPanel::OnMouseUp(PixelPoint p) noexcept
        StringIsEqual(gesture, "R"))) {
     /* Horizontal swipe detected — defer listener: flipping the pager
        from here would hide this panel during OnMouseUp (crash). */
-    if (dragging) {
-      dragging = false;
-      ReleaseCapture();
-    }
-    if (potential_tap) {
-      potential_tap = false;
+    if (dragging || potential_tap) {
+      dragging = potential_tap = false;
+      /* the child that accepted the press does not get this
+         mouse-up */
+      CancelChildCapture();
       ReleaseCapture();
     }
     defer_swipe_queue.push_back(
@@ -276,6 +275,9 @@ VScrollPanel::OnMouseUp(PixelPoint p) noexcept
     const bool enable_kinetic = UsePixelPan();
 
     dragging = false;
+    /* we swallowed the gesture that started on the child (see
+       #potential_tap), so it does not get this mouse-up either */
+    CancelChildCapture();
     ReleaseCapture();
 
     if (enable_kinetic) {

--- a/src/Form/VScrollPanel.cpp
+++ b/src/Form/VScrollPanel.cpp
@@ -361,22 +361,26 @@ VScrollPanel::OnMouseDown(PixelPoint p) noexcept
     }
     return true;
   } else {
-    /* Start gesture tracking for swipe detection only in the
-       content area — not on the scrollbar, where slight horizontal
-       finger movement during a tap would misfire as a page-change
-       swipe (especially noticeable on e-ink touch screens). */
-    gesture_tracking = true;
-    gestures.Start(p, Layout::Scale(20));
-
     // First, let child widgets handle the event
     if (PanelControl::OnMouseDown(p)) {
+      if (HandlesDragging())
+        /* The child that took the press drags itself (a list that
+           pans, its scroll bar slider).  Leave the whole gesture to
+           it: capturing here would make EventChildAt() route every
+           further event to us, and the child would never see the rest
+           of its own drag.  Do not track a swipe either - panning a
+           list sideways must not flip the page. */
+        return true;
+
       potential_tap = true;
       drag_start = p;
+      StartGestureTracking(p);
       SetCapture();
       return true;
     }
 
     // No child widget handled it, so start dragging the content area
+    StartGestureTracking(p);
     dragging = true;
     drag_y = (int)origin + p.y;
     if (UsePixelPan())
@@ -384,6 +388,17 @@ VScrollPanel::OnMouseDown(PixelPoint p) noexcept
     SetCapture();
     return true;
   }
+}
+
+void
+VScrollPanel::StartGestureTracking(PixelPoint p) noexcept
+{
+  /* Track swipes only in the content area — not on the scrollbar,
+     where slight horizontal finger movement during a tap would
+     misfire as a page-change swipe (especially noticeable on e-ink
+     touch screens). */
+  gesture_tracking = true;
+  gestures.Start(p, Layout::Scale(20));
 }
 
 bool

--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -182,6 +182,13 @@ public:
   }
 
 private:
+  /**
+   * Begin watching the pointer for a swipe gesture.
+   *
+   * @param p the position of the press, relative to this window
+   */
+  void StartGestureTracking(PixelPoint p) noexcept;
+
   void SetupScrollBar() noexcept;
   void SetOriginClamped(int new_origin) noexcept;
   void OnKineticTimer() noexcept;

--- a/src/ui/control/List.cpp
+++ b/src/ui/control/List.cpp
@@ -506,7 +506,18 @@ ListControl::OnMouseUp(PixelPoint p) noexcept
   if (drag_mode == DragMode::SCROLL || drag_mode == DragMode::CURSOR) {
     const bool enable_kinetic = UsePixelPan() && drag_mode == DragMode::SCROLL;
 
+    /* a touch that did not turn into a scroll gesture selects the
+       item it started on (see #pending_cursor) */
+    const int tapped = drag_scrolled ? -1 : pending_cursor;
+
     drag_end();
+
+    if (tapped >= 0) {
+      /* undo the wobble of a finger that did not really scroll */
+      SetPixelOrigin(drag_y - drag_y_window);
+      SetCursorIndex(tapped);
+      return true;
+    }
 
     if (enable_kinetic) {
       kinetic.MouseUp(GetPixelOrigin());
@@ -521,6 +532,9 @@ ListControl::OnMouseUp(PixelPoint p) noexcept
 void
 ListControl::drag_end() noexcept
 {
+  pending_cursor = -1;
+  drag_scrolled = false;
+
   if (drag_mode != DragMode::NONE) {
     if (drag_mode == DragMode::CURSOR)
       InvalidateItem(cursor);
@@ -536,16 +550,10 @@ ListControl::OnMouseMove(PixelPoint p, unsigned keys) noexcept
   // If we are currently dragging the ScrollBar slider
   if (scroll_bar.IsDragging()) {
     // -> Update ListBox origin
-    if (UsePixelPan())
-      SetPixelOrigin(scroll_bar.DragMove(length * item_height,
-                                         GetSize().height,
-                                         p.y));
-    else
-      SetOrigin(scroll_bar.DragMove(length, items_visible, p.y));
-
+    ScrollBarDragMove(p.y);
     return true;
   } else if (drag_mode == DragMode::CURSOR) {
-    if (abs(p.y - drag_y_window) > ((int)item_height / 5)) {
+    if (IsScrollGesture(p.y)) {
       drag_mode = DragMode::SCROLL;
       InvalidateItem(cursor);
     } else
@@ -553,6 +561,9 @@ ListControl::OnMouseMove(PixelPoint p, unsigned keys) noexcept
   }
 
   if (drag_mode == DragMode::SCROLL) {
+    if (IsScrollGesture(p.y))
+      drag_scrolled = true;
+
     int new_origin = drag_y - p.y;
     SetPixelOrigin(new_origin);
     if (UsePixelPan())
@@ -561,6 +572,16 @@ ListControl::OnMouseMove(PixelPoint p, unsigned keys) noexcept
   }
 
   return PaintWindow::OnMouseMove(p, keys);
+}
+
+void
+ListControl::ScrollBarDragMove(int y) noexcept
+{
+  if (UsePixelPan())
+    SetPixelOrigin(scroll_bar.DragMove(length * item_height,
+                                       GetSize().height, y));
+  else
+    SetOrigin(scroll_bar.DragMove(length, items_visible, y));
 }
 
 bool
@@ -582,19 +603,15 @@ ListControl::OnMouseDown(PixelPoint Pos) noexcept
     // -> start mouse drag
     scroll_bar.DragBegin(this, Pos.y);
   } else if (scroll_bar.IsInside(Pos)) {
-    // if click in scroll bar up/down/pgup/pgdn
-    if (scroll_bar.IsInsideUpArrow(Pos.y))
-      // up
-      MoveOrigin(-1);
-    else if (scroll_bar.IsInsideDownArrow(Pos.y))
-      // down
-      MoveOrigin(1);
-    else if (scroll_bar.IsAboveSlider(Pos.y))
-      // page up
-      MoveOrigin(-(int)items_visible);
-    else if (scroll_bar.IsBelowSlider(Pos.y))
-      // page down
-      MoveOrigin(items_visible);
+    /* Pressed beside the slider: move the slider there on the press
+       itself, and let it follow the pointer from there.  Stepping a
+       row or a page instead only works on a bar that is long enough
+       to aim at, and this one rarely is: the slider of a short list
+       is thinner than a fingertip, and the two arrow buttons take a
+       control height each.  Rows can still be stepped with the wheel
+       and the cursor keys. */
+    scroll_bar.DragBeginCentred(this);
+    ScrollBarDragMove(Pos.y);
   } else {
     // if click in ListBox area
     // -> select appropriate item
@@ -621,6 +638,11 @@ ListControl::OnMouseDown(PixelPoint Pos) noexcept
           CanActivateItem()) {
         drag_mode = DragMode::CURSOR;
         InvalidateItem(cursor);
+      } else if (HasTouchScreen()) {
+        /* select on release, so that a swipe scrolls the list instead
+           of dragging the selection along (see #pending_cursor) */
+        pending_cursor = index;
+        drag_mode = DragMode::SCROLL;
       } else {
         // Select item if it was not selected before
         SetCursorIndex(index);

--- a/src/ui/control/List.hpp
+++ b/src/ui/control/List.hpp
@@ -8,6 +8,8 @@
 #include "ui/event/PeriodicTimer.hpp"
 #include "UIUtil/KineticManager.hpp"
 
+#include <cstdlib>
+
 struct DialogLook;
 class ContainerWindow;
 
@@ -140,6 +142,22 @@ class ListControl final : public PaintWindow {
    * top of the window
    */
   int drag_y_window;
+
+  /**
+   * The item the current drag started on, to be selected when the
+   * gesture turns out to be a tap.  On a touch screen the cursor is
+   * moved only on release: moving it on press would drag the
+   * selection along with every swipe, and would run the (possibly
+   * expensive) ListCursorHandler::OnCursorMoved() right when the
+   * scroll gesture begins.  Negative when unused.
+   */
+  int pending_cursor = -1;
+
+  /**
+   * Has the current drag moved far enough to count as scrolling
+   * rather than as a tap?
+   */
+  bool drag_scrolled = false;
 
   ListItemRenderer *item_renderer = nullptr;
   ListCursorHandler *cursor_handler = nullptr;
@@ -315,6 +333,24 @@ private:
   }
 
   void drag_end() noexcept;
+
+  /**
+   * Has the pointer moved far enough from the start of the drag to
+   * make this a scroll gesture instead of a tap?
+   *
+   * @param y the y coordinate of the pointer, relative to this window
+   */
+  [[gnu::pure]]
+  bool IsScrollGesture(int y) const noexcept {
+    return abs(y - drag_y_window) > (int)item_height / 5;
+  }
+
+  /**
+   * Scroll to the position the ScrollBar slider is being dragged to.
+   *
+   * @param y the y coordinate of the pointer, relative to this window
+   */
+  void ScrollBarDragMove(int y) noexcept;
 
   void DrawItems(Canvas &canvas, unsigned start, unsigned end) const noexcept;
 

--- a/src/ui/control/List.hpp
+++ b/src/ui/control/List.hpp
@@ -206,6 +206,16 @@ public:
   }
 
   /**
+   * The list pans its contents and drags its scroll bar slider, so a
+   * surrounding #VScrollPanel must leave a drag that started here
+   * alone.  Only while there actually is something to scroll: an
+   * entirely visible list lets the panel have the gesture.
+   */
+  bool HandlesDragging() const noexcept override {
+    return scroll_bar.IsDefined();
+  }
+
+  /**
    * Returns the height of list items
    * @return height of list items in pixel
    */

--- a/src/ui/control/ScrollBar.cpp
+++ b/src/ui/control/ScrollBar.cpp
@@ -222,6 +222,20 @@ ScrollBar::DragBegin(PaintWindow *w, unsigned y) noexcept
 }
 
 void
+ScrollBar::DragBeginCentred(PaintWindow *w) noexcept
+{
+  // Make sure that we are not dragging already
+  assert(!dragging);
+
+  // Pick the slider up by its middle
+  drag_offset = GetSliderHeight() / 2;
+  // ... and remember that we are dragging now
+  dragging = true;
+  w->SetCapture();
+  w->Invalidate(rc_slider);
+}
+
+void
 ScrollBar::DragEnd(PaintWindow *w) noexcept
 {
   // If we are not dragging right now -> nothing to end

--- a/src/ui/control/ScrollBar.hpp
+++ b/src/ui/control/ScrollBar.hpp
@@ -179,6 +179,16 @@ public:
   void DragBegin(PaintWindow *w, unsigned y) noexcept;
 
   /**
+   * Should be called when beginning to drag with the slider centred
+   * on the pointer instead of grabbed where it was hit.  A finger
+   * cannot hit a slider that is only a few pixels tall, so a touch
+   * anywhere on the track picks the slider up.
+   *
+   * @param w The Window object the ScrollBar is belonging to
+   */
+  void DragBeginCentred(PaintWindow *w) noexcept;
+
+  /**
    * Should be called when stopping to drag
    * (Called by ListControl::OnMouseUp)
    * @param w The Window object the ScrollBar is belonging to

--- a/src/ui/window/ContainerWindow.hpp
+++ b/src/ui/window/ContainerWindow.hpp
@@ -131,6 +131,17 @@ public:
     return capture_child != nullptr && capture_child->HandlesDragging();
   }
 
+  /**
+   * Tell the child that currently captures the mouse that its press
+   * was cancelled, and forget it.
+   *
+   * Use this when this container consumes the rest of a gesture
+   * itself: the child never sees the matching mouse-up, so without
+   * this it stays pressed and keeps the capture, and the stale
+   * #capture_child misroutes every later press to it.
+   */
+  void CancelChildCapture() noexcept;
+
 protected:
   [[gnu::pure]]
   Window *FindNextControl(Window *reference) noexcept;
@@ -139,6 +150,14 @@ protected:
   Window *FindPreviousControl(Window *reference) noexcept;
 
 public:
+#else /* USE_WINUSER */
+
+  /**
+   * On GDI the operating system owns the mouse capture; there is no
+   * child capture of ours to cancel.
+   */
+  void CancelChildCapture() noexcept {}
+
 #endif /* !USE_WINUSER */
 
   /**

--- a/src/ui/window/ContainerWindow.hpp
+++ b/src/ui/window/ContainerWindow.hpp
@@ -122,6 +122,15 @@ public:
   void ReleaseChildCapture(Window *window) noexcept;
   void ClearCapture() noexcept override;
 
+  /**
+   * A container drags nothing itself; defer to the child that is
+   * currently capturing the mouse, i.e. the one that owns the gesture
+   * in progress.
+   */
+  bool HandlesDragging() const noexcept override {
+    return capture_child != nullptr && capture_child->HandlesDragging();
+  }
+
 protected:
   [[gnu::pure]]
   Window *FindNextControl(Window *reference) noexcept;

--- a/src/ui/window/Window.hpp
+++ b/src/ui/window/Window.hpp
@@ -579,6 +579,20 @@ public:
 
 #endif /* USE_WINUSER */
 
+  /**
+   * Does this Window use mouse dragging for its own purposes, such as
+   * panning its contents or dragging a scroll bar slider?
+   *
+   * A scrolling container (#VScrollPanel) lets the user scroll by
+   * swiping over its contents, and for that it takes the gesture away
+   * from the child that accepted the press.  That must not happen for
+   * a child which drags itself: it would silently stop receiving the
+   * rest of its own gesture.
+   */
+  virtual bool HandlesDragging() const noexcept {
+    return false;
+  }
+
   [[gnu::pure]]
   bool HasFocus() const noexcept {
     assert(IsDefined());

--- a/src/ui/window/custom/ContainerWindow.cpp
+++ b/src/ui/window/custom/ContainerWindow.cpp
@@ -243,6 +243,11 @@ ContainerWindow::RemoveChild(Window &child) noexcept
 
   if (active_child == &child)
     active_child = nullptr;
+
+  /* never leave capture_child dangling at a window that is going
+     away */
+  if (capture_child == &child)
+    ReleaseChildCapture(&child);
 }
 
 Window *
@@ -362,6 +367,22 @@ ContainerWindow::ReleaseChildCapture(Window *window) noexcept
     parent->ReleaseChildCapture(this);
   else
     DisableCapture();
+}
+
+void
+ContainerWindow::CancelChildCapture() noexcept
+{
+  Window *child = capture_child;
+  if (child == nullptr)
+    return;
+
+  /* OnCancelMode() makes the child release the capture, which clears
+     capture_child through ReleaseChildCapture(); clear it explicitly
+     as well, in case the child does not */
+  child->OnCancelMode();
+
+  if (capture_child == child)
+    capture_child = nullptr;
 }
 
 void

--- a/src/ui/window/custom/Window.cpp
+++ b/src/ui/window/custom/Window.cpp
@@ -185,6 +185,14 @@ Window::Hide() noexcept
     return;
 
   visible = false;
+
+  /* a window that is no longer on screen must not keep the mouse
+     capture: every further event would be routed to it instead of to
+     what the user can actually see.  Both calls are cheap no-ops
+     unless this window, or a descendant, is capturing. */
+  parent->ReleaseChildCapture(this);
+  ClearCapture();
+
   parent->Invalidate();
 }
 


### PR DESCRIPTION
Fixes #2943.

Lists inside a settings panel could not be scrolled at all. The page list in Setup / Look / Pages is the clearest case: neither dragging the list nor dragging its scroll bar slider moved anything, on a phone as well as with a mouse on macOS. After a swipe over the panel it got worse, because the whole panel then stopped reacting to presses until the dialog was reopened.

Two separate causes, both in VScrollPanel, which wraps every settings panel so it can be scrolled by swiping and flipped by a horizontal swipe. It hands a press to the child first and then captures the mouse itself, which makes the child stop receiving the rest of its own gesture, so a list saw its press and then nothing. And when it swallowed a gesture it released only its own capture, leaving the child holding one, after which every press in the panel went to that one control no matter where the user pressed. A child that drags itself now keeps the whole gesture, and a swallowed press is cancelled properly. Hiding or removing a window no longer strands a capture either.

Separate from that, pressing a list scroll bar beside the slider now moves the slider to that spot on the press itself, instead of stepping a row or a page. The two arrow buttons take a control height each, so on the short bars in these panels there was almost nothing left to aim at. Rows can still be stepped with the wheel and the cursor keys. On touch screens a swipe over a list no longer drags the selection to the row the finger came down on.

Not verified on hardware other than iOS and macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking or touching beside a list scrollbar slider now positions it directly at the selected location.
  * Touch swipes no longer change the selected list item unexpectedly.
  * Settings panels can now be scrolled when dragging starts on interactive controls.
  * Mouse and touch gestures release correctly, ensuring subsequent presses reach the intended controls.
  * List selections remain stable after taps, while genuine swipes continue scrolling normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->