### PR TITLE
iOS: prevent altimeter callbacks after teardown

### DIFF
--- a/src/Apple/InternalSensors.cpp
+++ b/src/Apple/InternalSensors.cpp
@@ -160,8 +160,11 @@ InternalSensors::InternalSensors(SensorListener &_listener)
   :listener(_listener)
 #if TARGET_OS_IPHONE
   , altimeter(nullptr)
+  , altimeter_queue(nullptr)
   , motion_activity_manager(nullptr)
   , motion_activity_queue(nullptr)
+  , altimeter_callback_state(
+      std::make_shared<AltimeterCallbackState>(*this, _listener))
 #endif
 {
   if ([NSThread isMainThread]) {
@@ -262,6 +265,7 @@ void InternalSensors::Init()
         // Create persistent manager and queue to check permissions
         motion_activity_manager = [[CMMotionActivityManager alloc] init];
         motion_activity_queue = [[NSOperationQueue alloc] init];
+        const auto callback_state = altimeter_callback_state;
         
         // Query motion activity to trigger permission dialog
         [motion_activity_manager queryActivityStartingFromDate:[NSDate date]
@@ -273,23 +277,33 @@ void InternalSensors::Init()
                 NSLog(@"Error querying motion activities: %@", error);
                 // Schedule main-thread work for error handling
                 dispatch_async(dispatch_get_main_queue(), ^{
+                  const std::scoped_lock lock{callback_state->mutex};
+                  auto *owner = callback_state->owner;
+                  if (owner == nullptr)
+                    return;
+
                   // Ensure altimeter remains nullptr on error
-                  altimeter = nullptr;
+                  owner->altimeter = nullptr;
                   // Clear the persistent references since we're done
-                  motion_activity_manager = nullptr;
-                  motion_activity_queue = nullptr;
+                  owner->motion_activity_manager = nullptr;
+                  owner->motion_activity_queue = nullptr;
                 });
                 return;
             }
             
             // Schedule main-thread work for successful permission grant
             dispatch_async(dispatch_get_main_queue(), ^{
+              const std::scoped_lock lock{callback_state->mutex};
+              auto *owner = callback_state->owner;
+              if (owner == nullptr)
+                return;
+
               // Clear the persistent references since we're done with permission check
-              motion_activity_manager = nullptr;
-              motion_activity_queue = nullptr;
+              owner->motion_activity_manager = nullptr;
+              owner->motion_activity_queue = nullptr;
               
               // Only initialize altimeter if permission query succeeded
-              StartAltimeterUpdates();
+              owner->StartAltimeterUpdates();
             });
         }];
         
@@ -322,11 +336,20 @@ void InternalSensors::Deinit()
 {
   [location_manager stopUpdatingLocation];
   #if TARGET_OS_IPHONE
+  {
+    const std::scoped_lock lock{altimeter_callback_state->mutex};
+    altimeter_callback_state->owner = nullptr;
+    altimeter_callback_state->listener = nullptr;
+  }
+
   if (altimeter != nullptr) {
     [altimeter stopRelativeAltitudeUpdates];
   }
+  [altimeter_queue cancelAllOperations];
+  altimeter_queue = nullptr;
   
   // Clean up persistent motion activity manager and queue
+  [motion_activity_queue cancelAllOperations];
   motion_activity_manager = nullptr;
   motion_activity_queue = nullptr;
   #endif
@@ -355,10 +378,11 @@ void InternalSensors::StartAltimeterUpdates()
 
   // Initialize altimeter for pressure readings
   altimeter = [[CMAltimeter alloc] init];
-  NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+  altimeter_queue = [[NSOperationQueue alloc] init];
+  const auto callback_state = altimeter_callback_state;
   
   // Start receiving altimeter updates
-  [altimeter startRelativeAltitudeUpdatesToQueue:queue
+  [altimeter startRelativeAltitudeUpdatesToQueue:altimeter_queue
                                      withHandler:^(CMAltitudeData * _Nullable altitudeData, NSError * _Nullable error) {
     if (error) {
       NSLog(@"Error: %@", [error localizedDescription]);
@@ -366,7 +390,11 @@ void InternalSensors::StartAltimeterUpdates()
     }
 
     // Convert pressure readings (from kPa to hPa/mbar) and notify listener
-    listener.OnBarometricPressureSensor(
+    const std::scoped_lock lock{callback_state->mutex};
+    if (callback_state->listener == nullptr)
+      return;
+
+    callback_state->listener->OnBarometricPressureSensor(
       static_cast<float>(altitudeData.pressure.floatValue * 10.0f),
       PRESSURE_SENSOR_NOISE_VARIANCE
     );

--- a/src/Apple/InternalSensors.hpp
+++ b/src/Apple/InternalSensors.hpp
@@ -6,6 +6,9 @@
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 
+#include <memory>
+#include <mutex>
+
 class SensorListener;
 
 #import <CoreLocation/CoreLocation.h>
@@ -52,9 +55,27 @@ class InternalSensors {
   CLLocationManager *location_manager;
   LocationDelegate *location_delegate;
 #if TARGET_OS_IPHONE
+  /**
+   * CoreMotion may invoke an already queued altimeter handler after
+   * stopRelativeAltitudeUpdates() has returned.  The handler owns this state
+   * instead of capturing InternalSensors, so it can safely outlive this
+   * object.
+   */
+  struct AltimeterCallbackState {
+    std::mutex mutex;
+    InternalSensors *owner;
+    SensorListener *listener;
+
+    AltimeterCallbackState(InternalSensors &_owner,
+                           SensorListener &_listener) noexcept
+      : owner(&_owner), listener(&_listener) {}
+  };
+
   CMAltimeter *altimeter;
+  NSOperationQueue *altimeter_queue;
   CMMotionActivityManager *motion_activity_manager;
   NSOperationQueue *motion_activity_queue;
+  std::shared_ptr<AltimeterCallbackState> altimeter_callback_state;
 #endif
 
   void Init();


### PR DESCRIPTION
CoreMotion may invoke an altimeter update that was already queued after stopRelativeAltitudeUpdates() returns. Its handler currently captures InternalSensors and its SensorListener, which leaves a use-after-free during shutdown.

iOS crash reports for versions 7.45.1 and 7.45.2 point to this callback in `InternalSensors::StartAltimeterUpdates()`, reporting pointer authentication failures.

Keep callback state separately and disable it before teardown, so late callbacks return without touching application objects.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit
  must compile)
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of Apple device sensor updates during shutdown and reinitialization.
  * Prevented delayed motion and altimeter callbacks from accessing unavailable sensor resources.
  * Ensured pending sensor operations are safely canceled when sensors are deinitialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->