### PR TITLE
Task: navigate to the nearest point of the start and finish

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -58,6 +58,10 @@ Version 7.46 - not yet released
 * airspace
   - fill airspaces with a transparent colour; hatch patterns and the
     Airspace transparency setting are gone
+* task
+  - add a "Navigate to nearest point" task rule: aim at the start and
+    finish zone where the glider is going to cross it, not where the
+    task is shortest; off by default #2388
 * FLARM
   - fix ADS-B traffic ground speed wrapping above 457 km/h #2887
   - fix no-position targets missing from the radar and map #2847

--- a/doc/manual/en/ch04_xc_tasks.tex
+++ b/doc/manual/en/ch04_xc_tasks.tex
@@ -362,6 +362,9 @@ type allows the pilot to enter the following parameters
   \item [Arm start manually] If set to ``On'', some extra buttons are presented
   in order to let you \bmenug{Arm start} as well as \bmenug{Disarm start} in
   menu \bmenug{Nav 1/2}, controlling  the detection of the start condition.
+  \item [Navigate to nearest point] If set to ``On'', XCSoar aims at
+  the nearest point of the start and finish zone instead of the point
+  which makes the task shortest.  See Section~\ref{sec:task-rules}.
   \item [Start open time] This is the time when the start zone opens.
   \item [Start close time] This is the time when the start zone closes.
   \item [Start max.\ speed] This is the maximum speed allowed in the start observation
@@ -505,6 +508,25 @@ the configuration \config{taskrules} settings in
 For non-AAT tasks, an option is available to set the minimum finish
 altitude according to the FAI rule, whereby the minimum finish
 altitude is above 1000~meters below the start altitude.
+
+The page ``Task Rules'' also carries the option ``Navigate to nearest
+point'', which is ``Off'' by default.  Normally XCSoar aims at the
+point of the start and finish zone which makes the task shortest, on a
+line its centre.  While the option is set, it aims at the nearest point
+of the zone instead, which moves as the glider moves, so the distance,
+the estimated time and the arrival height describe the place the glider
+is going to cross.  Task distance, its optimisation and scoring are
+unchanged.  A sector is left alone, and so is a cylinder the glider is
+already inside, where the nearest point of the rim is the wrong way
+out.
+
+The arrival height is measured against the elevation of the waypoint,
+which is not necessarily the elevation under the nearest point.
+
+The option is stored in the task.  The ``Task Rules'' page sets the
+default for new tasks and for a task read from a file which carries no
+such attribute; the ``Rules'' page of the task manager changes the task
+in use.
 
 
 \section{Start a task}\label{sec:start-task}

--- a/doc/task_file.rst
+++ b/doc/task_file.rst
@@ -80,6 +80,14 @@ the two start gate times, which are omitted when no gate is set.
    Minimum task time in **seconds**, as an integer.  Only meaningful for
    ``AAT`` and ``MAT``.
 
+``navigate_nearest``
+   ``0`` or ``1``.  Whether navigation to the start and to the finish
+   aims at the nearest point of their zone rather than at the point
+   which makes the task shortest.  Lines and cylinders honour it;
+   sectors and keyholes ignore it, and so does a cylinder the glider is
+   already inside.  Scoring and the planned task distance are not
+   affected.
+
 ``start_requires_arm``
    ``0`` or ``1``.  Whether the start has to be armed manually.
 
@@ -321,8 +329,9 @@ here.  They do not, and there is nothing in ``.tsk`` to map them onto:
    (``src/Device/Driver/LX/LXNavDeclare.hpp``), derived at declaration
    time, not something read back from or stored in the task file.
 
-Keep both out of converters: a ``.tsk`` that grew a ``near`` attribute
-would be silently ignored by XCSoar and misleading to everyone else.
+Keep both out of converters.  What XCSoar itself aims at is
+``navigate_nearest`` above; a ``.tsk`` that grew a ``near`` attribute
+would be silently ignored and misleading to everyone else.
 
 A complete example
 ------------------
@@ -334,8 +343,8 @@ sector, as XCSoar writes it::
          finish_min_height_ref="AGL" finish_min_height="0"
          start_close_time="16:00" start_open_time="11:30"
          start_max_height_ref="AGL" start_max_height="0" start_max_speed="0"
-         start_score_exit="1" start_requires_arm="0" aat_min_time="10800"
-         type="RT">
+         start_score_exit="1" start_requires_arm="0"
+         navigate_nearest="0" aat_min_time="10800" type="RT">
    	<Point type="Start">
    		<Waypoint altitude="187" comment="" id="1" name="Aachen Merzbrueck">
    			<Location latitude="50.8231" longitude="6.18639"/>

--- a/po/bg.po
+++ b/po/bg.po
@@ -4460,6 +4460,12 @@ msgstr "Стартовата височина е спрямо"
 msgid "Reference used for start max height rule."
 msgstr "Височина използвана като правило за макс. стартова стойност."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Мин. финална височина"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -4468,6 +4468,12 @@ msgstr "Ref. altitudinici"
 msgid "Reference used for start max height rule."
 msgstr "Referència utilitzada per la regla d'alçada màxima de partida."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Altitud mínima final"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -4421,6 +4421,12 @@ msgstr "Reference startovní výšky"
 msgid "Reference used for start max height rule."
 msgstr "Reference použitá pro pravidlo maximální výšky."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Min. výška v cíli"
 

--- a/po/da.po
+++ b/po/da.po
@@ -4416,6 +4416,12 @@ msgstr "Starthøjhedsindeks"
 msgid "Reference used for start max height rule."
 msgstr "Indeks brugt for startmaksimumshøjde-reglen."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Slutminimumshøjde"
 

--- a/po/de.po
+++ b/po/de.po
@@ -4464,6 +4464,12 @@ msgstr "Abflughöhe bezogen auf"
 msgid "Reference used for start max height rule."
 msgstr "Bezug für die Regel über die max. Abflughöhe."
 
+msgid "Navigate to nearest point"
+msgstr "Zum nächstgelegenen Punkt navigieren"
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr "Navigiert zum nächstgelegenen Punkt der Abflug- und Zielzone."
+
 msgid "Finish min. height"
 msgstr "Min. Ankunftshöhe"
 

--- a/po/el.po
+++ b/po/el.po
@@ -4490,6 +4490,12 @@ msgstr "Αναφορά αρχικού ύψ."
 msgid "Reference used for start max height rule."
 msgstr "Αναφέρεται για την αρχική περιοχή ωρολόγιας μέγιστης."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Μέγιστη ωρολόγια βάθους"
 

--- a/po/es.po
+++ b/po/es.po
@@ -4489,6 +4489,12 @@ msgstr "Ref. de alt. de Salida"
 msgid "Reference used for start max height rule."
 msgstr "Referencia utilizada para la regla de altura máxima de salida."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Altura min. de meta"
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -4421,6 +4421,12 @@ msgstr "Aloituskorkeustasainen viite"
 msgid "Reference used for start max height rule."
 msgstr "Korkeustasainen sääntö aloitusmaxiimikorkeudelle."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Loppuminimi korkeus"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -4475,6 +4475,12 @@ msgstr "Réf. hauteur départ"
 msgid "Reference used for start max height rule."
 msgstr "Référence utilisée par la règle de hauteur max. de départ."
 
+msgid "Navigate to nearest point"
+msgstr "Naviguer vers le point le plus proche"
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr "Navigue vers le point le plus proche des zones de départ et d'arrivée."
+
 msgid "Finish min. height"
 msgstr "Hauteur min. d'arrivée"
 

--- a/po/he.po
+++ b/po/he.po
@@ -4455,6 +4455,12 @@ msgstr "בסיס ההתחלה"
 msgid "Reference used for start max height rule."
 msgstr "הבסיס משמש עבור חוק maksימלי של הגובה של התחלה."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "הגובה המינימלי הסופי"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -4422,6 +4422,12 @@ msgstr "Referenca za početnu visinu"
 msgid "Reference used for start max height rule."
 msgstr "Koristena referenca za pravilo maksimalne visine početka."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Minimalna visina završetka"
 

--- a/po/hu.po
+++ b/po/hu.po
@@ -4424,6 +4424,12 @@ msgstr "Start magasság referencia"
 msgid "Reference used for start max height rule."
 msgstr "A maximális startmagassághoz használt referencia."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Cél min magasság"
 

--- a/po/it.po
+++ b/po/it.po
@@ -4479,6 +4479,12 @@ msgid "Reference used for start max height rule."
 msgstr ""
 "Altitudine di riferimento per la regola di massima altezza di partenza."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Altezza minima di arrivo"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -4430,6 +4430,12 @@ msgstr "スタート高度設定"
 msgid "Reference used for start max height rule."
 msgstr "最高出発高度ルールの値"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "フィニッシュ最低高度"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -4363,6 +4363,12 @@ msgstr ""
 "최고 스타트 고도(시작 포인트의 고도상승한계)에 사용하는 고도측정 방식을 선택"
 "한다."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "최종골 최저고도"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -4443,6 +4443,12 @@ msgstr "Pradžios lygis atsižvelgiant į"
 msgid "Reference used for start max height rule."
 msgstr "Naudoti pradžios maksimalaus lygio taisyklėse"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Baigimo minimalus lygis"
 

--- a/po/nb.po
+++ b/po/nb.po
@@ -4404,6 +4404,12 @@ msgstr "Starthøyderef."
 msgid "Reference used for start max height rule."
 msgstr "Referanse brukes for start maksimalhøyde-regel."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Mål min. høyde"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -4463,6 +4463,12 @@ msgstr "Starthoogte ref."
 msgid "Reference used for start max height rule."
 msgstr "Referentie die gebruikt wordt voor de start max hoogte regel."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Finish min hoogte"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -4447,6 +4447,12 @@ msgstr "Poziom odn. odejścia"
 msgid "Reference used for start max height rule."
 msgstr "Poz.odn. użyto do wyznaczenia maks.wys.startu."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Min. wysok. na mecie"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -4443,6 +4443,12 @@ msgstr "Ref altura largada"
 msgid "Reference used for start max height rule."
 msgstr "Referência usada para regra máxima de altura inicial."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Altura mín chegada"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4444,6 +4444,12 @@ msgstr "Ref altura largada"
 msgid "Reference used for start max height rule."
 msgstr "Referência usada para regra máxima de altura inicial."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Altura mín chegada"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -4465,6 +4465,12 @@ msgstr "Înalțime de referință la început"
 msgid "Reference used for start max height rule."
 msgstr "Referința folosită pentru regulă maximă de înălțime la început."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Înalțime minima la finalizare"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -4453,6 +4453,12 @@ msgstr "Привязка высоты старта"
 msgid "Reference used for start max height rule."
 msgstr "Привязка, которая используется в правилах макс. высоты старта."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Мин. высота на финише"
 

--- a/po/sk.po
+++ b/po/sk.po
@@ -4423,6 +4423,12 @@ msgstr "Štartová výška ref."
 msgid "Reference used for start max height rule."
 msgstr "Referencia použitá pre pravidlo maximálnej štartovej výšky."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Minimálna výška príletu"
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -4432,6 +4432,12 @@ msgstr "Referenca za višino pri začetku"
 msgid "Reference used for start max height rule."
 msgstr "Odvzeto začetno maksimalno višino"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Končna minimalna višina"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -4423,6 +4423,12 @@ msgstr "Referenca za visinu početka"
 msgid "Reference used for start max height rule."
 msgstr "Referenca koristena za pravilo maksimalne dozvoljene visine početka"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Minimalna dozvoljena visina završetka"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -4381,6 +4381,12 @@ msgstr "Starthöjd referens"
 msgid "Reference used for start max height rule."
 msgstr "Referens för max starthöjd enligt regler."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Min målgångshöjd"
 

--- a/po/te.po
+++ b/po/te.po
@@ -4321,6 +4321,12 @@ msgstr "ప్రారంభ ఊరు ఉత్తరం"
 msgid "Reference used for start max height rule."
 msgstr "ప్రారంభ మేగిన ఉత్తమ ఊరు నిలిచడానికి ఉపయోగించాలనున్న ఉత్తరం"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "అవధి మార్గ నిలిచడం"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -4424,6 +4424,12 @@ msgstr "Başlangıç yükseklik referansı"
 msgid "Reference used for start max height rule."
 msgstr "Başlangıç maksimum yükseklik kuralı için kullanılan referans."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Bitiş minimum yükseklik"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -4444,6 +4444,12 @@ msgstr "Прив'язка висоти старту"
 msgid "Reference used for start max height rule."
 msgstr "Прив'язка, що використовується в правилах макс. висоти старту."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Мін. висота на фініші"
 

--- a/po/vi.po
+++ b/po/vi.po
@@ -4406,6 +4406,12 @@ msgstr "Chiều cao tham chiếu khởi động"
 msgid "Reference used for start max height rule."
 msgstr "Tham chiếu được sử dụng cho quy tắc chiều cao tối đa khởi động."
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "Chiều cao tối thiểu hoàn thành"
 

--- a/po/xcsoar.pot
+++ b/po/xcsoar.pot
@@ -5555,6 +5555,12 @@ msgstr ""
 msgid "Reference used for start max height rule."
 msgstr ""
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4280,6 +4280,12 @@ msgstr "开始参考高度。"
 msgid "Reference used for start max height rule."
 msgstr "参考用于开始的最大高度规则。"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "最终滑翔最小高度"
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -4279,6 +4279,12 @@ msgstr "開始參考高度。"
 msgid "Reference used for start max height rule."
 msgstr "參考用於開始的最大高度規則。"
 
+msgid "Navigate to nearest point"
+msgstr ""
+
+msgid "Navigate to the nearest point of the start and finish zones."
+msgstr ""
+
 msgid "Finish min. height"
 msgstr "最終滑翔最小高度"
 

--- a/src/Computer/WaveComputer.cpp
+++ b/src/Computer/WaveComputer.cpp
@@ -100,20 +100,6 @@ IsRatioInRange(double ratio) noexcept
   return ratio > -0.1 && ratio < 1.1;
 }
 
-/**
- * Wrapper for FlatLine::Interpolate() which will clip the ratio to
- * [0..1] so the result stays within the [a..b] bounds.
- */
-static constexpr FlatPoint
-InterpolateClip(const FlatLine line, double ratio) noexcept
-{
-  return ratio <= 0
-    ? line.a
-    : (ratio >= 1
-       ? line.b
-       : line.Interpolate(ratio));
-}
-
 struct RatioAndDistance {
   double ratio, squared_distance;
 };
@@ -124,7 +110,7 @@ CalcRatioAndDistance(const FlatLine line, const FlatPoint point) noexcept
 {
   RatioAndDistance result;
   result.ratio = line.ProjectedRatio(point);
-  FlatPoint projected = InterpolateClip(line, result.ratio);
+  FlatPoint projected = line.InterpolateClip(result.ratio);
   result.squared_distance = (point - projected).MagnitudeSquared();
   return result;
 }

--- a/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/TaskRulesConfigPanel.cpp
@@ -18,6 +18,7 @@ enum ControlIndex {
   StartMaxHeight,
   StartMaxHeightMargin,
   StartHeightRef,
+  NavigateNearest,
   spacer_2,
   FinishMinHeight,
   FinishHeightRef,
@@ -86,6 +87,11 @@ TaskRulesConfigPanel::Prepare(ContainerWindow &parent,
           (unsigned)task_behaviour.ordered_defaults.start_constraints.max_height_ref);
   SetExpertRow(StartHeightRef);
 
+  AddBoolean(_("Navigate to nearest point"),
+             _("Navigate to the nearest point of the start and finish zones."),
+             task_behaviour.ordered_defaults.navigate_nearest);
+  SetExpertRow(NavigateNearest);
+
   AddSpacer();
   SetExpertRow(spacer_2);
 
@@ -147,6 +153,9 @@ TaskRulesConfigPanel::Save(bool &_changed) noexcept
 
   changed |= SaveValueEnum(StartHeightRef, ProfileKeys::StartHeightRef,
                            otb.start_constraints.max_height_ref);
+
+  changed |= SaveValue(NavigateNearest, ProfileKeys::NavigateNearest,
+                       otb.navigate_nearest);
 
   changed |= SaveValue(FinishMinHeight, UnitGroup::ALTITUDE,
                        ProfileKeys::FinishMinHeight,

--- a/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
+++ b/src/Dialogs/Task/Manager/TaskPropertiesPanel.cpp
@@ -19,6 +19,7 @@ enum Controls {
   MIN_TIME,
   START_REQUIRES_ARM,
   START_SCORE_EXIT,
+  NAVIGATE_NEAREST,
   START_OPEN_TIME,
   START_CLOSE_TIME,
   START_MAX_SPEED,
@@ -54,6 +55,7 @@ TaskPropertiesPanel::RefreshView()
 
   LoadValue(START_REQUIRES_ARM, p.start_constraints.require_arm);
   LoadValue(START_SCORE_EXIT, p.start_constraints.score_exit);
+  LoadValue(NAVIGATE_NEAREST, p.navigate_nearest);
 
   LoadValue(START_OPEN_TIME, p.start_constraints.open_time_span.GetRoughStart());
   LoadValue(START_CLOSE_TIME, p.start_constraints.open_time_span.GetRoughEnd());
@@ -109,6 +111,7 @@ TaskPropertiesPanel::ReadValues()
     changed = true;
 
   changed |= SaveValue(START_SCORE_EXIT, p.start_constraints.score_exit);
+  changed |= SaveValue(NAVIGATE_NEAREST, p.navigate_nearest);
 
   RoughTime new_open = p.start_constraints.open_time_span.GetRoughStart();
   RoughTime new_close = p.start_constraints.open_time_span.GetRoughEnd();
@@ -218,6 +221,10 @@ TaskPropertiesPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
              false);
 
   AddBoolean(_("Score start exit"), nullptr, false);
+
+  AddBoolean(_("Navigate to nearest point"),
+             _("Navigate to the nearest point of the start and finish zones."),
+             false);
 
   const RoughTimeDelta time_zone =
     CommonInterface::GetComputerSettings().utc_offset;

--- a/src/Engine/Task/AbstractTask.cpp
+++ b/src/Engine/Task/AbstractTask.cpp
@@ -120,7 +120,7 @@ AbstractTask::UpdateStatsDistances(const GeoPoint &location,
 
   const TaskPoint *active = GetActiveTaskPoint();
   if (active != NULL) {
-    stats.current_leg.location_remaining = active->GetLocationRemaining();
+    stats.current_leg.location_remaining = active->GetLocationNavigation();
     stats.current_leg.vector_remaining = active->GetVectorRemaining(location);
     stats.current_leg.next_leg_vector = active->GetNextLegVector();
   } else {

--- a/src/Engine/Task/ObservationZones/CylinderZone.cpp
+++ b/src/Engine/Task/ObservationZones/CylinderZone.cpp
@@ -15,6 +15,21 @@ CylinderZone::ScoreAdjustment() const noexcept
   return radius;
 }
 
+GeoPoint
+CylinderZone::GetNearestPoint(const FlatProjection &,
+                              const GeoPoint &location) const noexcept
+{
+  const GeoVector v{GetReference(), location};
+
+  /* inside the cylinder the nearest point of the rim is behind the
+     aircraft: for a start that is the wrong way out, away from the
+     next task point.  Leave those to the caller. */
+  if (v.distance <= radius)
+    return GeoPoint::Invalid();
+
+  return GeoVector{radius, v.bearing}.EndPoint(GetReference());
+}
+
 OZBoundary
 CylinderZone::GetBoundary() const noexcept
 {

--- a/src/Engine/Task/ObservationZones/CylinderZone.hpp
+++ b/src/Engine/Task/ObservationZones/CylinderZone.hpp
@@ -86,6 +86,9 @@ public:
   double ScoreAdjustment() const noexcept override;
 
   /* virtual methods from class ObservationZonePoint */
+  GeoPoint GetNearestPoint(const FlatProjection &projection,
+                           const GeoPoint &location) const noexcept override;
+
   bool Equals(const ObservationZonePoint &other) const noexcept override;
   GeoPoint GetRandomPointInSector(const double mag) const noexcept override;
 

--- a/src/Engine/Task/ObservationZones/LineSectorZone.cpp
+++ b/src/Engine/Task/ObservationZones/LineSectorZone.cpp
@@ -2,6 +2,25 @@
 // Copyright The XCSoar Project
 
 #include "LineSectorZone.hpp"
+#include "Geo/Flat/FlatLine.hpp"
+#include "Geo/Flat/FlatProjection.hpp"
+
+GeoPoint
+LineSectorZone::GetNearestPoint(const FlatProjection &projection,
+                                const GeoPoint &location) const noexcept
+{
+  const FlatLine line{projection.ProjectFloat(GetSectorStart()),
+                      projection.ProjectFloat(GetSectorEnd())};
+
+  /* SetLength() and the constructor are public: guard
+     ProjectedRatio() against a division by zero on a gate of zero
+     length */
+  if (line.GetSquaredDistance() <= 0)
+    return GeoPoint::Invalid();
+
+  const auto ratio = line.ProjectedRatio(projection.ProjectFloat(location));
+  return projection.Unproject(line.InterpolateClip(ratio));
+}
 
 double
 LineSectorZone::ScoreAdjustment() const noexcept

--- a/src/Engine/Task/ObservationZones/LineSectorZone.hpp
+++ b/src/Engine/Task/ObservationZones/LineSectorZone.hpp
@@ -62,6 +62,9 @@ public:
   double ScoreAdjustment() const noexcept override;
 
   /* virtual methods from class ObservationZonePoint */
+  GeoPoint GetNearestPoint(const FlatProjection &projection,
+                           const GeoPoint &location) const noexcept override;
+
   std::unique_ptr<ObservationZonePoint> Clone(const GeoPoint &_reference) const noexcept override {
     return std::make_unique<LineSectorZone>(*this, _reference);
   }

--- a/src/Engine/Task/ObservationZones/ObservationZonePoint.cpp
+++ b/src/Engine/Task/ObservationZones/ObservationZonePoint.cpp
@@ -3,6 +3,13 @@
 
 #include "ObservationZonePoint.hpp"
 
+GeoPoint
+ObservationZonePoint::GetNearestPoint(const FlatProjection &,
+                                      const GeoPoint &) const noexcept
+{
+  return GeoPoint::Invalid();
+}
+
 bool
 ObservationZonePoint::Equals(const ObservationZonePoint &other) const noexcept
 {

--- a/src/Engine/Task/ObservationZones/ObservationZonePoint.hpp
+++ b/src/Engine/Task/ObservationZones/ObservationZonePoint.hpp
@@ -8,6 +8,8 @@
 
 #include <memory>
 
+class FlatProjection;
+
 /**
  * \todo 
  * - add arc type for future use
@@ -42,6 +44,20 @@ public:
    */
   virtual void SetLegs([[maybe_unused]] const GeoPoint *previous,
                        [[maybe_unused]] const GeoPoint *next) noexcept {}
+
+  /**
+   * Calculate the point on the boundary of this observation zone
+   * which is nearest to the given location.  Not every shape
+   * implements this; the default returns an invalid location, and the
+   * caller falls back to the point the task refers to.
+   *
+   * @param projection the projection used by the task
+   * @param location the location to measure from
+   * @return the nearest point, or an invalid location
+   */
+  [[gnu::pure]]
+  virtual GeoPoint GetNearestPoint(const FlatProjection &projection,
+                                   const GeoPoint &location) const noexcept;
 
   /**
    * Test whether an OZ is equivalent to this one

--- a/src/Engine/Task/ObservationZones/SectorZone.hpp
+++ b/src/Engine/Task/ObservationZones/SectorZone.hpp
@@ -139,6 +139,18 @@ public:
   double ScoreAdjustment() const noexcept override;
 
   /* virtual methods from class ObservationZonePoint */
+
+  /**
+   * A sector covers only part of the circle, so the rim point
+   * CylinderZone returns can fall outside it.
+   *
+   * \todo implement the sector geometry
+   */
+  GeoPoint GetNearestPoint(const FlatProjection &,
+                           const GeoPoint &) const noexcept override {
+    return GeoPoint::Invalid();
+  }
+
   bool Equals(const ObservationZonePoint &other) const noexcept override;
   std::unique_ptr<ObservationZonePoint> Clone(const GeoPoint &_reference) const noexcept override {
     return std::make_unique<SectorZone>(*this, _reference);

--- a/src/Engine/Task/Ordered/OrderedTask.cpp
+++ b/src/Engine/Task/Ordered/OrderedTask.cpp
@@ -470,6 +470,12 @@ OrderedTask::CheckTransitions(const AircraftState &state,
   if (!n_task)
     return false;
 
+  if (active_task_point == 0)
+    taskpoint_start->UpdateNearestPoint(state.location, task_projection);
+  else if (taskpoint_finish != nullptr &&
+           (int)active_task_point == n_task - 1)
+    taskpoint_finish->UpdateNearestPoint(state.location, task_projection);
+
   FlatBoundingBox bb_last(task_projection.ProjectInteger(state_last.location),
                           1);
   FlatBoundingBox bb_now(task_projection.ProjectInteger(state.location),

--- a/src/Engine/Task/Ordered/Points/FinishPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/FinishPoint.cpp
@@ -2,6 +2,8 @@
 // Copyright The XCSoar Project
 
 #include "FinishPoint.hpp"
+#include "Task/Ordered/Settings.hpp"
+#include "Task/ObservationZones/ObservationZonePoint.hpp"
 #include "Task/TaskBehaviour.hpp"
 
 #include <stdlib.h>

--- a/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
@@ -132,39 +132,48 @@ OrderedTaskPoint::Clone(const TaskBehaviour &task_behaviour,
   if (!waypoint)
     waypoint = GetWaypointPtr();
 
+  std::unique_ptr<OrderedTaskPoint> dest;
+
   switch (GetType()) {
   case TaskPointType::START:
-    return std::make_unique<StartPoint>(GetObservationZone().Clone(waypoint->location),
-                                        std::move(waypoint), task_behaviour,
-                                        ordered_task_settings.start_constraints);
+    dest =
+      std::make_unique<StartPoint>(GetObservationZone().Clone(waypoint->location),
+                                   std::move(waypoint), task_behaviour,
+                                   ordered_task_settings.start_constraints);
+    break;
 
   case TaskPointType::AST: {
     const ASTPoint &src = *(const ASTPoint *)this;
-    auto dest =
+    auto ast =
       std::make_unique<ASTPoint>(GetObservationZone().Clone(waypoint->location),
                    std::move(waypoint), task_behaviour, IsBoundaryScored());
-    dest->SetScoreExit(src.GetScoreExit());
-    return dest;
+    ast->SetScoreExit(src.GetScoreExit());
+    dest = std::move(ast);
+    break;
   }
 
   case TaskPointType::AAT:
-    return std::make_unique<AATPoint>(GetObservationZone().Clone(waypoint->location),
-                                      std::move(waypoint), task_behaviour);
+    dest =
+      std::make_unique<AATPoint>(GetObservationZone().Clone(waypoint->location),
+                                 std::move(waypoint), task_behaviour);
+    break;
 
   case TaskPointType::FINISH:
-    return std::make_unique<FinishPoint>(GetObservationZone().Clone(waypoint->location),
-                                         std::move(waypoint), task_behaviour,
-                                         ordered_task_settings.finish_constraints,
-                                         IsBoundaryScored());
+    dest =
+      std::make_unique<FinishPoint>(GetObservationZone().Clone(waypoint->location),
+                                    std::move(waypoint), task_behaviour,
+                                    ordered_task_settings.finish_constraints,
+                                    IsBoundaryScored());
+    break;
 
   case TaskPointType::UNORDERED:
     /* an OrderedTaskPoint must never be UNORDERED */
     gcc_unreachable();
     assert(false);
-    break;
+    return nullptr;
   }
 
-  return NULL;
+  return dest;
 }
 
 void

--- a/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/OrderedTaskPoint.cpp
@@ -6,6 +6,7 @@
 #include "ASTPoint.hpp"
 #include "AATPoint.hpp"
 #include "FinishPoint.hpp"
+#include "Task/Ordered/Settings.hpp"
 #include "Task/ObservationZones/ObservationZonePoint.hpp"
 #include "Task/ObservationZones/Boundary.hpp"
 #include "Geo/GeoBounds.hpp"
@@ -24,6 +25,41 @@ OrderedTaskPoint::OrderedTaskPoint(TaskPointType _type,
    ScoredTaskPoint(GetLocation(), b_scored),
    ObservationZoneClient(std::move(_oz))
 {
+}
+
+void
+OrderedTaskPoint::SetOrderedTaskSettings(const OrderedTaskSettings &otb) noexcept
+{
+  navigate_nearest = otb.navigate_nearest;
+
+  if (!navigate_nearest)
+    nearest_point = GeoPoint::Invalid();
+}
+
+const GeoPoint &
+OrderedTaskPoint::GetLocationNavigation() const noexcept
+{
+  /* the nearest point is only meaningful while the aircraft is still
+     heading for this task point */
+  return active_state == CURRENT_ACTIVE && nearest_point.IsValid()
+    ? nearest_point
+    : TaskPoint::GetLocationNavigation();
+}
+
+void
+OrderedTaskPoint::UpdateNearestPoint(const GeoPoint &location,
+                                     const FlatProjection &projection) noexcept
+{
+  nearest_point = navigate_nearest
+    ? GetObservationZone().GetNearestPoint(projection, location)
+    : GeoPoint::Invalid();
+}
+
+void
+OrderedTaskPoint::Reset() noexcept
+{
+  ScoredTaskPoint::Reset();
+  nearest_point = GeoPoint::Invalid();
 }
 
 void
@@ -173,6 +209,9 @@ OrderedTaskPoint::Clone(const TaskBehaviour &task_behaviour,
     return nullptr;
   }
 
+  /* the constructors take the start and finish constraints, but not
+     the settings which apply to every task point */
+  dest->SetOrderedTaskSettings(ordered_task_settings);
   return dest;
 }
 

--- a/src/Engine/Task/Ordered/Points/OrderedTaskPoint.hpp
+++ b/src/Engine/Task/Ordered/Points/OrderedTaskPoint.hpp
@@ -53,6 +53,20 @@ private:
   OrderedTaskPoint *tp_previous = nullptr;
   FlatBoundingBox flat_bb{}; // empty, not initialised
 
+  /**
+   * A copy of OrderedTaskSettings::navigate_nearest, managed by
+   * SetOrderedTaskSettings().
+   */
+  bool navigate_nearest = false;
+
+  /**
+   * The point of the observation zone nearest to the aircraft, or an
+   * invalid location when navigation refers to the point the task
+   * refers to.  Only OrderedTask fills this in, and only for the start
+   * and the finish.
+   */
+  GeoPoint nearest_point = GeoPoint::Invalid();
+
 public:
   /**
    * Constructor.
@@ -104,7 +118,17 @@ public:
   }
 
   virtual void SetTaskBehaviour([[maybe_unused]] const TaskBehaviour &tb) noexcept {}
-  virtual void SetOrderedTaskSettings([[maybe_unused]] const OrderedTaskSettings &otb) noexcept {}
+  virtual void SetOrderedTaskSettings(const OrderedTaskSettings &otb) noexcept;
+
+  /**
+   * Update the point navigation refers to, according to the current
+   * aircraft position and the OrderedTaskSettings.
+   *
+   * @param location the current aircraft location
+   * @param projection the projection used by the task
+   */
+  void UpdateNearestPoint(const GeoPoint &location,
+                          const FlatProjection &projection) noexcept;
 
   /**
    * Set previous/next task points.
@@ -272,10 +296,14 @@ public:
   const GeoPoint &GetLocationRemaining() const noexcept override {
     return ScoredTaskPoint::GetLocationRemaining();
   }
+  const GeoPoint &GetLocationNavigation() const noexcept override;
   GeoVector GetVectorRemaining(const GeoPoint &) const noexcept override {
     return TaskLeg::GetVectorRemaining();
   }
   GeoVector GetNextLegVector() const noexcept override;
+
+  /* virtual methods from class ScoredTaskPoint */
+  void Reset() noexcept override;
 
 protected:
   /* virtual methods from class ScoredTaskPoint */

--- a/src/Engine/Task/Ordered/Points/StartPoint.cpp
+++ b/src/Engine/Task/Ordered/Points/StartPoint.cpp
@@ -4,6 +4,7 @@
 #include "StartPoint.hpp"
 #include "Task/Ordered/Settings.hpp"
 #include "Task/ObservationZones/Boundary.hpp"
+#include "Task/ObservationZones/ObservationZonePoint.hpp"
 #include "Task/TaskBehaviour.hpp"
 #include "Geo/Math.hpp"
 

--- a/src/Engine/Task/Ordered/Settings.cpp
+++ b/src/Engine/Task/Ordered/Settings.cpp
@@ -7,6 +7,7 @@ void
 OrderedTaskSettings::SetDefaults()
 {
   aat_min_time = std::chrono::hours{3};
+  navigate_nearest = false;
   start_constraints.SetDefaults();
   finish_constraints.SetDefaults();
   fai_triangle.SetDefaults();

--- a/src/Engine/Task/Ordered/Settings.hpp
+++ b/src/Engine/Task/Ordered/Settings.hpp
@@ -17,6 +17,14 @@ struct OrderedTaskSettings {
   /** Desired AAT minimum task time (s) */
   std::chrono::duration<unsigned> aat_min_time;
 
+  /**
+   * Navigate to the point of the start and finish observation zones
+   * which is nearest to the aircraft, instead of the point the task
+   * refers to.  The shapes which do not implement
+   * ObservationZonePoint::GetNearestPoint() are left alone.
+   */
+  bool navigate_nearest;
+
   StartConstraints start_constraints;
   FinishConstraints finish_constraints;
 

--- a/src/Engine/Task/Points/TaskLeg.cpp
+++ b/src/Engine/Task/Points/TaskLeg.cpp
@@ -101,7 +101,7 @@ TaskLeg::GetRemainingVector(const GeoPoint &ref) const noexcept
         ? GeoVector::Zero()
         : GetPlannedVector();
 
-    return memo_remaining.calc(ref, destination.GetLocationRemaining());
+    return memo_remaining.calc(ref, destination.GetLocationNavigation());
   }
 
   case OrderedTaskPoint::BEFORE_ACTIVE:

--- a/src/Engine/Task/Points/TaskPoint.hpp
+++ b/src/Engine/Task/Points/TaskPoint.hpp
@@ -48,6 +48,20 @@ public:
   }
 
   /**
+   * Retrieve the location the aircraft is navigated to.  The current
+   * leg's remaining vector, the bearing line drawn on the map and
+   * TaskStats::current_leg::location_remaining use this; the planned,
+   * nominal, minimum, maximum and scored legs keep using
+   * GetLocationRemaining().
+   *
+   * @return Location
+   */
+  [[gnu::pure]]
+  virtual const GeoPoint &GetLocationNavigation() const noexcept {
+    return GetLocationRemaining();
+  }
+
+  /**
    * Calculate vector from aircraft to destination
    *
    * @return Vector for task leg

--- a/src/Engine/Task/Stats/ElementStat.hpp
+++ b/src/Engine/Task/Stats/ElementStat.hpp
@@ -20,7 +20,7 @@ struct ElementStat
 {
   /**
    * The remaining location, i.e. the result of
-   * ScoredTaskPoint::GetLocationRemaining().  Always check
+   * TaskPoint::GetLocationNavigation().  Always check
    * GeoPoint::IsValid() before using this attribute.  This is only
    * implemented for one leg (TaskStats::current_leg).
    */

--- a/src/Math/Line2D.hpp
+++ b/src/Math/Line2D.hpp
@@ -93,6 +93,16 @@ struct Line2D {
   }
 
   /**
+   * Like Interpolate(), but clip the ratio to [0..1], so the result
+   * is always between #a and #b.
+   */
+  constexpr Point InterpolateClip(double ratio) const {
+    return ratio <= 0
+      ? a
+      : (ratio >= 1 ? b : Interpolate(ratio));
+  }
+
+  /**
    * Calculate the position of the projection of #p onto this line,
    * expressed as ratio where 0=#a and 1=#b.
    */

--- a/src/Profile/Keys.hpp
+++ b/src/Profile/Keys.hpp
@@ -176,6 +176,7 @@ constexpr std::string_view TurnpointRadius = "TurnpointRadius";
 constexpr std::string_view FinishType = "FinishType";
 constexpr std::string_view FinishRadius = "FinishRadius";
 constexpr std::string_view TaskType = "TaskType";
+constexpr std::string_view NavigateNearest = "NavigateNearest";
 constexpr std::string_view AATMinTime = "AATMinTime";
 constexpr std::string_view AATTimeMargin = "AATTimeMargin";
 constexpr std::string_view PEVStartWaitTime = "PEVStartWaitTime";

--- a/src/Profile/TaskProfile.cpp
+++ b/src/Profile/TaskProfile.cpp
@@ -62,6 +62,7 @@ Profile::Load(const ProfileMap &map, OrderedTaskSettings &settings)
 {
   Load(map, settings.start_constraints);
   Load(map, settings.finish_constraints);
+  map.Get(ProfileKeys::NavigateNearest, settings.navigate_nearest);
   map.Get(ProfileKeys::AATMinTime, settings.aat_min_time);
 }
 

--- a/src/Renderer/TaskPointRenderer.cpp
+++ b/src/Renderer/TaskPointRenderer.cpp
@@ -95,7 +95,7 @@ TaskPointRenderer::DrawBearing(const TaskPoint &tp) noexcept
     return;
 
   canvas.Select(task_look.bearing_pen);
-  map_canvas.DrawLineWithOffset(location, tp.GetLocationRemaining());
+  map_canvas.DrawLineWithOffset(location, tp.GetLocationNavigation());
 }
 
 void

--- a/src/Task/Deserialiser.cpp
+++ b/src/Task/Deserialiser.cpp
@@ -253,6 +253,7 @@ static void
 Deserialise(OrderedTaskSettings &data, const ConstDataNode &node)
 {
   node.GetAttribute("aat_min_time", data.aat_min_time);
+  node.GetAttribute("navigate_nearest", data.navigate_nearest);
   node.GetAttribute("start_requires_arm",
                     data.start_constraints.require_arm);
   node.GetAttribute("start_score_exit",

--- a/src/Task/Serialiser.cpp
+++ b/src/Task/Serialiser.cpp
@@ -253,6 +253,7 @@ static void
 Serialise(WritableDataNode &node, const OrderedTaskSettings &data)
 {
   node.SetAttribute("aat_min_time", data.aat_min_time);
+  node.SetAttribute("navigate_nearest", data.navigate_nearest);
   node.SetAttribute("start_requires_arm",
                     data.start_constraints.require_arm);
   node.SetAttribute("start_score_exit",

--- a/test/src/TestOrderedTask.cpp
+++ b/test/src/TestOrderedTask.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Task/Ordered/Points/AATPoint.hpp"
 #include "Engine/Task/ObservationZones/CylinderZone.hpp"
 #include "Engine/Task/ObservationZones/LineSectorZone.hpp"
+#include "Engine/Task/ObservationZones/SectorZone.hpp"
 
 #define ACCURACY 500
 
@@ -520,6 +521,189 @@ TestTravelledDistance()
   }
 }
 
+struct StartLegStats {
+  double remaining, planned, distance_min;
+};
+
+/**
+ * Fly towards a start observation zone, with a finish point due north,
+ * and collect the values the option is supposed to affect.
+ */
+static StartLegStats
+FlyToStart(std::unique_ptr<ObservationZonePoint> start_zone,
+           bool navigate_nearest, const AircraftState &aircraft)
+{
+  OrderedTaskSettings settings = task_behaviour.ordered_defaults;
+  settings.navigate_nearest = navigate_nearest;
+
+  OrderedTask task(task_behaviour);
+  task.SetOrderedTaskSettings(settings);
+
+  const StartPoint tp1(std::move(start_zone), WaypointPtr(wp1),
+                       task_behaviour, settings.start_constraints);
+  task.Append(tp1);
+  const FinishPoint tp2(std::make_unique<LineSectorZone>(wp3->location),
+                        WaypointPtr(wp3), task_behaviour,
+                        settings.finish_constraints, false);
+  task.Append(tp2);
+  task.UpdateGeometry();
+
+  ok1(!IsError(task.CheckTask()));
+
+  task.Update(aircraft, aircraft, glide_polar);
+
+  const TaskStats &stats = task.GetStats();
+  const StartLegStats result{stats.current_leg.vector_remaining.distance,
+                             stats.total.planned.GetDistance(),
+                             stats.distance_min};
+
+  /* once the start is no longer the active task point, navigation
+     must let go of the observation zone again */
+  task.SetActiveTaskPoint(1);
+  task.Update(aircraft, aircraft, glide_polar);
+  ok1(task.GetPoint(0).GetLocationNavigation() ==
+      task.GetPoint(0).GetLocationRemaining());
+
+  return result;
+}
+
+/**
+ * Fly towards a finish observation zone, with the start already behind,
+ * and return the remaining distance of the current leg.
+ */
+static double
+FlyToFinish(std::unique_ptr<ObservationZonePoint> finish_zone,
+            bool navigate_nearest, const AircraftState &aircraft)
+{
+  OrderedTaskSettings settings = task_behaviour.ordered_defaults;
+  settings.navigate_nearest = navigate_nearest;
+
+  OrderedTask task(task_behaviour);
+  task.SetOrderedTaskSettings(settings);
+
+  const StartPoint tp1(std::make_unique<LineSectorZone>(wp1->location, 1000),
+                       WaypointPtr(wp1), task_behaviour,
+                       settings.start_constraints);
+  task.Append(tp1);
+  const FinishPoint tp2(std::move(finish_zone), WaypointPtr(wp3),
+                        task_behaviour, settings.finish_constraints, false);
+  task.Append(tp2);
+  task.UpdateGeometry();
+
+  ok1(!IsError(task.CheckTask()));
+
+  task.SetActiveTaskPoint(1);
+  task.Update(aircraft, aircraft, glide_polar);
+
+  return task.GetStats().current_leg.vector_remaining.distance;
+}
+
+/**
+ * With "navigate to nearest point" enabled, a start line and a start
+ * cylinder are navigated to at their nearest point, while the task keeps
+ * referring to the start waypoint.  A sector, and a cylinder the
+ * aircraft is inside of, are left alone.
+ */
+static void
+TestStartNearestPoint()
+{
+  /* the aircraft is behind the start line, well east of its center */
+  const auto aircraft = MakeTimedAircraft(0.05, 44.95, 1500,
+                                          FloatDuration{3600});
+
+  const auto line_off =
+    FlyToStart(std::make_unique<LineSectorZone>(wp1->location, 20000),
+               false, aircraft);
+  const auto line_on =
+    FlyToStart(std::make_unique<LineSectorZone>(wp1->location, 20000),
+               true, aircraft);
+
+  ok1(equals(line_off.remaining, aircraft.location.Distance(wp1->location)));
+
+  /* The line runs east/west through wp1, thus its nearest point is due
+     north of the aircraft.  Its ends follow a great circle and bulge
+     about 7.8 m north of the latitude of wp1, so the expected value is
+     only good to a few tens of metres; ACCURACY 500 would spend most
+     of its relative budget on that. */
+  ok1(equals(line_on.remaining,
+             aircraft.location.Distance(MakeGeoPoint(0.05, 45)), 100));
+
+  /* the option changes navigation only, not the task */
+  ok1(equals(line_off.planned, line_on.planned));
+  ok1(equals(line_off.distance_min, line_on.distance_min));
+
+  /* a start cylinder is navigated to at its near edge, one radius
+     short of the center on the bearing to the aircraft; the radius is
+     small enough to leave the aircraft outside the cylinder */
+  const auto cylinder_off =
+    FlyToStart(std::make_unique<CylinderZone>(wp1->location, 5000),
+               false, aircraft);
+  const auto cylinder_on =
+    FlyToStart(std::make_unique<CylinderZone>(wp1->location, 5000),
+               true, aircraft);
+
+  ok1(equals(cylinder_on.remaining,
+             aircraft.location.Distance(wp1->location) - 5000, 100));
+  ok1(cylinder_on.remaining < cylinder_off.remaining);
+  ok1(equals(cylinder_off.planned, cylinder_on.planned));
+
+  /* a sector covers only part of the circle, so it keeps the node
+     find_best_start() picks for it */
+  const auto sector_off =
+    FlyToStart(std::make_unique<SectorZone>(wp1->location, 10000),
+               false, aircraft);
+  const auto sector_on =
+    FlyToStart(std::make_unique<SectorZone>(wp1->location, 10000),
+               true, aircraft);
+
+  ok1(equals(sector_off.remaining, sector_on.remaining));
+
+  /* inside a start cylinder the nearest point of the rim is behind the
+     aircraft, away from the next task point, so the node
+     find_best_start() picks is kept */
+  const auto inside_off =
+    FlyToStart(std::make_unique<CylinderZone>(wp1->location, 20000),
+               false, aircraft);
+  const auto inside_on =
+    FlyToStart(std::make_unique<CylinderZone>(wp1->location, 20000),
+               true, aircraft);
+
+  ok1(equals(inside_off.remaining, inside_on.remaining));
+}
+
+/**
+ * With "navigate to nearest point" enabled, a finish line is reached at
+ * its nearest point.  A finish cylinder already refers to its rim.
+ */
+static void
+TestFinishNearestPoint()
+{
+  /* the aircraft is short of the finish, well east of its center */
+  const auto aircraft = MakeTimedAircraft(0.05, 45.95, 1500,
+                                          FloatDuration{3600});
+
+  const auto line_off =
+    FlyToFinish(std::make_unique<LineSectorZone>(wp3->location, 20000),
+                false, aircraft);
+  const auto line_on =
+    FlyToFinish(std::make_unique<LineSectorZone>(wp3->location, 20000),
+                true, aircraft);
+
+  ok1(equals(line_off, aircraft.location.Distance(wp3->location), 100));
+  ok1(equals(line_on,
+             aircraft.location.Distance(MakeGeoPoint(0.05, 46)), 100));
+
+  const auto cylinder_on =
+    FlyToFinish(std::make_unique<CylinderZone>(wp3->location, 3000),
+                true, aircraft);
+
+  /* the minimum distance path already picks a point on the rim of a
+     finish cylinder rather than its center, so the option only makes
+     that point the nearest one */
+  ok1(equals(cylinder_on,
+             aircraft.location.Distance(wp3->location) - 3000, 100));
+}
+
 static void
 TestAll()
 {
@@ -534,7 +718,7 @@ TestAll()
 
 int main()
 {
-  plan_tests(746 + 8);
+  plan_tests(746 + 8 + 31);
 
   task_behaviour.SetDefaults();
 
@@ -549,6 +733,9 @@ int main()
 
   glide_polar.SetMC(4);
   TestAll();
+
+  TestStartNearestPoint();
+  TestFinishNearestPoint();
 
   return exit_status();
 }

--- a/test/src/TestTaskSave.cpp
+++ b/test/src/TestTaskSave.cpp
@@ -58,6 +58,13 @@ static void
 TestTaskSave()
 {
   OrderedTask task_saved(task_behaviour);
+
+  /* a non-default task rule, to check that the task carries it
+     instead of falling back to the TaskBehaviour defaults on load */
+  OrderedTaskSettings settings = ordered_task_settings;
+  settings.navigate_nearest = true;
+  task_saved.SetOrderedTaskSettings(settings);
+
   task_saved.Append(StartPoint(std::make_unique<CylinderZone>(wp1->location, 500),
                          WaypointPtr(wp1),
                          task_behaviour,
@@ -87,6 +94,8 @@ TestTaskSave()
   ok1(task_loaded.get()->GetTaskPoint(0).GetWaypoint() == *wp1);
   ok1(task_loaded.get()->GetTaskPoint(1).GetWaypoint() == *wp2);
   ok1(task_loaded.get()->GetTaskPoint(2).GetWaypoint() == *wp3);
+
+  ok1(task_loaded.get()->GetOrderedTaskSettings().navigate_nearest);
 }
 
 static void
@@ -99,7 +108,7 @@ int main()
 {
   Directory::Create(Path{"output/results"});
 
-  plan_tests(10);
+  plan_tests(11);
   task_behaviour.SetDefaults();
   ordered_task_settings.SetDefaults();
   TestAll();


### PR DESCRIPTION
This answers #2388 on regatta start.

XCSoar aims at the point of the start or finish zone which makes the task shortest. On a line the boundary offers only the centre and the two ends, so it picks the centre; under a 20 km start line that is kilometres from where the glider will cross, and the distance, the time and the arrival height all describe a place nobody is flying to.

This adds a task rule which aims at the nearest point of the zone instead, while the start or the finish is the active task point. The point moves as the glider moves.

<img width="808" height="508" alt="image" src="https://github.com/user-attachments/assets/2cc61419-f1e8-4263-8a1b-472fbdc4a353" />

- `LineSectorZone` and `CylinderZone` implement `GetNearestPoint()`. Sectors and keyholes return an invalid location and keep the point the task already uses. So does a cylinder the glider is inside, where the nearest point of the rim is the wrong way out, away from the next task point.
- A line gains the most. On a cylinder the task already refers to a point of the rim, but the one which makes the task shortest rather than the one the glider is nearest to, quantised to one of twenty boundary samples; on the 5 km start cylinder of the test the two are 800 m apart.
- `GetLocationNavigation()` is a new virtual on `TaskPoint`, so the planned distance, the distance minimisation, the scoring and the AAT isolines keep using `GetLocationRemaining()`. The remaining vectors follow the nearer point, and with them the remaining distance, the glide solution and `TaskStats::current_leg`.
- Stored on `OrderedTaskSettings`, `.tsk` attribute `navigate_nearest`, profile key `NavigateNearest`. Off by default. Config → System → Task Defaults → Task Rules seeds new tasks and tasks read from a file which carry no such attribute; the "Rules" page of the task manager edits the task in use.

<img width="642" height="487" alt="Image" src="https://github.com/user-attachments/assets/79382e3c-08c4-490c-8487-8d0b7db2961c" />

Following the review: the rule moved off `StartConstraints` onto `OrderedTaskSettings`, since it now covers the finish as well and says where to navigate rather than what makes a start valid. A `.tsk` written by an earlier version of this branch loses the flag; nothing on master is affected.

Not in this PR: the LXNAV declaration still sends `Near=` hardcoded (`LLXVTSK Near=true`, finish `Near=1` / start `Near=0`). Plumbing it through `Declaration` changes what goes out on the port — with the rule off, a finish goes from `Near=1` to `Near=0` — so it deserves its own commit and its own `TestDriver` cases. Happy to follow up, as @lordfolken offered.

Tested with `make TARGET=UNIX check`: 114 files, 11089 tests, all green. `TestOrderedTask` covers the option on and off for a start line, a start cylinder, a start sector, a cylinder the glider is inside, and a finish line and cylinder, plus the planned and minimum distances staying put; `TestTaskSave` covers the `.tsk` round trip. Also flown in the simulator on a 20 km start line.

## Pre-Submission Checklist

### Git & Commit History

#### Branch & Rebase
- [x] PR is rebased on current `master`
- [x] Use `git rebase -i` to clean up commit history before PR submission

#### Commit Format & Messages
- [x] All commits follow the format: `<Component>: <Summary>` (no `src/` prefix)
- [x] Use present tense in commit messages ("Fix" not "Fixed", "Add" not "Added")
- [x] Commit messages explain *why* the change was made, not just *what* changed
- [x] Commit message body (if needed) provides detailed reasoning and context

#### Commit Structure
- [x] Each commit is atomic and builds successfully (every commit must compile)
- [x] One commit per logical change (don't mix refactoring with feature changes)
- [x] Self-contained commits (each commit changes one thing)
- [x] No fixup commits (squashed into parent commits using `git rebase -i`)
- [x] No duplicate commits (check with `git log --oneline`)
- [x] No "WIP" or "testing" commits (clean up before PR)

---

- [x] I'm ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional “Navigate to nearest point” task rule for start and finish observation zones.
  - Navigation guidance, displayed distance, estimated time, arrival height, and glide calculations now reflect the observation-zone point closest to the glider when enabled.
  - Added controls in task properties and settings, with the option disabled by default.
  - Start cylinders and lines are supported; sector behavior remains unchanged.

- **Documentation**
  - Added user guidance and limitations for the new task rule.

- **Tests**
  - Added coverage for nearest-point navigation and task-setting persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

