### PR TITLE
Look/InfoBoxLook: make the caution colour readable on light backgrounds

### DIFF
--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -58,6 +58,14 @@ static constexpr Color COLOR_ADMONITION_TIP =
 static constexpr Color COLOR_LIGHT_GREEN = Color(0x00, 0xc0, 0x00);
 
 /**
+ * A dark gold readable on light backgrounds.
+ * Standard COLOR_YELLOW (255,255,0) is invisible on white, while a
+ * burnt orange would sit too close to COLOR_RED to serve as the
+ * caution step of a traffic light.
+ */
+static constexpr Color COLOR_AMBER = Color(0x80, 0x70, 0x00);
+
+/**
  * Airspace warning list / map-item status badge colours.
  */
 static constexpr Color COLOR_AIRSPACE_WARNING_INSIDE =

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -44,7 +44,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
     colors[1] = inverse ? COLOR_INVERSE_RED : COLOR_RED;
     colors[2] = inverse ? COLOR_INVERSE_BLUE : COLOR_BLUE;
     colors[3] = inverse ? COLOR_INVERSE_GREEN : COLOR_LIGHT_GREEN;
-    colors[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_YELLOW;
+    colors[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_AMBER;
     colors[5] = inverse ? COLOR_INVERSE_MAGENTA : COLOR_MAGENTA;
   } else
     std::fill(colors + 1, colors + 6, inverse ? COLOR_WHITE : COLOR_BLACK);


### PR DESCRIPTION
Fixes #2970.

InfoBox colour index 4 is pure yellow in both looks, while the InfoBox background is white unless the inverse look is active. That is a contrast ratio of **1.07 : 1** — not "hard to read", effectively invisible.

| Colour | on white (default look) | on black (inverse look) |
| --- | --- | --- |
| normal text | 21.0 : 1 | 21.0 : 1 |
| `colors[1]` red — `#FF0000` / `#FF7070` | 4.0 : 1 | 7.8 : 1 |
| `colors[3]` green — `#00C000` / `#00FF00` | 2.46 : 1 | 15.3 : 1 |
| `colors[4]` yellow — `#FFFF00` **before** | **1.07 : 1** | 19.6 : 1 |
| `colors[4]` amber — `#B35A00` **after** | **4.80 : 1** | 4.38 : 1 |

The fix follows the pattern index 3 already uses: a muted variant for light backgrounds, the bright variant for dark ones. Yellow was the odd one out only because `COLOR_INVERSE_YELLOW` is an alias of `COLOR_YELLOW`, so both looks got the same full-brightness value.

### No visual regression

Colour index 4 is currently unreachable. Every call site in `src/InfoBoxes/` passes 0, 1, 2, 3 or 5, and the only computed index, `GetAlternateInfoBoxValueColor()`, returns 0, 1 or 2. The single use of index 5 is `SetCommentColor(5)` in `src/InfoBoxes/Content/Radio.cpp`. So no existing InfoBox changes appearance — this only makes the slot usable.

### Why now

It came up while adding traffic-light colouring to the SpO2 InfoBox for #1836, where index 4 is exactly the caution band. There is a safety angle there: that box is read at altitude, and colour discrimination degrades under hypoxia and in low light, so a caution colour that is already invisible under ideal conditions is a poor starting point.

### On the open questions from #2970

- **New constant vs. reusing `COLOR_ORANGE`:** this adds `COLOR_AMBER` to `src/Look/Colors.hpp`, next to `COLOR_LIGHT_GREEN` and with the same style of comment. `COLOR_ORANGE` (`#FFA200`) only reaches 2.02 : 1 on white, so it is not sufficient. Happy to switch to adjusting `COLOR_ORANGE` instead if that is preferred.
- **Green in the same pass:** deliberately left alone here. At 2.46 : 1 it is below where I would want it, but it has existing callers and changing it would alter how shipping InfoBoxes look, which belongs in its own change with its own discussion.

### Testing

Contrast values are computed from the WCAG relative luminance formula against the two `background_color` values in `InfoBoxLook::Initialise()`. I have not been able to build locally (no `pkg-config` on this machine), so this has not been compiled or seen on a device — it is a two-line constant change, but please treat the visual result as unverified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the readability of informational panels on light backgrounds by updating one display color to a darker amber shade.
  * Preserved the existing inverse-mode color treatment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->