### PR TITLE
Text entry: use the system keyboard on iOS, add a Paste button

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -3,6 +3,11 @@ Version 7.46 - not yet released
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit
 * iOS
+  - use the system keyboard for text entry so special characters
+    can be typed, and add a Paste button for the clipboard; the
+    Keyboard text-input style keeps XCSoar's own grid #2894
+  - use the system font instead of Helvetica, covering more
+    characters and providing a designed bold cut
   - save the settings when the app moves to the background, so they
     survive being swiped away in the app switcher
   - remove the thin white frame around full-screen dialogs (such as
@@ -36,6 +41,7 @@ Version 7.46 - not yet released
   - fix the Devices Debug button not writing port traffic to xcsoar.log
     #2903
 * dialogs
+  - let Shift type '_' on XCSoar's on-screen keyboard
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862

--- a/build/libevent.mk
+++ b/build/libevent.mk
@@ -1,5 +1,6 @@
 EVENT_SOURCES = \
 	$(SRC)/ui/event/Globals.cpp \
+	$(SRC)/ui/event/TextInput.cpp \
 	$(SRC)/ui/event/Idle.cpp \
 	$(SRC)/ui/event/DelayedNotify.cpp \
 	$(SRC)/ui/event/Notify.cpp

--- a/src/Dialogs/DialogSettings.hpp
+++ b/src/Dialogs/DialogSettings.hpp
@@ -8,12 +8,25 @@
 struct DialogSettings {
   enum class TextInputStyle : uint8_t {
     /**
-     * Use the platform default - i.e. keyboard if the device has a
-     * pointing device.
+     * Use the platform default - i.e. the keyboard of the operating
+     * system where there is one (#SystemKeyboard), else our own
+     * keyboard if the device has a pointing device.
      */
     Default,
+
+    /**
+     * Always use XCSoar's own on-screen keyboard.
+     */
     Keyboard,
+
     HighScore,
+
+    /**
+     * Use the on-screen keyboard provided by the operating system
+     * (e.g. on iOS), which gives access to all special characters.
+     * Falls back to #Keyboard if the platform has none.
+     */
+    SystemKeyboard,
   };
 
   enum class TabStyle : uint8_t {

--- a/src/Dialogs/DialogSettings.hpp
+++ b/src/Dialogs/DialogSettings.hpp
@@ -20,13 +20,6 @@ struct DialogSettings {
     Keyboard,
 
     HighScore,
-
-    /**
-     * Use the on-screen keyboard provided by the operating system
-     * (e.g. on iOS), which gives access to all special characters.
-     * Falls back to #Keyboard if the platform has none.
-     */
-    SystemKeyboard,
   };
 
   enum class TabStyle : uint8_t {

--- a/src/Dialogs/DialogSettings.hpp
+++ b/src/Dialogs/DialogSettings.hpp
@@ -8,9 +8,9 @@
 struct DialogSettings {
   enum class TextInputStyle : uint8_t {
     /**
-     * Use the platform default - i.e. the keyboard of the operating
-     * system where there is one (#SystemKeyboard), else our own
-     * keyboard if the device has a pointing device.
+     * Use the platform default - the operating system's on-screen
+     * keyboard where there is one, else XCSoar's own keyboard if the
+     * device has a pointing device.
      */
     Default,
 

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -18,7 +18,6 @@
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Hardware/Vibrator.hpp"
-#include "ui/event/TextInput.hpp"
 #include "Repository/FileType.hpp"
 #include "Version.hpp"
 
@@ -168,26 +167,9 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
     nullptr
   };
 
-  /* the system keyboard is only offered where the operating system
-     actually has one (e.g. iOS), where it is also the default */
-  static constexpr StaticEnumChoice text_input_list_system[] = {
-    { DialogSettings::TextInputStyle::Default, N_("Default"),
-      N_("The keyboard of the operating system.") },
-    { DialogSettings::TextInputStyle::Keyboard, N_("Keyboard"),
-      N_("XCSoar's own on-screen keyboard.") },
-    { DialogSettings::TextInputStyle::HighScore,
-      N_("HighScore Style") },
-    { DialogSettings::TextInputStyle::SystemKeyboard,
-      N_("System keyboard"),
-      N_("The keyboard of the operating system, which provides all special characters.") },
-    nullptr
-  };
-
   AddEnum(_("Text input style"),
           _("Determines how the user is prompted for text input (filename, teamcode etc.)"),
-          UI::TextInput::HasScreenKeyboard()
-          ? text_input_list_system : text_input_list,
-          (unsigned)settings.dialog.text_input_style);
+          text_input_list, (unsigned)settings.dialog.text_input_style);
   SetExpertRow(TextInput);
 
   /* on-screen keyboard doesn't work without a pointing device

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -18,6 +18,7 @@
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Hardware/Vibrator.hpp"
+#include "ui/event/TextInput.hpp"
 #include "Repository/FileType.hpp"
 #include "Version.hpp"
 
@@ -167,9 +168,26 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
     nullptr
   };
 
+  /* the system keyboard is only offered where the operating system
+     actually has one (e.g. iOS), where it is also the default */
+  static constexpr StaticEnumChoice text_input_list_system[] = {
+    { DialogSettings::TextInputStyle::Default, N_("Default"),
+      N_("The keyboard of the operating system.") },
+    { DialogSettings::TextInputStyle::Keyboard, N_("Keyboard"),
+      N_("XCSoar's own on-screen keyboard.") },
+    { DialogSettings::TextInputStyle::HighScore,
+      N_("HighScore Style") },
+    { DialogSettings::TextInputStyle::SystemKeyboard,
+      N_("System keyboard"),
+      N_("The keyboard of the operating system, which provides all special characters.") },
+    nullptr
+  };
+
   AddEnum(_("Text input style"),
           _("Determines how the user is prompted for text input (filename, teamcode etc.)"),
-          text_input_list, (unsigned)settings.dialog.text_input_style);
+          UI::TextInput::HasScreenKeyboard()
+          ? text_input_list_system : text_input_list,
+          (unsigned)settings.dialog.text_input_style);
   SetExpertRow(TextInput);
 
   /* on-screen keyboard doesn't work without a pointing device

--- a/src/Dialogs/TextEntry.cpp
+++ b/src/Dialogs/TextEntry.cpp
@@ -14,7 +14,6 @@ TextEntryDialog(char *text, size_t width,
 {
   switch (UIGlobals::GetDialogSettings().text_input_style) {
   case DialogSettings::TextInputStyle::Default:
-  case DialogSettings::TextInputStyle::SystemKeyboard:
     /* the keyboard of the operating system (iOS) is much more capable
        than ours, so use it wherever there is one */
     if (HasPointer() && UI::TextInput::HasScreenKeyboard())

--- a/src/Dialogs/TextEntry.cpp
+++ b/src/Dialogs/TextEntry.cpp
@@ -5,6 +5,7 @@
 #include "DialogSettings.hpp"
 #include "UIGlobals.hpp"
 #include "Asset.hpp"
+#include "ui/event/TextInput.hpp"
 
 bool
 TextEntryDialog(char *text, size_t width,
@@ -13,6 +14,16 @@ TextEntryDialog(char *text, size_t width,
 {
   switch (UIGlobals::GetDialogSettings().text_input_style) {
   case DialogSettings::TextInputStyle::Default:
+  case DialogSettings::TextInputStyle::SystemKeyboard:
+    /* the keyboard of the operating system (iOS) is much more capable
+       than ours, so use it wherever there is one */
+    if (HasPointer() && UI::TextInput::HasScreenKeyboard())
+      return TouchTextEntry(text, width, caption, accb, default_shift_state,
+                            true);
+
+    /* no system keyboard on this platform: fall back to our own */
+    [[fallthrough]];
+
   case DialogSettings::TextInputStyle::Keyboard:
     if (HasPointer())
       return TouchTextEntry(text, width, caption, accb, default_shift_state);

--- a/src/Dialogs/TextEntry.hpp
+++ b/src/Dialogs/TextEntry.hpp
@@ -40,8 +40,14 @@ bool
 KnobTextEntry(char *text, size_t width,
               const char *caption);
 
+/**
+ * @param use_system_keyboard use the operating system's on-screen
+ * keyboard instead of XCSoar's own one; ignored on platforms which
+ * have none
+ */
 bool
 TouchTextEntry(char *text, size_t size,
                const char *caption=nullptr,
                AllowedCharacters ac=AllowedCharacters(),
-               bool default_shift_state = true);
+               bool default_shift_state = true,
+               bool use_system_keyboard = false);

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -10,8 +10,11 @@
 #include "Asset.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/event/KeyCode.hpp"
+#include "ui/event/TextInput.hpp"
 #include "UIGlobals.hpp"
 #include "Language/Language.hpp"
+#include "util/CharUtil.hxx"
+#include "util/StringAPI.hxx"
 #include "util/StringCompare.hxx"
 #include "util/TruncateString.hpp"
 #include "ui/window/Window.hpp"
@@ -21,18 +24,26 @@
 namespace {
 struct TextEntryLayout {
   PixelRect editor;
+  PixelRect paste;
   PixelRect backspace;
   PixelRect keyboard;
   PixelRect ok, cancel, clear;
 };
 
+/**
+ * @param with_paste reserve room for the @em Paste button
+ */
 static void
-ComputeTextEntryLayout(const PixelRect &rc, TextEntryLayout &o) noexcept
+ComputeTextEntryLayout(const PixelRect &rc, bool with_paste,
+                       TextEntryLayout &o) noexcept
 {
   const int client_height = rc.GetHeight();
   const int padding = Layout::Scale(2);
   const int backspace_width = Layout::Scale(36);
   const int backspace_left = rc.right - padding - backspace_width;
+  const int paste_width = with_paste ? Layout::Scale(60) : 0;
+  const int paste_left = backspace_left - (with_paste ? padding : 0) -
+    paste_width;
   const int editor_height = Layout::Scale(22);
   const int editor_bottom = padding + editor_height;
   const int button_height = Layout::Scale(40);
@@ -69,7 +80,8 @@ ComputeTextEntryLayout(const PixelRect &rc, TextEntryLayout &o) noexcept
     ? rc.right
     : clear_left + Layout::Scale(50);
 
-  o.editor = {0, padding, backspace_left - padding, editor_bottom};
+  o.editor = {0, padding, paste_left - padding, editor_bottom};
+  o.paste = {paste_left, padding, paste_left + paste_width, editor_bottom};
   o.backspace = {backspace_left, padding, rc.right - padding, editor_bottom};
   o.keyboard = {padding, keyboard_top, rc.right - padding, keyboard_bottom};
   o.ok = {ok_left, button_top, ok_right, button_bottom};
@@ -80,7 +92,8 @@ ComputeTextEntryLayout(const PixelRect &rc, TextEntryLayout &o) noexcept
 static void
 ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
                      Button &cancel, Button &clear, KeyboardWidget &keyboard,
-                     Button &backspace, ContainerWindow &client_area) noexcept
+                     Button &backspace, Button *paste,
+                     ContainerWindow &client_area) noexcept
 {
   editor.Move(L.editor);
   ok.Move(L.ok);
@@ -88,6 +101,8 @@ ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
   clear.Move(L.clear);
   keyboard.Move(L.keyboard);
   backspace.Move(L.backspace);
+  if (paste != nullptr)
+    paste->Move(L.paste);
   client_area.Invalidate();
 }
 } // namespace
@@ -99,6 +114,7 @@ static Button *textentry_backspace = NULL;
 static Button *textentry_ok = NULL;
 static Button *textentry_cancel = NULL;
 static Button *textentry_clear = NULL;
+static Button *textentry_paste = NULL;
 
 static AllowedCharacters AllowedCharactersCallback;
 
@@ -112,6 +128,30 @@ UpdateAllowedCharacters()
 {
   if (AllowedCharactersCallback)
     kb->SetAllowedCharacters(AllowedCharactersCallback(edittext));
+}
+
+/**
+ * Check a character against the AllowedCharacters callback.
+ *
+ * @return the character to be inserted (may have been converted to
+ * upper case), or 0 if it is not allowed
+ */
+static char
+FilterCharacter(char ch)
+{
+  if (!AllowedCharactersCallback)
+    return ch;
+
+  const char *allowed = AllowedCharactersCallback(edittext);
+  if (allowed == nullptr || StringFind(allowed, ch) != nullptr)
+    return ch;
+
+  /* the allowed set is usually upper case only */
+  if (const char upper = ToUpperASCII(ch);
+      upper != ch && StringFind(allowed, upper) != nullptr)
+    return upper;
+
+  return 0;
 }
 
 static void
@@ -152,6 +192,28 @@ DoCharacter(char character)
   return true;
 }
 
+/**
+ * Append the system clipboard contents to the edit field.
+ */
+static void
+OnPaste()
+{
+  for (const char ch : UI::TextInput::GetClipboardText()) {
+    if (!IsPrintableASCII(ch))
+      /* TODO: ASCII only for now, because we don't have proper UTF-8
+         support yet */
+      continue;
+
+    const char filtered = FilterCharacter(ch);
+    if (filtered == 0)
+      continue;
+
+    if (!DoCharacter(filtered))
+      /* the edit field is full */
+      break;
+  }
+}
+
 static bool
 FormKeyDown(unsigned key_code)
 {
@@ -161,6 +223,20 @@ FormKeyDown(unsigned key_code)
   if (HasCursorKeys() && kb != nullptr &&
       kb->KeyPress(key_code, textentry_backspace, textentry_ok))
     return true;
+
+  /* the @em Paste button sits left of the on-screen backspace */
+  if (HasCursorKeys() && textentry_client != nullptr &&
+      textentry_paste != nullptr && textentry_backspace != nullptr) {
+    Window *const w = textentry_client->GetFocusedWindow();
+    if (key_code == KEY_LEFT && w == static_cast<Window *>(textentry_backspace)) {
+      textentry_paste->SetFocus();
+      return true;
+    }
+    if (key_code == KEY_RIGHT && w == static_cast<Window *>(textentry_paste)) {
+      textentry_backspace->SetFocus();
+      return true;
+    }
+  }
 
   if (HasCursorKeys() && textentry_client != nullptr && textentry_ok != nullptr &&
       textentry_cancel != nullptr && textentry_clear != nullptr) {
@@ -248,6 +324,8 @@ TouchTextEntry(char *text, size_t width,
 
   max_width = std::min(MAX_TEXTENTRY, width);
 
+  const bool with_paste = UI::TextInput::HasClipboard();
+
   const DialogLook &look = UIGlobals::GetDialogLook();
   WndForm form(UIGlobals::GetMainWindow(), look, caption);
   form.SetKeyDownFunction(FormKeyDown);
@@ -257,7 +335,7 @@ TouchTextEntry(char *text, size_t width,
   textentry_client = &client_area;
   const PixelRect rc0 = client_area.GetClientRect();
   TextEntryLayout L;
-  ComputeTextEntryLayout(rc0, L);
+  ComputeTextEntryLayout(rc0, with_paste, L);
 
   WndProperty _editor(client_area, look, "",
                       L.editor,
@@ -304,12 +382,20 @@ TouchTextEntry(char *text, size_t width,
 
   textentry_backspace = &backspace_button;
 
+  Button paste_button;
+  if (with_paste) {
+    paste_button.Create(client_area, look.button, _("Paste"), L.paste,
+                        button_style, [](){ OnPaste(); });
+    textentry_paste = &paste_button;
+  }
+
   form.SetClientLayoutFunction([&]() {
     const PixelRect rc = client_area.GetClientRect();
     TextEntryLayout layout;
-    ComputeTextEntryLayout(rc, layout);
+    ComputeTextEntryLayout(rc, with_paste, layout);
     ApplyTextEntryLayout(layout, _editor, ok_button, cancel_button, clear_button,
-                        keyboard, backspace_button, client_area);
+                         keyboard, backspace_button,
+                         with_paste ? &paste_button : nullptr, client_area);
   });
 
   AllowedCharactersCallback = accb;
@@ -329,6 +415,7 @@ TouchTextEntry(char *text, size_t width,
   textentry_ok = NULL;
   textentry_cancel = NULL;
   textentry_clear = NULL;
+  textentry_paste = NULL;
   textentry_client = NULL;
 
   keyboard.Hide();

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -31,10 +31,13 @@ struct TextEntryLayout {
 };
 
 /**
+ * @param with_keyboard show XCSoar's own on-screen keyboard?  If not,
+ * the operating system's keyboard covers the lower part of the screen,
+ * and everything is moved up below the editor.
  * @param with_paste reserve room for the @em Paste button
  */
 static void
-ComputeTextEntryLayout(const PixelRect &rc, bool with_paste,
+ComputeTextEntryLayout(const PixelRect &rc, bool with_keyboard, bool with_paste,
                        TextEntryLayout &o) noexcept
 {
   const int client_height = rc.GetHeight();
@@ -49,34 +52,43 @@ ComputeTextEntryLayout(const PixelRect &rc, bool with_paste,
   const int button_height = Layout::Scale(40);
   constexpr unsigned keyboard_rows = 5u;
   const int keyboard_top = editor_bottom + padding;
-  const int keyboard_height = int(keyboard_rows) * button_height;
+  const int keyboard_height = with_keyboard
+    ? int(keyboard_rows) * button_height
+    : 0;
   const int keyboard_bottom = keyboard_top + keyboard_height;
 
-  const bool vertical = client_height >= keyboard_bottom + button_height;
+  /* without our own keyboard, the action row stays right below the
+     editor, where the system keyboard cannot cover it */
+  const bool vertical = with_keyboard &&
+    client_height >= keyboard_bottom + button_height;
 
-  const int button_top = vertical
-    ? rc.bottom - button_height
-    : keyboard_bottom - button_height;
-  const int button_bottom = vertical
-    ? rc.bottom
-    : keyboard_bottom;
+  const int button_top = !with_keyboard
+    ? keyboard_top
+    : (vertical
+       ? rc.bottom - button_height
+       : keyboard_bottom - button_height);
+  const int button_bottom = button_top + button_height;
 
-  const int ok_left = vertical ? 0 : padding;
-  const int ok_right = vertical
+  /* the action row spans the whole width unless it has to share its
+     row with the last keyboard row */
+  const bool spread = vertical || !with_keyboard;
+
+  const int ok_left = spread ? 0 : padding;
+  const int ok_right = spread
     ? rc.right / 3
     : ok_left + Layout::Scale(80);
 
-  const int cancel_left = vertical
+  const int cancel_left = spread
     ? ok_right
     : Layout::Scale(175);
-  const int cancel_right = vertical
+  const int cancel_right = spread
     ? rc.right * 2 / 3
     : cancel_left + Layout::Scale(60);
 
-  const int clear_left = vertical
+  const int clear_left = spread
     ? cancel_right
     : Layout::Scale(235);
-  const int clear_right = vertical
+  const int clear_right = spread
     ? rc.right
     : clear_left + Layout::Scale(50);
 
@@ -91,7 +103,7 @@ ComputeTextEntryLayout(const PixelRect &rc, bool with_paste,
 
 static void
 ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
-                     Button &cancel, Button &clear, KeyboardWidget &keyboard,
+                     Button &cancel, Button &clear, KeyboardWidget *keyboard,
                      Button &backspace, Button *paste,
                      ContainerWindow &client_area) noexcept
 {
@@ -99,7 +111,8 @@ ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
   ok.Move(L.ok);
   cancel.Move(L.cancel);
   clear.Move(L.clear);
-  keyboard.Move(L.keyboard);
+  if (keyboard != nullptr)
+    keyboard->Move(L.keyboard);
   backspace.Move(L.backspace);
   if (paste != nullptr)
     paste->Move(L.paste);
@@ -126,12 +139,13 @@ static char edittext[MAX_TEXTENTRY];
 static void
 UpdateAllowedCharacters()
 {
-  if (AllowedCharactersCallback)
+  if (kb != nullptr && AllowedCharactersCallback)
     kb->SetAllowedCharacters(AllowedCharactersCallback(edittext));
 }
 
 /**
- * Check a character against the AllowedCharacters callback.
+ * Check a character against the AllowedCharacters callback.  Without
+ * our own on-screen keyboard, nothing else enforces it.
  *
  * @return the character to be inserted (may have been converted to
  * upper case), or 0 if it is not allowed
@@ -301,6 +315,18 @@ FormCharacter(unsigned ch)
        support yet */
     return false;
 
+  if (kb == nullptr) {
+    /* without our own on-screen keyboard (which disables the buttons
+       for characters that are not allowed), the filter must be
+       applied here */
+    const char filtered = FilterCharacter((char)ch);
+    if (filtered == 0)
+      return true;
+
+    DoCharacter(filtered);
+    return true;
+  }
+
   DoCharacter((char)ch);
   return true;
 }
@@ -317,13 +343,18 @@ bool
 TouchTextEntry(char *text, size_t width,
                const char *caption,
                AllowedCharacters accb,
-               bool default_shift_state)
+               bool default_shift_state,
+               bool use_system_keyboard)
 {
   if (width == 0)
     width = MAX_TEXTENTRY;
 
   max_width = std::min(MAX_TEXTENTRY, width);
 
+  /* let the operating system provide the keyboard (giving access to
+     all special characters); if it has none, fall back to our own */
+  const bool system_keyboard = use_system_keyboard &&
+    UI::TextInput::HasScreenKeyboard();
   const bool with_paste = UI::TextInput::HasClipboard();
 
   const DialogLook &look = UIGlobals::GetDialogLook();
@@ -335,7 +366,7 @@ TouchTextEntry(char *text, size_t width,
   textentry_client = &client_area;
   const PixelRect rc0 = client_area.GetClientRect();
   TextEntryLayout L;
-  ComputeTextEntryLayout(rc0, with_paste, L);
+  ComputeTextEntryLayout(rc0, !system_keyboard, with_paste, L);
 
   WndProperty _editor(client_area, look, "",
                       L.editor,
@@ -370,11 +401,14 @@ TouchTextEntry(char *text, size_t width,
   KeyboardWidget keyboard(look.button, FormCharacter, !accb,
                           default_shift_state);
 
-  keyboard.Initialise(client_area, L.keyboard);
-  keyboard.Prepare(client_area, L.keyboard);
-  keyboard.Show(L.keyboard);
+  kb = nullptr;
+  if (!system_keyboard) {
+    keyboard.Initialise(client_area, L.keyboard);
+    keyboard.Prepare(client_area, L.keyboard);
+    keyboard.Show(L.keyboard);
 
-  kb = &keyboard;
+    kb = &keyboard;
+  }
 
   Button backspace_button(client_area, look.button, "<-",
                           L.backspace,
@@ -392,10 +426,12 @@ TouchTextEntry(char *text, size_t width,
   form.SetClientLayoutFunction([&]() {
     const PixelRect rc = client_area.GetClientRect();
     TextEntryLayout layout;
-    ComputeTextEntryLayout(rc, with_paste, layout);
+    ComputeTextEntryLayout(rc, !system_keyboard, with_paste, layout);
     ApplyTextEntryLayout(layout, _editor, ok_button, cancel_button, clear_button,
-                         keyboard, backspace_button,
+                         kb, backspace_button,
                          with_paste ? &paste_button : nullptr, client_area);
+    if (system_keyboard)
+      UI::TextInput::SetScreenKeyboardRect(layout.editor);
   });
 
   AllowedCharactersCallback = accb;
@@ -409,7 +445,16 @@ TouchTextEntry(char *text, size_t width,
   }
 
   UpdateTextboxProp();
+
+  if (system_keyboard) {
+    UI::TextInput::SetScreenKeyboardRect(L.editor);
+    UI::TextInput::ShowScreenKeyboard();
+  }
+
   const bool result = form.ShowModal() == mrOK;
+
+  if (system_keyboard)
+    UI::TextInput::HideScreenKeyboard();
 
   textentry_backspace = NULL;
   textentry_ok = NULL;
@@ -418,8 +463,11 @@ TouchTextEntry(char *text, size_t width,
   textentry_paste = NULL;
   textentry_client = NULL;
 
-  keyboard.Hide();
-  keyboard.Unprepare();
+  if (kb != nullptr) {
+    keyboard.Hide();
+    keyboard.Unprepare();
+    kb = nullptr;
+  }
 
   if (result) {
     CopyTruncateString(text, max_width, edittext);

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -101,6 +101,19 @@ ComputeTextEntryLayout(const PixelRect &rc, bool with_keyboard, bool with_paste,
   o.clear = {clear_left, button_top, clear_right, button_bottom};
 }
 
+/**
+ * The caption of the backspace key: the "erase to the left" symbol
+ * where the font has it, else an arrow made of ASCII.
+ */
+[[gnu::pure]]
+static const char *
+BackspaceCaption(const ButtonLook &look) noexcept
+{
+  return look.font != nullptr && look.font->HasGlyph(0x232B)
+    ? "⌫"
+    : "<-";
+}
+
 static void
 ApplyTextEntryLayout(const TextEntryLayout &L, WndProperty &editor, Button &ok,
                      Button &cancel, Button &clear, KeyboardWidget *keyboard,
@@ -410,7 +423,8 @@ TouchTextEntry(char *text, size_t width,
     kb = &keyboard;
   }
 
-  Button backspace_button(client_area, look.button, "<-",
+  Button backspace_button(client_area, look.button,
+                          BackspaceCaption(look.button),
                           L.backspace,
                           button_style, [](){ OnBackspace(); });
 

--- a/src/Widget/KeyboardWidget.cpp
+++ b/src/Widget/KeyboardWidget.cpp
@@ -164,6 +164,14 @@ KeyboardWidget::ResizeButtons()
 }
 
 void
+KeyboardWidget::MoveSymbolKey(PixelPoint position) noexcept
+{
+  /* the key holds either '-' or '_', depending on the shift state */
+  MoveButton('-', position);
+  MoveButton('_', position);
+}
+
+void
 KeyboardWidget::MoveButtonsToRow(const PixelRect &rc, const char *row_keys,
                                  unsigned row, int offset) noexcept
 {
@@ -186,15 +194,15 @@ KeyboardWidget::MoveButtons(const PixelRect &rc)
   MoveButtonsToRow(rc, "ZXCVBNM@.", 3, int(button_size.width));
 
   if (IsLandscape(rc)) {
-    MoveButton('-', rc.GetTopLeft() + PixelSize(int(button_size.width) * 9,
-                                                int(Layout::Scale(160U))));
+    MoveSymbolKey(rc.GetTopLeft() + PixelSize(int(button_size.width) * 9,
+                                              int(Layout::Scale(160U))));
     MoveButton(' ', rc.GetTopLeft() + PixelSize(int(Layout::Scale(80U)),
                                                  int(Layout::Scale(160U))));
     ResizeButton(' ', {Layout::Scale(93U), Layout::Scale(40U)});
   } else {
     const int h = int(button_size.height);
     const int w = int(button_size.width);
-    MoveButton('-', rc.GetTopLeft() + PixelSize(w * 8, h * 4));
+    MoveSymbolKey(rc.GetTopLeft() + PixelSize(w * 8, h * 4));
     MoveButton(' ', rc.GetTopLeft() + PixelSize(w * 2, h * 4));
     ResizeButton(' ', {button_size.width * 11 / 2, button_size.height});
   }
@@ -248,9 +256,14 @@ KeyboardWidget::UpdateShiftState() noexcept
       if (shift_state) {
         if (IsLowerAlphaASCII(c))
           buttons[i].SetCharacter(c - 0x20);
+        else if (show_shift_button && c == '-')
+          /* '-' doubles as '_', which is otherwise not reachable */
+          buttons[i].SetCharacter('_');
       } else {
         if (IsUpperAlphaASCII(c))
           buttons[i].SetCharacter(c + 0x20);
+        else if (show_shift_button && c == '_')
+          buttons[i].SetCharacter('-');
       }
     }
   }

--- a/src/Widget/KeyboardWidget.hpp
+++ b/src/Widget/KeyboardWidget.hpp
@@ -82,6 +82,13 @@ private:
   Button *FindButton(unsigned ch);
 
   void MoveButton(unsigned ch, PixelPoint position) noexcept;
+
+  /**
+   * Move the '-' / '_' key (only one of them exists at a time, see
+   * #UpdateShiftState).
+   */
+  void MoveSymbolKey(PixelPoint position) noexcept;
+
   void ResizeButton(unsigned ch, PixelSize size) noexcept;
   void ResizeButtons();
   void MoveButtonsToRow(const PixelRect &rc, const char *row_keys, unsigned row,

--- a/src/ui/canvas/Font.hpp
+++ b/src/ui/canvas/Font.hpp
@@ -104,6 +104,15 @@ public:
   [[gnu::pure]]
   PixelSize TextSize(std::string_view text) const noexcept;
 
+  /**
+   * Can this font render the given Unicode character?  Backends whose
+   * text API falls back to other fonts of the operating system always
+   * return true; those without a fallback (FreeType, which loads one
+   * font file) really check the font.
+   */
+  [[gnu::pure]]
+  bool HasGlyph(unsigned unicode) const noexcept;
+
 #if defined(USE_FREETYPE) || defined(USE_APPKIT) || defined(USE_UIKIT)
   static constexpr std::size_t BufferSize(const PixelSize size) noexcept {
     return std::size_t(size.width) * std::size_t(size.height);

--- a/src/ui/canvas/android/Font.cpp
+++ b/src/ui/canvas/android/Font.cpp
@@ -36,6 +36,13 @@ Font::Destroy() noexcept
   text_util_object = nullptr;
 }
 
+bool
+Font::HasGlyph([[maybe_unused]] unsigned unicode) const noexcept
+{
+  /* android.graphics.Paint falls back to other fonts of the system */
+  return true;
+}
+
 PixelSize
 Font::TextSize(std::string_view text) const noexcept
 {

--- a/src/ui/canvas/apple/Font.cpp
+++ b/src/ui/canvas/apple/Font.cpp
@@ -87,6 +87,13 @@ Font::Load(const FontDescription &d)
   capital_height = static_cast<unsigned>(ceilf([native_font capHeight]));
 }
 
+bool
+Font::HasGlyph([[maybe_unused]] unsigned unicode) const noexcept
+{
+  /* CoreText falls back to other fonts of the operating system */
+  return true;
+}
+
 PixelSize
 Font::TextSize(const std::string_view text) const noexcept
 {

--- a/src/ui/canvas/apple/Font.cpp
+++ b/src/ui/canvas/apple/Font.cpp
@@ -46,22 +46,34 @@ Font::Load(const FontDescription &d)
 {
   NativeFontT *native_font;
 
+  /* the bold cut of the system font is asked for directly, so only
+     italic (and bold for the monospace font) is left to the trait
+     conversion below */
+  bool convert_bold = d.IsBold();
+
 #ifndef ENABLE_OPENGL
   const std::lock_guard lock{apple_font_mutex};
 #endif
 
-  if (d.IsMonospace())
+  if (d.IsMonospace()) {
     native_font = [NativeFontT fontWithName: @"Courier" size: d.GetHeight()];
-  else
-    native_font = [NativeFontT fontWithName: @"Helvetica" size: d.GetHeight()];
+  } else {
+    /* the system font covers far more characters than Helvetica (e.g.
+       U+232B, the backspace symbol), and its bold cut is designed
+       rather than synthesised */
+    native_font = convert_bold
+      ? [NativeFontT boldSystemFontOfSize: d.GetHeight()]
+      : [NativeFontT systemFontOfSize: d.GetHeight()];
+    convert_bold = false;
+  }
 
   if (nil == native_font)
     throw std::runtime_error{"fontWithName named"};
 
-  if (d.IsItalic() || d.IsBold()) {
+  if (d.IsItalic() || convert_bold) {
 #ifdef USE_APPKIT
     NSFontTraitMask mask = 0;
-    if (d.IsBold())
+    if (convert_bold)
       mask |= NSBoldFontMask;
     if (d.IsItalic())
       mask |= NSItalicFontMask;
@@ -69,8 +81,12 @@ Font::Load(const FontDescription &d)
         convertFont: native_font
         toHaveTrait: mask];
 #else
-    UIFontDescriptorSymbolicTraits mask = 0;
-    if (d.IsBold())
+    /* start from what the font already has: -fontDescriptorWithSymbolicTraits:
+       replaces the traits, and the bold cut asked for above would be
+       lost when italic is added here */
+    UIFontDescriptorSymbolicTraits mask =
+      native_font.fontDescriptor.symbolicTraits;
+    if (convert_bold)
       mask |= UIFontDescriptorTraitBold;
     if (d.IsItalic())
       mask |= UIFontDescriptorTraitItalic;

--- a/src/ui/canvas/freetype/Font.cpp
+++ b/src/ui/canvas/freetype/Font.cpp
@@ -274,6 +274,18 @@ ForEachGlyph(const FT_Face face, unsigned ascent_height, T &&text,
     });
 }
 
+bool
+Font::HasGlyph(unsigned unicode) const noexcept
+{
+#ifndef ENABLE_OPENGL
+  const std::lock_guard lock{freetype_mutex};
+#endif
+
+  /* there is only this one font file and no fallback, so a character
+     the font does not have cannot be drawn at all */
+  return face != nullptr && FT_Get_Char_Index(face, unicode) != 0;
+}
+
 PixelSize
 Font::TextSize(std::string_view text) const noexcept
 {

--- a/src/ui/canvas/gdi/Font.cpp
+++ b/src/ui/canvas/gdi/Font.cpp
@@ -30,6 +30,14 @@ Font::Load(const FontDescription &d)
   CalculateHeights();
 }
 
+bool
+Font::HasGlyph([[maybe_unused]] unsigned unicode) const noexcept
+{
+  /* we do not know what the GDI font can do; assume the worst, which
+     only costs us a nicer symbol here and there */
+  return false;
+}
+
 PixelSize
 Font::TextSize(std::string_view text) const noexcept
 {

--- a/src/ui/event/TextInput.cpp
+++ b/src/ui/event/TextInput.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "TextInput.hpp"
+#include "ui/dim/Rect.hpp"
+
+#ifdef ENABLE_SDL
+#include <SDL_clipboard.h>
+#include <SDL_keyboard.h>
+#include <SDL_stdinc.h>
+#endif
+
+namespace UI::TextInput {
+
+bool
+HasScreenKeyboard() noexcept
+{
+#ifdef ENABLE_SDL
+  return ::SDL_HasScreenKeyboardSupport();
+#else
+  return false;
+#endif
+}
+
+void
+ShowScreenKeyboard() noexcept
+{
+#ifdef ENABLE_SDL
+  /* only touch the text input state on platforms with an on-screen
+     keyboard; on desktops, text input is enabled permanently and
+     switching it off would break the physical keyboard */
+  if (HasScreenKeyboard())
+    ::SDL_StartTextInput();
+#endif
+}
+
+void
+HideScreenKeyboard() noexcept
+{
+#ifdef ENABLE_SDL
+  if (HasScreenKeyboard())
+    ::SDL_StopTextInput();
+#endif
+}
+
+void
+SetScreenKeyboardRect([[maybe_unused]] const PixelRect &rc) noexcept
+{
+#ifdef ENABLE_SDL
+  if (!HasScreenKeyboard())
+    return;
+
+  SDL_Rect r{rc.left, rc.top, int(rc.GetWidth()), int(rc.GetHeight())};
+  ::SDL_SetTextInputRect(&r);
+#endif
+}
+
+bool
+HasClipboard() noexcept
+{
+#ifdef ENABLE_SDL
+  return true;
+#else
+  return false;
+#endif
+}
+
+std::string
+GetClipboardText()
+{
+#ifdef ENABLE_SDL
+  if (!::SDL_HasClipboardText())
+    return {};
+
+  char *text = ::SDL_GetClipboardText();
+  if (text == nullptr)
+    return {};
+
+  std::string result{text};
+  ::SDL_free(text);
+  return result;
+#else
+  return {};
+#endif
+}
+
+} // namespace UI::TextInput

--- a/src/ui/event/TextInput.hpp
+++ b/src/ui/event/TextInput.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <string>
+
+struct PixelRect;
+
+namespace UI::TextInput {
+
+/**
+ * Does the operating system provide an on-screen keyboard (e.g. on
+ * iOS)?  If it does, ShowScreenKeyboard() can be used instead of
+ * XCSoar's own #KeyboardWidget.
+ */
+[[gnu::pure]]
+bool
+HasScreenKeyboard() noexcept;
+
+/**
+ * Show the operating system's on-screen keyboard.  Characters typed
+ * on it are delivered as regular character events.  Does nothing if
+ * HasScreenKeyboard() is false (i.e. on desktops, where switching
+ * text input off again would break the physical keyboard).
+ */
+void
+ShowScreenKeyboard() noexcept;
+
+/**
+ * Hide the on-screen keyboard shown by ShowScreenKeyboard().
+ */
+void
+HideScreenKeyboard() noexcept;
+
+/**
+ * Tell the operating system where the text is being edited, so it can
+ * avoid covering it with the on-screen keyboard.  Best effort only.
+ */
+void
+SetScreenKeyboardRect(const PixelRect &rc) noexcept;
+
+/**
+ * Can this build read the system clipboard?
+ */
+[[gnu::const]]
+bool
+HasClipboard() noexcept;
+
+/**
+ * Returns the clipboard contents; an empty string if the clipboard is
+ * empty or unavailable.
+ */
+std::string
+GetClipboardText();
+
+} // namespace UI::TextInput


### PR DESCRIPTION
## Summary
- Cherry-pick of [#2855](https://github.com/XCSoar/XCSoar/pull/2855) onto current `master`.
- Default text entry uses the OS keyboard where SDL provides one (iOS), so `_` `/` `:` work; **Keyboard** keeps XCSoar's grid. Adds **Paste**, Shift-`_`, and the Apple system font.
- NEWS is under **7.46** (7.45 is already released).

Closes #2894. Supersedes #2855.

## Test plan
- [ ] iOS: Default text entry shows the system keyboard; special characters in a SkySight password
- [ ] iOS: Paste from the clipboard
- [ ] Keyboard style still shows XCSoar's grid, including Shift `_`
- [ ] Platforms without a system keyboard still get the XCSoar grid