### PR TITLE
Dialogs/Task/AlternatesList: Pin a field without a mode toggle

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -45,6 +45,9 @@ Version 7.46 - not yet released
     #2903
 * dialogs
   - let Shift type '_' on XCSoar's on-screen keyboard
+  - let Select as Alternate pin a landing field from AUTO, and use
+    Alternate Mode: Auto only to return the Alternate InfoBox to the
+    computed list #2912
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -710,11 +710,11 @@ As is with every waypoint list, additional information might be called by tappin
 
 The Alternate 1 / Alternate 2 InfoBoxes and their variants can be used either
 in \textbf{AUTO} mode or in \textbf{MANUAL} mode. AUTO is the default and
-shows the best automatically selected alternates. In MANUAL mode, a reachable
-alternate can be selected from the alternates list for each slot independently.
-This manual selection is runtime-only: it is not saved when XCSoar is
-restarted, and it remains active until the pilot changes it again or switches
-the slot back to AUTO.
+shows the best automatically selected alternates. Tap \bmenuw{Select as Alternate}
+to pin a reachable field from the list onto that InfoBox (MANUAL). This
+manual selection is runtime-only: it is not saved when XCSoar is
+restarted, and it remains active until the pilot chooses another field or
+taps \bmenuw{Alternate Mode: Auto} to return the slot to AUTO.
 
 Although the items on the alternate list obey different rules they interact
 in the same way

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -41,7 +41,7 @@ class AlternatesListWidget final
   Button *cancel_button = nullptr;
   Button *goto_button = nullptr;
   Button *select_button = nullptr;
-  Button *mode_button = nullptr;
+  Button *auto_button = nullptr;
   Button *manual_button = nullptr;
   Button *set_active_freq_button = nullptr;
   Button *set_standby_freq_button = nullptr;
@@ -143,11 +143,9 @@ private:
     if (set_active_freq_button == nullptr || set_standby_freq_button == nullptr)
       return;
 
-    if (mode_button != nullptr) {
-      mode_button->SetCaption(GetAlternateInfoBoxMode(GetConfiguredSlot()) ==
-                                  AlternateInfoBoxMode::MANUAL
-                                ? _("Altn mode: MANUAL")
-                                : _("Altn mode: AUTO"));
+    if (auto_button != nullptr) {
+      auto_button->SetEnabled(GetAlternateInfoBoxMode(GetConfiguredSlot()) ==
+                              AlternateInfoBoxMode::MANUAL);
     }
 
     if (!HasValidSelection()) {
@@ -170,10 +168,8 @@ private:
       details_button->SetEnabled(true);
     set_active_freq_button->SetEnabled(has_freq);
     set_standby_freq_button->SetEnabled(has_freq);
-    if (manual_button != nullptr) {
-      manual_button->SetEnabled(GetAlternateInfoBoxMode(GetConfiguredSlot()) ==
-                                  AlternateInfoBoxMode::MANUAL);
-    }
+    if (manual_button != nullptr)
+      manual_button->SetEnabled(true);
   }
 };
 
@@ -203,13 +199,15 @@ AlternatesListWidget::CreateButtons(WidgetDialog &dialog,
   }
 
   if (!select_mode && slot.has_value()) {
-    mode_button = dialog.AddButton("", [this](){
+    /* Alternate Mode: Auto returns a MANUAL slot to the computed
+       list. Pinning is Select as Alternate, which is always
+       available and sets MANUAL. */
+    auto_button = dialog.AddButton(C_("Button", "Alternate Mode: Auto"), [this](){
       const auto slot = GetConfiguredSlot();
-      const auto new_mode = GetAlternateInfoBoxMode(slot) ==
-        AlternateInfoBoxMode::MANUAL
-        ? AlternateInfoBoxMode::AUTO
-        : AlternateInfoBoxMode::MANUAL;
-      SetAlternateInfoBoxMode(slot, new_mode);
+      if (GetAlternateInfoBoxMode(slot) != AlternateInfoBoxMode::MANUAL)
+        return;
+
+      SetAlternateInfoBoxMode(slot, AlternateInfoBoxMode::AUTO);
       UpdateButtons();
     });
 


### PR DESCRIPTION
## Summary
- Let **Select as Alternate** pin a landing field from AUTO (it already switches the slot to MANUAL).
- Replace the Auto/Manual toggle with **Alternate Mode: Auto**, enabled only while a field is pinned, greyed when the slot is already following the computed list.
- Avoids the inverted-looking labels in #2912 without a next-action toggle that would bring back the two-tap path.

## Test plan
- [ ] Open Alternate 1 in AUTO: **Alternate Mode: Auto** is greyed; **Select as Alternate** is enabled with a row selected
- [ ] Select as Alternate pins the field, InfoBox title shows MAN, dialog closes
- [ ] Reopen: **Alternate Mode: Auto** is enabled; tapping it returns the slot to AUTO (InfoBox title AUTO)
- [ ] GoTo still navigates and aborts the task
- [ ] Alternate 2 is independent of Alternate 1