### PR TITLE
Fix wifi and systemd dialog quirks

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -75,6 +75,10 @@ Version 7.46 - not yet released
   - fix keyboard wrap in the Checklist: Down from Close returns
     to the list and highlights an item so Enter acts on that row
     #2862
+  - keep the Wi-Fi connection state visible when the network name is
+    long
+  - let Left/Right still change settings pages on Services until Up
+    selects a service action
 * infoboxen
   - pack portrait InfoBoxes on tall screens so title, value, and
     comment sit closer together; InfoBox title size still grows the

--- a/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
@@ -19,6 +19,7 @@
 #include "lib/dbus/Systemd.hxx"
 #include "ui/canvas/Canvas.hpp"
 #include "ui/canvas/Color.hpp"
+#include "ui/event/KeyCode.hpp"
 #include "ui/event/PeriodicTimer.hpp"
 #include "util/ScopeExit.hxx"
 
@@ -86,6 +87,7 @@ class SystemdListWidget final : public ListWidget {
   Button *toggle_button = nullptr;
   Button *restart_button = nullptr;
   ButtonPanelWidget *button_panel = nullptr;
+  bool actions_armed = false;
   UI::PeriodicTimer refresh_timer{[this]{ Refresh(); }};
 
 public:
@@ -111,12 +113,26 @@ public:
 
   void Hide() noexcept override {
     refresh_timer.Cancel();
+    DisarmActions();
     ListWidget::Hide();
   }
 
   void Unprepare() noexcept override {
     refresh_timer.Cancel();
+    DisarmActions();
     ListWidget::Unprepare();
+  }
+
+  bool KeyPress(unsigned key_code) noexcept override {
+    if (key_code == KEY_UP && !actions_armed && !services.empty() &&
+        button_panel != nullptr && GetList().HasFocus()) {
+      button_panel->GetButtonPanel().EnableCursorSelection();
+      actions_armed = true;
+      UpdateButtons();
+      return true;
+    }
+
+    return ListWidget::KeyPress(key_code);
   }
 
   void OnPaintItem(Canvas &canvas, const PixelRect rc,
@@ -197,9 +213,6 @@ private:
       Restart(GetList().GetCursorIndex());
     });
 
-    if (!services.empty())
-      buttons.EnableCursorSelection();
-
     UpdateButtons();
   }
 
@@ -236,12 +249,16 @@ private:
     if (restart_button != nullptr)
       restart_button->SetEnabled(is_active);
 
-    /* Moving between an active and an inactive unit can disable the
-       currently selected Restart action.  Keep cursor-key selection on an
-       operable action so Up/Down list navigation and Left/Right action
-       selection continue to work together. */
-    if (can_toggle && button_panel != nullptr)
+    if (actions_armed && can_toggle && button_panel != nullptr)
       button_panel->GetButtonPanel().ReselectToFirstEnabled();
+  }
+
+  void DisarmActions() noexcept {
+    if (!actions_armed || button_panel == nullptr)
+      return;
+
+    button_panel->GetButtonPanel().DisableCursorSelection();
+    actions_armed = false;
   }
 
   void Refresh() noexcept {

--- a/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/SystemdConfigPanel.cpp
@@ -151,8 +151,6 @@ public:
     const auto &service = services[idx];
     const auto &status = statuses[idx];
 
-    row_renderer.DrawFirstRow(canvas, rc, service.display_name);
-
     const char *state_text = _("Unavailable");
     Color state_color = COLOR_RED;
     if (status.valid) {
@@ -184,10 +182,12 @@ public:
       }
     }
 
+    PixelRect name_rc = rc;
     const auto old_color = canvas.GetTextColor();
     canvas.SetTextColor(state_color);
-    row_renderer.DrawRightFirstRow(canvas, rc, state_text);
+    name_rc.right = row_renderer.DrawRightFirstRow(canvas, rc, state_text);
     canvas.SetTextColor(old_color);
+    row_renderer.DrawFirstRow(canvas, name_rc, service.display_name);
     row_renderer.DrawSecondRow(canvas, rc, service.description);
     row_renderer.DrawRightSecondRow(canvas, rc, service.unit_name.c_str());
   }
@@ -249,7 +249,7 @@ private:
     if (restart_button != nullptr)
       restart_button->SetEnabled(is_active);
 
-    if (actions_armed && can_toggle && button_panel != nullptr)
+    if (actions_armed && button_panel != nullptr)
       button_panel->GetButtonPanel().ReselectToFirstEnabled();
   }
 

--- a/src/Dialogs/WifiDialog.cpp
+++ b/src/Dialogs/WifiDialog.cpp
@@ -338,22 +338,24 @@ WifiListWidget::OnPaintItem(Canvas &canvas, const PixelRect rc,
     ? nullptr
     : FormatWifiSecurityLabel(info.security);
 
-  row_renderer.DrawFirstRow(canvas, rc, GetPrimaryText(info));
-  row_renderer.DrawSecondRow(canvas, rc, GetSecondaryText(info));
-
   const bool connected = info.kind == WifiNetworkKind::ConnectedNetwork;
   const auto state = WifiNetworkEntry::FormatState(info);
+  PixelRect primary_rc = rc;
 
   if (!state.empty()) {
     const auto old_text_color = canvas.GetTextColor();
     if (connected)
       canvas.SetTextColor(COLOR_GREEN);
 
-    row_renderer.DrawRightFirstRow(canvas, rc, state.c_str());
+    primary_rc.right =
+      row_renderer.DrawRightFirstRow(canvas, rc, state.c_str());
 
     if (connected)
       canvas.SetTextColor(old_text_color);
   }
+
+  row_renderer.DrawFirstRow(canvas, primary_rc, GetPrimaryText(info));
+  row_renderer.DrawSecondRow(canvas, rc, GetSecondaryText(info));
 
   if (info.is_visible) {
     StaticString<64> text;

--- a/src/Form/ButtonPanel.cpp
+++ b/src/Form/ButtonPanel.cpp
@@ -288,14 +288,17 @@ ButtonPanel::ReselectToFirstEnabled() noexcept
   };
 
   if (selected_index < (int)buttons.size() &&
-      is_usable((unsigned)selected_index))
+      is_usable((unsigned)selected_index)) {
+    /* Keep or restore the highlight if it was cleared while this
+       action was briefly disabled. */
+    buttons[selected_index]->SetSelected(true);
     return;
-
-  if (selected_index < (int)buttons.size() && selected_index >= 0)
-    buttons[selected_index]->SetSelected(false);
+  }
 
   for (unsigned i = 0; i < buttons.size(); ++i) {
     if (is_usable(i)) {
+      if (selected_index < (int)buttons.size() && selected_index >= 0)
+        buttons[selected_index]->SetSelected(false);
       selected_index = (int)i;
       buttons[selected_index]->SetSelected(true);
       return;

--- a/src/Form/ButtonPanel.hpp
+++ b/src/Form/ButtonPanel.hpp
@@ -45,6 +45,14 @@ public:
     buttons[selected_index]->SetSelected(true);
   }
 
+  void DisableCursorSelection() noexcept {
+    if (selected_index < 0)
+      return;
+
+    buttons[selected_index]->SetSelected(false);
+    selected_index = -1;
+  }
+
   /**
    * After the enabled/visible state of a button has changed, move
    * #selected_index to the first enabled one if the current

--- a/src/Form/ButtonPanel.hpp
+++ b/src/Form/ButtonPanel.hpp
@@ -45,6 +45,10 @@ public:
     buttons[selected_index]->SetSelected(true);
   }
 
+  /**
+   * Stop KEY_LEFT / KEY_RIGHT from selecting actions, so those keys
+   * can be used by the parent (for example to change settings pages).
+   */
   void DisableCursorSelection() noexcept {
     if (selected_index < 0)
       return;


### PR DESCRIPTION
Related: #2274.

Minor fixes to those two dialogs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added keyboard navigation for available system service actions, while preserving Left/Right navigation between settings pages.
  * Improved action-button focus handling when entering, updating, and leaving system settings.
  * Restored button highlighting when the current selection remains valid.
* **Bug Fixes**
  * Fixed Wi‑Fi list rendering so connection status remains visible without overlapping long network names.
  * Fixed action selection behavior when cursor navigation is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->