### PR TITLE
Device: read blood oxygen saturation from BLE pulse oximeters

### DIFF
--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -313,6 +313,8 @@ final class BluetoothHelper
         features |= DetectDeviceListener.FEATURE_BLE_SERIAL;
       else if (BluetoothUuids.HEART_RATE_SERVICE.equals(uuid))
         features |= DetectDeviceListener.FEATURE_HEART_RATE;
+      else if (BluetoothUuids.PULSE_OXIMETER_SERVICE.equals(uuid))
+        features |= DetectDeviceListener.FEATURE_PULSE_OXIMETER;
       else if (BluetoothUuids.FLYTEC_SENSBOX_SERVICE.equals(uuid))
         features |= DetectDeviceListener.FEATURE_FLYTEC_SENSBOX;
     }

--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -134,8 +134,17 @@ public final class BluetoothSensor
     if (d == null)
       return false;
 
+    /* the PLX "Spot-check Measurement" characteristic is indicate-only,
+       and writing the notification bit to such a characteristic enables
+       nothing at all */
+    final boolean indicate =
+      (c.getProperties() & BluetoothGattCharacteristic.PROPERTY_NOTIFY) == 0 &&
+      (c.getProperties() & BluetoothGattCharacteristic.PROPERTY_INDICATE) != 0;
+
     gatt.setCharacteristicNotification(c, true);
-    d.setValue(BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
+    d.setValue(indicate
+               ? BluetoothGattDescriptor.ENABLE_INDICATION_VALUE
+               : BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE);
     return gatt.writeDescriptor(d);
   }
 
@@ -194,6 +203,98 @@ public final class BluetoothSensor
     listener.onHeartRateSensor(bpm);
   }
 
+  /**
+   * Bits of the PLX "Measurement Status" field which mean the value must
+   * not be shown to the pilot: the sensor either declares the
+   * measurement unusable, or marks it as demonstration or test data.
+   */
+  private static final int PLX_MEASUREMENT_REJECT =
+    (1 << 10) | /* Data for Demonstration */
+    (1 << 11) | /* Data for Testing */
+    (1 << 13) | /* Measurement Unavailable */
+    (1 << 14) | /* Questionable Measurement Detected */
+    (1 << 15);  /* Invalid Measurement Detected */
+
+  /**
+   * Locate the optional "Measurement Status" field, which sits behind a
+   * different number of optional fields in each of the two
+   * characteristics.
+   *
+   * @return the offset of the field, or -1 if the sensor did not send one
+   */
+  private static int findPLXMeasurementStatus(int flags, boolean spot_check) {
+    /* both characteristics begin with the flags byte and four bytes of
+       measurement, either SpO2 and pulse rate or the "SpO2PR-Normal"
+       pair */
+    int offset = 5;
+
+    if (spot_check) {
+      if ((flags & 0x02) == 0)
+        return -1;
+
+      if ((flags & 0x01) != 0)
+        /* skip the timestamp */
+        offset += 7;
+    } else {
+      if ((flags & 0x04) == 0)
+        return -1;
+
+      if ((flags & 0x01) != 0)
+        /* skip "SpO2PR-Fast" */
+        offset += 4;
+
+      if ((flags & 0x02) != 0)
+        /* skip "SpO2PR-Slow" */
+        offset += 4;
+    }
+
+    return offset;
+  }
+
+  /**
+   * Parse a PLX measurement and report the blood oxygen saturation.
+   *
+   * Both the "PLX Spot-Check Measurement" and the "PLX Continuous
+   * Measurement" characteristic start with a flags byte followed by
+   * SpO2 and the pulse rate, each an IEEE-11073 16 bit SFLOAT, so the
+   * same code handles both; only the optional fields behind them
+   * differ.
+   */
+  private void readPLXMeasurement(BluetoothGattCharacteristic c,
+                                  boolean spot_check) {
+    final Integer flags =
+      c.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT8, 0);
+    if (flags == null)
+      return;
+
+    final int status_offset = findPLXMeasurementStatus(flags, spot_check);
+    if (status_offset >= 0) {
+      final Integer status =
+        c.getIntValue(BluetoothGattCharacteristic.FORMAT_UINT16,
+                      status_offset);
+      if (status == null || (status & PLX_MEASUREMENT_REJECT) != 0)
+        /* truncated packet, or the sensor itself says the value is not
+           fit to be used */
+        return;
+    }
+
+    final Float spo2 = c.getFloatValue(BluetoothGattCharacteristic.FORMAT_SFLOAT,
+                                       1);
+    if (spo2 == null || spo2.isNaN())
+      /* the sensor reports "not available" while it is still
+         measuring */
+      return;
+
+    final int percent = Math.round(spo2);
+    if (percent <= 0 || percent > 100)
+      /* SFLOAT has several reserved values (NaN, NRes, infinity)
+         which Android may pass through as numbers; those are outside
+         the plausible range and get dropped here */
+      return;
+
+    listener.onBloodOxygenSensor(percent);
+  }
+
   static long toUnsignedLong(int x) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
       // Android 7 "Nougat" supports Java 8
@@ -215,6 +316,14 @@ public final class BluetoothSensor
     try {
       if (BluetoothUuids.HEART_RATE_MEASUREMENT_CHARACTERISTIC.equals(c.getUuid())) {
         readHeartRateMeasurement(c);
+      }
+
+      if (BluetoothUuids.PLX_CONTINUOUS_MEASUREMENT_CHARACTERISTIC.equals(c.getUuid())) {
+        readPLXMeasurement(c, false);
+      }
+
+      if (BluetoothUuids.PLX_SPOT_CHECK_MEASUREMENT_CHARACTERISTIC.equals(c.getUuid())) {
+        readPLXMeasurement(c, true);
       }
 
       if (BluetoothUuids.ENGINE_SENSORS_CHARACTERISTIC.equals(c.getUuid())) {

--- a/android/src/BluetoothUuids.java
+++ b/android/src/BluetoothUuids.java
@@ -25,6 +25,23 @@ public final class BluetoothUuids {
     UUID.fromString("00002A37-0000-1000-8000-00805F9B34FB");
 
   /**
+   * The Bluetooth SIG "Pulse Oximeter Service", used by sensors which
+   * measure the blood oxygen saturation (SpO2).
+   *
+   * @see https://www.bluetooth.com/specifications/specs/pulse-oximeter-service-1-0-1/
+   */
+  static final UUID PULSE_OXIMETER_SERVICE =
+    UUID.fromString("00001822-0000-1000-8000-00805F9B34FB");
+
+  /** a single measurement, sent when the sensor has finished measuring */
+  static final UUID PLX_SPOT_CHECK_MEASUREMENT_CHARACTERISTIC =
+    UUID.fromString("00002A5E-0000-1000-8000-00805F9B34FB");
+
+  /** a continuous stream of measurements */
+  static final UUID PLX_CONTINUOUS_MEASUREMENT_CHARACTERISTIC =
+    UUID.fromString("00002A5F-0000-1000-8000-00805F9B34FB");
+
+  /**
    * @see https://sites.google.com/view/ppgmeter/startpage
    * Engine sensors service and characteristic
    */
@@ -102,6 +119,7 @@ public final class BluetoothUuids {
   public static final UUID[] getAllServiceUuids() {
       return new UUID[] { GENERIC_ACCESS_SERVICE,
                           HEART_RATE_SERVICE,
+                          PULSE_OXIMETER_SERVICE,
                           ENGINE_SENSORS_SERVICE,
                           HM10_SERVICE,
                           NORDIC_UART_SERVICE,
@@ -115,6 +133,8 @@ public final class BluetoothUuids {
     return new UUID[] { CLIENT_CHARACTERISTIC_CONFIGURATION,
                         DEVICE_NAME_CHARACTERISTIC,
                         HEART_RATE_MEASUREMENT_CHARACTERISTIC,
+                        PLX_SPOT_CHECK_MEASUREMENT_CHARACTERISTIC,
+                        PLX_CONTINUOUS_MEASUREMENT_CHARACTERISTIC,
                         ENGINE_SENSORS_CHARACTERISTIC,
                         HM10_RX_TX_CHARACTERISTIC,
                         NORDIC_UART_RX_CHARACTERISTIC,

--- a/android/src/DetectDeviceListener.java
+++ b/android/src/DetectDeviceListener.java
@@ -15,6 +15,7 @@ interface DetectDeviceListener {
 
   static final long FEATURE_BLE_SERIAL = 0x1;
   static final long FEATURE_HEART_RATE = 0x2;
+  static final long FEATURE_PULSE_OXIMETER = 0x8;
   static final long FEATURE_FLYTEC_SENSBOX = 0x4;
 
   /**

--- a/android/src/NativeSensorListener.java
+++ b/android/src/NativeSensorListener.java
@@ -68,6 +68,9 @@ final class NativeSensorListener implements SensorListener {
   public native void onHeartRateSensor(int bpm);
 
   @Override
+  public native void onBloodOxygenSensor(int spo2);
+
+  @Override
   public native void onVoltageValues(int temp_adc, int voltage_index,
                                      int volt_adc);
 

--- a/android/src/SensorListener.java
+++ b/android/src/SensorListener.java
@@ -34,6 +34,11 @@ public interface SensorListener {
   void onI2CbaroSensor(int index, int sensorType, int pressure);
   void onVarioSensor(float vario);
   void onHeartRateSensor(int bpm);
+
+  /**
+   * @param spo2 the blood oxygen saturation [percent]
+   */
+  void onBloodOxygenSensor(int spo2);
   /**
    * @param[in] has_cht_temp Is the Engine Cylinder Head Temperature sensor present?
    * @param[in] cht_temp Engine Cylinder Head Temperature.

--- a/src/Android/NativeSensorListener.cpp
+++ b/src/Android/NativeSensorListener.cpp
@@ -231,6 +231,20 @@ Java_org_xcsoar_NativeSensorListener_onHeartRateSensor(JNIEnv *env,
   listener.OnHeartRateSensor(bpm);
 }
 
+gcc_visibility_default
+JNIEXPORT void JNICALL
+Java_org_xcsoar_NativeSensorListener_onBloodOxygenSensor(JNIEnv *env,
+                                                         jobject obj,
+                                                         jint spo2)
+{
+  jlong ptr = env->GetLongField(obj, NativeSensorListener::ptr_field);
+  if (ptr == 0)
+    return;
+
+  auto &listener = *(SensorListener *)ptr;
+  listener.OnBloodOxygenSensor(spo2);
+}
+
 JNIEXPORT void JNICALL
 Java_org_xcsoar_NativeSensorListener_onVoltageValues(JNIEnv *env, jobject obj,
                                                      jint temp_adc,

--- a/src/Device/AndroidSensors.cpp
+++ b/src/Device/AndroidSensors.cpp
@@ -158,6 +158,20 @@ DeviceDescriptor::OnHeartRateSensor(unsigned bpm) noexcept
 }
 
 void
+DeviceDescriptor::OnBloodOxygenSensor(unsigned spo2) noexcept
+{
+  const auto e = BeginEdit();
+  NMEAInfo &basic = *e;
+
+  basic.UpdateClock();
+  basic.alive.Update(basic.clock);
+  basic.blood_oxygen = spo2;
+  basic.blood_oxygen_available.Update(basic.clock);
+
+  e.Commit();
+}
+
+void
 DeviceDescriptor::OnEngineSensors(bool has_cht,
                                   Temperature cht,
                                   bool has_egt,

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -661,6 +661,7 @@ private:
                        AtmosphericPressure pressure) noexcept override;
   void OnVarioSensor(float vario) noexcept override;
   void OnHeartRateSensor(unsigned bpm) noexcept override;
+  void OnBloodOxygenSensor(unsigned spo2) noexcept override;
   void OnEngineSensors(bool has_cht,
                        Temperature cht,
                        bool has_egt,

--- a/src/Device/SensorListener.hpp
+++ b/src/Device/SensorListener.hpp
@@ -42,6 +42,11 @@ public:
                                AtmosphericPressure pressure) noexcept = 0;
   virtual void OnVarioSensor(float vario) noexcept = 0;
   virtual void OnHeartRateSensor(unsigned bpm) noexcept = 0;
+
+  /**
+   * @param spo2 the blood oxygen saturation [percent]
+   */
+  virtual void OnBloodOxygenSensor(unsigned spo2) noexcept = 0;
   /**
    * @param[in] has_cht Is the Engine Cylinder Head Temperature sensor present?
    * @param[in] cht Engine Cylinder Head Temperature.

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1211,6 +1211,14 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentPreviousWaypoint>::Create,
   },
 
+  // e_BloodOxygen
+  {
+    N_("Blood Oxygen"),
+    N_("SpO2"),
+    N_("Blood oxygen saturation in percent, from a Bluetooth pulse oximeter."),
+    UpdateInfoBoxBloodOxygen,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -30,6 +30,19 @@ UpdateInfoBoxHeartRate(InfoBoxData &data) noexcept
 }
 
 void
+UpdateInfoBoxBloodOxygen(InfoBoxData &data) noexcept
+{
+  const auto &basic = CommonInterface::Basic();
+
+  if (!basic.blood_oxygen_available) {
+    data.SetInvalid();
+    return;
+  }
+
+  data.SetValueFromPercent(basic.blood_oxygen);
+}
+
+void
 UpdateInfoBoxGLoad(InfoBoxData &data) noexcept
 {
   if (!CommonInterface::Basic().acceleration.available) {

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -8,6 +8,7 @@
 #include "Renderer/HorizonRenderer.hpp"
 #include "Hardware/PowerGlobal.hpp"
 #include "system/SystemLoad.hpp"
+#include "Formatter/TimeFormatter.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
 #include "Look/Look.hpp"
@@ -29,17 +30,100 @@ UpdateInfoBoxHeartRate(InfoBoxData &data) noexcept
   data.FmtValue("{}", basic.heart_rate);
 }
 
+/**
+ * Blood oxygen saturation below which the value is shown in yellow.
+ * Above it the value is drawn in the normal text colour.
+ *
+ * There is no official limit for aviation; this is the value recommended
+ * by the AOPA Air Safety Institute and in gliding literature, and it is
+ * also the alarm limit most commonly used on hospital monitors.
+ */
+static constexpr unsigned BLOOD_OXYGEN_CAUTION = 90;
+
+/**
+ * Blood oxygen saturation below which the value is shown in red.  This is
+ * the factory default alarm limit of pulse oximeters that are common in
+ * aviation, and the value at which gliding literature advises to use
+ * supplemental oxygen.
+ */
+static constexpr unsigned BLOOD_OXYGEN_WARNING = 85;
+
+/**
+ * How far the value has to rise above a threshold again before the colour
+ * improves.  Consumer pulse oximeters are only accurate to a few percent,
+ * so without this the colour would flicker while the value hovers around a
+ * threshold.  A deteriorating value changes the colour immediately.
+ */
+static constexpr unsigned BLOOD_OXYGEN_HYSTERESIS = 2;
+
+/**
+ * Show how old the value is once it exceeds this age.  A working pulse
+ * oximeter reports every few seconds; the pilot cannot tell a current
+ * reading from an old one, and the reading already lags the actual
+ * saturation by a minute or more, so an old value should not be presented
+ * as if it were current.
+ */
+static constexpr auto BLOOD_OXYGEN_SHOW_AGE = std::chrono::seconds(30);
+
+static constexpr unsigned BLOOD_OXYGEN_LEVEL_OK = 0;
+static constexpr unsigned BLOOD_OXYGEN_LEVEL_CAUTION = 1;
+static constexpr unsigned BLOOD_OXYGEN_LEVEL_WARNING = 2;
+
+[[gnu::const]]
+static unsigned
+BloodOxygenLevel(unsigned spo2, unsigned previous) noexcept
+{
+  if (spo2 < BLOOD_OXYGEN_WARNING +
+      (previous >= BLOOD_OXYGEN_LEVEL_WARNING ? BLOOD_OXYGEN_HYSTERESIS : 0))
+    return BLOOD_OXYGEN_LEVEL_WARNING;
+
+  if (spo2 < BLOOD_OXYGEN_CAUTION +
+      (previous >= BLOOD_OXYGEN_LEVEL_CAUTION ? BLOOD_OXYGEN_HYSTERESIS : 0))
+    return BLOOD_OXYGEN_LEVEL_CAUTION;
+
+  return BLOOD_OXYGEN_LEVEL_OK;
+}
+
 void
 UpdateInfoBoxBloodOxygen(InfoBoxData &data) noexcept
 {
   const auto &basic = CommonInterface::Basic();
 
+  /* the level the hysteresis compares against; only ever touched from the
+     user interface thread */
+  static unsigned level = BLOOD_OXYGEN_LEVEL_OK;
+
   if (!basic.blood_oxygen_available) {
+    /* a value that arrives after a gap is judged without hysteresis */
+    level = BLOOD_OXYGEN_LEVEL_OK;
     data.SetInvalid();
     return;
   }
 
+  level = BloodOxygenLevel(basic.blood_oxygen, level);
+
   data.SetValueFromPercent(basic.blood_oxygen);
+
+  static constexpr unsigned colors[] = {
+    0, // the normal text colour
+    4, // yellow
+    1, // red
+  };
+
+  data.SetValueColor(colors[level]);
+
+  /* this is the age of the reception, not of the measurement: the sensor
+     may have measured considerably earlier than it sent the value */
+  const Validity now{basic.clock};
+  if (now.IsValid()) {
+    const auto age = now.GetTimeDifference(basic.blood_oxygen_available);
+    if (age >= BLOOD_OXYGEN_SHOW_AGE) {
+      data.SetComment(FormatTimespanSmart(age).c_str());
+      return;
+    }
+  }
+
+  data.SetCommentInvalid();
 }
 
 void

--- a/src/InfoBoxes/Content/Other.hpp
+++ b/src/InfoBoxes/Content/Other.hpp
@@ -9,6 +9,9 @@ void
 UpdateInfoBoxHeartRate(InfoBoxData &data) noexcept;
 
 void
+UpdateInfoBoxBloodOxygen(InfoBoxData &data) noexcept;
+
+void
 UpdateInfoBoxGLoad(InfoBoxData &data) noexcept;
 
 void

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -155,6 +155,7 @@ namespace InfoBoxFactory
     e_QNH, /* Current QNH pressure setting; tap to adjust manually */
     e_ActiveWaypoint, /* Active waypoint infobox: shows the current task's next waypoint name (or Goto waypoint if no task), arrival altitude diff, and distance */
     e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
+    e_BloodOxygen, /* Blood oxygen saturation (SpO2) from a BLE pulse oximeter */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/Look/Colors.hpp
+++ b/src/Look/Colors.hpp
@@ -58,6 +58,12 @@ static constexpr Color COLOR_ADMONITION_TIP =
 static constexpr Color COLOR_LIGHT_GREEN = Color(0x00, 0xc0, 0x00);
 
 /**
+ * A dark amber readable on light backgrounds.
+ * Standard COLOR_YELLOW (255,255,0) is invisible on white.
+ */
+static constexpr Color COLOR_AMBER = Color(0xb3, 0x5a, 0x00);
+
+/**
  * Airspace warning list / map-item status badge colours.
  */
 static constexpr Color COLOR_AIRSPACE_WARNING_INSIDE =

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -44,7 +44,7 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
     colors[1] = inverse ? COLOR_INVERSE_RED : COLOR_RED;
     colors[2] = inverse ? COLOR_INVERSE_BLUE : COLOR_BLUE;
     colors[3] = inverse ? COLOR_INVERSE_GREEN : COLOR_LIGHT_GREEN;
-    colors[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_YELLOW;
+    colors[4] = inverse ? COLOR_INVERSE_YELLOW : COLOR_AMBER;
     colors[5] = inverse ? COLOR_INVERSE_MAGENTA : COLOR_MAGENTA;
   } else
     std::fill(colors + 1, colors + 6, inverse ? COLOR_WHITE : COLOR_BLACK);

--- a/src/NMEA/Info.cpp
+++ b/src/NMEA/Info.cpp
@@ -144,6 +144,7 @@ NMEAInfo::Reset() noexcept
   humidity_available.Clear();
 
   heart_rate_available.Clear();
+  blood_oxygen_available.Clear();
 
   engine_noise_level_available.Clear();
 
@@ -224,6 +225,11 @@ NMEAInfo::Expire() noexcept
   settings.Expire(clock);
   external_wind_available.Expire(clock, std::chrono::minutes(10));
   heart_rate_available.Expire(clock, std::chrono::seconds(10));
+
+  /* a finger pulse oximeter already lags the actual saturation by two
+     minutes or more, and a glider reaches a very different altitude
+     within a few minutes, so an old value misleads rather than informs */
+  blood_oxygen_available.Expire(clock, std::chrono::minutes(3));
   temperature_available.Expire(clock, std::chrono::seconds(30));
   humidity_available.Expire(clock, std::chrono::seconds(30));
   engine_noise_level_available.Expire(clock, std::chrono::seconds(30));
@@ -331,6 +337,9 @@ NMEAInfo::Complement(const NMEAInfo &add) noexcept
 
   if (heart_rate_available.Complement(add.heart_rate_available))
     heart_rate = add.heart_rate;
+
+  if (blood_oxygen_available.Complement(add.blood_oxygen_available))
+    blood_oxygen = add.blood_oxygen;
 
   if (engine_noise_level_available.Complement(add.engine_noise_level_available))
     engine_noise_level = add.engine_noise_level;

--- a/src/NMEA/Info.hpp
+++ b/src/NMEA/Info.hpp
@@ -322,6 +322,11 @@ struct NMEAInfo {
   Validity heart_rate_available;
   unsigned heart_rate;
 
+  Validity blood_oxygen_available;
+
+  /** blood oxygen saturation (SpO2) [percent] */
+  unsigned blood_oxygen;
+
   Validity engine_noise_level_available;
   unsigned engine_noise_level;
 


### PR DESCRIPTION
Implements #1836.

Adds support for the Bluetooth SIG **Pulse Oximeter Service (0x1822)**, so sensors reporting SpO2 over standard GATT work the same way heart rate sensors already do, plus an InfoBox that colours the value and shows how old it is.

> [!NOTE]
> **Includes the caution-colour fix.** The caution band needs InfoBox colour index 4, which is pure yellow on a white background today — a contrast ratio of 1.07 : 1. That slot is made usable by the first commit here, `Look/InfoBoxLook: make the caution colour readable on light backgrounds`. It was offered separately as #2971, which has since been closed, so it now belongs to this PR and is reviewed as part of it.

### What it does

- Parses both **PLX Spot-Check (0x2A5E)** and **PLX Continuous (0x2A5F)**. Both begin with a flags byte followed by SpO2 as an IEEE-11073 SFLOAT, so one parser handles both. SFLOAT's reserved "not available" values, which a sensor emits while still measuring, are rejected by a plausibility check on the percentage.
- **Traffic-light colouring**: normal text colour at or above 90 %, amber 85–89 %, red below 85 %.
- **Age display**: the comment line shows the age of the reading once it exceeds 30 s.
- **Validity: 3 minutes.**

### Where the thresholds come from

Documented at length in #1836; the short version, because these are safety-adjacent numbers and should not look arbitrary:

There is **no official aviation SpO2 threshold** — not FAA, not EASA, and Part-SAO (which is what actually governs sailplanes, rather than Part-NCO) contains no figures at all. FAA AC 61-107B explicitly cautions against treating a pulse oximeter as the sole hypoxia indicator.

- **90 %** is the value used by the [AOPA Air Safety Institute](https://download.aopa.org/asf/Air-Safety-Institute-Safety-Alert_Hypoxia.pdf) and in gliding literature, and is the most commonly recommended ICU alarm limit.
- **85 %** is the factory default low alarm on Nonin devices and the second warning threshold in the Aithre Illyrian app, and is where gliding literature advises donning oxygen.
- **92 % was deliberately not used** for the caution band: real measurements in unpressurised aircraft at 8,000 ft are already 92 ± 1 %, so it would sit on caution for much of a normal cross-country flight.

**Hysteresis:** a deteriorating value changes colour immediately; recovering across a threshold requires 2 percentage points of margin. Consumer oximeters are only accurate to about ±2 (ARMS), so without this the colour flickers when the value sits near a threshold.

**Why 3 minutes and not longer:** a finger pulse oximeter's own desaturation response time is 130 s normothermic and **215 s with cold fingers** ([MacLeod et al., Anaesthesia 2005](https://pubmed.ncbi.nlm.nih.gov/15601275/)) — cold fingers being the normal case in a glider. A generous display window stacks staleness on top of staleness.

The consequence is deliberate: **a sensor that only reports every 5–10 minutes will read "invalid" between measurements.** A device with that duty cycle cannot support a hypoxia indication in a cockpit, and making it look as though it can is the larger risk.

### Known limitation: the age is reception time, not measurement time

`DeviceDescriptor::OnBloodOxygenSensor()` stamps the value when the BLE notification arrives. The PLX Spot-Check characteristic has an optional timestamp field that is not parsed, so for a sensor that buffers and transmits late the displayed age is **smaller than the true age**.

This is the failure mode behind [NTSB Safety Alert SA-017](https://www.ntsb.gov/Advocacy/safety-alerts/Documents/SA-017.pdf) on in-cockpit NEXRAD, which documents two fatal accidents where the displayed age was about a minute while the data was 5–8 minutes old. The 3-minute validity bounds the exposure here, and the code comment states plainly what the number means.

Parsing that timestamp has its own problems — the Continuous characteristic has no timestamp field at all, the spot-check timestamp is a wall-clock date-time in an unspecified time zone, and the flags carry a "Device Clock is Not Set" bit precisely because device clocks often are not. Left out on purpose; happy to follow up separately.

### Testing

**Offline test of the PLX parsing.** The real `BluetoothSensor.java` compiled against stub Android classes, with `readPLXMeasurement()` and `findPLXMeasurementStatus()` driven by reflection. `getIntValue()` and `getFloatValue()` were reimplemented exactly as the Android Open Source Project does, so that this code is what gets tested rather than my own arithmetic.

25 assertions pass: the status-field offset in every flag combination of both characteristics, the normal case, exponent handling and rounding, values above 100, zero and negative, all five rejection bits individually, a harmless status bit that must *not* reject, and truncated packets. Three deliberate defects — timestamp offset 7 → 6, plausibility limit 100 → 1000, one rejection bit removed — were all caught, so the test does discriminate.

**Hardware test.** Pixel 3a (Android 12) against a BLE peripheral simulator written for macOS (CoreBluetooth, Pulse Oximeter `0x1822` with both `0x2A5F` and `0x2A5E`, plus Heart Rate `0x180D`), so packet contents could be controlled exactly. XCSoar connected, discovered the services and subscribed to all three characteristics.

| Case | Result |
|---|---|
| 97 % / 72 bpm | shown as 97 % |
| 88 % | shown yellow (caution) |
| 80 % | shown red (warning) |
| 100 % and 1 % | accepted |
| 101 % | rejected — display kept the previous value |
| "Invalid Measurement" bit set while the value changes | rejected; clearing the bit resumes immediately |
| Spot-check `0x2A5E` via **indicate**, continuous off | works — 93 % |
| Spot-check **with timestamp** (the +7 offset) | 91 % parsed correctly |
| Invalid bit *behind* the timestamp | correctly rejected |
| SpO2 stops while heart rate continues | value ages, comment shows "43 sec" |
| after roughly three minutes | value disappears |

The indicate path is worth singling out: it had never been exercised, since @alenz-68's c-med alpha uses the continuous characteristic.

**On real hardware.** @alenz-68 tested a build carrying these commits with a [c-med alpha](https://www.cosinuss.com/de/produkte/im-ohr-sensoren/c-med-alpha/) and reported correct heart rate and SpO2 readings in #1836.

**Worth knowing.** If the sensor stops sending *anything*, the value disappears after about ten seconds rather than after three minutes: `DeviceBlackboard::Merge()` skips devices that are no longer `alive`, and `alive` expires after ten seconds. The three-minute limit only applies while the device keeps sending something else. Not a defect — a stale value vanishing is the safe outcome — but it means the age display is only visible for a sensor that keeps delivering other data.

**Observation, not a change request.** `spo2.isNaN()` can never fire: Android computes SFLOAT as mantissa × 10^exponent without handling reserved values, so NaN arrives as `2047.0` and NRes as `-2048.0`. What rejects them is the `percent <= 0 || percent > 100` guard, as the comment above it implies.

---

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [x] Commit messages explain *why* the change was made, not just *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit must compile)
- [x] One commit per logical change (don't mix refactoring with feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

> The one box left unticked is deliberate: the commits are atomic and each changes one thing, but only the branch tip has been through CI. I have not built the three commits individually, so I cannot claim that every one of them compiles on its own. Say the word and I will check.

---

- [x] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bluetooth pulse oximeter support for continuous and spot-check SpO₂ measurements.
  * Added a Blood Oxygen info box displaying saturation percentage and reading age.
  * Added normal, caution, and warning indicators for oxygen levels.

* **Enhancements**
  * Blood oxygen readings expire after three minutes when stale.
  * Invalid or out-of-range readings are ignored.
  * Improved caution-state visibility with an amber display color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
