### PR TITLE
Apple: Follow the system appearance in dark mode Auto

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -101,6 +101,9 @@ Version 7.46 - not yet released
   - fix a settings panel going dead after a swipe: the control the
     swipe had started on kept the mouse capture, so every later press
     was delivered to it instead of to the control that was pressed
+  - fix Dark mode Auto on macOS and iOS always staying light: follow
+    the system appearance, including a scheduled switch while XCSoar
+    is running
 * documentation
   - describe the T Next Leg InfoBox and how to use it at a turn
 * development

--- a/build/main.mk
+++ b/build/main.mk
@@ -655,6 +655,7 @@ ifeq ($(TARGET_IS_DARWIN),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Apple/Services.cpp \
 	$(SRC)/Apple/BackgroundSave.cpp \
+	$(SRC)/Apple/DarkMode.cpp \
 	$(SRC)/Apple/SoundUtil.cpp \
 	$(SRC)/Apple/PathProvider.cpp \
 	$(SRC)/Apple/InternalSensors.cpp \

--- a/src/Apple/DarkMode.cpp
+++ b/src/Apple/DarkMode.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "DarkMode.hpp"
+#include "GlobalSettings.hpp"
+
+#include <TargetConditionals.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+static bool
+IsSystemDarkMode() noexcept
+{
+#if TARGET_OS_IPHONE
+  if (@available(iOS 13.0, *)) {
+    /* the window scene's trait collection is the authoritative source;
+       UITraitCollection.currentTraitCollection is only guaranteed to
+       be up to date inside UIKit callbacks, which this is not */
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes)
+      if ([scene isKindOfClass:UIWindowScene.class])
+        return ((UIWindowScene *)scene).traitCollection.userInterfaceStyle ==
+          UIUserInterfaceStyleDark;
+
+    return UITraitCollection.currentTraitCollection.userInterfaceStyle ==
+      UIUserInterfaceStyleDark;
+  }
+
+  /* iOS 12 and older have no dark appearance */
+  return false;
+#else
+  NSApplication *application = NSApp;
+  if (application == nil)
+    return false;
+
+  NSAppearanceName name =
+    [application.effectiveAppearance bestMatchFromAppearancesWithNames:
+     @[NSAppearanceNameAqua, NSAppearanceNameDarkAqua]];
+  return [name isEqualToString:NSAppearanceNameDarkAqua];
+#endif
+}
+
+bool
+UpdateAppleDarkMode() noexcept
+{
+  const bool dark_mode = IsSystemDarkMode();
+  if (dark_mode == GlobalSettings::dark_mode)
+    return false;
+
+  GlobalSettings::dark_mode = dark_mode;
+  return true;
+}

--- a/src/Apple/DarkMode.hpp
+++ b/src/Apple/DarkMode.hpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+/**
+ * Copies the operating system's appearance setting to
+ * GlobalSettings::dark_mode.
+ *
+ * macOS and iOS may switch the appearance while XCSoar is running,
+ * e.g. on their sunset-to-sunrise schedule, and neither sends the
+ * application a notification our event loop could see.  Therefore this
+ * must be called periodically while UISettings::DarkMode::AUTO is
+ * selected, and once before the look is rebuilt after the user has
+ * selected it.
+ *
+ * @return true if the value has changed
+ */
+bool
+UpdateAppleDarkMode() noexcept;

--- a/src/GlobalSettings.hpp
+++ b/src/GlobalSettings.hpp
@@ -9,11 +9,14 @@
  */
 namespace GlobalSettings {
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(__APPLE__)
 inline bool dark_mode = false;
-inline bool haptic_feedback = false;
 #else
 static constexpr bool dark_mode = false;
+#endif
+
+#ifdef ANDROID
+inline bool haptic_feedback = false;
 #endif
 
 } // namespace GlobalSettings

--- a/src/ProcessTimer.cpp
+++ b/src/ProcessTimer.cpp
@@ -33,6 +33,10 @@
 #include "NOTAM/NOTAMGlue.hpp"
 #endif
 
+#ifdef __APPLE__
+#include "Apple/DarkMode.hpp"
+#endif
+
 static void
 MessageProcessTimer() noexcept
 {
@@ -171,12 +175,38 @@ SettingsProcessTimer() noexcept
   ProcessAutoBugs();
 }
 
+#ifdef __APPLE__
+
+/**
+ * Follows the operating system's appearance setting, which macOS and
+ * iOS may switch at any time, e.g. on their sunset-to-sunrise
+ * schedule.  Neither sends the application an event our event loop
+ * could see, so the setting has to be polled; this is only necessary
+ * while the user has asked us to follow it.
+ */
+static void
+DarkModeProcessTimer() noexcept
+{
+  if (CommonInterface::GetUISettings().dark_mode !=
+      UISettings::DarkMode::AUTO)
+    return;
+
+  if (UpdateAppleDarkMode())
+    CommonInterface::main_window->ReinitialiseLook();
+}
+
+#endif
+
 static void
 CommonProcessTimer() noexcept
 {
   BlackboardProcessTimer();
 
   SettingsProcessTimer();
+
+#ifdef __APPLE__
+  DarkModeProcessTimer();
+#endif
 
   InfoBoxManager::ProcessTimer();
   InputEvents::ProcessTimer();

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -131,6 +131,7 @@
 #ifdef __APPLE__
 #include "Apple/Services.hpp"
 #include "Apple/BackgroundSave.hpp"
+#include "Apple/DarkMode.hpp"
 #endif
 
 #ifdef HAVE_EDL
@@ -351,6 +352,14 @@ Startup(UI::Display &display)
   main_window->Create(SystemWindowSize(), style);
   if (!main_window->IsDefined())
     return false;
+
+#ifdef __APPLE__
+  /* inherit the system appearance; this must happen after the window
+     exists, because on iOS the appearance is read from the window
+     scene, and before anything builds a Look or shows the progress
+     window */
+  UpdateAppleDarkMode();
+#endif
 
 #ifdef ENABLE_OPENGL
   LogFmt("OpenGL: "

--- a/src/UtilsSettings.cpp
+++ b/src/UtilsSettings.cpp
@@ -49,6 +49,10 @@
 #include "Repository/Glue.hpp"
 #include "net/http/Features.hpp"
 
+#ifdef __APPLE__
+#include "Apple/DarkMode.hpp"
+#endif
+
 bool DevicePortChanged = false;
 bool MapFileChanged = false;
 bool AirspaceFileChanged = false;
@@ -215,6 +219,12 @@ SettingsLeave(const UISettings &old_ui_settings)
 
   const MapSettings &old_settings_map = old_ui_settings.map;
   const MapSettings &settings_map = ui_settings.map;
+
+#ifdef __APPLE__
+  /* the system appearance is not polled while "Auto" is disabled;
+     refresh it now, because it may have changed since */
+  UpdateAppleDarkMode();
+#endif
 
   if (ui_settings.dark_mode != old_ui_settings.dark_mode ||
       ui_settings.info_boxes.use_colors != old_ui_settings.info_boxes.use_colors ||


### PR DESCRIPTION
On macOS and iOS, `GlobalSettings::dark_mode` was a compile-time `false`, so the "Auto" dark mode setting always resolved to the light theme. Only Android ever set that value, from its `onConfigurationChanged()` callback. On an iPhone with a scheduled Dark Appearance, XCSoar therefore stayed light after the system switched at night.

This adds `Apple/DarkMode`, which reads the current appearance from the window scene's trait collection on iOS and from `NSApp.effectiveAppearance` on macOS. The value is picked up at startup, refreshed before the look is rebuilt after a settings change, and polled from `ProcessTimer` while "Auto" is selected, so a scheduled switch is applied within half a second without restarting the app. With "On" or "Off" selected there is no polling at all.

Polling instead of a notification because iOS delivers appearance changes into the UIKit view hierarchy, which belongs to SDL here, and SDL2 does not forward them as an event.

Tested on iPhone and macOS, in both directions and with all three settings values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the macOS and iOS **Dark mode: Auto** setting so it follows the system appearance.
  - Scheduled appearance changes are now detected while the app is running.
  - The interface refreshes automatically when the system switches between light and dark modes.
  - The current system appearance is applied correctly during startup and when settings are updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->