### PR TITLE
Weather/xctherm: Fix UK forecast layers (met-ukv)

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,4 +1,6 @@
 Version 7.45.2 - not yet released
+* Weather/xctherm
+  - fix UK forecast overlays (met-ukv model and layer catalog) #3029
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -10018,14 +10018,6 @@ msgstr ""
 "Обхваща цялата алпийска дъга от Виена до Перпинян, с прогноза за вълна в "
 "целия регион на Алпите. Модел ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Обединено кралство. Модел ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Имейл XC Therm"
 
@@ -11290,4 +11282,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Модел UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Обединено кралство. Модел UKV."
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -10006,14 +10006,6 @@ msgstr ""
 "Cobreix tot l'arc alpí de Viena a Perpinyà, amb previsió d'ona a tots els "
 "Alps. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Regne Unit. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Email XC Therm"
 
@@ -11277,4 +11269,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Regne Unit. Model UKV."
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -9891,14 +9891,6 @@ msgstr ""
 "Pokryje celý alpský oblouk od Vídně po Perpignan a předpovídá vlnu v celé "
 "alpské oblasti. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Spojené království. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11148,4 +11140,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Spojené království. Model UKV."
 

--- a/po/da.po
+++ b/po/da.po
@@ -9957,14 +9957,6 @@ msgstr ""
 "Tæcker hela alpbågen fra Wien til Perpignan og vejrudsigttiserar vågor i "
 "hela Alperna. ICON-CH-modell."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Storbritannien. ICON-UK-modell."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-post"
 
@@ -11207,4 +11199,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-model"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Storbritannien. UKV-model."
 

--- a/po/de.po
+++ b/po/de.po
@@ -10022,14 +10022,6 @@ msgstr ""
 "Deckt den gesamten Alpenbogen von Wien bis Perpignan ab und prognostiziert "
 "Wellen im gesamten Alpenraum. ICON-CH-Modell."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Vereinigtes Königreich. ICON-UK-Modell."
-
 msgid "XC Therm email"
 msgstr "XC Therm E-Mail"
 
@@ -11300,4 +11292,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-Modell"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Vereinigtes Königreich. UKV-Modell."
 

--- a/po/el.po
+++ b/po/el.po
@@ -10034,14 +10034,6 @@ msgstr ""
 "Καλύπτει ολόκληρο το αλπικό τόξο από τη Βιέννη έως την Περπινιάν, πρόγνωση "
 "κύματος σε όλες τις Άλπεις. Μοντέλο ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ηνωμένο Βασίλειο. Μοντέλο ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Email XC Therm"
 
@@ -11314,4 +11306,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Μοντέλο UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Ηνωμένο Βασίλειο. Μοντέλο UKV."
 

--- a/po/es.po
+++ b/po/es.po
@@ -10058,14 +10058,6 @@ msgstr ""
 "Cubre todo el arco alpino desde Viena hasta Perpiñán, con previsión de onda "
 "en toda la región de los Alpes. Modelo ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Reino Unido. Modelo ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Correo XC Therm"
 
@@ -11338,4 +11330,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Modelo UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Reino Unido. Modelo UKV."
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -9908,14 +9908,6 @@ msgstr ""
 "Kattaa koko Alppikaaren Wienistä Perpignaniin ja ennustaa aaltoa koko "
 "Alppien alueella. ICON-CH-malli."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Yhdistynyt kuningaskunta. ICON-UK-malli."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11173,4 +11165,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-malli"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Yhdistynyt kuningaskunta. UKV-malli."
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -10051,14 +10051,6 @@ msgstr ""
 "Couvre l'arc alpin entier de Vienne à Perpignan, avec prévision d'onde sur "
 "toute la région alpine. Modèle ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Royaume-Uni. Modèle ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11334,4 +11326,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Modèle UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Royaume-Uni. Modèle UKV."
 

--- a/po/he.po
+++ b/po/he.po
@@ -9853,14 +9853,6 @@ msgstr ""
 "מכסה את כל הקשת האלפינית מווינה ועד פרפיניאן, חוזה גל בכל אזור האלפים. דגם "
 "ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "הממלכה המאוחדת. מודל ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11088,4 +11080,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "מודל UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "הממלכה המאוחדת. מודל UKV."
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -9923,14 +9923,6 @@ msgstr ""
 "Pokriva cijeli alpski luk od Beča do Perpignana, prognozirajući val u "
 "cijeloj alpskoj regiji. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11188,4 +11180,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Ujedinjeno Kraljevstvo. Model UKV."
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -9954,14 +9954,6 @@ msgstr ""
 "Lefedi a teljes alpesi ívet Bécstől Perpignanig, hullámot előrejelezve az "
 "egész Alpok régiójában. ICON-CH modell."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Egyesült Királyság. ICON-UK modell."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11228,4 +11220,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-modell"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Egyesült Királyság. UKV-modell."
 

--- a/po/it.po
+++ b/po/it.po
@@ -10064,14 +10064,6 @@ msgstr ""
 "Copre l'intero arco alpino da Vienna a Perpignano, prevedendo le onde in "
 "tutta la regione alpina. Modello ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Regno Unito. Modello ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Email XC Therm"
 
@@ -11343,4 +11335,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Modello UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Regno Unito. Modello UKV."
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -9966,14 +9966,6 @@ msgid ""
 "throughout the whole Alps region. ICON-CH model."
 msgstr "ウィーンからペルピニャンまでのアルプス弧全体をカバーし、アルプス全域のウェーブを予報。ICON-CH モデル。"
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "英国。ICON-UK モデル。"
-
 msgid "XC Therm email"
 msgstr "XC Therm メール"
 
@@ -11164,4 +11156,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV モデル"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "英国。UKV モデル。"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -9740,14 +9740,6 @@ msgid ""
 "throughout the whole Alps region. ICON-CH model."
 msgstr "비엔나에서 페르피냥까지 알프스 전 구간을 다루며 알프스 전역의 웨이브를 예보합니다. ICON-CH 모델."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -10947,4 +10939,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV 모델"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "영국. UKV 모델."
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -9948,14 +9948,6 @@ msgstr ""
 "Apima visą Alpių lanką nuo Vienos iki Perpinjano ir prognozuoja bangą visame"
 " Alpių regione. ICON-CH modelis."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Jungtinė Karalystė. ICON-UK modelis."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11220,4 +11212,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV modelis"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Jungtinė Karalystė. UKV modelis."
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -9870,14 +9870,6 @@ msgstr ""
 "Dekker hele alpebuen fra Wien til Perpignan og varsler bølger i hele Alpene."
 " ICON-CH-modell."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Storbritannien. ICON-UK-modell."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-post"
 
@@ -11123,4 +11115,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-modell"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Storbritannien. UKV-modell."
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -10012,14 +10012,6 @@ msgstr ""
 "Dekt de hele Alpenboog van Wenen tot Perpignan en voorspelt golf over de "
 "hele Alpenregio. ICON-CH-model."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Verenigd Koninkrijk. ICON-UK-model."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11287,4 +11279,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-model"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Verenigd Koninkrijk. UKV-model."
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -10012,14 +10012,6 @@ msgstr ""
 "Obejmuje cały łuk alpejski od Wiednia do Perpignan, prognozując falę w całym"
 " regionie Alp. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Zjednoczone Królestwo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11279,4 +11271,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Zjednoczone Królestwo. Model UKV."
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -9972,14 +9972,6 @@ msgstr ""
 "Cobre todo o arco alpino de Viena a Perpignan, prevendo onda em toda a "
 "região dos Alpes. Modelo ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Reino Unido. Modelo ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11250,4 +11242,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Modelo UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Reino Unido. Modelo UKV."
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9969,14 +9969,6 @@ msgstr ""
 "Cobre todo o arco alpino de Viena a Perpignan, prevendo onda em toda a "
 "região dos Alpes. Modelo ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Reino Unido. Modelo ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11246,4 +11238,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Modelo UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Reino Unido. Modelo UKV."
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -9961,14 +9961,6 @@ msgstr ""
 "Acoperă întregul arc alpin de la Viena la Perpignan, prognozând unda în toți"
 " Alpii. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Regatul Unit. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Email XC Therm"
 
@@ -11233,4 +11225,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Regatul Unit. Model UKV."
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -10000,14 +10000,6 @@ msgstr ""
 "Охватывает всю альпийскую дугу от Вены до Перпиньяна, прогнозируя волну по "
 "всему региону Альп. Модель ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Соединённое Королевство. Модель ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Эл. почта XC Therm"
 
@@ -11265,4 +11257,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Модель UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Соединённое Королевство. Модель UKV."
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -9930,14 +9930,6 @@ msgstr ""
 "Pokryje celý alpský oblouk od Vídně po Perpignan a predpovídá vlnu v celé "
 "alpské oblasti. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Spolené království. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "E-mail XC Therm"
 
@@ -11193,4 +11185,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Spolené království. Model UKV."
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -9905,14 +9905,6 @@ msgstr ""
 "Pokriva cijeli alpski luk od Beča do Perpignana, prognozirajući val u "
 "cijeloj alpskoj regiji. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11170,4 +11162,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Ujedinjeno Kraljevstvo. Model UKV."
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -9914,14 +9914,6 @@ msgstr ""
 "Pokriva cijeli alpski luk od Beča do Perpignana, prognozirajući val u "
 "cijeloj alpskoj regiji. Model ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11176,4 +11168,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Ujedinjeno Kraljevstvo. Model UKV."
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9875,14 +9875,6 @@ msgstr ""
 "Täcker hela alpbågen från Wien till Perpignan och prognostiserar vågor i "
 "hela Alperna. ICON-CH-modell."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Storbritannien. ICON-UK-modell."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-post"
 
@@ -11131,4 +11123,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV-modell"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Storbritannien. UKV-modell."
 

--- a/po/te.po
+++ b/po/te.po
@@ -9742,14 +9742,6 @@ msgstr ""
 "వియన్నా నుండి పెర్పిగ్నాన్ వరకు మొత్తం ఆల్పైన్ ఆర్క్‌ను కవర్ చేస్తుంది, "
 "మొత్తం ఆల్ప్స్ ప్రాంతం అంతటా తరంగాన్ని అంచనా వేస్తుంది. ICON-CH మోడల్."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Ujedinjeno Kraljevstvo. Model ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11013,4 +11005,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Model UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Ujedinjeno Kraljevstvo. Model UKV."
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -9926,14 +9926,6 @@ msgstr ""
 "Viyana'dan Perpignan'a kadar Alp yayının tamamını kapsıyor ve tüm Alpler "
 "bölgesi boyunca dalga tahmini yapıyor. ICON-CH modeli."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Birleşik Krallık. ICON-UK modeli."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11196,4 +11188,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV modeli"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Birleşik Krallık. UKV modeli."
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -9999,14 +9999,6 @@ msgstr ""
 "Охоплює всю альпійську дугу від Відня до Перпіньяна, прогнозуючи хвилю по "
 "всьому регіону Альп. Модель ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Сполучене Королівство. Модель ICON-UK."
-
 msgid "XC Therm email"
 msgstr "Ел. пошта XC Therm"
 
@@ -11266,4 +11258,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Модель UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Сполучене Королівство. Модель UKV."
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -9882,14 +9882,6 @@ msgstr ""
 "Bao trùm toàn bộ vòng cung Alpine từ Vienna đến Perpignan, dự báo làn sóng "
 "trên toàn bộ khu vực Alps. mô hình ICON-CH."
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "Vương quốc Anh. Mô hình ICON-UK."
-
 msgid "XC Therm email"
 msgstr "XC Therm e-mail"
 
@@ -11141,4 +11133,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "Mô hình UKV"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "Vương quốc Anh. Mô hình UKV."
 

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xcsoar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-28 09:08+0200\n"
+"POT-Creation-Date: 2026-09-03 18:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6206,11 +6206,11 @@ msgid "Covers the entire Alpine arc from Vienna to Perpignan, forecasting wave t
 msgstr ""
 
 #, no-c-format
-msgid "UK"
+msgid "UKV Model"
 msgstr ""
 
 #, no-c-format
-msgid "United Kingdom. ICON-UK model."
+msgid "United Kingdom. UKV model."
 msgstr ""
 
 msgid "XC Therm email"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9576,14 +9576,6 @@ msgid ""
 "throughout the whole Alps region. ICON-CH model."
 msgstr "覆盖从维也纳到佩皮尼昂的整个阿尔卑斯弧，预报整个阿尔卑斯地区的波状气流。ICON-CH 模式。"
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "英国。ICON-UK 模式。"
-
 msgid "XC Therm email"
 msgstr "XC Therm 邮箱"
 
@@ -10766,4 +10758,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV 模式"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "英国。UKV 模式。"
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -9584,14 +9584,6 @@ msgid ""
 "throughout the whole Alps region. ICON-CH model."
 msgstr "覆蓋從維也納到佩皮尼昂的整個阿爾卑斯弧，預報整個阿爾卑斯地區的波狀氣流。ICON-CH 模式。"
 
-#, no-c-format
-msgid "UK"
-msgstr "UK"
-
-#, no-c-format
-msgid "United Kingdom. ICON-UK model."
-msgstr "英國。ICON-UK 模式。"
-
 msgid "XC Therm email"
 msgstr "XC Therm 信箱"
 
@@ -10774,4 +10766,12 @@ msgstr ""
 
 msgid "OpenVario audio vario daemon"
 msgstr ""
+
+#, no-c-format
+msgid "UKV Model"
+msgstr "UKV 模式"
+
+#, no-c-format
+msgid "United Kingdom. UKV model."
+msgstr "英國。UKV 模式。"
 

--- a/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/XCThermConfigPanel.cpp
@@ -28,8 +28,8 @@ static constexpr StaticEnumChoice xctherm_region_list[] = {
     N_("Covers the entire Alpine arc from Vienna to Perpignan, "
        "forecasting wave throughout the whole Alps region. "
        "ICON-CH model.") },
-  { unsigned(XCTherm::Region::UK), N_("UK"),
-    N_("United Kingdom. ICON-UK model.") },
+  { unsigned(XCTherm::Region::UK), N_("UKV Model"),
+    N_("United Kingdom. UKV model.") },
   nullptr
 };
 

--- a/src/Weather/xctherm/XCThermCatalog.hpp
+++ b/src/Weather/xctherm/XCThermCatalog.hpp
@@ -73,18 +73,18 @@ constexpr Layer CH_LAYERS[] = {
 };
 
 constexpr Layer UK_LAYERS[] = {
-  { "1000amsl", "vertical_wind_1000amsl",
-    N_("Vertical wind 1000 m AMSL"), N_("1000m AMSL"), 1000, false },
-  { "1500amsl", "vertical_wind_1500amsl",
-    N_("Vertical wind 1500 m AMSL"), N_("1500m AMSL"), 1500, false },
-  { "2000amsl", "vertical_wind_2000amsl",
-    N_("Vertical wind 2000 m AMSL"), N_("2000m AMSL"), 2000, false },
-  { "2500amsl", "vertical_wind_2500amsl",
-    N_("Vertical wind 2500 m AMSL"), N_("2500m AMSL"), 2500, false },
-  { "3000amsl", "vertical_wind_3000amsl",
-    N_("Vertical wind 3000 m AMSL"), N_("3000m AMSL"), 3000, false },
-  { "4200amsl", "vertical_wind_4200amsl",
-    N_("Vertical wind 4200 m AMSL"), N_("4200m AMSL"), 4200, false },
+  { "90000isbl", "vertical_wind_90000isbl",
+    N_("Vertical wind 900 hPa"), N_("900 hPa"), 1000, false },
+  { "85000isbl", "vertical_wind_85000isbl",
+    N_("Vertical wind 850 hPa"), N_("850 hPa"), 1500, false },
+  { "80000isbl", "vertical_wind_80000isbl",
+    N_("Vertical wind 800 hPa"), N_("800 hPa"), 2000, false },
+  { "75000isbl", "vertical_wind_75000isbl",
+    N_("Vertical wind 750 hPa"), N_("750 hPa"), 2500, false },
+  { "70000isbl", "vertical_wind_70000isbl",
+    N_("Vertical wind 700 hPa"), N_("700 hPa"), 3000, false },
+  { "60000isbl", "vertical_wind_60000isbl",
+    N_("Vertical wind 600 hPa"), N_("600 hPa"), 4200, false },
   { "100agl", "vertical_wind_100agl",
     N_("Vertical wind 100 m AGL"), N_("100m AGL"), 100, true },
   { "200agl", "vertical_wind_200agl",
@@ -97,7 +97,7 @@ constexpr Layer UK_LAYERS[] = {
 
 constexpr RegionDef REGIONS[] = {
   { "icon-ch", CH_LAYERS, unsigned(std::size(CH_LAYERS)) },
-  { "icon-uk", UK_LAYERS, unsigned(std::size(UK_LAYERS)) },
+  { "met-ukv", UK_LAYERS, unsigned(std::size(UK_LAYERS)) },
 };
 
 static_assert(std::size(REGIONS) == unsigned(Region::COUNT),


### PR DESCRIPTION
## Summary

Fixes #3029

- Change UK tiles API slug from `icon-uk` to `met-ukv` (matches live XCTherm index)
- Replace UK layer catalog with AGL + ISBL parameters from `met-ukv/index.json`
- Rename region UI label to **UKV Model** with updated description and translations

## Root cause

XCSoar requested `icon-uk` and AMSL parameter names that do not exist on the XCTherm tiles service. Switzerland (`icon-ch`) worked because its slug and layer names matched the API.

## Test plan

- [ ] Configure valid XCTherm credentials
- [ ] Select **UKV Model** region in Config → Weather → XCTherm
- [ ] Verify index.json loads (no auth/404 errors in log)
- [ ] Download a vertical-wind layer over UK bounds and confirm overlay renders
- [ ] Check auto-switch selects sensible ISBL layer from GPS altitude
- [ ] Confirm CH region still works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed UK forecast overlays by switching to the UKV model and updating pressure-level data and labels.
  - Improved compatibility with the updated UK weather layer catalog.

- **User Interface**
  - The UK forecast option is now labeled **UKV Model**, with an updated United Kingdom description.

- **Localization**
  - Updated translations across supported languages to reflect the UKV model naming.

- **Documentation**
  - Added a changelog entry for the UK forecast overlay fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->