### PR TITLE
Topography/shapelib: restore the missing first line of the licence grant

### DIFF
--- a/src/Topography/shapelib/mapserver.h
+++ b/src/Topography/shapelib/mapserver.h
@@ -8,6 +8,7 @@
  ******************************************************************************
  * Copyright (c) 1996-2005 Regents of the University of Minnesota.
  *
+ * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
  * to deal in the Software without restriction, including without limitation
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,


### PR DESCRIPTION
`src/Topography/shapelib/mapserver.h` opens its MIT grant mid-sentence, at
"copy of this software and associated documentation files (the "Software")".
The line that begins it — "Permission is hereby granted, free of charge, to
any person obtaining a" — was lost upstream at some point. What remains reads
as a list of conditions with nothing actually granting anything, which is an
unhappy state for the licence of a file we redistribute.

The sibling files in the same directory, `mapshape.c` among them, carry the
grant intact, so the wording is not in doubt; the restored line makes the
block byte-identical to theirs.

Fixed upstream in MapServer/MapServer#7631 (merged 2026-08-31), which restored
the line in four headers: `mapquery.h`, `mapraster.h`, `maprendering.h` and
`mapserver.h`. Of those, only `mapserver.h` is vendored here, so this is the
whole of that change as it applies to XCSoar.

Comment-only; no code is affected.

https://claude.ai/code/session_01CdMj9MybfkNsQzentfEo8A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restored a missing line in the MIT license header.
  * No functional or user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->