### PR TITLE
Fix the start point jumping about while you wait to start

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -42,6 +42,10 @@ Version 7.46 - not yet released
     map follows the aircraft, including at 10x replay #2948
   - keep the pan-mode map scale while panning, and restore the saved
     circling or cruise scale when leaving pan mode
+* task
+  - reduce the dashed leg to the first turn point, and the remaining
+    task distance, jumping between the start boundary and the aircraft
+    position while inside the start sector #3056
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -46,6 +46,8 @@ Version 7.46 - not yet released
   - reduce the dashed leg to the first turn point, and the remaining
     task distance, jumping between the start boundary and the aircraft
     position while inside the start sector #3056
+  - fix the best cruise arrow and the bearing line pointing at
+    different places while inside the start sector
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
@@ -77,6 +77,12 @@ OrderedTaskPoint::GetSearchPoints() const noexcept
   if (IsFuture())
     return GetBoundaryPoints();
 
+  if (GetType() == TaskPointType::START && IsCurrent())
+    /* the start has not been crossed yet: the aircraft must still
+       leave through the boundary, so the samples it collected
+       inside the sector are no constraint */
+    return GetBoundaryPoints();
+
   return SampledTaskPoint::GetSearchPoints();
 }
 

--- a/src/Engine/Task/Ordered/Points/StartPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.cpp
@@ -16,8 +16,21 @@ StartPoint::StartPoint(std::unique_ptr<ObservationZonePoint> &&_oz,
   :OrderedTaskPoint(TaskPointType::START, std::move(_oz), std::move(wp), false),
    safety_height(tb.safety_height_arrival),
    margins(tb.start_margins),
-   constraints(_constraints)
+   constraints(_constraints),
+   start_location(GeoPoint::Invalid())
 {
+}
+
+const GeoPoint &
+StartPoint::GetLocationRemaining() const noexcept
+{
+  if (IsCurrent() && start_location.IsValid())
+    /* the start has not been crossed yet: navigate to the boundary
+       point find_best_start() chose, not to whatever node the
+       distance searches last wrote */
+    return start_location;
+
+  return OrderedTaskPoint::GetLocationRemaining();
 }
 
 void
@@ -77,6 +90,7 @@ StartPoint::find_best_start(const AircraftState &state,
     }
   }
 
+  start_location = best_location;
   SetSearchMin(SearchPoint(best_location, projection));
 }
 

--- a/src/Engine/Task/Ordered/Points/StartPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.hpp
@@ -28,6 +28,20 @@ class StartPoint final : public OrderedTaskPoint {
    */
   StartConstraints constraints;
 
+  /**
+   * The point on the observation zone boundary the aircraft is
+   * expected to cross, as chosen by find_best_start().  This is what
+   * the task navigates to while the start is the active task point.
+   *
+   * It is kept apart from the search point written by the minimum
+   * distance search, which answers a different question and is
+   * updated on a different schedule.
+   *
+   * Invalid until find_best_start() has run, which does not happen
+   * before the aircraft is flying.
+   */
+  GeoPoint start_location;
+
 public:
   /**
    * Constructor.  Sets task area to non-scorable; distances
@@ -74,6 +88,7 @@ public:
 
   /* virtual methods from class TaskPoint */
   double GetElevation() const noexcept override;
+  const GeoPoint &GetLocationRemaining() const noexcept override;
 
   /* virtual methods from class ScoredTaskPoint */
   bool CheckExitTransition(const AircraftState &ref_now,

--- a/src/Engine/Task/Ordered/Points/StartPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.hpp
@@ -54,12 +54,19 @@ public:
   }
 
   /**
-   * Search for the min point on the boundary from
-   * the aircraft state to the next point.  Should only
-   * be performed when the aircraft state is inside the sector
+   * Search the observation zone boundary for the node which minimises
+   * the distance from the aircraft via that node to the next task
+   * point, and make it this task point's "remaining" location.
+   *
+   * This runs on every cycle while the start is the active task
+   * point, wherever the aircraft is; it does not require the aircraft
+   * to be inside the sector.  It does not run before takeoff, though:
+   * OrderedTask::CheckTransitions() returns early while the aircraft
+   * is not flying.
    *
    * @param state Current aircraft state
    * @param next Next task point following the start
+   * @param projection the projection used by the task
    */
   void find_best_start(const AircraftState &state,
                        const OrderedTaskPoint &next,

--- a/test/src/TestOrderedTask.cpp
+++ b/test/src/TestOrderedTask.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Task/Ordered/Points/AATPoint.hpp"
 #include "Engine/Task/ObservationZones/CylinderZone.hpp"
 #include "Engine/Task/ObservationZones/LineSectorZone.hpp"
+#include "Math/Constants.hpp"
 
 #define ACCURACY 500
 
@@ -508,6 +509,81 @@ TestTravelledDistance()
   }
 }
 
+/**
+ * While the start point is still the active task point, the aircraft
+ * has not started yet: the origin of the first leg is a point on the
+ * start boundary where the start can still be crossed.  Two pieces of
+ * code write that value (StartPoint::find_best_start() and the
+ * minimum distance Dijkstra); both must search the boundary, so that
+ * the origin can at worst step from one boundary node to the next.
+ */
+static void
+TestStartLegOrigin()
+{
+  ordered_task_settings.SetDefaults();
+
+  constexpr double START_RADIUS = 10000;
+
+  /* CylinderZone::GetBoundary() samples the circle at 20 points, so
+     the leg origin can step from one of them to the next as the
+     aircraft drifts; that step grows with the radius */
+  constexpr double BOUNDARY_STEP = M_2PI * START_RADIUS / 20;
+
+  OrderedTask task(task_behaviour);
+  task.Append(StartPoint(std::make_unique<CylinderZone>(wp1->location,
+                                                        START_RADIUS),
+                         WaypointPtr(wp1), task_behaviour,
+                         ordered_task_settings.start_constraints));
+  task.Append(ASTPoint(std::make_unique<CylinderZone>(wp3->location, 500),
+                       WaypointPtr(wp3), task_behaviour));
+  task.Append(FinishPoint(std::make_unique<CylinderZone>(wp4->location, 500),
+                          WaypointPtr(wp4), task_behaviour,
+                          ordered_task_settings.finish_constraints));
+  task.UpdateGeometry();
+
+  ok1(!IsError(task.CheckTask()));
+
+  /* fly a straight line inside the start cylinder, well clear of its
+     boundary, so the aircraft never starts */
+
+  auto state_last = MakeTimedAircraft(0, 44.96, 2000, FloatDuration{3600});
+  GeoPoint previous = GeoPoint::Invalid();
+  double previous_distance_min = -1;
+
+  for (unsigned i = 0; i < 12; ++i) {
+    const auto state = MakeTimedAircraft(0.001 * i, 44.96, 2000,
+                                         FloatDuration{3600 + 5 * i});
+    task.Update(state, state_last, glide_polar);
+    state_last = state;
+
+    const GeoPoint origin = task.GetPoint(0).GetLocationRemaining();
+
+    /* the start has not been crossed yet */
+    ok1(task.GetActiveTaskPointIndex() == 0);
+
+    /* thus the leg origin must be a point where the start can still
+       be crossed, i.e. on the boundary of the start cylinder */
+    ok1(equals(wp1->location.Distance(origin), START_RADIUS));
+
+    /* the origin stays on the boundary and moves by at most one
+       node.  The two writers minimise different objectives over the
+       same nodes, so they can settle one node apart; this bounds
+       that step. */
+    ok1(!previous.IsValid() ||
+        previous.Distance(origin) < 1.5 * BOUNDARY_STEP);
+
+    /* the samples collected inside the sector must not shorten the
+       task: the minimum remaining distance does not depend on where
+       inside the start the aircraft happens to be */
+    const double distance_min = task.GetStats().distance_min;
+    ok1(previous_distance_min < 0 ||
+        equals(distance_min, previous_distance_min));
+
+    previous = origin;
+    previous_distance_min = distance_min;
+  }
+}
+
 static void
 TestAll()
 {
@@ -522,11 +598,12 @@ TestAll()
 
 int main()
 {
-  plan_tests(746);
+  plan_tests(795);
 
   task_behaviour.SetDefaults();
 
   TestTravelledDistance();
+  TestStartLegOrigin();
   TestAll();
 
   glide_polar.SetMC(1);

--- a/test/src/TestOrderedTask.cpp
+++ b/test/src/TestOrderedTask.cpp
@@ -511,11 +511,13 @@ TestTravelledDistance()
 
 /**
  * While the start point is still the active task point, the aircraft
- * has not started yet: the origin of the first leg is a point on the
- * start boundary where the start can still be crossed.  Two pieces of
- * code write that value (StartPoint::find_best_start() and the
- * minimum distance Dijkstra); both must search the boundary, so that
- * the origin can at worst step from one boundary node to the next.
+ * has not started yet: it must still leave through the boundary, so
+ * the samples it collects inside the sector constrain nothing.
+ *
+ * Two things follow, and this checks both.  The origin of the first
+ * leg stays on the boundary, moving by at most one of the nodes the
+ * boundary is sampled at.  The minimum remaining task distance stays
+ * put as the aircraft moves about inside the sector.
  */
 static void
 TestStartLegOrigin()


### PR DESCRIPTION
Fixes #3056.

Circling in a big start and waiting for the gate, the magenta line to the start point kept disappearing on me. Roughly one second in four it simply wasn't drawn, and only the dashed leg to the first turn point was left, looking like it started at the glider. On top of that the best cruise arrow often pointed somewhere else entirely — on one flight the two were nearly opposite each other.

| Cycle 1 | Cycle 2 |
|---|---|
| <img width="300" src="https://github.com/user-attachments/assets/a2c26c89-8446-4f07-86b2-a3ed690cc1b1" /> | <img width="300" src="https://github.com/user-attachments/assets/8d7168c7-eabe-45c9-8f42-f8ad95adea7a" /> |

Two parts of the program were each working out where on the start line or cylinder you're going to cross, using different rules, and both were writing their answer to the same place. Whichever ran last won, so the display kept flipping between them.

These commits make them work from the same candidates, and give the display its own answer so it can't be overwritten behind your back. The line stops vanishing, and the arrow and the line now point at the same spot.

**What this doesn't fix.** The program only ever considers a handful of spots around the edge of the start zone — twenty around a cylinder, three on a line. So the start point still hops between them as you drift about. The hop is smaller than before and both indicators now hop together, but it is still there. Doing that properly is a bigger change and felt like a separate job. It also leaves #2388 alone: the start point sitting at the centre or the end of a start line is the same coarse boundary seen from another angle.

Checked against two recorded flights and the task test suite, and flown in the simulator on an Android device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task distance and dashed-leg displays jumping between the start boundary and aircraft position while inside the start sector.
  * Corrected the best cruise arrow and bearing line so they point consistently while the aircraft remains inside the start sector.
  * Improved start navigation so it consistently targets the selected optimal point on the start boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->