### PR TITLE
Fix/issue 2943 Airspace/Notam Details: Scrolling and keyboard handling

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -62,6 +62,7 @@ Version 7.46 - not yet released
     crew or empty mass were sent before the device polar was known;
     preserve max weight and glider name when sending a polar #2397
 * dialogs
+  - fix NOTAM details text being truncated and unable to scroll #2943
   - put the Close button on the right of the Status and Weather
     tab strips
   - label Close on the Quick Menu, BlueFly setup, and file Download

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -212,6 +212,8 @@ AirspaceDetailsWidget::AckDayOrEnable() noexcept
  * Extended widget for displaying NOTAM-specific information
  */
 class NOTAMDetailsWidget final : public AirspaceDetailsWidget {
+  VScrollWidget *text_widget = nullptr;
+
 public:
   NOTAMDetailsWidget(ConstAirspacePtr _airspace,
                      ProtectedAirspaceWarningManager *_warnings)
@@ -219,6 +221,7 @@ public:
 
   /* virtual methods from class Widget */
   void Prepare(ContainerWindow &parent, const PixelRect &rc) noexcept override;
+  bool KeyPress(unsigned key_code) noexcept override;
 
 private:
   void AddNOTAMIdentifiers(const char *notam_number,
@@ -435,10 +438,12 @@ NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     notam_opt && !notam_opt->text.empty()
     ? SafeString(notam_opt->text)
     : SafeString(airspace_name != nullptr ? airspace_name : "");
-  Add(std::make_unique<VScrollWidget>(
+  auto scroll = std::make_unique<VScrollWidget>(
     std::make_unique<ScrollableLargeTextWidget>(GetLook(), text.c_str()),
     GetLook(), true, GetScrollableTextRowMaximumHeight(rc),
-    VScrollWidget::ScrollMode::MOVE));
+    VScrollWidget::ScrollMode::MOVE);
+  text_widget = scroll.get();
+  Add(std::move(scroll));
 
   AddNOTAMValidity(notam_opt, buffer);
   AddNOTAMAltitudes(buffer);
@@ -451,4 +456,10 @@ NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     const auto distance = closest.Distance(basic.location);
     AddReadOnly(_("Distance"), nullptr, FormatUserDistance(distance));
   }
+}
+
+bool
+NOTAMDetailsWidget::KeyPress(unsigned key_code) noexcept
+{
+  return text_widget != nullptr && text_widget->KeyPress(key_code);
 }

--- a/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
+++ b/src/Dialogs/Airspace/dlgAirspaceDetails.cpp
@@ -437,7 +437,8 @@ NOTAMDetailsWidget::Prepare([[maybe_unused]] ContainerWindow &parent,
     : SafeString(airspace_name != nullptr ? airspace_name : "");
   Add(std::make_unique<VScrollWidget>(
     std::make_unique<ScrollableLargeTextWidget>(GetLook(), text.c_str()),
-    GetLook(), true, GetScrollableTextRowMaximumHeight(rc)));
+    GetLook(), true, GetScrollableTextRowMaximumHeight(rc),
+    VScrollWidget::ScrollMode::MOVE));
 
   AddNOTAMValidity(notam_opt, buffer);
   AddNOTAMAltitudes(buffer);

--- a/src/Form/VScrollPanel.cpp
+++ b/src/Form/VScrollPanel.cpp
@@ -395,6 +395,9 @@ VScrollPanel::OnMouseDown(PixelPoint p) noexcept
 void
 VScrollPanel::StartGestureTracking(PixelPoint p) noexcept
 {
+  if (!listener.IsVScrollPanelGestureEnabled())
+    return;
+
   /* Track swipes only in the content area — not on the scrollbar,
      where slight horizontal finger movement during a tap would
      misfire as a page-change swipe (especially noticeable on e-ink

--- a/src/Form/VScrollPanel.hpp
+++ b/src/Form/VScrollPanel.hpp
@@ -30,6 +30,15 @@ public:
     (void)gesture;
     return false;
   }
+
+  /**
+   * Returns true if this panel should track and display horizontal swipe
+   * gestures.
+   */
+  [[gnu::pure]]
+  virtual bool IsVScrollPanelGestureEnabled() const noexcept {
+    return false;
+  }
 };
 
 /**

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -144,7 +144,7 @@ VScrollWidget::Show(const PixelRect &rc) noexcept
 
   visible = true;
 
-  if (reserve_scrollbar) {
+  if (PaintsScrollOrigin()) {
     /* Viewport-sized child: paint uses VScrollPanel::GetOrigin().
        Avoids Move()/Invalidate of a full virtual-height window on
        every smooth-scroll tick. */
@@ -190,7 +190,7 @@ VScrollWidget::Move(const PixelRect &rc) noexcept
      and child widget changes size) */
   if (visible) {
     UpdateVirtualHeight(rc);
-    widget->Move(reserve_scrollbar
+    widget->Move(PaintsScrollOrigin()
                  ? GetWindow().GetPhysicalRect()
                  : GetWindow().GetVirtualRect());
   }
@@ -295,7 +295,7 @@ VScrollWidget::OnVScrollPanelChange() noexcept
   if (!visible)
     return;
 
-  if (reserve_scrollbar) {
+  if (PaintsScrollOrigin()) {
     /* Origin-only updates already Invalidate() the panel.  Do not
        Move() the child (Window::Move always invalidates, and the
        child stays at the physical viewport).  Resize still goes

--- a/src/Widget/VScrollWidget.cpp
+++ b/src/Widget/VScrollWidget.cpp
@@ -224,11 +224,11 @@ VScrollWidget::KeyPress(unsigned key_code) noexcept
 {
   /* Let the child widget handle the key first
      (for link/checkbox navigation in rich text). */
-  if (widget->KeyPress(key_code))
+  if (PaintsScrollOrigin() && widget->KeyPress(key_code))
     return true;
 
   if (!reserve_scrollbar)
-    return false;
+    return widget->KeyPress(key_code);
 
   /* Handle scrolling keys — only consume directional keys if there
      is room to scroll.  Otherwise return false so the parent widget

--- a/src/Widget/VScrollWidget.hpp
+++ b/src/Widget/VScrollWidget.hpp
@@ -16,9 +16,11 @@ struct DialogLook;
  *
  * When @a reserve_scrollbar is true the child widget's width is
  * reduced by the scrollbar width so content never hides behind the
- * scrollbar, and the child is sized to the physical viewport (not
- * the full virtual content height) so scrolling does not Move() a
- * tall window each frame.  This mode also enables enhanced keyboard
+ * scrollbar.  With ScrollMode::PAINT, the child is sized to the physical
+ * viewport (not the full virtual content height) so scrolling does not
+ * Move() a tall window each frame.  ScrollMode::MOVE supports children
+ * which do not paint the panel's scroll origin themselves.
+ * Reserving the scrollbar also enables enhanced keyboard
  * handling (Up/Down scroll only when scrollable) and the gesture
  * callback for horizontal swipes.
  *
@@ -28,6 +30,15 @@ struct DialogLook;
  * appropriate for flexible form-style widgets such as RowFormWidget.
  */
 class VScrollWidget final : public WindowWidget, VScrollPanelListener {
+public:
+  enum class ScrollMode {
+    /** Move the full-height child window when scrolling. */
+    MOVE,
+    /** The viewport-sized child paints using VScrollPanel::GetOrigin(). */
+    PAINT,
+  };
+
+private:
   const DialogLook &look;
 
   std::unique_ptr<Widget> widget;
@@ -36,6 +47,8 @@ class VScrollWidget final : public WindowWidget, VScrollPanelListener {
 
   /** Reserve horizontal space for the scrollbar. */
   bool reserve_scrollbar;
+
+  const ScrollMode scroll_mode;
 
   /** Optional maximum height reported to parent layout. */
   unsigned maximum_layout_height;
@@ -54,14 +67,18 @@ public:
    * @param _reserve_scrollbar  If true, reserve space for scrollbar
    *                            and enable enhanced keyboard/gesture
    *                            handling (for rich-text / prose content)
+   * @param _scroll_mode How reserved-scrollbar content is scrolled;
+   *                     PAINT requires the child to read the panel origin
    */
   explicit VScrollWidget(std::unique_ptr<Widget> &&_widget,
                          const DialogLook &_look,
                          bool _reserve_scrollbar = false,
-                         unsigned _maximum_layout_height = 0) noexcept
+                         unsigned _maximum_layout_height = 0,
+                         ScrollMode _scroll_mode = ScrollMode::PAINT) noexcept
     :look(_look),
      widget(std::move(_widget)),
      reserve_scrollbar(_reserve_scrollbar),
+     scroll_mode(_scroll_mode),
      maximum_layout_height(_maximum_layout_height) {}
 
   Widget &GetWidget() noexcept {
@@ -105,6 +122,10 @@ public:
   bool KeyPress(unsigned key_code) noexcept override;
 
 private:
+  bool PaintsScrollOrigin() const noexcept {
+    return reserve_scrollbar && scroll_mode == ScrollMode::PAINT;
+  }
+
   VScrollPanel &GetWindow() noexcept {
     return (VScrollPanel &)WindowWidget::GetWindow();
   }

--- a/src/Widget/VScrollWidget.hpp
+++ b/src/Widget/VScrollWidget.hpp
@@ -148,4 +148,7 @@ private:
   /* virtual methods from class VScrollPanelListener */
   void OnVScrollPanelChange() noexcept override;
   bool OnVScrollPanelGesture(const char *gesture) noexcept override;
+  bool IsVScrollPanelGestureEnabled() const noexcept override {
+    return reserve_scrollbar && static_cast<bool>(gesture_callback);
+  }
 };


### PR DESCRIPTION
Fixes #2943, now for real.

The NOTAM details scrollbar changed the scroll-panel origin but left the plain-text child fixed in its physical viewport. Rich text already paints from that origin; `LargeTextWindow` does not. The first commit lets this child move with the panel, so scrollbar and touch scrolling reveal the remaining text.

The second commit routes Up/Down, Page Up/Down, Home, and End through the NOTAM pane before the dialog action buttons. At either end of the text, the key continues to Ack Day or Close.

Validated by compiling the changed macOS sources. The NOTAM details dialog was also tested manually on macOS with overflowing text and the scrollbar.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase

- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR
  submission

#### Commit Format & Messages

- [x] All commits follow the format: `<Component>: <Summary>` (no
  `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add"
  not "Added")
- [x] Commit messages explain *why* the change was made, not just
  *what* changed
- [x] Commit message body provides detailed reasoning and context

#### Commit Structure

- [x] Each commit is atomic and builds successfully
- [x] One commit per logical change (don't mix refactoring with
  feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using
  `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed NOTAM details text being truncated and unable to scroll.
  - Improved scrolling behavior and keyboard navigation in scrollable dialogs.
  - Ensured content displays correctly across supported widget layouts.
  - Improved horizontal swipe gesture handling in scrollable panels.

- **Documentation**
  - Added a changelog entry documenting the NOTAM details scrolling fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->