### PR TITLE
Device/Condor3Spectate: Fix altitude offset from GPS geoid

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -54,6 +54,7 @@ Version 7.46 - not yet released
   - skip estimated TAS from ground speed and wind when GPS track is
     missing
 * devices
+  - fix Condor 3 Spectate showing altitude about 40 m (136 ft) too low #3055
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -209,9 +209,17 @@ try {
   port = std::move(_port);
 
   parser.Reset();
-  parser.SetReal(!StringIsEqual(driver->name, "Condor") &&
-                 !StringIsEqual(driver->name, "Condor3UDP"));
-  if (config.IsDriver("Condor") || config.IsDriver("Condor3UDP"))
+  /* Condor NMEA GGA has no geoid field; the scenery altitude is already
+     MSL.  Applying EGM96 made GPS ~40 m low (#3055).  Condor3 and
+     Spectate use the same GPS stream; Spectate does not parse LXWP0,
+     so the generic GGA path is the altitude InfoBox. */
+  const bool condor_family =
+    StringIsEqual(driver->name, "Condor") ||
+    StringIsEqual(driver->name, "Condor3") ||
+    StringIsEqual(driver->name, "Condor3UDP") ||
+    StringIsEqual(driver->name, "Condor3Spectate");
+  parser.SetReal(!condor_family);
+  if (condor_family)
     parser.DisableGeoid();
 
   if (driver->CreateOnPort != nullptr) {

--- a/src/Device/Driver/Condor3Spectate.cpp
+++ b/src/Device/Driver/Condor3Spectate.cpp
@@ -386,14 +386,35 @@ Condor3SpectateBuilder::Build(Path path, const char *own_cn,
     const boost::json::object *own = FindOwnShip(players, own_cn_view);
 
     double ref_lat = 0, ref_lon = 0, ref_alt = 0;
+    bool have_pos = false;
+
     if (live_ref != nullptr && live_ref->defined) {
+      /* Horizontal only: live UDP/NMEA updates faster than the
+         Spectate.json poll.  Do not take altitude from here: GPS
+         may have EGM96 subtracted, while Spectate.json is Condor's
+         altimeter (MSL).  Mixing them made every target ~40 m high. */
       ref_lat = live_ref->latitude;
       ref_lon = live_ref->longitude;
       ref_alt = live_ref->altitude;
-    } else if (own != nullptr) {
-      if (!PlayerCoords(*own, ref_lat, ref_lon, ref_alt))
-        return false;
-    } else {
+      have_pos = true;
+    }
+
+    if (own != nullptr) {
+      double own_lat, own_lon, own_alt;
+      if (!PlayerCoords(*own, own_lat, own_lon, own_alt)) {
+        if (!have_pos)
+          return false;
+      } else {
+        ref_alt = own_alt;
+        if (!have_pos) {
+          ref_lat = own_lat;
+          ref_lon = own_lon;
+          have_pos = true;
+        }
+      }
+    }
+
+    if (!have_pos) {
       bool found_ref = false;
       for (const auto &item : players) {
         if (!item.is_object())
@@ -454,10 +475,10 @@ Condor3SpectateDevice::OnCalculatedUpdate(const MoreData &basic,
 
   live_ref.latitude = basic.location.latitude.Degrees();
   live_ref.longitude = basic.location.longitude.Degrees();
-  if (basic.gps_altitude_available)
-    live_ref.altitude = basic.gps_altitude;
-  else if (basic.baro_altitude_available)
-    live_ref.altitude = basic.baro_altitude;
+  /* Same preference as FlarmComputer / GetAnyAltitude: Condor
+     altimeter (baro) matches Spectate.json, unlike GPS-with-geoid. */
+  if (const auto altitude = basic.GetAnyAltitude())
+    live_ref.altitude = *altitude;
   else
     live_ref.altitude = 0;
   live_ref.defined = true;

--- a/src/Device/Driver/Condor3Spectate.hpp
+++ b/src/Device/Driver/Condor3Spectate.hpp
@@ -35,8 +35,10 @@ public:
    *
    * @param own_cn if non-empty, exclude this competition number from
    * traffic list
-   * @param live_ref when defined, use Condor3UDP position as the
-   * coordinate reference instead of own-ship from Spectate.json
+   * @param live_ref when defined, use the live GPS position for
+   * PFLAA north/east.  Relative altitude still uses Spectate.json
+   * own-ship when the competition number is found, so GPS geoid
+   * and Condor altimeter heights are not mixed.
    */
   static bool Build(Path path, const char *own_cn, Lines &lines,
                     const Condor3SpectateReference *live_ref=nullptr) noexcept;

--- a/test/src/TestDriver.cpp
+++ b/test/src/TestDriver.cpp
@@ -11,6 +11,7 @@
 #include "Device/Driver/CAI302.hpp"
 #include "Device/Driver/CProbe.hpp"
 #include "Device/Driver/Condor.hpp"
+#include "Device/Driver/Condor3Spectate.hpp"
 #include "Device/Driver/Condor3UDP.hpp"
 #include "Device/Driver/EW.hpp"
 #include "Device/Driver/EWMicroRecorder.hpp"
@@ -63,15 +64,19 @@
 #include "Input/InputEvents.hpp"
 #include "Logger/Settings.hpp"
 #include "LocalPath.hpp"
+#include "NMEA/Derived.hpp"
 #include "NMEA/GPSState.hpp"
 #include "NMEA/Info.hpp"
+#include "NMEA/MoreData.hpp"
 #include "Operation/Operation.hpp"
 #include "Plane/Plane.hpp"
 #include "Protection.hpp"
 #include "TestUtil.hpp"
 #include "Units/System.hpp"
+#include "io/FileOutputStream.hxx"
 #include "io/NullDataHandler.hpp"
 #include "system/Path.hpp"
+#include "util/SpanCast.hxx"
 #include "util/StaticString.hxx"
 #include "util/ByteOrder.hxx"
 #include "util/PackedFloat.hxx"
@@ -79,6 +84,7 @@
 #include <fmt/format.h>
 
 #include <chrono>
+#include <cstdio>
 #include <cstring>
 #include <memory>
 #include <span>
@@ -1731,6 +1737,96 @@ TestCondor3UDP()
   ok1(device->ParseNMEA("bank=0.5", info));
   ok1(info.attitude.bank_angle_available);
   ok1(equals(info.attitude.bank_angle.Radians(), -0.5));
+
+  delete device;
+}
+
+static bool
+FindPflaaRelativeVertical(const Condor3SpectateBuilder::Lines &lines,
+                          int &rel_v) noexcept
+{
+  for (const auto &line : lines) {
+    int alarm, north, east, vertical;
+    if (sscanf(line.c_str(), "$PFLAA,%d,%d,%d,%d,",
+               &alarm, &north, &east, &vertical) == 4) {
+      rel_v = vertical;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+static void
+WriteSpectateJson(Path path)
+{
+  static constexpr char json[] =
+    "["
+    "{\"ID\":\"1\",\"CN\":\"AA\","
+    "\"latitude\":\"N45.000000\",\"longitude\":\"E013.000000\","
+    "\"altitude\":\"1000\",\"speed\":\"100\",\"heading\":\"90\","
+    "\"vario\":\"0\"},"
+    "{\"ID\":\"2\",\"CN\":\"BB\","
+    "\"latitude\":\"N45.000000\",\"longitude\":\"E013.000000\","
+    "\"altitude\":\"1100\",\"speed\":\"100\",\"heading\":\"90\","
+    "\"vario\":\"0\"}"
+    "]";
+
+  FileOutputStream fos(path, FileOutputStream::Mode::CREATE);
+  fos.Write(AsBytes(std::string_view{json}));
+  fos.Commit();
+}
+
+static void
+TestCondor3Spectate()
+{
+  const auto json_path =
+    AllocatedPath::Build(GetPrimaryDataPath(), "spectate.json");
+  WriteSpectateJson(json_path);
+
+  Condor3SpectateBuilder::Lines lines;
+  ok1(Condor3SpectateBuilder::Build(json_path, "AA", lines));
+  int rel_v = 0;
+  ok1(FindPflaaRelativeVertical(lines, rel_v));
+  ok1(rel_v == 100);
+
+  /* GPS 41 m below Spectate own-ship used to lift every target by
+     that geoid offset.  Relative vertical must stay Spectate-to-Spectate. */
+  Condor3SpectateReference live_ref;
+  live_ref.latitude = 45;
+  live_ref.longitude = 13;
+  live_ref.altitude = 959;
+  live_ref.defined = true;
+  lines.clear();
+  ok1(Condor3SpectateBuilder::Build(json_path, "AA", lines, &live_ref));
+  ok1(FindPflaaRelativeVertical(lines, rel_v));
+  ok1(rel_v == 100);
+
+  NullPort null_port;
+  Device *device = condor3_spectate_driver.CreateOnPort(dummy_config,
+                                                       null_port);
+  ok1(device != nullptr);
+  auto *spectate = dynamic_cast<Condor3SpectateDevice *>(device);
+  ok1(spectate != nullptr);
+  if (spectate == nullptr) {
+    skip(2, 0, "Condor3SpectateDevice missing");
+    delete device;
+    return;
+  }
+
+  MoreData basic;
+  basic.Reset();
+  basic.clock = TimeStamp{FloatDuration{1}};
+  basic.location = GeoPoint(Angle::Degrees(13), Angle::Degrees(45));
+  basic.location_available.Update(basic.clock);
+  basic.gps_altitude = 959;
+  basic.gps_altitude_available.Update(basic.clock);
+  basic.ProvideBaroAltitudeTrue(1000);
+
+  DerivedInfo calculated{};
+  spectate->OnCalculatedUpdate(basic, calculated);
+  ok1(spectate->GetLiveReference().defined);
+  ok1(equals(spectate->GetLiveReference().altitude, 1000));
 
   delete device;
 }
@@ -3511,7 +3607,8 @@ int main()
              + 5 /* MWVRelativeTrue */ + 4 /* StallRatio */
              + 12 /* TempHumidityValidity */ + 2 /* ReadGeoAngleNoDot */
              + 13 /* GLL */ + 20 /* GSA */ + 23 /* MalformedInput */
-             + 59 /* Condor3UDP */ + 29 /* FlarmTrafficBuilder */
+             + 59 /* Condor3UDP */ + 10 /* Condor3Spectate */
+             + 29 /* FlarmTrafficBuilder */
              + 24 /* TrafficExtensionsWire */
              + 42 /* LK8EX1 */
              + 30 /* LXV7PolarWrite */);
@@ -3534,6 +3631,7 @@ int main()
   TestLX(condor_driver, true, true);
   TestLX(condor3_driver, true, false);
   TestCondor3UDP();
+  TestCondor3Spectate();
   TestLXEos();
   TestLXV7();
   TestLXV7POLAR();


### PR DESCRIPTION
## Summary
- Condor GGA has no geoid field; the Spectate driver does not parse `$LXWP0`, so the generic NMEA parser applied EGM96 and GPS (the altitude InfoBox) sat about 40 m / 136 ft too low.
- Treat Condor 3 and Spectate like Condor for geoid / simulator GPS, and compute Spectate PFLAA relative height from `Spectate.json` own-ship so traffic is not shifted by the same offset.
- Fixes #3055

## Test plan
- [ ] Condor 3 NMEA (`Condor Soaring Simulator 3`): GPS and baro altitude still match the Condor altimeter (no new geoid dip).
- [ ] Spectate as the device on the Condor NMEA/serial link: altitude InfoBox matches Condor / Condor 3, not ~136 ft low.
- [ ] Spectate file driver with own CN set: co-altitude traffic shows ~0 relative height, not +136 ft.
- [ ] All three Condor 3 drivers together: own altitude stays on the altimeter (baro); Spectate traffic relative height still matches Condor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Condor 3 Spectate altitude reporting, which could appear approximately 40 m (136 ft) too low.
  - Improved reference-position and altitude handling for Condor, Condor 3, and Condor 3 Spectate data.
  - Corrected live reference altitude selection to provide more reliable relative altitude information.

- **Tests**
  - Added coverage for Condor 3 Spectate reference positions, relative altitude output, and live reference altitude handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->