### PR TITLE
Android/BluetoothSensor: fix connection error reported on every connect

### DIFF
--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -32,9 +32,31 @@ public final class BluetoothSensor
   private final SensorListener listener;
   private final SafeDestruct safeDestruct = new SafeDestruct();
 
+  /** kept for reconnecting after a failed connection attempt */
+  private final Context context;
+  private final BluetoothDevice device;
+
   private BluetoothGatt gatt;
 
   private int state = STATE_LIMBO;
+
+  /**
+   * Android drops the first connection attempt to a BLE device often
+   * enough that treating it as fatal is wrong: reporting a failure
+   * makes DeviceDescriptor::OnSysTicker() close the whole device and
+   * reopen it seconds later, which the pilot sees as an error message
+   * followed by a connection that works anyway.  Retry in place
+   * instead, and only give up once the device has had its chances.
+   */
+  private static final int MAX_CONNECT_RETRIES = 2;
+  private int connectRetries = 0;
+
+  /**
+   * Has this object ever reached STATE_CONNECTED?  A drop before that
+   * is a failed attempt and worth retrying; one after it is the
+   * device going away, which is not.
+   */
+  private boolean everConnected = false;
 
   private BluetoothGattCharacteristic currentEnableNotification;
   private final Queue<BluetoothGattCharacteristic> enableNotificationQueue =
@@ -49,6 +71,8 @@ public final class BluetoothSensor
     throws IOException
   {
     this.listener = listener;
+    this.context = context;
+    this.device = device;
 
     if (Build.VERSION.SDK_INT >= 23){
       /**
@@ -265,16 +289,70 @@ public final class BluetoothSensor
     }
   }
 
+  /**
+   * Close the failed connection and ask for a new one.  Android needs
+   * the old client interface released before it will hand out
+   * another, so the close is not optional.
+   */
+  private void retryConnect() {
+    new Handler(Looper.getMainLooper()).post(new Runnable() {
+      @Override
+      public void run() {
+        if (!safeDestruct.increment())
+          /* close() got there first */
+          return;
+
+        try {
+          if (gatt != null) {
+            gatt.close();
+            gatt = null;
+          }
+
+          try {
+            gatt = device.connectGatt(context, false, BluetoothSensor.this);
+          } catch (SecurityException e) {
+            submitError("Bluetooth connect not permitted");
+            return;
+          }
+
+          if (gatt == null)
+            submitError("Bluetooth GATT connect failed");
+        } finally {
+          safeDestruct.decrement();
+        }
+      }
+    });
+  }
+
   @Override
   public void onConnectionStateChange(BluetoothGatt gatt,
                                       int status, int newState) {
-    if (BluetoothProfile.STATE_CONNECTED == newState) {
-      if (!gatt.discoverServices()) {
+    if (BluetoothProfile.STATE_CONNECTED == newState &&
+        BluetoothGatt.GATT_SUCCESS == status) {
+      everConnected = true;
+      connectRetries = 0;
+
+      if (!gatt.discoverServices())
         submitError("Discovering GATT services request failed");
-      }
-    } else {
-      submitError("GATT disconnected");
+
+      return;
     }
+
+    if (BluetoothProfile.STATE_DISCONNECTED != newState)
+      /* CONNECTING or DISCONNECTING: on the way somewhere, and not a
+         state worth reporting either way */
+      return;
+
+    if (!everConnected && status != BluetoothGatt.GATT_SUCCESS &&
+        connectRetries < MAX_CONNECT_RETRIES) {
+      ++connectRetries;
+      retryConnect();
+      return;
+    }
+
+    submitError(BluetoothGatt.GATT_SUCCESS == status
+                ? "GATT disconnected"
+                : "GATT connection failed (status " + status + ")");
   }
 
   @Override

--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -36,7 +36,12 @@ public final class BluetoothSensor
   private final Context context;
   private final BluetoothDevice device;
 
-  private BluetoothGatt gatt;
+  /**
+   * Assigned on the main thread, read on the Binder thread that
+   * delivers the GATT callbacks, so the two have to agree on what
+   * they see.
+   */
+  private volatile BluetoothGatt gatt;
 
   private int state = STATE_LIMBO;
 
@@ -330,6 +335,15 @@ public final class BluetoothSensor
   @Override
   public void onConnectionStateChange(BluetoothGatt gatt,
                                       int status, int newState) {
+    final BluetoothGatt current = this.gatt;
+    if (current != null && gatt != current)
+      /* a disconnect still in flight from the client retryConnect()
+         has already closed.  Acting on it would close its replacement
+         and spend another retry on a connection that is fine.  The
+         null case is the first callback racing the assignment in the
+         constructor, and that one is ours. */
+      return;
+
     if (BluetoothProfile.STATE_CONNECTED == newState &&
         BluetoothGatt.GATT_SUCCESS == status) {
       everConnected = true;

--- a/android/src/BluetoothSensor.java
+++ b/android/src/BluetoothSensor.java
@@ -105,10 +105,13 @@ public final class BluetoothSensor
       } catch (SecurityException e) {
         throw new IOException("Bluetooth GATT connect not permitted", e);
       }
-    }
 
-    if (gatt == null)
-      throw new IOException("Bluetooth GATT connect failed");
+      /* only this branch has connected synchronously and can say
+         whether it worked; the posted one reports its own failure
+         through submitError() once it has actually run */
+      if (gatt == null)
+        throw new IOException("Bluetooth GATT connect failed");
+    }
   }
 
   @Override


### PR DESCRIPTION
Three defects in the BLE connection path. The first two are visible as the same symptom: an error message when connecting a sensor, followed a few seconds later by a connection that works anyway. Reported with a cosinuss c-med alpha in #1836.

### The handle is checked before it is set

The constructor ends with

```java
if (gatt == null)
  throw new IOException("Bluetooth GATT connect failed");
```

That was correct while `connectGatt()` ran synchronously. `acb495ab6` moved the call onto the main thread through `Handler.post()` for Android 6 and newer — for a good reason, the OS was calling `close()` before the connection was established — but the check stayed where it was. It now runs immediately after `post()` returns, before the posted `Runnable` has assigned the field, so on every device newer than Android 6 the constructor throws.

`DeviceDescriptor` then closes the device and reopens it seconds later, which is the delay the tester saw. The exact text he quoted, `java.io.IOException: Bluetooth GATT connect failed`, comes from this line.

The check moves into the synchronous branch, the only one that can answer the question. The posted branch already reports its own failure through `submitError()` once it has actually run.

### The connection state ignored its status

`onConnectionStateChange()` discarded the `status` argument and treated every state other than `CONNECTED` as a failure — including `CONNECTING` and `DISCONNECTING`. Android also drops the first connect attempt to a BLE device often enough that this is routine rather than exceptional: it delivers status 133 with `STATE_DISCONNECTED`, the sensor reports `STATE_FAILED`, and `DeviceDescriptor::OnSysTicker()` tears the device down.

A disconnect before the device was ever connected is now treated as a failed attempt: close the client interface, which Android requires released before it hands out another, and connect again, up to twice. A disconnect after a successful connection remains an error. The message carries the status code so the next report says which failure it was.

### A retry could tear down its own replacement

`retryConnect()` closes the failed client and asks Android for a new one, but a disconnect from the old client can still arrive afterwards. `onConnectionStateChange()` did not look at which client a callback came from, so that late event took the retry branch again, closed the *replacement* and spent another retry on a connection that was fine.

The callback's client is now compared with the current one and a mismatch is dropped. A null current is the first callback racing the assignment in the constructor and still ours, so it passes. The field is written on the main thread and read on the Binder thread that delivers the callbacks, so it is `volatile`.

This one was found by CodeRabbit's review of the first two commits, not by testing.

Neither change affects the data path; the SpO2 and heart rate work in #2972 is independent of this.

### Testing

Tested on a Pixel 3a (Android 12) in two halves — the failure path and the success path — each as a before/after comparison against a plain `master` build, same device, same profile, same permissions, only these three commits differing.

**Failure path.** Port A configured as a BLE sensor pointing at a device that cannot answer a GATT connect, so every attempt ends in status 133. The `master` build used as the control was the upstream run for `74000b5bf`, whose `BluetoothSensor.java` is character-for-character identical to current master and which already contains #3026.

| | master | this PR |
|---|---:|---:|
| spurious `java.io.IOException` on open | 1 | **0** |
| connect attempts | 1 | **3** (initial + 2 retries) |
| GATT clients released (`unregisterApp`) | 0 | **3** |
| errors reported to XCSoar | 1 | 1 |

The message also becomes truthful: `master` says `GATT disconnected` although no connection ever existed, this PR says `GATT connection failed (status 133)`.

On `master` the exception appears 29 ms after `Opening device` and **113 ms before** the posted connect even starts — which is the defect, visible in the timestamps.

**Success path.** Against a BLE peripheral simulator written for macOS (CoreBluetooth, Heart Rate `0x180D`), so that a connection actually succeeds:

| | Result |
|---|---|
| spurious `IOException` | 0 |
| connect attempts | 1 — the retry does not fire on a working connection |
| errors reported | 0 |
| service discovery | `onSearchComplete Status=0` |
| subscription | `0x2A37 enable: true` |
| data | heart rate 72 shown in the InfoBox |

That last part is what tests the third commit: had the identity guard discarded the legitimate `CONNECTED` callback, neither discovery nor subscription would have happened.

**Not covered.** The peripheral was a simulator, not a real sensor, so hardware timing and vendor quirks are outside this test. @alenz-68 tested a build carrying these commits with a cosinuss c-med alpha and reported the connection working in #1836, which covers that side. Whether the two retries help a real sensor over an occasional status 133 is the one claim still resting on his reports rather than on my measurements.

---

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [x] Commit messages explain *why* the change was made, not just *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit must compile)
- [x] One commit per logical change (don't mix refactoring with feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

> The one box left unticked is deliberate: the commits are atomic and each changes one thing, but only the branch tip has been through CI. I have not built the three commits individually, so I cannot claim that every one of them compiles on its own.

---

- [x] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth sensor reconnection after temporary connection failures.
  * Added limited automatic retries for initial Bluetooth connections.
  * Improved error messages to distinguish connection failures from unexpected disconnections.
  * Prevented duplicate or misleading failure reports during asynchronous connection attempts.
  * Improved connection stability by ignoring outdated events from previously closed connections.
  * Reduced connection state inconsistencies during Bluetooth operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
