### PR TITLE
Startup: exit with success when the user quits during startup

### DIFF
--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -146,12 +146,22 @@ static AllMonitors *all_monitors;
 static GlideComputerTaskEvents *task_events;
 static DeviceFactory *device_factory;
 
+/** @see WasStartupCancelledByUser() */
+static bool startup_cancelled_by_user = false;
+
+bool
+WasStartupCancelledByUser() noexcept
+{
+  return startup_cancelled_by_user;
+}
+
 static bool
 LoadProfile()
 {
   if (Profile::GetPath() == nullptr &&
       !dlgStartupShowModal()) {
     LogString("LoadProfile: no profile path and startup dialog was cancelled");
+    startup_cancelled_by_user = true;
     return false;
   }
 
@@ -368,6 +378,7 @@ Startup(UI::Display &display)
     SimulatorPromptResult result = dlgSimulatorPromptShowModal();
     switch (result) {
     case SPR_QUIT:
+      startup_cancelled_by_user = true;
       return false;
 
     case SPR_FLY:
@@ -553,8 +564,10 @@ Startup(UI::Display &display)
 #endif
 
   // Show unified Quick Guide dialog (warranty + guide pages)
-  if (!dlgQuickGuideShowModal())
+  if (!dlgQuickGuideShowModal()) {
+    startup_cancelled_by_user = true;
     return false;
+  }
 
   GlidePolar &gp = CommonInterface::SetComputerSettings().polar.glide_polar_task;
   gp = GlidePolar(0);

--- a/src/Startup.hpp
+++ b/src/Startup.hpp
@@ -9,6 +9,16 @@ bool
 Startup(UI::Display &display);
 
 /**
+ * True if Startup() returned false because the USER chose to quit
+ * (startup profile dialog cancelled, simulator prompt "Quit", quick
+ * guide / warranty declined) - as opposed to a real startup failure.
+ * Lets the caller exit with EXIT_SUCCESS for a deliberate quit.
+ */
+[[gnu::pure]]
+bool
+WasStartupCancelledByUser() noexcept;
+
+/**
  * Write all user state which is only kept in memory (the profile
  * settings and the FLARM databases) to disk.  Apart from the regular
  * shutdown, this is called whenever the operating system may kill the

--- a/src/XCSoar.cpp
+++ b/src/XCSoar.cpp
@@ -79,6 +79,10 @@ Main()
   int ret = EXIT_FAILURE;
   if (Startup(screen_init.GetDisplay()))
     ret = CommonInterface::main_window->RunEventLoop();
+  else if (WasStartupCancelledByUser())
+    /* quitting from the startup dialogs is a deliberate user action,
+       not an error */
+    ret = EXIT_SUCCESS;
 
   /* The export-flight cache owns an InjectTask on the Asio event loop. */
   ShutdownExportFlightsPanel();


### PR DESCRIPTION
Quitting from the startup dialogs (startup profile dialog cancelled, simulator prompt "Quit", quick guide / warranty declined) made main() return EXIT_FAILURE - indistinguishable from a real startup failure. Track user-initiated cancellation and return EXIT_SUCCESS for it.


Claude-Session: https://claude.ai/code/session_01Ei3obPrxYZcfgmRXyAEsa6

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exiting during startup dialogs now completes successfully instead of being reported as a startup failure.
  * Improved handling of cancelled profile setup, simulator exit prompts, and dismissed Quick Guide dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->