### PR TITLE
Android/UsbSerialHelper: relicense to GPL-2.0-or-later

### DIFF
--- a/android/src/UsbSerialHelper.java
+++ b/android/src/UsbSerialHelper.java
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
 package org.xcsoar;

--- a/android/src/UsbSerialPort.java
+++ b/android/src/UsbSerialPort.java
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
 package org.xcsoar;

--- a/src/Android/UsbSerialHelper.cpp
+++ b/src/Android/UsbSerialHelper.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
 #include "UsbSerialHelper.hpp"

--- a/src/Android/UsbSerialHelper.hpp
+++ b/src/Android/UsbSerialHelper.hpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Copyright The XCSoar Project
 
 #pragma once


### PR DESCRIPTION
Closes #3004.

Four files carried `SPDX-License-Identifier: GPL-2.0-only` while the other 3852 source files carry `GPL-2.0-or-later` and 304 carry `BSD-2-Clause`. `README.md` states the project is GPL-2.0-or-later, so these four were out of step with both the tree and the project's own description.

```
android/src/UsbSerialHelper.java
android/src/UsbSerialPort.java
src/Android/UsbSerialHelper.cpp
src/Android/UsbSerialHelper.hpp
```

They were imported from LK8000 in `0884d7ed6` (2021-06-29) and faithfully carried LK8000's header wording of the day, which lacked the "or (at your option) any later version" clause. The SPDX sweep in `94aec80af` (2023-03-21) rendered that wording as `GPL-2.0-only` mechanically, so the tag was never a decision of its own.

Twelve days after the import, LK8000 relaxed the same files upstream to "GPL V2 or later" in `6ddd613fb`, explicitly for Apache-2.0 compatibility. That change never propagated here.

@brunotl, who wrote both the XCSoar import and the LK8000 relicensing, confirmed in #3004:

> I see no reason to keep it under GPL-2.0-only in XCSoar. The change to "GPL-2.0 or later" in LK8000 was intentional, so the XCSoar copy can be updated accordingly.

The change is four lines; no code is touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated licensing terms for USB serial components to allow use under GPL-2.0-or-later.
  * No functional or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->