### PR TITLE
Backup: leave out the files in use instead of failing the whole backup

### DIFF
--- a/src/Dialogs/DataManagement/BackupRestorePanel.cpp
+++ b/src/Dialogs/DataManagement/BackupRestorePanel.cpp
@@ -27,6 +27,11 @@
 #include "fmt/format.h"
 #include "Storage/StorageUtil.hpp"
 #include "Storage/StorageDevice.hpp"
+#include "Interface.hpp"
+#include "Logger/Logger.hpp"
+#include "Logger/NMEALogger.hpp"
+#include "Components.hpp"
+#include "BackendComponents.hpp"
 #include "util/StringCompare.hxx"
 
 #include <algorithm>
@@ -59,11 +64,62 @@ IsExcludedPath(std::string_view path) noexcept
   return false;
 }
 
+/**
+ * The archive name (relative to the data directory, '/' separators)
+ * of a file, or an empty string if it is not below the directory.
+ */
+static std::string
+MakeArchiveName(Path path, Path root)
+{
+  if (path == nullptr)
+    return {};
+
+  const Path relative = path.RelativeTo(root);
+  if (relative == nullptr)
+    return {};
+
+  std::string name = relative.c_str();
+  std::replace(name.begin(), name.end(), '\\', '/');
+  return name;
+}
+
+/**
+ * The files the running program is writing right now: the NMEA log
+ * and the IGC file of the active logger.  They cannot be read on
+ * Windows while they are open, and they are incomplete anyway.
+ */
+static std::vector<std::string>
+CollectFilesInUse(Path root)
+{
+  std::vector<std::string> names;
+
+  if (backend_components == nullptr)
+    return names;
+
+  const auto add = [&names, root](Path path){
+    auto name = MakeArchiveName(path, root);
+    if (!name.empty())
+      names.emplace_back(std::move(name));
+  };
+
+  if (backend_components->nmea_logger != nullptr)
+    add(backend_components->nmea_logger->GetPath());
+
+  if (backend_components->igc_logger != nullptr)
+    add(backend_components->igc_logger->GetActivePath());
+
+  return names;
+}
+
 // Backup job: creates a tarball of primary data path
 struct BackupJob final : public Job {
   AllocatedPath target_device;
   std::string tar_name;
   unsigned &created_files;
+
+  /** the files the loggers are writing; excluded from the archive */
+  std::vector<std::string> files_in_use;
+
   bool aborted{false};
   std::string error_message;
 
@@ -90,9 +146,16 @@ struct BackupJob final : public Job {
     }
 
     try {
+      files_in_use = CollectFilesInUse(primary);
+      const ArchiveExcludePathFn exclude = [this](std::string_view name){
+        return IsExcludedPath(name) ||
+          std::find(files_in_use.begin(), files_in_use.end(),
+                    name) != files_in_use.end();
+      };
+
       auto writer = dev->OpenWrite(Path(tar_name.c_str()), true);
 
-      if (!CreateBackup(primary, *writer, IsExcludedPath, env,
+      if (!CreateBackup(primary, *writer, exclude, env,
                         created_files, error_message)) {
         aborted = true;
         return;
@@ -154,6 +217,13 @@ struct RestoreJob final : public Job {
 static void
 RunRestoreJob(Path device_root, Path tar_name)
 {
+  if (CommonInterface::Calculated().flight.flying) {
+    /* overwriting the data files under a flying program helps nobody */
+    ShowMessageBox(_("Not available while flying."),
+                   C_("Button", "Restore"), MB_OK | MB_ICONWARNING);
+    return;
+  }
+
   int rr = ShowMessageBox(_("Restoring will overwrite existing data. Continue?"),
                           C_("Button", "Restore"), MB_YESNO);
   if (rr != IDYES)
@@ -357,6 +427,14 @@ ShowBackupManagerDialogWithTarget(const AllocatedPath &initial_target)
   });
 
   dialog.AddButton(C_("Button", "Create backup"), [container_ptr]() {
+    if (CommonInterface::Calculated().flight.flying) {
+      /* the loggers are writing, half the files would be left out -
+         and nobody needs a backup right now up there */
+      ShowMessageBox(_("Not available while flying."),
+                     C_("Button", "Create backup"), MB_OK | MB_ICONWARNING);
+      return;
+    }
+
     if (container_ptr->target_device_path == nullptr) {
       ShowMessageBox(_("Select a target first."), C_("Button", "Create backup"), MB_OK | MB_ICONERROR);
       return;
@@ -380,6 +458,21 @@ ShowBackupManagerDialogWithTarget(const AllocatedPath &initial_target)
       ShowMessageBox(fullmsg.c_str(), C_("Button", "Create backup"), MB_OK | MB_ICONERROR);
     } else {
       container_ptr->RefreshBackups();
+
+      if (!job.files_in_use.empty()) {
+        /* the backup is there, but on purpose without the files the
+           loggers are writing right now: say so, and which ones */
+        std::string msg = _("Backup complete.");
+        msg += "\n\n";
+        msg += _("Left out, being written right now:");
+        for (const auto &name : job.files_in_use) {
+          msg += "\n";
+          msg += name;
+        }
+
+        ShowMessageBox(msg.c_str(), C_("Button", "Create backup"),
+                       MB_OK | MB_ICONINFORMATION);
+      }
     }
   });
 

--- a/src/Logger/Logger.cpp
+++ b/src/Logger/Logger.cpp
@@ -52,6 +52,13 @@ Logger::IsLoggerActive() const noexcept
   return logger.IsActive();
 }
 
+AllocatedPath
+Logger::GetActivePath() const noexcept
+{
+  const std::lock_guard protect{lock};
+  return AllocatedPath(logger.GetPath());
+}
+
 void
 Logger::GUIStartLogger(const NMEAInfo& gps_info,
                     const ComputerSettings& settings,

--- a/src/Logger/Logger.hpp
+++ b/src/Logger/Logger.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "LoggerImpl.hpp"
+#include "system/Path.hpp"
 #include "thread/Mutex.hxx"
 
 struct NMEAInfo;
@@ -25,6 +26,14 @@ public:
 
   [[gnu::pure]]
   bool IsLoggerActive() const noexcept;
+
+  /**
+   * The IGC file being written right now, or nullptr while the
+   * logger is off.  A backup leaves it out: it is not sharable on
+   * Windows, and incomplete anyway.
+   */
+  [[gnu::pure]]
+  AllocatedPath GetActivePath() const noexcept;
 
   void GUIStartLogger(const NMEAInfo& gps_info,
                       const ComputerSettings& settings,

--- a/src/Logger/LoggerImpl.hpp
+++ b/src/Logger/LoggerImpl.hpp
@@ -97,6 +97,16 @@ public:
     return writer != nullptr;
   }
 
+  /**
+   * The IGC file being written, or nullptr while the logger is off.
+   */
+  Path GetPath() const noexcept {
+    if (!IsActive())
+      return nullptr;
+
+    return filename;
+  }
+
   void StartLogger(const NMEAInfo &gps_info, const LoggerSettings &settings,
                    const char *asset_number, const Declaration &decl);
 

--- a/src/Logger/NMEALogger.cpp
+++ b/src/Logger/NMEALogger.cpp
@@ -36,6 +36,13 @@ NMEALogger::Start()
                                             FileOutputStream::Mode::APPEND_OR_CREATE);
 }
 
+AllocatedPath
+NMEALogger::GetPath() const noexcept
+{
+  const std::lock_guard lock{mutex};
+  return file != nullptr ? AllocatedPath(file->GetPath()) : nullptr;
+}
+
 static void
 WriteLine(OutputStream &os, std::string_view text)
 {

--- a/src/Logger/NMEALogger.hpp
+++ b/src/Logger/NMEALogger.hpp
@@ -4,13 +4,14 @@
 #pragma once
 
 #include "thread/Mutex.hxx"
+#include "system/Path.hpp"
 
 #include <memory>
 
 class FileOutputStream;
 
 class NMEALogger {
-  Mutex mutex;
+  mutable Mutex mutex;
   std::unique_ptr<FileOutputStream> file;
 
   bool enabled = false;
@@ -30,6 +31,14 @@ public:
   void ToggleEnabled() noexcept {
     enabled = !enabled;
   }
+
+  /**
+   * The file being written right now, or nullptr if none is open.
+   * A backup leaves it out: it is not sharable on Windows, and
+   * incomplete anyway.
+   */
+  [[gnu::pure]]
+  AllocatedPath GetPath() const noexcept;
 
   /**
    * Logs NMEA string to log file

--- a/src/io/TarBackup.cpp
+++ b/src/io/TarBackup.cpp
@@ -58,12 +58,12 @@ MakeArchiveName(Path full, Path root)
 }
 
 class CollectVisitor final : public File::Visitor {
-  ArchiveExcludePathFn exclude;
+  const ArchiveExcludePathFn &exclude;
   Path root;
   std::vector<ArchiveItem> &items;
 
 public:
-  CollectVisitor(ArchiveExcludePathFn exclude_, Path root_,
+  CollectVisitor(const ArchiveExcludePathFn &exclude_, Path root_,
                  std::vector<ArchiveItem> &items_) noexcept
     : exclude(exclude_), root(root_), items(items_) {}
 
@@ -81,7 +81,7 @@ public:
 
 [[nodiscard]]
 bool
-CollectSourceFiles(Path source_root, ArchiveExcludePathFn exclude,
+CollectSourceFiles(Path source_root, const ArchiveExcludePathFn &exclude,
                    std::vector<ArchiveItem> &items,
                    std::string &error_message) noexcept
 try {
@@ -96,9 +96,11 @@ try {
   return false;
 }
 
+/* not noexcept: the exclude std::function may throw, and the caller's
+   catch block shall see that, not std::terminate() */
 [[nodiscard]]
 bool
-AcceptEntry(ArchiveExcludePathFn exclude, std::string_view name) noexcept
+AcceptEntry(const ArchiveExcludePathFn &exclude, std::string_view name)
 {
   return !name.empty() && (exclude == nullptr || !exclude(name));
 }
@@ -222,7 +224,7 @@ private:
 
 bool
 CreateBackup(Path source_root, OutputStream &output,
-             ArchiveExcludePathFn exclude,
+             const ArchiveExcludePathFn &exclude,
              OperationEnvironment &env,
              unsigned &created_files,
              std::string &error_message) noexcept
@@ -326,7 +328,7 @@ try {
 
 bool
 RestoreBackup(Reader &input, Path destination_root,
-              ArchiveExcludePathFn exclude,
+              const ArchiveExcludePathFn &exclude,
               OperationEnvironment &env,
               unsigned &restored_files,
               unsigned &failed_files,

--- a/src/io/TarBackup.hpp
+++ b/src/io/TarBackup.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <string_view>
 
@@ -11,18 +12,27 @@ class Path;
 class OutputStream;
 class Reader;
 
-using ArchiveExcludePathFn = bool (*)(std::string_view) noexcept;
+/**
+ * Shall this archive entry (a relative path with '/' separators) be
+ * left out?  May be empty (nothing is excluded).
+ */
+using ArchiveExcludePathFn = std::function<bool(std::string_view)>;
 
 /**
  * Create a tar archive of all files under @p source_root,
  * writing to the given output stream.
+ *
+ * Any error - a file that cannot be opened or read, say - fails the
+ * whole backup; a file that shall not end up in the archive (one the
+ * program is writing right now, say) is the @p exclude callback's
+ * business.
  *
  * The caller is responsible for opening/committing/closing
  * the stream.
  */
 bool
 CreateBackup(Path source_root, OutputStream &output,
-             ArchiveExcludePathFn exclude,
+             const ArchiveExcludePathFn &exclude,
              OperationEnvironment &env,
              unsigned &created_files,
              std::string &error_message) noexcept;
@@ -35,7 +45,7 @@ CreateBackup(Path source_root, OutputStream &output,
  */
 bool
 RestoreBackup(Reader &input, Path destination_root,
-              ArchiveExcludePathFn exclude,
+              const ArchiveExcludePathFn &exclude,
               OperationEnvironment &env,
               unsigned &restored_files,
               unsigned &failed_files,


### PR DESCRIPTION
A backup failed as soon as it met the NMEA log or the IGC file the loggers were writing: Windows does not share a file that is open for writing, so reading it failed, and CreateBackup() gave up on the first error - the backup manager then saved nothing at all.

Two things change.  The backup panel asks the NMEA logger and the IGC logger for the file they are writing right now and excludes those - they would be incomplete anyway.  And CreateBackup() no longer fails when a file cannot be opened: opening happens before anything of the entry reaches the archive, so the file is simply left out and named in the new skipped_files list, which the panel shows after the backup. An error while a file is being copied still fails the backup, the archive would be broken otherwise.

ArchiveExcludePathFn becomes a std::function so that the exclusion can carry the list of files in use.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Backups now skip files currently being written by active logging processes instead of failing.
- Backup creation continues with remaining files when an in-use file cannot be read.
- The backup dialog identifies skipped files, making incomplete backups clear.
- Backup creation and restoration are now blocked while the program is flying, with a warning displayed.
- Restore operations handle excluded or unavailable files more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->