### PR TITLE
darwin: Read DEBUG_ALL_MAP_OVERLAYS from .env and rebuild on toggle

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -138,6 +138,8 @@ Version 7.46 - not yet released
   - build system: add DEBUG_ALL_MAP_OVERLAYS=y make option to force
     GlueMapWindow HUD overlays on with placeholder data for layout
     testing
+  - macOS/iOS: read DEBUG_ALL_MAP_OVERLAYS=y from darwin/.env, so Xcode
+    builds can force all map overlays
 
 Version 7.45 - 2026-08-15
 * highlights

--- a/build/mapwindow.mk
+++ b/build/mapwindow.mk
@@ -48,3 +48,18 @@ endif
 endif
 
 $(eval $(call link-library,libmapwindow,LIBMAPWINDOW))
+
+# Rebuild the objects which evaluate DEBUG_ALL_MAP_OVERLAYS when the
+# option is toggled; make does not track preprocessor flag changes.
+MAP_OVERLAYS_FLAGS_STAMP = $(ABI_OUTPUT_DIR)/.debug_all_map_overlays.stamp
+$(MAP_OVERLAYS_FLAGS_STAMP): FORCE | $(ABI_OUTPUT_DIR)/dirstamp
+	@value=$(DEBUG_ALL_MAP_OVERLAYS); \
+	if [ ! -f $@ ] || [ "$$(cat $@ 2>/dev/null)" != "$$value" ]; then \
+		echo "$$value" > $@.$(RANDOM_NUMBER).tmp && \
+			mv $@.$(RANDOM_NUMBER).tmp $@; \
+	fi
+
+MAP_OVERLAYS_FLAGS_SOURCES = \
+	$(SRC)/MapWindow/GlueMapWindowEvents.cpp \
+	$(SRC)/MapWindow/GlueMapWindowOverlays.cpp
+$(call SRC_TO_OBJ,$(MAP_OVERLAYS_FLAGS_SOURCES)): $(MAP_OVERLAYS_FLAGS_STAMP)

--- a/darwin/.env.example
+++ b/darwin/.env.example
@@ -7,6 +7,11 @@
 # Read by darwin/build.sh (Xcode builds) and darwin/install.sh.
 # TESTING=y
 
+# Force all map overlays to be drawn regardless of flight state, for
+# checking the map layout without a simulated flight (see
+# doc/debugging.rst). Read by darwin/build.sh (Xcode builds).
+# DEBUG_ALL_MAP_OVERLAYS=y
+
 # App Store Connect - App's numeric ID (NOT your personal Apple ID email)
 APPLE_ID_NUMERIC=1234567890
 

--- a/darwin/build.sh
+++ b/darwin/build.sh
@@ -38,6 +38,18 @@ case "$(printf '%s' "${TESTING:-n}" | tr '[:upper:]' '[:lower:]')" in
 esac
 export TESTING
 
+# Normalise the DEBUG_ALL_MAP_OVERLAYS flag (see doc/debugging.rst)
+case "$(printf '%s' "${DEBUG_ALL_MAP_OVERLAYS:-n}" | tr '[:upper:]' '[:lower:]')" in
+    y|yes|true|1)
+        DEBUG_ALL_MAP_OVERLAYS="y"
+        echo "build.sh: Forcing all map overlays (DEBUG_ALL_MAP_OVERLAYS=y)"
+        ;;
+    *)
+        DEBUG_ALL_MAP_OVERLAYS="n"
+        ;;
+esac
+export DEBUG_ALL_MAP_OVERLAYS
+
 # Set debug flag based on configuration
 DEBUG="n"
 if [ "${CONFIGURATION}" = "Debug" ]; then
@@ -99,7 +111,8 @@ echo "Building with $NUM_CPUS parallel jobs..."
 # Execute make with error checking
 # TESTING must be passed on the command line: build/options.mk assigns a
 # default with "=", which would override the value from the environment.
-if ! gmake -j"${NUM_CPUS}" USE_CCACHE=y V=2 OPTIMIZE="-O0" DEBUG="$DEBUG" TESTING="$TESTING" TARGET="$TARGET" $IPA_TARGET; then
+# DEBUG_ALL_MAP_OVERLAYS is passed the same way for consistency.
+if ! gmake -j"${NUM_CPUS}" USE_CCACHE=y V=2 OPTIMIZE="-O0" DEBUG="$DEBUG" TESTING="$TESTING" DEBUG_ALL_MAP_OVERLAYS="$DEBUG_ALL_MAP_OVERLAYS" TARGET="$TARGET" $IPA_TARGET; then
     echo "Error: Build failed" >&2
     exit 1
 fi

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -402,7 +402,8 @@ That script reads optional settings from `darwin/.env` (see
 `darwin/.env.example`); for example ``TESTING=y`` builds the testing
 flavour with the red icon, which on iOS uses the separate bundle
 identifier ``XCSoar-testing`` and can therefore be installed next to the
-stable app.
+stable app. Likewise ``DEBUG_ALL_MAP_OVERLAYS=y`` forces all map overlays
+to be drawn (see :doc:`debugging`).
 For iOS debugging with Visual Studio Code, the `iOS Debug`
 extension (https://github.com/nisargjhaveri/vscode-ios-debug) can be used.
 Note that this also requires an Xcode installation.

--- a/doc/debugging.rst
+++ b/doc/debugging.rst
@@ -135,6 +135,9 @@ build with ``DEBUG_ALL_MAP_OVERLAYS=y``::
 
   make -j$(nproc) TARGET=UNIX USE_CCACHE=y DEBUG_ALL_MAP_OVERLAYS=y
 
+For Xcode builds on iOS and macOS, set ``DEBUG_ALL_MAP_OVERLAYS=y`` in
+:file:`darwin/.env` instead; :file:`darwin/build.sh` passes it to make.
+
 The flag is defined in :file:`build/options.mk` (default ``n``) and
 adds ``-DDEBUG_ALL_MAP_OVERLAYS=1``. When enabled, it forces the
 thermal band, FLARM alarm-level icon (not the FLARM traffic gauge


### PR DESCRIPTION
Xcode builds for macOS and iOS can now enable the map overlay debug option the same way as `TESTING`: set `DEBUG_ALL_MAP_OVERLAYS=y` in `darwin/.env` and `darwin/build.sh` passes it to make. The value is normalised (`y`, `yes`, `true`, `1`) and documented in `.env.example`, `doc/build.rst` and `doc/debugging.rst`.

Toggling the option previously had no effect on an existing build tree because make does not track preprocessor flag changes, so the two objects evaluating the macro kept their old state. A stamp file in `build/mapwindow.mk` now records the current value and the affected objects are rebuilt when it changes, following the pattern already used for `XCSOAR_TESTING` in `build/resource.mk`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `DEBUG_ALL_MAP_OVERLAYS` setting for macOS and iOS builds.
  - When enabled, all map overlays are displayed regardless of flight state, helping users inspect map layouts without a simulated flight.
  - Changes to the setting now trigger the necessary rebuild automatically.

- **Documentation**
  - Added setup guidance and an example configuration for enabling the map overlay debugging option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->