### PR TITLE
Issue #3016: Fix repetitive airspace warnings not working

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -208,6 +208,8 @@ Version 7.45 - 2026-08-15
     list, Left/Right the action row
   - remove the ineffective “Unknown” row from airspace warning,
     display, and colour settings #1772
+  - fix repetitive airspace warning sound only playing once instead
+    of repeating while inside or near airspace #3016
 * infoboxen
   - add InfoBoxes: Altitude IGC, Home, Active Waypoint, Previous
     Waypoint, and QNH #2320 #2521

--- a/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceWarnings.cpp
@@ -26,7 +26,6 @@
 #include "Language/Language.hpp"
 #include "Widget/ListWidget.hpp"
 #include "UIGlobals.hpp"
-#include "Audio/Sound.hpp"
 #include "LogFile.hpp"
 #include "util/StringFormat.hpp"
 #include <Message.hpp>
@@ -66,15 +65,9 @@ class AirspaceWarningListWidget final
 
   TwoTextRowsRenderer row_renderer;
 
-  /**
-   * Airspace repetitive warning sound interval counter.
-   */
-  unsigned sound_interval_counter;
-
 public:
   AirspaceWarningListWidget(ProtectedAirspaceWarningManager &aw)
-    :airspace_warnings(aw),
-     sound_interval_counter(1)
+    :airspace_warnings(aw)
   {}
 
   void CreateButtons(WidgetDialog &dialog) {
@@ -215,7 +208,6 @@ AirspaceWarningListWidget::OnCursorMoved(unsigned i) noexcept
 void
 AirspaceWarningListWidget::Show(const PixelRect &rc) noexcept
 {
-  sound_interval_counter = 0;
   ListWidget::Show(rc);
   UpdateList();
   update_list_timer.Schedule(std::chrono::milliseconds(500));
@@ -490,34 +482,9 @@ AirspaceWarningListWidget::UpdateList()
       /* the selection may have changed, update CursorAirspace */
       OnCursorMoved(GetList().GetCursorIndex());
 
-    // Process repetitive sound warnings if they are enabled in config
-    const AirspaceWarningConfig &warning_config =
-      CommonInterface::GetComputerSettings().airspace.warnings;
-    if (warning_config.repetitive_sound) {
-      FloatDuration tt_closest_airspace{1000};
-      for (const auto &i : warning_list) {
-        /* Find smallest time to nearest aispace (cannot always rely
-           on fact that closest airspace should be in the beginning of
-           the list) */
-        if (!i.IsInside())
-          tt_closest_airspace = std::min(tt_closest_airspace,
-                                         i.GetSolution().elapsed_time);
-        else
-          tt_closest_airspace = {};
-      }
-
-      const unsigned sound_interval =
-        ((tt_closest_airspace * 3 / warning_config.warning_time) + 1) * 2;
-      if (sound_interval_counter >= sound_interval) {
-        PlayResource("IDR_WAV_BEEPBWEEP");
-        sound_interval_counter = 1;
-      } else
-        ++sound_interval_counter;
-    }
   } else {
     GetList().SetLength(1);
     selected_airspace = NULL;
-    sound_interval_counter = 0;
   }
 
   GetList().Invalidate();

--- a/src/Monitor/AirspaceWarningMonitor.cpp
+++ b/src/Monitor/AirspaceWarningMonitor.cpp
@@ -29,6 +29,7 @@
 #include "Message.hpp"
 
 #include <exception>
+#include <algorithm>
 
 class AirspaceWarningWidget final
   : public QuestionWidget {
@@ -259,9 +260,37 @@ public:
 void
 AirspaceWarningMonitor::Reset() noexcept
 {
+  sound_timer.Cancel();
+  sound_interval_counter = 0;
   const auto &calculated = CommonInterface::Calculated();
 
   last = calculated.airspace_warnings.latest;
+}
+
+void
+AirspaceWarningMonitor::PlayRepetitiveSound() noexcept
+{
+  const auto &config = CommonInterface::GetComputerSettings().airspace.warnings;
+  if (!config.repetitive_sound || backend_components == nullptr)
+    return;
+  const auto *manager = backend_components->GetAirspaceWarnings();
+  if (manager == nullptr)
+    return;
+  ProtectedAirspaceWarningManager::Lease lease(*manager);
+  FloatDuration closest{1000};
+  bool active = false;
+  for (const auto &warning : *lease.operator->()) {
+    if (!warning.IsActive()) continue;
+    active = true;
+    if (warning.IsInside()) closest = {};
+    else closest = std::min(closest, warning.GetSolution().elapsed_time);
+  }
+  if (!active) { sound_interval_counter = 0; sound_timer.Cancel(); return; }
+  const unsigned interval = ((closest * 3 / config.warning_time) + 1) * 2;
+  if (sound_interval_counter >= interval) {
+    PlayResource("IDR_WAV_BEEPBWEEP");
+    sound_interval_counter = 1;
+  } else ++sound_interval_counter;
 }
 
 void
@@ -301,6 +330,10 @@ AirspaceWarningMonitor::Check() noexcept
     // un-blank the display, play a sound
     ResetUserIdle();
     PlayResource("IDR_WAV_BEEPBWEEP");
+    if (CommonInterface::GetUISettings().enable_airspace_warning_dialog) {
+      sound_interval_counter = 0;
+      sound_timer.Schedule(std::chrono::milliseconds(500));
+    }
 
     // show airspace warnings dialog
     if (CommonInterface::GetUISettings().enable_airspace_warning_dialog)
@@ -335,4 +368,8 @@ AirspaceWarningMonitor::Check() noexcept
   // un-blank the display, play a sound
   ResetUserIdle();
   PlayResource("IDR_WAV_BEEPBWEEP");
+  if (CommonInterface::GetUISettings().enable_airspace_warning_dialog) {
+    sound_interval_counter = 0;
+    sound_timer.Schedule(std::chrono::milliseconds(500));
+  }
 }

--- a/src/Monitor/AirspaceWarningMonitor.hpp
+++ b/src/Monitor/AirspaceWarningMonitor.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "NMEA/Validity.hpp"
+#include "ui/event/PeriodicTimer.hpp"
 
 /**
  * Check for new airspace warnings and show the airspace warning
@@ -14,12 +15,15 @@ class AirspaceWarningMonitor {
   class AirspaceWarningWidget *widget = nullptr;
 
   Validity last;
+  unsigned sound_interval_counter = 0;
+  UI::PeriodicTimer sound_timer{[this]{ PlayRepetitiveSound(); }};
 
 public:
   void Reset() noexcept;
   void Check() noexcept;
 
 private:
+  void PlayRepetitiveSound() noexcept;
   void HideWidget() noexcept;
 
   void Schedule() noexcept {


### PR DESCRIPTION
Moved the block that handles the repetitive sound playing from the dialog box into the main airspace warning monitor.

Confirmed this was a real issue, as reported in #3016. Also confirmed this now works as expected after my fix, by manually placing myself in an airspace with the config setting set. 

----
Thank you for contributing to XCSoar!


- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Airspace warnings now provide consistent, repetitive audible reminders when the warning dialog is enabled.
  * Reminder timing adapts to the nearest active airspace warning.
  * Repetitive alerts stop automatically when no relevant warnings remain.
  * Warning sounds reset appropriately when airspace warning monitoring restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->