### PR TITLE
Pinch-to-zoom and kinetic panning for waypoint pictures and weather images

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -82,6 +82,12 @@ Version 7.46 - not yet released
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
 * ui
+  - add pinch-to-zoom on waypoint pictures and downloaded weather
+    images: the image scales smoothly and follows the two fingers,
+    which also pan it #2868
+  - let a quick swipe across a zoomed waypoint picture or weather
+    image keep it moving for a moment, so that panning across a large
+    picture needs fewer strokes
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
 * development

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -71,6 +71,8 @@ Version 7.46 - not yet released
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862
+  - fix crash when moving the keyboard focus on the waypoint picture
+    page or in the flugwetter.de image view
 * infoboxen
   - pack portrait InfoBoxes on tall screens so title, value, and
     comment sit closer together; InfoBox title size still grows the

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -179,7 +179,7 @@ class WaypointDetailsWidget final
   LargeTextWindow details_text;
 
   StaticArray<Bitmap, 5> images;
-  int zoom = 0;
+  double zoom_factor = ImageZoomView::FIT_ZOOM_FACTOR;
 
 public:
   WaypointDetailsWidget(WidgetDialog &_dialog,
@@ -220,7 +220,9 @@ public:
   void OnMagnifyClicked();
   void OnShrinkClicked();
 
-  void AdjustViewForZoomChange(int old_zoom, int new_zoom) noexcept;
+  void AdjustViewForZoomChange(double old_zoom, double new_zoom) noexcept;
+
+  void SetZoomFactor(double new_zoom_factor) noexcept;
 
   void OnGotoClicked();
   void OnSimJumpClicked();
@@ -606,7 +608,7 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
     image_style.Hide();
 
     image_window.Create(parent, layout.main, image_style);
-    image_window.SetContent(&images[0], &zoom);
+    image_window.SetContent(&images[0], &zoom_factor);
 
     waypoint_image_input_target = this;
     const int mode_id = InputEvents::GetModeId("wptimg");
@@ -647,7 +649,7 @@ WaypointDetailsWidget::UpdatePage() noexcept
     magnify_button.SetVisible(image_page);
     shrink_button.SetVisible(image_page);
     if (image_page)
-      image_window.SetContent(&images[page - 3], &zoom);
+      image_window.SetContent(&images[page - 3], &zoom_factor);
   }
 
   UpdateCaption();
@@ -656,13 +658,13 @@ WaypointDetailsWidget::UpdatePage() noexcept
 void
 WaypointDetailsWidget::UpdateZoomControls()
 {
-  magnify_button.SetEnabled(zoom < ImageZoomView::max_zoom_level);
-  shrink_button.SetEnabled(zoom > 0);
+  magnify_button.SetEnabled(zoom_factor < ImageZoomView::MAX_ZOOM_FACTOR);
+  shrink_button.SetEnabled(!ImageZoomView::IsFitZoomFactor(zoom_factor));
 }
 
 void
-WaypointDetailsWidget::AdjustViewForZoomChange(const int old_zoom,
-                                               const int new_zoom) noexcept
+WaypointDetailsWidget::AdjustViewForZoomChange(const double old_zoom,
+                                               const double new_zoom) noexcept
 {
   if (images.empty() || page < 3 || !image_window.IsDefined())
     return;
@@ -698,37 +700,36 @@ WaypointDetailsWidget::NextPage(int step)
     image_window.Invalidate();
 
   if (page >= 3) {
-    const int old_zoom = zoom;
-    zoom = 0;
-    AdjustViewForZoomChange(old_zoom, zoom);
+    const double old_zoom_factor = zoom_factor;
+    zoom_factor = ImageZoomView::FIT_ZOOM_FACTOR;
+    AdjustViewForZoomChange(old_zoom_factor, zoom_factor);
     UpdateZoomControls();
   }
 }
 
 void
-WaypointDetailsWidget::OnMagnifyClicked()
+WaypointDetailsWidget::SetZoomFactor(const double new_zoom_factor) noexcept
 {
-  if (zoom >= ImageZoomView::max_zoom_level)
+  const double old_zoom_factor = zoom_factor;
+  zoom_factor = ImageZoomView::ClampZoomFactor(new_zoom_factor);
+  if (zoom_factor == old_zoom_factor)
     return;
 
-  const int old_zoom = zoom;
-  ++zoom;
-  AdjustViewForZoomChange(old_zoom, zoom);
+  AdjustViewForZoomChange(old_zoom_factor, zoom_factor);
   image_window.Invalidate();
   UpdateZoomControls();
 }
 
 void
+WaypointDetailsWidget::OnMagnifyClicked()
+{
+  SetZoomFactor(zoom_factor * ImageZoomView::ZOOM_STEP_FACTOR);
+}
+
+void
 WaypointDetailsWidget::OnShrinkClicked()
 {
-  if (zoom <= 0)
-    return;
-
-  const int old_zoom = zoom;
-  --zoom;
-  AdjustViewForZoomChange(old_zoom, zoom);
-  image_window.Invalidate();
-  UpdateZoomControls();
+  SetZoomFactor(zoom_factor / ImageZoomView::ZOOM_STEP_FACTOR);
 }
 
 bool
@@ -755,18 +756,15 @@ WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
     OnShrinkClicked();
     return;
   }
-  if (StringIsEqual(misc, "reset") && zoom > 0) {
-    const int old_zoom = zoom;
-    zoom = 0;
-    AdjustViewForZoomChange(old_zoom, zoom);
-    UpdateZoomControls();
-    image_window.Invalidate();
+  if (StringIsEqual(misc, "reset") &&
+      !ImageZoomView::IsFitZoomFactor(zoom_factor)) {
+    SetZoomFactor(ImageZoomView::FIT_ZOOM_FACTOR);
     goto_button.SetFocus();
     return;
   }
 
   if (StringIsEqual(misc, "left")) {
-    if (zoom == 0) {
+    if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       previous_button.SetFocus();
       NextPage(-1);
     } else
@@ -774,14 +772,14 @@ WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
     return;
   }
   if (StringIsEqual(misc, "right")) {
-    if (zoom == 0) {
+    if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       next_button.SetFocus();
       NextPage(+1);
     } else
       image_window.NudgeViewByPixelOffset({50, 0});
     return;
   }
-  if (zoom == 0)
+  if (ImageZoomView::IsFitZoomFactor(zoom_factor))
     return;
 
   if (StringIsEqual(misc, "up"))
@@ -810,7 +808,7 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
     if (!images.empty() && image_window.IsVisible()) {
       shrink_button.SetFocus();
       shrink_button.Click();
-      if (zoom == 0) {
+      if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
         next_button.SetFocus();
       } else {
         image_window.Invalidate();
@@ -821,14 +819,14 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
     return false;
 
   case KEY_LEFT:
-    if (zoom == 0) {
+    if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       previous_button.SetFocus();
       NextPage(-1);
     }
     return false;
 
   case KEY_RIGHT:
-    if (zoom == 0) {
+    if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       next_button.SetFocus();
       NextPage(+1);
       return true;
@@ -836,12 +834,9 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
     return false;
 
     case KEY_ESCAPE:
-      if (!images.empty() && zoom > 0) {
-        const int old_zoom = zoom;
-        zoom = 0;
-        AdjustViewForZoomChange(old_zoom, zoom);
-        image_window.Invalidate();
-        UpdateZoomControls();
+      if (!images.empty() &&
+          !ImageZoomView::IsFitZoomFactor(zoom_factor)) {
+        SetZoomFactor(ImageZoomView::FIT_ZOOM_FACTOR);
         goto_button.SetFocus();
         return true;
       }

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -618,6 +618,7 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
                       : std::nullopt;
     image_window.SetTryKeyInput(
         [this](unsigned k) { return TryWaypointImageKey(k); });
+    image_window.SetOnZoomChanged([this]() { UpdateZoomControls(); });
   } else {
     wptimg_mode.reset();
   }
@@ -630,8 +631,10 @@ WaypointDetailsWidget::Unprepare() noexcept
   if (waypoint_image_input_target == this)
     waypoint_image_input_target = nullptr;
   wptimg_mode.reset();
-  if (!images.empty())
+  if (!images.empty()) {
     image_window.SetTryKeyInput(nullptr);
+    image_window.SetOnZoomChanged(nullptr);
+  }
   info_widget.Unprepare();
   commands_widget.Unprepare();
 }

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -598,7 +598,14 @@ WaypointDetailsWidget::Prepare(ContainerWindow &parent,
   commands_widget.Prepare();
 
   if (!images.empty()) {
-    image_window.Create(parent, layout.main, dock_style);
+    /* no ControlParent() here: the image window is a PaintWindow
+       without children, and WindowList::FindControl() casts a
+       "control parent" to ContainerWindow while looking for the next
+       control */
+    WindowStyle image_style;
+    image_style.Hide();
+
+    image_window.Create(parent, layout.main, image_style);
     image_window.SetContent(&images[0], &zoom);
 
     waypoint_image_input_target = this;

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -766,12 +766,15 @@ WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
     return;
   }
 
+  /* ::Layout, not this class's nested Layout struct */
+  const int step = ::Layout::Scale(ImageZoomView::PAN_STEP);
+
   if (StringIsEqual(misc, "left")) {
     if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       previous_button.SetFocus();
       NextPage(-1);
     } else
-      image_window.NudgeViewByPixelOffset({-50, 0});
+      image_window.NudgeViewByPixelOffset({-step, 0});
     return;
   }
   if (StringIsEqual(misc, "right")) {
@@ -779,16 +782,16 @@ WaypointDetailsWidget::OnWaypointImageEvent(const char *misc) noexcept
       next_button.SetFocus();
       NextPage(+1);
     } else
-      image_window.NudgeViewByPixelOffset({50, 0});
+      image_window.NudgeViewByPixelOffset({step, 0});
     return;
   }
   if (ImageZoomView::IsFitZoomFactor(zoom_factor))
     return;
 
   if (StringIsEqual(misc, "up"))
-    image_window.NudgeViewByPixelOffset({0, -50});
+    image_window.NudgeViewByPixelOffset({0, -step});
   else if (StringIsEqual(misc, "down"))
-    image_window.NudgeViewByPixelOffset({0, 50});
+    image_window.NudgeViewByPixelOffset({0, step});
 }
 
 bool

--- a/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
+++ b/src/Dialogs/Waypoint/dlgWaypointDetails.cpp
@@ -828,6 +828,7 @@ WaypointDetailsWidget::KeyPress(unsigned key_code) noexcept {
     if (ImageZoomView::IsFitZoomFactor(zoom_factor)) {
       previous_button.SetFocus();
       NextPage(-1);
+      return true;
     }
     return false;
 

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -146,12 +146,14 @@ public:
     image_window.SetContent(&bitmap, &zoom_factor);
     image_window.SetTryKeyInput(
       [this](unsigned key_code) { return TryImageKey(key_code); });
+    image_window.SetOnZoomChanged([this]() { UpdateZoomControls(); });
     UpdateZoomControls();
   }
 
   void Unprepare() noexcept override
   {
     image_window.SetTryKeyInput(nullptr);
+    image_window.SetOnZoomChanged(nullptr);
   }
 
   void Show(const PixelRect &rc) noexcept override

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -10,6 +10,7 @@
 
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
+#include "Screen/Layout.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Dialogs/CoFunctionDialog.hpp"
 #include "Dialogs/Error.hpp"
@@ -94,6 +95,8 @@ public:
   bool
   TryImageKey(unsigned key_code) noexcept
   {
+    const int step = Layout::Scale(ImageZoomView::PAN_STEP);
+
     switch (key_code) {
     case KEY_F2:
       Magnify();
@@ -106,25 +109,25 @@ public:
     case KEY_LEFT:
       if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
-      image_window.NudgeViewByPixelOffset({-50, 0});
+      image_window.NudgeViewByPixelOffset({-step, 0});
       return true;
 
     case KEY_RIGHT:
       if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
-      image_window.NudgeViewByPixelOffset({50, 0});
+      image_window.NudgeViewByPixelOffset({step, 0});
       return true;
 
     case KEY_UP:
       if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
-      image_window.NudgeViewByPixelOffset({0, -50});
+      image_window.NudgeViewByPixelOffset({0, -step});
       return true;
 
     case KEY_DOWN:
       if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
-      image_window.NudgeViewByPixelOffset({0, 50});
+      image_window.NudgeViewByPixelOffset({0, step});
       return true;
 
     default:

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -33,7 +33,7 @@
 class PCMetImageWidget final : public NullWidget {
   const Bitmap &bitmap;
   ImageZoomFrame image_window;
-  int zoom = 0;
+  double zoom_factor = ImageZoomView::FIT_ZOOM_FACTOR;
 
   Button *magnify_button = nullptr;
   Button *shrink_button = nullptr;
@@ -41,12 +41,12 @@ class PCMetImageWidget final : public NullWidget {
   void UpdateZoomControls() noexcept
   {
     if (magnify_button != nullptr)
-      magnify_button->SetEnabled(zoom < ImageZoomView::max_zoom_level);
+      magnify_button->SetEnabled(zoom_factor < ImageZoomView::MAX_ZOOM_FACTOR);
     if (shrink_button != nullptr)
-      shrink_button->SetEnabled(zoom > 0);
+      shrink_button->SetEnabled(!ImageZoomView::IsFitZoomFactor(zoom_factor));
   }
 
-  void AdjustView(const int old_zoom, const int new_zoom) noexcept
+  void AdjustView(const double old_zoom, const double new_zoom) noexcept
   {
     if (!image_window.IsDefined())
       return;
@@ -69,28 +69,26 @@ public:
     UpdateZoomControls();
   }
 
-  void Magnify() noexcept
+  void SetZoomFactor(const double new_zoom_factor) noexcept
   {
-    if (zoom >= ImageZoomView::max_zoom_level)
+    const double old_zoom_factor = zoom_factor;
+    zoom_factor = ImageZoomView::ClampZoomFactor(new_zoom_factor);
+    if (zoom_factor == old_zoom_factor)
       return;
 
-    const int old_zoom = zoom;
-    ++zoom;
-    AdjustView(old_zoom, zoom);
+    AdjustView(old_zoom_factor, zoom_factor);
     image_window.Invalidate();
     UpdateZoomControls();
   }
 
+  void Magnify() noexcept
+  {
+    SetZoomFactor(zoom_factor * ImageZoomView::ZOOM_STEP_FACTOR);
+  }
+
   void Shrink() noexcept
   {
-    if (zoom <= 0)
-      return;
-
-    const int old_zoom = zoom;
-    --zoom;
-    AdjustView(old_zoom, zoom);
-    image_window.Invalidate();
-    UpdateZoomControls();
+    SetZoomFactor(zoom_factor / ImageZoomView::ZOOM_STEP_FACTOR);
   }
 
   bool
@@ -106,25 +104,25 @@ public:
       return true;
 
     case KEY_LEFT:
-      if (zoom == 0)
+      if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
       image_window.NudgeViewByPixelOffset({-50, 0});
       return true;
 
     case KEY_RIGHT:
-      if (zoom == 0)
+      if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
       image_window.NudgeViewByPixelOffset({50, 0});
       return true;
 
     case KEY_UP:
-      if (zoom == 0)
+      if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
       image_window.NudgeViewByPixelOffset({0, -50});
       return true;
 
     case KEY_DOWN:
-      if (zoom == 0)
+      if (ImageZoomView::IsFitZoomFactor(zoom_factor))
         return false;
       image_window.NudgeViewByPixelOffset({0, 50});
       return true;
@@ -145,7 +143,7 @@ public:
     image_style.Hide();
 
     image_window.Create(parent, rc, image_style);
-    image_window.SetContent(&bitmap, &zoom);
+    image_window.SetContent(&bitmap, &zoom_factor);
     image_window.SetTryKeyInput(
       [this](unsigned key_code) { return TryImageKey(key_code); });
     UpdateZoomControls();

--- a/src/Dialogs/Weather/PCMetDialog.cpp
+++ b/src/Dialogs/Weather/PCMetDialog.cpp
@@ -137,9 +137,12 @@ public:
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override
   {
+    /* no ControlParent() here: the image window is a PaintWindow
+       without children, and WindowList::FindControl() casts a
+       "control parent" to ContainerWindow while looking for the next
+       control */
     WindowStyle image_style;
     image_style.Hide();
-    image_style.ControlParent();
 
     image_window.Create(parent, rc, image_style);
     image_window.SetContent(&bitmap, &zoom);

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -5,6 +5,7 @@
 #include "ImageZoomView.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
+#include "Screen/Layout.hpp"
 #include "ui/canvas/Bitmap.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Features.hpp"
@@ -317,21 +318,23 @@ ImageZoomFrame::OnKeyDown(const unsigned key_code) noexcept
   if (try_key_input && try_key_input(key_code))
     return true;
 
+  const int step = Layout::Scale(ImageZoomView::PAN_STEP);
+
   switch (key_code) {
   case KEY_LEFT:
-    pending_offset.x -= 50;
+    pending_offset.x -= step;
     break;
 
   case KEY_RIGHT:
-    pending_offset.x += 50;
+    pending_offset.x += step;
     break;
 
   case KEY_UP:
-    pending_offset.y -= 50;
+    pending_offset.y -= step;
     break;
 
   case KEY_DOWN:
-    pending_offset.y += 50;
+    pending_offset.y += step;
     break;
 
   default:

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -10,6 +10,8 @@
 #include "ui/canvas/Features.hpp"
 #include "ui/event/KeyCode.hpp"
 
+#include <cmath>
+
 void
 ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
                        const WindowStyle &style) noexcept
@@ -18,8 +20,7 @@ ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
 }
 
 void
-ImageZoomFrame::SetContent(const Bitmap *_bitmap,
-                           double *_zoom_factor) noexcept
+ImageZoomFrame::SetContent(const Bitmap *_bitmap, double *_zoom_factor) noexcept
 {
   bitmap = _bitmap;
   zoom_factor = _zoom_factor;
@@ -33,6 +34,12 @@ void
 ImageZoomFrame::SetTryKeyInput(std::function<bool(unsigned)> &&f) noexcept
 {
   try_key_input = std::move(f);
+}
+
+void
+ImageZoomFrame::SetOnZoomChanged(std::function<void()> &&f) noexcept
+{
+  on_zoom_changed = std::move(f);
 }
 
 void
@@ -74,6 +81,10 @@ ImageZoomFrame::OnMouseDown(const PixelPoint p) noexcept
 {
   is_dragging = true;
   last_mouse_pos = p;
+
+  /* capture the pointer, so the drag continues outside this window,
+     and so multi-touch events are delivered here */
+  SetCapture();
   return true;
 }
 
@@ -81,7 +92,109 @@ bool
 ImageZoomFrame::OnMouseUp([[maybe_unused]] const PixelPoint p) noexcept
 {
   is_dragging = false;
+#ifdef HAVE_MULTI_TOUCH
+  is_pinching = false;
+#endif
+  ReleaseCapture();
   return true;
+}
+
+#ifdef HAVE_MULTI_TOUCH
+
+bool
+ImageZoomFrame::OnMultiTouchDown() noexcept
+{
+  if (bitmap == nullptr || zoom_factor == nullptr)
+    return false;
+
+  /* the second finger takes over: a single-finger drag must not pan
+     while the pinch is running */
+  is_dragging = false;
+  is_pinching = false;
+  return true;
+}
+
+bool
+ImageZoomFrame::OnMultiTouchMove(const PixelPoint a,
+                                 const PixelPoint b) noexcept
+{
+  if (bitmap == nullptr || zoom_factor == nullptr)
+    return false;
+
+  const double distance = std::hypot(double(a.x - b.x), double(a.y - b.y));
+  if (distance < 1)
+    return true;
+
+  const PixelPoint centroid{(a.x + b.x) / 2, (a.y + b.y) / 2};
+
+  if (!is_pinching) {
+    is_dragging = false;
+    is_pinching = true;
+    pinch_distance = distance;
+    pinch_zoom_factor = *zoom_factor;
+    pinch_last_a = a;
+    pinch_last_b = b;
+
+    /* remember which bitmap position the fingers grabbed; it stays
+       below them for the rest of the gesture */
+    pinch_anchor = ImageZoomView::CanvasToBitmap(centroid, view_pos,
+                                                 GetSize(),
+                                                 bitmap->GetSize(),
+                                                 *zoom_factor);
+
+    /* the gesture writes the view position directly, and a pan offset
+       which has not been painted yet would be applied on top of it */
+    pending_offset = {};
+    return true;
+  }
+
+  if (a == pinch_last_a && b == pinch_last_b)
+    /* one motion event per finger arrives, but both positions are read
+       from the current device state; skip the duplicate */
+    return true;
+
+  pinch_last_a = a;
+  pinch_last_b = b;
+
+  /* scale with the distance between the fingers, and keep the grabbed
+     bitmap position below their centre; this zooms and pans in one
+     step */
+  *zoom_factor = ImageZoomView::ClampZoomFactor(pinch_zoom_factor *
+                                                distance / pinch_distance);
+
+  ImageZoomView::MoveViewTo(pinch_anchor, centroid, view_pos, GetSize(),
+                            bitmap->GetSize(), *zoom_factor);
+
+  if (on_zoom_changed)
+    on_zoom_changed();
+
+  Invalidate();
+  return true;
+}
+
+bool
+ImageZoomFrame::OnMultiTouchUp() noexcept
+{
+  if (!is_pinching)
+    return false;
+
+  /* keep the current zoom factor; the remaining finger does not resume
+     panning, because that would jump the image */
+  is_pinching = false;
+  return true;
+}
+
+#endif /* HAVE_MULTI_TOUCH */
+
+void
+ImageZoomFrame::OnCancelMode() noexcept
+{
+  is_dragging = false;
+#ifdef HAVE_MULTI_TOUCH
+  is_pinching = false;
+#endif
+
+  WndOwnerDrawFrame::OnCancelMode();
 }
 
 bool

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -9,8 +9,22 @@
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Features.hpp"
 #include "ui/event/KeyCode.hpp"
+#include "Asset.hpp"
+#include "Hardware/CPU.hpp"
 
 #include <cmath>
+
+/**
+ * Can the image glide on after a drag?  Fast displays get kinetic
+ * panning; e-paper and slow CPUs stop with the finger (same gate as
+ * the list and the map pan animations).
+ */
+[[gnu::pure]]
+static bool
+UseKineticPan() noexcept
+{
+  return !HasEPaper() && !IsSlowCPU();
+}
 
 void
 ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
@@ -22,6 +36,8 @@ ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
 void
 ImageZoomFrame::SetContent(const Bitmap *_bitmap, double *_zoom_factor) noexcept
 {
+  kinetic_timer.Cancel();
+
   bitmap = _bitmap;
   zoom_factor = _zoom_factor;
   view_pos = {};
@@ -72,6 +88,11 @@ ImageZoomFrame::OnMouseMove(const PixelPoint p,
 
   pending_offset += last_mouse_pos - p;
   last_mouse_pos = p;
+  drag_moved = true;
+
+  kinetic_x.MouseMove(p.x);
+  kinetic_y.MouseMove(p.y);
+
   Invalidate();
   return true;
 }
@@ -79,8 +100,14 @@ ImageZoomFrame::OnMouseMove(const PixelPoint p,
 bool
 ImageZoomFrame::OnMouseDown(const PixelPoint p) noexcept
 {
+  kinetic_timer.Cancel();
+
   is_dragging = true;
+  drag_moved = false;
   last_mouse_pos = p;
+
+  kinetic_x.MouseDown(p.x);
+  kinetic_y.MouseDown(p.y);
 
   /* capture the pointer, so the drag continues outside this window,
      and so multi-touch events are delivered here */
@@ -89,14 +116,55 @@ ImageZoomFrame::OnMouseDown(const PixelPoint p) noexcept
 }
 
 bool
-ImageZoomFrame::OnMouseUp([[maybe_unused]] const PixelPoint p) noexcept
+ImageZoomFrame::OnMouseUp(const PixelPoint p) noexcept
 {
+  if (is_dragging && drag_moved)
+    StartKineticPan(p);
+
   is_dragging = false;
 #ifdef HAVE_MULTI_TOUCH
   is_pinching = false;
 #endif
   ReleaseCapture();
   return true;
+}
+
+void
+ImageZoomFrame::StartKineticPan(const PixelPoint p) noexcept
+{
+  if (!UseKineticPan())
+    return;
+
+  kinetic_x.MouseUp(p.x);
+  kinetic_y.MouseUp(p.y);
+
+  if (kinetic_x.IsSteady() && kinetic_y.IsSteady())
+    /* the finger rested before it was lifted */
+    return;
+
+  /* the kinetic managers extrapolate from their own last filtered
+     position, which may differ from p; start from what they report
+     now, so that the glide continues without a jump */
+  kinetic_last = {kinetic_x.GetPosition(), kinetic_y.GetPosition()};
+
+  kinetic_timer.Schedule(std::chrono::milliseconds(30));
+}
+
+void
+ImageZoomFrame::OnKineticTimer() noexcept
+{
+  if (kinetic_x.IsSteady() && kinetic_y.IsSteady()) {
+    kinetic_timer.Cancel();
+    return;
+  }
+
+  const PixelPoint p{kinetic_x.GetPosition(), kinetic_y.GetPosition()};
+  if (p == kinetic_last)
+    return;
+
+  pending_offset += kinetic_last - p;
+  kinetic_last = p;
+  Invalidate();
 }
 
 #ifdef HAVE_MULTI_TOUCH
@@ -106,6 +174,8 @@ ImageZoomFrame::OnMultiTouchDown() noexcept
 {
   if (bitmap == nullptr || zoom_factor == nullptr)
     return false;
+
+  kinetic_timer.Cancel();
 
   /* the second finger takes over: a single-finger drag must not pan
      while the pinch is running */
@@ -193,8 +263,17 @@ ImageZoomFrame::OnCancelMode() noexcept
 #ifdef HAVE_MULTI_TOUCH
   is_pinching = false;
 #endif
+  kinetic_timer.Cancel();
 
   WndOwnerDrawFrame::OnCancelMode();
+}
+
+void
+ImageZoomFrame::OnDestroy() noexcept
+{
+  kinetic_timer.Cancel();
+
+  WndOwnerDrawFrame::OnDestroy();
 }
 
 bool
@@ -223,6 +302,8 @@ ImageZoomFrame::OnKeyCheck(const unsigned key_code) const noexcept
 bool
 ImageZoomFrame::OnKeyDown(const unsigned key_code) noexcept
 {
+  kinetic_timer.Cancel();
+
   if (try_key_input && try_key_input(key_code))
     return true;
 

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -12,6 +12,10 @@
 #include "Asset.hpp"
 #include "Hardware/CPU.hpp"
 
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Scissor.hpp"
+#endif
+
 #include <cmath>
 
 /**
@@ -74,6 +78,12 @@ ImageZoomFrame::OnPaint(Canvas &canvas) noexcept
 
   if (bitmap == nullptr || zoom_factor == nullptr)
     return;
+
+#ifdef ENABLE_OPENGL
+  /* the zoomed bitmap reaches beyond the canvas by up to one source
+     pixel */
+  const GLCanvasScissor scissor(canvas);
+#endif
 
   ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_factor,
                                    view_pos, pending_offset);

--- a/src/Widget/ImageZoomFrame.cpp
+++ b/src/Widget/ImageZoomFrame.cpp
@@ -18,10 +18,11 @@ ImageZoomFrame::Create(ContainerWindow &parent, const PixelRect rc,
 }
 
 void
-ImageZoomFrame::SetContent(const Bitmap *_bitmap, int *zoom) noexcept
+ImageZoomFrame::SetContent(const Bitmap *_bitmap,
+                           double *_zoom_factor) noexcept
 {
   bitmap = _bitmap;
-  zoom_level = zoom;
+  zoom_factor = _zoom_factor;
   view_pos = {};
   pending_offset = {};
   if (IsDefined())
@@ -48,10 +49,10 @@ ImageZoomFrame::OnPaint(Canvas &canvas) noexcept
   if (HaveClipping())
     canvas.Clear(look.background_color);
 
-  if (bitmap == nullptr || zoom_level == nullptr)
+  if (bitmap == nullptr || zoom_factor == nullptr)
     return;
 
-  ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_level,
+  ImageZoomView::PaintZoomedBitmap(canvas, *bitmap, *zoom_factor,
                                    view_pos, pending_offset);
 }
 

--- a/src/Widget/ImageZoomFrame.hpp
+++ b/src/Widget/ImageZoomFrame.hpp
@@ -5,7 +5,9 @@
 
 #include "Form/Draw.hpp"
 #include "ui/dim/Point.hpp"
+#include "ui/event/PeriodicTimer.hpp"
 #include "ui/window/Features.hpp"
+#include "UIUtil/KineticManager.hpp"
 
 #include <functional>
 
@@ -16,13 +18,19 @@ class Canvas;
 class WindowStyle;
 
 /**
- * Owner-draw window for pan/zoom bitmap viewing (drag, arrow nudge and
- * pinch-to-zoom).
+ * Owner-draw window for pan/zoom bitmap viewing (drag, kinetic pan,
+ * arrow nudge and pinch-to-zoom).
  */
 class ImageZoomFrame final : public WndOwnerDrawFrame {
   PixelPoint last_mouse_pos, pending_offset;
   DoublePoint2D view_pos{};
   bool is_dragging = false;
+
+  /**
+   * Did the pointer move during the current drag?  A tap must not
+   * start a kinetic movement.
+   */
+  bool drag_moved = false;
 
 #ifdef HAVE_MULTI_TOUCH
   /**
@@ -36,6 +44,16 @@ class ImageZoomFrame final : public WndOwnerDrawFrame {
   double pinch_distance = 0, pinch_zoom_factor = 0;
   bool is_pinching = false;
 #endif
+
+  KineticManager kinetic_x{std::chrono::milliseconds{700}};
+  KineticManager kinetic_y{std::chrono::milliseconds{700}};
+  UI::PeriodicTimer kinetic_timer{[this]{ OnKineticTimer(); }};
+
+  /**
+   * The last position which was read from the kinetic managers; only
+   * the difference between two ticks is applied to the view.
+   */
+  PixelPoint kinetic_last;
 
   const Bitmap *bitmap = nullptr;
   double *zoom_factor = nullptr;
@@ -67,6 +85,14 @@ public:
     pending_offset = {};
   }
 
+private:
+  /**
+   * Let the image glide on after the finger was lifted.
+   */
+  void StartKineticPan(PixelPoint p) noexcept;
+
+  void OnKineticTimer() noexcept;
+
 protected:
   bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override;
   bool OnMouseDown(PixelPoint p) noexcept override;
@@ -77,6 +103,7 @@ protected:
   bool OnMultiTouchUp() noexcept override;
 #endif
   void OnCancelMode() noexcept override;
+  void OnDestroy() noexcept override;
   bool OnKeyCheck(unsigned key_code) const noexcept override;
   bool OnKeyDown(unsigned key_code) noexcept override;
   void OnPaint(Canvas &canvas) noexcept override;

--- a/src/Widget/ImageZoomFrame.hpp
+++ b/src/Widget/ImageZoomFrame.hpp
@@ -5,6 +5,7 @@
 
 #include "Form/Draw.hpp"
 #include "ui/dim/Point.hpp"
+#include "ui/window/Features.hpp"
 
 #include <functional>
 
@@ -15,17 +16,32 @@ class Canvas;
 class WindowStyle;
 
 /**
- * Owner-draw window for pan/zoom bitmap viewing (drag and arrow nudge).
+ * Owner-draw window for pan/zoom bitmap viewing (drag, arrow nudge and
+ * pinch-to-zoom).
  */
 class ImageZoomFrame final : public WndOwnerDrawFrame {
   PixelPoint last_mouse_pos, pending_offset;
   DoublePoint2D view_pos{};
   bool is_dragging = false;
 
+#ifdef HAVE_MULTI_TOUCH
+  /**
+   * The bitmap position which the pinch gesture keeps below the centre
+   * between the two fingers.
+   */
+  DoublePoint2D pinch_anchor;
+
+  PixelPoint pinch_last_a, pinch_last_b;
+
+  double pinch_distance = 0, pinch_zoom_factor = 0;
+  bool is_pinching = false;
+#endif
+
   const Bitmap *bitmap = nullptr;
   double *zoom_factor = nullptr;
 
   std::function<bool(unsigned key_code)> try_key_input;
+  std::function<void()> on_zoom_changed;
 
 public:
   void Create(ContainerWindow &parent, PixelRect rc,
@@ -34,6 +50,12 @@ public:
   void SetContent(const Bitmap *bitmap, double *zoom_factor) noexcept;
 
   void SetTryKeyInput(std::function<bool(unsigned key_code)> &&f) noexcept;
+
+  /**
+   * Set a callback which is invoked after this window has changed the
+   * zoom factor itself (pinch-to-zoom).
+   */
+  void SetOnZoomChanged(std::function<void()> &&f) noexcept;
 
   void NudgeViewByPixelOffset(PixelPoint o) noexcept;
 
@@ -49,6 +71,12 @@ protected:
   bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override;
   bool OnMouseDown(PixelPoint p) noexcept override;
   bool OnMouseUp(PixelPoint p) noexcept override;
+#ifdef HAVE_MULTI_TOUCH
+  bool OnMultiTouchDown() noexcept override;
+  bool OnMultiTouchMove(PixelPoint a, PixelPoint b) noexcept override;
+  bool OnMultiTouchUp() noexcept override;
+#endif
+  void OnCancelMode() noexcept override;
   bool OnKeyCheck(unsigned key_code) const noexcept override;
   bool OnKeyDown(unsigned key_code) noexcept override;
   void OnPaint(Canvas &canvas) noexcept override;

--- a/src/Widget/ImageZoomFrame.hpp
+++ b/src/Widget/ImageZoomFrame.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 #include "Form/Draw.hpp"
+#include "ui/dim/Point.hpp"
 
 #include <functional>
 
-struct PixelPoint;
 struct PixelRect;
 class Bitmap;
 class ContainerWindow;
@@ -18,11 +18,12 @@ class WindowStyle;
  * Owner-draw window for pan/zoom bitmap viewing (drag and arrow nudge).
  */
 class ImageZoomFrame final : public WndOwnerDrawFrame {
-  PixelPoint last_mouse_pos, view_pos, pending_offset;
+  PixelPoint last_mouse_pos, pending_offset;
+  DoublePoint2D view_pos{};
   bool is_dragging = false;
 
   const Bitmap *bitmap = nullptr;
-  int *zoom_level = nullptr;
+  double *zoom_factor = nullptr;
 
   std::function<bool(unsigned key_code)> try_key_input;
 
@@ -30,13 +31,13 @@ public:
   void Create(ContainerWindow &parent, PixelRect rc,
               const WindowStyle &style) noexcept;
 
-  void SetContent(const Bitmap *bitmap, int *zoom) noexcept;
+  void SetContent(const Bitmap *bitmap, double *zoom_factor) noexcept;
 
   void SetTryKeyInput(std::function<bool(unsigned key_code)> &&f) noexcept;
 
   void NudgeViewByPixelOffset(PixelPoint o) noexcept;
 
-  PixelPoint &GetViewPosition() noexcept {
+  DoublePoint2D &GetViewPosition() noexcept {
     return view_pos;
   }
 

--- a/src/Widget/ImageZoomView.cpp
+++ b/src/Widget/ImageZoomView.cpp
@@ -6,6 +6,7 @@
 #include "ui/canvas/Canvas.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace ImageZoomView {
 
@@ -159,10 +160,20 @@ PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap,
       ? (bmp_size.width - visible_width) / 2
       : view_pos.x + pending_offset.x / scale;
     view_pos.x = std::clamp(view_pos.x, 0.0, bmp_size.width - visible_width);
-    src_pos.x = int(view_pos.x);
-    src_size.width = unsigned(visible_width);
-    screen_pos.x = 0;
-    screen_size.width = canvas_size.width;
+
+    /* Blit whole source pixels, but place them at the exact fractional
+       position: rounding the source rectangle instead would quantise
+       the image position to whole source pixels, which is a visible
+       wobble while zooming.  The outermost pixel column reaches beyond
+       the canvas and is clipped. */
+    const int first = int(view_pos.x);
+    const int last = std::min(int(std::ceil(view_pos.x + visible_width)),
+                              int(bmp_size.width));
+    src_pos.x = first;
+    src_size.width = unsigned(last - first);
+    screen_pos.x = int(std::lround((first - view_pos.x) * scale));
+    screen_size.width = unsigned(int(std::lround((last - view_pos.x) * scale)) -
+                                 screen_pos.x);
   }
 
   const double scaled_height = bmp_size.height * scale;
@@ -179,10 +190,15 @@ PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap,
       : view_pos.y + pending_offset.y / scale;
     view_pos.y = std::clamp(view_pos.y, 0.0,
                             bmp_size.height - visible_height);
-    src_pos.y = int(view_pos.y);
-    src_size.height = unsigned(visible_height);
-    screen_pos.y = 0;
-    screen_size.height = canvas_size.height;
+
+    const int first = int(view_pos.y);
+    const int last = std::min(int(std::ceil(view_pos.y + visible_height)),
+                              int(bmp_size.height));
+    src_pos.y = first;
+    src_size.height = unsigned(last - first);
+    screen_pos.y = int(std::lround((first - view_pos.y) * scale));
+    screen_size.height = unsigned(int(std::lround((last - view_pos.y) * scale)) -
+                                  screen_pos.y);
   }
 
   pending_offset = {};

--- a/src/Widget/ImageZoomView.cpp
+++ b/src/Widget/ImageZoomView.cpp
@@ -6,18 +6,15 @@
 #include "ui/canvas/Canvas.hpp"
 
 #include <algorithm>
-#include <cmath>
 
 namespace ImageZoomView {
 
 namespace {
 
-static constexpr int zoom_factors[] = {1, 2, 4, 8, 16, 32};
-
 [[gnu::const]]
 static double
 GetImageScale(const PixelSize canvas_size, const PixelSize bitmap_size,
-              const int zoom_level) noexcept
+              const double zoom_factor) noexcept
 {
   if (bitmap_size.width == 0 || bitmap_size.height == 0 ||
       canvas_size.width == 0 || canvas_size.height == 0)
@@ -26,42 +23,77 @@ GetImageScale(const PixelSize canvas_size, const PixelSize bitmap_size,
   const double fit_scale = std::min(
     static_cast<double>(canvas_size.width) / bitmap_size.width,
     static_cast<double>(canvas_size.height) / bitmap_size.height);
-  return fit_scale *
-         zoom_factors[std::clamp(zoom_level, 0, max_zoom_level)];
+  return fit_scale * ClampZoomFactor(zoom_factor);
 }
 
 [[gnu::const]]
 static double
-FocalOnAxis(const double bmp_size, const double canvas_size,
-              const double old_scale, const int old_zoom,
-              const double view_pos) noexcept
+CanvasToBitmapAxis(const double bmp_size, const double canvas_size,
+                   const double scale, const double view_pos,
+                   const double anchor) noexcept
 {
-  if (old_zoom == 0 || bmp_size * old_scale <= canvas_size)
-    return bmp_size * 0.5;
+  const double bitmap_pos = bmp_size * scale <= canvas_size
+    /* the whole image is visible, centred in the canvas */
+    ? (anchor - (canvas_size - bmp_size * scale) * 0.5) / scale
+    : view_pos + anchor / scale;
 
-  return view_pos + (canvas_size * 0.5) / old_scale;
+  return std::clamp(bitmap_pos, 0.0, bmp_size);
 }
 
 static void
-RepositionAxis(const double bmp_size, const double canvas_size,
-               const double new_scale, const double focal,
-               double &view_pos) noexcept
+MoveViewAxis(const double bmp_size, const double canvas_size,
+             const double scale, const double bitmap_pos,
+             const double anchor, double &view_pos) noexcept
 {
-  if (bmp_size * new_scale <= canvas_size) {
+  if (bmp_size * scale <= canvas_size) {
     view_pos = 0;
     return;
   }
 
-  const double visible = canvas_size / new_scale;
-  view_pos = focal - (canvas_size * 0.5) / new_scale;
-  view_pos = std::clamp(view_pos, 0.0, std::max(0.0, bmp_size - visible));
+  const double visible = canvas_size / scale;
+  view_pos = std::clamp(bitmap_pos - anchor / scale, 0.0,
+                        std::max(0.0, bmp_size - visible));
 }
 
 } // namespace
 
+DoublePoint2D
+CanvasToBitmap(const PixelPoint p, const DoublePoint2D view_pos,
+               const PixelSize canvas_size, const PixelSize bitmap_size,
+               const double zoom_factor) noexcept
+{
+  const double scale = GetImageScale(canvas_size, bitmap_size, zoom_factor);
+
+  return {
+    CanvasToBitmapAxis(bitmap_size.width, canvas_size.width, scale,
+                       view_pos.x, p.x),
+    CanvasToBitmapAxis(bitmap_size.height, canvas_size.height, scale,
+                       view_pos.y, p.y),
+  };
+}
+
 void
-AdjustImageViewOnZoomChange(const int old_zoom, const int new_zoom,
-                            PixelPoint &view_pos,
+MoveViewTo(const DoublePoint2D bitmap_pos, const PixelPoint anchor,
+           DoublePoint2D &view_pos,
+           const PixelSize canvas_size, const PixelSize bitmap_size,
+           const double zoom_factor) noexcept
+{
+  if (bitmap_size.width == 0 || bitmap_size.height == 0 ||
+      canvas_size.width == 0 || canvas_size.height == 0)
+    return;
+
+  const double scale = GetImageScale(canvas_size, bitmap_size, zoom_factor);
+
+  MoveViewAxis(bitmap_size.width, canvas_size.width, scale,
+               bitmap_pos.x, anchor.x, view_pos.x);
+  MoveViewAxis(bitmap_size.height, canvas_size.height, scale,
+               bitmap_pos.y, anchor.y, view_pos.y);
+}
+
+void
+AdjustImageViewOnZoomChange(const double old_zoom_factor,
+                            const double new_zoom_factor,
+                            DoublePoint2D &view_pos,
                             const PixelSize canvas_size,
                             const PixelSize bitmap_size) noexcept
 {
@@ -69,84 +101,92 @@ AdjustImageViewOnZoomChange(const int old_zoom, const int new_zoom,
       canvas_size.width == 0 || canvas_size.height == 0)
     return;
 
-  if (new_zoom == 0) {
+  if (IsFitZoomFactor(new_zoom_factor)) {
     view_pos = {0, 0};
     return;
   }
 
-  const double old_scale = GetImageScale(canvas_size, bitmap_size, old_zoom);
-  const double new_scale = GetImageScale(canvas_size, bitmap_size, new_zoom);
+  const double old_scale = GetImageScale(canvas_size, bitmap_size,
+                                         old_zoom_factor);
+  const double new_scale = GetImageScale(canvas_size, bitmap_size,
+                                         new_zoom_factor);
 
   const double bmp_w = bitmap_size.width;
   const double bmp_h = bitmap_size.height;
-
-  double view_x = view_pos.x;
-  double view_y = view_pos.y;
+  const double centre_x = canvas_size.width * 0.5;
+  const double centre_y = canvas_size.height * 0.5;
 
   const double focal_x =
-    FocalOnAxis(bmp_w, canvas_size.width, old_scale, old_zoom, view_x);
+    CanvasToBitmapAxis(bmp_w, canvas_size.width, old_scale, view_pos.x,
+                       centre_x);
   const double focal_y =
-    FocalOnAxis(bmp_h, canvas_size.height, old_scale, old_zoom, view_y);
+    CanvasToBitmapAxis(bmp_h, canvas_size.height, old_scale, view_pos.y,
+                       centre_y);
 
-  RepositionAxis(bmp_w, canvas_size.width, new_scale, focal_x, view_x);
-  RepositionAxis(bmp_h, canvas_size.height, new_scale, focal_y, view_y);
-
-  view_pos.x = int(std::lround(view_x));
-  view_pos.y = int(std::lround(view_y));
+  MoveViewAxis(bmp_w, canvas_size.width, new_scale, focal_x, centre_x,
+               view_pos.x);
+  MoveViewAxis(bmp_h, canvas_size.height, new_scale, focal_y, centre_y,
+               view_pos.y);
 }
 
 void
-PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, const int zoom,
-                  PixelPoint &view_pos, PixelPoint &pending_offset) noexcept
+PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap,
+                  const double zoom_factor, DoublePoint2D &view_pos,
+                  PixelPoint &pending_offset) noexcept
 {
-  PixelSize img_size = bitmap.GetSize();
-  if (img_size.width == 0 || img_size.height == 0 ||
-      canvas.GetWidth() == 0 || canvas.GetHeight() == 0)
+  const PixelSize bmp_size = bitmap.GetSize();
+  const PixelSize canvas_size{unsigned(canvas.GetWidth()),
+                              unsigned(canvas.GetHeight())};
+  if (bmp_size.width == 0 || bmp_size.height == 0 ||
+      canvas_size.width == 0 || canvas_size.height == 0)
     return;
 
-  const double scale = GetImageScale(
-    {unsigned(canvas.GetWidth()), unsigned(canvas.GetHeight())},
-    img_size, zoom);
+  const double scale = GetImageScale(canvas_size, bmp_size, zoom_factor);
 
-  PixelPoint screen_pos;
-  PixelSize screen_size;
+  PixelPoint screen_pos, src_pos;
+  PixelSize screen_size, src_size;
 
-  const double scaled_width = img_size.width * scale;
-  if (scaled_width <= canvas.GetWidth()) {
+  const double scaled_width = bmp_size.width * scale;
+  if (scaled_width <= canvas_size.width) {
     view_pos.x = 0;
-    screen_pos.x = (canvas.GetWidth() - int(scaled_width)) / 2;
+    src_pos.x = 0;
+    src_size.width = bmp_size.width;
+    screen_pos.x = (int(canvas_size.width) - int(scaled_width)) / 2;
     screen_size.width = unsigned(scaled_width);
   } else {
-    const double visible_width = canvas.GetWidth() / scale;
-    view_pos.x = zoom == 0
-      ? int((img_size.width - visible_width) / 2)
-      : int(view_pos.x + pending_offset.x / scale);
-    view_pos.x = std::clamp(view_pos.x, 0,
-                            int(img_size.width - visible_width));
-    img_size.width = unsigned(visible_width);
+    const double visible_width = canvas_size.width / scale;
+    view_pos.x = IsFitZoomFactor(zoom_factor)
+      ? (bmp_size.width - visible_width) / 2
+      : view_pos.x + pending_offset.x / scale;
+    view_pos.x = std::clamp(view_pos.x, 0.0, bmp_size.width - visible_width);
+    src_pos.x = int(view_pos.x);
+    src_size.width = unsigned(visible_width);
     screen_pos.x = 0;
-    screen_size.width = unsigned(canvas.GetWidth());
+    screen_size.width = canvas_size.width;
   }
 
-  const double scaled_height = img_size.height * scale;
-  if (scaled_height <= canvas.GetHeight()) {
+  const double scaled_height = bmp_size.height * scale;
+  if (scaled_height <= canvas_size.height) {
     view_pos.y = 0;
-    screen_pos.y = (canvas.GetHeight() - int(scaled_height)) / 2;
+    src_pos.y = 0;
+    src_size.height = bmp_size.height;
+    screen_pos.y = (int(canvas_size.height) - int(scaled_height)) / 2;
     screen_size.height = unsigned(scaled_height);
   } else {
-    const double visible_height = canvas.GetHeight() / scale;
-    view_pos.y = zoom == 0
-      ? int((img_size.height - visible_height) / 2)
-      : int(view_pos.y + pending_offset.y / scale);
-    view_pos.y = std::clamp(view_pos.y, 0,
-                            int(img_size.height - visible_height));
-    img_size.height = unsigned(visible_height);
+    const double visible_height = canvas_size.height / scale;
+    view_pos.y = IsFitZoomFactor(zoom_factor)
+      ? (bmp_size.height - visible_height) / 2
+      : view_pos.y + pending_offset.y / scale;
+    view_pos.y = std::clamp(view_pos.y, 0.0,
+                            bmp_size.height - visible_height);
+    src_pos.y = int(view_pos.y);
+    src_size.height = unsigned(visible_height);
     screen_pos.y = 0;
-    screen_size.height = unsigned(canvas.GetHeight());
+    screen_size.height = canvas_size.height;
   }
 
   pending_offset = {};
-  canvas.Stretch(screen_pos, screen_size, bitmap, view_pos, img_size);
+  canvas.Stretch(screen_pos, screen_size, bitmap, src_pos, src_size);
 }
 
 } // namespace ImageZoomView

--- a/src/Widget/ImageZoomView.hpp
+++ b/src/Widget/ImageZoomView.hpp
@@ -79,6 +79,11 @@ AdjustImageViewOnZoomChange(double old_zoom_factor, double new_zoom_factor,
 
 /**
  * Paint a bitmap with the given zoom factor and pan offset.
+ *
+ * While zoomed in, this paints up to one source pixel beyond the
+ * canvas on each side; the caller must clip (OpenGL does not clip
+ * against siblings).
+ *
  * @param view_pos Top-left of the visible region in bitmap pixels
  * @param pending_offset Drag/key nudge in screen pixels (applied once, then cleared)
  */

--- a/src/Widget/ImageZoomView.hpp
+++ b/src/Widget/ImageZoomView.hpp
@@ -31,6 +31,12 @@ static constexpr double MAX_ZOOM_FACTOR = 32;
  */
 static constexpr double ZOOM_STEP_FACTOR = 2;
 
+/**
+ * The distance of one pan step (arrow keys), in logical pixels; pass
+ * it through Layout::Scale().
+ */
+static constexpr int PAN_STEP = 50;
+
 constexpr double
 ClampZoomFactor(double zoom_factor) noexcept
 {

--- a/src/Widget/ImageZoomView.hpp
+++ b/src/Widget/ImageZoomView.hpp
@@ -3,33 +3,88 @@
 
 #pragma once
 
+#include "ui/dim/Point.hpp"
 #include "ui/dim/Size.hpp"
+
+#include <algorithm>
 
 class Bitmap;
 class Canvas;
-struct PixelPoint;
 
 /**
  * Shared fit/zoom/pan math and painting for bitmap viewers.
+ *
+ * The zoom factor is continuous and relative to the scale at which the
+ * whole image fits into the canvas.
  */
 namespace ImageZoomView {
 
-static constexpr int max_zoom_level = 5;
+/**
+ * The zoom factor which fits the whole image into the canvas.
+ */
+static constexpr double FIT_ZOOM_FACTOR = 1;
 
+static constexpr double MAX_ZOOM_FACTOR = 32;
+
+/**
+ * The factor of one zoom step (buttons and keys).
+ */
+static constexpr double ZOOM_STEP_FACTOR = 2;
+
+constexpr double
+ClampZoomFactor(double zoom_factor) noexcept
+{
+  return std::clamp(zoom_factor, FIT_ZOOM_FACTOR, MAX_ZOOM_FACTOR);
+}
+
+/**
+ * Is the whole image visible?
+ */
+constexpr bool
+IsFitZoomFactor(double zoom_factor) noexcept
+{
+  return zoom_factor <= FIT_ZOOM_FACTOR;
+}
+
+/**
+ * Determine the position in the bitmap which is displayed at the given
+ * canvas position.
+ */
+[[gnu::pure]]
+DoublePoint2D
+CanvasToBitmap(PixelPoint p, DoublePoint2D view_pos,
+               PixelSize canvas_size, PixelSize bitmap_size,
+               double zoom_factor) noexcept;
+
+/**
+ * Move the view so that the given bitmap position is displayed at the
+ * given canvas position; this is what makes an image follow the
+ * fingers during a pinch gesture.
+ */
 void
-AdjustImageViewOnZoomChange(int old_zoom, int new_zoom,
-                            PixelPoint &view_pos,
+MoveViewTo(DoublePoint2D bitmap_pos, PixelPoint anchor,
+           DoublePoint2D &view_pos,
+           PixelSize canvas_size, PixelSize bitmap_size,
+           double zoom_factor) noexcept;
+
+/**
+ * Adjust the view position when the zoom factor changes, keeping the
+ * bitmap position in the centre of the canvas in place.
+ */
+void
+AdjustImageViewOnZoomChange(double old_zoom_factor, double new_zoom_factor,
+                            DoublePoint2D &view_pos,
                             PixelSize canvas_size,
                             PixelSize bitmap_size) noexcept;
 
 /**
- * Paint a bitmap with discrete zoom levels and pan offset.
+ * Paint a bitmap with the given zoom factor and pan offset.
  * @param view_pos Top-left of the visible region in bitmap pixels
  * @param pending_offset Drag/key nudge in screen pixels (applied once, then cleared)
  */
 void
-PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, int zoom,
-                    PixelPoint &view_pos,
+PaintZoomedBitmap(Canvas &canvas, const Bitmap &bitmap, double zoom_factor,
+                    DoublePoint2D &view_pos,
                     PixelPoint &pending_offset) noexcept;
 
 } // namespace ImageZoomView

--- a/src/Widget/ViewImageWidget.cpp
+++ b/src/Widget/ViewImageWidget.cpp
@@ -14,7 +14,7 @@ ViewImageWidget::SetBitmap(const Bitmap *_bitmap) noexcept
     return;
 
   auto &frame = (ImageZoomFrame &)GetWindow();
-  frame.SetContent(bitmap, &zoom);
+  frame.SetContent(bitmap, &zoom_factor);
   frame.Invalidate();
 }
 
@@ -27,6 +27,6 @@ ViewImageWidget::Prepare(ContainerWindow &parent,
 
   auto frame = std::make_unique<ImageZoomFrame>();
   frame->Create(parent, rc, hidden);
-  frame->SetContent(bitmap, &zoom);
+  frame->SetContent(bitmap, &zoom_factor);
   SetWindow(std::move(frame));
 }

--- a/src/Widget/ViewImageWidget.hpp
+++ b/src/Widget/ViewImageWidget.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "WindowWidget.hpp"
+#include "ImageZoomView.hpp"
 
 class Bitmap;
 
@@ -13,7 +14,7 @@ class Bitmap;
  */
 class ViewImageWidget : public WindowWidget {
   const Bitmap *bitmap;
-  int zoom = 0;
+  double zoom_factor = ImageZoomView::FIT_ZOOM_FACTOR;
 
 public:
   explicit ViewImageWidget(const Bitmap *_bitmap=nullptr) noexcept


### PR DESCRIPTION
Closes #2868. The zoom level is now a continuous factor instead of six fixed steps, so a pinch scales smoothly and the picture stays under the fingers. A quick swipe lets it glide on, reusing `KineticManager` like the list and the map.

The arrow keys pan by a fixed distance on screen, so one press covers less of the picture the further you zoom in. Should the step instead depend on the zoom level, so that crossing the picture always takes about the same number of presses?

### Crash fix, please consider cherry-picking for 7.45.2

The first two commits (fe19c73, 12f5f16) fix a crash that already exists in 7.45 and is unrelated to this feature: the image window is created with `ControlParent()`, but `ImageZoomFrame` is a `PaintWindow`, and `WindowList::FindControl()` casts every control parent to `ContainerWindow`. Moving the keyboard focus on a waypoint picture or a flugwetter.de image then walks a garbage child list.

I couldn't test `PCMetDialog.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added smooth pinch-to-zoom and two-finger panning for waypoint pictures and downloaded weather images.
- Added continuous zooming for more precise image scaling.
- Added kinetic panning, allowing zoomed images to glide briefly after a quick swipe.

## Bug Fixes
- Fixed a crash when keyboard focus changes in waypoint picture and weather image views.
- Improved image positioning and navigation while zoomed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->