### PR TITLE
Dialogs/Settings: Put display hardware settings on the Display panel

### DIFF
--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
@@ -4,7 +4,6 @@
 #include "DisplayConfigPanel.hpp"
 #include "ui/canvas/Features.hpp" // for DRAW_MOUSE_CURSOR
 #include "Profile/Keys.hpp"
-#include "Profile/Profile.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Hardware/DisplayBrightness.hpp"
 #include "Hardware/RotateDisplay.hpp"
@@ -17,6 +16,7 @@
 #include "UtilsSettings.hpp"
 #include "Asset.hpp"
 #include "util/Macros.hpp"
+#include "util/StaticString.hxx"
 
 #ifdef ANDROID
 #include "Android/Main.hpp"
@@ -36,14 +36,16 @@
 
 enum ControlIndex {
   AppDisplayType,
-#ifdef ANDROID
-  FullScreen,
-#endif
+  CustomDPI,
   Orientation,
-  DarkMode,
 #if defined(HAVE_DISPLAY_BRIGHTNESS_CONTROL)
   ScreenBrightness,
 #endif
+#ifdef ANDROID
+  FullScreen,
+#endif
+  DarkMode,
+  UIScale,
 #ifdef DRAW_MOUSE_CURSOR
   CursorSize,
   CursorInverted,
@@ -90,6 +92,22 @@ static constexpr StaticEnumChoice dark_mode_list[] = {
   nullptr
 };
 
+static void
+FillDpiChoices(DataFieldEnum &df, unsigned value) noexcept
+{
+  static constexpr unsigned dpi_choices[] = {
+    120, 160, 240, 260, 280, 300, 340, 360, 400, 420, 520,
+  };
+
+  df.AddChoice(0, _("Automatic"));
+  for (unsigned dpi : dpi_choices) {
+    StaticString<20> buffer;
+    buffer.Format(_("%u dpi"), dpi);
+    df.AddChoice(dpi, buffer);
+  }
+  df.SetValue(value);
+}
+
 class DisplayConfigPanel final : public RowFormWidget {
   std::unique_ptr<DisplayBrightness> brightness;
 
@@ -98,7 +116,6 @@ public:
     :RowFormWidget(UIGlobals::GetDialogLook()),
      brightness(DisplayBrightness::Detect()) {}
 
-public:
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   bool Save(bool &changed) noexcept override;
 };
@@ -118,10 +135,13 @@ DisplayConfigPanel::Prepare(ContainerWindow &parent,
           (unsigned)ui_settings.display.display_type);
   SetExpertRow(AppDisplayType);
 
-#ifdef ANDROID
-  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
-             ui_settings.display.full_screen);
-#endif
+  WndProperty *wp_dpi = AddEnum(_("Display resolution"),
+                                _("The display resolution is used to adapt line widths, "
+                                  "font size, landable size and more."));
+  FillDpiChoices(*(DataFieldEnum *)wp_dpi->GetDataField(),
+                 ui_settings.custom_dpi);
+  wp_dpi->RefreshDisplay();
+  SetExpertRow(CustomDPI);
 
   if (Display::RotateSupported())
     AddEnum(_("Display orientation"),
@@ -130,9 +150,6 @@ DisplayConfigPanel::Prepare(ContainerWindow &parent,
             (unsigned)ui_settings.display.orientation);
   else
     AddDummy();
-
-  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
-          (unsigned)ui_settings.dark_mode);
 
 #ifdef HAVE_DISPLAY_BRIGHTNESS_CONTROL
   if (brightness != nullptr) {
@@ -148,6 +165,19 @@ DisplayConfigPanel::Prepare(ContainerWindow &parent,
   } else
     AddDummy();
 #endif
+
+#ifdef ANDROID
+  AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
+             ui_settings.display.full_screen);
+#endif
+
+  AddEnum(_("Dark mode"), nullptr, dark_mode_list,
+          (unsigned)ui_settings.dark_mode);
+
+  AddInteger(_("Text size"),
+             nullptr,
+             "%d %%", "%d", 75, 200, 5,
+             ui_settings.scale);
 
 #ifdef DRAW_MOUSE_CURSOR
   AddInteger(_("Cursor zoom"), _("Cursor zoom factor"), "%d x", "%d x",
@@ -170,32 +200,46 @@ DisplayConfigPanel::Save(bool &_changed) noexcept
     SetDisplayType(ui_settings.display.display_type);
   }
 
+  if (SaveValueEnum(CustomDPI, ProfileKeys::CustomDPI,
+                    ui_settings.custom_dpi))
+    require_restart = changed = true;
+
+  if (Display::RotateSupported() &&
+      SaveValueEnum(Orientation, ProfileKeys::MapOrientation,
+                    ui_settings.display.orientation)) {
+    changed = true;
+
+    if (!Display::Rotate(ui_settings.display.orientation))
+      LogString("Display rotation failed");
+
+#ifdef USE_POLL_EVENT
+    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
+#endif
+
+    CommonInterface::main_window->CheckResize();
+  }
+
+#ifdef HAVE_DISPLAY_BRIGHTNESS_CONTROL
+  if (brightness != nullptr && brightness->IsWritable()) {
+    const unsigned old_percent = brightness->GetBrightnessPercent();
+    const unsigned new_percent = GetValueInteger(ScreenBrightness);
+    if (new_percent != old_percent)
+      brightness->SetBrightnessPercent(new_percent);
+  }
+#endif
+
 #ifdef ANDROID
   changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,
                        ui_settings.display.full_screen);
   native_view->SetFullScreen(Java::GetEnv(), ui_settings.display.full_screen);
 #endif
 
-  bool orientation_changed = false;
-
-  if (Display::RotateSupported()) {
-    orientation_changed =
-      SaveValueEnum(Orientation, ProfileKeys::MapOrientation,
-                    ui_settings.display.orientation);
-    changed |= orientation_changed;
-  }
-
   changed |= SaveValueEnum(DarkMode, ProfileKeys::DarkMode,
                            ui_settings.dark_mode);
 
-  if (brightness != nullptr && brightness->IsWritable()) {
-#ifdef HAVE_DISPLAY_BRIGHTNESS_CONTROL
-    const unsigned old_percent = brightness->GetBrightnessPercent();
-    const unsigned new_percent = GetValueInteger(ScreenBrightness);
-    if (new_percent != old_percent)
-      brightness->SetBrightnessPercent(new_percent);
-#endif
-  }
+  if (SaveValueInteger(UIScale, ProfileKeys::UIScale,
+                       ui_settings.scale))
+    require_restart = changed = true;
 
 #ifdef DRAW_MOUSE_CURSOR
   changed |= SaveValueInteger(CursorSize, ProfileKeys::CursorSize,
@@ -208,19 +252,6 @@ DisplayConfigPanel::Save(bool &_changed) noexcept
     ui_settings.display.invert_cursor_colors);
 #endif
 
-  if (orientation_changed) {
-    assert(Display::RotateSupported());
-
-    if (!Display::Rotate(ui_settings.display.orientation))
-      LogString("Display rotation failed");
-
-#ifdef USE_POLL_EVENT
-    UI::event_queue->SetDisplayOrientation(ui_settings.display.orientation);
-#endif
-
-    CommonInterface::main_window->CheckResize();
-  }
-
   _changed |= changed;
   return true;
 }
@@ -230,5 +261,3 @@ CreateDisplayConfigPanel()
 {
   return std::make_unique<DisplayConfigPanel>();
 }
-
-#undef HAVE_DISPLAY_BRIGHTNESS_CONTROL

--- a/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/DisplayConfigPanel.cpp
@@ -15,6 +15,8 @@
 #include "Widget/RowFormWidget.hpp"
 #include "UIGlobals.hpp"
 #include "UtilsSettings.hpp"
+#include "Asset.hpp"
+#include "util/Macros.hpp"
 
 #ifdef ANDROID
 #include "Android/Main.hpp"
@@ -33,6 +35,7 @@
 #endif
 
 enum ControlIndex {
+  AppDisplayType,
 #ifdef ANDROID
   FullScreen,
 #endif
@@ -46,6 +49,22 @@ enum ControlIndex {
   CursorInverted,
 #endif
 };
+
+static constexpr StaticEnumChoice display_type_list[] = {
+  { DisplayType::LCD, NC_("Setting", "LCD"),
+    N_("Conventional LCD or OLED. Full scrolling animations.") },
+  { DisplayType::E_INK, NC_("Setting", "E-ink"),
+    N_("Monochrome electronic paper. Disables kinetic and smooth "
+       "scrolling.") },
+  { DisplayType::COLOR_E_INK, NC_("Setting", "Color e-ink"),
+    N_("Color electronic paper. Disables kinetic and smooth "
+       "scrolling like monochrome e-ink.") },
+  nullptr
+};
+
+static_assert(ARRAY_SIZE(display_type_list) ==
+              unsigned(DisplayType::COUNT) + 1,
+              "display_type_list must match DisplayType::COUNT");
 
 static constexpr StaticEnumChoice display_orientation_list[] = {
   { DisplayOrientation::DEFAULT,
@@ -92,6 +111,13 @@ DisplayConfigPanel::Prepare(ContainerWindow &parent,
 
   RowFormWidget::Prepare(parent, rc);
 
+  AddEnum(C_("Setting", "Display type"),
+          _("Select the display technology. E-ink modes disable kinetic "
+            "and smooth scrolling for slow refresh screens."),
+          display_type_list,
+          (unsigned)ui_settings.display.display_type);
+  SetExpertRow(AppDisplayType);
+
 #ifdef ANDROID
   AddBoolean(_("Full screen"), _("Run XCSoar in full screen mode"),
              ui_settings.display.full_screen);
@@ -137,6 +163,12 @@ DisplayConfigPanel::Save(bool &_changed) noexcept
   bool changed = false;
 
   UISettings &ui_settings = CommonInterface::SetUISettings();
+
+  if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
+                    ui_settings.display.display_type)) {
+    changed = true;
+    SetDisplayType(ui_settings.display.display_type);
+  }
 
 #ifdef ANDROID
   changed |= SaveValue(FullScreen, ProfileKeys::FullScreen,

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -24,8 +24,6 @@
 using namespace std::chrono;
 
 enum ControlIndex {
-  UIScale,
-  CustomDPI,
   InputFile,
 #ifdef HAVE_NLS
   LanguageFile,
@@ -75,33 +73,6 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
   const UISettings &settings = CommonInterface::GetUISettings();
 
   RowFormWidget::Prepare(parent, rc);
-
-  AddInteger(_("Text size"),
-             nullptr,
-             "%d %%", "%d", 75, 200, 5,
-             settings.scale);
-
-  WndProperty *wp_dpi = AddEnum(_("Display Resolution"),
-                                _("The display resolution is used to adapt line widths, "
-                                  "font size, landable size and more."));
-  if (wp_dpi != nullptr) {
-    static constexpr unsigned dpi_choices[] = {
-      120, 160, 240, 260, 280, 300, 340, 360, 400, 420, 520,
-    };
-    const unsigned *dpi_choices_end =
-      dpi_choices + sizeof(dpi_choices) / sizeof(dpi_choices[0]);
-
-    DataFieldEnum &df = *(DataFieldEnum *)wp_dpi->GetDataField();
-    df.AddChoice(0, _("Automatic"));
-    for (const unsigned *dpi = dpi_choices; dpi != dpi_choices_end; ++dpi) {
-      StaticString<20> buffer;
-      buffer.Format(_("%u dpi"), *dpi);
-      df.AddChoice(*dpi, buffer);
-    }
-    df.SetValue(settings.custom_dpi);
-    wp_dpi->RefreshDisplay();
-  }
-  SetExpertRow(CustomDPI);
 
   AddFile(_("Events"),
           _("The Input Events file defines the menu system and how XCSoar responds to "
@@ -231,14 +202,6 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
 {
   UISettings &settings = CommonInterface::SetUISettings();
   bool changed = false;
-
-  if (SaveValueInteger(UIScale, ProfileKeys::UIScale,
-                       settings.scale))
-    require_restart = changed = true;
-
-  if (SaveValueEnum(CustomDPI, ProfileKeys::CustomDPI,
-                    settings.custom_dpi))
-    require_restart = changed = true;
 
   if (SaveValueFileReader(InputFile, ProfileKeys::InputFile))
     require_restart = changed = true;

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -12,10 +12,8 @@
 #include "UIGlobals.hpp"
 #include "Asset.hpp"
 #include "Menu/ShowButton.hpp"
-#include "util/Macros.hpp"
 
 enum ControlIndex {
-  AppDisplayType,
   AppInfoBoxGeom,
   InfoBoxTitleScale,
   TabDialogStyle,
@@ -27,22 +25,6 @@ enum ControlIndex {
   ShowZoomButton,
   ShowQuickMenuButton,
 };
-
-static constexpr StaticEnumChoice display_type_list[] = {
-  { DisplayType::LCD, NC_("Setting", "LCD"),
-    N_("Conventional LCD or OLED. Full scrolling animations.") },
-  { DisplayType::E_INK, NC_("Setting", "E-ink"),
-    N_("Monochrome electronic paper. Disables kinetic and smooth "
-       "scrolling.") },
-  { DisplayType::COLOR_E_INK, NC_("Setting", "Color e-ink"),
-    N_("Color electronic paper. Disables kinetic and smooth "
-       "scrolling like monochrome e-ink.") },
-  nullptr
-};
-
-static_assert(ARRAY_SIZE(display_type_list) ==
-              unsigned(DisplayType::COUNT) + 1,
-              "display_type_list must match DisplayType::COUNT");
 
 static constexpr StaticEnumChoice info_box_geometry_list[] = {
   { InfoBoxSettings::Geometry::SPLIT_8,
@@ -154,13 +136,6 @@ LayoutConfigPanel::Prepare(ContainerWindow &parent,
 
   RowFormWidget::Prepare(parent, rc);
 
-  AddEnum(C_("Setting", "Display type"),
-          _("Select the display technology. E-ink modes disable kinetic "
-            "and smooth scrolling for slow refresh screens."),
-          display_type_list,
-          (unsigned)ui_settings.display.display_type);
-  SetExpertRow(AppDisplayType);
-
   AddEnum(_("InfoBox geometry"),
           _("A list of possible InfoBox layouts. Do some trials to find the best for your screen size."),
           info_box_geometry_list, (unsigned)ui_settings.info_boxes.geometry);
@@ -234,12 +209,6 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
 
   UISettings &ui_settings = CommonInterface::SetUISettings();
   saved = true;
-
-  if (SaveValueEnum(AppDisplayType, ProfileKeys::DisplayType,
-                    ui_settings.display.display_type)) {
-    changed = true;
-    SetDisplayType(ui_settings.display.display_type);
-  }
 
   bool info_box_geometry_changed = false;
 


### PR DESCRIPTION
## Summary
- Move Display type from Look → Layout to Look → Display (LCD / e-ink belongs with orientation and brightness, not InfoBox layout).
- Move Text size and Display resolution from Look → Language, Input onto the same Display page.
- Group Display type, resolution, and orientation at the top, then brightness, full screen, dark mode, text size, and cursor.

## Test plan
- [ ] Open Config → Look → Display and confirm Display type, Display resolution, Display orientation, brightness, full screen, dark mode, text size, and cursor.
- [ ] Confirm Expert still hides Display type and Display resolution.
- [ ] Confirm Look → Layout no longer has Display type, and Look → Language, Input no longer has Text size or Display resolution.
- [ ] Change Text size / Display resolution, save, and confirm a restart is requested; Display type still applies immediately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display type selection to Display settings.
  * Added display resolution (DPI) controls.
  * Added a Text size setting for adjusting UI scale.
  * Display changes now support restart-required updates where applicable.

* **Improvements**
  * Reorganized Display settings for easier access.
  * Moved display type, resolution, and text size options from other settings panels into Display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->