### PR TITLE
Form: Draw a soft drop shadow around dialogs

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -96,6 +96,8 @@ Version 7.46 - not yet released
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the
     computed list #2912
+  - surround dialogs with a soft drop shadow, replacing the narrow
+    shade that was cast along their bottom and right edges
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862

--- a/build/form.mk
+++ b/build/form.mk
@@ -6,6 +6,7 @@ FORM_SOURCES = \
 	$(SRC)/UIUtil/KineticManager.cpp \
 	$(SRC)/Renderer/TextRenderer.cpp \
 	$(SRC)/Renderer/TabRenderer.cpp \
+	$(SRC)/Renderer/BoxShadowRenderer.cpp \
 	$(SRC)/Renderer/ButtonRenderer.cpp \
 	$(SRC)/Renderer/TextButtonRenderer.cpp \
 	$(SRC)/Renderer/SymbolRenderer.cpp \

--- a/src/Form/Form.cpp
+++ b/src/Form/Form.cpp
@@ -8,16 +8,13 @@
 #include "ui/window/SingleWindow.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/event/KeyCode.hpp"
-#include "util/Macros.hpp"
 #include "Look/DialogLook.hpp"
+#include "Renderer/BoxShadowRenderer.hpp"
 #include "ui/event/Globals.hpp"
 #include "ui/window/custom/Reference.hpp"
 
 #ifdef ENABLE_OPENGL
-#include "ui/canvas/opengl/Program.hpp"
-#include "ui/canvas/opengl/Shaders.hpp"
 #include "ui/canvas/opengl/Scope.hpp"
-#include "ui/canvas/opengl/VertexPointer.hpp"
 #endif
 
 #ifdef ANDROID
@@ -367,52 +364,9 @@ WndForm::OnPaint(Canvas &canvas) noexcept
   [[maybe_unused]] const bool is_active = main_window.IsTopDialog(*this);
 
 #ifdef ENABLE_OPENGL
-  if (!IsDithered() && !IsMaximised() && is_active) {
-    /* draw a shade around the current dialog to emphasise it */
-    const ScopeAlphaBlend alpha_blend;
-
-    const PixelRect rc = GetClientRect();
-    const int size = Layout::VptScale(4);
-
-    const BulkPixelPoint vertices[8] = {
-      { rc.left + size, rc.top + size },
-      { rc.right, rc.top + size },
-      { rc.right, rc.bottom },
-      { rc.left + size, rc.bottom },
-      { rc.left, rc.top + size },
-      { rc.right + size, rc.top + size },
-      { rc.right + size, rc.bottom + size },
-      { rc.left + size, rc.bottom + size },
-    };
-
-    const ScopeVertexPointer vp(vertices);
-
-    static constexpr Color inner_color = COLOR_BLACK.WithAlpha(192);
-    static constexpr Color outer_color = COLOR_BLACK.WithAlpha(16);
-    static constexpr Color colors[8] = {
-      inner_color,
-      inner_color,
-      inner_color,
-      inner_color,
-      outer_color,
-      outer_color,
-      outer_color,
-      outer_color,
-    };
-
-    const ScopeColorPointer cp(colors);
-
-    static constexpr GLubyte indices[] = {
-      0, 4, 1, 4, 5, 1,
-      1, 5, 2, 5, 6, 2,
-      2, 6, 3, 6, 7, 3,
-      3, 7, 0, 7, 4, 0,
-    };
-
-    OpenGL::solid_shader->Use();
-    glDrawElements(GL_TRIANGLES, ARRAY_SIZE(indices),
-                   GL_UNSIGNED_BYTE, indices);
-  }
+  if (!IsDithered() && !IsMaximised() && is_active)
+    /* draw a soft shadow around the current dialog to emphasise it */
+    DrawBoxShadow(GetClientRect());
 #endif
 
   ContainerWindow::OnPaint(canvas);

--- a/src/Renderer/BoxShadowRenderer.cpp
+++ b/src/Renderer/BoxShadowRenderer.cpp
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BoxShadowRenderer.hpp"
+#include "ui/dim/Rect.hpp"
+
+#ifdef ENABLE_OPENGL
+
+#include "Math/Point2D.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Color.hpp"
+#include "ui/canvas/opengl/Program.hpp"
+#include "ui/canvas/opengl/Scope.hpp"
+#include "ui/canvas/opengl/Shaders.hpp"
+#include "ui/canvas/opengl/VertexPointer.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <numbers>
+
+namespace {
+
+/**
+ * How far the opaque core of the shadow reaches beyond the box, in
+ * virtual points.
+ */
+constexpr int SHADOW_SPREAD = 6;
+
+/**
+ * The width of the blurred transition, in virtual points.  It is
+ * centered on the edge of the shadow's shape, i.e. the shadow fades
+ * out over the last SHADOW_BLUR/2 points and reaches
+ * SHADOW_SPREAD+SHADOW_BLUR/2 beyond the box.
+ */
+constexpr int SHADOW_BLUR = 32;
+
+/**
+ * The opacity of the black shadow where it is darkest.
+ */
+constexpr uint8_t SHADOW_ALPHA = 115;
+
+/**
+ * The number of segments each corner arc of a contour is approximated
+ * with.
+ */
+constexpr unsigned CORNER_SEGMENTS = 8;
+
+/**
+ * The number of vertices of one contour: four corner arcs, each
+ * starting and ending on one of the straight edges.
+ */
+constexpr unsigned CONTOUR_VERTICES = 4 * (CORNER_SEGMENTS + 1);
+
+/**
+ * The maximum number of contours; this limits both the amount of work
+ * per shadow and the size of the index buffer.
+ */
+constexpr unsigned MAX_CONTOURS = 33;
+
+static_assert(MAX_CONTOURS * CONTOUR_VERTICES <= 0x10000,
+              "Too many vertices for 16 bit indices");
+
+/**
+ * The largest mesh #MAX_CONTOURS can produce: one triangle fan filling
+ * the innermost contour, plus two triangles per vertex between each
+ * pair of adjacent contours.
+ */
+constexpr unsigned MAX_VERTICES = MAX_CONTOURS * CONTOUR_VERTICES;
+constexpr unsigned MAX_INDICES = (CONTOUR_VERTICES - 2) * 3
+  + (MAX_CONTOURS - 1) * CONTOUR_VERTICES * 6;
+
+/**
+ * The opacity of a Gaussian blur across its transition, approximated
+ * with a smoothstep(): 1 at the inner end (x=0), 0.5 exactly on the
+ * edge of the shadow shape (x=0.5) and 0 at the outer end (x=1).
+ */
+constexpr float
+BlurOpacity(float x) noexcept
+{
+  x = std::clamp(x, 0.f, 1.f);
+  return 1.f - x * x * (3.f - 2.f * x);
+}
+
+/**
+ * The unit circle offsets of one quarter arc, from (1,0) to (0,1).
+ */
+const auto quarter_arc = []{
+  std::array<FloatPoint2D, CORNER_SEGMENTS + 1> result{};
+  for (unsigned i = 0; i <= CORNER_SEGMENTS; ++i) {
+    const float angle = float(std::numbers::pi / 2) * i / CORNER_SEGMENTS;
+    result[i] = {std::cos(angle), std::sin(angle)};
+  }
+  return result;
+}();
+
+/**
+ * Emit the contour of all points which have the given distance to the
+ * four corner points of #centers - i.e. a rounded rectangle.
+ *
+ * All contours of one shadow share the same #centers, which makes the
+ * triangles between two of them annular sectors: their corner values
+ * lie on a plane, so both halves of each quad interpolate the same
+ * gradient.  Contours built as nested sharp-cornered rectangles would
+ * instead meet in a mitre at each corner, and because that mitre is
+ * wider than the straight bands, it shows up as a bright diagonal
+ * streak extending each corner.
+ *
+ * The contour is emitted clockwise, starting on the left edge, and
+ * always consists of #CONTOUR_VERTICES vertices, so that two contours
+ * can be stitched together with a ring of triangles.
+ */
+void
+AppendContour(FloatPoint2D *dest, const PixelRect &centers,
+              float radius) noexcept
+{
+  const float left = centers.left, top = centers.top;
+  const float right = centers.right, bottom = centers.bottom;
+
+  for (const auto i : quarter_arc)
+    /* top left, from the left edge to the top edge */
+    *dest++ = {left - radius * i.x, top - radius * i.y};
+
+  for (const auto i : quarter_arc)
+    /* top right, from the top edge to the right edge */
+    *dest++ = {right + radius * i.y, top - radius * i.x};
+
+  for (const auto i : quarter_arc)
+    /* bottom right, from the right edge to the bottom edge */
+    *dest++ = {right + radius * i.x, bottom + radius * i.y};
+
+  for (const auto i : quarter_arc)
+    /* bottom left, from the bottom edge to the left edge */
+    *dest++ = {left - radius * i.y, bottom + radius * i.x};
+}
+
+} // anonymous namespace
+
+#endif /* ENABLE_OPENGL */
+
+void
+DrawBoxShadow([[maybe_unused]] const PixelRect &rc) noexcept
+{
+#ifdef ENABLE_OPENGL
+  /* the shape which gets blurred: the box, inflated by the spread */
+  PixelRect shape = rc;
+  shape.Grow(Layout::VptScale(SHADOW_SPREAD));
+
+  const int blur = Layout::VptScale(SHADOW_BLUR);
+
+  /* the blur transition reaches this far outside and inside of the
+     shape's edge */
+  const int outer = blur / 2;
+  const int inner = std::min<int>(outer,
+                                  std::min(shape.GetWidth(),
+                                           shape.GetHeight()) / 2);
+
+  /* the corner arcs of all contours are centered on these four
+     points; the innermost contour collapses onto them, and the
+     outermost is #inner+#outer away */
+  const PixelRect centers{
+    shape.left + inner, shape.top + inner,
+    shape.right - inner, shape.bottom - inner,
+  };
+
+  /* one contour every two pixels is plenty for a smooth gradient */
+  const unsigned n_intervals = std::clamp<unsigned>((outer + inner) / 2,
+                                                    1, MAX_CONTOURS - 1);
+  const unsigned n_contours = n_intervals + 1;
+
+  /* both buffers are sized for the largest mesh we can produce, so
+     that this noexcept function never needs to allocate */
+  std::array<FloatPoint2D, MAX_VERTICES> vertices;
+  std::array<Color, MAX_VERTICES> colors;
+
+  for (unsigned i = 0; i < n_contours; ++i) {
+    const float radius = float(outer + inner) * i / n_intervals;
+
+    AppendContour(&vertices[i * CONTOUR_VERTICES], centers, radius);
+
+    /* the opacity depends on the distance to the shape's edge, which
+       this contour crosses at radius==inner */
+    const float opacity = BlurOpacity((radius - inner + blur / 2.f) / blur);
+    const Color color =
+      COLOR_BLACK.WithAlpha(uint8_t(std::lround(SHADOW_ALPHA * opacity)));
+    std::fill_n(&colors[i * CONTOUR_VERTICES], CONTOUR_VERTICES, color);
+  }
+
+  std::array<GLushort, MAX_INDICES> indices;
+  unsigned n_indices = 0;
+
+  /* fill the innermost contour with a triangle fan */
+  for (unsigned i = 1; i + 1 < CONTOUR_VERTICES; ++i) {
+    indices[n_indices++] = 0;
+    indices[n_indices++] = i;
+    indices[n_indices++] = i + 1;
+  }
+
+  /* stitch adjacent contours together with a ring of triangles; the
+     vertex colors make OpenGL interpolate the blur gradient */
+  for (unsigned i = 0; i < n_intervals; ++i) {
+    const unsigned a = i * CONTOUR_VERTICES;
+    const unsigned b = a + CONTOUR_VERTICES;
+
+    for (unsigned j = 0; j < CONTOUR_VERTICES; ++j) {
+      const unsigned j2 = (j + 1) % CONTOUR_VERTICES;
+
+      indices[n_indices++] = a + j;
+      indices[n_indices++] = b + j;
+      indices[n_indices++] = a + j2;
+
+      indices[n_indices++] = b + j;
+      indices[n_indices++] = b + j2;
+      indices[n_indices++] = a + j2;
+    }
+  }
+
+  assert(n_indices <= indices.size());
+
+  const ScopeAlphaBlend alpha_blend;
+  const ScopeVertexPointer vp(vertices.data());
+  const ScopeColorPointer cp(colors.data());
+
+  OpenGL::solid_shader->Use();
+  glDrawElements(GL_TRIANGLES, GLsizei(n_indices),
+                 GL_UNSIGNED_SHORT, indices.data());
+#endif
+}

--- a/src/Renderer/BoxShadowRenderer.hpp
+++ b/src/Renderer/BoxShadowRenderer.hpp
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+struct PixelRect;
+
+/**
+ * Draw a soft black drop shadow around the given rectangle, to make it
+ * look like it floats above what is painted behind it.  The shadow
+ * surrounds the rectangle evenly on all four sides, and its corners
+ * are rounded, the way the corners of a blurred rectangle are.
+ *
+ * This must be called before the box itself is painted: the shadow is
+ * drawn as a solid shape which is blurred at its edges, so the area
+ * covered by the box gets painted over as well.
+ *
+ * The rectangle is relative to the current Canvas, and the shadow
+ * extends beyond it, which means the caller must be allowed to paint
+ * outside of its own window.
+ *
+ * This is implemented with OpenGL and does nothing on other platforms.
+ */
+void
+DrawBoxShadow(const PixelRect &rc) noexcept;


### PR DESCRIPTION
Closes #2916.

Replaces the old shade, which was a narrow band cast along the bottom and right edges, with a soft drop shadow that surrounds the dialog evenly on all four sides.

The shadow looks better over the map than over a white background or the beige dialog background. That is fine for now, and the numbers can be tweaked any time as more elements of a modernised UI land.

<img width="100%" alt="Image" src="https://github.com/user-attachments/assets/69d984c2-5f7b-4e39-9f5d-aa9dd23fac86" />
<img width="49%" alt="Bildschirmfoto 2026-08-26 um 21 28 18" src="https://github.com/user-attachments/assets/ebd614f8-0c01-4741-89ef-4df60e77a12f" />
<img width="49%" alt="Bildschirmfoto 2026-08-26 um 21 28 43" src="https://github.com/user-attachments/assets/564b4989-dd6e-4578-998e-e459405064ad" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added soft, rounded drop shadows around eligible active dialogs.
  * Shadows surround non-maximized dialogs on all four sides, including the corners.
  * Dialog shadows appear beneath the dialog content for a natural layered appearance.

* **Style**
  * Improved dialog depth and visual polish with smoother, more consistent shadow effects.
  * Replaced the previous narrow bottom-right edge shading with a broader, softer shadow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->