### PR TITLE
Engine/GlideSolvers/GlidePolar: Fix next-leg equivalent thermal

### DIFF
--- a/src/Computer/GlideComputerAirData.cpp
+++ b/src/Computer/GlideComputerAirData.cpp
@@ -412,6 +412,7 @@ GlideComputerAirData::NextLegEqThermal([[maybe_unused]] const NMEAInfo &basic,
       !calculated.wind_available) {
     // Assign a negative value to invalidate the result
     calculated.next_leg_eq_thermal = -1;
+    calculated.next_leg_eq_thermal_inverse = -1;
     return;
   }
 
@@ -423,4 +424,6 @@ GlideComputerAirData::NextLegEqThermal([[maybe_unused]] const NMEAInfo &basic,
 
   calculated.next_leg_eq_thermal =
       settings.polar.glide_polar_task.GetNextLegEqThermal(wind_comp, next_comp);
+  calculated.next_leg_eq_thermal_inverse =
+      settings.polar.glide_polar_task.GetNextLegEqThermal(next_comp, wind_comp);
 }

--- a/src/Engine/GlideSolvers/GlidePolar.cpp
+++ b/src/Engine/GlideSolvers/GlidePolar.cpp
@@ -497,7 +497,7 @@ GlidePolar::GetNextLegEqThermal(double current_wind,
   /* calculate coefficients of the polar shifted to the right
      by an amount equal to head wind (ground speed polar) */
   const PolarCoefficients s_polar(polar.a,
-                                  polar.b - 2 * next_wind * polar.a,
+                                  polar.b + 2 * next_wind * polar.a,
                                   polar.c + next_wind *
                                   (next_wind * polar.a + polar.b));
 

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -886,7 +886,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Thermal next leg equivalent"),
     N_("T Next Leg"),
-    N_("Thermal climb rate on the next leg that is equivalent to a thermal climb rate equal to the MacCready setting on the current leg."),
+    N_("Main value: thermal climb rate on the next leg that is equivalent to a thermal climb rate equal to the MacCready setting on the current leg. Secondary value: thermal climb rate on the current leg that is equivalent to a thermal climb rate equal to the MacCready setting on the next leg."),
     UpdateInfoBoxNextLegEqThermal,
   },
 

--- a/src/InfoBoxes/Content/Thermal.cpp
+++ b/src/InfoBoxes/Content/Thermal.cpp
@@ -186,6 +186,13 @@ UpdateInfoBoxNextLegEqThermal(InfoBoxData &data) noexcept
   }
 
   SetVSpeed(data, next_leg_eq_thermal);
+
+  const auto next_leg_eq_thermal_inverse =
+    CommonInterface::Calculated().next_leg_eq_thermal_inverse;
+  if (next_leg_eq_thermal_inverse >= 0)
+    data.SetCommentFromVerticalSpeed(next_leg_eq_thermal_inverse, false);
+  else
+    data.SetCommentInvalid();
 }
 
 void

--- a/src/NMEA/Derived.hpp
+++ b/src/NMEA/Derived.hpp
@@ -244,6 +244,13 @@ struct DerivedInfo:
   double next_leg_eq_thermal;
 
   /**
+   * Thermal value of current leg that is equivalent (gives the same average
+   * speed) to the current MacCready setting on the next leg.
+   * A negative value should be treated as invalid.
+   */
+  double next_leg_eq_thermal_inverse;
+
+  /**
    * @todo Reset to cleared state
    */
   void Reset();

--- a/test/src/TestGlidePolar.cpp
+++ b/test/src/TestGlidePolar.cpp
@@ -24,6 +24,7 @@ private:
   void TestMC();
   void TestDensityRatio();
   void TestDensityRatioMC();
+  void TestNextLegEqThermal();
 };
 
 void
@@ -260,6 +261,47 @@ GlidePolarTest::TestDensityRatioMC()
 }
 
 void
+GlidePolarTest::TestNextLegEqThermal()
+{
+  const double w = Units::ToSysUnit(30, Unit::KILOMETER_PER_HOUR);
+
+  for (const double mc : {0.1, 1.5, 4.0}) {
+    polar.SetMC(mc);
+
+    ok1(equals(polar.GetNextLegEqThermal(0, 0), mc));
+    ok1(equals(polar.GetNextLegEqThermal(w, w), mc));
+    ok1(equals(polar.GetNextLegEqThermal(-w, -w), mc));
+
+    ok1(polar.GetNextLegEqThermal(w, -w) < mc);
+    ok1(polar.GetNextLegEqThermal(-w, w) > mc);
+  }
+
+  GlidePolar asw20(0);
+  asw20.SetReferenceMass(377, false);
+  asw20.SetEmptyMass(377, false);
+  asw20.SetCrewMass(0, false);
+  asw20.SetCoefficients(PolarCoefficients::From3VW(
+      Units::ToSysUnit(116.2, Unit::KILOMETER_PER_HOUR),
+      Units::ToSysUnit(174.3, Unit::KILOMETER_PER_HOUR),
+      Units::ToSysUnit(213.04, Unit::KILOMETER_PER_HOUR),
+      -0.77, -1.89, -3.3), false);
+  asw20.Update();
+  asw20.SetMC(1.5);
+
+  const double primary = asw20.GetNextLegEqThermal(w, -w);
+  const double secondary = asw20.GetNextLegEqThermal(-w, w);
+
+  ok1(equals(asw20.GetNextLegEqThermal(w, w), asw20.GetMC()));
+  ok1(equals(asw20.GetNextLegEqThermal(-w, -w), asw20.GetMC()));
+  ok1(equals(primary, 0.59634));
+  ok1(equals(secondary, 2.87184));
+  ok1(primary > 0 && primary < asw20.GetMC());
+  ok1(secondary > asw20.GetMC());
+
+  polar.SetMC(0);
+}
+
+void
 GlidePolarTest::Run()
 {
   Init();
@@ -270,11 +312,12 @@ GlidePolarTest::Run()
   TestMC();
   TestDensityRatio();
   TestDensityRatioMC();
+  TestNextLegEqThermal();
 }
 
 int main()
 {
-  plan_tests(69 + 3);
+  plan_tests(69 + 3 + 21);
 
   GlidePolarTest test;
   test.Run();


### PR DESCRIPTION
# Fix the "Thermal next leg equivalent" infobox computation

The bug was found by observing calculations for ASW 20 with MC=1.5, W=30 km/h, current leg against the wind, next leg with the wind. Old calculation gave a negative value that doesn't match the reality.

`GlideComputerAirData` passes headwind-positive current and next wind components to `GetNextLegEqThermal()`.  For a headwind h and ground speed `x`, the airspeed polar is `s(x + h)`, so the ground-speed coefficient is `b + 2*a*h`, not `b - 2*a*h`.

The original 2012 implementation already used this wind projection convention, so this appears to have been a latent bug.

Also added as a secondary value for the infobox thermal climb rate on the current leg that is equivalent to a thermal climb rate equal to the MacCready setting on the next leg.

The screenshot shows the fixed **T Next Leg** infobox.

<img width="300" height="512" alt="Screenshot_20260825_161727" src="https://github.com/user-attachments/assets/d3f069c6-31cb-4477-bfea-3db9f7996f43" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added next-leg equivalent thermal calculations, including the corresponding current-leg value.
  * The Thermal Next Leg Equivalent infobox now displays both values when valid.
  * Expanded the infobox description to clarify the meaning of each value.

* **Bug Fixes**
  * Corrected wind adjustment handling for next-leg thermal calculations.
  * Invalid results are now clearly marked when required data is unavailable.

* **Tests**
  * Added coverage for next-leg thermal calculations across multiple settings and wind conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->