### PR TITLE
Renderer/WindArrow: Draw dual arrows for instantaneous external wind

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -30,6 +30,8 @@ Version 7.46 - not yet released
   - fix choosing SkySight as a page overlay with no layers available
     silently switching back to None
 * map
+  - draw dual wind arrows when instantaneous external wind is
+    available (average grey, instantaneous blue; e.g. Larus ``I``)
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box
@@ -46,6 +48,8 @@ Version 7.46 - not yet released
   - skip estimated TAS from ground speed and wind when GPS track is
     missing
 * devices
+  - accept Larus ``$PLARW`` instantaneous wind (``I``) in addition to
+    average (``A``)
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log

--- a/src/Device/Driver/Larus.cpp
+++ b/src/Device/Driver/Larus.cpp
@@ -303,8 +303,10 @@ LarusDevice::PLARW(NMEAInputLine &line, NMEAInfo &info)
   case 'A':
     info.ProvideExternalWind(wind);
     break;
+  case 'I':
+    info.ProvideExternalInstantaneousWind(wind);
+    break;
   default:
-    // xcsoar does not support instantaneous wind
     return false;
   }
 

--- a/src/InfoBoxes/Content/Weather.cpp
+++ b/src/InfoBoxes/Content/Weather.cpp
@@ -227,5 +227,6 @@ InfoBoxContentWindArrow::OnCustomPaint(Canvas &canvas,
   WindArrowRenderer renderer(UIGlobals::GetLook().wind_arrow_info_box);
   renderer.DrawArrow(canvas, radar_renderer.GetCenter(), angle,
                      arrow_width, length, arrow_tail_length,
-                     style, offset, scale);
+                     style, offset, scale,
+                     UIGlobals::GetLook().wind_arrow_info_box.arrow_brush);
 }

--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -85,4 +85,8 @@ static constexpr Color COLOR_XCTHERM_RED_ORANGE = Color(0xff, 0x40, 0x00);
 static constexpr Color COLOR_XCTHERM_RED = Color(0xff, 0x00, 0x00);
 static constexpr Color COLOR_XCTHERM_PURPLE = Color(0xa0, 0x20, 0xf0);
 
+/** Instantaneous external wind arrow (map overlay). */
+static constexpr Color COLOR_WIND_ARROW_INSTANTANEOUS =
+  Color(0x80, 0x80, 0xff);
+
 static constexpr uint8_t ALPHA_OVERLAY = 0xA0;

--- a/src/Look/WindArrowLook.cpp
+++ b/src/Look/WindArrowLook.cpp
@@ -13,8 +13,15 @@ WindArrowLook::Initialise(const Font &_font, bool inverse)
                    inverse
                    ? (HasColors() ? LightColor(COLOR_GRAY) : COLOR_WHITE)
                    : (HasColors() ? DarkColor(COLOR_GRAY) : COLOR_BLACK));
-  shaft_pen.Create(Pen::DASH2, Layout::ScalePenWidth(1), inverse ? COLOR_WHITE : COLOR_BLACK);
-  arrow_brush.Create(IsDithered() ? COLOR_DARK_GRAY : ColorWithAlpha(COLOR_GRAY, ALPHA_OVERLAY));
-  
+  shaft_pen.Create(Pen::DASH2, Layout::ScalePenWidth(1),
+                   inverse ? COLOR_WHITE : COLOR_BLACK);
+  arrow_brush.Create(IsDithered()
+                     ? COLOR_DARK_GRAY
+                     : ColorWithAlpha(COLOR_GRAY, ALPHA_OVERLAY));
+  arrow_brush_instantaneous.Create(
+      IsDithered()
+      ? COLOR_WIND_ARROW_INSTANTANEOUS
+      : ColorWithAlpha(COLOR_WIND_ARROW_INSTANTANEOUS, ALPHA_OVERLAY));
+
   font = &_font;
 }

--- a/src/Look/WindArrowLook.hpp
+++ b/src/Look/WindArrowLook.hpp
@@ -11,7 +11,10 @@ class Font;
 struct WindArrowLook
 {
   Pen arrow_pen, shaft_pen;
+  /** Average / calculated wind (grey). */
   Brush arrow_brush;
+  /** Instantaneous external wind (blue). */
+  Brush arrow_brush_instantaneous;
 
   const Font *font;
 

--- a/src/MapWindow/MapWindowSymbols.cpp
+++ b/src/MapWindow/MapWindowSymbols.cpp
@@ -20,7 +20,8 @@ MapWindow::DrawWind(Canvas &canvas, const PixelPoint &Start,
 
   WindArrowRenderer wind_arrow_renderer(look.wind);
   wind_arrow_renderer.Draw(canvas, render_projection.GetScreenAngle(),
-                           Start, rc, Calculated(), GetMapSettings());
+                           Start, rc, Calculated(), Basic(),
+                           GetMapSettings());
 }
 
 void

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -139,6 +139,7 @@ NMEAInfo::Reset() noexcept
   settings.Clear();
 
   external_wind_available.Clear();
+  external_instantaneous_wind_available.Clear();
 
   temperature_available.Clear();
   humidity_available.Clear();
@@ -223,6 +224,8 @@ NMEAInfo::Expire() noexcept
   netto_vario_available.Expire(clock, std::chrono::seconds(5));
   settings.Expire(clock);
   external_wind_available.Expire(clock, std::chrono::minutes(10));
+  external_instantaneous_wind_available.Expire(clock,
+                                               std::chrono::seconds(10));
   heart_rate_available.Expire(clock, std::chrono::seconds(10));
   temperature_available.Expire(clock, std::chrono::seconds(30));
   humidity_available.Expire(clock, std::chrono::seconds(30));
@@ -319,6 +322,10 @@ NMEAInfo::Complement(const NMEAInfo &add) noexcept
 
   if (external_wind_available.Complement(add.external_wind_available))
     external_wind = add.external_wind;
+
+  if (external_instantaneous_wind_available.Complement(
+          add.external_instantaneous_wind_available))
+    external_instantaneous_wind = add.external_instantaneous_wind;
 
   if (temperature_available.Complement(add.temperature_available))
     temperature = add.temperature;

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -269,17 +269,29 @@ struct NMEAInfo {
   //################
 
   /**
-   * Is external wind information available?
+   * Is external average wind information available?
    * @see ExternalWindSpeed
    * @see ExternalWindDirection
    */
   Validity external_wind_available;
 
   /**
-   * The wind read from the device.  If ExternalWindAvailable is
-   * false, then this value is undefined.
+   * The average wind read from the device.  If ExternalWindAvailable
+   * is false, then this value is undefined.
    */
   SpeedVector external_wind;
+
+  /**
+   * Is external instantaneous wind information available?
+   */
+  Validity external_instantaneous_wind_available;
+
+  /**
+   * The instantaneous wind read from the device.  If
+   * ExternalInstantaneousWindAvailable is false, then this value is
+   * undefined.
+   */
+  SpeedVector external_instantaneous_wind;
 
   /**
    * Is temperature information available?
@@ -604,11 +616,20 @@ struct NMEAInfo {
   }
 
   /**
-   * Set the external wind value.
+   * Set the external average wind value.
    */
   constexpr void ProvideExternalWind(const SpeedVector &value) noexcept {
     external_wind = value;
     external_wind_available.Update(clock);
+  }
+
+  /**
+   * Set the external instantaneous wind value.
+   */
+  constexpr void
+  ProvideExternalInstantaneousWind(const SpeedVector &value) noexcept {
+    external_instantaneous_wind = value;
+    external_instantaneous_wind_available.Update(clock);
   }
 
   /**

--- a/src/Renderer/WindArrowRenderer.cpp
+++ b/src/Renderer/WindArrowRenderer.cpp
@@ -11,6 +11,7 @@
 #include "Math/Util.hpp"
 #include "Math/Screen.hpp"
 #include "NMEA/Derived.hpp"
+#include "NMEA/MoreData.hpp"
 #include "Units/Units.hpp"
 #include "util/Macros.hpp"
 #include "MapSettings.hpp"
@@ -25,7 +26,8 @@ WindArrowRenderer::DrawArrow(Canvas &canvas, PixelPoint pos, Angle angle,
                              unsigned tail_length,
                              WindArrowStyle arrow_style,
                              int offset,
-                             unsigned scale) noexcept
+                             unsigned scale,
+                             const Brush &brush) noexcept
 {
   // Draw arrow
 
@@ -40,7 +42,7 @@ WindArrowRenderer::DrawArrow(Canvas &canvas, PixelPoint pos, Angle angle,
   PolygonRotateShift({arrow, ARRAY_SIZE(arrow)}, pos, angle, scale);
 
   canvas.Select(look.arrow_pen);
-  canvas.Select(look.arrow_brush);
+  canvas.Select(brush);
   {
 #ifdef ENABLE_OPENGL
     const ScopeAlphaBlend alpha_blend;
@@ -67,7 +69,8 @@ void
 WindArrowRenderer::Draw(Canvas &canvas, const Angle screen_angle,
                         const SpeedVector wind, const PixelPoint pos,
                         const PixelRect &rc,
-                        WindArrowStyle arrow_style) noexcept
+                        WindArrowStyle arrow_style,
+                        const Brush &brush) noexcept
 {
   constexpr unsigned arrow_width = 6;
   constexpr unsigned arrow_tail_length = 3;
@@ -83,7 +86,7 @@ WindArrowRenderer::Draw(Canvas &canvas, const Angle screen_angle,
             arrow_width, length, arrow_tail_length,
             arrow_style,
             arrow_offset,
-            scale);
+            scale, brush);
 
   // Draw wind speed label
 
@@ -109,17 +112,22 @@ WindArrowRenderer::Draw(Canvas &canvas, const Angle screen_angle,
 void
 WindArrowRenderer::Draw(Canvas &canvas, const Angle screen_angle,
                         const PixelPoint pos, const PixelRect &rc,
-                        const DerivedInfo &calculated,
+                        const DerivedInfo &calculated, const MoreData &basic,
                         const MapSettings &settings) noexcept
 {
-  if (!calculated.wind_available ||
-      settings.wind_arrow_style == WindArrowStyle::NO_ARROW)
+  if (settings.wind_arrow_style == WindArrowStyle::NO_ARROW)
     return;
 
-  // don't bother drawing it if not significant
-  if (calculated.wind.norm < 1)
-    return;
+  // Average / calculated wind (grey)
+  if (calculated.wind_available && calculated.wind.norm >= 1)
+    WindArrowRenderer::Draw(canvas, screen_angle, calculated.wind, pos, rc,
+                            settings.wind_arrow_style, look.arrow_brush);
 
-  WindArrowRenderer::Draw(canvas, screen_angle, calculated.wind, pos, rc,
-                          settings.wind_arrow_style);
+  // Instantaneous external wind (blue)
+  if (basic.external_instantaneous_wind_available &&
+      basic.external_instantaneous_wind.norm >= 1)
+    WindArrowRenderer::Draw(canvas, screen_angle,
+                            basic.external_instantaneous_wind, pos, rc,
+                            settings.wind_arrow_style,
+                            look.arrow_brush_instantaneous);
 }

--- a/src/Renderer/WindArrowRenderer.hpp
+++ b/src/Renderer/WindArrowRenderer.hpp
@@ -7,12 +7,14 @@
 
 class Canvas;
 class Angle;
+class Brush;
 struct PixelPoint;
 struct PixelRect;
 struct WindArrowLook;
 struct SpeedVector;
 struct DerivedInfo;
 struct MapSettings;
+struct MoreData;
 enum class WindArrowStyle : uint8_t;
 
 class WindArrowRenderer {
@@ -23,15 +25,16 @@ public:
     :look(_look) {}
 
   void Draw(Canvas &canvas, Angle screen_angle, SpeedVector wind,
-            PixelPoint pos, const PixelRect &rc, WindArrowStyle arrow_style) noexcept;
+            PixelPoint pos, const PixelRect &rc, WindArrowStyle arrow_style,
+            const Brush &brush) noexcept;
 
   void Draw(Canvas &canvas, Angle screen_angle, PixelPoint pos,
             const PixelRect &rc, const DerivedInfo &calculated,
-            const MapSettings &settings) noexcept;
+            const MoreData &basic, const MapSettings &settings) noexcept;
 
   void DrawArrow(Canvas &canvas, PixelPoint pos, Angle angle,
                  unsigned width, unsigned length, unsigned tail_length,
                  WindArrowStyle arrow_style,
-                 int offset,
-                 unsigned scale) noexcept;
+                 int offset, unsigned scale,
+                 const Brush &brush) noexcept;
 };

--- a/test/src/RunWindArrowRenderer.cpp
+++ b/test/src/RunWindArrowRenderer.cpp
@@ -14,12 +14,13 @@
 
 class WindWindow : public PaintWindow
 {
+  const WindArrowLook &look;
   WindArrowRenderer renderer;
   SpeedVector wind;
 
 public:
-  WindWindow(const WindArrowLook &look)
-    :renderer(look), wind(10, 0) {}
+  WindWindow(const WindArrowLook &_look)
+    :look(_look), renderer(_look), wind(10, 0) {}
 
   SpeedVector GetWind() const {
     return wind;
@@ -41,7 +42,8 @@ protected:
     canvas.SelectHollowBrush();
     canvas.DrawCircle(pt, 2);
 
-    renderer.Draw(canvas, Angle::Zero(), wind, pt, rc, WindArrowStyle::ARROW_HEAD);
+    renderer.Draw(canvas, Angle::Zero(), wind, pt, rc,
+                  WindArrowStyle::ARROW_HEAD, look.arrow_brush);
   }
 };
 

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -1236,6 +1236,12 @@ TestLarus()
   ok1(equals(nmea_info.external_wind.bearing, 73.0));
   ok1(equals(nmea_info.external_wind.norm, Units::ToSysUnit(23, Unit::KILOMETER_PER_HOUR)));
 
+  ok1(device->ParseNMEA("$PLARW,80,15,I,A*5C", nmea_info));
+  ok1(nmea_info.external_instantaneous_wind_available);
+  ok1(equals(nmea_info.external_instantaneous_wind.bearing, 80.0));
+  ok1(equals(nmea_info.external_instantaneous_wind.norm,
+             Units::ToSysUnit(15, Unit::KILOMETER_PER_HOUR)));
+
   // $PLARS water ballast, bugs, mc, qnh, cir
   ok1(device->ParseNMEA("$PLARS,L,BAL,0.331*5C", nmea_info));
   ok1(nmea_info.settings.ballast_fraction_available);


### PR DESCRIPTION
## Summary
- Store instantaneous external wind on `NMEAInfo` and accept Larus `$PLARW` type `I` (in addition to average `A`).
- When instantaneous wind is available, draw dual map wind arrows: average in grey and instantaneous in blue.

## Test plan
- With a Larus (or replay/`TestDriver` `$PLARW,...,I,...`): confirm both arrows appear on the map
- Average-only wind (`A`): single arrow behaviour unchanged
- InfoBox / weather wind display still uses average external wind as before
- `TestDriver` Larus instantaneous wind checks pass

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge

