### PR TITLE
Weather/xctherm: Fix polygon cull for rotated map

### DIFF
--- a/src/Geo/Quadrilateral.cpp
+++ b/src/Geo/Quadrilateral.cpp
@@ -4,16 +4,17 @@
 #include "Quadrilateral.hpp"
 #include "GeoBounds.hpp"
 
-#include <algorithm>
-
 GeoBounds
 GeoQuadrilateral::GetBounds() const noexcept
 {
-  // TODO: not wraparound-safe
+  GeoBounds bounds = GeoBounds::Invalid();
 
-  const auto longitude = std::minmax({top_left.longitude, top_right.longitude, bottom_left.longitude, bottom_right.longitude});
-  const auto latitude = std::minmax({top_left.latitude, top_right.latitude, bottom_left.latitude, bottom_right.latitude});
+  /* Normalize longitudes so antimeridian wrap is detected correctly
+     (ScreenToGeo can yield values outside ±180° while panning). */
+  for (GeoPoint p : {top_left, top_right, bottom_left, bottom_right}) {
+    p.Normalize();
+    bounds.Extend(p);
+  }
 
-  return GeoBounds(GeoPoint(longitude.first, latitude.second),
-                   GeoPoint(longitude.second, latitude.first));
+  return bounds;
 }

--- a/src/MapWindow/OverlayBitmap.cpp
+++ b/src/MapWindow/OverlayBitmap.cpp
@@ -58,12 +58,26 @@ GeoFrom2D(DoublePoint2D p) noexcept
 
 /**
  * Convert a #GeoBounds instance to a boost::geometry box.
+ *
+ * Longitude must not wrap (west native <= east native).  Callers that
+ * may pass antimeridian-wrapping bounds must split first.
  */
 [[gnu::const]]
 static boost::geometry::model::box<DoublePoint2D>
 ToBox(const GeoBounds b) noexcept
 {
   return {GeoTo2D(b.GetSouthWest()), GeoTo2D(b.GetNorthEast())};
+}
+
+/**
+ * True when #GeoBounds longitude crosses ±180° in native coordinates
+ * (west > east), so a single cartesian box would be inverted/empty.
+ */
+[[gnu::const]]
+static bool
+LongitudeWraps(const GeoBounds &b) noexcept
+{
+  return b.GetWest().Native() > b.GetEast().Native();
 }
 
 /**
@@ -80,24 +94,53 @@ ToArrayQuadrilateral(const GeoQuadrilateral q) noexcept
 }
 
 /**
+ * Intersect @p geo with one non-wrapping screen box; append into @p out.
+ */
+static void
+ClipAgainstBox(const ArrayQuadrilateral &geo,
+               const GeoBounds &box,
+               ClippedMultiPolygon &out) noexcept
+{
+  ClippedMultiPolygon piece;
+  try {
+    boost::geometry::intersection(geo, ToBox(box), piece);
+  } catch (const boost::geometry::exception &) {
+    /* self-intersecting geometries → skip this piece */
+    return;
+  }
+
+  for (auto &polygon : piece)
+    out.push_back(std::move(polygon));
+}
+
+/**
  * Clip the quadrilateral inside the screen bounds.
+ *
+ * Screen bounds that wrap the antimeridian are split into two ordinary
+ * boxes (±180° seam); a single boost box cannot represent that wrap.
  */
 [[gnu::pure]]
 static ClippedMultiPolygon
 Clip(const GeoQuadrilateral &_geo, const GeoBounds &_bounds) noexcept
 {
   const auto geo = ToArrayQuadrilateral(_geo);
-  const auto bounds = ToBox(_bounds);
-
   ClippedMultiPolygon clipped;
 
-  try {
-    boost::geometry::intersection(geo, bounds, clipped);
-  } catch (const boost::geometry::exception &) {
-    /* this can (theoretically) occur with self-intersecting
-       geometries; in that case, return an empty polygon */
+  if (!LongitudeWraps(_bounds)) {
+    ClipAgainstBox(geo, _bounds, clipped);
+    return clipped;
   }
 
+  /* west..+180° and -180°..east */
+  const GeoBounds west_side(
+    GeoPoint(_bounds.GetWest(), _bounds.GetNorth()),
+    GeoPoint(Angle::HalfCircle(), _bounds.GetSouth()));
+  const GeoBounds east_side(
+    GeoPoint(-Angle::HalfCircle(), _bounds.GetNorth()),
+    GeoPoint(_bounds.GetEast(), _bounds.GetSouth()));
+
+  ClipAgainstBox(geo, west_side, clipped);
+  ClipAgainstBox(geo, east_side, clipped);
   return clipped;
 }
 

--- a/src/Projection/Projection.cpp
+++ b/src/Projection/Projection.cpp
@@ -32,7 +32,9 @@ Projection::ScreenToGeo(PixelPoint src) const noexcept
 
   g.longitude = geo_location.longitude + g.longitude * latitude.invfastcosine();
 
-  return g;
+  /* Keep longitude in (-180°, 180°]; unnormalized values (e.g. -188°)
+     break GeoBounds wrap detection and cartesian overlay clipping. */
+  return g.Normalize();
 }
 
 PixelPoint

--- a/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
+++ b/src/Weather/xctherm/XCThermGeoJSONOverlay.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include "XCThermAPI.hpp"
 
+#include "Geo/GeoBounds.hpp"
 #include "Look/Colors.hpp"
 #include "Projection/WindowProjection.hpp"
 #include "ui/canvas/Canvas.hpp"
@@ -233,7 +234,9 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
   std::vector<BulkPixelPoint> screen_points;
   screen_points.reserve(256);
 
-  const auto screen_rect = projection.GetScreenRect();
+  /* Same idea as TopographyFileRenderer: cull in geo space against
+     GetScreenBounds(), which already covers a rotated viewport. */
+  const GeoBounds &screen_bounds = projection.GetScreenBounds();
 
   for (const auto &band : forecast.bands) {
     /* Set color for this wind band.
@@ -261,21 +264,11 @@ XCThermGeoJSONOverlay::Draw(Canvas &canvas,
       if (ring.size() < 3)
         continue;
 
-      /* Quick bounding-box visibility check */
-      GeoPoint bb_min = ring[0], bb_max = ring[0];
-      for (const auto &pt : ring) {
-        if (pt.longitude < bb_min.longitude) bb_min.longitude = pt.longitude;
-        if (pt.latitude < bb_min.latitude) bb_min.latitude = pt.latitude;
-        if (pt.longitude > bb_max.longitude) bb_max.longitude = pt.longitude;
-        if (pt.latitude > bb_max.latitude) bb_max.latitude = pt.latitude;
-      }
+      GeoBounds poly_bounds(ring[0]);
+      for (std::size_t i = 1; i < ring.size(); ++i)
+        poly_bounds.Extend(ring[i]);
 
-      /* Check if bounding box intersects the screen */
-      auto tl = projection.GeoToScreen(GeoPoint(bb_min.longitude, bb_max.latitude));
-      auto br = projection.GeoToScreen(GeoPoint(bb_max.longitude, bb_min.latitude));
-
-      if (br.x < screen_rect.left || tl.x > screen_rect.right ||
-          br.y < screen_rect.top || tl.y > screen_rect.bottom)
+      if (!poly_bounds.Overlaps(screen_bounds))
         continue;
 
       /* Project all points to screen coordinates */

--- a/test/src/TestGeoBounds.cpp
+++ b/test/src/TestGeoBounds.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Geo/GeoBounds.hpp"
+#include "Geo/Quadrilateral.hpp"
 #include "TestUtil.hpp"
 
 #include <stdio.h>
@@ -15,7 +16,7 @@ MakeGeoBounds(int west, int north, int east, int south)
 
 int main()
 {
-  plan_tests(58);
+  plan_tests(74);
 
   GeoPoint g(Angle::Degrees(2), Angle::Degrees(4));
 
@@ -109,6 +110,55 @@ int main()
   ok1(equals(x.GetNorth(), inner.GetNorth()));
   ok1(equals(x.GetEast(), inner.GetEast()));
   ok1(equals(x.GetSouth(), inner.GetSouth()));
+
+  /* GeoQuadrilateral::GetBounds must be wraparound-safe */
+  const GeoQuadrilateral plain{
+    GeoPoint(Angle::Degrees(10), Angle::Degrees(20)),
+    GeoPoint(Angle::Degrees(30), Angle::Degrees(20)),
+    GeoPoint(Angle::Degrees(10), Angle::Degrees(0)),
+    GeoPoint(Angle::Degrees(30), Angle::Degrees(0)),
+  };
+  const GeoBounds plain_bounds = plain.GetBounds();
+  ok1(equals(plain_bounds.GetWest(), 10));
+  ok1(equals(plain_bounds.GetEast(), 30));
+  ok1(equals(plain_bounds.GetNorth(), 20));
+  ok1(equals(plain_bounds.GetSouth(), 0));
+  ok1(plain_bounds.IsInside(GeoPoint(Angle::Degrees(20),
+                                     Angle::Degrees(10))));
+
+  /* corners on both sides of the antimeridian */
+  const GeoQuadrilateral wrap{
+    GeoPoint(Angle::Degrees(170), Angle::Degrees(10)),
+    GeoPoint(Angle::Degrees(-170), Angle::Degrees(10)),
+    GeoPoint(Angle::Degrees(170), Angle::Degrees(-10)),
+    GeoPoint(Angle::Degrees(-170), Angle::Degrees(-10)),
+  };
+  const GeoBounds wrap_bounds = wrap.GetBounds();
+  ok1(equals(wrap_bounds.GetWest(), 170));
+  ok1(equals(wrap_bounds.GetEast(), -170));
+  ok1(equals(wrap_bounds.GetNorth(), 10));
+  ok1(equals(wrap_bounds.GetSouth(), -10));
+  ok1(wrap_bounds.IsInside(GeoPoint(Angle::Degrees(180),
+                                    Angle::Degrees(0))));
+  ok1(wrap_bounds.IsInside(GeoPoint(Angle::Degrees(-180),
+                                    Angle::Degrees(0))));
+  ok1(!wrap_bounds.IsInside(GeoPoint(Angle::Degrees(0),
+                                     Angle::Degrees(0))));
+
+  /* Unnormalized longitudes past ±180° (as ScreenToGeo can produce) */
+  const GeoQuadrilateral unnormalized{
+    GeoPoint(Angle::Degrees(-188), Angle::Degrees(10)),
+    GeoPoint(Angle::Degrees(-172), Angle::Degrees(10)),
+    GeoPoint(Angle::Degrees(-188), Angle::Degrees(-10)),
+    GeoPoint(Angle::Degrees(-172), Angle::Degrees(-10)),
+  };
+  const GeoBounds unnorm_bounds = unnormalized.GetBounds();
+  ok1(equals(unnorm_bounds.GetWest(), 172));
+  ok1(equals(unnorm_bounds.GetEast(), -172));
+  ok1(unnorm_bounds.IsInside(GeoPoint(Angle::Degrees(180),
+                                      Angle::Degrees(0))));
+  ok1(unnorm_bounds.IsInside(GeoPoint(Angle::Degrees(175),
+                                      Angle::Degrees(0))));
 
   return exit_status();
 }


### PR DESCRIPTION
## Summary

On XCTherm pages, forecast polygons could disappear when the map wasn't North Up.
To see this: in the sim, with XCtherm overlay, map orientation track up, track somewhere else than north, zoom in, zoom out..

The old visibility check took the polygon's geo bounding box, projected only the NW and SE corners to screen, and treated that as a screen rectangle. That works when the map is north-up, but when the map is rotated those two corners don't match the real on-screen shape, so visible polygons got culled away.

The fix matches what topography already does: compare geo bounds to `projection.GetScreenBounds()`, which accounts for rotation.

## Pre-submission checklist

### Git & commit history
- [x] PR is rebased on current `master`
- [x] Clean commit history (single commit)
- [x] No fixup / WIP / testing commits
- [x] No duplicate commits

### Commit format & messages
- [x] `<Component>: <Summary>` format (no `src/` prefix)
- [x] Present tense ("Fix" not "Fixed")
- [x] Commit message explains why, not just what

### Commit structure
- [x] Atomic / one logical change (1 file)
- [x] Self-contained
- [x] No refactor mixed in
- [x] Builds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved wind-band map rendering by skipping polygons outside the visible screen area.
  * Reduced unnecessary geometry processing while preserving the displayed weather overlay.

* **Bug Fixes**
  * Improved map rendering for areas crossing the international date line.
  * Corrected geographic bounds handling for shapes that wrap around the date line.
  * Normalized longitudes returned when converting screen positions to geographic coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->