### PR TITLE
Weather/PCMet: draw the aircraft position in the DWD satellite images

### DIFF
--- a/build/main.mk
+++ b/build/main.mk
@@ -735,6 +735,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Repository/Glue.cpp \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
+	$(SRC)/Weather/PCMet/Georeference.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/METARParser.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -90,6 +90,7 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
+	TestPCMetGeoreference \
 	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
@@ -610,6 +611,13 @@ TEST_GEO_BOUNDS_SOURCES = \
 	$(TEST_SRC_DIR)/TestGeoBounds.cpp
 TEST_GEO_BOUNDS_DEPENDS = GEO MATH
 $(eval $(call link-program,TestGeoBounds,TEST_GEO_BOUNDS))
+
+TEST_PCMET_GEOREFERENCE_SOURCES = \
+	$(SRC)/Weather/PCMet/Georeference.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestPCMetGeoreference.cpp
+TEST_PCMET_GEOREFERENCE_DEPENDS = GEO MATH
+$(eval $(call link-program,TestPCMetGeoreference,TEST_PCMET_GEOREFERENCE))
 
 TEST_FLARM_NET_SOURCES = \
 	$(SRC)/FLARM/FlarmNetReader.cpp \

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -675,3 +675,11 @@ forecasts and live weather data in the
 Below ``Overlay'', you can choose layers for the map window.
 ``pc\_met'' is a collection of live images which are usually displayed
 on the DWD web site \url{www.flugwetter.de}.
+
+In the satellite images (``Satellitenbilder''), XCSoar draws the
+aircraft symbol at your current GPS position, as long as you are
+inside the map section shown by the image.  The symbol is updated
+while the image is open, and it follows the zoom and pan of the image
+viewer.  Note that these images use the polar stereographic
+projection of the DWD, in which the meridians converge; north is
+straight up only along 10\degree{} East.

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -22,21 +22,37 @@
 #include "Widget/ImageZoomFrame.hpp"
 #include "Widget/Widget.hpp"
 #include "Weather/PCMet/Images.hpp"
+#include "Weather/PCMet/Georeference.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
+#include "Renderer/AircraftRenderer.hpp"
+#include "Look/MapLook.hpp"
+#include "MapSettings.hpp"
 #include "co/InvokeTask.hxx"
 #include "co/Task.hxx"
 #include "net/http/Init.hpp"
 #include "system/Path.hpp"
 #include "Interface.hpp"
 #include "ui/event/KeyCode.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+
+#include <chrono>
 
 class PCMetImageWidget final : public NullWidget {
   const Bitmap &bitmap;
+
+  /**
+   * The geographic extent of #bitmap; nullptr if it is not known, in
+   * which case the aircraft symbol is not drawn.
+   */
+  const PCMet::ImageGeoreference *const georeference;
+
   ImageZoomFrame image_window;
   int zoom = 0;
 
   Button *magnify_button = nullptr;
   Button *shrink_button = nullptr;
+
+  UI::PeriodicTimer update_timer{[this]{ image_window.Invalidate(); }};
 
   void UpdateZoomControls() noexcept
   {
@@ -58,9 +74,49 @@ class PCMetImageWidget final : public NullWidget {
     image_window.ClearPendingOffset();
   }
 
+  /**
+   * Draw the aircraft symbol at the current GPS position, on top of
+   * the image.
+   */
+  void DrawAircraft(Canvas &canvas,
+                    const ImageZoomView::Layout &layout) noexcept
+  {
+    if (georeference == nullptr)
+      return;
+
+    const auto &basic = CommonInterface::Basic();
+    if (!basic.location_available)
+      return;
+
+    const auto pixel = georeference->ToPixel(basic.location);
+    if (!georeference->IsInside(pixel))
+      /* outside the map section this image shows */
+      return;
+
+    /* the georeference refers to the nominal image size; scale in case
+       the DWD ever delivers a different one */
+    const PixelSize size = bitmap.GetSize();
+    const PixelSize nominal = georeference->nominal_size;
+    const auto position = layout.BitmapToScreen({
+      pixel.x * size.width / nominal.width,
+      pixel.y * size.height / nominal.height,
+    });
+
+    if (!layout.screen_rect.Contains(position))
+      /* scrolled out of view */
+      return;
+
+    AircraftRenderer::Draw(canvas, CommonInterface::GetMapSettings(),
+                           UIGlobals::GetMapLook().aircraft,
+                           basic.attitude.heading
+                           - georeference->GetUpBearing(basic.location),
+                           position);
+  }
+
 public:
-  explicit PCMetImageWidget(const Bitmap &_bitmap) noexcept
-    :bitmap(_bitmap) {}
+  PCMetImageWidget(const Bitmap &_bitmap,
+                   const PCMet::ImageGeoreference *_georeference) noexcept
+    :bitmap(_bitmap), georeference(_georeference) {}
 
   void SetZoomButtons(Button *magnify, Button *shrink) noexcept
   {
@@ -145,22 +201,35 @@ public:
     image_window.SetContent(&bitmap, &zoom);
     image_window.SetTryKeyInput(
       [this](unsigned key_code) { return TryImageKey(key_code); });
+
+    if (georeference != nullptr)
+      image_window.SetOverlayRenderer(
+        [this](Canvas &canvas, const ImageZoomView::Layout &layout) {
+          DrawAircraft(canvas, layout);
+        });
+
     UpdateZoomControls();
   }
 
   void Unprepare() noexcept override
   {
     image_window.SetTryKeyInput(nullptr);
+    image_window.SetOverlayRenderer(nullptr);
   }
 
   void Show(const PixelRect &rc) noexcept override
   {
     image_window.MoveAndShow(rc);
     image_window.SetFocus();
+
+    if (georeference != nullptr)
+      /* keep the aircraft symbol up to date while we are moving */
+      update_timer.Schedule(std::chrono::seconds{1});
   }
 
   void Hide() noexcept override
   {
+    update_timer.Cancel();
     image_window.Hide();
   }
 
@@ -180,12 +249,14 @@ public:
 };
 
 static void
-BitmapDialog(const Bitmap &bitmap)
+BitmapDialog(const Bitmap &bitmap,
+             const PCMet::ImageGeoreference *georeference)
 {
   WidgetDialog dialog(WidgetDialog::Full{},
                       UIGlobals::GetMainWindow(),
                       UIGlobals::GetDialogLook(),
-                      "Flugwetter", new PCMetImageWidget(bitmap));
+                      "Flugwetter",
+                      new PCMetImageWidget(bitmap, georeference));
   auto &image = static_cast<PCMetImageWidget &>(dialog.GetWidget());
 
   dialog.AddButton(_("Close"), mrOK);
@@ -215,7 +286,7 @@ BitmapDialog(const PCMet::ImageType &type, const PCMet::ImageArea &area)
 
     Bitmap bitmap;
     bitmap.LoadFile(*path);
-    BitmapDialog(bitmap);
+    BitmapDialog(bitmap, PCMet::FindImageGeoreference(type.uri, area.name));
   } catch (...) {
     ShowError(std::current_exception(), "Flugwetter");
   }

--- a/src/Weather/PCMet/Georeference.cpp
+++ b/src/Weather/PCMet/Georeference.cpp
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Georeference.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "Math/Angle.hpp"
+#include "util/StringAPI.hxx"
+
+#include <algorithm>
+#include <cmath>
+
+namespace {
+
+/* The parameters of the DWD polar stereographic grid, as published in
+   "RADOLAN und RADVOR: Beschreibung des Kompositformats" version
+   2.5.8, chapter 1.3 "Georeferenzierung": the projection plane cuts
+   the sphere at 60°N, is aligned with the 10°E meridian, and the
+   earth is a sphere of radius 6370.04km with zero eccentricity. */
+constexpr double EARTH_RADIUS = 6370.04;
+constexpr double STANDARD_PARALLEL = 60;
+constexpr double CENTRAL_MERIDIAN = 10;
+
+struct AreaGeoreference {
+  const char *area;
+  PCMet::ImageGeoreference georeference;
+};
+
+/**
+ * The map sections of the "Satellitenbilder" products.  All three
+ * channels (vis_hrv, ir_rgb, ir_108) of one area share the same
+ * section, therefore the suffix of the area name selects the entry.
+ *
+ * These were measured on downloaded images.  The DWD draws a marker
+ * for each major airport, and the two overview images additionally
+ * carry a 5° graticule; fitting the projection to either gives the
+ * same result to within 0.06% in resolution and half a pixel in
+ * position.  The residuals are 0.4 to 0.6 pixel, and the three German
+ * sections come out at the same resolution independently, which is a
+ * good sign that the numbers are sound.
+ */
+constexpr AreaGeoreference sat_georeferences[] = {
+  /* "Europa" */
+  { "eu", { {1000, 750}, 6.4813, { 563.728, -287.134 } } },
+
+  /* "Mitteleuropa" */
+  { "ce", { {1000, 750}, 2.5819, { 566.107, -1249.418 } } },
+
+  /* "Deutschland" and its northern and southern half */
+  { "mdl", { {1000, 750}, 1.1987, { 488.056, -3148.038 } } },
+  { "ndl", { {1000, 750}, 1.1984, { 510.923, -2816.887 } } },
+  { "sdl", { {1000, 750}, 1.1993, { 460.644, -3586.498 } } },
+};
+
+/**
+ * Extract the map section suffix of a satellite area name, e.g.
+ * "mdl" from "vis_hrv_mdl".
+ */
+[[gnu::pure]]
+const char *
+GetSatAreaSuffix(const char *area) noexcept
+{
+  const char *underscore = StringFindLast(area, '_');
+  return underscore != nullptr ? underscore + 1 : area;
+}
+
+} // anonymous namespace
+
+DoublePoint2D
+PCMet::ImageGeoreference::ToPixel(const GeoPoint &p) const noexcept
+{
+  /* distance from the pole in the projection plane; the scale factor
+     makes the projection true at STANDARD_PARALLEL */
+  const double scale = (1 + Angle::Degrees(STANDARD_PARALLEL).sin())
+    / (1 + p.latitude.sin());
+  const double radius = EARTH_RADIUS * scale * p.latitude.cos();
+
+  const Angle delta = p.longitude - Angle::Degrees(CENTRAL_MERIDIAN);
+  const double x = radius * delta.sin();
+  const double y = -radius * delta.cos();
+
+  /* the projection y axis points north, the image y axis points down */
+  return {
+    pole.x + x / resolution,
+    pole.y - y / resolution,
+  };
+}
+
+Angle
+PCMet::ImageGeoreference::GetUpBearing(const GeoPoint &p) const noexcept
+{
+  return p.longitude - Angle::Degrees(CENTRAL_MERIDIAN);
+}
+
+bool
+PCMet::ImageGeoreference::IsInside(const DoublePoint2D pixel) const noexcept
+{
+  return pixel.x >= 0 && pixel.x < nominal_size.width &&
+    pixel.y >= 0 && pixel.y < nominal_size.height;
+}
+
+const PCMet::ImageGeoreference *
+PCMet::FindImageGeoreference(const char *type_uri,
+                             const char *area_name) noexcept
+{
+  if (type_uri == nullptr || area_name == nullptr)
+    /* the image tables are terminated by a null entry, so a caller
+       walking one past the end would land here */
+    return nullptr;
+
+  if (!StringIsEqual(type_uri, "sat/index.htm"))
+    /* only the satellite images are georeferenced so far */
+    return nullptr;
+
+  const char *suffix = GetSatAreaSuffix(area_name);
+
+  const auto i = std::find_if(std::begin(sat_georeferences),
+                              std::end(sat_georeferences),
+                              [suffix](const AreaGeoreference &a){
+                                return StringIsEqual(a.area, suffix);
+                              });
+
+  return i != std::end(sat_georeferences) ? &i->georeference : nullptr;
+}

--- a/src/Weather/PCMet/Georeference.hpp
+++ b/src/Weather/PCMet/Georeference.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Math/Point2D.hpp"
+#include "ui/dim/Size.hpp"
+
+struct GeoPoint;
+class Angle;
+
+namespace PCMet {
+
+/**
+ * Maps geographic coordinates to pixels of a pc_met satellite image.
+ *
+ * The images carry no georeferencing metadata, but each product always
+ * shows the same fixed map section, so the parameters can be
+ * hard-coded here.  They use the polar stereographic projection of the
+ * Deutscher Wetterdienst, the same grid the RADOLAN radar composites
+ * are published on: standard parallel 60° North, central meridian
+ * 10° East, spherical earth.  The images are axis-aligned to the
+ * projection, i.e. there is no rotation, and the pixels are square.
+ *
+ * Note that the DWD documents this grid for the radar composites
+ * only; that the satellite images use it as well was determined by
+ * measuring them.
+ *
+ * The values were derived from the graticule drawn into the
+ * "Mitteleuropa" and "Europa" images; see #Georeference.cpp.
+ */
+struct ImageGeoreference {
+  /**
+   * The image size the values below refer to.  Images of a different
+   * size are assumed to show the same map section and are scaled.
+   */
+  PixelSize nominal_size;
+
+  /** the width of one pixel in the projection plane [km] */
+  double resolution;
+
+  /**
+   * The pixel position of the projection origin, i.e. where the North
+   * Pole would be.  This is far outside the image.
+   */
+  DoublePoint2D pole;
+
+  constexpr bool IsDefined() const noexcept {
+    return resolution > 0;
+  }
+
+  /**
+   * Project a geographic location to #nominal_size pixel coordinates,
+   * (0,0) being the top left corner.  The result may be outside the
+   * image; use IsInside() to check.
+   */
+  [[gnu::pure]]
+  DoublePoint2D ToPixel(const GeoPoint &p) const noexcept;
+
+  /**
+   * Is this pixel position inside the image?
+   */
+  [[gnu::pure]]
+  bool IsInside(DoublePoint2D pixel) const noexcept;
+
+  /**
+   * The true bearing that corresponds to the "up" direction of the
+   * image at this location.  The meridians converge towards the pole,
+   * so this is zero only on the central meridian; over Germany it
+   * reaches about 5°.  Subtract it from a true bearing to get the
+   * angle to draw on screen.
+   */
+  [[gnu::pure]]
+  Angle GetUpBearing(const GeoPoint &p) const noexcept;
+};
+
+/**
+ * Look up the georeference for a pc_met image.
+ *
+ * @param type_uri the ImageType::uri of the product
+ * @param area_name the ImageArea::name of the map section
+ * @return nullptr if the extent of this image is not known
+ */
+[[gnu::pure]]
+const ImageGeoreference *FindImageGeoreference(const char *type_uri,
+                                               const char *area_name) noexcept;
+
+} // namespace PCMet

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -35,6 +35,13 @@ ImageZoomFrame::SetTryKeyInput(std::function<bool(unsigned)> &&f) noexcept
 }
 
 void
+ImageZoomFrame::SetOverlayRenderer(std::function<void(Canvas &,
+                                                      const ImageZoomView::Layout &)> &&f) noexcept
+{
+  overlay_renderer = std::move(f);
+}
+
+void
 ImageZoomFrame::NudgeViewByPixelOffset(const PixelPoint o) noexcept
 {
   pending_offset += o;
@@ -51,8 +58,12 @@ ImageZoomFrame::OnPaint(Canvas &canvas) noexcept
   if (bitmap == nullptr || zoom_level == nullptr)
     return;
 
-  ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_level,
-                                   view_pos, pending_offset);
+  const auto layout =
+    ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_level,
+                                     view_pos, pending_offset);
+
+  if (overlay_renderer && layout.IsDefined())
+    overlay_renderer(canvas, layout);
 }
 
 bool

--- a/src/Widget/ImageZoomFrame.hpp
+++ b/src/Widget/ImageZoomFrame.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "Form/Draw.hpp"
+#include "ImageZoomView.hpp"
 
 #include <functional>
 
-struct PixelPoint;
 struct PixelRect;
 class Bitmap;
 class ContainerWindow;
@@ -26,6 +26,9 @@ class ImageZoomFrame final : public WndOwnerDrawFrame {
 
   std::function<bool(unsigned key_code)> try_key_input;
 
+  std::function<void(Canvas &canvas,
+                     const ImageZoomView::Layout &layout)> overlay_renderer;
+
 public:
   void Create(ContainerWindow &parent, PixelRect rc,
               const WindowStyle &style) noexcept;
@@ -33,6 +36,16 @@ public:
   void SetContent(const Bitmap *bitmap, int *zoom) noexcept;
 
   void SetTryKeyInput(std::function<bool(unsigned key_code)> &&f) noexcept;
+
+  /**
+   * Install a function which paints on top of the bitmap, e.g. to
+   * mark a position inside the image.  It is passed the layout
+   * describing where the bitmap was painted.
+   *
+   * The function is called from OnPaint() and must not throw.
+   */
+  void SetOverlayRenderer(std::function<void(Canvas &canvas,
+                                             const ImageZoomView::Layout &layout)> &&f) noexcept;
 
   void NudgeViewByPixelOffset(PixelPoint o) noexcept;
 

--- a/src/Widget/ImageZoomView.cpp
+++ b/src/Widget/ImageZoomView.cpp
@@ -95,14 +95,14 @@ AdjustImageViewOnZoomChange(const int old_zoom, const int new_zoom,
   view_pos.y = int(std::lround(view_y));
 }
 
-void
+Layout
 PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, const int zoom,
                   PixelPoint &view_pos, PixelPoint &pending_offset) noexcept
 {
   PixelSize img_size = bitmap.GetSize();
   if (img_size.width == 0 || img_size.height == 0 ||
       canvas.GetWidth() == 0 || canvas.GetHeight() == 0)
-    return;
+    return {};
 
   const double scale = GetImageScale(
     {unsigned(canvas.GetWidth()), unsigned(canvas.GetHeight())},
@@ -147,6 +147,23 @@ PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, const int zoom,
 
   pending_offset = {};
   canvas.Stretch(screen_pos, screen_size, bitmap, view_pos, img_size);
+
+  if (img_size.width == 0 || img_size.height == 0)
+    /* degenerate source rectangle; no overlay can be placed on it */
+    return {};
+
+  /* Stretch() was given integral rectangles, so the scale it applied
+     is the ratio of those, not the floating point scale computed
+     above; using the latter would drift the overlay away from the
+     bitmap towards the far edge */
+  return {
+    PixelRect{screen_pos, screen_size},
+    view_pos,
+    {
+      double(screen_size.width) / img_size.width,
+      double(screen_size.height) / img_size.height,
+    },
+  };
 }
 
 } // namespace ImageZoomView

--- a/src/Widget/ImageZoomView.hpp
+++ b/src/Widget/ImageZoomView.hpp
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include "ui/dim/Rect.hpp"
 #include "ui/dim/Size.hpp"
+#include "Math/Point2D.hpp"
+
+#include <cmath>
 
 class Bitmap;
 class Canvas;
-struct PixelPoint;
 
 /**
  * Shared fit/zoom/pan math and painting for bitmap viewers.
@@ -15,6 +18,43 @@ struct PixelPoint;
 namespace ImageZoomView {
 
 static constexpr int max_zoom_level = 5;
+
+/**
+ * Describes where PaintZoomedBitmap() has put the bitmap on the
+ * canvas.  This allows callers to paint overlays on top of the
+ * bitmap at a known bitmap position.
+ */
+struct Layout {
+  /** the area of the canvas covered by the bitmap */
+  PixelRect screen_rect;
+
+  /** the top-left of the visible region, in bitmap pixels */
+  PixelPoint view_pos;
+
+  /**
+   * The factors converting bitmap pixels to canvas pixels.  The two
+   * axes are tracked separately because Canvas::Stretch() works on
+   * integral rectangles: the effective scale is the ratio of the
+   * rectangles it was actually given, and rounding can differ per
+   * axis.
+   */
+  DoublePoint2D scale{0, 0};
+
+  constexpr bool IsDefined() const noexcept {
+    return scale.x > 0 && scale.y > 0;
+  }
+
+  /**
+   * Convert a position inside the bitmap to a canvas position.
+   */
+  [[gnu::pure]]
+  PixelPoint BitmapToScreen(DoublePoint2D p) const noexcept {
+    return {
+      screen_rect.left + int(std::lround((p.x - view_pos.x) * scale.x)),
+      screen_rect.top + int(std::lround((p.y - view_pos.y) * scale.y)),
+    };
+  }
+};
 
 void
 AdjustImageViewOnZoomChange(int old_zoom, int new_zoom,
@@ -26,8 +66,9 @@ AdjustImageViewOnZoomChange(int old_zoom, int new_zoom,
  * Paint a bitmap with discrete zoom levels and pan offset.
  * @param view_pos Top-left of the visible region in bitmap pixels
  * @param pending_offset Drag/key nudge in screen pixels (applied once, then cleared)
+ * @return where the bitmap was painted; undefined if nothing was painted
  */
-void
+Layout
 PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, int zoom,
                     PixelPoint &view_pos,
                     PixelPoint &pending_offset) noexcept;

--- a/test/src/TestPCMetGeoreference.cpp
+++ b/test/src/TestPCMetGeoreference.cpp
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/PCMet/Georeference.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "TestUtil.hpp"
+
+static constexpr GeoPoint
+MakeGeoPoint(double longitude, double latitude) noexcept
+{
+  return GeoPoint(Angle::Degrees(longitude), Angle::Degrees(latitude));
+}
+
+/**
+ * Check that an airport lands on the pixel where the DWD marker was
+ * measured in a downloaded image.
+ */
+static bool
+ProjectsTo(const PCMet::ImageGeoreference &g,
+           double longitude, double latitude,
+           double x, double y, double tolerance = 2.5) noexcept
+{
+  const auto p = g.ToPixel(MakeGeoPoint(longitude, latitude));
+  return fabs(p.x - x) <= tolerance && fabs(p.y - y) <= tolerance;
+}
+
+int main()
+{
+  plan_tests(25);
+
+  /* the satellite images are georeferenced, and all three channels of
+     one area share the same section */
+  const auto *germany = PCMet::FindImageGeoreference("sat/index.htm",
+                                                     "vis_hrv_mdl");
+  ok1(germany != nullptr);
+  ok1(germany->IsDefined());
+  ok1(PCMet::FindImageGeoreference("sat/index.htm", "ir_108_mdl") == germany);
+  ok1(PCMet::FindImageGeoreference("sat/index.htm", "ir_rgb_mdl") == germany);
+
+  /* unknown products have no georeference */
+  ok1(PCMet::FindImageGeoreference("sat/index.htm", "vis_hrv_xyz") == nullptr);
+  ok1(PCMet::FindImageGeoreference("rad/index.htm", "rx") == nullptr);
+
+  /* the image tables are null-terminated, so a caller walking one
+     entry too far must not crash */
+  ok1(PCMet::FindImageGeoreference("sat/index.htm", nullptr) == nullptr);
+  ok1(PCMet::FindImageGeoreference(nullptr, nullptr) == nullptr);
+
+  /* airport markers measured in nb_ir_rgb_mdl_2608261845_sat.jpg */
+  ok1(ProjectsTo(*germany,  9.9882, 53.6304, 487.12, 109.50));  // EDDH
+  ok1(ProjectsTo(*germany, 13.5033, 52.3667, 695.29, 223.44));  // EDDB
+  ok1(ProjectsTo(*germany,  8.5706, 50.0333, 398.04, 456.46));  // EDDF
+  ok1(ProjectsTo(*germany, 11.7861, 48.3538, 605.47, 621.32));  // EDDM
+  ok1(ProjectsTo(*germany, 16.5697, 48.1103, 922.29, 622.71));  // LOWW
+
+  /* the northern and southern halves are separate products */
+  const auto *north = PCMet::FindImageGeoreference("sat/index.htm",
+                                                   "vis_hrv_ndl");
+  const auto *south = PCMet::FindImageGeoreference("sat/index.htm",
+                                                   "vis_hrv_sdl");
+  ok1(ProjectsTo(*north,  9.9882, 53.6304, 510.34, 441.60));   // EDDH
+  ok1(ProjectsTo(*south, 11.7861, 48.3538, 577.95, 181.85));   // EDDM
+
+  /* the Europa section, checked against markers far apart */
+  const auto *europe = PCMet::FindImageGeoreference("sat/index.htm",
+                                                    "ir_rgb_eu");
+  ok1(europe != nullptr);
+  ok1(ProjectsTo(*europe, 37.9063, 55.4088, 831.04, 217.86, 2));  // UUDD
+  ok1(ProjectsTo(*europe, -6.2701, 53.4213, 394.36, 294.64, 2));  // EIDW
+
+  /* the central meridian runs straight up the image */
+  const auto a = germany->ToPixel(MakeGeoPoint(10, 48));
+  const auto b = germany->ToPixel(MakeGeoPoint(10, 54));
+  ok1(equals(a.x, b.x));
+  ok1(a.y > b.y);
+
+  /* the meridians converge, so north is up on 10E only */
+  ok1(equals(germany->GetUpBearing(MakeGeoPoint(10, 50)).Degrees(), 0));
+  ok1(equals(germany->GetUpBearing(MakeGeoPoint(15, 50)).Degrees(), 5));
+
+  /* IsInside() */
+  ok1(germany->IsInside(germany->ToPixel(MakeGeoPoint(11, 48))));
+  ok1(!germany->IsInside(germany->ToPixel(MakeGeoPoint(11, 60))));
+  ok1(!germany->IsInside(germany->ToPixel(MakeGeoPoint(-5, 48))));
+
+  return exit_status();
+}


### PR DESCRIPTION
Draws the aircraft symbol at the current GPS position in the pc_met
satellite images, so that the cloud picture can be related to where
you actually are.

### Why the georeference is hard-coded

The images the DWD delivers are plain JPEGs without any georeferencing
metadata, but each product always shows the same fixed map section, so
the parameters can live in a table.

They are **not** a plain lat/lon box. The images use the DWD polar
stereographic grid — standard parallel 60°N, central meridian 10°E,
sphere of radius 6370.04km — the same projection documented for the
RADOLAN radar composites in "RADOLAN und RADVOR: Beschreibung des
Kompositformats" 2.5.8, chapter 1.3. Note that the DWD documents that
grid for the radar composites only; that the satellite images share it
was determined by measuring them, and is noted as such in the source.

Two consequences worth pointing out for review:

* A linear lat/lon interpolation is wrong. Over Germany it is off by
  more than 10km, and over the Europe section it fails completely.
* North is not up. The meridians converge, by up to 5° over Germany,
  so the symbol is rotated by `GetUpBearing()`.

### How the constants were obtained

The two overview images ("Europa", "Mitteleuropa") have a 5° graticule
drawn into them. Fitting the projection to those crosses gives 0.37
pixel RMS. The German sections have no graticule, but all images carry
a marker for each major airport; fitting those gives the same result
for the overview images to within 0.05% in resolution and half a pixel
in position, so the same method was used for the German sections.

| section | km/px | RMS |
|---|---|---|
| `eu` | 6.4813 | 0.44px |
| `ce` | 2.5819 | 0.52px |
| `mdl` | 1.1987 | 0.57px |
| `ndl` | 1.1984 | 0.57px |
| `sdl` | 1.1993 | 0.51px |

The three German sections were fitted independently and came out at
the same resolution to within 0.08%, which is a good sign that the
numbers are sound.

If a product is ever re-cropped, `sat_georeferences[]` in
`Weather/PCMet/Georeference.cpp` is the only place to touch. Where no
georeference is known, `FindImageGeoreference()` returns nullptr and
nothing is drawn, rather than drawing the aircraft in the wrong place.

### Changes

* `Widget/ImageZoomView` returns the layout it painted, so callers can
  place overlays on the bitmap.
* `Widget/ImageZoomFrame` gains an overlay renderer hook.
* `Weather/PCMet/Georeference` is new, with a unit test.
* `Dialogs/Weather/PCMetDialog` draws the aircraft and keeps it
  updated while the image is open.

### Testing

`TestPCMetGeoreference` checks the projection against airport markers
measured in real images, the behaviour of the central meridian, the
meridian convergence and the bounds check. Built and run for the UNIX
target.

The aircraft drawing itself has not been exercised against a live GPS
position; that needs a pc_met account and a flight.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge

Opened as a draft: the georeference constants were measured rather
than taken from a DWD specification, and maintainers may want to weigh
in on that before this is merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added aircraft position overlays to supported PCMet satellite, radar, and combined weather images.
  * The aircraft marker updates while viewing and follows image zoom and panning.
  * Added accurate positioning across supported image regions and regional products.
  * The overlay respects map boundaries and excludes non-map legend areas.
* **Documentation**
  * Updated the manual with overlay behavior and satellite image projection details.
* **Tests**
  * Added coverage for image positioning, supported regions, orientation, and image boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->