### PR TITLE
FLARM: Download flights over the Hub REST API

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,6 +42,9 @@ Version 7.46 - not yet released
   - keep the pan-mode map scale while panning, and restore the saved
     circling or cruise scale when leaving pan mode
 * FLARM
+  - download flights over the FLARM Hub REST API when the device is
+    connected as a TCP client, for PowerFLARM devices which refuse the
+    binary protocol #1882
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847
 * glide computer

--- a/build/libclient.mk
+++ b/build/libclient.mk
@@ -4,6 +4,7 @@ ifeq ($(HAVE_HTTP),y)
 
 LIBCLIENT_SOURCES = \
 	$(SRC)/net/client/auth/JwtBearerSession.cpp \
+	$(SRC)/net/client/FlarmHub/Client.cpp \
 	$(SRC)/net/client/SyncHttp.cpp \
 	$(SRC)/net/client/tim/Client.cpp \
 	$(SRC)/net/client/xctherm/Http.cpp \

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -561,6 +561,28 @@ DeviceDescriptor::Close() noexcept
 }
 
 void
+DeviceDescriptor::CloseBorrowed() noexcept
+{
+  assert(InMainThread());
+  assert(IsBorrowed());
+
+  borrowed = false;
+  Close();
+  borrowed = true;
+}
+
+void
+DeviceDescriptor::ScheduleReopenBorrowed() noexcept
+{
+  assert(InMainThread());
+  assert(IsBorrowed());
+
+  borrowed = false;
+  SlowReopen();
+  borrowed = true;
+}
+
+void
 DeviceDescriptor::Reopen(OperationEnvironment &env)
 {
   assert(InMainThread());
@@ -577,6 +599,12 @@ DeviceDescriptor::OnReopenTimer() noexcept
 
   if (!waiting_to_call_open)
     return;
+
+  if (IsOccupied()) {
+    /* somebody is still using this device; try again later */
+    reopen_timer.Schedule(std::chrono::seconds(5));
+    return;
+  }
 
   waiting_to_call_open = false;
 

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -419,6 +419,21 @@ public:
   void Close() noexcept;
 
   /**
+   * Close the port although this object is borrowed, because the
+   * borrower needs the hardware to be reachable by somebody else
+   * (e.g. the FLARM Hub REST API, which cannot obtain its own
+   * connection to the FLARM while we occupy the NMEA port).  The
+   * device stays borrowed and must still be returned.
+   */
+  void CloseBorrowed() noexcept;
+
+  /**
+   * Schedule reopening the port closed by CloseBorrowed().  The port
+   * is opened only after the device has been returned.
+   */
+  void ScheduleReopenBorrowed() noexcept;
+
+  /**
    * @param env a persistent object
    */
   void Reopen(OperationEnvironment &env);

--- a/src/Device/RecordedFlight.hpp
+++ b/src/Device/RecordedFlight.hpp
@@ -40,6 +40,11 @@ struct RecordedFlightInfo : FlightInfo {
     uint8_t flarm;
 
     /**
+     * Flight index, used by the FLARM Hub REST API.
+     */
+    unsigned flarm_hub;
+
+    /**
      * Flight number, used by Volkslogger driver
      */
     uint8_t volkslogger;

--- a/src/Logger/ExternalLogger.cpp
+++ b/src/Logger/ExternalLogger.cpp
@@ -7,6 +7,7 @@
 #include "Dialogs/Message.hpp"
 #include "Dialogs/ComboPicker.hpp"
 #include "Language/Language.hpp"
+#include "Device/Config.hpp"
 #include "Device/Descriptor.hpp"
 #include "Device/MultipleDevices.hpp"
 #include "Device/RecordedFlight.hpp"
@@ -29,6 +30,17 @@
 #include "time/BrokenDate.hpp"
 #include "Interface.hpp"
 #include "net/client/WeGlide/UploadIGCFile.hpp"
+
+#ifdef HAVE_HTTP
+#include "Dialogs/CoFunctionDialog.hpp"
+#include "Operation/PluggableOperationEnvironment.hpp"
+#include "Operation/ProgressListener.hpp"
+#include "co/InvokeTask.hxx"
+#include "net/client/FlarmHub/Client.hpp"
+#include "net/http/Init.hpp"
+#endif
+
+#include <optional>
 
 
 class DeclareJob {
@@ -125,6 +137,49 @@ ExternalLogger::Declare(const Declaration &decl, const Waypoint *home)
                 _("Declare task"), MB_OK | MB_ICONINFORMATION);
 }
 
+/**
+ * Determine the host which may serve the FLARM Hub REST API for this
+ * device.  Newer PowerFLARM devices do not implement the binary
+ * protocol and hand out their flights only over HTTP.
+ *
+ * @return the host or nullptr
+ */
+[[gnu::pure]]
+static const char *
+GetFlarmHubHost([[maybe_unused]] const DeviceConfig &config) noexcept
+{
+#ifdef HAVE_HTTP
+  if (config.port_type == DeviceConfig::PortType::TCP_CLIENT &&
+      config.IsDriver("FLARM") && !config.ip_address.empty())
+    return config.ip_address.c_str();
+#endif
+
+  return nullptr;
+}
+
+/**
+ * Closes the port of a borrowed device and schedules reopening it
+ * when the caller leaves the current scope.
+ */
+class ScopeCloseBorrowedDevice {
+  DeviceDescriptor &device;
+
+public:
+  explicit ScopeCloseBorrowedDevice(DeviceDescriptor &_device) noexcept
+    :device(_device) {
+    device.CloseBorrowed();
+  }
+
+  ~ScopeCloseBorrowedDevice() noexcept {
+    device.ScheduleReopenBorrowed();
+  }
+
+  ScopeCloseBorrowedDevice(const ScopeCloseBorrowedDevice &) = delete;
+
+  ScopeCloseBorrowedDevice &
+  operator=(const ScopeCloseBorrowedDevice &) = delete;
+};
+
 class ReadFlightListJob {
   DeviceDescriptor &device;
   RecordedFlightList &flight_list;
@@ -146,6 +201,40 @@ DoReadFlightList(DeviceDescriptor &device, RecordedFlightList &flight_list)
   JobDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
             "", job, true);
   return job.GetResult();
+}
+
+/**
+ * Read the list of flights, preferring the FLARM Hub REST API over
+ * the FLARM binary protocol.
+ *
+ * @param flarm_hub_host is cleared if this host has no Hub REST API
+ */
+static TriStateJobResult
+ReadFlightList(DeviceDescriptor &device, RecordedFlightList &flight_list,
+               [[maybe_unused]] const char *&flarm_hub_host)
+{
+#ifdef HAVE_HTTP
+  if (flarm_hub_host != nullptr) {
+    PluggableOperationEnvironment env;
+    const auto available =
+      ShowCoFunctionDialog(UIGlobals::GetMainWindow(),
+                           UIGlobals::GetDialogLook(),
+                           _("Download flight"),
+                           FlarmHub::CoReadFlightList(*Net::curl,
+                                                      flarm_hub_host,
+                                                      flight_list, env),
+                           &env);
+    if (!available)
+      return TriStateJobResult::CANCELLED;
+
+    if (*available)
+      return TriStateJobResult::SUCCESS;
+
+    flarm_hub_host = nullptr;
+  }
+#endif
+
+  return DoReadFlightList(device, flight_list);
 }
 
 class DownloadFlightJob {
@@ -171,6 +260,40 @@ DoDownloadFlight(DeviceDescriptor &device,
   JobDialog(UIGlobals::GetMainWindow(), UIGlobals::GetDialogLook(),
             "", job, true);
   return job.GetResult();
+}
+
+#ifdef HAVE_HTTP
+
+static Co::InvokeTask
+DownloadFlarmHubFlight(const char *host, unsigned index, Path path,
+                       ProgressListener &progress)
+{
+  co_await FlarmHub::CoDownloadFlight(*Net::curl, host, index, path,
+                                      progress);
+}
+
+#endif
+
+static TriStateJobResult
+DownloadFlight(DeviceDescriptor &device, const RecordedFlightInfo &flight,
+               Path path, [[maybe_unused]] const char *flarm_hub_host)
+{
+#ifdef HAVE_HTTP
+  if (flarm_hub_host != nullptr) {
+    PluggableOperationEnvironment env;
+    return ShowCoDialog(UIGlobals::GetMainWindow(),
+                        UIGlobals::GetDialogLook(),
+                        _("Download flight"),
+                        DownloadFlarmHubFlight(flarm_hub_host,
+                                               flight.internal.flarm_hub,
+                                               path, env),
+                        &env)
+      ? TriStateJobResult::SUCCESS
+      : TriStateJobResult::CANCELLED;
+  }
+#endif
+
+  return DoDownloadFlight(device, flight, path);
 }
 
 static void
@@ -262,13 +385,18 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
   };
 
   MessageOperationEnvironment env;
-  const ScopeEnableSecondDeviceNMEA enable_second_device_nmea{device, env};
+  std::optional<ScopeEnableSecondDeviceNMEA> enable_second_device_nmea;
+  enable_second_device_nmea.emplace(device, env);
 
   // Download the list of flights that the logger contains
   RecordedFlightList flight_list;
 
+  /* the host serving the FLARM Hub REST API, or nullptr if the
+     flights are read with the FLARM binary protocol */
+  const char *flarm_hub_host = GetFlarmHubHost(device.GetConfig());
+
   try {
-    switch (DoReadFlightList(device, flight_list)) {
+    switch (ReadFlightList(device, flight_list, flarm_hub_host)) {
     case TriStateJobResult::SUCCESS:
       break;
 
@@ -299,6 +427,16 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
   const auto logs_path = LocalPath(GetFileTypeDefaultDir(FileType::IGC));
   Directory::CreateRecursive(logs_path);
 
+  /* the FLARM Hub cannot obtain its own connection to the FLARM while
+     we occupy the NMEA port, and answers with HTTP status 500 */
+  std::optional<ScopeCloseBorrowedDevice> close_device;
+  if (flarm_hub_host != nullptr) {
+    /* the device is not used at all, and it must not be talked to
+       after its port has been closed */
+    enable_second_device_nmea.reset();
+    close_device.emplace(device);
+  }
+
   while (true) {
     // Show list of the flights
     const RecordedFlightInfo *flight = ShowFlightList(flight_list);
@@ -310,7 +448,9 @@ ExternalLogger::DownloadFlightFrom(DeviceDescriptor &device)
                                                      "temp.igc"));
 
     try {
-      switch (DoDownloadFlight(device, *flight, transaction.GetTemporaryPath())) {
+      switch (DownloadFlight(device, *flight,
+                             transaction.GetTemporaryPath(),
+                             flarm_hub_host)) {
       case TriStateJobResult::SUCCESS:
         break;
 

--- a/src/co/Sleep.hxx
+++ b/src/co/Sleep.hxx
@@ -5,6 +5,7 @@
 
 #include "Compat.hxx"
 #include "event/CoarseTimerEvent.hxx"
+#include "event/FineTimerEvent.hxx"
 #include "event/Chrono.hxx"
 #include "util/BindMethod.hxx"
 
@@ -18,10 +19,11 @@ namespace Co {
  * Suspend the current coroutine until @p delay has elapsed on
  * @p loop.  Must run on the thread that owns @p loop.
  */
-class SleepAwaitable final {
+template<typename Timer>
+class BasicSleepAwaitable final {
   const Event::Duration delay;
   std::coroutine_handle<> continuation{nullptr};
-  CoarseTimerEvent timer;
+  Timer timer;
 
   void OnExpired() noexcept {
     timer.Cancel();
@@ -30,11 +32,11 @@ class SleepAwaitable final {
   }
 
 public:
-  SleepAwaitable(EventLoop &loop, Event::Duration delay) noexcept
+  BasicSleepAwaitable(EventLoop &loop, Event::Duration delay) noexcept
     :delay(delay),
      timer(loop, BIND_THIS_METHOD(OnExpired)) {}
 
-  ~SleepAwaitable() noexcept {
+  ~BasicSleepAwaitable() noexcept {
     timer.Cancel();
   }
 
@@ -50,10 +52,23 @@ public:
   void await_resume() noexcept {}
 };
 
+using SleepAwaitable = BasicSleepAwaitable<CoarseTimerEvent>;
+
+/**
+ * Like #SleepAwaitable, but for delays below one second.
+ */
+using FineSleepAwaitable = BasicSleepAwaitable<FineTimerEvent>;
+
 inline SleepAwaitable
 Sleep(EventLoop &loop, Event::Duration delay) noexcept
 {
   return SleepAwaitable{loop, delay};
+}
+
+inline FineSleepAwaitable
+FineSleep(EventLoop &loop, Event::Duration delay) noexcept
+{
+  return FineSleepAwaitable{loop, delay};
 }
 
 } // namespace Co

--- a/src/net/client/FlarmHub/Client.cpp
+++ b/src/net/client/FlarmHub/Client.cpp
@@ -3,13 +3,15 @@
 
 #include "Client.hpp"
 #include "Device/RecordedFlight.hpp"
+#include "co/Sleep.hxx"
 #include "io/FileOutputStream.hxx"
 #include "lib/curl/CoRequest.hxx"
 #include "lib/curl/CoStreamRequest.hxx"
 #include "lib/curl/Easy.hxx"
+#include "lib/curl/Global.hxx"
 #include "lib/curl/Setup.hxx"
 #include "lib/fmt/RuntimeError.hxx"
-#include "net/http/Progress.hpp"
+#include "Operation/ProgressListener.hpp"
 #include "system/Path.hpp"
 #include "time/BrokenDate.hpp"
 #include "time/BrokenTime.hpp"
@@ -20,12 +22,22 @@
 
 #include <stdexcept>
 
+#include <limits.h>
 #include <stdio.h>
 
 namespace FlarmHub {
 
 static constexpr long PROBE_CONNECT_TIMEOUT = 3;
 static constexpr long PROBE_TIMEOUT = 5;
+
+static constexpr long PROGRESS_TIMEOUT = 5;
+/**
+ * Ask the Hub this often while a transfer is running.  Co::Sleep()
+ * cannot be used for this: #CoarseTimerEvent documents a granularity
+ * of about one second.
+ */
+static constexpr Event::Duration PROGRESS_POLL_INTERVAL =
+  std::chrono::milliseconds(250);
 
 /**
  * Parse a timestamp such as "2020-05-01T06:17:48" (local time of the
@@ -116,9 +128,9 @@ ParseFlightList(const boost::json::value &json,
 }
 
 /**
- * The Hub is a small embedded HTTP server which serves one connection
- * at a time; give each request its own connection instead of leaving
- * an idle one behind, which would block the next request.
+ * Give each request its own connection: the Hub is a small embedded
+ * HTTP server which stops answering once an idle connection from a
+ * previous request is left on it.
  */
 static void
 SetupRequest(CurlEasy &easy)
@@ -126,6 +138,42 @@ SetupRequest(CurlEasy &easy)
   Curl::Setup(easy);
   easy.SetOption(CURLOPT_FRESH_CONNECT, 1L);
   easy.SetOption(CURLOPT_FORBID_REUSE, 1L);
+}
+
+/**
+ * Report the progress of the transfer between the Hub and the FLARM,
+ * which is the slow part; the Hub's own response to us is chunked and
+ * therefore has no Content-Length.  Asks right away so the size is
+ * known as early as possible, and runs until the caller destroys it.
+ */
+static Co::EagerTask<void>
+CoPollProgress(CurlGlobal &curl, std::string url, ProgressListener &progress)
+{
+  while (true) {
+    try {
+      CurlEasy easy{url.c_str()};
+      SetupRequest(easy);
+      easy.SetFailOnError();
+      easy.SetTimeout(PROGRESS_TIMEOUT);
+
+      const auto response = co_await Curl::CoRequest(curl, std::move(easy));
+      const auto json = boost::json::parse(response.body);
+      const auto &object = json.as_object();
+      const auto total = object.at("total").to_number<uint_least64_t>();
+      const auto loaded = object.at("loaded").to_number<uint_least64_t>();
+
+      /* a finished transfer is usually a leftover from the previous
+         one */
+      if (total > 0 && total <= UINT_MAX && loaded < total) {
+        progress.SetProgressRange(total);
+        progress.SetProgressPosition(loaded);
+      }
+    } catch (...) {
+      /* the progress display is not essential */
+    }
+
+    co_await Co::FineSleep(curl.GetEventLoop(), PROGRESS_POLL_INTERVAL);
+  }
 }
 
 static Co::Task<bool>
@@ -160,9 +208,16 @@ CoReadFlightList(CurlGlobal &curl, const char *host,
 
   CurlEasy easy{url.c_str()};
   SetupRequest(easy);
-  const Net::ProgressAdapter progress_adapter{easy, progress};
 
-  const auto response = co_await Curl::CoRequest(curl, std::move(easy));
+  /* register the request before asking for progress, so that the Hub
+     sees our connection first */
+  Curl::CoRequest request{curl, std::move(easy)};
+
+  const auto poll =
+    CoPollProgress(curl, fmt::format("http://{}/api/transfer/progress", host),
+                   progress);
+
+  const auto response = co_await request;
   if (response.status != 200)
     throw FmtRuntimeError("Failed to read the FLARM flight list: "
                           "HTTP status {}", response.status);
@@ -181,10 +236,16 @@ CoDownloadFlight(CurlGlobal &curl, const char *host, unsigned index,
 
   CurlEasy easy{url.c_str()};
   SetupRequest(easy);
-  const Net::ProgressAdapter progress_adapter{easy, progress};
 
-  const auto response =
-    co_await Curl::CoStreamRequest(curl, std::move(easy), file);
+  /* register the request before asking for progress, so that the Hub
+     sees our connection first */
+  Curl::CoStreamRequest request{curl, std::move(easy), file};
+
+  const auto poll =
+    CoPollProgress(curl, fmt::format("http://{}/api/transfer/progress", host),
+                   progress);
+
+  const auto response = co_await request;
 
   if (response.status != 200)
     throw FmtRuntimeError("Failed to download the IGC file: "

--- a/src/net/client/FlarmHub/Client.cpp
+++ b/src/net/client/FlarmHub/Client.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Client.hpp"
+#include "Device/RecordedFlight.hpp"
+#include "io/FileOutputStream.hxx"
+#include "lib/curl/CoRequest.hxx"
+#include "lib/curl/CoStreamRequest.hxx"
+#include "lib/curl/Easy.hxx"
+#include "lib/curl/Setup.hxx"
+#include "lib/fmt/RuntimeError.hxx"
+#include "net/http/Progress.hpp"
+#include "system/Path.hpp"
+#include "time/BrokenDate.hpp"
+#include "time/BrokenTime.hpp"
+
+#include <boost/json.hpp>
+
+#include <fmt/format.h>
+
+#include <stdexcept>
+
+#include <stdio.h>
+
+namespace FlarmHub {
+
+static constexpr long PROBE_CONNECT_TIMEOUT = 3;
+static constexpr long PROBE_TIMEOUT = 5;
+
+/**
+ * Parse a timestamp such as "2020-05-01T06:17:48" (local time of the
+ * device, without a time zone suffix).
+ */
+static bool
+ParseTimestamp(const char *s, BrokenDate &date, BrokenTime &time) noexcept
+{
+  unsigned year, month, day, hour, minute, second;
+  if (sscanf(s, "%u-%u-%uT%u:%u:%u", &year, &month, &day,
+             &hour, &minute, &second) != 6 ||
+      year > 9999 || month > 12 || day > 31 ||
+      hour > 23 || minute > 59 || second > 59)
+    return false;
+
+  date = BrokenDate{year, month, day};
+  time = BrokenTime{hour, minute, second};
+  return date.IsPlausible();
+}
+
+/**
+ * Parse a duration such as "00:12:45".
+ */
+static bool
+ParseDuration(const char *s, unsigned &seconds) noexcept
+{
+  unsigned hour, minute, second;
+  if (sscanf(s, "%u:%u:%u", &hour, &minute, &second) != 3 ||
+      hour > 999 || minute > 59 || second > 59)
+    return false;
+
+  seconds = (hour * 60 + minute) * 60 + second;
+  return true;
+}
+
+[[gnu::pure]]
+static const char *
+GetString(const boost::json::object &object, const char *key) noexcept
+{
+  const auto i = object.find(key);
+  if (i == object.end() || !i->value().is_string())
+    return nullptr;
+
+  return i->value().get_string().c_str();
+}
+
+static bool
+ParseFlight(const boost::json::object &object,
+            RecordedFlightInfo &flight) noexcept
+{
+  const auto index = object.find("index");
+  const char *const timestamp = GetString(object, "timestamp");
+  const char *const duration = GetString(object, "duration");
+  if (index == object.end() || !index->value().is_int64() ||
+      index->value().get_int64() < 0 ||
+      timestamp == nullptr || duration == nullptr)
+    return false;
+
+  unsigned seconds;
+  if (!ParseTimestamp(timestamp, flight.date, flight.start_time) ||
+      !ParseDuration(duration, seconds))
+    return false;
+
+  const unsigned end = flight.start_time.GetSecondOfDay() + seconds;
+  flight.end_time = BrokenTime::FromSecondOfDayChecked(end);
+  flight.internal.flarm_hub = index->value().get_int64();
+  return true;
+}
+
+static void
+ParseFlightList(const boost::json::value &json,
+                RecordedFlightList &flight_list)
+{
+  if (!json.is_array())
+    throw std::runtime_error("Malformed FLARM Hub flight list");
+
+  for (const auto &i : json.get_array()) {
+    if (flight_list.full())
+      break;
+
+    if (!i.is_object())
+      continue;
+
+    RecordedFlightInfo flight;
+    if (ParseFlight(i.get_object(), flight))
+      flight_list.append(flight);
+  }
+}
+
+/**
+ * The Hub is a small embedded HTTP server which serves one connection
+ * at a time; give each request its own connection instead of leaving
+ * an idle one behind, which would block the next request.
+ */
+static void
+SetupRequest(CurlEasy &easy)
+{
+  Curl::Setup(easy);
+  easy.SetOption(CURLOPT_FRESH_CONNECT, 1L);
+  easy.SetOption(CURLOPT_FORBID_REUSE, 1L);
+}
+
+static Co::Task<bool>
+CoProbe(CurlGlobal &curl, const char *host)
+{
+  const auto url = fmt::format("http://{}/api/info", host);
+
+  CurlEasy easy{url.c_str()};
+  SetupRequest(easy);
+  easy.SetFailOnError();
+  easy.SetConnectTimeout(PROBE_CONNECT_TIMEOUT);
+  easy.SetTimeout(PROBE_TIMEOUT);
+
+  try {
+    co_await Curl::CoRequest(curl, std::move(easy));
+  } catch (...) {
+    co_return false;
+  }
+
+  co_return true;
+}
+
+Co::Task<bool>
+CoReadFlightList(CurlGlobal &curl, const char *host,
+                 RecordedFlightList &flight_list,
+                 ProgressListener &progress)
+{
+  if (!co_await CoProbe(curl, host))
+    co_return false;
+
+  const auto url = fmt::format("http://{}/api/flarm/igc", host);
+
+  CurlEasy easy{url.c_str()};
+  SetupRequest(easy);
+  const Net::ProgressAdapter progress_adapter{easy, progress};
+
+  const auto response = co_await Curl::CoRequest(curl, std::move(easy));
+  if (response.status != 200)
+    throw FmtRuntimeError("Failed to read the FLARM flight list: "
+                          "HTTP status {}", response.status);
+
+  ParseFlightList(boost::json::parse(response.body), flight_list);
+  co_return true;
+}
+
+Co::Task<void>
+CoDownloadFlight(CurlGlobal &curl, const char *host, unsigned index,
+                 Path path, ProgressListener &progress)
+{
+  const auto url = fmt::format("http://{}/api/flarm/igc/{}", host, index);
+
+  FileOutputStream file{path};
+
+  CurlEasy easy{url.c_str()};
+  SetupRequest(easy);
+  const Net::ProgressAdapter progress_adapter{easy, progress};
+
+  const auto response =
+    co_await Curl::CoStreamRequest(curl, std::move(easy), file);
+
+  if (response.status != 200)
+    throw FmtRuntimeError("Failed to download the IGC file: "
+                          "HTTP status {}", response.status);
+
+  file.Commit();
+}
+
+} // namespace FlarmHub

--- a/src/net/client/FlarmHub/Client.hpp
+++ b/src/net/client/FlarmHub/Client.hpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "co/Task.hxx"
+
+class CurlGlobal;
+class Path;
+class ProgressListener;
+class RecordedFlightList;
+
+/**
+ * A client for the FLARM Hub REST API, which is the only way to read
+ * the flight log of devices that do not implement the FLARM binary
+ * protocol (e.g. the PowerFLARM Flex).
+ */
+namespace FlarmHub {
+
+/**
+ * Check whether the given host serves the FLARM Hub REST API and read
+ * the list of recorded flights.
+ *
+ * Throws on error.
+ *
+ * @return false if this host has no Hub REST API; the caller shall
+ * then fall back to the FLARM binary protocol
+ */
+Co::Task<bool>
+CoReadFlightList(CurlGlobal &curl, const char *host,
+                 RecordedFlightList &flight_list,
+                 ProgressListener &progress);
+
+/**
+ * Download one IGC file.
+ *
+ * Throws on error.
+ *
+ * @param index the flight index from RecordedFlightInfo::flarm_hub
+ */
+Co::Task<void>
+CoDownloadFlight(CurlGlobal &curl, const char *host, unsigned index,
+                 Path path, ProgressListener &progress);
+
+} // namespace FlarmHub


### PR DESCRIPTION
The PowerFLARM Flex answers `$PFLAX` with `ERROR,NOTSUPPORTED` on every interface, so the flight download over the binary protocol cannot work on these devices. The Hub REST API is the intended replacement.

When a device is configured as a TCP client with the FLARM driver, XCSoar now probes `GET /api/info` once per download session. On success the flight list and the IGC files are read over HTTP, otherwise everything stays on the binary protocol as before.

Two details cost some testing. The Hub serves one connection at a time and stops answering entirely once a pooled keep-alive connection is left on it, so every request gets a fresh connection. And it cannot obtain its own connection to the FLARM while XCSoar occupies the NMEA port, answering HTTP 500, so the port is closed for the duration of the download and reopened afterwards.

Tested with a PowerFLARM Flex over Wi-Fi on iOS.

Closes #1882.

@yorickreum Would you be able to test this PR once I've sent you the FLARM?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for viewing and downloading recorded flights through the FLARM Hub REST API when compatible PowerFLARM devices are connected as TCP clients.
  - Flight download progress is displayed during transfers.
  - Existing FLARM binary-protocol support remains available when the Hub API cannot be used.

- **Bug Fixes**
  - Improved device handling during FLARM Hub downloads, including safely retrying access when the device is temporarily occupied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->