### PR TITLE
Show the glide ratio for the safety MC setting

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -72,6 +72,9 @@ Version 7.46 - not yet released
   - let Select as Alternate pin a landing field from AUTO, and use
     Alternate Mode: Auto only to return the Alternate InfoBox to the
     computed list #2912
+  - show the glide ratio for each safety MC value in the Safety Factors
+    setup, both next to the setting and while picking a value, based on
+    the active polar #2552
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862

--- a/src/Dialogs/ComboPicker.cpp
+++ b/src/Dialogs/ComboPicker.cpp
@@ -10,6 +10,7 @@
 #include "Renderer/TextRowListItemRenderer.hpp"
 #include "UIGlobals.hpp"
 #include "Look/DialogLook.hpp"
+#include "Screen/Layout.hpp"
 #include "util/StaticString.hxx"
 
 static const ComboList *ComboListPopup;
@@ -23,7 +24,29 @@ public:
 
   void OnPaintItem(Canvas &canvas, const PixelRect rc,
                    unsigned i) noexcept override {
-    row_renderer.DrawTextRow(canvas, rc, combo_list[i].display_string.c_str());
+    const ComboList::Item &item = combo_list[i];
+    const char *const display_string = item.display_string.c_str();
+
+    row_renderer.DrawTextRow(canvas, rc, display_string);
+
+    if (item.annotation.empty())
+      return;
+
+    /* keep the annotation clear of the scroll bar */
+    PixelRect annotation_rc = rc;
+    annotation_rc.right -= Layout::GetTextPadding() * 2;
+
+    const char *const annotation = item.annotation.c_str();
+    const int left_end = row_renderer.NextColumn(canvas, rc, display_string);
+    const int right_limit =
+      row_renderer.PreviousRightColumn(canvas, annotation_rc, annotation);
+
+    /* Skip the annotation when the row is too narrow for both texts.
+       PreviousRightColumn() reports "does not fit at all" as rc.right,
+       which passes this check; DrawRightColumn() detects that case
+       again and then draws nothing. */
+    if (right_limit > left_end + (int)Layout::GetTextPadding())
+      row_renderer.DrawRightColumn(canvas, annotation_rc, annotation);
   }
 };
 

--- a/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SafetyFactorsConfigPanel.cpp
@@ -7,14 +7,21 @@
 #include "Widget/RowFormWidget.hpp"
 #include "Form/DataField/Float.hpp"
 #include "Form/DataField/Enum.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Form/DataField/ComboList.hpp"
 #include "Interface.hpp"
 #include "Task/ProtectedTaskManager.hpp"
 #include "Language/Language.hpp"
 #include "Units/Units.hpp"
 #include "Formatter/UserUnits.hpp"
+#include "Formatter/GlideRatioFormatter.hpp"
+#include "Engine/GlideSolvers/GlidePolar.hpp"
 #include "UIGlobals.hpp"
 #include "Components.hpp"
 #include "BackendComponents.hpp"
+#include "util/StaticString.hxx"
+
+#include <algorithm>
 
 enum ControlIndex {
   ArrivalHeight,
@@ -23,18 +30,175 @@ enum ControlIndex {
   PolarDegradation,
   AutoBugs,
   SafetyMC,
+  SafetyMCGlideRatio,
   RiskFactor,
   TurnBackMarker,
 };
 
-class SafetyFactorsConfigPanel final : public RowFormWidget {
+/**
+ * Format the best glide ratio in still air at the given MacCready
+ * setting, i.e. the glide ratio achieved when flying at the speed to
+ * fly for it.  The polar must be valid.
+ *
+ * @param user_mc the MacCready setting in the user's vertical speed unit
+ */
+static void
+FormatGlideRatioAtMC(char *buffer, size_t size,
+                     const GlidePolar &polar, double user_mc) noexcept
+{
+  GlidePolar mc_polar = polar;
+  mc_polar.SetMC(Units::ToSysVSpeed(user_mc));
+  FormatGlideRatio(buffer, size, mc_polar.GetBestLD());
+}
+
+/**
+ * The safety MC data field, which shows the glide ratio resulting from
+ * each MacCready value next to it in the combo list.
+ */
+class SafetyMCDataField final : public DataFieldFloat {
+  /**
+   * The polar the glide ratios are calculated with; invalid when no
+   * polar is configured, in which case no glide ratio is shown.
+   */
+  GlidePolar polar;
+
+public:
+  using DataFieldFloat::DataFieldFloat;
+
+  void SetPolar(const GlidePolar &_polar) noexcept {
+    polar = _polar;
+  }
+
+protected:
+  /* virtual methods from class DataFieldFloat */
+  void AppendComboValue(ComboList &combo_list,
+                        double value) const noexcept override;
+};
+
+void
+SafetyMCDataField::AppendComboValue(ComboList &combo_list,
+                                    double value) const noexcept
+{
+  if (!polar.IsValid()) {
+    DataFieldFloat::AppendComboValue(combo_list, value);
+    return;
+  }
+
+  StaticString<decltype(edit_format)::capacity()> edit;
+  edit.Format(edit_format, value);
+
+  StaticString<decltype(display_format)::capacity()> display;
+  display.Format(display_format, value, GetUnits());
+
+  char glide_ratio[16];
+  FormatGlideRatioAtMC(glide_ratio, sizeof(glide_ratio), polar, value);
+
+  const unsigned i = combo_list.Append(edit, display);
+  combo_list.SetAnnotation(i, glide_ratio);
+}
+
+class SafetyFactorsConfigPanel final
+  : public RowFormWidget, DataFieldListener {
+  /**
+   * The help text of the safety MC row, which explains the glide ratio
+   * and names the active polar.  #WndProperty does not copy the help
+   * text, so it is kept here; the fixed capacity keeps the pointer
+   * handed to it valid even when the text is rebuilt.
+   */
+  StaticString<1024> safety_mc_help;
+
 public:
   SafetyFactorsConfigPanel()
     :RowFormWidget(UIGlobals::GetDialogLook()) {}
 
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
   bool Save(bool &changed) noexcept override;
+
+private:
+  /**
+   * @return the polar the safety MC glide ratio is calculated with,
+   * including the polar degradation currently entered in this dialog;
+   * invalid when no polar is configured
+   */
+  GlidePolar GetGlideRatioPolar() const noexcept;
+
+  void BuildSafetyMCHelp() noexcept;
+  void UpdateSafetyMCGlideRatio() noexcept;
+
+  /* methods from DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
 };
+
+void
+SafetyFactorsConfigPanel::OnModified(DataField &df) noexcept
+{
+  if (IsDataField(SafetyMC, df) || IsDataField(PolarDegradation, df))
+    UpdateSafetyMCGlideRatio();
+}
+
+GlidePolar
+SafetyFactorsConfigPanel::GetGlideRatioPolar() const noexcept
+{
+  const PolarSettings &settings = CommonInterface::GetComputerSettings().polar;
+  GlidePolar polar = settings.glide_polar_task;
+
+  if (!polar.IsValid())
+    return polar;
+
+  /* preview the degradation value currently entered in this dialog,
+     applied to the bugs setting like PolarSettings::SetDegradationFactor();
+     the clamp is redundant for values entered here, but keeps SetBugs()
+     inside its assertion range */
+  const double degradation_factor =
+    1 - std::clamp(GetValueFloat(PolarDegradation), 0., 50.) / 100;
+  polar.SetBugs(degradation_factor * settings.bugs);
+
+  return polar;
+}
+
+void
+SafetyFactorsConfigPanel::BuildSafetyMCHelp() noexcept
+{
+  const ComputerSettings &settings = CommonInterface::GetComputerSettings();
+
+  safety_mc_help = _("The MacCready setting used, when safety MC is enabled for reach calculations, in task abort mode and for determining arrival altitude at airfields.");
+  safety_mc_help += "\n\n";
+
+  if (!settings.polar.glide_polar_task.IsValid()) {
+    safety_mc_help += _("No glide polar is configured, so no glide ratio "
+                        "can be shown. Select a plane first.");
+    return;
+  }
+
+  safety_mc_help += _("The glide ratio next to each value is the best "
+                      "glide ratio in still air at that MacCready "
+                      "setting, including bugs, ballast and polar "
+                      "degradation.");
+
+  if (!settings.plane.polar_name.empty()) {
+    safety_mc_help += "\n";
+    safety_mc_help.AppendFormat(_("Active polar: %s"),
+                                settings.plane.polar_name.c_str());
+  }
+}
+
+void
+SafetyFactorsConfigPanel::UpdateSafetyMCGlideRatio() noexcept
+{
+  const GlidePolar polar = GetGlideRatioPolar();
+
+  auto &df = (SafetyMCDataField &)GetDataField(SafetyMC);
+  df.SetPolar(polar);
+
+  if (!polar.IsValid()) {
+    SetText(SafetyMCGlideRatio, _("Unknown"));
+    return;
+  }
+
+  char buffer[16];
+  FormatGlideRatioAtMC(buffer, sizeof(buffer), polar, df.GetValue());
+  SetText(SafetyMCGlideRatio, buffer);
+}
 
 void
 SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
@@ -81,7 +245,8 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
              "50% indicates the glider's sink rate is doubled."),
            "%.0f %%", "%.0f",
            0, 50, 1, false,
-           (1 - settings_computer.polar.degradation_factor) * 100);
+           (1 - settings_computer.polar.degradation_factor) * 100,
+           this);
   SetExpertRow(PolarDegradation);
 
   AddBoolean(_("Auto bugs"), /* xgettext:no-c-format */
@@ -89,14 +254,24 @@ SafetyFactorsConfigPanel::Prepare(ContainerWindow &parent,
              settings_computer.polar.auto_bugs);
   SetExpertRow(AutoBugs);
 
-  AddFloat(_("Safety MC"),
-           _("The MacCready setting used, when safety MC is enabled for reach calculations, in task abort mode and for determining arrival altitude at airfields."),
-           "%.1f %s", "%.1f",
-           0, Units::ToUserVSpeed(10), GetUserVerticalSpeedStep(),
-           false, UnitGroup::VERTICAL_SPEED, task_behaviour.safety_mc);
+  BuildSafetyMCHelp();
+
+  auto *safety_mc =
+    new SafetyMCDataField("%.1f", "%.1f %s",
+                          0, Units::ToUserVSpeed(10),
+                          Units::ToUserVSpeed(task_behaviour.safety_mc),
+                          GetUserVerticalSpeedStep(), false, this);
+  safety_mc->SetUnits(Units::GetVerticalSpeedName());
+  safety_mc->SetFormat(GetUserVerticalSpeedFormat(false, false));
+  Add(_("Safety MC"), safety_mc_help, safety_mc);
   SetExpertRow(SafetyMC);
-  DataFieldFloat &safety_mc = (DataFieldFloat &)GetDataField(SafetyMC);
-  safety_mc.SetFormat(GetUserVerticalSpeedFormat(false, false));
+
+  /* no help text: this row always carries a value, and
+     WndProperty::BeginEditing() then shows the value instead of the
+     help; the explanation is on the safety MC row above */
+  AddReadOnly(_("Safety MC glide ratio"));
+  SetExpertRow(SafetyMCGlideRatio);
+  UpdateSafetyMCGlideRatio();
 
   AddFloat(_("STF risk factor"),
            _("The STF risk factor reduces the MacCready setting used to calculate speed to fly as the glider gets low, in order to compensate for risk. Set to 0.0 for no compensation, 1.0 scales MC linearly with current height (with reference to height of the maximum climb). If considered, 0.3 is recommended."),

--- a/src/Form/DataField/ComboList.hpp
+++ b/src/Form/DataField/ComboList.hpp
@@ -17,6 +17,12 @@ public:
     std::string display_string;
     std::string help_text;
 
+    /**
+     * Optional text drawn at the right edge of the row, e.g. a value
+     * derived from this item.
+     */
+    std::string annotation;
+
     Item(int _int_value, const char *_string_value,
          const char *_display_string,
          const char *_help_text = nullptr) noexcept;
@@ -87,6 +93,15 @@ public:
 
   unsigned Append(const char *string_value) noexcept {
     return Append(string_value, string_value);
+  }
+
+  /**
+   * Set the annotation of an item returned by Append().
+   */
+  void SetAnnotation(unsigned i, const char *annotation) noexcept {
+    items[i].annotation = annotation != nullptr
+      ? annotation
+      : "";
   }
 
   void Sort() noexcept;

--- a/src/Form/DataField/Float.hpp
+++ b/src/Form/DataField/Float.hpp
@@ -6,7 +6,7 @@
 #include "Number.hpp"
 #include "time/PeriodClock.hpp"
 
-class DataFieldFloat final : public NumberDataField {
+class DataFieldFloat : public NumberDataField {
   double mValue;
   double mMin;
   double mMax;
@@ -34,6 +34,10 @@ public:
 
   void SetUnits(const char *text) noexcept {
     unit = text;
+  }
+
+  const char *GetUnits() const noexcept {
+    return unit;
   }
 
   void SetMin(double v) noexcept {
@@ -71,5 +75,10 @@ public:
   void SetFromCombo(int iDataFieldIndex, const char *sValue) noexcept override;
 
 protected:
-  void AppendComboValue(ComboList &combo_list, double value) const noexcept;
+  /**
+   * Append one value to the combo list.  Derived classes may override
+   * this to annotate the entries with a derived value.
+   */
+  virtual void AppendComboValue(ComboList &combo_list,
+                                double value) const noexcept;
 };


### PR DESCRIPTION
Addresses part of #2552. This changes no calculation, it only adds a display.

The Safety Factors setup now shows the glide ratio that a safety MC value produces with the currently active polar, both as a read only row next to the setting and right aligned in the list where the value is picked. Pilots who think in glide ratios get the number they are used to, while reach and abort calculations keep working exactly as before. When no polar is configured the glide ratio is omitted everywhere and the help text explains why.

Two small additive changes were needed to get there: `DataFieldFloat::AppendComboValue()` became virtual so a subclass can annotate its own combo list entries, and `ComboList::Item` gained an optional annotation that `ComboPicker` draws at the right edge of a row. Every other picker renders exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safety Factors settings now show the calculated glide ratio for each Safety MacCready value.
  * Glide ratios reflect the active polar, including current degradation and bug settings.
  * The current glide ratio appears alongside the selected setting and while choosing a value.
  * “Unknown” is shown when no valid polar is available.
  * Selection lists now display explanatory annotations alongside available choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->