### PR TITLE
Widget/CursorBarWidget: Fix dark mode colours

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,8 @@ Version 7.46 - not yet released
 * weather
   - show the overlay name as XC Therm (with a space) in setup, weather
     dialogs, map titles, and download messages
+  - fix the weather cursor bar keeping light colours in dark mode,
+    and unreadable labels on Windows
   - fix SkySight re-downloading forecast metadata when stepping
     layers on the weather cursor, which could hit the API rate
     limit #2867

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -871,6 +871,7 @@ MainWindow::ReinitialiseLook() noexcept
                              ib_layout.control_size.width);
 
   InfoBoxManager::ScheduleRedraw();
+  Invalidate();
 }
 
 #ifdef ANDROID

--- a/src/Widget/CursorBarWidget.cpp
+++ b/src/Widget/CursorBarWidget.cpp
@@ -10,6 +10,7 @@
 #include "Form/Button.hpp"
 #include "Renderer/SymbolButtonRenderer.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Features.hpp"
 #include "ui/window/SolidContainerWindow.hpp"
 #include "ui/window/PaintWindow.hpp"
 #include "util/StaticArray.hxx"
@@ -60,6 +61,11 @@ protected:
 
   void OnPaint(Canvas &canvas) noexcept override {
     const auto rc = GetClientRect();
+    if (HaveClipping())
+      /* with clipping, the parent's background does not extend into
+         child windows, so we must fill the background ourselves */
+      canvas.Clear(look.background_brush);
+
     canvas.SetBackgroundTransparent();
     canvas.SetTextColor(is_available
                         ? look.text_color
@@ -137,7 +143,6 @@ public:
     style.Hide();
     style.ControlParent();
     SolidContainerWindow::Create(parent, rc, look.background_color, style);
-    SetGradientTopColor(look.background_gradient_top_color);
 
     int total_h, row_h, btn_w, w;
     ComputeLayout(rc, row_count, total_h, row_h, btn_w, w);
@@ -218,7 +223,8 @@ protected:
   }
 
   void OnPaint(Canvas &canvas) noexcept override {
-    SolidContainerWindow::OnPaint(canvas);
+    canvas.Clear(look.background_brush);
+    ContainerWindow::OnPaint(canvas);
 
     if (row_count < 2)
       return;


### PR DESCRIPTION
## Summary
- Paint the weather cursor bar and its labels from `DialogLook` so a dark-mode change is picked up without recreating the widget.
- Fill clipped (GDI) label windows so dark-mode text is not drawn on a light default background.
- Invalidate the main window when the look is reinitialised.

## Test plan
- [ ] Open a weather page with the cursor bar, switch to dark mode, and confirm the bar background, stepper buttons, and centre labels follow the theme.
- [ ] Switch back to light mode and confirm the bar returns to dialog colours.
- [ ] On Windows, confirm centre labels stay readable in both themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weather cursor bars retaining light colours in dark mode.
  * Improved label readability on Windows.
  * Corrected cursor bar background rendering when clipping is enabled.
  * Refreshed the main window display after appearance settings are reinitialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->