### PR TITLE
Pages: Per-page terrain colors and active-page cursor

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -30,6 +30,11 @@ Version 7.46 - not yet released
   - fix choosing SkySight as a page overlay with no layers available
     silently switching back to None
 * map
+  - add Terrain colors on Config → Look → Pages (map pages) so each
+    page can use its own ramp or the Map Display → Terrain default;
+    the choice is stored with the page and restored after restart
+  - open Config → Look → Pages with the currently active map page
+    selected in the list
   - fix the ragged white halo behind map labels on high-DPI screens
     #2879
   - fix the map scale arrows: draw them at the height of the scale box

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -14,6 +14,7 @@
 #include "Profile/PageProfile.hpp"
 #include "Profile/Current.hpp"
 #include "Interface.hpp"
+#include "UIState.hpp"
 #include "DataGlobals.hpp"
 #include "Weather/Features.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
@@ -52,9 +53,13 @@ private:
     MAIN,
     INFO_BOX_PANEL,
     BOTTOM,
+    TERRAIN_COLORS,
     OVERLAY,
     OVERLAY_DETAIL,
   };
+
+  /** Sentinel for "use Map Display → Terrain colors". */
+  static constexpr unsigned TERRAIN_DEFAULT = 0xffff;
 
   static constexpr unsigned IBP_NONE = 0x7000;
   static constexpr unsigned IBP_AUTO = 0x7001;
@@ -349,6 +354,7 @@ PageLayoutEditWidget::UpdateOverlayControls() noexcept
     }
   }
 
+  SetRowEnabled(TERRAIN_COLORS, map_page);
   SetRowEnabled(OVERLAY, map_page);
   SetRowEnabled(OVERLAY_DETAIL, detail_enabled);
 }
@@ -358,6 +364,11 @@ PageLayoutEditWidget::ApplyValueToForm() noexcept
 {
   LoadValueEnum(BOTTOM, value.bottom);
   GetControl(BOTTOM).RefreshDisplay();
+  LoadValueEnum(TERRAIN_COLORS,
+                value.terrain_ramp < 0
+                ? TERRAIN_DEFAULT
+                : (unsigned)value.terrain_ramp);
+  GetControl(TERRAIN_COLORS).RefreshDisplay();
   LoadValueEnum(OVERLAY, value.overlay);
   GetControl(OVERLAY).RefreshDisplay();
   FillOverlayDetailControl();
@@ -430,6 +441,34 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
           bottom_list,
           (unsigned)PageLayout::Bottom::NOTHING, this);
 
+  static constexpr StaticEnumChoice terrain_list[] = {
+    { TERRAIN_DEFAULT, N_("Default"),
+      N_("Use the Terrain colors from Map Display → Terrain.") },
+    { 0, N_("Low lands"), },
+    { 1, N_("Mountainous"), },
+    { 2, N_("Imhof 7"), },
+    { 3, N_("Imhof 4"), },
+    { 4, N_("Imhof 12"), },
+    { 5, N_("Imhof Atlas"), },
+    { 6, N_("ICAO"), },
+    { 9, N_("Vibrant"), },
+    { 7, N_("Grey"), },
+    { 8, N_("White"), },
+    {10, N_("Sandstone"), },
+    {11, N_("Pastel"), },
+    {12, N_("Italian Avioportolano VFR Chart"), },
+    {13, N_("German DFS VFR Chart"), },
+    {14, N_("French SIA VFR Chart"), },
+    {15, N_("High Contrast"), },
+    {16, N_("High Contrast low lands"), },
+    {17, N_("Very low lands"), },
+    nullptr
+  };
+  AddEnum(_("Terrain colors"),
+          _("Terrain color ramp for this map page. Default follows "
+            "Map Display → Terrain."),
+          terrain_list, TERRAIN_DEFAULT, this);
+
   static constexpr StaticEnumChoice overlay_list[] = {
     { PageLayout::Overlay::NONE, N_("None") },
     { PageLayout::Overlay::RASP, NC_("Abbreviation", "RASP") },
@@ -465,6 +504,10 @@ PageLayoutEditWidget::SetValue(const PageLayout &_value)
 
   LoadValueEnum(MAIN, value.main);
   LoadValueEnum(BOTTOM, value.bottom);
+  LoadValueEnum(TERRAIN_COLORS,
+                value.terrain_ramp < 0
+                ? TERRAIN_DEFAULT
+                : (unsigned)value.terrain_ramp);
   LoadValueEnum(OVERLAY, value.overlay);
 
   unsigned ib = IBP_NONE;
@@ -523,6 +566,10 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
         value.bottom = PageLayout::Bottom::NOTHING;
 #endif
     }
+  } else if (&df == &GetDataField(TERRAIN_COLORS)) {
+    const DataFieldEnum &dfe = (const DataFieldEnum &)df;
+    const unsigned ramp = dfe.GetValue();
+    value.terrain_ramp = ramp == TERRAIN_DEFAULT ? -1 : (int)ramp;
   } else if (&df == &GetDataField(OVERLAY)) {
     const DataFieldEnum &dfe = (const DataFieldEnum &)df;
     const auto overlay = (PageLayout::Overlay)dfe.GetValue();
@@ -629,7 +676,18 @@ PageListWidget::Initialise(ContainerWindow &parent,
 void
 PageListWidget::Show(const PixelRect &rc) noexcept
 {
+  /* Select the page that is currently active on the map.  Must run
+     in Show() (after Prepare): SetCursorIndex invokes OnCursorMoved →
+     editor->SetValue(), which needs the editor rows. */
+  unsigned current = CommonInterface::GetUIState().pages.current_index;
+  if (settings.n_pages > 0) {
+    if (current >= settings.n_pages)
+      current = settings.n_pages - 1;
+    GetList().SetCursorIndex(current);
+  }
+
   editor->SetValue(settings.pages[GetList().GetCursorIndex()]);
+  UpdateButtons();
 
   ListWidget::Show(rc);
 }

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -17,6 +17,9 @@
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Components.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Terrain/TerrainSettings.hpp"
 #include "Weather/MapOverlay/ControlsFactory.hpp"
 #include "Weather/MapOverlay/ControlsWidget.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
@@ -53,6 +56,7 @@ namespace PageActions {
    * Restore the map zoom afte switching to a configured page.
    */
   static void RestoreMapZoom();
+  static void RestoreTerrainColors();
 
   /**
    * Loads the layout without updating current page information in
@@ -398,6 +402,32 @@ PageActions::RestoreMapZoom()
       map->QuickRedraw();
     }
   }
+
+  RestoreTerrainColors();
+}
+
+void
+PageActions::RestoreTerrainColors()
+{
+  const PagesState &state = CommonInterface::GetUIState().pages;
+  if (state.special_page.IsDefined())
+    return;
+
+  const PageSettings &settings = CommonInterface::GetUISettings().pages;
+  const PageLayout &layout = settings.pages[state.current_index];
+  unsigned ramp;
+  if (layout.terrain_ramp >= 0)
+    ramp = (unsigned)layout.terrain_ramp;
+  else if (!Profile::Get(ProfileKeys::TerrainRamp, ramp) ||
+           ramp >= TerrainRendererSettings::NUM_RAMPS)
+    ramp = 0;
+
+  MapSettings &map_settings = CommonInterface::SetMapSettings();
+  if (map_settings.terrain.ramp == ramp)
+    return;
+
+  map_settings.terrain.ramp = ramp;
+  ActionInterface::SendMapSettings(true);
 }
 
 const PageLayout &
@@ -444,6 +474,7 @@ PageActions::Update()
   }
 
   LoadLayout(GetCurrentLayout());
+  RestoreTerrainColors();
 }
 
 void

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "util/StaticString.hxx"
+#include "Terrain/TerrainSettings.hpp"
 
 #include <array>
 #include <cstdint>
@@ -157,6 +158,12 @@ struct PageLayout
   int xctherm_layer;
   int xctherm_time;
 
+  /**
+   * Per-page terrain color ramp for map pages.  Negative means use the
+   * global TerrainRamp from Map Display → Terrain.
+   */
+  int terrain_ramp;
+
   PageLayout() = default;
 
   constexpr PageLayout(bool _valid, InfoBoxConfig _infobox_config)
@@ -171,7 +178,8 @@ struct PageLayout
      edl_time(EDL_TIME_AUTO),
      edl_isobar(0),
      xctherm_layer(XCTHERM_LAYER_AUTO),
-     xctherm_time(XCTHERM_TIME_AUTO) {}
+     xctherm_time(XCTHERM_TIME_AUTO),
+     terrain_ramp(-1) {}
 
   constexpr PageLayout(InfoBoxConfig _infobox_config)
     :valid(true), main(Main::MAP),
@@ -185,7 +193,8 @@ struct PageLayout
      edl_time(EDL_TIME_AUTO),
      edl_isobar(0),
      xctherm_layer(XCTHERM_LAYER_AUTO),
-     xctherm_time(XCTHERM_TIME_AUTO) {}
+     xctherm_time(XCTHERM_TIME_AUTO),
+     terrain_ramp(-1) {}
 
   /**
    * Return an "undefined" page.  Its IsDefined() method will return
@@ -349,6 +358,10 @@ struct PageLayout
       if (xctherm_time < XCTHERM_TIME_AUTO || xctherm_time >= 24)
         xctherm_time = XCTHERM_TIME_AUTO;
     }
+
+    if (terrain_ramp < -1 ||
+        terrain_ramp >= (int)TerrainRendererSettings::NUM_RAMPS)
+      terrain_ramp = -1;
   }
 
   [[nodiscard]]

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -6,6 +6,7 @@
 #include "Map.hpp"
 #include "PageSettings.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Terrain/TerrainSettings.hpp"
 #include "util/NumberParser.hxx"
 #include "util/StaticString.hxx"
 #include "util/StringFormat.hpp"
@@ -112,6 +113,12 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
       pl.skysight_time = PageLayout::SKYSIGHT_TIME_AUTO;
   }
 
+  strcpy(profileKey + prefixLen, "TerrainRamp");
+  if (!map.Get(profileKey, pl.terrain_ramp) ||
+      pl.terrain_ramp < -1 ||
+      pl.terrain_ramp >= (int)TerrainRendererSettings::NUM_RAMPS)
+    pl.terrain_ramp = -1;
+
   if (pl.overlay == PageLayout::Overlay::NONE &&
       pl.bottom == PageLayout::Bottom::WEATHER_CONTROLS &&
       pl.skysight_overlay.empty())
@@ -187,6 +194,9 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
   StaticString<32> skysight_time;
   skysight_time.Format("%lld", (long long)page.skysight_time);
   map.Set(profileKey, skysight_time.c_str());
+
+  strcpy(profileKey + prefixLen, "TerrainRamp");
+  map.Set(profileKey, page.terrain_ramp);
 }
 
 

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -68,7 +68,13 @@ public:
   }
 
   void SetSettings(const TerrainRendererSettings &_settings) {
+    if (settings == _settings)
+      return;
+
     settings = _settings;
+    /* Ramp/contrast/etc. change with the same map view (e.g. per-page
+       terrain colors) must not reuse the cached image. */
+    Flush();
   }
 
 #ifdef ENABLE_OPENGL


### PR DESCRIPTION
## Summary
Map pages that carry a weather overlay (SkySight, XC Therm, RASP, EDL, …) often need a different terrain look than the normal navigation page so the overlay stays readable. This adds a per-page **Terrain colors** choice on Config → Look → Pages: pick a ramp for that page, or **Default** to follow Map Display → Terrain. The choice is stored with the page and applied when switching pages.

Also opens the Pages list with the currently active map page selected.

## Test plan
- Config → Look → Pages: set Terrain colors on a weather-overlay map page (not Default) and leave another page on Default
- Switch between those pages and confirm the terrain ramp changes with the page
- Restart the app and confirm the per-page choices persist
- Confirm Default still follows Map Display → Terrain when that global ramp is changed
- Open Config → Look → Pages and confirm the list cursor is on the page currently shown on the map

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configure terrain colors independently for each map page.
  - Choose a page-specific terrain color scheme or follow the global Map Display setting.
  - Terrain color preferences are saved and restored across application restarts.
  - The Pages settings dialog now opens with the active map page selected.

- **Bug Fixes**
  - Invalid terrain color selections are safely reset to the global default.
  - Terrain display updates now refresh correctly when settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->