### PR TITLE
InfoBoxes: Add an arrange mode for the InfoBoxes of a page

### DIFF
--- a/Data/Input/default.xci
+++ b/Data/Input/default.xci
@@ -1690,6 +1690,14 @@ event=Mode weather
 label=Forecast\nControls
 location=45
 
+mode=RemoteStick
+type=key
+data=0
+event=ArrangeInfoBoxes
+event=Mode default
+label=Arrange\nInfoBoxes
+location=46
+
 # -------------
 # Define gesture to open Quickmenu without keyboard or remote
 # ("Draw a button on the screen")

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -76,6 +76,12 @@ Version 7.46 - not yet released
     to the list and highlights an item so Enter acts on that row
     #2862
 * infoboxen
+  - rearrange the InfoBoxes of a page by dragging one onto another;
+    a long press or the Quick Menu opens that mode, and the cursor
+    keys and a remote stick do the same
+  - compose the InfoBox sets in the configuration with the same view:
+    every InfoBox is a card which can be moved around, and Copy and
+    Paste stand next to its other buttons
   - pack portrait InfoBoxes on tall screens so title, value, and
     comment sit closer together; InfoBox title size still grows the
     boxes toward square at 150%
@@ -103,6 +109,8 @@ Version 7.46 - not yet released
     was delivered to it instead of to the control that was pressed
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
+  - describe how to rearrange the InfoBoxes, and correct how the
+    InfoBox dialogue is opened
 * development
   - build system: use Android SDK 36 and Build-Tools 36.0.0
   - documentation: document the release and post-release version workflow

--- a/build/infobox.mk
+++ b/build/infobox.mk
@@ -28,6 +28,8 @@ LIBINFOBOX_SOURCES = \
 	$(SRC)/InfoBoxes/InfoBoxWindow.cpp \
 	$(SRC)/InfoBoxes/InfoBoxLayout.cpp \
 	$(SRC)/InfoBoxes/InfoBoxManager.cpp \
+	$(SRC)/InfoBoxes/InfoBoxArrange.cpp \
+	$(SRC)/InfoBoxes/InfoBoxArrangeWindow.cpp \
 	$(SRC)/InfoBoxes/Panel/AltitudeInfo.cpp \
 	$(SRC)/InfoBoxes/Panel/AltitudeSimulator.cpp \
 	$(SRC)/InfoBoxes/Panel/AltitudeSetup.cpp \

--- a/doc/input_events.rst
+++ b/doc/input_events.rst
@@ -250,6 +250,10 @@ Event list
    - Controls waypoint advance trigger arming. Possible arguments:
      ``on`` (arm), ``off`` (disarm), ``toggle``, ``show``
      (display current state).
+ * - ``ArrangeInfoBoxes``
+   - Opens the InfoBox arrange mode, which edits the InfoBox set of
+     the page currently shown: an InfoBox can be dragged to another
+     slot or moved there with the cursor keys.
  * - ``AudioDeadband``
    - Adjusts the audio deadband of internal vario sounds. Possible
      arguments: ``+`` (increase deadband), ``-`` (decrease

--- a/doc/manual/en/ch02_user_interface.tex
+++ b/doc/manual/en/ch02_user_interface.tex
@@ -513,7 +513,7 @@ To go through the various screen pages, use gesture left/right (touch-screen), o
 
 (This section applies only when a touch-screen or mouse is present.)
 
-Some InfoBox values can be changed by the user by selecting (i.e.\ long-pressing) the
+Some InfoBox values can be changed by the user by tapping the
 InfoBox with the touch-screen or mouse.  This brings up a small tabular dialogue:
 
 \begin{description}
@@ -532,6 +532,35 @@ InfoBox with the touch-screen or mouse.  This brings up a small tabular dialogue
 Examples of InfoBoxes that can
 be adjusted include MacCready setting, wind speed, and altitude (QNH).
 
+
+\subsection*{Rearranging InfoBoxes}\label{sec:arrange_infoboxes}
+
+Press and hold an InfoBox for a moment to enter the arrange mode; the
+`\emph{Arrange InfoBoxes}' item of the Quick Menu opens the same mode.
+The screen is dimmed and every InfoBox is replaced by a card showing
+only its number and its caption.
+
+Drag a card onto another one to exchange the two.  The InfoBox which
+makes way slides over into the slot the dragged one has left.  Putting
+a second finger on the screen aborts the drag.  Tapping a card explains
+what that InfoBox shows, holding it opens the list of all available
+InfoBoxes.
+
+Without a touch-screen the cursor keys and a remote stick select an
+InfoBox, and Tab steps through them one after another, following the
+rows or columns the geometry puts them in.  Enter takes the
+selected InfoBox, the cursor keys then move it, and Enter puts it down
+again.  Taking an InfoBox and putting it down without having moved it
+opens the list of available InfoBoxes instead.
+
+`\emph{Help}' explains how an InfoBox is moved and how it is replaced.
+`\emph{Close}' leaves the mode and keeps the new order, and so does the
+timeout after the same time as the menu; the Escape key leaves the mode
+and restores the order the page had before.
+
+The InfoBox sets are composed in the same view, where two more buttons
+copy a set and paste it into another one
+(see Section~\ref{conf:infobox_sets}).
 
 \subsection*{Changing InfoBox sets}
 

--- a/doc/manual/en/ch11_configuration.tex
+++ b/doc/manual/en/ch11_configuration.tex
@@ -828,16 +828,18 @@ This page shows and let you customise the available InfoBox sets.
 
 \subsection*{InfoBox Set Customisation}
 
+The dialogue shows the set the way it is laid out on the screen: every
+InfoBox is a card with its number and its caption, and the set is
+composed by moving these cards around, exactly as on the map (see
+Section~\ref{sec:arrange_infoboxes}).
+
 \begin{description}
 \item[Name]  Sets the name of the currently customized InfoBox set. The 
   button starts the text input dialogue of XCSoar.
-\item[InfoBox]  The number identifying the current box.
-\item[Content]  Select the information you want to see in the current box.
+\item[Help]  Explains how an InfoBox is moved and how it is replaced.
+\item[Copy]  Remembers all InfoBoxes of this set.
+\item[Paste]  Replaces the InfoBoxes of another set with them.
 \end{description}
-
-The right side of the dialogue always gives the overview on the composed set. 
-When composing at the PC you can use the mouse to select the individual boxes 
-right from the overview.
 
 See Section~\ref{cha:infobox} for a description of the InfoBox types and their meanings.
 

--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -4,84 +4,64 @@
 #include "dlgConfigInfoboxes.hpp"
 #include "Dialogs/WidgetDialog.hpp"
 #include "Dialogs/Message.hpp"
+#include "Dialogs/TextEntry.hpp"
 #include "Look/DialogLook.hpp"
-#include "Look/Colors.hpp"
-#include "UIGlobals.hpp"
-#include "Widget/RowFormWidget.hpp"
-#include "Form/Frame.hpp"
-#include "Form/Button.hpp"
-#include "ui/canvas/Canvas.hpp"
-#include "Screen/Layout.hpp"
-#include "Form/DataField/Enum.hpp"
-#include "Form/DataField/Listener.hpp"
-#include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Widget/Widget.hpp"
+#include "InfoBoxes/InfoBoxArrangeWindow.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
-#include "InfoBoxes/Content/Factory.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Interface.hpp"
-#include "Look/InfoBoxLook.hpp"
 #include "Language/Language.hpp"
-#include "util/StringAPI.hxx"
-#include "util/StaticArray.hxx"
-
-#include <cassert>
-#include <fmt/format.h>
+#include "util/StaticString.hxx"
 
 using namespace UI;
 
 static InfoBoxSettings::Panel clipboard;
 static unsigned clipboard_size;
 
-class InfoBoxesConfigWidget;
-
-class InfoBoxPreview : public PaintWindow {
-  InfoBoxesConfigWidget *parent;
-  unsigned i;
-
-public:
-  void SetParent(InfoBoxesConfigWidget &_parent, unsigned _i) {
-    parent = &_parent;
-    i = _i;
-  }
-
-protected:
-  /* virtual methods from class Window */
-  bool OnMouseDown(PixelPoint p) noexcept override;
-  bool OnMouseDouble(PixelPoint p) noexcept override;
-
-  /* virtual methods from class PaintWindow */
-  void OnPaint(Canvas &canvas) noexcept override;
-};
-
-class InfoBoxesConfigWidget final
-  : public RowFormWidget, DataFieldListener {
-
-  enum Controls {
-    NAME, INFOBOX, CONTENT, DESCRIPTION
-  };
-
+class InfoBoxesConfigWidget final : public NullWidget {
   struct Layout {
     InfoBoxLayout::Layout info_boxes;
 
-    PixelRect form;
-
-    PixelRect copy_button, paste_button, close_button;
-
+    Layout() = default;
     Layout(PixelRect rc, InfoBoxSettings::Geometry geometry);
   };
 
+  /** the InfoBoxes of this set; it reports every change back */
+  class ArrangeWindow final : public InfoBoxArrangeWindow {
+    InfoBoxesConfigWidget &widget;
+
+  public:
+    ArrangeWindow(InfoBoxesConfigWidget &_widget,
+                  const DialogLook &_dialog_look,
+                  const InfoBoxLook &_look) noexcept
+      :InfoBoxArrangeWindow(_look, _dialog_look, Style::DIALOG),
+       widget(_widget) {}
+
+  protected:
+    /* virtual methods from class InfoBoxArrangeWindow */
+    void OnArrangeModified() noexcept override {
+      widget.changed = true;
+    }
+  };
+
   WndForm &dialog;
-  const InfoBoxLook &look;
 
   InfoBoxSettings::Panel &data;
   const bool allow_name_change;
-  bool changed;
+  bool changed = false;
 
   const InfoBoxSettings::Geometry geometry;
 
-  StaticArray<InfoBoxPreview, InfoBoxSettings::Panel::MAX_CONTENTS> previews;
-  unsigned current_preview;
+  /** the caption of the button which renames the set */
+  StaticString<64> name_caption;
 
-  Button copy_button, paste_button, close_button;
+  Layout layout;
+
+  ArrangeWindow arrange;
+
+  /** the button which pastes the clipboard */
+  unsigned paste_button;
 
 public:
   InfoBoxesConfigWidget(WndForm &_dialog,
@@ -90,109 +70,50 @@ public:
                         InfoBoxSettings::Panel &_data,
                         bool _allow_name_change,
                         InfoBoxSettings::Geometry _geometry)
-    :RowFormWidget(dialog_look),
-     dialog(_dialog),
-     look(_look),
+    :dialog(_dialog),
      data(_data),
      allow_name_change(_allow_name_change),
-     changed(false),
-     geometry(_geometry) {}
+     geometry(_geometry),
+     arrange(*this, dialog_look, _look) {}
 
-  const InfoBoxLook &GetInfoBoxLook() const {
-    return look;
+private:
+  void RefreshPasteButton() noexcept {
+    arrange.SetButtonEnabled(paste_button, clipboard_size > 0);
   }
 
-  const InfoBoxSettings::Panel &GetData() const {
-    return data;
+  void OnRename() noexcept;
+  void OnCopy() noexcept;
+  void OnPaste() noexcept;
+
+  /** Recalculate the layout for @p rc and hand it to #arrange. */
+  void UpdateLayout(const PixelRect &rc) noexcept {
+    layout = Layout(rc, geometry);
+    arrange.SetLayout(layout.info_boxes, layout.info_boxes.remaining);
   }
 
-  void RefreshPasteButton() {
-    paste_button.SetEnabled(clipboard_size > 0);
-  }
-
-  void RefreshEditContentDescription();
-  void RefreshEditContent();
-
-  void OnCopy();
-  void OnPaste();
-
-  void SetCurrentInfoBox(unsigned _current_preview);
-
-  unsigned GetCurrentInfoBox() const {
-    return current_preview;
-  }
-
-  InfoBoxFactory::Type GetContents(unsigned i) const {
-    return data.contents[i];
-  }
-
-  void BeginEditing() {
-    GetControl(CONTENT).BeginEditing();
-  }
-
+public:
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
 
   bool Save(bool &changed) noexcept override;
 
   void Show(const PixelRect &rc) noexcept override {
-    const Layout layout(rc, geometry);
-
-    RowFormWidget::Show(layout.form);
-
-    copy_button.MoveAndShow(layout.copy_button);
-    paste_button.MoveAndShow(layout.paste_button);
-    close_button.MoveAndShow(layout.close_button);
-
-    for (unsigned i = 0; i < previews.size(); ++i)
-      previews[i].MoveAndShow(layout.info_boxes.positions[i]);
+    UpdateLayout(rc);
+    arrange.MoveAndShow(rc);
   }
 
   void Hide() noexcept override {
-    RowFormWidget::Hide();
-
-    copy_button.Hide();
-    paste_button.Hide();
-    close_button.Hide();
-
-    for (auto &i : previews)
-      i.Hide();
+    arrange.Hide();
   }
 
   void Move(const PixelRect &rc) noexcept override {
-    const Layout layout(rc, geometry);
-
-    RowFormWidget::Move(layout.form);
-
-    copy_button.Move(layout.copy_button);
-    paste_button.Move(layout.paste_button);
-    close_button.Move(layout.close_button);
+    UpdateLayout(rc);
+    arrange.Move(rc);
   }
 
   bool SetFocus() noexcept override {
-    GetGeneric(INFOBOX).SetFocus();
+    arrange.SetFocus();
     return true;
-  }
-
-private:
-  /* virtual methods from class DataFieldListener */
-
-  void OnModified(DataField &df) noexcept override {
-    if (IsDataField(INFOBOX, df)) {
-      const DataFieldEnum &dfe = (const DataFieldEnum &)df;
-      SetCurrentInfoBox(dfe.GetValue());
-    } else if (IsDataField(CONTENT, df)) {
-      const DataFieldEnum &dfe = (const DataFieldEnum &)df;
-
-      auto new_value = (InfoBoxFactory::Type)dfe.GetValue();
-      if (new_value == data.contents[current_preview])
-        return;
-
-      changed = true;
-      data.contents[current_preview] = new_value;
-      previews[current_preview].Invalidate();
-      RefreshEditContentDescription();
-    }
   }
 };
 
@@ -202,112 +123,62 @@ InfoBoxesConfigWidget::Layout::Layout(PixelRect rc,
   const unsigned title_scale =
     CommonInterface::GetUISettings().info_boxes.scale_title_font;
   info_boxes = InfoBoxLayout::Calculate(rc, geometry, title_scale);
-
-  form = info_boxes.remaining;
-  auto buttons = form.CutTopSafe(::Layout::GetMaximumControlHeight());
-
-  copy_button = paste_button = close_button = buttons;
-  copy_button.right = paste_button.left =
-    (2 * buttons.left + buttons.right) / 3;
-  paste_button.right = close_button.left =
-    (buttons.left + 2 * buttons.right) / 3;
 }
 
 void
 InfoBoxesConfigWidget::Prepare(ContainerWindow &parent,
                                const PixelRect &rc) noexcept
 {
-  const Layout layout(rc, geometry);
+  UpdateLayout(rc);
 
-  AddText(_("Name"),
-          _("The name of this InfoBox panel configuration."),
-          allow_name_change ? (const char *)data.name : gettext(data.name));
-  SetReadOnly(NAME, !allow_name_change);
+  arrange.SetExtraHelp(allow_name_change
+                       ? _("The button with the name of the set renames it, "
+                           "Copy remembers all its InfoBoxes, and Paste "
+                           "replaces the InfoBoxes of another set with "
+                           "them.")
+                       : _("Copy remembers all InfoBoxes of this set, Paste "
+                           "replaces the InfoBoxes of another set with "
+                           "them."));
 
-  DataFieldEnum *dfe = new DataFieldEnum(this);
-  for (unsigned i = 0; i < layout.info_boxes.count; ++i) {
-    const auto label = fmt::format_int(i + 1);
-    dfe->addEnumText(label.c_str(), i);
-  }
+  /* the upper row changes the set, the lower one acts on the dialogue */
+  name_caption = gettext(data.name);
+  const unsigned name_button =
+    arrange.AddButton(1, name_caption, [this]{ OnRename(); });
+  arrange.AddButton(1, _("Copy"), [this]{ OnCopy(); });
+  paste_button = arrange.AddButton(1, _("Paste"), [this]{ OnPaste(); });
 
-  Add(_("InfoBox"), nullptr, dfe);
+  arrange.AddButton(_("Help"), [this]{ arrange.ShowHelp(); });
+  arrange.AddButton(_("Close"), dialog.MakeModalResultCallback(mrOK));
 
-  dfe = new DataFieldEnum(this);
-  for (unsigned i = InfoBoxFactory::MIN_TYPE_VAL; i < InfoBoxFactory::NUM_TYPES; i++) {
-    const char *name = InfoBoxFactory::GetName((InfoBoxFactory::Type) i);
-    const char *desc = InfoBoxFactory::GetDescription((InfoBoxFactory::Type) i);
-    if (name != NULL)
-      dfe->addEnumText(gettext(name), i, desc != NULL ? gettext(desc) : NULL);
-  }
+  arrange.SetPanel(data);
+  arrange.Create(parent, rc);
+  arrange.FocusSlot(0);
 
-  dfe->EnableItemHelp(true);
-  dfe->Sort(0);
-
-  Add(_("Content"), nullptr, dfe);
-
-  ContainerWindow &form_parent = (ContainerWindow &)RowFormWidget::GetWindow();
-  AddRemaining(std::make_unique<WndFrame>(form_parent, GetLook(), rc));
-
-  WindowStyle button_style;
-  button_style.Hide();
-  button_style.TabStop();
-
-  const auto &button_look = GetLook().button;
-  copy_button.Create(parent, button_look, _("Copy Set"), layout.copy_button,
-                     button_style, [this](){ OnCopy(); });
-  paste_button.Create(parent, button_look, _("Paste Set"), layout.paste_button,
-                      button_style, [this](){ OnPaste(); });
-  close_button.Create(parent, button_look, _("Close"), layout.close_button,
-                      button_style, dialog.MakeModalResultCallback(mrOK));
-
-  WindowStyle preview_style;
-  preview_style.Hide();
-
-  previews.resize(layout.info_boxes.count);
-  for (unsigned i = 0; i < layout.info_boxes.count; ++i) {
-    previews[i].SetParent(*this, i);
-    previews[i].Create(parent, layout.info_boxes.positions[i],
-                       preview_style);
-  }
-
-  current_preview = 0;
-
-  RefreshEditContent();
+  /* only the sets the user has made himself can be renamed */
+  arrange.SetButtonEnabled(name_button, allow_name_change);
   RefreshPasteButton();
 }
 
 bool
 InfoBoxesConfigWidget::Save(bool &changed_r) noexcept
 {
-  if (allow_name_change) {
-    const auto *new_name = GetValueString(InfoBoxesConfigWidget::NAME);
-    if (!StringIsEqual(new_name, data.name)) {
-      data.name = new_name;
-      changed = true;
-    }
-  }
-
   changed_r = changed;
   return true;
 }
 
 void
-InfoBoxesConfigWidget::RefreshEditContentDescription()
+InfoBoxesConfigWidget::OnRename() noexcept
 {
-  DataFieldEnum &df = (DataFieldEnum &)GetDataField(CONTENT);
-  WndFrame &description = (WndFrame &)GetRow(DESCRIPTION);
-  description.SetText(df.GetHelp() != nullptr ? df.GetHelp() : "");
+  if (!TextEntryDialog(data.name, _("Name")))
+    return;
+
+  name_caption = data.name;
+  changed = true;
+  arrange.Invalidate();
 }
 
 void
-InfoBoxesConfigWidget::RefreshEditContent()
-{
-  LoadValueEnum(CONTENT, data.contents[current_preview]);
-  RefreshEditContentDescription();
-}
-
-void
-InfoBoxesConfigWidget::OnCopy()
+InfoBoxesConfigWidget::OnCopy() noexcept
 {
   clipboard = data;
   clipboard_size = InfoBoxSettings::Panel::MAX_CONTENTS;
@@ -316,13 +187,14 @@ InfoBoxesConfigWidget::OnCopy()
 }
 
 void
-InfoBoxesConfigWidget::OnPaste()
+InfoBoxesConfigWidget::OnPaste() noexcept
 {
   if (clipboard_size == 0)
     return;
 
-  if(ShowMessageBox(_("Overwrite all InfoBoxes in this set?"), _("InfoBox paste set"),
-                 MB_YESNO | MB_ICONQUESTION) != IDYES)
+  if (ShowMessageBox(_("Overwrite all InfoBoxes in this set?"),
+                     _("InfoBox paste set"),
+                     MB_YESNO | MB_ICONQUESTION) != IDYES)
     return;
 
   for (unsigned item = 0; item < clipboard_size; item++) {
@@ -331,76 +203,10 @@ InfoBoxesConfigWidget::OnPaste()
       continue;
 
     data.contents[item] = content;
-
-    if (item < previews.size())
-      previews[item].Invalidate();
   }
 
-  RefreshEditContent();
   changed = true;
-}
-
-void
-InfoBoxesConfigWidget::SetCurrentInfoBox(unsigned _current_preview)
-{
-  assert(_current_preview < previews.size());
-
-  if (_current_preview == current_preview)
-    return;
-
-  previews[current_preview].Invalidate();
-  current_preview = _current_preview;
-  previews[current_preview].Invalidate();
-
-  LoadValueEnum(INFOBOX, current_preview);
-
-  RefreshEditContent();
-}
-
-bool
-InfoBoxPreview::OnMouseDown([[maybe_unused]] PixelPoint p) noexcept
-{
-  parent->SetCurrentInfoBox(i);
-  return true;
-}
-
-bool
-InfoBoxPreview::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
-{
-  parent->BeginEditing();
-  return true;
-}
-
-void
-InfoBoxPreview::OnPaint(Canvas &canvas) noexcept
-{
-  const auto &dlook = UIGlobals::GetDialogLook();
-  const bool is_current = i == parent->GetCurrentInfoBox();
-
-  if (is_current)
-    canvas.Clear(dlook.dark_mode
-                 ? COLOR_XCSOAR_DARK : COLOR_BLACK);
-  else
-    canvas.Clear(dlook.background_color);
-
-  canvas.SelectHollowBrush();
-  canvas.Select(Pen(Layout::ScaleFinePenWidth(1),
-                    dlook.dark_mode ? COLOR_GRAY : COLOR_BLACK));
-  canvas.DrawRectangle(PixelRect{PixelSize{canvas.GetWidth() - 1, canvas.GetHeight() - 1}});
-
-  InfoBoxFactory::Type type = parent->GetContents(i);
-  const char *caption = type < InfoBoxFactory::NUM_TYPES
-    ? InfoBoxFactory::GetCaption(type)
-    : NULL;
-  if (caption == NULL)
-    caption = _("Invalid");
-  else
-    caption = gettext(caption);
-
-  canvas.Select(parent->GetInfoBoxLook().title_font);
-  canvas.SetBackgroundTransparent();
-  canvas.SetTextColor(is_current ? COLOR_WHITE : dlook.text_color);
-  canvas.DrawText({2, 2}, caption);
+  arrange.Invalidate();
 }
 
 bool
@@ -411,11 +217,19 @@ dlgConfigInfoboxesShowModal(SingleWindow &parent,
                             InfoBoxSettings::Panel &data_r,
                             bool allow_name_change)
 {
+  /* the dialogue edits the set in place, so Escape puts it back the
+     way it was */
+  const InfoBoxSettings::Panel saved = data_r;
+
   TWidgetDialog<InfoBoxesConfigWidget> dialog(WidgetDialog::Full{}, parent,
                                               dialog_look, nullptr);
   dialog.SetWidget(dialog, dialog_look, _look,
                    data_r, allow_name_change, geometry);
 
-  dialog.ShowModal();
+  if (dialog.ShowModal() != mrOK) {
+    data_r = saved;
+    return false;
+  }
+
   return dialog.GetChanged();
 }

--- a/src/Form/Form.cpp
+++ b/src/Form/Form.cpp
@@ -348,8 +348,9 @@ WndForm::ShowModal()
         continue;
 
 #ifdef ENABLE_SDL
-      if (event.GetKeyCode() == SDLK_TAB) {
-        /* the Tab key moves the keyboard focus */
+      if (event.GetKeyCode() == SDLK_TAB && !CheckKey(this, event)) {
+        /* the Tab key moves the keyboard focus, unless the focused
+           control handles it itself */
         const Uint8 *keystate = ::SDL_GetKeyboardState(nullptr);
         event.event.key.keysym.sym =
             keystate[SDL_SCANCODE_LSHIFT] || keystate[SDL_SCANCODE_RSHIFT]

--- a/src/InfoBoxes/InfoBoxArrange.cpp
+++ b/src/InfoBoxes/InfoBoxArrange.cpp
@@ -57,7 +57,7 @@ CancelTimeout() noexcept
 class OverlayWindow final : public InfoBoxArrangeWindow {
 public:
   explicit OverlayWindow(const InfoBoxLook &_look) noexcept
-    :InfoBoxArrangeWindow(_look, UIGlobals::GetDialogLook()) {
+    :InfoBoxArrangeWindow(_look, UIGlobals::GetDialogLook(), Style::MAP) {
     AddButton(_("Help"), [this]{ ShowHelp(); });
     AddButton(_("Close"), []{ InfoBoxArrange::Save(); });
   }

--- a/src/InfoBoxes/InfoBoxArrange.cpp
+++ b/src/InfoBoxes/InfoBoxArrange.cpp
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "InfoBoxArrange.hpp"
+#include "InfoBoxArrangeWindow.hpp"
+#include "InfoBoxLayout.hpp"
+#include "InfoBoxManager.hpp"
+#include "InfoBoxWindow.hpp"
+#include "Interface.hpp"
+#include "Language/Language.hpp"
+#include "Look/Look.hpp"
+#include "UIGlobals.hpp"
+#include "UISettings.hpp"
+#include "ui/event/Timer.hpp"
+#include "ui/window/SingleWindow.hpp"
+
+#include <memory>
+#include <optional>
+
+namespace {
+
+/** is the arrange mode active? */
+bool active;
+
+/** the InfoBox configuration as it was when the mode was entered */
+InfoBoxSettings::Panel saved_panel;
+
+/** leaves the arrange mode after the menu timeout */
+std::optional<UI::Timer> timeout_timer;
+
+/**
+ * Restart the inactivity timeout; the arrange mode closes itself
+ * after the same time as the main menu.
+ */
+void
+RestartTimeout() noexcept
+{
+  if (!timeout_timer)
+    timeout_timer.emplace([]{ InfoBoxArrange::Save(); });
+
+  timeout_timer->Schedule(CommonInterface::GetUISettings().menu_timeout);
+}
+
+/** Stop the timeout while a dialog covers the arrange mode. */
+void
+CancelTimeout() noexcept
+{
+  if (timeout_timer)
+    timeout_timer->Cancel();
+}
+
+/**
+ * The arrange mode on the map: a window which covers the whole screen
+ * while the InfoBox windows are hidden, so that dragging a card across
+ * the map cannot pan or zoom it.
+ */
+class OverlayWindow final : public InfoBoxArrangeWindow {
+public:
+  explicit OverlayWindow(const InfoBoxLook &_look) noexcept
+    :InfoBoxArrangeWindow(_look, UIGlobals::GetDialogLook()) {
+    AddButton(_("Help"), [this]{ ShowHelp(); });
+    AddButton(_("Close"), []{ InfoBoxArrange::Save(); });
+  }
+
+protected:
+  /* virtual methods from class InfoBoxArrangeWindow */
+  void OnArrangeActivity() noexcept override {
+    RestartTimeout();
+  }
+
+  void OnArrangeSuspend() noexcept override {
+    CancelTimeout();
+  }
+};
+
+/**
+ * The overlay window.  It is only hidden (and not destroyed) when the
+ * mode ends, because that happens from its own event handler.
+ */
+std::unique_ptr<OverlayWindow> overlay;
+
+/** Show the overlay and hide the InfoBox windows behind it. */
+void
+ShowControls() noexcept
+{
+  auto &parent = UIGlobals::GetMainWindow();
+
+  if (overlay == nullptr)
+    overlay = std::make_unique<OverlayWindow>(UIGlobals::GetLook().info_box);
+
+  overlay->SetPanel(InfoBoxManager::GetCurrentPanel());
+  overlay->SetLayout(InfoBoxManager::layout,
+                     InfoBoxManager::layout.remaining);
+
+  if (overlay->IsDefined())
+    overlay->Move(parent.GetClientRect());
+  else
+    overlay->Create(parent, parent.GetClientRect());
+
+  overlay->Show();
+  overlay->BringToTop();
+
+  /* the overlay paints the InfoBoxes itself */
+  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
+    if (auto *window = InfoBoxManager::GetWindow(i))
+      window->FastHide();
+}
+
+/** Common part of InfoBoxArrange::Save() and InfoBoxArrange::Cancel(). */
+void
+Leave() noexcept
+{
+  active = false;
+
+  if (overlay != nullptr) {
+    /* the finger may still rest on a card */
+    overlay->Drop();
+    overlay->Hide();
+  }
+
+  CancelTimeout();
+
+  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
+    if (auto *window = InfoBoxManager::GetWindow(i))
+      window->Show();
+
+  InfoBoxManager::Refresh();
+  InfoBoxManager::ScheduleRedraw();
+}
+
+} // namespace
+
+bool
+InfoBoxArrange::IsActive() noexcept
+{
+  return active;
+}
+
+void
+InfoBoxArrange::Begin(unsigned id, PixelPoint pointer) noexcept
+{
+  if (InfoBoxManager::GetWindow(id) == nullptr)
+    return;
+
+  if (!active) {
+    active = true;
+    saved_panel = InfoBoxManager::GetCurrentPanel();
+    ShowControls();
+  }
+
+  /* the long press has already picked the InfoBox up, so it follows
+     the finger right away */
+  overlay->BeginDrag(id, pointer, true);
+}
+
+void
+InfoBoxArrange::Save() noexcept
+{
+  if (!active)
+    return;
+
+  Leave();
+  InfoBoxManager::SaveCurrentPanel();
+}
+
+void
+InfoBoxArrange::Cancel() noexcept
+{
+  if (!active)
+    return;
+
+  InfoBoxManager::GetCurrentPanel() = saved_panel;
+  Leave();
+}
+
+void
+InfoBoxArrange::Reset() noexcept
+{
+  active = false;
+  timeout_timer.reset();
+  overlay.reset();
+}

--- a/src/InfoBoxes/InfoBoxArrange.cpp
+++ b/src/InfoBoxes/InfoBoxArrange.cpp
@@ -71,6 +71,11 @@ protected:
   void OnArrangeSuspend() noexcept override {
     CancelTimeout();
   }
+
+  bool OnArrangeCancel() noexcept override {
+    InfoBoxArrange::Cancel();
+    return true;
+  }
 };
 
 /**
@@ -156,6 +161,20 @@ InfoBoxArrange::Begin(unsigned id, PixelPoint pointer) noexcept
   /* the long press has already picked the InfoBox up, so it follows
      the finger right away */
   overlay->BeginDrag(id, pointer, true);
+}
+
+void
+InfoBoxArrange::Begin() noexcept
+{
+  if (active || InfoBoxManager::GetWindow(0) == nullptr)
+    return;
+
+  active = true;
+  saved_panel = InfoBoxManager::GetCurrentPanel();
+  ShowControls();
+
+  overlay->FocusSlot(0);
+  RestartTimeout();
 }
 
 bool

--- a/src/InfoBoxes/InfoBoxArrange.cpp
+++ b/src/InfoBoxes/InfoBoxArrange.cpp
@@ -104,6 +104,10 @@ ShowControls() noexcept
   for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
     if (auto *window = InfoBoxManager::GetWindow(i))
       window->FastHide();
+
+  /* after hiding the InfoBoxes, so that a hidden one cannot keep the
+     keyboard focus */
+  overlay->SetFocus();
 }
 
 /** Common part of InfoBoxArrange::Save() and InfoBoxArrange::Cancel(). */
@@ -115,6 +119,7 @@ Leave() noexcept
   if (overlay != nullptr) {
     /* the finger may still rest on a card */
     overlay->Drop();
+    overlay->FocusParent();
     overlay->Hide();
   }
 
@@ -151,6 +156,16 @@ InfoBoxArrange::Begin(unsigned id, PixelPoint pointer) noexcept
   /* the long press has already picked the InfoBox up, so it follows
      the finger right away */
   overlay->BeginDrag(id, pointer, true);
+}
+
+bool
+InfoBoxArrange::SetFocus() noexcept
+{
+  if (!active || overlay == nullptr)
+    return false;
+
+  overlay->SetFocus();
+  return true;
 }
 
 void

--- a/src/InfoBoxes/InfoBoxArrange.hpp
+++ b/src/InfoBoxes/InfoBoxArrange.hpp
@@ -30,6 +30,14 @@ void
 Begin(unsigned id, PixelPoint pointer) noexcept;
 
 /**
+ * Enter the arrange mode without a press, for example from the menu.
+ * The first InfoBox is selected; the cursor keys take over from
+ * there.
+ */
+void
+Begin() noexcept;
+
+/**
  * Give the keyboard focus back to the arrange overlay, so that the
  * cursor keys reach it instead of the map.
  *

--- a/src/InfoBoxes/InfoBoxArrange.hpp
+++ b/src/InfoBoxes/InfoBoxArrange.hpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/dim/Point.hpp"
+
+/**
+ * Touch friendly arranging of the InfoBoxes on the current page.
+ *
+ * While the arrange mode is active, an overlay covers the screen: it
+ * fades out everything behind it, replaces the InfoBoxes by simplified
+ * cards and lets one card at a time be dragged onto another one to
+ * exchange the two.  The cards are placed on the slots of the InfoBox
+ * geometry, not on the current window positions, so every slot of the
+ * layout is offered as a drop target.
+ */
+namespace InfoBoxArrange {
+
+[[gnu::pure]]
+bool
+IsActive() noexcept;
+
+/**
+ * Enter the arrange mode and start dragging the InfoBox @p id, which
+ * has just been pressed at @p pointer (in the coordinates of the
+ * InfoBox' parent window).
+ */
+void
+Begin(unsigned id, PixelPoint pointer) noexcept;
+
+/**
+ * Leave the arrange mode and save the new order to the profile.
+ */
+void
+Save() noexcept;
+
+/**
+ * Leave the arrange mode and restore the order the page had when it
+ * was entered.
+ */
+void
+Cancel() noexcept;
+
+/**
+ * Forget all state; called when the InfoBox windows are destroyed.
+ */
+void
+Reset() noexcept;
+
+} // namespace InfoBoxArrange

--- a/src/InfoBoxes/InfoBoxArrange.hpp
+++ b/src/InfoBoxes/InfoBoxArrange.hpp
@@ -30,6 +30,15 @@ void
 Begin(unsigned id, PixelPoint pointer) noexcept;
 
 /**
+ * Give the keyboard focus back to the arrange overlay, so that the
+ * cursor keys reach it instead of the map.
+ *
+ * @return false if the arrange mode is not active
+ */
+bool
+SetFocus() noexcept;
+
+/**
  * Leave the arrange mode and save the new order to the profile.
  */
 void

--- a/src/InfoBoxes/InfoBoxArrangeWindow.cpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.cpp
@@ -35,6 +35,9 @@ constexpr uint8_t OVERLAY_ALPHA = 0xe6;
 /** how long a displaced InfoBox takes to slide into its new slot */
 constexpr auto SHUFFLE_DURATION = std::chrono::milliseconds(250);
 
+/** how long an InfoBox has to be held before the picker opens */
+constexpr auto PICKER_DELAY = std::chrono::milliseconds(600);
+
 /**
  * How much the card grows when it is picked up, relative to the slot
  * it came from.
@@ -282,7 +285,8 @@ InfoBoxArrangeWindow::PaintCards(Canvas &canvas) noexcept
     const PixelPoint offset = GetShuffleOffset(i);
     rc.Offset(offset.x, offset.y);
     rc.Grow(-(int)look.preview_padding);
-    DrawCard(canvas, ToLocal(rc), i, card_number[i], false);
+    DrawCard(canvas, ToLocal(rc), i, card_number[i],
+             (int)i == described_slot);
   }
 
   if (drag && drag->following)
@@ -316,6 +320,47 @@ InfoBoxArrangeWindow::PaintPanelName(Canvas &canvas) noexcept
 }
 
 void
+InfoBoxArrangeWindow::PaintDescription(Canvas &canvas) noexcept
+{
+  if (described_slot < 0)
+    return;
+
+  const auto type = panel->contents[described_slot];
+  const char *name = gettext(InfoBoxFactory::GetName(type));
+  const char *description = InfoBoxFactory::GetDescription(type);
+
+  PixelRect rc = ToLocal(content);
+  rc.Grow(-Layout::Scale(8));
+
+  /* keep clear of the panel name and the buttons; on a small screen
+     the description is cut off instead of covering them */
+  rc.bottom = std::min(rc.bottom, GetPanelNameRect().top - Layout::Scale(8));
+  if (rc.bottom <= rc.top)
+    return;
+
+  canvas.SetBackgroundTransparent();
+  canvas.SetTextColor(look.background_color);
+
+  canvas.Select(dialog_look.bold_font);
+  name_renderer.Draw(canvas, rc, name);
+  rc.top += name_renderer.GetHeight(canvas, rc.GetWidth(), name)
+    + Layout::Scale(4);
+
+  if (description != nullptr && rc.top < rc.bottom) {
+    const char *text = gettext(description);
+
+    /* the small font is only used when the description does not fit
+       into what is left */
+    canvas.Select(dialog_look.text_font);
+    if (description_renderer.GetHeight(canvas, rc.GetWidth(), text) >
+        (unsigned)rc.GetHeight())
+      canvas.Select(dialog_look.small_font);
+
+    description_renderer.Draw(canvas, rc, text);
+  }
+}
+
+void
 InfoBoxArrangeWindow::OnPaint(Canvas &canvas) noexcept
 {
 #ifdef ENABLE_OPENGL
@@ -331,6 +376,7 @@ InfoBoxArrangeWindow::OnPaint(Canvas &canvas) noexcept
                              look.preview_backdrop_color);
 #endif
 
+  PaintDescription(canvas);
   PaintPanelName(canvas);
   PaintButtons(canvas);
 
@@ -400,6 +446,20 @@ InfoBoxArrangeWindow::OnShuffleTimer() noexcept
 }
 
 void
+InfoBoxArrangeWindow::OnPickerTimer() noexcept
+{
+  if (!drag || drag->following)
+    return;
+
+  const unsigned slot = drag->slot;
+  drag.reset();
+  ReleaseCapture();
+  Invalidate();
+
+  ShowPicker(slot);
+}
+
+void
 InfoBoxArrangeWindow::ShowPicker(unsigned slot) noexcept
 {
   OnArrangeSuspend();
@@ -417,7 +477,9 @@ InfoBoxArrangeWindow::ShowHelp() noexcept
   /* the timeout must not end the mode behind the dialog */
   OnArrangeSuspend();
   HelpDialog(_("Arrange InfoBoxes"),
-             _("Drag an InfoBox onto another one to exchange the two."));
+             _("Drag an InfoBox onto another one to exchange the two.  "
+               "Long press an InfoBox to choose a different InfoBox for "
+               "that position."));
   OnArrangeActivity();
   SetFocus();
 }
@@ -475,6 +537,12 @@ InfoBoxArrangeWindow::BeginDrag(unsigned slot, PixelPoint pointer,
   drag_snapshot = *panel;
   ResetCardNumbers();
 
+  described_slot = slot;
+
+  if (!follow)
+    /* holding the InfoBox still opens the picker */
+    picker_timer.Schedule(PICKER_DELAY);
+
   SetCapture();
   OnArrangeActivity();
   Invalidate();
@@ -494,6 +562,7 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
       return;
 
     drag->following = true;
+    picker_timer.Cancel();
   }
 
   /* exchange with the slot the finger has moved into, so that a drag
@@ -509,7 +578,7 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
        because it follows the finger */
     StartShuffle(drag->slot, layout->positions[slot]);
 
-    drag->slot = slot;
+    drag->slot = described_slot = slot;
   }
 
   Invalidate();
@@ -521,6 +590,7 @@ InfoBoxArrangeWindow::Drop() noexcept
   if (!drag)
     return;
 
+  picker_timer.Cancel();
   drag.reset();
   ResetCardNumbers();
   ReleaseCapture();
@@ -534,9 +604,11 @@ InfoBoxArrangeWindow::CancelDrag() noexcept
   if (!drag)
     return;
 
+  picker_timer.Cancel();
   drag.reset();
   *panel = drag_snapshot;
   ResetCardNumbers();
+  described_slot = -1;
 
   for (auto &i : shuffle)
     i.start = {};
@@ -594,14 +666,7 @@ InfoBoxArrangeWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
   if (!drag)
     return true;
 
-  const unsigned slot = drag->slot;
-  const bool tap = !drag->following;
   Drop();
-
-  if (tap)
-    /* a tap: let the user choose the contents of this InfoBox */
-    ShowPicker(slot);
-
   return true;
 }
 

--- a/src/InfoBoxes/InfoBoxArrangeWindow.cpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.cpp
@@ -14,11 +14,16 @@
 #include "Screen/Layout.hpp"
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Canvas.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "util/StaticString.hxx"
 #include "util/StringCompare.hxx"
 
 #ifdef ENABLE_OPENGL
 #include "ui/canvas/opengl/Scope.hpp"
+#endif
+
+#ifdef ENABLE_SDL
+#include <SDL_keyboard.h>
 #endif
 
 #include <algorithm>
@@ -58,6 +63,55 @@ int
 GetDeadZone() noexcept
 {
   return Layout::Scale(8);
+}
+
+/**
+ * Are the InfoBoxes arranged in columns?  This does not follow the
+ * screen orientation: several geometries put the InfoBoxes into
+ * columns on a portrait screen, and into rows on a landscape one.
+ */
+[[gnu::pure]]
+bool
+HasColumns(const InfoBoxLayout::Layout &layout) noexcept
+{
+  unsigned rows = 0, columns = 0;
+
+  for (unsigned i = 0; i < layout.count; ++i) {
+    const PixelPoint p = layout.positions[i].GetCenter();
+    bool new_row = true, new_column = true;
+
+    for (unsigned j = 0; j < i; ++j) {
+      const PixelPoint q = layout.positions[j].GetCenter();
+      new_row &= q.y != p.y;
+      new_column &= q.x != p.x;
+    }
+
+    rows += new_row;
+    columns += new_column;
+  }
+
+  /* more rows than columns means the InfoBoxes stand side by side */
+  return rows > columns;
+}
+
+/**
+ * Is a shift key held down?  The window layer passes only the key
+ * code, so Shift+Tab has to be recognised here; this follows
+ * IsCtrlKeyPressed() in GlueMapWindowEvents.
+ */
+[[gnu::pure]]
+bool
+IsShiftKeyPressed() noexcept
+{
+#ifdef ENABLE_SDL
+  return SDL_GetModState() & (KMOD_LSHIFT | KMOD_RSHIFT);
+#elif defined(USE_WINUSER)
+  return GetKeyState(VK_SHIFT) & 0x8000;
+#else
+  /* X11 sends XK_ISO_Left_Tab instead; elsewhere Tab only moves
+     forwards */
+  return false;
+#endif
 }
 
 } // namespace
@@ -109,11 +163,30 @@ InfoBoxArrangeWindow::SetLayout(const InfoBoxLayout::Layout &_layout,
 {
   layout = &_layout;
   content = _content;
+  columns = HasColumns(_layout);
 }
 
 /*
  * geometry
  */
+
+PixelPoint
+InfoBoxArrangeWindow::SlotCenter(unsigned slot) const noexcept
+{
+  return layout->positions[slot].GetCenter();
+}
+
+int
+InfoBoxArrangeWindow::Along(PixelPoint p) const noexcept
+{
+  return columns ? p.x : p.y;
+}
+
+int
+InfoBoxArrangeWindow::Across(PixelPoint p) const noexcept
+{
+  return columns ? p.y : p.x;
+}
 
 int
 InfoBoxArrangeWindow::FindSlot(PixelPoint p) const noexcept
@@ -224,15 +297,27 @@ InfoBoxArrangeWindow::ToLocal(PixelRect rc) const noexcept
 void
 InfoBoxArrangeWindow::DrawCard(Canvas &canvas, const PixelRect &rc,
                                unsigned slot, unsigned number,
-                               bool active) noexcept
+                               CardState state) noexcept
 {
   const int radius = look.preview_radius;
+  const bool active = state == CardState::ACTIVE;
 
   canvas.SelectNullPen();
-  canvas.Select(Brush{active
-                      ? look.preview_active_color
-                      : look.background_color});
+  canvas.Select(Brush{state == CardState::NORMAL
+                      ? look.background_color
+                      : look.preview_active_color});
   canvas.DrawRoundRectangle(rc, {radius * 2, radius * 2});
+
+  if (state == CardState::FOCUSED) {
+    /* leave only a ring of the highlight colour */
+    const int width = look.preview_focus_width;
+    PixelRect inner = rc;
+    inner.Grow(-width);
+
+    canvas.Select(Brush{look.background_color});
+    canvas.DrawRoundRectangle(inner, {(radius - width) * 2,
+                                      (radius - width) * 2});
+  }
 
   /* the caption comes from the configuration and not from the InfoBox
      itself, because content providers overwrite the title at runtime
@@ -273,6 +358,17 @@ InfoBoxArrangeWindow::DrawCard(Canvas &canvas, const PixelRect &rc,
                          rc, caption);
 }
 
+InfoBoxArrangeWindow::CardState
+InfoBoxArrangeWindow::GetCardState(unsigned slot) const noexcept
+{
+  if ((int)slot != described_slot || focused_button >= 0)
+    return CardState::NORMAL;
+
+  return selection == Selection::FOCUSED
+    ? CardState::FOCUSED
+    : CardState::ACTIVE;
+}
+
 void
 InfoBoxArrangeWindow::PaintCards(Canvas &canvas) noexcept
 {
@@ -285,13 +381,12 @@ InfoBoxArrangeWindow::PaintCards(Canvas &canvas) noexcept
     const PixelPoint offset = GetShuffleOffset(i);
     rc.Offset(offset.x, offset.y);
     rc.Grow(-(int)look.preview_padding);
-    DrawCard(canvas, ToLocal(rc), i, card_number[i],
-             (int)i == described_slot);
+    DrawCard(canvas, ToLocal(rc), i, card_number[i], GetCardState(i));
   }
 
   if (drag && drag->following)
     DrawCard(canvas, ToLocal(GetFloatingRect()), drag->slot,
-             card_number[drag->slot], true);
+             card_number[drag->slot], CardState::ACTIVE);
 }
 
 void
@@ -322,7 +417,8 @@ InfoBoxArrangeWindow::PaintPanelName(Canvas &canvas) noexcept
 void
 InfoBoxArrangeWindow::PaintDescription(Canvas &canvas) noexcept
 {
-  if (described_slot < 0)
+  if (described_slot < 0 || focused_button >= 0)
+    /* nothing describes a button */
     return;
 
   const auto type = panel->contents[described_slot];
@@ -388,6 +484,13 @@ InfoBoxArrangeWindow::OnPaint(Canvas &canvas) noexcept
 /*
  * the InfoBoxes
  */
+
+void
+InfoBoxArrangeWindow::Exchange(unsigned a, unsigned b) noexcept
+{
+  std::swap(panel->contents[a], panel->contents[b]);
+  std::swap(card_number[a], card_number[b]);
+}
 
 void
 InfoBoxArrangeWindow::ResetCardNumbers() noexcept
@@ -474,14 +577,295 @@ InfoBoxArrangeWindow::ShowPicker(unsigned slot) noexcept
 void
 InfoBoxArrangeWindow::ShowHelp() noexcept
 {
+  StaticString<768> text;
+  text.clear();
+
+  if (HasPointer())
+    text = _("Drag an InfoBox onto another one to exchange the two.  "
+             "Long press an InfoBox to choose a different InfoBox for "
+             "that position.");
+
+  if (HasCursorKeys()) {
+    if (!text.empty())
+      text.append("\n\n");
+
+    text.append(_("Press Enter to take the selected InfoBox, move it with "
+                  "the cursor keys and press Enter again to put it down.  "
+                  "Pressing Enter twice without moving an InfoBox chooses "
+                  "a different InfoBox for that position."));
+  }
+
   /* the timeout must not end the mode behind the dialog */
   OnArrangeSuspend();
-  HelpDialog(_("Arrange InfoBoxes"),
-             _("Drag an InfoBox onto another one to exchange the two.  "
-               "Long press an InfoBox to choose a different InfoBox for "
-               "that position."));
+  HelpDialog(_("Arrange InfoBoxes"), text);
   OnArrangeActivity();
   SetFocus();
+}
+
+/*
+ * the cursor keys
+ */
+
+PixelPoint
+InfoBoxArrangeWindow::GetButtonRowOrigin() const noexcept
+{
+  const PixelPoint center = GetButtonRowRect().GetCenter();
+
+  return columns
+    ? PixelPoint{center.x, button_row_cross}
+    : PixelPoint{button_row_cross, center.y};
+}
+
+int
+InfoBoxArrangeWindow::FindNeighbour(PixelPoint origin,
+                                    int dx, int dy) const noexcept
+{
+  int best = -1, best_distance = 0;
+
+  for (unsigned i = 0; i < layout->count; ++i) {
+    const PixelPoint p = layout->positions[i].GetCenter();
+    const int along = (p.x - origin.x) * dx + (p.y - origin.y) * dy;
+    if (along <= 0)
+      continue;
+
+    /* the closest slot in that direction wins, and among those the
+       one which is least off to the side */
+    const int across = std::abs((p.x - origin.x) * dy
+                                - (p.y - origin.y) * dx);
+    const int distance = along + 4 * across;
+
+    if (best < 0 || distance < best_distance) {
+      best = i;
+      best_distance = distance;
+    }
+  }
+
+  return best;
+}
+
+bool
+InfoBoxArrangeWindow::IsButtonRowCloser(PixelPoint origin, int slot,
+                                        bool forward) const noexcept
+{
+  const int buttons_along =
+    Along(GetButtonRowRect().GetCenter()) - Along(origin);
+  if (forward ? buttons_along <= 0 : buttons_along >= 0)
+    return false;
+
+  if (slot < 0)
+    return true;
+
+  return std::abs(buttons_along) <
+    std::abs(Along(SlotCenter(slot)) - Along(origin));
+}
+
+void
+InfoBoxArrangeWindow::FocusButtonNear(PixelPoint origin) noexcept
+{
+  button_row_cross = Across(origin);
+
+  int best = -1, best_distance = 0;
+
+  for (unsigned i = 0; i < buttons.size(); ++i) {
+    const int distance =
+      std::abs(GetButtonRect(i).GetCenter().x - origin.x);
+
+    if (best < 0 || distance < best_distance) {
+      best = i;
+      best_distance = distance;
+    }
+  }
+
+  if (best >= 0)
+    focused_button = best;
+}
+
+bool
+InfoBoxArrangeWindow::MoveFromButton(int dx, int dy, bool along) noexcept
+{
+  /* the buttons stand side by side, so left and right switch between
+     them */
+  const int button = dx != 0 ? focused_button + dx : -1;
+
+  if (button >= 0 && button < (int)buttons.size())
+    focused_button = button;
+  else if (!along)
+    return true;
+  else {
+    const int slot = FindNeighbour(GetButtonRowOrigin(), dx, dy);
+    if (slot < 0)
+      return true;
+
+    described_slot = slot;
+    focused_button = -1;
+  }
+
+  selection = Selection::FOCUSED;
+  Invalidate();
+  return true;
+}
+
+InfoBoxArrangeWindow::TabKey
+InfoBoxArrangeWindow::GetTabKey(unsigned i) const noexcept
+{
+  const unsigned count = layout->count;
+
+  const PixelPoint p = i < count
+    ? layout->positions[i].GetCenter()
+    : GetButtonRect(i - count).GetCenter();
+
+  return {Along(p), Across(p)};
+}
+
+void
+InfoBoxArrangeWindow::FocusItem(unsigned i) noexcept
+{
+  const unsigned count = layout->count;
+
+  if (i < count) {
+    described_slot = i;
+    focused_button = -1;
+  } else {
+    focused_button = i - count;
+    button_row_cross = Across(GetButtonRect(focused_button).GetCenter());
+  }
+
+  selection = Selection::FOCUSED;
+  Invalidate();
+}
+
+bool
+InfoBoxArrangeWindow::MoveTab(bool forward) noexcept
+{
+  OnArrangeActivity();
+
+  if (selection == Selection::MOVING)
+    /* a taken InfoBox is moved with the cursor keys */
+    return true;
+
+  const unsigned slot_count = layout->count;
+  const unsigned current = focused_button >= 0
+    ? slot_count + focused_button
+    : (described_slot >= 0 ? unsigned(described_slot) : 0);
+  const TabKey key = GetTabKey(current);
+
+  int next = -1, wrap = -1;
+  TabKey next_key{}, wrap_key{};
+
+  for (unsigned i = 0; i < slot_count + buttons.size(); ++i) {
+    if (i == current)
+      continue;
+
+    const TabKey k = GetTabKey(i);
+
+    if (forward ? key < k : k < key) {
+      if (next < 0 || (forward ? k < next_key : next_key < k)) {
+        next = i;
+        next_key = k;
+      }
+    } else if (wrap < 0 || (forward ? k < wrap_key : wrap_key < k)) {
+      wrap = i;
+      wrap_key = k;
+    }
+  }
+
+  const int item = next >= 0 ? next : wrap;
+  if (item >= 0)
+    FocusItem(item);
+
+  return true;
+}
+
+bool
+InfoBoxArrangeWindow::MoveSelection(int dx, int dy) noexcept
+{
+  OnArrangeActivity();
+
+  if (described_slot < 0 && focused_button < 0) {
+    described_slot = 0;
+    selection = Selection::FOCUSED;
+    Invalidate();
+    return true;
+  }
+
+  if (selection == Selection::MOVING) {
+    /* a taken InfoBox stays among the slots; it must not land on a
+       button */
+    const int slot = FindNeighbour(SlotCenter(described_slot), dx, dy);
+    if (slot < 0)
+      return true;
+
+    /* carry the InfoBox along, exchanging it with the neighbour; both
+       slide into their new slot */
+    Exchange(described_slot, slot);
+    StartShuffle(described_slot, layout->positions[slot]);
+    StartShuffle(slot, layout->positions[described_slot]);
+
+    described_slot = slot;
+    Invalidate();
+    return true;
+  }
+
+  /* the cursor moves along the axis the InfoBoxes are stacked on:
+     down when they stand in rows, to the side when they stand in
+     columns.  The button row takes its place in that order by where
+     it sits on the screen, between the InfoBoxes before and after
+     it */
+  const bool along = columns ? dx != 0 : dy != 0;
+
+  if (focused_button >= 0)
+    return MoveFromButton(dx, dy, along);
+
+  const PixelPoint origin = SlotCenter(described_slot);
+  const int slot = FindNeighbour(origin, dx, dy);
+
+  if (along && IsButtonRowCloser(origin, slot, dx + dy > 0))
+    FocusButtonNear(origin);
+  else if (slot >= 0)
+    described_slot = slot;
+  else
+    return true;
+
+  selection = Selection::FOCUSED;
+  Invalidate();
+  return true;
+}
+
+bool
+InfoBoxArrangeWindow::Activate() noexcept
+{
+  OnArrangeActivity();
+
+  if (focused_button >= 0) {
+    OnButton(focused_button);
+    return true;
+  }
+
+  if (described_slot < 0)
+    return true;
+
+  if (selection != Selection::MOVING) {
+    grab_slot = described_slot;
+    selection = Selection::MOVING;
+    Invalidate();
+    return true;
+  }
+
+  const bool unmoved = (unsigned)described_slot == grab_slot;
+  selection = Selection::FOCUSED;
+
+  /* the numbers travelled with the InfoBoxes while one was carried;
+     now they belong to their slots again */
+  ResetCardNumbers();
+
+  Invalidate();
+
+  if (unmoved)
+    /* taking and putting down without moving means the user wants to
+       change the InfoBox instead */
+    ShowPicker(described_slot);
+
+  return true;
 }
 
 /*
@@ -491,9 +875,13 @@ InfoBoxArrangeWindow::ShowHelp() noexcept
 ButtonState
 InfoBoxArrangeWindow::GetButtonState(int i) const noexcept
 {
-  return held_button == i && button_down
-    ? ButtonState::PRESSED
-    : ButtonState::ENABLED;
+  if (held_button == i && button_down)
+    return ButtonState::PRESSED;
+
+  if (focused_button == i)
+    return ButtonState::FOCUSED;
+
+  return ButtonState::ENABLED;
 }
 
 void
@@ -529,6 +917,15 @@ InfoBoxArrangeWindow::ReleaseButton() noexcept
  */
 
 void
+InfoBoxArrangeWindow::FocusSlot(unsigned slot) noexcept
+{
+  described_slot = slot;
+  focused_button = -1;
+  selection = Selection::FOCUSED;
+  Invalidate();
+}
+
+void
 InfoBoxArrangeWindow::BeginDrag(unsigned slot, PixelPoint pointer,
                                 bool follow) noexcept
 {
@@ -537,7 +934,11 @@ InfoBoxArrangeWindow::BeginDrag(unsigned slot, PixelPoint pointer,
   drag_snapshot = *panel;
   ResetCardNumbers();
 
+  /* the card the user has grabbed is the one being described; that
+     way only ever one card is highlighted */
   described_slot = slot;
+  selection = Selection::TOUCH;
+  focused_button = -1;
 
   if (!follow)
     /* holding the InfoBox still opens the picker */
@@ -570,8 +971,7 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
      with the slot it started from */
   const int slot = FindSlot(p);
   if (slot >= 0 && unsigned(slot) != drag->slot) {
-    std::swap(panel->contents[drag->slot], panel->contents[slot]);
-    std::swap(card_number[drag->slot], card_number[slot]);
+    Exchange(drag->slot, slot);
 
     /* the InfoBox which was in the way slides over to the slot the
        dragged one has just left; the dragged one needs no animation
@@ -689,6 +1089,62 @@ InfoBoxArrangeWindow::OnMultiTouchDown() noexcept
 }
 
 #endif
+
+bool
+InfoBoxArrangeWindow::OnKeyCheck(unsigned key_code) const noexcept
+{
+  switch (key_code) {
+  case KEY_UP:
+  case KEY_DOWN:
+  case KEY_LEFT:
+  case KEY_RIGHT:
+  case KEY_RETURN:
+  case KEY_ESCAPE:
+  case KEY_TAB:
+#ifdef USE_X11
+  case XK_ISO_Left_Tab:
+#endif
+    return true;
+
+  default:
+    return false;
+  }
+}
+
+bool
+InfoBoxArrangeWindow::OnKeyDown(unsigned key_code) noexcept
+{
+  switch (key_code) {
+  case KEY_LEFT:
+    return MoveSelection(-1, 0);
+
+  case KEY_RIGHT:
+    return MoveSelection(1, 0);
+
+  case KEY_UP:
+    return MoveSelection(0, -1);
+
+  case KEY_DOWN:
+    return MoveSelection(0, 1);
+
+  case KEY_TAB:
+    return MoveTab(!IsShiftKeyPressed());
+
+#ifdef USE_X11
+  case XK_ISO_Left_Tab:
+    /* X11 has its own key symbol for Shift+Tab */
+    return MoveTab(false);
+#endif
+
+  case KEY_RETURN:
+    return Activate();
+
+  case KEY_ESCAPE:
+    return OnArrangeCancel();
+  }
+
+  return PaintWindow::OnKeyDown(key_code);
+}
 
 void
 InfoBoxArrangeWindow::OnCancelMode() noexcept

--- a/src/InfoBoxes/InfoBoxArrangeWindow.cpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.cpp
@@ -1,0 +1,567 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "InfoBoxArrangeWindow.hpp"
+#include "InfoBoxLayout.hpp"
+#include "InfoBoxManager.hpp"
+#include "Content/Factory.hpp"
+#include "Dialogs/HelpDialog.hpp"
+#include "Language/Language.hpp"
+#include "Look/DialogLook.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "Screen/Layout.hpp"
+#include "ui/canvas/Brush.hpp"
+#include "ui/canvas/Canvas.hpp"
+#include "util/StaticString.hxx"
+#include "util/StringCompare.hxx"
+
+#ifdef ENABLE_OPENGL
+#include "ui/canvas/opengl/Scope.hpp"
+#endif
+
+#include <algorithm>
+#include <cstdlib>
+
+namespace {
+
+/**
+ * How much of the map shines through the overlay?  Only a hint of it
+ * is left, so that the text on the backdrop stays legible.
+ */
+constexpr uint8_t OVERLAY_ALPHA = 0xe6;
+
+/**
+ * How much the card grows when it is picked up, relative to the slot
+ * it came from.
+ */
+[[gnu::pure]]
+int
+GetDragLift() noexcept
+{
+  return Layout::Scale(5);
+}
+
+/**
+ * The distance the finger has to travel before the InfoBox detaches
+ * from its slot; below that, the press is still a tap.
+ */
+[[gnu::pure]]
+int
+GetDeadZone() noexcept
+{
+  return Layout::Scale(8);
+}
+
+} // namespace
+
+InfoBoxArrangeWindow::InfoBoxArrangeWindow(const InfoBoxLook &_look,
+                                           const DialogLook &_dialog_look)
+  noexcept
+  :look(_look), dialog_look(_dialog_look),
+   button_renderer(_dialog_look.button)
+{
+  ResetCardNumbers();
+}
+
+void
+InfoBoxArrangeWindow::AddButton(const char *caption,
+                                Callback callback) noexcept
+{
+  auto &button = buttons.append();
+  button.caption = caption;
+  button.callback = std::move(callback);
+}
+
+void
+InfoBoxArrangeWindow::Create(ContainerWindow &parent,
+                             const PixelRect &rc) noexcept
+{
+  WindowStyle window_style;
+  window_style.Hide();
+  window_style.TabStop();
+  PaintWindow::Create(parent, rc, window_style);
+
+#ifndef USE_WINUSER
+  /* the map below must still be painted (and invalidated), even
+     though this window covers the whole screen */
+  SetTransparent();
+#endif
+}
+
+void
+InfoBoxArrangeWindow::SetPanel(InfoBoxSettings::Panel &_panel) noexcept
+{
+  panel = &_panel;
+  ResetCardNumbers();
+}
+
+void
+InfoBoxArrangeWindow::SetLayout(const InfoBoxLayout::Layout &_layout,
+                                PixelRect _content) noexcept
+{
+  layout = &_layout;
+  content = _content;
+}
+
+/*
+ * geometry
+ */
+
+int
+InfoBoxArrangeWindow::FindSlot(PixelPoint p) const noexcept
+{
+  for (unsigned i = 0; i < layout->count; ++i)
+    if (layout->positions[i].Contains(p))
+      return i;
+
+  return -1;
+}
+
+PixelRect
+InfoBoxArrangeWindow::GetFloatingRect() const noexcept
+{
+  PixelRect rc = drag->start_rect;
+  rc.Offset(drag->pointer.x - drag->origin.x,
+            drag->pointer.y - drag->origin.y);
+
+  /* the padding stays behind in the slot; the card itself is picked
+     up and grows a little */
+  rc.Grow(GetDragLift() - (int)look.preview_padding);
+  return rc;
+}
+
+int
+InfoBoxArrangeWindow::GetButtonGap() noexcept
+{
+  return Layout::Scale(8);
+}
+
+int
+InfoBoxArrangeWindow::GetButtonWidth() const noexcept
+{
+  const int count = buttons.size();
+  const int gap = GetButtonGap();
+
+  /* wide enough for the longest caption, so that no button has to
+     wrap its text */
+  int width = Layout::Scale(80);
+  for (const auto &i : buttons)
+    width = std::max(width,
+                     (int)TextButtonRenderer::
+                     GetMinimumButtonWidth(dialog_look.button, i.caption));
+
+  /* but never wider than the row itself */
+  return std::min(width,
+                  ((int)content.GetWidth() - (count + 1) * gap) / count);
+}
+
+PixelRect
+InfoBoxArrangeWindow::GetButtonRowRect() const noexcept
+{
+  const int count = buttons.size();
+  const int height = (int)Layout::GetMaximumControlHeight();
+  const int gap = GetButtonGap();
+  const int total = count * GetButtonWidth() + (count - 1) * gap;
+
+  PixelRect r;
+  r.bottom = content.bottom - gap;
+  r.top = r.bottom - height;
+  r.left = (content.left + content.right - total) / 2;
+  r.right = r.left + total;
+  return r;
+}
+
+PixelRect
+InfoBoxArrangeWindow::GetButtonRect(int i) const noexcept
+{
+  const int width = GetButtonWidth();
+
+  PixelRect r = GetButtonRowRect();
+  r.left += i * (width + GetButtonGap());
+  r.right = r.left + width;
+  return r;
+}
+
+int
+InfoBoxArrangeWindow::FindButton(PixelPoint p) const noexcept
+{
+  for (unsigned i = 0; i < buttons.size(); ++i)
+    if (GetButtonRect(i).Contains(p))
+      return i;
+
+  return -1;
+}
+
+PixelRect
+InfoBoxArrangeWindow::GetPanelNameRect() const noexcept
+{
+  PixelRect rc = ToLocal(GetButtonRowRect());
+  rc.bottom = rc.top - Layout::Scale(12);
+  rc.top = rc.bottom - (int)look.title_font_bold.GetHeight();
+  return rc;
+}
+
+PixelRect
+InfoBoxArrangeWindow::ToLocal(PixelRect rc) const noexcept
+{
+  const auto origin = GetPosition().GetTopLeft();
+  rc.Offset(-origin.x, -origin.y);
+  return rc;
+}
+
+/*
+ * painting
+ */
+
+void
+InfoBoxArrangeWindow::DrawCard(Canvas &canvas, const PixelRect &rc,
+                               unsigned slot, unsigned number,
+                               bool active) noexcept
+{
+  const int radius = look.preview_radius;
+
+  canvas.SelectNullPen();
+  canvas.Select(Brush{active
+                      ? look.preview_active_color
+                      : look.background_color});
+  canvas.DrawRoundRectangle(rc, {radius * 2, radius * 2});
+
+  /* the caption comes from the configuration and not from the InfoBox
+     itself, because content providers overwrite the title at runtime
+     (the Next Waypoint InfoBox shows the waypoint name, for
+     example) */
+  const char *caption =
+    gettext(InfoBoxFactory::GetCaption(panel->contents[slot]));
+
+  StaticString<8> number_text;
+  number_text.Format("#%u", number);
+
+  canvas.SetBackgroundTransparent();
+  canvas.SetTextColor(active ? COLOR_WHITE : look.title.fg_color);
+
+  canvas.Select(look.preview_number_font);
+  const PixelSize number_size = canvas.CalcTextSize(number_text);
+
+  canvas.Select(look.title_font_bold);
+  const PixelSize caption_size = canvas.CalcTextSize(caption);
+
+  /* both lines are clipped to the card, so that a caption which is
+     too long for it does not run out into the backdrop; if they do
+     not fit at all, they start at the top edge */
+  int y = rc.top + std::max(0, ((int)rc.GetHeight()
+                                - (int)(number_size.height
+                                        + caption_size.height)) / 2);
+
+  canvas.Select(look.preview_number_font);
+  canvas.DrawClippedText({std::max(rc.left,
+                                   rc.CenteredTopLeft(number_size).x), y},
+                         rc, number_text);
+
+  y += number_size.height;
+
+  canvas.Select(look.title_font_bold);
+  canvas.DrawClippedText({std::max(rc.left,
+                                   rc.CenteredTopLeft(caption_size).x), y},
+                         rc, caption);
+}
+
+void
+InfoBoxArrangeWindow::PaintCards(Canvas &canvas) noexcept
+{
+  for (unsigned i = 0; i < layout->count; ++i) {
+    if (drag && drag->following && i == drag->slot)
+      /* this one follows the finger; its slot stays empty */
+      continue;
+
+    PixelRect rc = layout->positions[i];
+    rc.Grow(-(int)look.preview_padding);
+    DrawCard(canvas, ToLocal(rc), i, card_number[i], false);
+  }
+
+  if (drag && drag->following)
+    DrawCard(canvas, ToLocal(GetFloatingRect()), drag->slot,
+             card_number[drag->slot], true);
+}
+
+void
+InfoBoxArrangeWindow::PaintButtons(Canvas &canvas) noexcept
+{
+  for (unsigned i = 0; i < buttons.size(); ++i) {
+    button_renderer.SetCaption(buttons[i].caption);
+    button_renderer.DrawButton(canvas, ToLocal(GetButtonRect(i)),
+                               GetButtonState(i));
+  }
+}
+
+void
+InfoBoxArrangeWindow::PaintPanelName(Canvas &canvas) noexcept
+{
+  const char *name = gettext(panel->name);
+  if (StringIsEmpty(name))
+    return;
+
+  canvas.SetBackgroundTransparent();
+  canvas.SetTextColor(look.background_color);
+  canvas.Select(look.title_font_bold);
+
+  const PixelRect rc = GetPanelNameRect();
+  canvas.TextAutoClipped(rc.CenteredTopLeft(canvas.CalcTextSize(name)), name);
+}
+
+void
+InfoBoxArrangeWindow::OnPaint(Canvas &canvas) noexcept
+{
+#ifdef ENABLE_OPENGL
+  {
+    const ScopeAlphaBlend alpha_blend;
+    canvas.DrawFilledRectangle(canvas.GetRect(),
+                               look.preview_backdrop_color
+                               .WithAlpha(OVERLAY_ALPHA));
+  }
+#else
+  /* without alpha blending, hide the map instead of fading it */
+  canvas.DrawFilledRectangle(canvas.GetRect(),
+                             look.preview_backdrop_color);
+#endif
+
+  PaintPanelName(canvas);
+  PaintButtons(canvas);
+
+  /* the cards come last: the one which follows the finger must not
+     disappear behind anything */
+  PaintCards(canvas);
+}
+
+/*
+ * the InfoBoxes
+ */
+
+void
+InfoBoxArrangeWindow::ResetCardNumbers() noexcept
+{
+  for (unsigned i = 0; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i)
+    card_number[i] = i + 1;
+}
+
+void
+InfoBoxArrangeWindow::ShowPicker(unsigned slot) noexcept
+{
+  OnArrangeSuspend();
+
+  if (InfoBoxManager::ShowInfoBoxPicker(*panel, slot))
+    Invalidate();
+
+  OnArrangeActivity();
+  SetFocus();
+}
+
+void
+InfoBoxArrangeWindow::ShowHelp() noexcept
+{
+  /* the timeout must not end the mode behind the dialog */
+  OnArrangeSuspend();
+  HelpDialog(_("Arrange InfoBoxes"),
+             _("Drag an InfoBox onto another one to exchange the two."));
+  OnArrangeActivity();
+}
+
+/*
+ * the buttons
+ */
+
+ButtonState
+InfoBoxArrangeWindow::GetButtonState(int i) const noexcept
+{
+  return held_button == i && button_down
+    ? ButtonState::PRESSED
+    : ButtonState::ENABLED;
+}
+
+void
+InfoBoxArrangeWindow::OnButton(int i) noexcept
+{
+  buttons[i].callback();
+}
+
+void
+InfoBoxArrangeWindow::HoldButton(int i, bool down) noexcept
+{
+  if (i == held_button && down == button_down)
+    return;
+
+  held_button = i;
+  button_down = down;
+  Invalidate();
+}
+
+void
+InfoBoxArrangeWindow::ReleaseButton() noexcept
+{
+  if (held_button < 0)
+    return;
+
+  held_button = -1;
+  button_down = false;
+  Invalidate();
+}
+
+/*
+ * dragging
+ */
+
+void
+InfoBoxArrangeWindow::BeginDrag(unsigned slot, PixelPoint pointer,
+                                bool follow) noexcept
+{
+  drag.emplace(DragState{slot, layout->positions[slot], pointer, pointer,
+                         follow});
+  drag_snapshot = *panel;
+  ResetCardNumbers();
+
+  SetCapture();
+  OnArrangeActivity();
+  Invalidate();
+}
+
+void
+InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
+{
+  if (!drag)
+    return;
+
+  drag->pointer = p;
+
+  if (!drag->following) {
+    const auto d = p - drag->origin;
+    if (std::abs(d.x) + std::abs(d.y) < GetDeadZone())
+      return;
+
+    drag->following = true;
+  }
+
+  /* exchange with the slot the finger has moved into, so that a drag
+     across several slots shifts them one by one instead of swapping
+     with the slot it started from */
+  const int slot = FindSlot(p);
+  if (slot >= 0 && unsigned(slot) != drag->slot) {
+    std::swap(panel->contents[drag->slot], panel->contents[slot]);
+    std::swap(card_number[drag->slot], card_number[slot]);
+    drag->slot = slot;
+  }
+
+  Invalidate();
+}
+
+void
+InfoBoxArrangeWindow::Drop() noexcept
+{
+  if (!drag)
+    return;
+
+  drag.reset();
+  ResetCardNumbers();
+  ReleaseCapture();
+  OnArrangeActivity();
+  Invalidate();
+}
+
+void
+InfoBoxArrangeWindow::CancelDrag() noexcept
+{
+  if (!drag)
+    return;
+
+  drag.reset();
+  *panel = drag_snapshot;
+  ResetCardNumbers();
+  Invalidate();
+}
+
+/*
+ * input
+ */
+
+bool
+InfoBoxArrangeWindow::OnMouseDown(PixelPoint p) noexcept
+{
+  OnArrangeActivity();
+
+  const PixelPoint parent_p = ToParentCoordinates(p);
+
+  if (const int button = FindButton(parent_p); button >= 0)
+    HoldButton(button, true);
+  else if (const int slot = FindSlot(parent_p); slot >= 0)
+    BeginDrag(slot, parent_p, false);
+
+  return true;
+}
+
+bool
+InfoBoxArrangeWindow::OnMouseMove(PixelPoint p,
+                                  [[maybe_unused]] unsigned keys) noexcept
+{
+  const PixelPoint parent_p = ToParentCoordinates(p);
+
+  if (held_button >= 0)
+    HoldButton(held_button, GetButtonRect(held_button).Contains(parent_p));
+  else
+    Drag(parent_p);
+
+  return true;
+}
+
+bool
+InfoBoxArrangeWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
+{
+  if (held_button >= 0) {
+    const int button = held_button;
+    const bool clicked = button_down;
+    ReleaseButton();
+
+    if (clicked)
+      OnButton(button);
+
+    return true;
+  }
+
+  if (!drag)
+    return true;
+
+  const unsigned slot = drag->slot;
+  const bool tap = !drag->following;
+  Drop();
+
+  if (tap)
+    /* a tap: let the user choose the contents of this InfoBox */
+    ShowPicker(slot);
+
+  return true;
+}
+
+bool
+InfoBoxArrangeWindow::OnMouseDouble([[maybe_unused]] PixelPoint p) noexcept
+{
+  /* arranging InfoBoxes has no use for the menu */
+  return true;
+}
+
+#ifdef HAVE_MULTI_TOUCH
+
+bool
+InfoBoxArrangeWindow::OnMultiTouchDown() noexcept
+{
+  /* a second finger aborts the drag */
+  CancelDrag();
+  ReleaseCapture();
+  return true;
+}
+
+#endif
+
+void
+InfoBoxArrangeWindow::OnCancelMode() noexcept
+{
+  ReleaseButton();
+  CancelDrag();
+  PaintWindow::OnCancelMode();
+}

--- a/src/InfoBoxes/InfoBoxArrangeWindow.cpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.cpp
@@ -5,7 +5,9 @@
 #include "InfoBoxLayout.hpp"
 #include "InfoBoxManager.hpp"
 #include "Content/Factory.hpp"
+#include "Asset.hpp"
 #include "Dialogs/HelpDialog.hpp"
+#include "Hardware/CPU.hpp"
 #include "Language/Language.hpp"
 #include "Look/DialogLook.hpp"
 #include "Look/InfoBoxLook.hpp"
@@ -29,6 +31,9 @@ namespace {
  * is left, so that the text on the backdrop stays legible.
  */
 constexpr uint8_t OVERLAY_ALPHA = 0xe6;
+
+/** how long a displaced InfoBox takes to slide into its new slot */
+constexpr auto SHUFFLE_DURATION = std::chrono::milliseconds(250);
 
 /**
  * How much the card grows when it is picked up, relative to the slot
@@ -274,6 +279,8 @@ InfoBoxArrangeWindow::PaintCards(Canvas &canvas) noexcept
       continue;
 
     PixelRect rc = layout->positions[i];
+    const PixelPoint offset = GetShuffleOffset(i);
+    rc.Offset(offset.x, offset.y);
     rc.Grow(-(int)look.preview_padding);
     DrawCard(canvas, ToLocal(rc), i, card_number[i], false);
   }
@@ -344,6 +351,55 @@ InfoBoxArrangeWindow::ResetCardNumbers() noexcept
 }
 
 void
+InfoBoxArrangeWindow::StartShuffle(unsigned slot,
+                                   const PixelRect &from) noexcept
+{
+  if (HasEPaper() || IsSlowCPU())
+    /* e-paper and slow CPUs snap instead of animating, the same gate
+       the list and the map pan animations use */
+    return;
+
+  const PixelRect &to = layout->positions[slot];
+  shuffle[slot].offset = {from.left - to.left, from.top - to.top};
+  shuffle[slot].start = std::chrono::steady_clock::now();
+
+  shuffle_timer.Schedule(std::chrono::milliseconds(16));
+}
+
+PixelPoint
+InfoBoxArrangeWindow::GetShuffleOffset(unsigned slot) const noexcept
+{
+  const auto elapsed = std::chrono::steady_clock::now() - shuffle[slot].start;
+  if (elapsed >= SHUFFLE_DURATION)
+    return {0, 0};
+
+  const double t = std::chrono::duration<double>(elapsed)
+    / std::chrono::duration<double>(SHUFFLE_DURATION);
+
+  /* ease in out cubic, the curve UIKit animates with by default */
+  const double e = t < 0.5
+    ? 4 * t * t * t
+    : 1 - 4 * (1 - t) * (1 - t) * (1 - t);
+
+  return {int(shuffle[slot].offset.x * (1 - e)),
+          int(shuffle[slot].offset.y * (1 - e))};
+}
+
+void
+InfoBoxArrangeWindow::OnShuffleTimer() noexcept
+{
+  Invalidate();
+
+  for (unsigned i = 0; i < layout->count; ++i) {
+    const auto offset = GetShuffleOffset(i);
+    if (offset.x != 0 || offset.y != 0)
+      return;
+  }
+
+  shuffle_timer.Cancel();
+}
+
+void
 InfoBoxArrangeWindow::ShowPicker(unsigned slot) noexcept
 {
   OnArrangeSuspend();
@@ -363,6 +419,7 @@ InfoBoxArrangeWindow::ShowHelp() noexcept
   HelpDialog(_("Arrange InfoBoxes"),
              _("Drag an InfoBox onto another one to exchange the two."));
   OnArrangeActivity();
+  SetFocus();
 }
 
 /*
@@ -446,6 +503,12 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
   if (slot >= 0 && unsigned(slot) != drag->slot) {
     std::swap(panel->contents[drag->slot], panel->contents[slot]);
     std::swap(card_number[drag->slot], card_number[slot]);
+
+    /* the InfoBox which was in the way slides over to the slot the
+       dragged one has just left; the dragged one needs no animation
+       because it follows the finger */
+    StartShuffle(drag->slot, layout->positions[slot]);
+
     drag->slot = slot;
   }
 
@@ -474,6 +537,10 @@ InfoBoxArrangeWindow::CancelDrag() noexcept
   drag.reset();
   *panel = drag_snapshot;
   ResetCardNumbers();
+
+  for (auto &i : shuffle)
+    i.start = {};
+
   Invalidate();
 }
 

--- a/src/InfoBoxes/InfoBoxArrangeWindow.cpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.cpp
@@ -12,9 +12,11 @@
 #include "Look/DialogLook.hpp"
 #include "Look/InfoBoxLook.hpp"
 #include "Screen/Layout.hpp"
+#include "UIGlobals.hpp"
 #include "ui/canvas/Brush.hpp"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/event/KeyCode.hpp"
+#include "ui/window/SingleWindow.hpp"
 #include "util/StaticString.hxx"
 #include "util/StringCompare.hxx"
 
@@ -27,6 +29,7 @@
 #endif
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 
 namespace {
@@ -116,22 +119,34 @@ IsShiftKeyPressed() noexcept
 
 } // namespace
 
+bool InfoBoxArrangeWindow::card_floating;
+
 InfoBoxArrangeWindow::InfoBoxArrangeWindow(const InfoBoxLook &_look,
-                                           const DialogLook &_dialog_look)
-  noexcept
-  :look(_look), dialog_look(_dialog_look),
+                                           const DialogLook &_dialog_look,
+                                           Style _style) noexcept
+  :look(_look), dialog_look(_dialog_look), style(_style),
    button_renderer(_dialog_look.button)
 {
   ResetCardNumbers();
 }
 
-void
-InfoBoxArrangeWindow::AddButton(const char *caption,
+unsigned
+InfoBoxArrangeWindow::AddButton(unsigned row, const char *caption,
                                 Callback callback) noexcept
 {
   auto &button = buttons.append();
   button.caption = caption;
   button.callback = std::move(callback);
+  button.row = row;
+  button.enabled = true;
+  return buttons.size() - 1;
+}
+
+void
+InfoBoxArrangeWindow::SetButtonEnabled(unsigned i, bool enabled) noexcept
+{
+  buttons[i].enabled = enabled;
+  Invalidate();
 }
 
 void
@@ -144,9 +159,10 @@ InfoBoxArrangeWindow::Create(ContainerWindow &parent,
   PaintWindow::Create(parent, rc, window_style);
 
 #ifndef USE_WINUSER
-  /* the map below must still be painted (and invalidated), even
-     though this window covers the whole screen */
-  SetTransparent();
+  if (style == Style::MAP)
+    /* the map below must still be painted (and invalidated), even
+       though this window covers the whole screen */
+    SetTransparent();
 #endif
 }
 
@@ -217,35 +233,82 @@ InfoBoxArrangeWindow::GetButtonGap() noexcept
   return Layout::Scale(8);
 }
 
-int
-InfoBoxArrangeWindow::GetButtonWidth() const noexcept
+unsigned
+InfoBoxArrangeWindow::GetButtonRowCount() const noexcept
 {
-  const int count = buttons.size();
-  const int gap = GetButtonGap();
-
-  /* wide enough for the longest caption, so that no button has to
-     wrap its text */
-  int width = Layout::Scale(80);
+  unsigned count = 1;
   for (const auto &i : buttons)
-    width = std::max(width,
-                     (int)TextButtonRenderer::
-                     GetMinimumButtonWidth(dialog_look.button, i.caption));
+    count = std::max(count, i.row + 1);
 
-  /* but never wider than the row itself */
-  return std::min(width,
-                  ((int)content.GetWidth() - (count + 1) * gap) / count);
+  return count;
+}
+
+unsigned
+InfoBoxArrangeWindow::GetRowButtonCount(unsigned row) const noexcept
+{
+  unsigned count = 0;
+  for (const auto &i : buttons)
+    if (i.row == row)
+      ++count;
+
+  return count;
+}
+
+unsigned
+InfoBoxArrangeWindow::GetIndexInRow(unsigned i) const noexcept
+{
+  unsigned index = 0;
+  for (unsigned j = 0; j < i; ++j)
+    if (buttons[j].row == buttons[i].row)
+      ++index;
+
+  return index;
+}
+
+int
+InfoBoxArrangeWindow::GetButtonWidth(unsigned row) const noexcept
+{
+  const int count = GetRowButtonCount(row);
+  assert(count > 0);
+
+  const int gap = GetButtonGap();
+  const int width = ((int)content.GetWidth() - (count + 1) * gap) / count;
+
+  return style == Style::MAP
+    /* on the map the buttons stay compact; they are not what the mode
+       is about */
+    ? std::min(width, Layout::Scale(80))
+    /* in a dialog they fill the width, like the description above
+       them */
+    : width;
+}
+
+int
+InfoBoxArrangeWindow::GetButtonHeight() const noexcept
+{
+  const int gap = GetButtonGap();
+  const int rows = GetButtonRowCount();
+
+  /* the rows share the lower half of the area between the cards, and
+     only get flatter than a dialog control when even that is too
+     little */
+  const int available = ((int)content.GetHeight() / 2 - gap) / rows - gap;
+
+  return std::clamp(available,
+                    (int)Layout::GetMinimumControlHeight(),
+                    (int)Layout::GetMaximumControlHeight());
 }
 
 PixelRect
-InfoBoxArrangeWindow::GetButtonRowRect() const noexcept
+InfoBoxArrangeWindow::GetButtonRowRect(unsigned row) const noexcept
 {
-  const int count = buttons.size();
-  const int height = (int)Layout::GetMaximumControlHeight();
+  const int count = GetRowButtonCount(row);
+  const int height = GetButtonHeight();
   const int gap = GetButtonGap();
-  const int total = count * GetButtonWidth() + (count - 1) * gap;
+  const int total = count * GetButtonWidth(row) + (count - 1) * gap;
 
   PixelRect r;
-  r.bottom = content.bottom - gap;
+  r.bottom = content.bottom - gap - (int)row * (height + gap);
   r.top = r.bottom - height;
   r.left = (content.left + content.right - total) / 2;
   r.right = r.left + total;
@@ -253,14 +316,141 @@ InfoBoxArrangeWindow::GetButtonRowRect() const noexcept
 }
 
 PixelRect
+InfoBoxArrangeWindow::GetButtonBlockRect() const noexcept
+{
+  PixelRect r = GetButtonRowRect(0);
+
+  for (unsigned row = 1; row < GetButtonRowCount(); ++row) {
+    const PixelRect above = GetButtonRowRect(row);
+    r.top = above.top;
+    r.left = std::min(r.left, above.left);
+    r.right = std::max(r.right, above.right);
+  }
+
+  return r;
+}
+
+PixelRect
 InfoBoxArrangeWindow::GetButtonRect(int i) const noexcept
 {
-  const int width = GetButtonWidth();
+  const unsigned row = buttons[i].row;
+  const int width = GetButtonWidth(row);
 
-  PixelRect r = GetButtonRowRect();
-  r.left += i * (width + GetButtonGap());
+  PixelRect r = GetButtonRowRect(row);
+  r.left += (int)GetIndexInRow(i) * (width + GetButtonGap());
   r.right = r.left + width;
   return r;
+}
+
+double
+InfoBoxArrangeWindow::GetSlotFraction(unsigned slot) const noexcept
+{
+  const PixelPoint center = SlotCenter(slot);
+
+  unsigned count = 0, index = 0;
+
+  for (unsigned i = 0; i < layout->count; ++i) {
+    const PixelPoint p = SlotCenter(i);
+    if (Along(p) != Along(center))
+      /* another row or column */
+      continue;
+
+    if (Across(p) < Across(center))
+      ++index;
+
+    ++count;
+  }
+
+  return (index + 0.5) / count;
+}
+
+double
+InfoBoxArrangeWindow::GetButtonFraction(unsigned i) const noexcept
+{
+  return (GetIndexInRow(i) + 0.5) / GetRowButtonCount(buttons[i].row);
+}
+
+double
+InfoBoxArrangeWindow::GetButtonCrossFraction(unsigned i) const noexcept
+{
+  if (!columns)
+    return GetButtonFraction(i);
+
+  /* the rows of the block are stacked across the axis, and row 0 is
+     the bottom one */
+  const unsigned rows = GetButtonRowCount();
+  return (rows - 1 - buttons[i].row + 0.5) / rows;
+}
+
+std::optional<int>
+InfoBoxArrangeWindow::FindSlotGroup(int along, int direction) const noexcept
+{
+  std::optional<int> group;
+
+  for (unsigned i = 0; i < layout->count; ++i) {
+    const int g = Along(SlotCenter(i));
+    if ((g - along) * direction <= 0)
+      continue;
+
+    if (!group || (g - *group) * direction < 0)
+      group = g;
+  }
+
+  return group;
+}
+
+int
+InfoBoxArrangeWindow::FindSlotAt(int group, double fraction) const noexcept
+{
+  int best = -1;
+  double best_distance = 0;
+
+  for (unsigned i = 0; i < layout->count; ++i) {
+    if (Along(SlotCenter(i)) != group)
+      continue;
+
+    const double distance = std::abs(GetSlotFraction(i) - fraction);
+
+    if (best < 0 || distance < best_distance) {
+      best = i;
+      best_distance = distance;
+    }
+  }
+
+  return best;
+}
+
+int
+InfoBoxArrangeWindow::FindButtonAt(unsigned row,
+                                   double fraction) const noexcept
+{
+  int best = -1;
+  double best_distance = 0;
+
+  for (unsigned i = 0; i < buttons.size(); ++i) {
+    if (buttons[i].row != row || !buttons[i].enabled)
+      continue;
+
+    const double distance = std::abs(GetButtonFraction(i) - fraction);
+
+    if (best < 0 || distance < best_distance) {
+      best = i;
+      best_distance = distance;
+    }
+  }
+
+  return best;
+}
+
+int
+InfoBoxArrangeWindow::FindNextInRow(int i, int dx) const noexcept
+{
+  /* the buttons of a row are added from left to right */
+  for (int j = i + dx; j >= 0 && j < (int)buttons.size(); j += dx)
+    if (buttons[j].row == buttons[i].row && buttons[j].enabled)
+      return j;
+
+  return -1;
 }
 
 int
@@ -276,9 +466,11 @@ InfoBoxArrangeWindow::FindButton(PixelPoint p) const noexcept
 PixelRect
 InfoBoxArrangeWindow::GetPanelNameRect() const noexcept
 {
-  PixelRect rc = ToLocal(GetButtonRowRect());
+  PixelRect rc = ToLocal(GetButtonBlockRect());
   rc.bottom = rc.top - Layout::Scale(12);
-  rc.top = rc.bottom - (int)look.title_font_bold.GetHeight();
+  rc.top = rc.bottom - (style == Style::MAP
+                        ? (int)look.title_font_bold.GetHeight()
+                        : 0);
   return rc;
 }
 
@@ -402,6 +594,10 @@ InfoBoxArrangeWindow::PaintButtons(Canvas &canvas) noexcept
 void
 InfoBoxArrangeWindow::PaintPanelName(Canvas &canvas) noexcept
 {
+  if (style != Style::MAP)
+    /* the dialog names the panel itself */
+    return;
+
   const char *name = gettext(panel->name);
   if (StringIsEmpty(name))
     return;
@@ -435,7 +631,9 @@ InfoBoxArrangeWindow::PaintDescription(Canvas &canvas) noexcept
     return;
 
   canvas.SetBackgroundTransparent();
-  canvas.SetTextColor(look.background_color);
+  canvas.SetTextColor(style == Style::MAP
+                      ? look.background_color
+                      : dialog_look.text_color);
 
   canvas.Select(dialog_look.bold_font);
   name_renderer.Draw(canvas, rc, name);
@@ -459,18 +657,19 @@ InfoBoxArrangeWindow::PaintDescription(Canvas &canvas) noexcept
 void
 InfoBoxArrangeWindow::OnPaint(Canvas &canvas) noexcept
 {
+  if (style == Style::MAP) {
 #ifdef ENABLE_OPENGL
-  {
     const ScopeAlphaBlend alpha_blend;
     canvas.DrawFilledRectangle(canvas.GetRect(),
                                look.preview_backdrop_color
                                .WithAlpha(OVERLAY_ALPHA));
-  }
 #else
-  /* without alpha blending, hide the map instead of fading it */
-  canvas.DrawFilledRectangle(canvas.GetRect(),
-                             look.preview_backdrop_color);
+    /* without alpha blending, hide the map instead of fading it */
+    canvas.DrawFilledRectangle(canvas.GetRect(),
+                               look.preview_backdrop_color);
 #endif
+  } else
+    canvas.Clear(dialog_look.background_color);
 
   PaintDescription(canvas);
   PaintPanelName(canvas);
@@ -490,6 +689,7 @@ InfoBoxArrangeWindow::Exchange(unsigned a, unsigned b) noexcept
 {
   std::swap(panel->contents[a], panel->contents[b]);
   std::swap(card_number[a], card_number[b]);
+  OnArrangeModified();
 }
 
 void
@@ -567,8 +767,10 @@ InfoBoxArrangeWindow::ShowPicker(unsigned slot) noexcept
 {
   OnArrangeSuspend();
 
-  if (InfoBoxManager::ShowInfoBoxPicker(*panel, slot))
+  if (InfoBoxManager::ShowInfoBoxPicker(*panel, slot)) {
     Invalidate();
+    OnArrangeModified();
+  }
 
   OnArrangeActivity();
   SetFocus();
@@ -595,6 +797,11 @@ InfoBoxArrangeWindow::ShowHelp() noexcept
                   "a different InfoBox for that position."));
   }
 
+  if (extra_help != nullptr) {
+    text.append("\n\n");
+    text.append(extra_help);
+  }
+
   /* the timeout must not end the mode behind the dialog */
   OnArrangeSuspend();
   HelpDialog(_("Arrange InfoBoxes"), text);
@@ -605,16 +812,6 @@ InfoBoxArrangeWindow::ShowHelp() noexcept
 /*
  * the cursor keys
  */
-
-PixelPoint
-InfoBoxArrangeWindow::GetButtonRowOrigin() const noexcept
-{
-  const PixelPoint center = GetButtonRowRect().GetCenter();
-
-  return columns
-    ? PixelPoint{center.x, button_row_cross}
-    : PixelPoint{button_row_cross, center.y};
-}
 
 int
 InfoBoxArrangeWindow::FindNeighbour(PixelPoint origin,
@@ -644,11 +841,24 @@ InfoBoxArrangeWindow::FindNeighbour(PixelPoint origin,
 }
 
 bool
+InfoBoxArrangeWindow::HasEnabledButton() const noexcept
+{
+  for (const auto &i : buttons)
+    if (i.enabled)
+      return true;
+
+  return false;
+}
+
+bool
 InfoBoxArrangeWindow::IsButtonRowCloser(PixelPoint origin, int slot,
                                         bool forward) const noexcept
 {
+  if (!HasEnabledButton())
+    return false;
+
   const int buttons_along =
-    Along(GetButtonRowRect().GetCenter()) - Along(origin);
+    Along(GetButtonBlockRect().GetCenter()) - Along(origin);
   if (forward ? buttons_along <= 0 : buttons_along >= 0)
     return false;
 
@@ -659,44 +869,67 @@ InfoBoxArrangeWindow::IsButtonRowCloser(PixelPoint origin, int slot,
     std::abs(Along(SlotCenter(slot)) - Along(origin));
 }
 
-void
-InfoBoxArrangeWindow::FocusButtonNear(PixelPoint origin) noexcept
+bool
+InfoBoxArrangeWindow::FocusButtonFrom(int dx, int dy) noexcept
 {
-  button_row_cross = Across(origin);
+  const int button = columns
+    /* the cursor arrives from the side and takes the button at that
+       end of the bottom row */
+    ? FindButtonAt(0, dx > 0 ? 0. : 1.)
+    /* it arrives from above or from below and keeps the place it
+       remembers */
+    : FindButtonAt(dy > 0 ? GetButtonRowCount() - 1 : 0, cross_fraction);
 
-  int best = -1, best_distance = 0;
+  if (button < 0)
+    return false;
 
-  for (unsigned i = 0; i < buttons.size(); ++i) {
-    const int distance =
-      std::abs(GetButtonRect(i).GetCenter().x - origin.x);
+  focused_button = button;
+  return true;
+}
 
-    if (best < 0 || distance < best_distance) {
-      best = i;
-      best_distance = distance;
-    }
-  }
-
-  if (best >= 0)
-    focused_button = best;
+void
+InfoBoxArrangeWindow::RememberCross() noexcept
+{
+  if (focused_button >= 0)
+    cross_fraction = GetButtonCrossFraction(focused_button);
+  else if (described_slot >= 0)
+    cross_fraction = GetSlotFraction(described_slot);
 }
 
 bool
 InfoBoxArrangeWindow::MoveFromButton(int dx, int dy, bool along) noexcept
 {
-  /* the buttons stand side by side, so left and right switch between
-     them */
-  const int button = dx != 0 ? focused_button + dx : -1;
+  /* left and right switch between the buttons of a row, up and down
+     between the rows, where the button keeps its place in the row */
+  const unsigned row = buttons[focused_button].row;
+  int button = -1;
 
-  if (button >= 0 && button < (int)buttons.size())
+  if (dx != 0)
+    button = FindNextInRow(focused_button, dx);
+  else if (dy < 0 ? row + 1 < GetButtonRowCount() : row > 0)
+    /* when the button rows follow the axis, the cursor keeps the
+       place it remembers; when they lie across it, it keeps its
+       place in the row */
+    button = FindButtonAt(dy < 0 ? row + 1 : row - 1,
+                          columns
+                          ? GetButtonFraction(focused_button)
+                          : cross_fraction);
+
+  if (button >= 0) {
     focused_button = button;
-  else if (!along)
+
+    if (!along)
+      RememberCross();
+  } else if (!along)
     return true;
   else {
-    const int slot = FindNeighbour(GetButtonRowOrigin(), dx, dy);
-    if (slot < 0)
+    /* the cursor returns to the InfoBoxes at the place it remembers */
+    const auto group =
+      FindSlotGroup(Along(GetButtonBlockRect().GetCenter()), dx + dy);
+    if (!group)
       return true;
 
-    described_slot = slot;
+    described_slot = FindSlotAt(*group, cross_fraction);
     focused_button = -1;
   }
 
@@ -710,11 +943,23 @@ InfoBoxArrangeWindow::GetTabKey(unsigned i) const noexcept
 {
   const unsigned count = layout->count;
 
-  const PixelPoint p = i < count
-    ? layout->positions[i].GetCenter()
-    : GetButtonRect(i - count).GetCenter();
+  if (i < count) {
+    const PixelPoint p = layout->positions[i].GetCenter();
+    return {Along(p), 0, Across(p)};
+  }
 
-  return {Along(p), Across(p)};
+  const unsigned button = i - count;
+  const PixelPoint p = GetButtonRect(button).GetCenter();
+
+  /* when the InfoBoxes stand in rows, every button row is a group of
+     its own, between the InfoBoxes above and below it; when they
+     stand in columns, the whole button block is one group between
+     them, and inside it the rows are read from top to bottom, each
+     from left to right */
+  return columns
+    ? TabKey{Along(GetButtonBlockRect().GetCenter()),
+             int(GetButtonRowCount() - 1 - buttons[button].row), p.x}
+    : TabKey{Along(p), 0, Across(p)};
 }
 
 void
@@ -727,8 +972,9 @@ InfoBoxArrangeWindow::FocusItem(unsigned i) noexcept
     focused_button = -1;
   } else {
     focused_button = i - count;
-    button_row_cross = Across(GetButtonRect(focused_button).GetCenter());
   }
+
+  RememberCross();
 
   selection = Selection::FOCUSED;
   Invalidate();
@@ -756,6 +1002,10 @@ InfoBoxArrangeWindow::MoveTab(bool forward) noexcept
     if (i == current)
       continue;
 
+    if (i >= slot_count && !buttons[i - slot_count].enabled)
+      /* a disabled button is skipped */
+      continue;
+
     const TabKey k = GetTabKey(i);
 
     if (forward ? key < k : k < key) {
@@ -777,12 +1027,41 @@ InfoBoxArrangeWindow::MoveTab(bool forward) noexcept
 }
 
 bool
+InfoBoxArrangeWindow::CanMoveSelection(int dx, int dy) const noexcept
+{
+  if (style == Style::MAP)
+    /* nothing else on the map can have the focus, so the edge of the
+       layout is a wall */
+    return true;
+
+  if (selection == Selection::MOVING)
+    /* the InfoBox the user carries must not be left behind */
+    return true;
+
+  if (described_slot < 0 && focused_button < 0)
+    /* the first key press selects the first InfoBox */
+    return true;
+
+  const bool along = columns ? dx != 0 : dy != 0;
+
+  if (focused_button >= 0)
+    /* the cursor moves inside the button block or leaves it */
+    return true;
+
+  const PixelPoint origin = SlotCenter(described_slot);
+  const int slot = FindNeighbour(origin, dx, dy);
+
+  return slot >= 0 || (along && IsButtonRowCloser(origin, slot, dx + dy > 0));
+}
+
+bool
 InfoBoxArrangeWindow::MoveSelection(int dx, int dy) noexcept
 {
   OnArrangeActivity();
 
   if (described_slot < 0 && focused_button < 0) {
     described_slot = 0;
+    RememberCross();
     selection = Selection::FOCUSED;
     Invalidate();
     return true;
@@ -802,6 +1081,11 @@ InfoBoxArrangeWindow::MoveSelection(int dx, int dy) noexcept
     StartShuffle(slot, layout->positions[described_slot]);
 
     described_slot = slot;
+
+    /* the cursor sits on the InfoBox it carries, so it leaves the
+       layout where that one has landed */
+    RememberCross();
+
     Invalidate();
     return true;
   }
@@ -819,11 +1103,21 @@ InfoBoxArrangeWindow::MoveSelection(int dx, int dy) noexcept
   const PixelPoint origin = SlotCenter(described_slot);
   const int slot = FindNeighbour(origin, dx, dy);
 
-  if (along && IsButtonRowCloser(origin, slot, dx + dy > 0))
-    FocusButtonNear(origin);
-  else if (slot >= 0)
+  if (along && IsButtonRowCloser(origin, slot, dx + dy > 0)) {
+    if (!FocusButtonFrom(dx, dy))
+      return true;
+  } else if (along) {
+    /* the cursor keeps its place inside the row (portrait) or column
+       it moves to */
+    const auto group = FindSlotGroup(Along(origin), dx + dy);
+    if (!group)
+      return true;
+
+    described_slot = FindSlotAt(*group, cross_fraction);
+  } else if (slot >= 0) {
     described_slot = slot;
-  else
+    RememberCross();
+  } else
     return true;
 
   selection = Selection::FOCUSED;
@@ -875,6 +1169,9 @@ InfoBoxArrangeWindow::Activate() noexcept
 ButtonState
 InfoBoxArrangeWindow::GetButtonState(int i) const noexcept
 {
+  if (!buttons[i].enabled)
+    return ButtonState::DISABLED;
+
   if (held_button == i && button_down)
     return ButtonState::PRESSED;
 
@@ -887,7 +1184,8 @@ InfoBoxArrangeWindow::GetButtonState(int i) const noexcept
 void
 InfoBoxArrangeWindow::OnButton(int i) noexcept
 {
-  buttons[i].callback();
+  if (buttons[i].enabled)
+    buttons[i].callback();
 }
 
 void
@@ -921,6 +1219,7 @@ InfoBoxArrangeWindow::FocusSlot(unsigned slot) noexcept
 {
   described_slot = slot;
   focused_button = -1;
+  RememberCross();
   selection = Selection::FOCUSED;
   Invalidate();
 }
@@ -939,6 +1238,8 @@ InfoBoxArrangeWindow::BeginDrag(unsigned slot, PixelPoint pointer,
   described_slot = slot;
   selection = Selection::TOUCH;
   focused_button = -1;
+
+  card_floating = follow;
 
   if (!follow)
     /* holding the InfoBox still opens the picker */
@@ -963,6 +1264,7 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
       return;
 
     drag->following = true;
+    card_floating = true;
     picker_timer.Cancel();
   }
 
@@ -982,6 +1284,11 @@ InfoBoxArrangeWindow::Drag(PixelPoint p) noexcept
   }
 
   Invalidate();
+
+  if (style == Style::DIALOG)
+    /* the card is not clipped to this window, so the main window has
+       to clear what it leaves outside the dialog */
+    UIGlobals::GetMainWindow().Invalidate();
 }
 
 void
@@ -992,7 +1299,9 @@ InfoBoxArrangeWindow::Drop() noexcept
 
   picker_timer.Cancel();
   drag.reset();
+  card_floating = false;
   ResetCardNumbers();
+  RememberCross();
   ReleaseCapture();
   OnArrangeActivity();
   Invalidate();
@@ -1006,6 +1315,7 @@ InfoBoxArrangeWindow::CancelDrag() noexcept
 
   picker_timer.Cancel();
   drag.reset();
+  card_floating = false;
   *panel = drag_snapshot;
   ResetCardNumbers();
   described_slot = -1;
@@ -1013,6 +1323,7 @@ InfoBoxArrangeWindow::CancelDrag() noexcept
   for (auto &i : shuffle)
     i.start = {};
 
+  OnArrangeModified();
   Invalidate();
 }
 
@@ -1095,7 +1406,11 @@ InfoBoxArrangeWindow::OnKeyCheck(unsigned key_code) const noexcept
 {
   switch (key_code) {
   case KEY_UP:
+    return CanMoveSelection(0, -1);
+
   case KEY_DOWN:
+    return CanMoveSelection(0, 1);
+
   case KEY_LEFT:
   case KEY_RIGHT:
   case KEY_RETURN:

--- a/src/InfoBoxes/InfoBoxArrangeWindow.hpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.hpp
@@ -36,6 +36,33 @@ public:
   static constexpr unsigned MAX_BUTTONS = 2;
 
 private:
+  /** How is the InfoBox the user is working with drawn? */
+  enum class CardState {
+    /** just one of the InfoBoxes */
+    NORMAL,
+
+    /**
+     * Selected with the cursor keys.  Like a focused button, the card
+     * only gets a ring, because it is not taken yet.
+     */
+    FOCUSED,
+
+    /** tapped, taken with Enter, or following the finger */
+    ACTIVE,
+  };
+
+  /** How was the InfoBox which is being worked with selected? */
+  enum class Selection {
+    /** by tapping it, or by grabbing it with the finger */
+    TOUCH,
+
+    /** with the cursor keys */
+    FOCUSED,
+
+    /** taken with Enter, ready to be moved with the cursor keys */
+    MOVING,
+  };
+
   /** One of the buttons below the cards. */
   struct ButtonItem {
     const char *caption;
@@ -71,11 +98,34 @@ private:
     std::chrono::steady_clock::time_point start{};
   };
 
+  /**
+   * Sort key for the Tab order: it follows the axis the InfoBoxes are
+   * stacked on, so row by row when they stand in rows and column by
+   * column when they stand in columns, and the buttons take their
+   * place in that order by where they sit on the screen.
+   */
+  struct TabKey {
+    /** the row or column on the screen */
+    int group;
+
+    /** the place inside that group */
+    int position;
+
+    constexpr bool operator<(const TabKey &other) const noexcept {
+      return group != other.group
+        ? group < other.group
+        : position < other.position;
+    }
+  };
+
   const InfoBoxLook &look;
   const DialogLook &dialog_look;
 
   InfoBoxSettings::Panel *panel = nullptr;
   const InfoBoxLayout::Layout *layout = nullptr;
+
+  /** are the InfoBoxes of #layout arranged in columns? */
+  bool columns = false;
 
   /** the area between the cards, for the description and the buttons */
   PixelRect content;
@@ -93,6 +143,16 @@ private:
   /** the button the press started on, or -1 */
   int held_button = -1;
 
+  /** the button the cursor keys have selected, or -1 */
+  int focused_button = -1;
+
+  /**
+   * The place across the axis the cursor came from when it entered
+   * the button row, so that crossing the row does not drop it in the
+   * middle of the layout.
+   */
+  int button_row_cross = 0;
+
   /** is the finger still on #held_button? */
   bool button_down = false;
 
@@ -107,6 +167,12 @@ private:
 
   /** the InfoBox whose description is shown, or -1 */
   int described_slot = -1;
+
+  /** how #described_slot was selected */
+  Selection selection = Selection::TOUCH;
+
+  /** the slot #Selection::MOVING started from */
+  unsigned grab_slot;
 
   TextRenderer name_renderer, description_renderer;
 
@@ -139,6 +205,9 @@ public:
   void SetLayout(const InfoBoxLayout::Layout &_layout,
                  PixelRect _content) noexcept;
 
+  /** Select an InfoBox with no drag, for the cursor keys. */
+  void FocusSlot(unsigned slot) noexcept;
+
   /** Begin a drag which was started on another window. */
   void BeginDrag(unsigned slot, PixelPoint pointer, bool follow) noexcept;
 
@@ -163,7 +232,27 @@ protected:
    */
   virtual void OnArrangeSuspend() noexcept {}
 
+  /**
+   * The Escape key was pressed.
+   *
+   * @return true if this window has handled it
+   */
+  virtual bool OnArrangeCancel() noexcept {
+    return false;
+  }
+
 private:
+  [[gnu::pure]]
+  PixelPoint SlotCenter(unsigned slot) const noexcept;
+
+  /** The coordinate along the axis the InfoBoxes are stacked on. */
+  [[gnu::pure]]
+  int Along(PixelPoint p) const noexcept;
+
+  /** The coordinate across that axis. */
+  [[gnu::pure]]
+  int Across(PixelPoint p) const noexcept;
+
   /** Which slot covers the given position in parent coordinates? */
   [[gnu::pure]]
   int FindSlot(PixelPoint p) const noexcept;
@@ -202,13 +291,19 @@ private:
   [[gnu::pure]]
   ButtonState GetButtonState(int i) const noexcept;
 
+  [[gnu::pure]]
+  CardState GetCardState(unsigned slot) const noexcept;
+
   void DrawCard(Canvas &canvas, const PixelRect &rc, unsigned slot,
-                unsigned number, bool active) noexcept;
+                unsigned number, CardState state) noexcept;
 
   void PaintCards(Canvas &canvas) noexcept;
   void PaintButtons(Canvas &canvas) noexcept;
   void PaintPanelName(Canvas &canvas) noexcept;
   void PaintDescription(Canvas &canvas) noexcept;
+
+  /** Exchange the InfoBoxes in two slots. */
+  void Exchange(unsigned a, unsigned b) noexcept;
 
   void ResetCardNumbers() noexcept;
 
@@ -226,6 +321,55 @@ private:
 
   /** Let the user choose a different InfoBox for @p slot. */
   void ShowPicker(unsigned slot) noexcept;
+
+  /**
+   * Where the cursor leaves the button row: on the row itself, but at
+   * the place across the axis it came from.
+   */
+  [[gnu::pure]]
+  PixelPoint GetButtonRowOrigin() const noexcept;
+
+  /**
+   * Which slot lies next to @p origin in the direction (@p dx, @p dy)?
+   *
+   * @return the slot, or -1 if there is none in that direction
+   */
+  [[gnu::pure]]
+  int FindNeighbour(PixelPoint origin, int dx, int dy) const noexcept;
+
+  /**
+   * Does the button row come before @p slot when moving away from
+   * @p origin?
+   */
+  [[gnu::pure]]
+  bool IsButtonRowCloser(PixelPoint origin, int slot,
+                         bool forward) const noexcept;
+
+  /** Focus the button which is closest to @p origin. */
+  void FocusButtonNear(PixelPoint origin) noexcept;
+
+  /** Move the cursor away from the button row. */
+  bool MoveFromButton(int dx, int dy, bool along) noexcept;
+
+  [[gnu::pure]]
+  TabKey GetTabKey(unsigned i) const noexcept;
+
+  void FocusItem(unsigned i) noexcept;
+
+  /**
+   * Move the focus one step along the Tab order, wrapping around at
+   * the ends.
+   */
+  bool MoveTab(bool forward) noexcept;
+
+  /** Move the selection with the cursor keys or a remote stick. */
+  bool MoveSelection(int dx, int dy) noexcept;
+
+  /**
+   * Enter takes the selected InfoBox, puts it down again, or opens
+   * the picker if it was put down where it was taken.
+   */
+  bool Activate() noexcept;
 
   /** Run what the button in @p i does. */
   void OnButton(int i) noexcept;
@@ -248,5 +392,7 @@ protected:
 #ifdef HAVE_MULTI_TOUCH
   bool OnMultiTouchDown() noexcept override;
 #endif
+  bool OnKeyCheck(unsigned key_code) const noexcept override;
+  bool OnKeyDown(unsigned key_code) noexcept override;
   void OnCancelMode() noexcept override;
 };

--- a/src/InfoBoxes/InfoBoxArrangeWindow.hpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.hpp
@@ -31,9 +31,36 @@ namespace InfoBoxLayout { struct Layout; }
  */
 class InfoBoxArrangeWindow : public PaintWindow {
 public:
+  /** Where is this window used? */
+  enum class Style {
+    /**
+     * On top of the map: the background is translucent, the name of
+     * the panel is painted above the buttons, and the cursor keys stop
+     * at the edge of the layout.
+     */
+    MAP,
+
+    /**
+     * Inside a dialog: the background is opaque, the panel is named by
+     * the dialog, and the cursor leaves the window at the edge of the
+     * layout so that the other controls remain reachable.
+     */
+    DIALOG,
+  };
+
   using Callback = std::function<void()>;
 
-  static constexpr unsigned MAX_BUTTONS = 2;
+  /**
+   * Does a card follow the finger right now?  While it does, the
+   * window behind this one has to clear itself, because the card is
+   * not clipped to this window.
+   */
+  [[gnu::pure]]
+  static bool IsCardFloating() noexcept {
+    return card_floating;
+  }
+
+  static constexpr unsigned MAX_BUTTONS = 5;
 
 private:
   /** How is the InfoBox the user is working with drawn? */
@@ -67,6 +94,11 @@ private:
   struct ButtonItem {
     const char *caption;
     Callback callback;
+
+    /** 0 is the bottom row, 1 the one above it */
+    unsigned row;
+
+    bool enabled;
   };
 
   /** The InfoBox which is being dragged. */
@@ -108,18 +140,27 @@ private:
     /** the row or column on the screen */
     int group;
 
-    /** the place inside that group */
+    /** the button row inside that group, top to bottom */
+    int button_row;
+
+    /** the place inside that button row */
     int position;
 
     constexpr bool operator<(const TabKey &other) const noexcept {
-      return group != other.group
-        ? group < other.group
-        : position < other.position;
+      if (group != other.group)
+        return group < other.group;
+
+      if (button_row != other.button_row)
+        return button_row < other.button_row;
+
+      return position < other.position;
     }
   };
 
   const InfoBoxLook &look;
   const DialogLook &dialog_look;
+
+  const Style style;
 
   InfoBoxSettings::Panel *panel = nullptr;
   const InfoBoxLayout::Layout *layout = nullptr;
@@ -135,6 +176,12 @@ private:
   /** draws all buttons, one after the other */
   TextButtonRenderer button_renderer;
 
+  /** another paragraph for the help text, or nullptr */
+  const char *extra_help = nullptr;
+
+  /** @see IsCardFloating() */
+  static bool card_floating;
+
   std::optional<DragState> drag;
 
   /** the InfoBox configuration as it was when the drag started */
@@ -147,11 +194,12 @@ private:
   int focused_button = -1;
 
   /**
-   * The place across the axis the cursor came from when it entered
-   * the button row, so that crossing the row does not drop it in the
-   * middle of the layout.
+   * Where the cursor sits across the axis it moves on, as a fraction
+   * of the row or column it is in.  Crossing the button block keeps
+   * this fraction, so that the cursor returns to the place it came
+   * from.
    */
-  int button_row_cross = 0;
+  double cross_fraction = 0.5;
 
   /** is the finger still on #held_button? */
   bool button_down = false;
@@ -183,13 +231,32 @@ private:
 
 public:
   InfoBoxArrangeWindow(const InfoBoxLook &_look,
-                       const DialogLook &_dialog_look) noexcept;
+                       const DialogLook &_dialog_look,
+                       Style _style) noexcept;
 
   /**
-   * Add a button below the cards, to the right of the previous one.
-   * Only before Create().
+   * Add a button below the cards, to the right of the previous one of
+   * its row.  Row 0 is the bottom row, row 1 the one above it; the
+   * rows are filled from the bottom up, so none of them may stay
+   * empty.  Only before Create().
+   *
+   * @return the index for SetButtonEnabled()
    */
-  void AddButton(const char *caption, Callback callback) noexcept;
+  unsigned AddButton(unsigned row, const char *caption,
+                     Callback callback) noexcept;
+
+  /** Add a button to the bottom row. */
+  unsigned AddButton(const char *caption, Callback callback) noexcept {
+    return AddButton(0, caption, std::move(callback));
+  }
+
+  /** A disabled button is drawn greyed out and cannot be selected. */
+  void SetButtonEnabled(unsigned i, bool enabled) noexcept;
+
+  /** Another paragraph for the help text, shown after the general one. */
+  void SetExtraHelp(const char *text) noexcept {
+    extra_help = text;
+  }
 
   void Create(ContainerWindow &parent, const PixelRect &rc) noexcept;
 
@@ -232,6 +299,9 @@ protected:
    */
   virtual void OnArrangeSuspend() noexcept {}
 
+  /** The panel has been modified. */
+  virtual void OnArrangeModified() noexcept {}
+
   /**
    * The Escape key was pressed.
    *
@@ -265,17 +335,89 @@ private:
   [[gnu::pure]]
   static int GetButtonGap() noexcept;
 
-  /** How wide is a button?  They all have the same width. */
+  /** How many rows do the buttons occupy? */
   [[gnu::pure]]
-  int GetButtonWidth() const noexcept;
+  unsigned GetButtonRowCount() const noexcept;
 
-  /** The row which holds the buttons. */
+  /** How many buttons are in @p row? */
   [[gnu::pure]]
-  PixelRect GetButtonRowRect() const noexcept;
+  unsigned GetRowButtonCount(unsigned row) const noexcept;
+
+  /** Which place does the button @p i take inside its row? */
+  [[gnu::pure]]
+  unsigned GetIndexInRow(unsigned i) const noexcept;
+
+  /**
+   * How wide is a button of @p row?  The buttons of a row share the
+   * width which is available to them, so that every row is as wide as
+   * the description above it.
+   */
+  [[gnu::pure]]
+  int GetButtonWidth(unsigned row) const noexcept;
+
+  /** How high is a button?  Enough rows make them flatter. */
+  [[gnu::pure]]
+  int GetButtonHeight() const noexcept;
+
+  /** One of the rows which hold the buttons. */
+  [[gnu::pure]]
+  PixelRect GetButtonRowRect(unsigned row) const noexcept;
+
+  /** All button rows together. */
+  [[gnu::pure]]
+  PixelRect GetButtonBlockRect() const noexcept;
 
   /** One of the buttons in #GetButtonRowRect(). */
   [[gnu::pure]]
   PixelRect GetButtonRect(int i) const noexcept;
+
+  /**
+   * Where does the InfoBox in @p slot sit across the axis, from 0
+   * (the first place of its row or column) to 1 (the last one)?  Rows
+   * of different length are compared by this fraction, so that the
+   * second of five InfoBoxes lands on the first of three buttons and
+   * not on the second.
+   */
+  [[gnu::pure]]
+  double GetSlotFraction(unsigned slot) const noexcept;
+
+  /** Where does the button @p i sit inside its row? */
+  [[gnu::pure]]
+  double GetButtonFraction(unsigned i) const noexcept;
+
+  /** Where does the button @p i sit across the axis? */
+  [[gnu::pure]]
+  double GetButtonCrossFraction(unsigned i) const noexcept;
+
+  /**
+   * The next InfoBox row or column beyond
+   * @p along in the direction @p direction.
+   *
+   * @return std::nullopt if there is none
+   */
+  [[gnu::pure]]
+  std::optional<int> FindSlotGroup(int along, int direction) const noexcept;
+
+  /** Which InfoBox of @p group sits closest to @p fraction? */
+  [[gnu::pure]]
+  int FindSlotAt(int group, double fraction) const noexcept;
+
+  /**
+   * Which button of @p row sits closest to @p fraction?
+   *
+   * @return the button, or -1 if the row has none to select
+   */
+  [[gnu::pure]]
+  int FindButtonAt(unsigned row, double fraction) const noexcept;
+
+  /**
+   * The next button the user may select inside the row of @p i.
+   *
+   * @param dx -1 for the left, 1 for the right neighbour
+   * @return the button, or -1 if the row ends there
+   */
+  [[gnu::pure]]
+  int FindNextInRow(int i, int dx) const noexcept;
 
   /** Which button covers the given position in parent coordinates? */
   [[gnu::pure]]
@@ -323,13 +465,6 @@ private:
   void ShowPicker(unsigned slot) noexcept;
 
   /**
-   * Where the cursor leaves the button row: on the row itself, but at
-   * the place across the axis it came from.
-   */
-  [[gnu::pure]]
-  PixelPoint GetButtonRowOrigin() const noexcept;
-
-  /**
    * Which slot lies next to @p origin in the direction (@p dx, @p dy)?
    *
    * @return the slot, or -1 if there is none in that direction
@@ -345,8 +480,19 @@ private:
   bool IsButtonRowCloser(PixelPoint origin, int slot,
                          bool forward) const noexcept;
 
-  /** Focus the button which is closest to @p origin. */
-  void FocusButtonNear(PixelPoint origin) noexcept;
+  /** Is there any button the user may select? */
+  [[gnu::pure]]
+  bool HasEnabledButton() const noexcept;
+
+  /**
+   * Move the cursor from the InfoBoxes into the buttons.
+   *
+   * @return false if there is no button to select
+   */
+  bool FocusButtonFrom(int dx, int dy) noexcept;
+
+  /** Remember where the cursor sits across the axis. */
+  void RememberCross() noexcept;
 
   /** Move the cursor away from the button row. */
   bool MoveFromButton(int dx, int dy, bool along) noexcept;
@@ -361,6 +507,10 @@ private:
    * the ends.
    */
   bool MoveTab(bool forward) noexcept;
+
+  /** Would MoveSelection() move the cursor? */
+  [[gnu::pure]]
+  bool CanMoveSelection(int dx, int dy) const noexcept;
 
   /** Move the selection with the cursor keys or a remote stick. */
   bool MoveSelection(int dx, int dy) noexcept;

--- a/src/InfoBoxes/InfoBoxArrangeWindow.hpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.hpp
@@ -5,9 +5,11 @@
 
 #include "InfoBoxSettings.hpp"
 #include "Renderer/TextButtonRenderer.hpp"
+#include "ui/event/PeriodicTimer.hpp"
 #include "ui/window/PaintWindow.hpp"
 #include "util/StaticArray.hxx"
 
+#include <chrono>
 #include <functional>
 #include <optional>
 
@@ -56,6 +58,17 @@ private:
     bool following;
   };
 
+  /**
+   * An InfoBox which was displaced by the dragged one slides into its
+   * new slot instead of jumping there.
+   */
+  struct Shuffle {
+    /** where the card starts, relative to its slot */
+    PixelPoint offset{0, 0};
+
+    std::chrono::steady_clock::time_point start{};
+  };
+
   const InfoBoxLook &look;
   const DialogLook &dialog_look;
 
@@ -81,12 +94,16 @@ private:
   /** is the finger still on #held_button? */
   bool button_down = false;
 
+  Shuffle shuffle[InfoBoxSettings::Panel::MAX_CONTENTS];
+
   /**
    * The number each slot shows.  While dragging, the numbers travel
    * with the InfoBoxes instead of staying on the slots, so that they
    * only change once the finger is lifted.
    */
   unsigned card_number[InfoBoxSettings::Panel::MAX_CONTENTS];
+
+  UI::PeriodicTimer shuffle_timer{[this]{ OnShuffleTimer(); }};
 
 public:
   InfoBoxArrangeWindow(const InfoBoxLook &_look,
@@ -183,6 +200,15 @@ private:
   void PaintPanelName(Canvas &canvas) noexcept;
 
   void ResetCardNumbers() noexcept;
+
+  /** Let the InfoBox in @p slot slide in from @p from. */
+  void StartShuffle(unsigned slot, const PixelRect &from) noexcept;
+
+  /** How far is the InfoBox in @p slot still away from its slot? */
+  [[gnu::pure]]
+  PixelPoint GetShuffleOffset(unsigned slot) const noexcept;
+
+  void OnShuffleTimer() noexcept;
 
   /** Let the user choose a different InfoBox for @p slot. */
   void ShowPicker(unsigned slot) noexcept;

--- a/src/InfoBoxes/InfoBoxArrangeWindow.hpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.hpp
@@ -5,7 +5,9 @@
 
 #include "InfoBoxSettings.hpp"
 #include "Renderer/TextButtonRenderer.hpp"
+#include "Renderer/TextRenderer.hpp"
 #include "ui/event/PeriodicTimer.hpp"
+#include "ui/event/Timer.hpp"
 #include "ui/window/PaintWindow.hpp"
 #include "util/StaticArray.hxx"
 
@@ -103,6 +105,14 @@ private:
    */
   unsigned card_number[InfoBoxSettings::Panel::MAX_CONTENTS];
 
+  /** the InfoBox whose description is shown, or -1 */
+  int described_slot = -1;
+
+  TextRenderer name_renderer, description_renderer;
+
+  /** opens the InfoBox picker when an InfoBox is held down */
+  UI::Timer picker_timer{[this]{ OnPickerTimer(); }};
+
   UI::PeriodicTimer shuffle_timer{[this]{ OnShuffleTimer(); }};
 
 public:
@@ -198,6 +208,7 @@ private:
   void PaintCards(Canvas &canvas) noexcept;
   void PaintButtons(Canvas &canvas) noexcept;
   void PaintPanelName(Canvas &canvas) noexcept;
+  void PaintDescription(Canvas &canvas) noexcept;
 
   void ResetCardNumbers() noexcept;
 
@@ -209,6 +220,9 @@ private:
   PixelPoint GetShuffleOffset(unsigned slot) const noexcept;
 
   void OnShuffleTimer() noexcept;
+
+  /** Open the picker for the InfoBox which is being held down. */
+  void OnPickerTimer() noexcept;
 
   /** Let the user choose a different InfoBox for @p slot. */
   void ShowPicker(unsigned slot) noexcept;

--- a/src/InfoBoxes/InfoBoxArrangeWindow.hpp
+++ b/src/InfoBoxes/InfoBoxArrangeWindow.hpp
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "InfoBoxSettings.hpp"
+#include "Renderer/TextButtonRenderer.hpp"
+#include "ui/window/PaintWindow.hpp"
+#include "util/StaticArray.hxx"
+
+#include <functional>
+#include <optional>
+
+struct DialogLook;
+struct InfoBoxLook;
+
+namespace InfoBoxLayout { struct Layout; }
+
+/**
+ * Shows the InfoBoxes of one panel as cards which the user can
+ * exchange by dragging them, with the cursor keys or with a remote
+ * stick.  Tapping a card describes its InfoBox, and a long press
+ * chooses a different one.
+ *
+ * The window paints everything it shows, which is why the card which
+ * follows the finger can never end up behind another window.
+ */
+class InfoBoxArrangeWindow : public PaintWindow {
+public:
+  using Callback = std::function<void()>;
+
+  static constexpr unsigned MAX_BUTTONS = 2;
+
+private:
+  /** One of the buttons below the cards. */
+  struct ButtonItem {
+    const char *caption;
+    Callback callback;
+  };
+
+  /** The InfoBox which is being dragged. */
+  struct DragState {
+    /** the slot the dragged InfoBox occupies right now */
+    unsigned slot;
+
+    /** the slot rectangle the drag started from */
+    PixelRect start_rect;
+
+    /** the press position in parent coordinates when the drag started */
+    PixelPoint origin;
+
+    /** the current pointer position in parent coordinates */
+    PixelPoint pointer;
+
+    /** does the InfoBox follow the finger already? */
+    bool following;
+  };
+
+  const InfoBoxLook &look;
+  const DialogLook &dialog_look;
+
+  InfoBoxSettings::Panel *panel = nullptr;
+  const InfoBoxLayout::Layout *layout = nullptr;
+
+  /** the area between the cards, for the description and the buttons */
+  PixelRect content;
+
+  StaticArray<ButtonItem, MAX_BUTTONS> buttons;
+
+  /** draws all buttons, one after the other */
+  TextButtonRenderer button_renderer;
+
+  std::optional<DragState> drag;
+
+  /** the InfoBox configuration as it was when the drag started */
+  InfoBoxSettings::Panel drag_snapshot;
+
+  /** the button the press started on, or -1 */
+  int held_button = -1;
+
+  /** is the finger still on #held_button? */
+  bool button_down = false;
+
+  /**
+   * The number each slot shows.  While dragging, the numbers travel
+   * with the InfoBoxes instead of staying on the slots, so that they
+   * only change once the finger is lifted.
+   */
+  unsigned card_number[InfoBoxSettings::Panel::MAX_CONTENTS];
+
+public:
+  InfoBoxArrangeWindow(const InfoBoxLook &_look,
+                       const DialogLook &_dialog_look) noexcept;
+
+  /**
+   * Add a button below the cards, to the right of the previous one.
+   * Only before Create().
+   */
+  void AddButton(const char *caption, Callback callback) noexcept;
+
+  void Create(ContainerWindow &parent, const PixelRect &rc) noexcept;
+
+  /** Which panel does the user arrange? */
+  void SetPanel(InfoBoxSettings::Panel &_panel) noexcept;
+
+  /**
+   * @param _layout where the cards are
+   * @param _content the area between them, for the description and the
+   * buttons; usually InfoBoxLayout::Layout::remaining, less what the
+   * caller puts there itself
+   */
+  void SetLayout(const InfoBoxLayout::Layout &_layout,
+                 PixelRect _content) noexcept;
+
+  /** Begin a drag which was started on another window. */
+  void BeginDrag(unsigned slot, PixelPoint pointer, bool follow) noexcept;
+
+  /** Abort the drag and undo the exchanges it has made. */
+  void CancelDrag() noexcept;
+
+  /** Finish a drag which is still in progress. */
+  void Drop() noexcept;
+
+  /** Explain how an InfoBox is moved and how it is replaced. */
+  void ShowHelp() noexcept;
+
+protected:
+  /**
+   * The user has done something; the map overlay restarts its timeout.
+   */
+  virtual void OnArrangeActivity() noexcept {}
+
+  /**
+   * A modal dialog is about to cover this window; the map overlay
+   * stops its timeout until the next OnArrangeActivity().
+   */
+  virtual void OnArrangeSuspend() noexcept {}
+
+private:
+  /** Which slot covers the given position in parent coordinates? */
+  [[gnu::pure]]
+  int FindSlot(PixelPoint p) const noexcept;
+
+  /** Where does the card which follows the finger sit? */
+  [[gnu::pure]]
+  PixelRect GetFloatingRect() const noexcept;
+
+  /** The gap between the buttons and around the button row. */
+  [[gnu::pure]]
+  static int GetButtonGap() noexcept;
+
+  /** How wide is a button?  They all have the same width. */
+  [[gnu::pure]]
+  int GetButtonWidth() const noexcept;
+
+  /** The row which holds the buttons. */
+  [[gnu::pure]]
+  PixelRect GetButtonRowRect() const noexcept;
+
+  /** One of the buttons in #GetButtonRowRect(). */
+  [[gnu::pure]]
+  PixelRect GetButtonRect(int i) const noexcept;
+
+  /** Which button covers the given position in parent coordinates? */
+  [[gnu::pure]]
+  int FindButton(PixelPoint p) const noexcept;
+
+  /** Where the name of the panel is drawn, above the buttons. */
+  [[gnu::pure]]
+  PixelRect GetPanelNameRect() const noexcept;
+
+  [[gnu::pure]]
+  PixelRect ToLocal(PixelRect rc) const noexcept;
+
+  [[gnu::pure]]
+  ButtonState GetButtonState(int i) const noexcept;
+
+  void DrawCard(Canvas &canvas, const PixelRect &rc, unsigned slot,
+                unsigned number, bool active) noexcept;
+
+  void PaintCards(Canvas &canvas) noexcept;
+  void PaintButtons(Canvas &canvas) noexcept;
+  void PaintPanelName(Canvas &canvas) noexcept;
+
+  void ResetCardNumbers() noexcept;
+
+  /** Let the user choose a different InfoBox for @p slot. */
+  void ShowPicker(unsigned slot) noexcept;
+
+  /** Run what the button in @p i does. */
+  void OnButton(int i) noexcept;
+
+  void HoldButton(int i, bool down) noexcept;
+  void ReleaseButton() noexcept;
+
+  /** Move the dragged card; @p p is in parent coordinates. */
+  void Drag(PixelPoint p) noexcept;
+
+protected:
+  /* virtual methods from class PaintWindow */
+  void OnPaint(Canvas &canvas) noexcept override;
+
+  /* virtual methods from class Window */
+  bool OnMouseDown(PixelPoint p) noexcept override;
+  bool OnMouseMove(PixelPoint p, unsigned keys) noexcept override;
+  bool OnMouseUp(PixelPoint p) noexcept override;
+  bool OnMouseDouble(PixelPoint p) noexcept override;
+#ifdef HAVE_MULTI_TOUCH
+  bool OnMultiTouchDown() noexcept override;
+#endif
+  void OnCancelMode() noexcept override;
+};

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -4,6 +4,7 @@
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "InfoBoxes/InfoBoxWindow.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
+#include "InfoBoxes/InfoBoxArrange.hpp"
 #include "InfoBoxes/Content/Factory.hpp"
 #include "Language/Language.hpp"
 #include "Form/DataField/ComboList.hpp"
@@ -48,6 +49,8 @@ InfoBoxManager::Hide() noexcept
 {
   if (infoboxes_hidden)
     return;
+
+  InfoBoxArrange::Save();
 
   infoboxes_hidden = true;
 
@@ -227,6 +230,8 @@ InfoBoxManager::Create(ContainerWindow &parent,
 void
 InfoBoxManager::Destroy() noexcept
 {
+  InfoBoxArrange::Reset();
+
   infoboxes_ready = false;
   first = true;
 
@@ -236,13 +241,10 @@ InfoBoxManager::Destroy() noexcept
   }
 }
 
-void
-InfoBoxManager::ShowInfoBoxPicker(const int i) noexcept
+bool
+InfoBoxManager::ShowInfoBoxPicker(InfoBoxSettings::Panel &panel,
+                                  unsigned i) noexcept
 {
-  InfoBoxSettings &settings = CommonInterface::SetUISettings().info_boxes;
-  const unsigned panel_index = CommonInterface::GetUIState().panel_index;
-  InfoBoxSettings::Panel &panel = settings.panels[panel_index];
-
   const InfoBoxFactory::Type old_type = panel.contents[i];
 
   ComboList list;
@@ -259,23 +261,56 @@ InfoBoxManager::ShowInfoBoxPicker(const int i) noexcept
   /* let the user select */
 
   StaticString<20> caption;
-  caption.Format("%s: %d", _("InfoBox"), i + 1);
+  caption.Format("%s: %u", _("InfoBox"), i + 1);
   int result = ComboPicker(caption, list, nullptr, true);
   if (result < 0)
-    return;
+    return false;
 
   /* was there a modification? */
 
   InfoBoxFactory::Type new_type = (InfoBoxFactory::Type)list[result].int_value;
   if (new_type == old_type)
-    return;
-
-  /* yes: apply and save it */
+    return false;
 
   panel.contents[i] = new_type;
-  DisplayInfoBox();
+  return true;
+}
 
+void
+InfoBoxManager::ShowInfoBoxPicker(const int i) noexcept
+{
+  if (i < 0)
+    return;
+
+  InfoBoxSettings &settings = CommonInterface::SetUISettings().info_boxes;
+  const unsigned panel_index = CommonInterface::GetUIState().panel_index;
+  InfoBoxSettings::Panel &panel = settings.panels[panel_index];
+
+  if (!ShowInfoBoxPicker(panel, i))
+    return;
+
+  DisplayInfoBox();
   Profile::Save(Profile::map, panel, panel_index);
+}
+
+InfoBoxSettings::Panel &
+InfoBoxManager::GetCurrentPanel() noexcept
+{
+  InfoBoxSettings &settings = CommonInterface::SetUISettings().info_boxes;
+  return settings.panels[CommonInterface::GetUIState().panel_index];
+}
+
+void
+InfoBoxManager::Refresh() noexcept
+{
+  DisplayInfoBox();
+}
+
+void
+InfoBoxManager::SaveCurrentPanel() noexcept
+{
+  const unsigned panel_index = CommonInterface::GetUIState().panel_index;
+  Profile::Save(Profile::map, GetCurrentPanel(), panel_index);
 }
 
 void

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "InfoBoxSettings.hpp"
+
 struct InfoBoxLook;
 class ContainerWindow;
 class InfoBoxWindow;
@@ -55,13 +57,42 @@ void
 Hide() noexcept;
 
 /**
- * Opens a dialog to select the InfoBox contents for
- * the InfoBox indicated by id, or the focused InfoBox.
- * @param id The id of the InfoBox to configure.  If negative,
- * then it configures the focused InfoBox if there is one.
+ * Opens a dialog to select the content of one InfoBox of @p panel.
+ *
+ * @return true if the user has chosen a different InfoBox
+ */
+bool
+ShowInfoBoxPicker(InfoBoxSettings::Panel &panel, unsigned i) noexcept;
+
+/**
+ * Opens a dialog to select the InfoBox contents for the InfoBox
+ * indicated by id, and saves the change to the profile.
+ *
+ * @param id The id of the InfoBox to configure; nothing happens if it
+ * is negative.
  */
 void
-ShowInfoBoxPicker(const int id = -1) noexcept;
+ShowInfoBoxPicker(int id) noexcept;
+
+/**
+ * The InfoBox configuration of the page which is currently shown.
+ */
+[[gnu::pure]]
+InfoBoxSettings::Panel &
+GetCurrentPanel() noexcept;
+
+/**
+ * Update the InfoBox windows after #GetCurrentPanel() was modified.
+ */
+void
+Refresh() noexcept;
+
+/**
+ * Save the configuration of the page which is currently shown to the
+ * profile.
+ */
+void
+SaveCurrentPanel() noexcept;
 
 /**
  * Clear focus from all InfoBoxes except the one with the specified ID.

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -14,12 +14,20 @@
 #include "ui/event/KeyCode.hpp"
 #include "Dialogs/dlgInfoBoxAccess.hpp"
 #include "InfoBoxes/InfoBoxManager.hpp"
+#include "InfoBoxes/InfoBoxArrange.hpp"
 #include "Asset.hpp"
 
 #include <algorithm>
 
 /** timeout of infobox focus */
 static constexpr std::chrono::steady_clock::duration FOCUS_TIMEOUT_MAX = std::chrono::seconds(20);
+
+/**
+ * How long the InfoBox has to be pressed before the arrange mode
+ * starts.  This is long enough to not get in the way of a tap, but
+ * short enough to stay comfortable.
+ */
+static constexpr auto REORDER_DELAY = std::chrono::milliseconds(600);
 
 InfoBoxWindow::InfoBoxWindow(ContainerWindow &parent, PixelRect rc,
                              unsigned border_flags,
@@ -376,7 +384,7 @@ InfoBoxWindow::OnKeyDown(unsigned key_code) noexcept
 }
 
 bool
-InfoBoxWindow::OnMouseDown([[maybe_unused]] PixelPoint p) noexcept
+InfoBoxWindow::OnMouseDown(PixelPoint p) noexcept
 {
   dialog_timer.Cancel();
 
@@ -387,8 +395,9 @@ InfoBoxWindow::OnMouseDown([[maybe_unused]] PixelPoint p) noexcept
     pressed = true;
     Invalidate();
 
+    press_point = p;
     long_press_pending = true;
-    dialog_timer.Schedule(std::chrono::seconds(1));
+    dialog_timer.Schedule(REORDER_DELAY);
   }
 
   return true;
@@ -408,19 +417,17 @@ InfoBoxWindow::OnMouseUp([[maybe_unused]] PixelPoint p) noexcept
 
     ReleaseCapture();
 
-    if (was_pressed) {
-      if (long_press_pending) {
-        long_press_pending = false;
-        
-        InfoBoxManager::ClearFocusExcept(id);
-        SetFocus();
+    if (was_pressed && long_press_pending) {
+      long_press_pending = false;
 
-        const bool click_handled = content != nullptr && content->HandleClick();
+      InfoBoxManager::ClearFocusExcept(id);
+      SetFocus();
 
-        if (!click_handled && GetDialogContent() != nullptr)
-          /* delay the dialog opening to prevent double click detection */
-          dialog_timer.Schedule(std::chrono::milliseconds(300));
-      }
+      const bool click_handled = content != nullptr && content->HandleClick();
+
+      if (!click_handled && GetDialogContent() != nullptr)
+        /* delay the dialog opening to prevent double click detection */
+        dialog_timer.Schedule(std::chrono::milliseconds(300));
     }
 
     return true;
@@ -497,20 +504,17 @@ InfoBoxWindow::OnKillFocus() noexcept
 void
 InfoBoxWindow::OnDialogTimer() noexcept
 {
-  if (long_press_pending) {
-    long_press_pending = false;
-    
-    dragging = pressed = false;
-    Invalidate();
-    ReleaseCapture();
-    
-    InfoBoxManager::ShowInfoBoxPicker(id);
-  } else {
-    dragging = pressed = false;
-    Invalidate();
-    ReleaseCapture();
-    
-    if (GetDialogContent() != nullptr)
-      ShowDialog();
-  }
+  const bool long_press = long_press_pending;
+  long_press_pending = false;
+
+  dragging = pressed = false;
+  Invalidate();
+  ReleaseCapture();
+
+  if (long_press)
+    /* the arrange overlay takes over the gesture which is still in
+       progress */
+    InfoBoxArrange::Begin(id, ToParentCoordinates(press_point));
+  else if (GetDialogContent() != nullptr)
+    ShowDialog();
 }

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -48,9 +48,13 @@ class InfoBoxWindow : public LazyPaintWindow
 
   /**
    * Track whether a long press is pending (timer hasn't fired yet).
-   * Used to distinguish between long press (show picker) and short press (show dialog).
+   * Used to distinguish between long press (start arranging) and
+   * short press (show dialog).
    */
   bool long_press_pending = false;
+
+  /** the position of the press which #dialog_timer is watching */
+  PixelPoint press_point{0, 0};
 
   /** a timer which returns keyboard focus back to the map window after a while */
   UI::Timer focus_timer{[this]{ FocusParent(); }};

--- a/src/Input/InputEvents.hpp
+++ b/src/Input/InputEvents.hpp
@@ -214,6 +214,7 @@ void eventFlarmDetails(const char *misc);
 void eventCredits(const char *misc);
 void eventWeather(const char *misc);
 void eventQuickMenu(const char *misc);
+void eventArrangeInfoBoxes(const char *misc);
 void eventFileManager(const char *misc);
 void eventDataManagement(const char *misc);
 void eventExportFlights(const char *misc);

--- a/src/Input/InputEventsActions.cpp
+++ b/src/Input/InputEventsActions.cpp
@@ -57,6 +57,7 @@ https://xcsoar.readthedocs.io/en/latest/input_events.html
 #include "Projection/MapWindowProjection.hpp"
 #include "Audio/Sound.hpp"
 #include "UIActions.hpp"
+#include "InfoBoxes/InfoBoxArrange.hpp"
 #include "Interface.hpp"
 #include "ActionInterface.hpp"
 #include "Language/Language.hpp"
@@ -786,6 +787,12 @@ void
 InputEvents::eventQuickMenu([[maybe_unused]] const char *misc)
 {
  dlgQuickMenuShowModal(*CommonInterface::main_window);
+}
+
+void
+InputEvents::eventArrangeInfoBoxes([[maybe_unused]] const char *misc)
+{
+  InfoBoxArrange::Begin();
 }
 
 void

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -31,6 +31,10 @@ InfoBoxLook::Initialise(bool _inverse, bool use_colors,
     : Color(0xe0, 0xe0, 0xe0);
   focused_background_color = COLOR_XCSOAR_LIGHT;
   pressed_background_color = COLOR_YELLOW;
+  /* the arrange backdrop is the opposite of the InfoBox background,
+     so that the InfoBox cards stand out on it */
+  preview_backdrop_color = inverse ? COLOR_WHITE : COLOR_BLACK;
+  preview_active_color = COLOR_XCSOAR;
 
   if (inverse) {
     focused_background_color = DarkColor(focused_background_color);
@@ -57,6 +61,10 @@ InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
 
   Color border_color = COLOR_GRAY;
   border_pen.Create(border_width, border_color);
+
+  preview_padding = Layout::Scale(4);
+  preview_radius = Layout::Scale(6);
+
   unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), value.fg_color);
 
   FontDescription title_font_d(8);
@@ -65,6 +73,9 @@ InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
 
   title_font.Load(title_font_d);
   title_font_bold.Load(title_font_d.WithBold(true));
+
+  preview_number_font.Load(FontDescription(std::max(title_font_d.GetHeight()
+                                                    * 2u / 3u, 7u)));
 
   FontDescription value_font_d(10, true);
   AutoSizeFont(value_font_d, width, "1234m");

--- a/src/Look/InfoBoxLook.cpp
+++ b/src/Look/InfoBoxLook.cpp
@@ -64,6 +64,7 @@ InfoBoxLook::ReinitialiseLayout(unsigned width, unsigned scale_title_font)
 
   preview_padding = Layout::Scale(4);
   preview_radius = Layout::Scale(6);
+  preview_focus_width = Layout::ScaleFinePenWidth(3);
 
   unit_fraction_pen.Create(Layout::ScaleFinePenWidth(1), value.fg_color);
 

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -19,6 +19,15 @@ struct InfoBoxLook {
   Color background_color, focused_background_color, pressed_background_color;
 
   /**
+   * The simplified InfoBox cards shown while the InfoBoxes are being
+   * arrangeed (see #InfoBoxArrange).  #preview_backdrop_color covers
+   * the whole screen, #preview_active_color fills the card which
+   * follows the finger.
+   */
+  Color preview_backdrop_color, preview_active_color;
+  unsigned preview_padding, preview_radius;
+
+  /**
    * Used only by #InfoBoxSettings::BorderStyle::SHADED.
    */
   Color caption_background_color;
@@ -38,6 +47,9 @@ struct InfoBoxLook {
 
   Font title_font;
   Font title_font_bold;
+
+  /** the small font for the slot number in the arrange preview */
+  Font preview_number_font;
 
   Color colors[6];
 

--- a/src/Look/InfoBoxLook.hpp
+++ b/src/Look/InfoBoxLook.hpp
@@ -25,7 +25,7 @@ struct InfoBoxLook {
    * follows the finger.
    */
   Color preview_backdrop_color, preview_active_color;
-  unsigned preview_padding, preview_radius;
+  unsigned preview_padding, preview_radius, preview_focus_width;
 
   /**
    * Used only by #InfoBoxSettings::BorderStyle::SHADED.

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -4,6 +4,7 @@
 #include "MapWindow/GlueMapWindow.hpp"
 #include "PopupMessage.hpp"
 #include "InfoBoxes/InfoBoxManager.hpp"
+#include "InfoBoxes/InfoBoxArrange.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
 #include "UIActions.hpp"
 #include "PageActions.hpp"
@@ -1204,7 +1205,9 @@ MainWindow::RunTimer() noexcept
   } else if (!CommonInterface::Calculated().circling ||
              InputEvents::IsFlavour("TA")) {
     thermal_assistant.Hide();
-  } else if (!HasDialog()) {
+  } else if (!HasDialog() && !InfoBoxArrange::IsActive()) {
+    /* the arrange overlay covers the whole screen, and the gauge
+       raises itself above everything else when it appears */
     if (!thermal_assistant.IsDefined())
       thermal_assistant.Set(new GaugeThermalAssistant(CommonInterface::GetLiveBlackboard(),
                                                       look->thermal_assistant_gauge));
@@ -1343,23 +1346,28 @@ void
 MainWindow::OnPaint(Canvas &canvas) noexcept
 {
 #ifdef ENABLE_OPENGL
-  /* The gesture trail is painted by the #GlueMapWindow, but it
-     follows the pointer past the map borders, and OpenGL does not
-     clip a child window to its rectangle.  Areas which no child
-     window repaints (the safe area insets reserved by the
-     #TopWindow, for example) would keep those pixels forever, and
-     each buffer of the swap chain needs a clean frame of its own.
-     Therefore clear the whole window while a trail exists, and for
-     as many extra frames as the swap chain has buffers after it is
-     gone. */
-  const bool gesture_trail = map != nullptr && map->HasGestureTrail();
-  if (gesture_trail)
-    clear_gesture_frames = GetPresentationBufferCount();
+  /* The gesture trail is painted by the #GlueMapWindow and the
+     dragged InfoBox by the arrange overlay, but both follow the
+     pointer past their own window borders, and OpenGL does not clip a
+     child window to its rectangle.  Areas which no child window
+     repaints (the safe area insets reserved by the #TopWindow, for
+     example) would keep those pixels forever, and each buffer of the
+     swap chain needs a clean frame of its own.  Therefore clear the
+     whole window while a trail exists, and for as many extra frames
+     as the swap chain has buffers after it is gone. */
+  const bool arranging = look != nullptr && InfoBoxArrange::IsActive();
+  const bool trail = arranging ||
+    (map != nullptr && map->HasGestureTrail());
+  if (trail)
+    clear_trail_frames = GetPresentationBufferCount();
 
-  if (gesture_trail || clear_gesture_frames > 0) {
-    canvas.DrawFilledRectangle(canvas.GetRect(), COLOR_BLACK);
+  if (trail || clear_trail_frames > 0) {
+    canvas.DrawFilledRectangle(canvas.GetRect(),
+                               arranging
+                               ? look->info_box.preview_backdrop_color
+                               : COLOR_BLACK);
 
-    if (!gesture_trail && --clear_gesture_frames > 0)
+    if (!trail && --clear_trail_frames > 0)
       /* nothing else is going to request the remaining frames */
       Invalidate();
   }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -967,6 +967,10 @@ MainWindow::ResumeThreads() noexcept
 void
 MainWindow::SetDefaultFocus() noexcept
 {
+  if (InfoBoxArrange::SetFocus())
+    /* the InfoBox arrange overlay is modal; it must keep the keys */
+    return;
+
   if (map != nullptr && widget == nullptr)
     map->SetFocus();
   else if (widget == nullptr || !widget->SetFocus())
@@ -1058,7 +1062,10 @@ MainWindow::OnSetFocus() noexcept
 {
   SingleWindow::OnSetFocus();
 
-  if (!HasDialog()) {
+  if (HasDialog())
+    /* recover the dialog focus if it got lost */
+    GetTopDialog().FocusFirstControl();
+  else if (!InfoBoxArrange::SetFocus()) {
     /* the main window should never have the keyboard focus; if we
        happen to get the focus despite of that, forward it to the map
        window to make keyboard shortcuts work */
@@ -1066,9 +1073,7 @@ MainWindow::OnSetFocus() noexcept
       map->SetFocus();
     else if (widget != nullptr)
       widget->SetFocus();
-  } else
-    /* recover the dialog focus if it got lost */
-    GetTopDialog().FocusFirstControl();
+  }
 }
 
 void

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -5,6 +5,7 @@
 #include "PopupMessage.hpp"
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "InfoBoxes/InfoBoxArrange.hpp"
+#include "InfoBoxes/InfoBoxArrangeWindow.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
 #include "UIActions.hpp"
 #include "PageActions.hpp"
@@ -1361,7 +1362,7 @@ MainWindow::OnPaint(Canvas &canvas) noexcept
      whole window while a trail exists, and for as many extra frames
      as the swap chain has buffers after it is gone. */
   const bool arranging = look != nullptr && InfoBoxArrange::IsActive();
-  const bool trail = arranging ||
+  const bool trail = arranging || InfoBoxArrangeWindow::IsCardFloating() ||
     (map != nullptr && map->HasGestureTrail());
   if (trail)
     clear_trail_frames = GetPresentationBufferCount();

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -165,14 +165,15 @@ private:
 #else
   /**
    * Number of frames which must still be repainted with a cleared
-   * background to erase a gesture trail which the #GlueMapWindow has
-   * painted outside its own rectangle.  Sized from the swap-chain
-   * depth so every presentation buffer gets a clean frame.
+   * background to erase what the #GlueMapWindow (gesture trail) or
+   * the InfoBox arrange overlay (dragged InfoBox) has painted outside
+   * its own rectangle.  Sized from the swap-chain depth so every
+   * presentation buffer gets a clean frame.
    *
    * @see OnPaint()
    * @see TopWindow::GetPresentationBufferCount()
    */
-  unsigned clear_gesture_frames = 0;
+  unsigned clear_trail_frames = 0;
 #endif
 
   bool restore_page_pending = false;

--- a/src/ui/canvas/custom/MoreCanvas.cpp
+++ b/src/ui/canvas/custom/MoreCanvas.cpp
@@ -168,11 +168,12 @@ Canvas::DrawFormattedText(const PixelRect r, const std::string_view text,
       }
     }
 
-    if (prev_p) {
+    if (prev_p)
+      /* keep wrapping the rest of the text even though it does not
+         fit; the loop below stops at the bottom of the rectangle, but
+         a line which was never wrapped would be drawn across the whole
+         canvas */
       lines++;
-      if (lines >= max_lines)
-        break;
-    }
   }
 
   if (format & DT_CALCRECT) {


### PR DESCRIPTION
Closes #3051.

A long press on an InfoBox enters an arrange mode: every InfoBox becomes a card with its number and caption, and dragging one onto another exchanges the two. Without a touch screen the cursor keys and a remote stick do the same, and the Quick Menu has an *Arrange InfoBoxes* entry. The same view composes the sets under *Look -> InfoBox Sets*.

Two fixes came out of this and are separate commits: `ui/canvas/MoreCanvas` did not wrap the text beyond the visible lines, which drew the remainder across the whole canvas, and `Form/Form` rewrote the Tab key into Down before the focused control could claim it.

The reasoning behind the design decisions, the open questions and the known limitations are in #3051, so that they stay out of the review here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an InfoBox arrangement mode with drag-and-drop, cursor-key, keyboard, and remote-stick support.
  - Added a card-based InfoBox set editor with rename, copy, paste, help, and cancellation support.
  - Added Quick Menu/input access and long-press entry for rearranging InfoBoxes.
- **Bug Fixes**
  - Improved keyboard focus handling for Tab navigation.
  - Corrected formatted text wrapping in constrained areas.
- **Documentation**
  - Updated the user manual and event reference with arrangement instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->