### PR TITLE
PageSettings: Add per-page terrain setting overrides

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,9 @@
 Version 7.46 - not yet released
+* ui
+  - allow overriding all Map Display → Terrain settings per page
+    (terrain, topography, colors, slope shading, contrast, brightness,
+    contours) via Config → Pages → Custom settings; the editor is a
+    scrollable full-screen page with an Add button
 * android
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit

--- a/build/main.mk
+++ b/build/main.mk
@@ -354,6 +354,7 @@ XCSOAR_SOURCES := \
 	$(SRC)/Input/InputParser.cpp \
 	$(SRC)/Input/TaskEventObserver.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(SRC)/PageSetting.cpp \
 	$(SRC)/PageOverlayTitle.cpp \
 	$(SRC)/PageState.cpp \
 	$(SRC)/PageActions.cpp \

--- a/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/PagesConfigPanel.cpp
@@ -3,13 +3,21 @@
 
 #include "PagesConfigPanel.hpp"
 #include "Dialogs/Message.hpp"
+#include "Dialogs/ComboPicker.hpp"
+#include "Dialogs/WidgetDialog.hpp"
+#include "Form/DataField/ComboList.hpp"
 #include "Look/DialogLook.hpp"
+#include "util/StaticArray.hxx"
+#include "util/Compiler.h"
+#include "util/StringFormat.hpp"
 #include "Renderer/TextRowRenderer.hpp"
 #include "Form/Button.hpp"
 #include "Form/ButtonPanel.hpp"
 #include "Form/DataField/Enum.hpp"
 #include "Form/DataField/Listener.hpp"
 #include "PageActions.hpp"
+#include "PageSetting.hpp"
+#include "PageSettingDescriptor.hpp"
 #include "Language/Language.hpp"
 #include "Profile/PageProfile.hpp"
 #include "Profile/Current.hpp"
@@ -27,6 +35,7 @@
 #include "Widget/ListWidget.hpp"
 #include "Widget/TwoWidgets.hpp"
 #include "Widget/ButtonPanelWidget.hpp"
+#include "Widget/VScrollWidget.hpp"
 #include "UIGlobals.hpp"
 #include "util/StaticString.hxx"
 
@@ -34,10 +43,143 @@
 #include "Weather/SkySight/SkySightClient.hpp"
 #endif
 
+#include <cassert>
+
 /* this macro exists in the WIN32 API */
 #ifdef DELETE
 #undef DELETE
 #endif
+
+static constexpr unsigned CHOICE_GLOBAL = 0xffff;
+
+class PageCustomSettingsWidget;
+
+static void
+ShowPageCustomSettingsDialog(PageSettingOverrides &overrides) noexcept;
+
+/**
+ * Hosts a scrollable custom-settings form and can remeasure after rows
+ * are shown or hidden.
+ */
+class PageCustomSettingsHost final : public NullWidget {
+  std::unique_ptr<VScrollWidget> scroll;
+  PageCustomSettingsWidget *form = nullptr;
+  PixelRect position{};
+  bool visible = false;
+
+public:
+  PageCustomSettingsHost(const DialogLook &look,
+                         PageSettingOverrides &overrides) noexcept;
+
+  void RefreshLayout() noexcept {
+    if (visible)
+      scroll->Move(position);
+  }
+
+  PageCustomSettingsWidget &GetForm() noexcept {
+    return *form;
+  }
+
+  PixelSize GetMinimumSize() const noexcept override {
+    return scroll->GetMinimumSize();
+  }
+
+  PixelSize GetMaximumSize() const noexcept override {
+    return scroll->GetMaximumSize();
+  }
+
+  void Initialise(ContainerWindow &parent,
+                  const PixelRect &rc) noexcept override {
+    position = rc;
+    scroll->Initialise(parent, rc);
+  }
+
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override {
+    position = rc;
+    scroll->Prepare(parent, rc);
+  }
+
+  void Unprepare() noexcept override {
+    scroll->Unprepare();
+  }
+
+  bool Save(bool &changed) noexcept override {
+    return scroll->Save(changed);
+  }
+
+  void Show(const PixelRect &rc) noexcept override {
+    position = rc;
+    visible = true;
+    scroll->Show(rc);
+  }
+
+  void Hide() noexcept override {
+    visible = false;
+    scroll->Hide();
+  }
+
+  void Move(const PixelRect &rc) noexcept override {
+    position = rc;
+    scroll->Move(rc);
+  }
+
+  bool SetFocus() noexcept override {
+    return scroll->SetFocus();
+  }
+
+  bool HasFocus() const noexcept override {
+    return scroll->HasFocus();
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    return scroll->KeyPress(key_code);
+  }
+};
+
+class PageCustomSettingsWidget final
+  : public RowFormWidget, private DataFieldListener {
+  PageSettingOverrides &overrides;
+  PageCustomSettingsHost *host = nullptr;
+  Button *add_button = nullptr;
+  Button *delete_button = nullptr;
+  int selected_control = -1;
+
+  void FillControl(PageSettingId id, unsigned control) noexcept;
+  void SyncRows() noexcept;
+  void UpdateActionButtons() noexcept;
+  void OnAddClicked() noexcept;
+  void OnDeleteClicked() noexcept;
+  void SelectControl(unsigned control) noexcept;
+
+public:
+  PageCustomSettingsWidget(const DialogLook &_look,
+                           PageSettingOverrides &_overrides) noexcept
+    :RowFormWidget(_look), overrides(_overrides) {}
+
+  void SetHost(PageCustomSettingsHost &_host) noexcept {
+    host = &_host;
+  }
+
+  void SetActionButtons(Button &_add, Button &_delete) noexcept {
+    add_button = &_add;
+    delete_button = &_delete;
+    UpdateActionButtons();
+  }
+
+  void AddClicked() noexcept {
+    OnAddClicked();
+  }
+
+  void DeleteClicked() noexcept {
+    OnDeleteClicked();
+  }
+
+  void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+
+private:
+  void OnModified(DataField &df) noexcept override;
+};
 
 class PageLayoutEditWidget final
   : public RowFormWidget, private DataFieldListener {
@@ -54,25 +196,31 @@ private:
     BOTTOM,
     OVERLAY,
     OVERLAY_DETAIL,
+    CUSTOM_SETTINGS,
   };
 
   static constexpr unsigned IBP_NONE = 0x7000;
   static constexpr unsigned IBP_AUTO = 0x7001;
 
   PageLayout value;
+  PageSettingOverrides *overrides = nullptr;
+  unsigned page_index = 0;
 
   Listener &listener;
 
   void UpdateOverlayControls() noexcept;
   void FillOverlayDetailControl() noexcept;
   void ApplyValueToForm() noexcept;
+  void UpdateCustomSettingsButton() noexcept;
+  void OnCustomSettingsClicked() noexcept;
 
 public:
   PageLayoutEditWidget(const DialogLook &_look, Listener &_listener)
     :RowFormWidget(_look), value(PageLayout::Default()),
      listener(_listener) {}
 
-  void SetValue(const PageLayout &_value);
+  void SetValue(unsigned index, const PageLayout &_value,
+                PageSettingOverrides &_overrides);
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
@@ -116,6 +264,7 @@ public:
       if (n < PageSettings::MAX_PAGES) {
         auto &page = settings.pages[n];
         page = PageLayout::Default();
+        settings.overrides[n].Clear();
         GetList().SetLength(n + 1);
         GetList().SetCursorIndex(n);
       }
@@ -128,12 +277,17 @@ public:
         std::copy(settings.pages.begin() + cursor + 1,
                   settings.pages.begin() + n,
                   settings.pages.begin() + cursor);
+        std::copy(settings.overrides.begin() + cursor + 1,
+                  settings.overrides.begin() + n,
+                  settings.overrides.begin() + cursor);
+        settings.overrides[n - 1].Clear();
         GetList().SetLength(n - 1);
 
         if (cursor == n - 1)
           GetList().SetCursorIndex(cursor - 1);
         else
-          editor->SetValue(settings.pages[cursor]);
+          editor->SetValue(cursor, settings.pages[cursor],
+                           settings.overrides[cursor]);
       }
     });
 
@@ -141,6 +295,8 @@ public:
       const unsigned cursor = GetList().GetCursorIndex();
       if (cursor > 0) {
         std::swap(settings.pages[cursor], settings.pages[cursor - 1]);
+        std::swap(settings.overrides[cursor],
+                  settings.overrides[cursor - 1]);
         GetList().SetCursorIndex(cursor - 1);
       }
     });
@@ -150,6 +306,8 @@ public:
       const unsigned cursor = GetList().GetCursorIndex();
       if (cursor + 1 < n) {
         std::swap(settings.pages[cursor], settings.pages[cursor + 1]);
+        std::swap(settings.overrides[cursor],
+                  settings.overrides[cursor + 1]);
         GetList().SetCursorIndex(cursor + 1);
       }
     });
@@ -455,11 +613,19 @@ PageLayoutEditWidget::Prepare([[maybe_unused]] ContainerWindow &parent, [[maybe_
   GetControl(OVERLAY_DETAIL).GetDataField()->EnableItemHelp(true);
   FillOverlayDetailControl();
   UpdateOverlayControls();
+
+  AddButton(_("Custom settings"), [this](){
+    OnCustomSettingsClicked();
+  });
+  UpdateCustomSettingsButton();
 }
 
 void
-PageLayoutEditWidget::SetValue(const PageLayout &_value)
+PageLayoutEditWidget::SetValue(unsigned index, const PageLayout &_value,
+                               PageSettingOverrides &_overrides)
 {
+  page_index = index;
+  overrides = &_overrides;
   value = _value;
   value.Normalise();
 
@@ -482,6 +648,239 @@ PageLayoutEditWidget::SetValue(const PageLayout &_value)
 
   FillOverlayDetailControl();
   UpdateOverlayControls();
+  UpdateCustomSettingsButton();
+}
+
+void
+PageLayoutEditWidget::UpdateCustomSettingsButton() noexcept
+{
+  StaticString<64> caption;
+  const unsigned n = overrides != nullptr ? overrides->n_items : 0;
+  if (n == 0)
+    caption = _("Custom settings");
+  else
+    caption.Format("%s (%u)", _("Custom settings"), n);
+
+  auto &button = (Button &)GetRow(CUSTOM_SETTINGS);
+  button.SetCaption(caption);
+}
+
+void
+PageLayoutEditWidget::OnCustomSettingsClicked() noexcept
+{
+  if (overrides == nullptr)
+    return;
+
+  ShowPageCustomSettingsDialog(*overrides);
+  UpdateCustomSettingsButton();
+}
+
+void
+PageCustomSettingsWidget::FillControl(PageSettingId id,
+                                      unsigned control) noexcept
+{
+  auto &df = (DataFieldEnum &)GetDataField(control);
+  df.ClearChoices();
+  df.AddChoice(CHOICE_GLOBAL, _("Global setting"));
+
+  const auto &desc = PageSettingRegistry::Get(id);
+  if (desc.type == PageSettingType::INTEGER) {
+    char label[16];
+    for (int v = desc.int_min; v <= desc.int_max; v += desc.int_step) {
+      StringFormat(label, sizeof(label), "%d %%", v);
+      df.AddChoice(unsigned(v), label);
+    }
+  } else {
+    assert(desc.choices != nullptr);
+    for (const StaticEnumChoice *c = desc.choices;
+         c->display_string != nullptr; ++c)
+      df.AddChoice(c->id, gettext(c->display_string), nullptr,
+                   c->help != nullptr ? gettext(c->help) : nullptr);
+  }
+
+  unsigned selected = CHOICE_GLOBAL;
+  if (const int *v = overrides.FindValue(id); v != nullptr &&
+      *v != PageSettingOverrides::INHERIT)
+    selected = unsigned(*v);
+
+  df.SetValue(selected);
+  GetControl(control).RefreshDisplay();
+}
+
+void
+PageCustomSettingsWidget::UpdateActionButtons() noexcept
+{
+  if (add_button != nullptr) {
+    bool can_add = false;
+    for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i)
+      if (!overrides.Contains(PageSettingId(i))) {
+        can_add = true;
+        break;
+      }
+    add_button->SetEnabled(can_add);
+  }
+
+  if (delete_button != nullptr)
+    delete_button->SetEnabled(selected_control >= 0 &&
+                              overrides.Contains(PageSettingId(selected_control)));
+}
+
+void
+PageCustomSettingsWidget::SelectControl(unsigned control) noexcept
+{
+  if (selected_control >= 0 &&
+      unsigned(selected_control) != control)
+    GetControl(unsigned(selected_control)).SetCaptionSelected(false);
+
+  selected_control = int(control);
+  GetControl(control).SetCaptionSelected(true);
+  GetControl(control).SetFocus();
+  UpdateActionButtons();
+}
+
+void
+PageCustomSettingsWidget::SyncRows() noexcept
+{
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    const auto id = PageSettingId(i);
+    const bool present = overrides.Contains(id);
+    SetRowAvailable(i, present);
+    if (present)
+      FillControl(id, i);
+    GetControl(i).SetCaptionSelected(false);
+  }
+
+  if (selected_control >= 0 &&
+      !overrides.Contains(PageSettingId(selected_control)))
+    selected_control = -1;
+
+  UpdateLayout();
+  if (host != nullptr)
+    host->RefreshLayout();
+
+  UpdateActionButtons();
+
+  if (selected_control >= 0) {
+    auto &control = GetControl(unsigned(selected_control));
+    control.SetCaptionSelected(true);
+    control.SetFocus();
+  }
+}
+
+void
+PageCustomSettingsWidget::OnAddClicked() noexcept
+{
+  ComboList list;
+  StaticArray<PageSettingId, unsigned(PageSettingId::COUNT)> ids;
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    const auto id = PageSettingId(i);
+    if (overrides.Contains(id))
+      continue;
+    const auto &desc = PageSettingRegistry::Get(id);
+    list.Append(ids.size(), gettext(desc.label));
+    ids.append(id);
+  }
+
+  if (list.empty())
+    return;
+
+  const int result = ComboPicker(_("Add"), list, nullptr);
+  if (result < 0 || unsigned(result) >= ids.size())
+    return;
+
+  const auto id = ids[result];
+  overrides.Add(id, PageSettingOverrides::INHERIT);
+  selected_control = int(id);
+  SyncRows();
+}
+
+void
+PageCustomSettingsWidget::OnDeleteClicked() noexcept
+{
+  if (selected_control < 0)
+    return;
+
+  const auto id = PageSettingId(selected_control);
+  if (!overrides.Contains(id))
+    return;
+
+  overrides.Remove(id);
+  selected_control = -1;
+  SyncRows();
+}
+
+void
+PageCustomSettingsWidget::Prepare(ContainerWindow &parent,
+                                  const PixelRect &rc) noexcept
+{
+  RowFormWidget::Prepare(parent, rc);
+
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    const auto &desc = PageSettingRegistry::Get(i);
+    AddEnum(gettext(desc.label), gettext(desc.help), this);
+    auto &control = GetControl(i);
+    control.GetDataField()->EnableItemHelp(true);
+    control.SetCaptionClickSelects(true, [this, i](){
+      SelectControl(i);
+    });
+    SetRowAvailable(i, false);
+  }
+
+  SyncRows();
+}
+
+void
+PageCustomSettingsWidget::OnModified(DataField &df) noexcept
+{
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    if (&df != &GetDataField(i))
+      continue;
+
+    SelectControl(i);
+
+    const auto id = PageSettingId(i);
+    const DataFieldEnum &dfe = (const DataFieldEnum &)df;
+    const unsigned choice = dfe.GetValue();
+    if (choice == CHOICE_GLOBAL)
+      overrides.SetValue(id, PageSettingOverrides::INHERIT);
+    else
+      overrides.SetValue(id, int(choice));
+    return;
+  }
+
+  gcc_unreachable();
+}
+
+static void
+ShowPageCustomSettingsDialog(PageSettingOverrides &overrides) noexcept
+{
+  const DialogLook &look = UIGlobals::GetDialogLook();
+  WidgetDialog dialog(WidgetDialog::Full{}, UIGlobals::GetMainWindow(),
+                      look, _("Custom settings"));
+
+  auto host = std::make_unique<PageCustomSettingsHost>(look, overrides);
+  auto &form = host->GetForm();
+
+  dialog.FinishPreliminary(std::move(host));
+  Button *add = dialog.AddButton(_("Add"), [&form](){
+    form.AddClicked();
+  });
+  Button *del = dialog.AddButton(_("Delete"), [&form](){
+    form.DeleteClicked();
+  });
+  form.SetActionButtons(*add, *del);
+  dialog.AddButton(_("Close"), mrOK);
+  dialog.ShowModal();
+}
+
+PageCustomSettingsHost::PageCustomSettingsHost(const DialogLook &look,
+                                               PageSettingOverrides &overrides) noexcept
+{
+  auto form_widget =
+    std::make_unique<PageCustomSettingsWidget>(look, overrides);
+  form = form_widget.get();
+  scroll = std::make_unique<VScrollWidget>(std::move(form_widget), look);
+  form->SetHost(*this);
 }
 
 void
@@ -601,9 +1000,8 @@ PageLayoutEditWidget::OnModified(DataField &df) noexcept
       }
 #endif
     }
-  } else {
+  } else
     gcc_unreachable();
-  }
 
   value.Normalise();
   ApplyValueToForm();
@@ -629,7 +1027,8 @@ PageListWidget::Initialise(ContainerWindow &parent,
 void
 PageListWidget::Show(const PixelRect &rc) noexcept
 {
-  editor->SetValue(settings.pages[GetList().GetCursorIndex()]);
+  const unsigned i = GetList().GetCursorIndex();
+  editor->SetValue(i, settings.pages[i], settings.overrides[i]);
 
   ListWidget::Show(rc);
 }
@@ -643,6 +1042,8 @@ PageListWidget::Save(bool &_changed) noexcept
   std::fill(settings.pages.begin() + settings.n_pages,
             settings.pages.end(),
             PageLayout::Undefined());
+  for (unsigned i = settings.n_pages; i < PageSettings::MAX_PAGES; ++i)
+    settings.overrides[i].Clear();
 
   for (unsigned i = 0; i < settings.n_pages; ++i)
     settings.pages[i].Normalise();
@@ -653,6 +1054,11 @@ PageListWidget::Save(bool &_changed) noexcept
     const PageLayout &src = settings.pages[i];
     if (src != dest) {
       Profile::Save(Profile::map, src, i);
+      changed = true;
+    }
+
+    if (settings.overrides[i] != _settings.overrides[i]) {
+      Profile::Save(Profile::map, settings.overrides[i], i);
       changed = true;
     }
   }
@@ -688,7 +1094,7 @@ PageListWidget::OnCursorMoved[[maybe_unused]] (unsigned idx) noexcept
 {
   UpdateButtons();
 
-  editor->SetValue(settings.pages[idx]);
+  editor->SetValue(idx, settings.pages[idx], settings.overrides[idx]);
 }
 
 void
@@ -705,7 +1111,7 @@ PageListWidget::OnModified(const PageLayout &new_value) noexcept
 
   if (i == 0 && !new_value.IsDefined()) {
     /* refuse to delete the first page (kludge) */
-    editor->SetValue(settings.pages[i]);
+    editor->SetValue(i, settings.pages[i], settings.overrides[i]);
     return;
   }
 

--- a/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TerrainDisplayConfigPanel.cpp
@@ -9,6 +9,7 @@
 #include "Form/DataField/Boolean.hpp"
 #include "Language/Language.hpp"
 #include "MapSettings.hpp"
+#include "Terrain/TerrainDisplayChoices.hpp"
 #include "Terrain/TerrainRenderer.hpp"
 #include "Topography/TopographyRenderer.hpp"
 #include "Topography/TopographyStore.hpp"
@@ -130,13 +131,13 @@ TerrainDisplayConfigPanel::ShowTerrainControls()
 static short
 ByteToPercent(short byte)
 {
-  return (byte * 200 + 100) / 510;
+  return TerrainByteToPercent(byte);
 }
 
 static short
 PercentToByte(short percent)
 {
-  return (percent * 510 + 255) / 200;
+  return TerrainPercentToByte(percent);
 }
 
 void
@@ -243,47 +244,16 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
              settings_map.topography_enabled);
   GetDataField(EnableTopography).SetListener(this);
 
-  static constexpr StaticEnumChoice terrain_ramp_list[] = {
-    { 0, N_("Low lands"), },
-    { 1, N_("Mountainous"), },
-    { 2, N_("Imhof 7"), },
-    { 3, N_("Imhof 4"), },
-    { 4, N_("Imhof 12"), },
-    { 5, N_("Imhof Atlas"), },
-    { 6, N_("ICAO"), },
-    { 9, N_("Vibrant"), },
-    { 7, N_("Grey"), },
-    { 8, N_("White"), },
-    {10, N_("Sandstone"), },
-    {11, N_("Pastel"), },
-    {12, N_("Italian Avioportolano VFR Chart"), },
-    {13, N_("German DFS VFR Chart"), },
-    {14, N_("French SIA VFR Chart"), },
-    {15, N_("High Contrast"), },
-    {16, N_("High Contrast low lands"), },
-    {17, N_("Very low lands"), },
-    nullptr
-  };
-
   AddEnum(_("Terrain colors"),
           _("Defines the color ramp used in terrain rendering."),
-          terrain_ramp_list, terrain.ramp);
+          terrain_ramp_choices, terrain.ramp);
   GetDataField(TerrainColors).SetListener(this);
-
-  static constexpr StaticEnumChoice slope_shading_list[] = {
-    { SlopeShading::OFF, N_("Off"), },
-    { SlopeShading::FIXED, NC_("Setting", "Fixed (North-West)"), },
-    { SlopeShading::SUN, N_("Sun"), },
-    { SlopeShading::WIND, N_("Wind"), },
-    { SlopeShading::TOP_LEFT, NC_("Setting", "Fixed (Top Left)"), },
-    nullptr
-  };
 
   AddEnum(_("Slope shading"),
           _("The terrain can be shaded among slopes to indicate either "
             "wind direction, sun position, a geographically fixed shading from "
             "North-West, or a screen-relative fixed shading from top left."),
-          slope_shading_list, (unsigned)terrain.slope_shading);
+          terrain_slope_shading_choices, (unsigned)terrain.slope_shading);
   GetDataField(TerrainSlopeShading).SetListener(this);
   SetExpertRow(TerrainSlopeShading);
 
@@ -301,29 +271,10 @@ TerrainDisplayConfigPanel::Prepare(ContainerWindow &parent,
   GetDataField(TerrainBrightness).SetListener(this);
   SetExpertRow(TerrainBrightness);
 
-  static constexpr StaticEnumChoice contours_list[] = {
-    { Contours::OFF, N_("Off"), NC_("Setting", "No contour lines"), },
-    { Contours::MOUNTAINS, NC_("Setting", "Mountains"),
-      N_("For steep mountain terrain, 256m minimum spacing"), },
-    { Contours::HIGHLANDS, NC_("Setting", "Highlands"),
-      N_("Medium density, with 64m minimum spacing"), },
-    { Contours::LOWLANDS, NC_("Setting", "Lowlands"),
-      N_("More line density for gentler slopes. 16m minimum spacing"), },
-    { Contours::SUPERFINE, NC_("Setting", "Superfine"),
-      N_("Maximum density contour lines down to 8m spacing"), },
-    { Contours::FIXED_256, NC_("Setting", "Fixed 256m"),
-      N_("Fixed 256m spacing, no zoom dependence"), },
-    { Contours::FIXED_128, NC_("Setting", "Fixed 128m"),
-      N_("Fixed 128m spacing, no zoom dependence"), },
-    { Contours::FIXED_64, NC_("Setting", "Fixed 64m"),
-      N_("Fixed 64m spacing, no zoom dependence"), },
-    nullptr
-  };
-
   AddEnum(_("Contours"),
           _("Draw contour lines on the terrain. Contour mode "
             "controls density of contour lines."),
-          contours_list, (unsigned)terrain.contours);
+          terrain_contours_choices, (unsigned)terrain.contours);
   GetDataField(TerrainContours).SetListener(this);
   SetExpertRow(TerrainContours);
 

--- a/src/Form/Edit.cpp
+++ b/src/Form/Edit.cpp
@@ -135,6 +135,16 @@ WndProperty::SetCaptionWidth(int _caption_width) noexcept
   UpdateLayout();
 }
 
+void
+WndProperty::SetCaptionSelected(bool selected) noexcept
+{
+  if (caption_selected == selected)
+    return;
+
+  caption_selected = selected;
+  Invalidate();
+}
+
 bool
 WndProperty::BeginEditing() noexcept
 {
@@ -207,6 +217,18 @@ WndProperty::UpdateLayout() noexcept
   Invalidate();
 }
 
+bool
+WndProperty::IsPointInCaption(PixelPoint p) const noexcept
+{
+  if (caption.empty())
+    return false;
+
+  if (caption_width >= 0)
+    return p.x < edit_rc.left;
+
+  return p.y < edit_rc.top;
+}
+
 void
 WndProperty::OnResize(PixelSize new_size) noexcept
 {
@@ -229,7 +251,7 @@ WndProperty::OnMouseDown([[maybe_unused]] PixelPoint p) noexcept
 }
 
 bool
-WndProperty::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
+WndProperty::OnMouseUp(PixelPoint p) noexcept
 {
   if (dragging) {
     dragging = false;
@@ -238,7 +260,13 @@ WndProperty::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
     if (pressed) {
       pressed = false;
       Invalidate();
-      BeginEditing();
+      if (caption_click_selects && IsPointInCaption(p)) {
+        /* Caption click: select the row for actions such as Delete. */
+        SetFocus();
+        if (caption_selected_callback)
+          caption_selected_callback();
+      } else
+        BeginEditing();
     }
 
     return true;
@@ -313,6 +341,9 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
     visible_edit_rc.bottom = canvas_height;
 
   const bool focused = HasCursorKeys() && HasFocus();
+  /* Touch selection for Delete uses the same focus blue as Quick
+     Menu buttons (#look.focused), even when HasCursorKeys() is false. */
+  const bool caption_hilite = caption_selected && !pressed;
 
   /* background and selector */
   if (pressed)
@@ -325,28 +356,38 @@ WndProperty::OnPaint(Canvas &canvas) noexcept
     canvas.Clear(look.background_color);
 
   if (!caption.empty()) {
-    canvas.SetTextColor(focused && !pressed
-                          ? look.focused.text_color
-                          : look.text_color);
-    canvas.SetBackgroundTransparent();
-    canvas.Select(look.text_font);
-
-    PixelSize tsize = canvas.CalcTextSize(caption.c_str());
+    PixelSize tsize = look.text_font.TextSize(caption.c_str());
 
     PixelPoint org;
     unsigned clip_width;
+    PixelRect caption_rc;
     if (caption_width < 0) {
       org.x = edit_rc.left;
       org.y = edit_rc.top - tsize.height;
       clip_width = canvas.GetWidth();
+      caption_rc = PixelRect(0, 0, canvas_width, edit_rc.top);
     } else {
       org.x = Layout::GetTextPadding();
       org.y = (canvas.GetHeight() - tsize.height) / 2;
       clip_width = caption_width;
+      caption_rc = PixelRect(0, 0, edit_rc.left, canvas_height);
     }
 
     if (org.x < 1)
       org.x = 1;
+
+    if (caption_hilite) {
+      /* Same blue as Quick Menu focused buttons (#look.focused). */
+      canvas.DrawFilledRectangle(caption_rc,
+                                 look.focused.background_color);
+      canvas.SetTextColor(look.focused.text_color);
+    } else {
+      canvas.SetTextColor(focused && !pressed
+                            ? look.focused.text_color
+                            : look.text_color);
+    }
+    canvas.SetBackgroundTransparent();
+    canvas.Select(look.text_font);
 
     if (HaveClipping())
       canvas.DrawText(org, caption.c_str());

--- a/src/Form/Edit.hpp
+++ b/src/Form/Edit.hpp
@@ -6,6 +6,7 @@
 #include "Form/Control.hpp"
 #include "ui/dim/Rect.hpp"
 
+#include <functional>
 #include <string>
 
 struct DialogLook;
@@ -47,6 +48,22 @@ public:
 
   bool dragging = false, pressed = false;
 
+  /**
+   * When true, a click on the caption focuses/selects the row without
+   * opening the editor; a click on the value still begins editing.
+   */
+  bool caption_click_selects = false;
+
+  /**
+   * When true, the caption is drawn with Quick Menu focus colours
+   * (#DialogLook::focused), independent of keyboard focus — so touch
+   * selection for Delete stays visible.
+   */
+  bool caption_selected = false;
+
+  /** Optional callback after a caption-select click. */
+  std::function<void()> caption_selected_callback;
+
 public:
   /**
    * Constructor of the WndProperty
@@ -84,6 +101,24 @@ public:
   void SetReadOnly(bool _read_only=true) noexcept {
     read_only = _read_only;
   }
+
+  /**
+   * If enabled, clicking the caption selects the control (focus)
+   * without opening the value editor.  @p on_selected is invoked
+   * after focus is set (may be empty).
+   */
+  void SetCaptionClickSelects(bool enabled,
+                              std::function<void()> on_selected = {}) noexcept {
+    caption_click_selects = enabled;
+    caption_selected_callback = std::move(on_selected);
+  }
+
+  /**
+   * Highlight the caption with Quick Menu focus colours
+   * (#DialogLook::focused). Independent of #HasCursorKeys focus
+   * painting.
+   */
+  void SetCaptionSelected(bool selected) noexcept;
 
   [[gnu::pure]]
   bool IsReadOnly() const noexcept {
@@ -168,4 +203,7 @@ private:
   int DecValue() noexcept;
 
   void UpdateLayout() noexcept;
+
+  [[gnu::pure]]
+  bool IsPointInCaption(PixelPoint p) const noexcept;
 };

--- a/src/PageActions.cpp
+++ b/src/PageActions.cpp
@@ -2,10 +2,12 @@
 // Copyright The XCSoar Project
 
 #include "PageActions.hpp"
+#include "PageSetting.hpp"
 #include "UIActions.hpp"
 #include "UIState.hpp"
 #include "Interface.hpp"
 #include "ActionInterface.hpp"
+#include "LogFile.hpp"
 #include "MainWindow.hpp"
 #include "util/ScopeExit.hxx"
 #include "CrossSection/CrossSectionWidget.hpp"
@@ -53,6 +55,12 @@ namespace PageActions {
    * Restore the map zoom afte switching to a configured page.
    */
   static void RestoreMapZoom();
+
+  /**
+   * Reload registered Map Display settings from the global profile,
+   * then apply sparse per-page overrides for the current page.
+   */
+  static void ApplyPageDisplaySettings() noexcept;
 
   /**
    * Loads the layout without updating current page information in
@@ -342,6 +350,9 @@ PageActions::LeavePage()
 {
   PagesState &state = CommonInterface::SetUIState().pages;
 
+  LogFmt("perPage: LeavePage index={} special={}",
+         state.current_index, state.special_page.IsDefined());
+
   LeaveWeatherOverlayPage(GetActiveLayout());
 
   if (state.special_page.IsDefined())
@@ -354,6 +365,8 @@ PageActions::LeavePage()
     page.cruise_scale = map_settings.cruise_scale;
     page.circling_scale = map_settings.circling_scale;
     page.auto_zoom_enabled = map_settings.auto_zoom_enabled;
+    LogFmt("perPage:   zoom snapshot cruise={} circling={} auto_zoom={}",
+           page.cruise_scale, page.circling_scale, page.auto_zoom_enabled);
   }
 }
 
@@ -369,7 +382,24 @@ PageActions::Restore()
   special_page.SetUndefined();
 
   LoadLayout(GetConfiguredLayout());
+  ApplyPageDisplaySettings();
   RestoreMapZoom();
+}
+
+void
+PageActions::ApplyPageDisplaySettings() noexcept
+{
+  const PagesState &state = CommonInterface::GetUIState().pages;
+  if (state.special_page.IsDefined()) {
+    LogFmt("perPage: ApplyPageDisplaySettings skip (special page)");
+    return;
+  }
+
+  LogFmt("perPage: ApplyPageDisplaySettings index={}",
+         state.current_index);
+  PageSettingApplyGlobalBaseline();
+  PageSettingApplyPageOverrides(state.current_index);
+  PageSettingNotifyLive();
 }
 
 void
@@ -392,12 +422,17 @@ PageActions::RestoreMapZoom()
 
     map_settings.auto_zoom_enabled = page.auto_zoom_enabled;
 
+    LogFmt("perPage: RestoreMapZoom index={} cruise={} circling={} auto_zoom={}",
+           state.current_index, map_settings.cruise_scale,
+           map_settings.circling_scale, map_settings.auto_zoom_enabled);
+
     GlueMapWindow *map = UIGlobals::GetMapIfActive();
     if (map != nullptr) {
       map->RestoreMapScale();
       map->QuickRedraw();
     }
-  }
+  } else
+    LogFmt("perPage: RestoreMapZoom skip (distinct_zoom off)");
 }
 
 const PageLayout &
@@ -435,15 +470,22 @@ PageActions::Update()
   /* While panning, GetCurrentLayout() is the transient FullScreen page.
      LoadLayout() calls DisablePan() without Restore(), which would leave
      the UI stuck on FullScreen without the configured bottom widget. */
-  if (IsPanning())
+  if (IsPanning()) {
+    LogFmt("perPage: Update skip (panning)");
     return;
+  }
 
   if (IsStuckPanFullScreenLayout()) {
+    LogFmt("perPage: Update restore stuck pan fullscreen");
     Restore();
     return;
   }
 
+  const PagesState &state = CommonInterface::GetUIState().pages;
+  LogFmt("perPage: Update LoadLayout index={} special={}",
+         state.current_index, state.special_page.IsDefined());
   LoadLayout(GetCurrentLayout());
+  ApplyPageDisplaySettings();
 }
 
 void
@@ -475,9 +517,10 @@ PageActions::Next()
   LeavePage();
 
   PagesState &state = CommonInterface::SetUIState().pages;
-
+  const unsigned from = state.current_index;
   state.current_index = NextIndex();
   state.special_page.SetUndefined();
+  LogFmt("perPage: Next {} -> {}", from, state.current_index);
 
   Update();
   RestoreMapZoom();
@@ -505,9 +548,10 @@ PageActions::Prev()
   LeavePage();
 
   PagesState &state = CommonInterface::SetUIState().pages;
-
+  const unsigned from = state.current_index;
   state.current_index = PrevIndex();
   state.special_page.SetUndefined();
+  LogFmt("perPage: Prev {} -> {}", from, state.current_index);
 
   Update();
   RestoreMapZoom();

--- a/src/PageSetting.cpp
+++ b/src/PageSetting.cpp
@@ -1,0 +1,582 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "PageSetting.hpp"
+#include "PageSettingDescriptor.hpp"
+#include "util/Macros.hpp"
+#include "PageSettings.hpp"
+#include "ActionInterface.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "LogFile.hpp"
+#include "MapSettings.hpp"
+#include "Profile/Current.hpp"
+#include "Profile/Keys.hpp"
+#include "Profile/Profile.hpp"
+#include "Terrain/TerrainDisplayChoices.hpp"
+#include "Terrain/TerrainSettings.hpp"
+#include "UISettings.hpp"
+
+#include <cassert>
+
+bool
+PageSettingOverrides::Contains(PageSettingId id) const noexcept
+{
+  for (unsigned i = 0; i < n_items; ++i)
+    if (items[i].id == id)
+      return true;
+  return false;
+}
+
+int *
+PageSettingOverrides::FindValue(PageSettingId id) noexcept
+{
+  for (unsigned i = 0; i < n_items; ++i)
+    if (items[i].id == id)
+      return &items[i].value;
+  return nullptr;
+}
+
+const int *
+PageSettingOverrides::FindValue(PageSettingId id) const noexcept
+{
+  for (unsigned i = 0; i < n_items; ++i)
+    if (items[i].id == id)
+      return &items[i].value;
+  return nullptr;
+}
+
+bool
+PageSettingOverrides::Add(PageSettingId id, int value) noexcept
+{
+  if (Contains(id))
+    return false;
+  if (n_items >= MAX_ITEMS)
+    return false;
+
+  items[n_items++] = {id, value};
+  return true;
+}
+
+bool
+PageSettingOverrides::Remove(PageSettingId id) noexcept
+{
+  for (unsigned i = 0; i < n_items; ++i) {
+    if (items[i].id != id)
+      continue;
+
+    for (unsigned j = i + 1; j < n_items; ++j)
+      items[j - 1] = items[j];
+    --n_items;
+    return true;
+  }
+  return false;
+}
+
+void
+PageSettingOverrides::SetValue(PageSettingId id, int value) noexcept
+{
+  if (int *v = FindValue(id); v != nullptr) {
+    *v = value;
+    return;
+  }
+
+  Add(id, value);
+}
+
+namespace {
+
+/* --- Terrain enable ------------------------------------------------ */
+
+[[nodiscard]]
+int
+TerrainEnableGetLive() noexcept
+{
+  return CommonInterface::GetMapSettings().terrain.enable ? 1 : 0;
+}
+
+void
+TerrainEnableSetLive(int value) noexcept
+{
+  CommonInterface::SetMapSettings().terrain.enable = value != 0;
+}
+
+void
+TerrainEnableSaveGlobalProfile(int value) noexcept
+{
+  Profile::Set(ProfileKeys::DrawTerrain, value != 0);
+}
+
+[[nodiscard]]
+int
+TerrainEnableLoadGlobalProfile() noexcept
+{
+  bool enable = true;
+  Profile::Get(ProfileKeys::DrawTerrain, enable);
+  return enable ? 1 : 0;
+}
+
+/* --- Topography ---------------------------------------------------- */
+
+[[nodiscard]]
+int
+TopographyEnableGetLive() noexcept
+{
+  return CommonInterface::GetMapSettings().topography_enabled ? 1 : 0;
+}
+
+void
+TopographyEnableSetLive(int value) noexcept
+{
+  CommonInterface::SetMapSettings().topography_enabled = value != 0;
+}
+
+void
+TopographyEnableSaveGlobalProfile(int value) noexcept
+{
+  Profile::Set(ProfileKeys::DrawTopography, value != 0);
+}
+
+[[nodiscard]]
+int
+TopographyEnableLoadGlobalProfile() noexcept
+{
+  bool enable = true;
+  Profile::Get(ProfileKeys::DrawTopography, enable);
+  return enable ? 1 : 0;
+}
+
+/* --- Terrain colors ------------------------------------------------ */
+
+[[nodiscard]]
+int
+TerrainColorsGetLive() noexcept
+{
+  return CommonInterface::GetMapSettings().terrain.ramp;
+}
+
+void
+TerrainColorsSetLive(int value) noexcept
+{
+  if (value < 0 ||
+      unsigned(value) >= TerrainRendererSettings::NUM_RAMPS)
+    return;
+
+  CommonInterface::SetMapSettings().terrain.ramp = unsigned(value);
+}
+
+void
+TerrainColorsSaveGlobalProfile(int value) noexcept
+{
+  if (value < 0 ||
+      unsigned(value) >= TerrainRendererSettings::NUM_RAMPS)
+    return;
+
+  Profile::Set(ProfileKeys::TerrainRamp, unsigned(value));
+}
+
+[[nodiscard]]
+int
+TerrainColorsLoadGlobalProfile() noexcept
+{
+  unsigned ramp = 0;
+  if (!Profile::Get(ProfileKeys::TerrainRamp, ramp) ||
+      ramp >= TerrainRendererSettings::NUM_RAMPS)
+    ramp = 0;
+  return int(ramp);
+}
+
+/* --- Slope shading ------------------------------------------------- */
+
+[[nodiscard]]
+int
+TerrainSlopeGetLive() noexcept
+{
+  return int(CommonInterface::GetMapSettings().terrain.slope_shading);
+}
+
+void
+TerrainSlopeSetLive(int value) noexcept
+{
+  if (value < 0 || value >= int(SlopeShading::COUNT))
+    return;
+
+  CommonInterface::SetMapSettings().terrain.slope_shading =
+    SlopeShading(value);
+}
+
+void
+TerrainSlopeSaveGlobalProfile(int value) noexcept
+{
+  if (value < 0 || value >= int(SlopeShading::COUNT))
+    return;
+
+  Profile::SetEnum(ProfileKeys::SlopeShadingType, SlopeShading(value));
+}
+
+[[nodiscard]]
+int
+TerrainSlopeLoadGlobalProfile() noexcept
+{
+  uint8_t temp = uint8_t(SlopeShading::FIXED);
+  if (!Profile::Get(ProfileKeys::SlopeShadingType, temp) ||
+      temp >= uint8_t(SlopeShading::COUNT))
+    temp = uint8_t(SlopeShading::FIXED);
+  return int(temp);
+}
+
+/* --- Contrast / brightness (percent in catalog, byte in MapSettings) */
+
+[[nodiscard]]
+int
+TerrainContrastGetLive() noexcept
+{
+  return TerrainByteToPercent(
+    CommonInterface::GetMapSettings().terrain.contrast);
+}
+
+void
+TerrainContrastSetLive(int value) noexcept
+{
+  if (value < 0 || value > 100)
+    return;
+
+  CommonInterface::SetMapSettings().terrain.contrast =
+    TerrainPercentToByte(short(value));
+}
+
+void
+TerrainContrastSaveGlobalProfile(int value) noexcept
+{
+  if (value < 0 || value > 100)
+    return;
+
+  Profile::Set(ProfileKeys::TerrainContrast,
+               TerrainPercentToByte(short(value)));
+}
+
+[[nodiscard]]
+int
+TerrainContrastLoadGlobalProfile() noexcept
+{
+  short contrast = 65;
+  Profile::Get(ProfileKeys::TerrainContrast, contrast);
+  return TerrainByteToPercent(contrast);
+}
+
+[[nodiscard]]
+int
+TerrainBrightnessGetLive() noexcept
+{
+  return TerrainByteToPercent(
+    CommonInterface::GetMapSettings().terrain.brightness);
+}
+
+void
+TerrainBrightnessSetLive(int value) noexcept
+{
+  if (value < 0 || value > 100)
+    return;
+
+  CommonInterface::SetMapSettings().terrain.brightness =
+    TerrainPercentToByte(short(value));
+}
+
+void
+TerrainBrightnessSaveGlobalProfile(int value) noexcept
+{
+  if (value < 0 || value > 100)
+    return;
+
+  Profile::Set(ProfileKeys::TerrainBrightness,
+               TerrainPercentToByte(short(value)));
+}
+
+[[nodiscard]]
+int
+TerrainBrightnessLoadGlobalProfile() noexcept
+{
+  short brightness = 192;
+  Profile::Get(ProfileKeys::TerrainBrightness, brightness);
+  return TerrainByteToPercent(brightness);
+}
+
+/* --- Contours ------------------------------------------------------ */
+
+[[nodiscard]]
+int
+TerrainContoursGetLive() noexcept
+{
+  return int(CommonInterface::GetMapSettings().terrain.contours);
+}
+
+void
+TerrainContoursSetLive(int value) noexcept
+{
+  if (value < 0 || value >= int(Contours::COUNT))
+    return;
+
+  CommonInterface::SetMapSettings().terrain.contours = Contours(value);
+}
+
+void
+TerrainContoursSaveGlobalProfile(int value) noexcept
+{
+  if (value < 0 || value >= int(Contours::COUNT))
+    return;
+
+  Profile::SetEnum(ProfileKeys::TerrainContours, Contours(value));
+}
+
+[[nodiscard]]
+int
+TerrainContoursLoadGlobalProfile() noexcept
+{
+  uint8_t temp = uint8_t(Contours::OFF);
+  if (!Profile::Get(ProfileKeys::TerrainContours, temp) ||
+      temp >= uint8_t(Contours::COUNT))
+    temp = uint8_t(Contours::OFF);
+  return int(temp);
+}
+
+/**
+ * Map Display → Terrain catalog (all seven panel settings).
+ * Choice tables shared with TerrainDisplayConfigPanel.
+ */
+static constexpr PageSettingDescriptor registry[] = {
+  {
+    PageSettingId::TERRAIN_ENABLE,
+    PageSettingType::BOOL,
+    N_("Terrain Display"),
+    N_("Show terrain on this page. Global uses Map Display → Terrain."),
+    "OverrideTerrainEnable",
+    terrain_enable_choices,
+    0, 0, 0,
+    TerrainEnableGetLive,
+    TerrainEnableSetLive,
+    TerrainEnableSaveGlobalProfile,
+    TerrainEnableLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TOPOGRAPHY_ENABLE,
+    PageSettingType::BOOL,
+    N_("Topography display"),
+    N_("Show topography on this page. Global uses Map Display → Terrain."),
+    "OverrideTopographyEnable",
+    terrain_enable_choices,
+    0, 0, 0,
+    TopographyEnableGetLive,
+    TopographyEnableSetLive,
+    TopographyEnableSaveGlobalProfile,
+    TopographyEnableLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TERRAIN_COLORS,
+    PageSettingType::ENUM,
+    N_("Terrain colors"),
+    N_("Color ramp for terrain on this page. "
+       "Global uses Map Display → Terrain."),
+    "OverrideTerrainColors",
+    terrain_ramp_choices,
+    0, 0, 0,
+    TerrainColorsGetLive,
+    TerrainColorsSetLive,
+    TerrainColorsSaveGlobalProfile,
+    TerrainColorsLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TERRAIN_SLOPE_SHADING,
+    PageSettingType::ENUM,
+    N_("Slope shading"),
+    N_("Terrain slope shading on this page. "
+       "Global uses Map Display → Terrain."),
+    "OverrideTerrainSlopeShading",
+    terrain_slope_shading_choices,
+    0, 0, 0,
+    TerrainSlopeGetLive,
+    TerrainSlopeSetLive,
+    TerrainSlopeSaveGlobalProfile,
+    TerrainSlopeLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TERRAIN_CONTRAST,
+    PageSettingType::INTEGER,
+    N_("Terrain contrast"),
+    N_("Terrain contrast on this page (percent). "
+       "Global uses Map Display → Terrain."),
+    "OverrideTerrainContrast",
+    nullptr,
+    0, 100, 5,
+    TerrainContrastGetLive,
+    TerrainContrastSetLive,
+    TerrainContrastSaveGlobalProfile,
+    TerrainContrastLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TERRAIN_BRIGHTNESS,
+    PageSettingType::INTEGER,
+    N_("Terrain brightness"),
+    N_("Terrain brightness on this page (percent). "
+       "Global uses Map Display → Terrain."),
+    "OverrideTerrainBrightness",
+    nullptr,
+    0, 100, 5,
+    TerrainBrightnessGetLive,
+    TerrainBrightnessSetLive,
+    TerrainBrightnessSaveGlobalProfile,
+    TerrainBrightnessLoadGlobalProfile,
+  },
+  {
+    PageSettingId::TERRAIN_CONTOURS,
+    PageSettingType::ENUM,
+    N_("Contours"),
+    N_("Terrain contour lines on this page. "
+       "Global uses Map Display → Terrain."),
+    "OverrideTerrainContours",
+    terrain_contours_choices,
+    0, 0, 0,
+    TerrainContoursGetLive,
+    TerrainContoursSetLive,
+    TerrainContoursSaveGlobalProfile,
+    TerrainContoursLoadGlobalProfile,
+  },
+};
+
+static_assert(ARRAY_SIZE(registry) == unsigned(PageSettingId::COUNT),
+              "Registry size must match PageSettingId::COUNT");
+
+} // namespace
+
+namespace PageSettingRegistry {
+
+unsigned
+Count() noexcept
+{
+  return unsigned(PageSettingId::COUNT);
+}
+
+const PageSettingDescriptor &
+Get(PageSettingId id) noexcept
+{
+  assert(unsigned(id) < unsigned(PageSettingId::COUNT));
+  return registry[unsigned(id)];
+}
+
+const PageSettingDescriptor &
+Get(unsigned index) noexcept
+{
+  assert(index < unsigned(PageSettingId::COUNT));
+  return registry[index];
+}
+
+bool
+IsValidValue(const PageSettingDescriptor &desc, int value) noexcept
+{
+  if (value == PageSettingOverrides::INHERIT)
+    return true;
+
+  if (desc.type == PageSettingType::INTEGER) {
+    if (value < desc.int_min || value > desc.int_max)
+      return false;
+    if (desc.int_step <= 0)
+      return true;
+    return (value - desc.int_min) % desc.int_step == 0;
+  }
+
+  assert(desc.choices != nullptr);
+  for (const StaticEnumChoice *c = desc.choices;
+       c->display_string != nullptr; ++c)
+    if (int(c->id) == value)
+      return true;
+  return false;
+}
+
+} // namespace PageSettingRegistry
+
+void
+PageSettingNotifyLive() noexcept
+{
+  ActionInterface::SendMapSettings(true);
+}
+
+void
+PageSettingApply(PageSettingId id, int value,
+                 std::optional<unsigned> page_index) noexcept
+{
+  const auto &desc = PageSettingRegistry::Get(id);
+  if (!PageSettingRegistry::IsValidValue(desc, value)) {
+    LogFmt("perPage: Apply reject id={} value={} (invalid)",
+           unsigned(id), value);
+    return;
+  }
+
+  if (!page_index.has_value()) {
+    if (value == PageSettingOverrides::INHERIT)
+      value = desc.LoadGlobalProfile();
+    LogFmt("perPage: Apply global '{}' value={}", desc.label, value);
+    desc.SetLive(value);
+    desc.SaveGlobalProfile(value);
+    PageSettingNotifyLive();
+    return;
+  }
+
+  auto &pages = CommonInterface::SetUISettings().pages;
+  if (*page_index >= PageSettings::MAX_PAGES) {
+    LogFmt("perPage: Apply page reject index={} id={}",
+           *page_index, unsigned(id));
+    return;
+  }
+
+  LogFmt("perPage: Apply page={} '{}' value={}",
+         *page_index, desc.label, value);
+  pages.overrides[*page_index].SetValue(id, value);
+}
+
+void
+PageSettingApplyGlobalBaseline() noexcept
+{
+  LogFmt("perPage: ApplyGlobalBaseline ({} settings)",
+         PageSettingRegistry::Count());
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    const auto &desc = PageSettingRegistry::Get(i);
+    const int value = desc.LoadGlobalProfile();
+    const int live = desc.GetLive();
+    LogFmt("perPage:   baseline '{}' = {} (live was {})",
+           desc.label, value, live);
+    desc.SetLive(value);
+  }
+}
+
+void
+PageSettingApplyPageOverrides(unsigned page_index) noexcept
+{
+  if (page_index >= PageSettings::MAX_PAGES) {
+    LogFmt("perPage: ApplyPageOverrides skip bad index={}", page_index);
+    return;
+  }
+
+  const auto &overrides =
+    CommonInterface::GetUISettings().pages.overrides[page_index];
+
+  LogFmt("perPage: ApplyPageOverrides page={} n_items={}",
+         page_index, overrides.n_items);
+
+  for (unsigned i = 0; i < overrides.n_items; ++i) {
+    const auto &item = overrides.items[i];
+    const auto &desc = PageSettingRegistry::Get(item.id);
+
+    if (item.value == PageSettingOverrides::INHERIT) {
+      LogFmt("perPage:   override '{}' inherit (skip)", desc.label);
+      continue;
+    }
+
+    if (!PageSettingRegistry::IsValidValue(desc, item.value)) {
+      LogFmt("perPage:   override '{}' value={} invalid (skip)",
+             desc.label, item.value);
+      continue;
+    }
+
+    LogFmt("perPage:   override '{}' = {}", desc.label, item.value);
+    desc.SetLive(item.value);
+  }
+}

--- a/src/PageSetting.hpp
+++ b/src/PageSetting.hpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+/**
+ * Identifiers for settings that may be overridden per page.
+ * The registry in PageSetting.cpp is the catalog (Map Display →
+ * Terrain pilot group first).
+ */
+enum class PageSettingId : uint8_t {
+  TERRAIN_ENABLE = 0,
+  TOPOGRAPHY_ENABLE,
+  TERRAIN_COLORS,
+  TERRAIN_SLOPE_SHADING,
+  TERRAIN_CONTRAST,
+  TERRAIN_BRIGHTNESS,
+  TERRAIN_CONTOURS,
+
+  COUNT
+};
+
+/**
+ * Sparse per-page setting overrides.  Only entries present in #items
+ * appear in the Pages editor; value #INHERIT means "use the global
+ * setting" while keeping the field on this page.
+ *
+ * #MAX_ITEMS caps overrides per page; it is independent of catalog
+ * #PageSettingId::COUNT.
+ */
+struct PageSettingOverrides {
+  static constexpr unsigned MAX_ITEMS = 32;
+
+  /** Sentinel: follow the global / profile value. */
+  static constexpr int INHERIT = -1;
+
+  struct Item {
+    PageSettingId id;
+    int value;
+  };
+
+  Item items[MAX_ITEMS];
+  unsigned n_items;
+
+  constexpr void Clear() noexcept {
+    n_items = 0;
+  }
+
+  [[nodiscard]]
+  constexpr bool IsEmpty() const noexcept {
+    return n_items == 0;
+  }
+
+  [[nodiscard]]
+  bool Contains(PageSettingId id) const noexcept;
+
+  [[nodiscard]]
+  int *FindValue(PageSettingId id) noexcept;
+
+  [[nodiscard]]
+  const int *FindValue(PageSettingId id) const noexcept;
+
+  /**
+   * Add @p id if missing.  New entries default to #INHERIT.
+   * @return true when a new entry was added
+   */
+  bool Add(PageSettingId id, int value = INHERIT) noexcept;
+
+  bool Remove(PageSettingId id) noexcept;
+
+  void SetValue(PageSettingId id, int value) noexcept;
+
+  [[nodiscard]]
+  constexpr bool operator==(const PageSettingOverrides &other) const noexcept {
+    if (n_items != other.n_items)
+      return false;
+    for (unsigned i = 0; i < n_items; ++i)
+      if (items[i].id != other.items[i].id ||
+          items[i].value != other.items[i].value)
+        return false;
+    return true;
+  }
+
+  [[nodiscard]]
+  constexpr bool operator!=(const PageSettingOverrides &other) const noexcept {
+    return !(*this == other);
+  }
+};
+
+static_assert(std::is_trivial_v<PageSettingOverrides>);
+static_assert(PageSettingOverrides::MAX_ITEMS >=
+              unsigned(PageSettingId::COUNT),
+              "MAX_ITEMS must allow one of each catalog setting");
+
+struct PageSettingDescriptor;
+
+/**
+ * Catalog of page-applicable settings (labels, choices, apply).
+ */
+namespace PageSettingRegistry {
+
+[[nodiscard]]
+unsigned
+Count() noexcept;
+
+[[nodiscard]]
+const PageSettingDescriptor &
+Get(PageSettingId id) noexcept;
+
+[[nodiscard]]
+const PageSettingDescriptor &
+Get(unsigned index) noexcept;
+
+[[nodiscard]]
+bool
+IsValidValue(const PageSettingDescriptor &desc, int value) noexcept;
+
+} // namespace PageSettingRegistry
+
+/**
+ * Apply a setting value.
+ *
+ * @param page_index nullopt writes the global MapSettings (+ profile)
+ *   and notifies the map; a page index writes into that page's
+ *   override list only (live apply happens on page switch).
+ */
+void
+PageSettingApply(PageSettingId id, int value,
+                 std::optional<unsigned> page_index = std::nullopt) noexcept;
+
+/**
+ * Reload live MapSettings from the global profile for all catalog
+ * settings (no map notify).  Pair with #PageSettingApplyPageOverrides
+ * then #PageSettingNotifyLive.
+ */
+void
+PageSettingApplyGlobalBaseline() noexcept;
+
+/**
+ * Apply sparse overrides for @p page_index onto live MapSettings
+ * (no map notify).  #INHERIT entries are skipped.
+ */
+void
+PageSettingApplyPageOverrides(unsigned page_index) noexcept;
+
+/** Push live MapSettings to the map (one FullRedraw). */
+void
+PageSettingNotifyLive() noexcept;

--- a/src/PageSettingDescriptor.hpp
+++ b/src/PageSettingDescriptor.hpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "PageSetting.hpp"
+#include "Form/DataField/Enum.hpp"
+
+/**
+ * Value shape for a catalog setting.  Storage remains #int
+ * (bool 0/1, enum choice id, or integer range value).
+ */
+enum class PageSettingType : uint8_t {
+  ENUM,
+  BOOL,
+  INTEGER,
+};
+
+/**
+ * One catalog entry: UI, profile keys, and live get/set.
+ * Map Display → Terrain is the pilot group; extend by adding rows.
+ */
+struct PageSettingDescriptor {
+  PageSettingId id;
+
+  PageSettingType type;
+
+  /** UI label (N_(); gettext when showing). */
+  const char *label;
+
+  /** Short help for the Pages editor (N_()). */
+  const char *help;
+
+  /**
+   * Profile key suffix after "PageN" for per-page overrides
+   * (e.g. "OverrideTerrainColors").
+   */
+  const char *override_key;
+
+  /**
+   * Choice list for ENUM/BOOL editors.  Pages UI prepends Global /
+   * Remove.  nullptr for INTEGER (range filled from int_*).
+   */
+  const StaticEnumChoice *choices;
+
+  /** Inclusive range for INTEGER; unused (0) for ENUM/BOOL. */
+  int int_min;
+  int int_max;
+  int int_step;
+
+  /** Read live MapSettings (or equivalent). */
+  int (*GetLive)() noexcept;
+
+  /**
+   * Write live MapSettings only — no profile, no SendMapSettings.
+   * Callers batch a single notify after apply.
+   */
+  void (*SetLive)(int value) noexcept;
+
+  /** Persist the global profile value. */
+  void (*SaveGlobalProfile)(int value) noexcept;
+
+  /** Load the global profile value (or a safe default). */
+  int (*LoadGlobalProfile)() noexcept;
+};

--- a/src/PageSettings.cpp
+++ b/src/PageSettings.cpp
@@ -105,6 +105,9 @@ PageSettings::SetDefaults() noexcept
 
   std::fill(pages.begin() + 2, pages.end(), PageLayout::Undefined());
 
+  for (auto &o : overrides)
+    o.Clear();
+
   n_pages = 2;
 
   distinct_zoom = true;
@@ -113,10 +116,22 @@ PageSettings::SetDefaults() noexcept
 void
 PageSettings::Compress() noexcept
 {
-  auto last = std::remove_if(pages.begin(), pages.end(),
-                             [](const PageLayout &layout) {
-                               return !layout.IsDefined();
-                             });
-  std::fill(last, pages.end(), PageLayout::Undefined());
-  n_pages = std::distance(pages.begin(), last);
+  unsigned write = 0;
+  for (unsigned read = 0; read < MAX_PAGES; ++read) {
+    if (!pages[read].IsDefined())
+      continue;
+
+    if (write != read) {
+      pages[write] = pages[read];
+      overrides[write] = overrides[read];
+    }
+    ++write;
+  }
+
+  for (unsigned i = write; i < MAX_PAGES; ++i) {
+    pages[i] = PageLayout::Undefined();
+    overrides[i].Clear();
+  }
+
+  n_pages = write;
 }

--- a/src/PageSettings.hpp
+++ b/src/PageSettings.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "util/StaticString.hxx"
+#include "PageSetting.hpp"
 
 #include <array>
 #include <cstdint>
@@ -359,6 +360,12 @@ struct PageSettings {
   static constexpr unsigned MAX_PAGES = 8;
 
   std::array<PageLayout, MAX_PAGES> pages;
+
+  /**
+   * Sparse Map Display (and similar) overrides per page.  Parallel to
+   * #pages; empty means inherit every registered setting from global.
+   */
+  std::array<PageSettingOverrides, MAX_PAGES> overrides;
 
   unsigned n_pages;
 

--- a/src/Profile/PageProfile.cpp
+++ b/src/Profile/PageProfile.cpp
@@ -5,12 +5,15 @@
 #include "Keys.hpp"
 #include "Map.hpp"
 #include "PageSettings.hpp"
+#include "PageSetting.hpp"
+#include "PageSettingDescriptor.hpp"
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "util/NumberParser.hxx"
 #include "util/StaticString.hxx"
 #include "util/StringFormat.hpp"
 
 #include <stdio.h>
+#include <string.h>
 
 /**
  * Old enum moved from PageSettings.
@@ -122,11 +125,37 @@ Load(const ProfileMap &map, PageLayout &_pl, const unsigned page)
   _pl = pl;
 }
 
+static void
+LoadOverrides(const ProfileMap &map, PageSettingOverrides &overrides,
+              const unsigned page)
+{
+  overrides.Clear();
+
+  char profileKey[64];
+  int prefixLen = StringFormat(profileKey, sizeof(profileKey), "Page%u", page);
+  if (prefixLen <= 0 || (size_t)prefixLen >= sizeof(profileKey))
+    return;
+
+  for (unsigned i = 0; i < PageSettingRegistry::Count(); ++i) {
+    const auto &desc = PageSettingRegistry::Get(i);
+    strcpy(profileKey + prefixLen, desc.override_key);
+    int value;
+    if (!map.Get(profileKey, value))
+      continue;
+
+    if (!PageSettingRegistry::IsValidValue(desc, value))
+      value = PageSettingOverrides::INHERIT;
+    overrides.Add(desc.id, value);
+  }
+}
+
 void
 Profile::Load(const ProfileMap &map, PageSettings &settings)
 {
-  for (unsigned i = 0; i < PageSettings::MAX_PAGES; ++i)
+  for (unsigned i = 0; i < PageSettings::MAX_PAGES; ++i) {
     ::Load(map, settings.pages[i], i);
+    LoadOverrides(map, settings.overrides[i], i);
+  }
 
   settings.Compress();
 
@@ -189,10 +218,37 @@ Profile::Save(ProfileMap &map, const PageLayout &page, const unsigned i)
   map.Set(profileKey, skysight_time.c_str());
 }
 
+static void
+SaveOverrides(ProfileMap &map, const PageSettingOverrides &overrides,
+              const unsigned i)
+{
+  char profileKey[64];
+  int prefixLen = StringFormat(profileKey, sizeof(profileKey), "Page%u", i);
+  if (prefixLen <= 0 || (size_t)prefixLen >= sizeof(profileKey))
+    return;
+
+  for (unsigned r = 0; r < PageSettingRegistry::Count(); ++r) {
+    const auto &desc = PageSettingRegistry::Get(r);
+    strcpy(profileKey + prefixLen, desc.override_key);
+    if (const int *value = overrides.FindValue(desc.id); value != nullptr)
+      map.Set(profileKey, *value);
+    else
+      map.Remove(profileKey);
+  }
+}
+
+void
+Profile::Save(ProfileMap &map, const PageSettingOverrides &overrides,
+              const unsigned i)
+{
+  SaveOverrides(map, overrides, i);
+}
 
 void
 Profile::Save(ProfileMap &map, const PageSettings &settings)
 {
-  for (unsigned i = 0; i < PageSettings::MAX_PAGES; ++i)
+  for (unsigned i = 0; i < PageSettings::MAX_PAGES; ++i) {
     Save(map, settings.pages[i], i);
+    SaveOverrides(map, settings.overrides[i], i);
+  }
 }

--- a/src/Profile/PageProfile.hpp
+++ b/src/Profile/PageProfile.hpp
@@ -6,10 +6,13 @@
 class ProfileMap;
 struct PageLayout;
 struct PageSettings;
+struct PageSettingOverrides;
 
 namespace Profile {
   void Load(const ProfileMap &map, PageSettings &settings);
 
   void Save(ProfileMap &map, const PageLayout &page, unsigned i);
+  void Save(ProfileMap &map, const PageSettingOverrides &overrides,
+            unsigned i);
   void Save(ProfileMap &map, const PageSettings &settings);
 };

--- a/src/Terrain/TerrainDisplayChoices.hpp
+++ b/src/Terrain/TerrainDisplayChoices.hpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Shared Map Display → Terrain choice lists (Config panel and page
+ * overrides).  Single source of truth for labels and ids.
+ */
+
+#include "Form/DataField/Enum.hpp"
+#include "Language/Language.hpp"
+#include "Terrain/TerrainSettings.hpp"
+
+/** Terrain color ramp (ids match TerrainRendererSettings::ramp). */
+static constexpr StaticEnumChoice terrain_ramp_choices[] = {
+  { 0, N_("Low lands") },
+  { 1, N_("Mountainous") },
+  { 2, N_("Imhof 7") },
+  { 3, N_("Imhof 4") },
+  { 4, N_("Imhof 12") },
+  { 5, N_("Imhof Atlas") },
+  { 6, N_("ICAO") },
+  { 9, N_("Vibrant") },
+  { 7, N_("Grey") },
+  { 8, N_("White") },
+  { 10, N_("Sandstone") },
+  { 11, N_("Pastel") },
+  { 12, N_("Italian Avioportolano VFR Chart") },
+  { 13, N_("German DFS VFR Chart") },
+  { 14, N_("French SIA VFR Chart") },
+  { 15, N_("High Contrast") },
+  { 16, N_("High Contrast low lands") },
+  { 17, N_("Very low lands") },
+  nullptr
+};
+
+static constexpr StaticEnumChoice terrain_slope_shading_choices[] = {
+  { SlopeShading::OFF, N_("Off") },
+  { SlopeShading::FIXED, NC_("Setting", "Fixed (North-West)") },
+  { SlopeShading::SUN, N_("Sun") },
+  { SlopeShading::WIND, N_("Wind") },
+  { SlopeShading::TOP_LEFT, NC_("Setting", "Fixed (Top Left)") },
+  nullptr
+};
+
+static constexpr StaticEnumChoice terrain_contours_choices[] = {
+  { Contours::OFF, N_("Off"), NC_("Setting", "No contour lines") },
+  { Contours::MOUNTAINS, NC_("Setting", "Mountains"),
+    N_("For steep mountain terrain, 256m minimum spacing") },
+  { Contours::HIGHLANDS, NC_("Setting", "Highlands"),
+    N_("Medium density, with 64m minimum spacing") },
+  { Contours::LOWLANDS, NC_("Setting", "Lowlands"),
+    N_("More line density for gentler slopes. 16m minimum spacing") },
+  { Contours::SUPERFINE, NC_("Setting", "Superfine"),
+    N_("Maximum density contour lines down to 8m spacing") },
+  { Contours::FIXED_256, NC_("Setting", "Fixed 256m"),
+    N_("Fixed 256m spacing, no zoom dependence") },
+  { Contours::FIXED_128, NC_("Setting", "Fixed 128m"),
+    N_("Fixed 128m spacing, no zoom dependence") },
+  { Contours::FIXED_64, NC_("Setting", "Fixed 64m"),
+    N_("Fixed 64m spacing, no zoom dependence") },
+  nullptr
+};
+
+/** On/Off for terrain (and similar) boolean page overrides. */
+static constexpr StaticEnumChoice terrain_enable_choices[] = {
+  { 0, N_("Off") },
+  { 1, N_("On") },
+  nullptr
+};
+
+/** Convert terrain contrast/brightness byte (0..255) ↔ percent (0..100). */
+[[nodiscard]] [[gnu::const]]
+constexpr short
+TerrainByteToPercent(short byte) noexcept
+{
+  return short((byte * 200 + 100) / 510);
+}
+
+[[nodiscard]] [[gnu::const]]
+constexpr short
+TerrainPercentToByte(short percent) noexcept
+{
+  return short((percent * 510 + 255) / 200);
+}

--- a/src/Terrain/TerrainRenderer.cpp
+++ b/src/Terrain/TerrainRenderer.cpp
@@ -362,7 +362,11 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
      can fail even when the projection is unchanged.  Use
      CompareExact (not tolerant Compare) so a tiny pan cannot skip
      the IsInside coverage check. */
-  if (!quantisation_improved &&
+  const bool settings_unchanged =
+    have_generated && settings == last_generated_settings;
+
+  if (settings_unchanged &&
+      !quantisation_improved &&
       compare_projection.CompareExact(map_projection) &&
       terrain_serial == terrain.GetSerial() &&
       sunazimuth.CompareRoughly(last_sun_azimuth)) {
@@ -387,7 +391,8 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
       return false;
   }
 
-  if (!quantisation_improved &&
+  if (settings_unchanged &&
+      !quantisation_improved &&
       old_bounds.IsValid() && old_bounds.IsInside(new_bounds) &&
       !IsLargeSizeDifference(old_bounds, new_bounds) &&
       terrain_serial == terrain.GetSerial() &&
@@ -446,6 +451,8 @@ TerrainRenderer::Generate(const WindowProjection &map_projection,
                                 last_contour_spacing);
 
   last_projection_scale = map_projection.GetScale();
+  last_generated_settings = settings;
+  have_generated = true;
 
   return true;
 }

--- a/src/Terrain/TerrainRenderer.hpp
+++ b/src/Terrain/TerrainRenderer.hpp
@@ -29,6 +29,14 @@ protected:
   double last_projection_scale = 0;
   unsigned last_contour_spacing = 0;
 
+  /**
+   * Settings used to build the cached terrain image.  OpenGL may reuse
+   * that image when the projection is unchanged; without this, ramp /
+   * contrast / contour changes would not repaint until pan or zoom.
+   */
+  TerrainRendererSettings last_generated_settings{};
+  bool have_generated = false;
+
   RasterRenderer raster_renderer;
 
 public:
@@ -46,6 +54,7 @@ public:
     raster_renderer.Invalidate();
 #endif
     compare_projection.Clear();
+    have_generated = false;
   }
 
 public:


### PR DESCRIPTION
## Summary

This PR is a **showcase implementation** of the per-page display configuration direction discussed in [#2952](https://github.com/XCSoar/XCSoar/pull/2952#issuecomment-5459001301).

I want to know if this feels to you interesting enough to keep implementing.
<img width="220" height="470" alt="image" src="https://github.com/user-attachments/assets/b6a98c72-3cdd-4aae-98da-158ea6a10931" /><img width="220" height="470" alt="image" src="https://github.com/user-attachments/assets/0f1313de-3746-43bb-9ca3-cda663be1714" />


**Why:** many display settings are useful page by page (terrain look, orientation, airspace, declutter, etc.). Doing each as a one-off global or hard-coded page flag does not scale; one model for “global default + optional per-page override” keeps Config simple and Pages flexible.

The idea:

- **Global settings** stay where they are today (Config menus set the defaults).
- **Per-page overrides** are optional: on each page, the user adds only the fields they want to customize.
- On **page change**, XCSoar applies the global baseline, then the overrides for that page.

Settings are described in a catalog (PageSettingDescriptor): label, help, choices, profile keys, and live get/set. The catalog drives profile I/O for page overrides, apply on page change, and the Pages editor UI.

Single source of truth (partial): enum choice lists and contrast/brightness conversion are shared with Config (TerrainDisplayChoices.hpp). Labels, live mutate, and global profile I/O are still duplicated — Config panel vs catalog each have their own strings and get/set/save paths.

Next step (before adding more settings): make Config consume the catalog descriptors (or at least the shared get/set/profile helpers), so there is one place to maintain — not more choice extraction.

Implementation can be gradual: more Config settings can move into the catalog one group at a time, after that dedup.

The same model can also cover a per-page commands list (separate from settings): zoom, airspace hide/show, and other quick-menu / display-menu actions that should be page-specific.

Apply pipeline (on page change) :

ApplyGlobalBaseline() — load every catalog entry’s global profile value into live map settings
ApplyPageOverrides() — apply stored overrides for the active page; 
PageSettingNotifyLive() — one batched SendMapSettings after both steps

Editing paths

Config — global: apply live, save to profile (still its own path today)
Pages → Custom settings — updates only the per-page override store

## Test plan

- [ ] Config → Map Display → Terrain: change a global value; confirm it applies on pages without overrides
- [ ] Config → Pages → edit a page → Custom settings → Add a terrain field; set a page-specific value
- [ ] Switch pages: overridden value applies on that page; other pages use global defaults
- [ ] Delete an override; confirm the page falls back to global
- [ ] Restart app; confirm overrides persist in the profile
- [ ] Change terrain settings at runtime; confirm map terrain updates (OpenGL cache refresh)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-page custom Terrain display settings, including terrain type, colors, shading, contrast, brightness, and contours.
  - Added a full-screen, scrollable editor for adding, changing, and removing page-specific overrides.
  - Custom settings are saved with page layouts and applied automatically when switching pages.
  - Added clearer caption selection behavior in settings controls.

- **Bug Fixes**
  - Terrain imagery now refreshes correctly when display settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->