### PR TITLE
Add <cstdint> include for uint8_t in AlternateInfoBoxMode

### DIFF
--- a/src/InfoBoxes/Content/Alternate.hpp
+++ b/src/InfoBoxes/Content/Alternate.hpp
@@ -7,6 +7,7 @@
 #include "Engine/Waypoint/Ptr.hpp"
 
 #include <cstddef>
+#include <cstdint>
 
 enum class AlternateInfoBoxMode : uint8_t {
   AUTO,


### PR DESCRIPTION
Super tiny fix to include the right header file for a .hpp file. This randomly works in some other scenarios due to compilation order, but this fix was needed for me to make it compile on WAYLAND with "make TARGET=WAYLAND"


- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and build reliability by ensuring required integer types are available for alternate information box modes and slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->