### PR TITLE
experiment/Computer/Wind add BucketWind to support wind speed near airspeed

### DIFF
--- a/build/test.mk
+++ b/build/test.mk
@@ -90,7 +90,7 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
-	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
+	TestLogger TestGRecord TestClimbAvCalc TestBucketWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
 	TestWaypointReader TestThermalBase \
@@ -652,14 +652,15 @@ TEST_CLIMB_AV_CALC_SOURCES = \
 TEST_CLIMB_AV_CALC_DEPENDS = MATH
 $(eval $(call link-program,TestClimbAvCalc,TEST_CLIMB_AV_CALC))
 
-TEST_CIRCLING_WIND_SOURCES = \
+TEST_BUCKET_WIND_SOURCES = \
 	$(SRC)/Computer/Wind/CirclingWind.cpp \
+	$(SRC)/Computer/Wind/BucketWind.cpp \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/tap.c \
-	$(TEST_SRC_DIR)/TestCirclingWind.cpp
-TEST_CIRCLING_WIND_DEPENDS = LIBNMEA GEO MATH UTIL TIME FMT UNITS
-$(eval $(call link-program,TestCirclingWind,TEST_CIRCLING_WIND))
+	$(TEST_SRC_DIR)/TestBucketWind.cpp
+TEST_BUCKET_WIND_DEPENDS = LIBNMEA GEO MATH UTIL TIME FMT UNITS
+$(eval $(call link-program,TestBucketWind,TEST_BUCKET_WIND))
 
 TEST_FILTERED_VARIO_COMPUTER_SOURCES = \
 	$(SRC)/Atmosphere/AirDensity.cpp \
@@ -1187,7 +1188,7 @@ DEBUG_PROGRAM_NAMES += \
 	RunIGCWriter \
 	RunFlightLogger RunFlyingComputer \
 	RunCirclingWind RunWindEKF RunWindComputer \
-	RunExternalWind \
+	RunBucketWind RunExternalWind \
 	RunTask \
 	LoadImage ViewImage \
 	RunCanvas RunMapWindow RunRichTextRenderer \
@@ -1944,6 +1945,17 @@ RUN_CIRCLING_WIND_SOURCES = \
 	$(TEST_SRC_DIR)/RunCirclingWind.cpp
 RUN_CIRCLING_WIND_DEPENDS = $(DEBUG_REPLAY_DEPENDS) GEO MATH UTIL
 $(eval $(call link-program,RunCirclingWind,RUN_CIRCLING_WIND))
+
+RUN_BUCKET_WIND_SOURCES = \
+	$(DEBUG_REPLAY_SOURCES) \
+	$(SRC)/Formatter/TimeFormatter.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(SRC)/Computer/Wind/BucketWind.cpp \
+	$(SRC)/TransponderCode.cpp \
+	$(SRC)/Formatter/NMEAFormatter.cpp \
+	$(TEST_SRC_DIR)/RunBucketWind.cpp
+RUN_BUCKET_WIND_DEPENDS = $(DEBUG_REPLAY_DEPENDS) GEO MATH UTIL
+$(eval $(call link-program,RunBucketWind,RUN_BUCKET_WIND))
 
 RUN_WIND_EKF_SOURCES = \
 	$(DEBUG_REPLAY_SOURCES) \

--- a/src/Computer/Wind/BucketWind.cpp
+++ b/src/Computer/Wind/BucketWind.cpp
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BucketWind.hpp"
+
+#include <cmath>
+
+namespace {
+
+constexpr unsigned MIN_BINS = 12;
+constexpr double MIN_TAS = 1;
+constexpr double MIN_WIND = 0.1;
+constexpr double MAX_WIND = 30;
+
+[[gnu::const]]
+double
+Det3(double a00, double a01, double a02,
+     double a10, double a11, double a12,
+     double a20, double a21, double a22) noexcept
+{
+  return a00 * (a11 * a22 - a12 * a21)
+       - a01 * (a10 * a22 - a12 * a20)
+       + a02 * (a10 * a21 - a11 * a20);
+}
+
+/**
+ * Least-squares fit of y = mean + b·cosθ + c·sinθ.
+ *
+ * The 3×3 system is the normal equations for those three unknowns.
+ * Returns false if the tracks do not span enough angles (singular).
+ */
+bool
+FitMeanCosSin(double n,
+              double sum_cos, double sum_sin,
+              double sum_cos2, double sum_sin2, double sum_cos_sin,
+              double sum_y, double sum_y_cos, double sum_y_sin,
+              double &mean, double &b, double &c) noexcept
+{
+  const double det = Det3(n,       sum_cos,     sum_sin,
+                          sum_cos, sum_cos2,    sum_cos_sin,
+                          sum_sin, sum_cos_sin, sum_sin2);
+  if (std::fabs(det) < 1e-9)
+    return false;
+
+  /* Cramer's rule: replace one column at a time with the right-hand
+     side (sum_y, sum_y_cos, sum_y_sin). */
+  mean = Det3(sum_y,     sum_cos,     sum_sin,
+              sum_y_cos, sum_cos2,    sum_cos_sin,
+              sum_y_sin, sum_cos_sin, sum_sin2) / det;
+
+  b = Det3(n,       sum_y,     sum_sin,
+           sum_cos, sum_y_cos, sum_cos_sin,
+           sum_sin, sum_y_sin, sum_sin2) / det;
+
+  c = Det3(n,       sum_cos,     sum_y,
+           sum_cos, sum_cos2,    sum_y_cos,
+           sum_sin, sum_cos_sin, sum_y_sin) / det;
+  return true;
+}
+
+} // namespace
+
+unsigned
+BucketWind::BinIndex(Angle track) noexcept
+{
+  const double deg = track.AsBearing().Degrees();
+  const unsigned i = unsigned(std::floor(deg / BIN_WIDTH_DEG));
+  return i % N_BINS;
+}
+
+Angle
+BucketWind::BinCentre(unsigned i) noexcept
+{
+  return Angle::Degrees((i + 0.5) * BIN_WIDTH_DEG);
+}
+
+void
+BucketWind::Reset() noexcept
+{
+  for (auto &bin : bins)
+    bin = {};
+}
+
+void
+BucketWind::Update(TimeStamp time, Angle track,
+                   double ground_speed) noexcept
+{
+  auto &bin = bins[BinIndex(track)];
+  bin.time = time;
+  bin.ground_speed = ground_speed;
+}
+
+BucketWind::Result
+BucketWind::Fit(TimeStamp now, FloatDuration max_age) const noexcept
+{
+  Result result;
+
+  double n = 0;
+  double sum_cos = 0, sum_sin = 0;
+  double sum_cos2 = 0, sum_sin2 = 0, sum_cos_sin = 0;
+  double sum_gs = 0, sum_gs_cos = 0, sum_gs_sin = 0;
+
+  for (unsigned i = 0; i < N_BINS; ++i) {
+    const Bin &bin = bins[i];
+    if (!bin.time.IsDefined() || now < bin.time)
+      continue;
+    if (now - bin.time > max_age)
+      continue;
+
+    const double theta = BinCentre(i).Radians();
+    const double cos_t = std::cos(theta);
+    const double sin_t = std::sin(theta);
+    const double gs = bin.ground_speed;
+
+    n += 1;
+    sum_cos += cos_t;
+    sum_sin += sin_t;
+    sum_cos2 += cos_t * cos_t;
+    sum_sin2 += sin_t * sin_t;
+    sum_cos_sin += cos_t * sin_t;
+    sum_gs += gs;
+    sum_gs_cos += gs * cos_t;
+    sum_gs_sin += gs * sin_t;
+  }
+
+  result.n_bins = unsigned(n);
+  if (result.n_bins < MIN_BINS)
+    return result;
+
+  double mean_gs, cos_coeff, sin_coeff;
+  if (!FitMeanCosSin(n, sum_cos, sum_sin, sum_cos2, sum_sin2, sum_cos_sin,
+                     sum_gs, sum_gs_cos, sum_gs_sin,
+                     mean_gs, cos_coeff, sin_coeff))
+    return result;
+
+  /* Amplitude of the cosine is the wind speed (light-wind model).
+     Peak ground speed is downwind, so wind-from is the opposite. */
+  const double wind_speed = std::hypot(cos_coeff, sin_coeff);
+  if (wind_speed < MIN_WIND || wind_speed >= MAX_WIND || mean_gs < MIN_TAS)
+    return result;
+
+  const Angle downwind = Angle::Radians(std::atan2(sin_coeff, cos_coeff));
+  result.tas = mean_gs;
+  result.wind = SpeedVector(downwind.Reciprocal().AsBearing(), wind_speed);
+  result.valid = true;
+  return result;
+}

--- a/src/Computer/Wind/BucketWind.hpp
+++ b/src/Computer/Wind/BucketWind.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/SpeedVector.hpp"
+#include "Math/Angle.hpp"
+#include "time/Stamp.hpp"
+
+/**
+ * GPS-only wind estimate for discussion #2918 (prototype).
+ *
+ * Ground speed versus ground track looks like a cosine: fastest over
+ * the ground is downwind, slowest is upwind.  Split the compass into
+ * 72 bins of 5°, keep the latest GPS speed in each bin, then fit
+ *
+ *   ground_speed(track) ≈ tas + wind * cos(track - downwind)
+ *
+ * That is the usual light-wind approximation.  It does not need a
+ * detected thermal or a round GPS circle — only a spread of tracks.
+ */
+class BucketWind {
+  static constexpr unsigned N_BINS = 72;
+  static constexpr double BIN_WIDTH_DEG = 360. / N_BINS;
+
+  struct Bin {
+    TimeStamp time = TimeStamp::Undefined();
+    double ground_speed = 0;
+  };
+
+  Bin bins[N_BINS];
+
+  [[gnu::const]]
+  static unsigned BinIndex(Angle track) noexcept;
+
+  [[gnu::const]]
+  static Angle BinCentre(unsigned i) noexcept;
+
+public:
+  struct Result {
+    bool valid = false;
+    /** Meteorological wind (direction FROM). */
+    SpeedVector wind = SpeedVector::Zero();
+    /** Mean ground speed of the fit; ≈ TAS when wind is light. */
+    double tas = 0;
+    unsigned n_bins = 0;
+  };
+
+  void Reset() noexcept;
+
+  void Update(TimeStamp time, Angle track,
+              double ground_speed) noexcept;
+
+  /**
+   * Fit wind from bins that are still younger than #max_age.
+   */
+  [[nodiscard]]
+  Result Fit(TimeStamp now,
+             FloatDuration max_age = FloatDuration{180}) const noexcept;
+};

--- a/test/src/RunBucketWind.cpp
+++ b/test/src/RunBucketWind.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Computer/Wind/BucketWind.hpp"
+#include "system/Args.hpp"
+#include "DebugReplay.hpp"
+#include "Formatter/TimeFormatter.hpp"
+#include "Computer/Settings.hpp"
+
+#include <stdio.h>
+#include <memory>
+
+int main(int argc, char **argv)
+{
+  Args args(argc, argv, "DRIVER FILE");
+  std::unique_ptr<DebugReplay> replay(CreateDebugReplay(args));
+  if (!replay)
+    return EXIT_FAILURE;
+
+  args.ExpectEnd();
+
+  printf("# time wind_bearing (deg) wind_speed (m/s) calculated_TAS instrument_TAS N_BINS\n");
+
+  const MoreData &data = replay->Basic();
+  BucketWind bucket_wind;
+  bucket_wind.Reset();
+
+  while (replay->Next()) {
+    if (data.time.IsDefined() && data.track_available && data.ground_speed_available) {
+      bucket_wind.Update(data.time, data.track, data.ground_speed);
+
+      BucketWind::Result result = bucket_wind.Fit(replay->Basic().time);
+      if (result.valid) {
+        char time_buffer[32];
+        FormatTime(time_buffer, replay->Basic().time);
+
+        printf("%s %d %g %g %g %d\n",
+                 time_buffer,
+                 (int)result.wind.bearing.Degrees(),
+                 (double)result.wind.norm,
+                 (double)result.tas,
+                 (double)data.true_airspeed,
+                 (int)result.n_bins);
+      }
+    }
+  }
+}
+

--- a/test/src/TestBucketWind.cpp
+++ b/test/src/TestBucketWind.cpp
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Computer/Wind/BucketWind.hpp"
+#include "Computer/Wind/CirclingWind.hpp"
+#include "FakeLogFile.hpp"
+#include "NMEA/CirclingInfo.hpp"
+#include "NMEA/MoreData.hpp"
+#include "TestUtil.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+struct CircleConfig {
+  double tas;
+  SpeedVector wind;
+  double period_s;
+  double dt_s = 1;
+  unsigned circles = 3;
+  /** If < 360, stop after this many degrees of heading. */
+  double heading_span_deg = 360;
+};
+
+struct Sample {
+  TimeStamp time;
+  Angle track;
+  double gs;
+};
+
+static void
+AppendCircle(std::vector<Sample> &out, const CircleConfig &cfg)
+{
+  const Angle wind_to = cfg.wind.bearing.Reciprocal();
+  const double wind_east = cfg.wind.norm * wind_to.sin();
+  const double wind_north = cfg.wind.norm * wind_to.cos();
+
+  const double max_t =
+    cfg.period_s * cfg.circles * (cfg.heading_span_deg / 360.);
+  const unsigned n = unsigned(std::ceil(max_t / cfg.dt_s)) + 2;
+
+  double t = 0;
+  for (unsigned i = 0; i < n; ++i) {
+    const Angle heading = Angle::Degrees(360 * t / cfg.period_s);
+    const double air_east = cfg.tas * heading.sin();
+    const double air_north = cfg.tas * heading.cos();
+    const SpeedVector gs(air_east + wind_east, air_north + wind_north);
+
+    out.push_back({
+      TimeStamp{FloatDuration{t + 1}},
+      gs.bearing,
+      gs.norm,
+    });
+    t += cfg.dt_s;
+    if (t > max_t)
+      break;
+  }
+}
+
+static MoreData
+MakeFix(const Sample &s) noexcept
+{
+  MoreData info;
+  info.Reset();
+  info.clock = s.time;
+  info.time = s.time;
+  info.time_available.Update(info.clock);
+  info.track = s.track;
+  info.track_available.Update(info.clock);
+  info.ground_speed = s.gs;
+  info.ground_speed_available.Update(info.clock);
+  return info;
+}
+
+static CirclingWind::Result
+RunCircling(const std::vector<Sample> &samples, bool circling) noexcept
+{
+  CirclingWind circling_wind;
+  circling_wind.Reset();
+
+  CirclingInfo circling_info;
+  circling_info.Clear();
+  circling_info.circling = circling;
+
+  CirclingWind::Result last(0);
+  for (const auto &s : samples) {
+    const auto result = circling_wind.NewSample(MakeFix(s), circling_info);
+    if (result.IsValid())
+      last = result;
+  }
+  return last;
+}
+
+static BucketWind::Result
+RunBuckets(const std::vector<Sample> &samples) noexcept
+{
+  BucketWind buckets;
+  buckets.Reset();
+  for (const auto &s : samples)
+    buckets.Update(s.time, s.track, s.gs);
+
+  if (samples.empty())
+    return {};
+  return buckets.Fit(samples.back().time);
+}
+
+static bool
+WindClose(SpeedVector got, SpeedVector want,
+          double speed_tol, Angle bearing_tol) noexcept
+{
+  const auto bearing_error =
+    std::fabs((got.bearing.AsBearing() - want.bearing).AsDelta().Degrees());
+
+  if (std::fabs(got.norm - want.norm) > speed_tol ||
+      bearing_error > bearing_tol.Degrees()) {
+    diag("got %.2f m/s %.1f deg, want %.2f m/s %.1f deg "
+         "(bearing error %.1f deg)",
+         got.norm, got.bearing.AsBearing().Degrees(),
+         want.norm, want.bearing.AsBearing().Degrees(),
+         bearing_error);
+    return false;
+  }
+
+  return true;
+}
+
+static void
+PrintRow(const char *name, const CirclingWind::Result &cw,
+         const BucketWind::Result &bw, const SpeedVector &truth) noexcept
+{
+  if (name != nullptr && std::strlen(name) > 0)
+    std::printf("# %-18s  circling %s %5.1f m/s %4.0f°   "
+                "bucket %s %5.1f m/s %4.0f°   truth %5.1f m/s %4.0f°\n",
+                name,
+                cw.IsValid() ? "ok" : "--",
+                cw.IsValid() ? cw.wind.norm : 0,
+                cw.IsValid() ? cw.wind.bearing.Degrees() : 0,
+                bw.valid ? "ok" : "--",
+                bw.valid ? bw.wind.norm : 0,
+                bw.valid ? bw.wind.bearing.Degrees() : 0,
+                truth.norm, truth.bearing.Degrees());
+}
+
+static void
+ComparePGCircle() noexcept
+{
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  std::vector<Sample> samples;
+  AppendCircle(samples, {
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+  });
+
+  const auto cw = RunCircling(samples, true);
+  const auto bw = RunBuckets(samples);
+  PrintRow("PG full circle", cw, bw, wind);
+
+  /* CirclingWind may reject a PG circle (issue #2905).  Buckets
+     should still recover the wind from the same GPS traces. */
+  ok1(bw.valid);
+  ok1(WindClose(bw.wind, wind, 2, Angle::Degrees(40)));
+}
+
+static void
+CompareGliderCircle() noexcept
+{
+  const SpeedVector wind(Angle::Degrees(270), 5);
+  std::vector<Sample> samples;
+  AppendCircle(samples, {
+    .tas = 25,
+    .wind = wind,
+    .period_s = 20,
+  });
+
+  const auto cw = RunCircling(samples, true);
+  const auto bw = RunBuckets(samples);
+  PrintRow("glider circle", cw, bw, wind);
+
+  ok1(cw.IsValid());
+  ok1(bw.valid);
+  ok1(WindClose(cw.wind, wind, 1.5, Angle::Degrees(30)));
+  ok1(WindClose(bw.wind, wind, 1.5, Angle::Degrees(30)));
+}
+
+static void
+ComparePartialArc() noexcept
+{
+  /* Not a full circle: CirclingWind should stay quiet; buckets can
+     still fit if enough track angles are seen. */
+  const SpeedVector wind(Angle::Degrees(90), 5);
+  std::vector<Sample> samples;
+  AppendCircle(samples, {
+    .tas = 9,
+    .wind = wind,
+    .period_s = 25,
+    .circles = 1,
+    .heading_span_deg = 220,
+  });
+
+  const auto cw = RunCircling(samples, true);
+  const auto bw = RunBuckets(samples);
+  PrintRow("PG 220° arc", cw, bw, wind);
+
+  ok1(!cw.IsValid());
+  ok1(bw.valid);
+  ok1(WindClose(bw.wind, wind, 2.5, Angle::Degrees(50)));
+}
+
+static void
+CompareCruiseSweep() noexcept
+{
+  /* Slow heading change, no thermal: still fills buckets. */
+  const SpeedVector wind(Angle::Degrees(0), 6);
+  std::vector<Sample> samples;
+  AppendCircle(samples, {
+    .tas = 9,
+    .wind = wind,
+    .period_s = 180,
+    .circles = 1,
+  });
+
+  const auto cw = RunCircling(samples, false);
+  const auto bw = RunBuckets(samples);
+  PrintRow("cruise 360° sweep", cw, bw, wind);
+
+  ok1(!cw.IsValid());
+  ok1(bw.valid);
+  ok1(WindClose(bw.wind, wind, 2, Angle::Degrees(40)));
+}
+
+int
+main()
+{
+  plan_tests(2 + 4 + 3 + 3);
+
+  SetFakeLogFileQuiet(true);
+
+  std::printf("# CirclingWind vs 72-bucket cosine fit (discussion #2918)\n");
+  ComparePGCircle();
+  CompareGliderCircle();
+  ComparePartialArc();
+  CompareCruiseSweep();
+
+  return exit_status();
+}


### PR DESCRIPTION

Experimental implementation of a new wind algorithm.

It requires IAS nearly constant.
Paragliders should benefit the most.

Picking up work from **wind calculation dedicated to para glider** PR #2918
More detail to the idea and assumptions are found under that PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPS-based wind estimation using directional sampling across the compass.
  * Wind results include direction, speed, estimated true airspeed, and sample coverage.
  * Added replay support for reviewing wind calculations from recorded flight data.
  * Improved estimate reliability by handling stale data and insufficient flight coverage.

* **Tests**
  * Added validation for full-circle, partial-arc, and cruise flight scenarios.
  * Added build targets for wind estimation tests and replay utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->