### PR TITLE
Weather/EUMETView: Draw Meteosat satellite imagery as overlay on the map

### DIFF
--- a/build/libhttp.mk
+++ b/build/libhttp.mk
@@ -11,6 +11,7 @@ LIBHTTP_SOURCES = \
 	$(SRC)/lib/curl/CoRequest.cxx \
 	$(SRC)/lib/curl/CoStreamRequest.cxx \
 	$(SRC)/net/http/CoDownloadToFile.cpp \
+	$(SRC)/net/http/CoGetRange.cpp \
 	$(SRC)/lib/curl/Global.cxx \
 	$(SRC)/net/http/Init.cpp
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -637,7 +637,8 @@ ifeq ($(OPENGL),y)
 ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Weather/MapOverlayWidget.cpp \
-	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp
+	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp \
+	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp
 endif
 endif
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -643,6 +643,7 @@ XCSOAR_SOURCES += \
 	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp \
 	$(SRC)/Weather/EUMETView/Satellite.cpp \
 	$(SRC)/Weather/EUMETView/SatelliteData.cpp \
+	$(SRC)/Weather/EUMETView/Enhance.cpp \
 	$(SRC)/Weather/EUMETView/SatellitePageOverlay.cpp
 endif
 endif

--- a/build/main.mk
+++ b/build/main.mk
@@ -631,6 +631,7 @@ ifeq ($(HAVE_WIN32),y)
 endif
 
 $(call SRC_TO_OBJ,$(SRC)/Dialogs/Inflate.cpp): CPPFLAGS += $(ZLIB_CPPFLAGS)
+$(call SRC_TO_OBJ,$(SRC)/Weather/OPERA/Radar.cpp): CPPFLAGS += $(ZLIB_CPPFLAGS)
 
 ifeq ($(OPENGL),y)
 ifeq ($(HAVE_HTTP),y)
@@ -736,6 +737,8 @@ XCSOAR_SOURCES += \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
+	$(SRC)/Weather/OPERA/Radar.cpp \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/METARParser.cpp \
 	$(SRC)/Weather/NOAAFormatter.cpp \

--- a/build/main.mk
+++ b/build/main.mk
@@ -640,7 +640,10 @@ XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp \
 	$(SRC)/Weather/OPERA/Radar.cpp \
 	$(SRC)/Weather/OPERA/RadarData.cpp \
-	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp
+	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp \
+	$(SRC)/Weather/EUMETView/Satellite.cpp \
+	$(SRC)/Weather/EUMETView/SatelliteData.cpp \
+	$(SRC)/Weather/EUMETView/SatellitePageOverlay.cpp
 endif
 endif
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -638,6 +638,8 @@ ifeq ($(HAVE_HTTP),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Dialogs/Weather/MapOverlayWidget.cpp \
 	$(SRC)/Dialogs/Weather/EdlSettingsWidget.cpp \
+	$(SRC)/Weather/OPERA/Radar.cpp \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/OPERA/RadarPageOverlay.cpp
 endif
 endif
@@ -738,8 +740,6 @@ XCSOAR_SOURCES += \
 	$(SRC)/Renderer/NOAAListRenderer.cpp \
 	$(SRC)/Weather/PCMet/Images.cpp \
 	$(SRC)/Weather/PCMet/Overlays.cpp \
-	$(SRC)/Weather/OPERA/Radar.cpp \
-	$(SRC)/Weather/OPERA/RadarData.cpp \
 	$(SRC)/Weather/NOAAGlue.cpp \
 	$(SRC)/Weather/METARParser.cpp \
 	$(SRC)/Weather/NOAAFormatter.cpp \

--- a/build/screen.mk
+++ b/build/screen.mk
@@ -38,6 +38,7 @@ SCREEN_CUSTOM_SOURCES = \
 	$(WINDOW_SRC_DIR)/custom/DoubleClick.cpp \
 	$(CANVAS_SRC_DIR)/FontSearch.cpp \
 	$(CANVAS_SRC_DIR)/custom/GeoBitmap.cpp \
+	$(CANVAS_SRC_DIR)/custom/GeoBitmapTile.cpp \
 	$(CANVAS_SRC_DIR)/custom/Pen.cpp \
 	$(CONTROL_SRC_DIR)/custom/LargeTextWindow.cpp \
 	$(CONTROL_SRC_DIR)/RichTextWindow.cpp \
@@ -246,6 +247,7 @@ SCREEN_SOURCES += \
 
 ifeq ($(OPENGL),y)
 SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/GeoBitmap.cpp
+SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/GeoBitmapTile.cpp
 ifeq ($(TIFF),y)
 SCREEN_SOURCES += $(CANVAS_SRC_DIR)/custom/LibTiff.cpp
 endif

--- a/build/test.mk
+++ b/build/test.mk
@@ -581,6 +581,7 @@ $(eval $(call link-program,TestAngle,TEST_ANGLE))
 
 TEST_OPERA_RADAR_SOURCES = \
 	$(SRC)/Weather/OPERA/RadarData.cpp \
+	$(SRC)/ui/canvas/custom/GeoBitmapTile.cpp \
 	$(TEST_SRC_DIR)/tap.c \
 	$(TEST_SRC_DIR)/TestOperaRadar.cpp
 TEST_OPERA_RADAR_DEPENDS = GEO MATH TIME FMT UTIL

--- a/build/test.mk
+++ b/build/test.mk
@@ -91,6 +91,7 @@ TEST_NAMES = \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
 	TestOperaRadar \
+	TestEumetviewSatellite \
 	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
@@ -586,6 +587,15 @@ TEST_OPERA_RADAR_SOURCES = \
 	$(TEST_SRC_DIR)/TestOperaRadar.cpp
 TEST_OPERA_RADAR_DEPENDS = GEO MATH TIME FMT UTIL
 $(eval $(call link-program,TestOperaRadar,TEST_OPERA_RADAR))
+
+TEST_EUMETVIEW_SATELLITE_SOURCES = \
+	$(SRC)/Weather/EUMETView/SatelliteData.cpp \
+	$(SRC)/ui/canvas/custom/GeoBitmapTile.cpp \
+	$(SRC)/Geo/Quadrilateral.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestEumetviewSatellite.cpp
+TEST_EUMETVIEW_SATELLITE_DEPENDS = GEO MATH TIME FMT UTIL
+$(eval $(call link-program,TestEumetviewSatellite,TEST_EUMETVIEW_SATELLITE))
 
 TEST_ARANGE_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -92,6 +92,7 @@ TEST_NAMES = \
 	TestRadixTree TestGeoBounds TestGeoClip \
 	TestOperaRadar \
 	TestEumetviewSatellite \
+	TestEumetviewEnhance \
 	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
@@ -596,6 +597,13 @@ TEST_EUMETVIEW_SATELLITE_SOURCES = \
 	$(TEST_SRC_DIR)/TestEumetviewSatellite.cpp
 TEST_EUMETVIEW_SATELLITE_DEPENDS = GEO MATH TIME FMT UTIL
 $(eval $(call link-program,TestEumetviewSatellite,TEST_EUMETVIEW_SATELLITE))
+
+TEST_EUMETVIEW_ENHANCE_SOURCES = \
+	$(SRC)/Weather/EUMETView/Enhance.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestEumetviewEnhance.cpp
+TEST_EUMETVIEW_ENHANCE_DEPENDS = MATH UTIL
+$(eval $(call link-program,TestEumetviewEnhance,TEST_EUMETVIEW_ENHANCE))
 
 TEST_ARANGE_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/build/test.mk
+++ b/build/test.mk
@@ -90,6 +90,7 @@ TEST_NAMES = \
 	TestValidity TestUTM \
 	TestAllocatedGrid \
 	TestRadixTree TestGeoBounds TestGeoClip \
+	TestOperaRadar \
 	TestLogger TestGRecord TestClimbAvCalc TestCirclingWind \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
@@ -577,6 +578,13 @@ TEST_ANGLE_SOURCES = \
 	$(TEST_SRC_DIR)/TestAngle.cpp
 TEST_ANGLE_DEPENDS = MATH
 $(eval $(call link-program,TestAngle,TEST_ANGLE))
+
+TEST_OPERA_RADAR_SOURCES = \
+	$(SRC)/Weather/OPERA/RadarData.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestOperaRadar.cpp
+TEST_OPERA_RADAR_DEPENDS = GEO MATH TIME FMT UTIL
+$(eval $(call link-program,TestOperaRadar,TEST_OPERA_RADAR))
 
 TEST_ARANGE_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -655,6 +655,38 @@ EDL imagery as a map overlay and does not expose additional model
 parameters beyond the forecast hour and the fixed isobar levels
 published by the EDL service.
 
+\section{Rain radar}\label{sec:rain-radar}
+
+XCSoar can draw the European weather radar composite on the map.  The
+data comes from EUMETNET's OPERA programme, is published under CC~BY
+4.0 and needs no account and no subscription.
+
+The layer is listed as \emph{Radar (EUMETNET OPERA)} on the
+``Overlay'' page of the
+\menulabelr{\bmenug{Info}\blink\bmenug{Weather}} \bmenug{Info} menu.
+Select it and press \bmenug{Use}; \bmenug{Disable} switches it off
+again.
+
+Selecting it downloads the newest composite and draws the part
+covering the area the map is currently showing, so pan and zoom the
+map first and select the layer afterwards.  \bmenug{Update} fetches a
+fresh image for the area now visible.  A new composite is published
+every five minutes.
+
+The colours are the classes the Deutscher Wetterdienst uses for its
+own radar images, from cyan for the weakest echo through green,
+yellow and orange to red and violet for the heaviest, so the picture
+reads the way German pilots are used to.  Areas the radar network
+does not reach are left transparent rather than shaded, because the
+map underneath should stay visible.
+
+Coverage reaches from the Azores to northern Scandinavia and from
+Iceland to eastern Europe; nineteen national weather services
+contribute.
+
+Note that this feature requires and uses an internet connection.  A
+composite is about four megabytes.
+
 \section{pc\_met, Deutscher Wetterdienst}\label{sec:pcmet}
 
 German weather service ``Deutscher Wetterdienst'' provides several

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -758,8 +758,9 @@ The products offered are:
 \end{description}
 
 The imagery is fetched as a block of five by five tiles centred on
-the aircraft, each about twenty-five kilometres across, so the block
-reaches at least fifty kilometres in every direction.
+the aircraft.  At the scales a glider is flown at, a tile is about
+twenty-five kilometres across, so the block reaches at least fifty
+kilometres in every direction.
 
 The tiles are requested \emph{nearest first}: the one the glider is
 over, then the ring around it, then the next ring outwards.  This is
@@ -779,7 +780,15 @@ The tiles sit on the standard map tile grid, so flying on does not
 throw the picture away: when the aircraft crosses into the next tile,
 the tiles the new block shares with the old one stay exactly where
 they are and only the ones that have come into range are fetched.
-Panning and zooming fetch nothing at all.
+Panning fetches nothing at all.
+
+Zooming the map \emph{in} fetches nothing either --- the satellite has
+no finer detail to give, so a closer look would only spend data
+enlarging what is already on the screen.  Zooming \emph{out} past what
+the block covers does move it to a coarser grid, so that the imagery
+keeps covering the map instead of shrinking to the middle of it.  Each
+step is a halving, so an ordinary change of scale does not move it,
+and the coarsest grid spans a couple of thousand kilometres.
 
 A frame is not on the server the moment it is taken; the delay runs
 from about thirteen minutes on the rapid scan product to half an hour

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -682,6 +682,17 @@ composite has been published or when the map has been panned outside
 the area the current image was fetched for, so a page left open does
 not download continuously.
 
+While such a page is open, XCSoar watches how old the picture is.  A
+frame is already seven to twelve minutes old when it arrives, because
+the network needs about four minutes to publish it and it is only
+renewed every five.  Once a frame passes twenty minutes it is removed
+from the map \emph{before} a replacement is fetched, so a failing or
+slow connection can never leave a stale echo on display.  If the
+replacement then fails to arrive, a warning says so; that warning
+offers to stop appearing, and can be switched back on with
+\emph{Warn when radar expires} on the \emph{Look / Language, Input}
+configuration page (Section~\ref{sec:interface}).
+
 The colours are the classes the Deutscher Wetterdienst uses for its
 own radar images, from cyan for the weakest echo through green,
 yellow and orange to red and violet for the heaviest, so the picture

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -722,6 +722,81 @@ contribute.
 
 Note that this feature requires and uses an internet connection.
 
+\section{Satellite imagery}\label{sec:satellite}
+
+XCSoar can draw Meteosat imagery underneath the moving map, so that
+terrain, airspace and the task are read on top of the cloud picture,
+at the map's own scale and orientation.
+
+The imagery comes from EUMETView, EUMETSAT's public web map service.
+It needs no account and no subscription: the rendered products are
+CC~BY 4.0, and the service declares neither fees nor access
+constraints.  This is the same Meteosat data the Deutscher
+Wetterdienst sells on in its \emph{pc\_met} satellite images, taken
+one step earlier in the chain, and for the Meteosat Third Generation
+layers at a finer sampling than \emph{pc\_met} carries at all.
+
+To switch it on, set \emph{Map overlay} to \emph{Satellite} in
+\config{screenpages} and choose a product under \emph{Satellite
+layer}.  Each page keeps its own choice, so one page can carry visible
+light and another infrared.
+
+The products offered are:
+
+\begin{description}
+\item[European HRV RGB] the closest counterpart to the \emph{pc\_met}
+  \emph{vis\_hrv} images, and the default.
+\item[Visible 0.6\,\textmu m (MTG)] the Third Generation imager at its
+  finest solar sampling, about twice as detailed as the previous
+  generation's high resolution channel.
+\item[Infrared 10.5\,\textmu m (MTG)] cloud top temperature, which
+  works at night.
+\item[True colour (MTG)] and \textbf{Geo colour (MTG)}, composites
+  that read like a photograph.
+\item[Rapid scan natural colour] renewed every five minutes rather
+  than every ten, over Europe.
+\end{description}
+
+The imagery is fetched as a block of five by five tiles centred on
+the aircraft, each about twenty-five kilometres across, so the block
+reaches at least fifty kilometres in every direction.
+
+The tiles are requested \emph{nearest first}: the one the glider is
+over, then the ring around it, then the next ring outwards.  This is
+deliberate, because a glider's mobile connection is usually slow and
+often absent.  The tile under the aircraft is about three kilobytes
+and is on the map almost at once; after nine tiles, some thirty
+kilobytes, the picture already covers the area a glider can reach,
+and the full block costs about eighty.  If the connection dies part
+way through, what remains on the map is a complete picture of the
+ground that matters most, rather than a half-drawn one.
+
+Only one tile is requested at a time.  Stacking requests on a thin
+link makes every tile arrive late instead of the nearest one arriving
+early.
+
+The tiles sit on the standard map tile grid, so flying on does not
+throw the picture away: when the aircraft crosses into the next tile,
+the tiles the new block shares with the old one stay exactly where
+they are and only the ones that have come into range are fetched.
+Panning and zooming fetch nothing at all.
+
+A frame is not on the server the moment it is taken; the delay runs
+from about thirteen minutes on the rapid scan product to half an hour
+on the slower composites, and XCSoar waits accordingly rather than
+asking for a picture that does not exist yet.  EUMETView answers a
+request for a frame it does not have with an error rather than an
+older picture, so this margin is measured rather than guessed.  As with the radar, a
+frame that grows too old for its layer is taken off the map before a
+replacement is requested, so a failing connection cannot leave
+yesterday's weather on display.
+
+EUMETSAT's data policy requires the source to be named wherever the
+imagery is shown.  XCSoar carries the attribution in the overlay's
+label, which the map shows when the image is tapped.
+
+Note that this feature requires and uses an internet connection.
+
 \section{pc\_met, Deutscher Wetterdienst}\label{sec:pcmet}
 
 German weather service ``Deutscher Wetterdienst'' provides several

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -673,6 +673,15 @@ map first and select the layer afterwards.  \bmenug{Update} fetches a
 fresh image for the area now visible.  A new composite is published
 every five minutes.
 
+A map page can also carry the radar permanently: set \emph{Map
+overlay} to \emph{Rain radar} in
+\config{screenpages}.  The image is then fetched
+in the background whenever the page is shown, without a progress
+dialog interrupting the flight.  It is only re-fetched when a newer
+composite has been published or when the map has been panned outside
+the area the current image was fetched for, so a page left open does
+not download continuously.
+
 The colours are the classes the Deutscher Wetterdienst uses for its
 own radar images, from cyan for the weakest echo through green,
 yellow and orange to red and violet for the heaviest, so the picture

--- a/doc/manual/en/ch06_atmosphere_and_instruments.tex
+++ b/doc/manual/en/ch06_atmosphere_and_instruments.tex
@@ -667,25 +667,41 @@ The layer is listed as \emph{Radar (EUMETNET OPERA)} on the
 Select it and press \bmenug{Use}; \bmenug{Disable} switches it off
 again.
 
-Selecting it downloads the newest composite and draws the part
-covering the area the map is currently showing, so pan and zoom the
-map first and select the layer afterwards.  \bmenug{Update} fetches a
-fresh image for the area now visible.  A new composite is published
-every five minutes.
+Selecting it draws the part of the newest composite covering the area
+the map is currently showing, so pan and zoom the map first and select
+the layer afterwards.  \bmenug{Update} fetches a fresh image for the
+area now visible.  A new composite is published every five minutes.
 
 A map page can also carry the radar permanently: set \emph{Map
 overlay} to \emph{Rain radar} in
-\config{screenpages}.  The image is then fetched
+\config{screenpages}.  The picture is then fetched
 in the background whenever the page is shown, without a progress
-dialog interrupting the flight.  It is only re-fetched when a newer
-composite has been published or when the map has been panned outside
-the area the current image was fetched for, so a page left open does
-not download continuously.
+dialog interrupting the flight.
 
-While such a page is open, XCSoar watches how old the picture is.  A
-frame is already seven to twelve minutes old when it arrives, because
-the network needs about four minutes to publish it and it is only
-renewed every five.  Once a frame passes twenty minutes it is removed
+It arrives in pieces, nearest first.  XCSoar divides the area around
+the aircraft into a block of tiles and fetches them in rings growing
+outwards from underneath the glider, so on a slow or intermittent
+connection the weather you are flying into is drawn before the
+distant weather is.  Each tile stays on the map on its own: flying on
+fetches only the tiles that come into range, and panning or zooming
+keeps whatever still fits.
+
+This is also what keeps the feature affordable.  The composite is one
+file of about five megabytes covering the continent, but it is
+tiled and carries a pyramid of reduced-resolution copies, and the
+server serves byte ranges, so XCSoar reads its index and then only
+those tiles it actually needs, at the resolution the map is drawn at.
+At the scales one flies at that is between two and three per cent of
+the file -- typically a hundred and fifty kilobytes for the whole
+block, and about a hundred for the first tile, the one under the
+aircraft.  Zoomed out far enough to see half the continent it is more,
+because more ground is being asked for.
+
+While such a page is open, XCSoar watches how old the picture is.
+XCSoar asks for a frame seven minutes old, because one takes four to
+six minutes to reach the server after it is measured; frames are
+renewed every five minutes, so what is on the map is between seven and
+twelve minutes old.  Once a frame passes twenty minutes it is removed
 from the map \emph{before} a replacement is fetched, so a failing or
 slow connection can never leave a stale echo on display.  If the
 replacement then fails to arrive, a warning says so; that warning
@@ -704,8 +720,7 @@ Coverage reaches from the Azores to northern Scandinavia and from
 Iceland to eastern Europe; nineteen national weather services
 contribute.
 
-Note that this feature requires and uses an internet connection.  A
-composite is about four megabytes.
+Note that this feature requires and uses an internet connection.
 
 \section{pc\_met, Deutscher Wetterdienst}\label{sec:pcmet}
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -798,9 +798,11 @@ When editing a page, the following options are available for map pages:
   \emph{Weather controls} to show in-flight RASP, EDL, or XC Therm forecast
   controls when the page uses a weather overlay.
 \item[Map overlay]  Optional weather overlay drawn on map pages: \emph{None},
-  \emph{RASP}, \emph{EDL}, or \emph{XC Therm}.  RASP requires a loaded RASP
-  file; EDL and XC Therm require network-capable builds with the respective
-  weather provider configured.
+  \emph{RASP}, \emph{EDL}, \emph{XC Therm}, or \emph{Rain radar}.  RASP
+  requires a loaded RASP file; EDL and XC Therm require network-capable
+  builds with the respective weather provider configured.  \emph{Rain
+  radar} draws the EUMETNET OPERA composite (Section~\ref{sec:rain-radar})
+  and needs no account, only an internet connection.
 \item[Layer / Level]  When \emph{Map overlay} is \emph{RASP}, selects
   which RASP field is displayed on this page.  When the overlay is
   \emph{EDL}, selects the pressure level (altitude band): \emph{Auto}

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -798,11 +798,15 @@ When editing a page, the following options are available for map pages:
   \emph{Weather controls} to show in-flight RASP, EDL, or XC Therm forecast
   controls when the page uses a weather overlay.
 \item[Map overlay]  Optional weather overlay drawn on map pages: \emph{None},
-  \emph{RASP}, \emph{EDL}, \emph{XC Therm}, or \emph{Rain radar}.  RASP
-  requires a loaded RASP file; EDL and XC Therm require network-capable
-  builds with the respective weather provider configured.  \emph{Rain
-  radar} draws the EUMETNET OPERA composite (Section~\ref{sec:rain-radar})
-  and needs no account, only an internet connection.
+  \emph{RASP}, \emph{EDL}, \emph{XC Therm}, \emph{Rain radar}, or
+  \emph{Satellite}.  RASP requires a loaded RASP file; EDL and XC Therm
+  require network-capable builds with the respective weather provider
+  configured.  \emph{Rain radar} draws the EUMETNET OPERA composite
+  (Section~\ref{sec:rain-radar}) and \emph{Satellite} draws Meteosat
+  imagery from EUMETView (Section~\ref{sec:satellite}); neither needs an
+  account, only an internet connection.
+\item[Satellite layer]  When \emph{Map overlay} is \emph{Satellite},
+  selects which EUMETView product this page draws.
 \item[Layer / Level]  When \emph{Map overlay} is \emph{RASP}, selects
   which RASP field is displayed on this page.  When the overlay is
   \emph{EDL}, selects the pressure level (altitude band): \emph{Auto}

--- a/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/InterfaceConfigPanel.cpp
@@ -35,6 +35,7 @@ enum ControlIndex {
 #endif
   ShowQuickGuideOnStartup,
   ShowReleaseNotesOnStartup,
+  WarnRadarExpired,
   DisclaimerAccepted,
 };
 
@@ -177,6 +178,14 @@ InterfaceConfigPanel::Prepare(ContainerWindow &parent,
                "startup."),
              !news_seen);
 
+  bool hide_radar_warning = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hide_radar_warning);
+  AddBoolean(C_("Setting", "Warn when radar expires"),
+             _("If enabled, a warning is shown when the rain radar "
+               "overlay could not be refreshed and was removed from "
+               "the map."),
+             !hide_radar_warning);
+
   const char *disclaimer_acknowledged_version =
     Profile::Get(ProfileKeys::DisclaimerAcknowledgedVersion);
   const bool disclaimer_acknowledged =
@@ -275,6 +284,12 @@ InterfaceConfigPanel::Save(bool &_changed) noexcept
   if (SaveValue(ShowQuickGuideOnStartup,
                 ProfileKeys::HideQuickGuideDialogOnStartup,
                 hide_quick_guide, true))
+    changed = true;
+
+  bool hide_radar_warning = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hide_radar_warning);
+  if (SaveValue(WarnRadarExpired, ProfileKeys::HideRadarStaleWarning,
+                hide_radar_warning, true))
     changed = true;
 
   const bool show_release_notes = GetValueBoolean(ShowReleaseNotesOnStartup);

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -16,6 +16,9 @@
 #include "Interface.hpp"
 #include "DataGlobals.hpp"
 #include "Weather/Features.hpp"
+#ifdef HAVE_WEATHER_OVERLAY
+#include "Weather/EUMETView/Satellite.hpp"
+#endif
 #include "Weather/Rasp/FieldControls.hpp"
 #include "Weather/Rasp/RaspStore.hpp"
 #ifdef HAVE_EDL
@@ -298,9 +301,32 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
     break;
   }
 
+#ifdef HAVE_WEATHER_OVERLAY
+  case PageLayout::Overlay::SATELLITE: {
+    control.SetCaption(C_("Setting", "Satellite layer"));
+    control.SetHelpText(
+      _("Which EUMETView satellite product this page draws under the "
+        "map."));
+
+    const auto layers = EUMETView::GetLayers();
+    for (std::size_t i = 0; i < layers.size(); ++i)
+      df.AddChoice(int(i), gettext(layers[i].label));
+
+    if (value.satellite_layer >= 0 &&
+        std::size_t(value.satellite_layer) < layers.size())
+      df.SetValue(unsigned(value.satellite_layer));
+    else
+      df.SetValue(unsigned(PageLayout::SATELLITE_LAYER_DEFAULT));
+    break;
+  }
+#endif
+
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::XCTHERM:
   case PageLayout::Overlay::RADAR:
+#ifndef HAVE_WEATHER_OVERLAY
+  case PageLayout::Overlay::SATELLITE:
+#endif
 #ifndef HAVE_EDL
   case PageLayout::Overlay::EDL:
 #endif
@@ -338,6 +364,11 @@ PageLayoutEditWidget::UpdateOverlayControls() noexcept
     case PageLayout::Overlay::SKYSIGHT:
 #ifdef HAVE_HTTP
       detail_enabled = DataGlobals::GetSkySight() != nullptr;
+#endif
+      break;
+    case PageLayout::Overlay::SATELLITE:
+#ifdef HAVE_WEATHER_OVERLAY
+      detail_enabled = true;
 #endif
       break;
     case PageLayout::Overlay::NONE:
@@ -444,6 +475,7 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 #endif
 #ifdef HAVE_WEATHER_OVERLAY
     { PageLayout::Overlay::RADAR, N_("Rain radar") },
+    { PageLayout::Overlay::SATELLITE, N_("Satellite") },
 #endif
     nullptr
   };
@@ -577,6 +609,10 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
 #ifdef HAVE_EDL
     else if (value.overlay == PageLayout::Overlay::EDL)
       value.edl_isobar = dfe.GetValue();
+#endif
+#ifdef HAVE_WEATHER_OVERLAY
+    else if (value.overlay == PageLayout::Overlay::SATELLITE)
+      value.satellite_layer = dfe.GetValue();
 #endif
     else if (value.overlay == PageLayout::Overlay::SKYSIGHT) {
 #ifdef HAVE_HTTP

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -300,6 +300,7 @@ PageLayoutEditWidget::FillOverlayDetailControl() noexcept
 
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::XCTHERM:
+  case PageLayout::Overlay::RADAR:
 #ifndef HAVE_EDL
   case PageLayout::Overlay::EDL:
 #endif
@@ -341,6 +342,7 @@ PageLayoutEditWidget::UpdateOverlayControls() noexcept
       break;
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::XCTHERM:
+    case PageLayout::Overlay::RADAR:
 #ifndef HAVE_EDL
     case PageLayout::Overlay::EDL:
 #endif
@@ -439,6 +441,9 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
 #ifdef HAVE_HTTP
     { PageLayout::Overlay::XCTHERM, "XC Therm" },
     { PageLayout::Overlay::SKYSIGHT, "SkySight" },
+#endif
+#ifdef HAVE_WEATHER_OVERLAY
+    { PageLayout::Overlay::RADAR, N_("Rain radar") },
 #endif
     nullptr
   };

--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -17,6 +17,8 @@
 #include "Language/Language.hpp"
 #include "Weather/PCMet/Overlays.hpp"
 #include "Weather/OPERA/Radar.hpp"
+#include "Weather/EUMETView/Satellite.hpp"
+#include "Weather/EUMETView/SatellitePageOverlay.hpp"
 #include "Geo/GeoBounds.hpp"
 #include "Interface.hpp"
 #include "LocalPath.hpp"
@@ -56,6 +58,17 @@ class WeatherMapOverlayListWidget final
     bool radar = false;
     GeoBounds radar_bounds = GeoBounds::Invalid();
 
+    /**
+     * Index into EUMETView::GetLayers() for a satellite entry, or -1.
+     *
+     * The satellite imagery is not a single bitmap like everything
+     * else in this list: it is a block of tiles that fills in around
+     * the aircraft.  Rather than fetch it a second way here, the
+     * entry switches on the very same machinery a satellite page
+     * uses, and the tiles then arrive in the background.
+     */
+    int satellite_layer = -1;
+
     explicit Item(PCMet::OverlayInfo &&_pc_met)
       :name(_pc_met.label.c_str()), path(_pc_met.path.c_str()),
        pc_met(new PCMet::OverlayInfo(std::move(_pc_met))) {}
@@ -64,6 +77,15 @@ class WeatherMapOverlayListWidget final
 
     explicit Item(Radar)
       :name(gettext(N_("Radar (EUMETNET OPERA)"))), radar(true) {}
+
+    struct Satellite { int layer; };
+
+    explicit Item(Satellite s)
+      :satellite_layer(s.layer) {
+      name.Format("%s (%s)",
+                  gettext(EUMETView::GetLayer(s.layer).label),
+                  _("Satellite"));
+    }
 
     Item(const char *_name, Path _path)
       :name(_name), path(_path) {}
@@ -108,6 +130,17 @@ private:
   }
 
   int FindActiveIndex() const {
+    if (const int layer = EUMETView::GetActiveLayer(); layer >= 0) {
+      /* the satellite block is many overlays carrying an attribution
+         label, so it cannot be found by matching a bitmap's name */
+      unsigned i = 0;
+      for (const auto &item : items) {
+        if (item.satellite_layer == layer)
+          return int(i);
+        ++i;
+      }
+    }
+
     const auto *map = UIGlobals::GetMap();
     if (map == nullptr)
       return -1;
@@ -215,6 +248,9 @@ private:
   void UseClicked(unsigned i);
 
   void DisableClicked() {
+    if (EUMETView::GetActiveLayer() >= 0)
+      EUMETView::DeactivatePageOverlay();
+
     auto *map = UIGlobals::GetMap();
     if (map != nullptr)
       map->SetOverlay(nullptr);
@@ -249,6 +285,10 @@ WeatherMapOverlayListWidget::UpdateList()
   /* the radar composite is open data and needs no account, so it is
      always offered */
   items.emplace_back(Item::Radar{});
+
+  /* so is the satellite imagery, one entry per product */
+  for (std::size_t i = 0; i < EUMETView::GetLayers().size(); ++i)
+    items.emplace_back(Item::Satellite{int(i)});
 
   struct Visitor : public File::Visitor {
     std::vector<Item> &items;
@@ -450,7 +490,20 @@ WeatherMapOverlayListWidget::UseClicked(unsigned i)
 
   const char *label = nullptr;
   auto &item = items[i];
-  if (item.radar) {
+
+  if (EUMETView::GetActiveLayer() >= 0 && item.satellite_layer < 0)
+    /* every other entry installs a single bitmap into the first
+       overlay slot, which would leave the other twenty-four tiles of
+       a satellite block standing underneath it */
+    EUMETView::DeactivatePageOverlay();
+
+  if (item.satellite_layer >= 0) {
+    /* no modal download: the block fills in around the aircraft in
+       the background, nearest tile first, exactly as on a page */
+    EUMETView::ActivatePageOverlay(item.satellite_layer);
+    UpdateActiveIndex();
+    return;
+  } else if (item.radar) {
     /* unlike the other entries this is fetched for the visible area,
        so it is downloaded again even if we already have a file */
     if (!DownloadRadar(item))
@@ -496,7 +549,11 @@ WeatherMapOverlayListWidget::UpdateClicked()
   BrokenDateTime now = BrokenDateTime::NowUTC();
   int i = 0;
   for (auto &item : items) {
-    if (item.radar) {
+    if (item.satellite_layer >= 0) {
+      if (i == active_index)
+        /* a no-op unless a newer frame is due or a tile is missing */
+        EUMETView::ActivatePageOverlay(item.satellite_layer);
+    } else if (item.radar) {
       if (i == active_index && DownloadRadar(item))
         SetOverlay(item.path, item.radar_bounds, item.name.c_str());
     } else if (item.pc_met) {

--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -16,6 +16,8 @@
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Language/Language.hpp"
 #include "Weather/PCMet/Overlays.hpp"
+#include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Interface.hpp"
 #include "LocalPath.hpp"
 #include "Operation/PluggableOperationEnvironment.hpp"
@@ -27,6 +29,7 @@
 #include "util/StringAPI.hxx"
 #include "util/StringCompare.hxx"
 
+#include <algorithm>
 #include <optional>
 #include <vector>
 
@@ -45,9 +48,22 @@ class WeatherMapOverlayListWidget final
 
     std::unique_ptr<PCMet::OverlayInfo> pc_met;
 
+    /**
+     * Set for the radar composite, which is downloaded on demand for
+     * the currently visible map area.  #radar_bounds is the area the
+     * cached image covers.
+     */
+    bool radar = false;
+    GeoBounds radar_bounds = GeoBounds::Invalid();
+
     explicit Item(PCMet::OverlayInfo &&_pc_met)
       :name(_pc_met.label.c_str()), path(_pc_met.path.c_str()),
        pc_met(new PCMet::OverlayInfo(std::move(_pc_met))) {}
+
+    struct Radar {};
+
+    explicit Item(Radar)
+      :name(gettext(N_("Radar (EUMETNET OPERA)"))), radar(true) {}
 
     Item(const char *_name, Path _path)
       :name(_name), path(_path) {}
@@ -186,6 +202,15 @@ protected:
 
 private:
   void SetOverlay(Path path, const char *label=nullptr);
+  void SetOverlay(Path path, const GeoBounds &bounds,
+                  const char *label);
+
+  /**
+   * Download the radar composite for the area the map currently shows.
+   *
+   * @return false if the download failed or was cancelled
+   */
+  bool DownloadRadar(Item &item);
 
   void UseClicked(unsigned i);
 
@@ -221,6 +246,10 @@ WeatherMapOverlayListWidget::UpdateList()
     for (auto &i : PCMet::CollectOverlays())
       items.emplace_back(std::move(i));
 
+  /* the radar composite is open data and needs no account, so it is
+     always offered */
+  items.emplace_back(Item::Radar{});
+
   struct Visitor : public File::Visitor {
     std::vector<Item> &items;
 
@@ -247,7 +276,14 @@ WeatherMapOverlayListWidget::UpdateList()
 
   const bool empty = items.empty();
   use_button->SetEnabled(!empty);
-  update_button->SetEnabled(pc_met_settings.ftp_credentials.IsDefined());
+
+  /* "Update" re-downloads; that is possible for the pc_met overlays
+     only with credentials, but always for the radar composite */
+  const bool can_update = pc_met_settings.ftp_credentials.IsDefined() ||
+    std::any_of(items.begin(), items.end(), [](const Item &i){
+      return i.radar;
+    });
+  update_button->SetEnabled(can_update);
 
   UpdateActiveIndex();
 }
@@ -331,6 +367,79 @@ WeatherMapOverlayListWidget::SetOverlay(Path path, const char *label)
   UpdateActiveIndex();
 }
 
+bool
+WeatherMapOverlayListWidget::DownloadRadar(Item &item)
+{
+  const auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return false;
+
+  const auto &projection = map->VisibleProjection();
+  const auto bounds = projection.GetScreenBounds();
+  if (!bounds.IsValid())
+    return false;
+
+  const auto size = projection.GetScreenSize();
+
+  try {
+    PluggableOperationEnvironment env;
+
+    auto path = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
+                                     UIGlobals::GetDialogLook(),
+                                     _("Download"),
+                                     OPERA::DownloadRadar(bounds,
+                                                          size.width,
+                                                          size.height,
+                                                          *Net::curl, env),
+                                     &env);
+    if (!path)
+      return false;
+
+    item.path = std::move(*path);
+    item.radar_bounds = bounds;
+    UpdatePreview(item.path);
+    return true;
+  } catch (...) {
+    ShowError(std::current_exception(), _("Weather"));
+    return false;
+  }
+}
+
+/**
+ * Install an image whose extent is known from the request rather
+ * than from the file, which is how the radar composite arrives.
+ */
+void
+WeatherMapOverlayListWidget::SetOverlay(Path path, const GeoBounds &bounds,
+                                        const char *label)
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || !bounds.IsValid())
+    return;
+
+  Bitmap bitmap;
+  try {
+    if (!bitmap.LoadFile(path))
+      return;
+  } catch (...) {
+    ShowError(std::current_exception(), _("Weather"));
+    return;
+  }
+
+  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                GeoQuadrilateral{
+                                                  bounds.GetNorthWest(),
+                                                  bounds.GetNorthEast(),
+                                                  bounds.GetSouthWest(),
+                                                  bounds.GetSouthEast(),
+                                                },
+                                                label);
+  bmp->SetAlpha(0.6);
+  map->SetOverlay(std::move(bmp));
+
+  UpdateActiveIndex();
+}
+
 void
 WeatherMapOverlayListWidget::UseClicked(unsigned i)
 {
@@ -341,7 +450,15 @@ WeatherMapOverlayListWidget::UseClicked(unsigned i)
 
   const char *label = nullptr;
   auto &item = items[i];
-  if (item.pc_met) {
+  if (item.radar) {
+    /* unlike the other entries this is fetched for the visible area,
+       so it is downloaded again even if we already have a file */
+    if (!DownloadRadar(item))
+      return;
+
+    SetOverlay(item.path, item.radar_bounds, item.name.c_str());
+    return;
+  } else if (item.pc_met) {
     const auto &info = *item.pc_met;
     label = info.label.c_str();
     if (item.path == nullptr) {
@@ -379,7 +496,10 @@ WeatherMapOverlayListWidget::UpdateClicked()
   BrokenDateTime now = BrokenDateTime::NowUTC();
   int i = 0;
   for (auto &item : items) {
-    if (item.pc_met) {
+    if (item.radar) {
+      if (i == active_index && DownloadRadar(item))
+        SetOverlay(item.path, item.radar_bounds, item.name.c_str());
+    } else if (item.pc_met) {
       try {
         const auto &info = *item.pc_met;
 

--- a/src/Dialogs/Weather/MapOverlayWidget.cpp
+++ b/src/Dialogs/Weather/MapOverlayWidget.cpp
@@ -387,10 +387,10 @@ WeatherMapOverlayListWidget::DownloadRadar(Item &item)
     auto path = ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
                                      UIGlobals::GetDialogLook(),
                                      _("Download"),
-                                     OPERA::DownloadRadar(bounds,
-                                                          size.width,
-                                                          size.height,
-                                                          *Net::curl, env),
+                                     OPERA::DownloadArea(bounds,
+                                                         size.width,
+                                                         size.height,
+                                                         *Net::curl, env),
                                      &env);
     if (!path)
       return false;

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -184,8 +184,9 @@ ShowWeatherDialog(const char *page)
   if (page != nullptr && StringIsEqual(page, "overlay"))
     start_page = widget.GetSize();
 
-  // TODO: better and translatable title?
-  widget.AddTab(CreateWeatherMapOverlayWidget(), "Overlay");
+  /* the other tabs are named after their service, which is why they
+     are not translated; this one is a common noun */
+  widget.AddTab(CreateWeatherMapOverlayWidget(), _("Overlay"));
 #endif
 
   /* restore previous page */

--- a/src/Dialogs/Weather/WeatherDialog.cpp
+++ b/src/Dialogs/Weather/WeatherDialog.cpp
@@ -18,7 +18,7 @@
 #include "SkySightDialog.hpp"
 #include "Dialogs/Settings/Panels/SkySightConfigPanel.hpp"
 #endif
-#if 0
+#ifdef HAVE_WEATHER_OVERLAY
 #include "MapOverlayWidget.hpp"
 #endif
 #include "Widget/TextWidget.hpp"
@@ -176,11 +176,10 @@ ShowWeatherDialog(const char *page)
   widget.AddTab(CreatePCMetTabWidget(), "Flugwetter");
 #endif
 
-#if 0
-  /* The German DWD has terminated our access to georeferenced images,
-     so this code is disabled for now, but will remain here;
-     eventually, we should refactor the code to be generic, allowing
-     arbitrary georeferenced images */
+#ifdef HAVE_WEATHER_OVERLAY
+  /* this was disabled while the only source was the DWD, whose
+     georeferenced images we lost access to; the radar composite needs
+     no account, so there is something to show again */
 
   if (page != nullptr && StringIsEqual(page, "overlay"))
     start_page = widget.GetSize();

--- a/src/Dialogs/Weather/WeatherOverlayDraft.cpp
+++ b/src/Dialogs/Weather/WeatherOverlayDraft.cpp
@@ -85,6 +85,7 @@ State::IsDirty() const noexcept
       draft.skysight_time != baseline.skysight_time;
 
   case PageLayout::Overlay::RADAR:
+  case PageLayout::Overlay::SATELLITE:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     return false;

--- a/src/Dialogs/Weather/WeatherOverlayDraft.cpp
+++ b/src/Dialogs/Weather/WeatherOverlayDraft.cpp
@@ -84,6 +84,7 @@ State::IsDirty() const noexcept
     return draft.skysight_overlay != baseline.skysight_overlay ||
       draft.skysight_time != baseline.skysight_time;
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     return false;

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -277,6 +277,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
     case PageLayout::Overlay::SKYSIGHT:
     case PageLayout::Overlay::RASP:
     case PageLayout::Overlay::RADAR:
+    case PageLayout::Overlay::SATELLITE:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return plus
@@ -298,6 +299,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
 
     case PageLayout::Overlay::RASP:
     case PageLayout::Overlay::RADAR:
+    case PageLayout::Overlay::SATELLITE:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Layer\nList\n(F2/+)");
@@ -317,6 +319,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
 
     case PageLayout::Overlay::RASP:
     case PageLayout::Overlay::RADAR:
+    case PageLayout::Overlay::SATELLITE:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Time\nAuto\n(F3/-)");

--- a/src/Menu/ExpandMacros.cpp
+++ b/src/Menu/ExpandMacros.cpp
@@ -276,6 +276,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
 
     case PageLayout::Overlay::SKYSIGHT:
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return plus
@@ -296,6 +297,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
       return "";
 
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Layer\nList\n(F2/+)");
@@ -314,6 +316,7 @@ LookupMacro(std::string_view name, bool &invalid) noexcept
       return C_("Weather control", "Time\nAuto\n(F3/-)");
 
     case PageLayout::Overlay::RASP:
+    case PageLayout::Overlay::RADAR:
     case PageLayout::Overlay::NONE:
     case PageLayout::Overlay::MAX:
       return C_("Weather control", "Time\nAuto\n(F3/-)");

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -18,6 +18,9 @@
 #endif
 #ifdef HAVE_HTTP
 #include "Weather/xctherm/XCThermDownloadGlue.hpp"
+#ifdef HAVE_WEATHER_OVERLAY
+#include "Weather/OPERA/RadarPageOverlay.hpp"
+#endif
 #include "DataGlobals.hpp"
 #include "Weather/SkySight/SkySightClient.hpp"
 #endif
@@ -40,6 +43,9 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
   ,edl(new EDL::DownloadGlue(curl))
 # endif
   ,xctherm_download(new XCThermDownloadGlue(curl))
+# ifdef HAVE_WEATHER_OVERLAY
+  ,opera_radar(new RadarDownloadGlue(curl))
+# endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   ,rasp_download(new RaspDownloadGlue())
@@ -88,6 +94,11 @@ NetComponents::BeginShutdown() noexcept
 
   if (xctherm_download != nullptr)
     xctherm_download->BeginShutdown();
+
+# ifdef HAVE_WEATHER_OVERLAY
+  if (opera_radar != nullptr)
+    opera_radar->BeginShutdown();
+# endif
 
 #ifdef HAVE_DOWNLOAD_MANAGER
   if (rasp_download != nullptr)

--- a/src/NetComponents.cpp
+++ b/src/NetComponents.cpp
@@ -20,6 +20,7 @@
 #include "Weather/xctherm/XCThermDownloadGlue.hpp"
 #ifdef HAVE_WEATHER_OVERLAY
 #include "Weather/OPERA/RadarPageOverlay.hpp"
+#include "Weather/EUMETView/SatellitePageOverlay.hpp"
 #endif
 #include "DataGlobals.hpp"
 #include "Weather/SkySight/SkySightClient.hpp"
@@ -45,6 +46,7 @@ NetComponents::NetComponents(EventLoop &event_loop, CurlGlobal &curl,
   ,xctherm_download(new XCThermDownloadGlue(curl))
 # ifdef HAVE_WEATHER_OVERLAY
   ,opera_radar(new RadarDownloadGlue(curl))
+  ,eumetview_satellite(new SatelliteDownloadGlue(curl))
 # endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
@@ -98,6 +100,9 @@ NetComponents::BeginShutdown() noexcept
 # ifdef HAVE_WEATHER_OVERLAY
   if (opera_radar != nullptr)
     opera_radar->BeginShutdown();
+
+  if (eumetview_satellite != nullptr)
+    eumetview_satellite->BeginShutdown();
 # endif
 
 #ifdef HAVE_DOWNLOAD_MANAGER

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -20,6 +20,9 @@ class NOTAMGlue;
 namespace EDL { class DownloadGlue; }
 #endif
 class XCThermDownloadGlue;
+#ifdef HAVE_WEATHER_OVERLAY
+class RadarDownloadGlue;
+#endif
 #ifdef HAVE_DOWNLOAD_MANAGER
 class RaspDownloadGlue;
 #endif
@@ -43,6 +46,9 @@ struct NetComponents {
   const std::unique_ptr<EDL::DownloadGlue> edl;
 # endif
   const std::unique_ptr<XCThermDownloadGlue> xctherm_download;
+# ifdef HAVE_WEATHER_OVERLAY
+  const std::unique_ptr<RadarDownloadGlue> opera_radar;
+# endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
   const std::unique_ptr<RaspDownloadGlue> rasp_download;

--- a/src/NetComponents.hpp
+++ b/src/NetComponents.hpp
@@ -22,6 +22,7 @@ namespace EDL { class DownloadGlue; }
 class XCThermDownloadGlue;
 #ifdef HAVE_WEATHER_OVERLAY
 class RadarDownloadGlue;
+class SatelliteDownloadGlue;
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER
 class RaspDownloadGlue;
@@ -48,6 +49,7 @@ struct NetComponents {
   const std::unique_ptr<XCThermDownloadGlue> xctherm_download;
 # ifdef HAVE_WEATHER_OVERLAY
   const std::unique_ptr<RadarDownloadGlue> opera_radar;
+  const std::unique_ptr<SatelliteDownloadGlue> eumetview_satellite;
 # endif
 #endif
 #ifdef HAVE_DOWNLOAD_MANAGER

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -37,6 +37,7 @@
 #include "Weather/xctherm/XCThermMapOverlay.hpp"
 #ifdef HAVE_WEATHER_OVERLAY
 #include "Weather/OPERA/RadarPageOverlay.hpp"
+#include "Weather/EUMETView/SatellitePageOverlay.hpp"
 #endif
 #endif
 
@@ -74,6 +75,7 @@ namespace PageActions {
   static void LeaveXcthermOverlay() noexcept;
   static void LeaveSkySightOverlay() noexcept;
   static void LeaveRadarOverlay() noexcept;
+  static void LeaveSatelliteOverlay() noexcept;
 
   static void LeaveWeatherOverlayPage(const PageLayout &layout) noexcept;
 
@@ -82,6 +84,7 @@ namespace PageActions {
   static void ApplyXcthermOverlay(const PageLayout &layout) noexcept;
   static void ApplySkySightOverlay(const PageLayout &layout) noexcept;
   static void ApplyRadarOverlay() noexcept;
+  static void ApplySatelliteOverlay(const PageLayout &layout) noexcept;
 
   static void ApplyPageOverlay(const PageLayout &layout) noexcept;
 };
@@ -185,6 +188,23 @@ PageActions::ApplyRadarOverlay() noexcept
 }
 
 void
+PageActions::LeaveSatelliteOverlay() noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  EUMETView::DeactivatePageOverlay();
+#endif
+}
+
+void
+PageActions::ApplySatelliteOverlay([[maybe_unused]] const PageLayout &layout)
+  noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  EUMETView::ActivatePageOverlay(layout.satellite_layer);
+#endif
+}
+
+void
 PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
 {
   if (layout.UsesEdlOverlay())
@@ -197,6 +217,8 @@ PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
     LeaveSkySightOverlay();
   else if (layout.UsesRadarOverlay())
     LeaveRadarOverlay();
+  else if (layout.UsesSatelliteOverlay())
+    LeaveSatelliteOverlay();
 }
 
 void
@@ -339,6 +361,8 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
     LeaveSkySightOverlay();
   if (!layout.UsesRadarOverlay())
     LeaveRadarOverlay();
+  if (!layout.UsesSatelliteOverlay())
+    LeaveSatelliteOverlay();
 
   ClearPageOverlays();
 
@@ -364,6 +388,10 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
 
   case PageLayout::Overlay::RADAR:
     ApplyRadarOverlay();
+    break;
+
+  case PageLayout::Overlay::SATELLITE:
+    ApplySatelliteOverlay(layout);
     break;
 
   case PageLayout::Overlay::MAX:

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -302,6 +302,10 @@ PageActions::SuspendWeatherOverlaysForPan() noexcept
     weather.xctherm.SuspendForPan();
   if (layout.UsesSkySightOverlay())
     weather.skysight.SuspendForPan();
+#ifdef HAVE_WEATHER_OVERLAY
+  if (layout.UsesRadarOverlay())
+    OPERA::SuspendForPan();
+#endif
 }
 
 void
@@ -312,6 +316,9 @@ PageActions::ResumeWeatherOverlaysAfterPan() noexcept
   weather.rasp.ResumeAfterPan();
   weather.xctherm.ResumeAfterPan();
   weather.skysight.ResumeAfterPan();
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ResumeAfterPan();
+#endif
 }
 
 void

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -17,6 +17,7 @@
 #include "UIGlobals.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "Components.hpp"
+#include "Weather/Features.hpp"
 #include "Weather/MapOverlay/ControlsFactory.hpp"
 #include "Weather/MapOverlay/ControlsWidget.hpp"
 #include "Weather/Rasp/FieldControls.hpp"
@@ -34,6 +35,9 @@
 #include "Weather/SkySight/SkySightClient.hpp"
 #include "Weather/xctherm/FieldControls.hpp"
 #include "Weather/xctherm/XCThermMapOverlay.hpp"
+#ifdef HAVE_WEATHER_OVERLAY
+#include "Weather/OPERA/RadarPageOverlay.hpp"
+#endif
 #endif
 
 #if defined(ENABLE_SDL) && defined(main)
@@ -69,6 +73,7 @@ namespace PageActions {
   static void LeaveEdlOverlay() noexcept;
   static void LeaveXcthermOverlay() noexcept;
   static void LeaveSkySightOverlay() noexcept;
+  static void LeaveRadarOverlay() noexcept;
 
   static void LeaveWeatherOverlayPage(const PageLayout &layout) noexcept;
 
@@ -76,6 +81,7 @@ namespace PageActions {
   static void ApplyEdlOverlay(const PageLayout &layout) noexcept;
   static void ApplyXcthermOverlay(const PageLayout &layout) noexcept;
   static void ApplySkySightOverlay(const PageLayout &layout) noexcept;
+  static void ApplyRadarOverlay() noexcept;
 
   static void ApplyPageOverlay(const PageLayout &layout) noexcept;
 };
@@ -163,6 +169,22 @@ PageActions::LeaveSkySightOverlay() noexcept
 }
 
 void
+PageActions::LeaveRadarOverlay() noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ClearMapOverlay();
+#endif
+}
+
+void
+PageActions::ApplyRadarOverlay() noexcept
+{
+#ifdef HAVE_WEATHER_OVERLAY
+  OPERA::ActivatePageOverlay();
+#endif
+}
+
+void
 PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
 {
   if (layout.UsesEdlOverlay())
@@ -173,6 +195,8 @@ PageActions::LeaveWeatherOverlayPage(const PageLayout &layout) noexcept
     LeaveXcthermOverlay();
   else if (layout.UsesSkySightOverlay())
     LeaveSkySightOverlay();
+  else if (layout.UsesRadarOverlay())
+    LeaveRadarOverlay();
 }
 
 void
@@ -306,6 +330,8 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
     LeaveXcthermOverlay();
   if (!layout.UsesSkySightOverlay())
     LeaveSkySightOverlay();
+  if (!layout.UsesRadarOverlay())
+    LeaveRadarOverlay();
 
   ClearPageOverlays();
 
@@ -327,6 +353,10 @@ PageActions::ApplyPageOverlay(const PageLayout &layout) noexcept
 
   case PageLayout::Overlay::SKYSIGHT:
     ApplySkySightOverlay(layout);
+    break;
+
+  case PageLayout::Overlay::RADAR:
+    ApplyRadarOverlay();
     break;
 
   case PageLayout::Overlay::MAX:

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -172,7 +172,7 @@ void
 PageActions::LeaveRadarOverlay() noexcept
 {
 #ifdef HAVE_WEATHER_OVERLAY
-  OPERA::ClearMapOverlay();
+  OPERA::DeactivatePageOverlay();
 #endif
 }
 

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -327,6 +327,8 @@ PageActions::SuspendWeatherOverlaysForPan() noexcept
 #ifdef HAVE_WEATHER_OVERLAY
   if (layout.UsesRadarOverlay())
     OPERA::SuspendForPan();
+  if (layout.UsesSatelliteOverlay())
+    EUMETView::SuspendForPan();
 #endif
 }
 
@@ -340,6 +342,7 @@ PageActions::ResumeWeatherOverlaysAfterPan() noexcept
   weather.skysight.ResumeAfterPan();
 #ifdef HAVE_WEATHER_OVERLAY
   OPERA::ResumeAfterPan();
+  EUMETView::ResumeAfterPan();
 #endif
 }
 

--- a/src/PageOverlayTitle.cpp
+++ b/src/PageOverlayTitle.cpp
@@ -108,6 +108,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     builder.Append(_("Radar"));
     break;
 
+  case PageLayout::Overlay::SATELLITE:
+    builder.Append(", ");
+    builder.Append(_("Satellite"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/src/PageOverlayTitle.cpp
+++ b/src/PageOverlayTitle.cpp
@@ -103,6 +103,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     }
     break;
 
+  case PageLayout::Overlay::RADAR:
+    builder.Append(", ");
+    builder.Append(_("Radar"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -281,6 +281,23 @@ struct PageLayout
   }
 
   /**
+   * Does this page carry an overlay that has to survive a pan?
+   *
+   * Panning shows the fullscreen map, whose layout carries no overlay
+   * at all, so without this the overlay would be torn down on the way
+   * in and fetched again on the way out.  This is deliberately not
+   * #UsesWeatherOverlay(): that one also gates the weather controls
+   * widget and the "weather" input mode, and an overlay with no
+   * forecast cursors would land the pilot in an empty control bar.
+   */
+  [[gnu::const]]
+  constexpr bool
+  UsesSuspendableOverlay() const noexcept
+  {
+    return UsesWeatherOverlay() || UsesRadarOverlay();
+  }
+
+  /**
    * Convert legacy page layouts to the current representation.
    */
   constexpr void Normalise() noexcept

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -112,6 +112,7 @@ struct PageLayout
     EDL,
     XCTHERM,
     SKYSIGHT,
+    RADAR,
 
     MAX
   } overlay;
@@ -261,6 +262,13 @@ struct PageLayout
   {
     return IsMapMain() && overlay == Overlay::SKYSIGHT &&
       !skysight_overlay.empty();
+  }
+
+  [[gnu::const]]
+  constexpr bool
+  UsesRadarOverlay() const noexcept
+  {
+    return IsMapMain() && overlay == Overlay::RADAR;
   }
 
   [[gnu::const]]

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -113,6 +113,7 @@ struct PageLayout
     XCTHERM,
     SKYSIGHT,
     RADAR,
+    SATELLITE,
 
     MAX
   } overlay;
@@ -158,6 +159,16 @@ struct PageLayout
   int xctherm_layer;
   int xctherm_time;
 
+  /**
+   * Selected EUMETView layer when #overlay is Overlay::SATELLITE, as
+   * an index into EUMETView::GetLayers().  Kept as a plain int so
+   * that this header does not have to pull the layer table in;
+   * #SATELLITE_LAYER_DEFAULT mirrors EUMETView::DEFAULT_LAYER.
+   */
+  static constexpr int SATELLITE_LAYER_DEFAULT = 0;
+
+  int satellite_layer;
+
   PageLayout() = default;
 
   constexpr PageLayout(bool _valid, InfoBoxConfig _infobox_config)
@@ -172,7 +183,8 @@ struct PageLayout
      edl_time(EDL_TIME_AUTO),
      edl_isobar(0),
      xctherm_layer(XCTHERM_LAYER_AUTO),
-     xctherm_time(XCTHERM_TIME_AUTO) {}
+     xctherm_time(XCTHERM_TIME_AUTO),
+     satellite_layer(SATELLITE_LAYER_DEFAULT) {}
 
   constexpr PageLayout(InfoBoxConfig _infobox_config)
     :valid(true), main(Main::MAP),
@@ -186,7 +198,8 @@ struct PageLayout
      edl_time(EDL_TIME_AUTO),
      edl_isobar(0),
      xctherm_layer(XCTHERM_LAYER_AUTO),
-     xctherm_time(XCTHERM_TIME_AUTO) {}
+     xctherm_time(XCTHERM_TIME_AUTO),
+     satellite_layer(SATELLITE_LAYER_DEFAULT) {}
 
   /**
    * Return an "undefined" page.  Its IsDefined() method will return
@@ -269,6 +282,13 @@ struct PageLayout
   UsesRadarOverlay() const noexcept
   {
     return IsMapMain() && overlay == Overlay::RADAR;
+  }
+
+  [[gnu::const]]
+  constexpr bool
+  UsesSatelliteOverlay() const noexcept
+  {
+    return IsMapMain() && overlay == Overlay::SATELLITE;
   }
 
   [[gnu::const]]

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -314,7 +314,8 @@ struct PageLayout
   constexpr bool
   UsesSuspendableOverlay() const noexcept
   {
-    return UsesWeatherOverlay() || UsesRadarOverlay();
+    return UsesWeatherOverlay() || UsesRadarOverlay() ||
+      UsesSatelliteOverlay();
   }
 
   /**

--- a/src/Pan.cpp
+++ b/src/Pan.cpp
@@ -29,7 +29,7 @@ GlueMapWindow *
 PreparePanFullscreen(bool abort_if_already_panning) noexcept
 {
   const bool suspending_weather =
-    PageActions::GetCurrentLayout().UsesWeatherOverlay();
+    PageActions::GetCurrentLayout().UsesSuspendableOverlay();
   if (suspending_weather)
     PageActions::SuspendWeatherOverlaysForPan();
 

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -355,6 +355,8 @@ constexpr std::string_view GDL90UseSystemUtcDate = "GDL90UseSystemUtcDate";
 
 constexpr std::string_view HideQuickGuideDialogOnStartup =
   "HideQuickGuideDialogOnStartup";
+constexpr std::string_view HideRadarStaleWarning =
+  "HideRadarStaleWarning";
 constexpr std::string_view DisclaimerAcknowledgedVersion =
   "DisclaimerAcknowledgedVersion";
 constexpr std::string_view LastSeenNewsVersion =

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -92,6 +92,10 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
   if (!map.Get(profileKey, pl.xctherm_time))
     pl.xctherm_time = PageLayout::XCTHERM_TIME_AUTO;
 
+  strcpy(profileKey + prefixLen, "SatelliteLayer");
+  if (!map.Get(profileKey, pl.satellite_layer) || pl.satellite_layer < 0)
+    pl.satellite_layer = PageLayout::SATELLITE_LAYER_DEFAULT;
+
   strcpy(profileKey + prefixLen, "SkysightOverlay");
   const char *skysight_overlay_value = map.Get(profileKey);
   strcpy(profileKey + prefixLen, "SkysightOverlay");
@@ -179,6 +183,9 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
 
   strcpy(profileKey + prefixLen, "XCThermTime");
   map.Set(profileKey, page.xctherm_time);
+
+  strcpy(profileKey + prefixLen, "SatelliteLayer");
+  map.Set(profileKey, page.satellite_layer);
 
   strcpy(profileKey + prefixLen, "SkysightOverlay");
   map.Set(profileKey, page.skysight_overlay.c_str());

--- a/src/Weather/EUMETView/Enhance.cpp
+++ b/src/Weather/EUMETView/Enhance.cpp
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Enhance.hpp"
+#include "ui/canvas/custom/UncompressedImage.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+namespace {
+
+/** how quickly the stretch follows a change in the scene */
+constexpr auto TIME_CONSTANT = std::chrono::minutes{60};
+
+/** the shape of the stretch; below one lifts the dark end */
+constexpr double GAMMA = 0.85;
+
+/**
+ * The unsharp mask, in pixels rather than metres, so the sharpening
+ * stays at the scale the eye sees whatever zoom the tile came from.
+ */
+constexpr double SHARPEN_SIGMA = 1.5;
+constexpr double SHARPEN_AMOUNT = 0.7;
+
+[[gnu::const]]
+unsigned
+Luminance(unsigned r, unsigned g, unsigned b) noexcept
+{
+  /* the usual Rec. 601 weights; for the single channel products this
+     is a no-op, because libpng widens grey to equal RGB */
+  return (r * 77 + g * 151 + b * 28) >> 8;
+}
+
+/** bytes per pixel, or zero for a format we cannot handle */
+[[gnu::const]]
+unsigned
+BytesPerPixel(UncompressedImage::Format format) noexcept
+{
+  switch (format) {
+  case UncompressedImage::Format::GRAY:
+    return 1;
+
+  case UncompressedImage::Format::RGB:
+    return 3;
+
+  case UncompressedImage::Format::RGBA:
+    return 4;
+
+  case UncompressedImage::Format::INVALID:
+    break;
+  }
+
+  return 0;
+}
+
+struct Kernel {
+  std::array<float, 16> tap{};
+  int radius = 0;
+};
+
+[[gnu::const]]
+Kernel
+MakeKernel(double sigma) noexcept
+{
+  Kernel k;
+  k.radius = std::min(int(std::ceil(3 * sigma)), int(k.tap.size() / 2));
+
+  float sum = 0;
+  for (int i = -k.radius; i <= k.radius; ++i) {
+    const float v = float(std::exp(-double(i) * i / (2 * sigma * sigma)));
+    k.tap[std::size_t(i + k.radius)] = v;
+    sum += v;
+  }
+
+  for (int i = 0; i <= 2 * k.radius; ++i)
+    k.tap[std::size_t(i)] /= sum;
+
+  return k;
+}
+
+} // anonymous namespace
+
+void
+EUMETView::ToneHistogram::Add(const UncompressedImage &image) noexcept
+{
+  const unsigned bpp = BytesPerPixel(image.GetFormat());
+  if (bpp == 0)
+    return;
+
+  const auto *const data = (const uint8_t *)image.GetData();
+  if (data == nullptr)
+    return;
+
+  const std::size_t pitch = image.GetPitch();
+
+  for (unsigned y = 0; y < image.GetHeight(); ++y) {
+    const uint8_t *row = data + std::size_t(y) * pitch;
+
+    for (unsigned x = 0; x < image.GetWidth(); ++x, row += bpp) {
+      /* a fully transparent pixel is outside the disc or missing, and
+         counting it would drag the dark end down */
+      if (bpp == 4 && row[3] < 0x80)
+        continue;
+
+      ++bins[bpp == 1 ? row[0] : Luminance(row[0], row[1], row[2])];
+      ++total;
+    }
+  }
+}
+
+uint8_t
+EUMETView::ToneHistogram::Percentile(unsigned permille) const noexcept
+{
+  if (total == 0)
+    return 0;
+
+  const uint64_t want = total * permille / 1000;
+  uint64_t seen = 0;
+
+  for (unsigned i = 0; i < bins.size(); ++i) {
+    seen += bins[i];
+    if (seen > want)
+      return uint8_t(i);
+  }
+
+  return 255;
+}
+
+EUMETView::ToneWindow
+EUMETView::MakeToneWindow(const ToneHistogram &histogram) noexcept
+{
+  if (histogram.IsEmpty())
+    return {0, 0};
+
+  ToneWindow w{histogram.Percentile(20), histogram.Percentile(980)};
+
+  /* a scene of one brightness -- solid cloud, or night -- gives a
+     window with no width; stretching it would turn noise into
+     violent contrast, so leave the image alone instead */
+  if (w.high <= w.low + 8)
+    return {0, 0};
+
+  return w;
+}
+
+EUMETView::ToneWindow
+EUMETView::BlendToneWindow(ToneWindow previous, ToneWindow fresh,
+                           std::chrono::steady_clock::duration elapsed) noexcept
+{
+  if (!previous.IsValid())
+    return fresh;
+  if (!fresh.IsValid())
+    return previous;
+
+  const double dt = std::chrono::duration<double>(elapsed).count();
+  const double tau = std::chrono::duration<double>(TIME_CONSTANT).count();
+  if (dt <= 0)
+    return previous;
+
+  const double alpha = 1.0 - std::exp(-dt / tau);
+
+  const auto mix = [alpha](uint8_t old_value, uint8_t new_value) {
+    return uint8_t(std::lround(old_value + alpha * (new_value - old_value)));
+  };
+
+  return {mix(previous.low, fresh.low), mix(previous.high, fresh.high)};
+}
+
+unsigned
+EUMETView::ToneWindowDistance(ToneWindow a, ToneWindow b) noexcept
+{
+  return std::max(unsigned(std::abs(int(a.low) - int(b.low))),
+                  unsigned(std::abs(int(a.high) - int(b.high))));
+}
+
+UncompressedImage
+EUMETView::Enhance(const UncompressedImage &image, ToneWindow window) noexcept
+{
+  const unsigned bpp = BytesPerPixel(image.GetFormat());
+  if (bpp == 0 || !window.IsValid())
+    return {};
+
+  const auto *const src = (const uint8_t *)image.GetData();
+  if (src == nullptr)
+    return {};
+
+  const unsigned width = image.GetWidth(), height = image.GetHeight();
+  const std::size_t pitch = image.GetPitch();
+  const std::size_t n = std::size_t(width) * height;
+  if (n == 0)
+    return {};
+
+  /* the stretch and the gamma both depend only on the input value, so
+     they collapse into one table of 256 entries */
+  std::array<uint8_t, 256> curve;
+  const double span = double(window.high) - window.low;
+  for (unsigned i = 0; i < curve.size(); ++i) {
+    const double t = std::clamp((double(i) - window.low) / span, 0.0, 1.0);
+    curve[i] = uint8_t(std::lround(std::pow(t, GAMMA) * 255.0));
+  }
+
+  /* work on luminance: one plane to blur instead of three, and the
+     colour products keep their hue because the gain is applied to all
+     channels alike */
+  auto plane = std::make_unique<uint8_t[]>(n);
+  for (unsigned y = 0; y < height; ++y) {
+    const uint8_t *row = src + std::size_t(y) * pitch;
+    uint8_t *out = plane.get() + std::size_t(y) * width;
+
+    for (unsigned x = 0; x < width; ++x, row += bpp)
+      out[x] = curve[bpp == 1 ? row[0] : Luminance(row[0], row[1], row[2])];
+  }
+
+  /* separable Gaussian, two passes over the plane */
+  const auto kernel = MakeKernel(SHARPEN_SIGMA);
+  auto tmp = std::make_unique<float[]>(n);
+  auto blur = std::make_unique<float[]>(n);
+
+  for (unsigned y = 0; y < height; ++y) {
+    const uint8_t *row = plane.get() + std::size_t(y) * width;
+    float *out = tmp.get() + std::size_t(y) * width;
+
+    for (unsigned x = 0; x < width; ++x) {
+      float a = 0;
+      for (int i = -kernel.radius; i <= kernel.radius; ++i) {
+        const int xx = std::clamp(int(x) + i, 0, int(width) - 1);
+        a += kernel.tap[std::size_t(i + kernel.radius)] * row[xx];
+      }
+      out[x] = a;
+    }
+  }
+
+  for (unsigned y = 0; y < height; ++y) {
+    float *out = blur.get() + std::size_t(y) * width;
+
+    for (unsigned x = 0; x < width; ++x) {
+      float a = 0;
+      for (int i = -kernel.radius; i <= kernel.radius; ++i) {
+        const int yy = std::clamp(int(y) + i, 0, int(height) - 1);
+        a += kernel.tap[std::size_t(i + kernel.radius)] *
+          tmp[std::size_t(yy) * width + x];
+      }
+      out[x] = a;
+    }
+  }
+
+  auto dest = std::make_unique<uint8_t[]>(n * bpp);
+
+  for (unsigned y = 0; y < height; ++y) {
+    const uint8_t *row = src + std::size_t(y) * pitch;
+    uint8_t *out = dest.get() + std::size_t(y) * width * bpp;
+
+    for (unsigned x = 0; x < width; ++x, row += bpp, out += bpp) {
+      const std::size_t i = std::size_t(y) * width + x;
+      const float sharp = plane[i] + SHARPEN_AMOUNT * (plane[i] - blur[i]);
+      const unsigned value = unsigned(std::clamp(sharp, 0.0f, 255.0f));
+
+      if (bpp == 1) {
+        out[0] = uint8_t(value);
+        continue;
+      }
+
+      /* scale the three channels by the same factor, so a colour
+         composite keeps its hue and only its brightness changes */
+      const unsigned before = Luminance(row[0], row[1], row[2]);
+      for (unsigned c = 0; c < 3; ++c)
+        out[c] = before == 0
+          ? uint8_t(value)
+          : uint8_t(std::min(255u, row[c] * value / before));
+
+      if (bpp == 4)
+        out[3] = row[3];
+    }
+  }
+
+  return {image.GetFormat(), std::size_t(width) * bpp, width, height,
+          std::move(dest)};
+}

--- a/src/Weather/EUMETView/Enhance.hpp
+++ b/src/Weather/EUMETView/Enhance.hpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+
+class UncompressedImage;
+
+namespace EUMETView {
+
+/**
+ * A luminance histogram, accumulated over the tiles of a block.
+ *
+ * The imagery arrives as radiance, not albedo: EUMETView applies no
+ * contrast enhancement of its own, so a tile straight from the server
+ * is dark and flat, and how dark depends on the sun.  The cure is to
+ * stretch it, and the stretch has to know how bright the scene
+ * actually is -- which is what this counts.
+ */
+class ToneHistogram {
+  std::array<uint32_t, 256> bins{};
+  uint64_t total = 0;
+
+public:
+  void Clear() noexcept {
+    bins = {};
+    total = 0;
+  }
+
+  [[nodiscard]]
+  bool IsEmpty() const noexcept {
+    return total == 0;
+  }
+
+  [[nodiscard]]
+  uint64_t GetCount() const noexcept {
+    return total;
+  }
+
+  /**
+   * Count the pixels of one tile.  Grey, RGB and RGBA are all
+   * accepted; colour is reduced to luminance.
+   */
+  void Add(const UncompressedImage &image) noexcept;
+
+  /**
+   * @return the brightness below which @p permille of the samples
+   * lie, or 0 when empty
+   */
+  [[gnu::pure]]
+  uint8_t Percentile(unsigned permille) const noexcept;
+};
+
+/**
+ * The range of the input that is mapped onto the full output range.
+ */
+struct ToneWindow {
+  uint8_t low = 0, high = 255;
+
+  [[nodiscard]]
+  constexpr bool IsValid() const noexcept {
+    return high > low;
+  }
+
+  [[nodiscard]]
+  constexpr bool operator==(const ToneWindow &) const noexcept = default;
+};
+
+/**
+ * The window this histogram calls for: the 2nd and 98th percentile.
+ *
+ * Not the extremes, because a handful of outlying pixels would then
+ * decide the contrast of the whole picture.
+ *
+ * @return an invalid window if the histogram cannot support one
+ */
+[[gnu::pure]]
+ToneWindow MakeToneWindow(const ToneHistogram &histogram) noexcept;
+
+/**
+ * Mix a freshly measured window into the one carried over from the
+ * previous refresh, so the picture does not jump from frame to frame.
+ *
+ * The weight follows the elapsed time rather than the number of
+ * frames, because the imagery is fetched irregularly: after a long
+ * gap the old window says nothing about the present scene and is
+ * discarded, while frames in quick succession are smoothed.  One
+ * formula covers a page left open, a page opened twice an hour, and a
+ * single fetch, with no special cases.
+ *
+ * @param previous the window in use so far; an invalid one makes
+ * @p fresh the result
+ */
+[[gnu::pure]]
+ToneWindow BlendToneWindow(ToneWindow previous, ToneWindow fresh,
+                           std::chrono::steady_clock::duration elapsed) noexcept;
+
+/**
+ * How far apart two windows are, in brightness steps.  Used to decide
+ * whether a finished block is worth redrawing.
+ */
+[[gnu::pure]]
+unsigned ToneWindowDistance(ToneWindow a, ToneWindow b) noexcept;
+
+/**
+ * Stretch @p image onto @p window, then sharpen it.
+ *
+ * The sharpening is the one thing here that adds no information: it
+ * amplifies the scale of individual cloud cells so that the gaps
+ * between them read at a glance, at the cost of a little noise.
+ *
+ * @return the enhanced image, or an invalid image if the input is not
+ * one of the supported formats
+ */
+[[nodiscard]]
+UncompressedImage Enhance(const UncompressedImage &image,
+                          ToneWindow window) noexcept;
+
+} // namespace EUMETView

--- a/src/Weather/EUMETView/Satellite.cpp
+++ b/src/Weather/EUMETView/Satellite.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Satellite.hpp"
+#include "net/http/CoDownloadToFile.hpp"
+#include "co/Task.hxx"
+#include "io/FileMapping.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "LocalPath.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+
+Co::Task<AllocatedPath>
+EUMETView::DownloadTile(const Layer &layer, const GeoBitmap::TileData &tile,
+                        const BrokenDateTime &frame_time,
+                        CurlGlobal &curl, ProgressListener &progress)
+{
+  const auto url = MakeTileURL(layer, tile, frame_time);
+  if (url.empty())
+    throw std::runtime_error("No tile to fetch");
+
+  const auto cache = MakeCacheDirectory("eumetview");
+
+  /* one file per tile of the current frame, so that a tile already on
+     disk is not fetched again while the aircraft moves across it, and
+     the name follows the "satellite-<zoom>-<x>-<y>" convention the
+     rest of XCSoar uses for georeferenced tiles */
+  auto path = AllocatedPath::Build(cache,
+                                   fmt::format("satellite-{}-{}-{}.png",
+                                               tile.zoom, tile.x,
+                                               tile.y).c_str());
+
+  {
+    const auto ignored_response = co_await
+      Net::CoDownloadToFile(curl, url.c_str(), nullptr, nullptr,
+                            path, nullptr, progress);
+  }
+
+  /* EUMETView reports its errors as a WMS ServiceExceptionReport
+     carried in an ordinary "200 OK", so the file we just wrote may
+     well be XML.  Catch that here, where the message can still be
+     read, rather than letting it fail namelessly in the bitmap
+     loader. */
+  {
+    const FileMapping mapping{path};
+    const std::span<const std::byte> data{mapping};
+
+    if (!IsPNG(data)) {
+      const std::string_view text{(const char *)data.data(),
+                                  std::min(data.size(), std::size_t(4096))};
+
+      if (auto message = ExtractServiceException(text); !message.empty())
+        throw std::runtime_error(std::move(message));
+
+      throw std::runtime_error("The server did not return an image");
+    }
+  }
+
+  co_return std::move(path);
+}

--- a/src/Weather/EUMETView/Satellite.hpp
+++ b/src/Weather/EUMETView/Satellite.hpp
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/canvas/custom/GeoBitmap.hpp"
+#include "system/Path.hpp"
+
+#include <cstddef>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+struct BrokenDateTime;
+struct GeoPoint;
+class GeoBounds;
+class CurlGlobal;
+class ProgressListener;
+namespace Co { template<typename T> class Task; }
+
+/**
+ * Meteosat imagery from EUMETView, EUMETSAT's public web map service.
+ *
+ * The projection is a request parameter here, so we ask for the very
+ * box we want to draw and get a north-up image back.  The four corner
+ * georeference #MapOverlayBitmap works with is therefore correct by
+ * construction, and no reprojection happens on the device.
+ *
+ * The rendered image products are CC BY 4.0; `Fees` and
+ * `AccessConstraints` are both declared `none` in the capabilities
+ * document, so no account is needed.
+ *
+ * @see https://user.eumetsat.int/resources/user-guides/eumetview-user-guide
+ */
+namespace EUMETView {
+
+/**
+ * The attribution EUMETSAT's data policy requires us to display
+ * wherever the imagery is shown.  The year of the frame being drawn
+ * is appended to it.
+ */
+static constexpr const char *ATTRIBUTION =
+  "Contains modified EUMETSAT Meteosat data";
+
+/**
+ * One layer offered to the pilot.
+ *
+ * The set is fixed rather than read from `GetCapabilities`: the
+ * service publishes over a hundred layers, most of them of no use in
+ * a glider, and a hardcoded table costs no XML parser and no request
+ * before the first image.
+ */
+struct Layer {
+  /** the WMS layer name, as it appears in `GetCapabilities` */
+  const char *name;
+
+  /** what the configuration dialog calls it */
+  const char *label;
+
+  /**
+   * New frames appear on this grid, in minutes past the hour; the
+   * layer's `PT..M` period.
+   */
+  unsigned cadence_minutes;
+
+  /**
+   * How far behind the wall clock to look for the newest frame.  A
+   * frame is not on the server the instant it is nominally acquired,
+   * and asking for one that is not there yet is an error rather than
+   * an older picture: EUMETView answers `InvalidDimensionValue`, "no
+   * nearest match found", instead of falling back.
+   *
+   * Measured per layer; see #LATENCY_MEASURED_ON.
+   */
+  unsigned latency_minutes;
+
+  /**
+   * How old the frame on the map may get, counted from the time it
+   * depicts, before it is taken down.  It is already
+   * #latency_minutes to #latency_minutes + #cadence_minutes old when
+   * it arrives, so this has to stay clear of that sum and leave room
+   * for one failed refresh.
+   */
+  unsigned max_age_minutes;
+};
+
+/** The date the latency figures in #GetLayers() were measured. */
+static constexpr const char *LATENCY_MEASURED_ON = "2026-08-29";
+
+/** Every layer we offer, in the order the configuration lists them. */
+[[gnu::const]]
+std::span<const Layer> GetLayers() noexcept;
+
+/**
+ * The layer with the given index, clamped, so that a profile written
+ * by a newer version cannot select a layer that is not there.
+ */
+[[gnu::const]]
+const Layer &GetLayer(int index) noexcept;
+
+/**
+ * The index of the layer shown when the pilot has not chosen one.
+ * `msg_fes:rgb_eview` is the closest counterpart to what German
+ * pilots know from the pc_met `vis_hrv` images.
+ */
+static constexpr int DEFAULT_LAYER = 0;
+
+/**
+ * The zoom level of the tile grid the imagery is fetched on.
+ *
+ * A tile is then about 25 km across in mid latitudes, so the 5 x 5
+ * block below reaches at least fifty kilometres in every direction
+ * from the aircraft, as an overlay meant to be flown by should.
+ *
+ * Fixed rather than derived from the map scale on purpose: the grid
+ * is what makes a tile reusable, and a zoom that followed the map
+ * would throw the whole picture away on every pinch.  Zooming in
+ * would buy nothing either, the satellite having no more detail to
+ * give.
+ */
+static constexpr uint16_t TILE_ZOOM = 10;
+
+/**
+ * How many tiles to either side of the aircraft's own tile, so the
+ * block is (2 * #TILE_RANGE + 1) squared.
+ */
+static constexpr unsigned TILE_RANGE = 2;
+
+/** The number of tiles in the block. */
+static constexpr unsigned TILE_COUNT =
+  (2 * TILE_RANGE + 1) * (2 * TILE_RANGE + 1);
+
+/**
+ * The edge length requested per tile, in pixels.
+ *
+ * About 195 m per pixel, which oversamples every layer here by two to
+ * three times.  That is deliberate and nearly free: the interpolation
+ * happens on the server, a tile still costs only about three
+ * kilobytes, and the alternative -- one pixel per satellite sample --
+ * would draw visibly blocky under a map the pilot zooms.
+ */
+static constexpr unsigned TILE_PIXELS = 128;
+
+/**
+ * The tile the aircraft is in.
+ *
+ * @return an invalid tile if @p location is not valid
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+GeoBitmap::TileData GetAircraftTile(const GeoPoint &location) noexcept;
+
+/**
+ * The tiles to fetch around @p base, nearest first, so that on a slow
+ * or intermittent link the ground under the aircraft is drawn before
+ * anything else and the picture then fills outwards.
+ *
+ * Tiles that fall off the top or bottom of the world are dropped, so
+ * the result can be shorter than #TILE_COUNT.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::vector<GeoBitmap::TileData>
+CollectTiles(const GeoBitmap::TileData &base) noexcept;
+
+/** Are these the same tile? */
+[[gnu::const]]
+constexpr bool
+IsSameTile(const GeoBitmap::TileData &a,
+           const GeoBitmap::TileData &b) noexcept
+{
+  return a.zoom == b.zoom && a.x == b.x && a.y == b.y;
+}
+
+/**
+ * The time of the newest frame of @p layer that can be expected to be
+ * on the server at @p utc, rounded down to the layer's cadence.
+ *
+ * @return an invalid time if @p utc is not plausible
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+BrokenDateTime FrameTime(const Layer &layer,
+                         const BrokenDateTime &utc) noexcept;
+
+/**
+ * Build the `GetMap` URL for one tile of one frame.
+ *
+ * @return an empty string if the time or the tile is not usable
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::string MakeTileURL(const Layer &layer, const GeoBitmap::TileData &tile,
+                        const BrokenDateTime &frame_time);
+
+/**
+ * Is this response a PNG?
+ *
+ * Worth asking, because EUMETView reports its errors as a WMS
+ * `ServiceExceptionReport` carried in a perfectly ordinary `200 OK`.
+ * Without this check the XML would be stored as if it were the image
+ * and fail later, namelessly, in the bitmap loader.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+bool IsPNG(std::span<const std::byte> data) noexcept;
+
+/**
+ * The message out of a WMS `ServiceExceptionReport`, for the log.
+ *
+ * @return an empty string if @p data is not one, or carries no
+ * message
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::string ExtractServiceException(std::string_view data) noexcept;
+
+/**
+ * Download one tile of @p layer.
+ *
+ * Throws on error.
+ *
+ * @return the path of the downloaded image
+ */
+Co::Task<AllocatedPath>
+DownloadTile(const Layer &layer, const GeoBitmap::TileData &tile,
+             const BrokenDateTime &frame_time,
+             CurlGlobal &curl, ProgressListener &progress);
+
+} // namespace EUMETView

--- a/src/Weather/EUMETView/Satellite.hpp
+++ b/src/Weather/EUMETView/Satellite.hpp
@@ -107,19 +107,24 @@ const Layer &GetLayer(int index) noexcept;
 static constexpr int DEFAULT_LAYER = 0;
 
 /**
- * The zoom level of the tile grid the imagery is fetched on.
+ * The finest tile grid we ever fetch on.
  *
  * A tile is then about 25 km across in mid latitudes, so the 5 x 5
- * block below reaches at least fifty kilometres in every direction
- * from the aircraft, as an overlay meant to be flown by should.
+ * block reaches at least fifty kilometres in every direction from the
+ * aircraft, as an overlay meant to be flown by should.
  *
- * Fixed rather than derived from the map scale on purpose: the grid
- * is what makes a tile reusable, and a zoom that followed the map
- * would throw the whole picture away on every pinch.  Zooming in
- * would buy nothing either, the satellite having no more detail to
- * give.
+ * Zooming the map in never goes finer than this: the satellite has no
+ * more detail to give, and a finer grid would only spend data
+ * upsampling what is already there.
  */
-static constexpr uint16_t TILE_ZOOM = 10;
+static constexpr uint16_t MAX_TILE_ZOOM = 10;
+
+/**
+ * The coarsest grid, where a tile is some four hundred kilometres
+ * across and the block spans a couple of thousand.  Past that the map
+ * shows more than the satellite can see anyway.
+ */
+static constexpr uint16_t MIN_TILE_ZOOM = 6;
 
 /**
  * How many tiles to either side of the aircraft's own tile, so the
@@ -143,14 +148,32 @@ static constexpr unsigned TILE_COUNT =
 static constexpr unsigned TILE_PIXELS = 128;
 
 /**
- * The tile the aircraft is in.
+ * The grid to fetch on for a given map view: the finest one whose
+ * block still covers what the map shows, so that zooming out widens
+ * the imagery instead of leaving it covering the middle of the
+ * screen.
+ *
+ * Coarsening is the only thing the map scale decides.  Each step is a
+ * halving, so an ordinary pinch does not move it, and it never goes
+ * finer than #MAX_TILE_ZOOM.
+ *
+ * @param screen what the map shows, or an invalid bounds if unknown
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+uint16_t ChooseZoom(const GeoBounds &screen) noexcept;
+
+/**
+ * The tile the aircraft is in, on the given grid.
  *
  * @return an invalid tile if @p location is not valid
  *
  * Exposed for the unit test.
  */
 [[gnu::pure]]
-GeoBitmap::TileData GetAircraftTile(const GeoPoint &location) noexcept;
+GeoBitmap::TileData GetAircraftTile(const GeoPoint &location,
+                                    uint16_t zoom) noexcept;
 
 /**
  * The tiles to fetch around @p base, nearest first, so that on a slow

--- a/src/Weather/EUMETView/Satellite.hpp
+++ b/src/Weather/EUMETView/Satellite.hpp
@@ -167,7 +167,6 @@ std::vector<GeoBitmap::TileData>
 CollectTiles(const GeoBitmap::TileData &base) noexcept;
 
 /** Are these the same tile? */
-[[gnu::const]]
 constexpr bool
 IsSameTile(const GeoBitmap::TileData &a,
            const GeoBitmap::TileData &b) noexcept

--- a/src/Weather/EUMETView/SatelliteData.cpp
+++ b/src/Weather/EUMETView/SatelliteData.cpp
@@ -78,13 +78,42 @@ EUMETView::GetLayer(int index) noexcept
   return LAYERS[index];
 }
 
+uint16_t
+EUMETView::ChooseZoom(const GeoBounds &screen) noexcept
+{
+  if (!screen.IsValid())
+    return MAX_TILE_ZOOM;
+
+  /* the widest the map shows; the block is square, so the larger of
+     the two has to fit */
+  const double view = std::max(screen.GetGeoWidth(), screen.GetGeoHeight());
+  if (!(view > 0))
+    return MAX_TILE_ZOOM;
+
+  /* a tile at zoom z spans EQUATOR / 2^z along the parallel, and the
+     block is (2 * TILE_RANGE + 1) of them.  Take the coarsest step
+     that still covers the view, then refuse to go finer than the
+     satellite's own detail. */
+  constexpr double EQUATOR = 40075017;
+  const double parallel =
+    EQUATOR * std::cos(screen.GetCenter().latitude.Radians());
+  const double tiles_across = 2 * TILE_RANGE + 1;
+
+  const double ratio = tiles_across * parallel / view;
+  if (!(ratio > 1))
+    return MIN_TILE_ZOOM;
+
+  const int zoom = int(std::floor(std::log2(ratio)));
+  return uint16_t(std::clamp(zoom, int(MIN_TILE_ZOOM), int(MAX_TILE_ZOOM)));
+}
+
 GeoBitmap::TileData
-EUMETView::GetAircraftTile(const GeoPoint &location) noexcept
+EUMETView::GetAircraftTile(const GeoPoint &location, uint16_t zoom) noexcept
 {
   if (!location.IsValid())
     return {};
 
-  return GeoBitmap::GetTile(GeoBounds{location}, TILE_ZOOM);
+  return GeoBitmap::GetTile(GeoBounds{location}, zoom);
 }
 
 std::vector<GeoBitmap::TileData>

--- a/src/Weather/EUMETView/SatelliteData.cpp
+++ b/src/Weather/EUMETView/SatelliteData.cpp
@@ -1,0 +1,263 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Satellite.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Language/Language.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <string>
+
+namespace {
+
+constexpr const char *SERVICE_URL = "https://view.eumetsat.int/geoserver/wms";
+
+constexpr std::array<EUMETView::Layer, 6> LAYERS{{
+  /* first, and the default: the closest counterpart to the pc_met
+     vis_hrv images, and the one product here that covers Europe at
+     the HRV sampling German pilots are used to reading */
+  {"msg_fes:rgb_eview", N_("European HRV RGB"), 15, 30, 65},
+
+  /* MTG, which resolves about twice as finely as SEVIRI HRV */
+  {"mtg_fd:vis06_hrfi", N_("Visible 0.6 µm (MTG)"), 10, 25, 50},
+  {"mtg_fd:ir105_hrfi", N_("Infrared 10.5 µm (MTG)"), 10, 25, 50},
+
+  /* the RGB composites are assembled from several channels and reach
+     the server a few minutes behind the single channel products */
+  {"mtg_fd:rgb_truecolour", N_("True colour (MTG)"), 10, 30, 55},
+  {"mtg_fd:rgb_geocolour", N_("Geo colour (MTG)"), 10, 30, 55},
+
+  /* five minute cadence, and the promptest of them by a wide margin */
+  {"msg_rss:rgb_natural_nrt", N_("Rapid scan natural colour"), 5, 15, 30},
+}};
+
+/**
+ * Percent-encode the characters of a WMS layer name that are
+ * reserved in a query value.  GeoServer accepts the colon raw, but a
+ * name that survives any proxy in between costs one line.
+ */
+[[gnu::pure]]
+std::string
+EncodeLayerName(const char *name) noexcept
+{
+  std::string result;
+  for (const char *p = name; *p != '\0'; ++p) {
+    if (*p == ':')
+      result += "%3A";
+    else
+      result.push_back(*p);
+  }
+
+  return result;
+}
+
+} // anonymous namespace
+
+std::span<const EUMETView::Layer>
+EUMETView::GetLayers() noexcept
+{
+  return LAYERS;
+}
+
+const EUMETView::Layer &
+EUMETView::GetLayer(int index) noexcept
+{
+  /* clamped rather than checked: a profile written by a newer version
+     may name a layer this build does not have, and falling back to
+     the default beats refusing to draw anything */
+  if (index < 0 || unsigned(index) >= LAYERS.size())
+    index = DEFAULT_LAYER;
+
+  return LAYERS[index];
+}
+
+GeoBitmap::TileData
+EUMETView::GetAircraftTile(const GeoPoint &location) noexcept
+{
+  if (!location.IsValid())
+    return {};
+
+  return GeoBitmap::GetTile(GeoBounds{location}, TILE_ZOOM);
+}
+
+std::vector<GeoBitmap::TileData>
+EUMETView::CollectTiles(const GeoBitmap::TileData &base) noexcept
+{
+  std::vector<GeoBitmap::TileData> result;
+  if (!base.IsValid())
+    return result;
+
+  const int tiles_per_axis = 1 << base.zoom;
+
+  /* longitude wraps, so a flight over the date line keeps a complete
+     block instead of losing half of it */
+  const auto normalise_x = [tiles_per_axis](int value) {
+    int result = value % tiles_per_axis;
+    if (result < 0)
+      result += tiles_per_axis;
+
+    return uint32_t(result);
+  };
+
+  struct Candidate {
+    GeoBitmap::TileData tile;
+    unsigned priority;
+  };
+
+  std::vector<Candidate> candidates;
+  candidates.reserve(TILE_COUNT);
+
+  const int range = int(TILE_RANGE);
+  for (int dx = -range; dx <= range; ++dx) {
+    for (int dy = -range; dy <= range; ++dy) {
+      const int y = int(base.y) + dy;
+      if (y < 0 || y >= tiles_per_axis)
+        /* latitude does not wrap: off the top or bottom of the world
+           there is no tile to ask for */
+        continue;
+
+      candidates.push_back({
+        {base.zoom, normalise_x(int(base.x) + dx), uint32_t(y)},
+        unsigned(dx * dx + dy * dy),
+      });
+    }
+  }
+
+  /* squared distance from the aircraft's own tile, so the block is
+     walked as rings growing outwards from underneath the glider */
+  std::stable_sort(candidates.begin(), candidates.end(),
+                   [](const auto &a, const auto &b) {
+                     return a.priority < b.priority;
+                   });
+
+  result.reserve(candidates.size());
+  for (const auto &candidate : candidates)
+    result.push_back(candidate.tile);
+
+  return result;
+}
+
+BrokenDateTime
+EUMETView::FrameTime(const Layer &layer, const BrokenDateTime &utc) noexcept
+{
+  if (!utc.IsPlausible())
+    /* without a clock we cannot tell which frame is the current one,
+       and guessing would ask for one that does not exist */
+    return BrokenDateTime::Invalid();
+
+  auto t = utc - std::chrono::minutes{layer.latency_minutes};
+  t.minute = (t.minute / layer.cadence_minutes) * layer.cadence_minutes;
+  t.second = 0;
+  return t;
+}
+
+std::string
+EUMETView::MakeTileURL(const Layer &layer, const GeoBitmap::TileData &tile,
+                       const BrokenDateTime &frame_time)
+{
+  if (!tile.IsValid() || !frame_time.IsPlausible())
+    return {};
+
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  if (!bounds.IsValid())
+    return {};
+
+  /* The tile grid is the Web Mercator one, but the image is asked for
+     in CRS:84 and therefore comes back in plate carree.  That is the
+     projection MapOverlayBitmap assumes when it interpolates between
+     the four corners, so the georeference is exact; requesting
+     EPSG:3857 would return a Mercator image and leave the renderer
+     interpolating latitude linearly through it.
+
+     CRS:84 rather than EPSG:4326 because the latter puts latitude
+     first in WMS 1.3.0, a standing source of silently transposed
+     maps. */
+  return fmt::format("{}?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap"
+                     "&LAYERS={}&STYLES=&CRS=CRS:84"
+                     "&BBOX={:.6f},{:.6f},{:.6f},{:.6f}"
+                     "&WIDTH={}&HEIGHT={}&FORMAT=image/png&TRANSPARENT=TRUE"
+                     "&TIME={:04}-{:02}-{:02}T{:02}:{:02}:00Z",
+                     SERVICE_URL, EncodeLayerName(layer.name),
+                     bounds.GetWest().Degrees(), bounds.GetSouth().Degrees(),
+                     bounds.GetEast().Degrees(), bounds.GetNorth().Degrees(),
+                     TILE_PIXELS, TILE_PIXELS,
+                     frame_time.year, frame_time.month, frame_time.day,
+                     frame_time.hour, frame_time.minute);
+}
+
+bool
+EUMETView::IsPNG(std::span<const std::byte> data) noexcept
+{
+  static constexpr std::array<unsigned char, 8> SIGNATURE{
+    0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+  };
+
+  if (data.size() < SIGNATURE.size())
+    return false;
+
+  return std::equal(SIGNATURE.begin(), SIGNATURE.end(), data.begin(),
+                    [](unsigned char a, std::byte b){
+                      return a == (unsigned char)b;
+                    });
+}
+
+std::string
+EUMETView::ExtractServiceException(std::string_view data) noexcept
+{
+  /* the report's own element is <ServiceExceptionReport>, which
+     starts with the same characters, so a plain search would find the
+     wrapper and return the inner tag along with the message */
+  std::string_view::size_type open = 0;
+  while (true) {
+    open = data.find("<ServiceException", open);
+    if (open == data.npos)
+      return {};
+
+    const auto after = open + std::strlen("<ServiceException");
+    if (after >= data.size())
+      return {};
+
+    if (const char ch = data[after];
+        ch == '>' || ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r')
+      break;
+
+    ++open;
+  }
+
+  const auto text = data.find('>', open);
+  if (text == data.npos)
+    return {};
+
+  const auto close = data.find("</ServiceException>", text);
+  if (close == data.npos)
+    return {};
+
+  auto message = data.substr(text + 1, close - text - 1);
+
+  /* the report is pretty-printed across several lines; fold it into
+     one so it fits a log entry */
+  std::string result;
+  bool space = true;
+  for (char ch : message) {
+    if (ch == '\n' || ch == '\r' || ch == '\t' || ch == ' ') {
+      if (!space && !result.empty())
+        result.push_back(' ');
+      space = true;
+    } else {
+      result.push_back(ch);
+      space = false;
+    }
+  }
+
+  while (!result.empty() && result.back() == ' ')
+    result.pop_back();
+
+  return result;
+}

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -244,26 +244,16 @@ IsShown(const GeoBitmap::TileData &tile, int layer,
 void
 ReleaseUnwantedSlots() noexcept
 {
-  for (unsigned i = 0; i < slots.size(); ++i) {
-    const auto &slot = slots[i];
-    if (!slot.IsUsed())
-      continue;
-
-    /* only the position decides.  A tile showing an older frame stays
-       on the map until the new frame's tile for the same ground has
-       actually arrived, so a newly published frame does not blank the
-       overlay for the length of twenty-five requests.  Letting it go
-       stale is bounded by the age limit below, which is the mechanism
-       for that; this one is only about which ground is covered. */
-    const bool keep = slot.layer == block_layer &&
-      std::any_of(wanted.begin(), wanted.end(),
-                  [&slot](const auto &t){
-                    return EUMETView::IsSameTile(slot.tile, t);
-                  });
-
-    if (!keep)
+  /* Only a change of product empties the map.  A tile the block no
+     longer wants -- left behind by flying on, or drawn on the grid
+     the map used before it was zoomed -- stays until something
+     actually replaces it, because taking it down first would blank
+     the overlay for as long as the new block takes to arrive.  They
+     are evicted one at a time by InstallTile(), as the tiles that
+     cover the same ground come in. */
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && slots[i].layer != block_layer)
       ReleaseSlot(i);
-  }
 }
 
 /**
@@ -284,6 +274,42 @@ FindSlotFor(const GeoBitmap::TileData &tile) noexcept
   for (unsigned i = 0; i < slots.size(); ++i)
     if (!slots[i].IsUsed())
       return int(i);
+
+  /* Every slot is taken, so one of the tiles the block no longer
+     wants has to go.  Take one this tile covers: a coarser tile spans
+     several finer ones, and leaving those underneath would draw the
+     same ground twice, each at partial opacity, and darken it. */
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed())
+      continue;
+
+    const bool wanted_here =
+      std::any_of(wanted.begin(), wanted.end(),
+                  [&slot](const auto &t){
+                    return EUMETView::IsSameTile(slot.tile, t);
+                  });
+
+    if (!wanted_here && bounds.Overlaps(GeoBitmap::GetBounds(slot.tile))) {
+      ReleaseSlot(i);
+      return int(i);
+    }
+  }
+
+  /* nothing overlapping to reclaim; give up the first stale tile
+     anywhere rather than drop the one that just arrived */
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (slot.IsUsed() &&
+        std::none_of(wanted.begin(), wanted.end(),
+                     [&slot](const auto &t){
+                       return EUMETView::IsSameTile(slot.tile, t);
+                     })) {
+      ReleaseSlot(i);
+      return int(i);
+    }
+  }
 
   return -1;
 }
@@ -410,12 +436,21 @@ SatelliteDownloadGlue::OnCompleteNotify() noexcept
 }
 
 void
-SatelliteDownloadGlue::Schedule() noexcept
+SatelliteDownloadGlue::Schedule(bool soon) noexcept
 {
-  /* the fastest layer publishes every five minutes, so once a minute
-     catches a new frame soon enough; it also retries whatever the
-     link dropped */
-  timer.Schedule(std::chrono::minutes{1});
+  /* Once the block stands there is nothing to do until the next frame
+     is published, and the fastest layer publishes every five minutes,
+     so a minute is soon enough -- and cheap enough to run for as long
+     as the page is open.
+     
+     While it is still being built the same minute is far too long.
+     The first activation usually happens before the GPS has a fix,
+     and the block is centred on the aircraft, so it can do nothing
+     but wait; a minute of that is most of the delay before any
+     imagery appears. */
+  timer.Schedule(soon
+                 ? std::chrono::steady_clock::duration{std::chrono::seconds{1}}
+                 : std::chrono::steady_clock::duration{std::chrono::minutes{1}});
 }
 
 void
@@ -457,21 +492,22 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
 
   active_layer = layer_index;
 
-  /* arm the timer first: it has to keep running even on the turns
-     where there is nothing to fetch, or the picture would never age
-     out and a dropped tile would never be retried */
-  glue->Schedule();
-
   const auto &basic = CommonInterface::Basic();
-  if (!basic.location_available)
+  if (!basic.location_available) {
     /* the block is centred on the aircraft, so without a fix there is
-       nothing to centre it on */
+       nothing to centre it on -- but a fix is usually seconds away at
+       startup, and waiting a minute to notice it is most of the delay
+       before any imagery appears */
+    glue->Schedule(true);
     return;
+  }
 
   const auto &layer = GetLayer(layer_index);
   const auto frame_time = FrameTime(layer, BrokenDateTime::NowUTC());
-  if (!frame_time.IsPlausible())
+  if (!frame_time.IsPlausible()) {
+    glue->Schedule(true);
     return;
+  }
 
   const auto &projection = map->VisibleProjection();
   const auto screen = projection.IsValid()
@@ -483,8 +519,10 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
      the middle of the screen.  A change of grid makes a different
      base tile, which rebuilds the block below. */
   const auto base = GetAircraftTile(basic.location, ChooseZoom(screen));
-  if (!base.IsValid())
+  if (!base.IsValid()) {
+    glue->Schedule(true);
     return;
+  }
 
   /* recompute the block when the aircraft has crossed into another
      tile, or when a newer frame is due.  Everything is keyed on the
@@ -500,15 +538,24 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
     consecutive_failures = 0;
   }
 
-  if (glue->IsRunning() || wanted.empty())
+  if (glue->IsRunning() || wanted.empty()) {
+    glue->Schedule(true);
     return;
+  }
 
-  if (consecutive_failures >= wanted.size())
-    /* the whole block failed in a row; wait for the timer rather than
-       spin */
+  if (consecutive_failures >= wanted.size()) {
+    /* the whole block failed in a row; back off to the slow tick
+       rather than spin on a link or a layer that is not answering */
+    glue->Schedule(false);
     return;
+  }
 
   const auto next = NextMissingTile();
+
+  /* keep looking often while the block is still coming in, and settle
+     back to once a minute once it stands */
+  glue->Schedule(next.IsValid());
+
   if (!next.IsValid())
     /* the block is complete */
     return;

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -384,6 +384,18 @@ SatelliteDownloadGlue::OnCompleteNotify() noexcept
        is of something else entirely */
     return;
 
+  if (std::none_of(wanted.begin(), wanted.end(),
+                   [this](const auto &t){
+                     return EUMETView::IsSameTile(t, tile);
+                   }))
+    /* the block moved out from under this request: the aircraft
+       crossed into another tile while it was in flight, the block was
+       rebuilt around the new centre and this tile's slot was given
+       back.  The frame never changed, so checking that would not
+       catch it, and installing now would put a tile outside the block
+       on the map and hold a slot the block still wants. */
+    return;
+
   /* a tile that arrives but will not load must count as a failure,
      or NextMissingTile() would hand back the same tile for ever and
      we would download it in a loop */

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "SatellitePageOverlay.hpp"
+#include "Enhance.hpp"
 #include "co/Task.hxx"
 #include "Components.hpp"
 #include "NetComponents.hpp"
@@ -15,6 +16,8 @@
 #include "Operation/ProgressListener.hpp"
 #include "lib/curl/Global.hxx"
 #include "ui/canvas/Bitmap.hpp"
+#include "ui/canvas/custom/LibPNG.hpp"
+#include "ui/canvas/custom/UncompressedImage.hpp"
 #include "util/BindMethod.hxx"
 
 #include <fmt/format.h>
@@ -136,6 +139,9 @@ struct Slot {
   /** the frame this tile depicts */
   BrokenDateTime frame_time = BrokenDateTime::Invalid();
 
+  /** the cached file, so the tile can be drawn again with a new stretch */
+  AllocatedPath path{nullptr};
+
   constexpr bool IsUsed() const noexcept {
     return overlay != nullptr;
   }
@@ -164,6 +170,27 @@ GeoBitmap::TileData block_base{};
 
 /** the tiles the block wants, nearest to the aircraft first */
 std::vector<GeoBitmap::TileData> wanted;
+
+/**
+ * The brightness of the block being filled, counted tile by tile as
+ * they arrive.
+ */
+EUMETView::ToneHistogram block_histogram;
+
+/**
+ * The stretch in force.  Invalid before the first block has finished,
+ * which is what makes the first block stretch every tile on its own:
+ * something has to be drawn before anything is known about the scene,
+ * and a tile of its own is the only measure available.  The seams
+ * that costs are gone as soon as the block completes.
+ */
+EUMETView::ToneWindow tone_window{0, 0};
+
+/** when #tone_window was last measured, for the time-decayed blend */
+std::chrono::steady_clock::time_point tone_time{};
+
+/** a window that has moved less than this is not worth a redraw */
+constexpr unsigned TONE_REDRAW_THRESHOLD = 5;
 
 /**
  * Tiles that failed, so a layer the server will not serve at all does
@@ -329,7 +356,31 @@ InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
 
   Bitmap bitmap;
   try {
-    if (!bitmap.LoadFile(path))
+    auto image = LoadPNG(path);
+    if (!image.IsDefined())
+      return false;
+
+    /* every tile counts towards the block, whichever stretch it is
+       drawn with; the count is what the next block will be stretched
+       on */
+    block_histogram.Add(image);
+
+    /* before the first block has finished there is no measure of the
+       scene, so the tile is stretched on itself.  That makes the tile
+       boundaries visible until the block completes, which is the
+       price of drawing something immediately. */
+    auto window = tone_window;
+    if (!window.IsValid()) {
+      EUMETView::ToneHistogram own;
+      own.Add(image);
+      window = EUMETView::MakeToneWindow(own);
+    }
+
+    if (auto enhanced = EUMETView::Enhance(image, window);
+        enhanced.IsDefined())
+      image = std::move(enhanced);
+
+    if (!bitmap.Load(std::move(image)))
       return false;
   } catch (...) {
     LogError(std::current_exception(), "Satellite overlay");
@@ -361,6 +412,7 @@ InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
     slot.tile = tile;
     slot.layer = layer_index;
     slot.frame_time = frame_time;
+    slot.path = AllocatedPath{path};
     map->SetOverlay(unsigned(index), std::move(bmp));
     return true;
   } catch (...) {
@@ -383,6 +435,44 @@ NextMissingTile() noexcept
       return tile;
 
   return {};
+}
+
+/**
+ * The block stands: measure it, fold the measurement into the stretch
+ * carried between refreshes, and draw the tiles again if that moved
+ * the stretch far enough to see.
+ *
+ * The redraw is what removes the seams the first block was drawn
+ * with.  From then on it hardly ever fires, because the stretch of
+ * one refresh is a good prediction of the next.
+ */
+void
+FinishBlock() noexcept
+{
+  const auto fresh = EUMETView::MakeToneWindow(block_histogram);
+  if (!fresh.IsValid())
+    return;
+
+  const auto now = std::chrono::steady_clock::now();
+  const auto previous = tone_window;
+  tone_window = EUMETView::BlendToneWindow(previous, fresh, now - tone_time);
+  tone_time = now;
+
+  if (previous.IsValid() &&
+      EUMETView::ToneWindowDistance(previous, tone_window) < TONE_REDRAW_THRESHOLD)
+    /* the picture would not visibly change */
+    return;
+
+  for (auto &slot : slots) {
+    if (!slot.IsUsed() || slot.path == nullptr)
+      continue;
+
+    /* InstallTile() finds this very slot again, because the tile it
+       is asked for is the one already in it.  A failure here is not
+       worth reacting to: the tile drawn with the old stretch stays,
+       which is exactly what we would fall back to anyway. */
+    (void)InstallTile(slot.path, slot.layer, slot.tile, slot.frame_time);
+  }
 }
 
 } // anonymous namespace
@@ -544,6 +634,7 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
     wanted = CollectTiles(base);
     ReleaseUnwantedSlots();
     consecutive_failures = 0;
+    block_histogram.Clear();
   }
 
   if (glue->IsRunning() || wanted.empty()) {
@@ -564,9 +655,11 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
      back to once a minute once it stands */
   glue->Schedule(next.IsValid());
 
-  if (!next.IsValid())
+  if (!next.IsValid()) {
     /* the block is complete */
+    FinishBlock();
     return;
+  }
 
   glue->Start(layer_index, next, frame_time);
 }

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -154,18 +154,31 @@ std::vector<GeoBitmap::TileData> wanted;
 unsigned consecutive_failures = 0;
 
 /**
- * How long ago the frame on the map was taken, or a negative duration
+ * How old the oldest tile still on the map is, or a negative duration
  * when nothing is on the map.
+ *
+ * Measured against the tiles actually drawn rather than the frame we
+ * are currently chasing: while a new frame is being fetched the two
+ * differ, and it is what the pilot can see that has to be judged.
  */
 [[gnu::pure]]
 std::chrono::system_clock::duration
-BlockAge() noexcept
+DisplayedAge() noexcept
 {
   const auto now = BrokenDateTime::NowUTC();
-  if (!block_frame.IsPlausible() || !now.IsPlausible())
+  if (!now.IsPlausible())
     return std::chrono::system_clock::duration{-1};
 
-  return now - block_frame;
+  auto oldest = std::chrono::system_clock::duration{-1};
+  for (const auto &slot : slots) {
+    if (!slot.IsUsed() || !slot.frame_time.IsPlausible())
+      continue;
+
+    if (const auto age = now - slot.frame_time; age > oldest)
+      oldest = age;
+  }
+
+  return oldest;
 }
 
 /** Drop one slot, if the map is still showing what we put there. */
@@ -217,22 +230,36 @@ ReleaseUnwantedSlots() noexcept
     if (!slot.IsUsed())
       continue;
 
-    const bool keep = slot.frame_time == block_frame &&
-      std::any_of(wanted.begin(), wanted.end(),
-                  [&slot](const auto &t){
-                    return EUMETView::IsSameTile(slot.tile, t);
-                  });
+    /* only the position decides.  A tile showing an older frame stays
+       on the map until the new frame's tile for the same ground has
+       actually arrived, so a newly published frame does not blank the
+       overlay for the length of twenty-five requests.  Letting it go
+       stale is bounded by the age limit below, which is the mechanism
+       for that; this one is only about which ground is covered. */
+    const bool keep = std::any_of(wanted.begin(), wanted.end(),
+                                  [&slot](const auto &t){
+                                    return EUMETView::IsSameTile(slot.tile, t);
+                                  });
 
     if (!keep)
       ReleaseSlot(i);
   }
 }
 
-/** The first slot not holding a tile we want to keep. */
+/**
+ * Where to put a tile: the slot already covering that ground, so a
+ * newer frame replaces the older picture of it rather than piling a
+ * second overlay on top and exhausting the slots; otherwise any free
+ * one.
+ */
 [[gnu::pure]]
 int
-FindFreeSlot() noexcept
+FindSlotFor(const GeoBitmap::TileData &tile) noexcept
 {
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && EUMETView::IsSameTile(slots[i].tile, tile))
+      return int(i);
+
   for (unsigned i = 0; i < slots.size(); ++i)
     if (!slots[i].IsUsed())
       return int(i);
@@ -248,7 +275,7 @@ InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
   if (map == nullptr || path == nullptr)
     return;
 
-  const int index = FindFreeSlot();
+  const int index = FindSlotFor(tile);
   if (index < 0)
     return;
 
@@ -354,7 +381,7 @@ SatelliteDownloadGlue::OnTimer() noexcept
     /* no page is showing the imagery */
     return;
 
-  const auto age = BlockAge();
+  const auto age = DisplayedAge();
   if (age >= std::chrono::system_clock::duration::zero() &&
       age > std::chrono::minutes{
         EUMETView::GetLayer(active_layer).max_age_minutes}) {

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -507,6 +507,12 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
   glue->Start(layer_index, next, frame_time);
 }
 
+int
+EUMETView::GetActiveLayer() noexcept
+{
+  return active_layer;
+}
+
 void
 EUMETView::ClearMapOverlay() noexcept
 {

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -1,0 +1,451 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "SatellitePageOverlay.hpp"
+#include "co/Task.hxx"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "UIGlobals.hpp"
+#include "Interface.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "MapWindow/GlueMapWindow.hpp"
+#include "MapWindow/OverlayBitmap.hpp"
+#include "MapWindow/OverlayLimits.hpp"
+#include "Operation/ProgressListener.hpp"
+#include "lib/curl/Global.hxx"
+#include "ui/canvas/Bitmap.hpp"
+#include "util/BindMethod.hxx"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+static_assert(EUMETView::TILE_COUNT <= MapWindowOverlay::MAX_MAP_OVERLAYS,
+              "the tile block has to fit the map's overlay slots");
+
+/**
+ * The imagery is drawn under the map, so it has to stay a background:
+ * terrain, airspace and the task are what the pilot is flying by, and
+ * an opaque infrared frame would bury them.
+ */
+static constexpr double OVERLAY_ALPHA = 0.55;
+
+/**
+ * A tile is a few kilobytes, and there are up to twenty-five of them.
+ * Showing the download bar for each would flicker it across the top
+ * of the map for the whole flight, so the tiles are fetched quietly.
+ */
+class QuietProgress final : public ProgressListener {
+public:
+  void SetProgressRange([[maybe_unused]] unsigned range) noexcept override {}
+  void SetProgressPosition([[maybe_unused]] unsigned position) noexcept override {}
+};
+
+static QuietProgress quiet_progress;
+
+SatelliteDownloadGlue *
+GetSatelliteDownloadGlue() noexcept
+{
+  if (net_components == nullptr)
+    return nullptr;
+
+  return net_components->eumetview_satellite.get();
+}
+
+SatelliteDownloadGlue::SatelliteDownloadGlue(CurlGlobal &_curl) noexcept
+  :curl(_curl),
+   task(curl.GetEventLoop())
+{
+}
+
+void
+SatelliteDownloadGlue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  path = nullptr;
+  completion_error = {};
+}
+
+void
+SatelliteDownloadGlue::Start(int _layer_index,
+                             const GeoBitmap::TileData &_tile,
+                             const BrokenDateTime &_frame_time) noexcept
+{
+  if (task.IsShuttingDown() || task.IsRunning())
+    /* leave the running request alone: overwriting what it was asked
+       for would georeference its image by this tile's corners */
+    return;
+
+  if (!_tile.IsValid() || !_frame_time.IsPlausible())
+    return;
+
+  layer_index = _layer_index;
+  tile = _tile;
+  frame_time = _frame_time;
+  path = nullptr;
+  completion_error = {};
+
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+SatelliteDownloadGlue::RunDownload()
+{
+  path = co_await EUMETView::DownloadTile(EUMETView::GetLayer(layer_index),
+                                          tile, frame_time, curl,
+                                          quiet_progress);
+}
+
+void
+SatelliteDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
+
+namespace {
+
+/**
+ * One overlay slot, and the tile it is showing.
+ *
+ * The slot index is the map's overlay index, so a tile that survives
+ * a move stays exactly where it is and is never re-uploaded.
+ */
+struct Slot {
+  /** the overlay we installed, so we never remove somebody else's */
+  const MapOverlay *overlay = nullptr;
+
+  GeoBitmap::TileData tile{};
+
+  /** the frame this tile depicts */
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+
+  constexpr bool IsUsed() const noexcept {
+    return overlay != nullptr;
+  }
+};
+
+std::array<Slot, EUMETView::TILE_COUNT> slots;
+
+/** the layer the open page selected, or -1 when no page shows one */
+int active_layer = -1;
+
+/** the frame the block is being filled with */
+BrokenDateTime block_frame = BrokenDateTime::Invalid();
+
+/** the aircraft's tile the current block is centred on */
+GeoBitmap::TileData block_base{};
+
+/** the tiles the block wants, nearest to the aircraft first */
+std::vector<GeoBitmap::TileData> wanted;
+
+/**
+ * Tiles that failed, so a layer the server will not serve at all does
+ * not spin through the whole block once a second.  Cleared whenever
+ * the frame moves on.
+ */
+unsigned consecutive_failures = 0;
+
+/**
+ * How long ago the frame on the map was taken, or a negative duration
+ * when nothing is on the map.
+ */
+[[gnu::pure]]
+std::chrono::system_clock::duration
+BlockAge() noexcept
+{
+  const auto now = BrokenDateTime::NowUTC();
+  if (!block_frame.IsPlausible() || !now.IsPlausible())
+    return std::chrono::system_clock::duration{-1};
+
+  return now - block_frame;
+}
+
+/** Drop one slot, if the map is still showing what we put there. */
+void
+ReleaseSlot(unsigned index) noexcept
+{
+  auto &slot = slots[index];
+  if (!slot.IsUsed())
+    return;
+
+  if (auto *map = UIGlobals::GetMap();
+      map != nullptr && map->GetOverlay(index) == slot.overlay)
+    map->SetOverlay(index, nullptr);
+
+  slot = {};
+}
+
+/** Is this tile already on the map, showing the right frame? */
+[[gnu::pure]]
+bool
+IsShown(const GeoBitmap::TileData &tile,
+        const BrokenDateTime &frame_time) noexcept
+{
+  const auto *map = UIGlobals::GetMap();
+  if (map == nullptr)
+    return false;
+
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (slot.IsUsed() && map->GetOverlay(i) == slot.overlay &&
+        EUMETView::IsSameTile(slot.tile, tile) &&
+        slot.frame_time == frame_time)
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * Give up the slots holding tiles the block no longer wants -- the
+ * ones left behind as the aircraft flew on, and everything at all
+ * when the frame moved on.
+ */
+void
+ReleaseUnwantedSlots() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed())
+      continue;
+
+    const bool keep = slot.frame_time == block_frame &&
+      std::any_of(wanted.begin(), wanted.end(),
+                  [&slot](const auto &t){
+                    return EUMETView::IsSameTile(slot.tile, t);
+                  });
+
+    if (!keep)
+      ReleaseSlot(i);
+  }
+}
+
+/** The first slot not holding a tile we want to keep. */
+[[gnu::pure]]
+int
+FindFreeSlot() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (!slots[i].IsUsed())
+      return int(i);
+
+  return -1;
+}
+
+void
+InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
+            const BrokenDateTime &frame_time) noexcept
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || path == nullptr)
+    return;
+
+  const int index = FindFreeSlot();
+  if (index < 0)
+    return;
+
+  Bitmap bitmap;
+  try {
+    if (!bitmap.LoadFile(path))
+      return;
+  } catch (...) {
+    LogError(std::current_exception(), "Satellite overlay");
+    return;
+  }
+
+  /* EUMETSAT's data policy makes the attribution mandatory wherever
+     the imagery is shown; the overlay label carries it, so tapping
+     the map names the source */
+  const auto &layer = EUMETView::GetLayer(layer_index);
+  const auto label = fmt::format("{} — {} {}", gettext(layer.label),
+                                 EUMETView::ATTRIBUTION, frame_time.year);
+
+  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                GeoBitmap::GetGeoQuadrilateral(tile),
+                                                label.c_str());
+  bmp->SetAlpha(OVERLAY_ALPHA);
+
+  auto &slot = slots[index];
+  slot.overlay = bmp.get();
+  slot.tile = tile;
+  slot.frame_time = frame_time;
+  map->SetOverlay(unsigned(index), std::move(bmp));
+}
+
+/**
+ * The next tile of the block that is not on the map yet, or an
+ * invalid tile when the block is complete.  #wanted is already in
+ * nearest first order, so this walks outwards from the aircraft.
+ */
+[[gnu::pure]]
+GeoBitmap::TileData
+NextMissingTile() noexcept
+{
+  for (const auto &tile : wanted)
+    if (!IsShown(tile, block_frame))
+      return tile;
+
+  return {};
+}
+
+} // anonymous namespace
+
+void
+SatelliteDownloadGlue::OnCompleteNotify() noexcept
+{
+  if (task.IsShuttingDown())
+    return;
+
+  if (completion_error) {
+    LogError(std::exchange(completion_error, {}), "Satellite download");
+
+    /* send the tile that failed to the back of the queue, so one the
+       server will not serve does not stand in front of the rest of
+       the block for the whole flight */
+    if (const auto i = std::find_if(wanted.begin(), wanted.end(),
+                                    [this](const auto &t){
+                                      return EUMETView::IsSameTile(t, tile);
+                                    });
+        i != wanted.end())
+      std::rotate(i, i + 1, wanted.end());
+
+    /* one lost tile is nothing on a link like this; a whole block of
+       them means the layer or the connection is gone, and hammering
+       it would only spend the pilot's data */
+    ++consecutive_failures;
+    return;
+  }
+
+  consecutive_failures = 0;
+  InstallTile(path, layer_index, tile, frame_time);
+
+  /* straight on to the next tile, so the block fills as fast as the
+     link allows rather than one tile per timer tick */
+  EUMETView::ActivatePageOverlay(active_layer);
+}
+
+void
+SatelliteDownloadGlue::Schedule() noexcept
+{
+  /* the fastest layer publishes every five minutes, so once a minute
+     catches a new frame soon enough; it also retries whatever the
+     link dropped */
+  timer.Schedule(std::chrono::minutes{1});
+}
+
+void
+SatelliteDownloadGlue::Cancel() noexcept
+{
+  timer.Cancel();
+}
+
+void
+SatelliteDownloadGlue::OnTimer() noexcept
+{
+  if (active_layer < 0)
+    /* no page is showing the imagery */
+    return;
+
+  const auto age = BlockAge();
+  if (age >= std::chrono::system_clock::duration::zero() &&
+      age > std::chrono::minutes{
+        EUMETView::GetLayer(active_layer).max_age_minutes}) {
+    /* down it comes before anything is fetched, so that a refresh
+       which hangs or fails cannot leave an hours-old cloud picture
+       standing with nothing to say so */
+    EUMETView::ClearMapOverlay();
+  }
+
+  /* a new minute is a new chance for whatever the link dropped */
+  consecutive_failures = 0;
+
+  EUMETView::ActivatePageOverlay(active_layer);
+}
+
+void
+EUMETView::ActivatePageOverlay(int layer_index) noexcept
+{
+  auto *glue = GetSatelliteDownloadGlue();
+  const auto *map = UIGlobals::GetMap();
+  if (glue == nullptr || map == nullptr || layer_index < 0)
+    return;
+
+  active_layer = layer_index;
+
+  /* arm the timer first: it has to keep running even on the turns
+     where there is nothing to fetch, or the picture would never age
+     out and a dropped tile would never be retried */
+  glue->Schedule();
+
+  const auto &basic = CommonInterface::Basic();
+  if (!basic.location_available)
+    /* the block is centred on the aircraft, so without a fix there is
+       nothing to centre it on */
+    return;
+
+  const auto &layer = GetLayer(layer_index);
+  const auto frame_time = FrameTime(layer, BrokenDateTime::NowUTC());
+  if (!frame_time.IsPlausible())
+    return;
+
+  const auto base = GetAircraftTile(basic.location);
+  if (!base.IsValid())
+    return;
+
+  /* recompute the block when the aircraft has crossed into another
+     tile, or when a newer frame is due.  Everything is keyed on the
+     tile grid, so a few kilometres of flight change nothing and the
+     tiles already fetched stay on the map. */
+  if (!IsSameTile(base, block_base) || !(frame_time == block_frame)) {
+    block_base = base;
+    block_frame = frame_time;
+    wanted = CollectTiles(base);
+    ReleaseUnwantedSlots();
+    consecutive_failures = 0;
+  }
+
+  if (glue->IsRunning() || wanted.empty())
+    return;
+
+  if (consecutive_failures >= wanted.size())
+    /* the whole block failed in a row; wait for the timer rather than
+       spin */
+    return;
+
+  const auto next = NextMissingTile();
+  if (!next.IsValid())
+    /* the block is complete */
+    return;
+
+  glue->Start(layer_index, next, frame_time);
+}
+
+void
+EUMETView::ClearMapOverlay() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i)
+    ReleaseSlot(i);
+
+  block_frame = BrokenDateTime::Invalid();
+  block_base = {};
+  wanted.clear();
+  consecutive_failures = 0;
+}
+
+void
+EUMETView::DeactivatePageOverlay() noexcept
+{
+  if (auto *glue = GetSatelliteDownloadGlue(); glue != nullptr)
+    glue->Cancel();
+
+  active_layer = -1;
+  ClearMapOverlay();
+}

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -342,23 +342,31 @@ InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
   const auto &layer = EUMETView::GetLayer(layer_index);
   /* the frame time is the part the pilot needs: it says how old the
      cloud picture is.  The year alone said nothing. */
-  const auto label = fmt::format("{} {:02}:{:02}Z — {} {}",
-                                 gettext(layer.label),
-                                 frame_time.hour, frame_time.minute,
-                                 EUMETView::ATTRIBUTION, frame_time.year);
+  /* both the label and the overlay allocate, and this runs under a
+     noexcept completion handler, where an exception is std::terminate
+     rather than a lost tile */
+  try {
+    const auto label = fmt::format("{} {:02}:{:02}Z — {} {}",
+                                   gettext(layer.label),
+                                   frame_time.hour, frame_time.minute,
+                                   EUMETView::ATTRIBUTION, frame_time.year);
 
-  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
-                                                GeoBitmap::GetGeoQuadrilateral(tile),
-                                                label.c_str());
-  bmp->SetAlpha(OVERLAY_ALPHA);
+    auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                  GeoBitmap::GetGeoQuadrilateral(tile),
+                                                  label.c_str());
+    bmp->SetAlpha(OVERLAY_ALPHA);
 
-  auto &slot = slots[index];
-  slot.overlay = bmp.get();
-  slot.tile = tile;
-  slot.layer = layer_index;
-  slot.frame_time = frame_time;
-  map->SetOverlay(unsigned(index), std::move(bmp));
-  return true;
+    auto &slot = slots[index];
+    slot.overlay = bmp.get();
+    slot.tile = tile;
+    slot.layer = layer_index;
+    slot.frame_time = frame_time;
+    map->SetOverlay(unsigned(index), std::move(bmp));
+    return true;
+  } catch (...) {
+    LogError(std::current_exception(), "Satellite overlay");
+    return false;
+  }
 }
 
 /**

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -473,7 +473,16 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
   if (!frame_time.IsPlausible())
     return;
 
-  const auto base = GetAircraftTile(basic.location);
+  const auto &projection = map->VisibleProjection();
+  const auto screen = projection.IsValid()
+    ? projection.GetScreenBounds()
+    : GeoBounds::Invalid();
+
+  /* the grid follows the map only in the coarsening direction, so
+     zooming out widens the imagery rather than leaving it covering
+     the middle of the screen.  A change of grid makes a different
+     base tile, which rebuilds the block below. */
+  const auto base = GetAircraftTile(basic.location, ChooseZoom(screen));
   if (!base.IsValid())
     return;
 

--- a/src/Weather/EUMETView/SatellitePageOverlay.cpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.cpp
@@ -29,6 +29,12 @@
 static_assert(EUMETView::TILE_COUNT <= MapWindowOverlay::MAX_MAP_OVERLAYS,
               "the tile block has to fit the map's overlay slots");
 
+/* PageSettings.hpp cannot include the layer table, so it carries its
+   own copy of the default index; tie the two together here rather
+   than letting them drift apart silently */
+static_assert(PageLayout::SATELLITE_LAYER_DEFAULT == EUMETView::DEFAULT_LAYER,
+              "the profile default must name the default layer");
+
 /**
  * The imagery is drawn under the map, so it has to stay a background:
  * terrain, airspace and the task are what the pilot is flying by, and
@@ -124,6 +130,9 @@ struct Slot {
 
   GeoBitmap::TileData tile{};
 
+  /** which product this tile is of */
+  int layer = -1;
+
   /** the frame this tile depicts */
   BrokenDateTime frame_time = BrokenDateTime::Invalid();
 
@@ -136,6 +145,16 @@ std::array<Slot, EUMETView::TILE_COUNT> slots;
 
 /** the layer the open page selected, or -1 when no page shows one */
 int active_layer = -1;
+
+/**
+ * Set while the map is panning, when the page is momentarily replaced
+ * by a layout carrying no overlay.  That is not the pilot leaving the
+ * imagery behind, so the tiles stay.
+ */
+bool suspended_for_pan = false;
+
+/** the layer the block is being filled with */
+int block_layer = -1;
 
 /** the frame the block is being filled with */
 BrokenDateTime block_frame = BrokenDateTime::Invalid();
@@ -199,7 +218,7 @@ ReleaseSlot(unsigned index) noexcept
 /** Is this tile already on the map, showing the right frame? */
 [[gnu::pure]]
 bool
-IsShown(const GeoBitmap::TileData &tile,
+IsShown(const GeoBitmap::TileData &tile, int layer,
         const BrokenDateTime &frame_time) noexcept
 {
   const auto *map = UIGlobals::GetMap();
@@ -209,7 +228,7 @@ IsShown(const GeoBitmap::TileData &tile,
   for (unsigned i = 0; i < slots.size(); ++i) {
     const auto &slot = slots[i];
     if (slot.IsUsed() && map->GetOverlay(i) == slot.overlay &&
-        EUMETView::IsSameTile(slot.tile, tile) &&
+        EUMETView::IsSameTile(slot.tile, tile) && slot.layer == layer &&
         slot.frame_time == frame_time)
       return true;
   }
@@ -236,10 +255,11 @@ ReleaseUnwantedSlots() noexcept
        overlay for the length of twenty-five requests.  Letting it go
        stale is bounded by the age limit below, which is the mechanism
        for that; this one is only about which ground is covered. */
-    const bool keep = std::any_of(wanted.begin(), wanted.end(),
-                                  [&slot](const auto &t){
-                                    return EUMETView::IsSameTile(slot.tile, t);
-                                  });
+    const bool keep = slot.layer == block_layer &&
+      std::any_of(wanted.begin(), wanted.end(),
+                  [&slot](const auto &t){
+                    return EUMETView::IsSameTile(slot.tile, t);
+                  });
 
     if (!keep)
       ReleaseSlot(i);
@@ -257,7 +277,8 @@ int
 FindSlotFor(const GeoBitmap::TileData &tile) noexcept
 {
   for (unsigned i = 0; i < slots.size(); ++i)
-    if (slots[i].IsUsed() && EUMETView::IsSameTile(slots[i].tile, tile))
+    if (slots[i].IsUsed() && slots[i].layer == block_layer &&
+        EUMETView::IsSameTile(slots[i].tile, tile))
       return int(i);
 
   for (unsigned i = 0; i < slots.size(); ++i)
@@ -267,32 +288,37 @@ FindSlotFor(const GeoBitmap::TileData &tile) noexcept
   return -1;
 }
 
-void
+[[nodiscard]]
+bool
 InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
             const BrokenDateTime &frame_time) noexcept
 {
   auto *map = UIGlobals::GetMap();
   if (map == nullptr || path == nullptr)
-    return;
+    return false;
 
   const int index = FindSlotFor(tile);
   if (index < 0)
-    return;
+    return false;
 
   Bitmap bitmap;
   try {
     if (!bitmap.LoadFile(path))
-      return;
+      return false;
   } catch (...) {
     LogError(std::current_exception(), "Satellite overlay");
-    return;
+    return false;
   }
 
   /* EUMETSAT's data policy makes the attribution mandatory wherever
      the imagery is shown; the overlay label carries it, so tapping
      the map names the source */
   const auto &layer = EUMETView::GetLayer(layer_index);
-  const auto label = fmt::format("{} — {} {}", gettext(layer.label),
+  /* the frame time is the part the pilot needs: it says how old the
+     cloud picture is.  The year alone said nothing. */
+  const auto label = fmt::format("{} {:02}:{:02}Z — {} {}",
+                                 gettext(layer.label),
+                                 frame_time.hour, frame_time.minute,
                                  EUMETView::ATTRIBUTION, frame_time.year);
 
   auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
@@ -303,8 +329,10 @@ InstallTile(Path path, int layer_index, const GeoBitmap::TileData &tile,
   auto &slot = slots[index];
   slot.overlay = bmp.get();
   slot.tile = tile;
+  slot.layer = layer_index;
   slot.frame_time = frame_time;
   map->SetOverlay(unsigned(index), std::move(bmp));
+  return true;
 }
 
 /**
@@ -317,7 +345,7 @@ GeoBitmap::TileData
 NextMissingTile() noexcept
 {
   for (const auto &tile : wanted)
-    if (!IsShown(tile, block_frame))
+    if (!IsShown(tile, block_layer, block_frame))
       return tile;
 
   return {};
@@ -351,8 +379,18 @@ SatelliteDownloadGlue::OnCompleteNotify() noexcept
     return;
   }
 
-  consecutive_failures = 0;
-  InstallTile(path, layer_index, tile, frame_time);
+  if (layer_index != block_layer)
+    /* the pilot changed product while this was in flight; the image
+       is of something else entirely */
+    return;
+
+  /* a tile that arrives but will not load must count as a failure,
+     or NextMissingTile() would hand back the same tile for ever and
+     we would download it in a loop */
+  if (InstallTile(path, layer_index, tile, frame_time))
+    consecutive_failures = 0;
+  else
+    ++consecutive_failures;
 
   /* straight on to the next tile, so the block fills as fast as the
      link allows rather than one tile per timer tick */
@@ -431,7 +469,9 @@ EUMETView::ActivatePageOverlay(int layer_index) noexcept
      tile, or when a newer frame is due.  Everything is keyed on the
      tile grid, so a few kilometres of flight change nothing and the
      tiles already fetched stay on the map. */
-  if (!IsSameTile(base, block_base) || !(frame_time == block_frame)) {
+  if (layer_index != block_layer || !IsSameTile(base, block_base) ||
+      !(frame_time == block_frame)) {
+    block_layer = layer_index;
     block_base = base;
     block_frame = frame_time;
     wanted = CollectTiles(base);
@@ -461,6 +501,7 @@ EUMETView::ClearMapOverlay() noexcept
   for (unsigned i = 0; i < slots.size(); ++i)
     ReleaseSlot(i);
 
+  block_layer = -1;
   block_frame = BrokenDateTime::Invalid();
   block_base = {};
   wanted.clear();
@@ -470,9 +511,27 @@ EUMETView::ClearMapOverlay() noexcept
 void
 EUMETView::DeactivatePageOverlay() noexcept
 {
+  if (suspended_for_pan)
+    /* the page was only replaced by the full screen pan layout.  The
+       tiles still show the right ground, and throwing them away here
+       would cost the whole block again the moment panning ends. */
+    return;
+
   if (auto *glue = GetSatelliteDownloadGlue(); glue != nullptr)
     glue->Cancel();
 
   active_layer = -1;
   ClearMapOverlay();
+}
+
+void
+EUMETView::SuspendForPan() noexcept
+{
+  suspended_for_pan = true;
+}
+
+void
+EUMETView::ResumeAfterPan() noexcept
+{
+  suspended_for_pan = false;
 }

--- a/src/Weather/EUMETView/SatellitePageOverlay.hpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.hpp
@@ -107,6 +107,17 @@ void ActivatePageOverlay(int layer_index) noexcept;
 void ClearMapOverlay() noexcept;
 
 /**
+ * Which layer is on the map, or -1 if none is.
+ *
+ * The tiles carry an attribution label rather than a bare layer name,
+ * and there are up to twenty-five of them, so the Weather dialog
+ * cannot recognise them the way it recognises a single named bitmap.
+ * It asks here instead.
+ */
+[[gnu::pure]]
+int GetActiveLayer() noexcept;
+
+/**
  * Leave the satellite page: stop fetching and take the tiles down.
  */
 void DeactivatePageOverlay() noexcept;

--- a/src/Weather/EUMETView/SatellitePageOverlay.hpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.hpp
@@ -80,8 +80,16 @@ public:
   void Start(int _layer_index, const GeoBitmap::TileData &_tile,
              const BrokenDateTime &_frame_time) noexcept;
 
-  /** Begin driving the sequence. */
-  void Schedule() noexcept;
+  /**
+   * Begin driving the sequence.
+   *
+   * @param soon while the block is still being built, or there is no
+   * fix to build it around yet.  Waiting a whole minute to notice
+   * that the GPS has come alive is most of the delay before the first
+   * tile appears; once the block is complete there is nothing to look
+   * for until the next frame is published.
+   */
+  void Schedule(bool soon) noexcept;
 
   /** Stop, because no page shows the imagery any more. */
   void Cancel() noexcept;

--- a/src/Weather/EUMETView/SatellitePageOverlay.hpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.hpp
@@ -111,4 +111,15 @@ void ClearMapOverlay() noexcept;
  */
 void DeactivatePageOverlay() noexcept;
 
+/**
+ * Entering pan mode replaces the page with a full screen map whose
+ * layout carries no overlay, which would otherwise be taken as
+ * leaving the page and throw the block away -- eighty kilobytes to
+ * fetch again because the pilot dragged the map.  The tiles are still
+ * the right ones, so hold on to them until #ResumeAfterPan().
+ */
+void SuspendForPan() noexcept;
+
+void ResumeAfterPan() noexcept;
+
 } // namespace EUMETView

--- a/src/Weather/EUMETView/SatellitePageOverlay.hpp
+++ b/src/Weather/EUMETView/SatellitePageOverlay.hpp
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Satellite.hpp"
+#include "co/InvokeTask.hxx"
+#include "net/AsyncTask.hpp"
+#include "system/Path.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "ui/event/Notify.hpp"
+#include "ui/event/PeriodicTimer.hpp"
+
+#include <exception>
+
+class CurlGlobal;
+
+/**
+ * Fetches the satellite imagery tile by tile on the network
+ * #EventLoop and installs each tile as a map overlay from the UI
+ * thread.
+ *
+ * The imagery is drawn as a block of tiles rather than one image so
+ * that a slow or intermittent link -- which is what a glider has --
+ * still puts something useful on the map quickly.  The tiles are
+ * requested nearest first, so the ground under the aircraft is drawn
+ * within a few kilobytes and the picture then fills outwards; if the
+ * connection dies half way, what is left is a complete picture of the
+ * area that matters most.
+ *
+ * A tile already fetched is kept as the aircraft moves, so flying
+ * across the block costs only the tiles that come into range.
+ */
+class SatelliteDownloadGlue final {
+  CurlGlobal &curl;
+  Net::AsyncTask task;
+  UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
+
+  /**
+   * What the running download is for.  These belong to the glue
+   * rather than to the caller, so that a request arriving while
+   * another is in flight cannot relabel the image already on its way.
+   */
+  int layer_index = -1;
+  GeoBitmap::TileData tile{};
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+
+  AllocatedPath path{nullptr};
+  std::exception_ptr completion_error;
+
+  /**
+   * Drives the sequence: picks up a newer frame, asks for the next
+   * missing tile, and takes the picture down once it is too old.
+   */
+  UI::PeriodicTimer timer{[this]{ OnTimer(); }};
+
+  Co::InvokeTask RunDownload();
+  void OnCompletion(std::exception_ptr error) noexcept;
+  void OnCompleteNotify() noexcept;
+  void OnTimer() noexcept;
+
+public:
+  explicit SatelliteDownloadGlue(CurlGlobal &_curl) noexcept;
+
+  ~SatelliteDownloadGlue() noexcept { BeginShutdown(); }
+
+  SatelliteDownloadGlue(const SatelliteDownloadGlue &) = delete;
+  SatelliteDownloadGlue &operator=(const SatelliteDownloadGlue &) = delete;
+
+  [[nodiscard]]
+  bool IsRunning() const noexcept { return task.IsRunning(); }
+
+  void BeginShutdown() noexcept;
+
+  /**
+   * Fetch one tile, unless a download is already in flight.  Only one
+   * request is ever outstanding: stacking them on a thin link makes
+   * every tile arrive late instead of the nearest one arriving early.
+   */
+  void Start(int _layer_index, const GeoBitmap::TileData &_tile,
+             const BrokenDateTime &_frame_time) noexcept;
+
+  /** Begin driving the sequence. */
+  void Schedule() noexcept;
+
+  /** Stop, because no page shows the imagery any more. */
+  void Cancel() noexcept;
+};
+
+/**
+ * The shared #SatelliteDownloadGlue from #net_components (UI thread
+ * only).
+ */
+SatelliteDownloadGlue *GetSatelliteDownloadGlue() noexcept;
+
+namespace EUMETView {
+
+/**
+ * Show the imagery around the aircraft, fetching what is missing.
+ */
+void ActivatePageOverlay(int layer_index) noexcept;
+
+/**
+ * Take our tiles off the map, leaving any overlay somebody else put
+ * there alone.
+ */
+void ClearMapOverlay() noexcept;
+
+/**
+ * Leave the satellite page: stop fetching and take the tiles down.
+ */
+void DeactivatePageOverlay() noexcept;
+
+} // namespace EUMETView

--- a/src/Weather/Features.hpp
+++ b/src/Weather/Features.hpp
@@ -10,5 +10,9 @@
 #define HAVE_PCMET
 #ifdef ENABLE_OPENGL
 #define HAVE_EDL
+
+/* the map overlay widget is only built for OpenGL targets, because
+   drawing a georeferenced bitmap needs the OpenGL canvas */
+#define HAVE_WEATHER_OVERLAY
 #endif
 #endif

--- a/src/Weather/MapOverlay/ControlsFactory.cpp
+++ b/src/Weather/MapOverlay/ControlsFactory.cpp
@@ -45,6 +45,7 @@ CreateControlsModel(const PageLayout &layout) noexcept
 #endif
 
   case PageLayout::Overlay::RADAR:
+  case PageLayout::Overlay::SATELLITE:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/ControlsFactory.cpp
+++ b/src/Weather/MapOverlay/ControlsFactory.cpp
@@ -44,6 +44,7 @@ CreateControlsModel(const PageLayout &layout) noexcept
     break;
 #endif
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/PagePlacement.hpp
+++ b/src/Weather/MapOverlay/PagePlacement.hpp
@@ -49,6 +49,7 @@ CopyWeatherOverlayCursors(PageLayout &dest,
     dest.skysight_time = src.skysight_time;
     break;
 
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/PagePlacement.hpp
+++ b/src/Weather/MapOverlay/PagePlacement.hpp
@@ -49,6 +49,10 @@ CopyWeatherOverlayCursors(PageLayout &dest,
     dest.skysight_time = src.skysight_time;
     break;
 
+  case PageLayout::Overlay::SATELLITE:
+    dest.satellite_layer = src.satellite_layer;
+    break;
+
   case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:

--- a/src/Weather/MapOverlay/WeatherSetupDialog.cpp
+++ b/src/Weather/MapOverlay/WeatherSetupDialog.cpp
@@ -26,8 +26,12 @@ ShowWeatherSetupDialog() noexcept
   case PageLayout::Overlay::SKYSIGHT:
     page = "skysight";
     break;
-  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::SATELLITE:
+    /* the imagery is listed on the Overlay tab, so open it there
+       rather than wherever the dialog was left last */
+    page = "overlay";
+    break;
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/WeatherSetupDialog.cpp
+++ b/src/Weather/MapOverlay/WeatherSetupDialog.cpp
@@ -27,6 +27,7 @@ ShowWeatherSetupDialog() noexcept
     page = "skysight";
     break;
   case PageLayout::Overlay::RADAR:
+  case PageLayout::Overlay::SATELLITE:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/MapOverlay/WeatherSetupDialog.cpp
+++ b/src/Weather/MapOverlay/WeatherSetupDialog.cpp
@@ -26,6 +26,7 @@ ShowWeatherSetupDialog() noexcept
   case PageLayout::Overlay::SKYSIGHT:
     page = "skysight";
     break;
+  case PageLayout::Overlay::RADAR:
   case PageLayout::Overlay::NONE:
   case PageLayout::Overlay::MAX:
     break;

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -4,302 +4,81 @@
 #include "Radar.hpp"
 #include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
-#include "net/http/CoDownloadToFile.hpp"
+#include "Math/Point2D.hpp"
+#include "net/http/CoGetRange.hpp"
 #include "co/Task.hxx"
-#include "io/FileMapping.hpp"
 #include "io/FileOutputStream.hxx"
-#include "time/BrokenDateTime.hpp"
 #include "util/AllocatedArray.hxx"
 #include "util/ByteOrder.hxx"
+#include "time/BrokenDateTime.hpp"
 #include "LocalPath.hpp"
+#include "Operation/ProgressListener.hpp"
 
 #include <zlib.h>
 
 #include <algorithm>
 #include <bit>
-#include <cmath>
 #include <cstring>
-#include <span>
 #include <stdexcept>
-#include <vector>
+#include <utility>
 
 namespace {
 
+/** The class of a pixel with no echo, or none we hold. */
+constexpr int8_t NO_CLASS = -1;
+
 /**
- * The subset of TIFF we need: the composite is a tiled, Deflate
- * compressed, two band float image with a pyramid of overviews.
+ * The largest tile we will inflate, as a guard against a directory
+ * that claims an absurd tile size.  The composite's own tiles are
+ * 512 by 512 of two float bands, a megabyte each.
  */
+constexpr std::size_t MAX_TILE_PIXELS = 4u * 1024 * 1024;
+
+/** the largest single image the Weather dialog will draw */
+constexpr unsigned MAX_AREA_PIXELS = 1024;
+
 /**
- * Stands in for "no measurement here".  A plain low value rather than
- * a NaN, because we are built with -ffast-math and must not rely on
- * NaN comparisons behaving.
+ * Uncompress one tile, take its first band and classify it.
+ *
+ * The classification happens here rather than at draw time so that
+ * what is kept is one byte per pixel instead of four, and so that a
+ * pixel is classified once however many times it is drawn.
  */
-constexpr float NO_ECHO = -1e30f;
-
-struct TiffLevel {
-  unsigned width = 0, height = 0;
-  unsigned tile_width = 0, tile_height = 0;
-  unsigned samples = 0;
-  std::vector<uint32_t> tile_offset, tile_length;
-  double scale = 0;
-  double origin_x = 0, origin_y = 0;
-
-  unsigned TilesAcross() const noexcept {
-    return (width + tile_width - 1) / tile_width;
-  }
-};
-
-class TiffReader {
-  std::span<const std::byte> file;
-  bool big_endian = false;
-
-public:
-  explicit TiffReader(std::span<const std::byte> _file):file(_file) {
-    if (file.size() < 8)
-      throw std::runtime_error("Truncated radar image");
-
-    const auto *p = (const uint8_t *)file.data();
-    if (p[0] == 'M' && p[1] == 'M')
-      big_endian = true;
-    else if (p[0] != 'I' || p[1] != 'I')
-      throw std::runtime_error("Not a TIFF radar image");
-  }
-
-  uint16_t U16(std::size_t o) const {
-    if (o + 2 > file.size())
-      throw std::runtime_error("Truncated radar image");
-    const auto *p = (const uint8_t *)file.data() + o;
-    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
-  }
-
-  uint32_t U32(std::size_t o) const {
-    if (o + 4 > file.size())
-      throw std::runtime_error("Truncated radar image");
-    const auto *p = (const uint8_t *)file.data() + o;
-    return big_endian
-      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | p[3])
-      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 | uint32_t(p[1]) << 8 | p[0]);
-  }
-
-  double F64(std::size_t o) const {
-    /* U32() already applies the file byte order within each half, so
-       all that is left is which half comes first */
-    const uint64_t first = U32(o), second = U32(o + 4);
-    return std::bit_cast<double>(big_endian
-                                 ? first << 32 | second
-                                 : second << 32 | first);
-  }
-
-  bool IsForeignByteOrder() const noexcept {
-    return big_endian != (std::endian::native == std::endian::big);
-  }
-
-  std::span<const std::byte> Slice(std::size_t o, std::size_t n) const {
-    if (o + n > file.size())
-      throw std::runtime_error("Truncated radar image");
-    return file.subspan(o, n);
-  }
-
-  std::size_t FirstDirectory() const { return U32(4); }
-
-  /**
-   * Read one image file directory.
-   *
-   * @return the offset of the next one, zero at the end
-   */
-  std::size_t ReadDirectory(std::size_t offset, TiffLevel &level) const;
-};
-
-constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
-constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
-constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
-constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
-constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
-constexpr unsigned COMPRESSION_DEFLATE = 8;
-
-std::size_t
-TiffReader::ReadDirectory(std::size_t offset, TiffLevel &level) const
+std::vector<int8_t>
+InflateTile(std::span<const std::byte> compressed,
+            const OPERA::CompositeLevel &level, bool foreign_byte_order)
 {
-  const unsigned n = U16(offset);
-  unsigned compression = 0;
+  const std::size_t pixels =
+    std::size_t(level.tile_width) * level.tile_height;
+  if (pixels == 0 || pixels > MAX_TILE_PIXELS || level.samples == 0)
+    throw std::runtime_error("Unusable radar image");
 
-  for (unsigned i = 0; i < n; ++i) {
-    const std::size_t e = offset + 2 + i * 12;
-    const unsigned tag = U16(e), type = U16(e + 2);
-    const uint32_t count = U32(e + 4);
-
-    /* the value is inline when it fits in four bytes */
-    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
-    const std::size_t at = std::size_t(size) * count <= 4 ? e + 8 : U32(e + 8);
-
-    const auto scalar = [&]() -> uint32_t {
-      return type == 3 ? U16(at) : U32(at);
-    };
-
-    switch (tag) {
-    case TAG_WIDTH: level.width = scalar(); break;
-    case TAG_HEIGHT: level.height = scalar(); break;
-    case TAG_COMPRESSION: compression = scalar(); break;
-    case TAG_SAMPLES: level.samples = scalar(); break;
-    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
-    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
-
-    case TAG_TILE_OFFSETS:
-    case TAG_TILE_LENGTHS: {
-      auto &out = tag == TAG_TILE_OFFSETS ? level.tile_offset : level.tile_length;
-      out.clear();
-      out.reserve(count);
-      for (uint32_t j = 0; j < count; ++j)
-        out.push_back(type == 3 ? U16(at + j * 2) : U32(at + j * 4));
-      break;
-    }
-
-    case TAG_PIXEL_SCALE:
-      if (count >= 2)
-        level.scale = F64(at);
-      break;
-
-    case TAG_TIEPOINT:
-      /* the first three doubles are the raster point, the next three
-         the projected point it maps to */
-      if (count >= 6) {
-        level.origin_x = F64(at + 3 * 8);
-        level.origin_y = F64(at + 4 * 8);
-      }
-      break;
-    }
-  }
-
-  if (level.width > 0) {
-    if (compression != COMPRESSION_DEFLATE)
-      throw std::runtime_error("Unsupported radar image compression");
-
-    if (level.samples == 0)
-      /* the tag is mandatory, but a missing one would make us read
-         zero bytes per pixel */
-      level.samples = 1;
-  }
-
-  return U32(offset + 2 + std::size_t(n) * 12);
-}
-
-/**
- * Uncompress one tile and return its first band.
- */
-void
-InflateTile(std::span<const std::byte> tile, const TiffLevel &level,
-            bool foreign_byte_order, float *out)
-{
-  const std::size_t pixels = std::size_t(level.tile_width) * level.tile_height;
   AllocatedArray<float> raw{pixels * level.samples};
 
   uLongf size = uLongf(raw.size() * sizeof(float));
   if (::uncompress((Bytef *)raw.data(), &size,
-                   (const Bytef *)tile.data(), uLong(tile.size())) != Z_OK ||
+                   (const Bytef *)compressed.data(),
+                   uLong(compressed.size())) != Z_OK ||
       size < pixels * level.samples * sizeof(float))
     throw std::runtime_error("Damaged radar image");
 
+  std::vector<int8_t> out;
+  out.resize(pixels);
+
   for (std::size_t i = 0; i < pixels; ++i) {
-    const float value = raw[i * level.samples];
-    out[i] = foreign_byte_order
-      ? std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)))
-      : value;
+    float value = raw[i * level.samples];
+    if (foreign_byte_order)
+      value = std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)));
+
+    /* the composite marks "looked and saw nothing" with a NaN and "no
+       radar here" with a large negative number; both come out as the
+       "nothing to draw" class */
+    out[i] = OPERA::IsNotANumber(value)
+      ? NO_CLASS
+      : int8_t(OPERA::ClassifyReflectivity(value));
   }
-}
 
-} // anonymous namespace
-
-namespace {
-
-/**
- * Pick the coarsest overview that still resolves the requested
- * detail.  Asking for a finer one only costs bandwidth and memory.
- */
-const TiffLevel &
-SelectLevel(const std::vector<TiffLevel> &levels,
-            double metres_per_pixel) noexcept
-{
-  const TiffLevel *best = &levels.front();
-
-  for (const auto &level : levels)
-    if (level.width > 0 && level.scale > 0 &&
-        level.scale <= metres_per_pixel)
-      /* the levels are ordered fine to coarse, so the last one that
-         is still fine enough is the cheapest usable one */
-      best = &level;
-
-  return *best;
-}
-
-/**
- * The part of one level we need, decoded into a contiguous grid.
- */
-class Patch {
-  unsigned x0 = 0, y0 = 0, width = 0, height = 0;
-  AllocatedArray<float> data;
-
-public:
-  Patch(const TiffReader &tiff, const TiffLevel &level,
-        unsigned col0, unsigned row0, unsigned col1, unsigned row1);
-
-  /**
-   * @return the reflectivity, or #NO_ECHO where there is none
-   */
-  float Get(unsigned col, unsigned row) const noexcept {
-    if (col < x0 || row < y0)
-      return NO_ECHO;
-
-    const unsigned x = col - x0, y = row - y0;
-    if (x >= width || y >= height)
-      return NO_ECHO;
-
-    return data[std::size_t(y) * width + x];
-  }
-};
-
-Patch::Patch(const TiffReader &tiff, const TiffLevel &level,
-             unsigned col0, unsigned row0, unsigned col1, unsigned row1)
-{
-  const unsigned across = level.TilesAcross();
-  const unsigned tx0 = col0 / level.tile_width, tx1 = col1 / level.tile_width;
-  const unsigned ty0 = row0 / level.tile_height, ty1 = row1 / level.tile_height;
-
-  x0 = tx0 * level.tile_width;
-  y0 = ty0 * level.tile_height;
-  width = (tx1 - tx0 + 1) * level.tile_width;
-  height = (ty1 - ty0 + 1) * level.tile_height;
-
-  data.ResizeDiscard(std::size_t(width) * height);
-  std::fill_n(data.data(), data.size(), NO_ECHO);
-
-  AllocatedArray<float> tile{std::size_t(level.tile_width) * level.tile_height};
-
-  for (unsigned ty = ty0; ty <= ty1; ++ty) {
-    for (unsigned tx = tx0; tx <= tx1; ++tx) {
-      const std::size_t i = std::size_t(ty) * across + tx;
-      if (i >= level.tile_offset.size() || i >= level.tile_length.size() ||
-          level.tile_length[i] == 0)
-        continue;
-
-      InflateTile(tiff.Slice(level.tile_offset[i], level.tile_length[i]),
-                  level, tiff.IsForeignByteOrder(), tile.data());
-
-      for (unsigned y = 0; y < level.tile_height; ++y) {
-        const unsigned dy = (ty - ty0) * level.tile_height + y;
-        if (dy >= height)
-          break;
-
-        const float *src = tile.data() + std::size_t(y) * level.tile_width;
-        float *dest = data.data() + std::size_t(dy) * width +
-          (tx - tx0) * level.tile_width;
-
-        for (unsigned x = 0; x < level.tile_width; ++x)
-          /* the composite marks "looked and saw nothing" with a NaN
-             and "no radar here" with a large negative number */
-          dest[x] = OPERA::IsNotANumber(src[x]) ? NO_ECHO : src[x];
-      }
-    }
-  }
+  return out;
 }
 
 /**
@@ -309,11 +88,13 @@ void
 WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
 {
   /* one filter byte per row, filter type 0 ("none") */
-  AllocatedArray<uint8_t> raw{std::size_t(height) * (1 + std::size_t(width) * 4)};
+  AllocatedArray<uint8_t> raw{
+    std::size_t(height) * (1 + std::size_t(width) * 4)};
   for (unsigned y = 0; y < height; ++y) {
     uint8_t *dest = raw.data() + std::size_t(y) * (1 + std::size_t(width) * 4);
     *dest++ = 0;
-    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4, dest);
+    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4,
+                dest);
   }
 
   uLongf compressed_size = ::compressBound(uLong(raw.size()));
@@ -324,8 +105,8 @@ WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
 
   FileOutputStream file{path, FileOutputStream::Mode::CREATE};
 
-  const auto WriteChunk = [&file](const char *type,
-                                  const uint8_t *payload, std::size_t size){
+  const auto write_chunk = [&file](const char *type,
+                                   const uint8_t *payload, std::size_t size){
     uint8_t header[8];
     header[0] = uint8_t(size >> 24); header[1] = uint8_t(size >> 16);
     header[2] = uint8_t(size >> 8); header[3] = uint8_t(size);
@@ -344,181 +125,235 @@ WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
     file.Write(std::as_bytes(std::span{tail}));
   };
 
-  static constexpr uint8_t signature[] = {
+  static constexpr uint8_t SIGNATURE[] = {
     0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
   };
-  file.Write(std::as_bytes(std::span{signature}));
+  file.Write(std::as_bytes(std::span{SIGNATURE}));
 
   const uint8_t ihdr[13] = {
-    uint8_t(width >> 24), uint8_t(width >> 16), uint8_t(width >> 8), uint8_t(width),
-    uint8_t(height >> 24), uint8_t(height >> 16), uint8_t(height >> 8), uint8_t(height),
+    uint8_t(width >> 24), uint8_t(width >> 16),
+    uint8_t(width >> 8), uint8_t(width),
+    uint8_t(height >> 24), uint8_t(height >> 16),
+    uint8_t(height >> 8), uint8_t(height),
     8, 6, 0, 0, 0,
   };
-  WriteChunk("IHDR", ihdr, sizeof(ihdr));
-  WriteChunk("IDAT", compressed.data(), compressed_size);
-  WriteChunk("IEND", nullptr, 0);
+  write_chunk("IHDR", ihdr, sizeof(ihdr));
+  write_chunk("IDAT", compressed.data(), compressed_size);
+  write_chunk("IEND", nullptr, 0);
 
   file.Commit();
 }
 
 } // anonymous namespace
 
-namespace {
-
-/**
- * Reproject the composite into a north-up latitude/longitude image
- * and colour it.
- */
-AllocatedArray<uint8_t>
-Render(const TiffReader &tiff, const std::vector<TiffLevel> &levels,
-       const GeoBounds &bounds, unsigned width, unsigned height)
+bool
+OPERA::RadarComposite::HasTile(unsigned level, unsigned tile) const noexcept
 {
-  const double north = bounds.GetNorth().Degrees();
-  const double south = bounds.GetSouth().Degrees();
-  const double west = bounds.GetWest().Degrees();
-  const double east = bounds.GetEast().Degrees();
+  return std::any_of(tiles.begin(), tiles.end(),
+                     [level, tile](const auto &i){
+                       return i.level == level && i.index == tile;
+                     });
+}
 
-  /* the projection is curved, so probe a coarse grid rather than
-     just the corners to find the extent we need */
-  static constexpr unsigned PROBE = 8;
-  double min_x = 1e30, max_x = -1e30, min_y = 1e30, max_y = -1e30;
-  for (unsigned j = 0; j <= PROBE; ++j) {
-    for (unsigned i = 0; i <= PROBE; ++i) {
-      const auto p = OPERA::Project(GeoPoint{
-        Angle::Degrees(west + (east - west) * i / PROBE),
-        Angle::Degrees(south + (north - south) * j / PROBE),
-      });
-      min_x = std::min(min_x, p.x); max_x = std::max(max_x, p.x);
-      min_y = std::min(min_y, p.y); max_y = std::max(max_y, p.y);
-    }
-  }
+Co::Task<void>
+OPERA::RadarComposite::Open(std::string _url, CurlGlobal &curl)
+{
+  if (IsOpen() && url == _url)
+    co_return;
 
-  const auto &level = SelectLevel(levels, (max_x - min_x) / width);
-  if (level.width == 0 || level.scale <= 0 ||
-      level.tile_width == 0 || level.tile_height == 0)
+  Reset();
+
+  /* one range request buys the whole directory: what levels the file
+     has, how it is tiled, and where every tile of it lies */
+  const auto header = co_await Net::CoGetRange(curl, _url.c_str(),
+                                               0, INDEX_BYTES);
+
+  index = ParseIndex(std::as_bytes(std::span{header}));
+  url = std::move(_url);
+}
+
+Co::Task<void>
+OPERA::RadarComposite::FetchTile(unsigned level_index, unsigned tile,
+                                 CurlGlobal &curl)
+{
+  if (!IsOpen() || HasTile(level_index, tile))
+    co_return;
+
+  if (level_index >= index.levels.size())
     throw std::runtime_error("Unusable radar image");
 
-  const auto ToColumn = [&level](double x){
-    return (x - level.origin_x) / level.scale;
-  };
-  const auto ToRow = [&level](double y){
-    return (level.origin_y - y) / level.scale;
+  const auto &level = index.levels[level_index];
+  if (!level.IsUsable() || tile >= level.tile_offset.size())
+    throw std::runtime_error("Unusable radar image");
+
+  const auto length = level.tile_length[tile];
+  if (length == 0)
+    /* an empty tile is not an error: the file marks areas the radar
+       network does not reach that way */
+    co_return;
+
+  const auto compressed = co_await Net::CoGetRange(curl, url.c_str(),
+                                                   level.tile_offset[tile],
+                                                   length);
+  if (compressed.size() < length)
+    throw std::runtime_error("Truncated radar image");
+
+  auto data = InflateTile(std::as_bytes(std::span{compressed}), level,
+                          index.foreign_byte_order);
+
+  /* the awaits above can have run concurrently with another fetch of
+     the same tile; keep only one copy */
+  if (HasTile(level_index, tile))
+    co_return;
+
+  /* the oldest goes first, which is the one the aircraft flew away
+     from: the block is filled from its centre outwards, so what was
+     fetched longest ago is what is furthest behind */
+  while (tiles.size() >= MAX_CACHED_TILES)
+    tiles.erase(tiles.begin());
+
+  tiles.push_back({level_index, tile, std::move(data)});
+}
+
+bool
+OPERA::RadarComposite::Render(unsigned level_index, const GeoBounds &bounds,
+                              unsigned width, unsigned height,
+                              Path path) const
+{
+  if (!IsOpen() || level_index >= index.levels.size() ||
+      !bounds.IsValid() || width == 0 || height == 0)
+    throw std::runtime_error("Unusable radar image");
+
+  const auto &level = index.levels[level_index];
+  if (!level.IsUsable())
+    throw std::runtime_error("Unusable radar image");
+
+  /* the handful of source tiles this area touches, looked up once
+     rather than searched for per pixel */
+  struct Held {
+    unsigned index;
+    const std::vector<int8_t> *data;
   };
 
-  const double c0 = ToColumn(min_x), c1 = ToColumn(max_x);
-  const double r0 = ToRow(max_y), r1 = ToRow(min_y);
-  if (c1 < 0 || r1 < 0 || c0 >= level.width || r0 >= level.height)
-    /* the map is looking somewhere the composite does not cover */
-    throw std::runtime_error("Outside the radar composite");
+  /* only the tiles this area actually touches, so that the lookup in
+     the pixel loop below scans four entries rather than the whole
+     cache */
+  std::vector<Held> held;
+  for (const auto source : CoveringSourceTiles(level, bounds))
+    for (const auto &tile : tiles)
+      if (tile.level == level_index && tile.index == source)
+        held.push_back({tile.index, &tile.data});
 
-  const Patch patch{tiff, level,
-                    unsigned(std::max(0.0, c0)),
-                    unsigned(std::max(0.0, r0)),
-                    unsigned(std::min(double(level.width - 1), c1)),
-                    unsigned(std::min(double(level.height - 1), r1))};
+  if (held.empty())
+    /* nothing of this area has arrived yet, or the composite does not
+       reach it */
+    return false;
+
+  const unsigned across = level.TilesAcross();
+
+  const auto sample = [&](double column, double row) -> int8_t {
+    if (column < 0 || row < 0 ||
+        column >= double(level.width) || row >= double(level.height))
+      return NO_CLASS;
+
+    const unsigned c = unsigned(column), r = unsigned(row);
+    const unsigned i = (r / level.tile_height) * across + c / level.tile_width;
+
+    for (const auto &tile : held)
+      if (tile.index == i) {
+        const std::size_t x = c % level.tile_width;
+        const std::size_t y = r % level.tile_height;
+        const std::size_t at = y * level.tile_width + x;
+        return at < tile.data->size() ? (*tile.data)[at] : NO_CLASS;
+      }
+
+    return NO_CLASS;
+  };
+
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+
+  const RasterProjector projector{bounds.GetWest().Degrees(),
+                                  bounds.GetEast().Degrees(), width};
+  AllocatedArray<DoublePoint2D> row_points{width};
 
   AllocatedArray<uint8_t> image{std::size_t(width) * height * 4};
   std::fill_n(image.data(), image.size(), uint8_t(0));
 
+  bool any = false;
+
   for (unsigned y = 0; y < height; ++y) {
     const double latitude = north - (north - south) * (y + 0.5) / height;
+    projector.ProjectRow(latitude, row_points.data());
 
     for (unsigned x = 0; x < width; ++x) {
-      const double longitude = west + (east - west) * (x + 0.5) / width;
-
-      const auto p = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
-                                             Angle::Degrees(latitude)});
-      const double column = ToColumn(p.x), row = ToRow(p.y);
-      if (column < 0 || row < 0 ||
-          column >= level.width || row >= level.height)
-        continue;
+      const auto &p = row_points[x];
+      const double column = (p.x - level.origin_x) / level.scale;
+      const double row = (level.origin_y - p.y) / level.scale;
 
       /* take the strongest of the source pixels this one covers; the
          composite is a maximum product, and picking just one would
-         drop isolated echoes when zoomed out */
-      float dbz = NO_ECHO;
+         drop isolated echoes when zoomed out.  The classification is
+         monotonic, so the strongest class is the class of the
+         strongest echo. */
+      int8_t cls = NO_CLASS;
       for (unsigned dy = 0; dy < 2; ++dy)
         for (unsigned dx = 0; dx < 2; ++dx)
-          dbz = std::max(dbz, patch.Get(unsigned(column) + dx,
-                                        unsigned(row) + dy));
+          cls = std::max(cls, sample(column + dx, row + dy));
 
-      const int cls = OPERA::ClassifyReflectivity(dbz);
       if (cls < 0)
         continue;
 
-      const uint32_t colour = OPERA::GetClassColour(unsigned(cls));
+      const uint32_t colour = GetClassColour(unsigned(cls));
       uint8_t *dest = image.data() + (std::size_t(y) * width + x) * 4;
       dest[0] = uint8_t(colour >> 16);
       dest[1] = uint8_t(colour >> 8);
       dest[2] = uint8_t(colour);
       dest[3] = 0xff;
+      any = true;
     }
   }
 
-  return image;
+  WritePNG(path, width, height, image.data());
+
+  /* the caller uses this to leave a clear sky alone rather than spend
+     a map overlay slot and a texture upload on a transparent tile */
+  return any;
 }
 
-} // anonymous namespace
-
 Co::Task<AllocatedPath>
-OPERA::DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
-                     CurlGlobal &curl, ProgressListener &progress)
+OPERA::DownloadArea(const GeoBounds &bounds, unsigned width, unsigned height,
+                    CurlGlobal &curl, ProgressListener &progress)
 {
   if (!bounds.IsValid())
     throw std::runtime_error("No map area to cover");
 
-  width = std::clamp(width, 1u, MAX_IMAGE_SIZE);
-  height = std::clamp(height, 1u, MAX_IMAGE_SIZE);
+  width = std::clamp(width, 1u, MAX_AREA_PIXELS);
+  height = std::clamp(height, 1u, MAX_AREA_PIXELS);
 
   const auto url = MakeCompositeURL(BrokenDateTime::NowUTC());
   if (url.empty())
     throw std::runtime_error("The clock is not set");
 
-  const auto cache = MakeCacheDirectory("opera");
-  const auto source = AllocatedPath::Build(cache, "composite.tiff");
-  auto rendered = AllocatedPath::Build(cache, "composite.png");
+  RadarComposite composite;
+  co_await composite.Open(url, curl);
 
-  {
-    const auto ignored_response = co_await
-      Net::CoDownloadToFile(curl, url.c_str(), nullptr, nullptr,
-                            source, nullptr, progress);
+  const auto &index = composite.GetIndex();
+  const auto level = SelectLevel(index, TileMetresPerPixel(bounds, width));
+  const auto sources = CoveringSourceTiles(index.levels[level], bounds);
+  if (sources.empty())
+    throw std::runtime_error("Outside the radar composite");
+
+  progress.SetProgressRange(unsigned(sources.size()));
+
+  unsigned done = 0;
+  for (const auto source : sources) {
+    co_await composite.FetchTile(level, source, curl);
+    progress.SetProgressPosition(++done);
   }
 
-  const FileMapping mapping{source};
-  const TiffReader tiff{mapping};
+  auto path = AllocatedPath::Build(MakeCacheDirectory("opera"), "area.png");
+  composite.Render(level, bounds, width, height, path);
 
-  std::vector<TiffLevel> levels;
-  /* count every directory, not just the usable ones: a damaged file
-     can chain empty directories, or point one at itself */
-  for (std::size_t offset = tiff.FirstDirectory(), n = 0;
-       offset != 0 && n < 32; ++n) {
-    TiffLevel level;
-    offset = tiff.ReadDirectory(offset, level);
-    if (level.width > 0)
-      levels.push_back(std::move(level));
-  }
-
-  if (levels.empty())
-    throw std::runtime_error("Empty radar image");
-
-  /* only the full resolution image carries the projection keys; the
-     overviews cover the same area with fewer pixels, so their scale
-     follows from the size ratio */
-  for (auto &level : levels) {
-    if (level.scale > 0 || level.width == 0 || levels.front().width == 0)
-      continue;
-
-    level.scale = levels.front().scale *
-      double(levels.front().width) / level.width;
-    level.origin_x = levels.front().origin_x;
-    level.origin_y = levels.front().origin_y;
-  }
-
-  if (levels.front().scale <= 0)
-    throw std::runtime_error("Radar image without a georeference");
-
-  const auto image = Render(tiff, levels, bounds, width, height);
-  WritePNG(rendered, width, height, image.data());
-
-  co_return std::move(rendered);
+  co_return std::move(path);
 }

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -28,9 +28,10 @@ namespace {
 constexpr int8_t NO_CLASS = -1;
 
 /**
- * The largest tile we will inflate, as a guard against a directory
- * that claims an absurd tile size.  The composite's own tiles are
- * 512 by 512 of two float bands, a megabyte each.
+ * The largest tile we will inflate, counted in samples rather than in
+ * pixels, as a guard against a directory that claims an absurd tile
+ * size or band count.  The composite's own tiles are 512 by 512 of
+ * two float bands, half a million samples.
  */
 constexpr std::size_t MAX_TILE_PIXELS = 4u * 1024 * 1024;
 
@@ -50,7 +51,13 @@ InflateTile(std::span<const std::byte> compressed,
 {
   const std::size_t pixels =
     std::size_t(level.tile_width) * level.tile_height;
-  if (pixels == 0 || pixels > MAX_TILE_PIXELS || level.samples == 0)
+
+  /* the sample count comes out of the file just as the tile size
+     does, so the buffer has to be bounded by the product rather than
+     by the pixel count alone; written as a division so that the check
+     itself cannot overflow */
+  if (pixels == 0 || level.samples == 0 ||
+      pixels > MAX_TILE_PIXELS / level.samples)
     throw std::runtime_error("Unusable radar image");
 
   AllocatedArray<float> raw{pixels * level.samples};

--- a/src/Weather/OPERA/Radar.cpp
+++ b/src/Weather/OPERA/Radar.cpp
@@ -1,0 +1,524 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Radar.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "net/http/CoDownloadToFile.hpp"
+#include "co/Task.hxx"
+#include "io/FileMapping.hpp"
+#include "io/FileOutputStream.hxx"
+#include "time/BrokenDateTime.hpp"
+#include "util/AllocatedArray.hxx"
+#include "util/ByteOrder.hxx"
+#include "LocalPath.hpp"
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+/**
+ * The subset of TIFF we need: the composite is a tiled, Deflate
+ * compressed, two band float image with a pyramid of overviews.
+ */
+/**
+ * Stands in for "no measurement here".  A plain low value rather than
+ * a NaN, because we are built with -ffast-math and must not rely on
+ * NaN comparisons behaving.
+ */
+constexpr float NO_ECHO = -1e30f;
+
+struct TiffLevel {
+  unsigned width = 0, height = 0;
+  unsigned tile_width = 0, tile_height = 0;
+  unsigned samples = 0;
+  std::vector<uint32_t> tile_offset, tile_length;
+  double scale = 0;
+  double origin_x = 0, origin_y = 0;
+
+  unsigned TilesAcross() const noexcept {
+    return (width + tile_width - 1) / tile_width;
+  }
+};
+
+class TiffReader {
+  std::span<const std::byte> file;
+  bool big_endian = false;
+
+public:
+  explicit TiffReader(std::span<const std::byte> _file):file(_file) {
+    if (file.size() < 8)
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)file.data();
+    if (p[0] == 'M' && p[1] == 'M')
+      big_endian = true;
+    else if (p[0] != 'I' || p[1] != 'I')
+      throw std::runtime_error("Not a TIFF radar image");
+  }
+
+  uint16_t U16(std::size_t o) const {
+    if (o + 2 > file.size())
+      throw std::runtime_error("Truncated radar image");
+    const auto *p = (const uint8_t *)file.data() + o;
+    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
+  }
+
+  uint32_t U32(std::size_t o) const {
+    if (o + 4 > file.size())
+      throw std::runtime_error("Truncated radar image");
+    const auto *p = (const uint8_t *)file.data() + o;
+    return big_endian
+      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | p[3])
+      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 | uint32_t(p[1]) << 8 | p[0]);
+  }
+
+  double F64(std::size_t o) const {
+    /* U32() already applies the file byte order within each half, so
+       all that is left is which half comes first */
+    const uint64_t first = U32(o), second = U32(o + 4);
+    return std::bit_cast<double>(big_endian
+                                 ? first << 32 | second
+                                 : second << 32 | first);
+  }
+
+  bool IsForeignByteOrder() const noexcept {
+    return big_endian != (std::endian::native == std::endian::big);
+  }
+
+  std::span<const std::byte> Slice(std::size_t o, std::size_t n) const {
+    if (o + n > file.size())
+      throw std::runtime_error("Truncated radar image");
+    return file.subspan(o, n);
+  }
+
+  std::size_t FirstDirectory() const { return U32(4); }
+
+  /**
+   * Read one image file directory.
+   *
+   * @return the offset of the next one, zero at the end
+   */
+  std::size_t ReadDirectory(std::size_t offset, TiffLevel &level) const;
+};
+
+constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
+constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+constexpr unsigned COMPRESSION_DEFLATE = 8;
+
+std::size_t
+TiffReader::ReadDirectory(std::size_t offset, TiffLevel &level) const
+{
+  const unsigned n = U16(offset);
+  unsigned compression = 0;
+
+  for (unsigned i = 0; i < n; ++i) {
+    const std::size_t e = offset + 2 + i * 12;
+    const unsigned tag = U16(e), type = U16(e + 2);
+    const uint32_t count = U32(e + 4);
+
+    /* the value is inline when it fits in four bytes */
+    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
+    const std::size_t at = std::size_t(size) * count <= 4 ? e + 8 : U32(e + 8);
+
+    const auto scalar = [&]() -> uint32_t {
+      return type == 3 ? U16(at) : U32(at);
+    };
+
+    switch (tag) {
+    case TAG_WIDTH: level.width = scalar(); break;
+    case TAG_HEIGHT: level.height = scalar(); break;
+    case TAG_COMPRESSION: compression = scalar(); break;
+    case TAG_SAMPLES: level.samples = scalar(); break;
+    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
+    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
+
+    case TAG_TILE_OFFSETS:
+    case TAG_TILE_LENGTHS: {
+      auto &out = tag == TAG_TILE_OFFSETS ? level.tile_offset : level.tile_length;
+      out.clear();
+      out.reserve(count);
+      for (uint32_t j = 0; j < count; ++j)
+        out.push_back(type == 3 ? U16(at + j * 2) : U32(at + j * 4));
+      break;
+    }
+
+    case TAG_PIXEL_SCALE:
+      if (count >= 2)
+        level.scale = F64(at);
+      break;
+
+    case TAG_TIEPOINT:
+      /* the first three doubles are the raster point, the next three
+         the projected point it maps to */
+      if (count >= 6) {
+        level.origin_x = F64(at + 3 * 8);
+        level.origin_y = F64(at + 4 * 8);
+      }
+      break;
+    }
+  }
+
+  if (level.width > 0) {
+    if (compression != COMPRESSION_DEFLATE)
+      throw std::runtime_error("Unsupported radar image compression");
+
+    if (level.samples == 0)
+      /* the tag is mandatory, but a missing one would make us read
+         zero bytes per pixel */
+      level.samples = 1;
+  }
+
+  return U32(offset + 2 + std::size_t(n) * 12);
+}
+
+/**
+ * Uncompress one tile and return its first band.
+ */
+void
+InflateTile(std::span<const std::byte> tile, const TiffLevel &level,
+            bool foreign_byte_order, float *out)
+{
+  const std::size_t pixels = std::size_t(level.tile_width) * level.tile_height;
+  AllocatedArray<float> raw{pixels * level.samples};
+
+  uLongf size = uLongf(raw.size() * sizeof(float));
+  if (::uncompress((Bytef *)raw.data(), &size,
+                   (const Bytef *)tile.data(), uLong(tile.size())) != Z_OK ||
+      size < pixels * level.samples * sizeof(float))
+    throw std::runtime_error("Damaged radar image");
+
+  for (std::size_t i = 0; i < pixels; ++i) {
+    const float value = raw[i * level.samples];
+    out[i] = foreign_byte_order
+      ? std::bit_cast<float>(ByteSwap32(std::bit_cast<uint32_t>(value)))
+      : value;
+  }
+}
+
+} // anonymous namespace
+
+namespace {
+
+/**
+ * Pick the coarsest overview that still resolves the requested
+ * detail.  Asking for a finer one only costs bandwidth and memory.
+ */
+const TiffLevel &
+SelectLevel(const std::vector<TiffLevel> &levels,
+            double metres_per_pixel) noexcept
+{
+  const TiffLevel *best = &levels.front();
+
+  for (const auto &level : levels)
+    if (level.width > 0 && level.scale > 0 &&
+        level.scale <= metres_per_pixel)
+      /* the levels are ordered fine to coarse, so the last one that
+         is still fine enough is the cheapest usable one */
+      best = &level;
+
+  return *best;
+}
+
+/**
+ * The part of one level we need, decoded into a contiguous grid.
+ */
+class Patch {
+  unsigned x0 = 0, y0 = 0, width = 0, height = 0;
+  AllocatedArray<float> data;
+
+public:
+  Patch(const TiffReader &tiff, const TiffLevel &level,
+        unsigned col0, unsigned row0, unsigned col1, unsigned row1);
+
+  /**
+   * @return the reflectivity, or #NO_ECHO where there is none
+   */
+  float Get(unsigned col, unsigned row) const noexcept {
+    if (col < x0 || row < y0)
+      return NO_ECHO;
+
+    const unsigned x = col - x0, y = row - y0;
+    if (x >= width || y >= height)
+      return NO_ECHO;
+
+    return data[std::size_t(y) * width + x];
+  }
+};
+
+Patch::Patch(const TiffReader &tiff, const TiffLevel &level,
+             unsigned col0, unsigned row0, unsigned col1, unsigned row1)
+{
+  const unsigned across = level.TilesAcross();
+  const unsigned tx0 = col0 / level.tile_width, tx1 = col1 / level.tile_width;
+  const unsigned ty0 = row0 / level.tile_height, ty1 = row1 / level.tile_height;
+
+  x0 = tx0 * level.tile_width;
+  y0 = ty0 * level.tile_height;
+  width = (tx1 - tx0 + 1) * level.tile_width;
+  height = (ty1 - ty0 + 1) * level.tile_height;
+
+  data.ResizeDiscard(std::size_t(width) * height);
+  std::fill_n(data.data(), data.size(), NO_ECHO);
+
+  AllocatedArray<float> tile{std::size_t(level.tile_width) * level.tile_height};
+
+  for (unsigned ty = ty0; ty <= ty1; ++ty) {
+    for (unsigned tx = tx0; tx <= tx1; ++tx) {
+      const std::size_t i = std::size_t(ty) * across + tx;
+      if (i >= level.tile_offset.size() || i >= level.tile_length.size() ||
+          level.tile_length[i] == 0)
+        continue;
+
+      InflateTile(tiff.Slice(level.tile_offset[i], level.tile_length[i]),
+                  level, tiff.IsForeignByteOrder(), tile.data());
+
+      for (unsigned y = 0; y < level.tile_height; ++y) {
+        const unsigned dy = (ty - ty0) * level.tile_height + y;
+        if (dy >= height)
+          break;
+
+        const float *src = tile.data() + std::size_t(y) * level.tile_width;
+        float *dest = data.data() + std::size_t(dy) * width +
+          (tx - tx0) * level.tile_width;
+
+        for (unsigned x = 0; x < level.tile_width; ++x)
+          /* the composite marks "looked and saw nothing" with a NaN
+             and "no radar here" with a large negative number */
+          dest[x] = OPERA::IsNotANumber(src[x]) ? NO_ECHO : src[x];
+      }
+    }
+  }
+}
+
+/**
+ * Write an RGBA image as a PNG.  Throws on error.
+ */
+void
+WritePNG(Path path, unsigned width, unsigned height, const uint8_t *rgba)
+{
+  /* one filter byte per row, filter type 0 ("none") */
+  AllocatedArray<uint8_t> raw{std::size_t(height) * (1 + std::size_t(width) * 4)};
+  for (unsigned y = 0; y < height; ++y) {
+    uint8_t *dest = raw.data() + std::size_t(y) * (1 + std::size_t(width) * 4);
+    *dest++ = 0;
+    std::copy_n(rgba + std::size_t(y) * width * 4, std::size_t(width) * 4, dest);
+  }
+
+  uLongf compressed_size = ::compressBound(uLong(raw.size()));
+  AllocatedArray<uint8_t> compressed{compressed_size};
+  if (::compress2(compressed.data(), &compressed_size,
+                  raw.data(), uLong(raw.size()), 6) != Z_OK)
+    throw std::runtime_error("Failed to compress the radar image");
+
+  FileOutputStream file{path, FileOutputStream::Mode::CREATE};
+
+  const auto WriteChunk = [&file](const char *type,
+                                  const uint8_t *payload, std::size_t size){
+    uint8_t header[8];
+    header[0] = uint8_t(size >> 24); header[1] = uint8_t(size >> 16);
+    header[2] = uint8_t(size >> 8); header[3] = uint8_t(size);
+    std::memcpy(header + 4, type, 4);
+    file.Write(std::as_bytes(std::span{header}));
+    if (size > 0)
+      file.Write(std::as_bytes(std::span{payload, size}));
+
+    uLong crc = ::crc32(0, header + 4, 4);
+    if (size > 0)
+      crc = ::crc32(crc, payload, uInt(size));
+
+    const uint8_t tail[4] = {
+      uint8_t(crc >> 24), uint8_t(crc >> 16), uint8_t(crc >> 8), uint8_t(crc),
+    };
+    file.Write(std::as_bytes(std::span{tail}));
+  };
+
+  static constexpr uint8_t signature[] = {
+    0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a,
+  };
+  file.Write(std::as_bytes(std::span{signature}));
+
+  const uint8_t ihdr[13] = {
+    uint8_t(width >> 24), uint8_t(width >> 16), uint8_t(width >> 8), uint8_t(width),
+    uint8_t(height >> 24), uint8_t(height >> 16), uint8_t(height >> 8), uint8_t(height),
+    8, 6, 0, 0, 0,
+  };
+  WriteChunk("IHDR", ihdr, sizeof(ihdr));
+  WriteChunk("IDAT", compressed.data(), compressed_size);
+  WriteChunk("IEND", nullptr, 0);
+
+  file.Commit();
+}
+
+} // anonymous namespace
+
+namespace {
+
+/**
+ * Reproject the composite into a north-up latitude/longitude image
+ * and colour it.
+ */
+AllocatedArray<uint8_t>
+Render(const TiffReader &tiff, const std::vector<TiffLevel> &levels,
+       const GeoBounds &bounds, unsigned width, unsigned height)
+{
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+  const double west = bounds.GetWest().Degrees();
+  const double east = bounds.GetEast().Degrees();
+
+  /* the projection is curved, so probe a coarse grid rather than
+     just the corners to find the extent we need */
+  static constexpr unsigned PROBE = 8;
+  double min_x = 1e30, max_x = -1e30, min_y = 1e30, max_y = -1e30;
+  for (unsigned j = 0; j <= PROBE; ++j) {
+    for (unsigned i = 0; i <= PROBE; ++i) {
+      const auto p = OPERA::Project(GeoPoint{
+        Angle::Degrees(west + (east - west) * i / PROBE),
+        Angle::Degrees(south + (north - south) * j / PROBE),
+      });
+      min_x = std::min(min_x, p.x); max_x = std::max(max_x, p.x);
+      min_y = std::min(min_y, p.y); max_y = std::max(max_y, p.y);
+    }
+  }
+
+  const auto &level = SelectLevel(levels, (max_x - min_x) / width);
+  if (level.width == 0 || level.scale <= 0 ||
+      level.tile_width == 0 || level.tile_height == 0)
+    throw std::runtime_error("Unusable radar image");
+
+  const auto ToColumn = [&level](double x){
+    return (x - level.origin_x) / level.scale;
+  };
+  const auto ToRow = [&level](double y){
+    return (level.origin_y - y) / level.scale;
+  };
+
+  const double c0 = ToColumn(min_x), c1 = ToColumn(max_x);
+  const double r0 = ToRow(max_y), r1 = ToRow(min_y);
+  if (c1 < 0 || r1 < 0 || c0 >= level.width || r0 >= level.height)
+    /* the map is looking somewhere the composite does not cover */
+    throw std::runtime_error("Outside the radar composite");
+
+  const Patch patch{tiff, level,
+                    unsigned(std::max(0.0, c0)),
+                    unsigned(std::max(0.0, r0)),
+                    unsigned(std::min(double(level.width - 1), c1)),
+                    unsigned(std::min(double(level.height - 1), r1))};
+
+  AllocatedArray<uint8_t> image{std::size_t(width) * height * 4};
+  std::fill_n(image.data(), image.size(), uint8_t(0));
+
+  for (unsigned y = 0; y < height; ++y) {
+    const double latitude = north - (north - south) * (y + 0.5) / height;
+
+    for (unsigned x = 0; x < width; ++x) {
+      const double longitude = west + (east - west) * (x + 0.5) / width;
+
+      const auto p = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
+                                             Angle::Degrees(latitude)});
+      const double column = ToColumn(p.x), row = ToRow(p.y);
+      if (column < 0 || row < 0 ||
+          column >= level.width || row >= level.height)
+        continue;
+
+      /* take the strongest of the source pixels this one covers; the
+         composite is a maximum product, and picking just one would
+         drop isolated echoes when zoomed out */
+      float dbz = NO_ECHO;
+      for (unsigned dy = 0; dy < 2; ++dy)
+        for (unsigned dx = 0; dx < 2; ++dx)
+          dbz = std::max(dbz, patch.Get(unsigned(column) + dx,
+                                        unsigned(row) + dy));
+
+      const int cls = OPERA::ClassifyReflectivity(dbz);
+      if (cls < 0)
+        continue;
+
+      const uint32_t colour = OPERA::GetClassColour(unsigned(cls));
+      uint8_t *dest = image.data() + (std::size_t(y) * width + x) * 4;
+      dest[0] = uint8_t(colour >> 16);
+      dest[1] = uint8_t(colour >> 8);
+      dest[2] = uint8_t(colour);
+      dest[3] = 0xff;
+    }
+  }
+
+  return image;
+}
+
+} // anonymous namespace
+
+Co::Task<AllocatedPath>
+OPERA::DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
+                     CurlGlobal &curl, ProgressListener &progress)
+{
+  if (!bounds.IsValid())
+    throw std::runtime_error("No map area to cover");
+
+  width = std::clamp(width, 1u, MAX_IMAGE_SIZE);
+  height = std::clamp(height, 1u, MAX_IMAGE_SIZE);
+
+  const auto url = MakeCompositeURL(BrokenDateTime::NowUTC());
+  if (url.empty())
+    throw std::runtime_error("The clock is not set");
+
+  const auto cache = MakeCacheDirectory("opera");
+  const auto source = AllocatedPath::Build(cache, "composite.tiff");
+  auto rendered = AllocatedPath::Build(cache, "composite.png");
+
+  {
+    const auto ignored_response = co_await
+      Net::CoDownloadToFile(curl, url.c_str(), nullptr, nullptr,
+                            source, nullptr, progress);
+  }
+
+  const FileMapping mapping{source};
+  const TiffReader tiff{mapping};
+
+  std::vector<TiffLevel> levels;
+  /* count every directory, not just the usable ones: a damaged file
+     can chain empty directories, or point one at itself */
+  for (std::size_t offset = tiff.FirstDirectory(), n = 0;
+       offset != 0 && n < 32; ++n) {
+    TiffLevel level;
+    offset = tiff.ReadDirectory(offset, level);
+    if (level.width > 0)
+      levels.push_back(std::move(level));
+  }
+
+  if (levels.empty())
+    throw std::runtime_error("Empty radar image");
+
+  /* only the full resolution image carries the projection keys; the
+     overviews cover the same area with fewer pixels, so their scale
+     follows from the size ratio */
+  for (auto &level : levels) {
+    if (level.scale > 0 || level.width == 0 || levels.front().width == 0)
+      continue;
+
+    level.scale = levels.front().scale *
+      double(levels.front().width) / level.width;
+    level.origin_x = levels.front().origin_x;
+    level.origin_y = levels.front().origin_y;
+  }
+
+  if (levels.front().scale <= 0)
+    throw std::runtime_error("Radar image without a georeference");
+
+  const auto image = Render(tiff, levels, bounds, width, height);
+  WritePNG(rendered, width, height, image.data());
+
+  co_return std::move(rendered);
+}

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -33,8 +33,28 @@ static constexpr unsigned CADENCE_MINUTES = 5;
 /**
  * How far behind the wall clock to look for the newest composite.  A
  * frame is not on the server the instant it is nominally acquired.
+ *
+ * Measured over a full day of the DBZH series: the delay between the
+ * time a frame depicts and the time it appears in the bucket was 4.2
+ * min at the median, 4.7 min at the 99th percentile and 6.3 min at
+ * its worst.  This constant is itself the margin: when the wall clock
+ * lands on a slot boundary the frame we ask for is only
+ * #LATENCY_MINUTES old, so anything below the worst observed delay
+ * would sometimes request a frame that is not there yet.
  */
-static constexpr unsigned LATENCY_MINUTES = 10;
+static constexpr unsigned LATENCY_MINUTES = 7;
+
+/**
+ * How old the frame on the map may get, counted from the time it
+ * depicts, before it is taken down.
+ *
+ * A frame is already #LATENCY_MINUTES to #LATENCY_MINUTES +
+ * #CADENCE_MINUTES old when it arrives, so this has to stay clear of
+ * that.  Twenty minutes leaves room for one failed refresh before the
+ * picture disappears, and puts a hard bound on how stale an echo the
+ * pilot can be looking at.
+ */
+static constexpr unsigned MAX_AGE_MINUTES = 20;
 
 /**
  * The largest image we render.  The composite is a 1km grid; more
@@ -52,6 +72,18 @@ static constexpr unsigned MAX_IMAGE_SIZE = 1024;
  */
 [[gnu::pure]]
 std::string MakeCompositeURL(const BrokenDateTime &utc);
+
+/**
+ * The time the composite that #MakeCompositeURL() points at nominally
+ * depicts.  The caller needs it to tell how old the picture on the
+ * map has become.
+ *
+ * @return an invalid time if @p utc is not plausible
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+BrokenDateTime CompositeTime(const BrokenDateTime &utc);
 
 /**
  * Project a geographic location onto the composite's grid, which is

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "system/Path.hpp"
+#include "Math/Point2D.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+
+struct BrokenDateTime;
+struct GeoPoint;
+class GeoBounds;
+class CurlGlobal;
+class ProgressListener;
+namespace Co { template<typename T> class Task; }
+
+/**
+ * The EUMETNET OPERA radar composite, a pan-European reflectivity
+ * mosaic published every five minutes under CC BY 4.0.
+ *
+ * @see https://eumetnet.github.io/openradardata-documentation/
+ */
+namespace OPERA {
+
+/** New composites appear on this grid, in minutes past the hour. */
+static constexpr unsigned CADENCE_MINUTES = 5;
+
+/**
+ * How far behind the wall clock to look for the newest composite.  A
+ * frame is not on the server the instant it is nominally acquired.
+ */
+static constexpr unsigned LATENCY_MINUTES = 10;
+
+/**
+ * The largest image we render.  The composite is a 1km grid; more
+ * pixels than this only upsamples.
+ */
+static constexpr unsigned MAX_IMAGE_SIZE = 1024;
+
+/**
+ * Build the URL of the composite covering the given UTC time.  The
+ * time is rounded down to #CADENCE_MINUTES.
+ *
+ * @return an empty string if the time is not plausible
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::string MakeCompositeURL(const BrokenDateTime &utc);
+
+/**
+ * Project a geographic location onto the composite's grid, which is
+ * Lambert azimuthal equal-area centred on 55N 10E.  The result is in
+ * metres in the projection plane, x east and y north.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+DoublePoint2D Project(const GeoPoint &p) noexcept;
+
+/**
+ * Map a reflectivity to one of the colour classes.  A value that is
+ * not a number means the radar looked and saw nothing.
+ *
+ * The class boundaries were measured against the German weather
+ * service's own European product rather than derived from a Z-R
+ * relation: the offset between this composite, which is a maximum
+ * over all elevations, and a near-ground product is not constant but
+ * shrinks as the echo grows stronger, so no single exponent fits.
+ *
+ * Exposed for the unit test.
+ *
+ * @return the class index, or -1 for "no precipitation"
+ */
+[[gnu::const]]
+int ClassifyReflectivity(double dbz) noexcept;
+
+/**
+ * Is this "not a number"?
+ *
+ * The composite marks "the radar looked and saw nothing" that way,
+ * and we are built with -ffast-math, under which the compiler may
+ * assume no such value ever occurs; so this looks at the bits rather
+ * than comparing.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::const]]
+bool IsNotANumber(double value) noexcept;
+
+/** The number of colour classes #ClassifyReflectivity() may return. */
+static constexpr unsigned N_CLASSES = 15;
+
+/**
+ * The colour of one class, as 0xRRGGBB.  These are the classes the
+ * Deutscher Wetterdienst uses for its radar images, so the result
+ * looks like what German pilots are used to reading.
+ */
+[[gnu::const]]
+uint32_t GetClassColour(unsigned i) noexcept;
+
+/**
+ * Download the newest composite and render the part covering
+ * @p bounds as a PNG.
+ *
+ * Throws on error.
+ *
+ * @return the path of the rendered image
+ */
+Co::Task<AllocatedPath>
+DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
+              CurlGlobal &curl, ProgressListener &progress);
+
+} // namespace OPERA

--- a/src/Weather/OPERA/Radar.hpp
+++ b/src/Weather/OPERA/Radar.hpp
@@ -3,14 +3,15 @@
 
 #pragma once
 
-#include "system/Path.hpp"
+#include "ui/canvas/custom/GeoBitmap.hpp"
 #include "Math/Point2D.hpp"
+#include "system/Path.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <memory>
 #include <span>
 #include <string>
+#include <vector>
 
 struct BrokenDateTime;
 struct GeoPoint;
@@ -22,6 +23,13 @@ namespace Co { template<typename T> class Task; }
 /**
  * The EUMETNET OPERA radar composite, a pan-European reflectivity
  * mosaic published every five minutes under CC BY 4.0.
+ *
+ * The composite is one cloud-optimized GeoTIFF of about five
+ * megabytes covering the whole continent.  Pulling all of it down to
+ * draw the weather around one glider would be absurd over a flight
+ * connection, so this module reads it the way it was meant to be
+ * read: a small range request for the directory, then a range request
+ * per tile, nearest to the aircraft first.
  *
  * @see https://eumetnet.github.io/openradardata-documentation/
  */
@@ -55,12 +63,6 @@ static constexpr unsigned LATENCY_MINUTES = 7;
  * pilot can be looking at.
  */
 static constexpr unsigned MAX_AGE_MINUTES = 20;
-
-/**
- * The largest image we render.  The composite is a 1km grid; more
- * pixels than this only upsamples.
- */
-static constexpr unsigned MAX_IMAGE_SIZE = 1024;
 
 /**
  * Build the URL of the composite covering the given UTC time.  The
@@ -136,16 +138,363 @@ static constexpr unsigned N_CLASSES = 15;
 [[gnu::const]]
 uint32_t GetClassColour(unsigned i) noexcept;
 
+/* ------------------------------------------------------------------
+ * the display grid
+ * ------------------------------------------------------------------ */
+
 /**
- * Download the newest composite and render the part covering
- * @p bounds as a PNG.
+ * The zoom levels the overlay grid may use.
+ *
+ * The lower bound keeps one tile from spanning so much of the globe
+ * that the flat quadrilateral the map draws it with stops matching
+ * the ground; the upper bound is where a tile is finer than the one
+ * kilometre the radar actually resolves and further zoom would only
+ * magnify the same pixels.
+ */
+static constexpr uint16_t MIN_TILE_ZOOM = 4;
+static constexpr uint16_t MAX_TILE_ZOOM = 10;
+
+/**
+ * How many tiles to either side of the aircraft's own tile, so the
+ * block is (2 * #TILE_RANGE + 1) squared.
+ */
+static constexpr unsigned TILE_RANGE = 2;
+
+/** The number of tiles in the block. */
+static constexpr unsigned TILE_COUNT =
+  (2 * TILE_RANGE + 1) * (2 * TILE_RANGE + 1);
+
+/**
+ * The edge length rendered per tile, in pixels.
+ *
+ * The grid zoom is chosen so that a tile is about a third of the
+ * screen diagonal, which at typical soaring scales puts this at two
+ * to five hundred metres per pixel -- oversampling the composite's
+ * kilometre grid, so that the overlay does not draw blocky under a
+ * map the pilot zooms.  Where the map is wider than the pyramid's
+ * finest level is worth reading, #SelectLevel() drops to a coarser
+ * one and the cost falls with it.
+ */
+static constexpr unsigned TILE_PIXELS = 256;
+
+/**
+ * How much finer than the map's own scale the tile grid is chosen.
+ *
+ * GeoBitmap::GetTile() sizes a tile to the screen diagonal; one step
+ * finer makes the block of #TILE_COUNT cover the screen with a margin
+ * to pan into, rather than five screens of imagery the pilot will
+ * never look at.
+ */
+static constexpr unsigned TILE_ZOOM_STEP = 1;
+
+/**
+ * The tile the aircraft is in.
+ *
+ * @return an invalid tile if @p location is not valid
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+GeoBitmap::TileData GetAircraftTile(const GeoPoint &location,
+                                    uint16_t zoom) noexcept;
+
+/**
+ * The tiles to fetch around @p base, nearest first, so that on a slow
+ * or intermittent link the ground under the aircraft is drawn before
+ * anything else and the picture then fills outwards.
+ *
+ * Tiles that fall off the top or bottom of the world are dropped, so
+ * the result can be shorter than #TILE_COUNT.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::vector<GeoBitmap::TileData>
+CollectTiles(const GeoBitmap::TileData &base) noexcept;
+
+/** Are these the same tile? */
+[[gnu::const]]
+constexpr bool
+IsSameTile(const GeoBitmap::TileData &a,
+           const GeoBitmap::TileData &b) noexcept
+{
+  return a.zoom == b.zoom && a.x == b.x && a.y == b.y;
+}
+
+/* ------------------------------------------------------------------
+ * the composite's own tiling
+ * ------------------------------------------------------------------ */
+
+/** One level of the composite's overview pyramid. */
+struct CompositeLevel {
+  unsigned width = 0, height = 0;
+  unsigned tile_width = 0, tile_height = 0;
+  unsigned samples = 0;
+
+  /** metres per pixel */
+  double scale = 0;
+
+  /** the projected coordinate of the grid's top left corner */
+  double origin_x = 0, origin_y = 0;
+
+  std::vector<uint_least32_t> tile_offset, tile_length;
+
+  [[gnu::pure]]
+  unsigned TilesAcross() const noexcept {
+    return tile_width > 0 ? (width + tile_width - 1) / tile_width : 0;
+  }
+
+  [[gnu::pure]]
+  unsigned TilesDown() const noexcept {
+    return tile_height > 0 ? (height + tile_height - 1) / tile_height : 0;
+  }
+
+  [[gnu::pure]]
+  bool IsUsable() const noexcept {
+    return width > 0 && height > 0 && tile_width > 0 && tile_height > 0 &&
+      scale > 0 && !tile_offset.empty() &&
+      tile_offset.size() == tile_length.size();
+  }
+};
+
+/**
+ * The composite's directory: what the file contains and where each
+ * tile of it lies, without any of the pixels.
+ */
+struct CompositeIndex {
+  /** ordered fine to coarse, as the file stores them */
+  std::vector<CompositeLevel> levels;
+
+  /** does the file's byte order differ from this machine's? */
+  bool foreign_byte_order = false;
+
+  [[gnu::pure]]
+  bool IsValid() const noexcept {
+    return !levels.empty() && levels.front().IsUsable();
+  }
+};
+
+/**
+ * How much of the file to fetch to be sure of holding the whole
+ * directory.
+ *
+ * Measured against the live service: the header, all five image file
+ * directories and every tile offset and length table end within the
+ * first 5 691 bytes.  Sixteen kilobytes is room for the file to grow
+ * without another round trip, and is still a thousandth of it.
+ */
+static constexpr std::size_t INDEX_BYTES = 16384;
+
+/**
+ * Parse the composite's directory out of the head of the file.
+ *
+ * Throws if @p header is not the start of a composite, or if the
+ * directory reaches past what was fetched.
+ *
+ * Exposed for the unit test.
+ */
+CompositeIndex ParseIndex(std::span<const std::byte> header);
+
+/**
+ * Projects a north-up latitude/longitude raster onto the composite's
+ * grid, a row at a time.
+ *
+ * A row shares one latitude and every row shares the same longitudes,
+ * so the trigonometry belongs outside the inner loop.  That matters
+ * on the processors XCSoar runs on: once the download has shrunk to a
+ * few tiles, the reprojection is the only expensive step left.
+ *
+ * Exposed for the unit test.
+ */
+class RasterProjector {
+  std::vector<DoublePoint2D> delta;
+
+public:
+  /**
+   * @param west the longitude of the left edge, in degrees
+   * @param east the longitude of the right edge, in degrees
+   * @param width how many pixels lie between them
+   */
+  RasterProjector(double west, double east, unsigned width);
+
+  [[gnu::pure]]
+  unsigned GetWidth() const noexcept { return delta.size(); }
+
+  /**
+   * Project one row of pixel centres.
+   *
+   * @param latitude the row's latitude, in degrees
+   * @param out receives #GetWidth() points, x east and y north in
+   * metres in the projection plane
+   */
+  void ProjectRow(double latitude, DoublePoint2D *out) const noexcept;
+};
+
+/**
+ * The ground resolution an area would be drawn at, in metres per
+ * pixel, measured in the composite's own projection.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+double TileMetresPerPixel(const GeoBounds &bounds, unsigned pixels) noexcept;
+
+/**
+ * How much coarser than the requested resolution a level may be and
+ * still be chosen.
+ *
+ * #TILE_PIXELS oversamples the composite by design, and the composite
+ * is a maximum product, so halving the sampling loses no echo -- only
+ * a little of the shape of its edge.  It does, though, quarter what
+ * has to travel: one step up the pyramid is four times fewer pixels.
+ * Measured over a live frame, insisting on the finer level cost 12.5%
+ * of the whole file at the scale a 200 km tile is drawn at, against
+ * 3% for the coarser one.
+ */
+static constexpr double LEVEL_TOLERANCE = 2;
+
+/**
+ * The coarsest level that still resolves @p metres_per_pixel to
+ * within #LEVEL_TOLERANCE, which is the cheapest one worth fetching
+ * for that scale.
+ *
+ * Exposed for the unit test.
+ *
+ * @return an index into CompositeIndex::levels
+ */
+[[gnu::pure]]
+unsigned SelectLevel(const CompositeIndex &index,
+                     double metres_per_pixel) noexcept;
+
+/**
+ * The tiles of @p level that cover @p bounds, in the file's own tile
+ * numbering.
+ *
+ * Exposed for the unit test.
+ */
+[[gnu::pure]]
+std::vector<unsigned>
+CoveringSourceTiles(const CompositeLevel &level,
+                    const GeoBounds &bounds) noexcept;
+
+/* ------------------------------------------------------------------
+ * fetching and drawing
+ * ------------------------------------------------------------------ */
+
+/**
+ * One composite frame: its directory, and the tiles of it fetched so
+ * far.
+ *
+ * Held across display tiles and across map movements so that a frame
+ * is read from the network once.  Lives on the network thread.
+ */
+class RadarComposite {
+  /**
+   * One decoded tile of the composite, kept as colour classes rather
+   * than reflectivities.
+   *
+   * A class is one byte where a reflectivity is four, and the
+   * classification is monotonic, so taking the strongest class over
+   * an area gives the same answer as classifying the strongest
+   * reflectivity.  On the machines XCSoar runs on that is worth
+   * having: a tile of the full resolution level is 256 kB this way
+   * rather than a megabyte.
+   */
+  struct SourceTile {
+    unsigned level, index;
+
+    /** the colour class per pixel, or -1 where there is no echo */
+    std::vector<int8_t> data;
+  };
+
+  /**
+   * How many decoded tiles to keep.
+   *
+   * This has to hold a whole block, or tiles would be evicted while
+   * the block that needs them is still filling and would travel a
+   * second time.  Measured against a live frame, a block needs two
+   * source tiles at the scales one flies at, eight at the widest
+   * zoom, and fifteen at the worst point in between -- where the
+   * block is wide enough to span many of them but still fine enough
+   * to want the second level of the pyramid.
+   *
+   * Every level tiles at 512 by 512, so a tile is 256 kB as a class
+   * per pixel whichever level it came from, and this bounds the cache
+   * at four megabytes.
+   */
+  static constexpr std::size_t MAX_CACHED_TILES = 16;
+
+  std::string url;
+  CompositeIndex index;
+  std::vector<SourceTile> tiles;
+
+public:
+  /** The composite this holds, empty before #Open(). */
+  [[gnu::pure]]
+  const std::string &GetURL() const noexcept { return url; }
+
+  [[gnu::pure]]
+  bool IsOpen() const noexcept { return index.IsValid(); }
+
+  [[gnu::pure]]
+  const CompositeIndex &GetIndex() const noexcept { return index; }
+
+  /** Forget everything, because the frame has moved on. */
+  void Reset() noexcept {
+    url.clear();
+    index = {};
+    tiles.clear();
+  }
+
+  [[gnu::pure]]
+  bool HasTile(unsigned level, unsigned tile) const noexcept;
+
+  /**
+   * Read the directory of @p url, unless it is already open.
+   *
+   * Throws on error.
+   */
+  Co::Task<void> Open(std::string _url, CurlGlobal &curl);
+
+  /**
+   * Fetch one tile of one level, unless it is already held.
+   *
+   * Throws on error.
+   */
+  Co::Task<void> FetchTile(unsigned level, unsigned tile, CurlGlobal &curl);
+
+  /**
+   * Draw the part of the composite covering @p bounds into a PNG at
+   * @p path, north up.
+   *
+   * Tiles that were never fetched come out transparent, so a picture
+   * that is still filling in shows what has arrived rather than
+   * nothing.
+   *
+   * Throws on error.
+   *
+   * @return whether anything was drawn; where the sky is clear there
+   * is no point spending a map overlay slot on the result
+   */
+  bool Render(unsigned level, const GeoBounds &bounds,
+              unsigned width, unsigned height, Path path) const;
+};
+
+/**
+ * Download the newest composite and draw the part covering @p bounds
+ * as a single image.
+ *
+ * This is the Weather dialog's path, which shows one picture of the
+ * area the map happens to be looking at inside a modal download.  The
+ * page overlay does not use it: it fills the map tile by tile instead,
+ * reusing one #RadarComposite across them.
  *
  * Throws on error.
  *
  * @return the path of the rendered image
  */
 Co::Task<AllocatedPath>
-DownloadRadar(const GeoBounds &bounds, unsigned width, unsigned height,
-              CurlGlobal &curl, ProgressListener &progress);
+DownloadArea(const GeoBounds &bounds, unsigned width, unsigned height,
+             CurlGlobal &curl, ProgressListener &progress);
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -63,21 +63,31 @@ constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
 
 } // anonymous namespace
 
-std::string
-OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+BrokenDateTime
+OPERA::CompositeTime(const BrokenDateTime &utc)
 {
   if (!utc.IsPlausible())
     /* without a clock we cannot tell which composite is the current
        one, and guessing would show yesterday's weather */
-    return {};
+    return BrokenDateTime::Invalid();
 
-  const auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
-  const unsigned minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+  auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
+  t.minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+  t.second = 0;
+  return t;
+}
+
+std::string
+OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+{
+  const auto t = CompositeTime(utc);
+  if (!t.IsPlausible())
+    return {};
 
   return fmt::format("{}/{:04}/{:02}/{:02}/OPERA/COMP/"
                      "OPERA@{:04}{:02}{:02}T{:02}{:02}@0@DBZH.tiff",
                      BUCKET_URL, t.year, t.month, t.day,
-                     t.year, t.month, t.day, t.hour, minute);
+                     t.year, t.month, t.day, t.hour, t.minute);
 }
 
 DoublePoint2D

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "Math/Constants.hpp"
@@ -10,9 +11,11 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
 #include <cstring>
 #include <functional>
+#include <stdexcept>
 
 namespace {
 
@@ -27,13 +30,6 @@ constexpr double CENTRE_LONGITUDE = 10;
 constexpr double FALSE_EASTING = 1950000;
 constexpr double FALSE_NORTHING = -2100000;
 
-/**
- * The lower reflectivity bound of each colour class.
- *
- * The last entry is the "everything above" class; a value below the
- * first one is not drawn at all, which is what the reference product
- * does with the weakest echoes.
- */
 /**
  * The lower dBZ bound of each colour class, obtained by matching the
  * quantiles of the composite against a DWD European radar image.
@@ -61,7 +57,291 @@ constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
   0xfe0000, 0xe5004c, 0xcc0098, 0x6600cb, 0x0000fe,
 };
 
+/* ------------------------------------------------------------------
+ * a very small TIFF directory reader
+ *
+ * Only what the composite is: a tiled, Deflate compressed, two band
+ * float image with a pyramid of overviews.  It reads the head of the
+ * file alone, so every offset has to be checked against how much of
+ * the file we actually hold.
+ * ------------------------------------------------------------------ */
+
+constexpr unsigned TAG_WIDTH = 256, TAG_HEIGHT = 257;
+constexpr unsigned TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+constexpr unsigned TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+constexpr unsigned TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+constexpr unsigned TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+constexpr unsigned COMPRESSION_DEFLATE = 8;
+
+/** how many image file directories to walk before giving up */
+constexpr unsigned MAX_DIRECTORIES = 32;
+
+/**
+ * The most tiles a level may claim.  The composite's finest level has
+ * 72; this is room for one a hundred times its size, and a bound on
+ * what a corrupt count can make us reserve.
+ */
+constexpr uint32_t MAX_TILES = 65536;
+
+class HeaderReader {
+  std::span<const std::byte> header;
+  bool big_endian = false;
+
+public:
+  explicit HeaderReader(std::span<const std::byte> _header)
+    :header(_header)
+  {
+    if (header.size() < 8)
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data();
+    if (p[0] == 'M' && p[1] == 'M')
+      big_endian = true;
+    else if (p[0] != 'I' || p[1] != 'I')
+      throw std::runtime_error("Not a TIFF radar image");
+
+    /* 42 is a classic TIFF; a BigTIFF would be 43 and would need
+       eight byte offsets, which this reader does not do */
+    if (U16(2) != 42)
+      throw std::runtime_error("Unsupported radar image format");
+  }
+
+  bool IsForeignByteOrder() const noexcept {
+    return big_endian != (std::endian::native == std::endian::big);
+  }
+
+  /**
+   * Is there room for @p length bytes at @p offset?
+   *
+   * Written as a subtraction rather than as `offset + length > size()`
+   * because the offsets come out of the file: on a 32 bit target a
+   * corrupt one near the top of the range would make that sum wrap
+   * and the check pass.
+   */
+  bool Holds(std::size_t offset, std::size_t length) const noexcept {
+    return length <= header.size() && offset <= header.size() - length;
+  }
+
+  uint16_t U16(std::size_t o) const {
+    if (!Holds(o, 2))
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data() + o;
+    return big_endian ? uint16_t(p[0] << 8 | p[1]) : uint16_t(p[1] << 8 | p[0]);
+  }
+
+  uint32_t U32(std::size_t o) const {
+    if (!Holds(o, 4))
+      throw std::runtime_error("Truncated radar image");
+
+    const auto *p = (const uint8_t *)header.data() + o;
+    return big_endian
+      ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 |
+         uint32_t(p[2]) << 8 | p[3])
+      : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 |
+         uint32_t(p[1]) << 8 | p[0]);
+  }
+
+  double F64(std::size_t o) const {
+    /* U32() already applies the file byte order within each half, so
+       all that is left is which half comes first */
+    const uint64_t first = U32(o), second = U32(o + 4);
+    return std::bit_cast<double>(big_endian
+                                 ? first << 32 | second
+                                 : second << 32 | first);
+  }
+
+  std::size_t FirstDirectory() const { return U32(4); }
+
+  /**
+   * @return the offset of the next directory, zero at the end
+   */
+  std::size_t ReadDirectory(std::size_t offset,
+                            OPERA::CompositeLevel &level) const;
+};
+
+std::size_t
+HeaderReader::ReadDirectory(std::size_t offset,
+                            OPERA::CompositeLevel &level) const
+{
+  const unsigned n = U16(offset);
+
+  /* validate the whole directory up front, so that the entry reads
+     below cannot form an offset that wraps before it is checked */
+  if (!Holds(offset, 2 + std::size_t(n) * 12 + 4))
+    throw std::runtime_error("Truncated radar image");
+
+  unsigned compression = 0;
+
+  for (unsigned i = 0; i < n; ++i) {
+    const std::size_t e = offset + 2 + std::size_t(i) * 12;
+    const unsigned tag = U16(e), type = U16(e + 2);
+    const uint32_t count = U32(e + 4);
+
+    /* the value is inline when it fits in the four bytes of the entry */
+    const std::size_t size = type == 3 ? 2 : (type == 12 ? 8 : 4);
+    const std::size_t at = size * std::size_t(count) <= 4
+      ? e + 8
+      : U32(e + 8);
+
+    const auto scalar = [this, type, at]() -> uint32_t {
+      return type == 3 ? U16(at) : U32(at);
+    };
+
+    switch (tag) {
+    case TAG_WIDTH: level.width = scalar(); break;
+    case TAG_HEIGHT: level.height = scalar(); break;
+    case TAG_COMPRESSION: compression = scalar(); break;
+    case TAG_SAMPLES: level.samples = scalar(); break;
+    case TAG_TILE_WIDTH: level.tile_width = scalar(); break;
+    case TAG_TILE_HEIGHT: level.tile_height = scalar(); break;
+
+    case TAG_TILE_OFFSETS:
+    case TAG_TILE_LENGTHS: {
+      /* the count comes out of the file; a corrupt one must not turn
+         into a four gigabyte reservation */
+      if (count > MAX_TILES)
+        throw std::runtime_error("Unusable radar image");
+
+      const std::size_t stride = type == 3 ? 2 : 4;
+      if (!Holds(at, std::size_t(count) * stride))
+        throw std::runtime_error("Truncated radar image");
+
+      auto &out = tag == TAG_TILE_OFFSETS
+        ? level.tile_offset
+        : level.tile_length;
+      out.clear();
+      out.reserve(count);
+      for (uint32_t j = 0; j < count; ++j)
+        out.push_back(stride == 2
+                      ? U16(at + std::size_t(j) * 2)
+                      : U32(at + std::size_t(j) * 4));
+      break;
+    }
+
+    case TAG_PIXEL_SCALE:
+      if (count >= 2)
+        level.scale = F64(at);
+      break;
+
+    case TAG_TIEPOINT:
+      /* the first three doubles are the raster point, the next three
+         the projected point it maps to */
+      if (count >= 6) {
+        level.origin_x = F64(at + 3 * 8);
+        level.origin_y = F64(at + 4 * 8);
+      }
+      break;
+    }
+  }
+
+  if (level.width > 0) {
+    if (compression != COMPRESSION_DEFLATE)
+      throw std::runtime_error("Unsupported radar image compression");
+
+    if (level.samples == 0)
+      /* the tag is mandatory, but a missing one would make us read
+         zero bytes per pixel */
+      level.samples = 1;
+  }
+
+  return U32(offset + 2 + std::size_t(n) * 12);
+}
+
+/** the extent an area occupies in the composite's projection */
+struct ProjectedExtent {
+  double min_x, max_x, min_y, max_y;
+};
+
+[[gnu::pure]]
+ProjectedExtent
+GetProjectedExtent(const GeoBounds &bounds) noexcept
+{
+  const double north = bounds.GetNorth().Degrees();
+  const double south = bounds.GetSouth().Degrees();
+  const double west = bounds.GetWest().Degrees();
+  const double east = bounds.GetEast().Degrees();
+
+  /* the projection is curved, so probe a coarse grid rather than just
+     the corners to find the extent the area really needs */
+  static constexpr unsigned PROBE = 4;
+  ProjectedExtent extent{1e30, -1e30, 1e30, -1e30};
+
+  for (unsigned j = 0; j <= PROBE; ++j)
+    for (unsigned i = 0; i <= PROBE; ++i) {
+      const auto p = OPERA::Project(GeoPoint{
+        Angle::Degrees(west + (east - west) * i / PROBE),
+        Angle::Degrees(south + (north - south) * j / PROBE),
+      });
+      extent.min_x = std::min(extent.min_x, p.x);
+      extent.max_x = std::max(extent.max_x, p.x);
+      extent.min_y = std::min(extent.min_y, p.y);
+      extent.max_y = std::max(extent.max_y, p.y);
+    }
+
+  return extent;
+}
+
 } // anonymous namespace
+
+OPERA::RasterProjector::RasterProjector(double west, double east,
+                                        unsigned width)
+{
+  delta.resize(width);
+
+  const double lon0 = CENTRE_LONGITUDE * M_PI / 180;
+  for (unsigned x = 0; x < width; ++x) {
+    const double longitude = west + (east - west) * (x + 0.5) / width;
+    const double d = longitude * M_PI / 180 - lon0;
+    delta[x] = {std::sin(d), std::cos(d)};
+  }
+}
+
+void
+OPERA::RasterProjector::ProjectRow(double latitude,
+                                   DoublePoint2D *out) const noexcept
+{
+  const double lat = latitude * M_PI / 180;
+  const double lat0 = CENTRE_LATITUDE * M_PI / 180;
+  const double sin_lat = std::sin(lat), cos_lat = std::cos(lat);
+  const double sin_lat0 = std::sin(lat0), cos_lat0 = std::cos(lat0);
+
+  const double a = sin_lat0 * sin_lat;
+  const double b = cos_lat0 * cos_lat;
+  const double c = cos_lat0 * sin_lat;
+  const double d = sin_lat0 * cos_lat;
+
+  for (std::size_t x = 0; x < delta.size(); ++x) {
+    const double sin_delta = delta[x].x, cos_delta = delta[x].y;
+
+    const double denominator = 1 + a + b * cos_delta;
+    if (denominator <= 0) {
+      /* the antipode of the projection centre has no image */
+      out[x] = {0, 0};
+      continue;
+    }
+
+    const double k = EARTH_RADIUS * std::sqrt(2 / denominator);
+    out[x] = {
+      FALSE_EASTING + k * cos_lat * sin_delta,
+      FALSE_NORTHING + k * (c - d * cos_delta),
+    };
+  }
+}
+
+double
+OPERA::TileMetresPerPixel(const GeoBounds &bounds, unsigned pixels) noexcept
+{
+  if (!bounds.IsValid() || pixels == 0)
+    return 0;
+
+  const auto extent = GetProjectedExtent(bounds);
+
+  /* the wider of the two axes, so that neither ends up undersampled
+     by a level chosen for the other */
+  return std::max(extent.max_x - extent.min_x,
+                  extent.max_y - extent.min_y) / pixels;
+}
 
 BrokenDateTime
 OPERA::CompositeTime(const BrokenDateTime &utc)
@@ -140,4 +420,165 @@ uint32_t
 OPERA::GetClassColour(unsigned i) noexcept
 {
   return CLASS_COLOUR[i < N_CLASSES ? i : N_CLASSES - 1];
+}
+
+GeoBitmap::TileData
+OPERA::GetAircraftTile(const GeoPoint &location, uint16_t zoom) noexcept
+{
+  if (!location.IsValid() || zoom < MIN_TILE_ZOOM || zoom > MAX_TILE_ZOOM)
+    return {};
+
+  return GeoBitmap::GetTile(GeoBounds{location}, zoom);
+}
+
+std::vector<GeoBitmap::TileData>
+OPERA::CollectTiles(const GeoBitmap::TileData &base) noexcept
+{
+  std::vector<GeoBitmap::TileData> result;
+  if (!base.IsValid())
+    return result;
+
+  const int tiles_per_axis = 1 << base.zoom;
+
+  /* longitude wraps, so a flight over the date line keeps a complete
+     block instead of losing half of it */
+  const auto normalise_x = [tiles_per_axis](int value) {
+    int wrapped = value % tiles_per_axis;
+    if (wrapped < 0)
+      wrapped += tiles_per_axis;
+
+    return uint32_t(wrapped);
+  };
+
+  struct Candidate {
+    GeoBitmap::TileData tile;
+    unsigned priority;
+  };
+
+  std::vector<Candidate> candidates;
+  candidates.reserve(TILE_COUNT);
+
+  const int range = int(TILE_RANGE);
+  for (int dx = -range; dx <= range; ++dx) {
+    for (int dy = -range; dy <= range; ++dy) {
+      const int y = int(base.y) + dy;
+      if (y < 0 || y >= tiles_per_axis)
+        /* latitude does not wrap: off the top or bottom of the world
+           there is no tile to ask for */
+        continue;
+
+      candidates.push_back({
+        {base.zoom, normalise_x(int(base.x) + dx), uint32_t(y)},
+        unsigned(dx * dx + dy * dy),
+      });
+    }
+  }
+
+  /* squared distance from the aircraft's own tile, so the block is
+     walked as rings growing outwards from underneath the glider */
+  std::stable_sort(candidates.begin(), candidates.end(),
+                   [](const auto &a, const auto &b) {
+                     return a.priority < b.priority;
+                   });
+
+  result.reserve(candidates.size());
+  for (const auto &candidate : candidates)
+    result.push_back(candidate.tile);
+
+  return result;
+}
+
+OPERA::CompositeIndex
+OPERA::ParseIndex(std::span<const std::byte> header)
+{
+  const HeaderReader reader{header};
+
+  CompositeIndex index;
+  index.foreign_byte_order = reader.IsForeignByteOrder();
+
+  /* count every directory, not just the usable ones: a damaged file
+     can chain empty directories, or point one at itself */
+  for (std::size_t offset = reader.FirstDirectory(), n = 0;
+       offset != 0 && n < MAX_DIRECTORIES; ++n) {
+    CompositeLevel level;
+    offset = reader.ReadDirectory(offset, level);
+    if (level.width > 0)
+      index.levels.push_back(std::move(level));
+  }
+
+  if (index.levels.empty())
+    throw std::runtime_error("Empty radar image");
+
+  /* only the full resolution image carries the projection keys; the
+     overviews cover the same area with fewer pixels, so their scale
+     follows from the size ratio */
+  const auto &full = index.levels.front();
+  if (full.scale <= 0)
+    throw std::runtime_error("Radar image without a georeference");
+
+  for (auto &level : index.levels) {
+    if (level.scale > 0 || level.width == 0)
+      continue;
+
+    level.scale = full.scale * double(full.width) / level.width;
+    level.origin_x = full.origin_x;
+    level.origin_y = full.origin_y;
+  }
+
+  return index;
+}
+
+unsigned
+OPERA::SelectLevel(const CompositeIndex &index,
+                   double metres_per_pixel) noexcept
+{
+  unsigned best = 0;
+
+  const double limit = metres_per_pixel * LEVEL_TOLERANCE;
+
+  for (unsigned i = 0; i < index.levels.size(); ++i)
+    if (index.levels[i].IsUsable() && index.levels[i].scale <= limit)
+      /* the levels are ordered fine to coarse, so the last one that
+         is still fine enough is the cheapest usable one */
+      best = i;
+
+  return best;
+}
+
+std::vector<unsigned>
+OPERA::CoveringSourceTiles(const CompositeLevel &level,
+                           const GeoBounds &bounds) noexcept
+{
+  std::vector<unsigned> result;
+  if (!level.IsUsable() || !bounds.IsValid())
+    return result;
+
+  const auto extent = GetProjectedExtent(bounds);
+
+  const double c0 = (extent.min_x - level.origin_x) / level.scale;
+  const double c1 = (extent.max_x - level.origin_x) / level.scale;
+  const double r0 = (level.origin_y - extent.max_y) / level.scale;
+  const double r1 = (level.origin_y - extent.min_y) / level.scale;
+
+  if (c1 < 0 || r1 < 0 ||
+      c0 >= double(level.width) || r0 >= double(level.height))
+    /* the area is somewhere the composite does not cover */
+    return result;
+
+  const unsigned across = level.TilesAcross(), down = level.TilesDown();
+  const unsigned tx0 = unsigned(std::max(0.0, c0)) / level.tile_width;
+  const unsigned ty0 = unsigned(std::max(0.0, r0)) / level.tile_height;
+  const unsigned tx1 =
+    unsigned(std::min(double(level.width - 1), c1)) / level.tile_width;
+  const unsigned ty1 =
+    unsigned(std::min(double(level.height - 1), r1)) / level.tile_height;
+
+  for (unsigned ty = ty0; ty <= ty1 && ty < down; ++ty)
+    for (unsigned tx = tx0; tx <= tx1 && tx < across; ++tx) {
+      const unsigned i = ty * across + tx;
+      if (i < level.tile_offset.size() && level.tile_length[i] > 0)
+        result.push_back(i);
+    }
+
+  return result;
 }

--- a/src/Weather/OPERA/RadarData.cpp
+++ b/src/Weather/OPERA/RadarData.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Radar.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "Math/Constants.hpp"
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <functional>
+
+namespace {
+
+constexpr const char *BUCKET_URL =
+  "https://s3.waw3-1.cloudferro.com/openradar-24h";
+
+/* the Lambert azimuthal equal-area grid the composite is published
+   on, read from the GeoTIFF's own keys */
+constexpr double EARTH_RADIUS = 6378140;
+constexpr double CENTRE_LATITUDE = 55;
+constexpr double CENTRE_LONGITUDE = 10;
+constexpr double FALSE_EASTING = 1950000;
+constexpr double FALSE_NORTHING = -2100000;
+
+/**
+ * The lower reflectivity bound of each colour class.
+ *
+ * The last entry is the "everything above" class; a value below the
+ * first one is not drawn at all, which is what the reference product
+ * does with the weakest echoes.
+ */
+/**
+ * The lower dBZ bound of each colour class, obtained by matching the
+ * quantiles of the composite against a DWD European radar image.
+ *
+ * Classes 1 and 9 were absent from that image, so the match left them
+ * with an empty range; their bounds are interpolated evenly in dBZ
+ * (that is, geometrically in rain rate) between the neighbours it did
+ * determine.  The array must stay strictly increasing, or
+ * ClassifyReflectivity() would step over a class and one colour would
+ * never be drawn.
+ */
+constexpr std::array<double, OPERA::N_CLASSES> CLASS_MINIMUM{
+  18.77, 21.16, 23.56, 25.95, 30.43, 34.62, 38.68, 42.82,
+  47.81, 50.77, 53.73, 56.69, 60.70, 62.96, 66.14,
+};
+
+static_assert(std::ranges::adjacent_find(CLASS_MINIMUM,
+                                         std::greater_equal<>{}) ==
+              CLASS_MINIMUM.end(),
+              "the class bounds must be strictly increasing");
+
+constexpr std::array<uint32_t, OPERA::N_CLASSES> CLASS_COLOUR{
+  0x33ffff, 0x1acc9a, 0x019934, 0x4db31b, 0x99cc01,
+  0xcce601, 0xffff01, 0xffc401, 0xff8901, 0xff4501,
+  0xfe0000, 0xe5004c, 0xcc0098, 0x6600cb, 0x0000fe,
+};
+
+} // anonymous namespace
+
+std::string
+OPERA::MakeCompositeURL(const BrokenDateTime &utc)
+{
+  if (!utc.IsPlausible())
+    /* without a clock we cannot tell which composite is the current
+       one, and guessing would show yesterday's weather */
+    return {};
+
+  const auto t = utc - std::chrono::minutes{LATENCY_MINUTES};
+  const unsigned minute = (t.minute / CADENCE_MINUTES) * CADENCE_MINUTES;
+
+  return fmt::format("{}/{:04}/{:02}/{:02}/OPERA/COMP/"
+                     "OPERA@{:04}{:02}{:02}T{:02}{:02}@0@DBZH.tiff",
+                     BUCKET_URL, t.year, t.month, t.day,
+                     t.year, t.month, t.day, t.hour, minute);
+}
+
+DoublePoint2D
+OPERA::Project(const GeoPoint &p) noexcept
+{
+  const double lat = p.latitude.Radians();
+  const double lon = p.longitude.Radians();
+  const double lat0 = CENTRE_LATITUDE * M_PI / 180;
+  const double delta = lon - CENTRE_LONGITUDE * M_PI / 180;
+
+  const double denominator = 1 + std::sin(lat0) * std::sin(lat) +
+    std::cos(lat0) * std::cos(lat) * std::cos(delta);
+  if (denominator <= 0)
+    /* the antipode of the projection centre has no image */
+    return {0, 0};
+
+  const double k = EARTH_RADIUS * std::sqrt(2 / denominator);
+
+  return {
+    FALSE_EASTING + k * std::cos(lat) * std::sin(delta),
+    FALSE_NORTHING + k * (std::cos(lat0) * std::sin(lat) -
+                          std::sin(lat0) * std::cos(lat) * std::cos(delta)),
+  };
+}
+
+bool
+OPERA::IsNotANumber(double value) noexcept
+{
+  uint64_t bits;
+  static_assert(sizeof(bits) == sizeof(value));
+  std::memcpy(&bits, &value, sizeof(bits));
+
+  return ((bits >> 52) & 0x7ff) == 0x7ff && (bits & 0xfffffffffffffULL) != 0;
+}
+
+int
+OPERA::ClassifyReflectivity(double dbz) noexcept
+{
+  if (IsNotANumber(dbz) || dbz < CLASS_MINIMUM.front())
+    return -1;
+
+  unsigned i = 0;
+  while (i + 1 < N_CLASSES && dbz >= CLASS_MINIMUM[i + 1])
+    ++i;
+
+  return int(i);
+}
+
+uint32_t
+OPERA::GetClassColour(unsigned i) noexcept
+{
+  return CLASS_COLOUR[i < N_CLASSES ? i : N_CLASSES - 1];
+}

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -9,6 +9,9 @@
 #include "UIGlobals.hpp"
 #include "LogFile.hpp"
 #include "Language/Language.hpp"
+#include "Dialogs/Message.hpp"
+#include "Profile/Profile.hpp"
+#include "Profile/Keys.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "MapWindow/OverlayBitmap.hpp"
 #include "Weather/BackgroundDownloadProgress.hpp"
@@ -17,6 +20,7 @@
 #include "ui/canvas/Bitmap.hpp"
 #include "util/BindMethod.hxx"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -97,8 +101,62 @@ const MapOverlay *installed_overlay = nullptr;
 std::string installed_url;
 GeoBounds installed_bounds = GeoBounds::Invalid();
 
+/** the time #installed_overlay depicts */
+BrokenDateTime installed_time = BrokenDateTime::Invalid();
+
 /** the composite the running download is fetching */
 std::string pending_url;
+BrokenDateTime pending_time = BrokenDateTime::Invalid();
+
+/**
+ * Set when a frame was taken off the map for age and the refresh that
+ * should replace it has not succeeded yet.  If that refresh fails,
+ * the pilot is told the radar is gone rather than left wondering.
+ */
+bool stale_removed = false;
+
+[[gnu::pure]]
+bool
+IsStaleWarningHidden() noexcept
+{
+  bool hidden = false;
+  Profile::Get(ProfileKeys::HideRadarStaleWarning, hidden);
+  return hidden;
+}
+
+void
+WarnStale() noexcept
+{
+  if (IsStaleWarningHidden())
+    return;
+
+  /* the opt-out follows the Quick Guide dialog: answering "no" writes
+     the choice to the profile, and the Network configuration page can
+     switch it back on */
+  if (ShowMessageBox(_("The radar image could not be refreshed and has "
+                       "been removed, so that no outdated echo is shown.\n\n"
+                       "Warn again when this happens?"),
+                     _("Radar"), MB_YESNO | MB_ICONWARNING) == IDNO) {
+    Profile::Set(ProfileKeys::HideRadarStaleWarning, true);
+    Profile::Save();
+  }
+}
+
+/**
+ * How long ago the frame on the map was taken, or a negative duration
+ * when nothing is on the map.
+ */
+[[gnu::pure]]
+std::chrono::system_clock::duration
+OverlayAge() noexcept
+{
+  const auto now = BrokenDateTime::NowUTC();
+  if (installed_overlay == nullptr ||
+      !installed_time.IsPlausible() || !now.IsPlausible())
+    return std::chrono::system_clock::duration{-1};
+
+  return now - installed_time;
+}
 
 void
 InstallOverlay(Path path, const GeoBounds &bounds) noexcept
@@ -128,6 +186,8 @@ InstallOverlay(Path path, const GeoBounds &bounds) noexcept
   installed_overlay = bmp.get();
   installed_bounds = bounds;
   installed_url = pending_url;
+  installed_time = pending_time;
+  stale_removed = false;
   map->SetOverlay(std::move(bmp));
 }
 
@@ -160,10 +220,52 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
 
   if (completion_error) {
     LogError(std::exchange(completion_error, {}), "Radar download");
+
+    /* a lost request on its own is not worth a dialog; it only
+       matters once it means the map has no radar left to show */
+    if (std::exchange(stale_removed, false))
+      WarnStale();
+
     return;
   }
 
   InstallOverlay(path, bounds);
+}
+
+void
+RadarDownloadGlue::ScheduleAgeCheck() noexcept
+{
+  /* the composite changes every five minutes, so checking once a
+     minute is often enough to catch a new one and cheap enough to run
+     for as long as the page is open */
+  age_timer.Schedule(std::chrono::minutes{1});
+}
+
+void
+RadarDownloadGlue::CancelAgeCheck() noexcept
+{
+  age_timer.Cancel();
+}
+
+void
+RadarDownloadGlue::OnAgeTimer() noexcept
+{
+  const auto age = OverlayAge();
+  if (age < std::chrono::system_clock::duration::zero())
+    /* nothing on the map to keep fresh */
+    return;
+
+  if (age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
+    /* down it comes before anything is fetched: an echo this old is
+       worse than none, and a refresh that hangs or fails must not be
+       able to leave it standing */
+    OPERA::ClearMapOverlay();
+    stale_removed = true;
+  }
+
+  /* ActivatePageOverlay() is a no-op while the frame we hold is still
+     the newest one, so this only fetches when there is something new */
+  OPERA::ActivatePageOverlay();
 }
 
 void
@@ -174,17 +276,24 @@ OPERA::ActivatePageOverlay() noexcept
   if (glue == nullptr || map == nullptr)
     return;
 
+  /* arm the watchdog first: it has to keep running even on the turns
+     where there is nothing new to fetch, or the picture would never
+     age out */
+  glue->ScheduleAgeCheck();
+
   const auto &projection = map->VisibleProjection();
   if (!projection.IsValid())
     return;
 
   const auto &bounds = projection.GetScreenBounds();
-  const auto url = OPERA::MakeCompositeURL(BrokenDateTime::NowUTC());
+  const auto now = BrokenDateTime::NowUTC();
+  const auto url = OPERA::MakeCompositeURL(now);
   if (url.empty() || IsStillCurrent(url.c_str(), bounds))
     return;
 
   const auto size = projection.GetScreenSize();
   pending_url = url;
+  pending_time = OPERA::CompositeTime(now);
   glue->Start(bounds, size.width, size.height);
 }
 
@@ -200,5 +309,16 @@ OPERA::ClearMapOverlay() noexcept
 
   installed_overlay = nullptr;
   installed_bounds = GeoBounds::Invalid();
+  installed_time = BrokenDateTime::Invalid();
   installed_url.clear();
+}
+
+void
+OPERA::DeactivatePageOverlay() noexcept
+{
+  if (auto *glue = GetRadarDownloadGlue(); glue != nullptr)
+    glue->CancelAgeCheck();
+
+  stale_removed = false;
+  ClearMapOverlay();
 }

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -338,18 +338,29 @@ RadarDownloadGlue::Start(std::string _url, const GeoBitmap::TileData &_base,
       !_frame_time.IsPlausible() || _slot >= slots.size())
     return;
 
+  /* one file per slot, so the cache cannot grow with the flight.
+     Built before anything is assigned: this allocates, and we are
+     noexcept, so a failure here has to leave the glue as it was
+     rather than half-armed -- and must not reach the caller, where it
+     would be std::terminate() rather than a lost tile. */
+  AllocatedPath new_path{nullptr};
+  try {
+    new_path = AllocatedPath::Build(MakeCacheDirectory("opera"),
+                                    fmt::format("rain-{}.png",
+                                                _slot).c_str());
+  } catch (...) {
+    LogError(std::current_exception(), "Radar overlay");
+    return;
+  }
+
   url = std::move(_url);
   base_tile = _base;
   tile = _tile;
   frame_time = _frame_time;
   slot = _slot;
   drawn = false;
-  path = nullptr;
+  path = std::move(new_path);
   completion_error = {};
-
-  /* one file per slot, so the cache cannot grow with the flight */
-  path = AllocatedPath::Build(MakeCacheDirectory("opera"),
-                              fmt::format("rain-{}.png", slot).c_str());
 
   /* hold the slot now: the next tile must not be handed the same one
      while this download is in flight */

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -2,28 +2,38 @@
 // Copyright The XCSoar Project
 
 #include "RadarPageOverlay.hpp"
-#include "Radar.hpp"
 #include "co/Task.hxx"
 #include "Components.hpp"
 #include "NetComponents.hpp"
 #include "UIGlobals.hpp"
+#include "Interface.hpp"
+#include "LocalPath.hpp"
 #include "LogFile.hpp"
 #include "Language/Language.hpp"
 #include "Dialogs/Message.hpp"
 #include "Profile/Profile.hpp"
 #include "Profile/Keys.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/Quadrilateral.hpp"
 #include "MapWindow/GlueMapWindow.hpp"
 #include "MapWindow/OverlayBitmap.hpp"
+#include "MapWindow/OverlayLimits.hpp"
 #include "Weather/BackgroundDownloadProgress.hpp"
 #include "lib/curl/Global.hxx"
-#include "time/BrokenDateTime.hpp"
 #include "ui/canvas/Bitmap.hpp"
 #include "util/BindMethod.hxx"
 
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <memory>
-#include <string>
 #include <utility>
+#include <vector>
+
+static_assert(OPERA::TILE_COUNT <= MapWindowOverlay::MAX_MAP_OVERLAYS,
+              "the radar block must fit in the map's overlay slots");
 
 RadarDownloadGlue *
 GetRadarDownloadGlue() noexcept
@@ -40,73 +50,64 @@ RadarDownloadGlue::RadarDownloadGlue(CurlGlobal &_curl) noexcept
 {
 }
 
-void
-RadarDownloadGlue::BeginShutdown() noexcept
-{
-  task.BeginShutdown();
-  complete_notify.ClearNotification();
-  path = nullptr;
-  completion_error = {};
-  BackgroundDownloadProgress::Get().ForceHide();
-}
-
-void
-RadarDownloadGlue::Start(const GeoBounds &_bounds,
-                         unsigned _width, unsigned _height) noexcept
-{
-  if (task.IsShuttingDown() || task.IsRunning())
-    return;
-
-  if (!_bounds.IsValid() || _width == 0 || _height == 0)
-    return;
-
-  bounds = _bounds;
-  width = _width;
-  height = _height;
-  path = nullptr;
-  completion_error = {};
-
-  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
-  BackgroundDownloadProgress::Get().SetProgressRange(100);
-
-  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
-}
-
-Co::InvokeTask
-RadarDownloadGlue::RunDownload()
-{
-  path = co_await OPERA::DownloadRadar(bounds, width, height, curl,
-                                       BackgroundDownloadProgress::Get());
-}
-
-void
-RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
-{
-  completion_error = std::move(error);
-  complete_notify.SendNotification();
-}
-
 namespace {
 
 /**
- * The overlay we installed, so that we never remove one somebody else
- * put there.
+ * One overlay slot, and the tile it is showing.
+ *
+ * The slot index is the map's overlay index, so a tile that survives
+ * a move stays exactly where it is and is never re-uploaded.
  */
-const MapOverlay *installed_overlay = nullptr;
+struct Slot {
+  /** the overlay we installed, so we never remove somebody else's */
+  const MapOverlay *overlay = nullptr;
+
+  GeoBitmap::TileData tile{};
+
+  /** the frame this tile depicts */
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+
+  /**
+   * Held for a download in flight, or for a tile that turned out to
+   * hold no echo and so has nothing to install.  Either way the slot
+   * is spoken for and must not be handed out again.
+   */
+  bool reserved = false;
+
+  constexpr bool IsUsed() const noexcept {
+    return overlay != nullptr || reserved;
+  }
+};
+
+std::array<Slot, OPERA::TILE_COUNT> slots;
+
+/** does any page show the radar? */
+bool active = false;
 
 /**
- * What #installed_overlay shows: the composite it came from, and the
- * area it was fetched for.
+ * Is the radar being held on the map across a pan?  Panning swaps in
+ * a layout with no overlay, which would otherwise tear the block down
+ * and cost a full refetch on the way back.
  */
-std::string installed_url;
-GeoBounds installed_bounds = GeoBounds::Invalid();
+bool suspended_for_pan = false;
 
-/** the time #installed_overlay depicts */
-BrokenDateTime installed_time = BrokenDateTime::Invalid();
+/** the frame the block is being filled with */
+BrokenDateTime block_frame = BrokenDateTime::Invalid();
 
-/** the composite the running download is fetching */
-std::string pending_url;
-BrokenDateTime pending_time = BrokenDateTime::Invalid();
+/** the aircraft's tile the current block is centred on */
+GeoBitmap::TileData block_base{};
+
+/** the tiles the block wants, nearest to the aircraft first */
+std::vector<GeoBitmap::TileData> wanted;
+
+/**
+ * Tiles that failed in a row, so a composite the server will not
+ * serve does not spin through the whole block once a second.
+ */
+unsigned consecutive_failures = 0;
+
+/** is the progress bar up for the block being filled? */
+bool progress_shown = false;
 
 /**
  * Set when a frame was taken off the map for age and the refresh that
@@ -114,6 +115,26 @@ BrokenDateTime pending_time = BrokenDateTime::Invalid();
  * the pilot is told the radar is gone rather than left wondering.
  */
 bool stale_removed = false;
+
+void
+BeginProgress() noexcept
+{
+  if (progress_shown)
+    return;
+
+  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
+  progress_shown = true;
+}
+
+void
+EndProgress() noexcept
+{
+  if (!progress_shown)
+    return;
+
+  BackgroundDownloadProgress::Get().End();
+  progress_shown = false;
+}
 
 [[gnu::pure]]
 bool
@@ -131,7 +152,7 @@ WarnStale() noexcept
     return;
 
   /* the opt-out follows the Quick Guide dialog: answering "no" writes
-     the choice to the profile, and the Network configuration page can
+     the choice to the profile, and the Look configuration page can
      switch it back on */
   if (ShowMessageBox(_("The radar image could not be refreshed and has "
                        "been removed, so that no outdated echo is shown.\n\n"
@@ -148,21 +169,99 @@ WarnStale() noexcept
  */
 [[gnu::pure]]
 std::chrono::system_clock::duration
-OverlayAge() noexcept
+BlockAge() noexcept
 {
   const auto now = BrokenDateTime::NowUTC();
-  if (installed_overlay == nullptr ||
-      !installed_time.IsPlausible() || !now.IsPlausible())
+  if (!block_frame.IsPlausible() || !now.IsPlausible())
     return std::chrono::system_clock::duration{-1};
 
-  return now - installed_time;
+  return now - block_frame;
+}
+
+/** Drop one slot, if the map is still showing what we put there. */
+void
+ReleaseSlot(unsigned index) noexcept
+{
+  auto &slot = slots[index];
+  if (!slot.IsUsed())
+    return;
+
+  if (auto *map = UIGlobals::GetMap();
+      map != nullptr && slot.overlay != nullptr &&
+      map->GetOverlay(index) == slot.overlay)
+    map->SetOverlay(index, nullptr);
+
+  slot = {};
+}
+
+/** Is this tile already dealt with, showing the right frame? */
+[[gnu::pure]]
+bool
+IsShown(const GeoBitmap::TileData &tile,
+        const BrokenDateTime &frame_time) noexcept
+{
+  const auto *map = UIGlobals::GetMap();
+
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed() || !OPERA::IsSameTile(slot.tile, tile) ||
+        !(slot.frame_time == frame_time))
+      continue;
+
+    if (slot.overlay == nullptr)
+      /* reserved: either in flight or known to hold no echo -- either
+         way there is nothing left to fetch for it */
+      return true;
+
+    if (map != nullptr && map->GetOverlay(i) == slot.overlay)
+      return true;
+  }
+
+  return false;
+}
+
+/**
+ * Give up the slots holding tiles the block no longer wants -- the
+ * ones left behind as the aircraft flew on, and everything at all
+ * when the frame moved on.
+ */
+void
+ReleaseUnwantedSlots() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i) {
+    const auto &slot = slots[i];
+    if (!slot.IsUsed())
+      continue;
+
+    const bool keep = slot.frame_time == block_frame &&
+      std::any_of(wanted.begin(), wanted.end(),
+                  [&slot](const auto &t){
+                    return OPERA::IsSameTile(slot.tile, t);
+                  });
+
+    if (!keep)
+      ReleaseSlot(i);
+  }
+}
+
+/** The first slot not holding a tile we want to keep. */
+[[gnu::pure]]
+int
+FindFreeSlot() noexcept
+{
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (!slots[i].IsUsed())
+      return int(i);
+
+  return -1;
 }
 
 void
-InstallOverlay(Path path, const GeoBounds &bounds) noexcept
+InstallTile(unsigned index, Path path, const GeoBitmap::TileData &tile,
+            const BrokenDateTime &frame_time) noexcept
 {
   auto *map = UIGlobals::GetMap();
-  if (map == nullptr || path == nullptr || !bounds.IsValid())
+  if (map == nullptr || path == nullptr || index >= slots.size())
     return;
 
   Bitmap bitmap;
@@ -174,40 +273,128 @@ InstallOverlay(Path path, const GeoBounds &bounds) noexcept
     return;
   }
 
+  /* OPERA is published under CC BY 4.0, so the attribution has to
+     travel with the picture; the overlay label carries it, which is
+     what the map shows when the pilot taps it */
+  const auto label = fmt::format("{} — EUMETNET OPERA", gettext(N_("Radar")));
+
   auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
-                                                GeoQuadrilateral{
-                                                  bounds.GetNorthWest(),
-                                                  bounds.GetNorthEast(),
-                                                  bounds.GetSouthWest(),
-                                                  bounds.GetSouthEast(),
-                                                },
-                                                _("Radar"));
+                                                GeoBitmap::GetGeoQuadrilateral(tile),
+                                                label.c_str());
   bmp->SetAlpha(0.6);
-  installed_overlay = bmp.get();
-  installed_bounds = bounds;
-  installed_url = pending_url;
-  installed_time = pending_time;
+
+  auto &slot = slots[index];
+  slot.overlay = bmp.get();
+  slot.tile = tile;
+  slot.frame_time = frame_time;
+  slot.reserved = false;
+  map->SetOverlay(index, std::move(bmp));
+
   stale_removed = false;
-  map->SetOverlay(std::move(bmp));
 }
 
 /**
- * Is the overlay we already installed still the right one?  The
- * composite is published every five minutes, so re-fetching the same
- * one costs bandwidth and shows nothing new; and an image fetched for
- * a wider area still covers a map that has not been panned out of it.
+ * The next tile of the block that is not dealt with yet, or an
+ * invalid tile when the block is complete.  #wanted is already in
+ * nearest first order, so this walks outwards from the aircraft.
  */
-bool
-IsStillCurrent(const char *url, const GeoBounds &bounds) noexcept
+[[gnu::pure]]
+GeoBitmap::TileData
+NextMissingTile() noexcept
 {
-  const auto *map = UIGlobals::GetMap();
-  return map != nullptr && installed_overlay != nullptr &&
-    map->GetOverlay() == installed_overlay &&
-    installed_url == url &&
-    installed_bounds.IsValid() && installed_bounds.IsInside(bounds);
+  for (const auto &tile : wanted)
+    if (!IsShown(tile, block_frame))
+      return tile;
+
+  return {};
 }
 
 } // anonymous namespace
+
+void
+RadarDownloadGlue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  path = nullptr;
+  completion_error = {};
+  progress_shown = false;
+  BackgroundDownloadProgress::Get().ForceHide();
+}
+
+void
+RadarDownloadGlue::Start(std::string _url, const GeoBitmap::TileData &_base,
+                         const GeoBitmap::TileData &_tile,
+                         const BrokenDateTime &_frame_time,
+                         unsigned _slot) noexcept
+{
+  /* every request parameter is set here, after the guards: an early
+     return must not leave the next completion labelled with a request
+     that was never made */
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  if (_url.empty() || !_base.IsValid() || !_tile.IsValid() ||
+      !_frame_time.IsPlausible() || _slot >= slots.size())
+    return;
+
+  url = std::move(_url);
+  base_tile = _base;
+  tile = _tile;
+  frame_time = _frame_time;
+  slot = _slot;
+  drawn = false;
+  path = nullptr;
+  completion_error = {};
+
+  /* one file per slot, so the cache cannot grow with the flight */
+  path = AllocatedPath::Build(MakeCacheDirectory("opera"),
+                              fmt::format("rain-{}.png", slot).c_str());
+
+  /* hold the slot now: the next tile must not be handed the same one
+     while this download is in flight */
+  slots[slot].tile = tile;
+  slots[slot].frame_time = frame_time;
+  slots[slot].reserved = true;
+
+  BeginProgress();
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+RadarDownloadGlue::RunDownload()
+{
+  /* one range request for the directory; a no-op once the frame is
+     open, which is every tile after the first */
+  co_await composite.Open(url, curl);
+
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  const auto &index = composite.GetIndex();
+
+  /* the overview that matches what the block is drawn at, taken from
+     its centre tile so that every tile of it uses the same one:
+     asking for a finer level only costs bandwidth and decode time,
+     and asking for different ones across the block would fetch the
+     same ground twice */
+  const auto level_index =
+    OPERA::SelectLevel(index,
+                       OPERA::TileMetresPerPixel(GeoBitmap::GetBounds(base_tile),
+                                                 OPERA::TILE_PIXELS));
+
+  for (const auto source : OPERA::CoveringSourceTiles(index.levels[level_index],
+                                                      bounds))
+    co_await composite.FetchTile(level_index, source, curl);
+
+  drawn = composite.Render(level_index, bounds,
+                           OPERA::TILE_PIXELS, OPERA::TILE_PIXELS, path);
+}
+
+void
+RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
 
 void
 RadarDownloadGlue::OnCompleteNotify() noexcept
@@ -215,21 +402,50 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
   if (task.IsShuttingDown())
     return;
 
-  if (!task.IsRunning())
-    BackgroundDownloadProgress::Get().End();
-
   if (completion_error) {
     LogError(std::exchange(completion_error, {}), "Radar download");
 
-    /* a lost request on its own is not worth a dialog; it only
-       matters once it means the map has no radar left to show */
+    ReleaseSlot(slot);
+
+    /* send the tile that failed to the back of the queue, so one the
+       server will not serve does not stand in front of the rest of
+       the block for the whole flight */
+    if (const auto i = std::find_if(wanted.begin(), wanted.end(),
+                                    [this](const auto &t){
+                                      return OPERA::IsSameTile(t, tile);
+                                    });
+        i != wanted.end())
+      std::rotate(i, i + 1, wanted.end());
+
+    ++consecutive_failures;
+    EndProgress();
+
+    /* a lost tile on its own is not worth a dialog; it only matters
+       once it means the map has no radar left to show */
     if (std::exchange(stale_removed, false))
       WarnStale();
 
     return;
   }
 
-  InstallOverlay(path, bounds);
+  consecutive_failures = 0;
+
+  if (!(frame_time == block_frame))
+    /* the block moved on while this was in flight -- a newer frame is
+       due, or the radar was taken off the map.  Installing it now
+       would put a frame on the map that the age watchdog has already
+       decided against. */
+    ReleaseSlot(slot);
+  else if (drawn)
+    InstallTile(slot, path, tile, frame_time);
+  else
+    /* clear sky here: the slot stays reserved for this tile so the
+       block does not ask for it again, but nothing is drawn */
+    slots[slot].reserved = true;
+
+  /* straight on to the next tile, so the block fills as fast as the
+     link allows rather than one tile per timer tick */
+  OPERA::ActivatePageOverlay();
 }
 
 void
@@ -250,12 +466,12 @@ RadarDownloadGlue::CancelAgeCheck() noexcept
 void
 RadarDownloadGlue::OnAgeTimer() noexcept
 {
-  const auto age = OverlayAge();
-  if (age < std::chrono::system_clock::duration::zero())
-    /* nothing on the map to keep fresh */
+  if (!active)
     return;
 
-  if (age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
+  const auto age = BlockAge();
+  if (age >= std::chrono::system_clock::duration::zero() &&
+      age > std::chrono::minutes{OPERA::MAX_AGE_MINUTES}) {
     /* down it comes before anything is fetched: an echo this old is
        worse than none, and a refresh that hangs or fails must not be
        able to leave it standing */
@@ -263,8 +479,9 @@ RadarDownloadGlue::OnAgeTimer() noexcept
     stale_removed = true;
   }
 
-  /* ActivatePageOverlay() is a no-op while the frame we hold is still
-     the newest one, so this only fetches when there is something new */
+  /* a new minute is a new chance for whatever the link dropped */
+  consecutive_failures = 0;
+
   OPERA::ActivatePageOverlay();
 }
 
@@ -276,49 +493,117 @@ OPERA::ActivatePageOverlay() noexcept
   if (glue == nullptr || map == nullptr)
     return;
 
+  active = true;
+
   /* arm the watchdog first: it has to keep running even on the turns
      where there is nothing new to fetch, or the picture would never
-     age out */
+     age out and a dropped tile would never be retried */
   glue->ScheduleAgeCheck();
 
   const auto &projection = map->VisibleProjection();
   if (!projection.IsValid())
     return;
 
-  const auto &bounds = projection.GetScreenBounds();
   const auto now = BrokenDateTime::NowUTC();
-  const auto url = OPERA::MakeCompositeURL(now);
-  if (url.empty() || IsStillCurrent(url.c_str(), bounds))
+  auto url = MakeCompositeURL(now);
+  const auto frame_time = CompositeTime(now);
+  if (url.empty() || !frame_time.IsPlausible())
+    /* without a clock we cannot tell which composite is the current
+       one, and guessing would show yesterday's weather */
     return;
 
-  const auto size = projection.GetScreenSize();
-  pending_url = url;
-  pending_time = OPERA::CompositeTime(now);
-  glue->Start(bounds, size.width, size.height);
+  /* One step finer than the map's own scale, so the block covers the
+     screen with a margin to pan into.  The geometric choice is asked
+     for one step coarser than the grid we want, so that adding the
+     step lands inside [MIN_TILE_ZOOM, MAX_TILE_ZOOM] rather than
+     saturating one short of either end. */
+  const auto map_tile = GeoBitmap::GetTile(projection,
+                                           MIN_TILE_ZOOM - TILE_ZOOM_STEP,
+                                           MAX_TILE_ZOOM - TILE_ZOOM_STEP);
+  const auto zoom = uint16_t(map_tile.zoom + TILE_ZOOM_STEP);
+
+  const auto &basic = CommonInterface::Basic();
+  const auto base = basic.location_available
+    ? GetAircraftTile(basic.location, zoom)
+    /* before the first fix there is no aircraft to centre on, so the
+       block goes where the pilot is looking instead */
+    : GeoBitmap::GetTile(projection.GetScreenBounds(), zoom);
+  if (!base.IsValid())
+    return;
+
+  /* recompute the block when the aircraft has crossed into another
+     tile, when the map scale changed the grid, or when a newer frame
+     is due.  Everything is keyed on the tile grid, so a few
+     kilometres of flight change nothing and the tiles already on the
+     map stay there. */
+  if (!IsSameTile(base, block_base) || !(frame_time == block_frame)) {
+    block_base = base;
+    block_frame = frame_time;
+    wanted = CollectTiles(base);
+    ReleaseUnwantedSlots();
+    consecutive_failures = 0;
+  }
+
+  if (glue->IsRunning() || wanted.empty())
+    return;
+
+  if (consecutive_failures >= wanted.size()) {
+    /* the whole block failed in a row; wait for the timer rather than
+       spin through it again */
+    EndProgress();
+    return;
+  }
+
+  const auto next = NextMissingTile();
+  if (!next.IsValid()) {
+    /* the block is complete */
+    EndProgress();
+    return;
+  }
+
+  const auto slot = FindFreeSlot();
+  if (slot < 0)
+    return;
+
+  glue->Start(std::move(url), base, next, frame_time, unsigned(slot));
 }
 
 void
 OPERA::ClearMapOverlay() noexcept
 {
-  auto *map = UIGlobals::GetMap();
-  if (map == nullptr || installed_overlay == nullptr)
-    return;
+  for (unsigned i = 0; i < slots.size(); ++i)
+    ReleaseSlot(i);
 
-  if (map->GetOverlay() == installed_overlay)
-    map->SetOverlay(nullptr);
-
-  installed_overlay = nullptr;
-  installed_bounds = GeoBounds::Invalid();
-  installed_time = BrokenDateTime::Invalid();
-  installed_url.clear();
+  block_frame = BrokenDateTime::Invalid();
+  block_base = {};
+  wanted.clear();
+  consecutive_failures = 0;
+  EndProgress();
 }
 
 void
 OPERA::DeactivatePageOverlay() noexcept
 {
+  if (suspended_for_pan)
+    /* the pilot is dragging the map, not leaving the radar behind */
+    return;
+
   if (auto *glue = GetRadarDownloadGlue(); glue != nullptr)
     glue->CancelAgeCheck();
 
+  active = false;
   stale_removed = false;
   ClearMapOverlay();
+}
+
+void
+OPERA::SuspendForPan() noexcept
+{
+  suspended_for_pan = true;
+}
+
+void
+OPERA::ResumeAfterPan() noexcept
+{
+  suspended_for_pan = false;
 }

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "RadarPageOverlay.hpp"
+#include "Radar.hpp"
+#include "co/Task.hxx"
+#include "Components.hpp"
+#include "NetComponents.hpp"
+#include "UIGlobals.hpp"
+#include "LogFile.hpp"
+#include "Language/Language.hpp"
+#include "MapWindow/GlueMapWindow.hpp"
+#include "MapWindow/OverlayBitmap.hpp"
+#include "Weather/BackgroundDownloadProgress.hpp"
+#include "lib/curl/Global.hxx"
+#include "time/BrokenDateTime.hpp"
+#include "ui/canvas/Bitmap.hpp"
+#include "util/BindMethod.hxx"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+RadarDownloadGlue *
+GetRadarDownloadGlue() noexcept
+{
+  if (net_components == nullptr)
+    return nullptr;
+
+  return net_components->opera_radar.get();
+}
+
+RadarDownloadGlue::RadarDownloadGlue(CurlGlobal &_curl) noexcept
+  :curl(_curl),
+   task(curl.GetEventLoop())
+{
+}
+
+void
+RadarDownloadGlue::BeginShutdown() noexcept
+{
+  task.BeginShutdown();
+  complete_notify.ClearNotification();
+  path = nullptr;
+  completion_error = {};
+  BackgroundDownloadProgress::Get().ForceHide();
+}
+
+void
+RadarDownloadGlue::Start(const GeoBounds &_bounds,
+                         unsigned _width, unsigned _height) noexcept
+{
+  if (task.IsShuttingDown() || task.IsRunning())
+    return;
+
+  if (!_bounds.IsValid() || _width == 0 || _height == 0)
+    return;
+
+  bounds = _bounds;
+  width = _width;
+  height = _height;
+  path = nullptr;
+  completion_error = {};
+
+  BackgroundDownloadProgress::Get().Begin(_("Downloading radar..."));
+  BackgroundDownloadProgress::Get().SetProgressRange(100);
+
+  task.Start(RunDownload(), BIND_THIS_METHOD(OnCompletion));
+}
+
+Co::InvokeTask
+RadarDownloadGlue::RunDownload()
+{
+  path = co_await OPERA::DownloadRadar(bounds, width, height, curl,
+                                       BackgroundDownloadProgress::Get());
+}
+
+void
+RadarDownloadGlue::OnCompletion(std::exception_ptr error) noexcept
+{
+  completion_error = std::move(error);
+  complete_notify.SendNotification();
+}
+
+namespace {
+
+/**
+ * The overlay we installed, so that we never remove one somebody else
+ * put there.
+ */
+const MapOverlay *installed_overlay = nullptr;
+
+/**
+ * What #installed_overlay shows: the composite it came from, and the
+ * area it was fetched for.
+ */
+std::string installed_url;
+GeoBounds installed_bounds = GeoBounds::Invalid();
+
+/** the composite the running download is fetching */
+std::string pending_url;
+
+void
+InstallOverlay(Path path, const GeoBounds &bounds) noexcept
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || path == nullptr || !bounds.IsValid())
+    return;
+
+  Bitmap bitmap;
+  try {
+    if (!bitmap.LoadFile(path))
+      return;
+  } catch (...) {
+    LogError(std::current_exception(), "Radar overlay");
+    return;
+  }
+
+  auto bmp = std::make_unique<MapOverlayBitmap>(std::move(bitmap),
+                                                GeoQuadrilateral{
+                                                  bounds.GetNorthWest(),
+                                                  bounds.GetNorthEast(),
+                                                  bounds.GetSouthWest(),
+                                                  bounds.GetSouthEast(),
+                                                },
+                                                _("Radar"));
+  bmp->SetAlpha(0.6);
+  installed_overlay = bmp.get();
+  installed_bounds = bounds;
+  installed_url = pending_url;
+  map->SetOverlay(std::move(bmp));
+}
+
+/**
+ * Is the overlay we already installed still the right one?  The
+ * composite is published every five minutes, so re-fetching the same
+ * one costs bandwidth and shows nothing new; and an image fetched for
+ * a wider area still covers a map that has not been panned out of it.
+ */
+bool
+IsStillCurrent(const char *url, const GeoBounds &bounds) noexcept
+{
+  const auto *map = UIGlobals::GetMap();
+  return map != nullptr && installed_overlay != nullptr &&
+    map->GetOverlay() == installed_overlay &&
+    installed_url == url &&
+    installed_bounds.IsValid() && installed_bounds.IsInside(bounds);
+}
+
+} // anonymous namespace
+
+void
+RadarDownloadGlue::OnCompleteNotify() noexcept
+{
+  if (task.IsShuttingDown())
+    return;
+
+  if (!task.IsRunning())
+    BackgroundDownloadProgress::Get().End();
+
+  if (completion_error) {
+    LogError(std::exchange(completion_error, {}), "Radar download");
+    return;
+  }
+
+  InstallOverlay(path, bounds);
+}
+
+void
+OPERA::ActivatePageOverlay() noexcept
+{
+  auto *glue = GetRadarDownloadGlue();
+  const auto *map = UIGlobals::GetMap();
+  if (glue == nullptr || map == nullptr)
+    return;
+
+  const auto &projection = map->VisibleProjection();
+  if (!projection.IsValid())
+    return;
+
+  const auto &bounds = projection.GetScreenBounds();
+  const auto url = OPERA::MakeCompositeURL(BrokenDateTime::NowUTC());
+  if (url.empty() || IsStillCurrent(url.c_str(), bounds))
+    return;
+
+  const auto size = projection.GetScreenSize();
+  pending_url = url;
+  glue->Start(bounds, size.width, size.height);
+}
+
+void
+OPERA::ClearMapOverlay() noexcept
+{
+  auto *map = UIGlobals::GetMap();
+  if (map == nullptr || installed_overlay == nullptr)
+    return;
+
+  if (map->GetOverlay() == installed_overlay)
+    map->SetOverlay(nullptr);
+
+  installed_overlay = nullptr;
+  installed_bounds = GeoBounds::Invalid();
+  installed_url.clear();
+}

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -430,11 +430,21 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
 
   consecutive_failures = 0;
 
-  if (!(frame_time == block_frame))
-    /* the block moved on while this was in flight -- a newer frame is
-       due, or the radar was taken off the map.  Installing it now
-       would put a frame on the map that the age watchdog has already
-       decided against. */
+  /* The block can move while a tile is in flight, and then this
+     answer is to a question nobody is asking any more.  Two ways:
+     a newer frame fell due, or the aircraft crossed into another tile
+     and the block was rebuilt around it.  The frame check alone
+     misses the second -- the frame is unchanged there, but
+     ReleaseUnwantedSlots() has already given this slot back, and
+     installing now would drop a tile from outside the block onto the
+     map and hold a slot the block wants for something else. */
+  const bool still_wanted = frame_time == block_frame &&
+    std::any_of(wanted.begin(), wanted.end(),
+                [this](const auto &t){
+                  return OPERA::IsSameTile(t, tile);
+                });
+
+  if (!still_wanted)
     ReleaseSlot(slot);
   else if (drawn)
     InstallTile(slot, path, tile, frame_time);

--- a/src/Weather/OPERA/RadarPageOverlay.cpp
+++ b/src/Weather/OPERA/RadarPageOverlay.cpp
@@ -225,33 +225,53 @@ IsShown(const GeoBitmap::TileData &tile,
  * ones left behind as the aircraft flew on, and everything at all
  * when the frame moved on.
  */
-void
-ReleaseUnwantedSlots() noexcept
+[[gnu::pure]]
+bool
+IsWanted(const GeoBitmap::TileData &tile) noexcept
 {
-  for (unsigned i = 0; i < slots.size(); ++i) {
-    const auto &slot = slots[i];
-    if (!slot.IsUsed())
-      continue;
-
-    const bool keep = slot.frame_time == block_frame &&
-      std::any_of(wanted.begin(), wanted.end(),
-                  [&slot](const auto &t){
-                    return OPERA::IsSameTile(slot.tile, t);
-                  });
-
-    if (!keep)
-      ReleaseSlot(i);
-  }
+  return std::any_of(wanted.begin(), wanted.end(),
+                     [&tile](const auto &t){
+                       return OPERA::IsSameTile(tile, t);
+                     });
 }
 
-/** The first slot not holding a tile we want to keep. */
+/**
+ * Reserve a slot for a tile about to be fetched.
+ *
+ * Nothing is released ahead of time.  A newly published composite
+ * changes every tile's frame at once, and a change of map scale moves
+ * the whole grid, so releasing what the block no longer wants would
+ * empty the map -- every five minutes at the OPERA cadence -- and
+ * leave it empty for as long as a full block takes to arrive.
+ *
+ * Give up one echo at a time instead, and preferably the one the
+ * incoming tile is about to cover, so the hole is exactly where the
+ * replacement lands.  Leaving an old tile under a new one would draw
+ * the same ground twice, each at partial opacity, and darken it.
+ */
 [[gnu::pure]]
 int
-FindFreeSlot() noexcept
+ClaimSlotFor(const GeoBitmap::TileData &tile) noexcept
 {
   for (unsigned i = 0; i < slots.size(); ++i)
     if (!slots[i].IsUsed())
       return int(i);
+
+  const auto bounds = GeoBitmap::GetBounds(tile);
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && !IsWanted(slots[i].tile) &&
+        bounds.Overlaps(GeoBitmap::GetBounds(slots[i].tile))) {
+      ReleaseSlot(i);
+      return int(i);
+    }
+
+  /* nothing overlapping to reclaim; give up the first tile the block
+     no longer wants, wherever it is */
+  for (unsigned i = 0; i < slots.size(); ++i)
+    if (slots[i].IsUsed() && !IsWanted(slots[i].tile)) {
+      ReleaseSlot(i);
+      return int(i);
+    }
 
   return -1;
 }
@@ -445,15 +465,10 @@ RadarDownloadGlue::OnCompleteNotify() noexcept
      answer is to a question nobody is asking any more.  Two ways:
      a newer frame fell due, or the aircraft crossed into another tile
      and the block was rebuilt around it.  The frame check alone
-     misses the second -- the frame is unchanged there, but
-     ReleaseUnwantedSlots() has already given this slot back, and
-     installing now would drop a tile from outside the block onto the
-     map and hold a slot the block wants for something else. */
-  const bool still_wanted = frame_time == block_frame &&
-    std::any_of(wanted.begin(), wanted.end(),
-                [this](const auto &t){
-                  return OPERA::IsSameTile(t, tile);
-                });
+     misses the second -- the frame is unchanged there, and installing
+     would drop a tile from outside the block onto the map and hold a
+     slot the block wants for something else. */
+  const bool still_wanted = frame_time == block_frame && IsWanted(tile);
 
   if (!still_wanted)
     ReleaseSlot(slot);
@@ -561,7 +576,6 @@ OPERA::ActivatePageOverlay() noexcept
     block_base = base;
     block_frame = frame_time;
     wanted = CollectTiles(base);
-    ReleaseUnwantedSlots();
     consecutive_failures = 0;
   }
 
@@ -582,7 +596,7 @@ OPERA::ActivatePageOverlay() noexcept
     return;
   }
 
-  const auto slot = FindFreeSlot();
+  const auto slot = ClaimSlotFor(next);
   if (slot < 0)
     return;
 

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -3,36 +3,71 @@
 
 #pragma once
 
-#include "Geo/GeoBounds.hpp"
+#include "Radar.hpp"
 #include "co/InvokeTask.hxx"
 #include "net/AsyncTask.hpp"
 #include "system/Path.hpp"
+#include "time/BrokenDateTime.hpp"
 #include "ui/event/Notify.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 
 #include <exception>
+#include <string>
 
 class CurlGlobal;
 
 /**
- * Runs OPERA::DownloadRadar() on the network #EventLoop and installs
- * the finished image as the map overlay from the UI thread.
+ * Fills the map with the radar composite, one display tile at a time,
+ * from underneath the aircraft outwards.
+ *
+ * The composite is a single five megabyte file covering the continent,
+ * so it is read with range requests: one for its directory, then one
+ * per tile of it that the block actually needs.  Everything runs on
+ * the network #EventLoop; finished tiles are installed as map
+ * overlays from the UI thread.
  *
  * Unlike the Weather dialog, which downloads inside a modal progress
  * dialog, a page overlay has to appear without the pilot waiting for
- * it, so the fetch runs in the background and the map gains the image
- * whenever it is ready.
+ * it.
  */
 class RadarDownloadGlue final {
   CurlGlobal &curl;
   Net::AsyncTask task;
   UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
 
-  /** the area the running download was requested for */
-  GeoBounds bounds = GeoBounds::Invalid();
-  unsigned width = 0, height = 0;
+  /**
+   * The frame being read, and the tiles of it decoded so far.  Held
+   * across display tiles, so that a composite is opened once and each
+   * of its tiles travels once however many display tiles it feeds.
+   *
+   * Network thread only.
+   */
+  OPERA::RadarComposite composite;
+
+  /* what the running download is for; written by the UI thread before
+     the task starts, read by the network thread while it runs */
+  std::string url;
+
+  /**
+   * The tile the block is centred on, which is what the pyramid level
+   * is chosen from.
+   *
+   * One level for the whole block, rather than one per tile: the
+   * block spans enough latitude at a wide zoom that a per-tile choice
+   * lands on two different levels, and then the same ground travels
+   * twice and meets itself as a resolution seam across the map.
+   */
+  GeoBitmap::TileData base_tile{};
+
+  GeoBitmap::TileData tile{};
+  BrokenDateTime frame_time = BrokenDateTime::Invalid();
+  unsigned slot = 0;
 
   AllocatedPath path{nullptr};
+
+  /** did the finished tile hold any echo worth installing? */
+  bool drawn = false;
+
   std::exception_ptr completion_error;
 
   /**
@@ -61,11 +96,11 @@ public:
   void BeginShutdown() noexcept;
 
   /**
-   * Fetch the composite for the given area, unless one is already in
-   * flight.
+   * Fetch one display tile, unless a download is already in flight.
    */
-  void Start(const GeoBounds &_bounds,
-             unsigned _width, unsigned _height) noexcept;
+  void Start(std::string _url, const GeoBitmap::TileData &_base,
+             const GeoBitmap::TileData &_tile,
+             const BrokenDateTime &_frame_time, unsigned _slot) noexcept;
 
   /** Begin watching the age of the displayed frame. */
   void ScheduleAgeCheck() noexcept;
@@ -82,21 +117,39 @@ RadarDownloadGlue *GetRadarDownloadGlue() noexcept;
 namespace OPERA {
 
 /**
- * Request the composite for the area the map currently shows, and
- * install it when it arrives.
+ * Fetch and draw the block around the aircraft, and keep it filling.
+ *
+ * Safe to call as often as the map changes: it starts a download only
+ * when there is a tile missing and nothing already in flight.
  */
 void ActivatePageOverlay() noexcept;
 
 /**
- * Remove the radar overlay, but only if the map is still showing the
- * one we installed.
+ * Take the radar off the map, leaving alone any overlay somebody else
+ * installed.
  */
 void ClearMapOverlay() noexcept;
 
 /**
  * Leave the radar page: stop watching the frame's age and take it
  * off the map.
+ *
+ * Does nothing while the overlay is suspended for a pan.
  */
 void DeactivatePageOverlay() noexcept;
+
+/**
+ * Hold the radar on the map across a pan.
+ *
+ * Panning shows the fullscreen map, whose layout carries no overlay,
+ * so the page machinery deactivates the radar on the way in and would
+ * fetch the whole block again on the way out.  Between these two
+ * calls #DeactivatePageOverlay() is ignored and the tiles stay where
+ * they are.
+ */
+void SuspendForPan() noexcept;
+
+/** Let the radar be taken off the map again. */
+void ResumeAfterPan() noexcept;
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -8,6 +8,7 @@
 #include "net/AsyncTask.hpp"
 #include "system/Path.hpp"
 #include "ui/event/Notify.hpp"
+#include "ui/event/PeriodicTimer.hpp"
 
 #include <exception>
 
@@ -34,9 +35,17 @@ class RadarDownloadGlue final {
   AllocatedPath path{nullptr};
   std::exception_ptr completion_error;
 
+  /**
+   * Watches the age of the frame on the map while a radar page is
+   * open: it fetches a newer one as soon as one exists, and takes the
+   * picture down once it is older than OPERA::MAX_AGE_MINUTES.
+   */
+  UI::PeriodicTimer age_timer{[this]{ OnAgeTimer(); }};
+
   Co::InvokeTask RunDownload();
   void OnCompletion(std::exception_ptr error) noexcept;
   void OnCompleteNotify() noexcept;
+  void OnAgeTimer() noexcept;
 
 public:
   explicit RadarDownloadGlue(CurlGlobal &_curl) noexcept;
@@ -57,6 +66,12 @@ public:
    */
   void Start(const GeoBounds &_bounds,
              unsigned _width, unsigned _height) noexcept;
+
+  /** Begin watching the age of the displayed frame. */
+  void ScheduleAgeCheck() noexcept;
+
+  /** Stop watching, because no page shows the radar any more. */
+  void CancelAgeCheck() noexcept;
 };
 
 /**
@@ -77,5 +92,11 @@ void ActivatePageOverlay() noexcept;
  * one we installed.
  */
 void ClearMapOverlay() noexcept;
+
+/**
+ * Leave the radar page: stop watching the frame's age and take it
+ * off the map.
+ */
+void DeactivatePageOverlay() noexcept;
 
 } // namespace OPERA

--- a/src/Weather/OPERA/RadarPageOverlay.hpp
+++ b/src/Weather/OPERA/RadarPageOverlay.hpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/GeoBounds.hpp"
+#include "co/InvokeTask.hxx"
+#include "net/AsyncTask.hpp"
+#include "system/Path.hpp"
+#include "ui/event/Notify.hpp"
+
+#include <exception>
+
+class CurlGlobal;
+
+/**
+ * Runs OPERA::DownloadRadar() on the network #EventLoop and installs
+ * the finished image as the map overlay from the UI thread.
+ *
+ * Unlike the Weather dialog, which downloads inside a modal progress
+ * dialog, a page overlay has to appear without the pilot waiting for
+ * it, so the fetch runs in the background and the map gains the image
+ * whenever it is ready.
+ */
+class RadarDownloadGlue final {
+  CurlGlobal &curl;
+  Net::AsyncTask task;
+  UI::Notify complete_notify{[this]{ OnCompleteNotify(); }};
+
+  /** the area the running download was requested for */
+  GeoBounds bounds = GeoBounds::Invalid();
+  unsigned width = 0, height = 0;
+
+  AllocatedPath path{nullptr};
+  std::exception_ptr completion_error;
+
+  Co::InvokeTask RunDownload();
+  void OnCompletion(std::exception_ptr error) noexcept;
+  void OnCompleteNotify() noexcept;
+
+public:
+  explicit RadarDownloadGlue(CurlGlobal &_curl) noexcept;
+
+  ~RadarDownloadGlue() noexcept { BeginShutdown(); }
+
+  RadarDownloadGlue(const RadarDownloadGlue &) = delete;
+  RadarDownloadGlue &operator=(const RadarDownloadGlue &) = delete;
+
+  [[nodiscard]]
+  bool IsRunning() const noexcept { return task.IsRunning(); }
+
+  void BeginShutdown() noexcept;
+
+  /**
+   * Fetch the composite for the given area, unless one is already in
+   * flight.
+   */
+  void Start(const GeoBounds &_bounds,
+             unsigned _width, unsigned _height) noexcept;
+};
+
+/**
+ * The shared #RadarDownloadGlue from #net_components (UI thread only).
+ */
+RadarDownloadGlue *GetRadarDownloadGlue() noexcept;
+
+namespace OPERA {
+
+/**
+ * Request the composite for the area the map currently shows, and
+ * install it when it arrives.
+ */
+void ActivatePageOverlay() noexcept;
+
+/**
+ * Remove the radar overlay, but only if the map is still showing the
+ * one we installed.
+ */
+void ClearMapOverlay() noexcept;
+
+} // namespace OPERA

--- a/src/net/http/CoGetRange.cpp
+++ b/src/net/http/CoGetRange.cpp
@@ -7,7 +7,7 @@
 
 #include <fmt/format.h>
 
-#include <cassert>
+#include <limits>
 #include <stdexcept>
 
 namespace Net {
@@ -16,8 +16,16 @@ Co::Task<std::string>
 CoGetRange(CurlGlobal &curl, const char *url,
            uint_least64_t offset, std::size_t length)
 {
-  assert(url != nullptr);
-  assert(length > 0);
+  /* checked rather than asserted: this is a public entry point, and
+     an assertion would be compiled out of the builds that ship */
+  if (url == nullptr || *url == '\0')
+    throw std::invalid_argument("No URL to fetch");
+
+  if (length == 0)
+    throw std::invalid_argument("Empty byte range");
+
+  if (offset > std::numeric_limits<uint_least64_t>::max() - (length - 1))
+    throw std::invalid_argument("Byte range out of bounds");
 
   CurlEasy easy{url};
   Curl::Setup(easy);

--- a/src/net/http/CoGetRange.cpp
+++ b/src/net/http/CoGetRange.cpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "CoGetRange.hpp"
+#include "lib/curl/CoRequest.hxx"
+#include "lib/curl/Setup.hxx"
+
+#include <fmt/format.h>
+
+#include <cassert>
+#include <stdexcept>
+
+namespace Net {
+
+Co::Task<std::string>
+CoGetRange(CurlGlobal &curl, const char *url,
+           uint_least64_t offset, std::size_t length)
+{
+  assert(url != nullptr);
+  assert(length > 0);
+
+  CurlEasy easy{url};
+  Curl::Setup(easy);
+  easy.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+  easy.SetOption(CURLOPT_MAXREDIRS, 10L);
+  easy.SetFailOnError();
+  easy.SetTimeout(30);
+
+  const auto range = fmt::format("{}-{}", offset, offset + length - 1);
+  easy.SetOption(CURLOPT_RANGE, range.c_str());
+
+  /* a server that does not understand the range would answer with the
+     whole file; refuse it up front rather than let one tile pull
+     megabytes over a flight connection */
+  easy.SetOption(CURLOPT_MAXFILESIZE_LARGE, curl_off_t(length + 4096));
+
+  auto response = co_await Curl::CoRequest(curl, std::move(easy));
+
+  /* 206 is the only answer that means "here is the part you asked
+     for"; a 200 is the whole file and must not be mistaken for it */
+  if (response.status != 206)
+    throw std::runtime_error("The server does not serve byte ranges");
+
+  if (response.body.size() > length)
+    throw std::runtime_error("The server sent more than the range");
+
+  co_return std::move(response.body);
+}
+
+} // namespace Net

--- a/src/net/http/CoGetRange.hpp
+++ b/src/net/http/CoGetRange.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/Task.hxx"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+class CurlGlobal;
+
+namespace Net {
+
+/**
+ * Download a byte range of a URL into memory.
+ *
+ * This exists for files that are far larger than the part we need --
+ * a cloud-optimized GeoTIFF, say, where the tile under the aircraft
+ * is a few kilobytes of a multi-megabyte composite.  Nothing is
+ * written to disk, because a range is small by construction and the
+ * caller wants it in memory anyway.
+ *
+ * Throws on error, including when the server ignores the range and
+ * offers the whole file instead.
+ *
+ * @param offset the first byte to fetch
+ * @param length how many bytes, which must not be zero
+ */
+Co::Task<std::string>
+CoGetRange(CurlGlobal &curl, const char *url,
+           uint_least64_t offset, std::size_t length);
+
+} // namespace Net

--- a/src/ui/canvas/custom/GeoBitmap.cpp
+++ b/src/ui/canvas/custom/GeoBitmap.cpp
@@ -23,46 +23,6 @@
 
 using namespace GeoBitmap;
 
-static uint32_t
-LonToTileX(double lon, unsigned zoom) noexcept
-{
-  return uint32_t(std::floor((lon + 180.0) / 360.0 *
-                             (uint32_t{1} << zoom)));
-}
-
-static uint32_t
-LatToTileY(double lat, unsigned zoom) noexcept
-{
-  const double latitude_radians = lat * M_PI / 180.0;
-  return uint32_t(std::floor(
-    (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
-    (uint32_t{1} << zoom)));
-}
-
-static double
-TileXToLon(uint32_t x, unsigned zoom) noexcept
-{
-  return x / double(uint32_t{1} << zoom) * 360.0 - 180.0;
-}
-
-static double
-TileYToLat(uint32_t y, unsigned zoom) noexcept
-{
-  const double n = M_PI - 2.0 * M_PI * y /
-    double(uint32_t{1} << zoom);
-  return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
-}
-
-TileData
-GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
-{
-  return {
-    zoom,
-    LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
-    LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
-  };
-}
-
 TileData
 GeoBitmap::GetTile(const MapWindowProjection &projection,
                    uint16_t zoom_min, uint16_t zoom_max) noexcept
@@ -74,30 +34,6 @@ GeoBitmap::GetTile(const MapWindowProjection &projection,
   const auto zoom = (uint16_t)std::clamp((int)std::floor(std::log2(ratio)) + 1,
                                          (int)zoom_min, (int)zoom_max);
   return GetTile(projection.GetScreenBounds(), zoom);
-}
-
-GeoQuadrilateral
-GeoBitmap::GetGeoQuadrilateral(const TileData &tile) noexcept
-{
-  GeoQuadrilateral bounds;
-
-  bounds.top_left.longitude = Angle::Degrees(TileXToLon(tile.x, tile.zoom));
-  bounds.top_left.latitude = Angle::Degrees(TileYToLat(tile.y, tile.zoom));
-  bounds.bottom_left.longitude = bounds.top_left.longitude;
-  bounds.bottom_left.latitude = Angle::Degrees(TileYToLat(tile.y + 1, tile.zoom));
-
-  bounds.top_right.longitude = Angle::Degrees(TileXToLon(tile.x + 1, tile.zoom));
-  bounds.top_right.latitude = bounds.top_left.latitude;
-  bounds.bottom_right.longitude = bounds.top_right.longitude;
-  bounds.bottom_right.latitude = bounds.bottom_left.latitude;
-
-  return bounds;
-}
-
-GeoBounds
-GeoBitmap::GetBounds(const TileData &tile) noexcept
-{
-  return GetGeoQuadrilateral(tile).GetBounds();
 }
 
 static GeoQuadrilateral

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+/*
+ * The slippy map tile geometry, kept apart from GeoBitmap.cpp so that
+ * it links without a canvas: the tile grid is useful to code that
+ * plans downloads long before there is anything to draw, and that
+ * code should not have to pull in OpenGL to ask where a tile is.
+ */
+
+#include "GeoBitmap.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/Quadrilateral.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace GeoBitmap;
+
+static uint32_t
+LonToTileX(double lon, unsigned zoom) noexcept
+{
+  return uint32_t(std::floor((lon + 180.0) / 360.0 *
+                             (uint32_t{1} << zoom)));
+}
+
+static uint32_t
+LatToTileY(double lat, unsigned zoom) noexcept
+{
+  const double latitude_radians = lat * M_PI / 180.0;
+  return uint32_t(std::floor(
+    (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
+    (uint32_t{1} << zoom)));
+}
+
+static double
+TileXToLon(uint32_t x, unsigned zoom) noexcept
+{
+  return x / double(uint32_t{1} << zoom) * 360.0 - 180.0;
+}
+
+static double
+TileYToLat(uint32_t y, unsigned zoom) noexcept
+{
+  const double n = M_PI - 2.0 * M_PI * y /
+    double(uint32_t{1} << zoom);
+  return 180.0 / M_PI * std::atan(0.5 * (std::exp(n) - std::exp(-n)));
+}
+
+TileData
+GeoBitmap::GetTile(const GeoBounds &bounds, uint16_t zoom) noexcept
+{
+  return {
+    zoom,
+    LonToTileX(bounds.GetCenter().longitude.Degrees(), zoom),
+    LatToTileY(bounds.GetCenter().latitude.Degrees(), zoom),
+  };
+}
+
+GeoQuadrilateral
+GeoBitmap::GetGeoQuadrilateral(const TileData &tile) noexcept
+{
+  GeoQuadrilateral bounds;
+
+  bounds.top_left.longitude = Angle::Degrees(TileXToLon(tile.x, tile.zoom));
+  bounds.top_left.latitude = Angle::Degrees(TileYToLat(tile.y, tile.zoom));
+  bounds.bottom_left.longitude = bounds.top_left.longitude;
+  bounds.bottom_left.latitude = Angle::Degrees(TileYToLat(tile.y + 1, tile.zoom));
+
+  bounds.top_right.longitude = Angle::Degrees(TileXToLon(tile.x + 1, tile.zoom));
+  bounds.top_right.latitude = bounds.top_left.latitude;
+  bounds.bottom_right.longitude = bounds.top_right.longitude;
+  bounds.bottom_right.latitude = bounds.bottom_left.latitude;
+
+  return bounds;
+}
+
+GeoBounds
+GeoBitmap::GetBounds(const TileData &tile) noexcept
+{
+  return GetGeoQuadrilateral(tile).GetBounds();
+}

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -27,10 +27,20 @@ LonToTileX(double lon, unsigned zoom) noexcept
 static uint32_t
 LatToTileY(double lat, unsigned zoom) noexcept
 {
-  const double latitude_radians = lat * M_PI / 180.0;
-  return uint32_t(std::floor(
+  /* the grid is only defined between the Web Mercator cut-offs, where
+     the projection runs to infinity; beyond them tan() explodes and
+     the cast below would be undefined.  A wild fix must yield an edge
+     tile, not chaos. */
+  constexpr double MERCATOR_LIMIT = 85.05112878;
+  const double latitude_radians =
+    std::clamp(lat, -MERCATOR_LIMIT, MERCATOR_LIMIT) * M_PI / 180.0;
+
+  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
+  const double y = std::floor(
     (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
-    (uint32_t{1} << zoom)));
+    tiles_per_axis);
+
+  return uint32_t(std::clamp(y, 0.0, double(tiles_per_axis - 1)));
 }
 
 static double

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -20,8 +20,19 @@ using namespace GeoBitmap;
 static uint32_t
 LonToTileX(double lon, unsigned zoom) noexcept
 {
-  return uint32_t(std::floor((lon + 180.0) / 360.0 *
-                             (uint32_t{1} << zoom)));
+  /* longitude wraps rather than running out, but a caller can still
+     hand us one outside the grid -- exactly 180 lands one tile past
+     the last, and a wild GPS fix lands anywhere -- and the cast of an
+     out-of-range double to uint32_t is undefined.  Wrap into the
+     grid, which is what the projection means anyway. */
+  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
+  const double x = std::floor((lon + 180.0) / 360.0 * tiles_per_axis);
+  if (!(x >= 0) || !(x < double(tiles_per_axis))) {
+    const double wrapped = std::fmod(x, double(tiles_per_axis));
+    return uint32_t(wrapped < 0 ? wrapped + tiles_per_axis : wrapped);
+  }
+
+  return uint32_t(x);
 }
 
 static uint32_t

--- a/src/ui/canvas/custom/GeoBitmapTile.cpp
+++ b/src/ui/canvas/custom/GeoBitmapTile.cpp
@@ -17,22 +17,44 @@
 
 using namespace GeoBitmap;
 
+/** The number of tiles along each axis, for a zoom we can shift by. */
+static constexpr uint32_t
+TilesPerAxis(unsigned zoom) noexcept
+{
+  /* the shift is undefined once zoom reaches the width of the type,
+     and TileData carries a uint16_t that nothing else validates */
+  return uint32_t{1} << std::min(zoom, unsigned(GeoBitmap::MAX_TILE_ZOOM));
+}
+
 static uint32_t
 LonToTileX(double lon, unsigned zoom) noexcept
 {
-  /* longitude wraps rather than running out, but a caller can still
-     hand us one outside the grid -- exactly 180 lands one tile past
-     the last, and a wild GPS fix lands anywhere -- and the cast of an
-     out-of-range double to uint32_t is undefined.  Wrap into the
-     grid, which is what the projection means anyway. */
-  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
-  const double x = std::floor((lon + 180.0) / 360.0 * tiles_per_axis);
-  if (!(x >= 0) || !(x < double(tiles_per_axis))) {
-    const double wrapped = std::fmod(x, double(tiles_per_axis));
-    return uint32_t(wrapped < 0 ? wrapped + tiles_per_axis : wrapped);
-  }
+  const uint32_t tiles_per_axis = TilesPerAxis(zoom);
+  const double scaled = (lon + 180.0) / 360.0 * tiles_per_axis;
+  const double x = std::floor(scaled);
 
-  return uint32_t(x);
+  if (x >= 0 && x < double(tiles_per_axis))
+    return uint32_t(x);
+
+  if (x == double(tiles_per_axis))
+    /* the antimeridian, one index past the last column.  It is the
+       eastern edge of that column, and that is the tile a flight
+       reaching it is in; wrapping to the first column would put the
+       tile on the far side of the map, because
+       GeoQuadrilateral::GetBounds() does not wrap.
+
+       Tested against the index rather than the exact longitude: a
+       degree value that has been through Angle's radians and back is
+       not exactly 180 any more, and the boundary has to hold for what
+       actually arrives. */
+    return tiles_per_axis - 1;
+
+  /* anywhere else outside the grid is a longitude that has run past
+     the world, which the projection simply wraps.  The cast of an
+     out-of-range double to uint32_t would be undefined, so wrap
+     first. */
+  const double wrapped = std::fmod(x, double(tiles_per_axis));
+  return uint32_t(wrapped < 0 ? wrapped + tiles_per_axis : wrapped);
 }
 
 static uint32_t
@@ -46,7 +68,7 @@ LatToTileY(double lat, unsigned zoom) noexcept
   const double latitude_radians =
     std::clamp(lat, -MERCATOR_LIMIT, MERCATOR_LIMIT) * M_PI / 180.0;
 
-  const uint32_t tiles_per_axis = uint32_t{1} << zoom;
+  const uint32_t tiles_per_axis = TilesPerAxis(zoom);
   const double y = std::floor(
     (1.0 - std::asinh(std::tan(latitude_radians)) / M_PI) / 2.0 *
     tiles_per_axis);

--- a/src/ui/canvas/custom/LibPNG.cpp
+++ b/src/ui/canvas/custom/LibPNG.cpp
@@ -87,6 +87,12 @@ LoadPNG(png_structp png_ptr, png_infop info_ptr,
        instead */
     png_set_palette_to_rgb(png_ptr);
 
+  if (color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
+    /* we have no format for gray with an alpha channel, so widen it
+       to RGBA rather than fail; single channel WMS imagery arrives
+       this way */
+    png_set_gray_to_rgb(png_ptr);
+
   png_read_update_info(png_ptr, info_ptr);
   png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth,
                &color_type, &interlace_type, nullptr, nullptr);

--- a/test/src/PageOverlayTitleStub.cpp
+++ b/test/src/PageOverlayTitleStub.cpp
@@ -50,6 +50,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     }
     break;
 
+  case PageLayout::Overlay::RADAR:
+    builder.Append(", ");
+    builder.Append(_("Radar"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/test/src/PageOverlayTitleStub.cpp
+++ b/test/src/PageOverlayTitleStub.cpp
@@ -55,6 +55,11 @@ AppendOverlayTitle(BasicStringBuilder<char> &builder,
     builder.Append(_("Radar"));
     break;
 
+  case PageLayout::Overlay::SATELLITE:
+    builder.Append(", ");
+    builder.Append(_("Satellite"));
+    break;
+
   case PageLayout::Overlay::MAX:
     gcc_unreachable();
   }

--- a/test/src/TestEumetviewEnhance.cpp
+++ b/test/src/TestEumetviewEnhance.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/EUMETView/Enhance.hpp"
+#include "ui/canvas/custom/UncompressedImage.hpp"
+#include "TestUtil.hpp"
+
+#include <chrono>
+#include <memory>
+
+using namespace std::chrono;
+
+/**
+ * A grey image whose pixels run 0, 1, 2 ... 255, 0, 1 ... so that
+ * every brightness occurs equally often and the percentiles are known.
+ */
+static UncompressedImage
+MakeRamp(unsigned width, unsigned height)
+{
+  auto data = std::make_unique<uint8_t[]>(size_t(width) * height);
+  for (size_t i = 0; i < size_t(width) * height; ++i)
+    data[i] = uint8_t(i % 256);
+
+  return {UncompressedImage::Format::GRAY, width, width, height,
+          std::move(data)};
+}
+
+int main()
+{
+  plan_tests(16);
+
+  /* an empty histogram cannot name a window */
+  EUMETView::ToneHistogram empty;
+  ok1(empty.IsEmpty());
+  ok1(empty.GetCount() == 0);
+  ok1(!EUMETView::MakeToneWindow(empty).IsValid());
+
+  /* on a flat ramp the percentiles land where arithmetic says */
+  EUMETView::ToneHistogram ramp;
+  ramp.Add(MakeRamp(256, 16));
+  ok1(!ramp.IsEmpty());
+  ok1(ramp.GetCount() == 256u * 16u);
+  ok1(ramp.Percentile(0) == 0);
+  ok1(ramp.Percentile(1000) == 255);
+  ok1(ramp.Percentile(500) >= 127 && ramp.Percentile(500) <= 129);
+
+  const auto window = EUMETView::MakeToneWindow(ramp);
+  ok1(window.IsValid());
+  ok1(window.low >= 3 && window.low <= 7);        /* 2 % of 256 */
+  ok1(window.high >= 248 && window.high <= 252);  /* 98 % of 256 */
+
+  /* a scene of one brightness must not be stretched: there is nothing
+     to stretch, and the gain would only amplify noise */
+  auto flat_data = std::make_unique<uint8_t[]>(64);
+  for (unsigned i = 0; i < 64; ++i)
+    flat_data[i] = 100;
+  EUMETView::ToneHistogram flat;
+  flat.Add({UncompressedImage::Format::GRAY, 8, 8, 8, std::move(flat_data)});
+  ok1(!EUMETView::MakeToneWindow(flat).IsValid());
+
+  /* the blend is decided by elapsed time, not by a frame count: after
+     a long gap the carried-over window says nothing and is replaced,
+     while frames in quick succession barely move it */
+  const EUMETView::ToneWindow old_window{10, 200};
+  const EUMETView::ToneWindow fresh{110, 250};
+
+  const auto quick = EUMETView::BlendToneWindow(old_window, fresh, minutes{10});
+  ok1(quick.low > old_window.low && quick.low < old_window.low + 30);
+
+  const auto after_gap = EUMETView::BlendToneWindow(old_window, fresh, hours{5});
+  ok1(after_gap.low > fresh.low - 5);
+
+  /* and with nothing carried over, the fresh measurement stands */
+  ok1(EUMETView::BlendToneWindow({0, 0}, fresh, minutes{10}) == fresh);
+
+  ok1(EUMETView::ToneWindowDistance({10, 200}, {12, 205}) == 5);
+
+  return exit_status();
+}

--- a/test/src/TestEumetviewSatellite.cpp
+++ b/test/src/TestEumetviewSatellite.cpp
@@ -19,7 +19,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(51);
+  plan_tests(55);
 
   const auto layers = EUMETView::GetLayers();
   ok1(!layers.empty());
@@ -176,6 +176,33 @@ int main()
   }
 
   ok1(wild_stays_in_grid);
+
+  /* the antimeridian is the eastern edge of the last column and the
+     western edge of the first, so the two ends are *different* tiles
+     -- and which one a position gets has to follow the direction it
+     was reached from, or a flight crossing the date line would find
+     its tile on the far side of the map.  GeoQuadrilateral::GetBounds()
+     does not wrap, so this is geometry and not merely bookkeeping. */
+  const auto east = EUMETView::GetAircraftTile({Angle::Degrees(180),
+                                                Angle::Degrees(0)},
+                                               EUMETView::MAX_TILE_ZOOM);
+  ok1(east.x == per_axis - 1);
+
+  /* +180 and -180 are the same Angle once the value has been through
+     radians, so there is no "other end" to ask for; what matters is
+     that reaching the boundary does not jump.  Just short of it must
+     be the same tile as the boundary itself. */
+  const auto almost = EUMETView::GetAircraftTile({Angle::Degrees(179.99),
+                                                  Angle::Degrees(0)},
+                                                 EUMETView::MAX_TILE_ZOOM);
+  ok1(EUMETView::IsSameTile(almost, east));
+
+  /* past the world, though, the projection wraps */
+  const auto beyond = EUMETView::GetAircraftTile({Angle::Degrees(180.5),
+                                                  Angle::Degrees(0)},
+                                                 EUMETView::MAX_TILE_ZOOM);
+  ok1(beyond.x < per_axis);
+  ok1(!EUMETView::IsSameTile(beyond, east));
 
   /* longitude wraps, so a flight over the date line keeps a whole
      block instead of losing the half that fell off the edge */

--- a/test/src/TestEumetviewSatellite.cpp
+++ b/test/src/TestEumetviewSatellite.cpp
@@ -19,7 +19,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(47);
+  plan_tests(51);
 
   const auto layers = EUMETView::GetLayers();
   ok1(!layers.empty());
@@ -89,16 +89,16 @@ int main()
   /* ---------------- the tile block ---------------- */
 
   const GeoPoint aircraft{Angle::Degrees(11), Angle::Degrees(50)};
-  const auto base = EUMETView::GetAircraftTile(aircraft);
+  const auto base = EUMETView::GetAircraftTile(aircraft, EUMETView::MAX_TILE_ZOOM);
   ok1(base.IsValid());
-  ok1(base.zoom == EUMETView::TILE_ZOOM);
+  ok1(base.zoom == EUMETView::MAX_TILE_ZOOM);
 
   /* the aircraft has to be inside its own tile, or the block would be
      centred on the wrong ground */
   ok1(GeoBitmap::GetBounds(base).IsInside(aircraft));
 
   /* without a fix there is nothing to centre on */
-  ok1(!EUMETView::GetAircraftTile(GeoPoint::Invalid()).IsValid());
+  ok1(!EUMETView::GetAircraftTile(GeoPoint::Invalid(), EUMETView::MAX_TILE_ZOOM).IsValid());
 
   const auto tiles = EUMETView::CollectTiles(base);
   ok1(tiles.size() == EUMETView::TILE_COUNT);
@@ -154,7 +154,8 @@ int main()
   /* near the pole the block runs off the top of the world; the tiles
      that remain must still be a valid, shorter list */
   const auto polar = EUMETView::GetAircraftTile({Angle::Degrees(0),
-                                                 Angle::Degrees(84.9)});
+                                                 Angle::Degrees(84.9)},
+                                                EUMETView::MAX_TILE_ZOOM);
   const auto polar_tiles = EUMETView::CollectTiles(polar);
   ok1(polar_tiles.size() <= EUMETView::TILE_COUNT);
   ok1(!polar_tiles.empty());
@@ -162,14 +163,14 @@ int main()
   /* a position outside the grid must still name a tile inside it: the
      cast of an out-of-range double to uint32_t is undefined, and a
      GPS fix can be anything.  The grid is 2^zoom tiles per axis. */
-  const uint32_t per_axis = uint32_t{1} << EUMETView::TILE_ZOOM;
+  const uint32_t per_axis = uint32_t{1} << EUMETView::MAX_TILE_ZOOM;
   bool wild_stays_in_grid = true;
   for (const auto &p : {GeoPoint{Angle::Degrees(180), Angle::Degrees(0)},
                         GeoPoint{Angle::Degrees(-180), Angle::Degrees(0)},
                         GeoPoint{Angle::Degrees(0), Angle::Degrees(89.9)},
                         GeoPoint{Angle::Degrees(0), Angle::Degrees(-89.9)},
                         GeoPoint{Angle::Degrees(180), Angle::Degrees(89.9)}}) {
-    const auto t = EUMETView::GetAircraftTile(p);
+    const auto t = EUMETView::GetAircraftTile(p, EUMETView::MAX_TILE_ZOOM);
     if (!t.IsValid() || t.x >= per_axis || t.y >= per_axis)
       wild_stays_in_grid = false;
   }
@@ -179,8 +180,61 @@ int main()
   /* longitude wraps, so a flight over the date line keeps a whole
      block instead of losing the half that fell off the edge */
   const auto dateline = EUMETView::GetAircraftTile({Angle::Degrees(179.99),
-                                                    Angle::Degrees(50)});
+                                                    Angle::Degrees(50)},
+                                                   EUMETView::MAX_TILE_ZOOM);
   ok1(EUMETView::CollectTiles(dateline).size() == EUMETView::TILE_COUNT);
+
+  /* ---------------- the grid follows the map outwards ---------------- */
+
+  /* a map at gliding scales gets the finest grid: the satellite has
+     no more detail, so zooming in must never cost a refetch */
+  const GeoBounds close{
+    GeoPoint{Angle::Degrees(10.8), Angle::Degrees(50.1)},
+    GeoPoint{Angle::Degrees(11.2), Angle::Degrees(49.9)},
+  };
+  ok1(EUMETView::ChooseZoom(close) == EUMETView::MAX_TILE_ZOOM);
+  ok1(EUMETView::ChooseZoom(GeoBounds::Invalid()) ==
+      EUMETView::MAX_TILE_ZOOM);
+
+  /* and zooming out coarsens it, rather than leaving the imagery
+     covering the middle of the screen.  Whatever the map shows, the
+     block it picks has to cover it. */
+  bool block_covers_view = true;
+  bool never_finer_than_max = true;
+  for (const double half : {0.2, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0}) {
+    const GeoBounds view{
+      GeoPoint{Angle::Degrees(11 - half), Angle::Degrees(50 + half / 2)},
+      GeoPoint{Angle::Degrees(11 + half), Angle::Degrees(50 - half / 2)},
+    };
+
+    const auto zoom = EUMETView::ChooseZoom(view);
+    if (zoom > EUMETView::MAX_TILE_ZOOM)
+      never_finer_than_max = false;
+
+    const auto tiles = EUMETView::CollectTiles(
+      EUMETView::GetAircraftTile(aircraft, zoom));
+    if (tiles.empty()) {
+      block_covers_view = false;
+      continue;
+    }
+
+    GeoBounds block = GeoBitmap::GetBounds(tiles.front());
+    for (const auto &tile : tiles) {
+      const auto b = GeoBitmap::GetBounds(tile);
+      block.Extend(b.GetNorthWest());
+      block.Extend(b.GetSouthEast());
+    }
+
+    /* the block is centred on the aircraft, not on the view, so at
+       the coarsest grid a view wider than the world cannot be
+       covered; require it up to the point where the grid runs out */
+    if (zoom > EUMETView::MIN_TILE_ZOOM &&
+        block.GetGeoWidth() < view.GetGeoWidth())
+      block_covers_view = false;
+  }
+
+  ok1(block_covers_view);
+  ok1(never_finer_than_max);
 
   /* ---------------- the request ---------------- */
 

--- a/test/src/TestEumetviewSatellite.cpp
+++ b/test/src/TestEumetviewSatellite.cpp
@@ -19,7 +19,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(46);
+  plan_tests(47);
 
   const auto layers = EUMETView::GetLayers();
   ok1(!layers.empty());
@@ -158,6 +158,23 @@ int main()
   const auto polar_tiles = EUMETView::CollectTiles(polar);
   ok1(polar_tiles.size() <= EUMETView::TILE_COUNT);
   ok1(!polar_tiles.empty());
+
+  /* a position outside the grid must still name a tile inside it: the
+     cast of an out-of-range double to uint32_t is undefined, and a
+     GPS fix can be anything.  The grid is 2^zoom tiles per axis. */
+  const uint32_t per_axis = uint32_t{1} << EUMETView::TILE_ZOOM;
+  bool wild_stays_in_grid = true;
+  for (const auto &p : {GeoPoint{Angle::Degrees(180), Angle::Degrees(0)},
+                        GeoPoint{Angle::Degrees(-180), Angle::Degrees(0)},
+                        GeoPoint{Angle::Degrees(0), Angle::Degrees(89.9)},
+                        GeoPoint{Angle::Degrees(0), Angle::Degrees(-89.9)},
+                        GeoPoint{Angle::Degrees(180), Angle::Degrees(89.9)}}) {
+    const auto t = EUMETView::GetAircraftTile(p);
+    if (!t.IsValid() || t.x >= per_axis || t.y >= per_axis)
+      wild_stays_in_grid = false;
+  }
+
+  ok1(wild_stays_in_grid);
 
   /* longitude wraps, so a flight over the date line keeps a whole
      block instead of losing the half that fell off the edge */

--- a/test/src/TestEumetviewSatellite.cpp
+++ b/test/src/TestEumetviewSatellite.cpp
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/EUMETView/Satellite.hpp"
+#include "Geo/GeoBounds.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "TestUtil.hpp"
+
+#include <span>
+#include <string>
+
+[[gnu::pure]]
+static bool
+Contains(const std::string &haystack, const char *needle) noexcept
+{
+  return haystack.find(needle) != std::string::npos;
+}
+
+int main()
+{
+  plan_tests(46);
+
+  const auto layers = EUMETView::GetLayers();
+  ok1(!layers.empty());
+
+  /* every layer has to be able to hold a frame long enough to be
+     replaced: a frame is already latency..latency+cadence minutes old
+     when it arrives, so an age limit inside that window would expire
+     the picture as it was installed, and the overlay would flicker
+     rather than refresh */
+  bool ages_are_clear = true;
+  bool table_is_sane = true;
+  for (const auto &layer : layers) {
+    /* the margin has to leave room for one refresh to fail */
+    if (layer.max_age_minutes <
+        layer.latency_minutes + 2 * layer.cadence_minutes)
+      ages_are_clear = false;
+
+    if (layer.cadence_minutes == 0 || 60 % layer.cadence_minutes != 0)
+      /* the frame grid has to divide the hour, or rounding the minute
+         down to a multiple of it would name times that never occur */
+      table_is_sane = false;
+
+    if (layer.name == nullptr || layer.label == nullptr)
+      table_is_sane = false;
+  }
+
+  ok1(ages_are_clear);
+  ok1(table_is_sane);
+
+  /* an index out of range must fall back rather than read past the
+     table: a profile written by a newer version can name a layer this
+     build does not have */
+  ok1(&EUMETView::GetLayer(-1) == &layers[EUMETView::DEFAULT_LAYER]);
+  ok1(&EUMETView::GetLayer(int(layers.size())) ==
+      &layers[EUMETView::DEFAULT_LAYER]);
+  ok1(&EUMETView::GetLayer(0) == &layers[0]);
+
+  /* ---------------- frame times ---------------- */
+
+  const auto &ten = EUMETView::GetLayer(1);
+  ok1(ten.cadence_minutes == 10);
+
+  const BrokenDateTime noon{BrokenDate{2026, 8, 28}, BrokenTime{12, 30, 45}};
+  const auto frame = EUMETView::FrameTime(ten, noon);
+  ok1(frame.IsPlausible());
+  ok1(frame.minute % ten.cadence_minutes == 0);
+  ok1(frame.second == 0);
+
+  /* it is never newer than the delay, and never older than the delay
+     plus one cadence step */
+  const auto age = noon - frame;
+  ok1(age >= std::chrono::minutes{ten.latency_minutes});
+  ok1(age < std::chrono::minutes{ten.latency_minutes + ten.cadence_minutes});
+
+  /* the delay may carry the frame back across midnight */
+  const BrokenDateTime after_midnight{BrokenDate{2026, 8, 28},
+                                      BrokenTime{0, 2, 0}};
+  const auto wrapped = EUMETView::FrameTime(ten, after_midnight);
+  ok1(wrapped.IsPlausible());
+  ok1(wrapped.day == 27);
+  ok1(wrapped.hour == 23);
+
+  /* without a clock we must not guess: asking EUMETView for a frame
+     that does not exist is an error, not an older picture */
+  ok1(!EUMETView::FrameTime(ten, BrokenDateTime::Invalid()).IsPlausible());
+
+  /* ---------------- the tile block ---------------- */
+
+  const GeoPoint aircraft{Angle::Degrees(11), Angle::Degrees(50)};
+  const auto base = EUMETView::GetAircraftTile(aircraft);
+  ok1(base.IsValid());
+  ok1(base.zoom == EUMETView::TILE_ZOOM);
+
+  /* the aircraft has to be inside its own tile, or the block would be
+     centred on the wrong ground */
+  ok1(GeoBitmap::GetBounds(base).IsInside(aircraft));
+
+  /* without a fix there is nothing to centre on */
+  ok1(!EUMETView::GetAircraftTile(GeoPoint::Invalid()).IsValid());
+
+  const auto tiles = EUMETView::CollectTiles(base);
+  ok1(tiles.size() == EUMETView::TILE_COUNT);
+
+  /* the aircraft's own tile is fetched first.  This is the whole
+     point of the ordering: on a link that may die at any moment, the
+     ground under the glider has to be the part that arrives. */
+  ok1(EUMETView::IsSameTile(tiles.front(), base));
+
+  /* and the rest follow outwards, never getting closer again, so the
+     picture grows as rings around the aircraft */
+  bool rings_grow = true;
+  bool all_distinct = true;
+  unsigned previous = 0;
+  for (std::size_t i = 0; i < tiles.size(); ++i) {
+    const auto dx = int(tiles[i].x) - int(base.x);
+    const auto dy = int(tiles[i].y) - int(base.y);
+    const unsigned distance = unsigned(dx * dx + dy * dy);
+    if (distance < previous)
+      rings_grow = false;
+
+    previous = distance;
+
+    for (std::size_t j = 0; j < i; ++j)
+      if (EUMETView::IsSameTile(tiles[i], tiles[j]))
+        all_distinct = false;
+  }
+
+  ok1(rings_grow);
+  ok1(all_distinct);
+
+  /* the block has to reach far enough to be worth flying by: at least
+     fifty kilometres in every direction from the aircraft */
+  GeoBounds block = GeoBitmap::GetBounds(tiles.front());
+  for (const auto &tile : tiles) {
+    const auto b = GeoBitmap::GetBounds(tile);
+    block.Extend(b.GetNorthWest());
+    block.Extend(b.GetSouthEast());
+  }
+
+  ok1(block.IsInside(aircraft));
+  ok1(block.GetGeoWidth() >= 100000);
+  ok1(block.GetGeoHeight() >= 100000);
+
+  /* one tile is a useful picture on its own, not a postage stamp */
+  const auto centre = GeoBitmap::GetBounds(base);
+  ok1(centre.GetGeoWidth() > 10000);
+  ok1(centre.GetGeoWidth() < 60000);
+
+  /* an invalid base tile yields no work rather than a garbage block */
+  ok1(EUMETView::CollectTiles({}).empty());
+
+  /* near the pole the block runs off the top of the world; the tiles
+     that remain must still be a valid, shorter list */
+  const auto polar = EUMETView::GetAircraftTile({Angle::Degrees(0),
+                                                 Angle::Degrees(84.9)});
+  const auto polar_tiles = EUMETView::CollectTiles(polar);
+  ok1(polar_tiles.size() <= EUMETView::TILE_COUNT);
+  ok1(!polar_tiles.empty());
+
+  /* longitude wraps, so a flight over the date line keeps a whole
+     block instead of losing the half that fell off the edge */
+  const auto dateline = EUMETView::GetAircraftTile({Angle::Degrees(179.99),
+                                                    Angle::Degrees(50)});
+  ok1(EUMETView::CollectTiles(dateline).size() == EUMETView::TILE_COUNT);
+
+  /* ---------------- the request ---------------- */
+
+  const auto url = EUMETView::MakeTileURL(ten, base, frame);
+  ok1(Contains(url, "https://view.eumetsat.int/geoserver/wms?"));
+  ok1(Contains(url, "REQUEST=GetMap"));
+
+  /* the layer name's colon is reserved in a query value */
+  ok1(Contains(url, "LAYERS=mtg_fd%3Avis06_hrfi"));
+
+  /* CRS:84 and not EPSG:4326, whose axis order is latitude first in
+     WMS 1.3.0; getting this wrong transposes the image silently */
+  ok1(Contains(url, "CRS=CRS:84"));
+  ok1(Contains(url, "&TIME=2026-08-28T"));
+  ok1(Contains(url, "&WIDTH=128&HEIGHT=128"));
+
+  /* an unusable request must produce no URL at all rather than one
+     the server will reject */
+  ok1(EUMETView::MakeTileURL(ten, {}, frame).empty());
+  ok1(EUMETView::MakeTileURL(ten, base, BrokenDateTime::Invalid()).empty());
+
+  /* ---------------- what came back ---------------- */
+
+  static constexpr std::byte PNG[]{
+    std::byte(0x89), std::byte('P'), std::byte('N'), std::byte('G'),
+    std::byte(0x0d), std::byte(0x0a), std::byte(0x1a), std::byte(0x0a),
+    std::byte(0), std::byte(0),
+  };
+  ok1(EUMETView::IsPNG(PNG));
+  ok1(!EUMETView::IsPNG(std::span<const std::byte>{PNG}.first(4)));
+
+  /* EUMETView reports its errors as a ServiceExceptionReport inside a
+     perfectly ordinary "200 OK", so the image we asked for may in
+     fact be XML; it has to be recognised while the message can still
+     be read */
+  static constexpr char EXCEPTION[] =
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    "<ServiceExceptionReport version=\"1.3.0\">"
+    "   <ServiceException code=\"InvalidDimensionValue\" locator=\"time\">\n"
+    "      No nearest match found on mtg_fd:vis06_hrfi\n"
+    "</ServiceException></ServiceExceptionReport>";
+  ok1(!EUMETView::IsPNG(std::as_bytes(std::span{EXCEPTION}).first(8)));
+  ok1(EUMETView::ExtractServiceException(EXCEPTION) ==
+      "No nearest match found on mtg_fd:vis06_hrfi");
+  ok1(EUMETView::ExtractServiceException("not xml at all").empty());
+
+  return exit_status();
+}

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -2,14 +2,163 @@
 // Copyright The XCSoar Project
 
 #include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoBounds.hpp"
 #include "Geo/GeoPoint.hpp"
 #include "time/BrokenDateTime.hpp"
 #include "TestUtil.hpp"
 
+#include <algorithm>
+#include <array>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <vector>
 
 #include <string.h>
+
+/**
+ * Assembles a classic little endian TIFF header, so that the
+ * directory reader can be exercised without the network and without a
+ * five megabyte fixture in the tree.
+ */
+class HeaderBuilder {
+  std::vector<uint8_t> data;
+
+public:
+  HeaderBuilder() {
+    data = {'I', 'I', 42, 0, 0, 0, 0, 0};
+  }
+
+  std::size_t Size() const noexcept { return data.size(); }
+
+  void PutU16(std::size_t at, uint16_t value) noexcept {
+    data[at] = uint8_t(value);
+    data[at + 1] = uint8_t(value >> 8);
+  }
+
+  void PutU32(std::size_t at, uint32_t value) noexcept {
+    for (unsigned i = 0; i < 4; ++i)
+      data[at + i] = uint8_t(value >> (8 * i));
+  }
+
+  std::size_t AppendU32Array(const std::vector<uint32_t> &values) {
+    const auto at = data.size();
+    for (const auto value : values) {
+      data.resize(data.size() + 4);
+      PutU32(data.size() - 4, value);
+    }
+
+    return at;
+  }
+
+  std::size_t AppendDoubles(const std::vector<double> &values) {
+    const auto at = data.size();
+    for (const auto value : values) {
+      uint64_t bits;
+      std::memcpy(&bits, &value, sizeof(bits));
+      data.resize(data.size() + 8);
+      for (unsigned i = 0; i < 8; ++i)
+        data[data.size() - 8 + i] = uint8_t(bits >> (8 * i));
+    }
+
+    return at;
+  }
+
+  /** @return the offset the directory was written at */
+  std::size_t AppendDirectory(const std::vector<std::array<uint32_t, 4>> &tags) {
+    const auto at = data.size();
+    data.resize(at + 2 + tags.size() * 12 + 4, 0);
+    PutU16(at, uint16_t(tags.size()));
+
+    std::size_t e = at + 2;
+    for (const auto &tag : tags) {
+      PutU16(e, uint16_t(tag[0]));
+      PutU16(e + 2, uint16_t(tag[1]));
+      PutU32(e + 4, tag[2]);
+      PutU32(e + 8, tag[3]);
+      e += 12;
+    }
+
+    return at;
+  }
+
+  void SetFirstDirectory(uint32_t at) noexcept { PutU32(4, at); }
+
+  void SetNextDirectory(std::size_t directory, uint32_t next) noexcept {
+    const auto n = uint16_t(data[directory] | (data[directory + 1] << 8));
+    PutU32(directory + 2 + std::size_t(n) * 12, next);
+  }
+
+  std::span<const std::byte> Get() const noexcept {
+    return std::as_bytes(std::span{data});
+  }
+};
+
+/* the tag numbers the reader looks for */
+static constexpr uint32_t TAG_WIDTH = 256, TAG_HEIGHT = 257;
+static constexpr uint32_t TAG_COMPRESSION = 259, TAG_SAMPLES = 277;
+static constexpr uint32_t TAG_TILE_WIDTH = 322, TAG_TILE_HEIGHT = 323;
+static constexpr uint32_t TAG_TILE_OFFSETS = 324, TAG_TILE_LENGTHS = 325;
+static constexpr uint32_t TAG_PIXEL_SCALE = 33550, TAG_TIEPOINT = 33922;
+static constexpr uint32_t TYPE_SHORT = 3, TYPE_LONG = 4, TYPE_DOUBLE = 12;
+
+/**
+ * A two level composite whose full resolution grid is 1024 by 1024 in
+ * 512 pixel tiles, arranged so that the projection centre falls in the
+ * middle of it.
+ */
+static HeaderBuilder
+MakeComposite()
+{
+  /* the grid origin, chosen so that 10E 55N lands at column 768, row
+     768: the middle of the last of the four tiles, well clear of the
+     boundaries so that the test asks about tile arithmetic rather
+     than about which side of an edge a rounding error falls on */
+  static constexpr double ORIGIN_X = 1950000 - 768 * 1000.0;
+  static constexpr double ORIGIN_Y = -2100000 + 768 * 1000.0;
+
+  HeaderBuilder b;
+
+  const auto offsets0 = b.AppendU32Array({4096, 8192, 12288, 16384});
+  const auto lengths0 = b.AppendU32Array({100, 200, 300, 400});
+  const auto offsets1 = b.AppendU32Array({20480});
+  const auto lengths1 = b.AppendU32Array({500});
+  const auto scale = b.AppendDoubles({1000, 1000, 0});
+  const auto tiepoint = b.AppendDoubles({0, 0, 0, ORIGIN_X, ORIGIN_Y, 0});
+
+  const auto ifd0 = b.AppendDirectory({{
+    {TAG_WIDTH, TYPE_LONG, 1, 1024},
+    {TAG_HEIGHT, TYPE_LONG, 1, 1024},
+    {TAG_COMPRESSION, TYPE_SHORT, 1, 8},
+    {TAG_SAMPLES, TYPE_SHORT, 1, 2},
+    {TAG_TILE_WIDTH, TYPE_SHORT, 1, 512},
+    {TAG_TILE_HEIGHT, TYPE_SHORT, 1, 512},
+    {TAG_TILE_OFFSETS, TYPE_LONG, 4, uint32_t(offsets0)},
+    {TAG_TILE_LENGTHS, TYPE_LONG, 4, uint32_t(lengths0)},
+    {TAG_PIXEL_SCALE, TYPE_DOUBLE, 3, uint32_t(scale)},
+    {TAG_TIEPOINT, TYPE_DOUBLE, 6, uint32_t(tiepoint)},
+  }});
+
+  /* the overview carries no georeference of its own, exactly as the
+     real file's do; its scale has to follow from the size ratio */
+  const auto ifd1 = b.AppendDirectory({{
+    {TAG_WIDTH, TYPE_LONG, 1, 512},
+    {TAG_HEIGHT, TYPE_LONG, 1, 512},
+    {TAG_COMPRESSION, TYPE_SHORT, 1, 8},
+    {TAG_SAMPLES, TYPE_SHORT, 1, 2},
+    {TAG_TILE_WIDTH, TYPE_SHORT, 1, 512},
+    {TAG_TILE_HEIGHT, TYPE_SHORT, 1, 512},
+    {TAG_TILE_OFFSETS, TYPE_LONG, 1, uint32_t(offsets1)},
+    {TAG_TILE_LENGTHS, TYPE_LONG, 1, uint32_t(lengths1)},
+  }});
+
+  b.SetFirstDirectory(uint32_t(ifd0));
+  b.SetNextDirectory(ifd0, uint32_t(ifd1));
+
+  return b;
+}
 
 [[gnu::pure]]
 static bool
@@ -20,7 +169,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(28);
+  plan_tests(77);
 
   /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
      which rounds down to the 12:00 composite */
@@ -85,10 +234,23 @@ int main()
   ok1(OPERA::ClassifyReflectivity(18) < 0);
 
   /* and neither is "no radar here", which the composite marks with a
-     large negative number.  Its other marker, a NaN, cannot be tested
-     here: we are built with -ffast-math, under which a literal NaN is
-     folded away before it ever reaches the function. */
+     large negative number */
   ok1(OPERA::ClassifyReflectivity(-9999000) < 0);
+
+  /* its other marker is a NaN.  A literal one would be folded away
+     under -ffast-math before it ever reached the function, so build
+     it from the bit pattern -- which is what IsNotANumber() inspects
+     anyway, for the same reason. */
+  const uint64_t nan_bits = 0x7ff8000000000000ULL;
+  double quiet_nan;
+  std::memcpy(&quiet_nan, &nan_bits, sizeof(quiet_nan));
+
+  ok1(OPERA::IsNotANumber(quiet_nan));
+  ok1(OPERA::ClassifyReflectivity(quiet_nan) < 0);
+
+  /* and an ordinary number must not be mistaken for one */
+  ok1(!OPERA::IsNotANumber(30.0));
+  ok1(!OPERA::IsNotANumber(-9999000.0));
 
   /* and the classes climb from there */
   ok1(OPERA::ClassifyReflectivity(19) == 0);
@@ -117,6 +279,187 @@ int main()
 
   ok1(distinct == OPERA::N_CLASSES);
   ok1(previous == int(OPERA::N_CLASSES) - 1);
+
+  /* --- the display grid ------------------------------------------ */
+
+  const GeoPoint augsburg{Angle::Degrees(10.9), Angle::Degrees(48.35)};
+
+  /* the grid only exists between the two zoom bounds */
+  ok1(!OPERA::GetAircraftTile(augsburg, OPERA::MIN_TILE_ZOOM - 1).IsValid());
+  ok1(!OPERA::GetAircraftTile(augsburg, OPERA::MAX_TILE_ZOOM + 1).IsValid());
+  ok1(!OPERA::GetAircraftTile(GeoPoint::Invalid(),
+                              OPERA::MAX_TILE_ZOOM).IsValid());
+
+  const auto base = OPERA::GetAircraftTile(augsburg, 9);
+  ok1(base.IsValid());
+  ok1(base.zoom == 9);
+
+  /* the tile the aircraft is in must be the one that contains it */
+  ok1(GeoBitmap::GetBounds(base).IsInside(augsburg));
+
+  const auto block = OPERA::CollectTiles(base);
+  ok1(block.size() == OPERA::TILE_COUNT);
+
+  /* nearest first: the aircraft's own tile leads, and the four tiles
+     sharing an edge with it come before the four diagonal ones */
+  ok1(OPERA::IsSameTile(block.front(), base));
+
+  const auto ring = [&base](const GeoBitmap::TileData &t) {
+    const int dx = int(t.x) - int(base.x), dy = int(t.y) - int(base.y);
+    return dx * dx + dy * dy;
+  };
+
+  bool ordered = true;
+  for (std::size_t i = 1; i < block.size(); ++i)
+    if (ring(block[i]) < ring(block[i - 1]))
+      ordered = false;
+
+  ok1(ordered);
+  ok1(ring(block[1]) == 1 && ring(block[4]) == 1);
+  ok1(ring(block[5]) == 2);
+
+  /* every tile of the block is distinct, or a slot would be spent
+     twice on the same picture */
+  auto sorted = block;
+  std::sort(sorted.begin(), sorted.end(),
+            [](const auto &a, const auto &b){
+              return a.x != b.x ? a.x < b.x : a.y < b.y;
+            });
+  ok1(std::adjacent_find(sorted.begin(), sorted.end(),
+                         OPERA::IsSameTile) == sorted.end());
+
+  /* an invalid centre yields no block at all */
+  ok1(OPERA::CollectTiles({}).empty());
+
+  /* a coarser tile covers more ground per pixel */
+  const auto fine = GeoBitmap::GetBounds(OPERA::GetAircraftTile(augsburg, 10));
+  const auto coarse = GeoBitmap::GetBounds(OPERA::GetAircraftTile(augsburg, 8));
+  const auto fine_scale = OPERA::TileMetresPerPixel(fine, OPERA::TILE_PIXELS);
+  const auto coarse_scale = OPERA::TileMetresPerPixel(coarse,
+                                                      OPERA::TILE_PIXELS);
+  ok1(fine_scale > 0);
+  ok1(coarse_scale > 3 * fine_scale);
+  ok1(OPERA::TileMetresPerPixel(fine, 0) == 0);
+
+  /* --- the raster projector -------------------------------------- */
+
+  /* it has to agree with Project() to the last bit, being nothing but
+     the same arithmetic with the trigonometry hoisted out */
+  static constexpr unsigned WIDTH = 8;
+  const double left = 8.0, right = 12.0, latitude = 50.0;
+  const OPERA::RasterProjector projector{left, right, WIDTH};
+  ok1(projector.GetWidth() == WIDTH);
+
+  DoublePoint2D row[WIDTH];
+  projector.ProjectRow(latitude, row);
+
+  bool agrees = true;
+  for (unsigned x = 0; x < WIDTH; ++x) {
+    const double longitude = left + (right - left) * (x + 0.5) / WIDTH;
+    const auto expected = OPERA::Project(GeoPoint{Angle::Degrees(longitude),
+                                                  Angle::Degrees(latitude)});
+    if (std::fabs(row[x].x - expected.x) > 1e-6 ||
+        std::fabs(row[x].y - expected.y) > 1e-6)
+      agrees = false;
+  }
+
+  ok1(agrees);
+
+  /* --- the composite directory ----------------------------------- */
+
+  const auto composite_header = MakeComposite();
+  const auto index = OPERA::ParseIndex(composite_header.Get());
+
+  ok1(index.IsValid());
+  ok1(index.levels.size() == 2);
+  ok1(index.levels[0].width == 1024 && index.levels[0].height == 1024);
+  ok1(index.levels[0].TilesAcross() == 2 && index.levels[0].TilesDown() == 2);
+  ok1(index.levels[0].tile_offset.size() == 4);
+  ok1(index.levels[0].tile_length[3] == 400);
+  ok1(equals(index.levels[0].scale, 1000));
+
+  /* the overview has no georeference of its own; it must inherit the
+     origin and take its scale from the size ratio, or every pixel of
+     it would land in the wrong place */
+  ok1(equals(index.levels[1].scale, 2000));
+  ok1(equals(index.levels[1].origin_x, index.levels[0].origin_x));
+  ok1(equals(index.levels[1].origin_y, index.levels[0].origin_y));
+  ok1(index.levels[1].IsUsable());
+
+  /* garbage must be refused rather than parsed into nonsense */
+  const std::byte truncated[4]{};
+  try {
+    OPERA::ParseIndex(std::span{truncated});
+    ok1(false);
+  } catch (...) {
+    ok1(true);
+  }
+
+  const std::byte not_tiff[16]{std::byte{'X'}, std::byte{'Y'}};
+  try {
+    OPERA::ParseIndex(std::span{not_tiff});
+    ok1(false);
+  } catch (...) {
+    ok1(true);
+  }
+
+  /* a directory that reaches past what was fetched must be refused
+     rather than read off the end.  The offsets in the file are 32 bit
+     and unchecked arithmetic on them wraps on a 32 bit target, which
+     is where this guard earns its keep. */
+  const auto full = MakeComposite();
+  const auto whole = full.Get();
+  for (std::size_t cut : {std::size_t{8}, whole.size() / 2,
+                          whole.size() - 4}) {
+    try {
+      OPERA::ParseIndex(whole.first(cut));
+      ok1(false);
+    } catch (...) {
+      ok1(true);
+    }
+  }
+
+  /* --- level selection ------------------------------------------- */
+
+  /* the coarsest level that still resolves what was asked for, to
+     within the oversampling tolerance */
+  ok1(OPERA::SelectLevel(index, 3000) == 1);
+  ok1(OPERA::SelectLevel(index, 1500) == 1);
+
+  /* the tolerance has to bite exactly at its own boundary, or the
+     rule would be one the measurements do not describe: level 1 is
+     2000 m, so it may serve a request down to 1000 m and no finer */
+  ok1(OPERA::SelectLevel(index, 2000 / OPERA::LEVEL_TOLERANCE) == 1);
+  ok1(OPERA::SelectLevel(index, 2000 / OPERA::LEVEL_TOLERANCE - 1) == 0);
+
+  /* asking for more detail than the file holds must not fall off the
+     bottom; the finest level is the best that can be done */
+  ok1(OPERA::SelectLevel(index, 10) == 0);
+
+  /* --- which tiles an area needs --------------------------------- */
+
+  /* a small area around the projection centre falls in the last of
+     the four tiles, the one the grid was laid out to put it in */
+  const GeoBounds centre_area{GeoPoint{Angle::Degrees(10),
+                                       Angle::Degrees(55)}};
+  const auto needed = OPERA::CoveringSourceTiles(index.levels[0],
+                                                 centre_area);
+  ok1(needed.size() == 1);
+  ok1(needed.front() == 3);
+
+  /* the overview covers the same ground in one tile */
+  const auto needed_coarse = OPERA::CoveringSourceTiles(index.levels[1],
+                                                        centre_area);
+  ok1(needed_coarse.size() == 1);
+  ok1(needed_coarse.front() == 0);
+
+  /* an area the composite does not reach asks for nothing at all,
+     rather than for a tile that is not there */
+  const GeoBounds far_away{GeoPoint{Angle::Degrees(-140),
+                                    Angle::Degrees(-40)}};
+  ok1(OPERA::CoveringSourceTiles(index.levels[0], far_away).empty());
+  ok1(OPERA::CoveringSourceTiles(index.levels[0],
+                                 GeoBounds::Invalid()).empty());
 
   return exit_status();
 }

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -6,6 +6,7 @@
 #include "time/BrokenDateTime.hpp"
 #include "TestUtil.hpp"
 
+#include <chrono>
 #include <cmath>
 
 #include <string.h>
@@ -19,26 +20,43 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(22);
+  plan_tests(28);
 
-  /* 12:07 rounds down to the 12:00 composite: ten minutes of
-     dissemination margin, then down to the five minute grid */
+  /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
+     which rounds down to the 12:00 composite */
   const BrokenDateTime noon{BrokenDate{2026, 8, 28}, BrokenTime{12, 7, 30}};
   const auto url = OPERA::MakeCompositeURL(noon);
 
   ok1(Contains(url, "https://s3.waw3-1.cloudferro.com/openradar-24h/"));
   ok1(Contains(url, "/2026/08/28/OPERA/COMP/"));
-  ok1(Contains(url, "OPERA@20260828T1155@0@DBZH.tiff"));
+  ok1(Contains(url, "OPERA@20260828T1200@0@DBZH.tiff"));
 
   /* the margin may cross midnight, and then the date has to follow */
   const BrokenDateTime after_midnight{BrokenDate{2026, 8, 28},
                                       BrokenTime{0, 3, 0}};
   const auto wrapped = OPERA::MakeCompositeURL(after_midnight);
   ok1(Contains(wrapped, "/2026/08/27/OPERA/COMP/"));
-  ok1(Contains(wrapped, "OPERA@20260827T2350@0@DBZH.tiff"));
+  ok1(Contains(wrapped, "OPERA@20260827T2355@0@DBZH.tiff"));
 
   /* without a clock we must not guess */
   ok1(OPERA::MakeCompositeURL(BrokenDateTime::Invalid()).empty());
+
+  /* CompositeTime() must name the very frame the URL points at, or
+     the age of the picture on the map would be computed against the
+     wrong instant */
+  const auto composite = OPERA::CompositeTime(noon);
+  ok1(composite.hour == 12 && composite.minute == 0);
+  ok1(composite.second == 0);
+  ok1(!OPERA::CompositeTime(BrokenDateTime::Invalid()).IsPlausible());
+
+  /* the frame we request is never newer than the margin and never
+     older than the margin plus one cadence step; the age limit has to
+     sit clear of that, or a frame would expire as it arrived */
+  const auto fresh_age = noon - composite;
+  ok1(fresh_age >= std::chrono::minutes{OPERA::LATENCY_MINUTES});
+  ok1(fresh_age < std::chrono::minutes{OPERA::LATENCY_MINUTES +
+                                       OPERA::CADENCE_MINUTES});
+  ok1(fresh_age < std::chrono::minutes{OPERA::MAX_AGE_MINUTES});
 
   /* the projection centre lands on the grid's false origin */
   const auto centre = OPERA::Project(GeoPoint{Angle::Degrees(10),

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -169,7 +169,7 @@ Contains(const std::string &haystack, const char *needle) noexcept
 
 int main()
 {
-  plan_tests(77);
+  plan_tests(83);
 
   /* 12:07:30 minus the seven minute dissemination margin is 12:00:30,
      which rounds down to the 12:00 composite */
@@ -296,6 +296,22 @@ int main()
 
   /* the tile the aircraft is in must be the one that contains it */
   ok1(GeoBitmap::GetBounds(base).IsInside(augsburg));
+
+  /* the grid must survive a fix at its edges: longitude 180 lands one
+     tile past the last column and latitude past the Mercator cut-off
+     runs to infinity, and casting either out-of-range double to
+     uint32_t is undefined.  Both have to come back inside the grid. */
+  for (const double longitude : {180.0, -180.0, 179.9999999}) {
+    const auto edge = OPERA::GetAircraftTile(
+      GeoPoint{Angle::Degrees(longitude), Angle::Degrees(48.35)}, 9);
+    ok1(edge.IsValid() && edge.x < (uint32_t(1) << 9));
+  }
+
+  for (const double latitude : {89.9, -89.9, 85.05112878}) {
+    const auto edge = OPERA::GetAircraftTile(
+      GeoPoint{Angle::Degrees(10.9), Angle::Degrees(latitude)}, 9);
+    ok1(edge.IsValid() && edge.y < (uint32_t(1) << 9));
+  }
 
   const auto block = OPERA::CollectTiles(base);
   ok1(block.size() == OPERA::TILE_COUNT);

--- a/test/src/TestOperaRadar.cpp
+++ b/test/src/TestOperaRadar.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Weather/OPERA/Radar.hpp"
+#include "Geo/GeoPoint.hpp"
+#include "time/BrokenDateTime.hpp"
+#include "TestUtil.hpp"
+
+#include <cmath>
+
+#include <string.h>
+
+[[gnu::pure]]
+static bool
+Contains(const std::string &haystack, const char *needle) noexcept
+{
+  return haystack.find(needle) != std::string::npos;
+}
+
+int main()
+{
+  plan_tests(22);
+
+  /* 12:07 rounds down to the 12:00 composite: ten minutes of
+     dissemination margin, then down to the five minute grid */
+  const BrokenDateTime noon{BrokenDate{2026, 8, 28}, BrokenTime{12, 7, 30}};
+  const auto url = OPERA::MakeCompositeURL(noon);
+
+  ok1(Contains(url, "https://s3.waw3-1.cloudferro.com/openradar-24h/"));
+  ok1(Contains(url, "/2026/08/28/OPERA/COMP/"));
+  ok1(Contains(url, "OPERA@20260828T1155@0@DBZH.tiff"));
+
+  /* the margin may cross midnight, and then the date has to follow */
+  const BrokenDateTime after_midnight{BrokenDate{2026, 8, 28},
+                                      BrokenTime{0, 3, 0}};
+  const auto wrapped = OPERA::MakeCompositeURL(after_midnight);
+  ok1(Contains(wrapped, "/2026/08/27/OPERA/COMP/"));
+  ok1(Contains(wrapped, "OPERA@20260827T2350@0@DBZH.tiff"));
+
+  /* without a clock we must not guess */
+  ok1(OPERA::MakeCompositeURL(BrokenDateTime::Invalid()).empty());
+
+  /* the projection centre lands on the grid's false origin */
+  const auto centre = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                              Angle::Degrees(55)});
+  ok1(equals(centre.x, 1950000));
+  ok1(equals(centre.y, -2100000));
+
+  /* east is +x, north is +y */
+  const auto east = OPERA::Project(GeoPoint{Angle::Degrees(15),
+                                            Angle::Degrees(55)});
+  const auto north = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                             Angle::Degrees(60)});
+  ok1(east.x > centre.x);
+  ok1(std::fabs(east.y - centre.y) < std::fabs(east.x - centre.x));
+  ok1(north.y > centre.y);
+  ok1(std::fabs(north.x - centre.x) < std::fabs(north.y - centre.y));
+
+  /* one degree of latitude is roughly 111km in this projection */
+  const auto one_degree = OPERA::Project(GeoPoint{Angle::Degrees(10),
+                                                  Angle::Degrees(56)});
+  ok1(std::fabs(one_degree.y - centre.y) > 110000);
+  ok1(std::fabs(one_degree.y - centre.y) < 112000);
+
+  /* weak echo is not drawn at all; the reference product clips it */
+  ok1(OPERA::ClassifyReflectivity(0) < 0);
+  ok1(OPERA::ClassifyReflectivity(18) < 0);
+
+  /* and neither is "no radar here", which the composite marks with a
+     large negative number.  Its other marker, a NaN, cannot be tested
+     here: we are built with -ffast-math, under which a literal NaN is
+     folded away before it ever reaches the function. */
+  ok1(OPERA::ClassifyReflectivity(-9999000) < 0);
+
+  /* and the classes climb from there */
+  ok1(OPERA::ClassifyReflectivity(19) == 0);
+  ok1(OPERA::ClassifyReflectivity(40) > OPERA::ClassifyReflectivity(30));
+  ok1(OPERA::GetClassColour(999) ==
+      OPERA::GetClassColour(OPERA::N_CLASSES - 1));
+
+  /* every class must be reachable, and every colour therefore
+     reachable with it: two equal bounds would make the classifier step
+     over one and that colour would never be drawn.  Walk the whole
+     scale and check that it visits each index in turn, once. */
+  int previous = -1;
+  unsigned distinct = 0;
+  for (double dbz = 0; dbz < 80; dbz += 0.01) {
+    const int i = OPERA::ClassifyReflectivity(dbz);
+    if (i == previous)
+      continue;
+
+    /* it may never skip an index or go backwards */
+    if (i != previous + 1)
+      break;
+
+    previous = i;
+    ++distinct;
+  }
+
+  ok1(distinct == OPERA::N_CLASSES);
+  ok1(previous == int(OPERA::N_CLASSES) - 1);
+
+  return exit_status();
+}


### PR DESCRIPTION
Closes #2997.

> **Stacked on #2998.** This branch is based on it, because a satellite overlay
> extends the very same `PageLayout::Overlay` enum and the same `switch`
> statements it adds. The commits below `ui/canvas/LibPNG: accept gray with an
> alpha channel` belong to that PR; the six from there upwards belong to this
> one. Rebased onto #2998 as of its `567213675`. Happy to rebase onto master
> once #2998 lands, or to reorder if you would rather see this first.

Draws Meteosat imagery from EUMETView underneath the moving map, so terrain,
airspace and the task are read on top of the cloud picture rather than in a
separate viewer.

It is the same Meteosat data the DWD sells on in its pc_met satellite images,
taken one step earlier in the chain: CC BY 4.0, no account, and the MTG layers
resolve about twice as finely as the SEVIRI HRV channel pc_met is rastered
from. The reasoning is in #2997.

## Fetching, for a glider's connection

The imagery is fetched as a 5x5 block of tiles on the standard map tile grid,
centred on the aircraft, each about 25 km across.

**Tiles are requested nearest first** — the one the glider is over, then the
ring around it, then the next ring outwards. A glider's mobile link is slow and
often absent, so what matters is not how fast the whole picture arrives but
that the useful part arrives first. Measured against the live service:

| after | covers | bytes |
|---|---|---|
| 1 tile | the ground under the glider | 3 kB |
| 9 tiles | the area reachable from here | 28 kB |
| 25 tiles | the full block, >100 km across | 78 kB |

A link that dies half way therefore leaves a complete picture of the ground
that matters most, not a half-drawn one. Only one request is ever in flight;
stacking them on a thin link makes every tile arrive late instead of the
nearest one arriving early.

Because the tiles sit on the shared grid, flying on is cheap: crossing into the
next tile keeps every tile the new block still overlaps and fetches only what
has come into range. Panning fetches nothing, and neither does zooming in — the
satellite has no finer detail to give. Zooming *out* past what the block covers
moves it to a coarser grid, so the imagery keeps covering the map instead of
shrinking to the middle of it; each step is a halving, so an ordinary change of
scale does not move it.

Nothing is taken off the map before its replacement arrives. A tile the block no
longer wants — left behind by flying on, or drawn on the grid the map used
before it was zoomed — stays until a tile covering the same ground is installed
over it. Only a change of product empties the map outright.

## Why a WMS makes the georeference free

EUMETView is a WMS, so the projection is a request parameter. Asking for a
north-up lat/lon box returns an image for exactly that box, so the four-corner
georeference `MapOverlayBitmap` works with is correct by construction. Nothing
is reprojected on the device, and none of the changes to the shared
`OverlayBitmap` code that drawing the pc_met images accurately would have
needed (see #2997) are required here.

Note the tiles are requested in `CRS:84`, not `EPSG:3857`: the grid is only
used to decide *which* rectangles to fetch. Requesting Mercator would leave the
renderer interpolating latitude linearly through a Mercator image.

## Measured, not guessed

EUMETView answers a request for a frame it does not yet have with
`InvalidDimensionValue` rather than with an older picture, so the dissemination
margin has to be right. Polling `GetCapabilities` once a minute gave worst
delays of 13 min on the rapid scan product, 21 on the MTG single-channel layers
and 25 on the RGB composites. Each layer's margin is rounded up from that to
the next multiple of its cadence.

`mtg_fd:rgb_fog` is deliberately **left out**, although low cloud is what most
often decides whether a day starts: over the same measurement it never advanced
at all, standing hours behind the others. No fixed delay describes it — it
wants the time dimension read from `GetCapabilities`, which is a larger change.

## Two supporting commits

* **`ui/canvas/LibPNG: accept gray with an alpha channel`** — the loader had no
  format for 8-bit gray + alpha and threw "Unsupported PNG color type".
  EUMETView returns exactly that for its single-channel layers, so without this
  half the products cannot be drawn. Verified against real responses from all
  six layers.
* **`ui/canvas/GeoBitmap: separate the tile geometry from the loader`** — pure
  code motion, so that asking where a tile is does not require linking the
  canvas. Which tiles cover an area is a question asked while planning
  downloads, and by a unit test, neither of which can pull in OpenGL. (This one
  and the latitude clamp beside it are now in #2998, cherry-picked, so they no
  longer appear here.)
* **`ui/canvas/GeoBitmap: keep a wild longitude inside the tile grid`** —
  `LonToTileX()` cast an unchecked index to `uint32_t`, which is undefined
  outside the type's range. Longitude 180 alone lands one tile past the last
  column. Harmless while the only caller passed map bounds; reachable now that
  tiles are chosen from a GPS position.

## Staleness

Two mechanisms, deliberately different. A tile is replaced only once the new
frame's tile for the same ground has arrived, so a newly published frame never
blanks the overlay for the length of twenty-five requests — on a link that
cannot keep up, a ten minute old cloud picture beats no picture. The hard bound
is the per-layer age limit, measured against the *oldest tile still drawn*
rather than the frame being chased; when it is passed the imagery comes down
**before** a replacement is requested, so a hanging connection cannot leave
hours-old cloud standing.

Unlike the radar, this does not raise a dialog when it expires: a stale echo is
a hazard, a stale cloud picture is not.

## Testing

* `TestEumetviewSatellite`, 47 assertions: ring ordering (own tile first,
  distance never decreasing, no duplicates), block coverage >= 100 km, date-line
  wrap, polar truncation, out-of-grid positions, frame-time rounding and
  midnight wrap, URL shape, and `ServiceExceptionReport` handling.
* **Flown by the reporter of #2997 in the GUI**, which is how three faults came
  to light that no test had: the imagery was unreachable from Info / Weather /
  Overlay where anyone would look for it; zooming out left the block behind; and
  the first tile took over a minute to appear. Measured before and after on the
  running app: **65 s to the first tile, now 5 s** — the download was never the
  problem (25 tiles in 15 s, 0.37 s median each), it was a refresh timer running
  once a minute while there was no GPS fix yet to centre the block on.
* **Exercised in the running application**, not only in tests: a scratch data
  path with `Page0Overlay="6"`, started with `-simulator`. All 25 tiles arrived
  as valid PNGs, and their mtimes give the download order as squared tile
  distance from the aircraft — 0, then 1×4, 2×4, 4×4, 5×8, 8×4, strictly
  monotonic. So the ring ordering holds at runtime and not merely in
  `CollectTiles()`.
* End-to-end against the live service: all 25 tiles of every layer fetch in ring
  order and return valid, non-blank PNGs.
* Errors arrive as a `ServiceExceptionReport` inside an ordinary `200 OK`, so the
  response is checked for a PNG signature before it is believed and the
  exception text is logged — otherwise the XML would be stored as the image and
  fail namelessly in the bitmap loader.
* Whole tree builds clean for `TARGET=MACOS` with both `GEOTIFF=n` and
  `GEOTIFF=y`; `xcsoar` links and `TestOperaRadar` still passes 77/77.

I have not built the Android or Windows targets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rain Radar and Satellite weather map overlays.
  * Added selectable satellite imagery layers with automatic tile downloads, caching, refresh, and attribution.
  * Added radar expiration warnings with an option to disable them.
  * Overlays remain available while panning and refresh automatically.
  * Radar imagery works independently of existing weather credentials.

* **Bug Fixes**
  * Added support for grayscale PNG images with transparency.

* **Documentation**
  * Documented radar and satellite overlay behavior and requirements.

* **Tests**
  * Added radar and satellite imagery coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

