### PR TITLE
Dialogs: Put Close on the right, and distinguish Close, Back, and Cancel

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -51,6 +51,8 @@ Version 7.46 - not yet released
 * dialogs
   - put the Close button on the right of the Status and Weather
     tab strips
+  - label Close on the Quick Menu, BlueFly setup, and file Download
+    dialogs, which were not aborting an edit
   - let Shift type '_' on XCSoar's on-screen keyboard
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -53,6 +53,8 @@ Version 7.46 - not yet released
     tab strips
   - label Close on the Quick Menu, BlueFly setup, and file Download
     dialogs, which were not aborting an edit
+  - replace Close with Back on Configuration settings pages, so Close
+    on the menu still means leave and save
   - let Shift type '_' on XCSoar's on-screen keyboard
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -49,6 +49,8 @@ Version 7.46 - not yet released
   - fix the Devices Debug button not writing port traffic to xcsoar.log
     #2903
 * dialogs
+  - put the Close button on the right of the Status and Weather
+    tab strips
   - let Shift type '_' on XCSoar's on-screen keyboard
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the

--- a/src/Dialogs/Device/BlueFly/BlueFlyConfigurationDialog.cpp
+++ b/src/Dialogs/Device/BlueFly/BlueFlyConfigurationDialog.cpp
@@ -166,6 +166,6 @@ dlgConfigurationBlueFlyVarioShowModal(Device &_device)
                       "BlueFly Vario",
                       new BlueFlyConfigurationWidget(look, dialog, device));
 
-  dialog.AddButton(_("Cancel"), mrCancel);
+  dialog.AddButton(_("Close"), mrCancel);
   dialog.ShowModal();
 }

--- a/src/Dialogs/DownloadFilePicker.cpp
+++ b/src/Dialogs/DownloadFilePicker.cpp
@@ -324,9 +324,9 @@ DownloadFilePicker(FileType file_type)
            UIGlobals::GetDialogLook(), _("Download"));
   dialog.SetWidget(dialog, file_type);
   dialog.GetWidget().CreateButtons();
-  dialog.AddButton(_("Cancel"), mrCancel);
+  dialog.AddButton(_("Close"), mrCancel);
   /* No EnableCursorSelection: Left/Right page the list (ListControl).
-     Up/Down walk list ↔ Download/Cancel; Enter downloads the cursor row. */
+     Up/Down walk list ↔ Download/Close; Enter downloads the cursor row. */
   dialog.ShowModal();
 
   return dialog.GetWidget().GetPath();

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -322,7 +322,8 @@ OnUserLevel(bool expert) noexcept
 }
 
 /**
- * close dialog from menu page.  from content, goes to menu page
+ * Close on the menu page commits (mrOK).  On a settings page, return
+ * to the menu (Back).
  */
 static void
 OnCloseClicked(WidgetDialog &dialog)
@@ -343,6 +344,10 @@ OnPageFlipped(WidgetDialog &dialog, TabMenuDisplay &menu)
   if (caption == nullptr)
     caption = _("Configuration");
   dialog.SetCaption(caption);
+
+  pager->SetCloseButtonCaption(pager->GetCurrentIndex() == 0
+                               ? _("Close")
+                               : _("Back"));
 }
 
 void dlgConfigurationShowModal()
@@ -377,7 +382,7 @@ void dlgConfigurationShowModal()
 
   dialog.FinishPreliminary(pager);
 
-  /* Esc on a settings panel returns to the menu (same as Close);
+  /* Esc on a settings panel returns to the menu (same as Back);
      on the menu itself, leave Esc to cancel the dialog. */
   dialog.SetKeyDownFunction([&dialog](unsigned key_code) {
     if (key_code != KEY_ESCAPE || pager->GetCurrentIndex() == 0)

--- a/src/Dialogs/dlgQuickMenu.cpp
+++ b/src/Dialogs/dlgQuickMenu.cpp
@@ -497,7 +497,7 @@ ShowQuickMenu(UI::SingleWindow &parent, const Menu &menu) noexcept
     quick_menu.NavigatePage(GridView::Direction::RIGHT);
   });
 
-  dialog.AddButton(_("Cancel"), mrCancel);
+  dialog.AddButton(_("Close"), mrCancel);
 
   quick_menu.SetNavigationButtons(prev_button, next_button);
 

--- a/src/Widget/ArrowPagerWidget.cpp
+++ b/src/Widget/ArrowPagerWidget.cpp
@@ -14,6 +14,8 @@
 #include "Renderer/SymbolButtonRenderer.hpp"
 #include "Renderer/TextButtonRenderer.hpp"
 
+#include <algorithm>
+
 ArrowPagerWidget::Layout::Layout(const ButtonLook &look, PixelRect rc,
                                  const Widget *extra_widget) noexcept
   :main(rc)
@@ -24,8 +26,11 @@ ArrowPagerWidget::Layout::Layout(const ButtonLook &look, PixelRect rc,
   if (width > height) {
     /* landscape */
 
+    /* Size for Close or Back so a caller can swap the caption without
+       clipping. */
     const unsigned close_button_width =
-      TextButtonRenderer::GetMinimumButtonWidth(look, _("Close"));
+      std::max(TextButtonRenderer::GetMinimumButtonWidth(look, _("Close")),
+               TextButtonRenderer::GetMinimumButtonWidth(look, _("Back")));
     const unsigned arrow_buttons_width =
       2 * ::Layout::GetMaximumControlHeight();
 

--- a/src/Widget/TabWidget.cpp
+++ b/src/Widget/TabWidget.cpp
@@ -48,7 +48,7 @@ TabWidget::Layout::Layout(Orientation orientation, PixelRect rc,
       if (extra_width > max_width)
         extra_width = max_width;
 
-      extra = tab_display.CutLeftSafe(extra_width);
+      extra = tab_display.CutRightSafe(extra_width);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Place Close on the **right** of the Status and Weather tab strips (horizontal tabs).
- Label **Close** (not Cancel) on Quick Menu, BlueFly setup, and file Download, which only dismiss the view.
- In Configuration, label the chrome button **Back** on a settings page and **Close** on the menu. Close on the menu still saves; Esc on the menu still discards.

## Test plan
- [ ] Configuration: open a panel → Back (or Esc) returns to the menu without saving; Close on the menu saves.
- [ ] Configuration: Esc on the menu discards unsaved edits.
- [ ] Status and Weather in landscape / wide layout: Close sits on the right of the tabs.
- [ ] Quick Menu, BlueFly setup, and file Download show Close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved dialog navigation by placing Close controls consistently on the right side of status and weather tabs.
  - Configuration settings pages now use Back, while Close exits and saves from menus.
  - Updated dialog actions from Cancel to Close for clearer labeling.

- **Bug Fixes**
  - Adjusted tab layouts and button sizing to accommodate Close and Back labels without compromising the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->