### PR TITLE
Draw the distance rings with a fine pen

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -28,6 +28,8 @@ Version 7.46 - not yet released
   - fix choosing SkySight as a page overlay with no layers available
     silently switching back to None
 * map
+  - draw the distance rings thinner, so they no longer dominate the map
+    on high-DPI screens
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/src/Look/MapLook.cpp
+++ b/src/Look/MapLook.cpp
@@ -59,7 +59,7 @@ MapLook::Initialise(const MapSettings &settings,
   tbm_pen.Create(Layout::ScalePenWidth(2), HasColors() ? COLOR_GREEN : COLOR_BLACK);
   tbm_brush.Create(HasColors() ? COLOR_GREEN : COLOR_BLACK);
 
-  distance_rings_pen.Create(Layout::ScalePenWidth(1),
+  distance_rings_pen.Create(Layout::ScaleFinePenWidth(1),
                             HasColors() ? COLOR_GRAY : COLOR_BLACK);
 
   contest_pens[0].Create(Layout::ScalePenWidth(1) + 2, COLOR_RED);


### PR DESCRIPTION
The current distance rings are a bit to bold. Should I experiment with opacity as well?

Before | After |
-|-
<img width="603" height="1311" alt="Bildschirmfoto 2026-08-24 um 00 46 47" src="https://github.com/user-attachments/assets/78839f5c-b2d9-48da-901a-c110aa1e3df7" /> | <img width="603" height="1311" alt="Bildschirmfoto 2026-08-24 um 00 46 30" src="https://github.com/user-attachments/assets/c44819ba-db25-42e3-8374-3e1c2bc30881" />

Here is another screenshot on darker terrain. 

<img width="752" height="624" alt="Bildschirmfoto 2026-08-24 um 01 00 23" src="https://github.com/user-attachments/assets/5217367c-d2df-40a3-9fc0-657912cad19e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated map distance rings to appear thinner and less prominent on high-DPI displays.

* **Documentation**
  * Added a release note documenting the updated distance-ring appearance in Version 7.46.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->