### PR TITLE
Dialogs/TouchTextEntry: Submit iOS text entries on Return

### DIFF
--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -253,6 +253,11 @@ FormKeyDown(unsigned key_code)
     return true;
   }
 
+  /* The system keyboard reports Space as a key event before text input.
+     Do not let the focused action button interpret it as activation. */
+  if (kb == nullptr && key_code == KEY_SPACE)
+    return true;
+
   /* On devices with cursor keys, first let the on-screen keyboard
      move focus between key buttons; use Backspace for delete.  On
      others (e.g. Kobo), Left and Back both act as backspace. */

--- a/src/Dialogs/TouchTextEntry.cpp
+++ b/src/Dialogs/TouchTextEntry.cpp
@@ -244,6 +244,15 @@ OnPaste()
 static bool
 FormKeyDown(unsigned key_code)
 {
+  /* iOS sends Return as a keyboard event while its system keyboard is
+     visible.  Accept the entry there, but let a hardware keyboard's
+     Return activate the focused button. */
+  if (kb == nullptr && !HasKeyboard() && key_code == KEY_RETURN &&
+      textentry_ok != nullptr) {
+    textentry_ok->Click();
+    return true;
+  }
+
   /* On devices with cursor keys, first let the on-screen keyboard
      move focus between key buttons; use Backspace for delete.  On
      others (e.g. Kobo), Left and Back both act as backspace. */


### PR DESCRIPTION
iOS reports the soft keyboard Return key as a key event.  It was dispatched to the focused soft button, which can be Clear, deleting the entered value.

Handle Return before focus dispatch and activate OK, matching the expected submit behaviour.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pressing Return now consistently activates the OK button and submits text entries, including when the iOS system keyboard is open.
  * Pressing Space while entering text no longer unintentionally activates the focused action button when the system keyboard is in use.
  * Text entry actions now respond more predictably when switching between the system keyboard and the app’s keyboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->