### PR TITLE
InfoBoxes, Menu/MenuBar: Pack boxes and cap pan menus on tall phones

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -64,6 +64,9 @@ Version 7.46 - not yet released
     from ground speed and wind instead of an instrument
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
+* ui
+  - keep pan-mode menu buttons about 20 mm tall on tall phones,
+    large enough for a gloved tap
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -57,6 +57,9 @@ Version 7.46 - not yet released
     to the list and highlights an item so Enter acts on that row
     #2862
 * infoboxen
+  - pack portrait InfoBoxes on tall screens so title, value, and
+    comment sit closer together; InfoBox title size still grows the
+    boxes toward square at 150%
   - show Airspeed TAS and IAS in blue when the value is estimated
     from ground speed and wind instead of an instrument
   - replace light green on Alternate MANUAL final glide with blue,

--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -17,6 +17,7 @@
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
 #include "InfoBoxes/Content/Factory.hpp"
+#include "Interface.hpp"
 #include "Look/InfoBoxLook.hpp"
 #include "Language/Language.hpp"
 #include "util/StringAPI.hxx"
@@ -198,7 +199,9 @@ private:
 InfoBoxesConfigWidget::Layout::Layout(PixelRect rc,
                                       InfoBoxSettings::Geometry geometry)
 {
-  info_boxes = InfoBoxLayout::Calculate(rc, geometry);
+  const unsigned title_scale =
+    CommonInterface::GetUISettings().info_boxes.scale_title_font;
+  info_boxes = InfoBoxLayout::Calculate(rc, geometry, title_scale);
 
   form = info_boxes.remaining;
   auto buttons = form.CutTopSafe(::Layout::GetMaximumControlHeight());

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -31,7 +31,8 @@ ValidateGeometry(InfoBoxSettings::Geometry geometry,
 
 static void
 CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
-                 InfoBoxSettings::Geometry geometry) noexcept;
+                 InfoBoxSettings::Geometry geometry,
+                 unsigned scale_title_font) noexcept;
 
 } // namespace InfoBoxLayout
 
@@ -101,7 +102,8 @@ MakeRightColumn(const InfoBoxLayout::Layout &layout,
 }
 
 InfoBoxLayout::Layout
-InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry) noexcept
+InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
+                         unsigned scale_title_font) noexcept
 {
   const PixelSize screen_size = rc.GetSize();
 
@@ -114,7 +116,7 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry) noexc
   layout.count = geometry_counts[(unsigned)geometry];
   assert(layout.count <= InfoBoxSettings::Panel::MAX_CONTENTS);
 
-  CalcInfoBoxSizes(layout, screen_size, geometry);
+  CalcInfoBoxSizes(layout, screen_size, geometry, scale_title_font);
 
   layout.ClearVario();
 
@@ -514,11 +516,21 @@ InfoBoxLayout::ValidateGeometry(InfoBoxSettings::Geometry geometry,
 
 static constexpr unsigned
 CalculateInfoBoxRowHeight(unsigned screen_height,
-                          unsigned control_width) noexcept
+                          unsigned control_width,
+                          unsigned scale_title_font) noexcept
 {
-  return std::clamp(unsigned(screen_height / CONTROLHEIGHTRATIO),
-                    control_width * 5 / 7,
-                    control_width);
+  /* 5:7 packs default titles; grow toward square as title zoom goes
+     to 150% so title+comment still fit. */
+  unsigned max_height = control_width * 5 / 7;
+  if (scale_title_font > 100) {
+    const unsigned extra = control_width * 2 / 7;
+    max_height += extra * (scale_title_font - 100) / 50;
+    if (max_height > control_width)
+      max_height = control_width;
+  }
+
+  return std::min(unsigned(screen_height / CONTROLHEIGHTRATIO),
+                  max_height);
 }
 
 static constexpr unsigned
@@ -532,7 +544,8 @@ CalculateInfoBoxColumnWidth(unsigned screen_width,
 
 void
 InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
-                                InfoBoxSettings::Geometry geometry) noexcept
+                                InfoBoxSettings::Geometry geometry,
+                                unsigned scale_title_font) noexcept
 {
   const bool landscape = screen_size.width > screen_size.height;
 
@@ -551,8 +564,10 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
                                                               layout.control_size.height);
     } else {
       layout.control_size.width = 2 * screen_size.width / layout.count;
-      layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                             layout.control_size.width);
+      layout.control_size.height =
+        CalculateInfoBoxRowHeight(screen_size.height,
+                                  layout.control_size.width,
+                                  scale_title_font);
     }
 
     break;
@@ -566,8 +581,10 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
                                                               layout.control_size.height);
     } else {
       layout.control_size.width = 3 * screen_size.width / layout.count;
-      layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                             layout.control_size.width);
+      layout.control_size.height =
+        CalculateInfoBoxRowHeight(screen_size.height,
+                                  layout.control_size.width,
+                                  scale_title_font);
     }
 
     break;
@@ -580,8 +597,10 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
                                                               layout.control_size.height);
     } else {
       layout.control_size.width = screen_size.width / layout.count;
-      layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                             layout.control_size.width);
+      layout.control_size.height =
+        CalculateInfoBoxRowHeight(screen_size.height,
+                                  layout.control_size.width,
+                                  scale_title_font);
     }
 
     break;
@@ -589,15 +608,19 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
   case InfoBoxSettings::Geometry::BOTTOM_8_VARIO:
     // calculate control dimensions
     layout.control_size.width = 2 * screen_size.width / (layout.count + 2);
-    layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                           layout.control_size.width);
+    layout.control_size.height =
+      CalculateInfoBoxRowHeight(screen_size.height,
+                                layout.control_size.width,
+                                scale_title_font);
     break;
 
   case InfoBoxSettings::Geometry::TOP_8_VARIO:
     // calculate control dimensions
     layout.control_size.width = 2 * screen_size.width / (layout.count + 2);
-    layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                           layout.control_size.width);
+    layout.control_size.height =
+      CalculateInfoBoxRowHeight(screen_size.height,
+                                layout.control_size.width,
+                                scale_title_font);
     break;
 
   case InfoBoxSettings::Geometry::RIGHT_9_VARIO:
@@ -632,8 +655,10 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
       layout.control_size.width = layout.control_size.height * 1.44;
     } else {
       layout.control_size.width = 3 * screen_size.width / layout.count;
-      layout.control_size.height = CalculateInfoBoxRowHeight(screen_size.height,
-                                                             layout.control_size.width);
+      layout.control_size.height =
+        CalculateInfoBoxRowHeight(screen_size.height,
+                                  layout.control_size.width,
+                                  scale_title_font);
     }
     break;
 

--- a/src/InfoBoxes/InfoBoxLayout.hpp
+++ b/src/InfoBoxes/InfoBoxLayout.hpp
@@ -33,7 +33,8 @@ struct Layout {
 
 [[gnu::pure]]
 Layout
-Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry) noexcept;
+Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
+          unsigned scale_title_font=100) noexcept;
 
 [[gnu::const]]
 int

--- a/src/Input/InputEvents.cpp
+++ b/src/Input/InputEvents.cpp
@@ -42,6 +42,7 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "Weather/MapOverlay/InputEvents.hpp"
 #include "Menu/MenuBar.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
+#include "Screen/Layout.hpp"
 
 #ifdef KOBO
 #include "ui/event/KeyCode.hpp"
@@ -212,22 +213,14 @@ InputEvents::drawButtons(Mode mode, bool full) noexcept
   CommonInterface::main_window->ShowMenu(menu, overlay_menu, full);
 
   GlueMapWindow *map = CommonInterface::main_window->GetMapIfActive();
-  if (map != nullptr)
-  {
-    if (mode != MODE_DEFAULT)
-    {
-      /* Adjust the margin to ensure that GlueMapWindow elements,
-       * such as the scale, are not overdrawn by the buttons
-       * when in Pan mode. */
+  if (map != nullptr) {
+    /* Only portrait pan mode covers the scale with a bottom menu. */
+    unsigned margin = 0;
+    if (mode != MODE_DEFAULT && map->IsPanning() && !Layout::landscape) {
       PixelRect screen_rect = map->GetParentClientRect();
-      unsigned factor = (screen_rect.GetHeight() > screen_rect.GetWidth())
-        ? menubar_height_scale_factor
-        : 5;
-      
-      map->SetBottomMarginFactor(factor);
-    } else {
-      map->SetBottomMarginFactor(0);
+      margin = MenuBar::GetButtonHeight(screen_rect.GetHeight(), true);
     }
+    map->SetBottomMargin(margin);
   }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -480,7 +480,8 @@ MainWindow::InitialiseConfigured()
   PixelRect rc = GetClientRect();
 
   const InfoBoxLayout::Layout ib_layout =
-    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
+    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry,
+                             ui_settings.info_boxes.scale_title_font);
 
   assert(look != nullptr);
   look->InitialiseConfigured(CommonInterface::GetUISettings(),
@@ -706,7 +707,8 @@ MainWindow::ReinitialiseLayout() noexcept
   const UISettings &ui_settings = CommonInterface::GetUISettings();
 
   const InfoBoxLayout::Layout ib_layout =
-    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry);
+    InfoBoxLayout::Calculate(rc, ui_settings.info_boxes.geometry,
+                             ui_settings.info_boxes.scale_title_font);
 
   look->ReinitialiseLayout(ib_layout.control_size.width, ui_settings.info_boxes.scale_title_font);
 
@@ -860,7 +862,8 @@ MainWindow::ReinitialiseLook() noexcept
 
   const InfoBoxLayout::Layout ib_layout =
     InfoBoxLayout::Calculate(GetClientRect(),
-                             ui_settings.info_boxes.geometry);
+                             ui_settings.info_boxes.geometry,
+                             ui_settings.info_boxes.scale_title_font);
 
   assert(look != nullptr);
   look->InitialiseConfigured(CommonInterface::GetUISettings(),
@@ -1359,9 +1362,10 @@ MainWindow::SetFullScreen(bool _full_screen) noexcept
   /* Overlapped gauges (FLARM, thermal assistant) use GetMainRect() for
      "avoid InfoBoxes" corners; re-layout when fullscreen changes. */
   const PixelRect rc = GetClientRect();
+  const auto &info_boxes = CommonInterface::GetUISettings().info_boxes;
   const InfoBoxLayout::Layout ib_layout =
-    InfoBoxLayout::Calculate(rc,
-                             CommonInterface::GetUISettings().info_boxes.geometry);
+    InfoBoxLayout::Calculate(rc, info_boxes.geometry,
+                             info_boxes.scale_title_font);
   ReinitialiseLayout_flarm(rc, ib_layout);
   ReinitialiseLayoutTA(rc, ib_layout);
 

--- a/src/Menu/MenuBar.cpp
+++ b/src/Menu/MenuBar.cpp
@@ -4,9 +4,21 @@
 #include "MenuBar.hpp"
 #include "ui/window/ContainerWindow.hpp"
 #include "Input/InputEvents.hpp"
+#include "Screen/Layout.hpp"
 
 #include <algorithm>
 #include <cassert>
+
+unsigned
+MenuBar::GetButtonHeight(unsigned screen_height, bool portrait) noexcept
+{
+  unsigned height = std::max(1u,
+    screen_height / (portrait ? menubar_height_scale_factor : 5u));
+  const unsigned cap = Layout::GetInflightButtonHeight();
+  if (portrait && cap > 0 && height > cap)
+    height = cap;
+  return height;
+}
 
 [[gnu::pure]]
 static PixelRect
@@ -17,8 +29,7 @@ GetButtonPosition(unsigned i, PixelRect rc)
   const bool portrait = screen_height > screen_width;
 
   unsigned width = std::max(1u, screen_width / (portrait ? 4u : 5u));
-  unsigned height = std::max(1u,
-    screen_height / (portrait ? menubar_height_scale_factor : 5u));
+  unsigned height = MenuBar::GetButtonHeight(screen_height, portrait);
 
   if (i == 0) {
     rc.left = rc.right;

--- a/src/Menu/MenuBar.hpp
+++ b/src/Menu/MenuBar.hpp
@@ -51,4 +51,13 @@ public:
    * to a new position.
    */
   void OnResize(const PixelRect &rc);
+
+  /**
+   * Portrait: screen/6, capped at
+   * Layout::GetInflightButtonHeight() for gloved use on tall phones.
+   * Landscape: screen/5, uncapped.
+   */
+  [[gnu::pure]]
+  static unsigned GetButtonHeight(unsigned screen_height,
+                                  bool portrait) noexcept;
 };

--- a/src/Screen/Layout.hpp
+++ b/src/Screen/Layout.hpp
@@ -273,6 +273,22 @@ GetMaximumControlHeight() noexcept
 }
 
 /**
+ * In-flight tap target (pan menu, map cursor bar), in points.
+ * ~20 mm, large enough for a gloved tap (2 * map hit radius).
+ */
+static constexpr unsigned inflight_button_pt = 56;
+
+/**
+ * Pixel size of #inflight_button_pt.
+ */
+[[gnu::pure]]
+static inline unsigned
+GetInflightButtonHeight() noexcept
+{
+  return PtScale(inflight_button_pt);
+}
+
+/**
  * Returns the radius (in pixels) of the hit circle around map
  * items.
  */


### PR DESCRIPTION
## Summary
- Pack portrait InfoBoxes on tall screens so title, value, and comment sit closer together. **InfoBox title size** still grows the boxes toward square at 150%.
- Cap pan-mode menu buttons at 56 pt (~20 mm) so they stay glove-sized instead of a sixth of a tall phone. The weather cursor bar is unchanged.

Fixes #2927

## Test plan
- [x] Portrait phone, default InfoBox title size: boxes are a wide rectangle, not square; title/value/comment look packed
- [x] Set InfoBox title size to 150%: boxes grow toward square and titles are not clipped
- [x] Enter pan mode: bottom (and side) menu buttons are about 20 mm tall and usable with a glove
- [x] Map scale sits above the pan buttons, not under them
- [x] Weather overlay cursor bar is still the compact two-row strip, not 20 mm per row
- [x] Short/4:3 layout (or landscape) is not obviously worse than before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added alternate pinning while in AUTO mode.
  - Improved InfoBox layout on tall portrait screens, including support for larger title fonts.
  - Adjusted pan-mode buttons for a consistent, touch-friendly height on tall phones.
- **Style**
  - Display estimated airspeed and manually selected alternate final glide in blue.
- **Bug Fixes**
  - Improved portrait InfoBox spacing and sizing.
  - Added a maximum button-height limit for comfortable in-flight use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->