### PR TITLE
Device/Factory: do not close Android sensors right after opening them

### DIFF
--- a/src/Device/Factory.cpp
+++ b/src/Device/Factory.cpp
@@ -14,7 +14,7 @@
 #include "Android/IOIOHelper.hpp"
 #include "Android/NunchuckDevice.hpp"
 #include "Android/VoltageDevice.hpp"
-#include "java/Closeable.hxx"
+#include "java/Object.hxx"
 #endif
 
 #ifdef __APPLE__
@@ -60,7 +60,7 @@ DeviceFactory::OpenInternalSensors(SensorListener &listener)
 
 #ifdef ANDROID
 
-std::pair<Java::LocalCloseable, Java::LocalCloseable>
+std::pair<Java::LocalObject, Java::LocalObject>
 DeviceFactory::OpenDroidSoarV2(SensorListener &listener)
 {
   if (ioio_helper == nullptr)
@@ -84,7 +84,7 @@ DeviceFactory::OpenDroidSoarV2(SensorListener &listener)
   };
 }
 
-Java::LocalCloseable
+Java::LocalObject
 DeviceFactory::OpenI2Cbaro(const DeviceConfig &config, SensorListener &listener)
 {
   if (ioio_helper == nullptr)
@@ -99,7 +99,7 @@ DeviceFactory::OpenI2Cbaro(const DeviceConfig &config, SensorListener &listener)
                                listener);
 }
 
-Java::LocalCloseable
+Java::LocalObject
 DeviceFactory::OpenNunchuck(const DeviceConfig &config, SensorListener &listener)
 {
   if (ioio_helper == nullptr)
@@ -111,7 +111,7 @@ DeviceFactory::OpenNunchuck(const DeviceConfig &config, SensorListener &listener
                                 listener);
 }
 
-Java::LocalCloseable
+Java::LocalObject
 DeviceFactory::OpenVoltage(SensorListener &listener)
 {
   if (ioio_helper == nullptr)
@@ -123,13 +123,13 @@ DeviceFactory::OpenVoltage(SensorListener &listener)
                                listener);
 }
 
-Java::LocalCloseable
+Java::LocalObject
 DeviceFactory::OpenGliderLink(SensorListener &listener)
 {
   return GliderLink::Create(Java::GetEnv(), context, listener);
 }
 
-Java::LocalCloseable
+Java::LocalObject
 DeviceFactory::OpenBluetoothSensor(const DeviceConfig &config,
                                    SensorListener &listener)
 {

--- a/src/Device/Factory.hpp
+++ b/src/Device/Factory.hpp
@@ -21,7 +21,8 @@ class InternalSensors;
 #endif
 
 #ifdef ANDROID
-namespace Java { class LocalCloseable; }
+#include "java/Object.hxx"
+
 class _jobject;
 class Context;
 class BluetoothHelper;
@@ -69,11 +70,16 @@ public:
 #endif
 
 #ifdef ANDROID
-  std::pair<Java::LocalCloseable, Java::LocalCloseable> OpenDroidSoarV2(SensorListener &listener);
-  Java::LocalCloseable OpenI2Cbaro(const DeviceConfig &config, SensorListener &listener);
-  Java::LocalCloseable OpenNunchuck(const DeviceConfig &config, SensorListener &listener);
-  Java::LocalCloseable OpenVoltage(SensorListener &listener);
-  Java::LocalCloseable OpenGliderLink(SensorListener &listener);
-  Java::LocalCloseable OpenBluetoothSensor(const DeviceConfig &config, SensorListener &listener);
+  /* these return Java::LocalObject and not Java::LocalCloseable on
+     purpose: the caller wraps the result in a Java::GlobalCloseable
+     which owns the object from then on.  A LocalCloseable here would
+     close the sensor at the end of the caller's full-expression,
+     right after it was opened. */
+  std::pair<Java::LocalObject, Java::LocalObject> OpenDroidSoarV2(SensorListener &listener);
+  Java::LocalObject OpenI2Cbaro(const DeviceConfig &config, SensorListener &listener);
+  Java::LocalObject OpenNunchuck(const DeviceConfig &config, SensorListener &listener);
+  Java::LocalObject OpenVoltage(SensorListener &listener);
+  Java::LocalObject OpenGliderLink(SensorListener &listener);
+  Java::LocalObject OpenBluetoothSensor(const DeviceConfig &config, SensorListener &listener);
 #endif
 };


### PR DESCRIPTION
Every Android sensor that XCSoar opens through `DeviceFactory` is closed again immediately, in the same expression that opens it. The sensor object survives, so nothing looks broken from the outside, but everything it reports back to XCSoar is silently discarded from that moment on.

## What happens

`DeviceDescriptor::OpenBluetoothSensor()` — and its five siblings — do this:

```cpp
java_sensor = new Java::GlobalCloseable(factory.OpenBluetoothSensor(config, *this));
```

`DeviceFactory::OpenBluetoothSensor()` returned `Java::LocalCloseable`. The constructor selected is

```cpp
GlobalRef(const LocalRef<T> &src) noexcept
    :GlobalRef(src.GetEnv(), src.Get()) {}
```

which takes its source **by const reference** and makes a new global reference from it. The local one is left intact, so the temporary is still alive after the global reference exists — and at the end of the full-expression `~LocalCloseable()` runs and calls `close()` on the object that was just opened.

For `BluetoothSensor` that call reaches `safeDestruct.beginShutdown()`. After that, `SafeDestruct.increment()` returns `false` for good, and every path back into XCSoar is behind it:

* `onCharacteristicChanged()` — no measurement ever arrives
* `submitError()` — no error is ever reported
* `setStateSafe()` — the state field is still updated, but the listener is never notified
* the retry after a failed connect — silently does nothing

There is a second consequence. `SafeDestruct.beginShutdown()` throws `IllegalStateException` when called twice, so the *real* `close()` later throws before reaching `gatt.close()`. The exception is swallowed by `Java::CloseCloseable`, and the GATT client is never released — the link stays up and the sensor does not reappear in a new scan.

## Why nobody noticed

`BluetoothSensor`'s constructor posts the GATT connect to the Android main thread, with this comment:

```java
/**
 * Run GATT connect, discover etc. on main thread. If not,
 * recent Android os will call close() before connection
 * is fully established.
 */
```

That deferral is what has kept BLE sensors working: the connect runs *after* the premature `close()`, so a link is established and `getState()` reports READY. Only what travels back through `SafeDestruct` is lost. The workaround in the constructor has been compensating for this bug, and the comment describes the symptom without naming the cause.

On top of that, the common configurations do not go through this code at all — see Scope below.

## Evidence

Measured on a Pixel 3a, Android 12, with a build carrying temporary log statements around the construction and inside `close()`:

```
18:47:48.755 I/XCSoar : XCSDBG: OpenBluetoothSensor: before GlobalCloseable
18:47:48.765 W/XCSDBG : ctor: enter, posting connect
18:47:48.765 W/XCSDBG : ~LocalCloseable o=0x78fee5a009 -> calling close()
18:47:48.767 W/XCSDBG : close(): called, gatt=null
18:47:48.767 W/XCSDBG : java.lang.Throwable
18:47:48.767 W/XCSDBG :     at org.xcsoar.BluetoothSensor.close(BluetoothSensor.java:145)
18:47:48.767 I/XCSoar : XCSDBG: OpenBluetoothSensor: after GlobalCloseable
18:47:48.783 W/XCSDBG : ctor.runnable: running
```

The `close()` lands between the two brackets around the `GlobalCloseable` construction, immediately after `~LocalCloseable`, and the Java stack trace has no calling Java frame — it arrives through JNI.

## Scope

Affected — everything the factory returned as `Java::LocalCloseable`:

| Port type | Java class | what its `close()` does immediately |
|---|---|---|
| BLE sensor | `BluetoothSensor` | `beginShutdown()`; measurements, errors, state changes and retry are all dead |
| GliderLink | `GliderLinkReceiver` | `beginShutdown()` **and** `context.unregisterReceiver(this)` |
| DroidSoar V2 (2 objects) | `I2Cbaro` | closes the IOIO handles, `interrupt()` |
| IOIO I²C pressure sensor | `I2Cbaro` | same |
| IOIO switches and Nunchuk | `Nunchuck` | closes the handle, `interrupt()` |
| IOIO voltage sensor | `Voltage` | closes all three handles, `interrupt()` |

Only the BLE sensor case is measured. The other five follow from the same construction and from reading their `close()`; I have none of that hardware. GliderLink looks worst: it has no deferred operation that could survive the teardown, so its broadcast receiver is unregistered right after being registered.

Not affected, which is why this went unnoticed for so long:

* the internal GPS and sensors — `InternalSensors::InternalSensors()` takes `const Java::LocalObject &`, whose destructor only releases the local reference
* everything opened through `OpenPort()` as a `Port` — serial, RFCOMM, USB serial and **IOIO UART**. An IOIO board used as a UART bridge is untouched; only the IOIO port types where the board itself is the sensor go through the factory functions above.

## The fix

The six functions return `Java::LocalObject` instead of `Java::LocalCloseable`. Ownership of the Java object, and the responsibility to close it, belongs to the `GlobalCloseable` that holds the sensor for its whole lifetime; the temporary never needed it.

All six `Create()` functions in `src/Android/` already return `Java::LocalObject`, so this only removes an implicit conversion — there is no change on the calling side, and `Java::GlobalRef` accepts a `LocalRef` as before.

`Java::LocalCloseable` itself is left alone; `src/Android/TextEntryDialog.cpp` uses it correctly for an object it really does own.

## Testing

All CI targets build.

**Instrumented build, Pixel 3a (Android 12), BLE sensor configured against a device that cannot answer a GATT connect**, so the failure path is exercised. Same build, same device, same profile, permissions granted; only the fix differs:

| | without the fix | with the fix |
|---|---|---|
| `close()` during construction | 1 | 0 |
| connect attempts | 1 | 3 (initial + 2 retries) |
| retries suppressed by `SafeDestruct` | 1 | 0 |
| errors reported to XCSoar | 0 | 1 |
| GATT clients released | 0 | 3 |

Without the fix the log says literally `retryConnect.runnable: SUPPRESSED, safeDestruct is shut down`. With it, `close()` is followed by `cancelOpen()`, `close()` and `unregisterApp()` as it should be.

**Release build without instrumentation, same device:** three connect attempts, three GATT clients released, and `Device error on BLE Sensor: … GATT connection failed (status 133)` shown in the device list.

**On real hardware by a third party.** @alenz-68 tested a build containing this fix with a cosinuss c-med alpha pulse oximeter and reported in #1836: heart rate and SpO2 readings both correct; `Edit → Port → Disabled` now shows *Disabled* and stops the values; the *Disable* button behaves the same and *Enable* restores the connection; restarting XCSoar reconnects both with the sensor running and once it is switched on. Before this fix the same build showed *No data* after connecting, and a disabled sensor stayed connected.

I have no GliderLink or IOIO sensor hardware, so those five cases remain reasoned from the code rather than measured.

---

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [x] Commit messages explain *why* the change was made, not just *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit must compile)
- [x] One commit per logical change (don't mix refactoring with feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Android sensor connection handling for supported devices.
  * Existing sensor-opening behavior and error handling remain unchanged.
  * No user-facing features or supported sensor integrations were added or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->