### PR TITLE
Waypoint: Add map display filter by CUP type

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -30,6 +30,10 @@ Version 7.46 - not yet released
   - fix choosing SkySight as a page overlay with no layers available
     silently switching back to None
 * map
+  - add a waypoint type Display filter on the map Waypoints settings
+    page (SeeYou CUP styles; task and watched waypoints stay visible),
+    including a Non-ICAO airports toggle (hide airports whose short
+    name is not four characters)
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/build/main.mk
+++ b/build/main.mk
@@ -106,6 +106,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Waypoint/WaypointInfoWidget.cpp \
 	$(SRC)/Dialogs/Waypoint/WaypointCommandsWidget.cpp \
 	$(SRC)/Dialogs/Waypoint/dlgWaypointDetails.cpp \
+	$(SRC)/Dialogs/Waypoint/dlgWaypointFilter.cpp \
 	$(SRC)/Dialogs/Waypoint/Manager.cpp \
 	$(SRC)/Dialogs/Waypoint/dlgWaypointEdit.cpp \
 	$(SRC)/Dialogs/Waypoint/WaypointList.cpp \

--- a/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp
@@ -9,6 +9,8 @@
 #include "Language/Language.hpp"
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
+#include "ConfigPanel.hpp"
+#include "Dialogs/Waypoint/WaypointDialogs.hpp"
 
 enum ControlIndex {
   WaypointLabels,
@@ -33,6 +35,8 @@ public:
 
   /* methods from Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  void Show(const PixelRect &rc) noexcept override;
+  void Hide() noexcept override;
   bool Save(bool &changed) noexcept override;
 
 private:
@@ -192,6 +196,23 @@ WaypointDisplayConfigPanel::Prepare(ContainerWindow &parent,
   SetExpertRow(AppScaleRunwayLength);
 
   UpdateVisibilities();
+}
+
+void
+WaypointDisplayConfigPanel::Show(const PixelRect &rc) noexcept
+{
+  ConfigPanel::BorrowExtraButton(2, _("Filter"), [](){
+    dlgWaypointFilterShowModal();
+  });
+
+  RowFormWidget::Show(rc);
+}
+
+void
+WaypointDisplayConfigPanel::Hide() noexcept
+{
+  RowFormWidget::Hide();
+  ConfigPanel::ReturnExtraButton(2);
 }
 
 bool

--- a/src/Dialogs/Waypoint/WaypointDialogs.hpp
+++ b/src/Dialogs/Waypoint/WaypointDialogs.hpp
@@ -54,6 +54,13 @@ ShowWaypointListPersistentDialog(
 void
 dlgConfigWaypointsShowModal(Waypoints &waypoints) noexcept;
 
+/**
+ * Map display filter for waypoint types (SeeYou CUP styles).
+ * Toggle Display like the airspace filter dialog.
+ */
+void
+dlgWaypointFilterShowModal() noexcept;
+
 enum class WaypointEditResult {
   /** editing was canceled by the user */
   CANCEL,

--- a/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
+++ b/src/Dialogs/Waypoint/WaypointInfoWidget.cpp
@@ -85,6 +85,9 @@ GetWaypointTypeName(Waypoint::Type type) noexcept
     return _("PG Landing Zone");
   case Waypoint::Type::THERMAL_HOTSPOT:
     return _("Thermal hotspot");
+
+  case Waypoint::Type::COUNT:
+    break;
   }
 
   return _("Unknown");

--- a/src/Dialogs/Waypoint/dlgWaypointFilter.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointFilter.cpp
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "WaypointDialogs.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Widget/ListWidget.hpp"
+#include "Profile/Profile.hpp"
+#include "Renderer/WaypointRendererSettings.hpp"
+#include "Renderer/TextRowRenderer.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "Screen/Layout.hpp"
+#include "UIGlobals.hpp"
+#include "Look/DialogLook.hpp"
+#include "Interface.hpp"
+#include "ActionInterface.hpp"
+#include "Language/Language.hpp"
+#include "Engine/Waypoint/Waypoint.hpp"
+
+#include <cassert>
+#include <cstddef>
+
+/**
+ * SeeYou / OpenAIP CUP styles mapped by ParseStyle() — no thermal
+ * hotspot (that type is not a CUP style).
+ */
+static constexpr Waypoint::Type FILTER_TYPES[] = {
+  Waypoint::Type::NORMAL,
+  Waypoint::Type::AIRFIELD,
+  Waypoint::Type::OUTLANDING,
+  Waypoint::Type::MOUNTAIN_PASS,
+  Waypoint::Type::MOUNTAIN_TOP,
+  Waypoint::Type::OBSTACLE,
+  Waypoint::Type::VOR,
+  Waypoint::Type::NDB,
+  Waypoint::Type::TOWER,
+  Waypoint::Type::DAM,
+  Waypoint::Type::TUNNEL,
+  Waypoint::Type::BRIDGE,
+  Waypoint::Type::POWERPLANT,
+  Waypoint::Type::CASTLE,
+  Waypoint::Type::INTERSECTION,
+  Waypoint::Type::MARKER,
+  Waypoint::Type::REPORTING_POINT,
+  Waypoint::Type::PGTAKEOFF,
+  Waypoint::Type::PGLANDING,
+};
+
+static constexpr unsigned FILTER_TYPE_COUNT = std::size(FILTER_TYPES);
+
+/** Extra row: airports without a 4-character (ICAO) short name. */
+static constexpr unsigned NON_ICAO_AIRPORTS_ROW = FILTER_TYPE_COUNT;
+
+static constexpr unsigned FILTER_ROW_COUNT = FILTER_TYPE_COUNT + 1;
+
+static const char *
+GetFilterTypeName(Waypoint::Type type) noexcept
+{
+  switch (type) {
+  case Waypoint::Type::NORMAL:
+    return _("Turnpoint");
+  case Waypoint::Type::AIRFIELD:
+    return _("Airport");
+  case Waypoint::Type::OUTLANDING:
+    return _("Landable");
+  case Waypoint::Type::MOUNTAIN_PASS:
+    return _("Mountain Pass");
+  case Waypoint::Type::MOUNTAIN_TOP:
+    return _("Mountain Top");
+  case Waypoint::Type::OBSTACLE:
+    return _("Transmitter Mast");
+  case Waypoint::Type::TOWER:
+    return _("Tower");
+  case Waypoint::Type::TUNNEL:
+    return _("Tunnel");
+  case Waypoint::Type::BRIDGE:
+    return _("Bridge");
+  case Waypoint::Type::POWERPLANT:
+    return _("Power Plant");
+  case Waypoint::Type::VOR:
+    return _("VOR");
+  case Waypoint::Type::NDB:
+    return _("NDB");
+  case Waypoint::Type::DAM:
+    return _("Dam");
+  case Waypoint::Type::CASTLE:
+    return _("Castle");
+  case Waypoint::Type::INTERSECTION:
+    return _("Intersection");
+  case Waypoint::Type::MARKER:
+    return _("Marker");
+  case Waypoint::Type::REPORTING_POINT:
+    return _("Control Point");
+  case Waypoint::Type::PGTAKEOFF:
+    return _("PG Take Off");
+  case Waypoint::Type::PGLANDING:
+    return _("PG Landing Zone");
+  case Waypoint::Type::THERMAL_HOTSPOT:
+  case Waypoint::Type::COUNT:
+    break;
+  }
+
+  return _("Unknown");
+}
+
+class WaypointFilterListWidget : public ListWidget {
+  bool changed;
+  TextRowRenderer row_renderer;
+
+public:
+  WaypointFilterListWidget() noexcept
+    :changed(false) {}
+
+  bool IsModified() const noexcept {
+    return changed;
+  }
+
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override {
+    const auto &look = UIGlobals::GetDialogLook();
+    ListControl &list = CreateList(parent, look, rc,
+                                   row_renderer.CalculateLayout(*look.list.font));
+    list.SetLength(FILTER_ROW_COUNT);
+  }
+
+  void OnPaintItem(Canvas &canvas, const PixelRect rc,
+                   unsigned idx) noexcept override;
+
+  bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept override {
+    return true;
+  }
+
+  void OnActivateItem(unsigned index) noexcept override;
+};
+
+void
+WaypointFilterListWidget::OnPaintItem(Canvas &canvas, PixelRect rc,
+                                      unsigned i) noexcept
+{
+  assert(i < FILTER_ROW_COUNT);
+  const WaypointRendererSettings &settings =
+    CommonInterface::GetMapSettings().waypoint;
+
+  const bool display = i == NON_ICAO_AIRPORTS_ROW
+    ? settings.display_non_icao_airports
+    : settings.IsTypeDisplayed(FILTER_TYPES[i]);
+
+  rc.right = display
+    ? row_renderer.DrawRightColumn(canvas, rc, _("Display"))
+    : row_renderer.PreviousRightColumn(canvas, rc, _("Display"));
+
+  const char *name = i == NON_ICAO_AIRPORTS_ROW
+    ? _("Non-ICAO airports")
+    : GetFilterTypeName(FILTER_TYPES[i]);
+  row_renderer.DrawTextRow(canvas, rc, name);
+}
+
+void
+WaypointFilterListWidget::OnActivateItem(unsigned index) noexcept
+{
+  assert(index < FILTER_ROW_COUNT);
+
+  WaypointRendererSettings &settings =
+    CommonInterface::SetMapSettings().waypoint;
+
+  if (index == NON_ICAO_AIRPORTS_ROW)
+    settings.SaveNonIcaoAirportsDisplay(!settings.display_non_icao_airports);
+  else {
+    const Waypoint::Type type = FILTER_TYPES[index];
+    settings.SaveTypeDisplay(type, !settings.IsTypeDisplayed(type));
+  }
+
+  changed = true;
+  ActionInterface::SendMapSettings();
+  GetList().Invalidate();
+}
+
+void
+dlgWaypointFilterShowModal() noexcept
+{
+  TWidgetDialog<WaypointFilterListWidget>
+    dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+           UIGlobals::GetDialogLook(),
+           _("Waypoints"));
+  dialog.AddButton(_("Close"), mrOK);
+  dialog.SetWidget();
+
+  dialog.ShowModal();
+
+  if (dialog.GetWidget().IsModified())
+    Profile::Save();
+}

--- a/src/Engine/Waypoint/Waypoint.hpp
+++ b/src/Engine/Waypoint/Waypoint.hpp
@@ -45,7 +45,13 @@ struct Waypoint {
     INTERSECTION,
     REPORTING_POINT,
     PGTAKEOFF,
-    PGLANDING
+    PGLANDING,
+
+    /**
+     * Number of #Type values (for display-filter arrays).  Not a
+     * real waypoint type.
+     */
+    COUNT
   };
 
   /**

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -32,6 +32,8 @@ constexpr std::string_view DisplayText = "DisplayText";
 constexpr std::string_view WaypointArrivalHeightDisplay = "WaypointArrivalHeightDisplay";
 constexpr std::string_view WaypointLabelSelection = "WayPointLabelSelection";
 constexpr std::string_view WaypointLabelStyle = "WayPointLabelStyle";
+constexpr std::string_view WaypointDisplayNonIcaoAirports =
+  "WaypointDisplayNonIcaoAirports";
 constexpr std::string_view WeatherStations = "WeatherStations";
 constexpr std::string_view DisplayUpValue = "DisplayUp";
 constexpr std::string_view OrientationCruise = "OrientationCruise";

--- a/src/Renderer/WaypointIconRenderer.cpp
+++ b/src/Renderer/WaypointIconRenderer.cpp
@@ -67,13 +67,16 @@ GetWaypointIcon(const WaypointLook &look, const Waypoint &wp,
     return look.pgtakeoff_icon;
   case Waypoint::Type::PGLANDING:
     return look.pglanding_icon;
-  default:
-    if (in_task) {
-      return look.task_turn_point_icon;
-    } else {
-      return look.turn_point_icon;
-    }
+  case Waypoint::Type::NORMAL:
+  case Waypoint::Type::AIRFIELD:
+  case Waypoint::Type::OUTLANDING:
+  case Waypoint::Type::COUNT:
+    break;
   }
+
+  if (in_task)
+    return look.task_turn_point_icon;
+  return look.turn_point_icon;
 }
 
 static void

--- a/src/Renderer/WaypointRenderer.cpp
+++ b/src/Renderer/WaypointRenderer.cpp
@@ -414,6 +414,11 @@ protected:
     if (waypoints.full())
       return;
 
+    const bool watched = way_point->flags.watched;
+    if (!in_task && !watched &&
+        !settings.IsWaypointDisplayed(*way_point))
+      return;
+
     if (!projection.WaypointInScaleFilter(*way_point) && !in_task)
       return;
 

--- a/src/Renderer/WaypointRendererSettings.cpp
+++ b/src/Renderer/WaypointRendererSettings.cpp
@@ -3,6 +3,19 @@
 
 #include "WaypointRendererSettings.hpp"
 #include "Profile/Profile.hpp"
+#include "util/StringFormat.hpp"
+
+#include <cassert>
+
+static const char *
+MakeWaypointTypeDisplayName(char *buffer, size_t size, unsigned i) noexcept
+{
+  const int written = StringFormat(buffer, size, "WaypointTypeDisplay%u", i);
+  assert(written > 0 && size_t(written) < size);
+  if (written <= 0 || size_t(written) >= size)
+    buffer[0] = '\0';
+  return buffer;
+}
 
 void
 WaypointRendererSettings::LoadFromProfile() noexcept
@@ -33,4 +46,48 @@ WaypointRendererSettings::LoadFromProfile() noexcept
   Get(ProfileKeys::AppScaleRunwayLength, scale_runway_length);
   Get(ProfileKeys::AppLandableRenderingScale, landable_rendering_scale);
   Get(ProfileKeys::MapWaypointIconScale, map_waypoint_icon_scale);
+
+  for (unsigned i = 0; i < unsigned(Waypoint::Type::COUNT); ++i) {
+    char name[64];
+    MakeWaypointTypeDisplayName(name, sizeof(name), i);
+    Get(name, display_types[i]);
+  }
+
+  Get(ProfileKeys::WaypointDisplayNonIcaoAirports,
+      display_non_icao_airports);
+}
+
+bool
+WaypointRendererSettings::IsWaypointDisplayed(const Waypoint &waypoint) const noexcept
+{
+  if (!IsTypeDisplayed(waypoint.type))
+    return false;
+
+  if (!display_non_icao_airports && waypoint.IsAirport() &&
+      waypoint.shortname.length() != 4)
+    return false;
+
+  return true;
+}
+
+void
+WaypointRendererSettings::SaveTypeDisplay(Waypoint::Type type,
+                                          bool display) noexcept
+{
+  const unsigned type_index = unsigned(type);
+  if (type_index >= unsigned(Waypoint::Type::COUNT))
+    return;
+
+  display_types[type_index] = display;
+
+  char name[64];
+  MakeWaypointTypeDisplayName(name, sizeof(name), type_index);
+  Profile::Set(name, display);
+}
+
+void
+WaypointRendererSettings::SaveNonIcaoAirportsDisplay(bool display) noexcept
+{
+  display_non_icao_airports = display;
+  Profile::Set(ProfileKeys::WaypointDisplayNonIcaoAirports, display);
 }

--- a/src/Renderer/WaypointRendererSettings.hpp
+++ b/src/Renderer/WaypointRendererSettings.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "LabelShape.hpp"
+#include "Engine/Waypoint/Waypoint.hpp"
 
 #include <cstdint>
 
@@ -61,6 +62,29 @@ struct WaypointRendererSettings {
    */
   int map_waypoint_icon_scale;
 
+  /**
+   * Per-type map display filter (SeeYou / OpenAIP CUP styles).
+   * Indexed by #Waypoint::Type.  Task and watched waypoints are
+   * always drawn regardless of this filter.
+   */
+  bool display_types[unsigned(Waypoint::Type::COUNT)];
+
+  /**
+   * When false, hide airports whose short name is not exactly four
+   * characters (typical ICAO code length).  Task and watched
+   * waypoints are always drawn.
+   */
+  bool display_non_icao_airports;
+
+  [[gnu::pure]]
+  bool IsTypeDisplayed(Waypoint::Type type) const noexcept {
+    const unsigned i = unsigned(type);
+    return i >= unsigned(Waypoint::Type::COUNT) || display_types[i];
+  }
+
+  [[gnu::pure]]
+  bool IsWaypointDisplayed(const Waypoint &waypoint) const noexcept;
+
   void SetDefaults() noexcept {
     display_text_type = DisplayTextType::SHORT_NAME;
     arrival_height_display = ArrivalHeightDisplay::GLIDE;
@@ -72,7 +96,17 @@ struct WaypointRendererSettings {
     scale_runway_length = false;
     landable_rendering_scale = 100;
     map_waypoint_icon_scale = 100;
+
+    for (bool &display : display_types)
+      display = true;
+
+    display_non_icao_airports = true;
   }
 
   void LoadFromProfile() noexcept;
+
+  /** Persist one type's display flag to the profile. */
+  void SaveTypeDisplay(Waypoint::Type type, bool display) noexcept;
+
+  void SaveNonIcaoAirportsDisplay(bool display) noexcept;
 };

--- a/src/Waypoint/CupWriter.cpp
+++ b/src/Waypoint/CupWriter.cpp
@@ -109,6 +109,7 @@ GetSeeYouFlags(const Waypoint &wp) noexcept
     return "21"sv;
 
   case Waypoint::Type::THERMAL_HOTSPOT:
+  case Waypoint::Type::COUNT:
     break;
   }
 


### PR DESCRIPTION
## Summary
- Add a **Filter** button on Config → Map Display → Waypoints to choose which SeeYou CUP waypoint types are drawn on the map.
- Task and watched waypoints stay visible regardless of the filter.
- Include a **Non-ICAO airports** toggle (hide airports whose short name is not four characters).

## Test plan
- Open Config → Map Display → Waypoints and use the Filter button
- Toggle a few types off and confirm they disappear from the map
- Confirm task and watched waypoints still show when their type is filtered off
- Toggle Non-ICAO airports and confirm airports without a 4-character short name hide/show
- Restart the app and confirm filter settings persist

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge

