### PR TITLE
Task: Add more nodes along edge of circular OZ

### DIFF
--- a/src/Engine/Task/ObservationZones/Boundary.cpp
+++ b/src/Engine/Task/ObservationZones/Boundary.cpp
@@ -4,11 +4,13 @@
 #include "Boundary.hpp"
 #include "Geo/GeoVector.hpp"
 
+#include <algorithm>
+
 void
 OZBoundary::GenerateArcExcluding(const GeoPoint &center, double radius,
                                  Angle start_radial, Angle end_radial) noexcept
 {
-  const unsigned steps = 20;
+  const unsigned steps = std::max(20,std::min(360, (int) (radius / 25)));
   const Angle delta = Angle::FullCircle() / steps;
   const Angle start = start_radial.AsBearing();
   Angle end = end_radial.AsBearing();

--- a/src/Engine/Task/ObservationZones/CylinderZone.cpp
+++ b/src/Engine/Task/ObservationZones/CylinderZone.cpp
@@ -20,7 +20,7 @@ CylinderZone::GetBoundary() const noexcept
 {
   OZBoundary boundary;
 
-  const unsigned steps = 20;
+  const unsigned steps = std::max(20,std::min(360, (int)(GetRadius() / 25)));
   const auto delta = Angle::FullCircle() / steps;
 
   GeoVector vector(GetRadius(), Angle::Zero());


### PR DESCRIPTION
This allow the Dijkstra algorithm to return more precise min distances and aiming points. Fixes #3077.

The maximum number of nodes is set to 360. There doesn't seems to be any performance impact on Linux on a laptop. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the accuracy and smoothness of circular observation-zone boundaries by adapting detail levels to the zone size.
  * Large-radius zones now render with more boundary segments, while smaller zones retain efficient rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->