### PR TITLE
Port: a write that took nothing is a retry, not an assertion

### DIFF
--- a/src/Device/Port/Port.cpp
+++ b/src/Device/Port/Port.cpp
@@ -11,7 +11,6 @@
 #include "util/SpanCast.hxx"
 
 #include <algorithm>
-#include <cassert>
 
 Port::Port(PortListener *_listener, DataHandler &_handler) noexcept
   :listener(_listener), handler(_handler) {}
@@ -45,14 +44,29 @@ Port::FullWrite(std::span<const std::byte> src,
   const TimeoutClock timeout(_timeout);
 
   while (!src.empty()) {
+    if (env.IsCancelled())
+      throw OperationCancelled{};
+
     if (timeout.HasExpired())
       throw DeviceTimeout{"Port write timeout"};
 
     std::size_t nbytes = Write(src);
-    assert(nbytes > 0);
 
     if (env.IsCancelled())
       throw OperationCancelled{};
+
+    if (nbytes == 0) {
+      /* the port took nothing this time: a serial port on Windows
+         does that when its own write timeout expires first, e.g. on
+         a USB adapter that is still coming up right after the
+         machine did - try again until our timeout expires, but do
+         not spin on a port that returns at once; the sleep is
+         capped by the remaining time so the deadline cannot be
+         overshot */
+      env.Sleep(std::min<std::chrono::steady_clock::duration>(
+          std::chrono::milliseconds(20), timeout.GetRemainingOrZero()));
+      continue;
+    }
 
     src = src.subspan(nbytes);
   }


### PR DESCRIPTION
Port::FullWrite() asserted that every Write() call moved at least one byte.  The Windows serial port does not promise that: its writes run with a total timeout of one second (SetRxTimeout()), and when the driver cannot get the data out in time - a USB serial adapter still coming up right after the machine did, while the device drivers already send their initialisation - WriteFile() completes with zero bytes.  A debug build then died in the assertion ("nbytes > 0"), a release build spun on the port until FullWrite's own timeout.

Treat a zero-byte write as what it is: nothing happened yet.  Keep trying until the caller's timeout expires, with a short pause so that a port returning at once does not turn the loop into a busy one.

Thank you for contributing to XCSoar!

We truly appreciate your time and effort in making XCSoar better. We know
that contributing to an open-source project can be challenging, and we're
grateful that you've chosen to help.

This checklist is here to help guide you through the submission process.
Don't worry if you're not sure about something—feel free to ask questions
or submit your PR, and we'll work together to get it ready.

For coding, style guide, architecture information please see our
[development guide](https://xcsoar.readthedocs.io/en/latest/index.html).

For Git tips and tricks, including interactive rebase, fixup commits, and
common workflows, see the
[Git Tips](https://xcsoar.readthedocs.io/en/latest/git_tips.html)
documentation.

For testing and debugging utilities, see the
[Test & Debug
Utilities](https://xcsoar.readthedocs.io/en/latest/test_debug_utilities.html)
documentation. 

## Pre-Submission Checklist

Please verify the following before submitting your PR:

### Git & Commit History

#### Branch & Rebase
- [ ] PR is rebased on current `master`
- [ ] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages
- [ ] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [ ] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [ ] Commit messages explain *why* the change was made, not just
  *what* changed
- [ ] Commit message body (if needed) provides detailed reasoning and
  context

#### Commit Structure
- [ ] Each commit is atomic and builds successfully (every commit
  must compile)
- [ ] One commit per logical change (don't mix refactoring with
  feature changes)
- [ ] Self-contained commits (each commit changes one thing)
- [ ] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [ ] No duplicate commits (check with `git log --oneline`)
- [ ] No "WIP" or "testing" commits (clean up before PR)

---

- [ ] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved write reliability when the underlying port temporarily accepts zero bytes.
  - Write attempts now retry until the configured timeout expires without exceeding the deadline.
  - Cancellation is detected promptly during retry waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->