### PR TITLE
Linux systemd controls

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -789,6 +789,13 @@ ifeq ($(HAVE_PCM_PLAYER),y)
 XCSOAR_SOURCES += $(SRC)/Audio/VarioGlue.cpp
 endif
 
+# Selected systemd unit controls for desktop/embedded Linux.
+ifeq ($(TARGET_IS_LINUX)$(TARGET_IS_KOBO)$(TARGET_IS_ANDROID),ynn)
+XCSOAR_SOURCES += \
+	$(SRC)/Dialogs/Settings/Panels/SystemdConfigPanel.cpp \
+	$(SRC)/Linux/SystemdServiceList.cpp
+endif
+
 include $(topdir)/build/net-wifi.mk
 
 XCSOAR_DEPENDS = \

--- a/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SystemdConfigPanel.hpp"
+#include "Dialogs/Error.hpp"
+#include "Dialogs/JobDialog.hpp"
+#include "Form/Button.hpp"
+#include "Form/ButtonPanel.hpp"
+#include "Job/Job.hpp"
+#include "Language/Language.hpp"
+#include "Linux/SystemdServiceList.hpp"
+#include "Look/DialogLook.hpp"
+#include "Renderer/TwoTextRowsRenderer.hpp"
+#include "UIGlobals.hpp"
+#include "Widget/ButtonPanelWidget.hpp"
+#include "Widget/ListWidget.hpp"
+#include "lib/dbus/Connection.hxx"
+#include "lib/dbus/ScopeMatch.hxx"
+#include "lib/dbus/Systemd.hxx"
+#include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+#include "util/ScopeExit.hxx"
+
+#include <chrono>
+#include <exception>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace {
+
+static constexpr auto refresh_interval = std::chrono::seconds{1};
+static constexpr int systemd_action_timeout_ms = 30000;
+
+enum class SystemdAction {
+  START,
+  STOP,
+  RESTART,
+};
+
+class SystemdActionJob final : public Job {
+  const SystemdAction action;
+  const std::string unit_name;
+
+public:
+  SystemdActionJob(SystemdAction _action, const std::string &_unit_name)
+    :action(_action), unit_name(_unit_name) {}
+
+  void Run([[maybe_unused]] OperationEnvironment &env) override {
+    auto connection = ODBus::Connection::GetSystemPrivate();
+    AtScopeExit(&connection) { connection.Close(); };
+
+    const ODBus::ScopeMatch match{connection, Systemd::job_removed_match};
+
+    switch (action) {
+    case SystemdAction::START:
+      Systemd::StartUnit(connection, unit_name.c_str(), "replace",
+                         systemd_action_timeout_ms);
+      Systemd::EnableUnitFile(connection, unit_name.c_str());
+      break;
+
+    case SystemdAction::STOP:
+      Systemd::StopUnit(connection, unit_name.c_str(), "replace",
+                        systemd_action_timeout_ms);
+      Systemd::DisableUnitFile(connection, unit_name.c_str());
+      break;
+
+    case SystemdAction::RESTART:
+      Systemd::RestartUnit(connection, unit_name.c_str(), "replace",
+                           systemd_action_timeout_ms);
+      break;
+    }
+  }
+};
+
+struct ServiceStatus {
+  Systemd::ActiveState state = Systemd::ActiveState::INACTIVE;
+  bool valid = false;
+};
+
+class SystemdListWidget final : public ListWidget {
+  std::vector<SystemdService> services = BuildSystemdServiceList();
+  std::vector<ServiceStatus> statuses{services.size()};
+  TwoTextRowsRenderer row_renderer;
+  Button *toggle_button = nullptr;
+  Button *restart_button = nullptr;
+  ButtonPanelWidget *button_panel = nullptr;
+  UI::PeriodicTimer refresh_timer{[this]{ Refresh(); }};
+
+public:
+  void SetButtonPanel(ButtonPanelWidget &_button_panel) noexcept {
+    button_panel = &_button_panel;
+  }
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override {
+    const auto &look = UIGlobals::GetDialogLook();
+    CreateList(parent, look, rc,
+               row_renderer.CalculateLayout(look.text_font, look.small_font));
+    GetList().SetLength(services.empty() ? 1u : services.size());
+
+    if (button_panel != nullptr)
+      CreateButtons(button_panel->GetButtonPanel());
+  }
+
+  void Show(const PixelRect &rc) noexcept override {
+    ListWidget::Show(rc);
+    Refresh();
+    refresh_timer.Schedule(refresh_interval);
+  }
+
+  void Hide() noexcept override {
+    refresh_timer.Cancel();
+    ListWidget::Hide();
+  }
+
+  void Unprepare() noexcept override {
+    refresh_timer.Cancel();
+    ListWidget::Unprepare();
+  }
+
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned idx) noexcept override {
+    if (idx >= services.size()) {
+      if (services.empty() && idx == 0) {
+        row_renderer.DrawFirstRow(canvas, rc,
+                                  _("No supported services found"));
+        row_renderer.DrawSecondRow(
+          canvas, rc, _("No selected systemd units are installed."));
+      }
+
+      return;
+    }
+
+    const auto &service = services[idx];
+    const auto &status = statuses[idx];
+
+    row_renderer.DrawFirstRow(canvas, rc, service.display_name);
+
+    const char *state_text = _("Unavailable");
+    Color state_color = COLOR_RED;
+    if (status.valid) {
+      switch (status.state) {
+      case Systemd::ActiveState::ACTIVE:
+        state_text = _("On");
+        state_color = COLOR_GREEN;
+        break;
+      case Systemd::ActiveState::INACTIVE:
+        state_text = _("Off");
+        state_color = canvas.GetTextColor();
+        break;
+      case Systemd::ActiveState::ACTIVATING:
+        state_text = _("Starting...");
+        state_color = COLOR_ORANGE;
+        break;
+      case Systemd::ActiveState::DEACTIVATING:
+        state_text = _("Stopping...");
+        state_color = COLOR_ORANGE;
+        break;
+      case Systemd::ActiveState::RELOADING:
+        state_text = _("Reloading...");
+        state_color = COLOR_ORANGE;
+        break;
+      case Systemd::ActiveState::FAILED:
+        state_text = _("Failed");
+        state_color = COLOR_RED;
+        break;
+      }
+    }
+
+    const auto old_color = canvas.GetTextColor();
+    canvas.SetTextColor(state_color);
+    row_renderer.DrawRightFirstRow(canvas, rc, state_text);
+    canvas.SetTextColor(old_color);
+    row_renderer.DrawSecondRow(canvas, rc, service.description);
+    row_renderer.DrawRightSecondRow(canvas, rc, service.unit_name.c_str());
+  }
+
+  void OnCursorMoved([[maybe_unused]] unsigned index) noexcept override {
+    UpdateButtons();
+  }
+
+  bool CanActivateItem(unsigned index) const noexcept override {
+    return CanToggle(index);
+  }
+
+  void OnActivateItem(unsigned index) noexcept override {
+    Toggle(index);
+  }
+
+private:
+  void CreateButtons(ButtonPanel &buttons) noexcept {
+    toggle_button = buttons.Add(_("Turn on"), [this]{
+      Toggle(GetList().GetCursorIndex());
+    });
+    restart_button = buttons.Add(_("Restart"), [this]{
+      Restart(GetList().GetCursorIndex());
+    });
+
+    if (!services.empty())
+      buttons.EnableCursorSelection();
+
+    UpdateButtons();
+  }
+
+  [[gnu::pure]] bool CanToggle(unsigned index) const noexcept {
+    if (index >= statuses.size() || !statuses[index].valid)
+      return false;
+
+    switch (statuses[index].state) {
+    case Systemd::ActiveState::ACTIVE:
+    case Systemd::ActiveState::INACTIVE:
+    case Systemd::ActiveState::FAILED:
+      return true;
+
+    case Systemd::ActiveState::ACTIVATING:
+    case Systemd::ActiveState::DEACTIVATING:
+    case Systemd::ActiveState::RELOADING:
+      return false;
+    }
+
+    return false;
+  }
+
+  void UpdateButtons() noexcept {
+    const auto index = GetList().GetCursorIndex();
+    const bool can_toggle = CanToggle(index);
+    const bool is_active = index < statuses.size() && statuses[index].valid &&
+      statuses[index].state == Systemd::ActiveState::ACTIVE;
+
+    if (toggle_button != nullptr) {
+      toggle_button->SetCaption(is_active ? _("Turn off") : _("Turn on"));
+      toggle_button->SetEnabled(can_toggle);
+    }
+
+    if (restart_button != nullptr)
+      restart_button->SetEnabled(is_active);
+
+    /* Moving between an active and an inactive unit can disable the
+       currently selected Restart action.  Keep cursor-key selection on an
+       operable action so Up/Down list navigation and Left/Right action
+       selection continue to work together. */
+    if (can_toggle && button_panel != nullptr)
+      button_panel->GetButtonPanel().ReselectToFirstEnabled();
+  }
+
+  void Refresh() noexcept {
+    try {
+      auto connection = ODBus::Connection::GetSystem();
+      for (std::size_t i = 0; i < services.size(); ++i) {
+        try {
+          statuses[i].state = Systemd::GetUnitActiveState(
+            connection, services[i].unit_name.c_str());
+          statuses[i].valid = true;
+        } catch (...) {
+          statuses[i].valid = false;
+        }
+      }
+    } catch (...) {
+      for (auto &status : statuses)
+        status.valid = false;
+    }
+
+    GetList().Invalidate();
+    UpdateButtons();
+  }
+
+  void Toggle(unsigned index) noexcept {
+    if (!CanToggle(index))
+      return;
+
+    refresh_timer.Cancel();
+    try {
+      const auto &unit = services[index].unit_name;
+      const auto action = statuses[index].state == Systemd::ActiveState::ACTIVE
+        ? SystemdAction::STOP
+        : SystemdAction::START;
+      SystemdActionJob job{action, unit};
+
+      if (!JobDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
+                     _("System service"), job))
+        throw std::runtime_error{"Failed to start system service job"};
+
+      Refresh();
+    } catch (...) {
+      ShowError(std::current_exception(), _("System service"));
+      Refresh();
+    }
+    refresh_timer.Schedule(refresh_interval);
+  }
+
+  void Restart(unsigned index) noexcept {
+    if (index >= statuses.size() || !statuses[index].valid ||
+        statuses[index].state != Systemd::ActiveState::ACTIVE)
+      return;
+
+    refresh_timer.Cancel();
+    try {
+      SystemdActionJob job{SystemdAction::RESTART,
+                           services[index].unit_name};
+      if (!JobDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
+                     _("System service"), job))
+        throw std::runtime_error{"Failed to start system service job"};
+
+      Refresh();
+    } catch (...) {
+      ShowError(std::current_exception(), _("System service"));
+      Refresh();
+    }
+    refresh_timer.Schedule(refresh_interval);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Widget>
+CreateSystemdConfigPanel()
+{
+  auto list = std::make_unique<SystemdListWidget>();
+  auto panel = std::make_unique<ButtonPanelWidget>(
+    std::move(list), ButtonPanelWidget::Alignment::BOTTOM);
+  static_cast<SystemdListWidget &>(panel->GetWidget()).SetButtonPanel(*panel);
+  return panel;
+}

--- a/src/Dialogs/Settings/Panels/SystemdConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/SystemdConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateSystemdConfigPanel();

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -79,6 +79,10 @@
 #include "Panels/WeGlideConfigPanel.hpp"
 #include "Panels/NetworkConfigPanel.hpp"
 
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(KOBO)
+#include "Panels/SystemdConfigPanel.hpp"
+#endif
+
 #include <cassert>
 
 static unsigned current_page;
@@ -168,6 +172,9 @@ static constexpr TabMenuPage setup_pages[] = {
   { N_("Audio"), CreateAudioConfigPanel },
 #endif
   { N_("Network"), CreateNetworkConfigPanel },
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(KOBO)
+  { N_("Services"), CreateSystemdConfigPanel },
+#endif
   { nullptr, nullptr }
 };
 

--- a/src/Form/TabMenuDisplay.cpp
+++ b/src/Form/TabMenuDisplay.cpp
@@ -90,12 +90,23 @@ TabMenuDisplay::UpdateLayout() noexcept
   const auto window_size = GetSize();
   const unsigned border_width = GetTabLineHeight();
   const unsigned n_main_menu_items = std::max(GetNumMainMenuItems(), 1u);
-  const unsigned menu_button_height =
-    std::min(Layout::GetMaximumControlHeight(),
-             window_size.height / n_main_menu_items);
-  const unsigned menu_button_width = (window_size.width - 2 * border_width) / 2;
+
+  unsigned n_vertical_items = n_main_menu_items;
+  for (unsigned i = 0; i < GetNumMainMenuItems(); ++i)
+    n_vertical_items = std::max(n_vertical_items,
+                                GetMainMenuButton(i).NumSubMenus());
 
   const unsigned offset = Layout::Scale(2);
+  const unsigned vertical_spacing =
+    (n_vertical_items + 1) * border_width + 2 * offset;
+  const unsigned available_height = window_size.height > vertical_spacing
+    ? window_size.height - vertical_spacing
+    : window_size.height;
+  const unsigned menu_button_height =
+    std::min(Layout::GetMaximumControlHeight(),
+             available_height / n_vertical_items);
+  const unsigned menu_button_width = (window_size.width - 2 * border_width) / 2;
+
   const unsigned item_height = menu_button_height + border_width;
 
   for (unsigned main_i = 0, main_y = border_width;

--- a/src/Linux/SystemdServiceList.cpp
+++ b/src/Linux/SystemdServiceList.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SystemdServiceList.hpp"
+#include "Language/Language.hpp"
+#include "lib/dbus/Connection.hxx"
+#include "lib/dbus/Systemd.hxx"
+
+#include <initializer_list>
+
+namespace {
+
+static void
+AddFirstInstalled(std::vector<SystemdService> &services,
+                  ODBus::Connection &connection,
+                  const char *id, const char *display_name,
+                  const char *description,
+                  std::initializer_list<const char *> alternatives)
+{
+  const char *best_unit = nullptr;
+  unsigned best_score = 0;
+
+  for (const auto *unit_name : alternatives) {
+    if (!Systemd::UnitExists(connection, unit_name))
+      continue;
+
+    unsigned score = 1;
+    try {
+      if (Systemd::IsUnitActive(connection, unit_name))
+        score = 3;
+      else if (Systemd::IsUnitEnabled(connection, unit_name))
+        score = 2;
+    } catch (...) {
+    }
+
+    if (score > best_score) {
+      best_unit = unit_name;
+      best_score = score;
+    }
+  }
+
+  if (best_unit != nullptr)
+    services.push_back({id, display_name, description, best_unit});
+}
+
+} // namespace
+
+std::vector<SystemdService>
+BuildSystemdServiceList() noexcept
+{
+  std::vector<SystemdService> services;
+
+  try {
+    auto connection = ODBus::Connection::GetSystem();
+
+    AddFirstInstalled(services, connection, "ssh", _("SSH server"),
+                      _("Remote terminal access"),
+                      {"ssh.socket", "sshd.socket", "dropbear.socket",
+                       "ssh.service", "sshd.service", "dropbear.service"});
+    AddFirstInstalled(services, connection, "sensord", _("Sensors"),
+                      _("OpenVario sensor daemon"),
+                      {"sensord.socket", "sensord.service"});
+    AddFirstInstalled(services, connection, "variod", _("Audio vario"),
+                      _("OpenVario audio vario daemon"),
+                      {"variod.socket", "variod.service"});
+  } catch (...) {
+    /* The settings page remains empty when systemd is unavailable. */
+  }
+
+  return services;
+}

--- a/src/Linux/SystemdServiceList.hpp
+++ b/src/Linux/SystemdServiceList.hpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * One explicitly selected systemd unit exposed by XCSoar.
+ *
+ * Unit names are deliberately not supplied by users: this list is an
+ * allowlist of host facilities which XCSoar is permitted to control.
+ */
+struct SystemdService {
+  const char *id;
+  const char *display_name;
+  const char *description;
+  std::string unit_name;
+};
+
+/**
+ * Resolve the selected unit allowlist against the local system.
+ * Only installed units are returned.  For facilities with distro-specific
+ * names (such as SSH), the active alternative is preferred, followed by an
+ * enabled alternative and then any installed alternative.  Ties retain the
+ * configured list order.
+ */
+std::vector<SystemdService>
+BuildSystemdServiceList() noexcept;

--- a/src/lib/dbus/Systemd.cxx
+++ b/src/lib/dbus/Systemd.cxx
@@ -307,6 +307,52 @@ StopUnit(ODBus::Connection &connection,
   WaitJobRemoved(connection, object_path);
 }
 
+bool
+UnitExists(ODBus::Connection &connection, const char *name) noexcept
+{
+  try {
+    using namespace ODBus;
+
+    auto msg = Message::NewMethodCall("org.freedesktop.systemd1",
+            "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager",
+            "GetUnitFileState");
+    AppendMessageIter{*msg.Get()}.Append(name);
+
+    Message reply = CallMethodSync(connection, msg, false);
+    if (reply.IsError("org.freedesktop.systemd1.NoSuchUnitFile"))
+      return false;
+
+    reply.CheckThrowError();
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+void
+RestartUnit(ODBus::Connection &connection,
+            const char *name, const char *mode)
+{
+  using namespace ODBus;
+
+  auto msg = Message::NewMethodCall("org.freedesktop.systemd1",
+            "/org/freedesktop/systemd1",
+            "org.freedesktop.systemd1.Manager",
+            "RestartUnit");
+
+  AppendMessageIter{*msg.Get()}.Append(name).Append(mode);
+
+  Message reply = CallMethodSync(connection, msg);
+
+  Error error;
+  const char *object_path;
+  if (!reply.GetArgs(error, DBUS_TYPE_OBJECT_PATH, &object_path))
+    error.Throw("RestartUnit reply failed");
+
+  WaitJobRemoved(connection, object_path);
+}
+
 void
 ResetFailedUnit(ODBus::Connection &connection, const char *name)
 {

--- a/src/lib/dbus/Systemd.cxx
+++ b/src/lib/dbus/Systemd.cxx
@@ -12,22 +12,48 @@
 #include "Error.hxx"
 #include "util/StringAPI.hxx"
 
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
 #include <string>
 
 namespace Systemd {
 
 void
-WaitJobRemoved(ODBus::Connection &connection, const char *object_path)
+WaitJobRemoved(ODBus::Connection &connection, const char *object_path,
+               int timeout_ms)
 {
   using namespace ODBus;
+  using Clock = std::chrono::steady_clock;
+
+  const bool has_timeout = timeout_ms >= 0;
+  const auto deadline = Clock::now() +
+    std::chrono::milliseconds{has_timeout ? timeout_ms : 0};
 
   while (true) {
+    if (has_timeout && Clock::now() >= deadline)
+      throw std::runtime_error{"Timed out waiting for systemd job"};
+
     auto msg = Message::Pop(*connection);
     if (!msg.IsDefined()) {
-      if (dbus_connection_read_write(connection, -1))
+      int wait_ms = -1;
+      if (has_timeout) {
+        const auto now = Clock::now();
+        if (now >= deadline)
+          throw std::runtime_error{"Timed out waiting for systemd job"};
+
+        const auto remaining = std::chrono::ceil<std::chrono::milliseconds>(
+          deadline - now).count();
+        wait_ms = static_cast<int>(std::min<int64_t>(
+          remaining, std::numeric_limits<int>::max()));
+      }
+
+      if (dbus_connection_read_write(connection, wait_ms))
         continue;
-      else
-        break;
+
+      throw std::runtime_error{"D-Bus connection closed while waiting for systemd job"};
     }
 
     if (msg.IsSignal("org.freedesktop.systemd1.Manager", "JobRemoved")) {
@@ -263,7 +289,7 @@ IsUnitActive(ODBus::Connection &connection, const char *name)
 
 void
 StartUnit(ODBus::Connection &connection,
-       const char *name, const char *mode)
+       const char *name, const char *mode, int timeout_ms)
 {
   using namespace ODBus;
 
@@ -281,12 +307,12 @@ StartUnit(ODBus::Connection &connection,
   if (!reply.GetArgs(error, DBUS_TYPE_OBJECT_PATH, &object_path))
     error.Throw("StartUnit reply failed");
 
-  WaitJobRemoved(connection, object_path);
+  WaitJobRemoved(connection, object_path, timeout_ms);
 }
 
 void
 StopUnit(ODBus::Connection &connection,
-      const char *name, const char *mode)
+      const char *name, const char *mode, int timeout_ms)
 {
   using namespace ODBus;
 
@@ -304,7 +330,7 @@ StopUnit(ODBus::Connection &connection,
   if (!reply.GetArgs(error, DBUS_TYPE_OBJECT_PATH, &object_path))
     error.Throw("StopUnit reply failed");
 
-  WaitJobRemoved(connection, object_path);
+  WaitJobRemoved(connection, object_path, timeout_ms);
 }
 
 bool
@@ -332,7 +358,7 @@ UnitExists(ODBus::Connection &connection, const char *name) noexcept
 
 void
 RestartUnit(ODBus::Connection &connection,
-            const char *name, const char *mode)
+            const char *name, const char *mode, int timeout_ms)
 {
   using namespace ODBus;
 
@@ -350,7 +376,7 @@ RestartUnit(ODBus::Connection &connection,
   if (!reply.GetArgs(error, DBUS_TYPE_OBJECT_PATH, &object_path))
     error.Throw("RestartUnit reply failed");
 
-  WaitJobRemoved(connection, object_path);
+  WaitJobRemoved(connection, object_path, timeout_ms);
 }
 
 void

--- a/src/lib/dbus/Systemd.hxx
+++ b/src/lib/dbus/Systemd.hxx
@@ -95,6 +95,26 @@ StopUnit(ODBus::Connection &connection,
 	 const char *name, const char *mode="replace");
 
 /**
+ * Returns whether a unit file with the specified name is installed.
+ *
+ * This is intended for optional, explicitly configured units.  A D-Bus
+ * failure is treated like a missing unit.
+ */
+bool
+UnitExists(ODBus::Connection &connection, const char *name) noexcept;
+
+/**
+ * Restart a unit.
+ *
+ * Note: the caller must establish a match on "JobRemoved".
+ *
+ * Throws on error.
+ */
+void
+RestartUnit(ODBus::Connection &connection,
+	    const char *name, const char *mode="replace");
+
+/**
  * Resets the "failed" state of a specific unit.
  *
  * Throws on error.

--- a/src/lib/dbus/Systemd.hxx
+++ b/src/lib/dbus/Systemd.hxx
@@ -24,9 +24,13 @@ constexpr auto unit_removed_match = "type='signal',"
 
 /**
  * Throws on error.
+ *
+ * @param timeout_ms maximum time to wait for completion, or -1 to wait
+ * indefinitely
  */
 void
-WaitJobRemoved(ODBus::Connection &connection, const char *object_path);
+WaitJobRemoved(ODBus::Connection &connection, const char *object_path,
+	       int timeout_ms=-1);
 
 /**
  * Wait for the UnitRemoved signal for the specified unit name.
@@ -83,7 +87,7 @@ IsUnitActive(ODBus::Connection &connection, const char *name);
  */
 void
 StartUnit(ODBus::Connection &connection,
-	  const char *name, const char *mode="replace");
+	  const char *name, const char *mode="replace", int timeout_ms=-1);
 
 /**
  * Note: the caller must establish a match on "JobRemoved".
@@ -92,7 +96,7 @@ StartUnit(ODBus::Connection &connection,
  */
 void
 StopUnit(ODBus::Connection &connection,
-	 const char *name, const char *mode="replace");
+	 const char *name, const char *mode="replace", int timeout_ms=-1);
 
 /**
  * Returns whether a unit file with the specified name is installed.
@@ -112,7 +116,7 @@ UnitExists(ODBus::Connection &connection, const char *name) noexcept;
  */
 void
 RestartUnit(ODBus::Connection &connection,
-	    const char *name, const char *mode="replace");
+	    const char *name, const char *mode="replace", int timeout_ms=-1);
 
 /**
  * Resets the "failed" state of a specific unit.


### PR DESCRIPTION
For embedded systems to control the backend linux. Only services relevant for the user are exposed (notably OpenVario sensord, variod, SSH server). WiFi control is explicitly not integrated as it is controlled separately by the WiFi Dialog via D-BUS.

Ref: #2274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Linux-only **Services** settings page for viewing, enabling, disabling, starting, stopping, and restarting supported system services.
  * Service statuses refresh automatically while the page is open, with clear status indicators and error messages.
  * Supported services are detected based on availability and current state.

* **Bug Fixes**
  * Improved settings menu sizing when submenu entries exceed the number of main-menu items.
  * Added timeout handling for service operations to prevent stalled actions and provide clearer failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->