### PR TITLE
Weather: Add configurable map-bottom controls height

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -22,6 +22,8 @@ Version 7.46 - not yet released
 * weather
   - show the overlay name as XC Therm (with a space) in setup, weather
     dialogs, map titles, and download messages
+  - add Config → Weather → Controls height (30–100 %) for the
+    map-bottom weather overlay control rows
   - fix the weather cursor bar keeping light colours in dark mode,
     and unreadable labels on Windows
   - fix SkySight re-downloading forecast metadata when stepping

--- a/build/main.mk
+++ b/build/main.mk
@@ -140,6 +140,7 @@ DIALOG_SOURCES = \
 	$(SRC)/Dialogs/Settings/Panels/TimeConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WaypointDisplayConfigPanel.cpp \
 	$(SRC)/Dialogs/Settings/Panels/WeatherConfigPanel.cpp \
+	$(SRC)/Dialogs/Settings/Panels/WeatherControlsConfigPanel.cpp \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/PCMetConfigPanel.cpp) \
 	$(if $(filter y,$(HAVE_HTTP)),$(SRC)/Dialogs/Settings/Panels/XCThermConfigPanel.cpp) \
 	$(SRC)/Dialogs/Settings/Panels/WeGlideConfigPanel.cpp \

--- a/src/Dialogs/Settings/Panels/WeatherControlsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/WeatherControlsConfigPanel.cpp
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "WeatherControlsConfigPanel.hpp"
+#include "Form/DataField/Enum.hpp"
+#include "Profile/Keys.hpp"
+#include "Weather/Settings.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "Interface.hpp"
+#include "MainWindow.hpp"
+#include "Language/Language.hpp"
+#include "UIGlobals.hpp"
+
+enum ControlIndex {
+  CONTROLS_HEIGHT,
+};
+
+static constexpr StaticEnumChoice controls_height_list[] = {
+  { 30, "30 %" },
+  { 40, "40 %" },
+  { 50, "50 %" },
+  { 60, "60 %" },
+  { 70, "70 %" },
+  { 80, "80 %" },
+  { 90, "90 %" },
+  { 100, "100 %" },
+  nullptr
+};
+
+class WeatherControlsConfigPanel final : public RowFormWidget {
+public:
+  WeatherControlsConfigPanel()
+    :RowFormWidget(UIGlobals::GetDialogLook()) {}
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool Save(bool &changed) noexcept override;
+};
+
+void
+WeatherControlsConfigPanel::Prepare(ContainerWindow &parent,
+                                    const PixelRect &rc) noexcept
+{
+  const auto &settings = CommonInterface::GetComputerSettings().weather;
+
+  RowFormWidget::Prepare(parent, rc);
+
+  AddEnum(_("Height"),
+          _("Height of the weather overlay control rows at the bottom of "
+            "the map, as a percentage of the default touch/control height."),
+          controls_height_list,
+          settings.controls_height_percent);
+}
+
+bool
+WeatherControlsConfigPanel::Save(bool &_changed) noexcept
+{
+  bool changed = false;
+  auto &settings = CommonInterface::SetComputerSettings().weather;
+
+  changed |= SaveValueEnum(CONTROLS_HEIGHT,
+                           ProfileKeys::WeatherControlsHeightPercent,
+                           settings.controls_height_percent);
+
+  if (settings.controls_height_percent < 30)
+    settings.controls_height_percent = 30;
+  else if (settings.controls_height_percent > 100)
+    settings.controls_height_percent = 100;
+
+  if (changed && CommonInterface::main_window != nullptr)
+    CommonInterface::main_window->ReinitialiseLayout();
+
+  _changed |= changed;
+  return true;
+}
+
+std::unique_ptr<Widget>
+CreateWeatherControlsConfigPanel()
+{
+  return std::make_unique<WeatherControlsConfigPanel>();
+}

--- a/src/Dialogs/Settings/Panels/WeatherControlsConfigPanel.hpp
+++ b/src/Dialogs/Settings/Panels/WeatherControlsConfigPanel.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+CreateWeatherControlsConfigPanel();

--- a/src/Dialogs/Settings/dlgConfiguration.cpp
+++ b/src/Dialogs/Settings/dlgConfiguration.cpp
@@ -72,6 +72,7 @@
 #ifdef HAVE_HTTP
 #include "Panels/XCThermConfigPanel.hpp"
 #endif
+#include "Panels/WeatherControlsConfigPanel.hpp"
 #ifdef HAVE_HTTP
 #include "Panels/SkySightConfigPanel.hpp"
 #endif
@@ -149,6 +150,7 @@ static constexpr TabMenuPage weather_pages[] = {
 #ifdef HAVE_HTTP
   { "XC Therm", CreateXCThermConfigPanel },
 #endif
+  { N_("Controls"), CreateWeatherControlsConfigPanel },
   { nullptr, nullptr }
 };
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -343,6 +343,8 @@ constexpr std::string_view XCThermModel = "XCThermModel";
 constexpr std::string_view XCThermParameter = "XCThermParameter";
 constexpr std::string_view XCThermWaveHeight = "XCThermWaveHeight";
 constexpr std::string_view XCThermVerticalWindAGL = "XCThermVerticalWindAGL";
+constexpr std::string_view WeatherControlsHeightPercent =
+  "WeatherControlsHeightPercent";
 constexpr std::string_view RaspLayerOpacity = "RaspLayerOpacity";
 constexpr std::string_view RaspContours = "RaspContours";
 

--- a/src/Profile/WeatherProfile.cpp
+++ b/src/Profile/WeatherProfile.cpp
@@ -53,6 +53,17 @@ Profile::Load(const ProfileMap &map, WeatherSettings &settings)
 
   map.Get(ProfileKeys::RaspAutoUpdate, settings.rasp.auto_update);
   map.Get(ProfileKeys::EdlAutoUpdate, settings.edl.auto_update);
+  map.Get(ProfileKeys::WeatherControlsHeightPercent,
+          settings.controls_height_percent);
+  if (settings.controls_height_percent < 30)
+    settings.controls_height_percent = 30;
+  else if (settings.controls_height_percent > 100)
+    settings.controls_height_percent = 100;
+  /* Snap to nearest 10 %. */
+  settings.controls_height_percent =
+    ((settings.controls_height_percent + 5) / 10) * 10;
+  if (settings.controls_height_percent < 30)
+    settings.controls_height_percent = 30;
 
   {
     StaticString<64> xctherm_email;

--- a/src/Weather/Settings.hpp
+++ b/src/Weather/Settings.hpp
@@ -126,6 +126,13 @@ struct WeatherSettings {
   EdlSettings edl;
   XCThermSettings xctherm;
 
+  /**
+   * Height of map-bottom weather control rows as a percentage of the
+   * default control height (30…100, steps of 10).  100 = current
+   * default (touch: maximum control height).
+   */
+  unsigned controls_height_percent;
+
   void SetDefaults() noexcept {
 #ifdef HAVE_PCMET
     pcmet.SetDefaults();
@@ -142,5 +149,6 @@ struct WeatherSettings {
     rasp.SetDefaults();
     edl.SetDefaults();
     xctherm.SetDefaults();
+    controls_height_percent = 100;
   }
 };

--- a/src/Widget/CursorBarWidget.cpp
+++ b/src/Widget/CursorBarWidget.cpp
@@ -4,6 +4,7 @@
 #include "CursorBarWidget.hpp"
 
 #include "Asset.hpp"
+#include "Interface.hpp"
 #include "Look/DialogLook.hpp"
 #include "Screen/Layout.hpp"
 #include "UIGlobals.hpp"
@@ -251,9 +252,18 @@ unsigned
 CursorBarWidget::DefaultHeight(unsigned rows) noexcept
 {
   rows = std::clamp(rows, 1U, MAX_ROWS);
-  const unsigned row_h = HasTouchScreen()
+  unsigned row_h = HasTouchScreen()
     ? Layout::GetMaximumControlHeight()
     : Layout::GetMinimumControlHeight();
+
+  unsigned percent =
+    CommonInterface::GetComputerSettings().weather.controls_height_percent;
+  if (percent < 30)
+    percent = 30;
+  else if (percent > 100)
+    percent = 100;
+  row_h = std::max(1u, (row_h * percent + 50) / 100);
+
   const unsigned separators = rows > 1 ? rows - 1 : 0;
   return row_h * rows + separators * SEPARATOR_H;
 }


### PR DESCRIPTION
## Summary
- Add **Config → Weather → Controls** with a **Height** setting (30–100 %, steps of 10) for the map-bottom weather overlay cursor-bar rows.
- Lets cockpit-mounted devices shrink those controls without changing other UI control sizes (default remains 100 %).

## Test plan
- Config → Weather → Controls → set Height to 50 % (or 30 %), leave settings, open a weather overlay page with the bottom cursor bar — rows should be shorter
- Set Height back to 100 % and confirm the bar returns to the default touch/control height
- Restart the app and confirm the chosen percentage persists
- Confirm other UI controls (menus, dialogs) are unchanged

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation.

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable weather-controls overlay height setting under **Config → Weather → Controls**.
  - Choose a height between 30% and 100% in 10% increments.
  - The weather controls now resize immediately when the setting changes.
  - Saved settings are validated and adjusted to supported values when loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->