### PR TITLE
io/CupxArchive: Fix open files in binary mode on Windows

### DIFF
--- a/src/io/CupxArchive.cpp
+++ b/src/io/CupxArchive.cpp
@@ -293,6 +293,12 @@ CupxArchive::ExtractImage(Path cupx_path, std::string_view image_name)
   if (!fd.IsDefined())
     return {};
 
+#ifdef _WIN32
+  /* the file descriptor defaults to O_TEXT mode on Windows, which
+     corrupts binary reads (CR/LF translation, 0x1A = EOF) */
+  fd.SetBinaryMode();
+#endif
+
   if (!SkipCupxHeader(fd))
     return {};
 
@@ -332,6 +338,12 @@ CupxArchive::ExtractPointsCup(Path cupx_path)
   auto fd = OpenCupx(cupx_path);
   if (!fd.IsDefined())
     return {};
+
+#ifdef _WIN32
+  /* the file descriptor defaults to O_TEXT mode on Windows, which
+     corrupts binary reads (CR/LF translation, 0x1A = EOF) */
+  fd.SetBinaryMode();
+#endif
 
   const off_t filesize = fd.GetSize();
   if (filesize < 0)


### PR DESCRIPTION
FileDescriptor::Open() uses ::open() without O_BINARY, so on Windows the file is opened in text mode: CR/LF pairs are translated on read and a 0x1A byte is treated as end-of-file. This corrupts the binary ZIP structures inside a .cupx archive, causing both POINTS.CUP and image extraction to fail — waypoint files in CUPX format silently loaded no waypoints on Windows.

Call SetBinaryMode() on the descriptor right after opening the archive in ExtractPointsCup() and ExtractImage().

Not reproducible on Linux/Android/macOS, where open() has no text mode; this only affected Windows builds.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge
