### PR TITLE
Weather/xctherm: Reduce GeoJSON overlay flicker

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,11 @@ Version 7.46 - not yet released
 * weather
   - show the overlay name as XC Therm (with a space) in setup, weather
     dialogs, map titles, and download messages
+  - clean XCTherm GeoJSON on import: drop holes, split self-crossing
+    contours, drop degenerate rings, decompose concave polygons into
+    convex pieces, and draw weaker |climb| bands before stronger ones
+  - draw XCTherm polygons with float screen coordinates (no integer
+    snap before triangulation) to reduce zoom flicker
   - fix the weather cursor bar keeping light colours in dark mode,
     and unreadable labels on Windows
   - fix SkySight re-downloading forecast metadata when stepping

--- a/build/main.mk
+++ b/build/main.mk
@@ -740,6 +740,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Weather/xctherm/XCThermDownload.cpp \
 	$(SRC)/Weather/xctherm/XCThermDownloadGlue.cpp \
 	$(SRC)/Weather/xctherm/XCThermGeoJSON.cpp \
+	$(SRC)/Weather/xctherm/XCThermGeoJSONCleanup.cpp \
 	$(SRC)/Weather/xctherm/XCThermGeoQuery.cpp \
 	$(SRC)/Weather/xctherm/XCThermGeoJSONOverlay.cpp \
 	$(SRC)/Weather/xctherm/XCThermMapOverlay.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -955,6 +955,7 @@ $(eval $(call link-program,TestColorRamp,TEST_COLOR_RAMP))
 TEST_XCTHERM_BAND_QUERY_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \
 	$(SRC)/Weather/xctherm/XCThermGeoQuery.cpp \
+	$(SRC)/Weather/xctherm/XCThermGeoJSONCleanup.cpp \
 	$(TEST_SRC_DIR)/TestXCThermBandQuery.cpp
 TEST_XCTHERM_BAND_QUERY_DEPENDS = GEO MATH
 $(eval $(call link-program,TestXCThermBandQuery,TEST_XCTHERM_BAND_QUERY))

--- a/src/Projection/Projection.cpp
+++ b/src/Projection/Projection.cpp
@@ -53,6 +53,30 @@ Projection::GeoToScreen(const GeoPoint &g) const noexcept
   return sc;
 }
 
+FloatPoint2D
+Projection::GeoToScreenF(const GeoPoint &g,
+                         const FastRotation &rotation) const noexcept
+{
+  assert(IsValid());
+
+  const GeoPoint d = geo_location - g;
+  const auto p = rotation.Rotate(DoublePoint2D{
+    g.latitude.fastcosine() * AngleToPixels(d.longitude),
+    AngleToPixels(d.latitude),
+  });
+
+  return {
+    float(screen_origin.x - p.x),
+    float(screen_origin.y + p.y),
+  };
+}
+
+FloatPoint2D
+Projection::GeoToScreenF(const GeoPoint &g) const noexcept
+{
+  return GeoToScreenF(g, FastRotation{screen_angle});
+}
+
 void
 Projection::SetScale(const double _scale) noexcept
 {

--- a/src/Projection/Projection.hpp
+++ b/src/Projection/Projection.hpp
@@ -5,6 +5,7 @@
 
 #include "Geo/GeoPoint.hpp"
 #include "Math/FastRotation.hpp"
+#include "Math/Point2D.hpp"
 #include "Math/Util.hpp"
 #include "ui/dim/Point.hpp"
 
@@ -118,6 +119,21 @@ public:
    */
   [[gnu::pure]]
   PixelPoint GeoToScreen(const GeoPoint &g) const noexcept;
+
+  /**
+   * Same as #GeoToScreen, but keeps sub-pixel precision (no integer
+   * truncation).  Prefer this when triangulating dense polygons.
+   */
+  [[gnu::pure]]
+  FloatPoint2D GeoToScreenF(const GeoPoint &g) const noexcept;
+
+  /**
+   * Like #GeoToScreenF with a caller-provided rotation (avoids
+   * rebuilding #FastRotation per vertex).
+   */
+  [[gnu::pure]]
+  FloatPoint2D GeoToScreenF(const GeoPoint &g,
+                            const FastRotation &rotation) const noexcept;
 
   /**
    * Returns the origin/rotation center in screen coordinates

--- a/src/Weather/xctherm/XCThermGeoJSON.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSON.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "XCThermGeoJSON.hpp"
+#include "XCThermGeoJSONCleanup.hpp"
 
 #include <boost/json.hpp>
 
@@ -81,6 +82,35 @@ ParseMultiPolygonCoords(const boost::json::array &arr,
 }
 
 /**
+ * Parse geometry.coordinates for either Polygon or MultiPolygon.
+ * Polygon coordinates are [ring, …]; MultiPolygon are [[ring, …], …].
+ */
+static void
+ParseGeometryCoordinates(const boost::json::object &geom,
+                         std::vector<std::vector<Ring>> &polygons)
+{
+  auto it_coords = geom.find("coordinates");
+  if (it_coords == geom.end() || !it_coords->value().is_array())
+    return;
+
+  const auto &coords = it_coords->value().as_array();
+  std::string_view type;
+  if (auto it_type = geom.find("type");
+      it_type != geom.end() && it_type->value().is_string())
+    type = it_type->value().as_string();
+
+  if (type == "Polygon") {
+    std::vector<Ring> polygon;
+    ParsePolygon(coords, polygon);
+    if (!polygon.empty())
+      polygons.push_back(std::move(polygon));
+  } else {
+    /* MultiPolygon (default) and unknown types with MultiPolygon shape. */
+    ParseMultiPolygonCoords(coords, polygons);
+  }
+}
+
+/**
  * Parse one Feature (one line of the GeoJSON stream).
  *
  * Expected shape:
@@ -115,18 +145,14 @@ ParseFeature(std::string_view line, WindBand &band) noexcept
     band.min_ms = it_min->value().to_number<double>();
     band.max_ms = it_max->value().to_number<double>();
 
-    /* geometry.coordinates */
+    /* geometry.coordinates — Polygon or MultiPolygon */
     auto it_geom = feature.find("geometry");
     if (it_geom == feature.end() || !it_geom->value().is_object())
       return false;
     const auto &geom = it_geom->value().as_object();
 
-    auto it_coords = geom.find("coordinates");
-    if (it_coords == geom.end() || !it_coords->value().is_array())
-      return false;
-
-    ParseMultiPolygonCoords(it_coords->value().as_array(), band.polygons);
-    return true;
+    ParseGeometryCoordinates(geom, band.polygons);
+    return !band.polygons.empty();
   } catch (const std::exception &) {
     /* Malformed line — skip silently (server sometimes ends a tile
        with a partially-buffered Feature). */
@@ -155,18 +181,18 @@ Parse(std::string_view content, bool skip_neutral) noexcept
         const bool is_neutral =
           band.min_ms >= -0.2 && band.max_ms <= 0.2;
         if ((!skip_neutral || !is_neutral) && !band.polygons.empty()) {
-          /* Grow the layer's geographic extent over this band's
-             exterior rings, so callers can cheaply test coverage. */
-          for (const auto &polygon : band.polygons)
-            if (!polygon.empty())
-              for (const auto &pt : polygon[0])
-                layer.bounds.Extend(pt);
+          /* Drop holes, split self-crossings, drop degenerate junk. */
+          CleanBandPolygons(band);
+          if (!band.polygons.empty()) {
+            /* Grow the layer's geographic extent over this band's
+               exterior rings, so callers can cheaply test coverage. */
+            for (const auto &polygon : band.polygons)
+              if (!polygon.empty())
+                for (const auto &pt : polygon[0])
+                  layer.bounds.Extend(pt);
 
-          /* push_back can throw bad_alloc; the function is noexcept
-             on the .hpp, so we keep allocations modest by reserving
-             nothing extra and trust that std::terminate on OOM is
-             acceptable here (consistent with the rest of the file). */
-          layer.bands.push_back(std::move(band));
+            layer.bands.push_back(std::move(band));
+          }
         }
       }
     }
@@ -175,6 +201,9 @@ Parse(std::string_view content, bool skip_neutral) noexcept
       break;
     pos = eol + 1;
   }
+
+  /* Weaker |mid| first so opaque fill lets stronger bands win. */
+  SortBandsByAbsMid(layer);
 
   return layer;
 }

--- a/src/Weather/xctherm/XCThermGeoJSON.hpp
+++ b/src/Weather/xctherm/XCThermGeoJSON.hpp
@@ -27,8 +27,9 @@ struct WindBand {
   double max_ms;  // maximum vertical wind m/s
 
   /**
-   * Each polygon is a vector of rings.
-   * Ring 0 = exterior, rings 1..n = holes (rare in weather data).
+   * Each polygon is a vector of rings.  After Parse() cleanup only the
+   * exterior remains (ring 0); holes are dropped because the overlay
+   * does not draw them.
    */
   std::vector<std::vector<Ring>> polygons;
 
@@ -89,7 +90,14 @@ struct ForecastLayer {
  *
  * Each Feature must have:
  *   properties: { "min": <float>, "max": <float> }
- *   geometry: { "type": "MultiPolygon", "coordinates": [...] }
+ *   geometry: Polygon or MultiPolygon coordinates
+ *
+ * Post-import cleanup:
+ *   - drop holes (not drawn)
+ *   - split self-crossing exteriors
+ *   - drop degenerate / zero-area junk
+ *   - decompose concave exteriors into convex pieces
+ *   - sort bands by ascending |midpoint|
  *
  * @param content The full file content
  * @param skip_neutral If true, skip the band where

--- a/src/Weather/xctherm/XCThermGeoJSONCleanup.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONCleanup.cpp
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "XCThermGeoJSONCleanup.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+#include <utility>
+
+namespace XCThermGeoJSON {
+
+namespace {
+
+struct XY {
+  double x, y;
+};
+
+/** Near-zero area in lon/lat degrees² (degenerate / collapsed). */
+constexpr double AREA_EPS = 1e-18;
+
+/** Vertex equality in lon/lat degrees. */
+constexpr double VERTEX_EPS = 1e-12;
+
+/** Treat nearly collinear turns as non-left (reflex/flat). */
+constexpr double TURN_EPS = 1e-18;
+
+[[gnu::const]]
+static bool
+Near(XY a, XY b) noexcept
+{
+  return std::fabs(a.x - b.x) <= VERTEX_EPS &&
+    std::fabs(a.y - b.y) <= VERTEX_EPS;
+}
+
+[[gnu::pure]]
+static XY
+ToXY(const GeoPoint &p) noexcept
+{
+  return {p.longitude.Degrees(), p.latitude.Degrees()};
+}
+
+[[gnu::pure]]
+static GeoPoint
+ToGeo(XY p) noexcept
+{
+  return GeoPoint(Angle::Degrees(p.x), Angle::Degrees(p.y));
+}
+
+static void
+StripClosingDuplicate(std::vector<XY> &pts) noexcept
+{
+  if (pts.size() >= 2 && Near(pts.front(), pts.back()))
+    pts.pop_back();
+}
+
+static void
+RemoveConsecutiveDuplicates(std::vector<XY> &pts) noexcept
+{
+  if (pts.empty())
+    return;
+
+  std::size_t w = 1;
+  for (std::size_t r = 1; r < pts.size(); ++r) {
+    if (!Near(pts[r], pts[w - 1]))
+      pts[w++] = pts[r];
+  }
+  pts.resize(w);
+}
+
+[[gnu::pure]]
+static double
+SignedShoelace(const std::vector<XY> &pts) noexcept
+{
+  const std::size_t n = pts.size();
+  if (n < 3)
+    return 0;
+
+  double sum = 0;
+  for (std::size_t i = 0; i < n; ++i) {
+    const XY a = pts[i];
+    const XY b = pts[(i + 1) % n];
+    sum += a.x * b.y - b.x * a.y;
+  }
+  return 0.5 * sum;
+}
+
+[[gnu::pure]]
+static double
+AbsShoelace(const std::vector<XY> &pts) noexcept
+{
+  return std::fabs(SignedShoelace(pts));
+}
+
+/** Cross product (b-a)×(c-a); positive = left turn. */
+[[gnu::const]]
+static double
+Cross(XY a, XY b, XY c) noexcept
+{
+  return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+}
+
+static void
+EnsureCCW(std::vector<XY> &pts) noexcept
+{
+  if (SignedShoelace(pts) < 0)
+    std::reverse(pts.begin(), pts.end());
+}
+
+/**
+ * Proper intersection of open segments AB and CD (shared endpoints do
+ * not count). Returns the intersection point when segments cross.
+ */
+[[gnu::pure]]
+static std::optional<XY>
+ProperIntersection(XY a, XY b, XY c, XY d) noexcept
+{
+  const double rx = b.x - a.x;
+  const double ry = b.y - a.y;
+  const double sx = d.x - c.x;
+  const double sy = d.y - c.y;
+  const double den = rx * sy - ry * sx;
+  if (std::fabs(den) <= VERTEX_EPS)
+    return std::nullopt; /* parallel / collinear */
+
+  const double qx = c.x - a.x;
+  const double qy = c.y - a.y;
+  const double t = (qx * sy - qy * sx) / den;
+  const double u = (qx * ry - qy * rx) / den;
+
+  /* Strictly between endpoints — excludes shared vertices. */
+  constexpr double lo = 1e-9;
+  constexpr double hi = 1.0 - 1e-9;
+  if (t <= lo || t >= hi || u <= lo || u >= hi)
+    return std::nullopt;
+
+  return XY{a.x + t * rx, a.y + t * ry};
+}
+
+struct Crossing {
+  std::size_t i; /* edge pts[i] → pts[i+1] */
+  std::size_t j; /* edge pts[j] → pts[j+1] */
+  XY point;
+};
+
+[[gnu::pure]]
+static std::optional<Crossing>
+FindFirstCrossing(const std::vector<XY> &pts) noexcept
+{
+  const std::size_t n = pts.size();
+  if (n < 4)
+    return std::nullopt;
+
+  for (std::size_t i = 0; i < n; ++i) {
+    const XY a = pts[i];
+    const XY b = pts[(i + 1) % n];
+    for (std::size_t j = i + 1; j < n; ++j) {
+      /* Skip adjacent edges and the wrap-around adjacent pair. */
+      if (j == i || j == (i + 1) % n || i == (j + 1) % n)
+        continue;
+      if (i == 0 && j == n - 1)
+        continue;
+
+      if (auto hit = ProperIntersection(a, b, pts[j],
+                                        pts[(j + 1) % n])) {
+        Crossing c;
+        c.i = i;
+        c.j = j;
+        c.point = *hit;
+        return c;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+/**
+ * Split a ring at one proper edge crossing into two open rings
+ * (no repeated closing vertex).
+ */
+static std::pair<std::vector<XY>, std::vector<XY>>
+SplitAtCrossing(const std::vector<XY> &pts, Crossing c) noexcept
+{
+  const std::size_t n = pts.size();
+  std::vector<XY> a, b;
+  a.reserve(n);
+  b.reserve(n);
+
+  a.push_back(c.point);
+  for (std::size_t k = (c.i + 1) % n; k != (c.j + 1) % n;
+       k = (k + 1) % n)
+    a.push_back(pts[k]);
+
+  b.push_back(c.point);
+  for (std::size_t k = (c.j + 1) % n; k != (c.i + 1) % n;
+       k = (k + 1) % n)
+    b.push_back(pts[k]);
+
+  return {std::move(a), std::move(b)};
+}
+
+static Ring
+ToClosedRing(const std::vector<XY> &pts) noexcept
+{
+  Ring ring;
+  ring.reserve(pts.size() + 1);
+  for (const XY p : pts)
+    ring.push_back(ToGeo(p));
+  if (!ring.empty())
+    ring.push_back(ring.front());
+  return ring;
+}
+
+[[gnu::pure]]
+static bool
+IsConvexCCW(const std::vector<XY> &pts) noexcept
+{
+  const std::size_t n = pts.size();
+  if (n < 3)
+    return false;
+
+  for (std::size_t i = 0; i < n; ++i) {
+    const XY a = pts[(i + n - 1) % n];
+    const XY b = pts[i];
+    const XY c = pts[(i + 1) % n];
+    if (Cross(a, b, c) < -TURN_EPS)
+      return false;
+  }
+  return true;
+}
+
+[[gnu::pure]]
+static std::optional<std::size_t>
+FindReflex(const std::vector<XY> &pts) noexcept
+{
+  const std::size_t n = pts.size();
+  for (std::size_t i = 0; i < n; ++i) {
+    const XY a = pts[(i + n - 1) % n];
+    const XY b = pts[i];
+    const XY c = pts[(i + 1) % n];
+    if (Cross(a, b, c) < -TURN_EPS)
+      return i;
+  }
+  return std::nullopt;
+}
+
+/** Ray-cast point-in-polygon (lon/lat as plane). */
+[[gnu::pure]]
+static bool
+PointInRing(const std::vector<XY> &pts, XY p) noexcept
+{
+  bool inside = false;
+  const std::size_t n = pts.size();
+  for (std::size_t i = 0, j = n - 1; i < n; j = i++) {
+    const XY a = pts[i];
+    const XY b = pts[j];
+    if (((a.y > p.y) != (b.y > p.y)) &&
+        (p.x < (b.x - a.x) * (p.y - a.y) / (b.y - a.y) + a.x))
+      inside = !inside;
+  }
+  return inside;
+}
+
+[[gnu::pure]]
+static bool
+SegmentClear(const std::vector<XY> &pts,
+             std::size_t i, std::size_t j) noexcept
+{
+  const std::size_t n = pts.size();
+  const XY a = pts[i];
+  const XY b = pts[j];
+
+  for (std::size_t e = 0; e < n; ++e) {
+    const std::size_t f = (e + 1) % n;
+    /* Skip edges incident to i or j. */
+    if (e == i || f == i || e == j || f == j)
+      continue;
+    if (ProperIntersection(a, b, pts[e], pts[f]))
+      return false;
+  }
+  return true;
+}
+
+/**
+ * True if ij is an internal diagonal of a simple CCW ring.
+ */
+[[gnu::pure]]
+static bool
+DiagonalInside(const std::vector<XY> &pts,
+               std::size_t i, std::size_t j) noexcept
+{
+  const std::size_t n = pts.size();
+  if (n < 4)
+    return false;
+
+  const std::size_t d = (j + n - i) % n;
+  if (d <= 1 || d >= n - 1)
+    return false; /* adjacent */
+
+  if (!SegmentClear(pts, i, j))
+    return false;
+
+  const XY mid{
+    0.5 * (pts[i].x + pts[j].x),
+    0.5 * (pts[i].y + pts[j].y),
+  };
+  return PointInRing(pts, mid);
+}
+
+static std::pair<std::vector<XY>, std::vector<XY>>
+SplitAtDiagonal(const std::vector<XY> &pts,
+                std::size_t i, std::size_t j) noexcept
+{
+  const std::size_t n = pts.size();
+  if (i > j)
+    std::swap(i, j);
+
+  std::vector<XY> a, b;
+  a.reserve(j - i + 1);
+  b.reserve(n - (j - i) + 1);
+
+  for (std::size_t k = i; k <= j; ++k)
+    a.push_back(pts[k]);
+
+  for (std::size_t k = j; k < n; ++k)
+    b.push_back(pts[k]);
+  for (std::size_t k = 0; k <= i; ++k)
+    b.push_back(pts[k]);
+
+  return {std::move(a), std::move(b)};
+}
+
+/**
+ * Ear-clip into triangles when a diagonal split cannot be found.
+ * Each triangle is convex.
+ */
+static void
+TriangulateEars(std::vector<XY> pts,
+                std::vector<std::vector<XY>> &convex_out,
+                unsigned depth) noexcept
+{
+  if (depth > 64 || pts.size() < 3)
+    return;
+
+  RemoveConsecutiveDuplicates(pts);
+  StripClosingDuplicate(pts);
+  if (pts.size() < 3 || AbsShoelace(pts) <= AREA_EPS)
+    return;
+
+  EnsureCCW(pts);
+  if (pts.size() == 3) {
+    convex_out.push_back(std::move(pts));
+    return;
+  }
+
+  const std::size_t n = pts.size();
+  for (std::size_t i = 0; i < n; ++i) {
+    const std::size_t prev = (i + n - 1) % n;
+    const std::size_t next = (i + 1) % n;
+    if (Cross(pts[prev], pts[i], pts[next]) <= TURN_EPS)
+      continue; /* not a convex ear tip */
+    if (!DiagonalInside(pts, prev, next))
+      continue;
+
+    convex_out.push_back({pts[prev], pts[i], pts[next]});
+
+    std::vector<XY> rest;
+    rest.reserve(n - 1);
+    for (std::size_t k = 0; k < n; ++k)
+      if (k != i)
+        rest.push_back(pts[k]);
+    TriangulateEars(std::move(rest), convex_out, depth + 1);
+    return;
+  }
+
+  /* No ear found — drop as unrecoverable. */
+}
+
+/**
+ * Recursively split a simple CCW ring into convex pieces.
+ */
+static void
+DecomposeConvex(std::vector<XY> pts,
+                std::vector<std::vector<XY>> &convex_out,
+                unsigned depth) noexcept
+{
+  if (depth > 64)
+    return;
+
+  RemoveConsecutiveDuplicates(pts);
+  StripClosingDuplicate(pts);
+  if (pts.size() < 3 || AbsShoelace(pts) <= AREA_EPS)
+    return;
+
+  EnsureCCW(pts);
+
+  if (IsConvexCCW(pts)) {
+    convex_out.push_back(std::move(pts));
+    return;
+  }
+
+  const auto reflex = FindReflex(pts);
+  if (!reflex) {
+    /* Numerically odd but not marked reflex — force triangulation. */
+    TriangulateEars(std::move(pts), convex_out, 0);
+    return;
+  }
+
+  const std::size_t i = *reflex;
+  const std::size_t n = pts.size();
+  for (std::size_t j = 0; j < n; ++j) {
+    if (!DiagonalInside(pts, i, j))
+      continue;
+
+    auto [left, right] = SplitAtDiagonal(pts, i, j);
+    DecomposeConvex(std::move(left), convex_out, depth + 1);
+    DecomposeConvex(std::move(right), convex_out, depth + 1);
+    return;
+  }
+
+  TriangulateEars(std::move(pts), convex_out, 0);
+}
+
+static void
+AppendCleaned(std::vector<XY> pts,
+              std::vector<std::vector<Ring>> &out,
+              unsigned depth) noexcept
+{
+  /* Pathological rings could recurse; bail out rather than blow the
+     stack — the leftover geometry is dropped as junk. */
+  if (depth > 32)
+    return;
+
+  RemoveConsecutiveDuplicates(pts);
+  StripClosingDuplicate(pts);
+
+  if (pts.size() < 3)
+    return;
+
+  /* Self-crossing rings often have near-zero *signed* area (lobes
+     cancel).  Split before the area junk check. */
+  if (auto cross = FindFirstCrossing(pts)) {
+    auto [left, right] = SplitAtCrossing(pts, *cross);
+    AppendCleaned(std::move(left), out, depth + 1);
+    AppendCleaned(std::move(right), out, depth + 1);
+    return;
+  }
+
+  if (AbsShoelace(pts) <= AREA_EPS)
+    return;
+
+  /* Simple ring: cut into convex pieces for reliable ear-clip draw. */
+  std::vector<std::vector<XY>> convex_parts;
+  DecomposeConvex(std::move(pts), convex_parts, 0);
+  for (auto &part : convex_parts) {
+    if (part.size() >= 3 && AbsShoelace(part) > AREA_EPS)
+      out.push_back({ToClosedRing(part)});
+  }
+}
+
+} // namespace
+
+std::vector<std::vector<Ring>>
+CleanExterior(const Ring &exterior) noexcept
+{
+  std::vector<XY> pts;
+  pts.reserve(exterior.size());
+  for (const GeoPoint &p : exterior)
+    pts.push_back(ToXY(p));
+
+  std::vector<std::vector<Ring>> out;
+  AppendCleaned(std::move(pts), out, 0);
+  return out;
+}
+
+void
+CleanBandPolygons(WindBand &band) noexcept
+{
+  std::vector<std::vector<Ring>> cleaned;
+  cleaned.reserve(band.polygons.size());
+
+  for (const auto &polygon : band.polygons) {
+    if (polygon.empty())
+      continue;
+
+    /* Holes are not drawn — discard them at import. */
+    auto parts = CleanExterior(polygon[0]);
+    for (auto &part : parts)
+      cleaned.push_back(std::move(part));
+  }
+
+  band.polygons = std::move(cleaned);
+}
+
+void
+SortBandsByAbsMid(ForecastLayer &layer) noexcept
+{
+  std::sort(layer.bands.begin(), layer.bands.end(),
+            [](const WindBand &a, const WindBand &b) noexcept {
+              const double mid_a = (a.min_ms + a.max_ms) * 0.5;
+              const double mid_b = (b.min_ms + b.max_ms) * 0.5;
+              return std::fabs(mid_a) < std::fabs(mid_b);
+            });
+}
+
+} // namespace XCThermGeoJSON

--- a/src/Weather/xctherm/XCThermGeoJSONCleanup.hpp
+++ b/src/Weather/xctherm/XCThermGeoJSONCleanup.hpp
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "XCThermGeoJSON.hpp"
+
+#include <vector>
+
+namespace XCThermGeoJSON {
+
+/**
+ * Post-import cleanup for one exterior ring:
+ * - drop consecutive duplicate vertices
+ * - drop junk (fewer than 3 vertices, near-zero area)
+ * - split self-crossing rings into simple exteriors
+ * - decompose concave rings into convex pieces
+ *
+ * Returns zero or more exterior-only polygons (each a single ring).
+ */
+std::vector<std::vector<Ring>>
+CleanExterior(const Ring &exterior) noexcept;
+
+/**
+ * Apply CleanExterior() to every polygon in @p band, keep exterior
+ * only (holes discarded), and drop empty results.
+ */
+void
+CleanBandPolygons(WindBand &band) noexcept;
+
+/**
+ * Sort bands by ascending |midpoint| so weaker fills draw first and
+ * stronger bands overwrite (matches opaque overlay compositing).
+ */
+void
+SortBandsByAbsMid(ForecastLayer &layer) noexcept;
+
+} // namespace XCThermGeoJSON

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -13,6 +13,8 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Color.hpp"
 #ifdef ENABLE_OPENGL
+#include "Math/FastRotation.hpp"
+#include "Math/Point2D.hpp"
 #include "ui/canvas/opengl/Scope.hpp"
 #endif
 
@@ -226,12 +228,15 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
 #ifdef ENABLE_OPENGL
   /* Enable alpha blending for the entire overlay draw */
   const ScopeAlphaBlend alpha_blend;
-#endif
 
-  /* Temporary buffer for screen-space polygon points.
-     We reuse this across polygons to avoid reallocation. */
+  /* Float screen verts — avoid integer snap before ear-clip. */
+  std::vector<FloatPoint2D> screen_points;
+  screen_points.reserve(256);
+  const FastRotation screen_rotation{projection.GetScreenAngle()};
+#else
   std::vector<BulkPixelPoint> screen_points;
   screen_points.reserve(256);
+#endif
 
   const auto screen_rect = projection.GetScreenRect();
 
@@ -252,8 +257,7 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
     canvas.SelectNullPen();
 
     for (const auto &polygon : band.polygons) {
-      /* We only draw the exterior ring (ring 0).
-         Holes are rare in weather contour data. */
+      /* Parse() keeps exterior-only rings (holes dropped). */
       if (polygon.empty())
         continue;
 
@@ -278,8 +282,15 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
           br.y < screen_rect.top || tl.y > screen_rect.bottom)
         continue;
 
-      /* Project all points to screen coordinates */
       screen_points.clear();
+#ifdef ENABLE_OPENGL
+      for (const auto &pt : ring)
+        screen_points.push_back(projection.GeoToScreenF(pt,
+                                                        screen_rotation));
+
+      canvas.DrawPolygon(screen_points.data(),
+                         (unsigned)screen_points.size(), 0.f);
+#else
       for (const auto &pt : ring) {
         auto sp = projection.GeoToScreen(pt);
         screen_points.push_back(BulkPixelPoint{sp.x, sp.y});
@@ -287,6 +298,7 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
 
       canvas.DrawPolygon(screen_points.data(),
                          (unsigned)screen_points.size());
+#endif
     }
   }
 }

--- a/src/ui/canvas/opengl/Canvas.cpp
+++ b/src/ui/canvas/opengl/Canvas.cpp
@@ -232,6 +232,26 @@ Canvas::DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept
 }
 
 void
+Canvas::DrawPolygon(const FloatPoint2D *points, unsigned num_points,
+                    float min_distance) noexcept
+{
+  if (brush.IsHollow() || num_points < 3)
+    return;
+
+  OpenGL::solid_shader->Use();
+
+  ScopeVertexPointer vp(points);
+  brush.Bind();
+
+  static AllocatedArray<GLushort> triangle_buffer;
+  unsigned idx_count = PolygonToTriangles(points, num_points,
+                                          triangle_buffer, min_distance);
+  if (idx_count > 0)
+    glDrawElements(GL_TRIANGLES, idx_count, GL_UNSIGNED_SHORT,
+                   triangle_buffer.data());
+}
+
+void
 Canvas::DrawTriangleFan(const BulkPixelPoint *points, unsigned num_points) noexcept
 {
   if (brush.IsHollow() && !pen.IsDefined())

--- a/src/ui/canvas/opengl/Canvas.hpp
+++ b/src/ui/canvas/opengl/Canvas.hpp
@@ -10,6 +10,7 @@
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Font.hpp"
 #include "ui/canvas/Pen.hpp"
+#include "Math/Point2D.hpp"
 
 #include <string_view>
 
@@ -227,6 +228,13 @@ public:
   void DrawPolyline(const BulkPixelPoint *points, unsigned num_points) noexcept;
 
   void DrawPolygon(const BulkPixelPoint *points, unsigned num_points) noexcept;
+
+  /**
+   * Fill a polygon from float screen vertices (sub-pixel).  No outline.
+   * @param min_distance ear-clip neighbour thinning; 0 keeps all verts
+   */
+  void DrawPolygon(const FloatPoint2D *points, unsigned num_points,
+                   float min_distance = 0) noexcept;
 
   /**
    * Draw a triangle fan (GL_TRIANGLE_FAN).  The first point is the

--- a/src/ui/canvas/opengl/Triangulate.cpp
+++ b/src/ui/canvas/opengl/Triangulate.cpp
@@ -256,6 +256,16 @@ PolygonToTriangles(const FloatPoint2D *points, unsigned num_points,
   return _PolygonToTriangles(points, num_points, triangles, min_distance);
 }
 
+unsigned
+PolygonToTriangles(const FloatPoint2D *points, unsigned num_points,
+                   AllocatedArray<GLushort> &triangles,
+                   float min_distance) noexcept
+{
+  triangles.GrowDiscard(3 * (num_points - 2));
+  return _PolygonToTriangles(points, num_points, triangles.data(),
+                             min_distance);
+}
+
 /**
  * Count the occurrences of each value.
  */

--- a/src/ui/canvas/opengl/Triangulate.hpp
+++ b/src/ui/canvas/opengl/Triangulate.hpp
@@ -31,6 +31,11 @@ unsigned
 PolygonToTriangles(const FloatPoint2D *points, unsigned num_points,
                    GLushort *triangles, float min_distance=1) noexcept;
 
+unsigned
+PolygonToTriangles(const FloatPoint2D *points, unsigned num_points,
+                   AllocatedArray<GLushort> &triangles,
+                   float min_distance=0) noexcept;
+
 /**
  * Pack triangle indices into a triangle strip.
  * Empty triangles are inserted to connect individual strips. Thus we always

--- a/test/src/TestXCThermBandQuery.cpp
+++ b/test/src/TestXCThermBandQuery.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Weather/xctherm/XCThermGeoJSON.hpp"
+#include "Weather/xctherm/XCThermGeoJSONCleanup.hpp"
 #include "TestUtil.hpp"
 
 using namespace XCThermGeoJSON;
@@ -32,9 +33,22 @@ P(double lon, double lat)
   return GeoPoint(Angle::Degrees(lon), Angle::Degrees(lat));
 }
 
+static Ring
+MakeBowtie()
+{
+  /* Classic self-crossing quad (figure-8). */
+  Ring ring;
+  ring.push_back(P(0, 0));
+  ring.push_back(P(1, 1));
+  ring.push_back(P(0, 1));
+  ring.push_back(P(1, 0));
+  ring.push_back(P(0, 0));
+  return ring;
+}
+
 int main()
 {
-  plan_tests(14 + 4);
+  plan_tests(14 + 4 + 8 + 3);
 
   ForecastLayer layer;
   /* Two disjoint bands side by side:
@@ -100,6 +114,71 @@ int main()
   ok1(FindBandAtPoint(holed, P(0.5, 0.5), lo, hi));
   ok1(equals(lo, 1.0));
   ok1(equals(hi, 2.0));
+
+  /* --- Cleanup: drop holes --- */
+  {
+    WindBand band = MakeSquareBand(1.0, 2.0, 0, 0, 4, 4);
+    Ring hole;
+    hole.push_back(P(1.5, 1.5));
+    hole.push_back(P(2.5, 1.5));
+    hole.push_back(P(2.5, 2.5));
+    hole.push_back(P(1.5, 2.5));
+    hole.push_back(P(1.5, 1.5));
+    band.polygons[0].push_back(std::move(hole));
+    CleanBandPolygons(band);
+    ok1(band.polygons.size() == 1);
+    ok1(band.polygons[0].size() == 1);
+  }
+
+  /* --- Cleanup: split bowtie into two simple parts --- */
+  {
+    auto parts = CleanExterior(MakeBowtie());
+    ok1(parts.size() == 2);
+    ok1(parts[0].size() == 1 && parts[0][0].size() >= 4);
+    ok1(parts[1].size() == 1 && parts[1][0].size() >= 4);
+  }
+
+  /* --- Cleanup: concave L becomes multiple convex pieces --- */
+  {
+    Ring ell;
+    ell.push_back(P(0, 0));
+    ell.push_back(P(2, 0));
+    ell.push_back(P(2, 1));
+    ell.push_back(P(1, 1));
+    ell.push_back(P(1, 2));
+    ell.push_back(P(0, 2));
+    ell.push_back(P(0, 0));
+    auto parts = CleanExterior(ell);
+    ok1(parts.size() >= 2);
+    ok1(parts.size() <= 4);
+    /* Each piece is a single exterior ring with at least a triangle. */
+    bool all_ok = !parts.empty();
+    for (const auto &poly : parts)
+      if (poly.size() != 1 || poly[0].size() < 4)
+        all_ok = false;
+    ok1(all_ok);
+  }
+
+  /* --- Cleanup: drop zero-area junk --- */
+  {
+    Ring flat;
+    flat.push_back(P(0, 0));
+    flat.push_back(P(1, 0));
+    flat.push_back(P(2, 0));
+    flat.push_back(P(0, 0));
+    ok1(CleanExterior(flat).empty());
+  }
+
+  /* --- Sort bands by ascending |mid| --- */
+  {
+    ForecastLayer sorted;
+    sorted.bands.push_back(MakeSquareBand(3.0, 4.0, 0, 0, 1, 1));   /* |mid|=3.5 */
+    sorted.bands.push_back(MakeSquareBand(-1.0, -0.5, 0, 0, 1, 1)); /* |mid|=0.75 */
+    sorted.bands.push_back(MakeSquareBand(0.2, 0.5, 0, 0, 1, 1));   /* |mid|=0.35 */
+    SortBandsByAbsMid(sorted);
+    ok1(equals((sorted.bands[0].min_ms + sorted.bands[0].max_ms) / 2, 0.35));
+    ok1(equals((sorted.bands[2].min_ms + sorted.bands[2].max_ms) / 2, 3.5));
+  }
 
   return exit_status();
 }


### PR DESCRIPTION
## Summary
On the current XCTherm GeoJSON overlay, pan and zoom can make some contour polygons flicker, and in flight some of them stop being drawn entirely. Integer screen snapping before OpenGL triangulation is a major cause: vertices jump between pixels as the map moves, so ear-clipping can fail or change shape frame to frame.

This change:
- Cleans XCTherm GeoJSON on import (drop holes, split self-crossing contours, drop degenerate rings, decompose concave polygons into convex pieces) and draws weaker `|climb|` bands before stronger ones
- Draws polygons with float screen coordinates so triangulation no longer snaps before ear-clip
- Keeps the existing intensity-based alpha ramp (no opaque fill)

## Test plan
- Enable an XC Therm vertical-wind overlay and confirm polygons still draw with the usual colour/alpha
- Pan and zoom (including in flight / moving map) and check contours no longer flicker or drop out
- Spot-check nested lift/sink bands still layer correctly (weaker under stronger)
- Confirm point info / climb lookup still matches the drawn bands

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge

