### PR TITLE
ui/canvas/egl/TopCanvas: Drop private native-window buffer query

### DIFF
--- a/src/ui/canvas/custom/TopCanvas.hpp
+++ b/src/ui/canvas/custom/TopCanvas.hpp
@@ -71,8 +71,8 @@ class TopCanvas
    * Swap-chain depth.  Extra full-window clears after an OpenGL
    * gesture trail use this so every presentation buffer gets a
    * clean frame.  Default 4 covers typical EGL/Android queues
-   * (triple-buffer plus a spare); Android overwrites it from the
-   * native window when the surface is acquired.
+   * (triple-buffer plus a spare); GetPresentationBufferCount()
+   * may raise it from EGL_BUFFER_AGE_KHR after the first swap.
    */
   unsigned presentation_buffer_count = 4;
 #endif

--- a/src/ui/canvas/egl/TopCanvas.cpp
+++ b/src/ui/canvas/egl/TopCanvas.cpp
@@ -123,17 +123,9 @@ TopCanvas::AcquireSurface()
   if (native_window == nullptr)
     return false;
 
-  int min_undequeued = 0;
-  if (ANativeWindow_query(native_window,
-                          NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS,
-                          &min_undequeued) == 0 &&
-      min_undequeued > 0) {
-    /* BufferQueue: minUndequeued + 1 for the producer, +1 if
-       eglSwapBuffers is asynchronous. */
-    unsigned n = unsigned(min_undequeued) + 2;
-    if (n > presentation_buffer_count)
-      presentation_buffer_count = n;
-  }
+  /* NDK r26 (minSdk 21) has no public ANativeWindow_query();
+     NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS is private.  Depth
+     comes from EGL_BUFFER_AGE_KHR in GetPresentationBufferCount(). */
 
   CreateSurface(native_window);
 


### PR DESCRIPTION
## Summary
- Remove `ANativeWindow_query(..., NATIVE_WINDOW_MIN_UNDEQUEUED_BUFFERS)` from `AcquireSurface()`. That token is from private `system/window.h`; NDK r26 / minSdk 21 does not declare it, so ANDROIDFAT CI failed (`use of undeclared identifier`).
- Keep swap-chain depth at the default of 4, raised by `EGL_BUFFER_AGE_KHR` in `GetPresentationBufferCount()` after the first swap.

## Test plan
- [x] `make -j$(nproc) TARGET=ANDROIDX64 DEBUG=n USE_CCACHE=y` (the ABI that failed on CI)
- [ ] ANDROIDFAT CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android surface buffer handling to use the available presentation-buffer information more reliably.
  - Removed reliance on an unavailable native-window query, improving compatibility with newer Android NDK versions.

- **Documentation**
  - Updated internal documentation to accurately describe Android presentation-buffer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->