### PR TITLE
Weather/OPERA: show the European radar composite as a map overlay

### DIFF
--- a/build/libhttp.mk
+++ b/build/libhttp.mk
@@ -11,6 +11,7 @@ LIBHTTP_SOURCES = \
 	$(SRC)/lib/curl/CoRequest.cxx \
 	$(SRC)/lib/curl/CoStreamRequest.cxx \
 	$(SRC)/net/http/CoDownloadToFile.cpp \
+	$(SRC)/net/http/CoGetRange.cpp \
 	$(SRC)/lib/curl/Global.cxx \
 	$(SRC)/net/http/Init.cpp
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -637,7 +637,8 @@ ifeq ($(OPENGL),y)
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Weather/MapOverlayWidget.cpp \
-	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp
+	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp \
+	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp
 endif
 endif
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -631,6 +631,7 @@ ifeq ($(HAVE_WIN32),y)
 endif
 
 $(call SRC_TO_OBJ,$(SRC)/Dialogs/Inflate.cpp): CPPFLAGS += $(ZLIB_CPPFLAGS)
+$(call SRC_TO_OBJ,$(SRC)/Weather/OPERA/Radar.cpp): CPPFLAGS += $(ZLIB_CPPFLAGS)
 
 ifeq ($(OPENGL),y)
 ifeq ($(HAVE_HTTP),y)
@@ -736,6 +737,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
+	$(SRC)/Weather/OPERA/Radar.cpp \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/METARParser.cpp \
 	$(SRC)/Weather/NOAAFormatter.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -638,6 +638,8 @@ ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Weather/MapOverlayWidget.cpp \
 	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp \
+	$(SRC)/Weather/OPERA/Radar.cpp \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp
 endif
 endif
@@ -738,8 +740,6 @@ XCSOAR_SOURCES += \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
-	$(SRC)/Weather/OPERA/Radar.cpp \
-	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/METARParser.cpp \
 	$(SRC)/Weather/NOAAFormatter.cpp \

--- a/build/screen.mk
+++ b/build/screen.mk
@@ -38,6 +38,7 @@ SCREEN_CUSTOM_SOURCES = \
 	$(WINDOW_SRC_DIR)/custom/DoubleClick.cpp \
 	$(CANVAS_SRC_DIR)/FontSearch.cpp \
 	$(CANVAS_SRC_DIR)/custom/GeoBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/GeoBitmapTile.cpp \
 	$(CANVAS_SRC_DIR)/custom/Pen.cpp \
 	$(CONTROL_SRC_DIR)/custom/LargeTextWindow.cpp \
 	$(CONTROL_SRC_DIR)/RichTextWindow.cpp \
@@ -246,6 +247,7 @@ SCREEN_SOURCES += \
 
 ifeq ($(OPENGL),y)
 SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/GeoBitmap.cpp
+SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/GeoBitmapTile.cpp
 ifeq ($(TIFF),y)
 SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/LibTiff.cpp
 endif

--- a/build/test.mk
+++ b/build/test.mk
@@ -581,6 +581,7 @@ $(eval $(call link-program,TestAngle,TEST_ANGLE))
 
 TEST_OPERA_RADAR_SOURCES = \
 	$(SRC)/Weather/OPERA/RadarData.cpp \
+	$(SRC)/ui/canvas/custom/GeoBitmapTile.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestOperaRadar.cpp
 TEST_OPERA_RADAR_DEPENDS = GEO MATH TIME FMT UTIL

--- a/build/test.mk
+++ b/build/test.mk
@@ -90,6 +90,7 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
+	TestOperaRadar \
 	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
@@ -577,6 +578,13 @@ TEST_ANGLE_SOURCES = \
 	$(TEST_SRC_DIR)/TestAngle.cpp
 TEST_ANGLE_DEPENDS = MATH
 $(eval $(call link-program,TestAngle,TEST_ANGLE))
+
+TEST_OPERA_RADAR_SOURCES = \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestOperaRadar.cpp
+TEST_OPERA_RADAR_DEPENDS = GEO MATH TIME FMT UTIL
+$(eval $(call link-program,TestOperaRadar,TEST_OPERA_RADAR))
 
 TEST_ARANGE_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -655,6 +655,38 @@ EDL imagery as a map overlay and does not expose additional model
 parameters beyond the forecast hour and the fixed isobar levels
 published by the EDL service.
 
+\section{Rain radar}\label{sec:rain-radar}
+
+XCSoar can draw the European weather radar composite on the map.  The
+data comes from EUMETNET's OPERA programme, is published under CC~BY
+4.0 and needs no account and no subscription.
+
+The layer is listed as \emph{Radar (EUMETNET OPERA)} on the
+``Overlay'' page of the
+\menulabelr{\bmenug{Info}\blink\bmenug{Weather}} \bmenug{Info} menu.
+Select it and press \bmenug{Use}; \bmenug{Disable} switches it off
+again.
+
+Selecting it downloads the newest composite and draws the part
+covering the area the map is currently showing, so pan and zoom the
+map first and select the layer afterwards.  \bmenug{Update} fetches a
+fresh image for the area now visible.  A new composite is published
+every five minutes.
+
+The colours are the classes the Deutscher Wetterdienst uses for its
+own radar images, from cyan for the weakest echo through green,
+yellow and orange to red and violet for the heaviest, so the picture
+reads the way German pilots are used to.  Areas the radar network
+does not reach are left transparent rather than shaded, because the
+map underneath should stay visible.
+
+Coverage reaches from the Azores to northern Scandinavia and from
+Iceland to eastern Europe; nineteen national weather services
+contribute.
+
+Note that this feature requires and uses an internet connection.  A
+composite is about four megabytes.
+
 \section{pc\_met, Deutscher Wetterdienst}\label{sec:pcmet}
 
 German weather service ``Deutscher Wetterdienst'' provides several

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -682,6 +682,17 @@ composite has been published or when the map has been panned outside
 the area the current image was fetched for, so a page left open does
 not download continuously.
 
+While such a page is open, XCSoar watches how old the picture is.  A
+frame is already seven to twelve minutes old when it arrives, because
+the network needs about four minutes to publish it and it is only
+renewed every five.  Once a frame passes twenty minutes it is removed
+from the map \emph{before} a replacement is fetched, so a failing or
+slow connection can never leave a stale echo on display.  If the
+replacement then fails to arrive, a warning says so; that warning
+offers to stop appearing, and can be switched back on with
+\emph{Warn when radar expires} on the \emph{Look / Language, Input}
+configuration page (Section~\ref{sec:interface}).
+
 The colours are the classes the Deutscher Wetterdienst uses for its
 own radar images, from cyan for the weakest echo through green,
 yellow and orange to red and violet for the heaviest, so the picture

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -673,6 +673,15 @@ map first and select the layer afterwards.  \bmenug{Update} fetches a
 fresh image for the area now visible.  A new composite is published
 every five minutes.
 
+A map page can also carry the radar permanently: set \emph{Map
+overlay} to \emph{Rain radar} in
+\config{screenpages}.  The image is then fetched
+in the background whenever the page is shown, without a progress
+dialog interrupting the flight.  It is only re-fetched when a newer
+composite has been published or when the map has been panned outside
+the area the current image was fetched for, so a page left open does
+not download continuously.
+
 The colours are the classes the Deutscher Wetterdienst uses for its
 own radar images, from cyan for the weakest echo through green,
 yellow and orange to red and violet for the heaviest, so the picture

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -667,25 +667,41 @@ The layer is listed as \emph{Radar (EUMETNET OPERA)} on the
 Select it and press \bmenug{Use}; \bmenug{Disable} switches it off
 again.
 
-Selecting it downloads the newest composite and draws the part
-covering the area the map is currently showing, so pan and zoom the
-map first and select the layer afterwards.  \bmenug{Update} fetches a
-fresh image for the area now visible.  A new composite is published
-every five minutes.
+Selecting it draws the part of the newest composite covering the area
+the map is currently showing, so pan and zoom the map first and select
+the layer afterwards.  \bmenug{Update} fetches a fresh image for the
+area now visible.  A new composite is published every five minutes.
 
 A map page can also carry the radar permanently: set \emph{Map
 overlay} to \emph{Rain radar} in
-\config{screenpages}.  The image is then fetched
+\config{screenpages}.  The picture is then fetched
 in the background whenever the page is shown, without a progress
-dialog interrupting the flight.  It is only re-fetched when a newer
-composite has been published or when the map has been panned outside
-the area the current image was fetched for, so a page left open does
-not download continuously.
+dialog interrupting the flight.
 
-While such a page is open, XCSoar watches how old the picture is.  A
-frame is already seven to twelve minutes old when it arrives, because
-the network needs about four minutes to publish it and it is only
-renewed every five.  Once a frame passes twenty minutes it is removed
+It arrives in pieces, nearest first.  XCSoar divides the area around
+the aircraft into a block of tiles and fetches them in rings growing
+outwards from underneath the glider, so on a slow or intermittent
+connection the weather you are flying into is drawn before the
+distant weather is.  Each tile stays on the map on its own: flying on
+fetches only the tiles that come into range, and panning or zooming
+keeps whatever still fits.
+
+This is also what keeps the feature affordable.  The composite is one
+file of about five megabytes covering the continent, but it is
+tiled and carries a pyramid of reduced-resolution copies, and the
+server serves byte ranges, so XCSoar reads its index and then only
+those tiles it actually needs, at the resolution the map is drawn at.
+At the scales one flies at that is between two and three per cent of
+the file -- typically a hundred and fifty kilobytes for the whole
+block, and about a hundred for the first tile, the one under the
+aircraft.  Zoomed out far enough to see half the continent it is more,
+because more ground is being asked for.
+
+While such a page is open, XCSoar watches how old the picture is.
+XCSoar asks for a frame seven minutes old, because one takes four to
+six minutes to reach the server after it is measured; frames are
+renewed every five minutes, so what is on the map is between seven and
+twelve minutes old.  Once a frame passes twenty minutes it is removed
 from the map \emph{before} a replacement is fetched, so a failing or
 slow connection can never leave a stale echo on display.  If the
 replacement then fails to arrive, a warning says so; that warning
@@ -704,8 +720,7 @@ Coverage reaches from the Azores to northern Scandinavia and from
 Iceland to eastern Europe; nineteen national weather services
 contribute.
 
-Note that this feature requires and uses an internet connection.  A
-composite is about four megabytes.
+Note that this feature requires and uses an internet connection.
 
 \section{pc\_met, Deutscher Wetterdienst}\label{sec:pcmet}
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -798,9 +798,11 @@ When editing a page, the following options are available for map pages:
   \emph{Weather controls} to show in-flight RASP, EDL, or XC Therm forecast
   controls when the page uses a weather overlay.
 \item[Map overlay]  Optional weather overlay drawn on map pages: \emph{None},
-  \emph{RASP}, \emph{EDL}, or \emph{XC Therm}.  RASP requires a loaded RASP
-  file; EDL and XC Therm require network-capable builds with the respective
-  weather provider configured.
+  \emph{RASP}, \emph{EDL}, \emph{XC Therm}, or \emph{Rain radar}.  RASP
+  requires a loaded RASP file; EDL and XC Therm require network-capable
+  builds with the respective weather provider configured.  \emph{Rain
+  radar} draws the EUMETNET OPERA composite (Section~\ref{sec:rain-radar})
+  and needs no account, only an internet connection.
 \item[Layer / Level]  When \emph{Map overlay} is \emph{RASP}, selects
   which RASP field is displayed on this page.  When the overlay is
   \emph{EDL}, selects the pressure level (altitude band): \emph{Auto}

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -35,6 +35,7 @@ enum ControlIndex {
 #endif
   ShowQuickGuideOnStartup,
   ShowReleaseNotesOnStartup,
+  WarnRadarExpired,
   DisclaimerAccepted,
 };
 
@@ -177,6 +178,14 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
                "startup."),
              !news_seen);
 
+  bool hide_radar_warning = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hide_radar_warning);
+  AddBoolean(C_("Setting", "Warn when radar expires"),
+             _("If enabled, a warning is shown when the rain radar "
+               "overlay could not be refreshed and was removed from "
+               "the map."),
+             !hide_radar_warning);
+
   const char *disclaimer_acknowledged_version =
     Profile::Get(ProfileKeys::DisclaimerAcknowledgedVersion);
   const bool disclaimer_acknowledged =
@@ -275,6 +284,12 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
   if (SaveValue(ShowQuickGuideOnStartup,
                 ProfileKeys::HideQuickGuideDialogOnStartup,
                 hide_quick_guide, true))
+    changed = true;
+
+  bool hide_radar_warning = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hide_radar_warning);
+  if (SaveValue(WarnRadarExpired, ProfileKeys::HideRadarStaleWarning,
+                hide_radar_warning, true))
     changed = true;
 
   const bool show_release_notes = GetValueBoolean(ShowReleaseNotesOnStartup);

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -300,6 +300,7 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
 
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::XCTHERM:
+  case PageLayout::Overlay::RADAR:
 #ifndef HAVE_EDL
   case PageLayout::Overlay::EDL:
 #endif
@@ -341,6 +342,7 @@ PageLayoutEditWidget::UpdateOverlayControls() noexcept
       break;
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::XCTHERM:
+    case PageLayout::Overlay::RADAR:
 #ifndef HAVE_EDL
     case PageLayout::Overlay::EDL:
 #endif
@@ -439,6 +441,9 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 #ifdef HAVE_HTTP
     { PageLayout::Overlay::XCTHERM, "XC Therm" },
     { PageLayout::Overlay::SKYSIGHT, "SkySight" },
+#endif
+#ifdef HAVE_WEATHER_OVERLAY
+    { PageLayout::Overlay::RADAR, N_("Rain radar") },
 #endif
     nullptr
   };

--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -16,6 +16,8 @@
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Language/Language.hpp"
 #include "Weather/PCMet/Overlays.hpp"
+#include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Interface.hpp"
 #include "LocalPath.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
@@ -27,6 +29,7 @@
 #include "util/StringAPI.hxx"
 #include "util/StringCompare.hxx"
 
+#include <algorithm>
 #include <optional>
 #include <vector>
 
@@ -45,9 +48,22 @@ class WeatherMapOverlayListWidget final
 
     std::unique_ptr<PCMet::OverlayInfo> pc_met;
 
+    /**
+     * Set for the radar composite, which is downloaded on demand for
+     * the currently visible map area.  #radar_bounds is the area the
+     * cached image covers.
+     */
+    bool radar = false;
+    GeoBounds radar_bounds = GeoBounds::Invalid();
+
     explicit Item(PCMet::OverlayInfo &&_pc_met)
       :name(_pc_met.label.c_str()), path(_pc_met.path.c_str()),
        pc_met(new PCMet::OverlayInfo(std::move(_pc_met))) {}
+
+    struct Radar {};
+
+    explicit Item(Radar)
+      :name(gettext(N_("Radar (EUMETNET OPERA)"))), radar(true) {}
 
     Item(const char *_name, Path _path)
       :name(_name), path(_path) {}
@@ -186,6 +202,15 @@ protected:
 
 private:
   void SetOverlay(Path path, const char *label=nullptr);
+  void SetOverlay(Path path, const GeoBounds &bounds,
+                  const char *label);
+
+  /**
+   * Download the radar composite for the area the map currently shows.
+   *
+   * @return false if the download failed or was cancelled
+   */
+  bool DownloadRadar(Item &item);
 
   void UseClicked(unsigned i);
 
@@ -221,6 +246,10 @@ WeatherMapOverlayListWidget::UpdateList()
     for (auto &i : PCMet::CollectOverlays())
       items.emplace_back(std::move(i));
 
+  /* the radar composite is open data and needs no account, so it is
+     always offered */
+  items.emplace_back(Item::Radar{});
+
   struct Visitor : public File::Visitor {
     std::vector<Item> &items;
 
@@ -247,7 +276,14 @@ WeatherMapOverlayListWidget::UpdateList()
 
   const bool empty = items.empty();
   use_button->SetEnabled(!empty);
-  update_button->SetEnabled(pc_met_settings.ftp_credentials.IsDefined());
+
+  /* "Update" re-downloads; that is possible for the pc_met overlays
+     only with credentials, but always for the radar composite */
+  const bool can_update = pc_met_settings.ftp_credentials.IsDefined() ||
+    std::any_of(items.begin(), items.end(), [](const Item &i){
+      return i.radar;
+    });
+  update_button->SetEnabled(can_update);
 
   UpdateActiveIndex();
 }
@@ -331,6 +367,79 @@ WeatherMapOverlayListWidget::SetOverlay(Path path, const char *label)
   UpdateActiveIndex();
 }
 
+bool
+WeatherMapOverlayListWidget::DownloadRadar(Item &item)
+{
+  const auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return false;
+
+  const auto &projection = map->VisibleProjection();
+  const auto bounds = projection.GetScreenBounds();
+  if (!bounds.IsValid())
+    return false;
+
+  const auto size = projection.GetScreenSize();
+
+  try {
+    PluggableOperationEnvironment env;
+
+    auto path = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
+                                     UIGlobals::GetDialogLook(),
+                                     _("Download"),
+                                     OPERA::DownloadRadar(bounds,
+                                                          size.width,
+                                                          size.height,
+                                                          *Net::curl, env),
+                                     &env);
+    if (!path)
+      return false;
+
+    item.path = std::move(*path);
+    item.radar_bounds = bounds;
+    UpdatePreview(item.path);
+    return true;
+  } catch (...) {
+    ShowError(std::current_exception(), _("Weather"));
+    return false;
+  }
+}
+
+/**
+ * Install an image whose extent is known from the request rather
+ * than from the file, which is how the radar composite arrives.
+ */
+void
+WeatherMapOverlayListWidget::SetOverlay(Path path, const GeoBounds &bounds,
+                                        const char *label)
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || !bounds.IsValid())
+    return;
+
+  Bitmap bitmap;
+  try {
+    if (!bitmap.LoadFile(path))
+      return;
+  } catch (...) {
+    ShowError(std::current_exception(), _("Weather"));
+    return;
+  }
+
+  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                GeoQuadrilateral{
+                                                  bounds.GetNorthWest(),
+                                                  bounds.GetNorthEast(),
+                                                  bounds.GetSouthWest(),
+                                                  bounds.GetSouthEast(),
+                                                },
+                                                label);
+  bmp->SetAlpha(0.6);
+  map->SetOverlay(std::move(bmp));
+
+  UpdateActiveIndex();
+}
+
 void
 WeatherMapOverlayListWidget::UseClicked(unsigned i)
 {
@@ -341,7 +450,15 @@ WeatherMapOverlayListWidget::UseClicked(unsigned i)
 
   const char *label = nullptr;
   auto &item = items[i];
-  if (item.pc_met) {
+  if (item.radar) {
+    /* unlike the other entries this is fetched for the visible area,
+       so it is downloaded again even if we already have a file */
+    if (!DownloadRadar(item))
+      return;
+
+    SetOverlay(item.path, item.radar_bounds, item.name.c_str());
+    return;
+  } else if (item.pc_met) {
     const auto &info = *item.pc_met;
     label = info.label.c_str();
     if (item.path == nullptr) {
@@ -379,7 +496,10 @@ WeatherMapOverlayListWidget::UpdateClicked()
   BrokenDateTime now = BrokenDateTime::NowUTC();
   int i = 0;
   for (auto &item : items) {
-    if (item.pc_met) {
+    if (item.radar) {
+      if (i == active_index && DownloadRadar(item))
+        SetOverlay(item.path, item.radar_bounds, item.name.c_str());
+    } else if (item.pc_met) {
       try {
         const auto &info = *item.pc_met;
 

--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -387,10 +387,10 @@ WeatherMapOverlayListWidget::DownloadRadar(Item &item)
     auto path = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
                                      UIGlobals::GetDialogLook(),
                                      _("Download"),
-                                     OPERA::DownloadRadar(bounds,
-                                                          size.width,
-                                                          size.height,
-                                                          *Net::curl, env),
+                                     OPERA::DownloadArea(bounds,
+                                                         size.width,
+                                                         size.height,
+                                                         *Net::curl, env),
                                      &env);
     if (!path)
       return false;

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -184,8 +184,9 @@ ShowWeatherDialog(const char *page)
   if (page != nullptr && StringIsEqual(page, "overlay"))
     start_page = widget.GetSize();
 
-  // TODO: better and translatable title?
-  widget.AddTab(CreateWeatherMapOverlayWidget(), "Overlay");
+  /* the other tabs are named after their service, which is why they
+     are not translated; this one is a common noun */
+  widget.AddTab(CreateWeatherMapOverlayWidget(), _("Overlay"));
 #endif
 
   /* restore previous page */

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -18,7 +18,7 @@
 #include "SkySightDialog.hpp"
 #include "Dialogs/Settings/Panels/SkySightConfigPanel.hpp"
 #endif
-#if 0
+#ifdef HAVE_WEATHER_OVERLAY
 #include "MapOverlayWidget.hpp"
 #endif
 #include "Widget/TextWidget.hpp"
@@ -176,11 +176,10 @@ ShowWeatherDialog(const char *page)
   widget.AddTab(CreatePCMetTabWidget(), "Flugwetter");
 #endif
 
-#if 0
-  /* The German DWD has terminated our access to georeferenced images,
-     so this code is disabled for now, but will remain here;
-     eventually, we should refactor the code to be generic, allowing
-     arbitrary georeferenced images */
+#ifdef HAVE_WEATHER_OVERLAY
+  /* this was disabled while the only source was the DWD, whose
+     georeferenced images we lost access to; the radar composite needs
+     no account, so there is something to show again */
 
   if (page != nullptr && StringIsEqual(page, "overlay"))
     start_page = widget.GetSize();

--- a/src/Dialogs/Weather/WeatherOverlayDraft.cpp
+++ b/src/Dialogs/Weather/WeatherOverlayDraft.cpp
@@ -84,6 +84,7 @@ State::IsDirty() const noexcept
     return draft.skysight_overlay != baseline.skysight_overlay ||
       draft.skysight_time != baseline.skysight_time;
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     return false;

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -276,6 +276,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
 
     case PageLayout::Overlay::SKYSIGHT:
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return plus
@@ -296,6 +297,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
       return "";
 
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Layer\nList\n(F2/+)");
@@ -314,6 +316,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
       return C_("Weather control", "Time\nAuto\n(F3/-)");
 
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Time\nAuto\n(F3/-)");

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -18,6 +18,9 @@
 #endif
 #ifdef HAVE_HTTP
 #include "Weather/xctherm/XCThermDownloadGlue.hpp"
+#ifdef HAVE_WEATHER_OVERLAY
+#include "Weather/OPERA/RadarPageOverlay.hpp"
+#endif
 #include "DataGlobals.hpp"
 #include "Weather/SkySight/SkySightClient.hpp"
 #endif
@@ -40,6 +43,9 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
   ,edl(new EDL::DownloadGlue(curl))
 # endif
   ,xctherm_download(new XCThermDownloadGlue(curl))
+# ifdef HAVE_WEATHER_OVERLAY
+  ,opera_radar(new RadarDownloadGlue(curl))
+# endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   ,rasp_download(new RaspDownloadGlue())
@@ -88,6 +94,11 @@ NetComponents::BeginShutdown() noexcept
 
   if (xctherm_download != nullptr)
     xctherm_download->BeginShutdown();
+
+# ifdef HAVE_WEATHER_OVERLAY
+  if (opera_radar != nullptr)
+    opera_radar->BeginShutdown();
+# endif
 
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (rasp_download != nullptr)

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -20,6 +20,9 @@ class NOTAMGlue;
 namespace EDL { class DownloadGlue; }
 #endif
 class XCThermDownloadGlue;
+#ifdef HAVE_WEATHER_OVERLAY
+class RadarDownloadGlue;
+#endif
 #ifdef HAVE_DOWNLOAD_MANAGER
 class RaspDownloadGlue;
 #endif
@@ -43,6 +46,9 @@ struct NetComponents {
   const std::unique_ptr<EDL::DownloadGlue> edl;
 # endif
   const std::unique_ptr<XCThermDownloadGlue> xctherm_download;
+# ifdef HAVE_WEATHER_OVERLAY
+  const std::unique_ptr<RadarDownloadGlue> opera_radar;
+# endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   const std::unique_ptr<RaspDownloadGlue> rasp_download;

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -302,6 +302,10 @@ PageActions::SuspendWeatherOverlaysForPan() noexcept
     weather.xctherm.SuspendForPan();
   if (layout.UsesSkySightOverlay())
     weather.skysight.SuspendForPan();
+#ifdef HAVE_WEATHER_OVERLAY
+  if (layout.UsesRadarOverlay())
+    OPERA::SuspendForPan();
+#endif
 }
 
 void
@@ -312,6 +316,9 @@ PageActions::ResumeWeatherOverlaysAfterPan() noexcept
   weather.rasp.ResumeAfterPan();
   weather.xctherm.ResumeAfterPan();
   weather.skysight.ResumeAfterPan();
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ResumeAfterPan();
+#endif
 }
 
 void

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -17,6 +17,7 @@
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Components.hpp"
+#include "Weather/Features.hpp"
 #include "Weather/MapOverlay/ControlsFactory.hpp"
 #include "Weather/MapOverlay/ControlsWidget.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
@@ -34,6 +35,9 @@
 #include "Weather/SkySight/SkySightClient.hpp"
 #include "Weather/xctherm/FieldControls.hpp"
 #include "Weather/xctherm/XCThermMapOverlay.hpp"
+#ifdef HAVE_WEATHER_OVERLAY
+#include "Weather/OPERA/RadarPageOverlay.hpp"
+#endif
 #endif
 
 #if defined(ENABLE_SDL) && defined(main)
@@ -69,6 +73,7 @@ namespace PageActions {
   static void LeaveEdlOverlay() noexcept;
   static void LeaveXcthermOverlay() noexcept;
   static void LeaveSkySightOverlay() noexcept;
+  static void LeaveRadarOverlay() noexcept;
 
   static void LeaveWeatherOverlayPage(const PageLayout &layout) noexcept;
 
@@ -76,6 +81,7 @@ namespace PageActions {
   static void ApplyEdlOverlay(const PageLayout &layout) noexcept;
   static void ApplyXcthermOverlay(const PageLayout &layout) noexcept;
   static void ApplySkySightOverlay(const PageLayout &layout) noexcept;
+  static void ApplyRadarOverlay() noexcept;
 
   static void ApplyPageOverlay(const PageLayout &layout) noexcept;
 };
@@ -163,6 +169,22 @@ PageActions::LeaveSkySightOverlay() noexcept
 }
 
 void
+PageActions::LeaveRadarOverlay() noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ClearMapOverlay();
+#endif
+}
+
+void
+PageActions::ApplyRadarOverlay() noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ActivatePageOverlay();
+#endif
+}
+
+void
 PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
 {
   if (layout.UsesEdlOverlay())
@@ -173,6 +195,8 @@ PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
     LeaveXcthermOverlay();
   else if (layout.UsesSkySightOverlay())
     LeaveSkySightOverlay();
+  else if (layout.UsesRadarOverlay())
+    LeaveRadarOverlay();
 }
 
 void
@@ -306,6 +330,8 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
     LeaveXcthermOverlay();
   if (!layout.UsesSkySightOverlay())
     LeaveSkySightOverlay();
+  if (!layout.UsesRadarOverlay())
+    LeaveRadarOverlay();
 
   ClearPageOverlays();
 
@@ -327,6 +353,10 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
 
   case PageLayout::Overlay::SKYSIGHT:
     ApplySkySightOverlay(layout);
+    break;
+
+  case PageLayout::Overlay::RADAR:
+    ApplyRadarOverlay();
     break;
 
   case PageLayout::Overlay::MAX:

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -172,7 +172,7 @@ void
 PageActions::LeaveRadarOverlay() noexcept
 {
 #ifdef HAVE_WEATHER_OVERLAY
-  OPERA::ClearMapOverlay();
+  OPERA::DeactivatePageOverlay();
 #endif
 }
 

--- a/src/PageOverlayTitle.cpp
+++ b/src/PageOverlayTitle.cpp
@@ -103,6 +103,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     }
     break;
 
+  case PageLayout::Overlay::RADAR:
+    builder.Append(", ");
+    builder.Append(_("Radar"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -281,6 +281,23 @@ struct PageLayout
   }
 
   /**
+   * Does this page carry an overlay that has to survive a pan?
+   *
+   * Panning shows the fullscreen map, whose layout carries no overlay
+   * at all, so without this the overlay would be torn down on the way
+   * in and fetched again on the way out.  This is deliberately not
+   * #UsesWeatherOverlay(): that one also gates the weather controls
+   * widget and the "weather" input mode, and an overlay with no
+   * forecast cursors would land the pilot in an empty control bar.
+   */
+  [[gnu::const]]
+  constexpr bool
+  UsesSuspendableOverlay() const noexcept
+  {
+    return UsesWeatherOverlay() || UsesRadarOverlay();
+  }
+
+  /**
    * Convert legacy page layouts to the current representation.
    */
   constexpr void Normalise() noexcept

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -112,6 +112,7 @@ struct PageLayout
     EDL,
     XCTHERM,
     SKYSIGHT,
+    RADAR,
 
     MAX
   } overlay;
@@ -261,6 +262,13 @@ struct PageLayout
   {
     return IsMapMain() && overlay == Overlay::SKYSIGHT &&
       !skysight_overlay.empty();
+  }
+
+  [[gnu::const]]
+  constexpr bool
+  UsesRadarOverlay() const noexcept
+  {
+    return IsMapMain() && overlay == Overlay::RADAR;
   }
 
   [[gnu::const]]

--- a/src/Pan.cpp
+++ b/src/Pan.cpp
@@ -29,7 +29,7 @@ GlueMapWindow *
 PreparePanFullscreen(bool abort_if_already_panning) noexcept
 {
   const bool suspending_weather =
-    PageActions::GetCurrentLayout().UsesWeatherOverlay();
+    PageActions::GetCurrentLayout().UsesSuspendableOverlay();
   if (suspending_weather)
     PageActions::SuspendWeatherOverlaysForPan();
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -355,6 +355,8 @@ constexpr std::string_view GDL90UseSystemUtcDate = "GDL90UseSystemUtcDate";
 
 constexpr std::string_view HideQuickGuideDialogOnStartup =
   "HideQuickGuideDialogOnStartup";
+constexpr std::string_view HideRadarStaleWarning =
+  "HideRadarStaleWarning";
 constexpr std::string_view DisclaimerAcknowledgedVersion =
   "DisclaimerAcknowledgedVersion";
 constexpr std::string_view LastSeenNewsVersion =

--- a/src/Weather/Features.hpp
+++ b/src/Weather/Features.hpp
@@ -10,5 +10,9 @@
 #define HAVE_PCMET
 #ifdef ENABLE_OPENGL
 #define HAVE_EDL
+
+/* the map overlay widget is only built for OpenGL targets, because
+   drawing a georeferenced bitmap needs the OpenGL canvas */
+#define HAVE_WEATHER_OVERLAY
 #endif
 #endif

--- a/src/Weather/MapOverlay/ControlsFactory.cpp
+++ b/src/Weather/MapOverlay/ControlsFactory.cpp
@@ -44,6 +44,7 @@ CreateControlsModel(const PageLayout &layout) noexcept
     break;
 #endif
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/PagePlacement.hpp
+++ b/src/Weather/MapOverlay/PagePlacement.hpp
@@ -49,6 +49,7 @@ CopyWeatherOverlayCursors(PageLayout &dest,
     dest.skysight_time = src.skysight_time;
     break;
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/WeatherSetupDialog.cpp
+++ b/src/Weather/MapOverlay/WeatherSetupDialog.cpp
@@ -26,6 +26,7 @@ ShowWeatherSetupDialog() noexcept
   case PageLayout::Overlay::SKYSIGHT:
     page = "skysight";
     break;
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -4,302 +4,81 @@
 #include "Radar.hpp"
 #include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
-#include "net/http/CoDownloadToFile.hpp"
+#include "Math/Point2D.hpp"
+#include "net/http/CoGetRange.hpp"
 #include "co/Task.hxx"
-#include "io/FileMapping.hpp"
 #include "io/FileOutputStream.hxx"
-#include "time/BrokenDateTime.hpp"
 #include "util/AllocatedArray.hxx"
 #include "util/ByteOrder.hxx"
+#include "time/BrokenDateTime.hpp"
 #include "LocalPath.hpp"
+#include "Operation/ProgressListener.hpp"
 
 #include <zlib.h>
 
 #include <algorithm>
 #include <bit>
-#include <cmath>
 #include <cstring>
-#include <span>
 #include <stdexcept>
-#include <vector>
+#include <utility>
 
 namespace {
 
+/** The class of a pixel with no echo, or none we hold. */
+constexpr int8_t NO_CLASS = -1;
+
 /**
- * The subset of TIFF we need: the composite is a tiled, Deflate
- * compressed, two band float image with a pyramid of overviews.
+ * The largest tile we will inflate, as a guard against a directory
+ * that claims an absurd tile size.  The composite's own tiles are
+ * 512 by 512 of two float bands, a megabyte each.
  */
+constexpr std::size_t MAX_TILE_PIXELS = 4u * 1024 * 1024;
+
+/** the largest single image the Weather dialog will draw */
+constexpr unsigned MAX_AREA_PIXELS = 1024;
+
 /**
- * Stands in for "no measurement here".  A plain low value rather than
- * a NaN, because we are built with -ffast-math and must not rely on
- * NaN comparisons behaving.
+ * Uncompress one tile, take its first band and classify it.
+ *
+ * The classification happens here rather than at draw time so that
+ * what is kept is one byte per pixel instead of four, and so that a
+ * pixel is classified once however many times it is drawn.
  */
-constexpr float NO_ECHO = -1e30f;
-
-struct TiffLevel {
-  unsigned width = 0, height = 0;
-  unsigned tile_width = 0, tile_height = 0;
-  unsigned samples = 0;
-  std::vector<uint32_t> tile_offset, tile_length;
-  double scale = 0;
-  double origin_x = 0, origin_y = 0;
-
-  unsigned TilesAcross() const noexcept {
-    return (width + tile_width - 1) / tile_width;
-  }
-};
-
-class TiffReader {
-  std::span<const std::byte> file;
-  bool big_endian = false;
-
-public:
-  explicit TiffReader(std::span<const std::byte> _file):file(_file) {
-    if (file.size() < 8)
-      throw std::runtime_error("Truncated radar image");
-
-    const auto *p = (const uint8_t *)file.data();
-    if (p[0] == 'M' && p[1] == 'M')
-      big_endian = true;
-    else if (p[0] != 'I' || p[1] != 'I')
-      throw std::runtime_error("Not a TIFF radar image");
-  }
-
-  uint16_t U16(std::size_t o) const {
-    if (o + 2 > file.size())
-      throw std::runtime_error("Truncated radar image");
-    const auto *p = (const uint8_t *)file.data() + o;
-    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
-  }
-
-  uint32_t U32(std::size_t o) const {
-    if (o + 4 > file.size())
-      throw std::runtime_error("Truncated radar image");
-    const auto *p = (const uint8_t *)file.data() + o;
-    return big_endian
-      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | p[3])
-      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 | uint32_t(p[1]) << 8 | p[0]);
-  }
-
-  double F64(std::size_t o) const {
-    /* U32() already applies the file byte order within each half, so
-       all that is left is which half comes first */
-    const uint64_t first = U32(o), second = U32(o + 4);
-    return std::bit_cast<double>(big_endian
-                                 ? first << 32 | second
-                                 : second << 32 | first);
-  }
-
-  bool IsForeignByteOrder() const noexcept {
-    return big_endian != (std::endian::native == std::endian::big);
-  }
-
-  std::span<const std::byte> Slice(std::size_t o, std::size_t n) const {
-    if (o + n > file.size())
-      throw std::runtime_error("Truncated radar image");
-    return file.subspan(o, n);
-  }
-
-  std::size_t FirstDirectory() const { return U32(4); }
-
-  /**
-   * Read one image file directory.
-   *
-   * @return the offset of the next one, zero at the end
-   */
-  std::size_t ReadDirectory(std::size_t offset, TiffLevel &level) const;
-};
-
-constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
-constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
-constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
-constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
-constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
-constexpr unsigned COMPRESSION_DEFLATE = 8;
-
-std::size_t
-TiffReader::ReadDirectory(std::size_t offset, TiffLevel &level) const
+std::vector<int8_t>
+InflateTile(std::span<const std::byte> compressed,
+            const OPERA::CompositeLevel &level, bool foreign_byte_order)
 {
-  const unsigned n = U16(offset);
-  unsigned compression = 0;
+  const std::size_t pixels =
+    std::size_t(level.tile_width) * level.tile_height;
+  if (pixels == 0 || pixels > MAX_TILE_PIXELS || level.samples == 0)
+    throw std::runtime_error("Unusable radar image");
 
-  for (unsigned i = 0; i < n; ++i) {
-    const std::size_t e = offset + 2 + i * 12;
-    const unsigned tag = U16(e), type = U16(e + 2);
-    const uint32_t count = U32(e + 4);
-
-    /* the value is inline when it fits in four bytes */
-    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
-    const std::size_t at = std::size_t(size) * count <= 4 ? e + 8 : U32(e + 8);
-
-    const auto scalar = [&]() -> uint32_t {
-      return type == 3 ? U16(at) : U32(at);
-    };
-
-    switch (tag) {
-    case TAG_WIDTH: level.width = scalar(); break;
-    case TAG_HEIGHT: level.height = scalar(); break;
-    case TAG_COMPRESSION: compression = scalar(); break;
-    case TAG_SAMPLES: level.samples = scalar(); break;
-    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
-    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
-
-    case TAG_TILE_OFFSETS:
-    case TAG_TILE_LENGTHS: {
-      auto &out = tag == TAG_TILE_OFFSETS ? level.tile_offset : level.tile_length;
-      out.clear();
-      out.reserve(count);
-      for (uint32_t j = 0; j < count; ++j)
-        out.push_back(type == 3 ? U16(at + j * 2) : U32(at + j * 4));
-      break;
-    }
-
-    case TAG_PIXEL_SCALE:
-      if (count >= 2)
-        level.scale = F64(at);
-      break;
-
-    case TAG_TIEPOINT:
-      /* the first three doubles are the raster point, the next three
-         the projected point it maps to */
-      if (count >= 6) {
-        level.origin_x = F64(at + 3 * 8);
-        level.origin_y = F64(at + 4 * 8);
-      }
-      break;
-    }
-  }
-
-  if (level.width > 0) {
-    if (compression != COMPRESSION_DEFLATE)
-      throw std::runtime_error("Unsupported radar image compression");
-
-    if (level.samples == 0)
-      /* the tag is mandatory, but a missing one would make us read
-         zero bytes per pixel */
-      level.samples = 1;
-  }
-
-  return U32(offset + 2 + std::size_t(n) * 12);
-}
-
-/**
- * Uncompress one tile and return its first band.
- */
-void
-InflateTile(std::span<const std::byte> tile, const TiffLevel &level,
-            bool foreign_byte_order, float *out)
-{
-  const std::size_t pixels = std::size_t(level.tile_width) * level.tile_height;
   AllocatedArray<float> raw{pixels * level.samples};
 
   uLongf size = uLongf(raw.size() * sizeof(float));
   if (::uncompress((Bytef *)raw.data(), &size,
-                   (const Bytef *)tile.data(), uLong(tile.size())) != Z_OK ||
+                   (const Bytef *)compressed.data(),
+                   uLong(compressed.size())) != Z_OK ||
       size < pixels * level.samples * sizeof(float))
     throw std::runtime_error("Damaged radar image");
 
+  std::vector<int8_t> out;
+  out.resize(pixels);
+
   for (std::size_t i = 0; i < pixels; ++i) {
-    const float value = raw[i * level.samples];
-    out[i] = foreign_byte_order
-      ? std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)))
-      : value;
+    float value = raw[i * level.samples];
+    if (foreign_byte_order)
+      value = std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)));
+
+    /* the composite marks "looked and saw nothing" with a NaN and "no
+       radar here" with a large negative number; both come out as the
+       "nothing to draw" class */
+    out[i] = OPERA::IsNotANumber(value)
+      ? NO_CLASS
+      : int8_t(OPERA::ClassifyReflectivity(value));
   }
-}
 
-} // anonymous namespace
-
-namespace {
-
-/**
- * Pick the coarsest overview that still resolves the requested
- * detail.  Asking for a finer one only costs bandwidth and memory.
- */
-const TiffLevel &
-SelectLevel(const std::vector<TiffLevel> &levels,
-            double metres_per_pixel) noexcept
-{
-  const TiffLevel *best = &levels.front();
-
-  for (const auto &level : levels)
-    if (level.width > 0 && level.scale > 0 &&
-        level.scale <= metres_per_pixel)
-      /* the levels are ordered fine to coarse, so the last one that
-         is still fine enough is the cheapest usable one */
-      best = &level;
-
-  return *best;
-}
-
-/**
- * The part of one level we need, decoded into a contiguous grid.
- */
-class Patch {
-  unsigned x0 = 0, y0 = 0, width = 0, height = 0;
-  AllocatedArray<float> data;
-
-public:
-  Patch(const TiffReader &tiff, const TiffLevel &level,
-        unsigned col0, unsigned row0, unsigned col1, unsigned row1);
-
-  /**
-   * @return the reflectivity, or #NO_ECHO where there is none
-   */
-  float Get(unsigned col, unsigned row) const noexcept {
-    if (col < x0 || row < y0)
-      return NO_ECHO;
-
-    const unsigned x = col - x0, y = row - y0;
-    if (x >= width || y >= height)
-      return NO_ECHO;
-
-    return data[std::size_t(y) * width + x];
-  }
-};
-
-Patch::Patch(const TiffReader &tiff, const TiffLevel &level,
-             unsigned col0, unsigned row0, unsigned col1, unsigned row1)
-{
-  const unsigned across = level.TilesAcross();
-  const unsigned tx0 = col0 / level.tile_width, tx1 = col1 / level.tile_width;
-  const unsigned ty0 = row0 / level.tile_height, ty1 = row1 / level.tile_height;
-
-  x0 = tx0 * level.tile_width;
-  y0 = ty0 * level.tile_height;
-  width = (tx1 - tx0 + 1) * level.tile_width;
-  height = (ty1 - ty0 + 1) * level.tile_height;
-
-  data.ResizeDiscard(std::size_t(width) * height);
-  std::fill_n(data.data(), data.size(), NO_ECHO);
-
-  AllocatedArray<float> tile{std::size_t(level.tile_width) * level.tile_height};
-
-  for (unsigned ty = ty0; ty <= ty1; ++ty) {
-    for (unsigned tx = tx0; tx <= tx1; ++tx) {
-      const std::size_t i = std::size_t(ty) * across + tx;
-      if (i >= level.tile_offset.size() || i >= level.tile_length.size() ||
-          level.tile_length[i] == 0)
-        continue;
-
-      InflateTile(tiff.Slice(level.tile_offset[i], level.tile_length[i]),
-                  level, tiff.IsForeignByteOrder(), tile.data());
-
-      for (unsigned y = 0; y < level.tile_height; ++y) {
-        const unsigned dy = (ty - ty0) * level.tile_height + y;
-        if (dy >= height)
-          break;
-
-        const float *src = tile.data() + std::size_t(y) * level.tile_width;
-        float *dest = data.data() + std::size_t(dy) * width +
-          (tx - tx0) * level.tile_width;
-
-        for (unsigned x = 0; x < level.tile_width; ++x)
-          /* the composite marks "looked and saw nothing" with a NaN
-             and "no radar here" with a large negative number */
-          dest[x] = OPERA::IsNotANumber(src[x]) ? NO_ECHO : src[x];
-      }
-    }
-  }
+  return out;
 }
 
 /**
@@ -309,11 +88,13 @@ void
 WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
 {
   /* one filter byte per row, filter type 0 ("none") */
-  AllocatedArray<uint8_t> raw{std::size_t(height) * (1 + std::size_t(width) * 4)};
+  AllocatedArray<uint8_t> raw{
+    std::size_t(height) * (1 + std::size_t(width) * 4)};
   for (unsigned y = 0; y < height; ++y) {
     uint8_t *dest = raw.data() + std::size_t(y) * (1 + std::size_t(width) * 4);
     *dest++ = 0;
-    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4, dest);
+    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4,
+                dest);
   }
 
   uLongf compressed_size = ::compressBound(uLong(raw.size()));
@@ -324,8 +105,8 @@ WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
 
   FileOutputStream file{path, FileOutputStream::Mode::CREATE};
 
-  const auto WriteChunk = [&file](const char *type,
-                                  const uint8_t *payload, std::size_t size){
+  const auto write_chunk = [&file](const char *type,
+                                   const uint8_t *payload, std::size_t size){
     uint8_t header[8];
     header[0] = uint8_t(size >> 24); header[1] = uint8_t(size >> 16);
     header[2] = uint8_t(size >> 8); header[3] = uint8_t(size);
@@ -344,181 +125,235 @@ WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
     file.Write(std::as_bytes(std::span{tail}));
   };
 
-  static constexpr uint8_t signature[] = {
+  static constexpr uint8_t SIGNATURE[] = {
     0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
   };
-  file.Write(std::as_bytes(std::span{signature}));
+  file.Write(std::as_bytes(std::span{SIGNATURE}));
 
   const uint8_t ihdr[13] = {
-    uint8_t(width >> 24), uint8_t(width >> 16), uint8_t(width >> 8), uint8_t(width),
-    uint8_t(height >> 24), uint8_t(height >> 16), uint8_t(height >> 8), uint8_t(height),
+    uint8_t(width >> 24), uint8_t(width >> 16),
+    uint8_t(width >> 8), uint8_t(width),
+    uint8_t(height >> 24), uint8_t(height >> 16),
+    uint8_t(height >> 8), uint8_t(height),
     8, 6, 0, 0, 0,
   };
-  WriteChunk("IHDR", ihdr, sizeof(ihdr));
-  WriteChunk("IDAT", compressed.data(), compressed_size);
-  WriteChunk("IEND", nullptr, 0);
+  write_chunk("IHDR", ihdr, sizeof(ihdr));
+  write_chunk("IDAT", compressed.data(), compressed_size);
+  write_chunk("IEND", nullptr, 0);
 
   file.Commit();
 }
 
 } // anonymous namespace
 
-namespace {
-
-/**
- * Reproject the composite into a north-up latitude/longitude image
- * and colour it.
- */
-AllocatedArray<uint8_t>
-Render(const TiffReader &tiff, const std::vector<TiffLevel> &levels,
-       const GeoBounds &bounds, unsigned width, unsigned height)
+bool
+OPERA::RadarComposite::HasTile(unsigned level, unsigned tile) const noexcept
 {
-  const double north = bounds.GetNorth().Degrees();
-  const double south = bounds.GetSouth().Degrees();
-  const double west = bounds.GetWest().Degrees();
-  const double east = bounds.GetEast().Degrees();
+  return std::any_of(tiles.begin(), tiles.end(),
+                     [level, tile](const auto &i){
+                       return i.level == level && i.index == tile;
+                     });
+}
 
-  /* the projection is curved, so probe a coarse grid rather than
-     just the corners to find the extent we need */
-  static constexpr unsigned PROBE = 8;
-  double min_x = 1e30, max_x = -1e30, min_y = 1e30, max_y = -1e30;
-  for (unsigned j = 0; j <= PROBE; ++j) {
-    for (unsigned i = 0; i <= PROBE; ++i) {
-      const auto p = OPERA::Project(GeoPoint{
-        Angle::Degrees(west + (east - west) * i / PROBE),
-        Angle::Degrees(south + (north - south) * j / PROBE),
-      });
-      min_x = std::min(min_x, p.x); max_x = std::max(max_x, p.x);
-      min_y = std::min(min_y, p.y); max_y = std::max(max_y, p.y);
-    }
-  }
+Co::Task<void>
+OPERA::RadarComposite::Open(std::string _url, CurlGlobal &curl)
+{
+  if (IsOpen() && url == _url)
+    co_return;
 
-  const auto &level = SelectLevel(levels, (max_x - min_x) / width);
-  if (level.width == 0 || level.scale <= 0 ||
-      level.tile_width == 0 || level.tile_height == 0)
+  Reset();
+
+  /* one range request buys the whole directory: what levels the file
+     has, how it is tiled, and where every tile of it lies */
+  const auto header = co_await Net::CoGetRange(curl, _url.c_str(),
+                                               0, INDEX_BYTES);
+
+  index = ParseIndex(std::as_bytes(std::span{header}));
+  url = std::move(_url);
+}
+
+Co::Task<void>
+OPERA::RadarComposite::FetchTile(unsigned level_index, unsigned tile,
+                                 CurlGlobal &curl)
+{
+  if (!IsOpen() || HasTile(level_index, tile))
+    co_return;
+
+  if (level_index >= index.levels.size())
     throw std::runtime_error("Unusable radar image");
 
-  const auto ToColumn = [&level](double x){
-    return (x - level.origin_x) / level.scale;
-  };
-  const auto ToRow = [&level](double y){
-    return (level.origin_y - y) / level.scale;
+  const auto &level = index.levels[level_index];
+  if (!level.IsUsable() || tile >= level.tile_offset.size())
+    throw std::runtime_error("Unusable radar image");
+
+  const auto length = level.tile_length[tile];
+  if (length == 0)
+    /* an empty tile is not an error: the file marks areas the radar
+       network does not reach that way */
+    co_return;
+
+  const auto compressed = co_await Net::CoGetRange(curl, url.c_str(),
+                                                   level.tile_offset[tile],
+                                                   length);
+  if (compressed.size() < length)
+    throw std::runtime_error("Truncated radar image");
+
+  auto data = InflateTile(std::as_bytes(std::span{compressed}), level,
+                          index.foreign_byte_order);
+
+  /* the awaits above can have run concurrently with another fetch of
+     the same tile; keep only one copy */
+  if (HasTile(level_index, tile))
+    co_return;
+
+  /* the oldest goes first, which is the one the aircraft flew away
+     from: the block is filled from its centre outwards, so what was
+     fetched longest ago is what is furthest behind */
+  while (tiles.size() >= MAX_CACHED_TILES)
+    tiles.erase(tiles.begin());
+
+  tiles.push_back({level_index, tile, std::move(data)});
+}
+
+bool
+OPERA::RadarComposite::Render(unsigned level_index, const GeoBounds &bounds,
+                              unsigned width, unsigned height,
+                              Path path) const
+{
+  if (!IsOpen() || level_index >= index.levels.size() ||
+      !bounds.IsValid() || width == 0 || height == 0)
+    throw std::runtime_error("Unusable radar image");
+
+  const auto &level = index.levels[level_index];
+  if (!level.IsUsable())
+    throw std::runtime_error("Unusable radar image");
+
+  /* the handful of source tiles this area touches, looked up once
+     rather than searched for per pixel */
+  struct Held {
+    unsigned index;
+    const std::vector<int8_t> *data;
   };
 
-  const double c0 = ToColumn(min_x), c1 = ToColumn(max_x);
-  const double r0 = ToRow(max_y), r1 = ToRow(min_y);
-  if (c1 < 0 || r1 < 0 || c0 >= level.width || r0 >= level.height)
-    /* the map is looking somewhere the composite does not cover */
-    throw std::runtime_error("Outside the radar composite");
+  /* only the tiles this area actually touches, so that the lookup in
+     the pixel loop below scans four entries rather than the whole
+     cache */
+  std::vector<Held> held;
+  for (const auto source : CoveringSourceTiles(level, bounds))
+    for (const auto &tile : tiles)
+      if (tile.level == level_index && tile.index == source)
+        held.push_back({tile.index, &tile.data});
 
-  const Patch patch{tiff, level,
-                    unsigned(std::max(0.0, c0)),
-                    unsigned(std::max(0.0, r0)),
-                    unsigned(std::min(double(level.width - 1), c1)),
-                    unsigned(std::min(double(level.height - 1), r1))};
+  if (held.empty())
+    /* nothing of this area has arrived yet, or the composite does not
+       reach it */
+    return false;
+
+  const unsigned across = level.TilesAcross();
+
+  const auto sample = [&](double column, double row) -> int8_t {
+    if (column < 0 || row < 0 ||
+        column >= double(level.width) || row >= double(level.height))
+      return NO_CLASS;
+
+    const unsigned c = unsigned(column), r = unsigned(row);
+    const unsigned i = (r / level.tile_height) * across + c / level.tile_width;
+
+    for (const auto &tile : held)
+      if (tile.index == i) {
+        const std::size_t x = c % level.tile_width;
+        const std::size_t y = r % level.tile_height;
+        const std::size_t at = y * level.tile_width + x;
+        return at < tile.data->size() ? (*tile.data)[at] : NO_CLASS;
+      }
+
+    return NO_CLASS;
+  };
+
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+
+  const RasterProjector projector{bounds.GetWest().Degrees(),
+                                  bounds.GetEast().Degrees(), width};
+  AllocatedArray<DoublePoint2D> row_points{width};
 
   AllocatedArray<uint8_t> image{std::size_t(width) * height * 4};
   std::fill_n(image.data(), image.size(), uint8_t(0));
 
+  bool any = false;
+
   for (unsigned y = 0; y < height; ++y) {
     const double latitude = north - (north - south) * (y + 0.5) / height;
+    projector.ProjectRow(latitude, row_points.data());
 
     for (unsigned x = 0; x < width; ++x) {
-      const double longitude = west + (east - west) * (x + 0.5) / width;
-
-      const auto p = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
-                                             Angle::Degrees(latitude)});
-      const double column = ToColumn(p.x), row = ToRow(p.y);
-      if (column < 0 || row < 0 ||
-          column >= level.width || row >= level.height)
-        continue;
+      const auto &p = row_points[x];
+      const double column = (p.x - level.origin_x) / level.scale;
+      const double row = (level.origin_y - p.y) / level.scale;
 
       /* take the strongest of the source pixels this one covers; the
          composite is a maximum product, and picking just one would
-         drop isolated echoes when zoomed out */
-      float dbz = NO_ECHO;
+         drop isolated echoes when zoomed out.  The classification is
+         monotonic, so the strongest class is the class of the
+         strongest echo. */
+      int8_t cls = NO_CLASS;
       for (unsigned dy = 0; dy < 2; ++dy)
         for (unsigned dx = 0; dx < 2; ++dx)
-          dbz = std::max(dbz, patch.Get(unsigned(column) + dx,
-                                        unsigned(row) + dy));
+          cls = std::max(cls, sample(column + dx, row + dy));
 
-      const int cls = OPERA::ClassifyReflectivity(dbz);
       if (cls < 0)
         continue;
 
-      const uint32_t colour = OPERA::GetClassColour(unsigned(cls));
+      const uint32_t colour = GetClassColour(unsigned(cls));
       uint8_t *dest = image.data() + (std::size_t(y) * width + x) * 4;
       dest[0] = uint8_t(colour >> 16);
       dest[1] = uint8_t(colour >> 8);
       dest[2] = uint8_t(colour);
       dest[3] = 0xff;
+      any = true;
     }
   }
 
-  return image;
+  WritePNG(path, width, height, image.data());
+
+  /* the caller uses this to leave a clear sky alone rather than spend
+     a map overlay slot and a texture upload on a transparent tile */
+  return any;
 }
 
-} // anonymous namespace
-
 Co::Task<AllocatedPath>
-OPERA::DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
-                     CurlGlobal &curl, ProgressListener &progress)
+OPERA::DownloadArea(const GeoBounds &bounds, unsigned width, unsigned height,
+                    CurlGlobal &curl, ProgressListener &progress)
 {
   if (!bounds.IsValid())
     throw std::runtime_error("No map area to cover");
 
-  width = std::clamp(width, 1u, MAX_IMAGE_SIZE);
-  height = std::clamp(height, 1u, MAX_IMAGE_SIZE);
+  width = std::clamp(width, 1u, MAX_AREA_PIXELS);
+  height = std::clamp(height, 1u, MAX_AREA_PIXELS);
 
   const auto url = MakeCompositeURL(BrokenDateTime::NowUTC());
   if (url.empty())
     throw std::runtime_error("The clock is not set");
 
-  const auto cache = MakeCacheDirectory("opera");
-  const auto source = AllocatedPath::Build(cache, "composite.tiff");
-  auto rendered = AllocatedPath::Build(cache, "composite.png");
+  RadarComposite composite;
+  co_await composite.Open(url, curl);
 
-  {
-    const auto ignored_response = co_await
-      Net::CoDownloadToFile(curl, url.c_str(), nullptr, nullptr,
-                            source, nullptr, progress);
+  const auto &index = composite.GetIndex();
+  const auto level = SelectLevel(index, TileMetresPerPixel(bounds, width));
+  const auto sources = CoveringSourceTiles(index.levels[level], bounds);
+  if (sources.empty())
+    throw std::runtime_error("Outside the radar composite");
+
+  progress.SetProgressRange(unsigned(sources.size()));
+
+  unsigned done = 0;
+  for (const auto source : sources) {
+    co_await composite.FetchTile(level, source, curl);
+    progress.SetProgressPosition(++done);
   }
 
-  const FileMapping mapping{source};
-  const TiffReader tiff{mapping};
+  auto path = AllocatedPath::Build(MakeCacheDirectory("opera"), "area.png");
+  composite.Render(level, bounds, width, height, path);
 
-  std::vector<TiffLevel> levels;
-  /* count every directory, not just the usable ones: a damaged file
-     can chain empty directories, or point one at itself */
-  for (std::size_t offset = tiff.FirstDirectory(), n = 0;
-       offset != 0 && n < 32; ++n) {
-    TiffLevel level;
-    offset = tiff.ReadDirectory(offset, level);
-    if (level.width > 0)
-      levels.push_back(std::move(level));
-  }
-
-  if (levels.empty())
-    throw std::runtime_error("Empty radar image");
-
-  /* only the full resolution image carries the projection keys; the
-     overviews cover the same area with fewer pixels, so their scale
-     follows from the size ratio */
-  for (auto &level : levels) {
-    if (level.scale > 0 || level.width == 0 || levels.front().width == 0)
-      continue;
-
-    level.scale = levels.front().scale *
-      double(levels.front().width) / level.width;
-    level.origin_x = levels.front().origin_x;
-    level.origin_y = levels.front().origin_y;
-  }
-
-  if (levels.front().scale <= 0)
-    throw std::runtime_error("Radar image without a georeference");
-
-  const auto image = Render(tiff, levels, bounds, width, height);
-  WritePNG(rendered, width, height, image.data());
-
-  co_return std::move(rendered);
+  co_return std::move(path);
 }

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -28,9 +28,10 @@ namespace {
 constexpr int8_t NO_CLASS = -1;
 
 /**
- * The largest tile we will inflate, as a guard against a directory
- * that claims an absurd tile size.  The composite's own tiles are
- * 512 by 512 of two float bands, a megabyte each.
+ * The largest tile we will inflate, counted in samples rather than in
+ * pixels, as a guard against a directory that claims an absurd tile
+ * size or band count.  The composite's own tiles are 512 by 512 of
+ * two float bands, half a million samples.
  */
 constexpr std::size_t MAX_TILE_PIXELS = 4u * 1024 * 1024;
 
@@ -50,7 +51,13 @@ InflateTile(std::span<const std::byte> compressed,
 {
   const std::size_t pixels =
     std::size_t(level.tile_width) * level.tile_height;
-  if (pixels == 0 || pixels > MAX_TILE_PIXELS || level.samples == 0)
+
+  /* the sample count comes out of the file just as the tile size
+     does, so the buffer has to be bounded by the product rather than
+     by the pixel count alone; written as a division so that the check
+     itself cannot overflow */
+  if (pixels == 0 || level.samples == 0 ||
+      pixels > MAX_TILE_PIXELS / level.samples)
     throw std::runtime_error("Unusable radar image");
 
   AllocatedArray<float> raw{pixels * level.samples};

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Radar.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "net/http/CoDownloadToFile.hpp"
+#include "co/Task.hxx"
+#include "io/FileMapping.hpp"
+#include "io/FileOutputStream.hxx"
+#include "time/BrokenDateTime.hpp"
+#include "util/AllocatedArray.hxx"
+#include "util/ByteOrder.hxx"
+#include "LocalPath.hpp"
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+/**
+ * The subset of TIFF we need: the composite is a tiled, Deflate
+ * compressed, two band float image with a pyramid of overviews.
+ */
+/**
+ * Stands in for "no measurement here".  A plain low value rather than
+ * a NaN, because we are built with -ffast-math and must not rely on
+ * NaN comparisons behaving.
+ */
+constexpr float NO_ECHO = -1e30f;
+
+struct TiffLevel {
+  unsigned width = 0, height = 0;
+  unsigned tile_width = 0, tile_height = 0;
+  unsigned samples = 0;
+  std::vector<uint32_t> tile_offset, tile_length;
+  double scale = 0;
+  double origin_x = 0, origin_y = 0;
+
+  unsigned TilesAcross() const noexcept {
+    return (width + tile_width - 1) / tile_width;
+  }
+};
+
+class TiffReader {
+  std::span<const std::byte> file;
+  bool big_endian = false;
+
+public:
+  explicit TiffReader(std::span<const std::byte> _file):file(_file) {
+    if (file.size() < 8)
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)file.data();
+    if (p[0] == 'M' && p[1] == 'M')
+      big_endian = true;
+    else if (p[0] != 'I' || p[1] != 'I')
+      throw std::runtime_error("Not a TIFF radar image");
+  }
+
+  uint16_t U16(std::size_t o) const {
+    if (o + 2 > file.size())
+      throw std::runtime_error("Truncated radar image");
+    const auto *p = (const uint8_t *)file.data() + o;
+    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
+  }
+
+  uint32_t U32(std::size_t o) const {
+    if (o + 4 > file.size())
+      throw std::runtime_error("Truncated radar image");
+    const auto *p = (const uint8_t *)file.data() + o;
+    return big_endian
+      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | p[3])
+      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 | uint32_t(p[1]) << 8 | p[0]);
+  }
+
+  double F64(std::size_t o) const {
+    /* U32() already applies the file byte order within each half, so
+       all that is left is which half comes first */
+    const uint64_t first = U32(o), second = U32(o + 4);
+    return std::bit_cast<double>(big_endian
+                                 ? first << 32 | second
+                                 : second << 32 | first);
+  }
+
+  bool IsForeignByteOrder() const noexcept {
+    return big_endian != (std::endian::native == std::endian::big);
+  }
+
+  std::span<const std::byte> Slice(std::size_t o, std::size_t n) const {
+    if (o + n > file.size())
+      throw std::runtime_error("Truncated radar image");
+    return file.subspan(o, n);
+  }
+
+  std::size_t FirstDirectory() const { return U32(4); }
+
+  /**
+   * Read one image file directory.
+   *
+   * @return the offset of the next one, zero at the end
+   */
+  std::size_t ReadDirectory(std::size_t offset, TiffLevel &level) const;
+};
+
+constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
+constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+constexpr unsigned COMPRESSION_DEFLATE = 8;
+
+std::size_t
+TiffReader::ReadDirectory(std::size_t offset, TiffLevel &level) const
+{
+  const unsigned n = U16(offset);
+  unsigned compression = 0;
+
+  for (unsigned i = 0; i < n; ++i) {
+    const std::size_t e = offset + 2 + i * 12;
+    const unsigned tag = U16(e), type = U16(e + 2);
+    const uint32_t count = U32(e + 4);
+
+    /* the value is inline when it fits in four bytes */
+    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
+    const std::size_t at = std::size_t(size) * count <= 4 ? e + 8 : U32(e + 8);
+
+    const auto scalar = [&]() -> uint32_t {
+      return type == 3 ? U16(at) : U32(at);
+    };
+
+    switch (tag) {
+    case TAG_WIDTH: level.width = scalar(); break;
+    case TAG_HEIGHT: level.height = scalar(); break;
+    case TAG_COMPRESSION: compression = scalar(); break;
+    case TAG_SAMPLES: level.samples = scalar(); break;
+    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
+    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
+
+    case TAG_TILE_OFFSETS:
+    case TAG_TILE_LENGTHS: {
+      auto &out = tag == TAG_TILE_OFFSETS ? level.tile_offset : level.tile_length;
+      out.clear();
+      out.reserve(count);
+      for (uint32_t j = 0; j < count; ++j)
+        out.push_back(type == 3 ? U16(at + j * 2) : U32(at + j * 4));
+      break;
+    }
+
+    case TAG_PIXEL_SCALE:
+      if (count >= 2)
+        level.scale = F64(at);
+      break;
+
+    case TAG_TIEPOINT:
+      /* the first three doubles are the raster point, the next three
+         the projected point it maps to */
+      if (count >= 6) {
+        level.origin_x = F64(at + 3 * 8);
+        level.origin_y = F64(at + 4 * 8);
+      }
+      break;
+    }
+  }
+
+  if (level.width > 0) {
+    if (compression != COMPRESSION_DEFLATE)
+      throw std::runtime_error("Unsupported radar image compression");
+
+    if (level.samples == 0)
+      /* the tag is mandatory, but a missing one would make us read
+         zero bytes per pixel */
+      level.samples = 1;
+  }
+
+  return U32(offset + 2 + std::size_t(n) * 12);
+}
+
+/**
+ * Uncompress one tile and return its first band.
+ */
+void
+InflateTile(std::span<const std::byte> tile, const TiffLevel &level,
+            bool foreign_byte_order, float *out)
+{
+  const std::size_t pixels = std::size_t(level.tile_width) * level.tile_height;
+  AllocatedArray<float> raw{pixels * level.samples};
+
+  uLongf size = uLongf(raw.size() * sizeof(float));
+  if (::uncompress((Bytef *)raw.data(), &size,
+                   (const Bytef *)tile.data(), uLong(tile.size())) != Z_OK ||
+      size < pixels * level.samples * sizeof(float))
+    throw std::runtime_error("Damaged radar image");
+
+  for (std::size_t i = 0; i < pixels; ++i) {
+    const float value = raw[i * level.samples];
+    out[i] = foreign_byte_order
+      ? std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)))
+      : value;
+  }
+}
+
+} // anonymous namespace
+
+namespace {
+
+/**
+ * Pick the coarsest overview that still resolves the requested
+ * detail.  Asking for a finer one only costs bandwidth and memory.
+ */
+const TiffLevel &
+SelectLevel(const std::vector<TiffLevel> &levels,
+            double metres_per_pixel) noexcept
+{
+  const TiffLevel *best = &levels.front();
+
+  for (const auto &level : levels)
+    if (level.width > 0 && level.scale > 0 &&
+        level.scale <= metres_per_pixel)
+      /* the levels are ordered fine to coarse, so the last one that
+         is still fine enough is the cheapest usable one */
+      best = &level;
+
+  return *best;
+}
+
+/**
+ * The part of one level we need, decoded into a contiguous grid.
+ */
+class Patch {
+  unsigned x0 = 0, y0 = 0, width = 0, height = 0;
+  AllocatedArray<float> data;
+
+public:
+  Patch(const TiffReader &tiff, const TiffLevel &level,
+        unsigned col0, unsigned row0, unsigned col1, unsigned row1);
+
+  /**
+   * @return the reflectivity, or #NO_ECHO where there is none
+   */
+  float Get(unsigned col, unsigned row) const noexcept {
+    if (col < x0 || row < y0)
+      return NO_ECHO;
+
+    const unsigned x = col - x0, y = row - y0;
+    if (x >= width || y >= height)
+      return NO_ECHO;
+
+    return data[std::size_t(y) * width + x];
+  }
+};
+
+Patch::Patch(const TiffReader &tiff, const TiffLevel &level,
+             unsigned col0, unsigned row0, unsigned col1, unsigned row1)
+{
+  const unsigned across = level.TilesAcross();
+  const unsigned tx0 = col0 / level.tile_width, tx1 = col1 / level.tile_width;
+  const unsigned ty0 = row0 / level.tile_height, ty1 = row1 / level.tile_height;
+
+  x0 = tx0 * level.tile_width;
+  y0 = ty0 * level.tile_height;
+  width = (tx1 - tx0 + 1) * level.tile_width;
+  height = (ty1 - ty0 + 1) * level.tile_height;
+
+  data.ResizeDiscard(std::size_t(width) * height);
+  std::fill_n(data.data(), data.size(), NO_ECHO);
+
+  AllocatedArray<float> tile{std::size_t(level.tile_width) * level.tile_height};
+
+  for (unsigned ty = ty0; ty <= ty1; ++ty) {
+    for (unsigned tx = tx0; tx <= tx1; ++tx) {
+      const std::size_t i = std::size_t(ty) * across + tx;
+      if (i >= level.tile_offset.size() || i >= level.tile_length.size() ||
+          level.tile_length[i] == 0)
+        continue;
+
+      InflateTile(tiff.Slice(level.tile_offset[i], level.tile_length[i]),
+                  level, tiff.IsForeignByteOrder(), tile.data());
+
+      for (unsigned y = 0; y < level.tile_height; ++y) {
+        const unsigned dy = (ty - ty0) * level.tile_height + y;
+        if (dy >= height)
+          break;
+
+        const float *src = tile.data() + std::size_t(y) * level.tile_width;
+        float *dest = data.data() + std::size_t(dy) * width +
+          (tx - tx0) * level.tile_width;
+
+        for (unsigned x = 0; x < level.tile_width; ++x)
+          /* the composite marks "looked and saw nothing" with a NaN
+             and "no radar here" with a large negative number */
+          dest[x] = OPERA::IsNotANumber(src[x]) ? NO_ECHO : src[x];
+      }
+    }
+  }
+}
+
+/**
+ * Write an RGBA image as a PNG.  Throws on error.
+ */
+void
+WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
+{
+  /* one filter byte per row, filter type 0 ("none") */
+  AllocatedArray<uint8_t> raw{std::size_t(height) * (1 + std::size_t(width) * 4)};
+  for (unsigned y = 0; y < height; ++y) {
+    uint8_t *dest = raw.data() + std::size_t(y) * (1 + std::size_t(width) * 4);
+    *dest++ = 0;
+    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4, dest);
+  }
+
+  uLongf compressed_size = ::compressBound(uLong(raw.size()));
+  AllocatedArray<uint8_t> compressed{compressed_size};
+  if (::compress2(compressed.data(), &compressed_size,
+                  raw.data(), uLong(raw.size()), 6) != Z_OK)
+    throw std::runtime_error("Failed to compress the radar image");
+
+  FileOutputStream file{path, FileOutputStream::Mode::CREATE};
+
+  const auto WriteChunk = [&file](const char *type,
+                                  const uint8_t *payload, std::size_t size){
+    uint8_t header[8];
+    header[0] = uint8_t(size >> 24); header[1] = uint8_t(size >> 16);
+    header[2] = uint8_t(size >> 8); header[3] = uint8_t(size);
+    std::memcpy(header + 4, type, 4);
+    file.Write(std::as_bytes(std::span{header}));
+    if (size > 0)
+      file.Write(std::as_bytes(std::span{payload, size}));
+
+    uLong crc = ::crc32(0, header + 4, 4);
+    if (size > 0)
+      crc = ::crc32(crc, payload, uInt(size));
+
+    const uint8_t tail[4] = {
+      uint8_t(crc >> 24), uint8_t(crc >> 16), uint8_t(crc >> 8), uint8_t(crc),
+    };
+    file.Write(std::as_bytes(std::span{tail}));
+  };
+
+  static constexpr uint8_t signature[] = {
+    0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+  };
+  file.Write(std::as_bytes(std::span{signature}));
+
+  const uint8_t ihdr[13] = {
+    uint8_t(width >> 24), uint8_t(width >> 16), uint8_t(width >> 8), uint8_t(width),
+    uint8_t(height >> 24), uint8_t(height >> 16), uint8_t(height >> 8), uint8_t(height),
+    8, 6, 0, 0, 0,
+  };
+  WriteChunk("IHDR", ihdr, sizeof(ihdr));
+  WriteChunk("IDAT", compressed.data(), compressed_size);
+  WriteChunk("IEND", nullptr, 0);
+
+  file.Commit();
+}
+
+} // anonymous namespace
+
+namespace {
+
+/**
+ * Reproject the composite into a north-up latitude/longitude image
+ * and colour it.
+ */
+AllocatedArray<uint8_t>
+Render(const TiffReader &tiff, const std::vector<TiffLevel> &levels,
+       const GeoBounds &bounds, unsigned width, unsigned height)
+{
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+  const double west = bounds.GetWest().Degrees();
+  const double east = bounds.GetEast().Degrees();
+
+  /* the projection is curved, so probe a coarse grid rather than
+     just the corners to find the extent we need */
+  static constexpr unsigned PROBE = 8;
+  double min_x = 1e30, max_x = -1e30, min_y = 1e30, max_y = -1e30;
+  for (unsigned j = 0; j <= PROBE; ++j) {
+    for (unsigned i = 0; i <= PROBE; ++i) {
+      const auto p = OPERA::Project(GeoPoint{
+        Angle::Degrees(west + (east - west) * i / PROBE),
+        Angle::Degrees(south + (north - south) * j / PROBE),
+      });
+      min_x = std::min(min_x, p.x); max_x = std::max(max_x, p.x);
+      min_y = std::min(min_y, p.y); max_y = std::max(max_y, p.y);
+    }
+  }
+
+  const auto &level = SelectLevel(levels, (max_x - min_x) / width);
+  if (level.width == 0 || level.scale <= 0 ||
+      level.tile_width == 0 || level.tile_height == 0)
+    throw std::runtime_error("Unusable radar image");
+
+  const auto ToColumn = [&level](double x){
+    return (x - level.origin_x) / level.scale;
+  };
+  const auto ToRow = [&level](double y){
+    return (level.origin_y - y) / level.scale;
+  };
+
+  const double c0 = ToColumn(min_x), c1 = ToColumn(max_x);
+  const double r0 = ToRow(max_y), r1 = ToRow(min_y);
+  if (c1 < 0 || r1 < 0 || c0 >= level.width || r0 >= level.height)
+    /* the map is looking somewhere the composite does not cover */
+    throw std::runtime_error("Outside the radar composite");
+
+  const Patch patch{tiff, level,
+                    unsigned(std::max(0.0, c0)),
+                    unsigned(std::max(0.0, r0)),
+                    unsigned(std::min(double(level.width - 1), c1)),
+                    unsigned(std::min(double(level.height - 1), r1))};
+
+  AllocatedArray<uint8_t> image{std::size_t(width) * height * 4};
+  std::fill_n(image.data(), image.size(), uint8_t(0));
+
+  for (unsigned y = 0; y < height; ++y) {
+    const double latitude = north - (north - south) * (y + 0.5) / height;
+
+    for (unsigned x = 0; x < width; ++x) {
+      const double longitude = west + (east - west) * (x + 0.5) / width;
+
+      const auto p = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
+                                             Angle::Degrees(latitude)});
+      const double column = ToColumn(p.x), row = ToRow(p.y);
+      if (column < 0 || row < 0 ||
+          column >= level.width || row >= level.height)
+        continue;
+
+      /* take the strongest of the source pixels this one covers; the
+         composite is a maximum product, and picking just one would
+         drop isolated echoes when zoomed out */
+      float dbz = NO_ECHO;
+      for (unsigned dy = 0; dy < 2; ++dy)
+        for (unsigned dx = 0; dx < 2; ++dx)
+          dbz = std::max(dbz, patch.Get(unsigned(column) + dx,
+                                        unsigned(row) + dy));
+
+      const int cls = OPERA::ClassifyReflectivity(dbz);
+      if (cls < 0)
+        continue;
+
+      const uint32_t colour = OPERA::GetClassColour(unsigned(cls));
+      uint8_t *dest = image.data() + (std::size_t(y) * width + x) * 4;
+      dest[0] = uint8_t(colour >> 16);
+      dest[1] = uint8_t(colour >> 8);
+      dest[2] = uint8_t(colour);
+      dest[3] = 0xff;
+    }
+  }
+
+  return image;
+}
+
+} // anonymous namespace
+
+Co::Task<AllocatedPath>
+OPERA::DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
+                     CurlGlobal &curl, ProgressListener &progress)
+{
+  if (!bounds.IsValid())
+    throw std::runtime_error("No map area to cover");
+
+  width = std::clamp(width, 1u, MAX_IMAGE_SIZE);
+  height = std::clamp(height, 1u, MAX_IMAGE_SIZE);
+
+  const auto url = MakeCompositeURL(BrokenDateTime::NowUTC());
+  if (url.empty())
+    throw std::runtime_error("The clock is not set");
+
+  const auto cache = MakeCacheDirectory("opera");
+  const auto source = AllocatedPath::Build(cache, "composite.tiff");
+  auto rendered = AllocatedPath::Build(cache, "composite.png");
+
+  {
+    const auto ignored_response = co_await
+      Net::CoDownloadToFile(curl, url.c_str(), nullptr, nullptr,
+                            source, nullptr, progress);
+  }
+
+  const FileMapping mapping{source};
+  const TiffReader tiff{mapping};
+
+  std::vector<TiffLevel> levels;
+  /* count every directory, not just the usable ones: a damaged file
+     can chain empty directories, or point one at itself */
+  for (std::size_t offset = tiff.FirstDirectory(), n = 0;
+       offset != 0 && n < 32; ++n) {
+    TiffLevel level;
+    offset = tiff.ReadDirectory(offset, level);
+    if (level.width > 0)
+      levels.push_back(std::move(level));
+  }
+
+  if (levels.empty())
+    throw std::runtime_error("Empty radar image");
+
+  /* only the full resolution image carries the projection keys; the
+     overviews cover the same area with fewer pixels, so their scale
+     follows from the size ratio */
+  for (auto &level : levels) {
+    if (level.scale > 0 || level.width == 0 || levels.front().width == 0)
+      continue;
+
+    level.scale = levels.front().scale *
+      double(levels.front().width) / level.width;
+    level.origin_x = levels.front().origin_x;
+    level.origin_y = levels.front().origin_y;
+  }
+
+  if (levels.front().scale <= 0)
+    throw std::runtime_error("Radar image without a georeference");
+
+  const auto image = Render(tiff, levels, bounds, width, height);
+  WritePNG(rendered, width, height, image.data());
+
+  co_return std::move(rendered);
+}

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -33,8 +33,28 @@ static constexpr unsigned CADENCE_MINUTES = 5;
 /**
  * How far behind the wall clock to look for the newest composite.  A
  * frame is not on the server the instant it is nominally acquired.
+ *
+ * Measured over a full day of the DBZH series: the delay between the
+ * time a frame depicts and the time it appears in the bucket was 4.2
+ * min at the median, 4.7 min at the 99th percentile and 6.3 min at
+ * its worst.  This constant is itself the margin: when the wall clock
+ * lands on a slot boundary the frame we ask for is only
+ * #LATENCY_MINUTES old, so anything below the worst observed delay
+ * would sometimes request a frame that is not there yet.
  */
-static constexpr unsigned LATENCY_MINUTES = 10;
+static constexpr unsigned LATENCY_MINUTES = 7;
+
+/**
+ * How old the frame on the map may get, counted from the time it
+ * depicts, before it is taken down.
+ *
+ * A frame is already #LATENCY_MINUTES to #LATENCY_MINUTES +
+ * #CADENCE_MINUTES old when it arrives, so this has to stay clear of
+ * that.  Twenty minutes leaves room for one failed refresh before the
+ * picture disappears, and puts a hard bound on how stale an echo the
+ * pilot can be looking at.
+ */
+static constexpr unsigned MAX_AGE_MINUTES = 20;
 
 /**
  * The largest image we render.  The composite is a 1km grid; more
@@ -52,6 +72,18 @@ static constexpr unsigned MAX_IMAGE_SIZE = 1024;
  */
 [[gnu::pure]]
 std::string MakeCompositeURL(const BrokenDateTime &utc);
+
+/**
+ * The time the composite that #MakeCompositeURL() points at nominally
+ * depicts.  The caller needs it to tell how old the picture on the
+ * map has become.
+ *
+ * @return an invalid time if @p utc is not plausible
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+BrokenDateTime CompositeTime(const BrokenDateTime &utc);
 
 /**
  * Project a geographic location onto the composite's grid, which is

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+#include "Math/Point2D.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+
+struct BrokenDateTime;
+struct GeoPoint;
+class GeoBounds;
+class CurlGlobal;
+class ProgressListener;
+namespace Co { template<typename T> class Task; }
+
+/**
+ * The EUMETNET OPERA radar composite, a pan-European reflectivity
+ * mosaic published every five minutes under CC BY 4.0.
+ *
+ * @see https://eumetnet.github.io/openradardata-documentation/
+ */
+namespace OPERA {
+
+/** New composites appear on this grid, in minutes past the hour. */
+static constexpr unsigned CADENCE_MINUTES = 5;
+
+/**
+ * How far behind the wall clock to look for the newest composite.  A
+ * frame is not on the server the instant it is nominally acquired.
+ */
+static constexpr unsigned LATENCY_MINUTES = 10;
+
+/**
+ * The largest image we render.  The composite is a 1km grid; more
+ * pixels than this only upsamples.
+ */
+static constexpr unsigned MAX_IMAGE_SIZE = 1024;
+
+/**
+ * Build the URL of the composite covering the given UTC time.  The
+ * time is rounded down to #CADENCE_MINUTES.
+ *
+ * @return an empty string if the time is not plausible
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::string MakeCompositeURL(const BrokenDateTime &utc);
+
+/**
+ * Project a geographic location onto the composite's grid, which is
+ * Lambert azimuthal equal-area centred on 55N 10E.  The result is in
+ * metres in the projection plane, x east and y north.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+DoublePoint2D Project(const GeoPoint &p) noexcept;
+
+/**
+ * Map a reflectivity to one of the colour classes.  A value that is
+ * not a number means the radar looked and saw nothing.
+ *
+ * The class boundaries were measured against the German weather
+ * service's own European product rather than derived from a Z-R
+ * relation: the offset between this composite, which is a maximum
+ * over all elevations, and a near-ground product is not constant but
+ * shrinks as the echo grows stronger, so no single exponent fits.
+ *
+ * Exposed for the unit test.
+ *
+ * @return the class index, or -1 for "no precipitation"
+ */
+[[gnu::const]]
+int ClassifyReflectivity(double dbz) noexcept;
+
+/**
+ * Is this "not a number"?
+ *
+ * The composite marks "the radar looked and saw nothing" that way,
+ * and we are built with -ffast-math, under which the compiler may
+ * assume no such value ever occurs; so this looks at the bits rather
+ * than comparing.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::const]]
+bool IsNotANumber(double value) noexcept;
+
+/** The number of colour classes #ClassifyReflectivity() may return. */
+static constexpr unsigned N_CLASSES = 15;
+
+/**
+ * The colour of one class, as 0xRRGGBB.  These are the classes the
+ * Deutscher Wetterdienst uses for its radar images, so the result
+ * looks like what German pilots are used to reading.
+ */
+[[gnu::const]]
+uint32_t GetClassColour(unsigned i) noexcept;
+
+/**
+ * Download the newest composite and render the part covering
+ * @p bounds as a PNG.
+ *
+ * Throws on error.
+ *
+ * @return the path of the rendered image
+ */
+Co::Task<AllocatedPath>
+DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
+              CurlGlobal &curl, ProgressListener &progress);
+
+} // namespace OPERA

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -3,14 +3,15 @@
 
 #pragma once
 
-#include "system/Path.hpp"
+#include "ui/canvas/custom/GeoBitmap.hpp"
 #include "Math/Point2D.hpp"
+#include "system/Path.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <span>
 #include <string>
+#include <vector>
 
 struct BrokenDateTime;
 struct GeoPoint;
@@ -22,6 +23,13 @@ namespace Co { template<typename T> class Task; }
 /**
  * The EUMETNET OPERA radar composite, a pan-European reflectivity
  * mosaic published every five minutes under CC BY 4.0.
+ *
+ * The composite is one cloud-optimized GeoTIFF of about five
+ * megabytes covering the whole continent.  Pulling all of it down to
+ * draw the weather around one glider would be absurd over a flight
+ * connection, so this module reads it the way it was meant to be
+ * read: a small range request for the directory, then a range request
+ * per tile, nearest to the aircraft first.
  *
  * @see https://eumetnet.github.io/openradardata-documentation/
  */
@@ -55,12 +63,6 @@ static constexpr unsigned LATENCY_MINUTES = 7;
  * pilot can be looking at.
  */
 static constexpr unsigned MAX_AGE_MINUTES = 20;
-
-/**
- * The largest image we render.  The composite is a 1km grid; more
- * pixels than this only upsamples.
- */
-static constexpr unsigned MAX_IMAGE_SIZE = 1024;
 
 /**
  * Build the URL of the composite covering the given UTC time.  The
@@ -136,16 +138,363 @@ static constexpr unsigned N_CLASSES = 15;
 [[gnu::const]]
 uint32_t GetClassColour(unsigned i) noexcept;
 
+/* ------------------------------------------------------------------
+ * the display grid
+ * ------------------------------------------------------------------ */
+
 /**
- * Download the newest composite and render the part covering
- * @p bounds as a PNG.
+ * The zoom levels the overlay grid may use.
+ *
+ * The lower bound keeps one tile from spanning so much of the globe
+ * that the flat quadrilateral the map draws it with stops matching
+ * the ground; the upper bound is where a tile is finer than the one
+ * kilometre the radar actually resolves and further zoom would only
+ * magnify the same pixels.
+ */
+static constexpr uint16_t MIN_TILE_ZOOM = 4;
+static constexpr uint16_t MAX_TILE_ZOOM = 10;
+
+/**
+ * How many tiles to either side of the aircraft's own tile, so the
+ * block is (2 * #TILE_RANGE + 1) squared.
+ */
+static constexpr unsigned TILE_RANGE = 2;
+
+/** The number of tiles in the block. */
+static constexpr unsigned TILE_COUNT =
+  (2 * TILE_RANGE + 1) * (2 * TILE_RANGE + 1);
+
+/**
+ * The edge length rendered per tile, in pixels.
+ *
+ * The grid zoom is chosen so that a tile is about a third of the
+ * screen diagonal, which at typical soaring scales puts this at two
+ * to five hundred metres per pixel -- oversampling the composite's
+ * kilometre grid, so that the overlay does not draw blocky under a
+ * map the pilot zooms.  Where the map is wider than the pyramid's
+ * finest level is worth reading, #SelectLevel() drops to a coarser
+ * one and the cost falls with it.
+ */
+static constexpr unsigned TILE_PIXELS = 256;
+
+/**
+ * How much finer than the map's own scale the tile grid is chosen.
+ *
+ * GeoBitmap::GetTile() sizes a tile to the screen diagonal; one step
+ * finer makes the block of #TILE_COUNT cover the screen with a margin
+ * to pan into, rather than five screens of imagery the pilot will
+ * never look at.
+ */
+static constexpr unsigned TILE_ZOOM_STEP = 1;
+
+/**
+ * The tile the aircraft is in.
+ *
+ * @return an invalid tile if @p location is not valid
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+GeoBitmap::TileData GetAircraftTile(const GeoPoint &location,
+                                    uint16_t zoom) noexcept;
+
+/**
+ * The tiles to fetch around @p base, nearest first, so that on a slow
+ * or intermittent link the ground under the aircraft is drawn before
+ * anything else and the picture then fills outwards.
+ *
+ * Tiles that fall off the top or bottom of the world are dropped, so
+ * the result can be shorter than #TILE_COUNT.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::vector<GeoBitmap::TileData>
+CollectTiles(const GeoBitmap::TileData &base) noexcept;
+
+/** Are these the same tile? */
+[[gnu::const]]
+constexpr bool
+IsSameTile(const GeoBitmap::TileData &a,
+           const GeoBitmap::TileData &b) noexcept
+{
+  return a.zoom == b.zoom && a.x == b.x && a.y == b.y;
+}
+
+/* ------------------------------------------------------------------
+ * the composite's own tiling
+ * ------------------------------------------------------------------ */
+
+/** One level of the composite's overview pyramid. */
+struct CompositeLevel {
+  unsigned width = 0, height = 0;
+  unsigned tile_width = 0, tile_height = 0;
+  unsigned samples = 0;
+
+  /** metres per pixel */
+  double scale = 0;
+
+  /** the projected coordinate of the grid's top left corner */
+  double origin_x = 0, origin_y = 0;
+
+  std::vector<uint_least32_t> tile_offset, tile_length;
+
+  [[gnu::pure]]
+  unsigned TilesAcross() const noexcept {
+    return tile_width > 0 ? (width + tile_width - 1) / tile_width : 0;
+  }
+
+  [[gnu::pure]]
+  unsigned TilesDown() const noexcept {
+    return tile_height > 0 ? (height + tile_height - 1) / tile_height : 0;
+  }
+
+  [[gnu::pure]]
+  bool IsUsable() const noexcept {
+    return width > 0 && height > 0 && tile_width > 0 && tile_height > 0 &&
+      scale > 0 && !tile_offset.empty() &&
+      tile_offset.size() == tile_length.size();
+  }
+};
+
+/**
+ * The composite's directory: what the file contains and where each
+ * tile of it lies, without any of the pixels.
+ */
+struct CompositeIndex {
+  /** ordered fine to coarse, as the file stores them */
+  std::vector<CompositeLevel> levels;
+
+  /** does the file's byte order differ from this machine's? */
+  bool foreign_byte_order = false;
+
+  [[gnu::pure]]
+  bool IsValid() const noexcept {
+    return !levels.empty() && levels.front().IsUsable();
+  }
+};
+
+/**
+ * How much of the file to fetch to be sure of holding the whole
+ * directory.
+ *
+ * Measured against the live service: the header, all five image file
+ * directories and every tile offset and length table end within the
+ * first 5 691 bytes.  Sixteen kilobytes is room for the file to grow
+ * without another round trip, and is still a thousandth of it.
+ */
+static constexpr std::size_t INDEX_BYTES = 16384;
+
+/**
+ * Parse the composite's directory out of the head of the file.
+ *
+ * Throws if @p header is not the start of a composite, or if the
+ * directory reaches past what was fetched.
+ *
+ * Exposed for the unit test.
+ */
+CompositeIndex ParseIndex(std::span<const std::byte> header);
+
+/**
+ * Projects a north-up latitude/longitude raster onto the composite's
+ * grid, a row at a time.
+ *
+ * A row shares one latitude and every row shares the same longitudes,
+ * so the trigonometry belongs outside the inner loop.  That matters
+ * on the processors XCSoar runs on: once the download has shrunk to a
+ * few tiles, the reprojection is the only expensive step left.
+ *
+ * Exposed for the unit test.
+ */
+class RasterProjector {
+  std::vector<DoublePoint2D> delta;
+
+public:
+  /**
+   * @param west the longitude of the left edge, in degrees
+   * @param east the longitude of the right edge, in degrees
+   * @param width how many pixels lie between them
+   */
+  RasterProjector(double west, double east, unsigned width);
+
+  [[gnu::pure]]
+  unsigned GetWidth() const noexcept { return delta.size(); }
+
+  /**
+   * Project one row of pixel centres.
+   *
+   * @param latitude the row's latitude, in degrees
+   * @param out receives #GetWidth() points, x east and y north in
+   * metres in the projection plane
+   */
+  void ProjectRow(double latitude, DoublePoint2D *out) const noexcept;
+};
+
+/**
+ * The ground resolution an area would be drawn at, in metres per
+ * pixel, measured in the composite's own projection.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+double TileMetresPerPixel(const GeoBounds &bounds, unsigned pixels) noexcept;
+
+/**
+ * How much coarser than the requested resolution a level may be and
+ * still be chosen.
+ *
+ * #TILE_PIXELS oversamples the composite by design, and the composite
+ * is a maximum product, so halving the sampling loses no echo -- only
+ * a little of the shape of its edge.  It does, though, quarter what
+ * has to travel: one step up the pyramid is four times fewer pixels.
+ * Measured over a live frame, insisting on the finer level cost 12.5%
+ * of the whole file at the scale a 200 km tile is drawn at, against
+ * 3% for the coarser one.
+ */
+static constexpr double LEVEL_TOLERANCE = 2;
+
+/**
+ * The coarsest level that still resolves @p metres_per_pixel to
+ * within #LEVEL_TOLERANCE, which is the cheapest one worth fetching
+ * for that scale.
+ *
+ * Exposed for the unit test.
+ *
+ * @return an index into CompositeIndex::levels
+ */
+[[gnu::pure]]
+unsigned SelectLevel(const CompositeIndex &index,
+                     double metres_per_pixel) noexcept;
+
+/**
+ * The tiles of @p level that cover @p bounds, in the file's own tile
+ * numbering.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::vector<unsigned>
+CoveringSourceTiles(const CompositeLevel &level,
+                    const GeoBounds &bounds) noexcept;
+
+/* ------------------------------------------------------------------
+ * fetching and drawing
+ * ------------------------------------------------------------------ */
+
+/**
+ * One composite frame: its directory, and the tiles of it fetched so
+ * far.
+ *
+ * Held across display tiles and across map movements so that a frame
+ * is read from the network once.  Lives on the network thread.
+ */
+class RadarComposite {
+  /**
+   * One decoded tile of the composite, kept as colour classes rather
+   * than reflectivities.
+   *
+   * A class is one byte where a reflectivity is four, and the
+   * classification is monotonic, so taking the strongest class over
+   * an area gives the same answer as classifying the strongest
+   * reflectivity.  On the machines XCSoar runs on that is worth
+   * having: a tile of the full resolution level is 256 kB this way
+   * rather than a megabyte.
+   */
+  struct SourceTile {
+    unsigned level, index;
+
+    /** the colour class per pixel, or -1 where there is no echo */
+    std::vector<int8_t> data;
+  };
+
+  /**
+   * How many decoded tiles to keep.
+   *
+   * This has to hold a whole block, or tiles would be evicted while
+   * the block that needs them is still filling and would travel a
+   * second time.  Measured against a live frame, a block needs two
+   * source tiles at the scales one flies at, eight at the widest
+   * zoom, and fifteen at the worst point in between -- where the
+   * block is wide enough to span many of them but still fine enough
+   * to want the second level of the pyramid.
+   *
+   * Every level tiles at 512 by 512, so a tile is 256 kB as a class
+   * per pixel whichever level it came from, and this bounds the cache
+   * at four megabytes.
+   */
+  static constexpr std::size_t MAX_CACHED_TILES = 16;
+
+  std::string url;
+  CompositeIndex index;
+  std::vector<SourceTile> tiles;
+
+public:
+  /** The composite this holds, empty before #Open(). */
+  [[gnu::pure]]
+  const std::string &GetURL() const noexcept { return url; }
+
+  [[gnu::pure]]
+  bool IsOpen() const noexcept { return index.IsValid(); }
+
+  [[gnu::pure]]
+  const CompositeIndex &GetIndex() const noexcept { return index; }
+
+  /** Forget everything, because the frame has moved on. */
+  void Reset() noexcept {
+    url.clear();
+    index = {};
+    tiles.clear();
+  }
+
+  [[gnu::pure]]
+  bool HasTile(unsigned level, unsigned tile) const noexcept;
+
+  /**
+   * Read the directory of @p url, unless it is already open.
+   *
+   * Throws on error.
+   */
+  Co::Task<void> Open(std::string _url, CurlGlobal &curl);
+
+  /**
+   * Fetch one tile of one level, unless it is already held.
+   *
+   * Throws on error.
+   */
+  Co::Task<void> FetchTile(unsigned level, unsigned tile, CurlGlobal &curl);
+
+  /**
+   * Draw the part of the composite covering @p bounds into a PNG at
+   * @p path, north up.
+   *
+   * Tiles that were never fetched come out transparent, so a picture
+   * that is still filling in shows what has arrived rather than
+   * nothing.
+   *
+   * Throws on error.
+   *
+   * @return whether anything was drawn; where the sky is clear there
+   * is no point spending a map overlay slot on the result
+   */
+  bool Render(unsigned level, const GeoBounds &bounds,
+              unsigned width, unsigned height, Path path) const;
+};
+
+/**
+ * Download the newest composite and draw the part covering @p bounds
+ * as a single image.
+ *
+ * This is the Weather dialog's path, which shows one picture of the
+ * area the map happens to be looking at inside a modal download.  The
+ * page overlay does not use it: it fills the map tile by tile instead,
+ * reusing one #RadarComposite across them.
  *
  * Throws on error.
  *
  * @return the path of the rendered image
  */
 Co::Task<AllocatedPath>
-DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
-              CurlGlobal &curl, ProgressListener &progress);
+DownloadArea(const GeoBounds &bounds, unsigned width, unsigned height,
+             CurlGlobal &curl, ProgressListener &progress);
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -63,21 +63,31 @@ constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
 
 } // anonymous namespace
 
-std::string
-OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+BrokenDateTime
+OPERA::CompositeTime(const BrokenDateTime &utc)
 {
   if (!utc.IsPlausible())
     /* without a clock we cannot tell which composite is the current
        one, and guessing would show yesterday's weather */
-    return {};
+    return BrokenDateTime::Invalid();
 
-  const auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
-  const unsigned minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+  auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
+  t.minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+  t.second = 0;
+  return t;
+}
+
+std::string
+OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+{
+  const auto t = CompositeTime(utc);
+  if (!t.IsPlausible())
+    return {};
 
   return fmt::format("{}/{:04}/{:02}/{:02}/OPERA/COMP/"
                      "OPERA@{:04}{:02}{:02}T{:02}{:02}@0@DBZH.tiff",
                      BUCKET_URL, t.year, t.month, t.day,
-                     t.year, t.month, t.day, t.hour, minute);
+                     t.year, t.month, t.day, t.hour, t.minute);
 }
 
 DoublePoint2D

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "Math/Constants.hpp"
@@ -10,9 +11,11 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
 #include <cstring>
 #include <functional>
+#include <stdexcept>
 
 namespace {
 
@@ -27,13 +30,6 @@ constexpr double CENTRE_LONGITUDE = 10;
 constexpr double FALSE_EASTING = 1950000;
 constexpr double FALSE_NORTHING = -2100000;
 
-/**
- * The lower reflectivity bound of each colour class.
- *
- * The last entry is the "everything above" class; a value below the
- * first one is not drawn at all, which is what the reference product
- * does with the weakest echoes.
- */
 /**
  * The lower dBZ bound of each colour class, obtained by matching the
  * quantiles of the composite against a DWD European radar image.
@@ -61,7 +57,291 @@ constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
   0xfe0000, 0xe5004c, 0xcc0098, 0x6600cb, 0x0000fe,
 };
 
+/* ------------------------------------------------------------------
+ * a very small TIFF directory reader
+ *
+ * Only what the composite is: a tiled, Deflate compressed, two band
+ * float image with a pyramid of overviews.  It reads the head of the
+ * file alone, so every offset has to be checked against how much of
+ * the file we actually hold.
+ * ------------------------------------------------------------------ */
+
+constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
+constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+constexpr unsigned COMPRESSION_DEFLATE = 8;
+
+/** how many image file directories to walk before giving up */
+constexpr unsigned MAX_DIRECTORIES = 32;
+
+/**
+ * The most tiles a level may claim.  The composite's finest level has
+ * 72; this is room for one a hundred times its size, and a bound on
+ * what a corrupt count can make us reserve.
+ */
+constexpr uint32_t MAX_TILES = 65536;
+
+class HeaderReader {
+  std::span<const std::byte> header;
+  bool big_endian = false;
+
+public:
+  explicit HeaderReader(std::span<const std::byte> _header)
+    :header(_header)
+  {
+    if (header.size() < 8)
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data();
+    if (p[0] == 'M' && p[1] == 'M')
+      big_endian = true;
+    else if (p[0] != 'I' || p[1] != 'I')
+      throw std::runtime_error("Not a TIFF radar image");
+
+    /* 42 is a classic TIFF; a BigTIFF would be 43 and would need
+       eight byte offsets, which this reader does not do */
+    if (U16(2) != 42)
+      throw std::runtime_error("Unsupported radar image format");
+  }
+
+  bool IsForeignByteOrder() const noexcept {
+    return big_endian != (std::endian::native == std::endian::big);
+  }
+
+  /**
+   * Is there room for @p length bytes at @p offset?
+   *
+   * Written as a subtraction rather than as `offset + length > size()`
+   * because the offsets come out of the file: on a 32 bit target a
+   * corrupt one near the top of the range would make that sum wrap
+   * and the check pass.
+   */
+  bool Holds(std::size_t offset, std::size_t length) const noexcept {
+    return length <= header.size() && offset <= header.size() - length;
+  }
+
+  uint16_t U16(std::size_t o) const {
+    if (!Holds(o, 2))
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data() + o;
+    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
+  }
+
+  uint32_t U32(std::size_t o) const {
+    if (!Holds(o, 4))
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data() + o;
+    return big_endian
+      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 |
+         uint32_t(p[2]) << 8 | p[3])
+      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 |
+         uint32_t(p[1]) << 8 | p[0]);
+  }
+
+  double F64(std::size_t o) const {
+    /* U32() already applies the file byte order within each half, so
+       all that is left is which half comes first */
+    const uint64_t first = U32(o), second = U32(o + 4);
+    return std::bit_cast<double>(big_endian
+                                 ? first << 32 | second
+                                 : second << 32 | first);
+  }
+
+  std::size_t FirstDirectory() const { return U32(4); }
+
+  /**
+   * @return the offset of the next directory, zero at the end
+   */
+  std::size_t ReadDirectory(std::size_t offset,
+                            OPERA::CompositeLevel &level) const;
+};
+
+std::size_t
+HeaderReader::ReadDirectory(std::size_t offset,
+                            OPERA::CompositeLevel &level) const
+{
+  const unsigned n = U16(offset);
+
+  /* validate the whole directory up front, so that the entry reads
+     below cannot form an offset that wraps before it is checked */
+  if (!Holds(offset, 2 + std::size_t(n) * 12 + 4))
+    throw std::runtime_error("Truncated radar image");
+
+  unsigned compression = 0;
+
+  for (unsigned i = 0; i < n; ++i) {
+    const std::size_t e = offset + 2 + std::size_t(i) * 12;
+    const unsigned tag = U16(e), type = U16(e + 2);
+    const uint32_t count = U32(e + 4);
+
+    /* the value is inline when it fits in the four bytes of the entry */
+    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
+    const std::size_t at = size * std::size_t(count) <= 4
+      ? e + 8
+      : U32(e + 8);
+
+    const auto scalar = [this, type, at]() -> uint32_t {
+      return type == 3 ? U16(at) : U32(at);
+    };
+
+    switch (tag) {
+    case TAG_WIDTH: level.width = scalar(); break;
+    case TAG_HEIGHT: level.height = scalar(); break;
+    case TAG_COMPRESSION: compression = scalar(); break;
+    case TAG_SAMPLES: level.samples = scalar(); break;
+    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
+    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
+
+    case TAG_TILE_OFFSETS:
+    case TAG_TILE_LENGTHS: {
+      /* the count comes out of the file; a corrupt one must not turn
+         into a four gigabyte reservation */
+      if (count > MAX_TILES)
+        throw std::runtime_error("Unusable radar image");
+
+      const std::size_t stride = type == 3 ? 2 : 4;
+      if (!Holds(at, std::size_t(count) * stride))
+        throw std::runtime_error("Truncated radar image");
+
+      auto &out = tag == TAG_TILE_OFFSETS
+        ? level.tile_offset
+        : level.tile_length;
+      out.clear();
+      out.reserve(count);
+      for (uint32_t j = 0; j < count; ++j)
+        out.push_back(stride == 2
+                      ? U16(at + std::size_t(j) * 2)
+                      : U32(at + std::size_t(j) * 4));
+      break;
+    }
+
+    case TAG_PIXEL_SCALE:
+      if (count >= 2)
+        level.scale = F64(at);
+      break;
+
+    case TAG_TIEPOINT:
+      /* the first three doubles are the raster point, the next three
+         the projected point it maps to */
+      if (count >= 6) {
+        level.origin_x = F64(at + 3 * 8);
+        level.origin_y = F64(at + 4 * 8);
+      }
+      break;
+    }
+  }
+
+  if (level.width > 0) {
+    if (compression != COMPRESSION_DEFLATE)
+      throw std::runtime_error("Unsupported radar image compression");
+
+    if (level.samples == 0)
+      /* the tag is mandatory, but a missing one would make us read
+         zero bytes per pixel */
+      level.samples = 1;
+  }
+
+  return U32(offset + 2 + std::size_t(n) * 12);
+}
+
+/** the extent an area occupies in the composite's projection */
+struct ProjectedExtent {
+  double min_x, max_x, min_y, max_y;
+};
+
+[[gnu::pure]]
+ProjectedExtent
+GetProjectedExtent(const GeoBounds &bounds) noexcept
+{
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+  const double west = bounds.GetWest().Degrees();
+  const double east = bounds.GetEast().Degrees();
+
+  /* the projection is curved, so probe a coarse grid rather than just
+     the corners to find the extent the area really needs */
+  static constexpr unsigned PROBE = 4;
+  ProjectedExtent extent{1e30, -1e30, 1e30, -1e30};
+
+  for (unsigned j = 0; j <= PROBE; ++j)
+    for (unsigned i = 0; i <= PROBE; ++i) {
+      const auto p = OPERA::Project(GeoPoint{
+        Angle::Degrees(west + (east - west) * i / PROBE),
+        Angle::Degrees(south + (north - south) * j / PROBE),
+      });
+      extent.min_x = std::min(extent.min_x, p.x);
+      extent.max_x = std::max(extent.max_x, p.x);
+      extent.min_y = std::min(extent.min_y, p.y);
+      extent.max_y = std::max(extent.max_y, p.y);
+    }
+
+  return extent;
+}
+
 } // anonymous namespace
+
+OPERA::RasterProjector::RasterProjector(double west, double east,
+                                        unsigned width)
+{
+  delta.resize(width);
+
+  const double lon0 = CENTRE_LONGITUDE * M_PI / 180;
+  for (unsigned x = 0; x < width; ++x) {
+    const double longitude = west + (east - west) * (x + 0.5) / width;
+    const double d = longitude * M_PI / 180 - lon0;
+    delta[x] = {std::sin(d), std::cos(d)};
+  }
+}
+
+void
+OPERA::RasterProjector::ProjectRow(double latitude,
+                                   DoublePoint2D *out) const noexcept
+{
+  const double lat = latitude * M_PI / 180;
+  const double lat0 = CENTRE_LATITUDE * M_PI / 180;
+  const double sin_lat = std::sin(lat), cos_lat = std::cos(lat);
+  const double sin_lat0 = std::sin(lat0), cos_lat0 = std::cos(lat0);
+
+  const double a = sin_lat0 * sin_lat;
+  const double b = cos_lat0 * cos_lat;
+  const double c = cos_lat0 * sin_lat;
+  const double d = sin_lat0 * cos_lat;
+
+  for (std::size_t x = 0; x < delta.size(); ++x) {
+    const double sin_delta = delta[x].x, cos_delta = delta[x].y;
+
+    const double denominator = 1 + a + b * cos_delta;
+    if (denominator <= 0) {
+      /* the antipode of the projection centre has no image */
+      out[x] = {0, 0};
+      continue;
+    }
+
+    const double k = EARTH_RADIUS * std::sqrt(2 / denominator);
+    out[x] = {
+      FALSE_EASTING + k * cos_lat * sin_delta,
+      FALSE_NORTHING + k * (c - d * cos_delta),
+    };
+  }
+}
+
+double
+OPERA::TileMetresPerPixel(const GeoBounds &bounds, unsigned pixels) noexcept
+{
+  if (!bounds.IsValid() || pixels == 0)
+    return 0;
+
+  const auto extent = GetProjectedExtent(bounds);
+
+  /* the wider of the two axes, so that neither ends up undersampled
+     by a level chosen for the other */
+  return std::max(extent.max_x - extent.min_x,
+                  extent.max_y - extent.min_y) / pixels;
+}
 
 BrokenDateTime
 OPERA::CompositeTime(const BrokenDateTime &utc)
@@ -140,4 +420,165 @@ uint32_t
 OPERA::GetClassColour(unsigned i) noexcept
 {
   return CLASS_COLOUR[i < N_CLASSES ? i : N_CLASSES - 1];
+}
+
+GeoBitmap::TileData
+OPERA::GetAircraftTile(const GeoPoint &location, uint16_t zoom) noexcept
+{
+  if (!location.IsValid() || zoom < MIN_TILE_ZOOM || zoom > MAX_TILE_ZOOM)
+    return {};
+
+  return GeoBitmap::GetTile(GeoBounds{location}, zoom);
+}
+
+std::vector<GeoBitmap::TileData>
+OPERA::CollectTiles(const GeoBitmap::TileData &base) noexcept
+{
+  std::vector<GeoBitmap::TileData> result;
+  if (!base.IsValid())
+    return result;
+
+  const int tiles_per_axis = 1 << base.zoom;
+
+  /* longitude wraps, so a flight over the date line keeps a complete
+     block instead of losing half of it */
+  const auto normalise_x = [tiles_per_axis](int value) {
+    int wrapped = value % tiles_per_axis;
+    if (wrapped < 0)
+      wrapped += tiles_per_axis;
+
+    return uint32_t(wrapped);
+  };
+
+  struct Candidate {
+    GeoBitmap::TileData tile;
+    unsigned priority;
+  };
+
+  std::vector<Candidate> candidates;
+  candidates.reserve(TILE_COUNT);
+
+  const int range = int(TILE_RANGE);
+  for (int dx = -range; dx <= range; ++dx) {
+    for (int dy = -range; dy <= range; ++dy) {
+      const int y = int(base.y) + dy;
+      if (y < 0 || y >= tiles_per_axis)
+        /* latitude does not wrap: off the top or bottom of the world
+           there is no tile to ask for */
+        continue;
+
+      candidates.push_back({
+        {base.zoom, normalise_x(int(base.x) + dx), uint32_t(y)},
+        unsigned(dx * dx + dy * dy),
+      });
+    }
+  }
+
+  /* squared distance from the aircraft's own tile, so the block is
+     walked as rings growing outwards from underneath the glider */
+  std::stable_sort(candidates.begin(), candidates.end(),
+                   [](const auto &a, const auto &b) {
+                     return a.priority < b.priority;
+                   });
+
+  result.reserve(candidates.size());
+  for (const auto &candidate : candidates)
+    result.push_back(candidate.tile);
+
+  return result;
+}
+
+OPERA::CompositeIndex
+OPERA::ParseIndex(std::span<const std::byte> header)
+{
+  const HeaderReader reader{header};
+
+  CompositeIndex index;
+  index.foreign_byte_order = reader.IsForeignByteOrder();
+
+  /* count every directory, not just the usable ones: a damaged file
+     can chain empty directories, or point one at itself */
+  for (std::size_t offset = reader.FirstDirectory(), n = 0;
+       offset != 0 && n < MAX_DIRECTORIES; ++n) {
+    CompositeLevel level;
+    offset = reader.ReadDirectory(offset, level);
+    if (level.width > 0)
+      index.levels.push_back(std::move(level));
+  }
+
+  if (index.levels.empty())
+    throw std::runtime_error("Empty radar image");
+
+  /* only the full resolution image carries the projection keys; the
+     overviews cover the same area with fewer pixels, so their scale
+     follows from the size ratio */
+  const auto &full = index.levels.front();
+  if (full.scale <= 0)
+    throw std::runtime_error("Radar image without a georeference");
+
+  for (auto &level : index.levels) {
+    if (level.scale > 0 || level.width == 0)
+      continue;
+
+    level.scale = full.scale * double(full.width) / level.width;
+    level.origin_x = full.origin_x;
+    level.origin_y = full.origin_y;
+  }
+
+  return index;
+}
+
+unsigned
+OPERA::SelectLevel(const CompositeIndex &index,
+                   double metres_per_pixel) noexcept
+{
+  unsigned best = 0;
+
+  const double limit = metres_per_pixel * LEVEL_TOLERANCE;
+
+  for (unsigned i = 0; i < index.levels.size(); ++i)
+    if (index.levels[i].IsUsable() && index.levels[i].scale <= limit)
+      /* the levels are ordered fine to coarse, so the last one that
+         is still fine enough is the cheapest usable one */
+      best = i;
+
+  return best;
+}
+
+std::vector<unsigned>
+OPERA::CoveringSourceTiles(const CompositeLevel &level,
+                           const GeoBounds &bounds) noexcept
+{
+  std::vector<unsigned> result;
+  if (!level.IsUsable() || !bounds.IsValid())
+    return result;
+
+  const auto extent = GetProjectedExtent(bounds);
+
+  const double c0 = (extent.min_x - level.origin_x) / level.scale;
+  const double c1 = (extent.max_x - level.origin_x) / level.scale;
+  const double r0 = (level.origin_y - extent.max_y) / level.scale;
+  const double r1 = (level.origin_y - extent.min_y) / level.scale;
+
+  if (c1 < 0 || r1 < 0 ||
+      c0 >= double(level.width) || r0 >= double(level.height))
+    /* the area is somewhere the composite does not cover */
+    return result;
+
+  const unsigned across = level.TilesAcross(), down = level.TilesDown();
+  const unsigned tx0 = unsigned(std::max(0.0, c0)) / level.tile_width;
+  const unsigned ty0 = unsigned(std::max(0.0, r0)) / level.tile_height;
+  const unsigned tx1 =
+    unsigned(std::min(double(level.width - 1), c1)) / level.tile_width;
+  const unsigned ty1 =
+    unsigned(std::min(double(level.height - 1), r1)) / level.tile_height;
+
+  for (unsigned ty = ty0; ty <= ty1 && ty < down; ++ty)
+    for (unsigned tx = tx0; tx <= tx1 && tx < across; ++tx) {
+      const unsigned i = ty * across + tx;
+      if (i < level.tile_offset.size() && level.tile_length[i] > 0)
+        result.push_back(i);
+    }
+
+  return result;
 }

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Radar.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "Math/Constants.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <functional>
+
+namespace {
+
+constexpr const char *BUCKET_URL =
+  "https://s3.waw3-1.cloudferro.com/openradar-24h";
+
+/* the Lambert azimuthal equal-area grid the composite is published
+   on, read from the GeoTIFF's own keys */
+constexpr double EARTH_RADIUS = 6378140;
+constexpr double CENTRE_LATITUDE = 55;
+constexpr double CENTRE_LONGITUDE = 10;
+constexpr double FALSE_EASTING = 1950000;
+constexpr double FALSE_NORTHING = -2100000;
+
+/**
+ * The lower reflectivity bound of each colour class.
+ *
+ * The last entry is the "everything above" class; a value below the
+ * first one is not drawn at all, which is what the reference product
+ * does with the weakest echoes.
+ */
+/**
+ * The lower dBZ bound of each colour class, obtained by matching the
+ * quantiles of the composite against a DWD European radar image.
+ *
+ * Classes 1 and 9 were absent from that image, so the match left them
+ * with an empty range; their bounds are interpolated evenly in dBZ
+ * (that is, geometrically in rain rate) between the neighbours it did
+ * determine.  The array must stay strictly increasing, or
+ * ClassifyReflectivity() would step over a class and one colour would
+ * never be drawn.
+ */
+constexpr std::array<double, OPERA::N_CLASSES> CLASS_MINIMUM{
+  18.77, 21.16, 23.56, 25.95, 30.43, 34.62, 38.68, 42.82,
+  47.81, 50.77, 53.73, 56.69, 60.70, 62.96, 66.14,
+};
+
+static_assert(std::ranges::adjacent_find(CLASS_MINIMUM,
+                                         std::greater_equal<>{}) ==
+              CLASS_MINIMUM.end(),
+              "the class bounds must be strictly increasing");
+
+constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
+  0x33ffff, 0x1acc9a, 0x019934, 0x4db31b, 0x99cc01,
+  0xcce601, 0xffff01, 0xffc401, 0xff8901, 0xff4501,
+  0xfe0000, 0xe5004c, 0xcc0098, 0x6600cb, 0x0000fe,
+};
+
+} // anonymous namespace
+
+std::string
+OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+{
+  if (!utc.IsPlausible())
+    /* without a clock we cannot tell which composite is the current
+       one, and guessing would show yesterday's weather */
+    return {};
+
+  const auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
+  const unsigned minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+
+  return fmt::format("{}/{:04}/{:02}/{:02}/OPERA/COMP/"
+                     "OPERA@{:04}{:02}{:02}T{:02}{:02}@0@DBZH.tiff",
+                     BUCKET_URL, t.year, t.month, t.day,
+                     t.year, t.month, t.day, t.hour, minute);
+}
+
+DoublePoint2D
+OPERA::Project(const GeoPoint &p) noexcept
+{
+  const double lat = p.latitude.Radians();
+  const double lon = p.longitude.Radians();
+  const double lat0 = CENTRE_LATITUDE * M_PI / 180;
+  const double delta = lon - CENTRE_LONGITUDE * M_PI / 180;
+
+  const double denominator = 1 + std::sin(lat0) * std::sin(lat) +
+    std::cos(lat0) * std::cos(lat) * std::cos(delta);
+  if (denominator <= 0)
+    /* the antipode of the projection centre has no image */
+    return {0, 0};
+
+  const double k = EARTH_RADIUS * std::sqrt(2 / denominator);
+
+  return {
+    FALSE_EASTING + k * std::cos(lat) * std::sin(delta),
+    FALSE_NORTHING + k * (std::cos(lat0) * std::sin(lat) -
+                          std::sin(lat0) * std::cos(lat) * std::cos(delta)),
+  };
+}
+
+bool
+OPERA::IsNotANumber(double value) noexcept
+{
+  uint64_t bits;
+  static_assert(sizeof(bits) == sizeof(value));
+  std::memcpy(&bits, &value, sizeof(bits));
+
+  return ((bits >> 52) & 0x7ff) == 0x7ff && (bits & 0xfffffffffffffULL) != 0;
+}
+
+int
+OPERA::ClassifyReflectivity(double dbz) noexcept
+{
+  if (IsNotANumber(dbz) || dbz < CLASS_MINIMUM.front())
+    return -1;
+
+  unsigned i = 0;
+  while (i + 1 < N_CLASSES && dbz >= CLASS_MINIMUM[i + 1])
+    ++i;
+
+  return int(i);
+}
+
+uint32_t
+OPERA::GetClassColour(unsigned i) noexcept
+{
+  return CLASS_COLOUR[i < N_CLASSES ? i : N_CLASSES - 1];
+}

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -9,6 +9,9 @@
 #include "UIGlobals.hpp"
 #include "LogFile.hpp"
 #include "Language/Language.hpp"
+#include "Dialogs/Message.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "MapWindow/OverlayBitmap.hpp"
 #include "Weather/BackgroundDownloadProgress.hpp"
@@ -17,6 +20,7 @@
 #include "ui/canvas/Bitmap.hpp"
 #include "util/BindMethod.hxx"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -97,8 +101,62 @@ const MapOverlay *installed_overlay = nullptr;
 std::string installed_url;
 GeoBounds installed_bounds = GeoBounds::Invalid();
 
+/** the time #installed_overlay depicts */
+BrokenDateTime installed_time = BrokenDateTime::Invalid();
+
 /** the composite the running download is fetching */
 std::string pending_url;
+BrokenDateTime pending_time = BrokenDateTime::Invalid();
+
+/**
+ * Set when a frame was taken off the map for age and the refresh that
+ * should replace it has not succeeded yet.  If that refresh fails,
+ * the pilot is told the radar is gone rather than left wondering.
+ */
+bool stale_removed = false;
+
+[[gnu::pure]]
+bool
+IsStaleWarningHidden() noexcept
+{
+  bool hidden = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hidden);
+  return hidden;
+}
+
+void
+WarnStale() noexcept
+{
+  if (IsStaleWarningHidden())
+    return;
+
+  /* the opt-out follows the Quick Guide dialog: answering "no" writes
+     the choice to the profile, and the Network configuration page can
+     switch it back on */
+  if (ShowMessageBox(_("The radar image could not be refreshed and has "
+                       "been removed, so that no outdated echo is shown.\n\n"
+                       "Warn again when this happens?"),
+                     _("Radar"), MB_YESNO | MB_ICONWARNING) == IDNO) {
+    Profile::Set(ProfileKeys::HideRadarStaleWarning, true);
+    Profile::Save();
+  }
+}
+
+/**
+ * How long ago the frame on the map was taken, or a negative duration
+ * when nothing is on the map.
+ */
+[[gnu::pure]]
+std::chrono::system_clock::duration
+OverlayAge() noexcept
+{
+  const auto now = BrokenDateTime::NowUTC();
+  if (installed_overlay == nullptr ||
+      !installed_time.IsPlausible() || !now.IsPlausible())
+    return std::chrono::system_clock::duration{-1};
+
+  return now - installed_time;
+}
 
 void
 InstallOverlay(Path path, const GeoBounds &bounds) noexcept
@@ -128,6 +186,8 @@ InstallOverlay(Path path, const GeoBounds &bounds) noexcept
   installed_overlay = bmp.get();
   installed_bounds = bounds;
   installed_url = pending_url;
+  installed_time = pending_time;
+  stale_removed = false;
   map->SetOverlay(std::move(bmp));
 }
 
@@ -160,10 +220,52 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
 
   if (completion_error) {
     LogError(std::exchange(completion_error, {}), "Radar download");
+
+    /* a lost request on its own is not worth a dialog; it only
+       matters once it means the map has no radar left to show */
+    if (std::exchange(stale_removed, false))
+      WarnStale();
+
     return;
   }
 
   InstallOverlay(path, bounds);
+}
+
+void
+RadarDownloadGlue::ScheduleAgeCheck() noexcept
+{
+  /* the composite changes every five minutes, so checking once a
+     minute is often enough to catch a new one and cheap enough to run
+     for as long as the page is open */
+  age_timer.Schedule(std::chrono::minutes{1});
+}
+
+void
+RadarDownloadGlue::CancelAgeCheck() noexcept
+{
+  age_timer.Cancel();
+}
+
+void
+RadarDownloadGlue::OnAgeTimer() noexcept
+{
+  const auto age = OverlayAge();
+  if (age < std::chrono::system_clock::duration::zero())
+    /* nothing on the map to keep fresh */
+    return;
+
+  if (age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
+    /* down it comes before anything is fetched: an echo this old is
+       worse than none, and a refresh that hangs or fails must not be
+       able to leave it standing */
+    OPERA::ClearMapOverlay();
+    stale_removed = true;
+  }
+
+  /* ActivatePageOverlay() is a no-op while the frame we hold is still
+     the newest one, so this only fetches when there is something new */
+  OPERA::ActivatePageOverlay();
 }
 
 void
@@ -174,17 +276,24 @@ OPERA::ActivatePageOverlay() noexcept
   if (glue == nullptr || map == nullptr)
     return;
 
+  /* arm the watchdog first: it has to keep running even on the turns
+     where there is nothing new to fetch, or the picture would never
+     age out */
+  glue->ScheduleAgeCheck();
+
   const auto &projection = map->VisibleProjection();
   if (!projection.IsValid())
     return;
 
   const auto &bounds = projection.GetScreenBounds();
-  const auto url = OPERA::MakeCompositeURL(BrokenDateTime::NowUTC());
+  const auto now = BrokenDateTime::NowUTC();
+  const auto url = OPERA::MakeCompositeURL(now);
   if (url.empty() || IsStillCurrent(url.c_str(), bounds))
     return;
 
   const auto size = projection.GetScreenSize();
   pending_url = url;
+  pending_time = OPERA::CompositeTime(now);
   glue->Start(bounds, size.width, size.height);
 }
 
@@ -200,5 +309,16 @@ OPERA::ClearMapOverlay() noexcept
 
   installed_overlay = nullptr;
   installed_bounds = GeoBounds::Invalid();
+  installed_time = BrokenDateTime::Invalid();
   installed_url.clear();
+}
+
+void
+OPERA::DeactivatePageOverlay() noexcept
+{
+  if (auto *glue = GetRadarDownloadGlue(); glue != nullptr)
+    glue->CancelAgeCheck();
+
+  stale_removed = false;
+  ClearMapOverlay();
 }

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -338,18 +338,29 @@ RadarDownloadGlue::Start(std::string _url, const GeoBitmap::TileData &_base,
       !_frame_time.IsPlausible() || _slot >= slots.size())
     return;
 
+  /* one file per slot, so the cache cannot grow with the flight.
+     Built before anything is assigned: this allocates, and we are
+     noexcept, so a failure here has to leave the glue as it was
+     rather than half-armed -- and must not reach the caller, where it
+     would be std::terminate() rather than a lost tile. */
+  AllocatedPath new_path{nullptr};
+  try {
+    new_path = AllocatedPath::Build(MakeCacheDirectory("opera"),
+                                    fmt::format("rain-{}.png",
+                                                _slot).c_str());
+  } catch (...) {
+    LogError(std::current_exception(), "Radar overlay");
+    return;
+  }
+
   url = std::move(_url);
   base_tile = _base;
   tile = _tile;
   frame_time = _frame_time;
   slot = _slot;
   drawn = false;
-  path = nullptr;
+  path = std::move(new_path);
   completion_error = {};
-
-  /* one file per slot, so the cache cannot grow with the flight */
-  path = AllocatedPath::Build(MakeCacheDirectory("opera"),
-                              fmt::format("rain-{}.png", slot).c_str());
 
   /* hold the slot now: the next tile must not be handed the same one
      while this download is in flight */

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -2,28 +2,38 @@
 // Copyright The XCSoar Project
 
 #include "RadarPageOverlay.hpp"
-#include "Radar.hpp"
 #include "co/Task.hxx"
 #include "Components.hpp"
 #include "NetComponents.hpp"
 #include "UIGlobals.hpp"
+#include "Interface.hpp"
+#include "LocalPath.hpp"
 #include "LogFile.hpp"
 #include "Language/Language.hpp"
 #include "Dialogs/Message.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Keys.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/Quadrilateral.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "MapWindow/OverlayBitmap.hpp"
+#include "MapWindow/OverlayLimits.hpp"
 #include "Weather/BackgroundDownloadProgress.hpp"
 #include "lib/curl/Global.hxx"
-#include "time/BrokenDateTime.hpp"
 #include "ui/canvas/Bitmap.hpp"
 #include "util/BindMethod.hxx"
 
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <memory>
-#include <string>
 #include <utility>
+#include <vector>
+
+static_assert(OPERA::TILE_COUNT <= MapWindowOverlay::MAX_MAP_OVERLAYS,
+              "the radar block must fit in the map's overlay slots");
 
 RadarDownloadGlue *
 GetRadarDownloadGlue() noexcept
@@ -40,73 +50,64 @@ RadarDownloadGlue::RadarDownloadGlue(CurlGlobal &_curl) noexcept
 {
 }
 
-void
-RadarDownloadGlue::BeginShutdown() noexcept
-{
-  task.BeginShutdown();
-  complete_notify.ClearNotification();
-  path = nullptr;
-  completion_error = {};
-  BackgroundDownloadProgress::Get().ForceHide();
-}
-
-void
-RadarDownloadGlue::Start(const GeoBounds &_bounds,
-                         unsigned _width, unsigned _height) noexcept
-{
-  if (task.IsShuttingDown() || task.IsRunning())
-    return;
-
-  if (!_bounds.IsValid() || _width == 0 || _height == 0)
-    return;
-
-  bounds = _bounds;
-  width = _width;
-  height = _height;
-  path = nullptr;
-  completion_error = {};
-
-  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
-  BackgroundDownloadProgress::Get().SetProgressRange(100);
-
-  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
-}
-
-Co::InvokeTask
-RadarDownloadGlue::RunDownload()
-{
-  path = co_await OPERA::DownloadRadar(bounds, width, height, curl,
-                                       BackgroundDownloadProgress::Get());
-}
-
-void
-RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
-{
-  completion_error = std::move(error);
-  complete_notify.SendNotification();
-}
-
 namespace {
 
 /**
- * The overlay we installed, so that we never remove one somebody else
- * put there.
+ * One overlay slot, and the tile it is showing.
+ *
+ * The slot index is the map's overlay index, so a tile that survives
+ * a move stays exactly where it is and is never re-uploaded.
  */
-const MapOverlay *installed_overlay = nullptr;
+struct Slot {
+  /** the overlay we installed, so we never remove somebody else's */
+  const MapOverlay *overlay = nullptr;
+
+  GeoBitmap::TileData tile{};
+
+  /** the frame this tile depicts */
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+
+  /**
+   * Held for a download in flight, or for a tile that turned out to
+   * hold no echo and so has nothing to install.  Either way the slot
+   * is spoken for and must not be handed out again.
+   */
+  bool reserved = false;
+
+  constexpr bool IsUsed() const noexcept {
+    return overlay != nullptr || reserved;
+  }
+};
+
+std::array<Slot, OPERA::TILE_COUNT> slots;
+
+/** does any page show the radar? */
+bool active = false;
 
 /**
- * What #installed_overlay shows: the composite it came from, and the
- * area it was fetched for.
+ * Is the radar being held on the map across a pan?  Panning swaps in
+ * a layout with no overlay, which would otherwise tear the block down
+ * and cost a full refetch on the way back.
  */
-std::string installed_url;
-GeoBounds installed_bounds = GeoBounds::Invalid();
+bool suspended_for_pan = false;
 
-/** the time #installed_overlay depicts */
-BrokenDateTime installed_time = BrokenDateTime::Invalid();
+/** the frame the block is being filled with */
+BrokenDateTime block_frame = BrokenDateTime::Invalid();
 
-/** the composite the running download is fetching */
-std::string pending_url;
-BrokenDateTime pending_time = BrokenDateTime::Invalid();
+/** the aircraft's tile the current block is centred on */
+GeoBitmap::TileData block_base{};
+
+/** the tiles the block wants, nearest to the aircraft first */
+std::vector<GeoBitmap::TileData> wanted;
+
+/**
+ * Tiles that failed in a row, so a composite the server will not
+ * serve does not spin through the whole block once a second.
+ */
+unsigned consecutive_failures = 0;
+
+/** is the progress bar up for the block being filled? */
+bool progress_shown = false;
 
 /**
  * Set when a frame was taken off the map for age and the refresh that
@@ -114,6 +115,26 @@ BrokenDateTime pending_time = BrokenDateTime::Invalid();
  * the pilot is told the radar is gone rather than left wondering.
  */
 bool stale_removed = false;
+
+void
+BeginProgress() noexcept
+{
+  if (progress_shown)
+    return;
+
+  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
+  progress_shown = true;
+}
+
+void
+EndProgress() noexcept
+{
+  if (!progress_shown)
+    return;
+
+  BackgroundDownloadProgress::Get().End();
+  progress_shown = false;
+}
 
 [[gnu::pure]]
 bool
@@ -131,7 +152,7 @@ WarnStale() noexcept
     return;
 
   /* the opt-out follows the Quick Guide dialog: answering "no" writes
-     the choice to the profile, and the Network configuration page can
+     the choice to the profile, and the Look configuration page can
      switch it back on */
   if (ShowMessageBox(_("The radar image could not be refreshed and has "
                        "been removed, so that no outdated echo is shown.\n\n"
@@ -148,21 +169,99 @@ WarnStale() noexcept
  */
 [[gnu::pure]]
 std::chrono::system_clock::duration
-OverlayAge() noexcept
+BlockAge() noexcept
 {
   const auto now = BrokenDateTime::NowUTC();
-  if (installed_overlay == nullptr ||
-      !installed_time.IsPlausible() || !now.IsPlausible())
+  if (!block_frame.IsPlausible() || !now.IsPlausible())
     return std::chrono::system_clock::duration{-1};
 
-  return now - installed_time;
+  return now - block_frame;
+}
+
+/** Drop one slot, if the map is still showing what we put there. */
+void
+ReleaseSlot(unsigned index) noexcept
+{
+  auto &slot = slots[index];
+  if (!slot.IsUsed())
+    return;
+
+  if (auto *map = UIGlobals::GetMap();
+      map != nullptr && slot.overlay != nullptr &&
+      map->GetOverlay(index) == slot.overlay)
+    map->SetOverlay(index, nullptr);
+
+  slot = {};
+}
+
+/** Is this tile already dealt with, showing the right frame? */
+[[gnu::pure]]
+bool
+IsShown(const GeoBitmap::TileData &tile,
+        const BrokenDateTime &frame_time) noexcept
+{
+  const auto *map = UIGlobals::GetMap();
+
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed() || !OPERA::IsSameTile(slot.tile, tile) ||
+        !(slot.frame_time == frame_time))
+      continue;
+
+    if (slot.overlay == nullptr)
+      /* reserved: either in flight or known to hold no echo -- either
+         way there is nothing left to fetch for it */
+      return true;
+
+    if (map != nullptr && map->GetOverlay(i) == slot.overlay)
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * Give up the slots holding tiles the block no longer wants -- the
+ * ones left behind as the aircraft flew on, and everything at all
+ * when the frame moved on.
+ */
+void
+ReleaseUnwantedSlots() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed())
+      continue;
+
+    const bool keep = slot.frame_time == block_frame &&
+      std::any_of(wanted.begin(), wanted.end(),
+                  [&slot](const auto &t){
+                    return OPERA::IsSameTile(slot.tile, t);
+                  });
+
+    if (!keep)
+      ReleaseSlot(i);
+  }
+}
+
+/** The first slot not holding a tile we want to keep. */
+[[gnu::pure]]
+int
+FindFreeSlot() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (!slots[i].IsUsed())
+      return int(i);
+
+  return -1;
 }
 
 void
-InstallOverlay(Path path, const GeoBounds &bounds) noexcept
+InstallTile(unsigned index, Path path, const GeoBitmap::TileData &tile,
+            const BrokenDateTime &frame_time) noexcept
 {
   auto *map = UIGlobals::GetMap();
-  if (map == nullptr || path == nullptr || !bounds.IsValid())
+  if (map == nullptr || path == nullptr || index >= slots.size())
     return;
 
   Bitmap bitmap;
@@ -174,40 +273,128 @@ InstallOverlay(Path path, const GeoBounds &bounds) noexcept
     return;
   }
 
+  /* OPERA is published under CC BY 4.0, so the attribution has to
+     travel with the picture; the overlay label carries it, which is
+     what the map shows when the pilot taps it */
+  const auto label = fmt::format("{} — EUMETNET OPERA", gettext(N_("Radar")));
+
   auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
-                                                GeoQuadrilateral{
-                                                  bounds.GetNorthWest(),
-                                                  bounds.GetNorthEast(),
-                                                  bounds.GetSouthWest(),
-                                                  bounds.GetSouthEast(),
-                                                },
-                                                _("Radar"));
+                                                GeoBitmap::GetGeoQuadrilateral(tile),
+                                                label.c_str());
   bmp->SetAlpha(0.6);
-  installed_overlay = bmp.get();
-  installed_bounds = bounds;
-  installed_url = pending_url;
-  installed_time = pending_time;
+
+  auto &slot = slots[index];
+  slot.overlay = bmp.get();
+  slot.tile = tile;
+  slot.frame_time = frame_time;
+  slot.reserved = false;
+  map->SetOverlay(index, std::move(bmp));
+
   stale_removed = false;
-  map->SetOverlay(std::move(bmp));
 }
 
 /**
- * Is the overlay we already installed still the right one?  The
- * composite is published every five minutes, so re-fetching the same
- * one costs bandwidth and shows nothing new; and an image fetched for
- * a wider area still covers a map that has not been panned out of it.
+ * The next tile of the block that is not dealt with yet, or an
+ * invalid tile when the block is complete.  #wanted is already in
+ * nearest first order, so this walks outwards from the aircraft.
  */
-bool
-IsStillCurrent(const char *url, const GeoBounds &bounds) noexcept
+[[gnu::pure]]
+GeoBitmap::TileData
+NextMissingTile() noexcept
 {
-  const auto *map = UIGlobals::GetMap();
-  return map != nullptr && installed_overlay != nullptr &&
-    map->GetOverlay() == installed_overlay &&
-    installed_url == url &&
-    installed_bounds.IsValid() && installed_bounds.IsInside(bounds);
+  for (const auto &tile : wanted)
+    if (!IsShown(tile, block_frame))
+      return tile;
+
+  return {};
 }
 
 } // anonymous namespace
+
+void
+RadarDownloadGlue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  path = nullptr;
+  completion_error = {};
+  progress_shown = false;
+  BackgroundDownloadProgress::Get().ForceHide();
+}
+
+void
+RadarDownloadGlue::Start(std::string _url, const GeoBitmap::TileData &_base,
+                         const GeoBitmap::TileData &_tile,
+                         const BrokenDateTime &_frame_time,
+                         unsigned _slot) noexcept
+{
+  /* every request parameter is set here, after the guards: an early
+     return must not leave the next completion labelled with a request
+     that was never made */
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  if (_url.empty() || !_base.IsValid() || !_tile.IsValid() ||
+      !_frame_time.IsPlausible() || _slot >= slots.size())
+    return;
+
+  url = std::move(_url);
+  base_tile = _base;
+  tile = _tile;
+  frame_time = _frame_time;
+  slot = _slot;
+  drawn = false;
+  path = nullptr;
+  completion_error = {};
+
+  /* one file per slot, so the cache cannot grow with the flight */
+  path = AllocatedPath::Build(MakeCacheDirectory("opera"),
+                              fmt::format("rain-{}.png", slot).c_str());
+
+  /* hold the slot now: the next tile must not be handed the same one
+     while this download is in flight */
+  slots[slot].tile = tile;
+  slots[slot].frame_time = frame_time;
+  slots[slot].reserved = true;
+
+  BeginProgress();
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+RadarDownloadGlue::RunDownload()
+{
+  /* one range request for the directory; a no-op once the frame is
+     open, which is every tile after the first */
+  co_await composite.Open(url, curl);
+
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  const auto &index = composite.GetIndex();
+
+  /* the overview that matches what the block is drawn at, taken from
+     its centre tile so that every tile of it uses the same one:
+     asking for a finer level only costs bandwidth and decode time,
+     and asking for different ones across the block would fetch the
+     same ground twice */
+  const auto level_index =
+    OPERA::SelectLevel(index,
+                       OPERA::TileMetresPerPixel(GeoBitmap::GetBounds(base_tile),
+                                                 OPERA::TILE_PIXELS));
+
+  for (const auto source : OPERA::CoveringSourceTiles(index.levels[level_index],
+                                                      bounds))
+    co_await composite.FetchTile(level_index, source, curl);
+
+  drawn = composite.Render(level_index, bounds,
+                           OPERA::TILE_PIXELS, OPERA::TILE_PIXELS, path);
+}
+
+void
+RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
 
 void
 RadarDownloadGlue::OnCompleteNotify() noexcept
@@ -215,21 +402,50 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
   if (task.IsShuttingDown())
     return;
 
-  if (!task.IsRunning())
-    BackgroundDownloadProgress::Get().End();
-
   if (completion_error) {
     LogError(std::exchange(completion_error, {}), "Radar download");
 
-    /* a lost request on its own is not worth a dialog; it only
-       matters once it means the map has no radar left to show */
+    ReleaseSlot(slot);
+
+    /* send the tile that failed to the back of the queue, so one the
+       server will not serve does not stand in front of the rest of
+       the block for the whole flight */
+    if (const auto i = std::find_if(wanted.begin(), wanted.end(),
+                                    [this](const auto &t){
+                                      return OPERA::IsSameTile(t, tile);
+                                    });
+        i != wanted.end())
+      std::rotate(i, i + 1, wanted.end());
+
+    ++consecutive_failures;
+    EndProgress();
+
+    /* a lost tile on its own is not worth a dialog; it only matters
+       once it means the map has no radar left to show */
     if (std::exchange(stale_removed, false))
       WarnStale();
 
     return;
   }
 
-  InstallOverlay(path, bounds);
+  consecutive_failures = 0;
+
+  if (!(frame_time == block_frame))
+    /* the block moved on while this was in flight -- a newer frame is
+       due, or the radar was taken off the map.  Installing it now
+       would put a frame on the map that the age watchdog has already
+       decided against. */
+    ReleaseSlot(slot);
+  else if (drawn)
+    InstallTile(slot, path, tile, frame_time);
+  else
+    /* clear sky here: the slot stays reserved for this tile so the
+       block does not ask for it again, but nothing is drawn */
+    slots[slot].reserved = true;
+
+  /* straight on to the next tile, so the block fills as fast as the
+     link allows rather than one tile per timer tick */
+  OPERA::ActivatePageOverlay();
 }
 
 void
@@ -250,12 +466,12 @@ RadarDownloadGlue::CancelAgeCheck() noexcept
 void
 RadarDownloadGlue::OnAgeTimer() noexcept
 {
-  const auto age = OverlayAge();
-  if (age < std::chrono::system_clock::duration::zero())
-    /* nothing on the map to keep fresh */
+  if (!active)
     return;
 
-  if (age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
+  const auto age = BlockAge();
+  if (age >= std::chrono::system_clock::duration::zero() &&
+      age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
     /* down it comes before anything is fetched: an echo this old is
        worse than none, and a refresh that hangs or fails must not be
        able to leave it standing */
@@ -263,8 +479,9 @@ RadarDownloadGlue::OnAgeTimer() noexcept
     stale_removed = true;
   }
 
-  /* ActivatePageOverlay() is a no-op while the frame we hold is still
-     the newest one, so this only fetches when there is something new */
+  /* a new minute is a new chance for whatever the link dropped */
+  consecutive_failures = 0;
+
   OPERA::ActivatePageOverlay();
 }
 
@@ -276,49 +493,117 @@ OPERA::ActivatePageOverlay() noexcept
   if (glue == nullptr || map == nullptr)
     return;
 
+  active = true;
+
   /* arm the watchdog first: it has to keep running even on the turns
      where there is nothing new to fetch, or the picture would never
-     age out */
+     age out and a dropped tile would never be retried */
   glue->ScheduleAgeCheck();
 
   const auto &projection = map->VisibleProjection();
   if (!projection.IsValid())
     return;
 
-  const auto &bounds = projection.GetScreenBounds();
   const auto now = BrokenDateTime::NowUTC();
-  const auto url = OPERA::MakeCompositeURL(now);
-  if (url.empty() || IsStillCurrent(url.c_str(), bounds))
+  auto url = MakeCompositeURL(now);
+  const auto frame_time = CompositeTime(now);
+  if (url.empty() || !frame_time.IsPlausible())
+    /* without a clock we cannot tell which composite is the current
+       one, and guessing would show yesterday's weather */
     return;
 
-  const auto size = projection.GetScreenSize();
-  pending_url = url;
-  pending_time = OPERA::CompositeTime(now);
-  glue->Start(bounds, size.width, size.height);
+  /* One step finer than the map's own scale, so the block covers the
+     screen with a margin to pan into.  The geometric choice is asked
+     for one step coarser than the grid we want, so that adding the
+     step lands inside [MIN_TILE_ZOOM, MAX_TILE_ZOOM] rather than
+     saturating one short of either end. */
+  const auto map_tile = GeoBitmap::GetTile(projection,
+                                           MIN_TILE_ZOOM - TILE_ZOOM_STEP,
+                                           MAX_TILE_ZOOM - TILE_ZOOM_STEP);
+  const auto zoom = uint16_t(map_tile.zoom + TILE_ZOOM_STEP);
+
+  const auto &basic = CommonInterface::Basic();
+  const auto base = basic.location_available
+    ? GetAircraftTile(basic.location, zoom)
+    /* before the first fix there is no aircraft to centre on, so the
+       block goes where the pilot is looking instead */
+    : GeoBitmap::GetTile(projection.GetScreenBounds(), zoom);
+  if (!base.IsValid())
+    return;
+
+  /* recompute the block when the aircraft has crossed into another
+     tile, when the map scale changed the grid, or when a newer frame
+     is due.  Everything is keyed on the tile grid, so a few
+     kilometres of flight change nothing and the tiles already on the
+     map stay there. */
+  if (!IsSameTile(base, block_base) || !(frame_time == block_frame)) {
+    block_base = base;
+    block_frame = frame_time;
+    wanted = CollectTiles(base);
+    ReleaseUnwantedSlots();
+    consecutive_failures = 0;
+  }
+
+  if (glue->IsRunning() || wanted.empty())
+    return;
+
+  if (consecutive_failures >= wanted.size()) {
+    /* the whole block failed in a row; wait for the timer rather than
+       spin through it again */
+    EndProgress();
+    return;
+  }
+
+  const auto next = NextMissingTile();
+  if (!next.IsValid()) {
+    /* the block is complete */
+    EndProgress();
+    return;
+  }
+
+  const auto slot = FindFreeSlot();
+  if (slot < 0)
+    return;
+
+  glue->Start(std::move(url), base, next, frame_time, unsigned(slot));
 }
 
 void
 OPERA::ClearMapOverlay() noexcept
 {
-  auto *map = UIGlobals::GetMap();
-  if (map == nullptr || installed_overlay == nullptr)
-    return;
+  for (unsigned i = 0; i < slots.size(); ++i)
+    ReleaseSlot(i);
 
-  if (map->GetOverlay() == installed_overlay)
-    map->SetOverlay(nullptr);
-
-  installed_overlay = nullptr;
-  installed_bounds = GeoBounds::Invalid();
-  installed_time = BrokenDateTime::Invalid();
-  installed_url.clear();
+  block_frame = BrokenDateTime::Invalid();
+  block_base = {};
+  wanted.clear();
+  consecutive_failures = 0;
+  EndProgress();
 }
 
 void
 OPERA::DeactivatePageOverlay() noexcept
 {
+  if (suspended_for_pan)
+    /* the pilot is dragging the map, not leaving the radar behind */
+    return;
+
   if (auto *glue = GetRadarDownloadGlue(); glue != nullptr)
     glue->CancelAgeCheck();
 
+  active = false;
   stale_removed = false;
   ClearMapOverlay();
+}
+
+void
+OPERA::SuspendForPan() noexcept
+{
+  suspended_for_pan = true;
+}
+
+void
+OPERA::ResumeAfterPan() noexcept
+{
+  suspended_for_pan = false;
 }

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RadarPageOverlay.hpp"
+#include "Radar.hpp"
+#include "co/Task.hxx"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "UIGlobals.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "MapWindow/GlueMapWindow.hpp"
+#include "MapWindow/OverlayBitmap.hpp"
+#include "Weather/BackgroundDownloadProgress.hpp"
+#include "lib/curl/Global.hxx"
+#include "time/BrokenDateTime.hpp"
+#include "ui/canvas/Bitmap.hpp"
+#include "util/BindMethod.hxx"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+RadarDownloadGlue *
+GetRadarDownloadGlue() noexcept
+{
+  if (net_components == nullptr)
+    return nullptr;
+
+  return net_components->opera_radar.get();
+}
+
+RadarDownloadGlue::RadarDownloadGlue(CurlGlobal &_curl) noexcept
+  :curl(_curl),
+   task(curl.GetEventLoop())
+{
+}
+
+void
+RadarDownloadGlue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  path = nullptr;
+  completion_error = {};
+  BackgroundDownloadProgress::Get().ForceHide();
+}
+
+void
+RadarDownloadGlue::Start(const GeoBounds &_bounds,
+                         unsigned _width, unsigned _height) noexcept
+{
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  if (!_bounds.IsValid() || _width == 0 || _height == 0)
+    return;
+
+  bounds = _bounds;
+  width = _width;
+  height = _height;
+  path = nullptr;
+  completion_error = {};
+
+  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
+  BackgroundDownloadProgress::Get().SetProgressRange(100);
+
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+RadarDownloadGlue::RunDownload()
+{
+  path = co_await OPERA::DownloadRadar(bounds, width, height, curl,
+                                       BackgroundDownloadProgress::Get());
+}
+
+void
+RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
+
+namespace {
+
+/**
+ * The overlay we installed, so that we never remove one somebody else
+ * put there.
+ */
+const MapOverlay *installed_overlay = nullptr;
+
+/**
+ * What #installed_overlay shows: the composite it came from, and the
+ * area it was fetched for.
+ */
+std::string installed_url;
+GeoBounds installed_bounds = GeoBounds::Invalid();
+
+/** the composite the running download is fetching */
+std::string pending_url;
+
+void
+InstallOverlay(Path path, const GeoBounds &bounds) noexcept
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || path == nullptr || !bounds.IsValid())
+    return;
+
+  Bitmap bitmap;
+  try {
+    if (!bitmap.LoadFile(path))
+      return;
+  } catch (...) {
+    LogError(std::current_exception(), "Radar overlay");
+    return;
+  }
+
+  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                GeoQuadrilateral{
+                                                  bounds.GetNorthWest(),
+                                                  bounds.GetNorthEast(),
+                                                  bounds.GetSouthWest(),
+                                                  bounds.GetSouthEast(),
+                                                },
+                                                _("Radar"));
+  bmp->SetAlpha(0.6);
+  installed_overlay = bmp.get();
+  installed_bounds = bounds;
+  installed_url = pending_url;
+  map->SetOverlay(std::move(bmp));
+}
+
+/**
+ * Is the overlay we already installed still the right one?  The
+ * composite is published every five minutes, so re-fetching the same
+ * one costs bandwidth and shows nothing new; and an image fetched for
+ * a wider area still covers a map that has not been panned out of it.
+ */
+bool
+IsStillCurrent(const char *url, const GeoBounds &bounds) noexcept
+{
+  const auto *map = UIGlobals::GetMap();
+  return map != nullptr && installed_overlay != nullptr &&
+    map->GetOverlay() == installed_overlay &&
+    installed_url == url &&
+    installed_bounds.IsValid() && installed_bounds.IsInside(bounds);
+}
+
+} // anonymous namespace
+
+void
+RadarDownloadGlue::OnCompleteNotify() noexcept
+{
+  if (task.IsShuttingDown())
+    return;
+
+  if (!task.IsRunning())
+    BackgroundDownloadProgress::Get().End();
+
+  if (completion_error) {
+    LogError(std::exchange(completion_error, {}), "Radar download");
+    return;
+  }
+
+  InstallOverlay(path, bounds);
+}
+
+void
+OPERA::ActivatePageOverlay() noexcept
+{
+  auto *glue = GetRadarDownloadGlue();
+  const auto *map = UIGlobals::GetMap();
+  if (glue == nullptr || map == nullptr)
+    return;
+
+  const auto &projection = map->VisibleProjection();
+  if (!projection.IsValid())
+    return;
+
+  const auto &bounds = projection.GetScreenBounds();
+  const auto url = OPERA::MakeCompositeURL(BrokenDateTime::NowUTC());
+  if (url.empty() || IsStillCurrent(url.c_str(), bounds))
+    return;
+
+  const auto size = projection.GetScreenSize();
+  pending_url = url;
+  glue->Start(bounds, size.width, size.height);
+}
+
+void
+OPERA::ClearMapOverlay() noexcept
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || installed_overlay == nullptr)
+    return;
+
+  if (map->GetOverlay() == installed_overlay)
+    map->SetOverlay(nullptr);
+
+  installed_overlay = nullptr;
+  installed_bounds = GeoBounds::Invalid();
+  installed_url.clear();
+}

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -430,11 +430,21 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
 
   consecutive_failures = 0;
 
-  if (!(frame_time == block_frame))
-    /* the block moved on while this was in flight -- a newer frame is
-       due, or the radar was taken off the map.  Installing it now
-       would put a frame on the map that the age watchdog has already
-       decided against. */
+  /* The block can move while a tile is in flight, and then this
+     answer is to a question nobody is asking any more.  Two ways:
+     a newer frame fell due, or the aircraft crossed into another tile
+     and the block was rebuilt around it.  The frame check alone
+     misses the second -- the frame is unchanged there, but
+     ReleaseUnwantedSlots() has already given this slot back, and
+     installing now would drop a tile from outside the block onto the
+     map and hold a slot the block wants for something else. */
+  const bool still_wanted = frame_time == block_frame &&
+    std::any_of(wanted.begin(), wanted.end(),
+                [this](const auto &t){
+                  return OPERA::IsSameTile(t, tile);
+                });
+
+  if (!still_wanted)
     ReleaseSlot(slot);
   else if (drawn)
     InstallTile(slot, path, tile, frame_time);

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -225,33 +225,53 @@ IsShown(const GeoBitmap::TileData &tile,
  * ones left behind as the aircraft flew on, and everything at all
  * when the frame moved on.
  */
-void
-ReleaseUnwantedSlots() noexcept
+[[gnu::pure]]
+bool
+IsWanted(const GeoBitmap::TileData &tile) noexcept
 {
-  for (unsigned i = 0; i < slots.size(); ++i) {
-    const auto &slot = slots[i];
-    if (!slot.IsUsed())
-      continue;
-
-    const bool keep = slot.frame_time == block_frame &&
-      std::any_of(wanted.begin(), wanted.end(),
-                  [&slot](const auto &t){
-                    return OPERA::IsSameTile(slot.tile, t);
-                  });
-
-    if (!keep)
-      ReleaseSlot(i);
-  }
+  return std::any_of(wanted.begin(), wanted.end(),
+                     [&tile](const auto &t){
+                       return OPERA::IsSameTile(tile, t);
+                     });
 }
 
-/** The first slot not holding a tile we want to keep. */
+/**
+ * Reserve a slot for a tile about to be fetched.
+ *
+ * Nothing is released ahead of time.  A newly published composite
+ * changes every tile's frame at once, and a change of map scale moves
+ * the whole grid, so releasing what the block no longer wants would
+ * empty the map -- every five minutes at the OPERA cadence -- and
+ * leave it empty for as long as a full block takes to arrive.
+ *
+ * Give up one echo at a time instead, and preferably the one the
+ * incoming tile is about to cover, so the hole is exactly where the
+ * replacement lands.  Leaving an old tile under a new one would draw
+ * the same ground twice, each at partial opacity, and darken it.
+ */
 [[gnu::pure]]
 int
-FindFreeSlot() noexcept
+ClaimSlotFor(const GeoBitmap::TileData &tile) noexcept
 {
   for (unsigned i = 0; i < slots.size(); ++i)
     if (!slots[i].IsUsed())
       return int(i);
+
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && !IsWanted(slots[i].tile) &&
+        bounds.Overlaps(GeoBitmap::GetBounds(slots[i].tile))) {
+      ReleaseSlot(i);
+      return int(i);
+    }
+
+  /* nothing overlapping to reclaim; give up the first tile the block
+     no longer wants, wherever it is */
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && !IsWanted(slots[i].tile)) {
+      ReleaseSlot(i);
+      return int(i);
+    }
 
   return -1;
 }
@@ -445,15 +465,10 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
      answer is to a question nobody is asking any more.  Two ways:
      a newer frame fell due, or the aircraft crossed into another tile
      and the block was rebuilt around it.  The frame check alone
-     misses the second -- the frame is unchanged there, but
-     ReleaseUnwantedSlots() has already given this slot back, and
-     installing now would drop a tile from outside the block onto the
-     map and hold a slot the block wants for something else. */
-  const bool still_wanted = frame_time == block_frame &&
-    std::any_of(wanted.begin(), wanted.end(),
-                [this](const auto &t){
-                  return OPERA::IsSameTile(t, tile);
-                });
+     misses the second -- the frame is unchanged there, and installing
+     would drop a tile from outside the block onto the map and hold a
+     slot the block wants for something else. */
+  const bool still_wanted = frame_time == block_frame && IsWanted(tile);
 
   if (!still_wanted)
     ReleaseSlot(slot);
@@ -561,7 +576,6 @@ OPERA::ActivatePageOverlay() noexcept
     block_base = base;
     block_frame = frame_time;
     wanted = CollectTiles(base);
-    ReleaseUnwantedSlots();
     consecutive_failures = 0;
   }
 
@@ -582,7 +596,7 @@ OPERA::ActivatePageOverlay() noexcept
     return;
   }
 
-  const auto slot = FindFreeSlot();
+  const auto slot = ClaimSlotFor(next);
   if (slot < 0)
     return;
 

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -3,36 +3,71 @@
 
 #pragma once
 
-#include "Geo/GeoBounds.hpp"
+#include "Radar.hpp"
 #include "co/InvokeTask.hxx"
 #include "net/AsyncTask.hpp"
 #include "system/Path.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 
 #include <exception>
+#include <string>
 
 class CurlGlobal;
 
 /**
- * Runs OPERA::DownloadRadar() on the network #EventLoop and installs
- * the finished image as the map overlay from the UI thread.
+ * Fills the map with the radar composite, one display tile at a time,
+ * from underneath the aircraft outwards.
+ *
+ * The composite is a single five megabyte file covering the continent,
+ * so it is read with range requests: one for its directory, then one
+ * per tile of it that the block actually needs.  Everything runs on
+ * the network #EventLoop; finished tiles are installed as map
+ * overlays from the UI thread.
  *
  * Unlike the Weather dialog, which downloads inside a modal progress
  * dialog, a page overlay has to appear without the pilot waiting for
- * it, so the fetch runs in the background and the map gains the image
- * whenever it is ready.
+ * it.
  */
 class RadarDownloadGlue final {
   CurlGlobal &curl;
   Net::AsyncTask task;
   UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
 
-  /** the area the running download was requested for */
-  GeoBounds bounds = GeoBounds::Invalid();
-  unsigned width = 0, height = 0;
+  /**
+   * The frame being read, and the tiles of it decoded so far.  Held
+   * across display tiles, so that a composite is opened once and each
+   * of its tiles travels once however many display tiles it feeds.
+   *
+   * Network thread only.
+   */
+  OPERA::RadarComposite composite;
+
+  /* what the running download is for; written by the UI thread before
+     the task starts, read by the network thread while it runs */
+  std::string url;
+
+  /**
+   * The tile the block is centred on, which is what the pyramid level
+   * is chosen from.
+   *
+   * One level for the whole block, rather than one per tile: the
+   * block spans enough latitude at a wide zoom that a per-tile choice
+   * lands on two different levels, and then the same ground travels
+   * twice and meets itself as a resolution seam across the map.
+   */
+  GeoBitmap::TileData base_tile{};
+
+  GeoBitmap::TileData tile{};
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+  unsigned slot = 0;
 
   AllocatedPath path{nullptr};
+
+  /** did the finished tile hold any echo worth installing? */
+  bool drawn = false;
+
   std::exception_ptr completion_error;
 
   /**
@@ -61,11 +96,11 @@ public:
   void BeginShutdown() noexcept;
 
   /**
-   * Fetch the composite for the given area, unless one is already in
-   * flight.
+   * Fetch one display tile, unless a download is already in flight.
    */
-  void Start(const GeoBounds &_bounds,
-             unsigned _width, unsigned _height) noexcept;
+  void Start(std::string _url, const GeoBitmap::TileData &_base,
+             const GeoBitmap::TileData &_tile,
+             const BrokenDateTime &_frame_time, unsigned _slot) noexcept;
 
   /** Begin watching the age of the displayed frame. */
   void ScheduleAgeCheck() noexcept;
@@ -82,21 +117,39 @@ RadarDownloadGlue *GetRadarDownloadGlue() noexcept;
 namespace OPERA {
 
 /**
- * Request the composite for the area the map currently shows, and
- * install it when it arrives.
+ * Fetch and draw the block around the aircraft, and keep it filling.
+ *
+ * Safe to call as often as the map changes: it starts a download only
+ * when there is a tile missing and nothing already in flight.
  */
 void ActivatePageOverlay() noexcept;
 
 /**
- * Remove the radar overlay, but only if the map is still showing the
- * one we installed.
+ * Take the radar off the map, leaving alone any overlay somebody else
+ * installed.
  */
 void ClearMapOverlay() noexcept;
 
 /**
  * Leave the radar page: stop watching the frame's age and take it
  * off the map.
+ *
+ * Does nothing while the overlay is suspended for a pan.
  */
 void DeactivatePageOverlay() noexcept;
+
+/**
+ * Hold the radar on the map across a pan.
+ *
+ * Panning shows the fullscreen map, whose layout carries no overlay,
+ * so the page machinery deactivates the radar on the way in and would
+ * fetch the whole block again on the way out.  Between these two
+ * calls #DeactivatePageOverlay() is ignored and the tiles stay where
+ * they are.
+ */
+void SuspendForPan() noexcept;
+
+/** Let the radar be taken off the map again. */
+void ResumeAfterPan() noexcept;
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -8,6 +8,7 @@
 #include "net/AsyncTask.hpp"
 #include "system/Path.hpp"
 #include "ui/event/Notify.hpp"
+#include "ui/event/PeriodicTimer.hpp"
 
 #include <exception>
 
@@ -34,9 +35,17 @@ class RadarDownloadGlue final {
   AllocatedPath path{nullptr};
   std::exception_ptr completion_error;
 
+  /**
+   * Watches the age of the frame on the map while a radar page is
+   * open: it fetches a newer one as soon as one exists, and takes the
+   * picture down once it is older than OPERA::MAX_AGE_MINUTES.
+   */
+  UI::PeriodicTimer age_timer{[this]{ OnAgeTimer(); }};
+
   Co::InvokeTask RunDownload();
   void OnCompletion(std::exception_ptr error) noexcept;
   void OnCompleteNotify() noexcept;
+  void OnAgeTimer() noexcept;
 
 public:
   explicit RadarDownloadGlue(CurlGlobal &_curl) noexcept;
@@ -57,6 +66,12 @@ public:
    */
   void Start(const GeoBounds &_bounds,
              unsigned _width, unsigned _height) noexcept;
+
+  /** Begin watching the age of the displayed frame. */
+  void ScheduleAgeCheck() noexcept;
+
+  /** Stop watching, because no page shows the radar any more. */
+  void CancelAgeCheck() noexcept;
 };
 
 /**
@@ -77,5 +92,11 @@ void ActivatePageOverlay() noexcept;
  * one we installed.
  */
 void ClearMapOverlay() noexcept;
+
+/**
+ * Leave the radar page: stop watching the frame's age and take it
+ * off the map.
+ */
+void DeactivatePageOverlay() noexcept;
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/GeoBounds.hpp"
+#include "co/InvokeTask.hxx"
+#include "net/AsyncTask.hpp"
+#include "system/Path.hpp"
+#include "ui/event/Notify.hpp"
+
+#include <exception>
+
+class CurlGlobal;
+
+/**
+ * Runs OPERA::DownloadRadar() on the network #EventLoop and installs
+ * the finished image as the map overlay from the UI thread.
+ *
+ * Unlike the Weather dialog, which downloads inside a modal progress
+ * dialog, a page overlay has to appear without the pilot waiting for
+ * it, so the fetch runs in the background and the map gains the image
+ * whenever it is ready.
+ */
+class RadarDownloadGlue final {
+  CurlGlobal &curl;
+  Net::AsyncTask task;
+  UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
+
+  /** the area the running download was requested for */
+  GeoBounds bounds = GeoBounds::Invalid();
+  unsigned width = 0, height = 0;
+
+  AllocatedPath path{nullptr};
+  std::exception_ptr completion_error;
+
+  Co::InvokeTask RunDownload();
+  void OnCompletion(std::exception_ptr error) noexcept;
+  void OnCompleteNotify() noexcept;
+
+public:
+  explicit RadarDownloadGlue(CurlGlobal &_curl) noexcept;
+
+  ~RadarDownloadGlue() noexcept { BeginShutdown(); }
+
+  RadarDownloadGlue(const RadarDownloadGlue &) = delete;
+  RadarDownloadGlue &operator=(const RadarDownloadGlue &) = delete;
+
+  [[nodiscard]]
+  bool IsRunning() const noexcept { return task.IsRunning(); }
+
+  void BeginShutdown() noexcept;
+
+  /**
+   * Fetch the composite for the given area, unless one is already in
+   * flight.
+   */
+  void Start(const GeoBounds &_bounds,
+             unsigned _width, unsigned _height) noexcept;
+};
+
+/**
+ * The shared #RadarDownloadGlue from #net_components (UI thread only).
+ */
+RadarDownloadGlue *GetRadarDownloadGlue() noexcept;
+
+namespace OPERA {
+
+/**
+ * Request the composite for the area the map currently shows, and
+ * install it when it arrives.
+ */
+void ActivatePageOverlay() noexcept;
+
+/**
+ * Remove the radar overlay, but only if the map is still showing the
+ * one we installed.
+ */
+void ClearMapOverlay() noexcept;
+
+} // namespace OPERA

--- a/src/net/http/CoGetRange.cpp
+++ b/src/net/http/CoGetRange.cpp
@@ -7,7 +7,7 @@
 
 #include <fmt/format.h>
 
-#include <cassert>
+#include <limits>
 #include <stdexcept>
 
 namespace Net {
@@ -16,8 +16,16 @@ Co::Task<std::string>
 CoGetRange(CurlGlobal &curl, const char *url,
            uint_least64_t offset, std::size_t length)
 {
-  assert(url != nullptr);
-  assert(length > 0);
+  /* checked rather than asserted: this is a public entry point, and
+     an assertion would be compiled out of the builds that ship */
+  if (url == nullptr || *url == '\0')
+    throw std::invalid_argument("No URL to fetch");
+
+  if (length == 0)
+    throw std::invalid_argument("Empty byte range");
+
+  if (offset > std::numeric_limits<uint_least64_t>::max() - (length - 1))
+    throw std::invalid_argument("Byte range out of bounds");
 
   CurlEasy easy{url};
   Curl::Setup(easy);

--- a/src/net/http/CoGetRange.cpp
+++ b/src/net/http/CoGetRange.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "CoGetRange.hpp"
+#include "lib/curl/CoRequest.hxx"
+#include "lib/curl/Setup.hxx"
+
+#include <fmt/format.h>
+
+#include <cassert>
+#include <stdexcept>
+
+namespace Net {
+
+Co::Task<std::string>
+CoGetRange(CurlGlobal &curl, const char *url,
+           uint_least64_t offset, std::size_t length)
+{
+  assert(url != nullptr);
+  assert(length > 0);
+
+  CurlEasy easy{url};
+  Curl::Setup(easy);
+  easy.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+  easy.SetOption(CURLOPT_MAXREDIRS, 10L);
+  easy.SetFailOnError();
+  easy.SetTimeout(30);
+
+  const auto range = fmt::format("{}-{}", offset, offset + length - 1);
+  easy.SetOption(CURLOPT_RANGE, range.c_str());
+
+  /* a server that does not understand the range would answer with the
+     whole file; refuse it up front rather than let one tile pull
+     megabytes over a flight connection */
+  easy.SetOption(CURLOPT_MAXFILESIZE_LARGE, curl_off_t(length + 4096));
+
+  auto response = co_await Curl::CoRequest(curl, std::move(easy));
+
+  /* 206 is the only answer that means "here is the part you asked
+     for"; a 200 is the whole file and must not be mistaken for it */
+  if (response.status != 206)
+    throw std::runtime_error("The server does not serve byte ranges");
+
+  if (response.body.size() > length)
+    throw std::runtime_error("The server sent more than the range");
+
+  co_return std::move(response.body);
+}
+
+} // namespace Net

--- a/src/net/http/CoGetRange.hpp
+++ b/src/net/http/CoGetRange.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/Task.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+class CurlGlobal;
+
+namespace Net {
+
+/**
+ * Download a byte range of a URL into memory.
+ *
+ * This exists for files that are far larger than the part we need --
+ * a cloud-optimized GeoTIFF, say, where the tile under the aircraft
+ * is a few kilobytes of a multi-megabyte composite.  Nothing is
+ * written to disk, because a range is small by construction and the
+ * caller wants it in memory anyway.
+ *
+ * Throws on error, including when the server ignores the range and
+ * offers the whole file instead.
+ *
+ * @param offset the first byte to fetch
+ * @param length how many bytes, which must not be zero
+ */
+Co::Task<std::string>
+CoGetRange(CurlGlobal &curl, const char *url,
+           uint_least64_t offset, std::size_t length);
+
+} // namespace Net

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -23,46 +23,6 @@
 
 using namespace GeoBitmap;
 
-static uint32_t
-LonToTileX(double lon, unsigned zoom) noexcept
-{
-  return uint32_t(std::floor((lon + 180.0) / 360.0 *
-                             (uint32_t{1} << zoom)));
-}
-
-static uint32_t
-LatToTileY(double lat, unsigned zoom) noexcept
-{
-  const double latitude_radians = lat * M_PI / 180.0;
-  return uint32_t(std::floor(
-    (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
-    (uint32_t{1} << zoom)));
-}
-
-static double
-TileXToLon(uint32_t x, unsigned zoom) noexcept
-{
-  return x / double(uint32_t{1} << zoom) * 360.0 - 180.0;
-}
-
-static double
-TileYToLat(uint32_t y, unsigned zoom) noexcept
-{
-  const double n = M_PI - 2.0 * M_PI * y /
-    double(uint32_t{1} << zoom);
-  return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
-}
-
-TileData
-GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
-{
-  return {
-    zoom,
-    LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
-    LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
-  };
-}
-
 TileData
 GeoBitmap::GetTile(const MapWindowProjection &projection,
                    uint16_t zoom_min, uint16_t zoom_max) noexcept
@@ -74,30 +34,6 @@ GeoBitmap::GetTile(const MapWindowProjection &projection,
   const auto zoom = (uint16_t)std::clamp((int)std::floor(std::log2(ratio)) + 1,
                                          (int)zoom_min, (int)zoom_max);
   return GetTile(projection.GetScreenBounds(), zoom);
-}
-
-GeoQuadrilateral
-GeoBitmap::GetGeoQuadrilateral(const TileData &tile) noexcept
-{
-  GeoQuadrilateral bounds;
-
-  bounds.top_left.longitude = Angle::Degrees(TileXToLon(tile.x, tile.zoom));
-  bounds.top_left.latitude = Angle::Degrees(TileYToLat(tile.y, tile.zoom));
-  bounds.bottom_left.longitude = bounds.top_left.longitude;
-  bounds.bottom_left.latitude = Angle::Degrees(TileYToLat(tile.y + 1, tile.zoom));
-
-  bounds.top_right.longitude = Angle::Degrees(TileXToLon(tile.x + 1, tile.zoom));
-  bounds.top_right.latitude = bounds.top_left.latitude;
-  bounds.bottom_right.longitude = bounds.top_right.longitude;
-  bounds.bottom_right.latitude = bounds.bottom_left.latitude;
-
-  return bounds;
-}
-
-GeoBounds
-GeoBitmap::GetBounds(const TileData &tile) noexcept
-{
-  return GetGeoQuadrilateral(tile).GetBounds();
 }
 
 static GeoQuadrilateral

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+/*
+ * The slippy map tile geometry, kept apart from GeoBitmap.cpp so that
+ * it links without a canvas: the tile grid is useful to code that
+ * plans downloads long before there is anything to draw, and that
+ * code should not have to pull in OpenGL to ask where a tile is.
+ */
+
+#include "GeoBitmap.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/Quadrilateral.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace GeoBitmap;
+
+static uint32_t
+LonToTileX(double lon, unsigned zoom) noexcept
+{
+  return uint32_t(std::floor((lon + 180.0) / 360.0 *
+                             (uint32_t{1} << zoom)));
+}
+
+static uint32_t
+LatToTileY(double lat, unsigned zoom) noexcept
+{
+  const double latitude_radians = lat * M_PI / 180.0;
+  return uint32_t(std::floor(
+    (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
+    (uint32_t{1} << zoom)));
+}
+
+static double
+TileXToLon(uint32_t x, unsigned zoom) noexcept
+{
+  return x / double(uint32_t{1} << zoom) * 360.0 - 180.0;
+}
+
+static double
+TileYToLat(uint32_t y, unsigned zoom) noexcept
+{
+  const double n = M_PI - 2.0 * M_PI * y /
+    double(uint32_t{1} << zoom);
+  return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
+}
+
+TileData
+GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
+{
+  return {
+    zoom,
+    LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
+    LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
+  };
+}
+
+GeoQuadrilateral
+GeoBitmap::GetGeoQuadrilateral(const TileData &tile) noexcept
+{
+  GeoQuadrilateral bounds;
+
+  bounds.top_left.longitude = Angle::Degrees(TileXToLon(tile.x, tile.zoom));
+  bounds.top_left.latitude = Angle::Degrees(TileYToLat(tile.y, tile.zoom));
+  bounds.bottom_left.longitude = bounds.top_left.longitude;
+  bounds.bottom_left.latitude = Angle::Degrees(TileYToLat(tile.y + 1, tile.zoom));
+
+  bounds.top_right.longitude = Angle::Degrees(TileXToLon(tile.x + 1, tile.zoom));
+  bounds.top_right.latitude = bounds.top_left.latitude;
+  bounds.bottom_right.longitude = bounds.top_right.longitude;
+  bounds.bottom_right.latitude = bounds.bottom_left.latitude;
+
+  return bounds;
+}
+
+GeoBounds
+GeoBitmap::GetBounds(const TileData &tile) noexcept
+{
+  return GetGeoQuadrilateral(tile).GetBounds();
+}

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -27,10 +27,20 @@ LonToTileX(double lon, unsigned zoom) noexcept
 static uint32_t
 LatToTileY(double lat, unsigned zoom) noexcept
 {
-  const double latitude_radians = lat * M_PI / 180.0;
-  return uint32_t(std::floor(
+  /* the grid is only defined between the Web Mercator cut-offs, where
+     the projection runs to infinity; beyond them tan() explodes and
+     the cast below would be undefined.  A wild fix must yield an edge
+     tile, not chaos. */
+  constexpr double MERCATOR_LIMIT = 85.05112878;
+  const double latitude_radians =
+    std::clamp(lat, -MERCATOR_LIMIT, MERCATOR_LIMIT) * M_PI / 180.0;
+
+  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
+  const double y = std::floor(
     (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
-    (uint32_t{1} << zoom)));
+    tiles_per_axis);
+
+  return uint32_t(std::clamp(y, 0.0, double(tiles_per_axis - 1)));
 }
 
 static double

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -20,8 +20,19 @@ using namespace GeoBitmap;
 static uint32_t
 LonToTileX(double lon, unsigned zoom) noexcept
 {
-  return uint32_t(std::floor((lon + 180.0) / 360.0 *
-                             (uint32_t{1} << zoom)));
+  /* longitude wraps rather than running out, but a caller can still
+     hand us one outside the grid -- exactly 180 lands one tile past
+     the last, and a wild GPS fix lands anywhere -- and the cast of an
+     out-of-range double to uint32_t is undefined.  Wrap into the
+     grid, which is what the projection means anyway. */
+  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
+  const double x = std::floor((lon + 180.0) / 360.0 * tiles_per_axis);
+  if (!(x >= 0) || !(x < double(tiles_per_axis))) {
+    const double wrapped = std::fmod(x, double(tiles_per_axis));
+    return uint32_t(wrapped < 0 ? wrapped + tiles_per_axis : wrapped);
+  }
+
+  return uint32_t(x);
 }
 
 static uint32_t

--- a/test/src/PageOverlayTitleStub.cpp
+++ b/test/src/PageOverlayTitleStub.cpp
@@ -50,6 +50,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     }
     break;
 
+  case PageLayout::Overlay::RADAR:
+    builder.Append(", ");
+    builder.Append(_("Radar"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -2,14 +2,163 @@
 // Copyright The XCSoar Project
 
 #include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "TestUtil.hpp"
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <vector>
 
 #include <string.h>
+
+/**
+ * Assembles a classic little endian TIFF header, so that the
+ * directory reader can be exercised without the network and without a
+ * five megabyte fixture in the tree.
+ */
+class HeaderBuilder {
+  std::vector<uint8_t> data;
+
+public:
+  HeaderBuilder() {
+    data = {'I', 'I', 42, 0, 0, 0, 0, 0};
+  }
+
+  std::size_t Size() const noexcept { return data.size(); }
+
+  void PutU16(std::size_t at, uint16_t value) noexcept {
+    data[at] = uint8_t(value);
+    data[at + 1] = uint8_t(value >> 8);
+  }
+
+  void PutU32(std::size_t at, uint32_t value) noexcept {
+    for (unsigned i = 0; i < 4; ++i)
+      data[at + i] = uint8_t(value >> (8 * i));
+  }
+
+  std::size_t AppendU32Array(const std::vector<uint32_t> &values) {
+    const auto at = data.size();
+    for (const auto value : values) {
+      data.resize(data.size() + 4);
+      PutU32(data.size() - 4, value);
+    }
+
+    return at;
+  }
+
+  std::size_t AppendDoubles(const std::vector<double> &values) {
+    const auto at = data.size();
+    for (const auto value : values) {
+      uint64_t bits;
+      std::memcpy(&bits, &value, sizeof(bits));
+      data.resize(data.size() + 8);
+      for (unsigned i = 0; i < 8; ++i)
+        data[data.size() - 8 + i] = uint8_t(bits >> (8 * i));
+    }
+
+    return at;
+  }
+
+  /** @return the offset the directory was written at */
+  std::size_t AppendDirectory(const std::vector<std::array<uint32_t, 4>> &tags) {
+    const auto at = data.size();
+    data.resize(at + 2 + tags.size() * 12 + 4, 0);
+    PutU16(at, uint16_t(tags.size()));
+
+    std::size_t e = at + 2;
+    for (const auto &tag : tags) {
+      PutU16(e, uint16_t(tag[0]));
+      PutU16(e + 2, uint16_t(tag[1]));
+      PutU32(e + 4, tag[2]);
+      PutU32(e + 8, tag[3]);
+      e += 12;
+    }
+
+    return at;
+  }
+
+  void SetFirstDirectory(uint32_t at) noexcept { PutU32(4, at); }
+
+  void SetNextDirectory(std::size_t directory, uint32_t next) noexcept {
+    const auto n = uint16_t(data[directory] | (data[directory + 1] << 8));
+    PutU32(directory + 2 + std::size_t(n) * 12, next);
+  }
+
+  std::span<const std::byte> Get() const noexcept {
+    return std::as_bytes(std::span{data});
+  }
+};
+
+/* the tag numbers the reader looks for */
+static constexpr uint32_t TAG_WIDTH = 256, TAG_HEIGHT = 257;
+static constexpr uint32_t TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+static constexpr uint32_t TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+static constexpr uint32_t TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+static constexpr uint32_t TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+static constexpr uint32_t TYPE_SHORT = 3, TYPE_LONG = 4, TYPE_DOUBLE = 12;
+
+/**
+ * A two level composite whose full resolution grid is 1024 by 1024 in
+ * 512 pixel tiles, arranged so that the projection centre falls in the
+ * middle of it.
+ */
+static HeaderBuilder
+MakeComposite()
+{
+  /* the grid origin, chosen so that 10E 55N lands at column 768, row
+     768: the middle of the last of the four tiles, well clear of the
+     boundaries so that the test asks about tile arithmetic rather
+     than about which side of an edge a rounding error falls on */
+  static constexpr double ORIGIN_X = 1950000 - 768 * 1000.0;
+  static constexpr double ORIGIN_Y = -2100000 + 768 * 1000.0;
+
+  HeaderBuilder b;
+
+  const auto offsets0 = b.AppendU32Array({4096, 8192, 12288, 16384});
+  const auto lengths0 = b.AppendU32Array({100, 200, 300, 400});
+  const auto offsets1 = b.AppendU32Array({20480});
+  const auto lengths1 = b.AppendU32Array({500});
+  const auto scale = b.AppendDoubles({1000, 1000, 0});
+  const auto tiepoint = b.AppendDoubles({0, 0, 0, ORIGIN_X, ORIGIN_Y, 0});
+
+  const auto ifd0 = b.AppendDirectory({{
+    {TAG_WIDTH, TYPE_LONG, 1, 1024},
+    {TAG_HEIGHT, TYPE_LONG, 1, 1024},
+    {TAG_COMPRESSION, TYPE_SHORT, 1, 8},
+    {TAG_SAMPLES, TYPE_SHORT, 1, 2},
+    {TAG_TILE_WIDTH, TYPE_SHORT, 1, 512},
+    {TAG_TILE_HEIGHT, TYPE_SHORT, 1, 512},
+    {TAG_TILE_OFFSETS, TYPE_LONG, 4, uint32_t(offsets0)},
+    {TAG_TILE_LENGTHS, TYPE_LONG, 4, uint32_t(lengths0)},
+    {TAG_PIXEL_SCALE, TYPE_DOUBLE, 3, uint32_t(scale)},
+    {TAG_TIEPOINT, TYPE_DOUBLE, 6, uint32_t(tiepoint)},
+  }});
+
+  /* the overview carries no georeference of its own, exactly as the
+     real file's do; its scale has to follow from the size ratio */
+  const auto ifd1 = b.AppendDirectory({{
+    {TAG_WIDTH, TYPE_LONG, 1, 512},
+    {TAG_HEIGHT, TYPE_LONG, 1, 512},
+    {TAG_COMPRESSION, TYPE_SHORT, 1, 8},
+    {TAG_SAMPLES, TYPE_SHORT, 1, 2},
+    {TAG_TILE_WIDTH, TYPE_SHORT, 1, 512},
+    {TAG_TILE_HEIGHT, TYPE_SHORT, 1, 512},
+    {TAG_TILE_OFFSETS, TYPE_LONG, 1, uint32_t(offsets1)},
+    {TAG_TILE_LENGTHS, TYPE_LONG, 1, uint32_t(lengths1)},
+  }});
+
+  b.SetFirstDirectory(uint32_t(ifd0));
+  b.SetNextDirectory(ifd0, uint32_t(ifd1));
+
+  return b;
+}
 
 [[gnu::pure]]
 static bool
@@ -20,7 +169,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(28);
+  plan_tests(77);
 
   /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
      which rounds down to the 12:00 composite */
@@ -85,10 +234,23 @@ int main()
   ok1(OPERA::ClassifyReflectivity(18) < 0);
 
   /* and neither is "no radar here", which the composite marks with a
-     large negative number.  Its other marker, a NaN, cannot be tested
-     here: we are built with -ffast-math, under which a literal NaN is
-     folded away before it ever reaches the function. */
+     large negative number */
   ok1(OPERA::ClassifyReflectivity(-9999000) < 0);
+
+  /* its other marker is a NaN.  A literal one would be folded away
+     under -ffast-math before it ever reached the function, so build
+     it from the bit pattern -- which is what IsNotANumber() inspects
+     anyway, for the same reason. */
+  const uint64_t nan_bits = 0x7ff8000000000000ULL;
+  double quiet_nan;
+  std::memcpy(&quiet_nan, &nan_bits, sizeof(quiet_nan));
+
+  ok1(OPERA::IsNotANumber(quiet_nan));
+  ok1(OPERA::ClassifyReflectivity(quiet_nan) < 0);
+
+  /* and an ordinary number must not be mistaken for one */
+  ok1(!OPERA::IsNotANumber(30.0));
+  ok1(!OPERA::IsNotANumber(-9999000.0));
 
   /* and the classes climb from there */
   ok1(OPERA::ClassifyReflectivity(19) == 0);
@@ -117,6 +279,187 @@ int main()
 
   ok1(distinct == OPERA::N_CLASSES);
   ok1(previous == int(OPERA::N_CLASSES) - 1);
+
+  /* --- the display grid ------------------------------------------ */
+
+  const GeoPoint augsburg{Angle::Degrees(10.9), Angle::Degrees(48.35)};
+
+  /* the grid only exists between the two zoom bounds */
+  ok1(!OPERA::GetAircraftTile(augsburg, OPERA::MIN_TILE_ZOOM - 1).IsValid());
+  ok1(!OPERA::GetAircraftTile(augsburg, OPERA::MAX_TILE_ZOOM + 1).IsValid());
+  ok1(!OPERA::GetAircraftTile(GeoPoint::Invalid(),
+                              OPERA::MAX_TILE_ZOOM).IsValid());
+
+  const auto base = OPERA::GetAircraftTile(augsburg, 9);
+  ok1(base.IsValid());
+  ok1(base.zoom == 9);
+
+  /* the tile the aircraft is in must be the one that contains it */
+  ok1(GeoBitmap::GetBounds(base).IsInside(augsburg));
+
+  const auto block = OPERA::CollectTiles(base);
+  ok1(block.size() == OPERA::TILE_COUNT);
+
+  /* nearest first: the aircraft's own tile leads, and the four tiles
+     sharing an edge with it come before the four diagonal ones */
+  ok1(OPERA::IsSameTile(block.front(), base));
+
+  const auto ring = [&base](const GeoBitmap::TileData &t) {
+    const int dx = int(t.x) - int(base.x), dy = int(t.y) - int(base.y);
+    return dx * dx + dy * dy;
+  };
+
+  bool ordered = true;
+  for (std::size_t i = 1; i < block.size(); ++i)
+    if (ring(block[i]) < ring(block[i - 1]))
+      ordered = false;
+
+  ok1(ordered);
+  ok1(ring(block[1]) == 1 && ring(block[4]) == 1);
+  ok1(ring(block[5]) == 2);
+
+  /* every tile of the block is distinct, or a slot would be spent
+     twice on the same picture */
+  auto sorted = block;
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto &a, const auto &b){
+              return a.x != b.x ? a.x < b.x : a.y < b.y;
+            });
+  ok1(std::adjacent_find(sorted.begin(), sorted.end(),
+                         OPERA::IsSameTile) == sorted.end());
+
+  /* an invalid centre yields no block at all */
+  ok1(OPERA::CollectTiles({}).empty());
+
+  /* a coarser tile covers more ground per pixel */
+  const auto fine = GeoBitmap::GetBounds(OPERA::GetAircraftTile(augsburg, 10));
+  const auto coarse = GeoBitmap::GetBounds(OPERA::GetAircraftTile(augsburg, 8));
+  const auto fine_scale = OPERA::TileMetresPerPixel(fine, OPERA::TILE_PIXELS);
+  const auto coarse_scale = OPERA::TileMetresPerPixel(coarse,
+                                                      OPERA::TILE_PIXELS);
+  ok1(fine_scale > 0);
+  ok1(coarse_scale > 3 * fine_scale);
+  ok1(OPERA::TileMetresPerPixel(fine, 0) == 0);
+
+  /* --- the raster projector -------------------------------------- */
+
+  /* it has to agree with Project() to the last bit, being nothing but
+     the same arithmetic with the trigonometry hoisted out */
+  static constexpr unsigned WIDTH = 8;
+  const double left = 8.0, right = 12.0, latitude = 50.0;
+  const OPERA::RasterProjector projector{left, right, WIDTH};
+  ok1(projector.GetWidth() == WIDTH);
+
+  DoublePoint2D row[WIDTH];
+  projector.ProjectRow(latitude, row);
+
+  bool agrees = true;
+  for (unsigned x = 0; x < WIDTH; ++x) {
+    const double longitude = left + (right - left) * (x + 0.5) / WIDTH;
+    const auto expected = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
+                                                  Angle::Degrees(latitude)});
+    if (std::fabs(row[x].x - expected.x) > 1e-6 ||
+        std::fabs(row[x].y - expected.y) > 1e-6)
+      agrees = false;
+  }
+
+  ok1(agrees);
+
+  /* --- the composite directory ----------------------------------- */
+
+  const auto composite_header = MakeComposite();
+  const auto index = OPERA::ParseIndex(composite_header.Get());
+
+  ok1(index.IsValid());
+  ok1(index.levels.size() == 2);
+  ok1(index.levels[0].width == 1024 && index.levels[0].height == 1024);
+  ok1(index.levels[0].TilesAcross() == 2 && index.levels[0].TilesDown() == 2);
+  ok1(index.levels[0].tile_offset.size() == 4);
+  ok1(index.levels[0].tile_length[3] == 400);
+  ok1(equals(index.levels[0].scale, 1000));
+
+  /* the overview has no georeference of its own; it must inherit the
+     origin and take its scale from the size ratio, or every pixel of
+     it would land in the wrong place */
+  ok1(equals(index.levels[1].scale, 2000));
+  ok1(equals(index.levels[1].origin_x, index.levels[0].origin_x));
+  ok1(equals(index.levels[1].origin_y, index.levels[0].origin_y));
+  ok1(index.levels[1].IsUsable());
+
+  /* garbage must be refused rather than parsed into nonsense */
+  const std::byte truncated[4]{};
+  try {
+    OPERA::ParseIndex(std::span{truncated});
+    ok1(false);
+  } catch (...) {
+    ok1(true);
+  }
+
+  const std::byte not_tiff[16]{std::byte{'X'}, std::byte{'Y'}};
+  try {
+    OPERA::ParseIndex(std::span{not_tiff});
+    ok1(false);
+  } catch (...) {
+    ok1(true);
+  }
+
+  /* a directory that reaches past what was fetched must be refused
+     rather than read off the end.  The offsets in the file are 32 bit
+     and unchecked arithmetic on them wraps on a 32 bit target, which
+     is where this guard earns its keep. */
+  const auto full = MakeComposite();
+  const auto whole = full.Get();
+  for (std::size_t cut : {std::size_t{8}, whole.size() / 2,
+                          whole.size() - 4}) {
+    try {
+      OPERA::ParseIndex(whole.first(cut));
+      ok1(false);
+    } catch (...) {
+      ok1(true);
+    }
+  }
+
+  /* --- level selection ------------------------------------------- */
+
+  /* the coarsest level that still resolves what was asked for, to
+     within the oversampling tolerance */
+  ok1(OPERA::SelectLevel(index, 3000) == 1);
+  ok1(OPERA::SelectLevel(index, 1500) == 1);
+
+  /* the tolerance has to bite exactly at its own boundary, or the
+     rule would be one the measurements do not describe: level 1 is
+     2000 m, so it may serve a request down to 1000 m and no finer */
+  ok1(OPERA::SelectLevel(index, 2000 / OPERA::LEVEL_TOLERANCE) == 1);
+  ok1(OPERA::SelectLevel(index, 2000 / OPERA::LEVEL_TOLERANCE - 1) == 0);
+
+  /* asking for more detail than the file holds must not fall off the
+     bottom; the finest level is the best that can be done */
+  ok1(OPERA::SelectLevel(index, 10) == 0);
+
+  /* --- which tiles an area needs --------------------------------- */
+
+  /* a small area around the projection centre falls in the last of
+     the four tiles, the one the grid was laid out to put it in */
+  const GeoBounds centre_area{GeoPoint{Angle::Degrees(10),
+                                       Angle::Degrees(55)}};
+  const auto needed = OPERA::CoveringSourceTiles(index.levels[0],
+                                                 centre_area);
+  ok1(needed.size() == 1);
+  ok1(needed.front() == 3);
+
+  /* the overview covers the same ground in one tile */
+  const auto needed_coarse = OPERA::CoveringSourceTiles(index.levels[1],
+                                                        centre_area);
+  ok1(needed_coarse.size() == 1);
+  ok1(needed_coarse.front() == 0);
+
+  /* an area the composite does not reach asks for nothing at all,
+     rather than for a tile that is not there */
+  const GeoBounds far_away{GeoPoint{Angle::Degrees(-140),
+                                    Angle::Degrees(-40)}};
+  ok1(OPERA::CoveringSourceTiles(index.levels[0], far_away).empty());
+  ok1(OPERA::CoveringSourceTiles(index.levels[0],
+                                 GeoBounds::Invalid()).empty());
 
   return exit_status();
 }

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -6,6 +6,7 @@
 #include "time/BrokenDateTime.hpp"
 #include "TestUtil.hpp"
 
+#include <chrono>
 #include <cmath>
 
 #include <string.h>
@@ -19,26 +20,43 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(22);
+  plan_tests(28);
 
-  /* 12:07 rounds down to the 12:00 composite: ten minutes of
-     dissemination margin, then down to the five minute grid */
+  /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
+     which rounds down to the 12:00 composite */
   const BrokenDateTime noon{BrokenDate{2026, 8, 28}, BrokenTime{12, 7, 30}};
   const auto url = OPERA::MakeCompositeURL(noon);
 
   ok1(Contains(url, "https://s3.waw3-1.cloudferro.com/openradar-24h/"));
   ok1(Contains(url, "/2026/08/28/OPERA/COMP/"));
-  ok1(Contains(url, "OPERA@20260828T1155@0@DBZH.tiff"));
+  ok1(Contains(url, "OPERA@20260828T1200@0@DBZH.tiff"));
 
   /* the margin may cross midnight, and then the date has to follow */
   const BrokenDateTime after_midnight{BrokenDate{2026, 8, 28},
                                       BrokenTime{0, 3, 0}};
   const auto wrapped = OPERA::MakeCompositeURL(after_midnight);
   ok1(Contains(wrapped, "/2026/08/27/OPERA/COMP/"));
-  ok1(Contains(wrapped, "OPERA@20260827T2350@0@DBZH.tiff"));
+  ok1(Contains(wrapped, "OPERA@20260827T2355@0@DBZH.tiff"));
 
   /* without a clock we must not guess */
   ok1(OPERA::MakeCompositeURL(BrokenDateTime::Invalid()).empty());
+
+  /* CompositeTime() must name the very frame the URL points at, or
+     the age of the picture on the map would be computed against the
+     wrong instant */
+  const auto composite = OPERA::CompositeTime(noon);
+  ok1(composite.hour == 12 && composite.minute == 0);
+  ok1(composite.second == 0);
+  ok1(!OPERA::CompositeTime(BrokenDateTime::Invalid()).IsPlausible());
+
+  /* the frame we request is never newer than the margin and never
+     older than the margin plus one cadence step; the age limit has to
+     sit clear of that, or a frame would expire as it arrived */
+  const auto fresh_age = noon - composite;
+  ok1(fresh_age >= std::chrono::minutes{OPERA::LATENCY_MINUTES});
+  ok1(fresh_age < std::chrono::minutes{OPERA::LATENCY_MINUTES +
+                                       OPERA::CADENCE_MINUTES});
+  ok1(fresh_age < std::chrono::minutes{OPERA::MAX_AGE_MINUTES});
 
   /* the projection centre lands on the grid's false origin */
   const auto centre = OPERA::Project(GeoPoint{Angle::Degrees(10),

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -169,7 +169,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(77);
+  plan_tests(83);
 
   /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
      which rounds down to the 12:00 composite */
@@ -296,6 +296,22 @@ int main()
 
   /* the tile the aircraft is in must be the one that contains it */
   ok1(GeoBitmap::GetBounds(base).IsInside(augsburg));
+
+  /* the grid must survive a fix at its edges: longitude 180 lands one
+     tile past the last column and latitude past the Mercator cut-off
+     runs to infinity, and casting either out-of-range double to
+     uint32_t is undefined.  Both have to come back inside the grid. */
+  for (const double longitude : {180.0, -180.0, 179.9999999}) {
+    const auto edge = OPERA::GetAircraftTile(
+      GeoPoint{Angle::Degrees(longitude), Angle::Degrees(48.35)}, 9);
+    ok1(edge.IsValid() && edge.x < (uint32_t(1) << 9));
+  }
+
+  for (const double latitude : {89.9, -89.9, 85.05112878}) {
+    const auto edge = OPERA::GetAircraftTile(
+      GeoPoint{Angle::Degrees(10.9), Angle::Degrees(latitude)}, 9);
+    ok1(edge.IsValid() && edge.y < (uint32_t(1) << 9));
+  }
 
   const auto block = OPERA::CollectTiles(base);
   ok1(block.size() == OPERA::TILE_COUNT);

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "TestUtil.hpp"
+
+#include <cmath>
+
+#include <string.h>
+
+[[gnu::pure]]
+static bool
+Contains(const std::string &haystack, const char *needle) noexcept
+{
+  return haystack.find(needle) != std::string::npos;
+}
+
+int main()
+{
+  plan_tests(22);
+
+  /* 12:07 rounds down to the 12:00 composite: ten minutes of
+     dissemination margin, then down to the five minute grid */
+  const BrokenDateTime noon{BrokenDate{2026, 8, 28}, BrokenTime{12, 7, 30}};
+  const auto url = OPERA::MakeCompositeURL(noon);
+
+  ok1(Contains(url, "https://s3.waw3-1.cloudferro.com/openradar-24h/"));
+  ok1(Contains(url, "/2026/08/28/OPERA/COMP/"));
+  ok1(Contains(url, "OPERA@20260828T1155@0@DBZH.tiff"));
+
+  /* the margin may cross midnight, and then the date has to follow */
+  const BrokenDateTime after_midnight{BrokenDate{2026, 8, 28},
+                                      BrokenTime{0, 3, 0}};
+  const auto wrapped = OPERA::MakeCompositeURL(after_midnight);
+  ok1(Contains(wrapped, "/2026/08/27/OPERA/COMP/"));
+  ok1(Contains(wrapped, "OPERA@20260827T2350@0@DBZH.tiff"));
+
+  /* without a clock we must not guess */
+  ok1(OPERA::MakeCompositeURL(BrokenDateTime::Invalid()).empty());
+
+  /* the projection centre lands on the grid's false origin */
+  const auto centre = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                              Angle::Degrees(55)});
+  ok1(equals(centre.x, 1950000));
+  ok1(equals(centre.y, -2100000));
+
+  /* east is +x, north is +y */
+  const auto east = OPERA::Project(GeoPoint{Angle::Degrees(15),
+                                            Angle::Degrees(55)});
+  const auto north = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                             Angle::Degrees(60)});
+  ok1(east.x > centre.x);
+  ok1(std::fabs(east.y - centre.y) < std::fabs(east.x - centre.x));
+  ok1(north.y > centre.y);
+  ok1(std::fabs(north.x - centre.x) < std::fabs(north.y - centre.y));
+
+  /* one degree of latitude is roughly 111km in this projection */
+  const auto one_degree = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                                  Angle::Degrees(56)});
+  ok1(std::fabs(one_degree.y - centre.y) > 110000);
+  ok1(std::fabs(one_degree.y - centre.y) < 112000);
+
+  /* weak echo is not drawn at all; the reference product clips it */
+  ok1(OPERA::ClassifyReflectivity(0) < 0);
+  ok1(OPERA::ClassifyReflectivity(18) < 0);
+
+  /* and neither is "no radar here", which the composite marks with a
+     large negative number.  Its other marker, a NaN, cannot be tested
+     here: we are built with -ffast-math, under which a literal NaN is
+     folded away before it ever reaches the function. */
+  ok1(OPERA::ClassifyReflectivity(-9999000) < 0);
+
+  /* and the classes climb from there */
+  ok1(OPERA::ClassifyReflectivity(19) == 0);
+  ok1(OPERA::ClassifyReflectivity(40) > OPERA::ClassifyReflectivity(30));
+  ok1(OPERA::GetClassColour(999) ==
+      OPERA::GetClassColour(OPERA::N_CLASSES - 1));
+
+  /* every class must be reachable, and every colour therefore
+     reachable with it: two equal bounds would make the classifier step
+     over one and that colour would never be drawn.  Walk the whole
+     scale and check that it visits each index in turn, once. */
+  int previous = -1;
+  unsigned distinct = 0;
+  for (double dbz = 0; dbz < 80; dbz += 0.01) {
+    const int i = OPERA::ClassifyReflectivity(dbz);
+    if (i == previous)
+      continue;
+
+    /* it may never skip an index or go backwards */
+    if (i != previous + 1)
+      break;
+
+    previous = i;
+    ++distinct;
+  }
+
+  ok1(distinct == OPERA::N_CLASSES);
+  ok1(previous == int(OPERA::N_CLASSES) - 1);
+
+  return exit_status();
+}


### PR DESCRIPTION
Implements #174. Draws the European weather radar composite on the map.

**No account, no subscription.** EUMETNET publishes the OPERA composite under CC BY 4.0 without registration, covering **22.6°W–29.8°E and 35.9°N–70.6°N** with the contributions of nineteen national weather services. It is the only open radar source that spans the continent rather than a single country.

> [!NOTE]
> This replaces the earlier revision of this PR, which used the DWD's WMS. That covered Germany only — measured, not assumed: sampling it across Europe, France returns nothing but the no-data mask and Spain, Italy, Norway and Ireland return no pixels at all. OPERA covers the continent, resolves finer, and is equally free.

### What it does

* Fetches the newest composite; the filename is deterministic from the clock, so no API call is needed to find it. A new one appears every five minutes.
* The file is a **cloud-optimized GeoTIFF with a pyramid of overviews**, so the level matching the map scale is used rather than the full 1 km grid — a European overview is a single tile — and only the tiles covering the visible area are decoded.
* Reprojects from the composite's Lambert azimuthal equal-area grid into a north-up raster for the area the map shows. `MapOverlayBitmap` cannot describe that projection with four corners, so the image is handed over with the bounds it was requested for rather than a georeferenced file.
* Areas the radar network does not reach stay transparent rather than shaded, because the map underneath should remain visible.

### The colour scale

The classes are the ones the Deutscher Wetterdienst uses for its own radar images, so the picture reads the way German pilots are used to. The ramp itself is exact — `maps.dwd.de` serves its SLD style, and it agrees with the DWD's own imagery to within one bit per channel.

Mapping reflectivity onto those classes needed measurement rather than a Z-R relation, and that is the part worth reviewing:

* Class medians against the DWD's European product give **Z = 326 · R^1.42**. The exponent matches the DWD's documented `Z = 256 · R^1.42` ([Radarniederschlag, DWD 2015](https://www.dwd.de/DE/leistungen/radarniederschlag/rn_info/download_niederschlagsbestimmung.pdf?__blob=publicationFile&v=4)) essentially exactly.
* But no single relation fits the whole range. Comparing this composite against the DWD's own **WN** composite from `opendata.dwd.de` over Germany — 144 390 pixel pairs, both 1 km, same minute — the offset is **intensity-dependent**: +8.4 dB at 5–15 dBZ, +4.0 at 15–25, +2.8 at 25–35, +1.9 at 35–45. OPERA's `DBZH` is a maximum over all elevations; WN maxes over the flat precipitation scan. Where the near-ground echo is weak the column maximum picks up much stronger signal aloft.
* So the class boundaries were matched directly. Two independent routes — via WN plus the documented DWD relation, and via quantile-matching colour areas in the finished image — agree to **1–2.5 dB** across 0.4 to 10 mm/h.

The result, rendered into the same frame at the same minute as the DWD's own product, is in #174: same systems, same colours, same coverage boundary.

### Scope

One download per activation, for the area visible at that moment; `Update` fetches again. **No automatic refresh and no tile cache** — that design is sketched in #2997 and belongs in a follow-up, together with HTTP range requests so that only the needed tiles travel rather than the whole 4 MB file.

### Known limitation

The reprojected image is handed to `Bitmap::LoadFile()` as a PNG. That works on every target whose canvas is the `custom` one — Android, Linux, Kobo, macOS, iOS and the OpenGL Windows builds — but the plain GDI builds (`PC`, `WIN64`) load images through `GdiLoadImage()`, which reads BMP only, so the overlay would stay empty there. They compile; they just would not show it.

Writing BMP instead does not help: the `custom` loader handles TIFF, JPEG and PNG, not BMP. Doing it properly means handing over an `UncompressedImage` rather than a file, which is declared only for `!USE_GDI || ENABLE_OPENGL` — the same set. Happy to add that path and gate the entry on those targets if you would rather have it explicit than silent.

### Testing

`TestOperaRadar` covers the URL construction including the midnight rollover and the refusal to guess without a clock, the projection against its own false origin and the scale of a degree, and the classification including the clip of the weakest echoes.

I cannot build locally, so CI is the first real check on the C++. What was verified by hand against the live service: the composite's tiling, overview pyramid and range support; its GeoTIFF keys, from which the projection constants in the code are taken; and the calibration described above, end to end from range request through inflate to a rendered image.
