### PR TITLE
Kobo/PowerOff: resolve flight log from data path

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -16,6 +16,9 @@ Version 7.46 - not yet released
   - remove the thin white frame around full-screen dialogs (such as
     the Fly/Simulator screen), which no longer stop one pixel short of
     the display edge
+* Kobo
+  - fix the power-off screen not listing flights after flights.log
+    moved into the logs directory #3001
 * input
   - fix USB HID remotes (e.g. SteFly) that stop sending keys on
     OpenVario after the stick re-enumerates #2820

--- a/build/kobo.mk
+++ b/build/kobo.mk
@@ -55,6 +55,9 @@ ifeq ($(TARGET_IS_KOBO),y)
 KOBO_POWER_OFF_SOURCES = \
 	$(TEST_SRC_DIR)/Fonts.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
+	$(SRC)/DataFilePath.cpp \
+	$(SRC)/LocalPath.cpp \
+	$(SRC)/Repository/FileType.cpp \
 	$(SRC)/Hardware/RotateDisplay.cpp \
 	$(SRC)/Hardware/DisplayDPI.cpp \
 	$(SRC)/Hardware/Battery.cpp \

--- a/src/Kobo/PowerOff.cpp
+++ b/src/Kobo/PowerOff.cpp
@@ -21,6 +21,8 @@
 #include "Model.hpp"
 #include "Hardware/Battery.hpp"
 #include "Hardware/PowerInfo.hpp"
+#include "DataFilePath.hpp"
+#include "LocalPath.hpp"
 #include "util/StringStrip.hxx"
 #include "util/UTF8.hpp"
 
@@ -91,8 +93,9 @@ DrawUserText(Canvas &canvas, PixelRect &rc) noexcept
   std::array<char, 2048> buffer;
 
   std::string_view text;
+  const auto path = LocalPath("kobo/poweroff.txt");
 
-  if (UniqueFileDescriptor fd; fd.OpenReadOnly("/mnt/onboard/XCSoarData/kobo/poweroff.txt")) {
+  if (UniqueFileDescriptor fd; fd.OpenReadOnly(path.c_str())) {
     ssize_t nbytes = fd.Read(std::as_writable_bytes(std::span{buffer}));
     if (nbytes <= 0)
       return;
@@ -133,7 +136,7 @@ DrawUserText(Canvas &canvas, PixelRect &rc) noexcept
 static void
 DrawFlights(Canvas &canvas, const PixelRect &rc)
 try {
-  FileLineReaderA file(Path("/mnt/onboard/XCSoarData/flights.log"));
+  FileLineReaderA file(ResolveLogsDataPath("flights.log"));
 
   FlightListRenderer renderer(normal_font, bold_font);
 
@@ -159,6 +162,8 @@ Draw(Canvas &canvas)
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] char **argv)
 {
+  InitialiseDataPath();
+
   /* enable FreeType anti-aliasing, because we don't use dithering in
      this program */
   FreeType::mono = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Kobo power-off screen so flight information appears correctly after log files are moved to the logs directory.
  * Improved compatibility with configured data and storage locations when displaying power-off messages and flight information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->