### PR TITLE
InfoBoxes/Content/Alternate: Use blue for MANUAL final glide

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -56,6 +56,8 @@ Version 7.46 - not yet released
 * infoboxen
   - show Airspeed TAS and IAS in blue when the value is estimated
     from ground speed and wind instead of an instrument
+  - replace light green on Alternate MANUAL final glide with blue,
+    matching Next waypoint
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -356,11 +356,10 @@ best automatic alternate (AUTO, default) or a manually selected alternate
 chosen from the alternates list during flight. Manual selections are
 runtime-only and remain active until changed again or switched back to AUTO.
 The value is shown in red when the glide computer marks the alternate as not
-achievable at the current MacCready setting.  In AUTO mode, blue indicates
-final glide and grey that further climb is required.  In MANUAL mode, light
-green indicates the chosen alternate is on final glide; red is also used
-when the solution is achievable but still below final glide (further climb
-needed).
+achievable at the current MacCready setting.  Blue indicates final glide,
+as for Next waypoint.  In AUTO mode, the default colour means further climb
+is required.  In MANUAL mode, red is also used when the solution is
+achievable but still below final glide.
 
 \ibi{Alternate 1}{Altn 1}{Name and bearing to the best alternate
 landing location.}

--- a/src/InfoBoxes/Content/Alternate.cpp
+++ b/src/InfoBoxes/Content/Alternate.cpp
@@ -60,6 +60,15 @@ GetAlternateModeShortLabel(AlternateInfoBoxMode mode) noexcept
     : C_("Abbreviation", "AUTO");
 }
 
+/**
+ * Value colour for Alternate InfoBoxes.
+ *
+ * Unreachable is red.  Final glide is blue, like Next waypoint (a
+ * calculated glide state, not MacCready green).  Below final glide,
+ * AUTO stays default because the computer is still ranking fields;
+ * MANUAL is red because the pilot pinned this field and it is not
+ * yet flyable straight in.
+ */
 [[gnu::pure]]
 unsigned
 GetAlternateInfoBoxValueColor(const ResolvedAlternateInfo& alternate) noexcept
@@ -67,11 +76,11 @@ GetAlternateInfoBoxValueColor(const ResolvedAlternateInfo& alternate) noexcept
   if (!alternate.solution.IsOk())
     return 1;
 
-  if (alternate.mode == AlternateInfoBoxMode::MANUAL)
-    return alternate.solution.IsFinalGlide() ? 3 : 1;
-
   if (alternate.solution.IsFinalGlide())
     return 2;
+
+  if (alternate.mode == AlternateInfoBoxMode::MANUAL)
+    return 1;
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Use **blue** for Alternate MANUAL on final glide, like Next waypoint (a calculated glide state).
- Stop using light green there; that colour already means MacCready MANUAL (pilot-set).
- Below final glide, MANUAL stays **red** (pinned field, not yet straight-in); AUTO stays default.

Related to the colour-philosophy work in #2922; this does not close that issue.

## Test plan
- [ ] Alternate AUTO: default below final glide, blue on final glide, red if unreachable
- [ ] Alternate MANUAL: red below final glide (even with a reasonable GR), blue on final glide
- [ ] MacCready still green in MANUAL and blue in AUTO
- [ ] Colour InfoBoxes off: still readable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Alternate InfoBox coloring so achievable manual-mode final-glide solutions now use blue, matching the Next waypoint display.
  - Manual-mode alternates below final glide remain red, as do unachievable solutions.
  - Automatic-mode alternates requiring additional climb retain the default display color.

- **Documentation**
  - Updated the manual to describe the revised Alternate InfoBox color meanings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->