### PR TITLE
iOS: Bluetooth LE support and more robust FLARM flight download

### DIFF
--- a/Data/iOS/Info.plist.in.xml
+++ b/Data/iOS/Info.plist.in.xml
@@ -106,6 +106,7 @@
             <string>audio</string>
             <string>location</string>
             <string>fetch</string>
+            <string>bluetooth-central</string>
         </array>
         <key>BGTaskSchedulerPermittedIdentifiers</key>
         <array>

--- a/Data/iOS/Info.plist.in.xml
+++ b/Data/iOS/Info.plist.in.xml
@@ -138,5 +138,9 @@
         <string>XCODE_BUILD_PLACEHOLDER</string>
         <key>DTPlatformBuild</key>
         <string>SDK_BUILD_PLACEHOLDER</string>
+        <key>NSBluetoothAlwaysUsageDescription</key>
+        <string>XCSoar uses Bluetooth to receive data from external devices such as FLARM, GPS and variometer sensors.</string>
+        <key>NSBluetoothPeripheralUsageDescription</key>
+        <string>XCSoar uses Bluetooth to receive data from external devices such as FLARM, GPS and variometer sensors.</string>
     </dict>
 </plist>

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -63,6 +63,9 @@ Version 7.46 - not yet released
     Bluetooth LE bridges): wait for the connection before entering
     binary mode, longer ping window, and retries when selecting a
     flight so single lost frames no longer drop flights from the list
+  - FLARM: automatically restart an interrupted flight download and
+    skip the already saved part instead of failing the whole
+    transfer
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -59,6 +59,10 @@ Version 7.46 - not yet released
   - skip estimated TAS from ground speed and wind when GPS track is
     missing
 * devices
+  - FLARM: more robust flight download over slow links (e.g.
+    Bluetooth LE bridges): wait for the connection before entering
+    binary mode, longer ping window, and retries when selecting a
+    flight so single lost frames no longer drop flights from the list
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,9 @@ Version 7.46 - not yet released
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit
 * iOS
+  - add Bluetooth LE support: device discovery and serial port
+    connections (HM-10, Nordic UART, Microchip/ISSC and compatible
+    bridges) via CoreBluetooth #1815
   - use the system keyboard for text entry so special characters
     can be typed, and add a Paste button for the clipboard; the
     Keyboard text-input style keeps XCSoar's own grid #2894

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -4,6 +4,8 @@ Version 7.46 - not yet released
   - fix crash when exiting the app #2873
   - fix crash when restarting the app immediately after exit
 * iOS
+  - keep Bluetooth LE connections and transfers alive while the app
+    is briefly in the background (bluetooth-central background mode)
   - add Bluetooth LE support: device discovery and serial port
     connections (HM-10, Nordic UART, Microchip/ISSC and compatible
     bridges) via CoreBluetooth #1815

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -66,6 +66,8 @@ Version 7.46 - not yet released
   - FLARM: automatically restart an interrupted flight download and
     skip the already saved part instead of failing the whole
     transfer
+  - XCVario: allow a second driver on the port, so the flights of a
+    FLARM connected to the XCVario can be downloaded
   - fix the map ground track line following heading instead of ground
     track with Condor 3 UDP in a crosswind #2900
   - fix the Devices Debug button not writing port traffic to xcsoar.log

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -66,6 +66,7 @@ Version 7.46 - not yet released
   - fix LXNAV polar sync writes that could zero the vario polar when
     crew or empty mass were sent before the device polar was known;
     preserve max weight and glider name when sending a polar #2397
+  - Port monitor: also show data written to the device
 * dialogs
   - put the Close button on the right of the Status and Weather
     tab strips

--- a/android/src/BluetoothHelper.java
+++ b/android/src/BluetoothHelper.java
@@ -299,6 +299,9 @@ final class BluetoothHelper
   /**
    * Identify the detected service UUIDs and convert it to a feature
    * flag bit set.
+   *
+   * Keep this in sync with FeaturesFromAdvertisedServices() in
+   * src/Apple/BluetoothHelper.cpp.
    */
   private static long getFeatures(Collection<ParcelUuid> serviceUuids) {
     long features = 0;

--- a/android/src/BluetoothUuids.java
+++ b/android/src/BluetoothUuids.java
@@ -7,6 +7,9 @@ import java.util.UUID;
 
 /**
  * Various Bluetooth service/characteristic UUIDs.
+ *
+ * Keep this in sync with src/Apple/BluetoothUuids.hpp, the iOS
+ * counterpart of this class.
  */
 public final class BluetoothUuids {
   static final UUID GENERIC_ACCESS_SERVICE =

--- a/android/src/DetectDeviceListener.java
+++ b/android/src/DetectDeviceListener.java
@@ -7,7 +7,8 @@ package org.xcsoar;
  * Continuously receives callbacks about detected or updated devices.
  */
 interface DetectDeviceListener {
-  /* keep this in sync with src/Android/DetectDeviceListener.hpp */
+  /* keep this in sync with src/Android/DetectDeviceListener.hpp and
+     src/Apple/DetectDeviceListener.hpp */
   static final int TYPE_IOIO = 1;
   static final int TYPE_BLUETOOTH_CLASSIC = 2;
   static final int TYPE_BLUETOOTH_LE = 3;

--- a/build/detect.mk
+++ b/build/detect.mk
@@ -16,7 +16,8 @@ HOST_IS_X86_64 := $(call bool_or,$(call string_contains,$(UNAME_M),x86_64),$(cal
 HOST_IS_ARM := $(call string_contains,$(UNAME_M),armv)
 HOST_IS_ARMV6 := $(call string_equals,$(UNAME_M),armv6l)
 HOST_IS_ARMV7 := $(call string_equals,$(UNAME_M),armv7l)
-HOST_IS_AARCH64 := $(call string_contains,$(UNAME_M),aarch64)
+# "aarch64" on Linux, "arm64" on Apple Silicon macOS
+HOST_IS_AARCH64 := $(call bool_or,$(call string_contains,$(UNAME_M),aarch64),$(call string_equals,$(UNAME_M),arm64))
 
 HOST_IS_ARM_OR_AARCH64 = $(call bool_or,$(HOST_IS_ARM),$(HOST_IS_AARCH64))
 

--- a/build/ios.mk
+++ b/build/ios.mk
@@ -1,6 +1,7 @@
 ifeq ($(TARGET_IS_IOS),y)
 
 TARGET_LDLIBS += -framework UIKit
+TARGET_LDLIBS += -framework CoreBluetooth
 
 IPA_TMPDIR = $(TARGET_OUTPUT_DIR)/ipa
 

--- a/build/main.mk
+++ b/build/main.mk
@@ -665,7 +665,9 @@ endif
 ifeq ($(TARGET_IS_IOS),y)
 XCSOAR_SOURCES += \
 	$(SRC)/Apple/BluetoothHelper.cpp \
-	$(SRC)/Apple/PortBridge.cpp
+	$(SRC)/Apple/PortBridge.cpp \
+	$(SRC)/Device/Port/ApplePort.cpp \
+	$(SRC)/Device/Port/AppleBluetoothPort.cpp
 endif
 
 ifeq ($(TARGET_IS_OSX),y)

--- a/build/main.mk
+++ b/build/main.mk
@@ -662,6 +662,12 @@ XCSOAR_SOURCES += \
 	$(SRC)/Device/SmartDeviceSensors.cpp
 endif
 
+ifeq ($(TARGET_IS_IOS),y)
+XCSOAR_SOURCES += \
+	$(SRC)/Apple/BluetoothHelper.cpp \
+	$(SRC)/Apple/PortBridge.cpp
+endif
+
 ifeq ($(TARGET_IS_OSX),y)
 XCSOAR_SOURCES += $(SRC)/Apple/MacOSMainMenu.cpp
 endif

--- a/build/python/build/cmake.py
+++ b/build/python/build/cmake.py
@@ -43,11 +43,13 @@ set(CMAKE_AR {toolchain.ar})
 set(CMAKE_RANLIB {toolchain.ranlib})
 """)
 
-    if cmake_system_name == 'Darwin':
-        # On macOS, cmake forcibly adds an "-isysroot" flag even if
-        # one is already present in the flags variable; this breaks
-        # cross-compiling for iOS, and can be worked around by setting
-        # the CMAKE_OSX_SYSROOT variable
+    if cmake_system_name in ('Darwin', 'iOS'):
+        # On Apple platforms, cmake forcibly adds an "-isysroot" flag
+        # even if one is already present in the flags variable, using
+        # its own default SDK (the macOS SDK); since the last
+        # "-isysroot" wins, this breaks cross-compiling for iOS and
+        # the iOS simulator, and can be worked around by setting the
+        # CMAKE_OSX_SYSROOT variable
         # (https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_SYSROOT.html).
         m = re.search(r'-isysroot +(\S+)', toolchain.cflags)
         if m:

--- a/build/test.mk
+++ b/build/test.mk
@@ -1054,6 +1054,7 @@ TEST_DRIVER_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/DataFilePath.cpp \
 	$(SRC)/FLARM/Error.cpp \
 	$(SRC)/FLARM/Traffic.cpp \
@@ -1270,6 +1271,7 @@ DEBUG_REPLAY_SOURCES = \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/IGC/IGCParser.cpp \
 	$(SRC)/IGC/Generator.cpp \
@@ -1628,6 +1630,7 @@ READ_PORT_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -1640,6 +1643,7 @@ RUN_PORT_HANDLER_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -1652,6 +1656,7 @@ LOG_PORT_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -1665,6 +1670,7 @@ RUN_LXNAV_POLAR_ECHO_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(SRC)/Version.cpp \
@@ -1680,6 +1686,7 @@ SPLICE_PORTS_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -1697,6 +1704,7 @@ RUN_DEVICE_DRIVER_SOURCES = \
 	$(SRC)/Device/Util/NMEAWriter.cpp \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/FLARM/Error.cpp \
 	$(SRC)/FLARM/Traffic.cpp \
@@ -1724,6 +1732,7 @@ RUN_DECLARE_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/IGC/IGCParser.cpp \
 	$(SRC)/IGC/Generator.cpp \
@@ -1749,6 +1758,7 @@ RUN_ENABLE_NMEA_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/IGC/IGCParser.cpp \
 	$(SRC)/IGC/Generator.cpp \
@@ -1772,6 +1782,7 @@ RUN_VEGA_SETTINGS_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
 	$(TEST_SRC_DIR)/FakeMessage.cpp \
@@ -1788,6 +1799,7 @@ RUN_FLARM_UTILS_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -1802,6 +1814,7 @@ RUN_LX1600_UTILS_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
@@ -1817,6 +1830,7 @@ RUN_FLIGHT_LIST_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/IGC/IGCParser.cpp \
 	$(SRC)/IGC/Generator.cpp \
@@ -1841,6 +1855,7 @@ RUN_DOWNLOAD_FLIGHT_SOURCES = \
 	$(SRC)/Device/Util/NMEAReader.cpp \
 	$(SRC)/Device/Declaration.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/RadioFrequency.cpp \
 	$(SRC)/IGC/IGCParser.cpp \
 	$(SRC)/IGC/Generator.cpp \
@@ -1862,6 +1877,7 @@ $(eval $(call link-program,RunDownloadFlight,RUN_DOWNLOAD_FLIGHT))
 CAI302_TOOL_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Atmosphere/AirDensity.cpp \
 	$(SRC)/Atmosphere/Pressure.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
@@ -2886,6 +2902,7 @@ FEED_NMEA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -2898,6 +2915,7 @@ FEED_VEGA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \
@@ -2915,6 +2933,7 @@ EMULATE_DEVICE_SOURCES = \
 	$(SRC)/Device/Driver/FLARM/BinaryProtocol.cpp \
 	$(SRC)/Device/Driver/FLARM/CRC16.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/io/CSVLine.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(SRC)/Formatter/NMEAFormatter.cpp \
@@ -2932,6 +2951,7 @@ FEED_FLYNET_DATA_SOURCES = \
 	$(SRC)/Device/Port/ConfiguredPort.cpp \
 	$(TEST_SRC_DIR)/FakeSpectateFilePort.cpp \
 	$(SRC)/Device/Config.cpp \
+	$(TEST_SRC_DIR)/FakeAppleBluetooth.cpp \
 	$(SRC)/Operation/ConsoleOperationEnvironment.cpp \
 	$(TEST_SRC_DIR)/FakeLogFile.cpp \
 	$(TEST_SRC_DIR)/FakeLanguage.cpp \

--- a/src/Apple/BluetoothHelper.cpp
+++ b/src/Apple/BluetoothHelper.cpp
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BluetoothHelper.hpp"
+#include "BluetoothUuids.hpp"
+#include "DetectDeviceListener.hpp"
+#include "IOSBluetoothManager.h"
+#include "PortBridge.hpp"
+#include "LogFile.hpp"
+#include "thread/Mutex.hxx"
+
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <Foundation/Foundation.h>
+
+#include <cassert>
+#include <map>
+#include <set>
+#include <string>
+
+/**
+ * A name cache for BluetoothHelper::GetNameFromAddress(), which must
+ * return a pointer to a string which is never freed; same pattern as
+ * the Android implementation.  Entries are only ever added, never
+ * modified or removed, so the returned pointers stay valid (std::map
+ * nodes do not move).
+ *
+ * Filled by #IOSBluetoothManager on its dispatch queue, read from
+ * any thread; protected by #address_to_name_mutex.
+ */
+static std::map<std::string, std::string, std::less<>> address_to_name;
+static Mutex address_to_name_mutex;
+
+/**
+ * Remember the name of a peripheral, unless it is unknown or
+ * already cached.
+ */
+static void
+CacheName(NSString *address, NSString *name) noexcept
+{
+  if (name.length == 0)
+    return;
+
+  const std::lock_guard lock{address_to_name_mutex};
+  address_to_name.emplace(address.UTF8String, name.UTF8String);
+}
+
+@implementation IOSBluetoothManager {
+  CBCentralManager *centralManager;
+
+  /** all peripherals seen so far, keyed by identifier UUID string */
+  NSMutableDictionary<NSString *, CBPeripheral *> *discoveredPeripherals;
+
+  /** the feature mask most recently determined for each peripheral */
+  NSMutableDictionary<NSString *, NSNumber *> *peripheralFeatures;
+
+  /** registered detection listeners; only accessed on the queue */
+  std::set<DetectDeviceListener *> listeners;
+
+  /**
+   * All open bridges, keyed by identifier UUID string.  The bridges
+   * are owned by their #ApplePort; they unregister themselves via
+   * closeBridge:.
+   */
+  std::map<std::string, PortBridge *, std::less<>> bridges;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _queue = dispatch_queue_create("XCSoar Bluetooth",
+                                   DISPATCH_QUEUE_SERIAL);
+    discoveredPeripherals = [NSMutableDictionary dictionary];
+    peripheralFeatures = [NSMutableDictionary dictionary];
+    centralManager = [[CBCentralManager alloc] initWithDelegate:self
+                                                          queue:_queue];
+  }
+  return self;
+}
+
+- (bool)isEnabled
+{
+  return centralManager.state == CBManagerStatePoweredOn;
+}
+
+/**
+ * Identify the advertised service UUIDs and convert them to a
+ * feature flag bit set.
+ *
+ * Keep this in sync with getFeatures() in
+ * android/src/BluetoothHelper.java.
+ */
+static uint64_t
+FeaturesFromAdvertisedServices(NSArray<CBUUID *> *serviceUuids) noexcept
+{
+  using namespace BluetoothUuids;
+
+  uint64_t features = 0;
+
+  for (CBUUID *uuid in serviceUuids) {
+    if ([uuid isEqual:Uuid<HM10_SERVICE>()] ||
+        [uuid isEqual:Uuid<NORDIC_UART_SERVICE>()] ||
+        [uuid isEqual:Uuid<ISSC_UART_SERVICE>()])
+      /* any BLE UART service can be used with the generic "BLE
+         serial" port implementation */
+      features |= DetectDeviceListener::FEATURE_BLE_SERIAL;
+    else if ([uuid isEqual:Uuid<HEART_RATE_SERVICE>()])
+      features |= DetectDeviceListener::FEATURE_HEART_RATE;
+    else if ([uuid isEqual:Uuid<FLYTEC_SENSBOX_SERVICE>()])
+      features |= DetectDeviceListener::FEATURE_FLYTEC_SENSBOX;
+  }
+
+  return features;
+}
+
+/**
+ * Look up the bridge for the given peripheral.  Must be called on the
+ * dispatch queue.
+ *
+ * @return the bridge or nullptr if the peripheral has no open bridge
+ */
+- (PortBridge *)bridgeForPeripheral:(CBPeripheral *)peripheral
+{
+  auto i = bridges.find(std::string_view{
+      peripheral.identifier.UUIDString.UTF8String});
+  return i != bridges.end() ? i->second : nullptr;
+}
+
+/**
+ * Start or stop scanning depending on whether somebody is currently
+ * interested in scan results.  Must be called on the dispatch queue.
+ */
+- (void)updateScanState
+{
+  if (centralManager.state != CBManagerStatePoweredOn)
+    return;
+
+  bool want_scan = !listeners.empty();
+
+  /* keep scanning while a configured device has not been discovered
+     yet */
+  for (const auto &i : bridges)
+    if (i.second->GetPeripheral() == nil)
+      want_scan = true;
+
+  if (want_scan && !centralManager.isScanning)
+    /* unlike Android, scan without a service UUID filter: many BLE
+       UART bridges do not advertise their serial service UUID, and
+       iOS applications cannot enumerate bonded devices; note that
+       unfiltered scans yield no results while the app is in the
+       background (the "bluetooth-central" background mode only
+       permits filtered scans there), which is fine because scanning
+       is a foreground activity (port picker), and pending
+       connectPeripheral requests are not affected */
+    [centralManager scanForPeripheralsWithServices:nil options:nil];
+  else if (!want_scan && centralManager.isScanning)
+    [centralManager stopScan];
+}
+
+/**
+ * Attach a peripheral to the given bridge and start connecting.  If
+ * the peripheral is not yet known, a scan is started instead.  Must
+ * be called on the dispatch queue.
+ */
+- (void)attachAndConnectBridge:(PortBridge *)bridge
+{
+  if (centralManager.state != CBManagerStatePoweredOn) {
+    /* postponed until centralManagerDidUpdateState reports that
+       Bluetooth is available */
+    [self updateScanState];
+    return;
+  }
+
+  NSString *address = bridge->GetAddress();
+  CBPeripheral *peripheral = discoveredPeripherals[address];
+
+  if (peripheral == nil) {
+    /* not discovered in this session; ask the system whether it
+       already knows the peripheral */
+    NSUUID *uuid = [[NSUUID alloc] initWithUUIDString:address];
+    if (uuid != nil) {
+      NSArray<CBPeripheral *> *known =
+        [centralManager retrievePeripheralsWithIdentifiers:@[uuid]];
+      if (known.count > 0) {
+        peripheral = known.firstObject;
+        discoveredPeripherals[address] = peripheral;
+        CacheName(address, peripheral.name);
+      }
+    }
+  }
+
+  if (peripheral != nil) {
+    /* the request has no timeout; it completes whenever the
+       peripheral accepts the connection */
+    LogFormat("Bluetooth: connecting to %s", address.UTF8String);
+    bridge->OnPeripheralAttached(peripheral);
+    peripheral.delegate = self;
+    [centralManager connectPeripheral:peripheral options:nil];
+  } else
+    LogFormat("Bluetooth: device %s is not known, scanning for it",
+              address.UTF8String);
+
+  [self updateScanState];
+}
+
+- (void)addDetectDeviceListener:(DetectDeviceListener *)listener
+{
+  dispatch_sync(_queue, ^{
+    listeners.insert(listener);
+
+    /* similar to Android's bonded device enumeration: register
+       peripherals which are already connected at the system level and
+       provide a known UART service */
+    if (centralManager.state == CBManagerStatePoweredOn) {
+      NSArray<CBPeripheral *> *connected =
+        [centralManager retrieveConnectedPeripheralsWithServices:
+                          BluetoothUuids::SerialServiceUuids()];
+      for (CBPeripheral *peripheral in connected) {
+        NSString *address = peripheral.identifier.UUIDString;
+        discoveredPeripherals[address] = peripheral;
+        CacheName(address, peripheral.name);
+        if (peripheralFeatures[address] == nil)
+          peripheralFeatures[address] =
+            @(DetectDeviceListener::FEATURE_BLE_SERIAL);
+      }
+    }
+
+    /* report all peripherals discovered so far to the new listener */
+    for (NSString *address in discoveredPeripherals) {
+      CBPeripheral *peripheral = discoveredPeripherals[address];
+      NSString *name = peripheral.name;
+      if (name.length == 0)
+        continue;
+
+      /* like in the discovery callback, every peripheral is a
+         potential serial bridge */
+      const uint64_t features =
+        peripheralFeatures[address].unsignedLongLongValue |
+        DetectDeviceListener::FEATURE_BLE_SERIAL;
+
+      listener->OnDeviceDetected(DetectDeviceListener::Type::BLUETOOTH_LE,
+                                 address.UTF8String, name.UTF8String,
+                                 features);
+    }
+
+    [self updateScanState];
+  });
+}
+
+- (void)removeDetectDeviceListener:(DetectDeviceListener *)listener
+{
+  dispatch_sync(_queue, ^{
+    listeners.erase(listener);
+
+    /* this stops the scan when the last listener is removed (unless
+       a bridge is still waiting for its peripheral) */
+    [self updateScanState];
+  });
+}
+
+- (PortBridge *)connect:(NSString *)address
+{
+  __block PortBridge *bridge = nullptr;
+
+  dispatch_sync(_queue, ^{
+    bridge = new PortBridge(self, address);
+    bridges[address.UTF8String] = bridge;
+    [self attachAndConnectBridge:bridge];
+  });
+
+  return bridge;
+}
+
+- (void)closeBridge:(PortBridge *)bridge
+{
+  dispatch_sync(_queue, ^{
+    NSString *address = bridge->GetAddress();
+
+    if (auto i = bridges.find(std::string_view{address.UTF8String});
+        i != bridges.end() && i->second == bridge)
+      bridges.erase(i);
+
+    if (CBPeripheral *peripheral = bridge->GetPeripheral();
+        peripheral != nil)
+      [centralManager cancelPeripheralConnection:peripheral];
+
+    [self updateScanState];
+  });
+}
+
+- (void)scheduleWrite:(NSString *)address
+{
+  dispatch_async(_queue, ^{
+    if (auto i = bridges.find(std::string_view{address.UTF8String});
+        i != bridges.end())
+      i->second->SendPendingChunks();
+  });
+}
+
+/* CBCentralManagerDelegate */
+
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central
+{
+  switch (central.state) {
+  case CBManagerStatePoweredOn:
+    LogFormat("Bluetooth: powered on");
+
+    /* (re)connect all configured devices */
+    for (const auto &i : bridges)
+      [self attachAndConnectBridge:i.second];
+
+    [self updateScanState];
+    break;
+
+  case CBManagerStatePoweredOff:
+  case CBManagerStateResetting:
+    LogFormat("Bluetooth: powered off");
+
+    /* all CBPeripheral instances are invalid now */
+    [discoveredPeripherals removeAllObjects];
+
+    for (const auto &i : bridges) {
+      i.second->OnDisconnected();
+      i.second->OnPeripheralLost();
+    }
+    break;
+
+  case CBManagerStateUnauthorized:
+    LogFormat("Bluetooth: access not authorized");
+    break;
+
+  case CBManagerStateUnsupported:
+    LogFormat("Bluetooth: not supported on this device");
+    break;
+
+  case CBManagerStateUnknown:
+    break;
+  }
+}
+
+- (void)centralManager:(CBCentralManager *)central
+ didDiscoverPeripheral:(CBPeripheral *)peripheral
+     advertisementData:(NSDictionary<NSString *, id> *)advertisementData
+                  RSSI:(NSNumber *)RSSI
+{
+  NSString *address = peripheral.identifier.UUIDString;
+  discoveredPeripherals[address] = peripheral;
+
+  /* is a configured port waiting for this peripheral? */
+  if (auto i = bridges.find(std::string_view{address.UTF8String});
+      i != bridges.end() && i->second->GetPeripheral() == nil) {
+    LogFormat("Bluetooth: connecting to %s", address.UTF8String);
+    i->second->OnPeripheralAttached(peripheral);
+    peripheral.delegate = self;
+    [centralManager connectPeripheral:peripheral options:nil];
+    [self updateScanState];
+  }
+
+  uint64_t features = FeaturesFromAdvertisedServices(
+      advertisementData[CBAdvertisementDataServiceUUIDsKey]);
+
+  NSString *name = peripheral.name;
+  if (name.length == 0)
+    name = advertisementData[CBAdvertisementDataLocalNameKey];
+
+  CacheName(address, name);
+
+#ifndef NDEBUG
+  /* unlike the port picker, which also lists peripherals known from
+     the system cache, this proves that the device is advertising
+     right now */
+  LogFormat("Bluetooth: discovered %s (%s) rssi=%d",
+            address.UTF8String,
+            name.length > 0 ? name.UTF8String : "?",
+            RSSI.intValue);
+#endif
+
+  if (features == 0 && name.length == 0)
+    /* skip anonymous peripherals without any recognised service to
+       avoid cluttering the port picker with unusable entries */
+    return;
+
+  /* consider every peripheral a potential serial bridge: BLE UART
+     bridges often do not advertise their serial service UUID at all,
+     or advertise a sensor service (e.g. Flytec Sensbox) in addition
+     to it; and since BLE sensors are not supported on iOS (yet), a
+     "BLE sensor" port would be a dead end anyway - without this
+     flag, such a device could not be configured as a port and e.g.
+     the FLARM flight download would stay unavailable */
+  features |= DetectDeviceListener::FEATURE_BLE_SERIAL;
+
+  peripheralFeatures[address] = @(features);
+
+  for (auto *listener : listeners)
+    listener->OnDeviceDetected(DetectDeviceListener::Type::BLUETOOTH_LE,
+                               address.UTF8String,
+                               name.length > 0 ? name.UTF8String : nullptr,
+                               features);
+}
+
+- (void)centralManager:(CBCentralManager *)central
+  didConnectPeripheral:(CBPeripheral *)peripheral
+{
+  CacheName(peripheral.identifier.UUIDString, peripheral.name);
+
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnConnected();
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didFailToConnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error
+{
+  LogFormat("Bluetooth: connection to %s failed: %s",
+            peripheral.identifier.UUIDString.UTF8String,
+            error.localizedDescription.UTF8String);
+
+  if ([self bridgeForPeripheral:peripheral] == nullptr)
+    return;
+
+  /* retry after a small delay, but only if the bridge still exists
+     by then */
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, NSEC_PER_SEC), _queue, ^{
+    if ([self bridgeForPeripheral:peripheral] != nullptr &&
+        centralManager.state == CBManagerStatePoweredOn)
+      [centralManager connectPeripheral:peripheral options:nil];
+  });
+}
+
+- (void)centralManager:(CBCentralManager *)central
+didDisconnectPeripheral:(CBPeripheral *)peripheral
+                 error:(NSError *)error
+{
+  if (error != nil)
+    LogFormat("Bluetooth: %s disconnected: %s",
+              peripheral.identifier.UUIDString.UTF8String,
+              error.localizedDescription.UTF8String);
+
+  if (auto *bridge = [self bridgeForPeripheral:peripheral]) {
+    bridge->OnDisconnected();
+
+    /* attempt to reconnect, like Android's HM10Port; the connection
+       request does not time out and completes whenever the device
+       becomes reachable again */
+    if (centralManager.state == CBManagerStatePoweredOn) {
+      LogFormat("Bluetooth: reconnecting to %s",
+                peripheral.identifier.UUIDString.UTF8String);
+      [centralManager connectPeripheral:peripheral options:nil];
+    }
+  }
+}
+
+/* CBPeripheralDelegate */
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverServices:(NSError *)error
+{
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnServicesDiscovered(error);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didDiscoverCharacteristicsForService:(CBService *)service
+             error:(NSError *)error
+{
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnCharacteristicsDiscovered(error);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error
+{
+  if (error != nil)
+    LogFormat("Bluetooth: enabling notifications for %s failed: %s",
+              peripheral.identifier.UUIDString.UTF8String,
+              error.localizedDescription.UTF8String);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error
+{
+  if (error != nil)
+    return;
+
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnDataReceived(characteristic, characteristic.value);
+}
+
+- (void)peripheral:(CBPeripheral *)peripheral
+didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+             error:(NSError *)error
+{
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnWriteCompleted(error);
+}
+
+- (void)peripheralIsReadyToSendWriteWithoutResponse:(CBPeripheral *)peripheral
+{
+  if (auto *bridge = [self bridgeForPeripheral:peripheral])
+    bridge->OnReadyToSendWriteWithoutResponse();
+}
+
+@end
+
+BluetoothHelper::BluetoothHelper() noexcept
+  :manager([[IOSBluetoothManager alloc] init])
+{
+}
+
+BluetoothHelper::~BluetoothHelper() noexcept
+{
+  manager = nil;
+}
+
+bool
+BluetoothHelper::IsEnabled() const noexcept
+{
+  return [manager isEnabled];
+}
+
+const char *
+BluetoothHelper::GetNameFromAddress(const char *address) const noexcept
+{
+  assert(address != nullptr);
+
+  const std::lock_guard lock{address_to_name_mutex};
+
+  if (auto i = address_to_name.find(std::string_view{address});
+      i != address_to_name.end())
+    return i->second.c_str();
+
+  return nullptr;
+}
+
+void
+BluetoothHelper::AddDetectDeviceListener(DetectDeviceListener &l) noexcept
+{
+  [manager addDetectDeviceListener:&l];
+}
+
+void
+BluetoothHelper::RemoveDetectDeviceListener(DetectDeviceListener &l) noexcept
+{
+  [manager removeDetectDeviceListener:&l];
+}
+
+PortBridge *
+BluetoothHelper::connect(const char *address) noexcept
+{
+  assert(address != nullptr);
+
+  return [manager connect:[NSString stringWithUTF8String:address]];
+}

--- a/src/Apple/BluetoothHelper.hpp
+++ b/src/Apple/BluetoothHelper.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+@class IOSBluetoothManager;
+
+class DetectDeviceListener;
+class PortBridge;
+
+/**
+ * The iOS counterpart of Android's #BluetoothHelper: provides
+ * Bluetooth LE device discovery and GATT serial port connections via
+ * CoreBluetooth.
+ *
+ * All methods may be called from any thread except the CoreBluetooth
+ * dispatch queue (see #IOSBluetoothManager).
+ */
+class BluetoothHelper final {
+  IOSBluetoothManager *manager;
+
+public:
+  BluetoothHelper() noexcept;
+  ~BluetoothHelper() noexcept;
+
+  BluetoothHelper(const BluetoothHelper &) = delete;
+  BluetoothHelper &operator=(const BluetoothHelper &) = delete;
+
+  /**
+   * Is Bluetooth switched on?
+   */
+  [[gnu::pure]]
+  bool IsEnabled() const noexcept;
+
+  /**
+   * Look up the name of a peripheral which was discovered or
+   * connected earlier in this session.  May be called from any
+   * thread, including the CoreBluetooth dispatch queue.
+   *
+   * @param address the identifier UUID of the peripheral
+   * @return the peripheral's name or nullptr if it is unknown; the
+   * returned string is never freed
+   */
+  [[gnu::pure]]
+  const char *GetNameFromAddress(const char *address) const noexcept;
+
+  /**
+   * Start scanning for Bluetooth devices.  Call
+   * RemoveDetectDeviceListener() with the same listener when you're
+   * done.
+   */
+  void AddDetectDeviceListener(DetectDeviceListener &l) noexcept;
+
+  /**
+   * Stop scanning for Bluetooth devices.
+   *
+   * @param l the listener passed to AddDetectDeviceListener()
+   */
+  void RemoveDetectDeviceListener(DetectDeviceListener &l) noexcept;
+
+  /**
+   * Open a GATT serial port connection to the given peripheral.  The
+   * connection is established asynchronously; this method never
+   * returns nullptr, and problems are reported through the bridge's
+   * #PortState.
+   *
+   * The returned object is owned by the caller.
+   */
+  PortBridge *connect(const char *address) noexcept;
+};

--- a/src/Apple/BluetoothUuids.hpp
+++ b/src/Apple/BluetoothUuids.hpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#import <CoreBluetooth/CoreBluetooth.h>
+
+/**
+ * Various Bluetooth service/characteristic UUIDs.
+ *
+ * Keep this in sync with android/src/BluetoothUuids.java, the
+ * Android counterpart of this namespace: the constants use the same
+ * names and values.  Some of them are not used on iOS (yet); the
+ * comment next to each of those explains why.
+ */
+namespace BluetoothUuids {
+
+/**
+ * Not used on iOS: CoreBluetooth provides the device name as
+ * CBPeripheral.name, the Generic Access service need not be read.
+ */
+static constexpr char GENERIC_ACCESS_SERVICE[] =
+  "00001800-0000-1000-8000-00805F9B34FB";
+
+/**
+ * Not used on iOS: -[CBPeripheral setNotifyValue:forCharacteristic:]
+ * writes this descriptor by itself.
+ */
+static constexpr char CLIENT_CHARACTERISTIC_CONFIGURATION[] =
+  "00002902-0000-1000-8000-00805f9b34fb";
+
+/**
+ * Not used on iOS: see GENERIC_ACCESS_SERVICE.
+ */
+static constexpr char DEVICE_NAME_CHARACTERISTIC[] =
+  "00002A00-0000-1000-8000-00805F9B34FB";
+
+static constexpr char HEART_RATE_SERVICE[] =
+  "0000180D-0000-1000-8000-00805F9B34FB";
+
+/**
+ * Not used on iOS: BLE sensors are not supported (yet), only serial
+ * port bridges; the service UUID above is only used to derive the
+ * feature flags for the port picker.
+ */
+static constexpr char HEART_RATE_MEASUREMENT_CHARACTERISTIC[] =
+  "00002A37-0000-1000-8000-00805F9B34FB";
+
+/**
+ * @see https://sites.google.com/view/ppgmeter/startpage
+ * Engine sensors service and characteristic
+ *
+ * Not used on iOS: BLE sensors are not supported (yet).
+ */
+static constexpr char ENGINE_SENSORS_SERVICE[] =
+  "D2865ECA-2C07-4610-BF03-8AEEBEF047FB";
+static constexpr char ENGINE_SENSORS_CHARACTERISTIC[] =
+  "D2865ECB-2C07-4610-BF03-8AEEBEF047FB";
+
+static constexpr char HM10_SERVICE[] =
+  "0000FFE0-0000-1000-8000-00805F9B34FB";
+
+/**
+ * The HM-10 and compatible bluetooth modules use a GATT characteristic
+ * with this UUID for sending and receiving data.
+ */
+static constexpr char HM10_RX_TX_CHARACTERISTIC[] =
+  "0000FFE1-0000-1000-8000-00805F9B34FB";
+
+/**
+ * Nordic UART Service (NUS) - provides a BLE serial bridge using
+ * separate RX and TX characteristics.
+ */
+static constexpr char NORDIC_UART_SERVICE[] =
+  "6E400001-B5A3-F393-E0A9-E50E24DCCA9E";
+
+/**
+ * Nordic UART RX characteristic - XCSoar writes data to it.
+ */
+static constexpr char NORDIC_UART_RX_CHARACTERISTIC[] =
+  "6E400002-B5A3-F393-E0A9-E50E24DCCA9E";
+
+/**
+ * Nordic UART TX characteristic - XCSoar receives data from here.
+ */
+static constexpr char NORDIC_UART_TX_CHARACTERISTIC[] =
+  "6E400003-B5A3-F393-E0A9-E50E24DCCA9E";
+
+/**
+ * Microchip/ISSC transparent UART service (e.g. BlueFly Vario BLE).
+ */
+static constexpr char ISSC_UART_SERVICE[] =
+  "49535343-FE7D-4AE5-8FA9-9FAFD205E455";
+
+/**
+ * ISSC UART RX characteristic - XCSoar writes data to it
+ * (Write Without Response).
+ */
+static constexpr char ISSC_UART_RX_CHARACTERISTIC[] =
+  "49535343-8841-43F4-A8D4-ECBE34729BB3";
+
+/**
+ * ISSC UART TX characteristic - XCSoar receives data from here
+ * (Notify).
+ */
+static constexpr char ISSC_UART_TX_CHARACTERISTIC[] =
+  "49535343-1E4D-4BD9-BA61-23C647249616";
+
+/* Flytec Sensbox */
+static constexpr char FLYTEC_SENSBOX_SERVICE[] =
+  "aba27100-143b-4b81-a444-edcd0000f020";
+
+/**
+ * @see https://github.com/flytec/SensBoxLib_iOS/blob/master/_SensBox%20Documentation/SensorBox%20BLE%20Protocol.pdf
+ *
+ * Not used on iOS: BLE sensors are not supported (yet); the service
+ * UUID above is only used to derive the feature flags for the port
+ * picker.
+ */
+static constexpr char FLYTEC_SENSBOX_NAVIGATION_SENSOR_CHARACTERISTIC[] =
+  "aba27100-143b-4b81-a444-edcd0000f022";
+static constexpr char FLYTEC_SENSBOX_MOVEMENT_SENSOR_CHARACTERISTIC[] =
+  "aba27100-143b-4b81-a444-edcd0000f023";
+static constexpr char FLYTEC_SENSBOX_SECOND_GPS_CHARACTERISTIC[] =
+  "aba27100-143b-4b81-a444-edcd0000f024";
+static constexpr char FLYTEC_SENSBOX_SYSTEM_CHARACTERISTIC[] =
+  "aba27100-143b-4b81-a444-edcd0000f025";
+
+/**
+ * Convert one of the constants above to a #CBUUID.  The object is
+ * created on first use and then cached, because the scan callback
+ * compares UUIDs many times per second.
+ */
+template<const char *uuid>
+[[gnu::pure]]
+static inline CBUUID *
+Uuid() noexcept
+{
+  static CBUUID *const instance = [CBUUID UUIDWithString:@(uuid)];
+  return instance;
+}
+
+/**
+ * All service UUIDs which provide a serial port emulation.
+ *
+ * Unlike Android's getAllServiceUuids(), this is not a scan filter:
+ * iOS scans without one, because many UART bridges do not advertise
+ * their service UUID.  It is only used to find bridges which are
+ * already connected at the system level.  There is no counterpart
+ * of getAllCharacteristicsUuids(), which Android needs for BLE
+ * sensors only.
+ */
+[[gnu::pure]]
+static inline NSArray<CBUUID *> *
+SerialServiceUuids() noexcept
+{
+  static NSArray<CBUUID *> *const uuids = @[
+    Uuid<HM10_SERVICE>(),
+    Uuid<NORDIC_UART_SERVICE>(),
+    Uuid<ISSC_UART_SERVICE>(),
+  ];
+  return uuids;
+}
+
+} // namespace BluetoothUuids

--- a/src/Apple/DetectDeviceListener.hpp
+++ b/src/Apple/DetectDeviceListener.hpp
@@ -6,12 +6,18 @@
 #include <cstdint>
 
 /**
- * C++ wrapper for the Java class BluetoothAdapter.LeScanCallback.
+ * A listener interface which receives callbacks about detected
+ * (Bluetooth) devices.  This is a copy of the Android declaration
+ * (src/Android/DetectDeviceListener.hpp) so shared code like the port
+ * picker can use the same interface on both platforms.
+ *
+ * Keep this in sync with src/Android/DetectDeviceListener.hpp and
+ * android/src/DetectDeviceListener.java.
  */
 class DetectDeviceListener {
 public:
-  /* keep this in sync with android/src/DetectDeviceListener.java and
-     src/Apple/DetectDeviceListener.hpp */
+  /* keep this in sync with src/Android/DetectDeviceListener.hpp and
+     android/src/DetectDeviceListener.java */
   enum class Type {
     IOIO = 1,
     BLUETOOTH_CLASSIC = 2,

--- a/src/Apple/IOSBluetoothManager.h
+++ b/src/Apple/IOSBluetoothManager.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#import <CoreBluetooth/CoreBluetooth.h>
+#import <Foundation/Foundation.h>
+
+class DetectDeviceListener;
+class PortBridge;
+
+/**
+ * The CoreBluetooth backend of the iOS #BluetoothHelper.  It owns the
+ * #CBCentralManager, performs device discovery and dispatches
+ * CoreBluetooth delegate callbacks to the affected #PortBridge
+ * instances.
+ *
+ * All CoreBluetooth work runs on a private serial dispatch queue
+ * (#queue).  The public methods may be called from any thread, but
+ * must not be called from the dispatch queue itself.
+ */
+@interface IOSBluetoothManager
+    : NSObject <CBCentralManagerDelegate, CBPeripheralDelegate>
+
+/** the serial dispatch queue which runs all CoreBluetooth work */
+@property(nonatomic, readonly) dispatch_queue_t queue;
+
+/**
+ * Is Bluetooth currently switched on?
+ */
+- (bool)isEnabled;
+
+/**
+ * Register a device detection listener and start scanning for
+ * peripherals.  Already discovered peripherals are reported to the
+ * new listener immediately.
+ */
+- (void)addDetectDeviceListener:(DetectDeviceListener *)listener;
+
+/**
+ * Unregister a device detection listener.  Scanning is stopped when
+ * the last listener has been removed.
+ */
+- (void)removeDetectDeviceListener:(DetectDeviceListener *)listener;
+
+/**
+ * Create a #PortBridge for the peripheral with the given identifier
+ * and start connecting to it asynchronously.  This method never
+ * returns nullptr; connection problems are reported through the
+ * bridge's #PortState.
+ *
+ * The returned object is owned by the caller; deleting it closes the
+ * connection.
+ */
+- (PortBridge *)connect:(NSString *)address;
+
+/**
+ * Unregister a bridge and disconnect from its peripheral.  Invoked by
+ * the #PortBridge destructor; after this method returns, no callback
+ * will reach the bridge anymore.
+ */
+- (void)closeBridge:(PortBridge *)bridge;
+
+/**
+ * Schedule a PortBridge::SendPendingChunks() call for the given
+ * address on the dispatch queue.
+ */
+- (void)scheduleWrite:(NSString *)address;
+
+@end

--- a/src/Apple/PortBridge.cpp
+++ b/src/Apple/PortBridge.cpp
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "PortBridge.hpp"
+#include "BluetoothUuids.hpp"
+#include "IOSBluetoothManager.h"
+#include "LogFile.hpp"
+#include "Device/Port/Listener.hpp"
+#include "io/DataHandler.hpp"
+
+#include <algorithm>
+#include <chrono>
+
+/**
+ * How long Write() and Drain() wait for the write buffer; equal to
+ * the timeout used by Android's HM10WriteBuffer.
+ */
+static constexpr auto WRITE_TIMEOUT = std::chrono::seconds(5);
+
+PortBridge::PortBridge(IOSBluetoothManager *_manager,
+                       NSString *_address) noexcept
+  :manager(_manager), address(_address)
+{
+}
+
+PortBridge::~PortBridge() noexcept
+{
+  {
+    const std::lock_guard lock{mutex};
+    closed = true;
+    cond.notify_all();
+  }
+
+  /* synchronously unregister from the manager; after this call, no
+     CoreBluetooth callback can reach this object anymore */
+  [manager closeBridge:this];
+}
+
+void
+PortBridge::SetListener(PortListener *_listener) noexcept
+{
+  const std::lock_guard lock{mutex};
+  listener = _listener;
+}
+
+void
+PortBridge::SetInputListener(DataHandler *_handler) noexcept
+{
+  const std::lock_guard lock{mutex};
+  handler = _handler;
+}
+
+PortState
+PortBridge::GetState() const noexcept
+{
+  const std::lock_guard lock{mutex};
+  return state;
+}
+
+void
+PortBridge::SetState(PortState new_state) noexcept
+{
+  PortListener *l;
+
+  {
+    const std::lock_guard lock{mutex};
+    if (new_state == state)
+      return;
+
+    state = new_state;
+    l = listener;
+    cond.notify_all();
+  }
+
+  if (l != nullptr)
+    l->PortStateChanged();
+}
+
+void
+PortBridge::Error(const char *msg) noexcept
+{
+  PortListener *l;
+
+  {
+    const std::lock_guard lock{mutex};
+    state = PortState::FAILED;
+    l = listener;
+    write_buffer.Clear();
+    cond.notify_all();
+  }
+
+  if (l != nullptr)
+    l->PortError(msg);
+}
+
+bool
+PortBridge::Drain() noexcept
+{
+  std::unique_lock lock{mutex};
+
+  cond.wait_for(lock, WRITE_TIMEOUT, [this]{
+    return write_buffer.empty() || closed || state == PortState::FAILED;
+  });
+
+  return write_buffer.empty() && state != PortState::FAILED;
+}
+
+std::size_t
+PortBridge::Write(std::span<const std::byte> src) noexcept
+{
+  std::size_t nbytes;
+
+  {
+    std::unique_lock lock{mutex};
+
+    /* wait for space in the write buffer, like Android's
+       HM10WriteBuffer.drainSome() */
+    cond.wait_for(lock, WRITE_TIMEOUT, [this]{
+      return !write_buffer.IsFull() || closed ||
+        state == PortState::FAILED;
+    });
+
+    if (closed || state == PortState::FAILED)
+      return 0;
+
+    nbytes = write_buffer.MoveFrom(src);
+  }
+
+  if (nbytes > 0)
+    /* have the dispatch queue transmit the new data; the manager
+       looks up this bridge by its address, which is safe even if it
+       gets closed and deleted before the block runs */
+    [manager scheduleWrite:address];
+
+  return nbytes;
+}
+
+inline bool
+PortBridge::CanSendChunk() const noexcept
+{
+  if (write_type == CBCharacteristicWriteWithResponse)
+    return !write_pending;
+
+  if (@available(iOS 11, macOS 10.13, *))
+    return peripheral.canSendWriteWithoutResponse;
+
+  /* no flow control available on this OS version; send blindly */
+  return true;
+}
+
+void
+PortBridge::SendPendingChunks() noexcept
+{
+  if (peripheral == nil || tx_characteristic == nil)
+    /* not connected yet; the data stays buffered and is flushed by
+       SelectCharacteristics() */
+    return;
+
+  while (CanSendChunk()) {
+    NSData *chunk;
+
+    {
+      const std::lock_guard lock{mutex};
+
+      const auto r = write_buffer.Read();
+      if (r.empty())
+        return;
+
+      const std::size_t nbytes = std::min(r.size(), chunk_size);
+      chunk = [NSData dataWithBytes:r.data() length:nbytes];
+      write_buffer.Consume(nbytes);
+
+      /* wake up Write() and Drain() */
+      cond.notify_all();
+    }
+
+    if (write_type == CBCharacteristicWriteWithResponse)
+      write_pending = true;
+
+    [peripheral writeValue:chunk
+         forCharacteristic:tx_characteristic
+                      type:write_type];
+  }
+}
+
+void
+PortBridge::OnPeripheralAttached(CBPeripheral *_peripheral) noexcept
+{
+  peripheral = _peripheral;
+}
+
+void
+PortBridge::OnPeripheralLost() noexcept
+{
+  peripheral = nil;
+}
+
+void
+PortBridge::OnConnected() noexcept
+{
+  LogFormat("Bluetooth: connected to %s", address.UTF8String);
+
+  rx_characteristic = nil;
+  tx_characteristic = nil;
+
+  [peripheral discoverServices:nil];
+}
+
+void
+PortBridge::OnDisconnected() noexcept
+{
+  rx_characteristic = nil;
+  tx_characteristic = nil;
+  write_pending = false;
+  pending_characteristic_discoveries = 0;
+
+  {
+    const std::lock_guard lock{mutex};
+    /* discard buffered data; sending the rest of a partial datagram
+       after reconnecting would only confuse the peer */
+    write_buffer.Clear();
+    cond.notify_all();
+  }
+
+  SetState(PortState::LIMBO);
+}
+
+void
+PortBridge::OnServicesDiscovered(NSError *error) noexcept
+{
+  if (error != nil) {
+    LogFormat("Bluetooth: service discovery for %s failed: %s",
+              address.UTF8String, error.localizedDescription.UTF8String);
+    Error("Bluetooth service discovery failed");
+    return;
+  }
+
+  if (peripheral.services.count == 0) {
+    Error("Bluetooth device has no services");
+    return;
+  }
+
+  pending_characteristic_discoveries = peripheral.services.count;
+  for (CBService *service in peripheral.services)
+    [peripheral discoverCharacteristics:nil forService:service];
+}
+
+void
+PortBridge::OnCharacteristicsDiscovered(NSError *error) noexcept
+{
+  if (error != nil)
+    LogFormat("Bluetooth: characteristic discovery for %s failed: %s",
+              address.UTF8String, error.localizedDescription.UTF8String);
+
+  if (pending_characteristic_discoveries == 0)
+    return;
+
+  if (--pending_characteristic_discoveries == 0)
+    SelectCharacteristics();
+}
+
+[[gnu::pure]]
+static bool
+CanNotify(CBCharacteristic *c) noexcept
+{
+  return (c.properties & (CBCharacteristicPropertyNotify |
+                          CBCharacteristicPropertyIndicate)) != 0;
+}
+
+[[gnu::pure]]
+static bool
+CanWrite(CBCharacteristic *c) noexcept
+{
+  return (c.properties & (CBCharacteristicPropertyWrite |
+                          CBCharacteristicPropertyWriteWithoutResponse)) != 0;
+}
+
+/**
+ * Find a characteristic with the given UUID.
+ */
+[[gnu::pure]]
+static CBCharacteristic *
+FindCharacteristic(CBService *service, CBUUID *uuid) noexcept
+{
+  for (CBCharacteristic *c in service.characteristics)
+    if ([c.UUID isEqual:uuid])
+      return c;
+
+  return nil;
+}
+
+/**
+ * Find the first characteristic in this service which supports
+ * writing.
+ */
+[[gnu::pure]]
+static CBCharacteristic *
+FindWritableCharacteristic(CBService *service) noexcept
+{
+  for (CBCharacteristic *c in service.characteristics)
+    if (CanWrite(c))
+      return c;
+
+  return nil;
+}
+
+void
+PortBridge::SelectCharacteristics() noexcept
+{
+  using namespace BluetoothUuids;
+
+  CBCharacteristic *rx = nil, *tx = nil;
+
+#ifndef NDEBUG
+  /* list what the peripheral offers; without this, a device which
+     serves its data on a service we do not know about looks like a
+     device which does not work at all */
+  for (CBService *service in peripheral.services)
+    for (CBCharacteristic *c in service.characteristics)
+      LogFormat("Bluetooth: %s has service %s characteristic %s props=0x%x",
+                address.UTF8String,
+                service.UUID.UUIDString.UTF8String,
+                c.UUID.UUIDString.UTF8String,
+                unsigned(c.properties));
+#endif
+
+  for (CBService *service in peripheral.services) {
+    if ([service.UUID isEqual:Uuid<HM10_SERVICE>()]) {
+      /* first choice: HM-10, which uses a single characteristic for
+         both directions; some clones however make it notify-only and
+         provide a separate characteristic (e.g. FFE2) for writing */
+      if (CBCharacteristic *c =
+            FindCharacteristic(service, Uuid<HM10_RX_TX_CHARACTERISTIC>());
+          c != nil && CanNotify(c)) {
+        if (CBCharacteristic *w =
+              CanWrite(c) ? c : FindWritableCharacteristic(service);
+            w != nil) {
+          rx = c;
+          tx = w;
+          break;
+        }
+      }
+    } else if ([service.UUID isEqual:Uuid<NORDIC_UART_SERVICE>()]) {
+      /* second choice: the Nordic UART Service */
+      CBCharacteristic *nus_rx =
+        FindCharacteristic(service, Uuid<NORDIC_UART_TX_CHARACTERISTIC>());
+      CBCharacteristic *nus_tx =
+        FindCharacteristic(service, Uuid<NORDIC_UART_RX_CHARACTERISTIC>());
+      if (nus_rx != nil && CanNotify(nus_rx) &&
+          nus_tx != nil && CanWrite(nus_tx)) {
+        rx = nus_rx;
+        tx = nus_tx;
+      }
+    } else if ([service.UUID isEqual:Uuid<ISSC_UART_SERVICE>()]) {
+      /* third choice: the Microchip/ISSC transparent UART */
+      CBCharacteristic *issc_rx =
+        FindCharacteristic(service, Uuid<ISSC_UART_TX_CHARACTERISTIC>());
+      CBCharacteristic *issc_tx =
+        FindCharacteristic(service, Uuid<ISSC_UART_RX_CHARACTERISTIC>());
+      if (rx == nil && issc_rx != nil && CanNotify(issc_rx) &&
+          issc_tx != nil && CanWrite(issc_tx)) {
+        rx = issc_rx;
+        tx = issc_tx;
+      }
+    }
+  }
+
+  if (rx == nil || tx == nil) {
+    /* fallback for UART bridges with proprietary UUIDs and for
+       non-conforming implementations of the services above: use the
+       first service which contains both a notifying and a writable
+       characteristic */
+    for (CBService *service in peripheral.services) {
+      CBCharacteristic *service_rx = nil, *service_tx = nil;
+
+      for (CBCharacteristic *c in service.characteristics) {
+        if (service_rx == nil && CanNotify(c))
+          service_rx = c;
+        if (service_tx == nil && CanWrite(c))
+          service_tx = c;
+      }
+
+      if (service_rx != nil && service_tx != nil) {
+        rx = service_rx;
+        tx = service_tx;
+        break;
+      }
+    }
+  }
+
+  if (rx == nil || tx == nil) {
+    Error("No usable Bluetooth characteristics found");
+    return;
+  }
+
+  rx_characteristic = rx;
+  tx_characteristic = tx;
+
+  write_type = (tx.properties & CBCharacteristicPropertyWriteWithoutResponse)
+    ? CBCharacteristicWriteWithoutResponse
+    : CBCharacteristicWriteWithResponse;
+
+  /* iOS negotiates the ATT MTU automatically right after
+     connecting; unlike Android (BluetoothGatt.requestMtu()), an
+     application cannot request a larger one.
+     maximumWriteValueLengthForType: reflects the negotiated result:
+     for writes without response it is the MTU minus the 3 byte ATT
+     header.  If a peripheral stays at the small default, that limit
+     is imposed by the bridge firmware (often configurable there,
+     e.g. "AT+MTU" on HM-10 clones). */
+  const std::size_t max_wor = [peripheral
+    maximumWriteValueLengthForType:CBCharacteristicWriteWithoutResponse];
+  const std::size_t max_wr = [peripheral
+    maximumWriteValueLengthForType:write_type];
+
+  /* limit all writes to the size of one ATT packet (MTU minus the
+     ATT header); larger writes would be fragmented by iOS, which
+     many BLE UART bridges cannot handle */
+  chunk_size = std::clamp(std::min(max_wor, max_wr),
+                          std::size_t(20), std::size_t(512));
+
+  const unsigned att_mtu = unsigned(max_wor) + 3;
+
+  [peripheral setNotifyValue:YES forCharacteristic:rx];
+
+  /* the properties reveal e.g. whether the bridge uses (slow,
+     acknowledged) indications instead of notifications */
+  LogFormat("Bluetooth: %s is ready"
+            " (rx=%s props=0x%x tx=%s props=0x%x %s mtu=%u chunk=%u)",
+            address.UTF8String,
+            rx.UUID.UUIDString.UTF8String, unsigned(rx.properties),
+            tx.UUID.UUIDString.UTF8String, unsigned(tx.properties),
+            write_type == CBCharacteristicWriteWithoutResponse
+            ? "write-without-response" : "write-with-response",
+            att_mtu, unsigned(chunk_size));
+
+  if (att_mtu <= 23)
+    /* the peer kept the Bluetooth LE default MTU; bulk transfers
+       such as IGC flight downloads will be slow */
+    LogFormat("Bluetooth: %s negotiated only the minimum ATT MTU;"
+              " check the bridge firmware settings for a larger MTU",
+              address.UTF8String);
+
+  SetState(PortState::READY);
+
+  /* flush data which was queued while we were connecting */
+  SendPendingChunks();
+}
+
+void
+PortBridge::OnDataReceived(CBCharacteristic *characteristic,
+                           NSData *value) noexcept
+{
+  if (characteristic != rx_characteristic || value.length == 0)
+    return;
+
+#ifndef NDEBUG
+  /* log the cumulative number of received bytes and notifications,
+     at most every five seconds, to help diagnosing stalled or slow
+     transfers (the ratio exposes the peer's notification pacing) */
+  rx_bytes += value.length;
+  ++rx_notifications;
+  if (const auto now = std::chrono::steady_clock::now();
+      now >= next_rx_log) {
+    LogFormat("Bluetooth: %s: %llu bytes in %llu notifications so far",
+              address.UTF8String,
+              (unsigned long long)rx_bytes,
+              (unsigned long long)rx_notifications);
+    next_rx_log = now + std::chrono::seconds(5);
+  }
+#endif
+
+  DataHandler *h;
+
+  {
+    const std::lock_guard lock{mutex};
+    h = handler;
+  }
+
+  if (h != nullptr)
+    h->DataReceived({(const std::byte *)value.bytes, value.length});
+}
+
+void
+PortBridge::OnWriteCompleted(NSError *error) noexcept
+{
+  write_pending = false;
+
+  if (error != nil) {
+    LogFormat("Bluetooth: write to %s failed: %s",
+              address.UTF8String, error.localizedDescription.UTF8String);
+    Error("Bluetooth write failed");
+    return;
+  }
+
+  SendPendingChunks();
+}
+
+void
+PortBridge::OnReadyToSendWriteWithoutResponse() noexcept
+{
+  SendPendingChunks();
+}

--- a/src/Apple/PortBridge.hpp
+++ b/src/Apple/PortBridge.hpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "Device/Port/State.hpp"
+#include "thread/Cond.hxx"
+#include "thread/Mutex.hxx"
+#include "util/StaticFifoBuffer.hxx"
+
+#import <CoreBluetooth/CoreBluetooth.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+@class IOSBluetoothManager;
+
+class PortListener;
+class DataHandler;
+
+/**
+ * The iOS counterpart of Android's #PortBridge: glue between the C++
+ * #Port world and a CoreBluetooth GATT connection.  One instance
+ * exists per opened BLE serial port; it is owned by an #ApplePort.
+ *
+ * The #IOSBluetoothManager keeps a registry of all bridges and
+ * forwards CoreBluetooth delegate callbacks to the matching instance;
+ * all On*() methods and SendPendingChunks() are invoked on the
+ * manager's serial dispatch queue.  The remaining methods may be
+ * called from any thread.
+ *
+ * Writes are buffered and sent in chunks of at most one MTU, pacing
+ * the transmission with CoreBluetooth's flow control (see
+ * SendPendingChunks()), like Android's HM10WriteBuffer.
+ */
+class PortBridge final {
+  IOSBluetoothManager *const manager;
+
+  NSString *const address;
+
+  /* the following fields are only accessed on the manager's dispatch
+     queue */
+
+  CBPeripheral *peripheral = nil;
+
+  /** the characteristic which notifies us about received data */
+  CBCharacteristic *rx_characteristic = nil;
+
+  /** the characteristic we write outgoing data to */
+  CBCharacteristic *tx_characteristic = nil;
+
+  CBCharacteristicWriteType write_type = CBCharacteristicWriteWithResponse;
+
+  /** maximum number of payload bytes per GATT write */
+  std::size_t chunk_size = 20;
+
+  /** number of services with unfinished characteristic discovery */
+  NSUInteger pending_characteristic_discoveries = 0;
+
+  /**
+   * A write-with-response is in flight; wait for OnWriteCompleted()
+   * before sending the next chunk.
+   */
+  bool write_pending = false;
+
+  /** total number of bytes received, for the throughput log */
+  uint64_t rx_bytes = 0;
+
+  /** total number of received notifications, for the throughput log */
+  uint64_t rx_notifications = 0;
+
+  /** earliest time OnDataReceived() logs the next throughput line */
+  std::chrono::steady_clock::time_point next_rx_log{};
+
+  /* the following fields are protected by the mutex */
+
+  mutable Mutex mutex;
+  Cond cond;
+
+  StaticFifoBuffer<std::byte, 4096> write_buffer;
+
+  PortState state = PortState::LIMBO;
+
+  bool closed = false;
+
+  PortListener *listener = nullptr;
+  DataHandler *handler = nullptr;
+
+public:
+  PortBridge(IOSBluetoothManager *manager, NSString *address) noexcept;
+
+  /**
+   * Unregisters this bridge from the manager and disconnects from the
+   * peripheral.
+   */
+  ~PortBridge() noexcept;
+
+  PortBridge(const PortBridge &) = delete;
+  PortBridge &operator=(const PortBridge &) = delete;
+
+  NSString *GetAddress() const noexcept {
+    return address;
+  }
+
+  /**
+   * May only be called on the manager's dispatch queue.
+   */
+  CBPeripheral *GetPeripheral() const noexcept {
+    return peripheral;
+  }
+
+  void SetListener(PortListener *listener) noexcept;
+  void SetInputListener(DataHandler *handler) noexcept;
+
+  [[gnu::pure]]
+  PortState GetState() const noexcept;
+
+  /**
+   * Wait (with timeout) until all buffered data has been sent.
+   *
+   * @return false on error or timeout
+   */
+  bool Drain() noexcept;
+
+  /**
+   * Copy data to the write buffer.  Blocks (with timeout) while the
+   * buffer is full.
+   *
+   * @return the number of bytes accepted
+   */
+  std::size_t Write(std::span<const std::byte> src) noexcept;
+
+  /* callbacks invoked by #IOSBluetoothManager on its dispatch
+     queue */
+
+  void OnPeripheralAttached(CBPeripheral *peripheral) noexcept;
+
+  /**
+   * The attached peripheral object has become invalid because
+   * Bluetooth was switched off; forget it, so that a fresh instance
+   * gets attached (by retrieval or by scan) once Bluetooth is back.
+   */
+  void OnPeripheralLost() noexcept;
+  void OnConnected() noexcept;
+  void OnDisconnected() noexcept;
+  void OnServicesDiscovered(NSError *error) noexcept;
+  void OnCharacteristicsDiscovered(NSError *error) noexcept;
+  void OnDataReceived(CBCharacteristic *characteristic,
+                      NSData *value) noexcept;
+  void OnWriteCompleted(NSError *error) noexcept;
+  void OnReadyToSendWriteWithoutResponse() noexcept;
+
+  /**
+   * Send as many chunks from the write buffer as flow control
+   * currently permits.
+   */
+  void SendPendingChunks() noexcept;
+
+private:
+  void SetState(PortState new_state) noexcept;
+
+  /**
+   * Report an error to the #PortListener and enter the FAILED state.
+   */
+  void Error(const char *msg) noexcept;
+
+  /**
+   * Pick the RX/TX characteristics after service/characteristic
+   * discovery has finished.
+   */
+  void SelectCharacteristics() noexcept;
+
+  [[gnu::pure]]
+  bool CanSendChunk() const noexcept;
+};

--- a/src/Apple/Services.cpp
+++ b/src/Apple/Services.cpp
@@ -11,6 +11,10 @@
 
 #if TARGET_OS_IPHONE
 
+#include "BluetoothHelper.hpp"
+
+BluetoothHelper *bluetooth_helper;
+
 /**
  * Serialises audio_vario_session_active against the deactivation of the
  * shared AVAudioSession. Without it, DeactivateAudioSession() could read
@@ -93,6 +97,8 @@ InitializeAppleServices()
 {
 #if TARGET_OS_IPHONE
   ActivateAudioSession();
+
+  bluetooth_helper = new BluetoothHelper();
 #endif
 }
 
@@ -110,6 +116,9 @@ DeinitializeAppleServices()
     LogFmt("AVAudioSession deinitialize error: {}",
            [[error localizedDescription] UTF8String]);
   }
+
+  delete bluetooth_helper;
+  bluetooth_helper = nullptr;
 #endif
 }
 

--- a/src/Apple/Services.hpp
+++ b/src/Apple/Services.hpp
@@ -12,6 +12,13 @@ void DeinitializeAppleServices();
 
 #if TARGET_OS_IPHONE
 
+class BluetoothHelper;
+
+/**
+ * The global Bluetooth LE helper, created by InitializeAppleServices().
+ */
+extern BluetoothHelper *bluetooth_helper;
+
 /**
  * (Re-)applies XCSoar's preferred AVAudioSession category and options
  * (Playback, MixWithOthers) and activates the session, so that XCSoar's

--- a/src/Device/Config.cpp
+++ b/src/Device/Config.cpp
@@ -2,6 +2,7 @@
 // Copyright The XCSoar Project
 
 #include "Config.hpp"
+#include "Features.hpp"
 #include "Asset.hpp"
 #include "Language/Language.hpp"
 #include "util/Compiler.h"
@@ -11,6 +12,11 @@
 #include "Android/Main.hpp"
 #include "Android/BluetoothHelper.hpp"
 #include "java/Global.hxx"
+#endif
+
+#ifdef HAVE_APPLE_BLUETOOTH
+#include "Apple/Services.hpp"
+#include "Apple/BluetoothHelper.hpp"
 #endif
 
 bool
@@ -27,12 +33,14 @@ DeviceConfig::IsAvailable() const noexcept
     return true;
 
   case PortType::RFCOMM:
-  case PortType::BLE_SERIAL:
   case PortType::BLE_SENSOR:
   case PortType::RFCOMM_SERVER:
   case PortType::GLIDER_LINK:
   case PortType::ANDROID_USB_SERIAL:
     return IsAndroid();
+
+  case PortType::BLE_SERIAL:
+    return IsAndroid() || IsIOS();
 
   case PortType::IOIOUART:
   case PortType::DROIDSOAR_V2:
@@ -161,6 +169,16 @@ DeviceConfig::BluetoothNameStartsWith([[maybe_unused]] const char *prefix) const
     bluetooth_helper->GetNameFromAddress(Java::GetEnv(),
                                          bluetooth_mac.c_str());
   return name != nullptr && StringStartsWith(name, prefix);
+#elif defined(HAVE_APPLE_BLUETOOTH)
+  if (!IsAppleBluetooth())
+    return false;
+
+  if (bluetooth_helper == nullptr)
+    return false;
+
+  const char *name =
+    bluetooth_helper->GetNameFromAddress(bluetooth_mac.c_str());
+  return name != nullptr && StringStartsWith(name, prefix);
 #else
   return false;
 #endif
@@ -217,6 +235,13 @@ DeviceConfig::GetPortName(char *buffer, size_t max_size) const noexcept
       if (name2 != nullptr)
         name = name2;
     }
+#elif defined(HAVE_APPLE_BLUETOOTH)
+    if (bluetooth_helper != nullptr) {
+      const char *name2 =
+        bluetooth_helper->GetNameFromAddress(name);
+      if (name2 != nullptr)
+        name = name2;
+    }
 #endif
 
     StringFormat(buffer, max_size, "%s: %s",
@@ -230,6 +255,13 @@ DeviceConfig::GetPortName(char *buffer, size_t max_size) const noexcept
     if (bluetooth_helper != nullptr) {
       const char *name2 =
         bluetooth_helper->GetNameFromAddress(Java::GetEnv(), name);
+      if (name2 != nullptr)
+        name = name2;
+    }
+#elif defined(HAVE_APPLE_BLUETOOTH)
+    if (bluetooth_helper != nullptr) {
+      const char *name2 =
+        bluetooth_helper->GetNameFromAddress(name);
       if (name2 != nullptr)
         name = name2;
     }

--- a/src/Device/Config.hpp
+++ b/src/Device/Config.hpp
@@ -143,7 +143,7 @@ struct DeviceConfig {
   /**
    * The Bluetooth MAC address of the peer.
    */
-  StaticString<32> bluetooth_mac;
+  StaticString<64> bluetooth_mac;
 
   /**
    * The IOIO UART ID.
@@ -361,6 +361,15 @@ struct DeviceConfig {
     }
 
     return false;
+  }
+
+  /**
+   * Is this a port which uses the Apple Bluetooth LE support?  Only
+   * serial bridges are supported there, BLE sensors and RFCOMM are
+   * not.
+   */
+  constexpr bool IsAppleBluetooth() const noexcept {
+    return port_type == PortType::BLE_SERIAL;
   }
 
   [[gnu::pure]]

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -208,6 +208,10 @@ try {
 
   port = std::move(_port);
 
+  /* transfer the monitor to the new port, e.g. when the port monitor
+     dialog triggered a reconnect */
+  port->SetWriteMonitor(monitor);
+
   parser.Reset();
   parser.SetReal(!StringIsEqual(driver->name, "Condor") &&
                  !StringIsEqual(driver->name, "Condor3UDP"));
@@ -1733,6 +1737,15 @@ DeviceDescriptor::PortError(const char *msg) noexcept
 
   if (port_listener != nullptr)
     port_listener->PortError(msg);
+}
+
+void
+DeviceDescriptor::SetMonitor(DataHandler *_monitor) noexcept
+{
+  monitor = _monitor;
+
+  if (port != nullptr)
+    port->SetWriteMonitor(_monitor);
 }
 
 bool

--- a/src/Device/Descriptor.cpp
+++ b/src/Device/Descriptor.cpp
@@ -682,7 +682,13 @@ DeviceDescriptor::CanDeclare() const noexcept
 bool
 DeviceDescriptor::IsLogger() const noexcept
 {
-  return driver != nullptr && driver->IsLogger();
+  if (driver != nullptr && driver->IsLogger())
+    return true;
+
+  /* the flights are on the device behind a pass-through device, e.g.
+     a FLARM connected to an XCVario; ReadFlightList() and
+     DownloadFlight() use #second_device for those */
+  return second_driver != nullptr && second_driver->IsLogger();
 }
 
 bool

--- a/src/Device/Descriptor.hpp
+++ b/src/Device/Descriptor.hpp
@@ -542,9 +542,12 @@ private:
   bool ParseNMEA(const char *line, struct NMEAInfo &info) noexcept;
 
 public:
-  void SetMonitor(DataHandler  *_monitor) noexcept {
-    monitor = _monitor;
-  }
+  /**
+   * Install a handler which receives a copy of all data received
+   * from and written to the port, e.g. for the port monitor dialog.
+   * Pass nullptr to remove.
+   */
+  void SetMonitor(DataHandler *_monitor) noexcept;
 
   void SetDispatcher(PortLineHandler *_dispatcher) noexcept {
     dispatcher = _dispatcher;

--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -5,6 +5,7 @@
 #include "CRC16.hpp"
 #include "Device/Error.hpp"
 #include "Device/Port/Port.hpp"
+#include "LogFile.hpp"
 #include "time/TimeoutClock.hpp"
 #include "util/SpanCast.hxx"
 
@@ -152,6 +153,18 @@ ReceiveSomeUnescape(Port &port, std::span<std::byte> dest,
   return p;
 }
 
+/**
+ * Give up on a frame after this much silence, even if the caller
+ * allows more time for the whole frame.  A bridge which drops the
+ * rest of a frame (e.g. a Bluetooth LE adapter with a short transmit
+ * queue) is detected in seconds instead of blocking until the frame
+ * timeout has expired, and the caller can retry that much earlier.
+ * Any link which is still delivering data keeps the frame alive,
+ * because each chunk restarts this timeout.
+ */
+static constexpr std::chrono::steady_clock::duration
+FRAME_IDLE_TIMEOUT = std::chrono::seconds{3};
+
 bool
 FLARM::ReceiveEscaped(Port &port, std::span<std::byte> dest,
                       OperationEnvironment &env,
@@ -163,11 +176,26 @@ FLARM::ReceiveEscaped(Port &port, std::span<std::byte> dest,
 
   // Receive data byte-by-byte including escaping until buffer is full
   std::byte *p = dest.data(), *end = p + dest.size();
-  while (p < end) {
-    p = ReceiveSomeUnescape(port, {p, std::size_t(end - p)},
-                            env, timeout);
-    if (p == nullptr)
-      return false;
+  try {
+    while (p < end) {
+      const TimeoutClock idle_timeout{std::min(timeout.GetRemainingOrZero(),
+                                               FRAME_IDLE_TIMEOUT)};
+
+      p = ReceiveSomeUnescape(port, {p, std::size_t(end - p)},
+                              env, idle_timeout);
+      if (p == nullptr)
+        return false;
+    }
+  } catch (const DeviceTimeout &) {
+#ifndef NDEBUG
+    if (p > dest.data())
+      /* the frame stopped arriving in the middle; over a Bluetooth
+         LE bridge, this typically means its buffer overflowed and
+         the rest of the frame was dropped */
+      LogFormat("FLARM: timeout after receiving %u of %u frame bytes",
+                unsigned(p - dest.data()), unsigned(dest.size()));
+#endif
+    throw;
   }
 
   return true;

--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -246,6 +246,8 @@ FlarmDevice::WaitForACKOrNACK(uint16_t sequence_number,
 {
   const TimeoutClock timeout(_timeout);
 
+  lost_frame_length = 0;
+
   // Receive frames until timeout or expected frame found
   while (!timeout.HasExpired()) {
     // Wait until the next start byte comes around
@@ -266,9 +268,17 @@ FlarmDevice::WaitForACKOrNACK(uint16_t sequence_number,
 
     // Read payload and check length
     data.GrowDiscard(length);
-    if (!ReceiveEscaped({data.data(), length},
-                        env, timeout.GetRemainingOrZero()))
-      continue;
+    try {
+      if (!ReceiveEscaped({data.data(), length},
+                          env, timeout.GetRemainingOrZero()))
+        continue;
+    } catch (const DeviceTimeout &) {
+      /* remember how much this frame would have carried: a restarted
+         flight download can step over it if that part of the file has
+         already been saved */
+      lost_frame_length = length;
+      throw;
+    }
 
     // Verify CRC
     if (header.crc != FLARM::CalculateCRC(header, {data.data(), length}))

--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -9,6 +9,7 @@
 #include "util/SpanCast.hxx"
 
 #include <algorithm> // for std::find_if()
+#include <vector>
 
 static constexpr auto
 FindSpecial(std::span<const std::byte>::iterator begin,
@@ -73,6 +74,38 @@ FLARM::SendEscaped(Port &port, std::span<const std::byte> src,
 
     p++;
   }
+}
+
+static void
+AppendEscaped(std::vector<std::byte> &dest,
+              std::span<const std::byte> src) noexcept
+{
+  for (const std::byte b : src) {
+    if (b == FLARM::START_FRAME) {
+      dest.push_back(FLARM::ESCAPE);
+      dest.push_back(FLARM::ESCAPE_START);
+    } else if (b == FLARM::ESCAPE) {
+      dest.push_back(FLARM::ESCAPE);
+      dest.push_back(FLARM::ESCAPE_ESCAPE);
+    } else
+      dest.push_back(b);
+  }
+}
+
+void
+FLARM::SendFrame(Port &port, const FrameHeader &header,
+                 std::span<const std::byte> payload,
+                 OperationEnvironment &env,
+                 std::chrono::steady_clock::duration timeout)
+{
+  std::vector<std::byte> frame;
+  frame.reserve(1 + 2 * (sizeof(header) + payload.size()));
+
+  frame.push_back(START_FRAME);
+  AppendEscaped(frame, ReferenceAsBytes(header));
+  AppendEscaped(frame, payload);
+
+  port.FullWrite(frame, env, timeout);
 }
 
 static std::byte *
@@ -140,12 +173,6 @@ FLARM::ReceiveEscaped(Port &port, std::span<std::byte> dest,
   return true;
 }
 
-void
-FlarmDevice::SendStartByte()
-{
-  port.Write(FLARM::START_FRAME);
-}
-
 inline void
 FlarmDevice::WaitForStartByte(OperationEnvironment &env,
                               std::chrono::steady_clock::duration timeout)
@@ -172,14 +199,6 @@ FlarmDevice::PrepareFrameHeader(FLARM::MessageType message_type,
 {
   return FLARM::PrepareFrameHeader(sequence_number++, message_type,
                                    payload);
-}
-
-void
-FlarmDevice::SendFrameHeader(const FLARM::FrameHeader &header,
-                             OperationEnvironment &env,
-                             std::chrono::steady_clock::duration timeout)
-{
-  SendEscaped(ReferenceAsBytes(header), env, timeout);
 }
 
 bool
@@ -274,8 +293,7 @@ try {
 
   // Send request and wait for positive answer
 
-  SendStartByte();
-  SendFrameHeader(header, env, timeout.GetRemainingOrZero());
+  SendFrame(header, {}, env, timeout.GetRemainingOrZero());
   return WaitForACK(header.sequence_number, env, timeout.GetRemainingOrZero());
 } catch (const DeviceTimeout &) {
   return false;
@@ -291,6 +309,5 @@ FlarmDevice::BinaryReset(OperationEnvironment &env,
   FLARM::FrameHeader header = PrepareFrameHeader(FLARM::MessageType::EXIT);
 
   // Send request and wait for positive answer
-  SendStartByte();
-  SendFrameHeader(header, env, timeout.GetRemainingOrZero());
+  SendFrame(header, {}, env, timeout.GetRemainingOrZero());
 }

--- a/src/Device/Driver/FLARM/BinaryProtocol.cpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.cpp
@@ -255,13 +255,22 @@ FlarmDevice::WaitForACKOrNACK(uint16_t sequence_number,
 
     // Read the following FrameHeader
     FLARM::FrameHeader header;
-    if (!ReceiveFrameHeader(header, env, timeout.GetRemainingOrZero()))
+    if (!ReceiveFrameHeader(header, env, timeout.GetRemainingOrZero())) {
+#ifndef NDEBUG
+      LogFormat("FLARM: malformed frame header");
+#endif
       continue;
+    }
 
     // Read and check length of the FrameHeader
     length = header.length;
-    if (length <= sizeof(header))
+    if (length <= sizeof(header)) {
+#ifndef NDEBUG
+      LogFormat("FLARM: discarding short frame (type=0x%02x length=%u)",
+                unsigned(header.type), unsigned(length));
+#endif
       continue;
+    }
 
     // Calculate payload length
     length -= sizeof(header);
@@ -270,8 +279,13 @@ FlarmDevice::WaitForACKOrNACK(uint16_t sequence_number,
     data.GrowDiscard(length);
     try {
       if (!ReceiveEscaped({data.data(), length},
-                          env, timeout.GetRemainingOrZero()))
+                          env, timeout.GetRemainingOrZero())) {
+#ifndef NDEBUG
+        LogFormat("FLARM: malformed frame payload (type=0x%02x length=%u)",
+                  unsigned(header.type), unsigned(length));
+#endif
         continue;
+      }
     } catch (const DeviceTimeout &) {
       /* remember how much this frame would have carried: a restarted
          flight download can step over it if that part of the file has
@@ -281,22 +295,44 @@ FlarmDevice::WaitForACKOrNACK(uint16_t sequence_number,
     }
 
     // Verify CRC
-    if (header.crc != FLARM::CalculateCRC(header, {data.data(), length}))
+    if (header.crc != FLARM::CalculateCRC(header, {data.data(), length})) {
+#ifndef NDEBUG
+      LogFormat("FLARM: discarding frame with bad CRC (type=0x%02x length=%u)",
+                unsigned(header.type), unsigned(length));
+#endif
       continue;
+    }
 
     // Check message type
     if (header.type != FLARM::MessageType::ACK &&
-        header.type != FLARM::MessageType::NACK)
+        header.type != FLARM::MessageType::NACK) {
+#ifndef NDEBUG
+      LogFormat("FLARM: ignoring frame (type=0x%02x length=%u)",
+                unsigned(header.type), unsigned(length));
+#endif
       continue;
+    }
 
     // Check payload length
-    if (length < 2)
+    if (length < 2) {
+#ifndef NDEBUG
+      LogFormat("FLARM: discarding %s without sequence number",
+                header.type == FLARM::MessageType::ACK ? "ACK" : "NACK");
+#endif
       continue;
+    }
 
     // Check whether the received ACK is for the right sequence number
-    if (FromLE16(*((const uint16_t *)(const void *)data.data())) ==
-        sequence_number)
+    const uint16_t received_sequence_number =
+      FromLE16(*((const uint16_t *)(const void *)data.data()));
+    if (received_sequence_number == sequence_number)
       return (FLARM::MessageType)header.type;
+
+#ifndef NDEBUG
+    LogFormat("FLARM: ignoring %s with sequence %u (expecting %u)",
+              header.type == FLARM::MessageType::ACK ? "ACK" : "NACK",
+              unsigned(received_sequence_number), unsigned(sequence_number));
+#endif
   }
 
   return FLARM::MessageType::ERROR;

--- a/src/Device/Driver/FLARM/BinaryProtocol.hpp
+++ b/src/Device/Driver/FLARM/BinaryProtocol.hpp
@@ -83,7 +83,7 @@ static_assert(std::is_trivial<FrameHeader>::value, "type is not trivial");
 
 /**
  * Convenience function. Returns a pre-populated FrameHeader instance that is
- * ready to be sent by the SendFrameHeader() function.
+ * ready to be sent by the SendFrame() function.
  * @param message_type Message type of the FrameHeader
  * @param payload the payload; used for CRC calculations
  * @return An initialized FrameHeader instance
@@ -104,6 +104,18 @@ void
 SendEscaped(Port &port, std::span<const std::byte> src,
             OperationEnvironment &env,
             std::chrono::steady_clock::duration timeout);
+
+/**
+ * Send one complete frame: the start byte, the escaped header and the
+ * escaped payload, in a single write.  On a packet oriented link such
+ * as Bluetooth LE, every write is a packet of its own, and a frame
+ * which is spread over several of them is easily mangled by a bridge.
+ */
+void
+SendFrame(Port &port, const FrameHeader &header,
+          std::span<const std::byte> payload,
+          OperationEnvironment &env,
+          std::chrono::steady_clock::duration timeout);
 
 /**
  * Reads a specified number of bytes from the port while applying the

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -163,22 +163,11 @@ private:
   bool DeclareInternal(const Declaration &declaration,
                        OperationEnvironment &env);
 
-  void SendEscaped(std::span<const std::byte> src,
-                   OperationEnvironment &env,
-                   std::chrono::steady_clock::duration timeout) {
-    FLARM::SendEscaped(port, src, env, timeout);
-  }
-
   bool ReceiveEscaped(std::span<std::byte> dest,
                       OperationEnvironment &env,
                       std::chrono::steady_clock::duration timeout) {
     return FLARM::ReceiveEscaped(port, dest, env, timeout);
   }
-
-  /**
-   * Send the byte that is used to signal that start of a new frame
-   */
-  void SendStartByte();
 
   /**
    * Waits for a certain amount of time until the next frame start signal byte
@@ -191,7 +180,7 @@ private:
 
   /**
    * Convenience function. Returns a pre-populated FrameHeader instance that is
-   * ready to be sent by the SendFrameHeader() function.
+   * ready to be sent by the SendFrame() function.
    * @param message_type Message type of the FrameHeader
    * @param data Optional pointer to the first byte of the payload. Used for
    * CRC calculations.
@@ -202,13 +191,14 @@ private:
                                         std::span<const std::byte> payload={}) noexcept;
 
   /**
-   * Sends a FrameHeader to the port. Remember that a StartByte should be
-   * sent first!
-   * @param header FrameHeader that should be sent.
+   * Send a complete frame in one write; see FLARM::SendFrame().
    */
-  void SendFrameHeader(const FLARM::FrameHeader &header,
-                       OperationEnvironment &env,
-                       std::chrono::steady_clock::duration timeout);
+  void SendFrame(const FLARM::FrameHeader &header,
+                 std::span<const std::byte> payload,
+                 OperationEnvironment &env,
+                 std::chrono::steady_clock::duration timeout) {
+    FLARM::SendFrame(port, header, payload, env, timeout);
+  }
 
   /**
    * Reads a FrameHeader from the port. This should only be done directly

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -18,6 +18,7 @@ class OperationEnvironment;
 class RecordedFlightList;
 struct RecordedFlightInfo;
 class NMEAInputLine;
+class BufferedOutputStream;
 
 class FlarmDevice: public AbstractDevice
 {
@@ -275,12 +276,21 @@ private:
   bool ReadFlightInfo(RecordedFlightInfo &flight, OperationEnvironment &env);
 
   /**
-   * Sends GetIGCData messages to the Flarm and downloads the currently
-   * selected flight
-   * @param path Path to the IGC file to write into
+   * Sends GetIGCData messages to the Flarm and downloads the
+   * currently selected flight
+   *
+   * @param os the output stream to append the IGC data to
+   * @param offset the number of bytes which have already been
+   * written to the stream by a previous, failed transfer of the same
+   * flight; that part of the restarted stream is skipped instead of
+   * being written again.  Updated as data is written.
+   * @param max_progress the highest percentage reported so far; a
+   * restarted transfer makes the FLARM count from zero again, and the
+   * progress bar must not jump backwards.  Updated as data arrives.
    * @return True if received and written successfully, otherwise False
    */
-  bool DownloadFlight(Path path, OperationEnvironment &env);
+  bool DownloadFlight(BufferedOutputStream &os, std::size_t &offset,
+                      unsigned &max_progress, OperationEnvironment &env);
 
 public:
   /**

--- a/src/Device/Driver/FLARM/Device.hpp
+++ b/src/Device/Driver/FLARM/Device.hpp
@@ -37,6 +37,14 @@ class FlarmDevice: public AbstractDevice
   uint16_t sequence_number = 0;
 
   /**
+   * The announced payload size of the frame whose payload stopped
+   * arriving in the middle, or 0 if the last WaitForACKOrNACK() call
+   * did not lose a frame that way.  A restarted flight download uses
+   * it to skip a frame which it has already saved.
+   */
+  uint16_t lost_frame_length = 0;
+
+  /**
    * Settings that were received in PDVSC sentences.
    */
   DeviceSettingsMap<std::string> settings;

--- a/src/Device/Driver/FLARM/Logger.cpp
+++ b/src/Device/Driver/FLARM/Logger.cpp
@@ -345,6 +345,21 @@ FlarmDevice::DownloadFlight(BufferedOutputStream &os, std::size_t &offset,
     }
 
     if (result != FLARM::MessageType::ACK || length <= 3) {
+      /* the payload of this frame did not arrive completely; if it
+         belongs to the part which a previous attempt has already
+         saved, its contents are not needed and the transfer can carry
+         on instead of starting over once more */
+      if (lost_frame_length > 3 &&
+          skip >= std::size_t(lost_frame_length - 3)) {
+        skip -= lost_frame_length - 3;
+
+#ifndef NDEBUG
+        LogFormat("FLARM: stepping over %u lost bytes which are already"
+                  " saved", unsigned(lost_frame_length - 3));
+#endif
+        continue;
+      }
+
       /* a lost frame must not be requested again: the FLARM does not
          repeat it, it answers the next GETIGCDATA with the *following*
          chunk, and the missing one would leave a hole in the IGC file.

--- a/src/Device/Driver/FLARM/Logger.cpp
+++ b/src/Device/Driver/FLARM/Logger.cpp
@@ -9,9 +9,12 @@
 #include "system/Path.hpp"
 #include "LogFile.hpp"
 #include "Operation/Operation.hpp"
+#include "Operation/Cancelled.hpp"
 
+#include <algorithm> // for std::min(), std::max()
 #include <cstdlib>
 #include <cstring>
+#include <span>
 
 static bool
 ParseDate(const char *str, BrokenDate &date)
@@ -312,64 +315,90 @@ FlarmDevice::ReadFlightList(RecordedFlightList &flight_list,
 }
 
 bool
-FlarmDevice::DownloadFlight(Path path, OperationEnvironment &env)
+FlarmDevice::DownloadFlight(BufferedOutputStream &os, std::size_t &offset,
+                            unsigned &max_progress,
+                            OperationEnvironment &env)
 {
-  static constexpr unsigned get_igcdata_retries = 3;
+  /* the FLARM binary protocol cannot seek inside a flight record;
+     after a restarted transfer, the part which was already saved is
+     discarded instead of being written twice */
+  std::size_t skip = offset;
 
-  FileOutputStream fos(path);
-  BufferedOutputStream os(fos);
-
-  env.SetProgressRange(100);
   while (true) {
     // Create header for getting IGC file data
     FLARM::FrameHeader header = PrepareFrameHeader(FLARM::MessageType::GETIGCDATA);
 
     AllocatedArray<std::byte> data;
     uint16_t length = 0;
-    bool ack = false;
 
-    for (unsigned retry = 0; retry < get_igcdata_retries; ++retry) {
-      // Send request
-      SendFrame(header, {}, env, std::chrono::seconds(1));
+    // Send request
+    SendFrame(header, {}, env, std::chrono::seconds(1));
 
-      // Wait for an answer and save the payload for further processing
-      try {
-        ack = WaitForACKOrNACK(header.sequence_number, data,
-                               length, env,
-                               std::chrono::seconds(10)) ==
-          FLARM::MessageType::ACK;
-      } catch (const DeviceTimeout &) {
-        ack = false;
-      }
-
-      if (ack)
-        break;
+    /* wait for an answer and save the payload for further processing;
+       an IGC data frame is several hundred bytes, which can take a
+       while on a slow link (e.g. a Bluetooth LE bridge) */
+    auto result = FLARM::MessageType::ERROR;
+    try {
+      result = WaitForACKOrNACK(header.sequence_number, data,
+                                length, env, std::chrono::seconds(30));
+    } catch (const DeviceTimeout &) {
     }
 
-    // If no ACK was received
-    if (!ack || length <= 3)
+    if (result != FLARM::MessageType::ACK || length <= 3) {
+      /* a lost frame must not be requested again: the FLARM does not
+         repeat it, it answers the next GETIGCDATA with the *following*
+         chunk, and the missing one would leave a hole in the IGC file.
+         Fail this session instead; the caller restarts the transfer
+         from the beginning and skips the part which was already
+         written */
+      LogFormat("FLARM: %s to GETIGCDATA after %lu bytes",
+                result == FLARM::MessageType::NACK
+                ? "NACK"
+                : (result == FLARM::MessageType::ACK
+                   ? "short answer" : "no answer"),
+                (unsigned long)offset);
       return false;
+    }
 
     length -= 3;
 
     // Read progress (in percent)
-    const auto progress = static_cast<unsigned>(data[2]);
-    env.SetProgressPosition(std::min(progress, 100u));
+    const auto progress = std::min(static_cast<unsigned>(data[2]), 100u);
 
-    const char last_char = (char)data.back();
-    bool is_last_packet = (last_char == 0x1A);
-    if (is_last_packet)
-      length--;
+    /* a restarted transfer sends the flight from the beginning, so
+       the FLARM counts from zero again although the file is already
+       written up to #offset; keep the progress bar monotonic */
+    max_progress = std::max(max_progress, progress);
+    env.SetProgressPosition(max_progress);
+
+#ifndef NDEBUG
+    LogFormat("FLARM: received IGC data frame (%u bytes, %u%%)",
+              unsigned(length), progress);
+#endif
 
     // Read IGC data
-    os.Write({data.data() + 3, length});
+    std::span<const std::byte> payload{data.data() + 3, length};
+
+    // The last packet ends with 0x1A
+    const bool is_last_packet = !payload.empty() &&
+      payload.back() == std::byte{0x1A};
+    if (is_last_packet)
+      payload = payload.first(payload.size() - 1);
+
+    if (skip > 0) {
+      const std::size_t n = std::min(skip, payload.size());
+      payload = payload.subspan(n);
+      skip -= n;
+    }
+
+    if (!payload.empty()) {
+      os.Write(payload);
+      offset += payload.size();
+    }
 
     if (is_last_packet)
       break;
   }
-
-  os.Flush();
-  fos.Commit();
 
   return true;
 }
@@ -379,22 +408,64 @@ bool
 FlarmDevice::DownloadFlight(const RecordedFlightInfo &flight,
                             Path path, OperationEnvironment &env)
 {
-  if (!BinaryMode(env))
-    return false;
+  /* how often to restart the transfer after a mid-transfer failure;
+     the equivalent of the resumable LX Nano downloads.  The FLARM
+     binary protocol cannot resume at an offset, so the transfer is
+     restarted and the already saved part is skipped.
+     Every attempt which gets past the previous one makes progress, so
+     a link which loses a frame now and then still finishes; the price
+     is that each restart reads the flight from the beginning again */
+  static constexpr unsigned session_attempts = 20;
 
-  FLARM::MessageType ack_result = SelectFlight(flight.internal.flarm, env);
+  FileOutputStream fos(path);
+  BufferedOutputStream os(fos);
 
-  // If no ACK was received -> cancel
-  if (ack_result != FLARM::MessageType::ACK)
-    return false;
+  env.SetProgressRange(100);
 
-  try {
-    if (DownloadFlight(path, env))
-      return true;
-  } catch (...) {
+  std::size_t offset = 0;
+  unsigned max_progress = 0;
+
+  for (unsigned attempt = 1;; ++attempt) {
+    try {
+      if (!BinaryMode(env))
+        return false;
+
+      // If no ACK was received -> cancel
+      if (SelectFlight(flight.internal.flarm, env) != FLARM::MessageType::ACK)
+        return false;
+
+      if (DownloadFlight(os, offset, max_progress, env)) {
+        os.Flush();
+        fos.Commit();
+        return true;
+      }
+    } catch (OperationCancelled &) {
+      mode = Mode::UNKNOWN;
+      throw;
+    } catch (...) {
+      mode = Mode::UNKNOWN;
+
+      if (attempt >= session_attempts)
+        throw;
+
+      LogError(std::current_exception(), "FLARM: flight download error");
+    }
+
+    if (attempt >= session_attempts)
+      break;
+
+    LogFormat("FLARM: flight download attempt %u of %u failed"
+              " after %lu bytes, restarting the transfer",
+              attempt, session_attempts, (unsigned long)offset);
+
+    /* force BinaryMode() to re-establish the (possibly dead) binary
+       session before the next attempt */
     mode = Mode::UNKNOWN;
-    throw;
   }
+
+  LogFormat("FLARM: flight download failed after %u attempts"
+            " (%lu bytes received)",
+            session_attempts, (unsigned long)offset);
 
   mode = Mode::UNKNOWN;
 

--- a/src/Device/Driver/FLARM/Logger.cpp
+++ b/src/Device/Driver/FLARM/Logger.cpp
@@ -7,6 +7,7 @@
 #include "io/FileOutputStream.hxx"
 #include "io/BufferedOutputStream.hxx"
 #include "system/Path.hpp"
+#include "LogFile.hpp"
 #include "Operation/Operation.hpp"
 
 #include <cstdlib>
@@ -218,12 +219,14 @@ FlarmDevice::ReadFlightInfo(RecordedFlightInfo &flight,
   // Send request
   SendFrame(header, {}, env, std::chrono::seconds(1));
 
-  // Wait for an answer and save the payload for further processing
+  /* wait for an answer and save the payload for further processing;
+     the record info frame is ~100 bytes, which can take several
+     seconds on a slow link (e.g. a Bluetooth LE bridge) */
   AllocatedArray<std::byte> data;
   uint16_t length;
   const auto ack_result =
     WaitForACKOrNACK(header.sequence_number, data, length,
-                     env, std::chrono::seconds(5));
+                     env, std::chrono::seconds(10));
 
   // If neither ACK nor NACK was received
   if (ack_result != FLARM::MessageType::ACK || length <= 2)
@@ -236,17 +239,44 @@ FlarmDevice::ReadFlightInfo(RecordedFlightInfo &flight,
 FLARM::MessageType
 FlarmDevice::SelectFlight(uint8_t record_number, OperationEnvironment &env)
 {
-  // Create header for selecting a log record
+  static constexpr unsigned max_attempts = 3;
+
   std::byte data[] = { static_cast<std::byte>(record_number) };
-  FLARM::FrameHeader header = PrepareFrameHeader(FLARM::MessageType::SELECTRECORD,
-                                                 std::span{data});
 
-  // Send request
-  SendFrame(header, std::span{data}, env, std::chrono::seconds(1));
+  /* retry with a fresh frame on timeout; over high-latency links
+     such as Bluetooth LE bridges, a single short timeout is not
+     always enough, and a lost frame would otherwise silently drop a
+     flight from the list */
+  for (unsigned attempt = 1;; ++attempt) {
+    // Create header for selecting a log record
+    FLARM::FrameHeader header =
+      PrepareFrameHeader(FLARM::MessageType::SELECTRECORD, std::span{data});
 
-  // Wait for an answer
-  return WaitForACKOrNACK(header.sequence_number,
-                          env, std::chrono::seconds(1));
+    // Send request
+    SendFrame(header, std::span{data}, env, std::chrono::seconds(1));
+
+    // Wait for an answer
+    try {
+      const auto result = WaitForACKOrNACK(header.sequence_number,
+                                           env, std::chrono::seconds(2));
+      if (result != FLARM::MessageType::ERROR || attempt >= max_attempts)
+        return result;
+
+#ifndef NDEBUG
+      LogFormat("FLARM: no answer to SELECTRECORD %u (attempt %u of %u)",
+                record_number, attempt, max_attempts);
+#endif
+    } catch (const DeviceTimeout &) {
+      if (attempt >= max_attempts)
+        throw;
+
+#ifndef NDEBUG
+      LogFormat("FLARM: timeout waiting for SELECTRECORD %u answer"
+                " (attempt %u of %u)",
+                record_number, attempt, max_attempts);
+#endif
+    }
+  }
 }
 
 bool

--- a/src/Device/Driver/FLARM/Logger.cpp
+++ b/src/Device/Driver/FLARM/Logger.cpp
@@ -216,8 +216,7 @@ FlarmDevice::ReadFlightInfo(RecordedFlightInfo &flight,
   FLARM::FrameHeader header = PrepareFrameHeader(FLARM::MessageType::GETRECORDINFO);
 
   // Send request
-  SendStartByte();
-  SendFrameHeader(header, env, std::chrono::seconds(1));
+  SendFrame(header, {}, env, std::chrono::seconds(1));
 
   // Wait for an answer and save the payload for further processing
   AllocatedArray<std::byte> data;
@@ -243,9 +242,7 @@ FlarmDevice::SelectFlight(uint8_t record_number, OperationEnvironment &env)
                                                  std::span{data});
 
   // Send request
-  SendStartByte();
-  SendFrameHeader(header, env, std::chrono::seconds(1));
-  SendEscaped(std::span{data}, env, std::chrono::seconds(1));
+  SendFrame(header, std::span{data}, env, std::chrono::seconds(1));
 
   // Wait for an answer
   return WaitForACKOrNACK(header.sequence_number,
@@ -303,8 +300,7 @@ FlarmDevice::DownloadFlight(Path path, OperationEnvironment &env)
 
     for (unsigned retry = 0; retry < get_igcdata_retries; ++retry) {
       // Send request
-      SendStartByte();
-      SendFrameHeader(header, env, std::chrono::seconds(1));
+      SendFrame(header, {}, env, std::chrono::seconds(1));
 
       // Wait for an answer and save the payload for further processing
       try {

--- a/src/Device/Driver/FLARM/Mode.cpp
+++ b/src/Device/Driver/FLARM/Mode.cpp
@@ -78,16 +78,27 @@ FlarmDevice::BinaryMode(OperationEnvironment &env)
   // of time (around 1.5 sec). Due to that it is recommended to issue new pings
   // for a certain time until the ping is ACKed properly or a timeout occurs.
   for (unsigned i = 0; i < 10; ++i) {
-    if (BinaryPing(env, std::chrono::milliseconds(500))) {
+    /* give slow links (small ATT MTU, long connection interval) some
+       more time after the first attempts */
+    const auto timeout = std::chrono::milliseconds(i < 5 ? 500 : 1000);
+
+    if (BinaryPing(env, timeout)) {
       // We are now in binary mode and have verified that with a binary ping
 
       // Remember that we should now be in binary mode (for further assert() calls)
       was_binary = true;
       mode = Mode::BINARY;
+
+#ifndef NDEBUG
+      if (i > 0)
+        LogFormat("FLARM: binary mode established after %u pings", i + 1);
+#endif
+
       return true;
     }
   }
 
   // Apparently the switch to binary mode didn't work
+  LogFormat("FLARM: no answer to binary ping, cannot enter binary mode");
   return false;
 }

--- a/src/Device/Driver/FLARM/Mode.cpp
+++ b/src/Device/Driver/FLARM/Mode.cpp
@@ -3,6 +3,7 @@
 
 #include "Device.hpp"
 #include "Device/Port/Port.hpp"
+#include "LogFile.hpp"
 #include "Operation/Operation.hpp"
 
 bool
@@ -53,6 +54,16 @@ FlarmDevice::BinaryMode(OperationEnvironment &env)
 {
   if (mode == Mode::BINARY)
     return true;
+
+  /* especially on Bluetooth LE ports, the connection may not be
+     established yet (e.g. iOS is still connecting to the
+     peripheral, which has no timeout); wait for it (cancellable)
+     instead of wasting the ping attempts below on a dead link, like
+     the LX Nano driver does */
+  if (!port.WaitConnected(env)) {
+    LogFormat("FLARM: port not connected, cannot enter binary mode");
+    return false;
+  }
 
   port.StopRxThread();
 

--- a/src/Device/Driver/XCVario.cpp
+++ b/src/Device/Driver/XCVario.cpp
@@ -302,7 +302,13 @@ XVCCreateOnPort([[maybe_unused]] const DeviceConfig &config, Port &com_port)
 const struct DeviceRegister xcv_driver = {
   "XCVario",
   "XCVario",
-  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS,
+  /* the XCVario forwards the serial data of the device connected to
+     it (usually a FLARM), and it needs no command to do so; declaring
+     PASS_THROUGH allows a second driver to be configured on the same
+     port, and AbstractDevice::EnablePassThrough() does nothing and
+     succeeds */
+  DeviceRegister::RECEIVE_SETTINGS | DeviceRegister::SEND_SETTINGS |
+  DeviceRegister::PASS_THROUGH,
   XVCCreateOnPort,
 };
 

--- a/src/Device/Factory.cpp
+++ b/src/Device/Factory.cpp
@@ -31,6 +31,9 @@ DeviceFactory::OpenPort(const DeviceConfig &config, PortListener *listener,
                     ioio_helper,
                     usb_serial_helper,
 #endif
+#ifdef HAVE_APPLE_BLUETOOTH
+                    bluetooth_helper,
+#endif
                     config, listener, handler);
 }
 

--- a/src/Device/Factory.hpp
+++ b/src/Device/Factory.hpp
@@ -30,6 +30,10 @@ class IOIOHelper;
 class UsbSerialHelper;
 #endif
 
+#ifdef HAVE_APPLE_BLUETOOTH
+class BluetoothHelper;
+#endif
+
 class DeviceFactory final {
   EventLoop &event_loop;
   Cares::Channel &cares;
@@ -42,6 +46,10 @@ class DeviceFactory final {
   UsbSerialHelper *const usb_serial_helper;
 #endif
 
+#ifdef HAVE_APPLE_BLUETOOTH
+  BluetoothHelper *const bluetooth_helper;
+#endif
+
 public:
   constexpr DeviceFactory(EventLoop &_event_loop, Cares::Channel &_cares
 #ifdef ANDROID
@@ -51,6 +59,9 @@ public:
                           IOIOHelper *_ioio_helper,
                           UsbSerialHelper *_usb_serial_helper
 #endif
+#ifdef HAVE_APPLE_BLUETOOTH
+                          , BluetoothHelper *_bluetooth_helper
+#endif
     ) noexcept
     :event_loop(_event_loop), cares(_cares)
 #ifdef ANDROID
@@ -59,6 +70,9 @@ public:
      bluetooth_helper(_bluetooth_helper),
      ioio_helper(_ioio_helper),
      usb_serial_helper(_usb_serial_helper)
+#endif
+#ifdef HAVE_APPLE_BLUETOOTH
+    , bluetooth_helper(_bluetooth_helper)
 #endif
     {}
 

--- a/src/Device/Features.hpp
+++ b/src/Device/Features.hpp
@@ -3,9 +3,19 @@
 
 #pragma once
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#endif
+
 static constexpr unsigned NUMDEV = 8;
 static constexpr unsigned INTERNAL_DEVICE_SLOT = NUMDEV - 1;
 
 #if defined(ANDROID) || defined(__APPLE__)
 #define HAVE_INTERNAL_GPS
+#endif
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+/* Bluetooth LE serial ports via CoreBluetooth, see
+   src/Apple/BluetoothHelper.hpp */
+#define HAVE_APPLE_BLUETOOTH
 #endif

--- a/src/Device/Port/AppleBluetoothPort.cpp
+++ b/src/Device/Port/AppleBluetoothPort.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "AppleBluetoothPort.hpp"
+#include "ApplePort.hpp"
+#include "Apple/BluetoothHelper.hpp"
+
+#include <cassert>
+
+std::unique_ptr<Port>
+OpenAppleBleSerialPort(BluetoothHelper &bluetooth_helper,
+                       const char *address, PortListener *listener,
+                       DataHandler &handler)
+{
+  assert(address != nullptr);
+
+  PortBridge *bridge = bluetooth_helper.connect(address);
+  assert(bridge != nullptr);
+
+  return std::make_unique<ApplePort>(listener, handler, bridge);
+}

--- a/src/Device/Port/AppleBluetoothPort.hpp
+++ b/src/Device/Port/AppleBluetoothPort.hpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class BluetoothHelper;
+class Port;
+class PortListener;
+class DataHandler;
+
+/**
+ * Open a serial port connection to a Bluetooth LE (GATT) device.
+ */
+std::unique_ptr<Port>
+OpenAppleBleSerialPort(BluetoothHelper &bluetooth_helper,
+                       const char *address, PortListener *_listener,
+                       DataHandler &_handler);

--- a/src/Device/Port/ApplePort.cpp
+++ b/src/Device/Port/ApplePort.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "ApplePort.hpp"
+#include "Apple/PortBridge.hpp"
+
+#include <cassert>
+
+ApplePort::ApplePort(PortListener *_listener, DataHandler &_handler,
+                     PortBridge *_bridge) noexcept
+  :BufferedPort(_listener, _handler), bridge(_bridge)
+{
+  assert(bridge != nullptr);
+
+  bridge->SetListener(_listener);
+  bridge->SetInputListener(this);
+}
+
+ApplePort::~ApplePort() noexcept
+{
+  assert(bridge != nullptr);
+
+  delete bridge;
+}
+
+PortState
+ApplePort::GetState() const noexcept
+{
+  assert(bridge != nullptr);
+
+  return bridge->GetState();
+}
+
+bool
+ApplePort::Drain()
+{
+  assert(bridge != nullptr);
+
+  return bridge->Drain();
+}
+
+unsigned
+ApplePort::GetBaudrate() const noexcept
+{
+  return 0;
+}
+
+void
+ApplePort::SetBaudrate([[maybe_unused]] unsigned baud_rate)
+{
+  /* a BLE GATT bridge has no configurable baud rate; accept the
+     request silently, like Android's HM10Port */
+}
+
+std::size_t
+ApplePort::Write(std::span<const std::byte> src)
+{
+  assert(bridge != nullptr);
+
+  return bridge->Write(src);
+}

--- a/src/Device/Port/ApplePort.hpp
+++ b/src/Device/Port/ApplePort.hpp
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "BufferedPort.hpp"
+
+class PortBridge;
+
+/**
+ * A #Port implementation which transmits data over a Bluetooth LE
+ * GATT connection (see Apple/PortBridge.hpp).
+ */
+class ApplePort : public BufferedPort
+{
+  PortBridge *bridge;
+
+public:
+  ApplePort(PortListener *_listener, DataHandler &_handler,
+            PortBridge *bridge) noexcept;
+  ~ApplePort() noexcept override;
+
+  /* virtual methods from class Port */
+  PortState GetState() const noexcept override;
+  bool Drain() override;
+  unsigned GetBaudrate() const noexcept override;
+  void SetBaudrate(unsigned baud_rate) override;
+  std::size_t Write(std::span<const std::byte> src) override;
+};

--- a/src/Device/Port/ConfiguredPort.cpp
+++ b/src/Device/Port/ConfiguredPort.cpp
@@ -16,6 +16,10 @@
 #include "AndroidUsbSerialPort.hpp"
 #endif
 
+#ifdef HAVE_APPLE_BLUETOOTH
+#include "AppleBluetoothPort.hpp"
+#endif
+
 #if defined(HAVE_POSIX)
 #include "TTYPort.hpp"
 #else
@@ -69,6 +73,8 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
                  BluetoothHelper *bluetooth_helper,
                  IOIOHelper *ioio_helper,
                  UsbSerialHelper *usb_serial_helper,
+#elif defined(HAVE_APPLE_BLUETOOTH)
+                 BluetoothHelper *bluetooth_helper,
 #endif
                  const DeviceConfig &config, PortListener *listener,
                  DataHandler &handler)
@@ -98,6 +104,15 @@ OpenPortInternal(EventLoop &event_loop, Cares::Channel &cares,
     return OpenAndroidBleSerialPort(*bluetooth_helper,
                                     config.bluetooth_mac,
                                     listener, handler);
+#elif defined(HAVE_APPLE_BLUETOOTH)
+    if (config.bluetooth_mac.empty())
+      throw std::runtime_error("No Bluetooth MAC configured");
+
+    if (bluetooth_helper == nullptr)
+      throw std::runtime_error("Bluetooth not available");
+
+    return OpenAppleBleSerialPort(*bluetooth_helper, config.bluetooth_mac,
+                                listener, handler);
 #else
     throw std::runtime_error("Bluetooth not available");
 #endif
@@ -244,6 +259,8 @@ OpenPort(EventLoop &event_loop, Cares::Channel &cares,
          BluetoothHelper *bluetooth_helper,
          IOIOHelper *ioio_helper,
          UsbSerialHelper *usb_serial_helper,
+#elif defined(HAVE_APPLE_BLUETOOTH)
+         BluetoothHelper *bluetooth_helper,
 #endif
          const DeviceConfig &config, PortListener *listener,
          DataHandler &handler)
@@ -253,6 +270,8 @@ OpenPort(EventLoop &event_loop, Cares::Channel &cares,
                                bluetooth_helper,
                                ioio_helper,
                                usb_serial_helper,
+#elif defined(HAVE_APPLE_BLUETOOTH)
+                               bluetooth_helper,
 #endif
                                config, listener, handler);
   if (port != nullptr)

--- a/src/Device/Port/ConfiguredPort.hpp
+++ b/src/Device/Port/ConfiguredPort.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "Device/Features.hpp"
+
 #include <memory>
 
 namespace Cares { class Channel; }
@@ -16,6 +18,8 @@ struct DeviceConfig;
 class BluetoothHelper;
 class IOIOHelper;
 class UsbSerialHelper;
+#elif defined(HAVE_APPLE_BLUETOOTH)
+class BluetoothHelper;
 #endif
 
 /**
@@ -28,6 +32,8 @@ OpenPort(EventLoop &event_loop, Cares::Channel &cares,
          BluetoothHelper *bluetooth_helper,
          IOIOHelper *ioio_helper,
          UsbSerialHelper *usb_serial_helper,
+#elif defined(HAVE_APPLE_BLUETOOTH)
+         BluetoothHelper *bluetooth_helper,
 #endif
          const DeviceConfig &config, PortListener *listener,
          DataHandler &handler);

--- a/src/Device/Port/DumpPort.cpp
+++ b/src/Device/Port/DumpPort.cpp
@@ -4,6 +4,7 @@
 #include "DumpPort.hpp"
 #include "Device/Error.hpp"
 #include "HexDump.hpp"
+#include "io/DataHandler.hpp"
 
 #include <cstdint>
 #include <stdio.h>
@@ -68,6 +69,9 @@ DumpPort::Write(std::span<const std::byte> src)
     LogFmt("Write({})={}", src.size(), nbytes);
     HexDump("W ", src.first(nbytes));
   }
+
+  if (write_monitor != nullptr && nbytes > 0)
+    write_monitor->DataReceived(src.first(nbytes));
 
   return nbytes;
 }

--- a/src/Device/Port/DumpPort.hpp
+++ b/src/Device/Port/DumpPort.hpp
@@ -20,6 +20,12 @@ class DumpPort final : public Port {
   std::chrono::steady_clock::time_point until =
     std::chrono::steady_clock::time_point::max();
 
+  /**
+   * An optional handler which receives a copy of all data written to
+   * the port; see SetWriteMonitor().
+   */
+  DataHandler *write_monitor = nullptr;
+
 public:
   /**
    * Initialises the new instance.  Dumping is enabled forever by
@@ -50,6 +56,16 @@ public:
 
   bool IsEnabled() const noexcept {
     return until > std::chrono::steady_clock::time_point{};
+  }
+
+  /**
+   * Install a handler which receives a copy of all data written to
+   * the port, independently of the log file dump; used by the port
+   * monitor dialog to display outgoing data.  Pass nullptr to
+   * remove the handler.
+   */
+  void SetWriteMonitor(DataHandler *monitor) noexcept {
+    write_monitor = monitor;
   }
 
   Port &GetInnerPort() noexcept {

--- a/src/Dialogs/Device/DeviceListDialog.cpp
+++ b/src/Dialogs/Device/DeviceListDialog.cpp
@@ -47,6 +47,11 @@
 #include "Android/BluetoothHelper.hpp"
 #endif
 
+#ifdef HAVE_APPLE_BLUETOOTH
+#include "Apple/Services.hpp"
+#include "Apple/BluetoothHelper.hpp"
+#endif
+
 using namespace UI;
 
 class DeviceListWidget final
@@ -74,7 +79,7 @@ class DeviceListWidget final
     bool engine:1;
     bool debug:1;
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
     bool bluetooth_disabled:1;
 #else
     static constexpr bool bluetooth_disabled = false;
@@ -143,6 +148,10 @@ class DeviceListWidget final
       bluetooth_disabled = config.IsAndroidBluetooth() &&
         bluetooth_helper != nullptr &&
         !bluetooth_helper->IsEnabled(Java::GetEnv());
+#elif defined(HAVE_APPLE_BLUETOOTH)
+      bluetooth_disabled = config.IsAppleBluetooth() &&
+        bluetooth_helper != nullptr &&
+        !bluetooth_helper->IsEnabled();
 #endif
 
       battery_percent = basic.battery_level_available
@@ -582,6 +591,16 @@ DeviceListWidget::ReconnectCurrent()
        config.port_type == DeviceConfig::PortType::RFCOMM_SERVER) &&
       bluetooth_helper != nullptr &&
       !bluetooth_helper->IsEnabled(Java::GetEnv())) {
+    ShowMessageBox(_("Bluetooth is disabled"), _("Reconnect"),
+                   MB_OK | MB_ICONERROR);
+    return;
+  }
+#elif defined(HAVE_APPLE_BLUETOOTH)
+  const DeviceConfig &config =
+    CommonInterface::SetSystemSettings().devices[current];
+  if (config.IsAppleBluetooth() &&
+      bluetooth_helper != nullptr &&
+      !bluetooth_helper->IsEnabled()) {
     ShowMessageBox(_("Bluetooth is disabled"), _("Reconnect"),
                    MB_OK | MB_ICONERROR);
     return;

--- a/src/Dialogs/Device/PortDataField.cpp
+++ b/src/Dialogs/Device/PortDataField.cpp
@@ -25,6 +25,11 @@
 #include "Device/Port/AndroidIOIOUartPort.hpp"
 #endif
 
+#ifdef HAVE_APPLE_BLUETOOTH
+#include "Apple/Services.hpp"
+#include "Apple/BluetoothHelper.hpp"
+#endif
+
 static constexpr struct {
   DeviceConfig::PortType type;
   const char *label;
@@ -212,6 +217,9 @@ SetBluetoothPort(DataFieldEnum &df, DeviceConfig::PortType type,
     if (bluetooth_helper != nullptr)
       name = bluetooth_helper->GetNameFromAddress(Java::GetEnv(),
                                                   bluetooth_mac);
+#elif defined(HAVE_APPLE_BLUETOOTH)
+    if (bluetooth_helper != nullptr)
+      name = bluetooth_helper->GetNameFromAddress(bluetooth_mac);
 #endif
     df.SetValue(AddPort(df, type, bluetooth_mac, name));
   }

--- a/src/Dialogs/Device/PortPicker.cpp
+++ b/src/Dialogs/Device/PortPicker.cpp
@@ -13,6 +13,7 @@
 #include "ui/event/Notify.hpp"
 #include "Language/Language.hpp"
 #include "UIGlobals.hpp"
+#include "Device/Features.hpp"
 
 #ifdef ANDROID
 #include "java/Global.hxx"
@@ -20,6 +21,15 @@
 #include "Android/BluetoothHelper.hpp"
 #include "Android/UsbSerialHelper.hpp"
 #include "Android/DetectDeviceListener.hpp"
+#endif
+
+#ifdef HAVE_APPLE_BLUETOOTH
+#include "Apple/Services.hpp"
+#include "Apple/BluetoothHelper.hpp"
+#include "Apple/DetectDeviceListener.hpp"
+#endif
+
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
 #include "thread/Mutex.hxx"
 #include <list>
 #endif
@@ -66,7 +76,7 @@ private:
 
 class PortPickerWidget
   : public ListWidget
-#ifdef ANDROID
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
   , DetectDeviceListener
 #endif
 {
@@ -81,7 +91,9 @@ class PortPickerWidget
 #ifdef ANDROID
   Java::LocalObject detect_listener;
   Java::LocalObject usb_serial_detect_listener;
+#endif
 
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
   struct DetectedPort {
     DeviceConfig::PortType type;
     std::string address, name;
@@ -138,6 +150,11 @@ public:
   void Show(const PixelRect &rc) noexcept override {
     ListWidget::Show(rc);
 
+#ifdef HAVE_APPLE_BLUETOOTH
+    if (bluetooth_helper != nullptr)
+      bluetooth_helper->AddDetectDeviceListener(*this);
+#endif
+
 #ifdef ANDROID
     if (bluetooth_helper != nullptr) {
       const auto env = Java::GetEnv();
@@ -155,6 +172,11 @@ public:
   }
 
   void Hide() noexcept override {
+#ifdef HAVE_APPLE_BLUETOOTH
+    if (bluetooth_helper != nullptr)
+      bluetooth_helper->RemoveDetectDeviceListener(*this);
+#endif
+
 #ifdef ANDROID
     if (detect_listener) {
       bluetooth_helper->RemoveDetectDeviceListener(detect_listener.GetEnv(),
@@ -187,7 +209,7 @@ public:
     dialog.SetModalResult(mrOK);
   }
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
 private:
   /* virtual methods from class DetectDeviceListener */
   void OnDeviceDetected(Type type, const char *address,
@@ -218,7 +240,7 @@ PortPickerWidget::ReloadComboList() noexcept
   list.Invalidate();
 }
 
-#ifdef ANDROID
+#if defined(ANDROID) || defined(HAVE_APPLE_BLUETOOTH)
 
 void
 PortPickerWidget::OnDeviceDetected(Type type, const char *address,

--- a/src/Startup.cpp
+++ b/src/Startup.cpp
@@ -525,6 +525,9 @@ Startup(UI::Display &display)
     *context, permission_manager,
     bluetooth_helper, ioio_helper, usb_serial_helper,
 #endif
+#ifdef HAVE_APPLE_BLUETOOTH
+    bluetooth_helper,
+#endif
   };
 
   backend_components->devices = std::make_unique<MultipleDevices>(*backend_components->device_blackboard,

--- a/test/src/FakeAppleBluetooth.cpp
+++ b/test/src/FakeAppleBluetooth.cpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+/* Stubs for the iOS Bluetooth LE support: the test programs link
+   Device/Config.cpp and Device/Port/ConfiguredPort.cpp, which refer
+   to these symbols on iOS (including the simulator), but the
+   CoreBluetooth implementation is not part of the test binaries. */
+
+#include "Device/Features.hpp"
+
+#ifdef HAVE_APPLE_BLUETOOTH
+
+#include "Apple/BluetoothHelper.hpp"
+#include "Device/Port/AppleBluetoothPort.hpp"
+
+BluetoothHelper *bluetooth_helper;
+
+const char *
+BluetoothHelper::GetNameFromAddress(const char *) const noexcept
+{
+  return nullptr;
+}
+
+std::unique_ptr<Port>
+OpenAppleBleSerialPort(BluetoothHelper &, const char *,
+                       PortListener *, DataHandler &)
+{
+  /* never reached: the test programs leave bluetooth_helper at
+     nullptr, so ConfiguredPort fails before calling this */
+  return nullptr;
+}
+
+#endif


### PR DESCRIPTION
This is the successor of #1824 for #1815. I closed the old PR so the long thread there does not get flooded any further. The commits are regrouped, without fixups, one topic per commit.

@yorickreum, I have cleaned up the branch and am now fairly far along with the iOS Bluetooth changes. I will test it again on the old FLARM devices at the airfield in the next few days, at the latest on the weekend.

What is included:

- Bluetooth LE support on iOS via CoreBluetooth: device discovery in the port picker and serial port connections over HM-10, Nordic UART, Microchip/ISSC and compatible bridges. The iOS Bluetooth code is behind a dedicated `HAVE_APPLE_BLUETOOTH` feature macro so the macOS test programs still link.
- The `bluetooth-central` background mode, so connections and transfers survive a brief switch to the background.
- The port monitor now also shows the data written to the device.
- Two small build fixes for Apple Silicon hosts and the iOS simulator.
- A more robust FLARM flight download over slow links: wait for the connection before entering binary mode, longer timeouts, retries when selecting a flight, detection of stalled frames, and an automatic restart of an interrupted download which skips the already saved part.
- XCVario allows a second driver, so the flights of a FLARM connected behind it can be downloaded.

I am not sure whether the FLARM changes could cause problems with other devices or connection types. Someone with more expertise should review and test them thoroughly. As far as I can judge on iOS, the flight download works considerably better with them than before.

The code contains quite a lot of new log output (`LogFormat`). Some of it is already limited to debug builds with `#ifndef NDEBUG`.

Closes #1815.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS Bluetooth LE device discovery and serial connections for HM-10, Nordic UART, Microchip/ISSC, and compatible devices.
  * Bluetooth connections and transfers can continue while the iOS app is briefly backgrounded.
  * Added support for downloading FLARM flights through XCVario pass-through connections.
  * Port monitoring now displays data sent to connected devices.

* **Bug Fixes**
  * Improved FLARM downloads over slow or interrupted connections with retries, reconnection, and resume support.
  * Improved Bluetooth connection handling and device name display on iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->