### PR TITLE
InfoBoxes: Dynamic layouts, an invisible slot and custom text

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -91,6 +91,23 @@ Version 7.46 - not yet released
     from ground speed and wind instead of an instrument
   - replace light green on Alternate MANUAL final glide with blue,
     matching Next waypoint
+  - add a Release space InfoBox which is not displayed and hands its
+    space to the other InfoBoxes of the same line, so a line can hold
+    fewer but wider InfoBoxes than the chosen geometry provides
+  - add a Merge along line InfoBox which is not displayed and lets the
+    InfoBox before it in the same line grow over its place, giving long
+    values such as waypoint names more room
+  - add a Merge across lines InfoBox which is not displayed and lets
+    the InfoBox of the previous line grow over its place, giving the
+    graphical InfoBoxes such as Barogram or Horizon twice the height
+  - add an Invisible InfoBox which is not drawn at all; the map is
+    extended over its slot and shows in its place, a short tap acts on
+    the map and a long press picks a different InfoBox for the slot
+  - add a Custom text InfoBox whose title, value and comment are set
+    by tapping it on the map, for labelling a page or as a separator
+    between groups of InfoBoxes #613
+  - fix the InfoBox border style only taking effect after the next
+    layout change, so the map kept showing the previous style
 * ui
   - Support manual UTC offsets up to +14:00 in 15-minute increments
   - Keep automatic UTC offsets synchronized with the operating-system

--- a/build/infobox.mk
+++ b/build/infobox.mk
@@ -25,6 +25,8 @@ LIBINFOBOX_SOURCES = \
 	$(SRC)/InfoBoxes/Format.cpp \
 	$(SRC)/InfoBoxes/Units.cpp \
 	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
+	$(SRC)/InfoBoxes/Border.cpp \
+	$(SRC)/InfoBoxes/BorderWindow.cpp \
 	$(SRC)/InfoBoxes/InfoBoxWindow.cpp \
 	$(SRC)/InfoBoxes/InfoBoxLayout.cpp \
 	$(SRC)/InfoBoxes/InfoBoxManager.cpp \

--- a/build/infobox.mk
+++ b/build/infobox.mk
@@ -38,7 +38,8 @@ LIBINFOBOX_SOURCES = \
 	$(SRC)/InfoBoxes/Panel/SpeedSimulator.cpp \
 	$(SRC)/InfoBoxes/Panel/ATCReference.cpp \
 	$(SRC)/InfoBoxes/Panel/ATCSetup.cpp \
-	$(SRC)/InfoBoxes/Panel/RadioEdit.cpp
+	$(SRC)/InfoBoxes/Panel/RadioEdit.cpp \
+	$(SRC)/InfoBoxes/Panel/CustomTextEdit.cpp
 
 LIBINFOBOX_DEPENDS = SCREEN
 

--- a/build/test.mk
+++ b/build/test.mk
@@ -411,8 +411,10 @@ TEST_WRAP_CLOCK_DEPENDS = MATH TIME
 $(eval $(call link-program,TestWrapClock,TEST_WRAP_CLOCK))
 
 TEST_PROFILE_SOURCES = \
+	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
 	$(SRC)/LocalPath.cpp \
 	$(SRC)/PageSettings.cpp \
+	$(SRC)/Profile/InfoBoxConfig.cpp \
 	$(SRC)/Profile/PageProfile.cpp \
 	$(SRC)/Profile/Profile.cpp \
 	$(SRC)/Profile/WeatherProfile.cpp \

--- a/build/test.mk
+++ b/build/test.mk
@@ -78,6 +78,7 @@ TEST_NAMES = \
 	test_pressure \
 	test_task \
 	TestInputTransformMode \
+	TestInfoBoxLayout \
 	TestOverwritingRingBuffer \
 	TestDateTime TestISO8601 TestRoughTime TestRoughSpeed TestWrapClock \
 	TestPolylineDecoder \
@@ -571,6 +572,15 @@ TEST_MATH_TABLES_SOURCES = \
 	$(TEST_SRC_DIR)/TestMathTables.cpp
 TEST_MATH_TABLES_DEPENDS = MATH
 $(eval $(call link-program,TestMathTables,TEST_MATH_TABLES))
+
+TEST_INFOBOX_LAYOUT_SOURCES = \
+	$(SRC)/InfoBoxes/InfoBoxLayout.cpp \
+	$(SRC)/InfoBoxes/InfoBoxSettings.cpp \
+	$(TEST_SRC_DIR)/tap.c \
+	$(TEST_SRC_DIR)/FakeLanguage.cpp \
+	$(TEST_SRC_DIR)/TestInfoBoxLayout.cpp
+TEST_INFOBOX_LAYOUT_DEPENDS = UTIL
+$(eval $(call link-program,TestInfoBoxLayout,TEST_INFOBOX_LAYOUT))
 
 TEST_ANGLE_SOURCES = \
 	$(TEST_SRC_DIR)/tap.c \

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -395,3 +395,12 @@ configured terrain clearance altitude.}
 
 \ibi{Active radio frequency}{Act Freq}{Currently active radio frequency.}
 \ibi{Standby radio frequency}{Stby Freq}{Currently standby radio frequency.}
+
+%%%%%%%%%%%
+\section{Miscellaneous}
+
+\ibi{Release space}{Release}{Not displayed and claims no space of its own:
+the other InfoBoxes of the same line grow into the gap.  A line is a row in
+portrait and a column in landscape.  Use it for a line with fewer but wider
+InfoBoxes than the selected geometry provides, for example four InfoBoxes in a
+row of five, without switching to a different InfoBox geometry.}

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -419,3 +419,8 @@ Horizon.  The previous line is the row above in portrait and the column to the
 left in landscape.  Several of them next to each other let a wide InfoBox grow
 over all of them, which gives a 2x2 block.  If the two do not line up exactly,
 or if there is no InfoBox to merge into, this behaves like Release space.}
+
+\ibi{Invisible}{Invisible}{This InfoBox is invisible: the map is extended over
+its slot and shows in its place.  An invisible InfoBox can no longer be tapped,
+so use the InfoBox configuration page to assign a different InfoBox to that
+slot again.}

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -421,6 +421,6 @@ over all of them, which gives a 2x2 block.  If the two do not line up exactly,
 or if there is no InfoBox to merge into, this behaves like Release space.}
 
 \ibi{Invisible}{Invisible}{This InfoBox is invisible: the map is extended over
-its slot and shows in its place.  An invisible InfoBox can no longer be tapped,
-so use the InfoBox configuration page to assign a different InfoBox to that
-slot again.}
+its slot and shows in its place.  A short tap on an invisible InfoBox acts on
+the map underneath; a long press opens the InfoBox selection list, so a
+different InfoBox can be assigned to that slot again.}

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -404,3 +404,10 @@ the other InfoBoxes of the same line grow into the gap.  A line is a row in
 portrait and a column in landscape.  Use it for a line with fewer but wider
 InfoBoxes than the selected geometry provides, for example four InfoBoxes in a
 row of five, without switching to a different InfoBox geometry.}
+
+\ibi{Merge along line}{Merge}{This slot is merged into the preceding InfoBox of
+the same line.  That InfoBox then spans both and gets twice the space, which
+helps with long values such as waypoint names.  The preceding InfoBox is the
+one to the left in portrait and the one above in landscape.  Several of them in
+a row widen it further.  In the first slot of a line it behaves like Release
+space.}

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -424,3 +424,12 @@ or if there is no InfoBox to merge into, this behaves like Release space.}
 its slot and shows in its place.  A short tap on an invisible InfoBox acts on
 the map underneath; a long press opens the InfoBox selection list, so a
 different InfoBox can be assigned to that slot again.}
+
+\ibi{Custom text}{Text}{Title, value and comment of this InfoBox can be set by
+the pilot instead of being computed from flight data.  To edit them, assign
+this InfoBox in the InfoBox set editor, then tap it on the map and choose
+Setup.  That makes it useful as a label for an InfoBox page or as a visual
+separator between groups of InfoBoxes.  Leave a line empty to hide it.  The
+Shaded InfoBox border style, for example, draws a grey bar behind the title
+whenever the title is not empty, so a title consisting of a single space shows
+that bar without any text.}

--- a/doc/manual/en/ch10_infobox_reference.tex
+++ b/doc/manual/en/ch10_infobox_reference.tex
@@ -411,3 +411,11 @@ helps with long values such as waypoint names.  The preceding InfoBox is the
 one to the left in portrait and the one above in landscape.  Several of them in
 a row widen it further.  In the first slot of a line it behaves like Release
 space.}
+
+\ibi{Merge across lines}{Merge line}{This slot is merged into the InfoBox at the
+same position of the previous line.  That InfoBox then spans both and gets
+twice the height, which helps the graphical InfoBoxes such as Barogram or
+Horizon.  The previous line is the row above in portrait and the column to the
+left in landscape.  Several of them next to each other let a wide InfoBox grow
+over all of them, which gives a 2x2 block.  If the two do not line up exactly,
+or if there is no InfoBox to merge into, this behaves like Release space.}

--- a/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
+++ b/src/Dialogs/Settings/Panels/LayoutConfigPanel.cpp
@@ -222,6 +222,9 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
     SaveValueInteger(InfoBoxTitleScale, ProfileKeys::InfoBoxTitleScale,
                   ui_settings.info_boxes.scale_title_font);
 
+  /* anything that requires the InfoBox windows to be created again */
+  bool info_box_layout_changed = info_box_geometry_changed;
+
   changed |= info_box_geometry_changed;
 
   changed |= SaveValueEnum(AppStatusMessageAlignment, ProfileKeys::AppStatusMessageAlignment,
@@ -234,8 +237,12 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   changed |= SaveValueEnum(AppInfoBoxTheme, ProfileKeys::AppInfoBoxTheme,
                            ui_settings.info_boxes.theme);
 
-  changed |= SaveValueEnum(AppInfoBoxBorder, ProfileKeys::AppInfoBoxBorder,
-                           ui_settings.info_boxes.border_style);
+  if (SaveValueEnum(AppInfoBoxBorder, ProfileKeys::AppInfoBoxBorder,
+                    ui_settings.info_boxes.border_style))
+    /* the border flags of an InfoBox are calculated when its window
+       is created, and the "Tab" style suppresses them altogether;
+       without new windows the map would keep showing the old style */
+    info_box_layout_changed = changed = true;
 
   bool overlay_buttons_changed = false;
   if (SaveValue(ShowMenuButton, ProfileKeys::ShowMenuButton,
@@ -253,7 +260,7 @@ LayoutConfigPanel::Save(bool &_changed) noexcept
   DialogSettings &dialog_settings = CommonInterface::SetUISettings().dialog;
   changed |= SaveValueEnum(TabDialogStyle, ProfileKeys::AppDialogTabStyle, dialog_settings.tab_style);
 
-  if (info_box_geometry_changed)
+  if (info_box_layout_changed)
     CommonInterface::main_window->ReinitialiseLayout();
 
   _changed |= changed;

--- a/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
+++ b/src/Dialogs/Settings/dlgConfigInfoboxes.cpp
@@ -331,6 +331,7 @@ InfoBoxesConfigWidget::OnPaste()
       continue;
 
     data.contents[item] = content;
+    data.text[item] = clipboard.text[item];
 
     if (item < previews.size())
       previews[item].Invalidate();

--- a/src/InfoBoxes/Border.cpp
+++ b/src/InfoBoxes/Border.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "Border.hpp"
+#include "ui/canvas/Canvas.hpp"
+
+void
+DrawBorder(Canvas &canvas, unsigned border_kind, const Pen &pen) noexcept
+{
+  if (border_kind == 0)
+    return;
+
+  canvas.Select(pen);
+
+  const int width = canvas.GetWidth(), height = canvas.GetHeight();
+
+  if (border_kind & BORDERTOP)
+    canvas.DrawExactLine({0, 0}, {width - 1, 0});
+
+  if (border_kind & BORDERRIGHT)
+    canvas.DrawExactLine({width - 1, 0}, {width - 1, height});
+
+  if (border_kind & BORDERBOTTOM)
+    canvas.DrawExactLine({0, height - 1}, {width - 1, height - 1});
+
+  if (border_kind & BORDERLEFT)
+    canvas.DrawExactLine({0, 0}, {0, height - 1});
+}

--- a/src/InfoBoxes/Border.hpp
+++ b/src/InfoBoxes/Border.hpp
@@ -15,3 +15,18 @@ enum BorderKind_t {
 #define BORDERRIGHT  (1<<bkRight)
 #define BORDERBOTTOM (1<<bkBottom)
 #define BORDERLEFT   (1<<bkLeft)
+
+class Canvas;
+class Pen;
+
+/**
+ * Draw the given borders (a bit set of #BORDERTOP, #BORDERRIGHT,
+ * #BORDERBOTTOM, #BORDERLEFT) along the edges of the canvas.
+ *
+ * Note that #BORDERTOP and #BORDERLEFT are drawn on the first
+ * row/column while #BORDERBOTTOM and #BORDERRIGHT are drawn on the
+ * last one; two neighbouring InfoBoxes therefore draw the edge they
+ * share on different pixels, and only one of them may draw it.
+ */
+void
+DrawBorder(Canvas &canvas, unsigned border_kind, const Pen &pen) noexcept;

--- a/src/InfoBoxes/BorderWindow.cpp
+++ b/src/InfoBoxes/BorderWindow.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "BorderWindow.hpp"
+#include "Border.hpp"
+#include "Look/InfoBoxLook.hpp"
+
+InfoBoxBorderWindow::InfoBoxBorderWindow(ContainerWindow &parent, PixelRect rc,
+                                         unsigned _border_kind,
+                                         const InfoBoxLook &_look) noexcept
+  :look(_look), border_kind(_border_kind)
+{
+  WindowStyle style;
+  style.Hide();
+
+  /* the slot shows the map, so the map window below shall receive all
+     input events for this area */
+  style.Disable();
+
+  Create(parent, rc, style);
+
+#ifndef USE_WINUSER
+  /* only the border lines are painted; the map window below stays
+     visible */
+  SetTransparent();
+#endif
+}
+
+void
+InfoBoxBorderWindow::SetBorderKind(unsigned _border_kind) noexcept
+{
+  if (_border_kind == border_kind)
+    return;
+
+  border_kind = _border_kind;
+  Invalidate();
+}
+
+void
+InfoBoxBorderWindow::OnPaint(Canvas &canvas) noexcept
+{
+  DrawBorder(canvas, border_kind, look.border_pen);
+}

--- a/src/InfoBoxes/BorderWindow.hpp
+++ b/src/InfoBoxes/BorderWindow.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include "ui/window/PaintWindow.hpp"
+
+struct InfoBoxLook;
+
+/**
+ * Draws the borders of an InfoBox slot which is configured
+ * "invisible".  Such a slot has no visible #InfoBoxWindow: the map
+ * window is extended over it, and this window paints nothing but the
+ * border lines on top of the map, leaving the rest untouched.
+ *
+ * This keeps every grid line on the very pixel it would occupy
+ * without the invisible slot.  Letting the neighbouring InfoBoxes draw
+ * the shared edges instead moves them by one pixel, because
+ * #BORDERTOP / #BORDERLEFT are drawn on the first row/column of a
+ * window while #BORDERBOTTOM / #BORDERRIGHT are drawn on the last one.
+ *
+ * Requires transparent windows, which the USE_WINUSER (GDI) backend
+ * does not provide; #InfoBoxManager falls back to letting the
+ * neighbours draw the edges there.
+ */
+class InfoBoxBorderWindow final : public PaintWindow {
+  const InfoBoxLook &look;
+
+  unsigned border_kind;
+
+public:
+  InfoBoxBorderWindow(ContainerWindow &parent, PixelRect rc,
+                      unsigned _border_kind,
+                      const InfoBoxLook &_look) noexcept;
+
+  void SetBorderKind(unsigned _border_kind) noexcept;
+
+protected:
+  /* virtual methods from class Window */
+  void OnPaint(Canvas &canvas) noexcept override;
+};

--- a/src/InfoBoxes/Content/Base.hpp
+++ b/src/InfoBoxes/Content/Base.hpp
@@ -10,7 +10,19 @@ class Canvas;
 
 class InfoBoxContent
 {
+  /**
+   * The index of the InfoBox this content is displayed in.
+   */
+  unsigned slot = 0;
+
 public:
+  /**
+   * Called by #InfoBoxWindow when the content is installed.
+   */
+  void SetSlot(unsigned _slot) noexcept {
+    slot = _slot;
+  }
+
   enum InfoBoxKeyCodes {
     ibkLeft = -2,
     ibkDown = -1,
@@ -28,4 +40,9 @@ public:
 
   [[gnu::pure]]
   virtual const InfoBoxPanel *GetDialogContent() noexcept;
+
+protected:
+  unsigned GetSlot() const noexcept {
+    return slot;
+  }
 };

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1227,6 +1227,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxPlaceholder,
   },
 
+  // e_MergeAcrossLines
+  {
+    NC_("InfoBox", "Merge across lines"),
+    NC_("Abbreviation", "Merge line"),
+    N_("This slot is merged into the InfoBox at the same position of the previous line. That InfoBox then spans both and gets twice the height, which helps the graphical InfoBoxes such as Barogram or Horizon. The previous line is the row above in portrait and the column to the left in landscape. If the two do not line up exactly, or if there is no InfoBox to merge into, this behaves like Release space."),
+    UpdateInfoBoxPlaceholder,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1219,6 +1219,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxPlaceholder,
   },
 
+  // e_MergeAlongLine
+  {
+    NC_("InfoBox", "Merge along line"),
+    NC_("Abbreviation", "Merge"),
+    N_("This slot is merged into the preceding InfoBox of the same line. That InfoBox then spans both and gets twice the space, which helps with long values such as waypoint names. The preceding InfoBox is the one to the left in portrait and the one above in landscape. Several in a row widen it further; in the first slot of a line it behaves like Release space."),
+    UpdateInfoBoxPlaceholder,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1243,6 +1243,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxInvisible,
   },
 
+  // e_CustomText
+  {
+    NC_("InfoBox", "Custom text"),
+    NC_("Abbreviation", "Text"),
+    N_("Title, value and comment of this InfoBox can be set by you instead of being computed from flight data. To edit them, tap this InfoBox on the map and choose Setup. Useful as a label for an InfoBox page or as a visual separator between groups of InfoBoxes."),
+    IBFHelper<InfoBoxContentCustomText>::Create,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1235,6 +1235,14 @@ static constexpr MetaData meta_data[] = {
     UpdateInfoBoxPlaceholder,
   },
 
+  // e_Invisible
+  {
+    N_("Invisible"),
+    N_("Invisible"),
+    N_("This InfoBox is invisible: the map is extended over its slot and shows in its place."),
+    UpdateInfoBoxInvisible,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Factory.cpp
+++ b/src/InfoBoxes/Content/Factory.cpp
@@ -1211,6 +1211,14 @@ static constexpr MetaData meta_data[] = {
     IBFHelper<InfoBoxContentPreviousWaypoint>::Create,
   },
 
+  // e_ReleaseSpace
+  {
+    NC_("InfoBox", "Release space"),
+    NC_("Abbreviation", "Release"),
+    N_("Placeholder which is not displayed and claims no space of its own: the other InfoBoxes of the same line grow into the gap. A line is a row in portrait and a column in landscape. Use it for a line with fewer but wider InfoBoxes than the selected geometry provides."),
+    UpdateInfoBoxPlaceholder,
+  },
+
 };
 
 static_assert(ARRAY_SIZE(meta_data) == NUM_TYPES,

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -143,6 +143,16 @@ UpdateInfoBoxPlaceholder(InfoBoxData &data) noexcept
 }
 
 void
+UpdateInfoBoxInvisible(InfoBoxData &data) noexcept
+{
+  /* nothing is ever drawn for this InfoBox; clear all texts so that
+     no leftovers of the previous content can show up */
+  data.SetTitle("");
+  data.SetValue("");
+  data.SetComment("");
+}
+
+void
 InfoBoxContentHorizon::OnCustomPaint(Canvas &canvas,
                                      const PixelRect &rc) noexcept
 {

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -5,6 +5,9 @@
 #include "InfoBoxes/Data.hpp"
 #include "Dialogs/Dialogs.h"
 #include "Interface.hpp"
+#include "UIState.hpp"
+#include "InfoBoxes/Panel/Panel.hpp"
+#include "InfoBoxes/Panel/CustomTextEdit.hpp"
 #include "Renderer/HorizonRenderer.hpp"
 #include "Hardware/PowerGlobal.hpp"
 #include "system/SystemLoad.hpp"
@@ -150,6 +153,29 @@ UpdateInfoBoxInvisible(InfoBoxData &data) noexcept
   data.SetTitle("");
   data.SetValue("");
   data.SetComment("");
+}
+
+void
+InfoBoxContentCustomText::Update(InfoBoxData &data) noexcept
+{
+  const auto &settings = CommonInterface::GetUISettings().info_boxes;
+  const unsigned panel = CommonInterface::GetUIState().panel_index;
+  const InfoBoxCustomText &text = settings.panels[panel].text[GetSlot()];
+
+  data.SetTitle(text.title.c_str());
+  data.SetValue(text.value.c_str());
+  data.SetComment(text.comment.c_str());
+}
+
+static constexpr InfoBoxPanel custom_text_infobox_panels[] = {
+  { NC_("Menu", "Setup"), LoadCustomTextEditPanel },
+  { nullptr, nullptr }
+};
+
+const InfoBoxPanel *
+InfoBoxContentCustomText::GetDialogContent() noexcept
+{
+  return custom_text_infobox_panels;
 }
 
 void

--- a/src/InfoBoxes/Content/Other.cpp
+++ b/src/InfoBoxes/Content/Other.cpp
@@ -134,6 +134,15 @@ UpdateInfoBoxFreeRAM(InfoBoxData &data) noexcept
 }
 
 void
+UpdateInfoBoxPlaceholder(InfoBoxData &data) noexcept
+{
+  /* there is nothing to show: the window is hidden, except when a
+     whole line consists of placeholders, because a line cannot
+     collapse */
+  data.SetInvalid();
+}
+
+void
 InfoBoxContentHorizon::OnCustomPaint(Canvas &canvas,
                                      const PixelRect &rc) noexcept
 {

--- a/src/InfoBoxes/Content/Other.hpp
+++ b/src/InfoBoxes/Content/Other.hpp
@@ -29,6 +29,14 @@ UpdateInfoBoxFreeRAM(InfoBoxData &data) noexcept;
 void
 UpdateInfoBoxNbrSat(InfoBoxData &data) noexcept;
 
+/**
+ * The layout placeholders: InfoBoxes which are not displayed and only
+ * give their space to other InfoBoxes; see
+ * InfoBoxLayout::ApplyContents().
+ */
+void
+UpdateInfoBoxPlaceholder(InfoBoxData &data) noexcept;
+
 class InfoBoxContentNbrSat final : public InfoBoxContent {
 public:
   void Update(InfoBoxData &data) noexcept override;

--- a/src/InfoBoxes/Content/Other.hpp
+++ b/src/InfoBoxes/Content/Other.hpp
@@ -51,6 +51,18 @@ public:
   bool HandleClick() noexcept override;
 };
 
+/**
+ * Shows the free text configured for this InfoBox slot; see
+ * #InfoBoxSettings::Panel::text.
+ */
+class InfoBoxContentCustomText final : public InfoBoxContent {
+public:
+  void Update(InfoBoxData &data) noexcept override;
+
+  [[gnu::pure]]
+  const InfoBoxPanel *GetDialogContent() noexcept override;
+};
+
 class InfoBoxContentHorizon : public InfoBoxContent
 {
 public:

--- a/src/InfoBoxes/Content/Other.hpp
+++ b/src/InfoBoxes/Content/Other.hpp
@@ -37,6 +37,14 @@ UpdateInfoBoxNbrSat(InfoBoxData &data) noexcept;
 void
 UpdateInfoBoxPlaceholder(InfoBoxData &data) noexcept;
 
+/**
+ * The "invisible" InfoBox: it has no title, no value and no comment.
+ * Its window is never shown; the map is extended over the slot
+ * instead (see #InfoBoxManager::ExpandOverInvisible()).
+ */
+void
+UpdateInfoBoxInvisible(InfoBoxData &data) noexcept;
+
 class InfoBoxContentNbrSat final : public InfoBoxContent {
 public:
   void Update(InfoBoxData &data) noexcept override;

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -155,6 +155,7 @@ namespace InfoBoxFactory
     e_QNH, /* Current QNH pressure setting; tap to adjust manually */
     e_ActiveWaypoint, /* Active waypoint infobox: shows the current task's next waypoint name (or Goto waypoint if no task), arrival altitude diff, and distance */
     e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
+    e_ReleaseSpace, /* Occupies no space of its own: the InfoBox is not displayed and the other InfoBoxes of the same line grow into the gap */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -156,6 +156,7 @@ namespace InfoBoxFactory
     e_ActiveWaypoint, /* Active waypoint infobox: shows the current task's next waypoint name (or Goto waypoint if no task), arrival altitude diff, and distance */
     e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
     e_ReleaseSpace, /* Occupies no space of its own: the InfoBox is not displayed and the other InfoBoxes of the same line grow into the gap */
+    e_MergeAlongLine, /* Occupies no space of its own: the InfoBox is not displayed and the preceding InfoBox of the same line grows over it */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -157,6 +157,7 @@ namespace InfoBoxFactory
     e_PreviousWaypoint, /* Previous waypoint infobox: shows the task waypoint before the active leg (start when on the first leg) with arrival altitude diff and distance; selection is informational only and never advances the task or sets a Goto */
     e_ReleaseSpace, /* Occupies no space of its own: the InfoBox is not displayed and the other InfoBoxes of the same line grow into the gap */
     e_MergeAlongLine, /* Occupies no space of its own: the InfoBox is not displayed and the preceding InfoBox of the same line grows over it */
+    e_MergeAcrossLines, /* Occupies no space of its own: the InfoBox is not displayed and the InfoBox above it in the previous line grows over it */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -159,6 +159,7 @@ namespace InfoBoxFactory
     e_MergeAlongLine, /* Occupies no space of its own: the InfoBox is not displayed and the preceding InfoBox of the same line grows over it */
     e_MergeAcrossLines, /* Occupies no space of its own: the InfoBox is not displayed and the InfoBox above it in the previous line grows over it */
     e_Invisible, /* Draws nothing at all; the map is extended over this InfoBox slot instead */
+    e_CustomText, /* Shows the free text configured for this slot instead of a value */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/Content/Type.hpp
+++ b/src/InfoBoxes/Content/Type.hpp
@@ -158,6 +158,7 @@ namespace InfoBoxFactory
     e_ReleaseSpace, /* Occupies no space of its own: the InfoBox is not displayed and the other InfoBoxes of the same line grow into the gap */
     e_MergeAlongLine, /* Occupies no space of its own: the InfoBox is not displayed and the preceding InfoBox of the same line grows over it */
     e_MergeAcrossLines, /* Occupies no space of its own: the InfoBox is not displayed and the InfoBox above it in the previous line grows over it */
+    e_Invisible, /* Draws nothing at all; the map is extended over this InfoBox slot instead */
     e_NUM_TYPES /* Last item */
   };
 

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -119,6 +119,11 @@ InfoBoxLayout::Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
 
   CalcInfoBoxSizes(layout, screen_size, geometry, scale_title_font);
 
+  for (unsigned i = 0; i < layout.count; ++i) {
+    layout.borders[i] = GetBorder(geometry, layout.landscape, i);
+    layout.visible[i] = true;
+  }
+
   layout.ClearVario();
 
   unsigned right = rc.right;
@@ -956,4 +961,152 @@ InfoBoxLayout::GetBorder(InfoBoxSettings::Geometry geometry, bool landscape,
   }
 
   return border;
+}
+
+struct Group {
+  /** the index after the last InfoBox of this row or column */
+  unsigned end;
+
+  /** is this a row (and not a column)? */
+  bool horizontal;
+};
+
+/**
+ * Determine the row (or column) which starts at the given index: the
+ * longest run of InfoBoxes sharing the same top and bottom edge (a
+ * row) or the same left and right edge (a column).
+ */
+[[gnu::pure]]
+static Group
+FindGroup(const PixelRect *positions, unsigned start, unsigned count) noexcept
+{
+  const PixelRect &first = positions[start];
+
+  if (start + 1 < count) {
+    const PixelRect &second = positions[start + 1];
+
+    if (second.top == first.top && second.bottom == first.bottom) {
+      unsigned end = start + 2;
+      while (end < count && positions[end].top == first.top &&
+             positions[end].bottom == first.bottom)
+        ++end;
+      return {end, true};
+    }
+
+    if (second.left == first.left && second.right == first.right) {
+      unsigned end = start + 2;
+      while (end < count && positions[end].left == first.left &&
+             positions[end].right == first.right)
+        ++end;
+      return {end, false};
+    }
+  }
+
+  return {start + 1, true};
+}
+
+/**
+ * Distribute the space of one row (or column) among its InfoBoxes,
+ * according to the given weights; a weight of zero hides the InfoBox.
+ */
+static void
+DistributeGroup(InfoBoxLayout::Layout &layout,
+                unsigned start, unsigned end, bool horizontal,
+                const unsigned *weights, unsigned total) noexcept
+{
+  const int begin = horizontal
+    ? layout.positions[start].left
+    : layout.positions[start].top;
+  const int limit = horizontal
+    ? layout.positions[end - 1].right
+    : layout.positions[end - 1].bottom;
+  const int size = limit - begin;
+
+  /* the far edges of the geometry, needed below and overwritten by
+     the loop */
+  int edges[InfoBoxSettings::Panel::MAX_CONTENTS];
+  for (unsigned i = start; i < end; ++i)
+    edges[i] = horizontal
+      ? layout.positions[i].right
+      : layout.positions[i].bottom;
+
+  /* as long as the line still holds one weight unit per slot, nothing
+     was released and the InfoBoxes can keep the edges of the geometry;
+     spreading the line evenly instead would round them differently and
+     move them off the grid of the neighbouring lines */
+  const bool keep_edges = total == end - start;
+
+  unsigned first_visible = end, last_visible = end;
+  unsigned accumulated = 0;
+  int previous = begin;
+
+  for (unsigned i = start; i < end; ++i) {
+    if (weights[i] == 0) {
+      layout.visible[i] = false;
+      continue;
+    }
+
+    accumulated += weights[i];
+
+    const int next = keep_edges
+      ? edges[start + accumulated - 1]
+      : begin + size * int(accumulated) / int(total);
+
+    if (horizontal) {
+      layout.positions[i].left = previous;
+      layout.positions[i].right = next;
+    } else {
+      layout.positions[i].top = previous;
+      layout.positions[i].bottom = next;
+    }
+
+    previous = next;
+
+    if (first_visible == end)
+      first_visible = i;
+    last_visible = i;
+  }
+
+  /* the outer InfoBoxes have taken over the outer edges of the row
+     (or column), and with them their borders */
+
+  const int near_mask = horizontal ? BORDERLEFT : BORDERTOP;
+  layout.borders[first_visible] =
+    (layout.borders[first_visible] & ~near_mask) |
+    (layout.borders[start] & near_mask);
+
+  const int far_mask = horizontal ? BORDERRIGHT : BORDERBOTTOM;
+  layout.borders[last_visible] =
+    (layout.borders[last_visible] & ~far_mask) |
+    (layout.borders[end - 1] & far_mask);
+}
+
+void
+InfoBoxLayout::ApplyContents(Layout &layout,
+                             const InfoBoxSettings::Panel &panel) noexcept
+{
+  for (unsigned start = 0; start < layout.count;) {
+    const auto group = FindGroup(layout.positions, start, layout.count);
+
+    unsigned weights[InfoBoxSettings::Panel::MAX_CONTENTS];
+    unsigned total = 0, collapsed = 0;
+
+    for (unsigned i = start; i < group.end; ++i) {
+      if (panel.contents[i] == InfoBoxFactory::e_ReleaseSpace) {
+        weights[i] = 0;
+        ++collapsed;
+      } else {
+        weights[i] = 1;
+        ++total;
+      }
+    }
+
+    /* leave the row alone if nothing was collapsed, and also if
+       everything was: a row cannot disappear */
+    if (collapsed > 0 && total > 0)
+      DistributeGroup(layout, start, group.end, group.horizontal,
+                      weights, total);
+
+    start = group.end;
+  }
 }

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -1091,13 +1091,33 @@ InfoBoxLayout::ApplyContents(Layout &layout,
     unsigned weights[InfoBoxSettings::Panel::MAX_CONTENTS];
     unsigned total = 0, collapsed = 0;
 
+    /* the most recent InfoBox which claims space of its own;
+       #InfoBoxFactory::e_MergeAlongLine hands its slot to that one */
+    unsigned previous = group.end;
+
     for (unsigned i = start; i < group.end; ++i) {
-      if (panel.contents[i] == InfoBoxFactory::e_ReleaseSpace) {
+      switch (panel.contents[i]) {
+      case InfoBoxFactory::e_ReleaseSpace:
         weights[i] = 0;
         ++collapsed;
-      } else {
+        break;
+
+      case InfoBoxFactory::e_MergeAlongLine:
+        weights[i] = 0;
+        ++collapsed;
+
+        if (previous < group.end) {
+          ++weights[previous];
+          ++total;
+        }
+
+        break;
+
+      default:
         weights[i] = 1;
         ++total;
+        previous = i;
+        break;
       }
     }
 

--- a/src/InfoBoxes/InfoBoxLayout.cpp
+++ b/src/InfoBoxes/InfoBoxLayout.cpp
@@ -963,8 +963,14 @@ InfoBoxLayout::GetBorder(InfoBoxSettings::Geometry geometry, bool landscape,
   return border;
 }
 
+/**
+ * One line of the layout: a row in portrait, a column in landscape.
+ */
 struct Group {
-  /** the index after the last InfoBox of this row or column */
+  /** the index of the first InfoBox of this line */
+  unsigned start;
+
+  /** the index after the last InfoBox of this line */
   unsigned end;
 
   /** is this a row (and not a column)? */
@@ -990,7 +996,7 @@ FindGroup(const PixelRect *positions, unsigned start, unsigned count) noexcept
       while (end < count && positions[end].top == first.top &&
              positions[end].bottom == first.bottom)
         ++end;
-      return {end, true};
+      return {start, end, true};
     }
 
     if (second.left == first.left && second.right == first.right) {
@@ -998,11 +1004,11 @@ FindGroup(const PixelRect *positions, unsigned start, unsigned count) noexcept
       while (end < count && positions[end].left == first.left &&
              positions[end].right == first.right)
         ++end;
-      return {end, false};
+      return {start, end, false};
     }
   }
 
-  return {start + 1, true};
+  return {start, start + 1, true};
 }
 
 /**
@@ -1010,10 +1016,12 @@ FindGroup(const PixelRect *positions, unsigned start, unsigned count) noexcept
  * according to the given weights; a weight of zero hides the InfoBox.
  */
 static void
-DistributeGroup(InfoBoxLayout::Layout &layout,
-                unsigned start, unsigned end, bool horizontal,
+DistributeGroup(InfoBoxLayout::Layout &layout, const Group &group,
                 const unsigned *weights, unsigned total) noexcept
 {
+  const unsigned start = group.start, end = group.end;
+  const bool horizontal = group.horizontal;
+
   const int begin = horizontal
     ? layout.positions[start].left
     : layout.positions[start].top;
@@ -1081,52 +1089,252 @@ DistributeGroup(InfoBoxLayout::Layout &layout,
     (layout.borders[end - 1] & far_mask);
 }
 
+static constexpr unsigned NO_ANCHOR = ~0u;
+
+/**
+ * Calculate how many slots of its line each InfoBox claims; a weight
+ * of zero means that the InfoBox is not displayed.
+ *
+ * #InfoBoxFactory::e_MergeAcrossLines keeps its weight, because only
+ * its extent across the lines is handed over; that keeps the columns
+ * of both lines aligned.
+ *
+ * @param rejected InfoBoxes which have no InfoBox to merge into and
+ * therefore release their space instead
+ * @param total receives the sum of all weights
+ * @return the number of InfoBoxes with weight zero
+ */
+static unsigned
+CalculateWeights(const InfoBoxSettings::Panel &panel, const Group &group,
+                 const bool *rejected,
+                 unsigned *weights, unsigned &total) noexcept
+{
+  unsigned collapsed = 0;
+
+  /* the most recent InfoBox which claims space of its own;
+     #InfoBoxFactory::e_MergeAlongLine hands its slot to that one */
+  unsigned previous = group.end;
+
+  total = 0;
+
+  for (unsigned i = group.start; i < group.end; ++i) {
+    switch (panel.contents[i]) {
+    case InfoBoxFactory::e_ReleaseSpace:
+      weights[i] = 0;
+      ++collapsed;
+      break;
+
+    case InfoBoxFactory::e_MergeAlongLine:
+      weights[i] = 0;
+      ++collapsed;
+
+      if (previous < group.end) {
+        ++weights[previous];
+        ++total;
+      }
+
+      break;
+
+    case InfoBoxFactory::e_MergeAcrossLines:
+      if (rejected[i]) {
+        weights[i] = 0;
+        ++collapsed;
+        break;
+      }
+
+      [[fallthrough]];
+
+    default:
+      weights[i] = 1;
+      ++total;
+      previous = i;
+      break;
+    }
+  }
+
+  return collapsed;
+}
+
+/**
+ * Find the InfoBox in the previous line which the
+ * #InfoBoxFactory::e_MergeAcrossLines slot @p i shall merge into.
+ *
+ * @param anchors the anchor of each slot already merged across lines
+ * @return the index of the InfoBox, or #NO_ANCHOR if there is none
+ */
+[[gnu::pure]]
+static unsigned
+FindAnchor(const InfoBoxLayout::Layout &layout,
+           const InfoBoxSettings::Panel &panel,
+           const Group &line, const Group &previous,
+           const unsigned *anchors, unsigned i) noexcept
+{
+  if (previous.horizontal != line.horizontal ||
+      previous.end - previous.start != line.end - line.start)
+    /* the two lines are not built alike, so their slots cannot line
+       up */
+    return NO_ANCHOR;
+
+  const PixelRect &a = layout.positions[previous.start];
+  const PixelRect &b = layout.positions[line.start];
+  if (line.horizontal ? a.bottom != b.top : a.right != b.left)
+    /* the two lines do not touch; there is map in between */
+    return NO_ANCHOR;
+
+  unsigned j = previous.start + (i - line.start);
+
+  while (true) {
+    switch (panel.contents[j]) {
+    case InfoBoxFactory::e_MergeAcrossLines:
+      /* a stack of more than two lines */
+      return anchors[j];
+
+    case InfoBoxFactory::e_MergeAlongLine:
+      /* follow it to the InfoBox which swallowed it */
+      if (j == previous.start)
+        return NO_ANCHOR;
+
+      --j;
+      continue;
+
+    case InfoBoxFactory::e_ReleaseSpace:
+      /* that slot has given its space to the rest of its line, so
+         there is nothing left to merge into */
+      return NO_ANCHOR;
+
+    default:
+      return layout.visible[j] ? j : NO_ANCHOR;
+    }
+  }
+}
+
+/**
+ * Let the InfoBox @p anchor grow over the slots [start,end) of the
+ * next line.  That is only possible if both cover exactly the same
+ * columns (rows in landscape); otherwise the result would not be a
+ * rectangle.
+ *
+ * @return false if they do not line up
+ */
+static bool
+ExtendAnchor(InfoBoxLayout::Layout &layout, bool horizontal,
+             unsigned anchor, unsigned start, unsigned end) noexcept
+{
+  const PixelRect &first = layout.positions[start];
+  const PixelRect &last = layout.positions[end - 1];
+  PixelRect &rc = layout.positions[anchor];
+
+  if (horizontal) {
+    if (rc.left != first.left || rc.right != last.right)
+      return false;
+
+    rc.bottom = last.bottom;
+    layout.borders[anchor] = (layout.borders[anchor] & ~BORDERBOTTOM) |
+      (layout.borders[end - 1] & BORDERBOTTOM);
+  } else {
+    if (rc.top != first.top || rc.bottom != last.bottom)
+      return false;
+
+    rc.right = last.right;
+    layout.borders[anchor] = (layout.borders[anchor] & ~BORDERRIGHT) |
+      (layout.borders[end - 1] & BORDERRIGHT);
+  }
+
+  return true;
+}
+
+/**
+ * Merge all #InfoBoxFactory::e_MergeAcrossLines slots into the
+ * InfoBoxes of the previous line.
+ *
+ * @param rejected receives the slots which could not be merged
+ * @return true if another slot was rejected; the layout has to be
+ * calculated again, because that slot now releases its space
+ */
+static bool
+MergeAcrossLines(InfoBoxLayout::Layout &layout,
+                 const InfoBoxSettings::Panel &panel,
+                 const Group *lines, unsigned n_lines,
+                 bool *rejected) noexcept
+{
+  unsigned anchors[InfoBoxSettings::Panel::MAX_CONTENTS];
+  std::fill_n(anchors, layout.count, NO_ANCHOR);
+
+  for (unsigned l = 1; l < n_lines; ++l) {
+    const Group &line = lines[l], &previous = lines[l - 1];
+
+    for (unsigned i = line.start; i < line.end; ++i) {
+      if (panel.contents[i] != InfoBoxFactory::e_MergeAcrossLines ||
+          rejected[i])
+        continue;
+
+      const unsigned anchor =
+        FindAnchor(layout, panel, line, previous, anchors, i);
+
+      /* collect the following slots which merge into the same
+         InfoBox, so that a group of them can cover a wide anchor */
+      unsigned end = i + 1;
+      while (end < line.end &&
+             panel.contents[end] == InfoBoxFactory::e_MergeAcrossLines &&
+             !rejected[end] &&
+             FindAnchor(layout, panel, line, previous,
+                        anchors, end) == anchor)
+        ++end;
+
+      if (anchor == NO_ANCHOR ||
+          !ExtendAnchor(layout, line.horizontal, anchor, i, end)) {
+        for (unsigned j = i; j < end; ++j)
+          rejected[j] = true;
+
+        return true;
+      }
+
+      for (unsigned j = i; j < end; ++j) {
+        layout.visible[j] = false;
+        anchors[j] = anchor;
+      }
+
+      i = end - 1;
+    }
+  }
+
+  return false;
+}
+
 void
 InfoBoxLayout::ApplyContents(Layout &layout,
                              const InfoBoxSettings::Panel &panel) noexcept
 {
+  Group lines[InfoBoxSettings::Panel::MAX_CONTENTS];
+  unsigned n_lines = 0;
+
   for (unsigned start = 0; start < layout.count;) {
-    const auto group = FindGroup(layout.positions, start, layout.count);
+    lines[n_lines] = FindGroup(layout.positions, start, layout.count);
+    start = lines[n_lines++].end;
+  }
 
-    unsigned weights[InfoBoxSettings::Panel::MAX_CONTENTS];
-    unsigned total = 0, collapsed = 0;
+  const Layout geometry = layout;
 
-    /* the most recent InfoBox which claims space of its own;
-       #InfoBoxFactory::e_MergeAlongLine hands its slot to that one */
-    unsigned previous = group.end;
+  /* an InfoBox which cannot be merged into the previous line releases
+     its space instead; that shifts its line and may invalidate other
+     merges, so repeat until the set of rejected slots is stable */
+  bool rejected[InfoBoxSettings::Panel::MAX_CONTENTS] = {};
 
-    for (unsigned i = start; i < group.end; ++i) {
-      switch (panel.contents[i]) {
-      case InfoBoxFactory::e_ReleaseSpace:
-        weights[i] = 0;
-        ++collapsed;
-        break;
+  while (true) {
+    layout = geometry;
 
-      case InfoBoxFactory::e_MergeAlongLine:
-        weights[i] = 0;
-        ++collapsed;
+    for (unsigned l = 0; l < n_lines; ++l) {
+      unsigned weights[InfoBoxSettings::Panel::MAX_CONTENTS], total;
+      const unsigned collapsed =
+        CalculateWeights(panel, lines[l], rejected, weights, total);
 
-        if (previous < group.end) {
-          ++weights[previous];
-          ++total;
-        }
-
-        break;
-
-      default:
-        weights[i] = 1;
-        ++total;
-        previous = i;
-        break;
-      }
+      /* leave the line alone if nothing was collapsed, and also if
+         everything was: a line cannot disappear */
+      if (collapsed > 0 && total > 0)
+        DistributeGroup(layout, lines[l], weights, total);
     }
 
-    /* leave the row alone if nothing was collapsed, and also if
-       everything was: a row cannot disappear */
-    if (collapsed > 0 && total > 0)
-      DistributeGroup(layout, start, group.end, group.horizontal,
-                      weights, total);
-
-    start = group.end;
+    if (!MergeAcrossLines(layout, panel, lines, n_lines, rejected))
+      break;
   }
 }

--- a/src/InfoBoxes/InfoBoxLayout.hpp
+++ b/src/InfoBoxes/InfoBoxLayout.hpp
@@ -18,6 +18,17 @@ struct Layout {
   unsigned count;
   PixelRect positions[InfoBoxSettings::Panel::MAX_CONTENTS];
 
+  /**
+   * The border flags (see #BorderKind_t) of each InfoBox.
+   */
+  int borders[InfoBoxSettings::Panel::MAX_CONTENTS];
+
+  /**
+   * Is this InfoBox displayed at all?  ApplyContents() clears this
+   * for InfoBoxes which have released their space.
+   */
+  bool visible[InfoBoxSettings::Panel::MAX_CONTENTS];
+
   PixelRect vario;
 
   PixelRect remaining;
@@ -40,5 +51,15 @@ Calculate(PixelRect rc, InfoBoxSettings::Geometry geometry,
 int
 GetBorder(InfoBoxSettings::Geometry geometry, bool landscape,
           unsigned i) noexcept;
+
+/**
+ * Redistribute the InfoBox positions of the given layout according to
+ * the contents of the given panel.  An InfoBox which claims no space
+ * of its own (#InfoBoxFactory::e_ReleaseSpace) becomes invisible, and the
+ * remaining InfoBoxes of the same row (or column) grow into the gap.
+ */
+void
+ApplyContents(Layout &layout,
+              const InfoBoxSettings::Panel &panel) noexcept;
 
 } // namespace InfoBoxLayout

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -204,6 +204,22 @@ UpdateBorders() noexcept
       infoboxes[i]->SetBorderKind(CalculateBorder(settings, panel, i));
 }
 
+int
+InfoBoxManager::FindInvisibleAt(PixelPoint p) noexcept
+{
+  if (!infoboxes_ready || invisible_mask == 0 || infoboxes_hidden)
+    /* in full screen mode the whole screen is map, and the InfoBox
+       slots are not shown at all */
+    return -1;
+
+  for (unsigned i = 0; i < layout.count; ++i)
+    if ((invisible_mask & (uint_least32_t(1) << i)) != 0 &&
+        layout.positions[i].Contains(p))
+      return int(i);
+
+  return -1;
+}
+
 PixelRect
 InfoBoxManager::ExpandOverInvisible(PixelRect rc) noexcept
 {

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -11,9 +11,13 @@
 #include "Profile/InfoBoxConfig.hpp"
 #include "Profile/Current.hpp"
 #include "Interface.hpp"
+#include "Look/InfoBoxLook.hpp"
+#include "MainWindow.hpp"
+#include "ui/canvas/Canvas.hpp"
 #include "UIState.hpp"
 
-#include <algorithm> // for std::equal()
+#include <algorithm>
+#include <cstdint>
 
 namespace InfoBoxManager {
 
@@ -43,13 +47,28 @@ DisplayInfoBox() noexcept;
 static void
 InfoBoxDrawIfDirty() noexcept;
 
-static void
+/**
+ * Apply the contents of the given panel to #layout.  Returns true if
+ * the layout was recalculated, which means the InfoBox slots may have
+ * moved.
+ */
+static bool
 UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept;
 
 } // namespace InfoBoxManager
 
 static bool infoboxes_dirty = false;
 static bool infoboxes_hidden = false;
+
+/**
+ * Bit mask of the InfoBox slots which are currently configured as
+ * #InfoBoxFactory::e_Invisible.  Kept up to date by DisplayInfoBox();
+ * a change of this mask means the map window needs to be resized.
+ */
+static uint_least32_t invisible_mask = 0;
+
+static_assert(InfoBoxSettings::Panel::MAX_CONTENTS <= 32,
+              "invisible_mask is too small");
 
 /* True after Create() finishes and until Destroy() runs.  Startup can
    re-enter layout (terrain load, PageActions::Update) while windows
@@ -58,6 +77,80 @@ static bool infoboxes_hidden = false;
 static bool infoboxes_ready = false;
 
 static InfoBoxWindow *infoboxes[InfoBoxSettings::Panel::MAX_CONTENTS];
+
+[[gnu::pure]]
+static const InfoBoxSettings::Panel &
+GetCurrentPanel() noexcept
+{
+  const unsigned panel = CommonInterface::GetUIState().panel_index;
+  return CommonInterface::GetUISettings().info_boxes.panels[panel];
+}
+
+/**
+ * Is the given slot of the current panel configured as
+ * #InfoBoxFactory::e_Invisible?  Such an InfoBox is never shown; the
+ * map window is extended over it instead.
+ */
+[[gnu::pure]]
+static bool
+IsInvisible(const InfoBoxSettings::Panel &panel, unsigned i) noexcept
+{
+  return panel.contents[i] == InfoBoxFactory::e_Invisible;
+}
+
+/**
+ * Recalculate #invisible_mask; returns true if it has changed, which
+ * means the map window needs to be moved.
+ */
+static bool
+UpdateInvisibleMask() noexcept
+{
+  const InfoBoxSettings::Panel &panel = GetCurrentPanel();
+
+  uint_least32_t mask = 0;
+  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
+    if (IsInvisible(panel, i))
+      mask |= uint_least32_t(1) << i;
+
+  if (mask == invisible_mask)
+    return false;
+
+  invisible_mask = mask;
+  return true;
+}
+
+PixelRect
+InfoBoxManager::ExpandOverInvisible(PixelRect rc) noexcept
+{
+  if (invisible_mask == 0)
+    return rc;
+
+  for (unsigned i = 0; i < layout.count; ++i) {
+    if ((invisible_mask & (uint_least32_t(1) << i)) == 0)
+      continue;
+
+    const PixelRect &ib = layout.positions[i];
+    rc.left = std::min(rc.left, ib.left);
+    rc.top = std::min(rc.top, ib.top);
+    rc.right = std::max(rc.right, ib.right);
+    rc.bottom = std::max(rc.bottom, ib.bottom);
+  }
+
+  return rc;
+}
+
+void
+InfoBoxManager::PaintInvisible(Canvas &canvas,
+                               const InfoBoxLook &look) noexcept
+{
+  if (!infoboxes_ready || infoboxes_hidden || invisible_mask == 0)
+    return;
+
+  for (unsigned i = 0; i < layout.count; ++i)
+    if ((invisible_mask & (uint_least32_t(1) << i)) != 0)
+      canvas.DrawFilledRectangle(layout.positions[i],
+                                 look.background_color);
+}
 
 // TODO locking
 void
@@ -88,20 +181,25 @@ InfoBoxManager::Show() noexcept
   if (!infoboxes_ready)
     return;
 
+  const InfoBoxSettings::Panel &panel = GetCurrentPanel();
+
   for (unsigned i = 0; i < layout.count; i++) {
-    if (infoboxes[i] != nullptr && layout.visible[i])
+    /* "invisible" InfoBoxes stay hidden (the map is drawn there), and
+       so do those which have released their space */
+    if (infoboxes[i] != nullptr && layout.visible[i] &&
+        !IsInvisible(panel, i))
       infoboxes[i]->Show();
   }
 
   SetDirty();
 }
 
-void
+bool
 InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
 {
   if (std::equal(layout_contents, layout_contents + layout.count,
                  panel.contents))
-    return;
+    return false;
 
   std::copy_n(panel.contents, layout.count, layout_contents);
 
@@ -125,9 +223,11 @@ InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
                                 : layout.borders[i]);
     infoboxes[i]->Move(layout.positions[i]);
 
-    if (!infoboxes_hidden)
+    if (!infoboxes_hidden && !IsInvisible(panel, i))
       infoboxes[i]->Show();
   }
+
+  return true;
 }
 
 void
@@ -148,7 +248,7 @@ InfoBoxManager::DisplayInfoBox() noexcept
   const InfoBoxSettings::Panel &settings =
     CommonInterface::GetUISettings().info_boxes.panels[panel];
 
-  UpdateLayout(settings);
+  const bool layout_changed = UpdateLayout(settings);
 
   for (unsigned i = 0; i < layout.count; i++) {
     if (infoboxes[i] == nullptr)
@@ -172,8 +272,9 @@ InfoBoxManager::DisplayInfoBox() noexcept
 
     /* apply the visibility on every pass: Show() may have run while
        UIState::panel_index still pointed at the previous page, and
-       would then have shown an InfoBox which this page collapses */
-    if (!layout.visible[i])
+       would then have shown an InfoBox which this page collapses or
+       draws the map over */
+    if (DisplayType == InfoBoxFactory::e_Invisible || !layout.visible[i])
       infoboxes[i]->FastHide();
     else if (!infoboxes_hidden)
       infoboxes[i]->Show();
@@ -183,6 +284,15 @@ InfoBoxManager::DisplayInfoBox() noexcept
 
   first = false;
   displaying = false;
+
+  const bool mask_changed = UpdateInvisibleMask();
+
+  if ((mask_changed || (layout_changed && invisible_mask != 0)) &&
+      CommonInterface::main_window != nullptr)
+    /* the map window covers the "invisible" slots: follow both a
+       change of the set and a move of the slots which the new
+       contents of the panel may have caused */
+    CommonInterface::main_window->RelayoutMapArea();
 }
 
 void
@@ -265,6 +375,11 @@ InfoBoxManager::Create(ContainerWindow &parent,
   layout = _layout;
   InfoBoxLayout::ApplyContents(layout, panel);
   std::copy_n(panel.contents, layout.count, layout_contents);
+
+  /* determine the "invisible" slots before the caller queries
+     ExpandOverInvisible() to position the map window */
+  invisible_mask = 0;
+  UpdateInvisibleMask();
 
   for (unsigned i = layout.count; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i)
     infoboxes[i] = nullptr;

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -5,6 +5,9 @@
 #include "InfoBoxes/InfoBoxWindow.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
 #include "InfoBoxes/Border.hpp"
+#ifndef USE_WINUSER
+#include "InfoBoxes/BorderWindow.hpp"
+#endif
 #include "InfoBoxes/Content/Factory.hpp"
 #include "Language/Language.hpp"
 #include "Form/DataField/ComboList.hpp"
@@ -79,6 +82,15 @@ static bool infoboxes_ready = false;
 
 static InfoBoxWindow *infoboxes[InfoBoxSettings::Panel::MAX_CONTENTS];
 
+#ifndef USE_WINUSER
+/**
+ * One per slot; only those of "invisible" slots are ever shown.  They
+ * draw the border lines of a slot whose #InfoBoxWindow is hidden, on
+ * top of the map which shows through.
+ */
+static InfoBoxBorderWindow *border_windows[InfoBoxSettings::Panel::MAX_CONTENTS];
+#endif
+
 [[gnu::pure]]
 static const InfoBoxSettings::Panel &
 GetCurrentPanel() noexcept
@@ -121,27 +133,32 @@ UpdateInvisibleMask() noexcept
 }
 
 /**
- * Which edges of InfoBox @p i touch an "invisible" slot?
- *
- * Neighbouring InfoBoxes share one border: only one of the two draws
- * it (see #InfoBoxLayout::GetBorder()).  If that neighbour is
- * invisible, nothing is drawn there at all and the InfoBox would have
- * an open side towards the map; it has to draw the shared edge itself.
+ * The edges of an InfoBox slot which touch another slot, split by
+ * whether that neighbour is visible or "invisible".  An edge which
+ * appears in neither set faces the map outside the InfoBox area.
+ */
+struct NeighbourEdges {
+  unsigned visible = 0, invisible = 0;
+};
+
+/**
+ * Determine which edges of slot @p i touch which kind of neighbour.
+ * This is purely geometric and therefore works for every InfoBox
+ * geometry without knowing anything about it.
  */
 [[gnu::pure]]
-static unsigned
-GetInvisibleNeighbourBorders(unsigned i) noexcept
+static NeighbourEdges
+GetNeighbourEdges(unsigned i) noexcept
 {
-  if (invisible_mask == 0)
-    return 0;
-
   const auto &layout = InfoBoxManager::layout;
   const PixelRect &rc = layout.positions[i];
 
-  unsigned border = 0;
+  NeighbourEdges edges;
 
   for (unsigned j = 0; j < layout.count; ++j) {
-    if (j == i || (invisible_mask & (uint_least32_t(1) << j)) == 0)
+    if (j == i || !layout.visible[j])
+      /* a collapsed slot keeps its rectangle from the geometry, which
+         its neighbours have grown over; it is not an edge any more */
       continue;
 
     const PixelRect &other = layout.positions[j];
@@ -151,6 +168,7 @@ GetInvisibleNeighbourBorders(unsigned i) noexcept
     const bool overlaps_x = rc.left < other.right && other.left < rc.right;
     const bool overlaps_y = rc.top < other.bottom && other.top < rc.bottom;
 
+    unsigned border = 0;
     if (overlaps_x && rc.top == other.bottom)
       border |= BORDERTOP;
     if (overlaps_x && rc.bottom == other.top)
@@ -159,14 +177,30 @@ GetInvisibleNeighbourBorders(unsigned i) noexcept
       border |= BORDERLEFT;
     if (overlaps_y && rc.right == other.left)
       border |= BORDERRIGHT;
+
+    if ((invisible_mask & (uint_least32_t(1) << j)) != 0)
+      edges.invisible |= border;
+    else
+      edges.visible |= border;
   }
 
-  return border;
+  return edges;
 }
 
 /**
- * Calculate the border flags for InfoBox @p i, taking "invisible"
- * neighbours into account.
+ * The border flags the layout assigns to slot @p i.
+ */
+[[gnu::pure]]
+static unsigned
+GetLayoutBorder(unsigned i) noexcept
+{
+  /* these have been adjusted by InfoBoxLayout::ApplyContents() where
+     an InfoBox has grown over a collapsed neighbour */
+  return unsigned(InfoBoxManager::layout.borders[i]);
+}
+
+/**
+ * Calculate the border flags for the #InfoBoxWindow of slot @p i.
  */
 [[gnu::pure]]
 static unsigned
@@ -178,19 +212,49 @@ CalculateBorder(const InfoBoxSettings &settings,
     return 0;
 
   if (IsInvisible(panel, i))
-    /* not drawn anyway */
+    /* the window is hidden; an #InfoBoxBorderWindow draws the edges
+       of this slot (or, on GDI, the visible neighbours do) */
     return 0;
 
-  /* layout.borders has been adjusted by
-     InfoBoxLayout::ApplyContents() where an InfoBox has grown over a
-     collapsed neighbour */
-  return unsigned(InfoBoxManager::layout.borders[i]) |
-    GetInvisibleNeighbourBorders(i);
+#ifdef USE_WINUSER
+  /* no transparent windows: the neighbours have to draw the edges of
+     an invisible slot, which shifts them by one pixel */
+  return GetLayoutBorder(i) | GetNeighbourEdges(i).invisible;
+#else
+  return GetLayoutBorder(i);
+#endif
 }
 
+#ifndef USE_WINUSER
+
 /**
- * Apply CalculateBorder() to all InfoBox windows.  Called when the set
- * of "invisible" InfoBoxes has changed.
+ * Calculate the border flags for the #InfoBoxBorderWindow of slot
+ * @p i: the edges the layout assigns to this slot, but only where the
+ * slot borders a visible InfoBox.
+ *
+ * An edge towards another invisible slot is dropped so that a group of
+ * invisible slots forms one uninterrupted hole, and an edge which
+ * faces the map outside the InfoBox area is dropped as well, because
+ * there the map simply continues.
+ */
+[[gnu::pure]]
+static unsigned
+CalculateSlotBorder(const InfoBoxSettings &settings,
+                    const InfoBoxSettings::Panel &panel, unsigned i) noexcept
+{
+  if (settings.border_style == InfoBoxSettings::BorderStyle::TAB ||
+      !IsInvisible(panel, i))
+    return 0;
+
+  return GetLayoutBorder(i) & GetNeighbourEdges(i).visible;
+}
+
+#endif
+
+/**
+ * Apply CalculateBorder() and CalculateSlotBorder() to all windows,
+ * and show or hide the border windows.  Called when the set of
+ * "invisible" InfoBoxes has changed.
  */
 static void
 UpdateBorders() noexcept
@@ -199,9 +263,22 @@ UpdateBorders() noexcept
     CommonInterface::GetUISettings().info_boxes;
   const InfoBoxSettings::Panel &panel = GetCurrentPanel();
 
-  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
+  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i) {
     if (infoboxes[i] != nullptr)
       infoboxes[i]->SetBorderKind(CalculateBorder(settings, panel, i));
+
+#ifndef USE_WINUSER
+    if (border_windows[i] != nullptr) {
+      const unsigned border = CalculateSlotBorder(settings, panel, i);
+      border_windows[i]->SetBorderKind(border);
+
+      if (border != 0 && !infoboxes_hidden)
+        border_windows[i]->Show();
+      else
+        border_windows[i]->FastHide();
+    }
+#endif
+  }
 }
 
 int
@@ -268,6 +345,11 @@ InfoBoxManager::Hide() noexcept
   for (unsigned i = 0; i < layout.count; i++) {
     if (infoboxes[i] != nullptr)
       infoboxes[i]->FastHide();
+
+#ifndef USE_WINUSER
+    if (border_windows[i] != nullptr)
+      border_windows[i]->FastHide();
+#endif
   }
 }
 
@@ -292,6 +374,9 @@ InfoBoxManager::Show() noexcept
       infoboxes[i]->Show();
   }
 
+  /* ... but their borders are drawn */
+  UpdateBorders();
+
   SetDirty();
 }
 
@@ -313,10 +398,19 @@ InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
 
     if (!layout.visible[i]) {
       infoboxes[i]->Hide();
+#ifndef USE_WINUSER
+      if (border_windows[i] != nullptr)
+        border_windows[i]->FastHide();
+#endif
       continue;
     }
 
     infoboxes[i]->Move(layout.positions[i]);
+
+#ifndef USE_WINUSER
+    if (border_windows[i] != nullptr)
+      border_windows[i]->Move(layout.positions[i]);
+#endif
 
     if (!infoboxes_hidden && !IsInvisible(panel, i))
       infoboxes[i]->Show();
@@ -483,8 +577,12 @@ InfoBoxManager::Create(ContainerWindow &parent,
   invisible_mask = 0;
   UpdateInvisibleMask();
 
-  for (unsigned i = layout.count; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i)
+  for (unsigned i = layout.count; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i) {
     infoboxes[i] = nullptr;
+#ifndef USE_WINUSER
+    border_windows[i] = nullptr;
+#endif
+  }
 
   WindowStyle style;
   style.Hide();
@@ -499,6 +597,17 @@ InfoBoxManager::Create(ContainerWindow &parent,
                                      i, style);
   }
 
+#ifndef USE_WINUSER
+  /* create the border windows after the InfoBox windows so they end up
+     in front of them; they are shown only for "invisible" slots (by
+     UpdateBorders(), from Show()) */
+  for (unsigned i = layout.count; i-- > 0;)
+    border_windows[i] =
+      new InfoBoxBorderWindow(parent, layout.positions[i],
+                              CalculateSlotBorder(settings, panel, i),
+                              look);
+#endif
+
   infoboxes_hidden = true;
   infoboxes_ready = true;
 }
@@ -512,6 +621,11 @@ InfoBoxManager::Destroy() noexcept
   for (unsigned i = 0; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i) {
     delete infoboxes[i];
     infoboxes[i] = nullptr;
+
+#ifndef USE_WINUSER
+    delete border_windows[i];
+    border_windows[i] = nullptr;
+#endif
   }
 }
 

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -4,6 +4,7 @@
 #include "InfoBoxes/InfoBoxManager.hpp"
 #include "InfoBoxes/InfoBoxWindow.hpp"
 #include "InfoBoxes/InfoBoxLayout.hpp"
+#include "InfoBoxes/Border.hpp"
 #include "InfoBoxes/Content/Factory.hpp"
 #include "Language/Language.hpp"
 #include "Form/DataField/ComboList.hpp"
@@ -119,6 +120,90 @@ UpdateInvisibleMask() noexcept
   return true;
 }
 
+/**
+ * Which edges of InfoBox @p i touch an "invisible" slot?
+ *
+ * Neighbouring InfoBoxes share one border: only one of the two draws
+ * it (see #InfoBoxLayout::GetBorder()).  If that neighbour is
+ * invisible, nothing is drawn there at all and the InfoBox would have
+ * an open side towards the map; it has to draw the shared edge itself.
+ */
+[[gnu::pure]]
+static unsigned
+GetInvisibleNeighbourBorders(unsigned i) noexcept
+{
+  if (invisible_mask == 0)
+    return 0;
+
+  const auto &layout = InfoBoxManager::layout;
+  const PixelRect &rc = layout.positions[i];
+
+  unsigned border = 0;
+
+  for (unsigned j = 0; j < layout.count; ++j) {
+    if (j == i || (invisible_mask & (uint_least32_t(1) << j)) == 0)
+      continue;
+
+    const PixelRect &other = layout.positions[j];
+
+    /* do the two rectangles share a section of the edge, or do they
+       just touch in a corner? */
+    const bool overlaps_x = rc.left < other.right && other.left < rc.right;
+    const bool overlaps_y = rc.top < other.bottom && other.top < rc.bottom;
+
+    if (overlaps_x && rc.top == other.bottom)
+      border |= BORDERTOP;
+    if (overlaps_x && rc.bottom == other.top)
+      border |= BORDERBOTTOM;
+    if (overlaps_y && rc.left == other.right)
+      border |= BORDERLEFT;
+    if (overlaps_y && rc.right == other.left)
+      border |= BORDERRIGHT;
+  }
+
+  return border;
+}
+
+/**
+ * Calculate the border flags for InfoBox @p i, taking "invisible"
+ * neighbours into account.
+ */
+[[gnu::pure]]
+static unsigned
+CalculateBorder(const InfoBoxSettings &settings,
+                const InfoBoxSettings::Panel &panel, unsigned i) noexcept
+{
+  if (settings.border_style == InfoBoxSettings::BorderStyle::TAB)
+    /* this style draws no borders at all */
+    return 0;
+
+  if (IsInvisible(panel, i))
+    /* not drawn anyway */
+    return 0;
+
+  /* layout.borders has been adjusted by
+     InfoBoxLayout::ApplyContents() where an InfoBox has grown over a
+     collapsed neighbour */
+  return unsigned(InfoBoxManager::layout.borders[i]) |
+    GetInvisibleNeighbourBorders(i);
+}
+
+/**
+ * Apply CalculateBorder() to all InfoBox windows.  Called when the set
+ * of "invisible" InfoBoxes has changed.
+ */
+static void
+UpdateBorders() noexcept
+{
+  const InfoBoxSettings &settings =
+    CommonInterface::GetUISettings().info_boxes;
+  const InfoBoxSettings::Panel &panel = GetCurrentPanel();
+
+  for (unsigned i = 0; i < InfoBoxManager::layout.count; ++i)
+    if (infoboxes[i] != nullptr)
+      infoboxes[i]->SetBorderKind(CalculateBorder(settings, panel, i));
+}
+
 PixelRect
 InfoBoxManager::ExpandOverInvisible(PixelRect rc) noexcept
 {
@@ -206,9 +291,6 @@ InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
   layout = base_layout;
   InfoBoxLayout::ApplyContents(layout, panel);
 
-  const auto border_style =
-    CommonInterface::GetUISettings().info_boxes.border_style;
-
   for (unsigned i = 0; i < layout.count; ++i) {
     if (infoboxes[i] == nullptr)
       continue;
@@ -218,14 +300,14 @@ InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
       continue;
     }
 
-    infoboxes[i]->SetBorderKind(border_style == InfoBoxSettings::BorderStyle::TAB
-                                ? 0
-                                : layout.borders[i]);
     infoboxes[i]->Move(layout.positions[i]);
 
     if (!infoboxes_hidden && !IsInvisible(panel, i))
       infoboxes[i]->Show();
   }
+
+  /* the collapsed slots have handed their edges to their neighbours */
+  UpdateBorders();
 
   return true;
 }
@@ -286,6 +368,11 @@ InfoBoxManager::DisplayInfoBox() noexcept
   displaying = false;
 
   const bool mask_changed = UpdateInvisibleMask();
+
+  if (mask_changed)
+    /* the set of "invisible" InfoBoxes has changed: the neighbours
+       must draw the now unpainted shared edges themselves */
+    UpdateBorders();
 
   if ((mask_changed || (layout_changed && invisible_mask != 0)) &&
       CommonInterface::main_window != nullptr)
@@ -366,8 +453,7 @@ InfoBoxManager::Create(ContainerWindow &parent,
   const InfoBoxSettings &settings =
     CommonInterface::GetUISettings().info_boxes;
 
-  const InfoBoxSettings::Panel &panel =
-    settings.panels[CommonInterface::GetUIState().panel_index];
+  const InfoBoxSettings::Panel &panel = GetCurrentPanel();
 
   infoboxes_ready = false;
   first = true;
@@ -390,15 +476,10 @@ InfoBoxManager::Create(ContainerWindow &parent,
   // create infobox windows
   for (unsigned i = layout.count; i-- > 0;) {
     const PixelRect &rc = layout.positions[i];
-    int Border =
-      settings.border_style == InfoBoxSettings::BorderStyle::TAB
-      ? 0
-      /* layout.borders is derived from the effective layout, while
-         settings.geometry is the configured layout */
-      : layout.borders[i];
 
     infoboxes[i] = new InfoBoxWindow(parent, rc,
-                                     Border, settings, look,
+                                     CalculateBorder(settings, panel, i),
+                                     settings, look,
                                      i, style);
   }
 

--- a/src/InfoBoxes/InfoBoxManager.cpp
+++ b/src/InfoBoxes/InfoBoxManager.cpp
@@ -13,9 +13,23 @@
 #include "Interface.hpp"
 #include "UIState.hpp"
 
+#include <algorithm> // for std::equal()
+
 namespace InfoBoxManager {
 
 InfoBoxLayout::Layout layout;
+
+/**
+ * The layout as calculated from the geometry alone, before the
+ * contents of the current panel were applied to it.
+ */
+static InfoBoxLayout::Layout base_layout;
+
+/**
+ * The panel contents which #layout was derived from.
+ */
+static InfoBoxFactory::Type
+layout_contents[InfoBoxSettings::Panel::MAX_CONTENTS];
 
 /**
  * Is this the initial DisplayInfoBox() call?  If yes, then all
@@ -28,6 +42,9 @@ DisplayInfoBox() noexcept;
 
 static void
 InfoBoxDrawIfDirty() noexcept;
+
+static void
+UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept;
 
 } // namespace InfoBoxManager
 
@@ -72,11 +89,45 @@ InfoBoxManager::Show() noexcept
     return;
 
   for (unsigned i = 0; i < layout.count; i++) {
-    if (infoboxes[i] != nullptr)
+    if (infoboxes[i] != nullptr && layout.visible[i])
       infoboxes[i]->Show();
   }
 
   SetDirty();
+}
+
+void
+InfoBoxManager::UpdateLayout(const InfoBoxSettings::Panel &panel) noexcept
+{
+  if (std::equal(layout_contents, layout_contents + layout.count,
+                 panel.contents))
+    return;
+
+  std::copy_n(panel.contents, layout.count, layout_contents);
+
+  layout = base_layout;
+  InfoBoxLayout::ApplyContents(layout, panel);
+
+  const auto border_style =
+    CommonInterface::GetUISettings().info_boxes.border_style;
+
+  for (unsigned i = 0; i < layout.count; ++i) {
+    if (infoboxes[i] == nullptr)
+      continue;
+
+    if (!layout.visible[i]) {
+      infoboxes[i]->Hide();
+      continue;
+    }
+
+    infoboxes[i]->SetBorderKind(border_style == InfoBoxSettings::BorderStyle::TAB
+                                ? 0
+                                : layout.borders[i]);
+    infoboxes[i]->Move(layout.positions[i]);
+
+    if (!infoboxes_hidden)
+      infoboxes[i]->Show();
+  }
 }
 
 void
@@ -97,6 +148,8 @@ InfoBoxManager::DisplayInfoBox() noexcept
   const InfoBoxSettings::Panel &settings =
     CommonInterface::GetUISettings().info_boxes.panels[panel];
 
+  UpdateLayout(settings);
+
   for (unsigned i = 0; i < layout.count; i++) {
     if (infoboxes[i] == nullptr)
       continue;
@@ -116,6 +169,14 @@ InfoBoxManager::DisplayInfoBox() noexcept
       infoboxes[i]->SetContentProvider(InfoBoxFactory::Create(DisplayType));
       DisplayTypeLast[i] = DisplayType;
     }
+
+    /* apply the visibility on every pass: Show() may have run while
+       UIState::panel_index still pointed at the previous page, and
+       would then have shown an InfoBox which this page collapses */
+    if (!layout.visible[i])
+      infoboxes[i]->FastHide();
+    else if (!infoboxes_hidden)
+      infoboxes[i]->Show();
 
     infoboxes[i]->UpdateContent();
   }
@@ -195,9 +256,15 @@ InfoBoxManager::Create(ContainerWindow &parent,
   const InfoBoxSettings &settings =
     CommonInterface::GetUISettings().info_boxes;
 
+  const InfoBoxSettings::Panel &panel =
+    settings.panels[CommonInterface::GetUIState().panel_index];
+
   infoboxes_ready = false;
   first = true;
+  base_layout = _layout;
   layout = _layout;
+  InfoBoxLayout::ApplyContents(layout, panel);
+  std::copy_n(panel.contents, layout.count, layout_contents);
 
   for (unsigned i = layout.count; i < InfoBoxSettings::Panel::MAX_CONTENTS; ++i)
     infoboxes[i] = nullptr;
@@ -211,9 +278,9 @@ InfoBoxManager::Create(ContainerWindow &parent,
     int Border =
       settings.border_style == InfoBoxSettings::BorderStyle::TAB
       ? 0
-      /* layout.geometry is the effective layout, while
+      /* layout.borders is derived from the effective layout, while
          settings.geometry is the configured layout */
-      : InfoBoxLayout::GetBorder(layout.geometry, layout.landscape, i);
+      : layout.borders[i];
 
     infoboxes[i] = new InfoBoxWindow(parent, rc,
                                      Border, settings, look,

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -41,6 +41,20 @@ ExpandOverInvisible(PixelRect rc) noexcept;
 void
 PaintInvisible(Canvas &canvas, const InfoBoxLook &look) noexcept;
 
+/**
+ * Find the "invisible" InfoBox slot containing the given point.
+ *
+ * Those slots show the map and their window is hidden, so the map
+ * window receives their input events; it uses this to offer the
+ * InfoBox picker on a long press (see
+ * #GlueMapWindow::OnInfoBoxPickerTimer()).
+ *
+ * @param p a point in #MainWindow client coordinates
+ * @return the InfoBox id, or -1 if there is no invisible slot there
+ */
+[[gnu::pure]] int
+FindInvisibleAt(PixelPoint p) noexcept;
+
 void
 ProcessTimer() noexcept;
 

--- a/src/InfoBoxes/InfoBoxManager.hpp
+++ b/src/InfoBoxes/InfoBoxManager.hpp
@@ -3,7 +3,10 @@
 
 #pragma once
 
+#include "ui/dim/Rect.hpp"
+
 struct InfoBoxLook;
+class Canvas;
 class ContainerWindow;
 class InfoBoxWindow;
 
@@ -13,6 +16,30 @@ namespace InfoBoxManager
 {
 
 extern InfoBoxLayout::Layout layout;
+
+/**
+ * Expand the given map area rectangle so that it also covers all
+ * InfoBox slots of the current panel which are configured as
+ * #InfoBoxFactory::e_Invisible.  Those InfoBox windows are never
+ * shown, and because the map window is kept at the bottom of the
+ * z-order, the map becomes visible in their place.
+ *
+ * Returns @p rc unmodified if there is no invisible InfoBox.
+ */
+[[gnu::pure]] PixelRect
+ExpandOverInvisible(PixelRect rc) noexcept;
+
+/**
+ * Fill the area of all "invisible" InfoBox slots with the InfoBox
+ * background colour.
+ *
+ * Their own window is hidden and usually the map window shows through,
+ * but a page which replaces the map by a #Widget leaves this area to
+ * no window at all: it would keep whatever pixels happened to be there
+ * before.  #MainWindow::OnPaint() calls this for those pages.
+ */
+void
+PaintInvisible(Canvas &canvas, const InfoBoxLook &look) noexcept;
 
 void
 ProcessTimer() noexcept;

--- a/src/InfoBoxes/InfoBoxSettings.cpp
+++ b/src/InfoBoxes/InfoBoxSettings.cpp
@@ -3,15 +3,47 @@
 
 #include "InfoBoxSettings.hpp"
 #include "Language/Language.hpp"
+#include "util/StringAPI.hxx"
 
 #include <algorithm>
+#include <cstddef>
 using namespace InfoBoxFactory;
+
+bool
+InfoBoxCustomText::AssignLine(StaticString<MAX_LENGTH> &dest,
+                              const char *src) noexcept
+{
+  /* RowFormWidget::GetValueString() returns nullptr for a #DataField
+     which does not implement GetAsString(); treat it like an empty
+     line */
+  if (src == nullptr)
+    src = "";
+
+  char buffer[MAX_LENGTH];
+  std::size_t length = 0;
+
+  for (; *src != '\0' && length + 1 < sizeof(buffer); ++src)
+    if (*src != '"' && *src != SEPARATOR)
+      buffer[length++] = *src;
+
+  buffer[length] = '\0';
+
+  if (StringIsEqual(buffer, dest))
+    return false;
+
+  dest = buffer;
+  dest.CropIncompleteUTF8();
+  return true;
+}
 
 void
 InfoBoxSettings::Panel::Clear() noexcept
 {
   name.clear();
   std::fill_n(contents, MAX_CONTENTS, InfoBoxFactory::MIN_TYPE_VAL);
+
+  for (auto &i : text)
+    i.Clear();
 }
 
 bool

--- a/src/InfoBoxes/InfoBoxSettings.hpp
+++ b/src/InfoBoxes/InfoBoxSettings.hpp
@@ -7,7 +7,45 @@
 #include "util/Compiler.h"
 #include "InfoBoxes/Content/Type.hpp"
 
+#include <cstddef>
 #include <cstdint>
+
+/**
+ * The three freely editable lines of an #InfoBoxFactory::e_CustomText
+ * InfoBox.
+ */
+struct InfoBoxCustomText {
+  static constexpr std::size_t MAX_LENGTH = 24;
+
+  /**
+   * All three lines share one profile value, separated by this
+   * character; it must therefore not occur in the text itself.
+   */
+  static constexpr char SEPARATOR = '|';
+
+  StaticString<MAX_LENGTH> title, value, comment;
+
+  void Clear() noexcept {
+    title.clear();
+    value.clear();
+    comment.clear();
+  }
+
+  [[gnu::pure]]
+  bool IsEmpty() const noexcept {
+    return title.empty() && value.empty() && comment.empty();
+  }
+
+  /**
+   * Copy one edited line, dropping the characters the profile cannot
+   * store: the quotation mark terminates the value, and #SEPARATOR
+   * separates the three lines.
+   *
+   * @return true if the line was modified
+   */
+  static bool AssignLine(StaticString<MAX_LENGTH> &dest,
+                         const char *src) noexcept;
+};
 
 struct InfoBoxSettings {
   enum PanelIndex {
@@ -22,6 +60,12 @@ struct InfoBoxSettings {
 
     StaticString<32u> name;
     InfoBoxFactory::Type contents[MAX_CONTENTS];
+
+    /**
+     * The free text of the #InfoBoxFactory::e_CustomText InfoBoxes;
+     * empty for every other type.
+     */
+    InfoBoxCustomText text[MAX_CONTENTS];
 
     void Clear() noexcept;
 

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -188,28 +188,7 @@ InfoBoxWindow::Paint(Canvas &canvas)
   PaintComment(canvas);
   PaintValue(canvas, background_color);
 
-  if (border_kind != 0) {
-    canvas.Select(look.border_pen);
-
-    const int width = canvas.GetWidth(),
-      height = canvas.GetHeight();
-
-    if (border_kind & BORDERTOP) {
-      canvas.DrawExactLine({0, 0}, {width - 1, 0});
-    }
-
-    if (border_kind & BORDERRIGHT) {
-      canvas.DrawExactLine({width - 1, 0}, {width - 1, height});
-    }
-
-    if (border_kind & BORDERBOTTOM) {
-      canvas.DrawExactLine({0, height - 1}, {width - 1, height - 1});
-    }
-
-    if (border_kind & BORDERLEFT) {
-      canvas.DrawExactLine({0, 0}, {0, height - 1});
-    }
-  }
+  DrawBorder(canvas, border_kind, look.border_pen);
 }
 
 void

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -301,10 +301,27 @@ InfoBoxWindow::OnDestroy() noexcept
 }
 
 void
+InfoBoxWindow::SetBorderKind(unsigned _border_kind) noexcept
+{
+  if (_border_kind == border_kind)
+    return;
+
+  border_kind = _border_kind;
+  CalculateRects();
+  Invalidate();
+}
+
+void
 InfoBoxWindow::OnResize(PixelSize new_size) noexcept
 {
   PaintWindow::OnResize(new_size);
 
+  CalculateRects();
+}
+
+void
+InfoBoxWindow::CalculateRects() noexcept
+{
   PixelRect rc = GetClientRect();
 
   if (border_kind & BORDERLEFT)

--- a/src/InfoBoxes/InfoBoxWindow.cpp
+++ b/src/InfoBoxes/InfoBoxWindow.cpp
@@ -195,6 +195,9 @@ void
 InfoBoxWindow::SetContentProvider(std::unique_ptr<InfoBoxContent> _content)
 {
   content = std::move(_content);
+  if (content)
+    content->SetSlot(id);
+
   ++content_serial;
 
   data.SetInvalid();

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -21,6 +21,12 @@ class InfoBoxWindow : public LazyPaintWindow
   const InfoBoxSettings &settings;
   const InfoBoxLook &look;
 
+  /**
+   * Which of the four edges this InfoBox draws itself.  Not const: it
+   * is updated when a neighbour becomes "invisible" (or visible
+   * again), because the shared edge is then no longer drawn by that
+   * neighbour.
+   */
   unsigned border_kind;
 
   const unsigned id;
@@ -123,9 +129,9 @@ public:
   }
 
   /**
-   * Change the border flags (see #BorderKind_t).  This is used when
-   * the InfoBox grows into the space of a collapsed neighbour and
-   * takes over its outer edge.
+   * Change which edges this InfoBox draws; see #border_kind.  Used
+   * when it grows over a collapsed neighbour and takes over its outer
+   * edge, or when a neighbour becomes "invisible".
    */
   void SetBorderKind(unsigned _border_kind) noexcept;
 

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -22,10 +22,9 @@ class InfoBoxWindow : public LazyPaintWindow
   const InfoBoxLook &look;
 
   /**
-   * Which of the four edges this InfoBox draws itself.  Not const: it
-   * is updated when a neighbour becomes "invisible" (or visible
-   * again), because the shared edge is then no longer drawn by that
-   * neighbour.
+   * Which of the four edges this InfoBox draws itself.  Not const
+   * because it follows a neighbour becoming "invisible" (or visible
+   * again); see #InfoBoxManager::CalculateBorder().
    */
   unsigned border_kind;
 

--- a/src/InfoBoxes/InfoBoxWindow.hpp
+++ b/src/InfoBoxes/InfoBoxWindow.hpp
@@ -21,7 +21,7 @@ class InfoBoxWindow : public LazyPaintWindow
   const InfoBoxSettings &settings;
   const InfoBoxLook &look;
 
-  const unsigned border_kind;
+  unsigned border_kind;
 
   const unsigned id;
 
@@ -89,6 +89,12 @@ class InfoBoxWindow : public LazyPaintWindow
    */
   void Paint(Canvas &canvas);
 
+  /**
+   * Recalculate the title, value and comment rectangles from the
+   * current window size and border flags.
+   */
+  void CalculateRects() noexcept;
+
 public:
   void PaintInto(Canvas &dest, int xoff, int yoff,
                  unsigned width, unsigned height);
@@ -115,6 +121,13 @@ public:
   const InfoBoxLook &GetLook() const {
     return look;
   }
+
+  /**
+   * Change the border flags (see #BorderKind_t).  This is used when
+   * the InfoBox grows into the space of a collapsed neighbour and
+   * takes over its outer edge.
+   */
+  void SetBorderKind(unsigned _border_kind) noexcept;
 
   void SetContentProvider(std::unique_ptr<InfoBoxContent> _content);
 

--- a/src/InfoBoxes/Panel/CustomTextEdit.cpp
+++ b/src/InfoBoxes/Panel/CustomTextEdit.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "CustomTextEdit.hpp"
+#include "Form/DataField/Listener.hpp"
+#include "Widget/RowFormWidget.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
+#include "Interface.hpp"
+#include "UIState.hpp"
+#include "UIGlobals.hpp"
+#include "Language/Language.hpp"
+#include "Profile/Current.hpp"
+#include "Profile/InfoBoxConfig.hpp"
+
+/**
+ * Edit the three lines of an #InfoBoxFactory::e_CustomText InfoBox
+ * without leaving the map; the same lines can be edited in the
+ * InfoBox set editor.
+ */
+class CustomTextEditPanel final : public RowFormWidget,
+                                  private DataFieldListener {
+  enum Controls {
+    TITLE, VALUE, COMMENT
+  };
+
+  /** the InfoBox this panel was opened for */
+  const unsigned id;
+
+public:
+  explicit CustomTextEditPanel(unsigned _id) noexcept
+    :RowFormWidget(UIGlobals::GetDialogLook()), id(_id) {}
+
+  /* virtual methods from class Widget */
+  void Prepare(ContainerWindow &parent,
+               const PixelRect &rc) noexcept override;
+
+private:
+  /* virtual methods from class DataFieldListener */
+  void OnModified(DataField &df) noexcept override;
+};
+
+void
+CustomTextEditPanel::Prepare([[maybe_unused]] ContainerWindow &parent,
+                             [[maybe_unused]] const PixelRect &rc) noexcept
+{
+  const auto &settings = CommonInterface::GetUISettings().info_boxes;
+  const unsigned panel_index = CommonInterface::GetUIState().panel_index;
+  const InfoBoxCustomText &text = settings.panels[panel_index].text[id];
+
+  AddText(_("Title"), _("The title line of this InfoBox."),
+          text.title.c_str(), this);
+  AddText(_("Value"), _("The value line of this InfoBox."),
+          text.value.c_str(), this);
+  AddText(_("Comment"), _("The comment line of this InfoBox."),
+          text.comment.c_str(), this);
+}
+
+void
+CustomTextEditPanel::OnModified([[maybe_unused]] DataField &df) noexcept
+{
+  auto &settings = CommonInterface::SetUISettings().info_boxes;
+  const unsigned panel_index = CommonInterface::GetUIState().panel_index;
+  InfoBoxSettings::Panel &panel = settings.panels[panel_index];
+  InfoBoxCustomText &text = panel.text[id];
+
+  bool modified = InfoBoxCustomText::AssignLine(text.title,
+                                                GetValueString(TITLE));
+  modified |= InfoBoxCustomText::AssignLine(text.value,
+                                            GetValueString(VALUE));
+  modified |= InfoBoxCustomText::AssignLine(text.comment,
+                                            GetValueString(COMMENT));
+
+  if (!modified)
+    return;
+
+  InfoBoxManager::SetDirty();
+  Profile::Save(Profile::map, panel, panel_index);
+}
+
+std::unique_ptr<Widget>
+LoadCustomTextEditPanel(unsigned id)
+{
+  return std::make_unique<CustomTextEditPanel>(id);
+}

--- a/src/InfoBoxes/Panel/CustomTextEdit.hpp
+++ b/src/InfoBoxes/Panel/CustomTextEdit.hpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#pragma once
+
+#include <memory>
+
+class Widget;
+
+std::unique_ptr<Widget>
+LoadCustomTextEditPanel(unsigned id);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -300,6 +300,21 @@ MainWindow::EndCoalesceMapLayout() noexcept
   }
 }
 
+PixelRect
+MainWindow::GetExtendedMapRect(PixelRect map_area) const noexcept
+{
+  PixelRect rc = InfoBoxManager::ExpandOverInvisible(map_area);
+
+  if (rc.top < map_area.top && rc.top > GetClientRect().top)
+    /* the map window is a buffered window and its buffer reaches the
+       screen one row below the window's top edge, which would leave
+       the first row of an "invisible" slot unpainted; begin one row
+       higher, hidden behind the InfoBox above the slot */
+    --rc.top;
+
+  return rc;
+}
+
 void
 MainWindow::LayoutMapArea() noexcept
 {
@@ -326,7 +341,7 @@ MainWindow::LayoutMapArea() noexcept
      map window sits at the bottom of the z-order, so the remaining
      (visible) InfoBoxes are drawn on top of it */
   const PixelRect map_area = GetMapRectAbove(main_rect, bottom_rect);
-  const PixelRect extended = InfoBoxManager::ExpandOverInvisible(map_area);
+  const PixelRect extended = GetExtendedMapRect(map_area);
 
   map->Move(extended);
   map->BringToBottom();
@@ -550,8 +565,7 @@ MainWindow::InitialiseConfigured()
   map->SetComputerSettings(CommonInterface::GetComputerSettings());
   map->SetMapSettings(CommonInterface::GetMapSettings());
   map->SetUIState(CommonInterface::GetUIState());
-  const PixelRect extended_map_rect =
-    InfoBoxManager::ExpandOverInvisible(map_rect);
+  const PixelRect extended_map_rect = GetExtendedMapRect(map_rect);
   map->Create(*this, extended_map_rect);
 
   /* the map is created after the InfoBoxes, so it would be on top of

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -262,9 +262,9 @@ ComputeMapAreaRect(const PixelRect &main_rect,
 PixelRect
 MainWindow::GetMapAreaRect() const noexcept
 {
-  if (map != nullptr)
-    return map->GetPosition();
-
+  /* deliberately not using map->GetPosition() here: the map window may
+     be extended over "invisible" InfoBoxes, but overlay buttons and
+     other decorations shall stay inside the regular map area */
   return ComputeMapAreaRect(GetMainRect(), top_widget, bottom_widget);
 }
 
@@ -322,7 +322,32 @@ MainWindow::LayoutMapArea() noexcept
   if (HaveBottomWidget())
     bottom_widget->Move(bottom_rect);
 
-  map->Move(GetMapRectAbove(main_rect, bottom_rect));
+  /* extend the map over all InfoBox slots configured "invisible"; the
+     map window sits at the bottom of the z-order, so the remaining
+     (visible) InfoBoxes are drawn on top of it */
+  const PixelRect map_area = GetMapRectAbove(main_rect, bottom_rect);
+  const PixelRect extended = InfoBoxManager::ExpandOverInvisible(map_area);
+
+  map->Move(extended);
+  map->BringToBottom();
+
+  /* keep the HUD overlays (compass, map scale, final glide bar, ...)
+     inside the part of the map window which is not covered by
+     InfoBoxes */
+  PixelRect overlay_rect = map_area;
+  overlay_rect.Offset(-extended.left, -extended.top);
+  map->SetOverlayRect(overlay_rect);
+}
+
+void
+MainWindow::RelayoutMapArea() noexcept
+{
+  if (map == nullptr)
+    return;
+
+  LayoutMapArea();
+  UpdateMapOverlayButtonLayout();
+  map->FullRedraw();
 }
 
 void
@@ -332,42 +357,47 @@ MainWindow::UpdateMapOverlayButtonLayout() noexcept
     widget == nullptr && map != nullptr &&
     PageActions::AllowMapOverlayButtons();
 
+  /* not map->GetPosition(): the map window may be extended over
+     "invisible" InfoBoxes, but the buttons belong into the regular map
+     area */
+  const PixelRect map_area = GetMapAreaRect();
+
   if (show_menu_button != nullptr) {
     show_menu_button->SetVisible(overlay_buttons_active);
     show_menu_button->SetEnabled(overlay_buttons_active);
     if (overlay_buttons_active)
-      show_menu_button->Move(GetShowMenuButtonRect(map->GetPosition()));
+      show_menu_button->Move(GetShowMenuButtonRect(map_area));
   }
   if (show_quickmenu_button != nullptr) {
     show_quickmenu_button->SetVisible(overlay_buttons_active);
     show_quickmenu_button->SetEnabled(overlay_buttons_active);
     if (overlay_buttons_active)
-      show_quickmenu_button->Move(GetShowQuickMenuButtonRect(map->GetPosition()));
+      show_quickmenu_button->Move(GetShowQuickMenuButtonRect(map_area));
   }
   if (show_zoom_out_button != nullptr) {
     show_zoom_out_button->SetVisible(overlay_buttons_active);
     show_zoom_out_button->SetEnabled(overlay_buttons_active);
     if (overlay_buttons_active)
-      show_zoom_out_button->Move(GetShowZoomButtonRect(map->GetPosition(),
+      show_zoom_out_button->Move(GetShowZoomButtonRect(map_area,
                                                        ShowZoomButton::Sign::ZOOM_OUT));
   }
   if (show_zoom_in_button != nullptr) {
     show_zoom_in_button->SetVisible(overlay_buttons_active);
     show_zoom_in_button->SetEnabled(overlay_buttons_active);
     if (overlay_buttons_active)
-      show_zoom_in_button->Move(GetShowZoomButtonRect(map->GetPosition(),
+      show_zoom_in_button->Move(GetShowZoomButtonRect(map_area,
                                                       ShowZoomButton::Sign::ZOOM_IN));
   }
 
 #ifdef ANDROID
   if (show_rotate_button != nullptr && overlay_buttons_active)
-    show_rotate_button->Move(GetShowRotateButtonRect(map->GetPosition()));
+    show_rotate_button->Move(GetShowRotateButtonRect(map_area));
 #endif
 
   if (map != nullptr)
     /* keep the north arrow clear of the overlay buttons */
     map->SetTopRightMargin(overlay_buttons_active
-                           ? GetMapOverlayTopRightWidth(map->GetPosition())
+                           ? GetMapOverlayTopRightWidth(map_area)
                            : 0);
 
   /* Newly created overlay buttons are added after the map; keep the map
@@ -520,7 +550,18 @@ MainWindow::InitialiseConfigured()
   map->SetComputerSettings(CommonInterface::GetComputerSettings());
   map->SetMapSettings(CommonInterface::GetMapSettings());
   map->SetUIState(CommonInterface::GetUIState());
-  map->Create(*this, map_rect);
+  const PixelRect extended_map_rect =
+    InfoBoxManager::ExpandOverInvisible(map_rect);
+  map->Create(*this, extended_map_rect);
+
+  /* the map is created after the InfoBoxes, so it would be on top of
+     them; it must be at the bottom because it may be extended over
+     "invisible" InfoBox slots */
+  map->BringToBottom();
+
+  PixelRect map_overlay_rect = map_rect;
+  map_overlay_rect.Offset(-extended_map_rect.left, -extended_map_rect.top);
+  map->SetOverlayRect(map_overlay_rect);
 
   popup = new PopupMessage(*this, look->dialog, ui_settings);
   popup->Create(map_rect);
@@ -1365,9 +1406,13 @@ MainWindow::OnPaint(Canvas &canvas) noexcept
   }
 #endif
 
+  /* not map->GetPosition(): that may be extended over "invisible"
+     InfoBoxes */
+  const PixelRect map_area = GetMapAreaRect();
+
   if (HaveTopWidget() && map != nullptr) {
     /* draw a separator between top widget and map */
-    PixelRect rc = map->GetPosition();
+    PixelRect rc = map_area;
     rc.bottom = rc.top;
     rc.top -= separator_height;
     canvas.DrawFilledRectangle(rc, COLOR_BLACK);
@@ -1375,11 +1420,17 @@ MainWindow::OnPaint(Canvas &canvas) noexcept
 
   if (HaveBottomWidget() && map != nullptr) {
     /* draw a separator between main area and bottom area */
-    PixelRect rc = map->GetPosition();
+    PixelRect rc = map_area;
     rc.top = rc.bottom;
     rc.bottom += separator_height;
     canvas.DrawFilledRectangle(rc, COLOR_BLACK);
   }
+
+  if (look != nullptr && (map == nullptr || !map->IsVisible()))
+    /* an "invisible" InfoBox slot shows the map window below it, but
+       this page has no map: give the slot the InfoBox background
+       colour, because no window would paint it at all */
+    InfoBoxManager::PaintInvisible(canvas, look->info_box);
 
   SingleWindow::OnPaint(canvas);
 }

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -298,6 +298,15 @@ private:
 
   void UpdateMapOverlayButtonLayout() noexcept;
 
+public:
+  /**
+   * Re-run #LayoutMapArea() and the dependent layouts.  Called by
+   * #InfoBoxManager when the set of "invisible" InfoBoxes changes,
+   * because those slots are covered by the map window.
+   */
+  void RelayoutMapArea() noexcept;
+
+private:
   /**
    * Adjust the flarm radar position
    */

--- a/src/MainWindow.hpp
+++ b/src/MainWindow.hpp
@@ -291,6 +291,13 @@ private:
   PixelRect GetMapAreaRect() const noexcept;
 
   /**
+   * The rectangle the map window really occupies: @p map_area
+   * extended over all InfoBox slots configured "invisible".
+   */
+  [[gnu::pure]]
+  PixelRect GetExtendedMapRect(PixelRect map_area) const noexcept;
+
+  /**
    * Move top/bottom widgets and the map into the area returned by
    * #GetMapAreaRect().
    */

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -234,6 +234,18 @@ private:
 
   UI::Timer map_item_timer{[this]{ OnMapItemTimer(); }};
 
+  /**
+   * Long press on an "invisible" InfoBox slot: those slots show the
+   * map, so this window receives their input.  A short press acts on
+   * the map as usual, a long press opens the InfoBox picker.
+   */
+  UI::Timer infobox_picker_timer{[this]{ OnInfoBoxPickerTimer(); }};
+
+  /**
+   * The InfoBox id #infobox_picker_timer was armed for, or -1.
+   */
+  int infobox_picker_id = -1;
+
   UI::Notify redraw_notify{[this]{ PartialRedraw(); }};
 
   /**
@@ -499,6 +511,19 @@ protected:
 
 private:
   void OnMapItemTimer() noexcept;
+
+  /**
+   * Arm #infobox_picker_timer if the given point (in window
+   * coordinates) is inside an "invisible" InfoBox slot.
+   */
+  void ArmInfoBoxPicker(PixelPoint p) noexcept;
+
+  void CancelInfoBoxPicker() noexcept {
+    infobox_picker_timer.Cancel();
+    infobox_picker_id = -1;
+  }
+
+  void OnInfoBoxPickerTimer() noexcept;
 
 #ifdef ENABLE_OPENGL
   void OnKineticTimer() noexcept;

--- a/src/MapWindow/GlueMapWindow.hpp
+++ b/src/MapWindow/GlueMapWindow.hpp
@@ -396,7 +396,7 @@ private:
   void DrawGPSStatus(Canvas &canvas, const PixelRect &rc,
                      const NMEAInfo &info) const noexcept;
   void DrawCrossHairs(Canvas &canvas) const noexcept;
-  void DrawPanInfo(Canvas &canvas) const noexcept;
+  void DrawPanInfo(Canvas &canvas, const PixelRect &rc) const noexcept;
   void DrawThermalBand(Canvas &canvas, const PixelRect &rc) const noexcept;
   void DrawFinalGlide(Canvas &canvas, const PixelRect &rc) const noexcept;
   void DrawVario(Canvas &canvas, const PixelRect &rc) const noexcept;

--- a/src/MapWindow/GlueMapWindowDisplayMode.cpp
+++ b/src/MapWindow/GlueMapWindowDisplayMode.cpp
@@ -461,7 +461,10 @@ GlueMapWindow::SetLocationLazy(const GeoPoint location) noexcept
 void
 GlueMapWindow::UpdateProjection() noexcept
 {
-  const PixelRect rc = GetClientRect();
+  /* not GetClientRect(): the window may be extended over "invisible"
+     InfoBox slots, and the aircraft belongs into the middle of the
+     area which is really visible */
+  const PixelRect rc = GetOverlayRect();
 
   /* not using MapWindowBlackboard here because these methods are
      called by the main thread */

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -9,6 +9,7 @@
 #include "Math/FastMath.hpp"
 #include "util/Compiler.h"
 #include "Interface.hpp"
+#include "InfoBoxes/InfoBoxManager.hpp"
 #include "Pan.hpp"
 #include "Topography/Thread.hpp"
 #include "Asset.hpp"
@@ -54,6 +55,7 @@ GlueMapWindow::OnDestroy() noexcept
 #endif
 
   map_item_timer.Cancel();
+  CancelInfoBoxPicker();
 
   MapWindow::OnDestroy();
 }
@@ -79,6 +81,11 @@ GlueMapWindow::OnMouseMove(PixelPoint p, unsigned keys) noexcept
       ((unsigned)ManhattanDistance(drag_start, p) > threshold ||
        mouse_down_clock.Elapsed() > std::chrono::milliseconds(200)))
     arm_mapitem_list = false;
+
+  if (infobox_picker_id >= 0 &&
+      (unsigned)ManhattanDistance(drag_start, p) > threshold)
+    /* the finger wandered off: this is a drag, not a long press */
+    CancelInfoBoxPicker();
 
   switch (drag_mode) {
   case DRAG_NONE:
@@ -191,6 +198,10 @@ GlueMapWindow::OnMouseDown(PixelPoint p) noexcept
 
   drag_start = p;
 
+  /* before the early return below: an "invisible" InfoBox slot can be
+     long pressed even while the map has no valid projection yet */
+  ArmInfoBoxPicker(p);
+
   if (!visible_projection.IsValid()) {
     gestures.Start(p, Layout::Scale(20));
     drag_mode = DRAG_GESTURE;
@@ -238,6 +249,10 @@ GlueMapWindow::OnMouseDown(PixelPoint p) noexcept
 bool
 GlueMapWindow::OnMouseUp(PixelPoint p) noexcept
 {
+  /* released before the long press elapsed: a short press acts on the
+     map as usual */
+  CancelInfoBoxPicker();
+
   if (drag_mode != DRAG_NONE)
     ReleaseCapture();
 
@@ -426,6 +441,10 @@ GlueMapWindow::DiscardPendingFingerGesture() noexcept
 void
 GlueMapWindow::BeginMultiTouchOwnership() noexcept
 {
+  /* a second finger makes this a multi-touch gesture, not a long
+     press on an "invisible" InfoBox slot */
+  CancelInfoBoxPicker();
+
   DiscardPendingFingerGesture();
   multi_touch_was_panning = IsPanning();
   multi_touch_pan_ui = false;
@@ -652,6 +671,8 @@ GlueMapWindow::OnCancelMode() noexcept
 {
   MapWindow::OnCancelMode();
 
+  CancelInfoBoxPicker();
+
   if (drag_mode != DRAG_NONE) {
 #ifdef HAVE_MULTI_TOUCH
     const bool was_multi_touch = GestureOwnsMap();
@@ -755,6 +776,44 @@ GlueMapWindow::OnMapItemTimer() noexcept
   }
 
   ShowMapItems(drag_start_geopoint, false);
+}
+
+void
+GlueMapWindow::ArmInfoBoxPicker(PixelPoint p) noexcept
+{
+  /* InfoBoxManager::layout uses MainWindow client coordinates */
+  const auto origin = GetPosition().GetTopLeft();
+  infobox_picker_id =
+    InfoBoxManager::FindInvisibleAt(p.At(origin.x, origin.y));
+
+  if (infobox_picker_id >= 0)
+    infobox_picker_timer.Schedule(std::chrono::seconds(1));
+}
+
+void
+GlueMapWindow::OnInfoBoxPickerTimer() noexcept
+{
+  const int id = infobox_picker_id;
+  CancelInfoBoxPicker();
+
+  if (id < 0)
+    return;
+
+  /* the press turned out to be a long press on an "invisible" InfoBox
+     slot: abort the map interaction and let the user pick a different
+     InfoBox for that slot */
+  arm_mapitem_list = false;
+  map_item_timer.Cancel();
+
+  if (drag_mode != DRAG_NONE) {
+    drag_mode = DRAG_NONE;
+    ReleaseCapture();
+  }
+
+  /* suppress the mouse up which follows the long press */
+  ignore_single_click = true;
+
+  InfoBoxManager::ShowInfoBoxPicker(id);
 }
 
 #ifdef ENABLE_OPENGL

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -737,9 +737,9 @@ GlueMapWindow::OnPaintBuffer(Canvas &canvas) noexcept
 
   MapWindow::OnPaintBuffer(canvas);
 
-  DrawMapScale(canvas, GetClientRect(), render_projection);
+  DrawMapScale(canvas, GetOverlayRect(), render_projection);
   if (IsPanChromeVisible())
-    DrawPanInfo(canvas);
+    DrawPanInfo(canvas, GetOverlayRect());
 
 #ifdef ENABLE_OPENGL
   LeaveDrawThread();

--- a/src/MapWindow/GlueMapWindowEvents.cpp
+++ b/src/MapWindow/GlueMapWindowEvents.cpp
@@ -806,8 +806,18 @@ GlueMapWindow::OnInfoBoxPickerTimer() noexcept
   map_item_timer.Cancel();
 
   if (drag_mode != DRAG_NONE) {
+    if (drag_mode == DRAG_GESTURE)
+      /* Drop the gesture trail.  TrackingGestureManager::Start()
+         records a point right away, so a trail is already being drawn
+         when the long press elapses; without Finish() it would stay
+         visible next to the modal picker and continue afterwards. */
+      gestures.Finish();
+
     drag_mode = DRAG_NONE;
     ReleaseCapture();
+
+    /* redraw the map without the trail before the picker opens */
+    Invalidate();
   }
 
   /* suppress the mouse up which follows the long press */

--- a/src/MapWindow/GlueMapWindowOverlays.cpp
+++ b/src/MapWindow/GlueMapWindowOverlays.cpp
@@ -86,7 +86,8 @@ GlueMapWindow::DrawCrossHairs(Canvas &canvas) const noexcept
 }
 
 void
-GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
+GlueMapWindow::DrawPanInfo(Canvas &canvas,
+                           const PixelRect &rc) const noexcept
 {
   if (!render_projection.IsValid())
     return;
@@ -102,7 +103,7 @@ GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
 
   unsigned padding = Layout::FastScale(4);
   unsigned height = font.GetHeight();
-  PixelPoint p(render_projection.GetScreenSize().width - padding, padding);
+  PixelPoint p(rc.right - (int)padding, rc.top + (int)padding);
 
   if (compass_visible)
     /* don't obscure the north arrow */
@@ -116,8 +117,7 @@ GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
       elevation_long.Format("%s: %s", _("Elevation"),
                             FormatUserAltitude(elevation.GetValue()).c_str());
 
-      TextInBox(canvas, elevation_long, p, mode,
-                render_projection.GetScreenSize());
+      TextInBox(canvas, elevation_long, p, mode, rc);
 
       p.y += height;
     }
@@ -132,7 +132,7 @@ GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
     if (newline != nullptr)
       *newline = '\0';
 
-    TextInBox(canvas, start, p, mode, render_projection.GetScreenSize());
+    TextInBox(canvas, start, p, mode, rc);
 
     p.y += height;
 
@@ -155,8 +155,7 @@ GlueMapWindow::DrawPanInfo(Canvas &canvas) const noexcept
       else
         rasp_line.Format("%s: %s", label, value.c_str());
 
-      TextInBox(canvas, rasp_line, p, mode,
-                render_projection.GetScreenSize());
+      TextInBox(canvas, rasp_line, p, mode, rc);
 
       p.y += height;
     }
@@ -418,7 +417,8 @@ GlueMapWindow::DrawMapScale(Canvas &canvas, const PixelRect &rc,
     mode.vertical_position = TextInBoxMode::VerticalPosition::ABOVE;
     mode.shape = LabelShape::OUTLINED;
 
-    TextInBox(canvas, buffer, {0, scale_pos.bottom - height}, mode, rc, nullptr);
+    TextInBox(canvas, buffer, {rc.left, scale_pos.bottom - height}, mode, rc,
+              nullptr);
   }
 }
 

--- a/src/MapWindow/MapWindow.cpp
+++ b/src/MapWindow/MapWindow.cpp
@@ -146,8 +146,10 @@ MapWindow::OnPaintBuffer(Canvas &canvas) noexcept
     const ScopeUnlock unlock{mutex};
 #endif
 
-    // Render the moving map
-    Render(canvas, GetClientRect());
+    /* Render the moving map; GetOverlayRect() (not GetClientRect())
+       keeps the HUD overlays inside the area which is not covered by
+       InfoBoxes */
+    Render(canvas, GetOverlayRect());
     draw_sw.Finish();
   }
 

--- a/src/MapWindow/MapWindow.hpp
+++ b/src/MapWindow/MapWindow.hpp
@@ -171,6 +171,18 @@ protected:
    */
   unsigned top_right_margin = 0;
 
+  /**
+   * The part of this window which is really visible to the user, in
+   * window coordinates.  The map window may be larger than that: it is
+   * extended below InfoBox slots configured "invisible", and the
+   * remaining (opaque) InfoBoxes are drawn on top of it.  HUD overlays
+   * (compass, map scale, final glide bar, ...) are placed inside this
+   * rectangle so they cannot end up behind an InfoBox.
+   *
+   * An empty rectangle means "the whole client area".
+   */
+  PixelRect overlay_rect{0, 0, 0, 0};
+
 #ifndef ENABLE_OPENGL
   /**
    * Tracks whether the buffer canvas contains valid data.  We use
@@ -209,6 +221,26 @@ public:
 
   bool IsPanning() const noexcept {
     return follow_mode == FOLLOW_PAN;
+  }
+
+  /**
+   * Restrict the placement of HUD overlays to the given part of this
+   * window (window coordinates); see #overlay_rect.  Pass an empty
+   * rectangle to use the whole client area again.
+   */
+  void SetOverlayRect(PixelRect rc) noexcept {
+    overlay_rect = rc;
+  }
+
+  /**
+   * The rectangle HUD overlays are placed in; see #overlay_rect.
+   */
+  [[gnu::pure]]
+  PixelRect GetOverlayRect() const noexcept {
+    return overlay_rect.left < overlay_rect.right &&
+      overlay_rect.top < overlay_rect.bottom
+      ? overlay_rect
+      : GetClientRect();
   }
 
   void SetWaypoints(Waypoints *_waypoints) noexcept {

--- a/src/Profile/InfoBoxConfig.cpp
+++ b/src/Profile/InfoBoxConfig.cpp
@@ -7,7 +7,9 @@
 #include "InfoBoxes/InfoBoxSettings.hpp"
 #include "util/StringFormat.hpp"
 
+#include <cstddef>
 #include <cstring>
+#include <string_view>
 
 using namespace InfoBoxFactory;
 
@@ -32,6 +34,56 @@ GetV60InfoBoxManagerConfig(const ProfileMap &map, InfoBoxSettings &settings)
       settings.panels[3].contents[i] = (Type)((temp >> 24) & 0xFF);
     }
   }
+}
+
+/**
+ * The three lines of a custom text InfoBox share one profile value,
+ * separated by #InfoBoxCustomText::SEPARATOR.  A missing separator
+ * leaves the remaining lines empty.
+ */
+static void
+ParseCustomText(const char *src, InfoBoxCustomText &text) noexcept
+{
+  text.Clear();
+
+  if (src == nullptr)
+    return;
+
+  std::string_view rest{src};
+
+  for (auto *field : {&text.title, &text.value, &text.comment}) {
+    const auto separator = rest.find(InfoBoxCustomText::SEPARATOR);
+
+    field->assign(separator == rest.npos
+                  ? rest
+                  : rest.substr(0, separator));
+    field->CropIncompleteUTF8();
+
+    if (separator == rest.npos)
+      return;
+
+    rest = rest.substr(separator + 1);
+  }
+}
+
+/**
+ * The inverse of ParseCustomText(); an empty text becomes an empty
+ * value, so that the profile of everybody who does not use this
+ * InfoBox stays as it was.
+ */
+static void
+FormatCustomText(const InfoBoxCustomText &text,
+                 char *buffer, std::size_t size) noexcept
+{
+  if (text.IsEmpty()) {
+    *buffer = '\0';
+    return;
+  }
+
+  StringFormat(buffer, size, "%s%c%s%c%s",
+               text.title.c_str(), InfoBoxCustomText::SEPARATOR,
+               text.value.c_str(), InfoBoxCustomText::SEPARATOR,
+               text.comment.c_str());
 }
 
 static bool
@@ -152,6 +204,13 @@ Profile::Load(const ProfileMap &map, InfoBoxSettings &settings)
         continue;
 
       GetIBType(map, profileKey, panel.contents[j]);
+
+      const int t = StringFormat(profileKey, sizeof(profileKey),
+                                 "InfoBoxPanel%uText%u", i, j);
+      if (t < 0 || static_cast<size_t>(t) >= sizeof(profileKey))
+        continue;
+
+      ParseCustomText(map.Get(profileKey), panel.text[j]);
     }
   }
 }
@@ -172,5 +231,16 @@ Profile::Save(ProfileMap &map,
     const int n = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uBox%u", index, j);
     if (n >= 0 && static_cast<size_t>(n) < sizeof(profileKey))
       map.Set(profileKey, panel.contents[j]);
+
+    const int t = StringFormat(profileKey, sizeof(profileKey), "InfoBoxPanel%uText%u", index, j);
+    if (t < 0 || static_cast<size_t>(t) >= sizeof(profileKey))
+      continue;
+
+    char buffer[3 * InfoBoxCustomText::MAX_LENGTH + 3];
+    FormatCustomText(panel.text[j], buffer, sizeof(buffer));
+
+    /* do not add an empty value, but do overwrite one that exists */
+    if (buffer[0] != '\0' || map.Exists(profileKey))
+      map.Set(profileKey, buffer);
   }
 }

--- a/test/src/TestInfoBoxLayout.cpp
+++ b/test/src/TestInfoBoxLayout.cpp
@@ -252,13 +252,66 @@ TestMergeAcrossLines()
   }
 }
 
+static void
+TestInvisible()
+{
+  /* other than the placeholders, an "invisible" InfoBox claims a slot
+     of its own: that slot is where the map shows through */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_Invisible}});
+
+    ok1(l.visible[1]);
+    ok1(l.positions[1].left == 120);
+    ok1(l.positions[1].right == 240);
+    ok1(l.positions[1].top == 0);
+    ok1(l.positions[1].bottom == 85);
+  }
+
+  /* it takes part in the redistribution of its line, so a neighbour
+     which releases its space widens the hole */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_Invisible}, {2, e_ReleaseSpace}});
+
+    ok1(l.visible[1]);
+    ok1(!l.visible[2]);
+    ok1(l.positions[1].left == 160);
+    ok1(l.positions[1].right == 320);
+  }
+
+  /* a Merge along line grows it over the following slot */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_Invisible}, {2, e_MergeAlongLine}});
+
+    ok1(l.visible[1]);
+    ok1(!l.visible[2]);
+    ok1(l.positions[1].right == 360);
+  }
+
+  /* and it can be the anchor of a Merge across lines, which makes the
+     hole two lines tall */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_Invisible}, {5, e_MergeAcrossLines}});
+
+    ok1(l.visible[1]);
+    ok1(!l.visible[5]);
+    ok1(l.positions[1].top == 0);
+    ok1(l.positions[1].bottom == 170);
+    ok1(l.positions[4].right == 120);
+  }
+}
+
 int main()
 {
-  plan_tests(24 + 19 + 33);
+  plan_tests(24 + 19 + 33 + 17);
 
   TestReleaseSpace();
   TestMergeAlongLine();
   TestMergeAcrossLines();
+  TestInvisible();
 
   return exit_status();
 }

--- a/test/src/TestInfoBoxLayout.cpp
+++ b/test/src/TestInfoBoxLayout.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright The XCSoar Project
+
+#include "InfoBoxes/InfoBoxLayout.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
+#include "InfoBoxes/Border.hpp"
+#include "TestUtil.hpp"
+
+#include <initializer_list>
+#include <utility>
+
+using Geometry = InfoBoxSettings::Geometry;
+using namespace InfoBoxFactory;
+
+/**
+ * Calculate the given geometry and apply the given InfoBox types to
+ * it, the way #InfoBoxManager does.
+ */
+static InfoBoxLayout::Layout
+Apply(PixelRect rc, Geometry geometry,
+      std::initializer_list<std::pair<unsigned, Type>> contents) noexcept
+{
+  InfoBoxSettings::Panel panel;
+  panel.Clear();
+
+  for (const auto &i : contents)
+    panel.contents[i.first] = i.second;
+
+  auto layout = InfoBoxLayout::Calculate(rc, geometry);
+  InfoBoxLayout::ApplyContents(layout, panel);
+  return layout;
+}
+
+static void
+TestReleaseSpace()
+{
+  /* portrait: a line is a row of four, and the released slot hands a
+     third of its width to each of the others */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_ReleaseSpace}});
+
+    ok1(!l.visible[1]);
+    ok1(l.visible[0]);
+    ok1(l.visible[2]);
+    ok1(l.visible[3]);
+
+    ok1(l.positions[0].left == 0);
+    ok1(l.positions[0].right == 160);
+    ok1(l.positions[2].left == 160);
+    ok1(l.positions[2].right == 320);
+    ok1(l.positions[3].left == 320);
+    ok1(l.positions[3].right == 480);
+
+    /* the other lines are untouched */
+    ok1(l.positions[4].right == 120);
+    ok1(l.positions[8].right == 120);
+  }
+
+  /* landscape: a line is a column */
+  {
+    const auto l = Apply({0, 0, 800, 480}, Geometry::SPLIT_3X4,
+                         {{1, e_ReleaseSpace}});
+
+    ok1(!l.visible[1]);
+    ok1(l.positions[0].top == 0);
+    ok1(l.positions[0].bottom == 160);
+    ok1(l.positions[2].top == 160);
+    ok1(l.positions[3].bottom == 480);
+  }
+
+  /* the InfoBox which grows over the last slot of a line takes over
+     its outer border */
+  {
+    const auto base = InfoBoxLayout::Calculate({0, 0, 480, 800},
+                                               Geometry::SPLIT_3X4);
+    ok1((base.borders[2] & BORDERRIGHT) != 0);
+    ok1((base.borders[3] & BORDERRIGHT) == 0);
+
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{3, e_ReleaseSpace}});
+    ok1(l.positions[2].right == 480);
+    ok1((l.borders[2] & BORDERRIGHT) == 0);
+  }
+
+  /* a line which consists of placeholders only cannot collapse */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{0, e_ReleaseSpace}, {1, e_ReleaseSpace},
+                          {2, e_ReleaseSpace}, {3, e_ReleaseSpace}});
+
+    ok1(l.visible[0]);
+    ok1(l.visible[3]);
+    ok1(l.positions[0].right == 120);
+  }
+}
+
+int main()
+{
+  plan_tests(24);
+
+  TestReleaseSpace();
+
+  return exit_status();
+}

--- a/test/src/TestInfoBoxLayout.cpp
+++ b/test/src/TestInfoBoxLayout.cpp
@@ -158,12 +158,107 @@ TestMergeAlongLine()
   }
 }
 
+static void
+TestMergeAcrossLines()
+{
+  /* the InfoBox at the same position of the previous line grows over
+     the slot and gets twice the height */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{5, e_MergeAcrossLines}});
+
+    ok1(!l.visible[5]);
+    ok1(l.positions[1].left == 120);
+    ok1(l.positions[1].right == 240);
+    ok1(l.positions[1].top == 0);
+    ok1(l.positions[1].bottom == 170);
+
+    /* the rest of both lines is untouched */
+    ok1(l.positions[4].right == 120);
+    ok1(l.positions[6].left == 240);
+  }
+
+  /* two of them next to each other under an anchor which is twice as
+     wide give a 2x2 block */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_MergeAlongLine},
+                          {4, e_MergeAcrossLines}, {5, e_MergeAcrossLines}});
+
+    ok1(!l.visible[1]);
+    ok1(!l.visible[4]);
+    ok1(!l.visible[5]);
+    ok1(l.positions[0].left == 0);
+    ok1(l.positions[0].right == 240);
+    ok1(l.positions[0].bottom == 170);
+  }
+
+  /* one slot under a wide anchor would give an L shape; that is
+     rejected and the slot releases its space instead */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_MergeAlongLine}, {4, e_MergeAcrossLines}});
+
+    ok1(l.positions[0].bottom == 85);
+    ok1(!l.visible[4]);
+    ok1(l.positions[5].left == 0);
+    ok1(l.positions[5].right == 160);
+  }
+
+  /* an anchor which has released its space is no anchor */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{1, e_ReleaseSpace}, {5, e_MergeAcrossLines}});
+
+    ok1(!l.visible[1]);
+    ok1(!l.visible[5]);
+    ok1(l.positions[4].right == 160);
+  }
+
+  /* lines which do not touch cannot be merged: there is map between
+     the second and the third line of this geometry */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{8, e_MergeAcrossLines}});
+
+    ok1(!l.visible[8]);
+    ok1(l.positions[4].bottom == 170);
+    ok1(l.positions[9].left == 0);
+    ok1(l.positions[9].right == 160);
+  }
+
+  /* landscape: the previous line is the column to the left */
+  {
+    const auto l = Apply({0, 0, 800, 480}, Geometry::SPLIT_3X4,
+                         {{5, e_MergeAcrossLines}});
+
+    ok1(!l.visible[5]);
+    ok1(l.positions[1].top == 120);
+    ok1(l.positions[1].bottom == 240);
+    ok1(l.positions[1].left == 0);
+    ok1(l.positions[1].right == 280);
+  }
+
+  /* the previous line may have been redistributed by a merge of its
+     own; its edges must still line up with this one */
+  {
+    const auto l = Apply({0, 0, 922, 1990}, Geometry::SPLIT_3X4,
+                         {{3, e_MergeAlongLine}, {5, e_MergeAcrossLines}});
+
+    ok1(!l.visible[5]);
+    ok1(l.positions[1].left == 230);
+    ok1(l.positions[1].right == 460);
+    ok1(l.positions[1].bottom == l.positions[4].bottom);
+  }
+}
+
 int main()
 {
-  plan_tests(24 + 19);
+  plan_tests(24 + 19 + 33);
 
   TestReleaseSpace();
   TestMergeAlongLine();
+  TestMergeAcrossLines();
 
   return exit_status();
 }

--- a/test/src/TestInfoBoxLayout.cpp
+++ b/test/src/TestInfoBoxLayout.cpp
@@ -95,11 +95,75 @@ TestReleaseSpace()
   }
 }
 
+static void
+TestMergeAlongLine()
+{
+  /* the preceding InfoBox grows over the slot and gets twice the
+     space */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{2, e_MergeAlongLine}});
+
+    ok1(!l.visible[2]);
+    ok1(l.positions[1].left == 120);
+    ok1(l.positions[1].right == 360);
+    ok1(l.positions[3].left == 360);
+    ok1(l.positions[3].right == 480);
+  }
+
+  /* two of them widen it further, and it takes over the outer border
+     of the line */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{2, e_MergeAlongLine}, {3, e_MergeAlongLine}});
+
+    ok1(!l.visible[2]);
+    ok1(!l.visible[3]);
+    ok1(l.positions[1].right == 480);
+    ok1((l.borders[1] & BORDERRIGHT) == 0);
+  }
+
+  /* in the first slot of a line there is nothing to merge into, so it
+     releases its space instead */
+  {
+    const auto l = Apply({0, 0, 480, 800}, Geometry::SPLIT_3X4,
+                         {{0, e_MergeAlongLine}});
+
+    ok1(!l.visible[0]);
+    ok1(l.positions[1].left == 0);
+    ok1(l.positions[1].right == 160);
+  }
+
+  /* landscape: the preceding InfoBox is the one above */
+  {
+    const auto l = Apply({0, 0, 800, 480}, Geometry::SPLIT_3X4,
+                         {{2, e_MergeAlongLine}});
+
+    ok1(!l.visible[2]);
+    ok1(l.positions[1].top == 120);
+    ok1(l.positions[1].bottom == 360);
+  }
+
+  /* merging keeps the edges of the geometry: the line still lines up
+     with its neighbour even when the width is not a multiple of the
+     number of columns */
+  {
+    const auto l = Apply({0, 0, 922, 1990}, Geometry::SPLIT_3X4,
+                         {{3, e_MergeAlongLine}});
+
+    ok1(l.positions[0].right == l.positions[4].right);
+    ok1(l.positions[1].right == l.positions[5].right);
+    ok1(l.positions[2].left == l.positions[6].left);
+    ok1(l.positions[2].right == 922);
+  }
+}
+
 int main()
 {
-  plan_tests(24);
+  plan_tests(24 + 19);
 
   TestReleaseSpace();
+  TestMergeAlongLine();
 
   return exit_status();
 }

--- a/test/src/TestProfile.cpp
+++ b/test/src/TestProfile.cpp
@@ -8,6 +8,8 @@
 #include "PageSettings.hpp"
 #include "Profile/Map.hpp"
 #include "Profile/WeatherProfile.hpp"
+#include "Profile/InfoBoxConfig.hpp"
+#include "InfoBoxes/InfoBoxSettings.hpp"
 #include "Weather/Settings.hpp"
 #include "io/FileLineReader.hpp"
 #include "system/Path.hpp"
@@ -209,6 +211,71 @@ TestWeatherPageCursorRoundTrip()
   ok1(loaded.pages[2].skysight_time == skysight.skysight_time);
 }
 
+
+static void
+TestInfoBoxCustomText()
+{
+  /* the profile format has no escaping, so the quotation mark and the
+     separator are dropped from an edited line */
+  {
+    InfoBoxCustomText text;
+
+    ok1(InfoBoxCustomText::AssignLine(text.title, "a|b\"c"));
+    ok1(text.title == "abc");
+
+    /* the same text again is not a modification */
+    ok1(!InfoBoxCustomText::AssignLine(text.title, "abc"));
+
+    /* a null string clears the line, like an empty one */
+    ok1(InfoBoxCustomText::AssignLine(text.title, nullptr));
+    ok1(text.title.empty());
+  }
+
+  /* the three lines share one profile value per slot */
+  {
+    ProfileMap map;
+
+    InfoBoxSettings::Panel panel;
+    panel.Clear();
+    panel.contents[0] = InfoBoxFactory::e_CustomText;
+    panel.text[0].title = "Page";
+    panel.text[0].value = "Cruise";
+    panel.text[0].comment = "one more thing";
+
+    Profile::Save(map, panel, 7);
+
+    const char *packed = map.Get("InfoBoxPanel7Text0");
+    ok1(packed != nullptr);
+    ok1(packed != nullptr &&
+        StringIsEqual(packed, "Page|Cruise|one more thing"));
+
+    /* a slot without text does not add a value */
+    ok1(map.Get("InfoBoxPanel7Text1") == nullptr);
+
+    InfoBoxSettings settings;
+    settings.SetDefaults();
+    Profile::Load(map, settings);
+
+    ok1(settings.panels[7].text[0].title == "Page");
+    ok1(settings.panels[7].text[0].value == "Cruise");
+    ok1(settings.panels[7].text[0].comment == "one more thing");
+  }
+
+  /* a missing separator leaves the remaining lines empty */
+  {
+    ProfileMap map;
+    map.Set("InfoBoxPanel7Text0", "only a title");
+
+    InfoBoxSettings settings;
+    settings.SetDefaults();
+    Profile::Load(map, settings);
+
+    ok1(settings.panels[7].text[0].title == "only a title");
+    ok1(settings.panels[7].text[0].value.empty());
+    ok1(settings.panels[7].text[0].comment.empty());
+  }
+}
+
 #ifdef HAVE_HTTP
 
 static void
@@ -259,7 +326,7 @@ TestSkySightProfileCompatibility()
 
 int main()
 try {
-  plan_tests(50
+  plan_tests(50 + 14
 #ifdef HAVE_HTTP
              + 8
 #endif
@@ -270,6 +337,7 @@ try {
   TestReader();
   TestMigration();
   TestWeatherPageCursorRoundTrip();
+  TestInfoBoxCustomText();
 #ifdef HAVE_HTTP
   TestSkySightProfileCompatibility();
 #endif


### PR DESCRIPTION
Closes https://github.com/XCSoar/XCSoar/issues/3034. Five new InfoBox types that change what the InfoBox grid can do, plus one fix that fell out of the same work. Every existing geometry keeps working as before; the new types only take effect where they are configured.

- **Release space** is not displayed and hands its space to the other InfoBoxes of the same line, so a line can hold fewer but wider InfoBoxes than the chosen geometry provides.
- **Merge along line** is not displayed and lets the InfoBox before it in the same line grow over its place, which gives long values such as waypoint names more room.
- **Merge across lines** is not displayed and lets the InfoBox of the previous line grow over its place, which gives the graphical InfoBoxes such as Barogram or Horizon twice the height (combine with a 2x2 merge).
- **Invisible** is not drawn at all. The map is extended over the slot and shows in its place, a short tap acts on the map and a long press picks a different InfoBox for the slot.
- **Custom text** has a title, value and comment which the pilot types in by tapping the InfoBox. Useful for labelling a page or as a separator between groups of InfoBoxes. Closes #613.

Also included: the InfoBox border style now takes effect right away instead of only after the next layout change.

New TAP tests cover the layout algorithm and the profile round trip of the custom text. All five types are documented in the InfoBox reference of the English manual.

One open question for reviewers: the custom text of a slot is stored in a single profile key, with the three lines separated by "|". Profile values are not escaped, so a "|" typed into the text cannot round trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five InfoBox types: Release space, Merge along line, Merge across lines, Invisible, and Custom text.
  * Custom text InfoBoxes support editable titles, values, and comments with profile persistence.
  * Invisible InfoBoxes let the map extend into unused slots, with long-press access to the InfoBox picker.
  * Added dynamic space redistribution and merging for supported layouts.

* **Bug Fixes**
  * InfoBox border style changes now apply immediately.
  * Improved overlay positioning around InfoBoxes.

* **Documentation**
  * Added reference documentation for the new InfoBox types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->