### PR TITLE
Startup: run the data-layout migration before loading the profile

### DIFF
--- a/src/DataLayoutMigration.cpp
+++ b/src/DataLayoutMigration.cpp
@@ -225,22 +225,16 @@ UpdateProfileFromMoves(ProfileMap &profile, const MovedEntries &moved_entries)
 static void
 UpdateAllProfilesFromMoves(const MovedEntries &moved_entries)
 {
-  bool active_profile_changed = false;
-  for (const auto *entry : moved_entries)
-    active_profile_changed |= UpdateProfileReferences(entry->source_path,
-                                                      entry->destination_path);
-
-  if (active_profile_changed)
-    Profile::Save();
+  /* this runs BEFORE the profile is selected and loaded (see
+     LoadProfile() in Startup.cpp): update every profile file directly
+     on disk.  Profile::map is not loaded yet, so it must be neither
+     read nor saved here - a Profile::Save() at this point would
+     overwrite the selected profile file with an empty map */
 
   std::vector<AllocatedPath> profile_paths;
   CollectProfilePaths(profile_paths);
 
-  const Path active_profile_path = Profile::GetPath();
   for (const auto &profile_path : profile_paths) {
-    if (active_profile_path != nullptr && profile_path == active_profile_path)
-      continue;
-
     ProfileMap profile;
     try {
       Profile::LoadFile(profile, profile_path);
@@ -254,6 +248,17 @@ UpdateAllProfilesFromMoves(const MovedEntries &moved_entries)
       LogError(std::current_exception(), message.c_str());
     }
   }
+
+  /* an explicitly selected profile (e.g. a full-path "-profile=")
+     may itself have been moved: adjust only the in-memory path here,
+     the migrated file is then loaded normally by Profile::Load() */
+  const Path active_profile_path = Profile::GetPath();
+  if (active_profile_path != nullptr)
+    for (const auto *entry : moved_entries)
+      if (entry->source_path == active_profile_path) {
+        Profile::SetFiles(entry->destination_path);
+        break;
+      }
 }
 
 void

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -158,6 +158,13 @@ WasStartupCancelledByUser() noexcept
 static bool
 LoadProfile()
 {
+  /* run the data-layout migration BEFORE the profile is selected and
+     loaded: it moves root-level profiles into profiles/ - selecting or
+     loading first ends up with an empty profile that later overwrites
+     the migrated one on exit (settings loss on first start after an
+     upgrade) */
+  MigrateDataLayoutToSubdirs();
+
   if (Profile::GetPath() == nullptr &&
       !dlgStartupShowModal()) {
     LogString("LoadProfile: no profile path and startup dialog was cancelled");
@@ -166,7 +173,6 @@ LoadProfile()
   }
 
   Profile::Load();
-  MigrateDataLayoutToSubdirs();
   Profile::Use(Profile::map);
 
   Units::SetConfig(CommonInterface::GetUISettings().format.units);

--- a/test/src/TestDataLayoutMigration.cpp
+++ b/test/src/TestDataLayoutMigration.cpp
@@ -61,10 +61,14 @@ TestMigratesFilesAndAllProfiles()
                     "MapFile=%LOCAL_PATH%\\terrain.xcm\n"
                     "PlanePath=%LOCAL_PATH%\\plane.xcp\n"));
 
+  /* like LoadProfile() in Startup.cpp: the profile path may already
+     be selected, but the migration runs BEFORE Profile::Load() - the
+     in-memory map is still empty at that point */
   Profile::SetFiles(default_prf);
-  Profile::Load();
 
   MigrateDataLayoutToSubdirs();
+
+  Profile::Load();
 
   const auto map_path =
     AllocatedPath::Build(AllocatedPath::Build(data_path, Path("maps")),
@@ -92,6 +96,20 @@ TestMigratesFilesAndAllProfiles()
 
   ok1(Profile::GetPath() != nullptr);
   ok1(StringFind(Profile::GetPath().c_str(), "profiles") != nullptr);
+
+  /* the selected profile is now updated directly on disk as well (it
+     used to be skipped in favour of the in-memory map, which is not
+     loaded yet at migration time) */
+  const auto moved_default_prf =
+    AllocatedPath::Build(AllocatedPath::Build(data_path, Path("profiles")),
+                         Path("default.prf"));
+  ok1(!File::Exists(default_prf));
+
+  ProfileMap default_map;
+  Profile::LoadFile(default_map, moved_default_prf);
+  std::string raw_default_map;
+  ok1(default_map.Get(ProfileKeys::MapFile, raw_default_map));
+  ok1(StringFind(raw_default_map.c_str(), "maps") != nullptr);
 
   const auto moved_competition_prf =
     AllocatedPath::Build(AllocatedPath::Build(data_path, Path("profiles")),
@@ -147,7 +165,6 @@ TestDoesNotWriteMarkerWhenAllMovesFail()
                     "MapFile=%LOCAL_PATH%\\terrain.xcm\n"));
 
   Profile::SetFiles(default_prf);
-  Profile::Load();
 
   ok1(WriteTextFile(AllocatedPath::Build(data_path, Path("maps")),
                     "not a directory"));
@@ -155,6 +172,8 @@ TestDoesNotWriteMarkerWhenAllMovesFail()
                     "not a directory"));
 
   MigrateDataLayoutToSubdirs();
+
+  Profile::Load();
 
   ok1(!File::Exists(LocalPath(".xcsoar-subdir-layout-v1")));
   ok1(File::Exists(AllocatedPath::Build(data_path, Path("terrain.xcm"))));
@@ -165,7 +184,7 @@ main()
 {
   SetFakeLogFileQuiet(true);
 
-  plan_tests(43);
+  plan_tests(46);
   TestMigratesFilesAndAllProfiles();
   TestDoesNotWriteMarkerWhenAllMovesFail();
   return exit_status();


### PR DESCRIPTION
MigrateDataLayoutToSubdirs() ran AFTER the profile was selected and loaded.  On the first start over a pre-subdir-layout data directory the profile still lives in the data root at that point: the startup dialog does not list it, a basename -profile= argument resolves to profiles/ where nothing exists yet - the session starts with default settings and overwrites the (meanwhile migrated) profile on exit. One-time settings loss on every upgrade.

Run the migration first, then select and load.


Claude-Session: https://claude.ai/code/session_01Ei3obPrxYZcfgmRXyAEsa6

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile migration during startup to prevent migrated profiles from being replaced by empty profiles.
  * Improved profile selection and loading when existing profiles are moved into the profiles directory.
  * Ensured migrated profile data, including map paths, is preserved and loaded correctly.
  * Improved handling of the active profile when its location changes during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->