### PR TITLE
InfoBoxes: Add "Speed VMG" InfoBox

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -83,6 +83,8 @@ Version 7.46 - not yet released
     from ground speed and wind instead of an instrument
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
+  - add "Speed VMG" InfoBox: the part of the ground speed that closes
+    the distance to the next waypoint
 * ui
   - keep pan-mode menu buttons about 20 mm tall on tall phones,
     large enough for a gloved tap
@@ -103,6 +105,8 @@ Version 7.46 - not yet released
     was delivered to it instead of to the control that was pressed
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
+  - describe the Speed VMG InfoBox in the English, German and Brazilian
+    Portuguese manuals
 * development
   - build system: use Android SDK 36 and Build-Tools 36.0.0
   - documentation: document the release and post-release version workflow

--- a/build/test.mk
+++ b/build/test.mk
@@ -94,6 +94,7 @@ TEST_NAMES = \
 	TestFilteredVarioComputer \
 	TestVarioSynthesiser TestAudioVario \
 	TestWaypointReader TestThermalBase \
+	TestVelocityMadeGood \
 	TestFlarmNet TestFlarmMessaging \
 	TestColorRamp TestXCThermBandQuery TestGeoPoint TestDiffFilter \
 	TestFileUtil TestRepository TestFileType TestPath TestPolars TestCSVLine TestGlidePolar \
@@ -651,6 +652,12 @@ TEST_CLIMB_AV_CALC_SOURCES = \
 	$(TEST_SRC_DIR)/TestClimbAvCalc.cpp
 TEST_CLIMB_AV_CALC_DEPENDS = MATH
 $(eval $(call link-program,TestClimbAvCalc,TEST_CLIMB_AV_CALC))
+
+TEST_VELOCITY_MADE_GOOD_SOURCES = \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/TestVelocityMadeGood.cpp
+TEST_VELOCITY_MADE_GOOD_DEPENDS = MATH
+$(eval $(call link-program,TestVelocityMadeGood,TEST_VELOCITY_MADE_GOOD))
 
 TEST_CIRCLING_WIND_SOURCES = \
 	$(SRC)/Computer/Wind/CirclingWind.cpp \

--- a/doc/manual/de/ch10_infobox_reference.tex
+++ b/doc/manual/de/ch10_infobox_reference.tex
@@ -206,6 +206,13 @@ Wenn der ''Block-Speed-toFly'' Modus aktiviert ist, zeigt diese InfoBox die MacC
 \ibi{Nächster Wegpunkt - Distanz}{WP Dist}{Die Entfernung zum nächsten gewählten Wegpunkt.
 Bei AAT- Aufgaben ist dies der gewählte Zielpunkt innerhalb des AAT-Sektors.}
 
+\ibi{Geschwindigkeit VMG}{V VMG}{Die Geschwindigkeit über Grund in Richtung des
+nächsten Wegpunkts: der Anteil, mit dem die Entfernung zum Wegpunkt tatsächlich
+abnimmt. Sie entspricht der vollen Geschwindigkeit über Grund bei direktem Kurs
+zum Wegpunkt, sinkt quer dazu auf null und wird negativ, wenn man sich entfernt.
+Sie zeigt, was das Verlassen der direkten Route für bessere Steigwerte an
+Fortschritt auf dem Schenkel kostet.}
+
 \ibi{Nächster Wegpunkt - relative Ankunftshöhe}{WP H Diff}{Ankunftshöhe am nächsten Wegpunkt (relativ zur gewählten Sicherheitshöhe).
 Bei AAT-Aufgaben bezogen auf das Ziel innerhalb des AAT - Sektors.}
 

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -218,6 +218,13 @@ is the true bearing to the target within the AAT sector.}
 \ibi{Next radial}{Radial}{True bearing from the next waypoint to your position.}
 \ibi{Next distance}{WP Dist}{Distance to the currently selected waypoint.
 For AAT tasks, this is the distance to the target within the AAT sector.}
+\ibi{Speed VMG}{V VMG}{Velocity made good towards the next waypoint: the
+component of the ground speed along the bearing to it, that is the rate at which
+the distance is shrinking. It equals the ground speed when tracking straight at
+the waypoint, falls to zero at right angles to it and becomes negative when
+flying away. It shows what leaving the direct course for better lift costs in
+progress along the leg: a high ground speed well off track can result in less
+progress than a slower speed flown straight at the waypoint.}
 \ibi{Next altitude difference}{WP AltD}{Arrival altitude at the next waypoint
 relative to the safety arrival height. For AAT tasks, the target within the AAT 
 sector is used.}

--- a/doc/manual/pt_BR/ch10_infobox_reference.tex
+++ b/doc/manual/pt_BR/ch10_infobox_reference.tex
@@ -109,6 +109,7 @@ Nas descrições seguintes dos tipos de infoboxes, o primeiro título é como ap
 \ibi{Next Bearing}{Proa}{Direção verdadeira do próximo waypoint.  Para provas AAT, esta é a direção verdadeira ao alvo dentro do setor AAT.}
 \ibi{Next radial}{Radial}{Direção verdadeira do próximo waypoint até a sua posição.}
 \ibi{Próxima distância}{WP Dist}{A distância do waypoint atualmente selecionado.  Para provas AAT, esta é a distância ao alvo dentro da área AAT.}
+\ibi{Speed VMG}{V VMG}{Velocidade efetiva em direção ao próximo waypoint: a componente da velocidade em relação ao solo ao longo da direção para esse waypoint, ou seja, a taxa com que a distância diminui.  É igual à velocidade em relação ao solo ao voar direto ao waypoint, cai a zero perpendicularmente a ele e fica negativa ao se afastar.  Mostra o que custa, em progresso na perna, deixar a rota direta em busca de melhores ascendências.}
 \ibi{Diferença na próxima altitude}{WP AltD}{Altitude de chegada ao próximo waypoint relativo à altura de chegada de segurança.  Para provas AAT, os alvos dentro do setor AAT são usados.}
 \ibi{Próximo MC0 diferença de altitude}{WP MC0 AltD}{Altitude de chegada ao próximo waypoint com ajuste zero de MacCready relativo à altitude de chegada de segurança.  Para provas AAT, o alvo dentro do setor AAT é usado.}   
 \ibi{Altitude de chegada próximo ponto}{WP AltA}{Altitude absoluta de chegada no próximo waypoint no planeio final.  Para provas AAT, o alvor dentro do setor AAT é usado.}

--- a/po/de.po
+++ b/po/de.po
@@ -8275,6 +8275,20 @@ msgid "Polar W"
 msgstr "Polare W"
 
 #, no-c-format
+msgctxt "InfoBox"
+msgid "Speed VMG"
+msgstr "Geschwindigkeit VMG"
+
+#, no-c-format
+msgctxt "Abbreviation"
+msgid "V VMG"
+msgstr "V VMG"
+
+#, no-c-format
+msgid "The component of the ground speed in the direction of the next waypoint. It equals the ground speed when tracking straight at it, falls to zero at right angles and goes negative when flying away. It puts a number on what a detour off the direct course costs."
+msgstr "Der Anteil der Geschwindigkeit über Grund in Richtung des nächsten Wegpunkts. Er entspricht der vollen Geschwindigkeit über Grund bei direktem Kurs, fällt quer dazu auf null und wird negativ, wenn man sich entfernt. Er beziffert, was ein Umweg abseits der direkten Route kostet."
+
+#, no-c-format
 msgctxt "InfoBox caption (gravity/load factor)"
 msgid "G"
 msgstr "G"

--- a/po/fr.po
+++ b/po/fr.po
@@ -8290,6 +8290,20 @@ msgid "Polar W"
 msgstr "Polaire W"
 
 #, no-c-format
+msgctxt "InfoBox"
+msgid "Speed VMG"
+msgstr "Vitesse VMG"
+
+#, no-c-format
+msgctxt "Abbreviation"
+msgid "V VMG"
+msgstr "V VMG"
+
+#, no-c-format
+msgid "The component of the ground speed in the direction of the next waypoint. It equals the ground speed when tracking straight at it, falls to zero at right angles and goes negative when flying away. It puts a number on what a detour off the direct course costs."
+msgstr "La composante de la vitesse sol dans la direction du prochain point de virage. Elle égale la vitesse sol droit au point, tombe à zéro perpendiculairement et devient négative en s'éloignant. Elle chiffre ce que coûte un détour hors de la route directe."
+
+#, no-c-format
 msgctxt "InfoBox caption (gravity/load factor)"
 msgid "G"
 msgstr "G"

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -8992,6 +8992,20 @@ msgid "Previous waypoint: when an ordered task is loaded, automatically tracks t
 msgstr ""
 
 #, no-c-format
+msgctxt "InfoBox"
+msgid "Speed VMG"
+msgstr ""
+
+#, no-c-format
+msgctxt "Abbreviation"
+msgid "V VMG"
+msgstr ""
+
+#, no-c-format
+msgid "The component of the ground speed in the direction of the next waypoint. It equals the ground speed when tracking straight at it, falls to zero at right angles and goes negative when flying away. It puts a number on what a detour off the direct course costs."
+msgstr ""
+
+#, no-c-format
 msgctxt "InfoBox caption (gravity/load factor)"
 msgid "G"
 msgstr ""

--- a/src/Computer/VelocityMadeGood.hpp
+++ b/src/Computer/VelocityMadeGood.hpp
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Geo/SpeedVector.hpp"
+#include "Math/Angle.hpp"
+
+/**
+ * Calculate the velocity made good (VMG) towards a target: the
+ * component of a velocity along the bearing to that target.  This is
+ * the rate at which the distance to the target shrinks while the
+ * aircraft holds its current velocity.
+ *
+ * @param velocity the velocity over ground
+ * @param target_bearing the bearing from the aircraft to the target
+ * @return the velocity made good [m/s]; the full ground speed when
+ * heading straight at the target, zero when flying at right angles to
+ * it and negative when flying away from it
+ */
+[[gnu::const]]
+static inline double
+CalculateVelocityMadeGood(SpeedVector velocity,
+                          Angle target_bearing) noexcept
+{
+  return velocity.norm * (target_bearing - velocity.bearing).cos();
+}

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1211,6 +1211,14 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentPreviousWaypoint>::Create,
   },
 
+  // e_WP_VMG
+  {
+    NC_("InfoBox", "Speed VMG"),
+    NC_("Abbreviation", "V VMG"),
+    N_("The component of the ground speed in the direction of the next waypoint. It equals the ground speed when tracking straight at it, falls to zero at right angles and goes negative when flying away. It puts a number on what a detour off the direct course costs."),
+    IBFHelper<InfoBoxContentSpeedVMG>::Create,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Task.cpp
+++ b/src/InfoBoxes/Content/Task.cpp
@@ -9,6 +9,7 @@
 #include "Task/ProtectedTaskManager.hpp"
 #include "Dialogs/Dialogs.h"
 #include "Dialogs/Waypoint/WaypointDialogs.hpp"
+#include "Computer/VelocityMadeGood.hpp"
 #include "Engine/Util/Gradient.hpp"
 #include "Engine/Waypoint/Waypoint.hpp"
 #include "Units/Units.hpp"
@@ -95,6 +96,29 @@ UpdateInfoBoxBearingDiff(InfoBoxData &data) noexcept
 
   Angle Value = vector_remaining.bearing - basic.track;
   data.SetValueFromBearingDifference(Value);
+  data.SetValueColor(task_stats.inside_oz ? 3 : 0);
+}
+
+void
+UpdateInfoBoxSpeedVMG(InfoBoxData &data) noexcept
+{
+  const NMEAInfo &basic = CommonInterface::Basic();
+  const TaskStats &task_stats = CommonInterface::Calculated().task_stats;
+  const GeoVector &vector_remaining = task_stats.current_leg.vector_remaining;
+  if (!basic.track_available || !basic.ground_speed_available ||
+      !task_stats.task_valid || !vector_remaining.IsValid() ||
+      vector_remaining.distance <= 10) {
+    data.SetInvalid();
+    return;
+  }
+
+  const SpeedVector ground_velocity{basic.track, basic.ground_speed};
+  const auto vmg = CalculateVelocityMadeGood(ground_velocity,
+                                             vector_remaining.bearing);
+
+  /* no decimals: the value is noisy enough that a tenth of a unit
+     would only flicker */
+  data.SetValueFromSpeed(vmg, false);
   data.SetValueColor(task_stats.inside_oz ? 3 : 0);
 }
 

--- a/src/InfoBoxes/Content/Task.hpp
+++ b/src/InfoBoxes/Content/Task.hpp
@@ -44,6 +44,17 @@ public:
 };
 
 void
+UpdateInfoBoxSpeedVMG(InfoBoxData &data) noexcept;
+
+class InfoBoxContentSpeedVMG : public InfoBoxContentNextWaypointBase
+{
+public:
+  void Update(InfoBoxData &data) noexcept override {
+    UpdateInfoBoxSpeedVMG(data);
+  }
+};
+
+void
 UpdateInfoBoxRadial(InfoBoxData &data) noexcept;
 
 class InfoBoxContentRadial : public InfoBoxContentNextWaypointBase

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -155,6 +155,7 @@ namespace InfoBoxFactory
     e_QNH, /* Current QNH pressure setting; tap to adjust manually */
     e_ActiveWaypoint, /* Active waypoint infobox: shows the current task's next waypoint name (or Goto waypoint if no task), arrival altitude diff, and distance */
     e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
+    e_WP_VMG, /* Speed VMG: the component of ground speed made good towards the next waypoint */
     e_NUM_TYPES /* Last item */
   };
 

--- a/test/src/TestVelocityMadeGood.cpp
+++ b/test/src/TestVelocityMadeGood.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Computer/VelocityMadeGood.hpp"
+#include "TestUtil.hpp"
+
+int main()
+{
+  plan_tests(8);
+
+  /* tracking due north at 30 m/s */
+  constexpr SpeedVector north{Angle::Zero(), 30};
+
+  /* a target straight ahead is approached at the whole ground speed */
+  ok1(equals(CalculateVelocityMadeGood(north, Angle::Zero()), 30));
+
+  /* a target abeam is not approached at all */
+  ok1(is_zero(CalculateVelocityMadeGood(north, Angle::QuarterCircle())));
+
+  /* a target behind recedes at the whole ground speed */
+  ok1(equals(CalculateVelocityMadeGood(north, Angle::HalfCircle()), -30));
+
+  /* 60 degrees off track leaves half of the ground speed */
+  ok1(equals(CalculateVelocityMadeGood(north, Angle::Degrees(60)), 15));
+
+  /* only the magnitude of the angle matters, not the side the target
+     is on */
+  ok1(equals(CalculateVelocityMadeGood(north, Angle::Degrees(-60)), 15));
+
+  /* the bearings need no normalisation beforehand */
+  ok1(is_zero(CalculateVelocityMadeGood(north, Angle::Degrees(270))));
+
+  /* more than 90 degrees off track means the distance grows */
+  ok1(CalculateVelocityMadeGood(north, Angle::Degrees(120)) < 0);
+
+  /* standing still makes no distance good in any direction */
+  ok1(is_zero(CalculateVelocityMadeGood(SpeedVector::Zero(),
+                                        Angle::Degrees(42))));
+
+  return exit_status();
+}


### PR DESCRIPTION
Adds an InfoBox showing the velocity made good towards the next turn point: the component of the ground speed along the direct route to it, that is the rate at which the distance is actually shrinking.

<img width="650" height="510" alt="image" src="https://github.com/user-attachments/assets/63f83a5a-a1bd-4458-8c5b-80f4c027b391" />

## Why

Ground speed alone does not say what leaving the direct course for better lift costs in progress along the leg. A high ground speed well off track can be less efficient than a slower speed flown straight at the waypoint, and this InfoBox turns two candidate courses into two comparable numbers.

It's also an Infobox that's available in the base Condor 3 PDA that I use in online competition and would like to have IRL. 

## Notes

- The new type is appended at the end of `InfoBoxFactory::Type`, since the enum is indexed by position and stored in user profiles.

## Testing

- `make WERROR=y` clean; every commit builds on its own
- `make check`: 113 test programs, 10918 assertions, all pass
- New `TestVelocityMadeGood` unit test
- `make manual` builds; `msgfmt --check` clean on the touched catalogues
- Flown in Condor 3 on Android (arm64)

## Pre-Submission Checklist

### Git & Commit History
- [x] PR is rebased on current `master`
- [x] Commit history cleaned up before submission

### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Present tense in commit messages
- [x] Commit messages explain *why* the change was made
- [x] Commit message bodies provide reasoning and context

### Commit Structure
- [x] Each commit is atomic and builds successfully
- [x] One commit per logical change
- [x] Self-contained commits
- [x] No fixup commits
- [x] No duplicate commits
- [x] No "WIP" or "testing" commits
---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Speed VMG” InfoBox showing the ground-speed component toward the next waypoint.
  * Values indicate progress toward the waypoint, including zero when traveling perpendicular and negative values when moving away.
* **Documentation**
  * Added Speed VMG guidance to the English, German, and Brazilian Portuguese manuals.
  * Added German and French translations.
* **Tests**
  * Added coverage for Speed VMG calculations across multiple headings, including direct, perpendicular, and opposite travel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->