### PR TITLE
po: Regenerate translation catalog

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -1797,6 +1797,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Избери цвят"
 
+#, no-c-format
 msgid "Display"
 msgstr "Показване"
 
@@ -2041,10 +2042,6 @@ msgstr "Типове повратни точки"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Език, клавиатура"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Оформление на екрана"
 
 #, no-c-format
 msgid "Audio"
@@ -3385,9 +3382,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Размер на шрифта"
-
-msgid "Display Resolution"
-msgstr "Разделителна способност на екрана"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Разделителната способност на екрана се използва за да адаптира дебелината на линиите, размера на шрифта, възможните места за кацане и др."
@@ -8351,12 +8345,6 @@ msgstr ""
 "Размер на символите на пътните точки на картата като процент от вградената "
 "графика (диалозите със списъци запазват фиксиран размер на иконата в реда)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Режим Altn: РУЧНОЙ"
-
-msgid "Altn mode: AUTO"
-msgstr "Режим Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11213,4 +11201,93 @@ msgstr "Авто"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ръчно"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1793,6 +1793,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Selecció de color"
 
+#, no-c-format
 msgid "Display"
 msgstr "Visualització"
 
@@ -2038,10 +2039,6 @@ msgstr "Tipus de Punts de Viratge"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Llengua, Entrada"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Disposició de Pantalla"
 
 #, no-c-format
 msgid "Audio"
@@ -3380,9 +3377,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Mida del text"
-
-msgid "Display Resolution"
-msgstr "Resolució de visualització"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "La resolució de visualització s'usa per adaptar la mida de les línies, el tamany de la lletra, el tamany dels aterrages i més."
@@ -8341,12 +8335,6 @@ msgstr ""
 "Mida dels símbols de punt de ruta al mapa com a percentatge del gràfic "
 "incorporat (els diàlegs de llista mantenen una mida fixe)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUALE"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11200,4 +11188,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manual"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -1785,6 +1785,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Vyber barvu"
 
+#, no-c-format
 msgid "Display"
 msgstr "Zobraz"
 
@@ -2026,10 +2027,6 @@ msgstr "Typ otočných bodů"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Jazyk, vstup"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Rozložení obrazovky"
 
 #, no-c-format
 msgid "Audio"
@@ -3355,9 +3352,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Velikost textu"
-
-msgid "Display Resolution"
-msgstr "Rozlišení displeje"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Nastavení rozlišení displeje je používáno k adaptaci šíře linek, velikosti fontů, velikosti nouzových ploch a dalším úpravám."
@@ -8248,12 +8242,6 @@ msgstr ""
 "Velikost symbolů bodů trati na mapě jako procento vestavěné grafiky (dialogy"
 " seznamů zachovávají pevnou velikost ikony řádku)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Režim Altn: RUČNÍ"
-
-msgid "Altn mode: AUTO"
-msgstr "Režim Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11071,4 +11059,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ručně"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/da.po
+++ b/po/da.po
@@ -1789,6 +1789,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Vælg Farve"
 
+#, no-c-format
 msgid "Display"
 msgstr "Visning"
 
@@ -2031,10 +2032,6 @@ msgstr "Vendepunktyprige"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Sprog, Indtastning"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Skærmplanlægning"
 
 #, no-c-format
 msgid "Audio"
@@ -3357,9 +3354,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tekststørrelse"
-
-msgid "Display Resolution"
-msgstr "Visningsopnåelse"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Visningsopnåelsen bruges til at anpassede linjesæder, tegnesæder, landbar størrelser og mere."
@@ -8309,12 +8303,6 @@ msgstr ""
 "Størrelse på vejpunktsymboler på kortet som procent af den indbyggede grafik"
 " (listedialoger beholder fast rækkeikonstørrelse)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Alternativtilstand: MANUEL"
-
-msgid "Altn mode: AUTO"
-msgstr "Alternativtilstand: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11130,4 +11118,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuelt"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -1801,6 +1801,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Farbauswahl"
 
+#, no-c-format
 msgid "Display"
 msgstr "Anzeige"
 
@@ -2047,10 +2048,6 @@ msgstr "Wendepunkt Typen"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Sprache, Eingaben"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Anordnung"
 
 #, no-c-format
 msgid "Audio"
@@ -3384,9 +3381,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Schriftgröße"
-
-msgid "Display Resolution"
-msgstr "Bildschirmauflösung"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Die Bildschirmauflösung passt die Stärke der Linien, Schriftgrößen, Größe der Landemarkierung und anderer Symbole an."
@@ -8352,12 +8346,6 @@ msgstr ""
 "Größe der Wegpunktsymbole auf der Karte als Prozentsatz der eingebauten "
 "Grafik (Listendialoge behalten feste Zeilensymbolgröße)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn-Modus: MANUELL"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn-Modus: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11223,4 +11211,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuell"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -1798,6 +1798,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Επιλογή Χρώματος"
 
+#, no-c-format
 msgid "Display"
 msgstr "Οθόνη"
 
@@ -2044,10 +2045,6 @@ msgstr "Σημεία στροφής τύπου"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Γλώσσα, Εισάγων"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Προσαρμογή παραθυρών"
 
 #, no-c-format
 msgid "Audio"
@@ -3388,9 +3385,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "ΚΕΙΜΕΝΟ"
-
-msgid "Display Resolution"
-msgstr "Διαστάσεις Εκτόπισης"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Η διαστάση της οθόνης χρησιμοποιείται για την αρμοδιότητα στην εκτίμηση πλυμάτων, μέγεθος κειμένου και άλλες διαδικασίες."
@@ -8367,12 +8361,6 @@ msgstr ""
 "Μέγεθος συμβόλων waypoint στον χάρτη ως ποσοστό του ενσωματωμένου γραφικού "
 "(τα παράθυρα λίστας κρατούν σταθερό μέγεθος εικονιδίου γραμμής)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Λειτ. εναλλ.: ΧΕΙΡ."
-
-msgid "Altn mode: AUTO"
-msgstr "Λειτ. εναλλ.: ΑΥΤΟΜ."
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11237,4 +11225,93 @@ msgstr "Αυτόματα"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Χειροκίνητα"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -1801,6 +1801,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Seleccionar Color"
 
+#, no-c-format
 msgid "Display"
 msgstr "Pantalla"
 
@@ -2045,10 +2046,6 @@ msgstr "Tipos de Puntos de viraje"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Idioma, Entrada"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Diseño de la pantalla"
 
 #, no-c-format
 msgid "Audio"
@@ -3399,9 +3396,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tamaño del texto"
-
-msgid "Display Resolution"
-msgstr "Resolución de la pantalla"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "La resolución de la pantalla se utiliza para adaptar el ancho de las líneas, el tamaño de la fuente, el tamaño de la superficie de aterrizaje y más."
@@ -8389,12 +8383,6 @@ msgstr ""
 "Tamaño de los símbolos de waypoint en el mapa como porcentaje del arte "
 "integrado (los diálogos de lista mantienen un tamaño fijo de icono de fila)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUAL"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11261,4 +11249,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manual"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -1785,6 +1785,7 @@ msgstr "Jos käytössä, yläreunan rivillä nähdään saapumiskorkeus sijainti
 msgid "Select Color"
 msgstr "Valitse väri"
 
+#, no-c-format
 msgid "Display"
 msgstr "Näyttö"
 
@@ -2029,10 +2030,6 @@ msgstr "Käännepisteiden tyypit"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Kieli ja syöte"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Näytön asettelu"
 
 #, no-c-format
 msgid "Audio"
@@ -3356,9 +3353,6 @@ msgstr "Ohjaus \"loppuliukun\" InfoBox -tilassa \"auto\" -sivuilla."
 
 msgid "Text size"
 msgstr "Teksti"
-
-msgid "Display Resolution"
-msgstr "Näytön suunta"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Näyttöresoluutio käytetään suorittamaan linjien leveydet, fonttikokoja, maahanmuuttajien koon ja muita asioita."
@@ -8249,12 +8243,6 @@ msgstr ""
 "Reittipistesymbolien koko kartalla prosentteina sisäänrakennetusta "
 "grafiikasta (luetteloikkunoissa rivikuvakkeen koko pysyy kiinteänä)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11096,4 +11084,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuaalinen"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1801,6 +1801,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Choisir une couleur"
 
+#, no-c-format
 msgid "Display"
 msgstr "Affich."
 
@@ -2048,10 +2049,6 @@ msgstr "Types de point de virage"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Langue, Entrées"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Agencement de l'écran"
 
 #, no-c-format
 msgid "Audio"
@@ -3393,9 +3390,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Taille du texte"
-
-msgid "Display Resolution"
-msgstr "Résolution de l'écran"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "La résolution de l'affichage est utilisée pour adapter les largeurs de ligne, la taille de la police, la taille des terrains posables, etc."
@@ -8368,12 +8362,6 @@ msgstr ""
 "Taille des symboles de waypoint sur la carte en pourcentage des graphismes "
 "intégrés (les listes de dialogue gardent une taille d'icône de ligne fixe)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Mode Altn : MANUEL"
-
-msgid "Altn mode: AUTO"
-msgstr "Mode Altn : AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11257,4 +11245,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuel"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -1836,6 +1836,7 @@ msgstr "אם מופעל שורה תופסת עלייה הגעה במקומך."
 msgid "Select Color"
 msgstr "בחOOSE COLOR"
 
+#, no-c-format
 msgid "Display"
 msgstr "תצוגה"
 
@@ -2076,10 +2077,6 @@ msgstr "סוג נקודת סיבוב"
 #, no-c-format
 msgid "Language, Input"
 msgstr "שפה"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "מערך התצוגה"
 
 #, no-c-format
 msgid "Audio"
@@ -3414,9 +3411,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "טקסט"
-
-msgid "Display Resolution"
-msgstr "אין פתרון"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "התולעת נמצאת בשימוש כדי להתאים את רוחב הנקודות, הגודל של הטקסט, גודל היעד ועוד."
@@ -8225,12 +8219,6 @@ msgstr ""
 "גודל סמלי נקודות הדרך על המפה כאחוז מהגרפיקה המובנית (תיבות דו־שיח של רשימה "
 "שומרות על גודל אייקון קבוע בשורה)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11011,4 +10999,93 @@ msgstr "אוטו"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "ידנית"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -1780,6 +1780,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Odabir boje"
 
+#, no-c-format
 msgid "Display"
 msgstr "Prikaži"
 
@@ -2022,10 +2023,6 @@ msgstr "Tipovi okretnih točaka"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Jezik, unos"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Raspored ekrana"
 
 #, no-c-format
 msgid "Audio"
@@ -3355,9 +3352,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Veličina teksta"
-
-msgid "Display Resolution"
-msgstr "Resolucija prikaza"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Resolucija prikaza se koristi za prilagođavanje širine linija, veličine fonta, veličine letljivih objekata i mnogo drugog."
@@ -8274,12 +8268,6 @@ msgstr ""
 "Veličina simbola točaka rute na karti kao postotak ugrađene grafike "
 "(dijalozi popisa zadržavaju fiksnu veličinu ikone retka)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11111,4 +11099,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ručno"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -1786,6 +1786,7 @@ msgstr "Engedélyezésével egy új sorban meg fog jelenni az érkezési magass�
 msgid "Select Color"
 msgstr "Válasszon színt"
 
+#, no-c-format
 msgid "Display"
 msgstr "Kijelző"
 
@@ -2029,10 +2030,6 @@ msgstr "Fordulópont típusok"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Nyelv, adatbevitel"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Képernyő elrendezés"
 
 #, no-c-format
 msgid "Audio"
@@ -3364,9 +3361,6 @@ msgstr "A 'végsiklás' InfóDoboz mód használata az 'automatikus' oldalakon."
 
 msgid "Text size"
 msgstr "Szöveg méret"
-
-msgid "Display Resolution"
-msgstr "Képernyő felbontás"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Képernyő felbontása a vonalvastagságok, betűméretek és egyebek megfelelő megjelenítéséhez."
@@ -8291,12 +8285,6 @@ msgstr ""
 "A fordulópont-szimbólumok mérete a térképen a beépített grafika százalékában"
 " (a listaablakok rögzített sorkikonméretet tartanak)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11151,4 +11139,93 @@ msgstr "Automata"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Kézi"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -1789,6 +1789,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Seleziona colore"
 
+#, no-c-format
 msgid "Display"
 msgstr "Mostra"
 
@@ -2035,10 +2036,6 @@ msgstr "Tipi di Boa"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Lingua, Immissione"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Schermo"
 
 #, no-c-format
 msgid "Audio"
@@ -3388,9 +3385,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Dimensione testo"
-
-msgid "Display Resolution"
-msgstr "Risoluzione display"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "La risoluzione del display è utilizzata per adattare lo spessore delle linee, la dimensione dei caratteri, degli atterrabili ed altro."
@@ -8393,12 +8387,6 @@ msgstr ""
 "Dimensione dei simboli waypoint sulla mappa come percentuale della grafica "
 "integrata (le finestre elenco mantengono una dimensione icona fissa)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUALE"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11266,4 +11254,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuale"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -1812,6 +1812,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "色の選択"
 
+#, no-c-format
 msgid "Display"
 msgstr "表示"
 
@@ -2061,10 +2062,6 @@ msgstr "旋回点の種類"
 #, no-c-format
 msgid "Language, Input"
 msgstr "入力言語"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "画面表示"
 
 #, no-c-format
 msgid "Audio"
@@ -3380,9 +3377,6 @@ msgstr "ファイナルグライド　モードを自動モードで使用する
 
 msgid "Text size"
 msgstr "文字サイズ"
-
-msgid "Display Resolution"
-msgstr "表示解像度"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "画面表示解像度は、線の幅、フォントサイズ、表示ラベルなど。"
@@ -8372,12 +8366,6 @@ msgstr "ウェイポイントアイコンサイズ"
 msgid "Size of waypoint symbols on the map as a percentage of the built-in artwork (list dialogs keep a fixed row icon size)."
 msgstr "地図上のウェイポイント記号サイズを内蔵アートワークに対する百分率で指定（一覧ダイアログは固定の行アイコンサイズ）。"
 
-msgid "Altn mode: MANUAL"
-msgstr "代替モード: 手動"
-
-msgid "Altn mode: AUTO"
-msgstr "代替モード: 自動"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11087,4 +11075,93 @@ msgstr "自動"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "手動"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -1787,6 +1787,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "색상선택"
 
+#, no-c-format
 msgid "Display"
 msgstr "화면"
 
@@ -2027,10 +2028,6 @@ msgstr "턴포인트종류"
 #, no-c-format
 msgid "Language, Input"
 msgstr "언어, 입력"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "화면표시"
 
 #, no-c-format
 msgid "Audio"
@@ -3330,9 +3327,6 @@ msgstr "골포인트 비행일때, 정보창을 골러시(Final Glide)로 자동
 
 msgid "Text size"
 msgstr "글자 크기"
-
-msgid "Display Resolution"
-msgstr "화면해상도"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "해상도조정: 표시되는 선의 굵기와 글자크기가 달라진다."
@@ -8135,12 +8129,6 @@ msgstr "Veličina ikone točke"
 msgid "Size of waypoint symbols on the map as a percentage of the built-in artwork (list dialogs keep a fixed row icon size)."
 msgstr "지도 위 웨이포인트 기호 크기(내장 그래픽 대비 백분율; 목록 대화상자는 고정 행 아이콘 크기 유지)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -10870,4 +10858,93 @@ msgstr "자동"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "수동"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -1784,6 +1784,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Pasirinkti spalva"
 
+#, no-c-format
 msgid "Display"
 msgstr "Rodyti"
 
@@ -2026,10 +2027,6 @@ msgstr "Posūkio taškų tipai"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Kalbos, įvestis"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Skraipojimo lentelė"
 
 #, no-c-format
 msgid "Audio"
@@ -3362,9 +3359,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Teksto dydis"
-
-msgid "Display Resolution"
-msgstr "Naudotojo įrašo resoliucija"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Naudotojo įrašo resoliucija naudojama, kad aptiktų linijų plotus, šriftinės dydžio ir ledo dydžio."
@@ -8292,12 +8286,6 @@ msgstr ""
 "Maršruto taškų simbolių dydis žemėlapyje procentais nuo įmontuotos grafikos "
 "(sąrašo dialogai išlaiko fiksuotą eilutės piktogramos dydį)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11143,4 +11131,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Rankinis"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -1804,6 +1804,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Velg farge"
 
+#, no-c-format
 msgid "Display"
 msgstr "Vis"
 
@@ -2045,10 +2046,6 @@ msgstr "Vendepunktstyper"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Språk, Input"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Skjermoppsett"
 
 #, no-c-format
 msgid "Audio"
@@ -3354,9 +3351,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tekst"
-
-msgid "Display Resolution"
-msgstr "Vis orientering"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Skjermoppløsning brukes for å anpasse linjesledd, tegnemål og mer."
@@ -8227,12 +8221,6 @@ msgstr ""
 "Storlek på veisepunktsymboler på kartet shvis procent av inbyggd grafik "
 "(listdialoger beholder fast radikonstorlek)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Alternativmodus: MANUELL"
-
-msgid "Altn mode: AUTO"
-msgstr "Alternativmodus: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11046,4 +11034,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Man"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -1794,6 +1794,7 @@ msgstr "Laat regel voor de aankomst hoogte van de lokatie zien."
 msgid "Select Color"
 msgstr "Selecteer Kleur"
 
+#, no-c-format
 msgid "Display"
 msgstr "Weergave"
 
@@ -2040,10 +2041,6 @@ msgstr "Keerpunt Typen"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Taal, Invoer"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Schermindeling"
 
 #, no-c-format
 msgid "Audio"
@@ -3387,9 +3384,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tekstgrootte"
-
-msgid "Display Resolution"
-msgstr "Schermresolutie"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "De schermresolutie wordt gebruikt om de regelbreedte, tekst- en veldgrootte aan te passen."
@@ -8347,12 +8341,6 @@ msgstr ""
 "Grootte van waypointsymbolen op de kaart als percentage van de ingebouwde "
 "graphics (lijstdialogen houden een vaste rijpictogramgrootte)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn-modus: HANDMATIG"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn-modus: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11210,4 +11198,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Handmatig"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1799,6 +1799,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Wybierz kolor"
 
+#, no-c-format
 msgid "Display"
 msgstr "Pokazuj"
 
@@ -2043,10 +2044,6 @@ msgstr "Punkty Trasy"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Język, Komunikaty"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Układ ekranu"
 
 #, no-c-format
 msgid "Audio"
@@ -3378,9 +3375,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Rozmiar tekstu"
-
-msgid "Display Resolution"
-msgstr "Rozdzielczość wyświetlacza"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Rozdzielczość wyświetlacza pomaga dostosować szerokość linii, rozmiar czcionki, lądowisk i innych."
@@ -8353,12 +8347,6 @@ msgstr ""
 "Rozmiar symboli punktów trasy na mapie jako procent wbudowanej grafiki (okna"
 " list zachowują stały rozmiar ikony wiersza)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Tryb Altn: RĘCZNY"
-
-msgid "Altn mode: AUTO"
-msgstr "Tryb Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11202,4 +11190,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ręcznie"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -1790,6 +1790,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Selecionar Cor"
 
+#, no-c-format
 msgid "Display"
 msgstr "Ecrã"
 
@@ -2034,10 +2035,6 @@ msgstr "Tipos de Turnpoints"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Idioma, Entrada"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Layout da Ecrã"
 
 #, no-c-format
 msgid "Audio"
@@ -3369,9 +3366,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tamanho do texto"
-
-msgid "Display Resolution"
-msgstr "Orientação do display"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "A resolução da exibição é usada para adaptar as larguras das linhas, o tamanho da fonte, o tamanho dos aterros e mais."
@@ -8308,12 +8302,6 @@ msgstr ""
 "Tamanho dos símbolos de waypoint no mapa como percentagem da arte "
 "incorporada (diálogos de lista mantêm um tamanho de ícone de linha fixo)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUAL"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11173,4 +11161,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manual"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1790,6 +1790,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Selecionar Cor"
 
+#, no-c-format
 msgid "Display"
 msgstr "Mostrar"
 
@@ -2034,10 +2035,6 @@ msgstr "Tipos de Turnpoints"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Idioma, Entrada"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Layout da Tela"
 
 #, no-c-format
 msgid "Audio"
@@ -3370,9 +3367,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Tamanho do texto"
-
-msgid "Display Resolution"
-msgstr "Orientação do display"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "A resolução da exibição é usada para adaptar as larguras das linhas, o tamanho da fonte, o tamanho dos aterros e mais."
@@ -8304,12 +8298,6 @@ msgstr ""
 "Tamanho dos símbolos de waypoint no mapa como porcentagem da arte "
 "incorporada (diálogos de lista mantêm um tamanho de ícone de linha fixo)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUAL"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11169,4 +11157,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manual"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -1797,6 +1797,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Selectează culoare"
 
+#, no-c-format
 msgid "Display"
 msgstr "Afișare"
 
@@ -2041,10 +2042,6 @@ msgstr "Tipuri de puncte de intoarcere"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Limba, Intrare"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Dispozitiv de afișare a ecranului"
 
 #, no-c-format
 msgid "Audio"
@@ -3380,9 +3377,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Mărime text"
-
-msgid "Display Resolution"
-msgstr "Résoluția afișajului"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Résoluția afișajului este utilizată pentru a adapta lățimile liniei, dimensiunea fontului, dimensiunea terenurilor landabile și mai multe."
@@ -8297,12 +8291,6 @@ msgstr ""
 "Dimensiunea simbolurilor de punct de traseu pe hartă ca procent din grafica "
 "încorporată (dialogurile listă păstrează o dimensiune fixă)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Modo Altn: MANUALE"
-
-msgid "Altn mode: AUTO"
-msgstr "Modo Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11156,4 +11144,93 @@ msgstr "Automat"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manual"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -1792,6 +1792,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Выберите цвет"
 
+#, no-c-format
 msgid "Display"
 msgstr "Отобразить"
 
@@ -2035,10 +2036,6 @@ msgstr "Тип поворотной точки"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Язык, ввод"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Вид экрана"
 
 #, no-c-format
 msgid "Audio"
@@ -3373,9 +3370,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "ТЕКСТ"
-
-msgid "Display Resolution"
-msgstr "Ориентация дисплея"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Разрешение экрана используется для адаптации ширины линий, размера шрифта, размера посадочной площадки и т.д."
@@ -8344,12 +8338,6 @@ msgstr ""
 "Размер символов ППМ на карте в процентах от встроенной графики (диалоги "
 "списков сохраняют фиксированный размер значка строки)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Режим Altn: РУЧНОЙ"
-
-msgid "Altn mode: AUTO"
-msgstr "Режим Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11188,4 +11176,93 @@ msgstr "Авто"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Вручную"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -1794,6 +1794,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Zvoľ farbu"
 
+#, no-c-format
 msgid "Display"
 msgstr "Zobrazenie"
 
@@ -2038,10 +2039,6 @@ msgstr "Typy otočných bodov"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Jazyk, vstup"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Rozloženie obrazovky"
 
 #, no-c-format
 msgid "Audio"
@@ -3360,9 +3357,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Veľkosť textu"
-
-msgid "Display Resolution"
-msgstr "Rozlíšenie displeja"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Rozlíšenie displeja je použité na adaptáciu hrúbky čiar, veľkosť písma a iného."
@@ -8285,12 +8279,6 @@ msgstr ""
 "Velikost symbolô bodov trate na mapě jako procento vestavěné grafiky "
 "(dialogy zoznamô zachovávají pevnou velikost ikony riadku)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Režim Altn: RUČNÍ"
-
-msgid "Altn mode: AUTO"
-msgstr "Režim Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11116,4 +11104,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ručne"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -1787,6 +1787,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Izberite barvo"
 
+#, no-c-format
 msgid "Display"
 msgstr "Prikaz"
 
@@ -2031,10 +2032,6 @@ msgstr "Tipi obratnih točk | Turnpoint Types"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Jezik, vnos | Language, Input"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Prikaz zaslona | Screen Layout"
 
 #, no-c-format
 msgid "Audio"
@@ -3364,9 +3361,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Velikost besedila"
-
-msgid "Display Resolution"
-msgstr "Rešitev zaslona"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Rešitev zaslona se uporablja za dostosovanje širine vrstic, velikosti pismenosti, velikosti letalnih območij in več."
@@ -8255,12 +8249,6 @@ msgstr ""
 "Veličina simbola točk poti na zemljevidu kao postotak ugrađene grafike "
 "(dijalozi seznama zadržavaju fiksnu veličinu ikone retka)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11093,4 +11081,93 @@ msgstr "Avto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Ročno"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -1776,6 +1776,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Odabir boje"
 
+#, no-c-format
 msgid "Display"
 msgstr "Ekran"
 
@@ -2019,10 +2020,6 @@ msgstr "Tipovi tacka okreta"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Jezik, Unos"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Prikaz prozora"
 
 #, no-c-format
 msgid "Audio"
@@ -3356,9 +3353,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Veličina teksta"
-
-msgid "Display Resolution"
-msgstr "Lokalno vreme"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Resolucija prikaza se koristi za prilagođavanje širine linija, veličine fonta, veličine letljivih površina i mnogo drugih."
@@ -8266,12 +8260,6 @@ msgstr ""
 "Veličina simbola tačaka rute na karti kao postotak ugrađene grafike "
 "(dijalozi popisa zadržavaju fiksnu veličinu ikone retka)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11099,4 +11087,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Uputstvo"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1787,6 +1787,7 @@ msgstr "Om aktiverad, visar en rad högst upp med ankomsthöjd vid platsen."
 msgid "Select Color"
 msgstr "Välj färg"
 
+#, no-c-format
 msgid "Display"
 msgstr "Visa"
 
@@ -2029,10 +2030,6 @@ msgstr "Vändpunktstyper"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Språk, inmatning"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Skärmupplägg"
 
 #, no-c-format
 msgid "Audio"
@@ -3341,9 +3338,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Textstorlek"
-
-msgid "Display Resolution"
-msgstr "Skärmupplösning"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Skärmupplösningen används för att anpassa linjebredd, font-storlek, banstorlek med mera."
@@ -8223,12 +8217,6 @@ msgstr ""
 "Storlek på vägpointsymboler på kartan som procent av inbyggd grafik "
 "(listdialoger behåller fast radikonstorlek)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn-läge: MANUELL"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn-läge: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11054,4 +11042,93 @@ msgstr "Auto"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Manuell"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -1757,6 +1757,7 @@ msgstr "ఇఫ్ ఎన్నికా వైపు శీర్షం కల�
 msgid "Select Color"
 msgstr "కోలర్ ఎంపిక నియంత్రణ"
 
+#, no-c-format
 msgid "Display"
 msgstr "పేజీన్యాలు దాదాపు"
 
@@ -2000,10 +2001,6 @@ msgstr "టర్న్ పాయింట్ రకాలు"
 #, no-c-format
 msgid "Language, Input"
 msgstr "భాషలు, ఇంపులు"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "స్కీన్ లేబ్లైట్"
 
 #, no-c-format
 msgid "Audio"
@@ -3289,9 +3286,6 @@ msgstr "అటో\" పాజెస్‌లో \"ఫైనల్‌గ్లై
 
 msgid "Text size"
 msgstr "టెక్స్‌ వేలు"
-
-msgid "Display Resolution"
-msgstr "డిస్ప్లే రిజల్యూషన్"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "ప్రాక్తన విడుదల దృష్టి నియంత్రణ అవసరమైన రేఖ వెడల్పనలు, ఫోం చదువు, లాండబుల్ వెడల్పనలు మరియు కొత్త రేఖలకు సరైన చదువులను నియంత్రించడానికి ఉపయోగించబడుతుంది."
@@ -8078,12 +8072,6 @@ msgstr ""
 "అంతర్నిర్మిత కళాకృతి యొక్క శాతంగా మ్యాప్‌లోని వే పాయింట్ చిహ్నాల పరిమాణం "
 "(జాబితా డైలాగ్‌లు స్థిర వరుస చిహ్నం పరిమాణాన్ని ఉంచుతాయి)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -10936,4 +10924,93 @@ msgstr "ఆటో"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "మానిలోయిక్"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -1773,6 +1773,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Renk Seç"
 
+#, no-c-format
 msgid "Display"
 msgstr "Görünüm"
 
@@ -2019,10 +2020,6 @@ msgstr "Dönüş Noktaları Türleri"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Dil, Giriş"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Ekran Düzeni"
 
 #, no-c-format
 msgid "Audio"
@@ -3359,9 +3356,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Metin boyutu"
-
-msgid "Display Resolution"
-msgstr "Görüntü çözünürlüğü"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Görüntü çözünürlüğü, çizgi kalınlıklarını, yazı tipi boyutlarını ve atlanabilir alanları ayarlama gibi kullanılır."
@@ -8265,12 +8259,6 @@ msgstr ""
 "Yerleşik resmin yüzdesi olarak haritadaki yol noktası sembollerinin boyutu "
 "(liste iletişim kutuları sabit bir satır simgesi boyutunu korur)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11119,4 +11107,93 @@ msgstr "Otomatik"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "El ile"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -1802,6 +1802,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Обрати колір"
 
+#, no-c-format
 msgid "Display"
 msgstr "Показати"
 
@@ -2046,10 +2047,6 @@ msgstr "Типи ППМ"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Мова, ввід"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Конфігурація екрану"
 
 #, no-c-format
 msgid "Audio"
@@ -3370,9 +3367,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Розмір тексту"
-
-msgid "Display Resolution"
-msgstr "Роздільна зд. дисплея"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Роздільна здатність дисплея використовується для адаптації ширини лінії, розміру шрифту, розміру приземлення тощо."
@@ -8343,12 +8337,6 @@ msgstr ""
 "Розмір символів ППМ на карті у відсотках від вбудованої графіки (діалоги "
 "списків зберігають фіксований розмір значка рядка)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Режим Altn: РУЧНОЙ"
-
-msgid "Altn mode: AUTO"
-msgstr "Режим Altn: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11189,4 +11177,93 @@ msgstr "Авто"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Вручну"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -1775,6 +1775,7 @@ msgstr ""
 msgid "Select Color"
 msgstr "Chọn Màu sắc"
 
+#, no-c-format
 msgid "Display"
 msgstr "Hiển thị"
 
@@ -2018,10 +2019,6 @@ msgstr "Loại điểm quay vòng"
 #, no-c-format
 msgid "Language, Input"
 msgstr "Ngôn ngữ, Nhập liệu"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "Thiết kế màn hình"
 
 #, no-c-format
 msgid "Audio"
@@ -3340,9 +3337,6 @@ msgstr ""
 
 msgid "Text size"
 msgstr "Kích thước văn bản"
-
-msgid "Display Resolution"
-msgstr "Độ phân giải màn hình"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "Độ phân giải màn hình được sử dụng để điều chỉnh độ rộng của các đường, kích cỡ chữ, và kích thước hạ cánh."
@@ -8238,12 +8232,6 @@ msgstr ""
 "của tác phẩm nghệ thuật tích hợp (hộp thoại danh sách giữ kích thước biểu "
 "tượng hàng cố định)."
 
-msgid "Altn mode: MANUAL"
-msgstr "Altn način: RUČNI"
-
-msgid "Altn mode: AUTO"
-msgstr "Altn način: AUTO"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -11064,4 +11052,93 @@ msgstr "Tự động"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "Hướng dẫn thủ công"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xcsoar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-20 22:41+0200\n"
+"POT-Creation-Date: 2026-08-28 09:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2590,6 +2590,7 @@ msgstr ""
 msgid "Select Color"
 msgstr ""
 
+#, no-c-format
 msgid "Display"
 msgstr ""
 
@@ -3006,7 +3007,7 @@ msgid "Language, Input"
 msgstr ""
 
 #, no-c-format
-msgid "Screen Layout"
+msgid "Layout"
 msgstr ""
 
 #, no-c-format
@@ -3015,6 +3016,10 @@ msgstr ""
 
 #, no-c-format
 msgid "Audio"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
 msgstr ""
 
 #, no-c-format
@@ -3042,6 +3047,9 @@ msgid "Expert"
 msgstr ""
 
 msgid "Configuration"
+msgstr ""
+
+msgid "Back"
 msgstr ""
 
 msgid "The name of this InfoBox panel configuration."
@@ -4177,6 +4185,125 @@ msgstr ""
 msgid "This parameter enables or disables the No Position Target Distance Ring in Flarm Radar"
 msgstr ""
 
+#, no-c-format
+msgctxt "Setting"
+msgid "LCD"
+msgstr ""
+
+#, no-c-format
+msgid "Conventional LCD or OLED. Full scrolling animations."
+msgstr ""
+
+#, no-c-format
+msgctxt "Setting"
+msgid "E-ink"
+msgstr ""
+
+#, no-c-format
+msgid "Monochrome electronic paper. Disables kinetic and smooth scrolling."
+msgstr ""
+
+#, no-c-format
+msgctxt "Setting"
+msgid "Color e-ink"
+msgstr ""
+
+#, no-c-format
+msgid "Color electronic paper. Disables kinetic and smooth scrolling like monochrome e-ink."
+msgstr ""
+
+#, no-c-format
+msgid "Portrait"
+msgstr ""
+
+#, no-c-format
+msgid "Landscape"
+msgstr ""
+
+#, no-c-format
+msgid "Reverse Portrait"
+msgstr ""
+
+#, no-c-format
+msgid "Reverse Landscape"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+#, no-c-format
+msgid "Use the system-wide setting"
+msgstr ""
+
+#, no-c-format
+msgid "Black text on white background"
+msgstr ""
+
+#, no-c-format
+msgid "White text on black background"
+msgstr ""
+
+msgid "Automatic"
+msgstr ""
+
+#, c-format
+msgid "%u dpi"
+msgstr ""
+
+#, no-c-format
+msgctxt "Setting"
+msgid "Display type"
+msgstr ""
+
+msgid "Select the display technology. E-ink modes disable kinetic and smooth scrolling for slow refresh screens."
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "The display resolution is used to adapt line widths, font size, landable size and more."
+msgstr ""
+
+msgid "Display orientation"
+msgstr ""
+
+msgid "Rotate the display on devices that support it."
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+msgid "Full screen"
+msgstr ""
+
+msgid "Run XCSoar in full screen mode"
+msgstr ""
+
+msgid "Dark mode"
+msgstr ""
+
+msgid "Text size"
+msgstr ""
+
+msgid "Cursor zoom"
+msgstr ""
+
+msgid "Cursor zoom factor"
+msgstr ""
+
+msgid "Invert cursor color"
+msgstr ""
+
+msgid "Enable black cursor"
+msgstr ""
+
 msgid "Speed arrows"
 msgstr ""
 
@@ -4317,22 +4444,6 @@ msgstr ""
 msgid "Controls whether the \"final glide\" InfoBox mode should be used on \"auto\" pages."
 msgstr ""
 
-msgid "Text size"
-msgstr ""
-
-msgid "Display Resolution"
-msgstr ""
-
-msgid "The display resolution is used to adapt line widths, font size, landable size and more."
-msgstr ""
-
-msgid "Automatic"
-msgstr ""
-
-#, c-format
-msgid "%u dpi"
-msgstr ""
-
 msgid "Events"
 msgstr ""
 
@@ -4395,49 +4506,6 @@ msgid "Safety disclaimer accepted"
 msgstr ""
 
 msgid "Whether the safety disclaimer has been accepted for this version."
-msgstr ""
-
-#, no-c-format
-msgid "Portrait"
-msgstr ""
-
-#, no-c-format
-msgid "Landscape"
-msgstr ""
-
-#, no-c-format
-msgid "Reverse Portrait"
-msgstr ""
-
-#, no-c-format
-msgid "Reverse Landscape"
-msgstr ""
-
-#, no-c-format
-msgctxt "Setting"
-msgid "LCD"
-msgstr ""
-
-#, no-c-format
-msgid "Conventional LCD or OLED. Full scrolling animations."
-msgstr ""
-
-#, no-c-format
-msgctxt "Setting"
-msgid "E-ink"
-msgstr ""
-
-#, no-c-format
-msgid "Monochrome electronic paper. Disables kinetic and smooth scrolling."
-msgstr ""
-
-#, no-c-format
-msgctxt "Setting"
-msgid "Color e-ink"
-msgstr ""
-
-#, no-c-format
-msgid "Color electronic paper. Disables kinetic and smooth scrolling like monochrome e-ink."
 msgstr ""
 
 #, no-c-format
@@ -4577,18 +4645,6 @@ msgid "Glass"
 msgstr ""
 
 #, no-c-format
-msgid "Use the system-wide setting"
-msgstr ""
-
-#, no-c-format
-msgid "Black text on white background"
-msgstr ""
-
-#, no-c-format
-msgid "White text on black background"
-msgstr ""
-
-#, no-c-format
 msgid "Follow global"
 msgstr ""
 
@@ -4610,29 +4666,6 @@ msgstr ""
 
 #, no-c-format
 msgid "Always use light text on a dark InfoBox background."
-msgstr ""
-
-msgid "Full screen"
-msgstr ""
-
-msgid "Run XCSoar in full screen mode"
-msgstr ""
-
-msgid "Display orientation"
-msgstr ""
-
-msgid "Rotate the display on devices that support it."
-msgstr ""
-
-msgid "Dark mode"
-msgstr ""
-
-#, no-c-format
-msgctxt "Setting"
-msgid "Display type"
-msgstr ""
-
-msgid "Select the display technology. E-ink modes disable kinetic and smooth scrolling for slow refresh screens."
 msgstr ""
 
 msgid "InfoBox geometry"
@@ -4683,18 +4716,6 @@ msgid "Show QuickMenu button"
 msgstr ""
 
 msgid "Show the QuickMenu button"
-msgstr ""
-
-msgid "Cursor zoom"
-msgstr ""
-
-msgid "Cursor zoom factor"
-msgstr ""
-
-msgid "Invert cursor color"
-msgstr ""
-
-msgid "Enable black cursor"
 msgstr ""
 
 #, no-c-format
@@ -5051,6 +5072,15 @@ msgid "Optional weather overlay on map pages. Use with Weather controls in the b
 msgstr ""
 
 msgid "Select a weather map overlay to configure its layer or level for this page."
+msgstr ""
+
+msgid "SkySight is unavailable."
+msgstr ""
+
+msgid "SkySight API rate-limited. Retrying shortly."
+msgstr ""
+
+msgid "Loading SkySight catalog..."
 msgstr ""
 
 #, no-c-format
@@ -6528,10 +6558,12 @@ msgstr ""
 msgid "Optimized"
 msgstr ""
 
-msgid "Altn mode: MANUAL"
-msgstr ""
-
-msgid "Altn mode: AUTO"
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
 msgstr ""
 
 #, no-c-format
@@ -6554,6 +6586,9 @@ msgstr ""
 #, no-c-format
 msgctxt "Menu"
 msgid "Alternates 2"
+msgstr ""
+
+msgid "Paste"
 msgstr ""
 
 msgid "Reset"
@@ -7066,12 +7101,6 @@ msgstr ""
 msgid "This function is not available on your platform yet."
 msgstr ""
 
-msgid "SkySight API rate-limited. Retrying shortly."
-msgstr ""
-
-msgid "Loading SkySight catalog..."
-msgstr ""
-
 msgid "No SkySight layers selected. Press Add to list to choose parameters."
 msgstr ""
 
@@ -7205,9 +7234,6 @@ msgstr ""
 #, no-c-format
 msgctxt "Button"
 msgid "Clear downloaded data"
-msgstr ""
-
-msgid "SkySight is unavailable."
 msgstr ""
 
 msgid "Failed to acknowledge airspace warning"
@@ -7486,6 +7512,57 @@ msgstr ""
 
 #, c-format
 msgid "Caching EDL forecast %s..."
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
 msgstr ""
 
 msgid "Could not contact the WiFi service."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1757,6 +1757,7 @@ msgstr "如果启用，将在顶部添加一行显示您的到达那个位置的
 msgid "Select Color"
 msgstr "选择颜色"
 
+#, no-c-format
 msgid "Display"
 msgstr "显示"
 
@@ -1997,10 +1998,6 @@ msgstr "转弯点类型"
 #, no-c-format
 msgid "Language, Input"
 msgstr "语言，输入"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "屏幕布局"
 
 #, no-c-format
 msgid "Audio"
@@ -3272,9 +3269,6 @@ msgstr "控制最终滑翔信息框模式是否应用于自动页。"
 
 msgid "Text size"
 msgstr "文本大小"
-
-msgid "Display Resolution"
-msgstr "显示分辨率"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "显示分辨率用于适应线宽、字体大小、可着陆区大小等。"
@@ -7988,12 +7982,6 @@ msgstr "航点图标大小"
 msgid "Size of waypoint symbols on the map as a percentage of the built-in artwork (list dialogs keep a fixed row icon size)."
 msgstr "地图上航点符号大小，为内置图稿的百分比（列表对话框保持固定行图标大小）。"
 
-msgid "Altn mode: MANUAL"
-msgstr "备降模式：手动"
-
-msgid "Altn mode: AUTO"
-msgstr "备降模式：自动"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -10689,4 +10677,93 @@ msgstr "自动"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "手册"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -1757,6 +1757,7 @@ msgstr "如果啟用，將在頂部添加一行顯示您的到達那個位置的
 msgid "Select Color"
 msgstr "選擇顏色"
 
+#, no-c-format
 msgid "Display"
 msgstr "顯示"
 
@@ -1997,10 +1998,6 @@ msgstr "轉彎點類型"
 #, no-c-format
 msgid "Language, Input"
 msgstr "語言，輸入"
-
-#, no-c-format
-msgid "Screen Layout"
-msgstr "螢幕佈局"
 
 #, no-c-format
 msgid "Audio"
@@ -3272,9 +3269,6 @@ msgstr "控制最終滑翔資訊框模式是否應用於自動頁。"
 
 msgid "Text size"
 msgstr "文本大小"
-
-msgid "Display Resolution"
-msgstr "顯示解析度"
 
 msgid "The display resolution is used to adapt line widths, font size, landable size and more."
 msgstr "顯示解析度用於適應線寬、字體大小、可著陸區大小等。"
@@ -7996,12 +7990,6 @@ msgstr "航點圖示大小"
 msgid "Size of waypoint symbols on the map as a percentage of the built-in artwork (list dialogs keep a fixed row icon size)."
 msgstr "地圖上航點符號大小，為內建圖稿的百分比（列表對話框保持固定列圖示大小）。"
 
-msgid "Altn mode: MANUAL"
-msgstr "備降模式：手動"
-
-msgid "Altn mode: AUTO"
-msgstr "備降模式：自動"
-
 msgid ""
 "# Gesture Navigation\n"
 "\n"
@@ -10697,4 +10685,93 @@ msgstr "自動"
 msgctxt "Setting"
 msgid "Manual"
 msgstr "手冊"
+
+#, no-c-format
+msgid "Layout"
+msgstr ""
+
+#, no-c-format
+msgid "Services"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+#, no-c-format
+msgid "Auto"
+msgstr ""
+
+msgid "Display resolution"
+msgstr ""
+
+msgid "Screen brightness"
+msgstr ""
+
+msgid "Adjust the screen brightness."
+msgstr ""
+
+msgid "Screen brightness is read-only because writing requires additional permissions."
+msgstr ""
+
+#. Alternate Mode: Auto returns a MANUAL slot to the computed
+#. list. Pinning is Select as Alternate, which is always
+#. available and sets MANUAL.
+#, no-c-format
+msgctxt "Button"
+msgid "Alternate Mode: Auto"
+msgstr ""
+
+msgid "Paste"
+msgstr ""
+
+msgid "No supported services found"
+msgstr ""
+
+msgid "No selected systemd units are installed."
+msgstr ""
+
+msgid "Unavailable"
+msgstr ""
+
+msgid "Starting..."
+msgstr ""
+
+msgid "Stopping..."
+msgstr ""
+
+msgid "Reloading..."
+msgstr ""
+
+msgid "Failed"
+msgstr ""
+
+msgid "Turn on"
+msgstr ""
+
+msgid "Restart"
+msgstr ""
+
+msgid "Turn off"
+msgstr ""
+
+msgid "System service"
+msgstr ""
+
+msgid "SSH server"
+msgstr ""
+
+msgid "Remote terminal access"
+msgstr ""
+
+msgid "Sensors"
+msgstr ""
+
+msgid "OpenVario sensor daemon"
+msgstr ""
+
+msgid "Audio vario"
+msgstr ""
+
+msgid "OpenVario audio vario daemon"
+msgstr ""
 


### PR DESCRIPTION
## Summary
- Same catalog refresh as `v7.45.x` (`7320db6256`): `po/xcsoar.pot` was behind xgettext (Display/Layout split, systemd services, iOS Paste, Alternate Mode: Auto, and other strings).
- Tag CI on `v7.45.1` requires the in-tree template to match. Master only autocommits pot drift to `translationupdates`.

## Test plan
- [ ] `build-translation.yml` on this PR
- [x] Produced by `make update-po` on `v7.45.x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated translation catalogs and the shared translation template with new display, layout, brightness, clipboard, alternate-mode, and service-management labels.
  * Added terminology for SSH, sensor, and audio-vario services.
  * Removed obsolete screen layout, resolution, and alternate-mode entries.
  * Newly added messages are currently untranslated in the affected languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->