### PR TITLE
Task/TaskBehaviour: Separate Task MC from Safety MC

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -44,6 +44,7 @@ Version 7.46 - not yet released
 * glide computer
   - add a Task MC setting for the MacCready used at startup, instead
     of copying Safety MC into speed-to-fly #2552
+  - default Safety MC to 3.2 m/s, about 25:1 on the default LS-8 polar
   - fix best-glide speed and speed-to-fly at altitude when MacCready
     is set, so density scaling no longer inflates MacCready #2881
   - fix circling wind staying blank on paragliders and other aircraft

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -71,6 +71,8 @@ Version 7.46 - not yet released
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the
     computed list #2912
+  - show the same terrain reach on the Alternates list as the map,
+    including turning around obstacles
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -89,6 +89,7 @@ Version 7.46 - not yet released
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
   - describe the Task MC setting on the Safety Factors page
+  - clarify that Safety MC is for reach, not speed-to-fly
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,6 +42,8 @@ Version 7.46 - not yet released
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847
 * glide computer
+  - start MacCready at zero instead of copying Safety MC, so reach
+    safety no longer sets speed-to-fly on startup #2552
   - fix best-glide speed and speed-to-fly at altitude when MacCready
     is set, so density scaling no longer inflates MacCready #2881
   - fix circling wind staying blank on paragliders and other aircraft

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -89,7 +89,10 @@ Version 7.46 - not yet released
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
   - describe the Task MC setting on the Safety Factors page
-  - clarify that Safety MC is for reach, not speed-to-fly
+  - clarify Reach polar versus always-Safety-MC (InfoBoxes, waypoint
+    details), and that abort does not copy Safety MC into the ring
+  - describe Reach display options: terrain reach versus thermal-base
+    working line
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,8 +42,8 @@ Version 7.46 - not yet released
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847
 * glide computer
-  - start MacCready at zero instead of copying Safety MC, so reach
-    safety no longer sets speed-to-fly on startup #2552
+  - add a Task MC setting for the MacCready used at startup, instead
+    of copying Safety MC into speed-to-fly #2552
   - fix best-glide speed and speed-to-fly at altitude when MacCready
     is set, so density scaling no longer inflates MacCready #2881
   - fix circling wind staying blank on paragliders and other aircraft
@@ -82,10 +82,12 @@ Version 7.46 - not yet released
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
 * ui
+  - rename Reach polar Task to Task MC, matching Safety MC
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
+  - describe the Task MC setting on the Safety Factors page
 * development
   - documentation: document the release and post-release version workflow
   - macOS/iOS: read TESTING=y from darwin/.env, so Xcode builds can

--- a/doc/lua.rst
+++ b/doc/lua.rst
@@ -456,6 +456,9 @@ The following attributes are provided by ``xcsoar.settings``:
    - Area pressure for barometric altimeter calibration [Pascal].
  * - ``max_temp``
    - The forecast ground temperature [Kelvin].
+ * - ``taskmc``
+   - The MacCready setting used at startup for speed-to-fly and task
+     calculations [:math:`m/s`].
  * - ``safetymc``
    - The MacCready setting used, when safety MC is enabled for reach
      calculations, in task abort mode and for determining arrival

--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -549,7 +549,7 @@ Furthermore, the reach calculations are used for footprint, landable
 waypoint arrival heights, abort mode and the alternates dialogue.  The glider
 performance and MacCready setting used in these calculations are configurable\config{reachpolar}:
 \begin{description}
-\item[Task] The MC value is that used in the task.
+\item[Task MC] The MC value is that used in the task.
 \item[Safety MC] A configurable, typically low MC value is set by the user to set
   performance near, but slightly degraded, to best glide performance. The amount of safety 
   in the reach calculation is then the gap between best glide performance and the glide

--- a/doc/manual/en/ch03_navigation.tex
+++ b/doc/manual/en/ch03_navigation.tex
@@ -494,13 +494,14 @@ element functions in the same way as markers or waypoints.
 
 \section{Glide range line}\label{sec:reach}
 
-A reachable glide `footprint' is displayed on the map display as a
-black and white dashed line, indicating where the glider would descend
-through the terrain clearance height.  The reach shows clearance
-tracks extending in all directions, optionally including paths around
-terrain obstructions.  This feature is useful in assessing range with
-respect to topography when searching low for lift, and when flying in
-mountainous areas.
+A reachable glide `footprint' is displayed on the map as a dashed line,
+indicating where the glider would descend through the terrain clearance
+height (terrain reach).  Reach display can also show a working line: how
+far the glider can fly and still arrive at typical thermal-base height
+from this flight.  The reach shows clearance tracks extending in all
+directions, optionally including paths around terrain obstructions.
+This feature is useful in assessing range with respect to topography when
+searching low for lift, and when flying in mountainous areas.
 
 Reach calculations may be configured \config{turningreach} to two levels of detail:
 \begin{description}
@@ -545,16 +546,18 @@ Note that task calculations are otherwise unaffected by reach
 calculations --- for example, altitudes required as shown in the final
 glide bar or task data as displayed in InfoBoxes do not take reach into account.
 
-Furthermore, the reach calculations are used for footprint, landable
-waypoint arrival heights, abort mode and the alternates dialogue.  The glider
-performance and MacCready setting used in these calculations are configurable\config{reachpolar}:
+Furthermore, terrain reach is used for the footprint, landable waypoint
+colours, abort mode and the Alternates list.  The MacCready used in these
+calculations is configurable\config{reachpolar}:
 \begin{description}
-\item[Task MC] The MC value is that used in the task.
-\item[Safety MC] A configurable, typically low MC value is set by the user to set
-  performance near, but slightly degraded, to best glide performance. The amount of safety 
-  in the reach calculation is then the gap between best glide performance and the glide
-  performance following the safety MC speed to fly. 
+\item[Task MC] The live task MacCready (the same value as speed-to-fly).
+\item[Safety MC] A separate MacCready for conservative reach.  Default is
+  3.2~m/s, about 25:1 on the default LS-8 polar.  Higher values treat fewer
+  fields as reachable.  Speed-to-fly is not affected.
 \end{description}
+The working line always uses Task MC.  Alternate InfoBoxes and the
+waypoint Alt.\ diff.\ MC safety figure always use Safety MC, even if
+Reach polar is Task MC.
 
 \section{Status tabs `\emph{Flight}' and `\emph{Time}'}\label{sec:flight-status}
 

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -703,6 +703,9 @@ options are maintained. They are filtered by the configured ``alternates mode''
 criteria (Simple, Task, or Home). \config{alternatesmode}
 Choosing Task or Home puts some bias on the presentation of alternates to the
 heading, you were taking whilst still task oriented.
+Landable colours and arrival altitude use the same terrain reach as the
+map, including turns around obstacles when Reach mode is Turning.
+\config{turningreach}
 
 As is with every waypoint list, additional information might be called by tapping \bmenuw{Details} before deciding which final to go. Select a waypoint from the list and push \bmenuw{Goto}.
 \sketch{figures/alternates_list.png}

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -153,8 +153,8 @@ altitude required to reach the waypoint at the safety height) for
 the corresponding waypoint:
 \begin{description}
 \item[Alt diff MC 0] Altitude difference at MC setting of~0
-\item[Alt diff MC safety] Altitude difference at the abort/safety MacCready
-  setting (see~\ref{sec:safety-factor})
+\item[Alt diff MC safety] Altitude difference at Safety MC.  This always
+  uses Safety MC, even if Reach polar is Task MC.
 \item[Alt diff MC current] Altitude difference at the current MacCready setting
 \end{description}
 
@@ -676,12 +676,11 @@ command or by invoking the abort mode. In either case, the ordered task might be
 \subsection*{Task Abort}\label{sec:taskabort}
 Invoking the abort mode forces XCSoar to enter a special case of the final glide mode. \menulabelr{\bmenug{Nav 2/2}\blink\bmenug{Task Abort}} For a discussion on
 flight modes refer to Section~\ref{sec:flightmodes}. In this flight mode
-the configuration option `reach polar' determines whether
-waypoint arrival heights in abort mode uses the MacCready value prior
-to aborting the task, or if the safety MacCready value is used. \config{reachpolar}
-Default is to use the safety MacCready value.  When switching to
-abort mode, the MacCready setting is set to the safety value
-if it is lower than the current setting.
+the configuration option Reach polar determines whether
+waypoint arrival heights in abort mode use the live Task MC or Safety MC.
+\config{reachpolar}
+Default is Safety MC.  Abort does not change the MacCready ring;
+speed-to-fly stays on Task MC.
 
 With invoking abort mode the cross-country task is disabled. On the map radials
 are drawn pointing to the nearest landables to instantly

--- a/doc/manual/en/ch05_glide_computer.tex
+++ b/doc/manual/en/ch05_glide_computer.tex
@@ -429,8 +429,8 @@ to safely reach the destination.
 When calculating the arrival heights of landable fields (for map
 display purposes and in abort mode), a safety MacCready value can be
 specified in the configuration settings.  This safety value is set to
-zero by default.  Larger values make the arrival height calculation
-more conservative.
+3.2~m/s by default (about 25:1 on the default LS-8 polar).  Larger
+values make the arrival height calculation more conservative.
 
 
 \section{Final glide calculator}

--- a/doc/manual/en/ch05_glide_computer.tex
+++ b/doc/manual/en/ch05_glide_computer.tex
@@ -412,10 +412,9 @@ landing point either from the waypoint file, or if no height is
 specified in the waypoint file, from the terrain file.
 
 \textbf{The estimated arrival altitude displayed next to landable
-  waypoints is by default calculated for best glide angle at zero
-  MacCready ring setting (MC$=0$), adjusted for wind.  However, a
-  safety MacCready setting may be configured to modify the MacCready
-  setting used in this calculation, as described below.}
+  waypoints uses the Reach polar (Safety MC by default).  Reach polar
+  can be set to Task MC instead.  Safety MC defaults to 3.2~m/s, about
+  25:1 on the default LS-8 polar.}
 
 Landable fields are only marked as reachable if the estimated arrival
 elevation above ground is above the arrival altitude safety height,
@@ -427,10 +426,10 @@ cross) is displayed on the screen, then the glider must climb in order
 to safely reach the destination.
 
 When calculating the arrival heights of landable fields (for map
-display purposes and in abort mode), a safety MacCready value can be
-specified in the configuration settings.  This safety value is set to
-3.2~m/s by default (about 25:1 on the default LS-8 polar).  Larger
-values make the arrival height calculation more conservative.
+display purposes and in abort mode), Reach polar selects Task MC or
+Safety MC.  Safety MC is 3.2~m/s by default (about 25:1 on the default
+LS-8 polar).  Larger values make the arrival height calculation more
+conservative.  Speed-to-fly is not affected.
 
 
 \section{Final glide calculator}

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -463,9 +463,10 @@ of the safety heights. \\
 \item[Task MC]  \label{conf:taskMC} The MacCready setting used at startup for
   speed-to-fly and task calculations.  Safety MC is used only for reach, abort
   and landing arrival.  Default is 0.5~m/s.
-\item[Safety MC*]  When safety MC is enabled, this MacCready setting is used for reach 
-  calculations, task abort, alternates and for determining arrival altitude at airfields.
-  Default is 3.2~m/s (about 25:1 on the default LS-8 polar).\label{conf:safetyMC} 
+\item[Safety MC*]  The MacCready used for reach, abort and landing arrival
+  when Safety MC is selected for reach calculations.  Speed-to-fly is not
+  affected.  Higher values treat fewer fields as reachable.
+  Default is 3.2~m/s, about 25:1 on the default LS-8 polar.\label{conf:safetyMC} 
 \item[STF risk factor*] 
   The STF risk factor reduces the MacCready setting used to calculate
   speed to fly as the glider gets low, in order to compensate for

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -464,7 +464,8 @@ of the safety heights. \\
   speed-to-fly and task calculations.  Safety MC is used only for reach, abort
   and landing arrival.  Default is 0.5~m/s.
 \item[Safety MC*]  When safety MC is enabled, this MacCready setting is used for reach 
-  calculations, task abort, alternates and for determining arrival altitude at airfields.\label{conf:safetyMC} 
+  calculations, task abort, alternates and for determining arrival altitude at airfields.
+  Default is 3.2~m/s (about 25:1 on the default LS-8 polar).\label{conf:safetyMC} 
 \item[STF risk factor*] 
   The STF risk factor reduces the MacCready setting used to calculate
   speed to fly as the glider gets low, in order to compensate for

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -448,24 +448,25 @@ This page allows the safety heights and behaviour for the alternates mode to be 
   the glider must clear during final glide. \\
 See Section~\ref{sec:safety-heights} for more details on the meanings
 of the safety heights. \\
-\item[Alternates mode]  \label{conf:alternatesmode} Determines sorting of alternates 
-  in the alternates dialogue. \\
-  {\bf Simple}: The alternates will only be sorted by arrival height. 
-    The first waypoint in the list is therefore the most reachable waypoint. \\
-  {\bf Task}: The sorting will also take the current task direction into account, 
-    such that the sort order is according to minimum extra distance travelled to 
-    the respective field and onwards to the task. \\
-  {\bf Home}: The sorting will try to find landing options in the current direction 
-    to the configured home waypoint.  Similar to `task' but with 
-    the home field as the desired destination.
+\item[Alternates mode]  \label{conf:alternatesmode} Determines sorting of
+  alternates in the alternates dialogue and in abort mode. \\
+  {\bf Simple}: Reachable airfields are listed first (nearest at top), then
+    outlanding sites (nearest at top). \\
+  {\bf Task}: Reachable airfields are listed first (smallest detour to the
+    active turnpoint at top), then outlanding sites. \\
+  {\bf Home}: Reachable airfields are listed first (smallest detour toward
+    home at top), then outlanding sites.
 \item[Polar degradation*]  A permanent polar degradation. 0\% means no degradation, 
   50\% indicates the glider's sink rate is doubled.
-\item[Task MC]  \label{conf:taskMC} The MacCready setting used at startup for
-  speed-to-fly and task calculations.  Safety MC is used only for reach, abort
-  and landing arrival.  Default is 0.5~m/s.
-\item[Safety MC*]  The MacCready used for reach, abort and landing arrival
-  when Safety MC is selected for reach calculations.  Speed-to-fly is not
-  affected.  Higher values treat fewer fields as reachable.
+\item[Task MC]  \label{conf:taskMC} The MacCready used at startup for
+  speed-to-fly and task calculations.  Changing it here also sets the live
+  MacCready.  Terrain reach, landable colours, abort and the Alternates list
+  follow Reach polar, not this value unless Reach polar is Task MC.
+  Default is 0.5~m/s.
+\item[Safety MC*]  The MacCready used for terrain reach, landable colours,
+  abort and the Alternates list when Reach polar is Safety MC.  Alternate
+  InfoBoxes and waypoint Alt.\ diff.\ MC safety always use this value.
+  Speed-to-fly is not affected.  Higher values treat fewer fields as reachable.
   Default is 3.2~m/s, about 25:1 on the default LS-8 polar.\label{conf:safetyMC} 
 \item[STF risk factor*] 
   The STF risk factor reduces the MacCready setting used to calculate
@@ -567,12 +568,22 @@ optimisations.
   {\bf Off}: Reach calculations disabled. \\
   {\bf Straight}: The reach is from straight line paths from the glider. \\
   {\bf Turning}: The reach is calculated allowing turns around terrain obstacles.
-\item[Reach display]  \label{conf:gliderange} This determines whether the
-glide reach is drawn as a line resp.\ a shade on the map area.
-\item[Reach polar*]  \label{conf:reachpolar} This determines the glide performance 
-  used in reach, landable arrival, abort and alternate calculations. \\
-  {\bf Task MC}: Uses task MacCready value; \\
+\item[Reach polar*]  \label{conf:reachpolar} Which MacCready is used for
+  terrain reach, landable colours, abort and the Alternates list.
+  The working line always uses Task MC.  Alternate InfoBoxes and waypoint
+  Alt.\ diff.\ MC safety always use Safety MC. \\
+  {\bf Task MC}: Uses task MacCready value. \\
   {\bf Safety MC}: Uses safety MacCready value.
+\item[Reach display]  \label{conf:gliderange} How the glide reach is drawn
+  on the map. Terrain reach uses the Reach polar down to the ground.
+  Working reach is how far you can glide and still arrive at typical
+  thermal-base height from this flight; it always uses Task MC. \\
+  {\bf Off}: No reach overlay on the map. \\
+  {\bf Terrain line}: How far you can glide to the ground. Uses the Reach polar. \\
+  {\bf Terrain shade}: Shades the map beyond glide to the ground. Uses the Reach polar. \\
+  {\bf Working line}: How far you can glide and still arrive at typical thermal-base height from this flight. Always uses Task MC. \\
+  {\bf Working line, terrain line}: Working line to typical thermal-base height using Task MC, plus terrain line to the ground using the Reach polar. \\
+  {\bf Working line, terrain shade}: Working line to typical thermal-base height using Task MC, plus shade beyond the ground using the Reach polar.
 \end{description}
 
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -566,8 +566,10 @@ optimisations.
 \item[Reach mode]  \label{conf:turningreach} How calculations are performed of 
   the reach of the glider with respect to terrain. \\
   {\bf Off}: Reach calculations disabled. \\
-  {\bf Straight}: The reach is from straight line paths from the glider. \\
+  {\bf Straight}: The reach is from straight line paths from the glider.
+    Landable colours and the Alternates list use this reach. \\
   {\bf Turning}: The reach is calculated allowing turns around terrain obstacles.
+    Landable colours and the Alternates list use this reach.
 \item[Reach polar*]  \label{conf:reachpolar} Which MacCready is used for
   terrain reach, landable colours, abort and the Alternates list.
   The working line always uses Task MC.  Alternate InfoBoxes and waypoint

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -460,6 +460,9 @@ of the safety heights. \\
     the home field as the desired destination.
 \item[Polar degradation*]  A permanent polar degradation. 0\% means no degradation, 
   50\% indicates the glider's sink rate is doubled.
+\item[Task MC]  \label{conf:taskMC} The MacCready setting used at startup for
+  speed-to-fly and task calculations.  Safety MC is used only for reach, abort
+  and landing arrival.  Default is zero (best glide).
 \item[Safety MC*]  When safety MC is enabled, this MacCready setting is used for reach 
   calculations, task abort, alternates and for determining arrival altitude at airfields.\label{conf:safetyMC} 
 \item[STF risk factor*] 
@@ -566,7 +569,7 @@ optimisations.
 glide reach is drawn as a line resp.\ a shade on the map area.
 \item[Reach polar*]  \label{conf:reachpolar} This determines the glide performance 
   used in reach, landable arrival, abort and alternate calculations. \\
-  {\bf Task}: Uses task MacCready value; \\
+  {\bf Task MC}: Uses task MacCready value; \\
   {\bf Safety MC}: Uses safety MacCready value.
 \end{description}
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -462,7 +462,7 @@ of the safety heights. \\
   50\% indicates the glider's sink rate is doubled.
 \item[Task MC]  \label{conf:taskMC} The MacCready setting used at startup for
   speed-to-fly and task calculations.  Safety MC is used only for reach, abort
-  and landing arrival.  Default is zero (best glide).
+  and landing arrival.  Default is 0.5~m/s.
 \item[Safety MC*]  When safety MC is enabled, this MacCready setting is used for reach 
   calculations, task abort, alternates and for determining arrival altitude at airfields.\label{conf:safetyMC} 
 \item[STF risk factor*] 

--- a/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
@@ -111,9 +111,11 @@ RouteConfigPanel::Prepare(ContainerWindow &parent,
     { RoutePlannerConfig::ReachMode::OFF, N_("Off"),
       N_("Reach calculations disabled.") },
     { RoutePlannerConfig::ReachMode::STRAIGHT, N_("Straight"),
-      N_("The reach is from straight line paths from the glider.") },
+      N_("The reach is from straight line paths from the glider. "
+         "Landable colours and the Alternates list use this reach.") },
     { RoutePlannerConfig::ReachMode::TURNING, N_("Turning"),
-      N_("The reach is calculated allowing turns around terrain obstacles.") },
+      N_("The reach is calculated allowing turns around terrain obstacles. "
+         "Landable colours and the Alternates list use this reach.") },
     nullptr
   };
 

--- a/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
@@ -125,8 +125,8 @@ RouteConfigPanel::Prepare(ContainerWindow &parent,
           this);
 
   static constexpr StaticEnumChoice reach_polar_list[] = {
-    { RoutePlannerConfig::Polar::TASK, N_("Task"),
-      N_("Uses task glide polar.") },
+    { RoutePlannerConfig::Polar::TASK, N_("Task MC"),
+      N_("Uses task MacCready value.") },
     { RoutePlannerConfig::Polar::SAFETY, N_("Safety MC"),
       N_("Uses safety MacCready value.") },
     nullptr

--- a/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/RouteConfigPanel.cpp
@@ -133,23 +133,31 @@ RouteConfigPanel::Prepare(ContainerWindow &parent,
   };
 
   AddEnum(_("Reach polar"),
-          _("This determines the glide performance used in reach, landable arrival, abort and alternate calculations."),
+          _("Which MacCready is used for terrain reach, landable "
+            "colours, abort and the Alternates list. The working line "
+            "always uses Task MC. Alternate InfoBoxes and waypoint "
+            "Alt. diff. MC safety always use Safety MC."),
           reach_polar_list, (unsigned)route_planner.reach_polar_mode);
   SetExpertRow(ReachPolarMode);
 
   static constexpr StaticEnumChoice final_glide_terrain_list[] = {
     { FeaturesSettings::FinalGlideTerrain::OFF, N_("Off"),
-      N_("Disables the reach display.") },
+      N_("No reach overlay on the map.") },
     { FeaturesSettings::FinalGlideTerrain::TERRAIN_LINE, N_("Terrain line"),
-      N_("Draws a dashed line at the terrain glide reach.") },
+      N_("How far you can glide to the ground. Uses the Reach polar.") },
     { FeaturesSettings::FinalGlideTerrain::TERRAIN_SHADE, N_("Terrain shade"),
-      N_("Shades terrain outside glide reach.") },
+      N_("Shades the map beyond glide to the ground. Uses the Reach polar.") },
     { FeaturesSettings::FinalGlideTerrain::WORKING, N_("Working line"),
-      N_("Draws a dashed line at the working glide reach.") },
-    { FeaturesSettings::FinalGlideTerrain::WORKING_TERRAIN_LINE, N_("Working line, terrain line"),
-      N_("Draws a dashed line at the working and terrain glide reaches.") },
-    { FeaturesSettings::FinalGlideTerrain::WORKING_TERRAIN_SHADE, N_("Working line, terrain shade"),
-      N_("Draws a dashed line at working, and shade terrain, glide reaches.") },
+      N_("How far you can glide and still arrive at typical thermal-base "
+         "height from this flight. Always uses Task MC.") },
+    { FeaturesSettings::FinalGlideTerrain::WORKING_TERRAIN_LINE,
+      N_("Working line, terrain line"),
+      N_("Working line to typical thermal-base height using Task MC, plus "
+         "terrain line to the ground using the Reach polar.") },
+    { FeaturesSettings::FinalGlideTerrain::WORKING_TERRAIN_SHADE,
+      N_("Working line, terrain shade"),
+      N_("Working line to typical thermal-base height using Task MC, plus "
+         "shade beyond the ground using the Reach polar.") },
     nullptr
   };
 

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -15,6 +15,7 @@
 #include "UIGlobals.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "ActionInterface.hpp"
 
 enum ControlIndex {
   ArrivalHeight,
@@ -22,6 +23,7 @@ enum ControlIndex {
   AlternateMode,
   PolarDegradation,
   AutoBugs,
+  TaskMC,
   SafetyMC,
   RiskFactor,
   TurnBackMarker,
@@ -89,6 +91,16 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
              settings_computer.polar.auto_bugs);
   SetExpertRow(AutoBugs);
 
+  AddFloat(_("Task MC"),
+           _("The MacCready setting used at startup for speed-to-fly "
+             "and task calculations. Safety MC is used only for reach, "
+             "abort and landing arrival."),
+           "%.1f %s", "%.1f",
+           0, Units::ToUserVSpeed(10), GetUserVerticalSpeedStep(),
+           false, UnitGroup::VERTICAL_SPEED, task_behaviour.task_mc);
+  DataFieldFloat &task_mc = (DataFieldFloat &)GetDataField(TaskMC);
+  task_mc.SetFormat(GetUserVerticalSpeedFormat(false, false));
+
   AddFloat(_("Safety MC"),
            _("The MacCready setting used, when safety MC is enabled for reach calculations, in task abort mode and for determining arrival altitude at airfields."),
            "%.1f %s", "%.1f",
@@ -145,6 +157,13 @@ SafetyFactorsConfigPanel::Save(bool &_changed) noexcept
 
   if (SaveValue(AutoBugs, settings_computer.polar.auto_bugs)) {
     Profile::Set(ProfileKeys::AutoBugs, settings_computer.polar.auto_bugs);
+    changed = true;
+  }
+
+  if (SaveValue(TaskMC, UnitGroup::VERTICAL_SPEED, task_behaviour.task_mc)) {
+    Profile::Set(ProfileKeys::TaskMacCready,
+                 iround(task_behaviour.task_mc * 10));
+    ActionInterface::SetMacCready(task_behaviour.task_mc);
     changed = true;
   }
 

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -92,9 +92,11 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
   SetExpertRow(AutoBugs);
 
   AddFloat(_("Task MC"),
-           _("The MacCready setting used at startup for speed-to-fly "
-             "and task calculations. Safety MC is used only for reach, "
-             "abort and landing arrival."),
+           _("The MacCready used at startup for speed-to-fly and task "
+             "calculations. Changing it here also sets the live "
+             "MacCready. Terrain reach, landable colours, abort and the "
+             "Alternates list follow Reach polar, not this value unless "
+             "Reach polar is Task MC."),
            "%.1f %s", "%.1f",
            0, Units::ToUserVSpeed(10), GetUserVerticalSpeedStep(),
            false, UnitGroup::VERTICAL_SPEED, task_behaviour.task_mc);
@@ -102,10 +104,11 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
   task_mc.SetFormat(GetUserVerticalSpeedFormat(false, false));
 
   AddFloat(_("Safety MC"),
-           _("The MacCready used for reach, abort and landing arrival "
-             "when Safety MC is selected for reach calculations. "
-             "Speed-to-fly is not affected. Higher values treat fewer "
-             "fields as reachable."),
+           _("The MacCready used for terrain reach, landable colours, "
+             "abort and the Alternates list when Reach polar is Safety "
+             "MC. Alternate InfoBoxes and waypoint Alt. diff. MC safety "
+             "always use this value. Speed-to-fly is not affected. "
+             "Higher values treat fewer fields as reachable."),
            "%.1f %s", "%.1f",
            0, Units::ToUserVSpeed(10), GetUserVerticalSpeedStep(),
            false, UnitGroup::VERTICAL_SPEED, task_behaviour.safety_mc);

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -102,7 +102,10 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
   task_mc.SetFormat(GetUserVerticalSpeedFormat(false, false));
 
   AddFloat(_("Safety MC"),
-           _("The MacCready setting used, when safety MC is enabled for reach calculations, in task abort mode and for determining arrival altitude at airfields."),
+           _("The MacCready used for reach, abort and landing arrival "
+             "when Safety MC is selected for reach calculations. "
+             "Speed-to-fly is not affected. Higher values treat fewer "
+             "fields as reachable."),
            "%.1f %s", "%.1f",
            0, Units::ToUserVSpeed(10), GetUserVerticalSpeedStep(),
            false, UnitGroup::VERTICAL_SPEED, task_behaviour.safety_mc);

--- a/src/Dialogs/Task/AlternatesListDialog.cpp
+++ b/src/Dialogs/Task/AlternatesListDialog.cpp
@@ -4,6 +4,7 @@
 #include "TaskDialogs.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
+#include "Dialogs/Waypoint/GetWaypointReachability.hpp"
 #include "Form/Form.hpp"
 #include "InfoBoxes/Content/Alternate.hpp"
 #include "Widget/ListWidget.hpp"
@@ -115,12 +116,21 @@ public:
     const ComputerSettings &settings = CommonInterface::GetComputerSettings();
     const Waypoint &waypoint = *alternates[index].waypoint;
     const GlideResult& solution = alternates[index].solution;
+    const auto reach = GetWaypointReach(waypoint);
+
+    double arrival_altitude =
+      solution.SelectAltitudeDifference(settings.task.glide);
+    if (reach.result.terrain_valid == ReachResult::Validity::VALID)
+      arrival_altitude = reach.result.terrain;
+    else if (reach.reachability != WaypointReachability::INVALID)
+      arrival_altitude = reach.result.direct;
 
     WaypointListRenderer::Draw(canvas, rc, waypoint, solution.vector.distance,
-                               solution.SelectAltitudeDifference(settings.task.glide),
+                               arrival_altitude,
                                row_renderer,
                                UIGlobals::GetMapLook().waypoint,
-                               CommonInterface::GetMapSettings().waypoint);
+                               CommonInterface::GetMapSettings().waypoint,
+                               reach.reachability);
   }
 
   bool CanActivateItem([[maybe_unused]] unsigned index) const noexcept override {

--- a/src/Dialogs/Waypoint/GetWaypointReachability.cpp
+++ b/src/Dialogs/Waypoint/GetWaypointReachability.cpp
@@ -8,11 +8,11 @@
 #include "Components.hpp"
 #include "Interface.hpp"
 
-WaypointReachability
-GetWaypointReachability(const Waypoint &waypoint) noexcept
+WaypointReach
+GetWaypointReach(const Waypoint &waypoint) noexcept
 {
   if (!waypoint.IsLandable() && !waypoint.flags.watched)
-    return WaypointReachability::INVALID;
+    return {};
 
   const auto *glide_computer = backend_components != nullptr
     ? backend_components->glide_computer.get()
@@ -25,5 +25,5 @@ GetWaypointReachability(const Waypoint &waypoint) noexcept
                                 : nullptr,
                                 CommonInterface::Basic(),
                                 CommonInterface::Calculated(),
-                                settings.polar, settings.task).reachability;
+                                settings.polar, settings.task);
 }

--- a/src/Dialogs/Waypoint/GetWaypointReachability.hpp
+++ b/src/Dialogs/Waypoint/GetWaypointReachability.hpp
@@ -8,10 +8,20 @@
 struct Waypoint;
 
 /**
- * Reachability for drawing a waypoint icon in a dialog, using the
- * same calculation as the map (current aircraft state and route
- * planner when available).
+ * Reach for drawing a waypoint in a dialog, using the same
+ * calculation as the map (current aircraft state and route planner
+ * when available).
  */
 [[nodiscard]]
-WaypointReachability
-GetWaypointReachability(const Waypoint &waypoint) noexcept;
+WaypointReach
+GetWaypointReach(const Waypoint &waypoint) noexcept;
+
+/**
+ * Reachability enum for drawing a waypoint icon in a dialog.
+ */
+[[nodiscard]]
+inline WaypointReachability
+GetWaypointReachability(const Waypoint &waypoint) noexcept
+{
+  return GetWaypointReach(waypoint).reachability;
+}

--- a/src/Dialogs/dlgQuickGuide.cpp
+++ b/src/Dialogs/dlgQuickGuide.cpp
@@ -183,6 +183,8 @@ SafetyFactorsDifferFromDefaults() noexcept
     return true;
   if (p.auto_bugs != d_pol.auto_bugs)
     return true;
+  if (std::abs(t.task_mc - d_task.task_mc) > eps)
+    return true;
   if (std::abs(t.safety_mc - d_task.safety_mc) > eps)
     return true;
   if (std::abs(t.risk_gamma - d_task.risk_gamma) > eps)

--- a/src/Engine/Route/Config.hpp
+++ b/src/Engine/Route/Config.hpp
@@ -37,7 +37,10 @@ struct RoutePlannerConfig
       straight line */
   ReachMode reach_calc_mode;
 
-  /** Whether reach/abort calculations will use the task or safety polar */
+  /**
+   * Task MC or Safety MC for terrain reach, landable colours, abort
+   * and the Alternates list. Working reach always uses Task MC.
+   */
   Polar reach_polar_mode;
 
   void SetDefaults();

--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -36,7 +36,7 @@ TaskBehaviour::SetDefaults()
   calc_glide_required = true;
   goto_nonlandable = true;
   risk_gamma = 0;
-  task_mc = 0;
+  task_mc = 0.5;
   safety_mc = 0.5;
   safety_height_arrival = 300;
   task_type_default = TaskFactoryType::RACING;

--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -36,6 +36,7 @@ TaskBehaviour::SetDefaults()
   calc_glide_required = true;
   goto_nonlandable = true;
   risk_gamma = 0;
+  task_mc = 0;
   safety_mc = 0.5;
   safety_height_arrival = 300;
   task_type_default = TaskFactoryType::RACING;

--- a/src/Engine/Task/TaskBehaviour.cpp
+++ b/src/Engine/Task/TaskBehaviour.cpp
@@ -37,7 +37,8 @@ TaskBehaviour::SetDefaults()
   goto_nonlandable = true;
   risk_gamma = 0;
   task_mc = 0.5;
-  safety_mc = 0.5;
+  /* About 25:1 still-air L/D on the default LS-8 (15m) polar. */
+  safety_mc = 3.2;
   safety_height_arrival = 300;
   task_type_default = TaskFactoryType::RACING;
   start_margins.SetDefaults();

--- a/src/Engine/Task/TaskBehaviour.hpp
+++ b/src/Engine/Task/TaskBehaviour.hpp
@@ -95,6 +95,12 @@ struct TaskBehaviour {
   /** Compensation factor for risk at low altitude */
   double risk_gamma;
 
+  /**
+   * MacCready value (m/s) applied to the task polar at startup for
+   * speed-to-fly and task calculations.
+   */
+  double task_mc;
+
   /** Safety MacCready value (m/s) used by abort task */
   double safety_mc;
 

--- a/src/Engine/Task/TaskBehaviour.hpp
+++ b/src/Engine/Task/TaskBehaviour.hpp
@@ -101,7 +101,11 @@ struct TaskBehaviour {
    */
   double task_mc;
 
-  /** Safety MacCready value (m/s) used by abort task */
+  /**
+   * Safety MacCready (m/s) for terrain reach, landable colours, abort
+   * and the Alternates list when Reach polar is Safety MC.  Alternate
+   * InfoBoxes and waypoint Alt. diff. MC safety always use this value.
+   */
   double safety_mc;
 
   /** Minimum height above terrain for arrival height at landable waypoint (m) */

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1153,7 +1153,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Alternate 1 altitude difference"),
     N_("Altn 1 AltD"),
-    N_("Arrival altitude at the best alternate landing location relative to the safety arrival height."),
+    N_("Arrival altitude at the best alternate landing location using Safety MC, relative to the safety arrival height."),
     []() noexcept -> InfoBoxContent * {
       return new InfoBoxContentAlternateAltDiff(AlternateInfoBoxSlot::FIRST);
     },
@@ -1163,7 +1163,7 @@ static constexpr MetaData meta_data[] = {
   {
     N_("Alternate 2 altitude difference"),
     N_("Altn 2 AltD"),
-    N_("Arrival altitude at the second-best alternate landing location relative to the safety arrival height."),
+    N_("Arrival altitude at the second-best alternate landing location using Safety MC, relative to the safety arrival height."),
     []() noexcept -> InfoBoxContent * {
       return new InfoBoxContentAlternateAltDiff(AlternateInfoBoxSlot::SECOND);
     },

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -185,6 +185,7 @@ constexpr std::string_view EnableNavBaroAltitude = "EnableNavBaroAltitude";
 constexpr std::string_view LoggerTimeStepCruise = "LoggerTimeStepCruise";
 constexpr std::string_view LoggerTimeStepCircling = "LoggerTimeStepCircling";
 
+constexpr std::string_view TaskMacCready = "TaskMacCready";
 constexpr std::string_view SafetyMacCready = "SafetyMacCready";
 constexpr std::string_view AbortTaskMode = "AbortTaskMode";
 constexpr std::string_view AutoMcMode = "AutoMcMode";

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -78,6 +78,9 @@ Profile::Load(const ProfileMap &map, TaskBehaviour &settings)
   if (map.Get(ProfileKeys::RiskGamma, Temp))
     settings.risk_gamma = Temp / 10.;
 
+  if (map.Get(ProfileKeys::TaskMacCready, Temp))
+    settings.task_mc = Temp / 10.;
+
   if (map.Get(ProfileKeys::SafetyMacCready, Temp))
     settings.safety_mc = Temp / 10.;
 

--- a/src/Renderer/WaypointListRenderer.cpp
+++ b/src/Renderer/WaypointListRenderer.cpp
@@ -117,7 +117,8 @@ WaypointListRenderer::Draw(Canvas &canvas, PixelRect rc,
                            double arrival_altitude,
                            const TwoTextRowsRenderer &row_renderer,
                            const WaypointLook &look,
-                           const WaypointRendererSettings &settings)
+                           const WaypointRendererSettings &settings,
+                           WaypointReachability reachable)
 {
   const unsigned padding = Layout::GetTextPadding();
   const unsigned line_height = rc.GetHeight();
@@ -129,9 +130,10 @@ WaypointListRenderer::Draw(Canvas &canvas, PixelRect rc,
   const PixelPoint pt(rc.left + line_height / 2,
                       rc.top + line_height / 2);
 
-  const auto reachable = arrival_altitude > 0
-    ? WaypointReachability::TERRAIN
-    : WaypointReachability::UNREACHABLE;
+  if (reachable == WaypointReachability::INVALID)
+    reachable = arrival_altitude > 0
+      ? WaypointReachability::TERRAIN
+      : WaypointReachability::UNREACHABLE;
 
   WaypointIconRenderer wir(settings, look, canvas);
   wir.SetIconSize(icon_size);

--- a/src/Renderer/WaypointListRenderer.hpp
+++ b/src/Renderer/WaypointListRenderer.hpp
@@ -32,5 +32,6 @@ namespace WaypointListRenderer
             double distance, double arrival_altitude,
             const TwoTextRowsRenderer &row_renderer,
             const WaypointLook &look,
-            const WaypointRendererSettings &settings);
+            const WaypointRendererSettings &settings,
+            WaypointReachability reachable=WaypointReachability::INVALID);
 }

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -577,7 +577,6 @@ Startup(UI::Display &display)
 
   GlidePolar &gp = CommonInterface::SetComputerSettings().polar.glide_polar_task;
   gp = GlidePolar(0);
-  gp.SetMC(computer_settings.task.safety_mc);
   gp.SetBugs(computer_settings.polar.degradation_factor);
   gp.SetCrewMass(computer_settings.logger.crew_mass_template);
   PlaneGlue::FromProfile(CommonInterface::SetComputerSettings().plane,

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -577,6 +577,7 @@ Startup(UI::Display &display)
 
   GlidePolar &gp = CommonInterface::SetComputerSettings().polar.glide_polar_task;
   gp = GlidePolar(0);
+  gp.SetMC(computer_settings.task.task_mc);
   gp.SetBugs(computer_settings.polar.degradation_factor);
   gp.SetCrewMass(computer_settings.logger.crew_mass_template);
   PlaneGlue::FromProfile(CommonInterface::SetComputerSettings().plane,

--- a/src/lua/Settings.cpp
+++ b/src/lua/Settings.cpp
@@ -54,6 +54,14 @@ l_settings_index(lua_State *L)
         CommonInterface::GetComputerSettings();
     
       Lua::Push(L, settings_computer.forecast_temperature.ToKelvin());
+  } else if (StringIsEqual(name, "taskmc")) {
+      /* The MacCready setting used at startup for speed-to-fly and
+         task calculations. */
+      const ComputerSettings &settings_computer =
+        CommonInterface::GetComputerSettings();
+      const TaskBehaviour &task_behaviour = settings_computer.task;
+
+      Lua::Push(L, task_behaviour.task_mc);
   } else if (StringIsEqual(name, "safetymc")) {
       /* The MacCready setting used, when safety MC is enabled 
          for reach calculations, in task abort mode and for 


### PR DESCRIPTION
## Summary
- Stop copying Safety MC into speed-to-fly at startup; add a Task MC setting (default 0.5 m/s) for the MacCready used at launch.
- Raise the Safety MC default to 3.2 m/s (~25:1 still-air L/D on the default LS-8 polar) for reach, abort, and landable arrival only.
- Label Reach polar **Task MC** (was Task) so it matches Safety MC.

Fixes #2552

This does not replace Safety MC with a user-facing safety glide ratio. Reach polar can still be Task MC or Safety MC; speed-to-fly stays on Task MC / the live ring.

## Test plan
- [ ] Fresh profile: Task MC is 0.5 m/s, Safety MC is 3.2 m/s; MacCready InfoBox matches Task MC after startup, not Safety MC.
- [ ] Changing Task MC on Config → Glide Computer → Safety Factors updates live MC; changing Safety MC does not.
- [ ] Reach polar Task MC vs Safety MC still switches landable/reach maths; working line still uses Task MC.
- [ ] Existing profile with a saved SafetyMacCready keeps that value (only new profiles get 3.2).
- [ ] Lua `xcsoar.settings.taskmc` is readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable **Task MC** for startup speed-to-fly and task calculations, defaulting to 0.5 m/s.
  * Exposed Task MC through the Lua settings API.
* **Updates**
  * Renamed the Reach polar option to **Task MC**.
  * Changed the default **Safety MC** to 3.2 m/s.
  * Clarified Reach display modes, working-line behavior, alternate calculations, landable colors, and abort-mode handling.
  * Updated the Safety Factors screen and manuals with revised settings guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->