### PR TITLE
InfoBoxes: outline coloured values and units (rebase of #1966)

### DIFF
--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -9,6 +9,7 @@
 #include "Input/InputEvents.hpp"
 #include "Renderer/GlassRenderer.hpp"
 #include "Renderer/UnitSymbolRenderer.hpp"
+#include "Renderer/TextInBox.hpp"
 #include "Screen/Layout.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/event/KeyCode.hpp"
@@ -20,6 +21,25 @@
 
 /** timeout of infobox focus */
 static constexpr std::chrono::steady_clock::duration FOCUS_TIMEOUT_MAX = std::chrono::seconds(20);
+
+/**
+ * Pick an outline colour that separates coloured text from the given
+ * InfoBox background: a light outline on a dark background and the
+ * other way round.
+ */
+static Color
+GetOutlineColor(Color background_color) noexcept
+{
+#ifdef GREYSCALE
+  const unsigned luminosity = background_color.GetLuminosity();
+#else
+  const unsigned luminosity = (background_color.Red()
+                               + background_color.Green()
+                               + background_color.Blue()) / 3;
+#endif
+
+  return luminosity < 0x80 ? COLOR_WHITE : COLOR_BLACK;
+}
 
 InfoBoxWindow::InfoBoxWindow(ContainerWindow &parent, PixelRect rc,
                              unsigned border_flags,
@@ -99,12 +119,13 @@ InfoBoxWindow::PaintTitle(Canvas &canvas)
 }
 
 void
-InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_color)
+InfoBoxWindow::PaintValue(Canvas &canvas, Color background_color)
 {
   if (data.value.empty())
     return;
 
-  canvas.SetTextColor(look.GetValueColor(data.value_color));
+  const Color value_color = look.GetValueColor(data.value_color);
+  canvas.SetTextColor(value_color);
 
   canvas.Select(look.value_font);
   int ascent_height = look.value_font.GetAscentHeight();
@@ -122,7 +143,17 @@ InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_colo
   if (value_p.x < 0)
     value_p.x = 0;
 
-  canvas.TextAutoClipped(value_p, data.value);
+  /* the value colours are picked to convey a meaning, not for contrast
+     against the InfoBox background; outline the ones that are neither
+     black nor white, so they stay readable on either background */
+  const bool outline = value_color != COLOR_BLACK && value_color != COLOR_WHITE;
+  const Color outline_color = GetOutlineColor(background_color);
+
+  if (outline)
+    RenderShadowedText(canvas, data.value.c_str(), value_p,
+                       value_color, outline_color);
+  else
+    canvas.TextAutoClipped(value_p, data.value);
 
   if (unit_width != 0) {
     const int unit_height =
@@ -132,8 +163,13 @@ InfoBoxWindow::PaintValue(Canvas &canvas, [[maybe_unused]] Color background_colo
                                    ascent_height - unit_height);
 
     canvas.Select(look.unit_font);
-    UnitSymbolRenderer::Draw(canvas, unit_p,
-                             data.value_unit, look.unit_fraction_pen);
+    if (outline)
+      UnitSymbolRenderer::Draw(canvas, unit_p,
+                               data.value_unit, look.unit_fraction_pen,
+                               value_color, outline_color);
+    else
+      UnitSymbolRenderer::Draw(canvas, unit_p,
+                               data.value_unit, look.unit_fraction_pen);
   }
 }
 

--- a/src/Renderer/TextInBox.cpp
+++ b/src/Renderer/TextInBox.cpp
@@ -85,20 +85,30 @@ DrawTextHalo(Canvas &canvas, const char *text, const PixelPoint p,
 void
 RenderShadowedText(Canvas &canvas, const char *text,
                    PixelPoint p,
-                   bool inverted) noexcept
+                   Color text_color, Color outline_color) noexcept
 {
   if (text == nullptr || text[0] == '\0')
     return;
 
   canvas.SetBackgroundTransparent();
 
-  canvas.SetTextColor(inverted ? COLOR_BLACK : COLOR_WHITE);
+  canvas.SetTextColor(outline_color);
 
   /* at least 1px, or tiny fonts get no halo at all */
   DrawTextHalo(canvas, text, p, std::max(1u, canvas.GetFontHeight() / 12u));
 
-  canvas.SetTextColor(inverted ? COLOR_WHITE : COLOR_BLACK);
+  canvas.SetTextColor(text_color);
   canvas.DrawText(p, text);
+}
+
+void
+RenderShadowedText(Canvas &canvas, const char *text,
+                   PixelPoint p,
+                   bool inverted) noexcept
+{
+  RenderShadowedText(canvas, text, p,
+                     inverted ? COLOR_WHITE : COLOR_BLACK,
+                     inverted ? COLOR_BLACK : COLOR_WHITE);
 }
 
 // returns true if really wrote something

--- a/src/Renderer/TextInBox.hpp
+++ b/src/Renderer/TextInBox.hpp
@@ -9,11 +9,21 @@ struct PixelPoint;
 struct PixelSize;
 struct PixelRect;
 class Canvas;
+class Color;
 class LabelBlock;
 void
 RenderShadowedText(Canvas &canvas, const char *text,
                    PixelPoint p,
                    bool inverted) noexcept;
+
+/**
+ * Like above, but with an explicit pair of colours, for text that is
+ * neither black nor white.
+ */
+void
+RenderShadowedText(Canvas &canvas, const char *text,
+                   PixelPoint p,
+                   Color text_color, Color outline_color) noexcept;
 
 struct TextInBoxMode {
   enum Alignment : uint8_t {

--- a/src/Renderer/UnitSymbolRenderer.cpp
+++ b/src/Renderer/UnitSymbolRenderer.cpp
@@ -2,7 +2,9 @@
 // Copyright The XCSoar Project
 
 #include "UnitSymbolRenderer.hpp"
+#include "TextInBox.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/canvas/Color.hpp"
 #include "util/Macros.hpp"
 
 #include <algorithm>
@@ -109,10 +111,24 @@ UnitSymbolRenderer::GetAscentHeight(const Font &font, const Unit unit) noexcept
   return font.GetAscentHeight() + font.GetHeight();
 }
 
-void
-UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
-                         const Unit unit,
-                         const Pen &unit_fraction_pen) noexcept
+/**
+ * Draw one line of the symbol, with a halo when one was asked for.
+ */
+static void
+DrawSymbolLine(Canvas &canvas, const PixelPoint p, const char *text,
+               const Color *halo) noexcept
+{
+  if (halo == nullptr)
+    canvas.DrawText(p, text);
+  else
+    RenderShadowedText(canvas, text, p, halo[0], halo[1]);
+}
+
+static void
+DrawSymbol(Canvas &canvas, const PixelPoint pos,
+           const Unit unit,
+           const Pen &unit_fraction_pen,
+           const Color *halo) noexcept
 {
   assert((size_t)unit < ARRAY_SIZE(symbol_strings));
 
@@ -124,7 +140,7 @@ UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
   assert(strings.line2 != nullptr);
 
   if (!strings.line1) {
-    canvas.DrawText(pos, strings.line2);
+    DrawSymbolLine(canvas, pos, strings.line2, halo);
     return;
   }
 
@@ -138,10 +154,10 @@ UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
                       pos.At(size1.width, size1.height));
     }
 
-    canvas.DrawText(pos, strings.line1);
-    canvas.DrawText(pos.At((size1.width - size2.width) / 2,
-                           size1.height),
-                    strings.line2);
+    DrawSymbolLine(canvas, pos, strings.line1, halo);
+    DrawSymbolLine(canvas, pos.At((size1.width - size2.width) / 2,
+                                  size1.height),
+                   strings.line2, halo);
   } else {
     if (strings.is_fraction) {
       canvas.Select(unit_fraction_pen);
@@ -149,7 +165,27 @@ UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
                       pos.At(size2.width, size1.height));
     }
 
-    canvas.DrawText(pos.At((size2.width - size1.width) / 2, 0), strings.line1);
-    canvas.DrawText(pos.At(0, size1.height), strings.line2);
+    DrawSymbolLine(canvas, pos.At((size2.width - size1.width) / 2, 0),
+                   strings.line1, halo);
+    DrawSymbolLine(canvas, pos.At(0, size1.height), strings.line2, halo);
   }
+}
+
+void
+UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
+                         const Unit unit,
+                         const Pen &unit_fraction_pen) noexcept
+{
+  DrawSymbol(canvas, pos, unit, unit_fraction_pen, nullptr);
+}
+
+void
+UnitSymbolRenderer::Draw(Canvas &canvas, const PixelPoint pos,
+                         const Unit unit,
+                         const Pen &unit_fraction_pen,
+                         const Color text_color,
+                         const Color outline_color) noexcept
+{
+  const Color halo[]{text_color, outline_color};
+  DrawSymbol(canvas, pos, unit, unit_fraction_pen, halo);
 }

--- a/src/Renderer/UnitSymbolRenderer.hpp
+++ b/src/Renderer/UnitSymbolRenderer.hpp
@@ -8,6 +8,7 @@
 struct PixelPoint;
 struct PixelSize;
 class Canvas;
+class Color;
 class Font;
 class Pen;
 
@@ -24,4 +25,12 @@ namespace UnitSymbolRenderer
 
   void Draw(Canvas &canvas, PixelPoint pos, Unit unit,
             const Pen &unit_fraction_pen) noexcept;
+
+  /**
+   * Like above, but with a halo, so the symbol stays readable in the
+   * same cases the value next to it does.
+   */
+  void Draw(Canvas &canvas, PixelPoint pos, Unit unit,
+            const Pen &unit_fraction_pen,
+            Color text_color, Color outline_color) noexcept;
 }


### PR DESCRIPTION
Rebase of #1966 onto current master.

The InfoBox value colours are picked to convey a meaning, not for contrast against
the background, so an amber or yellow value can be hard to read — on a light
background in particular. This draws those values (and their unit symbol) with the
same halo that `RenderShadowedText()` already provides for map labels. Values that
are plain black or white keep the cheaper unshadowed path, so nothing changes for
the vast majority of InfoBoxes.

Credit for the idea and the original implementation goes to @lordfolken in #1966.
That branch no longer applies to master (the `TCHAR` → `char` migration, plus a fair
amount of reformatting), so this is a hand-port of its substance. Three deliberate
differences:

1. **The halo offset formula is master's, unchanged.** #1966 added a second formula,
   `h <= 16 ? h/20 : h/32`. Master's `DrawTextHalo()` already uses
   `std::max(1u, GetFontHeight() / 12u)` with `std::clamp(4 * offset, 8u, 16u)`
   copies distributed around a circle, which is both thicker at large font sizes and
   already DPI-aware. Adopting the PR's formula would make outlines *thinner* from
   24 px up, so there is nothing to port here.

2. **No `Red()` on a `Color` in portable code.** #1966's `GetOutlineColor()` calls
   `background_color.Red() + .Green() + .Blue()`, which does not compile under
   `GREYSCALE` — those accessors only exist in the non-`GREYSCALE` branch of
   `memory/Color.hpp`, so the Kobo target would have failed to build. The brightness
   test here is behind `#ifdef GREYSCALE` and uses `GetLuminosity()` there.

3. **No duplicated symbol-drawing code.** Rather than copying the body of
   `UnitSymbolRenderer::Draw()`, it is factored into a static
   `DrawSymbol(..., const Color *halo)` that both overloads share; `halo == nullptr`
   means "as before". This also picks up a line #1966 missed — the second symbol
   line in the `size1.width > size2.width` branch was still drawn without a halo.

Likewise, `RenderShadowedText(canvas, text, p, bool inverted)` now delegates to the
new colour-taking overload instead of carrying its own copy of the drawing code.

Checked with `-fsyntax-only` for the three touched translation units, with and
without `GREYSCALE`.

Supersedes #1966.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Readability**
  * Added contrasting outlines around colored values and unit symbols in information boxes.
  * Text and units now remain clear against both light and dark backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->