### PR TITLE
InfoBoxes/GaugeVario: Fit vario to available size

### DIFF
--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -66,7 +66,7 @@ static const char option_summary[] =
   "  -resizable          resizable window\n"
 #endif
 #ifdef HAVE_CMDLINE_REPLAY
-  "  -replay=PATH        replay flight from IGC at PATH (desktop Unix/macOS)\n"
+  "  -replay=PATH        replay IGC or NMEA log at PATH (desktop Unix/macOS)\n"
 #endif
 #ifdef _WIN32
   "  -console            open debug output console\n"

--- a/src/Gauge/GaugeVario.cpp
+++ b/src/Gauge/GaugeVario.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Gauge/GaugeVario.hpp"
+#include "Gauge/VarioGeometry.hpp"
 #include "Computer/STF.hpp"
 #include "Look/VarioLook.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -18,6 +19,18 @@ static constexpr double DELTA_V_STEP = 4.0;
 static constexpr double DELTA_V_LIMIT = 16.0;
 #define TEXT_BUG "Bug"
 #define TEXT_BALLAST "Bal"
+
+static int
+GetDialRadius(const VarioLook &look, unsigned window_width) noexcept
+{
+  const int arc_padding = look.arc_label_font.GetHeight();
+  const int tick_length = look.Scale(Layout::GetTextPadding() * 4);
+  const int label_width = look.arc_label_font.TextSize("-5").width;
+  const int right = int(std::min(window_width, look.geometry_width))
+    - int(look.Scale(Layout::GetTextPadding()));
+
+  return std::max(1, right - tick_length - arc_padding / 2 - label_width / 2);
+}
 
 inline
 GaugeVario::BallastGeometry::BallastGeometry(const VarioLook &look,
@@ -109,14 +122,14 @@ inline
 GaugeVario::LabelValueGeometry::LabelValueGeometry(const VarioLook &look,
                                                    PixelPoint position) noexcept
   :label_right(position.x),
-   label_top(position.y + Layout::Scale(1)),
+   label_top(position.y + look.Scale(Layout::Scale(1))),
    label_bottom(label_top + look.label_font.GetCapitalHeight()),
    label_y(label_top + look.label_font.GetCapitalHeight()
            - look.label_font.GetAscentHeight()),
    // TODO: update after units got reconfigured?
    value_right(position.x - UnitSymbolRenderer::GetSize(look.unit_font,
                                                         Units::current.vertical_speed_unit).width),
-   value_top(label_bottom + Layout::Scale(2)),
+   value_top(label_bottom + look.Scale(Layout::Scale(2))),
    value_bottom(value_top + look.value_font.GetCapitalHeight()),
    value_y(value_top + look.value_font.GetCapitalHeight()
            - look.value_font.GetAscentHeight())
@@ -126,7 +139,7 @@ GaugeVario::LabelValueGeometry::LabelValueGeometry(const VarioLook &look,
 inline unsigned
 GaugeVario::LabelValueGeometry::GetHeight(const VarioLook &look) noexcept
 {
-  return Layout::Scale(4) + look.value_font.GetCapitalHeight()
+  return look.Scale(Layout::Scale(4)) + look.value_font.GetCapitalHeight()
     + look.label_font.GetCapitalHeight();
 }
 
@@ -134,13 +147,14 @@ inline
 GaugeVario::Geometry::Geometry(const VarioLook &look, const PixelRect &rc) noexcept
   :ballast(look, rc), bugs(look, rc)
 {
-  nlength0 = Layout::Scale(15);
-  nlength1 = Layout::Scale(6);
-  nwidth = Layout::Scale(4);
-  nline = Layout::Scale(8);
+  nlength0 = look.Scale(Layout::Scale(10));
+  nlength1 = look.Scale(Layout::Scale(2));
+  nwidth = look.Scale(Layout::Scale(4));
+  nline = look.Scale(Layout::Scale(8));
 
   offset = rc.GetMiddleRight();
-  offset.x -= Layout::GetTextPadding();
+  offset.x -= look.Scale(Layout::GetTextPadding());
+  dial_radius = GetDialRadius(look, rc.GetWidth());
 
   const PixelSize value_offset{0u, LabelValueGeometry::GetHeight(look)};
 
@@ -161,7 +175,7 @@ GaugeVario::GaugeVario(const FullBlackboard &_blackboard,
 static constexpr int
 WidthToHeight(int width) noexcept
 {
-  return width * 112 / 100;
+  return width * int(VarioGeometry::VERTICAL_SCALE_PERCENT) / 100;
 }
 
 static constexpr PixelPoint
@@ -181,7 +195,7 @@ GaugeVario::RenderBackground(Canvas &canvas, const PixelRect &rc) noexcept
 
   const int arc_padding = look.arc_label_font.GetHeight();
 
-  const int x_radius = rc.GetWidth() - arc_padding;
+  const int x_radius = GetDialRadius(look, rc.GetWidth());
   const int y_radius = WidthToHeight(x_radius);
 
   for (std::size_t i = 0; i < arc.size(); ++i) {
@@ -219,13 +233,14 @@ GaugeVario::RenderBackground(Canvas &canvas, const PixelRect &rc) noexcept
 
   const int n_ticks = GAUGEVARIORANGE / (tick_value_step / unit_factor);
 
-  const int tick_length = Layout::GetTextPadding() * 4;
+  const int tick_length = look.Scale(Layout::GetTextPadding() * 4);
 
   const IntPoint2D tick_start{1 - x_radius, 0};
   const IntPoint2D tick_end{-tick_length - x_radius, 0};
   const IntPoint2D label_center{-x_radius - arc_padding / 2 - tick_length, 0};
 
-  for (int i = -n_ticks; i < n_ticks; ++i) {
+  /* The end labels sit beyond the fitted dial on compact layouts. */
+  for (int i = 1 - n_ticks; i < n_ticks; ++i) {
     Angle angle = tick_angle_step * i;
     const FastIntegerRotation r{angle};
 
@@ -289,11 +304,10 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
       ival_av_thermal = ValueToNeedlePos(Calculated().current_thermal.lift_rate);
   }
 
-  auto vval = Basic().VarioOutputFilterActive()
-    ? (Basic().brutto_vario_available
-        ? Basic().FilteredBruttoVario()
-        : 0.)
-    : Basic().brutto_vario;
+  const bool vario_available = Basic().brutto_vario_available;
+  const auto vval = Basic().VarioOutputFilterActive()
+    ? (vario_available ? Basic().FilteredBruttoVario() : 0.)
+    : (vario_available ? Basic().brutto_vario : 0.);
   ival = ValueToNeedlePos(vval);
   sval = ValueToNeedlePos(Calculated().sink_rate);
   if (Settings().show_average_needle) {
@@ -312,24 +326,31 @@ GaugeVario::OnPaintBuffer(Canvas &canvas) noexcept
     ival_last = ival_av;
   }
 
-  if (!IsPersistent() || (sval != sval_last) || (ival != vval_last))
+  if (vario_line_drawn &&
+      (!vario_available || !IsPersistent() ||
+       (sval != sval_last) || (ival != vval_last))) {
     RenderVarioLine(canvas, vval_last, sval_last, true);
+    vario_line_drawn = false;
+  }
 
   sval_last = sval;
   if (Settings().show_thermal_average_needle) {
-      if (!IsPersistent() || ival_av_thermal != ival_av_last)
-          RenderNeedle(canvas, ival_av_last, false, true);
+    if (!IsPersistent() || ival_av_thermal != ival_av_last)
+      RenderNeedle(canvas, ival_av_last, false, true);
 
-      ival_av_last = ival_av_thermal;
+    ival_av_last = ival_av_thermal;
   } else {
-      if (!IsPersistent() || ival != vval_last)
-        RenderNeedle(canvas, vval_last, false, true);
+    if (!IsPersistent() || ival != vval_last)
+      RenderNeedle(canvas, vval_last, false, true);
 
-      vval_last = ival;
+    vval_last = ival;
   }
 
   // now draw items
-  RenderVarioLine(canvas, ival, sval, false);
+  if (vario_available) {
+    RenderVarioLine(canvas, ival, sval, false);
+    vario_line_drawn = true;
+  }
   if (Settings().show_average_needle)
     RenderNeedle(canvas, ival_av, true, false);
 
@@ -357,14 +378,14 @@ GaugeVario::MakePolygon(const int i) noexcept
 
   const FastIntegerRotation r(Angle::Degrees(i));
 
-  bit[0] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength0, geometry.nwidth}),
+  bit[0] = TransformRotatedPoint(r.Rotate({-geometry.dial_radius + geometry.nlength0, geometry.nwidth}),
                                  geometry.offset);
-  bit[1] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength1, 0}),
+  bit[1] = TransformRotatedPoint(r.Rotate({-geometry.dial_radius + geometry.nlength1, 0}),
                                  geometry.offset);
-  bit[2] = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nlength0, -geometry.nwidth}),
+  bit[2] = TransformRotatedPoint(r.Rotate({-geometry.dial_radius + geometry.nlength0, -geometry.nwidth}),
                                  geometry.offset);
 
-  *bline = TransformRotatedPoint(r.Rotate({-geometry.offset.x + geometry.nline, 0}),
+  *bline = TransformRotatedPoint(r.Rotate({-geometry.dial_radius + geometry.nline, 0}),
                                  geometry.offset);
 }
 
@@ -385,13 +406,13 @@ void
 GaugeVario::RenderClimb(Canvas &canvas) noexcept
 {
   const PixelRect rc = GetClientRect();
-  int x = rc.right - Layout::Scale(14);
-  int y = rc.bottom - Layout::Scale(24);
+  int x = rc.right - int(look.Scale(Layout::Scale(14)));
+  int y = rc.bottom - int(look.Scale(Layout::Scale(24)));
 
   if (!dirty)
     return;
 
-  const PixelSize dest_size{Layout::VptScale(9)};
+  const PixelSize dest_size{look.Scale(Layout::VptScale(9))};
 
   if (Basic().switch_state.flight_mode == SwitchState::FlightMode::CIRCLING)
     canvas.Stretch({x, y}, dest_size, look.climb_bitmap, {12, 0}, {12, 12});
@@ -572,17 +593,19 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
 
   double v_diff;
 
-  const unsigned arrow_y_size = Layout::Scale(3);
-  const unsigned arrow_x_size = Layout::Scale(7);
+  const unsigned arrow_y_size = look.Scale(Layout::Scale(3));
+  const unsigned arrow_x_size = look.Scale(Layout::Scale(7));
 
   const PixelRect rc = GetClientRect();
 
   int nary = NARROWS * arrow_y_size;
-  int ytop = rc.top + YOFFSET + nary; // JMW
-  int ybottom = rc.bottom - YOFFSET - nary - Layout::FastScale(1);
+  const int y_offset = look.Scale(YOFFSET);
+  int ytop = rc.top + y_offset + nary; // JMW
+  int ybottom = rc.bottom - y_offset - nary
+    - int(look.Scale(Layout::FastScale(1)));
 
-  ytop += Layout::Scale(14);
-  ybottom -= Layout::Scale(14);
+  ytop += look.Scale(Layout::Scale(14));
+  ybottom -= look.Scale(Layout::Scale(14));
 
   x = rc.right - 2 * arrow_x_size;
 
@@ -600,16 +623,17 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
     last_v_diff = v_diff;
 
     if (IsPersistent()) {
-      const unsigned height = nary + arrow_y_size + Layout::FastScale(2);
+      const unsigned height = nary + arrow_y_size
+        + look.Scale(Layout::FastScale(2));
 
       const PixelSize size{arrow_x_size * 2 + 1, height};
 
       // bottom (too slow)
-      canvas.DrawFilledRectangle({{x, ybottom + YOFFSET}, size},
+      canvas.DrawFilledRectangle({{x, ybottom + y_offset}, size},
                                  look.background_color);
 
       // top (too fast)
-      canvas.DrawFilledRectangle({{x, ytop - YOFFSET + 1 - (int)height}, size},
+      canvas.DrawFilledRectangle({{x, ytop - y_offset + 1 - int(height)}, size},
                                  look.background_color);
     }
 
@@ -634,7 +658,7 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
     if (v_diff > 0) {
       // too slow
       y = ybottom;
-      y += YOFFSET;
+      y += y_offset;
 
       const PixelSize size{arrow_x_size * 2 + 1, arrow_y_size - 1};
       while (v_diff > 0) {
@@ -656,7 +680,7 @@ GaugeVario::RenderSpeedToFly(Canvas &canvas, int x, int y) noexcept
     } else if (v_diff < 0) {
       // too fast
       y = ytop;
-      y -= YOFFSET;
+      y -= y_offset;
 
       const PixelSize size{arrow_x_size * 2 + 1, y - arrow_y_size + 1};
       while (v_diff < 0) {
@@ -774,13 +798,27 @@ GaugeVario::OnResize(PixelSize new_size) noexcept
 {
   AntiFlickerWindow::OnResize(new_size);
 
+  ReinitialiseLook();
+}
+
+void
+GaugeVario::ReinitialiseLook() noexcept
+{
+
   geometry = {look, GetClientRect()};
 
   /* trigger reinitialisation */
+  dirty = true;
   background_dirty = true;
   needle_initialised = false;
+  vario_line_drawn = false;
 
   average_di.Reset();
   mc_di.Reset();
   gross_di.Reset();
+
+  last_ballast = -1;
+  last_bugs = -1;
+
+  Invalidate();
 }

--- a/src/Gauge/GaugeVario.hpp
+++ b/src/Gauge/GaugeVario.hpp
@@ -53,6 +53,7 @@ class GaugeVario : public AntiFlickerWindow
 
   struct Geometry {
     int nlength0, nlength1, nwidth, nline;
+    int dial_radius;
 
     PixelPoint offset;
 
@@ -97,6 +98,7 @@ class GaugeVario : public AntiFlickerWindow
 
   bool background_dirty = true;
   bool needle_initialised = false;
+  bool vario_line_drawn = false;
 
   LabelValueDrawInfo average_di, mc_di, gross_di;
 
@@ -118,6 +120,8 @@ public:
   GaugeVario(const FullBlackboard &blackboard,
              ContainerWindow &parent, const VarioLook &look,
              PixelRect rc, const WindowStyle style=WindowStyle()) noexcept;
+
+  void ReinitialiseLook() noexcept;
 
 protected:
   const MoreData &Basic() const noexcept {

--- a/src/Gauge/GlueGaugeVario.cpp
+++ b/src/Gauge/GlueGaugeVario.cpp
@@ -33,6 +33,12 @@ GlueGaugeVario::Hide() noexcept
 }
 
 void
+GlueGaugeVario::ReinitialiseLook() noexcept
+{
+  ((GaugeVario &)GetWindow()).ReinitialiseLook();
+}
+
+void
 GlueGaugeVario::OnGPSUpdate([[maybe_unused]] const MoreData &basic)
 {
   ((GaugeVario &)GetWindow()).Invalidate();

--- a/src/Gauge/GlueGaugeVario.hpp
+++ b/src/Gauge/GlueGaugeVario.hpp
@@ -26,6 +26,8 @@ public:
   void Show(const PixelRect &rc) noexcept override;
   void Hide() noexcept override;
 
+  void ReinitialiseLook() noexcept;
+
 private:
   virtual void OnGPSUpdate(const MoreData &basic) override;
 };

--- a/src/Gauge/VarioGeometry.hpp
+++ b/src/Gauge/VarioGeometry.hpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+namespace VarioGeometry {
+
+static constexpr unsigned VERTICAL_SCALE_PERCENT = 112;
+
+static constexpr unsigned COMPACT_HEIGHT_PERCENT = 90;
+
+static constexpr unsigned
+GetMaximumWidth(unsigned height) noexcept
+{
+  return height * 100 / (2 * VERTICAL_SCALE_PERCENT);
+}
+
+static constexpr unsigned
+GetCompactWidth(unsigned height) noexcept
+{
+  return GetMaximumWidth(height * COMPACT_HEIGHT_PERCENT / 100);
+}
+
+} // namespace VarioGeometry

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -3,6 +3,7 @@
 
 #include "InfoBoxes/InfoBoxLayout.hpp"
 #include "Border.hpp"
+#include "Gauge/VarioGeometry.hpp"
 #include "util/Macros.hpp"
 
 #include <algorithm> // for std::clamp()
@@ -155,7 +156,8 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
     break;
 
   case InfoBoxSettings::Geometry::BOTTOM_8_VARIO:
-    layout.vario.left = rc.right - layout.control_size.width;
+    layout.vario.left = rc.right - VarioGeometry::GetCompactWidth(
+      layout.control_size.height * 2);
     layout.vario.right = rc.right;
     layout.vario.top = rc.bottom - layout.control_size.height * 2;
     layout.vario.bottom = rc.bottom;
@@ -181,7 +183,8 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
     break;
 
   case InfoBoxSettings::Geometry::TOP_8_VARIO:
-    layout.vario.left = rc.right - layout.control_size.width;
+    layout.vario.left = rc.right - VarioGeometry::GetCompactWidth(
+      layout.control_size.height * 2);
     layout.vario.right = rc.right;
     layout.vario.top = rc.top;
     layout.vario.bottom = rc.top + layout.control_size.height * 2;
@@ -542,6 +545,32 @@ CalculateInfoBoxColumnWidth(unsigned screen_width,
                     control_height * 7 / 5);
 }
 
+static void
+CalculatePortraitVarioSizes(InfoBoxLayout::Layout &layout,
+                            PixelSize screen_size,
+                            unsigned scale_title_font) noexcept
+{
+  unsigned width = screen_size.width / 4;
+
+  for (unsigned i = 0; i < 8; ++i) {
+    const unsigned height =
+      CalculateInfoBoxRowHeight(screen_size.height, width,
+                                scale_title_font);
+    const unsigned vario_width =
+      VarioGeometry::GetCompactWidth(height * 2);
+    const unsigned next_width = (screen_size.width - vario_width) / 4;
+
+    if (next_width == width)
+      break;
+
+    width = next_width;
+  }
+
+  layout.control_size.width = width;
+  layout.control_size.height =
+    CalculateInfoBoxRowHeight(screen_size.height, width, scale_title_font);
+}
+
 void
 InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
                                 InfoBoxSettings::Geometry geometry,
@@ -606,21 +635,8 @@ InfoBoxLayout::CalcInfoBoxSizes(Layout &layout, PixelSize screen_size,
     break;
 
   case InfoBoxSettings::Geometry::BOTTOM_8_VARIO:
-    // calculate control dimensions
-    layout.control_size.width = 2 * screen_size.width / (layout.count + 2);
-    layout.control_size.height =
-      CalculateInfoBoxRowHeight(screen_size.height,
-                                layout.control_size.width,
-                                scale_title_font);
-    break;
-
   case InfoBoxSettings::Geometry::TOP_8_VARIO:
-    // calculate control dimensions
-    layout.control_size.width = 2 * screen_size.width / (layout.count + 2);
-    layout.control_size.height =
-      CalculateInfoBoxRowHeight(screen_size.height,
-                                layout.control_size.width,
-                                scale_title_font);
+    CalculatePortraitVarioSizes(layout, screen_size, scale_title_font);
     break;
 
   case InfoBoxSettings::Geometry::RIGHT_9_VARIO:

--- a/src/Look/VarioLook.cpp
+++ b/src/Look/VarioLook.cpp
@@ -55,23 +55,40 @@ VarioLook::Initialise(bool _inverse, bool _colors,
 }
 
 void
-VarioLook::ReinitialiseLayout(unsigned width)
+VarioLook::ReinitialiseLayout(unsigned width, unsigned reference_width)
 {
+  geometry_width = width;
+  geometry_scale_percent = reference_width > 0
+    ? width * 100 / reference_width
+    : 100;
+
+  arc_pen.Create(Layout::ScalePenWidth(2), text_color);
+  tick_pen.Create(Layout::ScalePenWidth(1), text_color);
+  thick_background_pen.Create(Layout::Scale(5), background_color);
+  thick_sink_pen.Create(Layout::Scale(5), sink_color);
+  thick_lift_pen.Create(Layout::Scale(5), lift_color);
+
+  /* Keep the value column legible when the dial has to shrink to fit a
+     compact portrait Vario window. */
+  const unsigned font_width = reference_width > 0
+    ? std::clamp(reference_width * 4 / 5, width, width * 4 / 3)
+    : width;
+
   FontDescription arc_label_font_d(8);
-  AutoSizeFont(arc_label_font_d, width / 10, "-5");
+  AutoSizeFont(arc_label_font_d, font_width / 10, "-5");
   arc_label_font.Load(arc_label_font_d);
 
   FontDescription value_font_d(14);
-  AutoSizeFont(value_font_d, width / 1.5, "-00.0m");
+  AutoSizeFont(value_font_d, font_width / 1.5, "-00.0m");
   value_font.Load(value_font_d);
 
   FontDescription unit_font_d(8);
-  AutoSizeFont(unit_font_d, width / 4.22, "00.0m");
+  AutoSizeFont(unit_font_d, font_width / 4.22, "00.0m");
   unit_font.Load(unit_font_d);
   unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), COLOR_GRAY);
 
   FontDescription label_font_d(8);
-  AutoSizeFont(label_font_d, width / 2, "Auto MC");
+  AutoSizeFont(label_font_d, font_width / 2, "Auto MC");
   label_font.Load(label_font_d);
 
 #ifdef HAVE_TEXT_CACHE

--- a/src/Look/VarioLook.hpp
+++ b/src/Look/VarioLook.hpp
@@ -13,6 +13,8 @@ class Font;
 
 struct VarioLook {
   bool inverse, colors;
+  unsigned geometry_scale_percent = 100;
+  unsigned geometry_width = 0;
 
   Color background_color, text_color, dimmed_text_color;
 
@@ -39,5 +41,10 @@ struct VarioLook {
                   unsigned width,
                   const Font &text_font);
 
-  void ReinitialiseLayout(unsigned width);
+  void ReinitialiseLayout(unsigned width, unsigned reference_width=0);
+
+  unsigned Scale(unsigned value) const noexcept {
+    const unsigned scaled = value * geometry_scale_percent / 100;
+    return scaled > 0 ? scaled : 1;
+  }
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,6 +19,7 @@
 #include "Gauge/GaugeFLARM.hpp"
 #include "Gauge/GaugeThermalAssistant.hpp"
 #include "Gauge/GlueGaugeVario.hpp"
+#include "Gauge/VarioGeometry.hpp"
 #include "Form/Form.hpp"
 #include "Widget/Widget.hpp"
 #include "Look/GlobalFonts.hpp"
@@ -610,9 +611,16 @@ MainWindow::ReinitialiseLayout_vario(const InfoBoxLayout::Layout &layout) noexce
     return;
   }
 
+  const unsigned width = std::min(layout.vario.GetWidth(),
+                                  VarioGeometry::GetCompactWidth(
+                                    layout.vario.GetHeight()));
+  look->vario.ReinitialiseLayout(width, layout.control_size.width);
+
   if (!vario.IsDefined())
     vario.Set(new GlueGaugeVario(CommonInterface::GetLiveBlackboard(),
                                  look->vario));
+  else
+    static_cast<GlueGaugeVario *>(vario.Get())->ReinitialiseLook();
 
   vario.Move(layout.vario);
   vario.Show();
@@ -869,6 +877,15 @@ MainWindow::ReinitialiseLook() noexcept
   look->InitialiseConfigured(CommonInterface::GetUISettings(),
                              Fonts::map, Fonts::map_bold,
                              ib_layout.control_size.width);
+
+  if (ib_layout.HasVario()) {
+    const unsigned width = std::min(ib_layout.vario.GetWidth(),
+                                    VarioGeometry::GetCompactWidth(
+                                      ib_layout.vario.GetHeight()));
+    look->vario.ReinitialiseLayout(width, ib_layout.control_size.width);
+    if (vario.IsDefined())
+      static_cast<GlueGaugeVario *>(vario.Get())->ReinitialiseLook();
+  }
 
   InfoBoxManager::ScheduleRedraw();
   Invalidate();


### PR DESCRIPTION
Commit fdd2ddfb88 (InfoBoxes/InfoBoxLayout: Pack portrait boxes on tall screens) made portrait InfoBox rows substantially shorter than their width. GaugeVario retained a full-width InfoBox column and derived its dial geometry from that width, allowing the dial, tick labels and indicator to draw outside the two-row vario window.

Derive the vario allocation and renderer geometry from the available window size, reserving space for scale labels.  Reclaim unused vario width for the adjacent InfoBoxes, and keep vario typography legible within the fitted window.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ x] PR is rebased on current `master`
- [ x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved variometer sizing and layout across portrait and landscape displays.
  - Adjusted dial geometry, labels, ticks, needles, and speed-to-fly arrows for more consistent scaling.
  - Variometer visuals now refresh correctly when the display is resized or its layout changes.

- **Bug Fixes**
  - Prevented misleading needle and vario-line rendering when brutto variometer data is unavailable.
  - Improved compact variometer placement in multi-panel layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->