### PR TITLE
Map: Keep the live snail trail stable while panning and circling

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -34,6 +34,8 @@ Version 7.46 - not yet released
     #2879
   - fix the map scale arrows: draw them at the height of the scale box
     instead of overlapping it
+  - fix the live snail trail losing circling detail and jumping as the
+    map follows the aircraft, including at 10x replay #2948
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -36,6 +36,8 @@ Version 7.46 - not yet released
     instead of overlapping it
   - fix the live snail trail losing circling detail and jumping as the
     map follows the aircraft, including at 10x replay #2948
+  - keep the pan-mode map scale while panning, and restore the saved
+    circling or cruise scale when leaving pan mode
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/src/Engine/Trace/Trace.cpp
+++ b/src/Engine/Trace/Trace.cpp
@@ -503,6 +503,84 @@ StrideForBudget(unsigned point_count, unsigned max_points,
   return std::max(stride, need);
 }
 
+/**
+ * Distance-thin from the newest sample backward, then always keep the
+ * oldest candidate.  Anchoring at the tip stops the kept vertices from
+ * walking when the viewport drops an old point (follow / replay).
+ */
+static void
+ThinByDistanceFromTip(const TracePointVector &candidates,
+                      TracePointVector &out,
+                      unsigned sq_range) noexcept
+{
+  out.clear();
+  if (candidates.empty())
+    return;
+
+  out.reserve(candidates.size());
+  out.push_back(candidates.back());
+  size_t last = candidates.size() - 1;
+  for (size_t k = candidates.size() - 1; k-- > 0;) {
+    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >= sq_range) {
+      out.push_back(candidates[k]);
+      last = k;
+    }
+  }
+
+  if (out.back().GetTime() != candidates.front().GetTime())
+    out.push_back(candidates.front());
+
+  std::reverse(out.begin(), out.end());
+}
+
+/**
+ * If the thinned path still exceeds \a max_points, stride only the
+ * older prefix so recent circling stays dense.
+ */
+static void
+FitPointBudget(TracePointVector &points, unsigned max_points,
+               unsigned min_stride) noexcept
+{
+  if (max_points < 2 || points.size() <= max_points)
+    return;
+
+  constexpr unsigned TAIL_CAP = 512;
+  const unsigned tail =
+    std::min(unsigned(points.size() - 2),
+             std::min(TAIL_CAP, max_points * 3 / 4));
+  if (tail < 2 || max_points <= tail + 1) {
+    ApplyPointStride(points,
+                     StrideForBudget(unsigned(points.size()), max_points,
+                                     min_stride));
+    return;
+  }
+
+  TracePointVector prefix;
+  prefix.insert(prefix.end(), points.begin(), points.end() - tail);
+  ApplyPointStride(prefix,
+                   StrideForBudget(unsigned(prefix.size()),
+                                   max_points - tail, min_stride));
+
+  TracePointVector kept;
+  kept.reserve(prefix.size() + tail);
+  kept.insert(kept.end(), prefix.begin(), prefix.end());
+
+  const auto tail_begin = points.end() - tail;
+  const size_t skip =
+    !kept.empty() && kept.back().GetTime() == tail_begin->GetTime() ? 1 : 0;
+  kept.insert(kept.end(), tail_begin + skip, points.end());
+  points.swap(kept);
+}
+
+static void
+ThinTraceCandidates(const TracePointVector &candidates,
+                    TracePointVector &out,
+                    const TrailSpatialFilter &filter) noexcept
+{
+  ThinByDistanceFromTip(candidates, out, filter.sq_range);
+  FitPointBudget(out, filter.max_points, filter.point_stride);
+}
+
 void
 FilterTraceByBounds(const TracePointVector &in,
                     TracePointVector &out,
@@ -548,21 +626,7 @@ FilterTraceByBounds(const TracePointVector &in,
   if (candidates.empty())
     return;
 
-  out.reserve(candidates.size());
-  out.push_back(candidates.front());
-  size_t last = 0;
-  for (size_t k = 1; k < candidates.size(); ++k) {
-    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >=
-        filter.sq_range) {
-      out.push_back(candidates[k]);
-      last = k;
-    }
-  }
-
-  const unsigned stride =
-    StrideForBudget(unsigned(out.size()), filter.max_points,
-                    filter.point_stride);
-  ApplyPointStride(out, stride);
+  ThinTraceCandidates(candidates, out, filter);
 }
 
 TrailSpatialFilter
@@ -674,19 +738,5 @@ Trace::GetPoints(TracePointVector &v, const Time min_time,
   if (candidates.empty())
     return;
 
-  v.reserve(candidates.size());
-  v.push_back(candidates.front());
-  size_t last = 0;
-  for (size_t k = 1; k < candidates.size(); ++k) {
-    if (candidates[k].FlatSquareDistanceTo(candidates[last]) >=
-        filter.sq_range) {
-      v.push_back(candidates[k]);
-      last = k;
-    }
-  }
-
-  const unsigned stride =
-    StrideForBudget(unsigned(v.size()), filter.max_points,
-                    filter.point_stride);
-  ApplyPointStride(v, stride);
+  ThinTraceCandidates(candidates, v, filter);
 }

--- a/src/Engine/Trace/Trace.hpp
+++ b/src/Engine/Trace/Trace.hpp
@@ -34,16 +34,16 @@ struct TrailSpatialFilter {
   unsigned point_stride = 1;
   /**
    * Soft cap on returned points.  If distance thinning still exceeds
-   * this, stride is raised so draw cost stays bounded (PG and glider).
+   * this, the older prefix is strided so the recent tail stays dense.
    */
   unsigned max_points = 0;
   bool valid = false;
 };
 
 /**
- * Bounds-first then spacing-thin, matching Trace::GetPoints(..., bounds, ...).
- * Used by TrailRenderer on a local time-window history without re-walking
- * the store under lock.
+ * Bounds-first then spacing-thin from the newest sample, matching
+ * Trace::GetPoints(..., bounds, ...).  Used by TrailRenderer on a local
+ * time-window history without re-walking the store under lock.
  */
 void FilterTraceByBounds(const TracePointVector &in,
                          TracePointVector &out,
@@ -423,8 +423,9 @@ public:
   /**
    * Fill the vector with trace points not before #min_time that lie
    * inside \a bounds or on legs that intersect \a bounds, then apply
-   * minimum resolution #min_distance.  Bounds are applied before
-   * spacing thinning so cost tracks the viewport, not flight length.
+   * minimum resolution #min_distance from the newest sample backward.
+   * Bounds are applied before spacing thinning so cost tracks the
+   * viewport, not flight length. The latest point is always kept.
    */
   void GetPoints(TracePointVector &v, Time min_time,
                  const GeoBounds &bounds,

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -68,6 +68,11 @@ GlueMapWindow::SetPan(bool enable) noexcept
     break;
   }
 
+  /* Pan keeps its own scale.  Circling zoom must not yank it; leaving
+     pan restores the saved circling/cruise scale. */
+  if (!enable)
+    RestoreMapScale();
+
   FullRedraw();
 }
 
@@ -81,6 +86,7 @@ GlueMapWindow::TogglePan() noexcept
 
   case FOLLOW_PAN:
     follow_mode = FOLLOW_SELF;
+    RestoreMapScale();
     break;
   }
 
@@ -117,6 +123,10 @@ GlueMapWindow::UpdateScreenBounds() noexcept
 void
 GlueMapWindow::PersistCurrentScale() noexcept
 {
+  /* Pan zoom is temporary; do not overwrite circling/cruise scales. */
+  if (IsPanning())
+    return;
+
   const bool circling =
     CommonInterface::GetUIState().display_mode == DisplayMode::CIRCLING;
   MapSettings &settings = CommonInterface::SetMapSettings();
@@ -288,6 +298,9 @@ inline void
 GlueMapWindow::SwitchZoomClimb() noexcept
 {
   const MapSettings &settings = CommonInterface::GetMapSettings();
+
+  if (IsPanning())
+    return;
 
   if (settings.circle_zoom_enabled)
     RestoreMapScale();

--- a/src/Renderer/TrailRenderer.cpp
+++ b/src/Renderer/TrailRenderer.cpp
@@ -24,19 +24,11 @@ static constexpr double TRAIL_ZOOMED_OUT_MAP_SCALE = 6000;
 static constexpr double TRAIL_BOUNDS_SCALE = 4.;
 
 /**
- * On-screen trail sample spacing in points (1/72").  Converted to pixels
- * via Layout::PtScale (DPI / UI scale) then to metres via the projection,
- * so thinning tracks physical size across phones, OV boxes, and Kobo.
+ * On-screen spacing between kept trail fixes, in pixels (v7.44 used 3).
+ * Do not use Layout::PtScale here: on phones that becomes 10–100 px and
+ * circling vertices jump as the thinning lattice walks (#2948).
  */
-static constexpr unsigned TRAIL_SPACING_PT_MIN = 2;
-static constexpr unsigned TRAIL_SPACING_PT_MAX = 18;
-
-/**
- * Grow spacing with zoom-out: GetMapScale / this → pixel target before
- * PtScale clamps.  Smaller → more thinning when zoomed out.  Still only
- * feeds the px→m pipeline (not a device-specific stride ladder).
- */
-static constexpr double TRAIL_SPACING_MAP_SCALE_DIV = 250.;
+static constexpr int TRAIL_SPACING_PX = 3;
 
 namespace {
 
@@ -215,22 +207,14 @@ ComputeCatmullRomWeights(double t) noexcept
 
 /**
  * Target on-screen spacing between kept fixes, in pixels.
- * Floor/ceiling use Layout::PtScale so the same physical size on glass
- * applies across DPI/resolution; zoom only moves within that range.
  * Metres come from WindowProjection::DistancePixelsToMeters in
- * MakeTrailQuery — not from magic GetMapScale stride bands.
+ * MakeTrailQuery.
  */
-[[gnu::pure]]
+[[gnu::const]]
 static int
-GetTrailSpacingPixels(double map_scale) noexcept
+GetTrailSpacingPixels() noexcept
 {
-  const int min_px =
-    std::max(1, int(Layout::PtScale(TRAIL_SPACING_PT_MIN)));
-  const int max_px =
-    std::max(min_px, int(Layout::PtScale(TRAIL_SPACING_PT_MAX)));
-  const int from_zoom =
-    int(map_scale / TRAIL_SPACING_MAP_SCALE_DIV);
-  return std::clamp(from_zoom, min_px, max_px);
+  return TRAIL_SPACING_PX;
 }
 
 /** Max number of recent trace points that receive Catmull-Rom smoothing. */
@@ -469,30 +453,27 @@ TrailRenderer::LoadTrace(const TraceComputer &trace_computer,
 }
 
 /**
- * Soft cap on drawable trail samples.  Scaled with short-edge resolution
- * and point size so denser panels may keep a bit more; clamped so weak
- * ARM targets stay bounded regardless of airspeed / zoom.
+ * Soft cap on drawable trail samples.  Short-edge pixel count, with a
+ * floor so a high-DPI phone is not starved (PtScale in the divisor
+ * used to drop the budget to ~96 and stride away circling).
  */
 [[gnu::pure]]
 static unsigned
 GetTrailPointBudget() noexcept
 {
-  const unsigned pt = std::max(1u, Layout::PtScale(2));
-  const unsigned by_screen = Layout::min_screen_pixels / pt;
-  return std::clamp(by_screen, 96u, 384u);
+  return std::clamp(Layout::min_screen_pixels, 1024u, 4096u);
 }
 
 TrailQuery
 TrailRenderer::MakeTrailQuery(TimeStamp min_time,
                               const WindowProjection &projection) noexcept
 {
-  const double map_scale = projection.GetMapScale();
   TrailQuery query;
   query.min_time = min_time.Cast<std::chrono::duration<unsigned>>();
   query.bounds = projection.GetScreenBounds().Scale(TRAIL_BOUNDS_SCALE);
   query.project_location = projection.GetGeoScreenCenter();
   query.min_distance_m =
-    projection.DistancePixelsToMeters(GetTrailSpacingPixels(map_scale));
+    projection.DistancePixelsToMeters(GetTrailSpacingPixels());
   query.point_stride = 1;
   query.max_points = GetTrailPointBudget();
   return query;

--- a/test/src/TestTraceBounds.cpp
+++ b/test/src/TestTraceBounds.cpp
@@ -6,6 +6,7 @@
 #include "Geo/GeoBounds.hpp"
 #include "TestUtil.hpp"
 
+#include <algorithm>
 #include <chrono>
 
 using namespace std::chrono;
@@ -69,6 +70,79 @@ TestBoundsFirstQuery() noexcept
 }
 
 /**
+ * Coarse min_distance used to drop the newest samples; the tip must
+ * still be present (open leg / follow would otherwise rubber-band).
+ */
+static void
+TestThinningKeepsLatestPoint() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 256);
+
+  constexpr unsigned n_points = 40;
+  constexpr double step_deg = 0.0001; /* ~11 m */
+
+  for (unsigned i = 0; i < n_points; ++i) {
+    const GeoPoint loc(Angle::Degrees(8 + i * step_deg),
+                       Angle::Degrees(48));
+    trace.push_back(TracePoint(loc, seconds{i * 2}, 1000, 0, 0));
+  }
+
+  const GeoPoint end_loc = trace.back().GetLocation();
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(7.9), Angle::Degrees(48.1)),
+    GeoPoint(Angle::Degrees(8.1), Angle::Degrees(47.9)));
+
+  TracePointVector bounded;
+  /* 5 km: only first would survive a forward thin without keeping the tip. */
+  trace.GetPoints(bounded, {}, box, end_loc, 5000.);
+  ok1(!bounded.empty());
+  ok1(bounded.front().GetTime() == seconds{0});
+  ok1(bounded.back().GetTime() == trace.back().GetTime());
+  ok1(bounded.size() == 2);
+}
+
+/**
+ * Dropping the oldest sample must not retarget the whole thinning
+ * lattice.  Kept times from the tip stay the same (follow / 10x replay).
+ */
+static void
+TestThinningAnchoredAtTip() noexcept
+{
+  Trace trace(seconds{0}, Trace::null_time, 256);
+
+  constexpr unsigned n_points = 40;
+  constexpr double step_deg = 0.0005; /* ~55 m */
+
+  for (unsigned i = 0; i < n_points; ++i) {
+    const GeoPoint loc(Angle::Degrees(8 + i * step_deg),
+                       Angle::Degrees(48));
+    trace.push_back(TracePoint(loc, seconds{i * 2}, 1000, 0, 0));
+  }
+
+  const GeoPoint end_loc = trace.back().GetLocation();
+  const GeoBounds box(
+    GeoPoint(Angle::Degrees(7.9), Angle::Degrees(48.1)),
+    GeoPoint(Angle::Degrees(8.1), Angle::Degrees(47.9)));
+
+  TracePointVector full, dropped_first;
+  trace.GetPoints(full, {}, box, end_loc, 200.);
+  trace.GetPoints(dropped_first, seconds{2}, box, end_loc, 200.);
+
+  ok1(!full.empty());
+  ok1(!dropped_first.empty());
+  ok1(full.back().GetTime() == trace.back().GetTime());
+  ok1(dropped_first.back().GetTime() == trace.back().GetTime());
+
+  size_t match = 0;
+  while (match < full.size() && match < dropped_first.size() &&
+         full[full.size() - 1 - match].GetTime() ==
+           dropped_first[dropped_first.size() - 1 - match].GetTime())
+    ++match;
+
+  ok1(match >= std::min(full.size(), dropped_first.size()) - 1);
+}
+
+/**
  * A single long leg that crosses the viewport must keep both endpoints
  * (outside → outside with segment through the box).
  */
@@ -104,8 +178,10 @@ TestCrossingLegKept() noexcept
 int
 main()
 {
-  plan_tests(9 + 7);
+  plan_tests(9 + 7 + 4 + 5);
   TestBoundsFirstQuery();
   TestCrossingLegKept();
+  TestThinningKeepsLatestPoint();
+  TestThinningAnchoredAtTip();
   return exit_status();
 }


### PR DESCRIPTION
## Summary
- Thin the live snail trail from the newest fix, keep the first and last points, and use 3 px spacing so circling detail does not walk as the map follows the aircraft (#2948).
- Leave the pan-mode map scale alone when circling zoom would otherwise switch it.

## Test plan
- [ ] Replay a circling flight (including 10x) and confirm the live trail stays attached to the aircraft and keeps turn shape.
- [ ] Enter pan, start a thermal (or wait for circling zoom), and confirm the pan scale does not jump; leaving pan restores cruise/climb scale as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live aircraft trails to reduce jumping and preserve circling detail, including during 10× replay.
  * Trail rendering now remains consistent across display resolutions and zoom levels.
  * Fixed map scale changes while panning so the selected circling or cruise scale is restored correctly afterward.
  * Ensured the newest trail point remains visible when trails are simplified, preserving recent trail detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->